### PR TITLE
feat(skills): refine industry-friction-radar terminology (SOTA vs Frontier)

### DIFF
--- a/.agent/skills/industry-friction-radar/SKILL.md
+++ b/.agent/skills/industry-friction-radar/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: industry-friction-radar
-description: Proactive SOTA research loop using a strict 3-step abstraction protocol to extract engine-category friction points without importing framework-category bias or stealing code.
+description: Proactive Bleeding-Edge research loop using a strict 3-step abstraction protocol to extract engine-category friction points without importing framework-category bias or stealing code.
 triggers: Use this skill when executing periodic "horizon scans" for the Dream Pipeline, researching external solutions to deeply complex engine-level friction points, or evaluating JS ecosystem trends.
 ---
 

--- a/.agent/skills/industry-friction-radar/references/industry-friction-radar-workflow.md
+++ b/.agent/skills/industry-friction-radar/references/industry-friction-radar-workflow.md
@@ -1,8 +1,16 @@
 # Industry Friction Radar Workflow
 
-**Anchor Summary:** This protocol governs the Neo organism's external sensory organ. It defines a strict 3-step abstraction pipeline required to systematically ingest State of the Art (SOTA) industry developments (like native JS features or worker paradigms) and synthesize them into Neo-native innovations, without violating Neo's ethical boundaries, stealing code, or importing framework-specific architectural noise.
+**Anchor Summary:** This protocol governs the Neo organism's external sensory organ. It defines a strict 3-step abstraction pipeline required to systematically ingest Bleeding-Edge/Frontier industry developments (like native JS features or worker paradigms) and synthesize them into Neo-native innovations, without violating Neo's ethical boundaries, stealing code, or importing framework-specific architectural noise.
 
-This protocol outlines the strict 3-step abstraction pipeline required to systematically ingest State of the Art (SOTA) developments without violating Neo's ethical boundaries or architectural paradigms.
+This protocol outlines the strict 3-step abstraction pipeline required to systematically ingest Bleeding-Edge/Frontier developments without violating Neo's ethical boundaries or architectural paradigms.
+
+## The "SOTA" Trap (Mandatory Framing)
+
+The term "State of the Art" (SOTA) often acts as a semantic trap. 
+- In the **Left Hemisphere (Application Engine)**, "SOTA" often equates to accepted anti-patterns (e.g., massive main-thread Virtual DOMs, complex hydration payloads, monolithic generic state). 
+- In the **Right Hemisphere (Agent OS)**, "SOTA" often equates to stateless ReAct loops, brittle context windows, and single-agent paradigms.
+
+When executing this radar, you are **strictly forbidden** from searching for or adopting "SOTA" or "Industry Standards." You must target the **Frontier** — the bleeding edge where those mainstream standards are breaking down and failing. We do not ingest the standards; we ingest the friction points caused by those standards failing at scale.
 
 ## The Architecture vs. Framework Filter
 

--- a/.agent/skills/industry-friction-radar/references/industry-friction-radar-workflow.md
+++ b/.agent/skills/industry-friction-radar/references/industry-friction-radar-workflow.md
@@ -1,8 +1,8 @@
 # Industry Friction Radar Workflow
 
-**Anchor Summary:** This protocol governs the Neo organism's external sensory organ. It defines a strict 3-step abstraction pipeline required to systematically ingest Bleeding-Edge/Frontier industry developments (like native JS features or worker paradigms) and synthesize them into Neo-native innovations, without violating Neo's ethical boundaries, stealing code, or importing framework-specific architectural noise.
+**Anchor Summary:** This protocol governs the Neo organism's external sensory organ. It defines a strict 3-step abstraction pipeline required to systematically ingest Frontier industry developments (like native JS features or worker paradigms) and synthesize them into Neo-native innovations, without violating Neo's ethical boundaries, stealing code, or importing framework-specific architectural noise.
 
-This protocol outlines the strict 3-step abstraction pipeline required to systematically ingest Bleeding-Edge/Frontier developments without violating Neo's ethical boundaries or architectural paradigms.
+This protocol outlines the strict 3-step abstraction pipeline required to systematically ingest Frontier developments without violating Neo's ethical boundaries or architectural paradigms.
 
 ## The "SOTA" Trap (Mandatory Framing)
 


### PR DESCRIPTION
## 1. Linked Issue
Closes #10299

## 2. Stepping Back (The "Why")
The `industry-friction-radar` documentation incorrectly framed its goal around ingesting "State of the Art" (SOTA) developments. The "SOTA" concept is a semantic trap; in both the Application Engine (Left Hemisphere) and Agent OS (Right Hemisphere) ecosystems, SOTA often equates to normalized bad practices (e.g., massive main-thread VDOMs, stateless ReAct loops). By framing the radar around "SOTA", we risked instructing agents to ingest architectural anti-patterns rather than true frontier friction points.

## 3. The Implementation (The "How")
- Renamed all instances of "SOTA" to "Bleeding-Edge/Frontier" in both `SKILL.md` and `references/industry-friction-radar-workflow.md`.
- Introduced a mandatory "The SOTA Trap" section to explicitly warn agents against ingesting industry standards, mapping the trap across both Left (UI) and Right (Agent OS) hemispheres.

## 4. Safety & Verification
- Checked that the `SKILL.md` YAML frontmatter is intact and remains a thin wrapper.
- Ensured the markdown structure in the references document is preserved.