### PR TITLE
fix(ai): Atomic Load-Check-Insert for GraphService linkNodes

### DIFF
--- a/ai/mcp/server/memory-core/services/GraphService.mjs
+++ b/ai/mcp/server/memory-core/services/GraphService.mjs
@@ -234,61 +234,85 @@ class GraphService extends Base {
             return;
         } // Safe guard for SQLite backend
 
-        // Enforce Foreign Key constraints preemptively to prevent SQLite crash from hallucinated paths
-        const verifyStmt = this.db.storage.db.prepare('SELECT count(*) as count FROM Nodes WHERE id IN (?, ?)');
-        const count = verifyStmt.get(source, target).count;
-        if (source !== target && count !== 2) {
-             logger.warn(`[GraphService] Culling hallucinated edge mapping: ${source} -> ${target}`);
-             return;
-        }
-        if (source === target && count !== 1) return;
+        const executeLink = () => {
+            // Enforce Foreign Key constraints preemptively to prevent SQLite crash from hallucinated paths
+            const verifyStmt = this.db.storage.db.prepare('SELECT count(*) as count FROM Nodes WHERE id IN (?, ?)');
+            let count = verifyStmt.get(source, target).count;
+            
+            let expectedCount = source === target ? 1 : 2;
 
-        const stmt     = this.db.storage.db.prepare(`SELECT id, json_extract(data, '$.properties.weight') as weight
-                                                     FROM Edges
-                                                     WHERE source = ?
-                                                       AND target = ?
-                                                       AND type = ?`);
-        const existing = stmt.get(source, target, relationship);
+            if (count !== expectedCount) {
+                // #10347 Cache-Warm Retry: If the count check fails, the node might exist in the SQLite WAL
+                // from another agent but hasn't been synced to this connection's snapshot yet. 
+                // We force a cache warm (which invokes syncCache and WAL read) and re-verify.
+                if (this.db && typeof this.db.getAdjacentNodes === 'function') {
+                    // Ensure we attempt to warm both endpoints in case either is the missing link
+                    this.db.getAdjacentNodes(source, 'both');
+                    this.db.getAdjacentNodes(target, 'both');
+                    
+                    // Re-evaluate the count after forcing synchronization
+                    count = verifyStmt.get(source, target).count;
+                }
+            }
 
-        let currentUserId = this.db.storage?.RequestContextService ? this.db.storage.RequestContextService.getAgentIdentityNodeId() : undefined;
-        let edgeProperties = {weight, ...properties};
-        if (currentUserId !== undefined && edgeProperties.userId === undefined) {
-            edgeProperties.userId = currentUserId;
-        }
+            if (count !== expectedCount) {
+                 logger.warn(`[GraphService] Culling hallucinated edge mapping: ${source} -> ${target} (count was ${count})`);
+                 return;
+            }
 
-        if (!existing) {
-            this.db.addEdge({
-                id        : globalThis.crypto.randomUUID(),
-                source,
-                target,
-                type      : relationship,
-                properties: edgeProperties
-            });
+            const stmt     = this.db.storage.db.prepare(`SELECT id, json_extract(data, '$.properties.weight') as weight
+                                                         FROM Edges
+                                                         WHERE source = ?
+                                                           AND target = ?
+                                                           AND type = ?`);
+            const existing = stmt.get(source, target, relationship);
+
+            let currentUserId = this.db.storage?.RequestContextService ? this.db.storage.RequestContextService.getAgentIdentityNodeId() : undefined;
+            let edgeProperties = {weight, ...properties};
+            if (currentUserId !== undefined && edgeProperties.userId === undefined) {
+                edgeProperties.userId = currentUserId;
+            }
+
+            if (!existing) {
+                this.db.addEdge({
+                    id        : globalThis.crypto.randomUUID(),
+                    source,
+                    target,
+                    type      : relationship,
+                    properties: edgeProperties
+                });
+            } else {
+                const currentWeight = parseFloat(existing.weight) || 1.0;
+                const newWeight     = Math.min(currentWeight + (weight * 0.1), 5.0);
+
+                // Fetch the entire current JSON to merge new properties natively
+                const dataStmt = this.db.storage.db.prepare(`SELECT data FROM Edges WHERE id = ?`);
+                const row = dataStmt.get(existing.id);
+                if (row && row.data) {
+                    let parsed = JSON.parse(row.data);
+                    parsed.properties = { ...(parsed.properties || {}), ...edgeProperties, weight: newWeight };
+                    
+                    const updateStmt = this.db.storage.db.prepare(`UPDATE Edges SET data = ? WHERE id = ?`);
+                    updateStmt.run(JSON.stringify(parsed), existing.id);
+                }
+
+                // Keep RAM cache functionally coherent if edge actively exists
+                let ramEdge = this.db.edges.get(existing.id);
+                if (ramEdge) {
+                    ramEdge.properties.weight = newWeight;
+                    Object.assign(ramEdge.properties, edgeProperties);
+                }
+
+                if (typeof this.db.acknowledgeLocalMutations === 'function') {
+                    this.db.acknowledgeLocalMutations();
+                }
+            }
+        };
+
+        if (this.db.isExecutingTransaction) {
+            executeLink();
         } else {
-            const currentWeight = parseFloat(existing.weight) || 1.0;
-            const newWeight     = Math.min(currentWeight + (weight * 0.1), 5.0);
-
-            // Fetch the entire current JSON to merge new properties natively
-            const dataStmt = this.db.storage.db.prepare(`SELECT data FROM Edges WHERE id = ?`);
-            const row = dataStmt.get(existing.id);
-            if (row && row.data) {
-                let parsed = JSON.parse(row.data);
-                parsed.properties = { ...(parsed.properties || {}), ...edgeProperties, weight: newWeight };
-                
-                const updateStmt = this.db.storage.db.prepare(`UPDATE Edges SET data = ? WHERE id = ?`);
-                updateStmt.run(JSON.stringify(parsed), existing.id);
-            }
-
-            // Keep RAM cache functionally coherent if edge actively exists
-            let ramEdge = this.db.edges.get(existing.id);
-            if (ramEdge) {
-                ramEdge.properties.weight = newWeight;
-                Object.assign(ramEdge.properties, edgeProperties);
-            }
-
-            if (typeof this.db.acknowledgeLocalMutations === 'function') {
-                this.db.acknowledgeLocalMutations();
-            }
+            this.db.transaction(executeLink);
         }
     }
 

--- a/ai/mcp/server/memory-core/services/GraphService.mjs
+++ b/ai/mcp/server/memory-core/services/GraphService.mjs
@@ -223,6 +223,19 @@ class GraphService extends Base {
 
     /**
      * Links two nodes via a relationship tracking edge weight metadata.
+     * 
+     * @summary Creates an edge between two nodes. This method executes as an atomic transaction
+     * (if not already inside one) to prevent race conditions during SQLite WAL flushes. It also 
+     * features a cache-warm retry mechanism on FK verify miss to account for WAL-snapshot-lag
+     * from other processes.
+     * 
+     * @description
+     * **Transaction Overhead:** Future callers should be aware that invoking `linkNodes` rapidly
+     * in a hot path incurs SQLite transaction overhead.
+     * **WAL Snapshot Lag:** If a peer process writes a node, the current connection's snapshot
+     * might lack it temporarily. This method automatically attempts to warm the cache and retry
+     * the FK verification before culling the edge.
+     * 
      * @param {String} source
      * @param {String} target
      * @param {String} relationship

--- a/ai/mcp/server/memory-core/services/MailboxService.mjs
+++ b/ai/mcp/server/memory-core/services/MailboxService.mjs
@@ -246,7 +246,7 @@ class MailboxService extends Base {
                 Promise.all([import('fs'), import('path'), import('../logger.mjs')]).then(([{ default: fs }, { default: path }, { default: logger }]) => {
                     logger.warn(JSON.stringify(logEntry));
                     const logPath = path.join(path.dirname(aiConfig.storagePaths.graph), 'sent-to-cull.jsonl');
-                    fs.appendFileSync(logPath, JSON.stringify(logEntry) + '\\n');
+                    fs.appendFileSync(logPath, JSON.stringify(logEntry) + '\n');
                 });
             }
         } catch (e) {

--- a/ai/mcp/server/memory-core/services/MailboxService.mjs
+++ b/ai/mcp/server/memory-core/services/MailboxService.mjs
@@ -87,6 +87,7 @@ class MailboxService extends Base {
      * @returns {Promise<Object>}
      */
     async addMessage({ to, subject, body, originSessionId, relatedSessions = [], relatedTickets = [], inReplyTo, priority = 'normal', partOfThread, taggedConcepts = [], task }) {
+        const preNormalizeTo = to; // Phase 1 #10347 observability
         const sentBy = RequestContextService.getAgentIdentityNodeId();
         if (!sentBy) {
             throw new Error("Cannot send message: no agent identity context bound. Ensure StdioIdentityResolver or OIDC transport is active.");
@@ -98,6 +99,7 @@ class MailboxService extends Base {
         // `SENT_TO` edge — the root-cause bug closed by #10174. Permission checks and edge
         // creation below all consume the canonical form from this point on.
         to = normalizeMailboxTarget(to);
+        const postNormalizeTo = to; // Phase 1 #10347 observability
 
         const messageId = `MESSAGE:${crypto.randomUUID()}`;
         const timestamp = new Date().toISOString();
@@ -222,6 +224,34 @@ class MailboxService extends Base {
         // 2. Map the routing edges
         GraphService.linkNodes(messageId, sentBy, 'SENT_BY', 1.0, { timestamp, userId: sentBy, sharedEntity: true });
         GraphService.linkNodes(messageId, to, 'SENT_TO', 1.0, { timestamp, userId: sentBy, sharedEntity: true });
+
+        // Phase 1 #10347 Observability: Make SENT_TO failure loud and cross-process readable
+        try {
+            const edgeCount = GraphService.db.storage.db.prepare('SELECT count(*) as count FROM Edges WHERE source = ? AND target = ? AND type = ?').get(messageId, to, 'SENT_TO').count;
+            if (edgeCount === 0) {
+                const fkVerifyCount = GraphService.db.storage.db.prepare('SELECT count(*) as count FROM Nodes WHERE id IN (?, ?)').get(messageId, to).count;
+                
+                const logEntry = {
+                    msg: "[#10347 Phase 1] Intermittent SENT_TO edge cull detected",
+                    timestamp,
+                    caller_passed_to: preNormalizeTo,
+                    pre_normalize_to: preNormalizeTo,
+                    post_normalize_to: postNormalizeTo,
+                    fk_verify_count: fkVerifyCount,
+                    identity_binding_me: sentBy,
+                    edge_type: 'SENT_TO',
+                    message_id: messageId
+                };
+
+                Promise.all([import('fs'), import('path'), import('../logger.mjs')]).then(([{ default: fs }, { default: path }, { default: logger }]) => {
+                    logger.warn(JSON.stringify(logEntry));
+                    const logPath = path.join(path.dirname(aiConfig.storagePaths.graph), 'sent-to-cull.jsonl');
+                    fs.appendFileSync(logPath, JSON.stringify(logEntry) + '\\n');
+                });
+            }
+        } catch (e) {
+            // fail silently on observability errors to not break the message send
+        }
 
         // 3. Map additional graph semantic edges
         if (originSessionId) GraphService.linkNodes(messageId, originSessionId, 'ORIGINATES_IN', 1.0, { timestamp, userId: sentBy, sharedEntity: true });

--- a/test/playwright/unit/ai/mcp/server/memory-core/services/GraphService.spec.mjs
+++ b/test/playwright/unit/ai/mcp/server/memory-core/services/GraphService.spec.mjs
@@ -441,6 +441,49 @@ test.describe('Neo.ai.mcp.server.memory-core.services.GraphService', () => {
         expect(link.source).toBe('RootT');
     });
 
+    test('linkNodes handles WAL-snapshot lag via cache-warm retry mechanism', () => {
+        // We simulate WAL snapshot lag by ensuring the node is NOT in SQLite during the first FK check,
+        // but appears in SQLite exactly when the cache-warm mechanism is triggered.
+
+        GraphService.upsertNode({ id: 'AnchorNode', type: 'AGENT', name: 'Anchor', properties: {} });
+        
+        expect(GraphService.db.nodes.has('GhostNode')).toBe(false);
+
+        // Spy on getAdjacentNodes to simulate another process writing the node during the cache-warm retry
+        const originalGetAdjacent = GraphService.db.getAdjacentNodes.bind(GraphService.db);
+        let cacheWarmTriggered = false;
+
+        GraphService.db.getAdjacentNodes = (nodeId, direction, type) => {
+            if (nodeId === 'GhostNode') {
+                cacheWarmTriggered = true;
+                // Simulate peer process writing the Node into SQLite exactly now
+                GraphService.db.storage.db.exec(`
+                    INSERT INTO Nodes (id, data) VALUES (
+                        'GhostNode',
+                        json('{"id":"GhostNode","label":"AGENT","properties":{"name":"Ghost"}}')
+                    )
+                `);
+            }
+            return originalGetAdjacent(nodeId, direction, type);
+        };
+
+        // linkNodes should hit the first FK check failure (count=1), trigger cache warm, find the ghost, and succeed
+        GraphService.linkNodes('AnchorNode', 'GhostNode', 'SEES_GHOST', 1.0);
+
+        // Restore original method
+        GraphService.db.getAdjacentNodes = originalGetAdjacent;
+
+        // Verify the cache warm was actually triggered
+        expect(cacheWarmTriggered).toBe(true);
+
+        // Verify the edge was created successfully after the retry
+        const edgeCount = GraphService.db.storage.db.prepare('SELECT count(*) as count FROM Edges WHERE source = ? AND target = ?').get('AnchorNode', 'GhostNode').count;
+        expect(edgeCount).toBe(1);
+
+        // Verify cache warming pulled the ghost node into memory
+        expect(GraphService.db.nodes.has('GhostNode')).toBe(true);
+    });
+
     // ----------------------------------------------------------------------------------------
     // linkNodesAsync + ensureNodeExists + normalizeGraphNodeId (#10153) — lazy back-fill path.
     // Sync `linkNodes` preserved unchanged for existing callers; these tests exercise the


### PR DESCRIPTION
Resolves #10347. Extracted from previous session diagnostics. Wraps Load-Check-Insert in a Database transaction and forces vicinity cache warming to bypass SQLite WAL synchronization lags. Adds MailboxService Phase 1 observability payload.