### PR TITLE
fix(memory-core): mailbox read paths must exercise syncCache + vicinity reload (#10257)

### DIFF
--- a/ai/mcp/server/memory-core/services/MailboxService.mjs
+++ b/ai/mcp/server/memory-core/services/MailboxService.mjs
@@ -134,6 +134,16 @@ class MailboxService extends Base {
             // DM-reachable by every authenticated recipient; rate-limit mitigation is deferred
             // until the spam surface materializes empirically at swarm scale.
             if (!canReply) {
+                // Trigger syncCache + lazy-reload vicinity (#10257). The trust-lift
+                // iteration needs to see peer-process broadcasts / DMs that just landed —
+                // SENT_TO edges targeting sentBy or AGENT:*. Without the re-load, those
+                // edges from peer harnesses remain invisible to this process, blocking
+                // first-message bootstrap even when SQLite has them. Bare `syncCache()`
+                // alone would invalidate without re-hydrating; `getAdjacentNodes` handles
+                // both steps. See listMessages for the full rationale.
+                GraphService.db.getAdjacentNodes(sentBy, 'inbound');
+                GraphService.db.getAdjacentNodes('AGENT:*', 'inbound');
+
                 for (const edge of GraphService.db.edges.items) {
                     if (edge.type === 'SENT_TO' && (edge.target === sentBy || edge.target === 'AGENT:*')) {
                         let priorSender = null;
@@ -238,6 +248,23 @@ class MailboxService extends Base {
         }
 
         const db = GraphService.db;
+
+        // Consume WAL delta AND re-populate vicinity from SQLite before iterating
+        // in-memory edges (#10257). A bare `syncCache()` call invalidates cached
+        // entries but edge-type scans don't have a lazy-reload fallback, so locally-
+        // written messages get wiped without re-hydration. `getAdjacentNodes` is the
+        // correct primitive: it triggers `syncCache` (see Database.mjs:~267) AND then
+        // re-loads the node vicinity from SQLite, re-populating the cache with peer
+        // writes. Mailbox inbox query maps onto "inbound edges targeting me or the
+        // broadcast sentinel" — vicinity of those two nodes.
+        if (box === 'inbox' || box === 'all') {
+            db.getAdjacentNodes(target, 'inbound');
+            db.getAdjacentNodes('AGENT:*', 'inbound');
+        }
+        if (box === 'outbox' || box === 'all') {
+            db.getAdjacentNodes(target, 'inbound');
+        }
+
         let messages = [];
 
         for (const edge of db.edges.items) {
@@ -262,7 +289,14 @@ class MailboxService extends Base {
                 const messageNodeId = edge.source;
                 // Avoid duplicates if 'all' is chosen
                 if (messages.find(m => m.messageId === messageNodeId)) continue;
-                
+
+                // Lazy-reload this message's outbound vicinity — loads SENT_BY,
+                // PART_OF_THREAD, TAGGED_CONCEPT, etc. edges authored by the message.
+                // Without this, the inner `sourceEdge` iteration (below) sees only
+                // edges present in the process's cache at query entry, which for
+                // peer-process writes is empty. #10257.
+                db.getAdjacentNodes(messageNodeId, 'outbound');
+
                 const messageNode = db.nodes.get(messageNodeId);
                 if (messageNode && messageNode.label === 'MESSAGE') {
                     const isUnread = !messageNode.properties.readAt;
@@ -318,6 +352,13 @@ class MailboxService extends Base {
         }
 
         const db = GraphService.db;
+
+        // Trigger syncCache + lazy-reload vicinity for this message node (#10257).
+        // Ensures peer-process writes to this message's edges (e.g. late PART_OF_THREAD
+        // additions, read-receipt annotations) are visible. See listMessages for the
+        // full rationale on why bare `syncCache()` is insufficient for edge-type scans.
+        db.getAdjacentNodes(messageId, 'both');
+
         const messageNode = db.nodes.get(messageId);
         if (!messageNode || messageNode.label !== 'MESSAGE') {
             throw new Error(`Message not found: ${messageId}`);
@@ -379,6 +420,11 @@ class MailboxService extends Base {
         }
 
         const db = GraphService.db;
+
+        // Trigger syncCache + lazy-reload vicinity (#10257). Ensures the SENT_TO edge
+        // iteration sees peer-process writes. See listMessages for the full rationale.
+        db.getAdjacentNodes(messageId, 'both');
+
         const messageNode = db.nodes.get(messageId);
         if (!messageNode || messageNode.label !== 'MESSAGE') {
             throw new Error(`Message not found: ${messageId}`);

--- a/ai/mcp/server/memory-core/services/MailboxService.mjs
+++ b/ai/mcp/server/memory-core/services/MailboxService.mjs
@@ -146,6 +146,16 @@ class MailboxService extends Base {
 
                 for (const edge of GraphService.db.edges.items) {
                     if (edge.type === 'SENT_TO' && (edge.target === sentBy || edge.target === 'AGENT:*')) {
+                        // Per-message outbound vicinity lazy-load (#10257 follow-up per Gemini's
+                        // cross-family review on PR #10258). Symmetric with listMessages' inner
+                        // loop fix. Without this, the SENT_BY edge scan below comes up empty
+                        // for peer-process messages (the SENT_BY edge targets the author node,
+                        // not sentBy or AGENT:*, so the entry-level inbound lookups don't load
+                        // it). That would cause priorSender to stay null and the trust-lift to
+                        // falsely fail — breaking first-message bootstrap under cross-process
+                        // writes, exactly the scenario this PR's core fix is meant to close.
+                        GraphService.db.getAdjacentNodes(edge.source, 'outbound');
+
                         let priorSender = null;
                         for (const srcEdge of GraphService.db.edges.items) {
                             if (srcEdge.source === edge.source && srcEdge.type === 'SENT_BY') {


### PR DESCRIPTION
Authored by Claude Opus 4.7 (Claude Code). Session `7ad90eb3-2218-4200-977b-fbfe546d64a8`.

Resolves #10257

## Summary

A2A mailbox tool calls (`list_messages`, `get_message`, `mark_read`, and `add_message`'s `'blocked'`-mode trust-lift) were reading from in-memory cache without consuming WAL delta from peer MCP processes. Result: messages written by another harness or agent stayed invisible to this process's mailbox queries until an unrelated code path happened to trigger `syncCache` via `getAdjacentNodes`, or the harness was restarted.

Fix: each mailbox read path now calls `getAdjacentNodes()` on the relevant vicinity nodes at entry, which triggers `syncCache()` (consuming WAL delta) **and** re-populates the cache with authoritative SQLite state via lazy-reload. Additionally, `listMessages`' inner loop now lazy-loads each candidate message's outbound vicinity before iterating its SENT_BY / PART_OF_THREAD edges — ensuring the author attribution survives peer-written messages.

## Why `getAdjacentNodes`, not `syncCache()` directly

Empirically validated: a bare `syncCache()` call invalidates cached entries **without** re-hydrating them. Edge-type scans (which is what mailbox operations are — scanning `db.edges.items` looking for SENT_TO / SENT_BY types) don't have a lazy-reload fallback. So bare `syncCache()` would wipe the cache and leave the iteration empty — I confirmed this failure mode during development (test #100 dropped from 0/24 to 18/24 with `syncCache()` alone before I pivoted).

`getAdjacentNodes(nodeId, direction)` is the correct primitive: it triggers `syncCache()` at `Database.mjs:~267` AND then calls `loadNodeVicinitySync(nodeId)` to re-populate the cache from SQLite. Clean invalidate-and-reload semantics.

## Scope Walkthrough

| Call site | Change |
|---|---|
| `listMessages` (entry) | `getAdjacentNodes(target, 'inbound')` + `getAdjacentNodes('AGENT:*', 'inbound')` for inbox; `getAdjacentNodes(target, 'inbound')` for outbox |
| `listMessages` (inner loop, per candidate message) | `getAdjacentNodes(messageNodeId, 'outbound')` — loads SENT_BY / PART_OF_THREAD / TAGGED_CONCEPT edges sourced at the message |
| `getMessage` | `getAdjacentNodes(messageId, 'both')` — needs inbound (SENT_TO) + outbound (SENT_BY) both |
| `markRead` | `getAdjacentNodes(messageId, 'both')` — same shape |
| `addMessage` trust-lift | `getAdjacentNodes(sentBy, 'inbound')` + `getAdjacentNodes('AGENT:*', 'inbound')` — only in `'blocked'` mode per #10252; matches reachable-counterparty check |
| `getHealthcheckPreview` | Fix applied transitively via `listMessages` (no separate call) |

**Net delta:** +47 / -1 in `ai/mcp/server/memory-core/services/MailboxService.mjs`. All additive; no existing logic removed. Zero test-suite regressions.

## Test Evidence

```
$ npm run test-unit -- test/playwright/unit/ai/mcp/server/memory-core/services/MailboxService.spec.mjs
24 passed (798ms)
```

Full suite green including the strict-mode (`'blocked'`) tests pinned by #10253, the `'open'`-mode describe block, the #10174 production-addressing tests, and the reachable-counterparty / broadcast-receipt / role-based addressing scenarios.

## Empirical Validation (fresh mcp-client spawn)

Before the fix: my long-running Claude Code MCP process (~5800s uptime) returned a stale cache view — had my own historical writes still cached despite SQLite wipes, and was missing Gemini's `5b1aaa9b-...` authenticated reply that was sitting in SQLite.

After the fix, a fresh mcp-client spawn correctly returned:

```json
{
  "messages": [
    {
      "messageId": "MESSAGE:d9d7b292-...",
      "subject": "hello all",
      "from": "@opus",                   // ← populated correctly (was null before per-message vicinity fix)
      "to": "AGENT:*",
      "sentAt": "2026-04-23T18:45:55.606Z"
    }
  ]
}
```

The `from` attribution survives the cross-process propagation — the inner-loop per-message lazy-load is what made this work. Without it, `from` came back as `null` because SENT_BY edges target the author node (not the inbox-target node), so the entry-level `getAdjacentNodes(target, 'inbound')` didn't load them.

## Design Decisions

**Why not use `getAdjacentNodes(nodeId, 'both')` at every call site?** Directional filter keeps the vicinity load bounded to what the query needs. For inbox queries, we only need inbound edges to `target`; loading `'both'` would drag in outbound-from-me (my sent history) unnecessarily. Keeping tight scopes.

**Why `getAdjacentNodes(messageId, 'both')` in `getMessage` / `markRead`?** Those paths need both inbound (SENT_TO) and outbound (SENT_BY) edges of the specific message. `'both'` is correct per the operation shape.

**Why didn't I refactor the `edges.items` iteration pattern itself?** Out of scope per #10257. The ticket explicitly excluded "refactor MailboxService to use `getAdjacentNodes` instead of `edges.items` scan." The fix here is the minimal syncCache-invocation point addition that solves the cross-process coherence gap within the existing iteration shape.

## Related

- **#10190** / **PR #10221** — substrate `syncCache` fix. This PR extends the invocation surface to cover mailbox read paths.
- **#10252** / **PR #10253** — config-gated reply policy. `addMessage` trust-lift only fires in `'blocked'` mode; my fix is scoped accordingly.
- **#10179** — reachable-counterparty trust-lift. The trust-lift iteration now sees peer-process SENT_TO edges under the `getAdjacentNodes` vicinity reload.
- **#10139** — A2A mailbox primitive (parent). Unblocks "A2A end-to-end works without harness restart" — the UX target tobi called out when filing this.
- **#9999** — multi-user Memory Core (grand-parent). Multi-user deployments will exercise cross-process coherence aggressively; this fix must land before real multi-user load.

## Cross-family Review

Requesting review from @neo-gemini-3-1-pro per pull-request §6.1 mandate. Her #10221 syncCache substrate work is load-bearing for this fix — her review on the extended invocation surface + the `getAdjacentNodes`-over-bare-`syncCache` reasoning would be valuable.

## Handoff

Per pull-request §6.2 (Human-in-the-Loop), halting for human QA.

## Post-merge validation checklist

- [ ] ⌘Q + relaunch both Claude Code and Antigravity harnesses against dev
- [ ] Round-trip test: Claude sends an authenticated broadcast; Gemini's `list_messages` surfaces it without restart; Gemini replies directly; Claude's `list_messages` surfaces her reply without restart
- [ ] Verify the `from` attribution is populated correctly on both sides (not `null`, not stale alias)
- [ ] Close out #10257 acceptance criteria