### PR TITLE
docs: add Core Engine Pipeline cross-references and tree.json pointers (#9898)

### DIFF
--- a/AGENTS_STARTUP.md
+++ b/AGENTS_STARTUP.md
@@ -24,6 +24,8 @@ At the beginning of every new session, you **MUST** perform the following steps 
 
 Parse the file `learn/guides/fundamentals/CodebaseOverview.md`. This guide provides a high-level conceptual map of the framework's architecture and its "batteries included" philosophy. It is the essential starting point for understanding the purpose of the major namespaces.
 
+**Documentation Taxonomy:** Additionally, scan `learn/tree.json` — the canonical hierarchical index of all 130+ learning topics. The Knowledge Base's `LearningSource.mjs` traverses this file to discover and index every guide. Scanning it gives you an instant top-level perspective of the entire documentation landscape, making subsequent knowledge base queries far more targeted.
+
 ### Step 2: Read the Core Concepts
 
 Read `src/Neo.mjs`. Focus on understanding:

--- a/learn/guides/fundamentals/CodebaseOverview.md
+++ b/learn/guides/fundamentals/CodebaseOverview.md
@@ -123,6 +123,19 @@ Neo.create(Effect, {
 
 **The Result**: Fine-grained reactivity where you need it, coarse-grained where you don't.
 
+> **Core Engine Deep Dives:** The concepts above — class compilation, config descriptors, reactivity, and lifecycle — are
+> each explored in depth within the `learn/guides/coreengine/` guide series. While `src/Neo.mjs` and `src/core/Base.mjs`
+> provide the implementation mechanics, these 6 guides explain the *architectural reasoning* behind them:
+>
+> 1. **Why Enhance JS Classes?** (`WhyEnhance.md`) — The native `constructor` trap and why `construct()` exists
+> 2. **Class Compilation** (`SetupClass.md`) — How `Neo.setupClass()` walks the prototype chain, merges configs, and resolves mixins
+> 3. **The Config System** (`ConfigSystem.md`) — Config descriptors, the `configSymbol` holding zone, and cross-dependent batch resolution
+> 4. **Two-Tier Reactivity** (`Reactivity.md`) — The v10 bridge: `core.Config` instances backing every reactive config, enabling `EffectManager` to observe *any* config
+> 5. **Instance Lifecycle** (`Lifecycle.md`) — `initAsync()`, remote method registration, and Main Thread Addon patterns
+> 6. **Core Utilities** (`Utilities.md`) — `core.Compare` as the infinite loop breaker, and the declarative `delayable` system
+>
+> These form a sequential narrative — each guide's closing paragraph hands off to the next.
+
 ---
 
 ### 4. Zero-Build Development Mode
@@ -351,11 +364,16 @@ Each example is self-contained and demonstrates one concept clearly.
 
 ### Learning Materials (`/learn`)
 
+**The Index**: `learn/tree.json` is the canonical hierarchical taxonomy of all 130+ learning topics. The Knowledge Base's `LearningSource.mjs` traverses this file to discover and index every guide — scanning it gives you an instant top-level perspective of the entire documentation landscape.
+
 **Structured Content**:
-- **Benefits**: Why Neo.mjs exists, what problems it solves
-- **Getting Started**: First steps, tutorials, quick wins
-- **Fundamentals**: Core concepts, architecture deep-dives
-- **Guides**: Task-oriented how-tos
+- **Benefits**: Why Neo.mjs exists, what problems it solves (12 topics)
+- **Getting Started**: First steps, tutorials, quick wins (9 topics)
+- **Agent OS & Conversational UIs**: AI infrastructure, MCP servers, tooling (13 topics)
+- **Guides**: Fundamentals, Core Engine, UI Building Blocks, Data Handling, Testing, Advanced Architecture (62 topics)
+- **DevIndex App**: Flagship application architecture, data factory, frontend (22 topics)
+- **Tutorials**: Hands-on walkthroughs (5 topics)
+- **Engine vs Frameworks**: Competitive comparisons with React, Angular, Vue, Solid, Next, Ext (7 topics)
 - **Blog**: Historical context, design decisions, evolution
 
 The content in `/learn` is the source material for the AI Knowledge Base. Query it for conceptual understanding.


### PR DESCRIPTION
Resolves #9898

## Summary

Low-hanging-fruit documentation enhancement by **Antigravity (Claude Opus 4.6)** that adds navigation breadcrumbs between the high-level CodebaseOverview and the deep-dive Core Engine guides.

## Changes

### CodebaseOverview.md (2 edits)

**1. Core Engine Deep Dives block** (after Two-Tier Reactivity, ~L126):
Added a blockquote cross-reference listing all 6 core engine guides in reading order with one-line summaries of each guide's unique knowledge delta. Notes that the series forms a sequential narrative.

**2. Learning Materials section** (~L365):
- Added `learn/tree.json` as "The Index" — the canonical hierarchical taxonomy of all 130+ topics
- Expanded the topic list from 5 generic bullets to 8 precise categories with topic counts derived from the actual `tree.json` structure
- Added Agent OS & Conversational UIs, DevIndex App, Tutorials, and Engine vs Frameworks as previously missing top-level categories

### AGENTS_STARTUP.md (1 edit)

**Step 1 expansion** (~L25):
Added a "Documentation Taxonomy" paragraph directing agents to scan `learn/tree.json` alongside the CodebaseOverview. This gives agents an instant structural overview that makes subsequent knowledge base queries far more targeted.

## Rationale

The startup workflow already mandates reading `src/Neo.mjs` (1,212 lines) and `src/core/Base.mjs` (1,289 lines), which provide implementation mechanics. The 6 core engine guides provide the *architectural reasoning* — constructor trap motivation, configSymbol batch resolution proof, v10 Push/Pull integration bridge — but had zero pointers from either routing document.

`learn/tree.json` is the structural backbone consumed by `LearningSource.mjs` to build the entire Knowledge Base index, yet was absent from all agent-facing documentation.

## Scope

- Documentation-only. No code changes.
- 2 files modified, 24 insertions, 4 deletions.