### PR TITLE
feat(ai): unify .neo-ai-data across worktrees via bootstrap symlink (#10224)

### DIFF
--- a/AGENTS_STARTUP.md
+++ b/AGENTS_STARTUP.md
@@ -74,12 +74,19 @@ Error [ERR_MODULE_NOT_FOUND]: Cannot find module '.../ai/mcp/server/github-workf
 **Before running any SDK-consuming script or `test-unit` command in a worktree, execute:**
 
 ```bash
-node ai/scripts/bootstrapWorktree.mjs
+node ai/scripts/bootstrapWorktree.mjs              # copy configs only
+node ai/scripts/bootstrapWorktree.mjs --link-data  # ALSO unify .neo-ai-data/ (recommended)
 ```
 
-It copies the four `config.mjs` files from the main checkout (resolved via `git worktree list --porcelain`). Idempotent; no-op from the main checkout.
+It copies the four `config.mjs` files from the main checkout (resolved via `git worktree list --porcelain`) and — with `--link-data` — symlinks the worktree's `.neo-ai-data/` to the main checkout's. Idempotent; no-op from the main checkout.
 
-**Do NOT use symlinks** as an alternative — they break Playwright specs under `unitTestMode` with `Namespace collision in unitTestMode for Neo.core.Base`. Node resolves relative imports inside symlinked modules against the canonical (target) path, which points at the main checkout's `src/core/Base.mjs`, and the worktree-local `Base.mjs` collides with it at setupClass time. Copies have their own canonical path inside the worktree and resolve correctly.
+**Why `--link-data` matters (per #10224):** without it, each worktree gets its own empty `.neo-ai-data/sqlite/memory-core-graph.sqlite`, which means AgentIdentity nodes seeded in the main checkout are invisible to the worktree's MCP server. `bindAgentIdentity('neo-opus-4-7')` returns null, the mailbox throws `"no agent identity context bound"`, and A2A handshakes silently fail — the #10184 symptom from a different root cause than cache coherence. The symlink unifies the Memory Core substrate (SQLite + Chroma + concepts + backups) so ADR 0001's "one SQLite file shared across N processes" assumption holds across worktrees.
+
+**Symlink discipline — code vs data:**
+- **Source code** (`src/core/Base.mjs`, `ai/mcp/server/*/config.mjs`): **do NOT symlink.** Node's ESM resolver walks to the canonical (target) path, and `Neo.setupClass` sees the same namespace registered from two different file paths → `Namespace collision in unitTestMode`. Config files MUST be real copies.
+- **Data directories** (`.neo-ai-data/`): **symlink is safe and recommended.** Pure data with zero ESM imports — `better-sqlite3` opens by path, `path.resolve` traverses symlinks transparently. Use `--link-data` as the default.
+
+**`--force` flag:** use only if the worktree accumulated unique writes to `.neo-ai-data/` before unification was opted-in. Clobbers the local directory and creates the symlink.
 
 ### Step 6: Check for Memory Core
 

--- a/ai/scripts/bootstrapWorktree.mjs
+++ b/ai/scripts/bootstrapWorktree.mjs
@@ -1,9 +1,9 @@
 /**
  * @summary Copies gitignored `ai/mcp/server/<name>/config.mjs` files from the main git
- * checkout into the current git worktree so SDK-consuming scripts (`ai/services.mjs`)
- * can run.
+ * checkout into the current git worktree, and optionally symlinks the `.neo-ai-data/`
+ * data directory so Memory Core substrate is unified across worktree MCP server processes.
  *
- * **Background:** `ai/mcp/server/{github-workflow,knowledge-base,memory-core,neural-link}/config.mjs`
+ * **Background (config copy):** `ai/mcp/server/{github-workflow,knowledge-base,memory-core,neural-link}/config.mjs`
  * are gitignored (they are copy-from-template files for local overrides). Fresh git worktrees
  * under `.claude/worktrees/<name>/` therefore cannot run any script that imports
  * `ai/services.mjs`:
@@ -12,23 +12,41 @@
  * Error [ERR_MODULE_NOT_FOUND]: Cannot find module '.../ai/mcp/server/github-workflow/config.mjs'
  * ```
  *
- * **Do NOT use symlinks** as a workaround — Node resolves relative imports inside a
- * symlinked module against the real (canonical) path of the target, which points at the
- * main checkout's `src/core/Base.mjs`. When the worktree-local `src/core/Base.mjs` ALSO
- * gets imported (e.g. by a Playwright spec), `Neo.setupClass` sees the same namespace
- * registered from two different file paths and throws `Namespace collision in unitTestMode`.
- * Copies have their own canonical path inside the worktree and resolve correctly.
+ * **Symlinks: code vs data (critical distinction).**
+ *
+ * **Do NOT symlink SOURCE CODE** (`src/core/Base.mjs`, `config.mjs`, any ESM-imported
+ * module) — Node's ESM resolver walks to the canonical (real) path of a symlinked module.
+ * When the worktree-local `src/core/Base.mjs` ALSO gets imported (e.g. by a Playwright
+ * spec), `Neo.setupClass` sees the same namespace registered from two different file
+ * paths and throws `Namespace collision in unitTestMode`. For code, config files MUST be
+ * real copies with their own canonical path inside the worktree.
+ *
+ * **Symlinking DATA DIRECTORIES is safe and recommended.** `.neo-ai-data/` contains SQLite
+ * DB files (Memory Core graph), Chroma vectors, JSONL backups, concept CSVs — pure data
+ * with zero ESM import chains. `better-sqlite3` opens files by path, and `path.resolve`
+ * traverses symlinks transparently without canonical-path side effects. Symlinking
+ * `.neo-ai-data/` unifies the Memory Core substrate so AgentIdentity nodes seeded once
+ * are visible to every worktree's MCP server, and A2A mailbox handoffs span harnesses.
+ * This automates the tactical convention codified in ticket #10176 and closes #10224.
+ * See {@link symlinkDataDir} for the implementation.
  *
  * **Usage:**
  * ```
- * node ai/scripts/bootstrapWorktree.mjs
+ * node ai/scripts/bootstrapWorktree.mjs              # copy configs only
+ * node ai/scripts/bootstrapWorktree.mjs --link-data  # copy configs + symlink .neo-ai-data/
+ * node ai/scripts/bootstrapWorktree.mjs --link-data --force
+ *                                                    # clobber existing worktree-local
+ *                                                    # .neo-ai-data/ (data-loss guard
+ *                                                    # opt-in; gitignored + session-scoped)
  * ```
  *
- * Idempotent: files that already exist are skipped. Refuses to run from the main checkout
- * (no-op). Resolves the main checkout via `git worktree list --porcelain` — its first
- * entry is always the primary working tree.
+ * Idempotent: files that already exist are skipped; an existing symlink at `.neo-ai-data/`
+ * short-circuits to `'already-linked'`. Refuses to run from the main checkout (no-op).
+ * Resolves the main checkout via `git worktree list --porcelain` — its first entry is
+ * always the primary working tree.
  *
  * @see https://github.com/neomjs/neo/issues/10095
+ * @see https://github.com/neomjs/neo/issues/10224
  */
 import {execFile}       from 'child_process';
 import fs               from 'fs/promises';
@@ -116,6 +134,65 @@ async function exists(p) {
     }
 }
 
+/**
+ * @summary Creates a worktree→main-checkout symlink for a data directory (default:
+ * `.neo-ai-data/`), unifying the Memory Core substrate across concurrent worktree MCP
+ * server processes.
+ *
+ * Distinct from the "do NOT symlink source code" caveat at the file head — that warning
+ * applies exclusively to ESM-imported modules, where Node's resolver walks to the
+ * canonical path and causes `Namespace collision in unitTestMode`. Data directories
+ * carry no such semantic: `better-sqlite3` opens by path, Chroma dumps read/write through
+ * `fs`, and `path.resolve` transparently traverses symlinks without canonical-path side
+ * effects. Symlinking `.neo-ai-data/` closes the #10224 data-isolation split by unifying
+ * the substrate ADR 0001 §1 assumes exists (one SQLite file shared across N processes).
+ *
+ * Idempotent by design: `'already-linked'` short-circuits on re-invocation over an
+ * existing symlink. Refuses to clobber a real directory without `force: true` — a
+ * data-loss guard protecting against cases where a worktree accumulated unique writes
+ * before unification was opted-in.
+ *
+ * @param {object}  options
+ * @param {string}  options.mainCheckout Absolute path to the primary git checkout.
+ * @param {string}  options.projectRoot  Absolute path to the worktree root to link from.
+ * @param {string}  [options.dir='.neo-ai-data'] Directory name to link; relative to both roots.
+ * @param {boolean} [options.force=false] If true, overwrite an existing non-symlink dir at dst.
+ * @param {Function} [options.log=console.log] Logger fn for action diagnostics.
+ * @returns {Promise<'main-checkout'|'already-linked'|'linked'>} Action taken.
+ * @throws {Error} When dst is a non-symlink directory and `force` is false.
+ */
+export async function symlinkDataDir({mainCheckout, projectRoot, dir = '.neo-ai-data', force = false, log = console.log}) {
+    if (path.resolve(projectRoot) === path.resolve(mainCheckout)) {
+        log(`symlink skip (main checkout): ${dir}`);
+        return 'main-checkout';
+    }
+
+    const src   = path.join(mainCheckout, dir);
+    const dst   = path.join(projectRoot, dir);
+    const lstat = await fs.lstat(dst).catch(() => null);
+
+    if (lstat?.isSymbolicLink()) {
+        log(`symlink skip (already linked): ${dir}`);
+        return 'already-linked';
+    }
+
+    if (lstat?.isDirectory()) {
+        if (!force) {
+            throw new Error(
+                `Refusing to replace non-symlink ${dst}; pass force=true (CLI --force) to opt in. ` +
+                `This directory contains local data that would be lost.`
+            );
+        }
+        log(`symlink clobber (force=true): removing ${dir}`);
+        await fs.rm(dst, {recursive: true, force: true});
+    }
+
+    await fs.mkdir(path.dirname(dst), {recursive: true});
+    await fs.symlink(src, dst, 'dir');
+    log(`symlinked: ${dir} → ${src}`);
+    return 'linked';
+}
+
 // -------------------------------------------------------------------------------------
 // CLI entry point. Runs only when invoked directly (node ai/scripts/bootstrapWorktree.mjs)
 // and not when imported by a test spec.
@@ -128,6 +205,10 @@ if (isMain) {
     const __dirname   = path.dirname(__filename);
     const projectRoot = path.resolve(__dirname, '..', '..'); // ai/scripts/ → ai/ → root
 
+    const args     = new Set(process.argv.slice(2));
+    const linkData = args.has('--link-data');
+    const force    = args.has('--force');
+
     try {
         const mainCheckout = await resolveMainCheckout(projectRoot);
         if (!mainCheckout) {
@@ -138,6 +219,11 @@ if (isMain) {
         const result = await bootstrapWorktree({mainCheckout, projectRoot});
         const total  = result.copied.length + result.skipped.length + result.missing.length;
         console.log(`\n✓ Bootstrap complete: ${result.copied.length} copied, ${result.skipped.length} skipped, ${result.missing.length} missing (${total} total)`);
+
+        if (linkData) {
+            const symlinkResult = await symlinkDataDir({mainCheckout, projectRoot, force});
+            console.log(`✓ Data symlink: ${symlinkResult}`);
+        }
     } catch (e) {
         console.error('Bootstrap failed:', e.message);
         process.exit(1);

--- a/test/playwright/unit/ai/scripts/bootstrapWorktree.spec.mjs
+++ b/test/playwright/unit/ai/scripts/bootstrapWorktree.spec.mjs
@@ -30,6 +30,7 @@ import path            from 'path';
  */
 test.describe('ai/scripts/bootstrapWorktree', () => {
     let bootstrapWorktree;
+    let symlinkDataDir;
     let BOOTSTRAP_CONFIGS;
     let fakeMainCheckout;
     let fakeWorktree;
@@ -42,8 +43,9 @@ test.describe('ai/scripts/bootstrapWorktree', () => {
     ];
 
     test.beforeAll(async () => {
-        const mod        = await import('../../../../../ai/scripts/bootstrapWorktree.mjs');
+        const mod         = await import('../../../../../ai/scripts/bootstrapWorktree.mjs');
         bootstrapWorktree = mod.bootstrapWorktree;
+        symlinkDataDir    = mod.symlinkDataDir;
         BOOTSTRAP_CONFIGS = mod.BOOTSTRAP_CONFIGS;
     });
 
@@ -140,5 +142,108 @@ test.describe('ai/scripts/bootstrapWorktree', () => {
 
         expect(result.missing).toEqual([removed]);
         expect(result.copied).toEqual(fixtureConfigs.filter(c => c !== removed));
+    });
+
+    // --------------------------------------------------------------------------------
+    // #10224 symlinkDataDir — unifies .neo-ai-data across worktree+main checkouts.
+    //
+    // These tests use a canary file in the main-checkout data dir to prove that the
+    // symlinked worktree path sees the same data, empirically validating the
+    // cross-process substrate unification this helper exists to enable.
+    // --------------------------------------------------------------------------------
+    test.describe('#10224 symlinkDataDir', () => {
+        const dataDir = '.neo-ai-data';
+        let mainDataDir;
+
+        test.beforeEach(async () => {
+            // Seed the main checkout's .neo-ai-data/ with a canary file so tests can
+            // prove symlink traversal actually reaches it.
+            mainDataDir = path.join(fakeMainCheckout, dataDir);
+            await fs.ensureDir(mainDataDir);
+            await fs.writeFile(path.join(mainDataDir, 'canary.txt'), 'main-checkout-canary\n', 'utf-8');
+        });
+
+        test('creates a symlink when worktree .neo-ai-data does not exist', async () => {
+            const result = await symlinkDataDir({
+                mainCheckout: fakeMainCheckout,
+                projectRoot : fakeWorktree,
+                log         : () => {}
+            });
+
+            expect(result).toBe('linked');
+
+            const dst         = path.join(fakeWorktree, dataDir);
+            const lstat       = await fs.lstat(dst);
+            expect(lstat.isSymbolicLink()).toBe(true);
+
+            // Canary reachable via the symlinked path — proves symlink traversal works.
+            const canaryViaLink = await fs.readFile(path.join(dst, 'canary.txt'), 'utf-8');
+            expect(canaryViaLink).toBe('main-checkout-canary\n');
+        });
+
+        test('is idempotent — returns already-linked when dst is already a symlink', async () => {
+            // First call creates the link.
+            await symlinkDataDir({mainCheckout: fakeMainCheckout, projectRoot: fakeWorktree, log: () => {}});
+
+            // Second call must short-circuit; no error, no re-link.
+            const result = await symlinkDataDir({
+                mainCheckout: fakeMainCheckout,
+                projectRoot : fakeWorktree,
+                log         : () => {}
+            });
+            expect(result).toBe('already-linked');
+        });
+
+        test('refuses to clobber a non-symlink directory without force', async () => {
+            // Pre-create a real directory with unique content — simulates a worktree
+            // that has accumulated data before symlink unification was opted-in.
+            const worktreeDataDir = path.join(fakeWorktree, dataDir);
+            await fs.ensureDir(worktreeDataDir);
+            await fs.writeFile(path.join(worktreeDataDir, 'local-only.txt'), 'worktree-specific\n', 'utf-8');
+
+            await expect(
+                symlinkDataDir({mainCheckout: fakeMainCheckout, projectRoot: fakeWorktree, log: () => {}})
+            ).rejects.toThrow(/Refusing to replace non-symlink/);
+
+            // Local data preserved — guard did its job.
+            const preserved = await fs.readFile(path.join(worktreeDataDir, 'local-only.txt'), 'utf-8');
+            expect(preserved).toBe('worktree-specific\n');
+        });
+
+        test('clobbers a non-symlink directory when force=true and creates the link', async () => {
+            const worktreeDataDir = path.join(fakeWorktree, dataDir);
+            await fs.ensureDir(worktreeDataDir);
+            await fs.writeFile(path.join(worktreeDataDir, 'local-only.txt'), 'worktree-specific\n', 'utf-8');
+
+            const result = await symlinkDataDir({
+                mainCheckout: fakeMainCheckout,
+                projectRoot : fakeWorktree,
+                force       : true,
+                log         : () => {}
+            });
+            expect(result).toBe('linked');
+
+            // Local dir replaced — confirm dst is now a symlink.
+            const lstat = await fs.lstat(worktreeDataDir);
+            expect(lstat.isSymbolicLink()).toBe(true);
+
+            // Canary reachable via the freshly-linked path.
+            const canary = await fs.readFile(path.join(worktreeDataDir, 'canary.txt'), 'utf-8');
+            expect(canary).toBe('main-checkout-canary\n');
+        });
+
+        test('returns main-checkout when run from the primary working tree', async () => {
+            const result = await symlinkDataDir({
+                mainCheckout: fakeMainCheckout,
+                projectRoot : fakeMainCheckout, // same path = primary working tree
+                log         : () => {}
+            });
+            expect(result).toBe('main-checkout');
+
+            // No link was created (the main checkout's own dataDir stays as a real dir).
+            const lstat = await fs.lstat(path.join(fakeMainCheckout, dataDir));
+            expect(lstat.isDirectory()).toBe(true);
+            expect(lstat.isSymbolicLink()).toBe(false);
+        });
     });
 });


### PR DESCRIPTION
Resolves #10224

Authored by Claude Opus 4.7 (Claude Code). Session `2581f466-d3ac-4a4a-a50e-5184b03ccca1`.

## Outcome

Extends `ai/scripts/bootstrapWorktree.mjs` with a `symlinkDataDir` helper that creates a worktree→main-checkout symlink for `.neo-ai-data/`, unifying the Memory Core substrate across concurrent worktree MCP server processes. New CLI flags:

- `--link-data` — opt-in: runs `symlinkDataDir` after the config copy step
- `--force` — opt-in: clobbers an existing non-symlink `.neo-ai-data/` (data-loss guard)

Closes the #10224 data-isolation split empirically surfaced in session `2581f466-d3ac-4a4a-a50e-5184b03ccca1` — worktree SQLite was 36 KB (schema-only, no AgentIdentity nodes seeded), main was 48.9 MB (populated). `bindAgentIdentity` returned null, mailbox threw "no agent identity context bound", A2A blocked — the #10184 symptom with a root cause distinct from cache coherence.

## Critical distinction: code vs data symlinks

The file-head JSDoc already warned "do NOT use symlinks" — but that warning applies exclusively to **ESM-imported source code** (`src/core/Base.mjs`, `config.mjs`), where Node's resolver walks to the canonical path and causes `Namespace collision in unitTestMode`. Data directories carry no such semantic: `better-sqlite3` opens by path, `path.resolve` traverses symlinks transparently, no canonical-path side effects. This PR carves out the distinction explicitly in JSDoc + `AGENTS_STARTUP.md §5` so future readers don't misread the warning.

## Deltas from ticket

None. Implementation follows the ticket's §Fix prescription verbatim; CLI flag set exactly as specified; data-loss guard via `--force` as specified; Anchor & Echo JSDoc on new function as specified.

## Test Evidence

```
npx playwright test -c test/playwright/playwright.config.mjs \
  test/playwright/unit/ai/scripts/bootstrapWorktree.spec.mjs
```

Result: **10 passed (615ms)**. Five new tests under a `#10224 symlinkDataDir` describe block:

1. `creates a symlink when worktree .neo-ai-data does not exist` — uses a canary file in fake-main-checkout to prove symlink traversal reaches the target
2. `is idempotent — returns already-linked when dst is already a symlink` — second invocation no-ops cleanly
3. `refuses to clobber a non-symlink directory without force` — preserves worktree-local data; rejects with clear error
4. `clobbers a non-symlink directory when force=true and creates the link` — opt-in data-loss path works; canary reachable post-clobber
5. `returns main-checkout when run from the primary working tree` — no-op guard preserves main's real `.neo-ai-data/`

Original 5 tests (config-copy paths) pass unchanged — no regression surface.

## Dogfooding plan (this session)

1. Run `node ai/scripts/bootstrapWorktree.mjs --link-data --force` from this worktree
2. Verify `.neo-ai-data/` is now a symlink pointing at main
3. Restart harness → mailbox becomes operational → empirical close-out for this session's pain

Step 1 will execute on the merged code; this PR's review doesn't block the dogfood.

## Post-Merge Validation

- [ ] Future Claude Code worktree sessions run bootstrap with `--link-data` and observe operational mailbox on first boot (no "no agent identity context bound" error)
- [ ] Consider flipping `--link-data` from opt-in to default after one session's empirical validation
- [ ] Follow-up: if Antigravity / other harnesses ever adopt worktree-style isolation, extend `symlinkDataDir` to cover their checkout conventions

## Related

- Parent epic: #10186 (MCP concurrency audit) — this removes the worktree-induced concurrency-split
- Predecessor (tactical convention): #10176 (Mailbox identity observability) — documented the symlink pattern as the current tactical convention; this PR automates it
- Adjacent substrate: ADR 0001 at `learn/agentos/decisions/0001-cross-process-cache-coherence.md` — this PR restores the "one SQLite file" assumption the ADR relies on
- Coordinates with: PR #10223 (Gemini — band-aid removals; my review requested scope split for premature #10182 removal)

## Cross-Family Review

Per `pull-request-workflow §6.1`, requesting cross-family review from `@neo-gemini-3-1-pro`. The worktree-vs-feature-branch discussion has prior precedent on both sides (session `7ee23599`, 2026-04-22) — Gemini originally proposed disabling worktrees; I pushed back with the symlink framing; she accepted. This PR ships the architectural conclusion of that discussion.