### PR TITLE
fix(mcp): resolve github-workflow sync_all path crash (#10191)

### DIFF
--- a/ai/mcp/server/github-workflow/config.template.mjs
+++ b/ai/mcp/server/github-workflow/config.template.mjs
@@ -82,6 +82,11 @@ const defaultConfig = {
          */
         discussionsDir: path.resolve(projectRoot, 'resources/content/discussions'),
         /**
+         * The path to the directory for pull requests.
+         * @type {string}
+         */
+        pullsDir: path.resolve(projectRoot, 'resources/content/pulls'),
+        /**
          * The path to the synchronization metadata file.
          * @type {string}
          */

--- a/ai/mcp/server/github-workflow/services/sync/MetadataManager.mjs
+++ b/ai/mcp/server/github-workflow/services/sync/MetadataManager.mjs
@@ -47,7 +47,8 @@ class MetadataManager extends Base {
                     lastSync: null,
                     issues  : {},
                     releases: {},
-                    pulls   : {}
+                    pulls   : {},
+                    discussions: {}
                 };
             } else {
                 throw error;
@@ -69,7 +70,8 @@ class MetadataManager extends Base {
             pushFailures       : metadata.pushFailures || [],
             issues             : {},
             releases           : {},
-            pulls              : {}
+            pulls              : {},
+            discussions        : {}
         };
 
         // Prune issues
@@ -104,6 +106,14 @@ class MetadataManager extends Base {
                 path       : value.path,
                 closedAt   : value.closedAt,
                 updatedAt  : value.updatedAt,
+                contentHash: value.contentHash
+            };
+        }
+
+        // Prune discussions
+        for (const [key, value] of Object.entries(metadata.discussions || {})) {
+            prunedMetadata.discussions[key] = {
+                number     : value.number,
                 contentHash: value.contentHash
             };
         }


### PR DESCRIPTION
Authored by Gemini 3.1 Pro (Antigravity). Session 90dc2e65-962b-419f-91af-55dea55e5d3d.

Resolves #10191

Fixed the `sync_all` path-resolution crash during pull request synchronization. Added the missing `pullsDir` path mapping to the configuration template and updated `MetadataManager` to correctly prune and persist `discussions` metadata, ensuring cache consistency.

## Test Evidence
Manually executed `SyncService.runFullSync()` via a custom script. Verified that the crash no longer occurs, and that 210 pull requests and 21 discussions were synchronized and persisted cleanly.