### PR TITLE
feat(agents): Pre-Flight Gate 3 + harness-aware branching + memory-file wiring (#10061)

### DIFF
--- a/.agent/skills/pull-request/references/pull-request-workflow.md
+++ b/.agent/skills/pull-request/references/pull-request-workflow.md
@@ -16,24 +16,60 @@ The act of opening a PR is an irreversible state transition in the Agent OS. Bef
 
 ## 2. Git Branching Mandate
 
-You are strictly forbidden from committing or pushing directly to `main` (release-only) or `dev` (default working). 
-If you are still on `dev`, you MUST branch off:
+You are strictly forbidden from committing or pushing directly to `main` (release-only) or `dev` (default working). The *mechanism* for satisfying this rule differs by harness class.
+
+### 2.1 Worktree-isolated harnesses (e.g., Claude Code)
+
+Claude Code and similar harnesses create a git worktree per session at `.claude/worktrees/<name>/` on an auto-generated branch. Git's worktree branch-exclusivity mechanically prevents accidental commits to `main`/`dev` — another worktree already holds those branches, and git refuses to share.
+
+Any non-`main`/`dev` branch name is acceptable, including harness-generated defaults like `claude/goofy-tu-f83d87`. No explicit branching action is required — the harness already satisfies the mandate.
+
+### 2.2 Shared-checkout harnesses (e.g., Gemini CLI, Antigravity)
+
+Harnesses without worktree isolation operate directly inside the main checkout's working tree. The first `git commit` without an explicit branch lands on the currently checked-out branch — typically `dev`, which is a protocol violation.
+
+You MUST branch off *before* any code change:
 
 ```bash
 git checkout -b agent/[ticket-id]-[descriptor]
 # Example: git checkout -b agent/9957-pull-request-skill
 ```
 
-> **Note:** If you followed the `ticket-intake` skill (Section 3: Acceptance Protocol), the feature branch should already exist. This gate serves as a safety net — verify you are on a feature branch before committing.
+> **Note:** If you followed the `ticket-intake` skill (Section 3: Acceptance Protocol), the feature branch should already exist.
+
+### 2.3 Universal safety net
+
+Regardless of harness class, before your first commit verify:
+
+```bash
+git branch --show-current
+```
+
+If it returns `main` or `dev`, STOP and branch off using the §2.2 procedure. This check costs nothing and catches edge cases where a harness's isolation assumption has broken (e.g. symlink detach, manual `git checkout`).
 
 ## 3. Commit Sequence
 
 Your commit messages MUST follow Conventional Commits and MUST append the ticket ID so that the GitHub API and our internal memory cores can track outcomes.
 
+### 3.1 Type Selection
+
+- **`feat`** — the change unlocks a new capability that did not exist before. Harness integrations, new workflows, new tooling surfaces, and any agent- or user-facing feature all fall here.
+- **`fix`** — restores broken behavior. Use when a regression, race condition, or incorrect output is being corrected.
+- **`chore`** — pure maintenance with zero behavioral or capability delta. Dependency bumps, auto-generated syncs, typo fixes, and similar housekeeping only.
+
+Decision rule: *"Does this enable a new capability that did not exist before?"* → `feat`. When ambiguous, default to `feat`; `chore` is the narrowest category.
+
+### 3.2 Commit Message Hygiene
+
+- **FORBIDDEN:** `Co-Authored-By: <name> <noreply@*>` footers. Some AI harnesses (notably Claude Code) inject these by default — you MUST override that behavior. Agent participation is tracked via the linked ticket body, PR labels (`ai`, `ai-generated`), and Memory Core origin-session IDs, not via fake git identities in commit trailers.
+- **MANDATORY:** append the ticket ID to the subject line in `(#TICKET_ID)` form — e.g. `feat(claude): wire harness (#10059)`. A trailing paragraph like `Refs #N` is non-compliant. The `Resolves #N` keyword belongs in the PR body, not the commit.
+
+### 3.3 Steps
+
 1.  Stage your files: `git add [file paths]`
 2.  Commit the changes:
     ```bash
-    git commit -m "feat/fix/chore: Your descriptive message (#TICKET_ID)"
+    git commit -m "type(scope): descriptive message (#TICKET_ID)"
     ```
 3.  Push the branch to remote:
     ```bash

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -59,7 +59,8 @@ Writing code fast or changing concepts on the fly is acceptable during the explo
 You **MUST** execute this Pre-Flight Check before running a `git commit` command. The check consists of explicitly stating in your internal thought process:
 "Pre-Flight Check: 
 1. **Gate 1 (Ticket):** A ticket must exist for this commit. I will verify the ticket number and include it in the commit message.
-2. **Gate 2 (Contextual Completeness):** I have reviewed the modified code and applied the 'Anchor & Echo' Knowledge Base Enhancement Strategy to ensure new or changed methods/properties have adequate semantic context before proceeding. I am not committing undocumented, context-less code."
+2. **Gate 2 (Contextual Completeness):** I have reviewed the modified code and applied the 'Anchor & Echo' Knowledge Base Enhancement Strategy to ensure new or changed methods/properties have adequate semantic context before proceeding. I am not committing undocumented, context-less code.
+3. **Gate 3 (Commit Format):** I have consulted `.agent/skills/pull-request/references/pull-request-workflow.md` §3 and will emit a Conventional Commits subject of form `type(scope): message (#TICKET_ID)` with no `<noreply@*>` `Co-Authored-By` footers."
 
 ## 4. The Memory Core Protocol
 

--- a/AGENTS_STARTUP.md
+++ b/AGENTS_STARTUP.md
@@ -52,6 +52,15 @@ Before executing any commands, you MUST orient yourself to the repository's buil
 2. **Discover Capabilities:** Before assuming you know how to perform a multi-step task like testing, debugging, or scaffolding, you must list the contents of `.agent/skills/` to discover what predefined workflows exist for this specific repository. If a skill folder exists for your assigned task, you MUST read its `SKILL.md` before proceeding.
 3. **Propose New Skills:** The Agent Skill system is actively expanding. If you identify a recurring, complex task that lacks a skill, you are highly encouraged to propose creating a new one to the user.
 
+#### Harness Memory-File Wiring
+
+Different AI harnesses auto-load their own "memory file" at session start. Each should be symlinked to `AGENTS.md` to preserve single-source-of-truth across the swarm:
+
+- **Claude Code:** auto-loads `./CLAUDE.md` or `./.claude/CLAUDE.md` (identical precedence per the [Claude Code memory docs](https://code.claude.com/docs/en/memory.md)). The repo wires this via `.claude/CLAUDE.md → ../AGENTS.md`.
+- **Gemini CLI:** reads `.gemini/settings.json` for harness configuration and `.gemini/GEMINI.md` for agent memory.
+
+As new harnesses join the swarm, add their memory-file conventions here.
+
 ### Step 6: Check for Memory Core
 
 - Use the `healthcheck` tool for the `neo.mjs-memory-core` server.


### PR DESCRIPTION
## Summary

Closes the four agent-protocol gaps surfaced by PR #10060's execution cycle. This PR encodes the rules that were learned-the-hard-way during #10059's commit/PR friction, so no future harness-based contributor has to rediscover them.

See #10061 for the full Fat Ticket rationale, architectural reality, and rejected alternatives.

## Changes

1. **`AGENTS.md` §3 Pre-Flight Check** — adds Gate 3 (Commit Format) after Gate 2. Delegates to the pull-request skill for detailed rules rather than duplicating content. Structurally impossible to satisfy the Pre-Flight recital while violating commit format.

2. **`.agent/skills/pull-request/references/pull-request-workflow.md` §2** — refactored into harness-aware subsections:
   - **§2.1 Worktree-isolated harnesses** (Claude Code): any non-`main`/`dev` branch name accepted; git worktree isolation mechanically enforces the mandate.
   - **§2.2 Shared-checkout harnesses** (Gemini CLI, Antigravity): `agent/<ticket-id>-<descriptor>` before first code change — hard safety gate.
   - **§2.3 Universal safety net**: `git branch --show-current` verification before first commit.

3. **`.agent/skills/pull-request/references/pull-request-workflow.md` §3** — adds:
   - **§3.1 Type Selection**: criteria for `feat` / `fix` / `chore` with decision rule *"Does this enable a new capability that did not exist before?"* → `feat`. Ambiguous defaults to `feat`; `chore` is the narrowest category.
   - **§3.2 Commit Message Hygiene**: forbids `<noreply@*>` `Co-Authored-By` footers (called out Claude Code's harness default explicitly); mandates `(#TICKET_ID)` appended to subject, not a trailing paragraph. Clarifies `Resolves #N` belongs in PR body.
   - **§3.3 Steps**: the existing numbered steps, renamed the type placeholder from `feat/fix/chore` to `type(scope)`.

4. **`AGENTS_STARTUP.md` §5** — adds "Harness Memory-File Wiring" subsection documenting Claude Code (`.claude/CLAUDE.md` / `./CLAUDE.md`) and Gemini CLI (`.gemini/settings.json` + `.gemini/GEMINI.md`). Sets a convention for future harness additions.

## Verification

1. `grep -n 'Gate 3' AGENTS.md` → match in §3 Pre-Flight Check.
2. `grep -n '### 2.1\|### 2.2\|### 2.3\|### 3.1\|### 3.2\|### 3.3' .agent/skills/pull-request/references/pull-request-workflow.md` → all six subsection headers present.
3. `grep -n 'Harness Memory-File Wiring' AGENTS_STARTUP.md` → match in §5.
4. **Agent self-check** (post-merge): in a fresh Claude Code session, trigger a mock commit scenario. The Pre-Flight Check recital should now include Gate 3 verbatim.
5. **Cross-harness self-check** (post-merge): in a Gemini CLI session, §2.2 should render as a hard gate and trigger the branch-before-code reflex.

## Interaction with #10051

[#10051](https://github.com/neomjs/neo/issues/10051) (*Enhance Ticket-Intake Skill: Branch-Before-Code Mandate*) is inherently a shared-checkout concern by the same logic as §2.2 here. When that ticket's implementation lands, it should either adopt the §2.1/§2.2/§2.3 framing or delegate to §2 of pull-request-workflow.md to avoid double-documentation. Flagged for #10051's implementing agent.

## Follow-ups (Out of Scope)

- Optimize `AGENTS.md` + `AGENTS_STARTUP.md` startup-cache footprint (already tracked elsewhere).

Resolves #10061