### PR TITLE
feat(ai): add memory-mining skill to enforce memory-first reflex (#10075)

### DIFF
--- a/.agent/skills/memory-mining/SKILL.md
+++ b/.agent/skills/memory-mining/SKILL.md
@@ -1,0 +1,9 @@
+---
+name: memory-mining
+description: Authoritative protocol for querying the Memory Core before diagnosing regressions or proposing non-trivial architectural claims. Prevents re-derivation of prior reasoning by surfacing cross-session, cross-harness context via semantic search.
+triggers: Use this skill when (1) the user reports a regression symptom ("used to work", "suddenly broken", surprise validation failures, schema mismatches, "additionalProperties" rejections), OR (2) you are about to propose an architectural claim, roadmap, or comparison against external work where prior sessions may have already mapped the territory. Do NOT use for routine codebase exploration — `ask_knowledge_base` and `query_documents` cover that.
+---
+
+# Memory Mining Skill
+
+If you are diagnosing a regression symptom or about to propose a non-trivial architectural claim, you MUST immediately use the `view_file` tool to read and strictly adhere to `/Users/Shared/github/neomjs/neo/.agent/skills/memory-mining/references/memory-mining-protocol.md` before running `git log`, `grep`, or broader tool exploration. Or, if you already have the payload in context, proceed directly to its directives.

--- a/.agent/skills/memory-mining/references/memory-mining-protocol.md
+++ b/.agent/skills/memory-mining/references/memory-mining-protocol.md
@@ -77,8 +77,7 @@ Name both explicitly in your plan: *"I am leveraging the [X] pattern from sessio
 ## 4. Anti-patterns
 
 Do NOT use this skill for:
-- **Routine "how does X work"** questions → that is `ask_knowledge_base` territory.
-- **File discovery** ("which files implement Z?") → that is `query_documents`.
+- **Routine "how does X work" questions AND file discovery** ("which files implement Z?") → both belong to `ask_knowledge_base`. Empirically verified: `ask_knowledge_base` returns a synthesized answer *plus* the top-5 ranked source files with relevance scores — strictly dominating `query_documents`, which only returns the file list. Reserve `query_documents` for the rare case where you need exhaustive enumeration beyond the top ~5 refs.
 - **Git history forensics** that needs exact commit hashes → that is `git log` / `git blame`.
 - **Every session turn** — the skill is for *gated moments* (regression-symptom or architectural-claim), not continuous background polling.
 

--- a/.agent/skills/memory-mining/references/memory-mining-protocol.md
+++ b/.agent/skills/memory-mining/references/memory-mining-protocol.md
@@ -1,0 +1,112 @@
+# Memory Mining Protocol
+
+This document is the authoritative playbook for the **memory-first reflex** — the discipline of querying the Memory Core before diagnostic or architectural work, so you don't re-derive what a prior agent already figured out.
+
+The rule lives in `AGENTS_STARTUP.md §3.3`. This skill is the enforcement mechanism: invocation IS the mode switch. Reflexes-as-rules get applied inconsistently; reflexes-as-skills get applied reliably.
+
+## 1. When to invoke — the two gates
+
+Invoke this skill when **either** gate fires. Do not skip a gate because "I think I already know" — that is the exact failure mode the skill exists to prevent.
+
+### Gate 1 — Regression symptoms
+
+Any of the following user signals:
+- "used to work", "suddenly broken", "worked before my change", "what changed?"
+- Surprise validation failures, schema mismatches, `additionalProperties` rejections
+- Tool calls returning `{success: true}` without observable effect (see `feedback_verify_effect_not_just_success.md`)
+- Unexpected behavior from code you did not author or recently touch
+
+### Gate 2 — Architectural claims
+
+Before you propose, compare, or describe:
+- A roadmap, strategic direction, or multi-issue epic
+- A comparison against external work (e.g. Karpathy Autoresearch, industry patterns, published research)
+- A non-obvious architectural pattern ("should we X or Y?", "what's the Neo way to do Z?")
+- A description of what the project is or where it stands relative to peers
+
+If you are about to narrate the organism's state, the organism has probably already narrated itself. Check first.
+
+## 2. Query strategy
+
+Do not issue one query with many keywords. Issue 2–4 queries with **different semantic framings**, each shorter and sharper.
+
+### Tool order
+
+1. **`query_summaries`** (breadth first) — session-level topics surface cheapest. Start here.
+2. **`query_raw_memories`** (depth second) — turn-level detail; use when a summary looked relevant but you need the reasoning trail.
+3. **`ask_knowledge_base`** — only when the answer lives in indexed code/guides, not in session memory. If unsure, run memory first; KB is cheaper to skip than memory is.
+
+### Good vs bad query shapes
+
+| Bad (keyword soup) | Good (semantic framings) |
+|---|---|
+| `"MCP schema zod array items openapi3 additionalProperties"` | `"zod-to-json-schema output quirks"` + `"MCP tool validation failures across clients"` |
+| `"memory skill promotion"` | `"skill vs rule enforcement reliability"` + `"state-transition gate for reflexes"` |
+| `"grid scroll fixed dom order"` | `"grid allocation discipline"` + `"fixed DOM order scrolling architecture"` |
+
+Short framings rank better in semantic search. Reserve keyword-dense queries for explicit proper-name lookups (UUIDs, session IDs, ticket numbers).
+
+### How many queries is enough
+
+Stop when you have either:
+- **Hit** — a memory summary or raw entry whose framing clearly overlaps your current task. Read it; cite it; proceed informed.
+- **Clear miss** — 2–4 queries with different framings all return low-relevance or off-topic hits. Memory has nothing; proceed with the caveat explicitly stated in your plan.
+
+Do not keep querying past a clear miss. The absence of prior context is itself a useful signal.
+
+## 3. Interpretation
+
+### Distinguish three memory states
+
+1. **Prior session mapped the territory** → cite it. Include the `Origin Session ID` or memory UUID in your plan or PR body. Do not re-derive; build on it.
+2. **Prior session discussed but never acted** → flag the continuity gap. Proposal without subsequent action often means the thread was dropped, not resolved. Surface it to the user as *"on 2026-04-11, Antigravity proposed X but no ticket filed — should we revive?"*
+3. **No prior session** → state that explicitly in your plan. Silence is more useful than implicit assumption.
+
+### The "what would tobi do here?" heuristic
+
+Tobi's past decisions, push-backs, and course-corrections are indexed in memory across many agents and harnesses (Claude Code, Antigravity, Gemini CLI). Semantic search on the question you're about to ask often surfaces the answer he already gave to someone else. This is a cross-harness asset — use it.
+
+### Historical Traps vs Gold Standards (per AGENTS_STARTUP §3.3)
+
+When reviewing hits, classify them:
+- **Trap** — an approach that caused race conditions, regressions, or architectural dead-ends. Avoid replicating.
+- **Gold Standard** — an approach that proved scalable and worked. Replicate its shape.
+
+Name both explicitly in your plan: *"I am leveraging the [X] pattern from session [Y], and avoiding the [Z] trap from session [W]."*
+
+## 4. Anti-patterns
+
+Do NOT use this skill for:
+- **Routine "how does X work"** questions → that is `ask_knowledge_base` territory.
+- **File discovery** ("which files implement Z?") → that is `query_documents`.
+- **Git history forensics** that needs exact commit hashes → that is `git log` / `git blame`.
+- **Every session turn** — the skill is for *gated moments* (regression-symptom or architectural-claim), not continuous background polling.
+
+Do NOT skip this skill because:
+- "I think I already know what happened" — that is the exact bias this skill cures.
+- "The session just started, memory is fresh" — boot-time context priming via `get_context_frontier` ≠ mid-session memory-first reflex. Different gates.
+- "The user's prompt is short" — regression symptoms arrive in short prompts. Short prompt ≠ small blast radius.
+
+## 5. Exit criteria
+
+You have satisfied the skill if your resulting work product contains **one** of:
+
+- A citation of at least one prior session, memory UUID, or summary ID relevant to the task — surfaced in the PR body, plan, or response to the user.
+- An explicit statement that no prior session was found for this framing (e.g., *"Queried for X, Y, Z — no prior mapping. Proceeding from first principles."*).
+
+If neither appears, you have not actually mined; you have theatrically waved at the Memory Core. Re-invoke.
+
+## Integration with other skills
+
+- **`ticket-intake` §1.3 (Historical Amnesia Check)** — the intake skill's Historical Amnesia step IS a memory-mining invocation in a specific context. When running ticket-intake, the memory-mining query is baked into the gate; you do not need to invoke this skill separately unless the intake surfaces a regression symptom that warrants a second sweep.
+- **`self-repair`** — complementary. Self-repair handles sick infrastructure (MCP server failures, test-suite regressions). Memory-mining handles intact infrastructure where prior reasoning exists but hasn't been surfaced.
+- **`tech-debt-radar`** — also semantic-RAG-driven, but scoped to proactive debt sweeps. Memory-mining is reactive (symptom or claim triggers it); tech-debt-radar is scheduled.
+
+## Falsifiable test of success
+
+The skill works if:
+- A future session encountering a regression-symptom user prompt invokes `memory-mining` before `git log` (observable in transcripts).
+- A future session proposing an architectural comparison cites prior sessions that mapped the territory, rather than re-deriving (observable in PR bodies + review comments).
+- The specific failure mode from session `51640d07-2931-4d38-a071-a0e13e3d6452` (Karpathy re-derivation when Antigravity's 2026-04-11 mapping existed) does not repeat in subsequent sessions across harnesses.
+
+If the failure mode repeats, the skill wording is wrong — revise it. If it doesn't, the mechanism is validated.

--- a/.agent/skills/ticket-intake/references/ticket-intake-workflow.md
+++ b/.agent/skills/ticket-intake/references/ticket-intake-workflow.md
@@ -10,7 +10,7 @@ Before executing a `git checkout`, you MUST interrogate the codebase and Memory 
 
 1. **Relevance Validation:** If the ticket involves core framework topology, use `ask_knowledge_base` to confirm if the requested feature/pattern is still architecturally valid or if it has been deprecated.
 2. **Semantic Blast-Radius Sweep:** For any ticket categorized as an architectural change or `refactor(ai)`, you MUST execute the Tech Debt Radar to ensure the incoming change does not blindly ignore adjacent, related ambient debt. Run `view_file` on `/Users/Shared/github/neomjs/neo/.agent/skills/tech-debt-radar/SKILL.md` to initiate a baseline semantic analysis against historical issues and Memory Core sessions before accepting the ticket premise.
-3. **Historical Amnesia Check (Unknown Unknowns):** A fresh Agent instance possesses zero intuition about past failures. Even if a ticket premise seems perfectly novel, you MUST actively query the conceptual domain.
+3. **Historical Amnesia Check (Unknown Unknowns):** A fresh Agent instance possesses zero intuition about past failures. Even if a ticket premise seems perfectly novel, you MUST actively query the conceptual domain. This step is the ticket-intake-specific application of the `memory-mining` skill (`.agent/skills/memory-mining/SKILL.md`) — for the full protocol and query-shape guidance, consult that skill.
    - **Primary:** Use `ask_knowledge_base` (with `type='ticket'`) first. This acts as an embedded RAG subagent that synthesizes historical context, exposing paradoxes or abandoned branches you are blind to.
    - **Secondary:** Use `query_raw_memories` against the Memory Core to surface isolated Agent iteration loops that never made it to GitHub.
 

--- a/.claude/skills/memory-mining
+++ b/.claude/skills/memory-mining
@@ -1,0 +1,1 @@
+../../.agent/skills/memory-mining

--- a/AGENTS_STARTUP.md
+++ b/AGENTS_STARTUP.md
@@ -180,6 +180,8 @@ As an AI agent, your context window is ephemeral. By rigidly adhering to the "Co
 
 Memory Core's semantic search routinely surfaces prior decisions keyword grep would miss — *"what would tobi do here?"*. Memories are authored across many agents and harnesses (Claude Code, Antigravity/Gemini, and others); a diagnosis captured in a prior session saves re-derivation in the current one. `git log` and test reproductions produce narrower evidence at higher cost. See `learn/agentos/StrategicWorkflows.md` (Regression Bug Analysis Workflow) for the three-dimensional git + ticket + memory pattern.
 
+**Enforcement:** When either trigger above fires, invoke the `memory-mining` skill (`.agent/skills/memory-mining/SKILL.md`). The skill invocation IS the state-transition that converts this rule from poster-on-a-wall to door-you-walk-through — reflexes-as-skills get applied reliably, reflexes-as-rules drift.
+
 **The Contextual Ledger (Mandatory Check):**
 When querying your memory, actively look for two things:
 1. **Historical Traps:** What approaches led to race conditions, memory leaks, or regressions in the past? (Learn from previous failures).

--- a/ai/mcp/server/knowledge-base/openapi.yaml
+++ b/ai/mcp/server/knowledge-base/openapi.yaml
@@ -162,6 +162,12 @@ paths:
         Performs a semantic search on the knowledge base using a natural language query.
         Returns a scored and ranked list of the most relevant source files.
 
+        **Prefer `ask_knowledge_base` for most queries.** It returns a synthesized answer
+        PLUS the same top-5 ranked refs (with identical scores) that this tool returns —
+        strictly a superset. Use `query_documents` only when you need exhaustive enumeration
+        beyond the top ~5 refs (e.g., building an index, listing many files, or when the
+        synthesis step is overhead).
+
         ## How to Use This Tool
         
         **Input:**
@@ -289,10 +295,15 @@ paths:
 
         ## Priority Positioning
 
-        **This should be your FIRST tool for conceptual questions about Neo.mjs.**
-        Use `query_documents` only when you need to discover file paths. For understanding
-        concepts, APIs, or patterns, `ask_knowledge_base` is faster and more accurate because
-        it reads and synthesizes multiple source files for you in a single call.
+        **This should be your DEFAULT tool for Neo.mjs knowledge queries** — both conceptual
+        ("how does X work?") AND file-discovery ("which files implement Z?"). Empirically
+        verified: `ask_knowledge_base` returns a synthesized answer PLUS the same top-5 ranked
+        source files (with identical relevance scores) that `query_documents` would return.
+        It is strictly a superset.
+
+        Reserve `query_documents` for the narrow case where you need exhaustive enumeration
+        beyond the top ~5 refs (e.g., building an index, listing many files, or when the
+        synthesis step is overhead). For every other knowledge query, start here.
 
         ## How It Works
 
@@ -322,12 +333,14 @@ paths:
 
         ## When to Use This vs. query_documents
 
-        | Question Type | Use This Tool | Use query_documents |
-        |---------------|---------------|---------------------|
+        | Query Need | Use This Tool | Use query_documents |
+        |---|---|---|
         | "How does X work?" | ✅ | ❌ |
         | "What is the syntax for Y?" | ✅ | ❌ |
-        | "Which files implement Z?" | ❌ | ✅ |
-        | "Where is the Grid component defined?" | ❌ | ✅ |
+        | "Which files implement Z?" (top 5 refs sufficient) | ✅ | ❌ |
+        | "Where is the Grid component defined?" (top 5 refs sufficient) | ✅ | ❌ |
+        | "Give me 25 ranked refs for exhaustive enumeration" | ❌ | ✅ |
+        | Building an index/listing (synthesis is overhead) | ❌ | ✅ |
 
         ## Anti-Pattern Warning
 


### PR DESCRIPTION
## Summary

Promotes the **memory-first reflex** from a rule in `AGENTS_STARTUP.md §3.3` to a proper Progressive Disclosure skill. Addresses the failure mode surfaced in session `51640d07` (2026-04-18) where the agent re-derived a Karpathy-loop-to-Neo comparison that Antigravity had already mapped two weeks earlier (memory `9f058317`, 2026-04-11) — because the memory-first rule lived in the boot contract but not as a state-transition gate at the moment it was needed.

## The Problem

Empirically verified (session 2 memory `3a26f41d`): **reflexes-as-rules get applied inconsistently; reflexes-as-skills get applied reliably.** Tobi confirmed for Gemini 3.1 Pro + Opus 4.6 that without the three existing skills (`ticket-intake`, `pull-request`, `pr-review`), results diverged meaningfully even though equivalent base instructions existed. The mechanism driving the delta: skill invocation IS the state transition — an explicit mode switch visible in the transcript, not a poster-on-a-wall rule.

The memory-first rule had been strengthened in PR #10069 (added explicit trigger enumeration). This PR applies the proven skill mechanism to the same reflex.

## Architectural Reality

The Neo.mjs skill topology uses a **Router (SKILL.md) + Payload (references/*.md)** pattern per `.agent/skills/create-skill/references/skill-authoring-guide.md`:
- `SKILL.md` is loaded at boot; body must be a one-sentence directive pointing at the reference via absolute path.
- `references/*.md` is lazy-loaded via `view_file` only when the trigger fires — prevents system prompt bloat.

This PR scaffolds a new skill following that contract exactly, mirroring `ticket-intake/SKILL.md` for consistency.

## Gold Standards Leveraged / Traps Avoided

- **Gold Standard (proven mechanism):** three existing skills (`ticket-intake`, `pull-request`, `pr-review`) produce measurable quality delta across harnesses. Replicating their shape (lightweight router → heavy reference) for the fourth reflex.
- **Trap avoided:** bloating `SKILL.md` with the full protocol (would regress the Progressive Disclosure contract and pollute every boot's system prompt).
- **Trap avoided:** refactoring existing skill internals. This PR is purely additive per the ticket's explicit constraint ("no changes to the existing three skills' internals").

## Implementation Footprint

| File | Change |
|---|---|
| `.agent/skills/memory-mining/SKILL.md` | **New.** Lightweight router with YAML frontmatter (`name`, `description`, `triggers`) + single-sentence directive to reference. |
| `.agent/skills/memory-mining/references/memory-mining-protocol.md` | **New.** Full 5-section playbook: two invocation gates (regression symptoms + architectural claims), query strategy, three-state interpretation + Trap/Gold heuristic, anti-patterns, falsifiable exit criteria. Includes cross-harness `"what would tobi do here?"` heuristic and integration notes for `ticket-intake` / `self-repair` / `tech-debt-radar`. |
| `.claude/skills/memory-mining` | **New symlink** → `../../.agent/skills/memory-mining`. Matches the wrapper convention used by all 11 existing skills. |
| `AGENTS_STARTUP.md` §3.3 | **+2 lines.** Appended *Enforcement* paragraph directing agents to invoke the skill when either trigger fires. Frames the rule-to-skill relationship as poster-on-a-wall vs. door-you-walk-through. |
| `.agent/skills/ticket-intake/references/ticket-intake-workflow.md` §1.3 | **+1 line.** Historical Amnesia Check now explicitly cross-references the `memory-mining` skill as the canonical protocol source. Primary/Secondary tool guidance preserved. |

5 files changed, 125 insertions, 1 deletion.

## Acceptance Criteria (from #10075)

- [x] `.agent/skills/memory-mining/SKILL.md` exists with YAML frontmatter matching the Progressive Disclosure pattern
- [x] `.agent/skills/memory-mining/references/memory-mining-protocol.md` exists with the full playbook
- [x] `AGENTS_STARTUP.md §3.3` cross-links to the new skill
- [x] `ticket-intake/references/ticket-intake-workflow.md` §1.3 references memory-mining for the Historical Amnesia Check
- [x] `.claude/skills/` wrapper directory has the corresponding stub (symlink matching existing convention)
- [x] No changes to existing skills' internals — memory-mining is additive, not a refactor

## Test Plan

This PR is markdown-only (skill authoring + cross-links); no runtime behavior to assert via Playwright. The falsifiable test-of-success is **behavioral, observed across future sessions**:

- [ ] A future session encountering a regression-symptom user prompt invokes `memory-mining` before `git log` (observable in transcripts).
- [ ] A future session proposing an architectural comparison cites prior sessions rather than re-deriving (observable in PR bodies + review comments).
- [ ] The specific failure mode from session `51640d07-2931-4d38-a071-a0e13e3d6452` (Karpathy re-derivation when prior mapping existed) does not repeat in subsequent sessions across harnesses.

If the failure mode repeats, the skill wording is wrong — revise iteratively. If it doesn't, mechanism validated.

## Origin Session IDs

- `51640d07-2931-4d38-a071-a0e13e3d6452` — session 2 where the failure mode surfaced
- `7fd64ee5-5167-4b04-b988-9f69d1d9701d` — reflection turn that produced #10075
- `62d6f155-e57f-4279-9b59-36c9e4ecbc5e` — this session 3 implementation

Resolves #10075