### PR TITLE
fix(mcp): tolerate extra properties on output schemas to satisfy strict validators (#9837)

### DIFF
--- a/ai/mcp/validation/OpenApiValidator.mjs
+++ b/ai/mcp/validation/OpenApiValidator.mjs
@@ -68,17 +68,26 @@ function resolveRef(doc, ref) {
 /**
  * Recursively builds a Zod schema from an OpenAPI schema object, handling
  * nested structures and JSON references.
- * @param {object} doc - The full OpenAPI document for reference resolution.
- * @param {object} schema - The OpenAPI schema object (or a resolved reference).
+ * @param {object}  doc             - The full OpenAPI document for reference resolution.
+ * @param {object}  schema          - The OpenAPI schema object (or a resolved reference).
+ * @param {object}  [opts]          - Optional build context.
+ * @param {boolean} [opts.lenient]  - When true, `z.object(...)` nodes without a declared
+ *                                    `additionalProperties` are emitted via `.passthrough()`
+ *                                    so the resulting JSON Schema tolerates extra fields.
+ *                                    Used for *output* schemas where implementations may
+ *                                    return more fields than the OpenAPI contract declares
+ *                                    (see #9837). Input schemas stay strict.
  * @returns {z.ZodType} A Zod schema representing the OpenAPI schema.
  */
-function buildZodSchemaFromNode(doc, schema) {
+function buildZodSchemaFromNode(doc, schema, opts = {}) {
+    const {lenient = false} = opts;
+
     if (schema.$ref) {
-        return buildZodSchemaFromNode(doc, resolveRef(doc, schema.$ref));
+        return buildZodSchemaFromNode(doc, resolveRef(doc, schema.$ref), opts);
     }
 
     if (schema.oneOf) {
-        const options = schema.oneOf.map(s => buildZodSchemaFromNode(doc, s));
+        const options = schema.oneOf.map(s => buildZodSchemaFromNode(doc, s, opts));
         return z.union(options);
     }
 
@@ -88,7 +97,7 @@ function buildZodSchemaFromNode(doc, schema) {
         if (schema.properties) {
             const required = schema.required || [];
             for (const [propName, propSchema] of Object.entries(schema.properties)) {
-                let propertySchema = buildZodSchemaFromNode(doc, propSchema);
+                let propertySchema = buildZodSchemaFromNode(doc, propSchema, opts);
                 if (!required.includes(propName)) {
                     propertySchema = propertySchema.optional();
                 }
@@ -102,16 +111,22 @@ function buildZodSchemaFromNode(doc, schema) {
             if (schema.additionalProperties === true) {
                 additionalSchema = z.any();
             } else if (typeof schema.additionalProperties === 'object') {
-                additionalSchema = buildZodSchemaFromNode(doc, schema.additionalProperties);
+                additionalSchema = buildZodSchemaFromNode(doc, schema.additionalProperties, opts);
             }
 
             if (additionalSchema) {
                 zodSchema = zodSchema.catchall(additionalSchema);
             }
+        } else if (lenient) {
+            // Output schemas tolerate server-side drift: emit `additionalProperties: true`
+            // so strict MCP clients (e.g. GitHub Copilot) accept responses that carry
+            // fields the OpenAPI contract forgot to declare. Input schemas stay strict —
+            // agents passing unknown fields should still fail validation.
+            zodSchema = zodSchema.passthrough();
         }
     } else if (schema.type === 'array') {
         if (schema.items) {
-            zodSchema = z.array(buildZodSchemaFromNode(doc, schema.items));
+            zodSchema = z.array(buildZodSchemaFromNode(doc, schema.items, opts));
         } else {
             // Fallback for OpenAPI arrays declared without `items`. We use z.unknown() rather than
             // z.any() because zod-to-json-schema with target:'openApi3' emits z.any() as the bare
@@ -156,8 +171,14 @@ function buildZodSchemaFromNode(doc, schema) {
  * @returns {z.ZodType|null} A Zod schema for the output, or null if no schema is defined.
  */
 function buildOutputZodSchema(doc, operation) {
-    const response = operation.responses?.['200'] || operation.responses?.['201'] || operation.responses?.['202'];
-    const schema = response?.content?.['application/json']?.schema;
+    const response    = operation.responses?.['200'] || operation.responses?.['201'] || operation.responses?.['202'];
+    const schema      = response?.content?.['application/json']?.schema;
+    // Every `z.object(...)` produced here is emitted with `.passthrough()` so the resulting
+    // JSON Schema sets `additionalProperties: true`. This is the output-side counterpart to
+    // the input-side strictness: server implementations drift faster than OpenAPI contracts,
+    // and strict MCP clients (GitHub Copilot) reject any response with undeclared fields.
+    // See #9837.
+    const outputOpts  = {lenient: true};
 
     if (schema) {
         let resolvedSchema = schema;
@@ -166,14 +187,18 @@ function buildOutputZodSchema(doc, operation) {
         }
 
         if (resolvedSchema.type !== 'object') {
-            return z.object({ result: buildZodSchemaFromNode(doc, schema) }).describe(schema.description || '');
+            return z.object({ result: buildZodSchemaFromNode(doc, schema, outputOpts) })
+                .passthrough()
+                .describe(schema.description || '');
         }
-        return buildZodSchemaFromNode(doc, schema);
+        return buildZodSchemaFromNode(doc, schema, outputOpts);
     }
 
     if (response?.content?.['text/plain']) {
         // For text/plain, we need to wrap it in an object for client compatibility
-        return z.object({ result: z.string().describe(response.description || '') }).required();
+        return z.object({ result: z.string().describe(response.description || '') })
+            .passthrough()
+            .required();
     }
 
     // If no schema is found, return null to indicate its absence.

--- a/test/playwright/unit/ai/mcp/validation/OpenApiValidatorCompliance.spec.mjs
+++ b/test/playwright/unit/ai/mcp/validation/OpenApiValidatorCompliance.spec.mjs
@@ -34,7 +34,32 @@ function findArraysWithoutItems(node, pathLabel = '') {
     return findings;
 }
 
-test.describe('OpenApiValidator: strict JSON-Schema compliance for array types', () => {
+/**
+ * Walks a JSON Schema node and returns every dotted path where a `type: "object"` node
+ * sets `additionalProperties: false`. For OUTPUT schemas this is the #9837 drift bug —
+ * server implementations return fields the OpenAPI contract forgot to declare, and
+ * strict MCP clients (GitHub Copilot) reject the payload with
+ * "data/result/0 must NOT have additional properties". OUTPUT schemas should stay
+ * lenient; INPUT schemas intentionally stay strict (this helper is only used against
+ * output emissions).
+ *
+ * @param {object} node           The schema node to walk.
+ * @param {string} pathLabel=''   Dotted path label for error reporting.
+ * @returns {string[]}            Paths of strict object nodes (empty when lenient).
+ */
+function findStrictObjects(node, pathLabel = '') {
+    const findings = [];
+    const walk = (n, p) => {
+        if (!n || typeof n !== 'object') return;
+        if (!Array.isArray(n) && n.type === 'object' && n.additionalProperties === false) findings.push(p);
+        if (Array.isArray(n)) n.forEach((v, i) => walk(v, `${p}[${i}]`));
+        else for (const k in n) walk(n[k], `${p}.${k}`);
+    };
+    walk(node, pathLabel);
+    return findings;
+}
+
+test.describe('OpenApiValidator: strict-client JSON-Schema compliance', () => {
     /**
      * Direct regression for https://github.com/neomjs/neo/issues/10064. Prior to the fix,
      * `z.array(z.any())` emitted `{"type":"array"}` under `target:'openApi3'` — stripping
@@ -48,16 +73,30 @@ test.describe('OpenApiValidator: strict JSON-Schema compliance for array types',
         expect(schema).toHaveProperty('items');
     });
 
+    /**
+     * Direct regression for https://github.com/neomjs/neo/issues/9837 (re-purposed).
+     * Confirms that `.passthrough()` on a `z.object(...)` flips the emission to
+     * `additionalProperties: true`. This is the mechanism by which output schemas
+     * tolerate server-side drift in returned fields.
+     */
+    test('z.object(...).passthrough() emits additionalProperties:true', async () => {
+        const {z} = await import('zod');
+        const strict  = zodToJsonSchema(z.object({a: z.string()}));
+        const lenient = zodToJsonSchema(z.object({a: z.string()}).passthrough());
+        expect(strict.additionalProperties).toBe(false);
+        expect(lenient.additionalProperties).toBe(true);
+    });
+
     for (const server of servers) {
-        test(`${server}: every emitted input/output schema has items on array nodes`, () => {
+        test(`${server}: every emitted input/output schema has items on array nodes (#10064)`, () => {
             const yamlPath = path.join(repoRoot, 'ai/mcp/server', server, 'openapi.yaml');
             expect(fs.existsSync(yamlPath), `${yamlPath} missing`).toBe(true);
 
             const doc     = yaml.load(fs.readFileSync(yamlPath, 'utf8'));
             const offenders = [];
 
-            for (const [urlPath, pathItem] of Object.entries(doc.paths || {})) {
-                for (const [method, op] of Object.entries(pathItem)) {
+            for (const [, pathItem] of Object.entries(doc.paths || {})) {
+                for (const [, op] of Object.entries(pathItem)) {
                     if (!op?.operationId) continue;
 
                     const inputSchema  = zodToJsonSchema(buildZodSchema(doc, op), {target: 'openApi3', $refStrategy: 'none'}),
@@ -72,6 +111,55 @@ test.describe('OpenApiValidator: strict JSON-Schema compliance for array types',
             }
 
             expect(offenders, `Non-compliant array nodes in ${server}:\n${offenders.join('\n')}`).toEqual([]);
+        });
+
+        test(`${server}: every emitted output schema tolerates extra properties (#9837)`, () => {
+            const yamlPath = path.join(repoRoot, 'ai/mcp/server', server, 'openapi.yaml');
+            const doc      = yaml.load(fs.readFileSync(yamlPath, 'utf8'));
+            const offenders = [];
+
+            for (const [, pathItem] of Object.entries(doc.paths || {})) {
+                for (const [, op] of Object.entries(pathItem)) {
+                    if (!op?.operationId) continue;
+
+                    const outputZod = buildOutputZodSchema(doc, op);
+                    if (!outputZod) continue;
+
+                    offenders.push(...findStrictObjects(zodToJsonSchema(outputZod), `${op.operationId}.output`));
+                }
+            }
+
+            expect(
+                offenders,
+                `Strict object nodes in ${server} output schemas (server drift will reject valid responses):\n${offenders.join('\n')}`
+            ).toEqual([]);
+        });
+
+        test(`${server}: every emitted input schema stays strict (regression guard against #9837 overreach)`, () => {
+            const yamlPath = path.join(repoRoot, 'ai/mcp/server', server, 'openapi.yaml');
+            const doc      = yaml.load(fs.readFileSync(yamlPath, 'utf8'));
+            let checkedOps = 0;
+            let strictOps  = 0;
+
+            for (const [, pathItem] of Object.entries(doc.paths || {})) {
+                for (const [, op] of Object.entries(pathItem)) {
+                    if (!op?.operationId) continue;
+
+                    const inputSchema = zodToJsonSchema(buildZodSchema(doc, op), {target: 'openApi3', $refStrategy: 'none'});
+
+                    // The root input schema is always `z.object(...)` — should NOT be passthrough.
+                    // (Individual nested property objects may legitimately be lenient; we only
+                    // guard the top-level contract surface here so agents passing unknown top-level
+                    // fields fail fast.)
+                    if (inputSchema.type === 'object') {
+                        checkedOps++;
+                        if (inputSchema.additionalProperties === false) strictOps++;
+                    }
+                }
+            }
+
+            expect(checkedOps, `${server} exposes no object-typed input schemas — audit needed`).toBeGreaterThan(0);
+            expect(strictOps, `${server} input-schema strictness must match op count`).toBe(checkedOps);
         });
     }
 });


### PR DESCRIPTION
## Summary

Strict MCP clients (notably GitHub Copilot) have been crashing on output-heavy Neural Link / Memory Core tools with:

> Error: Structured content does not match the tool's output schema: data/result/0 must NOT have additional properties

Every `z.object(...)` emitted from OpenAPI response schemas became `additionalProperties: false` in the JSON Schema, but the underlying services routinely return fields the OpenAPI contract forgot to declare (e.g. `ConnectionService.sessionData` returns `{appName, connectedAt, logs, sessionId}` while the schema declared a different six-field shape). The drift was invisible to lenient clients (Claude Desktop, Cursor) and became fatal the moment #10043 made outputSchemas spec-compliant, activating strict client-side validation.

## Fix (Output-side defense-in-depth)

In [ai/mcp/validation/OpenApiValidator.mjs](ai/mcp/validation/OpenApiValidator.mjs):

- `buildZodSchemaFromNode(...)` now accepts a `{lenient}` opt threaded through the entire recursion.
- When `lenient && !schema.additionalProperties`, `z.object(shape)` is wrapped in `.passthrough()` — `zod-to-json-schema` then emits `additionalProperties: true`.
- `buildOutputZodSchema(...)` passes `lenient: true` throughout and makes the `{result: ...}` envelope passthrough as well (covers the non-object-response wrapping path added by #10043).
- **Input side stays strict**: `buildZodSchema(...)` does not pass the flag — agents calling tools with unknown top-level fields still fail validation, preserving contract safety.

Asymmetry matches the fault model: *server implementations drift faster than OpenAPI contracts; client contracts stay pinned.*

## Scope — before / after

Output-side strict-object counts across every operation on every MCP server:

| Server | Total ops | Strict-obj before | Strict-obj after | Strict-item before | Strict-item after |
|---|---:|---:|---:|---:|---:|
| file-system | 6 | 2 | **0** | 0 | 0 |
| github-workflow | 18 | 17 | **0** | 3 | 0 |
| knowledge-base | 8 | 7 | **0** | 3 | 0 |
| memory-core | 17 | 17 | **0** | 5 | 0 |
| neural-link | 34 | 31 | **0** | 11 | 0 |
| **total** | **83** | **74** | **0** | **22** | **0** |

74 tools unblocked. Verified input side remains strict (e.g. `call_method` input `additionalProperties` stays `false`).

## Verification

Extended [test/playwright/unit/ai/mcp/validation/OpenApiValidatorCompliance.spec.mjs](test/playwright/unit/ai/mcp/validation/OpenApiValidatorCompliance.spec.mjs) with:
- Direct zod-emission guard: `z.object(...).passthrough()` flips `additionalProperties` to `true`.
- Per-server output-tolerance check: no emitted output schema object may carry `additionalProperties: false` anywhere in its tree.
- Per-server input-strictness guard: every root input schema must keep `additionalProperties: false`. Regression guard against accidentally leaking the output-leniency into the input path.

```
$ npx playwright test -c test/playwright/playwright.config.unit.mjs test/playwright/unit/ai/mcp/validation/
  17 passed (649ms)
```

(2 unit guards + 5 servers × 3 per-server assertions = 17 tests)

## Three-layer root cause (from self-repair diagnosis)

1. **OpenAPI schema drift**: declared response fields diverge from service returns over time.
2. **`zod-to-json-schema` quirk**: `z.object(...)` defaults to `additionalProperties: false` on emission.
3. **#10043 activation**: wrapping non-object responses in `{result: ...}` made outputSchemas spec-compliant (`type: object`), which flipped client-side strict validation on — exposing the latent drift.

Full forensic trace captured in [#9837](https://github.com/neomjs/neo/issues/9837)'s re-purposed body.

## Avoided Traps

- **Not** reverting #10043 — that change correctly satisfies the MCP spec.
- **Not** flipping `zod-to-json-schema` globally. `additionalProperties: false` is still correct for *inputs*; agents passing unknown fields should fail fast.
- **Not** auditing every response schema inline. 74 tools is too large a surface for one PR. This change tolerates drift; a follow-up audit ticket (Step 3 in #9837's body) will realign schemas at the source.

## Commit History

- `fix(mcp)`: tolerate extra properties on output schemas via lenient `buildZodSchemaFromNode` recursion + `buildOutputZodSchema` passthrough envelopes

## Follow-up (not this PR)

Schema-vs-implementation audit per Step 3 of #9837's body — realign declared response shapes with actual service returns so the leniency is defense-in-depth rather than load-bearing.

## Origin Session ID

`97343e6e-9d1c-4170-b3a5-6e58d41511b6` (diagnosed via `self-repair` skill)

Resolves #9837