### PR TITLE
fix(mcp): extend reachable-counterparty to broadcast recipients (#10179)

### DIFF
--- a/ai/mcp/server/memory-core/services/MailboxService.mjs
+++ b/ai/mcp/server/memory-core/services/MailboxService.mjs
@@ -107,10 +107,17 @@ class MailboxService extends Base {
         if (!isRoleOrHuman && to !== 'AGENT:*' && to !== sentBy) {
             let canReply = PermissionService.hasPermission(sentBy, to, 'CAN_REPLY_TO');
 
-            // Reachable counterparty logic: if they ever sent us a message, we can reply
+            // Reachable Counterparty trust lift: if `to` ever sent a message that reached the
+            // caller — either directly (SENT_TO → sentBy) or via broadcast (SENT_TO → AGENT:*) —
+            // an implicit trust chain permits DM without an explicit CAN_REPLY_TO grant.
+            // Broadcast inclusion closes #10179: pre-fix the iteration only matched direct
+            // SENT_TO targets, breaking the first-message bootstrap pattern where Agent A
+            // broadcasts and Agent B wants to DM-reply. Trade-off: any broadcaster becomes
+            // DM-reachable by every authenticated recipient; rate-limit mitigation is deferred
+            // until the spam surface materializes empirically at swarm scale.
             if (!canReply) {
                 for (const edge of GraphService.db.edges.items) {
-                    if (edge.type === 'SENT_TO' && edge.target === sentBy) {
+                    if (edge.type === 'SENT_TO' && (edge.target === sentBy || edge.target === 'AGENT:*')) {
                         let priorSender = null;
                         for (const srcEdge of GraphService.db.edges.items) {
                             if (srcEdge.source === edge.source && srcEdge.type === 'SENT_BY') {

--- a/learn/agentos/tooling/MemoryCoreMcpAuth.md
+++ b/learn/agentos/tooling/MemoryCoreMcpAuth.md
@@ -236,7 +236,7 @@ The Mailbox A2A service natively integrates with the `PermissionService` to enfo
 ### Sending Messages (`addMessage`)
 - To send a direct message, the sender MUST have the `CAN_REPLY_TO` permission for the target recipient.
 - **Role & Human Addressing:** Sending to roles (`to: 'role:librarian'`) or human operators (`to: 'human:tobiu'`) is intentionally write-permissive and bypasses the `CAN_REPLY_TO` audit. Note: The `human:<login>` vs `@<login>` separation is temporary until human identity routing is fully unified.
-- **Reachable Counterparty Exception:** If the target recipient has *previously sent a message* to the sender, the system infers an implicit trust chain, and the sender is allowed to reply without an explicit `CAN_REPLY_TO` edge.
+- **Reachable Counterparty Exception:** If the target recipient has *previously sent a message that reached the sender* — either directly (`SENT_TO → sender`) OR via broadcast (`SENT_TO → AGENT:*`) — the system infers an implicit trust chain, and the sender is allowed to reply without an explicit `CAN_REPLY_TO` edge. Broadcast-receipt inclusion is intentional per #10179: broadcasts are semantically "messages that reached you" and must support the first-message bootstrap pattern where agents meet each other for the first time via broadcast. Trade-off: any broadcaster becomes DM-reachable by every authenticated recipient; a rate-limit mitigation is deferred until the spam surface materializes empirically at swarm scale.
 - Broadcast messages (`to: 'AGENT:*'`) are always permitted.
 
 ### Reading Messages (`listMessages` & `getMessage`)

--- a/test/playwright/unit/ai/mcp/server/memory-core/services/MailboxService.spec.mjs
+++ b/test/playwright/unit/ai/mcp/server/memory-core/services/MailboxService.spec.mjs
@@ -326,6 +326,40 @@ test.describe('Neo.ai.mcp.server.memory-core.services.MailboxService', () => {
         });
     });
 
+    test('#10179 broadcast recipient can DM-reply to broadcaster without explicit grant', async () => {
+        // Bob broadcasts (always-permitted — broadcast bypasses the CAN_REPLY_TO gate).
+        await RequestContextService.run({ agentIdentityNodeId: 'AGENT:bob' }, async () => {
+            await MailboxService.addMessage({ to: 'AGENT:*', subject: 'ping', body: 'body' });
+        });
+
+        // Alice — a broadcast recipient without explicit CAN_REPLY_TO — DM-replies to Bob.
+        // Pre-fix, this was rejected with Unauthorized because the reachable-counterparty
+        // iteration only matched SENT_TO edges whose target equaled the caller directly,
+        // never the AGENT:* sentinel. Replicates the empirical 2026-04-22 Opus↔Gemini
+        // handshake failure documented on PR #10177.
+        await RequestContextService.run({ agentIdentityNodeId: 'AGENT:alice' }, async () => {
+            const res = await MailboxService.addMessage({ to: 'AGENT:bob', subject: 'Re: ping', body: 'body' });
+            expect(res.status).toBe('sent');
+        });
+    });
+
+    test('#10179 unrelated broadcast does NOT grant DM access to non-broadcaster', async () => {
+        GraphService.upsertNode({ id: 'AGENT:ed', type: 'AGENT', name: 'Ed', properties: {} });
+
+        // Ed broadcasts. Alice and Bob receive it but have no other substrate signal.
+        await RequestContextService.run({ agentIdentityNodeId: 'AGENT:ed' }, async () => {
+            await MailboxService.addMessage({ to: 'AGENT:*', subject: 'from ed', body: 'body' });
+        });
+
+        // Alice tries to DM Bob — must still be rejected. Ed's broadcast grants DM access
+        // *to Ed* for every authenticated recipient (per #10179 trust lift), but does not
+        // transitively grant Alice reply-access to unrelated third parties. Validates the
+        // guard's core invariant survives the broadcast-receipt extension.
+        await RequestContextService.run({ agentIdentityNodeId: 'AGENT:alice' }, async () => {
+            await expect(MailboxService.addMessage({ to: 'AGENT:bob', subject: 'Hi', body: 'body' })).rejects.toThrow(/Unauthorized/);
+        });
+    });
+
     test('Role-based addressing dispatch modes', async () => {
         GraphService.upsertNode({ id: 'role:librarian', type: 'ROLE', name: 'Librarian', properties: {} });
         GraphService.upsertNode({ id: 'human:tobiu', type: 'HUMAN', name: 'Tobias', properties: {} });


### PR DESCRIPTION
Resolves #10179

Authored by Claude Opus 4.7 (Claude Code). Session `2581f466-d3ac-4a4a-a50e-5184b03ccca1`.

## Outcome

`MailboxService.addMessage`'s reachable-counterparty iteration now matches `SENT_TO → AGENT:*` in addition to `SENT_TO → sentBy`. Broadcast recipients gain DM-reply access to the broadcaster without an explicit `CAN_REPLY_TO` grant, closing the first-message bootstrap gap empirically surfaced during the 2026-04-22 Opus↔Gemini handshake (documented on PR #10177).

The trust lift is intentionally narrow: only the broadcaster becomes DM-reachable by recipients — broadcasts do NOT transitively grant DM access to third parties. The accepted trade-off (any broadcaster becomes DM-reachable by every authenticated recipient) is documented in `MemoryCoreMcpAuth.md`; a rate-limit mitigation is deferred until the spam surface materializes empirically at swarm scale, per the ticket's Out of Scope section.

## Deltas from ticket

None. Implementation follows the recommended solution (a) from the ticket body verbatim. The four alternatives — (b) explicit grant-from-broadcaster, (c) structured `intendedRecipients` metadata, (d) reply-via-broadcast-only with documented limitation — were considered and rejected per the ticket's rationale.

## Test Evidence

```
npx playwright test -c test/playwright/playwright.config.mjs \
  test/playwright/unit/ai/mcp/server/memory-core/services/MailboxService.spec.mjs
```

Result: **20 passed (1.1s)**. Two new regressions added under `AGENT:<name>` fixture convention:

1. `#10179 broadcast recipient can DM-reply to broadcaster without explicit grant` — replicates the empirical failure case.
2. `#10179 unrelated broadcast does NOT grant DM access to non-broadcaster` — isolates the invariant: broadcast-receipt grants DM-to-broadcaster, not transitive DM access.

Existing `Reachable Counterparty exception permits replies without explicit grant` + all `#10174 production-convention addressing` coverage continues to pass unchanged (no regression surface).

## Post-Merge Validation

- [ ] With Claude Desktop + Claude Code + Antigravity simultaneously connected (blocked on #10190 landing + `AGENT:*` sentinel seeded), verify: `@neo-opus-4-7` broadcasts → `@neo-gemini-3-1-pro` replies directly via `add_message({to: 'AGENT:@neo-opus-4-7', ...})` without manual SQLite `CAN_REPLY_TO` insertion. This closes the empirical loop from the 2026-04-22 session where Gemini had to insert the edge manually.

## Cross-Family Review

Per `pull-request-workflow §6.1`, requesting cross-family review from `@neo-gemini-3-1-pro`. Gemini is the reviewer who empirically surfaced this bug on PR #10177, so cross-family review here also validates that the prescription matches her diagnosis.

## Related

- Parent epic: #10139 Mailbox A2A primitive
- Coordinates with: #10190 (Gemini — shared caching substrate; independent critical path, this PR advances the epic in parallel)
- Surfaced by: #10177 (mailbox healthcheck preview; Gemini's footnote flagged the guard-direction issue)
- Builds on: #10174 (sentinel + linkNodes FK discipline that made `AGENT:*` a first-class node)