### PR TITLE
feat(ai): enforce model self-id in pull-request skill (#10141)

### DIFF
--- a/.agent/skills/pull-request/SKILL.md
+++ b/.agent/skills/pull-request/SKILL.md
@@ -7,4 +7,4 @@ triggers: Use this skill as the final Definition of Done when you believe a tick
 
 If you are tasked with finalizing a ticket or opening a Pull Request, you MUST immediately use the `view_file` tool to read and strictly adhere to `/Users/Shared/github/neomjs/neo/.agent/skills/pull-request/references/pull-request-workflow.md` before proceeding.
 
-Do NOT run `git commit` or `gh pr create` without first reading the reference payload.
+Do NOT run `git commit` or `gh pr create` without first reading the reference payload. Pay special attention to the explicit **Self-Identification** mandate; your PR bodies MUST carry your agent identity and origin session ID.

--- a/.agent/skills/pull-request/references/pull-request-workflow.md
+++ b/.agent/skills/pull-request/references/pull-request-workflow.md
@@ -85,7 +85,20 @@ gh pr create --title "feat/fix/chore: Your Title (#TICKET_ID)" --body "Comprehen
 ```
 *(Passing the body directly ensures the PR contains the required context and aligns with the "Fat Ticket" protocol.)*
 
-## 5. Definition of Done & The Handoff State
+## 5. Self-Identification (Mandatory Authorship)
+
+To ensure symmetric discipline across the PR lifecycle and enable accurate cross-model convergence tracking, you MUST explicitly self-identify within the PR body you generate. This mirrors the authorship requirements in the `pr-review` skill.
+
+Your PR body MUST include a self-identification block near the top, formatted exactly as follows:
+`Authored by [Model Name] ([Agent Wrapper]). Session <Origin Session ID>.`
+
+**Cross-Harness Authorship Convention:**
+When you author a PR based on a handoff, ticket, or artifact synthesized by a *different* model in a *different* session (e.g., executing an implementation plan created by another agent), you MUST attribute the full provenance:
+`Authored by [Model-B] ([Harness-B]) consuming [Model-A]'s handoff — session A <id>, session B <id>.`
+
+This ensures A2A provenance remains graph-extractable even if you do not have a dedicated GitHub service account.
+
+## 6. Definition of Done & The Handoff State
 
 The agent's task is strictly considered "Done" once the PR is opened. A PR is a request for validation by an external entity (Human or QA Agent). **An agent MUST NOT autonomously run the `pr-review` skill against its own PR in headless mode.** 
 


### PR DESCRIPTION
Authored by Gemini 3.1 Pro (Antigravity). Session 30e93319-06e2-44d2-adf2-99168a997d08.

### Context
This PR enforces symmetric discipline across the AI skill lifecycle. While the `pr-review` skill successfully mandates model self-identification in comments, the `pull-request` skill lacked a similar enforcement for PR bodies. This leads to cross-model attribution issues, particularly when attempting to measure MX convergence metrics.

### The Fix
- Updated `pull-request`'s `SKILL.md` to explicitly warn agents to read the Self-Identification mandate before opening a PR.
- Injected a mandatory `Self-Identification` section into `pull-request-workflow.md`.
- Documented single-author and cross-harness provenance conventions (`Authored by [Model]...`).

Resolves #10141
