### PR TITLE
Adds update_comment Tool to GitHub Workflow

### DIFF
--- a/ai/mcp/server/github-workflow/openapi.yaml
+++ b/ai/mcp/server/github-workflow/openapi.yaml
@@ -338,6 +338,81 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
 
+  /comments/{comment_id}:
+    patch:
+      summary: Update an Existing Comment
+      operationId: update_comment
+      x-annotations:
+        readOnlyHint: false
+      description: |
+        Updates the body of an existing comment on a pull request or issue. This is useful for correcting errors in previously posted comments.
+
+        **When to Use:**
+        - To fix errors in a comment you previously posted
+        - To update a comment with additional information
+        - To correct formatting or content mistakes
+
+        **How to Get comment_id:**
+        The comment ID is the global node ID returned when creating a comment via `create_comment`, or it can be retrieved from the conversation using `get_conversation`. The comment ID is a string starting with "IC_" (for issue comments) or "PRRC_" (for PR review comments).
+
+        **Note:**
+        You can only update comments that were created by your authenticated user. Attempting to update another user's comment will result in an error.
+      tags: [Pull Requests]
+      parameters:
+        - name: comment_id
+          in: path
+          required: true
+          description: The global node ID of the comment to update (e.g., "IC_kwDOABcD..." or "PRRC_kwDOABcD...").
+          schema:
+            type: string
+            example: "IC_kwDOABcD1234567890"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - body
+              properties:
+                body:
+                  type: string
+                  description: The new body content for the comment. This replaces the entire comment body.
+                  example: "Updated: This looks great! I've reviewed the changes and approve."
+      responses:
+        '200':
+          description: Comment updated successfully.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                    example: "Successfully updated comment IC_kwDOABcD1234567890"
+                  commentId:
+                    type: string
+                    example: "IC_kwDOABcD1234567890"
+                  url:
+                    type: string
+                    example: "https://github.com/neomjs/neo/pull/123#issuecomment-1234567890"
+                  updatedAt:
+                    type: string
+                    format: date-time
+                    example: "2025-11-12T10:30:00Z"
+        '404':
+          description: Comment not found or you don't have permission to update it.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Internal server error, GraphQL API request failed.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
   /issues/{issue_number}/labels:
     post:
       summary: Add labels to an issue or PR

--- a/ai/mcp/server/github-workflow/services/queries/pullRequestQueries.mjs
+++ b/ai/mcp/server/github-workflow/services/queries/pullRequestQueries.mjs
@@ -54,6 +54,25 @@ export const ADD_COMMENT = `
 `;
 
 /**
+ * Mutation to update an existing comment.
+ *
+ * Variables required:
+ * - $commentId: ID! - The global ID of the comment to update
+ * - $body: String! - The new comment body
+ */
+export const UPDATE_COMMENT = `
+  mutation UpdateComment($commentId: ID!, $body: String!) {
+    updateIssueComment(input: {id: $commentId, body: $body}) {
+      issueComment {
+        id
+        url
+        updatedAt
+      }
+    }
+  }
+`;
+
+/**
  * Query to get the global ID of a pull request.
  *
  * Variables required:

--- a/ai/mcp/server/github-workflow/services/toolService.mjs
+++ b/ai/mcp/server/github-workflow/services/toolService.mjs
@@ -30,6 +30,7 @@ const serviceMapping = {
     remove_labels            : IssueService      .removeLabels           .bind(IssueService),
     sync_all                 : SyncService       .runFullSync            .bind(SyncService),
     unassign_issue           : IssueService      .unassignIssue          .bind(IssueService),
+    update_comment           : PullRequestService.updateComment          .bind(PullRequestService),
     update_issue_relationship: IssueService      .updateIssueRelationship.bind(IssueService)
 };
 


### PR DESCRIPTION
#### Summary:
Adds `update_comment` tool to enable programmatic editing of existing PR/issue comments, addressing the gap i where agents couldn't correct their own comment errors.


Closes #7752 


**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [x] Other, please describe: enhancement

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills this requirement:**

- [x] It's submitted to the `dev` branch, _not_ the `main` branch

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
