### PR TITLE
feat: Implement Neural Link Action Recorder (#9889)

### DIFF
--- a/ai/mcp/server/neural-link/Server.mjs
+++ b/ai/mcp/server/neural-link/Server.mjs
@@ -8,6 +8,10 @@ import ConnectionService                               from './services/Connecti
 import HealthService                                   from './services/HealthService.mjs';
 import {listTools, callTool}                           from './services/toolService.mjs';
 
+let _turnId = 0;
+
+export const getCurrentTurnId = () => _turnId;
+
 /**
  * @class Neo.ai.mcp.server.neural-link.Server
  * @extends Neo.core.Base
@@ -127,6 +131,7 @@ class Server extends Base {
 
         // Call Tool Handler
         this.mcpServer.server.setRequestHandler(CallToolRequestSchema, async (request) => {
+            _turnId++;
             const { name, arguments: args } = request.params;
 
             try {

--- a/ai/mcp/server/neural-link/config.template.mjs
+++ b/ai/mcp/server/neural-link/config.template.mjs
@@ -1,4 +1,5 @@
 import fs from 'fs/promises';
+import os from 'os';
 import path from 'path';
 import Base from '../../../../src/core/Base.mjs';
 
@@ -27,7 +28,17 @@ const defaultConfig = {
      * Timeout for RPC calls in milliseconds.
      * @type {number}
      */
-    rpcTimeout: 10000
+    rpcTimeout: 10000,
+    /**
+     * Path to the memory core SQLite database for action logging.
+     * @type {string}
+     */
+    memoryCoreDbPath: path.join(os.homedir(), '.neo-ai-data', 'memory-core.sqlite'),
+    /**
+     * Number of days to retain Action logs in the Neural Link Database.
+     * @type {number}
+     */
+    pruneLogsAfterDays: 14
 };
 
 /**

--- a/ai/mcp/server/neural-link/services/RecorderService.mjs
+++ b/ai/mcp/server/neural-link/services/RecorderService.mjs
@@ -30,6 +30,8 @@ class RecorderService extends Base {
     }
 
     /**
+     * Initializes the SQLite connection to the Memory Core and ensures the physical nl_action_log
+     * schema and indices exist. Uses WAL journal mode to support non-blocking concurrent writes.
      * @returns {Promise<void>}
      */
     async initAsync() {
@@ -76,7 +78,9 @@ class RecorderService extends Base {
     }
 
     /**
-     * @param {Object} entry 
+     * Synchronously persists a specific Neural Link tool invocation into the shared memory core.
+     * Guaranteed not to throw or block the main execution thread on persistence failures.
+     * @param {Object} entry The invocation payload containing sequences, tool metadata, args, and execution times.
      */
     log(entry) {
         if (!this.db) return;
@@ -111,8 +115,13 @@ class RecorderService extends Base {
     }
 
     /**
-     * @param {Object} config 
-     * @returns {Array}
+     * Executes queries against the internal Action Log. Principally used by DreamService triggers 
+     * to harvest execution chains for automated Playwright test synthesis.
+     * @param {Object} config Query parameters and offsets.
+     * @param {Number} [config.sinceTimestamp=0] Return logs after this epoch.
+     * @param {Number} [config.minSuccessRate] (Not yet implemented) Flattens metrics filtering.
+     * @param {Number} [config.limit] Optional hard limit.
+     * @returns {Array} An array of matched SQLite row objects.
      */
     querySequences({ sinceTimestamp = 0, minSuccessRate, limit } = {}) {
         if (!this.db) return [];
@@ -136,7 +145,8 @@ class RecorderService extends Base {
     }
 
     /**
-     * @param {Number} days 
+     * Permanently drops legacy Neural Link action records from the SQLite db to prevent unbounded disk growth.
+     * @param {Number} days The rolling window in days beyond which older records are permanently discarded.
      */
     pruneOlderThan(days) {
         if (!this.db) return;

--- a/ai/mcp/server/neural-link/services/RecorderService.mjs
+++ b/ai/mcp/server/neural-link/services/RecorderService.mjs
@@ -1,0 +1,154 @@
+import crypto from 'crypto';
+import fs     from 'fs-extra';
+import path   from 'path';
+import Base   from '../../../../../src/core/Base.mjs';
+import config from '../config.mjs';
+
+/**
+ * @summary Service to intercept and persist Neural Link tool invocations to the Native Graph database.
+ * @class Neo.ai.mcp.server.neural-link.services.RecorderService
+ * @extends Neo.core.Base
+ * @singleton
+ */
+class RecorderService extends Base {
+    static config = {
+        /**
+         * @member {String} className='Neo.ai.mcp.server.neural-link.services.RecorderService'
+         * @protected
+         */
+        className: 'Neo.ai.mcp.server.neural-link.services.RecorderService',
+        /**
+         * @member {Boolean} singleton=true
+         * @protected
+         */
+        singleton: true,
+        /**
+         * @member {Object|null} db=null
+         * @protected
+         */
+        db: null
+    }
+
+    /**
+     * @returns {Promise<void>}
+     */
+    async initAsync() {
+        await super.initAsync();
+        
+        try {
+            const dbPath = config.memoryCoreDbPath;
+            if (!dbPath) {
+                console.warn('[RecorderService] memoryCoreDbPath not configured. Disabling logging.');
+                return;
+            }
+            
+            await fs.ensureDir(path.dirname(dbPath));
+            const Database = (await import('better-sqlite3')).default;
+            
+            this.db = new Database(dbPath, { verbose: null });
+            this.db.pragma('journal_mode = WAL');
+            
+            // System table
+            this.db.exec(`
+                CREATE TABLE IF NOT EXISTS nl_action_log (
+                    id          TEXT PRIMARY KEY,
+                    agent_id    TEXT NOT NULL,
+                    session_id  TEXT,
+                    sequence_id TEXT NOT NULL,
+                    timestamp   INTEGER NOT NULL,
+                    tool        TEXT NOT NULL,
+                    args        TEXT NOT NULL,
+                    result      TEXT,
+                    success     INTEGER DEFAULT 0,
+                    duration_ms INTEGER,
+                    app_name    TEXT,
+                    reward      REAL DEFAULT NULL
+                );
+                CREATE INDEX IF NOT EXISTS idx_nl_action_log_sequence  ON nl_action_log(sequence_id);
+                CREATE INDEX IF NOT EXISTS idx_nl_action_log_session   ON nl_action_log(session_id);
+                CREATE INDEX IF NOT EXISTS idx_nl_action_log_timestamp ON nl_action_log(timestamp);
+            `);
+            
+            console.log('[RecorderService] Connected to Memory Core nl_action_log.');
+        } catch (err) {
+            console.warn('[RecorderService] Failed to initialize SQLite connection:', err.message);
+        }
+    }
+
+    /**
+     * @param {Object} entry 
+     */
+    log(entry) {
+        if (!this.db) return;
+        
+        try {
+            const insertStmt = this.db.prepare(`
+                INSERT INTO nl_action_log (
+                    id, agent_id, session_id, sequence_id, timestamp, 
+                    tool, args, result, success, duration_ms, app_name
+                ) VALUES (
+                    ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?
+                )
+            `);
+            
+            insertStmt.run(
+                crypto.randomUUID(),
+                entry.agent_id || 'unknown',
+                entry.session_id || null,
+                entry.sequence_id,
+                entry.timestamp,
+                entry.tool,
+                entry.args,
+                entry.result,
+                entry.success ? 1 : 0,
+                entry.duration_ms,
+                entry.app_name || null
+            );
+        } catch (err) {
+            // Swallowing exceptions so it never disrupts the main logic
+            console.error('[RecorderService] Failed to append log entry:', err);
+        }
+    }
+
+    /**
+     * @param {Object} config 
+     * @returns {Array}
+     */
+    querySequences({ sinceTimestamp = 0, minSuccessRate, limit } = {}) {
+        if (!this.db) return [];
+        
+        try {
+            let sql = `SELECT * FROM nl_action_log WHERE timestamp >= ?`;
+            const args = [sinceTimestamp];
+            
+            sql += ` ORDER BY timestamp DESC`;
+            
+            if (limit) {
+                sql += ` LIMIT ?`;
+                args.push(limit);
+            }
+            
+            return this.db.prepare(sql).all(...args);
+        } catch (err) {
+            console.error('[RecorderService] Failed to query sequences:', err);
+            return [];
+        }
+    }
+
+    /**
+     * @param {Number} days 
+     */
+    pruneOlderThan(days) {
+        if (!this.db) return;
+        
+        try {
+            const cutoff = Date.now() - (days * 24 * 60 * 60 * 1000);
+            const dropStmt = this.db.prepare(`DELETE FROM nl_action_log WHERE timestamp < ?`);
+            dropStmt.run(cutoff);
+        } catch (err) {
+            console.error('[RecorderService] Failed to prune logs:', err);
+        }
+    }
+}
+
+export default Neo.setupClass(RecorderService);

--- a/ai/mcp/server/neural-link/services/RecorderService.mjs
+++ b/ai/mcp/server/neural-link/services/RecorderService.mjs
@@ -4,6 +4,8 @@ import path   from 'path';
 import Base   from '../../../../../src/core/Base.mjs';
 import config from '../config.mjs';
 
+const MS_PER_DAY = 24 * 60 * 60 * 1000;
+
 /**
  * @summary Service to intercept and persist Neural Link tool invocations to the Native Graph database.
  * @class Neo.ai.mcp.server.neural-link.services.RecorderService
@@ -146,13 +148,13 @@ class RecorderService extends Base {
 
     /**
      * Permanently drops legacy Neural Link action records from the SQLite db to prevent unbounded disk growth.
-     * @param {Number} days The rolling window in days beyond which older records are permanently discarded.
+     * @param {Number} [days=config.pruneLogsAfterDays] The rolling window in days beyond which older records are permanently discarded.
      */
-    pruneOlderThan(days) {
+    pruneOlderThan(days = config.pruneLogsAfterDays) {
         if (!this.db) return;
         
         try {
-            const cutoff = Date.now() - (days * 24 * 60 * 60 * 1000);
+            const cutoff = Date.now() - (days * MS_PER_DAY);
             const dropStmt = this.db.prepare(`DELETE FROM nl_action_log WHERE timestamp < ?`);
             dropStmt.run(cutoff);
         } catch (err) {

--- a/ai/mcp/server/neural-link/services/toolService.mjs
+++ b/ai/mcp/server/neural-link/services/toolService.mjs
@@ -13,6 +13,9 @@ const __filename      = fileURLToPath(import.meta.url);
 const __dirname       = path.dirname(__filename);
 const openApiFilePath = path.join(__dirname, '../openapi.yaml');
 
+import {getCurrentTurnId} from '../Server.mjs';
+import RecorderService    from './RecorderService.mjs';
+
 const serviceMapping = {
     check_namespace              : RuntimeService    .checkNamespace            .bind(RuntimeService),
     find_instances               : InstanceService   .findInstances             .bind(InstanceService),
@@ -54,7 +57,52 @@ const toolService = Neo.create(ToolService, {
     serviceMapping
 });
 
-const callTool  = toolService.callTool.bind(toolService);
+const _callTool = toolService.callTool.bind(toolService);
+
+const callTool = async (name, args) => {
+    const t0        = Date.now();
+    const seqId     = `${ConnectionService.agentId || 'unknown'}_${getCurrentTurnId()}`;
+    const sessionId = args?.sessionId ?? ConnectionService.getDefaultSessionId();
+    const appName   = ConnectionService.sessionData.get(sessionId)?.appName ?? null;
+
+    let result, success = 0;
+    try {
+        result  = await _callTool(name, args);
+        success = 1;
+        return result;
+    } catch (err) {
+        result = { error: err.message };
+        throw err;
+    } finally {
+        let safeArgs   = '{}';
+        let safeResult = 'null';
+        try {
+            safeArgs = JSON.stringify(args ?? {});
+        } catch (e) {
+            safeArgs = JSON.stringify({ error: 'Unserializable Arguments' });
+        }
+        
+        try {
+            safeResult = JSON.stringify(result ?? null);
+        } catch (e) {
+            safeResult = JSON.stringify({ error: 'Unserializable Result' });
+        }
+        
+        RecorderService.log({
+            agent_id   : ConnectionService.agentId || 'unknown',
+            session_id : sessionId,
+            sequence_id: seqId,
+            timestamp  : t0,
+            tool       : name,
+            args       : safeArgs,
+            result     : safeResult,
+            success,
+            duration_ms: Date.now() - t0,
+            app_name   : appName
+        });
+    }
+};
+
 const listTools = toolService.listTools.bind(toolService);
 
 export {callTool, listTools};

--- a/test/playwright/unit/ai/neural-link/RecorderService.spec.mjs
+++ b/test/playwright/unit/ai/neural-link/RecorderService.spec.mjs
@@ -1,0 +1,158 @@
+import {setup} from '../../../setup.mjs';
+
+const appName = 'RecorderServiceTest';
+
+setup({
+    neoConfig: {
+        unitTestMode: true
+    },
+    appConfig: {
+        name             : appName,
+        isMounted        : () => true,
+        vnodeInitialising: false
+    }
+});
+
+import {test, expect} from '@playwright/test';
+import Neo            from '../../../../../src/Neo.mjs';
+import * as core      from '../../../../../src/core/_export.mjs';
+import fs             from 'fs';
+import path           from 'path';
+
+test.describe('Neo.ai.mcp.server.neural-link.services.RecorderService', () => {
+    let RecorderService;
+    let config;
+    const testDbName = `nl-recorder-test-${process.pid}-${Date.now()}.sqlite`;
+    let testDbPath;
+    
+    test.beforeAll(async () => {
+        config = (await import('../../../../../ai/mcp/server/neural-link/config.mjs')).default;
+        RecorderService = (await import('../../../../../ai/mcp/server/neural-link/services/RecorderService.mjs')).default;
+        
+        const tmpDir = path.resolve(process.cwd(), 'tmp');
+        if (!fs.existsSync(tmpDir)) {
+            fs.mkdirSync(tmpDir, { recursive: true });
+        }
+        testDbPath = path.join(tmpDir, testDbName);
+        
+        // Override the path for this test run
+        config.data.memoryCoreDbPath = testDbPath;
+        
+        // Ensure old DB is gone just in case
+        if (fs.existsSync(testDbPath)) {
+            try {
+                fs.unlinkSync(testDbPath);
+                if (fs.existsSync(`${testDbPath}-wal`)) fs.unlinkSync(`${testDbPath}-wal`);
+                if (fs.existsSync(`${testDbPath}-shm`)) fs.unlinkSync(`${testDbPath}-shm`);
+            } catch (e) {}
+        }
+        
+        await RecorderService.initAsync();
+    });
+    
+    test.afterAll(async () => {
+        if (RecorderService.db) {
+            try { RecorderService.db.close(); } catch (e) {}
+            RecorderService.db = null;
+        }
+        
+        if (fs.existsSync(testDbPath)) {
+            try { fs.unlinkSync(testDbPath); } catch (e) {}
+            if (fs.existsSync(`${testDbPath}-wal`)) try { fs.unlinkSync(`${testDbPath}-wal`); } catch (e) {}
+            if (fs.existsSync(`${testDbPath}-shm`)) try { fs.unlinkSync(`${testDbPath}-shm`); } catch (e) {}
+        }
+    });
+    
+    test('should initialize the database schema', async () => {
+        expect(RecorderService.db).toBeTruthy();
+        
+        const tables = RecorderService.db.prepare("SELECT name FROM sqlite_master WHERE type='table' AND name='nl_action_log'").all();
+        expect(tables.length).toBe(1);
+    });
+    
+    test('should log tool invocations correctly', () => {
+        const dummyLog = {
+            agent_id: 'agent-123',
+            session_id: 'session-456',
+            sequence_id: 'seq-789',
+            timestamp: Date.now(),
+            tool: 'test_tool',
+            args: JSON.stringify({ arg1: 'value' }),
+            result: JSON.stringify({ res: 'ok' }),
+            success: true,
+            duration_ms: 150,
+            app_name: appName
+        };
+        
+        RecorderService.log(dummyLog);
+        
+        const rows = RecorderService.db.prepare("SELECT * FROM nl_action_log WHERE sequence_id = 'seq-789'").all();
+        expect(rows.length).toBe(1);
+        
+        const row = rows[0];
+        expect(row.agent_id).toBe('agent-123');
+        expect(row.session_id).toBe('session-456');
+        expect(row.sequence_id).toBe('seq-789');
+        expect(row.tool).toBe('test_tool');
+        expect(row.success).toBe(1);
+        expect(row.reward).toBeNull();
+        expect(row.app_name).toBe(appName);
+    });
+    
+    test('should handle success as 0 when log indicates failure', () => {
+        const dummyLog = {
+            agent_id: 'agent-123',
+            session_id: 'session-456',
+            sequence_id: 'seq-fail-123',
+            timestamp: Date.now(),
+            tool: 'test_tool2',
+            args: '{}',
+            result: 'error',
+            success: false,
+            duration_ms: 10
+        };
+        
+        RecorderService.log(dummyLog);
+        
+        const rows = RecorderService.db.prepare("SELECT * FROM nl_action_log WHERE sequence_id = 'seq-fail-123'").all();
+        expect(rows.length).toBe(1);
+        expect(rows[0].success).toBe(0);
+        expect(rows[0].reward).toBeNull();
+    });
+    
+    test('querySequences should group and filter records', () => {
+        const timeNow = Date.now();
+        // create a future log
+         RecorderService.log({
+            agent_id: 'agent-future',
+            sequence_id: 'seq-future',
+            timestamp: timeNow + 5000,
+            tool: 'future_tool',
+            args: '{}',
+            success: true
+        });
+        
+        const futureRows = RecorderService.querySequences({ sinceTimestamp: timeNow + 1000 });
+        expect(futureRows.length).toBe(1);
+        expect(futureRows[0].sequence_id).toBe('seq-future');
+    });
+    
+    test('pruneOlderThan should delete old rows', () => {
+        // Insert a very old row
+        RecorderService.db.prepare(`
+            INSERT INTO nl_action_log (id, agent_id, sequence_id, timestamp, tool, args)
+            VALUES ('old-1', 'ag', 'seq-old', ?, 'tool', '{}')
+        `).run(Date.now() - (10 * 24 * 60 * 60 * 1000)); // 10 days ago
+        
+        const allBefore = RecorderService.db.prepare("SELECT count(*) as c FROM nl_action_log").get().c;
+        
+        // prune older than 5 days
+        RecorderService.pruneOlderThan(5);
+        
+        const allAfter = RecorderService.db.prepare("SELECT count(*) as c FROM nl_action_log").get().c;
+        expect(allAfter).toBe(allBefore - 1);
+        
+        const oldCheck = RecorderService.db.prepare("SELECT * FROM nl_action_log WHERE id = 'old-1'").get();
+        expect(oldCheck).toBeUndefined();
+    });
+});


### PR DESCRIPTION
Resolves #9889

**Summary**
This PR implements the `RecorderService` and action telemetry wrappers for the Neural Link server.

**Changes**
*   **config.mjs:** Exposed `memoryCoreDbPath`.
*   **Server.mjs:** Added `_turnId` counter incremented per MCP tool invocation.
*   **toolService.mjs:** Wrapped `callTool` with tracking telemetry to persist latency, errors, tooling args, and results natively without blocking tool execution.
*   **RecorderService.mjs:** Implements the SQLite schema `nl_action_log` natively utilizing `better-sqlite3` in `WAL` mode. Exposes capabilities like `pruneOlderThan` and `querySequences`.
*   **RecorderService.spec.mjs:** Isolated Playwright unit test suite that asserts sequence mappings and successful/unsuccessful invocations.