### PR TITLE
#4380 update inputPattern regex in form.field.Phone

### DIFF
--- a/src/form/field/Phone.mjs
+++ b/src/form/field/Phone.mjs
@@ -25,7 +25,7 @@ class Phone extends Text {
         /**
          * @member {RegExp|null} inputPattern=/^[0-9\-+\(\) ]+$/
          */
-        inputPattern: /^[0-9\-+\(\) ]+$/,
+        inputPattern: /^\+?\(?[0-9]+\)?([\-\s\.]?[/0-9]+)*$/,
         /**
          * Value for the inputType_ textfield config
          * @member {String} inputType='tel'


### PR DESCRIPTION
Please make sure to read the Contributing Guidelines:

https://github.com/neomjs/neo/blob/dev/CONTRIBUTING.md

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [x] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [x] Yes
- [ ] No

If yes, please describe the impact and migration path for existing applications:
The phone field by default will not accept multiple minus symbols. But it can be changed separately in inputPattern config. 

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch, _not_ the `master` branch
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)

If adding a **new feature**, the PR's description includes:
- [x] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
