### PR TITLE
feat(ai): config-lift guideGapWeightThreshold to aiConfig.data (#10086)

### DIFF
--- a/ai/daemons/services/GapInferenceEngine.mjs
+++ b/ai/daemons/services/GapInferenceEngine.mjs
@@ -1,22 +1,6 @@
-import Base                                 from '../../../src/core/Base.mjs';
-import {Memory_GraphService as GraphService} from '../../services.mjs';
-import logger                               from '../../mcp/server/memory-core/logger.mjs';
-
-/**
- * Minimum weight threshold for emitting a `[GUIDE_GAP]` on a CONCEPT node.
- *
- * **Derivation:** `ConceptService.calculateWeight` returns `tier_score + uniqueness + coverage_deficit`
- * where tier-1 gets `0.8`, tier-2 `0.5`, tier-3 `0.3`; uniqueness adds `0.2`; coverage deficit (no
- * EXPLAINED_BY) adds `0.3`. The minimum a tier-1 concept can score is `0.8` (covered, non-unique).
- * Setting threshold = `0.8` means *"at least tier-1 baseline priority"* — every tier-1 concept
- * without a guide qualifies; tier-2/3 concepts qualify only if uniqueness + deficit push them above.
- *
- * Not config-lifted in Phase 1 — if human tuning becomes a real need, promote to
- * `aiConfig.data.guideGapWeightThreshold` with the same default.
- * @type {Number}
- * @private
- */
-const GUIDE_GAP_WEIGHT_THRESHOLD = 0.8;
+import Base                                                        from '../../../src/core/Base.mjs';
+import {Memory_Config as aiConfig, Memory_GraphService as GraphService} from '../../services.mjs';
+import logger                                                      from '../../mcp/server/memory-core/logger.mjs';
 
 /**
  * @summary Service for deterministic capability-gap inference over the Native Edge Graph.
@@ -38,9 +22,12 @@ const GUIDE_GAP_WEIGHT_THRESHOLD = 0.8;
  *      missing and should be added). Surfaced through the same `capabilityGap` channel +
  *      `sandman_handoff.md` section pattern as the other gap types, not via `logger.warn`
  *      (logger is ephemeral; the graph + handoff is the durable substrate). Added in #10087.
- *    All three share the `GUIDE_GAP_WEIGHT_THRESHOLD` weight gate so low-priority concepts
- *    don't flood the handoff; the gate auto-surfaces meaningful signals as concept ingestion
- *    matures (#10036 / #10037 / #10050).
+ *    All three share the `aiConfig.data.guideGapWeightThreshold` gate (config-lifted in #10086
+ *    for curator tuning; defaults to `0.8` = tier-1 baseline). Low-priority concepts don't flood
+ *    the handoff; the gate auto-surfaces meaningful signals as concept ingestion matures
+ *    (#10036 / #10037 / #10050). The config name retains the historical `guideGap*` prefix for
+ *    the same reason the ticket does — the threshold was introduced for GUIDE_GAP in #10035,
+ *    then widened to gate all three concept-graph signals in #10087.
  *
  *    **Why graph traversal over LLM verification?** The concept graph's edges are
  *    curator-maintained (`.neo-ai-data/concepts/edges.jsonl` is version-controlled; each edge
@@ -145,12 +132,14 @@ class GapInferenceEngine extends Base {
      *   to live in `ConceptIngestor` — routing through `capabilityGap` + `sandman_handoff.md`
      *   makes the signal durable and aggregatable.
      *
-     * All three signals share the same `GUIDE_GAP_WEIGHT_THRESHOLD` weight gate. Lower-weight
-     * concepts (tier-3 without uniqueness or coverage deficit lift) are considered low-priority
-     * — missing guides/examples/implementations for them aren't worth surfacing in the handoff
-     * at the current early stage of the ontology. As concept ingestion matures (#10036 / #10037
-     * / #10050), richer weight signals auto-promote meaningful gaps through the same gate
-     * without config changes.
+     * All three signals share the same `aiConfig.data.guideGapWeightThreshold` weight gate
+     * (default `0.8` = tier-1 baseline; config-lifted in #10086 for curator tuning). Lower-weight
+     * concepts (tier-3 without uniqueness or coverage deficit lift) are considered low-priority —
+     * missing guides/examples/implementations for them aren't worth surfacing in the handoff at
+     * the current early stage of the ontology. As concept ingestion matures (#10036 / #10037 /
+     * #10050), richer weight signals auto-promote meaningful gaps through the same gate without
+     * config changes. The derivation of the default (0.8) lives in `config.template.mjs` next to
+     * the value itself.
      *
      * Uses the edges-direct traversal pattern (`db.edges.getByIndex('source', id).filter(...)`)
      * rather than `db.getAdjacentNodes(...)` because concept edges point at string identifiers
@@ -173,6 +162,10 @@ class GapInferenceEngine extends Base {
 
         logger.info(`[GapInferenceEngine] Concept-graph gap pass: traversing ${conceptNodes.length} concepts.`);
 
+        // Resolved once per cycle (not per concept) — the config value is read at gate time so
+        // mid-cycle config mutations in tests / runtime take effect without re-importing.
+        const threshold = aiConfig.data.guideGapWeightThreshold;
+
         for (const concept of conceptNodes) {
             const
                 outboundEdges       = GraphService.db.edges.getByIndex('source', concept.id),
@@ -182,7 +175,7 @@ class GapInferenceEngine extends Base {
                 weight              = concept.properties?.weight ?? 0,
                 gaps                = [];
 
-            if (weight >= GUIDE_GAP_WEIGHT_THRESHOLD) {
+            if (weight >= threshold) {
                 const name = concept.properties?.name || concept.name || concept.id;
 
                 if (explainedByEdges.length === 0) {

--- a/ai/mcp/server/memory-core/config.template.mjs
+++ b/ai/mcp/server/memory-core/config.template.mjs
@@ -199,6 +199,21 @@ const defaultConfig = {
      */
     decayFactor: Number(process.env.GRAPH_DECAY_FACTOR) || 0.98,
     /**
+     * Minimum weight threshold for emitting `[GUIDE_GAP]`, `[EXAMPLE_GAP]`, and `[ORPHAN_CONCEPT]`
+     * signals on CONCEPT nodes during `GapInferenceEngine.inferConceptGraphGaps`.
+     *
+     * **Derivation:** `ConceptService.calculateWeight` returns `tier_score + uniqueness + coverage_deficit`
+     * where tier-1 gets `0.8`, tier-2 `0.5`, tier-3 `0.3`; uniqueness adds `0.2`; coverage deficit (no
+     * EXPLAINED_BY) adds `0.3`. The minimum a tier-1 concept can score is `0.8` (covered, non-unique).
+     * Setting threshold = `0.8` means *"at least tier-1 baseline priority"* — every tier-1 concept
+     * without a guide qualifies; tier-2/3 concepts qualify only if uniqueness + deficit push them above.
+     *
+     * Tune up to silence tier-2/3 noise as ontology grows (#10036 / #10037 / #10050); tune down to
+     * surface lower-priority concepts in the handoff.
+     * @type {number}
+     */
+    guideGapWeightThreshold: Number(process.env.NEO_GUIDE_GAP_WEIGHT_THRESHOLD) || 0.8,
+    /**
      * Universal JSONL backup/export directory for all databases.
      * @type {string}
      */

--- a/test/playwright/unit/ai/daemons/DreamService.spec.mjs
+++ b/test/playwright/unit/ai/daemons/DreamService.spec.mjs
@@ -334,6 +334,38 @@ test.describe('Neo.ai.mcp.server.memory-core.services.DreamService', () => {
         expect(node.properties?.capabilityGap).toBeUndefined();
     });
 
+    test('threshold override via aiConfig.data.guideGapWeightThreshold changes emission behavior (#10086)', async () => {
+        // #10086: the weight gate lives in config (not a file-local constant). Verifying that
+        // GapInferenceEngine reads the live config value means curators can tune the handoff
+        // silence level without code changes — the stated goal of the config-lift.
+        const aiConfig = (await import('../../../../../ai/mcp/server/memory-core/config.mjs')).default;
+        const original = aiConfig.data.guideGapWeightThreshold;
+
+        // Plant a concept whose weight (0.5) is BELOW the default 0.8 — normally no gap emitted.
+        GraphService.upsertNode({
+            id        : 'concept-mid-weight',
+            type      : 'CONCEPT',
+            name      : 'MidWeight',
+            properties: {name: 'MidWeight', tier: 2, uniqueToNeo: false, weight: 0.5}
+        });
+
+        try {
+            // Override the threshold below the concept's weight. The same concept must now pass
+            // the gate and emit gaps through the same branch logic — proving the config is
+            // actually consulted at gate time, not captured at module load.
+            aiConfig.data.guideGapWeightThreshold = 0.3;
+
+            await DreamService.inferConceptGraphGaps();
+
+            const node = GraphService.db.nodes.get('concept-mid-weight');
+            expect(node.properties.capabilityGap).toBeDefined();
+            expect(node.properties.capabilityGap).toContain('[GUIDE_GAP]');
+            expect(node.properties.capabilityGap).toContain('[ORPHAN_CONCEPT]');
+        } finally {
+            aiConfig.data.guideGapWeightThreshold = original;
+        }
+    });
+
     test('should detect ORPHAN_CONCEPT for concepts with no IMPLEMENTED_BY edge (#10087)', async () => {
         // #10087: concepts without source-code anchoring emit `[ORPHAN_CONCEPT]` via the durable
         // `capabilityGap` channel rather than the deprecated per-orphan `logger.warn` in


### PR DESCRIPTION
## Summary

Promotes the previously file-local `GUIDE_GAP_WEIGHT_THRESHOLD = 0.8` constant in `GapInferenceEngine` to `aiConfig.data.guideGapWeightThreshold`, making the concept-graph gap weight gate curator-tunable without a code change. Default preserved (`0.8`); the derivation comment moves from the const JSDoc to the config template next to the value itself — where tuners will see it.

## The Problem

#10084 introduced the threshold as a file-local const with a full derivation comment. #10087 widened its scope from gating `[GUIDE_GAP]` alone to gating all three concept-graph signals (`[GUIDE_GAP]` + `[EXAMPLE_GAP]` + `[ORPHAN_CONCEPT]`). With three signals now bottlenecked through one number, the value of human-tuning has compounded: a single config bump can silence tier-2/3 noise across all three channels at once as the ontology grows (#10036 / #10037 / #10050).

## Architectural Reality (verified against precedent)

- `ai/mcp/server/memory-core/config.template.mjs` — checked-in source of truth for the config schema. The matching `config.mjs` is gitignored (see `.gitignore`), generated/maintained per-checkout via `bootstrapWorktree.mjs` or manual bootstrap. Only the template goes into git; local `config.mjs` parity is the individual operator's responsibility.
- `ai/services.mjs:51` — `Memory_Config` exported for SDK consumption. Used identically in `DreamService.mjs:82` (`aiConfig.data.autoDream`) — established pattern.
- `ai/daemons/services/GapInferenceEngine.mjs` — the threshold is used once, at the gate in `inferConceptGraphGaps`. Replacing the const with `aiConfig.data.guideGapWeightThreshold` is a 1-line substitution; caching as a local `const threshold` at the top of the method is an optimization (avoids repeated property access in the for-loop) but also reads the live config value at gate time, which lets tests mutate it at runtime.
- Environment-variable escape hatch: `NEO_GUIDE_GAP_WEIGHT_THRESHOLD` follows the existing pattern (`NEO_VECTOR_DIMENSION`, `GRAPH_DECAY_FACTOR`, etc.) so operators can tune without editing the config file.

## Implementation

| File | Change |
|---|---|
| `config.template.mjs` | New `guideGapWeightThreshold` key after `decayFactor` (both graph-pipeline floats). JSDoc carries the full ConceptService.calculateWeight derivation + post-#10087 context. Env override via `NEO_GUIDE_GAP_WEIGHT_THRESHOLD`. |
| `GapInferenceEngine.mjs` | Deleted the file-local const. Added `Memory_Config as aiConfig` to the existing `services.mjs` import. Cache `const threshold = aiConfig.data.guideGapWeightThreshold` once per cycle at the top of `inferConceptGraphGaps`. Class + method JSDoc updated to reference the config path and explain the historical `guideGap*` prefix (introduced in #10035 for GUIDE_GAP alone; widened in #10087 to gate all three concept-graph signals). |
| `DreamService.spec.mjs` | New test: threshold override via `aiConfig.data.guideGapWeightThreshold` changes emission behavior. Plants a weight-0.5 concept (below default 0.8), overrides threshold to 0.3, asserts both `[GUIDE_GAP]` and `[ORPHAN_CONCEPT]` now surface. `try/finally` restores the original. Proves the config is read at gate time, not captured at module load. |

**Parity note on the gitignored local `config.mjs`:** the shipped template is the source of truth. Each checkout's local `config.mjs` must mirror the new key for its tests + runtime to pick it up. Updated manually in this worktree; `bootstrapWorktree.mjs` will carry it forward to future worktrees once the main checkout's local config is updated.

## Gold Standards Leveraged / Traps Avoided

- **Gold Standard** (aiConfig.data pattern): follows the established `autoDream`, `autoGoldenPath`, `decayFactor` convention. No new architectural surface.
- **Gold Standard** (env override pattern): `NEO_GUIDE_GAP_WEIGHT_THRESHOLD` mirrors `GRAPH_DECAY_FACTOR`, `NEO_VECTOR_DIMENSION`. Consistent operator-control story.
- **Gold Standard** (runtime-read not module-load-captured): caching inside the method body, not at module top-level, means tests + live mutations are honored without module reimport.
- **Trap avoided** (rename scope-creep): the config name `guideGapWeightThreshold` is arguably imprecise post-#10087 (gates three signals, not one). Rename considered but scoped out to keep this PR tight — the ticket AC literally specifies `guideGapWeightThreshold`, and renaming would break the env-var operator contract. Documented the historical prefix in JSDoc so future readers aren't confused.
- **Trap avoided** (committing gitignored file): caught `config.mjs` in first staging attempt — `.gitignore` enforcement stopped it. Reshaped to commit only the template; parity note in commit + PR body documents the operator responsibility.

## Testing

```bash
npm run test-unit -- test/playwright/unit/ai/services/ConceptService.spec.mjs test/playwright/unit/ai/daemons/
```

**41 passed** (ConceptService 23, DreamService 10 — including new threshold-override test, DreamServiceGoldenPath 1, ConceptIngestor 7). Stable across 5 consecutive runs.

The new test covers AC #4 (*"threshold override via config produces different gap-emission behavior"*) explicitly: same concept, same graph state, different config value → different gap output. The existing "skip low-weight concepts" test remains as the default-path counterpart.

## Out of Scope / Follow-Up

- **Rename `guideGapWeightThreshold` → `conceptGapWeightThreshold`**: the historical prefix is misleading post-#10087. A rename PR would also update the env var name (breaking operator contract) and the JSDoc everywhere. Low value today (config likely not yet set by any operator); could ship later if the name becomes a stumbling block.
- **Bootstrap-worktree config regeneration** (#10088 adjacent): the template/local split requires manual sync or worktree re-bootstrap. Currently no tooling regenerates local `config.mjs` from template on template changes; operators edit both files in parallel. A `npm run sync-config` or similar could close this gap if it becomes painful.

## Related

- Parent epic: #10030 (Concept Ontology & Semantic Gap Inference)
- Origin PR: #10084 (introduced the const)
- Preceded by: #10100 (scope hoist — same epic), #10101 (ORPHAN_CONCEPT — widened threshold scope)
- Weight formula precedent: `ConceptService.calculateWeight` (`tier + uniqueness + coverage_deficit`)

Resolves #10086

Origin Session ID: 1db25bbe-f39d-4dcd-bb0e-bc125ce91326