### PR TITLE
refactor(ai): hoist concept-graph gap pass to cycle-scope (#10085)

### DIFF
--- a/ai/daemons/DreamService.mjs
+++ b/ai/daemons/DreamService.mjs
@@ -204,9 +204,9 @@ class DreamService extends Base {
                 logger.info(`[DreamService]   -> Topological Conflicts took: ${topoTime}s`);
                 
                 const capStart = Date.now();
-                await this.executeCapabilityGapInference(session, success);
+                await this.inferTestGapsFromSession(success);
                 const capTime = ((Date.now() - capStart) / 1000).toFixed(1);
-                logger.info(`[DreamService]   -> Capability Gap Inference took: ${capTime}s`);
+                logger.info(`[DreamService]   -> Session TEST_GAP Inference took: ${capTime}s`);
 
                 logger.info(`[DreamService] Total Session Digest Time: ${((Date.now() - startTime) / 1000).toFixed(1)}s`);
 
@@ -218,6 +218,13 @@ class DreamService extends Base {
                     logger.info(`[DreamService] Session ${session.meta.sessionId} marked as graphDigested in Memory Core.`);
                 }
                 }
+
+                // Hoisted from the per-session loop (#10085): concept-graph gap inference is
+                // ontology-scoped — same output every invocation within a single REM cycle — so
+                // running it once after the session loop replaces N redundant traversals.
+                const conceptGapStart = Date.now();
+                await this.inferConceptGraphGaps();
+                logger.info(`[DreamService] Cycle-scope GUIDE_GAP / EXAMPLE_GAP Inference took: ${((Date.now() - conceptGapStart) / 1000).toFixed(1)}s`);
             }
 
             // Universal Fade (Garbage Collection)
@@ -235,12 +242,25 @@ class DreamService extends Base {
     }
 
     /**
-     * Executes Capability Gap Inference natively via dynamic filesystem evaluation mathematically (bypassing LLM hallucinations).
-     * @param {Object} session The wrapped session object
-     * @param {Object} payload The parsed Tri-Vector schema
+     * Cycle-scoped GUIDE_GAP / EXAMPLE_GAP inference entry point. Delegates to
+     * `GapInferenceEngine` for deterministic concept-graph edge traversal (`EXPLAINED_BY` /
+     * `EXEMPLIFIED_BY`). Output depends only on ontology state, not on any individual session —
+     * invoked once per REM cycle after the per-session loop, before `runGarbageCollection`.
+     * Paired with `inferTestGapsFromSession` (session-scoped). See #10085 for the scope split.
      */
-    async executeCapabilityGapInference(session, payload) {
-        return GapInferenceEngine.executeCapabilityGapInference(session, payload);
+    async inferConceptGraphGaps() {
+        return GapInferenceEngine.inferConceptGraphGaps();
+    }
+
+    /**
+     * Session-scoped TEST_GAP inference entry point. Delegates to `GapInferenceEngine` for
+     * structural-node (CLASS / METHOD / COMPONENT) test-file coverage checks keyed to the
+     * current session's artifact. Invoked inside the REM loop once per session.
+     * Paired with `inferConceptGraphGaps` (cycle-scoped). See #10085 for the scope split.
+     * @param {Object} payload The parsed Tri-Vector schema from `SemanticGraphExtractor`
+     */
+    async inferTestGapsFromSession(payload) {
+        return GapInferenceEngine.inferTestGapsFromSession(payload);
     }
 
     /**

--- a/ai/daemons/services/GapInferenceEngine.mjs
+++ b/ai/daemons/services/GapInferenceEngine.mjs
@@ -61,31 +61,20 @@ class GapInferenceEngine extends Base {
     }
 
     /**
-     * Main entry point invoked by DreamService per session. Executes both the structural-node
-     * TEST_GAP pass (session-artifact scoped) and the concept-graph GUIDE_GAP / EXAMPLE_GAP pass
-     * (ontology scoped — session-independent).
-     *
-     * Gaps are persisted as a JSON-array-encoded string on `node.properties.capabilityGap`; each
-     * entry carries a tag prefix (`[TEST_GAP]`, `[GUIDE_GAP]`, `[EXAMPLE_GAP]`) so
-     * `GoldenPathSynthesizer` can categorize them into the correct display section in
-     * `sandman_handoff.md`. The `lastGapCheck` timestamp supports TTL-based staleness pruning.
-     *
-     * @param {Object} session The wrapped session object
-     * @param {Object} payload The parsed Tri-Vector schema from `SemanticGraphExtractor`
-     */
-    async executeCapabilityGapInference(session, payload) {
-        await this.inferTestGapsFromSession(payload);
-        await this.inferConceptGraphGaps();
-    }
-
-    /**
-     * Pass 1: per-structural-node TEST_GAP inference. Iterates CLASS / METHOD / COMPONENT nodes
+     * Session-scoped TEST_GAP inference entry point. Iterates CLASS / METHOD / COMPONENT nodes
      * from the session artifact and checks for a matching test file via tokenized regex scan.
      * Preserved from pre-#10035 behavior. Internal-config lifecycle hooks (`beforeSet*`,
      * `afterSet*`, `beforeGet*`) are excluded since they're structurally shared and not
      * individually testable.
-     * @param {Object} payload The parsed Tri-Vector schema
-     * @protected
+     *
+     * Gaps are persisted as a JSON-array-encoded string on `node.properties.capabilityGap` with
+     * `[TEST_GAP]` prefix so `GoldenPathSynthesizer` can categorize them into the correct
+     * `sandman_handoff.md` section. The `lastGapCheck` timestamp supports TTL-based staleness
+     * pruning.
+     *
+     * Paired with `inferConceptGraphGaps` — which runs at cycle-scope, not per-session — to form
+     * the full capability-gap pass. See #10085 for the scope split rationale.
+     * @param {Object} payload The parsed Tri-Vector schema from `SemanticGraphExtractor`
      */
     async inferTestGapsFromSession(payload) {
         if (!payload || !payload.session_artifact || !payload.session_artifact.graph || !payload.session_artifact.graph.nodes) return;
@@ -148,7 +137,11 @@ class GapInferenceEngine extends Base {
      * (`file:learn/guides/X.md`, `ext:react-jsx`) that are deliberately NOT materialized as graph
      * nodes. `getAdjacentNodes` would return empty for these targets and mis-flag every concept
      * as a guide gap. See #10035 for the architectural decision.
-     * @protected
+     *
+     * **Scope:** cycle-scoped. Output depends only on ontology state, not on any individual
+     * session — invoked once per REM cycle from `DreamService.processUndigestedSessions` after
+     * the per-session loop, before garbage collection. See #10085 for why this was hoisted out
+     * of the per-session loop.
      */
     async inferConceptGraphGaps() {
         const conceptNodes = GraphService.db.nodes.items.filter(n => n.label === 'CONCEPT');

--- a/test/playwright/unit/ai/daemons/DreamService.spec.mjs
+++ b/test/playwright/unit/ai/daemons/DreamService.spec.mjs
@@ -303,6 +303,89 @@ test.describe('Neo.ai.mcp.server.memory-core.services.DreamService', () => {
         expect(node.properties?.capabilityGap).toBeUndefined();
     });
 
+    test('processUndigestedSessions calls inferTestGapsFromSession per-session and inferConceptGraphGaps once per cycle (hoist contract — #10085)', async () => {
+        // Locks in the #10085 Item 1 contract: the concept-graph pass is ontology-scoped, so it
+        // must fire exactly once per REM cycle regardless of session count — not N times inside
+        // the per-session loop like the pre-refactor `executeCapabilityGapInference` wrapper did.
+        // Guards against any future "simplification" that re-inlines the cycle-scope call back
+        // into the session loop and silently reintroduces N×M traversal cost at ontology scale.
+
+        const aiConfig                = (await import('../../../../../ai/mcp/server/memory-core/config.mjs')).default;
+        const ConceptIngestor         = (await import('../../../../../ai/daemons/services/ConceptIngestor.mjs')).default;
+        const FileSystemIngestor      = (await import('../../../../../ai/mcp/server/memory-core/services/FileSystemIngestor.mjs')).default;
+        const TopologyInferenceEngine = (await import('../../../../../ai/daemons/services/TopologyInferenceEngine.mjs')).default;
+
+        const sessionCount = 3;
+        const mockSessions = Array.from({length: sessionCount}, (_, i) => ({
+            id      : `sess-${i}`,
+            document: 'mock-document',
+            meta    : {sessionId: `sess-${i}`, title: `Mock Session ${i}`}
+        }));
+
+        let testGapCalls                           = 0;
+        let conceptGapCalls                        = 0;
+        let sessionUpdateCount                     = 0;
+        let conceptGapCalledAfterLastSessionUpdate = false;
+
+        const orig = {
+            provider           : aiConfig.modelProvider,
+            findUndigested     : DreamService.findUndigestedSessions,
+            sessionsCollection : DreamService.sessionsCollection,
+            inferTest          : DreamService.inferTestGapsFromSession,
+            inferConcept       : DreamService.inferConceptGraphGaps,
+            runGarbageCol      : DreamService.runGarbageCollection,
+            synthesizeGolden   : DreamService.synthesizeGoldenPath,
+            triVector          : SemanticGraphExtractor.executeTriVectorExtraction,
+            syncConcepts       : ConceptIngestor.syncConceptsToGraph,
+            syncFs             : FileSystemIngestor.syncWorkspaceToGraph,
+            extractTopo        : TopologyInferenceEngine.extractTopology,
+            isProcessing       : DreamService.isProcessing
+        };
+
+        try {
+            aiConfig.modelProvider    = 'mock-provider';
+            DreamService.isProcessing = false;
+
+            DreamService.findUndigestedSessions = async () => mockSessions;
+            DreamService.sessionsCollection     = {
+                update: async () => { sessionUpdateCount++; }
+            };
+            DreamService.inferTestGapsFromSession = async () => { testGapCalls++; };
+            DreamService.inferConceptGraphGaps    = async () => {
+                conceptGapCalls++;
+                conceptGapCalledAfterLastSessionUpdate = (sessionUpdateCount === sessionCount);
+            };
+            DreamService.runGarbageCollection = async () => {};
+            DreamService.synthesizeGoldenPath = async () => {};
+
+            SemanticGraphExtractor.executeTriVectorExtraction = async () => ({
+                session_artifact: {graph: {nodes: [], edges: []}}
+            });
+            ConceptIngestor.syncConceptsToGraph     = async () => ({});
+            FileSystemIngestor.syncWorkspaceToGraph = async () => {};
+            TopologyInferenceEngine.extractTopology = async () => {};
+
+            await DreamService.processUndigestedSessions();
+
+            expect(testGapCalls).toBe(sessionCount);
+            expect(conceptGapCalls).toBe(1);
+            expect(conceptGapCalledAfterLastSessionUpdate).toBe(true);
+        } finally {
+            aiConfig.modelProvider                            = orig.provider;
+            DreamService.findUndigestedSessions               = orig.findUndigested;
+            DreamService.sessionsCollection                   = orig.sessionsCollection;
+            DreamService.inferTestGapsFromSession             = orig.inferTest;
+            DreamService.inferConceptGraphGaps                = orig.inferConcept;
+            DreamService.runGarbageCollection                 = orig.runGarbageCol;
+            DreamService.synthesizeGoldenPath                 = orig.synthesizeGolden;
+            SemanticGraphExtractor.executeTriVectorExtraction = orig.triVector;
+            ConceptIngestor.syncConceptsToGraph               = orig.syncConcepts;
+            FileSystemIngestor.syncWorkspaceToGraph           = orig.syncFs;
+            TopologyInferenceEngine.extractTopology           = orig.extractTopo;
+            DreamService.isProcessing                         = orig.isProcessing;
+        }
+    });
+
     test('synthesizeGoldenPath should mathematically select and inject Golden Path while rejecting BLOCKS', async () => {
         // Mock StorageRouter to return deterministic ChromaDB metric formats
         const originalGetSummary = StorageRouter.getSummaryCollection;

--- a/test/playwright/unit/ai/daemons/DreamService.spec.mjs
+++ b/test/playwright/unit/ai/daemons/DreamService.spec.mjs
@@ -181,8 +181,8 @@ test.describe('Neo.ai.mcp.server.memory-core.services.DreamService', () => {
 
         // Suppress QueryService dynamic import execution during this deterministic test
         const originalImport = global.import;
-        // 3. Trigger REM sleep cycle
-        await DreamService.executeCapabilityGapInference(session, payload);
+        // 3. Trigger session-scoped TEST_GAP inference (post-#10085 scope split)
+        await DreamService.inferTestGapsFromSession(payload);
 
         // Validate gaps are stored on the node correctly
         const updatedNode = GraphService.db.nodes.get('mock-file-1');
@@ -239,11 +239,8 @@ test.describe('Neo.ai.mcp.server.memory-core.services.DreamService', () => {
             type  : 'EXEMPLIFIED_BY'
         });
 
-        // Empty session payload — concept-graph pass is session-independent
-        const payload = {session_artifact: {graph: {nodes: [], edges: []}}};
-        const session = {meta: {sessionId: 'playwright-concept-graph-session'}};
-
-        await DreamService.executeCapabilityGapInference(session, payload);
+        // Concept-graph pass is session-independent (hoisted to cycle-scope in #10085).
+        await DreamService.inferConceptGraphGaps();
 
         const covered     = GraphService.db.nodes.get('concept-covered');
         const missingGuide = GraphService.db.nodes.get('concept-missing-guide');
@@ -279,10 +276,7 @@ test.describe('Neo.ai.mcp.server.memory-core.services.DreamService', () => {
             type  : 'EXPLAINED_BY'
         });
 
-        await DreamService.executeCapabilityGapInference(
-            {meta: {sessionId: 'playwright-example-gap-session'}},
-            {session_artifact: {graph: {nodes: [], edges: []}}}
-        );
+        await DreamService.inferConceptGraphGaps();
 
         const node = GraphService.db.nodes.get('concept-no-example');
 
@@ -302,10 +296,7 @@ test.describe('Neo.ai.mcp.server.memory-core.services.DreamService', () => {
             properties: {name: 'MinorHelper', tier: 3, uniqueToNeo: false, weight: 0.3}
         });
 
-        await DreamService.executeCapabilityGapInference(
-            {meta: {sessionId: 'playwright-low-weight-session'}},
-            {session_artifact: {graph: {nodes: [], edges: []}}}
-        );
+        await DreamService.inferConceptGraphGaps();
 
         const node = GraphService.db.nodes.get('concept-low-weight');
 

--- a/test/playwright/unit/ai/daemons/services/ConceptIngestor.spec.mjs
+++ b/test/playwright/unit/ai/daemons/services/ConceptIngestor.spec.mjs
@@ -103,6 +103,17 @@ test.describe('Neo.ai.daemons.services.ConceptIngestor', () => {
         if (tmpConceptsDir && fs.existsSync(tmpConceptsDir)) {
             try { fs.rmSync(tmpConceptsDir, {recursive: true}); } catch (e) {}
         }
+
+        // Symmetric cleanup: ConceptService is a cross-spec singleton. Under `fullyParallel: true`
+        // Playwright interleaves tests from multiple spec files in the same worker, so leaving
+        // `loaded = true` after our last sync call leaks state into ConceptService.spec.mjs tests
+        // that assert fresh-module state (e.g. `should throw if query methods are called before
+        // loadGraph`). Resetting here, not only in beforeEach, closes that cross-spec door.
+        ConceptService.nodes.clear();
+        ConceptService.edgesBySource.clear();
+        ConceptService.edgesByTarget.clear();
+        ConceptService.aliasIndex.clear();
+        ConceptService.loaded = false;
     });
 
     test.afterAll(() => {
@@ -263,25 +274,34 @@ test.describe('Neo.ai.daemons.services.ConceptIngestor', () => {
             ]
         );
 
-        await ConceptIngestor.syncConceptsToGraph();
+        const first = await ConceptIngestor.syncConceptsToGraph();
         const nodesAfterFirst = new Set(GraphService.db.nodes.items.map(n => n.id));
         const edgesAfterFirst = GraphService.db.edges.items
             .map(e => `${e.source}|${e.target}|${e.type}`)
             .sort()
             .join('\n');
 
-        await ConceptIngestor.syncConceptsToGraph();
+        const second = await ConceptIngestor.syncConceptsToGraph();
         const nodesAfterSecond = new Set(GraphService.db.nodes.items.map(n => n.id));
         const edgesAfterSecond = GraphService.db.edges.items
             .map(e => `${e.source}|${e.target}|${e.type}`)
             .sort()
             .join('\n');
 
+        // Graph-state equivalence
         expect(nodesAfterSecond.size).toBe(nodesAfterFirst.size);
         for (const id of nodesAfterFirst) {
             expect(nodesAfterSecond.has(id)).toBe(true);
         }
         expect(edgesAfterSecond).toBe(edgesAfterFirst);
+
+        // Skip-path contract: idempotency means the second sync must hit the hash-match skip path
+        // rather than re-upsert (which could silently diverge if differential-sync regressed).
+        // Without this assertion, a broken skip path that still produced identical final state
+        // would pass the graph-equivalence checks above — false green.
+        expect(second.conceptsSkipped).toBe(first.conceptsProcessed);
+        expect(second.conceptsUpserted).toBe(0);
+        expect(second.edgesReplaced).toBe(0);
     });
 
     test('should return stats object with the documented shape', async () => {

--- a/test/playwright/unit/ai/daemons/services/ConceptIngestor.spec.mjs
+++ b/test/playwright/unit/ai/daemons/services/ConceptIngestor.spec.mjs
@@ -1,0 +1,309 @@
+import {setup} from '../../../../setup.mjs';
+
+const appName = 'ConceptIngestorTest';
+
+setup({
+    neoConfig: {
+        unitTestMode: true
+    },
+    appConfig: {
+        name             : appName,
+        isMounted        : () => true,
+        vnodeInitialising: false
+    }
+});
+
+import {test, expect} from '@playwright/test';
+import Neo            from '../../../../../../src/Neo.mjs';
+import * as core      from '../../../../../../src/core/_export.mjs';
+import fs             from 'fs';
+import path           from 'path';
+import os             from 'os';
+
+test.describe('Neo.ai.daemons.services.ConceptIngestor', () => {
+    let GraphService;
+    let ConceptIngestor;
+    let ConceptService;
+    let logger;
+    let SystemLifecycleService;
+
+    const testDbName = `memory-core-concept-ingestor-test-${process.pid}-${Date.now()}.sqlite`;
+    let testDbPath;
+    let tmpConceptsDir;
+
+    let originalWarn;
+    let warnMessages = [];
+
+    test.beforeAll(async () => {
+        const aiConfig = (await import('../../../../../../ai/mcp/server/memory-core/config.mjs')).default;
+
+        const tmpDir = path.resolve(process.cwd(), 'tmp');
+        if (!fs.existsSync(tmpDir)) {
+            fs.mkdirSync(tmpDir, {recursive: true});
+        }
+        testDbPath = path.join(tmpDir, testDbName);
+
+        aiConfig.storagePaths.graph   = testDbPath;
+        aiConfig.autoIngestFileSystem = false;
+        aiConfig.handoffFilePath      = path.join(tmpDir, 'mock_sandman_handoff_concept_ingestor.md');
+
+        GraphService           = (await import('../../../../../../ai/mcp/server/memory-core/services/GraphService.mjs')).default;
+        ConceptIngestor        = (await import('../../../../../../ai/daemons/services/ConceptIngestor.mjs')).default;
+        ConceptService         = (await import('../../../../../../ai/services/ConceptService.mjs')).default;
+        logger                 = (await import('../../../../../../ai/mcp/server/memory-core/logger.mjs')).default;
+        SystemLifecycleService = (await import('../../../../../../ai/mcp/server/memory-core/services/lifecycle/SystemLifecycleService.mjs')).default;
+
+        if (fs.existsSync(testDbPath)) {
+            try {
+                fs.unlinkSync(testDbPath);
+                if (fs.existsSync(`${testDbPath}-wal`)) fs.unlinkSync(`${testDbPath}-wal`);
+                if (fs.existsSync(`${testDbPath}-shm`)) fs.unlinkSync(`${testDbPath}-shm`);
+            } catch (e) {}
+        }
+
+        if (!SystemLifecycleService._initPromise) {
+            await SystemLifecycleService.initAsync();
+        } else {
+            await SystemLifecycleService.ready();
+        }
+    });
+
+    test.beforeEach(() => {
+        ConceptService.nodes.clear();
+        ConceptService.edgesBySource.clear();
+        ConceptService.edgesByTarget.clear();
+        ConceptService.aliasIndex.clear();
+        ConceptService.loaded = false;
+
+        tmpConceptsDir = fs.mkdtempSync(path.join(os.tmpdir(), 'neo-concept-ingestor-test-'));
+        ConceptService.defaultConceptsDir = tmpConceptsDir;
+
+        if (GraphService.db) {
+            GraphService.db.nodes.clear();
+            GraphService.db.edges.clear();
+            GraphService.db.vicinityLoadedNodes.clear();
+
+            if (GraphService.db.storage?.db) {
+                GraphService.db.storage.clear();
+                GraphService.db.storage.db.exec('DELETE FROM GraphLog');
+                GraphService.db.lastSyncId = 0;
+            }
+        }
+
+        warnMessages = [];
+        originalWarn = logger.warn;
+        logger.warn  = (...args) => {
+            warnMessages.push(args.map(a => typeof a === 'string' ? a : JSON.stringify(a)).join(' '));
+        };
+    });
+
+    test.afterEach(() => {
+        if (originalWarn) logger.warn = originalWarn;
+
+        if (tmpConceptsDir && fs.existsSync(tmpConceptsDir)) {
+            try { fs.rmSync(tmpConceptsDir, {recursive: true}); } catch (e) {}
+        }
+    });
+
+    test.afterAll(() => {
+        if (GraphService?.db) {
+            if (GraphService.db.storage?.db) {
+                try { GraphService.db.storage.db.close(); } catch (e) {}
+            }
+            GraphService.db           = null;
+            GraphService._initPromise = null;
+        }
+
+        if (SystemLifecycleService) {
+            SystemLifecycleService._initPromise = null;
+        }
+
+        if (fs.existsSync(testDbPath)) {
+            try { fs.unlinkSync(testDbPath); } catch (e) {}
+            if (fs.existsSync(`${testDbPath}-wal`)) try { fs.unlinkSync(`${testDbPath}-wal`); } catch (e) {}
+            if (fs.existsSync(`${testDbPath}-shm`)) try { fs.unlinkSync(`${testDbPath}-shm`); } catch (e) {}
+        }
+    });
+
+    /**
+     * Writes the given nodes + edges into the per-test concept fixture dir as JSONL files
+     * the ConceptService will pick up on the next `loadGraph()` call.
+     * @param {Object[]} nodes
+     * @param {Object[]} edges
+     */
+    function writeFixture(nodes, edges) {
+        fs.writeFileSync(
+            path.join(tmpConceptsDir, 'nodes.jsonl'),
+            nodes.map(n => JSON.stringify(n)).join('\n'),
+            'utf8'
+        );
+        fs.writeFileSync(
+            path.join(tmpConceptsDir, 'edges.jsonl'),
+            edges.map(e => JSON.stringify(e)).join('\n'),
+            'utf8'
+        );
+    }
+
+    test('should skip unchanged concepts via payload hash match (differential sync)', async () => {
+        writeFixture(
+            [{id: 'threading', name: 'Multi-Threading', tier: 1, description: 'Workers', uniqueToNeo: true, tags: ['arch']}],
+            [{source: 'threading', target: 'file:src/worker/Manager.mjs', type: 'IMPLEMENTED_BY'}]
+        );
+
+        const first = await ConceptIngestor.syncConceptsToGraph();
+        expect(first.conceptsProcessed).toBe(1);
+        expect(first.conceptsUpserted).toBe(1);
+        expect(first.conceptsSkipped).toBe(0);
+
+        const second = await ConceptIngestor.syncConceptsToGraph();
+        expect(second.conceptsProcessed).toBe(1);
+        expect(second.conceptsUpserted).toBe(0);
+        expect(second.conceptsSkipped).toBe(1);
+    });
+
+    test('should re-upsert concept when payload fields change (hash mismatch)', async () => {
+        writeFixture(
+            [{id: 'threading', name: 'Multi-Threading', tier: 1, description: 'Original description', uniqueToNeo: true, tags: ['arch']}],
+            [{source: 'threading', target: 'file:src/worker/Manager.mjs', type: 'IMPLEMENTED_BY'}]
+        );
+
+        await ConceptIngestor.syncConceptsToGraph();
+
+        writeFixture(
+            [{id: 'threading', name: 'Multi-Threading', tier: 1, description: 'Updated description', uniqueToNeo: true, tags: ['arch']}],
+            [{source: 'threading', target: 'file:src/worker/Manager.mjs', type: 'IMPLEMENTED_BY'}]
+        );
+
+        const second = await ConceptIngestor.syncConceptsToGraph();
+        expect(second.conceptsUpserted).toBe(1);
+        expect(second.conceptsSkipped).toBe(0);
+
+        const node = GraphService.db.nodes.get('threading');
+        expect(node.properties.description).toBe('Updated description');
+    });
+
+    test('should emit logger.warn for orphan concepts (tier > 0, no IMPLEMENTED_BY edge)', async () => {
+        writeFixture(
+            [
+                {id: 'anchored', name: 'Anchored Concept', tier: 1, description: 'Has implementation', uniqueToNeo: false, tags: []},
+                {id: 'orphan',   name: 'Orphan Concept',   tier: 1, description: 'No source anchor',   uniqueToNeo: false, tags: []}
+            ],
+            [{source: 'anchored', target: 'file:src/Anchored.mjs', type: 'IMPLEMENTED_BY'}]
+        );
+
+        const stats = await ConceptIngestor.syncConceptsToGraph();
+
+        expect(stats.orphansDetected).toBe(1);
+
+        const orphanWarn = warnMessages.find(m => m.includes('Orphan concept detected'));
+        expect(orphanWarn).toBeDefined();
+        expect(orphanWarn).toContain('Orphan Concept');
+        expect(orphanWarn).toContain('orphan');
+    });
+
+    test('should persist only edges with canonical CONCEPT_EDGE_TYPES', async () => {
+        writeFixture(
+            [{id: 'a', name: 'A', tier: 1, description: '', uniqueToNeo: false, tags: []}],
+            [
+                {source: 'a', target: 'file:a.mjs',         type: 'IMPLEMENTED_BY'},
+                {source: 'a', target: 'file:a-guide.md',    type: 'EXPLAINED_BY'},
+                {source: 'a', target: 'file:a-invalid.md',  type: 'INVALID_TYPE'}
+            ]
+        );
+
+        await ConceptIngestor.syncConceptsToGraph();
+
+        const outbound = GraphService.db.edges.getByIndex('source', 'a');
+        const types    = outbound.map(e => e.type);
+
+        expect(types).toContain('IMPLEMENTED_BY');
+        expect(types).toContain('EXPLAINED_BY');
+        expect(types).not.toContain('INVALID_TYPE');
+    });
+
+    test('should seed stub nodes for edge targets with correct namespace labels (file:/ext:/concept)', async () => {
+        writeFixture(
+            [
+                {id: 'a', name: 'A', tier: 1, description: '', uniqueToNeo: false, tags: []},
+                {id: 'b', name: 'B', tier: 2, description: '', uniqueToNeo: false, tags: []}
+            ],
+            [
+                {source: 'a', target: 'file:src/A.mjs',  type: 'IMPLEMENTED_BY'},
+                {source: 'a', target: 'ext:react-hooks', type: 'ANALOGOUS_TO'},
+                {source: 'a', target: 'b',               type: 'PARENT_CONCEPT'}
+            ]
+        );
+
+        await ConceptIngestor.syncConceptsToGraph();
+
+        const fileNode = GraphService.db.nodes.get('file:src/A.mjs');
+        expect(fileNode).toBeDefined();
+        expect(fileNode.label).toBe('FILE');
+
+        const extNode = GraphService.db.nodes.get('ext:react-hooks');
+        expect(extNode).toBeDefined();
+        expect(extNode.label).toBe('EXT');
+
+        // Concept 'b' is materialized as a real CONCEPT node by its own upsert (no stub), not by the stub pathway.
+        const conceptB = GraphService.db.nodes.get('b');
+        expect(conceptB).toBeDefined();
+        expect(conceptB.label).toBe('CONCEPT');
+    });
+
+    test('should produce identical graph state across two consecutive sync calls (idempotency)', async () => {
+        writeFixture(
+            [
+                {id: 'a', name: 'A', tier: 1, description: '', uniqueToNeo: false, tags: []},
+                {id: 'b', name: 'B', tier: 2, description: '', uniqueToNeo: false, tags: []}
+            ],
+            [
+                {source: 'a', target: 'file:a.mjs', type: 'IMPLEMENTED_BY'},
+                {source: 'b', target: 'file:b.mjs', type: 'IMPLEMENTED_BY'},
+                {source: 'a', target: 'b',          type: 'PARENT_CONCEPT'}
+            ]
+        );
+
+        await ConceptIngestor.syncConceptsToGraph();
+        const nodesAfterFirst = new Set(GraphService.db.nodes.items.map(n => n.id));
+        const edgesAfterFirst = GraphService.db.edges.items
+            .map(e => `${e.source}|${e.target}|${e.type}`)
+            .sort()
+            .join('\n');
+
+        await ConceptIngestor.syncConceptsToGraph();
+        const nodesAfterSecond = new Set(GraphService.db.nodes.items.map(n => n.id));
+        const edgesAfterSecond = GraphService.db.edges.items
+            .map(e => `${e.source}|${e.target}|${e.type}`)
+            .sort()
+            .join('\n');
+
+        expect(nodesAfterSecond.size).toBe(nodesAfterFirst.size);
+        for (const id of nodesAfterFirst) {
+            expect(nodesAfterSecond.has(id)).toBe(true);
+        }
+        expect(edgesAfterSecond).toBe(edgesAfterFirst);
+    });
+
+    test('should return stats object with the documented shape', async () => {
+        writeFixture(
+            [{id: 'a', name: 'A', tier: 1, description: '', uniqueToNeo: false, tags: []}],
+            [{source: 'a', target: 'file:a.mjs', type: 'IMPLEMENTED_BY'}]
+        );
+
+        const stats = await ConceptIngestor.syncConceptsToGraph();
+
+        expect(stats).toHaveProperty('conceptsProcessed');
+        expect(stats).toHaveProperty('conceptsUpserted');
+        expect(stats).toHaveProperty('conceptsSkipped');
+        expect(stats).toHaveProperty('edgesReplaced');
+        expect(stats).toHaveProperty('orphansDetected');
+        expect(stats).toHaveProperty('errors');
+
+        expect(typeof stats.conceptsProcessed).toBe('number');
+        expect(typeof stats.conceptsUpserted).toBe('number');
+        expect(typeof stats.conceptsSkipped).toBe('number');
+        expect(typeof stats.edgesReplaced).toBe('number');
+        expect(typeof stats.orphansDetected).toBe('number');
+        expect(Array.isArray(stats.errors)).toBe(true);
+    });
+});


### PR DESCRIPTION
## Summary

Lands Items 1 + 2 of #10085 — hoisted `inferConceptGraphGaps` from per-session to cycle-scope (efficiency) and added a dedicated ConceptIngestor unit spec (coverage). Items 3 + 4 dropped after scope review; see rationale below.

## The Problem

#10084 (resolving #10035) replaced regex + LLM-verification guide-gap detection with deterministic concept-graph edge traversal. The refactor's self-review flagged four polish items as optional follow-ups. #10085 bundled all four. Ticket-intake review found that two of the four fail the Hypothesis-vs-Root-Cause gate: they prescribe logger-based fixes for a daemon where logger output is ephemeral and observability lives durably on graph nodes + `sandman_handoff.md`.

## Architectural Reality (verified against precedent)

- `ai/daemons/services/GapInferenceEngine.mjs` — pre-refactor `executeCapabilityGapInference(session, payload)` called both passes per session. The `inferConceptGraphGaps` pass filters `GraphService.db.nodes.items` by `label === 'CONCEPT'` — ontology-scoped, session-independent. Each per-session re-invocation produced identical output: N redundant traversals per REM cycle.
- `ai/daemons/DreamService.mjs` — Phase 0 (`ConceptIngestor.syncConceptsToGraph`) and the per-session `executeCapabilityGapInference` both nested in the undigested-sessions `else` branch. Cycle-scope hoist lives in the same branch, after the session for-loop, before `runGarbageCollection`. Placement mirrors #10084's Phase 0 pattern.
- `ai/daemons/services/GoldenPathSynthesizer.mjs:254-295` — downstream consumer. Scans all nodes, parses `capabilityGap` JSON arrays with tag prefixes (`[TEST_GAP]`/`[GUIDE_GAP]`/`[EXAMPLE_GAP]`), TTL-prunes at 7 days, renders dedicated sections in `sandman_handoff.md`. This is the durable observability substrate. `DreamService.spec.mjs` asserts on `node.properties.capabilityGap` and `sandman_handoff.md` file contents; **zero** assertions on logger output.
- `ai/mcp/server/memory-core/logger.mjs` — simple mutable object, gated by `aiConfig.debug`. Ephemeral. Suitable for phase-level progress only, not durable signals.

## Items landed

### Item 1 — cycle-scope hoist

Extracted `inferConceptGraphGaps` from the per-session wrapper; deleted `executeCapabilityGapInference`; promoted both inference entry points (`inferTestGapsFromSession`, `inferConceptGraphGaps`) from `@protected` to public API with matching thin facades on `DreamService`. Added cycle-scope call in `processUndigestedSessions` after the session loop, before garbage collection. Expanded Anchor JSDoc on both inference methods to echo the scope split so future `ask_knowledge_base` queries surface the right substrate.

### Item 2 — dedicated unit spec

Created `test/playwright/unit/ai/daemons/services/ConceptIngestor.spec.mjs`. Six AC coverage targets plus stats-shape contract:

| # | Target | Mechanism |
|---|---|---|
| 1 | Differential-sync **skip** path | sync twice with same fixture; assert `conceptsSkipped === 1` |
| 2 | Differential-sync **upsert** path | mutate description between syncs; assert `conceptsUpserted === 1` + persisted node reflects update |
| 3 | Orphan detection + `logger.warn` | monkey-patch `logger.warn`; fixture with one tier-1 concept lacking `IMPLEMENTED_BY`; assert `orphansDetected === 1` and warn message contains concept name |
| 4 | Canonical `CONCEPT_EDGE_TYPES` filtering | fixture with `IMPLEMENTED_BY` + `EXPLAINED_BY` + `INVALID_TYPE`; assert only canonical survived |
| 5 | Stub-node seeding by namespace | fixture with `file:` / `ext:` / concept-id edge targets; assert labels `FILE` / `EXT` / `CONCEPT` |
| 6 | Idempotency | two sync calls produce identical graph state (nodes + edges) |
| 7 | Stats return-shape contract | all six stats fields present with correct types |

## Items dropped from scope (rationale)

### Item 3 — `logger.info` stats re-emission in DreamService

**Dropped as redundant.** `ConceptIngestor.syncConceptsToGraph` already emits a phase-level summary `logger.info` at completion (`ai/daemons/services/ConceptIngestor.mjs:272`): `"[ConceptIngestor] Sync complete: X upserted, Y unchanged, Z edges, N orphans."` A DreamService-level re-emission adds noise at a second call site without a downstream consumer. The Item 3 premise ("the return shape exists so surface it") inverts the reasoning — presence of a return value isn't demand for a log line.

### Item 4 — consolidate per-orphan `logger.warn`

**Superseded by #10087**, which defines the correct architecture for orphan surfacing:

- New `[ORPHAN_CONCEPT]` tag in the existing `capabilityGap` channel (same pattern as `[EXAMPLE_GAP]` in #10084)
- Weight-gated by the same `GUIDE_GAP_WEIGHT_THRESHOLD` as `[GUIDE_GAP]` — silent today when ingestion derives concepts from guide titles only; auto-surfaces as richer ingestion from #10036 / #10037 / #10050 populates meaningful weight signals
- Rendered as `⚠️ Orphaned Concepts` section in `sandman_handoff.md` via `GoldenPathSynthesizer` — uniform 5-item limit + TTL pruning
- Action-biased entry text: *"Concept X has no IMPLEMENTED_BY — either write a guide / add an implementation, or retire from nodes.jsonl."*
- `logger.warn` deleted entirely once the capabilityGap channel covers the signal

Landing Item 4 here would cement the wrong mechanism (logger-based) right before #10087 replaces it. Per-orphan warn preserved in this PR; deletion ships with the #10087 follow-up.

## Gold Standards Leveraged / Traps Avoided

- **Gold Standard** (#10084 Phase-0 placement): cycle-scope hoist lives in the same `else` branch as `ConceptIngestor.syncConceptsToGraph` — consistent scope semantics.
- **Gold Standard** (tag-prefix taxonomy in capabilityGap): preserved the invariant that all concept-level gaps land on the same property with distinct tags. #10087 extends, not replaces.
- **Trap avoided** (logger as observability plane): DreamService is offline-run; logger lines scroll off. Tests assert on graph state + file contents; zero assertions on logs.
- **Trap avoided** (scope creep): the self-review flagged 4 items as "optional polish" — ticket-intake found only 2 belong here; the other 2 are architecturally entangled with #10087. Splitting cleanly avoids a rewrite cycle.

## Testing

```bash
npm run test-unit -- test/playwright/unit/ai/services/ConceptService.spec.mjs test/playwright/unit/ai/daemons/
```

**37 passed** — ConceptService 23, DreamService 6, DreamServiceGoldenPath 1, ConceptIngestor 7 new. Verified stable across 3 consecutive runs.

## Out of Scope / Follow-Up

- **#10087** — ORPHAN_CONCEPT channel promotion (architecture defined above); scheduled as the immediate next PR.
- **#10086** — config-lift `guideGapWeightThreshold` to `aiConfig.data` (when human tuning becomes real).

## Related

- Parent: #10030 (Concept Ontology & Semantic Gap Inference)
- Origin PR: #10084 (Required Actions section flagged all 4 items as polish)
- Sibling follow-ups not scoped here: #10086, #10087

Resolves #10085 (Items 1 + 2 landed; Items 3 + 4 closed as redundant / superseded — see ticket comment documenting the scope reduction)

Origin Session ID: 1db25bbe-f39d-4dcd-bb0e-bc125ce91326