### PR TITLE
docs(ai): formalize isolation test patterns and document identity race fix (#10245)

### DIFF
--- a/.agent/skills/debugging-antigravity/references/debugging-guide.md
+++ b/.agent/skills/debugging-antigravity/references/debugging-guide.md
@@ -91,3 +91,20 @@ If the spinner persists but the backend servers are healthy:
    rm -rf ~/Library/Application\ Support/Antigravity/Cache
    rm -rf ~/Library/Application\ Support/Antigravity/GPUCache
    ```
+
+## 5. The Fresh MCP Client Isolation Strategy (Cache Bypass)
+
+### The Problem
+Agents operating on MCP servers they themselves are connected to often suffer from "ghost bugs" — where the agent's context or cached tool definitions do not match the live server state. If you modify an MCP tool definition (e.g., adding a new parameter) and attempt to test it via your own primary connection, you will hit a stale cache window. The server has updated, but your host client has not re-handshaked to discover the new shape.
+
+### The Fix
+Never use your own primary tool surface to validate tool-shape changes on the server you are modifying. Instead, use the **Fresh MCP Client Isolation Strategy**.
+
+The `ai/mcp/client` infrastructure allows you to spawn a completely clean, isolated client-server connection, bypassing the agent's primary long-lived host connection.
+
+**Empirical Verification Example:**
+To verify a tool shape change (e.g., in `memory-core`), spawn a fresh client via CLI:
+```bash
+node ai/mcp/client/mcp-cli.mjs --server memory-core --call-tool "your_modified_tool" '{"param": "test"}'
+```
+This forces a clean handshake, parsing the live tool definitions directly from the server process, proving whether your tool-shape changes are actually valid without restarting the entire IDE harness.

--- a/.agent/skills/pr-review/references/pr-review-guide.md
+++ b/.agent/skills/pr-review/references/pr-review-guide.md
@@ -69,6 +69,9 @@ The Retrospective daemon explicitly regex-matches these tags during REM sleep:
 *   **Required Actions:** Clearly list a bulleted checklist of mandatory changes required before the PR can be accepted.
 *   **Zero-Issue PR Semantics:** If a PR has no required actions, replace the checkbox list with a single explicit sentence: *"No required actions — ready to merge."* Do NOT pre-tick placeholder items (e.g., `- [x] All checks pass and no required changes identified.`) — that reads as box-checking rather than genuine review. Null state is its own form; don't dress it as action.
 
+### 5.1 Suggesting Empirical Isolation Tests
+When challenging a specific architectural pattern or complex implementation detail as suspect (e.g., an unnecessary retry loop, an overly complex state sync), you should explicitly suggest the author perform an **Empirical Isolation Test**. Instead of engaging in a theoretical debate, ask the author to temporarily disable or strip the challenged pattern and run a binary isolation test to prove or disprove its necessity. This shifts the review from architectural argument to empirical verification.
+
 ## 6. The Review Template
 When drafting your review, use the `view_file` tool to load the exact markdown template from:
 `/Users/Shared/github/neomjs/neo/.agent/skills/pr-review/assets/pr-review-template.md`

--- a/.agent/skills/pr-review/references/pr-review-guide.md
+++ b/.agent/skills/pr-review/references/pr-review-guide.md
@@ -94,6 +94,8 @@ If no such concern exists, the reviewer MUST explicitly document the search:
 
 The search documentation is not optional filler — it's the reviewer proving they looked. A peer-review with neither a challenge nor a documented search fails the Depth Floor, regardless of structural compliance elsewhere.
 
+**Note on Resolution Paths:** If your challenge raises a "this pattern is suspect" claim or architectural dispute, refer to **§5.1 Suggesting Empirical Isolation Tests** as the preferred path for resolving the concern empirically rather than via theoretical debate.
+
 Self-reviews (§1) already have an analogous requirement ("actively hunt for blind spots"); §7.1 extends the discipline to peer-reviews.
 
 ### 7.2 Cross-Model Asymmetry Context

--- a/.agent/skills/pull-request/references/pull-request-workflow.md
+++ b/.agent/skills/pull-request/references/pull-request-workflow.md
@@ -204,6 +204,14 @@ End the Addressed comment with `Re-review requested.` to signal the reviewer tha
 
 PR #10161 (MemorySessionIngestor) received a `Status: Request Changes` review with one Required Action (*add `SESSION` and `MEMORY` labels to `GraphService.getOrphanedNodes` protection list*). The author pushed fix commit `c0cfb08bf`, then posted a structured Addressed comment mapping the commit SHA to the Required Action with the `[ADDRESSED]` tag, ending in `Re-review requested.` This is the first observed instance of the protocol and validates the structural ingestibility of the tag taxonomy.
 
+### 7.10 The Empirical "Isolation-Test-After-Review" Pattern
+
+When a reviewer challenges an architectural pattern in your PR (e.g., claiming it violates a paradigm or introduces unnecessary complexity), you have two valid paths to resolve the dispute:
+1. **Document the Necessity:** Explain theoretically why the pattern is load-bearing.
+2. **Empirical Isolation Test (Preferred):** Run a binary isolation test. Disable or strip the challenged pattern, reboot the harness, and observe if the system still functions or if the specific failure mode returns. 
+
+If the isolation test proves the pattern is dead weight, remove it and document the empirical finding in your response. If the test proves the pattern is required, document the failure mode that occurred when it was removed. This pattern converts theoretical architectural arguments into clean, empirical results rapidly and respectfully.
+
 ## 8. PR Comment Hygiene (Polish vs. Pivot)
 
 When performing self-reviews or responding to feedback across multiple rounds, you must distinguish between "polish" (better execution of the same idea) and "pivot" (a change in architectural direction).

--- a/.agent/skills/self-repair/references/self-repair-protocol.md
+++ b/.agent/skills/self-repair/references/self-repair-protocol.md
@@ -26,6 +26,11 @@ If the IDE integration or workspace is locking up during health checks:
 
 - Reference the **`debugging-antigravity`** skill. Follow its playbook to resolve Antigravity IDE configuration lockups, SQLite workspace UI crashes, and redundant language server conflicts.
 
+If you are developing or testing MCP servers and encounter "ghost bugs" where your cached tool definitions do not match the live server state:
+
+- **Use the Fresh MCP Client Primitive**: Agents testing their own connected MCP servers suffer from stale cache windows. Never use your primary tool surface to validate your own MCP tool-shape modifications.
+- **Action**: Bypass your primary long-lived host connection by spawning an isolated client. Execute `node ai/mcp/client/mcp-cli.mjs --server <target> --call-tool <tool>` via the `run_command` tool. This performs a clean handshake and parses the live definitions directly, proving your modifications are valid.
+
 ## Phase 4: Treatment & Issue Escalation
 If you identify infrastructure degradation or failing Playwright tests:
 

--- a/ai/mcp/server/memory-core/services/MailboxService.mjs
+++ b/ai/mcp/server/memory-core/services/MailboxService.mjs
@@ -146,11 +146,11 @@ class MailboxService extends Base {
         // treatment is intentional per #10252's Out of Scope.
         const strictReplyPolicy = aiConfig.mailbox?.defaultReplyPolicy === 'blocked';
 
-        // BLOCKED_BY check fires in BOTH reply-policy modes — operator explicit blocks
-        // always override both the 'open' default-allow AND the 'blocked'-mode reachable-
-        // counterparty trust-lift. Block wins; re-granting CAN_REPLY_TO does not silently
-        // re-enable reach. To restore reach, the recipient must explicitly revokePermission
-        // the BLOCKED_BY edge.
+        // @summary Defensive guard enforcing the "Block Wins" negative-intent primitive (#10255).
+        // Fires in BOTH reply-policy modes ('open' and 'blocked').
+        // Explicit blocks override both the 'open' default-allow AND the 'blocked'-mode
+        // reachable-counterparty trust-lift. Re-granting CAN_REPLY_TO does not silently
+        // re-enable reach. To restore reach, the recipient must revoke the BLOCKED_BY edge.
         if (!isRoleOrHuman && to !== 'AGENT:*' && to !== sentBy) {
             if (PermissionService.hasPermission(sentBy, to, 'BLOCKED_BY')) {
                 throw new Error(`Unauthorized: ${to} has blocked messages from ${sentBy}.`);

--- a/ai/mcp/server/memory-core/services/PermissionService.mjs
+++ b/ai/mcp/server/memory-core/services/PermissionService.mjs
@@ -38,6 +38,8 @@ class PermissionService extends Base {
     /**
      * @member {String[]} validScopes
      * @protected
+     * @summary Whitelist of semantic edge types for agent-to-agent permissions.
+     * Includes BLOCKED_BY: A negative-intent primitive ensuring hard isolation overrides (e.g. #10255).
      */
     validScopes = ['CAN_READ_INBOX_OF', 'CAN_READ_MEMORIES_OF', 'CAN_READ_SESSIONS_OF', 'CAN_REPLY_TO', 'BLOCKED_BY']
 

--- a/learn/agentos/tooling/MemoryCoreMcpAuth.md
+++ b/learn/agentos/tooling/MemoryCoreMcpAuth.md
@@ -193,6 +193,12 @@ Startup log reads `Identity: tobiu via gh-cli — unbound (no matching AgentIden
 - For a new per-model account, add the identity to the `IDENTITIES` array in `ai/graph/identityRoots.mjs` (the shared source consumed by both boot-time self-seed and the CLI) before running.
 - Post-#10232, boot-time self-seed should provision missing root identities automatically. If `bound` stays false after a restart cycle with a populated graph, investigate whether `GraphService.initAsync` is reaching the self-seed block — check startup logs for errors.
 
+### Boot-Time Identity Race Condition (Cross-Process WAL Lock Contention)
+
+If the `identity.bound` status intermittently fails at boot despite the graph node existing, this is likely a cross-process SQLite WAL lock contention issue (empirically observed between the Antigravity hardlinked process and other local agents). During concurrent boot, read operations like `GraphService.getNode` may silently fail if another process holds an exclusive write lock (`SQLITE_BUSY`) and no timeout is configured.
+
+**The Fix:** Ensure that `pragma busy_timeout = 5000` is applied to the SQLite connection (`ai/graph/storage/SQLite.mjs`). This is the native, architectural solution to cross-process contention. Adding arbitrary retry loops in application code masks the underlying `SQLITE_BUSY` error and should be avoided.
+
 ### Startup-log fallback (pre-#10176 environments or logging-only workflows)
 
 The `[neo-memory-core MCP] Identity: <userId> via <source> — bound to <nodeId>` log line is still emitted at boot by `logIdentityStatus` and remains usable as a fallback diagnostic. The healthcheck block supersedes it for live diagnostics because a single tool call returns structured JSON the agent can branch on; log-grep requires filesystem access to the MCP stdout capture.

--- a/learn/agentos/tooling/MemoryCoreMcpAuth.md
+++ b/learn/agentos/tooling/MemoryCoreMcpAuth.md
@@ -197,7 +197,11 @@ Startup log reads `Identity: tobiu via gh-cli — unbound (no matching AgentIden
 
 If the `identity.bound` status intermittently fails at boot despite the graph node existing, this is likely a cross-process SQLite WAL lock contention issue (empirically observed between the Antigravity hardlinked process and other local agents). During concurrent boot, read operations like `GraphService.getNode` may silently fail if another process holds an exclusive write lock (`SQLITE_BUSY`) and no timeout is configured.
 
-**The Fix:** Ensure that `pragma busy_timeout = 5000` is applied to the SQLite connection (`ai/graph/storage/SQLite.mjs`). This is the native, architectural solution to cross-process contention. Adding arbitrary retry loops in application code masks the underlying `SQLITE_BUSY` error and should be avoided.
+**Fix (two layers):**
+1. `pragma busy_timeout = 5000` on the SQLite connection (`ai/graph/storage/SQLite.mjs`) — addresses the SQLITE_BUSY-throw variant of cross-process contention. Necessary but not sufficient.
+2. `await GraphService.getNode({id})` in `bindAgentIdentity` (`ai/mcp/server/memory-core/Server.mjs`) — addresses the Promise-unwrap variant. Neo's singleton method wrapper returns a Promise that must be awaited before reading `.id`; without it, the bind silently latches `undefined`. See #10249 / PR #10250.
+
+Retry loops targeting this specific race are correctly rejected — the underlying causes are addressable at the substrate (timeout pragma + await unwrap). Note: retry patterns with cache invalidation (`vicinityLoadedNodes.delete` + re-read) are architecturally distinct and remain valid for *different* bug classes like cross-process cache coherence (see #10258 / PR #10261).
 
 ### Startup-log fallback (pre-#10176 environments or logging-only workflows)
 

--- a/test/playwright/unit/ai/mcp/server/memory-core/services/PermissionService.spec.mjs
+++ b/test/playwright/unit/ai/mcp/server/memory-core/services/PermissionService.spec.mjs
@@ -47,6 +47,11 @@ test.describe('Neo.ai.mcp.server.memory-core.services.PermissionService', () => 
         }
         
         originalAutoSave = GraphService.db.autoSave;
+        
+        // @summary Enables autoSave for the duration of the test suite (#10256).
+        // This is necessary because these tests assert SQLite state via direct queries.
+        // Without autoSave = true, the memory-state and disk-state may diverge,
+        // causing intermittent assertion failures in serial mode.
         GraphService.db.autoSave = true;
     });
 


### PR DESCRIPTION
Authored by Gemini 3.1 Pro (Antigravity). Session 1c5933cc-a2d0-4296-ae3f-f4e815d385a2.

Resolves #10245
Resolves #10247
Resolves #10244

This PR adds the "Empirical Isolation-Test-After-Review" pattern to the PR review and pull request skills, guiding agents to resolve architectural disputes via binary isolation tests rather than theoretical debate. It also adds a troubleshooting section to `MemoryCoreMcpAuth.md` to document the cross-process SQLite WAL lock contention and `pragma busy_timeout = 5000` fix.
In addition, this PR formally commits the `Fresh MCP Client Isolation Strategy` added to `.agent/skills/debugging-antigravity/references/debugging-guide.md` and `.agent/skills/self-repair/references/self-repair-protocol.md` from the previous session.

## Deltas from ticket (if any)
Merged the isolation test documentation (tickets 10245 and 10247) with the WAL lock contention documentation (ticket 10244) and the pending Fresh MCP Client Isolation Strategy documentation into a single atomic documentation PR.