### PR TITLE
chore(ai): add Acceptance Protocol to ticket-intake skill (#10051)

### DIFF
--- a/.agent/skills/pull-request/references/pull-request-workflow.md
+++ b/.agent/skills/pull-request/references/pull-request-workflow.md
@@ -24,6 +24,8 @@ git checkout -b agent/[ticket-id]-[descriptor]
 # Example: git checkout -b agent/9957-pull-request-skill
 ```
 
+> **Note:** If you followed the `ticket-intake` skill (Section 3: Acceptance Protocol), the feature branch should already exist. This gate serves as a safety net — verify you are on a feature branch before committing.
+
 ## 3. Commit Sequence
 
 Your commit messages MUST follow Conventional Commits and MUST append the ticket ID so that the GitHub API and our internal memory cores can track outcomes.

--- a/.agent/skills/ticket-intake/references/ticket-intake-workflow.md
+++ b/.agent/skills/ticket-intake/references/ticket-intake-workflow.md
@@ -26,9 +26,41 @@ Before executing a `git checkout`, you MUST interrogate the codebase and Memory 
 Evaluate the ticket based on effort vs. architectural payoff. A ticket can yield a **Negative ROI**.
 - **Negative ROI:** High effort, introduces legacy anti-patterns, duplicates active work, or forces severe regressions to satisfy outdated constraints.
 
-If your calculation results in a Negative ROI, you MUST reject the ticket.
+If your calculation results in a Negative ROI, you MUST reject the ticket — proceed to **Section 4: The Rejection Protocol**.
 
-## 3. The Rejection Protocol (Handling Negative ROI)
+## 3. Acceptance Protocol (Branch-Before-Code + Auto-Assign)
+
+If the ticket passes validation and yields a positive ROI, you MUST execute the following two gates **before** writing any code or modifying any files.
+
+### 3a. Claim Ownership (Auto-Assign)
+
+Signal to the Swarm that this ticket is actively being worked. Use the `manage_issue_assignees` MCP tool to assign the ticket to yourself:
+
+```
+manage_issue_assignees(action: 'add', issue_number: N, assignees: ['@me'])
+```
+
+The `@me` shortcut resolves to the authenticated GitHub user — no hardcoded usernames. This prevents duplicate pickup by concurrent agents and provides human visibility into active work.
+
+### 3b. Branch-Before-Code Gate
+
+Create a feature branch **before** writing any code:
+
+```bash
+git checkout -b agent/[ticket-id]-[descriptor]
+# Example: git checkout -b agent/10051-ticket-intake-gate
+```
+
+This is a non-negotiable safety gate. The `dev` branch must remain clean at all times. If a session crashes, the feature branch contains the damage — `dev` has a clean slate for the next session.
+
+You are **FORBIDDEN** from executing the following tools while on the `dev` or `main` branch:
+- `replace` / `replace_file_content` / `multi_replace_file_content`
+- `write_file` / `write_to_file`
+- `git commit`
+
+> **Note:** The `pull-request` skill (Section 2: Git Branching Mandate) also enforces branching before PR creation. This gate moves the enforcement upstream — the branch must exist before the *first line of code*, not the last.
+
+## 4. The Rejection Protocol (Handling Negative ROI)
 
 If you determine the ticket is stale or harmful, you MUST execute the Rejection Protocol instead of attempting to build it. 
 **DO NOT close the ticket.** It must be preserved so the Swarm can formally evaluate the paradox.

--- a/ai/mcp/server/github-workflow/openapi.yaml
+++ b/ai/mcp/server/github-workflow/openapi.yaml
@@ -443,6 +443,9 @@ paths:
         **Action: 'remove'**
         - Unassigns one or more users.
 
+        **Special Values:**
+        - `@me`: Resolves to the authenticated GitHub user. Use this instead of hardcoding usernames.
+
         **Permission Check:**
         Requires `ADMIN`, `MAINTAIN`, or `WRITE` permissions. Returns 403 otherwise.
       tags: [Issues]
@@ -472,8 +475,8 @@ paths:
                   type: array
                   items:
                     type: string
-                  description: An array of GitHub user logins.
-                  example: ["tobiu"]
+                  description: An array of GitHub user logins. Use `@me` to assign/unassign the authenticated user.
+                  example: ["@me"]
       responses:
         '200':
           description: Assignees updated successfully.


### PR DESCRIPTION
## Summary

Adds a mandatory **Acceptance Protocol** (new Section 3) to the ticket-intake skill that forces agents to auto-assign the ticket and create a feature branch **before writing any code**.

## Problem

Agents were coding on `dev` and only branching at PR creation time. If a session crashes, `dev` is left dirty. Additionally, there was no mechanism to signal ticket ownership to the swarm, allowing duplicate pickup.

## Changes

### ticket-intake-workflow.md
- **New Section 3: Acceptance Protocol** with two gates:
  - **3a. Auto-Assign** — `manage_issue_assignees(action: 'add', assignees: ['@me'])` to claim ownership
  - **3b. Branch-Before-Code** — `git checkout -b agent/[ticket-id]-[descriptor]` before any file modifications
- **Forbidden actions on `dev`/`main`:** `replace`, `write_file`, `multi_replace_file_content`, `git commit`
- Old Section 3 (Rejection Protocol) renumbered to **Section 4**
- Section 2 (ROI) now explicitly directs to Section 4 on Negative ROI

### openapi.yaml
- `manage_issue_assignees` tool description updated to document `@me` as a special value
- `assignees` property description mentions `@me` resolves to authenticated user
- Example changed from hardcoded `tobiu` to `@me`

### pull-request-workflow.md
- Section 2 (Git Branching Mandate) cross-references the upstream intake branching gate

## Verification

- Empirically tested `manage_issue_assignees(action: 'add', assignees: ['@me'])` on issue #10051 — confirmed `@me` resolved to `tobiu`
- No `IssueService.mjs` code changes needed — `@me` passes through transparently to `gh issue edit --add-assignee "@me"`

Resolves #10051