### PR TITLE
Convert functional/Parse5Processor.mjs Test from Siesta to Playwright #7284

### DIFF
--- a/test/playwright/unit/functional/Parse5Processor.spec.mjs
+++ b/test/playwright/unit/functional/Parse5Processor.spec.mjs
@@ -1,0 +1,82 @@
+import { test, expect } from '@playwright/test';
+import Neo from '../../../../src/Neo.mjs';
+import Button from '../../../../src/button/Base.mjs';
+import HtmlTemplateProcessor from '../../../../src/functional/util/HtmlTemplateProcessor.mjs';
+import { html } from '../../../../src/functional/util/html.mjs';
+
+const processor = HtmlTemplateProcessor;
+
+test.describe('functional/Parse5Processor', () => {
+    let parsedVdomResult;
+    const mockComponent = {
+        continueUpdateWithVdom: vdom => {
+            parsedVdomResult = vdom;
+        }
+    };
+
+    test('should parse a simple template with a single root node', async () => {
+        const template = html`<div><p>Hello</p></div>`;
+        await processor.process(template, mockComponent);
+
+        expect(parsedVdomResult).toEqual({
+            tag: 'div',
+            cn: [{
+                tag: 'p',
+                text: 'Hello'
+            }]
+        });
+    });
+
+    test('should handle interpolated values in text nodes', async () => {
+        const name = 'Neo';
+        const template = html`<p>Hello ${name}</p>`;
+        await processor.process(template, mockComponent);
+
+        expect(parsedVdomResult).toEqual({
+            tag: 'p',
+            text: 'Hello Neo'
+        });
+    });
+
+    test('should handle interpolated values in attributes', async () => {
+        const id = 'my-div';
+        const template = html`<div id="${id}"></div>`;
+        await processor.process(template, mockComponent);
+
+        expect(parsedVdomResult).toEqual({
+            tag: 'div',
+            id: 'my-div'
+        });
+    });
+
+    test('should handle non-string (object) values in attributes', async () => {
+        const styleObj = { color: 'blue', fontWeight: 'bold' };
+        const template = html`<div style="${styleObj}"></div>`;
+        await processor.process(template, mockComponent);
+
+        expect(parsedVdomResult).toEqual({
+            tag: 'div',
+            style: styleObj
+        });
+    });
+
+    test('should handle component tags via interpolation (lexical scope)', async () => {
+        const template = html`<${Button} text="Click Me"/>`;
+        await processor.process(template, mockComponent);
+
+        expect(parsedVdomResult).toEqual({
+            module: Button,
+            text: 'Click Me'
+        });
+    });
+
+    test('should handle component tags via global namespace string', async () => {
+        const template = html`<Neo.button.Base text="Global Click"/>`;
+        await processor.process(template, mockComponent);
+
+        expect(parsedVdomResult).toEqual({
+            module: Button,
+            text: 'Global Click'
+        });
+    });
+});


### PR DESCRIPTION
Closes #7284


Please make sure to read the Contributing Guidelines:

https://github.com/neomjs/neo/blob/dev/CONTRIBUTING.md

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [ ] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [ ] It's submitted to the `dev` branch, _not_ the `main` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
Used AI native workflows to migrate