### PR TITLE
fix #1556 - missing export/import classes in _export.mjs files

### DIFF
--- a/src/component/_export.mjs
+++ b/src/component/_export.mjs
@@ -1,4 +1,10 @@
-import Component from './Base.mjs';
-import Label     from './Label.mjs';
+import Component    from './Base.mjs';
+import BoxLabel     from './BoxLabel.mjs';
+import Chip         from './Chip.mjs';
+import Circle       from './Circle.mjs';
+import DateSelector from './DateSelector.mjs';
+import Gallery      from './Gallery.mjs';
+import Helix        from './Helix.mjs';
+import Label        from './Label.mjs';
 
-export {Component, Label};
+export {Component, BoxLabel, Chip, Circle, DateSelector, Gallery, Helix, Label};

--- a/src/core/_export.mjs
+++ b/src/core/_export.mjs
@@ -1,6 +1,7 @@
 import Base        from './Base.mjs';
+import IdGenerator      from './IdGenerator.mjs';
 import Logger      from './Logger.mjs';
 import Observable  from './Observable.mjs';
 import Util        from './Util.mjs';
 
-export {Base, Logger, Observable, Util};
+export {Base, IdGenerator, Logger, Observable, Util};

--- a/src/data/_export.mjs
+++ b/src/data/_export.mjs
@@ -1,4 +1,6 @@
 import * as connection from './connection/_export.mjs';
+import Model           from './Model.mjs';
+import RecordFactory   from './RecordFactory.mjs';
 import Store           from './Store.mjs';
 
-export {connection, Store};
+export {connection, Model, RecordFactory, Store};

--- a/src/form/_export.mjs
+++ b/src/form/_export.mjs
@@ -1,4 +1,6 @@
 import * as field   from './field/trigger/_export.mjs';
 import * as trigger from './field/_export.mjs';
+import Container    from './Container.mjs';
+import Fieldset     from './Fieldset.mjs';
 
-export {field, trigger};
+export {field, trigger, Container, Fieldset};

--- a/src/form/field/_export.mjs
+++ b/src/form/field/_export.mjs
@@ -1,6 +1,8 @@
 import Base     from './Base.mjs';
 import CheckBox from './CheckBox.mjs';
+import Chip     from './Chip.mjs';
 import Date     from './Date.mjs';
+import Email    from './Email.mjs';
 import Number   from './Number.mjs';
 import Password from './Password.mjs';
 import Picker   from './Picker.mjs';
@@ -9,5 +11,7 @@ import Range    from './Range.mjs';
 import Search   from './Search.mjs';
 import Select   from './Select.mjs';
 import Text     from './Text.mjs';
+import TextArea from './TextArea.mjs';
+import Time     from './Time.mjs';
 
-export {Base, CheckBox, Date, Number, Password, Picker, Radio, Range, Search, Select, Text};
+export {Base, CheckBox, Chip, Date, Email, Number, Password, Picker, Radio, Range, Search, Select, Text, TextArea, Time};

--- a/src/form/field/trigger/_export.mjs
+++ b/src/form/field/trigger/_export.mjs
@@ -1,4 +1,11 @@
-import Base  from './Base.mjs';
-import Clear from './Clear.mjs';
+import Base             from './Base.mjs';
+import Clear            from './Clear.mjs';
+import CopyToClipboard  from './CopyToClipboard.mjs';
+import Date             from './Date.mjs';
+import Picker           from './Picker.mjs';
+import SpinDown         from './SpinDown.mjs';
+import SpinUp           from './SpinUp.mjs';
+import SpinUpDown       from './SpinUpDown.mjs';
+import Time             from './Time.mjs';
 
-export {Base, Clear};
+export {Base, Clear, CopyToClipboard, Date, Picker, SpinDown, SpinUp, SpinUpDown, Time};

--- a/src/manager/_export.mjs
+++ b/src/manager/_export.mjs
@@ -1,5 +1,8 @@
 import Base      from './Base.mjs';
 import Component from './Component.mjs';
 import DomEvent  from './DomEvent.mjs';
+import Focus     from './Focus.mjs';
+import Instance  from './Instance.mjs';
+import Store     from './Store.mjs';
 
-export {Base, Component, DomEvent};
+export {Base, Component, DomEvent, Instance, Focus, Store};

--- a/src/util/_export.mjs
+++ b/src/util/_export.mjs
@@ -1,8 +1,16 @@
-import NeoArray  from './Array.mjs';
-import Css       from './Css.mjs';
-import Floating  from './Floating.mjs';
-import Function  from './Function.mjs';
-import NeoObject from './Object.mjs';
-import Style     from './Style.mjs';
+import NeoArray         from './Array.mjs';
+import ClassSystem      from './ClassSystem.mjs';
+import Css              from './Css.mjs';
+import Date             from './Date.mjs';
+import Floating         from './Floating.mjs';
+import Function         from './Function.mjs';
+import HashHistory      from './HashHistory.mjs';
+import KeyNavigation    from './KeyNavigation.mjs';
+import Matrix           from './Matrix.mjs';
+import NeoObject        from './Object.mjs';
+import Rectangle        from './Rectangle.mjs';
+import Style            from './Style.mjs';
+import VDom             from './VDom.mjs';
+import VNode            from './VNode.mjs';
 
-export {Css, Floating, Function, NeoArray, NeoObject, Style};
+export {NeoArray, ClassSystem, Css, Date, Floating, Function, HashHistory, KeyNavigation, Matrix, NeoObject, Rectangle, Style, VDom, VNode};


### PR DESCRIPTION
Issue: https://github.com/neomjs/neo/issues/1556
Description: Missing some classes modules in _export.mjs files


**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [x] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No


