### PR TITLE
feat(ai): wire stdio identity + anti-spoof guard for Memory Core MCP (#10145)

### DIFF
--- a/ai/mcp/server/memory-core/Server.mjs
+++ b/ai/mcp/server/memory-core/Server.mjs
@@ -3,10 +3,14 @@ import {CallToolRequestSchema, ListToolsRequestSchema} from '@modelcontextprotoc
 import Base                                            from '../../../../src/core/Base.mjs';
 import aiConfig                                        from './config.mjs';
 import logger                                          from './logger.mjs';
+import GraphService                                    from './services/GraphService.mjs';
 import HealthService                                   from './services/HealthService.mjs';
 import SessionService                                  from './services/SessionService.mjs';
 import InferenceLifecycleService                       from './services/lifecycle/InferenceLifecycleService.mjs';
 import {listTools, callTool}                           from './services/toolService.mjs';
+import AuthMiddleware                                  from '../shared/services/AuthMiddleware.mjs';
+import RequestContextService                           from '../shared/services/RequestContextService.mjs';
+import StdioIdentityResolver                           from '../shared/services/StdioIdentityResolver.mjs';
 
 /**
  * @summary The Memory Core MCP Server application.
@@ -40,6 +44,15 @@ class Server extends Base {
      * @protected
      */
     mcpServer = null
+    /**
+     * Resolved agent identity for stdio transport sessions (ticket #10145). Populated at
+     * `initAsync()` time via `StdioIdentityResolver` + AgentIdentity graph-node binding. Null
+     * when running under SSE transport (identity flows per-request via `AuthService` /
+     * `RequestContextService` instead) or when stdio resolution yielded no identity.
+     * @member {Object|null} stdioIdentity=null
+     * @protected
+     */
+    stdioIdentity = null
 
     /**
      * Async initialization sequence.
@@ -93,13 +106,135 @@ class Server extends Base {
                 resourceName: 'neo-memory-core MCP'
             });
         } else {
+            // Resolve stdio identity before connecting the transport (ticket #10145). The
+            // resolved context is cached on this.stdioIdentity and wrapped around every
+            // CallToolRequestSchema dispatch so downstream services (e.g. MemoryService) read
+            // a consistent identity via RequestContextService.getUserId(). SSE mode skips
+            // this path — TransportService performs the equivalent wrap per-request using
+            // OIDC-derived identity.
+            this.stdioIdentity = await this.resolveStdioIdentity();
+
             const {StdioServerTransport} = await import('@modelcontextprotocol/sdk/server/stdio.js');
             const transport = new StdioServerTransport();
             await this.mcpServer.connect(transport);
 
             logger.info('[neo-memory-core MCP] Server started on stdio transport');
             logger.info('[neo-memory-core MCP] Available tools loaded from OpenAPI spec');
+            this.logIdentityStatus();
         }
+    }
+
+    /**
+     * Resolves the active stdio agent identity and binds it to its AgentIdentity graph node.
+     *
+     * Composes three steps: (1) `StdioIdentityResolver.resolve()` returns the GitHub identity
+     * via the env-var → gh-CLI chain; (2) `GraphService.getNode({id: '@' + githubLogin})`
+     * looks up the matching seeded AgentIdentity node (#10144 convention); (3) the composite
+     * is shaped for `RequestContextService.run()` consumption.
+     *
+     * Missing graph node is non-fatal: the identity still flows as `userId` tag, but
+     * `agentIdentityNodeId` is null. Unseeded agents can write memories — they just can't yet
+     * terminate `AUTHORED_BY` edges on a graph node until someone adds them via
+     * `seedAgentIdentities.mjs`.
+     *
+     * @returns {Promise<Object|null>} Context object for `RequestContextService.run()`, or
+     *     `null` when resolution yielded no identity (single-tenant fallthrough).
+     * @protected
+     */
+    async resolveStdioIdentity() {
+        const resolved = await StdioIdentityResolver.resolve();
+
+        if (!resolved.githubLogin) {
+            return null;
+        }
+
+        const agentIdentityNodeId = await this.bindAgentIdentity(resolved.githubLogin);
+
+        return {
+            userId             : resolved.githubLogin,
+            username           : resolved.username,
+            agentIdentityNodeId,
+            source             : resolved.source
+        };
+    }
+
+    /**
+     * Builds the RequestContext for an SSE-transport request. Invoked by `TransportService.setup`
+     * via duck-typed hook — shared transport code checks `typeof server.buildRequestContext ===
+     * 'function'` and calls it once the OIDC-introspected `req.auth` is available. Returning
+     * `{}` when no identity is present preserves the single-tenant fallthrough semantics.
+     *
+     * This is the SSE analog of `resolveStdioIdentity()` — both paths end at a context shape
+     * `RequestContextService.run()` accepts, both bind `agentIdentityNodeId` via the same
+     * `bindAgentIdentity()` helper, and both tag the `source` provenance field.
+     *
+     * @param {Object|undefined} reqAuth The auth context populated by `AuthService.verifyAccessToken`.
+     *     Keys: `{userId, username, source: 'oidc', ...}`. Undefined when the SSE request
+     *     arrived with OIDC disabled (local dev).
+     * @returns {Promise<Object>} RequestContext shape; `{}` when no identity is resolvable.
+     * @protected
+     */
+    async buildRequestContext(reqAuth) {
+        if (!reqAuth?.userId) {
+            return {};
+        }
+
+        const agentIdentityNodeId = await this.bindAgentIdentity(reqAuth.userId);
+
+        return {
+            userId             : reqAuth.userId,
+            username           : reqAuth.username,
+            agentIdentityNodeId,
+            source             : reqAuth.source || 'oidc'
+        };
+    }
+
+    /**
+     * Resolves a bare GitHub login to its seeded AgentIdentity graph node ID (per ticket
+     * #10144's `@`-prefixed ID convention). Shared between `resolveStdioIdentity` (stdio boot)
+     * and `buildRequestContext` (per-SSE-request) so both transports reach the same node
+     * lookup behavior.
+     *
+     * Missing node is non-fatal: returns `null`. Downstream services that build `AUTHORED_BY`
+     * graph edges treat `null` as "skip edge creation for this write" rather than failing
+     * the write — unseeded agents can still accumulate memories.
+     *
+     * @param {String|undefined|null} userId The bare GitHub login (no `@` prefix).
+     * @returns {Promise<String|null>} The AgentIdentity node ID or `null` if unresolvable.
+     * @protected
+     */
+    async bindAgentIdentity(userId) {
+        if (!userId) {
+            return null;
+        }
+
+        const graphNodeId = '@' + userId;
+
+        try {
+            // Ensure the graph is fully loaded before the lookup. Without this await a
+            // cold-boot race would silently miss seeded identity nodes.
+            await GraphService.ready();
+            return GraphService.getNode({id: graphNodeId})?.id || null;
+        } catch (error) {
+            logger.warn(`[neo-memory-core MCP] AgentIdentity graph lookup failed for ${graphNodeId}: ${error.message}`);
+            return null;
+        }
+    }
+
+    /**
+     * Logs the resolved stdio identity state during startup for operator visibility.
+     * @protected
+     */
+    logIdentityStatus() {
+        if (!this.stdioIdentity) {
+            logger.info('[neo-memory-core MCP] Identity: unresolved (single-tenant fallthrough)');
+            return;
+        }
+
+        const {userId, agentIdentityNodeId, source} = this.stdioIdentity;
+        const bound                                 = agentIdentityNodeId ? `bound to ${agentIdentityNodeId}` : 'unbound (no matching AgentIdentity node)';
+
+        logger.info(`[neo-memory-core MCP] Identity: ${userId} via ${source} — ${bound}`);
     }
 
     /**
@@ -176,6 +311,11 @@ class Server extends Base {
             try {
                 logger.debug(`[MCP] Calling tool: ${name} with args:`, JSON.stringify(args));
 
+                // Anti-spoof guard (ticket #10145): reject any tool-call argument that would
+                // let the client override server-stamped identity. No-op on existing tool
+                // schemas; activates once Mailbox (#10139) adds `from` fields.
+                AuthMiddleware.validateNoIdentitySpoof(args);
+
                 const exemptFromHealthCheck = ['healthcheck', 'start_database', 'stop_database'];
 
                 if (!exemptFromHealthCheck.includes(name)) {
@@ -193,7 +333,16 @@ class Server extends Base {
                     }
                 }
 
-                const result = await callTool(name, args);
+                // Wrap the tool dispatch in RequestContextService.run() when a stdio identity
+                // was resolved (ticket #10145). This establishes the AsyncLocalStorage-scoped
+                // context that MemoryService.addMemory, etc. read via getUserId() to tag
+                // ChromaDB writes per tenant. SSE mode leaves stdioIdentity null because
+                // TransportService has already wrapped the /mcp request with per-request OIDC
+                // identity — re-wrapping here would clobber that context.
+                const dispatch = () => callTool(name, args);
+                const result   = this.stdioIdentity
+                    ? await RequestContextService.run(this.stdioIdentity, dispatch)
+                    : await dispatch();
 
                 let contentBlock;
                 let isError           = false;

--- a/ai/mcp/server/shared/services/AuthMiddleware.mjs
+++ b/ai/mcp/server/shared/services/AuthMiddleware.mjs
@@ -1,0 +1,111 @@
+import Base from '../../../../../src/core/Base.mjs';
+
+/**
+ * Set of argument keys that an MCP tool caller MUST NOT supply — the server always derives
+ * these from the active `RequestContextService` (OIDC Bearer token for SSE, stdio env-var /
+ * gh-CLI resolution per ticket #10145). Client-supplied values would let a Gemini-harness
+ * session forge a write attributed to `@neo-opus-4-7`, etc.
+ *
+ * **Scope note:** `recipient` / `to` fields are legitimate (destination address, not claim-of-
+ * authorship). Only claim-of-authorship fields belong here.
+ * @private
+ */
+const IDENTITY_OVERRIDE_KEYS = new Set([
+    'userId',
+    'agentId',
+    'agentIdentityNodeId',
+    'githubLogin',
+    'from',
+    'sender',
+    'authorLogin'
+]);
+
+/**
+ * @summary Thin argument-level anti-spoof middleware for MCP tool calls.
+ *
+ * Lives at the `callTool` dispatch choke-point. Rejects any tool-call whose arguments include
+ * a key that would let the client override server-stamped identity. Complements
+ * `AuthService` (OIDC transport-level authentication) and `RequestContextService` (identity
+ * propagation) — the three services together close the **multi-tenant anti-spoof** invariant:
+ *
+ * - `AuthService` / `StdioIdentityResolver` establish WHO the caller is.
+ * - `RequestContextService` propagates that identity into the service-method call chain.
+ * - `AuthMiddleware` blocks any tool-argument path that could contradict the propagated identity.
+ *
+ * **Present-day behavior:** no current MCP tool schema exposes any of the forbidden keys, so
+ * this middleware is a no-op on every live tool call. It exists as **defense-in-depth** for
+ * upcoming additions — particularly Mailbox (#10139) which adds `from` fields where the spoof
+ * surface becomes real. Shipping the guard before the surface is the inverse of "patch after
+ * incident" hygiene.
+ *
+ * **Not in scope:**
+ * - OIDC token verification — that's `AuthService`
+ * - Identity propagation — that's `RequestContextService`
+ * - Per-tenant read-filter enforcement — that's the service layer (e.g. `MemoryService.listMemories`
+ *   applies `where: {userId}` via `RequestContextService.getUserId()`)
+ *
+ * This class is a key example of the framework's **multi-tenant anti-spoof** model and
+ * demonstrates concepts like **agent identity**, **write-path integrity**, and
+ * **defense-in-depth**.
+ *
+ * @class Neo.ai.mcp.server.shared.services.AuthMiddleware
+ * @extends Neo.core.Base
+ * @singleton
+ * @see Neo.ai.mcp.server.shared.services.AuthService
+ * @see Neo.ai.mcp.server.shared.services.RequestContextService
+ * @see Neo.ai.mcp.server.shared.services.StdioIdentityResolver
+ */
+class AuthMiddleware extends Base {
+    static config = {
+        /**
+         * @member {String} className='Neo.ai.mcp.server.shared.services.AuthMiddleware'
+         * @protected
+         */
+        className: 'Neo.ai.mcp.server.shared.services.AuthMiddleware',
+        /**
+         * @member {Boolean} singleton=true
+         * @protected
+         */
+        singleton: true
+    }
+
+    /**
+     * Inspects the tool-call `args` for any forbidden identity-override key. Throws on a hit;
+     * returns normally on clean args.
+     *
+     * **Why throw instead of return an error payload:** the caller is `CallToolRequestSchema`'s
+     * handler in each MCP server's `Server.mjs`, which already has a uniform `try`/`catch` that
+     * converts thrown errors into MCP error responses. Throwing keeps the middleware stateless
+     * and preserves the existing error-shape contract.
+     *
+     * @param {Object|null|undefined} args Raw tool-call arguments.
+     * @throws {Error} When `args` contains a key listed in {@link IDENTITY_OVERRIDE_KEYS}.
+     */
+    validateNoIdentitySpoof(args) {
+        if (!args || typeof args !== 'object') {
+            return;
+        }
+
+        for (const key of Object.keys(args)) {
+            if (IDENTITY_OVERRIDE_KEYS.has(key)) {
+                throw new Error(
+                    `Identity-override spoof rejected: '${key}' is a server-stamped field. ` +
+                    `Remove it from tool arguments; the caller identity is derived from the ` +
+                    `active RequestContext (OIDC Bearer token for SSE, NEO_AGENT_IDENTITY or ` +
+                    `gh-CLI resolution for stdio). See learn/agentos/tooling/MemoryCoreMcpAuth.md.`
+                );
+            }
+        }
+    }
+
+    /**
+     * Returns a copy of the forbidden identity-override key set for testability and for
+     * documentation tooling. Do not mutate the returned collection.
+     * @returns {Set<String>}
+     */
+    getIdentityOverrideKeys() {
+        return new Set(IDENTITY_OVERRIDE_KEYS);
+    }
+}
+
+export default Neo.setupClass(AuthMiddleware);

--- a/ai/mcp/server/shared/services/AuthService.mjs
+++ b/ai/mcp/server/shared/services/AuthService.mjs
@@ -173,7 +173,10 @@ class AuthService extends Base {
                     scopes   : data.scope ? data.scope.split(' ') : [],
                     expiresAt: data.exp,
                     userId,
-                    username
+                    username,
+                    // Provenance tag consumed by `RequestContextService.getSource()` (#10145).
+                    // Distinguishes OIDC-derived identity from stdio env-var / gh-CLI paths.
+                    source   : 'oidc'
                 };
             }
         };

--- a/ai/mcp/server/shared/services/RequestContextService.mjs
+++ b/ai/mcp/server/shared/services/RequestContextService.mjs
@@ -10,20 +10,29 @@ import Base                from '../../../../../src/core/Base.mjs';
  * a Neo singleton so services can read request-scoped identity — `userId`, `username` — without
  * any of the primitive leaking into their method signatures.
  *
- * **Identity flow (Epic #9999, sub-epic #10016, ticket #10000):**
+ * **Identity flow (Epic #9999, sub-epic #10016, tickets #10000 + #10145):**
  *
- * 1. `AuthService.verifyAccessToken` validates the incoming Bearer token via OIDC introspection
- *    and returns `{userId, username, ...}` on the auth context, extracted from the introspection
- *    response's `preferred_username` / `sub` / `name` / `email` claims.
- * 2. `TransportService` wraps each `/mcp` request with `RequestContextService.run({userId,
- *    username}, () => transport.handleRequest(req, res, req.body))` — establishes the
- *    request-scoped context before the MCP transport dispatches the JSON-RPC call.
- * 3. Service methods (`MemoryService.addMemory`, `SummaryService.querySummaries`, etc.) call
- *    `RequestContextService.getUserId()` and either tag ChromaDB writes with `metadata.userId`
- *    or apply `where: {userId}` filters on reads — per the multi-tenant isolation contract.
- * 4. In **stdio transport mode** no middleware runs, so `getUserId()` returns `undefined`.
- *    Services treat this as **single-tenant mode** (backward-compatible) — no tag on writes,
- *    no filter on reads. This preserves the local-agent development experience unchanged.
+ * 1. **SSE transport (#10000):** `AuthService.verifyAccessToken` validates the incoming Bearer
+ *    token via OIDC introspection and returns `{userId, username, ...}` on the auth context,
+ *    extracted from the introspection response's `preferred_username` / `sub` / `name` /
+ *    `email` claims. `TransportService` wraps each `/mcp` request with
+ *    `RequestContextService.run({userId, username, agentIdentityNodeId, source: 'oidc'}, ...)`.
+ * 2. **Stdio transport (#10145):** `StdioIdentityResolver` resolves identity at server boot
+ *    via `NEO_AGENT_IDENTITY` env-var or `gh api user` CLI fallback. The memory-core `Server`
+ *    looks up the matching AgentIdentity graph node (per ticket #10144), then wraps every
+ *    `CallToolRequestSchema` dispatch with `RequestContextService.run({userId, username,
+ *    agentIdentityNodeId, source: 'env-var' | 'gh-cli'}, ...)`. Stdio now reaches parity with
+ *    SSE — per-agent GitHub account pinning tags writes with the correct tenant regardless of
+ *    transport.
+ * 3. **Service-layer consumption:** `MemoryService.addMemory`, `SummaryService.querySummaries`,
+ *    etc. call `RequestContextService.getUserId()` and either tag ChromaDB writes with
+ *    `metadata.userId` or apply `where: {userId}` filters on reads. Graph-edge-writing services
+ *    additionally call `getAgentIdentityNodeId()` to terminate `AUTHORED_BY` / `OWNED_BY` edges
+ *    on the correct identity node.
+ * 4. **Unresolved-identity fallthrough:** when neither transport resolves a userId (stdio with
+ *    neither env-var nor authenticated `gh` CLI, offline daemon contexts), `getUserId()` returns
+ *    `undefined` and services fall back to **single-tenant mode** — no tag on writes, no filter
+ *    on reads. Backward-compatible with pre-#10145 behavior.
  *
  * **Why AsyncLocalStorage and not explicit parameter threading:** userId is a cross-cutting
  * concern that every ChromaDB touch point cares about. Threading it as a parameter through
@@ -68,12 +77,29 @@ class RequestContextService extends Base {
     /**
      * Runs `callback` with the supplied context scoped to the active async call stack.
      *
-     * @param {Object}   context            The request-scoped context to expose.
-     * @param {String}   [context.userId]   The authenticated user's identifier (from OIDC
-     *                                      `preferred_username` or `sub`). Undefined when
-     *                                      no auth is active (stdio mode, localhost dev).
-     * @param {String}   [context.username] Human-readable display name for logging.
-     * @param {Function} callback           The async work to execute inside the context.
+     * @param {Object}   context                      The request-scoped context to expose.
+     * @param {String}   [context.userId]             The authenticated user's identifier (from
+     *                                                OIDC `preferred_username` / `sub`, or the
+     *                                                `StdioIdentityResolver` env-var / gh-CLI
+     *                                                chain in stdio mode). Undefined when no
+     *                                                identity is resolvable — services treat
+     *                                                that as single-tenant fallthrough.
+     * @param {String}   [context.username]           Human-readable display name for logging.
+     * @param {String}   [context.agentIdentityNodeId] ID of the bound AgentIdentity graph node
+     *                                                (per ticket #10144's seed convention:
+     *                                                `@`-prefixed GitHub login). Populated when
+     *                                                the resolved identity matches a seeded
+     *                                                node in the Native Edge Graph. Null when
+     *                                                the identity is unbound (e.g. unseeded
+     *                                                agent or stdio `unresolved` source).
+     * @param {String}   [context.source]             Provenance tag indicating where this
+     *                                                identity originated: `'oidc'` (SSE bearer
+     *                                                token), `'env-var'` (stdio
+     *                                                `NEO_AGENT_IDENTITY`), `'gh-cli'` (stdio
+     *                                                `gh api user` fallback), or `'unresolved'`.
+     *                                                Useful for auditability and debugging; not
+     *                                                used for isolation decisions.
+     * @param {Function} callback                     The async work to execute inside the context.
      * @returns {*} Whatever `callback` returns.
      */
     run(context, callback) {
@@ -90,8 +116,9 @@ class RequestContextService extends Base {
 
     /**
      * Convenience accessor for the authenticated user's identifier. Returns `undefined` when
-     * no request context is active (stdio transport, offline daemons) — call sites treat
-     * `undefined` as **single-tenant mode** and skip userId-based tagging / filtering.
+     * no request context is active (stdio transport without identity resolution, offline
+     * daemons) — call sites treat `undefined` as **single-tenant mode** and skip userId-based
+     * tagging / filtering.
      * @returns {String|undefined}
      */
     getUserId() {
@@ -106,6 +133,28 @@ class RequestContextService extends Base {
      */
     getUsername() {
         return this.storage.getStore()?.username
+    }
+
+    /**
+     * Convenience accessor for the bound AgentIdentity graph-node ID (per ticket #10144).
+     * Services building `AUTHORED_BY` / `OWNED_BY` edges at write time use this to terminate
+     * edges on the correct identity node. Returns `undefined` when no context is active, and
+     * `null` when context is active but the resolved identity has no matching AgentIdentity
+     * node in the graph (unseeded agent, new human user, etc.).
+     * @returns {String|null|undefined}
+     */
+    getAgentIdentityNodeId() {
+        return this.storage.getStore()?.agentIdentityNodeId
+    }
+
+    /**
+     * Convenience accessor for the identity-resolution provenance tag. One of `'oidc'`,
+     * `'env-var'`, `'gh-cli'`, `'unresolved'`, or `undefined` (no context). Used for
+     * auditability and debug logging — NOT for isolation decisions (use `getUserId()`).
+     * @returns {String|undefined}
+     */
+    getSource() {
+        return this.storage.getStore()?.source
     }
 }
 

--- a/ai/mcp/server/shared/services/StdioIdentityResolver.mjs
+++ b/ai/mcp/server/shared/services/StdioIdentityResolver.mjs
@@ -110,12 +110,15 @@ class StdioIdentityResolver extends Base {
             let output = execSync('gh api user', {
                 encoding: 'utf8',
                 stdio   : ['ignore', 'pipe', 'ignore'],
-                // 5s matches the MCP client-side init-handshake budget. A shorter budget (3s)
-                // risks consuming so much of the handshake that the client times out before the
-                // server finishes `initAsync` — particularly on stale auth tokens or proxied
-                // networks. A `gh` that can't answer in 5s is effectively broken — the
-                // unresolved-fallthrough path is the right destination.
-                timeout : 5000
+                // 1.5s fail-fast budget. A healthy `gh api user` resolves in <200ms; a call
+                // that takes longer is likely hanging on auth refresh or a degraded network.
+                // The MCP client-side init-handshake budget is ~5s TOTAL — it includes this
+                // call PLUS ChromaDB health checks, SystemLifecycleService.ready(),
+                // GraphService.ready(), and transport connect. Matching the gh timeout to the
+                // full budget would consume 100% on a hang, guaranteeing client timeout. Fail
+                // fast to unresolved-fallthrough (single-tenant mode) instead; agent harnesses
+                // that care about identity fidelity set `NEO_AGENT_IDENTITY` explicitly.
+                timeout : 1500
             });
 
             return JSON.parse(output)

--- a/ai/mcp/server/shared/services/StdioIdentityResolver.mjs
+++ b/ai/mcp/server/shared/services/StdioIdentityResolver.mjs
@@ -110,7 +110,12 @@ class StdioIdentityResolver extends Base {
             let output = execSync('gh api user', {
                 encoding: 'utf8',
                 stdio   : ['ignore', 'pipe', 'ignore'],
-                timeout : 3000
+                // 5s matches the MCP client-side init-handshake budget. A shorter budget (3s)
+                // risks consuming so much of the handshake that the client times out before the
+                // server finishes `initAsync` — particularly on stale auth tokens or proxied
+                // networks. A `gh` that can't answer in 5s is effectively broken — the
+                // unresolved-fallthrough path is the right destination.
+                timeout : 5000
             });
 
             return JSON.parse(output)

--- a/ai/mcp/server/shared/services/StdioIdentityResolver.mjs
+++ b/ai/mcp/server/shared/services/StdioIdentityResolver.mjs
@@ -1,0 +1,123 @@
+import {execSync} from 'child_process';
+import Base       from '../../../../../src/core/Base.mjs';
+
+/**
+ * @summary Resolves the active agent identity for stdio MCP transport sessions.
+ *
+ * The stdio transport has no request-level authentication primitive (unlike the SSE transport's
+ * OIDC Bearer token flow handled by `AuthService`). Identity must be pinned at process-boot time
+ * so that every subsequent `callTool` dispatch inherits a consistent tenant tag via
+ * `RequestContextService`, bringing stdio to **parity with the SSE identity propagation** shipped
+ * by ticket #10000.
+ *
+ * **Resolution chain** (first match wins):
+ *
+ * 1. **`NEO_AGENT_IDENTITY` environment variable** — explicit pinning for agent harnesses.
+ *    Claude Code sets this via `.claude/settings.json`; Gemini via `.gemini/settings.json`; other
+ *    harnesses via their native config surface. This is the authoritative path for per-model
+ *    GitHub account binding (precedent: #10144 seed identities `@neo-opus-4-7`, `@neo-gemini-3-1-pro`).
+ * 2. **`gh api user` via the GitHub CLI** — zero-friction fallback for local human developers
+ *    who have `gh` installed and authenticated. Matches the `@me` shortcut semantics used
+ *    across the Agent OS tooling surface.
+ * 3. **`unresolved`** — neither path yielded an identity. Downstream services treat this as
+ *    **single-tenant mode** (backward-compatible with pre-#10145 behavior). Not a startup
+ *    failure — preserves the existing local-agent developer experience.
+ *
+ * **Intentionally NOT in scope:**
+ * - OAuth2/OIDC token validation — that's `AuthService` (SSE transport only)
+ * - AgentIdentity graph-node binding — the consumer (`memory-core/Server.mjs`) calls
+ *   `Memory_GraphService.getNode({id: '@' + githubLogin})` after resolution, then composes
+ *   the full RequestContext. Keeping the graph lookup out of this service preserves the
+ *   `shared/` ↔ `memory-core/` layering boundary.
+ *
+ * This class is a key example of the framework's **multi-tenant identity resolution** model
+ * and demonstrates concepts like **agent identity**, **OAuth fallback patterns**, **zero-friction
+ * developer experience**, and **stdio-SSE transport parity**.
+ *
+ * @class Neo.ai.mcp.server.shared.services.StdioIdentityResolver
+ * @extends Neo.core.Base
+ * @singleton
+ * @see Neo.ai.mcp.server.shared.services.AuthService
+ * @see Neo.ai.mcp.server.shared.services.RequestContextService
+ */
+class StdioIdentityResolver extends Base {
+    static config = {
+        /**
+         * @member {String} className='Neo.ai.mcp.server.shared.services.StdioIdentityResolver'
+         * @protected
+         */
+        className: 'Neo.ai.mcp.server.shared.services.StdioIdentityResolver',
+        /**
+         * @member {Boolean} singleton=true
+         * @protected
+         */
+        singleton: true
+    }
+
+    /**
+     * Resolves the active agent identity via the configured chain (env-var → gh CLI → unresolved).
+     * Returns a plain object suitable for spreading into `RequestContextService.run()` context.
+     *
+     * **Normalization:** GitHub login strings are stored WITHOUT the leading `@` to match
+     * GitHub API conventions (`gh api user .login` returns `neo-opus-4-7`, not `@neo-opus-4-7`).
+     * Callers that need the `@`-prefixed graph-node-id form (per #10144 seed convention) prepend
+     * the `@` at lookup time.
+     *
+     * @returns {Promise<{githubLogin: String|null, username: String|null, source: String}>}
+     *     An identity descriptor. `source` is one of `'env-var'`, `'gh-cli'`, or `'unresolved'`.
+     */
+    async resolve() {
+        let envIdentity = process.env.NEO_AGENT_IDENTITY?.trim();
+
+        if (envIdentity) {
+            let login = envIdentity.startsWith('@') ? envIdentity.slice(1) : envIdentity;
+
+            return {
+                githubLogin: login,
+                username   : login,
+                source     : 'env-var'
+            }
+        }
+
+        let ghUser = this.resolveFromGhCli();
+
+        if (ghUser) {
+            return {
+                githubLogin: ghUser.login,
+                username   : ghUser.name || ghUser.login,
+                source     : 'gh-cli'
+            }
+        }
+
+        return {
+            githubLogin: null,
+            username   : null,
+            source     : 'unresolved'
+        }
+    }
+
+    /**
+     * Synchronously invokes `gh api user` to resolve the locally authenticated GitHub user.
+     * Returns `null` if the CLI is absent, the user is not authenticated, the call exceeds the
+     * timeout budget, or the JSON payload fails to parse. Silent-fail semantics are deliberate:
+     * an unauthenticated `gh` is an expected state that must NOT block server startup.
+     *
+     * @returns {Object|null} The parsed GitHub user payload (`{login, name, ...}`) or `null`.
+     * @protected
+     */
+    resolveFromGhCli() {
+        try {
+            let output = execSync('gh api user', {
+                encoding: 'utf8',
+                stdio   : ['ignore', 'pipe', 'ignore'],
+                timeout : 3000
+            });
+
+            return JSON.parse(output)
+        } catch (e) {
+            return null
+        }
+    }
+}
+
+export default Neo.setupClass(StdioIdentityResolver);

--- a/ai/mcp/server/shared/services/TransportService.mjs
+++ b/ai/mcp/server/shared/services/TransportService.mjs
@@ -122,14 +122,29 @@ class TransportService extends Base {
             }
 
             // Propagate the authenticated identity into the async call chain so service methods
-            // can tag ChromaDB writes and filter reads per tenant (ticket #10000). `req.auth` is
-            // populated by the `requireBearerAuth` middleware when OIDC is configured; when auth
-            // is disabled (local dev, no `aiConfig.auth.host`/`.issuerUrl`) the context is empty
-            // and downstream services fall through to single-tenant behavior.
-            const requestContext = {
-                userId  : req.auth?.userId,
-                username: req.auth?.username
-            };
+            // can tag ChromaDB writes and filter reads per tenant (ticket #10000 + #10145).
+            //
+            // Context-shape dispatch:
+            // - If the concrete server (e.g. memory-core) implements `buildRequestContext()`,
+            //   defer to it — the server may enrich the raw OIDC auth with server-specific
+            //   bindings like AgentIdentity graph-node IDs (memory-core's #10144 contract).
+            // - Otherwise fall back to the minimal `{userId, username}` shape — sufficient for
+            //   servers (knowledge-base, gh-workflow) that don't own an identity graph.
+            //
+            // `req.auth` is populated by the `requireBearerAuth` middleware when OIDC is
+            // configured; when auth is disabled (local dev, no `aiConfig.auth.host` /
+            // `.issuerUrl`) the context is empty and downstream services fall through to
+            // single-tenant behavior.
+            let requestContext;
+
+            if (typeof server.buildRequestContext === 'function') {
+                requestContext = await server.buildRequestContext(req.auth);
+            } else {
+                requestContext = {
+                    userId  : req.auth?.userId,
+                    username: req.auth?.username
+                };
+            }
 
             await RequestContextService.run(requestContext, () => transport.handleRequest(req, res, req.body));
         });

--- a/learn/agentos/tooling/MemoryCoreMcpAuth.md
+++ b/learn/agentos/tooling/MemoryCoreMcpAuth.md
@@ -42,7 +42,7 @@ Once the server starts, every tool call from a client MUST arrive with `Authoriz
 The stdio transport has no request-level authentication primitive — the security boundary is the trusted-process boundary. Identity is resolved **once at server boot** via the following chain:
 
 1. **`NEO_AGENT_IDENTITY` environment variable.** Explicit pinning — the authoritative source for agent harnesses. The value is normalized: a leading `@` is stripped so the runtime identity matches GitHub API conventions (`neo-opus-4-7`, not `@neo-opus-4-7`).
-2. **`gh api user` via the GitHub CLI.** Fallback for local human developers who have `gh` installed and authenticated. Silent-fails (returns `null`) if the CLI is absent, the user is not logged in, or the call exceeds a 3-second timeout — preserving zero-friction local development.
+2. **`gh api user` via the GitHub CLI.** Fallback for local human developers who have `gh` installed and authenticated. Silent-fails (returns `null`) if the CLI is absent, the user is not logged in, or the call exceeds a 5-second timeout — matches the MCP client-side init-handshake budget so a slow `gh` doesn't exhaust the client's connection window.
 3. **`unresolved`.** Neither path yielded identity. Downstream services treat this as **single-tenant mode** (backward-compatible) — no tag on writes, no filter on reads.
 
 The resolved identity is cached on the running server instance and wrapped around every `CallToolRequestSchema` dispatch via `RequestContextService.run()`.
@@ -150,7 +150,7 @@ Check startup logs for `[neo-memory-core MCP] Identity: <userId> via <source>`. 
 
 1. Verify `NEO_AGENT_IDENTITY` is set in the harness's MCP server environment — `env` block in `settings.json`, not shell export.
 2. If no `NEO_AGENT_IDENTITY` is set, verify `gh auth status` reports a valid login.
-3. If `gh` is installed but the timeout is exceeded, the 3-second budget may be too tight for a slow network; set `NEO_AGENT_IDENTITY` explicitly to skip the CLI call.
+3. If `gh` is installed but the timeout is exceeded, the 5-second budget may be too tight for a degraded network or stale auth; set `NEO_AGENT_IDENTITY` explicitly to skip the CLI call.
 
 ### AgentIdentity node is `unbound` despite identity resolution
 

--- a/learn/agentos/tooling/MemoryCoreMcpAuth.md
+++ b/learn/agentos/tooling/MemoryCoreMcpAuth.md
@@ -1,0 +1,231 @@
+# Memory Core MCP Authentication
+
+The Memory Core MCP server enforces **tenant-scoped identity** on every tool invocation — regardless of whether the caller connects over **stdio** (local agents, CI runners) or **SSE** (cloud-native, multi-tenant deployments). This guide describes the dual-path identity resolution, the `AgentIdentity` graph-node binding, and the anti-spoof invariant that together close the multi-tenant isolation contract shipped across tickets #10000, #10144, and #10145.
+
+## Why Identity Matters Here
+
+Every write to the Memory Core's ChromaDB collections is tagged with `metadata.userId`. Every read filters on the same field. Without a reliable identity source, tenant isolation is advisory — a client can claim to be anyone, or nothing at all. The multi-tenant Memory Core deployment scope of Epic #9999 requires this substrate to be authoritative, not cooperative.
+
+Three invariants together close the contract:
+
+1. **Identity is server-stamped, never client-supplied.** No MCP tool schema accepts a caller-identity argument. The caller's identity is derived inside the server from transport-level claims.
+2. **Write-path tagging is unconditional.** `addMemory`, `mutate_frontier`, and every future write tool reads identity from `RequestContextService.getUserId()` and tags writes with it. Read filters symmetrically apply `where: {userId}` when the context is populated.
+3. **Anti-spoof guards the argument surface.** The `AuthMiddleware` service rejects any tool-call argument containing a key that would contradict server-stamped identity — closing a spoof vector before Mailbox (#10139) creates its first surface.
+
+## The Two Paths
+
+| Transport | Identity Source | Implementation |
+|---|---|---|
+| **SSE** | OIDC Bearer-token introspection | `AuthService.verifyAccessToken` (shipped in #10000) |
+| **stdio** | `NEO_AGENT_IDENTITY` env-var, then `gh api user` fallback | `StdioIdentityResolver` (ticket #10145) |
+
+Both paths end at the same destination: a `RequestContextService.run(context, ...)` wrap around tool dispatch, where the `context` shape is identical. Service-layer code reading `RequestContextService.getUserId()` is transport-agnostic.
+
+### SSE Path — OIDC via `AuthService`
+
+Operators configure the Memory Core with either an OIDC discovery URL or a Keycloak-style issuer/realm pair. The `AuthService` handles discovery, token introspection, audience enforcement, and extracts `preferred_username` / `sub` as the authoritative `userId`. `TransportService` wraps each `/mcp` HTTP request in `RequestContextService.run()` using the auth context.
+
+Deployment example — Memory Core running behind Keycloak in a multi-tenant cloud environment:
+
+```
+NEO_MEMORY_CORE_TRANSPORT=sse
+NEO_MEMORY_CORE_SSE_PORT=3001
+NEO_MEMORY_CORE_AUTH_ISSUER_URL=https://auth.example.com/realms/neo/
+NEO_MEMORY_CORE_AUTH_CLIENT_ID=neo-memory-core
+NEO_MEMORY_CORE_AUTH_CLIENT_SECRET=<secret>
+```
+
+Once the server starts, every tool call from a client MUST arrive with `Authorization: Bearer <token>` where the token was issued by the configured issuer AND audience-matches the Memory Core's public URL. Tokens with `aud` claims targeting a different resource are rejected per RFC 9068.
+
+### Stdio Path — `StdioIdentityResolver`
+
+The stdio transport has no request-level authentication primitive — the security boundary is the trusted-process boundary. Identity is resolved **once at server boot** via the following chain:
+
+1. **`NEO_AGENT_IDENTITY` environment variable.** Explicit pinning — the authoritative source for agent harnesses. The value is normalized: a leading `@` is stripped so the runtime identity matches GitHub API conventions (`neo-opus-4-7`, not `@neo-opus-4-7`).
+2. **`gh api user` via the GitHub CLI.** Fallback for local human developers who have `gh` installed and authenticated. Silent-fails (returns `null`) if the CLI is absent, the user is not logged in, or the call exceeds a 3-second timeout — preserving zero-friction local development.
+3. **`unresolved`.** Neither path yielded identity. Downstream services treat this as **single-tenant mode** (backward-compatible) — no tag on writes, no filter on reads.
+
+The resolved identity is cached on the running server instance and wrapped around every `CallToolRequestSchema` dispatch via `RequestContextService.run()`.
+
+## Harness Configuration
+
+Each AI harness pins its model's identity at session start by setting `NEO_AGENT_IDENTITY`. Matches the per-model GitHub-account convention from ticket #10144 (`@neo-opus-4-7`, `@neo-gemini-3-1-pro`, `@tobiu`).
+
+### Claude Code (`.claude/settings.json`)
+
+```json
+{
+    "mcpServers": {
+        "neo.mjs-memory-core": {
+            "command": "node",
+            "args": ["ai/mcp/server/memory-core/mcp-server.mjs"],
+            "env": {
+                "NEO_AGENT_IDENTITY": "neo-opus-4-7"
+            }
+        }
+    }
+}
+```
+
+### Gemini CLI / Antigravity (`.gemini/settings.json`)
+
+```json
+{
+    "mcpServers": {
+        "neo.mjs-memory-core": {
+            "command": "node",
+            "args": ["ai/mcp/server/memory-core/mcp-server.mjs"],
+            "env": {
+                "NEO_AGENT_IDENTITY": "neo-gemini-3-1-pro"
+            }
+        }
+    }
+}
+```
+
+### Human developer (no override)
+
+No harness configuration required. `StdioIdentityResolver` falls back to `gh api user` and resolves to the authenticated human GitHub login. Equivalent to the `@me` shortcut semantics used elsewhere in the Agent OS tooling surface.
+
+## AgentIdentity Graph-Node Binding
+
+Ticket #10144 seeded three `AgentIdentity` nodes in the Native Edge Graph:
+
+- `@neo-opus-4-7` — Claude Opus 4.7
+- `@neo-gemini-3-1-pro` — Gemini 3.1 Pro
+- `@tobiu` — Tobias Uhlig (human owner)
+
+Each seeded node carries `{githubLogin, displayName, modelFamily, accountType}` properties and is addressable by its `@`-prefixed ID.
+
+After identity resolution (SSE or stdio), the Memory Core `Server.bindAgentIdentity(userId)` helper looks up the matching graph node by prepending `@` to the bare GitHub login. The result (either the node ID or `null`) lands in `RequestContext.agentIdentityNodeId`, exposed via `RequestContextService.getAgentIdentityNodeId()`.
+
+Services building `AUTHORED_BY` / `OWNED_BY` / future provenance edges at write time terminate their edges on the resolved node ID. Missing node is non-fatal — unseeded agents can still accumulate memories; they just can't yet terminate graph edges until someone adds them to `ai/scripts/seedAgentIdentities.mjs` and re-runs the seed script.
+
+## The Anti-Spoof Invariant
+
+`AuthMiddleware.validateNoIdentitySpoof(args)` rejects any tool-call whose arguments contain a key that would let the client override server-stamped identity. The currently forbidden keys:
+
+```
+userId
+agentId
+agentIdentityNodeId
+githubLogin
+from
+sender
+authorLogin
+```
+
+Present-day tool schemas (`add_memory`, `mutate_frontier`, etc.) don't accept any of these keys — so the middleware is a no-op on live traffic. It exists as **defense-in-depth** for Mailbox (#10139) which will add `from` fields where the spoof surface becomes real. Shipping the guard before the surface is the inverse of "patch after incident" hygiene.
+
+**Legitimate destination fields are NOT forbidden.** `recipient` / `to` (addressee of a mailbox message) are legitimate — the sender specifying where a message goes is not a claim of authorship.
+
+**Read-path filters by a different parameter name.** If a future tool legitimately needs to query across multiple users (e.g., an admin-only cross-tenant audit), the parameter MUST NOT be named `userId` — use `filterUserId` or similar to clearly distinguish it from the protected identity field.
+
+## Request Context Shape
+
+```javascript
+{
+    userId             : String,        // Bare GitHub login (no `@` prefix)
+    username           : String,        // Human-readable display name
+    agentIdentityNodeId: String | null, // `@`-prefixed graph node ID if bound
+    source             : String         // Provenance: 'oidc' | 'env-var' | 'gh-cli' | 'unresolved'
+}
+```
+
+All fields are populated on a best-effort basis. `userId` is `undefined` only when neither transport resolves an identity — the single-tenant fallthrough case.
+
+## OAuth 2.1 Spec Version
+
+The SSE path validates Bearer tokens per OAuth 2.1 draft conventions (audience enforcement, introspection-based validation, resource indicator checks per RFC 9068). Implementations targeting this Memory Core MUST:
+
+- Issue tokens with a specific `aud` (audience) claim matching the Memory Core's public URL
+- Support RFC 7662 introspection (or expose introspection metadata in the OIDC discovery document)
+- Populate `preferred_username` OR `sub` in the introspection response (both honored; `sub`-fallback guarantees a non-empty `userId` for machine-to-machine client-credential flows)
+
+## Troubleshooting
+
+### `addMemory` writes are not tagged with `userId` in stdio mode
+
+Check startup logs for `[neo-memory-core MCP] Identity: <userId> via <source>`. If the line reads `Identity: unresolved (single-tenant fallthrough)`:
+
+1. Verify `NEO_AGENT_IDENTITY` is set in the harness's MCP server environment — `env` block in `settings.json`, not shell export.
+2. If no `NEO_AGENT_IDENTITY` is set, verify `gh auth status` reports a valid login.
+3. If `gh` is installed but the timeout is exceeded, the 3-second budget may be too tight for a slow network; set `NEO_AGENT_IDENTITY` explicitly to skip the CLI call.
+
+### AgentIdentity node is `unbound` despite identity resolution
+
+Startup log reads `Identity: tobiu via gh-cli — unbound (no matching AgentIdentity node)`.
+
+- The graph node `@tobiu` does not exist in the current Memory Core graph.
+- Run `node ai/scripts/seedAgentIdentities.mjs` to re-seed the canonical identities.
+- For a new per-model account, add the identity to the `IDENTITIES` array in `seedAgentIdentities.mjs` before running.
+
+### `Identity-override spoof rejected` error on a tool call
+
+The `AuthMiddleware` refused a tool-call argument. Check that the client is not attempting to supply `userId`, `agent.authorLogin`, `from`, or any other field listed above. If the tool legitimately needs to pass an identity-adjacent value, rename the field at the schema layer.
+
+### SSE transport returns 401 despite a valid-looking Bearer token
+
+- Check the `aud` (audience) claim of the token — must match the Memory Core's public URL.
+- Check that the OIDC introspection endpoint is reachable from the Memory Core process.
+- Check that the `AuthService` was able to fetch the OIDC discovery document at startup (look for `[AuthService] OIDC Discovery successful for issuer: <url>` in the startup log).
+
+## Service Relationships
+
+```
+┌────────────────────────────────────────────────────────────────┐
+│                    MCP Tool Call Dispatch                       │
+│  ┌──────────────────┐    ┌──────────────────┐                   │
+│  │  SSE Transport   │    │ Stdio Transport  │                   │
+│  │ TransportService │    │    Server.mjs    │                   │
+│  └────────┬─────────┘    └────────┬─────────┘                   │
+│           │                       │                             │
+│           ▼                       ▼                             │
+│  ┌──────────────────┐    ┌───────────────────────┐              │
+│  │   AuthService    │    │ StdioIdentityResolver │              │
+│  │ (OIDC introspect)│    │ (env-var + gh-CLI)    │              │
+│  └────────┬─────────┘    └────────┬──────────────┘              │
+│           │                       │                             │
+│           └──────────┬────────────┘                             │
+│                      ▼                                          │
+│             ┌──────────────────┐                                │
+│             │  bindAgentIdent  │                                │
+│             │   (graph lookup) │                                │
+│             └────────┬─────────┘                                │
+│                      ▼                                          │
+│        ┌─────────────────────────────┐                          │
+│        │   RequestContextService     │                          │
+│        │ .run(identity, dispatch)    │                          │
+│        └────────────┬────────────────┘                          │
+│                     ▼                                           │
+│         ┌──────────────────────┐                                │
+│         │   AuthMiddleware     │                                │
+│         │ .validateNoSpoof()   │                                │
+│         └──────────┬───────────┘                                │
+│                    ▼                                            │
+│         ┌──────────────────────┐                                │
+│         │      callTool()      │                                │
+│         │  (service dispatch)  │                                │
+│         └──────────────────────┘                                │
+└────────────────────────────────────────────────────────────────┘
+```
+
+## See Also
+
+- `ai/mcp/server/shared/services/AuthService.mjs` — OIDC discovery and token introspection
+- `ai/mcp/server/shared/services/RequestContextService.mjs` — AsyncLocalStorage identity propagation
+- `ai/mcp/server/shared/services/StdioIdentityResolver.mjs` — Stdio identity resolution
+- `ai/mcp/server/shared/services/AuthMiddleware.mjs` — Anti-spoof argument validation
+- `ai/mcp/server/memory-core/Server.mjs` — Composition point for stdio transport
+- `ai/scripts/seedAgentIdentities.mjs` — AgentIdentity node seed script (#10144)
+- `learn/agentos/tooling/Authorization.md` — Server Authorization overview
+- `learn/agentos/tooling/MemoryCoreMcpApi.md` — Memory Core tool surface
+
+## Related Tickets
+
+- #10000 — Hardened Identity Ingestion (SSE OIDC path + RequestContextService)
+- #10144 — AgentIdentity node type + seed script
+- #10145 — OAuth2 authentication layer for Memory Core MCP connections (this doc)
+- #10016 — Multi-Tenant Identity & Data Privacy (parent sub-epic)
+- #10139 — Mailbox A2A primitive (future consumer of anti-spoof invariant)
+- #9999 — Cloud-Native Knowledge & Multi-Tenant Memory Core (grand-parent epic)

--- a/learn/agentos/tooling/MemoryCoreMcpAuth.md
+++ b/learn/agentos/tooling/MemoryCoreMcpAuth.md
@@ -42,7 +42,7 @@ Once the server starts, every tool call from a client MUST arrive with `Authoriz
 The stdio transport has no request-level authentication primitive — the security boundary is the trusted-process boundary. Identity is resolved **once at server boot** via the following chain:
 
 1. **`NEO_AGENT_IDENTITY` environment variable.** Explicit pinning — the authoritative source for agent harnesses. The value is normalized: a leading `@` is stripped so the runtime identity matches GitHub API conventions (`neo-opus-4-7`, not `@neo-opus-4-7`).
-2. **`gh api user` via the GitHub CLI.** Fallback for local human developers who have `gh` installed and authenticated. Silent-fails (returns `null`) if the CLI is absent, the user is not logged in, or the call exceeds a 5-second timeout — matches the MCP client-side init-handshake budget so a slow `gh` doesn't exhaust the client's connection window.
+2. **`gh api user` via the GitHub CLI.** Fallback for local human developers who have `gh` installed and authenticated. Silent-fails (returns `null`) if the CLI is absent, the user is not logged in, or the call exceeds a **1.5-second fail-fast budget**. A healthy `gh` resolves in <200ms; a slower call likely indicates auth-refresh or network degradation. The MCP client-side init-handshake budget (~5s total) must cover this call *plus* ChromaDB health checks, `SystemLifecycleService.ready()`, `GraphService.ready()`, and transport connect — so the gh timeout is intentionally a small fraction of that window. Single-tenant fallthrough is preferable to exhausting the handshake.
 3. **`unresolved`.** Neither path yielded identity. Downstream services treat this as **single-tenant mode** (backward-compatible) — no tag on writes, no filter on reads.
 
 The resolved identity is cached on the running server instance and wrapped around every `CallToolRequestSchema` dispatch via `RequestContextService.run()`.
@@ -150,7 +150,7 @@ Check startup logs for `[neo-memory-core MCP] Identity: <userId> via <source>`. 
 
 1. Verify `NEO_AGENT_IDENTITY` is set in the harness's MCP server environment — `env` block in `settings.json`, not shell export.
 2. If no `NEO_AGENT_IDENTITY` is set, verify `gh auth status` reports a valid login.
-3. If `gh` is installed but the timeout is exceeded, the 5-second budget may be too tight for a degraded network or stale auth; set `NEO_AGENT_IDENTITY` explicitly to skip the CLI call.
+3. If `gh` is installed but the 1.5-second fail-fast timeout is exceeded, the CLI is likely hanging on auth refresh or a degraded network. The design is intentional — fail-fast preserves the MCP handshake budget for the rest of `initAsync`. Set `NEO_AGENT_IDENTITY` explicitly to skip the CLI call entirely.
 
 ### AgentIdentity node is `unbound` despite identity resolution
 

--- a/learn/tree.json
+++ b/learn/tree.json
@@ -41,6 +41,7 @@
             {"name": "Google OAuth Demo",                              "parentId": "AgentOS/Tooling",                                     "id": "agentos/tooling/GoogleAuthDemo"},
             {"name": "Agent-Agnostic MCP Configuration",               "parentId": "AgentOS/Tooling",                                     "id": "agentos/tooling/AgentAgnosticMcpConfig"},
             {"name": "Memory Core MCP API",                            "parentId": "AgentOS/Tooling",                                     "id": "agentos/tooling/MemoryCoreMcpApi"},
+            {"name": "Memory Core MCP Authentication",                 "parentId": "AgentOS/Tooling",                                     "id": "agentos/tooling/MemoryCoreMcpAuth"},
             {"name": "Chrome DevTools MCP Server",                     "parentId": "AgentOS/Tooling",                                     "id": "agentos/tooling/ChromeDevToolsMcpServer"},
             {"name": "GitHub CLI Setup",                               "parentId": "AgentOS/Tooling",                                     "id": "agentos/tooling/GitHubCLISetup"},
             {"name": "GitHub Workflow Server: gh-absent",              "parentId": "AgentOS/Tooling",                                     "id": "agentos/tooling/GitHubWorkflowServerGhAbsent"},

--- a/test/playwright/unit/ai/mcp/server/memory-core/Auth.spec.mjs
+++ b/test/playwright/unit/ai/mcp/server/memory-core/Auth.spec.mjs
@@ -1,0 +1,257 @@
+import {setup} from '../../../../../setup.mjs';
+
+const appName = 'MemoryCoreAuthTest';
+
+setup({
+    neoConfig: {
+        unitTestMode: true
+    },
+    appConfig: {
+        name             : appName,
+        isMounted        : () => true,
+        vnodeInitialising: false
+    }
+});
+
+import {test, expect} from '@playwright/test';
+import Neo            from '../../../../../../../src/Neo.mjs';
+import * as core      from '../../../../../../../src/core/_export.mjs';
+
+test.describe('Neo.ai.mcp.server.shared.services.StdioIdentityResolver', () => {
+    let StdioIdentityResolver;
+    let originalResolveFromGhCli;
+    let originalEnvIdentity;
+
+    test.beforeAll(async () => {
+        StdioIdentityResolver    = (await import('../../../../../../../ai/mcp/server/shared/services/StdioIdentityResolver.mjs')).default;
+        originalResolveFromGhCli = StdioIdentityResolver.resolveFromGhCli.bind(StdioIdentityResolver);
+    });
+
+    test.beforeEach(() => {
+        // Snapshot env state so each test starts from a known baseline. Symmetric restore in
+        // afterEach prevents cross-test leakage under Playwright's fullyParallel mode.
+        originalEnvIdentity = process.env.NEO_AGENT_IDENTITY;
+        delete process.env.NEO_AGENT_IDENTITY;
+    });
+
+    test.afterEach(() => {
+        if (originalEnvIdentity !== undefined) {
+            process.env.NEO_AGENT_IDENTITY = originalEnvIdentity;
+        } else {
+            delete process.env.NEO_AGENT_IDENTITY;
+        }
+
+        StdioIdentityResolver.resolveFromGhCli = originalResolveFromGhCli;
+    });
+
+    test('resolves NEO_AGENT_IDENTITY when set, tags source as env-var', async () => {
+        process.env.NEO_AGENT_IDENTITY = 'neo-opus-4-7';
+
+        const identity = await StdioIdentityResolver.resolve();
+
+        expect(identity.githubLogin).toBe('neo-opus-4-7');
+        expect(identity.username).toBe('neo-opus-4-7');
+        expect(identity.source).toBe('env-var');
+    });
+
+    test('strips leading @ from NEO_AGENT_IDENTITY for GitHub API parity', async () => {
+        process.env.NEO_AGENT_IDENTITY = '@neo-gemini-3-1-pro';
+
+        const identity = await StdioIdentityResolver.resolve();
+
+        expect(identity.githubLogin).toBe('neo-gemini-3-1-pro');
+        expect(identity.source).toBe('env-var');
+    });
+
+    test('trims whitespace from NEO_AGENT_IDENTITY', async () => {
+        process.env.NEO_AGENT_IDENTITY = '  tobiu  ';
+
+        const identity = await StdioIdentityResolver.resolve();
+
+        expect(identity.githubLogin).toBe('tobiu');
+        expect(identity.source).toBe('env-var');
+    });
+
+    test('falls back to gh-cli when env-var is absent', async () => {
+        StdioIdentityResolver.resolveFromGhCli = () => ({
+            login: 'human-dev',
+            name : 'Human Developer'
+        });
+
+        const identity = await StdioIdentityResolver.resolve();
+
+        expect(identity.githubLogin).toBe('human-dev');
+        expect(identity.username).toBe('Human Developer');
+        expect(identity.source).toBe('gh-cli');
+    });
+
+    test('uses login as username when gh returns no name field', async () => {
+        StdioIdentityResolver.resolveFromGhCli = () => ({
+            login: 'anon-dev',
+            name : null
+        });
+
+        const identity = await StdioIdentityResolver.resolve();
+
+        expect(identity.username).toBe('anon-dev');
+    });
+
+    test('returns unresolved when both env-var and gh-cli fail', async () => {
+        StdioIdentityResolver.resolveFromGhCli = () => null;
+
+        const identity = await StdioIdentityResolver.resolve();
+
+        expect(identity.githubLogin).toBeNull();
+        expect(identity.username).toBeNull();
+        expect(identity.source).toBe('unresolved');
+    });
+
+    test('env-var takes precedence over gh-cli', async () => {
+        process.env.NEO_AGENT_IDENTITY = 'explicit-agent';
+        StdioIdentityResolver.resolveFromGhCli = () => {
+            throw new Error('gh-cli must not be invoked when env-var is set');
+        };
+
+        const identity = await StdioIdentityResolver.resolve();
+
+        expect(identity.githubLogin).toBe('explicit-agent');
+        expect(identity.source).toBe('env-var');
+    });
+});
+
+test.describe('Neo.ai.mcp.server.shared.services.AuthMiddleware', () => {
+    let AuthMiddleware;
+
+    test.beforeAll(async () => {
+        AuthMiddleware = (await import('../../../../../../../ai/mcp/server/shared/services/AuthMiddleware.mjs')).default;
+    });
+
+    test('accepts args without any forbidden identity-override keys', () => {
+        const cleanArgs = {
+            prompt  : 'what is the weather',
+            thought : 'calling API',
+            response: 'sunny',
+            agent   : 'antigravity',
+            model   : 'gemini-3.1-pro'
+        };
+
+        expect(() => AuthMiddleware.validateNoIdentitySpoof(cleanArgs)).not.toThrow();
+    });
+
+    test('accepts null or undefined args (no tool parameters)', () => {
+        expect(() => AuthMiddleware.validateNoIdentitySpoof(null)).not.toThrow();
+        expect(() => AuthMiddleware.validateNoIdentitySpoof(undefined)).not.toThrow();
+        expect(() => AuthMiddleware.validateNoIdentitySpoof({})).not.toThrow();
+    });
+
+    test('rejects args containing userId — server-stamped field', () => {
+        expect(() => AuthMiddleware.validateNoIdentitySpoof({
+            prompt: 'x',
+            userId: '@spoofed-identity'
+        })).toThrow(/Identity-override spoof rejected/);
+    });
+
+    test('rejects args containing githubLogin — server-stamped field', () => {
+        expect(() => AuthMiddleware.validateNoIdentitySpoof({
+            prompt     : 'x',
+            githubLogin: 'victim-login'
+        })).toThrow(/Identity-override spoof rejected/);
+    });
+
+    test('rejects args containing `from` — preemptive guard for Mailbox (#10139)', () => {
+        expect(() => AuthMiddleware.validateNoIdentitySpoof({
+            recipient: '@neo-opus-4-7',
+            from     : '@spoofed-sender',
+            body     : 'fake message'
+        })).toThrow(/Identity-override spoof rejected/);
+    });
+
+    test('rejects agentIdentityNodeId — prevents graph-node identity spoofing', () => {
+        expect(() => AuthMiddleware.validateNoIdentitySpoof({
+            agentIdentityNodeId: '@spoofed-node'
+        })).toThrow(/Identity-override spoof rejected/);
+    });
+
+    test('permits recipient field — legitimate destination address, not claim-of-authorship', () => {
+        // Mailbox will add `recipient` as the addressee. Sender-claim fields (`from`, `sender`,
+        // `authorLogin`) are forbidden; destination fields are not.
+        expect(() => AuthMiddleware.validateNoIdentitySpoof({
+            recipient: '@neo-opus-4-7',
+            body     : 'legitimate message'
+        })).not.toThrow();
+    });
+
+    test('error message points to troubleshooting guide', () => {
+        let error = null;
+
+        try {
+            AuthMiddleware.validateNoIdentitySpoof({userId: 'x'});
+        } catch (e) {
+            error = e;
+        }
+
+        expect(error).not.toBeNull();
+        expect(error.message).toContain('MemoryCoreMcpAuth.md');
+    });
+
+    test('exposes identity-override key set for testability', () => {
+        const keys = AuthMiddleware.getIdentityOverrideKeys();
+
+        expect(keys).toBeInstanceOf(Set);
+        expect(keys.has('userId')).toBe(true);
+        expect(keys.has('from')).toBe(true);
+        expect(keys.has('agentIdentityNodeId')).toBe(true);
+        // Returns a copy — mutating it must not affect the canonical set.
+        keys.clear();
+
+        const freshKeys = AuthMiddleware.getIdentityOverrideKeys();
+        expect(freshKeys.size).toBeGreaterThan(0);
+    });
+});
+
+test.describe('Neo.ai.mcp.server.shared.services.RequestContextService', () => {
+    let RequestContextService;
+
+    test.beforeAll(async () => {
+        RequestContextService = (await import('../../../../../../../ai/mcp/server/shared/services/RequestContextService.mjs')).default;
+    });
+
+    test('new accessors surface the extended context shape', async () => {
+        const context = {
+            userId             : 'neo-opus-4-7',
+            username           : 'Claude Opus 4.7',
+            agentIdentityNodeId: '@neo-opus-4-7',
+            source             : 'env-var'
+        };
+
+        await RequestContextService.run(context, async () => {
+            expect(RequestContextService.getUserId()).toBe('neo-opus-4-7');
+            expect(RequestContextService.getUsername()).toBe('Claude Opus 4.7');
+            expect(RequestContextService.getAgentIdentityNodeId()).toBe('@neo-opus-4-7');
+            expect(RequestContextService.getSource()).toBe('env-var');
+        });
+    });
+
+    test('accessors return undefined outside any run() scope', () => {
+        // Outside a run() wrap, single-tenant fallthrough is the contract.
+        expect(RequestContextService.getUserId()).toBeUndefined();
+        expect(RequestContextService.getAgentIdentityNodeId()).toBeUndefined();
+        expect(RequestContextService.getSource()).toBeUndefined();
+    });
+
+    test('null agentIdentityNodeId distinguishes unbound identity from single-tenant', async () => {
+        const context = {
+            userId             : 'unseeded-agent',
+            username           : 'Unseeded Agent',
+            agentIdentityNodeId: null,
+            source             : 'env-var'
+        };
+
+        await RequestContextService.run(context, async () => {
+            // Identity resolved, but no matching AgentIdentity graph node.
+            expect(RequestContextService.getUserId()).toBe('unseeded-agent');
+            expect(RequestContextService.getAgentIdentityNodeId()).toBeNull();
+            expect(RequestContextService.getSource()).toBe('env-var');
+        });
+    });
+});


### PR DESCRIPTION
Authored by Claude Opus 4.7 (Claude Code). Session `d69ac7a0-9fe8-4416-b766-cd9edb8bee71`.

Resolves #10145

Brings the Memory Core MCP **stdio transport** to identity parity with the OIDC/SSE path shipped by #10000. Previously stdio connections fell through to single-tenant mode regardless of which agent was running — writes went untagged, reads went unfiltered. With per-agent GitHub accounts (#10144 seed convention: `@neo-opus-4-7`, `@neo-gemini-3-1-pro`, `@tobiu`), stdio now resolves identity at boot via `NEO_AGENT_IDENTITY` env-var → `gh api user` fallback → unresolved chain, binds the matching `AgentIdentity` graph node, and wraps every `callTool` dispatch in `RequestContextService.run()` so downstream services (`MemoryService.addMemory`, etc.) tag writes per tenant.

## Deltas from ticket

The ticket body was reshaped during intake to reflect the architectural reality discovered during the code survey — documented inline in the ticket under "Scope-reshape note" and cited as the "Hypothesis vs Root Cause" challenge per `ticket-intake` §1.7:

- **Original ticket prescription:** "GitHub OAuth2 flow in Memory Core connect handshake" (implying new OAuth work for both transports).
- **Actual gap discovered:** OIDC/OAuth for SSE already shipped via #10000's `AuthService.mjs`; the real missing work was stdio-side `RequestContextService` population, `AgentIdentity` graph-node binding, and a preemptive anti-spoof guard for Mailbox (#10139).
- **Reshaped deliverables:** `StdioIdentityResolver` + `AuthMiddleware` + `bindAgentIdentity` helper + `buildRequestContext` hook in TransportService + design doc + tests. No SSE OAuth re-implementation — reuses the #10000 substrate.

## Test Evidence

```
$ npm run test-unit -- test/playwright/unit/ai/mcp/server/memory-core/Auth.spec.mjs
Running 19 tests using 7 workers
  19 passed (773ms)
```

Coverage:

- `StdioIdentityResolver`: env-var resolution, `@`-prefix stripping, whitespace trimming, gh-CLI fallback (mocked), `null`-returning gh-CLI fallthrough, env-var-over-gh-cli precedence, 7 cases total.
- `AuthMiddleware`: clean-args accept, `null`/`undefined`/`{}` accept, `userId` reject, `githubLogin` reject, `from` reject (Mailbox preemptive), `agentIdentityNodeId` reject, `recipient` accept (legitimate destination field), error-message-cites-doc assertion, key-set-is-copy assertion, 9 cases total.
- `RequestContextService` extended shape: new accessors populated, accessors undefined outside `run()`, `null agentIdentityNodeId` vs single-tenant distinction, 3 cases total.

Cross-test isolation: `afterEach` restores env + stubbed methods symmetrically per the Playwright `fullyParallel` discipline (same pattern as the `originalLinkNodes` fix in #10161).

## Post-Merge Validation

- [ ] Startup log of a fresh memory-core server under `NEO_AGENT_IDENTITY=neo-opus-4-7` reads `[neo-memory-core MCP] Identity: neo-opus-4-7 via env-var — bound to @neo-opus-4-7`
- [ ] `add_memory` called from a stdio agent produces a ChromaDB row with `metadata.userId === 'neo-opus-4-7'`
- [ ] Startup without `NEO_AGENT_IDENTITY` on a machine with `gh` authenticated resolves via gh-CLI fallback and logs the corresponding identity
- [ ] Design doc `learn/agentos/tooling/MemoryCoreMcpAuth.md` renders correctly in the portal and appears under AgentOS/Tooling in the tree

## Epic-Review Provenance

- Parent epic #10016 reviewed by **Claude Opus 4.7** during this session (2026-04-21T18:22Z) per `epic-review` §5 per-agent-per-epic one-shot, following Gemini 3.1 Pro's prior review (2026-04-21T14:28Z). Cross-model asymmetry dimension: Gemini flagged client-header-trust + ChromaDB where-metadata leak; Opus flagged sub-structure coherence gaps, `#10017` migration strategy ambiguity, OAuth 2.1 vs OAuth2 spec-version drift.

## Related

- Parent: #10016 (Multi-Tenant Identity & Data Privacy)
- Grand-parent epic: #9999 (Cloud-Native Knowledge & Multi-Tenant Memory Core)
- Predecessor (shipped): #10000 (Hardened Identity Ingestion — SSE OIDC path)
- Predecessor (shipped): #10144 (AgentIdentity node type + seed script)
- Unblocks: #10139 (Mailbox A2A — anti-spoof guard activates when `from` field lands), #10146 (cross-tenant perms + validation suite)
- Related review cycle: #10165 (Gemini's Phase-2 Opus-review complement)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
