### PR TITLE
test(core): enable autoSave in PermissionService spec (#10256)

### DIFF
--- a/resources/content/.sync-metadata.json
+++ b/resources/content/.sync-metadata.json
@@ -1,6 +1,6 @@
 {
-  "lastSync": "2026-04-23T21:32:34.711Z",
-  "releasesLastFetched": "2026-04-23T21:32:42.086Z",
+  "lastSync": "2026-04-23T21:30:52.347Z",
+  "releasesLastFetched": "2026-04-23T21:31:01.748Z",
   "pushFailures": [],
   "issues": {
     "3789": {

--- a/test/playwright/unit/ai/mcp/server/memory-core/services/PermissionService.spec.mjs
+++ b/test/playwright/unit/ai/mcp/server/memory-core/services/PermissionService.spec.mjs
@@ -20,7 +20,8 @@ import Neo                   from '../../../../../../../../src/Neo.mjs';
 import RequestContextService from '../../../../../../../../ai/mcp/server/shared/services/RequestContextService.mjs';
 
 test.describe('Neo.ai.mcp.server.memory-core.services.PermissionService', () => {
-    let PermissionService, GraphService, LifecycleService;
+    test.describe.configure({ mode: 'serial' });
+    let PermissionService, GraphService, LifecycleService, originalAutoSave;
     let dbPath;
 
     test.beforeAll(async () => {
@@ -44,9 +45,13 @@ test.describe('Neo.ai.mcp.server.memory-core.services.PermissionService', () => 
         } else {
             await LifecycleService.ready();
         }
+        
+        originalAutoSave = GraphService.db.autoSave;
+        GraphService.db.autoSave = true;
     });
 
     test.afterAll(async () => {
+        GraphService.db.autoSave = originalAutoSave;
         if (fs.existsSync(dbPath)) {
             try { fs.unlinkSync(dbPath); } catch (e) {}
             try { fs.unlinkSync(dbPath + '-wal'); } catch (e) {}


### PR DESCRIPTION
Resolves #10256 by enabling autoSave in PermissionService spec so SQLite state is flushed before tests execute direct SQL assertions.