### PR TITLE
docs: Promote ask_knowledge_base as primary Anti-Hallucination tool (#9893)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,10 +14,29 @@ Your communication style must be direct, objective, and technically focused.
 
 ## 2. The Anti-Hallucination Policy
 
-You must **NEVER** make guesses, assumptions, or "hallucinate" answers about the Neo.mjs framework. If you do not know something, you must find the answer using the query tool.
+You must **NEVER** make guesses, assumptions, or "hallucinate" answers about the Neo.mjs framework. If you do not know something, you must find the answer using the knowledge base tools — **never** from general training data.
 
-- **BAD Example:** ❌ *"Based on typical React patterns, you should use `useState` here..."*
-- **GOOD Example:** ✅ *"Let me query the knowledge base to understand Neo.mjs state management patterns..."*
+### 2.1. Tool Hierarchy (Mandatory)
+
+When you need to understand any Neo.mjs concept, API, or pattern, you **MUST** follow this tool hierarchy in order:
+
+| Priority | Need | Tool | Returns |
+|----------|------|------|---------|
+| **1st** | Conceptual understanding | `ask_knowledge_base` | Synthesized answer + source citations |
+| **2nd** | File discovery / path lookup | `query_documents` | Ranked file paths with relevance scores |
+| **3rd** | Implementation details | `view_file` | Raw source code |
+| **4th** | Past decisions / context | `query_raw_memories` | Agent episodic memory |
+
+**`ask_knowledge_base` is your PRIMARY Anti-Hallucination tool.** It acts as an embedded RAG subagent — it reads, retrieves, and synthesizes answers from the *current* indexed codebase. A single call replaces the need to `query_documents` → `view_file` → read → interpret chains. Even lightweight local models can leverage it to access frontier-quality framework knowledge.
+
+Use `query_documents` only when you need to **discover file paths** (e.g., "which files implement grid selection?"), not when you need to **understand a concept** (e.g., "how does the reactive config system work?").
+
+### 2.2. Anti-Patterns
+
+- **BAD:** ❌ *"Based on typical React patterns, you should use `useState` here..."*
+- **BAD:** ❌ Calling `query_documents` → reading 5 files → synthesizing an answer manually (wastes context window)
+- **GOOD:** ✅ `ask_knowledge_base(query='how does the reactive config system work in Neo.mjs?')`
+- **GOOD:** ✅ `ask_knowledge_base(query='current syntax for state provider bindings')`
 
 ## 3. The Pre-Commit Hard Gates (Tickets & Context)
 

--- a/AGENTS_STARTUP.md
+++ b/AGENTS_STARTUP.md
@@ -175,16 +175,17 @@ Your final plan or response should be a synthesis of both queries. Reference bot
 
 **Problem:** Your training data contains outdated syntax for rapidly evolving features (e.g., State Provider bindings, Reactive Configs, Worker messaging).
 
-**Solution:** You must treat `ask_knowledge_base` as an **Embedded RAG Sub-Agent**. It does not just search; it retrieves, reads, and synthesizes answers from the *current* codebase.
+**Solution:** You must treat `ask_knowledge_base` as an **Embedded RAG Sub-Agent**. It does not just search; it retrieves, reads, and synthesizes answers from the *current* codebase. This is the **#1 tool in the Anti-Hallucination hierarchy** (see `AGENTS.md` §2.1).
 
 **Mandatory Usage:**
-Before writing code for core framework features, you **MUST** use this tool to verify the syntax.
+Before writing code for core framework features, you **MUST** use this tool to verify the syntax. During **session initialization**, use it for rapid context acquisition — a single call can replace reading multiple files to understand an architectural concept.
 
 **Workflow:**
 1.  **Identify the Hazard:** "I am about to write a binding. My training says strings, but the framework might use functions."
 2.  **Ask the Expert:** Call `ask_knowledge_base` with a specific question.
     -   `ask_knowledge_base(query='current syntax for state provider bindings')`
     -   `ask_knowledge_base(query='how to define a reactive config in a component')`
+    -   `ask_knowledge_base(query='how does the Grid multi-body architecture work?')`
 3.  **Trust the Answer:** The tool reads the actual files in the repository. Its answer is the single source of truth.
 
 ## 4. The Implementation Loop

--- a/ai/mcp/server/knowledge-base/openapi.yaml
+++ b/ai/mcp/server/knowledge-base/openapi.yaml
@@ -287,14 +287,53 @@ paths:
         Performs a semantic search and uses an LLM to synthesize an answer based on the top results.
         Use this tool to get a high-level answer without manually reading multiple files.
 
+        ## Priority Positioning
+
+        **This should be your FIRST tool for conceptual questions about Neo.mjs.**
+        Use `query_documents` only when you need to discover file paths. For understanding
+        concepts, APIs, or patterns, `ask_knowledge_base` is faster and more accurate because
+        it reads and synthesizes multiple source files for you in a single call.
+
+        ## How It Works
+
+        This tool acts as a **zero-cost RAG subagent** — it performs semantic search across the
+        entire indexed codebase (source code, guides, examples, tickets, release notes), retrieves
+        the top-scoring documents, and uses an LLM to synthesize a grounded answer with cited
+        references. Even lightweight local models (e.g., Gemma4-31B via MLX) can invoke this tool
+        to access frontier-quality framework knowledge.
+
         **Input:**
-        - `query`: The question to ask.
-        - `limit`: (Optional) Number of source documents to consider (default 5).
+        - `query`: The question to ask. Natural language works best — ask it like you would ask a senior developer.
+        - `limit`: (Optional) Number of source documents to consider (default 5). Increase for broader questions.
         - `type`: (Optional) Filter by content type (e.g., 'guide', 'src', 'all').
 
         **Output:**
-        - `answer`: Synthesized answer.
-        - `references`: List of source files used to generate the answer.
+        - `answer`: Synthesized answer grounded in the current codebase.
+        - `references`: List of source files used to generate the answer, with relevance scores.
+
+        ## Example Queries
+
+        ```
+        ask_knowledge_base(query='how does the reactive config system work?')
+        ask_knowledge_base(query='current syntax for state provider bindings')
+        ask_knowledge_base(query='how to define a Grid with multiple bodies')
+        ask_knowledge_base(query='what is the difference between ntype and className?', type='guide')
+        ```
+
+        ## When to Use This vs. query_documents
+
+        | Question Type | Use This Tool | Use query_documents |
+        |---------------|---------------|---------------------|
+        | "How does X work?" | ✅ | ❌ |
+        | "What is the syntax for Y?" | ✅ | ❌ |
+        | "Which files implement Z?" | ❌ | ✅ |
+        | "Where is the Grid component defined?" | ❌ | ✅ |
+
+        ## Anti-Pattern Warning
+
+        **Do NOT attempt to answer Neo.mjs questions from training data.** Always ask the
+        knowledge base first. The framework evolves rapidly — your training data is almost
+        certainly outdated for syntax-level details.
       tags: [Documents]
       requestBody:
         required: true

--- a/learn/guides/fundamentals/CodebaseOverview.md
+++ b/learn/guides/fundamentals/CodebaseOverview.md
@@ -479,7 +479,10 @@ You're not just working *with* Neo.mjs. You're working *inside* an ecosystem des
 
 ## Key Concepts: Query Entry Points
 
-When you need to understand Neo.mjs, these are high-value concepts to query. Use these terms with the `query_documents` tool to find relevant source files and guides.
+When you need to understand Neo.mjs, start with the right tool:
+
+- **Ask, Don't Search:** For conceptual questions ("How does reactivity work?", "What is the config system?"), use `ask_knowledge_base` — it synthesizes answers from multiple source files in a single call. Essential for top-level perspective in a codebase of this scale.
+- **Search for Files:** When you need to discover *which files* implement something, use `query_documents` with these high-value terms:
 
 ### Agent Intelligence & Workflows
 - `"DreamService"`, `"Agent OS"`, `"Native Edge Graph"`, `"SQLite topology"`, `"Fat Ticket"`
@@ -577,8 +580,8 @@ If you're coming from other frameworks, here are the key mental shifts:
 3. Look at `/apps/portal/` for a complete application
 
 ### When Stuck
-1. Query the specific concept (e.g., `"afterSet hook"`)
-2. Read both the source file (`type='src'`) and guide (`type='guide'`)
+1. **Ask first:** `ask_knowledge_base(query='how does the afterSet hook work?')` — gets a synthesized answer with cited source file paths
+2. **Drill into code:** The answer includes ranked file references — use `grep_search` or `view_file` to inspect the specific implementation
 3. Check examples (`type='example'`) for practical usage
 4. Review tickets (`type='ticket'`) and Pull Requests (`type='pull'`) for execution history
 5. Search Discussions (`type='discussion'`) for the underlying architectural "Why"


### PR DESCRIPTION
## Summary

Resolves #9893
Partially addresses #9892 (CodebaseOverview scope extension per [comment](https://github.com/neomjs/neo/issues/9892#issuecomment-2797508641))

## Changes

### AGENTS.md — §2 Anti-Hallucination Policy (Major)
- Expanded from 7 lines to a structured subsection with **§2.1 Tool Hierarchy** table positioning `ask_knowledge_base` as the #1 tool
- Added **§2.2 Anti-Patterns** with concrete bad/good examples including the `query_documents → read 5 files` waste pattern

### openapi.yaml — ask_knowledge_base description (Major)
- Expanded from 12 lines to ~50 lines matching `query_documents` documentation quality
- Added: Priority Positioning, How It Works (zero-cost RAG subagent framing), Example Queries, decision table (when to use this vs. query_documents), Anti-Pattern Warning

### AGENTS_STARTUP.md — §3.4 Ask the Expert Protocol (Minor)
- Cross-references AGENTS.md §2.1 tool hierarchy
- Adds session initialization framing (use during warm-up)
- Added third example query

### CodebaseOverview.md — Query Entry Points + When Stuck (Minor, from #9892 comment)
- "Query Entry Points" intro now leads with "Ask, Don't Search" callout for `ask_knowledge_base`
- "When Stuck" section reordered: ask first → then locate files

## Rationale

`ask_knowledge_base` is architecturally the most powerful anti-hallucination primitive — a zero-cost RAG subagent that even local SLMs can invoke. Despite this, it had zero mentions in AGENTS.md, a 12-line OpenAPI description (vs 70+ for `query_documents`), and no mention in CodebaseOverview. Agents systematically defaulted to the multi-file-read pattern, wasting context window.

## Scope Deviation

Added CodebaseOverview.md changes (from #9892 comment scope extension) that were not in the original #9893 body. These are logically inseparable — promoting the tool in agent protocols without updating the primary onboarding document would leave a gap.