### PR TITLE
feat: Implement needs-re-triage negative ROI downgrade in DreamService (#9971)

### DIFF
--- a/ai/daemons/DreamService.mjs
+++ b/ai/daemons/DreamService.mjs
@@ -1186,10 +1186,17 @@ ${topContent}
                 // Lower distance = Higher significance. (Add 0.1 to avoid div by 0 and curb massive asymptotes)
                 const semanticScore = 1.0 / (semantic_distance + 0.1);
 
-                const priority = (semanticScore * SEMANTIC_WEIGHT) + (struct_score * STRUCTURAL_WEIGHT);
-
                 let nodeData = null;
                 try { nodeData = JSON.parse(row.data); } catch (e) { }
+
+                let priority = (semanticScore * SEMANTIC_WEIGHT) + (struct_score * STRUCTURAL_WEIGHT);
+
+                // Apply Negative ROI Protocol for automatically rejected Swarm tickets (#9971)
+                const labels = nodeData?.properties?.labels || [];
+                if (labels.includes('needs-re-triage')) {
+                    priority -= 10000;
+                    logger.debug(`[DreamService] Applied massive negative weight penalty to rejected node: ${issueId}`);
+                }
 
                 scoredNodes.push({
                     node: nodeData || { id: issueId },

--- a/test/playwright/unit/ai/daemons/DreamService.spec.mjs
+++ b/test/playwright/unit/ai/daemons/DreamService.spec.mjs
@@ -285,8 +285,8 @@ test.describe('Neo.ai.mcp.server.memory-core.services.DreamService', () => {
         StorageRouter.getGraphCollection = async () => {
             return {
                 query: async () => ({
-                    ids: [['epic-1', 'task-blocked', 'blocker', 'weak-task']],
-                    distances: [[0.1, 0.2, 0.9, 0.8]]
+                    ids: [['epic-1', 'task-blocked', 'blocker', 'weak-task', 'rejected-task']],
+                    distances: [[0.1, 0.2, 0.9, 0.8, 0.05]]
                 }),
                 get: async () => ({ ids: [], metadatas: [] }),
                 upsert: async () => {}
@@ -302,7 +302,8 @@ test.describe('Neo.ai.mcp.server.memory-core.services.DreamService', () => {
                         { id: 'epic-1', data: JSON.stringify({ id: 'epic-1', name: 'Epic Hero', properties: { state: 'OPEN'} }), struct_score: 5.0 },
                         { id: 'task-blocked', data: JSON.stringify({ id: 'task-blocked', name: 'Blocked Task', properties: { state: 'OPEN'} }), struct_score: 10.0 },
                         { id: 'blocker', data: JSON.stringify({ id: 'blocker', name: 'Blocker Bug', properties: { state: 'OPEN'} }), struct_score: 1.0 },
-                        { id: 'weak-task', data: JSON.stringify({ id: 'weak-task', name: 'Weak Task', properties: { state: 'OPEN'} }), struct_score: 0.1 }
+                        { id: 'weak-task', data: JSON.stringify({ id: 'weak-task', name: 'Weak Task', properties: { state: 'OPEN'} }), struct_score: 0.1 },
+                        { id: 'rejected-task', data: JSON.stringify({ id: 'rejected-task', name: 'Massive Stale Feature', properties: { state: 'OPEN', labels: ['needs-re-triage']} }), struct_score: 1000.0 }
                     ],
                     get: () => null,
                     run: () => {}
@@ -320,7 +321,8 @@ test.describe('Neo.ai.mcp.server.memory-core.services.DreamService', () => {
              { id: 'epic-1', properties: { state: 'OPEN' } },
              { id: 'task-blocked', properties: { state: 'OPEN' } },
              { id: 'blocker', properties: { state: 'OPEN' } },
-             { id: 'weak-task', properties: { state: 'OPEN' } }
+             { id: 'weak-task', properties: { state: 'OPEN' } },
+             { id: 'rejected-task', properties: { state: 'OPEN', labels: ['needs-re-triage'] } }
         ];
 
         GraphService.db.edges.getByIndex = (idx, val) => {
@@ -356,6 +358,7 @@ test.describe('Neo.ai.mcp.server.memory-core.services.DreamService', () => {
         expect(finalContent).toContain('Epic Hero');
         expect(finalContent).toContain('Weak Task'); 
         expect(finalContent).not.toContain('Blocked Task'); // REJECTED topologically by GraphService
+        expect(finalContent).not.toContain('Massive Stale Feature'); // REJECTED mathematically by Negative ROI penalty
         expect(finalContent).toContain('Math synthesis works natively.');
         expect(finalContent.indexOf('- **[Codebase Gap]**')).toBeLessThan(finalContent.indexOf('## Computed Golden Path'));
         expect(finalContent).not.toContain('Old Path');


### PR DESCRIPTION
### Architecture Modification
This PR intercepts the DreamService mathematical extraction engine. It natively parses the SQLite topological JSON object to verify if the `needs-re-triage` tag is applied to a task. If present, it executes a raw integer vector penalty of `-10000` on the result, permanently isolating the ticket from the Golden Path generation system. 

#### Testing
Included new Playwright mock configurations explicitly simulating a `1000.0` node structural weight with the tag applied. 

Resolves #9971.