### PR TITLE
Adds Blocked By and Blocking to issue relationship tool

### DIFF
--- a/ai/mcp/server/github-workflow/openapi.yaml
+++ b/ai/mcp/server/github-workflow/openapi.yaml
@@ -719,31 +719,35 @@ paths:
 
   /issues/relationship:
     post:
-      summary: Manage Parent-Child Issue Relationships
+      summary: Manage Issue Relationships (Parent-Child and Blocked-By)
       operationId: update_issue_relationship
       x-pass-as-object: true
       x-annotations:
         readOnlyHint: false
       description: |
-        Manages parent-child relationships between GitHub issues using the sub-issues feature.
-        This tool allows you to set or unset the parent of a child issue, which automatically
-        updates the parent's `subIssues` array on GitHub.
+        Manages relationships between GitHub issues including parent-child hierarchies and blocked-by dependencies.
+        This tool allows you to set or unset relationships between issues on GitHub.
+
+        **Relationship Types:**
+        - **parent_child**: Creates hierarchical relationships (epics with sub-tasks)
+        - **blocked_by**: Creates dependency relationships (issue A is blocked by issue B)
 
         **When to Use:**
         - To organize work by creating issue hierarchies (epics with sub-tasks)
-        - To link a child issue to a parent issue
-        - To unlink a child issue from its parent
+        - To track dependencies where one issue blocks another
+        - To unlink issues from their relationships
         - To move a child issue from one parent to another
 
         **Important Notes:**
         - Changes are made directly on GitHub via the GraphQL API
         - The local markdown files will be updated on the next `sync_all` operation
-        - An issue can only have ONE parent at a time
-        - Use `replace_parent=true` to replace an existing parent relationship
-        - To remove a parent, call with only `child_issue` specified (omit `parent_issue`)
+        - For parent_child: An issue can only have ONE parent at a time
+        - For blocked_by: An issue can be blocked by MULTIPLE issues
+        - Use `replace_parent=true` to replace an existing parent relationship (parent_child only)
+        - To remove relationships, call with only `child_issue` specified (omit `parent_issue`)
 
         **Workflow:**
-        1. Identify the child issue number and parent issue number
+        1. Identify the issue numbers and relationship type
         2. Call this tool to establish or modify the relationship
         3. Run `sync_all` to update local markdown files with the new relationship
       tags: [Issues]
@@ -756,19 +760,34 @@ paths:
               required:
                 - child_issue
               properties:
+                relationship_type:
+                  type: string
+                  enum: [parent_child, blocked_by]
+                  description: |
+                    The type of relationship to manage:
+                    - parent_child: Hierarchical parent-child relationships
+                    - blocked_by: Dependency blocking relationships
+                  default: parent_child
+                  example: parent_child
                 child_issue:
                   type: integer
-                  description: The issue number of the child issue.
+                  description: |
+                    The issue number of the child/blocked issue.
+                    For parent_child: This is the sub-issue.
+                    For blocked_by: This is the issue being blocked.
                   example: 7388
                 parent_issue:
                   type: integer
                   description: |
-                    The issue number of the parent issue. 
-                    Omit this field (or set to null) to remove the parent relationship.
+                    The issue number of the parent/blocking issue.
+                    For parent_child: This is the parent issue.
+                    For blocked_by: This is the issue doing the blocking.
+                    Omit this field (or set to null) to remove the relationship.
                   example: 7385
                 replace_parent:
                   type: boolean
                   description: |
+                    Only applicable for parent_child relationships.
                     If true, replaces the child's existing parent relationship.
                     If false and the child already has a parent, the operation will fail.
                   default: false

--- a/ai/mcp/server/github-workflow/services/IssueService.mjs
+++ b/ai/mcp/server/github-workflow/services/IssueService.mjs
@@ -6,7 +6,7 @@ import {exec}                      from 'child_process';
 import {promisify}                 from 'util';
 import {spawn}                     from 'child_process';
 import {GET_ISSUE_AND_LABEL_IDS, FETCH_ISSUES_FOR_SYNC, DEFAULT_QUERY_LIMITS}   from './queries/issueQueries.mjs';
-import {ADD_LABELS, REMOVE_LABELS, ADD_SUB_ISSUE, REMOVE_SUB_ISSUE, GET_ISSUE_ID} from './queries/mutations.mjs';
+import {ADD_LABELS, REMOVE_LABELS, ADD_SUB_ISSUE, REMOVE_SUB_ISSUE, ADD_BLOCKED_BY, REMOVE_BLOCKED_BY, GET_ISSUE_ID} from './queries/mutations.mjs';
 import RepositoryService           from './RepositoryService.mjs';
 
 const execAsync = promisify(exec);
@@ -390,18 +390,28 @@ class IssueService extends Base {
     }
 
     /**
-     * Manages parent-child relationships between GitHub issues using the sub-issues feature.
-     * This method allows setting or unsetting the parent of a child issue, which automatically
-     * updates the parent's subIssues array on GitHub.
+     * Manages relationships between GitHub issues including parent-child and blocked-by relationships.
+     * This method allows setting or unsetting relationships between issues on GitHub.
      *
      * @param {object} options
-     * @param {number} options.child_issue - The issue number of the child issue
-     * @param {number} [options.parent_issue] - The issue number of the parent issue (omit to unset parent)
-     * @param {boolean} [options.replace_parent=false] - If true, replaces existing parent relationship
+     * @param {string} [options.relationship_type='parent_child'] - Type of relationship: 'parent_child' or 'blocked_by'
+     * @param {number} options.child_issue - The issue number of the child/blocked issue
+     * @param {number} [options.parent_issue] - The issue number of the parent/blocking issue (omit to unset relationship)
+     * @param {boolean} [options.replace_parent=false] - If true, replaces existing parent relationship (parent_child only)
      * @returns {Promise<object>} Result with updated relationship information or error
      */
-    async updateIssueRelationship({child_issue, parent_issue = null, replace_parent = false}) {
+    async updateIssueRelationship({relationship_type = 'parent_child', child_issue, parent_issue = null, replace_parent = false}) {
         try {
+            // Validate relationship type
+            const validTypes = ['parent_child', 'blocked_by'];
+            if (!validTypes.includes(relationship_type)) {
+                return {
+                    error  : 'Invalid relationship_type',
+                    message: `relationship_type must be one of: ${validTypes.join(', ')}`,
+                    code   : 'INVALID_RELATIONSHIP_TYPE'
+                };
+            }
+
             // Get GraphQL IDs for both issues
             const childIdData = await GraphqlService.query(GET_ISSUE_ID, {
                 owner : aiConfig.owner,
@@ -411,6 +421,12 @@ class IssueService extends Base {
 
             const childIssueId = childIdData.repository.issue.id;
 
+            // Handle blocked_by relationship type
+            if (relationship_type === 'blocked_by') {
+                return await this.#handleBlockedByRelationship(child_issue, childIssueId, parent_issue);
+            }
+
+            // Handle parent_child relationship type (original logic)
             // If parent_issue is null or undefined, we're removing the relationship
             if (!parent_issue) {
                 // To remove a parent, we need the current parent's ID
@@ -501,6 +517,92 @@ class IssueService extends Base {
                 code   : 'GRAPHQL_API_ERROR'
             };
         }
+    }
+
+    /**
+     * Handles "blocked by" relationships between issues.
+     * @param {number} blockedIssue - The issue number being blocked
+     * @param {string} blockedIssueId - The GraphQL ID of the blocked issue
+     * @param {number|null} blockingIssue - The issue number doing the blocking (null to remove)
+     * @returns {Promise<object>} Result with updated relationship information
+     * @private
+     */
+    async #handleBlockedByRelationship(blockedIssue, blockedIssueId, blockingIssue) {
+        // If blockingIssue is null, we're removing a blocked-by relationship
+        if (!blockingIssue) {
+            // Fetch current blockedBy relationships
+            const blockedData = await GraphqlService.query(`
+                query GetBlockedBy($owner: String!, $repo: String!, $number: Int!) {
+                    repository(owner: $owner, name: $repo) {
+                        issue(number: $number) {
+                            blockedBy(first: 100) {
+                                nodes {
+                                    id
+                                    number
+                                }
+                            }
+                        }
+                    }
+                }
+            `, {
+                owner : aiConfig.owner,
+                repo  : aiConfig.repo,
+                number: blockedIssue
+            }, true); // Enable sub-issues feature for blocked-by access
+
+            const currentBlockers = blockedData.repository.issue.blockedBy.nodes;
+
+            if (currentBlockers.length === 0) {
+                logger.info(`Issue #${blockedIssue} has no blocking relationships to remove`);
+                return {
+                    message     : `Issue #${blockedIssue} has no blocked-by relationships to remove`,
+                    blockedIssue: blockedIssue,
+                    blockingIssue: null
+                };
+            }
+
+            // Remove all blockedBy relationships
+            const removals = [];
+            for (const blocker of currentBlockers) {
+                const result = await GraphqlService.query(REMOVE_BLOCKED_BY, {
+                    issueId        : blockedIssueId,
+                    blockingIssueId: blocker.id
+                }, true);
+                removals.push(blocker.number);
+            }
+
+            logger.info(`Successfully removed blocked-by relationships from #${blockedIssue}: ${removals.join(', ')}`);
+
+            return {
+                message       : `Successfully removed all blocked-by relationships from issue #${blockedIssue}`,
+                blockedIssue  : blockedIssue,
+                blockingIssue : null,
+                removedBlockers: removals
+            };
+        }
+
+        // Adding a blocked-by relationship
+        const blockingIdData = await GraphqlService.query(GET_ISSUE_ID, {
+            owner : aiConfig.owner,
+            repo  : aiConfig.repo,
+            number: blockingIssue
+        });
+
+        const blockingIssueId = blockingIdData.repository.issue.id;
+
+        // Add the blocked-by relationship
+        const result = await GraphqlService.query(ADD_BLOCKED_BY, {
+            issueId        : blockedIssueId,
+            blockingIssueId: blockingIssueId
+        }, true); // Enable sub-issues feature
+
+        logger.info(`Successfully added blocked-by relationship: #${blockedIssue} is now blocked by #${blockingIssue}`);
+
+        return {
+            message      : `Successfully set #${blockingIssue} as blocking #${blockedIssue}`,
+            blockedIssue : blockedIssue,
+            blockingIssue: blockingIssue
+        };
     }
 }
 

--- a/ai/mcp/server/github-workflow/services/queries/issueQueries.mjs
+++ b/ai/mcp/server/github-workflow/services/queries/issueQueries.mjs
@@ -120,6 +120,23 @@ export const FETCH_ISSUES_FOR_SYNC = `
             completed
             percentCompleted
           }
+          
+          # Blocked-by relationships
+          blockedBy(first: $maxSubIssues) {
+            nodes {
+              number
+              title
+              state
+            }
+          }
+          
+          blocking(first: $maxSubIssues) {
+            nodes {
+              number
+              title
+              state
+            }
+          }
         }
       }
     }
@@ -206,6 +223,20 @@ export const FETCH_SINGLE_ISSUE = `
           total
           completed
           percentCompleted
+        }
+        blockedBy(first: $maxSubIssues) {
+          nodes {
+            number
+            title
+            state
+          }
+        }
+        blocking(first: $maxSubIssues) {
+          nodes {
+            number
+            title
+            state
+          }
         }
       }
     }

--- a/ai/mcp/server/github-workflow/services/queries/mutations.mjs
+++ b/ai/mcp/server/github-workflow/services/queries/mutations.mjs
@@ -177,3 +177,83 @@ export const REMOVE_SUB_ISSUE = `
         }
     }
 `;
+
+/**
+ * Mutation to add a "blocked by" relationship to an issue.
+ *
+ * Variables required:
+ * - $issueId: ID! - The global GraphQL ID of the issue being blocked
+ * - $blockingIssueId: ID! - The global GraphQL ID of the issue that blocks it
+ */
+export const ADD_BLOCKED_BY = `
+    mutation AddBlockedBy(
+        $issueId: ID!
+        $blockingIssueId: ID!
+    ) {
+        addBlockedBy(input: {
+            issueId: $issueId
+            blockingIssueId: $blockingIssueId
+        }) {
+            issue {
+                number
+                title
+                blockedBy(first: 100) {
+                    nodes {
+                        number
+                        title
+                    }
+                }
+            }
+            blockingIssue {
+                number
+                title
+                blocking(first: 100) {
+                    nodes {
+                        number
+                        title
+                    }
+                }
+            }
+        }
+    }
+`;
+
+/**
+ * Mutation to remove a "blocked by" relationship from an issue.
+ *
+ * Variables required:
+ * - $issueId: ID! - The global GraphQL ID of the blocked issue
+ * - $blockingIssueId: ID! - The global GraphQL ID of the blocking issue to remove
+ */
+export const REMOVE_BLOCKED_BY = `
+    mutation RemoveBlockedBy(
+        $issueId: ID!
+        $blockingIssueId: ID!
+    ) {
+        removeBlockedBy(input: {
+            issueId: $issueId
+            blockingIssueId: $blockingIssueId
+        }) {
+            issue {
+                number
+                title
+                blockedBy(first: 100) {
+                    nodes {
+                        number
+                        title
+                    }
+                }
+            }
+            blockingIssue {
+                number
+                title
+                blocking(first: 100) {
+                    nodes {
+                        number
+                        title
+                    }
+                }
+            }
+        }
+    }
+`;


### PR DESCRIPTION
#### summary:
Extends the existing `update_issue_relationship` tool to support GitHub's "blocked by" and "blocking" relationship types, enabling dependency tracking between issues.


Closes #7749 



**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [x] Other, please describe: enhancement

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills this requirement:**

- [x] It's submitted to the `dev` branch, _not_ the `main` branch

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
