### PR TITLE
Optimize Vector Apoptosis Cartesian Deadlock & Suppress Chroma SDK Warnings

### DIFF
--- a/ai/graph/storage/SQLite.mjs
+++ b/ai/graph/storage/SQLite.mjs
@@ -86,6 +86,8 @@ class SQLite extends Base {
                 FOREIGN KEY (source) REFERENCES Nodes(id) ON DELETE CASCADE,
                 FOREIGN KEY (target) REFERENCES Nodes(id) ON DELETE CASCADE
             );
+            CREATE INDEX IF NOT EXISTS idx_edges_source ON Edges(source);
+            CREATE INDEX IF NOT EXISTS idx_edges_target ON Edges(target);
         `);
 
         // The Delta Log Hardware Mechanism mimicking Global Broadcast matrices securely natively without network payloads cleanly!

--- a/ai/mcp/server/memory-core/managers/ChromaManager.mjs
+++ b/ai/mcp/server/memory-core/managers/ChromaManager.mjs
@@ -129,7 +129,7 @@ class ChromaManager extends AbstractVectorManager {
                 const msg = args.join(' ');
                 if (msg.includes('No embedding function configuration found') ||
                     msg.includes('Could not deserialize the collection metadata') ||
-                    msg.includes('dummy embedding function')) {
+                    msg.includes('dummy_embedding_function')) {
                     return;
                 }
                 originalWarn.apply(console, args);

--- a/ai/mcp/server/memory-core/services/GraphService.mjs
+++ b/ai/mcp/server/memory-core/services/GraphService.mjs
@@ -627,8 +627,8 @@ class GraphService extends Base {
         const stmt = this.db.storage.db.prepare(`
             SELECT n.id, n.data
             FROM Nodes n
-            LEFT JOIN Edges e ON n.id = e.source OR n.id = e.target
-            WHERE e.id IS NULL
+            WHERE NOT EXISTS (SELECT 1 FROM Edges WHERE source = n.id)
+              AND NOT EXISTS (SELECT 1 FROM Edges WHERE target = n.id)
         `);
 
         let orphaned = [];


### PR DESCRIPTION
Resolves #9937

### Summary
- Fixed an O(N * M) Node.js event-loop freeze during Sandman Apoptosis by utilizing `NOT EXISTS` explicit sweeps instead of catastrophic unindexed `OR` `LEFT JOIN` paths.
- Embedded `CREATE INDEX` natively for `Edges(source)` and `Edges(target)` within the WAL Schema.
- Fixed SDK stderr noise suppression string formatting within `mcp-server-memory-core`.