### PR TITLE
fix(ai): invalidate endpoint vicinity caches on edge updates (#10260)

### DIFF
--- a/ai/graph/Database.mjs
+++ b/ai/graph/Database.mjs
@@ -111,7 +111,21 @@ class Database extends Base {
             this.isExecutingTransaction = false;
             this.autoSave               = false;
 
-            this.edges.remove(delta.invalidEdges);
+            let edgeIdsToRemove = [];
+            delta.invalidEdges.forEach(edgeRef => {
+                let edgeId = typeof edgeRef === 'string' ? edgeRef : edgeRef.id;
+                let edge   = this.edges.get(edgeId);
+
+                let source = edge ? edge.source : (edgeRef.source || null);
+                let target = edge ? edge.target : (edgeRef.target || null);
+
+                if (source) this.vicinityLoadedNodes.delete(source);
+                if (target) this.vicinityLoadedNodes.delete(target);
+
+                edgeIdsToRemove.push(edgeId);
+            });
+
+            this.edges.remove(edgeIdsToRemove);
 
             this.autoSave               = wasAutoSave;
             this.isExecutingTransaction = wasTransacting;

--- a/ai/graph/storage/SQLite.mjs
+++ b/ai/graph/storage/SQLite.mjs
@@ -272,18 +272,28 @@ class SQLite extends Base {
         let logs         = this.db.prepare('SELECT log_id, entity_id, entity_type FROM GraphLog WHERE log_id > ? ORDER BY log_id ASC').all(sinceId);
         let maxId        = sinceId;
         let invalidNodes = new Set();
-        let invalidEdges = new Set();
+        let invalidEdgesMap = new Map();
 
         for (let trace of logs) {
             maxId = trace.log_id > maxId ? trace.log_id : maxId;
             if (trace.entity_type === 'nodes') invalidNodes.add(trace.entity_id);
-            else if (trace.entity_type === 'edges') invalidEdges.add(trace.entity_id);
+            else if (trace.entity_type === 'edges') invalidEdgesMap.set(trace.entity_id, { id: trace.entity_id });
+        }
+
+        if (invalidEdgesMap.size > 0) {
+            let edgeIds = Array.from(invalidEdgesMap.keys());
+            let placeholders = edgeIds.map(() => '?').join(',');
+            let edgesQuery = this.db.prepare(`SELECT id, source, target FROM Edges WHERE id IN (${placeholders})`);
+            let edgesData = edgesQuery.all(...edgeIds);
+            for (let row of edgesData) {
+                invalidEdgesMap.set(row.id, { id: row.id, source: row.source, target: row.target });
+            }
         }
 
         return {
             lastLogId: maxId,
             invalidNodes: Array.from(invalidNodes),
-            invalidEdges: Array.from(invalidEdges)
+            invalidEdges: Array.from(invalidEdgesMap.values())
         };
     }
 

--- a/resources/content/.sync-metadata.json
+++ b/resources/content/.sync-metadata.json
@@ -1,6 +1,6 @@
 {
-  "lastSync": "2026-04-23T20:48:27.680Z",
-  "releasesLastFetched": "2026-04-23T20:48:35.997Z",
+  "lastSync": "2026-04-23T20:49:03.716Z",
+  "releasesLastFetched": "2026-04-23T20:49:11.477Z",
   "pushFailures": [],
   "issues": {
     "3789": {

--- a/test/playwright/unit/ai/graph/Database.spec.mjs
+++ b/test/playwright/unit/ai/graph/Database.spec.mjs
@@ -299,4 +299,54 @@ test.describe('Neo.ai.graph.Database', () => {
 
         db.destroy();
     });
+
+    test('should invalidate vicinity of both endpoints when syncCache invalidates edges (#10260)', async () => {
+        if (fs.existsSync(dbPath)) fs.unlinkSync(dbPath);
+        
+        // Setup Primary instance (Agent A)
+        let storageA = Neo.create(SQLite, { dbPath });
+        await storageA.initAsync();
+        let dbA = Neo.create(Database, { id: 'cache-a', storage: storageA });
+        await storageA.load();
+
+        // Setup Secondary instance (Agent B)
+        let storageB = Neo.create(SQLite, { dbPath });
+        await storageB.initAsync();
+        let dbB = Neo.create(Database, { id: 'cache-b', storage: storageB });
+        await storageB.load();
+
+        // Instance A creates two nodes
+        dbA.addNode({ id: 'node-x' });
+        dbA.addNode({ id: 'node-y' });
+
+        // Instance B syncs and then accesses both nodes, warming its vicinity cache
+        dbB.syncCache();
+        dbB.getAdjacentNodes('node-x');
+        dbB.getAdjacentNodes('node-y');
+        
+        expect(dbB.vicinityLoadedNodes.has('node-x')).toBe(true);
+        expect(dbB.vicinityLoadedNodes.has('node-y')).toBe(true);
+        expect(dbB.edges.getCount()).toBe(0);
+
+        // Instance A adds a new edge between the nodes
+        dbA.addEdge({ id: 'edge-xy', source: 'node-x', target: 'node-y', type: 'LINKS' });
+
+        // Without the #10260 fix, dbB.syncCache() would remove the edge ID from delta, 
+        // but it wouldn't clear 'node-x' or 'node-y' from vicinityLoadedNodes.
+        dbB.syncCache();
+        
+        // With #10260, they should no longer be marked as loaded
+        expect(dbB.vicinityLoadedNodes.has('node-x')).toBe(false);
+        expect(dbB.vicinityLoadedNodes.has('node-y')).toBe(false);
+
+        // A subsequent call to getAdjacentNodes triggers a SQLite fetch and hydrates the new edge
+        let adjacentToX = dbB.getAdjacentNodes('node-x');
+        expect(adjacentToX.length).toBe(1);
+        expect(adjacentToX[0].id).toBe('node-y');
+        expect(dbB.edges.getCount()).toBe(1);
+        expect(dbB.edges.get('edge-xy')).toBeTruthy();
+
+        dbA.destroy();
+        dbB.destroy();
+    });
 });


### PR DESCRIPTION
Authored by Gemini 3.1 Pro (Antigravity). Session 1c5933cc-a2d0-4296-ae3f-f4e815d385a2.

Resolves #10260

Updates the graph database cache synchronization (`Database.syncCache`) to explicitly invalidate the `vicinityLoadedNodes` state for the endpoints (source and target) of any added/removed edge. This closes the cross-process coherence gap where peer agents creating new edges wouldn't trigger hydration on existing nodes in the local cache.

## Deltas from ticket (if any)
None. Implemented exactly as requested. SQLite's `getDeltaLog` was updated to provide endpoint metadata efficiently by checking `Edges` for modified IDs when emitting deltas.

## Test Evidence
Ran Playwright unit tests for the Graph API.
Added a regression test to `Database.spec.mjs` verifying that adding an edge in Agent A causes Agent B's `syncCache()` to invalidate its cached endpoints, and that a subsequent `getAdjacentNodes()` successfully fetches the new edge.
All 11 Graph unit tests passed.

## Post-Merge Validation
- [ ] Verify that cross-agent ticket relationships propagate correctly in the live A2A setup.