### PR TITLE
Neo Override update

### DIFF
--- a/src/Neo.mjs
+++ b/src/Neo.mjs
@@ -52,7 +52,7 @@ Neo = globalThis.Neo = Object.assign({
             ntypeMap = Neo.ntypeMap,
             proto    = cls.prototype || cls,
             protos   = [],
-            config, ctor, overrides;
+            cfg, config, ctor, overrides;
 
         while (proto.__proto__) {
             ctor = proto.constructor;
@@ -69,10 +69,16 @@ Neo = globalThis.Neo = Object.assign({
         config = baseCfg || {};
 
         protos.forEach(element => {
+            let mixins;
+              
             ctor = element.constructor;
 
-            let cfg = ctor.config || {},
-                mixins;
+            cfg = ctor.config || {};
+            
+            if (Neo.overrides) {
+                overrides = Neo.ns(cfg.className, false, Neo.overrides);
+                overrides && Object.assign(cfg, overrides);
+            }
 
             Object.entries(cfg).forEach(([key, value]) => {
                 if (key.slice(-1) === '_') {
@@ -123,11 +129,6 @@ Neo = globalThis.Neo = Object.assign({
             delete config.mixins;
 
             Object.assign(config, cfg);
-
-            if (Neo.overrides) {
-                overrides = Neo.ns(config.className, false, Neo.overrides);
-                overrides && Object.assign(config, overrides);
-            }
 
             Object.assign(ctor, {
                 classConfigApplied: true,


### PR DESCRIPTION
@featureRequest: fix #3964
Allows now underscore items, which add support for afterSet and beforeSet.

@example

    Neo.overrides = {
        Neo: {
            component: {
                Base: {
                    foo_: 1,

                    afterSetFoo: function(newValue, oldValue) {
                        let style = this.style;
                        style.color = 'green';
                        this.style = style;
                    }
                }
            }
        }
    };

    export default Neo.overrides;

Please make sure to read the Contributing Guidelines:

https://github.com/neomjs/neo/blob/dev/CONTRIBUTING.md

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [x] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch, _not_ the `master` branch
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
