### PR TITLE
DomAccess:  add rmc CSSsupports  to access CSS.supports()

### DIFF
--- a/src/main/DomAccess.mjs
+++ b/src/main/DomAccess.mjs
@@ -390,15 +390,17 @@ class DomAccess extends Base {
      *   CSS.supports(propertyName, value)
      *   CSS.supports(supportCondition)
      * @param {Object} data
-     * @param {Object} data.CSSarguments
-     * @paran {String} data.CSSarguments.propertyName
-     * @paran {String} data.CSSarguments.supportCondition
-     * @paran {String} data.CSSarguments.value
+     * @param {Object} data.cssArguments
+     * @paran {String} data.cssArguments.propertyName
+     * @paran {String} data.cssArguments.supportCondition
+     * @paran {String} data.cssArguments.value
 
      */
     CSSsupports(data) {
-       let {propertyName, supportCondition, value}  = data.CSSarguments;
-       let result = value ? CSS.supports(propertyName,value) : CSS.supports(supportCondition);
+       let result,
+           {propertyName, supportCondition, value} = data.cssArguments;
+       
+       result = value ? CSS.supports(propertyName,value) : CSS.supports(supportCondition);
        return result;
     }
     

--- a/src/main/DomAccess.mjs
+++ b/src/main/DomAccess.mjs
@@ -82,6 +82,7 @@ class DomAccess extends Base {
                 'align',
                 'applyBodyCls',
                 'blur',
+                'CSSsupports',
                 'execCommand',
                 'focus',
                 'getAttributes',
@@ -378,6 +379,29 @@ class DomAccess extends Base {
         this.getElement(data.id)?.blur();
         return {id: data.id}
     }
+
+    /**
+     * https://developer.mozilla.org/en-US/docs/Web/API/CSS/supports_static
+     * CSS.supports() indicates if the browser supports a given CSS feature
+     * e.g. to validate user color input:
+     *   CSS.supports('color','red') -> true
+     *   CSS.supports('color','reddish') -> false
+     * two syntaxes: 
+     *   CSS.supports(propertyName, value)
+     *   CSS.supports(supportCondition)
+     * @param {Object} data
+     * @param {Object} data.CSSarguments
+     * @paran {String} data.CSSarguments.propertyName
+     * @paran {String} data.CSSarguments.supportCondition
+     * @paran {String} data.CSSarguments.value
+
+     */
+    CSSsupports(data) {
+       let {propertyName, supportCondition, value}  = data.CSSarguments;
+       let result = value ? CSS.supports(propertyName,value) : CSS.supports(supportCondition);
+       return result;
+    }
+    
 
     /**
      * @param {Object} data


### PR DESCRIPTION
Add   Neo.main.DomAccess.CSSsupports()  remote method call, to give App worker logic access to the CSS.supports() method.

use case:   test if user text field input, of a css color value, is a valid color value.  This is a bear to do any other way.   Too see how hard check: https://developer.mozilla.org/en-US/docs/Glossary/html_color_codes

**What kind of change does this PR introduce?** (check at least one)
- [x] Bugfix:

**Does this PR introduce a breaking change?** (check one)
- [x] No


