### PR TITLE
fix: Remove early abort in Sandman pipeline to permit ambient GC and GoldenPath (#9933)

### DIFF
--- a/ai/daemons/DreamService.mjs
+++ b/ai/daemons/DreamService.mjs
@@ -149,16 +149,14 @@ class DreamService extends Base {
         try {
             const sessions = await this.findUndigestedSessions();
             if (sessions.length === 0) {
-                logger.info('[DreamService] No undigested session memories found.');
-                return;
-            }
+                logger.info('[DreamService] No undigested session memories found. Proceeding to ambient task execution.');
+            } else {
+                logger.info(`[DreamService] Found ${sessions.length} undigested session(s). Beginning REM pipeline...`);
 
-            logger.info(`[DreamService] Found ${sessions.length} undigested session(s). Beginning REM pipeline...`);
+                // Phase 1: Ingest Live Workspace Files for Gap Analysis context mapping
+                await FileSystemIngestor.syncWorkspaceToGraph();
 
-            // Phase 1: Ingest Live Workspace Files for Gap Analysis context mapping
-            await FileSystemIngestor.syncWorkspaceToGraph();
-
-            for (const session of sessions) {
+                for (const session of sessions) {
                 logger.info(`[DreamService] Preparing session ${session.meta.sessionId} ("${session.meta.title}") for REM extraction.`);
                 
                 let rawEpisodicMemory = session.document;
@@ -203,6 +201,7 @@ class DreamService extends Base {
                         metadatas: [{ ...session.meta, graphDigested: true }]
                     });
                     logger.info(`[DreamService] Session ${session.meta.sessionId} marked as graphDigested in Memory Core.`);
+                }
                 }
             }
 


### PR DESCRIPTION
Resolves #9933. Modified `processUndigestedSessions()` to no longer abort execution when zero undigested sessions are present, allowing the daemon to ambiently perform Garbage Collection and synthesize the Golden Path roadmap consistently.