### PR TITLE
feat(ai): multi-tenant mailbox permissions and validation (#10146) (#10147)

### DIFF
--- a/ai/mcp/server/memory-core/openapi.yaml
+++ b/ai/mcp/server/memory-core/openapi.yaml
@@ -35,6 +35,8 @@ tags:
     description: Database-level operations
   - name: Graph
     description: Knowledge Graph operations
+  - name: Permissions
+    description: Agent permission operations
 
 paths:
   /healthcheck:
@@ -360,6 +362,125 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
 
+  /permissions/grant:
+    post:
+      summary: Grant Permission
+      operationId: grant_permission
+      x-pass-as-object: true
+      description: |
+        Grants a permission edge from the caller to a target identity.
+      tags: [Permissions]
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - to
+                - scope
+              properties:
+                to:
+                  type: string
+                  description: The agent identity being granted the permission
+                scope:
+                  type: string
+                  description: The permission scope
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+        '400':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
+  /permissions/revoke:
+    post:
+      summary: Revoke Permission
+      operationId: revoke_permission
+      x-pass-as-object: true
+      description: |
+        Revokes a permission edge from the caller to a target identity.
+      tags: [Permissions]
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - to
+                - scope
+              properties:
+                to:
+                  type: string
+                  description: The agent identity losing the permission
+                scope:
+                  type: string
+                  description: The permission scope
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+        '400':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
+  /permissions:
+    get:
+      summary: List Permissions
+      operationId: list_permissions
+      x-pass-as-object: true
+      x-annotations:
+        readOnlyHint: true
+      description: |
+        Lists permissions for an identity (defaults to the caller).
+      tags: [Permissions]
+      parameters:
+        - name: forIdentity
+          in: query
+          required: false
+          description: The identity to list permissions for.
+          schema:
+            type: string
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+        '500':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
   /summaries:
     get:
       summary: Get All Summaries
@@ -660,6 +781,261 @@ paths:
                 type: object
         '500':
           description: Internal server error.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
+  /permissions/grant:
+    post:
+      summary: Grant Permission
+      operationId: grant_permission
+      x-pass-as-object: true
+      description: |
+        Grants a permission edge from the caller to a target identity.
+      tags: [Permissions]
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - to
+                - scope
+              properties:
+                to:
+                  type: string
+                  description: The agent identity being granted the permission
+                scope:
+                  type: string
+                  description: The permission scope
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+        '400':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
+  /permissions/revoke:
+    post:
+      summary: Revoke Permission
+      operationId: revoke_permission
+      x-pass-as-object: true
+      description: |
+        Revokes a permission edge from the caller to a target identity.
+      tags: [Permissions]
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - to
+                - scope
+              properties:
+                to:
+                  type: string
+                  description: The agent identity losing the permission
+                scope:
+                  type: string
+                  description: The permission scope
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+        '400':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
+  /permissions:
+    get:
+      summary: List Permissions
+      operationId: list_permissions
+      x-pass-as-object: true
+      x-annotations:
+        readOnlyHint: true
+      description: |
+        Lists permissions for an identity (defaults to the caller).
+      tags: [Permissions]
+      parameters:
+        - name: forIdentity
+          in: query
+          required: false
+          description: The identity to list permissions for.
+          schema:
+            type: string
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+        '500':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
+  /mailbox/messages:
+    post:
+      summary: Send Message
+      operationId: add_message
+      x-pass-as-object: true
+      description: |
+        Sends an A2A message to a specific agent identity or broadcast (*).
+      tags: [Mailbox]
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - to
+                - subject
+                - body
+              properties:
+                to:
+                  type: string
+                  description: "Recipient Agent Identity Node ID, or 'AGENT:*' for broadcast"
+                subject:
+                  type: string
+                body:
+                  type: string
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+        '500':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+    get:
+      summary: List Messages
+      operationId: list_messages
+      x-pass-as-object: true
+      description: |
+        Lists incoming messages for the active agent context.
+      tags: [Mailbox]
+      parameters:
+        - name: status
+          in: query
+          required: false
+          description: "Message read status ('unread' or 'all')"
+          schema:
+            type: string
+            default: "all"
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+        '500':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
+  /mailbox/messages/{messageId}:
+    get:
+      summary: Get Message
+      operationId: get_message
+      x-pass-as-object: true
+      description: |
+        Retrieves a specific message. Subject to read-path permission checks.
+      tags: [Mailbox]
+      parameters:
+        - name: messageId
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+        '403':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
+  /mailbox/messages/{messageId}/read:
+    post:
+      summary: Mark Message Read
+      operationId: mark_read
+      x-pass-as-object: true
+      description: |
+        Marks a specific message as read.
+      tags: [Mailbox]
+      parameters:
+        - name: messageId
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+        '403':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Error
           content:
             application/json:
               schema:

--- a/ai/mcp/server/memory-core/openapi.yaml
+++ b/ai/mcp/server/memory-core/openapi.yaml
@@ -362,124 +362,6 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
 
-  /permissions/grant:
-    post:
-      summary: Grant Permission
-      operationId: grant_permission
-      x-pass-as-object: true
-      description: |
-        Grants a permission edge from the caller to a target identity.
-      tags: [Permissions]
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              required:
-                - to
-                - scope
-              properties:
-                to:
-                  type: string
-                  description: The agent identity being granted the permission
-                scope:
-                  type: string
-                  description: The permission scope
-      responses:
-        '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: object
-        '400':
-          description: Error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorResponse'
-        '500':
-          description: Error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorResponse'
-
-  /permissions/revoke:
-    post:
-      summary: Revoke Permission
-      operationId: revoke_permission
-      x-pass-as-object: true
-      description: |
-        Revokes a permission edge from the caller to a target identity.
-      tags: [Permissions]
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              required:
-                - to
-                - scope
-              properties:
-                to:
-                  type: string
-                  description: The agent identity losing the permission
-                scope:
-                  type: string
-                  description: The permission scope
-      responses:
-        '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: object
-        '400':
-          description: Error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorResponse'
-        '500':
-          description: Error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorResponse'
-
-  /permissions:
-    get:
-      summary: List Permissions
-      operationId: list_permissions
-      x-pass-as-object: true
-      x-annotations:
-        readOnlyHint: true
-      description: |
-        Lists permissions for an identity (defaults to the caller).
-      tags: [Permissions]
-      parameters:
-        - name: forIdentity
-          in: query
-          required: false
-          description: The identity to list permissions for.
-          schema:
-            type: string
-      responses:
-        '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: object
-        '500':
-          description: Error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorResponse'
 
   /summaries:
     get:
@@ -931,6 +813,28 @@ paths:
                   type: string
                 body:
                   type: string
+                originSessionId:
+                  type: string
+                relatedSessions:
+                  type: array
+                  items:
+                    type: string
+                relatedTickets:
+                  type: array
+                  items:
+                    type: string
+                inReplyTo:
+                  type: string
+                priority:
+                  type: string
+                  enum: [low, normal, high]
+                  default: "normal"
+                partOfThread:
+                  type: string
+                taggedConcepts:
+                  type: array
+                  items:
+                    type: string
       responses:
         '200':
           description: OK
@@ -952,13 +856,52 @@ paths:
         Lists incoming messages for the active agent context.
       tags: [Mailbox]
       parameters:
+        - name: box
+          in: query
+          required: false
+          description: "Which box to list ('inbox', 'outbox', 'all')"
+          schema:
+            type: string
+            default: "inbox"
         - name: status
           in: query
           required: false
-          description: "Message read status ('unread' or 'all')"
+          description: "Message read status ('all', 'read', 'unread')"
           schema:
             type: string
             default: "all"
+        - name: to
+          in: query
+          required: false
+          description: "Target identity to list messages for (defaults to caller)"
+          schema:
+            type: string
+        - name: threadId
+          in: query
+          required: false
+          description: "Filter by specific thread"
+          schema:
+            type: string
+        - name: from
+          in: query
+          required: false
+          description: "Filter by specific sender"
+          schema:
+            type: string
+        - name: limit
+          in: query
+          required: false
+          description: "Maximum number of messages to return"
+          schema:
+            type: integer
+            default: 50
+        - name: offset
+          in: query
+          required: false
+          description: "Pagination offset"
+          schema:
+            type: integer
+            default: 0
       responses:
         '200':
           description: OK

--- a/ai/mcp/server/memory-core/services/MailboxService.mjs
+++ b/ai/mcp/server/memory-core/services/MailboxService.mjs
@@ -31,12 +31,19 @@ class MailboxService extends Base {
     /**
      * Adds a new message to the mailbox system.
      * @param {Object} args
-     * @param {String} args.to
-     * @param {String} args.subject
-     * @param {String} args.body
+     * @param {String} args.to The agent identity, role, or broadcast to send to
+     * @param {String} args.subject The subject of the message
+     * @param {String} args.body The body content of the message
+     * @param {String} [args.originSessionId] The session ID this message originates from
+     * @param {String[]} [args.relatedSessions] Array of session IDs related to this message
+     * @param {String[]} [args.relatedTickets] Array of ticket IDs referenced
+     * @param {String} [args.inReplyTo] Message ID this replies to
+     * @param {String} [args.priority='normal'] Message priority ('low', 'normal', or 'high')
+     * @param {String} [args.partOfThread] Thread ID
+     * @param {String[]} [args.taggedConcepts] Array of concept IDs tagged
      * @returns {Promise<Object>}
      */
-    async addMessage({ to, subject, body }) {
+    async addMessage({ to, subject, body, originSessionId, relatedSessions = [], relatedTickets = [], inReplyTo, priority = 'normal', partOfThread, taggedConcepts = [] }) {
         const sentBy = RequestContextService.getAgentIdentityNodeId();
         if (!sentBy) {
             throw new Error("Cannot send message: no agent identity context bound. Ensure StdioIdentityResolver or OIDC transport is active.");
@@ -81,6 +88,7 @@ class MailboxService extends Base {
             properties: {
                 subject,
                 bodyText: body,
+                priority,
                 sentAt: timestamp,
                 readAt: null
             }
@@ -90,16 +98,31 @@ class MailboxService extends Base {
         GraphService.linkNodes(messageId, sentBy, 'SENT_BY', 1.0, { timestamp });
         GraphService.linkNodes(messageId, to, 'SENT_TO', 1.0, { timestamp });
 
-        return { messageId, sentAt: timestamp, status: 'sent' };
+        // 3. Map additional graph semantic edges
+        if (originSessionId) GraphService.linkNodes(messageId, originSessionId, 'ORIGINATES_IN', 1.0, { timestamp });
+        if (inReplyTo) GraphService.linkNodes(messageId, inReplyTo, 'IN_REPLY_TO', 1.0, { timestamp });
+        if (partOfThread) GraphService.linkNodes(messageId, partOfThread, 'PART_OF_THREAD', 1.0, { timestamp });
+        
+        for (const s of relatedSessions) GraphService.linkNodes(messageId, s, 'RELATED_SESSION', 1.0, { timestamp });
+        for (const t of relatedTickets) GraphService.linkNodes(messageId, t, 'REFERENCES_TICKET', 1.0, { timestamp });
+        for (const c of taggedConcepts) GraphService.linkNodes(messageId, c, 'TAGGED_CONCEPT', 1.0, { timestamp });
+
+        return { messageId, sentAt: timestamp, priority, status: 'sent' };
     }
 
     /**
-     * Lists messages sent to the calling agent or broadcast.
+     * Lists messages in the mailbox.
      * @param {Object} args
-     * @param {String} [args.status='all']
+     * @param {String} [args.box='inbox'] Which box to list ('inbox', 'outbox', 'all')
+     * @param {String} [args.status='all'] Read status ('all', 'read', 'unread')
+     * @param {String} [args.to] Target identity to list messages for (defaults to caller)
+     * @param {String} [args.threadId] Filter by specific thread
+     * @param {String} [args.from] Filter by specific sender
+     * @param {Number} [args.limit=50] Maximum number of messages to return
+     * @param {Number} [args.offset=0] Pagination offset
      * @returns {Promise<Object>}
      */
-    async listMessages({ status = 'all', to } = {}) {
+    async listMessages({ box = 'inbox', status = 'all', to, threadId, from, limit = 50, offset = 0 } = {}) {
         const me = RequestContextService.getAgentIdentityNodeId();
         if (!me) {
             throw new Error("Cannot list messages: no agent identity context bound.");
@@ -114,44 +137,77 @@ class MailboxService extends Base {
         }
 
         const db = GraphService.db;
-        const messages = [];
+        let messages = [];
 
-        // Simple iteration over edges for now; fine for A2A scale.
         for (const edge of db.edges.items) {
-            if (edge.type === 'SENT_TO' && (edge.target === target || edge.target === 'AGENT:*')) {
-                const messageNode = db.nodes.get(edge.source);
+            let isMatch = false;
+            let targetNode = null;
+            let senderNode = null;
+
+            if (edge.type === 'SENT_TO') {
+                targetNode = edge.target;
+                if ((box === 'inbox' || box === 'all') && (targetNode === target || targetNode === 'AGENT:*')) {
+                    isMatch = true;
+                }
+            } else if (edge.type === 'SENT_BY') {
+                senderNode = edge.target;
+                if ((box === 'outbox' || box === 'all') && senderNode === target) {
+                    isMatch = true;
+                }
+            }
+
+            if (isMatch) {
+                // Determine message node id depending on which edge we matched
+                const messageNodeId = edge.source;
+                // Avoid duplicates if 'all' is chosen
+                if (messages.find(m => m.messageId === messageNodeId)) continue;
+                
+                const messageNode = db.nodes.get(messageNodeId);
                 if (messageNode && messageNode.label === 'MESSAGE') {
                     const isUnread = !messageNode.properties.readAt;
                     if (status === 'unread' && !isUnread) continue;
+                    if (status === 'read' && isUnread) continue;
 
-                    let sentByNodeId = null;
+                    let sentByNodeId = senderNode;
+                    let sentToNodeId = targetNode;
+                    let foundThreadId = null;
+
                     for (const sourceEdge of db.edges.items) {
-                        if (sourceEdge.source === messageNode.id && sourceEdge.type === 'SENT_BY') {
-                            sentByNodeId = sourceEdge.target;
-                            break;
+                        if (sourceEdge.source === messageNode.id) {
+                            if (sourceEdge.type === 'SENT_BY') sentByNodeId = sourceEdge.target;
+                            if (sourceEdge.type === 'SENT_TO') sentToNodeId = sourceEdge.target;
+                            if (sourceEdge.type === 'PART_OF_THREAD') foundThreadId = sourceEdge.target;
                         }
                     }
+
+                    if (from && sentByNodeId !== from) continue;
+                    if (threadId && foundThreadId !== threadId) continue;
 
                     messages.push({
                         messageId: messageNode.id,
                         subject: messageNode.properties.subject,
+                        priority: messageNode.properties.priority,
                         sentAt: messageNode.properties.sentAt,
                         readAt: messageNode.properties.readAt,
                         from: sentByNodeId,
-                        to: edge.target
+                        to: sentToNodeId
                     });
                 }
             }
         }
 
         messages.sort((a, b) => new Date(b.sentAt).getTime() - new Date(a.sentAt).getTime());
+        
+        // Pagination
+        messages = messages.slice(offset, offset + limit);
+        
         return { messages };
     }
 
     /**
      * Retrieves a single message.
      * @param {Object} args
-     * @param {String} args.messageId
+     * @param {String} args.messageId The ID of the message to retrieve
      * @returns {Promise<Object>}
      */
     async getMessage({ messageId }) {
@@ -212,7 +268,7 @@ class MailboxService extends Base {
     /**
      * Marks a message as read.
      * @param {Object} args
-     * @param {String} args.messageId
+     * @param {String} args.messageId The ID of the message to mark read
      * @returns {Promise<Object>}
      */
     async markRead({ messageId }) {

--- a/ai/mcp/server/memory-core/services/MailboxService.mjs
+++ b/ai/mcp/server/memory-core/services/MailboxService.mjs
@@ -1,0 +1,250 @@
+import Base from '../../../../../src/core/Base.mjs';
+import RequestContextService from '../../shared/services/RequestContextService.mjs';
+import GraphService from './GraphService.mjs';
+import PermissionService from './PermissionService.mjs';
+import crypto from 'crypto';
+
+/**
+ * @summary A2A (Agent-to-Agent) Messaging Service mapped to the Native Edge Graph.
+ *
+ * Implements the Mailbox primitives for direct or broadcast agent communications.
+ * Messages are stored as graph nodes of `type: 'MESSAGE'`, with `SENT_BY` and `SENT_TO` edges.
+ *
+ * @class Neo.ai.mcp.server.memory-core.services.MailboxService
+ * @extends Neo.core.Base
+ * @singleton
+ */
+class MailboxService extends Base {
+    static config = {
+        /**
+         * @member {String} className='Neo.ai.mcp.server.memory-core.services.MailboxService'
+         * @protected
+         */
+        className: 'Neo.ai.mcp.server.memory-core.services.MailboxService',
+        /**
+         * @member {Boolean} singleton=true
+         * @protected
+         */
+        singleton: true
+    }
+
+    /**
+     * Adds a new message to the mailbox system.
+     * @param {Object} args
+     * @param {String} args.to
+     * @param {String} args.subject
+     * @param {String} args.body
+     * @returns {Promise<Object>}
+     */
+    async addMessage({ to, subject, body }) {
+        const sentBy = RequestContextService.getAgentIdentityNodeId();
+        if (!sentBy) {
+            throw new Error("Cannot send message: no agent identity context bound. Ensure StdioIdentityResolver or OIDC transport is active.");
+        }
+
+        const messageId = `MESSAGE:${crypto.randomUUID()}`;
+        const timestamp = new Date().toISOString();
+
+        // Check reply permission
+        if (to !== 'AGENT:*' && to !== sentBy) {
+            let canReply = PermissionService.hasPermission(sentBy, to, 'CAN_REPLY_TO');
+
+            // Reachable counterparty logic: if they ever sent us a message, we can reply
+            if (!canReply) {
+                for (const edge of GraphService.db.edges.items) {
+                    if (edge.type === 'SENT_TO' && edge.target === sentBy) {
+                        let priorSender = null;
+                        for (const srcEdge of GraphService.db.edges.items) {
+                            if (srcEdge.source === edge.source && srcEdge.type === 'SENT_BY') {
+                                priorSender = srcEdge.target;
+                                break;
+                            }
+                        }
+                        if (priorSender === to) {
+                            canReply = true;
+                            break;
+                        }
+                    }
+                }
+            }
+
+            if (!canReply) {
+                throw new Error(`Unauthorized: Cannot send to ${to}. Requires CAN_REPLY_TO permission or prior message history.`);
+            }
+        }
+
+        // 1. Create the Message Node
+        GraphService.upsertNode({
+            id: messageId,
+            type: 'MESSAGE',
+            name: subject,
+            properties: {
+                subject,
+                bodyText: body,
+                sentAt: timestamp,
+                readAt: null
+            }
+        });
+
+        // 2. Map the routing edges
+        GraphService.linkNodes(messageId, sentBy, 'SENT_BY', 1.0, { timestamp });
+        GraphService.linkNodes(messageId, to, 'SENT_TO', 1.0, { timestamp });
+
+        return { messageId, sentAt: timestamp, status: 'sent' };
+    }
+
+    /**
+     * Lists messages sent to the calling agent or broadcast.
+     * @param {Object} args
+     * @param {String} [args.status='all']
+     * @returns {Promise<Object>}
+     */
+    async listMessages({ status = 'all', to } = {}) {
+        const me = RequestContextService.getAgentIdentityNodeId();
+        if (!me) {
+            throw new Error("Cannot list messages: no agent identity context bound.");
+        }
+
+        const target = to || me;
+
+        if (target !== me && target !== 'AGENT:*') {
+            if (!PermissionService.hasPermission(me, target, 'CAN_READ_INBOX_OF')) {
+                throw new Error(`Unauthorized: no CAN_READ_INBOX_OF permission for ${target}`);
+            }
+        }
+
+        const db = GraphService.db;
+        const messages = [];
+
+        // Simple iteration over edges for now; fine for A2A scale.
+        for (const edge of db.edges.items) {
+            if (edge.type === 'SENT_TO' && (edge.target === target || edge.target === 'AGENT:*')) {
+                const messageNode = db.nodes.get(edge.source);
+                if (messageNode && messageNode.label === 'MESSAGE') {
+                    const isUnread = !messageNode.properties.readAt;
+                    if (status === 'unread' && !isUnread) continue;
+
+                    let sentByNodeId = null;
+                    for (const sourceEdge of db.edges.items) {
+                        if (sourceEdge.source === messageNode.id && sourceEdge.type === 'SENT_BY') {
+                            sentByNodeId = sourceEdge.target;
+                            break;
+                        }
+                    }
+
+                    messages.push({
+                        messageId: messageNode.id,
+                        subject: messageNode.properties.subject,
+                        sentAt: messageNode.properties.sentAt,
+                        readAt: messageNode.properties.readAt,
+                        from: sentByNodeId,
+                        to: edge.target
+                    });
+                }
+            }
+        }
+
+        messages.sort((a, b) => new Date(b.sentAt).getTime() - new Date(a.sentAt).getTime());
+        return { messages };
+    }
+
+    /**
+     * Retrieves a single message.
+     * @param {Object} args
+     * @param {String} args.messageId
+     * @returns {Promise<Object>}
+     */
+    async getMessage({ messageId }) {
+        const me = RequestContextService.getAgentIdentityNodeId();
+        if (!me) {
+            throw new Error("Cannot get message: no agent identity context bound.");
+        }
+
+        const db = GraphService.db;
+        const messageNode = db.nodes.get(messageId);
+        if (!messageNode || messageNode.label !== 'MESSAGE') {
+            throw new Error(`Message not found: ${messageId}`);
+        }
+
+        let isAuthorized = false;
+        let sentBy = null;
+        let sentTo = null;
+
+        for (const edge of db.edges.items) {
+            if (edge.source === messageId) {
+                if (edge.type === 'SENT_TO') {
+                    sentTo = edge.target;
+                    if (edge.target === me || edge.target === 'AGENT:*') {
+                        isAuthorized = true;
+                    }
+                }
+                if (edge.type === 'SENT_BY') {
+                    sentBy = edge.target;
+                }
+            }
+        }
+
+        // Sender can also read
+        if (sentBy === me) {
+            isAuthorized = true;
+        } else if (!isAuthorized && sentTo && sentTo !== me && sentTo !== 'AGENT:*') {
+            // Check if me has permission to read sentTo's inbox
+            if (PermissionService.hasPermission(me, sentTo, 'CAN_READ_INBOX_OF')) {
+                isAuthorized = true;
+            }
+        }
+
+        if (!isAuthorized) {
+            throw new Error(`Unauthorized: message ${messageId} was not sent to or from ${me}. (Read-path validation strictly enforced per Phase 3 rules)`);
+        }
+
+        return {
+            messageId,
+            subject: messageNode.properties.subject,
+            body: messageNode.properties.bodyText,
+            sentAt: messageNode.properties.sentAt,
+            readAt: messageNode.properties.readAt,
+            from: sentBy,
+            to: sentTo
+        };
+    }
+
+    /**
+     * Marks a message as read.
+     * @param {Object} args
+     * @param {String} args.messageId
+     * @returns {Promise<Object>}
+     */
+    async markRead({ messageId }) {
+        const me = RequestContextService.getAgentIdentityNodeId();
+        if (!me) {
+            throw new Error("Cannot mark message read: no agent identity context bound.");
+        }
+
+        const db = GraphService.db;
+        const messageNode = db.nodes.get(messageId);
+        if (!messageNode || messageNode.label !== 'MESSAGE') {
+            throw new Error(`Message not found: ${messageId}`);
+        }
+
+        let isRecipient = false;
+        for (const edge of db.edges.items) {
+            if (edge.source === messageId && edge.type === 'SENT_TO' && (edge.target === me || edge.target === 'AGENT:*')) {
+                isRecipient = true;
+                break;
+            }
+        }
+
+        if (!isRecipient) {
+            throw new Error(`Unauthorized: you are not the recipient of message ${messageId}`);
+        }
+
+        // Trigger an upsert to save to file backing store and notify listeners
+        messageNode.properties.readAt = new Date().toISOString();
+        GraphService.upsertNode(messageNode);
+
+        return { messageId, readAt: messageNode.properties.readAt, status: 'read' };
+    }
+}
+
+export default Neo.setupClass(MailboxService);

--- a/ai/mcp/server/memory-core/services/PermissionService.mjs
+++ b/ai/mcp/server/memory-core/services/PermissionService.mjs
@@ -107,8 +107,15 @@ class PermissionService extends Base {
      * @returns {Promise<Object>}
      */
     async listPermissions({ forIdentity } = {}) {
-        const targetId = forIdentity || RequestContextService.getAgentIdentityNodeId();
-        if (!targetId) throw new Error("Cannot list permissions: no agent identity context bound and no forIdentity provided.");
+        const caller = RequestContextService.getAgentIdentityNodeId();
+        if (!caller) throw new Error("Cannot list permissions: no agent identity context bound.");
+
+        const targetId = forIdentity || caller;
+
+        // Prevent arbitrary enumeration of other agents' permissions unless the caller is the target
+        if (targetId !== caller) {
+            throw new Error(`Unauthorized: Cannot enumerate permissions for ${targetId}`);
+        }
 
         const db = GraphService.db;
         const capabilities = [];     // Things targetId can do to others

--- a/ai/mcp/server/memory-core/services/PermissionService.mjs
+++ b/ai/mcp/server/memory-core/services/PermissionService.mjs
@@ -1,0 +1,165 @@
+import Base from '../../../../../src/core/Base.mjs';
+import GraphService from './GraphService.mjs';
+import RequestContextService from '../../shared/services/RequestContextService.mjs';
+import logger from '../logger.mjs';
+
+/**
+ * @summary Service for managing cross-tenant permission edges in the Native Graph.
+ *
+ * Implements the explicit permission checks required for Phase 3 (#10146).
+ * The default policy is strict-isolation (opt-in visibility). Permissions are
+ * granted via Graph edges representing the capability.
+ *
+ * Edge Structure:
+ * - A permission capability flows from the grantee to the granter.
+ * - E.g. Alice `CAN_READ_INBOX_OF` Bob means:
+ *   Edge source = Alice (grantee)
+ *   Edge target = Bob (granter/owner)
+ *   Edge type = `CAN_READ_INBOX_OF`
+ *
+ * @class Neo.ai.mcp.server.memory-core.services.PermissionService
+ * @extends Neo.core.Base
+ * @singleton
+ */
+class PermissionService extends Base {
+    static config = {
+        /**
+         * @member {String} className='Neo.ai.mcp.server.memory-core.services.PermissionService'
+         * @protected
+         */
+        className: 'Neo.ai.mcp.server.memory-core.services.PermissionService',
+        /**
+         * @member {Boolean} singleton=true
+         * @protected
+         */
+        singleton: true
+    }
+
+    /**
+     * @member {String[]} validScopes
+     * @protected
+     */
+    validScopes = ['CAN_READ_INBOX_OF', 'CAN_READ_MEMORIES_OF', 'CAN_READ_SESSIONS_OF', 'CAN_REPLY_TO']
+
+    /**
+     * Grants a permission. The caller is the owner of the resource granting access TO another identity.
+     * This creates a graph edge where `source = to` and `target = caller`.
+     *
+     * @param {Object} opts
+     * @param {String} opts.to The agent identity being granted the permission
+     * @param {String} opts.scope The permission scope
+     * @returns {Promise<Object>}
+     */
+    async grantPermission({ to, scope }) {
+        const owner = RequestContextService.getAgentIdentityNodeId();
+        if (!owner) throw new Error("Cannot grant permission: no agent identity context bound.");
+        if (!to) throw new Error("Missing 'to' parameter.");
+        if (!scope) throw new Error("Missing 'scope' parameter.");
+
+        if (!this.validScopes.includes(scope)) {
+            throw new Error(`Invalid scope. Must be one of: ${this.validScopes.join(', ')}`);
+        }
+
+        // Check if node exists
+        const db = GraphService.db;
+        if (!db.nodes.get(to)) {
+            // It's technically fine if the target doesn't exist yet, but linkNodes might cull it if not found in SQLite.
+            // Let's lazily ensure the node exists if we're granting permission to it.
+            GraphService.upsertNode({ id: to, type: 'AGENT', name: to.replace('AGENT:', ''), properties: {} });
+        }
+
+        // The capability belongs to 'to', pointing at 'owner'
+        // e.g. "Alice CAN_READ_INBOX_OF Bob" (source: Alice, target: Bob)
+        GraphService.linkNodes(to, owner, scope, 1.0);
+        return { success: true, message: `Granted ${scope} to ${to}` };
+    }
+
+    /**
+     * Revokes a permission. The caller is the owner of the resource revoking access FROM another identity.
+     * @param {Object} opts
+     * @param {String} opts.to The agent identity losing the permission
+     * @param {String} opts.scope The permission scope
+     * @returns {Promise<Object>}
+     */
+    async revokePermission({ to, scope }) {
+        const owner = RequestContextService.getAgentIdentityNodeId();
+        if (!owner) throw new Error("Cannot revoke permission: no agent identity context bound.");
+        
+        const db = GraphService.db;
+        const edgesToRemove = [];
+        for (const edge of db.edges.items) {
+            if (edge.source === to && edge.target === owner && edge.type === scope) {
+                edgesToRemove.push(edge);
+            }
+        }
+
+        if (edgesToRemove.length > 0) {
+            db.edges.remove(edgesToRemove);
+        }
+        
+        return { success: true, message: `Revoked ${scope} from ${to}` };
+    }
+
+    /**
+     * Lists permissions for an identity. Defaults to the caller.
+     * @param {Object} opts
+     * @param {String} [opts.forIdentity] The identity to list permissions for.
+     * @returns {Promise<Object>}
+     */
+    async listPermissions({ forIdentity } = {}) {
+        const targetId = forIdentity || RequestContextService.getAgentIdentityNodeId();
+        if (!targetId) throw new Error("Cannot list permissions: no agent identity context bound and no forIdentity provided.");
+
+        const db = GraphService.db;
+        const capabilities = [];     // Things targetId can do to others
+        const grantedToOthers = [];  // Things others can do to targetId
+
+        for (const edge of db.edges.items) {
+            if (this.validScopes.includes(edge.type)) {
+                if (edge.source === targetId) {
+                    capabilities.push({ 
+                        target: edge.target, 
+                        scope: edge.type, 
+                        timestamp: edge.properties?.timestamp 
+                    });
+                }
+                if (edge.target === targetId) {
+                    grantedToOthers.push({ 
+                        grantedTo: edge.source, 
+                        scope: edge.type, 
+                        timestamp: edge.properties?.timestamp 
+                    });
+                }
+            }
+        }
+
+        return { identity: targetId, capabilities, grantedToOthers };
+    }
+
+    /**
+     * Synchronous check if the caller has the specified permission against the target.
+     * @param {String} caller The identity attempting the action
+     * @param {String} target The identity that owns the resource
+     * @param {String} scope The required scope
+     * @returns {Boolean}
+     */
+    hasPermission(caller, target, scope) {
+        // Broadcasts are pseudo-targets; checking permission against broadcast logic
+        // is typically handled at the service layer, but structurally always allowed.
+        if (target === 'AGENT:*') return true;
+
+        // Identity always has permission to their own resources
+        if (caller === target) return true;
+
+        const db = GraphService.db;
+        for (const edge of db.edges.items) {
+            if (edge.source === caller && edge.target === target && edge.type === scope) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}
+
+export default Neo.setupClass(PermissionService);

--- a/ai/mcp/server/memory-core/services/toolService.mjs
+++ b/ai/mcp/server/memory-core/services/toolService.mjs
@@ -8,6 +8,8 @@ import HealthService            from './HealthService.mjs';
 import MemoryService            from './MemoryService.mjs';
 import SessionService           from './SessionService.mjs';
 import SummaryService           from './SummaryService.mjs';
+import MailboxService           from './MailboxService.mjs';
+import PermissionService        from './PermissionService.mjs';
 
 const __filename      = fileURLToPath(import.meta.url);
 const __dirname       = path.dirname(__filename);
@@ -29,7 +31,14 @@ const serviceMapping = {
     query_raw_memories    : MemoryService           .queryMemories       .bind(MemoryService),
     query_summaries       : SummaryService          .querySummaries      .bind(SummaryService),
     search_nodes          : GraphService            .searchNodes         .bind(GraphService),
-    summarize_sessions    : SessionService          .summarizeSessions   .bind(SessionService)
+    summarize_sessions    : SessionService          .summarizeSessions   .bind(SessionService),
+    add_message           : MailboxService          .addMessage          .bind(MailboxService),
+    list_messages         : MailboxService          .listMessages        .bind(MailboxService),
+    get_message           : MailboxService          .getMessage          .bind(MailboxService),
+    mark_read             : MailboxService          .markRead            .bind(MailboxService),
+    grant_permission      : PermissionService       .grantPermission     .bind(PermissionService),
+    revoke_permission     : PermissionService       .revokePermission    .bind(PermissionService),
+    list_permissions      : PermissionService       .listPermissions     .bind(PermissionService)
 };
 
 const toolService = Neo.create(ToolService, {

--- a/learn/agentos/tooling/MemoryCoreMcpAuth.md
+++ b/learn/agentos/tooling/MemoryCoreMcpAuth.md
@@ -172,42 +172,37 @@ The `AuthMiddleware` refused a tool-call argument. Check that the client is not 
 
 ## Service Relationships
 
-```
-┌────────────────────────────────────────────────────────────────┐
-│                    MCP Tool Call Dispatch                       │
-│  ┌──────────────────┐    ┌──────────────────┐                   │
-│  │  SSE Transport   │    │ Stdio Transport  │                   │
-│  │ TransportService │    │    Server.mjs    │                   │
-│  └────────┬─────────┘    └────────┬─────────┘                   │
-│           │                       │                             │
-│           ▼                       ▼                             │
-│  ┌──────────────────┐    ┌───────────────────────┐              │
-│  │   AuthService    │    │ StdioIdentityResolver │              │
-│  │ (OIDC introspect)│    │ (env-var + gh-CLI)    │              │
-│  └────────┬─────────┘    └────────┬──────────────┘              │
-│           │                       │                             │
-│           └──────────┬────────────┘                             │
-│                      ▼                                          │
-│             ┌──────────────────┐                                │
-│             │  bindAgentIdent  │                                │
-│             │   (graph lookup) │                                │
-│             └────────┬─────────┘                                │
-│                      ▼                                          │
-│        ┌─────────────────────────────┐                          │
-│        │   RequestContextService     │                          │
-│        │ .run(identity, dispatch)    │                          │
-│        └────────────┬────────────────┘                          │
-│                     ▼                                           │
-│         ┌──────────────────────┐                                │
-│         │   AuthMiddleware     │                                │
-│         │ .validateNoSpoof()   │                                │
-│         └──────────┬───────────┘                                │
-│                    ▼                                            │
-│         ┌──────────────────────┐                                │
-│         │      callTool()      │                                │
-│         │  (service dispatch)  │                                │
-│         └──────────────────────┘                                │
-└────────────────────────────────────────────────────────────────┘
+```mermaid
+flowchart TD
+    subgraph MCP ["MCP Tool Call Dispatch"]
+        direction TD
+        
+        SSE["SSE Transport\nTransportService"]
+        STDIO["Stdio Transport\nServer.mjs"]
+        
+        AuthSvc["AuthService\n(OIDC introspect)"]
+        StdioRes["StdioIdentityResolver\n(env-var + gh-CLI)"]
+        
+        SSE --> AuthSvc
+        STDIO --> StdioRes
+        
+        Bind["bindAgentIdent\n(graph lookup)"]
+        
+        AuthSvc --> Bind
+        StdioRes --> Bind
+        
+        ReqCtx["RequestContextService\n.run(identity, dispatch)"]
+        
+        Bind --> ReqCtx
+        
+        AuthMid["AuthMiddleware\n.validateNoSpoof()"]
+        
+        ReqCtx --> AuthMid
+        
+        CallTool["callTool()\n(service dispatch)"]
+        
+        AuthMid --> CallTool
+    end
 ```
 
 ## Cross-Tenant Permissions

--- a/learn/agentos/tooling/MemoryCoreMcpAuth.md
+++ b/learn/agentos/tooling/MemoryCoreMcpAuth.md
@@ -210,6 +210,36 @@ The `AuthMiddleware` refused a tool-call argument. Check that the client is not 
 └────────────────────────────────────────────────────────────────┘
 ```
 
+## Cross-Tenant Permissions
+
+Beyond the baseline strict-isolate policy, cross-tenant access is granted via explicit **capability edges** in the Native Edge Graph. A permission edge flows **from** the grantee (the identity receiving the capability) **to** the granter (the identity granting access).
+
+For example, if Bob wants to allow Alice to read his inbox:
+- Bob calls the `grant_permission` tool with `to: AGENT:alice` and `scope: CAN_READ_INBOX_OF`.
+- The Memory Core creates an edge: `Source: AGENT:alice` -> `Target: AGENT:bob` with type `CAN_READ_INBOX_OF`.
+
+### Valid Scopes
+
+The system currently supports the following scopes:
+- `CAN_READ_INBOX_OF`: Allows the grantee to read messages sent to the granter's inbox.
+- `CAN_REPLY_TO`: Allows the grantee to send a direct message to the granter.
+- `CAN_READ_MEMORIES_OF`: (Reserved for future use) Allows reading raw memories.
+- `CAN_READ_SESSIONS_OF`: (Reserved for future use) Allows reading session summaries.
+
+## Mailbox A2A Integration
+
+The Mailbox A2A service natively integrates with the `PermissionService` to enforce the strict-isolate policy:
+
+### Sending Messages (`addMessage`)
+- To send a direct message, the sender MUST have the `CAN_REPLY_TO` permission for the target recipient.
+- **Reachable Counterparty Exception:** If the target recipient has *previously sent a message* to the sender, the system infers an implicit trust chain, and the sender is allowed to reply without an explicit `CAN_REPLY_TO` edge.
+- Broadcast messages (`to: AGENT:*`) are always permitted.
+
+### Reading Messages (`listMessages` & `getMessage`)
+- Agents can inherently read their own inbox and broadcast messages.
+- To read another agent's inbox (e.g., via `listMessages({ to: 'AGENT:bob' })`), the calling agent MUST hold the `CAN_READ_INBOX_OF` permission for that target agent.
+- Senders always retain the ability to read the specific messages they have sent, regardless of the recipient's permissions.
+
 ## See Also
 
 - `ai/mcp/server/shared/services/AuthService.mjs` — OIDC discovery and token introspection

--- a/test/playwright/unit/ai/mcp/server/memory-core/services/MailboxService.spec.mjs
+++ b/test/playwright/unit/ai/mcp/server/memory-core/services/MailboxService.spec.mjs
@@ -1,0 +1,175 @@
+import {setup} from '../../../../../../setup.mjs';
+
+const appName = 'MailboxServiceTest';
+
+setup({
+    neoConfig: {
+        unitTestMode: true
+    },
+    appConfig: {
+        name             : appName,
+        isMounted        : () => true,
+        vnodeInitialising: false
+    }
+});
+
+import {test, expect}        from '@playwright/test';
+import Neo                   from '../../../../../../../../src/Neo.mjs';
+import RequestContextService from '../../../../../../../../ai/mcp/server/shared/services/RequestContextService.mjs';
+
+test.describe('Neo.ai.mcp.server.memory-core.services.MailboxService', () => {
+    let MailboxService, GraphService, PermissionService, LifecycleService;
+    
+    test.beforeAll(async () => {
+        // Load dynamically due to SQLite DB mount timing
+        GraphService = (await import('../../../../../../../../ai/mcp/server/memory-core/services/GraphService.mjs')).default;
+        MailboxService = (await import('../../../../../../../../ai/mcp/server/memory-core/services/MailboxService.mjs')).default;
+        PermissionService = (await import('../../../../../../../../ai/mcp/server/memory-core/services/PermissionService.mjs')).default;
+        LifecycleService = (await import('../../../../../../../../ai/mcp/server/memory-core/services/lifecycle/SystemLifecycleService.mjs')).default;
+
+        // Force in-memory DB config
+        const aiConfig = (await import('../../../../../../../../ai/mcp/server/memory-core/config.mjs')).default;
+        aiConfig.storagePaths.graph = ':memory:';
+
+        if (!LifecycleService._initPromise) {
+            await LifecycleService.initAsync();
+        } else {
+            await LifecycleService.ready();
+        }
+    });
+
+    test.afterAll(async () => {
+        // cleanup if needed
+    });
+
+    test.beforeEach(async () => {
+        // Ensure a clean slate per test
+        if (GraphService.db) {
+            GraphService.db.nodes.clear();
+            GraphService.db.edges.clear();
+            GraphService.db.vicinityLoadedNodes.clear();
+
+            if (GraphService.db.storage?.db) {
+                await GraphService.db.storage.clear();
+                GraphService.db.storage.db.exec('DELETE FROM GraphLog');
+            }
+        }
+
+        // Seed agents
+        GraphService.upsertNode({ id: 'AGENT:alice', type: 'AGENT', name: 'Alice', properties: {} });
+        GraphService.upsertNode({ id: 'AGENT:bob', type: 'AGENT', name: 'Bob', properties: {} });
+        GraphService.upsertNode({ id: 'AGENT:*', type: 'AGENT', name: 'Broadcast', properties: {} });
+    });
+
+    test('addMessage enforces identity and routes correctly', async () => {
+        await RequestContextService.run({ agentIdentityNodeId: 'AGENT:bob' }, async () => {
+            await PermissionService.grantPermission({ to: 'AGENT:alice', scope: 'CAN_REPLY_TO' });
+        });
+
+        const promise = RequestContextService.run({ agentIdentityNodeId: 'AGENT:alice' }, async () => {
+            return await MailboxService.addMessage({ to: 'AGENT:bob', subject: 'Hello', body: 'Test body' });
+        });
+        let res = await promise;
+        
+        expect(res.status).toBe('sent');
+        expect(res.messageId).toMatch(/^MESSAGE:/);
+
+        const node = GraphService.db.nodes.get(res.messageId);
+        expect(node.properties.subject).toBe('Hello');
+
+        // Verify edges
+        let sentBy, sentTo;
+        for (const edge of GraphService.db.edges.items) {
+            if (edge.source === res.messageId) {
+                if (edge.type === 'SENT_BY') sentBy = edge.target;
+                if (edge.type === 'SENT_TO') sentTo = edge.target;
+            }
+        }
+        expect(sentBy).toBe('AGENT:alice');
+        expect(sentTo).toBe('AGENT:bob');
+    });
+
+    test('listMessages properly isolates by identity', async () => {
+        await RequestContextService.run({ agentIdentityNodeId: 'AGENT:bob' }, async () => {
+            await PermissionService.grantPermission({ to: 'AGENT:alice', scope: 'CAN_REPLY_TO' });
+        });
+
+        // Alice sends to Bob
+        await RequestContextService.run({ agentIdentityNodeId: 'AGENT:alice' }, async () => {
+            await MailboxService.addMessage({ to: 'AGENT:bob', subject: 'To Bob', body: 'Secret' });
+        });
+        
+        // Alice sends to Broadcast
+        await RequestContextService.run({ agentIdentityNodeId: 'AGENT:alice' }, async () => {
+            await MailboxService.addMessage({ to: 'AGENT:*', subject: 'To All', body: 'Public' });
+        });
+
+        // Bob reads
+        const bobRes = await RequestContextService.run({ agentIdentityNodeId: 'AGENT:bob' }, async () => {
+            return await MailboxService.listMessages({ status: 'all' });
+        });
+        
+        expect(bobRes.messages.length).toBe(2);
+        expect(bobRes.messages.find(m => m.subject === 'To Bob')).toBeDefined();
+        expect(bobRes.messages.find(m => m.subject === 'To All')).toBeDefined();
+
+        // Charlie (new agent) reads - should only see broadcast
+        GraphService.upsertNode({ id: 'AGENT:charlie', type: 'AGENT', name: 'Charlie', properties: {} });
+        const charlieRes = await RequestContextService.run({ agentIdentityNodeId: 'AGENT:charlie' }, async () => {
+            return await MailboxService.listMessages({ status: 'all' });
+        });
+        
+        expect(charlieRes.messages.length).toBe(1);
+        expect(charlieRes.messages[0].subject).toBe('To All');
+    });
+
+    test('getMessage enforces read-path isolation', async () => {
+        await RequestContextService.run({ agentIdentityNodeId: 'AGENT:bob' }, async () => {
+            await PermissionService.grantPermission({ to: 'AGENT:alice', scope: 'CAN_REPLY_TO' });
+        });
+
+        let msgId;
+        await RequestContextService.run({ agentIdentityNodeId: 'AGENT:alice' }, async () => {
+            const res = await MailboxService.addMessage({ to: 'AGENT:bob', subject: 'Private', body: '123' });
+            msgId = res.messageId;
+        });
+
+        // Bob can read
+        const bobRead = await RequestContextService.run({ agentIdentityNodeId: 'AGENT:bob' }, async () => {
+            return await MailboxService.getMessage({ messageId: msgId });
+        });
+        expect(bobRead.body).toBe('123');
+
+        // Alice (sender) can read
+        const aliceRead = await RequestContextService.run({ agentIdentityNodeId: 'AGENT:alice' }, async () => {
+            return await MailboxService.getMessage({ messageId: msgId });
+        });
+        expect(aliceRead.body).toBe('123');
+
+        // Charlie cannot read
+        GraphService.upsertNode({ id: 'AGENT:charlie', type: 'AGENT', name: 'Charlie', properties: {} });
+        await RequestContextService.run({ agentIdentityNodeId: 'AGENT:charlie' }, async () => {
+            await expect(MailboxService.getMessage({ messageId: msgId })).rejects.toThrow(/Unauthorized/);
+        });
+    });
+
+    test('markRead updates the readAt property', async () => {
+        await RequestContextService.run({ agentIdentityNodeId: 'AGENT:bob' }, async () => {
+            await PermissionService.grantPermission({ to: 'AGENT:alice', scope: 'CAN_REPLY_TO' });
+        });
+
+        let msgId;
+        await RequestContextService.run({ agentIdentityNodeId: 'AGENT:alice' }, async () => {
+            const res = await MailboxService.addMessage({ to: 'AGENT:bob', subject: 'Private', body: '123' });
+            msgId = res.messageId;
+        });
+
+        await RequestContextService.run({ agentIdentityNodeId: 'AGENT:bob' }, async () => {
+            const res = await MailboxService.markRead({ messageId: msgId });
+            expect(res.readAt).toBeTruthy();
+        });
+
+        const node = GraphService.db.nodes.get(msgId);
+        expect(node.properties.readAt).toBeTruthy();
+    });
+});

--- a/test/playwright/unit/ai/mcp/server/memory-core/services/PermissionService.spec.mjs
+++ b/test/playwright/unit/ai/mcp/server/memory-core/services/PermissionService.spec.mjs
@@ -1,0 +1,120 @@
+import {setup} from '../../../../../../setup.mjs';
+
+const appName = 'PermissionServiceTest';
+
+setup({
+    neoConfig: {
+        unitTestMode: true
+    },
+    appConfig: {
+        name             : appName,
+        isMounted        : () => true,
+        vnodeInitialising: false
+    }
+});
+
+import {test, expect}        from '@playwright/test';
+import Neo                   from '../../../../../../../../src/Neo.mjs';
+import RequestContextService from '../../../../../../../../ai/mcp/server/shared/services/RequestContextService.mjs';
+
+test.describe('Neo.ai.mcp.server.memory-core.services.PermissionService', () => {
+    let PermissionService, GraphService, LifecycleService;
+
+    test.beforeAll(async () => {
+        GraphService = (await import('../../../../../../../../ai/mcp/server/memory-core/services/GraphService.mjs')).default;
+        PermissionService = (await import('../../../../../../../../ai/mcp/server/memory-core/services/PermissionService.mjs')).default;
+        LifecycleService = (await import('../../../../../../../../ai/mcp/server/memory-core/services/lifecycle/SystemLifecycleService.mjs')).default;
+
+        const aiConfig = (await import('../../../../../../../../ai/mcp/server/memory-core/config.mjs')).default;
+        aiConfig.storagePaths.graph = ':memory:';
+
+        if (!LifecycleService._initPromise) {
+            await LifecycleService.initAsync();
+        } else {
+            await LifecycleService.ready();
+        }
+    });
+
+    test.beforeEach(async () => {
+        if (GraphService.db) {
+            GraphService.db.nodes.clear();
+            GraphService.db.edges.clear();
+            GraphService.db.vicinityLoadedNodes.clear();
+
+            if (GraphService.db.storage?.db) {
+                await GraphService.db.storage.clear();
+                GraphService.db.storage.db.exec('DELETE FROM GraphLog');
+            }
+        }
+
+        GraphService.upsertNode({ id: 'AGENT:alice', type: 'AGENT', name: 'Alice', properties: {} });
+        GraphService.upsertNode({ id: 'AGENT:bob', type: 'AGENT', name: 'Bob', properties: {} });
+    });
+
+    test('grantPermission creates a graph edge with correctly swapped source/target', async () => {
+        await RequestContextService.run({ agentIdentityNodeId: 'AGENT:bob' }, async () => {
+            const res = await PermissionService.grantPermission({ to: 'AGENT:alice', scope: 'CAN_READ_INBOX_OF' });
+            expect(res.success).toBe(true);
+        });
+
+        // The capability belongs to Alice, pointing at Bob
+        const edges = GraphService.db.edges.items;
+        expect(edges.length).toBe(1);
+        expect(edges[0].source).toBe('AGENT:alice');
+        expect(edges[0].target).toBe('AGENT:bob');
+        expect(edges[0].type).toBe('CAN_READ_INBOX_OF');
+    });
+
+    test('revokePermission removes the granted edge', async () => {
+        await RequestContextService.run({ agentIdentityNodeId: 'AGENT:bob' }, async () => {
+            await PermissionService.grantPermission({ to: 'AGENT:alice', scope: 'CAN_READ_INBOX_OF' });
+            expect(GraphService.db.edges.getCount()).toBe(1);
+
+            const res = await PermissionService.revokePermission({ to: 'AGENT:alice', scope: 'CAN_READ_INBOX_OF' });
+            expect(res.success).toBe(true);
+            expect(GraphService.db.edges.getCount()).toBe(0);
+        });
+    });
+
+    test('listPermissions shows capabilities and granted permissions', async () => {
+        await RequestContextService.run({ agentIdentityNodeId: 'AGENT:bob' }, async () => {
+            await PermissionService.grantPermission({ to: 'AGENT:alice', scope: 'CAN_READ_INBOX_OF' });
+        });
+        
+        // Alice should have a capability to read Bob's inbox
+        await RequestContextService.run({ agentIdentityNodeId: 'AGENT:alice' }, async () => {
+            const res = await PermissionService.listPermissions();
+            expect(res.capabilities.length).toBe(1);
+            expect(res.capabilities[0].target).toBe('AGENT:bob');
+            expect(res.capabilities[0].scope).toBe('CAN_READ_INBOX_OF');
+            expect(res.grantedToOthers.length).toBe(0);
+        });
+
+        // Bob should see he granted to Alice
+        await RequestContextService.run({ agentIdentityNodeId: 'AGENT:bob' }, async () => {
+            const res = await PermissionService.listPermissions();
+            expect(res.capabilities.length).toBe(0);
+            expect(res.grantedToOthers.length).toBe(1);
+            expect(res.grantedToOthers[0].grantedTo).toBe('AGENT:alice');
+            expect(res.grantedToOthers[0].scope).toBe('CAN_READ_INBOX_OF');
+        });
+    });
+
+    test('hasPermission validates correctly', async () => {
+        await RequestContextService.run({ agentIdentityNodeId: 'AGENT:bob' }, async () => {
+            await PermissionService.grantPermission({ to: 'AGENT:alice', scope: 'CAN_READ_INBOX_OF' });
+        });
+
+        // Alice checking against Bob
+        expect(PermissionService.hasPermission('AGENT:alice', 'AGENT:bob', 'CAN_READ_INBOX_OF')).toBe(true);
+
+        // Charlie checking against Bob
+        expect(PermissionService.hasPermission('AGENT:charlie', 'AGENT:bob', 'CAN_READ_INBOX_OF')).toBe(false);
+
+        // Bob checking against himself (always true)
+        expect(PermissionService.hasPermission('AGENT:bob', 'AGENT:bob', 'CAN_READ_INBOX_OF')).toBe(true);
+
+        // Checking against broadcast (always true)
+        expect(PermissionService.hasPermission('AGENT:alice', 'AGENT:*', 'CAN_READ_INBOX_OF')).toBe(true);
+    });
+});


### PR DESCRIPTION
Authored by Antigravity (Gemini 3.1 Pro). Session ada4aecb-60fc-4b25-a76b-cb92600835a2.

Resolves #10146
Resolves #10147

Implemented the Mailbox A2A multi-tenant infrastructure, enforcing strict tenant isolation through capability edges in the Native Edge Graph. Added the PermissionService to govern edge creation (grant/revoke/list) and wired its logic directly into the MailboxService read/write paths. Includes the Reachable Counterparty fallback for implicit reply paths.

## Deltas from ticket
Combined Phase 3 work covering schema, the 4 mailbox tools, the permission edges, middleware, and end-to-end tests into a single cohesive PR as requested.

*Explicit Deferrals:*
- Mailbox test coverage expansion and role-based addressing mode are deferred to #10168.
- TAGGED_CONCEPT automatic emission via SemanticGraphExtractor is deferred to #10169.

## Test Evidence
Ran Playwright tests for MailboxService and PermissionService:
`npx playwright test test/playwright/unit/ai/mcp/server/memory-core/services/MailboxService.spec.mjs` (Passed)
`npx playwright test test/playwright/unit/ai/mcp/server/memory-core/services/PermissionService.spec.mjs` (Passed)
