### PR TITLE
chore(ai): add self-review detection to pr-review skill (#10054)

### DIFF
--- a/.agent/skills/pr-review/assets/pr-review-template.md
+++ b/.agent/skills/pr-review/assets/pr-review-template.md
@@ -2,7 +2,11 @@
 
 **Status:** [Approved / Request Changes / Comment]
 
-[Friendly Opening / General encouragement. e.g., "Thanks for putting this together! Great approach to solving [Problem]. I've left some review notes below. Let's get these squared away so we can merge."]
+**Peer-Review Opening:** [Friendly Opening / General encouragement. e.g., "Thanks for putting this together! Great approach to solving [Problem]. I've left some review notes below. Let's get these squared away so we can merge."]
+
+**Self-Review Opening:** [Clinical assessment. e.g., "Self-review of #[Ticket]. This implementation chose [approach] over [alternative] because [rationale]. Key trade-offs and gaps noted below."]
+
+*(Use exactly one opening based on the self-review detection result from the guide.)*
 
 ---
 

--- a/.agent/skills/pr-review/references/pr-review-guide.md
+++ b/.agent/skills/pr-review/references/pr-review-guide.md
@@ -9,18 +9,20 @@ This protocol ensures that feedback is:
 3. **Graph-Extractable:** Structured with specific Markdown tags so the background Retrospective Agent (Gemma 4:31B) can mathematically ingest the feedback into the Native Edge Graph.
 
 ## 1. Core Philosophy
-- **For Internal Agents:** Be objective, clinical, and strict. Enforce the "Fat Ticket" protocol and strict JSDoc completeness.
+- **For Internal Agents (Peer-Review):** Be objective, clinical, and strict. Enforce the "Fat Ticket" protocol and strict JSDoc completeness.
 - **For External/First-Time Contributors:** Start with positive reinforcement. Acknowledge their effort. Provide explicit, helpful examples when asking for changes.
+- **For Self-Review (same session):** Use first-person, introspective tone. The review is a structured reflection, not praise. Replace "you did X" with "I chose X because...". Focus on documenting *rationale*, *trade-offs*, and *gaps you are aware of* rather than scoring your own work favorably. Be harsher on self-scoring — actively hunt for blind spots.
 
 ## 2. Agent Operational Mandates: The Reflection Phase
 If you are an AI Agent tasked with writing a PR review directly on GitHub (acting against your own PR or others), you MUST follow this protocol. This serves as the critical "Stepping Back" strategy where you transition from "Driver/Implementer" to "Navigator/Reviewer".
 
 1. **Context Initialization:** You MUST retrieve the state of the PR using `get_pull_request_diff` and `get_conversation` (via the `neo-mjs-github-workflow` MCP server) before formulating your review.
-2. **Semantic Blast-Radius Sweep (Tech Debt Radar):** If the PR introduces fundamental framework architectural shifts or is labeled as `refactor(ai)`, you MUST execute the Tech Debt Radar (by triggering `view_file` on `/Users/Shared/github/neomjs/neo/.agent/skills/tech-debt-radar/SKILL.md`) to mandate a semantic sweep against historical issues and Memory Core sessions. This guarantees the newly proposed architecture does not collide with or ignore sweeping ambient debt across the repository before the PR is merged.
-3. **Scope Creep vs. Iteration:** As you step back to critically review your own architectural choices, you MUST explicitly "think outside the box" and challenge your initial assumptions:
+2. **Self-Review Detection:** After retrieving the PR conversation, extract the associated ticket number from the PR body (e.g., `Resolves #N`). Then query `query_raw_memories(query: '#N')` scoped to the **current Memory Core session ID**. If a match is found, the agent authored this PR in the current session — switch to **self-review mode** (first-person, clinical, no congratulatory openers). If no match, use standard **peer-review mode** (third-person, constructive).
+3. **Semantic Blast-Radius Sweep (Tech Debt Radar):** If the PR introduces fundamental framework architectural shifts or is labeled as `refactor(ai)`, you MUST execute the Tech Debt Radar (by triggering `view_file` on `/Users/Shared/github/neomjs/neo/.agent/skills/tech-debt-radar/SKILL.md`) to mandate a semantic sweep against historical issues and Memory Core sessions. This guarantees the newly proposed architecture does not collide with or ignore sweeping ambient debt across the repository before the PR is merged.
+4. **Scope Creep vs. Iteration:** As you step back to critically review your own architectural choices, you MUST explicitly "think outside the box" and challenge your initial assumptions:
     - **Minor Gaps:** If you uncover minor misses (e.g., missed JSDoc, missing Anchor & Echo context), push rapid successive commits to the PR to polish the execution.
     - **Major Refactors:** If you realize a mathematically superior architecture exists (e.g., massive GC optimization) that is *out-of-scope* for the current ticket, DO NOT attempt to cram it into the active PR. Secure the "good enough" PR, and instead propose a **Follow-Up System Enhancement Ticket** conceptually linked to the original PR to avoid scope creep.
-4. **Execution:** Once formulated, use the `manage_issue_comment` MCP tool (action: `create`) to post the review directly onto the PR thread, or formulate it in markdown locally if MCP is disconnected.
+5. **Execution:** Once formulated, use the `manage_issue_comment` MCP tool (action: `create`) to post the review directly onto the PR thread, or formulate it in markdown locally if MCP is disconnected.
 
 ## 3. Structural Evaluation Metrics
 Every PR review MUST score the work across the following categories on a scale of `0` to `100`:


### PR DESCRIPTION
## Summary

Adds a **self-review detection heuristic** to the pr-review skill so agents use first-person clinical tone when reviewing their own PRs instead of third-person congratulatory language.

## Problem

When an agent authors a PR and then reviews it in the same session, the review reads as self-congratulation:
> "Thanks for putting this together! Great approach... LGTM!"

This sounds off when the reviewer and the author are the same entity.

## Detection Heuristic

The detection uses the **Memory Core session ID** as the discriminator:

1. After `get_conversation`, extract ticket number from PR body (`Resolves #N`)
2. Query `query_raw_memories(query: '#N')` scoped to current session ID
3. **Match** → self-review mode (first-person, clinical)
4. **No match** → peer-review mode (third-person, constructive)

This correctly handles all four author/reviewer combinations:
| Author | Reviewer | Session Match | Mode |
|---|---|---|---|
| Agent (session A) | Same agent (session A) | ✅ | **Self-review** |
| Agent (session A) | Different agent (session B) | ❌ | Peer-review |
| Human | Agent | ❌ | Peer-review |
| External contributor | Agent | ❌ | Peer-review |

## Changes

### pr-review-guide.md
- Section 1: New `Self-Review (same session)` philosophy bullet
- Section 2: New step 2 `Self-Review Detection` with session-based authorship check
- Renumbered existing steps 2→3, 3→4, 4→5

### pr-review-template.md
- Dual opening block: peer-review (friendly) vs self-review (clinical)
- Usage note: "Use exactly one opening based on detection result"

Resolves #10054