### PR TITLE
fix(memory-core): force upsertNode SQLite lazy-load on cache miss (#10230)

### DIFF
--- a/ai/mcp/server/memory-core/services/GraphService.mjs
+++ b/ai/mcp/server/memory-core/services/GraphService.mjs
@@ -134,6 +134,11 @@ class GraphService extends Base {
      * @param {Object} nodeData
      */
     upsertNode({id, type, name, description, semanticVectorId, state, updatedAt, properties}) {
+        // Lazy-load from SQLite before in-memory check — prevents cold-cache stubs from
+        // overwriting rich SQLite rows via addNodes' ON CONFLICT DO UPDATE semantics.
+        // Mirrors the discipline in getNode:424. Resolves #10230.
+        this.db.getAdjacentNodes(id, 'both');
+
         let node = this.db.nodes.get(id);
 
         if (node) {

--- a/test/playwright/unit/ai/mcp/server/memory-core/services/GraphService.spec.mjs
+++ b/test/playwright/unit/ai/mcp/server/memory-core/services/GraphService.spec.mjs
@@ -214,6 +214,41 @@ test.describe('Neo.ai.mcp.server.memory-core.services.GraphService', () => {
         expect(GraphService.db.nodes.has('LazyNode')).toBe(true);
     });
 
+    test('upsertNode should lazy-load from SQLite to prevent cold-cache stub overwriting (resolves #10230)', async () => {
+        // Bypass upsertNode to simulate a rich node seeded directly into SQLite
+        GraphService.db.storage.addNodes([{
+            id: '@test-identity',
+            label: 'AgentIdentity',
+            properties: {
+                name: 'Test Identity',
+                githubLogin: 'test-user',
+                createdAt: '2026-04-23T00:00:00Z'
+            }
+        }]);
+
+        // Let the asynchronous store mutations propagate natively
+        await new Promise(resolve => setTimeout(resolve, 50));
+
+        // Simulate cold cache
+        GraphService.db.nodes.clear();
+
+        // Perform the upsert with a stub payload
+        GraphService.upsertNode({id: '@test-identity', type: 'AGENT'});
+
+        // Wait for potential async writes
+        await new Promise(resolve => setTimeout(resolve, 50));
+
+        // Re-read directly from SQLite to assert nothing was overwritten
+        const rows = GraphService.db.storage.db.prepare('SELECT data FROM Nodes WHERE id = ?').all('@test-identity');
+        expect(rows.length).toBe(1);
+        const data = JSON.parse(rows[0].data);
+        
+        expect(data.label).toBe('AGENT'); // Type is updated
+        expect(data.properties.name).toBe('Test Identity'); // Original properties preserved
+        expect(data.properties.githubLogin).toBe('test-user');
+        expect(data.properties.createdAt).toBe('2026-04-23T00:00:00Z');
+    });
+
     test('should recover from boot-time identity cache race (stuck vicinity cache)', async () => {
         GraphService.upsertNode({id: '@neo-opus-4-7', name: 'Identity Node'});
 


### PR DESCRIPTION
Closes #10230

**What this does**
Prepends `this.db.getAdjacentNodes(id, 'both')` to `upsertNode` to force a lazy-load from SQLite if the node isn't in the cache. 

**Why it matters**
Prevents the cold-cache condition where an incoming upsert creates a new minimal stub that overwrites existing rich seed data in SQLite, which was a primary identity wipe vector.