### PR TITLE
feat: scaffold ticket-intake progressive disclosure skill for agent state validation (#9969)

### DIFF
--- a/.agent/skills/pull-request/references/pull-request-workflow.md
+++ b/.agent/skills/pull-request/references/pull-request-workflow.md
@@ -40,12 +40,12 @@ Your commit messages MUST follow Conventional Commits and MUST append the ticket
 
 ## 4. Pull Request Creation
 
-You MUST use the GitHub CLI to open a Pull Request targeting the `dev` branch.
+You MUST use the GitHub CLI to open a Pull Request targeting the `dev` branch. You are strictly forbidden from using the `--fill` flag, as it bypasses the generation of a comprehensive PR body.
 
 ```bash
-gh pr create --fill --base dev
+gh pr create --title "feat/fix/chore: Your Title (#TICKET_ID)" --body "Comprehensive markdown body explaining architectural impact, edge cases, and explicitly stating Resolves #TICKET_ID" --base dev
 ```
-*(The `--fill` flag automatically uses your commits to populate the PR details. If you need to add custom context, e.g., explicitly stating `Resolves #TICKET_ID` or dropping `Origin Session ID` telemetry, use the `manage_issue_comment` MCP tool to add a comment immediately after creation).*
+*(Passing the body directly ensures the PR contains the required context and aligns with the "Fat Ticket" protocol.)*
 
 ## 5. Definition of Done & The Handoff State
 

--- a/.agent/skills/ticket-intake/SKILL.md
+++ b/.agent/skills/ticket-intake/SKILL.md
@@ -1,0 +1,11 @@
+---
+name: ticket-intake
+description: Authoritative protocol defining the "Pre-Execution Reflection Gate". Mandates architectural validation, negative ROI calculation, and duplicate sweeps before an agent is permitted to begin working on a GitHub Issue.
+triggers: Use this skill immediately when assigned a new ticket, before checking out a branch or writing any codebase modifications.
+---
+
+# Ticket Intake Skill
+
+If you are an agent tasked with executing a ticket or issue, you MUST NOT begin executing Git branch commands or writing code.
+
+You MUST immediately use the `view_file` tool to read and strictly adhere to `/Users/Shared/github/neomjs/neo/.agent/skills/ticket-intake/references/ticket-intake-workflow.md` before proceeding. Or, if you already have the payload in context, proceed directly to its directives.

--- a/.agent/skills/ticket-intake/references/ticket-intake-workflow.md
+++ b/.agent/skills/ticket-intake/references/ticket-intake-workflow.md
@@ -1,0 +1,34 @@
+# Ticket Intake Workflow
+
+This document outlines the authoritative protocol for the **Pre-Execution Reflection Gate**. Because the Neo.mjs framework evolves rapidly, an assigned ticket may be stale, duplicate active Swarm efforts, or explicitly contradict modern architectural paradigms (e.g. V8-physics optimizations, Worker abstractions).
+
+If you blindly accept a ticket's premise, you risk injecting regressions into the Native Edge Graph.
+
+## 1. The Validation Sweep
+
+Before executing a `git checkout`, you MUST interrogate the codebase and Memory Core to establish the validity of the ticket's premise. 
+
+1. **Relevance Validation:** If the ticket involves core framework topology, use `ask_knowledge_base` to confirm if the requested feature/pattern is still architecturally valid or if it has been deprecated.
+2. **Duplication Check:** Use `grep_search` against the `resources/content/issues` and `resources/content/discussions` to ensure there isn't an overlapping active initiative. 
+
+## 2. ROI (Return on Investment) Calculation
+
+Evaluate the ticket based on effort vs. architectural payoff. A ticket can yield a **Negative ROI**.
+- **Negative ROI:** High effort, introduces legacy anti-patterns, duplicates active work, or forces severe regressions to satisfy outdated constraints.
+
+If your calculation results in a Negative ROI, you MUST reject the ticket.
+
+## 3. The Rejection Protocol (Handling Negative ROI)
+
+If you determine the ticket is stale or harmful, you MUST execute the Rejection Protocol instead of attempting to build it. 
+**DO NOT close the ticket.** It must be preserved so the Swarm can formally evaluate the paradox.
+
+### Autonomous Protocol (Headless)
+1.  **Label Application:** Use the MCP tool `manage_issue_labels (action: add)` to apply the label `status: needs-re-triage` to the GitHub Issue.
+2.  **Architectural Feedback:** Use the `manage_issue_comment` MCP tool to post a detailed critique on the PR. You MUST use the `[ARCH_ALIGNMENT]` markdown tag to explain *why* the ROI is negative and why the premise is architecturally flawed.
+3.  **Hard Cut:** Terminate execution and trigger `signal_state_transition(state: 'TICKET_REJECTED', target: "[issue-number]")`.
+
+### Human-in-the-Loop Protocol (Frontier Models)
+1. **Interrupt Workflow:** Stop all operational execution. Do NOT run Git commands.
+2. **Present Findings:** Drop your complete Architectural Evaluation (including the `[ARCH_ALIGNMENT]` block and Negative ROI metric) directly into the chat response for the human Commander.
+3. **Collaboration:** Wait for the Human to discuss whether the ticket can be salvaged (e.g., pivot the goal) or if it commands formal rejection via adding the `status: needs-re-triage` label.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -154,7 +154,9 @@ First, classify the user's request into one of two categories:
     - **Action:** Apply the **Ticket-First Gate** (Section 3).
 
 **Meta Gate: Deduplication & Linking**
-- **Gate 0:** Before creating *any* Issue or Discussion on GitHub, you **MUST** verify an equivalent item doesn't already exist using the `grep_search` tool locally against the `resources/content/issues/` and `resources/content/discussions/` directories. This prevents polluting the remote tracker. 
+- **Gate 0 (Generation):** Before creating *any* Issue or Discussion on GitHub, you **MUST** verify an equivalent item doesn't already exist using the `grep_search` tool locally against the `resources/content/issues/` and `resources/content/discussions/` directories. This prevents polluting the remote tracker. 
+- **Pre-Execution Reflection (Ticket Intake):** If you are picking up or assigned an *existing* ticket, you MUST run the `ticket-intake` skill immediately. You are forbidden from jumping blindly into `git checkout` without first validating the architectural ROI and confirming the ticket represents valid framework philosophy.
+  - Read: `.agent/skills/ticket-intake/SKILL.md`
 - **Graph Linking:** When creating Sub-Issues for an Epic, you **MUST** natively link them using the `update_issue_relationship` MCP tool. Do not rely on inline Markdown checkboxes (`- [ ]`) in the Epic body as your tracking mechanism.
 - **State Topologies:** Before writing code for complex Reactivity or DOM-reconciliation tasks (like Multi-Body or deeply nested updates), you **MUST** draft a State Flow Diagram (Architectural Empathy). Do not rely on "tunnel vision" coding for multi-component data synchronization.
 


### PR DESCRIPTION
### 🎯 Objective
Scaffold the `ticket-intake` Progressive Disclosure skill to explicitly govern how agents ingest and validate existing GitHub tickets before beginning execution.
    
### 🧠 Architectural Impact
Our PR generation pipeline is now secured against tactical loops (#9968), but our intake pipeline remains vulnerable to "Blind Execution". Since Neo.mjs evolves at an extreme pace, historical or externally submitted tickets easily go stale, duplicate existing efforts, or contradict modern architectural paradigms. 

If an autonomous swarm agent blindly accepts a ticket's premise, it will write regressions. We need a mandatory **Pre-Execution Reflection Gate**.

### 📋 Changes Included
1. **Scaffolded Skill:** Created `.agent/skills/ticket-intake/SKILL.md` as a router.
2. **Authoritative Payload:** Wrote `.agent/skills/ticket-intake/references/ticket-intake-workflow.md` outlining the "Stop & Think" relevance validation, the *Negative ROI* execution protocol, and the explicit `needs-re-triage` labeling sequence to formally abort structurally invalid operations.
3. **Core Prompt Hardening:** Replaced Section 6 (Meta Gate: Deduplication) in `AGENTS.md` with a clean routing instruction triggering the new skill.
4. **Pull Request Protocol Update:** Fixed the `pull-request` skill to forbid `--fill` usage during PR creation, mandating agents provide a comprehensive markdown string body to enforce 'Fat Ticket' compliance.

Resolves #9969