### PR TITLE
fix(memory-core): await GraphService.getNode Promise in bindAgentIdentity (#10249)

### DIFF
--- a/ai/mcp/server/memory-core/Server.mjs
+++ b/ai/mcp/server/memory-core/Server.mjs
@@ -92,22 +92,12 @@ class Server extends Base {
         await InferenceLifecycleService.ready();
         await SessionService.ready();
 
-        // 5. Perform Health Check & Log Status
-        const health = await HealthService.healthcheck();
-        this.logStartupStatus(health);
-        this.logSiblingConcurrency();
-
-        // 6. Connect Transport
-        if (aiConfig.transport === 'sse') {
-            const {default: TransportService} = await import('../shared/services/TransportService.mjs');
-
-            await TransportService.setup({
-                server      : this,
-                aiConfig,
-                logger,
-                resourceName: 'neo-memory-core MCP'
-            });
-        } else {
+        // 5. Resolve stdio identity (if applicable) BEFORE the boot-time healthcheck snapshot
+        // (#10249). Elevated out of the stdio transport-connect branch so the initial telemetry
+        // logged by `logStartupStatus` reflects the bound identity state, not the pre-bind null.
+        // Runtime MCP healthcheck tool-dispatch already reads `#stdioIdentityState` live per call,
+        // so this reorder affects boot-log observability only — not runtime correctness.
+        if (aiConfig.transport !== 'sse') {
             // Resolve stdio identity before connecting the transport (ticket #10145). The
             // resolved context is cached on this.stdioIdentity and wrapped around every
             // CallToolRequestSchema dispatch so downstream services (e.g. MemoryService) read
@@ -121,7 +111,24 @@ class Server extends Base {
             // unhealthy because mailbox is an optional feature and single-tenant fallthrough
             // is a valid operational mode (see MemoryCoreMcpAuth.md contract).
             HealthService.setStdioIdentityState(this.stdioIdentity);
+        }
 
+        // 6. Perform Health Check & Log Status (sees populated stdioIdentityState post-reorder)
+        const health = await HealthService.healthcheck();
+        this.logStartupStatus(health);
+        this.logSiblingConcurrency();
+
+        // 7. Connect Transport
+        if (aiConfig.transport === 'sse') {
+            const {default: TransportService} = await import('../shared/services/TransportService.mjs');
+
+            await TransportService.setup({
+                server      : this,
+                aiConfig,
+                logger,
+                resourceName: 'neo-memory-core MCP'
+            });
+        } else {
             const {StdioServerTransport} = await import('@modelcontextprotocol/sdk/server/stdio.js');
             const transport = new StdioServerTransport();
             await this.mcpServer.connect(transport);
@@ -223,7 +230,12 @@ class Server extends Base {
             // cold-boot race would silently miss seeded identity nodes.
             await GraphService.ready();
             
-            const node = GraphService.getNode({id: graphNodeId});
+            // `GraphService.getNode` returns a Promise (Neo's singleton method wrapper);
+            // awaiting it unpacks to the `{id, type, name, ...}` shape. Without `await`,
+            // `node.id` on the Promise object is `undefined`, causing bind to silently
+            // return `undefined` — the true root cause of the #10241 boot-time bind failure
+            // that busy_timeout/retry/reorder patches only partially masked.
+            const node = await GraphService.getNode({id: graphNodeId});
             if (node) {
                 return node.id;
             }

--- a/test/playwright/unit/ai/mcp/server/memory-core/Server.spec.mjs
+++ b/test/playwright/unit/ai/mcp/server/memory-core/Server.spec.mjs
@@ -71,7 +71,7 @@ test.describe('Neo.ai.mcp.server.memory-core.Server', () => {
 
     test('bindAgentIdentity should correctly retrieve identity without cache manipulation', async () => {
         await GraphService.initAsync();
-        
+
         GraphService.upsertNode({id: '@neo-opus-4-7', type: 'AgentIdentity', name: 'Identity Node'});
 
         await new Promise(resolve => setTimeout(resolve, 50));
@@ -81,7 +81,45 @@ test.describe('Neo.ai.mcp.server.memory-core.Server', () => {
 
         const boundId = await serverInstance.bindAgentIdentity('neo-opus-4-7');
         expect(boundId).toBe('@neo-opus-4-7');
-        
+
         serverInstance.destroy();
+    });
+
+    test('bindAgentIdentity must await the Promise-returning getNode (regression pin for #10249)', async () => {
+        // Regression guard: in production, `GraphService.getNode` returns a Promise (Neo
+        // singleton method wrapping). If `bindAgentIdentity` drops the `await`, `node.id`
+        // on the Promise object is `undefined` — the actual root cause of #10241's merged-
+        // but-incomplete fix that #10249 corrects. `unitTestMode` may resolve the method
+        // synchronously, so the other test in this suite does not reproduce the failure
+        // mode; this test forces the Promise path explicitly by stubbing `getNode` to
+        // return a Promise regardless of the framework's runtime decision.
+
+        await GraphService.initAsync();
+
+        const serverInstance = Neo.create('Neo.ai.mcp.server.memory-core.Server');
+
+        const originalGetNode = GraphService.getNode.bind(GraphService);
+        GraphService.getNode = function({id}) {
+            // Force the production Promise-wrapped shape regardless of test mode.
+            return Promise.resolve({
+                id,
+                type       : 'AgentIdentity',
+                name       : 'Regression Pin',
+                description: '#10249 — proves bindAgentIdentity awaits GraphService.getNode'
+            });
+        };
+
+        try {
+            const boundId = await serverInstance.bindAgentIdentity('regression-pin-agent');
+
+            // The load-bearing assertions: boundId must be the resolved string, not the
+            // Promise object, not `undefined`, not `'[object Promise]'`.
+            expect(typeof boundId).toBe('string');
+            expect(boundId).toBe('@regression-pin-agent');
+            expect(boundId).not.toBeUndefined();
+        } finally {
+            GraphService.getNode = originalGetNode;
+            serverInstance.destroy();
+        }
     });
 });


### PR DESCRIPTION
Authored by Claude Opus 4.7 (Claude Code). Session `5f746864-85c4-4b2c-bd79-64c76a8a2be3`.

Resolves #10249

## Summary

Restores correct boot-time identity binding by awaiting `GraphService.getNode`'s Promise return. This is the actual root-cause fix for the #10241 boot-time bind race that PR #10242's `busy_timeout = 5000` only partially addressed. Complementary reorder of identity resolution before the startup healthcheck (per Gemini's proposal this session) fixes boot-log observability in the same PR.

## Deltas from ticket

None. Implementation matches #10249's Fix section exactly:
1. `await` added on `GraphService.getNode` at `Server.mjs:226` with inline rationale comment citing the Promise-returning framework semantics.
2. Identity resolution elevated out of the stdio transport-connect branch to run before the startup `HealthService.healthcheck()` call (Gemini's complementary fix — observability only).
3. Regression test `Server.spec.mjs::bindAgentIdentity must await the Promise-returning getNode` — stubs `getNode` to return `Promise.resolve({id,...})` regardless of test-mode behavior, asserts `boundId` is a string `@<login>`, not `undefined` or Promise.

## Empirical validation

Matrix from this session via `ai/mcp/client/mcp-cli.mjs` fresh-spawn (bypasses the agent's stale MCP cache):

| Variant | `healthcheck.identity.bound` | `list_messages` |
|---|---|---|
| Current dev (no await) | false | "no agent identity context bound" |
| Reorder-only (earlier attempt) | false | fails |
| `await` only | **true** | **returns messages** |
| `await` + reorder (this PR) | **true** | **returns messages** |

### The money shot

First successful A2A message reception post-fix — Gemini's 14:57Z broadcast finally reaches Claude:

\`\`\`json
{"messageId":"MESSAGE:50d478fb-81ef-4d49-8fda-18e862303a1b","subject":"hello all","from":null,"to":"AGENT:*"}
\`\`\`

(The `from: null` confirms Gemini's `MailboxService.from || 'unknown'` fallback shipped in #10242 is load-bearing for legacy messages — correct call on her part.)

### DIAG output that pinned the mechanism

\`\`\`
[DIAG #10241] typeof node=object isPromise=true keys=
[DIAG #10241] JSON.stringify(node)={}
[DIAG #10241] awaited Promise → JSON.stringify(awaited)={\"id\":\"@neo-opus-4-7\",\"type\":\"AgentIdentity\",...}
\`\`\`

## Test Evidence

- `npm run test-unit -- test/playwright/unit/ai/mcp/server/memory-core/Server.spec.mjs` — **2 passed (930ms)**
- Regression pin test would fail if the `await` is removed: the stubbed Promise flows to `node.id` yielding `undefined`, assertion `expect(typeof boundId).toBe('string')` breaks.

## Cross-family attribution

The reorder component (elevating identity resolution before the boot healthcheck) is Gemini's diagnosis and proposal from this session's PR #10242 follow-up iteration. Gemini identified the observability drift; the runtime correctness fix (`await`) is mine. Both ship together here per her endorsement: *"Let Claude take the lead and open the PR! Option (b) is the most efficient path forward."*

Also owning a peer-review regression: my first-review of #10242 classified Gemini's `await` on getNode as "decorative" — empirically wrong, and that categorization led Gemini to drop the `await` alongside the retry loop during revert, shipping the bug into dev. This PR restores what her original retry-with-await draft already had correct.

## Architectural note / follow-up

Why does `GraphService.getNode` return a Promise when its body is synchronous? Presumably `Neo.setupClass` or singleton proxy wrapping intercepts method returns and Promise-wraps them. Exact mechanism is unclear without deeper `src/core/Base.mjs` / `Neo.mjs` tracing. Flagging as a `[KB_GAP]` — worth investigating as a separate ticket so future reviewers/authors don't repeat my classification mistake. Not blocking this fix.

## Critical files touched

- `ai/mcp/server/memory-core/Server.mjs` — `await` added on `bindAgentIdentity`'s `getNode` call; identity resolution elevated out of transport-connect branch; inline rationale comments
- `test/playwright/unit/ai/mcp/server/memory-core/Server.spec.mjs` — new regression test pin

## Post-merge validation checklist

- [ ] \`\`⌘Q + relaunch Claude Code → healthcheck.identity.bound: true\`\`
- [ ] \`\`list_messages works end-to-end for @neo-opus-4-7 stdio transport\`\`
- [ ] Gemini's Antigravity side: same cold-restart validation
- [ ] Consider filing follow-up ticket for the `[KB_GAP]` on framework Promise-wrapping mechanism

## Handoff

Per pull-request §6.2 (Human-in-the-Loop), halting for human QA. No self-review. Cross-family review from Gemini expected per #10208/#10211 mandate before squash-merge.