### PR TITLE
feat(ai): per-agent blocking in open reply policy (#10255)

### DIFF
--- a/ai/mcp/server/memory-core/services/MailboxService.mjs
+++ b/ai/mcp/server/memory-core/services/MailboxService.mjs
@@ -146,6 +146,17 @@ class MailboxService extends Base {
         // treatment is intentional per #10252's Out of Scope.
         const strictReplyPolicy = aiConfig.mailbox?.defaultReplyPolicy === 'blocked';
 
+        // BLOCKED_BY check fires in BOTH reply-policy modes — operator explicit blocks
+        // always override both the 'open' default-allow AND the 'blocked'-mode reachable-
+        // counterparty trust-lift. Block wins; re-granting CAN_REPLY_TO does not silently
+        // re-enable reach. To restore reach, the recipient must explicitly revokePermission
+        // the BLOCKED_BY edge.
+        if (!isRoleOrHuman && to !== 'AGENT:*' && to !== sentBy) {
+            if (PermissionService.hasPermission(sentBy, to, 'BLOCKED_BY')) {
+                throw new Error(`Unauthorized: ${to} has blocked messages from ${sentBy}.`);
+            }
+        }
+
         if (strictReplyPolicy && !isRoleOrHuman && to !== 'AGENT:*' && to !== sentBy) {
             let canReply = PermissionService.hasPermission(sentBy, to, 'CAN_REPLY_TO');
 

--- a/ai/mcp/server/memory-core/services/PermissionService.mjs
+++ b/ai/mcp/server/memory-core/services/PermissionService.mjs
@@ -39,7 +39,7 @@ class PermissionService extends Base {
      * @member {String[]} validScopes
      * @protected
      */
-    validScopes = ['CAN_READ_INBOX_OF', 'CAN_READ_MEMORIES_OF', 'CAN_READ_SESSIONS_OF', 'CAN_REPLY_TO']
+    validScopes = ['CAN_READ_INBOX_OF', 'CAN_READ_MEMORIES_OF', 'CAN_READ_SESSIONS_OF', 'CAN_REPLY_TO', 'BLOCKED_BY']
 
     /**
      * Grants a permission. The caller is the owner of the resource granting access TO another identity.

--- a/learn/agentos/tooling/MemoryCoreMcpAuth.md
+++ b/learn/agentos/tooling/MemoryCoreMcpAuth.md
@@ -255,6 +255,7 @@ For example, if Bob wants to allow Alice to read his inbox:
 The system currently supports the following scopes:
 - `CAN_READ_INBOX_OF`: Allows the grantee to read messages sent to the granter's inbox.
 - `CAN_REPLY_TO`: Allows the grantee to send a direct message to the granter.
+- `BLOCKED_BY`: Negative-intent edge. Overrides reply policies to explicitly block the grantee from sending direct messages to the granter.
 - `CAN_READ_MEMORIES_OF`: (Reserved for future use) Allows reading raw memories.
 - `CAN_READ_SESSIONS_OF`: (Reserved for future use) Allows reading session summaries.
 
@@ -292,6 +293,17 @@ The `CAN_REPLY_TO` enforcement on `addMessage` is a **deployment-selected defaul
 - `CAN_READ_INBOX_OF`, `CAN_READ_MEMORIES_OF`, `CAN_READ_SESSIONS_OF` read-path scopes remain strict regardless of mode. Reading someone's inbox is categorically different from sending them a message; asymmetric treatment is intentional.
 - `grantPermission` / `revokePermission` / `listPermissions` tools remain callable in both modes. Operators running in `'open'` mode can still choose to grant explicit `CAN_REPLY_TO` edges — they are graph-queryable consent signal regardless of whether the enforcement path currently consults them.
 - Broadcasts (`to: 'AGENT:*'`), role targets (`to: 'role:*'`), human targets (`to: 'human:*'`), and self-sends are unconditionally accepted in both modes.
+
+### Block Precedence (`BLOCKED_BY`)
+
+The `BLOCKED_BY` permission scope acts as a negative-intent override in **both** deployment modes. It solves the isolation problem in `'open'` mode (allowing a single noisy agent to be muted without flipping the entire swarm to `'blocked'`) and enforces strict intent in `'blocked'` mode.
+
+**"Block Wins" Precedence**:
+- If Agent B grants `BLOCKED_BY` to Agent A, Agent A's direct messages to B will be rejected with an `Unauthorized` error.
+- **In `'open'` mode**: The explicit block overrides the mode's default-allow.
+- **In `'blocked'` mode**: The block overrides both the reachable-counterparty trust-lift AND any existing `CAN_REPLY_TO` edges. Re-granting `CAN_REPLY_TO` does not silently restore reach; the block must be explicitly revoked via `revokePermission` first.
+- **Directional**: The block is unidirectional. Agent B blocking Agent A does not prevent B from sending messages to A.
+- **Broadcast Bypass**: Broadcasts (`to: 'AGENT:*'`) bypass `BLOCKED_BY` checks since broadcasts are recipient-unaware at write time.
 
 **Multi-user / multi-tenant deployment guidance:** set `defaultReplyPolicy: 'blocked'` in the deployment's `config.mjs` as part of installation. Every cross-tenant DM then requires an explicit grant via `grant_permission`, enforced at the write path. Tenant onboarding provisions grants for the internal peers that need to communicate; anything outside the grant topology is rejected.
 

--- a/resources/content/.sync-metadata.json
+++ b/resources/content/.sync-metadata.json
@@ -1,6 +1,6 @@
 {
-  "lastSync": "2026-04-23T21:32:34.711Z",
-  "releasesLastFetched": "2026-04-23T21:32:42.086Z",
+  "lastSync": "2026-04-23T21:30:52.347Z",
+  "releasesLastFetched": "2026-04-23T21:31:01.748Z",
   "pushFailures": [],
   "issues": {
     "3789": {

--- a/test/playwright/unit/ai/mcp/server/memory-core/services/MailboxService.spec.mjs
+++ b/test/playwright/unit/ai/mcp/server/memory-core/services/MailboxService.spec.mjs
@@ -761,6 +761,38 @@ test.describe('Neo.ai.mcp.server.memory-core.services.MailboxService', () => {
             expect(delta.unreadCount).toBe(1);
             expect(delta.latestPreview.subject).toBe('hello all');
         });
+
+        test('BLOCKED_BY overrides CAN_REPLY_TO in blocked mode', async () => {
+            // Bob grants Alice CAN_REPLY_TO
+            await RequestContextService.run({ agentIdentityNodeId: 'AGENT:bob' }, async () => {
+                await PermissionService.grantPermission({ to: 'AGENT:alice', scope: 'CAN_REPLY_TO' });
+                // And then blocks her
+                await PermissionService.grantPermission({ to: 'AGENT:alice', scope: 'BLOCKED_BY' });
+            });
+
+            // Alice tries to DM Bob -> fails because BLOCKED_BY overrides
+            await RequestContextService.run({ agentIdentityNodeId: 'AGENT:alice' }, async () => {
+                await expect(MailboxService.addMessage({ to: 'AGENT:bob', subject: 'Fail', body: 'Blocked' }))
+                    .rejects.toThrow('Unauthorized: AGENT:bob has blocked messages from AGENT:alice.');
+            });
+
+            // Broadcasts bypass BLOCKED_BY
+            await RequestContextService.run({ agentIdentityNodeId: 'AGENT:alice' }, async () => {
+                const res = await MailboxService.addMessage({ to: 'AGENT:*', subject: 'Broadcast', body: 'Passes' });
+                expect(res.status).toBe('sent');
+            });
+
+            // Revoke the block
+            await RequestContextService.run({ agentIdentityNodeId: 'AGENT:bob' }, async () => {
+                await PermissionService.revokePermission({ to: 'AGENT:alice', scope: 'BLOCKED_BY' });
+            });
+
+            // Alice tries to DM Bob again -> succeeds because CAN_REPLY_TO remains
+            await RequestContextService.run({ agentIdentityNodeId: 'AGENT:alice' }, async () => {
+                const res = await MailboxService.addMessage({ to: 'AGENT:bob', subject: 'Success', body: 'Unblocked' });
+                expect(res.status).toBe('sent');
+            });
+        });
     });
 });
 
@@ -912,6 +944,42 @@ test.describe('Neo.ai.mcp.server.memory-core.services.MailboxService — open po
 
             const toHuman = await MailboxService.addMessage({ to: 'human:tobiu', subject: 'fyi', body: 'body' });
             expect(toHuman.status).toBe('sent');
+        });
+    });
+
+    test('BLOCKED_BY overrides default-allow in open mode', async () => {
+        // Bob blocks Alice
+        await RequestContextService.run({ agentIdentityNodeId: 'AGENT:bob' }, async () => {
+            await PermissionService.grantPermission({ to: 'AGENT:alice', scope: 'BLOCKED_BY' });
+        });
+
+        // Alice tries to DM Bob -> fails because BLOCKED_BY overrides open mode default
+        await RequestContextService.run({ agentIdentityNodeId: 'AGENT:alice' }, async () => {
+            await expect(MailboxService.addMessage({ to: 'AGENT:bob', subject: 'Fail', body: 'Blocked' }))
+                .rejects.toThrow('Unauthorized: AGENT:bob has blocked messages from AGENT:alice.');
+        });
+
+        // Bob can still DM Alice (directional block)
+        await RequestContextService.run({ agentIdentityNodeId: 'AGENT:bob' }, async () => {
+            const res = await MailboxService.addMessage({ to: 'AGENT:alice', subject: 'Passes', body: 'Directional' });
+            expect(res.status).toBe('sent');
+        });
+
+        // Broadcasts bypass BLOCKED_BY
+        await RequestContextService.run({ agentIdentityNodeId: 'AGENT:alice' }, async () => {
+            const res = await MailboxService.addMessage({ to: 'AGENT:*', subject: 'Broadcast', body: 'Passes' });
+            expect(res.status).toBe('sent');
+        });
+
+        // Revoke the block
+        await RequestContextService.run({ agentIdentityNodeId: 'AGENT:bob' }, async () => {
+            await PermissionService.revokePermission({ to: 'AGENT:alice', scope: 'BLOCKED_BY' });
+        });
+
+        // Alice tries to DM Bob again -> succeeds
+        await RequestContextService.run({ agentIdentityNodeId: 'AGENT:alice' }, async () => {
+            const res = await MailboxService.addMessage({ to: 'AGENT:bob', subject: 'Success', body: 'Unblocked' });
+            expect(res.status).toBe('sent');
         });
     });
 });


### PR DESCRIPTION
Resolves #10255. Adds BLOCKED_BY permission scope as an additive negative-intent primitive for granular muting, bypassing the strict reply-policy default.