### PR TITLE
Implement `focusTrap` in the Panel Dialog class

### DIFF
--- a/examples/dialog/DemoDialog.mjs
+++ b/examples/dialog/DemoDialog.mjs
@@ -132,6 +132,7 @@ class DemoDialog extends Dialog {
             index                  : nextIndex,
             listeners              : {close: me.onWindowClose, scope: me},
             modal                  : me.app.mainView.down({valueLabelText: 'Modal'}).checked,
+            trapFocus              : true,
             optionalAnimateTargetId: button.id,
             style                  : {left: me.getOffset(), top: me.getOffset()},
             title                  : 'Dialog ' + nextIndex

--- a/examples/dialog/MainContainer.mjs
+++ b/examples/dialog/MainContainer.mjs
@@ -90,6 +90,7 @@ class MainContainer extends Viewport {
             boundaryContainerId    : me.boundaryContainerId,
             listeners              : {close: me.onWindowClose, scope: me},
             modal                  : me.down({valueLabelText: 'Modal'}).checked,
+            trapFocus              : true,
             optionalAnimateTargetId: data.component.id,
             title                  : 'Dialog 1'
         })

--- a/resources/scss/src/dialog/Base.scss
+++ b/resources/scss/src/dialog/Base.scss
@@ -103,3 +103,9 @@
         }
     }
 }
+
+// A focusable, but zero-sized element used to grab and redirect focus in focus-trapped modals
+.neo-focus-trap {
+    position : absolute;
+    clip     : rect(0, 0, 0, 0);
+}

--- a/src/dialog/Base.mjs
+++ b/src/dialog/Base.mjs
@@ -127,7 +127,15 @@ class Base extends Panel {
         /**
          * @member {String|null} title_=null
          */
-        title_: null
+        title_: null,
+
+        /**
+         * Set to `true` to have tabbing wrap within this Dialog.
+         *
+         * Should be used with `modal`.
+         * @member {Boolean}
+         */
+        trapFocus : false
     }
 
     /**
@@ -252,6 +260,13 @@ class Base extends Panel {
         me.rendered && me.syncModalMask()
     }
 
+    afterSetMounted(mounted) {
+        super.afterSetMounted(...arguments);
+
+        // Ensure focus traping is up to date, enabled or disabled.
+        this.syncTrapFocus();
+    }
+
     /**
      * Triggered after the resizable config got changed
      * @param {Boolean} value
@@ -286,6 +301,16 @@ class Base extends Panel {
     afterSetTitle(value, oldValue) {
         if (this.headerToolbar) {
             this.headerToolbar.title = value
+        }
+    }
+
+    afterSetTrapFocus(trapFocus) {
+        this.syncTrapFocus();
+    }
+
+    syncTrapFocus() {
+        if (this.mounted) {
+            Neo.main.DomAccess.trapFocus({ id : this.id, trap : this.trapFocus });
         }
     }
 


### PR DESCRIPTION
This is so that that the <dialog> based dialog class can be replaced by the Neo Panel=based Dialog:

<img width="1726" alt="Screenshot 2023-10-09 at 17 47 55" src="https://github.com/neomjs/neo/assets/200516/ad49c2f9-662d-42fa-957d-d040d9c2f668">
