### PR TITLE
fix(ai): harden Database cache coherence natively and prevent multi-worker lock conflicts (#10190)

### DIFF
--- a/ai/graph/Database.mjs
+++ b/ai/graph/Database.mjs
@@ -75,7 +75,7 @@ class Database extends Base {
      * @see Neo.ai.graph.storage.SQLite#getDeltaLog
      */
     syncCache() {
-        if (!this.storage || !this.lastSyncId) {
+        if (!this.storage) {
             return;
         }
 
@@ -278,7 +278,9 @@ class Database extends Base {
             me.autoSave               = wasAutoSave;
             me.isExecutingTransaction = wasTransacting;
 
-            me.vicinityLoadedNodes.add(nodeId);
+            if (vicinity.nodes.length > 0 || vicinity.edges.length > 0) {
+                me.vicinityLoadedNodes.add(nodeId);
+            }
         }
 
         // 3. Increment LRU Matrix bounds tracking footprint usage cleanly natively

--- a/test/playwright/unit/ai/graph/Database.spec.mjs
+++ b/test/playwright/unit/ai/graph/Database.spec.mjs
@@ -30,10 +30,11 @@ test.describe('Neo.ai.graph.Database', () => {
     if (!fs.existsSync(tmpDir)) {
         fs.mkdirSync(tmpDir, { recursive: true });
     }
-    const dbPath = path.join(tmpDir, 'neo-graph-test.db');
+    let dbPath;
 
     test.beforeEach(async () => {
         testRun++;
+        dbPath = path.join(tmpDir, `neo-graph-test-${Date.now()}-${Math.random().toString(36).substring(7)}.db`);
         db = Neo.create(Database, {
             id: 'my-graph-db-' + testRun
         });
@@ -42,6 +43,11 @@ test.describe('Neo.ai.graph.Database', () => {
     test.afterEach(() => {
         db?.destroy();
         db = null;
+        if (fs.existsSync(dbPath)) {
+            try { fs.unlinkSync(dbPath); } catch (e) {}
+            try { fs.unlinkSync(dbPath + '-wal'); } catch (e) {}
+            try { fs.unlinkSync(dbPath + '-shm'); } catch (e) {}
+        }
     });
 
     test('should add and retrieve a node correctly', async () => {
@@ -242,7 +248,55 @@ test.describe('Neo.ai.graph.Database', () => {
         expect(dbSecondary.nodes.has('branch')).toBe(false);
         expect(dbSecondary.nodes.getCount()).toBe(1);
 
+        // Verify Secondary sees additions by Primary
+        dbPrimary.addNode({ id: 'new-branch' });
+        // The node insertion will trigger a delta log for 'new-branch', which invalidates 'new-branch'.
+        // Let's verify B sees the new node if it tries to load its vicinity.
+        dbSecondary.getAdjacentNodes('new-branch');
+        expect(dbSecondary.nodes.has('new-branch')).toBe(true);
+
         dbPrimary.destroy();
         dbSecondary.destroy();
+    });
+
+    test('should replay GraphLog mutations even on fresh boot when lastSyncId is 0 (Bug A)', async () => {
+        if (fs.existsSync(dbPath)) fs.unlinkSync(dbPath);
+        
+        let storageFresh = Neo.create(SQLite, { dbPath });
+        await storageFresh.initAsync();
+        let dbFresh = Neo.create(Database, { id: 'cache-fresh', storage: storageFresh });
+        await storageFresh.load(); // DB empty -> lastSyncId = 0
+        
+        expect(dbFresh.lastSyncId).toBe(0);
+
+        let storageOther = Neo.create(SQLite, { dbPath });
+        await storageOther.initAsync();
+        let dbOther = Neo.create(Database, { id: 'cache-other', storage: storageOther });
+        await storageOther.load();
+        
+        dbOther.addNode({ id: 'race-node' });
+        
+        // With Bug A fix, syncCache() processes the delta and lastSyncId advances
+        dbFresh.syncCache();
+        expect(dbFresh.lastSyncId).toBeGreaterThan(0);
+        
+        dbFresh.destroy();
+        dbOther.destroy();
+    });
+
+    test('should not mark vicinityLoadedNodes if lazy load returns empty (Bug B)', async () => {
+        if (fs.existsSync(dbPath)) fs.unlinkSync(dbPath);
+        
+        let storage = Neo.create(SQLite, { dbPath });
+        await storage.initAsync();
+        let db = Neo.create(Database, { id: 'bug-b', storage });
+        await storage.load();
+
+        db.getAdjacentNodes('ghost-node');
+
+        // Should NOT be marked loaded since vicinity was empty
+        expect(db.vicinityLoadedNodes.has('ghost-node')).toBe(false);
+
+        db.destroy();
     });
 });


### PR DESCRIPTION
Authored by Gemini 3.1 Pro (Antigravity). Session e068b094-fcae-436a-a9ab-c513246f7f71.

Resolves #10190

Hardened the `Database` Native Edge Graph cache coherence logic to remove multi-process divergence vulnerabilities. Implemented ADR 0001 prescriptions by stripping the `lastSyncId` early-return guard to resolve fresh-boot race conditions, and corrected the `vicinityLoadedNodes` marking bug to prevent caching of empty vicinity lookups natively.

## Deltas from ticket (if any)
Discovered that executing the Database tests in parallel using the Playwright runner caused severe SQLite disk I/O lock conflicts due to shared `dbPath` references. Implemented a unique, dynamic SQLite file generator (`Date.now()` + UUID string) per test run in `Database.spec.mjs` to ensure total isolation and prevent teardown pollution.

## Test Evidence
- Executed `npm run test-unit -- test/playwright/unit/ai/graph/Database.spec.mjs` natively.
- Re-run successfully verified 10 tests across 9 parallel workers, proving parallel DB isolation works.
- Executed `npm run test-unit -- test/playwright/unit/ai/mcp/server/memory-core/services/MailboxService.spec.mjs` natively.
- Validated that the Mailbox service continues to function flawlessly over the coherence-hardened `Database` engine.

## Post-Merge Validation
- [ ] Observe multi-agent live handshakes under high contention.
- [ ] Once substrate stability is verified via restart cycles, strip out the temporary `#10185` retry loops and `#10182` self-heal band-aids in a follow-up cleanup PR.

## Commits
- c381d0580 — fix(ai): harden Database cache coherence natively and prevent multi-worker lock conflicts (#10190)
