### PR TITLE
feat(memory-core): healthcheck identity observability block (#10176)

### DIFF
--- a/ai/mcp/server/memory-core/Server.mjs
+++ b/ai/mcp/server/memory-core/Server.mjs
@@ -116,6 +116,12 @@ class Server extends Base {
             // OIDC-derived identity.
             this.stdioIdentity = await this.resolveStdioIdentity();
 
+            // Surface stdio identity state for healthcheck observability (#10176). The block
+            // is informational-only — unbound identity does NOT flip healthcheck status to
+            // unhealthy because mailbox is an optional feature and single-tenant fallthrough
+            // is a valid operational mode (see MemoryCoreMcpAuth.md contract).
+            HealthService.setStdioIdentityState(this.stdioIdentity);
+
             const {StdioServerTransport} = await import('@modelcontextprotocol/sdk/server/stdio.js');
             const transport = new StdioServerTransport();
             await this.mcpServer.connect(transport);

--- a/ai/mcp/server/memory-core/openapi.yaml
+++ b/ai/mcp/server/memory-core/openapi.yaml
@@ -1216,6 +1216,33 @@ components:
                     type: string
                   priority:
                     type: string
+        identity:
+          type: object
+          description: |
+            Stdio transport identity observability (#10176). Surfaces the resolved
+            agent identity state for diagnostic purposes. Always present on stdio
+            transport; populated by Server.mjs post-`resolveStdioIdentity()`. `bound: false`
+            indicates the identity resolved but no seeded AgentIdentity graph node matched —
+            a valid single-tenant fallthrough state, not a health failure (status stays
+            `healthy`). `source: 'unresolved'` indicates the resolver yielded no userId
+            at all (env-var missing + gh-cli fallback failed or timed out).
+          properties:
+            source:
+              type: string
+              enum: [env-var, gh-cli, oidc, unresolved]
+              description: Provenance of the resolved identity
+              example: env-var
+            bound:
+              type: boolean
+              description: |
+                True iff the resolved login matched a seeded AgentIdentity graph node.
+                False for unseeded identities or when source is 'unresolved'.
+              example: true
+            nodeId:
+              type: string
+              nullable: true
+              description: The `@`-prefixed graph node ID when bound, else null
+              example: "@neo-opus-4-7"
         details:
           type: array
           items:

--- a/ai/mcp/server/memory-core/services/HealthService.mjs
+++ b/ai/mcp/server/memory-core/services/HealthService.mjs
@@ -6,6 +6,44 @@ import ChromaLifecycleService   from './lifecycle/ChromaLifecycleService.mjs';
 import logger                   from '../logger.mjs';
 
 /**
+ * @summary Projects the stdio identity state into the healthcheck-payload shape (#10176).
+ *
+ * Pure function: takes the cached stdioIdentity context (or null) and returns the
+ * observability block the healthcheck response exposes — `{source, bound, nodeId}`.
+ * Extracted as a module-scope function so unit tests can exercise the projection
+ * logic without bootstrapping the full Memory Core runtime.
+ *
+ * Three input shapes matter:
+ * 1. `null` — stdioIdentity never populated (SSE transport, or resolver ran before the
+ *    setter was invoked). Projects to `{source: 'unresolved', bound: false, nodeId: null}`.
+ * 2. Resolved without graph node — `gh-cli` / `env-var` yielded a userId but no seeded
+ *    AgentIdentity graph node matched. Projects to `{source: <resolved>, bound: false, nodeId: null}`.
+ *    Diagnostic: agent needs seeding via `ai/scripts/seedAgentIdentities.mjs` OR the boot-time
+ *    self-seed from #10232 wasn't triggered.
+ * 3. Resolved with graph node — fully bound identity. Projects to `{source: <resolved>, bound: true, nodeId: '@login'}`.
+ *    The success shape that A2A operation requires.
+ *
+ * `status` is NOT flipped by this projection. Unbound identity is a valid single-tenant
+ * fallthrough per the MemoryCoreMcpAuth contract — this block is pure observability, not
+ * a health gate. The architectural choice matches "surface, don't obscure" (PR #10227).
+ *
+ * @param {Object|null} stdioIdentityState Either `null` or `{userId, agentIdentityNodeId, source}`
+ * @returns {{source: String, bound: Boolean, nodeId: String|null}}
+ */
+export function buildIdentityBlock(stdioIdentityState) {
+    if (!stdioIdentityState) {
+        return {source: 'unresolved', bound: false, nodeId: null};
+    }
+
+    const {agentIdentityNodeId, source} = stdioIdentityState;
+    return {
+        source: source || 'unresolved',
+        bound : !!agentIdentityNodeId,
+        nodeId: agentIdentityNodeId || null
+    };
+}
+
+/**
  * @summary Monitors and validates the ChromaDB dependency for the Memory Core MCP server.
  *
  * This service acts as a gatekeeper, ensuring that ChromaDB is properly running,
@@ -95,6 +133,16 @@ class HealthService extends Base {
      * @private
      */
     #startupSummarizationDetails = null;
+
+    /**
+     * Cached stdio identity state for the healthcheck `identity` observability block (#10176).
+     * Populated by `Server.mjs` post-`resolveStdioIdentity()` via {@link HealthService#setStdioIdentityState}.
+     * Null when the setter hasn't fired yet (SSE transport, pre-boot, or timing races — all of
+     * which project to `source: 'unresolved'` via {@link buildIdentityBlock}).
+     * @member {Object|null} #stdioIdentityState
+     * @private
+     */
+    #stdioIdentityState = null;
 
     /**
      * Checks if the active vector and graph databases are running and accessible.
@@ -243,6 +291,7 @@ class HealthService extends Base {
                 summarizationDetails: this.#startupSummarizationDetails
             },
             mailboxPreview: await MailboxService.getHealthcheckPreview(),
+            identity : buildIdentityBlock(this.#stdioIdentityState),
             details  : [],
             version  : process.env.npm_package_version || '1.0.0',
             uptime   : process.uptime()
@@ -434,6 +483,25 @@ class HealthService extends Base {
         this.#startupSummarizationDetails = details;
 
         // Clear the cache to ensure next healthcheck returns updated info
+        this.clearCache();
+    }
+
+    /**
+     * Caches the resolved stdio identity so the healthcheck `identity` block can surface
+     * it (#10176). Called by `Server.mjs` after `resolveStdioIdentity()` completes in the
+     * stdio boot path. SSE transport does not call this — per-request OIDC identity is
+     * orthogonal to process-level stdio identity; observability for SSE per-request state
+     * is a separate concern.
+     *
+     * Clears the healthcheck cache so the next call returns a fresh payload including
+     * the new identity block.
+     *
+     * @param {Object|null} stdioIdentityState Either `null` (unresolved) or
+     *     `{userId, agentIdentityNodeId, source}`. The projection to the observable
+     *     `{source, bound, nodeId}` shape happens inside `buildIdentityBlock`.
+     */
+    setStdioIdentityState(stdioIdentityState) {
+        this.#stdioIdentityState = stdioIdentityState;
         this.clearCache();
     }
 

--- a/learn/agentos/tooling/MemoryCoreMcpAuth.md
+++ b/learn/agentos/tooling/MemoryCoreMcpAuth.md
@@ -152,21 +152,50 @@ The SSE path validates Bearer tokens per OAuth 2.1 draft conventions (audience e
 
 ## Troubleshooting
 
-### `addMemory` writes are not tagged with `userId` in stdio mode
+### Primary diagnostic: `healthcheck` identity block (#10176)
 
-Check startup logs for `[neo-memory-core MCP] Identity: <userId> via <source>`. If the line reads `Identity: unresolved (single-tenant fallthrough)`:
+The fastest single-call diagnostic is the `identity` block in the MCP `healthcheck` response. Call `healthcheck` and inspect `identity.*` — no need to grep startup logs or check multiple substrates:
 
-1. Verify `NEO_AGENT_IDENTITY` is set in the harness's MCP server environment — `env` block in `settings.json`, not shell export.
+```json
+{
+    "identity": {
+        "source": "env-var" | "gh-cli" | "oidc" | "unresolved",
+        "bound":  true | false,
+        "nodeId": "@neo-opus-4-7" | null
+    }
+}
+```
+
+The three substantive states and their implied fixes:
+
+| `identity.source` | `identity.bound` | Interpretation | Fix |
+|---|---|---|---|
+| `env-var` or `gh-cli` | `true` | ✓ Fully operational. Agent bound to graph node. | None needed. |
+| `env-var` or `gh-cli` | `false` | Identity resolved but no matching AgentIdentity graph node. | Run `node ai/scripts/seedAgentIdentities.mjs` OR verify the #10232 boot-time self-seed fired. If new per-model account: add to `ai/graph/identityRoots.mjs` and restart. |
+| `unresolved` | `false` | Resolver yielded no userId at all. | See "Identity unresolved" section below. |
+
+`status` stays `healthy` regardless of `bound` — unbound identity is a valid single-tenant fallthrough, not a health failure. This is observability, not a gate.
+
+### `identity.source: 'unresolved'` (stdio mode)
+
+Resolver chain failed entirely — neither env-var nor gh-CLI yielded a login:
+
+1. Verify `NEO_AGENT_IDENTITY` is set in the harness's MCP server environment — `env` block in `settings.json` / `claude_desktop_config.json`, not shell export.
 2. If no `NEO_AGENT_IDENTITY` is set, verify `gh auth status` reports a valid login.
 3. If `gh` is installed but the 1.5-second fail-fast timeout is exceeded, the CLI is likely hanging on auth refresh or a degraded network. The design is intentional — fail-fast preserves the MCP handshake budget for the rest of `initAsync`. Set `NEO_AGENT_IDENTITY` explicitly to skip the CLI call entirely.
 
-### AgentIdentity node is `unbound` despite identity resolution
+### `identity.bound: false` despite resolved `source`
 
-Startup log reads `Identity: tobiu via gh-cli — unbound (no matching AgentIdentity node)`.
+Startup log reads `Identity: tobiu via gh-cli — unbound (no matching AgentIdentity node)`, and `healthcheck.identity.bound` is `false`.
 
-- The graph node `@tobiu` does not exist in the current Memory Core graph.
+- The graph node `@<login>` does not exist in the current Memory Core graph.
 - Run `node ai/scripts/seedAgentIdentities.mjs` to re-seed the canonical identities.
-- For a new per-model account, add the identity to the `IDENTITIES` array in `seedAgentIdentities.mjs` before running.
+- For a new per-model account, add the identity to the `IDENTITIES` array in `ai/graph/identityRoots.mjs` (the shared source consumed by both boot-time self-seed and the CLI) before running.
+- Post-#10232, boot-time self-seed should provision missing root identities automatically. If `bound` stays false after a restart cycle with a populated graph, investigate whether `GraphService.initAsync` is reaching the self-seed block — check startup logs for errors.
+
+### Startup-log fallback (pre-#10176 environments or logging-only workflows)
+
+The `[neo-memory-core MCP] Identity: <userId> via <source> — bound to <nodeId>` log line is still emitted at boot by `logIdentityStatus` and remains usable as a fallback diagnostic. The healthcheck block supersedes it for live diagnostics because a single tool call returns structured JSON the agent can branch on; log-grep requires filesystem access to the MCP stdout capture.
 
 ### `Identity-override spoof rejected` error on a tool call
 

--- a/test/playwright/unit/ai/mcp/server/memory-core/services/HealthService.spec.mjs
+++ b/test/playwright/unit/ai/mcp/server/memory-core/services/HealthService.spec.mjs
@@ -1,0 +1,122 @@
+import {setup} from '../../../../../../setup.mjs';
+
+const appName = 'HealthServiceTest';
+
+setup({
+    neoConfig: {
+        unitTestMode: true
+    },
+    appConfig: {
+        name             : appName,
+        isMounted        : () => true,
+        vnodeInitialising: false
+    }
+});
+
+import {test, expect} from '@playwright/test';
+import Neo            from '../../../../../../../../src/Neo.mjs';
+import * as core       from '../../../../../../../../src/core/_export.mjs';
+import InstanceManager from '../../../../../../../../src/manager/Instance.mjs';
+
+/**
+ * @summary Coverage for the #10176 identity observability block in the healthcheck payload.
+ *
+ * The integration test (HealthService.healthcheck() end-to-end) requires ChromaDB + StorageRouter
+ * + multiple service singletons. Those are out of scope here — this spec pins the PURE projection
+ * logic via `buildIdentityBlock`, which is the load-bearing function for the AC shape contract.
+ * Integration correctness is validated post-merge via empirical restart + healthcheck inspection.
+ *
+ * @see Neo.ai.mcp.server.memory-core.services.HealthService#buildIdentityBlock
+ */
+test.describe('HealthService #10176 — buildIdentityBlock', () => {
+    let buildIdentityBlock;
+
+    test.beforeAll(async () => {
+        const mod = await import('../../../../../../../../ai/mcp/server/memory-core/services/HealthService.mjs');
+        buildIdentityBlock = mod.buildIdentityBlock;
+    });
+
+    test('null state projects to unresolved + unbound', () => {
+        expect(buildIdentityBlock(null)).toEqual({
+            source: 'unresolved',
+            bound : false,
+            nodeId: null
+        });
+    });
+
+    test('explicit unresolved state (resolver yielded no userId) projects to unresolved + unbound', () => {
+        // StdioIdentityResolver's failure mode: env-var missing AND gh-cli failed/timed-out.
+        // Server.mjs may pass through the explicit shape or null — both paths land in the
+        // same observable state. This covers the explicit-shape path.
+        const state = {userId: null, agentIdentityNodeId: null, source: 'unresolved'};
+        expect(buildIdentityBlock(state)).toEqual({
+            source: 'unresolved',
+            bound : false,
+            nodeId: null
+        });
+    });
+
+    test('env-var resolution with matching graph node projects to bound', () => {
+        // The expected success shape for A2A operation: NEO_AGENT_IDENTITY env var pinned at
+        // harness level, graph node seeded (#10232 boot-time self-seed), bindAgentIdentity
+        // resolved the node at boot.
+        const state = {
+            userId             : 'neo-opus-4-7',
+            agentIdentityNodeId: '@neo-opus-4-7',
+            source             : 'env-var'
+        };
+        expect(buildIdentityBlock(state)).toEqual({
+            source: 'env-var',
+            bound : true,
+            nodeId: '@neo-opus-4-7'
+        });
+    });
+
+    test('gh-cli resolution with matching graph node projects to bound', () => {
+        // Human-developer path or harness without NEO_AGENT_IDENTITY pin: gh CLI resolves
+        // the authenticated login, graph has the seeded node, bindAgentIdentity succeeds.
+        const state = {
+            userId             : 'tobiu',
+            agentIdentityNodeId: '@tobiu',
+            source             : 'gh-cli'
+        };
+        expect(buildIdentityBlock(state)).toEqual({
+            source: 'gh-cli',
+            bound : true,
+            nodeId: '@tobiu'
+        });
+    });
+
+    test('resolved userId without graph node projects to unbound (seed-state failure signal)', () => {
+        // Diagnostic shape: resolver worked (env-var or gh-cli yielded a login), but the
+        // AgentIdentity graph node for that login doesn't exist. This is THE signal #10176
+        // was filed to surface — operator immediately knows to run seedAgentIdentities.mjs
+        // OR verify #10232 self-seed fired on boot.
+        const state = {
+            userId             : 'neo-opus-4-7',
+            agentIdentityNodeId: null,
+            source             : 'env-var'
+        };
+        expect(buildIdentityBlock(state)).toEqual({
+            source: 'env-var',
+            bound : false,
+            nodeId: null
+        });
+    });
+
+    test('missing source defaults to unresolved', () => {
+        // Defense-in-depth: if a caller ever passes a state with userId but no source field
+        // (shouldn't happen per StdioIdentityResolver contract, but guard against drift),
+        // we project to the safe 'unresolved' value rather than undefined/leaked.
+        const state = {
+            userId             : 'neo-opus-4-7',
+            agentIdentityNodeId: '@neo-opus-4-7'
+            // no source
+        };
+        expect(buildIdentityBlock(state)).toEqual({
+            source: 'unresolved',
+            bound : true,
+            nodeId: '@neo-opus-4-7'
+        });
+    });
+});


### PR DESCRIPTION
Resolves #10176 (partial — core + spec + Troubleshooting guide; onboarding docs deferred to fast-follow, see Deltas)

Authored by Claude Opus 4.7 (Claude Code). Session `24aa1fa1-9a22-498e-97f2-760c12e5a79d`.

## Outcome

MCP `healthcheck` response now carries an `identity` observability block:

```json
{
    "identity": {
        "source": "env-var" | "gh-cli" | "oidc" | "unresolved",
        "bound":  true | false,
        "nodeId": "@neo-opus-4-7" | null
    }
}
```

Diagnostic chain for "identity unbound" failures collapses from 8+ tool calls (ps + lsof + env inspection + graph queries + startup-log grep) to a single `healthcheck` invocation. Empirical motivation: four sessions across two days (`0327771f`, `15852d91`, `8968b9f6`, `24aa1fa1`) paid the multi-tool diagnostic tax running down the same chain. Post-#10232 self-seed + post-#10190 cache coherence, the remaining failure class lives UPSTREAM of the graph substrate (env-var not reaching spawn, `gh-CLI` timeout, resolver chain failure). This PR surfaces that class directly.

## Architectural notes

- `status` stays `healthy` regardless of `bound`. Unbound identity is a valid single-tenant fallthrough per the MemoryCoreMcpAuth contract — this is pure observability, not a health gate. Aligns with "surface, don't obscure" discipline from PR #10227.
- `buildIdentityBlock(state)` is a module-scope pure function (exported for testability) — projection logic is unit-testable without bootstrapping the full Memory Core runtime.
- Wiring: `Server.mjs` calls `HealthService.setStdioIdentityState(this.stdioIdentity)` after `resolveStdioIdentity()` completes in the stdio boot path. Setter clears the healthcheck cache so the next call returns a fresh payload.
- SSE transport is out of scope (per-request OIDC identity is orthogonal to process-level stdio identity; per-request observability is a separate concern).

## Deltas from ticket

**Deferred to fast-follow ticket**: `#10176`'s ACs also include `AI_QUICK_START.md` Claude Desktop onboarding section + `.neo-ai-data` symlink convention docs + restart-gotcha (⌘Q, not window close) note. Those are operator-onboarding concerns, load-bearing for new contributor setup, but not load-bearing for the immediate A2A diagnostic use case that motivated this session's pickup of #10176. Filing a fast-follow ticket scoped to `docs(ai-quick-start): Claude Desktop + multi-harness symlink onboarding (#10176 follow-up)` keeps the substrate-observability substrate shipping on its own cycle.

Scope discipline rationale: the session-end goal was enabling the diagnostic call chain (*"why is bind null?"* → one healthcheck call) to unblock A2A empirical validation. The onboarding docs harden the path for future operators but don't gate current operational validation.

## Test Evidence

```
npx playwright test -c test/playwright/playwright.config.mjs \
  test/playwright/unit/ai/mcp/server/memory-core/services/HealthService.spec.mjs
```

Result: **6 passed (575ms)**. Coverage:

1. `null state projects to unresolved + unbound` — SSE transport / pre-boot / timing-race fallthrough
2. `explicit unresolved state (resolver yielded no userId)` — StdioIdentityResolver's chain-failure mode
3. `env-var resolution with matching graph node projects to bound` — expected A2A success shape
4. `gh-cli resolution with matching graph node projects to bound` — human-dev path
5. `resolved userId without graph node projects to unbound` — ***the diagnostic shape this PR exists to surface*** (seed-state failure signal)
6. `missing source defaults to unresolved` — defense-in-depth projection

## Post-Merge Validation

- [ ] Restart harness; call `healthcheck` on first tool call; inspect `identity.*`
- [ ] If `identity.bound === true` AND `identity.source === 'env-var'` → A2A operational state reached, `list_messages` should work, first real cross-family handshake with @neo-gemini-3-1-pro unblocked
- [ ] If `identity.source === 'unresolved'` → env-var isn't reaching the MCP spawn; the diagnostic narrows to "inspect Claude Desktop / Antigravity config file" in one step
- [ ] If `identity.source === 'env-var'` AND `identity.bound === false` → graph node missing; run `seedAgentIdentities.mjs` OR investigate why #10232 boot-time self-seed didn't fire
- [ ] File fast-follow ticket for the deferred AI_QUICK_START onboarding docs

## Related

- Source ticket: #10176 (Mailbox identity observability + Claude Desktop onboarding docs)
- Complements: #10232 (boot-time self-seed) — this PR surfaces the state #10232 prevents; both lines of defense
- Complements: #10190 (cache coherence via syncCache) — graph-side correctness was that; identity resolution correctness is this
- Replaces the startup-log-grep guidance in: `learn/agentos/tooling/MemoryCoreMcpAuth.md` §Troubleshooting
- Fast-follow ticket (to-be-filed post-merge): `docs(ai-quick-start): Claude Desktop + multi-harness symlink onboarding`

## Cross-Family Review

Per `pull-request-workflow §6.1`, requesting cross-family review from `@neo-gemini-3-1-pro`. Substantive code is ~50 lines across HealthService + Server + openapi + spec; review surface is tight.