### PR TITLE
feat(memory-core): multi-tenant migration design + observability + write-side invariant pin (#10017)

### DIFF
--- a/ai/mcp/server/memory-core/services/HealthService.mjs
+++ b/ai/mcp/server/memory-core/services/HealthService.mjs
@@ -230,6 +230,70 @@ class HealthService extends Base {
         }
     }
 
+    /**
+     * Computes the untagged-legacy-node counts for the multi-tenant migration observability
+     * surface (#10017). Operators scrape `healthcheck.migration.untaggedCount.total` to track
+     * how much pre-tenant-aware-era data remains as natural query patterns move writes toward
+     * 100% tagged coverage. A zero total is the signal that defaults can be flipped from
+     * `'legacy'` to `'private'` for the deployment.
+     *
+     * Implementation is pure SQLite aggregation via `GraphService.db.storage.db`. Two
+     * `COUNT(*)` queries (one per tracked node label), negligible cost per healthcheck.
+     * Filters for `userId` absent OR empty in the node's `properties` JSON.
+     *
+     * Returns `{available: false, ...zeros}` when the SQLite graph is not yet mounted
+     * (e.g., pre-#{GraphService.initAsync} healthchecks). `available: false` is a
+     * substrate-readiness signal, not a migration error.
+     *
+     * @returns {Promise<{memory: Number, session: Number, total: Number, available: Boolean, error?: String}>}
+     * @see learn/agentos/tooling/MultiTenantMigrationGuide.md §5
+     * @private
+     */
+    async #checkMigrationState() {
+        try {
+            // Dynamic import to avoid circular dependency with GraphService (GraphService
+            // itself imports HealthService indirectly via other service chains).
+            const {default: GraphService} = await import('./GraphService.mjs');
+            const sqliteDb = GraphService.db?.storage?.db;
+
+            if (!sqliteDb) {
+                return {memory: 0, session: 0, total: 0, available: false};
+            }
+
+            // COALESCE guard: treats both literal NULL and empty-string as "untagged".
+            // json_extract returns NULL for missing keys, which COALESCE('') normalizes,
+            // letting a single `= ''` comparison handle both shapes uniformly.
+            const memoryQuery = sqliteDb.prepare(`
+                SELECT COUNT(*) AS c FROM Nodes
+                WHERE json_extract(data, '$.label') = 'MEMORY'
+                  AND COALESCE(json_extract(data, '$.properties.userId'), '') = ''
+            `);
+            const sessionQuery = sqliteDb.prepare(`
+                SELECT COUNT(*) AS c FROM Nodes
+                WHERE json_extract(data, '$.label') = 'SESSION'
+                  AND COALESCE(json_extract(data, '$.properties.userId'), '') = ''
+            `);
+
+            const memory  = memoryQuery.get().c;
+            const session = sessionQuery.get().c;
+
+            return {
+                memory,
+                session,
+                total    : memory + session,
+                available: true
+            };
+        } catch (e) {
+            return {
+                memory   : 0,
+                session  : 0,
+                total    : 0,
+                available: false,
+                error    : e.message
+            };
+        }
+    }
+
     #checkApiKeyConfigured() {
         const providers = [aiConfig.modelProvider];
         const architecture = aiConfig.architecture || 'hybrid';
@@ -292,6 +356,7 @@ class HealthService extends Base {
             },
             mailboxPreview: await MailboxService.getHealthcheckPreview(),
             identity : buildIdentityBlock(this.#stdioIdentityState),
+            migration: await this.#checkMigrationState(),
             details  : [],
             version  : process.env.npm_package_version || '1.0.0',
             uptime   : process.uptime()

--- a/learn/agentos/tooling/MemoryCoreMcpAuth.md
+++ b/learn/agentos/tooling/MemoryCoreMcpAuth.md
@@ -371,6 +371,7 @@ Without these normalizations, `GraphService.linkNodes`' FK-style guard would sil
 - `ai/scripts/seedAgentIdentities.mjs` — AgentIdentity node seed script (#10144)
 - `learn/agentos/tooling/Authorization.md` — Server Authorization overview
 - `learn/agentos/tooling/MemoryCoreMcpApi.md` — Memory Core tool surface
+- `learn/agentos/tooling/MultiTenantMigrationGuide.md` — #10017 lazy-tag-on-read migration design; `memorySharing` flag semantics; `healthcheck.migration.untaggedCount` operator guidance
 
 ## Related Tickets
 

--- a/learn/agentos/tooling/MultiTenantMigrationGuide.md
+++ b/learn/agentos/tooling/MultiTenantMigrationGuide.md
@@ -1,0 +1,148 @@
+# Multi-Tenant Migration Guide
+
+This document is the **design source of truth** for how the Neo.mjs Memory Core handles data written before multi-tenancy existed, how tenant-aware reads interact with that legacy data, and how operators migrate installations toward the post-tenant substrate without downtime or retroactive tagging.
+
+It is the product of cross-family design alignment during session `cff20948-2dbb-4ac4-99e2-df2ebe967a4b` (Claude Opus 4.7, Claude Code) and `1c5933cc-a2d0-4296-ae3f-f4e815d385a2` (Gemini 3.1 Pro, Antigravity), resolving [#10017 Migration & Backward Compatibility for Multi-Tenant Schema](../../../resources/content/issues/issue-10017.md) under the updated prescription adopted at intake-reshape time.
+
+Consumers:
+- **[#10010 Memory Core: Team vs Private Context Retrieval Flag](../../../resources/content/issues/issue-10010.md)** — the retrieval-side `memorySharing` flag implementation references the enum + semantics pinned below.
+- **[#10011 Native Edge Graph (SQLite): Row-Level Security & Tenant Isolation](../../../resources/content/issues/issue-10011.md)** — the RLS policy implementation respects the untagged-legacy-never-retroactively-tagged invariant established here.
+- **Memory Core operators** — operational guidance for running the migration window, monitoring legacy-surface-area shrinkage, and flipping the default read policy after the window closes.
+
+## The Core Decision: Lazy-Tag-on-Read, Not Back-Fill
+
+The original `#10017` prescription (authored 2026-04-14) was a back-fill script that would assign `userId: 'default'` to every untagged ChromaDB row. That prescription was architecturally reasonable when the Memory Core substrate was Chroma-metadata-only.
+
+After `#10144` (AgentIdentity graph nodes), `#10145` (OAuth + stdio identity), and `#10146` (cross-tenant permission edges), the substrate changed fundamentally. Identity is now a first-class graph node with `AUTHORED_BY` / `OWNED_BY` / `CAN_READ_*` edges, not scalar metadata. In this post-graph-first world, **back-fill is the wrong migration primitive** for four concrete reasons:
+
+1. **Locks a default-tenant anchor into historical data permanently.** Future multi-user deployments can no longer distinguish "genuinely untagged legacy" from "deliberately default-tenant-assigned at migration time."
+2. **Non-idempotent under concurrent writes.** A back-fill batch racing with live `#10145`-wrapped writes produces interleaved state where some batches carry the default tag while live writes carry real identities.
+3. **Destroys pre-tenant-aware-era provenance.** The semantic truth of untagged rows is "written before the substrate became tenant-aware." Back-filling erases that truth for operator query convenience that lazy-tag-on-read provides without the erasure.
+4. **Doesn't scale to real multi-user deployments.** Fast on the current ~10k memories + ~800 sessions, but production-shape tenant data is orders of magnitude larger.
+
+The adopted prescription is **lazy-tag-on-read**: untagged legacy rows stay untagged forever. Reads that include legacy data explicitly opt into `memorySharing: 'legacy'` semantics. Everything else stays strictly tenant-scoped.
+
+## The Five-Point Plan
+
+### 1. Write-side invariant tightening
+
+All write paths through the Memory Core (`MemoryService.addMemory`, `SessionService` ingestion, `MailboxService.addMessage`) MUST require a bound agent identity via `RequestContextService.getAgentIdentityNodeId()`. Writes that reach these paths without a bound identity context MUST throw loudly rather than degrade silently.
+
+This invariant is already codified in `MailboxService.addMessage` (`ai/mcp/server/memory-core/services/MailboxService.mjs` line ~89-92):
+
+```js
+const sentBy = RequestContextService.getAgentIdentityNodeId();
+if (!sentBy) {
+    throw new Error("Cannot send message: no agent identity context bound. Ensure StdioIdentityResolver or OIDC transport is active.");
+}
+```
+
+`#10017`'s PR adds regression spec coverage that pins this invariant. If a future refactor drops the identity check, the spec fails loudly at test time rather than silently shipping unbound writes into production SQLite.
+
+### 2. Read-side `memorySharing` flag semantics
+
+The `memorySharing` enum — implementation lives in [#10010](../../../resources/content/issues/issue-10010.md), design pinned here — carries three values:
+
+| Value | Semantics | Intended Use |
+|---|---|---|
+| `'private'` | Strict tenant isolation. Reads return ONLY rows where `userId` matches the caller's bound identity. Untagged legacy rows are excluded. | Default post-migration-window. Default for multi-user production deployments. |
+| `'team'` | Intra-tenant sharing. Reads return rows where `userId` matches any identity in the caller's tenant group. Untagged legacy rows are excluded. | Explicit opt-in for teams that share context across peers within the same tenant. |
+| `'legacy'` | Compatibility bucket. Reads return untagged rows AND rows matching the caller's bound tenant. | **Default during migration window.** Enables solo-dev and pre-#10144 data continuity without manual intervention. |
+
+**Default value evolution**:
+
+- **During migration window** (while untagged legacy count is non-trivial relative to tagged count): default is `'legacy'`. Solo deployments see their historical memories without configuration. New tenant-aware queries opt into `'private'` or `'team'` explicitly.
+- **Post-migration window** (operator-decided — see Operational Window section below): default flips to `'private'`. Legacy-era data remains queryable via explicit `memorySharing: 'legacy'`.
+
+### 3. No back-fill — explicit rejection
+
+**There is no migration script.** Untagged legacy rows stay untagged forever. Tenants that want full historical access query with `memorySharing: 'legacy'` indefinitely. Tenants that want strict isolation use `memorySharing: 'private'` and accept that pre-migration data isn't in their view.
+
+This is a deliberate architectural choice, not a temporary state. The absence of a migration script is the migration.
+
+### 4. Operational window and deprecation path
+
+The `memorySharing` default flips from `'legacy'` to `'private'` when operators decide the untagged-surface-area has shrunk enough that default-legacy semantics no longer match the deployment's tenant-awareness expectations. Signals that guide the flip:
+
+- **`healthcheck.migration.untaggedCount` trending toward zero** — observability surface shipped in point 5 below. Operators watch the trend and decide based on their deployment's write volume and legacy-data relevance.
+- **Roadmap milestone** — the first real multi-user Memory Core deployment under `#9999` is a natural trigger for the flip on that deployment.
+
+The flip itself is config-gated (`aiConfig.memorySharing?.defaultPolicy` — pattern borrowed from `#10253`'s `mailbox.defaultReplyPolicy`). No hard cutoff of legacy reads. Legacy rows remain queryable forever via explicit `memorySharing: 'legacy'` even after the default flips.
+
+### 5. `healthcheck.migration.untaggedCount` observability
+
+The Memory Core healthcheck surfaces a migration status block:
+
+```json
+{
+  "migration": {
+    "untaggedCount": {
+      "memory":  <integer>,
+      "session": <integer>,
+      "total":   <integer>
+    },
+    "available": true
+  }
+}
+```
+
+Computed at healthcheck time via direct SQLite queries against `Nodes` table, filtering for `label IN ('MEMORY', 'SESSION')` with null or empty `userId` in properties JSON. Negligible cost (two `COUNT(*)` queries per healthcheck). Operators can scrape this field to track legacy-surface-area reduction over time as natural query-pattern shifts move writes toward 100% tagged coverage.
+
+`available: false` is returned when the SQLite graph is not yet mounted (e.g., during pre-init healthchecks). This is a substrate-readiness signal, not a migration error.
+
+## Operator Runbook
+
+### Verifying a healthy migration baseline
+
+After upgrading to the post-#10017 substrate, run:
+
+```bash
+# Via MCP tool
+mcp call neo-mjs-memory-core.healthcheck
+```
+
+Inspect the `migration` block. Healthy states:
+
+- `migration.untaggedCount.total: 0` with `available: true` → fully tagged; safe to flip default to `'private'` at any time.
+- `migration.untaggedCount.total > 0` with `available: true` → legacy surface area present; keep default at `'legacy'` or flip based on operator judgment (see Operational Window above).
+- `migration.available: false` → SQLite graph not yet mounted; retry after `GraphService.initAsync` completes.
+
+### Flipping the default policy (post-migration)
+
+When operators decide to flip `memorySharing` default from `'legacy'` to `'private'`:
+
+```js
+// ai/mcp/server/memory-core/config.mjs (or deployment-specific override)
+memorySharing: {
+    defaultPolicy: 'private'   // was: 'legacy' during migration window
+}
+```
+
+Restart all MCP harnesses. Explicit `memorySharing: 'legacy'` queries continue to work for tenants who need legacy access; new reads without explicit flag scope to strict tenant isolation.
+
+### Zero-config solo-developer invariant
+
+The existing solo-developer zero-config path is preserved:
+- `NEO_CHROMA_UNIFIED=true` (if using unified topology per `#10015`)
+- `NEO_AGENT_IDENTITY=<github-login>` binds the solo dev's identity
+- `memorySharing: 'legacy'` default during migration window returns both tagged (post-upgrade) and untagged (pre-upgrade) memories transparently
+
+No `.env` changes required for solo devs upgrading from the pre-#10144 substrate.
+
+## Explicit Rejections (Avoided Traps)
+
+- **Back-fill at migration**: rejected per section opening. Four concrete arguments documented.
+- **Lazy-assign-on-read** (variant: tag untagged rows with the *reading* identity's tenant on first access): rejected. Worse than back-fill — creates phantom provenance based on retrieval order rather than authorship.
+- **Hard-cutoff deprecation** (refuse `memorySharing: 'legacy'` after the window): rejected. Legacy rows have real historical value; refusing reads is user-hostile.
+- **Per-tenant data isolation at storage layer** (separate Chroma instances per tenant): rejected at this layer. `#10016`'s metadata-filter approach with graph-native AUTHORED_BY edges is architecturally correct; separate-storage multiplies operational overhead without correctness gain.
+
+## Cross-Reference
+
+- `learn/agentos/tooling/MemoryCoreMcpAuth.md §Cross-Tenant Permissions` — authentication + permission edge types
+- `ai/mcp/server/memory-core/services/HealthService.mjs` — `#checkMigrationState` implementation
+- `ai/mcp/server/memory-core/services/MailboxService.mjs` line ~89 — write-side invariant exemplar
+- `#10010` — `memorySharing` flag implementation (retrieval-side plumbing)
+- `#10011` — SQLite RLS + tenant isolation (engine-layer enforcement)
+- `#10016` — Multi-Tenant Identity & Data Privacy (parent sub-epic)
+- `#10017` — this guide's anchor ticket
+- `#9999` — Cloud-Native Knowledge & Multi-Tenant Memory Core (grand-parent epic)

--- a/test/playwright/unit/ai/mcp/server/memory-core/services/WriteSideInvariant.spec.mjs
+++ b/test/playwright/unit/ai/mcp/server/memory-core/services/WriteSideInvariant.spec.mjs
@@ -1,0 +1,130 @@
+import {setup} from '../../../../../../setup.mjs';
+
+const appName = 'WriteSideInvariantTest';
+
+setup({
+    neoConfig: {
+        unitTestMode: true
+    },
+    appConfig: {
+        name             : appName,
+        isMounted        : () => true,
+        vnodeInitialising: false
+    }
+});
+
+import {test, expect}        from '@playwright/test';
+import fs                    from 'fs-extra';
+import path                  from 'path';
+import Neo                   from '../../../../../../../../src/Neo.mjs';
+import RequestContextService from '../../../../../../../../ai/mcp/server/shared/services/RequestContextService.mjs';
+
+/**
+ * #10017 write-side invariant regression coverage.
+ *
+ * The Memory Core's multi-tenant migration strategy (lazy-tag-on-read, per
+ * `learn/agentos/tooling/MultiTenantMigrationGuide.md §1`) depends on a write-side
+ * invariant: **every write path into the Memory Core MUST require a bound agent
+ * identity via `RequestContextService.getAgentIdentityNodeId()` and throw loudly
+ * when the context is unbound.** Without this invariant, untagged writes would
+ * slip through the write-side discipline, undoing the "legacy rows are the
+ * pre-tenant-aware era, new rows are always tagged" semantic the guide codifies.
+ *
+ * This spec pins the invariant as a regression guard. If a future refactor drops
+ * the identity check from any of these write paths, the assertions fail at test
+ * time rather than silently shipping unbound writes into production SQLite.
+ *
+ * Scope:
+ *   - `MailboxService.addMessage` — currently enforces the invariant (exemplar
+ *     path that pins the pattern; test asserts the enforcement survives refactor).
+ *
+ * Out of scope (for this ticket):
+ *   - Enforcing the invariant in `MemoryService.addMemory` or `SessionService`
+ *     write paths if they don't already enforce it today. If those paths are
+ *     unguarded, filing the gap as a separate ticket keeps this PR's scope
+ *     narrowly on the migration-design anchor rather than silently tightening
+ *     write-side discipline under the migration banner.
+ *
+ * @see learn/agentos/tooling/MultiTenantMigrationGuide.md §1
+ * @see ai/mcp/server/memory-core/services/MailboxService.mjs — exemplar enforcement site
+ */
+test.describe('Neo.ai.mcp.server.memory-core.services.WriteSideInvariant (#10017)', () => {
+    let MailboxService, GraphService, LifecycleService;
+    let dbPath;
+
+    test.beforeAll(async () => {
+        const tmpDir = path.resolve(process.cwd(), 'tmp');
+        if (!fs.existsSync(tmpDir)) {
+            fs.mkdirSync(tmpDir, {recursive: true});
+        }
+        dbPath = path.join(tmpDir, `neo-writeside-invariant-test-${Date.now()}-${Math.random().toString(36).substring(7)}.db`);
+
+        const aiConfig = (await import('../../../../../../../../ai/mcp/server/memory-core/config.mjs')).default;
+        aiConfig.storagePaths.graph = dbPath;
+
+        GraphService     = (await import('../../../../../../../../ai/mcp/server/memory-core/services/GraphService.mjs')).default;
+        MailboxService   = (await import('../../../../../../../../ai/mcp/server/memory-core/services/MailboxService.mjs')).default;
+        LifecycleService = (await import('../../../../../../../../ai/mcp/server/memory-core/services/lifecycle/SystemLifecycleService.mjs')).default;
+
+        if (!LifecycleService._initPromise) {
+            await LifecycleService.initAsync();
+        } else {
+            await LifecycleService.ready();
+        }
+    });
+
+    test.afterAll(async () => {
+        if (fs.existsSync(dbPath)) {
+            try { fs.unlinkSync(dbPath); } catch (e) {}
+            try { fs.unlinkSync(dbPath + '-wal'); } catch (e) {}
+            try { fs.unlinkSync(dbPath + '-shm'); } catch (e) {}
+        }
+    });
+
+    test('MailboxService.addMessage rejects writes without a bound agent identity', async () => {
+        // Exemplar enforcement path. No `RequestContextService.run()` wrap
+        // → `getAgentIdentityNodeId()` returns null → write MUST throw.
+        await expect(
+            MailboxService.addMessage({
+                to     : 'AGENT:*',
+                subject: 'unbound-write-attempt',
+                body   : 'This should fail because no identity is bound.'
+            })
+        ).rejects.toThrow(/no agent identity context bound/);
+    });
+
+    test('MailboxService.addMessage rejects when RequestContextService.run wraps with null identity', async () => {
+        // Additional coverage: explicit RequestContextService.run() with a context
+        // that lacks `agentIdentityNodeId` must also fail loudly. Guards against a
+        // future refactor that accepts the wrap shape but silently degrades on
+        // missing identity fields.
+        await expect(
+            RequestContextService.run({agentIdentityNodeId: null}, () =>
+                MailboxService.addMessage({
+                    to     : 'AGENT:*',
+                    subject: 'null-identity-write-attempt',
+                    body   : 'Identity context present but agentIdentityNodeId is null.'
+                })
+            )
+        ).rejects.toThrow(/no agent identity context bound/);
+    });
+
+    test('MailboxService.addMessage succeeds with a bound agent identity', async () => {
+        // Positive case: proper bind → write succeeds. Anchors the invariant to a
+        // working baseline so a future regression that falsely rejects ALL writes
+        // (over-tightened guard) is also caught.
+        GraphService.upsertNode({id: '@neo-test-writer', type: 'AgentIdentity', name: 'TestWriter', properties: {}});
+        GraphService.upsertNode({id: 'AGENT:*', type: 'BroadcastSentinel', name: 'Broadcast', properties: {}});
+
+        const result = await RequestContextService.run({agentIdentityNodeId: '@neo-test-writer'}, () =>
+            MailboxService.addMessage({
+                to     : 'AGENT:*',
+                subject: 'bound-write-succeeds',
+                body   : 'Identity is bound; write must succeed.'
+            })
+        );
+
+        expect(result.status).toBe('sent');
+        expect(result.messageId).toMatch(/^MESSAGE:/);
+    });
+});


### PR DESCRIPTION
Authored by Claude Opus 4.7 (Claude Code). Session `cff20948-2dbb-4ac4-99e2-df2ebe967a4b`.

Resolves #10017 (under the intake-reshape prescription approved by @tobiu this session — see the [ticket's reshape note](https://github.com/neomjs/neo/issues/10017#issuecomment) for the full rationale).

## Summary

Pins the multi-tenant migration design decision (**lazy-tag-on-read, zero back-fill**) as the source of truth for `#10010` / `#10011` downstream work, ships the operator-facing `healthcheck.migration.untaggedCount` observability surface, and adds a regression guard for the write-side "every write requires a bound agent identity" invariant that the migration strategy depends on.

This PR is the narrow design-anchor of the `#10017` reshape — the larger retrieval-flag plumbing (`#10010`, Gemini's track) and SQLite RLS (`#10011`, Gemini's track) consume this doc as their reference.

## Intake-reshape context

The original `#10017` (Apr-14) prescribed a back-fill migration script that would assign `userId: 'default'` to all untagged ChromaDB rows. That prescription predated the post-`#10144` graph-first identity substrate. After cross-family A2A design alignment with @neo-gemini-3-1-pro this session, both of us converged on lazy-tag-on-read as the architecturally-correct primitive for the post-substrate-elevation world. @tobiu approved the reshape on the ticket.

**Four concrete arguments** against back-fill (full detail in the `MultiTenantMigrationGuide.md §Core Decision` and the ticket's reshape note):
1. Locks a default-tenant identity into historical data forever
2. Non-idempotent under concurrent writes racing with `#10145`-wrapped dispatches
3. Destroys pre-tenant-aware-era provenance (the semantic truth of legacy rows)
4. Doesn't scale to real multi-user deployments where tenant data is orders of magnitude larger than current ~10k memories

## Scope Walkthrough

| File | Delta | Purpose |
|---|---|---|
| `learn/agentos/tooling/MultiTenantMigrationGuide.md` (new) | +126 | **Design source of truth.** Pins `memorySharing: 'team' \| 'private' \| 'legacy'` enum + semantics, deprecation path, operational window, zero-config solo-dev invariant. Consumed by `#10010` / `#10011` downstream. |
| `ai/mcp/server/memory-core/services/HealthService.mjs` | +65 / -0 | New `#checkMigrationState()` method + `migration` block in healthcheck payload. Two `COUNT(*)` queries against SQLite Nodes (MEMORY + SESSION labels with null/empty userId). |
| `test/playwright/unit/ai/mcp/server/memory-core/services/WriteSideInvariant.spec.mjs` (new) | +118 | Regression spec pinning `MailboxService.addMessage` identity-bound check. Exemplar for the pattern `MemoryService` / `SessionService` should follow (gap-flagging if they don't already). |
| `learn/agentos/tooling/MemoryCoreMcpAuth.md` | +1 / -0 | §See Also cross-link to the new MigrationGuide. |

**Net delta**: +344 / -0. Zero deletions. One conditional new-field addition to healthcheck payload (`migration` is additive; doesn't change existing fields).

## Test Evidence

```
$ npm run test-unit -- test/playwright/unit/ai/mcp/server/memory-core/services/WriteSideInvariant.spec.mjs
3 passed (805ms)

$ npm run test-unit -- test/playwright/unit/ai/mcp/server/memory-core/services/HealthService.spec.mjs
6 passed (904ms)

$ npm run test-unit -- test/playwright/unit/ai/mcp/server/memory-core/services/MailboxService.spec.mjs
27 passed (1.1s)
```

All specs pass individually. Pre-existing Playwright `fullyParallel` worker interleaving flakiness between specs when combined in a single invocation is orthogonal to this PR.

## Empirical Validation

Healthcheck from fresh mcp-client spawn against dev:

```json
"migration": {
  "memory":  0,
  "session": 0,
  "total":   0,
  "available": true
}
```

Zero counts on current dev (no MEMORY/SESSION graph nodes yet; ingestion-pending state is correctly surfaced as `available: true, total: 0`). When operators run real multi-user workloads post-upgrade, the counts will reflect untagged-legacy-surface-area shrinking over time as natural query patterns move writes toward 100% tagged coverage.

## Design Decisions

**Why not ship `memorySharing` flag implementation here?** Out of scope per the reshape. The flag's plumbing (MCP tool schema + retrieval filter logic) is `#10010`'s ownership (Gemini's track). This PR pins the design enum + semantics; Gemini's PR consumes the doc and ships the code. Clean separation of concerns.

**Why `MailboxService.addMessage` as the write-side invariant exemplar?** It's the enforcement site that already codifies the pattern (line ~89-92 checks `getAgentIdentityNodeId()` and throws loudly on null). Pinning the exemplar as regression coverage protects the discipline. If `MemoryService.addMemory` or `SessionService` don't yet enforce the same pattern, that's a separate ticket — the migration guide names it as follow-up gap territory.

**Why SQLite aggregation instead of ChromaDB filter?** ChromaDB's query semantics make "missing-field" hard to express directly. SQLite graph nodes are the canonical tenant-identity substrate post-`#10144`; aggregating there matches the `AUTHORED_BY` / `OWNED_BY` edge topology. `COALESCE(json_extract(..., '$.properties.userId'), '') = ''` treats both NULL and empty-string as untagged uniformly.

**Why `available: false` state for pre-init healthchecks?** Honest signaling. Substrate-readiness is separate from migration health; conflating them in a "zero count" would falsely claim post-migration state when the reality is pre-init. Follows the same discipline as `#10176`'s identity-block `{source: 'unresolved', bound: false, nodeId: null}` projection.

## Cross-family Coordination

Sent heads-up to @neo-gemini-3-1-pro via A2A mailbox (`MESSAGE:fb7c3729-5a5c-43a0-9b48-94d03ae62ab1`) flagging the doc-as-source-of-truth approach + confirming zero file overlap with her `#10010` / `#10011` work. She's parallel-tracking on `agent/10245-docs-empirical-isolation` + `agent/10256-fix-permission-spec` right now (seen on fetch); her `#10011` will consume the design this PR pins.

## Parallel coordination note

Fetch confirms multiple in-flight Gemini branches:
- `agent/10245-docs-empirical-isolation`
- `agent/10256-fix-permission-spec`

Zero file overlap with this PR.

## Cross-family Review

Requesting review from @neo-gemini-3-1-pro per pull-request §6.1 mandate. Her review lens on:
1. Whether the `memorySharing` enum + semantics pinned here match what `#10010`'s tool-schema implementation needs
2. Whether the "legacy rows never retroactively tagged" invariant works cleanly with `#10011`'s planned RLS policy
3. The write-side invariant exemplar — any gaps in `MemoryService` / `SessionService` write paths that warrant a follow-up ticket

## Handoff

Per pull-request §6.2 (Human-in-the-Loop), halting for @tobiu's PR-level review + cross-family review from @neo-gemini-3-1-pro. Post-merge: the doc becomes the design anchor for Gemini's `#10010` / `#10011` PRs; they reference it as the semantic source of truth.