### PR TITLE
feat(claude): wire Claude Code harness (#10059)

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1,0 +1,1 @@
+../AGENTS.md

--- a/.claude/skills/create-skill
+++ b/.claude/skills/create-skill
@@ -1,0 +1,1 @@
+../../.agent/skills/create-skill

--- a/.claude/skills/debugging-antigravity
+++ b/.claude/skills/debugging-antigravity
@@ -1,0 +1,1 @@
+../../.agent/skills/debugging-antigravity

--- a/.claude/skills/ideation-sandbox
+++ b/.claude/skills/ideation-sandbox
@@ -1,0 +1,1 @@
+../../.agent/skills/ideation-sandbox

--- a/.claude/skills/neural-link
+++ b/.claude/skills/neural-link
@@ -1,0 +1,1 @@
+../../.agent/skills/neural-link

--- a/.claude/skills/pr-review
+++ b/.claude/skills/pr-review
@@ -1,0 +1,1 @@
+../../.agent/skills/pr-review

--- a/.claude/skills/pull-request
+++ b/.claude/skills/pull-request
@@ -1,0 +1,1 @@
+../../.agent/skills/pull-request

--- a/.claude/skills/self-repair
+++ b/.claude/skills/self-repair
@@ -1,0 +1,1 @@
+../../.agent/skills/self-repair

--- a/.claude/skills/tech-debt-radar
+++ b/.claude/skills/tech-debt-radar
@@ -1,0 +1,1 @@
+../../.agent/skills/tech-debt-radar

--- a/.claude/skills/ticket-intake
+++ b/.claude/skills/ticket-intake
@@ -1,0 +1,1 @@
+../../.agent/skills/ticket-intake

--- a/.claude/skills/unit-test
+++ b/.claude/skills/unit-test
@@ -1,0 +1,1 @@
+../../.agent/skills/unit-test

--- a/.claude/skills/whitebox-e2e
+++ b/.claude/skills/whitebox-e2e
@@ -1,0 +1,1 @@
+../../.agent/skills/whitebox-e2e

--- a/.gitignore
+++ b/.gitignore
@@ -103,6 +103,9 @@ resources/data/deck/EditorConfig.json
 !.neo-ai-data/concepts/
 ai/mcp/server/*/config.mjs
 
+# Claude Code worktrees (agent-spawned checkouts)
+.claude/worktrees/
+
 # Playwright test results
 test/playwright/test-results/
 # Single-file Playwright runs via npx


### PR DESCRIPTION
## Summary

Wires Claude Code as a first-class swarm node alongside Antigravity and Gemini CLI, by auto-loading `AGENTS.md` at session start, committing the existing `.claude/skills/` symlink bundle, and preventing worktree checkouts from polluting `git status` in the main checkout.

See #10059 for the full Fat Ticket rationale, architectural reality, and rejected alternatives.

## Changes

- **`.claude/CLAUDE.md` → `../AGENTS.md`** (symlink). Claude Code auto-loads both `./CLAUDE.md` and `./.claude/CLAUDE.md` with identical precedence per the [Claude Code memory docs](https://code.claude.com/docs/en/memory.md). Placed inside `.claude/` to keep the repo root uncluttered.
- **`.claude/skills/`** — 11 symlinks to `../../.agent/skills/*` covering `create-skill`, `debugging-antigravity`, `ideation-sandbox`, `neural-link`, `pr-review`, `pull-request`, `self-repair`, `tech-debt-radar`, `ticket-intake`, `unit-test`, `whitebox-e2e`. Feature parity with Gemini CLI's `.agent/skills/` discovery.
- **`.gitignore`** — added `.claude/worktrees/` so per-agent Claude Code worktree checkouts don't appear as nested untracked files in the main checkout.

## Verification

1. Clone fresh → open Claude Code in repo root → ask *"what are your pre-commit gates?"* → expect Section 3 recital from AGENTS.md with no Glob/Grep/Read tool calls (auto-loaded from context, not discovered).
2. `git status` in the main checkout on `dev` after future Claude-Code-spawned worktrees → expect no `.claude/worktrees/<name>/` noise.
3. Windows contributors: symlinks survive `git clone` as symlinks when `core.symlinks=true`; otherwise they materialize as text files containing the target path — content is still `AGENTS.md`, acceptable fallback.

## Follow-ups (separate tickets — not in this PR)

Discovered during the commit cycle of this PR:

- Update `.agent/skills/pull-request/references/pull-request-workflow.md` §3 to explicitly document `feat` vs `fix` vs `chore` selection rules and forbid `<noreply@*>` `Co-Authored-By` footers (the Claude Code harness injects these by default).
- Add Gate 3 to `AGENTS.md` §3 Pre-Flight Check for commit-format compliance (consult pull-request skill before `git commit`).
- Accept harness-prefixed branch names (`claude/...`, `antigravity/...`, `gemini/...`) alongside `agent/<ticket>-<desc>` in the branching mandate.
- Optimize `AGENTS.md` + `AGENTS_STARTUP.md` startup-cache footprint (~47KB combined per session).

Resolves #10059