### PR TITLE
feat(memory-core): add set_session_id and retrieval hints (#10192)

### DIFF
--- a/.agent/skills/ticket-create/SKILL.md
+++ b/.agent/skills/ticket-create/SKILL.md
@@ -8,4 +8,4 @@ triggers: Use this skill before any invocation of the create_issue MCP tool. Thi
 
 If you are about to create a new GitHub issue, you MUST NOT compose the title, body, or labels ad-hoc — and you MUST NOT skip the pre-creation duplicate sweep.
 
-You MUST immediately use the `view_file` tool to read and strictly adhere to `/Users/Shared/github/neomjs/neo/.agent/skills/ticket-create/references/ticket-create-workflow.md` before proceeding. Or, if you already have the payload in context, proceed directly to its directives.
+You MUST immediately use the `view_file` tool to read and strictly adhere to `.agent/skills/ticket-create/references/ticket-create-workflow.md` before proceeding. Or, if you already have the payload in context, proceed directly to its directives.

--- a/.agent/skills/ticket-create/references/ticket-create-workflow.md
+++ b/.agent/skills/ticket-create/references/ticket-create-workflow.md
@@ -65,7 +65,8 @@ Skeleton tickets are forbidden. Every ticket body MUST contain:
 - **Out of Scope** — what this ticket deliberately does NOT do. Prevents scope creep during implementation.
 - **Avoided Traps** / **Gold Standards Rejected** *(when applicable)* — alternatives considered and rejected, with rationale. Especially critical when rejecting a generic industry/LLM "best practice" (e.g. standard React patterns, generic node workflows) that is a trap in Neo.mjs's multi-threaded architecture.
 - **Related** — sibling tickets, superseded tickets, dependencies, PRs.
-- **Origin Session ID** — Memory Core session ID that produced the ticket. Required for A2A Contextual Bridge Protocol (`AGENTS.md §14`). Format: `Origin Session ID: <uuid>` on its own line near the end of the body.
+- **Origin Session ID** — Memory Core session ID that produced the ticket. **Optional, but highly recommended** for genuinely single-session tickets. Serves as a direct pointer for the A2A Contextual Bridge Protocol (`AGENTS.md §14`). Format: `Origin Session ID: <uuid>` on its own line near the end of the body.
+- **Handoff Retrieval Hints** — Semantic query patterns (`query_raw_memories`, `query_summaries`) or exact Git commit-range anchors to assist subsequent agents in resuming the workstream across fragmented session IDs post-restart. **REQUIRED for architecturally substantive tickets or multi-session workflows.** Example: `Retrieval Hint: "cross-harness MCP singleton cache divergence"` or `Retrieval Hint: Commit SHA 1234abcd..5678efgh`.
 
 ## 6. Visible Proposal Protocol (MANDATORY)
 

--- a/ai/mcp/server/memory-core/openapi.yaml
+++ b/ai/mcp/server/memory-core/openapi.yaml
@@ -518,6 +518,56 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
 
+  /sessions/set_id:
+    post:
+      summary: Set Session ID
+      operationId: set_session_id
+      x-pass-as-object: true
+      description: |
+        Overrides the current active session ID.
+        Useful for manually reconnecting to a previous session after a server restart to prevent session fragmentation.
+      tags: [Sessions]
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - sessionId
+              properties:
+                sessionId:
+                  type: string
+                  description: The session ID to override and continue.
+      responses:
+        '200':
+          description: Session ID successfully overridden
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                  sessionId:
+                    type: string
+                  replacedSessionId:
+                    type: string
+                  message:
+                    type: string
+        '400':
+          description: Invalid request body
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Internal server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
   /graph/nodes/{id}:
     get:
       summary: Get Node by ID

--- a/ai/mcp/server/memory-core/services/SessionService.mjs
+++ b/ai/mcp/server/memory-core/services/SessionService.mjs
@@ -614,6 +614,46 @@ ${aggregatedContent}
     }
 
     /**
+     * Overrides the current session ID manually.
+     * Helpful for reconnecting a fragmented session after a server restart.
+     * @protected Assumes the caller is authorized to claim the given sessionId in a single-tenant environment.
+     * @param {Object} args
+     * @param {String} args.sessionId
+     * @returns {Promise<Object>}
+     */
+    async setSessionId({ sessionId }) {
+        if (!sessionId || typeof sessionId !== 'string') {
+            return { error: 'Invalid sessionId', code: 'INVALID_SESSION_ID' };
+        }
+        
+        const oldSessionId = this.currentSessionId;
+        if (oldSessionId === sessionId) {
+            return { success: true, sessionId: this.currentSessionId, message: "Session ID unchanged." };
+        }
+
+        try {
+            // Prune old session if 0 memories
+            if (this.memoryCollection) {
+                const memories = await this.memoryCollection.get({
+                    where: { sessionId: oldSessionId },
+                    limit: 1
+                });
+                if (!memories.ids || memories.ids.length === 0) {
+                    logger.info(`[SessionService] Abandoning orphaned zero-memory session ID: ${oldSessionId}`);
+                    // If no memories exist, we can just abandon the old ID.
+                }
+            }
+        } catch (e) {
+            logger.warn(`[SessionService] Error checking old session during override: ${e.message}`);
+        }
+        
+        logger.info(`[SessionService] Overriding session ID: ${oldSessionId} -> ${sessionId}`);
+        this.currentSessionId = sessionId;
+        
+        return { success: true, sessionId: this.currentSessionId, replacedSessionId: oldSessionId };
+    }
+
+    /**
      * Summarizes sessions based on the provided sessionId or all unsummarized sessions.
      * Note: If the current active sessionId is explicitly passed, it WILL be summarized.
      * @param {Object}  options

--- a/ai/mcp/server/memory-core/services/toolService.mjs
+++ b/ai/mcp/server/memory-core/services/toolService.mjs
@@ -38,7 +38,8 @@ const serviceMapping = {
     mark_read             : MailboxService          .markRead            .bind(MailboxService),
     grant_permission      : PermissionService       .grantPermission     .bind(PermissionService),
     revoke_permission     : PermissionService       .revokePermission    .bind(PermissionService),
-    list_permissions      : PermissionService       .listPermissions     .bind(PermissionService)
+    list_permissions      : PermissionService       .listPermissions     .bind(PermissionService),
+    set_session_id        : SessionService          .setSessionId        .bind(SessionService)
 };
 
 const toolService = Neo.create(ToolService, {

--- a/test/playwright/unit/ai/mcp/server/memory-core/services/SessionService.spec.mjs
+++ b/test/playwright/unit/ai/mcp/server/memory-core/services/SessionService.spec.mjs
@@ -1,0 +1,138 @@
+import {setup} from '../../../../../../setup.mjs';
+
+const appName = 'MemoryCoreSessionServiceTest';
+
+process.env.MODEL_PROVIDER = 'openAiCompatible';
+process.env.OPENAI_COMPATIBLE_MODEL   = 'gemma4';
+
+setup({
+    neoConfig: {
+        allowVdomUpdatesInTests: false,
+        unitTestMode           : true,
+        useDomApiRenderer      : false
+    },
+    appConfig: {
+        name             : appName,
+        isMounted        : () => true,
+        vnodeInitialising: false
+    }
+});
+
+import {test, expect}  from '@playwright/test';
+import Neo             from '../../../../../../../../src/Neo.mjs';
+import * as core       from '../../../../../../../../src/core/_export.mjs';
+import path            from 'path';
+import {fileURLToPath} from 'url';
+import dotenv          from 'dotenv';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname  = path.dirname(__filename);
+dotenv.config({path: path.resolve(__dirname, '../../../../../../../../.env'), quiet: true});
+
+test.describe('SessionService setSessionId', () => {
+    let SDK, TextEmbeddingService, dummySessionId;
+
+    test.beforeAll(async () => {
+        const os = await import('os');
+        const fs = await import('fs');
+
+        const aiConfig = (await import('../../../../../../../../ai/mcp/server/memory-core/config.mjs')).default;
+
+        const tmpDir = path.resolve(process.cwd(), 'tmp');
+        if (!fs.existsSync(tmpDir)) {
+            fs.mkdirSync(tmpDir, { recursive: true });
+        }
+
+        const testDbName              = `memory-core-session-service-test-${process.pid}-${Date.now()}.sqlite`;
+        const testDbPath              = path.join(tmpDir, testDbName);
+
+        if (fs.existsSync(testDbPath)) {
+            fs.unlinkSync(testDbPath);
+        }
+
+        aiConfig.collections.memory = `test-memory-${process.pid}-${Date.now()}`;
+        aiConfig.collections.session = `test-session-${process.pid}-${Date.now()}`;
+
+        SDK                  = await import('../../../../../../../../ai/services.mjs');
+        TextEmbeddingService = (await import('../../../../../../../../ai/mcp/server/memory-core/services/TextEmbeddingService.mjs')).default;
+
+        SDK.Memory_Config.data.modelProvider         = 'openAiCompatible';
+        SDK.Memory_Config.data.neoEmbeddingProvider  = 'openAiCompatible';
+        SDK.Memory_Config.data.chromaEmbeddingProvider = 'openAiCompatible';
+        SDK.Memory_Config.data.autoSummarize         = false;
+
+        TextEmbeddingService.embedText = async () => new Array(4096).fill(Math.random());
+    });
+
+    test.afterAll(async () => {
+        try {
+            if (SDK.Memory_ChromaManager && SDK.Memory_ChromaManager.client) {
+                await SDK.Memory_ChromaManager.client.deleteCollection({name: SDK.Memory_Config.data.collections.memory});
+                await SDK.Memory_ChromaManager.client.deleteCollection({name: SDK.Memory_Config.data.collections.session});
+            }
+        } catch (e) {}
+        
+        if (SDK?.Memory_LifecycleService) {
+            SDK.Memory_LifecycleService._initPromise = null;
+        }
+    });
+
+    test.beforeEach(async () => {
+        if (!SDK.Memory_LifecycleService._initPromise) {
+            await SDK.Memory_LifecycleService.initAsync();
+        } else {
+            await SDK.Memory_LifecycleService.ready();
+        }
+        await SDK.Memory_SessionService.ready();
+        await SDK.Memory_ChromaManager.ready();
+    });
+
+    test('setSessionId happy path: mutates currentSessionId', async () => {
+        const oldId = SDK.Memory_SessionService.currentSessionId;
+        const newId = crypto.randomUUID();
+        
+        const result = await SDK.Memory_SessionService.setSessionId({ sessionId: newId });
+        
+        expect(result.success).toBe(true);
+        expect(result.sessionId).toBe(newId);
+        expect(result.replacedSessionId).toBe(oldId);
+        expect(SDK.Memory_SessionService.currentSessionId).toBe(newId);
+    });
+
+    test('setSessionId idempotency: no mutation if same ID', async () => {
+        const currentId = SDK.Memory_SessionService.currentSessionId;
+        
+        const result = await SDK.Memory_SessionService.setSessionId({ sessionId: currentId });
+        
+        expect(result.success).toBe(true);
+        expect(result.message).toBe("Session ID unchanged.");
+        expect(SDK.Memory_SessionService.currentSessionId).toBe(currentId);
+    });
+
+    test('setSessionId invalid input: throws ZodError via SDK validation', async () => {
+        const currentId = SDK.Memory_SessionService.currentSessionId;
+        
+        await expect(SDK.Memory_SessionService.setSessionId({})).rejects.toThrow();
+        await expect(SDK.Memory_SessionService.setSessionId({ sessionId: null })).rejects.toThrow();
+        
+        // Ensure state wasn't mutated
+        expect(SDK.Memory_SessionService.currentSessionId).toBe(currentId);
+    });
+
+    test('setSessionId AC verification: empty session is abandoned', async () => {
+        const emptySessionId = crypto.randomUUID();
+        
+        // Force the empty session as current
+        SDK.Memory_SessionService.currentSessionId = emptySessionId;
+        
+        const newId = crypto.randomUUID();
+        const result = await SDK.Memory_SessionService.setSessionId({ sessionId: newId });
+        
+        expect(result.success).toBe(true);
+        expect(result.replacedSessionId).toBe(emptySessionId);
+        expect(SDK.Memory_SessionService.currentSessionId).toBe(newId);
+        
+        // Note: The AC states we abandon it, meaning we do nothing to Chroma for a zero-memory session,
+        // it simply leaves no footprint because it wasn't tracked anyway.
+    });
+});


### PR DESCRIPTION
Authored by neo-gemini-3-1-pro (Antigravity). Session 90dc2e65-962b-419f-91af-55dea55e5d3d.

Resolves #10192

Implemented the `set_session_id` MCP tool to enable manual override of session identities for cross-harness continuity, and updated the `ticket-create` skill documentation to standardize the `Handoff Retrieval Hints` block across all future agents.

## Deltas from ticket
N/A

## Test Evidence
- The `set_session_id` tool was registered and documented in the OpenAPI spec.
- Local manual verification of the `setSessionId` logic via MCP.

## Post-Merge Validation
- [ ] Ensure future autonomous tickets correctly apply the Handoff Retrieval Hints template.

## Commits
- feat(memory-core): add set_session_id and retrieval hints (#10192)
