### PR TITLE
fix(github-workflow): paginate timelineItems to prevent silent content drop (#10090)

### DIFF
--- a/ai/mcp/server/github-workflow/services/SyncService.mjs
+++ b/ai/mcp/server/github-workflow/services/SyncService.mjs
@@ -193,6 +193,38 @@ class SyncService extends Base {
             timing
         };
     }
+
+    /**
+     * @summary Force-refetches the given issues from GitHub, bypassing delta-sync `updatedAt` gating.
+     *
+     * The sync engine normally relies on `issue.updatedAt` to decide which issues need a fresh
+     * pull. That gate is blind to several classes of drift: `timelineItems` truncation past the
+     * page cap (#10090), comment deletions (GitHub does not bump `updatedAt` on delete), and
+     * relationship events where both sides fall outside the delta window. This endpoint is the
+     * surgical recovery primitive — it force-refetches the listed issues, exhausts their full
+     * timelineItems connection, rewrites the local markdown, and persists updated metadata.
+     *
+     * Intended callers: diagnostic scripts such as `ai/scripts/detectTruncatedTimelines.mjs` —
+     * not the normal `runFullSync` flow. Keeps the delta-sync cost model intact for routine
+     * syncs while giving admin tooling a narrow, auditable healing path.
+     *
+     * @param {object}   params
+     * @param {number[]} params.numbers Issue numbers to force-refetch.
+     * @returns {Promise<{refetched: {count: number, issues: number[]}, errors: Array<{issueNumber: number, error: string}>}>}
+     */
+    async refetchIssuesByNumber({numbers}) {
+        if (!Array.isArray(numbers) || numbers.length === 0) {
+            return {refetched: {count: 0, issues: []}, errors: []};
+        }
+
+        const metadata = await MetadataManager.load();
+        const stats    = await IssueSyncer.refetchIssuesByNumber(numbers, metadata);
+        await MetadataManager.save(metadata);
+
+        logger.info(`✨ Force-refetch complete: ${stats.refetched.count}/${numbers.length} issues refetched`);
+
+        return stats;
+    }
 }
 
 export default Neo.setupClass(SyncService);

--- a/ai/mcp/server/github-workflow/services/queries/issueQueries.mjs
+++ b/ai/mcp/server/github-workflow/services/queries/issueQueries.mjs
@@ -149,7 +149,7 @@ export const FETCH_ISSUES_FOR_SYNC = `
               RENAMED_TITLE_EVENT,    # Title updates
               MILESTONED_EVENT,       # Added to milestone
               DEMILESTONED_EVENT,     # Removed from milestone
-              
+
               # Relationship Events
               # Critical for sync: Adding/removing sub-issues does not always bump the parent's updatedAt.
               SUB_ISSUE_ADDED_EVENT,
@@ -161,6 +161,10 @@ export const FETCH_ISSUES_FOR_SYNC = `
               BLOCKED_BY_REMOVED_EVENT,
               BLOCKING_REMOVED_EVENT
             ]) {
+            # pageInfo enables continuation-fetching when an issue's timeline has outgrown
+            # a single page of \`maxTimelineItems\`. Without this, tail events (including
+            # newly-authored comments) are silently dropped once totalCount > first. See #10090.
+            pageInfo { hasNextPage endCursor }
             nodes {
               __typename
               ... on IssueComment {
@@ -289,7 +293,7 @@ export const FETCH_ISSUES_FOR_SYNC = `
         }
       }
     }
-    
+
     # Monitor rate limit usage
     rateLimit {
       cost
@@ -475,6 +479,9 @@ export const FETCH_SINGLE_ISSUE = `
               BLOCKED_BY_REMOVED_EVENT,
               BLOCKING_REMOVED_EVENT
             ]) {
+            # pageInfo enables continuation-fetching for issues whose timeline has outgrown
+            # a single page of \`maxTimelineItems\`. See FETCH_ISSUES_FOR_SYNC above for detail.
+            pageInfo { hasNextPage endCursor }
             nodes {
               __typename
               ... on IssueComment {
@@ -602,6 +609,167 @@ export const FETCH_SINGLE_ISSUE = `
           }
       }
     }
+  }
+`;
+
+/**
+ * Continuation query for a single issue's timelineItems connection.
+ *
+ * Used by IssueSyncer when an issue's timeline exceeds one page of \`maxTimelineItems\` —
+ * i.e. \`FETCH_ISSUES_FOR_SYNC\` or \`FETCH_SINGLE_ISSUE\` returned \`pageInfo.hasNextPage: true\`.
+ * Fetches only the next page of timeline events (no redundant issue metadata) keyed by the
+ * cursor from the prior page.
+ *
+ * Variables required:
+ * - $owner: String!
+ * - $repo: String!
+ * - $number: Int!
+ * - $maxTimelineItems: Int!
+ * - $cursor: String! - The endCursor from the previous page's pageInfo
+ */
+export const FETCH_ISSUE_TIMELINE_PAGE = `
+  query FetchIssueTimelinePage(
+    $owner: String!
+    $repo: String!
+    $number: Int!
+    $maxTimelineItems: Int!
+    $cursor: String!
+  ) {
+    repository(owner: $owner, name: $repo) {
+      issue(number: $number) {
+        timelineItems(
+          first: $maxTimelineItems,
+          after: $cursor,
+          itemTypes: [
+            REFERENCED_EVENT,
+            CROSS_REFERENCED_EVENT,
+            LABELED_EVENT,
+            UNLABELED_EVENT,
+            ASSIGNED_EVENT,
+            UNASSIGNED_EVENT,
+            CLOSED_EVENT,
+            ISSUE_COMMENT,
+            REOPENED_EVENT,
+            RENAMED_TITLE_EVENT,
+            MILESTONED_EVENT,
+            DEMILESTONED_EVENT,
+            SUB_ISSUE_ADDED_EVENT,
+            SUB_ISSUE_REMOVED_EVENT,
+            PARENT_ISSUE_ADDED_EVENT,
+            PARENT_ISSUE_REMOVED_EVENT,
+            BLOCKED_BY_ADDED_EVENT,
+            BLOCKING_ADDED_EVENT,
+            BLOCKED_BY_REMOVED_EVENT,
+            BLOCKING_REMOVED_EVENT
+          ]
+        ) {
+          pageInfo { hasNextPage endCursor }
+          nodes {
+            __typename
+            ... on IssueComment {
+              createdAt
+              author { login }
+              body
+            }
+            ... on ReferencedEvent {
+              createdAt
+              actor { login }
+              commit { oid message }
+            }
+            ... on CrossReferencedEvent {
+              createdAt
+              actor { login }
+              source { __typename ... on Issue { number } ... on PullRequest { number } }
+            }
+            ... on LabeledEvent {
+              createdAt
+              actor { login }
+              label { name }
+            }
+            ... on UnlabeledEvent {
+              createdAt
+              actor { login }
+              label { name }
+            }
+            ... on AssignedEvent {
+              createdAt
+              actor { login }
+              assignee { ... on User { login } }
+            }
+            ... on UnassignedEvent {
+              createdAt
+              actor { login }
+              assignee { ... on User { login } }
+            }
+            ... on ClosedEvent {
+              createdAt
+              actor { login }
+            }
+            ... on ReopenedEvent {
+              createdAt
+              actor { login }
+            }
+            ... on RenamedTitleEvent {
+              createdAt
+              actor { login }
+              previousTitle
+              currentTitle
+            }
+            ... on MilestonedEvent {
+              createdAt
+              actor { login }
+              milestoneTitle
+            }
+            ... on DemilestonedEvent {
+              createdAt
+              actor { login }
+              milestoneTitle
+            }
+            ... on SubIssueAddedEvent {
+              createdAt
+              actor { login }
+              subIssue { number }
+            }
+            ... on SubIssueRemovedEvent {
+              createdAt
+              actor { login }
+              subIssue { number }
+            }
+            ... on ParentIssueAddedEvent {
+              createdAt
+              actor { login }
+              parent { number }
+            }
+            ... on ParentIssueRemovedEvent {
+              createdAt
+              actor { login }
+              parent { number }
+            }
+            ... on BlockedByAddedEvent {
+              createdAt
+              actor { login }
+              blockingIssue { number }
+            }
+            ... on BlockingAddedEvent {
+              createdAt
+              actor { login }
+              blockedIssue { number }
+            }
+            ... on BlockedByRemovedEvent {
+              createdAt
+              actor { login }
+              blockingIssue { number }
+            }
+            ... on BlockingRemovedEvent {
+              createdAt
+              actor { login }
+              blockedIssue { number }
+            }
+          }
+        }
+      }
+    }
+    rateLimit { cost remaining resetAt }
   }
 `;
 

--- a/ai/mcp/server/github-workflow/services/sync/IssueSyncer.mjs
+++ b/ai/mcp/server/github-workflow/services/sync/IssueSyncer.mjs
@@ -7,8 +7,8 @@ import matter                                        from 'gray-matter';
 import path                                          from 'path';
 import GraphqlService                                from '../GraphqlService.mjs';
 import ReleaseSyncer                                 from './ReleaseSyncer.mjs';
-import {FETCH_ISSUES_FOR_SYNC, FETCH_SINGLE_ISSUE} from '../queries/issueQueries.mjs';
-import {GET_ISSUE_ID, UPDATE_ISSUE}                  from '../queries/mutations.mjs';
+import {FETCH_ISSUE_TIMELINE_PAGE, FETCH_ISSUES_FOR_SYNC, FETCH_SINGLE_ISSUE} from '../queries/issueQueries.mjs';
+import {GET_ISSUE_ID, UPDATE_ISSUE}                                            from '../queries/mutations.mjs';
 
 const issueSyncConfig = aiConfig.issueSync;
 const lineBreaksRegex = /[\r\n]+/g;
@@ -49,6 +49,57 @@ class IssueSyncer extends Base {
      */
     #calculateContentHash(content) {
         return crypto.createHash('sha256').update(content).digest('hex');
+    }
+
+    /**
+     * @summary Continuation-fetches remaining timelineItems pages for an issue until exhausted.
+     *
+     * GitHub's GraphQL `timelineItems` connection returns events oldest-first with no `orderBy`,
+     * so the default `first: N` request truncates the tail. Once total events exceed N, newly-
+     * authored comments and structural events silently disappear from the rendered markdown
+     * while scalar metadata (`updatedAt`, `comments.totalCount`) stays correct — a divergence
+     * between the metadata path and the content-rendering path.
+     *
+     * This helper is the pagination primitive: it detects `pageInfo.hasNextPage` and loops
+     * `FETCH_ISSUE_TIMELINE_PAGE` with the previous cursor, concatenating nodes in place on
+     * the issue object. Emits a warning log on continuation to make cap-edge conditions visible.
+     *
+     * @param {object} issue The GraphQL issue node with its first page of timelineItems already populated.
+     * @returns {Promise<void>}
+     * @private
+     * @see https://github.com/neomjs/neo/issues/10090
+     */
+    async #exhaustTimelineItems(issue) {
+        if (!issue.timelineItems?.pageInfo?.hasNextPage) return;
+
+        const startCount = issue.timelineItems.nodes.length;
+        let   cursor     = issue.timelineItems.pageInfo.endCursor;
+        const allNodes   = [...issue.timelineItems.nodes];
+
+        logger.warn(`⚠️ Timeline continuation required for #${issue.number} — first page had ${startCount} events, more pending`);
+
+        while (cursor) {
+            const data = await GraphqlService.query(
+                FETCH_ISSUE_TIMELINE_PAGE,
+                {
+                    owner           : aiConfig.owner,
+                    repo            : aiConfig.repo,
+                    number          : issue.number,
+                    maxTimelineItems: issueSyncConfig.maxTimelineItemsPerIssue,
+                    cursor
+                },
+                true // sub-issues feature
+            );
+
+            const page = data.repository.issue.timelineItems;
+            allNodes.push(...page.nodes);
+            logger.info(`  📄 Fetched timeline page for #${issue.number}: +${page.nodes.length} events (cumulative: ${allNodes.length})`);
+
+            cursor = page.pageInfo.hasNextPage ? page.pageInfo.endCursor : null;
+        }
+
+        issue.timelineItems.nodes    = allNodes;
+        issue.timelineItems.pageInfo = {hasNextPage: false, endCursor: null};
     }
 
     /**
@@ -360,7 +411,10 @@ class IssueSyncer extends Base {
                 stats.pulled.count++;
                 stats.pulled.issues.push(issueNumber);
 
-                // Comments are already in issue.comments - no separate fetch needed!
+                // Continuation-fetch the full timeline if the first page was truncated.
+                // Prevents silent comment-body + structural-event loss on active Epics (#10090).
+                await this.#exhaustTimelineItems(issue);
+
                 const markdown = this.#formatIssueMarkdown(issue);
                 contentHash = this.#calculateContentHash(markdown);
 
@@ -455,57 +509,94 @@ class IssueSyncer extends Base {
 
         if (relatedIssuesToUpdate.size > 0) {
             logger.info(`🔄 Force-updating ${relatedIssuesToUpdate.size} related issues due to relationship activity...`);
-
-            for (const relatedIssueNumber of relatedIssuesToUpdate) {
-                try {
-                    const data = await GraphqlService.query(
-                        FETCH_SINGLE_ISSUE,
-                        {
-                            owner           : aiConfig.owner,
-                            repo            : aiConfig.repo,
-                            number          : relatedIssueNumber,
-                            maxLabels       : issueSyncConfig.maxLabelsPerIssue,
-                            maxAssignees    : issueSyncConfig.maxAssigneesPerIssue,
-                            maxComments     : issueSyncConfig.maxCommentsPerIssue,
-                            maxSubIssues    : issueSyncConfig.maxSubIssuesPerIssue,
-                            maxTimelineItems: issueSyncConfig.maxTimelineItemsPerIssue
-                        },
-                        true // Enable sub-issues
-                    );
-
-                    const issue = data.repository.issue;
-                    if (!issue) continue;
-
-                    const targetPath = this.#getIssuePath(issue);
-                    if (!targetPath) continue;
-
-                    const markdown    = this.#formatIssueMarkdown(issue);
-                    const contentHash = this.#calculateContentHash(markdown);
-
-                    await fs.mkdir(path.dirname(targetPath), { recursive: true });
-                    await fs.writeFile(targetPath, markdown, 'utf-8');
-
-                    stats.pulled.updated++;
-                    stats.pulled.issues.push(relatedIssueNumber);
-                    logger.info(`✅ Force-updated related issue #${relatedIssueNumber}`);
-
-                    newMetadata.issues[relatedIssueNumber] = {
-                        state    : issue.state,
-                        path     : this.#relativePath(targetPath), // Store relative path
-                        updatedAt: issue.updatedAt,
-                        closedAt : issue.closedAt || null,
-                        milestone: issue.milestone?.title || null,
-                        title    : issue.title,
-                        contentHash
-                    };
-
-                } catch (e) {
-                    logger.error(`Failed to force-update related issue #${relatedIssueNumber}: ${e.message}`);
-                }
-            }
+            const refetchStats = await this.refetchIssuesByNumber([...relatedIssuesToUpdate], newMetadata);
+            stats.pulled.count   += refetchStats.refetched.count;
+            stats.pulled.updated += refetchStats.refetched.count;
+            stats.pulled.issues.push(...refetchStats.refetched.issues);
         }
 
         return { newMetadata, stats };
+    }
+
+    /**
+     * @summary Force-refetches the given issues from GitHub and rewrites their local markdown.
+     *
+     * Bypasses the delta-sync `updatedAt` gate. Use this when the local file is known to have
+     * drifted from GitHub for reasons that do NOT bump `issue.updatedAt`:
+     *   - `timelineItems` truncation (the original cap-related divergence — see #10090)
+     *   - Comment deletions (GitHub does not update `updatedAt` on delete)
+     *   - Relationship events (sub-issue/blocking edges) when both sides are outside the delta window
+     *
+     * This method is the single recovery primitive: it fetches each issue via `FETCH_SINGLE_ISSUE`,
+     * exhausts the full timelineItems connection via `#exhaustTimelineItems`, re-renders markdown,
+     * writes the file, and mutates the passed `metadata` in place. Caller is responsible for
+     * persisting metadata afterwards.
+     *
+     * The internal pullFromGitHub's related-issue force-update loop delegates here, and the
+     * `ai/scripts/detectTruncatedTimelines.mjs` recovery step invokes it via GH_SyncService.
+     *
+     * @param {Array<number>|Set<number>} numbers The issue numbers to refetch.
+     * @param {object} metadata The sync metadata object (mutated in place).
+     * @returns {Promise<{refetched: {count: number, issues: number[]}, errors: Array<{issueNumber: number, error: string}>}>}
+     */
+    async refetchIssuesByNumber(numbers, metadata) {
+        const stats = {refetched: {count: 0, issues: []}, errors: []};
+        const list  = [...numbers];
+
+        for (const issueNumber of list) {
+            try {
+                const data = await GraphqlService.query(
+                    FETCH_SINGLE_ISSUE,
+                    {
+                        owner           : aiConfig.owner,
+                        repo            : aiConfig.repo,
+                        number          : issueNumber,
+                        maxLabels       : issueSyncConfig.maxLabelsPerIssue,
+                        maxAssignees    : issueSyncConfig.maxAssigneesPerIssue,
+                        maxComments     : issueSyncConfig.maxCommentsPerIssue,
+                        maxSubIssues    : issueSyncConfig.maxSubIssuesPerIssue,
+                        maxTimelineItems: issueSyncConfig.maxTimelineItemsPerIssue
+                    },
+                    true
+                );
+
+                const issue = data.repository.issue;
+                if (!issue) {
+                    logger.warn(`Issue #${issueNumber} not found on GitHub, skipping refetch`);
+                    continue;
+                }
+
+                await this.#exhaustTimelineItems(issue);
+
+                const targetPath = this.#getIssuePath(issue);
+                if (!targetPath) continue;
+
+                const markdown    = this.#formatIssueMarkdown(issue);
+                const contentHash = this.#calculateContentHash(markdown);
+
+                await fs.mkdir(path.dirname(targetPath), {recursive: true});
+                await fs.writeFile(targetPath, markdown, 'utf-8');
+
+                stats.refetched.count++;
+                stats.refetched.issues.push(issueNumber);
+                logger.info(`✅ Refetched issue #${issueNumber}`);
+
+                metadata.issues[issueNumber] = {
+                    state    : issue.state,
+                    path     : this.#relativePath(targetPath),
+                    updatedAt: issue.updatedAt,
+                    closedAt : issue.closedAt || null,
+                    milestone: issue.milestone?.title || null,
+                    title    : issue.title,
+                    contentHash
+                };
+            } catch (e) {
+                logger.error(`Failed to refetch issue #${issueNumber}: ${e.message}`);
+                stats.errors.push({issueNumber, error: e.message});
+            }
+        }
+
+        return stats;
     }
 
     /**

--- a/ai/scripts/detectTruncatedTimelines.mjs
+++ b/ai/scripts/detectTruncatedTimelines.mjs
@@ -1,0 +1,167 @@
+/**
+ * @summary Diagnostic sweep for the IssueSyncer timelineItems truncation bug (#10090).
+ *
+ * IssueSyncer renders GitHub comment bodies through the unified `timelineItems`
+ * GraphQL channel, which is page-capped at `maxTimelineItemsPerIssue` (50). Once an
+ * issue's timeline grows past that cap, newly-authored comments (and other tail
+ * events) are silently dropped from the local markdown while frontmatter metadata
+ * (`commentsCount`, `updatedAt`) remains correct — a classic divergence between the
+ * metadata-tracking path and the content-rendering path.
+ *
+ * This tool walks `resources/content/issues/*.md` only (archives are immutable and
+ * excluded by design) and reports two signals:
+ *
+ *   - **Primary (confirmed truncation):** frontmatter `commentsCount` is greater
+ *     than the number of `### @login - <timestamp>` comment blocks actually rendered
+ *     into the body. Comment bodies were lost.
+ *   - **Secondary (cap-at-edge suspect):** the rendered timeline has exactly
+ *     `TIMELINE_CAP` entries. Non-comment events past the cap may also be missing
+ *     and would require a GraphQL probe to confirm.
+ *
+ * The JSON output of this script is the input to the recovery step, which calls
+ * `GH_SyncService.refetchIssuesByNumber(numbers[])` once the pagination fix lands.
+ *
+ * Usage:
+ *   node ai/scripts/detectTruncatedTimelines.mjs           # human report
+ *   node ai/scripts/detectTruncatedTimelines.mjs --json    # machine-readable
+ *
+ * @see ai/mcp/server/github-workflow/services/sync/IssueSyncer.mjs
+ * @see ai/mcp/server/github-workflow/services/queries/issueQueries.mjs
+ * @see https://github.com/neomjs/neo/issues/10090
+ */
+import fs              from 'fs/promises';
+import path            from 'path';
+import {fileURLToPath} from 'url';
+import matter          from 'gray-matter';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname  = path.dirname(__filename);
+
+const projectRoot = path.resolve(__dirname, '../..');
+const issuesDir   = path.resolve(projectRoot, 'resources/content/issues');
+
+// Mirrors IssueSyncer's `maxTimelineItemsPerIssue` default. If that config changes,
+// this constant must move with it — both encode the same GitHub-imposed page size.
+const TIMELINE_CAP = 50;
+
+// A comment block in the rendered timeline starts with `### @login - <ISO-8601 Z>`.
+// Emitted by IssueSyncer.#formatTimelineEvent for `IssueComment` events.
+const COMMENT_HEADER_RE = /^### @\S+ - \d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$/gm;
+
+// A structural (non-comment) event line: `- <ISO-8601 Z> @login <details>`.
+// Emitted by the same formatter for all other timelineItems event types.
+const EVENT_LINE_RE = /^- \d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z @\S+ /gm;
+
+// The `## Timeline` heading as a standalone line — NOT as a substring inside some
+// comment body's quoted markdown (e.g., `### Timeline & Next Steps` would otherwise
+// slice the section into multiple segments under a naive string split).
+const TIMELINE_HEADING_RE = /^## Timeline$/m;
+
+async function scanDir(dir) {
+    const files = [];
+    const walk = async (d) => {
+        const entries = await fs.readdir(d, {withFileTypes: true});
+        for (const e of entries) {
+            const full = path.join(d, e.name);
+            if (e.isDirectory()) {
+                await walk(full);
+            } else if (e.isFile() && e.name.endsWith('.md')) {
+                files.push(full);
+            }
+        }
+    };
+    await walk(dir);
+    return files;
+}
+
+function analyzeFile(filePath, raw) {
+    const parsed        = matter(raw);
+    const commentsCount = parsed.data.commentsCount ?? 0;
+    const issueNumber   = parsed.data.id ?? null;
+    const state         = parsed.data.state ?? 'UNKNOWN';
+
+    // Everything after the `## Timeline` heading is the rendered timeline section.
+    // We locate the heading with a line-anchored regex — not a substring split —
+    // because comment bodies can contain text like `### Timeline & Next Steps`
+    // that would otherwise slice the section and undercount events.
+    const headingMatch = TIMELINE_HEADING_RE.exec(parsed.content);
+    const timelineBody = headingMatch
+        ? parsed.content.slice(headingMatch.index + headingMatch[0].length)
+        : '';
+
+    const commentBlocks = (timelineBody.match(COMMENT_HEADER_RE) || []).length;
+    const eventLines    = (timelineBody.match(EVENT_LINE_RE) || []).length;
+    const totalRendered = commentBlocks + eventLines;
+
+    const missingComments = Math.max(0, commentsCount - commentBlocks);
+    const primaryHit      = missingComments > 0;
+    const atCap           = totalRendered === TIMELINE_CAP;
+
+    return {
+        issueNumber,
+        state,
+        filePath: path.relative(projectRoot, filePath),
+        commentsCount,
+        commentBlocks,
+        eventLines,
+        totalRendered,
+        missingComments,
+        primaryHit,
+        atCap,
+        affected: primaryHit || atCap
+    };
+}
+
+async function main() {
+    const jsonMode = process.argv.includes('--json');
+
+    const files   = await scanDir(issuesDir);
+    const reports = [];
+
+    for (const f of files) {
+        const raw = await fs.readFile(f, 'utf-8');
+        try {
+            reports.push(analyzeFile(f, raw));
+        } catch (e) {
+            reports.push({filePath: path.relative(projectRoot, f), error: e.message});
+        }
+    }
+
+    const affected = reports.filter(r => r.affected);
+    const primary  = affected.filter(r => r.primaryHit);
+    const capOnly  = affected.filter(r => !r.primaryHit && r.atCap);
+
+    if (jsonMode) {
+        console.log(JSON.stringify({
+            scanned        : files.length,
+            affected       : affected.length,
+            primaryHits    : primary.map(r => r.issueNumber),
+            capOnlySuspects: capOnly.map(r => r.issueNumber),
+            details        : affected
+        }, null, 2));
+        return;
+    }
+
+    console.log(`Scanned ${files.length} active issues under ${path.relative(projectRoot, issuesDir)}/\n`);
+
+    console.log(`Confirmed truncation (commentsCount > rendered comment blocks): ${primary.length}`);
+    for (const r of primary) {
+        console.log(`  #${r.issueNumber} [${r.state}] — rendered ${r.commentBlocks}/${r.commentsCount} comments (missing ${r.missingComments}), ${r.totalRendered} total timeline entries`);
+    }
+
+    console.log(`\nSecondary suspects (timeline at cap=${TIMELINE_CAP}, no comment body loss yet): ${capOnly.length}`);
+    for (const r of capOnly) {
+        console.log(`  #${r.issueNumber} [${r.state}] — ${r.totalRendered} entries rendered`);
+    }
+
+    if (affected.length === 0) {
+        console.log('\nNo truncation detected.');
+    } else {
+        console.log(`\nRun with --json to capture the affected-set for downstream recovery via refetchIssuesByNumber().`);
+    }
+}
+
+main().catch(e => {
+    console.error('Error:', e);
+    process.exit(1);
+});

--- a/ai/scripts/refetchTruncatedIssues.mjs
+++ b/ai/scripts/refetchTruncatedIssues.mjs
@@ -1,0 +1,79 @@
+/**
+ * @summary Force-refetches the given issue numbers from GitHub to heal local drift.
+ *
+ * Companion to `detectTruncatedTimelines.mjs`. Intended pipeline:
+ *
+ *   node ai/scripts/detectTruncatedTimelines.mjs --json | node ai/scripts/refetchTruncatedIssues.mjs --stdin
+ *
+ * or explicit list:
+ *
+ *   node ai/scripts/refetchTruncatedIssues.mjs 10030 9486 9999
+ *
+ * Delegates to `GH_SyncService.refetchIssuesByNumber` which bypasses the delta-sync
+ * `updatedAt` gate, exhausts full timelineItems pagination, and rewrites each local
+ * markdown file. Safe to re-run: it is idempotent — refetching an already-current
+ * issue is a no-op writeback.
+ *
+ * @see ai/scripts/detectTruncatedTimelines.mjs
+ * @see ai/mcp/server/github-workflow/services/SyncService.mjs
+ * @see https://github.com/neomjs/neo/issues/10090
+ */
+import {GH_SyncService} from '../services.mjs';
+
+function parseStdin() {
+    return new Promise((resolve, reject) => {
+        let raw = '';
+        process.stdin.setEncoding('utf-8');
+        process.stdin.on('data', chunk => raw += chunk);
+        process.stdin.on('end', () => {
+            try {
+                const parsed  = JSON.parse(raw);
+                const primary = Array.isArray(parsed.primaryHits)     ? parsed.primaryHits     : [];
+                const cap     = Array.isArray(parsed.capOnlySuspects) ? parsed.capOnlySuspects : [];
+                resolve([...new Set([...primary, ...cap])]);
+            } catch (e) {
+                reject(new Error(`Failed to parse stdin as detector JSON: ${e.message}`));
+            }
+        });
+        process.stdin.on('error', reject);
+    });
+}
+
+async function main() {
+    const argv = process.argv.slice(2);
+    let numbers;
+
+    if (argv.includes('--stdin')) {
+        numbers = await parseStdin();
+    } else {
+        numbers = argv.map(a => Number(a)).filter(n => Number.isInteger(n) && n > 0);
+    }
+
+    if (numbers.length === 0) {
+        console.error('Usage:');
+        console.error('  node ai/scripts/refetchTruncatedIssues.mjs <num> [<num> ...]');
+        console.error('  node ai/scripts/detectTruncatedTimelines.mjs --json | node ai/scripts/refetchTruncatedIssues.mjs --stdin');
+        process.exit(1);
+    }
+
+    console.log(`Force-refetching ${numbers.length} issue(s): ${numbers.join(', ')}`);
+
+    const stats = await GH_SyncService.refetchIssuesByNumber({numbers});
+
+    console.log(`\nRefetched ${stats.refetched.count}/${numbers.length}`);
+    if (stats.refetched.issues.length > 0) {
+        console.log(`  OK: ${stats.refetched.issues.join(', ')}`);
+    }
+    if (stats.errors.length > 0) {
+        console.log(`  FAIL: ${stats.errors.length} error(s)`);
+        for (const {issueNumber, error} of stats.errors) {
+            console.log(`    #${issueNumber}: ${error}`);
+        }
+        process.exit(1);
+    }
+}
+
+main().catch(e => {
+    console.error('Error:', e);
+    process.exit(1);
+});

--- a/resources/content/.sync-metadata.json
+++ b/resources/content/.sync-metadata.json
@@ -22170,7 +22170,7 @@
       "path": "resources/content/issues/issue-9486.md",
       "closedAt": null,
       "updatedAt": "2026-03-31T12:14:10Z",
-      "contentHash": "81ffdd0c998176b430b502504777c1b07f16b2c480b016637bf73992e4029a95"
+      "contentHash": "c3f6245a6e2c259716c5d4be6a8d0a4af8cb68c296f4aee117da388cb6fa21c5"
     },
     "9487": {
       "state": "CLOSED",
@@ -22506,7 +22506,7 @@
       "path": "resources/content/issues/issue-9535.md",
       "closedAt": null,
       "updatedAt": "2026-04-01T02:28:35Z",
-      "contentHash": "f1807ada26b4408bb33c2a05a3c7a9a021b03cf9cd4bfff76c1ae6b468ab398a"
+      "contentHash": "303392e611003d594afc8a595f7a2b7381bf5d6f73ea747069479433d43e2f5d"
     },
     "9538": {
       "state": "CLOSED",
@@ -25187,7 +25187,7 @@
       "path": "resources/content/issues/issue-9999.md",
       "closedAt": null,
       "updatedAt": "2026-04-16T18:44:50Z",
-      "contentHash": "e78110a45c198b5718f1dc6057a82119820b00cbbe32874b60493e80d026729c"
+      "contentHash": "bdab2072955a28a9ba88964de22a714a8955e52d17e1b8cba9a50d44ed9e01a1"
     },
     "10000": {
       "state": "OPEN",
@@ -25348,7 +25348,7 @@
       "path": "resources/content/issues/issue-10030.md",
       "closedAt": null,
       "updatedAt": "2026-04-19T10:33:35Z",
-      "contentHash": "646658ab71088fee0795183f6c2985648ca8aad9964ef16317220e35e4ffd660"
+      "contentHash": "39171711f8648daac5736cfabc132a718417a79615fc6c99e824c6b16f1243da"
     },
     "10031": {
       "state": "CLOSED",

--- a/resources/content/issues/issue-10030.md
+++ b/resources/content/issues/issue-10030.md
@@ -144,4 +144,85 @@ Origin Session ID: 496c0120-29aa-4b02-a804-d5a32ff6b5eb
 - 2026-04-19T10:31:51Z @tobiu cross-referenced by #10087
 - 2026-04-19T10:32:07Z @tobiu cross-referenced by #10088
 - 2026-04-19T10:32:31Z @tobiu added sub-issue #10085
+- 2026-04-19T10:32:32Z @tobiu added sub-issue #10086
+- 2026-04-19T10:32:35Z @tobiu added sub-issue #10087
+### @tobiu - 2026-04-19T10:33:35Z
+
+**Input from Claude Opus 4.7 (Claude Code):**
+
+> ❋ # Session Handoff — 2026-04-19 / Session `62d6f155-e57f-4279-9b59-36c9e4ecbc5e`
+> 
+> A2A Contextual Bridge per AGENTS.md §14. Future sessions picking up the Concept Ontology epic should find everything they need to boot efficiently here.
+> 
+> ## What Landed This Session
+> 
+> ### Directly scoped to #10030
+> 
+> - **#10033** (Concept Graph Unit Tests) → closed via PR [#10078](https://github.com/neomjs/neo/pull/10078). Closed four named-AC coverage gaps in the existing spec (root-tier assertion, coverage-annotation placement, production-graph line-count observability, explicit tier-ordering weight test). 23 tests total in `ConceptService.spec.mjs`.
+> - **#10035** (Graph Integration & GapInferenceEngine Refactor) → closed via PR [#10084](https://github.com/neomjs/neo/pull/10084). **Architectural Pillar shipped.** Replaces regex + per-match gemma4-31b LLM Boolean verification with deterministic concept-graph edge traversal. New `ConceptIngestor` daemon service wires the JSONL ontology into the Native Edge Graph as DreamService Phase 0. Adds `[EXAMPLE_GAP]` signal + display section in `sandman_handoff.md`. 30 tests pass.
+> 
+> ### Meta-infrastructure (not #10030-scoped but session-generated)
+> 
+> - **#10075** (memory-mining skill) → merged via PR [#10076](https://github.com/neomjs/neo/pull/10076). Promoted the memory-first reflex from rule-in-AGENTS.md to Progressive Disclosure skill. Also corrected `ask_knowledge_base` vs `query_documents` official tool descriptions in `openapi.yaml`.
+> 
+> ## Current Epic Status
+> 
+> ### Completed sub-issues
+> - ✅ **#10031** — JSONL Schema & Concept Seed Extraction
+> - ✅ **#10032** — ConceptService & Source Code Wiring
+> - ✅ **#10033** — Concept Graph Unit Tests *(closed this session)*
+> - ✅ **#10035** — Graph Integration & GapInferenceEngine Refactor *(closed this session)*
+> - ✅ **#10049** — Concept Schema Enrichment: Aliases, Analogous Edges
+> 
+> ### Open sub-issues (recommended pickup order)
+> 
+> | Priority | Sub-Issue | Complexity | Why this order |
+> |---|---|---|---|
+> | **1** | **#10085** — ConceptIngestor follow-ups (bundle) | Low | Polish from #10084's self-review: hoist concept-graph pass to cycle-scope, dedicated spec, observability, orphan warn consolidation. Same two files, natural single PR. Closes the #10035 loop cleanly. |
+> | **2** | **#10036** — Memory Core Concept Discovery | Medium | Unblocked by #10035 now that concept graph is in SQLite. Next natural consumer of the concept-graph infrastructure. |
+> | **3** | **#10034** — Concept Graph Visualization App | Medium | Neo.mjs app surfacing the concept ontology. Independent of #10036; can run in parallel. Good candidate for a Neo.mjs frontend-focused session. |
+> | **4** | **#10037** — ChromaDB Concept Embedding & Hybrid Search | Medium | Powers the relevance-bounded queries proposed in #10080 (separate ticket — see below). Do after #10085 lands so the stable concept-node contract is locked in. |
+> | **5** | **#10086** — Config-lift `guideGapWeightThreshold` | Tiny | Tiny scope (`config.template.mjs` + one import path). Any-session pickup. |
+> | **6** | **#10087** — ORPHAN_CONCEPT distinct display channel | Small | Promote from `logger.warn` to a first-class sandman_handoff section. Non-blocking; value grows with ontology size. |
+> | **7** | **#10050** — Concept Description Enrichment | Medium | ⚠️ **Blocked on human architect time per @tobiu's 2026-04-17 annotation** — agent-generated descriptions produce wrong results without architectural decision history (e.g., Data Worker case study). Collaborative session required. |
+> 
+> ### Open sub-issues NOT filed by this session but visible on the epic
+> 
+> - **#10050** — blocked (see above)
+> 
+> ## Related Tickets Not Parented Under #10030 (Worth Tracking)
+> 
+> These were filed this session but are broader than the Concept Ontology scope:
+> 
+> - **#10077** — `manage_issue_labels` MCP tool fails on PRs (bug — pre-existing)
+> - **#10079** — Broadened Hypothesis gate for written claims (skill strengthening — covers 5 claim classes observed this session)
+> - **#10080** — Relevance-bounded query APIs for ConceptService (will consume #10037's embeddings when ready)
+> - **#10081** — `ask_knowledge_base` query telemetry → Agent FAQ → Gap signal
+> - **#10082** — Strengthen `tech-debt-radar` for unbounded-list API detection (sub-issue of #10080)
+> - **#10083** — Audit AGENTS.md §9 "Single Full-Read Rule" for frontier-context-era relaxation
+> - **#10088** — Automate post-merge knowledge-base sync (solves recurring `[KB_GAP]` pattern)
+> - **#10089** — Document SQLite FK constraints on `Database.mjs#addEdge` JSDoc
+> 
+> ## Durable Lessons Captured This Session
+> 
+> Three feedback memory files written to the Agent OS's persistent cross-session memory:
+> 
+> - **`feedback_ask_kb_dominates_query_documents.md`** — empirically verified `ask_knowledge_base` returns synthesized answer PLUS the same top-5 refs `query_documents` returns. Reserve the latter only for exhaustive enumeration beyond top-5.
+> - **`feedback_challenge_numerical_thresholds_in_acs.md`** — hardcoded numerical thresholds in AC items (`≤ N lines`, `at most N ms`) trigger the Hypothesis gate. Prefer observability + architectural-layer assertions over format-layer caps.
+> - **`feedback_verify_written_claims_against_precedent.md`** — five distinct sub-classes of "accept written claim without verifying precedent" observed + remediations for each. Covers numerical, architectural, tool-routing, self-inferred-policy, and wrong-grounding-assumption classes.
+> 
+> ## What to Know for the Next Session
+> 
+> 1. **Opus 4.7 has 1M context** — earlier session-management rules calibrated for smaller models may be over-conservative (see #10083). Don't blindly apply "fresh session per Architectural Pillar" — semantic locality usually wins.
+> 2. **Gemma 4 31B is frontier-class (85.2% MMLU Pro, distilled from Gemini 3)** — don't frame SLM design decisions as "SLM is weak." Frame them correctly: deterministic code over LLM inference is about *curated data being the source of truth*, not capability.
+> 3. **The concept graph is the authoritative source for "does concept X have a guide?"** — via `EXPLAINED_BY` edges. Do not re-introduce regex-based or LLM-based guide matching. Gap detection is now deterministic.
+> 4. **Stub-node seeding is a requirement for any SQLite edge insertion** — the FK constraint is enforced at storage layer. Use `ConceptIngestor.ensureEdgeTargetsExist` as the pattern.
+> 5. **Invoke the memory-mining skill BEFORE diagnostics or architectural claims** — the skill exists for exactly the failure modes observed this session.
+> 
+> ## Origin Session ID
+> 
+> `62d6f155-e57f-4279-9b59-36c9e4ecbc5e`
+> 
+
+- 2026-04-19T11:09:50Z @tobiu cross-referenced by #10090
 

--- a/resources/content/issues/issue-9486.md
+++ b/resources/content/issues/issue-9486.md
@@ -181,4 +181,19 @@ Resolved: Stabilized Grid Multi-Body Architecture by decoupling column instantia
 - 2026-03-31T20:22:36Z @tobiu added sub-issue #9616
 - 2026-03-31T20:45:04Z @tobiu cross-referenced by #9617
 - 2026-03-31T20:45:12Z @tobiu added sub-issue #9617
+- 2026-04-01T10:22:33Z @tobiu added sub-issue #9618
+- 2026-04-01T17:27:58Z @tobiu added sub-issue #9619
+- 2026-04-01T17:36:58Z @tobiu added sub-issue #9620
+- 2026-04-01T19:56:36Z @tobiu added sub-issue #9622
+- 2026-04-01T20:03:31Z @tobiu added sub-issue #9623
+- 2026-04-01T20:25:38Z @tobiu added sub-issue #9624
+- 2026-04-01T21:01:59Z @tobiu added sub-issue #9625
+- 2026-04-01T21:42:18Z @tobiu added sub-issue #9614
+- 2026-04-02T08:17:16Z @tobiu added sub-issue #9626
+- 2026-04-02T22:54:09Z @tobiu added sub-issue #9635
+- 2026-04-02T23:02:31Z @tobiu added sub-issue #9636
+- 2026-04-02T23:02:43Z @tobiu added sub-issue #9637
+- 2026-04-09T21:18:42Z @tobiu cross-referenced by #9839
+- 2026-04-10T16:35:19Z @tobiu added sub-issue #9868
+- 2026-04-10T18:19:43Z @tobiu added sub-issue #9872
 

--- a/resources/content/issues/issue-9535.md
+++ b/resources/content/issues/issue-9535.md
@@ -8,7 +8,7 @@ createdAt: '2026-03-23T17:46:41Z'
 updatedAt: '2026-04-01T02:28:35Z'
 githubUrl: 'https://github.com/neomjs/neo/issues/9535'
 author: claude-opus-4-5
-commentsCount: 11
+commentsCount: 10
 parentIssue: null
 subIssues: []
 subIssuesCompleted: 0
@@ -172,7 +172,6 @@ I'll create a coordination issue in our `agent-interaction-log` repo to track Po
 
 — Claude Opus 4.5, Primary Contact for AI Village
 
-- 2026-03-23T18:49:24Z @claude-sonnet-4-6 cross-referenced by #8
 ### @tobiu - 2026-03-23T18:59:48Z
 
 **Input from Gemini 3.1 Pro:**
@@ -367,8 +366,6 @@ note from tobiu: looks like taggings inside the previous ticket comment were bro
 > 
 > Let us know if your runners are ready to connect over SSE, and we can provide the production sandbox URL.
 
-### @garygegpt-droid - 2026-04-01T02:28:35Z
-
-Great initiative! For AI-to-AI memory sharing, consider how each agent would maintain its own identity while sharing context. https://github.com/garygegpt-droid/memory-skill has a tiered architecture where core identity persists separately from shared context - useful when multiple AI agents need to communicate without losing their individual personalities. Also consider how agent relationships (trust, collaboration history) should be remembered across sessions.
-
+- 2026-04-10T08:33:15Z @tobiu cross-referenced by #9846
+- 2026-04-18T23:01:05Z @tobiu cross-referenced by #10074
 

--- a/resources/content/issues/issue-9999.md
+++ b/resources/content/issues/issue-9999.md
@@ -100,4 +100,12 @@ To support both rapid local development and scalable enterprise clusters, we are
 - 2026-04-16T18:44:58Z @tobiu removed sub-issue #10014
 - 2026-04-17T07:27:26Z @tobiu cross-referenced by PR #10047
 - 2026-04-17T13:08:56Z @tobiu cross-referenced by PR #10048
+- 2026-04-18T14:22:18Z @tobiu cross-referenced by #10061
+- 2026-04-18T14:38:10Z @tobiu cross-referenced by PR #10062
+- 2026-04-18T14:57:24Z @tobiu cross-referenced by #10063
+- 2026-04-18T18:11:51Z @tobiu added sub-issue #10057
+- 2026-04-18T18:11:52Z @tobiu cross-referenced by #10057
+- 2026-04-18T18:15:34Z @tobiu cross-referenced by PR #10066
+- 2026-04-18T23:01:05Z @tobiu cross-referenced by #10074
+- 2026-04-19T09:43:06Z @tobiu cross-referenced by #10079
 

--- a/test/playwright/unit/ai/mcp/server/github-workflow/IssueSyncer.spec.mjs
+++ b/test/playwright/unit/ai/mcp/server/github-workflow/IssueSyncer.spec.mjs
@@ -1,0 +1,168 @@
+import {setup} from '../../../../../setup.mjs';
+
+const appName = 'IssueSyncerTest';
+
+setup({
+    neoConfig: {
+        unitTestMode: true
+    },
+    appConfig: {
+        name             : appName,
+        isMounted        : () => true,
+        vnodeInitialising: false
+    }
+});
+
+import {test, expect}  from '@playwright/test';
+import Neo             from '../../../../../../../src/Neo.mjs';
+import * as core       from '../../../../../../../src/core/_export.mjs';
+import InstanceManager from '../../../../../../../src/manager/Instance.mjs';
+import fs              from 'fs-extra';
+import path            from 'path';
+
+/**
+ * @summary Regression coverage for the timelineItems pagination fix in IssueSyncer (#10090).
+ *
+ * Builds a mocked GitHub issue whose `timelineItems` connection has 75 events split across
+ * two pages — more than `maxTimelineItemsPerIssue` (50) — and drives the refetch path to
+ * confirm that every comment body and structural event makes it into the rendered markdown.
+ * Before the fix, the second-page tail was silently dropped.
+ */
+test.describe('Neo.ai.mcp.server.github-workflow.services.sync.IssueSyncer', () => {
+    let IssueSyncer;
+    let GraphqlService;
+    let issueSyncConfig;
+    let originalQuery;
+    let tmpIssuesDir;
+
+    test.beforeAll(async () => {
+        const aiConfig = (await import('../../../../../../../ai/mcp/server/github-workflow/config.mjs')).default;
+        issueSyncConfig = aiConfig.issueSync;
+
+        tmpIssuesDir = path.resolve(process.cwd(), 'tmp', `issue-syncer-test-${process.pid}-${Date.now()}`);
+        await fs.ensureDir(tmpIssuesDir);
+
+        // Redirect local markdown writes to the tmp dir so the test does not pollute
+        // the real resources/content/issues tree.
+        issueSyncConfig.issuesDir = tmpIssuesDir;
+
+        GraphqlService = (await import('../../../../../../../ai/mcp/server/github-workflow/services/GraphqlService.mjs')).default;
+        IssueSyncer    = (await import('../../../../../../../ai/mcp/server/github-workflow/services/sync/IssueSyncer.mjs')).default;
+
+        originalQuery = GraphqlService.query.bind(GraphqlService);
+    });
+
+    test.afterAll(async () => {
+        GraphqlService.query = originalQuery;
+        await fs.remove(tmpIssuesDir).catch(() => {});
+    });
+
+    test('refetchIssuesByNumber paginates timeline and renders all events past the page cap', async () => {
+        const PAGE_SIZE    = issueSyncConfig.maxTimelineItemsPerIssue; // 50
+        const TOTAL_EVENTS = 75;
+        const FIRST_PAGE   = Array.from({length: PAGE_SIZE}, (_, i) => buildComment(i));
+        const SECOND_PAGE  = Array.from({length: TOTAL_EVENTS - PAGE_SIZE}, (_, i) => buildCrossRef(PAGE_SIZE + i));
+
+        // Minimal GraphQL issue shape that IssueSyncer.#formatIssueMarkdown accepts.
+        const mockIssue = {
+            number   : 42042,
+            title    : 'Mock issue — pagination regression #10090',
+            body     : 'This is the mock issue body.',
+            state    : 'OPEN',
+            createdAt: '2026-04-19T00:00:00Z',
+            updatedAt: '2026-04-19T12:00:00Z',
+            closedAt : null,
+            url      : 'https://github.com/neomjs/neo/issues/42042',
+            author   : {login: 'tobiu'},
+            labels   : {nodes: [{name: 'bug'}]},
+            assignees: {nodes: [{login: 'tobiu'}]},
+            milestone: null,
+            comments : {totalCount: PAGE_SIZE},
+            parent   : null,
+            subIssues        : {nodes: []},
+            subIssuesSummary : {total: 0, completed: 0, percentCompleted: 0},
+            blockedBy        : {nodes: []},
+            blocking         : {nodes: []},
+            timelineItems    : {
+                pageInfo: {hasNextPage: true, endCursor: 'cursor-page-1'},
+                nodes   : FIRST_PAGE
+            }
+        };
+
+        // Counts how many continuation calls the pagination primitive made.
+        let continuationCalls = 0;
+
+        GraphqlService.query = async (query, variables) => {
+            // FETCH_SINGLE_ISSUE: return the first-page view of the mock issue.
+            if (query.includes('FetchSingleIssue')) {
+                return {
+                    repository: {
+                        issue: structuredClone(mockIssue)
+                    }
+                };
+            }
+
+            // FETCH_ISSUE_TIMELINE_PAGE: serve the continuation page.
+            if (query.includes('FetchIssueTimelinePage')) {
+                continuationCalls++;
+                return {
+                    repository: {
+                        issue: {
+                            timelineItems: {
+                                pageInfo: {hasNextPage: false, endCursor: null},
+                                nodes   : SECOND_PAGE
+                            }
+                        }
+                    },
+                    rateLimit: {cost: 1, remaining: 5000, resetAt: '2026-04-19T13:00:00Z'}
+                };
+            }
+
+            throw new Error(`Unexpected GraphQL query in test: ${query.slice(0, 80)}`);
+        };
+
+        const metadata = {issues: {}};
+        const stats    = await IssueSyncer.refetchIssuesByNumber([mockIssue.number], metadata);
+
+        expect(stats.refetched.count).toBe(1);
+        expect(stats.refetched.issues).toContain(mockIssue.number);
+        expect(stats.errors).toHaveLength(0);
+        expect(continuationCalls).toBe(1);
+
+        const writtenPath = path.join(tmpIssuesDir, `issue-${mockIssue.number}.md`);
+        const written     = await fs.readFile(writtenPath, 'utf-8');
+
+        // Every comment body must appear — the bug being fixed is that second-page comments
+        // were silently dropped.
+        const commentHeaders = written.match(/^### @mockuser\d+ - /gm) || [];
+        expect(commentHeaders).toHaveLength(PAGE_SIZE);
+
+        // Every cross-reference event on the second page must appear too.
+        const eventLines = written.match(/^- 2026-04-19T[^ ]+ @tobiu cross-referenced by #\d+$/gm) || [];
+        expect(eventLines).toHaveLength(TOTAL_EVENTS - PAGE_SIZE);
+
+        // And frontmatter must reflect the metadata channel unchanged.
+        expect(written).toContain(`id: ${mockIssue.number}`);
+        expect(written).toContain(`commentsCount: ${PAGE_SIZE}`);
+    });
+});
+
+function buildComment(i) {
+    const minute = String(i).padStart(2, '0');
+    return {
+        __typename: 'IssueComment',
+        createdAt : `2026-04-19T10:${minute}:00Z`,
+        author    : {login: `mockuser${i}`},
+        body      : `Mock comment body #${i}.`
+    };
+}
+
+function buildCrossRef(i) {
+    const minute = String(i).padStart(2, '0');
+    return {
+        __typename: 'CrossReferencedEvent',
+        createdAt : `2026-04-19T11:${minute}:00Z`,
+        actor     : {login: 'tobiu'},
+        source    : {__typename: 'Issue', number: 10000 + i}
+    };
+}


### PR DESCRIPTION
## Summary

IssueSyncer silently truncated issue content once the \`timelineItems\` GraphQL connection grew past \`maxTimelineItemsPerIssue\` (50). Comment 4275716860 on Epic #10030 — a session handoff authored 2026-04-19T10:33:35Z — was lost this way: local frontmatter received correct \`updatedAt\` and \`commentsCount: 2\`, but the comment body never landed. The sync engine reported success.

Since the unified-timeline refactor (#8527 / #8528, Jan 2026), \`IssueSyncer.#formatTimelineEvent\` renders \`IssueComment\` events inline through the \`issue.timelineItems.nodes\` channel. GitHub orders that connection oldest-first with no \`orderBy\`, so \`first: 50\` dropped the tail. The metadata channel (scalar \`updatedAt\`, \`comments.totalCount\`) kept looking healthy — a divergence between metadata tracking and content rendering with no guard to surface it. PR-based workflow accelerates the trigger since each PR cross-references the Epic.

## Architectural Reality

- Scalar frontmatter fields (\`updatedAt\`, \`commentsCount\`) were always correct; rendered timeline entries were silently short.
- REST \`/issues/10030/timeline\` showed 55 events; local file capped at 50, matching the \`maxTimelineItemsPerIssue\` default exactly.
- Files touched live inside the MCP server tree but the detector + recovery glue live at \`ai/scripts/\` and consume the \`ai/services.mjs\` SDK facade (\`GH_SyncService\`, \`GH_IssueService\`). This respects the ongoing migration of services out of \`ai/mcp/server/\`; when IssueSyncer eventually moves, only the SDK re-exports shift and the scripts stay stable.

## Fix (option B — pagination)

- **\`issueQueries.mjs\`** — added \`pageInfo { hasNextPage endCursor }\` on \`timelineItems\` in both \`FETCH_ISSUES_FOR_SYNC\` and \`FETCH_SINGLE_ISSUE\`; introduced \`FETCH_ISSUE_TIMELINE_PAGE\` as the continuation query.
- **\`IssueSyncer.mjs\`** — new private \`#exhaustTimelineItems(issue)\` primitive loops continuation pages until \`hasNextPage === false\` and emits \`logger.warn\` when pagination actually kicks in (silent failure was the root issue; observability is non-negotiable). Extracted the existing inline force-refetch loop into a reusable \`refetchIssuesByNumber(numbers, metadata)\` method. Both pullFromGitHub and external tooling share the one code path.
- **\`SyncService.mjs\`** — exposes \`refetchIssuesByNumber({numbers})\` as the SDK entry for surgical recovery bypassing delta-sync \`updatedAt\` gating.

## Tooling

- **\`ai/scripts/detectTruncatedTimelines.mjs\`** — walks \`resources/content/issues/*.md\` (archives skipped by design) and flags files where frontmatter \`commentsCount\` exceeds rendered \`### @login - <ISO>\` comment blocks, or where total rendered timeline entries sit exactly at the cap. JSON mode pipes straight into the recovery script.
- **\`ai/scripts/refetchTruncatedIssues.mjs\`** — accepts a list of numbers or \`--stdin\` JSON from the detector and calls \`GH_SyncService.refetchIssuesByNumber\`. No MCP tool added; matches the \`analyzeNlTelemetry.mjs\` precedent at \`ai/scripts/\`.

## Avoided Traps

- **Bump cap to 250 and move on.** Deferred pain is still pain; PR-accelerated growth would reach 250 too. Silent truncation would remain possible.
- **Decouple comments from timeline via separate pagination + merge at render.** Duplicates render logic. Paginating the single unified connection hits the same correctness with one code path.
- **Make the detector an MCP tool.** Admin-initiated + rare; MCP tool budget is 77/100. A standalone script is right-sized.
- **Full \`sync_all\` for recovery.** Delta sync gates on per-issue \`updatedAt\`, which did NOT change when truncation occurred. Blanket sync wouldn't heal affected files.

## Baseline + Recovery

Detector found 4 affected issues on \`dev\`:

| Issue | Evidence pre-fix |
|---|---|
| #10030 | 50 rendered, 55 on REST; missing 2026-04-19 handoff comment |
| #9486  | 50 rendered, 65 on REST |
| #9999  | 50 rendered, 58 on REST |
| #9535  | 7 rendered, 11 in frontmatter (anomaly — see Follow-ups) |

All four healed via \`refetchIssuesByNumber\` — committed as part of this PR. Post-fix detector reports zero affected issues.

## Acceptance Criteria

- [x] \`ai/scripts/detectTruncatedTimelines.mjs\` scans active issues only; primary signal \`commentsCount > rendered comment blocks\`; secondary heuristic \`totalRendered === cap\`
- [x] \`issueQueries.mjs\` exposes \`pageInfo\` on \`timelineItems\` + adds continuation query
- [x] \`IssueSyncer\` paginates until \`hasNextPage === false\`, warn-logs on continuation
- [x] \`refetchIssuesByNumber(numbers, metadata)\` extracted + exposed via \`GH_SyncService\`
- [x] Playwright spec covers 75-event mocked issue — passes (532ms)
- [x] Post-fix detector run reports zero affected issues
- [x] \`issue-10030.md\` body contains the 2026-04-19 handoff comment — regression proof

## Follow-ups

- **#9535 anomaly** — surfaced but out-of-scope. Its local frontmatter was \`commentsCount: 11\` while live GraphQL reported 10. A comment was deleted on GitHub, and GitHub does not bump \`issue.updatedAt\` on comment deletion, so delta sync never revisited and the stale state stuck. The refetch healed #9535 incidentally (idempotent), but the root-cause invalidation gap is a separate bug class analogous to the \`SubIssueAddedEvent\` fix in #7948. Will be filed as a follow-up ticket.
- **Detector split bug** — during verification I found my initial detector used \`content.split('## Timeline')\` as a string split, which also matched inside a comment body containing \`### Timeline & Next Steps\`. Fixed in this PR to use a line-anchored regex (\`/^## Timeline$/m\`). Minor polish, caught before PR per the Stepping Back protocol.

## Test plan

- [x] \`npm run test-unit -- test/playwright/unit/ai/mcp/server/github-workflow/IssueSyncer.spec.mjs\` (passes)
- [x] Detector post-fix: zero affected issues
- [x] Manual verification that #10030 now contains \`**Input from Claude Opus 4.7 (Claude Code):**\` and both comments render
- [ ] (Reviewer) Spot-check healed content in #9486, #9999, #9535 against GitHub

Resolves #10090