### PR TITLE
fix(mcp): emit items for array schemas to satisfy strict validators (#10064)

### DIFF
--- a/ai/mcp/server/neural-link/openapi.yaml
+++ b/ai/mcp/server/neural-link/openapi.yaml
@@ -467,10 +467,16 @@ paths:
                     type: string
                   filters:
                     type: array
+                    items:
+                      type: object
                   sorters:
                     type: array
+                    items:
+                      type: object
                   items:
                     type: array
+                    items:
+                      type: object
 
   /data/store/list:
     post:
@@ -1556,7 +1562,8 @@ components:
           description: The method name (e.g. 'load' or 'series.push')
         args:
           type: array
-          description: Arguments to pass to the method
+          items: {}
+          description: Arguments to pass to the method (heterogeneous — any JSON-serializable value)
         sessionId:
           type: string
           description: The target App Worker Session ID

--- a/ai/mcp/validation/OpenApiValidator.mjs
+++ b/ai/mcp/validation/OpenApiValidator.mjs
@@ -113,7 +113,11 @@ function buildZodSchemaFromNode(doc, schema) {
         if (schema.items) {
             zodSchema = z.array(buildZodSchemaFromNode(doc, schema.items));
         } else {
-            zodSchema = z.array(z.any());
+            // Fallback for OpenAPI arrays declared without `items`. We use z.unknown() rather than
+            // z.any() because zod-to-json-schema with target:'openApi3' emits z.any() as the bare
+            // {"type":"array"} (stripping `items` entirely), which strict validators like GitHub
+            // Copilot reject. z.unknown() round-trips as {"type":"array","items":{}} — compliant.
+            zodSchema = z.array(z.unknown());
         }
     } else if (schema.type === 'string') {
         zodSchema = z.string();
@@ -124,7 +128,12 @@ function buildZodSchemaFromNode(doc, schema) {
     } else if (schema.type === 'boolean') {
         zodSchema = z.boolean();
     } else {
-        zodSchema = z.any();
+        // Catch-all for schemas without a declared type (e.g. `{}`, or an array `items: {}` sentinel).
+        // We use z.unknown() rather than z.any() because zod-to-json-schema with target:'openApi3'
+        // strips `items` from z.array(z.any()) but preserves it for z.array(z.unknown()). Runtime
+        // validation is identical (both accept any value); only the emitted JSON Schema differs,
+        // and only z.unknown() satisfies strict validators like GitHub Copilot's.
+        zodSchema = z.unknown();
     }
 
     if (schema.nullable) {

--- a/test/playwright/unit/ai/mcp/validation/OpenApiValidatorCompliance.spec.mjs
+++ b/test/playwright/unit/ai/mcp/validation/OpenApiValidatorCompliance.spec.mjs
@@ -1,0 +1,77 @@
+import {test, expect}        from '@playwright/test';
+import fs                    from 'fs';
+import path                  from 'path';
+import {fileURLToPath}       from 'url';
+import yaml                  from 'js-yaml';
+import {zodToJsonSchema}     from 'zod-to-json-schema';
+import {buildZodSchema,
+        buildOutputZodSchema} from '../../../../../../ai/mcp/validation/OpenApiValidator.mjs';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname  = path.dirname(__filename);
+const repoRoot   = path.resolve(__dirname, '../../../../../..');
+
+const servers = ['file-system', 'github-workflow', 'knowledge-base', 'memory-core', 'neural-link'];
+
+/**
+ * Walks a JSON Schema node and returns every dotted path where a `type: "array"` node
+ * lacks an `items` property. Strict JSON-Schema validators (e.g. GitHub Copilot's MCP
+ * client) reject such schemas with "array type must have items".
+ *
+ * @param {object} node           The schema node to walk.
+ * @param {string} pathLabel=''   Dotted path label for error reporting.
+ * @returns {string[]}            Paths of non-compliant array nodes (empty when compliant).
+ */
+function findArraysWithoutItems(node, pathLabel = '') {
+    const findings = [];
+    const walk = (n, p) => {
+        if (!n || typeof n !== 'object') return;
+        if (!Array.isArray(n) && n.type === 'array' && !('items' in n)) findings.push(p);
+        if (Array.isArray(n)) n.forEach((v, i) => walk(v, `${p}[${i}]`));
+        else for (const k in n) walk(n[k], `${p}.${k}`);
+    };
+    walk(node, pathLabel);
+    return findings;
+}
+
+test.describe('OpenApiValidator: strict JSON-Schema compliance for array types', () => {
+    /**
+     * Direct regression for https://github.com/neomjs/neo/issues/10064. Prior to the fix,
+     * `z.array(z.any())` emitted `{"type":"array"}` under `target:'openApi3'` — stripping
+     * the `items` field entirely — which caused GitHub Copilot to reject `call_method`.
+     * `z.unknown()` preserves `items: {}`, satisfying strict validators.
+     */
+    test('z.array(z.unknown()) emits items under openApi3 target', async () => {
+        const {z} = await import('zod');
+        const schema = zodToJsonSchema(z.array(z.unknown()), {target: 'openApi3', $refStrategy: 'none'});
+        expect(schema.type).toBe('array');
+        expect(schema).toHaveProperty('items');
+    });
+
+    for (const server of servers) {
+        test(`${server}: every emitted input/output schema has items on array nodes`, () => {
+            const yamlPath = path.join(repoRoot, 'ai/mcp/server', server, 'openapi.yaml');
+            expect(fs.existsSync(yamlPath), `${yamlPath} missing`).toBe(true);
+
+            const doc     = yaml.load(fs.readFileSync(yamlPath, 'utf8'));
+            const offenders = [];
+
+            for (const [urlPath, pathItem] of Object.entries(doc.paths || {})) {
+                for (const [method, op] of Object.entries(pathItem)) {
+                    if (!op?.operationId) continue;
+
+                    const inputSchema  = zodToJsonSchema(buildZodSchema(doc, op), {target: 'openApi3', $refStrategy: 'none'}),
+                          outputZod    = buildOutputZodSchema(doc, op),
+                          outputSchema = outputZod ? zodToJsonSchema(outputZod) : null;
+
+                    offenders.push(...findArraysWithoutItems(inputSchema,  `${op.operationId}.input`));
+                    if (outputSchema) {
+                        offenders.push(...findArraysWithoutItems(outputSchema, `${op.operationId}.output`));
+                    }
+                }
+            }
+
+            expect(offenders, `Non-compliant array nodes in ${server}:\n${offenders.join('\n')}`).toEqual([]);
+        });
+    }
+});


### PR DESCRIPTION
## Summary

GitHub Copilot's MCP client rejected `mcp_neo_mjs-neura_call_method` with:

> Failed to validate tool ... array type must have items

Root-caused to a three-stage interaction:

1. `neural-link/openapi.yaml` declared `CallMethodRequest.args` as `type: array` without an `items` field (four total occurrences across neural-link; other four MCP servers clean).
2. `OpenApiValidator.mjs` handled the missing `items` by producing `z.array(z.any())`.
3. `zod-to-json-schema` with `target: 'openApi3'` silently strips `items` from `z.array(z.any())`, emitting `{"type":"array"}`. Strict validators (Copilot) reject this; permissive ones (Claude, Cursor) accept it, which is why the bug was invisible until a Copilot user surfaced it.

## Fix (two layers)

**Layer 1 — `ai/mcp/validation/OpenApiValidator.mjs`**
Both the array fallback and the catch-all now return `z.unknown()` instead of `z.any()`. Runtime validation is identical (both accept anything); the only observable difference is in `zod-to-json-schema` emission — `z.unknown()` preserves `items: {}`, satisfying strict validators.

**Layer 2 — `ai/mcp/server/neural-link/openapi.yaml`**
- `CallMethodRequest.args` → added `items: {}` (heterogeneous method args)
- `/data/store/inspect` response `filters`, `sorters`, `items` → added `items: {type: object}`

## Verification

New regression test `test/playwright/unit/ai/mcp/validation/OpenApiValidatorCompliance.spec.mjs`:
- Asserts `z.array(z.unknown())` emits `items` under the `openApi3` target (direct guard on Layer 1).
- Walks the emitted input + output JSON Schemas for every operation on all five MCP servers, failing if any array node lacks `items`.

```
$ npx playwright test -c test/playwright/playwright.config.unit.mjs test/playwright/unit/ai/mcp/validation/OpenApiValidatorCompliance.spec.mjs
  6 passed (672ms)
```

## Orthogonality to prior work

- **#10043** (closed) removed the hardcoded `z.array(z.string())` — unrelated prior regression.
- **#9837** (open) covers nested array schemas defaulting to strings — also separate.
- **This PR** covers the residual third case: arrays with no `items` key at all.

## Avoided Traps

- **Not** reintroducing hardcoded `z.array(z.string())` fallback — would regress typed args.
- **Not** post-processing emitted JSON Schema to inject `items` — adds a second serialization layer when `z.unknown()` achieves the same outcome natively in Zod.
- **Not** silently widening every YAML array — keeps the YAML as the source of intent; Layer 1 is the safety net, not the primary contract.

## Origin Session ID

`97343e6e-9d1c-4170-b3a5-6e58d41511b6`

Resolves #10064