### PR TITLE
Overridden methods allow this.callOverridden()

### DIFF
--- a/.github/CODING_GUIDELINES.md
+++ b/.github/CODING_GUIDELINES.md
@@ -424,6 +424,10 @@ fields: [{
   + Good: `myView?.myFn?.();`
   + https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Optional_chaining
 * (43) Use method definitions (meaning avoid using the term `function`)
-  + Bad: `let obj = {a: function() {/**/}}`
-  + Good: `let obj = {a() {/**/}}`
+  + Bad: `let obj = {a: function() {/**/}};`
+  + Good: `let obj = {a() {/**/}};`
   + https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/Method_definitions
+* (44) Use shorthand property names when possible
+  + Bad: `let obj = {record: record}`
+  + Good: `let obj = {record};`
+  + https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Object_initializer#property_definitions

--- a/src/Neo.mjs
+++ b/src/Neo.mjs
@@ -76,7 +76,7 @@ Neo = globalThis.Neo = Object.assign({
             cfg = ctor.config || {};
             
             if (Neo.overrides) {
-                this.applyOverrides(element, cfg);
+                ctor.applyOverrides(cfg);
             }
 
 
@@ -178,42 +178,6 @@ Neo = globalThis.Neo = Object.assign({
         }
 
         return target;
-    },
-
-    /**
-     * Applying overrides and adding this.callOverridden to elements
-     * @param {Neo.core.Base} element 
-     * @param {Object}        cfg 
-     * @protected
-     */
-     applyOverrides (element, cfg) {
-        let overrides = Neo.ns(cfg.className, false, Neo.overrides);
-        if (overrides) {
-            // Apply all methods
-            for (const item in overrides) {
-                if(Neo.isFunction(overrides[item])) {
-                    // Already existing ones
-                    if (element[item]) {
-                        // Create callOverridden
-                        if(!Neo.isFunction(element.callOverridden)) {
-                            element.overriddenMethods = {};
-                            element.callOverridden = function (methodName, ...args) {
-                                this.overriddenMethods[methodName].call(this, ...args);
-                            };
-                        }
-                        // add to overriddenMethods
-                        element.overriddenMethods[item] = element[item];
-                    }
-
-                    // add override method
-                    element[item] = overrides[item];
-                    // delete override method from overrides object
-                    delete overrides[item]
-                }
-            }
-            // Apply configs
-            overrides && Object.assign(cfg, overrides);
-        }
     },
 
     /**

--- a/src/Neo.mjs
+++ b/src/Neo.mjs
@@ -79,7 +79,6 @@ Neo = globalThis.Neo = Object.assign({
                 ctor.applyOverrides(cfg);
             }
 
-
             Object.entries(cfg).forEach(([key, value]) => {
                 if (key.slice(-1) === '_') {
                     delete cfg[key];

--- a/src/Neo.mjs
+++ b/src/Neo.mjs
@@ -179,8 +179,14 @@ Neo = globalThis.Neo = Object.assign({
 
         return target;
     },
-      
-    applyOverrides (element, cfg) {
+
+    /**
+     * Applying overrides and adding this.callOverridden to elements
+     * @param {Neo.core.Base} element 
+     * @param {Object}        cfg 
+     * @protected
+     */
+     applyOverrides (element, cfg) {
         let overrides = Neo.ns(cfg.className, false, Neo.overrides);
         if (overrides) {
             // Apply all methods

--- a/src/core/Base.mjs
+++ b/src/core/Base.mjs
@@ -19,7 +19,7 @@ class Base {
       
     /**
      * Keep the overriden methods
-     * @type {{}}
+     * @type {Object}
      */
     static overriddenMethods = {}
 

--- a/src/core/Base.mjs
+++ b/src/core/Base.mjs
@@ -11,6 +11,13 @@ const configSymbol       = Symbol.for('configSymbol'),
  */
 class Base {
     /**
+     * Regex to grab the MethodName from an error 
+     * which is a second generation function
+     * @type {*}
+     */
+    static methodNameRegex = /\n.*\n\s+at\s+.*\.(\w+)\s+.*/;
+
+    /**
      * True automatically applies the core.Observable mixin
      * @member {Boolean} observable=false
      * @static
@@ -22,7 +29,7 @@ class Base {
      * @type {Object}
      */
     static overriddenMethods = {}
-
+    
     /**
      * Set this one to false in case you don't want to stick
      * to the "anti-pattern" to apply classes to the global Neo or App namespace
@@ -210,7 +217,7 @@ class Base {
      */
     callOverridden(...args) {
         let stack = new Error().stack,
-            regex = /\n.*\n\s+at\s+.*\.(\w+)\s+.*/,
+            regex = Base.methodNameRegex,
             methodName = stack.match(regex)[1];
 
         this.__proto__.constructor.overriddenMethods[methodName].call(this, ...args);

--- a/src/core/Base.mjs
+++ b/src/core/Base.mjs
@@ -149,13 +149,13 @@ class Base {
      * @param {Object} cfg
      * @protected
      */
-    static applyOverrides (cfg) {
+    static applyOverrides(cfg) {
         let overrides = Neo.ns(cfg.className, false, Neo.overrides);
 
         if (overrides) {
             // Apply all methods
             for (const item in overrides) {
-                if(Neo.isFunction(overrides[item])) {
+                if (Neo.isFunction(overrides[item])) {
                     // Already existing ones
                     let cls = this.prototype;
 
@@ -208,7 +208,7 @@ class Base {
      *
      * @param args
      */
-    callOverridden (...args) {
+    callOverridden(...args) {
         let stack = new Error().stack,
             regex = /\n.*\n\s+at\s+.*\.(\w+)\s+.*/,
             methodName = stack.match(regex)[1];


### PR DESCRIPTION
solving #3965

You can use now `this.callOverridden(methodName, ...arguments);`

@example

```
         Neo.overrides = {
             Neo: {
                 component: {
                     Base: {
                         afterSetHeight(value, oldValue) {
                             this.callOverridden('afterSetHeight', ...arguments);
                         }
                     }
                 }
             }
         };

        export default Neo.overrides;
```

Please make sure to read the Contributing Guidelines:

https://github.com/neomjs/neo/blob/dev/CONTRIBUTING.md

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [x] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch, _not_ the `master` branch
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
