### PR TITLE
fix #7467: AI query blog filtering issue

### DIFF
--- a/buildScripts/ai/queryKnowledgeBase.mjs
+++ b/buildScripts/ai/queryKnowledgeBase.mjs
@@ -83,7 +83,15 @@ class QueryKnowledgeBase {
 
         let whereClause = {};
         if (type && type !== 'all') {
-            whereClause = {type: type};
+            if (type === 'blog') {
+                // Blog content is stored as type: 'guide' with isBlog: true
+                whereClause = {
+                    type  : 'guide',
+                    isBlog: 'true'  // ChromaDB stores metadata as strings
+                };
+            } else {
+                whereClause = {type: type};
+            }
         }
 
         const queryOptions = {


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch, _not_ the `main` branch
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)

**Description:**

This PR fixes issue #7467 where the AI query system was unable to find content in blog posts when using the `-t blog` filter.

**Problem:**
The `npm run ai:query -- -q "term" -t blog` command was failing to return results even when the search term existed in blog files. This was breaking the AI knowledge base's ability to access blog content, undermining the framework's "Anti-Hallucination Policy".

**Root Cause:**
- Blog content is stored in the knowledge base as `type: 'guide'` with `isBlog: true`
- The query filter was incorrectly looking for `type: 'blog'` (which doesn't exist)
- This mismatch caused zero results for all blog queries

**Solution:**
Updated the filtering logic in `buildScripts/ai/queryKnowledgeBase.mjs` to correctly handle blog queries:

```javascript
// Before (broken)
whereClause = {type: type};

// After (fixed)
if (type === 'blog') {
    whereClause = {
        type: 'guide',
        isBlog: 'true'  // ChromaDB stores metadata as strings
    };
} else {
    whereClause = {type: type};
}