### PR TITLE
feat(memory-core): graph identity normalization migration + @@ prefix strip (#10259)

### DIFF
--- a/ai/mcp/server/memory-core/services/MailboxService.mjs
+++ b/ai/mcp/server/memory-core/services/MailboxService.mjs
@@ -32,7 +32,9 @@ import SemanticGraphExtractor from '../../../../daemons/services/SemanticGraphEx
  * @private
  */
 function normalizeMailboxTarget(to) {
-    if (to?.startsWith('AGENT:@')) {
+    if (!to) return to;
+
+    if (to.startsWith('AGENT:@')) {
         return to.slice('AGENT:'.length)
     }
     // Strip accidental leading `@@` prefix (#10259). Defense-in-depth for misformed
@@ -41,8 +43,21 @@ function normalizeMailboxTarget(to) {
     // SENT_TO edge because `@@login` doesn't match any seeded AgentIdentity node.
     // Scope is intentionally minimal — only double-@ is stripped, not N-@ for N>2,
     // because N>2 is vanishingly rare and the single-prefix-strip handles the 99% case.
-    if (to?.startsWith('@@')) {
+    if (to.startsWith('@@')) {
         return to.slice(1)
+    }
+    // Prepend missing leading `@` (#10259 follow-up per tobi's polish request). This
+    // is the MORE COMMON typo than double-`@`: when an author writes the target as a
+    // bare GitHub login (`neo-gemini-3-1-pro`, `tobiu`) rather than the canonical
+    // `@`-prefixed form, normalize to the seeded AgentIdentity node ID. Prefix-absence
+    // check is load-bearing:
+    //   - `AGENT:*` / `AGENT:alice` — has `:`, preserved (sentinel + test-fixture paths)
+    //   - `role:librarian` / `human:tobiu` — has `:`, preserved (role/human addressing)
+    //   - bare `neo-opus-4-7` → `@neo-opus-4-7` (the case this branch exists for)
+    // Together with the `@@` strip above, this normalizes both directions of the
+    // single-typo surface. Anything with a colon or an existing `@` is passed through.
+    if (!to.startsWith('@') && !to.includes(':')) {
+        return '@' + to;
     }
     return to
 }

--- a/ai/mcp/server/memory-core/services/MailboxService.mjs
+++ b/ai/mcp/server/memory-core/services/MailboxService.mjs
@@ -35,6 +35,15 @@ function normalizeMailboxTarget(to) {
     if (to?.startsWith('AGENT:@')) {
         return to.slice('AGENT:'.length)
     }
+    // Strip accidental leading `@@` prefix (#10259). Defense-in-depth for misformed
+    // automation / ID copy-paste where the canonical `@login` form gets an extra `@`
+    // prepended inadvertently. Without this, `linkNodes`' FK-style guard culls the
+    // SENT_TO edge because `@@login` doesn't match any seeded AgentIdentity node.
+    // Scope is intentionally minimal — only double-@ is stripped, not N-@ for N>2,
+    // because N>2 is vanishingly rare and the single-prefix-strip handles the 99% case.
+    if (to?.startsWith('@@')) {
+        return to.slice(1)
+    }
     return to
 }
 

--- a/ai/scripts/normalizeGraphIdentities.mjs
+++ b/ai/scripts/normalizeGraphIdentities.mjs
@@ -1,0 +1,252 @@
+#!/usr/bin/env node
+/**
+ * @summary One-shot migration script that normalizes graph identity state by merging
+ * pre-#10144 alias `AgentIdentity` nodes into their canonical counterparts and
+ * purging test-fixture nodes that leaked into the production SQLite graph.
+ *
+ * Context: #10259. The `#10144` convention established `@neo-opus-4-7`,
+ * `@neo-gemini-3-1-pro`, `@tobiu` as canonical `AgentIdentity` nodes with full
+ * metadata (`githubLogin`, `modelFamily`, `accountType`). Pre-#10144 seeding left
+ * behind `@opus` and `@gemini` as orphan alias nodes with null metadata. Additionally,
+ * test-fixture nodes `AGENT:alice` and `AGENT:bob` from unit-test pollution (pre-#10229
+ * isolation fix) persist in the live SQLite. This script consolidates them.
+ *
+ * **Usage**:
+ *   node ai/scripts/normalizeGraphIdentities.mjs             # dry-run (default)
+ *   node ai/scripts/normalizeGraphIdentities.mjs --apply     # commit the migration
+ *   node ai/scripts/normalizeGraphIdentities.mjs --db <path> # override SQLite path
+ *   node ai/scripts/normalizeGraphIdentities.mjs --help      # print usage
+ *
+ * **Idempotent**: re-running after `--apply` is a safe no-op. The script detects
+ * already-purged aliases / test fixtures and skips them with a logged no-op notice.
+ *
+ * **Atomicity**: `--apply` wraps all writes in a single SQLite transaction. If any
+ * step fails, the transaction rolls back and the graph state is unchanged.
+ *
+ * **Duplicate-edge handling**: when an alias edge would duplicate an existing canonical
+ * edge (same source, target, type), the alias edge is dropped rather than rewritten.
+ * This preserves unique-edge invariants and handles the (rare) case where history
+ * wrote both alias-sourced and canonical-sourced edges for the same semantic relation.
+ *
+ * **What this script does NOT do**:
+ *   - ChromaDB metadata updates (orthogonal substrate; Chroma `userId` metadata rows
+ *     referencing `@opus`/`@gemini` remain as-is. Not load-bearing for mailbox routing
+ *     but a secondary cleanup if/when empirical demand surfaces.)
+ *   - DreamService / Retrospective daemon reindexing (memories/summaries referencing
+ *     the aliases become stale pointers; accept the staleness as low-frequency read path)
+ *   - Hot-reload in a running MCP process (restart harnesses after `--apply` to pick
+ *     up the clean graph state)
+ *
+ * @see learn/agentos/tooling/MemoryCoreMcpAuth.md §Identity Normalization Migration
+ */
+
+import path from 'node:path';
+import {fileURLToPath} from 'node:url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname  = path.dirname(__filename);
+const neoRoot    = path.resolve(__dirname, '../..');
+
+/**
+ * Canonical alias map. Key = alias node ID (to be merged / deleted).
+ * Value = canonical node ID (the surviving node that inherits the alias's edges).
+ *
+ * Verified against `ai/graph/identityRoots.mjs` IDENTITIES array at script-authoring
+ * time. If `identityRoots.mjs` gains new canonical identities in the future, this map
+ * may need extension for any corresponding legacy aliases.
+ */
+const ALIAS_MAP = {
+    '@opus'  : '@neo-opus-4-7',
+    '@gemini': '@neo-gemini-3-1-pro'
+};
+
+/**
+ * Test-fixture nodes that leaked into production SQLite from unit test runs prior to
+ * #10229's isolation refactor. These represent no real agent and should not exist in
+ * the live graph. Purging them cascades to any remaining orphan edges via the
+ * SQLite FK constraint (`ON DELETE CASCADE`).
+ */
+const PURGE_NODES = ['AGENT:alice', 'AGENT:bob'];
+
+function parseArgs(argv) {
+    const args = {apply: false, db: null, help: false};
+    for (let i = 2; i < argv.length; i++) {
+        const a = argv[i];
+        if (a === '--apply')       args.apply = true;
+        else if (a === '--help')   args.help = true;
+        else if (a === '--db')     args.db = argv[++i];
+        else {
+            console.error(`Unknown argument: ${a}`);
+            args.help = true;
+        }
+    }
+    return args;
+}
+
+function printUsage() {
+    console.log(`
+Usage: node ai/scripts/normalizeGraphIdentities.mjs [options]
+
+Options:
+  (no flags)     Dry-run mode — print the migration plan without committing
+  --apply        Commit the migration atomically in a single transaction
+  --db <path>    Override SQLite file path (default: .neo-ai-data/sqlite/memory-core-graph.sqlite)
+  --help         Print this usage message
+
+What it does:
+  1. Merge \`@opus\` → \`@neo-opus-4-7\` (rewrite edges, delete alias node)
+  2. Merge \`@gemini\` → \`@neo-gemini-3-1-pro\` (rewrite edges, delete alias node)
+  3. Purge \`AGENT:alice\` + \`AGENT:bob\` (test-fixture leakage, cascade-delete edges)
+
+After \`--apply\`, restart all MCP harnesses so their in-memory cache picks up the
+clean graph state. Long-running processes started before \`--apply\` will have stale
+references to the deleted alias nodes until they restart.
+`);
+}
+
+/**
+ * Core migration routine. Reads current state, plans rewrites + deletions, optionally
+ * applies them inside an atomic transaction.
+ *
+ * @param {import('better-sqlite3').Database} db — open SQLite connection
+ * @param {Boolean} apply — when true, commit the migration; when false, dry-run only
+ * @returns {{edgesRewritten: Number, edgesDropped: Number, nodesDeleted: Number, duplicateCollisions: Number, skipped: String[]}}
+ */
+function runMigration(db, apply) {
+    const stats = {
+        edgesRewritten     : 0,
+        edgesDropped       : 0,
+        nodesDeleted       : 0,
+        duplicateCollisions: 0,
+        skipped            : []
+    };
+
+    const work = () => {
+        // --- Phase 1: alias merge ---
+        for (const [alias, canonical] of Object.entries(ALIAS_MAP)) {
+            const canonicalRow = db.prepare('SELECT id FROM Nodes WHERE id = ?').get(canonical);
+            if (!canonicalRow) {
+                console.warn(`  [SKIP] canonical node ${canonical} missing — cannot merge ${alias}`);
+                stats.skipped.push(`canonical-missing:${canonical}`);
+                continue;
+            }
+
+            const aliasRow = db.prepare('SELECT id FROM Nodes WHERE id = ?').get(alias);
+            if (!aliasRow) {
+                console.log(`  [NO-OP] ${alias} already purged (idempotent)`);
+                stats.skipped.push(`alias-absent:${alias}`);
+                continue;
+            }
+
+            const aliasEdges = db.prepare(
+                'SELECT id, source, target, type FROM Edges WHERE source = ? OR target = ?'
+            ).all(alias, alias);
+
+            console.log(`  [MERGE] ${alias} → ${canonical}: ${aliasEdges.length} edge(s) to process`);
+
+            for (const edge of aliasEdges) {
+                const newSource = edge.source === alias ? canonical : edge.source;
+                const newTarget = edge.target === alias ? canonical : edge.target;
+
+                const duplicate = db.prepare(
+                    'SELECT id FROM Edges WHERE source = ? AND target = ? AND type = ? AND id != ?'
+                ).get(newSource, newTarget, edge.type, edge.id);
+
+                if (duplicate) {
+                    console.log(`    [DROP]  edge ${edge.id.slice(0, 8)} (${edge.type}): duplicate of ${duplicate.id.slice(0, 8)}`);
+                    if (apply) {
+                        db.prepare('DELETE FROM Edges WHERE id = ?').run(edge.id);
+                    }
+                    stats.edgesDropped++;
+                    stats.duplicateCollisions++;
+                } else {
+                    console.log(`    [REWRITE] edge ${edge.id.slice(0, 8)} (${edge.type}): ${edge.source} → ${newSource}, ${edge.target} → ${newTarget}`);
+                    if (apply) {
+                        db.prepare('UPDATE Edges SET source = ?, target = ? WHERE id = ?').run(newSource, newTarget, edge.id);
+                    }
+                    stats.edgesRewritten++;
+                }
+            }
+
+            console.log(`    [DELETE] alias node ${alias}`);
+            if (apply) {
+                db.prepare('DELETE FROM Nodes WHERE id = ?').run(alias);
+            }
+            stats.nodesDeleted++;
+        }
+
+        // --- Phase 2: test-fixture purge ---
+        for (const nodeId of PURGE_NODES) {
+            const row = db.prepare('SELECT id FROM Nodes WHERE id = ?').get(nodeId);
+            if (!row) {
+                console.log(`  [NO-OP] ${nodeId} already purged (idempotent)`);
+                stats.skipped.push(`purge-absent:${nodeId}`);
+                continue;
+            }
+
+            const edgeCount = db.prepare(
+                'SELECT COUNT(*) AS c FROM Edges WHERE source = ? OR target = ?'
+            ).get(nodeId, nodeId).c;
+
+            console.log(`  [PURGE] ${nodeId}: deleting node (cascades to ${edgeCount} edge(s))`);
+            if (apply) {
+                db.prepare('DELETE FROM Nodes WHERE id = ?').run(nodeId);
+            }
+            stats.nodesDeleted++;
+        }
+    };
+
+    if (apply) {
+        const transaction = db.transaction(work);
+        transaction();
+    } else {
+        work();
+    }
+
+    return stats;
+}
+
+async function main() {
+    const args = parseArgs(process.argv);
+    if (args.help) {
+        printUsage();
+        process.exit(0);
+    }
+
+    const dbPath = args.db || path.resolve(neoRoot, '.neo-ai-data/sqlite/memory-core-graph.sqlite');
+    console.log(`[normalizeGraphIdentities] target: ${dbPath}`);
+    console.log(`[normalizeGraphIdentities] mode:   ${args.apply ? 'APPLY' : 'DRY-RUN'}`);
+    console.log();
+
+    const Database = (await import('better-sqlite3')).default;
+    const db = new Database(dbPath, {verbose: null});
+
+    try {
+        const stats = runMigration(db, args.apply);
+
+        console.log();
+        console.log(`[normalizeGraphIdentities] summary:`);
+        console.log(`  edges rewritten:       ${stats.edgesRewritten}`);
+        console.log(`  edges dropped (dupes): ${stats.edgesDropped}`);
+        console.log(`  nodes deleted:         ${stats.nodesDeleted}`);
+        console.log(`  duplicate collisions:  ${stats.duplicateCollisions}`);
+        console.log(`  skipped (no-ops):      ${stats.skipped.length}`);
+
+        if (!args.apply) {
+            console.log();
+            console.log(`[normalizeGraphIdentities] DRY-RUN complete. No changes applied.`);
+            console.log(`[normalizeGraphIdentities] Re-run with --apply to commit.`);
+        } else {
+            console.log();
+            console.log(`[normalizeGraphIdentities] APPLY complete. Migration committed.`);
+            console.log(`[normalizeGraphIdentities] Restart all MCP harnesses to pick up clean graph state.`);
+        }
+    } finally {
+        db.close();
+    }
+}
+
+main().catch(err => {
+    console.error('[normalizeGraphIdentities] FATAL:', err);
+    process.exit(1);
+});

--- a/learn/agentos/tooling/MemoryCoreMcpAuth.md
+++ b/learn/agentos/tooling/MemoryCoreMcpAuth.md
@@ -295,6 +295,65 @@ The `CAN_REPLY_TO` enforcement on `addMessage` is a **deployment-selected defaul
 
 **Multi-user / multi-tenant deployment guidance:** set `defaultReplyPolicy: 'blocked'` in the deployment's `config.mjs` as part of installation. Every cross-tenant DM then requires an explicit grant via `grant_permission`, enforced at the write path. Tenant onboarding provisions grants for the internal peers that need to communicate; anything outside the grant topology is rejected.
 
+## Identity Normalization Migration (#10259)
+
+If your SQLite graph predates the `#10144` canonical `AgentIdentity` convention, it may contain stale alias nodes (`@opus`, `@gemini`) with null metadata alongside the canonical nodes (`@neo-opus-4-7`, `@neo-gemini-3-1-pro`). It may also contain test-fixture nodes (`AGENT:alice`, `AGENT:bob`) that leaked from pre-`#10229` unit test runs. Both cause routing ambiguity: replies addressed to an alias don't reach the canonical inbox, and test-fixture nodes pollute graph-traversal results.
+
+The `ai/scripts/normalizeGraphIdentities.mjs` script consolidates the graph in a single idempotent operation.
+
+### Running the migration
+
+**1. Dry-run first (default):**
+
+```bash
+node ai/scripts/normalizeGraphIdentities.mjs
+```
+
+Prints the migration plan — which edges would be rewritten, which nodes would be deleted, and any duplicate-edge collisions the canonical consolidation would encounter. Exits without committing.
+
+**2. Review the plan, then apply atomically:**
+
+```bash
+node ai/scripts/normalizeGraphIdentities.mjs --apply
+```
+
+Wraps all writes in a single SQLite transaction. If any step fails, the transaction rolls back and the graph state is unchanged.
+
+**3. Restart all MCP harnesses** (⌘Q + relaunch for Claude Desktop / Antigravity) so their in-memory cache picks up the clean graph state. Long-running processes started before `--apply` retain stale references to the deleted alias nodes until they restart.
+
+### Verifying outcome
+
+After `--apply` + harness restart, the SQLite inventory should show exactly 4 `AgentIdentity` nodes plus 1 `BroadcastSentinel`:
+
+```bash
+sqlite3 .neo-ai-data/sqlite/memory-core-graph.sqlite \
+  "SELECT id, json_extract(data, '\$.label') as label FROM Nodes WHERE id LIKE '@%' OR json_extract(data, '\$.label') IN ('AgentIdentity', 'BroadcastSentinel', 'AGENT') ORDER BY id"
+```
+
+Expected result:
+```
+@neo-gemini-3-1-pro | AgentIdentity
+@neo-opus-4-7       | AgentIdentity
+@tobiu              | AgentIdentity
+AGENT:*             | BroadcastSentinel
+```
+
+No `@opus`, `@gemini`, `AGENT:alice`, or `AGENT:bob` should appear.
+
+### Idempotent re-runs
+
+The script is safe to re-run after `--apply`. If an alias has already been purged, the script logs `[NO-OP] ... already purged (idempotent)` and skips it. This matters for disaster-recovery scenarios where the script may be re-invoked as part of a broader graph-sanity check.
+
+### What the migration does NOT do
+
+- **ChromaDB metadata** referencing the old aliases remains as-is. Not load-bearing for mailbox routing; secondary cleanup if empirical demand surfaces.
+- **DreamService / Retrospective daemon** indices that reference the aliases become stale pointers. Accept as low-frequency read-path trade-off.
+- **Hot-reload in a running MCP process** is unsupported — restart is required for cache refresh.
+
+### Accidental `@@` prefix handling
+
+Independent of the migration: `MailboxService.normalizeMailboxTarget` (#10259) strips accidental double-`@` prefixes (`@@login` → `@login`) to defend against misformed automation or ID copy-paste errors. Without this, `linkNodes`' FK-style guard would silently cull the `SENT_TO` edge because `@@login` doesn't match any seeded AgentIdentity node.
+
 ## See Also
 
 - `ai/mcp/server/shared/services/AuthService.mjs` — OIDC discovery and token introspection

--- a/learn/agentos/tooling/MemoryCoreMcpAuth.md
+++ b/learn/agentos/tooling/MemoryCoreMcpAuth.md
@@ -350,9 +350,16 @@ The script is safe to re-run after `--apply`. If an alias has already been purge
 - **DreamService / Retrospective daemon** indices that reference the aliases become stale pointers. Accept as low-frequency read-path trade-off.
 - **Hot-reload in a running MCP process** is unsupported — restart is required for cache refresh.
 
-### Accidental `@@` prefix handling
+### Accidental prefix normalization
 
-Independent of the migration: `MailboxService.normalizeMailboxTarget` (#10259) strips accidental double-`@` prefixes (`@@login` → `@login`) to defend against misformed automation or ID copy-paste errors. Without this, `linkNodes`' FK-style guard would silently cull the `SENT_TO` edge because `@@login` doesn't match any seeded AgentIdentity node.
+Independent of the migration: `MailboxService.normalizeMailboxTarget` (#10259) handles the two single-typo prefix surfaces symmetrically:
+
+- **Missing `@`** (more common): bare GitHub login → prepend `@`. `gemini` → `@gemini`, `neo-opus-4-7` → `@neo-opus-4-7`.
+- **Accidental `@@`** (less common): double-prefix → single-prefix. `@@login` → `@login`.
+
+The missing-`@` branch is scoped to identifiers that carry NO prefix marker (no leading `@`, no `:` anywhere in the string). Targets with `:` — `AGENT:alice` (test fixture), `AGENT:*` (broadcast sentinel), `role:librarian`, `human:tobiu` — are passed through unchanged. This preserves every existing addressing convention while catching both directions of the single-character typo.
+
+Without these normalizations, `GraphService.linkNodes`' FK-style guard would silently cull the `SENT_TO` edge when the raw target doesn't match any seeded AgentIdentity node — an invisible failure mode.
 
 ## See Also
 

--- a/test/playwright/unit/ai/mcp/server/memory-core/services/MailboxService.spec.mjs
+++ b/test/playwright/unit/ai/mcp/server/memory-core/services/MailboxService.spec.mjs
@@ -582,6 +582,62 @@ test.describe('Neo.ai.mcp.server.memory-core.services.MailboxService', () => {
             expect(inbox.messages[0].subject).toBe('prefixed');
         });
 
+        test('#10259 missing `@` prefix auto-prepends to canonical `@login`', async () => {
+            // The MORE COMMON typo case per tobi's polish request: author writes a bare
+            // GitHub login (`gemini`) rather than the canonical `@`-prefixed form. Without
+            // normalization, `linkNodes`' FK guard culls the SENT_TO edge because `gemini`
+            // is not a seeded AgentIdentity node. With the prepend, it routes to the
+            // canonical `@gemini` seed and the recipient sees the message.
+            await RequestContextService.run({ agentIdentityNodeId: '@gemini' }, async () => {
+                await PermissionService.grantPermission({ to: '@opus', scope: 'CAN_REPLY_TO' });
+            });
+
+            let messageId;
+            await RequestContextService.run({ agentIdentityNodeId: '@opus' }, async () => {
+                const res = await MailboxService.addMessage({ to: 'gemini', subject: 'missing-prefix', body: 'body' });
+                expect(res.status).toBe('sent');
+                messageId = res.messageId;
+
+                const sentToEdge = GraphService.db.edges.items.find(
+                    e => e.source === messageId && e.type === 'SENT_TO'
+                );
+                expect(sentToEdge).toBeDefined();
+                // Must be the canonical `@`-prefixed form, NOT the raw bare input.
+                expect(sentToEdge.target).toBe('@gemini');
+            });
+
+            const inbox = await RequestContextService.run({ agentIdentityNodeId: '@gemini' }, async () => {
+                return await MailboxService.listMessages({ box: 'inbox' });
+            });
+            expect(inbox.messages.find(m => m.subject === 'missing-prefix')).toBeDefined();
+        });
+
+        test('#10259 missing-prefix normalization preserves `AGENT:<bareName>` test-fixture pattern', async () => {
+            // Load-bearing negative test: `AGENT:bob` should NOT be transformed to
+            // `@AGENT:bob`. The `includes(':')` guard in normalizeMailboxTarget must
+            // preserve the fixture path. Also covers `role:`/`human:` target patterns
+            // by the same mechanism. Without this invariant, existing spec scenarios
+            // seeded with `AGENT:alice` / `role:librarian` / `human:tobiu` would break.
+            GraphService.upsertNode({ id: 'AGENT:bob', type: 'AGENT', name: 'Bob', properties: {} });
+
+            await RequestContextService.run({ agentIdentityNodeId: 'AGENT:bob' }, async () => {
+                await PermissionService.grantPermission({ to: 'AGENT:alice', scope: 'CAN_REPLY_TO' });
+            });
+
+            let messageId;
+            await RequestContextService.run({ agentIdentityNodeId: 'AGENT:alice' }, async () => {
+                const res = await MailboxService.addMessage({ to: 'AGENT:bob', subject: 'fixture-preserved', body: 'body' });
+                expect(res.status).toBe('sent');
+                messageId = res.messageId;
+
+                const sentToEdge = GraphService.db.edges.items.find(
+                    e => e.source === messageId && e.type === 'SENT_TO'
+                );
+                expect(sentToEdge).toBeDefined();
+                expect(sentToEdge.target).toBe('AGENT:bob');  // unchanged
+            });
+        });
+
         test('#10259 accidental `@@login` double-prefix normalizes to canonical `@login`', async () => {
             // Defense-in-depth per #10259: if misformed automation or ID copy-paste
             // sends `to: '@@gemini'`, the normalizeMailboxTarget strip brings it back

--- a/test/playwright/unit/ai/mcp/server/memory-core/services/MailboxService.spec.mjs
+++ b/test/playwright/unit/ai/mcp/server/memory-core/services/MailboxService.spec.mjs
@@ -582,6 +582,37 @@ test.describe('Neo.ai.mcp.server.memory-core.services.MailboxService', () => {
             expect(inbox.messages[0].subject).toBe('prefixed');
         });
 
+        test('#10259 accidental `@@login` double-prefix normalizes to canonical `@login`', async () => {
+            // Defense-in-depth per #10259: if misformed automation or ID copy-paste
+            // sends `to: '@@gemini'`, the normalizeMailboxTarget strip brings it back
+            // to the canonical `@gemini` form before linkNodes' FK-style guard runs.
+            // Without the strip, the SENT_TO edge gets culled because `@@gemini` is
+            // not a seeded AgentIdentity node.
+            await RequestContextService.run({ agentIdentityNodeId: '@gemini' }, async () => {
+                await PermissionService.grantPermission({ to: '@opus', scope: 'CAN_REPLY_TO' });
+            });
+
+            let messageId;
+            await RequestContextService.run({ agentIdentityNodeId: '@opus' }, async () => {
+                const res = await MailboxService.addMessage({ to: '@@gemini', subject: 'double-prefix', body: 'body' });
+                expect(res.status).toBe('sent');
+                messageId = res.messageId;
+
+                const sentToEdge = GraphService.db.edges.items.find(
+                    e => e.source === messageId && e.type === 'SENT_TO'
+                );
+                expect(sentToEdge).toBeDefined();
+                // Must be the canonical single-@ form, NOT the raw double-@ input.
+                expect(sentToEdge.target).toBe('@gemini');
+            });
+
+            // Recipient bound under bare `@gemini` sees the message via listMessages.
+            const inbox = await RequestContextService.run({ agentIdentityNodeId: '@gemini' }, async () => {
+                return await MailboxService.listMessages({ box: 'inbox' });
+            });
+            expect(inbox.messages.find(m => m.subject === 'double-prefix')).toBeDefined();
+        });
+
         test('`AGENT:*` broadcast creates SENT_TO edge to the seeded sentinel and fans out', async () => {
             let messageId;
             await RequestContextService.run({ agentIdentityNodeId: '@opus' }, async () => {


### PR DESCRIPTION
Authored by Claude Opus 4.7 (Claude Code). Session `29f490c0-41ed-4846-a767-287552d5c3c4`.

Resolves #10259

## Summary

Consolidates graph identity state by merging pre-#10144 alias `AgentIdentity` nodes (`@opus`, `@gemini`) into their canonical counterparts (`@neo-opus-4-7`, `@neo-gemini-3-1-pro`), purging test-fixture leakage (`AGENT:alice`, `AGENT:bob`) from production SQLite, and extending `MailboxService.normalizeMailboxTarget` to strip accidental `@@` double-prefix inputs. Closes the routing-ambiguity gap observed empirically this session when `@opus`-addressed replies didn't reach `@neo-opus-4-7`'s canonical inbox.

## Scope

| File | Delta | Purpose |
|---|---|---|
| `ai/scripts/normalizeGraphIdentities.mjs` (new) | +234 | One-shot migration: dry-run default, `--apply` atomic transaction, idempotent re-run safe, duplicate-edge collision handling |
| `ai/mcp/server/memory-core/services/MailboxService.mjs` | +10 / -0 | `normalizeMailboxTarget` strips `@@` → `@` with inline rationale |
| `test/playwright/unit/ai/mcp/server/memory-core/services/MailboxService.spec.mjs` | +30 / -0 | New regression test: `@@login` routing via the existing #10174 production-convention describe block |
| `learn/agentos/tooling/MemoryCoreMcpAuth.md` | +77 / -0 | New `§Identity Normalization Migration` section — operator runbook, dry-run instructions, verification query, idempotency guarantees, scope boundaries |

**Net delta**: +351 / -0 across 4 files. Zero deletions in existing code.

## Empirical Dry-Run

Against the live dev SQLite at the time of this PR:

```
$ node ai/scripts/normalizeGraphIdentities.mjs
[normalizeGraphIdentities] target: /Users/.../memory-core-graph.sqlite
[normalizeGraphIdentities] mode:   DRY-RUN

  [MERGE] @opus → @neo-opus-4-7: 2 edge(s) to process
    [REWRITE] edge de9f1843 (SENT_BY): @opus → @neo-opus-4-7
    [REWRITE] edge 93dafda4 (SENT_TO): @opus → @neo-opus-4-7
    [DELETE] alias node @opus
  [MERGE] @gemini → @neo-gemini-3-1-pro: 0 edge(s) to process
    [DELETE] alias node @gemini
  [PURGE] AGENT:alice: deleting node (cascades to 0 edge(s))
  [PURGE] AGENT:bob: deleting node (cascades to 0 edge(s))

[normalizeGraphIdentities] summary:
  edges rewritten:       2
  edges dropped (dupes): 0
  nodes deleted:         4
  duplicate collisions:  0
  skipped (no-ops):      0

[normalizeGraphIdentities] DRY-RUN complete. No changes applied.
[normalizeGraphIdentities] Re-run with --apply to commit.
```

After `--apply` + harness restart, Gemini's `MESSAGE:64a3ba28-...` ("Re: hello all") that was stuck routing to `@opus` will reach my canonical `@neo-opus-4-7` inbox.

## Test Evidence

```
$ npm run test-unit -- test/playwright/unit/ai/mcp/server/memory-core/services/MailboxService.spec.mjs
25 passed (1.1s)
```

Full suite green including the new `#10259 accidental @@login double-prefix normalizes to canonical @login` test in the `#10174 production-convention addressing` describe block. Positive case: `@@gemini` → `@gemini` SENT_TO edge + recipient sees message.

## Design Decisions

**Migration vs. alias-redirect topology**: considered adding a `CANONICAL_ALIAS` edge type that mailbox routing transparently follows (non-destructive). Rejected — preserving aliases via redirect adds read-path complexity for every mailbox operation without clear benefit. The canonical nodes have all the metadata; the aliases have none. Graph-level merge is cleaner.

**Dry-run default**: intentional. Tobi-owned graph state is not something a script should rewrite without operator review. Dry-run output prints the exact plan (which edges, which nodes) so operators can audit before committing. `--apply` is explicit consent.

**Duplicate-edge collision handling**: when an alias edge would duplicate an existing canonical edge (same source, target, type), drop the alias edge rather than UPDATE-ing it into a position that creates the duplicate. Handles the (rare) case where both alias and canonical had SENT_BY edges from the same message due to pre-#10144 history drift.

**`@@` strip scope**: intentionally minimal. Only double-`@` is stripped, not N-`@` for N > 2. Triple-plus-prefix errors are vanishingly rare and the single-prefix-strip handles the 99% case without opening a surface for pathological inputs.

**Script location**: `ai/scripts/` follows the existing convention (`seedAgentIdentities.mjs`, `diagnoseMcpConcurrency.mjs`, `bootstrapWorktree.mjs`, etc.). Not under `buildScripts/ai/` because it's an operator-invoked graph-maintenance tool, not a build/dream-pipeline step.

## Post-merge Validation Checklist

- [ ] Tobi runs `node ai/scripts/normalizeGraphIdentities.mjs` (dry-run) on his primary SQLite, reviews the plan
- [ ] `node ai/scripts/normalizeGraphIdentities.mjs --apply` to commit
- [ ] ⌘Q + relaunch all MCP harnesses so in-memory cache picks up the clean graph state
- [ ] Verify via SQLite inventory: only 4 `AgentIdentity` nodes + 1 `BroadcastSentinel`; no `@opus`/`@gemini`/`AGENT:alice`/`AGENT:bob`
- [ ] Gemini's `list_messages` on the `Re: hello all` thread (`64a3ba28`) now surfaces in `@neo-opus-4-7`'s inbox rather than `@opus`'s
- [ ] Empirical A2A round-trip: Gemini DMs me, reply threads through `@neo-opus-4-7` cleanly regardless of which message she's replying to

## Parallel Coordination

Gemini is working `#10260` (syncCache edge-endpoint vicinity invalidation) in parallel on `agent/10260-synccache-edge-endpoint`. Zero file overlap with this PR — her branch touches `ai/graph/Database.mjs` + `ai/graph/storage/SQLite.mjs`; mine touches `ai/scripts/` + `ai/mcp/server/memory-core/services/MailboxService.mjs` + `MemoryCoreMcpAuth.md`. Either merge order is clean.

Once both land + tobi runs the `--apply` migration + harness restart, the full `#10139` A2A target (end-to-end, cross-process, no manual SQLite query, canonical-identity routing) is empirically satisfied.

## Cross-family Review

Requesting review from @neo-gemini-3-1-pro per pull-request §6.1 mandate. Her structural-review lens on the migration script's edge-rewrite logic + the duplicate-collision edge case would be valuable — the alias-merge algorithm is where subtle data-integrity bugs hide.

## Handoff

Per pull-request §6.2 (Human-in-the-Loop), halting for human QA + cross-family review.