### PR TITLE
feat(memory-core): surface effective chromadb topology in /health (#10127)

### DIFF
--- a/ai/mcp/server/memory-core/services/HealthService.mjs
+++ b/ai/mcp/server/memory-core/services/HealthService.mjs
@@ -44,6 +44,62 @@ export function buildIdentityBlock(stdioIdentityState) {
 }
 
 /**
+ * @summary Projects the effective ChromaDB topology resolution into the healthcheck `database.topology`
+ *          observability block (#10127).
+ *
+ * Pure function: takes an `aiConfig`-shaped input and returns the three-field projection operators
+ * need to verify ChromaDB coordinate resolution — `{mode, coordinates, resolvedVia}`. Extracted as a
+ * module-scope function so unit tests can exercise the projection without bootstrapping the full
+ * Memory Core runtime, mirroring the {@link buildIdentityBlock} precedent for module-scope pure
+ * projections.
+ *
+ * **Why this block exists:** Today's `{engines: {chroma: true}}` is a binary reachability flag. It
+ * cannot distinguish a client pointed at the KB's ChromaDB (unified topology, per sub-epic #10015)
+ * from one that silently spun up its own instance (federated topology). A forgotten `NEO_CHROMA_UNIFIED`
+ * env flag would cause Memory Core to mount a distinct volume and populate a distinct collection set,
+ * diverging from the KB state without any operator-visible signal until cross-tenant drift emerges.
+ * This block closes that gap: `mode` surfaces which topology branch won, `coordinates` pins the
+ * effective `{host, port}`, and `resolvedVia` names the exact config key path the resolver read —
+ * giving operators a direct pointer to what to fix when coordinates look wrong.
+ *
+ * **Consumes {@link Neo.ai.mcp.server.memory-core.managers.ChromaManager#resolveChromaCoordinates}**
+ * as the single source of truth for coordinate resolution. `resolveChromaCoordinates` was extracted
+ * as a pure method in #10001 specifically to make this kind of observability aggregation possible
+ * without singleton re-instantiation or config-resolution duplication.
+ *
+ * **Defensive error handling:** `resolveChromaCoordinates` throws when `chromaUnified=true` and
+ * `engines.kb.chroma` is undefined (misconfig via custom config override clobbering the `engines.kb`
+ * branch). Healthcheck must not explode under that condition — operators still need the remaining
+ * observability surface (identity, mailbox, migration counts). We surface the misconfig as observable
+ * data (`{coordinates: null, error: <message>}`) instead, aligning with the "surface, don't obscure"
+ * principle codified in PR #10227.
+ *
+ * @param {Object} cfg aiConfig-shaped input. Reads `cfg.chromaUnified` plus the branch targets
+ *     `engines.chroma.{host, port}` and `engines.kb.chroma.{host, port}` via `resolveChromaCoordinates`.
+ * @returns {{mode: String, coordinates: Object|null, resolvedVia: String, error?: String}}
+ *     `mode` is `'unified'` or `'federated'`. `coordinates` is `{host, port}` on success or `null` on
+ *     resolver throw. `resolvedVia` is the exact config key path that won the resolution —
+ *     `'engines.kb.chroma'` for unified mode, `'engines.chroma'` for federated. `error` is present
+ *     only when the resolver threw.
+ * @see Neo.ai.mcp.server.memory-core.managers.ChromaManager#resolveChromaCoordinates
+ * @see learn/agentos/MemoryCore.md
+ */
+export function buildTopologyBlock(cfg) {
+    const mode        = cfg.chromaUnified ? 'unified'           : 'federated';
+    const resolvedVia = cfg.chromaUnified ? 'engines.kb.chroma' : 'engines.chroma';
+
+    try {
+        return {
+            mode,
+            coordinates: ChromaManager.resolveChromaCoordinates(cfg),
+            resolvedVia
+        };
+    } catch (e) {
+        return {mode, coordinates: null, resolvedVia, error: e.message};
+    }
+}
+
+/**
  * @summary Monitors and validates the ChromaDB dependency for the Memory Core MCP server.
  *
  * This service acts as a gatekeeper, ensuring that ChromaDB is properly running,
@@ -345,7 +401,8 @@ class HealthService extends Base {
                 connection: {
                     connected  : false,
                     collections: null
-                }
+                },
+                topology  : buildTopologyBlock(aiConfig)
             },
             features : {
                 summarization: false

--- a/learn/agentos/MemoryCore.md
+++ b/learn/agentos/MemoryCore.md
@@ -66,11 +66,76 @@ The server exposes a suite of tools via the Model Context Protocol (MCP).
 
 ### Database Management
 
-*   **`healthcheck`**: Diagnostics tool. Checks ChromaDB status, collection health, and API key configuration.
+*   **`healthcheck`**: Diagnostics tool. Checks ChromaDB status, collection health, API key configuration, identity binding, and effective ChromaDB topology. See **Healthcheck Response Shape** below for the full payload contract.
 *   **`start_database`**: Starts the local ChromaDB process.
 *   **`stop_database`**: Stops the local ChromaDB process.
 *   **`export_database`**: Exports memories and summaries to JSONL files for backup.
 *   **`import_database`**: Imports data from JSONL backups.
+
+## Healthcheck Response Shape
+
+Operators running `healthcheck` (via MCP, or via the SSE `/healthcheck` endpoint when the server is exposed over HTTP) receive a structured payload covering connectivity, identity, mailbox, multi-tenant migration state, and ChromaDB topology resolution. The shape is stable — new observability blocks are additive, existing blocks are not renamed or reshaped.
+
+```json readonly
+{
+    "status": "healthy",
+    "timestamp": "2026-04-24T10:15:00.000Z",
+    "session":  { "currentId": "b02bd06c-..." },
+    "database": {
+        "process": { "managed": false, "strategy": "external" },
+        "connection": {
+            "connected": true,
+            "engines":   { "chroma": true, "sqlite": false },
+            "collections": {
+                "memories":  { "name": "neo-agent-memory",   "exists": true, "count": 8599 },
+                "summaries": { "name": "neo-agent-sessions", "exists": true, "count": 794 }
+            }
+        },
+        "topology": {
+            "mode": "federated",
+            "coordinates": { "host": "localhost", "port": 8100 },
+            "resolvedVia": "engines.chroma"
+        }
+    },
+    "features":  { "summarization": true },
+    "startup":   { "summarizationStatus": "not_attempted", "summarizationDetails": null },
+    "mailboxPreview": null,
+    "identity":  { "source": "env-var", "bound": true, "nodeId": "@neo-opus-4-7" },
+    "migration": { "memory": 0, "session": 0, "total": 0, "available": true },
+    "details":   ["Connected to an externally managed ChromaDB instance", "All features are operational"],
+    "version":   "1.0.0",
+    "uptime":    0.21
+}
+```
+
+### `database.topology` — Effective ChromaDB Coordinate Resolution
+
+Introduced in #10127 (follow-up to sub-epic #10015's unified-topology pillar — #10001 routing + #10007 lifecycle bypass). The block surfaces **which ChromaDB instance Memory Core is actually using**, so operators deploying in unified mode can verify the flag took effect without inspecting logs or re-running the config through `node -e`.
+
+| Field | Type | Meaning |
+|---|---|---|
+| `mode` | `'unified' \| 'federated'` | `'unified'` means Memory Core reuses the KB's ChromaDB instance (`chromaUnified=true`). `'federated'` means Memory Core owns its own instance (default). |
+| `coordinates` | `{host, port} \| null` | The effective `{host, port}` the client is targeting. `null` when `chromaUnified=true` but `engines.kb.chroma` is missing from config — a misconfig surfaced as observable data rather than a 500. |
+| `resolvedVia` | `'engines.kb.chroma' \| 'engines.chroma'` | The exact config key path the resolver read. Gives operators a direct pointer to what to inspect when coordinates look wrong. |
+| `error` | `string` (optional) | Present only when the resolver threw — names the specific misconfig. |
+
+**Why this matters:** Without `database.topology`, a forgotten `NEO_CHROMA_UNIFIED=true` silently caused Memory Core to spin up its own ChromaDB, mount a distinct volume, and populate a distinct collection set — diverging from the KB state until cross-tenant drift emerged. The block closes that observability gap in-band.
+
+### `identity` — Stdio Identity Binding
+
+Introduced in #10176. Surfaces whether the MCP server resolved a concrete AgentIdentity at boot:
+- `source`: `'env-var'` (NEO_AGENT_IDENTITY), `'gh-cli'` (authenticated login), or `'unresolved'`.
+- `bound`: `true` when the resolved userId matched a seeded AgentIdentity graph node. `false` is a seed-state failure signal — agent needs `ai/scripts/seedAgentIdentities.mjs` or the #10232 boot-time self-seed did not fire.
+- `nodeId`: The canonical `@login` AgentIdentity node when bound, `null` otherwise.
+
+### `migration` — Multi-Tenant Migration Progress
+
+Introduced in #10017 (see `learn/agentos/tooling/MultiTenantMigrationGuide.md`). Tracks how many pre-tenant-aware-era nodes remain untagged as natural query patterns lazy-tag data:
+- `memory` / `session`: Count of `MEMORY` / `SESSION` label nodes lacking a `userId` property.
+- `total`: Sum of the two.
+- `available`: `false` if the SQLite graph is not yet mounted (substrate-readiness signal, not a migration error).
+
+A zero `total` is the signal operators watch for to flip the `memorySharing` default from `'legacy'` to `'private'`.
 
 ## Two-Stage Query Workflow
 

--- a/test/playwright/unit/ai/mcp/server/memory-core/services/HealthService.spec.mjs
+++ b/test/playwright/unit/ai/mcp/server/memory-core/services/HealthService.spec.mjs
@@ -36,6 +36,7 @@ test.describe('HealthService #10176 — buildIdentityBlock', () => {
         buildIdentityBlock = mod.buildIdentityBlock;
     });
 
+
     test('null state projects to unresolved + unbound', () => {
         expect(buildIdentityBlock(null)).toEqual({
             source: 'unresolved',
@@ -118,5 +119,91 @@ test.describe('HealthService #10176 — buildIdentityBlock', () => {
             bound : true,
             nodeId: '@neo-opus-4-7'
         });
+    });
+});
+
+/**
+ * @summary Coverage for the #10127 topology observability block in the healthcheck payload.
+ *
+ * Mirrors the #10176 precedent above: the end-to-end integration path requires a live ChromaDB
+ * plus the full StorageRouter/ChromaManager singleton bootstrap, which is out of scope for a
+ * pure-projection unit test. This spec pins the contract of `buildTopologyBlock` — the module-scope
+ * pure function consumed from `#performHealthCheck` to fill `database.topology`. Integration
+ * correctness (does the value reach the MCP healthcheck response under both real topologies?) is
+ * validated empirically post-merge via harness restart + healthcheck inspection.
+ *
+ * The function delegates coordinate resolution to `ChromaManager.resolveChromaCoordinates` — a pure
+ * method extracted in #10001 whose own unit coverage exists separately. Here we verify the three
+ * surface properties operators consume: `mode` (unified vs federated), `coordinates` (pass-through
+ * of the resolver's output), and `resolvedVia` (the config-key-path string that names which branch
+ * won).
+ *
+ * @see Neo.ai.mcp.server.memory-core.services.HealthService#buildTopologyBlock
+ * @see Neo.ai.mcp.server.memory-core.managers.ChromaManager#resolveChromaCoordinates
+ */
+test.describe('HealthService #10127 — buildTopologyBlock', () => {
+    let buildTopologyBlock;
+
+    test.beforeAll(async () => {
+        const mod = await import('../../../../../../../../ai/mcp/server/memory-core/services/HealthService.mjs');
+        buildTopologyBlock = mod.buildTopologyBlock;
+    });
+
+    test('federated mode surfaces engines.chroma coordinates + resolvedVia path', () => {
+        // Default production topology: Memory Core owns its own ChromaDB, KB owns a separate one.
+        // `chromaUnified` unset/false → resolver returns `engines.chroma`, `resolvedVia` names that
+        // exact config key path so operators inspecting a wrong host/port know where to look.
+        const cfg = {
+            chromaUnified: false,
+            engines: {
+                chroma: {host: 'localhost', port: 8100},
+                kb    : {chroma: {host: 'localhost', port: 8000}}
+            }
+        };
+        expect(buildTopologyBlock(cfg)).toEqual({
+            mode       : 'federated',
+            coordinates: {host: 'localhost', port: 8100},
+            resolvedVia: 'engines.chroma'
+        });
+    });
+
+    test('unified mode surfaces engines.kb.chroma coordinates + resolvedVia path', () => {
+        // Sub-epic #10015 unified topology: Memory Core reuses the KB's ChromaDB instance. The whole
+        // point of the `/health` topology surface is making this mode verifiable from the wire —
+        // `mode: 'unified'` confirms the `NEO_CHROMA_UNIFIED=true` flag took effect, `coordinates`
+        // pins the exact KB-owned endpoint, `resolvedVia` names the config branch the resolver walked.
+        const cfg = {
+            chromaUnified: true,
+            engines: {
+                chroma: {host: 'localhost', port: 8100},
+                kb    : {chroma: {host: 'localhost', port: 8000}}
+            }
+        };
+        expect(buildTopologyBlock(cfg)).toEqual({
+            mode       : 'unified',
+            coordinates: {host: 'localhost', port: 8000},
+            resolvedVia: 'engines.kb.chroma'
+        });
+    });
+
+    test('unified mode with missing engines.kb.chroma surfaces error, does not throw', () => {
+        // Misconfig path: a custom config override clobbers `engines.kb` while leaving
+        // `chromaUnified=true`. `resolveChromaCoordinates` throws a descriptive error. Healthcheck
+        // must NOT propagate the throw — the remaining observability surface (identity, mailbox,
+        // migration) is still valuable, and the topology block itself is the right place to
+        // surface the misconfig as observable data. `coordinates: null` + `error` string aligns
+        // with the "surface, don't obscure" principle codified in PR #10227.
+        const cfg = {
+            chromaUnified: true,
+            engines: {
+                chroma: {host: 'localhost', port: 8100}
+                // engines.kb deliberately absent
+            }
+        };
+        const result = buildTopologyBlock(cfg);
+        expect(result.mode).toBe('unified');
+        expect(result.coordinates).toBeNull();
+        expect(result.resolvedVia).toBe('engines.kb.chroma');
+        expect(result.error).toMatch(/engines\.kb\.chroma/);
     });
 });


### PR DESCRIPTION
## Summary

Extends `HealthService.healthcheck()` with a `database.topology` observability block exposing which ChromaDB instance Memory Core is actually targeting — `{mode, coordinates, resolvedVia}`. Closes the in-band operator-facing verification gap for sub-epic #10015's unified-topology pillar (#10001 + #10007 landed earlier).

Before: `/health` returned `{engines: {chroma: true}}` — a binary reachability flag that could not distinguish unified mode (MC reuses the KB's ChromaDB) from federated mode (MC spins up its own). A forgotten `NEO_CHROMA_UNIFIED=true` was silent: MC mounted a distinct volume, populated a distinct collection set, and diverged from KB state until cross-tenant drift emerged.

After: operators running `healthcheck` get an immediate answer to ``which ChromaDB am I hitting, and which config key path did the resolver walk?`` — no log inspection, no `node -e`.

## Architectural Shape

Pure-projection-function-tested-in-isolation, mirroring the #10176 `buildIdentityBlock` precedent:

```javascript
export function buildTopologyBlock(cfg) {
    const mode        = cfg.chromaUnified ? 'unified'           : 'federated';
    const resolvedVia = cfg.chromaUnified ? 'engines.kb.chroma' : 'engines.chroma';
    try {
        return {mode, coordinates: ChromaManager.resolveChromaCoordinates(cfg), resolvedVia};
    } catch (e) {
        return {mode, coordinates: null, resolvedVia, error: e.message};
    }
}
```

- **Reuses `ChromaManager.resolveChromaCoordinates`** (extracted in #10001 specifically for this kind of aggregation). Resolution logic stays where it belongs; HealthService only reports.
- **Defensive try/catch** keeps healthcheck resilient when the resolver throws on missing `engines.kb.chroma`. Misconfig becomes observable data (`coordinates: null, error: <message>`) instead of a 500. Aligns with the ``surface, don't obscure`` principle codified in #10227.
- **Injected before connectivity checks** so operators see target coordinates even when `status: unhealthy`. Knowing the MC is pointed at the wrong host is MORE useful when the health check is failing, not less.

## Acceptance Criteria Mapping

- [x] `healthcheck` MCP tool response includes `database.topology` with `{mode, coordinates, resolvedVia}` fields.
- [x] Federated-mode response shows `mode: 'federated'`, coordinates matching `engines.chroma`, `resolvedVia: 'engines.chroma'`. *(covered by spec line 152)*
- [x] Unified-mode response shows `mode: 'unified'`, coordinates matching `engines.kb.chroma`, `resolvedVia: 'engines.kb.chroma'`. *(covered by spec line 170)*
- [x] New spec block `HealthService #10127 — buildTopologyBlock` covers both topology branches plus the defensive misconfig path.
- [x] `learn/agentos/MemoryCore.md` documents the new fields, also folding in the deferred doc pass from #10001 + #10007 under a new **Healthcheck Response Shape** section that covers the full payload contract (including the identity and migration observability blocks already shipped in #10176 / #10017).

## Stepping Back — Reflection Protocol

Considered and explicitly rejected:

- **Sibling `ChromaManager.resolveTopology(cfg)` method** returning `{mode, coordinates, resolvedVia}`. Would reduce HealthService caller burden, but widens `ChromaManager`'s contract without a second consumer. Kept `resolvedVia` computation in `buildTopologyBlock` — if/when a second consumer appears (e.g., `HealthService` topology for SQLite graph path, per the ticket's Out-of-Scope note), that's the moment to extract.
- **Gating `status: 'unhealthy'` on misconfig topology.** Rejected: topology reporting is pure observability, not a health gate. A misconfigured unified mode with a working federated fallback is still operationally healthy from MC's perspective — the operator just wouldn't realize they're in the wrong mode. The block surfaces the facts; escalation is a separate policy decision.

## Verification

### Primary (merged with this PR)

```bash
npx playwright test -c test/playwright/playwright.config.unit.mjs \
  test/playwright/unit/ai/mcp/server/memory-core/services/HealthService.spec.mjs
# 9 passed (1.1s) — 6 existing buildIdentityBlock + 3 new buildTopologyBlock
```

### Post-merge empirical (mirrors #10176 precedent)

1. Pull dev, harness restart (⌘Q + relaunch).
2. Call MCP `healthcheck`. Assert `response.database.topology` exists with `{mode, coordinates, resolvedVia}`.
3. With default config (`chromaUnified` unset), confirm `mode: 'federated'`, `resolvedVia: 'engines.chroma'`, coordinates match `aiConfig.engines.chroma`.
4. (Optional, unified-mode operator path) Set `NEO_CHROMA_UNIFIED=true`, restart, confirm `mode: 'unified'`, `resolvedVia: 'engines.kb.chroma'`.

## Out of Scope

- Altering `resolveChromaCoordinates` logic (reporting-only change).
- Topology reporting for non-ChromaDB subsystems (SQLite graph, inference, embedding) — separate tickets if the pattern generalizes.
- Shipping `chromaUnified` as a default in `config.template.mjs` — orthogonal to the observability surface.

## Related

- Consumes `ChromaManager.resolveChromaCoordinates` extracted in #10001
- Closes the follow-up commitment from PR #10121 (#10001) and PR #10123 (#10007)
- Documents alongside #10176 identity block and #10017 migration block in the new **Healthcheck Response Shape** section of `MemoryCore.md`
- Unblocks operator-facing diagnostics for sub-epic #10015 deployments

Resolves #10127

---

Origin Session ID: `cff20948-2dbb-4ac4-99e2-df2ebe967a4b` (handover) → follow-on pickup