### PR TITLE
feat: Scaffold Autonomous Agent State Signaling (#9951)

### DIFF
--- a/ai/mcp/server/github-workflow/openapi.yaml
+++ b/ai/mcp/server/github-workflow/openapi.yaml
@@ -950,6 +950,52 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
 
+  /system/state/transition:
+    post:
+      summary: Signal State Transition
+      operationId: signal_state_transition
+      x-pass-as-object: true
+      x-annotations:
+        readOnlyHint: false
+      description: |
+        Provides a native state-trap for Headless Orchestration to gracefully capture execution states or signal logic failures.
+        
+        Support `state: 'PR_OPENED'` to trigger autonomous turn-completion and shutdown sequences.
+        Support `state: 'BLOCKED'` and `state: 'HANDOFF'` for derailed agents, enabling them to pass a localized artifact mapping the problem back to the Orchestrator, which natively applies the `agent-task:blocked` label on GitHub.
+      tags: [Issues]
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - state
+              properties:
+                state:
+                  type: string
+                  enum: [PR_OPENED, BLOCKED, HANDOFF]
+                  description: The execution state to signal.
+                target_id:
+                  type: integer
+                  description: The target Issue or PR number associated with this state.
+                artifact_path:
+                  type: string
+                  description: Optional file path to a localized artifact mapping the problem.
+      responses:
+        '200':
+          description: State transition signal received and processed successfully.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SignalStateTransitionResponse'
+        '500':
+          description: Internal server error.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
 components:
   schemas:
     HealthCheckResponse:
@@ -1241,6 +1287,18 @@ components:
           type: string
           format: uri
           description: The URL of the newly created issue.
+
+    SignalStateTransitionResponse:
+      type: object
+      properties:
+        success:
+          type: boolean
+          description: Indicates whether the state transition was recorded successfully.
+          example: true
+        message:
+          type: string
+          description: A human-readable message describing the outcome.
+          example: "State PR_OPENED processed. Orchestrator turn completed."
 
     UpdateIssueRelationshipResponse:
       type: object

--- a/ai/mcp/server/github-workflow/services/AgentStateService.mjs
+++ b/ai/mcp/server/github-workflow/services/AgentStateService.mjs
@@ -1,0 +1,81 @@
+import Base         from '../../../../../src/core/Base.mjs';
+import IssueService from './IssueService.mjs';
+import logger       from '../logger.mjs';
+
+/**
+ * @summary Service for handling autonomous subagent state transitions.
+ *
+ * This service provides a deterministic state-trap mechanism for headless orchestrators
+ * to signal execution states, allowing for robust lifecycle management and self-healing.
+ *
+ * @class Neo.ai.mcp.server.github-workflow.services.AgentStateService
+ * @extends Neo.core.Base
+ * @singleton
+ */
+class AgentStateService extends Base {
+    static config = {
+        /**
+         * @member {String} className='Neo.ai.mcp.server.github-workflow.services.AgentStateService'
+         * @protected
+         */
+        className: 'Neo.ai.mcp.server.github-workflow.services.AgentStateService',
+        /**
+         * @member {Boolean} singleton=true
+         * @protected
+         */
+        singleton: true
+    }
+
+    /**
+     * Handles state transition signals from autonomous agents.
+     * @param {Object} options                The options object
+     * @param {String} options.state          The execution state to signal (PR_OPENED, BLOCKED, HANDOFF)
+     * @param {Number} [options.target_id]    The target Issue or PR number associated with this state
+     * @param {String} [options.artifact_path] Optional file path to a localized artifact mapping the problem
+     * @returns {Promise<Object>} A promise resolving to the transition outcome.
+     */
+    async signalStateTransition({state, target_id, artifact_path}) {
+        const validStates = ['PR_OPENED', 'BLOCKED', 'HANDOFF'];
+        
+        if (!validStates.includes(state)) {
+            return {
+                error: 'Invalid state',
+                message: `State must be one of: ${validStates.join(', ')}`,
+                code: 'INVALID_STATE'
+            };
+        }
+
+        logger.info(`Received state transition signal: ${state} (Target ID: ${target_id || 'None'})`);
+
+        if (state === 'BLOCKED' && target_id) {
+            try {
+                logger.info(`Agent reported BLOCKED state. Attempting to add 'agent-task:blocked' label to issue #${target_id}`);
+                const result = await IssueService.manageIssueLabels({
+                    issue_number: target_id,
+                    labels: ['agent-task:blocked'],
+                    action: 'add'
+                });
+
+                if (result.error) {
+                    logger.warn(`Failed to apply blocked label to issue #${target_id}: ${result.message}`);
+                } else {
+                    logger.info(`Successfully labeled issue #${target_id} as blocked.`);
+                }
+            } catch (error) {
+                logger.error(`Exception while applying blocked label to issue #${target_id}:`, error);
+            }
+        }
+
+        let message = `State ${state} processed. Orchestrator turn completed.`;
+        if (artifact_path) {
+            message += ` Referenced artifact: ${artifact_path}`;
+        }
+
+        return {
+            success: true,
+            message
+        };
+    }
+}
+
+export default Neo.setupClass(AgentStateService);

--- a/ai/mcp/server/github-workflow/services/toolService.mjs
+++ b/ai/mcp/server/github-workflow/services/toolService.mjs
@@ -1,5 +1,6 @@
 import path               from 'path';
 import {fileURLToPath}    from 'url';
+import AgentStateService  from './AgentStateService.mjs';
 import HealthService      from './HealthService.mjs';
 import IssueService       from './IssueService.mjs';
 import DiscussionService  from './DiscussionService.mjs';
@@ -30,6 +31,7 @@ const serviceMapping = {
     manage_issue_assignees   : IssueService      .manageIssueAssignees   .bind(IssueService),
     manage_issue_comment     : IssueService      .manageIssueComment     .bind(IssueService),
     manage_issue_labels      : IssueService      .manageIssueLabels      .bind(IssueService),
+    signal_state_transition  : AgentStateService .signalStateTransition  .bind(AgentStateService),
     sync_all                 : SyncService       .runFullSync            .bind(SyncService),
     update_issue_relationship: IssueService      .updateIssueRelationship.bind(IssueService)
 };


### PR DESCRIPTION
## Overview
This pull request implements the autonomous agent state signaling mechanism (`signal_state_transition` endpoint) to resolve #9951.

## Architectural Changes

- **`openapi.yaml`:**
  - Scaffolded the `/system/state/transition` POST endpoint to act as a deterministic state-trap for Headless Orchestration.
  - Defined boundaries for Enum execution states: `PR_OPENED`, `HANDOFF`, and `BLOCKED`.
- **`AgentStateService.mjs`:**
  - Implemented the service to trap state transitions.
  - If `state: 'BLOCKED'` is signaled alongside a `target_id`, the system proxy calls `IssueService.manageIssueLabels` to autonomously append the `agent-task:blocked` tag.
- **`toolService.mjs`:**
  - Wired up `signal_state_transition` to expose it generically across MCP clients.

## Resolves
Resolves #9951
