### PR TITLE
fix(github-workflow): remove commentsTotal sentinel sweep (#10110)

### DIFF
--- a/ai/mcp/server/github-workflow/config.template.mjs
+++ b/ai/mcp/server/github-workflow/config.template.mjs
@@ -167,11 +167,6 @@ const defaultConfig = {
          */
         maxAssigneesPerIssue: 10,
         /**
-         * Maximum number of comments to fetch per issue in GraphQL queries.
-         * @type {number}
-         */
-        maxCommentsPerIssue: 100,
-        /**
          * Maximum number of sub-issues to fetch per issue in GraphQL queries.
          * @type {number}
          */
@@ -180,15 +175,7 @@ const defaultConfig = {
          * Maximum number of timeline items to fetch per issue in GraphQL queries.
          * @type {number}
          */
-        maxTimelineItemsPerIssue: 50,
-        /**
-         * Batch size for the stale-comments-count sentinel sweep (#10092).
-         * Controls how many issues are queried via aliased GraphQL fields per request.
-         * Stay below GitHub's per-query complexity limit (~500 nodes). Each issue costs
-         * ~3 complexity units here, so 100 is a safe default.
-         * @type {number}
-         */
-        staleCommentsBatchSize: 100
+        maxTimelineItemsPerIssue: 50
     },
     /**
      * Configuration for pull request queries.

--- a/ai/mcp/server/github-workflow/services/SyncService.mjs
+++ b/ai/mcp/server/github-workflow/services/SyncService.mjs
@@ -101,19 +101,6 @@ class SyncService extends Base {
         // 4. Pull remote changes
         const { newMetadata, stats: pullStats } = await IssueSyncer.pullFromGitHub(metadata);
 
-        // 4b. Sentinel sweep for updatedAt-blind drift (comment deletions — #10092).
-        //     Runs AFTER the delta pull so newly-refreshed entries have current commentsTotal
-        //     and only genuinely-drifted issues survive as mismatches into the refetch step.
-        const staleCountsStats = await IssueSyncer.detectStaleCommentsCounts(newMetadata);
-        if (staleCountsStats.stale.length > 0) {
-            const staleNumbers = staleCountsStats.stale.map(s => s.number);
-            logger.warn(`🔍 Comment-count drift detected on ${staleNumbers.length} issue(s): ${staleNumbers.join(', ')}`);
-            const refetchStats = await IssueSyncer.refetchIssuesByNumber(staleNumbers, newMetadata);
-            pullStats.pulled.count   += refetchStats.refetched.count;
-            pullStats.pulled.updated += refetchStats.refetched.count;
-            pullStats.pulled.issues.push(...refetchStats.refetched.issues);
-        }
-
         // 5. Sync release notes
         const releaseStats = await ReleaseSyncer.syncNotes(metadata);
 
@@ -180,13 +167,7 @@ class SyncService extends Base {
             dropped     : pullStats.dropped,
             releases    : releaseStats,
             discussions : discussionStats,
-            pulls       : pullStats2,
-            staleCounts : {
-                checked: staleCountsStats.checked,
-                stale  : staleCountsStats.stale.length,
-                seeded : staleCountsStats.seeded,
-                errors : staleCountsStats.errors.length
-            }
+            pulls       : pullStats2
         };
 
         const timing = {
@@ -203,7 +184,6 @@ class SyncService extends Base {
         logger.info(`   Releases:    ${finalStats.releases.count} synced`);
         logger.info(`   Discussions: ${finalStats.discussions.count} synced`);
         logger.info(`   Pulls:       ${finalStats.pulls.count} synced`);
-        logger.info(`   StaleCounts: ${finalStats.staleCounts.checked} checked, ${finalStats.staleCounts.stale} drifted, ${finalStats.staleCounts.seeded} seeded${finalStats.staleCounts.errors > 0 ? `, ${finalStats.staleCounts.errors} errors` : ''}`);
         logger.info(`   Duration:    ${Math.round(timing.durationMs / 1000)}s`);
 
         return {

--- a/ai/mcp/server/github-workflow/services/queries/issueQueries.mjs
+++ b/ai/mcp/server/github-workflow/services/queries/issueQueries.mjs
@@ -30,7 +30,6 @@
  * - $since: DateTime - Only fetch issues updated since this date
  * - $maxLabels: Int! - Max labels per issue
  * - $maxAssignees: Int! - Max assignees per issue
- * - $maxComments: Int! - Max comments per issue
  * - $maxSubIssues: Int! - Max sub-issues to fetch
  */
 export const FETCH_ISSUES_FOR_SYNC = `
@@ -43,7 +42,6 @@ export const FETCH_ISSUES_FOR_SYNC = `
     $since: DateTime
     $maxLabels: Int!
     $maxAssignees: Int!
-    $maxComments: Int!
     $maxSubIssues: Int!
     $maxTimelineItems: Int!
   ) {
@@ -87,10 +85,6 @@ export const FETCH_ISSUES_FOR_SYNC = `
           
           milestone {
             title
-          }
-          
-          comments(first: $maxComments) {
-            totalCount
           }
           
           # Parent/child relationships
@@ -375,7 +369,6 @@ export const FETCH_ISSUES_LIST = `
  * - $number: Int!
  * - $maxLabels: Int!
  * - $maxAssignees: Int!
- * - $maxComments: Int!
  * - $maxSubIssues: Int!
  */
 export const FETCH_SINGLE_ISSUE = `
@@ -385,7 +378,6 @@ export const FETCH_SINGLE_ISSUE = `
     $number: Int!
     $maxLabels: Int!
     $maxAssignees: Int!
-    $maxComments: Int!
     $maxSubIssues: Int!
     $maxTimelineItems: Int!
   ) {
@@ -414,9 +406,6 @@ export const FETCH_SINGLE_ISSUE = `
         }
         milestone {
           title
-        }
-        comments(first: $maxComments) {
-          totalCount
         }
         parent {
           number
@@ -611,38 +600,6 @@ export const FETCH_SINGLE_ISSUE = `
     }
   }
 `;
-
-/**
- * @summary Builds a batched GraphQL query that fetches `comments.totalCount` for an
- * arbitrary list of issue numbers in a single request, using aliased fields.
- *
- * This is the detection primitive for the comment-deletion sentinel sweep (#10092).
- * Standard delta-sync is blind to deletions because GitHub does not bump
- * `issue.updatedAt` when a comment is removed. A periodic totals sweep compares the
- * live totalCount against the stored `commentsTotal` in metadata and force-refetches
- * any mismatches via `refetchIssuesByNumber`.
- *
- * Uses GraphQL field aliasing (`issue42: issue(number: 42) { ... }`) so that N issues
- * can be queried in one trip. Query complexity is ~3 × N — safely under GitHub's
- * per-request limit for batches up to ~150. Caller is responsible for chunking.
- *
- * @param {number[]} numbers The issue numbers to fetch totals for.
- * @returns {string} The composed GraphQL query string.
- */
-export function buildIssueTotalsBatchQuery(numbers) {
-    const aliasedFields = numbers
-        .map(n => `    issue${n}: issue(number: ${n}) { number comments { totalCount } }`)
-        .join('\n');
-
-    return `
-  query FetchIssueTotalsBatch($owner: String!, $repo: String!) {
-    repository(owner: $owner, name: $repo) {
-${aliasedFields}
-    }
-    rateLimit { cost remaining resetAt }
-  }
-`;
-}
 
 /**
  * Continuation query for a single issue's timelineItems connection.

--- a/ai/mcp/server/github-workflow/services/sync/IssueSyncer.mjs
+++ b/ai/mcp/server/github-workflow/services/sync/IssueSyncer.mjs
@@ -7,7 +7,7 @@ import matter                                        from 'gray-matter';
 import path                                          from 'path';
 import GraphqlService                                from '../GraphqlService.mjs';
 import ReleaseSyncer                                 from './ReleaseSyncer.mjs';
-import {buildIssueTotalsBatchQuery, FETCH_ISSUE_TIMELINE_PAGE, FETCH_ISSUES_FOR_SYNC, FETCH_SINGLE_ISSUE} from '../queries/issueQueries.mjs';
+import {FETCH_ISSUE_TIMELINE_PAGE, FETCH_ISSUES_FOR_SYNC, FETCH_SINGLE_ISSUE} from '../queries/issueQueries.mjs';
 import {GET_ISSUE_ID, UPDATE_ISSUE}                                                                        from '../queries/mutations.mjs';
 
 const issueSyncConfig = aiConfig.issueSync;
@@ -57,8 +57,8 @@ class IssueSyncer extends Base {
      * GitHub's GraphQL `timelineItems` connection returns events oldest-first with no `orderBy`,
      * so the default `first: N` request truncates the tail. Once total events exceed N, newly-
      * authored comments and structural events silently disappear from the rendered markdown
-     * while scalar metadata (`updatedAt`, `comments.totalCount`) stays correct — a divergence
-     * between the metadata path and the content-rendering path.
+     * while scalar metadata (`updatedAt`) stays correct — a divergence between the metadata
+     * path and the content-rendering path.
      *
      * This helper is the pagination primitive: it detects `pageInfo.hasNextPage` and loops
      * `FETCH_ISSUE_TIMELINE_PAGE` with the previous cursor, concatenating nodes in place on
@@ -103,6 +103,27 @@ class IssueSyncer extends Base {
     }
 
     /**
+     * @summary Counts `ISSUE_COMMENT` nodes in an issue's exhausted `timelineItems` set.
+     *
+     * Post-#10090 pagination-exhaust (`#exhaustTimelineItems`) guarantees `timelineItems.nodes`
+     * contains the complete per-issue event stream — including every surviving comment. This
+     * method returns the authoritative `commentsTotal` for metadata persistence, replacing the
+     * pre-timeline-era `issue.comments.totalCount` scalar (#10110). Single source of truth:
+     * the metadata value is now structurally guaranteed to match what the timeline renders in
+     * the local markdown.
+     *
+     * MUST be called only after `#exhaustTimelineItems(issue)` has run; otherwise the count
+     * reflects only the first timeline page and will under-report on long-timeline issues.
+     *
+     * @param {object} issue The GitHub issue with an exhausted `timelineItems` connection.
+     * @returns {number}
+     * @private
+     */
+    #countTimelineComments(issue) {
+        return issue.timelineItems.nodes.filter(n => n.__typename === 'IssueComment').length;
+    }
+
+    /**
      * Formats a GitHub issue and its comments into a single Markdown string with YAML frontmatter.
      * @param {object}   issue    The GitHub issue object.
      * @param {object[]} comments An array of comment objects associated with the issue.
@@ -120,7 +141,8 @@ class IssueSyncer extends Base {
             updatedAt         : issue.updatedAt,
             githubUrl         : issue.url,
             author            : issue.author.login,
-            commentsCount     : issue.comments.totalCount,
+            commentsCount     : this.#countTimelineComments(issue), // Derived from the exhausted timeline — #10110
+
             parentIssue       : issue.parent ? issue.parent.number : null,
             subIssues         : issue.subIssues?.nodes.map(sub => `[${sub.state === 'CLOSED' ? 'x' : ' '}] ${sub.number} ${sub.title.replace(lineBreaksRegex, ' ')}`) || [],
             subIssuesCompleted: issue.subIssuesSummary?.completed || 0,
@@ -341,7 +363,6 @@ class IssueSyncer extends Base {
                     since           : metadata.lastSync || issueSyncConfig.syncStartDate, // Use lastSync for delta updates
                     maxLabels       : issueSyncConfig.maxLabelsPerIssue,
                     maxAssignees    : issueSyncConfig.maxAssigneesPerIssue,
-                    maxComments     : issueSyncConfig.maxCommentsPerIssue,
                     maxSubIssues    : issueSyncConfig.maxSubIssuesPerIssue,
                     maxTimelineItems: issueSyncConfig.maxTimelineItemsPerIssue
                 },
@@ -447,7 +468,7 @@ class IssueSyncer extends Base {
                 milestone    : issue.milestone?.title || null,
                 title        : issue.title,
                 contentHash,                                    // Store hash for push comparison
-                commentsTotal: issue.comments?.totalCount ?? 0  // Sentinel for comment-deletion drift (#10092)
+                commentsTotal: this.#countTimelineComments(issue) // Derived from the exhausted timeline — #10110
             };
         }
 
@@ -554,7 +575,6 @@ class IssueSyncer extends Base {
                         number          : issueNumber,
                         maxLabels       : issueSyncConfig.maxLabelsPerIssue,
                         maxAssignees    : issueSyncConfig.maxAssigneesPerIssue,
-                        maxComments     : issueSyncConfig.maxCommentsPerIssue,
                         maxSubIssues    : issueSyncConfig.maxSubIssuesPerIssue,
                         maxTimelineItems: issueSyncConfig.maxTimelineItemsPerIssue
                     },
@@ -590,7 +610,7 @@ class IssueSyncer extends Base {
                     milestone    : issue.milestone?.title || null,
                     title        : issue.title,
                     contentHash,
-                    commentsTotal: issue.comments?.totalCount ?? 0
+                    commentsTotal: this.#countTimelineComments(issue) // Derived from the exhausted timeline — #10110
                 };
             } catch (e) {
                 logger.error(`Failed to refetch issue #${issueNumber}: ${e.message}`);
@@ -599,72 +619,6 @@ class IssueSyncer extends Base {
         }
 
         return stats;
-    }
-
-    /**
-     * @summary Sentinel sweep that detects comment-deletion drift invisible to delta sync.
-     *
-     * Delta-sync uses `issue.updatedAt` as the invalidation signal, and GitHub does **not**
-     * bump `updatedAt` when a comment is deleted. The local markdown and metadata therefore
-     * retain stale `commentsCount` indefinitely — the pattern that kept issue #9535 frozen
-     * during the #10090 investigation. The timeline-scan workaround from #7948 does not
-     * transfer because GraphQL exposes no `ISSUE_COMMENT_DELETED_EVENT` type.
-     *
-     * This sweep compares live `issue.comments.totalCount` against the stored
-     * `commentsTotal` sentinel in metadata for every tracked issue, in a single batched
-     * GraphQL request via `buildIssueTotalsBatchQuery`. Mismatches are handed to
-     * `refetchIssuesByNumber`, which is the same recovery primitive introduced in #10090.
-     *
-     * First-run semantics (lazy seeding): entries without `commentsTotal` are seeded
-     * in place from the live value without triggering a refetch. This lets the sentinel
-     * graduate cleanly on pre-existing metadata without one-shot refetch storms.
-     *
-     * @param {object} metadata The sync metadata object. Mutated in place to seed missing
-     *                          `commentsTotal` fields. Caller is responsible for persisting.
-     * @returns {Promise<{checked: number, stale: Array<{number: number, stored: number, live: number}>, seeded: number, errors: Array<{error: string, batch: number[]}>}>}
-     */
-    async detectStaleCommentsCounts(metadata) {
-        const issueNumbers = Object.keys(metadata.issues).map(Number).filter(n => Number.isInteger(n));
-        const result       = {checked: 0, stale: [], seeded: 0, errors: []};
-
-        if (issueNumbers.length === 0) return result;
-
-        const batchSize = issueSyncConfig.staleCommentsBatchSize || 100;
-
-        for (let i = 0; i < issueNumbers.length; i += batchSize) {
-            const batch = issueNumbers.slice(i, i + batchSize);
-            try {
-                const data = await GraphqlService.query(
-                    buildIssueTotalsBatchQuery(batch),
-                    {owner: aiConfig.owner, repo: aiConfig.repo},
-                    true
-                );
-
-                result.checked += batch.length;
-
-                for (const num of batch) {
-                    const node = data.repository[`issue${num}`];
-                    if (!node) continue; // Issue no longer exists on GitHub; drop handled elsewhere.
-
-                    const liveTotal   = node.comments.totalCount;
-                    const entry       = metadata.issues[num];
-                    const storedTotal = entry?.commentsTotal;
-
-                    if (storedTotal === undefined || storedTotal === null) {
-                        // Lazy seed: populate sentinel without triggering a refetch.
-                        entry.commentsTotal = liveTotal;
-                        result.seeded++;
-                    } else if (storedTotal !== liveTotal) {
-                        result.stale.push({number: num, stored: storedTotal, live: liveTotal});
-                    }
-                }
-            } catch (e) {
-                logger.error(`Stale-counts batch query failed for ${batch.length} issues: ${e.message}`);
-                result.errors.push({error: e.message, batch});
-            }
-        }
-
-        return result;
     }
 
     /**

--- a/ai/mcp/server/github-workflow/services/sync/IssueSyncer.mjs
+++ b/ai/mcp/server/github-workflow/services/sync/IssueSyncer.mjs
@@ -142,7 +142,6 @@ class IssueSyncer extends Base {
             githubUrl         : issue.url,
             author            : issue.author.login,
             commentsCount     : this.#countTimelineComments(issue), // Derived from the exhausted timeline — #10110
-
             parentIssue       : issue.parent ? issue.parent.number : null,
             subIssues         : issue.subIssues?.nodes.map(sub => `[${sub.state === 'CLOSED' ? 'x' : ' '}] ${sub.number} ${sub.title.replace(lineBreaksRegex, ' ')}`) || [],
             subIssuesCompleted: issue.subIssuesSummary?.completed || 0,

--- a/ai/mcp/server/github-workflow/services/sync/MetadataManager.mjs
+++ b/ai/mcp/server/github-workflow/services/sync/MetadataManager.mjs
@@ -80,10 +80,11 @@ class MetadataManager extends Base {
                 closedAt     : value.closedAt,
                 updatedAt    : value.updatedAt,
                 contentHash  : value.contentHash,
-                // commentsTotal is the sentinel field that the stale-counts sweep compares against
-                // live GitHub state to catch updatedAt-blind drift (notably comment deletions — see
-                // #10092). May be undefined on pre-migration entries; detectStaleCommentsCounts seeds
-                // missing values lazily without triggering a refetch.
+                // commentsTotal is the count of ISSUE_COMMENT nodes derived from the exhausted
+                // timelineItems connection (#10110). Single source of truth: the metadata value
+                // is structurally guaranteed to match the rendered markdown because both are
+                // produced from the same timeline. Pre-#10110 entries fed this from the separate
+                // comments.totalCount scalar (a pre-timeline-era leftover), now superseded.
                 commentsTotal: value.commentsTotal
             };
         }

--- a/test/playwright/unit/ai/mcp/server/github-workflow/IssueSyncer.spec.mjs
+++ b/test/playwright/unit/ai/mcp/server/github-workflow/IssueSyncer.spec.mjs
@@ -21,12 +21,20 @@ import fs              from 'fs-extra';
 import path            from 'path';
 
 /**
- * @summary Regression coverage for the timelineItems pagination fix in IssueSyncer (#10090).
+ * @summary Regression coverage for IssueSyncer's timeline-based comment accounting.
  *
- * Builds a mocked GitHub issue whose `timelineItems` connection has 75 events split across
- * two pages — more than `maxTimelineItemsPerIssue` (50) — and drives the refetch path to
- * confirm that every comment body and structural event makes it into the rendered markdown.
- * Before the fix, the second-page tail was silently dropped.
+ * Two axes of coverage:
+ *
+ * 1. **Timeline pagination (#10090).** Builds a mocked GitHub issue whose `timelineItems`
+ *    connection has 75 events split across two pages — more than `maxTimelineItemsPerIssue` (50) —
+ *    and drives the refetch path to confirm that every comment body and structural event makes
+ *    it into the rendered markdown. Before the fix, the second-page tail was silently dropped.
+ *
+ * 2. **Timeline-derived `commentsTotal` (#10110).** Asserts that the `commentsTotal` metadata
+ *    field and the frontmatter `commentsCount` are both derived from `timelineItems.nodes`
+ *    filtered for `__typename === 'IssueComment'` — the authoritative post-exhaust count — not
+ *    from the dropped `issue.comments.totalCount` scalar. Guards against regression back to the
+ *    pre-timeline-era dual-source pattern that motivated the deleted sentinel sweep.
  */
 test.describe('Neo.ai.mcp.server.github-workflow.services.sync.IssueSyncer', () => {
     let IssueSyncer;
@@ -57,131 +65,19 @@ test.describe('Neo.ai.mcp.server.github-workflow.services.sync.IssueSyncer', () 
         await fs.remove(tmpIssuesDir).catch(() => {});
     });
 
-    test('detectStaleCommentsCounts lazily seeds entries missing the sentinel', async () => {
-        const metadata = {
-            issues: {
-                100: {state: 'OPEN', commentsTotal: undefined},
-                101: {state: 'OPEN', commentsTotal: undefined}
-            }
-        };
-
-        GraphqlService.query = async (query) => {
-            if (query.includes('FetchIssueTotalsBatch')) {
-                return {
-                    repository: {
-                        issue100: {number: 100, comments: {totalCount: 5}},
-                        issue101: {number: 101, comments: {totalCount: 3}}
-                    },
-                    rateLimit: {cost: 1, remaining: 5000, resetAt: ''}
-                };
-            }
-            throw new Error(`Unexpected GraphQL query: ${query.slice(0, 80)}`);
-        };
-
-        const result = await IssueSyncer.detectStaleCommentsCounts(metadata);
-
-        expect(result.checked).toBe(2);
-        expect(result.seeded).toBe(2);
-        expect(result.stale).toHaveLength(0);
-        expect(result.errors).toHaveLength(0);
-        expect(metadata.issues[100].commentsTotal).toBe(5);
-        expect(metadata.issues[101].commentsTotal).toBe(3);
-    });
-
-    test('detectStaleCommentsCounts reports no drift when live totals match stored sentinels', async () => {
-        const metadata = {
-            issues: {
-                200: {state: 'OPEN', commentsTotal: 4},
-                201: {state: 'OPEN', commentsTotal: 7}
-            }
-        };
-
-        GraphqlService.query = async (query) => {
-            if (query.includes('FetchIssueTotalsBatch')) {
-                return {
-                    repository: {
-                        issue200: {number: 200, comments: {totalCount: 4}},
-                        issue201: {number: 201, comments: {totalCount: 7}}
-                    },
-                    rateLimit: {cost: 1, remaining: 5000, resetAt: ''}
-                };
-            }
-            throw new Error(`Unexpected GraphQL query: ${query.slice(0, 80)}`);
-        };
-
-        const result = await IssueSyncer.detectStaleCommentsCounts(metadata);
-
-        expect(result.checked).toBe(2);
-        expect(result.seeded).toBe(0);
-        expect(result.stale).toHaveLength(0);
-        expect(result.errors).toHaveLength(0);
-    });
-
-    test('detectStaleCommentsCounts reports drift when live totalCount diverges from stored sentinel', async () => {
-        // This is the #9535 scenario: a comment was deleted on GitHub, updatedAt did not bump,
-        // so the local frontmatter still says commentsCount: 11 while live reports 10.
-        const metadata = {
-            issues: {
-                300: {state: 'OPEN', commentsTotal: 11},
-                301: {state: 'OPEN', commentsTotal: 4} // unchanged; should NOT appear in stale
-            }
-        };
-
-        GraphqlService.query = async (query) => {
-            if (query.includes('FetchIssueTotalsBatch')) {
-                return {
-                    repository: {
-                        issue300: {number: 300, comments: {totalCount: 10}}, // deletion detected
-                        issue301: {number: 301, comments: {totalCount: 4}}
-                    },
-                    rateLimit: {cost: 1, remaining: 5000, resetAt: ''}
-                };
-            }
-            throw new Error(`Unexpected GraphQL query: ${query.slice(0, 80)}`);
-        };
-
-        const result = await IssueSyncer.detectStaleCommentsCounts(metadata);
-
-        expect(result.checked).toBe(2);
-        expect(result.seeded).toBe(0);
-        expect(result.stale).toHaveLength(1);
-        expect(result.stale[0]).toEqual({number: 300, stored: 11, live: 10});
-        expect(result.errors).toHaveLength(0);
-        // Stored sentinel is NOT mutated; refetchIssuesByNumber handles the authoritative update.
-        expect(metadata.issues[300].commentsTotal).toBe(11);
-    });
-
     test('refetchIssuesByNumber paginates timeline and renders all events past the page cap', async () => {
         const PAGE_SIZE    = issueSyncConfig.maxTimelineItemsPerIssue; // 50
         const TOTAL_EVENTS = 75;
         const FIRST_PAGE   = Array.from({length: PAGE_SIZE}, (_, i) => buildComment(i));
         const SECOND_PAGE  = Array.from({length: TOTAL_EVENTS - PAGE_SIZE}, (_, i) => buildCrossRef(PAGE_SIZE + i));
 
-        // Minimal GraphQL issue shape that IssueSyncer.#formatIssueMarkdown accepts.
-        const mockIssue = {
-            number   : 42042,
-            title    : 'Mock issue — pagination regression #10090',
-            body     : 'This is the mock issue body.',
-            state    : 'OPEN',
-            createdAt: '2026-04-19T00:00:00Z',
-            updatedAt: '2026-04-19T12:00:00Z',
-            closedAt : null,
-            url      : 'https://github.com/neomjs/neo/issues/42042',
-            author   : {login: 'tobiu'},
-            labels   : {nodes: [{name: 'bug'}]},
-            assignees: {nodes: [{login: 'tobiu'}]},
-            milestone: null,
-            comments : {totalCount: PAGE_SIZE},
-            parent   : null,
-            subIssues        : {nodes: []},
-            subIssuesSummary : {total: 0, completed: 0, percentCompleted: 0},
-            blockedBy        : {nodes: []},
-            blocking         : {nodes: []},
-            timelineItems    : {
-                pageInfo: {hasNextPage: true, endCursor: 'cursor-page-1'},
-                nodes   : FIRST_PAGE
-            }
-        };
+        const mockIssue = buildMockIssue({
+            number       : 42042,
+            title        : 'Mock issue — pagination regression #10090',
+            timelineFirst: FIRST_PAGE,
+            hasNextPage  : true,
+            endCursor    : 'cursor-page-1'
+        });
 
         // Counts how many continuation calls the pagination primitive made.
         let continuationCalls = 0;
@@ -235,9 +131,54 @@ test.describe('Neo.ai.mcp.server.github-workflow.services.sync.IssueSyncer', () 
         const eventLines = written.match(/^- 2026-04-19T[^ ]+ @tobiu cross-referenced by #\d+$/gm) || [];
         expect(eventLines).toHaveLength(TOTAL_EVENTS - PAGE_SIZE);
 
-        // And frontmatter must reflect the metadata channel unchanged.
+        // Frontmatter commentsCount is now derived from timelineItems (#10110) — authoritative
+        // against what the markdown actually renders in its Timeline section.
         expect(written).toContain(`id: ${mockIssue.number}`);
         expect(written).toContain(`commentsCount: ${PAGE_SIZE}`);
+
+        // Metadata sentinel is the same timeline-derived count — single source of truth.
+        expect(metadata.issues[mockIssue.number].commentsTotal).toBe(PAGE_SIZE);
+    });
+
+    test('commentsTotal is derived from timelineItems.nodes filtered for IssueComment (#10110)', async () => {
+        // Sanity-check the derivation primitive in isolation: a mixed timeline with 4 IssueComment
+        // nodes and 3 non-comment nodes must yield commentsTotal: 4 in both metadata and frontmatter —
+        // independent of any `issue.comments.totalCount` scalar (which is no longer fetched).
+        const COMMENT_COUNT = 4;
+        const EVENT_COUNT   = 3;
+        const MIXED_PAGE    = [
+            ...Array.from({length: COMMENT_COUNT}, (_, i) => buildComment(i)),
+            ...Array.from({length: EVENT_COUNT},   (_, i) => buildCrossRef(100 + i))
+        ];
+
+        const mockIssue = buildMockIssue({
+            number       : 42043,
+            title        : 'Mock issue — timeline-derived commentsTotal #10110',
+            timelineFirst: MIXED_PAGE,
+            hasNextPage  : false,
+            endCursor    : null
+        });
+
+        GraphqlService.query = async (query) => {
+            if (query.includes('FetchSingleIssue')) {
+                return {repository: {issue: structuredClone(mockIssue)}};
+            }
+            throw new Error(`Unexpected GraphQL query in test: ${query.slice(0, 80)}`);
+        };
+
+        const metadata = {issues: {}};
+        const stats    = await IssueSyncer.refetchIssuesByNumber([mockIssue.number], metadata);
+
+        expect(stats.refetched.count).toBe(1);
+        expect(stats.errors).toHaveLength(0);
+
+        // Metadata sentinel uses the timeline-derived count.
+        expect(metadata.issues[mockIssue.number].commentsTotal).toBe(COMMENT_COUNT);
+
+        // Frontmatter commentsCount uses the same derivation — no dual-source divergence possible.
+        const writtenPath = path.join(tmpIssuesDir, `issue-${mockIssue.number}.md`);
+        const written     = await fs.readFile(writtenPath, 'utf-8');
+        expect(written).toContain(`commentsCount: ${COMMENT_COUNT}`);
     });
 });
 
@@ -258,5 +199,35 @@ function buildCrossRef(i) {
         createdAt : `2026-04-19T11:${minute}:00Z`,
         actor     : {login: 'tobiu'},
         source    : {__typename: 'Issue', number: 10000 + i}
+    };
+}
+
+/**
+ * Builds the minimal GraphQL issue shape that `IssueSyncer.#formatIssueMarkdown` accepts.
+ * Post-#10110 the `comments` subselect is gone from the query, so the mock omits it too.
+ */
+function buildMockIssue({number, title, timelineFirst, hasNextPage, endCursor}) {
+    return {
+        number,
+        title,
+        body     : 'This is the mock issue body.',
+        state    : 'OPEN',
+        createdAt: '2026-04-19T00:00:00Z',
+        updatedAt: '2026-04-19T12:00:00Z',
+        closedAt : null,
+        url      : `https://github.com/neomjs/neo/issues/${number}`,
+        author   : {login: 'tobiu'},
+        labels   : {nodes: [{name: 'bug'}]},
+        assignees: {nodes: [{login: 'tobiu'}]},
+        milestone: null,
+        parent   : null,
+        subIssues       : {nodes: []},
+        subIssuesSummary: {total: 0, completed: 0, percentCompleted: 0},
+        blockedBy       : {nodes: []},
+        blocking        : {nodes: []},
+        timelineItems   : {
+            pageInfo: {hasNextPage, endCursor},
+            nodes   : timelineFirst
+        }
     };
 }


### PR DESCRIPTION
## Summary

Removes the per-sync `detectStaleCommentsCounts` sentinel sweep introduced by PR #10093 (ticket #10092) and derives the `commentsTotal` metadata field from the already-fetched `timelineItems.nodes` — the authoritative post-#10090 pagination source. The sweep was paying ~15s of serial GraphQL round-trip cost every `runFullSync` to catch a narrow edge case (comment deletion on a subsequently-quiet issue) that is explicitly accepted here.

## Architectural Impact

### What's removed

| Symbol | File | Rationale |
|---|---|---|
| `IssueSyncer.detectStaleCommentsCounts` | `services/sync/IssueSyncer.mjs` | 37 serial GraphQL round trips per sync over 3,669 tracked issues — dominant cost source |
| `buildIssueTotalsBatchQuery` | `services/queries/issueQueries.mjs` | Only consumer was the sweep |
| `comments { totalCount }` sub-selection | `FETCH_ISSUES_FOR_SYNC` + `FETCH_SINGLE_ISSUE` | No remaining consumer once commentsTotal is timeline-derived |
| `$maxComments` variable + `maxCommentsPerIssue` config knob | `issueQueries.mjs` + `config.template.mjs` | Orphaned by the sub-selection removal |
| `staleCommentsBatchSize` config knob | `config.template.mjs` | Sweep-only tuning knob |
| Stale-count stats + log line in `runFullSync` | `services/SyncService.mjs` | No longer produced |
| 3 stale-count test cases | `IssueSyncer.spec.mjs` | Cover removed code |

### What's added

- `IssueSyncer.#countTimelineComments(issue)` — private helper returning the count of `ISSUE_COMMENT` nodes in an exhausted `timelineItems` connection. Full JSDoc with preconditions.
- New spec case: *commentsTotal is derived from timelineItems.nodes filtered for IssueComment (#10110)* — mixed-timeline mock proves both `metadata.commentsTotal` and frontmatter `commentsCount` come from the same derivation, preventing regression to a dual-source pattern.

### What stays

- `refetchIssuesByNumber` — the healing primitive from #10090. On-demand recovery path still available to agents and diagnostic scripts.
- `#exhaustTimelineItems` — intrinsic to the fetch path; pagination unchanged. The regression test from PR #10091 remains and still passes.
- Relationship-event timeline scan from #7948 — also intrinsic to `pullFromGitHub`; untouched.

## Historical Context

The gh-workflow MCP server's first versions fetched comments from the dedicated comments endpoint, before unified timelines were introduced (primarily for the portal app's ticket rendering). Sourcing `commentsTotal` from the separate `issue.comments.totalCount` scalar was a pre-timeline-era leftover — every comment already lives in `timelineItems.nodes` as an `ISSUE_COMMENT` typed node once #10090's pagination-exhaust has run. The #10092 sentinel was secondary infrastructure built on top of that oversight; removing both restores a single source of truth.

## Accepted Blind Spot

A deleted comment on an issue that subsequently receives **zero activity** (no new comments, no label/milestone changes, no reactions) will remain locally rendered until something eventually bumps the issue's `updatedAt`. This is explicitly accepted: the cost of the sentinel sweep (~15s per every sync) is not justified by the narrow case it catches. Agents needing audit-grade accuracy can invoke `refetchIssuesByNumber` on demand.

## Expected Perf Effect

Boot-sync wall-clock should return to the pre-#10093 baseline (~5-10s instead of the ~20-30s that was exceeding Claude Code's MCP stdio handshake budget and causing intermittent UI invisibility of the gh-workflow server).

## Test Plan

- [x] `npx playwright test -c test/playwright/playwright.config.unit.mjs test/playwright/unit/ai/mcp/server/github-workflow/IssueSyncer.spec.mjs` → 2/2 passing (570ms)
- [ ] Post-merge: restart Claude Code and confirm gh-workflow registers within handshake budget on a clean boot with 3,669 tracked issues.

## Related

- **Reverses approach of:** PR #10093 (ticket #10092)
- **Supersedes:** #10094 — InvalidationDetector interface. With `CommentTotalsDetector` removed, only #7948's relationship-event scan remains, and that's intrinsic to `pullFromGitHub`, not a sweep. The detector abstraction has zero sweep instances left to unify. Recommend closing #10094 as superseded on merge.
- **Defuses:** #10096 — GraphQL partial-data discard on aliased batches. Motivated by the now-removed sweep consumer. No remaining known consumer in gh-workflow; the latent correctness concern in `GraphqlService` can be deferred or closed unless a new aliased-batch consumer appears.
- **Leaves intact:** #10090 (pagination stays; intrinsic to fetch path), #7948 (relationship-event scan stays; intrinsic to `pullFromGitHub`).

## Avoided Traps

- Scheduled / periodic sweep — still pays the cost, just on a timer.
- Transport-decoupling of startup sync — consistency with memory-core and knowledge-base (both block transport on sync completion) is a deliberate ecosystem contract.

Resolves #10110

🤖 Generated with [Claude Code](https://claude.com/claude-code)