### PR TITLE
feat(skills): add epic-review for pre-work epic evaluation (#10154)

### DIFF
--- a/.agent/skills/epic-review/SKILL.md
+++ b/.agent/skills/epic-review/SKILL.md
@@ -1,0 +1,10 @@
+---
+name: epic-review
+description: Authoritative protocol for pre-work review of epics. Five-stage gating chain — roadmap fit, approach elegance, sub-structure coherence, prescription layer, avoided-traps completeness — posted as a structured comment on the epic ticket. Per-agent-per-epic one-shot; subsequent sub pickups cite the prior review.
+triggers: Use this skill when an agent is about to pick up its first sub from an unreviewed epic (per model-identity). Also use when a user explicitly requests an epic review, or when an epic is freshly filed and a reviewer pre-validates before any sub pickup begins.
+---
+# Epic Review Skill
+
+If you are about to pick up your first sub-issue from an epic that your model-identity has not yet reviewed, you MUST immediately use the `view_file` tool to read and strictly adhere to `/Users/Shared/github/neomjs/neo/.agent/skills/epic-review/references/epic-review-workflow.md` before running `ticket-intake` or any sub-work steps.
+
+Subsequent sub pickups from the same epic by the same model-identity cite the prior review by URL reference instead of re-running the skill.

--- a/.agent/skills/epic-review/assets/epic-review-comment-template.md
+++ b/.agent/skills/epic-review/assets/epic-review-comment-template.md
@@ -1,0 +1,70 @@
+<!--
+Epic Review Comment Template
+Post via manage_issue_comment with action=create on the epic ticket.
+Short form vs long form depends on stage 1-2 gating outcome.
+Remove HTML comments before posting.
+-->
+
+## Epic Review by [model-identity] ([harness])
+
+### Stage 1 — Roadmap Fit
+
+[✅ / ❌]
+
+[1-2 sentences on current strategic alignment. Cite Golden Path node, Memory Core context, or sibling epic # if relevant.]
+
+<!-- If Stage 1 = ❌, stop here and close with a challenge section: -->
+<!--
+### Challenge
+
+[Named alternative: merge with epic #N, postpone until #M ships, reframe as X.]
+
+[Rationale: why this epic as currently framed does not fit the roadmap.]
+
+---
+
+Origin Session ID: [reviewer's session UUID]
+-->
+
+### Stage 2 — Approach Elegance
+
+[✅ / ❌]
+
+[1-2 sentences on architectural load-bearing of the approach. Cite reuse-vs-parallel-substrate observation, Gold Standard match or divergence, testability.]
+
+<!-- If Stage 2 = ❌, stop here with an alternative proposal: -->
+<!--
+### Alternative Approach
+
+[Named alternative with 2-3 sentence architectural rationale.]
+
+[Expected effort delta, substrate-reuse benefit, or risk reduction vs current framing.]
+
+---
+
+Origin Session ID: [reviewer's session UUID]
+-->
+
+### Stage 3 — Sub-Structure Coherence
+
+[✅ / ❌ / ⚠️]
+
+[Findings: coverage gaps, overlapping subs, phase-boundary circularity, missing prerequisite subs. Call out specific sub # and concern.]
+
+### Stage 4 — Prescription Layer
+
+[✅ / ❌ / ⚠️]
+
+[Per-sub findings — call out only subs where prescription layer is questionable. Subs passing ✅ do not need individual mention.]
+
+### Stage 5 — Avoided Traps Completeness
+
+[✅ / ❌ / ⚠️]
+
+[Suggested additions if gaps exist. Reference training-data anchor drift candidates if relevant.]
+
+---
+
+**Review verdict:** [Greenlight / Revisions Requested / Block]
+
+Origin Session ID: [reviewer's session UUID]

--- a/.agent/skills/epic-review/references/epic-review-workflow.md
+++ b/.agent/skills/epic-review/references/epic-review-workflow.md
@@ -1,0 +1,181 @@
+# Epic Review Workflow
+
+Authoritative protocol for pre-work review of epics. Epic-review is a skill-gated discipline change, not a mechanical enforcement layer — it runs at agent-pickup moment, produces a structured comment on the epic ticket, and then the agent proceeds with sub-work.
+
+Epic errors have N-sub blast radius. By the time `pr-review` catches drift on sub N, subs 1..N-1 have already pulled in the same wrong assumption. This skill gates at the larger blast radius — catching scope or approach errors *before* any sub work begins, when the cost of pivoting is cheapest.
+
+## 1. When to Invoke
+
+Fire this skill when **either** condition holds:
+
+1. You are about to pick up your first sub from an epic your model-identity has not yet reviewed.
+2. A user explicitly asks for an epic review (pre-validation before sub work begins).
+
+**Per-agent-per-epic one-shot semantics:** once your model-identity (e.g. `@neo-opus-4-7`, `@neo-gemini-3-1-pro`) has posted an epic-review comment on epic #N, subsequent sub pickups from #N by the same identity cite the prior review by URL reference rather than re-running this skill.
+
+Different model-identities reviewing the same epic independently is **encouraged** — cross-model readback of architectural intent is the primary value. Two identities reviewing epic #N = two comments. Do not attempt deduplication.
+
+If the epic body has materially changed since your prior review (check `updatedAt` vs your comment's timestamp), re-run this skill and post an updated review.
+
+## 2. Pre-Review Context Pull
+
+Before running the five-stage chain, pull the following context:
+
+1. **The epic body.** Use `view_file` on `resources/content/issues/issue-<epic-id>.md` (or `get_local_issue_by_id` if not synced locally).
+2. **All sub-issues under the epic.** Titles, labels, blocking relationships — the epic's frontmatter `subIssues` list is the canonical source. Read each sub's body if sub-structure coherence review (stage 3) will run.
+3. **Roadmap alignment.** Query the Memory Core for current strategic direction:
+   - `get_context_frontier()` — Golden Path authoritative routing
+   - `query_summaries({query: '<epic-subject>'})` — historical session context on the topic
+   - `query_raw_memories({query: '<epic-subject>'})` — finer-grained reasoning trails
+4. **Duplicate sweep.** Has a similar epic been filed and either closed or superseded? Check `resources/content/issues/` and `resources/content/issue-archive/` before running stage 1.
+
+## 3. The Five-Stage Chain
+
+**Ordering is load-bearing.** Stage 1 failure halts all subsequent stages. Stage 2 failure halts stages 3-5. An epic that doesn't fit the roadmap should not undergo scope-coherence review — that work is wasted if the epic gets closed or pivoted. Do not short-circuit the gating to "be thorough."
+
+### Stage 1 — Roadmap Fit
+
+**Question:** Does this epic belong in the current strategic direction?
+
+Checks:
+- Does it conflict with or duplicate an in-flight epic? (If yes — name the sibling explicitly and propose merge or redirection.)
+- Is it premature (depends on unshipped work in another epic)?
+- Is it redundant (another epic already covers this work at a different abstraction level)?
+- Is it misaligned with Golden Path top-weight nodes?
+- Does it represent a strategic pivot without an accompanying discussion or vision doc? (Mid-flight pivots need a Discussion before becoming an Epic.)
+
+**Stop condition:** if stage 1 fails, the comment is a **roadmap-fit challenge**. Do not run stages 2-5. Name the alternative (merge with epic X, postpone until Y ships, reframe as Z) and post the comment. The agent does not pick up subs until the challenge is resolved — either the epic body is updated defending the fit, or the epic is closed/restructured.
+
+### Stage 2 — Approach Elegance
+
+**Question:** Is the main architectural decision load-bearing? Would a more elegant alternative serve the same goal?
+
+Checks:
+- Does the approach **reuse existing substrate**, or does it invent parallel substrate? (Parallel substrate is a strong warning sign — it usually means the author missed a reusable primitive.)
+- Is the main abstraction layer the right one? (Same substrate-boundary question as `ticket-intake` prescription challenge, elevated one scope level.)
+- Is there a known **Gold Standard** from prior sessions this epic diverges from without rationale? Query Memory Core for comparable epics.
+- Does the approach **compound** existing capability, or does it fight against it?
+- Is the epic's main decision testable — can it be empirically validated, or is it an unfalsifiable preference?
+
+**Stop condition:** if stage 2 fails, the comment proposes one or more **alternative approaches** with rationale. Stages 3-5 skip. Agent does not pick up subs until the elegance question is resolved — either the original approach is defended (epic body updated with rationale), or the alternative is adopted (epic restructured).
+
+Stage 2 is the most empirically valuable gate. A non-elegant approach that passes structural review can waste N subs worth of effort before `pr-review` catches the foundational issue.
+
+### Stage 3 — Sub-Structure Coherence
+
+*(Runs only if stages 1-2 pass.)*
+
+**Question:** Do the subs collectively close the epic's success criteria?
+
+Checks:
+- **Coverage**: every item in the epic's acceptance criteria maps to at least one sub that closes it
+- **Overlaps**: two subs claiming to deliver the same outcome — flag for merge or scope-split
+- **Phase boundaries**: sub N's outputs feed sub N+1's inputs cleanly; no circular `blocked_by` dependencies
+- **Missing phases**: a prerequisite sub implied by the arc but not filed (e.g. a migration ticket, a schema ticket, a doc-update ticket)
+- **Scope creep risk**: subs whose titles or bodies exceed the parent epic's scope
+
+### Stage 4 — Prescription Layer
+
+*(Runs only if stages 1-2 pass.)*
+
+**Question:** For each sub, is the work at the right layer?
+
+Apply the same five-stage challenge chain from `ticket-intake`, but across the sub-graph rather than individual sub:
+- **Premise**: is each sub's stated problem real and reproducible?
+- **Prescription**: is the fix at the right substrate, or does it treat a symptom?
+- **Substrate**: service-layer / framework-core / daemon / documentation / config — right owner?
+- **Consumer**: who reads the output — human, agent, Memory Core, Native Edge Graph?
+- **Service-boundary**: does any sub cross a boundary it shouldn't (e.g. shipping config to a service that doesn't own the concern)?
+
+You are not running `ticket-intake` on each sub — that runs at sub pickup. You are checking that the sub-graph's prescription layer is architecturally coherent from the epic-level view.
+
+### Stage 5 — Avoided Traps Completeness
+
+*(Runs only if stages 1-2 pass.)*
+
+**Question:** What obvious wrong paths should the epic name as rejected?
+
+Checks:
+- Does the epic have an "Avoided Traps" section naming rejected alternatives with rationale?
+- Are there common failure modes (e.g., standard industry patterns that don't fit Neo's multi-threaded / Scene-Graph / Memory-Core-native architecture) the epic should preemptively flag?
+- Are **training-data anchor drift** candidates (e.g., "Neo is a framework" miscategorization, outdated model-name references, temporal anchors from training data) relevant to this epic's framing?
+- Does the epic's approach resemble one that was previously rejected in another session? Memory Core query may surface this.
+
+Missing traps are an **extension opportunity**, not a blocker — flag them in the comment for the epic author to add. Stage 5 never halts downstream work on its own.
+
+## 4. Comment Output Format
+
+Post the review as a comment on the epic ticket using `manage_issue_comment` with action `create`. Use the template at `.agent/skills/epic-review/assets/epic-review-comment-template.md` as the structural skeleton.
+
+**Short form** (stage 1 or 2 failure):
+- Header: `Epic Review — Stage [1|2] Challenge by [model-identity]`
+- Named stage that failed
+- Specific challenge or alternative proposal with rationale
+- No stage 3-5 content
+- Session ID footer
+
+**Long form** (stages 1-2 pass; stages 3-5 run):
+- Header: `Epic Review by [model-identity]`
+- Stage 1 — Roadmap Fit: ✅ with 1-2 sentence rationale
+- Stage 2 — Approach Elegance: ✅ with 1-2 sentence rationale
+- Stage 3 — Sub-Structure Coherence: findings (gaps/overlaps/boundary issues) or ✅
+- Stage 4 — Prescription Layer: per-sub findings or ✅
+- Stage 5 — Avoided Traps Completeness: suggested additions or ✅
+- Verdict line (Greenlight / Revisions Requested / Block)
+- Session ID footer
+
+Use the agent field on `manage_issue_comment` to self-identify: format `"[Model Name] ([Harness])"` — matches the `pr-review` self-identification pattern.
+
+## 5. Per-Agent-Per-Epic One-Shot Citation
+
+Once your model-identity has posted an epic-review comment, subsequent sub pickups from the same epic by the same identity cite the prior review by URL reference:
+
+> *Previously reviewed this epic: [comment URL]. Proceeding with sub pickup per `ticket-intake`.*
+
+This citation belongs in the `ticket-intake` reflection step for the sub, not as a new epic comment.
+
+## 6. Relationship to Sibling Skills
+
+| Skill | When | Scope | Relationship to epic-review |
+|---|---|---|---|
+| `ticket-create` | Epic birth | Creation-time | Produces the Fat Ticket body epic-review evaluates. Author-side vs reader-side — no overlap. |
+| `ticket-intake` | Sub pickup | Sub-scope | Epic-review runs *before* ticket-intake the first time your identity picks up any sub from this epic. After epic-review, ticket-intake proceeds per its own protocol. |
+| `pull-request` | PR creation | PR-scope | Orthogonal — epic-review does not interact with the PR layer. |
+| `pr-review` | PR validation | Post-work | Complementary — epic-review catches scope/approach drift *before* work; pr-review catches execution drift *after*. Different blast radius, different timing. |
+
+## 7. Anti-Patterns
+
+| Anti-pattern | Why it harms |
+|---|---|
+| Running all 5 stages unconditionally | Wastes effort on an epic that fails stage 1 or 2; defeats the gating structure |
+| Skipping epic-review because "I already read the epic body" | Epic-review is an **artifact**, not just comprehension — cross-model readback depends on the comment existing |
+| Per-sub-pickup epic-review | Per-agent-per-epic; cite the prior review, don't re-run |
+| Posting review as an issue body edit | Comments, not body edits — provenance and attribution live in comments |
+| Missing session ID footer | Breaks A2A provenance; the reviewer's Memory Core session is not queryable from the epic |
+| Heavyweight "approval" language | Epic-review is a discipline gate, not a formal sign-off — author and agent negotiate on comment thread |
+| Style-calibrating to another model | You are the reviewer you are; the cross-model asymmetry is the point |
+
+## 8. Cross-Model Asymmetry
+
+Different model families exhibit statistically-different failure modes when reviewing epics:
+
+- **Claude-family reviewers** tend toward over-rigor — may mark stage 5 gaps that don't need flagging, or question stage 2 elegance on subjective grounds.
+- **Gemini-family reviewers** tend toward quick-win framing — may pass stages 1-2 too quickly when an elegance concern warrants deeper review.
+
+These are **complementary** failure modes. Cross-model epic-review (same epic reviewed by a Claude identity and a Gemini identity) surfaces different dimensions of architectural risk. This is the value of per-model-identity independent reviews rather than deduplication.
+
+Do not calibrate your review to the "other model's style" — be the reviewer you are, and trust the asymmetry to compensate. If one model-family's reviews consistently miss a failure mode, the right fix is a skill enhancement (a new check in stages 1-5), not style mimicry.
+
+## 9. Verification Before Posting
+
+Before calling `manage_issue_comment`, confirm:
+
+- [ ] Stage ordering respected (1-2 gate 3-5)
+- [ ] Short form vs long form matches gating outcome
+- [ ] Session ID footer present
+- [ ] Comment references epic # correctly
+- [ ] Agent field self-identifies per `pr-review` convention
+- [ ] No adversarial or "proving-wrong" language — review targets architectural risk, not author competence
+- [ ] Verdict line is accurate (Greenlight / Revisions Requested / Block)
+
+If the review is a **Block** or **Revisions Requested**, the agent does not pick up subs from this epic until the blocking concern is resolved. File a follow-up comment or close the epic if the concern is load-bearing.

--- a/AGENTS_STARTUP.md
+++ b/AGENTS_STARTUP.md
@@ -303,6 +303,7 @@ Without this context, sub-agents will hallucinate bugs where none exist (e.g., c
 **Workflow skills (authoritative — read before invoking their respective tools):**
 - **Creating new tickets:** `.agent/skills/ticket-create/SKILL.md` — duplicate sweep, Fat Ticket body structure, title hygiene, label rules, visible-proposal protocol, five-stage challenge chain. Read before any `create_issue` invocation.
 - **Picking up existing tickets:** `.agent/skills/ticket-intake/SKILL.md` — validation sweep, ROI calculation, branch-before-code gate. Read before any `git checkout` on an assigned ticket.
+- **Reviewing an epic before picking up its subs:** `.agent/skills/epic-review/SKILL.md` — five-stage gating chain (roadmap fit, approach elegance, sub-structure coherence, prescription layer, avoided-traps completeness). Per-agent-per-epic one-shot; posts a structured comment on the epic ticket. Read before `ticket-intake` on any sub of an unreviewed epic.
 - **Opening pull requests:** `.agent/skills/pull-request/SKILL.md` — stepping-back reflection, conventional-commit format, ticket-ID suffix, handoff protocol. All code changes MUST culminate in a PR against `dev`; direct commits to `main`/`dev` are forbidden.
 - **Reviewing pull requests:** `.agent/skills/pr-review/SKILL.md` — structured evaluation metrics, graph ingestion tags, severity ladder. Human approval for squash-merge is required; agents MUST NOT autonomously merge their own PRs.
 


### PR DESCRIPTION
## Summary

Adds the `epic-review` skill — a pre-work review gate for epics with per-agent-per-epic one-shot semantics. Fires when an agent picks up its first sub from an unreviewed epic; produces a structured comment on the epic ticket; gates stages 1-2 (vision-fit + approach-elegance) before stages 3-5 (scope + prescription + traps).

Resolves #10154.

## Architectural Impact

### Blast radius gating

Sub errors cost 1 PR; `pr-review` catches them. Epic errors cost N subs before `pr-review` catches foundational drift on sub N. `epic-review` gates at the larger blast radius — catching scope or approach errors **before** any sub work begins, when the cost of pivoting is cheapest.

### Vision-fit before scope-coherence (load-bearing ordering)

Five-stage gating chain:
1. **Roadmap Fit** — does the epic belong in current strategic direction?
2. **Approach Elegance** — is the main architectural decision load-bearing, or is there a more elegant alternative?
3. **Sub-Structure Coherence** — do subs collectively close the epic's ACs? Overlaps / gaps / phase-boundary circularity?
4. **Prescription Layer** — is each sub at the right substrate? (Same challenges as `ticket-intake` applied across the sub-graph.)
5. **Avoided Traps Completeness** — what obvious wrong paths should the epic flag as rejected?

Stages 1-2 gate 3-5. Stage 1 failure halts all further stages and posts a roadmap-fit challenge. Stage 2 failure posts an alternative approach proposal. Only if 1-2 pass do 3-5 run in detail.

### Per-agent-per-epic one-shot

Epic-review fires once per model-identity per epic. Subsequent sub pickups from the same epic by the same identity **cite** the prior review by URL rather than re-running. Different model-identities reviewing the same epic is **encouraged** — cross-model readback of architectural intent is the primary value.

### Output is an artifact, not comprehension

Agents already internalize an epic silently before working its subs. Epic-review converts that internalization into a **structured comment** on the epic ticket. Three compounding returns: verifiable understanding, reusable artifact, cross-model readback.

## What's in This PR

- \`.agent/skills/epic-review/SKILL.md\` — lightweight router (Progressive Disclosure pattern per \`create-skill\` guide)
- \`.agent/skills/epic-review/references/epic-review-workflow.md\` — authoritative payload (5-stage chain, stop-condition semantics, comment format, sibling-skill relationships, anti-patterns, cross-model asymmetry, verification checklist)
- \`.agent/skills/epic-review/assets/epic-review-comment-template.md\` — short-form and long-form comment templates with inline HTML guidance
- \`AGENTS_STARTUP.md\` §9 — new bullet between \`ticket-intake\` and \`pull-request\` entries in the Workflow skills list

## Design Rationale

### Why skill-gated, not mechanical enforcement

Same philosophy as \`ticket-intake\` / \`pull-request\`: the skill documents the discipline, agents invoke at trigger moments. Mechanical enforcement (pre-pickup hook, comment-linter) was rejected — higher friction, inconsistent with existing workflow-skill pattern.

### Why per-agent-per-epic one-shot

First-pickup internalization is already required for an agent to work subs coherently. Artifact-ification of that internalization is free. Subsequent pickups cite prior review — avoids redundancy drag without losing provenance.

### Why stage 1-2 gating halts stages 3-5

If an epic is wrong for the roadmap or architecturally inelegant, the scope-coherence review of its current subs is wasted effort — those subs may be closed, restructured, or superseded. Cheaper to pivot the epic than to ship N subs on a shaky foundation.

### Why encourage multi-model review of the same epic

Claude-family and Gemini-family reviewers have statistically-different failure modes (over-rigor vs quick-win framing). Cross-model review surfaces complementary dimensions of architectural risk. Deduplication would lose this value; the skill explicitly calls this out.

## Edge Cases & Open Questions

- **Epic body changes after review** — skill documents re-run semantics when \`updatedAt\` exceeds comment timestamp. First empirical uses will show whether this is invoked correctly.
- **Two agents pick up subs simultaneously** — no dedup in v1; both comments land. If friction surfaces, v2 can add coordination.
- **Comment author identity before OAuth2 ships** — \`agent\` field on \`manage_issue_comment\` self-identifies per \`pr-review\` convention; post-OAuth2 (#10145) this will bind to AgentIdentity nodes natively via authenticated claims.
- **First empirical test** — Gemini using this skill on #10143 or #10016 post-merge. Calibration data from the first 2-3 uses will likely drive v1.1 iteration.

## Test Plan

- [ ] Gemini reviews this PR (first cross-model review pilot)
- [ ] Merge after Gemini approval
- [ ] Gemini picks up a sub from #10143 or #10016, invokes \`epic-review\` skill, posts structured comment on the epic
- [ ] Verify comment follows template, stage gating respected, session ID footer present
- [ ] Observe: does the skill surface insight (challenge, alternative, gap) or confirm alignment? Either outcome is valid; consistent silent passes for several epics would be a warning sign suggesting skill tightening.

## Related

- #10154 (this ticket — resolved by this PR)
- Discussion #10137 (MX paradigm — epic-review is MX-workflow infrastructure in motion)
- #10143, #10016, #10139 (empirical first-test candidates)
- Peer skills: \`.agent/skills/ticket-create\`, \`.agent/skills/ticket-intake\`, \`.agent/skills/pull-request\`, \`.agent/skills/pr-review\`
- Session context: \`71dc3cd8-d39d-48e1-ac62-e240ca67d1a5\` (workflow planning turn following the 11-ticket mailbox/identity/memory-first arc filing)