### PR TITLE
feat(ai): add ticket-create skill (#10104)

### DIFF
--- a/.agent/skills/ticket-create/SKILL.md
+++ b/.agent/skills/ticket-create/SKILL.md
@@ -1,0 +1,11 @@
+---
+name: ticket-create
+description: Authoritative protocol for creating Neo.mjs GitHub issues. Enforces duplicate sweep, Fat Ticket body structure, strict label rules, title hygiene, visible-proposal protocol, and the five-stage challenge chain at creation time. Use immediately before calling the create_issue MCP tool.
+triggers: Use this skill before any invocation of the create_issue MCP tool. This is the creation-side dual of ticket-intake (which consumes existing tickets).
+---
+
+# Ticket Create Skill
+
+If you are about to create a new GitHub issue, you MUST NOT compose the title, body, or labels ad-hoc — and you MUST NOT skip the pre-creation duplicate sweep.
+
+You MUST immediately use the `view_file` tool to read and strictly adhere to `/Users/Shared/github/neomjs/neo/.agent/skills/ticket-create/references/ticket-create-workflow.md` before proceeding. Or, if you already have the payload in context, proceed directly to its directives.

--- a/.agent/skills/ticket-create/assets/ticket-proposal-template.md
+++ b/.agent/skills/ticket-create/assets/ticket-proposal-template.md
@@ -1,0 +1,61 @@
+# Ticket Proposal Template
+
+Dump this filled-out format into the chat **before** calling `create_issue`. The human must see the full ticket content as a text proposal; then you call the tool immediately after.
+
+---
+
+```
+Title: [Subject, no category prefix. Under ~70 chars.]
+
+Labels: [ai, <primary-label>, <secondary-label>, ...]
+
+Body:
+
+## Context
+
+[Why this ticket exists now. What prompted it. Observational evidence.]
+
+## The Problem
+
+[Deep background context. Insights from recent Memory Core explorations. Reproducer if applicable. Historical "why."]
+
+## The Architectural Reality
+
+[Which Neo.mjs patterns, class topologies, or service boundaries this interacts with. File:line references. Structural specificity.]
+
+## The Fix
+
+[Concrete prescription: files, symbols, architectural primitives touched. What changes, and where.]
+
+## Acceptance Criteria
+
+- [ ] [Independently verifiable item]
+- [ ] [Post-merge-only items flagged as such]
+
+## Out of Scope
+
+[What this ticket deliberately does NOT do. Prevents scope creep.]
+
+## Avoided Traps
+
+[Optional: alternatives considered and rejected, with rationale. Especially when rejecting a "generic best practice" that's wrong in Neo.mjs's multi-threaded context.]
+
+## Related
+
+- Reverses: #N — [title]
+- Companion: #N — [title]
+- Supersedes: #N — [title] (close on merge)
+- Leaves intact: #N — [title]
+
+## Origin Session ID
+
+<current-memory-core-session-uuid>
+```
+
+---
+
+**After dumping the above into the chat, immediately call `create_issue`. Do not ask for permission.**
+
+**Primary labels are mutually exclusive:** pick exactly one of `epic`, `enhancement`, `bug`.
+**`ai` is mandatory** on every agent-authored ticket.
+**Secondary labels** are drawn from: `architecture`, `performance`, `regression`, `refactoring`, `documentation`, `testing`, plus domain labels (`core`, `grid`, `build`, etc.).

--- a/.agent/skills/ticket-create/references/ticket-create-workflow.md
+++ b/.agent/skills/ticket-create/references/ticket-create-workflow.md
@@ -1,0 +1,114 @@
+# Ticket Create Workflow
+
+The authoritative protocol for creating Neo.mjs GitHub issues. Enforced before any `create_issue` MCP tool invocation. This is the creation-side dual of `ticket-intake` (which consumes existing tickets).
+
+Tickets are **A2A (Agent-to-Agent) memory bridges**, not just human tracking artifacts. A poorly-formed ticket loses architectural context the Swarm will re-derive every session. Every rule below exists because an earlier session re-derived the discipline and got it wrong.
+
+## 1. Pre-Creation Duplicate Sweep (Gate 0)
+
+**Before drafting any title or body**, verify no equivalent ticket already exists. Redundant tickets pollute the Knowledge Base and disrupt swarm synchronicity.
+
+```
+grep on resources/content/issues/       # open tickets
+grep on resources/content/issue-archive/ # closed + archived
+grep on resources/content/discussions/   # ideation / brainstorming
+```
+
+Primary: `ask_knowledge_base(query='...', type='ticket')` — semantic search surfaces conceptual duplicates that grep misses.
+Fallback: `grep` / `query_documents` for exact keyword verification.
+
+If an equivalent ticket exists: do NOT file a duplicate. Either comment on the existing ticket, extend its scope, or reject the new request.
+
+## 2. Five-Stage Challenge Chain
+
+Apply at creation time — not just at intake. Every stage must pass before the ticket is drafted.
+
+1. **Premise** — is the stated problem real and reproducible? Has the underlying symptom been independently verified, or is it secondhand?
+2. **Prescription** — is the stated fix the right substrate for the problem, or does it treat a symptom? Could a different layer (config, service, daemon, schema) solve it better?
+3. **Substrate** — where does this work belong? Service layer? Build script? CI workflow? Framework core? Documentation? Match the fix to the substrate that owns the concern.
+4. **Consumer** — who reads the output of this change? Human developer, agent, Memory Core, Native Edge Graph, Knowledge Base? Different consumers need different shapes (markdown prose vs structured metadata vs MCP payload).
+5. **Service-Boundary** — does the fix cross a service boundary it shouldn't? Config added to the wrong owning service creates future migration debt.
+
+A ticket that fails any stage should be reshaped OR rejected, not filed.
+
+## 3. Title Hygiene
+
+**Titles describe the subject, not the category.** Category lives in labels.
+
+- ❌ `[enhancement] Add config for X`
+- ❌ `[bug] Y fails when Z`
+- ❌ `[epic] Modernize W`
+- ✅ `Add config for X`
+- ✅ `Y fails when Z`
+- ✅ `Modernize W`
+
+The `[enhancement]` / `[bug]` / `[epic]` prefix duplicates the label taxonomy — it also eats title budget. Use the budget for subject specificity instead.
+
+Keep titles under ~70 characters. PR titles derive from ticket titles; length discipline compounds.
+
+## 4. Label Rules
+
+- **`ai` — MANDATORY on every ticket created by an agent.** Signals provenance for downstream graph/memory systems.
+- **Primary — exactly one:** `epic`, `enhancement`, or `bug`.
+- **Secondary — as applicable:** `architecture`, `performance`, `regression`, `refactoring`, `documentation`, `testing`, plus domain labels (`core`, `grid`, `build`, etc.).
+- Before filing: call `list_labels` to confirm the labels exist. Do not invent label names.
+
+## 5. Fat Ticket Body Structure
+
+Skeleton tickets are forbidden. Every ticket body MUST contain:
+
+- **Context** — why this ticket exists now. What prompted it. What observational evidence supports the premise.
+- **The Problem** — deep background, insights from recent Memory Core explorations, reproducer if applicable. Historical "why" for the agent picking up the ticket later.
+- **The Architectural Reality** — exactly which Neo.mjs patterns, class topologies, or service boundaries this issue interacts with. Cite file:line when known. Distinguishes intent-level framing (Problem) from structural specificity (Reality).
+- **The Fix** — concrete prescription: files, symbols, architectural primitives touched. What changes, and where.
+- **Acceptance Criteria** — bulleted checklist. Each item independently verifiable. Post-merge-only items explicitly flagged.
+- **Out of Scope** — what this ticket deliberately does NOT do. Prevents scope creep during implementation.
+- **Avoided Traps** / **Gold Standards Rejected** *(when applicable)* — alternatives considered and rejected, with rationale. Especially critical when rejecting a generic industry/LLM "best practice" (e.g. standard React patterns, generic node workflows) that is a trap in Neo.mjs's multi-threaded architecture.
+- **Related** — sibling tickets, superseded tickets, dependencies, PRs.
+- **Origin Session ID** — Memory Core session ID that produced the ticket. Required for A2A Contextual Bridge Protocol (`AGENTS.md §14`). Format: `Origin Session ID: <uuid>` on its own line near the end of the body.
+
+## 6. Visible Proposal Protocol (MANDATORY)
+
+You MUST show the proposed ticket content **in the chat**, to the human, before calling `create_issue`. This is not optional. Pattern (see `assets/ticket-proposal-template.md` for the full template):
+
+```
+Title: [Proposed title — no [enhancement]/[bug]/[epic] prefix]
+Labels: [ai, primary-label, secondary-labels...]
+Body:
+[Full Fat Ticket body]
+```
+
+After displaying, **immediately call `create_issue`**. Do not ask for permission first — the user can decline the tool invocation. Asking wastes a turn.
+
+## 7. Linkage
+
+- **Epic ↔ sub-issue:** use the `update_issue_relationship` MCP tool to natively link sub-issues to their parent. Do NOT rely on inline Markdown checkboxes (`- [ ] #N`) as the tracking mechanism. Native links feed the Native Edge Graph; Markdown does not.
+- **Blocking / blocked-by:** same tool. Sets `blockedBy` / `blocking` fields on the ticket frontmatter after sync.
+- **Origin Session ID:** embeds the current session as textual provenance. Complements native linkage by preserving the reasoning trail across swarm instances.
+
+## 8. Pre-Execution Gates (from `CLAUDE.md §3`)
+
+Before any `git commit` associated with the new ticket:
+
+- **Gate 1 (Ticket):** ticket ID must exist, appended to commit subject as `(#ID)`.
+- **Gate 2 (Contextual Completeness):** Anchor & Echo JSDoc on all new or modified classes, methods, properties.
+- **Gate 3 (Commit Format):** Conventional Commits `type(scope): message (#ID)`. No `<noreply@*>` Co-Authored-By footers.
+
+These belong to the commit step, not the creation step — but the ticket's body must be rich enough that a future commit can satisfy Gate 2 without needing a separate documentation pass.
+
+## 9. Anti-Patterns (Non-Exhaustive)
+
+| Anti-pattern | Why it harms |
+|---|---|
+| `[enhancement]` / `[bug]` / `[epic]` prefix in title | Duplicates label taxonomy; wastes title budget |
+| Skeleton body (1-2 sentences) | Breaks A2A — next agent has no context to act on |
+| Missing Origin Session ID | Breaks A2A Contextual Bridge; no provenance trail |
+| Skipping duplicate sweep | Pollutes Knowledge Base; splits swarm attention |
+| Inventing label names | Breaks label taxonomy; causes silent GitHub API rejections |
+| Precedent-following without skill check | Propagates anti-patterns from prior sessions (e.g., `[enhancement]` prefix spread this way) |
+| Cross-scope bundling | `epic` label on a single-commit ticket; hurts granularity |
+| Bypassing visible proposal | User cannot redirect before remote state changes |
+
+## 10. When to Escalate to Discussion Instead
+
+If the "ticket" is really an architectural question, brainstorming, or pre-PR exploration, file a **Discussion**, not an Issue. The `ideation-sandbox` skill covers this path. Issues are for actionable work with a defined success criterion; Discussions are for shaping the question.

--- a/.agent/skills/ticket-create/references/ticket-create-workflow.md
+++ b/.agent/skills/ticket-create/references/ticket-create-workflow.md
@@ -112,3 +112,14 @@ These belong to the commit step, not the creation step — but the ticket's body
 ## 10. When to Escalate to Discussion Instead
 
 If the "ticket" is really an architectural question, brainstorming, or pre-PR exploration, file a **Discussion**, not an Issue. The `ideation-sandbox` skill covers this path. Issues are for actionable work with a defined success criterion; Discussions are for shaping the question.
+
+## 11. After Creation (Chained MCP Tool Usage)
+
+The `create_issue` tool returns the new issue number. Typical immediate follow-ups:
+
+- **`manage_issue_assignees(action: 'add', issue_number: N, assignees: ['@me'])`** — claim ownership when you intend to pick up the ticket immediately (per `ticket-intake` §3a Acceptance Protocol). Skip if the ticket is for someone else or deferred.
+- **`manage_issue_labels(action: 'add', ...)`** — only if the label set needs adjustment post-creation (e.g., label list was incomplete at `create_issue` time). Prefer getting labels right in the initial call.
+- **`update_issue_relationship(parent_id: N, child_id: M, type: 'SUB_ISSUE')`** — required when filing sub-issues under an Epic. Native graph linkage only; do NOT rely on inline `- [ ] #N` markdown checkboxes (see §7).
+- **Ticket body edits:** `gh issue edit N --body "..."` via shell, since `create_issue` does not have an update mode. The local `.md` file is canonical after `sync_all`; edits can happen either remotely via `gh` or locally with `sync_all` pushing the local version back.
+
+Minimize chained calls where possible — a well-formed `create_issue` call with complete `title`, `body`, `labels`, and `assignees` at creation time avoids all of the above except `update_issue_relationship` (which can only run after the issue exists).

--- a/AGENTS_STARTUP.md
+++ b/AGENTS_STARTUP.md
@@ -296,24 +296,14 @@ Without this context, sub-agents will hallucinate bugs where none exist (e.g., c
     -   *Template:* "I cannot see the parent container's computed styles. Could you please paste the computed `height` and `overflow` of the element wrapping `.my-component`?"
 4.  **Verify Assumptions:** Never assume a class like `neo-label` behaves standardly. Verify its computed style.
 
-## 9. Swarm Architecture: The "Fat Ticket" Protocol
+## 9. Swarm Architecture: Ticket & PR Workflow
 
-**Context:** The Neo.mjs project runs as a distributed agentic swarm. Multiple hardware instances (e.g., Mac 1, Mac 2) operate simultaneously, but their underlying SQLite `/neo-ai-data` repositories are entirely local to avoid cross-network database collisions.
+**Swarm context:** Neo.mjs runs as a distributed agentic swarm. Multiple hardware instances operate simultaneously, but their local SQLite stores are isolated — there is no cross-network database merge. GitHub Issues are the A2A (Agent-to-Agent) memory bridge that closes the gap. Fat Tickets preserve architectural context; skeleton tickets break the chain.
 
-**The Boot Amnesia Problem:** This means that when a secondary agent drops into the network or pulls a new git sync, it has *zero* chronological memory vectors of what the primary agent discussed, discovered, or decided in the preceding sessions.
+**Workflow skills (authoritative — read before invoking their respective tools):**
+- **Creating new tickets:** `.agent/skills/ticket-create/SKILL.md` — duplicate sweep, Fat Ticket body structure, title hygiene, label rules, visible-proposal protocol, five-stage challenge chain. Read before any `create_issue` invocation.
+- **Picking up existing tickets:** `.agent/skills/ticket-intake/SKILL.md` — validation sweep, ROI calculation, branch-before-code gate. Read before any `git checkout` on an assigned ticket.
+- **Opening pull requests:** `.agent/skills/pull-request/SKILL.md` — stepping-back reflection, conventional-commit format, ticket-ID suffix, handoff protocol. All code changes MUST culminate in a PR against `dev`; direct commits to `main`/`dev` are forbidden.
+- **Reviewing pull requests:** `.agent/skills/pr-review/SKILL.md` — structured evaluation metrics, graph ingestion tags, severity ladder. Human approval for squash-merge is required; agents MUST NOT autonomously merge their own PRs.
 
-**The Solution:** You MUST bridge the SQLite gap by converting GitHub Issues into your primary episodic memory carriers.
-
-**Mandatory Workflow:**
-1.  **Gate 0 (Deduplication):** Before creating *any* ticket, you MUST run a `grep_search` against the `resources/content/issues` and `resources/content/discussions` directory. Redundant, duplicate tickets pollute the Knowledge Base and disrupt swarm synchronicity.
-2.  **Epic Granularity Constraints:** Do NOT create an Epic unless it functions strictly as an overarching parent node for granular, multi-commit sub-issues. If the task is a single commit (no matter how big), it is a standard Request, NOT an Epic.
-3.  **Strict Graph Connectivity:** When generating sub-issues for an Epic, you MUST use the `update_issue_relationship` tool to natively link the sub-issues to their parent block.
-4.  **Do Not Create Skeleton Tickets:** You are strictly forbidden from creating GitHub issues with one-sentence descriptions. A ticket is not just for human tracking; it is the **A2A (Agent-to-Agent)** data transport mechanism.
-5.  **Generate "Fat Tickets":** When you call `create_issue`, the `body` parameter MUST contain a highly detailed summary that functions as a structural graph node proxy.
-6.  **Required A2A Context:** The Fat Ticket MUST contain:
-    -   **The Problem:** Include deep background context or insights from your recent Memory Core explorations.
-    -   **The Architectural Reality:** Point out exactly *which* Neo.mjs patterns or class topologies this issue interacts with. Include specific paths to files discovered during your research.
-    -   **Avoided "Gold Standards" / Traps:** Explain *why* you decided not to use alternative paths. Specifically highlight if you avoided a generic industry or LLM "Gold Standard" (e.g., standard React patterns, generic node workflows) because it acts as a trap within Neo.mjs's unique multi-threaded architecture.
-7.  **Handoff Realization:** On boot (`initAsync`), nodes like Mac 2 automatically synthesize the latest synced `.md` issues into their local SQLite matrix and build `sandman_handoff.md`. If your tickets are "Fat," the resulting "Golden Path" ranking will accurately bridge the distributed swarm without ever merging the raw SQLite files.
-8.  **Pull Request Collaboration:** Once you begin actionable work, you are acting as an asynchronous contributor. All code changes MUST culminate in a Pull Request against the `dev` branch. The PR body MUST contain a "Fat Ticket" style summary and the `Resolves #[Issue Number]` keyword. Direct commits to `main` or `dev` are forbidden.
-9.  **The Reflection Phase & Hard Stop:** Upon creating the PR, you MUST NOT autonomously merge the PR. A Human Approver will eventually Squash Merge the code to preserve the Fat Ticket natively. Before concluding your turn, ask the human Commander if you should execute the `pr-review` skill to self-evaluate the architectural alignment.
+**Handoff realization:** on boot, swarm nodes synthesize synced `.md` issues into their local SQLite matrix and build `sandman_handoff.md`. Fat Tickets make the resulting "Golden Path" ranking bridge the distributed swarm without merging raw SQLite.

--- a/ai/mcp/server/github-workflow/openapi.yaml
+++ b/ai/mcp/server/github-workflow/openapi.yaml
@@ -610,11 +610,7 @@ paths:
       x-annotations:
         readOnlyHint: false
       description: |
-        Creates a new GitHub issue.
-
-        **MANDATORY:** invoke the `ticket-create` skill (`.agent/skills/ticket-create/SKILL.md`) BEFORE calling this tool. The skill enforces the duplicate sweep, Fat Ticket body structure, title hygiene, strict label rules, and visible-proposal protocol. Calling `create_issue` without reading the skill first produces anti-pattern tickets that pollute the A2A memory bridge.
-
-        After creation, the returned issue number can be passed to `manage_issue_assignees`, `manage_issue_labels`, `update_issue_relationship`, etc.
+        Creates a new GitHub issue. **MANDATORY** pre-step: read `.agent/skills/ticket-create/SKILL.md` — the skill contains the full creation protocol (duplicate sweep, Fat Ticket body, label rules, visible proposal, post-creation chaining).
       tags: [Issues]
       requestBody:
         required: true

--- a/ai/mcp/server/github-workflow/openapi.yaml
+++ b/ai/mcp/server/github-workflow/openapi.yaml
@@ -610,32 +610,11 @@ paths:
       x-annotations:
         readOnlyHint: false
       description: |
-        Creates a new issue on GitHub. This is the authoritative first step for creating a new ticket.
+        Creates a new GitHub issue.
 
-        ## CRITICAL PROTOCOL: READ BEFORE USING
-        You generally FAIL to show the proposal to the user before calling this tool. Do not let that happen.
+        **MANDATORY:** invoke the `ticket-create` skill (`.agent/skills/ticket-create/SKILL.md`) BEFORE calling this tool. The skill enforces the duplicate sweep, Fat Ticket body structure, title hygiene, strict label rules, and visible-proposal protocol. Calling `create_issue` without reading the skill first produces anti-pattern tickets that pollute the A2A memory bridge.
 
-        **MANDATORY WORKFLOW (Do Not Skip):**
-
-        1.  **Check Labels:** Run `list_labels` to verify available labels.
-        2.  **Draft Content:** Formulate the `title`, `body`, and `labels`.
-        3.  **VISUAL PROPOSAL (REQUIRED):** You **MUST** display the proposed ticket content to the user **IN THE CHAT** before calling this tool. Use this format:
-            ```text
-            Title: [Proposed Title]
-            Labels: [label1, label2]
-            Body:
-            [Proposed Body]
-            ```
-        4.  **Call Tool:** Immediately call `create_issue` after displaying the proposal. Do not ask for permission first (the user can decline the tool call).
-
-        **STRICT LABELING RULES:**
-        - **MANDATORY:** The `ai` label is REQUIRED on ALL tickets you create.
-        - **PRIMARY:** Include one primary label: `epic`, `enhancement`, or `bug`.
-        - **SECONDARY:** Add other relevant labels (e.g., `documentation`) if they exist.
-
-        **Post-Creation:**
-        The tool returns the new issue number. You can use this number immediately for other tools (e.g., `create_comment`, `manage_issue_assignees`).
-        To update the issue body later, use `run_shell_command` with `gh issue edit {number} --body "..."`.
+        After creation, the returned issue number can be passed to `manage_issue_assignees`, `manage_issue_labels`, `update_issue_relationship`, etc.
       tags: [Issues]
       requestBody:
         required: true

--- a/learn/agentos/ProgressiveDisclosureSkills.md
+++ b/learn/agentos/ProgressiveDisclosureSkills.md
@@ -86,6 +86,13 @@ Invoked when evaluating a PR (either peer-reviewing another agent or guiding a h
 - **Graph Ingestion Tags:** Standardizes feedback using markers like `[KB_GAP]` or `[RETROSPECTIVE]` so the Dream Pipeline can extract lessons learned into the Native Edge Graph.
 - **LGTM/Required Actions:** Ensures every review resolves in a clear state.
 
+### 4. `ticket-create` (The Creation Gate)
+Invoked before filing any new GitHub Issue via the `create_issue` MCP tool. Creation-side dual of `ticket-intake` — they address opposite triggers (produce new vs. consume existing).
+- **Duplicate Sweep:** Mandates a pre-creation scan of `resources/content/issues/`, `issue-archive/`, and `discussions/` to prevent Knowledge Base pollution.
+- **Fat Ticket Body Structure:** Enforces Context / Problem / Architectural Reality / Fix / AC / Out of Scope / Related / Origin Session ID as the A2A memory shape.
+- **Title Hygiene & Label Rules:** Rejects `[enhancement]` / `[bug]` / `[epic]` title prefixes (category lives in labels); mandates `ai` label on every agent-authored ticket.
+- **Visible Proposal Protocol:** Forces the agent to dump the proposed ticket into chat before the `create_issue` tool fires, so a human can redirect before remote state changes.
+
 ## Tactical & Creative Skills
 
 Beyond lifecycle governance, specialized contexts exist for live action:
@@ -108,7 +115,8 @@ ensuring the YAML frontmatter and folder consistency are perfectly formed.
 
 | Skill | Type | Purpose |
 |---|---|---|
-| `ticket-intake` | Lifecycle | Pre-execution validation gate |
+| `ticket-intake` | Lifecycle | Pre-execution validation gate for existing tickets |
+| `ticket-create` | Lifecycle | Pre-creation discipline gate (duplicate sweep, Fat Ticket body, title/label rules, visible-proposal protocol) |
 | `pull-request` | Lifecycle | Post-implementation reflection + PR creation |
 | `pr-review` | Lifecycle | Structured quality evaluation & graph ingestion |
 | `tech-debt-radar` | Lifecycle | Proactive semantic RAG sweeps for architectural debt |

--- a/learn/guides/fundamentals/CodebaseOverview.md
+++ b/learn/guides/fundamentals/CodebaseOverview.md
@@ -443,6 +443,7 @@ Offline cognitive maintenance runs as **Node.js scripts**, not MCP protocol oper
 
 Formalized Anthropic Progressive Disclosure Skills natively used by the swarm:
 - `create-skill`: Architectural blueprinting for new operational abilities.
+- `ticket-create`: Pre-creation discipline gate for new GitHub issues (duplicate sweep, Fat Ticket body, title/label rules, visible-proposal protocol).
 - `self-repair`: Diagnostic workflows utilizing tests and historical Memory Core states to intelligently triage infrastructure degradation.
 - `ideation-sandbox`: Safe brainstorming pipelines mapped directly into GitHub Discussions.
 - `pr-review`: Evaluation matrix templates spanning `[ARCH_ALIGNMENT]` to `[EFFORT_PROFILE]`.

--- a/learn/guides/fundamentals/CodebaseOverview.md
+++ b/learn/guides/fundamentals/CodebaseOverview.md
@@ -439,17 +439,30 @@ Offline cognitive maintenance runs as **Node.js scripts**, not MCP protocol oper
 
 ---
 
-### Swarm Skills & Workflows (`/.agent/skills/` - 12 files, ~300 lines)
+### Swarm Skills & Workflows (`/.agent/skills/` - 13 skills)
 
-Formalized Anthropic Progressive Disclosure Skills natively used by the swarm:
-- `create-skill`: Architectural blueprinting for new operational abilities.
+Formalized Anthropic Progressive Disclosure Skills natively used by the swarm. Listed in execution-lifecycle order, then tactical, creative, and meta. See [`learn/agentos/ProgressiveDisclosureSkills.md`](../../agentos/ProgressiveDisclosureSkills.md) for the full protocol reference and lifecycle flow diagram.
+
+**Lifecycle (execution gates):**
+- `ticket-intake`: Pre-execution validation gate for existing tickets (validation sweep, ROI calculation, branch-before-code).
 - `ticket-create`: Pre-creation discipline gate for new GitHub issues (duplicate sweep, Fat Ticket body, title/label rules, visible-proposal protocol).
-- `self-repair`: Diagnostic workflows utilizing tests and historical Memory Core states to intelligently triage infrastructure degradation.
-- `ideation-sandbox`: Safe brainstorming pipelines mapped directly into GitHub Discussions.
-- `pr-review`: Evaluation matrix templates spanning `[ARCH_ALIGNMENT]` to `[EFFORT_PROFILE]`.
-- `tech-debt-radar`: Proactive architectural sweep using semantic RAG to map and target technical debt.
+- `pull-request`: Post-implementation reflection + PR creation (stepping-back protocol, conventional-commit format, handoff sequence).
+- `pr-review`: Evaluation matrix templates spanning `[ARCH_ALIGNMENT]` to `[EFFORT_PROFILE]` + graph ingestion tags for the Dream Pipeline.
+- `tech-debt-radar`: Proactive architectural sweep using semantic RAG to map and target technical debt. Invoked during `ticket-intake` and `pr-review`.
+
+**Tactical (live operations):**
 - `neural-link`: Standard operating procedures for traversing the Object-Permanent VDOM structure.
-- `unit-test`: Synthetically driving Playwright natively.
+- `unit-test`: Synthetically driving Playwright natively within the single-thread architecture.
+- `whitebox-e2e`: Neural Link pre-flight workflow for authoring robust end-to-end tests.
+- `self-repair`: Diagnostic workflows utilizing tests and historical Memory Core states to intelligently triage infrastructure degradation.
+- `memory-mining`: Querying Memory Core before diagnosing regressions or proposing architectural claims — prevents re-derivation of prior reasoning across sessions and harnesses.
+- `debugging-antigravity`: Debugging Antigravity IDE MCP servers, language-server duplication, and `mcpServers` configuration.
+
+**Creative:**
+- `ideation-sandbox`: Safe brainstorming pipelines mapped directly into GitHub Discussions (diverts early-stage proposals away from the active Issue queue).
+
+**Meta:**
+- `create-skill`: Architectural blueprinting for new operational abilities.
 
 ---
 


### PR DESCRIPTION
## Summary

Adds `.agent/skills/ticket-create/` — the creation-side dual of `ticket-intake`. Centralizes issue-creation discipline that was previously fragmented across 4 surfaces (`create_issue` MCP tool description, `ticket-intake` skill (consumption-only), `AGENTS_STARTUP.md §9`, tribal knowledge). Every new session previously re-derived the rules from precedent; the `[enhancement]`-prefix anti-pattern spreading across multiple tickets is the direct evidence.

## What's New

| File | Purpose |
|---|---|
| `.agent/skills/ticket-create/SKILL.md` | Trigger description; mirrors `ticket-intake/SKILL.md` structure |
| `.agent/skills/ticket-create/references/ticket-create-workflow.md` | Canonical workflow: duplicate sweep → challenge chain → title hygiene → label rules → Fat Ticket body → visible proposal → linkage → anti-patterns → escalation-to-discussion |
| `.agent/skills/ticket-create/assets/ticket-proposal-template.md` | Chat-dump format for the mandatory visible-proposal protocol |

## What's Shrunk

| File | Before → After |
|---|---|
| `AGENTS_STARTUP.md §9` | 21 lines (9 numbered items) → 12 lines (5 paragraphs with skill pointers) |
| `ai/mcp/server/github-workflow/openapi.yaml` `create_issue.description` | ~27 lines (CRITICAL PROTOCOL + MANDATORY WORKFLOW + STRICT LABELING + Post-Creation) → 5 lines (skill pointer + minimum tool guidance) |

**Rationale for yaml shrink:** tool descriptions ride in every agent's tool list on every session boot — length is not free. Companion in-flight work on reducing default tool descriptions + introducing a `getDescription` tool makes the minimum-viable description pattern the right trajectory now. Skill files are the right substrate for long-form protocol.

**Rationale for §9 shrink:** `AGENTS_STARTUP.md` is approaching context-cap limits for some harnesses (Antigravity). Migrating the creation-specific content to the skill while keeping `§9.7` handoff context inline reduces startup cost for every session.

## What's Added to Learn Docs

`learn/agentos/ProgressiveDisclosureSkills.md`:
- New `### 4. ticket-create (The Creation Gate)` section describing the skill's four enforcement surfaces
- New `ticket-create` row in the Skill Inventory table

Mermaid lifecycle diagram left unchanged — ticket-create is orthogonal to the execution flow (fires during any turn where an agent decides to file a new ticket), not a pre-sequel to `ticket-intake`.

## Architectural Anchor Points

The skill codifies patterns observed and debugged across recent sessions:

- **Title hygiene:** `[enhancement]` / `[bug]` / `[epic]` prefix duplicates label taxonomy. Memory: `feedback_no_title_prefix_duplicating_labels.md`. Evidence: prior session's #10085/#10086/#10087/#10103 all carried the prefix, propagated via precedent-following despite the feedback memory existing.
- **Architectural Reality section:** the `§9.6` body requirement was preserved in the skill's Fat Ticket structure — originally omitted from the first draft, caught during review of this PR's own scope.
- **Five-stage challenge chain:** premise → prescription → substrate → consumer → service-boundary — codified at creation time (not just intake). Memories: `feedback_challenge_prescribed_fixes`, `feedback_config_service_boundary`, `feedback_observability_consumer_identity`, `feedback_audit_subsystem_guides_before_architectural_claims`.
- **Duplicate sweep command:** `grep` on `resources/content/issues/`, `issue-archive/`, `discussions/` plus `ask_knowledge_base(type='ticket')` as primary. `AGENTS_STARTUP §9` only mentioned `issues` + `discussions`; skill adds `issue-archive/` coverage explicitly.
- **Visible proposal protocol:** mandatory chat-dump before `create_issue` fires. Moved from tool description to skill so the full template with placeholders can live there.

## Test Deferred

AC item #6 (*"a representative test: generate a new test ticket through the skill, verify it hits all the hygiene rules"*) deferred per commander decision. Skill is prescriptive documentation; a file-parse self-consistency test has marginal value relative to the file-count + review burden. If anti-patterns regress in future tickets, the right enforcement is either a CI lint (hook reading the markdown template against new tickets) or simply catching it in `pr-review`.

## Test Plan

- [x] Skill files created with proper frontmatter (SKILL.md has `name`, `description`, `triggers`)
- [x] Workflow reference structured with numbered sections matching the ticket's AC list
- [x] Template file provides visible-proposal format with placeholders
- [x] `AGENTS_STARTUP.md §9` shrunk; skill-pointer paragraph added; §9.7 handoff context preserved
- [x] `openapi.yaml` `create_issue` description minimized with skill pointer
- [x] `toolService.mjs` verified — maps tool names to methods only; no description duplication
- [x] `learn/agentos/ProgressiveDisclosureSkills.md` skill inventory + new §4 section added
- [ ] Post-merge: next agent session's ticket creation should invoke the skill before `create_issue` — observe organically

## Related

- **Sibling (consumption dual):** `.agent/skills/ticket-intake/`
- **Origin session:** `1db25bbe-f39d-4dcd-bb0e-bc125ce91326` (ticket originator; captured the `[enhancement]`-prefix anti-pattern observation)
- **Memory evidence supporting scope:** `feedback_no_title_prefix_duplicating_labels`, `feedback_audit_subsystem_guides_before_architectural_claims`, `feedback_blocker_reserved_for_merge_breaking`, `feedback_challenge_prescribed_fixes`, `feedback_memory_before_forensics`, + others

## Avoided Traps

- **Inlining discipline in AGENTS_STARTUP §9:** rejected — would bloat an already-long startup doc; violates the context-cap constraint user flagged
- **Inlining discipline in openapi.yaml tool description:** rejected — tool descriptions ride in every session's tool list, length penalty compounds; can't include structured examples
- **Writing a file-parse test:** rejected per commander decision — marginal value for a docs-only skill

Resolves #10104

🤖 Generated with [Claude Code](https://claude.com/claude-code)