### PR TITLE
docs(skills): explicitly mandate --base dev flag for PR creation (#10207)

### DIFF
--- a/.agent/skills/pull-request/references/pull-request-workflow.md
+++ b/.agent/skills/pull-request/references/pull-request-workflow.md
@@ -93,7 +93,11 @@ Decision rule: *"Does this enable a new capability that did not exist before?"* 
 
 ## 4. Pull Request Creation
 
-You MUST use the GitHub CLI to open a Pull Request targeting the `dev` branch. You are strictly forbidden from using the `--fill` flag, as it bypasses the generation of a comprehensive PR body.
+You MUST use the GitHub CLI to open a Pull Request targeting the `dev` branch. 
+
+**Mandatory Base Branch Flag:** You MUST explicitly include the `--base dev` flag in your command. Never rely on the default branch parameter, as it may inadvertently default to `main` and result in massive, thousands-of-commits diff bloat.
+
+**No Auto-Fill:** You are strictly forbidden from using the `--fill` flag, as it bypasses the generation of a comprehensive PR body.
 
 ```bash
 gh pr create --title "feat/fix/chore: Your Title (#TICKET_ID)" --body "Comprehensive markdown body explaining architectural impact, edge cases, and explicitly stating Resolves #TICKET_ID" --base dev


### PR DESCRIPTION
## Problem
Agents occasionally forget to specify the target branch when running `gh pr create`. When this happens, GitHub CLI defaults to the repository's default branch (often `main`). If `main` is severely behind `dev`, this results in massive diff bloat and pollutes the review cycle, risking near-miss merges of huge diffs.

## Solution
This PR explicitly addresses Issue #10207 by updating the `pull-request` skill workflow documentation:
1. Adds a **Mandatory Base Branch Flag** warning to section 4, explicitly requiring the `--base dev` flag.
2. Warns against relying on the default branch parameter to avoid diff bloat.

The first half of #10207 (promoting rebase-before-PR) was already codified via #10212 into section 2.3.1. This PR completes the requirements.

Resolves #10207

Authored by Gemini 3.1 Pro (Antigravity). Session 0b29a8fa-c6b0-42e2-ab3b-8015a99db2d8.
