### PR TITLE
fix classname typo in examples/todoList/version2/TodoListModel.mjs  issue #5858

### DIFF
--- a/examples/todoList/version2/TodoListModel.mjs
+++ b/examples/todoList/version2/TodoListModel.mjs
@@ -6,7 +6,7 @@ import Model from '../../../src/data/Model.mjs';
  */
 class TodoListModel extends Model {
     static config = {
-        className  : 'Neo.examples.todoList.version2.MainModel',
+        className  : 'Neo.examples.todoList.version2.TodoListModel',
         keyProperty: 'id',
 
         fields: [{


### PR DESCRIPTION
fix classname typo in examples/todoList/version2/TodoListModel.mjs  issue #5858

*



