### PR TITLE
Components need getParents for debugging Ticket #3738

### DIFF
--- a/src/component/Base.mjs
+++ b/src/component/Base.mjs
@@ -1111,6 +1111,14 @@ class Base extends CoreBase {
     }
 
     /**
+     * Get the parent components as an array
+     * @returns {Neo.component.Base[]}
+     */
+    getParents() {
+        return ComponentManager.getParents(this);
+    }
+
+    /**
      * @param {Object|String} opts
      * @returns {Neo.plugin.Base|null}
      */


### PR DESCRIPTION
As stated in the ticket #3738 we need getParents on a Component for debugging.