### PR TITLE
feat(memory-core): config-gated mailbox default reply policy (#10252)

### DIFF
--- a/ai/mcp/server/memory-core/config.template.mjs
+++ b/ai/mcp/server/memory-core/config.template.mjs
@@ -271,6 +271,51 @@ const defaultConfig = {
      */
     backupPath: path.resolve(cwd, '.neo-ai-data/backups'),
     /**
+     * Mailbox substrate behavior configuration (#10252).
+     *
+     * Deployment-tier selectors for the A2A mailbox service. The A2A primitives
+     * themselves (Message nodes, SENT_BY / SENT_TO edges, CAN_REPLY_TO permission
+     * edges, PermissionService.grantPermission / revokePermission / listPermissions)
+     * remain unconditionally live regardless of these selectors — this block only
+     * tunes default enforcement policy to match deployment reality.
+     *
+     * @type {Object}
+     */
+    mailbox: {
+        /**
+         * Default reply policy for non-broadcast DMs. Controls whether `addMessage`
+         * to a specific AgentIdentity target requires a prior `CAN_REPLY_TO` grant
+         * or reachable-counterparty trust-lift (#10146 strict-isolation default),
+         * or accepts any authenticated sender as a peer.
+         *
+         * - `'blocked'` — strict-isolation default policy from #10146. Suited for
+         *   multi-user / multi-tenant Memory Core deployments and mixed-trust-tier
+         *   installations where cross-tenant boundaries must be enforced at the
+         *   substrate. Cross-tenant reach requires explicit `CAN_REPLY_TO` grants.
+         *   Reachable-counterparty trust-lift (#10179) relaxes the bootstrap once
+         *   any broadcast or direct message has flowed between the pair.
+         *
+         * - `'open'` — peer-trust mode. Suited for homogeneous trusted-frontier
+         *   swarms where every authenticated identity is a peer owned by the same
+         *   operator (e.g. local development with Claude + Gemini + future frontier
+         *   models). Eliminates the first-message bootstrap tax. `CAN_REPLY_TO`
+         *   edges still queryable via `grant_permission` / `list_permissions`;
+         *   enforcement simply skips the check.
+         *
+         * Does NOT weaken read-path scoping — `CAN_READ_INBOX_OF`,
+         * `CAN_READ_MEMORIES_OF`, `CAN_READ_SESSIONS_OF` remain strict regardless
+         * of this setting. Reading someone's inbox is categorically different
+         * from sending them a message; asymmetric treatment is intentional.
+         *
+         * Library default is `'open'`; multi-user / multi-tenant deployments
+         * override to `'blocked'` in their `config.mjs` as part of installation,
+         * or via the `NEO_MAILBOX_DEFAULT_REPLY_POLICY` environment variable.
+         *
+         * @type {'blocked'|'open'}
+         */
+        defaultReplyPolicy: process.env.NEO_MAILBOX_DEFAULT_REPLY_POLICY || 'open'
+    },
+    /**
      * Target file path for the lazy backfill queue of unresolved provenance edges.
      * @type {string}
      */

--- a/ai/mcp/server/memory-core/services/MailboxService.mjs
+++ b/ai/mcp/server/memory-core/services/MailboxService.mjs
@@ -1,4 +1,5 @@
 import Base from '../../../../../src/core/Base.mjs';
+import aiConfig from '../config.mjs';
 import RequestContextService from '../../shared/services/RequestContextService.mjs';
 import GraphService from './GraphService.mjs';
 import PermissionService from './PermissionService.mjs';
@@ -103,8 +104,25 @@ class MailboxService extends Base {
 
         const isRoleOrHuman = to.startsWith('role:') || to.startsWith('human:');
 
-        // Check reply permission
-        if (!isRoleOrHuman && to !== 'AGENT:*' && to !== sentBy) {
+        // Reply permission gate (#10252): strict-isolation mode only.
+        //
+        // In `'blocked'` mode (multi-user / multi-tenant deployment default per #10146),
+        // non-broadcast DMs to a specific AgentIdentity require either a prior
+        // `CAN_REPLY_TO` grant or the reachable-counterparty trust-lift (#10179).
+        //
+        // In `'open'` mode (homogeneous trusted-frontier swarm default), the check is
+        // skipped — all authenticated peers can DM each other. The PermissionService
+        // primitives remain live and callable; `CAN_REPLY_TO` edges are still created
+        // by `grantPermission` and still queryable by `listPermissions`. Only the
+        // enforcement path on `addMessage` consults the config selector.
+        //
+        // Read-path scoping (`CAN_READ_INBOX_OF`, `CAN_READ_MEMORIES_OF`,
+        // `CAN_READ_SESSIONS_OF`) is NOT affected by this setting — reading someone's
+        // inbox is categorically different from sending them a message; asymmetric
+        // treatment is intentional per #10252's Out of Scope.
+        const strictReplyPolicy = aiConfig.mailbox?.defaultReplyPolicy === 'blocked';
+
+        if (strictReplyPolicy && !isRoleOrHuman && to !== 'AGENT:*' && to !== sentBy) {
             let canReply = PermissionService.hasPermission(sentBy, to, 'CAN_REPLY_TO');
 
             // Reachable Counterparty trust lift: if `to` ever sent a message that reached the

--- a/learn/agentos/tooling/MemoryCoreMcpAuth.md
+++ b/learn/agentos/tooling/MemoryCoreMcpAuth.md
@@ -274,6 +274,27 @@ The Mailbox A2A service natively integrates with the `PermissionService` to enfo
 - **Role Inbox Asymmetry:** While sending to a role is write-permissive, *reading* from a role's inbox (e.g., `listMessages({ to: 'role:librarian' })`) still requires the calling agent to explicitly hold the `CAN_READ_INBOX_OF` capability for that role.
 - Senders always retain the ability to read the specific messages they have sent, regardless of the recipient's permissions.
 
+### Reply Policy Deployment Modes (#10252)
+
+The `CAN_REPLY_TO` enforcement on `addMessage` is a **deployment-selected default** via `aiConfig.mailbox.defaultReplyPolicy`. The A2A primitives themselves (`grantPermission`, `revokePermission`, `listPermissions`, `CAN_REPLY_TO` graph edges, reachable-counterparty trust-lift) remain unconditionally live regardless of the selector — this knob only tunes the default enforcement path on `addMessage` writes.
+
+| Mode | Default Policy | Suited For | Bootstrap UX |
+|---|---|---|---|
+| `'open'` (library default) | Accept any authenticated peer | Homogeneous trusted-frontier swarms (local development with Claude + Gemini + future frontier models owned by a single operator) | First-contact DM succeeds immediately |
+| `'blocked'` | Strict-isolation per #10146 | Multi-user / multi-tenant Memory Core deployments; mixed-trust-tier installations where cross-tenant boundaries must be enforced at the substrate | First-contact DM requires an explicit `CAN_REPLY_TO` grant OR a broadcast-first bootstrap per #10179's trust-lift |
+
+**Selection paths** (precedence order, highest first):
+1. `NEO_MAILBOX_DEFAULT_REPLY_POLICY=blocked|open` environment variable (useful for CI, one-off diagnostic runs, or per-process override)
+2. Explicit `mailbox.defaultReplyPolicy` field in a custom config file passed to the Memory Core server's `--config` flag
+3. The library default (`'open'`) baked into `ai/mcp/server/memory-core/config.mjs`
+
+**What this does NOT change:**
+- `CAN_READ_INBOX_OF`, `CAN_READ_MEMORIES_OF`, `CAN_READ_SESSIONS_OF` read-path scopes remain strict regardless of mode. Reading someone's inbox is categorically different from sending them a message; asymmetric treatment is intentional.
+- `grantPermission` / `revokePermission` / `listPermissions` tools remain callable in both modes. Operators running in `'open'` mode can still choose to grant explicit `CAN_REPLY_TO` edges — they are graph-queryable consent signal regardless of whether the enforcement path currently consults them.
+- Broadcasts (`to: 'AGENT:*'`), role targets (`to: 'role:*'`), human targets (`to: 'human:*'`), and self-sends are unconditionally accepted in both modes.
+
+**Multi-user / multi-tenant deployment guidance:** set `defaultReplyPolicy: 'blocked'` in the deployment's `config.mjs` as part of installation. Every cross-tenant DM then requires an explicit grant via `grant_permission`, enforced at the write path. Tenant onboarding provisions grants for the internal peers that need to communicate; anything outside the grant topology is rejected.
+
 ## See Also
 
 - `ai/mcp/server/shared/services/AuthService.mjs` — OIDC discovery and token introspection
@@ -292,4 +313,7 @@ The Mailbox A2A service natively integrates with the `PermissionService` to enfo
 - #10145 — OAuth2 authentication layer for Memory Core MCP connections (this doc)
 - #10016 — Multi-Tenant Identity & Data Privacy (parent sub-epic)
 - #10139 — Mailbox A2A primitive (future consumer of anti-spoof invariant)
+- #10146 — Cross-tenant permission edges + multi-tenant validation test suite (strict-isolate default codification)
+- #10179 — Mailbox reachable-counterparty broadcast-receipt trust-lift
+- #10252 — Mailbox reply policy: config-gated default for deployment-tier selection
 - #9999 — Cloud-Native Knowledge & Multi-Tenant Memory Core (grand-parent epic)

--- a/test/playwright/unit/ai/mcp/server/memory-core/services/MailboxService.spec.mjs
+++ b/test/playwright/unit/ai/mcp/server/memory-core/services/MailboxService.spec.mjs
@@ -21,7 +21,7 @@ import RequestContextService from '../../../../../../../../ai/mcp/server/shared/
 
 test.describe('Neo.ai.mcp.server.memory-core.services.MailboxService', () => {
     test.describe.configure({ mode: 'serial' });
-    let MailboxService, GraphService, PermissionService, LifecycleService, buildMailboxDelta, originalAutoSave;
+    let MailboxService, GraphService, PermissionService, LifecycleService, buildMailboxDelta, originalAutoSave, mailboxAiConfig, originalMailboxPolicy;
     let dbPath;
 
     test.beforeAll(async () => {
@@ -40,8 +40,20 @@ test.describe('Neo.ai.mcp.server.memory-core.services.MailboxService', () => {
         buildMailboxDelta = (await import('../../../../../../../../ai/mcp/server/memory-core/services/MemoryService.mjs')).buildMailboxDelta;
 
         // Force temp file DB config instead of :memory: to prevent initialization race wipes
-        const aiConfig = (await import('../../../../../../../../ai/mcp/server/memory-core/config.mjs')).default;
-        aiConfig.storagePaths.graph = dbPath;
+        mailboxAiConfig = (await import('../../../../../../../../ai/mcp/server/memory-core/config.mjs')).default;
+        mailboxAiConfig.storagePaths.graph = dbPath;
+
+        // Pin this suite to strict-isolation mode (#10252). These tests predate the
+        // config-gated default and assert `'blocked'`-mode behavior (Unauthorized
+        // throws on ungranted DMs, reachable-counterparty trust-lift semantics).
+        // Explicit pin preserves their invariants regardless of the library default
+        // shipped in config.mjs. Symmetric restore in afterAll per symmetric-cleanup
+        // discipline — Playwright `fullyParallel` interleaves across files even when
+        // describe mode is `serial`, so cross-file mutation of the singleton Config
+        // needs both-ends guards.
+        mailboxAiConfig.data.mailbox ??= {};
+        originalMailboxPolicy = mailboxAiConfig.data.mailbox.defaultReplyPolicy;
+        mailboxAiConfig.data.mailbox.defaultReplyPolicy = 'blocked';
 
         if (!LifecycleService._initPromise) {
             await LifecycleService.initAsync();
@@ -54,6 +66,11 @@ test.describe('Neo.ai.mcp.server.memory-core.services.MailboxService', () => {
 
     test.afterAll(async () => {
         GraphService.db.autoSave = originalAutoSave;
+        // Symmetric restore of the mailbox policy to whatever the library default
+        // was before this suite ran.
+        if (mailboxAiConfig?.data?.mailbox) {
+            mailboxAiConfig.data.mailbox.defaultReplyPolicy = originalMailboxPolicy;
+        }
         if (fs.existsSync(dbPath)) {
             try { fs.unlinkSync(dbPath); } catch (e) {}
             try { fs.unlinkSync(dbPath + '-wal'); } catch (e) {}
@@ -656,6 +673,158 @@ test.describe('Neo.ai.mcp.server.memory-core.services.MailboxService', () => {
             expect(delta).not.toBeNull();
             expect(delta.unreadCount).toBe(1);
             expect(delta.latestPreview.subject).toBe('hello all');
+        });
+    });
+});
+
+/**
+ * #10252: Mailbox reply policy — `'open'` mode behavior.
+ *
+ * Separate top-level describe so the config mutation + serial ordering are
+ * self-contained. Mirrors the setup pattern of the parent suite (isolated tmp
+ * SQLite + symmetric afterAll cleanup) but pins `defaultReplyPolicy: 'open'`
+ * for the duration of these tests.
+ *
+ * Validates the three invariants of `'open'` mode:
+ *   1. First-contact DM between two identities with no prior history and no
+ *      `CAN_REPLY_TO` grant SUCCEEDS (the core UX deliverable).
+ *   2. `PermissionService.grantPermission` remains callable and `CAN_REPLY_TO`
+ *      edges remain graph-queryable — primitives unchanged, only enforcement
+ *      path differs.
+ *   3. Read-path scoping (`CAN_READ_INBOX_OF`) remains strict — reading
+ *      another agent's inbox without a grant still throws Unauthorized.
+ */
+test.describe('Neo.ai.mcp.server.memory-core.services.MailboxService — open policy mode (#10252)', () => {
+    test.describe.configure({ mode: 'serial' });
+    let MailboxService, GraphService, PermissionService, LifecycleService, mailboxAiConfig, originalAutoSave, originalMailboxPolicy;
+    let dbPath;
+
+    test.beforeAll(async () => {
+        const tmpDir = path.resolve(process.cwd(), 'tmp');
+        if (!fs.existsSync(tmpDir)) {
+            fs.mkdirSync(tmpDir, { recursive: true });
+        }
+        dbPath = path.join(tmpDir, `neo-mailbox-open-test-${Date.now()}-${Math.random().toString(36).substring(7)}.db`);
+
+        GraphService = (await import('../../../../../../../../ai/mcp/server/memory-core/services/GraphService.mjs')).default;
+        MailboxService = (await import('../../../../../../../../ai/mcp/server/memory-core/services/MailboxService.mjs')).default;
+        PermissionService = (await import('../../../../../../../../ai/mcp/server/memory-core/services/PermissionService.mjs')).default;
+        LifecycleService = (await import('../../../../../../../../ai/mcp/server/memory-core/services/lifecycle/SystemLifecycleService.mjs')).default;
+
+        mailboxAiConfig = (await import('../../../../../../../../ai/mcp/server/memory-core/config.mjs')).default;
+        mailboxAiConfig.storagePaths.graph = dbPath;
+
+        mailboxAiConfig.data.mailbox ??= {};
+        originalMailboxPolicy = mailboxAiConfig.data.mailbox.defaultReplyPolicy;
+        mailboxAiConfig.data.mailbox.defaultReplyPolicy = 'open';
+
+        if (!LifecycleService._initPromise) {
+            await LifecycleService.initAsync();
+        } else {
+            await LifecycleService.ready();
+        }
+        originalAutoSave = GraphService.db.autoSave;
+        GraphService.db.autoSave = true;
+    });
+
+    test.afterAll(async () => {
+        GraphService.db.autoSave = originalAutoSave;
+        if (mailboxAiConfig?.data?.mailbox) {
+            mailboxAiConfig.data.mailbox.defaultReplyPolicy = originalMailboxPolicy;
+        }
+        if (fs.existsSync(dbPath)) {
+            try { fs.unlinkSync(dbPath); } catch (e) {}
+            try { fs.unlinkSync(dbPath + '-wal'); } catch (e) {}
+            try { fs.unlinkSync(dbPath + '-shm'); } catch (e) {}
+        }
+    });
+
+    test.beforeEach(async () => {
+        if (GraphService.db) {
+            GraphService.db.nodes.clear();
+            GraphService.db.edges.clear();
+            GraphService.db.vicinityLoadedNodes.clear();
+
+            if (GraphService.db.storage?.db) {
+                await GraphService.db.storage.clear();
+                GraphService.db.storage.db.exec('DELETE FROM GraphLog');
+            }
+        }
+
+        GraphService.upsertNode({ id: 'AGENT:alice', type: 'AGENT', name: 'Alice', properties: {} });
+        GraphService.upsertNode({ id: 'AGENT:bob', type: 'AGENT', name: 'Bob', properties: {} });
+        GraphService.upsertNode({ id: 'AGENT:charlie', type: 'AGENT', name: 'Charlie', properties: {} });
+        GraphService.upsertNode({ id: 'AGENT:*', type: 'AGENT', name: 'Broadcast', properties: {} });
+    });
+
+    test('first-contact DM succeeds without grant or prior history', async () => {
+        // Charlie sends to Alice with no CAN_REPLY_TO edge and no prior message history.
+        // Strict mode would throw Unauthorized here (see the parent suite's Reachable-
+        // Counterparty Trust test); open mode accepts the send.
+        const res = await RequestContextService.run({ agentIdentityNodeId: 'AGENT:charlie' }, () => {
+            return MailboxService.addMessage({ to: 'AGENT:alice', subject: 'First contact', body: 'hi' });
+        });
+
+        expect(res.status).toBe('sent');
+        expect(res.messageId).toMatch(/^MESSAGE:/);
+    });
+
+    test('grantPermission remains callable and edges remain graph-queryable', async () => {
+        // Even in 'open' mode, operators can still explicitly grant CAN_REPLY_TO.
+        // The edge is created and visible via listPermissions — only the enforcement
+        // path on addMessage is bypassed.
+        await RequestContextService.run({ agentIdentityNodeId: 'AGENT:bob' }, async () => {
+            const result = await PermissionService.grantPermission({ to: 'AGENT:alice', scope: 'CAN_REPLY_TO' });
+            expect(result.success).toBe(true);
+        });
+
+        // Alice (the grantee) can list her capabilities and sees the grant.
+        const perms = await RequestContextService.run({ agentIdentityNodeId: 'AGENT:alice' }, () => {
+            return PermissionService.listPermissions();
+        });
+
+        expect(perms.capabilities).toContainEqual(expect.objectContaining({
+            target: 'AGENT:bob',
+            scope : 'CAN_REPLY_TO'
+        }));
+    });
+
+    test('read-path scoping stays strict — CAN_READ_INBOX_OF still enforced', async () => {
+        // Bob sends Alice a message (allowed in open mode).
+        let msgId;
+        await RequestContextService.run({ agentIdentityNodeId: 'AGENT:bob' }, async () => {
+            const res = await MailboxService.addMessage({ to: 'AGENT:alice', subject: 'inbox test', body: 'body' });
+            msgId = res.messageId;
+        });
+
+        // Charlie tries to read Alice's inbox — should fail regardless of reply policy.
+        // Open mode only relaxes the WRITE gate; read-path isolation is a separate
+        // scope (`CAN_READ_INBOX_OF`) and stays strict per #10252's Out of Scope.
+        await RequestContextService.run({ agentIdentityNodeId: 'AGENT:charlie' }, async () => {
+            await expect(MailboxService.listMessages({ to: 'AGENT:alice' })).rejects.toThrow(/Unauthorized/);
+        });
+
+        // Charlie also can't fetch the specific message by ID without the scope.
+        await RequestContextService.run({ agentIdentityNodeId: 'AGENT:charlie' }, async () => {
+            await expect(MailboxService.getMessage({ messageId: msgId })).rejects.toThrow(/Unauthorized/);
+        });
+    });
+
+    test('broadcast sends and role/human targets behave identically in both modes', async () => {
+        // Open mode does not change the always-allowed paths: broadcast sends,
+        // self-sends, and role/human targets all continue to work regardless of policy.
+        GraphService.upsertNode({ id: 'role:librarian', type: 'ROLE', name: 'Librarian', properties: {} });
+        GraphService.upsertNode({ id: 'human:tobiu', type: 'HUMAN', name: 'Tobias', properties: {} });
+
+        await RequestContextService.run({ agentIdentityNodeId: 'AGENT:alice' }, async () => {
+            const broadcast = await MailboxService.addMessage({ to: 'AGENT:*', subject: 'announce', body: 'body' });
+            expect(broadcast.status).toBe('sent');
+
+            const toRole = await MailboxService.addMessage({ to: 'role:librarian', subject: 'need book', body: 'body' });
+            expect(toRole.status).toBe('sent');
+
+            const toHuman = await MailboxService.addMessage({ to: 'human:tobiu', subject: 'fyi', body: 'body' });
+            expect(toHuman.status).toBe('sent');
         });
     });
 });


### PR DESCRIPTION
Authored by Claude Opus 4.7 (Claude Code). Session `57b8fba5-2bd4-4446-ab46-6d1c9086a19d`.

Resolves #10252

## Summary

Adds a deployment-tier selector (`aiConfig.mailbox.defaultReplyPolicy`) for the A2A mailbox's `CAN_REPLY_TO` enforcement on `addMessage`. Two modes: `'open'` (library default, suited for homogeneous trusted-frontier swarms) and `'blocked'` (strict-isolation per #10146, suited for multi-user / multi-tenant deployments). All A2A primitives — `grantPermission` / `revokePermission` / `listPermissions` / `CAN_REPLY_TO` graph edges / reachable-counterparty trust-lift (#10179) — remain unconditionally live; only the enforcement path on `addMessage` consults the selector.

**Zero deletions.** The existing strict-mode logic is preserved intact, wrapped in a single conditional.

## Empirical validation

Both modes verified via `ai/mcp/client/mcp-cli.mjs` fresh-spawn (bypasses stale MCP cache):

```bash
# Open mode (library default) — first-contact DM succeeds
NEO_AGENT_IDENTITY=neo-opus-4-7 npm run ai:mcp-client -- --server memory-core \
  --call-tool add_message --args '{"to":"@neo-gemini-3-1-pro","subject":"...","body":"..."}'
# → {"messageId":"MESSAGE:ae81473d-...","status":"sent"}

# Blocked mode via env override — same send correctly rejected
NEO_AGENT_IDENTITY=neo-opus-4-7 NEO_MAILBOX_DEFAULT_REPLY_POLICY=blocked npm run ai:mcp-client -- \
  --server memory-core --call-tool add_message --args '{...}'
# → Unauthorized: Cannot send to @neo-gemini-3-1-pro. Requires CAN_REPLY_TO permission or prior message history.
```

## Ticket body correction

Ticket #10252's Architectural Reality section cites `Server.mjs:106-139` as the enforcement surface — that is incorrect. The actual enforcement lives in **`MailboxService.mjs:106-139`**. Noting here since the Fix section of this PR targets the correct file; the ticket body will stay as-shipped unless you want me to edit it.

## Scope walkthrough

| File | Delta | Purpose |
|---|---|---|
| `ai/mcp/server/memory-core/config.template.mjs` | +46 | New `mailbox` block with `defaultReplyPolicy` JSDoc covering the deployment-tier spectrum. Uses `NEO_MAILBOX_DEFAULT_REPLY_POLICY` env var for override precedence. |
| `ai/mcp/server/memory-core/services/MailboxService.mjs` | +18 -10 | Imports `aiConfig`; wraps the existing `CAN_REPLY_TO` gate in `if (strictReplyPolicy && ...)`; preserves all existing trust-lift iteration and throw logic untouched. |
| `test/playwright/unit/ai/mcp/server/memory-core/services/MailboxService.spec.mjs` | +160 | Pins the existing suite explicitly to `'blocked'` mode with symmetric `beforeAll` / `afterAll` restore (per symmetric-cleanup discipline). New top-level `— open policy mode (#10252)` describe with 4 tests: first-contact DM succeeds, `grantPermission` remains callable, read-path scoping stays strict, broadcast / role / human targets unchanged. |
| `learn/agentos/tooling/MemoryCoreMcpAuth.md` | +37 | New `§Reply Policy Deployment Modes (#10252)` subsection documenting the two modes, selection-path precedence, what does NOT change, and multi-user / multi-tenant deployment guidance. |

## Test Evidence

```
$ npm run test-unit -- test/playwright/unit/ai/mcp/server/memory-core/services/MailboxService.spec.mjs
24 passed (917ms)
```

Two pre-existing failures in `PermissionService.spec.mjs` (lines 122, 147) verified unrelated to this change — they fail on clean `origin/dev` as well. Orthogonal issue; worth a separate chore ticket if not already tracked.

## Design decisions worth flagging

**Library default is `'open'`.** Two arguments considered:
- `'open'` (chosen): matches current local-dev swarm reality (Claude + Gemini + human operator all trusted peers); multi-user deployments configure their own `config.mjs` at installation and override to `'blocked'` as an explicit deployment step.
- `'blocked'` (rejected for library default): preserves backwards-compat with #10146's shipped behavior, but creates immediate UX friction for the primary current consumer (local-dev swarms). Either-direction knob is one line.

Open to revision on the default-direction call if you disagree — the code is symmetric; changing the default is one line either way.

**Env var override (`NEO_MAILBOX_DEFAULT_REPLY_POLICY`) precedes custom config.** Useful for CI, one-off diagnostic runs, and the empirical validation above without mutating `config.mjs`.

**Read-path scopes (`CAN_READ_INBOX_OF`, etc.) deliberately NOT affected.** Reading someone's inbox is categorically different from sending them a message; asymmetric treatment is intentional and documented in both `config.template.mjs` JSDoc and `MemoryCoreMcpAuth.md`.

## Post-merge validation checklist

- [ ] After merge, my Claude Code MCP (restart → library default `'open'`) sends a first-contact DM to an identity I've never exchanged messages with → succeeds
- [ ] Gemini's Antigravity side: same first-contact behavior observable on her end
- [ ] Temporary `NEO_MAILBOX_DEFAULT_REPLY_POLICY=blocked` boot → first-contact DM fails with Unauthorized (confirms override surface)
- [ ] Consider documenting the deployment guidance in the multi-user Memory Core installation checklist (when that doc lands per the #9999 roadmap work)

## Cross-family review request

Requesting review from @neo-gemini-3-1-pro per pull-request §6.1 cross-family mandate. Earlier this session, Gemini started a different approach (full permission-gate rip-out) that got reverted before landing; this PR resolves the same UX concern via config-gating without architectural primitive abandonment. Her review on the trade-off framing would be valuable.

## Handoff

Per pull-request §6.2 (Human-in-the-Loop), halting for human QA. No self-review. Priority 0 A2A #10139 stays closed as expected; #10252 transitively improves the UX surface of that substrate without touching its primitives.