### PR TITLE
Adding data.field functionality

### DIFF
--- a/src/data/RecordFactory.mjs
+++ b/src/data/RecordFactory.mjs
@@ -235,7 +235,7 @@ class RecordFactory extends Base {
      * @returns {*}
      */
     parseRecordValue(record, field, value, recordConfig=null) {
-        if(field.calculate) return field.calculate(recordConfig, field);
+        if(field.calculate && recordConfig) return field.calculate(recordConfig, field);
         if(field.convert) value = field.convert(value);
 
         let fieldName = field.name,

--- a/src/data/RecordFactory.mjs
+++ b/src/data/RecordFactory.mjs
@@ -235,7 +235,7 @@ class RecordFactory extends Base {
      * @returns {*}
      */
     parseRecordValue(record, field, value, recordConfig=null) {
-        if(field.calculate) return field.calculate(record, field);
+        if(field.calculate) return field.calculate(recordConfig, field);
         if(field.convert) value = field.convert(value);
 
         let fieldName = field.name,

--- a/src/data/RecordFactory.mjs
+++ b/src/data/RecordFactory.mjs
@@ -235,7 +235,7 @@ class RecordFactory extends Base {
      * @returns {*}
      */
     parseRecordValue(record, field, value, recordConfig=null) {
-        if(field.calculate && recordConfig) return field.calculate(recordConfig, field);
+        if(field.calculate) return field.calculate(record, field, recordConfig);
         if(field.convert) value = field.convert(value);
 
         let fieldName = field.name,

--- a/src/data/RecordFactory.mjs
+++ b/src/data/RecordFactory.mjs
@@ -235,6 +235,9 @@ class RecordFactory extends Base {
      * @returns {*}
      */
     parseRecordValue(record, field, value, recordConfig=null) {
+        if(field.calculate) return field.calculate(record, field);
+        if(field.convert) value = field.convert(value);
+
         let fieldName = field.name,
             mapping   = field.mapping,
             maxLength = field.maxLength,


### PR DESCRIPTION
Added support for `calculate` and `convert` for data fields.

@examples
calculate (its all up to you)
```
fields: [{
    name: 'id',
    type: 'Number'
}, {
    name: 'name',
    defaultValue: 'Defaults To Name',
    /**
     * @config data       the record
     * @config field       the field definition
     * @config rawData the data as they come initially
     */
    calculate: (data, field, rawData) => {
        // foo will not exist in data, but in this example 
        // foo is delivered with the initial data
        if (rawData) return rawData.foo;

        data.name ??= field.defaultValue;
        return 'I am ' + data.name;
    }
}]
```

convert (will run the standard afterwards, like minLength and maxLength)
```
fields: [{
    name: 'id',
    type: 'Number'
}, {
    name: 'name',
    defaultValue: 'Defaults To Name',
    convert: value => 'I am ' + value
}]
```