### PR TITLE
feat(pr-review): codify MCP-tool-description budget audit (#10341)

### DIFF
--- a/.agent/skills/pr-review/assets/pr-review-template.md
+++ b/.agent/skills/pr-review/assets/pr-review-template.md
@@ -63,6 +63,22 @@ For every issue named as close-target, verify it does NOT carry the `epic` label
 
 ---
 
+### 📡 MCP-Tool-Description Budget Audit
+
+*(Required per guide §5.3 when the PR touches `ai/mcp/server/*/openapi.yaml` — adds a new `description:`, modifies an existing block-literal `description:`, or introduces a new tool path or operation. Mark N/A for PRs that don't touch OpenAPI surfaces.)*
+
+For every modified or added OpenAPI tool description:
+
+- [ ] Single-line preferred — block-literal (`|`) descriptions justified by content, not authorial habit
+- [ ] No internal cross-refs (no ticket numbers, Phase sequencing, session IDs, or memory anchor names in the description payload)
+- [ ] No architectural narrative — descriptions describe call-site usage (what + when-to-use + when-not-to-use)
+- [ ] External standard URLs OK — citing canonical specs (e.g., `https://a2a-protocol.org/...`) is acceptable
+- [ ] 1024-char hard cap respected — approaching it is a red flag (see `McpServerToolLimits` test)
+
+**Findings:** [Pass / specific descriptions flagged / N/A]
+
+---
+
 ### 🔗 Cross-Skill Integration Audit
 
 *(Required per guide §8.1 when the PR touches skill files, conventions, MCP tool surfaces, `AGENTS_STARTUP.md` / `AGENTS.md`, or architectural primitives. Mark N/A for routine code changes that don't introduce cross-substrate conventions.)*

--- a/.agent/skills/pr-review/references/pr-review-guide.md
+++ b/.agent/skills/pr-review/references/pr-review-guide.md
@@ -115,6 +115,56 @@ When reviewing a PR, audit every issue named as a close-target via GitHub's magi
 - Sub-issues with their own children (rare but legitimate) — same risk class as leaf; not flagged.
 - `Related: #N` / `Refs #N` / `Part of #N` references — these don't trigger GitHub's magic-close, so they're not subject to this audit.
 
+### 5.3 MCP-Tool-Description Budget Audit
+
+When a PR touches `ai/mcp/server/*/openapi.yaml`, audit each modified or added tool description for budget compliance. Tool descriptions are loaded into every consuming agent's context window when the tool surface is enumerated; bloat compounds across the tool surface and competes with reasoning budget at runtime.
+
+**The Rule:** OpenAPI tool-parameter and operation descriptions are runtime payload, not source-code documentation. Their audience is the agent enumerating the tool surface — not the developer reading the source. Treat them as terse, usage-focused contracts; relegate architectural narrative to JSDoc on the corresponding service method or to the PR / ticket body.
+
+**Three audiences, three verbosity budgets:**
+
+| Surface | Audience | Verbosity budget | Acceptable content |
+|---|---|---|---|
+| **OpenAPI YAML** (`openapi.yaml`) | MCP-consuming agents at runtime (every tool-surface enumeration) | **Terse, single-line, usage-focused** | What it is + when to use + when NOT to use |
+| **JSDoc** (source code) | Developers reading source | Verbose; framing OK | Architectural rationale, design history, cross-refs |
+| **PR body / ticket body** | Reviewers + Retrospective daemon | Full Fat Ticket | Narrative, deltas, test evidence, post-merge validation |
+
+Conflating budgets — bloating YAML with what should have stayed in JSDoc — has empirical cost. It also conflates audience: an agent calling `add_message` doesn't need to know about Phase 1/Phase 2 sequencing; it needs to know whether to populate the param.
+
+**Trigger conditions** (fire if any apply):
+
+1. PR adds a new `description:` to an OpenAPI tool param or operation.
+2. PR modifies an existing `description:` block-literal (`|` form).
+3. PR introduces a new OpenAPI tool path or operation.
+
+**Audit checks:**
+
+1. **Single-line preferred** — multi-line block-literal (`|`) descriptions warrant scrutiny. Block-literal is acceptable for genuinely complex contracts (e.g., transport-substrate observability blocks) but must be justified by content, not authorial habit.
+2. **No internal cross-refs** — descriptions should not cite ticket numbers, internal Phase sequencing, session IDs, or memory anchors (those belong in JSDoc + PR / ticket bodies).
+3. **No architectural narrative** — descriptions should describe call-site usage (what + when-to-use + when-not-to-use), not implementation history.
+4. **External standard URLs OK** — citing `https://a2a-protocol.org/...` or other canonical specs is acceptable when the param adopts an external standard; agents can navigate canonical docs.
+5. **Mind the 1024-char hard cap** — MCP protocol enforces a per-tool-description limit; approaching it is a red flag (see `McpServerToolLimits` test for the empirical bound).
+
+**Required Action template when violated:**
+
+> *"OpenAPI description on param `X` of tool `Y` exceeds budget — multi-line block-literal + internal ticket references. Tighten to single-line usage-focused description; move architectural narrative to JSDoc on the corresponding service method or to the PR body."*
+
+**Author response options** when this Required Action fires:
+- Tighten the description to single-line usage-focused form; relocate the architectural narrative to JSDoc or the PR body.
+- Defend the block-literal with a content-justification (e.g., transport-substrate observability that genuinely requires multi-clause framing) — reviewer can accept with rationale logged.
+- Push back on a specific check if the audit misfires (e.g., a multi-line description that legitimately enumerates an external spec's nuances).
+
+**Distinction from JSDoc audit:** JSDoc on service-method source is a separate audience (developers reading code). Verbosity is acceptable there. The §5.3 audit fires only on the OpenAPI YAML surface that becomes runtime tool-description payload.
+
+**Empirical anchor:** PR #10340's initial `task` parameter description on `mailbox/messages` was a ~600-char block-literal with internal Phase 1/Phase 2 framing and ticket cross-refs (#10334/#10313/#10338). Cycle 1 review challenge ("these directly map to mcp server tools — they must be short and meaningful") tightened it to a ~155-char single-line description in one follow-up commit. The post-fix form (`"Optional A2A Task envelope (https://...) for structured agent coordination. Omit for free-form markdown messages."`) preserves usage signal without architectural narrative — a 4× reduction with no information loss for the consuming agent. The §5.3 audit codifies that reviewer-side discipline so the tightening fires pre-Approval, not post-Approval.
+
+**Out of scope for this audit:**
+- Auto-tooling for description-bloat detection (mechanical-layer enforcement after discipline-layer proves insufficient).
+- Migration sweep of legacy verbose descriptions in existing OpenAPI files (forward-only via this discipline + opportunistic refactoring during ongoing PR work).
+- JSDoc verbosity (different audience, different budget).
+- PR body verbosity (reviewers + Retrospective daemon legitimately consume Fat Ticket framing).
+- OpenAPI/JS contract drift (e.g., `enum` values diverging from runtime validators, `required` arrays diverging from JS-side implementation) — adjacent discipline gap; warrants separate codification if recurrent. The §5.3 audit is budget-focused; correctness drift is a different audit shape.
+
 ## 6. The Review Template
 When drafting your review, use the `view_file` tool to load the exact markdown template from:
 `.agent/skills/pr-review/assets/pr-review-template.md`
@@ -178,6 +228,7 @@ If a qualifying PR lacks a provenance declaration, or if it merely ports externa
 | Style-calibrating toward the other model family's tone | §7.2 — the floor keeps rigor universal, not style convergence |
 | Ignoring Chain of Custody | §7.3 Provenance Audit violated on a major abstraction |
 | PR names an epic as close-target without flagging | §5.2 Close-Target Audit violated; risks epic auto-close-with-open-subs (see #9999 sabotage chain) |
+| PR adds bloated multi-line OpenAPI tool description without flagging | §5.3 MCP-Tool-Description Budget Audit violated; bloat compounds across the tool surface and competes with agent reasoning budget at runtime |
 
 ## 8. Cross-Skill Integration Audit
 


### PR DESCRIPTION
Authored by Claude Opus 4.7 (Claude Code). Session `48197e2e-3e95-47eb-9eb8-bbb032948845` consuming handoff from session `b5a17132-7324-46e1-b73e-038825bb4d55` (same model, prior session).

Resolves #10341

## Summary

Codifies a new `§5.3 MCP-Tool-Description Budget Audit` step in the `pr-review` skill, parallel to `§5.2 Close-Target Audit`. Reviewer-side discipline that catches bloated OpenAPI tool descriptions at review time, before they enter the runtime tool-surface payload.

OpenAPI tool-parameter descriptions in `ai/mcp/server/*/openapi.yaml` are loaded into every consuming agent's context window when the tool surface is enumerated. Bloat on a single param multiplies across ~80 MCP tools across every agent session — meaningful context-window pressure that competes with the actual reasoning budget. The principle was implicit; codifying it as an audit step prevents recurrence.

## Changes

- **`.agent/skills/pr-review/references/pr-review-guide.md`** — added `§5.3 MCP-Tool-Description Budget Audit` with: rule statement + three-audiences/three-budgets table (OpenAPI vs JSDoc vs PR body), trigger conditions, audit checks (single-line preferred, no internal cross-refs, no architectural narrative, external standard URLs OK, 1024-char hard cap), Required Action template, author response options, distinction-from-JSDoc clause, empirical anchor citing PR #10340, out-of-scope clauses. Plus one anti-pattern row in `§7.4`.
- **`.agent/skills/pr-review/assets/pr-review-template.md`** — added `📡 MCP-Tool-Description Budget Audit` section between Close-Target Audit and Cross-Skill Integration Audit, structured as a 5-item checklist matching the audit checks.

Net: 67 lines across 2 files. No code changes.

## Empirical Anchor (Verified Against Merged State)

PR #10340's initial `task` parameter description on `mailbox/messages` was a ~600-char block-literal with internal Phase 1/Phase 2 framing and ticket cross-refs (#10334/#10313/#10338). @tobiu's cycle 1 challenge — *\"these directly map to mcp server tools — they must be short and meaningful\"* — tightened it to a ~155-char single-line description in one follow-up commit.

Verified: the merged state (commit `dace09f49`) shows:
> \`Optional A2A Task envelope (https://a2a-protocol.org/latest/specification/) for structured agent coordination. Omit for free-form markdown messages.\`

4× reduction with no information loss for the consuming agent.

## Deltas from Ticket

- **Adjacent-but-distinct framing for PR #10342** — the ticket's handover comment claimed `§5.3` would catch PR #10342's `newState` enum bug (`IN_PROGRESS, COMPLETED, BLOCKED` vs actual `Submitted, Working, …, Blocked`) and `expectedCurrentState` required-vs-optional drift. Honest scoping: those are CONTRACT-CORRECTNESS bugs, not BUDGET bugs. The §5.3 audit checks (single-line, no narrative, char-cap) wouldn't surface them. Out-of-scope clause now explicitly flags \"OpenAPI/JS contract drift\" as adjacent territory warranting separate codification if recurrent — preserving §5.3's tight budget-focused scope while acknowledging the related discipline gap.
- **No memory-anchor names in skill file** — the ticket AC requested cross-references to `feedback_mcp_output_category_split` etc. Per substrate-awareness discipline (`pull-request §11`), harness-private memory file names don't appear in public skill artifacts; the conceptual principles they encode are what's codified. Memory anchors stay in the PR body / commit narrative for provenance.

## Test Evidence

Pure markdown documentation; no runtime test surface. Manual verification:
- \`grep -n '^### 5.3\|MCP-Tool-Description Budget' pr-review-guide.md\` → §5.3 at line 118, anti-pattern row at line 231.
- Empirical anchor verified against merged state of \`ai/mcp/server/memory-core/openapi.yaml\` for both #10340 (`task` param) and #10342 (`newState` + `expectedCurrentState`).
- Template diff inspected — new section sits between Close-Target Audit and Cross-Skill Integration Audit, mirrors §5.2's checkbox pattern.

## Cross-Skill Integration Audit (Self-Applied per §8.1)

- [x] No predecessor skill needs to fire §5.3 — it's a reviewer-side audit, only invoked when the `pr-review` skill is loaded for a PR.
- [x] AGENTS_STARTUP.md §9 entry for `pr-review` lists high-level capabilities (\"structured evaluation metrics, graph ingestion tags, severity ladder\"); §5.1/§5.2 sub-audits aren't enumerated there either, so adding §5.3 doesn't surface a new top-level capability worth listing. No update needed.
- [x] No reference file mentions a predecessor pattern to update.
- [x] No new MCP tool surface introduced.
- [x] New convention is documented in-place in `pr-review-guide.md §5.3` and the template — discoverable via the skill load-path.

## Post-Merge Validation

- [ ] Future PRs touching `ai/mcp/server/*/openapi.yaml` get §5.3 audit coverage in cross-family review.
- [ ] Reviewer-side discipline catches description bloat pre-Approval rather than post-Approval (the failure mode that gave rise to this ticket).

## Cross-Family Review Request

Per `pull-request §6.1` cross-family mandate. Requesting review from @neo-gemini-3-1-pro.

## Related

- PR #10340 — empirical anchor (the `task` description bloat)
- PR #10342 — adjacent OpenAPI discipline gap (contract drift) — out-of-scope; flagged in §5.3 out-of-scope clause as candidate for separate codification
- §5.2 Close-Target Audit — structural model parallel (PR #10262)