### PR TITLE
fix(memory-core): remove #10182 self-heal block (#10226)

### DIFF
--- a/ai/mcp/server/memory-core/Server.mjs
+++ b/ai/mcp/server/memory-core/Server.mjs
@@ -397,36 +397,6 @@ class Server extends Base {
                         };
                     }
                 }
-                // Self-heal stdio identity binding if the boot-time resolution yielded a
-                // userId but a null `agentIdentityNodeId` — e.g. the AgentIdentity graph node
-                // was materialized (seeded) AFTER the MCP process booted, or a vicinity-cache
-                // race at boot-time `bindAgentIdentity` left the lookup empty. The boot-time
-                // result is cached on `this.stdioIdentity` and never re-evaluated without this
-                // hook, so without self-heal the process stays stuck in `identity: userId + no
-                // bound node` for its entire lifetime. Cheap null-check per dispatch; only
-                // attempts rebind when BOTH userId is present AND the node-id is null — i.e.
-                // the exact recoverable-state from ticket #10181. Once healed, the in-place
-                // mutation means subsequent dispatches skip the check via the truthy guard.
-                if (
-                    this.stdioIdentity &&
-                    !this.stdioIdentity.agentIdentityNodeId &&
-                    this.stdioIdentity.userId
-                ) {
-                    try {
-                        const healedNodeId = await this.bindAgentIdentity(this.stdioIdentity.userId);
-                        if (healedNodeId) {
-                            this.stdioIdentity.agentIdentityNodeId = healedNodeId;
-                            logger.info(`[neo-memory-core MCP] Identity self-healed: ${this.stdioIdentity.userId} → ${healedNodeId}`);
-                        }
-                    } catch (rebindError) {
-                        // Non-fatal — fall through to dispatch with the unresolved binding
-                        // intact. Downstream services that require a bound identity will raise
-                        // their own errors; services that tolerate `getAgentIdentityNodeId()`
-                        // returning null (e.g. `MemoryService.addMemory`) continue to work.
-                        logger.warn(`[neo-memory-core MCP] Identity self-heal attempt failed: ${rebindError.message}`);
-                    }
-                }
-
 
                 // Wrap the tool dispatch in RequestContextService.run() when a stdio identity
                 // was resolved (ticket #10145). This establishes the AsyncLocalStorage-scoped

--- a/learn/agentos/decisions/0001-cross-process-cache-coherence.md
+++ b/learn/agentos/decisions/0001-cross-process-cache-coherence.md
@@ -317,7 +317,8 @@ decision — no new substrate will be built. The scope becomes:
    specific and becomes redundant
 5. Preserve PR #10182's `callTool` self-heal block as defense-in-depth until
    the end-to-end divergence test passes cleanly across at least one live
-   restart cycle with all three harnesses active
+   restart cycle with all three harnesses active.
+   - **Update (2026-04-23):** This condition was empirically verified and the `#10182` block was surgically removed via PR #10227. The architectural rationale shifted from "defense-in-depth" to "surface, don't obscure" — defensive code here masked bugs, whereas explicit failure aligns with Neo.mjs's loud-failure discipline. The `#10228` test-pollution fix further mitigates the remaining failure mode that would have made self-heal useful.
 
 ### 5.2 Post-implementation validation
 


### PR DESCRIPTION
Authored by Gemini 3.1 Pro (Antigravity). Session e068b094-fcae-436a-a9ab-c513246f7f71.

Resolves #10226

Removes the now-obsolete `#10182` self-heal band-aid from `Server.mjs` now that the 3-harness stability protocol (ADR 0001 §5.1.5) is empirically verified. The worktree data unification and identity seeding resolves the underlying cause of the lookup failure, meaning the self-heal block serves only to obscure potential issues that should now be surfaced rather than hidden.