### PR TITLE
feat(ai): AgentIdentity node + GitHub account binding (#10144)

### DIFF
--- a/ai/scripts/seedAgentIdentities.mjs
+++ b/ai/scripts/seedAgentIdentities.mjs
@@ -63,7 +63,11 @@ async function seed() {
             Memory_GraphService.upsertNode(identity);
             console.log(`Created AgentIdentity: ${identity.id}`);
         } else {
-            // Fetch raw SQLite node to check if createdAt exists
+            // Defensive `createdAt` retention logic:
+            // We peek directly at the raw SQLite `Nodes` table to check if the existing node has a `createdAt` timestamp.
+            // This ensures an idempotent upsert without clobbering the creation-time provenance.
+            // If `upsertNode` semantics ever change to 'preserve existing properties if not in update payload', 
+            // this manual peek could be refactored or removed.
             let hasCreatedAt = false;
             if (Memory_GraphService.db && Memory_GraphService.db.storage) {
                 const stmt = Memory_GraphService.db.storage.db.prepare('SELECT data FROM Nodes WHERE id = ?');

--- a/ai/scripts/seedAgentIdentities.mjs
+++ b/ai/scripts/seedAgentIdentities.mjs
@@ -1,0 +1,100 @@
+/**
+ * @summary Seeds initial AgentIdentity nodes into the Neo.mjs Memory Core Native Graph.
+ * These nodes represent persistent identities for human owners and model agents.
+ * 
+ * Usage: node ai/scripts/seedAgentIdentities.mjs
+ */
+
+import { Memory_GraphService } from '../services.mjs';
+
+const IDENTITIES = [
+    {
+        id: '@neo-opus-4-7',
+        type: 'AgentIdentity',
+        name: 'Claude Opus 4.7',
+        description: 'Anthropic Claude Opus version 4.7 Agent Identity',
+        properties: {
+            githubLogin: '@neo-opus-4-7',
+            displayName: 'Claude Opus 4.7',
+            modelFamily: 'claude',
+            accountType: 'agent',
+            createdAt: new Date().toISOString()
+        }
+    },
+    {
+        id: '@neo-gemini-3-1-pro',
+        type: 'AgentIdentity',
+        name: 'Gemini 3.1 Pro',
+        description: 'Google Gemini 3.1 Pro Agent Identity',
+        properties: {
+            githubLogin: '@neo-gemini-3-1-pro',
+            displayName: 'Gemini 3.1 Pro',
+            modelFamily: 'gemini',
+            accountType: 'agent',
+            createdAt: new Date().toISOString()
+        }
+    },
+    {
+        id: '@tobiu',
+        type: 'AgentIdentity',
+        name: 'Tobias Uhlig',
+        description: 'Human Owner',
+        properties: {
+            githubLogin: '@tobiu',
+            displayName: 'Tobias Uhlig',
+            modelFamily: null,
+            accountType: 'human',
+            createdAt: new Date().toISOString()
+        }
+    }
+];
+
+async function seed() {
+    console.log('Bootstrapping Memory Graph Service...');
+    await Memory_GraphService.initAsync();
+    
+    console.log('Seeding Agent Identities...');
+    let seededCount = 0;
+    
+    for (const identity of IDENTITIES) {
+        const existing = Memory_GraphService.getNode({ id: identity.id });
+        
+        if (!existing) {
+            Memory_GraphService.upsertNode(identity);
+            console.log(`Created AgentIdentity: ${identity.id}`);
+        } else {
+            // Fetch raw SQLite node to check if createdAt exists
+            let hasCreatedAt = false;
+            if (Memory_GraphService.db && Memory_GraphService.db.storage) {
+                const stmt = Memory_GraphService.db.storage.db.prepare('SELECT data FROM Nodes WHERE id = ?');
+                const row = stmt.get(identity.id);
+                if (row && row.data) {
+                    try {
+                        const parsed = JSON.parse(row.data);
+                        if (parsed.properties && parsed.properties.createdAt) {
+                            hasCreatedAt = true;
+                        }
+                    } catch (e) {}
+                }
+            }
+
+            const propertiesToUpdate = { ...identity.properties };
+            if (hasCreatedAt) {
+                delete propertiesToUpdate.createdAt;
+            }
+
+            const updatedIdentity = { ...identity, properties: propertiesToUpdate };
+            Memory_GraphService.upsertNode(updatedIdentity);
+            console.log(`Updated AgentIdentity (${hasCreatedAt ? 'retained original' : 'added new'} createdAt): ${identity.id}`);
+        }
+        seededCount++;
+    }
+    
+    console.log(`Successfully processed ${seededCount} identities in the native graph.`);
+    process.exit(0);
+}
+
+seed().catch(err => {
+    console.error('Failed to seed AgentIdentities:', err);
+    process.exit(1);
+});

--- a/learn/agentos/IdentitySchema.md
+++ b/learn/agentos/IdentitySchema.md
@@ -1,0 +1,44 @@
+# AgentIdentity Graph Schema
+
+This document formalizes the `AgentIdentity` graph node schema within the Neo.mjs architectural graph database.
+
+## Architecture & Rationale
+
+The AgentOS Memory Core utilizes a persistent, hybrid semantic/graph database to link ephemeral conversation memory with structural repository data.
+
+To support the "Agent Experience" (MX) capabilities and fully attribute actions across long-lived Swarm intelligences, we provision explicit Identity nodes representing the actors interacting with the repository. 
+
+### Per-Model vs. Per-Version Account Binding
+
+A key design decision involved how to track model iterations (e.g., `gemini-3-pro` vs `gemini-3.1-pro` vs `gemini-4-pro`).
+
+**Decision:** We adopt a **Per-Model Identity** mapping (e.g. `@neo-gemini-3-1-pro`). 
+**Rationale:**
+1. **Low Churn:** Models undergo massive capability upgrades (like Gemini 3.0 to 3.1) which inherently change their reasoning processes. Tying accounts to distinct capabilities rather than an ambiguous parent prevents behavioral telemetry from becoming meaningless over time.
+2. **Cross-Session Traversal:** Explicit identity keys matching actual API accounts mean graph traversal queries (`MATCH (AgentIdentity {id: "@neo-opus-4-7"})-[:AUTHORED]->(Session)`) directly align with GitHub handles and PR authorship.
+3. **Traceability:** It provides full attribution via GitHub to a specific model version, establishing accountability for pull requests, code reviews, and autonomous system patches.
+
+## Schema Specification
+
+Each `AgentIdentity` node in the graph is structured with the following properties:
+
+| Property | Type | Description | Example |
+| :--- | :--- | :--- | :--- |
+| `id` | `String` | The unique primary key identifier, usually matching the GitHub login. | `'@neo-opus-4-7'` |
+| `type` / `label` | `String` | The graph node type. Must be `'AgentIdentity'`. | `'AgentIdentity'` |
+| `name` | `String` | Human-readable name. | `'Claude Opus 4.7'` |
+| `description` | `String` | A descriptive summary of the model and its role. | `'Anthropic Claude Opus version 4.7 Agent Identity'` |
+| `githubLogin` | `String` | The GitHub username representing the model. | `'@neo-opus-4-7'` |
+| `displayName` | `String` | Display name for UI consumption. | `'Claude Opus 4.7'` |
+| `modelFamily` | `String` | The underlying architectural family of the model. | `'claude'` |
+| `accountType` | `String` | The actor classification (`'agent'` or `'human'`). | `'agent'` |
+| `createdAt` | `ISO 8601 String` | Timestamp of node generation. Provisioning scripts retain this if the node exists. | `'2026-04-21T12:00:00.000Z'` |
+
+## Ingestion Mechanism
+
+Agent identities are seeded idempotently into the native graph using the `ai/scripts/seedAgentIdentities.mjs` utility. The script interacts with the `Memory_GraphService` to upsert nodes, taking care to preserve the original `createdAt` timestamp if updating existing properties.
+
+**Usage:**
+```bash
+node ai/scripts/seedAgentIdentities.mjs
+```

--- a/learn/agentos/IdentitySchema.md
+++ b/learn/agentos/IdentitySchema.md
@@ -6,7 +6,7 @@ This document formalizes the `AgentIdentity` graph node schema within the Neo.mj
 
 The AgentOS Memory Core utilizes a persistent, hybrid semantic/graph database to link ephemeral conversation memory with structural repository data.
 
-To support the "Agent Experience" (MX) capabilities and fully attribute actions across long-lived Swarm intelligences, we provision explicit Identity nodes representing the actors interacting with the repository. 
+To support the "Model Experience" (MX) capabilities — cf. Discussion #10137 for the distinction from Agent Experience (AX) — and fully attribute actions across long-lived Swarm intelligences, we provision explicit Identity nodes representing the actors interacting with the repository. 
 
 ### Per-Model vs. Per-Version Account Binding
 


### PR DESCRIPTION
This PR introduces the AgentIdentity graph node schema and a seed script to provision persistent identities in the Neo.mjs memory core graph.

### Architectural Impact
* Resolves #10144
* Adopts **per-model** identity binding (e.g. `@neo-opus-4-7`, `@neo-gemini-3-1-pro`) rather than ephemeral session-based or monolithic agent accounts. This ensures stability of accountability and traceability while supporting graph traversal aligned with GitHub author logs.
* Idempotent seeding mechanism correctly manages `createdAt` timestamps for pre-existing graph nodes vs. new ones.

### Files Modified
* `ai/scripts/seedAgentIdentities.mjs`: Idempotent provisioning script.
* `learn/agentos/IdentitySchema.md`: Formal documentation on schema parameters and the per-model binding rationale.

### Edge Cases Handled
* Properly checks for the existence of previous raw SQLite nodes to conditionally retain `createdAt` timestamps before performing standard `Memory_GraphService.upsertNode()` operations.