### PR TITLE
feat(ai): ai/scripts/bootstrapWorktree.mjs + AGENTS_STARTUP note (#10095)

### DIFF
--- a/AGENTS_STARTUP.md
+++ b/AGENTS_STARTUP.md
@@ -63,6 +63,24 @@ Different AI harnesses auto-load their own "memory file" at session start. Each 
 
 As new harnesses join the swarm, add their memory-file conventions here.
 
+#### Worktree Bootstrap (Claude Code)
+
+Claude Code creates a fresh git worktree per session at `.claude/worktrees/<name>/`. Because `ai/mcp/server/*/config.mjs` is gitignored (copy-from-template files for local overrides), worktrees start without these files. Any script that imports `ai/services.mjs` fails with:
+
+```
+Error [ERR_MODULE_NOT_FOUND]: Cannot find module '.../ai/mcp/server/github-workflow/config.mjs'
+```
+
+**Before running any SDK-consuming script or `test-unit` command in a worktree, execute:**
+
+```bash
+node ai/scripts/bootstrapWorktree.mjs
+```
+
+It copies the four `config.mjs` files from the main checkout (resolved via `git worktree list --porcelain`). Idempotent; no-op from the main checkout.
+
+**Do NOT use symlinks** as an alternative — they break Playwright specs under `unitTestMode` with `Namespace collision in unitTestMode for Neo.core.Base`. Node resolves relative imports inside symlinked modules against the canonical (target) path, which points at the main checkout's `src/core/Base.mjs`, and the worktree-local `Base.mjs` collides with it at setupClass time. Copies have their own canonical path inside the worktree and resolve correctly.
+
 ### Step 6: Check for Memory Core
 
 - Use the `healthcheck` tool for the `neo.mjs-memory-core` server.

--- a/ai/scripts/bootstrapWorktree.mjs
+++ b/ai/scripts/bootstrapWorktree.mjs
@@ -1,0 +1,145 @@
+/**
+ * @summary Copies gitignored `ai/mcp/server/<name>/config.mjs` files from the main git
+ * checkout into the current git worktree so SDK-consuming scripts (`ai/services.mjs`)
+ * can run.
+ *
+ * **Background:** `ai/mcp/server/{github-workflow,knowledge-base,memory-core,neural-link}/config.mjs`
+ * are gitignored (they are copy-from-template files for local overrides). Fresh git worktrees
+ * under `.claude/worktrees/<name>/` therefore cannot run any script that imports
+ * `ai/services.mjs`:
+ *
+ * ```
+ * Error [ERR_MODULE_NOT_FOUND]: Cannot find module '.../ai/mcp/server/github-workflow/config.mjs'
+ * ```
+ *
+ * **Do NOT use symlinks** as a workaround — Node resolves relative imports inside a
+ * symlinked module against the real (canonical) path of the target, which points at the
+ * main checkout's `src/core/Base.mjs`. When the worktree-local `src/core/Base.mjs` ALSO
+ * gets imported (e.g. by a Playwright spec), `Neo.setupClass` sees the same namespace
+ * registered from two different file paths and throws `Namespace collision in unitTestMode`.
+ * Copies have their own canonical path inside the worktree and resolve correctly.
+ *
+ * **Usage:**
+ * ```
+ * node ai/scripts/bootstrapWorktree.mjs
+ * ```
+ *
+ * Idempotent: files that already exist are skipped. Refuses to run from the main checkout
+ * (no-op). Resolves the main checkout via `git worktree list --porcelain` — its first
+ * entry is always the primary working tree.
+ *
+ * @see https://github.com/neomjs/neo/issues/10095
+ */
+import {execFile}       from 'child_process';
+import fs               from 'fs/promises';
+import path             from 'path';
+import {fileURLToPath}  from 'url';
+import {promisify}      from 'util';
+
+const execFileAsync = promisify(execFile);
+
+export const BOOTSTRAP_CONFIGS = [
+    'ai/mcp/server/github-workflow/config.mjs',
+    'ai/mcp/server/knowledge-base/config.mjs',
+    'ai/mcp/server/memory-core/config.mjs',
+    'ai/mcp/server/neural-link/config.mjs'
+];
+
+/**
+ * @summary Resolves the main git checkout path for a given project root by parsing
+ * `git worktree list --porcelain`. The first `worktree <path>` line is always the primary
+ * working tree regardless of where the command is invoked from.
+ *
+ * @param {string} cwd The directory to run git from.
+ * @returns {Promise<string|null>} Absolute path to the main checkout, or null on failure.
+ */
+export async function resolveMainCheckout(cwd) {
+    const {stdout} = await execFileAsync('git', ['worktree', 'list', '--porcelain'], {cwd});
+    const match    = stdout.match(/^worktree (.+)$/m);
+    return match ? match[1] : null;
+}
+
+/**
+ * @summary Copies missing config.mjs files from the main checkout into the target project root.
+ *
+ * Pure function form for testability — accepts explicit `mainCheckout`, `projectRoot`, and
+ * `configs` arguments. CLI mode (bottom of file) resolves these via git.
+ *
+ * @param {object}   options
+ * @param {string}   options.mainCheckout Absolute path to the primary git checkout.
+ * @param {string}   options.projectRoot  Absolute path to the worktree root to populate.
+ * @param {string[]} [options.configs]    Relative paths to copy; defaults to BOOTSTRAP_CONFIGS.
+ * @param {Function} [options.log]        Optional logger fn; defaults to console.log.
+ * @returns {Promise<{copied: string[], skipped: string[], missing: string[]}>}
+ */
+export async function bootstrapWorktree({mainCheckout, projectRoot, configs = BOOTSTRAP_CONFIGS, log = console.log}) {
+    if (path.resolve(projectRoot) === path.resolve(mainCheckout)) {
+        log('Running inside the main checkout — nothing to bootstrap.');
+        return {copied: [], skipped: [], missing: []};
+    }
+
+    const result = {copied: [], skipped: [], missing: []};
+
+    for (const rel of configs) {
+        const src = path.join(mainCheckout, rel);
+        const dst = path.join(projectRoot, rel);
+
+        const dstExists = await exists(dst);
+        if (dstExists) {
+            result.skipped.push(rel);
+            log(`skip (exists): ${rel}`);
+            continue;
+        }
+
+        const srcExists = await exists(src);
+        if (!srcExists) {
+            result.missing.push(rel);
+            log(`skip (source missing in main checkout): ${rel}`);
+            continue;
+        }
+
+        await fs.mkdir(path.dirname(dst), {recursive: true});
+        await fs.copyFile(src, dst);
+        result.copied.push(rel);
+        log(`copied: ${rel}`);
+    }
+
+    return result;
+}
+
+async function exists(p) {
+    try {
+        await fs.access(p);
+        return true;
+    } catch {
+        return false;
+    }
+}
+
+// -------------------------------------------------------------------------------------
+// CLI entry point. Runs only when invoked directly (node ai/scripts/bootstrapWorktree.mjs)
+// and not when imported by a test spec.
+// -------------------------------------------------------------------------------------
+
+const isMain = process.argv[1] && fileURLToPath(import.meta.url) === path.resolve(process.argv[1]);
+
+if (isMain) {
+    const __filename  = fileURLToPath(import.meta.url);
+    const __dirname   = path.dirname(__filename);
+    const projectRoot = path.resolve(__dirname, '..', '..'); // ai/scripts/ → ai/ → root
+
+    try {
+        const mainCheckout = await resolveMainCheckout(projectRoot);
+        if (!mainCheckout) {
+            console.error('Failed to resolve main checkout via git worktree list. Is this a git repository?');
+            process.exit(1);
+        }
+
+        const result = await bootstrapWorktree({mainCheckout, projectRoot});
+        const total  = result.copied.length + result.skipped.length + result.missing.length;
+        console.log(`\n✓ Bootstrap complete: ${result.copied.length} copied, ${result.skipped.length} skipped, ${result.missing.length} missing (${total} total)`);
+    } catch (e) {
+        console.error('Bootstrap failed:', e.message);
+        process.exit(1);
+    }
+}

--- a/test/playwright/unit/ai/scripts/bootstrapWorktree.spec.mjs
+++ b/test/playwright/unit/ai/scripts/bootstrapWorktree.spec.mjs
@@ -1,0 +1,144 @@
+import {setup} from '../../../setup.mjs';
+
+const appName = 'BootstrapWorktreeTest';
+
+setup({
+    neoConfig: {
+        unitTestMode: true
+    },
+    appConfig: {
+        name             : appName,
+        isMounted        : () => true,
+        vnodeInitialising: false
+    }
+});
+
+import {test, expect}  from '@playwright/test';
+import Neo             from '../../../../../src/Neo.mjs';
+import * as core       from '../../../../../src/core/_export.mjs';
+import InstanceManager from '../../../../../src/manager/Instance.mjs';
+import fs              from 'fs-extra';
+import path            from 'path';
+
+/**
+ * @summary Coverage for the worktree bootstrap script (#10095).
+ *
+ * Uses tmp dirs as fake main-checkout and fake worktree to exercise the copy logic
+ * without touching the real repo state. The CLI-mode `execFile` resolution of
+ * `git worktree list --porcelain` is not exercised here — that path is a thin wrapper
+ * around the already-covered `bootstrapWorktree(...)` function.
+ */
+test.describe('ai/scripts/bootstrapWorktree', () => {
+    let bootstrapWorktree;
+    let BOOTSTRAP_CONFIGS;
+    let fakeMainCheckout;
+    let fakeWorktree;
+
+    const fixtureConfigs = [
+        'ai/mcp/server/github-workflow/config.mjs',
+        'ai/mcp/server/knowledge-base/config.mjs',
+        'ai/mcp/server/memory-core/config.mjs',
+        'ai/mcp/server/neural-link/config.mjs'
+    ];
+
+    test.beforeAll(async () => {
+        const mod        = await import('../../../../../ai/scripts/bootstrapWorktree.mjs');
+        bootstrapWorktree = mod.bootstrapWorktree;
+        BOOTSTRAP_CONFIGS = mod.BOOTSTRAP_CONFIGS;
+    });
+
+    test.beforeEach(async () => {
+        const tmpBase    = path.resolve(process.cwd(), 'tmp', `bootstrap-worktree-test-${process.pid}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`);
+        fakeMainCheckout = path.join(tmpBase, 'main-checkout');
+        fakeWorktree     = path.join(tmpBase, 'worktree');
+
+        for (const rel of fixtureConfigs) {
+            const src = path.join(fakeMainCheckout, rel);
+            await fs.ensureDir(path.dirname(src));
+            await fs.writeFile(src, `// fixture content for ${rel}\n`, 'utf-8');
+        }
+        await fs.ensureDir(fakeWorktree);
+    });
+
+    test.afterEach(async () => {
+        if (fakeMainCheckout) {
+            await fs.remove(path.dirname(fakeMainCheckout)).catch(() => {});
+        }
+    });
+
+    test('exports the canonical BOOTSTRAP_CONFIGS list', () => {
+        expect(BOOTSTRAP_CONFIGS).toEqual(fixtureConfigs);
+    });
+
+    test('copies every missing config.mjs from main checkout into the worktree', async () => {
+        const logs   = [];
+        const result = await bootstrapWorktree({
+            mainCheckout: fakeMainCheckout,
+            projectRoot : fakeWorktree,
+            configs     : fixtureConfigs,
+            log         : (line) => logs.push(line)
+        });
+
+        expect(result.copied).toEqual(fixtureConfigs);
+        expect(result.skipped).toHaveLength(0);
+        expect(result.missing).toHaveLength(0);
+
+        for (const rel of fixtureConfigs) {
+            const dst     = path.join(fakeWorktree, rel);
+            const content = await fs.readFile(dst, 'utf-8');
+            expect(content).toContain(`fixture content for ${rel}`);
+        }
+    });
+
+    test('is idempotent — re-running after partial seed leaves existing files untouched', async () => {
+        // Pre-seed one of the four with distinct content; confirm it's preserved.
+        const preseeded    = fixtureConfigs[0];
+        const preseededDst = path.join(fakeWorktree, preseeded);
+        await fs.ensureDir(path.dirname(preseededDst));
+        await fs.writeFile(preseededDst, '// preserved local override\n', 'utf-8');
+
+        const result = await bootstrapWorktree({
+            mainCheckout: fakeMainCheckout,
+            projectRoot : fakeWorktree,
+            configs     : fixtureConfigs,
+            log         : () => {}
+        });
+
+        expect(result.copied).toEqual(fixtureConfigs.slice(1));
+        expect(result.skipped).toEqual([preseeded]);
+
+        const preserved = await fs.readFile(preseededDst, 'utf-8');
+        expect(preserved).toBe('// preserved local override\n');
+    });
+
+    test('refuses to copy when running inside the main checkout', async () => {
+        const logs   = [];
+        const result = await bootstrapWorktree({
+            mainCheckout: fakeMainCheckout,
+            projectRoot : fakeMainCheckout, // same path = main checkout mode
+            configs     : fixtureConfigs,
+            log         : (line) => logs.push(line)
+        });
+
+        expect(result.copied).toHaveLength(0);
+        expect(result.skipped).toHaveLength(0);
+        expect(result.missing).toHaveLength(0);
+        expect(logs.join('\n')).toContain('main checkout');
+    });
+
+    test('reports configs missing in the main checkout without throwing', async () => {
+        // Remove one fixture from the main checkout to simulate a partial release.
+        const removed = fixtureConfigs[2];
+        await fs.remove(path.join(fakeMainCheckout, removed));
+
+        const result = await bootstrapWorktree({
+            mainCheckout: fakeMainCheckout,
+            projectRoot : fakeWorktree,
+            configs     : fixtureConfigs,
+            log         : () => {}
+        });
+
+        expect(result.missing).toEqual([removed]);
+        expect(result.copied).toEqual(fixtureConfigs.filter(c => c !== removed));
+    });
+});


### PR DESCRIPTION
## Summary

Every fresh Claude Code worktree under `.claude/worktrees/` hits `ERR_MODULE_NOT_FOUND` the first time any script imports `ai/services.mjs`:

```
Error [ERR_MODULE_NOT_FOUND]: Cannot find module '.../ai/mcp/server/github-workflow/config.mjs'
```

Root cause: `ai/mcp/server/<name>/config.mjs` is gitignored (copy-from-template files for local overrides), so fresh worktrees inherit the tracked tree without them. Symlinks from the main checkout are NOT a workaround — Node resolves relative imports inside a symlinked module against the canonical target path, so `config.mjs`'s `import Base from '../../../../src/core/Base.mjs'` loads the main-checkout's Base.mjs. When the worktree-local Base.mjs also gets imported (e.g., by a Playwright spec), `Neo.setupClass` sees the same namespace registered from two different file paths and throws `Namespace collision in unitTestMode for Neo.core.Base`. Copies have their own canonical path inside the worktree and resolve correctly.

## Impact

Discovered during #10090 (PR #10091) and again during #10092 (PR #10093). Both times the workaround was manually copying four config.mjs files from the main checkout — ~15 minutes of friction per session. Next fresh worktree session on #10030 (Concept Ontology) would hit the same wall. This PR unblocks every future Claude Code session.

## Changes

- **`ai/scripts/bootstrapWorktree.mjs`** exports:
  - `resolveMainCheckout(cwd)` — parses `git worktree list --porcelain`; the first `worktree <path>` line is always the primary working tree regardless of where the command is invoked.
  - `bootstrapWorktree({mainCheckout, projectRoot, configs, log})` — pure copy logic, idempotent, refuses to run when invoked against the main checkout (no-op). Splits into `{copied, skipped, missing}` buckets for observable outcomes.

  CLI entry point resolves `mainCheckout` via git and logs a one-line summary. Uses `process.argv[1]`-vs-`import.meta.url` main guard so the module is importable by the spec without running the CLI.

- **`AGENTS_STARTUP.md`** — new `Worktree Bootstrap (Claude Code)` subsection under `Harness Memory-File Wiring` documenting the error, the required bootstrap command, and the symlink trap with its exact error signature. Future agents don't rediscover it.

- **`test/playwright/unit/ai/scripts/bootstrapWorktree.spec.mjs`** — five cases against tmp fake-main-checkout + fake-worktree dirs:
  1. Exports the canonical `BOOTSTRAP_CONFIGS` list.
  2. Copies all missing configs from main into worktree.
  3. Idempotent on partial seed (pre-existing local override preserved byte-for-byte).
  4. No-op when invoked against the main checkout itself.
  5. Reports configs missing in the main checkout without throwing.

## Test Coverage

```
npm run test-unit -- test/playwright/unit/ai/scripts/bootstrapWorktree.spec.mjs
# 5 passed (670ms)
```

## Live CLI Verification

```bash
rm ai/mcp/server/github-workflow/config.mjs
node ai/scripts/bootstrapWorktree.mjs
# copied: ai/mcp/server/github-workflow/config.mjs
# skip (exists): ai/mcp/server/knowledge-base/config.mjs
# skip (exists): ai/mcp/server/memory-core/config.mjs
# skip (exists): ai/mcp/server/neural-link/config.mjs
# ✓ Bootstrap complete: 1 copied, 3 skipped, 0 missing (4 total)
```

## Commit Type

Chose `feat` per pull-request-workflow §3.1 — unlocks a new capability (fresh-worktree-ready in one command) that did not exist before. `fix` was considered since the underlying wall is a failure mode, but the fix IS the new capability, and worktrees weren't previously supported out of the box for SDK scripts.

## Acceptance Criteria

- [x] `ai/scripts/bootstrapWorktree.mjs` — resolves main checkout via git, copies four `config.mjs` files, idempotent
- [x] Refuses to run when CWD is the main checkout (no-op safety)
- [x] Playwright spec verifying copy-behavior against a fake main-checkout tmp dir (5 cases)
- [x] `AGENTS_STARTUP.md` updated with the worktree bootstrap note under Harness Memory-File Wiring

## Test plan

- [x] `npm run test-unit -- test/playwright/unit/ai/scripts/bootstrapWorktree.spec.mjs` (5 passed)
- [x] Live CLI: delete + bootstrap cycle succeeds with correct copied/skipped counts
- [ ] (Reviewer) On next Claude Code worktree session, run `node ai/scripts/bootstrapWorktree.mjs` and confirm any SDK-consuming script now works without manual intervention

Resolves #10095