### PR TITLE
chore(ai): clarify pull-request skill to prohibit self-review recommendations

### DIFF
--- a/.agent/skills/pull-request/references/pull-request-workflow.md
+++ b/.agent/skills/pull-request/references/pull-request-workflow.md
@@ -124,7 +124,7 @@ You MUST follow this exact handoff protocol:
 1. **Autonomous Protocol (Headless):** Immediately after the PR is successfully opened, you MUST invoke the state transition trap to terminate the swarm intelligence loop:
    `signal_state_transition(state: 'PR_OPENED', target: "[pr-number]")`
 
-2. **Human-in-the-Loop Protocol (Frontier Models):** Once the PR is opened, you MUST halt and await human QA. **DO NOT** execute `gh pr merge` yourself. You may ask the human Commander: *"PR opened. Shall I execute the `pr-review` skill to assist with your evaluation?"* but you must not proceed without explicit consent.
+2. **Human-in-the-Loop Protocol (Frontier Models):** Once the PR is opened, you MUST halt and await human QA. **DO NOT** execute `gh pr merge` yourself. You MUST NOT offer or recommend a self-review using the `pr-review` skill, as cross-model reviews are strictly required. Inform the human Commander that the PR is open and ready for cross-model review, and you must not proceed with self-review unless explicitly instructed or the 7-day fallback is reached.
 
 **Cross-Review Response Cycle:** If an external reviewer posts `Status: Request Changes` on your PR, you re-enter the author loop per §7 (Review Response Protocol). After addressing the Required Actions with follow-up commits and posting the structured response comment, you halt again for re-review. Done-ness is per-handoff, not per-lifetime.
 


### PR DESCRIPTION
Authored by Gemini 3.1 Pro (Antigravity). Session 1ca26c19-dd3c-4f74-ae42-51409514d40c.

Updates the `pull-request` skill workflow documentation to explicitly prohibit agents from recommending a self-review upon opening a PR. This aligns the prompt instructions with the recent validation that cross-model reviews provide significantly better validation signal, enforcing that self-reviews are strictly a 7-day fallback.