### PR TITLE
fix(memory-core): replace lazy-stubbing in grantPermission with SQLite existence guard (#10231)

### DIFF
--- a/ai/mcp/server/memory-core/services/PermissionService.mjs
+++ b/ai/mcp/server/memory-core/services/PermissionService.mjs
@@ -60,12 +60,14 @@ class PermissionService extends Base {
             throw new Error(`Invalid scope. Must be one of: ${this.validScopes.join(', ')}`);
         }
 
-        // Check if node exists
-        const db = GraphService.db;
-        if (!db.nodes.get(to)) {
-            // It's technically fine if the target doesn't exist yet, but linkNodes might cull it if not found in SQLite.
-            // Let's lazily ensure the node exists if we're granting permission to it.
-            GraphService.upsertNode({ id: to, type: 'AGENT', name: to.replace('AGENT:', ''), properties: {} });
+        // Verify target exists in SQLite directly (not in-memory cache, per sibling ticket's
+        // lazy-load root-cause fix). Identity creation is a privileged operation (seedAgentIdentities.mjs);
+        // it should NOT be an implicit side-effect of a permission grant. Stubbing with type 'AGENT'
+        // + stripped metadata destroys seed data and creates type-inconsistent nodes.
+        // Pattern mirrors linkNodes:179-185 (FK-style existence guard).
+        const verifyStmt = GraphService.db.storage.db.prepare('SELECT count(*) as count FROM Nodes WHERE id = ?');
+        if (verifyStmt.get(to).count === 0) {
+            throw new Error(`Cannot grant ${scope} to ${to}: target does not exist. Identity nodes must be pre-seeded via ai/scripts/seedAgentIdentities.mjs.`);
         }
 
         // The capability belongs to 'to', pointing at 'owner'

--- a/test/playwright/unit/ai/mcp/server/memory-core/services/PermissionService.spec.mjs
+++ b/test/playwright/unit/ai/mcp/server/memory-core/services/PermissionService.spec.mjs
@@ -143,4 +143,29 @@ test.describe('Neo.ai.mcp.server.memory-core.services.PermissionService', () => 
                 .rejects.toThrow('Unauthorized: Cannot enumerate permissions for AGENT:bob');
         });
     });
+
+    test('grantPermission preserves existing node type and does not overwrite it (resolves #10231)', async () => {
+        // Pre-seed AGENT:* as a BroadcastSentinel
+        GraphService.upsertNode({ id: 'AGENT:*', type: 'BroadcastSentinel', name: '*', properties: {} });
+
+        await RequestContextService.run({ agentIdentityNodeId: 'AGENT:bob' }, async () => {
+            const res = await PermissionService.grantPermission({ to: 'AGENT:*', scope: 'CAN_REPLY_TO' });
+            expect(res.success).toBe(true);
+        });
+
+        // Assert type remains 'BroadcastSentinel'
+        const node = GraphService.getNode({ id: 'AGENT:*' });
+        expect(node.type).toBe('BroadcastSentinel');
+        
+        // Also assert in SQLite
+        const rows = GraphService.db.storage.db.prepare('SELECT data FROM Nodes WHERE id = ?').all('AGENT:*');
+        expect(JSON.parse(rows[0].data).label).toBe('BroadcastSentinel');
+    });
+
+    test('grantPermission throws when target does not exist (resolves #10231)', async () => {
+        await RequestContextService.run({ agentIdentityNodeId: 'AGENT:bob' }, async () => {
+            await expect(PermissionService.grantPermission({ to: 'AGENT:phantom', scope: 'CAN_REPLY_TO' }))
+                .rejects.toThrow('Cannot grant CAN_REPLY_TO to AGENT:phantom: target does not exist. Identity nodes must be pre-seeded via ai/scripts/seedAgentIdentities.mjs.');
+        });
+    });
 });


### PR DESCRIPTION
Closes #10231

**What this does**
Removes the lazy-stub creation fallback in `PermissionService.grantPermission` and replaces it with an explicit SQLite existence check. If the target node is missing, it now throws an explicit error instructing the operator to pre-seed identities. 

**Why it matters**
This resolves the secondary identity wipe vector where granting permissions to cold-cache or unseeded nodes would silently create 'AGENT' typed stubs, corrupting the Graph's type taxonomy and dropping crucial metadata.