### PR TITLE
feat: progressive disclosure for pull request skill (#9957)

### DIFF
--- a/.agent/skills/pull-request/SKILL.md
+++ b/.agent/skills/pull-request/SKILL.md
@@ -1,0 +1,10 @@
+---
+name: pull-request
+description: Standardized guidelines and procedural execution flow for opening a Pull Request. Mandates the "Stepping Back" reflection protocol and git/gh tool invocations.
+triggers: Use this skill as the final Definition of Done when you believe a ticket is complete and it is time to open a Pull Request, or if a human user asks you to submit a PR.
+---
+# Pull Request Skill
+
+If you are tasked with finalizing a ticket or opening a Pull Request, you MUST immediately use the `view_file` tool to read and strictly adhere to `/Users/Shared/github/neomjs/neo/.agent/skills/pull-request/references/pull-request-workflow.md` before proceeding.
+
+Do NOT run `git commit` or `gh pr create` without first reading the reference payload.

--- a/.agent/skills/pull-request/references/pull-request-workflow.md
+++ b/.agent/skills/pull-request/references/pull-request-workflow.md
@@ -48,15 +48,19 @@ gh pr create --fill --base dev
 ```
 *(The `--fill` flag automatically uses your commits to populate the PR details. If you need to add custom context, e.g., explicitly stating `Resolves #TICKET_ID` or dropping `Origin Session ID` telemetry, use the `manage_issue_comment` MCP tool to add a comment immediately after creation).*
 
-## 5. Definition of Done & The Handoff State
+## 5. Post-PR Polish & The Handoff State
 
-The agent's task is strictly considered "Done" once the PR is opened. You MUST halt and await human QA. **DO NOT** execute `gh pr merge` yourself under any circumstances.
+A Pull Request is a request for validation, not the finish line. You MUST execute a two-phased defense. You performed **Pre-PR Reflection** to control scope. Now, you must perform **Post-PR Reflection** to guarantee quality.
+
+1.  **Skill Chaining (MANDATORY):** Immediately after the PR is opened, you MUST invoke the `pr-review` skill against your own PR.
+2.  **Iterative Polish:** Act as your own harshest critic. If your review identifies minor gaps (missing JSDoc, logical edge cases), push follow-up commits to the branch to polish the execution.
+3.  **Human QA:** Once the PR passes your own critical review, you MUST halt. **DO NOT** execute `gh pr merge` yourself under any circumstances.
 
 ### State Transition Trap (Final Step)
 
-Once the PR is successfully opened, you MUST invoke the `signal_state_transition` tool to formally alert the Orchestrator that the workflow stage has completed.
+Only after the PR is successfully opened AND you have completed the Post-PR autonomous review cycle, you MUST formally alert the Orchestrator.
 
 1.  Execute the following MCP tool:
-    `signal_state_transition(state: 'PR_OPENED', target: "[pr-number]")`
+    `signal_state_transition(state: 'PR_READY_FOR_REVIEW', target: "[pr-number]")`
 
 This explicitly frees the current swarm intelligence instance to terminate or accept a new ticket from the `DreamService` queue.

--- a/.agent/skills/pull-request/references/pull-request-workflow.md
+++ b/.agent/skills/pull-request/references/pull-request-workflow.md
@@ -1,0 +1,62 @@
+# Pull Request Workflow
+
+This document outlines the authoritative protocol for structuring and executing Pull Requests within the Neo.mjs project. **This protocol applies to all agents, including headless autonomous sub-agents.**
+
+By consolidating the PR creation logic here, we prevent our agents from falling into tactical loops and enforce architectural reflection before any code is merged.
+
+## 1. The "Stepping Back" Reflection Protocol (Pre-Commit Gate)
+
+The act of opening a PR is an irreversible state transition in the Agent OS. Before executing `git commit` and `gh pr create`, you MUST step back from the tactical implementation and assume the persona of an Architect.
+
+In your internal monologue (thought process), explicitly answer the following:
+1.  **Did I fall into a tactical loop?** Did I just apply multiple iterative bandages to a file without fixing the architectural root cause?
+2.  **Are there major architectural gaps?** If so, and they are out of scope for the current ticket, DO NOT attempt to scope-creep them into this PR. Instead, formally acknowledge them in the PR body and propose a **Follow-Up System Enhancement Ticket**.
+3.  **Is my Context complete?** Does the code perfectly satisfy the 'Anchor & Echo' Knowledge Base Enhancement Strategy? (No undocumented configs or missing `@summary` tags).
+
+*If and only if* you pass this reflection phase, proceed to the Git execution sequence.
+
+## 2. Git Branching Mandate
+
+You are strictly forbidden from committing or pushing directly to `main` (release-only) or `dev` (default working). 
+If you are still on `dev`, you MUST branch off:
+
+```bash
+git checkout -b agent/[ticket-id]-[descriptor]
+# Example: git checkout -b agent/9957-pull-request-skill
+```
+
+## 3. Commit Sequence
+
+Your commit messages MUST follow Conventional Commits and MUST append the ticket ID so that the GitHub API and our internal memory cores can track outcomes.
+
+1.  Stage your files: `git add [file paths]`
+2.  Commit the changes:
+    ```bash
+    git commit -m "feat/fix/chore: Your descriptive message (#TICKET_ID)"
+    ```
+3.  Push the branch to remote:
+    ```bash
+    git push origin [branch-name]
+    ```
+
+## 4. Pull Request Creation
+
+You MUST use the GitHub CLI to open a Pull Request targeting the `dev` branch.
+
+```bash
+gh pr create --fill --base dev
+```
+*(The `--fill` flag automatically uses your commits to populate the PR details. If you need to add custom context, e.g., explicitly stating `Resolves #TICKET_ID` or dropping `Origin Session ID` telemetry, use the `manage_issue_comment` MCP tool to add a comment immediately after creation).*
+
+## 5. Definition of Done & The Handoff State
+
+The agent's task is strictly considered "Done" once the PR is opened. You MUST halt and await human QA. **DO NOT** execute `gh pr merge` yourself under any circumstances.
+
+### State Transition Trap (Final Step)
+
+Once the PR is successfully opened, you MUST invoke the `signal_state_transition` tool to formally alert the Orchestrator that the workflow stage has completed.
+
+1.  Execute the following MCP tool:
+    `signal_state_transition(state: 'PR_OPENED', target: "[pr-number]")`
+
+This explicitly frees the current swarm intelligence instance to terminate or accept a new ticket from the `DreamService` queue.

--- a/.agent/skills/pull-request/references/pull-request-workflow.md
+++ b/.agent/skills/pull-request/references/pull-request-workflow.md
@@ -6,12 +6,11 @@ By consolidating the PR creation logic here, we prevent our agents from falling 
 
 ## 1. The "Stepping Back" Reflection Protocol (Pre-Commit Gate)
 
-The act of opening a PR is an irreversible state transition in the Agent OS. Before executing `git commit` and `gh pr create`, you MUST step back from the tactical implementation and assume the persona of an Architect.
+The act of opening a PR is an irreversible state transition in the Agent OS. Before executing the final `git commit` and `gh pr create`, you MUST step back from the tactical implementation and assume the persona of an Architect.
 
-In your internal monologue (thought process), explicitly answer the following:
-1.  **Did I fall into a tactical loop?** Did I just apply multiple iterative bandages to a file without fixing the architectural root cause?
-2.  **Are there major architectural gaps?** If so, and they are out of scope for the current ticket, DO NOT attempt to scope-creep them into this PR. Instead, formally acknowledge them in the PR body and propose a **Follow-Up System Enhancement Ticket**.
-3.  **Is my Context complete?** Does the code perfectly satisfy the 'Anchor & Echo' Knowledge Base Enhancement Strategy? (No undocumented configs or missing `@summary` tags).
+**Scope Creep vs. Iteration:** You must explicitly "think outside the box" and challenge your initial tactical assumptions:
+- **Minor Gaps:** If your reflection uncovers minor misses (e.g., missed JSDoc, missing Anchor & Echo context, logical edge cases), you MUST fix them and add rapid successive commits to your local branch to polish the execution *before* opening the PR.
+- **Major Refactors:** If you realize a mathematically superior architecture exists (e.g., massive GC optimization) that is *out-of-scope* for the current ticket, DO NOT attempt to scope-creep and cram it into the active branch. Secure the "good enough" execution, and instead formally propose a **Follow-Up System Enhancement Ticket** conceptually linked to the original.
 
 *If and only if* you pass this reflection phase, proceed to the Git execution sequence.
 

--- a/.agent/skills/pull-request/references/pull-request-workflow.md
+++ b/.agent/skills/pull-request/references/pull-request-workflow.md
@@ -50,7 +50,9 @@ gh pr create --fill --base dev
 
 ## 5. Definition of Done & The Handoff State
 
-The agent's task is strictly considered "Done" once the PR is opened. A PR is a request for validation by an external entity (Human or QA Agent). **An agent MUST NOT autonomously run the `pr-review` skill against its own PR in headless mode.** Autonomous agents get the codebase to the best possible state *before* opening the PR.
+The agent's task is strictly considered "Done" once the PR is opened. A PR is a request for validation by an external entity (Human or QA Agent). **An agent MUST NOT autonomously run the `pr-review` skill against its own PR in headless mode.** 
+
+**Iterative Polish (Pre-PR):** Autonomous agents must act as their own harshest critic *before* the handoff. Get the codebase to the best possible state. If you identify minor gaps (missing JSDoc, logical edge cases) during your reflection, you MUST push follow-up polish commits to your branch *prior* to executing the final PR creation.
 
 You MUST follow this exact handoff protocol:
 

--- a/.agent/skills/pull-request/references/pull-request-workflow.md
+++ b/.agent/skills/pull-request/references/pull-request-workflow.md
@@ -48,19 +48,13 @@ gh pr create --fill --base dev
 ```
 *(The `--fill` flag automatically uses your commits to populate the PR details. If you need to add custom context, e.g., explicitly stating `Resolves #TICKET_ID` or dropping `Origin Session ID` telemetry, use the `manage_issue_comment` MCP tool to add a comment immediately after creation).*
 
-## 5. Post-PR Polish & The Handoff State
+## 5. Definition of Done & The Handoff State
 
-A Pull Request is a request for validation, not the finish line. You MUST execute a two-phased defense. You performed **Pre-PR Reflection** to control scope. Now, you must perform **Post-PR Reflection** to guarantee quality.
+The agent's task is strictly considered "Done" once the PR is opened. A PR is a request for validation by an external entity (Human or QA Agent). **An agent MUST NOT autonomously run the `pr-review` skill against its own PR in headless mode.** Autonomous agents get the codebase to the best possible state *before* opening the PR.
 
-1.  **Skill Chaining (MANDATORY):** Immediately after the PR is opened, you MUST invoke the `pr-review` skill against your own PR.
-2.  **Iterative Polish:** Act as your own harshest critic. If your review identifies minor gaps (missing JSDoc, logical edge cases), push follow-up commits to the branch to polish the execution.
-3.  **Human QA:** Once the PR passes your own critical review, you MUST halt. **DO NOT** execute `gh pr merge` yourself under any circumstances.
+You MUST follow this exact handoff protocol:
 
-### State Transition Trap (Final Step)
+1. **Autonomous Protocol (Headless):** Immediately after the PR is successfully opened, you MUST invoke the state transition trap to terminate the swarm intelligence loop:
+   `signal_state_transition(state: 'PR_OPENED', target: "[pr-number]")`
 
-Only after the PR is successfully opened AND you have completed the Post-PR autonomous review cycle, you MUST formally alert the Orchestrator.
-
-1.  Execute the following MCP tool:
-    `signal_state_transition(state: 'PR_READY_FOR_REVIEW', target: "[pr-number]")`
-
-This explicitly frees the current swarm intelligence instance to terminate or accept a new ticket from the `DreamService` queue.
+2. **Human-in-the-Loop Protocol (Frontier Models):** Once the PR is opened, you MUST halt and await human QA. **DO NOT** execute `gh pr merge` yourself. You may ask the human Commander: *"PR opened. Shall I execute the `pr-review` skill to assist with your evaluation?"* but you must not proceed without explicit consent.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -160,26 +160,14 @@ First, classify the user's request into one of two categories:
 
 **Note:** A conceptual discussion can become an actionable task. The moment the intent shifts from "what if..." to "let's do...", you must treat it as a new actionable request and apply the Ticket-First Gate.
 
-## 7. Git Protocol
+## 7. The Pull Request Mandate (Definition of Done)
 
-- **Ticket ID Required:** The commit subject line **MUST** end with `(#TICKET_ID)`.
-    - **Correct:** `feat: Add infinite canvas (#8392)`
-- **Standard:** Follow Conventional Commits.
+You are strictly **FORBIDDEN** from committing code or running `gh pr create` via raw bash commands based on generic workflow assumptions.
 
-## 8. Ticket Closure Protocol (Definition of Done)
+When you believe your codebase modifications are complete and ready for review, you **MUST** formally open a Pull Request. To do this, you are required to invoke the dedicated `pull-request` skill:
+- Read and adhere to the guidelines in `.agent/skills/pull-request/SKILL.md`
 
-You **MUST** perform these steps in order before marking a task as complete:
-
-1.  **Branching (MANDATORY):** You are strictly forbidden from committing or pushing directly to the `main` (release-only) or `dev` (default working) branches. You MUST checkout a new branch (e.g., `agent/9851-retrospective`).
-2.  **Commit & Push:** Commit your finalized changes to this branch and push the branch to the remote repository.
-3.  **Pull Request (MANDATORY):** Use `run_command` with `gh pr create --fill --base dev` to open a Pull Request targeting the `dev` branch. The PR body **MUST** include the keyword `Resolves #[Issue Number]` to guarantee automatic ticket closure upon merge.
-4.  **One PR per Ticket:** Enforce a strict 1-to-1 ratio between an Issue and a Pull Request. Do not bundle multiple unassociated issues into a single PR.
-    - **Epic Exception:** An Epic may have a single overarching PR that resolves all of its associated Sub-Issues.
-5.  **Assign:** Ensure the Pull Request and the underlying Ticket are assigned to the current user to capture credit.
-6.  **Handoff / Hard Stop (MANDATORY):** The agent's task is strictly considered "Done" once the PR is opened. You MUST halt and await human QA. **DO NOT** execute `gh pr merge` yourself under any circumstances.
-7.  **The Reflection Phase:** Before concluding the turn, ask the human Commander: "PR opened. Shall I execute the `pr-review` skill to perform a self-reflection log?" (Note: In fully autonomous "headless" mode, execute the skill automatically). See the `pr-review` skill for the rules on Iterative Polish vs. Follow-up Epics.
-8.  **Iterative PR Updates:** If requested to push new commits to an open PR that alter the scope or change the technical approach, you MUST post a new comment on the PR detailing the exact delta.
-9.  **Human Merge Rule:** (Note: When the Human Approver eventually merges the code, they will utilize a Squash Merge to preserve the Fat Ticket natively).
+This skill governs branch generation, conventional commit standards, the critical "Stepping Back" reflection phase, and the state handoff endpoint sequence. Follow it exactly.
 
 ## 9. Preventing Context Corruption (State Management)
 


### PR DESCRIPTION
### 🎯 Objective
Resolves #9957 - Scaffold `pull-request` Progressive Disclosure Skill.

This PR fundamentally optimizes the "Definition of Done" pipeline for the Neo.mjs Agent OS. We are officially dropping the verbose Git CLI operational strings from the core root `AGENTS.md` prompt, migrating them into a Just-In-Time loadable skill (`.agent/skills/pull-request/`). 

### 🏗️ Architectural Changes
1. **Context Bloat Reduction:** Removed `gh pr create` and branch checkout formatting arrays from `AGENTS.md`. Models will now naturally invoke the `pull-request` skill as their final stage trap.
2. **Headless Reflection Protocol:** Natively hardcoded the "Stepping Back" reflection protocol into `.agent/skills/pull-request/references/pull-request-workflow.md`. Autonomous models (e.g., local MLX networks) are now mathematically forced to introspect on tactical traps vs. architectural refactors *before* wrapping commits.
3. **State Trap Staging:** Documented the required sequence for executing `signal_state_transition` to formally drop the orchestration task lock (anticipating merging with #9951 logic).

### 🤖 A2A Context (Swarm Handoff)
- **Origin Session ID:** `ce92f035-b064-457e-be12-aad58dcffb53`
- Agents querying this ticket should note the structural reliance on the `create-skill` directory methodology. Progressive disclosure ensures `n_ctx` survival for frontier models maintaining 25-turn loops.
