### PR TITLE
tab.Container: getLayoutConfig() => replaced the switch block with an object (map)

### DIFF
--- a/src/tab/Container.mjs
+++ b/src/tab/Container.mjs
@@ -322,43 +322,32 @@ class Container extends BaseContainer {
      * @protected
      */
     getLayoutConfig() {
-        let me           = this,
-            layoutConfig = null;
+        const layoutMap = {
+            'bottom': {
+                ntype: 'vbox',
+                align: 'stretch',
+                direction: 'column-reverse',
+                pack: 'start'
+            },
+            'left': {
+                ntype: 'hbox',
+                align: 'stretch',
+                direction: 'row',
+                pack: 'start'
+            },
+            'right': {
+                ntype: 'hbox',
+                align: 'stretch',
+                direction: 'row-reverse',
+                pack: 'start'
+            },
+            'top': {
+                ntype: 'vbox',
+                align: 'stretch'
+            }
+        };
 
-        switch(me.tabBarPosition) {
-            case 'bottom':
-                layoutConfig = {
-                    ntype    : 'vbox',
-                    align    : 'stretch',
-                    direction: 'column-reverse',
-                    pack     : 'start'
-                };
-                break
-            case 'left':
-                layoutConfig = {
-                    ntype    : 'hbox',
-                    align    : 'stretch',
-                    direction: 'row',
-                    pack     : 'start'
-                };
-                break
-            case 'right':
-                layoutConfig = {
-                    ntype    : 'hbox',
-                    align    : 'stretch',
-                    direction: 'row-reverse',
-                    pack     : 'start'
-                };
-                break
-            case 'top':
-                layoutConfig = {
-                    ntype: 'vbox',
-                    align: 'stretch'
-                };
-                break
-        }
-
-        return layoutConfig
+        return layoutMap[this.tabBarPosition] || null;
     }
 
     /**


### PR DESCRIPTION
Tab Container


**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [x] Code style update
- [x] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

**The PR fulfills these requirements:**

- [X] It's submitted to the `dev` branch, _not_ the `main` branch
- [x] Enhancement #5429 

**Other information:**
This PR refactors the `getLayoutConfig` method to replace the `switch` statement with an object map. The new approach simplifies the logic and improves code readability by using an object to map `tabBarPosition` values directly to their respective layout configurations.

#### Changes:
- Replaced the `switch` block with an object `layoutMap` to store layout configurations for `bottom`, `left`, `right`, and `top`.
- Simplified the layout selection logic to access the corresponding configuration from the map based on `this.tabBarPosition`.
- Fallback behavior remains the same — if no matching layout configuration is found, the function will return `null`.

This change doesn't introduce any breaking changes but enhances maintainability and readability.