### PR TITLE
docs: remove commercial-partner reference from chromaUnified JSDoc

### DIFF
--- a/ai/mcp/server/memory-core/config.template.mjs
+++ b/ai/mcp/server/memory-core/config.template.mjs
@@ -151,7 +151,8 @@ const defaultConfig = {
      * When `true`, Memory Core connects to the shared Knowledge Base ChromaDB instance at
      * `kbChroma.{host, port}` instead of addressing its own instance at `engines.chroma.{host, port}`.
      * This enables **unified-topology** single-container deployments where KB and MC share one ChromaDB
-     * process (the klarso.com cloud pattern); `false` preserves the **federated** two-instance default.
+     * process — the pattern for centrally hosted multi-tenant Memory Core deployments. `false` preserves
+     * the **federated** two-instance default.
      *
      * Pairs with `autoStartDatabase`: in unified mode the operator should leave that `false` so MC does
      * not spawn a duplicate ChromaDB — the KB server owns the process. The federation choice is orthogonal


### PR DESCRIPTION
## Summary

Scrubs a commercial-partner mention from shipped source. The ChromaDB unified-topology flag's JSDoc (shipped via PR #10121, landed #10001) referenced a specific customer by name. This PR replaces the reference with capability-framed language so the public source tree stays customer-neutral.

## Scope

Single-line JSDoc edit in `ai/mcp/server/memory-core/config.template.mjs`:

```diff
- * process (the the tenant.com cloud pattern); \`false\` preserves the **federated** two-instance default.
+ * process — the pattern for centrally hosted multi-tenant Memory Core deployments. \`false\` preserves
+ * the **federated** two-instance default.
```

Behavior, defaults, env-var surface all unchanged. Zero code-path impact.

## Local worktree parity

The gitignored `ai/mcp/server/memory-core/config.mjs` mirror in this worktree has been updated locally to match. Operators on the main checkout should mirror the one-line change into their local `config.mjs` — or re-run `node ai/scripts/bootstrapWorktree.mjs` from a fresh worktree after the template merges and main's copy is updated.

## Follow-up

PR bodies and comments on #10121 + #10123 + related tickets are being scrubbed in parallel via `gh pr edit` / `manage_issue_comment update`. Same confidentiality hygiene applies there.

Resolves the confidentiality-hygiene concern flagged during the #10007 PR review. No ticket filed — the scrub is the fix.