### PR TITLE
feat(kb): add PullRequestSource for PR conversation embeddings (#10057)

### DIFF
--- a/ai/mcp/server/knowledge-base/services/DatabaseService.mjs
+++ b/ai/mcp/server/knowledge-base/services/DatabaseService.mjs
@@ -5,6 +5,7 @@ import VectorService      from './VectorService.mjs';
 import ApiSource          from '../source/ApiSource.mjs';
 import DiscussionSource   from '../source/DiscussionSource.mjs';
 import LearningSource     from '../source/LearningSource.mjs';
+import PullRequestSource  from '../source/PullRequestSource.mjs';
 import ReleaseNotesSource from '../source/ReleaseNotesSource.mjs';
 import TestSource         from '../source/TestSource.mjs';
 import TicketSource       from '../source/TicketSource.mjs';
@@ -127,6 +128,7 @@ class DatabaseService extends Base {
             ApiSource,
             DiscussionSource,
             LearningSource,
+            PullRequestSource,
             ReleaseNotesSource,
             TicketSource,
             TestSource

--- a/ai/mcp/server/knowledge-base/source/PullRequestSource.mjs
+++ b/ai/mcp/server/knowledge-base/source/PullRequestSource.mjs
@@ -1,0 +1,71 @@
+import Base     from './Base.mjs';
+import fs       from 'fs-extra';
+import path     from 'path';
+import aiConfig from '../config.mjs';
+
+/**
+ * @summary Extracts knowledge chunks from locally synced Pull Request conversations.
+ *
+ * This source provider iterates through the `resources/content/pulls` directory,
+ * embedding PR bodies and review conversations into the Knowledge Base. It closes
+ * the signal-asymmetry gap where Tickets capture the *problem* while PRs capture
+ * the *solution*: merge rationale, reviewer corrections, scope-creep warnings, and
+ * follow-up ticket links. Without this provider, `ask_knowledge_base` can surface
+ * the intent of a change but not the reasoning recorded during execution.
+ *
+ * @class Neo.ai.mcp.server.knowledge-base.source.PullRequestSource
+ * @extends Neo.ai.mcp.server.knowledge-base.source.Base
+ * @singleton
+ */
+class PullRequestSource extends Base {
+    static config = {
+        /**
+         * @member {String} className='Neo.ai.mcp.server.knowledge-base.source.PullRequestSource'
+         * @protected
+         */
+        className: 'Neo.ai.mcp.server.knowledge-base.source.PullRequestSource',
+        /**
+         * @member {Boolean} singleton=true
+         * @protected
+         */
+        singleton: true
+    }
+
+    /**
+     * Extracts knowledge chunks from local Markdown Pull Requests.
+     * @param {Object}   writeStream  The JSONL write stream.
+     * @param {Function} createHashFn Function to create content hash.
+     * @returns {Promise<Number>} The number of chunks extracted.
+     */
+    async extract(writeStream, createHashFn) {
+        let count = 0;
+        const targetPath = path.resolve(aiConfig.neoRootDir, 'resources/content/pulls');
+
+        if (await fs.pathExists(targetPath)) {
+            const pullFiles = await fs.readdir(targetPath);
+            pullFiles.sort();
+
+            for (const file of pullFiles) {
+                if (file.endsWith('.md')) {
+                    const filePath = path.join(targetPath, file);
+                    const content  = await fs.readFile(filePath, 'utf-8');
+                    const chunk    = {
+                        type   : 'pull',
+                        kind   : 'pull',
+                        name   : file.replace('.md', ''),
+                        content,
+                        source : filePath
+                    };
+
+                    chunk.hash = createHashFn(chunk);
+                    writeStream.write(JSON.stringify(chunk) + '\n');
+                    count++;
+                }
+            }
+        }
+
+        return count;
+    }
+}
+
+export default Neo.setupClass(PullRequestSource);

--- a/test/playwright/mcp/knowledge-base/PullRequestSource.spec.mjs
+++ b/test/playwright/mcp/knowledge-base/PullRequestSource.spec.mjs
@@ -1,0 +1,47 @@
+import {test, expect}  from '@playwright/test';
+import fs              from 'fs';
+import path            from 'path';
+import {fileURLToPath} from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname  = path.dirname(__filename);
+const repoRoot   = path.resolve(__dirname, '../../../..');
+
+test.describe('Knowledge Base PullRequestSource (#10057)', () => {
+    test('PullRequestSource.mjs exists and emits type="pull" chunks targeting resources/content/pulls', () => {
+        const sourcePath = path.join(repoRoot, 'ai/mcp/server/knowledge-base/source/PullRequestSource.mjs');
+
+        expect(fs.existsSync(sourcePath), `PullRequestSource.mjs not found at ${sourcePath}`).toBe(true);
+
+        const content = fs.readFileSync(sourcePath, 'utf8');
+
+        expect(content, 'className must match namespace').toMatch(/className:\s*'Neo\.ai\.mcp\.server\.knowledge-base\.source\.PullRequestSource'/);
+        expect(content, 'must target resources/content/pulls').toMatch(/resources\/content\/pulls/);
+        expect(content, "chunks must carry type: 'pull'").toMatch(/type\s*:\s*'pull'/);
+        expect(content, "chunks must carry kind: 'pull'").toMatch(/kind\s*:\s*'pull'/);
+        expect(content, 'must export via Neo.setupClass').toMatch(/export default Neo\.setupClass\(PullRequestSource\)/);
+    });
+
+    test('PullRequestSource is registered in DatabaseService sources array', () => {
+        const dbServicePath = path.join(repoRoot, 'ai/mcp/server/knowledge-base/services/DatabaseService.mjs');
+
+        expect(fs.existsSync(dbServicePath), `DatabaseService.mjs not found at ${dbServicePath}`).toBe(true);
+
+        const content = fs.readFileSync(dbServicePath, 'utf8');
+
+        expect(content, 'PullRequestSource must be imported').toMatch(/import\s+PullRequestSource\s+from\s+'\.\.\/source\/PullRequestSource\.mjs'/);
+
+        const arrayMatch = content.match(/const\s+sources\s*=\s*\[([\s\S]*?)\]/m);
+        expect(arrayMatch, 'sources array block not found in DatabaseService.mjs').not.toBeNull();
+        expect(arrayMatch[1], 'PullRequestSource must appear in the sources array').toMatch(/\bPullRequestSource\b/);
+    });
+
+    test('resources/content/pulls exists and holds markdown files to embed', () => {
+        const pullsDir = path.join(repoRoot, 'resources/content/pulls');
+
+        expect(fs.existsSync(pullsDir), `pulls directory not found at ${pullsDir}`).toBe(true);
+
+        const markdownFiles = fs.readdirSync(pullsDir).filter(f => f.endsWith('.md'));
+        expect(markdownFiles.length, 'expected at least one PR markdown file to embed').toBeGreaterThan(0);
+    });
+});

--- a/test/playwright/unit/ai/mcp/server/knowledge-base/PullRequestSource.spec.mjs
+++ b/test/playwright/unit/ai/mcp/server/knowledge-base/PullRequestSource.spec.mjs
@@ -5,7 +5,7 @@ import {fileURLToPath} from 'url';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname  = path.dirname(__filename);
-const repoRoot   = path.resolve(__dirname, '../../../..');
+const repoRoot   = path.resolve(__dirname, '../../../../../../..');
 
 test.describe('Knowledge Base PullRequestSource (#10057)', () => {
     test('PullRequestSource.mjs exists and emits type="pull" chunks targeting resources/content/pulls', () => {

--- a/test/playwright/unit/ai/mcp/server/knowledge-base/PullRequestSource.spec.mjs
+++ b/test/playwright/unit/ai/mcp/server/knowledge-base/PullRequestSource.spec.mjs
@@ -1,25 +1,130 @@
+import {setup} from '../../../../../setup.mjs';
+
+const appName = 'PullRequestSourceTest';
+
+setup({
+    neoConfig: {
+        unitTestMode: true
+    },
+    appConfig: {
+        name             : appName,
+        isMounted        : () => true,
+        vnodeInitialising: false
+    }
+});
+
 import {test, expect}  from '@playwright/test';
-import fs              from 'fs';
+import fs              from 'fs-extra';
 import path            from 'path';
 import {fileURLToPath} from 'url';
+import Neo             from '../../../../../../../src/Neo.mjs';
+import * as core       from '../../../../../../../src/core/_export.mjs';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname  = path.dirname(__filename);
 const repoRoot   = path.resolve(__dirname, '../../../../../../..');
 
-test.describe('Knowledge Base PullRequestSource (#10057)', () => {
-    test('PullRequestSource.mjs exists and emits type="pull" chunks targeting resources/content/pulls', () => {
-        const sourcePath = path.join(repoRoot, 'ai/mcp/server/knowledge-base/source/PullRequestSource.mjs');
+test.describe('Neo.ai.mcp.server.knowledge-base.source.PullRequestSource', () => {
+    let PullRequestSource;
+    let aiConfig;
+    let originalRoot;
+    let mockRoot;
 
-        expect(fs.existsSync(sourcePath), `PullRequestSource.mjs not found at ${sourcePath}`).toBe(true);
+    test.beforeAll(async () => {
+        aiConfig          = (await import('../../../../../../../ai/mcp/server/knowledge-base/config.mjs')).default;
+        PullRequestSource = (await import('../../../../../../../ai/mcp/server/knowledge-base/source/PullRequestSource.mjs')).default;
 
-        const content = fs.readFileSync(sourcePath, 'utf8');
+        originalRoot = aiConfig.neoRootDir;
 
-        expect(content, 'className must match namespace').toMatch(/className:\s*'Neo\.ai\.mcp\.server\.knowledge-base\.source\.PullRequestSource'/);
-        expect(content, 'must target resources/content/pulls').toMatch(/resources\/content\/pulls/);
-        expect(content, "chunks must carry type: 'pull'").toMatch(/type\s*:\s*'pull'/);
-        expect(content, "chunks must carry kind: 'pull'").toMatch(/kind\s*:\s*'pull'/);
-        expect(content, 'must export via Neo.setupClass').toMatch(/export default Neo\.setupClass\(PullRequestSource\)/);
+        const tmpDir = path.resolve(process.cwd(), 'tmp');
+        fs.ensureDirSync(tmpDir);
+        mockRoot = path.join(tmpDir, `pullrequest-source-mock-${process.pid}-${Date.now()}`);
+
+        const pullsDir = path.join(mockRoot, 'resources/content/pulls');
+        fs.ensureDirSync(pullsDir);
+        fs.writeFileSync(path.join(pullsDir, 'pr-0001.md'), '# First PR\nbody A');
+        fs.writeFileSync(path.join(pullsDir, 'pr-0002.md'), '# Second PR\nbody B');
+        fs.writeFileSync(path.join(pullsDir, 'notes.txt'), 'should be ignored — non-md');
+
+        aiConfig.neoRootDir = mockRoot;
+    });
+
+    test.afterAll(() => {
+        aiConfig.neoRootDir = originalRoot;
+        if (mockRoot && fs.existsSync(mockRoot)) fs.removeSync(mockRoot);
+    });
+
+    test('is a Neo.setupClass singleton with the expected className and extract() method', () => {
+        expect(PullRequestSource, 'default export must resolve').toBeDefined();
+        expect(PullRequestSource.className).toBe('Neo.ai.mcp.server.knowledge-base.source.PullRequestSource');
+        expect(typeof PullRequestSource.extract).toBe('function');
+    });
+
+    test('extract() emits one chunk per .md file with type: "pull" and correct metadata', async () => {
+        const written = [];
+        const writeStream = {
+            write(chunkStr) {
+                written.push(JSON.parse(chunkStr.trim()));
+                return true;
+            }
+        };
+        const createHashFn = chunk => 'hash:' + chunk.name;
+
+        const count = await PullRequestSource.extract(writeStream, createHashFn);
+
+        expect(count).toBe(2);
+        expect(written).toHaveLength(2);
+
+        const [first, second] = written;
+
+        expect(first).toMatchObject({
+            type   : 'pull',
+            kind   : 'pull',
+            name   : 'pr-0001',
+            content: '# First PR\nbody A',
+            hash   : 'hash:pr-0001'
+        });
+        expect(first.source).toBe(path.join(mockRoot, 'resources/content/pulls/pr-0001.md'));
+
+        expect(second).toMatchObject({
+            type   : 'pull',
+            kind   : 'pull',
+            name   : 'pr-0002',
+            content: '# Second PR\nbody B',
+            hash   : 'hash:pr-0002'
+        });
+    });
+
+    test('extract() ignores non-.md files in the pulls directory', async () => {
+        const written = [];
+        const writeStream = {
+            write(chunkStr) {
+                written.push(JSON.parse(chunkStr.trim()));
+                return true;
+            }
+        };
+
+        await PullRequestSource.extract(writeStream, chunk => chunk.name);
+
+        expect(written.map(w => w.name)).not.toContain('notes');
+    });
+
+    test('extract() returns 0 and writes nothing when the pulls directory is absent', async () => {
+        const missingRoot = path.join(mockRoot, 'does-not-exist');
+        aiConfig.neoRootDir = missingRoot;
+        try {
+            const written = [];
+            const writeStream = {
+                write(chunkStr) { written.push(chunkStr); return true; }
+            };
+
+            const count = await PullRequestSource.extract(writeStream, () => 'h');
+
+            expect(count).toBe(0);
+            expect(written).toHaveLength(0);
+        } finally {
+            aiConfig.neoRootDir = mockRoot;
+        }
     });
 
     test('PullRequestSource is registered in DatabaseService sources array', () => {
@@ -34,14 +139,5 @@ test.describe('Knowledge Base PullRequestSource (#10057)', () => {
         const arrayMatch = content.match(/const\s+sources\s*=\s*\[([\s\S]*?)\]/m);
         expect(arrayMatch, 'sources array block not found in DatabaseService.mjs').not.toBeNull();
         expect(arrayMatch[1], 'PullRequestSource must appear in the sources array').toMatch(/\bPullRequestSource\b/);
-    });
-
-    test('resources/content/pulls exists and holds markdown files to embed', () => {
-        const pullsDir = path.join(repoRoot, 'resources/content/pulls');
-
-        expect(fs.existsSync(pullsDir), `pulls directory not found at ${pullsDir}`).toBe(true);
-
-        const markdownFiles = fs.readdirSync(pullsDir).filter(f => f.endsWith('.md'));
-        expect(markdownFiles.length, 'expected at least one PR markdown file to embed').toBeGreaterThan(0);
     });
 });


### PR DESCRIPTION
## Summary

Adds `PullRequestSource` to the Knowledge Base, closing the RAG asymmetry where tickets capture the *problem* but PRs capture the *solution* (merge rationale, reviewer corrections, scope-creep warnings, follow-up links). After this lands, `ask_knowledge_base(query='how was X resolved?')` can surface both the intent (ticket) and the reasoning recorded during execution (PR).

## Scope

- **New**: `ai/mcp/server/knowledge-base/source/PullRequestSource.mjs` (~40 LOC, direct mirror of `DiscussionSource.mjs`)
- **Modified**: `ai/mcp/server/knowledge-base/services/DatabaseService.mjs` — import + register in the `sources` array (2 lines)
- **New**: `test/playwright/unit/ai/mcp/server/knowledge-base/PullRequestSource.spec.mjs` — 5 tests exercising the real singleton against a mock filesystem

## Design Decisions

### Followed DiscussionSource exactly; did NOT implement per-section chunking
The ticket prescribed "chunk the PR body + conversation into embeddable segments", but the actual `DiscussionSource` / `TicketSource` pattern is **one chunk per markdown file** — downstream chunking happens in `DatabaseService`. Deviating would have fragmented the taxonomy and broken `type=` filtering consistency. Documented this hypothesis-vs-root-cause correction in #10057's intake comment before starting.

### Chunk shape
```js
{ type: 'pull', kind: 'pull', name: 'pr-10065', content, source: '<abs path>', hash }
```
`type: 'pull'` matches the ticket's Acceptance Criteria for `query_documents(query='...', type='pull')`.

### Ticket location vs actual registration
Ticket said "register in `config.mjs`" — actual wiring lives in `DatabaseService.mjs:127` where the other six sources are listed. Followed actual architecture.

### Test style: real singleton, not static regex
The spec boots the framework via `setup()`, imports `core/_export.mjs` per unit-test skill Rule #1, dynamic-imports `aiConfig` + `PullRequestSource` so the test can stub `aiConfig.neoRootDir` to a tmp mock filesystem, captures `writeStream.write()` output, and asserts the exact chunk shape — type, kind, name, content, source, hash. A static-regex version was rejected during review as a structure check, not a unit test.

## Verification

```
$ node buildScripts/ai/initServerConfigs.mjs   # bootstraps gitignored config.mjs files
$ npx playwright test -c test/playwright/playwright.config.unit.mjs test/playwright/unit/ai/mcp/server/knowledge-base/
  5 passed (560ms)
```

Tests cover: (1) singleton identity — correct `className`, `extract()` method; (2) `extract()` emits one chunk per `.md` file with correct `type: 'pull'` / `kind: 'pull'` metadata; (3) non-`.md` files are ignored; (4) missing pulls directory returns `0` and writes nothing; (5) `DatabaseService.mjs` imports + registers `PullRequestSource`.

End-to-end embedding validation (`ai:sync-kb`) was not run in this worktree — requires ChromaDB + API keys. Post-merge, the next KB sync will pick up PRs automatically.

## Graph Wiring

- **Parent:** #9999 (set via `update_issue_relationship`)
- **Related (not parent):** #10030 — Concept Ontology is a different architectural layer (deterministic JSONL graph). Complementary: concepts tell you *what*; PR embeddings surface *how things got done*.

## Avoided Traps

- **Not** resurrecting the abandoned Macro KB approach (#10014, closed for semantic dilution). This is conventional chunked source — fundamentally different.
- **Not** extending `TicketSource` to scrape `Resolves #N` backlinks. That would duplicate content and blur the `type` taxonomy.
- **Not** bundling a drive-by fix for the stale `TicketSource.mjs:14-17` JSDoc (says `.github/ISSUE_ARCHIVE`, code reads `resources/content/issues`). Noted in intake comment for follow-up.

## Commit History

- `feat(kb)`: add PullRequestSource for PR conversation embeddings
- `test(kb)`: move spec to canonical `test/playwright/unit/ai/mcp/server/` path (was in legacy `test/playwright/mcp/`)
- `test(kb)`: exercise PullRequestSource singleton against mock fs (replaced static-regex checks)

## Origin Session ID

`97343e6e-9d1c-4170-b3a5-6e58d41511b6` (this session). The ticket itself originated in session `144326a4-c1e8-4eee-80e4-b984f3c79ddc` during PR #10053 review.

Resolves #10057