### PR TITLE
fix: reset isWindowDragging flag on drag end

### DIFF
--- a/src/dashboard/Container.mjs
+++ b/src/dashboard/Container.mjs
@@ -116,7 +116,7 @@ class Container extends BaseContainer {
             listeners         : {
                 dragBoundaryEntry: data => me.onDragBoundaryEntry(data),
                 dragBoundaryExit : data => me.onDragBoundaryExit(data),
-                dragEnd          : data => me.fire('dragEnd',           data)
+                dragEnd          : data => me.onDragEnd(data)
             },
             sortGroup: me.sortGroup
         })
@@ -175,6 +175,18 @@ class Container extends BaseContainer {
         Neo.main.addon.DragDrop.setConfigs({isWindowDragging: false, windowId});
 
         me.fire('dragBoundaryEntry', data)
+    }
+
+    /**
+     * @param {Object} data
+     */
+    onDragEnd(data) {
+        // Reset the window dragging flag when any drag operation ends
+        // This ensures proper cleanup even if the drag ends outside the viewport
+        this.#isWindowDragging = false;
+        
+        // Fire the event for other listeners
+        this.fire('dragEnd', data);
     }
 
     /**


### PR DESCRIPTION
## Bug
https://github.com/neomjs/neo/issues/8019 — The isWindowDragging flag gets stuck after external drop, preventing widget reintegration when popups are closed.

## Fix
Adds an explicit onDragEnd handler to the dashboard Container that resets the #isWindowDragging flag whenever any drag operation completes, ensuring proper cleanup regardless of where the drag ends.

## Root Cause
The #isWindowDragging flag was set to true in onDragBoundaryExit when starting window drags, but there was no mechanism to reset it when drag operations ended outside the main viewport. This caused onWindowDisconnect to exit early, skipping the widget reintegration logic.

## Testing
This fix ensures that:
- Window dragging flag is properly reset after all drag operations
- Widget reintegration works correctly when popups are closed
- No regression in normal drag/drop behavior within the dashboard

The solution follows the existing event-driven architecture and provides a centralized cleanup point for the window dragging state.

Greetings, saschabuehrle