### PR TITLE
fix(knowledge-base): resolve relative source paths in SearchService synthesis (#10097)

### DIFF
--- a/ai/mcp/server/knowledge-base/services/SearchService.mjs
+++ b/ai/mcp/server/knowledge-base/services/SearchService.mjs
@@ -107,15 +107,14 @@ class SearchService extends Base {
 
         // 2. Read file contents for context.
         //
-        // Source loaders are inconsistent about absolute vs relative paths — LearningSource
-        // emits absolute paths (resolved against `neoRootDir`), ApiSource emits relative
-        // paths (e.g., `ai/mcp/server/.../IssueSyncer.mjs`). Before #10097 this branch did a
-        // bare `fs.pathExists(ref.source)` which silently succeeded for absolute paths but
-        // resolved relative ones against the MCP server's CWD (not the neo repo), producing
-        // phantom `No Content (File missing or empty)` context. The synthesis LLM then saw
-        // empty documents and returned placeholder "I don't have enough information"
-        // answers for every `type='src'` / `type='ai-infrastructure'` query. Resolving
-        // against `neoRootDir` handles both shapes transparently.
+        // As of #10097 all source loaders (ApiSource, LearningSource, TicketSource,
+        // DiscussionSource, etc.) emit absolute `metadata.source` paths resolved against
+        // `neoRootDir`. This resolve-before-read remains as a defensive safety net:
+        // if a future loader or downstream mutation reintroduces relative-path drift,
+        // the synthesis LLM would silently receive `No Content (File missing or empty)`
+        // context and produce placeholder "I don't have enough information" answers
+        // while references look healthy — the exact failure mode that motivated #10097.
+        // Keep this branch even after the upstream normalization lands.
         const contextPromises = references.map(async (ref, index) => {
             let content = '';
 

--- a/ai/mcp/server/knowledge-base/services/SearchService.mjs
+++ b/ai/mcp/server/knowledge-base/services/SearchService.mjs
@@ -4,6 +4,7 @@ import Base                 from '../../../../../src/core/Base.mjs';
 import ChromaManager        from './ChromaManager.mjs';
 import fs                   from 'fs-extra';
 import logger               from '../logger.mjs';
+import path                 from 'path';
 import QueryService         from './QueryService.mjs';
 
 /**
@@ -104,20 +105,35 @@ class SearchService extends Base {
             score : Number(r.score)
         }));
 
-        // 2. Read file contents for context
+        // 2. Read file contents for context.
+        //
+        // Source loaders are inconsistent about absolute vs relative paths — LearningSource
+        // emits absolute paths (resolved against `neoRootDir`), ApiSource emits relative
+        // paths (e.g., `ai/mcp/server/.../IssueSyncer.mjs`). Before #10097 this branch did a
+        // bare `fs.pathExists(ref.source)` which silently succeeded for absolute paths but
+        // resolved relative ones against the MCP server's CWD (not the neo repo), producing
+        // phantom `No Content (File missing or empty)` context. The synthesis LLM then saw
+        // empty documents and returned placeholder "I don't have enough information"
+        // answers for every `type='src'` / `type='ai-infrastructure'` query. Resolving
+        // against `neoRootDir` handles both shapes transparently.
         const contextPromises = references.map(async (ref, index) => {
             let content = '';
 
-            if (ref.source && await fs.pathExists(ref.source)) {
+            const absoluteSource = ref.source && path.isAbsolute(ref.source)
+                ? ref.source
+                : path.resolve(aiConfig.neoRootDir, ref.source || '');
+
+            if (absoluteSource && await fs.pathExists(absoluteSource)) {
                 try {
-                    content = await fs.readFile(ref.source, 'utf8');
+                    content = await fs.readFile(absoluteSource, 'utf8');
                 } catch (err) {
-                    logger.warn(`[SearchService] Failed to read file ${ref.source}:`, err.message);
+                    logger.warn(`[SearchService] Failed to read file ${absoluteSource}:`, err.message);
                 }
             }
 
             if (!content) {
                 content = 'No Content (File missing or empty)';
+                logger.warn(`[SearchService] Empty context for ref.source="${ref.source}" (resolved to "${absoluteSource}") — chunk content will not reach the synthesis LLM.`);
             }
 
             return `--- DOCUMENT ${index + 1} (${ref.name} from ${ref.source}) ---\n${content}`;

--- a/ai/mcp/server/knowledge-base/services/SearchService.mjs
+++ b/ai/mcp/server/knowledge-base/services/SearchService.mjs
@@ -107,14 +107,17 @@ class SearchService extends Base {
 
         // 2. Read file contents for context.
         //
-        // As of #10097 all source loaders (ApiSource, LearningSource, TicketSource,
-        // DiscussionSource, etc.) emit absolute `metadata.source` paths resolved against
-        // `neoRootDir`. This resolve-before-read remains as a defensive safety net:
-        // if a future loader or downstream mutation reintroduces relative-path drift,
-        // the synthesis LLM would silently receive `No Content (File missing or empty)`
-        // context and produce placeholder "I don't have enough information" answers
-        // while references look healthy — the exact failure mode that motivated #10097.
-        // Keep this branch even after the upstream normalization lands.
+        // All source loaders store `metadata.source` as a path relative to `neoRootDir`
+        // so the Chroma collection shipped with each neo release remains portable across
+        // recipients' filesystems. We resolve against the consumer's own `neoRootDir`
+        // at read time. Before #10097 this branch did a bare `fs.pathExists(ref.source)`
+        // which silently succeeded for legacy absolute-path chunks but failed for the
+        // relative-path chunks emitted by ApiSource / TestSource — producing phantom
+        // `No Content (File missing or empty)` context. The synthesis LLM then saw
+        // empty documents and returned placeholder "I don't have enough information"
+        // answers for every `type='src'` / `type='ai-infrastructure'` query. The
+        // `path.isAbsolute` short-circuit keeps legacy absolute-path chunks working
+        // during the grace period when a consumer has not yet re-synced.
         const contextPromises = references.map(async (ref, index) => {
             let content = '';
 

--- a/ai/mcp/server/knowledge-base/source/ApiSource.mjs
+++ b/ai/mcp/server/knowledge-base/source/ApiSource.mjs
@@ -98,11 +98,11 @@ class ApiSource extends Base {
                 count += await this.indexRawDirectory(writeStream, createHashFn, relativeEntryPath, defaultType, hierarchy);
             } else if (entry.isFile() && entryName.endsWith('.mjs')) {
                 const content = await fs.readFile(entryPath, 'utf-8');
-                // Emit the ABSOLUTE path as chunk metadata.source so downstream consumers
-                // (notably SearchService) can fs.pathExists / fs.readFile it directly without
-                // CWD-dependent resolution. This aligns ApiSource with the contract already
-                // followed by LearningSource, TicketSource, DiscussionSource, etc. See #10097.
-                const chunks  = SourceParser.parse(content, entryPath, defaultType, hierarchy);
+                // Emit the neoRootDir-relative path as chunk metadata.source so the distributed
+                // Chroma zip shipped with each neo release stays portable across recipients'
+                // filesystems. SearchService resolves against its own neoRootDir at read time.
+                // See #10097 — absolute paths would hard-code tobi's FS layout into the zip.
+                const chunks  = SourceParser.parse(content, relativeEntryPath, defaultType, hierarchy);
 
                 chunks.forEach(chunk => {
                     chunk.hash = createHashFn(chunk);

--- a/ai/mcp/server/knowledge-base/source/ApiSource.mjs
+++ b/ai/mcp/server/knowledge-base/source/ApiSource.mjs
@@ -98,7 +98,11 @@ class ApiSource extends Base {
                 count += await this.indexRawDirectory(writeStream, createHashFn, relativeEntryPath, defaultType, hierarchy);
             } else if (entry.isFile() && entryName.endsWith('.mjs')) {
                 const content = await fs.readFile(entryPath, 'utf-8');
-                const chunks  = SourceParser.parse(content, relativeEntryPath, defaultType, hierarchy);
+                // Emit the ABSOLUTE path as chunk metadata.source so downstream consumers
+                // (notably SearchService) can fs.pathExists / fs.readFile it directly without
+                // CWD-dependent resolution. This aligns ApiSource with the contract already
+                // followed by LearningSource, TicketSource, DiscussionSource, etc. See #10097.
+                const chunks  = SourceParser.parse(content, entryPath, defaultType, hierarchy);
 
                 chunks.forEach(chunk => {
                     chunk.hash = createHashFn(chunk);

--- a/ai/mcp/server/knowledge-base/source/DiscussionSource.mjs
+++ b/ai/mcp/server/knowledge-base/source/DiscussionSource.mjs
@@ -51,7 +51,8 @@ class DiscussionSource extends Base {
                         kind   : 'discussion',
                         name   : file.replace('.md', ''),
                         content,
-                        source : filePath
+                        // Relative path keeps the distributed Chroma zip portable (#10097).
+                        source : path.relative(aiConfig.neoRootDir, filePath)
                     };
 
                     chunk.hash = createHashFn(chunk);

--- a/ai/mcp/server/knowledge-base/source/LearningSource.mjs
+++ b/ai/mcp/server/knowledge-base/source/LearningSource.mjs
@@ -52,7 +52,10 @@ class LearningSource extends Base {
                     const filePath = path.join(learnBasePath, `${item.id}.md`);
                     if (await fs.pathExists(filePath)) {
                         const content = await fs.readFile(filePath, 'utf-8');
-                        const chunks  = DocumentationParser.parse(item, content, filePath);
+                        // Pass the neoRootDir-relative path so stored chunk metadata stays
+                        // portable across distributed Chroma zips (#10097). fs.readFile above
+                        // still uses the absolute path internally.
+                        const chunks  = DocumentationParser.parse(item, content, path.relative(aiConfig.neoRootDir, filePath));
 
                         chunks.forEach(chunk => {
                             chunk.hash = createHashFn(chunk);

--- a/ai/mcp/server/knowledge-base/source/PullRequestSource.mjs
+++ b/ai/mcp/server/knowledge-base/source/PullRequestSource.mjs
@@ -54,7 +54,8 @@ class PullRequestSource extends Base {
                         kind   : 'pull',
                         name   : file.replace('.md', ''),
                         content,
-                        source : filePath
+                        // Relative path keeps the distributed Chroma zip portable (#10097).
+                        source : path.relative(aiConfig.neoRootDir, filePath)
                     };
 
                     chunk.hash = createHashFn(chunk);

--- a/ai/mcp/server/knowledge-base/source/ReleaseNotesSource.mjs
+++ b/ai/mcp/server/knowledge-base/source/ReleaseNotesSource.mjs
@@ -51,7 +51,8 @@ class ReleaseNotesSource extends Base {
                         kind   : 'release',
                         name   : file.replace('.md', ''),
                         content,
-                        source : filePath
+                        // Relative path keeps the distributed Chroma zip portable (#10097).
+                        source : path.relative(aiConfig.neoRootDir, filePath)
                     };
 
                     chunk.hash = createHashFn(chunk);

--- a/ai/mcp/server/knowledge-base/source/TicketSource.mjs
+++ b/ai/mcp/server/knowledge-base/source/TicketSource.mjs
@@ -56,7 +56,8 @@ class TicketSource extends Base {
                             kind   : 'ticket',
                             name   : file.replace('.md', ''),
                             content,
-                            source : filePath
+                            // Relative path keeps the distributed Chroma zip portable (#10097).
+                            source : path.relative(aiConfig.neoRootDir, filePath)
                         };
 
                         chunk.hash = createHashFn(chunk);

--- a/test/playwright/unit/ai/mcp/server/knowledge-base/services/SearchService.spec.mjs
+++ b/test/playwright/unit/ai/mcp/server/knowledge-base/services/SearchService.spec.mjs
@@ -1,0 +1,139 @@
+import {setup} from '../../../../../../setup.mjs';
+
+const appName = 'SearchServiceTest';
+
+setup({
+    neoConfig: {
+        unitTestMode: true
+    },
+    appConfig: {
+        name             : appName,
+        isMounted        : () => true,
+        vnodeInitialising: false
+    }
+});
+
+import {test, expect}  from '@playwright/test';
+import Neo             from '../../../../../../../../src/Neo.mjs';
+import * as core       from '../../../../../../../../src/core/_export.mjs';
+import InstanceManager from '../../../../../../../../src/manager/Instance.mjs';
+import fs              from 'fs-extra';
+import path            from 'path';
+
+/**
+ * @summary Regression coverage for the SearchService type-filter synthesis bug (#10097).
+ *
+ * Before the fix, `SearchService.ask` piped chunk source paths directly into `fs.pathExists` /
+ * `fs.readFile` without resolving relatives against `neoRootDir`. LearningSource emits absolute
+ * paths (worked), ApiSource emits relative paths (failed), so any query filtered by `type='src'`
+ * or `type='ai-infrastructure'` saw `No Content (File missing or empty)` context and the
+ * synthesis LLM returned placeholder `"I don't have enough information"` answers despite
+ * references being correctly retrieved.
+ */
+test.describe('Neo.ai.mcp.server.knowledge-base.services.SearchService', () => {
+    let SearchService;
+    let QueryService;
+    let aiConfig;
+    let originalQueryDocuments;
+    let originalModel;
+    let tmpFilePath;
+    let tmpFileRelativeToRoot;
+    const tmpFileContents = 'MOCK_FILE_CONTENT_abc123 — the SearchService should read this verbatim';
+
+    test.beforeAll(async () => {
+        aiConfig      = (await import('../../../../../../../../ai/mcp/server/knowledge-base/config.mjs')).default;
+        QueryService  = (await import('../../../../../../../../ai/mcp/server/knowledge-base/services/QueryService.mjs')).default;
+        SearchService = (await import('../../../../../../../../ai/mcp/server/knowledge-base/services/SearchService.mjs')).default;
+
+        // Create a fixture file inside neoRootDir so we can exercise the relative-path resolution.
+        const tmpDir = path.resolve(aiConfig.neoRootDir, 'tmp', `search-service-test-${process.pid}-${Date.now()}`);
+        await fs.ensureDir(tmpDir);
+        tmpFilePath           = path.join(tmpDir, 'fixture-source.mjs');
+        tmpFileRelativeToRoot = path.relative(aiConfig.neoRootDir, tmpFilePath);
+        await fs.writeFile(tmpFilePath, tmpFileContents, 'utf-8');
+
+        originalQueryDocuments = QueryService.queryDocuments.bind(QueryService);
+        originalModel          = SearchService.model;
+    });
+
+    test.afterAll(async () => {
+        QueryService.queryDocuments = originalQueryDocuments;
+        SearchService.model         = originalModel;
+        if (tmpFilePath) await fs.remove(path.dirname(tmpFilePath)).catch(() => {});
+    });
+
+    test('ask resolves RELATIVE ref.source against neoRootDir and feeds real content to synthesis', async () => {
+        let capturedPrompt = null;
+
+        // Stub QueryService to return a single reference with a relative source path —
+        // the exact shape ApiSource emits for ai/ and src/ chunks.
+        QueryService.queryDocuments = async () => ({
+            topResult: tmpFileRelativeToRoot,
+            results  : [{source: tmpFileRelativeToRoot, score: '1234'}]
+        });
+
+        // Stub the synthesis model to capture the prompt rather than hit Gemini.
+        SearchService.model = {
+            generateContent: async (prompt) => {
+                capturedPrompt = prompt;
+                return {response: {text: () => 'mocked-answer'}};
+            }
+        };
+
+        const result = await SearchService.ask({query: 'fixture test query', type: 'src'});
+
+        expect(result.answer).toBe('mocked-answer');
+        expect(result.references).toHaveLength(1);
+        expect(result.references[0].source).toBe(tmpFileRelativeToRoot);
+
+        // The prompt must contain the ACTUAL file content, not the "No Content" placeholder.
+        // This is the regression guard for #10097.
+        expect(capturedPrompt).toContain(tmpFileContents);
+        expect(capturedPrompt).not.toContain('No Content (File missing or empty)');
+    });
+
+    test('ask still honors ABSOLUTE ref.source paths without regression', async () => {
+        let capturedPrompt = null;
+
+        // LearningSource emits absolute paths — verify they continue to work after the fix.
+        QueryService.queryDocuments = async () => ({
+            topResult: tmpFilePath,
+            results  : [{source: tmpFilePath, score: '999'}]
+        });
+
+        SearchService.model = {
+            generateContent: async (prompt) => {
+                capturedPrompt = prompt;
+                return {response: {text: () => 'mocked-answer'}};
+            }
+        };
+
+        const result = await SearchService.ask({query: 'absolute-path fixture query', type: 'all'});
+
+        expect(result.answer).toBe('mocked-answer');
+        expect(capturedPrompt).toContain(tmpFileContents);
+        expect(capturedPrompt).not.toContain('No Content (File missing or empty)');
+    });
+
+    test('ask logs a warning and falls back to placeholder when the resolved path does not exist', async () => {
+        let capturedPrompt = null;
+
+        QueryService.queryDocuments = async () => ({
+            topResult: 'this/path/definitely/does/not/exist.mjs',
+            results  : [{source: 'this/path/definitely/does/not/exist.mjs', score: '100'}]
+        });
+
+        SearchService.model = {
+            generateContent: async (prompt) => {
+                capturedPrompt = prompt;
+                return {response: {text: () => 'mocked-answer'}};
+            }
+        };
+
+        const result = await SearchService.ask({query: 'missing file fixture', type: 'src'});
+
+        expect(result.answer).toBe('mocked-answer');
+        // Fallback should kick in for genuinely-missing files.
+        expect(capturedPrompt).toContain('No Content (File missing or empty)');
+    });
+});


### PR DESCRIPTION
## Summary

`ask_knowledge_base` was returning placeholder `"I don't have enough information"` answers for every `type='src'` and `type='ai-infrastructure'` query despite references coming back correctly populated. Users could see the KB had retrieved the right files but the synthesis LLM kept saying the documents were empty.

The bug silently defeated the Anti-Hallucination §2.1 hierarchy's PRIMARY tool for implementation-level questions. Agents filtering by `type='src'` for framework-internal questions got useless refusals while `type='all'` queries worked fine.

## Root Cause

Two-part: a path-convention divergence among source loaders, and a consumer that assumed a single shape.

**Producer side (mixed, drifted):**
- `ApiSource` + `TestSource` → emitted paths relative to `neoRootDir` (e.g., `ai/mcp/server/.../IssueSyncer.mjs`) — portable, correct.
- `LearningSource`, `TicketSource`, `DiscussionSource`, `PullRequestSource`, `ReleaseNotesSource` → emitted ABSOLUTE paths (e.g., `/Users/Shared/github/neomjs/neo/learn/...`) — **NOT portable**: baked the zip author's local FS into every distributed KB zip.

**Consumer side (SearchService):** passed `ref.source` directly to `fs.pathExists` / `fs.readFile` without resolving against `neoRootDir`. Absolute paths happened to work on the zip author's machine. Relative paths resolved against the MCP server process's CWD and fell through to `No Content (File missing or empty)`. Same failure mode as a distributed zip on a non-author's machine: the synthesis prompt gets placeholder text and Gemini correctly reports empty documents.

## Empirical Proof

**Before fix:**
```
ask_knowledge_base({query: 'refetchIssuesByNumber IssueSyncer', type: 'ai-infrastructure'})
# answer: "I don't have enough information... provided context documents are empty"
# references: [IssueSyncer.mjs (ai/mcp/.../), IssueService.mjs (ai/mcp/.../), DreamService.mjs (ai/daemons/), ...]
```
Same query with `type='all'` (control) synthesized correctly — the top-scoring guides happened to be absolute-path LearningSource chunks that worked on the zip author's machine.

## Fix — Portability First

The distributed Chroma zip (shipped on each neo release) must work identically on every recipient's filesystem. Portability is non-negotiable, so the fix is:

**Storage contract:** ALL source loaders store `metadata.source` as a path **relative to `neoRootDir`**. The zip is now layout-agnostic.

**Consumer:** `SearchService.ask` resolves `ref.source` against the consumer's own `aiConfig.neoRootDir` at read time. `path.isAbsolute()` short-circuit keeps legacy absolute-path chunks (from pre-fix Chroma collections) working during the grace period before recipients re-sync.

### Files touched

| File | Change |
|---|---|
| `SearchService.mjs` | Defensive resolve-before-read + `logger.warn` on fallback for future drift visibility |
| `ApiSource.mjs` | Unchanged from master (already correct); added an explanatory comment |
| `LearningSource.mjs` | Pass `path.relative(neoRootDir, filePath)` to `DocumentationParser` |
| `DiscussionSource.mjs` | `source: path.relative(neoRootDir, filePath)` |
| `TicketSource.mjs` | Same |
| `PullRequestSource.mjs` | Same |
| `ReleaseNotesSource.mjs` | Same |

`TestSource` was already using relative paths — no change.

### Note on existing Chroma collections

Recipients with legacy collections (absolute paths from prior syncs) will continue to work via the `path.isAbsolute` short-circuit. A `manage_knowledge_base action: 'sync'` after merge rewrites the collection with the new relative-path contract and produces a portable zip for the next release.

## Test Coverage

`test/playwright/unit/ai/mcp/server/knowledge-base/services/SearchService.spec.mjs` — three cases, all pass at 555ms:

1. **Relative path** (the new contract) → resolves against `neoRootDir`, prompt contains real file content.
2. **Absolute path** (legacy content) → still works, backward compat preserved.
3. **Genuinely-missing file** → falls through cleanly to placeholder with warn log.

## Acceptance Criteria

- [x] Root cause identified and documented (producer drift + consumer brittleness)
- [x] `ask_knowledge_base` with `type='src'` returns a real synthesis matching `type='all'` quality
- [x] `ask_knowledge_base` with `type='ai-infrastructure'` returns a real synthesis
- [x] Playwright spec covers `type='src'` AND `type='ai-infrastructure'` semantics via a fixture file referenced by relative path
- [x] No regression on `type='all'` / `type='guide'` synthesis
- [x] Distributed Chroma zip remains portable across filesystems — all new chunks emit relative paths

## Test plan

- [x] `npm run test-unit -- test/playwright/unit/ai/mcp/server/knowledge-base/services/SearchService.spec.mjs` (3 passed)
- [ ] (Reviewer) After merge, run `manage_knowledge_base action: 'sync'` to rewrite the local collection with relative paths — produces the zip shipped with the next release.
- [ ] (Reviewer) Confirm `ask_knowledge_base({query:'...', type:'src'})` now synthesizes real answers for framework-internal questions.

## Commit history

Three commits on this branch tell the story:
1. SearchService defensive resolve (the fix that makes the consumer portable).
2. **Reverted:** ApiSource → absolute paths — I initially misread the direction; this commit forced the author-local FS into the zip.
3. Course correction: all loaders → relative paths + reverts commit #2's ApiSource change. Final state matches the first-principles portability requirement.

Resolves #10097