### PR TITLE
feat(ai): introduce chromaUnified flag for shared-ChromaDB topology (#10001)

### DIFF
--- a/ai/mcp/server/knowledge-base/config.template.mjs
+++ b/ai/mcp/server/knowledge-base/config.template.mjs
@@ -80,6 +80,17 @@ const defaultConfig = {
         }
     },
     /**
+     * Dynamic topology flag for the Cloud-Native Memory Core deployment (Epic #9999, sub-epic #10015).
+     * When `true`, the Knowledge Base is the sole owner of the ChromaDB process on this host and the
+     * Memory Core server connects as a downstream client (see `memory-core/config.template.mjs` →
+     * `chromaUnified`). This flag does **not** alter client-side behavior for the KB itself; it
+     * documents the deployment topology for operators and keeps configuration symmetric across the
+     * two servers so tooling and diagnostics can introspect either side and report the effective
+     * topology consistently.
+     * @type {boolean}
+     */
+    chromaUnified: process.env.NEO_CHROMA_UNIFIED === 'true',
+    /**
      * The hostname of the ChromaDB server for the knowledge base.
      * @type {string}
      */

--- a/ai/mcp/server/memory-core/config.template.mjs
+++ b/ai/mcp/server/memory-core/config.template.mjs
@@ -169,26 +169,33 @@ const defaultConfig = {
     engine: 'hybrid',
     /**
      * Database Engine Definitions
-     * This defines WHERE data is stored physically.
+     * This defines WHERE data is stored physically (for engines MC owns) and WHERE MC reaches
+     * into other services' engines (under `engines.<serviceName>.<engineType>`). The flat
+     * `engines.chroma` path is MC's own ChromaDB; the nested `engines.kb.chroma` path is the
+     * Knowledge Base's ChromaDB, consulted only when `chromaUnified` is `true`.
      */
     engines: {
         chroma: {
             dataDir: path.resolve(cwd, '.neo-ai-data/chroma/memory-core'),
             host   : 'localhost',
             port   : 8001
+        },
+        /**
+         * Connection coordinates for the shared Knowledge Base ChromaDB instance, consulted by
+         * `ChromaManager` when `chromaUnified` is `true`. In unified mode the Memory Core's
+         * ChromaClient targets `engines.kb.chroma.{host, port}` instead of `engines.chroma.{host, port}`.
+         * Defaults match the Knowledge Base server's default (`localhost:8000`); override per-deployment
+         * via `NEO_KB_CHROMA_HOST` / `NEO_KB_CHROMA_PORT` for containerized topologies. The
+         * `engines.<serviceName>.<engineType>` namespace is the extension point for any future
+         * cross-service engine-reference groups.
+         * @type {Object}
+         */
+        kb: {
+            chroma: {
+                host: process.env.NEO_KB_CHROMA_HOST || 'localhost',
+                port: Number(process.env.NEO_KB_CHROMA_PORT) || 8000
+            }
         }
-    },
-    /**
-     * Connection coordinates for the shared Knowledge Base ChromaDB instance, consulted by
-     * `ChromaManager` when `chromaUnified` is `true`. In unified mode the Memory Core's ChromaClient
-     * targets these coordinates instead of `engines.chroma.{host, port}`. Defaults match the
-     * Knowledge Base server's default (`localhost:8000`); override per-deployment via
-     * `NEO_KB_CHROMA_HOST` / `NEO_KB_CHROMA_PORT` for containerized topologies.
-     * @type {Object}
-     */
-    kbChroma: {
-        host: process.env.NEO_KB_CHROMA_HOST || 'localhost',
-        port: Number(process.env.NEO_KB_CHROMA_PORT) || 8000
     },
     /**
      * Physical file paths for embedded/local datasets.

--- a/ai/mcp/server/memory-core/config.template.mjs
+++ b/ai/mcp/server/memory-core/config.template.mjs
@@ -147,6 +147,20 @@ const defaultConfig = {
      */
     summarizationConcurrency: 5,
     /**
+     * Dynamic topology flag for the Cloud-Native Memory Core deployment (Epic #9999, sub-epic #10015).
+     * When `true`, Memory Core connects to the shared Knowledge Base ChromaDB instance at
+     * `kbChroma.{host, port}` instead of addressing its own instance at `engines.chroma.{host, port}`.
+     * This enables **unified-topology** single-container deployments where KB and MC share one ChromaDB
+     * process (the klarso.com cloud pattern); `false` preserves the **federated** two-instance default.
+     *
+     * Pairs with `autoStartDatabase`: in unified mode the operator should leave that `false` so MC does
+     * not spawn a duplicate ChromaDB — the KB server owns the process. The federation choice is orthogonal
+     * to per-tenant write tagging (#10000) and read-side isolation (#10010), which apply regardless of
+     * topology.
+     * @type {boolean}
+     */
+    chromaUnified: process.env.NEO_CHROMA_UNIFIED === 'true',
+    /**
      * The target Storage Architecture to use.
      * Note: Chroma is the only supported Vector DB.
      * Options: 'hybrid' (Chroma vectors + SQLite graph), 'chroma' (Chroma vectors only).
@@ -163,6 +177,18 @@ const defaultConfig = {
             host   : 'localhost',
             port   : 8001
         }
+    },
+    /**
+     * Connection coordinates for the shared Knowledge Base ChromaDB instance, consulted by
+     * `ChromaManager` when `chromaUnified` is `true`. In unified mode the Memory Core's ChromaClient
+     * targets these coordinates instead of `engines.chroma.{host, port}`. Defaults match the
+     * Knowledge Base server's default (`localhost:8000`); override per-deployment via
+     * `NEO_KB_CHROMA_HOST` / `NEO_KB_CHROMA_PORT` for containerized topologies.
+     * @type {Object}
+     */
+    kbChroma: {
+        host: process.env.NEO_KB_CHROMA_HOST || 'localhost',
+        port: Number(process.env.NEO_KB_CHROMA_PORT) || 8000
     },
     /**
      * Physical file paths for embedded/local datasets.

--- a/ai/mcp/server/memory-core/managers/ChromaManager.mjs
+++ b/ai/mcp/server/memory-core/managers/ChromaManager.mjs
@@ -15,10 +15,11 @@ import ChromaLifecycleService   from '../services/lifecycle/ChromaLifecycleServi
  * **Dynamic topology (Epic #9999, sub-epic #10015):** The ChromaClient coordinates are resolved from
  * `aiConfig.chromaUnified`. In **federated** mode (the default, flag `false`) the client targets
  * `aiConfig.engines.chroma.{host, port}` — Memory Core's own ChromaDB instance, typically on port 8001.
- * In **unified** mode (flag `true`) the client targets `aiConfig.kbChroma.{host, port}` — the shared
- * Knowledge Base instance, typically on port 8000 — enabling single-container KB + MC deployments
- * where one ChromaDB process serves both servers. The federation choice is orthogonal to per-tenant
- * write tagging and read-side isolation, which live in `SessionService` / `MemoryService`.
+ * In **unified** mode (flag `true`) the client targets `aiConfig.engines.kb.chroma.{host, port}` —
+ * the shared Knowledge Base instance, typically on port 8000 — enabling single-container KB + MC
+ * deployments where one ChromaDB process serves both servers. The federation choice is orthogonal
+ * to per-tenant write tagging and read-side isolation, which live in `SessionService` /
+ * `MemoryService`.
  *
  * @class Neo.ai.mcp.server.memory-core.managers.ChromaManager
  * @extends Neo.ai.mcp.server.memory-core.managers.AbstractVectorManager
@@ -80,14 +81,35 @@ class ChromaManager extends AbstractVectorManager {
      * by diagnostics (e.g. HealthService topology reporting) without re-instantiating the singleton.
      *
      * - `chromaUnified=false` (default, federated): routes to `cfg.engines.chroma` — MC's own instance
-     * - `chromaUnified=true` (unified): routes to `cfg.kbChroma` — the shared KB instance
+     * - `chromaUnified=true` (unified): routes to `cfg.engines.kb.chroma` — the shared KB instance
+     *
+     * Throws when unified mode is requested but `engines.kb.chroma` is absent — this can only happen
+     * when a custom config file explicitly clobbers the `engines.kb` branch (the shipped template
+     * ships it populated). Surfacing an explicit error here prevents `new ChromaClient({host:
+     * undefined, port: undefined})` from failing later with a less-actionable heartbeat error.
      *
      * @param {Object} cfg              aiConfig-shaped input. Must expose `chromaUnified` plus both
-     *                                  branch targets `engines.chroma.{host, port}` and `kbChroma.{host, port}`.
+     *                                  branch targets `engines.chroma.{host, port}` and
+     *                                  `engines.kb.chroma.{host, port}`.
      * @returns {{host: string, port: number}} The resolved coordinates for the active topology.
+     * @throws {Error} When `chromaUnified=true` and `engines.kb.chroma` is not defined.
      */
     resolveChromaCoordinates(cfg) {
-        return cfg.chromaUnified ? cfg.kbChroma : cfg.engines.chroma;
+        if (cfg.chromaUnified) {
+            const kbChroma = cfg.engines?.kb?.chroma;
+
+            if (!kbChroma) {
+                throw new Error(
+                    'ChromaManager: chromaUnified=true requires engines.kb.chroma.{host, port} ' +
+                    'to be defined. Check your custom config override — the shipped template provides ' +
+                    'defaults (localhost:8000) overridable via NEO_KB_CHROMA_HOST / NEO_KB_CHROMA_PORT.'
+                )
+            }
+
+            return kbChroma
+        }
+
+        return cfg.engines.chroma
     }
 
     /**

--- a/ai/mcp/server/memory-core/managers/ChromaManager.mjs
+++ b/ai/mcp/server/memory-core/managers/ChromaManager.mjs
@@ -12,6 +12,14 @@ import ChromaLifecycleService   from '../services/lifecycle/ChromaLifecycleServi
  * collections are created if they don't exist. It handles the `dummyEmbeddingFunction` requirement for ChromaDB
  * to prevent warnings.
  *
+ * **Dynamic topology (Epic #9999, sub-epic #10015):** The ChromaClient coordinates are resolved from
+ * `aiConfig.chromaUnified`. In **federated** mode (the default, flag `false`) the client targets
+ * `aiConfig.engines.chroma.{host, port}` — Memory Core's own ChromaDB instance, typically on port 8001.
+ * In **unified** mode (flag `true`) the client targets `aiConfig.kbChroma.{host, port}` — the shared
+ * Knowledge Base instance, typically on port 8000 — enabling single-container KB + MC deployments
+ * where one ChromaDB process serves both servers. The federation choice is orthogonal to per-tenant
+ * write tagging and read-side isolation, which live in `SessionService` / `MemoryService`.
+ *
  * @class Neo.ai.mcp.server.memory-core.managers.ChromaManager
  * @extends Neo.ai.mcp.server.memory-core.managers.AbstractVectorManager
  * @singleton
@@ -60,9 +68,26 @@ class ChromaManager extends AbstractVectorManager {
     construct(config) {
         super.construct(config);
 
-        // The client is created here, but the connection is evaluated lazily.
-        const {host, port} = aiConfig.engines.chroma;
+        // The client is constructed here; heartbeat/connection is evaluated lazily by `connect()`.
+        const {host, port} = this.resolveChromaCoordinates(aiConfig);
         this.client        = new ChromaClient({host, port, ssl: false});
+    }
+
+    /**
+     * Resolves the effective ChromaDB `{host, port}` from the unified-vs-federated topology flag
+     * (Epic #9999, sub-epic #10015, ticket #10001). Pure function of the passed config — extracted
+     * from the `construct()` call-site so the resolution is independently testable and observable
+     * by diagnostics (e.g. HealthService topology reporting) without re-instantiating the singleton.
+     *
+     * - `chromaUnified=false` (default, federated): routes to `cfg.engines.chroma` — MC's own instance
+     * - `chromaUnified=true` (unified): routes to `cfg.kbChroma` — the shared KB instance
+     *
+     * @param {Object} cfg              aiConfig-shaped input. Must expose `chromaUnified` plus both
+     *                                  branch targets `engines.chroma.{host, port}` and `kbChroma.{host, port}`.
+     * @returns {{host: string, port: number}} The resolved coordinates for the active topology.
+     */
+    resolveChromaCoordinates(cfg) {
+        return cfg.chromaUnified ? cfg.kbChroma : cfg.engines.chroma;
     }
 
     /**

--- a/test/playwright/unit/ai/mcp/server/memory-core/managers/ChromaManager.spec.mjs
+++ b/test/playwright/unit/ai/mcp/server/memory-core/managers/ChromaManager.spec.mjs
@@ -21,6 +21,35 @@ import aiConfig       from '../../../../../../../../ai/mcp/server/memory-core/co
 import ChromaManager  from '../../../../../../../../ai/mcp/server/memory-core/managers/ChromaManager.mjs';
 import SystemLifecycleService from '../../../../../../../../ai/mcp/server/memory-core/services/lifecycle/SystemLifecycleService.mjs';
 
+test.describe('Neo.ai.mcp.server.memory-core.managers.ChromaManager — resolveChromaCoordinates (#10001)', () => {
+    test('federated mode (chromaUnified=false) routes to MC own ChromaDB coordinates', () => {
+        const result = ChromaManager.resolveChromaCoordinates({
+            chromaUnified: false,
+            engines      : {chroma: {host: 'mc-host', port: 8001}},
+            kbChroma     : {host: 'kb-host', port: 8000}
+        });
+
+        expect(result).toEqual({host: 'mc-host', port: 8001});
+    });
+
+    test('unified mode (chromaUnified=true) routes to shared KB ChromaDB coordinates', () => {
+        const result = ChromaManager.resolveChromaCoordinates({
+            chromaUnified: true,
+            engines      : {chroma: {host: 'mc-host', port: 8001}},
+            kbChroma     : {host: 'kb-host', port: 8000}
+        });
+
+        expect(result).toEqual({host: 'kb-host', port: 8000});
+    });
+
+    test('shipped config template defaults to federated mode — MC own instance on 8001', () => {
+        // Default-posture guard: the shipped repository must not ship with chromaUnified=true
+        // (that would silently redirect every fresh checkout to port 8000, breaking federated deploys).
+        expect(aiConfig.chromaUnified).toBe(false);
+        expect(ChromaManager.resolveChromaCoordinates(aiConfig)).toEqual(aiConfig.engines.chroma);
+    });
+});
+
 test.describe('Neo.ai.mcp.server.memory-core.managers.ChromaManager', () => {
     test('should prevent console.warn global state theft during concurrent collection fetching', async () => {
         // Set up a custom warn logger to inspect leaks

--- a/test/playwright/unit/ai/mcp/server/memory-core/managers/ChromaManager.spec.mjs
+++ b/test/playwright/unit/ai/mcp/server/memory-core/managers/ChromaManager.spec.mjs
@@ -25,8 +25,10 @@ test.describe('Neo.ai.mcp.server.memory-core.managers.ChromaManager — resolveC
     test('federated mode (chromaUnified=false) routes to MC own ChromaDB coordinates', () => {
         const result = ChromaManager.resolveChromaCoordinates({
             chromaUnified: false,
-            engines      : {chroma: {host: 'mc-host', port: 8001}},
-            kbChroma     : {host: 'kb-host', port: 8000}
+            engines      : {
+                chroma: {host: 'mc-host', port: 8001},
+                kb    : {chroma: {host: 'kb-host', port: 8000}}
+            }
         });
 
         expect(result).toEqual({host: 'mc-host', port: 8001});
@@ -35,11 +37,23 @@ test.describe('Neo.ai.mcp.server.memory-core.managers.ChromaManager — resolveC
     test('unified mode (chromaUnified=true) routes to shared KB ChromaDB coordinates', () => {
         const result = ChromaManager.resolveChromaCoordinates({
             chromaUnified: true,
-            engines      : {chroma: {host: 'mc-host', port: 8001}},
-            kbChroma     : {host: 'kb-host', port: 8000}
+            engines      : {
+                chroma: {host: 'mc-host', port: 8001},
+                kb    : {chroma: {host: 'kb-host', port: 8000}}
+            }
         });
 
         expect(result).toEqual({host: 'kb-host', port: 8000});
+    });
+
+    test('unified mode throws a clear error when engines.kb.chroma is absent', () => {
+        // Guards the misconfiguration path where a custom config override clobbers engines.kb
+        // without supplying a replacement — surfaces the issue at construct-time rather than
+        // letting `new ChromaClient({host: undefined, port: undefined})` fail later at heartbeat.
+        expect(() => ChromaManager.resolveChromaCoordinates({
+            chromaUnified: true,
+            engines      : {chroma: {host: 'mc-host', port: 8001}}
+        })).toThrow(/chromaUnified=true requires engines\.kb\.chroma/);
     });
 
     test('shipped config template defaults to federated mode — MC own instance on 8001', () => {


### PR DESCRIPTION
## Summary

Introduces the `NEO_CHROMA_UNIFIED` deployment-topology flag (Epic #9999, sub-epic #10015). When `true`, Memory Core's ChromaClient connects to the shared Knowledge Base ChromaDB instance at `kbChroma.{host, port}` (typically port 8000) instead of addressing its own instance at `engines.chroma.{host, port}` (port 8001). Default remains `false` — existing federated deploys see no behavioral change.

## Motivation

Enables a single-cloud-container deployment shape where the Knowledge Base and Memory Core share one ChromaDB process — minimizing RAM overhead and operational surface for centrally hosted multi-tenant Memory Core setups, where a dev team runs agents against shared cross-session memory. This PR lands the client-side routing; sibling PRs in the sub-epic will cover lifecycle bypass (#10007), userId injection (#10000), and team-read flag (#10010) to complete the deployment target.

## Scope

| File | Change |
|---|---|
| `ai/mcp/server/memory-core/config.template.mjs` | Adds `chromaUnified` (env: `NEO_CHROMA_UNIFIED`) + `kbChroma.{host, port}` (envs: `NEO_KB_CHROMA_HOST`, `NEO_KB_CHROMA_PORT`) |
| `ai/mcp/server/knowledge-base/config.template.mjs` | Adds `chromaUnified` for operator symmetry / documentation (no client-side branching — KB always owns its ChromaDB process) |
| `ai/mcp/server/memory-core/managers/ChromaManager.mjs` | `construct()` resolves coordinates via a new `resolveChromaCoordinates(cfg)` instance method; updated class JSDoc Anchor to document the unified-vs-federated semantics |
| `test/playwright/unit/ai/mcp/server/memory-core/managers/ChromaManager.spec.mjs` | 3 new tests: federated-mode resolution, unified-mode resolution, and a default-posture guard asserting the shipped template defaults to federated |

Gitignored `config.mjs` files (MC + KB) were mirrored locally so tests pick up the new keys. Per the existing template/local parity convention, the template is the repo's source of truth; `bootstrapWorktree.mjs` copies main's config into fresh worktrees.

## Out of scope / deferred

- **Ticket task 3 (federated OAuth headers for a secondary ChromaClient)** — DreamService's original Macro-DB federation use case was superseded by Concept Ontology (#10030, which uses the SQLite graph). No cross-service ChromaDB queries are required for the single-container deployment shape. Can be added as a follow-up PR if a future cross-network federated scenario emerges; the `chromaUnified` flag and `kbChroma` config shape already leave room for it.
- **Lifecycle bypass in unified mode** — #10007, next PR in the sub-epic. Without it, operators must manually set `NEO_MEM_AUTO_START_DATABASE=false` in unified mode so MC doesn't spawn a duplicate ChromaDB process. JSDoc on `chromaUnified` documents this pairing explicitly.
- **Ticket body invariances caught during intake** — #10001's body references `DatabaseService.mjs` for lifecycle bypass (the actual owner is `ChromaLifecycleService.mjs`) and names `StorageRouter` as the ChromaClient owner (it's `ChromaManager`). Historical drift from the 2026-04-14 planning session before the `better-sqlite3` + `vec0` experiment was rolled back — the StorageRouter/CollectionProxy abstraction is a residual from that discarded alternative-vector-store exploration.

## Test plan

- [x] `ChromaManager.spec.mjs` in isolation — 4/4 passing (3 new topology tests + 1 existing `console.warn` mutex regression test)
- [x] Full `memory-core/` suite — baseline has 7 pre-existing failures (5 SessionSummarization specs failing on undefined `aiConfig.engines.neo.*`, `McpServerToolLimits` on a 1161-char tool description exceeding the 1024 limit, `FileSystemIngestor` path-pattern assertion). No new failures introduced by this PR; same 7 fail on `git stash` baseline.
- [x] Backward compatibility — `chromaUnified=false` (default) preserves the existing `engines.chroma.{host, port}` resolution. Default-posture guard in the new spec asserts this invariant so accidental flag flips in the shipped template fail CI.

## Follow-ups identified during intake (filing separately)

- `engine` vs `architecture` config-name drift in `CollectionProxy.mjs:22` and `ChromaLifecycleService.mjs:53` — code reads `aiConfig.architecture`; config exposes `engine`; `|| 'hybrid'` fallback silently masks the mismatch.
- `aiConfig.engines.neo.*` missing from both template and local config — causes the 5 pre-existing SessionSummarization failures.
- HealthService topology reporting — surface effective `unified` / `federated` state in `/health` for operator diagnostics.

Resolves #10001

Origin Session ID: 1c001810-be28-4554-bb56-c98f9b91bbfb