### PR TITLE
fix(memory-core): mailbox SENT_TO persistence + fromIdentity filter + add_memory inbox delta (#10174)

### DIFF
--- a/ai/mcp/server/memory-core/openapi.yaml
+++ b/ai/mcp/server/memory-core/openapi.yaml
@@ -882,10 +882,14 @@ paths:
           description: "Filter by specific thread"
           schema:
             type: string
-        - name: from
+        - name: fromIdentity
           in: query
           required: false
-          description: "Filter by specific sender"
+          description: |
+            Filter by specific sender identity. Named `fromIdentity` rather than `from` to avoid
+            the anti-spoof reserved-key collision in `AuthMiddleware` — `from` is a
+            claim-of-authorship key blocked at the callTool choke-point, whereas this parameter
+            is a read-path filter with no authorship semantics. Renamed per #10174.
           schema:
             type: string
         - name: limit
@@ -1211,6 +1215,39 @@ components:
         message:
           type: string
           example: "Memory successfully added"
+        mailbox:
+          description: |
+            Per-turn A2A mailbox delta signal — unread-inbox awareness piggybacked on every
+            memory write. Bypasses the in-memory graph cache via a direct SQLite read, so
+            messages written by other harness processes surface immediately without requiring
+            an MCP server restart. `null` when the caller has no bound AgentIdentity
+            (single-tenant fallthrough). Shipped with #10174.
+          nullable: true
+          type: object
+          properties:
+            unreadCount:
+              type: integer
+              description: Number of unread messages addressed to the caller's inbox (direct + broadcast)
+              example: 2
+            latestPreview:
+              nullable: true
+              type: object
+              description: Newest unread message preview; `null` when the inbox is empty
+              properties:
+                messageId:
+                  type: string
+                  example: "MESSAGE:9ccb7868-9b7c-4199-9c3c-a9ba175e70f6"
+                subject:
+                  type: string
+                  example: "Re: First A2A handshake — Phase 4 split proposal"
+                from:
+                  type: string
+                  description: The sender's AgentIdentity node id
+                  example: "@neo-gemini-3-1-pro"
+                sentAt:
+                  type: string
+                  format: date-time
+                  example: "2026-04-22T13:33:41.675Z"
 
     MemoriesListResponse:
       type: object

--- a/ai/mcp/server/memory-core/services/MailboxService.mjs
+++ b/ai/mcp/server/memory-core/services/MailboxService.mjs
@@ -6,14 +6,55 @@ import crypto from 'crypto';
 import SemanticGraphExtractor from '../../../../daemons/services/SemanticGraphExtractor.mjs';
 
 /**
+ * Canonicalizes a mailbox `to` address to the form seeded in the AgentIdentity graph.
+ *
+ * Neo's mailbox tool-schema wording accepts the ambiguous `'AGENT:@login'` form in addition to the
+ * canonical seeded `'@login'` form. Left unnormalized, {@link Neo.ai.mcp.server.memory-core.services.GraphService#linkNodes}
+ * culls every `SENT_TO` edge whose prefixed-form target doesn't happen to match a seeded node —
+ * the silent-drop root cause documented in #10174. Centralizing normalization here preserves
+ * `linkNodes`'s defense-in-depth FK-style guard (hallucinated-path protection for every other
+ * edge-creation path in the graph) while honoring the mailbox's documented addressing surface.
+ *
+ * Accepted shapes and their canonical outputs:
+ * - `'@login'` → `'@login'` (already canonical)
+ * - `'AGENT:@login'` → `'@login'` (strip the `AGENT:` prefix)
+ * - `'AGENT:*'` → `'AGENT:*'` (broadcast sentinel — unchanged, seeded as a real `BroadcastSentinel`
+ *   node by `ai/scripts/seedAgentIdentities.mjs` so the FK guard accepts it)
+ * - `'role:<name>'` / `'human:<login>'` → unchanged (role + human addressing; the corresponding
+ *   node must pre-exist in the graph or be created by a separate seed pass)
+ * - Test-fixture convention `'AGENT:<bareName>'` without `@` → unchanged; MailboxService unit
+ *   tests seed these directly and bypass the production `bindAgentIdentity` path entirely. The
+ *   `.startsWith('AGENT:@')` guard intentionally does NOT strip for bare-name fixtures.
+ *
+ * @param {String} to The raw `to` address as supplied by the caller.
+ * @returns {String} The canonical address ready for `linkNodes` and permission-check consumption.
+ * @private
+ */
+function normalizeMailboxTarget(to) {
+    if (to?.startsWith('AGENT:@')) {
+        return to.slice('AGENT:'.length)
+    }
+    return to
+}
+
+/**
  * @summary A2A (Agent-to-Agent) Messaging Service mapped to the Native Edge Graph.
  *
  * Implements the Mailbox primitives for direct or broadcast agent communications.
  * Messages are stored as graph nodes of `type: 'MESSAGE'`, with `SENT_BY` and `SENT_TO` edges.
  *
+ * This class is a key example of the framework's **A2A messaging substrate** and demonstrates
+ * concepts like **agent identity**, **broadcast fan-out**, **reachable-counterparty trust
+ * inference**, and **server-stamped authorship** (the anti-spoof `SENT_BY` edge is derived from
+ * `RequestContextService.getAgentIdentityNodeId()`, never from client input — per
+ * `AuthMiddleware.IDENTITY_OVERRIDE_KEYS`).
+ *
  * @class Neo.ai.mcp.server.memory-core.services.MailboxService
  * @extends Neo.core.Base
  * @singleton
+ * @see Neo.ai.mcp.server.memory-core.services.GraphService
+ * @see Neo.ai.mcp.server.memory-core.services.PermissionService
+ * @see Neo.ai.mcp.server.shared.services.RequestContextService
  */
 class MailboxService extends Base {
     static config = {
@@ -49,6 +90,13 @@ class MailboxService extends Base {
         if (!sentBy) {
             throw new Error("Cannot send message: no agent identity context bound. Ensure StdioIdentityResolver or OIDC transport is active.");
         }
+
+        // Canonicalize addressing to match the seeded AgentIdentity graph-node IDs. Upstream tool-
+        // schema wording exposes the `'AGENT:@login'` prefixed form; the seed uses bare `@login`.
+        // Without this normalization, `GraphService.linkNodes`'s FK guard silently culls the
+        // `SENT_TO` edge — the root-cause bug closed by #10174. Permission checks and edge
+        // creation below all consume the canonical form from this point on.
+        to = normalizeMailboxTarget(to);
 
         const messageId = `MESSAGE:${crypto.randomUUID()}`;
         const timestamp = new Date().toISOString();
@@ -141,12 +189,16 @@ class MailboxService extends Base {
      * @param {String} [args.status='all'] Read status ('all', 'read', 'unread')
      * @param {String} [args.to] Target identity to list messages for (defaults to caller)
      * @param {String} [args.threadId] Filter by specific thread
-     * @param {String} [args.from] Filter by specific sender
+     * @param {String} [args.fromIdentity] Filter by specific sender. Named `fromIdentity` rather
+     *   than `from` to avoid the anti-spoof reserved-key collision in
+     *   {@link Neo.ai.mcp.server.shared.services.AuthMiddleware} — `from` is a claim-of-authorship
+     *   key blocked at the callTool choke-point, whereas this parameter is a read-path filter
+     *   with no authorship semantics. Renamed per #10174.
      * @param {Number} [args.limit=50] Maximum number of messages to return
      * @param {Number} [args.offset=0] Pagination offset
      * @returns {Promise<Object>}
      */
-    async listMessages({ box = 'inbox', status = 'all', to, threadId, from, limit = 50, offset = 0 } = {}) {
+    async listMessages({ box = 'inbox', status = 'all', to, threadId, fromIdentity, limit = 50, offset = 0 } = {}) {
         const me = RequestContextService.getAgentIdentityNodeId();
         if (!me) {
             throw new Error("Cannot list messages: no agent identity context bound.");
@@ -204,7 +256,7 @@ class MailboxService extends Base {
                         }
                     }
 
-                    if (from && sentByNodeId !== from) continue;
+                    if (fromIdentity && sentByNodeId !== fromIdentity) continue;
                     if (threadId && foundThreadId !== threadId) continue;
 
                     messages.push({

--- a/ai/mcp/server/memory-core/services/MemoryService.mjs
+++ b/ai/mcp/server/memory-core/services/MemoryService.mjs
@@ -7,6 +7,84 @@ import SessionService        from './SessionService.mjs';
 import aiConfig              from '../config.mjs';
 import RequestContextService from '../../shared/services/RequestContextService.mjs';
 
+/**
+ * Computes a lightweight inbox snapshot for the bound AgentIdentity to piggyback on every
+ * `add_memory` response — the per-turn **mailbox delta signal** shipped with #10174.
+ *
+ * Why it lives here rather than in `MailboxService`: `add_memory` is called by the agent's
+ * Memory Core Protocol every single turn (per `CLAUDE.md §4.2`'s Consolidate-Then-Save mandate).
+ * Extending its response payload gives agents push-style inbox awareness without adding a new
+ * polling endpoint and without waiting for the `ai/graph/Database.mjs` in-memory edge cache to
+ * gain cross-process coherence. The query intentionally bypasses `GraphService.db.edges.items`
+ * (the per-process in-memory cache that never sees remote writes without a server restart —
+ * observed empirically during the #10174 diagnostic) and reads straight from SQLite via
+ * `GraphService.db.storage.db.prepare()`, so a message sent by another harness's MCP server is
+ * visible as soon as its transaction commits.
+ *
+ * **Failure mode is non-fatal.** Any error inside this helper is swallowed and logged — the
+ * caller's memory write must always succeed on its own merits. An agent briefly missing its
+ * mailbox preview is an inconvenience; a silently dropped memory write would be a critical
+ * data-loss regression.
+ *
+ * @returns {{unreadCount: Number, latestPreview: Object|null}|null} A snapshot block with the
+ *     unread count + most-recent unread message preview (messageId, subject, from, sentAt).
+ *     Returns `null` when the caller has no bound agent identity (single-tenant fallthrough —
+ *     consistent with every other RequestContext-scoped operation in this service).
+ * @private
+ */
+function buildMailboxDelta() {
+    const me = RequestContextService.getAgentIdentityNodeId();
+    if (!me) return null;
+
+    const sqlite = GraphService.db?.storage?.db;
+    if (!sqlite) return null;
+
+    try {
+        // Unread-count: edges of type SENT_TO whose target is either the caller's bound
+        // identity OR the `AGENT:*` broadcast sentinel (seeded per #10174). readAt-null on the
+        // joined MESSAGE node filters to unread. DISTINCT e.source defends against duplicate
+        // SENT_TO edges (shouldn't happen in current schema, but cheap insurance).
+        const unreadRow = sqlite.prepare(`
+            SELECT COUNT(DISTINCT e.source) AS unreadCount
+            FROM Edges e
+            JOIN Nodes n ON n.id = e.source
+            WHERE e.type = 'SENT_TO'
+              AND (e.target = ? OR e.target = 'AGENT:*')
+              AND json_extract(n.data, '$.properties.readAt') IS NULL
+        `).get(me);
+
+        // Latest unread preview: newest sentAt wins. The correlated subquery resolves the
+        // sender identity via the message's SENT_BY edge. `messageId` on the outer select is
+        // the MESSAGE node id (redundant with n.id but explicit for caller ergonomics).
+        const previewRow = sqlite.prepare(`
+            SELECT
+                n.id AS messageId,
+                json_extract(n.data, '$.properties.subject') AS subject,
+                json_extract(n.data, '$.properties.sentAt') AS sentAt,
+                (
+                    SELECT se.target FROM Edges se
+                    WHERE se.source = n.id AND se.type = 'SENT_BY'
+                    LIMIT 1
+                ) AS "from"
+            FROM Edges e
+            JOIN Nodes n ON n.id = e.source
+            WHERE e.type = 'SENT_TO'
+              AND (e.target = ? OR e.target = 'AGENT:*')
+              AND json_extract(n.data, '$.properties.readAt') IS NULL
+            ORDER BY json_extract(n.data, '$.properties.sentAt') DESC
+            LIMIT 1
+        `).get(me);
+
+        return {
+            unreadCount  : unreadRow?.unreadCount ?? 0,
+            latestPreview: previewRow || null
+        };
+    } catch (error) {
+        logger.warn('[MemoryService] Mailbox delta query failed (non-fatal, memory write unaffected):', error.message);
+        return null;
+    }
+}
+
 
 /**
  * @summary Service for handling adding, listing, and querying agent memories.
@@ -64,7 +142,12 @@ class MemoryService extends Base {
      * @param {String} [options.model]   The model name (e.g. 'gemini-3.1-pro').
      * @param {Number} [options.amountToolCalls] The number of tool calls executed during the turn.
      * @param {Array|String} [options.toolsUsed] Descriptions or array of tools used.
-     * @returns {Promise<{id: string, sessionId: string, timestamp: string, message: string}>}
+     * @returns {Promise<{id: string, sessionId: string, timestamp: string, message: string, mailbox: Object|null}>}
+     *     Memory-write confirmation plus a per-turn **mailbox delta signal** (`mailbox` block —
+     *     `{unreadCount, latestPreview}` when the caller has a bound AgentIdentity, `null`
+     *     otherwise). Piggybacks inbox awareness on the protocol's mandatory per-turn save,
+     *     bypassing the in-memory graph cache so cross-harness writes surface immediately —
+     *     see {@link buildMailboxDelta} and ticket #10174.
      */
     async addMemory({prompt, response, thought, sessionId, agent, model, amountToolCalls, toolsUsed}) {
         try {
@@ -122,7 +205,12 @@ class MemoryService extends Base {
                 logger.warn(`[MemoryService] Real-Time parsing skipped: DreamService decoupled. Awaiting REM sleep.`);
             }
 
-            return {id: memoryId, sessionId, timestamp, message: "Memory successfully added"};
+            // 4. Mailbox delta signal: per-turn piggyback of inbox unread-count + latest preview.
+            //    Non-fatal — buildMailboxDelta swallows its own errors and returns null on failure,
+            //    so a degraded mailbox query never blocks a successful memory write.
+            const mailbox = buildMailboxDelta();
+
+            return {id: memoryId, sessionId, timestamp, message: "Memory successfully added", mailbox};
         } catch (error) {
             logger.error('[MemoryService] Error adding memory:', error);
             return {
@@ -444,3 +532,8 @@ class MemoryService extends Base {
 }
 
 export default Neo.setupClass(MemoryService);
+// Exported for unit-test consumption — see
+// `test/playwright/unit/ai/mcp/server/memory-core/services/MailboxService.spec.mjs` (#10174
+// regression coverage). Not part of the public service surface; consumers outside the test
+// suite should call `MemoryService.addMemory` and read the `mailbox` property on the response.
+export {buildMailboxDelta};

--- a/ai/scripts/seedAgentIdentities.mjs
+++ b/ai/scripts/seedAgentIdentities.mjs
@@ -1,7 +1,20 @@
 /**
- * @summary Seeds initial AgentIdentity nodes into the Neo.mjs Memory Core Native Graph.
- * These nodes represent persistent identities for human owners and model agents.
- * 
+ * @summary Seeds initial AgentIdentity + BroadcastSentinel nodes into the Neo.mjs Memory Core Native Graph.
+ *
+ * These nodes form the **addressable identity surface** for the A2A Mailbox substrate (#10139):
+ * human owners (`@tobiu`), model-backed agents (`@neo-opus-4-7`, `@neo-gemini-3-1-pro`), and the
+ * `AGENT:*` broadcast sentinel that carries fan-out `SENT_TO` edges emitted by
+ * {@link Neo.ai.mcp.server.memory-core.services.MailboxService#addMessage} for broadcast traffic.
+ *
+ * **Why the broadcast sentinel needs to be a real graph node (#10174):** `GraphService.linkNodes`
+ * enforces an FK-style guard that culls edges whose endpoints aren't present in the Nodes table.
+ * The guard is correct defense-in-depth against hallucinated LLM-generated edges but wrongly
+ * dropped every broadcast `SENT_TO` edge while this sentinel was merely a sentinel string. Seeding
+ * it as a real node satisfies the guard without relaxing it for other edge-creation paths.
+ *
+ * Idempotent re-run is safe: existing nodes preserve their original `createdAt` via the defensive
+ * SQLite peek below; new properties merge on top.
+ *
  * Usage: node ai/scripts/seedAgentIdentities.mjs
  */
 
@@ -44,6 +57,19 @@ const IDENTITIES = [
             displayName: 'Tobias Uhlig',
             modelFamily: null,
             accountType: 'human',
+            createdAt: new Date().toISOString()
+        }
+    },
+    {
+        id: 'AGENT:*',
+        type: 'BroadcastSentinel',
+        name: 'Broadcast',
+        description: 'Mailbox broadcast sentinel. `SENT_TO` edges targeting this node fan out to all authenticated recipients per MailboxService.listMessages visibility rules. Must exist as a real graph node so GraphService.linkNodes FK-style guard does not cull broadcast edges — see #10174.',
+        properties: {
+            githubLogin: null,
+            displayName: 'Broadcast',
+            modelFamily: null,
+            accountType: 'sentinel',
             createdAt: new Date().toISOString()
         }
     }

--- a/test/playwright/unit/ai/mcp/server/memory-core/services/MailboxService.spec.mjs
+++ b/test/playwright/unit/ai/mcp/server/memory-core/services/MailboxService.spec.mjs
@@ -19,14 +19,15 @@ import RequestContextService from '../../../../../../../../ai/mcp/server/shared/
 
 test.describe('Neo.ai.mcp.server.memory-core.services.MailboxService', () => {
     test.describe.configure({ mode: 'serial' });
-    let MailboxService, GraphService, PermissionService, LifecycleService, originalAutoSave;
-    
+    let MailboxService, GraphService, PermissionService, LifecycleService, buildMailboxDelta, originalAutoSave;
+
     test.beforeAll(async () => {
         // Load dynamically due to SQLite DB mount timing
         GraphService = (await import('../../../../../../../../ai/mcp/server/memory-core/services/GraphService.mjs')).default;
         MailboxService = (await import('../../../../../../../../ai/mcp/server/memory-core/services/MailboxService.mjs')).default;
         PermissionService = (await import('../../../../../../../../ai/mcp/server/memory-core/services/PermissionService.mjs')).default;
         LifecycleService = (await import('../../../../../../../../ai/mcp/server/memory-core/services/lifecycle/SystemLifecycleService.mjs')).default;
+        buildMailboxDelta = (await import('../../../../../../../../ai/mcp/server/memory-core/services/MemoryService.mjs')).buildMailboxDelta;
 
         // Force in-memory DB config
         const aiConfig = (await import('../../../../../../../../ai/mcp/server/memory-core/config.mjs')).default;
@@ -222,7 +223,7 @@ test.describe('Neo.ai.mcp.server.memory-core.services.MailboxService', () => {
         });
     });
 
-    test('listMessages filters by threadId and from', async () => {
+    test('listMessages filters by threadId and fromIdentity', async () => {
         GraphService.upsertNode({ id: 'AGENT:charlie', type: 'AGENT', name: 'Charlie', properties: {} });
         GraphService.upsertNode({ id: 'thread-X', type: 'THREAD', name: 'Thread X', properties: {} });
         GraphService.upsertNode({ id: 'thread-Y', type: 'THREAD', name: 'Thread Y', properties: {} });
@@ -242,13 +243,15 @@ test.describe('Neo.ai.mcp.server.memory-core.services.MailboxService', () => {
         });
 
         await RequestContextService.run({ agentIdentityNodeId: 'AGENT:bob' }, async () => {
-            const filterFrom = await MailboxService.listMessages({ from: 'AGENT:alice' });
+            // `fromIdentity` rather than `from` — the latter is blocked by AuthMiddleware
+            // as a claim-of-authorship key. See #10174 and MailboxService JSDoc.
+            const filterFrom = await MailboxService.listMessages({ fromIdentity: 'AGENT:alice' });
             expect(filterFrom.messages.length).toBe(2);
 
             const filterThread = await MailboxService.listMessages({ threadId: 'thread-X' });
             expect(filterThread.messages.length).toBe(2);
-            
-            const filterBoth = await MailboxService.listMessages({ from: 'AGENT:alice', threadId: 'thread-X' });
+
+            const filterBoth = await MailboxService.listMessages({ fromIdentity: 'AGENT:alice', threadId: 'thread-X' });
             expect(filterBoth.messages.length).toBe(1);
             expect(filterBoth.messages[0].subject).toBe('A1');
         });
@@ -348,10 +351,10 @@ test.describe('Neo.ai.mcp.server.memory-core.services.MailboxService', () => {
         // Reading requires CAN_READ_INBOX_OF if the target isn't the caller
         await RequestContextService.run({ agentIdentityNodeId: 'AGENT:bob' }, async () => {
             await expect(MailboxService.listMessages({ to: 'role:librarian' })).rejects.toThrow(/Unauthorized/);
-            
+
             // Grant bob permission to read librarian role
             GraphService.linkNodes('AGENT:bob', 'role:librarian', 'CAN_READ_INBOX_OF', 1.0);
-            
+
             const res = await MailboxService.listMessages({ to: 'role:librarian' });
             expect(res.messages.length).toBe(1);
             expect(res.messages[0].to).toBe('role:librarian');
@@ -360,7 +363,7 @@ test.describe('Neo.ai.mcp.server.memory-core.services.MailboxService', () => {
 
     test('addMessage auto-emits TAGGED_CONCEPT edges via SemanticGraphExtractor', async () => {
         const SemanticGraphExtractor = (await import('../../../../../../../../ai/daemons/services/SemanticGraphExtractor.mjs')).default;
-        
+
         // Mock the extractor to resolve immediately with predefined concepts
         const originalExtract = SemanticGraphExtractor.extractMessageConcepts;
         try {
@@ -386,7 +389,7 @@ test.describe('Neo.ai.mcp.server.memory-core.services.MailboxService', () => {
             expect(edges.length).toBe(2);
             expect(edges.find(e => e.target === 'CONCEPT:mcp-integration')).toBeDefined();
             expect(edges.find(e => e.target === 'CLASS:Neo.ai.mcp.server.memory-core.services.MailboxService')).toBeDefined();
-            
+
             // Verify nodes were created and have auto_extracted provenance
             const conceptNode = GraphService.db.nodes.get('CONCEPT:mcp-integration');
             expect(conceptNode).toBeDefined();
@@ -395,6 +398,179 @@ test.describe('Neo.ai.mcp.server.memory-core.services.MailboxService', () => {
         } finally {
             SemanticGraphExtractor.extractMessageConcepts = originalExtract;
         }
+    });
+
+    // ------------------------------------------------------------------
+    // #10174 regression coverage — production-convention addressing
+    //
+    // The tests above use the `AGENT:<name>` test-fixture convention. Production seeds
+    // AgentIdentity nodes under bare `@login` (per ai/scripts/seedAgentIdentities.mjs), and
+    // `RequestContextService.getAgentIdentityNodeId()` returns that bare form. The divergence
+    // between test and production conventions hid the SENT_TO cull bug for months — the
+    // following block mirrors the REAL seed so end-to-end regressions catch it.
+    // ------------------------------------------------------------------
+    test.describe('#10174 production-convention addressing', () => {
+        test.beforeEach(async () => {
+            // Mirror the seedAgentIdentities.mjs convention + AGENT:* broadcast sentinel.
+            GraphService.upsertNode({ id: '@opus',   type: 'AgentIdentity',     name: 'Opus',      properties: {} });
+            GraphService.upsertNode({ id: '@gemini', type: 'AgentIdentity',     name: 'Gemini',    properties: {} });
+            // (`AGENT:*` already seeded by the outer beforeEach — retained because production
+            //  uses the same sentinel id and this test block validates its addressability.)
+        });
+
+        test('bare `@login` addressing persists SENT_TO edge and surfaces in inbox', async () => {
+            await RequestContextService.run({ agentIdentityNodeId: '@gemini' }, async () => {
+                await PermissionService.grantPermission({ to: '@opus', scope: 'CAN_REPLY_TO' });
+            });
+
+            let messageId;
+            await RequestContextService.run({ agentIdentityNodeId: '@opus' }, async () => {
+                const res = await MailboxService.addMessage({ to: '@gemini', subject: 'direct ping', body: 'hello' });
+                expect(res.status).toBe('sent');
+                messageId = res.messageId;
+
+                // Core #10174 assertion: SENT_TO edge MUST persist. Pre-fix, GraphService.linkNodes
+                // culled this silently because @gemini was a seeded AgentIdentity node — wait,
+                // it should have worked. Actually: this specific case was the ONE that worked
+                // pre-fix (bare `@login` IS the seeded form). The value of this test is as a
+                // baseline against which the next two tests (`AGENT:@login` + `AGENT:*`) prove
+                // the fix by not regressing what already worked.
+                const sentToEdge = GraphService.db.edges.items.find(
+                    e => e.source === messageId && e.type === 'SENT_TO'
+                );
+                expect(sentToEdge).toBeDefined();
+                expect(sentToEdge.target).toBe('@gemini');
+            });
+
+            const inbox = await RequestContextService.run({ agentIdentityNodeId: '@gemini' }, async () => {
+                return await MailboxService.listMessages({ box: 'inbox' });
+            });
+            expect(inbox.messages.length).toBe(1);
+            expect(inbox.messages[0].subject).toBe('direct ping');
+        });
+
+        test('`AGENT:@login` prefixed form normalizes to bare `@login` SENT_TO target', async () => {
+            await RequestContextService.run({ agentIdentityNodeId: '@gemini' }, async () => {
+                await PermissionService.grantPermission({ to: '@opus', scope: 'CAN_REPLY_TO' });
+            });
+
+            let messageId;
+            await RequestContextService.run({ agentIdentityNodeId: '@opus' }, async () => {
+                // The ambiguous tool-schema form — pre-fix, this was culled because the
+                // literal 'AGENT:@gemini' string isn't a seeded node. Post-fix,
+                // normalizeMailboxTarget strips the `AGENT:` prefix.
+                const res = await MailboxService.addMessage({ to: 'AGENT:@gemini', subject: 'prefixed', body: 'body' });
+                expect(res.status).toBe('sent');
+                messageId = res.messageId;
+
+                const sentToEdge = GraphService.db.edges.items.find(
+                    e => e.source === messageId && e.type === 'SENT_TO'
+                );
+                expect(sentToEdge).toBeDefined();
+                // Must be the canonical bare `@login`, NOT the raw input `AGENT:@gemini`.
+                expect(sentToEdge.target).toBe('@gemini');
+            });
+
+            // Recipient bound under bare `@gemini` sees the message via listMessages.
+            const inbox = await RequestContextService.run({ agentIdentityNodeId: '@gemini' }, async () => {
+                return await MailboxService.listMessages({ box: 'inbox' });
+            });
+            expect(inbox.messages.length).toBe(1);
+            expect(inbox.messages[0].subject).toBe('prefixed');
+        });
+
+        test('`AGENT:*` broadcast creates SENT_TO edge to the seeded sentinel and fans out', async () => {
+            let messageId;
+            await RequestContextService.run({ agentIdentityNodeId: '@opus' }, async () => {
+                const res = await MailboxService.addMessage({ to: 'AGENT:*', subject: 'broadcast', body: 'body' });
+                expect(res.status).toBe('sent');
+                messageId = res.messageId;
+
+                // Pre-fix core bug: AGENT:* wasn't a seeded node, so linkNodes culled this edge,
+                // and zero recipients saw the broadcast. Post-fix (seed script adds AGENT:* as
+                // BroadcastSentinel), the edge persists and listMessages' `=== 'AGENT:*'` filter
+                // fans it out to every authenticated inbox query.
+                const sentToEdge = GraphService.db.edges.items.find(
+                    e => e.source === messageId && e.type === 'SENT_TO'
+                );
+                expect(sentToEdge).toBeDefined();
+                expect(sentToEdge.target).toBe('AGENT:*');
+            });
+
+            // Sender sees it in outbox
+            const opusOutbox = await RequestContextService.run({ agentIdentityNodeId: '@opus' }, async () => {
+                return await MailboxService.listMessages({ box: 'outbox' });
+            });
+            expect(opusOutbox.messages.length).toBe(1);
+
+            // Every OTHER authenticated identity sees it in inbox via broadcast fan-out
+            const geminiInbox = await RequestContextService.run({ agentIdentityNodeId: '@gemini' }, async () => {
+                return await MailboxService.listMessages({ box: 'inbox' });
+            });
+            expect(geminiInbox.messages.length).toBe(1);
+            expect(geminiInbox.messages[0].subject).toBe('broadcast');
+        });
+
+        test('buildMailboxDelta counts unread and surfaces latest preview for bound identity', async () => {
+            await RequestContextService.run({ agentIdentityNodeId: '@gemini' }, async () => {
+                await PermissionService.grantPermission({ to: '@opus', scope: 'CAN_REPLY_TO' });
+            });
+
+            await RequestContextService.run({ agentIdentityNodeId: '@opus' }, async () => {
+                const first = await MailboxService.addMessage({ to: '@gemini', subject: 'one', body: '1' });
+                // Force distinct sentAt so the ORDER BY ... LIMIT 1 is deterministic.
+                GraphService.db.nodes.get(first.messageId).properties.sentAt = '2026-04-22T13:00:00.000Z';
+                // Writes reflect through to SQLite via the upsert path used by addEdge → autoSave
+                // but explicit properties updates need a direct storage push or we rely on the
+                // in-memory store matching SQLite; since the test uses `:memory:` SQLite there's
+                // no cross-process coherence to worry about.
+                const second = await MailboxService.addMessage({ to: '@gemini', subject: 'two', body: '2' });
+                GraphService.db.nodes.get(second.messageId).properties.sentAt = '2026-04-22T14:00:00.000Z';
+
+                // Persist the patched sentAt to SQLite so the SELECT json_extract(...) read
+                // matches. addMessage wrote the original sentAt; we patched the in-memory copy
+                // but still need to write that through.
+                GraphService.db.storage.db.prepare(`
+                    UPDATE Nodes SET data = ? WHERE id = ?
+                `).run(JSON.stringify(GraphService.db.nodes.get(first.messageId)),  first.messageId);
+                GraphService.db.storage.db.prepare(`
+                    UPDATE Nodes SET data = ? WHERE id = ?
+                `).run(JSON.stringify(GraphService.db.nodes.get(second.messageId)), second.messageId);
+            });
+
+            const delta = await RequestContextService.run({ agentIdentityNodeId: '@gemini' }, () => {
+                return buildMailboxDelta();
+            });
+
+            expect(delta).not.toBeNull();
+            expect(delta.unreadCount).toBe(2);
+            expect(delta.latestPreview).not.toBeNull();
+            expect(delta.latestPreview.subject).toBe('two');  // newest-first ordering
+            expect(delta.latestPreview.from).toBe('@opus');
+            expect(delta.latestPreview.messageId).toMatch(/^MESSAGE:/);
+        });
+
+        test('buildMailboxDelta returns null when identity is unbound (single-tenant fallthrough)', async () => {
+            // No agentIdentityNodeId = unbound context, the stdio single-tenant case.
+            const delta = await RequestContextService.run({}, () => {
+                return buildMailboxDelta();
+            });
+            expect(delta).toBeNull();
+        });
+
+        test('buildMailboxDelta includes broadcast messages in unread count for all recipients', async () => {
+            await RequestContextService.run({ agentIdentityNodeId: '@opus' }, async () => {
+                await MailboxService.addMessage({ to: 'AGENT:*', subject: 'hello all', body: 'broadcast body' });
+            });
+
+            // Gemini's delta counts the broadcast even though it wasn't directly addressed
+            const delta = await RequestContextService.run({ agentIdentityNodeId: '@gemini' }, () => {
+                return buildMailboxDelta();
+            });
+            expect(delta).not.toBeNull();
+            expect(delta.unreadCount).toBe(1);
+            expect(delta.latestPreview.subject).toBe('hello all');
+        });
     });
 });
 


### PR DESCRIPTION
Authored by Claude Opus 4.7 (Claude Code). Session d907e342-28fc-4eb6-8c51-355772dbfb44.

Resolves #10174

The mailbox A2A primitive never worked end-to-end since it shipped via #10147. `addMessage` returned optimistic `status: 'sent'`, the `MESSAGE` node + `SENT_BY` edge persisted, but the `SENT_TO` edge — the sole substrate `listMessages` scans to populate an inbox — was silently dropped by `GraphService.linkNodes`'s FK-style guard whenever the target was the broadcast sentinel `AGENT:*` OR the ambiguous `AGENT:@login` prefixed form documented in the tool schema. Of the three addressing modes shipped in #10147's AC, only bare `@login` ever actually functioned; the AC-satisfying tests asserted on the response payload rather than reading back through `listMessages`. This PR fixes the four components that make the primitive whole + extends `add_memory` with a per-turn inbox delta signal so agents no longer need MCP restarts to see messages written by other harness processes.

Empirically surfaced during the first attempted A2A handshake between `@neo-opus-4-7` and `@neo-gemini-3-1-pro` this session — root cause diagnosed via direct SQLite inspection after three Claude Desktop restarts failed to materialize either agent's inbox.

## Deltas from ticket

**Pivoted Fix #3 from AuthMiddleware surgery to parameter rename.** The ticket proposed removing `from` from `AuthMiddleware.IDENTITY_OVERRIDE_KEYS` to unblock `listMessages({from: X})`. During implementation I noticed the middleware's own scope note explicitly separates claim-of-authorship keys (blocked) from destination-address fields (allowed) — removing `from` would open a real spoof surface for any future tool that accepts `from` as a write-side authorship claim. The correct substrate for the fix is the read-path parameter itself: renamed to `fromIdentity` in both the tool schema and `MailboxService.listMessages`. Middleware stays strict; defense-in-depth preserved. Full ticket body still describes the approach; see \"Evolution\" section below.

## Implementation summary

| File | Change |
|---|---|
| `ai/scripts/seedAgentIdentities.mjs` | Adds `AGENT:*` as a seeded `BroadcastSentinel` node so `linkNodes`' FK guard accepts broadcast SENT_TO edges |
| `ai/mcp/server/memory-core/services/MailboxService.mjs` | New module-scope `normalizeMailboxTarget()` helper; `addMessage` canonicalizes `'AGENT:@login'` → `'@login'` before `linkNodes`; `listMessages` parameter renamed `from` → `fromIdentity` (with JSDoc explaining the AuthMiddleware rationale) |
| `ai/mcp/server/memory-core/services/MemoryService.mjs` | New `buildMailboxDelta()` helper (exported for test consumption) that bypasses the in-memory graph cache via direct SQLite `SELECT`s for cross-process correctness; `addMemory` response gains `mailbox: {unreadCount, latestPreview}|null` block; failure is non-fatal and never aborts the memory write |
| `ai/mcp/server/memory-core/openapi.yaml` | `list_messages` parameter rename reflected in tool surface; `MemoryResponse` schema extended with the `mailbox` block (nullable) and nested `latestPreview` object |
| `test/playwright/unit/ai/mcp/server/memory-core/services/MailboxService.spec.mjs` | Existing `filters by threadId and from` test updated to `fromIdentity`; new `#10174 production-convention addressing` describe block with 6 regression tests covering bare-`@login`, `AGENT:@login` normalization, `AGENT:*` broadcast fan-out, and `buildMailboxDelta` contract (bound + unbound + broadcast-in-count) |

## Test Evidence

Targeted: `npm run test-unit -- test/playwright/unit/ai/mcp/server/memory-core/services/MailboxService.spec.mjs`
Result: **16/16 passed (883ms)** — 10 pre-existing tests (one updated for the param rename) + 6 net-new regression tests.

Broader memory-core suite: 78 pass, 14 pre-existing failures unrelated to this PR. Confirmed via `git diff` — the failing tests touch files this PR doesn't modify (`ChromaManager`, `FileSystemIngestor`, `DatabaseService.backupPath`, `GraphService`, `ChromaLifecycleService`, `QueryReRanker`, `SessionSummarization`, `McpServerToolLimits`). The last one fails specifically on `manage_database`'s description being 1161 chars > 1024 cap — a pre-existing content-length violation in openapi.yaml that this PR does not touch. Worth filing as a separate chore if not already tracked.

## Post-Merge Validation

- [ ] Run `node ai/scripts/seedAgentIdentities.mjs` against the shared `.neo-ai-data/sqlite/memory-core-graph.sqlite` to materialize the `AGENT:*` sentinel in the live DB (the seed is idempotent; re-runs preserve existing `createdAt`).
- [ ] After both harness MCP servers restart: `@neo-opus-4-7` broadcasts a verification message; `@neo-gemini-3-1-pro` calls `list_messages({box: 'inbox'})` and sees the message + SENT_TO edge with target `AGENT:*` in SQLite.
- [ ] `add_memory` response contains the `mailbox` block; subsequent `list_messages` counts match `unreadCount`.

## Evolution

**Fix #3 pivot: anti-spoof unblock → parameter rename.**
Ticket body proposed removing `from` from `AuthMiddleware.IDENTITY_OVERRIDE_KEYS` as the minimal fix for the `listMessages({from: X})` rejection. While reading the middleware source I caught its explicit scope note: destination-address fields are legitimate, claim-of-authorship fields are blocked. The collision isn't with the middleware's model — it's with `listMessages`' parameter name, which happens to be a read-path filter semantically but shares a name with an authorship-claim key. Renaming the read-path param to `fromIdentity` preserves the middleware's defense-in-depth (blocks future write-side `from` abuse) while giving the filter a non-colliding name. Zero-cost for callers since tool calls are schema-driven — the new parameter name propagates automatically.

Related: sibling ticket #10176 (identity observability + Claude Desktop docs) is the non-blocking dual; parent #10139 is the mailbox A2A epic; Gemini is in parallel on #10169 (TAGGED_CONCEPT auto-emit) which is orthogonal to this SENT_TO fix and can merge in either order.