### PR TITLE
test+feat(mailbox): role-based addressing + expanded coverage + serial fixture isolation (#10168)

### DIFF
--- a/ai/mcp/server/memory-core/services/MailboxService.mjs
+++ b/ai/mcp/server/memory-core/services/MailboxService.mjs
@@ -52,8 +52,10 @@ class MailboxService extends Base {
         const messageId = `MESSAGE:${crypto.randomUUID()}`;
         const timestamp = new Date().toISOString();
 
+        const isRoleOrHuman = to.startsWith('role:') || to.startsWith('human:');
+
         // Check reply permission
-        if (to !== 'AGENT:*' && to !== sentBy) {
+        if (!isRoleOrHuman && to !== 'AGENT:*' && to !== sentBy) {
             let canReply = PermissionService.hasPermission(sentBy, to, 'CAN_REPLY_TO');
 
             // Reachable counterparty logic: if they ever sent us a message, we can reply

--- a/learn/agentos/tooling/MemoryCoreMcpAuth.md
+++ b/learn/agentos/tooling/MemoryCoreMcpAuth.md
@@ -227,12 +227,14 @@ The Mailbox A2A service natively integrates with the `PermissionService` to enfo
 
 ### Sending Messages (`addMessage`)
 - To send a direct message, the sender MUST have the `CAN_REPLY_TO` permission for the target recipient.
+- **Role & Human Addressing:** Sending to roles (`to: 'role:librarian'`) or human operators (`to: 'human:tobiu'`) is intentionally write-permissive and bypasses the `CAN_REPLY_TO` audit. Note: The `human:<login>` vs `@<login>` separation is temporary until human identity routing is fully unified.
 - **Reachable Counterparty Exception:** If the target recipient has *previously sent a message* to the sender, the system infers an implicit trust chain, and the sender is allowed to reply without an explicit `CAN_REPLY_TO` edge.
-- Broadcast messages (`to: AGENT:*`) are always permitted.
+- Broadcast messages (`to: 'AGENT:*'`) are always permitted.
 
 ### Reading Messages (`listMessages` & `getMessage`)
 - Agents can inherently read their own inbox and broadcast messages.
 - To read another agent's inbox (e.g., via `listMessages({ to: 'AGENT:bob' })`), the calling agent MUST hold the `CAN_READ_INBOX_OF` permission for that target agent.
+- **Role Inbox Asymmetry:** While sending to a role is write-permissive, *reading* from a role's inbox (e.g., `listMessages({ to: 'role:librarian' })`) still requires the calling agent to explicitly hold the `CAN_READ_INBOX_OF` capability for that role.
 - Senders always retain the ability to read the specific messages they have sent, regardless of the recipient's permissions.
 
 ## See Also

--- a/test/playwright/unit/ai/mcp/server/memory-core/services/MailboxService.spec.mjs
+++ b/test/playwright/unit/ai/mcp/server/memory-core/services/MailboxService.spec.mjs
@@ -18,6 +18,7 @@ import Neo                   from '../../../../../../../../src/Neo.mjs';
 import RequestContextService from '../../../../../../../../ai/mcp/server/shared/services/RequestContextService.mjs';
 
 test.describe('Neo.ai.mcp.server.memory-core.services.MailboxService', () => {
+    test.describe.configure({ mode: 'serial' });
     let MailboxService, GraphService, PermissionService, LifecycleService;
     
     test.beforeAll(async () => {
@@ -36,6 +37,7 @@ test.describe('Neo.ai.mcp.server.memory-core.services.MailboxService', () => {
         } else {
             await LifecycleService.ready();
         }
+        GraphService.db.autoSave = true;
     });
 
     test.afterAll(async () => {
@@ -172,4 +174,187 @@ test.describe('Neo.ai.mcp.server.memory-core.services.MailboxService', () => {
         const node = GraphService.db.nodes.get(msgId);
         expect(node.properties.readAt).toBeTruthy();
     });
+
+    test('listMessages outbox mode retrieves sent messages', async () => {
+        await RequestContextService.run({ agentIdentityNodeId: 'AGENT:bob' }, async () => {
+            await PermissionService.grantPermission({ to: 'AGENT:alice', scope: 'CAN_REPLY_TO' });
+        });
+
+        await RequestContextService.run({ agentIdentityNodeId: 'AGENT:alice' }, async () => {
+            await MailboxService.addMessage({ to: 'AGENT:bob', subject: 'Outbox Msg 1', body: '1' });
+            await MailboxService.addMessage({ to: 'AGENT:bob', subject: 'Outbox Msg 2', body: '2' });
+            
+            const outboxRes = await MailboxService.listMessages({ box: 'outbox' });
+            expect(outboxRes.messages.length).toBe(2);
+            expect(outboxRes.messages[0].from).toBe('AGENT:alice');
+            expect(outboxRes.messages[0].to).toBe('AGENT:bob');
+            
+            const inboxRes = await MailboxService.listMessages({ box: 'inbox' });
+            expect(inboxRes.messages.length).toBe(0);
+        });
+    });
+
+    test('listMessages pagination (limit/offset) boundary', async () => {
+        await RequestContextService.run({ agentIdentityNodeId: 'AGENT:bob' }, async () => {
+            await PermissionService.grantPermission({ to: 'AGENT:alice', scope: 'CAN_REPLY_TO' });
+        });
+
+        await RequestContextService.run({ agentIdentityNodeId: 'AGENT:alice' }, async () => {
+            for (let i = 0; i < 5; i++) {
+                await MailboxService.addMessage({ to: 'AGENT:bob', subject: `Msg ${i}`, body: '...' });
+                await new Promise(r => setTimeout(r, 10)); // guarantee sorting order
+            }
+        });
+
+        await RequestContextService.run({ agentIdentityNodeId: 'AGENT:bob' }, async () => {
+            const page1 = await MailboxService.listMessages({ limit: 2, offset: 0 });
+            expect(page1.messages.length).toBe(2);
+            expect(page1.messages[0].subject).toBe('Msg 4'); // Sorted descending
+
+            const page2 = await MailboxService.listMessages({ limit: 2, offset: 2 });
+            expect(page2.messages.length).toBe(2);
+            expect(page2.messages[0].subject).toBe('Msg 2');
+
+            const page3 = await MailboxService.listMessages({ limit: 2, offset: 4 });
+            expect(page3.messages.length).toBe(1);
+            expect(page3.messages[0].subject).toBe('Msg 0');
+        });
+    });
+
+    test('listMessages filters by threadId and from', async () => {
+        GraphService.upsertNode({ id: 'AGENT:charlie', type: 'AGENT', name: 'Charlie', properties: {} });
+        GraphService.upsertNode({ id: 'thread-X', type: 'THREAD', name: 'Thread X', properties: {} });
+        GraphService.upsertNode({ id: 'thread-Y', type: 'THREAD', name: 'Thread Y', properties: {} });
+
+        await RequestContextService.run({ agentIdentityNodeId: 'AGENT:bob' }, async () => {
+            await PermissionService.grantPermission({ to: 'AGENT:alice', scope: 'CAN_REPLY_TO' });
+            await PermissionService.grantPermission({ to: 'AGENT:charlie', scope: 'CAN_REPLY_TO' });
+        });
+
+        await RequestContextService.run({ agentIdentityNodeId: 'AGENT:alice' }, async () => {
+            await MailboxService.addMessage({ to: 'AGENT:bob', subject: 'A1', body: '...', partOfThread: 'thread-X' });
+            await MailboxService.addMessage({ to: 'AGENT:bob', subject: 'A2', body: '...', partOfThread: 'thread-Y' });
+        });
+
+        await RequestContextService.run({ agentIdentityNodeId: 'AGENT:charlie' }, async () => {
+            await MailboxService.addMessage({ to: 'AGENT:bob', subject: 'C1', body: '...', partOfThread: 'thread-X' });
+        });
+
+        await RequestContextService.run({ agentIdentityNodeId: 'AGENT:bob' }, async () => {
+            const filterFrom = await MailboxService.listMessages({ from: 'AGENT:alice' });
+            expect(filterFrom.messages.length).toBe(2);
+
+            const filterThread = await MailboxService.listMessages({ threadId: 'thread-X' });
+            expect(filterThread.messages.length).toBe(2);
+            
+            const filterBoth = await MailboxService.listMessages({ from: 'AGENT:alice', threadId: 'thread-X' });
+            expect(filterBoth.messages.length).toBe(1);
+            expect(filterBoth.messages[0].subject).toBe('A1');
+        });
+    });
+
+    test('addMessage supports 6 new edge types and priority', async () => {
+        GraphService.upsertNode({ id: 'SESSION:123', type: 'SESSION', name: 'S123', properties: {} });
+        GraphService.upsertNode({ id: 'SESSION:456', type: 'SESSION', name: 'S456', properties: {} });
+        GraphService.upsertNode({ id: 'ISSUE:10168', type: 'ISSUE', name: 'I10168', properties: {} });
+        GraphService.upsertNode({ id: 'MESSAGE:abc', type: 'MESSAGE', name: 'MABC', properties: {} });
+        GraphService.upsertNode({ id: 'THREAD:xyz', type: 'THREAD', name: 'TXYZ', properties: {} });
+        GraphService.upsertNode({ id: 'CONCEPT:test', type: 'CONCEPT', name: 'CTest', properties: {} });
+
+        await RequestContextService.run({ agentIdentityNodeId: 'AGENT:bob' }, async () => {
+            await PermissionService.grantPermission({ to: 'AGENT:alice', scope: 'CAN_REPLY_TO' });
+        });
+
+        let msgId;
+        await RequestContextService.run({ agentIdentityNodeId: 'AGENT:alice' }, async () => {
+            const res = await MailboxService.addMessage({ 
+                to: 'AGENT:bob', 
+                subject: 'Rich semantics', 
+                body: 'body',
+                priority: 'high',
+                originSessionId: 'SESSION:123',
+                relatedSessions: ['SESSION:456'],
+                relatedTickets: ['ISSUE:10168'],
+                inReplyTo: 'MESSAGE:abc',
+                partOfThread: 'THREAD:xyz',
+                taggedConcepts: ['CONCEPT:test']
+            });
+            msgId = res.messageId;
+            expect(res.priority).toBe('high');
+        });
+
+        const node = GraphService.db.nodes.get(msgId);
+        expect(node.properties.priority).toBe('high');
+
+        let edges = GraphService.db.edges.items.filter(e => e.source === msgId);
+        expect(edges.find(e => e.type === 'ORIGINATES_IN' && e.target === 'SESSION:123')).toBeDefined();
+        expect(edges.find(e => e.type === 'RELATED_SESSION' && e.target === 'SESSION:456')).toBeDefined();
+        expect(edges.find(e => e.type === 'REFERENCES_TICKET' && e.target === 'ISSUE:10168')).toBeDefined();
+        expect(edges.find(e => e.type === 'IN_REPLY_TO' && e.target === 'MESSAGE:abc')).toBeDefined();
+        expect(edges.find(e => e.type === 'PART_OF_THREAD' && e.target === 'THREAD:xyz')).toBeDefined();
+        expect(edges.find(e => e.type === 'TAGGED_CONCEPT' && e.target === 'CONCEPT:test')).toBeDefined();
+    });
+
+    test('Reachable Counterparty exception permits replies without explicit grant', async () => {
+        // Alice sends to Bob (alice can send to broadcast or we need to ensure alice can send)
+        // Actually, to send initially, we need permission unless it is broadcast.
+        // Let's grant Bob CAN_REPLY_TO Alice so Bob can start. No wait, Reachable Counterparty:
+        // "if they ever sent us a message, we can reply"
+        
+        await RequestContextService.run({ agentIdentityNodeId: 'AGENT:bob' }, async () => {
+            await PermissionService.grantPermission({ to: 'AGENT:alice', scope: 'CAN_REPLY_TO' });
+        });
+
+        // 1. Alice sends to Bob (allowed via explicit grant)
+        await RequestContextService.run({ agentIdentityNodeId: 'AGENT:alice' }, async () => {
+            await MailboxService.addMessage({ to: 'AGENT:bob', subject: 'Hi Bob', body: 'body' });
+        });
+
+        // 2. Bob sends to Alice (no explicit grant, but Bob is replying to Alice)
+        await RequestContextService.run({ agentIdentityNodeId: 'AGENT:bob' }, async () => {
+            const res = await MailboxService.addMessage({ to: 'AGENT:alice', subject: 'Re: Hi Bob', body: 'body' });
+            expect(res.status).toBe('sent');
+        });
+        
+        // 3. Charlie tries to send to Alice (no grant, no history)
+        await RequestContextService.run({ agentIdentityNodeId: 'AGENT:charlie' }, async () => {
+            await expect(MailboxService.addMessage({ to: 'AGENT:alice', subject: 'Spam', body: 'spam' })).rejects.toThrow(/Unauthorized/);
+        });
+    });
+
+    test('Role-based addressing dispatch modes', async () => {
+        GraphService.upsertNode({ id: 'role:librarian', type: 'ROLE', name: 'Librarian', properties: {} });
+        GraphService.upsertNode({ id: 'human:tobiu', type: 'HUMAN', name: 'Tobias', properties: {} });
+
+        // Any agent can dispatch to a role or human without CAN_REPLY_TO
+        await RequestContextService.run({ agentIdentityNodeId: 'AGENT:alice' }, async () => {
+            await MailboxService.addMessage({ to: 'role:librarian', subject: 'Need book', body: 'body' });
+            await MailboxService.addMessage({ to: 'human:tobiu', subject: 'Help', body: 'body' });
+        });
+
+        // Verify they were dispatched
+        let librarianCount = 0;
+        let humanCount = 0;
+        for (const edge of GraphService.db.edges.items) {
+            if (edge.type === 'SENT_TO') {
+                if (edge.target === 'role:librarian') librarianCount++;
+                if (edge.target === 'human:tobiu') humanCount++;
+            }
+        }
+        expect(librarianCount).toBe(1);
+        expect(humanCount).toBe(1);
+        
+        // Reading requires CAN_READ_INBOX_OF if the target isn't the caller
+        await RequestContextService.run({ agentIdentityNodeId: 'AGENT:bob' }, async () => {
+            await expect(MailboxService.listMessages({ to: 'role:librarian' })).rejects.toThrow(/Unauthorized/);
+            
+            // Grant bob permission to read librarian role
+            GraphService.linkNodes('AGENT:bob', 'role:librarian', 'CAN_READ_INBOX_OF', 1.0);
+            
+            const res = await MailboxService.listMessages({ to: 'role:librarian' });
+            expect(res.messages.length).toBe(1);
+            expect(res.messages[0].to).toBe('role:librarian');
+        });
+    });
 });
+

--- a/test/playwright/unit/ai/mcp/server/memory-core/services/MailboxService.spec.mjs
+++ b/test/playwright/unit/ai/mcp/server/memory-core/services/MailboxService.spec.mjs
@@ -19,7 +19,7 @@ import RequestContextService from '../../../../../../../../ai/mcp/server/shared/
 
 test.describe('Neo.ai.mcp.server.memory-core.services.MailboxService', () => {
     test.describe.configure({ mode: 'serial' });
-    let MailboxService, GraphService, PermissionService, LifecycleService;
+    let MailboxService, GraphService, PermissionService, LifecycleService, originalAutoSave;
     
     test.beforeAll(async () => {
         // Load dynamically due to SQLite DB mount timing
@@ -37,11 +37,12 @@ test.describe('Neo.ai.mcp.server.memory-core.services.MailboxService', () => {
         } else {
             await LifecycleService.ready();
         }
+        originalAutoSave = GraphService.db.autoSave;
         GraphService.db.autoSave = true;
     });
 
     test.afterAll(async () => {
-        // cleanup if needed
+        GraphService.db.autoSave = originalAutoSave;
     });
 
     test.beforeEach(async () => {
@@ -201,8 +202,8 @@ test.describe('Neo.ai.mcp.server.memory-core.services.MailboxService', () => {
 
         await RequestContextService.run({ agentIdentityNodeId: 'AGENT:alice' }, async () => {
             for (let i = 0; i < 5; i++) {
-                await MailboxService.addMessage({ to: 'AGENT:bob', subject: `Msg ${i}`, body: '...' });
-                await new Promise(r => setTimeout(r, 10)); // guarantee sorting order
+                const res = await MailboxService.addMessage({ to: 'AGENT:bob', subject: `Msg ${i}`, body: '...' });
+                GraphService.db.nodes.get(res.messageId).properties.sentAt = new Date(1000000000000 + i * 1000).toISOString();
             }
         });
 

--- a/test/playwright/unit/ai/mcp/server/memory-core/services/PermissionService.spec.mjs
+++ b/test/playwright/unit/ai/mcp/server/memory-core/services/PermissionService.spec.mjs
@@ -117,4 +117,11 @@ test.describe('Neo.ai.mcp.server.memory-core.services.PermissionService', () => 
         // Checking against broadcast (always true)
         expect(PermissionService.hasPermission('AGENT:alice', 'AGENT:*', 'CAN_READ_INBOX_OF')).toBe(true);
     });
+
+    test('listPermissions denies access when requesting for another identity', async () => {
+        await RequestContextService.run({ agentIdentityNodeId: 'AGENT:alice' }, async () => {
+            await expect(PermissionService.listPermissions({ forIdentity: 'AGENT:bob' }))
+                .rejects.toThrow('Unauthorized: Cannot enumerate permissions for AGENT:bob');
+        });
+    });
 });


### PR DESCRIPTION
Authored by Gemini 3.1 Pro (Antigravity). Session ada4aecb-60fc-4b25-a76b-cb92600835a2.

Resolves #10168

Enforces strictly sequential test execution for the Mailbox Service Playwright suite by introducing `test.describe.configure({ mode: 'serial' });`, thereby eliminating non-deterministic SQLite `FOREIGN KEY constraint failed` errors caused by concurrent worker Database bootstrapping races. Includes expanded routing validation for role-based (`role:librarian`) and human (`human:tobiu`) address modes without regressing isolated memory mappings.

## Deltas from ticket (if any)
- Included missing `listPermissions({forIdentity: other})` access-denied test.
- Documented asymmetric role/human read-path semantics in `MemoryCoreMcpAuth.md`.

## Test Evidence
- Run: `npx playwright test test/playwright/unit/ai/mcp/server/memory-core/services/MailboxService.spec.mjs`
- Result: 10/10 passed in ~940ms. Zero `SQLITE_CONSTRAINT` violations observed.

## Post-Merge Validation
- [ ] Monitor CI pipelines to ensure stability translates to GitHub Actions runners.

## Commits
- `74899e1` — test(mailbox): Enforce sequential Playwright execution to fix SQLite memory pollution (#10168)
