### PR TITLE
feat(ai): extract Gemma4 provenance edges (#10152)

### DIFF
--- a/ai/daemons/services/SemanticGraphExtractor.mjs
+++ b/ai/daemons/services/SemanticGraphExtractor.mjs
@@ -207,10 +207,19 @@ DO NOT output markdown, \`\`\`json blocks, or any other explanations. Provide pu
                     const targetsSessionOrMemory = resolvedTarget.startsWith('SESSION:') || resolvedTarget.startsWith('MEMORY:') || resolvedSource.startsWith('SESSION:') || resolvedSource.startsWith('MEMORY:');
                     
                     if (isProvenance && targetsSessionOrMemory) {
+                        /**
+                         * @summary Provenance Edge Lazy-Queue Strategy
+                         * Provenance edges (MENTIONED_IN, DISCUSSED_IN, REFERENCED_BY) linking to past sessions/memories 
+                         * may reference nodes not in the current payload or synchronous graph cache. 
+                         * Instead of dropping them as invalid, we route them to a JSONL backfill queue.
+                         * Consumer-side draining and retry logic is handled under Epic #10153.
+                         */
                         logger.info(`[SemanticGraphExtractor] Queuing unresolved provenance edge for lazy back-fill: ${resolvedSource} -> ${resolvedTarget}`);
-                        const lazyQueueFile = path.join('/tmp', 'neo_lazy_edges.json');
+                        const lazyQueueFile = aiConfig.lazyEdgesQueuePath;
                         const edgeData = JSON.stringify({ ...edge, source: resolvedSource, target: resolvedTarget, timestamp: new Date().toISOString() }) + '\n';
                         try {
+                            // Ensure the directory exists before appending
+                            await fs.promises.mkdir(path.dirname(lazyQueueFile), { recursive: true });
                             await fs.promises.appendFile(lazyQueueFile, edgeData, 'utf8');
                         } catch (err) {
                             logger.error('[SemanticGraphExtractor] Failed to queue lazy edge:', err);

--- a/ai/daemons/services/SemanticGraphExtractor.mjs
+++ b/ai/daemons/services/SemanticGraphExtractor.mjs
@@ -69,7 +69,7 @@ Enforce this STRICT JSON schema:
         {
           "source": "String (must match a node id, or 'frontier')",
           "target": "String (must match a node id, or 'frontier')",
-          "relationship": "String (MUST BE EXACTLY ONE OF: IMPLEMENTS, EXTENDS, DEPENDS_ON, BLOCKS, BLOCKED_BY, RELATES_TO, RESOLVES, CAUSES_ISSUE)",
+          "relationship": "String (MUST BE EXACTLY ONE OF: IMPLEMENTS, EXTENDS, DEPENDS_ON, BLOCKS, BLOCKED_BY, RELATES_TO, RESOLVES, CAUSES_ISSUE, MENTIONED_IN, DISCUSSED_IN, REFERENCED_BY)",
           "weight": 1.0,
           "justification": "String (Brief reason for this edge's algorithmic relevance)"
         }
@@ -77,6 +77,12 @@ Enforce this STRICT JSON schema:
     }
   }
 }
+
+PROVENANCE EDGES:
+When extracting entities, you MUST emit provenance edges linking them back to the source Memory or Session, for example:
+- MENTIONED_IN (Concept -> Memory:xyz)
+- DISCUSSED_IN (Class/Method -> Session:xyz)
+- REFERENCED_BY (Issue -> Memory:xyz)
 
 DO NOT output markdown, \`\`\`json blocks, or any other explanations. Provide purely the JSON object.`;
 
@@ -193,7 +199,25 @@ DO NOT output markdown, \`\`\`json blocks, or any other explanations. Provide pu
                 const targetNode = artifact.graph.nodes.find(n => n.id === edge.target);
                 if (targetNode && targetNode._resolvedId) resolvedTarget = targetNode._resolvedId;
 
-                if (!validNodeRefs.has(resolvedSource) || !validNodeRefs.has(resolvedTarget)) {
+                const sourceExists = validNodeRefs.has(resolvedSource) || GraphService.db.nodes.has(resolvedSource);
+                const targetExists = validNodeRefs.has(resolvedTarget) || GraphService.db.nodes.has(resolvedTarget);
+
+                if (!sourceExists || !targetExists) {
+                    const isProvenance = ['MENTIONED_IN', 'DISCUSSED_IN', 'REFERENCED_BY'].includes(edge.relationship);
+                    const targetsSessionOrMemory = resolvedTarget.startsWith('SESSION:') || resolvedTarget.startsWith('MEMORY:') || resolvedSource.startsWith('SESSION:') || resolvedSource.startsWith('MEMORY:');
+                    
+                    if (isProvenance && targetsSessionOrMemory) {
+                        logger.info(`[SemanticGraphExtractor] Queuing unresolved provenance edge for lazy back-fill: ${resolvedSource} -> ${resolvedTarget}`);
+                        const lazyQueueFile = path.join('/tmp', 'neo_lazy_edges.json');
+                        const edgeData = JSON.stringify({ ...edge, source: resolvedSource, target: resolvedTarget, timestamp: new Date().toISOString() }) + '\n';
+                        try {
+                            await fs.promises.appendFile(lazyQueueFile, edgeData, 'utf8');
+                        } catch (err) {
+                            logger.error('[SemanticGraphExtractor] Failed to queue lazy edge:', err);
+                        }
+                        continue;
+                    }
+
                     logger.warn(`[SemanticGraphExtractor] Culling hallucinated edge from ${resolvedSource} to ${resolvedTarget}`);
                     continue; // Skip trying to link non-existent graph nodes
                 }

--- a/ai/mcp/server/memory-core/config.template.mjs
+++ b/ai/mcp/server/memory-core/config.template.mjs
@@ -269,7 +269,12 @@ const defaultConfig = {
      * Universal JSONL backup/export directory for all databases.
      * @type {string}
      */
-    backupPath: path.resolve(cwd, '.neo-ai-data/backups')
+    backupPath: path.resolve(cwd, '.neo-ai-data/backups'),
+    /**
+     * Target file path for the lazy backfill queue of unresolved provenance edges.
+     * @type {string}
+     */
+    lazyEdgesQueuePath: process.env.NEO_LAZY_EDGES_QUEUE_PATH || path.resolve(cwd, 'ai/data/memory-core/lazy-edges.jsonl')
 };
 
 /**

--- a/test/playwright/unit/ai/daemons/DreamService.spec.mjs
+++ b/test/playwright/unit/ai/daemons/DreamService.spec.mjs
@@ -642,6 +642,7 @@ test.describe('Neo.ai.mcp.server.memory-core.services.DreamService', () => {
         GraphService.db.edges.getByIndex = (idx, val) => {
             return GraphService.db.edges.items.filter(e => e[idx] === val);
         };
+        const originalLinkNodes = GraphService.linkNodes;
         GraphService.linkNodes = () => {};
         GraphService.getContextFrontier = () => ({ nodes: [], edges: [] });
 
@@ -701,6 +702,7 @@ test.describe('Neo.ai.mcp.server.memory-core.services.DreamService', () => {
         } else {
              delete GraphService.db.storage.db.prepare;
         }
+        GraphService.linkNodes = originalLinkNodes;
     });
 
     test('should retry extraction on malformed JSON payload up to 3 times to fix #9913', async () => {

--- a/test/playwright/unit/ai/daemons/services/SemanticGraphExtractor.spec.mjs
+++ b/test/playwright/unit/ai/daemons/services/SemanticGraphExtractor.spec.mjs
@@ -1,0 +1,187 @@
+import {setup} from '../../../../setup.mjs';
+
+const appName = 'SemanticGraphExtractorTest';
+
+setup({
+    neoConfig: {
+        unitTestMode: true
+    },
+    appConfig: {
+        name             : appName,
+        isMounted        : () => true,
+        vnodeInitialising: false
+    }
+});
+
+import {test, expect} from '@playwright/test';
+import Neo            from '../../../../../../src/Neo.mjs';
+import * as core      from '../../../../../../src/core/_export.mjs';
+import fs             from 'fs';
+import path           from 'path';
+
+test.describe('Neo.ai.daemons.services.SemanticGraphExtractor', () => {
+    test.describe.configure({mode: 'serial'});
+
+    let GraphService;
+    let SemanticGraphExtractor;
+    let SystemLifecycleService;
+    let OpenAiCompatible;
+
+    const testDbName = `memory-core-semantic-extractor-test-${process.pid}-${Date.now()}.sqlite`;
+    let testDbPath;
+
+    test.beforeAll(async () => {
+        const aiConfig = (await import('../../../../../../ai/mcp/server/memory-core/config.mjs')).default;
+
+        const tmpDir = path.resolve(process.cwd(), 'tmp');
+        if (!fs.existsSync(tmpDir)) {
+            fs.mkdirSync(tmpDir, {recursive: true});
+        }
+        testDbPath = path.join(tmpDir, testDbName);
+
+        aiConfig.storagePaths.graph   = testDbPath;
+        aiConfig.autoIngestFileSystem = false;
+
+        GraphService           = (await import('../../../../../../ai/mcp/server/memory-core/services/GraphService.mjs')).default;
+        SemanticGraphExtractor = (await import('../../../../../../ai/daemons/services/SemanticGraphExtractor.mjs')).default;
+        SystemLifecycleService = (await import('../../../../../../ai/mcp/server/memory-core/services/lifecycle/SystemLifecycleService.mjs')).default;
+        OpenAiCompatible       = (await import('../../../../../../ai/provider/OpenAiCompatible.mjs')).default;
+
+        if (fs.existsSync(testDbPath)) {
+            try {
+                fs.unlinkSync(testDbPath);
+                if (fs.existsSync(`${testDbPath}-wal`)) fs.unlinkSync(`${testDbPath}-wal`);
+                if (fs.existsSync(`${testDbPath}-shm`)) fs.unlinkSync(`${testDbPath}-shm`);
+            } catch (e) {}
+        }
+
+        if (!SystemLifecycleService._initPromise) {
+            await SystemLifecycleService.initAsync();
+        } else {
+            await SystemLifecycleService.ready();
+        }
+    });
+
+    test.beforeEach(() => {
+        if (GraphService.db) {
+            GraphService.db.nodes.clear();
+            GraphService.db.edges.clear();
+            GraphService.db.vicinityLoadedNodes.clear();
+
+            if (GraphService.db.storage?.db) {
+                GraphService.db.storage.clear();
+                GraphService.db.storage.db.exec('DELETE FROM GraphLog');
+                GraphService.db.lastSyncId = 0;
+            }
+        }
+    });
+
+    test.afterEach(() => {
+        if (GraphService.db) {
+            GraphService.db.nodes.clear();
+            GraphService.db.edges.clear();
+            GraphService.db.vicinityLoadedNodes.clear();
+            if (GraphService.db.storage?.db) {
+                GraphService.db.storage.clear();
+                GraphService.db.storage.db.exec('DELETE FROM GraphLog');
+                GraphService.db.lastSyncId = 0;
+            }
+        }
+    });
+
+    test.afterAll(() => {
+        if (GraphService?.db) {
+            if (GraphService.db.storage?.db) {
+                try { GraphService.db.storage.db.close(); } catch (e) {}
+            }
+            GraphService.db           = null;
+            GraphService._initPromise = null;
+        }
+
+        if (SystemLifecycleService) {
+            SystemLifecycleService._initPromise = null;
+        }
+
+        if (fs.existsSync(testDbPath)) {
+            try { fs.unlinkSync(testDbPath); } catch (e) {}
+            if (fs.existsSync(`${testDbPath}-wal`)) try { fs.unlinkSync(`${testDbPath}-wal`); } catch (e) {}
+            if (fs.existsSync(`${testDbPath}-shm`)) try { fs.unlinkSync(`${testDbPath}-shm`); } catch (e) {}
+        }
+    });
+
+    test('should extract provenance edges and queue unresolved targets to lazy back-fill (#10152)', async () => {
+        const baseGenerate = OpenAiCompatible.prototype.generate;
+        
+        OpenAiCompatible.prototype.generate = async function(messages) {
+            return {
+                content: JSON.stringify({
+                    a2a_version: "1.0",
+                    agent_id: "Antigravity",
+                    session_artifact: {
+                        graph: {
+                            nodes: [
+                                {
+                                    id: "CONCEPT:TestConcept",
+                                    type: "CONCEPT",
+                                    name: "TestConcept",
+                                    description: "Test concept for provenance edges"
+                                }
+                            ],
+                            edges: [
+                                {
+                                    source: "CONCEPT:TestConcept",
+                                    target: "MEMORY:non-existent-memory",
+                                    relationship: "MENTIONED_IN",
+                                    weight: 1.0,
+                                    justification: "Provenance test"
+                                },
+                                {
+                                    source: "CONCEPT:TestConcept",
+                                    target: "frontier",
+                                    relationship: "RELATES_TO"
+                                }
+                            ]
+                        }
+                    }
+                })
+            };
+        };
+
+        const session = {
+            id: 'mock-semantic-vector-id',
+            meta: { sessionId: 'playwright-provenance-test' },
+            document: "Mock episodic history for provenance"
+        };
+
+        const lazyQueueFile = path.join('/tmp', 'neo_lazy_edges.json');
+        if (fs.existsSync(lazyQueueFile)) {
+            fs.unlinkSync(lazyQueueFile);
+        }
+
+        const result = await SemanticGraphExtractor.executeTriVectorExtraction(session);
+
+        expect(result).not.toBeNull();
+        expect(result.session_artifact.graph.edges.length).toBe(2);
+
+        // Check if the lazy queue file was created and contains the edge
+        expect(fs.existsSync(lazyQueueFile)).toBe(true);
+        const queueContent = fs.readFileSync(lazyQueueFile, 'utf8');
+        expect(queueContent).toContain('"relationship":"MENTIONED_IN"');
+        expect(queueContent).toContain('"target":"MEMORY:non-existent-memory"');
+
+        // Check if RELATES_TO edge was added to the GraphService (since frontier exists)
+        const edges = GraphService.db.edges.items;
+        expect(edges.some(e => e.type === 'RELATES_TO' && e.source === 'CONCEPT:TestConcept')).toBe(true);
+        
+        // MENTIONED_IN shouldn't be in the DB directly because it targets a non-existent node
+        expect(edges.some(e => e.type === 'MENTIONED_IN')).toBe(false);
+
+        // Restore global function
+        OpenAiCompatible.prototype.generate = baseGenerate;
+        
+        // Cleanup
+        if (fs.existsSync(lazyQueueFile)) {
+            fs.unlinkSync(lazyQueueFile);
+        }
+    });
+});

--- a/test/playwright/unit/ai/daemons/services/SemanticGraphExtractor.spec.mjs
+++ b/test/playwright/unit/ai/daemons/services/SemanticGraphExtractor.spec.mjs
@@ -26,12 +26,13 @@ test.describe('Neo.ai.daemons.services.SemanticGraphExtractor', () => {
     let SemanticGraphExtractor;
     let SystemLifecycleService;
     let OpenAiCompatible;
+    let aiConfig;
 
     const testDbName = `memory-core-semantic-extractor-test-${process.pid}-${Date.now()}.sqlite`;
     let testDbPath;
 
     test.beforeAll(async () => {
-        const aiConfig = (await import('../../../../../../ai/mcp/server/memory-core/config.mjs')).default;
+        aiConfig = (await import('../../../../../../ai/mcp/server/memory-core/config.mjs')).default;
 
         const tmpDir = path.resolve(process.cwd(), 'tmp');
         if (!fs.existsSync(tmpDir)) {
@@ -137,6 +138,13 @@ test.describe('Neo.ai.daemons.services.SemanticGraphExtractor', () => {
                                 },
                                 {
                                     source: "CONCEPT:TestConcept",
+                                    target: "SESSION:non-existent-session",
+                                    relationship: "DISCUSSED_IN",
+                                    weight: 1.0,
+                                    justification: "Provenance test 2"
+                                },
+                                {
+                                    source: "CONCEPT:TestConcept",
                                     target: "frontier",
                                     relationship: "RELATES_TO"
                                 }
@@ -153,7 +161,7 @@ test.describe('Neo.ai.daemons.services.SemanticGraphExtractor', () => {
             document: "Mock episodic history for provenance"
         };
 
-        const lazyQueueFile = path.join('/tmp', 'neo_lazy_edges.json');
+        const lazyQueueFile = aiConfig.lazyEdgesQueuePath;
         if (fs.existsSync(lazyQueueFile)) {
             fs.unlinkSync(lazyQueueFile);
         }
@@ -161,13 +169,15 @@ test.describe('Neo.ai.daemons.services.SemanticGraphExtractor', () => {
         const result = await SemanticGraphExtractor.executeTriVectorExtraction(session);
 
         expect(result).not.toBeNull();
-        expect(result.session_artifact.graph.edges.length).toBe(2);
+        expect(result.session_artifact.graph.edges.length).toBe(3);
 
         // Check if the lazy queue file was created and contains the edge
         expect(fs.existsSync(lazyQueueFile)).toBe(true);
         const queueContent = fs.readFileSync(lazyQueueFile, 'utf8');
         expect(queueContent).toContain('"relationship":"MENTIONED_IN"');
         expect(queueContent).toContain('"target":"MEMORY:non-existent-memory"');
+        expect(queueContent).toContain('"relationship":"DISCUSSED_IN"');
+        expect(queueContent).toContain('"target":"SESSION:non-existent-session"');
 
         // Check if RELATES_TO edge was added to the GraphService (since frontier exists)
         const edges = GraphService.db.edges.items;


### PR DESCRIPTION
## Agent Identity
- **Agent:** Antigravity (Gemini 3.1 Pro)
- **Origin Session ID:** ada4aecb-60fc-4b25-a76b-cb92600835a2
- **Epic:** #9999

## Target Issue
Fixes #10152

## Summary of Changes
- Updated `SemanticGraphExtractor.mjs` systemInstruction prompt to mandate `MENTIONED_IN`, `DISCUSSED_IN`, and `REFERENCED_BY` provenance edges.
- Implemented edge validation logic that checks the global database and queues unresolved provenance edges for lazy back-fill in `/tmp/neo_lazy_edges.json`.
- Awaited the `fs.promises.appendFile` for the lazy edge queue to ensure durability.
- Added `SemanticGraphExtractor.spec.mjs` to verify provenance edge validation and lazy backfill.
- Fixed `GraphService.linkNodes` test leak in `DreamService.spec.mjs`.