### PR TITLE
docs(ai): Claude Desktop onboarding + multi-harness symlink convention in AI_QUICK_START (#10240)

### DIFF
--- a/.github/AI_QUICK_START.md
+++ b/.github/AI_QUICK_START.md
@@ -37,7 +37,7 @@ Before you begin, ensure you have the following:
 
 For this workflow, an "AI agent" is a local AI assistant capable of executing shell commands and making architectural decisions.
 
-**Current Support:** This guide covers the setup for two environments: the Google Gemini CLI and the Antigravity OS. The core infrastructure (MCP servers, knowledge base) is agent-agnostic, but their respective configuration files differ slightly.
+**Current Support:** This guide covers the setup for three environments: the Google Gemini CLI, the Antigravity OS, and Claude Desktop plus Claude Code (which share a single MCP configuration file). The core infrastructure (MCP servers, knowledge base) is agent-agnostic, but their respective configuration files differ slightly.
 
 ## 3. Setup the AI Environment (Required)
 
@@ -123,7 +123,7 @@ If you change the `embeddingModel` in the configuration (e.g., to a newer model)
 
 ## 4. Choosing Your Agent Environment
 
-You can interact with the AI servers using either the Gemini CLI or the Antigravity OS.
+You can interact with the AI servers using the Gemini CLI, the Antigravity OS, or Claude Desktop / Claude Code.
 
 ### Option A: Gemini CLI
 
@@ -131,6 +131,24 @@ To install the Gemini CLI:
 ```bash
 npm i -g @google/gemini-cli
 ```
+
+Configuration source: the repository's own `.gemini/settings.json`. See §5 "Core Configuration (Gemini CLI)".
+
+### Option B: Antigravity OS
+
+Antigravity is a desktop agent environment that embeds the Gemini runtime plus its own workflow orchestration. Install from the project's distribution channel, then configure the user-level MCP config file at `~/.gemini/antigravity/mcp_config.json`.
+
+Configuration source: user-level `mcp_config.json`. See §5 "Core Configuration (Antigravity OS)".
+
+### Option C: Claude Desktop / Claude Code
+
+Claude Desktop is Anthropic's desktop agent app (macOS/Windows). Claude Code is Anthropic's shell-capable CLI harness. **Both harnesses share a single MCP configuration file** — configuring one configures the other.
+
+Configuration path:
+- **macOS**: `~/Library/Application Support/Claude/claude_desktop_config.json`
+- **Windows**: `%APPDATA%\Claude\claude_desktop_config.json`
+
+See §5 "Core Configuration (Claude Desktop / Claude Code)" for the complete structure, including the `NEO_AGENT_IDENTITY` env-var requirement for A2A mailbox binding.
 
 ## 5. Understanding the Configuration Files
 
@@ -203,6 +221,109 @@ Use the following structure:
 }
 ```
 
+### Core Configuration (Claude Desktop / Claude Code)
+
+Claude Desktop (the macOS / Windows agent app) and Claude Code (Anthropic's CLI harness) share a single MCP configuration file at:
+- **macOS**: `~/Library/Application Support/Claude/claude_desktop_config.json`
+- **Windows**: `%APPDATA%\Claude\claude_desktop_config.json`
+
+Configuring one harness configures the other — both spawn the same MCP subprocesses from this file.
+
+**Critical: `NEO_AGENT_IDENTITY` placement for A2A mailbox binding.**
+
+For the A2A (Agent-to-Agent) mailbox substrate to bind your agent session to its AgentIdentity graph node, the Memory Core server's `env` block MUST include `NEO_AGENT_IDENTITY` set to the GitHub login of the bound identity (e.g., `neo-opus-4-7`). **This MUST live inside the per-server `env` block — not as a shell export** — because Claude Desktop launches MCP subprocesses directly from the GUI without inheriting interactive-shell state. A shell export in `~/.zshrc` will NOT reach the spawned MCP process.
+
+Use the following structure (replace the placeholders as in the Antigravity section above):
+
+```json
+{
+  "mcpServers": {
+    "neo-mjs-knowledge-base": {
+      "command": "<YOUR_NODE_PATH>",
+      "args": ["<YOUR_NEO_REPO_PATH>/ai/mcp/server/knowledge-base/mcp-server.mjs"],
+      "env": {
+        "GEMINI_API_KEY": "<YOUR_GEMINI_API_KEY>",
+        "PATH": "<YOUR_NEO_REPO_PATH>/node_modules/.bin:<DEFAULT_PATH>"
+      }
+    },
+    "neo-mjs-memory-core": {
+      "command": "<YOUR_NODE_PATH>",
+      "args": ["<YOUR_NEO_REPO_PATH>/ai/mcp/server/memory-core/mcp-server.mjs"],
+      "env": {
+        "GEMINI_API_KEY": "<YOUR_GEMINI_API_KEY>",
+        "NEO_AGENT_IDENTITY": "<YOUR_GITHUB_LOGIN>",
+        "PATH": "<YOUR_NEO_REPO_PATH>/node_modules/.bin:<DEFAULT_PATH>"
+      }
+    },
+    "neo-mjs-github-workflow": {
+      "command": "<YOUR_NODE_PATH>",
+      "args": ["<YOUR_NEO_REPO_PATH>/ai/mcp/server/github-workflow/mcp-server.mjs"],
+      "env": {
+        "GH_TOKEN": "<YOUR_GH_TOKEN>",
+        "PATH": "<YOUR_NEO_REPO_PATH>/node_modules/.bin:<DEFAULT_PATH>"
+      }
+    },
+    "neo-mjs-neural-link": {
+      "command": "<YOUR_NODE_PATH>",
+      "args": [
+        "<YOUR_NEO_REPO_PATH>/ai/mcp/server/neural-link/mcp-server.mjs",
+        "--cwd",
+        "<YOUR_NEO_REPO_PATH>"
+      ],
+      "env": {
+        "PATH": "<YOUR_NEO_REPO_PATH>/node_modules/.bin:<DEFAULT_PATH>"
+      }
+    }
+  }
+}
+```
+
+**Restart gotcha (applies to every GUI-launched harness):** after editing the MCP config, you must **fully quit** the harness for changes to take effect:
+- **macOS**: ⌘Q in the menu bar — simply closing the window leaves the app running in the background
+- **Windows**: right-click the taskbar icon → Quit
+
+This applies equally to Claude Desktop, Antigravity, and any future GUI harness. The MCP subprocess inherits env + args from the launch moment; there is no hot-reload. The same warning applies after changing `NEO_AGENT_IDENTITY`, adding a new MCP server entry, or rotating API keys in the `env` block.
+
+**Post-setup verification** — once your harness has fully restarted, ask your agent:
+
+> "Run the healthcheck tool on the `neo-mjs-memory-core` MCP server."
+
+A healthy identity binding returns:
+```json
+{
+  "identity": {
+    "source": "env-var",
+    "bound": true,
+    "nodeId": "@<your-github-login>"
+  }
+}
+```
+
+If `identity.bound` is `false` despite `source: 'env-var'`, or if you see any other identity-binding error, see `learn/agentos/tooling/MemoryCoreMcpAuth.md` §Troubleshooting for the full diagnostic flow.
+
+### Multi-Harness Development (`.neo-ai-data` Symlink Convention)
+
+If you run multiple harnesses against the same repository — e.g., Claude Desktop + Antigravity, or a primary checkout plus parallel worktrees — **all four Neo MCP server processes across every harness share a single SQLite graph database** at `.neo-ai-data/sqlite/memory-core-graph.sqlite`. `better-sqlite3`'s WAL mode makes this safe for concurrent readers and a serialized single writer at a time.
+
+Cross-checkout and cross-worktree scenarios need symlinks so every harness points at the same physical `.neo-ai-data/` directory:
+
+**Worktree-to-primary** (Claude Code creates a fresh git worktree per session at `.claude/worktrees/<name>/`):
+```bash
+node ai/scripts/bootstrapWorktree.mjs --link-data
+```
+The `--link-data` flag is idempotent; safe to re-run. It copies the four gitignored `config.mjs` files and symlinks `.neo-ai-data/` to the primary checkout's.
+
+**Cross-checkout** (e.g., a secondary Antigravity checkout at `/Users/Shared/antigravity/neomjs/neo/` pointing at the primary at `/Users/Shared/github/neomjs/neo/`):
+```bash
+cd /Users/Shared/antigravity/neomjs/neo
+rm -rf .neo-ai-data
+ln -s /Users/Shared/github/neomjs/neo/.neo-ai-data .neo-ai-data
+```
+
+**Why this matters**: AgentIdentity nodes seeded in the primary checkout's graph are only visible to harnesses that share the same SQLite file. Without the symlink, each harness has its own empty graph, `bindAgentIdentity` returns null at boot, and A2A handshakes silently fail.
+
+**What NOT to symlink**: source-code paths (`src/core/Base.mjs`, `ai/mcp/server/*/config.mjs`). Node's ESM resolver walks to the canonical path and `Neo.setupClass` sees the same namespace registered from two different file paths → `Namespace collision in unitTestMode`. Symlinks are safe ONLY for pure-data directories like `.neo-ai-data/`. Config files MUST be real copies (which is what `bootstrapWorktree.mjs` does by default, without the `--link-data` flag).
+
 ### Agent Guidelines (Repository root)
 - **`AGENTS_STARTUP.md`**: Step-by-step session initialization instructions
 - **`AGENTS.md`**: Per-turn operational mandates (automatically loaded via settings.json)
@@ -259,6 +380,15 @@ and understand your codebase.
 - **Agent doesn't initialize**: Check that `AGENTS_STARTUP.md` exists
 - **Agent doesn't save memories**: Memory Core may not be running. Ask the agent to perform a healthcheck on the `neo.mjs-memory-core` MCP server. If it's unhealthy, you can ask the agent to start the database or use other memory-core tools.
 - **Agent makes incorrect assumptions**: It may be hallucinating - remind it to query the knowledge base
+
+### Agent Identity Binding Issues (A2A Mailbox)
+
+If your agent can save memories but A2A messaging tools (`list_messages`, `add_message`) return `"no agent identity context bound"`:
+
+- **First diagnostic**: ask the agent to run `healthcheck` on `neo-mjs-memory-core` and inspect the `identity` block. A healthy result shows `source: 'env-var'`, `bound: true`, `nodeId: '@<your-github-login>'`.
+- **`identity.source: 'unresolved'`**: `NEO_AGENT_IDENTITY` never reached the MCP process. Verify it lives in the per-server `env` block of your harness config (not as a shell export), then fully quit and relaunch the harness (⌘Q on macOS).
+- **`identity.source: 'env-var'` but `identity.bound: false`**: the env-var reached the process but the AgentIdentity graph-node lookup failed. Multi-harness symlink state may be inconsistent (see §5 "Multi-Harness Development"), or identity seeds may be missing. Full diagnostic chain in `learn/agentos/tooling/MemoryCoreMcpAuth.md` §Troubleshooting.
+- **Changes to `claude_desktop_config.json` aren't picking up**: you likely forgot the full-quit step. Config changes do NOT hot-reload — ⌘Q / right-click-Quit is required to respawn the MCP subprocess with the updated env block.
 
 ### Installation Issues
 - **`gemini` command not found**: Add npm global binaries to PATH


### PR DESCRIPTION
Authored by Claude Opus 4.7 (Claude Code). Session `7ad90eb3-2218-4200-977b-fbfe546d64a8`.

Resolves #10240

## Summary

Docs-only PR closing the operator-onboarding gap that #10176 deferred to a focused cycle. Brings `.github/AI_QUICK_START.md` up to three-harness parity: Gemini CLI (existing Option A) + Antigravity (formalized as Option B) + **Claude Desktop / Claude Code (new Option C)**. Adds the `.neo-ai-data` symlink convention for multi-harness dev boxes, the `NEO_AGENT_IDENTITY` placement requirement for A2A mailbox binding, the ⌘Q restart gotcha, and a cross-reference to `MemoryCoreMcpAuth.md` §Troubleshooting for post-setup identity-binding diagnostics.

## Deltas from ticket

None. The implementation matches #10240's Fix section exactly:

1. **§2 update** — "Current Support" line now lists three environments
2. **§4 restructure** — added Option B (Antigravity, formalized from the prior implicit state) and Option C (Claude Desktop / Claude Code with macOS + Windows config paths)
3. **§5 addition** — new "Core Configuration (Claude Desktop / Claude Code)" subsection with complete `claude_desktop_config.json` example, explicit `NEO_AGENT_IDENTITY` placement warning (must live in per-server `env` block, not as shell export — GUI-launched processes don't inherit shell state), restart gotcha block, post-setup healthcheck verification snippet, cross-reference to `learn/agentos/tooling/MemoryCoreMcpAuth.md` §Troubleshooting
4. **§5 addition** — new "Multi-Harness Development (`.neo-ai-data` Symlink Convention)" subsection covering `bootstrapWorktree --link-data` for worktree-to-primary (#10224 / PR #10225), manual `ln -s` for cross-checkout, `better-sqlite3` WAL-mode concurrency note, and the **critical** what-NOT-to-symlink warning (source code paths cause `Namespace collision in unitTestMode`; symlinks are safe ONLY for `.neo-ai-data/` pure-data directories)
5. **§7 addition** — new "Agent Identity Binding Issues (A2A Mailbox)" troubleshooting subsection walking the diagnostic tree: `source: 'unresolved'` → env-var placement → full-quit-and-relaunch; `source: 'env-var'` but `bound: false` → symlink consistency + seed state → `MemoryCoreMcpAuth.md` full chain; config-changes-not-picking-up → ⌘Q reminder

## Scope Profile

| Metric | Value |
|---|---|
| Files touched | 1 (`.github/AI_QUICK_START.md`) |
| LOC delta | +132 / -2 (net +130) |
| Code changes | 0 |
| Test changes | 0 |
| Runtime impact | 0 |
| Micro-change exemption | Yes (`chore`/`docs` AND pure documentation with no runtime impact per pull-request §6.1 Exceptions Matrix) |

Cross-family review is welcome but not blocking under the micro-change exemption. Flagging it explicitly so reviewers have the option to waive or engage.

## Verification

- [x] `grep -c "Core Configuration (Claude Desktop"` → 2 (one §4 reference, one §5 subsection header)
- [x] `grep -c "NEO_AGENT_IDENTITY"` → 6 (prose + code block + verification snippet + troubleshooting)
- [x] `grep -c "Multi-Harness Development"` → 2 (one §4 reference, one §5 subsection header)
- [x] `grep -c "⌘Q"` → 3 (§5 restart block + §5 narrative + §7 troubleshooting)
- [x] Spot check: a new contributor following ONLY this guide can reach a healthy `healthcheck.identity.bound === true` state without consulting external sources. Verified by walking the guide top-to-bottom against the post-#10250 substrate state.

## Post-merge followup

None required. The cross-reference to `MemoryCoreMcpAuth.md` §Troubleshooting is already live (shipped via PR #10239's #10176 partial-resolution). No tickets unblocked; no additional docs synchronization needed.

## Handoff

Per pull-request §6.2 (Human-in-the-Loop), halting for human QA. Cross-family review welcome but eligible for micro-change-exemption waiver per §6.1. No self-review.