### PR TITLE
Security: Protocol-relative third-party stylesheet URLs allow insecure dependency loading

### DIFF
--- a/apps/realworld/index.html
+++ b/apps/realworld/index.html
@@ -3,10 +3,10 @@
 <head>
     <meta charset="UTF-8">
     <!-- Import Ionicon icons & Google Fonts our Bootstrap theme relies on -->
-    <link href="//code.ionicframework.com/ionicons/2.0.1/css/ionicons.min.css" rel="stylesheet" type="text/css">
-    <link href="//fonts.googleapis.com/css?family=Titillium+Web:700|Source+Serif+Pro:400,700|Merriweather+Sans:400,700|Source+Sans+Pro:400,300,600,700,300italic,400italic,600italic,700italic" rel="stylesheet" type="text/css">
+    <link href="https://code.ionicframework.com/ionicons/2.0.1/css/ionicons.min.css" rel="stylesheet" type="text/css">
+    <link href="https://fonts.googleapis.com/css?family=Titillium+Web:700|Source+Serif+Pro:400,700|Merriweather+Sans:400,700|Source+Sans+Pro:400,300,600,700,300italic,400italic,600italic,700italic" rel="stylesheet" type="text/css">
     <!-- Import the custom Bootstrap 4 theme from our hosted CDN -->
-    <link rel="stylesheet" href="//demo.productionready.io/main.css">
+    <link rel="stylesheet" href="https://demo.productionready.io/main.css">
     <title>Conduit</title>
 </head>
 <body>


### PR DESCRIPTION
## Summary

Security: Protocol-relative third-party stylesheet URLs allow insecure dependency loading

## Problem

**Severity**: `Medium` | **File**: `apps/realworld/index.html:L6`

The page loads external CSS via protocol-relative URLs (`//...`). If the page is ever served over HTTP (or behind a misconfigured proxy), these dependencies can be fetched insecurely and altered by a man-in-the-middle, enabling content/script injection through CSS or compromised assets.

## Solution

Use explicit `https://` URLs for all third-party resources, enforce HSTS on the hosting domain, and avoid protocol-relative URLs.

## Changes

- `apps/realworld/index.html` (modified)