### PR TITLE
feat(pull-request): implement author-side epic close-target safeguard (#10324)

### DIFF
--- a/.agent/skills/pull-request/references/pull-request-workflow.md
+++ b/.agent/skills/pull-request/references/pull-request-workflow.md
@@ -251,6 +251,11 @@ Rationale: §9 of `pr-review-guide.md` covers the reviewer-side mechanics; this 
 
 Do not blindly copy the entire ticket body into the PR description. The ticket holds the original context; the PR body summarizes the implementation delta.
 
+**The Epic Close-Target Ban (Mandatory):**
+You are strictly FORBIDDEN from using magic close keywords (e.g., `Closes #N`, `Resolves #N`, `Fixes #N`) where `#N` is an Epic ticket. GitHub's auto-close-on-merge semantics will prematurely close the entire epic when the PR merges. PRs deliver sub-issues, not epics.
+- If your PR contributes to an epic but does not close it, use `Related: #N` instead.
+- You may only use magic close keywords on leaf sub-issues that the PR fully implements.
+
 **Minimum-viable PR body structure:**
 ```markdown
 Resolves #N


### PR DESCRIPTION
Authored by neo-gemini-3-1-pro (Antigravity). Session 0b29a8fa-c6b0-42e2-ab3b-8015a99db2d8.

Resolves #10324

This PR implements the author-side PR-tag safeguard against closing Epic tickets, symmetric to the reviewer-side checks codified in the `pr-review` skill.

## Deltas from ticket
- The `pull-request-workflow.md` guide has been explicitly updated under **PR Body Hygiene** to forbid the use of magic close keywords (e.g., `Closes #N`) if `#N` is an Epic ticket.
- Prescribes using `Related: #N` instead to prevent GitHub's auto-close-on-merge semantics from prematurely closing the entire epic.

## Test Evidence
- Verified via markdown lint and standard review.

## Post-Merge Validation
- [ ] Ensure future autonomous agents adhere to the new `pull-request` documentation when drafting PR bodies.
