### PR TITLE
feat: Triangular Communication for OffscreenCanvas transfers (#9479)

### DIFF
--- a/src/component/Canvas.mjs
+++ b/src/component/Canvas.mjs
@@ -66,44 +66,19 @@ class Canvas extends Component {
             }
 
             if (offscreen) {
-                let data,
-                    delay = 50;
+                me.registerCanvasCallbacks ??= {};
 
-                while (me.mounted && !me.offscreenRegistered && !me.isDestroyed) {
-                    data = await Neo.main.DomAccess.getOffscreenCanvas({
-                        nodeId: id,
-                        windowId
-                    });
+                let promise = new Promise(resolve => {
+                    me.registerCanvasCallbacks[id] = resolve;
+                });
 
-                    if (data.offscreen) {
-                        await Neo.worker.Canvas.registerCanvas({
-                            node  : data.offscreen,
-                            nodeId: id,
-                            windowId
-                        }, [data.offscreen]);
+                Neo.main.DomAccess.transferCanvasToWorker({
+                    nodeId: id,
+                    windowId
+                });
 
-                        me.offscreenRegistered = true;
-                        break
-                    } else if (data.transferred) {
-                        if (Neo.config.useSharedWorkers) {
-                            let retrieveData = await Neo.worker.Canvas.retrieveCanvas({
-                                nodeId: id,
-                                windowId
-                            });
-
-                            if (retrieveData.hasCanvas) {
-                                me.offscreenRegistered = true;
-                                break
-                            }
-                        }
-                    }
-
-                    await me.timeout(delay);
-
-                    if (delay < 1000) {
-                        delay *= 2
-                    }
-                }
+                await promise;
+                me.offscreenRegistered = true;
             }
         } else if (offscreen) {
             if (me.offscreenRegistered) {

--- a/src/main/DomAccess.mjs
+++ b/src/main/DomAccess.mjs
@@ -84,6 +84,7 @@ class DomAccess extends Base {
                 'setStyle',
                 'startViewTransition',
                 'syncModalMask',
+                'transferCanvasToWorker',
                 'trapFocus',
                 'windowScrollTo'
             ]
@@ -1116,6 +1117,36 @@ class DomAccess extends Base {
                 this.syncModalMask({ id: topmostModal.id, modal: true })
             } else {
                 this._modalMask?.remove()
+            }
+        }
+    }
+
+    /**
+     * @summary Extracts an OffscreenCanvas and transfers it directly to the Canvas Worker.
+     *
+     * This method implements a "Triangular Communication" pattern required to bypass a core limitation in Firefox Nightly (and potentially other browsers) regarding SharedWorkers.
+     * Firefox fails silently when attempting to transfer an `OffscreenCanvas` from the Main Thread to the App Worker (SharedWorker), and then again from the App Worker to the Canvas Worker.
+     * By calling this method, the Main Thread extracts the canvas and sends it directly to the Canvas Worker, bypassing the App Worker entirely for the buffer transfer.
+     *
+     * @param {Object} data
+     * @param {String} data.id
+     * @param {String} data.nodeId
+     */
+    transferCanvasToWorker({nodeId}) {
+        let me   = this,
+            node = me.getElement(nodeId);
+
+        if (node) {
+            try {
+                let offscreen = node.transferControlToOffscreen();
+
+                Neo.worker.Manager.sendMessage('canvas', {
+                    action: 'registerCanvasDirect',
+                    node  : offscreen,
+                    nodeId
+                }, [offscreen])
+            } catch (e) {
+                // Ignore, means the canvas was already transferred or we do not support it
             }
         }
     }

--- a/src/worker/App.mjs
+++ b/src/worker/App.mjs
@@ -540,6 +540,27 @@ class App extends Base {
     }
 
     /**
+     * @summary Receives the ping from the Canvas Worker confirming a direct canvas transfer.
+     *
+     * This method resolves the promise created in `Neo.component.Canvas#afterSetMounted`.
+     * It is the final step in the "Triangular Communication" pattern where the Main Thread sends the
+     * `OffscreenCanvas` directly to the Canvas Worker, bypassing the App Worker's standard message payload,
+     * to avoid transfer restrictions in Firefox SharedWorkers.
+     *
+     * @param {Object} msg
+     * @param {String} msg.nodeId
+     * @protected
+     */
+    onCanvasRegistered({nodeId}) {
+        let instance = Neo.get(nodeId);
+
+        if (instance?.registerCanvasCallbacks?.[nodeId]) {
+            instance.registerCanvasCallbacks[nodeId]();
+            delete instance.registerCanvasCallbacks[nodeId]
+        }
+    }
+
+    /**
      * @param {Object} data
      */
     async onConnect(data) {

--- a/src/worker/Canvas.mjs
+++ b/src/worker/Canvas.mjs
@@ -91,6 +91,43 @@ class Canvas extends Base {
     }
 
     /**
+     * Overrides worker/Base to handle specific messages like registerCanvasDirect
+     * @param {MessageEvent} e
+     */
+    onMessage(e) {
+        let msg = e.data;
+
+        if (msg.action === 'registerCanvasDirect') {
+            this.registerCanvasDirect(msg)
+        } else {
+            super.onMessage(e)
+        }
+    }
+
+    /**
+     * @param {Object} msg
+     */
+    onRegisterNeoConfig(msg) {
+        super.onRegisterNeoConfig(msg);
+
+        if (Neo.config.useCanvasWorkerStartingPoint) {
+            let path = Neo.config.appPath;
+
+            if (path.endsWith('.mjs')) {
+                path = path.slice(0, -8); // removing "/app.mjs"
+            }
+
+            import(
+                /* webpackExclude: /(?:\/|\\)(buildScripts|dist|node_modules)/ */
+                /* webpackMode: "lazy" */
+                `../../${path}/canvas.mjs`
+                ).then(module => {
+                module.onStart()
+            })
+        }
+    }
+
+    /**
      * @param {Object} data
      */
     registerCanvas(data) {
@@ -104,6 +141,26 @@ class Canvas extends Base {
         me.map[data.nodeId] = data.node;
 
         return true
+    }
+
+    /**
+     * @summary Receives an OffscreenCanvas directly from the Main Thread.
+     *
+     * This is the receiving end of the "Triangular Communication" pattern initiated by `Neo.main.DomAccess.transferCanvasToWorker`.
+     * By receiving the canvas directly from Main, we avoid the `OffscreenCanvas` transfer restrictions inherent in Firefox's SharedWorker implementation.
+     * Once the canvas is registered internally, this method pings the App Worker back over their direct `MessageChannel` to confirm receipt so the App Worker can proceed with rendering instructions.
+     *
+     * @param {Object} msg
+     * @protected
+     */
+    registerCanvasDirect(msg) {
+        this.registerCanvas(msg);
+
+        // Ping App worker that canvas was received from main.
+        this.sendMessage('app', {
+            action: 'canvasRegistered',
+            nodeId: msg.nodeId
+        })
     }
 
     /**
@@ -136,29 +193,6 @@ class Canvas extends Base {
         // windowIds are reused. However, for correctness:
         if (me.canvasWindowMap[data.nodeId]) {
             delete me.canvasWindowMap[data.nodeId]
-        }
-    }
-
-    /**
-     * @param {Object} msg
-     */
-    onRegisterNeoConfig(msg) {
-        super.onRegisterNeoConfig(msg);
-
-        if (Neo.config.useCanvasWorkerStartingPoint) {
-            let path = Neo.config.appPath;
-
-            if (path.endsWith('.mjs')) {
-                path = path.slice(0, -8); // removing "/app.mjs"
-            }
-
-            import(
-                /* webpackExclude: /(?:\/|\\)(buildScripts|dist|node_modules)/ */
-                /* webpackMode: "lazy" */
-                `../../${path}/canvas.mjs`
-            ).then(module => {
-                module.onStart()
-            })
         }
     }
 }


### PR DESCRIPTION
Implements triangular communication to bypass a core bug in Firefox Nightly regarding OffscreenCanvas transfers in SharedWorkers. Fixes #9479