### PR TITLE
fix(MemoryCore): Resolve local MLX n_ctx exhaustion by truncating tail-end session documents (#9921)

### DIFF
--- a/ai/mcp/server/memory-core/services/SessionService.mjs
+++ b/ai/mcp/server/memory-core/services/SessionService.mjs
@@ -380,7 +380,16 @@ class SessionService extends Base {
 
         if (memories.ids.length === 0) return null;
 
-        const aggregatedContent = memories.documents.join('\n\n---\n\n');
+        let aggregatedContent = memories.documents.join('\n\n---\n\n');
+
+        // Fix for #9921: local inference n_ctx exhaustion. 
+        // Enforce a strict content length limit (~10000 chars roughly equals 2500 tokens).
+        // By slicing from the negative length, we keep the tail end of the session, preventing 
+        // early context noise from breaking the 'final resolution' of the turn.
+        const MAX_CONTENT_LENGTH = 10000;
+        if (aggregatedContent.length > MAX_CONTENT_LENGTH) {
+            aggregatedContent = '[TRUNCATED_EARLY_SESSION_HISTORY]...\n\n' + aggregatedContent.slice(-MAX_CONTENT_LENGTH);
+        }
 
         let lastActivity = Date.now();
         let firstActivity = lastActivity;

--- a/test/playwright/unit/ai/mcp/server/memory-core/services/SessionSummarization.spec.mjs
+++ b/test/playwright/unit/ai/mcp/server/memory-core/services/SessionSummarization.spec.mjs
@@ -219,4 +219,66 @@ test.describe('Memory Core Offline Summarization', () => {
         expect(metadata.participatingAgents.includes('developer')).toBe(true);
         expect(metadata.models.includes('gemma4')).toBe(true);
     });
+
+    test('SessionService correctly truncates massive session histories to fix #9921 n_ctx exhaustion', async () => {
+        if (!SDK.Memory_LifecycleService._initPromise) {
+            await SDK.Memory_LifecycleService.initAsync();
+        } else {
+            await SDK.Memory_LifecycleService.ready();
+        }
+        await SDK.Memory_SessionService.ready();
+
+        const bigDummySessionId = crypto.randomUUID();
+        await SDK.Memory_ChromaManager.ready();
+
+        // Create a massive string > 10000 chars (approx 20,000 chars)
+        const hugeString = new Array(20000).fill('A').join('');
+        
+        await SDK.Memory_Service.addMemory({
+            prompt   : "Massive text request",
+            thought  : "Thinking deeply...",
+            response : hugeString,
+            agent    : "developer",
+            model    : "gemini-3.1-pro",
+            sessionId: bigDummySessionId
+        });
+
+        // Mock the model.generateContent to avoid actual LLM calls and verify the exact prompt content
+        const originalGenerateContent = SDK.Memory_SessionService.model ? SDK.Memory_SessionService.model.generateContent : null;
+        let capturedPrompt = '';
+        
+        SDK.Memory_SessionService.model = {
+            generateContent: async (prompt) => {
+                capturedPrompt = prompt;
+                return {
+                    response: {
+                        text: () => JSON.stringify({
+                            title              : "Massive Session",
+                            summary            : "It was huge",
+                            memoryCount        : 1,
+                            timeSpanString     : "0 minutes",
+                            participatingAgents: ["developer"],
+                            models             : ["gemini-3.1-pro"],
+                            quality            : 5,
+                            productivity       : 5,
+                            topics             : ["testing"],
+                            decisionList       : ["implemented truncation"]
+                        })
+                    }
+                };
+            }
+        };
+
+        const result = await SDK.Memory_SessionService.summarizeSession(bigDummySessionId);
+        
+        // Restore
+        if (originalGenerateContent) {
+            SDK.Memory_SessionService.model.generateContent = originalGenerateContent;
+        }
+
+        // Verify it was truncated successfully
+        expect(capturedPrompt.includes('[TRUNCATED_EARLY_SESSION_HISTORY]...')).toBe(true);
+        // Prompt should be around 10k chars (content) + instructions, usually < 12000 total length
+        expect(capturedPrompt.length).toBeLessThan(12000); 
+    });
 });


### PR DESCRIPTION
Resolves #9921. Implements strict text length truncation on Session Service session history aggregation to prevent raw context payload sizes from crashing local MLX OpenAiCompatible endpoints via n_ctx exhaustion limits. Includes Unit Testing coverage as specified by the testing skill guidelines.