### PR TITLE
feat(build): allow create-class to drop classes into cwd

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31,8 +31,12 @@
                 "webpack-hook-plugin": "^1.0.7",
                 "webpack-node-externals": "^3.0.0"
             },
+            "bin": {
+                "create-class": "buildScripts/createClass.mjs"
+            },
             "devDependencies": {
-                "siesta-lite": "^5.5.2"
+                "siesta-lite": "^5.5.2",
+                "url": "^0.11.0"
             },
             "funding": {
                 "type": "GitHub Sponsors",
@@ -6288,6 +6292,16 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
+        "node_modules/querystring": {
+            "version": "0.2.0",
+            "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
+            "integrity": "sha512-X/xY82scca2tau62i9mDyU9K+I+djTMUsvwf7xnUX5GLvVzgJybOJf4Y6o9Zx3oJK/LSXg5tTZBjwzqVPaPO2g==",
+            "deprecated": "The querystring API is considered Legacy. new code should use the URLSearchParams API instead.",
+            "dev": true,
+            "engines": {
+                "node": ">=0.4.x"
+            }
+        },
         "node_modules/randombytes": {
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
@@ -7521,6 +7535,16 @@
                 "punycode": "^2.1.0"
             }
         },
+        "node_modules/url": {
+            "version": "0.11.0",
+            "resolved": "https://registry.npmjs.org/url/-/url-0.11.0.tgz",
+            "integrity": "sha512-kbailJa29QrtXnxgq+DdCEGlbTeYM2eJUxsz6vjZavrCYPMIFHMKQmSKYAIuUK2i7hgPm28a8piX5NTUtM/LKQ==",
+            "dev": true,
+            "dependencies": {
+                "punycode": "1.3.2",
+                "querystring": "0.2.0"
+            }
+        },
         "node_modules/url-parse-lax": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-1.0.0.tgz",
@@ -7532,6 +7556,12 @@
             "engines": {
                 "node": ">=0.10.0"
             }
+        },
+        "node_modules/url/node_modules/punycode": {
+            "version": "1.3.2",
+            "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
+            "integrity": "sha512-RofWgt/7fL5wP1Y7fxE7/EmTLzQVnB0ycyibJ0OOHIlJqTNzglYFxVwETOcIoJqJmpDXJ9xImDv+Fq34F/d4Dw==",
+            "dev": true
         },
         "node_modules/util-deprecate": {
             "version": "1.0.2",
@@ -12897,6 +12927,12 @@
                 "side-channel": "^1.0.4"
             }
         },
+        "querystring": {
+            "version": "0.2.0",
+            "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
+            "integrity": "sha512-X/xY82scca2tau62i9mDyU9K+I+djTMUsvwf7xnUX5GLvVzgJybOJf4Y6o9Zx3oJK/LSXg5tTZBjwzqVPaPO2g==",
+            "dev": true
+        },
         "randombytes": {
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
@@ -13830,6 +13866,24 @@
             "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
             "requires": {
                 "punycode": "^2.1.0"
+            }
+        },
+        "url": {
+            "version": "0.11.0",
+            "resolved": "https://registry.npmjs.org/url/-/url-0.11.0.tgz",
+            "integrity": "sha512-kbailJa29QrtXnxgq+DdCEGlbTeYM2eJUxsz6vjZavrCYPMIFHMKQmSKYAIuUK2i7hgPm28a8piX5NTUtM/LKQ==",
+            "dev": true,
+            "requires": {
+                "punycode": "1.3.2",
+                "querystring": "0.2.0"
+            },
+            "dependencies": {
+                "punycode": {
+                    "version": "1.3.2",
+                    "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
+                    "integrity": "sha512-RofWgt/7fL5wP1Y7fxE7/EmTLzQVnB0ycyibJ0OOHIlJqTNzglYFxVwETOcIoJqJmpDXJ9xImDv+Fq34F/d4Dw==",
+                    "dev": true
+                }
             }
         },
         "url-parse-lax": {

--- a/package.json
+++ b/package.json
@@ -7,6 +7,9 @@
         "type": "git",
         "url": "https://github.com/neomjs/neo.git"
     },
+    "bin": {
+        "neo-cc": "./buildScripts/createClass.mjs"
+    },
     "scripts": {
         "build-all": "node ./buildScripts/buildAll.mjs -f -n",
         "build-all-questions": "node ./buildScripts/buildAll.mjs -f",
@@ -59,7 +62,8 @@
         "webpack-node-externals": "^3.0.0"
     },
     "devDependencies": {
-        "siesta-lite": "^5.5.2"
+        "siesta-lite": "^5.5.2",
+        "url": "^0.11.0"
     },
     "funding": {
         "type": "GitHub Sponsors",


### PR DESCRIPTION
## `create-class` creates class files in current working directory

This PR introduces several new enhancements to the `create-class` script:

1. new option for dropping classes directly into the cwd: `-d`
2. option for specifying the app-source folder for computing namespace when `-d` is used: `-s`
3. script available as binary via `npx neo-cc` (test w/ `npm i -g` for repository clones)
4. several minor enhancements for original source related to path computing

## Changes
The original implementation remains unchanged regarding functionality, some lines had to be shifted and re-arranged into conditional statements given the new option the script provides. It was also necessary to distinguish between - and further reuse - the original `cwd`- and `__dirname`-variables, so the script can now be run outside of the `neo`-folder.

## Features

### `-d` Option
The `-d` options stands for `drop` and advises the script to run in a none-interactive environment. It will compute the namespace based on the current working directory up to the directory that is either used from the value found in the script's `sourceRootDirs`-array, or specified with the `-s`-option.

##### Example:
The user has an application in `/neo/apps/acme` and wants to create a new class for `acme.view.masterDetail.TableView`.

```bash
cd /neo/apps/acme/view/masterDetail
npx neo-cc -c TableView -b component.Base -d
```
results in a file `TableView.mjs` created at `/neo/apps/acme/view/masterDetail` with the following contents:

```javascript
import Base from '../../../../src/component/Base.mjs';

/**
 * @class acme.view.masterDetail.TableView
 * @extends Neo.component.Base
 */
class TableView extends Base {
    static getConfig() {return {
        /*
         * @member {String} className='acme.view.masterDetail.TableView'
         * @protected
         */
        className: 'acme.view.masterDetail.TableView',
        /*
         * @member {Object} _vdom
         */
        _vdom:
        {}
    }}
}

Neo.applyClassConfig(TableView);

export default TableView;
```

Note, that `apps` is by default mentioned in the `sourcesRootDir` of the script. The user can overwrite the directory where the sources (and therefore top-level namespaces reside)  by using the -s option:

##### Example:
The user has an application in `/neo/FOLDER/acme` and wants to create a new class for `acme.view.masterDetail.TableView`.

```bash
cd /neo/FOLDER/acme/view/masterDetail
npx neo-cc -c TableView -b component.Base -d -s FOLDER
```


**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [X] Feature
- [ ] Code style update
- [ ] Refactor
- [X] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [X] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [X] It's submitted to the `dev` branch, _not_ the `master` branch
- [X] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)

If adding a **new feature**, the PR's description includes:
- [X] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)
