### PR TITLE
Add MCP read and query endpoints

### DIFF
--- a/ai/mcp/server/memory/routes/memories.mjs
+++ b/ai/mcp/server/memory/routes/memories.mjs
@@ -1,6 +1,6 @@
-import {Router}        from 'express';
-import asyncHandler    from '../middleware/asyncHandler.mjs';
-import {listMemories}  from '../services/memoryService.mjs';
+import {Router}         from 'express';
+import asyncHandler     from '../middleware/asyncHandler.mjs';
+import {listMemories, queryMemories} from '../services/memoryService.mjs';
 
 const router = Router();
 
@@ -43,6 +43,45 @@ router.get('/memories', asyncHandler(async (req, res) => {
         count: memories.length,
         total,
         memories
+    });
+}));
+
+/**
+ * POST /memories/query
+ */
+router.post('/memories/query', asyncHandler(async (req, res) => {
+    const {query, nResults = 10, sessionId} = req.body ?? {};
+
+    if (!query || typeof query !== 'string' || query.trim().length === 0) {
+        const error = new Error('The "query" property is required in the request body.');
+        error.status = 400;
+        throw error;
+    }
+
+    if (sessionId && typeof sessionId !== 'string') {
+        const error = new Error('If provided, "sessionId" must be a string.');
+        error.status = 400;
+        throw error;
+    }
+
+    const parsedResults = parseInt(nResults, 10);
+
+    if (Number.isNaN(parsedResults) || parsedResults < 1 || parsedResults > 100) {
+        const error = new Error('The "nResults" value must be between 1 and 100.');
+        error.status = 400;
+        throw error;
+    }
+
+    const {count, memories} = await queryMemories({
+        query,
+        nResults: parsedResults,
+        sessionId
+    });
+
+    res.status(200).json({
+        query,
+        count,
+        results: memories
     });
 }));
 

--- a/ai/mcp/server/memory/routes/summaries.mjs
+++ b/ai/mcp/server/memory/routes/summaries.mjs
@@ -1,6 +1,6 @@
 import {Router}         from 'express';
 import asyncHandler     from '../middleware/asyncHandler.mjs';
-import {listSummaries}  from '../services/summaryService.mjs';
+import {listSummaries, querySummaries} from '../services/summaryService.mjs';
 
 const router = Router();
 
@@ -34,6 +34,52 @@ router.get('/summaries', asyncHandler(async (req, res) => {
         count: summaries.length,
         total,
         summaries
+    });
+}));
+
+router.post('/summaries/query', asyncHandler(async (req, res) => {
+    const {query, nResults = 10, category} = req.body ?? {};
+
+    if (!query || typeof query !== 'string' || query.trim().length === 0) {
+        const error = new Error('The "query" property is required in the request body.');
+        error.status = 400;
+        throw error;
+    }
+
+    if (category && typeof category !== 'string') {
+        const error = new Error('If provided, "category" must be a string.');
+        error.status = 400;
+        throw error;
+    }
+
+    if (category) {
+        const allowedCategories = ['bugfix', 'feature', 'refactoring', 'documentation', 'new-app', 'analysis', 'other'];
+
+        if (!allowedCategories.includes(category)) {
+            const error = new Error(`Invalid category "${category}". Supported categories: ${allowedCategories.join(', ')}`);
+            error.status = 400;
+            throw error;
+        }
+    }
+
+    const parsedResults = parseInt(nResults, 10);
+
+    if (Number.isNaN(parsedResults) || parsedResults < 1 || parsedResults > 100) {
+        const error = new Error('The "nResults" value must be between 1 and 100.');
+        error.status = 400;
+        throw error;
+    }
+
+    const {count, summaries} = await querySummaries({
+        query,
+        nResults: parsedResults,
+        category
+    });
+
+    res.status(200).json({
+        query,
+        count,
+        results: summaries
     });
 }));
 

--- a/ai/mcp/server/memory/services/summaryService.mjs
+++ b/ai/mcp/server/memory/services/summaryService.mjs
@@ -1,7 +1,8 @@
-import chromaManager from './chromaManager.mjs';
+import chromaManager   from './chromaManager.mjs';
+import {embedText}     from './textEmbeddingService.mjs';
 
 /**
- * Retrieves summaries in reverse chronological order and returns a page of results.
+ * Retrieves summaries in reverse chronological order.
  * @param {Object} options
  * @param {Number} options.limit
  * @param {Number} options.offset
@@ -37,11 +38,68 @@ export async function listSummaries({limit, offset}) {
         };
     }).sort((a, b) => new Date(b.timestamp) - new Date(a.timestamp));
 
-    const total = records.length;
-    const slice = records.slice(offset, offset + limit);
+    const total    = records.length;
+    const paged    = records.slice(offset, offset + limit);
 
     return {
         total,
-        summaries: slice
+        summaries: paged
+    };
+}
+
+/**
+ * Executes a semantic search across all session summaries.
+ * @param {Object} options
+ * @param {String} options.query
+ * @param {Number} options.nResults
+ * @param {String} [options.category]
+ * @returns {Promise<{count: number, summaries: Object[]}>}
+ */
+export async function querySummaries({query, nResults, category}) {
+    const collection = await chromaManager.getSummaryCollection();
+    const embedding  = await embedText(query);
+
+    const searchResult = await collection.query({
+        queryEmbeddings: [embedding],
+        nResults,
+        where          : category ? {category} : undefined,
+        include        : ['metadatas', 'documents']
+    });
+
+    const ids        = searchResult.ids?.[0] || [];
+    const distances  = searchResult.distances?.[0] || [];
+    const metadatas  = searchResult.metadatas?.[0] || [];
+    const documents  = searchResult.documents?.[0] || [];
+
+    const summaries = ids.map((id, index) => {
+        const metadata = metadatas[index] || {};
+        const document = documents[index] || '';
+        const distance = Number(distances[index] ?? 0);
+        const relevanceScore = Number((1 / (1 + distance)).toFixed(6));
+        const techSource = metadata.technologies || '';
+
+        return {
+            id,
+            sessionId  : metadata.sessionId,
+            timestamp  : metadata.timestamp,
+            title      : metadata.title,
+            summary    : document,
+            category   : metadata.category,
+            memoryCount: Number(metadata.memoryCount) || 0,
+            quality    : Number(metadata.quality) || 0,
+            productivity: Number(metadata.productivity) || 0,
+            impact     : Number(metadata.impact) || 0,
+            complexity : Number(metadata.complexity) || 0,
+            technologies: techSource
+                ? techSource.split(',').map(item => item.trim()).filter(Boolean)
+                : [],
+            distance,
+            relevanceScore
+        };
+    });
+
+    return {
+        count    : summaries.length,
+        summaries: summaries
     };
 }

--- a/ai/mcp/server/memory/services/textEmbeddingService.mjs
+++ b/ai/mcp/server/memory/services/textEmbeddingService.mjs
@@ -1,0 +1,37 @@
+import {GoogleGenerativeAI} from '@google/generative-ai';
+import aiConfig             from '../../../../../buildScripts/ai/aiConfig.mjs';
+
+let embeddingModel = null;
+
+function getEmbeddingModel() {
+    if (embeddingModel) {
+        return embeddingModel;
+    }
+
+    const apiKey = process.env.GEMINI_API_KEY;
+
+    if (!apiKey) {
+        const error = new Error('The GEMINI_API_KEY environment variable must be set to use semantic search endpoints.');
+        error.status = 503;
+        error.code   = 'missing_gemini_api_key';
+        throw error;
+    }
+
+    const genAI = new GoogleGenerativeAI(apiKey);
+
+    embeddingModel = genAI.getGenerativeModel({model: aiConfig.knowledgeBase.embeddingModel});
+
+    return embeddingModel;
+}
+
+/**
+ * Creates an embedding vector for the provided text.
+ * @param {String} text
+ * @returns {Promise<number[]>}
+ */
+export async function embedText(text) {
+    const model    = getEmbeddingModel();
+    const result   = await model.embedContent(text);
+
+    return result.embedding.values;
+}


### PR DESCRIPTION
Please make sure to read the Contributing Guidelines:
https://github.com/neomjs/neo/blob/dev/CONTRIBUTING.md

Fixes #7408 #7409

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [x] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch, _not_ the `main` branch
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)

If adding a **new feature**, the PR's description includes:
- [x] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Summary**
- add GET /memories backed by Chroma listMemories service with pagination
- add GET /summaries backed by listSummaries service returning metadata & docs
- keep responses aligned with MemoryCoreMcpApi design to unblock search + admin work
- Extends the Memory MCP service with semantic search: wraps Gemini embeddings in textEmbeddingService.mjs, reuses chromaManager, and augments both route handlers to expose POST /memories/query and POST /summaries/query. (ai/mcp/server/memory/services/textEmbeddingService.mjs:1, ai/mcp/server/memory/services/memoryService.mjs:1, ai/mcp/server/memory/services/summaryService.mjs:1, ai/mcp/server/memory/routes/memories.mjs:1, ai/mcp/server/memory/routes/summaries.mjs:1)
 - Each endpoint validates input, optionally filters by session/category, calls Chroma’s query, and returns relevance metadata (distance + normalized score) in the shape defined by openapi.yaml.