### PR TITLE
Fix: DreamService RAG Migration (#9931)

### DIFF
--- a/ai/daemons/DreamService.mjs
+++ b/ai/daemons/DreamService.mjs
@@ -516,14 +516,18 @@ ${contextText}
             logger.warn('[DreamService] Could not parse jsdocx structure.json.');
         }
 
+        // INTERNAL MAPPING NOTE: The native SQLite items iterate over `Neo.ai.graph.NodeModel`
+        // instances. To align with formal Graph Database taxonomy, the DTO `.type` property 
+        // is mapped to `.label` on Nodes (while Edges retain `.type`).
+
         // Gather test framework paths directly
         const testFilePaths = GraphService.db.nodes.items.filter(n =>
-            n.type === 'FILE' && n.properties?.path?.startsWith('test/')
+            n.label === 'FILE' && n.properties?.path?.startsWith('test/')
         ).map(n => n.properties?.path || '').map(p => p.toLowerCase());
 
         // Gather architectural guide paths natively
         const guideFilePaths = GraphService.db.nodes.items.filter(n =>
-            n.type === 'FILE' && n.properties?.path?.startsWith('learn/guides/')
+            n.label === 'FILE' && n.properties?.path?.startsWith('learn/guides/')
         ).map(n => n.properties?.path || '');
 
         for (const node of structuralNodes) {
@@ -831,8 +835,10 @@ ${topContent}
         const files = filesRaw.filter(f => f.endsWith('.md'));
         
         let nodesCollection = null;
-        if (SQLiteVectorManager.db) {
-            nodesCollection = await SQLiteVectorManager.getOrCreateCollection({ name: 'neo_graph_nodes' });
+        try {
+            nodesCollection = await StorageRouter.getGraphCollection();
+        } catch (e) {
+            logger.warn('[DreamService] Could not resolve graph collection via StorageRouter.');
         }
 
         for (const file of files) {
@@ -1010,20 +1016,21 @@ ${topContent}
             logger.info(`[DreamService] Apoptosis detected ${orphaned.length} orphaned nodes. Commencing eradication...`);
             GraphService.removeNodes(orphaned);
 
-            if (SQLiteVectorManager.db) {
+            try {
                 // Cross-layer purge from semantic embeddings
                 logger.info(`[DreamService] Purging semantic vectors for ${orphaned.length} deleted nodes.`);
 
-                ['neo_graph_nodes', 'neo_agent_sessions_summary'].forEach(async collectionName => {
-                    try {
-                        const collection = await SQLiteVectorManager.getOrCreateCollection({ name: collectionName });
-                        if (collection) {
-                            await collection.delete({ ids: orphaned });
-                        }
-                    } catch (e) {
-                        logger.warn(`[DreamService] Apoptosis soft-failure on collection ${collectionName}: ${e.message}`);
-                    }
-                });
+                const graphColl = await StorageRouter.getGraphCollection();
+                const summaryColl = await StorageRouter.getSummaryCollection();
+
+                if (graphColl) {
+                    await graphColl.delete({ ids: orphaned }).catch(() => {});
+                }
+                if (summaryColl) {
+                    await summaryColl.delete({ ids: orphaned }).catch(() => {});
+                }
+            } catch (e) {
+                logger.warn(`[DreamService] Apoptosis soft-failure on Vector purge: ${e.message}`);
             }
         }
     }
@@ -1040,19 +1047,28 @@ ${topContent}
         await this.ingestDiscussionStates();
         await this.ingestPullRequestFeedback();
 
-        if (!SQLiteVectorManager.db) {
-            logger.warn('[DreamService] SQLiteVectorManager not mounted. Skipping Golden Path extraction.');
+        let graphColl = null;
+        let summaryColl = null;
+        try {
+            graphColl = await StorageRouter.getGraphCollection();
+            summaryColl = await StorageRouter.getSummaryCollection();
+        } catch (e) {
+            logger.warn('[DreamService] StorageRouter unavailable. Skipping Golden Path extraction.');
+            return;
+        }
+
+        if (!graphColl || !summaryColl) {
+            logger.warn('[DreamService] Collections missing. Skipping Golden Path extraction.');
             return;
         }
 
         // Generate the Frontier Baseline Vector using the most recent session memory
         let frontierEmbedding = null;
         try {
-            const sessionsVec = await SQLiteVectorManager.getSummaryCollection();
-            const recent = await sessionsVec.get({ limit: 2, include: ['documents'] });
+            const recent = await summaryColl.get({ limit: 2, include: ['documents'] });
 
             let frontierText = "Neo.mjs Active Strategic Context: ";
-            if (recent && recent.documents.length > 0) {
+            if (recent && recent.documents && recent.documents.length > 0) {
                 frontierText += recent.documents.join("\n\n");
             } else {
                 frontierText += "Initialization and Stabilization.";
@@ -1065,68 +1081,89 @@ ${topContent}
             return;
         }
 
-        const f32 = new Float32Array(frontierEmbedding);
+        // Pillar 1: Semantic Distance from ChromaDB
+        let semanticIds = [];
+        let semanticDistances = [];
+        try {
+            const semanticResults = await graphColl.query({
+                queryEmbeddings: [frontierEmbedding],
+                nResults: 20
+            });
+            if (semanticResults && semanticResults.ids && semanticResults.ids.length > 0) {
+                semanticIds = semanticResults.ids[0];
+                semanticDistances = semanticResults.distances ? semanticResults.distances[0] : new Array(semanticIds.length).fill(0.1);
+            }
+        } catch (e) {
+            logger.warn('[DreamService] Failed to query semantic vectors from ChromaDB.', e);
+            return;
+        }
 
-        // Execute the unified Hybrid SQL Query directly mapping native structural weights against active vectors!
-        const stmt = SQLiteVectorManager.db.prepare(`
-            SELECT 
-                n.id,
-                n.data,
-                COALESCE((
-                    SELECT SUM(json_extract(e.data, '$.properties.weight')) 
-                    FROM Edges e 
-                    WHERE e.target = n.id AND e.type != 'BLOCKS'
-                ), 0.0) as struct_score,
-                v.distance as semantic_distance
-            FROM Nodes n
-            JOIN neo_graph_nodes_data d ON d.chroma_id = n.id
-            JOIN neo_graph_nodes_vec v ON v.rowid = d.rowid
-            WHERE json_extract(n.data, '$.properties.state') = 'OPEN'
-              AND v.embedding MATCH ? AND k = 20
-        `);
+        if (semanticIds.length === 0) {
+            logger.info('[DreamService] No semantic nodes found. Golden path empty.');
+            return;
+        }
 
-        // Check node validity and calculate priority mathematically internally securely
-        const results = stmt.all(f32);
+        // Pillar 2: Structural Weight from SQLite Graph
         const scoredNodes = [];
-
         const SEMANTIC_WEIGHT = 2.0;
         const STRUCTURAL_WEIGHT = 1.0;
 
-        for (const row of results) {
-            const issueId = row.id;
+        try {
+            const placeholders = semanticIds.map(() => '?').join(',');
+            const stmt = GraphService.db.storage.db.prepare(`
+                SELECT 
+                    n.id,
+                    n.data,
+                    COALESCE((
+                        SELECT SUM(json_extract(e.data, '$.properties.weight')) 
+                        FROM Edges e 
+                        WHERE e.target = n.id AND e.type != 'BLOCKS'
+                    ), 0.0) as struct_score
+                FROM Nodes n
+                WHERE json_extract(n.data, '$.properties.state') = 'OPEN'
+                  AND n.id IN (${placeholders})
+            `);
 
-            // Re-verify blocker topology natively using GraphService API
-            const blockers = GraphService.db.edges.getByIndex('target', issueId).filter(e => e.type === 'BLOCKS');
-            let isBlocked = false;
+            const results = stmt.all(...semanticIds);
 
-            for (const bEdge of blockers) {
-                const blockerNode = GraphService.db.nodes.get(bEdge.source);
-                if (blockerNode && blockerNode.properties?.state === 'OPEN') {
-                    isBlocked = true;
-                    break;
+            for (const row of results) {
+                const issueId = row.id;
+
+                // Re-verify blocker topology natively using GraphService API
+                const blockers = GraphService.db.edges.getByIndex('target', issueId).filter(e => e.type === 'BLOCKS');
+                let isBlocked = false;
+
+                for (const bEdge of blockers) {
+                    const blockerNode = GraphService.db.nodes.get(bEdge.source);
+                    if (blockerNode && blockerNode.properties?.state === 'OPEN') {
+                        isBlocked = true;
+                        break;
+                    }
                 }
+
+                if (isBlocked) continue; // Architecturally blocked issues cannot be Golden
+
+                const idx = semanticIds.indexOf(issueId);
+                const semantic_distance = parseFloat(semanticDistances[idx]) || 0.1;
+                const struct_score = parseFloat(row.struct_score) || 0;
+
+                // Lower distance = Higher significance. (Add 0.1 to avoid div by 0 and curb massive asymptotes)
+                const semanticScore = 1.0 / (semantic_distance + 0.1);
+
+                const priority = (semanticScore * SEMANTIC_WEIGHT) + (struct_score * STRUCTURAL_WEIGHT);
+
+                let nodeData = null;
+                try { nodeData = JSON.parse(row.data); } catch (e) { }
+
+                scoredNodes.push({
+                    node: nodeData || { id: issueId },
+                    score: priority,
+                    semantic: semanticScore,
+                    structural: struct_score
+                });
             }
-
-            if (isBlocked) continue; // Architecturally blocked issues cannot be Golden
-
-            const semantic_distance = parseFloat(row.semantic_distance) || 0.1;
-            const struct_score = parseFloat(row.struct_score) || 0;
-
-            // Lower distance = Higher significance. (Add 0.1 to avoid div by 0 and curb massive asymptotes)
-            const semanticScore = 1.0 / (semantic_distance + 0.1);
-
-            const priority = (semanticScore * SEMANTIC_WEIGHT) + (struct_score * STRUCTURAL_WEIGHT);
-
-            // Re-inflate node JSON locally
-            let nodeData = null;
-            try { nodeData = JSON.parse(row.data); } catch (e) { }
-
-            scoredNodes.push({
-                node: nodeData || { id: issueId },
-                score: priority,
-                semantic: semanticScore,
-                structural: struct_score
-            });
+        } catch (e) {
+            logger.warn('[DreamService] Error executing hybrid mapping across local Graph Store.', e);
         }
 
         // Sort descending by calculated priority

--- a/ai/graph/NodeModel.mjs
+++ b/ai/graph/NodeModel.mjs
@@ -4,6 +4,10 @@ import Model from '../../src/data/Model.mjs';
  * Represents a single Node within the Native Edge Graph Database engine. 
  * Nodes capture entity data in the GraphRAG topologies, pairing with ChrombaDB semantic vectors.
  * Leveraging Neo.data.Model enables exact schema validation and tracks structural changes for disk synchronization.
+ *
+ * @important The JSON DTO representation uses `.type` (e.g., 'CLASS', 'FILE'). However, to align 
+ * strictly with formal Graph Database taxonomy (where Nodes have 'labels' and Edges have 'types'), 
+ * NodeModel natively maps this JSON field to `.label` for internal storage and querying.
  * 
  * @class Neo.ai.graph.NodeModel
  * @extends Neo.data.Model

--- a/ai/mcp/server/memory-core/services/GraphService.mjs
+++ b/ai/mcp/server/memory-core/services/GraphService.mjs
@@ -105,6 +105,7 @@ class GraphService extends Base {
 
     /**
      * Upserts a Node representation into the graph securely linking the ID.
+     * @important The `type` string is mapped directly to `node.label` to comply with strict Graph Database taxonomy (Node Labels).
      * @param {Object} nodeData
      */
     upsertNode({id, type, name, description, semanticVectorId, state, updatedAt, properties}) {

--- a/test/playwright/unit/ai/daemons/DreamService.spec.mjs
+++ b/test/playwright/unit/ai/daemons/DreamService.spec.mjs
@@ -25,7 +25,7 @@ test.describe('Neo.ai.mcp.server.memory-core.services.DreamService', () => {
     let GraphService;
     let SystemLifecycleService;
     let DreamService;
-    let SQLiteVectorManager;
+    let StorageRouter;
     let OpenAiCompatible;
     let TextEmbeddingService;
     const testDbName = `memory-core-dream-test-${process.pid}-${Date.now()}.sqlite`;
@@ -52,7 +52,7 @@ test.describe('Neo.ai.mcp.server.memory-core.services.DreamService', () => {
 
         GraphService = (await import('../../../../../ai/mcp/server/memory-core/services/GraphService.mjs')).default;
         DreamService = (await import('../../../../../ai/daemons/DreamService.mjs')).default;
-        SQLiteVectorManager = (await import('../../../../../ai/mcp/server/memory-core/managers/SQLiteVectorManager.mjs')).default;
+        StorageRouter = (await import('../../../../../ai/mcp/server/memory-core/managers/StorageRouter.mjs')).default;
         OpenAiCompatible       = (await import('../../../../../ai/provider/OpenAiCompatible.mjs')).default;
         SystemLifecycleService = (await import('../../../../../ai/mcp/server/memory-core/services/lifecycle/SystemLifecycleService.mjs')).default;
         TextEmbeddingService   = (await import('../../../../../ai/mcp/server/memory-core/services/TextEmbeddingService.mjs')).default;
@@ -194,7 +194,7 @@ test.describe('Neo.ai.mcp.server.memory-core.services.DreamService', () => {
     test('should detect GUIDE_GAP using Boolean LLM Verification', async () => {
         const baseGenerate = OpenAiCompatible.prototype.generate;
         OpenAiCompatible.prototype.generate = async function(prompt) {
-            providerPrompt = prompt;
+            providerPrompt = typeof prompt === 'string' ? prompt : JSON.stringify(prompt);
             return {
                 content: JSON.stringify({
                     verified: false
@@ -208,6 +208,13 @@ test.describe('Neo.ai.mcp.server.memory-core.services.DreamService', () => {
             name       : 'RogueFeature',
             description  : 'A feature totally disconnected from the vision.',
             properties : {path: 'src/rogue/Rogue.mjs'}
+        });
+        
+        GraphService.upsertNode({
+            id: 'mock-guide-node',
+            type: 'FILE',
+            name: 'Rogue Guide',
+            properties: {path: 'learn/guides/rogue.md'}
         });
 
         // Prepare isolated node payload
@@ -236,23 +243,20 @@ test.describe('Neo.ai.mcp.server.memory-core.services.DreamService', () => {
         const originalQuery = QueryService.queryDocuments;
         QueryService.queryDocuments = async () => ({ topResult: '/mock/path/guide.md' });
 
-        const originalFsExists = fs.existsSync;
-        fs.existsSync = (path) => {
-            if (path === '/mock/path/guide.md') return true;
-            return originalFsExists(path);
+        const originalFsPromisesRead = fs.promises.readFile;
+        fs.promises.readFile = async (p, enc) => {
+            if (p.includes('rogue.md')) return "Mock Guide Content for RogueFeature.";
+            return originalFsPromisesRead(p, enc);
         };
-        const originalFsRead = fs.readFileSync;
-        fs.readFileSync = (path, enc) => {
-            if (path === '/mock/path/guide.md') return "Mock Guide Content for RogueFeature.";
-            return originalFsRead(path, enc);
-        }
 
+        const configOverride = (await import('../../../../../ai/mcp/server/memory-core/config.mjs')).default;
+        
         await DreamService.executeCapabilityGapInference(session, payload);
 
         // Verify Prompt explicitly hit Guide Gap Logic
-        expect(typeof providerPrompt).toBe('string');
-        expect(providerPrompt).toContain('QA Engine');
-        expect(providerPrompt).toContain('RogueFeature');
+        const promptText = typeof providerPrompt === 'string' ? providerPrompt : JSON.stringify(providerPrompt);
+        expect(promptText).toContain('QA Engine');
+        expect(promptText).toContain('RogueFeature');
 
         // Verify logging appended GUIDE_GAP
         const updatedNode = GraphService.db.nodes.get('node-guide-test');
@@ -260,38 +264,45 @@ test.describe('Neo.ai.mcp.server.memory-core.services.DreamService', () => {
         expect(updatedNode.properties.capabilityGap).toContain('[GUIDE_GAP]');
         expect(updatedNode.properties.capabilityGap).toContain('failed LLM semantic verification');
         
-        // Restore
+        // Restore global functions
         OpenAiCompatible.prototype.generate = baseGenerate;
         QueryService.queryDocuments = originalQuery;
-        fs.existsSync = originalFsExists;
-        fs.readFileSync = originalFsRead;
+        fs.promises.readFile = originalFsPromisesRead;
     });
 
     test('synthesizeGoldenPath should mathematically select and inject Golden Path while rejecting BLOCKS', async () => {
-        // Mock SQLiteVectorManager to return dynamic Math metrics without embedding dependencies
-        const originalPrepare = SQLiteVectorManager.db ? SQLiteVectorManager.db.prepare : null;
-        const originalGetSummary = SQLiteVectorManager.getSummaryCollection;
+        // Mock StorageRouter to return deterministic ChromaDB metric formats
+        const originalGetSummary = StorageRouter.getSummaryCollection;
+        const originalGetGraph = StorageRouter.getGraphCollection;
+        const originalPrepare = GraphService.db.storage.db.prepare;
         
-        if (!SQLiteVectorManager.db) {
-             SQLiteVectorManager.db = {};
-        }
-        
-        SQLiteVectorManager.getSummaryCollection = async () => {
+        StorageRouter.getSummaryCollection = async () => {
              return {
                  get: async () => ({ documents: [] })
              };
         };
+
+        StorageRouter.getGraphCollection = async () => {
+            return {
+                query: async () => ({
+                    ids: [['epic-1', 'task-blocked', 'blocker', 'weak-task']],
+                    distances: [[0.1, 0.2, 0.9, 0.8]]
+                }),
+                get: async () => ({ ids: [], metadatas: [] }),
+                upsert: async () => {}
+            };
+        };
         
-        SQLiteVectorManager.db.prepare = function(sql) {
+        GraphService.db.storage.db.prepare = function(sql) {
             // console.log("SQL PREPARE CALLED:", sql.substring(0, 50));
             if (sql.includes('SELECT') && sql.includes('Nodes')) {
                 console.log('MOCK TRIGGERED Nodes SELECT!');
                 return {
                     all: () => [
-                        { id: 'epic-1', data: JSON.stringify({ id: 'epic-1', name: 'Epic Hero', properties: { state: 'OPEN'} }), struct_score: 5.0, semantic_distance: 0.1 },
-                        { id: 'task-blocked', data: JSON.stringify({ id: 'task-blocked', name: 'Blocked Task', properties: { state: 'OPEN'} }), struct_score: 10.0, semantic_distance: 0.2 },
-                        { id: 'blocker', data: JSON.stringify({ id: 'blocker', name: 'Blocker Bug', properties: { state: 'OPEN'} }), struct_score: 1.0, semantic_distance: 0.9 },
-                        { id: 'weak-task', data: JSON.stringify({ id: 'weak-task', name: 'Weak Task', properties: { state: 'OPEN'} }), struct_score: 0.1, semantic_distance: 0.8 }
+                        { id: 'epic-1', data: JSON.stringify({ id: 'epic-1', name: 'Epic Hero', properties: { state: 'OPEN'} }), struct_score: 5.0 },
+                        { id: 'task-blocked', data: JSON.stringify({ id: 'task-blocked', name: 'Blocked Task', properties: { state: 'OPEN'} }), struct_score: 10.0 },
+                        { id: 'blocker', data: JSON.stringify({ id: 'blocker', name: 'Blocker Bug', properties: { state: 'OPEN'} }), struct_score: 1.0 },
+                        { id: 'weak-task', data: JSON.stringify({ id: 'weak-task', name: 'Weak Task', properties: { state: 'OPEN'} }), struct_score: 0.1 }
                     ],
                     get: () => null,
                     run: () => {}
@@ -362,11 +373,12 @@ test.describe('Neo.ai.mcp.server.memory-core.services.DreamService', () => {
         OpenAiCompatible.prototype.generate = baseGenerate;
         TextEmbeddingService.embedText = baseEmbed;
         fs.writeFileSync = mockWriteFile;
-        SQLiteVectorManager.getSummaryCollection = originalGetSummary;
+        StorageRouter.getSummaryCollection = originalGetSummary;
+        StorageRouter.getGraphCollection = originalGetGraph;
         if (originalPrepare) {
-             SQLiteVectorManager.db.prepare = originalPrepare;
+             GraphService.db.storage.db.prepare = originalPrepare;
         } else {
-             delete SQLiteVectorManager.db.prepare;
+             delete GraphService.db.storage.db.prepare;
         }
     });
 });

--- a/test/playwright/unit/ai/daemons/DreamServiceGoldenPath.spec.mjs
+++ b/test/playwright/unit/ai/daemons/DreamServiceGoldenPath.spec.mjs
@@ -27,7 +27,7 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname  = path.dirname(__filename);
 
 test.describe('DreamService Golden Path', () => {
-    let TextEmbeddingService, aiConfig, DreamService, GraphService, SQLiteVectorManager, SystemLifecycleService;
+    let TextEmbeddingService, aiConfig, DreamService, GraphService, SystemLifecycleService;
 
     test.beforeAll(async () => {
         aiConfig = (await import('../../../../../ai/mcp/server/memory-core/config.mjs')).default;
@@ -49,7 +49,6 @@ test.describe('DreamService Golden Path', () => {
         TextEmbeddingService = (await import('../../../../../ai/mcp/server/memory-core/services/TextEmbeddingService.mjs')).default;
         DreamService         = (await import('../../../../../ai/daemons/DreamService.mjs')).default;
         GraphService         = (await import('../../../../../ai/mcp/server/memory-core/services/GraphService.mjs')).default;
-        SQLiteVectorManager  = (await import('../../../../../ai/mcp/server/memory-core/managers/SQLiteVectorManager.mjs')).default;
         SystemLifecycleService = (await import('../../../../../ai/mcp/server/memory-core/services/lifecycle/SystemLifecycleService.mjs')).default;
 
         if (fs.existsSync(testDbPath)) {


### PR DESCRIPTION
Resolves #9931\n\n### Summary\n- Fixed DreamService graph node iteration to correctly evaluate `.label` instead of `.type` due to formal graph theory semantic mappings in Neo's internal persistence layer (where Nodes have labels, Edges have types).\n- Added explicit documentation detailing this label/type distinction.\n- Refactored DreamService.spec.mjs Playwright test mocks and fixed global teardown `fs` callback exceptions, ensuring 100% test pass rate.