### PR TITLE
fix: MCP Infrastructure Stability — Stdout Pollution, Crash Recovery, & Triage Mandate (#9977)

### DIFF
--- a/AGENTS_STARTUP.md
+++ b/AGENTS_STARTUP.md
@@ -67,7 +67,7 @@ Before executing any commands, you MUST orient yourself to the repository's buil
             - **Ask First:** If a summary seems relevant but you are unsure of the current session's goal, ask the user: *"I see a relevant past session about [Topic]. Should I load its full context?"*
             - **Autonomy:** You are authorized to proactively load a session if it contains critical technical details (e.g., a failed attempt at the same task) that will prevent you from making mistakes.
     - **Your First Turn:** Your only responsibility is to save your work for the current session. The initialization process itself is your first turn. **Before** you send your first response to the user (e.g., "I am ready"), you **MUST** call `add_memory` to save this initialization turn. This is the first of your mandatory, per-turn saves as defined by the Memory Core Protocol in `AGENTS.md`.
-- **If the healthcheck fails:** The Memory Core is not active. Proceed with the session without using memory tools. Your work will not be persisted for future analysis.
+- **If the healthcheck fails (The Infrastructure Triage Mandate):** Do NOT proceed with the session. A failed healthcheck indicates a sick core ecosystem. You MUST prioritize diagnosing and self-healing the failed infrastructure (e.g., inspecting Node.js process logs, debugging `stdout` pollution, or requesting human assistance) before attempting any actionable work or roadmap tasks. Proceeding without active infrastructure is strictly forbidden.
 
 **Note:** The per-turn Memory Core protocol (Consolidate-Then-Save, Pre-Flight Checks, Recovery Protocol) is defined in `AGENTS.md`, which is automatically loaded into your context via `settings.json`.
 

--- a/ai/mcp/server/memory-core/services/SessionService.mjs
+++ b/ai/mcp/server/memory-core/services/SessionService.mjs
@@ -387,7 +387,7 @@ class SessionService extends Base {
         const totalRawLength = memories.documents.reduce((acc, doc) => acc + doc.length, 0) + (memories.documents.length * 7);
         
         if (totalRawLength > MAX_CONTENT_LENGTH) {
-            console.log(`[SessionService] Session ${sessionId} exceeds ${MAX_CONTENT_LENGTH} chars. Initiating Map-Reduce summarization pipeline.`);
+            logger.info(`[SessionService] Session ${sessionId} exceeds ${MAX_CONTENT_LENGTH} chars. Initiating Map-Reduce summarization pipeline.`);
             const chunks = [];
             let currentChunk = '';
             
@@ -404,7 +404,7 @@ class SessionService extends Base {
 
             const subSummaries = [];
             for (let i = 0; i < chunks.length; i++) {
-                console.log(`[SessionService] Generating Sub-Summary ${i + 1}/${chunks.length} for session ${sessionId}`);
+                logger.info(`[SessionService] Generating Sub-Summary ${i + 1}/${chunks.length} for session ${sessionId}`);
                 const chunkPrompt = `Analyze this sequential segment of a longer AI agent session. Identify the main problem, tool execution paths taken, and any code modified. Keep it concise.\n\n${chunks[i]}`;
                 // Avoid using explicit response_format JSON here to allow plain-text summaries from subsets
                 const result = await this.model.generateContent(chunkPrompt);

--- a/ai/mcp/server/neural-link/services/ConnectionService.mjs
+++ b/ai/mcp/server/neural-link/services/ConnectionService.mjs
@@ -234,6 +234,16 @@ class ConnectionService extends Base {
     }
 
     /**
+     * @returns {String|null}
+     */
+    getDefaultSessionId() {
+        if (this.sessionData.size > 0) {
+            return Array.from(this.sessionData.keys()).pop();
+        }
+        return null;
+    }
+
+    /**
      * Returns the current status.
      * @returns {Object}
      */

--- a/ai/mcp/server/neural-link/services/RecorderService.mjs
+++ b/ai/mcp/server/neural-link/services/RecorderService.mjs
@@ -3,6 +3,7 @@ import fs     from 'fs-extra';
 import path   from 'path';
 import Base   from '../../../../../src/core/Base.mjs';
 import config from '../config.mjs';
+import logger from '../logger.mjs';
 
 const MS_PER_DAY = 24 * 60 * 60 * 1000;
 
@@ -42,7 +43,7 @@ class RecorderService extends Base {
         try {
             const dbPath = config.memoryCoreDbPath;
             if (!dbPath) {
-                console.warn('[RecorderService] memoryCoreDbPath not configured. Disabling logging.');
+                logger.warn('[RecorderService] memoryCoreDbPath not configured. Disabling logging.');
                 return;
             }
             
@@ -73,9 +74,9 @@ class RecorderService extends Base {
                 CREATE INDEX IF NOT EXISTS idx_nl_action_log_timestamp ON nl_action_log(timestamp);
             `);
             
-            console.log('[RecorderService] Connected to Memory Core nl_action_log.');
+            logger.info('[RecorderService] Connected to Memory Core nl_action_log.');
         } catch (err) {
-            console.warn('[RecorderService] Failed to initialize SQLite connection:', err.message);
+            logger.warn('[RecorderService] Failed to initialize SQLite connection:', err.message);
         }
     }
 
@@ -112,7 +113,7 @@ class RecorderService extends Base {
             );
         } catch (err) {
             // Swallowing exceptions so it never disrupts the main logic
-            console.error('[RecorderService] Failed to append log entry:', err);
+            logger.error('[RecorderService] Failed to append log entry:', err);
         }
     }
 
@@ -141,7 +142,7 @@ class RecorderService extends Base {
             
             return this.db.prepare(sql).all(...args);
         } catch (err) {
-            console.error('[RecorderService] Failed to query sequences:', err);
+            logger.error('[RecorderService] Failed to query sequences:', err);
             return [];
         }
     }
@@ -158,7 +159,7 @@ class RecorderService extends Base {
             const dropStmt = this.db.prepare(`DELETE FROM nl_action_log WHERE timestamp < ?`);
             dropStmt.run(cutoff);
         } catch (err) {
-            console.error('[RecorderService] Failed to prune logs:', err);
+            logger.error('[RecorderService] Failed to prune logs:', err);
         }
     }
 }


### PR DESCRIPTION
Resolves #9977. 

## Summary
This PR formalizes critical infrastructure stability patches discovered during a localized breakdown of the Memory Core and Neural Link MCP servers. The standard JSON-RPC `stdio` transport was corrupting due to raw console output, and missing class methods were causing hard crashes during tool dispatch.

## Architectural Changes

### 1. The Infrastructure Triage Mandate (`AGENTS_STARTUP.md`)
Previously, agents were instructed to ignore `healthcheck` failures and proceed on a degraded Golden Path. This has been explicitly reversed. If core ecosystem servers fail, agents are now strictly mandated to immediately pivot into diagnostic and self-healing workflows. Executing roadmap tasks with a sick framework ecosystem is now forbidden.

### 2. Eliminating `stdout` JSON-RPC Corruption
The MCP standard transport relies on pure JSON over `stdout`.
- **`Memory Core / SessionService`**: Replaced `console.log` with `logger.info` inside the asynchronous Map-Reduce summarization pipeline.
- **`Neural Link / RecorderService`**: Imported the centralized `logger.mjs` and refactored all `console.error` and `console.warn` statements to route through the standard logger.

### 3. Neural Link Runtime Crash Recovery
- **`ConnectionService.mjs`**: Implemented the missing `getDefaultSessionId()` method. The `toolService.mjs` dispatch layer implicitly expected this method to exist to support auto-targeting. Its absence caused soft crashes during any Neural Link tool execution where `sessionId` was omitted.