### PR TITLE
extracts inline graphql queries from issueService

### DIFF
--- a/ai/mcp/server/github-workflow/services/queries/issueQueries.mjs
+++ b/ai/mcp/server/github-workflow/services/queries/issueQueries.mjs
@@ -255,6 +255,50 @@ export const DEFAULT_QUERY_LIMITS = {
 };
 
 /**
+ * Query to get an issue's current parent relationship.
+ *
+ * Variables required:
+ * - $owner: String!
+ * - $repo: String!
+ * - $number: Int!
+ */
+export const GET_ISSUE_PARENT = `
+    query GetIssueParent($owner: String!, $repo: String!, $number: Int!) {
+        repository(owner: $owner, name: $repo) {
+            issue(number: $number) {
+                parent {
+                    id
+                    number
+                }
+            }
+        }
+    }
+`;
+
+/**
+ * Query to get an issue's current blockedBy relationships.
+ *
+ * Variables required:
+ * - $owner: String!
+ * - $repo: String!
+ * - $number: Int!
+ */
+export const GET_BLOCKED_BY = `
+    query GetBlockedBy($owner: String!, $repo: String!, $number: Int!) {
+        repository(owner: $owner, name: $repo) {
+            issue(number: $number) {
+                blockedBy(first: 100) {
+                    nodes {
+                        id
+                        number
+                    }
+                }
+            }
+        }
+    }
+`;
+
+/**
  * Fetches the GraphQL node ID for an issue and all labels in the repository.
  * This is a utility query used by mutations that add/remove labels.
  *


### PR DESCRIPTION
#### Summary:
Refactors IssueSyncer to eliminate redundant metadata duplication between YAML frontmatter and markdown body, treating frontmatter as the single source of truth.

**Does this PR resolve an issue?** (Required)

Closes #7758 

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [x] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills this requirement:**

- [x] It's submitted to the `dev` branch, _not_ the `main` branch

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
