### PR TITLE
main.addon.FileSystemAccessAPI   access local file system via picker dialogs

### DIFF
--- a/src/main/addon/FileSystemAccessAPI.mjs
+++ b/src/main/addon/FileSystemAccessAPI.mjs
@@ -1,0 +1,89 @@
+import Base from './Base.mjs';
+
+/**
+ * Basic support for File System Access API
+ *
+ * Note: the "File System API" is available in Web Workers.
+ * However the "File System Access API" extensions are Not available in Web Workers,
+ * because they must handle user gestures and Web Workers do Not have access to the
+ * UI, aka main, thread.
+ *
+ * The extensions return a promises fullfilled by FileSystemHandles,
+ * the FileSystemHandles are serializable and make it through (Neo's) Web Worker
+ * postMessage signaling to the App worker code, and we are in business,
+ *
+ * Only supported by Chrome, Edge, Opera; tested with Neo on Chrome, Opera, Edge:
+ * https://developer.chrome.com/docs/capabilities/web-apis/file-system-access#browser_support
+ *
+ * Note:  method parameters (the opts below) are identical to the method paratmeters in
+ * https://developer.mozilla.org/en-US/docs/Web/API/Window/showOpenFilePicker etc,
+ *
+ * @class Neo.main.addon.FileSystemAccessAPI
+ * @extends Neo.main.addon.Base
+ * @singleton
+ */
+class FileSystemAccessAPI extends Base {
+    static config = {
+        /**
+         * @member {String} className='Neo.main.addon.FileSystemAccessAPI'
+         * @protected
+         */
+        className: 'Neo.main.addon.FileSystemAccessAPI',
+        /**
+         * Remote method access for other workers
+         * @member {Object} remote={app: [//...]}
+         * @protected
+         */
+        remote: {
+            app: [
+                'showDirectoryPicker',
+                'showOpenFilePicker',
+                'showSaveFilePicker',
+                'supported'
+            ]
+        },
+    }
+
+    /**
+     * Shows a directory picker which allows the user to select a directory.
+     * returns a promise fullfilled by a directory handle object.
+     * @param {Object} opts (optional)
+     */
+    showDirectoryPicker(opts) {
+       return window.showDirectoryPicker(opts);
+    }
+
+    /**
+     * Shows a file picker which allows a user to select a file or files.
+     * returns a promise fullfilled an array of 1 or more filehandle objects.
+     * @param {Object} opts  (optional)
+     * https://developer.mozilla.org/en-US/docs/Web/API/Window/showOpenFilePicker
+     */
+    showOpenFilePicker(opts) {
+       return window.showOpenFilePicker(opts);
+    }
+
+    /**
+     * Shows a file picker that allows a user to save a file.
+     * returns a promise fullfilled by a filehandle object fullfillment.
+     * @param {Object} opts  (optional)
+     * https://developer.mozilla.org/en-US/docs/Web/API/Window/showSaveFilePicker
+     */
+    showSaveFilePicker(opts) {
+       return window.showSaveFilePicker(opts);
+    }
+
+    /**
+     * Tests if the browser supports the File System Access API.
+     * Returns true if it does, false if it does not.
+     **/
+    supported() {
+        if ('showOpenFilePicker' in self) {
+            return true
+        } else {
+            return false
+        }
+    }
+}
+
+export default Neo.setupClass(FileSystemAccessAPI);


### PR DESCRIPTION
**This PR adds the one file: src/main/addon/FileSystemAccessAPI.mjs**

**Basic support for the File System Access API:*

Supplies  methods `showDirectoryPicker(), showOpenFilePicker(), showSaveFilePicker()`;  plus the convenience method `supported() ` to test if a browser supports this API.

**Useful Information:**

The "_File System API"_ is available in Web Workers.
However the "_File System Access API_" _extensions_ are Not available in Web Workers,
because the extensions must handle _user gestures_ and Web Workers do Not have access to the
UI thread aka main thread.   Therefore we must add this support via the Neo main/addon approach,

Supported by Chrome, Edge, Opera, but not and never FireFox:
https://developer.chrome.com/docs/capabilities/web-apis/file-system-access#browser_support

Tested with Neo on Chrome, Opera, Edge.

See: https://wicg.github.io/file-system-access   W3C Community File System Access Report

**Reason for this support:**  

Quoting from the above W3C Report:

_This API enables developers to build powerful apps that interact with other (non-Web) apps on the user’s device via the device’s file system. Prominent examples of applications where users expect this functionality are IDEs, photo and video editors, text editors, and more._

In particular, "more" includes  data input files, user-generated annotated data output files, and user-determined session configuration state files, typical of data science and data analysis applications.  For instance, GIS applications.   Such "desktop" applications use the local file system extensively,  to read and persist user-generated files, and do not merely display data from the cloud.

So this is a minimal addon that provides maximal support for Desktop applications.
It could also serve the purpose of a minimalist first exercise in coding main addons.

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [x] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch, _not_ the `main` branch