### PR TITLE
readyState logic for running DomEvents.onDomContentLoaded

### DIFF
--- a/src/Main.mjs
+++ b/src/Main.mjs
@@ -113,10 +113,10 @@ class Main extends core.Base {
             scope              : me
         });
 
-        DomEvents.on('domContentLoaded', me.onDomContentLoaded, me);
-
         if (document.readyState !== 'loading') {
             DomEvents.onDomContentLoaded()
+        } else {
+            DomEvents.on('domContentLoaded', me.onDomContentLoaded, me)
         }
     }
 


### PR DESCRIPTION
Need to run DomEvents.onContentLoaded()
1. when the DOM is loaded, be it now or later
2. only the one time 
 
The existing code might run it twice.
For an account of loading events and readyState values see: https://javascript.info/onload-ondomcontentloaded

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch, _not_ the `main` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)
