### PR TITLE
feat(bootstrap): add --install and --build-all flags to bootstrapWorktree (#10351)

### DIFF
--- a/AGENTS_STARTUP.md
+++ b/AGENTS_STARTUP.md
@@ -76,9 +76,16 @@ Error [ERR_MODULE_NOT_FOUND]: Cannot find module '.../ai/mcp/server/github-workf
 ```bash
 node ai/scripts/bootstrapWorktree.mjs              # copy configs only
 node ai/scripts/bootstrapWorktree.mjs --link-data  # ALSO unify .neo-ai-data/ (recommended)
+node ai/scripts/bootstrapWorktree.mjs --link-data --install     # ALSO npm install + bundle-parse5
+node ai/scripts/bootstrapWorktree.mjs --link-data --build-all   # ALSO full Webpack build (frontend tickets)
 ```
 
 It copies the four `config.mjs` files from the main checkout (resolved via `git worktree list --porcelain`) and — with `--link-data` — symlinks the worktree's `.neo-ai-data/` to the main checkout's. Idempotent; no-op from the main checkout.
+
+**Per-task-class invocation guidance (per #10351):**
+- **Docs-only tickets** — `--link-data` is sufficient (no `node_modules` needed; the worktree filesystem itself + the data unification covers everything).
+- **Backend / MCP / unit-test tickets** — add `--install`. Empirical anchor: ~17s for `npm install` on a populated local cache (808 packages observed); `bundle-parse5` adds ~1-2s and IS required for the unit-test runner. Skips both if `node_modules/` already exists in the worktree.
+- **Frontend / Webpack-distribution tickets** — add `--build-all`. Implies `--install`; runs the full `npm run build-all` after dependencies are present. Use only when the ticket actually touches frontend bundles, themes, or Webpack thread distributions — backend tickets pay the full build cost for nothing otherwise.
 
 **Why `--link-data` matters (per #10224):** without it, each worktree gets its own empty `.neo-ai-data/sqlite/memory-core-graph.sqlite`, which means AgentIdentity nodes seeded in the main checkout are invisible to the worktree's MCP server. `bindAgentIdentity('neo-opus-4-7')` returns null, the mailbox throws `"no agent identity context bound"`, and A2A handshakes silently fail — the #10184 symptom from a different root cause than cache coherence. The symlink unifies the Memory Core substrate (SQLite + Chroma + concepts + backups) so ADR 0001's "one SQLite file shared across N processes" assumption holds across worktrees.
 

--- a/ai/scripts/bootstrapWorktree.mjs
+++ b/ai/scripts/bootstrapWorktree.mjs
@@ -220,22 +220,25 @@ export async function symlinkDataDir({mainCheckout, projectRoot, dir = '.neo-ai-
  */
 export async function installDependencies({projectRoot, log = console.log, exec = execFileAsync}) {
     const nodeModulesPath = path.join(projectRoot, 'node_modules');
+    let action;
 
     if (await exists(nodeModulesPath)) {
         log(`install skip (exists): node_modules`);
+        action = 'already-installed';
     } else {
         log(`installing dependencies (npm install)...`);
         const start = Date.now();
         await exec('npm', ['install'], {cwd: projectRoot});
         log(`installed dependencies in ${Math.round((Date.now() - start) / 1000)}s`);
+        action = 'installed';
     }
 
     log(`bundling parse5 (test-runner prerequisite)...`);
-    const start = Date.now();
+    const bundleStart = Date.now();
     await exec('npm', ['run', 'bundle-parse5'], {cwd: projectRoot});
-    log(`bundled parse5 in ${Math.round((Date.now() - start) / 1000)}s`);
+    log(`bundled parse5 in ${Math.round((Date.now() - bundleStart) / 1000)}s`);
 
-    return await exists(path.join(projectRoot, 'node_modules')) ? 'installed' : 'already-installed';
+    return action;
 }
 
 /**

--- a/ai/scripts/bootstrapWorktree.mjs
+++ b/ai/scripts/bootstrapWorktree.mjs
@@ -193,6 +193,78 @@ export async function symlinkDataDir({mainCheckout, projectRoot, dir = '.neo-ai-
     return 'linked';
 }
 
+/**
+ * @summary Installs the worktree's `node_modules` and bundles the parse5 test prerequisite.
+ *
+ * Worktrees off `origin/dev` start without `node_modules` (gitignored) AND without
+ * `dist/parse5.mjs` (gitignored test-runner prerequisite). Both are needed to run the
+ * Playwright unit-test suite or any SDK-consuming script. Adding these as opt-in flags
+ * here closes the manual-multi-step bootstrap gap surfaced empirically during #10339
+ * implementation (per #10351).
+ *
+ * Idempotent: skips `npm install` when `node_modules/` is already present (e.g.,
+ * symlinked from main, prior `--install` invocation, or manual `npm i`). Always runs
+ * `npm run bundle-parse5` because the bundle output lives under `dist/` (gitignored)
+ * and is cheap to rebuild — surfacing it explicitly under `--install` closes the
+ * "test runner fails with `Cannot find module '.../dist/parse5.mjs'`" friction.
+ *
+ * Cost anchor: ~17s for `npm install` on a populated local cache (808 packages,
+ * empirically observed during #10339 implementation, 2026-04-26). `bundle-parse5`
+ * adds ~1-2s. Friction-free when `node_modules` already exists (skip path is sub-millisecond).
+ *
+ * @param {object}   options
+ * @param {string}   options.projectRoot      Absolute path to the worktree root.
+ * @param {Function} [options.log]            Logger fn for action diagnostics.
+ * @param {Function} [options.exec]           execFile wrapper for dependency injection (testing).
+ * @returns {Promise<'already-installed'|'installed'>} Action taken.
+ */
+export async function installDependencies({projectRoot, log = console.log, exec = execFileAsync}) {
+    const nodeModulesPath = path.join(projectRoot, 'node_modules');
+
+    if (await exists(nodeModulesPath)) {
+        log(`install skip (exists): node_modules`);
+    } else {
+        log(`installing dependencies (npm install)...`);
+        const start = Date.now();
+        await exec('npm', ['install'], {cwd: projectRoot});
+        log(`installed dependencies in ${Math.round((Date.now() - start) / 1000)}s`);
+    }
+
+    log(`bundling parse5 (test-runner prerequisite)...`);
+    const start = Date.now();
+    await exec('npm', ['run', 'bundle-parse5'], {cwd: projectRoot});
+    log(`bundled parse5 in ${Math.round((Date.now() - start) / 1000)}s`);
+
+    return await exists(path.join(projectRoot, 'node_modules')) ? 'installed' : 'already-installed';
+}
+
+/**
+ * @summary Runs the full `npm run build-all` after ensuring dependencies are installed.
+ *
+ * Implies {@link installDependencies}. Required for tickets that touch the frontend
+ * Webpack distributions or themes — backend-only / MCP-only tickets do not need this.
+ *
+ * NOT idempotent in the same idempotent-skip sense as the other bootstrap helpers —
+ * `npm run build-all` re-runs every invocation. Webpack itself caches incremental builds,
+ * so re-runs against an already-built tree are still considerably faster than cold builds.
+ *
+ * @param {object}   options
+ * @param {string}   options.projectRoot      Absolute path to the worktree root.
+ * @param {Function} [options.log]            Logger fn for action diagnostics.
+ * @param {Function} [options.exec]           execFile wrapper for dependency injection (testing).
+ * @returns {Promise<'built'>} Action taken.
+ */
+export async function runBuildAll({projectRoot, log = console.log, exec = execFileAsync}) {
+    await installDependencies({projectRoot, log, exec});
+
+    log(`running full build (npm run build-all)...`);
+    const start = Date.now();
+    await exec('npm', ['run', 'build-all'], {cwd: projectRoot});
+    log(`build-all completed in ${Math.round((Date.now() - start) / 1000)}s`);
+
+    return 'built';
+}
+
 // -------------------------------------------------------------------------------------
 // CLI entry point. Runs only when invoked directly (node ai/scripts/bootstrapWorktree.mjs)
 // and not when imported by a test spec.
@@ -208,6 +280,8 @@ if (isMain) {
     const args     = new Set(process.argv.slice(2));
     const linkData = args.has('--link-data');
     const force    = args.has('--force');
+    const install  = args.has('--install');
+    const buildAll = args.has('--build-all');
 
     try {
         const mainCheckout = await resolveMainCheckout(projectRoot);
@@ -223,6 +297,14 @@ if (isMain) {
         if (linkData) {
             const symlinkResult = await symlinkDataDir({mainCheckout, projectRoot, force});
             console.log(`✓ Data symlink: ${symlinkResult}`);
+        }
+
+        if (buildAll) {
+            const buildResult = await runBuildAll({projectRoot});
+            console.log(`✓ Build: ${buildResult}`);
+        } else if (install) {
+            const installResult = await installDependencies({projectRoot});
+            console.log(`✓ Install: ${installResult}`);
         }
     } catch (e) {
         console.error('Bootstrap failed:', e.message);

--- a/test/playwright/unit/ai/scripts/bootstrapWorktree.spec.mjs
+++ b/test/playwright/unit/ai/scripts/bootstrapWorktree.spec.mjs
@@ -31,6 +31,8 @@ import path            from 'path';
 test.describe('ai/scripts/bootstrapWorktree', () => {
     let bootstrapWorktree;
     let symlinkDataDir;
+    let installDependencies;
+    let runBuildAll;
     let BOOTSTRAP_CONFIGS;
     let fakeMainCheckout;
     let fakeWorktree;
@@ -43,10 +45,12 @@ test.describe('ai/scripts/bootstrapWorktree', () => {
     ];
 
     test.beforeAll(async () => {
-        const mod         = await import('../../../../../ai/scripts/bootstrapWorktree.mjs');
-        bootstrapWorktree = mod.bootstrapWorktree;
-        symlinkDataDir    = mod.symlinkDataDir;
-        BOOTSTRAP_CONFIGS = mod.BOOTSTRAP_CONFIGS;
+        const mod           = await import('../../../../../ai/scripts/bootstrapWorktree.mjs');
+        bootstrapWorktree   = mod.bootstrapWorktree;
+        symlinkDataDir      = mod.symlinkDataDir;
+        installDependencies = mod.installDependencies;
+        runBuildAll         = mod.runBuildAll;
+        BOOTSTRAP_CONFIGS   = mod.BOOTSTRAP_CONFIGS;
     });
 
     test.beforeEach(async () => {
@@ -244,6 +248,124 @@ test.describe('ai/scripts/bootstrapWorktree', () => {
             const lstat = await fs.lstat(path.join(fakeMainCheckout, dataDir));
             expect(lstat.isDirectory()).toBe(true);
             expect(lstat.isSymbolicLink()).toBe(false);
+        });
+    });
+
+    // --------------------------------------------------------------------------------
+    // #10351 installDependencies + runBuildAll — opt-in flags that close the
+    // multi-step manual bootstrap gap (npm install + bundle-parse5 + optional build-all).
+    //
+    // These tests inject a mock `exec` to capture invoked commands without spawning real
+    // npm child processes. The pure-function form (with explicit dependency injection)
+    // mirrors the existing `bootstrapWorktree`/`symlinkDataDir` testability pattern.
+    // --------------------------------------------------------------------------------
+    test.describe('#10351 installDependencies', () => {
+        function makeMockExec() {
+            const calls = [];
+            const exec = async (cmd, args, opts) => {
+                calls.push({cmd, args, opts});
+                // Simulate npm install creating node_modules — flips the existence guard
+                // for downstream calls that re-check.
+                if (cmd === 'npm' && args[0] === 'install') {
+                    await fs.ensureDir(path.join(opts.cwd, 'node_modules'));
+                }
+                return {stdout: '', stderr: ''};
+            };
+            return {exec, calls};
+        }
+
+        test('runs `npm install` then `bundle-parse5` when node_modules is absent', async () => {
+            const {exec, calls} = makeMockExec();
+            const result = await installDependencies({
+                projectRoot: fakeWorktree,
+                exec,
+                log        : () => {}
+            });
+
+            expect(result).toBe('installed');
+            expect(calls).toHaveLength(2);
+            expect(calls[0].cmd).toBe('npm');
+            expect(calls[0].args).toEqual(['install']);
+            expect(calls[1].cmd).toBe('npm');
+            expect(calls[1].args).toEqual(['run', 'bundle-parse5']);
+
+            // Both invocations targeted the worktree (not main checkout).
+            for (const call of calls) {
+                expect(call.opts.cwd).toBe(fakeWorktree);
+            }
+        });
+
+        test('skips `npm install` when node_modules already exists, but always runs bundle-parse5', async () => {
+            // Pre-seed node_modules to simulate prior install / symlink.
+            await fs.ensureDir(path.join(fakeWorktree, 'node_modules'));
+
+            const {exec, calls} = makeMockExec();
+            const result = await installDependencies({
+                projectRoot: fakeWorktree,
+                exec,
+                log        : () => {}
+            });
+
+            expect(result).toBe('installed');
+            expect(calls).toHaveLength(1);
+            expect(calls[0].args).toEqual(['run', 'bundle-parse5']);
+        });
+
+        test('emits log lines for skip / install / bundle paths', async () => {
+            const logs   = [];
+            const {exec} = makeMockExec();
+
+            // First run — install branch
+            await installDependencies({projectRoot: fakeWorktree, exec, log: line => logs.push(line)});
+            expect(logs.join('\n')).toContain('installing dependencies');
+            expect(logs.join('\n')).toContain('bundling parse5');
+
+            // Second run — skip branch
+            const logs2 = [];
+            await installDependencies({projectRoot: fakeWorktree, exec, log: line => logs2.push(line)});
+            expect(logs2.join('\n')).toContain('install skip (exists)');
+            expect(logs2.join('\n')).toContain('bundling parse5');
+        });
+    });
+
+    test.describe('#10351 runBuildAll', () => {
+        function makeMockExec() {
+            const calls = [];
+            const exec = async (cmd, args, opts) => {
+                calls.push({cmd, args, opts});
+                if (cmd === 'npm' && args[0] === 'install') {
+                    await fs.ensureDir(path.join(opts.cwd, 'node_modules'));
+                }
+                return {stdout: '', stderr: ''};
+            };
+            return {exec, calls};
+        }
+
+        test('composes installDependencies then runs `npm run build-all`', async () => {
+            const {exec, calls} = makeMockExec();
+            const result = await runBuildAll({
+                projectRoot: fakeWorktree,
+                exec,
+                log        : () => {}
+            });
+
+            expect(result).toBe('built');
+            // Expected sequence: npm install, npm run bundle-parse5, npm run build-all
+            expect(calls).toHaveLength(3);
+            expect(calls[0].args).toEqual(['install']);
+            expect(calls[1].args).toEqual(['run', 'bundle-parse5']);
+            expect(calls[2].args).toEqual(['run', 'build-all']);
+        });
+
+        test('skips install when node_modules exists but still runs bundle-parse5 + build-all', async () => {
+            await fs.ensureDir(path.join(fakeWorktree, 'node_modules'));
+
+            const {exec, calls} = makeMockExec();
+            await runBuildAll({projectRoot: fakeWorktree, exec, log: () => {}});
+
+            expect(calls).toHaveLength(2);
+            expect(calls[0].args).toEqual(['run', 'bundle-parse5']);
+            expect(calls[1].args).toEqual(['run', 'build-all']);
         });
     });
 });

--- a/test/playwright/unit/ai/scripts/bootstrapWorktree.spec.mjs
+++ b/test/playwright/unit/ai/scripts/bootstrapWorktree.spec.mjs
@@ -306,7 +306,11 @@ test.describe('ai/scripts/bootstrapWorktree', () => {
                 log        : () => {}
             });
 
-            expect(result).toBe('installed');
+            // Return value MUST reflect the action actually taken (skip), not just the
+            // post-condition that node_modules exists. Per @neo-gemini-3-1-pro's PR #10352
+            // cycle 1 review: a returned-action contract that always reports `'installed'`
+            // because node_modules ends up present either way is semantically broken.
+            expect(result).toBe('already-installed');
             expect(calls).toHaveLength(1);
             expect(calls[0].args).toEqual(['run', 'bundle-parse5']);
         });


### PR DESCRIPTION
Authored by Claude Opus 4.7 (Claude Code). Session \`48197e2e-3e95-47eb-9eb8-bbb032948845\`.

Resolves #10351

## Summary

Closes the manual multi-step bootstrap gap surfaced empirically during #10339 implementation: a fresh worktree off \`origin/dev\` has no \`node_modules\` and no \`dist/parse5.mjs\` (test-runner prerequisite), so any agent picking up a backend/MCP/test ticket must re-derive the install + build chain. Adds two opt-in flags to the canonical bootstrap entry point so the chain is codified where agents already know to look (\`AGENTS_STARTUP.md §5\`).

## Changes

- **\`ai/scripts/bootstrapWorktree.mjs\`** — adds two new exports:
  - \`installDependencies({projectRoot, log, exec})\` — idempotent. Skips \`npm install\` when \`node_modules/\` already exists. ALWAYS runs \`npm run bundle-parse5\` (the bundle output lives under gitignored \`dist/\` and is the test-runner prerequisite that surfaced the original friction).
  - \`runBuildAll({projectRoot, log, exec})\` — composes \`installDependencies\` then runs \`npm run build-all\`. For frontend / Webpack-distribution tickets only.
  - CLI flag handling: \`--install\` triggers \`installDependencies\`; \`--build-all\` triggers \`runBuildAll\` (which implies install). Cleanly composable with existing \`--link-data\` and \`--force\` flags.
- **\`AGENTS_STARTUP.md §5\`** — extends the Worktree Bootstrap section with the new flag invocations + per-task-class guidance: docs-only → \`--link-data\`; backend/MCP/unit-test → \`--install\`; frontend/Webpack → \`--build-all\`. Empirical timing anchor cited (~17s install on populated cache, observed during #10339 implementation).
- **\`test/playwright/unit/ai/scripts/bootstrapWorktree.spec.mjs\`** — 5 new tests (10 → 15) covering: install when absent, skip when present, log-line emission, build-all composition, and idempotent install-skip during build-all. Uses dependency injection (\`exec\` mock) to verify command sequence without spawning real npm processes — mirrors existing \`bootstrapWorktree\`/\`symlinkDataDir\` testability pattern.

Net: 215 insertions across 3 files (1 doc, 1 script, 1 test).

## Empirical Anchor (this session-arc)

PR #10350 (#10339 TTL sweeper) blocked at the test-running step because the fresh worktree branch had no \`node_modules\`. Symlink-to-main approach was denied at the harness security layer. After \`npm install\` (~17s, 808 packages on populated local cache) AND \`npm run bundle-parse5\` (test-runner prerequisite), tests ran. Each unfamiliar agent re-derives this chain. Codifying it via \`--install\` flag closes the gap.

## Test Evidence

\`\`\`
15 passed (885ms)  // bootstrapWorktree.spec.mjs full suite
\`\`\`

10 existing tests + 5 new (\`#10351 installDependencies\` × 3, \`#10351 runBuildAll\` × 2). Pure-function form with injected \`exec\` mock — no real npm child processes spawned, deterministic and fast.

## Acceptance Criteria — Per-Item Status

- [x] \`bootstrapWorktree.mjs\` accepts \`--install\` flag; idempotently runs \`npm install\` when \`node_modules/\` is absent.
- [x] \`bootstrapWorktree.mjs\` accepts \`--build-all\` flag; implies \`--install\`; runs \`npm run build-all\`.
- [x] Both flags log progress + timing for observability.
- [x] \`bundle-parse5\` is run automatically as part of \`--install\` — folded in rather than separate flag (the second design option in the ticket).
- [x] \`AGENTS_STARTUP.md §5\` updated with per-task-class invocation guidance.
- [x] Empirical timing anchor cited inline (~17s install observed; build-all timing left to be measured at first real invocation).
- [x] Skip when running from main checkout — preserved by the existing pattern (the early return in \`bootstrapWorktree\` and \`symlinkDataDir\` already handles main-checkout-mode; \`installDependencies\` and \`runBuildAll\` always operate against the passed \`projectRoot\` regardless, which is fine because the CLI flow only invokes them when the user explicitly opts in).
- [x] Existing tests still pass — 15/15 green (10 existing + 5 new).
- [x] New test verifying idempotent install-skip — covered by \"skips \`npm install\` when node_modules already exists\".

## Cross-Skill Integration Audit (Self-Applied per pr-review §8.1)

- [x] No predecessor skill needs to fire the install — agents already know to invoke \`bootstrapWorktree.mjs\` per AGENTS_STARTUP §5; new flags compose naturally.
- [x] \`AGENTS_STARTUP.md §5\` updated.
- [x] No reference file mentions a predecessor pattern that needs updating.
- [x] No new MCP tool surface — opt-in CLI flags only.
- [x] New convention documented in-place in AGENTS_STARTUP §5 — discoverable via the existing boot-mandate path.
- [x] Per pr-review §5.3 (just merged via PR #10348): no \`ai/mcp/server/*/openapi.yaml\` modifications — N/A.

## Out of Scope

- **\`bundle-parse5\` as a separate \`--bundle-test-prereqs\` flag.** Considered; rejected for MVP because parse5 is the only test-runner prerequisite currently on this surface, and folding it into \`--install\` reduces flag-surface complexity. If more test-runner prerequisites emerge, splitting becomes a small follow-up.
- **Symlink \`node_modules\` from main checkout.** Considered + denied at harness security layer + carries canonical-path risk for some packages. Full local install is more robust. Per ticket Avoided Trap.
- **Auto-detection of \"do I need build-all\".** Heuristic-based auto-bootstrap is a separate ergonomic concern; explicit flags suffice for MVP.
- **Granular build flags (\`--build-themes\`, \`--build-threads\`).** Deferred unless empirical need surfaces.
- **Cross-harness applicability.** Scope is Claude Code worktrees specifically per AGENTS_STARTUP §5. Antigravity / Gemini CLI shared-checkout patterns don't need this script.

## Cross-Family Review Request

Per \`pull-request §6.1\` cross-family mandate. Requesting review from @neo-gemini-3-1-pro after she completes the cross-family reviews on PRs #10348 and #10350.

## Related

- #10339 — empirical-anchor ticket (PR #10350 hit the missing-\`node_modules\` blocker)
- #10095 — original worktree-substrate ticket
- #10224 — \`.neo-ai-data\` symlink unification (companion \`--link-data\` flag)
- #10350 — sibling PR (TTL sweeper); was blocked on this gap during implementation