### PR TITLE
fix: Add cwd to PullRequestService execAsync calls (#9895)

### DIFF
--- a/ai/mcp/server/github-workflow/services/PullRequestService.mjs
+++ b/ai/mcp/server/github-workflow/services/PullRequestService.mjs
@@ -41,7 +41,7 @@ class PullRequestService extends Base {
      */
     async checkoutPullRequest(prNumber) {
         try {
-            const {stdout} = await execAsync(`gh pr checkout ${prNumber}`);
+            const {stdout} = await execAsync(`gh pr checkout ${prNumber}`, {cwd: aiConfig.projectRoot});
             return {message: `Successfully checked out PR #${prNumber}`, details: stdout.trim()};
         } catch (error) {
             logger.error(`Error checking out PR #${prNumber}:`, error);
@@ -86,7 +86,7 @@ class PullRequestService extends Base {
      */
     async getPullRequestDiff(prNumber) {
         try {
-            const {stdout} = await execAsync(`gh pr diff ${prNumber}`);
+            const {stdout} = await execAsync(`gh pr diff ${prNumber}`, {cwd: aiConfig.projectRoot});
             return { result: stdout };
         } catch (error) {
             logger.error(`Error getting diff for PR #${prNumber}:`, error);

--- a/resources/content/.sync-metadata.json
+++ b/resources/content/.sync-metadata.json
@@ -1,6 +1,6 @@
 {
-  "lastSync": "2026-04-11T19:33:40.884Z",
-  "releasesLastFetched": "2026-04-11T19:33:48.493Z",
+  "lastSync": "2026-04-11T20:10:45.287Z",
+  "releasesLastFetched": "2026-04-11T20:10:52.316Z",
   "pushFailures": [],
   "issues": {
     "3789": {
@@ -24749,11 +24749,18 @@
       "contentHash": "98f1ca4ab2cd1c79f36e37c96a8df0b8a2e86b39fb8895b179bd3344eb12ac3f"
     },
     "9893": {
-      "state": "OPEN",
+      "state": "CLOSED",
       "path": "resources/content/issues/issue-9893.md",
+      "closedAt": "2026-04-11T20:04:12Z",
+      "updatedAt": "2026-04-11T20:04:12Z",
+      "contentHash": "e1173c0ccd490b517ce309c32435a0a87b39a3733aa07f02915435ad3c47e79b"
+    },
+    "9895": {
+      "state": "OPEN",
+      "path": "resources/content/issues/issue-9895.md",
       "closedAt": null,
-      "updatedAt": "2026-04-11T19:27:42Z",
-      "contentHash": "7ba0df753545c0e36036c9d20497d6632e4559454b6f2ca7b6deea9cda257c13"
+      "updatedAt": "2026-04-11T20:09:35Z",
+      "contentHash": "246a0aa2eb43a0647e8cd4da8a59fdb637888fe7370e4914044c976b2b985de0"
     }
   },
   "releases": {

--- a/resources/content/issues/issue-9893.md
+++ b/resources/content/issues/issue-9893.md
@@ -1,7 +1,7 @@
 ---
 id: 9893
 title: 'feat: Promote ask_knowledge_base as the primary Anti-Hallucination tool across agent protocols'
-state: OPEN
+state: CLOSED
 labels:
   - documentation
   - enhancement
@@ -9,7 +9,7 @@ labels:
 assignees:
   - tobiu
 createdAt: '2026-04-11T19:27:36Z'
-updatedAt: '2026-04-11T19:27:42Z'
+updatedAt: '2026-04-11T20:10:47Z'
 githubUrl: 'https://github.com/neomjs/neo/issues/9893'
 author: tobiu
 commentsCount: 0
@@ -19,6 +19,7 @@ subIssuesCompleted: 0
 subIssuesTotal: 0
 blockedBy: []
 blocking: []
+closedAt: '2026-04-11T20:04:12Z'
 ---
 # feat: Promote ask_knowledge_base as the primary Anti-Hallucination tool across agent protocols
 
@@ -86,7 +87,6 @@ If `AGENTS_STARTUP.md` includes a session boot sequence, `ask_knowledge_base` sh
 1. Grep verification: `ask_knowledge_base` appears in `AGENTS.md` §2 and `openapi.yaml` with expanded description
 2. Functional test: Ask a new agent "how does the config system work in Neo.mjs?" and verify it reaches for `ask_knowledge_base` before `query_documents` or `view_file`
 
-
 ## Timeline
 
 - 2026-04-11T19:27:38Z @tobiu added the `documentation` label
@@ -94,4 +94,9 @@ If `AGENTS_STARTUP.md` includes a session boot sequence, `ask_knowledge_base` sh
 - 2026-04-11T19:27:39Z @tobiu added the `ai` label
 - 2026-04-11T19:27:43Z @tobiu assigned to @tobiu
 - 2026-04-11T19:29:49Z @tobiu cross-referenced by #9892
+- 2026-04-11T19:55:45Z @tobiu referenced in commit `b4007bd` - "docs: Promote ask_knowledge_base as primary Anti-Hallucination tool (#9893)"
+- 2026-04-11T19:56:07Z @tobiu cross-referenced by PR #9894
+- 2026-04-11T19:59:53Z @tobiu referenced in commit `fc9b59c` - "docs: Promote ask_knowledge_base as primary Anti-Hallucination tool (#9893)"
+- 2026-04-11T20:04:11Z @tobiu referenced in commit `c6452ce` - "docs: Promote ask_knowledge_base as primary Anti-Hallucination tool (#9893) (#9894)"
+- 2026-04-11T20:04:12Z @tobiu closed this issue
 

--- a/resources/content/issues/issue-9895.md
+++ b/resources/content/issues/issue-9895.md
@@ -1,0 +1,55 @@
+---
+id: 9895
+title: 'bug: PullRequestService execAsync calls missing cwd — gh pr diff/checkout fail in headless environments'
+state: OPEN
+labels:
+  - bug
+  - ai
+assignees:
+  - tobiu
+createdAt: '2026-04-11T20:09:34Z'
+updatedAt: '2026-04-11T20:09:35Z'
+githubUrl: 'https://github.com/neomjs/neo/issues/9895'
+author: tobiu
+commentsCount: 0
+parentIssue: null
+subIssues: []
+subIssuesCompleted: 0
+subIssuesTotal: 0
+blockedBy: []
+blocking: []
+---
+# bug: PullRequestService execAsync calls missing cwd — gh pr diff/checkout fail in headless environments
+
+## Context
+
+`PullRequestService.mjs` has two `execAsync` calls (lines 44, 89) that invoke `gh pr checkout` and `gh pr diff` without passing `{cwd: aiConfig.projectRoot}`. When the MCP server process is spawned from a directory outside the git repo (e.g., CWD = `/` via stdio transport), both commands fail with exit code 1 because `gh` cannot resolve the repository context.
+
+## Root Cause
+
+`SyncService.mjs` correctly passes `{cwd}` to all 5 of its `execAsync` calls (lines 134-148). `PullRequestService.mjs` does not — likely an oversight from when the service was first written.
+
+## Fix
+
+Add `{cwd: aiConfig.projectRoot}` to both `execAsync` calls in `PullRequestService.mjs`:
+
+- Line 44: `execAsync(\`gh pr checkout ${prNumber}\`, {cwd: aiConfig.projectRoot})`
+- Line 89: `execAsync(\`gh pr diff ${prNumber}\`, {cwd: aiConfig.projectRoot})`
+
+## A2A Context (Fat Ticket)
+
+### Discovery Path
+Found during PR review of #9894 — the `get_pull_request_diff` MCP tool returned `GH_CLI_ERROR` with exit code 1. The same `gh pr diff 9894` command succeeded when run from the repo root via shell, confirming CWD as the differentiator.
+
+### Scope Boundary
+Two-line fix. No architectural changes. No new dependencies.
+
+### Verification
+After applying the fix, restart the MCP server and call `get_pull_request_diff` on any merged PR to confirm it returns diff output instead of an error.
+
+## Timeline
+
+- 2026-04-11T20:09:35Z @tobiu assigned to @tobiu
+- 2026-04-11T20:09:40Z @tobiu added the `bug` label
+- 2026-04-11T20:09:40Z @tobiu added the `ai` label
+

--- a/resources/content/pulls/pr-9894.md
+++ b/resources/content/pulls/pr-9894.md
@@ -1,0 +1,109 @@
+---
+number: 9894
+title: 'docs: Promote ask_knowledge_base as primary Anti-Hallucination tool (#9893)'
+author: tobiu
+state: MERGED
+createdAt: '2026-04-11T19:56:06Z'
+updatedAt: '2026-04-11T20:04:17Z'
+closedAt: '2026-04-11T20:04:10Z'
+mergedAt: '2026-04-11T20:04:10Z'
+head: agent/9893-promote-ask-knowledge-base
+base: dev
+url: 'https://github.com/neomjs/neo/pull/9894'
+---
+## Summary
+
+Resolves #9893
+Partially addresses #9892 (CodebaseOverview scope extension per [comment](https://github.com/neomjs/neo/issues/9892#issuecomment-2797508641))
+
+## Changes
+
+### AGENTS.md — §2 Anti-Hallucination Policy (Major)
+- Expanded from 7 lines to a structured subsection with **§2.1 Tool Hierarchy** table positioning `ask_knowledge_base` as the #1 tool
+- Added **§2.2 Anti-Patterns** with concrete bad/good examples including the `query_documents → read 5 files` waste pattern
+
+### openapi.yaml — ask_knowledge_base description (Major)
+- Expanded from 12 lines to ~50 lines matching `query_documents` documentation quality
+- Added: Priority Positioning, How It Works (zero-cost RAG subagent framing), Example Queries, decision table (when to use this vs. query_documents), Anti-Pattern Warning
+
+### AGENTS_STARTUP.md — §3.4 Ask the Expert Protocol (Minor)
+- Cross-references AGENTS.md §2.1 tool hierarchy
+- Adds session initialization framing (use during warm-up)
+- Added third example query
+
+### CodebaseOverview.md — Query Entry Points + When Stuck (Minor, from #9892 comment)
+- "Query Entry Points" intro now leads with "Ask, Don't Search" callout for `ask_knowledge_base`
+- "When Stuck" section reordered: ask first → then locate files
+
+## Rationale
+
+`ask_knowledge_base` is architecturally the most powerful anti-hallucination primitive — a zero-cost RAG subagent that even local SLMs can invoke. Despite this, it had zero mentions in AGENTS.md, a 12-line OpenAPI description (vs 70+ for `query_documents`), and no mention in CodebaseOverview. Agents systematically defaulted to the multi-file-read pattern, wasting context window.
+
+## Scope Deviation
+
+Added CodebaseOverview.md changes (from #9892 comment scope extension) that were not in the original #9893 body. These are logically inseparable — promoting the tool in agent protocols without updating the primary onboarding document would leave a gap.
+
+## Comments
+
+### `@tobiu` commented on 2026-04-11T20:00:06Z
+
+**Input from Claude Opus 4.6 (Antigravity):**
+
+> ❋ **Iterative Update (force-push):**
+> 
+> Fixed `CodebaseOverview.md` "When Stuck" step 2 per user review. The previous wording suggested using `query_documents` as a follow-up to locate files, but `ask_knowledge_base` already returns ranked file references with full paths and scores in its response. The redundant `query_documents` call was replaced with `grep_search` / `view_file` as the natural next step for drilling into specific implementations.
+> 
+> ```diff
+> -1. **Ask first:** ... — gets a synthesized answer with citations
+> -2. **Then locate files:** `query_documents(query='afterSet hook', type='src')` — if you need the actual source code
+> +1. **Ask first:** ... — gets a synthesized answer with cited source file paths
+> +2. **Drill into code:** The answer includes ranked file references — use `grep_search` or `view_file` to inspect the specific implementation
+> ```
+
+---
+
+### `@tobiu` commented on 2026-04-11T20:01:41Z
+
+**Input from Claude Opus 4.6 (Antigravity):**
+
+> ❋ # PR Review Summary
+> 
+> **Status:** Approved
+> 
+> Clean documentation-only PR. Four files surgically edited to promote `ask_knowledge_base` from an undocumented tool to the #1 position in the anti-hallucination hierarchy. The PR body is a proper Fat Ticket with rationale, scope deviation documentation, and cross-references. Iterative force-push was correctly documented via comment.
+> 
+> ---
+> 
+> ### 📊 Evaluation Metrics
+> *   **`[ARCH_ALIGNMENT]`**: 95 - Correctly positions `ask_knowledge_base` as a zero-cost RAG subagent within the existing Anti-Hallucination framework. The tool hierarchy table in AGENTS.md §2.1 follows the established cascading-priority pattern used across other protocol sections. Minor deduction: the openapi.yaml decision table uses ❌/✅ which may not render in all YAML consumers.
+> *   **`[CONTENT_COMPLETENESS]`**: 90 - All four documentation surfaces are covered (AGENTS.md, AGENTS_STARTUP.md, openapi.yaml, CodebaseOverview.md). Cross-references between files are bidirectional. The iterative PR comment documents the force-push delta. Deduction: no `AGENTS.md` §6 (Request Triage) update — that section says "using the knowledge base and other tools" generically and could also benefit from the `ask_knowledge_base` callout.
+> *   **`[EXECUTION_QUALITY]`**: 95 - YAML parse validated via node. No formatting regressions. The "When Stuck" fix (removing redundant `query_documents` step) was caught by user review and correctly addressed. All edits are additive — no existing semantics were broken.
+> *   **`[PRODUCTIVITY]`**: 100 - All goals of #9893 achieved plus the #9892 comment scope extension. The user's review feedback was incorporated in-session.
+> *   **`[IMPACT]`**: 75 - This is a force-multiplier for all future agent sessions. Every agent that reads AGENTS.md (i.e., every agent) will now default to `ask_knowledge_base` instead of the wasteful `query_documents → read 5 files` chain. However, the actual behavioral change depends on whether LLM providers weight OpenAPI descriptions and protocol docs equally in tool selection.
+> *   **`[COMPLEXITY]`**: 20 - Documentation-only. Four files, 74 insertions, 12 deletions. No code logic, no tests, no architectural risk.
+> *   **`[EFFORT_PROFILE]`**: Quick Win - High ROI (affects every agent session) with minimal complexity and zero regression risk.
+> 
+> ---
+> 
+> ### 🕸️ Context & Graph Linking
+> *   **Target Epic / Issue ID:** Resolves #9893
+> *   **Related Graph Nodes:** #9892 (CodebaseOverview expansion — partially addressed via the Query Entry Points / When Stuck changes), #9891 (Strategic Constraint Nodes — downstream consumer of better tool selection), `ask_knowledge_base` operationId, `query_documents` operationId
+> 
+> ---
+> 
+> ### 🧠 Graph Ingestion Notes
+> 
+> *   **`[KB_GAP]`**: The `ask_knowledge_base` tool existed since the KB MCP server's inception but had zero references in agent operational protocols (AGENTS.md). This gap caused systematic under-utilization — agents defaulted to `query_documents` because it had 70+ lines of OpenAPI documentation vs 12 for `ask_knowledge_base`. **Root cause:** tool documentation asymmetry directly drives tool selection in LLMs.
+> *   **`[TOOLING_GAP]`**: `get_pull_request_diff` MCP tool failed with exit code 1 for PR #9894 during this review. Fell back to `gh pr diff` via shell. Worth investigating — may be a timing issue with recently force-pushed PRs.
+> *   **`[RETROSPECTIVE]`**: This PR validates a meta-architectural insight: **documentation IS architecture for AI-native systems.** The behavioral change isn't in code — it's in how future agents will select tools based on the weight of documentation surrounding each tool. The "zero-cost RAG subagent" framing is a conceptual anchor that should be reinforced in future onboarding materials.
+> 
+> ---
+> 
+> ### 📋 Required Actions
+> 
+> None — approved for merge.
+> 
+> > **Optional enhancement for a follow-up commit:** Consider adding an `ask_knowledge_base` callout to AGENTS.md §6 (Request Triage), which currently says "using the knowledge base and other tools" generically. This would close the last documentation surface that references KB tools without specifying the priority order.
+
+---
+


### PR DESCRIPTION
## Summary

Resolves #9895

## Changes

### PullRequestService.mjs — Two-line fix

Added `{cwd: aiConfig.projectRoot}` to both `execAsync` calls:

```diff
- const {stdout} = await execAsync(`gh pr checkout ${prNumber}`);
+ const {stdout} = await execAsync(`gh pr checkout ${prNumber}`, {cwd: aiConfig.projectRoot});

- const {stdout} = await execAsync(`gh pr diff ${prNumber}`);
+ const {stdout} = await execAsync(`gh pr diff ${prNumber}`, {cwd: aiConfig.projectRoot});
```

## Root Cause

`PullRequestService` was the only service that didn't pass `{cwd}` to `execAsync`. `SyncService` passes it on all 5 of its calls. When the MCP server process is spawned via stdio transport (e.g., from Antigravity/Gemini CLI), the process CWD can be `/` rather than the git repo root. `gh pr diff` and `gh pr checkout` require being inside a git repository to resolve the PR context.

## Verification

Verified live after applying the fix and restarting the MCP server:
- **Before:** `get_pull_request_diff(9894)` → `GH_CLI_ERROR, exit code 1`
- **After:** `get_pull_request_diff(9894)` → ✅ Full diff content returned

## Scope

1 file, 2 insertions, 2 deletions. Zero architectural risk.