### PR TITLE
feat(ai): lazy back-fill for Memory + Session graph nodes (#10153)

### DIFF
--- a/ai/daemons/services/LazyEdgeDrainer.mjs
+++ b/ai/daemons/services/LazyEdgeDrainer.mjs
@@ -83,12 +83,19 @@ class LazyEdgeDrainer extends Base {
         const
             queuePath    = filePath || aiConfig.lazyEdgesQueuePath,
             drainingPath = queuePath + '.draining',
-            stats        = {totalLines: 0, processed: 0, succeeded: 0, failed: 0, skippedMalformed: 0, queueRotated: false};
+            stats        = {totalLines: 0, processed: 0, succeeded: 0, failed: 0, skippedMalformed: 0, queueRotated: false, orphanRecovered: false};
 
         if (!queuePath) {
             logger.warn('[LazyEdgeDrainer] No queue path configured (aiConfig.lazyEdgesQueuePath); nothing to drain.');
             return stats;
         }
+
+        // Recovery-on-boot for orphaned `.draining` files — addresses the SIGKILL edge case
+        // where a prior drain crashed between `rename` and the `try`/`catch` restore path
+        // (the catch only runs on thrown exceptions; `SIGKILL` / `SIGSTOP` / process exit
+        // bypass it). Merging orphan content back into the live queue is idempotent and
+        // preserves the "failures retained for retry" contract.
+        stats.orphanRecovered = await this.recoverOrphanedDraining(queuePath, drainingPath);
 
         try {
             if (dryRun) {
@@ -140,6 +147,51 @@ class LazyEdgeDrainer extends Base {
         }
 
         return stats;
+    }
+
+    /**
+     * Recovers an orphaned `.draining` file from a prior drain cycle that crashed between
+     * `rename(queuePath, drainingPath)` and the catch-block restore. Such orphans occur under
+     * process termination signals that bypass `try`/`catch` (`SIGKILL`, OOM kills, hardware
+     * failure). Without recovery, the orphaned edges would remain on disk but never be
+     * retried until manual intervention.
+     *
+     * Resolution: merge the orphan's content into the live queue (prepended so orphaned
+     * edges are processed first, preserving FIFO semantics for the entries that have been
+     * waiting longest), then delete the orphan. The merge is idempotent — a subsequent
+     * recovery-on-boot finds no orphan and no-ops.
+     *
+     * @param {String} queuePath    The live queue path
+     * @param {String} drainingPath The `.draining` orphan path
+     * @returns {Promise<Boolean>} `true` if an orphan was recovered; `false` if none existed.
+     * @protected
+     */
+    async recoverOrphanedDraining(queuePath, drainingPath) {
+        if (!fs.existsSync(drainingPath)) {
+            return false;
+        }
+
+        try {
+            const orphanContent = await fs.promises.readFile(drainingPath, 'utf8');
+
+            if (orphanContent.length > 0) {
+                const existingContent = fs.existsSync(queuePath)
+                    ? await fs.promises.readFile(queuePath, 'utf8')
+                    : '';
+
+                // Normalize trailing newline on the orphan so the concat doesn't produce
+                // adjacent JSON objects on a single line.
+                const merged = orphanContent.endsWith('\n') ? orphanContent + existingContent : orphanContent + '\n' + existingContent;
+                await fs.promises.writeFile(queuePath, merged, 'utf8');
+            }
+
+            await fs.promises.unlink(drainingPath);
+            logger.warn(`[LazyEdgeDrainer] Recovered orphaned ${drainingPath} from prior run and merged into live queue.`);
+            return true;
+        } catch (e) {
+            logger.error(`[LazyEdgeDrainer] Failed to recover orphaned ${drainingPath}:`, e);
+            return false;
+        }
     }
 
     /**

--- a/ai/daemons/services/LazyEdgeDrainer.mjs
+++ b/ai/daemons/services/LazyEdgeDrainer.mjs
@@ -1,0 +1,211 @@
+import fs     from 'fs';
+import Base   from '../../../src/core/Base.mjs';
+import {Memory_GraphService as GraphService} from '../../services.mjs';
+import aiConfig from '../../mcp/server/memory-core/config.mjs';
+import logger  from '../../mcp/server/memory-core/logger.mjs';
+
+/**
+ * @summary Drains the lazy-edges JSONL queue into the Native Edge Graph — the **consumer
+ * side** of the producer/consumer contract Gemini 3.1 Pro shipped in ticket #10152 / PR #10165
+ * (producer) and this ticket #10153 (consumer).
+ *
+ * `SemanticGraphExtractor` writes provenance edges (`MENTIONED_IN`, `DISCUSSED_IN`,
+ * `REFERENCED_BY`) whose `MEMORY:` / `SESSION:` targets may not yet exist in the graph — those
+ * edges get appended as JSONL lines to `aiConfig.lazyEdgesQueuePath` (defaults to
+ * `ai/data/memory-core/lazy-edges.jsonl`) rather than being culled. This service drains that
+ * queue: for each queued edge it calls `GraphService.linkNodesAsync`, which in turn triggers
+ * `MemorySessionIngestor.ingestSingleRow` to back-fill the missing endpoint from its Chroma
+ * source row before attempting the edge creation. Edges that still fail resolution (genuine
+ * hallucinations, missing Chroma rows) are written back to the queue for a future drain pass;
+ * successfully-drained edges are removed.
+ *
+ * **Atomicity via rename-then-drain:** the queue file is renamed to a `.draining` suffix at
+ * the start of a drain cycle, so any concurrent `SemanticGraphExtractor` appends create a fresh
+ * queue file rather than racing against the drain read. After processing, failures are appended
+ * to the (potentially fresh) queue file for the next cycle. This matches the standard "log
+ * rotation" pattern and preserves the queue's append-only producer semantics.
+ *
+ * **Invocation surface:** no MCP tool surface — this is an internal daemon service invoked
+ * from either the REM cycle (`DreamService`) or the standalone `ai/scripts/priorityBackfill.mjs`
+ * CLI. Keeping it off the MCP tool surface preserves the caller constraint that back-fill is
+ * an **operational** concern, not an **agent-facing** one.
+ *
+ * **Why a separate service rather than a method on `GraphService`:** the drainer owns
+ * filesystem I/O + JSONL parsing + queue rotation — responsibilities distinct from the
+ * in-memory / SQLite graph operations `GraphService` owns. Separating them keeps `GraphService`
+ * substrate-agnostic (no filesystem coupling) and makes the drainer testable in isolation with
+ * a mock queue path.
+ *
+ * @class Neo.ai.daemons.services.LazyEdgeDrainer
+ * @extends Neo.core.Base
+ * @singleton
+ * @see Neo.ai.daemons.services.MemorySessionIngestor
+ * @see Neo.ai.mcp.server.memory-core.services.GraphService
+ */
+class LazyEdgeDrainer extends Base {
+    static config = {
+        /**
+         * @member {String} className='Neo.ai.daemons.services.LazyEdgeDrainer'
+         * @protected
+         */
+        className: 'Neo.ai.daemons.services.LazyEdgeDrainer',
+        /**
+         * @member {Boolean} singleton=true
+         * @protected
+         */
+        singleton: true
+    }
+
+    /**
+     * Drains the lazy-edges JSONL queue, attempting to resolve each queued edge via
+     * `GraphService.linkNodesAsync` (which back-fills missing endpoints). Successfully-drained
+     * edges are removed; failures are written back to the queue for a future cycle.
+     *
+     * Idempotent: re-invoking against the same queue re-attempts any edges whose endpoints are
+     * still unresolvable (e.g. Chroma row genuinely missing). No duplicate graph edges are
+     * created — `linkNodesAsync` delegates to `linkNodes`, which recognizes existing
+     * source+target+type combinations and updates weight instead of duplicating.
+     *
+     * **Malformed-line policy:** lines that fail JSON parsing or lack required fields (`source`,
+     * `target`, `relationship`) are counted as `skippedMalformed` and discarded rather than
+     * retained — they would never succeed on retry and keeping them would bloat the queue. Operators
+     * with concerns about malformed-line loss should inspect the logs prior to draining.
+     *
+     * @param {Object}  [options]
+     * @param {String}  [options.filePath] Absolute path to the queue file. Defaults to
+     *     `aiConfig.lazyEdgesQueuePath`.
+     * @param {Boolean} [options.dryRun=false] If true, parses and counts the queue without
+     *     mutating the graph or the queue file. Useful for operator diagnostics.
+     * @returns {Promise<Object>} Drain statistics:
+     *     `{totalLines, processed, succeeded, failed, skippedMalformed, queueRotated}`.
+     */
+    async drainQueue({filePath = null, dryRun = false} = {}) {
+        const
+            queuePath    = filePath || aiConfig.lazyEdgesQueuePath,
+            drainingPath = queuePath + '.draining',
+            stats        = {totalLines: 0, processed: 0, succeeded: 0, failed: 0, skippedMalformed: 0, queueRotated: false};
+
+        if (!queuePath) {
+            logger.warn('[LazyEdgeDrainer] No queue path configured (aiConfig.lazyEdgesQueuePath); nothing to drain.');
+            return stats;
+        }
+
+        try {
+            if (dryRun) {
+                // Dry-run: read from the live queue without rotating, so concurrent producers
+                // remain undisturbed. The count may be a lower bound if producers append
+                // mid-read.
+                if (!fs.existsSync(queuePath)) {
+                    return stats;
+                }
+                const content = await fs.promises.readFile(queuePath, 'utf8');
+                return this.processLines(content, {stats, dryRun: true});
+            }
+
+            try {
+                await fs.promises.rename(queuePath, drainingPath);
+                stats.queueRotated = true;
+            } catch (e) {
+                if (e.code === 'ENOENT') {
+                    return stats; // Queue doesn't exist — nothing to drain.
+                }
+                throw e;
+            }
+
+            const content  = await fs.promises.readFile(drainingPath, 'utf8');
+            const failures = [];
+
+            await this.processLines(content, {stats, dryRun: false, failures});
+
+            if (failures.length > 0) {
+                // Append failures back to the live queue (may have grown via concurrent producers
+                // since the rename). The next drain cycle will retry them.
+                await fs.promises.appendFile(queuePath, failures.join('\n') + '\n', 'utf8');
+            }
+
+            await fs.promises.unlink(drainingPath).catch(() => {});
+
+            logger.info(
+                `[LazyEdgeDrainer] Drained ${queuePath}: ${stats.succeeded} resolved, ` +
+                `${stats.failed} retained for retry, ${stats.skippedMalformed} malformed discarded.`
+            );
+        } catch (e) {
+            logger.error('[LazyEdgeDrainer] Fatal drain error:', e);
+            // Best-effort restore — if we rotated but crashed mid-processing, put the draining
+            // file back as the live queue so nothing is lost.
+            if (stats.queueRotated) {
+                await fs.promises.rename(drainingPath, queuePath).catch(() => {});
+            }
+            throw e;
+        }
+
+        return stats;
+    }
+
+    /**
+     * Processes the raw JSONL content — one edge per line. Parses, validates, attempts
+     * resolution via `GraphService.linkNodesAsync`, and accumulates stats + failures.
+     *
+     * @param {String}  content JSONL content (one edge JSON per newline-delimited line)
+     * @param {Object}  opts
+     * @param {Object}  opts.stats Stats accumulator (mutated)
+     * @param {Boolean} opts.dryRun If true, skip the `linkNodesAsync` call
+     * @param {Array}   [opts.failures] Array accumulator for lines whose edge creation failed
+     * @returns {Promise<Object>} The mutated stats object
+     * @protected
+     */
+    async processLines(content, {stats, dryRun, failures}) {
+        const lines = content.split('\n').filter(l => l.trim().length > 0);
+
+        stats.totalLines = lines.length;
+
+        for (const line of lines) {
+            stats.processed++;
+
+            let edge;
+
+            try {
+                edge = JSON.parse(line);
+            } catch (e) {
+                stats.skippedMalformed++;
+                continue;
+            }
+
+            if (!edge.source || !edge.target || !edge.relationship) {
+                stats.skippedMalformed++;
+                continue;
+            }
+
+            if (dryRun) {
+                stats.succeeded++;
+                continue;
+            }
+
+            let ok = false;
+
+            try {
+                ok = await GraphService.linkNodesAsync(
+                    edge.source,
+                    edge.target,
+                    edge.relationship,
+                    edge.weight || 1.0,
+                    edge.properties || {}
+                );
+            } catch (e) {
+                logger.warn(`[LazyEdgeDrainer] linkNodesAsync threw for ${edge.source} -> ${edge.target}: ${e.message}`);
+                ok = false;
+            }
+
+            if (ok) {
+                stats.succeeded++;
+            } else {
+                stats.failed++;
+                failures?.push(line);
+            }
+        }
+
+        return stats;
+    }
+}
+
+export default Neo.setupClass(LazyEdgeDrainer);

--- a/ai/daemons/services/MemorySessionIngestor.mjs
+++ b/ai/daemons/services/MemorySessionIngestor.mjs
@@ -168,11 +168,15 @@ class MemorySessionIngestor extends Base {
                     type      : 'SESSION',
                     name      : session.meta.title || agentSessionId,
                     properties: {
-                        chromaId   : session.id,
-                        createdAt  : session.meta.createdAt,
-                        payloadHash: sessionPayloadHash,
-                        sessionId  : agentSessionId,
-                        userId     : session.meta.userId
+                        chromaId    : session.id,
+                        createdAt   : session.meta.createdAt,
+                        // Provenance marker distinguishing live REM-cycle ingestion from #10153
+                        // lazy back-fill. Queries discriminating between the two sources use
+                        // `liveIngested` vs `backfilled` on the node's properties.
+                        liveIngested: true,
+                        payloadHash : sessionPayloadHash,
+                        sessionId   : agentSessionId,
+                        userId      : session.meta.userId
                     }
                 });
                 stats.sessionUpserted = true;
@@ -210,11 +214,13 @@ class MemorySessionIngestor extends Base {
                         type      : 'MEMORY',
                         name      : memoryChromaId.slice(0, 12),
                         properties: {
-                            chromaId   : memoryChromaId,
-                            createdAt  : meta.createdAt,
-                            payloadHash: memoryPayloadHash,
-                            sessionId  : meta.sessionId ?? agentSessionId,
-                            userId     : meta.userId
+                            chromaId    : memoryChromaId,
+                            createdAt   : meta.createdAt,
+                            // Provenance marker — see sibling comment in the SESSION upsert.
+                            liveIngested: true,
+                            payloadHash : memoryPayloadHash,
+                            sessionId   : meta.sessionId ?? agentSessionId,
+                            userId      : meta.userId
                         }
                     });
 
@@ -236,6 +242,240 @@ class MemorySessionIngestor extends Base {
         }
 
         return stats;
+    }
+
+    /**
+     * Back-fills a single MEMORY or SESSION graph node from its Chroma source row — the per-row
+     * analog of `syncSessionToGraph` (which is batch-per-session). Invoked by #10153's lazy
+     * back-fill mechanism when `GraphService.linkNodes` encounters a missing target matching
+     * the `memory:` or `session:` prefix pattern.
+     *
+     * **Graph-node-id convention:** the canonical form is lowercase (`memory:<chromaId>`,
+     * `session:<sessionId>`) matching the IDs produced by `syncSessionToGraph`. This method
+     * accepts **case-insensitive** prefix matching so it can consume edges queued with the
+     * uppercase convention used by `SemanticGraphExtractor`'s lazy-edges queue (#10165) without
+     * requiring a canonical-format migration. The back-filled node always lands under the
+     * lowercase canonical ID; callers whose edge had the uppercase form should have their edge
+     * target re-normalized at the same call site (see the `linkNodes` prefix-normalization path
+     * landed in #10153).
+     *
+     * **Memory → Session dependency:** a Memory's `sessionId` metadata points at its parent
+     * Session. Back-filling a Memory whose parent Session is absent would dangle the
+     * `ORIGINATES_IN` edge, so this method recursively back-fills the Session first, then the
+     * Memory. Session back-fill has no further dependency chain.
+     *
+     * **Minimal-session fallback:** if a Session back-fill is requested but no summary row
+     * exists in the Chroma summary collection (possible for sessions that never reached
+     * summarization), a MINIMAL SESSION node is created with just `{sessionId, backfilled: true,
+     * minimal: true}` properties. This keeps the graph link-target resolvable even for
+     * partial-history sessions; a future live ingestion or summarization will upgrade the node
+     * by upserting the full payload.
+     *
+     * @param {String} graphNodeId The graph-node ID to back-fill. Accepts both lowercase
+     *     (`memory:<id>`, `session:<id>`) and uppercase (`MEMORY:<id>`, `SESSION:<id>`) prefix
+     *     forms. Unrecognized prefixes return a no-op result rather than raising.
+     * @param {Object} [options]
+     * @param {Object} [options.memoryCollection=null] Optional memory collection override for
+     *     test injection. Production callers pass nothing; falls back to
+     *     `StorageRouter.getMemoryCollection()`.
+     * @param {Object} [options.summaryCollection=null] Optional summary collection override for
+     *     test injection.
+     * @returns {Promise<Object>} Result descriptor:
+     *     `{success: Boolean, reason: String, graphNodeId?: String, error?: String}`. Possible
+     *     `reason` values: `'unrecognized-prefix'`, `'already-exists'`, `'backfilled'`,
+     *     `'backfilled-minimal'`, `'no-collection'`, `'chroma-fetch-failed'`,
+     *     `'chroma-row-not-found'`.
+     */
+    async ingestSingleRow(graphNodeId, {memoryCollection = null, summaryCollection = null} = {}) {
+        const parsed = this.parseGraphNodeId(graphNodeId);
+
+        if (!parsed) {
+            return {success: false, reason: 'unrecognized-prefix', graphNodeId};
+        }
+
+        const {type, bareId, canonicalGraphId} = parsed;
+
+        if (GraphService.db?.nodes?.get(canonicalGraphId)) {
+            return {success: true, reason: 'already-exists', graphNodeId: canonicalGraphId};
+        }
+
+        try {
+            if (type === 'MEMORY') {
+                return await this.backfillMemory(bareId, canonicalGraphId, {memoryCollection, summaryCollection});
+            } else {
+                return await this.backfillSession(bareId, canonicalGraphId, {summaryCollection});
+            }
+        } catch (e) {
+            logger.error(`[MemorySessionIngestor] Lazy back-fill error for ${graphNodeId}:`, e);
+            return {success: false, reason: 'error', graphNodeId: canonicalGraphId, error: e.message};
+        }
+    }
+
+    /**
+     * Parses a graph-node ID into its canonical (lowercase) form + type + bare identifier.
+     * Case-insensitive on the `memory:` / `session:` prefix so we can consume edges queued with
+     * either convention. Returns `null` for unrecognized prefixes; callers treat that as
+     * "not a back-fillable node — fall through to the existing cull path".
+     *
+     * @param {String} id Raw graph-node ID from a call site
+     * @returns {{type: String, bareId: String, canonicalGraphId: String}|null}
+     * @protected
+     */
+    parseGraphNodeId(id) {
+        if (!id || typeof id !== 'string') {
+            return null;
+        }
+
+        const lower = id.toLowerCase();
+
+        if (lower.startsWith('memory:')) {
+            const bareId = id.slice(7);
+            return {type: 'MEMORY', bareId, canonicalGraphId: 'memory:' + bareId};
+        }
+
+        if (lower.startsWith('session:')) {
+            const bareId = id.slice(8);
+            return {type: 'SESSION', bareId, canonicalGraphId: 'session:' + bareId};
+        }
+
+        return null;
+    }
+
+    /**
+     * Fetches a single Memory row from Chroma and upserts it as a MEMORY graph node, recursively
+     * ensuring the parent Session node exists so the `ORIGINATES_IN` edge terminates cleanly.
+     * Private helper for `ingestSingleRow`.
+     *
+     * @param {String} chromaId Chroma memory row ID (the bare ID, no `memory:` prefix)
+     * @param {String} canonicalGraphId Canonical graph-node ID (`memory:<chromaId>`)
+     * @param {Object} collections
+     * @param {Object} [collections.memoryCollection]
+     * @param {Object} [collections.summaryCollection]
+     * @returns {Promise<Object>} Result descriptor
+     * @protected
+     */
+    async backfillMemory(chromaId, canonicalGraphId, {memoryCollection, summaryCollection}) {
+        const collection = memoryCollection || await StorageRouter.getMemoryCollection();
+
+        if (!collection) {
+            return {success: false, reason: 'no-collection', graphNodeId: canonicalGraphId};
+        }
+
+        let raw;
+
+        try {
+            raw = await collection.get({ids: [chromaId], include: ['metadatas']});
+        } catch (e) {
+            return {success: false, reason: 'chroma-fetch-failed', graphNodeId: canonicalGraphId, error: e.message};
+        }
+
+        if (!raw?.ids?.length) {
+            return {success: false, reason: 'chroma-row-not-found', graphNodeId: canonicalGraphId};
+        }
+
+        const
+            meta         = raw.metadatas?.[0] || {},
+            sessionId    = meta.sessionId,
+            sessionNodeId = sessionId ? 'session:' + sessionId : null;
+
+        // Recursively ensure parent Session exists before creating the Memory edge. Without this
+        // the ORIGINATES_IN edge created below would dangle at the session endpoint.
+        if (sessionNodeId && !GraphService.db?.nodes?.get(sessionNodeId)) {
+            await this.backfillSession(sessionId, sessionNodeId, {summaryCollection});
+        }
+
+        const payloadHash = this.computeMemoryPayloadHash(meta);
+
+        GraphService.upsertNode({
+            id        : canonicalGraphId,
+            type      : 'MEMORY',
+            name      : chromaId.slice(0, 12),
+            properties: {
+                backfilled : true,
+                chromaId   : chromaId,
+                createdAt  : meta.createdAt,
+                payloadHash: payloadHash,
+                sessionId  : sessionId,
+                userId     : meta.userId
+            }
+        });
+
+        if (sessionNodeId) {
+            GraphService.linkNodes(canonicalGraphId, sessionNodeId, 'ORIGINATES_IN', 1.0);
+        }
+
+        return {success: true, reason: 'backfilled', graphNodeId: canonicalGraphId};
+    }
+
+    /**
+     * Fetches a single Session summary row from Chroma (by `sessionId` metadata filter, since
+     * session summary Chroma IDs are opaque) and upserts it as a SESSION graph node. Private
+     * helper for `ingestSingleRow`.
+     *
+     * **Minimal-session fallback:** if no summary row matches the sessionId, creates a minimal
+     * node so link targets resolve even for never-summarized sessions. See class-level note on
+     * the minimal-session fallback.
+     *
+     * @param {String} sessionId Agent-logical session ID (the bare ID, no `session:` prefix)
+     * @param {String} canonicalGraphId Canonical graph-node ID (`session:<sessionId>`)
+     * @param {Object} collections
+     * @param {Object} [collections.summaryCollection]
+     * @returns {Promise<Object>} Result descriptor
+     * @protected
+     */
+    async backfillSession(sessionId, canonicalGraphId, {summaryCollection}) {
+        const collection = summaryCollection || await StorageRouter.getSummaryCollection();
+
+        if (!collection) {
+            return {success: false, reason: 'no-collection', graphNodeId: canonicalGraphId};
+        }
+
+        let raw;
+
+        try {
+            raw = await collection.get({where: {sessionId}, include: ['metadatas']});
+        } catch (e) {
+            return {success: false, reason: 'chroma-fetch-failed', graphNodeId: canonicalGraphId, error: e.message};
+        }
+
+        if (!raw?.ids?.length) {
+            // Minimal-session fallback: no summary exists. Still create the node so downstream
+            // edges resolve; a future summarization cycle will upgrade the payload.
+            GraphService.upsertNode({
+                id        : canonicalGraphId,
+                type      : 'SESSION',
+                name      : sessionId,
+                properties: {
+                    backfilled: true,
+                    minimal   : true,
+                    sessionId : sessionId
+                }
+            });
+
+            return {success: true, reason: 'backfilled-minimal', graphNodeId: canonicalGraphId};
+        }
+
+        const
+            meta        = raw.metadatas?.[0] || {},
+            chromaId    = raw.ids[0],
+            session     = {id: chromaId, meta},
+            payloadHash = this.computeSessionPayloadHash(session);
+
+        GraphService.upsertNode({
+            id        : canonicalGraphId,
+            type      : 'SESSION',
+            name      : meta.title || sessionId,
+            properties: {
+                backfilled : true,
+                chromaId   : chromaId,
+                createdAt  : meta.createdAt,
+                payloadHash: payloadHash,
+                sessionId  : sessionId,
+                userId     : meta.userId
+            }
+        });
+
+        return {success: true, reason: 'backfilled', graphNodeId: canonicalGraphId};
     }
 }
 

--- a/ai/mcp/server/memory-core/services/GraphService.mjs
+++ b/ai/mcp/server/memory-core/services/GraphService.mjs
@@ -228,9 +228,129 @@ class GraphService extends Base {
     }
 
     /**
+     * Async variant of {@link GraphService#linkNodes linkNodes} that performs **lazy
+     * back-fill** on missing endpoints before attempting the edge creation (#10153).
+     *
+     * Where the sync `linkNodes` silently culls edges whose source or target is absent from the
+     * graph, this async path first attempts to materialize the missing endpoints from their
+     * Chroma source rows via `MemorySessionIngestor.ingestSingleRow`. Back-fill applies only to
+     * node IDs matching the `memory:<chromaId>` or `session:<sessionId>` prefix (case-insensitive
+     * — consumes the uppercase-prefix convention used by `SemanticGraphExtractor`'s lazy-edges
+     * queue #10165 without requiring a canonical-format migration). Unrecognized prefixes fall
+     * through to the sync `linkNodes` cull behavior unchanged.
+     *
+     * **Why a separate method rather than making `linkNodes` async:** the sync `linkNodes` is
+     * called from many synchronous code paths where adding an `await` would have wide blast
+     * radius. Net-new back-fill-aware callers (the `LazyEdgeDrainer` that consumes #10165's
+     * queue, future mailbox `IN_REPLY_TO` / identity `AUTHORED_BY` edge creators) use this
+     * async path; existing sync callers remain unaffected.
+     *
+     * **Prefix normalization:** if either endpoint uses the uppercase `MEMORY:`/`SESSION:`
+     * prefix, the back-filled node lands under the canonical lowercase ID and the edge is
+     * created against the canonical form. Callers should expect the edge's actual source/target
+     * in SQLite to be the normalized lowercase variant regardless of the input case.
+     *
+     * @param {String} source Source node ID
+     * @param {String} target Target node ID
+     * @param {String} relationship Edge type
+     * @param {Number} [weight=1.0] Edge weight
+     * @param {Object} [properties={}] Additional edge metadata
+     * @returns {Promise<Boolean>} `true` if the edge was created or already existed; `false` if
+     *     back-fill failed or the endpoints were unrecognized/unresolvable.
+     */
+    async linkNodesAsync(source, target, relationship, weight = 1.0, properties = {}) {
+        if (!this.db?.storage?.db) {
+            return false;
+        }
+
+        const
+            normalizedSource = this.normalizeGraphNodeId(source),
+            normalizedTarget = this.normalizeGraphNodeId(target);
+
+        const
+            sourceReady = await this.ensureNodeExists(normalizedSource),
+            targetReady = await this.ensureNodeExists(normalizedTarget);
+
+        if (!sourceReady || !targetReady) {
+            logger.warn(`[GraphService] linkNodesAsync: endpoint resolution failed (source=${sourceReady}, target=${targetReady}) — ${normalizedSource} -> ${normalizedTarget}`);
+            return false;
+        }
+
+        this.linkNodes(normalizedSource, normalizedTarget, relationship, weight, properties);
+        return true;
+    }
+
+    /**
+     * Ensures a graph node exists, attempting lazy back-fill from its Chroma source row if
+     * absent. Used by `linkNodesAsync` and the `LazyEdgeDrainer` to resolve missing endpoints
+     * before edge creation (#10153).
+     *
+     * Back-fill applies only to the `memory:` / `session:` prefix pattern — nodes managed by
+     * other substrates (concepts, classes, AgentIdentity, files) remain the responsibility of
+     * their owning ingestor. Returns `false` for unrecognized-prefix IDs: callers treat that as
+     * "genuine hallucination, cull" rather than "back-fill failed".
+     *
+     * **Dynamic import rationale:** `MemorySessionIngestor` imports `GraphService` via
+     * `ai/services.mjs`, so a static import here would create a module-load cycle. The dynamic
+     * import resolves at call-time, after both modules have finished their top-level evaluation.
+     *
+     * @param {String} graphNodeId Canonical-form graph node ID to resolve
+     * @returns {Promise<Boolean>} `true` if the node now exists (was present or was successfully
+     *     back-filled); `false` otherwise.
+     */
+    async ensureNodeExists(graphNodeId) {
+        if (!this.db?.storage?.db || !graphNodeId) {
+            return false;
+        }
+
+        if (this.db.nodes.has(graphNodeId)) {
+            return true;
+        }
+
+        const {default: MemorySessionIngestor} = await import('../../../../daemons/services/MemorySessionIngestor.mjs');
+        const result = await MemorySessionIngestor.ingestSingleRow(graphNodeId);
+
+        if (!result.success) {
+            if (result.reason !== 'unrecognized-prefix') {
+                logger.warn(`[GraphService] ensureNodeExists: back-fill failed for ${graphNodeId} — ${result.reason}${result.error ? ' (' + result.error + ')' : ''}`);
+            }
+            return false;
+        }
+
+        return this.db.nodes.has(result.graphNodeId || graphNodeId);
+    }
+
+    /**
+     * Normalizes a graph node ID's prefix to its canonical lowercase form. Non-`memory:` /
+     * non-`session:` IDs pass through unchanged. Used by `linkNodesAsync` to accept edges
+     * queued with the uppercase `MEMORY:`/`SESSION:` convention (#10165) without polluting the
+     * graph with case-variant duplicate nodes.
+     *
+     * @param {String} id Raw graph node ID
+     * @returns {String} Normalized ID (lowercase prefix when recognized, unchanged otherwise)
+     */
+    normalizeGraphNodeId(id) {
+        if (!id || typeof id !== 'string') {
+            return id;
+        }
+
+        const lower = id.toLowerCase();
+
+        if (lower.startsWith('memory:')) {
+            return 'memory:' + id.slice(7);
+        }
+
+        if (lower.startsWith('session:')) {
+            return 'session:' + id.slice(8);
+        }
+
+        return id;
+    }
+
+    /**
      * Applies geometric weight decay mapping to existing graph relationships over time.
      * Enforces a 24-hour algorithmic lock to prevent amnesia under high execution frequency.
-     * 
+     *
      * @param {Number} decayFactor
      * @param {Number} pruningThreshold
      * @param {Boolean} force Bypass the 24-hour lock (used strictly for manual forcing/tuning)

--- a/ai/scripts/priorityBackfill.mjs
+++ b/ai/scripts/priorityBackfill.mjs
@@ -1,0 +1,134 @@
+/**
+ * @summary Eager batch back-fill for high-activity sessions into the Native Edge Graph.
+ *
+ * Ticket #10153 — complement to the lazy back-fill path shipped in the same PR. Where the
+ * lazy path is reactive (back-fill-on-demand when `linkNodesAsync` encounters a missing
+ * endpoint), this CLI is proactive: pre-warms the graph with sessions and memories from a
+ * configurable recent window (default: last 30 days). Opt-in — run before mass cross-tenant
+ * operations (e.g. post-#10146 permission grant rollouts, or demonstrations of #10139 mailbox
+ * traffic across historical sessions) to avoid latency spikes from lazy back-fills during the
+ * workload.
+ *
+ * **Usage:**
+ * ```
+ * node ai/scripts/priorityBackfill.mjs [--days N] [--dry-run] [--skip-drain]
+ * ```
+ *
+ * - `--days N` — window in days (default 30)
+ * - `--dry-run` — report what would be back-filled without mutating graph or queue
+ * - `--skip-drain` — skip the post-ingest `LazyEdgeDrainer` pass
+ *
+ * **Two-phase execution:**
+ * 1. **Ingest phase:** fetches sessions with `metadata.createdAt >= (now - daysWindow)` from
+ *    the Chroma summary collection; for each, invokes `MemorySessionIngestor.syncSessionToGraph`
+ *    which upserts the SESSION node plus all MEMORY children + `ORIGINATES_IN` edges.
+ * 2. **Drain phase** (skippable): runs `LazyEdgeDrainer.drainQueue` to retry any queued
+ *    provenance edges (`MENTIONED_IN`/`DISCUSSED_IN`/`REFERENCED_BY` from Gemini's #10165 producer)
+ *    whose endpoints may now exist in the graph after phase 1.
+ */
+import 'dotenv/config';
+import {
+    Memory_GraphService as GraphService,
+    Memory_StorageRouter as StorageRouter
+} from '../services.mjs';
+import MemorySessionIngestor from '../daemons/services/MemorySessionIngestor.mjs';
+import LazyEdgeDrainer       from '../daemons/services/LazyEdgeDrainer.mjs';
+import logger                from '../mcp/server/memory-core/logger.mjs';
+
+const
+    args        = process.argv.slice(2),
+    flags       = {daysWindow: 30, dryRun: false, skipDrain: false};
+
+for (let i = 0; i < args.length; i++) {
+    const arg = args[i];
+
+    if (arg === '--days') {
+        flags.daysWindow = parseInt(args[++i], 10) || 30;
+    } else if (arg === '--dry-run') {
+        flags.dryRun = true;
+    } else if (arg === '--skip-drain') {
+        flags.skipDrain = true;
+    } else if (arg === '--help' || arg === '-h') {
+        console.log('Usage: node ai/scripts/priorityBackfill.mjs [--days N] [--dry-run] [--skip-drain]');
+        process.exit(0);
+    }
+}
+
+async function run() {
+    logger.info('[priorityBackfill] Bootstrapping Memory Graph Service...');
+    await GraphService.initAsync();
+
+    const summaryCollection = await StorageRouter.getSummaryCollection();
+
+    if (!summaryCollection) {
+        logger.error('[priorityBackfill] Summary collection unavailable — aborting.');
+        process.exit(1);
+    }
+
+    const
+        cutoffTimestamp = Date.now() - flags.daysWindow * 24 * 60 * 60 * 1000,
+        cutoffIso       = new Date(cutoffTimestamp).toISOString();
+
+    logger.info(`[priorityBackfill] Fetching sessions with createdAt >= ${cutoffIso} (window: ${flags.daysWindow} days)`);
+
+    const allSessions = await summaryCollection.get({include: ['metadatas']});
+    const inWindow    = [];
+
+    for (let i = 0; i < (allSessions?.ids?.length || 0); i++) {
+        const
+            meta      = allSessions.metadatas?.[i] || {},
+            createdAt = meta.createdAt;
+
+        if (createdAt && createdAt >= cutoffIso) {
+            inWindow.push({id: allSessions.ids[i], meta});
+        }
+    }
+
+    logger.info(`[priorityBackfill] ${inWindow.length} sessions in window.`);
+
+    if (flags.dryRun) {
+        logger.info('[priorityBackfill] Dry-run: skipping ingestion.');
+
+        if (!flags.skipDrain) {
+            const drainStats = await LazyEdgeDrainer.drainQueue({dryRun: true});
+            logger.info(`[priorityBackfill] Dry-run drain stats: ${JSON.stringify(drainStats)}`);
+        }
+
+        process.exit(0);
+    }
+
+    const totalStats = {
+        sessionsUpserted : 0,
+        memoriesUpserted : 0,
+        memoriesSkipped  : 0,
+        errors           : 0
+    };
+
+    for (const session of inWindow) {
+        try {
+            const stats = await MemorySessionIngestor.syncSessionToGraph(session);
+            if (stats.sessionUpserted) totalStats.sessionsUpserted++;
+            totalStats.memoriesUpserted += stats.memoriesUpserted;
+            totalStats.memoriesSkipped  += stats.memoriesSkipped;
+            totalStats.errors           += stats.errors.length;
+        } catch (e) {
+            logger.error(`[priorityBackfill] Session ${session.meta?.sessionId || session.id} failed:`, e);
+            totalStats.errors++;
+        }
+    }
+
+    logger.info(`[priorityBackfill] Ingest phase complete: ${JSON.stringify(totalStats)}`);
+
+    if (!flags.skipDrain) {
+        logger.info('[priorityBackfill] Draining lazy-edges queue...');
+        const drainStats = await LazyEdgeDrainer.drainQueue();
+        logger.info(`[priorityBackfill] Drain phase complete: ${JSON.stringify(drainStats)}`);
+    }
+
+    process.exit(0);
+}
+
+run().catch(err => {
+    logger.error('[priorityBackfill] Fatal:', err);
+    process.exit(1);
+});

--- a/learn/agentos/tooling/GraphBackfill.md
+++ b/learn/agentos/tooling/GraphBackfill.md
@@ -1,0 +1,127 @@
+# Graph Back-Fill: Memory & Session Node Lifecycle
+
+The Native Edge Graph's `MEMORY` and `SESSION` node types are materialized from Chroma row-level data by two complementary pipelines: the **live ingestion** path (`DreamService` → `MemorySessionIngestor.syncSessionToGraph`) runs during the REM cycle, and the **lazy back-fill** path (ticket #10153) materializes individual nodes on-demand when an edge references a missing target. This guide describes the back-fill substrate shipped in ticket #10153 — when it triggers, what it produces, and how to invoke it.
+
+## Why Back-Fill Exists
+
+Live ingestion handles sessions going forward from its deployment — every REM cycle processes newly-summarized sessions and materializes their Memory + Session graph nodes. But the Memory Core has a long history: ~9,040 pre-migration Chroma rows (8,246 memories + 794 summaries at filing) pre-date the live ingestion contract. Edges from extracted provenance (`MENTIONED_IN`, `DISCUSSED_IN`, `REFERENCED_BY` per #10152) and future mailbox threading (`IN_REPLY_TO` per #10147) reference these historical rows — if the target graph node doesn't yet exist, the edge would silently cull, leaving permanent asymmetry.
+
+Back-fill closes this asymmetry **lazily** (reactive — only materialize what's actually referenced) with an **eager CLI** opt-in for operators who need pre-warmed throughput before mass operations.
+
+## Entry Points
+
+| Trigger | Path | When |
+|---|---|---|
+| `GraphService.linkNodesAsync(source, target, ...)` | Per-edge lazy resolution | On any edge-creation attempt with a missing `memory:` / `session:` endpoint |
+| `LazyEdgeDrainer.drainQueue()` | JSONL queue consumer | Once per REM cycle (or on-demand), drains `ai/data/memory-core/lazy-edges.jsonl` written by #10165's `SemanticGraphExtractor` |
+| `node ai/scripts/priorityBackfill.mjs` | Eager batch CLI | Operator-triggered before workloads that span many historical sessions |
+
+All three converge on the same primitive: `MemorySessionIngestor.ingestSingleRow(graphNodeId)`.
+
+## Primitive: `ingestSingleRow`
+
+The per-row analog of `syncSessionToGraph`'s batch-per-session behavior. Given a graph node ID with the `memory:` or `session:` prefix (case-insensitive — accepts the uppercase `MEMORY:` / `SESSION:` form used by #10165's extractor without requiring a canonical-format migration), it fetches the corresponding Chroma row and upserts a graph node tagged `backfilled: true`.
+
+**Recursion:** a Memory's `sessionId` metadata points at its parent Session. If the Session node is absent when a Memory is back-filled, `ingestSingleRow` recursively back-fills the parent first so the `ORIGINATES_IN` edge doesn't dangle.
+
+**Minimal-session fallback:** if a Session back-fill is requested but no summary row exists in the Chroma summary collection (possible for sessions that never reached summarization), a minimal node is created with `{backfilled: true, minimal: true, sessionId}`. Link targets resolve; a future live summarization upgrades the payload via `syncSessionToGraph`.
+
+**Result contract:** `{success, reason, graphNodeId?, error?}` where `reason` is one of:
+`unrecognized-prefix`, `already-exists`, `backfilled`, `backfilled-minimal`, `no-collection`, `chroma-fetch-failed`, `chroma-row-not-found`, `error`.
+
+## The Async Edge Path: `linkNodesAsync`
+
+Existing sync `GraphService.linkNodes` silently culls edges with missing endpoints (log + return, preserving the foreign-key contract with SQLite). `linkNodesAsync` adds an awaitable back-fill pre-step:
+
+```js
+// Legacy — cull-on-missing. Keep existing callers unchanged.
+GraphService.linkNodes(source, target, relationship, weight);
+
+// New — back-fill-then-link. Returns boolean success.
+const ok = await GraphService.linkNodesAsync(source, target, relationship, weight);
+```
+
+**Why two methods rather than making `linkNodes` async:** sync `linkNodes` is called from many synchronous code paths where adding an `await` would propagate through wide call chains. Net-new back-fill-aware callers (the `LazyEdgeDrainer`, future mailbox/identity edge creators that traverse historical references) use `linkNodesAsync`; everything else remains unaffected.
+
+**Prefix normalization:** both endpoints are routed through `normalizeGraphNodeId` before the lookup. The edge lands on the canonical lowercase form regardless of input case. An edge passed as `MEMORY:xyz` lands in SQLite with `target = 'memory:xyz'`.
+
+## JSONL Lazy Queue (Producer/Consumer Contract with #10165)
+
+Gemini 3.1 Pro's [PR #10165](https://github.com/neomjs/neo/pull/10165) (ticket #10152) shipped the **producer** side: `SemanticGraphExtractor` writes provenance edges whose `MEMORY:` / `SESSION:` targets aren't yet in the graph to `aiConfig.lazyEdgesQueuePath` (default `ai/data/memory-core/lazy-edges.jsonl`) as one JSON object per line.
+
+This ticket (#10153) ships the **consumer** side: `LazyEdgeDrainer.drainQueue()` reads the queue, retries each edge via `linkNodesAsync` (which triggers `ingestSingleRow` for missing endpoints), writes failures back for the next cycle, and deletes the queue when fully drained.
+
+**Atomicity via rename-then-drain:** the queue file is renamed to a `.draining` suffix at the start of a drain cycle. Concurrent producer appends create a fresh queue file rather than racing the read. After processing, failures append to the (potentially fresh) queue for the next cycle. Standard log-rotation pattern.
+
+**Malformed-line policy:** lines that fail JSON parsing or lack the required `{source, target, relationship}` fields are counted and **discarded** — they would never succeed on retry and retaining them would bloat the queue.
+
+## Provenance Markers
+
+Every Memory and Session graph node carries exactly one of two mutually-exclusive provenance markers:
+
+| Marker | Source | Meaning |
+|---|---|---|
+| `liveIngested: true` | `MemorySessionIngestor.syncSessionToGraph` (REM cycle) | Node was materialized during a live DreamService pass over a summarized session |
+| `backfilled: true` | `MemorySessionIngestor.ingestSingleRow` (#10153) | Node was lazy-materialized from a historical Chroma row, typically in response to an edge reference |
+
+Queries discriminating between the two sources use these flags directly:
+
+```js
+// All live-ingested memories in the last week
+GraphService.db.nodes.values().filter(n =>
+    n.label === 'MEMORY' && n.properties.liveIngested === true &&
+    n.properties.createdAt >= oneWeekAgoIso
+);
+
+// All back-filled sessions (proxy for pre-migration historical reach)
+GraphService.db.nodes.values().filter(n =>
+    n.label === 'SESSION' && n.properties.backfilled === true
+);
+```
+
+Nodes that exist in the graph WITHOUT either marker are pre-#10153 legacy — treat them as live-ingested for historical reasoning; they'll receive the `liveIngested` tag on next payload-hash mismatch upsert.
+
+## Operator: `priorityBackfill.mjs`
+
+```
+node ai/scripts/priorityBackfill.mjs [--days N] [--dry-run] [--skip-drain]
+```
+
+- `--days N` — window in days (default 30). Sessions with `metadata.createdAt >= (now - N)` are ingested via `syncSessionToGraph`.
+- `--dry-run` — count what would be back-filled without mutating graph or queue.
+- `--skip-drain` — skip the post-ingest `LazyEdgeDrainer.drainQueue` pass.
+
+Use before mass cross-tenant operations (e.g. post-#10146 permission grant rollouts, or #10139 Mailbox traffic demonstrations across historical sessions) to avoid per-request latency spikes from lazy back-fills during the workload.
+
+## Node-ID Canonical Format (Coordination Note)
+
+The ingestor writes node IDs in the form `memory:<chromaId>` and `session:<sessionId>` — lowercase prefix. Gemini's #10165 extractor emits edges referencing `MEMORY:<chromaId>` and `SESSION:<sessionId>` — uppercase prefix. `ingestSingleRow` and `linkNodesAsync` both normalize case-insensitively on the consumer side, so neither convention "wins" yet.
+
+This is a known coordination seam. If the uppercase form becomes canonical, the ingestor's upsert path needs renaming. If lowercase wins, the extractor prompt and existing queued entries need updating. Current behavior: both forms resolve; the canonical-format decision is deferred to a follow-up.
+
+## Chroma Collection Mapping
+
+| Graph prefix | Chroma collection | Lookup key |
+|---|---|---|
+| `memory:<chromaId>` | `neo-agent-memory` (via `StorageRouter.getMemoryCollection()`) | Direct Chroma row ID |
+| `session:<sessionId>` | `neo-agent-sessions` (via `StorageRouter.getSummaryCollection()`) | Filter by `where.sessionId` — summary Chroma IDs are opaque |
+
+Tests inject stubs conforming to the same `collection.get({ids} | {where})` contract; no module-level monkey-patching required.
+
+## See Also
+
+- `ai/daemons/services/MemorySessionIngestor.mjs` — `ingestSingleRow` + `syncSessionToGraph`
+- `ai/daemons/services/LazyEdgeDrainer.mjs` — JSONL queue consumer
+- `ai/mcp/server/memory-core/services/GraphService.mjs` — `linkNodesAsync`, `ensureNodeExists`, `normalizeGraphNodeId`
+- `ai/scripts/priorityBackfill.mjs` — operator CLI
+- `learn/agentos/tooling/MemoryCoreMcpAuth.md` — identity propagation (orthogonal; user-tenant tagging happens at write time regardless of back-fill source)
+- `learn/agentos/DreamPipeline.md` — the REM cycle where live ingestion runs
+
+## Related Tickets
+
+- #10143 — Graph-first Memory artifacts (parent sub-epic)
+- #10151 — Live ingestion of Memory + Session nodes (shipped via #10161)
+- #10152 — `SemanticGraphExtractor` provenance edges (shipped via #10165, producer of the lazy queue)
+- #10153 — This ticket (back-fill consumer + on-demand lazy back-fill)
+- #10158 — Post-ship telemetry + retention policy (follow-up)
+- #9999 — Grand-parent epic: Cloud-Native Knowledge & Multi-Tenant Memory Core

--- a/learn/tree.json
+++ b/learn/tree.json
@@ -42,6 +42,7 @@
             {"name": "Agent-Agnostic MCP Configuration",               "parentId": "AgentOS/Tooling",                                     "id": "agentos/tooling/AgentAgnosticMcpConfig"},
             {"name": "Memory Core MCP API",                            "parentId": "AgentOS/Tooling",                                     "id": "agentos/tooling/MemoryCoreMcpApi"},
             {"name": "Memory Core MCP Authentication",                 "parentId": "AgentOS/Tooling",                                     "id": "agentos/tooling/MemoryCoreMcpAuth"},
+            {"name": "Graph Back-Fill: Memory & Session Lifecycle",    "parentId": "AgentOS/Tooling",                                     "id": "agentos/tooling/GraphBackfill"},
             {"name": "Chrome DevTools MCP Server",                     "parentId": "AgentOS/Tooling",                                     "id": "agentos/tooling/ChromeDevToolsMcpServer"},
             {"name": "GitHub CLI Setup",                               "parentId": "AgentOS/Tooling",                                     "id": "agentos/tooling/GitHubCLISetup"},
             {"name": "GitHub Workflow Server: gh-absent",              "parentId": "AgentOS/Tooling",                                     "id": "agentos/tooling/GitHubWorkflowServerGhAbsent"},

--- a/test/playwright/unit/ai/daemons/services/LazyEdgeDrainer.spec.mjs
+++ b/test/playwright/unit/ai/daemons/services/LazyEdgeDrainer.spec.mjs
@@ -212,6 +212,36 @@ test.describe('Neo.ai.daemons.services.LazyEdgeDrainer', () => {
         expect(remaining).toContain('memory:dryrun-m');
     });
 
+    test('drainQueue recovers orphaned .draining file from a prior-run SIGKILL', async () => {
+        // Simulate a prior drain that was SIGKILL'd between rename and completion: the
+        // `.draining` file exists with queued edges but the live queue may or may not have
+        // fresh appends from a concurrent producer.
+        const drainingPath = queuePath + '.draining';
+        const orphanedEdge = {source: 'CONCEPT:orphan', target: 'memory:orphan', relationship: 'MENTIONED_IN'};
+        const freshEdge    = {source: 'CONCEPT:fresh',  target: 'memory:fresh',  relationship: 'DISCUSSED_IN'};
+
+        fs.writeFileSync(drainingPath, JSON.stringify(orphanedEdge) + '\n');
+        fs.writeFileSync(queuePath,    JSON.stringify(freshEdge)   + '\n');
+
+        const processedTargets = [];
+        GraphService.linkNodesAsync = async (source, target) => {
+            processedTargets.push(target);
+            return true;
+        };
+
+        const stats = await LazyEdgeDrainer.drainQueue({filePath: queuePath});
+
+        expect(stats.orphanRecovered).toBe(true);
+        // Both the orphaned and the fresh edge should have been drained in this single run.
+        expect(stats.succeeded).toBe(2);
+        expect(processedTargets).toContain('memory:orphan');
+        expect(processedTargets).toContain('memory:fresh');
+        // Orphan file removed after successful recovery.
+        expect(fs.existsSync(drainingPath)).toBe(false);
+        // Live queue fully drained (no failures to retain).
+        expect(fs.existsSync(queuePath)).toBe(false);
+    });
+
     test('drainQueue handles thrown exceptions from linkNodesAsync as failures', async () => {
         fs.writeFileSync(queuePath, JSON.stringify({source: 'a', target: 'memory:throw', relationship: 'RELATES_TO'}) + '\n');
 

--- a/test/playwright/unit/ai/daemons/services/LazyEdgeDrainer.spec.mjs
+++ b/test/playwright/unit/ai/daemons/services/LazyEdgeDrainer.spec.mjs
@@ -1,0 +1,235 @@
+import {setup} from '../../../../setup.mjs';
+
+const appName = 'LazyEdgeDrainerTest';
+
+setup({
+    neoConfig: {
+        unitTestMode: true
+    },
+    appConfig: {
+        name             : appName,
+        isMounted        : () => true,
+        vnodeInitialising: false
+    }
+});
+
+import {test, expect} from '@playwright/test';
+import Neo            from '../../../../../../src/Neo.mjs';
+import * as core      from '../../../../../../src/core/_export.mjs';
+import fs             from 'fs';
+import path           from 'path';
+
+test.describe('Neo.ai.daemons.services.LazyEdgeDrainer', () => {
+    // Serial matches the sibling MemorySessionIngestor.spec — cold import chain of the Neo core
+    // + GraphService module graph benefits from warm module cache across tests.
+    test.describe.configure({mode: 'serial'});
+
+    let LazyEdgeDrainer;
+    let GraphService;
+    let SystemLifecycleService;
+    let logger;
+    let originalLinkNodesAsync;
+
+    const testDbName  = `memory-core-lazy-edge-drainer-test-${process.pid}-${Date.now()}.sqlite`;
+    const queueName   = `test-lazy-edges-${process.pid}-${Date.now()}.jsonl`;
+    let testDbPath;
+    let queuePath;
+
+    test.beforeAll(async () => {
+        const aiConfig = (await import('../../../../../../ai/mcp/server/memory-core/config.mjs')).default;
+
+        const tmpDir = path.resolve(process.cwd(), 'tmp');
+        if (!fs.existsSync(tmpDir)) {
+            fs.mkdirSync(tmpDir, {recursive: true});
+        }
+        testDbPath = path.join(tmpDir, testDbName);
+        queuePath  = path.join(tmpDir, queueName);
+
+        aiConfig.storagePaths.graph   = testDbPath;
+        aiConfig.autoIngestFileSystem = false;
+
+        LazyEdgeDrainer        = (await import('../../../../../../ai/daemons/services/LazyEdgeDrainer.mjs')).default;
+        GraphService           = (await import('../../../../../../ai/mcp/server/memory-core/services/GraphService.mjs')).default;
+        SystemLifecycleService = (await import('../../../../../../ai/mcp/server/memory-core/services/lifecycle/SystemLifecycleService.mjs')).default;
+        logger                 = (await import('../../../../../../ai/mcp/server/memory-core/logger.mjs')).default;
+
+        if (fs.existsSync(testDbPath)) {
+            try { fs.unlinkSync(testDbPath); } catch (e) {}
+            if (fs.existsSync(`${testDbPath}-wal`)) try { fs.unlinkSync(`${testDbPath}-wal`); } catch (e) {}
+            if (fs.existsSync(`${testDbPath}-shm`)) try { fs.unlinkSync(`${testDbPath}-shm`); } catch (e) {}
+        }
+
+        if (!SystemLifecycleService._initPromise) {
+            await SystemLifecycleService.initAsync();
+        } else {
+            await SystemLifecycleService.ready();
+        }
+    });
+
+    test.beforeEach(() => {
+        // Cross-test file isolation — each test owns its queue file state.
+        if (fs.existsSync(queuePath)) fs.unlinkSync(queuePath);
+        const drainingPath = queuePath + '.draining';
+        if (fs.existsSync(drainingPath)) fs.unlinkSync(drainingPath);
+
+        // Capture the real linkNodesAsync so tests can mock it without cross-test leak.
+        originalLinkNodesAsync = GraphService.linkNodesAsync.bind(GraphService);
+    });
+
+    test.afterEach(() => {
+        GraphService.linkNodesAsync = originalLinkNodesAsync;
+
+        if (fs.existsSync(queuePath)) fs.unlinkSync(queuePath);
+        const drainingPath = queuePath + '.draining';
+        if (fs.existsSync(drainingPath)) fs.unlinkSync(drainingPath);
+    });
+
+    test.afterAll(() => {
+        if (GraphService?.db) {
+            if (GraphService.db.storage?.db) {
+                try { GraphService.db.storage.db.close(); } catch (e) {}
+            }
+            GraphService.db           = null;
+            GraphService._initPromise = null;
+        }
+
+        if (SystemLifecycleService) {
+            SystemLifecycleService._initPromise = null;
+        }
+
+        if (fs.existsSync(testDbPath)) {
+            try { fs.unlinkSync(testDbPath); } catch (e) {}
+            if (fs.existsSync(`${testDbPath}-wal`)) try { fs.unlinkSync(`${testDbPath}-wal`); } catch (e) {}
+            if (fs.existsSync(`${testDbPath}-shm`)) try { fs.unlinkSync(`${testDbPath}-shm`); } catch (e) {}
+        }
+    });
+
+    test('drainQueue on non-existent queue file is a no-op', async () => {
+        const stats = await LazyEdgeDrainer.drainQueue({filePath: queuePath});
+
+        expect(stats.totalLines).toBe(0);
+        expect(stats.processed).toBe(0);
+        expect(stats.succeeded).toBe(0);
+        expect(stats.queueRotated).toBe(false);
+    });
+
+    test('drainQueue processes all valid edges and deletes the queue file', async () => {
+        const edges = [
+            {source: 'CONCEPT:a', target: 'memory:m1', relationship: 'MENTIONED_IN', weight: 1.0},
+            {source: 'CONCEPT:b', target: 'session:s1', relationship: 'DISCUSSED_IN', weight: 1.0}
+        ];
+        fs.writeFileSync(queuePath, edges.map(e => JSON.stringify(e)).join('\n') + '\n');
+
+        // Mock linkNodesAsync to always succeed.
+        GraphService.linkNodesAsync = async () => true;
+
+        const stats = await LazyEdgeDrainer.drainQueue({filePath: queuePath});
+
+        expect(stats.totalLines).toBe(2);
+        expect(stats.processed).toBe(2);
+        expect(stats.succeeded).toBe(2);
+        expect(stats.failed).toBe(0);
+        expect(stats.queueRotated).toBe(true);
+        // Queue file should be removed on full drain (no failures to retain).
+        expect(fs.existsSync(queuePath)).toBe(false);
+        // .draining file should be cleaned up too.
+        expect(fs.existsSync(queuePath + '.draining')).toBe(false);
+    });
+
+    test('drainQueue retains failures in the queue for future retry', async () => {
+        const edges = [
+            {source: 'CONCEPT:a', target: 'memory:resolvable', relationship: 'MENTIONED_IN'},
+            {source: 'CONCEPT:b', target: 'memory:unresolvable', relationship: 'MENTIONED_IN'}
+        ];
+        fs.writeFileSync(queuePath, edges.map(e => JSON.stringify(e)).join('\n') + '\n');
+
+        // Mock linkNodesAsync to succeed for 'resolvable', fail for 'unresolvable'.
+        GraphService.linkNodesAsync = async (source, target) => target === 'memory:resolvable';
+
+        const stats = await LazyEdgeDrainer.drainQueue({filePath: queuePath});
+
+        expect(stats.succeeded).toBe(1);
+        expect(stats.failed).toBe(1);
+        // Queue file should exist with the single failure line retained.
+        expect(fs.existsSync(queuePath)).toBe(true);
+        const retained = fs.readFileSync(queuePath, 'utf8');
+        expect(retained).toContain('memory:unresolvable');
+        expect(retained).not.toContain('memory:resolvable');
+    });
+
+    test('drainQueue skips malformed JSON lines without retaining them', async () => {
+        fs.writeFileSync(queuePath, [
+            JSON.stringify({source: 'a', target: 'memory:b', relationship: 'RELATES_TO'}),
+            '{this is not valid json',
+            JSON.stringify({source: 'c', target: 'session:d', relationship: 'DISCUSSED_IN'})
+        ].join('\n') + '\n');
+
+        GraphService.linkNodesAsync = async () => true;
+
+        const stats = await LazyEdgeDrainer.drainQueue({filePath: queuePath});
+
+        expect(stats.totalLines).toBe(3);
+        expect(stats.succeeded).toBe(2);
+        expect(stats.skippedMalformed).toBe(1);
+        expect(stats.failed).toBe(0);
+        // Malformed lines are discarded (never succeed on retry); no residual file.
+        expect(fs.existsSync(queuePath)).toBe(false);
+    });
+
+    test('drainQueue skips lines missing required fields as malformed', async () => {
+        fs.writeFileSync(queuePath, [
+            JSON.stringify({source: 'a', target: 'memory:b'}),            // missing relationship
+            JSON.stringify({source: 'a', relationship: 'MENTIONED_IN'}),  // missing target
+            JSON.stringify({target: 'memory:b', relationship: 'MENTIONED_IN'})  // missing source
+        ].join('\n') + '\n');
+
+        GraphService.linkNodesAsync = async () => true;
+
+        const stats = await LazyEdgeDrainer.drainQueue({filePath: queuePath});
+
+        expect(stats.totalLines).toBe(3);
+        expect(stats.skippedMalformed).toBe(3);
+        expect(stats.succeeded).toBe(0);
+    });
+
+    test('drainQueue dry-run reports stats without mutating the queue or the graph', async () => {
+        const edges = [
+            {source: 'CONCEPT:a', target: 'memory:dryrun-m', relationship: 'MENTIONED_IN'}
+        ];
+        fs.writeFileSync(queuePath, JSON.stringify(edges[0]) + '\n');
+
+        let linkCalled = false;
+        GraphService.linkNodesAsync = async () => { linkCalled = true; return true; };
+
+        const stats = await LazyEdgeDrainer.drainQueue({filePath: queuePath, dryRun: true});
+
+        expect(stats.totalLines).toBe(1);
+        expect(stats.succeeded).toBe(1);
+        expect(linkCalled).toBe(false);
+        // Queue file unchanged by dry-run.
+        expect(fs.existsSync(queuePath)).toBe(true);
+        const remaining = fs.readFileSync(queuePath, 'utf8');
+        expect(remaining).toContain('memory:dryrun-m');
+    });
+
+    test('drainQueue handles thrown exceptions from linkNodesAsync as failures', async () => {
+        fs.writeFileSync(queuePath, JSON.stringify({source: 'a', target: 'memory:throw', relationship: 'RELATES_TO'}) + '\n');
+
+        const originalWarn = logger.warn;
+        logger.warn = () => {};
+
+        try {
+            GraphService.linkNodesAsync = async () => { throw new Error('Synthetic DB error'); };
+
+            const stats = await LazyEdgeDrainer.drainQueue({filePath: queuePath});
+
+            expect(stats.processed).toBe(1);
+            expect(stats.failed).toBe(1);
+            expect(stats.succeeded).toBe(0);
+            // Failed edge retained for retry.
+            expect(fs.existsSync(queuePath)).toBe(true);
+        } finally {
+            logger.warn = originalWarn;
+        }
+    });
+});

--- a/test/playwright/unit/ai/daemons/services/MemorySessionIngestor.spec.mjs
+++ b/test/playwright/unit/ai/daemons/services/MemorySessionIngestor.spec.mjs
@@ -39,15 +39,25 @@ test.describe('Neo.ai.daemons.services.MemorySessionIngestor', () => {
     let warnMessages = [];
 
     /**
-     * Builds a stub Chroma memory collection fulfilling the contract
-     * `collection.get({where: {sessionId}, include: ['metadatas']}) → {ids, metadatas}`.
-     * Filters the given seed rows by sessionId so the ingestor sees only the session's
-     * memories, matching production Chroma filter semantics.
+     * Builds a stub Chroma memory collection supporting two query shapes:
+     * - `collection.get({where: {sessionId}, include: ['metadatas']}) → {ids, metadatas}` —
+     *   filters by sessionId (used by `syncSessionToGraph` for batch-per-session ingestion).
+     * - `collection.get({ids: [...]}) → {ids, metadatas}` — direct-id lookup (used by
+     *   `backfillMemory` for per-row back-fill via `ingestSingleRow`).
      */
     function stubMemoryCollection(seedRows) {
         return {
-            get: async ({where}) => {
-                const matching = seedRows.filter(r => r.metadata.sessionId === where.sessionId);
+            get: async ({ids, where} = {}) => {
+                let matching;
+
+                if (ids) {
+                    matching = seedRows.filter(r => ids.includes(r.id));
+                } else if (where?.sessionId) {
+                    matching = seedRows.filter(r => r.metadata.sessionId === where.sessionId);
+                } else {
+                    matching = seedRows;
+                }
+
                 return {
                     ids      : matching.map(r => r.id),
                     metadatas: matching.map(r => r.metadata)
@@ -345,5 +355,161 @@ test.describe('Neo.ai.daemons.services.MemorySessionIngestor', () => {
         expect(stats.sessionUpserted).toBe(false);
         expect(stats.errors.length).toBeGreaterThan(0);
         expect(stats.errors[0]).toContain('sessionId is required');
+    });
+
+    // ------------------------------------------------------------------------------------------
+    // ingestSingleRow (#10153) — per-row back-fill primitive. Consumed by
+    // `GraphService.ensureNodeExists` when `linkNodesAsync` hits a missing `memory:`/`session:`
+    // endpoint, and by `LazyEdgeDrainer` when draining the #10165 lazy-edges JSONL queue.
+    // ------------------------------------------------------------------------------------------
+
+    /**
+     * Stub matching `collection.get({ids}) → {ids, metadatas}` AND
+     * `collection.get({where: {sessionId}}) → {ids, metadatas}` — summary Chroma rows are
+     * looked up by `sessionId` metadata (opaque Chroma IDs) in `backfillSession`.
+     */
+    function stubSummaryCollection(seedRows) {
+        return {
+            get: async ({ids, where} = {}) => {
+                let matching;
+
+                if (ids) {
+                    matching = seedRows.filter(r => ids.includes(r.id));
+                } else if (where?.sessionId) {
+                    matching = seedRows.filter(r => r.metadata.sessionId === where.sessionId);
+                } else {
+                    matching = seedRows;
+                }
+
+                return {
+                    ids      : matching.map(r => r.id),
+                    metadatas: matching.map(r => r.metadata)
+                };
+            }
+        };
+    }
+
+    test('ingestSingleRow returns unrecognized-prefix for non memory:/session: ids', async () => {
+        const result = await MemorySessionIngestor.ingestSingleRow('CONCEPT:foo');
+
+        expect(result.success).toBe(false);
+        expect(result.reason).toBe('unrecognized-prefix');
+    });
+
+    test('ingestSingleRow returns already-exists when node is present', async () => {
+        GraphService.upsertNode({id: 'memory:abc', type: 'MEMORY', name: 'abc', properties: {}});
+
+        const result = await MemorySessionIngestor.ingestSingleRow('memory:abc');
+
+        expect(result.success).toBe(true);
+        expect(result.reason).toBe('already-exists');
+        expect(result.graphNodeId).toBe('memory:abc');
+    });
+
+    test('ingestSingleRow backfills Memory and recursively creates parent Session', async () => {
+        // Seed the parent Session node so GraphService.linkNodes's foreign-key check will pass
+        // when backfillMemory emits the ORIGINATES_IN edge. The backfillSession helper upserts
+        // the session node first, but the FK-verify in linkNodes reads from SQLite — which the
+        // in-memory upsert path populates via addNode → storage. This is consistent with the
+        // forward-ingestion test pattern in earlier cases here.
+        const memoryCollection  = stubMemoryCollection([
+            {id: 'mem-xyz', metadata: {sessionId: 'sess-xyz', createdAt: '2026-04-21T10:00:00Z', userId: 'tobiu'}}
+        ]);
+        const summaryCollection = stubSummaryCollection([
+            {id: 'chroma-summary-xyz', metadata: {sessionId: 'sess-xyz', createdAt: '2026-04-21T09:00:00Z', userId: 'tobiu', title: 'Recursive session'}}
+        ]);
+
+        const result = await MemorySessionIngestor.ingestSingleRow('memory:mem-xyz', {memoryCollection, summaryCollection});
+
+        expect(result.success).toBe(true);
+        expect(result.reason).toBe('backfilled');
+        expect(result.graphNodeId).toBe('memory:mem-xyz');
+
+        const memoryNode = GraphService.db.nodes.get('memory:mem-xyz');
+        expect(memoryNode).toBeTruthy();
+        expect(memoryNode.properties.backfilled).toBe(true);
+        expect(memoryNode.properties.sessionId).toBe('sess-xyz');
+
+        const sessionNode = GraphService.db.nodes.get('session:sess-xyz');
+        expect(sessionNode).toBeTruthy();
+        expect(sessionNode.properties.backfilled).toBe(true);
+
+        // ORIGINATES_IN edge from Memory → Session
+        const edge = GraphService.db.edges.items.find(e =>
+            e.source === 'memory:mem-xyz' && e.target === 'session:sess-xyz' && e.type === 'ORIGINATES_IN'
+        );
+        expect(edge).toBeTruthy();
+    });
+
+    test('ingestSingleRow backfills Session with full metadata when summary row exists', async () => {
+        const summaryCollection = stubSummaryCollection([
+            {id: 'chroma-summary-abc', metadata: {sessionId: 'sess-abc', createdAt: '2026-04-21T09:00:00Z', userId: 'tobiu', title: 'Abc session'}}
+        ]);
+
+        const result = await MemorySessionIngestor.ingestSingleRow('session:sess-abc', {summaryCollection});
+
+        expect(result.success).toBe(true);
+        expect(result.reason).toBe('backfilled');
+
+        const node = GraphService.db.nodes.get('session:sess-abc');
+        expect(node.properties.backfilled).toBe(true);
+        expect(node.properties.chromaId).toBe('chroma-summary-abc');
+        expect(node.properties.sessionId).toBe('sess-abc');
+        expect(node.properties.userId).toBe('tobiu');
+    });
+
+    test('ingestSingleRow falls back to minimal session when no summary row exists', async () => {
+        const summaryCollection = stubSummaryCollection([]);
+
+        const result = await MemorySessionIngestor.ingestSingleRow('session:sess-unknown', {summaryCollection});
+
+        expect(result.success).toBe(true);
+        expect(result.reason).toBe('backfilled-minimal');
+
+        const node = GraphService.db.nodes.get('session:sess-unknown');
+        expect(node.properties.backfilled).toBe(true);
+        expect(node.properties.minimal).toBe(true);
+        expect(node.properties.sessionId).toBe('sess-unknown');
+    });
+
+    test('ingestSingleRow normalizes uppercase MEMORY: prefix to canonical lowercase', async () => {
+        const memoryCollection  = stubMemoryCollection([
+            {id: 'mem-upper', metadata: {sessionId: 'sess-upper', createdAt: '2026-04-21T10:00:00Z', userId: 'tobiu'}}
+        ]);
+        const summaryCollection = stubSummaryCollection([
+            {id: 'chroma-summary-upper', metadata: {sessionId: 'sess-upper', createdAt: '2026-04-21T09:00:00Z', userId: 'tobiu'}}
+        ]);
+
+        // Caller passes the uppercase prefix (Gemini's #10165 extractor convention); the
+        // back-fill must land under the canonical lowercase form so the node is discoverable
+        // by the existing ingestor's `session:`/`memory:` ID contract.
+        const result = await MemorySessionIngestor.ingestSingleRow('MEMORY:mem-upper', {memoryCollection, summaryCollection});
+
+        expect(result.success).toBe(true);
+        expect(result.graphNodeId).toBe('memory:mem-upper');
+        expect(GraphService.db.nodes.get('memory:mem-upper')).toBeTruthy();
+        expect(GraphService.db.nodes.get('MEMORY:mem-upper')).toBeFalsy();
+    });
+
+    test('syncSessionToGraph tags upserted nodes with liveIngested: true provenance marker', async () => {
+        const session = {
+            id  : 'chroma-summary-live',
+            meta: {sessionId: 'agent-live', createdAt: '2026-04-21T09:00:00Z', userId: 'tobiu', title: 'Live'}
+        };
+        const memoryCollection = stubMemoryCollection([
+            {id: 'mem-live', metadata: {sessionId: 'agent-live', createdAt: '2026-04-21T09:01:00Z', userId: 'tobiu'}}
+        ]);
+
+        await MemorySessionIngestor.syncSessionToGraph(session, {memoryCollection});
+
+        const sessionNode = GraphService.db.nodes.get('session:agent-live');
+        const memoryNode  = GraphService.db.nodes.get('memory:mem-live');
+
+        expect(sessionNode.properties.liveIngested).toBe(true);
+        expect(memoryNode.properties.liveIngested).toBe(true);
+        // `backfilled` should remain undefined on live-ingested nodes; the two markers are
+        // mutually exclusive provenance tags per ticket #10153.
+        expect(sessionNode.properties.backfilled).toBeUndefined();
+        expect(memoryNode.properties.backfilled).toBeUndefined();
     });
 });

--- a/test/playwright/unit/ai/mcp/server/memory-core/services/GraphService.spec.mjs
+++ b/test/playwright/unit/ai/mcp/server/memory-core/services/GraphService.spec.mjs
@@ -362,4 +362,136 @@ test.describe('Neo.ai.mcp.server.memory-core.services.GraphService', () => {
         expect(link.weight).toBe(0.95);
         expect(link.source).toBe('RootT');
     });
+
+    // ----------------------------------------------------------------------------------------
+    // linkNodesAsync + ensureNodeExists + normalizeGraphNodeId (#10153) — lazy back-fill path.
+    // Sync `linkNodes` preserved unchanged for existing callers; these tests exercise the
+    // async path that resolves missing endpoints via `MemorySessionIngestor.ingestSingleRow`.
+    // ----------------------------------------------------------------------------------------
+
+    test('normalizeGraphNodeId lowercases memory:/session: prefixes and passes others through', () => {
+        expect(GraphService.normalizeGraphNodeId('MEMORY:abc')).toBe('memory:abc');
+        expect(GraphService.normalizeGraphNodeId('memory:abc')).toBe('memory:abc');
+        expect(GraphService.normalizeGraphNodeId('SESSION:xyz')).toBe('session:xyz');
+        expect(GraphService.normalizeGraphNodeId('session:xyz')).toBe('session:xyz');
+        expect(GraphService.normalizeGraphNodeId('CONCEPT:foo')).toBe('CONCEPT:foo');
+        expect(GraphService.normalizeGraphNodeId('frontier')).toBe('frontier');
+        expect(GraphService.normalizeGraphNodeId(null)).toBe(null);
+        expect(GraphService.normalizeGraphNodeId('')).toBe('');
+    });
+
+    test('linkNodesAsync creates the edge when both endpoints already exist', async () => {
+        GraphService.upsertNode({id: 'NodeA', type: 'TEST', name: 'A', properties: {}});
+        GraphService.upsertNode({id: 'NodeB', type: 'TEST', name: 'B', properties: {}});
+
+        const ok = await GraphService.linkNodesAsync('NodeA', 'NodeB', 'RELATES_TO', 1.0);
+
+        expect(ok).toBe(true);
+        const edge = GraphService.db.edges.items.find(e =>
+            e.source === 'NodeA' && e.target === 'NodeB' && e.type === 'RELATES_TO'
+        );
+        expect(edge).toBeTruthy();
+    });
+
+    test('linkNodesAsync back-fills missing memory: target via MemorySessionIngestor', async () => {
+        const MemorySessionIngestor = (await import('../../../../../../../../ai/daemons/services/MemorySessionIngestor.mjs')).default;
+        const originalIngest = MemorySessionIngestor.ingestSingleRow;
+
+        // Mock the ingestor to simulate a successful back-fill — upsert a node and return success.
+        MemorySessionIngestor.ingestSingleRow = async (id) => {
+            const normalized = id.toLowerCase().startsWith('memory:') ? 'memory:' + id.slice(7) :
+                               id.toLowerCase().startsWith('session:') ? 'session:' + id.slice(8) : id;
+            GraphService.upsertNode({id: normalized, type: 'MEMORY', name: normalized, properties: {backfilled: true}});
+            return {success: true, reason: 'backfilled', graphNodeId: normalized};
+        };
+
+        try {
+            GraphService.upsertNode({id: 'NodeSrc', type: 'TEST', name: 'Src', properties: {}});
+
+            const ok = await GraphService.linkNodesAsync('NodeSrc', 'memory:lazy-xyz', 'MENTIONED_IN', 1.0);
+
+            expect(ok).toBe(true);
+            expect(GraphService.db.nodes.get('memory:lazy-xyz')).toBeTruthy();
+            const edge = GraphService.db.edges.items.find(e =>
+                e.source === 'NodeSrc' && e.target === 'memory:lazy-xyz' && e.type === 'MENTIONED_IN'
+            );
+            expect(edge).toBeTruthy();
+        } finally {
+            MemorySessionIngestor.ingestSingleRow = originalIngest;
+        }
+    });
+
+    test('linkNodesAsync normalizes uppercase MEMORY: prefix to canonical lowercase', async () => {
+        const MemorySessionIngestor = (await import('../../../../../../../../ai/daemons/services/MemorySessionIngestor.mjs')).default;
+        const originalIngest = MemorySessionIngestor.ingestSingleRow;
+
+        MemorySessionIngestor.ingestSingleRow = async (id) => {
+            // The resolver is called with the already-normalized id; verify that fact.
+            expect(id).toBe('memory:upper-case-id');
+            GraphService.upsertNode({id: 'memory:upper-case-id', type: 'MEMORY', name: 'UC', properties: {backfilled: true}});
+            return {success: true, reason: 'backfilled', graphNodeId: 'memory:upper-case-id'};
+        };
+
+        try {
+            GraphService.upsertNode({id: 'NodeSrc2', type: 'TEST', name: 'Src', properties: {}});
+
+            // Caller passes uppercase prefix — linkNodesAsync normalizes before ensureNodeExists.
+            const ok = await GraphService.linkNodesAsync('NodeSrc2', 'MEMORY:upper-case-id', 'REFERENCED_BY', 1.0);
+
+            expect(ok).toBe(true);
+            // Edge lands against canonical lowercase id, not the uppercase input.
+            expect(GraphService.db.nodes.get('memory:upper-case-id')).toBeTruthy();
+            expect(GraphService.db.nodes.get('MEMORY:upper-case-id')).toBeFalsy();
+            const edge = GraphService.db.edges.items.find(e =>
+                e.target === 'memory:upper-case-id' && e.type === 'REFERENCED_BY'
+            );
+            expect(edge).toBeTruthy();
+        } finally {
+            MemorySessionIngestor.ingestSingleRow = originalIngest;
+        }
+    });
+
+    test('linkNodesAsync returns false when back-fill fails (hallucinated target)', async () => {
+        const MemorySessionIngestor = (await import('../../../../../../../../ai/daemons/services/MemorySessionIngestor.mjs')).default;
+        const originalIngest = MemorySessionIngestor.ingestSingleRow;
+
+        MemorySessionIngestor.ingestSingleRow = async (id) => ({
+            success: false,
+            reason : 'chroma-row-not-found',
+            graphNodeId: id
+        });
+
+        try {
+            GraphService.upsertNode({id: 'NodeSrc3', type: 'TEST', name: 'Src', properties: {}});
+
+            const ok = await GraphService.linkNodesAsync('NodeSrc3', 'memory:does-not-exist', 'MENTIONED_IN', 1.0);
+
+            expect(ok).toBe(false);
+            // No edge created — genuine hallucination, cull stands.
+            const edge = GraphService.db.edges.items.find(e =>
+                e.source === 'NodeSrc3' && e.target === 'memory:does-not-exist'
+            );
+            expect(edge).toBeFalsy();
+        } finally {
+            MemorySessionIngestor.ingestSingleRow = originalIngest;
+        }
+    });
+
+    test('linkNodesAsync returns false for unrecognized-prefix targets (non-back-fillable)', async () => {
+        GraphService.upsertNode({id: 'NodeSrc4', type: 'TEST', name: 'Src', properties: {}});
+
+        // No mock needed — ingestSingleRow will return {success: false, reason: 'unrecognized-prefix'}
+        // for the CONCEPT: prefix (not a memory:/session: target).
+        const ok = await GraphService.linkNodesAsync('NodeSrc4', 'CONCEPT:not-a-node', 'RELATES_TO', 1.0);
+
+        expect(ok).toBe(false);
+    });
+
+    test('ensureNodeExists returns true when node already in graph', async () => {
+        GraphService.upsertNode({id: 'memory:present', type: 'MEMORY', name: 'present', properties: {}});
+
+        const ready = await GraphService.ensureNodeExists('memory:present');
+
+        expect(ready).toBe(true);
+    });
 });


### PR DESCRIPTION
Authored by Claude Opus 4.7 (Claude Code). Session `d69ac7a0-9fe8-4416-b766-cd9edb8bee71`.

Resolves #10153

Closes the producer/consumer contract opened by Gemini's #10152 / [#10165](https://github.com/neomjs/neo/pull/10165): missing `MEMORY:` / `SESSION:` edge targets are now materialized from their Chroma source rows on-demand rather than silently culled. Together with the eager `priorityBackfill` CLI, this removes the forward-only-ingestion asymmetry that would otherwise leave ~9,040 pre-migration Chroma rows permanently unreachable by graph edges (mailbox `IN_REPLY_TO` per #10147, identity `AUTHORED_BY` per #10016, extractor provenance per #10152).

## Deltas from ticket

All AC items landed. One architectural compromise worth naming:

**Node-ID case canonicalization deferred.** The existing ingestor writes `memory:<chromaId>` / `session:<sessionId>` (lowercase prefix). Gemini's #10165 extractor emits edges referencing `MEMORY:<chromaId>` / `SESSION:<sessionId>` (uppercase prefix). My `ingestSingleRow` and `linkNodesAsync` both normalize case-insensitively on the consumer side, so neither convention "wins" yet. Canonical-format decision belongs in a follow-up ticket — either the ingestor renames its upsert path, or the extractor prompt + queued entries get rewritten. Both paths work today via normalization.

## Pipeline

| Entry point | Trigger | Scope |
|---|---|---|
| `GraphService.linkNodesAsync(source, target, ...)` | Per-edge lazy resolution | On any edge-creation attempt with a missing `memory:`/`session:` endpoint. Sync `linkNodes` unchanged — zero blast radius on existing callers. |
| `LazyEdgeDrainer.drainQueue()` | JSONL queue consumer | Drains `ai/data/memory-core/lazy-edges.jsonl` (producer: #10165) via atomic rename-then-drain |
| `node ai/scripts/priorityBackfill.mjs` | Operator eager batch | Two-phase: ingest last-N-days window via `syncSessionToGraph` + drain queue |

All three converge on the new primitive: `MemorySessionIngestor.ingestSingleRow(graphNodeId)`.

## New / Modified Files

**New services + CLI:**
- `ai/daemons/services/MemorySessionIngestor.mjs` (+200 LOC) — `ingestSingleRow` + `parseGraphNodeId` + `backfillMemory` + `backfillSession` + `liveIngested: true` marker on existing paths
- `ai/daemons/services/LazyEdgeDrainer.mjs` (new, 200 LOC) — JSONL queue consumer with rename-then-drain atomicity
- `ai/mcp/server/memory-core/services/GraphService.mjs` (+140 LOC) — `linkNodesAsync` + `ensureNodeExists` + `normalizeGraphNodeId`; sync `linkNodes` unchanged
- `ai/scripts/priorityBackfill.mjs` (new, 130 LOC) — operator CLI

**Design doc:**
- `learn/agentos/tooling/GraphBackfill.md` (new) — full pipeline explanation + operator recipes + provenance marker semantics + the case-canonicalization coordination note
- `learn/tree.json` — new doc registered under `AgentOS/Tooling`

**Tests (35 total across 3 specs):**
- `test/playwright/unit/ai/daemons/services/MemorySessionIngestor.spec.mjs` — existing 6 + 7 new (`ingestSingleRow` paths: unrecognized prefix, already-exists, recursive Memory→Session, full-metadata Session, minimal-session fallback, case-insensitive prefix, `liveIngested` marker)
- `test/playwright/unit/ai/mcp/server/memory-core/services/GraphService.spec.mjs` — existing 8 + 7 new (`normalizeGraphNodeId` pure, `linkNodesAsync` with both endpoints present, back-fill path via mocked ingestor, uppercase-prefix normalization, hallucinated-target cull, unrecognized-prefix cull, `ensureNodeExists` present-node)
- `test/playwright/unit/ai/daemons/services/LazyEdgeDrainer.spec.mjs` (new) — 7 (no-op on missing queue, valid-edges drain + file delete, failures retained, malformed JSON discarded, missing-fields discarded, dry-run non-mutating, throw-handling)

## Test Evidence

```
$ npm run test-unit -- test/playwright/unit/ai/daemons/services/MemorySessionIngestor.spec.mjs \
                     test/playwright/unit/ai/mcp/server/memory-core/services/GraphService.spec.mjs \
                     test/playwright/unit/ai/daemons/services/LazyEdgeDrainer.spec.mjs
  35 passed (845ms)
```

Existing specs untouched by the changes — the only additions are to the `static config` / class-method surface of two existing services, both backward-compatible (new properties / new methods, no signature changes on existing public API).

## Post-Merge Validation

- [ ] Run `node ai/scripts/priorityBackfill.mjs --dry-run --days 30` in a warm Memory Core to confirm the script reports a plausible window count + drain stats
- [ ] Confirm `liveIngested: true` appears on fresh REM-cycle upserts; `backfilled: true` appears on nodes materialized via lazy resolution or the CLI
- [ ] Verify the `ai/data/memory-core/lazy-edges.jsonl` queue drains cleanly after the next DreamService REM cycle once this + #10165 are both live
- [ ] Manual smoke: attempt a `linkNodesAsync` call with a genuinely-hallucinated `MEMORY:bogus-id` — confirm cull-behavior preserved (returns `false`, no edge, warn log)

## Epic-Review Provenance

- Parent #10143 epic-review by Gemini 3.1 Pro (2026-04-21, session `7a73e53f-801a-490f-b693-b431189aa1a9`). Opus self-authored skip-OK per `epic-review` §5 — I authored the #10143 reshape.

## Related

- Parent: #10143 (Graph-first Memory artifacts)
- Grand-parent epic: #9999 (Cloud-Native Knowledge & Multi-Tenant Memory Core)
- Predecessor (shipped): #10151 / PR [#10161](https://github.com/neomjs/neo/pull/10161) (live forward ingestion — `MemorySessionIngestor.syncSessionToGraph`)
- Predecessor (shipped): #10152 / PR [#10165](https://github.com/neomjs/neo/pull/10165) (extractor provenance edges + producer of the lazy queue)
- Sibling: #10158 (post-ship telemetry + retention — complementary)
- Follow-up: canonical `memory:` vs `MEMORY:` case settlement (to be filed post-merge if the coordination seam causes operational friction)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
