### PR TITLE
docs: add label component test plan (#7488)

### DIFF
--- a/.github/ISSUE/ticket-cpm-test-component-label.md
+++ b/.github/ISSUE/ticket-cpm-test-component-label.md
@@ -1,0 +1,54 @@
+---
+title: 'Create Playwright Component Test for Neo.component.Label'
+labels: 'enhancement, testing, hacktoberfest, good first issue, help wanted, ai'
+---
+
+GH ticket id: (leave blank, will be assigned)
+
+**Epic:** Migrate Component Tests from Siesta to Playwright (R&D)
+**Phase:** 2
+**Status:** To Do
+
+## Description
+
+This ticket is to create a new Playwright-based component test for `Neo.component.Label`.
+
+This test plan was generated using the AI-Native workflow defined in the "Cookbook Epic" and will serve as the acceptance criteria for the implementation. The test should be created in a new file `test/playwright/component/component/Label.spec.mjs` and follow the "Empty Viewport" architecture.
+
+## Acceptance Criteria
+
+### 1. Inherited Behavior Tests (from Neo.component.Base & Neo.component.Abstract)
+
+- [ ] **`appName` config:** Test that the `appName` config is correctly set and accessible.
+- [ ] **`bind` config:** Test that data binding works correctly with a state provider (if applicable).
+- [ ] **`cls` & `baseCls` configs:** Test that `baseCls` (`neo-label`) and custom `cls` values are correctly applied to the component's root element.
+- [ ] **`data` config:** Test that the `data` config correctly reflects merged data from parent state providers.
+- [ ] **`disabled` config:** Test that setting `disabled: true` adds the `.neo-disabled` class and prevents user interaction.
+- [ ] **`height`, `width`, `minHeight`, `maxHeight`, `minWidth`, `maxWidth` configs:** Test that dimension configs are correctly applied to the component's style.
+- [ ] **`hidden` config:** Test that setting `hidden: true` removes the component from the DOM (using `removeDom` hideMode) or sets `visibility: hidden` (using `visibility` hideMode).
+- [ ] **`html` config:** Test that the `html` config correctly sets the innerHTML of the component.
+- [ ] **`id` config:** Test that the component's unique ID is correctly set and used in the DOM.
+- [ ] **`isLoading` config:** Test that setting `isLoading: true` displays a loading mask with the `neo-load-mask` and `neo-masked` classes.
+- [ ] **`keys` config:** Test that keyboard navigation is correctly set up (if applicable).
+- [ ] **`mounted` config:** Test that the `mounted` config is true after the component is mounted to the DOM.
+- [ ] **`plugins` config:** Test that plugins are correctly instantiated and applied (if applicable).
+- [ ] **`reference` config:** Test that the component can be accessed via its reference.
+- [ ] [ ] **`role` config:** Test that the `role` attribute is correctly applied to the component's root element.
+- [ ] **`scrollable` config:** Test that setting `scrollable: true` adds the `neo-scrollable` class and applies `overflow: auto` style.
+- [ ] **`stateProvider` config:** Test that a state provider can be attached and its data accessed.
+- [ ] **`style` config:** Test that custom inline styles are correctly applied to the component's root element.
+- [ ] **`tag` config:** Test that the component's root HTML tag can be changed.
+- [ ] **`text` config:** Test that the `text` config correctly sets the textContent of the component.
+- [ ] **`theme` config:** Test that theme classes are correctly applied and inherited.
+- [ ] **`tooltip` config:** Test that a tooltip is correctly created and displayed on hover.
+- [ ] **`ui` config:** Test that custom UI classes are correctly applied (e.g., `neo-label-my-ui`).
+- [ ] **`windowId` config:** Test that the `windowId` is correctly set and used.
+- [ ] **`wrapperCls` & `wrapperStyle` configs:** Test that wrapper classes and styles are correctly applied.
+
+### 2. Component-Specific Feature Tests (Neo.component.Label)
+
+- [ ] **`baseCls`:** Verify that the `neo-label` class is always present on the component's root element.
+- [ ] **`tag`:** Verify that the component renders as a `<label>` HTML element by default.
+- [ ] **`text` config:** Verify that the `text` config directly sets the `textContent` of the `<label>` element.
+- [ ] **`user-select: none`:** Verify that the `user-select: none` CSS property is applied to the label, preventing text selection.
+- [ ] **`white-space: nowrap`:** Verify that the `white-space: nowrap` CSS property is applied to the label, preventing text wrapping.


### PR DESCRIPTION
Please make sure to read the Contributing Guidelines:

https://github.com/neomjs/neo/blob/dev/CONTRIBUTING.md

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**Does this PR resolve an issue?** (Required)

Closes #

<!-- If this PR doesn't close an issue, please explain why: -->

<!-- PRs without issue references may be closed. Please create an issue first if one doesn't exist. -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [x] Other, please describe: `Documentation Update`

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills this requirement:**

- [x] It's submitted to the `dev` branch, _not_ the `main` branch

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**

### 📝 Summary
This PR adds a detailed test plan outlining inherited behavior scenarios for the **Label component** `(Neo.form.field.Text)`.
It ensures consistent functionality, predictable DOM behavior, and compliance with Neo’s framework standards.

### 🔄 Changes
- Added test plan documentation for the Label component at: `.github/ISSUE/ticket-cpm-test-component-label.md`
- Covered inherited behaviors including:
    - `disabled`, `hidden`, `cls`, and `style` configurations
    - DOM state validation for disabled/hidden states
    - Programmatic value update handling (`value` config)
    - `isDirty` flag change detection


### 💡 Impact
- Establishes a **baseline test structure** for inherited Label behavior
- Enhances **framework consistency** and developer confidence when extending components
- **No runtime or functional code changes** — documentation-only contribution

**Other information:**

This PR is part of the **Hacktoberfest 2025 initiative** to improve test coverage and developer documentation across the Neo.mjs component library.

**Markdown preview:** [ticket-cpm-test-component-label](https://github.com/Alachi24/neo/blob/testplan_docs/label-component/.github/ISSUE/ticket-cpm-test-component-label.md)

Closes #7488 

Everything has been worked on and I had to redo a new PR for it to be in order.
kindly review and let me know if there are any other issue @tobiu 