### PR TITLE
fix(mcp): preserve open-bag input payloads through Zod validation (#10070)

### DIFF
--- a/ai/mcp/validation/OpenApiValidator.mjs
+++ b/ai/mcp/validation/OpenApiValidator.mjs
@@ -93,8 +93,11 @@ function buildZodSchemaFromNode(doc, schema, opts = {}) {
 
     let zodSchema;
     if (schema.type === 'object') {
-        const shape = {};
-        if (schema.properties) {
+        const shape            = {};
+        const hasProperties    = !!schema.properties;
+        const hasAdditionalDef = schema.additionalProperties !== undefined;
+
+        if (hasProperties) {
             const required = schema.required || [];
             for (const [propName, propSchema] of Object.entries(schema.properties)) {
                 let propertySchema = buildZodSchemaFromNode(doc, propSchema, opts);
@@ -120,8 +123,16 @@ function buildZodSchemaFromNode(doc, schema, opts = {}) {
         } else if (lenient) {
             // Output schemas tolerate server-side drift: emit `additionalProperties: true`
             // so strict MCP clients (e.g. GitHub Copilot) accept responses that carry
-            // fields the OpenAPI contract forgot to declare. Input schemas stay strict —
-            // agents passing unknown fields should still fail validation.
+            // fields the OpenAPI contract forgot to declare. See #9837.
+            zodSchema = zodSchema.passthrough();
+        } else if (!hasProperties && !hasAdditionalDef) {
+            // Open-bag INPUT: OpenAPI declared `type: object` with no `properties` and no
+            // `additionalProperties`. The absence of a declared shape is the author's
+            // design signal — "caller decides the keys" (e.g. `set_instance_properties`'s
+            // `properties` field, `find_instances`'s `selector`, `modify_state_provider`'s
+            // `data`). Without passthrough, Zod's strict parse silently strips the entire
+            // payload to `{}`, producing hollow `{success: true}` responses while the
+            // worker executes `instance.set({})` — a no-op. See #10070.
             zodSchema = zodSchema.passthrough();
         }
     } else if (schema.type === 'array') {

--- a/test/playwright/unit/ai/mcp/validation/OpenApiValidatorCompliance.spec.mjs
+++ b/test/playwright/unit/ai/mcp/validation/OpenApiValidatorCompliance.spec.mjs
@@ -59,6 +59,33 @@ function findStrictObjects(node, pathLabel = '') {
     return findings;
 }
 
+/**
+ * Walks a JSON Schema node looking for INPUT "open-bag" objects that would silently
+ * strip their payload to `{}` — the #10070 regression. An open-bag is a `type: "object"`
+ * node that declares NO child `properties` (the author signaled "caller decides the
+ * shape") AND strict `additionalProperties: false` (Zod then drops every unknown key).
+ * The root of an input schema is excluded — top-level inputs with declared fields
+ * legitimately stay strict; we only care about *nested* open-bag slots like
+ * `properties`, `selector`, `data`, `config`.
+ *
+ * @param {object} node           The schema node to walk.
+ * @param {string} pathLabel=''   Dotted path label for error reporting.
+ * @returns {string[]}            Paths of silently-stripping open-bag nodes (empty when safe).
+ */
+function findSilentlyStrippingOpenBags(node, pathLabel = '') {
+    const findings = [];
+    const walk = (n, p, isRoot) => {
+        if (!n || typeof n !== 'object') return;
+        if (!isRoot && !Array.isArray(n) && n.type === 'object' && !n.properties && n.additionalProperties === false) {
+            findings.push(p);
+        }
+        if (Array.isArray(n)) n.forEach((v, i) => walk(v, `${p}[${i}]`, false));
+        else for (const k in n) walk(n[k], `${p}.${k}`, false);
+    };
+    walk(node, pathLabel, true);
+    return findings;
+}
+
 test.describe('OpenApiValidator: strict-client JSON-Schema compliance', () => {
     /**
      * Direct regression for https://github.com/neomjs/neo/issues/10064. Prior to the fix,
@@ -85,6 +112,23 @@ test.describe('OpenApiValidator: strict-client JSON-Schema compliance', () => {
         const lenient = zodToJsonSchema(z.object({a: z.string()}).passthrough());
         expect(strict.additionalProperties).toBe(false);
         expect(lenient.additionalProperties).toBe(true);
+    });
+
+    /**
+     * Direct regression for https://github.com/neomjs/neo/issues/10070. Prior to the fix,
+     * `type: object` with no declared `properties` emitted strict `z.object({})` which
+     * Zod parses by stripping every unknown key — silently nulling the entire payload
+     * on open-bag inputs like `set_instance_properties.properties`. The fix emits
+     * `z.object({}).passthrough()` in that case, preserving the caller's payload.
+     */
+    test('buildZodSchema preserves open-bag input payloads (set_instance_properties.properties)', async () => {
+        const doc = yaml.load(fs.readFileSync(path.join(repoRoot, 'ai/mcp/server/neural-link/openapi.yaml'), 'utf8'));
+        const op  = doc.paths['/instance/properties/set'].post;
+        const parsed = buildZodSchema(doc, op).parse({
+            id        : 'neo-button-1',
+            properties: {text: 'KEEP_ME', arbitraryKey: 42}
+        });
+        expect(parsed.properties).toEqual({text: 'KEEP_ME', arbitraryKey: 42});
     });
 
     for (const server of servers) {
@@ -135,7 +179,27 @@ test.describe('OpenApiValidator: strict-client JSON-Schema compliance', () => {
             ).toEqual([]);
         });
 
-        test(`${server}: every emitted input schema stays strict (regression guard against #9837 overreach)`, () => {
+        test(`${server}: no nested open-bag input objects silently strip payloads (#10070)`, () => {
+            const yamlPath = path.join(repoRoot, 'ai/mcp/server', server, 'openapi.yaml');
+            const doc      = yaml.load(fs.readFileSync(yamlPath, 'utf8'));
+            const offenders = [];
+
+            for (const [, pathItem] of Object.entries(doc.paths || {})) {
+                for (const [, op] of Object.entries(pathItem)) {
+                    if (!op?.operationId) continue;
+
+                    const inputSchema = zodToJsonSchema(buildZodSchema(doc, op), {target: 'openApi3', $refStrategy: 'none'});
+                    offenders.push(...findSilentlyStrippingOpenBags(inputSchema, `${op.operationId}.input`));
+                }
+            }
+
+            expect(
+                offenders,
+                `Nested open-bag input nodes in ${server} still strip payloads (Zod strict empty-object default):\n${offenders.join('\n')}`
+            ).toEqual([]);
+        });
+
+        test(`${server}: every emitted input schema stays strict at the root (regression guard against #9837 overreach)`, () => {
             const yamlPath = path.join(repoRoot, 'ai/mcp/server', server, 'openapi.yaml');
             const doc      = yaml.load(fs.readFileSync(yamlPath, 'utf8'));
             let checkedOps = 0;


### PR DESCRIPTION
## Summary

Six Neural Link write tools have been silently no-op'ing since #10043. The MCP call returned `{success: true}` while the actual payload was stripped during Zod validation and never reached the worker. User tobiu surfaced it when `set_instance_properties` didn't change a button's DOM text despite a "success" response.

Concrete reproduction (pre-fix):
```js
buildZodSchema(doc, setInstancePropertiesOp).parse({id: 'neo-button-1', properties: {text: 'X'}})
// → {id: 'neo-button-1', properties: {}}    payload silently stripped
```

## Root Cause

Before #10043, `buildZodSchema` used a hardcoded switch where `type: object` fell through to `z.any()` (preserves payload as-is). #10043's recursion refactor emits strict `z.object({})` for `type: object` declarations that have no child `properties` — Zod's default strict parse then drops every unknown key.

Six neural-link tools declare `type: object` with no `properties` intentionally — the field is an open bag where the caller decides the shape:

| Tool | Broken field | Effect (pre-fix) |
|---|---|---|
| `set_instance_properties` | `.properties` | Silent no-op on config writes |
| `find_instances` | `.selector` | Selector empty — matches all or none |
| `query_component` | `.selector` | Same |
| `query_vdom` | `.selector` | Same |
| `modify_state_provider` | `.data` | Silent no-op on state updates |
| `manage_neo_config` | `.config` | Silent no-op on global config changes |

## Fix

In [ai/mcp/validation/OpenApiValidator.mjs](ai/mcp/validation/OpenApiValidator.mjs) `buildZodSchemaFromNode`, when walking `type: object` that has **no declared `properties` AND no declared `additionalProperties`**, emit `z.object({}).passthrough()` instead of strict `z.object({})`. Intent signal: the absence of a declared shape means "caller decides the keys". Strict parsing only makes sense when the author explicitly listed expected fields.

Branches:
- **Input** + has declared `properties` → **strict** (unknown top-level keys = caller error)
- **Input** + no declared `properties` + no `additionalProperties` → **open-bag passthrough** (this fix)
- **Input** + explicit `additionalProperties: <schema>` → respects declaration (existing behavior)
- **Output** side → unchanged, still lenient via #10067's earlier `{lenient}` path

This extends the schema-intent categorization the codebase has been building in #10064 / #9837 / #10067:

| Side | Has declared properties? | Correct strategy |
|---|---|---|
| Input (this PR) | **No** | **Open** — the omission signals "caller decides the shape" |
| Input | Yes | Strict — unknown keys are caller errors |
| Output (closed contract) | Yes, stable | Strict OK |
| Output (runtime introspection) | Varies / none | Open via `.passthrough()` (#10067) |

## Verification

### Unit spec
Extended [test/playwright/unit/ai/mcp/validation/OpenApiValidatorCompliance.spec.mjs](test/playwright/unit/ai/mcp/validation/OpenApiValidatorCompliance.spec.mjs) with:
- Direct payload-preservation assertion for `set_instance_properties.properties` (the exact regression)
- Per-server `findSilentlyStrippingOpenBags` walker: asserts no nested input object emits `{type: object, no properties, additionalProperties: false}` — the exact JSON-Schema shape that triggers Zod's payload strip

```
$ npx playwright test -c test/playwright/playwright.config.unit.mjs test/playwright/unit/ai/mcp/validation/
  23 passed (934ms)
```

### Whitebox E2E
The existing [test/playwright/e2e/ButtonBaseNL.spec.mjs](test/playwright/e2e/ButtonBaseNL.spec.mjs) was passing 1/4 before this PR (only the non-mutating "Layout vs DOM Physics" test survived). After the fix:

```
$ npx playwright test test/playwright/e2e/ButtonBaseNL.spec.mjs -c test/playwright/playwright.config.e2e.mjs
  4 passed (8.0s)
```

All three mutation tests (direct component mutation, user-driven UI → config → button, agent-driven NL → config → button) now round-trip correctly.

## Avoided Traps

- **Not** reverting #10043. Its recursion refactor was correct for declared object shapes; the bug was only in the undeclared-properties edge case.
- **Not** blanket-loosening all input validation. Inputs with declared `properties` stay strict — unknown fields there remain legitimate caller errors (regression-guarded by the existing #9837 input-strictness test).
- **Not** updating the six handlers to re-extract raw request bodies. The validator is the right layer; per-handler fixes would scatter the same workaround six times.
- **Not** bundling an explicit YAML audit (add `additionalProperties: true` to the 6 affected schemas). Worth doing eventually for clarity, but the validator change handles it robustly today. Flagged as optional Step 3 in #10070's body.

## Direct Motivation

Session `7258d884-6c5d-40d5-b180-d58ae9a9d729` bisected the regression in ~15 minutes by applying the memory-first reflex formalized in #10068/#10069:
1. User reported set_instance_properties no-op
2. Memory query showed prior successful uses in 2026-02-25 + 2026-03-24 → real regression confirmed
3. ButtonBaseNL.spec.mjs dropped 1/4 → framework-wide
4. Read+write bisection: both `text` and `_text` unchanged → NL routing, not reactivity
5. Traced to Zod `z.object({})` strict empty-object behavior → fix scoped

The bisection also surfaced a durable lesson saved as feedback memory: **`{success: true}` from an MCP write is not proof of effect**. Always read-back-after-write. The hollow success response in this bug looks identical to real success.

## Origin Session ID

`7258d884-6c5d-40d5-b180-d58ae9a9d729`

Resolves #10070