### PR TITLE
feat(ai): skip MC ChromaDB spawn in unified mode (#10007)

### DIFF
--- a/ai/mcp/server/memory-core/services/lifecycle/ChromaLifecycleService.mjs
+++ b/ai/mcp/server/memory-core/services/lifecycle/ChromaLifecycleService.mjs
@@ -234,6 +234,13 @@ class ChromaLifecycleService extends Base {
 
     /**
      * @summary High-level router for managing ChromaDB process state (start/stop) from the orchestrator.
+     *
+     * Backs the `manage_database` MCP tool (see `services/toolService.mjs`). In unified topology
+     * (`aiConfig.chromaUnified=true`, ticket #10007) the `start` action propagates `startDatabase`'s
+     * `{status: 'skipped_unified_mode'}` response rather than spawning; the `stop` action is naturally
+     * a no-op since `chromaProcess` was never populated — falls through to `stopDatabase`'s existing
+     * `{status: 'not_running'}` path. Operators invoking the tool manually in unified mode therefore
+     * get a structured, actionable response from both branches.
      * @param {Object} args
      * @returns {Promise<Object>}
      */

--- a/ai/mcp/server/memory-core/services/lifecycle/ChromaLifecycleService.mjs
+++ b/ai/mcp/server/memory-core/services/lifecycle/ChromaLifecycleService.mjs
@@ -10,7 +10,14 @@ import Observable from '../../../../../../src/core/Observable.mjs';
  * Following the dismantling of the monolithic database service, this class is now an explicitly isolated orchestrator
  * responsible for managing the local ChromaDB vector database daemon. It handles asynchronous initialization,
  * persistent heartbeat monitoring (`waitForHeartbeat`), and safe termination sequences independently.
- * 
+ *
+ * **Dynamic topology (Epic #9999, sub-epic #10015, ticket #10007):** When `aiConfig.chromaUnified` is
+ * `true`, this service becomes a no-op for daemon spawn — the Knowledge Base server owns the shared
+ * ChromaDB instance and Memory Core connects as a downstream client via `ChromaManager`.
+ * `startDatabase()` returns `{status: 'skipped_unified_mode'}` and `initAsync()` short-circuits before
+ * process spawn. The heartbeat / status methods continue to function: they query the shared instance
+ * via `ChromaManager.client` which was already routed to `engines.kb.chroma.{host, port}` in #10001.
+ *
  * Future AI sessions should search for `chroma startup`, `vector database lifecycle`, or `daemon orchestrator`.
  *
  * @class Neo.ai.mcp.server.memory-core.services.lifecycle.ChromaLifecycleService
@@ -47,9 +54,18 @@ class ChromaLifecycleService extends Base {
 
     /**
      * @summary Asynchronously initializes the ChromaLifecycleService, verifying engine config constraints.
+     *
+     * In unified-topology deployments (`chromaUnified=true`, ticket #10007) this short-circuits before
+     * any daemon-spawn gate so MC does not race the Knowledge Base server for the shared ChromaDB port.
      */
     async initAsync() {
         await super.initAsync();
+
+        if (aiConfig.chromaUnified) {
+            logger.log('[ChromaLifecycleService] chromaUnified=true — skipping own ChromaDB spawn; Memory Core connects to the shared Knowledge Base instance.');
+            return;
+        }
+
         if (aiConfig.autoStartDatabase && (aiConfig.architecture === 'chroma' || aiConfig.architecture === 'hybrid')) {
             await this.startDatabase();
         }
@@ -71,9 +87,22 @@ class ChromaLifecycleService extends Base {
 
     /**
      * @summary Boots the explicit local ChromaDB daemon as a detached process and awaits readiness.
+     *
+     * In unified topology (ticket #10007) this returns `{status: 'skipped_unified_mode'}` without
+     * attempting any spawn — the Knowledge Base server owns the shared instance. The defensive guard
+     * lives here (not only in `initAsync`) so the `manage_database` MCP tool, which delegates to
+     * this method via `manageDatabase()`, returns a clear no-op response if an operator invokes it
+     * manually in unified mode rather than silently spawning a duplicate daemon.
      * @returns {Promise<Object>}
      */
     async startDatabase() {
+        if (aiConfig.chromaUnified) {
+            return {
+                status: 'skipped_unified_mode',
+                detail: 'Memory Core runs as a downstream client of the Knowledge Base ChromaDB in unified mode. No daemon spawn required — see aiConfig.chromaUnified.'
+            };
+        }
+
         try {
             if (this.chromaProcess && !this.chromaProcess.killed) {
                 return { status: 'already_running', pid: this.chromaProcess.pid, detail: 'Started by this process.' };

--- a/test/playwright/unit/ai/mcp/server/memory-core/services/lifecycle/ChromaLifecycleService.spec.mjs
+++ b/test/playwright/unit/ai/mcp/server/memory-core/services/lifecycle/ChromaLifecycleService.spec.mjs
@@ -1,0 +1,59 @@
+import { setup } from '../../../../../../../setup.mjs';
+
+const appName = 'ChromaLifecycleServiceTest';
+
+setup({
+    neoConfig: {
+        unitTestMode: true
+    },
+    appConfig: {
+        name: appName,
+        isMounted: () => true,
+        vnodeInitialising: false
+    }
+});
+
+import {test, expect}         from '@playwright/test';
+import Neo                    from '../../../../../../../../../src/Neo.mjs';
+import * as core              from '../../../../../../../../../src/core/_export.mjs';
+import aiConfig               from '../../../../../../../../../ai/mcp/server/memory-core/config.mjs';
+import ChromaLifecycleService from '../../../../../../../../../ai/mcp/server/memory-core/services/lifecycle/ChromaLifecycleService.mjs';
+
+test.describe('Neo.ai.mcp.server.memory-core.services.lifecycle.ChromaLifecycleService — unified-mode bypass (#10007)', () => {
+    test('startDatabase returns skipped_unified_mode when chromaUnified=true', async () => {
+        const original = aiConfig.chromaUnified;
+
+        try {
+            aiConfig.chromaUnified = true;
+            const result = await ChromaLifecycleService.startDatabase();
+
+            expect(result.status).toBe('skipped_unified_mode');
+            expect(result.detail).toMatch(/downstream client of the Knowledge Base/i);
+            // Guard against accidental spawn: nothing should have populated chromaProcess.
+            expect(ChromaLifecycleService.chromaProcess).toBeNull();
+        } finally {
+            aiConfig.chromaUnified = original;
+        }
+    });
+
+    test('manageDatabase({action:"start"}) propagates skipped_unified_mode in unified mode', async () => {
+        const original = aiConfig.chromaUnified;
+
+        try {
+            aiConfig.chromaUnified = true;
+            const result = await ChromaLifecycleService.manageDatabase({action: 'start'});
+
+            expect(result.status).toBe('skipped_unified_mode');
+            expect(ChromaLifecycleService.chromaProcess).toBeNull();
+        } finally {
+            aiConfig.chromaUnified = original;
+        }
+    });
+
+    test('shipped config template defaults chromaUnified=false — federated-mode startup path stays active', () => {
+        // Default-posture guard: the shipped repository must not ship with chromaUnified=true.
+        // Complements the equivalent guard in ChromaManager.spec.mjs (#10001) — both the routing
+        // side and the lifecycle side must agree on the default topology.
+        expect(aiConfig.chromaUnified).toBe(false);
+    });
+});

--- a/test/playwright/unit/ai/mcp/server/memory-core/services/lifecycle/ChromaLifecycleService.spec.mjs
+++ b/test/playwright/unit/ai/mcp/server/memory-core/services/lifecycle/ChromaLifecycleService.spec.mjs
@@ -50,6 +50,32 @@ test.describe('Neo.ai.mcp.server.memory-core.services.lifecycle.ChromaLifecycleS
         }
     });
 
+    test('initAsync short-circuits in unified mode even when autoStartDatabase=true', async () => {
+        // Explicit coverage of the `initAsync` guard. Without this test, a future edit that reorders
+        // the short-circuit below the `autoStartDatabase && architecture` gate — or deletes it entirely
+        // — would pass the other two tests (they call `startDatabase` / `manageDatabase` directly and
+        // would still see the method-level guard). This test forces the bypass to be observable at
+        // the init-flow level by setting autoStartDatabase=true (which would normally trigger spawn)
+        // and asserting `chromaProcess` stays null.
+        const originalUnified     = aiConfig.chromaUnified;
+        const originalAutoStart   = aiConfig.autoStartDatabase;
+        const originalInitPromise = ChromaLifecycleService._initPromise;
+
+        try {
+            aiConfig.chromaUnified             = true;
+            aiConfig.autoStartDatabase         = true;
+            ChromaLifecycleService._initPromise = null;
+
+            await ChromaLifecycleService.initAsync();
+
+            expect(ChromaLifecycleService.chromaProcess).toBeNull();
+        } finally {
+            aiConfig.chromaUnified             = originalUnified;
+            aiConfig.autoStartDatabase         = originalAutoStart;
+            ChromaLifecycleService._initPromise = originalInitPromise;
+        }
+    });
+
     test('shipped config template defaults chromaUnified=false — federated-mode startup path stays active', () => {
         // Default-posture guard: the shipped repository must not ship with chromaUnified=true.
         // Complements the equivalent guard in ChromaManager.spec.mjs (#10001) — both the routing


### PR DESCRIPTION
## Summary

Completes the unified-topology bypass for Memory Core. When `aiConfig.chromaUnified === true`, `ChromaLifecycleService`:

- **`initAsync()`** short-circuits before any daemon-spawn gate so MC does not race the Knowledge Base server for the shared ChromaDB port
- **`startDatabase()`** returns `{status: 'skipped_unified_mode', detail: '...'}` without attempting a spawn — defensive guard so the `manage_database` MCP tool (which delegates here via `manageDatabase()`) also returns a clear no-op if an operator invokes it manually in unified mode

Pairs with #10001 (merged as PR #10121), which landed the client-side routing (`ChromaManager.resolveChromaCoordinates` selecting `engines.kb.chroma` when `chromaUnified=true`). Together these two PRs let operators deploy a single-container KB + MC topology without the manual `NEO_MEM_AUTO_START_DATABASE=false` workaround that #10001's JSDoc documented.

## Scope

| File | Change |
|---|---|
| `ai/mcp/server/memory-core/services/lifecycle/ChromaLifecycleService.mjs` | Class JSDoc Anchor expanded with unified-mode contract. `initAsync()` gains `aiConfig.chromaUnified` short-circuit. `startDatabase()` gains a top-of-function guard returning `skipped_unified_mode`. |
| `test/playwright/unit/ai/mcp/server/memory-core/services/lifecycle/ChromaLifecycleService.spec.mjs` | New spec. 3 tests: `startDatabase` returns `skipped_unified_mode` and does not mutate `chromaProcess`; `manageDatabase({action:'start'})` propagates the skip status; default-posture guard asserts the shipped config ships `chromaUnified=false` (mirrors the equivalent guard in `ChromaManager.spec.mjs` from #10001). |

No config template changes needed — `chromaUnified` already shipped via #10001.

## Ticket-body drift noted

#10007's body names `ai/mcp/server/memory-core/services/DatabaseService.mjs` as the refactor target. The actual lifecycle owner is `ChromaLifecycleService.mjs`. `DatabaseService.mjs` is the export/import/truncate service for the `manage_database_backup` MCP tool, which is unrelated to process spawn. Same ticket-body drift pattern I flagged during #10001 intake — planning-session files named before the `vec0` experiment rollback + the monolithic-service decomposition.

## Test plan

- [x] New `ChromaLifecycleService.spec.mjs` — 3/3 passing
- [x] `ChromaManager.spec.mjs` + both lifecycle specs together — 8/8 passing (no cross-spec regression)
- [x] Backward compatibility: `chromaUnified=false` (default) preserves existing `initAsync` → `startDatabase` path. Default-posture guard asserts this invariant.

## What this unblocks

With #10001 + #10007 both merged, the single-container KB + MC unified deployment works without manual operator workarounds:

1. Set `NEO_CHROMA_UNIFIED=true` on the cloud container
2. Set `NEO_KB_CHROMA_HOST` / `NEO_KB_CHROMA_PORT` if non-default
3. KB server starts, owns the ChromaDB daemon on port 8000
4. MC server starts, skips its own daemon spawn (this PR), routes `ChromaManager` client to port 8000 (#10001)

Next in the sub-epic sequence: #10000 (hardened identity ingestion from OAuth claims) + #10010 (team-vs-private read flag).

## Follow-up worth filing post-merge

**HealthService topology reporting** — operators deploying with unified mode will want `/health` to surface `{topology: 'unified' | 'federated'}` + the effective ChromaDB coordinates so they can verify the flag resolved as expected. Flagged as a follow-up during #10001 self-review; still open. Becomes more valuable once #10000 + #10010 land and the full multi-tenant deployment path is complete.

Resolves #10007

Origin Session ID: 1c001810-be28-4554-bb56-c98f9b91bbfb