### PR TITLE
fix(ai): Implement targeted daemon auto-start specific environment variables (#9881)

### DIFF
--- a/ai/mcp/server/knowledge-base/config.template.mjs
+++ b/ai/mcp/server/knowledge-base/config.template.mjs
@@ -19,6 +19,11 @@ const defaultConfig = {
      */
     autoSync: process.env.AUTO_SYNC !== 'false',
     /**
+     * Automatically start the local Chroma database process on startup.
+     * @type {boolean}
+     */
+    autoStartDatabase: process.env.NEO_KB_AUTO_START_DATABASE !== 'false',
+    /**
      * Global debug flag for all MCP servers.
      * @type {boolean}
      */

--- a/ai/mcp/server/knowledge-base/services/DatabaseLifecycleService.mjs
+++ b/ai/mcp/server/knowledge-base/services/DatabaseLifecycleService.mjs
@@ -46,7 +46,9 @@ class DatabaseLifecycleService extends Base {
      */
     async initAsync() {
         await super.initAsync();
-        await this.startDatabase();
+        if (aiConfig.autoStartDatabase) {
+            await this.startDatabase();
+        }
     }
 
     /**

--- a/ai/mcp/server/memory-core/config.template.mjs
+++ b/ai/mcp/server/memory-core/config.template.mjs
@@ -19,6 +19,16 @@ const defaultConfig = {
      */
     autoSummarize: process.env.AUTO_SUMMARIZE !== 'false',
     /**
+     * Automatically start the local database process (Chroma/SQLite) on startup.
+     * @type {boolean}
+     */
+    autoStartDatabase: process.env.NEO_MEM_AUTO_START_DATABASE !== 'false',
+    /**
+     * Automatically start the local inference server on startup.
+     * @type {boolean}
+     */
+    autoStartInference: process.env.NEO_MEM_AUTO_START_INFERENCE !== 'false',
+    /**
      * Automatically trigger GraphRAG extraction on startup.
      * @type {boolean}
      */

--- a/ai/mcp/server/memory-core/services/lifecycle/ChromaLifecycleService.mjs
+++ b/ai/mcp/server/memory-core/services/lifecycle/ChromaLifecycleService.mjs
@@ -50,7 +50,7 @@ class ChromaLifecycleService extends Base {
      */
     async initAsync() {
         await super.initAsync();
-        if (aiConfig.engine === 'chroma' || aiConfig.engine === 'both') {
+        if (aiConfig.autoStartDatabase && (aiConfig.engine === 'chroma' || aiConfig.engine === 'both')) {
             await this.startDatabase();
         }
     }

--- a/ai/mcp/server/memory-core/services/lifecycle/InferenceLifecycleService.mjs
+++ b/ai/mcp/server/memory-core/services/lifecycle/InferenceLifecycleService.mjs
@@ -49,7 +49,9 @@ class InferenceLifecycleService extends Base {
      */
     async initAsync() {
         await super.initAsync();
-        await this.startInferenceServer();
+        if (aiConfig.autoStartInference) {
+            await this.startInferenceServer();
+        }
     }
 
     /**

--- a/ai/services.mjs
+++ b/ai/services.mjs
@@ -31,8 +31,9 @@ import KB_SearchService             from './mcp/server/knowledge-base/services/S
 import KB_ChromaManager             from './mcp/server/knowledge-base/services/ChromaManager.mjs';
 import KB_Config                    from './mcp/server/knowledge-base/config.mjs';
 
-// Disable auto-sync for all scripts using the SDK to prevent double-runs
+// Disable auto-sync and auto-start for all scripts using the SDK to prevent double-runs and daemon spawns
 KB_Config.data.autoSync = false;
+KB_Config.data.autoStartDatabase = false;
 
 // --- Memory Core Services ---
 import Memory_Service               from './mcp/server/memory-core/services/MemoryService.mjs';
@@ -48,6 +49,8 @@ import Memory_LifecycleService      from './mcp/server/memory-core/services/life
 import Memory_Config                from './mcp/server/memory-core/config.mjs';
 
 Memory_Config.data.autoSummarize = false;
+Memory_Config.data.autoStartDatabase = false;
+Memory_Config.data.autoStartInference = false;
 
 // --- Neural Link Services ---
 import NeuralLink_ComponentService   from './mcp/server/neural-link/services/ComponentService.mjs';


### PR DESCRIPTION
Resolves #9881

## Context & Execution Summary
This Pull Request resolves the build pipeline error `Error: spawn chroma ENOENT` seen during CI data-sync runs. 

The original failure occurred because `ai/services.mjs` was inadvertently triggering the `initAsync` lifecycle on MCP lifecycle managers when the SDK was required by the `labels.mjs` build script, trying to unconditionally spawn the `chroma` and inference binaries in headless CLI environments.

## Architecture Alignment & Changes
- **Targeted Daemon Configurations**: Introduced completely scoped, targeted environment variables to override auto-start mechanics:
  - `NEO_KB_AUTO_START_DATABASE` (Knowledge Base)
  - `NEO_MEM_AUTO_START_DATABASE` (Memory Core)
  - `NEO_MEM_AUTO_START_INFERENCE` (Memory Core)
- **Lifecycle Pre-Flight**: Updated `DatabaseLifecycleService`, `ChromaLifecycleService`, and `InferenceLifecycleService` to gate binary execution behind these configurable flags.
- **SDK Overrides**: Explicitly clamped these flags to `false` in `ai/services.mjs`, ensuring SDK importers stay 100% headless unless explicitly overwritten.

## Definition of Done
- Validation Confirmed: `node ./buildScripts/docs/index/labels.mjs` executes natively without ENOENT daemon errors.
