### PR TITLE
fix: harden SessionService summarization payload (#9973)

### DIFF
--- a/ai/mcp/server/memory-core/openapi.yaml
+++ b/ai/mcp/server/memory-core/openapi.yaml
@@ -928,7 +928,7 @@ components:
           example: 5
         toolsUsed:
           type: array
-          description: "Descriptions or array of tools used."
+          description: "A list of tool names invoked during this turn. IMPORTANT: Do NOT include tool arguments, JSON payloads, or file contents. This must only be a tiny array of names (e.g., ['view_file', 'replace']) to prevent prompt bloat."
           items:
             type: string
           example: ["view_file", "replace"]

--- a/ai/mcp/server/memory-core/services/SessionService.mjs
+++ b/ai/mcp/server/memory-core/services/SessionService.mjs
@@ -446,13 +446,26 @@ class SessionService extends Base {
                         const parsedTools = JSON.parse(m.toolsUsed);
                         if (Array.isArray(parsedTools)) {
                             parsedTools.forEach(t => {
-                                if (t) allToolsUsed.add(typeof t === 'string' ? t : (t.name || t.toolAction || JSON.stringify(t)));
+                                if (t) {
+                                    if (typeof t === 'string') {
+                                        try {
+                                            const inner = JSON.parse(t);
+                                            const identifier = inner.name || inner.toolAction || inner.toolSummary || 'unknown_tool';
+                                            allToolsUsed.add(String(identifier).substring(0, 50));
+                                        } catch (e) {
+                                            allToolsUsed.add(t.substring(0, 50));
+                                        }
+                                    } else {
+                                        const identifier = t.name || t.toolAction || t.toolSummary || 'unknown_tool';
+                                        allToolsUsed.add(String(identifier).substring(0, 50));
+                                    }
+                                }
                             });
                         } else {
-                            allToolsUsed.add(m.toolsUsed);
+                            allToolsUsed.add(String(parsedTools).substring(0, 50));
                         }
                     } catch (e) {
-                        allToolsUsed.add(m.toolsUsed);
+                        allToolsUsed.add(String(m.toolsUsed).substring(0, 50));
                     }
                 }
             });

--- a/test/playwright/unit/ai/mcp/server/memory-core/services/SessionSummarization.spec.mjs
+++ b/test/playwright/unit/ai/mcp/server/memory-core/services/SessionSummarization.spec.mjs
@@ -292,4 +292,59 @@ test.describe('Memory Core Offline Summarization', () => {
         expect(finalPrompt.includes('[COMPRESSED SESSION SUB-SUMMARIES]')).toBe(true);
         expect(finalPrompt.length).toBeLessThan(12000); 
     });
+
+    test('SessionService limits toolsUsed stringification to prevent prompt explosion', async () => {
+        if (!SDK.Memory_LifecycleService._initPromise) {
+            await SDK.Memory_LifecycleService.initAsync();
+        } else {
+            await SDK.Memory_LifecycleService.ready();
+        }
+        await SDK.Memory_SessionService.ready();
+
+        const dummySessionId = crypto.randomUUID();
+        await SDK.Memory_ChromaManager.ready();
+
+        const massiveToolConfig = new Array(50000).fill('A').join('');
+        const toolsUsed = [JSON.stringify({
+            name: undefined,
+            toolAction: undefined,
+            content: massiveToolConfig
+        })];
+
+        await SDK.Memory_Service.addMemory({
+            prompt   : "Massive tools",
+            thought  : "Thinking...",
+            response : "Done",
+            agent    : "developer",
+            model    : "gemini-3.1-pro",
+            toolsUsed: toolsUsed,
+            sessionId: dummySessionId
+        });
+
+        const originalGenerateContent = SDK.Memory_SessionService.model ? SDK.Memory_SessionService.model.generateContent : null;
+        let capturedPrompts = [];
+        
+        SDK.Memory_SessionService.model = {
+            generateContent: async (prompt) => {
+                capturedPrompts.push(prompt);
+                return {
+                    response: {
+                        text: () => JSON.stringify({
+                            title: "Massive Session Tools", summary: "Done"
+                        })
+                    }
+                };
+            }
+        };
+
+        await SDK.Memory_SessionService.summarizeSession(dummySessionId);
+        
+        if (originalGenerateContent) {
+            SDK.Memory_SessionService.model.generateContent = originalGenerateContent;
+        }
+
+        const finalPrompt = capturedPrompts[capturedPrompts.length - 1];
+        // Ensure final prompt is kept reasonably sized despite huge tools logging JSON
+        expect(finalPrompt.length).toBeLessThan(15000);
+    });
 });


### PR DESCRIPTION
### Resolution for #9973

**Architectural Fix:**
- Refactored `SessionService.mjs` to aggressively parse and truncate `toolsUsed` configurations. This prevents autonomous LLMs from accidentally injecting massive multi-kilobyte script mutations directly into the summarization prompt.
- Added 50K-character payload bounds tests in `SessionSummarization.spec.mjs`.
- Updated `openapi.yaml` schema for `add_memory` to explicitly forbid agents from serializing JSON bodies into the logging endpoints.

Resolves #9973