### PR TITLE
fix(github-workflow): propagate GraphQL errors from LabelService (#10112)

### DIFF
--- a/ai/mcp/server/github-workflow/services/LabelService.mjs
+++ b/ai/mcp/server/github-workflow/services/LabelService.mjs
@@ -1,7 +1,6 @@
 import Base           from '../../../../../src/core/Base.mjs';
 import GraphqlService from './GraphqlService.mjs';
 import aiConfig       from '../config.mjs';
-import logger         from '../logger.mjs';
 import {FETCH_LABELS} from './queries/labelQueries.mjs';
 
 /**
@@ -30,43 +29,44 @@ class LabelService extends Base {
     }
 
     /**
-     * Fetches a list of all labels in the repository.
-     * @returns {Promise<object>} A promise that resolves to the list of labels.
+     * @summary Fetches a list of all labels in the repository via paginated GraphQL queries.
+     *
+     * GraphQL exceptions from `GraphqlService.query` (rate-limit 429, 5xx, network failures,
+     * malformed responses) propagate unmodified to the caller — they are NOT swallowed into
+     * an error-object wrapper. This preserves the original HTTP status, GraphQL error body,
+     * and stack trace for diagnosis. The MCP tool boundary at `Server.mjs:150-222` catches
+     * and converts thrown exceptions into structured MCP error payloads for protocol
+     * responses; non-MCP callers (build scripts, CLI) receive normal exception semantics.
+     *
+     * @returns {Promise<{count: number, labels: object[]}>} Resolves to the aggregated label set.
+     * @throws {Error} If the underlying GraphQL call fails. See `GraphqlService.query` for error shapes.
+     * @see https://github.com/neomjs/neo/issues/10112
      */
     async listLabels() {
         let allLabels   = [];
         let hasNextPage = true;
         let cursor      = null;
 
-        try {
-            while (hasNextPage) {
-                const variables = {
-                    owner : aiConfig.owner,
-                    repo  : aiConfig.repo,
-                    limit : 100,
-                    cursor
-                };
-
-                const data   = await GraphqlService.query(FETCH_LABELS, variables);
-                const labels = data.repository.labels;
-
-                allLabels.push(...labels.nodes);
-                hasNextPage = labels.pageInfo.hasNextPage;
-                cursor      = labels.pageInfo.endCursor;
-            }
-
-            return {
-                count : allLabels.length,
-                labels: allLabels
+        while (hasNextPage) {
+            const variables = {
+                owner: aiConfig.owner,
+                repo : aiConfig.repo,
+                limit: 100,
+                cursor
             };
-        } catch (error) {
-            logger.error('Error fetching labels via GraphQL:', error);
-            return {
-                error  : 'GraphQL API request failed',
-                message: error.message,
-                code   : 'GRAPHQL_API_ERROR'
-            };
+
+            const data   = await GraphqlService.query(FETCH_LABELS, variables);
+            const labels = data.repository.labels;
+
+            allLabels.push(...labels.nodes);
+            hasNextPage = labels.pageInfo.hasNextPage;
+            cursor      = labels.pageInfo.endCursor;
         }
+
+        return {
+            count : allLabels.length,
+            labels: allLabels
+        };
     }
 }
 

--- a/buildScripts/docs/index/labels.mjs
+++ b/buildScripts/docs/index/labels.mjs
@@ -53,11 +53,10 @@ async function createLabelIndex(options = {}) {
     console.log('Fetching labels from GitHub...');
 
     try {
+        // GH_LabelService.listLabels throws on GraphQL failure (rate-limit, 5xx, network) —
+        // the real error propagates through the outer catch below so CI logs surface the
+        // actual HTTP status and message rather than a generic "Invalid response" wrapper (#10112).
         const response = await GH_LabelService.listLabels();
-
-        if (!response || !response.labels) {
-            throw new Error('Invalid response from GH_LabelService');
-        }
 
         const labels = response.labels.map(label => ({
             color      : `#${label.color}`,

--- a/test/playwright/unit/ai/mcp/server/github-workflow/LabelService.spec.mjs
+++ b/test/playwright/unit/ai/mcp/server/github-workflow/LabelService.spec.mjs
@@ -1,0 +1,120 @@
+import {setup} from '../../../../../setup.mjs';
+
+const appName = 'LabelServiceTest';
+
+setup({
+    neoConfig: {
+        unitTestMode: true
+    },
+    appConfig: {
+        name             : appName,
+        isMounted        : () => true,
+        vnodeInitialising: false
+    }
+});
+
+import {test, expect}  from '@playwright/test';
+import Neo             from '../../../../../../../src/Neo.mjs';
+import * as core       from '../../../../../../../src/core/_export.mjs';
+import InstanceManager from '../../../../../../../src/manager/Instance.mjs';
+
+/**
+ * @summary Contract coverage for `LabelService.listLabels` error propagation (#10112).
+ *
+ * Prior to #10112, `listLabels` caught GraphQL failures internally and returned an
+ * `{error, message, code}` wrapper object alongside the happy-path `{count, labels}` —
+ * a union-typed return that hid the real HTTP status + GraphQL error body from callers
+ * (build scripts, CLI, the data-sync-pipeline CI workflow). Non-MCP callers lost diagnostics;
+ * the MCP tool boundary at `Server.mjs:150-222` already catches thrown exceptions, so the
+ * in-service wrap was redundant for its original protocol purpose.
+ *
+ * These tests lock the new throwing contract in place:
+ * 1. Happy path returns `{count, labels}` with aggregated pagination.
+ * 2. Underlying GraphQL errors propagate unmodified — no wrapper, no swallow.
+ */
+test.describe('Neo.ai.mcp.server.github-workflow.services.LabelService', () => {
+    let LabelService;
+    let GraphqlService;
+    let originalQuery;
+
+    test.beforeAll(async () => {
+        GraphqlService = (await import('../../../../../../../ai/mcp/server/github-workflow/services/GraphqlService.mjs')).default;
+        LabelService   = (await import('../../../../../../../ai/mcp/server/github-workflow/services/LabelService.mjs')).default;
+
+        originalQuery = GraphqlService.query.bind(GraphqlService);
+    });
+
+    test.afterAll(() => {
+        GraphqlService.query = originalQuery;
+    });
+
+    test('listLabels returns {count, labels} on success and aggregates across pages', async () => {
+        const PAGE_ONE = [
+            {name: 'bug',         color: 'd73a4a', description: "Something isn't working"},
+            {name: 'enhancement', color: 'a2eeef', description: 'New feature or request'}
+        ];
+        const PAGE_TWO = [
+            {name: 'ai',   color: '0e5ca2', description: null},
+            {name: 'core', color: '000000', description: 'Core framework functionality'}
+        ];
+
+        let callCount = 0;
+
+        GraphqlService.query = async (query, variables) => {
+            callCount++;
+            if (callCount === 1) {
+                return {
+                    repository: {
+                        labels: {
+                            nodes   : PAGE_ONE,
+                            pageInfo: {hasNextPage: true, endCursor: 'cursor-page-1'}
+                        }
+                    }
+                };
+            }
+            if (callCount === 2) {
+                return {
+                    repository: {
+                        labels: {
+                            nodes   : PAGE_TWO,
+                            pageInfo: {hasNextPage: false, endCursor: null}
+                        }
+                    }
+                };
+            }
+            throw new Error('Unexpected extra GraphQL call in happy-path test');
+        };
+
+        const result = await LabelService.listLabels();
+
+        expect(result.count).toBe(4);
+        expect(result.labels).toHaveLength(4);
+        expect(result.labels.map(l => l.name)).toEqual(['bug', 'enhancement', 'ai', 'core']);
+        expect(callCount).toBe(2);
+    });
+
+    test('listLabels propagates GraphQL exceptions unmodified (no wrapper object) — #10112', async () => {
+        const underlyingError = new Error('GitHub API request failed: 429 Too Many Requests');
+
+        GraphqlService.query = async () => {
+            throw underlyingError;
+        };
+
+        // Assert the exception propagates verbatim — not caught and returned as
+        // {error, message, code}, which was the pre-#10112 anti-pattern that hid
+        // the real HTTP status from CI logs.
+        await expect(LabelService.listLabels()).rejects.toBe(underlyingError);
+    });
+
+    test('listLabels does not mask non-Error throwables (malformed GraphQL responses)', async () => {
+        // Even for non-Error throwables (e.g., a String thrown directly, or a GraphQL
+        // errors-array dumped verbatim), the contract is propagation without wrapping.
+        const thrownValue = 'Synthetic non-Error payload';
+
+        GraphqlService.query = async () => {
+            throw thrownValue;
+        };
+
+        await expect(LabelService.listLabels()).rejects.toBe(thrownValue);
+    });
+});


### PR DESCRIPTION
## Summary

Removes the swallow-and-wrap pattern from `LabelService.listLabels()` so GraphQL exceptions propagate with their original status + message instead of being reduced to a generic `{error, message, code}` object that hides diagnostics. Restores observability on the `data-sync-pipeline` CI workflow — the next intermittent failure will print the actual underlying error (rate-limit 429, 5xx, network) in the CI log instead of the useless `"Invalid response from GH_LabelService"` wrapper.

## Architectural Impact

### Before
```javascript
async listLabels() {
    try {
        // ... paginated query ...
        return { count, labels };
    } catch (error) {
        logger.error('Error fetching labels via GraphQL:', error);
        return { error: 'GraphQL API request failed', message: error.message, code: 'GRAPHQL_API_ERROR' };
    }
}
```
- Union-typed return: `{count, labels}` OR `{error, message, code}`
- Callers forced to shape-check; `labels.mjs:58` did `!response || !response.labels` → threw its own `'Invalid response from GH_LabelService'`, burying the real error twice
- `logger.error` writes to stderr but the original Error object's status code / stack is already swallowed by string interpolation in `error.message`

### After
```javascript
async listLabels() {
    // ... paginated query ...
    return { count, labels };
    // No catch — GraphqlService exceptions propagate unmodified
}
```
- Single return shape; exceptions are exceptions
- `labels.mjs` no longer shape-checks; its existing outer `try/catch` logs the real error
- MCP tool boundary at `Server.mjs:150-222` already catches thrown exceptions and converts to structured MCP error payloads — the in-service wrap was redundant with protocol-level handling

## Why Not a Broader Refactor?

Same swallow-and-wrap exists at **11 call sites across 4 services** (`IssueService` × 6, `DiscussionService` × 2, `PullRequestService` × 2, `LabelService` × 1). Deliberately scoped narrow to `LabelService` because:

- It is the only service exposed through a CI-visible build script (`labels.mjs`) — its failures are user-visible
- The other 10 sites route through the MCP tool boundary which already produces usable structured errors for protocol responses
- A cross-service cleanup would be its own architectural ticket; bundling here would scope-creep and risk semantic drift

Leaving breadcrumbs for a future cleanup if pressure arises, but no commitment.

## Diagnostic Payoff

The prevailing hypothesis for why the pipeline fails intermittently: the `DevIndex Spider` 3x-loop consumes GraphQL rate-limit budget → subsequent GraphQL calls in the same workflow (labels, release, tickets index generation) hit 429. This PR cannot prove that by itself — but once it lands, the next CI failure will print the actual HTTP status + GraphQL error body, and the hypothesis can be empirically confirmed or refuted. Companion ticket #10113 addresses the suspected root cause (spider loop reduction).

## Test Coverage

New file: `test/playwright/unit/ai/mcp/server/github-workflow/LabelService.spec.mjs` with 3 cases:

1. **Happy path + pagination:** multi-page query returns aggregated `{count, labels}` with correct ordering
2. **Error propagation (#10112 core):** when `GraphqlService.query` throws, the exact thrown value propagates unmodified — no catch, no wrap, no synthetic replacement
3. **Non-Error throwables:** string / non-Error payloads also propagate unchanged (guards against regressing to catch-all wrapping)

All 3 pass; the existing 2 `IssueSyncer` cases from #10110 still pass — full gh-workflow spec suite 5/5 green (570ms).

## Test Plan

- [x] `npx playwright test -c test/playwright/playwright.config.unit.mjs test/playwright/unit/ai/mcp/server/github-workflow/` → 5/5 passing
- [ ] Post-merge: next `data-sync-pipeline` CI run exposes the actual underlying error when/if it fails

## Related

- **Companion:** #10113 — Reduce DevIndex Spider CI loop from 3x→1x (addresses suspected rate-limit root cause)
- **Future candidate:** cross-service error-propagation cleanup (10 remaining swallow sites in `IssueService`, `DiscussionService`, `PullRequestService`) — not scoped here; harmless via MCP tool boundary which already catches
- **Context:** builds on #10110 (merged in this session) — same session's earlier PR also refined the gh-workflow sync layer

## Avoided Traps

- Retry logic inside `LabelService` — wrong layer; retry belongs in `GraphqlService` as a cross-cutting primitive
- Wrapping MCP tool boundary to "normalize" shapes — unnecessary, that boundary already produces structured MCP error payloads from thrown exceptions
- Scope expansion to the 10 sibling swallow sites — tempting but violates the "one ticket → one discrete problem" rule

Resolves #10112

🤖 Generated with [Claude Code](https://claude.com/claude-code)