### PR TITLE
fix(github-workflow): sentinel sweep for comment-deletion drift (#10092)

### DIFF
--- a/ai/mcp/server/github-workflow/config.template.mjs
+++ b/ai/mcp/server/github-workflow/config.template.mjs
@@ -180,7 +180,15 @@ const defaultConfig = {
          * Maximum number of timeline items to fetch per issue in GraphQL queries.
          * @type {number}
          */
-        maxTimelineItemsPerIssue: 50
+        maxTimelineItemsPerIssue: 50,
+        /**
+         * Batch size for the stale-comments-count sentinel sweep (#10092).
+         * Controls how many issues are queried via aliased GraphQL fields per request.
+         * Stay below GitHub's per-query complexity limit (~500 nodes). Each issue costs
+         * ~3 complexity units here, so 100 is a safe default.
+         * @type {number}
+         */
+        staleCommentsBatchSize: 100
     },
     /**
      * Configuration for pull request queries.

--- a/ai/mcp/server/github-workflow/services/SyncService.mjs
+++ b/ai/mcp/server/github-workflow/services/SyncService.mjs
@@ -101,6 +101,19 @@ class SyncService extends Base {
         // 4. Pull remote changes
         const { newMetadata, stats: pullStats } = await IssueSyncer.pullFromGitHub(metadata);
 
+        // 4b. Sentinel sweep for updatedAt-blind drift (comment deletions — #10092).
+        //     Runs AFTER the delta pull so newly-refreshed entries have current commentsTotal
+        //     and only genuinely-drifted issues survive as mismatches into the refetch step.
+        const staleCountsStats = await IssueSyncer.detectStaleCommentsCounts(newMetadata);
+        if (staleCountsStats.stale.length > 0) {
+            const staleNumbers = staleCountsStats.stale.map(s => s.number);
+            logger.warn(`🔍 Comment-count drift detected on ${staleNumbers.length} issue(s): ${staleNumbers.join(', ')}`);
+            const refetchStats = await IssueSyncer.refetchIssuesByNumber(staleNumbers, newMetadata);
+            pullStats.pulled.count   += refetchStats.refetched.count;
+            pullStats.pulled.updated += refetchStats.refetched.count;
+            pullStats.pulled.issues.push(...refetchStats.refetched.issues);
+        }
+
         // 5. Sync release notes
         const releaseStats = await ReleaseSyncer.syncNotes(metadata);
 
@@ -161,13 +174,19 @@ class SyncService extends Base {
         const durationMs = endTime - startTime;
 
         const finalStats = {
-            reconciled : reconcileStats,
-            pushed     : pushStats,
-            pulled     : pullStats.pulled,
-            dropped    : pullStats.dropped,
-            releases   : releaseStats,
-            discussions: discussionStats,
-            pulls      : pullStats2
+            reconciled  : reconcileStats,
+            pushed      : pushStats,
+            pulled      : pullStats.pulled,
+            dropped     : pullStats.dropped,
+            releases    : releaseStats,
+            discussions : discussionStats,
+            pulls       : pullStats2,
+            staleCounts : {
+                checked: staleCountsStats.checked,
+                stale  : staleCountsStats.stale.length,
+                seeded : staleCountsStats.seeded,
+                errors : staleCountsStats.errors.length
+            }
         };
 
         const timing = {
@@ -184,6 +203,7 @@ class SyncService extends Base {
         logger.info(`   Releases:    ${finalStats.releases.count} synced`);
         logger.info(`   Discussions: ${finalStats.discussions.count} synced`);
         logger.info(`   Pulls:       ${finalStats.pulls.count} synced`);
+        logger.info(`   StaleCounts: ${finalStats.staleCounts.checked} checked, ${finalStats.staleCounts.stale} drifted, ${finalStats.staleCounts.seeded} seeded${finalStats.staleCounts.errors > 0 ? `, ${finalStats.staleCounts.errors} errors` : ''}`);
         logger.info(`   Duration:    ${Math.round(timing.durationMs / 1000)}s`);
 
         return {

--- a/ai/mcp/server/github-workflow/services/queries/issueQueries.mjs
+++ b/ai/mcp/server/github-workflow/services/queries/issueQueries.mjs
@@ -613,6 +613,38 @@ export const FETCH_SINGLE_ISSUE = `
 `;
 
 /**
+ * @summary Builds a batched GraphQL query that fetches `comments.totalCount` for an
+ * arbitrary list of issue numbers in a single request, using aliased fields.
+ *
+ * This is the detection primitive for the comment-deletion sentinel sweep (#10092).
+ * Standard delta-sync is blind to deletions because GitHub does not bump
+ * `issue.updatedAt` when a comment is removed. A periodic totals sweep compares the
+ * live totalCount against the stored `commentsTotal` in metadata and force-refetches
+ * any mismatches via `refetchIssuesByNumber`.
+ *
+ * Uses GraphQL field aliasing (`issue42: issue(number: 42) { ... }`) so that N issues
+ * can be queried in one trip. Query complexity is ~3 × N — safely under GitHub's
+ * per-request limit for batches up to ~150. Caller is responsible for chunking.
+ *
+ * @param {number[]} numbers The issue numbers to fetch totals for.
+ * @returns {string} The composed GraphQL query string.
+ */
+export function buildIssueTotalsBatchQuery(numbers) {
+    const aliasedFields = numbers
+        .map(n => `    issue${n}: issue(number: ${n}) { number comments { totalCount } }`)
+        .join('\n');
+
+    return `
+  query FetchIssueTotalsBatch($owner: String!, $repo: String!) {
+    repository(owner: $owner, name: $repo) {
+${aliasedFields}
+    }
+    rateLimit { cost remaining resetAt }
+  }
+`;
+}
+
+/**
  * Continuation query for a single issue's timelineItems connection.
  *
  * Used by IssueSyncer when an issue's timeline exceeds one page of \`maxTimelineItems\` —

--- a/ai/mcp/server/github-workflow/services/sync/IssueSyncer.mjs
+++ b/ai/mcp/server/github-workflow/services/sync/IssueSyncer.mjs
@@ -7,8 +7,8 @@ import matter                                        from 'gray-matter';
 import path                                          from 'path';
 import GraphqlService                                from '../GraphqlService.mjs';
 import ReleaseSyncer                                 from './ReleaseSyncer.mjs';
-import {FETCH_ISSUE_TIMELINE_PAGE, FETCH_ISSUES_FOR_SYNC, FETCH_SINGLE_ISSUE} from '../queries/issueQueries.mjs';
-import {GET_ISSUE_ID, UPDATE_ISSUE}                                            from '../queries/mutations.mjs';
+import {buildIssueTotalsBatchQuery, FETCH_ISSUE_TIMELINE_PAGE, FETCH_ISSUES_FOR_SYNC, FETCH_SINGLE_ISSUE} from '../queries/issueQueries.mjs';
+import {GET_ISSUE_ID, UPDATE_ISSUE}                                                                        from '../queries/mutations.mjs';
 
 const issueSyncConfig = aiConfig.issueSync;
 const lineBreaksRegex = /[\r\n]+/g;
@@ -440,13 +440,14 @@ class IssueSyncer extends Base {
             }
 
             newMetadata.issues[issueNumber] = {
-                state    : issue.state,
-                path     : this.#relativePath(targetPath), // Store relative path
-                updatedAt: issue.updatedAt,
-                closedAt : issue.closedAt || null,
-                milestone: issue.milestone?.title || null,
-                title    : issue.title,
-                contentHash // Store hash for push comparison
+                state        : issue.state,
+                path         : this.#relativePath(targetPath), // Store relative path
+                updatedAt    : issue.updatedAt,
+                closedAt     : issue.closedAt || null,
+                milestone    : issue.milestone?.title || null,
+                title        : issue.title,
+                contentHash,                                    // Store hash for push comparison
+                commentsTotal: issue.comments?.totalCount ?? 0  // Sentinel for comment-deletion drift (#10092)
             };
         }
 
@@ -582,13 +583,14 @@ class IssueSyncer extends Base {
                 logger.info(`✅ Refetched issue #${issueNumber}`);
 
                 metadata.issues[issueNumber] = {
-                    state    : issue.state,
-                    path     : this.#relativePath(targetPath),
-                    updatedAt: issue.updatedAt,
-                    closedAt : issue.closedAt || null,
-                    milestone: issue.milestone?.title || null,
-                    title    : issue.title,
-                    contentHash
+                    state        : issue.state,
+                    path         : this.#relativePath(targetPath),
+                    updatedAt    : issue.updatedAt,
+                    closedAt     : issue.closedAt || null,
+                    milestone    : issue.milestone?.title || null,
+                    title        : issue.title,
+                    contentHash,
+                    commentsTotal: issue.comments?.totalCount ?? 0
                 };
             } catch (e) {
                 logger.error(`Failed to refetch issue #${issueNumber}: ${e.message}`);
@@ -597,6 +599,72 @@ class IssueSyncer extends Base {
         }
 
         return stats;
+    }
+
+    /**
+     * @summary Sentinel sweep that detects comment-deletion drift invisible to delta sync.
+     *
+     * Delta-sync uses `issue.updatedAt` as the invalidation signal, and GitHub does **not**
+     * bump `updatedAt` when a comment is deleted. The local markdown and metadata therefore
+     * retain stale `commentsCount` indefinitely — the pattern that kept issue #9535 frozen
+     * during the #10090 investigation. The timeline-scan workaround from #7948 does not
+     * transfer because GraphQL exposes no `ISSUE_COMMENT_DELETED_EVENT` type.
+     *
+     * This sweep compares live `issue.comments.totalCount` against the stored
+     * `commentsTotal` sentinel in metadata for every tracked issue, in a single batched
+     * GraphQL request via `buildIssueTotalsBatchQuery`. Mismatches are handed to
+     * `refetchIssuesByNumber`, which is the same recovery primitive introduced in #10090.
+     *
+     * First-run semantics (lazy seeding): entries without `commentsTotal` are seeded
+     * in place from the live value without triggering a refetch. This lets the sentinel
+     * graduate cleanly on pre-existing metadata without one-shot refetch storms.
+     *
+     * @param {object} metadata The sync metadata object. Mutated in place to seed missing
+     *                          `commentsTotal` fields. Caller is responsible for persisting.
+     * @returns {Promise<{checked: number, stale: Array<{number: number, stored: number, live: number}>, seeded: number, errors: Array<{error: string, batch: number[]}>}>}
+     */
+    async detectStaleCommentsCounts(metadata) {
+        const issueNumbers = Object.keys(metadata.issues).map(Number).filter(n => Number.isInteger(n));
+        const result       = {checked: 0, stale: [], seeded: 0, errors: []};
+
+        if (issueNumbers.length === 0) return result;
+
+        const batchSize = issueSyncConfig.staleCommentsBatchSize || 100;
+
+        for (let i = 0; i < issueNumbers.length; i += batchSize) {
+            const batch = issueNumbers.slice(i, i + batchSize);
+            try {
+                const data = await GraphqlService.query(
+                    buildIssueTotalsBatchQuery(batch),
+                    {owner: aiConfig.owner, repo: aiConfig.repo},
+                    true
+                );
+
+                result.checked += batch.length;
+
+                for (const num of batch) {
+                    const node = data.repository[`issue${num}`];
+                    if (!node) continue; // Issue no longer exists on GitHub; drop handled elsewhere.
+
+                    const liveTotal   = node.comments.totalCount;
+                    const entry       = metadata.issues[num];
+                    const storedTotal = entry?.commentsTotal;
+
+                    if (storedTotal === undefined || storedTotal === null) {
+                        // Lazy seed: populate sentinel without triggering a refetch.
+                        entry.commentsTotal = liveTotal;
+                        result.seeded++;
+                    } else if (storedTotal !== liveTotal) {
+                        result.stale.push({number: num, stored: storedTotal, live: liveTotal});
+                    }
+                }
+            } catch (e) {
+                logger.error(`Stale-counts batch query failed for ${batch.length} issues: ${e.message}`);
+                result.errors.push({error: e.message, batch});
+            }
+        }
+
+        return result;
     }
 
     /**

--- a/ai/mcp/server/github-workflow/services/sync/MetadataManager.mjs
+++ b/ai/mcp/server/github-workflow/services/sync/MetadataManager.mjs
@@ -75,11 +75,16 @@ class MetadataManager extends Base {
         // Prune issues
         for (const [key, value] of Object.entries(metadata.issues)) {
             prunedMetadata.issues[key] = {
-                state      : value.state,
-                path       : value.path,
-                closedAt   : value.closedAt,
-                updatedAt  : value.updatedAt,
-                contentHash: value.contentHash
+                state        : value.state,
+                path         : value.path,
+                closedAt     : value.closedAt,
+                updatedAt    : value.updatedAt,
+                contentHash  : value.contentHash,
+                // commentsTotal is the sentinel field that the stale-counts sweep compares against
+                // live GitHub state to catch updatedAt-blind drift (notably comment deletions — see
+                // #10092). May be undefined on pre-migration entries; detectStaleCommentsCounts seeds
+                // missing values lazily without triggering a refetch.
+                commentsTotal: value.commentsTotal
             };
         }
 

--- a/test/playwright/unit/ai/mcp/server/github-workflow/IssueSyncer.spec.mjs
+++ b/test/playwright/unit/ai/mcp/server/github-workflow/IssueSyncer.spec.mjs
@@ -57,6 +57,100 @@ test.describe('Neo.ai.mcp.server.github-workflow.services.sync.IssueSyncer', () 
         await fs.remove(tmpIssuesDir).catch(() => {});
     });
 
+    test('detectStaleCommentsCounts lazily seeds entries missing the sentinel', async () => {
+        const metadata = {
+            issues: {
+                100: {state: 'OPEN', commentsTotal: undefined},
+                101: {state: 'OPEN', commentsTotal: undefined}
+            }
+        };
+
+        GraphqlService.query = async (query) => {
+            if (query.includes('FetchIssueTotalsBatch')) {
+                return {
+                    repository: {
+                        issue100: {number: 100, comments: {totalCount: 5}},
+                        issue101: {number: 101, comments: {totalCount: 3}}
+                    },
+                    rateLimit: {cost: 1, remaining: 5000, resetAt: ''}
+                };
+            }
+            throw new Error(`Unexpected GraphQL query: ${query.slice(0, 80)}`);
+        };
+
+        const result = await IssueSyncer.detectStaleCommentsCounts(metadata);
+
+        expect(result.checked).toBe(2);
+        expect(result.seeded).toBe(2);
+        expect(result.stale).toHaveLength(0);
+        expect(result.errors).toHaveLength(0);
+        expect(metadata.issues[100].commentsTotal).toBe(5);
+        expect(metadata.issues[101].commentsTotal).toBe(3);
+    });
+
+    test('detectStaleCommentsCounts reports no drift when live totals match stored sentinels', async () => {
+        const metadata = {
+            issues: {
+                200: {state: 'OPEN', commentsTotal: 4},
+                201: {state: 'OPEN', commentsTotal: 7}
+            }
+        };
+
+        GraphqlService.query = async (query) => {
+            if (query.includes('FetchIssueTotalsBatch')) {
+                return {
+                    repository: {
+                        issue200: {number: 200, comments: {totalCount: 4}},
+                        issue201: {number: 201, comments: {totalCount: 7}}
+                    },
+                    rateLimit: {cost: 1, remaining: 5000, resetAt: ''}
+                };
+            }
+            throw new Error(`Unexpected GraphQL query: ${query.slice(0, 80)}`);
+        };
+
+        const result = await IssueSyncer.detectStaleCommentsCounts(metadata);
+
+        expect(result.checked).toBe(2);
+        expect(result.seeded).toBe(0);
+        expect(result.stale).toHaveLength(0);
+        expect(result.errors).toHaveLength(0);
+    });
+
+    test('detectStaleCommentsCounts reports drift when live totalCount diverges from stored sentinel', async () => {
+        // This is the #9535 scenario: a comment was deleted on GitHub, updatedAt did not bump,
+        // so the local frontmatter still says commentsCount: 11 while live reports 10.
+        const metadata = {
+            issues: {
+                300: {state: 'OPEN', commentsTotal: 11},
+                301: {state: 'OPEN', commentsTotal: 4} // unchanged; should NOT appear in stale
+            }
+        };
+
+        GraphqlService.query = async (query) => {
+            if (query.includes('FetchIssueTotalsBatch')) {
+                return {
+                    repository: {
+                        issue300: {number: 300, comments: {totalCount: 10}}, // deletion detected
+                        issue301: {number: 301, comments: {totalCount: 4}}
+                    },
+                    rateLimit: {cost: 1, remaining: 5000, resetAt: ''}
+                };
+            }
+            throw new Error(`Unexpected GraphQL query: ${query.slice(0, 80)}`);
+        };
+
+        const result = await IssueSyncer.detectStaleCommentsCounts(metadata);
+
+        expect(result.checked).toBe(2);
+        expect(result.seeded).toBe(0);
+        expect(result.stale).toHaveLength(1);
+        expect(result.stale[0]).toEqual({number: 300, stored: 11, live: 10});
+        expect(result.errors).toHaveLength(0);
+        // Stored sentinel is NOT mutated; refetchIssuesByNumber handles the authoritative update.
+        expect(metadata.issues[300].commentsTotal).toBe(11);
+    });
+
     test('refetchIssuesByNumber paginates timeline and renders all events past the page cap', async () => {
         const PAGE_SIZE    = issueSyncConfig.maxTimelineItemsPerIssue; // 50
         const TOTAL_EVENTS = 75;


### PR DESCRIPTION
## Summary

Delta-sync uses `issue.updatedAt` as its invalidation signal, and GitHub does **not** bump `updatedAt` when a comment is deleted. Affected local files keep stale `commentsCount` + stale comment bodies indefinitely — the mode that kept #9535 frozen for weeks during the #10090 investigation. GraphQL exposes no `ISSUE_COMMENT_DELETED_EVENT`, so the timeline-scan pattern from #7948 (for sub-issue / blocking relationship drift) does not transfer here.

This PR adds the option-B "totals-only sentinel" approach from the #10092 ticket: a batched GraphQL query that compares live `comments.totalCount` against a new stored `commentsTotal` sentinel in metadata. Mismatches feed the existing `refetchIssuesByNumber` recovery primitive introduced in #10091 — no new surface, no polling, no `since:` filter. ~1 rate-limit unit per ~100 issues.

## Architectural Reality

- **Distinct from #10090**: That PR ensured full event retrieval when we DO fetch an issue (`timelineItems` pagination). This PR decides **when to fetch** the issues that `updatedAt` silently overlooks.
- **Distinct from #7948**: That precedent catches relationship events (`SubIssueAddedEvent`, `BlockedByAddedEvent`) that also don't bump `updatedAt` — but those events still appear in the timeline. Comment deletions leave no event trace; the timeline only shows the surviving nodes. The only correctness-preserving primitive is `comments.totalCount` equality.
- **Lazy seeding**: Entries missing the new `commentsTotal` field (pre-migration metadata) are seeded in place from the live value WITHOUT triggering a refetch. First sync after merge graduates every tracked issue cleanly; subsequent syncs catch drift.

## Changes

- **`issueQueries.mjs`** — `buildIssueTotalsBatchQuery(numbers)` function export (first non-template export in this file) that composes aliased GraphQL fields (`issue42: issue(number:42) { comments { totalCount } }`) for N issues in one request. Complexity ~3×N, safely under GitHub's per-query limit for the default batch size.
- **`IssueSyncer.mjs`** — new `detectStaleCommentsCounts(metadata)` primitive. Lazily seeds missing `commentsTotal` entries in place; otherwise records stale entries for downstream recovery. Metadata writes in `pullFromGitHub` and `refetchIssuesByNumber` now capture `commentsTotal` alongside `contentHash`.
- **`MetadataManager.mjs`** — persists `commentsTotal` in the pruned issue metadata shape.
- **`SyncService.mjs`** — wires the sweep inside `runFullSync` after the delta pull; pipes mismatches into `refetchIssuesByNumber`; surfaces `checked/stale/seeded/errors` counts in the final log line and the return stats.
- **`config.template.mjs`** — adds `staleCommentsBatchSize: 100` knob.

## Test Coverage

Extended `IssueSyncer.spec.mjs` with three cases (all pass, 608ms total for the 4-test suite):

1. **Lazy seed** — metadata missing `commentsTotal` → seeded in place from live total, no refetch triggered.
2. **Happy path** — stored === live for all issues → no drift, no refetches.
3. **Drift detection (#9535 pattern)** — stored `commentsTotal: 11`, live `totalCount: 10` → one stale entry recorded, stored sentinel untouched (caller runs `refetchIssuesByNumber` to authoritatively re-render).

## Live Verification

Ran an in-process GraphQL probe against `neomjs/neo` with 5 real issue numbers to confirm the aliased-field batch query works end-to-end against live GitHub:
```
issue10090: #10090 commentsTotal=0
issue10092: #10092 commentsTotal=0
issue9535:  #9535  commentsTotal=10
issue9999:  #9999  commentsTotal=1
issue10030: #10030 commentsTotal=2
rateLimit:  {"cost":1,"remaining":4993,...}
```

## Avoided Traps

- **Timeline-scan pattern (#7948 style).** Won't work — no deletion event type in GraphQL `timelineItems`.
- **Raising sync frequency.** Tightens the drift window; does not close it.
- **Polling a second API surface (REST `/timeline` has `DeletedCommentEvent`).** New infra dependency for a case solvable via existing GraphQL primitives.
- **Full-scan sweep on a timer.** Option A from the ticket; dropped `since:` means O(all issues) cost. Batched sentinel at O(issues/100) hits the same correctness at 1% of the cost.

## Acceptance Criteria

- [x] `buildIssueTotalsBatchQuery` fetches `{number, comments{totalCount}}` with no `since:` filter
- [x] `MetadataManager` persists `commentsTotal` per issue
- [x] `IssueSyncer.detectStaleCommentsCounts(metadata)` runs inside `runFullSync` after the delta pull; mismatches feed `refetchIssuesByNumber`
- [x] Playwright spec covers happy path AND deletion-detection path
- [x] `runFullSync` logs + return-stats expose `checked/stale/seeded/errors` counts

## Known Edge / Follow-up

- GraphQL `issue(number:N)` errors hard if `N` is a PR instead of an Issue, which fails the entire batch. `metadata.issues` excludes PRs by contract (PRs live in `metadata.pulls`), so this is a theoretical edge — but per-alias error isolation (retry-as-singles on batch failure) would be more defensive. Not in scope for this PR; worth capturing if it ever fires in production logs.

## Test plan

- [x] `npm run test-unit -- test/playwright/unit/ai/mcp/server/github-workflow/IssueSyncer.spec.mjs` — 4 passed
- [x] Live GraphQL probe against real repo — aliased batch query returns expected shape
- [ ] (Reviewer) On first merge + `sync_all`, the log should show `StaleCounts: ~500 checked, 0 drifted, ~500 seeded` as the one-time seeding event. Subsequent syncs should show `0 seeded` and `0 drifted` except when real deletions occur.

Resolves #10092

Related: #10090 (pagination fix — introduced `refetchIssuesByNumber`, the recovery primitive this PR reuses), #7948 (analogous updatedAt-blind workaround for relationship events)