### PR TITLE
perf(ai): Natively bypass Map-Reduce chunking to eliminate local inference bottlenecks

### DIFF
--- a/ai/daemons/DreamService.mjs
+++ b/ai/daemons/DreamService.mjs
@@ -168,15 +168,9 @@ class DreamService extends Base {
                             include: ['documents']
                         });
                         if (rawMemories && rawMemories.documents && rawMemories.documents.length > 0) {
-                            const sliced = rawMemories.documents.slice(-3); // take only final 3 concluding actions
-                            let rawStr = sliced.join('\n\n---\n\n');
-                            
-                            // Natively enforce strict token floor ensuring LLM has minimum 2500 tokens free to generate complex output maps
-                            const maxLen = 4000;
-                            if (rawStr.length > maxLen) {
-                                rawStr = rawStr.slice(-maxLen);
-                            }
-                            rawEpisodicMemory = rawStr;
+                            // Send the full raw memory to the LLM. Lossless context tracking is required.
+                            // If local APIs crash, it is a configuration issue with n_ctx, not a client logic error.
+                            rawEpisodicMemory = rawMemories.documents.join('\n\n---\n\n');
                         }
                     }
                 } catch (e) {

--- a/ai/mcp/server/memory-core/services/SessionService.mjs
+++ b/ai/mcp/server/memory-core/services/SessionService.mjs
@@ -386,46 +386,11 @@ class SessionService extends Base {
 
         if (memories.ids.length === 0) return null;
 
-        const MAX_CONTENT_LENGTH = 10000;
-        let aggregatedContent;
-
-        // Implement Map-Reduce Chunking for long sessions (Fixes #9965 & #9921 lossless)
-        const totalRawLength = memories.documents.reduce((acc, doc) => acc + doc.length, 0) + (memories.documents.length * 7);
-        
-        if (totalRawLength > MAX_CONTENT_LENGTH) {
-            logger.info(`[SessionService] Session ${sessionId} exceeds ${MAX_CONTENT_LENGTH} chars. Initiating Map-Reduce summarization pipeline.`);
-            const chunks = [];
-            let currentChunk = '';
-            
-            for (let i = 0; i < memories.documents.length; i++) {
-                const doc = memories.documents[i];
-                if (currentChunk.length + doc.length > MAX_CONTENT_LENGTH && currentChunk.length > 0) {
-                    chunks.push(currentChunk);
-                    currentChunk = doc;
-                } else {
-                    currentChunk += (currentChunk.length > 0 ? '\n\n---\n\n' : '') + doc;
-                }
-            }
-            if (currentChunk.length > 0) chunks.push(currentChunk);
-
-            const subSummaries = [];
-            for (let i = 0; i < chunks.length; i++) {
-                logger.info(`[SessionService] Generating Sub-Summary ${i + 1}/${chunks.length} for session ${sessionId}`);
-                const chunkPrompt = `Analyze this sequential segment of a longer AI agent session. Identify the main problem, tool execution paths taken, and any code modified. Keep it concise.\n\n${chunks[i]}`;
-                // Avoid using explicit response_format JSON here to allow plain-text summaries from subsets
-                const result = await this.model.generateContent(chunkPrompt);
-                subSummaries.push(result.response.text());
-            }
-
-            aggregatedContent = "[COMPRESSED SESSION SUB-SUMMARIES]\n\n" + subSummaries.map((s, i) => `--- Chunk ${i + 1} ---\n${s}`).join('\n\n');
-            
-            // Safety measure in case subSummaries aggregate still overflows heavily
-            if (aggregatedContent.length > MAX_CONTENT_LENGTH) {
-                aggregatedContent = '[TRUNCATED_COMPRESSED_HISTORY]...\n\n' + aggregatedContent.slice(-MAX_CONTENT_LENGTH);
-            }
-        } else {
-            aggregatedContent = memories.documents.join('\n\n---\n\n');
-        }
+        // Natively bypass arbitrary Context Windows or chunking loops.
+        // We enforce strict Lossless extraction for local performance consistency.
+        // NOTE: Large sessions natively require the backing daemon (MLX/OpenAiCompatible) to have 
+        // sufficient `n_ctx` capabilities (128k+).
+        const aggregatedContent = memories.documents.join('\n\n---\n\n');
 
         let lastActivity = Date.now();
         let firstActivity = lastActivity;

--- a/test/playwright/unit/ai/mcp/server/memory-core/services/SessionSummarization.spec.mjs
+++ b/test/playwright/unit/ai/mcp/server/memory-core/services/SessionSummarization.spec.mjs
@@ -220,7 +220,7 @@ test.describe('Memory Core Offline Summarization', () => {
         expect(metadata.models.includes('gemma4')).toBe(true);
     });
 
-    test('SessionService correctly map-reduces massive session histories to fix #9965', async () => {
+    test('SessionService correctly processes massive session histories natively without map-reduce', async () => {
         if (!SDK.Memory_LifecycleService._initPromise) {
             await SDK.Memory_LifecycleService.initAsync();
         } else {
@@ -251,13 +251,6 @@ test.describe('Memory Core Offline Summarization', () => {
             generateContent: async (prompt) => {
                 capturedPrompts.push(prompt);
                 
-                // Emulate Sub-Summary string if it is a map chunk
-                if (prompt.includes('Analyze this sequential segment')) {
-                    return {
-                        response: { text: () => "Mock chunk summary." }
-                    };
-                }
-
                 return {
                     response: {
                         text: () => JSON.stringify({
@@ -270,7 +263,7 @@ test.describe('Memory Core Offline Summarization', () => {
                             quality            : 5,
                             productivity       : 5,
                             topics             : ["testing"],
-                            decisionList       : ["implemented map reduce"]
+                            decisionList       : ["bypassed map reduce natively"]
                         })
                     }
                 };
@@ -284,13 +277,12 @@ test.describe('Memory Core Offline Summarization', () => {
             SDK.Memory_SessionService.model.generateContent = originalGenerateContent;
         }
 
-        // Verify map-reduce logic occurred due to large payload
-        expect(capturedPrompts.length).toBeGreaterThan(1);
+        // Verify ONLY ONE generation payload happened
+        expect(capturedPrompts.length).toBe(1);
         
-        // The last prompt should be the final compression that includes our compressed arrays
-        const finalPrompt = capturedPrompts[capturedPrompts.length - 1];
-        expect(finalPrompt.includes('[COMPRESSED SESSION SUB-SUMMARIES]')).toBe(true);
-        expect(finalPrompt.length).toBeLessThan(12000); 
+        // Output should be massive implicitly mapped correctly
+        const finalPrompt = capturedPrompts[0];
+        expect(finalPrompt.length).toBeGreaterThan(20000); 
     });
 
     test('SessionService limits toolsUsed stringification to prevent prompt explosion', async () => {

--- a/test/playwright/unit/ai/mcp/server/memory-core/services/SessionSummarization.spec.mjs
+++ b/test/playwright/unit/ai/mcp/server/memory-core/services/SessionSummarization.spec.mjs
@@ -68,8 +68,9 @@ test.describe('Memory Core Offline Summarization', () => {
         SDK.Memory_Config.data.modelProvider         = 'openAiCompatible';
         SDK.Memory_Config.data.neoEmbeddingProvider  = 'openAiCompatible';
         SDK.Memory_Config.data.chromaEmbeddingProvider = 'openAiCompatible';
-        SDK.Memory_Config.data.openAiCompatible.model          = 'gemma4:31b';
-        SDK.Memory_Config.data.openAiCompatible.embeddingModel = 'qwen3-embedding';
+        SDK.Memory_Config.data.openAiCompatible.host           = 'http://127.0.0.1:1234';
+        SDK.Memory_Config.data.openAiCompatible.model          = 'gemma-4-31b-it';
+        SDK.Memory_Config.data.openAiCompatible.embeddingModel = 'text-embedding-qwen3-embedding-8b';
         SDK.Memory_Config.data.autoSummarize         = false;
 
         // Adjust batch limit to speed up test execution
@@ -84,7 +85,7 @@ test.describe('Memory Core Offline Summarization', () => {
             const res  = await fetch(`${host}/v1/models`);
             if (res.ok) {
                 const data      = await res.json();
-                const hasGemma4 = data.data?.some(m => m.id.startsWith('gemma4'));
+                const hasGemma4 = data.data?.some(m => m.id.includes('gemma-4'));
                 if (hasGemma4) {
                     localModelActive = true;
                 }
@@ -165,6 +166,14 @@ test.describe('Memory Core Offline Summarization', () => {
             agent   : "developer",
             model   : "gemini-3.1-pro"
         }];
+        const hugeString = new Array(15000).fill('A').join('');
+        turns.push({
+            prompt  : "Can a massive block of text be evaluated without crashing?",
+            thought : "We need to ensure map-reduce is gone and flash attention handles 15k chars.",
+            response: hugeString,
+            agent   : "developer",
+            model   : "gemini-3.1-pro"
+        });
 
         // Ensure database is ready before adding memories
         await SDK.Memory_ChromaManager.ready();
@@ -194,7 +203,7 @@ test.describe('Memory Core Offline Summarization', () => {
 
         expect(result).not.toBeNull();
         expect(result.sessionId).toBe(dummySessionId);
-        expect(result.memoryCount).toBe(5);
+        expect(result.memoryCount).toBe(6);
         expect(result.summaryId).toBe(`summary_${dummySessionId}`);
         expect(result.title).toBeTruthy();
 
@@ -386,5 +395,42 @@ test.describe('Memory Core Offline Summarization', () => {
 
         expect(pos3).toBeLessThan(pos2);
         expect(pos2).toBeLessThan(pos1);
+    });
+
+    test('SessionService performance: measure latency for 1 session via API', async () => {
+        if (!localModelActive) {
+            test.skip(true, 'Skipping: openAiCompatible or API not found locally');
+            return;
+        }
+
+        if (!SDK.Memory_LifecycleService._initPromise) {
+            await SDK.Memory_LifecycleService.initAsync();
+        } else {
+            await SDK.Memory_LifecycleService.ready();
+        }
+        await SDK.Memory_SessionService.ready();
+
+        const perfSessionId = crypto.randomUUID();
+        await SDK.Memory_ChromaManager.ready();
+
+        // Inject 1 typical turn
+        await SDK.Memory_Service.addMemory({
+            prompt   : "Quick performance test for remote API generation",
+            thought  : "Measuring true API latency, avoiding map-reduce overhead.",
+            response : "This is a brief response to establish baseline latency for 1 session generation.",
+            agent    : "developer",
+            model    : "gemini-3.1-pro",
+            sessionId: perfSessionId
+        });
+
+        const start = Date.now();
+        const result = await SDK.Memory_SessionService.summarizeSession(perfSessionId);
+        const end = Date.now();
+        
+        const durationMs = end - start;
+        
+        expect(result).not.toBeNull();
+        expect(result.sessionId).toBe(perfSessionId);
+        expect(durationMs).toBeLessThan(20000);
     });
 });


### PR DESCRIPTION
### Description
Resolves #10021

This PR removes the lossy map-reduce bottleneck and hard slicing that was destroying local inference performance for Gemma4 on the M5 processors. The map-reduce loop resulted in 30-60 min runtimes for 17 sessions.

### Architectural Changes
- Removed map-reduce chunking from SessionService summarization.
- Removed slice(-3) from DreamService REM loop.
- Updated SessionSummarization tests.