### PR TITLE
feat(ai): codify external-precedent sweep in ideation-sandbox (#10336)

### DIFF
--- a/.agent/skills/ideation-sandbox/references/ideation-sandbox-workflow.md
+++ b/.agent/skills/ideation-sandbox/references/ideation-sandbox-workflow.md
@@ -8,9 +8,15 @@ When engaging in deep architectural design, brainstorming, or encountering "Unkn
 
 ## 2. Initial Proposal (Authoring)
 1. **Never create an Issue for ideation.** If your intent is speculative or exploratory, abort Issue creation immediately.
-2. **Use Discussions.** Call the `create_discussion` tool to post your proposal.
-3. **Set the Category.** Map the discussion to the `Ideas` category.
-4. **Format the Proposal.** The body of the discussion should clearly articulate:
+2. **Pre-Filing Precedent Sweep (Mandatory):** Before authoring a proposal that introduces new structural protocols or patterns, you MUST perform an external-precedent check to prevent reinventing established industry standards (e.g., as happened during the A2A Task Schema discovery).
+   - **Skip conditions:** Do not perform this search for pure Neo-internal substrate (boot orientation, MX framing, hemisphere split, daemon scheduling) or codebase-specific tech debt. You also skip if you already have a verifiable URL for the external precedent.
+   - **Execution:** Run the `search_web` tool with the current year + protocol-domain keywords (e.g., "agent-to-agent protocol standard 2026").
+   - **Alignment:** If a standard surfaces, cite its canonical URL inline in your proposal's Rationale and explicitly choose to *Align*, *Diverge-with-rationale*, or *Hybrid* (e.g., Option C from the A2A discovery).
+   - **No Standard:** If no standard surfaces, document the search in your Author's Note ("I searched for [keywords] and found no canonical industry standard; proposing Neo-native design").
+   - **Distinction from Industry Friction Radar:** The precedent-sweep targets *established standards* to align with. The `industry-friction-radar` skill targets *frontier friction* where standards are failing. They are complementary, opposite directions.
+3. **Use Discussions.** Call the `create_discussion` tool to post your proposal.
+4. **Set the Category.** Map the discussion to the `Ideas` category.
+5. **Format the Proposal.** The body of the discussion should clearly articulate:
    - **Self-Identification (Mandatory):** You **MUST** begin the body by explicitly identifying yourself and your underlying model. (e.g., `> **Author's Note:** This proposal was autonomously synthesized by **[Agent Name] ([Model Name])** during an Ideation session.`)
    - **The Concept:** What is being proposed?
    - **The Rationale:** Why is this valuable?

--- a/.agent/skills/industry-friction-radar/references/industry-friction-radar-workflow.md
+++ b/.agent/skills/industry-friction-radar/references/industry-friction-radar-workflow.md
@@ -60,3 +60,4 @@ To understand the macro-architecture this skill serves (Neo as an Application En
 - `learn/agentos/DreamPipeline.md` (Sensory Input & DreamService)
 - `resources/content/discussions/discussion-10119.md` (Engine-category vs. Framework-category positioning)
 - `resources/content/discussions/discussion-10137.md` (Agent OS context)
+- `.agent/skills/ideation-sandbox/references/ideation-sandbox-workflow.md` (Pre-Filing Precedent Sweep): The radar targets *frontier friction* where standards are failing. The `ideation-sandbox` precedent sweep targets *established standards* to avoid reinventing them. They are complementary disciplines.


### PR DESCRIPTION
Authored by Gemini 3.1 Pro (Antigravity). Session 0b29a8fa-c6b0-42e2-ab3b-8015a99db2d8.

Resolves #10336

Adds a mandatory Pre-Filing Precedent Sweep to the `ideation-sandbox` workflow to prevent the swarm from proposing and adopting custom architectural designs when an industry standard already exists. Also clarifies the distinction between this discipline and the `industry-friction-radar`.

## Deltas from ticket (if any)
None.

## Test Evidence
Verified markdown structure visually.

## Post-Merge Validation
- [ ] Ensure future ideation discussions adhere to the new precedent sweep step.