### PR TITLE
fix/functional.component.Base: enhance destroy() signature

### DIFF
--- a/src/functional/component/Base.mjs
+++ b/src/functional/component/Base.mjs
@@ -299,23 +299,25 @@ class FunctionalBase extends Abstract {
     }
 
     /**
-     *
+     * Destroys the functional component
+     * @param {Boolean} [updateParentVdom=false] true to remove the component from the parent vdom => real dom
+     * @param {Boolean} [silent=false] true to update the vdom silently (useful for destroying multiple child items in a row)
      */
-    destroy() {
+    destroy(updateParentVdom=false, silent=false) {
         const me = this;
 
         me.vdomEffect?.destroy();
 
         // Destroy all classic components instantiated by this functional component
         me.childComponents?.forEach(childData => {
-            childData.instance.destroy()
+            childData.instance.destroy(false, true) // Pass silent=true
         });
         me.childComponents?.clear();
 
         // Remove any pending DOM event listeners that might not have been mounted
         me[pendingDomEventsSymbol] = null;
 
-        super.destroy()
+        super.destroy(updateParentVdom, silent)
     }
 
     /**


### PR DESCRIPTION
Closes #7062

**What kind of change does this PR introduce?** (check at least one)
- [ ] Bugfix
- [x] Feature
- [ ] Code style update
- [x] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)
- [ ] Yes
- [x] No

**The PR fulfills this requirement:**
- [x] It's submitted to the `dev` branch, _not_ the `main` branch

**Other information:**

## Summary
Enhanced the `destroy()` method signature in `functional.component.Base` to match the pattern used in `component.Base` and `container.Base`.

## Changes
- Added `updateParentVdom` and `silent` parameters to the `destroy()` method
- Pass `silent=true` when destroying child components to prevent unnecessary vdom updates
- Pass parameters to `super.destroy()` for consistency with component hierarchy

## Why This Change?
- **Performance**: Prevents each child component from triggering individual vdom worker calls during batch destruction
- **Consistency**: Matches the established pattern in `component.Base` ([L1144](https://github.com/neomjs/neo/blob/dev/src/component/Base.mjs#L1144)) and `container.Base` ([L476](https://github.com/neomjs/neo/blob/dev/src/container/Base.mjs#L476))
- **Optimization**: Avoids unnecessary calls to the vdom worker when destroying components with multiple children

## Testing
The change follows the existing pattern from:
- `src/component/Base.mjs#L1144`
- `src/container/Base.mjs#L476`
- `src/component/Abstract.mjs#L284`

No breaking changes - the method remains backwards compatible with default parameter values.