### PR TITLE
docs(agentos): formalize memory-first reflex as per-turn mandate for ticket work (#10068)

### DIFF
--- a/AGENTS_STARTUP.md
+++ b/AGENTS_STARTUP.md
@@ -26,6 +26,8 @@ Parse the file `learn/guides/fundamentals/CodebaseOverview.md`. This guide provi
 
 **Documentation Taxonomy:** Additionally, scan `learn/tree.json` — the canonical hierarchical index of all 130+ learning topics. The Knowledge Base's `LearningSource.mjs` traverses this file to discover and index every guide. Scanning it gives you an instant top-level perspective of the entire documentation landscape, making subsequent knowledge base queries far more targeted.
 
+**Strategic Workflows:** Parse `learn/agentos/StrategicWorkflows.md`. This is the repository's canonical playbook for multi-step agent workflows — most importantly the **Regression Bug Analysis Workflow** (three-dimensional git + ticket + memory query pattern). It is the deep reference behind the memory-query triggers enumerated in §3.3 and is the single most effective antidote to reinventing the wheel across sessions and agents.
+
 ### Step 2: Read the Core Concepts
 
 Read `src/Neo.mjs`. Focus on understanding:
@@ -169,6 +171,14 @@ As an AI agent, your context window is ephemeral. By rigidly adhering to the "Co
 **Action:** Before beginning the implementation of any complex feature or bug fix, you **MUST** perform a brief, proactive exploration of the Memory Core. 
 - `query_summaries`: Search high-level session summaries for broad patterns (e.g., "race condition", "VDOM", "Canvas"). Use this to find relevant past sessions quickly.
 - `query_raw_memories`: Dive into specific implementation details from those sessions to understand the nuanced thought processes.
+
+**Memory-query triggers (mandatory before git/grep/test work).** Query the Memory Core *first* — not after — when you hit any of:
+- User reports a regression ("used to work", "suddenly broken", "worked before my change")
+- Surprise validation failures, schema mismatches, `additionalProperties` rejections, or other "suddenly the contract doesn't hold" symptoms
+- Architecturally non-obvious code where "why was it done this way" is unclear
+- Decision points where prior trade-offs likely inform the right answer ("should we X or Y?")
+
+Memory Core's semantic search routinely surfaces prior decisions keyword grep would miss — *"what would tobi do here?"*. Memories are authored across many agents and harnesses (Claude Code, Antigravity/Gemini, and others); a diagnosis captured in a prior session saves re-derivation in the current one. `git log` and test reproductions produce narrower evidence at higher cost. See `learn/agentos/StrategicWorkflows.md` (Regression Bug Analysis Workflow) for the three-dimensional git + ticket + memory pattern.
 
 **The Contextual Ledger (Mandatory Check):**
 When querying your memory, actively look for two things:

--- a/learn/agentos/StrategicWorkflows.md
+++ b/learn/agentos/StrategicWorkflows.md
@@ -24,11 +24,21 @@ To fix a regression not just by reverting code, but by understanding the *intent
     ```
     Reading the ticket will tell you the *planned* work.
 
-4.  **Find the Unwritten Context (`ai:query-memory`):** This is the most critical step. The ticket describes the plan, but the memory core holds the conversation, the debates, the alternative approaches, and the specific user constraints that shaped the final implementation. Query your memory using the ticket number or key phrases from the original discussion.
+4.  **Find the Unwritten Context (Memory Core):** This is the most critical step. The ticket describes the plan, but the memory core holds the conversation, the debates, the alternative approaches, and the specific user constraints that shaped the final implementation. Query your memory using the ticket number or key phrases from the original discussion.
+
+    **Inside an active MCP session (preferred when Claude Code, Antigravity, Gemini CLI, etc. are driving):** call the Memory Core MCP tools directly:
+    ```
+    query_summaries({query: "context for ticket #<ticket_number>"})
+    query_raw_memories({query: "<key phrase from original discussion>"})
+    ```
+    `query_summaries` returns high-level session overviews quickly; `query_raw_memories` drills into individual prompt/thought/response entries when you need the nuanced decision trail.
+
+    **Outside an MCP session (shell / CI / standalone scripts):** the CLI form covers the same ground:
     ```bash
     npm run ai:query-memory -- -q "context for ticket #<ticket_number>"
     ```
-    This query reveals the crucial **"why"** behind the code that is now causing a regression.
+
+    Either surface reveals the crucial **"why"** behind the code that is now causing a regression. Semantic search is the strength here — vector embeddings surface loosely-worded prior context that keyword grep over the repo would miss.
 
 5.  **Synthesize and Solve:** With the full context, you can now devise a solution that addresses the new regression while still respecting the original problem that the previous developer (or a past version of yourself) was trying to solve. Your final plan should explicitly reference the synthesis of these three sources of information:
     *   **What changed?** (from `git`)


### PR DESCRIPTION
## Summary

Three surgical documentation edits that promote the memory-first reflex from abstract mandate to concrete, trigger-driven behaviour — so agents reach for the Memory Core *before* `git log`, `grep`, or node reproductions, not after.

## Scope

### 1. `AGENTS_STARTUP.md` §Step 1 — mandatory reading
Added `learn/agentos/StrategicWorkflows.md` as a Step 1 sub-paragraph. Existing agents already read Step 1's *Codebase Overview* and *Documentation Taxonomy*; this unlocks the **Regression Bug Analysis Workflow** (three-dimensional git + ticket + memory pattern) on every session boot without renumbering downstream steps.

### 2. `AGENTS_STARTUP.md` §3.3 — memory-query triggers
Between the existing `Action` and `Contextual Ledger` sections, inserted an explicit trigger enumeration:
- User regression reports ("used to work", "suddenly broken")
- Surprise validation failures / `additionalProperties` rejections / contract-breakdown symptoms
- Architecturally non-obvious code ("why was it done this way")
- Decision points where prior trade-offs likely matter

Plus a framing paragraph on *why* semantic search excels here: cross-agent cross-harness memory pool (Claude Code + Antigravity/Gemini + others), and vector embeddings surfacing loosely-worded context keyword grep would miss. Cross-linked to the Regression Workflow guide.

### 3. `learn/agentos/StrategicWorkflows.md` Step 4 — invocation parity
Guide previously showed only the `npm run ai:query-memory` CLI form. Added the MCP-tool form (`query_summaries`, `query_raw_memories`) that agents actually invoke inside MCP sessions. Same workflow, two invocation surfaces — correct one selected by context (active MCP session vs shell/CI).

## Direct Motivation

During the execution of PR #10067 (#9837 — MCP output-schema drift), I spent ~15 minutes re-deriving the root cause via git diff + node reproductions. The exact diagnosis was already recorded in session `ee4bd866-b00d-49e6-9c2f-860d51db521a` (2026-04-16, the session that executed #10043) with plain-language wording: *"`additionalProperties: false` behavior per AJV JSONSchema enforcement"* and a named prior local fix. I only found it after tobiu asked me to check afterwards.

The per-turn mandate already existed abstractly; the deep playbook already existed in `learn/agentos/`. They just weren't cross-linked and the triggers weren't enumerated. This PR closes the discoverability loop.

## Architectural Reality (why edits landed in these three files only)

| Layer | File | Change |
|---|---|---|
| Per-turn mandate | `AGENTS_STARTUP.md §3.3` | Added concrete triggers to the existing Two-Stage Query Protocol |
| Mandatory boot reading | `AGENTS_STARTUP.md §Step 1` | Added StrategicWorkflows.md |
| Deep playbook | `learn/agentos/StrategicWorkflows.md` | Added MCP-tool form alongside CLI form |
| Pre-work | `.agent/skills/ticket-intake/` | **Unchanged** — already covers pre-work memory queries correctly |
| Infrastructure | `.agent/skills/self-repair/` | **Unchanged** — its scope is Agent OS recovery; regression forensics presupposes a healthy OS, so memory-first inside self-repair would be circular when memory-core is the sick component |

## Avoided Traps

- **Not** extending `.agent/skills/self-repair/`. Per tobiu's correction: self-repair's scope is infrastructure recovery; putting memory-first there is circular if memory-core itself is down.
- **Not** creating a new `.agent/skills/regression-analysis/` skill. The reflex is per-turn operational, not a discrete procedure — belongs in the operational mandate layer, not a skill, to avoid registry fragmentation.
- **Not** renumbering AGENTS_STARTUP steps. Step 2+ are referenced elsewhere in the document and in session-init memories; changing numbering would create dangling references. The new `Strategic Workflows` paragraph extends Step 1 alongside the existing `Documentation Taxonomy` paragraph.
- **Not** building tooling-level enforcement (auto-run memory queries on regression keywords). Valid future direction but out of scope for a docs refinement.

## Verification

No automated tests cover prose docs changes. Manual verification:
- `AGENTS_STARTUP.md` parses as valid markdown (headers intact, no broken references)
- `StrategicWorkflows.md` Step 4 continues to flow into Step 5
- All Step numbers in AGENTS_STARTUP.md remain stable (verified via `grep -n "^### Step"`)

## Acceptance Criteria (from #10068)

- [x] `AGENTS_STARTUP.md §2` lists `learn/agentos/StrategicWorkflows.md` as mandatory reading
- [x] `AGENTS_STARTUP.md §3.3` contains the explicit trigger enumeration with universal framing
- [x] `learn/agentos/StrategicWorkflows.md` Step 4 shows MCP-tool form alongside CLI form
- [x] No changes to `self-repair`, `ticket-intake`, or other skills
- [x] No new skill created

## Origin Session ID

`7258d884-6c5d-40d5-b180-d58ae9a9d729` (this session; PR #10067 execution where the 15-minute re-derivation surfaced the gap)

Resolves #10068