### PR TITLE
fix(mcp): wrap openapi description in quotes to prevent YAMLException on boot (#10305)

### DIFF
--- a/.agent/skills/self-repair/references/self-repair-protocol.md
+++ b/.agent/skills/self-repair/references/self-repair-protocol.md
@@ -12,6 +12,7 @@ Your first priority is determining if the bridge between the Neo.mjs Agent OS cl
     - **Neural Link Bridge** ensures realtime VDOM sync (script: `npm run ai:server-neural-link`)
     - Search for and terminate zombie processes if ports are locked before attempting to restart the services.
 3. **Deep Infrastructure Introspection (`ai/services.mjs`)**: The entire Agent OS backend is located in `/Users/Shared/github/neomjs/neo/ai`. The `ai/services.mjs` module aggregates dependencies, allowing you to bypass full MCP HTTP boundaries and interact natively with internal tooling. If servers crash on boot, use `ai/examples/` (such as chroma checks) or a generic Node process to invoke internal routines via `services.mjs` directly.
+    - *Known Failure Mode (The YAML Cascade):* Because `ai/services.mjs` eagerly parses configurations via `ToolService`, a syntax error (e.g., an unquoted string containing `: ` causing a `YAMLException`) in *any* MCP server's `openapi.yaml` will abort the initialization sequence, preventing subsequent MCP servers in the configuration from booting.
 4. **Native Terminal Execution**: If an MCP connection fails or an MCP server is unreachable, do not blindly guess why. Boot the Neo MCP servers directly in a separate terminal process using the `run_command` tool to witness the crash or monitor logs. You have native control; use it.
 
 ## Phase 2: Historical Forensics (The "How Did We Get Here" Protocol)

--- a/ai/mcp/server/github-workflow/openapi.yaml
+++ b/ai/mcp/server/github-workflow/openapi.yaml
@@ -1206,7 +1206,7 @@ components:
           example: "Successfully created comment on PR #10272"
         commentId:
           type: string
-          description: The canonical GitHub global node ID of the comment. Use with `get_conversation({comment_id: ...})` or in A2A payloads to reference just-this-comment.
+          description: "The canonical GitHub global node ID of the comment. Use with `get_conversation({comment_id: ...})` or in A2A payloads to reference just-this-comment."
           example: "IC_kwDOABcD1234567890"
         url:
           type: string


### PR DESCRIPTION
Resolves #10305

Fixed a critical boot failure in the Neo.mjs Memory Core MCP server and all other eagerly loaded MCP servers. The root cause was a YAML syntax error in `ai/mcp/server/github-workflow/openapi.yaml` (line 1209) causing a `YAMLException: bad indentation of a mapping entry`. An unquoted description containing the sequence `: ` (specifically inside a `get_conversation` example) triggered a parser failure which cascaded due to synchronous loading in `ai/services.mjs`.

## Deltas from ticket (if any)
N/A. Wrapped the offending description string in double quotes to satisfy the `js-yaml` parser.

## Test Evidence
- Verified fix locally.
- Successfully ran Playwright test suites:
    - `OpenApiValidatorCompliance.spec.mjs` (Passed, 23/23)
    - `McpServersHealth.spec.mjs` (Passed, 5/5)

Authored by Gemini 3.1 Pro (Antigravity). Session 0b29a8fa-c6b0-42e2-ab3b-8015a99db2d8.