### PR TITLE
Adding responseRoot for Stores

### DIFF
--- a/src/data/Store.mjs
+++ b/src/data/Store.mjs
@@ -96,6 +96,13 @@ class Store extends Base {
          */
         remoteSort: false,
         /**
+         * Add a path to the root of your data.
+         * If the responseRoot is 'data' this is optional.
+         * 
+         * @member {String} [responseRoot='data']
+         */
+        responseRoot: null,
+        /**
          * @member {Number} totalCount=0
          */
         totalCount: 0,
@@ -340,9 +347,16 @@ class Store extends Base {
             }).catch(err => {
                 console.log('Error for Neo.Xhr.request', err, me.id);
             }).then(data => {
-                me.data = Array.isArray(data.json) ? data.json : data.json.data;
+                let rootedData;
+
+                if (me.responseRoot) {
+                    rootedData = Neo.ns(me.responseRoot, true, data.json);
+                } else {
+                    rootedData = Array.isArray(data.json) ? data.json : data.json.data
+                }
+
+                me.data = rootedData;
                 // we do not need to fire a load event => onCollectionMutate()
-            });
         }
     }
 

--- a/src/data/Store.mjs
+++ b/src/data/Store.mjs
@@ -99,9 +99,9 @@ class Store extends Base {
          * Add a path to the root of your data.
          * If the responseRoot is 'data' this is optional.
          * 
-         * @member {String} [responseRoot='data']
+         * @member {String} responseRoot='data'
          */
-        responseRoot: null,
+        responseRoot: 'data',
         /**
          * @member {Number} totalCount=0
          */
@@ -347,15 +347,7 @@ class Store extends Base {
             }).catch(err => {
                 console.log('Error for Neo.Xhr.request', err, me.id);
             }).then(data => {
-                let rootedData;
-
-                if (me.responseRoot) {
-                    rootedData = Neo.ns(me.responseRoot, true, data.json);
-                } else {
-                    rootedData = Array.isArray(data.json) ? data.json : data.json.data
-                }
-
-                me.data = rootedData;
+                me.data = Neo.ns(me.responseRoot, false, data.json) || data.json;
                 // we do not need to fire a load event => onCollectionMutate()
         }
     }


### PR DESCRIPTION
# Added responseRoot
The responseRoot is the property path your data in the response. rootProperty is a property name. It may also be a dot-separated list of property names if the root is nested.

exampleData
```
{
    "feed": {
        data: [{
            "id"      : 1,
            "name": "Max"
        }]
    }
}
```

store
```
myStore: {
    url: 'path.to.store',
    responseRoot: 'feet.data'
}
```