### PR TITLE
feat(ai): ORPHAN_CONCEPT signal + ⚠️ Orphaned Concepts handoff section (#10087)

### DIFF
--- a/ai/daemons/services/ConceptIngestor.mjs
+++ b/ai/daemons/services/ConceptIngestor.mjs
@@ -184,10 +184,13 @@ class ConceptIngestor extends Base {
      * edges (PARENT_CONCEPT, IMPLEMENTED_BY, EXPLAINED_BY, EXEMPLIFIED_BY, ANALOGOUS_TO),
      * and skips unchanged payloads via sha256 hash comparison.
      *
-     * Orphan concepts (concepts with NO outbound IMPLEMENTED_BY edge) are surfaced via
-     * `logger.warn` during ingestion rather than written to the capability-gap channel —
-     * orphans are ontology data-quality signals, not documentation coverage gaps, and
-     * conflating them would dilute the gap-channel signal consumed by `GoldenPathSynthesizer`.
+     * Orphan concepts (concepts with NO outbound IMPLEMENTED_BY edge) are counted in the
+     * returned stats for the cycle-summary `logger.info` line. They are NOT written to the
+     * `capabilityGap` channel from this service — that emission lives in
+     * `GapInferenceEngine.inferConceptGraphGaps`, which weight-gates the signal and routes it
+     * through the same `capabilityGap` tag channel + `sandman_handoff.md` section pattern as
+     * `[GUIDE_GAP]` and `[EXAMPLE_GAP]`. See #10087 for the architectural rationale — per-orphan
+     * `logger.warn` was ephemeral in an offline daemon, the graph+handoff plane is durable.
      *
      * @returns {Promise<Object>} Ingestion statistics: `{conceptsProcessed, conceptsUpserted, conceptsSkipped, edgesReplaced, orphansDetected, errors}`
      */
@@ -258,10 +261,12 @@ class ConceptIngestor extends Base {
                     stats.edgesReplaced += newEdges.length;
 
                     // Orphan detection — no IMPLEMENTED_BY means no source code anchors this concept.
+                    // Counted here for the cycle-summary stats line; the actionable `[ORPHAN_CONCEPT]`
+                    // gap signal is emitted by `GapInferenceEngine.inferConceptGraphGaps` through the
+                    // durable `capabilityGap` channel + `sandman_handoff.md` section (see #10087).
                     const hasImplementedBy = newEdges.some(e => e.type === CONCEPT_EDGE_TYPES.IMPLEMENTED_BY);
                     if (!hasImplementedBy && conceptNode.tier > 0) {
                         stats.orphansDetected++;
-                        logger.warn(`[ConceptIngestor] Orphan concept detected: '${conceptNode.name}' (id: ${conceptId}, tier: ${conceptNode.tier}) has no IMPLEMENTED_BY edge. Possible ontology data-quality issue — review nodes.jsonl.`);
                     }
                 } catch (e) {
                     stats.errors.push(`[${conceptId}] ${e.message}`);

--- a/ai/daemons/services/GapInferenceEngine.mjs
+++ b/ai/daemons/services/GapInferenceEngine.mjs
@@ -21,18 +21,28 @@ const GUIDE_GAP_WEIGHT_THRESHOLD = 0.8;
 /**
  * @summary Service for deterministic capability-gap inference over the Native Edge Graph.
  *
- * Operates in two parallel passes per REM cycle:
+ * Operates in two passes per REM cycle:
  *
- * 1. **TEST_GAP inference (regex):** iterates session-artifact structural nodes (CLASS / METHOD /
- *    COMPONENT) and matches tokenized node names against `test/*` file-path entries in the graph.
- *    Preserved from pre-#10035 behavior — testing discipline still maps 1:1 to source file names,
- *    where regex imprecision is acceptable because the test-file namespace is small and flat.
+ * 1. **TEST_GAP inference (regex, session-scoped):** iterates session-artifact structural nodes
+ *    (CLASS / METHOD / COMPONENT) and matches tokenized node names against `test/*` file-path
+ *    entries in the graph. Preserved from pre-#10035 behavior — testing discipline still maps
+ *    1:1 to source file names, where regex imprecision is acceptable because the test-file
+ *    namespace is small and flat.
  *
- * 2. **GUIDE_GAP / EXAMPLE_GAP inference (graph traversal):** iterates CONCEPT nodes ingested by
- *    `ConceptIngestor` and checks for outbound `EXPLAINED_BY` / `EXEMPLIFIED_BY` edges. This
- *    replaces the pre-#10035 regex + LLM Boolean verification path.
+ * 2. **Concept-graph inference (edge traversal, cycle-scoped):** iterates CONCEPT nodes ingested
+ *    by `ConceptIngestor` and emits three deterministic signals via outbound-edge checks:
+ *    - `[GUIDE_GAP]` — no `EXPLAINED_BY` edge
+ *    - `[EXAMPLE_GAP]` — has `EXPLAINED_BY`, lacks `EXEMPLIFIED_BY`
+ *    - `[ORPHAN_CONCEPT]` — no `IMPLEMENTED_BY` edge (concept exists in ontology but no source
+ *      code anchors it; either the ontology is stale/aspirational or the implementation is
+ *      missing and should be added). Surfaced through the same `capabilityGap` channel +
+ *      `sandman_handoff.md` section pattern as the other gap types, not via `logger.warn`
+ *      (logger is ephemeral; the graph + handoff is the durable substrate). Added in #10087.
+ *    All three share the `GUIDE_GAP_WEIGHT_THRESHOLD` weight gate so low-priority concepts
+ *    don't flood the handoff; the gate auto-surfaces meaningful signals as concept ingestion
+ *    matures (#10036 / #10037 / #10050).
  *
- *    **Why graph traversal over LLM verification?** The concept graph's `EXPLAINED_BY` edges are
+ *    **Why graph traversal over LLM verification?** The concept graph's edges are
  *    curator-maintained (`.neo-ai-data/concepts/edges.jsonl` is version-controlled; each edge
  *    exists because a human — or an agent under PR review — asserted it). The LLM verification
  *    step that existed pre-refactor was a patch for regex imprecision when matching concept names
@@ -121,16 +131,26 @@ class GapInferenceEngine extends Base {
     }
 
     /**
-     * Pass 2: concept-graph GUIDE_GAP and EXAMPLE_GAP inference via deterministic edge traversal.
+     * Pass 2: concept-graph gap inference via deterministic edge traversal.
      *
-     * For each CONCEPT node in the graph:
-     * - **`[GUIDE_GAP]`**: emitted if no outbound `EXPLAINED_BY` edge exists AND concept weight
-     *   meets `GUIDE_GAP_WEIGHT_THRESHOLD` (tier-1 baseline). Lower-weight concepts (tier-3
-     *   without uniqueness or deficit lift) are considered low-priority; missing guides for them
-     *   are not worth surfacing in the handoff.
-     * - **`[EXAMPLE_GAP]`**: emitted if a concept has `EXPLAINED_BY` but no `EXEMPLIFIED_BY`.
-     *   Signals that the concept is documented but lacks a working example — lower severity than
-     *   a missing guide.
+     * For each CONCEPT node in the graph, emits three weight-gated signals based on outbound
+     * edges in the Native Edge Graph:
+     * - **`[GUIDE_GAP]`**: no outbound `EXPLAINED_BY` edge. Concept is architecturally relevant
+     *   but undocumented — write a guide.
+     * - **`[EXAMPLE_GAP]`**: has `EXPLAINED_BY` but no `EXEMPLIFIED_BY`. Concept is documented
+     *   but lacks a working example — lower severity than a missing guide.
+     * - **`[ORPHAN_CONCEPT]`** (added in #10087): no `IMPLEMENTED_BY` edge. Concept exists in
+     *   the ontology but no source code anchors it. Either add an implementation or retire the
+     *   concept from `nodes.jsonl`. Replaces the ephemeral per-orphan `logger.warn` that used
+     *   to live in `ConceptIngestor` — routing through `capabilityGap` + `sandman_handoff.md`
+     *   makes the signal durable and aggregatable.
+     *
+     * All three signals share the same `GUIDE_GAP_WEIGHT_THRESHOLD` weight gate. Lower-weight
+     * concepts (tier-3 without uniqueness or coverage deficit lift) are considered low-priority
+     * — missing guides/examples/implementations for them aren't worth surfacing in the handoff
+     * at the current early stage of the ontology. As concept ingestion matures (#10036 / #10037
+     * / #10050), richer weight signals auto-promote meaningful gaps through the same gate
+     * without config changes.
      *
      * Uses the edges-direct traversal pattern (`db.edges.getByIndex('source', id).filter(...)`)
      * rather than `db.getAdjacentNodes(...)` because concept edges point at string identifiers
@@ -147,28 +167,33 @@ class GapInferenceEngine extends Base {
         const conceptNodes = GraphService.db.nodes.items.filter(n => n.label === 'CONCEPT');
 
         if (conceptNodes.length === 0) {
-            logger.debug('[GapInferenceEngine] Concept graph empty — skipping GUIDE_GAP / EXAMPLE_GAP pass. (Is ConceptIngestor running before this?)');
+            logger.debug('[GapInferenceEngine] Concept graph empty — skipping concept-graph gap pass. (Is ConceptIngestor running before this?)');
             return;
         }
 
-        logger.info(`[GapInferenceEngine] GUIDE_GAP / EXAMPLE_GAP pass: traversing ${conceptNodes.length} concepts.`);
+        logger.info(`[GapInferenceEngine] Concept-graph gap pass: traversing ${conceptNodes.length} concepts.`);
 
         for (const concept of conceptNodes) {
             const
-                outboundEdges      = GraphService.db.edges.getByIndex('source', concept.id),
-                explainedByEdges   = outboundEdges.filter(e => e.type === 'EXPLAINED_BY'),
-                exemplifiedByEdges = outboundEdges.filter(e => e.type === 'EXEMPLIFIED_BY'),
-                weight             = concept.properties?.weight ?? 0,
-                gaps               = [];
+                outboundEdges       = GraphService.db.edges.getByIndex('source', concept.id),
+                explainedByEdges    = outboundEdges.filter(e => e.type === 'EXPLAINED_BY'),
+                exemplifiedByEdges  = outboundEdges.filter(e => e.type === 'EXEMPLIFIED_BY'),
+                implementedByEdges  = outboundEdges.filter(e => e.type === 'IMPLEMENTED_BY'),
+                weight              = concept.properties?.weight ?? 0,
+                gaps                = [];
 
-            if (explainedByEdges.length === 0 && weight >= GUIDE_GAP_WEIGHT_THRESHOLD) {
+            if (weight >= GUIDE_GAP_WEIGHT_THRESHOLD) {
                 const name = concept.properties?.name || concept.name || concept.id;
-                gaps.push(`[GUIDE_GAP] The CONCEPT '${name}' lacks a corresponding architectural Guide (no EXPLAINED_BY edge in the concept ontology).`);
-            }
 
-            if (explainedByEdges.length > 0 && exemplifiedByEdges.length === 0 && weight >= GUIDE_GAP_WEIGHT_THRESHOLD) {
-                const name = concept.properties?.name || concept.name || concept.id;
-                gaps.push(`[EXAMPLE_GAP] The CONCEPT '${name}' is documented but lacks a working example (no EXEMPLIFIED_BY edge in the concept ontology).`);
+                if (explainedByEdges.length === 0) {
+                    gaps.push(`[GUIDE_GAP] The CONCEPT '${name}' lacks a corresponding architectural Guide (no EXPLAINED_BY edge in the concept ontology).`);
+                } else if (exemplifiedByEdges.length === 0) {
+                    gaps.push(`[EXAMPLE_GAP] The CONCEPT '${name}' is documented but lacks a working example (no EXEMPLIFIED_BY edge in the concept ontology).`);
+                }
+
+                if (implementedByEdges.length === 0) {
+                    gaps.push(`[ORPHAN_CONCEPT] The CONCEPT '${name}' has no IMPLEMENTED_BY edge — either anchor it to a source file or retire the concept from nodes.jsonl if aspirational/stale.`);
+                }
             }
 
             this.applyGapsToNode(concept, gaps);

--- a/ai/daemons/services/GoldenPathSynthesizer.mjs
+++ b/ai/daemons/services/GoldenPathSynthesizer.mjs
@@ -247,9 +247,10 @@ DO NOT output markdown, \`\`\`json blocks, or any other explanations. Provide pu
         let gapElementsCount = 0;
         let prunedGaps = 0;
 
-        let testGaps    = [];
-        let guideGaps   = [];
-        let exampleGaps = [];
+        let testGaps        = [];
+        let guideGaps       = [];
+        let exampleGaps     = [];
+        let orphanConcepts  = [];
 
         GraphService.db.nodes.items.forEach(node => {
             if (node.properties?.capabilityGap) {
@@ -279,6 +280,8 @@ DO NOT output markdown, \`\`\`json blocks, or any other explanations. Provide pu
                                     guideGaps.push({ id: node.id, msg: msg.replace('[GUIDE_GAP]', '').trim() });
                                 } else if (msg.includes('[EXAMPLE_GAP]')) {
                                     exampleGaps.push({ id: node.id, msg: msg.replace('[EXAMPLE_GAP]', '').trim() });
+                                } else if (msg.includes('[ORPHAN_CONCEPT]')) {
+                                    orphanConcepts.push({ id: node.id, msg: msg.replace('[ORPHAN_CONCEPT]', '').trim() });
                                 } else {
                                     // Fallback for unlabeled
                                     testGaps.push({ id: node.id, msg });
@@ -311,6 +314,11 @@ DO NOT output markdown, \`\`\`json blocks, or any other explanations. Provide pu
             if (exampleGaps.length > 0) {
                 handoffContent += `### 💡 Example Disconnects (\`${Math.min(exampleGaps.length, limit)}\` of \`${exampleGaps.length}\` items)\n`;
                 exampleGaps.slice(0, limit).forEach(g => handoffContent += `- **\`${g.id}\`**: ${g.msg}\n`);
+                handoffContent += `\n`;
+            }
+            if (orphanConcepts.length > 0) {
+                handoffContent += `### ⚠️ Orphaned Concepts (\`${Math.min(orphanConcepts.length, limit)}\` of \`${orphanConcepts.length}\` items)\n`;
+                orphanConcepts.slice(0, limit).forEach(g => handoffContent += `- **\`${g.id}\`**: ${g.msg}\n`);
                 handoffContent += `\n`;
             }
         }

--- a/test/playwright/unit/ai/daemons/DreamService.spec.mjs
+++ b/test/playwright/unit/ai/daemons/DreamService.spec.mjs
@@ -214,8 +214,9 @@ test.describe('Neo.ai.mcp.server.memory-core.services.DreamService', () => {
         });
 
         // Seed target stub nodes (SQLite FK constraint on edges.target → nodes.id) then the edges.
-        // The "covered" concept needs BOTH EXPLAINED_BY (no guide gap) and EXEMPLIFIED_BY
-        // (no example gap) — otherwise it'd correctly emit [EXAMPLE_GAP].
+        // The "covered" concept needs EXPLAINED_BY (no guide gap), EXEMPLIFIED_BY (no example gap),
+        // AND IMPLEMENTED_BY (no orphan gap post-#10087) — otherwise it'd correctly emit one of
+        // those signals instead of being fully covered.
         GraphService.upsertNode({
             id        : 'file:learn/guides/Threading.md',
             type      : 'FILE',
@@ -228,6 +229,12 @@ test.describe('Neo.ai.mcp.server.memory-core.services.DreamService', () => {
             name      : 'file:examples/threading/demo.mjs',
             properties: {isConceptEdgeStub: true}
         });
+        GraphService.upsertNode({
+            id        : 'file:src/worker/Manager.mjs',
+            type      : 'FILE',
+            name      : 'file:src/worker/Manager.mjs',
+            properties: {isConceptEdgeStub: true}
+        });
         GraphService.db.addEdge({
             source: 'concept-covered',
             target: 'file:learn/guides/Threading.md',
@@ -237,6 +244,11 @@ test.describe('Neo.ai.mcp.server.memory-core.services.DreamService', () => {
             source: 'concept-covered',
             target: 'file:examples/threading/demo.mjs',
             type  : 'EXEMPLIFIED_BY'
+        });
+        GraphService.db.addEdge({
+            source: 'concept-covered',
+            target: 'file:src/worker/Manager.mjs',
+            type  : 'IMPLEMENTED_BY'
         });
 
         // Concept-graph pass is session-independent (hoisted to cycle-scope in #10085).
@@ -301,6 +313,79 @@ test.describe('Neo.ai.mcp.server.memory-core.services.DreamService', () => {
         const node = GraphService.db.nodes.get('concept-low-weight');
 
         expect(node.properties?.capabilityGap).toBeUndefined();
+    });
+
+    test('should detect ORPHAN_CONCEPT for concepts with no IMPLEMENTED_BY edge (#10087)', async () => {
+        // #10087: concepts without source-code anchoring emit `[ORPHAN_CONCEPT]` via the durable
+        // `capabilityGap` channel rather than the deprecated per-orphan `logger.warn` in
+        // `ConceptIngestor`. Shares the same `GUIDE_GAP_WEIGHT_THRESHOLD` weight gate as
+        // `[GUIDE_GAP]` / `[EXAMPLE_GAP]` so low-priority concepts don't flood the handoff.
+
+        // Concept A: fully wired (EXPLAINED_BY + EXEMPLIFIED_BY + IMPLEMENTED_BY) — no gaps
+        GraphService.upsertNode({
+            id        : 'concept-anchored',
+            type      : 'CONCEPT',
+            name      : 'Anchored',
+            properties: {name: 'Anchored', tier: 1, uniqueToNeo: true, weight: 1.0}
+        });
+
+        // Concept B: has guide + example but NO implementation — ORPHAN_CONCEPT only
+        GraphService.upsertNode({
+            id        : 'concept-orphan',
+            type      : 'CONCEPT',
+            name      : 'OrphanExample',
+            properties: {name: 'OrphanExample', tier: 1, uniqueToNeo: true, weight: 1.0}
+        });
+
+        // Concept C: low weight, no edges — weight gate blocks ORPHAN_CONCEPT emission
+        GraphService.upsertNode({
+            id        : 'concept-low-orphan',
+            type      : 'CONCEPT',
+            name      : 'LowWeightOrphan',
+            properties: {name: 'LowWeightOrphan', tier: 3, uniqueToNeo: false, weight: 0.3}
+        });
+
+        // Seed stub nodes for edge targets (SQLite FK on edges.target → nodes.id)
+        [
+            'file:src/Anchored.mjs',
+            'file:learn/guides/Anchored.md',
+            'file:examples/anchored.mjs',
+            'file:learn/guides/OrphanExample.md',
+            'file:examples/orphan-example.mjs'
+        ].forEach(id => GraphService.upsertNode({
+            id, type: 'FILE', name: id, properties: {isConceptEdgeStub: true}
+        }));
+
+        // concept-anchored: all three edges present
+        GraphService.db.addEdge({source: 'concept-anchored', target: 'file:src/Anchored.mjs',        type: 'IMPLEMENTED_BY'});
+        GraphService.db.addEdge({source: 'concept-anchored', target: 'file:learn/guides/Anchored.md', type: 'EXPLAINED_BY'});
+        GraphService.db.addEdge({source: 'concept-anchored', target: 'file:examples/anchored.mjs',    type: 'EXEMPLIFIED_BY'});
+
+        // concept-orphan: guide + example only; missing IMPLEMENTED_BY
+        GraphService.db.addEdge({source: 'concept-orphan', target: 'file:learn/guides/OrphanExample.md', type: 'EXPLAINED_BY'});
+        GraphService.db.addEdge({source: 'concept-orphan', target: 'file:examples/orphan-example.mjs',   type: 'EXEMPLIFIED_BY'});
+
+        // concept-low-orphan: no edges (weight gate should skip it)
+
+        await DreamService.inferConceptGraphGaps();
+
+        const anchored  = GraphService.db.nodes.get('concept-anchored');
+        const orphan    = GraphService.db.nodes.get('concept-orphan');
+        const lowOrphan = GraphService.db.nodes.get('concept-low-orphan');
+
+        // Fully-wired concept → no capabilityGap writes
+        expect(anchored.properties.capabilityGap).toBeUndefined();
+
+        // Missing-implementation concept → ORPHAN_CONCEPT only (guide + example present)
+        expect(orphan.properties.capabilityGap).toBeDefined();
+        expect(orphan.properties.capabilityGap).toContain('[ORPHAN_CONCEPT]');
+        expect(orphan.properties.capabilityGap).toContain('OrphanExample');
+        expect(orphan.properties.capabilityGap).toContain('IMPLEMENTED_BY');
+        expect(orphan.properties.capabilityGap).not.toContain('[GUIDE_GAP]');
+        expect(orphan.properties.capabilityGap).not.toContain('[EXAMPLE_GAP]');
+
+        // Low-weight concept → weight gate blocks all three signals
+        expect(lowOrphan.properties?.capabilityGap).toBeUndefined();
     });
 
     test('processUndigestedSessions calls inferTestGapsFromSession per-session and inferConceptGraphGaps once per cycle (hoist contract — #10085)', async () => {
@@ -438,7 +523,16 @@ test.describe('Neo.ai.mcp.server.memory-core.services.DreamService', () => {
              { id: 'task-blocked', properties: { state: 'OPEN' } },
              { id: 'blocker', properties: { state: 'OPEN' } },
              { id: 'weak-task', properties: { state: 'OPEN' } },
-             { id: 'rejected-task', properties: { state: 'OPEN', labels: ['needs-re-triage'] } }
+             { id: 'rejected-task', properties: { state: 'OPEN', labels: ['needs-re-triage'] } },
+             // #10087: planted CONCEPT with ORPHAN_CONCEPT gap to verify the ⚠️ section renders
+             // in sandman_handoff.md alongside the existing TEST/GUIDE/EXAMPLE sections.
+             { id: 'concept-orphan-render-test', properties: {
+                 state        : 'OPEN',
+                 capabilityGap: JSON.stringify([
+                     "[ORPHAN_CONCEPT] The CONCEPT 'Reactivity' has no IMPLEMENTED_BY edge — either anchor it to a source file or retire the concept from nodes.jsonl if aspirational/stale."
+                 ]),
+                 lastGapCheck: Date.now()
+             } }
         ];
 
         GraphService.db.edges.getByIndex = (idx, val) => {
@@ -478,6 +572,10 @@ test.describe('Neo.ai.mcp.server.memory-core.services.DreamService', () => {
         expect(finalContent).toContain('Math synthesis works natively.');
         expect(finalContent.indexOf('- **[Codebase Gap]**')).toBeLessThan(finalContent.indexOf('## Computed Golden Path'));
         expect(finalContent).not.toContain('Old Path');
+
+        // #10087: planted CONCEPT with [ORPHAN_CONCEPT] must surface as a dedicated section
+        expect(finalContent).toContain('⚠️ Orphaned Concepts');
+        expect(finalContent).toContain('Reactivity');
 
         // Run AGAIN to trigger duplication prevention natively
         await DreamService.synthesizeGoldenPath();

--- a/test/playwright/unit/ai/daemons/DreamService.spec.mjs
+++ b/test/playwright/unit/ai/daemons/DreamService.spec.mjs
@@ -114,6 +114,25 @@ test.describe('Neo.ai.mcp.server.memory-core.services.DreamService', () => {
         }
     });
 
+    test.afterEach(async () => {
+        // Symmetric cleanup per `feedback_symmetric_spec_cleanup.md`: `fullyParallel: true` lets
+        // Playwright interleave this spec with ConceptService/ConceptIngestor specs in the same
+        // worker, and `GraphService.db` is a shared singleton. Mirroring beforeEach here closes
+        // the cross-spec door — the next queued test from any spec sees a clean graph, not our
+        // trailing fixtures (CONCEPT nodes planted by the ORPHAN_CONCEPT detection test, etc.).
+        if (GraphService.db) {
+            GraphService.db.nodes.clear();
+            GraphService.db.edges.clear();
+            GraphService.db.vicinityLoadedNodes.clear();
+
+            if (GraphService.db.storage?.db) {
+                await GraphService.db.storage.clear();
+                GraphService.db.storage.db.exec('DELETE FROM GraphLog');
+                GraphService.db.lastSyncId = 0;
+            }
+        }
+    });
+
     test.afterAll(async () => {
         if (GraphService?.db) {
             if (GraphService.db.storage?.db) {
@@ -386,6 +405,32 @@ test.describe('Neo.ai.mcp.server.memory-core.services.DreamService', () => {
 
         // Low-weight concept → weight gate blocks all three signals
         expect(lowOrphan.properties?.capabilityGap).toBeUndefined();
+    });
+
+    test('should emit GUIDE_GAP and ORPHAN_CONCEPT together when concept lacks both EXPLAINED_BY and IMPLEMENTED_BY (#10087)', async () => {
+        // Locks in the independence of ORPHAN_CONCEPT from the GUIDE_GAP / EXAMPLE_GAP branch.
+        // GUIDE_GAP and EXAMPLE_GAP are mutually exclusive (one requires EXPLAINED_BY absent, the
+        // other requires it present), but ORPHAN_CONCEPT is orthogonal — a concept can be both
+        // undocumented AND unanchored. This compound case exercises the branch orthogonality that
+        // the three-case test above doesn't hit directly.
+        GraphService.upsertNode({
+            id        : 'concept-fully-uncovered',
+            type      : 'CONCEPT',
+            name      : 'FullyUncovered',
+            properties: {name: 'FullyUncovered', tier: 1, uniqueToNeo: true, weight: 1.3}
+        });
+
+        await DreamService.inferConceptGraphGaps();
+
+        const node = GraphService.db.nodes.get('concept-fully-uncovered');
+
+        expect(node.properties.capabilityGap).toBeDefined();
+        expect(node.properties.capabilityGap).toContain('[GUIDE_GAP]');
+        expect(node.properties.capabilityGap).toContain('[ORPHAN_CONCEPT]');
+        expect(node.properties.capabilityGap).toContain('FullyUncovered');
+        // EXAMPLE_GAP requires EXPLAINED_BY present; since we have neither edge, only GUIDE_GAP
+        // fires from the if/else-if pair, never EXAMPLE_GAP.
+        expect(node.properties.capabilityGap).not.toContain('[EXAMPLE_GAP]');
     });
 
     test('processUndigestedSessions calls inferTestGapsFromSession per-session and inferConceptGraphGaps once per cycle (hoist contract — #10085)', async () => {

--- a/test/playwright/unit/ai/daemons/services/ConceptIngestor.spec.mjs
+++ b/test/playwright/unit/ai/daemons/services/ConceptIngestor.spec.mjs
@@ -193,7 +193,10 @@ test.describe('Neo.ai.daemons.services.ConceptIngestor', () => {
         expect(node.properties.description).toBe('Updated description');
     });
 
-    test('should emit logger.warn for orphan concepts (tier > 0, no IMPLEMENTED_BY edge)', async () => {
+    test('should count orphan concepts in stats without emitting per-orphan logger.warn (#10087)', async () => {
+        // Post-#10087: orphan surfacing moved from the ephemeral logger.warn channel to the
+        // durable capabilityGap channel via GapInferenceEngine.inferConceptGraphGaps. ConceptIngestor
+        // retains the count for the cycle-summary info line but no longer warns per orphan.
         writeFixture(
             [
                 {id: 'anchored', name: 'Anchored Concept', tier: 1, description: 'Has implementation', uniqueToNeo: false, tags: []},
@@ -206,10 +209,10 @@ test.describe('Neo.ai.daemons.services.ConceptIngestor', () => {
 
         expect(stats.orphansDetected).toBe(1);
 
-        const orphanWarn = warnMessages.find(m => m.includes('Orphan concept detected'));
-        expect(orphanWarn).toBeDefined();
-        expect(orphanWarn).toContain('Orphan Concept');
-        expect(orphanWarn).toContain('orphan');
+        // The per-orphan warn was deliberately removed — only the cycle-summary info line should
+        // reference the count, and nothing at warn level should mention this specific orphan.
+        const perOrphanWarn = warnMessages.find(m => m.includes('Orphan concept detected') || m.includes('Orphan Concept'));
+        expect(perOrphanWarn).toBeUndefined();
     });
 
     test('should persist only edges with canonical CONCEPT_EDGE_TYPES', async () => {


### PR DESCRIPTION
## Summary

Promotes orphan concept detection from the ephemeral per-orphan `logger.warn` in `ConceptIngestor` to the durable `capabilityGap` tag channel + a dedicated `sandman_handoff.md` section — same pattern as `[GUIDE_GAP]` / `[EXAMPLE_GAP]` established in #10084. The next REM cycle and the next boot-loading agent session (Claude/Antigravity/Gemini) pick up the signal from the A2A context bridge; the Librarian daemon aggregates it during background maintenance. Incidental human auditors get it too, but they're the secondary consumer.

## The Problem

#10084 (resolving #10035) shipped deterministic concept-graph gap detection for `[GUIDE_GAP]` and `[EXAMPLE_GAP]` via the `capabilityGap` channel. Orphan detection (concepts with no `IMPLEMENTED_BY` edge) was deferred to the ephemeral `logger.warn` channel in `ConceptIngestor` — *"orphans are ontology data-quality signals, not coverage gaps."* That distinction is real but was the wrong place to draw it: `DreamService` runs offline, logger output scrolls off between cycles, and as the ontology grows (today's ~17 orphans will multiply with #10036 / #10037 / #10050 ingestion) the per-orphan log spam becomes noise while the signal itself stays invisible to the next boot-loading agent that reads `sandman_handoff.md` (per `AGENTS_STARTUP.md` §6) for strategic context.

This PR lands the architecture tobi and I aligned on during the #10085 ticket-intake review: share the `capabilityGap` channel with a new `[ORPHAN_CONCEPT]` tag, weight-gate the emission, render in a dedicated handoff section, and delete the `logger.warn` entirely.

## Architectural Reality (verified against precedent)

- `ai/daemons/services/GapInferenceEngine.mjs` — `inferConceptGraphGaps` already iterates CONCEPT nodes and checks outbound `EXPLAINED_BY` / `EXEMPLIFIED_BY` edges. Adding a third branch for `IMPLEMENTED_BY` costs one `filter` call per concept — same cost as the existing two checks. The `GUIDE_GAP_WEIGHT_THRESHOLD` gate wraps all three signals so they share the same silencing discipline.
- `ai/daemons/services/ConceptIngestor.mjs:262` — orphan detection loop already exists for `stats.orphansDetected`. Deleting the `logger.warn` on the next line is a one-line change; the stat counter stays for the cycle-summary INFO log at line 272, which is the architecturally-correct place for phase-level observability.
- `ai/daemons/services/GoldenPathSynthesizer.mjs:254-316` — downstream consumer for the A2A plane. The parse + render pattern for `[TEST_GAP]` / `[GUIDE_GAP]` / `[EXAMPLE_GAP]` is a structural template: one tag branch in the parser + one `if (arr.length > 0)` block in the renderer. Extending for `[ORPHAN_CONCEPT]` mirrors this exactly — the 5-item limit and TTL pruning apply uniformly.
- `DreamService.spec.mjs:194+` — the existing `GUIDE_GAP` covered-concept fixture had EXPLAINED_BY + EXEMPLIFIED_BY but no IMPLEMENTED_BY. With the new signal, that "fully covered" test control would correctly emit `[ORPHAN_CONCEPT]`, inverting the test's premise. Added IMPLEMENTED_BY to keep the control genuinely fully-wired.

## Implementation Footprint

| File | Change |
|---|---|
| `GapInferenceEngine.mjs` | `inferConceptGraphGaps` emits `[ORPHAN_CONCEPT]` when `implementedByEdges.length === 0 && weight >= threshold`. Class-level JSDoc updated to describe the three concept-graph signals + weight-gate rationale. |
| `ConceptIngestor.mjs` | Deleted per-orphan `logger.warn` (~3 lines). Kept `stats.orphansDetected++` for the cycle-summary INFO. JSDoc on `syncConceptsToGraph` updated to point at `GapInferenceEngine` as the surfacing home. |
| `GoldenPathSynthesizer.mjs` | `[ORPHAN_CONCEPT]` parse branch + `### ⚠️ Orphaned Concepts` render branch with same 5-item limit + TTL pattern. |
| `DreamService.spec.mjs` | New `[ORPHAN_CONCEPT]` detection test (three cases: fully-wired, orphan-only, low-weight gated). `synthesizeGoldenPath` test extended with planted CONCEPT + ⚠️ section assertion. `GUIDE_GAP` covered-concept fixture gets `IMPLEMENTED_BY` edge. |
| `ConceptIngestor.spec.mjs` | Orphan test now asserts `stats.orphansDetected` AND no per-orphan warn fires (AC3 enforcement). |

## Gold Standards Leveraged / Traps Avoided

- **Gold Standard** (tag-prefix taxonomy): preserves the invariant from #10084 that all concept-level gaps land in the same `capabilityGap` property with distinct tag prefixes. One loop in `GoldenPathSynthesizer`, one TTL pruning path, uniform 5-item limit.
- **Gold Standard** (weight gate on concept-level signals): reusing `GUIDE_GAP_WEIGHT_THRESHOLD` across all three signals keeps the tuning surface small and the semantics coherent. #10086 (config-lift) will move the single threshold, not three.
- **Gold Standard** (`else if` branching for mutually-exclusive signals): GUIDE_GAP and EXAMPLE_GAP can't both fire (one requires EXPLAINED_BY absent, the other requires it present). Restructured the inner block to make the exclusion explicit while leaving ORPHAN_CONCEPT as an independent check. Behavior unchanged, readability up.
- **Trap avoided** (logger as observability plane): per `feedback_challenge_prescribed_fixes.md`, logger output in an offline daemon is the wrong substrate for any signal a downstream agent needs to reason about across REM cycles. ORPHAN_CONCEPT now lives in the A2A plane (`capabilityGap` graph property → `sandman_handoff.md` section) where the next REM cycle's `GoldenPathSynthesizer`, the next boot-loading agent session, and the Librarian daemon all consume it durably.
- **Trap avoided** (pre-emptive config-lift): kept the weight threshold as the existing named constant. If tuning becomes a real need, #10086 promotes it.

## Testing

```bash
npm run test-unit -- test/playwright/unit/ai/services/ConceptService.spec.mjs test/playwright/unit/ai/daemons/
```

**39 passed** (ConceptService 23, DreamService 8 — one new ORPHAN detection test, DreamServiceGoldenPath 1, ConceptIngestor 7). Stable across 5 consecutive runs.

Behavioral test-of-success after merge:
- `sandman_handoff.md` emits `⚠️ Orphaned Concepts` for tier-1+ concepts without IMPLEMENTED_BY — visible to the next agent session booting the concept ontology context.
- `logger.warn` output shrinks by one line per orphan per REM cycle (quieter daemon logs, durable signal).
- Today's ~17 orphans + low-weight filter mean handoff stays mostly silent until #10036 / #10037 / #10050 enrich the ontology — the signal scales with the data.

## Out of Scope / Follow-Up

- **#10086** — config-lift `guideGapWeightThreshold` to `aiConfig.data`. Now gates three signals instead of one; the value of config-lifting has grown slightly.
- **#10050** — concept description enrichment (blocked on human architect time).
- **#10036 / #10037** — Memory Core + ChromaDB concept ingestion that will populate more meaningful weights and make the orphan signal louder across the A2A plane.

## Related

- Parent: #10030 (Concept Ontology & Semantic Gap Inference)
- Origin PR: #10084 (introduced the EXAMPLE_GAP pattern that this PR mirrors)
- Preceding PR: #10100 (closed Items 1 + 2 of #10085; flagged Item 4 as belonging here)
- Sibling: #10086 (config-lift threshold)

Resolves #10087

Origin Session ID: 1db25bbe-f39d-4dcd-bb0e-bc125ce91326