### PR TITLE
fix(ai): Protect structural graph nodes from Vector Apoptosis

### DIFF
--- a/ai/mcp/server/memory-core/services/GraphService.mjs
+++ b/ai/mcp/server/memory-core/services/GraphService.mjs
@@ -639,7 +639,7 @@ class GraphService extends Base {
                 data = JSON.parse(row.data);
             } catch(e) { continue; }
             
-            if (data.label !== 'SYSTEM_ANCHOR' && data.label !== 'System') {
+            if (data.label !== 'SYSTEM_ANCHOR' && data.label !== 'System' && data.label !== 'ISSUE' && data.label !== 'DISCUSSION' && data.label !== 'PULL_REQUEST') {
                 orphaned.push(row.id);
             }
         }

--- a/resources/content/issues/issue-9912.md
+++ b/resources/content/issues/issue-9912.md
@@ -1,6 +1,6 @@
 ---
 id: 9912
-title: 'bug(ai): Debug sqlite-vec metadata schema to restore DreamService Hash Bypass'
+title: 'bug(ai): Prevent Vector Apoptosis from eradicating structural entities'
 state: OPEN
 labels:
   - bug
@@ -19,15 +19,13 @@ subIssuesTotal: 0
 blockedBy: []
 blocking: []
 ---
-# bug(ai): Debug sqlite-vec metadata schema to restore DreamService Hash Bypass
-
-# Restore MD5 Hash Caching in DreamService
+# bug(ai): Prevent Vector Apoptosis from eradicating structural entities
 
 ### Context
-Since migrating to `sqlite-vec`, `runSandman.mjs` is unnecessarily re-embedding every OPEN issue. The metadata extraction payload `exMeta.hash === contentHash` is failing natively. 
+`runSandman.mjs` is unnecessarily re-embedding every OPEN issue and discussion during the REM extraction pipeline. We originally suspected `sqlite-vec` metadata formatting, but the root cause is that `GraphService.getOrphanedNodes()` considers any node without edges to be "orphaned" and permanently deletes it via Vector Apoptosis. 
 
 ### Objective
-We must identify if `sqlite-vec` natively returns `.metadatas` structurally different from Chroma, and update the condition to correctly skip redundant LLM token processing.
+Update `GraphService.getOrphanedNodes()` to explicitly protect structural entities like `ISSUE`, `DISCUSSION`, and `PULL_REQUEST` from apoptosis, so they remain in the Native Edge Graph and ChromaDB, successfully passing the hash equality bypass on subsequent runs.
 
 ## Timeline
 


### PR DESCRIPTION
Resolves #9912

### Fat Ticket Summary
This PR fixes the root cause of DreamService inexplicably re-embedding 100% of OPEN issues and discussions natively during its run. While originally suspected to be an `sqlite-vec` metadata serialization regression, investigation revealed it was an intentional, yet overly broad, side effect of the Vector Apoptosis garbage collection loop inside `GraphService.mjs`.

`GraphService.getOrphanedNodes()` was configured to return any node completely devoid of edges. Because raw unstructured `ISSUE` and `DISCUSSION` nodes inherently lack topology links upon basic entry, the Apoptosis engine classified all of them as orphaned. This spawned local deletion in the native engine *and* a cross-layer purge in ChromaDB, which actively destroyed all hashes. 15 seconds later, `ingestIssueStates` would recreate and thus re-embed them entirely.

By explicitly protecting `ISSUE`, `DISCUSSION`, and `PULL_REQUEST` from the Apoptosis filter natively, their baseline metadata hashes correctly persist in Chroma, allowing the `exMeta.hash === contentHash` evaluation to short-circuit redundantly slow LLM embedding transactions natively.

Origin Session ID: e4f479f7-1d8c-4e4d-ae35-3e9dd732c5e5