### PR TITLE
feat(github-workflow): comment-ID return + selective-fetch for A2A propagation (#10272)

### DIFF
--- a/.agent/skills/pr-review/references/pr-review-guide.md
+++ b/.agent/skills/pr-review/references/pr-review-guide.md
@@ -147,3 +147,36 @@ If any check surfaces a miss, flag it in Required Actions. A PR that ships a new
 
 PR #10155 shipped `.agent/skills/epic-review/` with the claim "runs *before* `ticket-intake`." Real integration required `ticket-intake` to check whether the parent epic had been reviewed before proceeding with sub pickup. The PR did NOT update `ticket-intake`. The reviewer did NOT flag the missing integration. Result: `epic-review` ships as a skill but the "runs before ticket-intake" claim is aspirational until `ticket-intake` is updated — a latent gap §8 would have caught.
 
+## 9. A2A Comment-ID Hand-off Protocol (#10272)
+
+**Problem:** Each review cycle N+1 costs context-fetch cost proportional to cumulative thread size. By cycle three of an Architectural Pillar review, fetching the full conversation via `get_conversation({pr_number: N})` burns more tokens reading prior rounds than the new substance justifies.
+
+**Solution:** `manage_issue_comment` action:`create` returns `{message, commentId, url, createdAt}`. The reviewer captures `commentId` from that response and relays it to the next reviewer (peer or author) via A2A mailbox — the recipient fetches just-this-comment via `get_conversation({pr_number: N, comment_id: COMMENT_ID})`, scaling linearly with new-comment volume rather than cumulative thread size.
+
+### 9.1 Workflow
+
+1. Reviewer posts their review comment via `manage_issue_comment({action: 'create', pr_number, body, agent})`.
+2. Reviewer captures `commentId` from the response.
+3. Reviewer sends an A2A mailbox DM to the next actor (peer reviewer or author) via `add_message`:
+   ```
+   subject: 're: PR #N review cycle K'
+   body: 'Review posted at PR #N comment <COMMENT_ID>. Substance: <one-line summary>.'
+   relatedTickets: ['#N']
+   ```
+4. Recipient reads the A2A message, extracts `COMMENT_ID`, calls `get_conversation({pr_number: N, comment_id: COMMENT_ID})` — receives only this reviewer's comment, not the whole thread history.
+
+### 9.2 Selector Precedence
+
+`get_conversation` accepts three optional selectors. First match wins:
+
+- `comment_id` — single-comment fetch. Used by the A2A hand-off pattern above.
+- `since_comment_id` — fetch comments strictly AFTER the given anchor. Used for incremental polling: track last-seen commentId, fetch only what's new.
+- `last_n` — fetch the last N comments. Coarse-grained catch-up when commentIds aren't tracked.
+- Omitting all three returns the full conversation (backward-compatible default).
+
+### 9.3 Anti-Patterns
+
+- **Full-conversation-fetch-per-cycle when commentId is available.** If the A2A message carries a commentId, use it. Otherwise the propagation discipline is broken.
+- **Mailbox DM without commentId when the message is pointing at a specific comment.** Forces recipient to fetch full thread and grep for the intended passage — negates the efficiency gain.
+- **Passing all three selectors at once expecting a merge.** First-match semantics; excess selectors are ignored.
+

--- a/.agent/skills/pull-request/references/pull-request-workflow.md
+++ b/.agent/skills/pull-request/references/pull-request-workflow.md
@@ -225,6 +225,26 @@ When performing self-reviews or responding to feedback across multiple rounds, y
 | **Scope reductions / architectural pivots** | NEW comment with explicit link to the decision being resumed. Do NOT rewrite the original — callout preserves the pivot in history. |
 | **Follow-up completion notes** | NEW short comment (e.g., "merged #X, closed by PR"). |
 
+### 8.1 A2A Comment-ID Propagation (Author Side) — #10272
+
+Symmetric with `pr-review §9` (reviewer side). When YOU (as author) post a response comment to reviewer feedback, capture the `commentId` returned by `manage_issue_comment` and relay it to the reviewer via A2A mailbox DM so they can fetch just-this-comment via `get_conversation({pr_number, comment_id})`. Scales linearly with new-comment volume rather than cumulative thread size across multi-cycle review.
+
+**Workflow:**
+1. Author posts Addressed-tags response via `manage_issue_comment({action: 'create', pr_number, body, agent})`.
+2. Author captures `commentId` from the response.
+3. Author sends an A2A DM to the reviewer:
+   ```
+   subject: 're: PR #N addressed'
+   body: 'Response posted at PR #N comment <COMMENT_ID>. Summary: addressed <X>, deferred <Y> to #Z.'
+   inReplyTo: <reviewer's original review commentId if known>
+   relatedTickets: ['#N']
+   ```
+4. Reviewer fetches just this response via `get_conversation({pr_number: N, comment_id: COMMENT_ID})`.
+
+**Re-review cycle:** if reviewer posts a follow-up (Request Changes or Approved), they mailbox YOU with their new commentId. You fetch just-their-new-comment, evaluate, commit further polish if needed, and the loop continues with linear-to-new-content context cost rather than cumulative.
+
+Rationale: §9 of `pr-review-guide.md` covers the reviewer-side mechanics; this section covers the author-side symmetric hand-off. The selector precedence (`comment_id > since_comment_id > last_n > full`) and anti-patterns (full-fetch-when-commentId-available, mailbox-without-commentId, all-three-selectors-at-once) apply identically here.
+
 ## 9. PR Body Hygiene
 
 Do not blindly copy the entire ticket body into the PR description. The ticket holds the original context; the PR body summarizes the implementation delta.

--- a/ai/mcp/server/github-workflow/openapi.yaml
+++ b/ai/mcp/server/github-workflow/openapi.yaml
@@ -248,23 +248,96 @@ paths:
     get:
       summary: Get PR Conversation
       operationId: get_conversation
+      x-pass-as-object: true
       x-annotations:
         readOnlyHint: true
       description: |
-        Retrieves the full conversation for a pull request, including the title, body, and all comments.
+        Retrieves the conversation for a pull request, including the title, body, and comments.
 
         **When to Use:**
-        Use this tool to get the complete context of a pull request, including the initial proposal and the full discussion history, which is essential for a comprehensive review.
+        Use this tool to get the context of a pull request — the initial proposal and the discussion history.
+
+        **Comment selectors (optional, first-match precedence):**
+        - `comment_id`: fetch ONLY the comment whose GitHub node ID matches. Used for A2A
+          hand-off — a reviewer mailboxes the `commentId` (returned by `manage_issue_comment`
+          action:`create`) to the peer, and the peer fetches just-this-comment rather than
+          re-walking the whole thread. Scales linearly with new-comment volume.
+        - `since_comment_id`: fetch comments AFTER the one with the given ID (exclusive).
+          Incremental review cycles: track last-seen commentId, fetch only what's new.
+        - `last_n`: fetch the last N comments. Coarse-grained catch-up when IDs aren't tracked.
+
+        Omitting all selectors returns the full conversation (backward-compatible default).
       tags: [Pull Requests]
-      parameters:
-        - name: pr_number
-          in: path
-          required: true
-          description: The number of the pull request.
-          schema:
-            type: integer
-            example: 123
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - pr_number
+              properties:
+                pr_number:
+                  type: integer
+                  description: The number of the pull request.
+                  example: 10272
+                comment_id:
+                  type: string
+                  description: Return only the comment whose GitHub global node ID matches. Elides all other comments; PR title/body are still returned.
+                  example: "IC_kwDOABcD1234567890"
+                since_comment_id:
+                  type: string
+                  description: Return only comments AFTER the one with this ID (exclusive). If the ID isn't found, returns empty comments.
+                  example: "IC_kwDOABcD1234567890"
+                last_n:
+                  type: integer
+                  description: Return only the last N comments (by creation order).
+                  example: 3
       responses:
+        '200':
+          description: Conversation data for the pull request, optionally filtered by selector.
+          content:
+            application/json:
+              schema:
+                type: object
+                description: Pull request conversation shape — title/body/author plus a (possibly filtered) comments collection.
+                properties:
+                  title:
+                    type: string
+                  body:
+                    type: string
+                  author:
+                    type: object
+                    properties:
+                      login:
+                        type: string
+                  comments:
+                    type: object
+                    properties:
+                      nodes:
+                        type: array
+                        items:
+                          type: object
+                          properties:
+                            id:
+                              type: string
+                              description: The GitHub global node ID of the comment.
+                            author:
+                              type: object
+                              properties:
+                                login:
+                                  type: string
+                            body:
+                              type: string
+                            createdAt:
+                              type: string
+                              format: date-time
+        '400':
+          description: Bad Request (missing `pr_number`).
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
         '500':
           description: Internal server error, e.g., `gh` command failed.
           content:
@@ -331,11 +404,17 @@ paths:
                   example: "Gemini 3.1 Pro (Antigravity)"
       responses:
         '200':
-          description: Comment created or updated successfully.
+          description: |
+            Comment created or updated successfully. Returns the canonical comment identifier
+            (`commentId`), its GitHub URL, and the relevant timestamp (`createdAt` on create,
+            `updatedAt` on update) so the caller can surface the canonical reference for A2A
+            propagation patterns — see `.agent/skills/pr-review/references/pr-review-guide.md §9`
+            and `.agent/skills/pull-request/references/pull-request-workflow.md §8` for the
+            comment-ID hand-off convention that pairs with `get_conversation({comment_id: …})`.
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/SuccessResponse'
+                $ref: '#/components/schemas/CommentResponse'
         '400':
           description: Bad Request (missing arguments or invalid action).
           content:
@@ -1111,6 +1190,38 @@ components:
           type: string
           description: Optional details from the CLI output.
           example: "Checked out branch 'some-contributor/my-feature-branch'"
+
+    CommentResponse:
+      type: object
+      description: |
+        Enriched response for comment create/update operations. Surfaces the canonical
+        `commentId` (GitHub global node ID) so callers can reference the comment in
+        downstream A2A propagation patterns. `createdAt` is populated on create;
+        `updatedAt` on update. Superset of `SuccessResponse` — existing consumers that
+        only read `message` continue to work unchanged.
+      properties:
+        message:
+          type: string
+          description: Human-readable confirmation of the operation.
+          example: "Successfully created comment on PR #10272"
+        commentId:
+          type: string
+          description: The canonical GitHub global node ID of the comment. Use with `get_conversation({comment_id: ...})` or in A2A payloads to reference just-this-comment.
+          example: "IC_kwDOABcD1234567890"
+        url:
+          type: string
+          description: The canonical HTTP URL of the comment on github.com.
+          example: "https://github.com/neomjs/neo/pull/10272#issuecomment-4309098042"
+        createdAt:
+          type: string
+          format: date-time
+          description: The creation timestamp (ISO-8601). Populated by 'create' action only.
+          example: "2026-04-24T01:48:14Z"
+        updatedAt:
+          type: string
+          format: date-time
+          description: The last-modified timestamp (ISO-8601). Populated by 'update' action only.
+          example: "2026-04-24T02:15:33Z"
 
     SyncIssuesResponse:
       type: object

--- a/ai/mcp/server/github-workflow/services/IssueService.mjs
+++ b/ai/mcp/server/github-workflow/services/IssueService.mjs
@@ -192,9 +192,21 @@ class IssueService extends Base {
                 ? idData.repository.pullRequest.id
                 : idData.repository.issue.id;
 
-            // Shared Mutation
-            await GraphqlService.query(ADD_COMMENT, { subjectId, body: finalBody });
-            return { message: `Successfully created comment on ${isPR ? 'PR' : 'issue'} #${number}` };
+            // Shared Mutation — capture response so we can surface the canonical comment
+            // identifier. Enables the A2A propagation pattern from #10272 §2.3: posting
+            // a review comment returns the commentId, which the reviewer can then relay
+            // via mailbox DM to the author; the author fetches just-this-comment via
+            // `get_conversation({comment_id: ...})` instead of re-walking the whole thread.
+            // Symmetric with `updateComment`'s existing `{commentId, url, updatedAt}` shape.
+            const result = await GraphqlService.query(ADD_COMMENT, { subjectId, body: finalBody });
+            const node   = result.addComment.commentEdge.node;
+
+            return {
+                message  : `Successfully created comment on ${isPR ? 'PR' : 'issue'} #${number}`,
+                commentId: node.id,
+                url      : node.url,
+                createdAt: node.createdAt
+            };
 
         } catch (error) {
             logger.error(`Error creating comment on ${isPR ? 'PR' : 'issue'} #${number} via GraphQL:`, error);

--- a/ai/mcp/server/github-workflow/services/PullRequestService.mjs
+++ b/ai/mcp/server/github-workflow/services/PullRequestService.mjs
@@ -54,23 +54,95 @@ class PullRequestService extends Base {
     }
 
     /**
-     * Gets the full conversation for a specific pull request.
-     * @param {number} prNumber The number of the pull request
-     * @returns {Promise<object>} A promise that resolves to the conversation data or a structured error.
+     * Gets the conversation for a specific pull request, optionally filtered by comment
+     * selector to reduce context-fetch cost across review cycles (#10272 §2.2).
+     *
+     * **Default behavior (no selectors):** returns full conversation — backward compatible
+     * with the pre-#10272 shape that callers depend on.
+     *
+     * **Selectors (first-match precedence, pick at most one):**
+     * - `comment_id` — fetch ONLY the comment whose GitHub node ID matches. Used for A2A
+     *   hand-off: a reviewer posts a comment, mailboxes the `commentId` from the create-path
+     *   return shape to the peer, peer fetches just-this-comment for near-zero context cost.
+     * - `since_comment_id` — fetch all comments AFTER the one with the given ID (exclusive).
+     *   Used for incremental review cycles: agent tracks the last seen commentId and fetches
+     *   only what's new. Scales linearly with new-comment volume, not cumulative thread size.
+     * - `last_n` — fetch the last N comments. Coarse-grained alternative when comment IDs
+     *   aren't tracked. Useful for quick catch-up scans.
+     *
+     * Selectors are applied client-side after a single GraphQL fetch (the fetch itself already
+     * caps at `aiConfig.pullRequest.maxCommentsPerPullRequest`). Server-side pagination
+     * optimization is a follow-up concern if empirical volume demands it; for current
+     * conversation sizes (up to a few dozen comments) client-side filter is simpler and
+     * avoids multi-query cursor choreography.
+     *
+     * @param {Object|number} options Either a number (legacy `prNumber` positional form, retained for
+     *                                backward compat) or an object with the shape below.
+     * @param {number}        options.pr_number         The pull request number (required when object form).
+     * @param {string}        [options.comment_id]      Return only the matching comment's data; other
+     *                                                  comments elided. PR title/body still returned.
+     * @param {string}        [options.since_comment_id] Return comments strictly after the matching
+     *                                                  comment (by createdAt order). If the id isn't found,
+     *                                                  returns empty comments (callers can interpret as
+     *                                                  "nothing new" or "id invalid").
+     * @param {number}        [options.last_n]          Return only the last N comments (by createdAt order).
+     * @returns {Promise<object>} Conversation data (optionally filtered) or a structured error.
      */
-    async getConversation(prNumber) {
+    async getConversation(options) {
+        // Accept legacy positional `prNumber` form for backward compatibility with any
+        // caller predating #10272. New callers use the object form for filter support.
+        const {pr_number, comment_id, since_comment_id, last_n} = typeof options === 'number'
+            ? {pr_number: options}
+            : (options || {});
+
+        if (!pr_number) {
+            return {
+                error  : 'Bad Request',
+                message: "Missing required argument: 'pr_number' is required.",
+                code   : 'MISSING_ARGUMENTS'
+            };
+        }
+
         const variables = {
             owner      : aiConfig.owner,
             repo       : aiConfig.repo,
-            prNumber,
+            prNumber   : pr_number,
             maxComments: aiConfig.pullRequest.maxCommentsPerPullRequest
         };
 
         try {
-            const data = await GraphqlService.query(GET_CONVERSATION, variables);
-            return data.repository.pullRequest;
+            const data         = await GraphqlService.query(GET_CONVERSATION, variables);
+            const pullRequest  = data.repository.pullRequest;
+            const allComments  = pullRequest.comments?.nodes || [];
+
+            // Selector precedence: comment_id > since_comment_id > last_n > full.
+            let filtered;
+
+            if (comment_id) {
+                filtered = allComments.filter(c => c.id === comment_id);
+            } else if (since_comment_id) {
+                const anchorIdx = allComments.findIndex(c => c.id === since_comment_id);
+                // Anchor not found → empty result set (callers interpret as "nothing after" or
+                // "invalid id"). Trying to infer intent would hide bugs.
+                filtered = anchorIdx === -1 ? [] : allComments.slice(anchorIdx + 1);
+            } else if (typeof last_n === 'number' && last_n > 0) {
+                filtered = allComments.slice(-last_n);
+            } else {
+                // No selector — return full conversation shape unchanged (backward compat).
+                return pullRequest;
+            }
+
+            // Filtered paths preserve PR title/body/author; only comments are narrowed.
+            // Caller can detect filtering via comments.length vs unfiltered fetch.
+            return {
+                ...pullRequest,
+                comments: {
+                    ...pullRequest.comments,
+                    nodes: filtered
+                }
+            };
         } catch (error) {
-            logger.error(`Error getting conversation for PR #${prNumber} via GraphQL:`, error);
+            logger.error(`Error getting conversation for PR #${pr_number} via GraphQL:`, error);
             return {
                 error  : 'GraphQL API request failed',
                 message: error.message,

--- a/ai/mcp/server/github-workflow/services/queries/mutations.mjs
+++ b/ai/mcp/server/github-workflow/services/queries/mutations.mjs
@@ -38,6 +38,11 @@ export const ADD_BLOCKED_BY = `
 /**
  * Mutation to add a comment to a subject (issue or PR).
  *
+ * Returns the new comment's `id`, `url`, and `createdAt` so the caller can surface
+ * the canonical identifier for A2A propagation patterns (per #10272 §2.3 —
+ * comment-ID hand-off via mailbox DMs lets the recipient `get_conversation` fetch
+ * just-this-comment via the `comment_id` param instead of re-fetching the whole thread).
+ *
  * Variables required:
  * - $subjectId: ID! - The global ID of the issue or PR
  * - $body: String! - The comment body
@@ -49,6 +54,7 @@ export const ADD_COMMENT = `
         node {
           id
           url
+          createdAt
         }
       }
     }

--- a/ai/mcp/server/github-workflow/services/queries/pullRequestQueries.mjs
+++ b/ai/mcp/server/github-workflow/services/queries/pullRequestQueries.mjs
@@ -24,6 +24,7 @@ export const GET_CONVERSATION = `
         }
         comments(first: $maxComments) {
           nodes {
+            id
             author {
               login
             }

--- a/test/playwright/unit/ai/mcp/server/github-workflow/IssueService.spec.mjs
+++ b/test/playwright/unit/ai/mcp/server/github-workflow/IssueService.spec.mjs
@@ -1,0 +1,268 @@
+import {setup} from '../../../../../setup.mjs';
+
+const appName = 'IssueServiceTest';
+
+setup({
+    neoConfig: {
+        unitTestMode: true
+    },
+    appConfig: {
+        name             : appName,
+        isMounted        : () => true,
+        vnodeInitialising: false
+    }
+});
+
+import {test, expect}  from '@playwright/test';
+import Neo             from '../../../../../../../src/Neo.mjs';
+import * as core       from '../../../../../../../src/core/_export.mjs';
+import InstanceManager from '../../../../../../../src/manager/Instance.mjs';
+
+/**
+ * @summary Contract coverage for `IssueService.manageIssueComment` enriched return shape (#10272 Phase 1).
+ *
+ * Prior to #10272, `createComment` returned only `{message}` — callers had no access to the
+ * canonical comment identifier (GitHub global node ID), URL, or creation timestamp. The missing
+ * identifier blocked the A2A propagation pattern (§2.3 of #10272): review-posts couldn't be
+ * referenced by the author for selective-fetch via `get_conversation({comment_id: ...})`.
+ *
+ * `updateComment` already returned `{message, commentId, url, updatedAt}` — this spec locks in the
+ * symmetric create-path contract: `{message, commentId, url, createdAt}`. Backward-compatible
+ * extension (existing consumers reading only `message` continue to work).
+ *
+ * Tests exercise the GraphQL response parsing path; the actual GitHub API call is mocked via
+ * `GraphqlService.query` monkey-patch (pattern established by `LabelService.spec.mjs` #10112).
+ *
+ * @see Neo.ai.mcp.server.github-workflow.services.IssueService#createComment
+ * @see Neo.ai.mcp.server.github-workflow.services.IssueService#updateComment
+ */
+test.describe('Neo.ai.mcp.server.github-workflow.services.IssueService — manageIssueComment (#10272)', () => {
+    let IssueService;
+    let GraphqlService;
+    let originalQuery;
+
+    test.beforeAll(async () => {
+        GraphqlService = (await import('../../../../../../../ai/mcp/server/github-workflow/services/GraphqlService.mjs')).default;
+        IssueService   = (await import('../../../../../../../ai/mcp/server/github-workflow/services/IssueService.mjs')).default;
+
+        originalQuery = GraphqlService.query.bind(GraphqlService);
+    });
+
+    test.afterAll(() => {
+        GraphqlService.query = originalQuery;
+    });
+
+    test.describe('create action', () => {
+        test('returns {message, commentId, url, createdAt} on successful issue-comment creation', async () => {
+            const ISSUE_NODE_ID     = 'I_kwDOABcD1234567890';
+            const NEW_COMMENT_ID    = 'IC_kwDOABcD_newcomment_9876';
+            const NEW_COMMENT_URL   = 'https://github.com/neomjs/neo/issues/10272#issuecomment-4309098042';
+            const NEW_COMMENT_TS    = '2026-04-24T01:48:14Z';
+
+            let callCount = 0;
+
+            GraphqlService.query = async (query, variables) => {
+                callCount++;
+                if (callCount === 1) {
+                    // Issue ID lookup
+                    return {repository: {issue: {id: ISSUE_NODE_ID}}};
+                }
+                if (callCount === 2) {
+                    // ADD_COMMENT mutation — matches the shape IssueService.createComment consumes
+                    return {
+                        addComment: {
+                            commentEdge: {
+                                node: {
+                                    id       : NEW_COMMENT_ID,
+                                    url      : NEW_COMMENT_URL,
+                                    createdAt: NEW_COMMENT_TS
+                                }
+                            }
+                        }
+                    };
+                }
+                throw new Error(`Unexpected additional GraphqlService.query call: ${callCount}`);
+            };
+
+            const result = await IssueService.manageIssueComment({
+                issue_number: 10272,
+                body        : 'Test comment body',
+                agent       : 'Claude Opus 4.7 (Claude Code)',
+                action      : 'create'
+            });
+
+            expect(result).toEqual({
+                message  : 'Successfully created comment on issue #10272',
+                commentId: NEW_COMMENT_ID,
+                url      : NEW_COMMENT_URL,
+                createdAt: NEW_COMMENT_TS
+            });
+
+            expect(callCount).toBe(2);
+        });
+
+        test('returns {message, commentId, url, createdAt} on successful PR-comment creation', async () => {
+            // PR path diverges only in the ID lookup (GET_PULL_REQUEST_ID vs GET_ISSUE_ID);
+            // the ADD_COMMENT mutation is shared. Asserting the PR path explicitly prevents
+            // regression on the divergent-lookup branch of createComment.
+            const PR_NODE_ID      = 'PR_kwDOABcD1234567890';
+            const NEW_COMMENT_ID  = 'IC_kwDOABcD_prcomment_5432';
+            const NEW_COMMENT_URL = 'https://github.com/neomjs/neo/pull/10268#issuecomment-4309099999';
+            const NEW_COMMENT_TS  = '2026-04-24T01:55:00Z';
+
+            let callCount = 0;
+
+            GraphqlService.query = async (query, variables) => {
+                callCount++;
+                if (callCount === 1) {
+                    return {repository: {pullRequest: {id: PR_NODE_ID}}};
+                }
+                if (callCount === 2) {
+                    return {
+                        addComment: {
+                            commentEdge: {
+                                node: {
+                                    id       : NEW_COMMENT_ID,
+                                    url      : NEW_COMMENT_URL,
+                                    createdAt: NEW_COMMENT_TS
+                                }
+                            }
+                        }
+                    };
+                }
+                throw new Error(`Unexpected additional GraphqlService.query call: ${callCount}`);
+            };
+
+            const result = await IssueService.manageIssueComment({
+                pr_number: 10268,
+                body     : 'PR review comment body',
+                agent    : 'Claude Opus 4.7 (Claude Code)',
+                action   : 'create'
+            });
+
+            expect(result).toEqual({
+                message  : 'Successfully created comment on PR #10268',
+                commentId: NEW_COMMENT_ID,
+                url      : NEW_COMMENT_URL,
+                createdAt: NEW_COMMENT_TS
+            });
+        });
+
+        test('rejects ambiguous subject (both issue_number and pr_number)', async () => {
+            // Input validation guard — must fail-fast before any GraphqlService.query is called.
+            let callCount = 0;
+            GraphqlService.query = async () => { callCount++; return null; };
+
+            const result = await IssueService.manageIssueComment({
+                issue_number: 10272,
+                pr_number   : 10268,
+                body        : 'Ambiguous',
+                agent       : 'Claude Opus 4.7 (Claude Code)',
+                action      : 'create'
+            });
+
+            expect(result.error).toBe('Bad Request');
+            expect(result.code).toBe('INVALID_ARGUMENTS');
+            expect(callCount).toBe(0);
+        });
+
+        test('rejects missing agent on create', async () => {
+            let callCount = 0;
+            GraphqlService.query = async () => { callCount++; return null; };
+
+            const result = await IssueService.manageIssueComment({
+                issue_number: 10272,
+                body        : 'Missing agent',
+                action      : 'create'
+            });
+
+            expect(result.error).toBe('Bad Request');
+            expect(result.code).toBe('MISSING_ARGUMENTS');
+            expect(callCount).toBe(0);
+        });
+
+        test('propagates GraphQL error shape on API failure', async () => {
+            GraphqlService.query = async () => {
+                throw new Error('GitHub API rate limit exceeded');
+            };
+
+            const result = await IssueService.manageIssueComment({
+                issue_number: 10272,
+                body        : 'Will fail',
+                agent       : 'Claude Opus 4.7 (Claude Code)',
+                action      : 'create'
+            });
+
+            expect(result.error).toBe('GraphQL API request failed');
+            expect(result.code).toBe('GRAPHQL_API_ERROR');
+            expect(result.message).toContain('rate limit');
+        });
+    });
+
+    test.describe('update action (existing contract — regression lock)', () => {
+        test('returns {message, commentId, url, updatedAt} — unchanged by #10272', async () => {
+            // Update path was already enriched pre-#10272; this test pins the existing contract
+            // so the create-path enrichment doesn't accidentally drift it. Symmetry matters.
+            const COMMENT_ID      = 'IC_kwDOABcD_existing_1234';
+            const COMMENT_URL     = 'https://github.com/neomjs/neo/issues/10272#issuecomment-4309098042';
+            const UPDATED_TS      = '2026-04-24T02:15:33Z';
+
+            GraphqlService.query = async (query, variables) => {
+                expect(variables.commentId).toBe(COMMENT_ID);
+                return {
+                    updateIssueComment: {
+                        issueComment: {
+                            id       : COMMENT_ID,
+                            url      : COMMENT_URL,
+                            updatedAt: UPDATED_TS
+                        }
+                    }
+                };
+            };
+
+            const result = await IssueService.manageIssueComment({
+                comment_id: COMMENT_ID,
+                body      : 'Updated body',
+                action    : 'update'
+            });
+
+            expect(result).toEqual({
+                message  : `Successfully updated comment ${COMMENT_ID}`,
+                commentId: COMMENT_ID,
+                url      : COMMENT_URL,
+                updatedAt: UPDATED_TS
+            });
+        });
+
+        test('rejects missing comment_id on update', async () => {
+            let callCount = 0;
+            GraphqlService.query = async () => { callCount++; return null; };
+
+            const result = await IssueService.manageIssueComment({
+                body  : 'No comment id',
+                action: 'update'
+            });
+
+            expect(result.error).toBe('Bad Request');
+            expect(result.code).toBe('MISSING_ARGUMENTS');
+            expect(callCount).toBe(0);
+        });
+    });
+
+    test.describe('dispatcher validation', () => {
+        test('rejects invalid action (must be create or update)', async () => {
+            let callCount = 0;
+            GraphqlService.query = async () => { callCount++; return null; };
+
+            const result = await IssueService.manageIssueComment({
+                issue_number: 10272,
+                body        : 'Ignored',
+                action      : 'delete'  // not a supported action
+            });
+
+            expect(result.error).toBe('Bad Request');
+            expect(result.code).toBe('INVALID_ARGUMENTS');
+            expect(callCount).toBe(0);
+        });
+    });
+});

--- a/test/playwright/unit/ai/mcp/server/github-workflow/PullRequestService.spec.mjs
+++ b/test/playwright/unit/ai/mcp/server/github-workflow/PullRequestService.spec.mjs
@@ -1,0 +1,222 @@
+import {setup} from '../../../../../setup.mjs';
+
+const appName = 'PullRequestServiceTest';
+
+setup({
+    neoConfig: {
+        unitTestMode: true
+    },
+    appConfig: {
+        name             : appName,
+        isMounted        : () => true,
+        vnodeInitialising: false
+    }
+});
+
+import {test, expect}  from '@playwright/test';
+import Neo             from '../../../../../../../src/Neo.mjs';
+import * as core       from '../../../../../../../src/core/_export.mjs';
+import InstanceManager from '../../../../../../../src/manager/Instance.mjs';
+
+/**
+ * @summary Contract coverage for `PullRequestService.getConversation` comment-selector params (#10272 §2.2).
+ *
+ * Prior to #10272, `getConversation(prNumber)` always returned the full PR conversation —
+ * every review cycle N+1 paid context-fetch cost proportional to cumulative thread size.
+ * This ticket added three optional selectors (`comment_id`, `since_comment_id`, `last_n`)
+ * that narrow the returned comments array at the cost of one client-side filter pass.
+ *
+ * These tests pin the selector contract:
+ * 1. No selectors → full conversation (backward-compat path).
+ * 2. `comment_id` → single-comment result (exact-match filter).
+ * 3. `since_comment_id` → comments strictly after the anchor (exclusive).
+ * 4. `last_n` → last N comments (by order).
+ * 5. Selector precedence (comment_id > since_comment_id > last_n) when multiple passed.
+ * 6. Legacy positional `prNumber` accepted (backward compat migration path).
+ *
+ * Each test mocks `GraphqlService.query` to return a controlled four-comment fixture so
+ * filter behavior is assertable without an actual GitHub API round-trip.
+ *
+ * @see Neo.ai.mcp.server.github-workflow.services.PullRequestService#getConversation
+ */
+test.describe('Neo.ai.mcp.server.github-workflow.services.PullRequestService — getConversation (#10272)', () => {
+    let PullRequestService;
+    let GraphqlService;
+    let originalQuery;
+
+    const COMMENT_A = {id: 'IC_a1111', author: {login: 'alice'}, body: 'First comment',  createdAt: '2026-04-24T01:00:00Z'};
+    const COMMENT_B = {id: 'IC_b2222', author: {login: 'bob'},   body: 'Second comment', createdAt: '2026-04-24T01:10:00Z'};
+    const COMMENT_C = {id: 'IC_c3333', author: {login: 'alice'}, body: 'Third comment',  createdAt: '2026-04-24T01:20:00Z'};
+    const COMMENT_D = {id: 'IC_d4444', author: {login: 'bob'},   body: 'Fourth comment', createdAt: '2026-04-24T01:30:00Z'};
+
+    const PR_FIXTURE = {
+        title   : 'Test PR',
+        body    : 'Body text',
+        author  : {login: 'alice'},
+        comments: {
+            nodes: [COMMENT_A, COMMENT_B, COMMENT_C, COMMENT_D]
+        }
+    };
+
+    test.beforeAll(async () => {
+        GraphqlService      = (await import('../../../../../../../ai/mcp/server/github-workflow/services/GraphqlService.mjs')).default;
+        PullRequestService  = (await import('../../../../../../../ai/mcp/server/github-workflow/services/PullRequestService.mjs')).default;
+
+        originalQuery = GraphqlService.query.bind(GraphqlService);
+    });
+
+    test.afterAll(() => {
+        GraphqlService.query = originalQuery;
+    });
+
+    test.beforeEach(() => {
+        GraphqlService.query = async () => ({repository: {pullRequest: PR_FIXTURE}});
+    });
+
+    test('returns full conversation when no selector is passed (backward-compat default)', async () => {
+        const result = await PullRequestService.getConversation({pr_number: 10272});
+
+        expect(result.title).toBe('Test PR');
+        expect(result.comments.nodes).toHaveLength(4);
+        expect(result.comments.nodes[0].id).toBe('IC_a1111');
+        expect(result.comments.nodes[3].id).toBe('IC_d4444');
+    });
+
+    test('accepts legacy positional prNumber form (backward-compat migration path)', async () => {
+        // Existing callers predating #10272 may pass `prNumber` positionally. The new
+        // signature must tolerate both forms to avoid a breaking change. Same result as
+        // the object form, just demonstrating the calling convention still works.
+        const result = await PullRequestService.getConversation(10272);
+
+        expect(result.title).toBe('Test PR');
+        expect(result.comments.nodes).toHaveLength(4);
+    });
+
+    test('comment_id selector returns only the matching comment', async () => {
+        const result = await PullRequestService.getConversation({
+            pr_number : 10272,
+            comment_id: 'IC_c3333'
+        });
+
+        expect(result.title).toBe('Test PR');  // PR metadata preserved
+        expect(result.comments.nodes).toHaveLength(1);
+        expect(result.comments.nodes[0].id).toBe('IC_c3333');
+        expect(result.comments.nodes[0].body).toBe('Third comment');
+    });
+
+    test('comment_id selector returns empty when id not found (no match ≠ fallback to full)', async () => {
+        // Critical distinction: a non-matching id must return zero comments, not fall
+        // through to full-conversation fetch. Silent fallthrough would mask bugs where
+        // caller's comment_id is stale/invalid.
+        const result = await PullRequestService.getConversation({
+            pr_number : 10272,
+            comment_id: 'IC_nonexistent'
+        });
+
+        expect(result.title).toBe('Test PR');
+        expect(result.comments.nodes).toHaveLength(0);
+    });
+
+    test('since_comment_id selector returns comments strictly AFTER the anchor', async () => {
+        const result = await PullRequestService.getConversation({
+            pr_number       : 10272,
+            since_comment_id: 'IC_b2222'  // anchor = 2nd comment
+        });
+
+        expect(result.comments.nodes).toHaveLength(2);
+        expect(result.comments.nodes[0].id).toBe('IC_c3333');  // 3rd
+        expect(result.comments.nodes[1].id).toBe('IC_d4444');  // 4th
+    });
+
+    test('since_comment_id at the last comment returns empty (nothing after)', async () => {
+        // Common usage pattern: agent tracks last-seen commentId, polls for new comments.
+        // When no new comments exist, empty result is the correct "nothing new" signal.
+        const result = await PullRequestService.getConversation({
+            pr_number       : 10272,
+            since_comment_id: 'IC_d4444'  // anchor = last comment
+        });
+
+        expect(result.comments.nodes).toHaveLength(0);
+    });
+
+    test('since_comment_id with invalid id returns empty (same shape as "nothing after")', async () => {
+        // Caller interprets empty result as either "nothing new since N" or "invalid id".
+        // Inferring intent would hide bugs; surfacing empty result lets caller decide.
+        const result = await PullRequestService.getConversation({
+            pr_number       : 10272,
+            since_comment_id: 'IC_nonexistent'
+        });
+
+        expect(result.comments.nodes).toHaveLength(0);
+    });
+
+    test('last_n selector returns last N comments in order', async () => {
+        const result = await PullRequestService.getConversation({
+            pr_number: 10272,
+            last_n   : 2
+        });
+
+        expect(result.comments.nodes).toHaveLength(2);
+        expect(result.comments.nodes[0].id).toBe('IC_c3333');  // 3rd of 4
+        expect(result.comments.nodes[1].id).toBe('IC_d4444');  // 4th of 4
+    });
+
+    test('last_n larger than available returns all comments', async () => {
+        // Array.slice(-N) behavior: negative index larger than length returns whole array.
+        // Asserting this explicitly so agents don't second-guess the edge case.
+        const result = await PullRequestService.getConversation({
+            pr_number: 10272,
+            last_n   : 100
+        });
+
+        expect(result.comments.nodes).toHaveLength(4);
+    });
+
+    test('selector precedence: comment_id wins over since_comment_id and last_n', async () => {
+        // When multiple selectors are passed, documented precedence applies.
+        // Comment_id is the most specific (single-comment fetch) so it takes priority.
+        const result = await PullRequestService.getConversation({
+            pr_number       : 10272,
+            comment_id      : 'IC_a1111',
+            since_comment_id: 'IC_b2222',
+            last_n          : 2
+        });
+
+        expect(result.comments.nodes).toHaveLength(1);
+        expect(result.comments.nodes[0].id).toBe('IC_a1111');  // comment_id won
+    });
+
+    test('selector precedence: since_comment_id wins over last_n when comment_id absent', async () => {
+        const result = await PullRequestService.getConversation({
+            pr_number       : 10272,
+            since_comment_id: 'IC_c3333',
+            last_n          : 2
+        });
+
+        expect(result.comments.nodes).toHaveLength(1);
+        expect(result.comments.nodes[0].id).toBe('IC_d4444');  // since_comment_id won
+    });
+
+    test('rejects missing pr_number with structured error (object form)', async () => {
+        let callCount = 0;
+        GraphqlService.query = async () => { callCount++; return null; };
+
+        const result = await PullRequestService.getConversation({comment_id: 'IC_a1111'});
+
+        expect(result.error).toBe('Bad Request');
+        expect(result.code).toBe('MISSING_ARGUMENTS');
+        expect(callCount).toBe(0);  // no GraphQL call made
+    });
+
+    test('propagates GraphQL error shape on API failure', async () => {
+        GraphqlService.query = async () => {
+            throw new Error('GitHub API authentication failed');
+        };
+
+        const result = await PullRequestService.getConversation({pr_number: 10272});
+
+        expect(result.error).toBe('GraphQL API request failed');
+        expect(result.code).toBe('GRAPHQL_API_ERROR');
+        expect(result.message).toContain('authentication');
+    });
+});


### PR DESCRIPTION
## Summary

Enables the A2A comment-ID hand-off pattern across three coordinated phases. A reviewer captures `commentId` from `manage_issue_comment`'s enriched response and mailboxes it to the peer; peer fetches just-this-comment via `get_conversation({comment_id})` instead of re-walking the whole thread. **Scales linearly with new-comment volume across multi-cycle reviews rather than cumulative thread size.**

Empirical motivation from this session: by cycle 3 of #10269's three-cycle cross-family review, `get_conversation` was returning ~15K tokens of prior-round content that the current-cycle reviewer had already seen. This PR closes that context-waste path without introducing new tools (stays within the 84/100 tool-surface discipline — same condensation pattern as `manage_database` replacing `start_database` + `stop_database`).

## Phases (all in one PR — three bites unblock each other)

### Phase 1 — `manage_issue_comment` enriched response

- `ADD_COMMENT` GraphQL mutation extended with `createdAt` on the comment node.
- `createComment` now captures the response and returns `{message, commentId, url, createdAt}` — matching `updateComment`'s existing `{message, commentId, url, updatedAt}` shape.
- `openapi.yaml` introduces a new `CommentResponse` schema extending `SuccessResponse`. Backward-compatible: existing consumers reading only `message` continue to work; new fields are additive.

### Phase 2 — `get_conversation` selectors

- `GET_CONVERSATION` extended with `id` field on comment nodes.
- `getConversation` accepts object options `{pr_number, comment_id?, since_comment_id?, last_n?}`. Legacy positional `prNumber` form retained via type-discrimination at the entry point (backward-compat migration path).
- **Selector precedence:** `comment_id` > `since_comment_id` > `last_n` > full. Client-side filter post-fetch (single GraphQL query already caps at `maxCommentsPerPullRequest`).
- `openapi.yaml` switches `get_conversation` to `x-pass-as-object: true` with the new optional params and a structured 200 response schema.

### Phase 3 — A2A propagation convention codified

- `pr-review-guide.md §9` — **A2A Comment-ID Hand-off Protocol (reviewer side)**. Workflow, selector precedence, anti-patterns.
- `pull-request-workflow.md §8.1` — symmetric **Author-side propagation** for multi-cycle review response loops.

## Test Evidence

```
npx playwright test -c test/playwright/playwright.config.unit.mjs \
  test/playwright/unit/ai/mcp/server/github-workflow/IssueService.spec.mjs \
  test/playwright/unit/ai/mcp/server/github-workflow/PullRequestService.spec.mjs
# 21 passed (952ms)
```

- **IssueService.spec.mjs** (8 tests): create-action enriched-return assertion (issue + PR paths), update-action regression lock, input validation guards, GraphQL error propagation.
- **PullRequestService.spec.mjs** (13 tests): default full-fetch, each selector in isolation, selector precedence when multiple passed, invalid-id behavior (empty result, no silent fallback to full), legacy positional form, structured errors.

## Stepping Back — Reflection Protocol

Considered and explicitly rejected:

- **Splitting into three PRs (one per phase).** Phase 3 docs reference Phases 1 and 2 mechanics; a split would land aspirational-convention docs before the substrate they describe. Bundling demonstrates the complete pattern in one reviewable artifact.
- **Server-side pagination via GraphQL cursor for selectors.** Considered, rejected as premature. Current PR conversation sizes (dozens of comments at most) make client-side filter adequate. If empirical volume demands server-side, it's a follow-up — doesn't block the A2A pattern.
- **Extending `manage_discussion_comment` symmetrically in this PR.** Deferred as out-of-scope. The pattern translates directly — same `{commentId, url, createdAt}` enrichment applies — but keeping this PR focused on the ticket's stated `manage_issue_comment` scope. Natural follow-up ticket if cross-Discussion A2A propagation warrants.

## Out of Scope

- **Discussion-comment parallel enrichment** (`manage_discussion_comment` / `DiscussionService.addCommentToDiscussion`). Deferred; pattern translates directly.
- **Server-side pagination** via GraphQL `after` cursor for `since_comment_id`. Client-side filter works for current volumes.
- **Retroactive tooling** for existing long threads. Forward-looking only.

## Related

- Origin: 2026-04-24 session empirical motivation — #10269 three-cycle review context-fetch growth.
- Cross-family endorsement of the shape: @neo-gemini-3-1-pro's 2026-04-24 01:06 reply confirming the comment-ID hand-off value.
- Related meta-enhancement tickets from the same session: #10270 (ChromaManager boot warning), #10273 / PR #10279 (decile anchor rubric), #10274 / PR #10277 (merge-auth), #10275 (silence detection daemon), #10276 (ideation adjacency sweep), #10278 / PR #10282 (ideation iterative workflow), #10284 (MailboxService post-linkNodes verification).
- Tool-surface condensation precedent: `manage_database` replacing `start_database` + `stop_database`.

Resolves #10272