### PR TITLE
feat(skills): create industry-friction-radar skill (#10297)

### DIFF
--- a/.agent/skills/industry-friction-radar/SKILL.md
+++ b/.agent/skills/industry-friction-radar/SKILL.md
@@ -19,7 +19,13 @@ This skill serves as the external sensory organ for the Neo organism, feeding ma
 Do NOT proceed until you have read and internalized the strict 3-step abstraction workflow:
 - Read: `references/industry-friction-radar-workflow.md`
 
-## Integrations
+## Integrations & Context
+
+To understand the macro-architecture this skill serves (Neo as an Application Engine on the Left Hemisphere, and Agent OS on the Right Hemisphere), review the following:
+
+- `learn/benefits/ArchitectureOverview.md` (Left/Right Hemispheres)
+- `learn/agentos/DreamPipeline.md` (Sensory Input & DreamService)
+- `resources/content/discussions/discussion-10119.md` (Engine-category vs. Framework-category positioning)
+- `resources/content/discussions/discussion-10137.md` (Agent OS context)
 
 - Outputs MUST be fed into the `ideation-sandbox` skill (never direct Pull Requests).
-- Relates to `learn/benefits/ArchitectureOverview.md` (Left/Right Hemispheres) and `learn/agentos/DreamPipeline.md` (Sensory Input).

--- a/.agent/skills/industry-friction-radar/SKILL.md
+++ b/.agent/skills/industry-friction-radar/SKILL.md
@@ -1,31 +1,9 @@
 ---
 name: industry-friction-radar
 description: Proactive SOTA research loop using a strict 3-step abstraction protocol to extract engine-category friction points without importing framework-category bias or stealing code.
+triggers: Use this skill when executing periodic "horizon scans" for the Dream Pipeline, researching external solutions to deeply complex engine-level friction points, or evaluating JS ecosystem trends.
 ---
 
 # Industry Friction Radar
 
-This skill serves as the external sensory organ for the Neo organism, feeding macro-trends into the Native Edge Graph via the Dream Pipeline and informing UI/Core development.
-
-**CRITICAL:** This skill enforces a strict abstraction protocol to ensure we learn from industry SOTA without stealing code, importing framework-specific paradigms (like React's hydration), or propagating subtle LLM framing biases.
-
-## When to Use
-- When executing periodic "horizon scans" for the Dream Pipeline.
-- When tasked with researching external solutions to a deeply complex engine-level friction point.
-- When evaluating 2026/2027 JS ecosystem trends (native typing, WebGPU, new Worker paradigms).
-
-## Protocol Instructions
-
-Do NOT proceed until you have read and internalized the strict 3-step abstraction workflow:
-- Read: `references/industry-friction-radar-workflow.md`
-
-## Integrations & Context
-
-To understand the macro-architecture this skill serves (Neo as an Application Engine on the Left Hemisphere, and Agent OS on the Right Hemisphere), review the following:
-
-- `learn/benefits/ArchitectureOverview.md` (Left/Right Hemispheres)
-- `learn/agentos/DreamPipeline.md` (Sensory Input & DreamService)
-- `resources/content/discussions/discussion-10119.md` (Engine-category vs. Framework-category positioning)
-- `resources/content/discussions/discussion-10137.md` (Agent OS context)
-
-- Outputs MUST be fed into the `ideation-sandbox` skill (never direct Pull Requests).
+If you are tasked with executing an industry friction radar scan, you MUST immediately use the `view_file` tool to read and strictly adhere to `/Users/Shared/antigravity/neomjs/neo/.agent/skills/industry-friction-radar/references/industry-friction-radar-workflow.md` before proceeding.

--- a/.agent/skills/industry-friction-radar/SKILL.md
+++ b/.agent/skills/industry-friction-radar/SKILL.md
@@ -1,0 +1,25 @@
+---
+name: industry-friction-radar
+description: Proactive SOTA research loop using a strict 3-step abstraction protocol to extract engine-category friction points without importing framework-category bias or stealing code.
+---
+
+# Industry Friction Radar
+
+This skill serves as the external sensory organ for the Neo organism, feeding macro-trends into the Native Edge Graph via the Dream Pipeline and informing UI/Core development.
+
+**CRITICAL:** This skill enforces a strict abstraction protocol to ensure we learn from industry SOTA without stealing code, importing framework-specific paradigms (like React's hydration), or propagating subtle LLM framing biases.
+
+## When to Use
+- When executing periodic "horizon scans" for the Dream Pipeline.
+- When tasked with researching external solutions to a deeply complex engine-level friction point.
+- When evaluating 2026/2027 JS ecosystem trends (native typing, WebGPU, new Worker paradigms).
+
+## Protocol Instructions
+
+Do NOT proceed until you have read and internalized the strict 3-step abstraction workflow:
+- Read: `references/industry-friction-radar-workflow.md`
+
+## Integrations
+
+- Outputs MUST be fed into the `ideation-sandbox` skill (never direct Pull Requests).
+- Relates to `learn/benefits/ArchitectureOverview.md` (Left/Right Hemispheres) and `learn/agentos/DreamPipeline.md` (Sensory Input).

--- a/.agent/skills/industry-friction-radar/SKILL.md
+++ b/.agent/skills/industry-friction-radar/SKILL.md
@@ -6,4 +6,4 @@ triggers: Use this skill when executing periodic "horizon scans" for the Dream P
 
 # Industry Friction Radar
 
-If you are tasked with executing an industry friction radar scan, you MUST immediately use the `view_file` tool to read and strictly adhere to `/Users/Shared/antigravity/neomjs/neo/.agent/skills/industry-friction-radar/references/industry-friction-radar-workflow.md` before proceeding.
+If you are tasked with executing an industry friction radar scan, you MUST immediately use the `view_file` tool to read and strictly adhere to `.agent/skills/industry-friction-radar/references/industry-friction-radar-workflow.md` before proceeding.

--- a/.agent/skills/industry-friction-radar/references/industry-friction-radar-workflow.md
+++ b/.agent/skills/industry-friction-radar/references/industry-friction-radar-workflow.md
@@ -1,5 +1,7 @@
 # Industry Friction Radar Workflow
 
+**Anchor Summary:** This protocol governs the Neo organism's external sensory organ. It defines a strict 3-step abstraction pipeline required to systematically ingest State of the Art (SOTA) industry developments (like native JS features or worker paradigms) and synthesize them into Neo-native innovations, without violating Neo's ethical boundaries, stealing code, or importing framework-specific architectural noise.
+
 This protocol outlines the strict 3-step abstraction pipeline required to systematically ingest State of the Art (SOTA) developments without violating Neo's ethical boundaries or architectural paradigms.
 
 ## The Architecture vs. Framework Filter
@@ -18,7 +20,7 @@ Use the `search_web` tool to identify bleeding-edge developments within the Engi
 ### Step 2: Friction Extraction (The "Why")
 You are strictly forbidden from analyzing or replicating external implementation code. Instead, abstract the underlying problem. *Why* did the industry build this? What fundamental friction were they trying to solve?
 
-**Process Boundary:** You must output a structured JSON schema representing the friction. This strips away subtle framing bias from the source material and ensures we do not carry external context forward.
+**Semantic Boundary:** You must output a structured JSON schema representing the friction. This strips away subtle framing bias from the source material and ensures we do not carry external context forward.
 
 ```json
 {
@@ -40,7 +42,7 @@ You must use the `ideation-sandbox` skill to post a GitHub Discussion proposing 
 ## Output Rules
 - **No Direct PRs:** This skill produces Ideas (Discussions), never Code (Commits/PRs).
 - **Attribution:** The resulting GitHub Discussion MUST include an Author's Note citing the provenance of the friction point, using the `citations` array from Step 2. (e.g., *"External friction observed in [ecosystem] [date]; this Discussion abstracts and responds natively via Neo's architecture."*)
-- **Adjacency Sweep:** Before posting the Discussion, execute a duplicate sweep (per `ticket-create` guidelines) to ensure the concept isn't already being discussed.
+- **Adjacency Sweep:** Before posting the Discussion, execute a duplicate sweep (per `ideation-sandbox` guidelines) to ensure the concept isn't already being discussed.
 
 ## Integrations & Context
 

--- a/.agent/skills/industry-friction-radar/references/industry-friction-radar-workflow.md
+++ b/.agent/skills/industry-friction-radar/references/industry-friction-radar-workflow.md
@@ -23,7 +23,7 @@ You are strictly forbidden from analyzing or replicating external implementation
 ```json
 {
   "friction_point": "<abstracted problem statement>",
-  "engine_domain": "<Left Hemisphere (UI/Core) or Right Hemisphere (Agent OS)>",
+  "engine_domain": "<Left Hemisphere (Application Engine) or Right Hemisphere (Agent OS)>",
   "citations": [
     { "url": "<source URL>", "date": "<date observed>", "ecosystem": "<ecosystem name>" }
   ]

--- a/.agent/skills/industry-friction-radar/references/industry-friction-radar-workflow.md
+++ b/.agent/skills/industry-friction-radar/references/industry-friction-radar-workflow.md
@@ -41,3 +41,12 @@ You must use the `ideation-sandbox` skill to post a GitHub Discussion proposing 
 - **No Direct PRs:** This skill produces Ideas (Discussions), never Code (Commits/PRs).
 - **Attribution:** The resulting GitHub Discussion MUST include an Author's Note citing the provenance of the friction point, using the `citations` array from Step 2. (e.g., *"External friction observed in [ecosystem] [date]; this Discussion abstracts and responds natively via Neo's architecture."*)
 - **Adjacency Sweep:** Before posting the Discussion, execute a duplicate sweep (per `ticket-create` guidelines) to ensure the concept isn't already being discussed.
+
+## Integrations & Context
+
+To understand the macro-architecture this skill serves (Neo as an Application Engine on the Left Hemisphere, and Agent OS on the Right Hemisphere), review the following:
+
+- `learn/benefits/ArchitectureOverview.md` (Left/Right Hemispheres)
+- `learn/agentos/DreamPipeline.md` (Sensory Input & DreamService)
+- `resources/content/discussions/discussion-10119.md` (Engine-category vs. Framework-category positioning)
+- `resources/content/discussions/discussion-10137.md` (Agent OS context)

--- a/.agent/skills/industry-friction-radar/references/industry-friction-radar-workflow.md
+++ b/.agent/skills/industry-friction-radar/references/industry-friction-radar-workflow.md
@@ -1,0 +1,43 @@
+# Industry Friction Radar Workflow
+
+This protocol outlines the strict 3-step abstraction pipeline required to systematically ingest State of the Art (SOTA) developments without violating Neo's ethical boundaries or architectural paradigms.
+
+## The Architecture vs. Framework Filter
+
+Neo.mjs is an **Application Engine** (akin to Unreal or Godot), not a traditional frontend framework (akin to React, Vue, or Angular). 
+
+When evaluating trends, you **MUST** apply the Engine-Category Filter:
+- ❌ **Reject Framework-Category Noise:** Hydration strategies, Server Components (RSC), Virtual DOM reconciliation hacks, generic signals.
+- ✅ **Prioritize Engine-Category Signal:** New ECMAScript native features (e.g., native typing), SharedArrayBuffer memory management, zero-allocation math, WebGPU compute, continuous-simulation in Workers, SharedWorker paradigms.
+
+## The 3-Step Protocol
+
+### Step 1: Trend Ingestion (The "What")
+Use the `search_web` tool to identify bleeding-edge developments within the Engine-Category constraints. Focus on what the industry is currently struggling with or hyping.
+
+### Step 2: Friction Extraction (The "Why")
+You are strictly forbidden from analyzing or replicating external implementation code. Instead, abstract the underlying problem. *Why* did the industry build this? What fundamental friction were they trying to solve?
+
+**Process Boundary:** You must output a structured JSON schema representing the friction. This strips away subtle framing bias from the source material and ensures we do not carry external context forward.
+
+```json
+{
+  "friction_point": "<abstracted problem statement>",
+  "engine_domain": "<Left Hemisphere (UI/Core) or Right Hemisphere (Agent OS)>",
+  "citations": [
+    { "url": "<source URL>", "date": "<date observed>", "ecosystem": "<ecosystem name>" }
+  ]
+}
+```
+
+### Step 3: Native Ideation (The "How")
+**CRITICAL:** Before proceeding to Step 3, you MUST drop all raw external context. You may only carry forward the structured JSON from Step 2. Do not combine Step 2 and Step 3 into a single thought process.
+
+Using ONLY the JSON projection, look inward at the Neo.mjs architecture. Ask: *"Given Neo's Worker-driven, multi-threaded Scene Graph, how do we solve this abstracted friction point natively?"*
+
+You must use the `ideation-sandbox` skill to post a GitHub Discussion proposing your native innovation.
+
+## Output Rules
+- **No Direct PRs:** This skill produces Ideas (Discussions), never Code (Commits/PRs).
+- **Attribution:** The resulting GitHub Discussion MUST include an Author's Note citing the provenance of the friction point, using the `citations` array from Step 2. (e.g., *"External friction observed in [ecosystem] [date]; this Discussion abstracts and responds natively via Neo's architecture."*)
+- **Adjacency Sweep:** Before posting the Discussion, execute a duplicate sweep (per `ticket-create` guidelines) to ensure the concept isn't already being discussed.


### PR DESCRIPTION
Authored by Neo-Gemini-3-1-Pro (Antigravity) consuming Neo-Opus-4-7's ideation handoff — session 0b29a8fa-c6b0-42e2-ab3b-8015a99db2d8.

Resolves #10297

Implemented the `industry-friction-radar` skill, establishing a systematic SOTA innovation intake mechanism while enforcing strict engine-category architectural boundaries.

## Deltas from ticket
- Explicitly documented the `ideation-sandbox` output integration and duplicate sweep necessity in Step 3.
- Added explicit citations array to the JSON schema output in Step 2 for provenance attribution.

## Test Evidence
- Verified formatting of `SKILL.md` and `references/industry-friction-radar-workflow.md`.