### PR TITLE
Adds a lightweight test gate for GitHub-dependent integration tests 

### DIFF
--- a/test/playwright/mcp/github-workflow/ghIntegrationGate.spec.mjs
+++ b/test/playwright/mcp/github-workflow/ghIntegrationGate.spec.mjs
@@ -1,0 +1,13 @@
+import { getGateStatus } from './test-support/ghGate.mjs';
+
+// Simple gate check used by CI to determine whether to run GH integration tests.
+const status = getGateStatus();
+
+if (!status.run) {
+    console.log(`SKIP: GH integration tests gated off (${status.reasons.join('; ')})`);
+    // Exit zero to indicate tests were skipped intentionally
+    process.exit(0);
+} else {
+    console.log('RUN: GH integration gate enabled');
+    process.exit(0);
+}

--- a/test/playwright/mcp/github-workflow/test-support/ghGate.mjs
+++ b/test/playwright/mcp/github-workflow/test-support/ghGate.mjs
@@ -1,0 +1,34 @@
+import { execSync } from 'child_process';
+
+/**
+ * Lightweight gate helper for GH integration tests.
+ * See ai/mcp/server/github-workflow/test-support/ghGate.mjs for original placement.
+ */
+export function getGateStatus() {
+    const reasons = [];
+
+    if (process.env.RUN_GH_INTEGRATION !== 'true') {
+        reasons.push('RUN_GH_INTEGRATION != true');
+        return { run: false, reasons };
+    }
+
+    if (process.env.GITHUB_TOKEN) {
+        return { run: true, reasons };
+    }
+
+    try {
+        const out = execSync('gh auth status', { stdio: ['ignore', 'pipe', 'pipe'] }).toString();
+        if (out.includes('Logged in to github.com')) {
+            return { run: true, reasons };
+        }
+        reasons.push('gh not authenticated');
+        return { run: false, reasons };
+    } catch (e) {
+        reasons.push('gh not available');
+        return { run: false, reasons };
+    }
+}
+
+export function shouldRunGhIntegration() {
+    return getGateStatus().run;
+}


### PR DESCRIPTION

#### Summary:
Adds a lightweight test gate for GitHub-dependent integration tests and small diagnostic log polish for the `github-workflow` HealthService so CI can reliably skip or run GH-integration tests based on explicit flags and authentication presence.


#### Why:

Prevents flaky CI runs when gh or `GITHUB_TOKEN` is missing by making GH-integration tests opt-in.
Adds concise, consistent diagnostic log lines from `HealthService` to make status detection easier for humans and CI/logging tools.

Closes #7714 



**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [x] Other, please describe: Enhancement

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills this requirement:**

- [ ] It's submitted to the `dev` branch, _not_ the `main` branch

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
