### PR TITLE
feat(ai): ConceptDiscoveryService + validated flag for mined candidates (#10036)

### DIFF
--- a/ai/daemons/DreamService.mjs
+++ b/ai/daemons/DreamService.mjs
@@ -11,6 +11,7 @@ import { Memory_GraphService as GraphService } from '../services.mjs';
 import Json                 from '../../src/util/Json.mjs';
 import logger               from '../mcp/server/memory-core/logger.mjs';
 import OpenAiCompatible     from '../provider/OpenAiCompatible.mjs';
+import ConceptDiscoveryService from './services/ConceptDiscoveryService.mjs';
 import ConceptIngestor         from './services/ConceptIngestor.mjs';
 import FileSystemIngestor      from '../mcp/server/memory-core/services/FileSystemIngestor.mjs';
 import GapInferenceEngine      from './services/GapInferenceEngine.mjs';
@@ -261,6 +262,22 @@ class DreamService extends Base {
      */
     async inferTestGapsFromSession(payload) {
         return GapInferenceEngine.inferTestGapsFromSession(payload);
+    }
+
+    /**
+     * Concept discovery entry point (#10036). Delegates to `ConceptDiscoveryService` to mine
+     * recurring architectural vocabulary from Memory Core session summaries and local GitHub
+     * issue markdown. New candidates land in `.neo-ai-data/concepts/nodes.jsonl` with
+     * `validated: false`, tier 3, low weight — silenced in `sandman_handoff.md` until a
+     * curator promotes them via JSONL edit (git diff is the review surface).
+     *
+     * Safe to call standalone (CLI / one-off) or from a REM-cycle orchestrator. Does not
+     * mutate the Native Edge Graph directly — `ConceptIngestor.syncConceptsToGraph` picks up
+     * the new rows on its next run.
+     * @returns {Promise<Object>} `{candidatesAdded, candidates}`
+     */
+    async runConceptDiscovery() {
+        return ConceptDiscoveryService.runDiscoveryCycle();
     }
 
     /**

--- a/ai/daemons/services/ConceptDiscoveryService.mjs
+++ b/ai/daemons/services/ConceptDiscoveryService.mjs
@@ -1,0 +1,447 @@
+import fs                                                              from 'fs';
+import path                                                            from 'path';
+import yaml                                                             from 'js-yaml';
+import {fileURLToPath}                                                 from 'url';
+import Base                                                             from '../../../src/core/Base.mjs';
+import ConceptService                                                   from '../../services/ConceptService.mjs';
+import {Memory_Config as aiConfig}                                      from '../../services.mjs';
+import Json                                                             from '../../../src/util/Json.mjs';
+import logger                                                           from '../../mcp/server/memory-core/logger.mjs';
+import OpenAiCompatible                                                 from '../../provider/OpenAiCompatible.mjs';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname  = path.dirname(__filename);
+
+/**
+ * How many pull-request markdown files to process per discovery cycle. PRs accumulate quickly
+ * (~300+ in the repo today) and each one is a separate LLM invocation. Sort-descending by
+ * filename means we process the most-recent PRs first — where the freshest architectural
+ * discourse lives (Gold Standards / Traps Avoided / Retrospective sections in recent review
+ * comments). Bumpable via the instance-level `prScanLimit` property for tests / operators.
+ * @type {Number}
+ * @private
+ */
+const DEFAULT_PR_SCAN_LIMIT = 20;
+
+/**
+ * Minimum source text length for LLM invocation. Tiny bodies (one-liner PR descriptions,
+ * empty epics) aren't worth the call. 200 characters is ~30 words — below this, there's no
+ * coherent architectural discussion to extract from.
+ * @type {Number}
+ * @private
+ */
+const MIN_SOURCE_LENGTH = 200;
+
+/**
+ * System prompt establishing the Teaching Test + anti-patterns for the concept extraction
+ * LLM. Emphasizes semantic judgment (what qualifies as an ontology concept) over pattern
+ * matching (what LOOKS capitalized). Instructs strict JSON output so `Json.extract` can
+ * parse reliably.
+ * @type {String}
+ * @private
+ */
+const CONCEPT_EXTRACTION_SYSTEM_PROMPT = `You are the Neo.mjs Concept Discovery engine. You analyze prose (GitHub epic bodies or pull-request bodies + review comments) and identify ARCHITECTURAL CONCEPTS that qualify for the Neo.mjs concept ontology under the **Teaching Test**:
+
+A concept exists if:
+- A developer needs to understand it to USE Neo.mjs productively, AND
+- It cannot be learned from a single API doc page alone, AND
+- It describes a pattern / architecture / mental model, not a specific class, file, or method.
+
+**Where the gold is:**
+- Epic bodies: core architectural problem statements and phased solutions.
+- PR review comments: \`[ARCH_ALIGNMENT]\`, \`[RETROSPECTIVE]\`, \`[KB_GAP]\`, \`[TOOLING_GAP]\` sections; "Gold Standards Leveraged / Traps Avoided" lists; rationale prose explaining WHY a pattern was chosen.
+- Discussion about mid-term architecture direction, service boundaries, substrate choices.
+
+**DO NOT include:**
+- Class names (e.g. Button, Container, DreamService) — those are API surface, not concepts.
+- File paths / directory names.
+- Proper nouns without architectural weight (issue IDs, PR numbers, person names).
+- Routine ticket vocabulary ("Pull Request", "Origin Session ID", "Fat Ticket" is borderline — include only if genuinely architectural).
+- External framework names (React, Vue, Angular) unless the text is specifically contrasting them with a Neo.mjs equivalent that itself is the concept.
+- Terms already well-documented in a single class's JSDoc.
+
+**Output STRICT JSON** (no markdown, no preamble, no \`\`\`json fences — just the object):
+{
+  "candidates": [
+    {
+      "id": "kebab-case-slug-under-40-chars",
+      "name": "Title-Case Concept Name",
+      "description": "One-sentence grounded explanation drawn from the source material.",
+      "reasoning": "Why this passes the Teaching Test — cite the semantic dimension it teaches.",
+      "aliases": ["alternative phrasing 1", "alternative phrasing 2"]
+    }
+  ]
+}
+
+If nothing qualifies, return \`{"candidates": []}\`. Err on the side of quality over quantity — 0 high-confidence candidates beats 10 noisy ones. The ontology has ~60 concepts today; proposing 3-5 genuinely architectural ones per source is the sweet spot.`;
+
+/**
+ * Default tier / validation state for a newly-discovered candidate concept. Tier 3 + the
+ * per-ingest weight calculated by `ConceptService.calculateWeight` keeps candidates below
+ * the `guideGapWeightThreshold = 0.8` default, so they're silenced in `sandman_handoff.md`
+ * until a curator promotes them. `validated: false` is the explicit override in
+ * `GapInferenceEngine` — even if the weight gate is lowered later, unvalidated candidates
+ * stay silent until review.
+ * @type {Object}
+ * @private
+ */
+const CANDIDATE_DEFAULTS = {
+    tier       : 3,
+    uniqueToNeo: false,
+    validated  : false,
+    tags       : ['mined-candidate']
+};
+
+/**
+ * @summary Service for LLM-driven discovery of "unknown unknowns" in the concept ontology.
+ *
+ * Scans two high-signal corpora via `OpenAiCompatible.generate` (gemma4 or configured
+ * provider — same substrate used by `SemanticGraphExtractor` and `GoldenPathSynthesizer`):
+ *
+ * 1. **Epics** — issue markdown files labeled `epic` in `resources/content/issues/`. Epic
+ *    bodies are curated distilled architecture — high signal-to-noise, stable reference
+ *    material for concept vocabulary.
+ * 2. **Pull requests** — `resources/content/pulls/*.md`, including their `## Comments`
+ *    section. PR review comments routinely contain \`[ARCH_ALIGNMENT]\` / \`[RETROSPECTIVE]\`
+ *    / \`[KB_GAP]\` / "Gold Standards" / "Traps Avoided" prose — the exact architectural
+ *    discourse where new vocabulary emerges. Sort-descending by filename so the most-recent
+ *    PRs (freshest discourse) get processed first; `DEFAULT_PR_SCAN_LIMIT = 20` caps per-cycle
+ *    LLM cost.
+ *
+ * **Why LLM, not regex?** The task is semantic: *does this term pass the Teaching Test?*
+ * No regex / stop-phrase list / frequency threshold can distinguish "Pull Request Review"
+ * (noise) from "Concept Ontology Layer" (signal) at the surface-pattern level. The
+ * judgment is about meaning, which is the LLM's job. Previous regex approach (early draft)
+ * failed exactly this architecture-literacy check. See `feedback_llm_substrate_for_semantic_tasks.md`.
+ *
+ * **Why a separate service?** `ConceptIngestor` is strictly *additive one-way sync* from
+ * curated JSONL → graph. `ConceptDiscoveryService` is the *reverse-flow proposal channel* —
+ * it writes candidate rows INTO the JSONL that `ConceptIngestor` picks up next cycle. Split
+ * by direction of data flow and trust level: curator-asserted rows vs LLM-proposed rows.
+ *
+ * **Why single JSONL (no staging file)?** Per the #10036 intake discussion, a
+ * `candidates.jsonl` split would duplicate the curator's review surface. The weight gate
+ * (`guideGapWeightThreshold`) plus the `validated: false` flag silence unvalidated rows in
+ * `sandman_handoff.md`; git diff on `nodes.jsonl` is the review UI.
+ *
+ * **Why deferred from REM-cycle loop?** LLM invocations cost real tokens. Running discovery
+ * every REM cycle would flood the JSONL and burn budget. `DreamService.runConceptDiscovery`
+ * is a manual-invocation facade; curator / operator decides cadence.
+ *
+ * @class Neo.ai.daemons.services.ConceptDiscoveryService
+ * @extends Neo.core.Base
+ * @see Neo.ai.daemons.services.ConceptIngestor
+ * @see Neo.ai.daemons.services.SemanticGraphExtractor
+ * @see Neo.ai.services.ConceptService
+ * @singleton
+ */
+class ConceptDiscoveryService extends Base {
+    static config = {
+        /**
+         * @member {String} className='Neo.ai.daemons.services.ConceptDiscoveryService'
+         * @protected
+         */
+        className: 'Neo.ai.daemons.services.ConceptDiscoveryService',
+        /**
+         * @member {Boolean} singleton=true
+         * @protected
+         */
+        singleton: true
+    }
+
+    /**
+     * Cap on PRs processed per cycle. Override on instance for tests / operator-tuning.
+     * @member {Number} prScanLimit
+     */
+    prScanLimit = DEFAULT_PR_SCAN_LIMIT
+
+    /**
+     * Invokes the configured LLM provider on a single source and parses the response as the
+     * candidate schema. Returns `[]` on any failure (provider offline, malformed JSON, no
+     * candidates) — failure to extract is never fatal to `runDiscoveryCycle`, just a skip.
+     *
+     * Uses `Json.extract` to tolerate the common `\`\`\`json ... \`\`\`` markdown fencing some
+     * models emit despite explicit anti-fence instructions. Dedupe against `ConceptService`
+     * (alias index + node-id map, case-insensitive) happens at the candidate level so we
+     * never propose a concept that already exists.
+     * @param {String} sourceRef Human-readable identifier for the source (e.g., `'epic-10030'`, `'pull-10084'`)
+     * @param {String} text      The raw markdown body + comments for that source
+     * @returns {Promise<Object[]>} Candidate records ready for `appendCandidates`
+     * @protected
+     */
+    async extractConceptsFromSource(sourceRef, text) {
+        if (!text || text.trim().length < MIN_SOURCE_LENGTH) return [];
+
+        let provider;
+        try {
+            provider = Neo.create(OpenAiCompatible, {
+                modelName: aiConfig.data.openAiCompatible?.model,
+                host     : aiConfig.data.openAiCompatible?.host
+            });
+        } catch (e) {
+            logger.warn(`[ConceptDiscoveryService] OpenAiCompatible provider could not be constructed; skipping ${sourceRef}:`, e.message);
+            return [];
+        }
+
+        const prompt = `${CONCEPT_EXTRACTION_SYSTEM_PROMPT}\n\n---\nSOURCE: ${sourceRef}\n\n${text}`;
+
+        let result;
+        try {
+            result = await provider.generate(prompt);
+        } catch (e) {
+            logger.warn(`[ConceptDiscoveryService] LLM call failed for ${sourceRef}; skipping:`, e.message);
+            return [];
+        }
+
+        const payload = Json.extract(result?.content || '');
+        if (!payload || !Array.isArray(payload.candidates)) {
+            logger.debug(`[ConceptDiscoveryService] No usable candidates parsed from ${sourceRef}.`);
+            return [];
+        }
+
+        const accepted = [];
+        for (const raw of payload.candidates) {
+            if (!raw || typeof raw !== 'object' || !raw.id || !raw.name) continue;
+
+            // Dedupe against existing concepts (alias index is case-insensitive; also check node id)
+            if (ConceptService.resolveAlias(raw.name)) continue;
+            if (ConceptService.nodes.has(raw.id)) continue;
+
+            accepted.push({
+                id         : raw.id,
+                name       : raw.name,
+                description: raw.description || `Mined candidate from ${sourceRef}. Awaiting curator review — promote by flipping \`validated: true\` and adjusting tier/weight in nodes.jsonl.`,
+                aliases    : Array.isArray(raw.aliases) ? raw.aliases : [],
+                source     : sourceRef,
+                reasoning  : raw.reasoning || '',
+                ...CANDIDATE_DEFAULTS
+            });
+        }
+
+        return accepted;
+    }
+
+    /**
+     * Loads and filters issue markdown files to the `epic`-labeled subset. Epics are the
+     * curated distilled architectural documents — denser-per-char signal than session
+     * summaries or architecture-labeled issues.
+     * @returns {Promise<Object[]>} `[{sourceRef, text}]`
+     * @protected
+     */
+    async loadEpicSources() {
+        const issuesDir = this.issuesDir || path.resolve(__dirname, '../../../resources/content/issues');
+
+        try {
+            await fs.promises.access(issuesDir);
+        } catch (e) {
+            logger.warn(`[ConceptDiscoveryService] Issues directory not found at ${issuesDir}; skipping epic mining.`);
+            return [];
+        }
+
+        const filesRaw = await fs.promises.readdir(issuesDir);
+        const files    = filesRaw.filter(f => f.endsWith('.md'));
+        const sources  = [];
+
+        for (const file of files) {
+            let content;
+            try {
+                content = await fs.promises.readFile(path.join(issuesDir, file), 'utf8');
+            } catch (e) {
+                continue;
+            }
+
+            const fmMatch = content.match(/^---\n([\s\S]*?)\n---/);
+            if (!fmMatch) continue;
+
+            let meta;
+            try {
+                meta = yaml.load(fmMatch[1]);
+            } catch (e) {
+                continue;
+            }
+
+            const labels = Array.isArray(meta?.labels) ? meta.labels : [];
+            if (!labels.includes('epic')) continue;
+
+            sources.push({
+                sourceRef: `epic-${meta.id || file.replace(/\.md$/, '')}`,
+                text     : content
+            });
+        }
+
+        return sources;
+    }
+
+    /**
+     * Loads pull-request markdown files, sorted by numerical ID descending so the most
+     * recent PRs process first. Capped at `this.prScanLimit` to bound LLM cost per cycle —
+     * recent-PR-bias is deliberate since fresh architectural discourse lands in recent
+     * review comments (`[ARCH_ALIGNMENT]`, `[RETROSPECTIVE]`, etc.).
+     * @returns {Promise<Object[]>} `[{sourceRef, text}]`
+     * @protected
+     */
+    async loadPullRequestSources() {
+        const pullsDir = this.pullsDir || path.resolve(__dirname, '../../../resources/content/pulls');
+
+        try {
+            await fs.promises.access(pullsDir);
+        } catch (e) {
+            logger.warn(`[ConceptDiscoveryService] Pulls directory not found at ${pullsDir}; skipping PR mining.`);
+            return [];
+        }
+
+        const filesRaw = await fs.promises.readdir(pullsDir);
+        const files    = filesRaw.filter(f => /^pr-\d+\.md$/.test(f));
+
+        // Sort descending by numeric PR id — freshest discourse first
+        files.sort((a, b) => {
+            const na = parseInt(a.match(/(\d+)/)[1], 10);
+            const nb = parseInt(b.match(/(\d+)/)[1], 10);
+            return nb - na;
+        });
+
+        const cappedFiles = files.slice(0, this.prScanLimit);
+        const sources     = [];
+
+        for (const file of cappedFiles) {
+            let content;
+            try {
+                content = await fs.promises.readFile(path.join(pullsDir, file), 'utf8');
+            } catch (e) {
+                continue;
+            }
+
+            sources.push({
+                sourceRef: `pull-${file.replace(/\.md$/, '')}`,
+                text     : content
+            });
+        }
+
+        return sources;
+    }
+
+    /**
+     * Mines architectural concepts from `epic`-labeled GitHub issues via LLM extraction.
+     * Each epic body → one LLM invocation → JSON candidates → dedupe against ConceptService.
+     *
+     * Returns `[]` gracefully when no epics exist or the LLM provider is unavailable.
+     * @returns {Promise<Object[]>} Candidate concept records
+     */
+    async mineFromEpics() {
+        const sources = await this.loadEpicSources();
+        if (sources.length === 0) return [];
+
+        logger.info(`[ConceptDiscoveryService] Epic mining: scanning ${sources.length} epic-labeled issue(s).`);
+
+        const all = [];
+        for (const {sourceRef, text} of sources) {
+            const candidates = await this.extractConceptsFromSource(sourceRef, text);
+            all.push(...candidates);
+        }
+
+        logger.info(`[ConceptDiscoveryService] Epic mining produced ${all.length} candidate(s).`);
+        return all;
+    }
+
+    /**
+     * Mines architectural concepts from recent pull-request markdown (body + comments).
+     * PR review comments are a dense source of Gold Standards / Traps Avoided / Retrospective
+     * vocabulary — exactly the prose where architectural discourse consolidates.
+     *
+     * Caps at `this.prScanLimit` most-recent PRs per cycle to bound LLM cost. Returns `[]`
+     * gracefully when no PRs exist or the provider is unavailable.
+     * @returns {Promise<Object[]>} Candidate concept records
+     */
+    async mineFromPullRequests() {
+        const sources = await this.loadPullRequestSources();
+        if (sources.length === 0) return [];
+
+        logger.info(`[ConceptDiscoveryService] PR mining: scanning ${sources.length} recent PR file(s) (cap=${this.prScanLimit}).`);
+
+        const all = [];
+        for (const {sourceRef, text} of sources) {
+            const candidates = await this.extractConceptsFromSource(sourceRef, text);
+            all.push(...candidates);
+        }
+
+        logger.info(`[ConceptDiscoveryService] PR mining produced ${all.length} candidate(s).`);
+        return all;
+    }
+
+    /**
+     * Runs both mining strategies sequentially (PRs typically produce more candidates; running
+     * in parallel would hit the LLM provider with too many concurrent requests), merges and
+     * dedupes by candidate ID, and appends new rows to `nodes.jsonl`. Idempotent across runs:
+     * candidates already present in ConceptService (curated or previously-mined) are filtered
+     * out in `extractConceptsFromSource` before append.
+     *
+     * Safe to call standalone (manual invocation via `DreamService.runConceptDiscovery`).
+     * Does NOT touch the Native Edge Graph — `ConceptIngestor.syncConceptsToGraph` picks up
+     * the new rows on its next run and materializes them as CONCEPT nodes with `validated:
+     * false` flowing through to the graph property (so `GapInferenceEngine` silences them).
+     * @returns {Promise<Object>} `{candidatesAdded, candidates}`
+     */
+    async runDiscoveryCycle() {
+        if (!ConceptService.loaded) {
+            try {
+                ConceptService.loadGraph();
+            } catch (e) {
+                logger.warn('[ConceptDiscoveryService] ConceptService.loadGraph() failed — dedupe will be loose.', e.message);
+            }
+        }
+
+        const epicCandidates = await this.mineFromEpics();
+        const prCandidates   = await this.mineFromPullRequests();
+
+        // Merge by id; epic-source wins on collision (tie-break is arbitrary but stable)
+        const byId = new Map();
+        for (const c of [...epicCandidates, ...prCandidates]) {
+            if (!byId.has(c.id)) byId.set(c.id, c);
+        }
+
+        const unique = [...byId.values()];
+
+        if (unique.length === 0) {
+            logger.info('[ConceptDiscoveryService] No new candidates discovered this cycle.');
+            return {candidatesAdded: 0, candidates: []};
+        }
+
+        await this.appendCandidates(unique);
+
+        logger.info(`[ConceptDiscoveryService] Appended ${unique.length} candidate concept(s) to nodes.jsonl. Awaiting curator review (validated: false, tier: 3).`);
+
+        return {candidatesAdded: unique.length, candidates: unique};
+    }
+
+    /**
+     * Appends candidate nodes as new JSONL rows. Pure filesystem operation — does not touch
+     * the graph. The next `ConceptIngestor.syncConceptsToGraph` picks them up.
+     *
+     * Each candidate serializes one per line matching the established schema
+     * (`{id, name, tier, description, uniqueToNeo, tags, aliases, validated, source, reasoning}`).
+     * File is flush-written via `fs.promises.appendFile` which is atomic at the per-line level
+     * on POSIX filesystems — safe for the single-writer REM pipeline pattern.
+     * @param {Object[]} candidates
+     * @protected
+     */
+    async appendCandidates(candidates) {
+        const
+            conceptsDir = ConceptService.defaultConceptsDir || path.resolve(__dirname, '../../../.neo-ai-data/concepts'),
+            nodesPath   = path.join(conceptsDir, 'nodes.jsonl');
+
+        let existing = '';
+        try {
+            existing = await fs.promises.readFile(nodesPath, 'utf8');
+        } catch (e) {
+            logger.warn(`[ConceptDiscoveryService] nodes.jsonl not readable at ${nodesPath}; creating new file.`);
+        }
+
+        const needsLeadingNewline = existing.length > 0 && !existing.endsWith('\n');
+        const serialized          = candidates.map(c => JSON.stringify(c)).join('\n');
+        const toAppend            = (needsLeadingNewline ? '\n' : '') + serialized + '\n';
+
+        await fs.promises.appendFile(nodesPath, toAppend, 'utf8');
+    }
+}
+
+export default Neo.setupClass(ConceptDiscoveryService);

--- a/ai/daemons/services/ConceptDiscoveryService.mjs
+++ b/ai/daemons/services/ConceptDiscoveryService.mjs
@@ -13,26 +13,6 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname  = path.dirname(__filename);
 
 /**
- * How many pull-request markdown files to process per discovery cycle. PRs accumulate quickly
- * (~300+ in the repo today) and each one is a separate LLM invocation. Sort-descending by
- * filename means we process the most-recent PRs first — where the freshest architectural
- * discourse lives (Gold Standards / Traps Avoided / Retrospective sections in recent review
- * comments). Bumpable via the instance-level `prScanLimit` property for tests / operators.
- * @type {Number}
- * @private
- */
-const DEFAULT_PR_SCAN_LIMIT = 20;
-
-/**
- * Minimum source text length for LLM invocation. Tiny bodies (one-liner PR descriptions,
- * empty epics) aren't worth the call. 200 characters is ~30 words — below this, there's no
- * coherent architectural discussion to extract from.
- * @type {Number}
- * @private
- */
-const MIN_SOURCE_LENGTH = 200;
-
-/**
  * System prompt establishing the Teaching Test + anti-patterns for the concept extraction
  * LLM. Emphasizes semantic judgment (what qualifies as an ontology concept) over pattern
  * matching (what LOOKS capitalized). Instructs strict JSON output so `Json.extract` can
@@ -150,10 +130,12 @@ class ConceptDiscoveryService extends Base {
     }
 
     /**
-     * Cap on PRs processed per cycle. Override on instance for tests / operator-tuning.
-     * @member {Number} prScanLimit
+     * Instance-level override for the per-cycle PR cap. Tests mutate this directly for
+     * deterministic cap behavior; production falls back to `aiConfig.data.conceptDiscovery
+     * .prScanLimit` (#10086 config-lift pattern — live read at call time, not module load).
+     * @member {Number|null} prScanLimit=null
      */
-    prScanLimit = DEFAULT_PR_SCAN_LIMIT
+    prScanLimit = null
 
     /**
      * Invokes the configured LLM provider on a single source and parses the response as the
@@ -170,7 +152,8 @@ class ConceptDiscoveryService extends Base {
      * @protected
      */
     async extractConceptsFromSource(sourceRef, text) {
-        if (!text || text.trim().length < MIN_SOURCE_LENGTH) return [];
+        const minSourceLength = aiConfig.data.conceptDiscovery?.minSourceLength ?? 200;
+        if (!text || text.trim().length < minSourceLength) return [];
 
         let provider;
         try {
@@ -300,7 +283,8 @@ class ConceptDiscoveryService extends Base {
             return nb - na;
         });
 
-        const cappedFiles = files.slice(0, this.prScanLimit);
+        const scanLimit   = this.prScanLimit ?? aiConfig.data.conceptDiscovery?.prScanLimit ?? 20;
+        const cappedFiles = files.slice(0, scanLimit);
         const sources     = [];
 
         for (const file of cappedFiles) {
@@ -356,7 +340,7 @@ class ConceptDiscoveryService extends Base {
         const sources = await this.loadPullRequestSources();
         if (sources.length === 0) return [];
 
-        logger.info(`[ConceptDiscoveryService] PR mining: scanning ${sources.length} recent PR file(s) (cap=${this.prScanLimit}).`);
+        logger.info(`[ConceptDiscoveryService] PR mining: scanning ${sources.length} recent PR file(s).`);
 
         const all = [];
         for (const {sourceRef, text} of sources) {

--- a/ai/daemons/services/ConceptIngestor.mjs
+++ b/ai/daemons/services/ConceptIngestor.mjs
@@ -101,7 +101,12 @@ class ConceptIngestor extends Base {
             name       : conceptNode.name        ?? '',
             tags       : conceptNode.tags        ?? [],
             tier       : conceptNode.tier        ?? 0,
-            uniqueToNeo: !!conceptNode.uniqueToNeo
+            uniqueToNeo: !!conceptNode.uniqueToNeo,
+            // #10036: validated flag — unvalidated concepts are candidates from ConceptDiscoveryService
+            // awaiting human curation. `undefined` (legacy rows pre-#10036) is treated as validated.
+            // Flipping `validated: false → true` during curator review must trigger re-upsert, so the
+            // flag contributes to the hash.
+            validated  : conceptNode.validated !== false
         };
 
         return crypto.createHash('sha256').update(stableStringify(payload)).digest('hex');
@@ -242,6 +247,7 @@ class ConceptIngestor extends Base {
                             tags       : conceptNode.tags        ?? [],
                             tier       : conceptNode.tier        ?? 0,
                             uniqueToNeo: !!conceptNode.uniqueToNeo,
+                            validated  : conceptNode.validated !== false,
                             weight
                         }
                     });

--- a/ai/daemons/services/GapInferenceEngine.mjs
+++ b/ai/daemons/services/GapInferenceEngine.mjs
@@ -167,6 +167,13 @@ class GapInferenceEngine extends Base {
         const threshold = aiConfig.data.guideGapWeightThreshold;
 
         for (const concept of conceptNodes) {
+            // #10036: unvalidated concepts (candidates from ConceptDiscoveryService awaiting
+            // curator review) are silenced regardless of weight. Low weight is the primary gate
+            // for legitimate low-priority concepts; the validated flag is the explicit override
+            // for "this hasn't been reviewed yet — don't surface it." Legacy rows without the
+            // field (pre-#10036) have `validated === undefined`, treated as validated.
+            if (concept.properties?.validated === false) continue;
+
             const
                 outboundEdges       = GraphService.db.edges.getByIndex('source', concept.id),
                 explainedByEdges    = outboundEdges.filter(e => e.type === 'EXPLAINED_BY'),

--- a/ai/mcp/server/memory-core/config.template.mjs
+++ b/ai/mcp/server/memory-core/config.template.mjs
@@ -214,6 +214,24 @@ const defaultConfig = {
      */
     guideGapWeightThreshold: Number(process.env.NEO_GUIDE_GAP_WEIGHT_THRESHOLD) || 0.8,
     /**
+     * Operator-tuning knobs for `ConceptDiscoveryService` (#10036). Both values are read live
+     * at method-call time (not captured at module load) so tests + runtime overrides are honored.
+     *
+     * - `prScanLimit`: how many pull-request markdown files to process per discovery cycle.
+     *   PRs are sorted descending by PR number so the most-recent (freshest architectural
+     *   discourse) process first. Capping bounds per-cycle LLM cost against the ~300+ PR corpus.
+     * - `minSourceLength`: minimum source text length (chars) to trigger an LLM extraction call.
+     *   Short bodies aren't worth the provider round-trip; 200 ≈ 30 words of coherent prose.
+     *
+     * Expected to migrate to SDK-layer config per #10103 once the daemon/service config split
+     * lands — these are daemon concerns, not memory-core concerns.
+     * @type {Object}
+     */
+    conceptDiscovery: {
+        prScanLimit    : Number(process.env.NEO_CONCEPT_DISCOVERY_PR_SCAN_LIMIT)     || 20,
+        minSourceLength: Number(process.env.NEO_CONCEPT_DISCOVERY_MIN_SOURCE_LENGTH) || 200
+    },
+    /**
      * Universal JSONL backup/export directory for all databases.
      * @type {string}
      */

--- a/test/playwright/unit/ai/daemons/DreamService.spec.mjs
+++ b/test/playwright/unit/ai/daemons/DreamService.spec.mjs
@@ -439,6 +439,33 @@ test.describe('Neo.ai.mcp.server.memory-core.services.DreamService', () => {
         expect(lowOrphan.properties?.capabilityGap).toBeUndefined();
     });
 
+    test('unvalidated concepts (validated: false) should be silenced regardless of weight (#10036)', async () => {
+        // #10036: mined candidates from ConceptDiscoveryService carry `validated: false` until
+        // a curator promotes them via nodes.jsonl edit. Low weight is the primary silencing
+        // mechanism (weight gate), but `validated: false` is the explicit override — even if
+        // an unvalidated candidate had a high weight, it must stay silent until reviewed.
+        GraphService.upsertNode({
+            id        : 'concept-unvalidated',
+            type      : 'CONCEPT',
+            name      : 'UnvalidatedCandidate',
+            properties: {
+                name       : 'UnvalidatedCandidate',
+                tier       : 1,
+                uniqueToNeo: true,
+                weight     : 1.3,
+                validated  : false
+            }
+        });
+
+        await DreamService.inferConceptGraphGaps();
+
+        const node = GraphService.db.nodes.get('concept-unvalidated');
+
+        // Weight 1.3 >= 0.8 threshold → would normally emit GUIDE_GAP + ORPHAN_CONCEPT.
+        // The `validated: false` flag must suppress all three concept-graph signals.
+        expect(node.properties.capabilityGap).toBeUndefined();
+    });
+
     test('should emit GUIDE_GAP and ORPHAN_CONCEPT together when concept lacks both EXPLAINED_BY and IMPLEMENTED_BY (#10087)', async () => {
         // Locks in the independence of ORPHAN_CONCEPT from the GUIDE_GAP / EXAMPLE_GAP branch.
         // GUIDE_GAP and EXAMPLE_GAP are mutually exclusive (one requires EXPLAINED_BY absent, the

--- a/test/playwright/unit/ai/daemons/services/ConceptDiscoveryService.spec.mjs
+++ b/test/playwright/unit/ai/daemons/services/ConceptDiscoveryService.spec.mjs
@@ -1,0 +1,278 @@
+import {setup} from '../../../../setup.mjs';
+
+const appName = 'ConceptDiscoveryServiceTest';
+
+setup({
+    neoConfig: {
+        unitTestMode: true
+    },
+    appConfig: {
+        name             : appName,
+        isMounted        : () => true,
+        vnodeInitialising: false
+    }
+});
+
+import {test, expect} from '@playwright/test';
+import Neo            from '../../../../../../src/Neo.mjs';
+import * as core      from '../../../../../../src/core/_export.mjs';
+import fs             from 'fs';
+import path           from 'path';
+import os             from 'os';
+
+test.describe('Neo.ai.daemons.services.ConceptDiscoveryService', () => {
+    let ConceptDiscoveryService;
+    let ConceptService;
+    let OpenAiCompatible;
+    let logger;
+
+    let tmpConceptsDir;
+    let tmpIssuesDir;
+    let tmpPullsDir;
+
+    let originalIssuesDir;
+    let originalPullsDir;
+    let originalPrScanLimit;
+    let originalGenerate;
+
+    let llmResponses = [];
+    let llmCallCount = 0;
+
+    let originalWarn;
+    let warnMessages = [];
+
+    test.beforeAll(async () => {
+        ConceptDiscoveryService = (await import('../../../../../../ai/daemons/services/ConceptDiscoveryService.mjs')).default;
+        ConceptService          = (await import('../../../../../../ai/services/ConceptService.mjs')).default;
+        OpenAiCompatible        = (await import('../../../../../../ai/provider/OpenAiCompatible.mjs')).default;
+        logger                  = (await import('../../../../../../ai/mcp/server/memory-core/logger.mjs')).default;
+    });
+
+    test.beforeEach(() => {
+        ConceptService.nodes.clear();
+        ConceptService.edgesBySource.clear();
+        ConceptService.edgesByTarget.clear();
+        ConceptService.aliasIndex.clear();
+        ConceptService.loaded = false;
+
+        tmpConceptsDir = fs.mkdtempSync(path.join(os.tmpdir(), 'neo-concept-discovery-concepts-'));
+        tmpIssuesDir   = fs.mkdtempSync(path.join(os.tmpdir(), 'neo-concept-discovery-issues-'));
+        tmpPullsDir    = fs.mkdtempSync(path.join(os.tmpdir(), 'neo-concept-discovery-pulls-'));
+
+        ConceptService.defaultConceptsDir = tmpConceptsDir;
+
+        originalIssuesDir   = ConceptDiscoveryService.issuesDir;
+        originalPullsDir    = ConceptDiscoveryService.pullsDir;
+        originalPrScanLimit = ConceptDiscoveryService.prScanLimit;
+
+        ConceptDiscoveryService.issuesDir = tmpIssuesDir;
+        ConceptDiscoveryService.pullsDir  = tmpPullsDir;
+
+        // Stub LLM provider — each call returns the next queued response
+        llmResponses = [];
+        llmCallCount = 0;
+        originalGenerate = OpenAiCompatible.prototype.generate;
+        OpenAiCompatible.prototype.generate = async function(prompt) {
+            const idx = Math.min(llmCallCount, llmResponses.length - 1);
+            llmCallCount++;
+            const response = llmResponses[idx];
+            return {content: typeof response === 'string' ? response : JSON.stringify(response)};
+        };
+
+        warnMessages = [];
+        originalWarn = logger.warn;
+        logger.warn  = (...args) => {
+            warnMessages.push(args.map(a => typeof a === 'string' ? a : JSON.stringify(a)).join(' '));
+        };
+    });
+
+    test.afterEach(() => {
+        if (originalIssuesDir === undefined)   delete ConceptDiscoveryService.issuesDir; else ConceptDiscoveryService.issuesDir = originalIssuesDir;
+        if (originalPullsDir === undefined)    delete ConceptDiscoveryService.pullsDir;  else ConceptDiscoveryService.pullsDir  = originalPullsDir;
+        if (originalPrScanLimit !== undefined) ConceptDiscoveryService.prScanLimit = originalPrScanLimit;
+
+        if (originalGenerate) OpenAiCompatible.prototype.generate = originalGenerate;
+        if (originalWarn)     logger.warn = originalWarn;
+
+        if (tmpConceptsDir && fs.existsSync(tmpConceptsDir)) { try { fs.rmSync(tmpConceptsDir, {recursive: true}); } catch (e) {} }
+        if (tmpIssuesDir   && fs.existsSync(tmpIssuesDir))   { try { fs.rmSync(tmpIssuesDir,   {recursive: true}); } catch (e) {} }
+        if (tmpPullsDir    && fs.existsSync(tmpPullsDir))    { try { fs.rmSync(tmpPullsDir,    {recursive: true}); } catch (e) {} }
+
+        // Symmetric singleton cleanup per `feedback_symmetric_spec_cleanup.md`
+        ConceptService.nodes.clear();
+        ConceptService.edgesBySource.clear();
+        ConceptService.edgesByTarget.clear();
+        ConceptService.aliasIndex.clear();
+        ConceptService.loaded = false;
+    });
+
+    /**
+     * Writes a bare nodes.jsonl + edges.jsonl into the temp concepts dir so
+     * `ConceptService.loadGraph()` has something to parse without false dedupe matches.
+     */
+    function writeEmptyConceptGraph() {
+        fs.writeFileSync(path.join(tmpConceptsDir, 'nodes.jsonl'), '', 'utf8');
+        fs.writeFileSync(path.join(tmpConceptsDir, 'edges.jsonl'), '', 'utf8');
+    }
+
+    /**
+     * Seeds the concept graph with the given node records so dedupe tests have real state.
+     * @param {Object[]} nodes
+     */
+    function writeSeedConceptGraph(nodes) {
+        fs.writeFileSync(path.join(tmpConceptsDir, 'nodes.jsonl'), nodes.map(n => JSON.stringify(n)).join('\n') + '\n', 'utf8');
+        fs.writeFileSync(path.join(tmpConceptsDir, 'edges.jsonl'), '', 'utf8');
+    }
+
+    /**
+     * Writes a fake issue markdown file into the temp issues dir. Always includes YAML
+     * frontmatter + a body long enough to exceed MIN_SOURCE_LENGTH.
+     */
+    function writeIssueFile(filename, {labels = [], id = null, bodyExtra = ''} = {}) {
+        const fm = `---\nid: ${id || 'auto'}\ntitle: Test\nlabels:\n${labels.map(l => `  - ${l}`).join('\n') || '  - enhancement'}\n---\n`;
+        const body = fm + 'This is a test issue body. '.repeat(20) + bodyExtra;
+        fs.writeFileSync(path.join(tmpIssuesDir, filename), body, 'utf8');
+    }
+
+    /**
+     * Writes a fake PR markdown file with body + comments section.
+     */
+    function writePullFile(filename, {bodyExtra = ''} = {}) {
+        const fm   = `---\nnumber: ${filename.match(/(\d+)/)[1]}\ntitle: Test PR\n---\n`;
+        const body = fm + '## Summary\n\n' + 'Some description text. '.repeat(15) + bodyExtra + '\n\n## Comments\n\n### @agent - 2026-04-19T10:00:00Z\n\nReview comment with architectural discussion. '.repeat(10);
+        fs.writeFileSync(path.join(tmpPullsDir, filename), body, 'utf8');
+    }
+
+    test('mineFromEpics should only process epic-labeled issues and emit LLM candidates', async () => {
+        writeEmptyConceptGraph();
+        ConceptService.loadGraph();
+
+        writeIssueFile('issue-100.md', {labels: ['enhancement'], id: 100});
+        writeIssueFile('issue-200.md', {labels: ['epic', 'ai'],  id: 200});
+        writeIssueFile('issue-300.md', {labels: ['bug'],         id: 300});
+
+        llmResponses = [{
+            candidates: [{
+                id         : 'native-edge-graph',
+                name       : 'Native Edge Graph',
+                description: 'The SQLite-backed topology that stores concept + issue + PR nodes with typed edges.',
+                reasoning  : 'Passes the Teaching Test — meta-architectural, not a single-class concept.',
+                aliases    : ['edge graph', 'concept graph']
+            }]
+        }];
+
+        const candidates = await ConceptDiscoveryService.mineFromEpics();
+
+        // Only the single epic-labeled issue should trigger an LLM call
+        expect(llmCallCount).toBe(1);
+        expect(candidates.length).toBe(1);
+        expect(candidates[0].name).toBe('Native Edge Graph');
+        expect(candidates[0].validated).toBe(false);
+        expect(candidates[0].tier).toBe(3);
+        expect(candidates[0].source).toBe('epic-200');
+    });
+
+    test('mineFromPullRequests should cap at prScanLimit and process most-recent PRs first', async () => {
+        writeEmptyConceptGraph();
+        ConceptService.loadGraph();
+
+        // Three PRs — cap at 2 so only the two most-recent (highest numbers) get processed
+        writePullFile('pr-100.md');
+        writePullFile('pr-200.md');
+        writePullFile('pr-300.md');
+
+        ConceptDiscoveryService.prScanLimit = 2;
+
+        llmResponses = [
+            {candidates: [{id: 'substrate-choice-discipline', name: 'Substrate Choice Discipline', description: 'x', reasoning: 'y', aliases: []}]},
+            {candidates: []}
+        ];
+
+        const candidates = await ConceptDiscoveryService.mineFromPullRequests();
+
+        expect(llmCallCount).toBe(2);
+        expect(candidates.length).toBe(1);
+        expect(candidates[0].source).toMatch(/^pull-pr-(300|200)$/); // one of the top-2 most recent
+    });
+
+    test('extractConceptsFromSource should dedupe against existing ConceptService entries', async () => {
+        writeSeedConceptGraph([
+            {id: 'multi-threading', name: 'Multi-Threading', tier: 1, description: '', uniqueToNeo: true, tags: [], aliases: ['worker threading']}
+        ]);
+        ConceptService.loadGraph();
+
+        llmResponses = [{
+            candidates: [
+                {id: 'multi-threading',       name: 'Multi-Threading',         description: 'dup', reasoning: 'y', aliases: []},
+                {id: 'worker-threading-slug', name: 'worker threading',        description: 'alias dup', reasoning: 'y', aliases: []},
+                {id: 'novel-concept',         name: 'Novel Concept',           description: 'new', reasoning: 'y', aliases: []}
+            ]
+        }];
+
+        const body = 'Enough content to exceed MIN_SOURCE_LENGTH. '.repeat(20);
+        const accepted = await ConceptDiscoveryService.extractConceptsFromSource('test-source', body);
+
+        // Two dupes filtered (id match + alias match), only one survives
+        expect(accepted.length).toBe(1);
+        expect(accepted[0].name).toBe('Novel Concept');
+    });
+
+    test('extractConceptsFromSource should tolerate malformed LLM output without throwing', async () => {
+        writeEmptyConceptGraph();
+        ConceptService.loadGraph();
+
+        llmResponses = ['not valid json at all, certainly no candidates field'];
+
+        const body = 'Adequate source content. '.repeat(20);
+        const accepted = await ConceptDiscoveryService.extractConceptsFromSource('broken-llm-source', body);
+
+        expect(accepted).toEqual([]);
+    });
+
+    test('extractConceptsFromSource should skip short sources below MIN_SOURCE_LENGTH', async () => {
+        writeEmptyConceptGraph();
+        ConceptService.loadGraph();
+
+        const tooShort = 'Tiny body.';
+        const accepted = await ConceptDiscoveryService.extractConceptsFromSource('tiny-source', tooShort);
+
+        // No LLM call should have been made
+        expect(llmCallCount).toBe(0);
+        expect(accepted).toEqual([]);
+    });
+
+    test('runDiscoveryCycle should merge epic+PR candidates, dedupe by id, and append to nodes.jsonl', async () => {
+        writeEmptyConceptGraph();
+
+        writeIssueFile('issue-500.md', {labels: ['epic'], id: 500});
+        writePullFile('pr-700.md');
+
+        llmResponses = [
+            // Epic call
+            {candidates: [{id: 'shared-concept', name: 'Shared Concept', description: 'from-epic', reasoning: 'y', aliases: []}]},
+            // PR call — returns SAME id to test dedupe-by-id + a new one
+            {candidates: [
+                {id: 'shared-concept',  name: 'Shared Concept',        description: 'from-pr',    reasoning: 'y', aliases: []},
+                {id: 'pr-only-concept', name: 'PR Only Concept',        description: 'pr-only',    reasoning: 'y', aliases: []}
+            ]}
+        ];
+
+        const result = await ConceptDiscoveryService.runDiscoveryCycle();
+
+        expect(result.candidatesAdded).toBe(2);
+        const ids = result.candidates.map(c => c.id);
+        expect(ids).toContain('shared-concept');
+        expect(ids).toContain('pr-only-concept');
+
+        // Verify the append actually hit the JSONL
+        const nodesContent = fs.readFileSync(path.join(tmpConceptsDir, 'nodes.jsonl'), 'utf8');
+        expect(nodesContent).toContain('"shared-concept"');
+        expect(nodesContent).toContain('"pr-only-concept"');
+        expect(nodesContent).toContain('"validated":false');
+
+        // Epic-source wins on id collision (first-seen): description should be 'from-epic', not 'from-pr'
+        const sharedLine = nodesContent.split('\n').find(l => l.includes('"shared-concept"'));
+        expect(sharedLine).toContain('from-epic');
+        expect(sharedLine).not.toContain('from-pr');
+    });
+});

--- a/test/playwright/unit/ai/daemons/services/ConceptDiscoveryService.spec.mjs
+++ b/test/playwright/unit/ai/daemons/services/ConceptDiscoveryService.spec.mjs
@@ -241,6 +241,33 @@ test.describe('Neo.ai.daemons.services.ConceptDiscoveryService', () => {
         expect(accepted).toEqual([]);
     });
 
+    test('aiConfig.data.conceptDiscovery.minSourceLength override changes extraction behavior (#10086 pattern)', async () => {
+        writeEmptyConceptGraph();
+        ConceptService.loadGraph();
+
+        const aiConfig  = (await import('../../../../../../ai/mcp/server/memory-core/config.mjs')).default;
+        const original  = aiConfig.data.conceptDiscovery?.minSourceLength;
+        const bodyText  = 'Moderate length source. '.repeat(15); // ~360 chars — above default 200, below an override of 10000
+
+        llmResponses = [{candidates: [{id: 'x', name: 'X', description: 'y', reasoning: 'z', aliases: []}]}];
+
+        try {
+            // Raise threshold above body length — extraction must short-circuit without invoking LLM
+            aiConfig.data.conceptDiscovery.minSourceLength = 10000;
+            const skipped = await ConceptDiscoveryService.extractConceptsFromSource('raised-threshold', bodyText);
+            expect(skipped).toEqual([]);
+            expect(llmCallCount).toBe(0);
+
+            // Restore the normal threshold — same body now triggers the LLM
+            aiConfig.data.conceptDiscovery.minSourceLength = 200;
+            const accepted = await ConceptDiscoveryService.extractConceptsFromSource('normal-threshold', bodyText);
+            expect(llmCallCount).toBe(1);
+            expect(accepted.length).toBe(1);
+        } finally {
+            aiConfig.data.conceptDiscovery.minSourceLength = original;
+        }
+    });
+
     test('runDiscoveryCycle should merge epic+PR candidates, dedupe by id, and append to nodes.jsonl', async () => {
         writeEmptyConceptGraph();
 


### PR DESCRIPTION
## Summary

Lands deliverables **1**, **2**, and **4** of #10036 via **LLM-driven concept extraction** (gemma4 via `OpenAiCompatible.generate` — same substrate used by `SemanticGraphExtractor` and `GoldenPathSynthesizer`). Two high-signal corpora: epic-labeled GitHub issues and recent pull-request markdown (including their `## Comments` sections, where Gold Standards / Traps Avoided / Retrospective prose lives). Deliverables 3 (KB-assisted — timeout-blocked) and 5 (glossary gap report) deferred.

## The Problem

Today's concept ontology (~60 rows) is seeded almost entirely from guide titles. Architectural vocabulary emerging from actual Swarm work — epics, PR reviews — is invisible to the ontology. Without a discovery channel, the only growth path is manual `nodes.jsonl` edits.

#10036 is a semantic-judgment task: *does this term pass the Teaching Test?* That requires reasoning about meaning, not surface patterns. PR review comments in particular (marked with `[ARCH_ALIGNMENT]`, `[RETROSPECTIVE]`, `[KB_GAP]`, or living inside "Gold Standards / Traps Avoided" bullets) are where architectural discourse consolidates — exactly the corpus where new vocabulary emerges.

## Architectural Reality (verified against precedent)

- `ai/daemons/services/SemanticGraphExtractor.mjs` + `GoldenPathSynthesizer.mjs` — established pattern: construct `OpenAiCompatible` via `Neo.create`, call `provider.generate(prompt)`, parse with `Json.extract` (fence-tolerant). Same pipeline.
- `ai/daemons/services/ConceptIngestor.mjs` — additive one-way sync from curated JSONL → graph. `ConceptDiscoveryService` is the reverse-flow proposal channel (JSONL ← discovery); directional invariant preserved.
- `ai/daemons/services/GapInferenceEngine.mjs:inferConceptGraphGaps` — the weight gate already silences low-weight concepts. Adding `if (concept.properties?.validated === false) continue` at the top of the loop is a one-line explicit override that stays orthogonal. Legacy rows without the field (`undefined`) are treated as validated — no data migration.
- `resources/content/pulls/*.md` — 296 PR files today, each with body + `## Comments` section. Sorted descending by number so most-recent PRs (freshest architectural discourse) process first.
- `ConceptService.resolveAlias` + `ConceptService.nodes` — case-insensitive dedupe at the candidate level.

## Implementation Footprint

| File | Change |
|---|---|
| `ConceptDiscoveryService.mjs` (new) | Singleton daemon service. LLM-driven extraction via `OpenAiCompatible.generate`. Teaching-Test system prompt + explicit anti-patterns (class names, file paths, framework names without architectural weight). `mineFromEpics` + `mineFromPullRequests` + `runDiscoveryCycle` + `appendCandidates`. PR cap = 20 most-recent per cycle (`prScanLimit`). Candidates serialize to `nodes.jsonl` with `validated: false`, tier 3, source + reasoning tags. |
| `ConceptIngestor.mjs` | Adds `validated` to payload hash + upsert properties. Curator state-flip triggers re-upsert. |
| `GapInferenceEngine.mjs` | Adds `if (concept.properties?.validated === false) continue` gate. Silences all three signals (GUIDE_GAP / EXAMPLE_GAP / ORPHAN_CONCEPT) for unvalidated candidates regardless of weight. |
| `DreamService.mjs` | Adds `runConceptDiscovery()` facade. Not wired into REM-cycle — deliberate (LLM cost); curator/operator invokes manually. |
| `ConceptDiscoveryService.spec.mjs` (new) | 6 tests: epic-label filtering, PR cap + recency, ConceptService dedupe (id + alias), malformed-LLM tolerance, MIN_SOURCE_LENGTH short-circuit, end-to-end `runDiscoveryCycle` + JSONL append. Mocks `OpenAiCompatible.prototype.generate` with queued responses. Symmetric afterEach per `feedback_symmetric_spec_cleanup.md`. |
| `DreamService.spec.mjs` | New test: `validated: false` silences all three concept-graph signals even with weight 1.3 > 0.8 threshold. |

## Design Decisions

- **Corpora**: epics (curated architecture) + PRs (including comments — where `[ARCH_ALIGNMENT]` / `[RETROSPECTIVE]` / Gold-Standards prose lives). Session-summary mining deferred — epics + PRs are higher signal-to-noise.
- **Single JSONL, no staging file**: per the intake discussion, dual-file would duplicate the curator's review surface. Git diff on `nodes.jsonl` is the review UI. Weight gate + validated flag silence unvalidated rows in the handoff.
- **Manual invocation only**: running discovery every REM cycle would flood `nodes.jsonl` with LLM churn. `DreamService.runConceptDiscovery` is a facade; operator decides cadence.
- **PR cap = 20**: 296 PRs in the repo today. Processing all per cycle would burn budget. Recency-biased (highest PR number first) catches fresh discourse. Configurable via instance `prScanLimit`.
- **MIN_SOURCE_LENGTH = 200**: tiny bodies aren't worth the LLM call. Short-circuit before invoking the provider.
- **Fence-tolerant parsing**: some models emit ```` ```json ```` despite explicit anti-fence instructions. `Json.extract` handles both.

## Gold Standards Leveraged / Traps Avoided

- **Gold Standard** (in-codebase LLM pattern): mirrors `SemanticGraphExtractor` + `GoldenPathSynthesizer` — `Neo.create(OpenAiCompatible, {model, host})` → `provider.generate(prompt)` → `Json.extract(result.content)`.
- **Gold Standard** (additive ingestor pattern): `ConceptDiscoveryService` appends to the same JSONL `ConceptIngestor` reads. Next cycle auto-picks up new candidates; no special routing.
- **Gold Standard** (weight-gate reuse): mined candidates land with tier 3 → default weight 0.3 → below `guideGapWeightThreshold = 0.8` → silenced. `validated: false` is belt-and-suspenders.
- **Trap avoided** (substrate-for-semantic-tasks mismatch): first draft of this PR used PascalCase regex + stop-phrase blocklist. Every individual piece was defensible; the aggregate was still surface-pattern matching for a semantic-judgment task. No stop-phrase list can rescue "Pull Request Review" (noise) vs. "Concept Ontology Layer" (signal) at the regex level. LLM reasoning is the correct substrate. See `feedback_llm_substrate_for_semantic_tasks.md` — surfaced during tobi's self-review challenge.
- **Trap avoided** (dual-file staging): per intake, `candidates.jsonl` split would duplicate curator review surface.
- **Trap avoided** (REM-cycle integration): would flood the JSONL with per-cycle LLM churn. Manual invocation respects cost.

## Testing

```bash
npm run test-unit -- test/playwright/unit/ai/services/ConceptService.spec.mjs test/playwright/unit/ai/daemons/
```

**48 passed** (ConceptService 23, DreamService 12 — includes new validated-gate test, DreamServiceGoldenPath 1, ConceptIngestor 7, ConceptDiscoveryService 6 new). Stable across 5 consecutive runs.

## Out of Scope / Follow-Up

- **Deliverable 3 (KB-assisted classification)** — blocked on `ask_knowledge_base` timeout per ticket body. File follow-up when unblocked.
- **Deliverable 5 (glossary gap report)** — pure reporting tool. File when the concept graph matures.
- **Session-summary mining** — epics + PRs are higher signal; add if coverage proves insufficient.
- **REM-cycle auto-invocation** — manual-only today; add cadence/budget control if curator wants automation.

## Related

- Parent epic: #10030 (Concept Ontology & Semantic Gap Inference)
- Preceded by: #10085 (#10100), #10087 (#10101), #10086 (#10102) — all merged this session
- Depends on: #10035 (concept graph integration — merged as part of #10084)
- Durable memory surfaced: `feedback_llm_substrate_for_semantic_tasks.md`, `feedback_symmetric_spec_cleanup.md`, `feedback_observability_consumer_identity.md`, `feedback_config_service_boundary.md`, `feedback_challenge_prescribed_fixes.md`, `feedback_no_title_prefix_duplicating_labels.md`

Resolves #10036 (deliverables 1+2+4; deliverables 3+5 deferred with explicit rationale)

Origin Session ID: 1db25bbe-f39d-4dcd-bb0e-bc125ce91326