### PR TITLE
docs: restructure CodebaseOverview Query Entry Points to lead with ask_knowledge_base (#9900)

### DIFF
--- a/learn/guides/fundamentals/CodebaseOverview.md
+++ b/learn/guides/fundamentals/CodebaseOverview.md
@@ -548,7 +548,7 @@ synthesizes a grounded answer, and cites its references — all in a single call
 **Example queries:**
 - `ask_knowledge_base(query='how does the reactive config system work?')`
 - `ask_knowledge_base(query='current syntax for state provider bindings')`
-- `ask_knowledge_base(query='how to define a Grid with multiple bodies')`
+- `ask_knowledge_base(query='how to configure locked columns in a Grid')`
 - `ask_knowledge_base(query='what is the difference between ntype and className?', type='guide')`
 
 | Question Type | Tool | Returns |

--- a/learn/guides/fundamentals/CodebaseOverview.md
+++ b/learn/guides/fundamentals/CodebaseOverview.md
@@ -537,10 +537,30 @@ You're not just working *with* Neo.mjs. You're working *inside* an ecosystem des
 
 ## Key Concepts: Query Entry Points
 
-When you need to understand Neo.mjs, start with the right tool:
+### Ask First, Search Second
 
-- **Ask, Don't Search:** For conceptual questions ("How does reactivity work?", "What is the config system?"), use `ask_knowledge_base` — it synthesizes answers from multiple source files in a single call. Essential for top-level perspective in a codebase of this scale.
-- **Search for Files:** When you need to discover *which files* implement something, use `query_documents` with these high-value terms:
+Your most powerful tool is `ask_knowledge_base`. It reads multiple source files, 
+synthesizes a grounded answer, and cites its references — all in a single call.
+
+> [!WARNING]
+> Do NOT attempt to answer Neo.mjs questions from training data. The framework evolves rapidly — your training data is almost certainly outdated for syntax-level details.
+
+**Example queries:**
+- `ask_knowledge_base(query='how does the reactive config system work?')`
+- `ask_knowledge_base(query='current syntax for state provider bindings')`
+- `ask_knowledge_base(query='how to define a Grid with multiple bodies')`
+- `ask_knowledge_base(query='what is the difference between ntype and className?', type='guide')`
+
+| Question Type | Tool | Returns |
+|---|---|---|
+| "How does X work?" | `ask_knowledge_base` | Synthesized answer + source citations |
+| "Which files implement Z?" | `query_documents` | Ranked file paths with relevance scores |
+| Exact implementation details | `view_file` | Raw source code |
+
+### File Discovery Keywords
+
+When you specifically need to discover *which files* implement something, 
+use `query_documents` with these high-value terms:
 
 ### Agent Intelligence & Workflows
 - `"DreamService"`, `"Agent OS"`, `"Native Edge Graph"`, `"SQLite topology"`, `"Fat Ticket"`


### PR DESCRIPTION
Resolves #9900.

## Objective
The Codebase Overview (which is the foundational startup document for all agents) was structurally misaligned, disproportionately featuring `query_documents` over the strictly prioritized `ask_knowledge_base` tool.

## Architectural Changes
- Removed the implicit bias toward the legacy `query_documents` search workflow.
- Placed `ask_knowledge_base` at the absolute forefront, codifying its role as the zero-cost RAG subagent for all conceptual discoveries.
- Outlined explicit use-cases and example queries.
- Added a structural warning against hallucinations via out-of-context training data.
- Established a decision table (Ask -> Search -> Dissect).