### PR TITLE
Fix #4799 - form.field.Select Editable False Behavior

### DIFF
--- a/resources/scss/src/form/field/Picker.scss
+++ b/resources/scss/src/form/field/Picker.scss
@@ -4,8 +4,6 @@
 
         .neo-textfield-input {
             cursor        : pointer;
-            pointer-events: none;
-            user-select   : none;
         }
     }
 }

--- a/src/form/field/Picker.mjs
+++ b/src/form/field/Picker.mjs
@@ -117,10 +117,13 @@ class Picker extends Text {
      * @protected
      */
     afterSetEditable(value, oldValue) {
+        let me = this;
         let cls = this.cls;
 
         NeoArray.toggle(cls, 'neo-not-editable', !value);
         this.cls = cls;
+
+        me['readOnly'] = me.editable ? null : true;
     }
 
     /**
@@ -149,6 +152,16 @@ class Picker extends Text {
         if (this.picker) {
             this.picker.theme = value
         }
+    }
+
+    /**
+     * Determines whether a trigger should be hidden when the field is read-only.
+     *
+     * @returns {Boolean} - Returns true if the trigger should be hidden, false otherwise.
+     * @protected
+     */
+    shouldHideTrigger() {
+        return false;
     }
 
     /**

--- a/src/form/field/Text.mjs
+++ b/src/form/field/Text.mjs
@@ -649,8 +649,18 @@ class Text extends Base {
         me.changeInputElKey('readonly', value ? value : null);
 
         me.triggers?.forEach(trigger => {
-            trigger.hidden = value ? true : trigger.getHiddenState?.() || false
+            trigger.hidden = value && me.shouldHideTrigger() ? true : trigger.getHiddenState?.() || false
         })
+    }
+
+    /**
+     * Determines whether a trigger should be hidden when the field is read-only.
+     *
+     * @returns {Boolean} - Returns true if the trigger should be hidden, false otherwise.
+     * @protected
+     */
+    shouldHideTrigger() {
+        return true;
     }
 
     /**


### PR DESCRIPTION


https://github.com/neomjs/neo/assets/24494104/7491568f-ee24-4664-87ae-a98f60cdb361

## Summary:
This PR addresses the issue outlined in #4799 regarding the behavior of `form.field.Select` when `editable` is set to `false`. Previously, the picker wouldn't hide onFocusLeave() due to certain CSS rules (pointer-events: none; user-select: none;) applied to the input node, causing manager.Focus to be confused as the field wasn't receiving a click event.

## Changes:
- Modified the `shouldHideTrigger` method in `Text.mjs` to return `true` to hide the trigger when the field is read-only.
- Overridden the `shouldHideTrigger` method in `Picker.mjs` to return `false` to not hide the trigger for the Picker class.
- Removed the CSS rules (`pointer-events: none; user-select: none;`) that were causing the onFocusLeave event issue from `.neo-pickerfield .neo-not-editable .neo-textfield-input`.

These changes result in a cleaner and expected behavior of the `form.field.Select` component when `editable` is set to `false`, ensuring that the picker hides correctly on onFocusLeave without being affected by the specified CSS rules.

## Testing:
- Ensure that the `form.field.Select` component behaves as expected when `editable` is set to both `true` and `false`.
- Verify that the onFocusLeave event triggers the picker to hide correctly.
- Test the interaction and focus behavior of the input node and picker trigger under different conditions.

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch, _not_ the `master` branch
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)

