### PR TITLE
Add isoDate option for DateField class

### DIFF
--- a/src/form/field/Date.mjs
+++ b/src/form/field/Date.mjs
@@ -38,6 +38,10 @@ class DateField extends Picker {
          */
         errorTextInvalidDate: 'Not a valid date',
         /**
+         * @member {Boolean} isoDate=false
+         */
+        isoDate: false,
+        /**
          * True to hide the DatePicker when selecting a day
          * @member {Boolean} hidePickerOnSelect=false
          */
@@ -159,6 +163,17 @@ class DateField extends Picker {
     }
 
     /**
+     * Triggered before the value config got changed
+     * @param {String} value
+     * @param {String} oldValue
+     * @protected
+     */
+    beforeSetValue(value, oldValue) {
+        const val = super.beforeSetValue(value, oldValue);
+        return (this.isoDate && val) ? val.substring(0, 10) : val;
+    }
+
+    /**
      * @returns {Neo.component.DateSelector}
      */
     createPickerComponent() {
@@ -171,7 +186,13 @@ class DateField extends Picker {
     getValue() {
         let value = this.value;
 
-        return this.submitDateObject && value ? new Date(`${value}T00:00:00.000Z`) : value
+        if(this.submitDateObject && value) {
+            return new Date(`${value}T00:00:00.000Z`);
+        } else if(this.isoDate && value) {
+            return new Date(value).toISOString();
+        }
+
+        return value;
     }
 
     /**


### PR DESCRIPTION
Please make sure to read the Contributing Guidelines:

https://github.com/neomjs/neo/blob/dev/CONTRIBUTING.md

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [X] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [X] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [X] It's submitted to the `dev` branch, _not_ the `main` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
