### PR TITLE
Add empty viewport app

### DIFF
--- a/test/apps/component-test-app/app.mjs
+++ b/test/apps/component-test-app/app.mjs
@@ -1,0 +1,6 @@
+import EmptyViewport from './view/EmptyViewport.mjs';
+
+export const onStart = () => Neo.app({
+    mainView: EmptyViewport,
+    name    : 'ComponentTestApp'
+});

--- a/test/apps/component-test-app/index.html
+++ b/test/apps/component-test-app/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Neo.mjs Component Test App</title>
+</head>
+<body>
+    <script src="../../../src/MicroLoader.mjs" type="module"></script>
+</body>
+</html>

--- a/test/apps/component-test-app/neo-config.json
+++ b/test/apps/component-test-app/neo-config.json
@@ -1,0 +1,9 @@
+{
+    "appPath"         : "test/apps/component-test-app/app.mjs",
+    "basePath"        : "../../../",
+    "environment"     : "development",
+    "mainPath"        : "./Main.mjs",
+    "mainThreadAddons": [],
+    "themes"          : ["neo-theme-light"],
+    "useFallbackApi"  : false
+}

--- a/test/apps/component-test-app/view/EmptyViewport.mjs
+++ b/test/apps/component-test-app/view/EmptyViewport.mjs
@@ -1,0 +1,16 @@
+import Viewport from '../../../src/container/Viewport.mjs';
+
+/**
+ * @class ComponentTestApp.view.EmptyViewport
+ * @extends Neo.container.Viewport
+ */
+class EmptyViewport extends Viewport {
+    static config = {
+        className: 'ComponentTestApp.view.EmptyViewport',
+        id       : 'component-test-viewport',
+        layout   : 'fit',
+        items    : []
+    }
+}
+
+export default Neo.setupClass(EmptyViewport);


### PR DESCRIPTION
Please make sure to read the Contributing Guidelines:

https://github.com/neomjs/neo/blob/dev/CONTRIBUTING.md

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

Fixes #7437

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [x] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch, _not_ the `main` branch
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)

If adding a **new feature**, the PR's description includes:
- [x] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Summary**

- add a minimal “empty viewport” app under test/apps/component-test-app/, exposing a stable root (component-test-viewport) for RMA-based component tests (test/apps/component-test-app/app.mjs:1, test/apps/component-test-app/index.html:1)
- update the dedicated Playwright component config so tests launch against the new app entry point (test/playwright/playwright.config.component.mjs:1)