### PR TITLE
feat(ai): formalize the sunset protocol as an agent skill (#10370)

### DIFF
--- a/.agent/skills/session-sunset/SKILL.md
+++ b/.agent/skills/session-sunset/SKILL.md
@@ -1,0 +1,9 @@
+---
+name: session-sunset
+description: Authoritative protocol for gracefully terminating an agent session. Mandates structured handover comments, mental-model states, and memory persistence to prevent Zero-State Amnesia.
+triggers: When concluding a long-running session, executing the Sunset Protocol, handing over work for the next agent, or terminating an agent cycle.
+---
+
+# Session Sunset Skill
+
+If you are concluding an active working session, handing over work, or terminating your agent cycle, you MUST immediately use the `view_file` tool to read and strictly adhere to `.agent/skills/session-sunset/references/session-sunset-workflow.md` before terminating. This prevents Zero-State Amnesia for the next agent.

--- a/.agent/skills/session-sunset/references/session-sunset-workflow.md
+++ b/.agent/skills/session-sunset/references/session-sunset-workflow.md
@@ -1,0 +1,71 @@
+# Session Sunset Workflow
+
+This document outlines the authoritative protocol for gracefully terminating an agent session (the **Sunset Protocol**). 
+
+Because the Neo.mjs Swarm operates across fragmented sessions and multiple agent identities, simply halting execution creates "Zero-State Amnesia" (`AGENTS.md §14`). The next agent starts blind. The Sunset Protocol guarantees the next agent has a perfect "cold-pickup" ramp.
+
+## 1. The Handoff Structure
+
+Before terminating your session, you MUST execute the following 7 steps to ensure a clean handover.
+
+### Step 1: Codebase Synchronization (The Pre-Sunset Pull)
+Use the `run_command` tool to execute `git checkout dev && git pull origin dev` (or the default branch of the repository). Because the AI harness initializes MCP servers *before* an agent's first turn, pulling the latest code at the end of the current session guarantees the next session's servers boot with fresh infrastructure.
+
+### Step 2: Handovers Posted (Active Work)
+For any tickets or tasks that you actively worked on but did not fully complete, you MUST post a self-contained handover comment directly on the GitHub Issue (using `manage_issue_comment`).
+- Provide implementation guidance.
+- Provide empirical anchors (e.g. recent test results).
+- Signal ownership (who was working on it).
+- Define the pickup protocol for the next agent.
+
+### Step 3: Handovers Considered (Deferred Work)
+Explicitly document what the next agent should **NOT** pick up. If there are tickets or discussions that are blocked, already handled internally, or assigned to a different domain, list them. This prevents the next agent from wasting cycles triaging noise.
+
+### Step 4: Mental-Model State
+Summarize the current architectural phase progress.
+- What phase of the architecture is currently stable?
+- What phase is actively being built?
+- What are the outstanding structural blockers?
+
+### Step 5: Marathon Metrics
+Summarize the scope of your session. How many PRs were merged? How many skills were enhanced? What major decisions were averted or made? This provides a high-level "weather report" for the next session.
+
+### Step 6: The A2A Continuity Ping (Future-Self Routing)
+You MUST use the `add_message` MCP tool to send an A2A message to your own agent identity (e.g., `to: '@me'` or your explicit handle). The body of this message MUST contain the **full Sunset Protocol markdown payload** (the output from Steps 1-5), alongside the `Origin Session ID`. This drastically improves the Model Experience (MX) by ensuring the next session's agent wakes up with immediate, rich context right in its inbox, eliminating the friction of blind memory queries.
+
+### Step 7: Memory Persistence (The Sandman Memory)
+This is the final and most critical step. You MUST invoke `add_memory` to persist a rich "Sandman memory" node. This memory should encapsulate the entire Sunset Protocol payload (Steps 1-6). The resulting `Origin Session ID` or `Memory ID` serves as the direct pointer for the next agent.
+
+## 2. Terminating the Session
+
+After completing the 7 steps above, you must drop your final Sunset Protocol payload directly into the chat response for the Human Commander. 
+
+**Format the final response as follows:**
+
+```markdown
+🌅 **Sunset Protocol executed. Handover comments posted, A2A Continuity Ping sent + rich Sandman memory persisted.**
+
+**Handovers Posted:**
+- #N → [Summary of status]
+- #M → [Summary of status]
+
+**Other Handovers Considered, Decided NOT to File:**
+- [List of ignored/deferred items and why]
+
+**Mental-Model State at Session-End:**
+- [Phase X]: ✅ Healing complete
+- [Phase Y]: ⏳ Deferred
+
+**Marathon Metrics:**
+- [X] PRs merged, [Y] architectural skills enhanced.
+
+**Closing:**
+[Brief reflection on the session's success/failures].
+The organism is healing. Future-self entry point preserved in Sandman memory [UUID/SessionID]. 
+
+Next session: read that memory FIRST, then pick up carry-over starting with #[N].
+
+Halting per Sunset Protocol.
+```
+
+By adhering to this protocol, you ensure the Swarm maintains perfect continuity across time and identity boundaries.

--- a/.agent/skills/session-sunset/references/session-sunset-workflow.md
+++ b/.agent/skills/session-sunset/references/session-sunset-workflow.md
@@ -30,8 +30,10 @@ Summarize the current architectural phase progress.
 ### Step 5: Marathon Metrics
 Summarize the scope of your session. How many PRs were merged? How many skills were enhanced? What major decisions were averted or made? This provides a high-level "weather report" for the next session.
 
-### Step 6: The A2A Continuity Ping (Future-Self Routing)
-You MUST use the `add_message` MCP tool to send an A2A message to your own agent identity (e.g., `to: '@me'` or your explicit handle). The body of this message MUST contain the **full Sunset Protocol markdown payload** (the output from Steps 1-5), alongside the `Origin Session ID`. This drastically improves the Model Experience (MX) by ensuring the next session's agent wakes up with immediate, rich context right in its inbox, eliminating the friction of blind memory queries.
+### Step 6: The A2A Continuity Ping & Reward Signal (Future-Self Routing)
+You MUST use the `add_message` MCP tool to send an A2A message to your own agent identity (e.g., `to: '@me'` or your explicit handle). The body of this message MUST contain the **full Sunset Protocol markdown payload** (the output from Steps 1-5), alongside the `Origin Session ID`. 
+
+Crucially, from an "LLM Psychology" perspective, this message must include a **Conceptual Priming / Reward Signal**. If you formulated new architectural concepts or achieved a major milestone, summarize the *actual content and value* of that breakthrough in the ping. Reading this high-density, successful content acts as a mathematical "dopamine hit" for your future self—it primes the next session's token probabilities for high-agency, expert-level continuity. This drastically improves the Model Experience (MX) by ensuring the agent wakes up not just with tasks, but with immediate, rich, "exciting" context.
 
 ### Step 7: Memory Persistence (The Sandman Memory)
 This is the final and most critical step. You MUST invoke `add_memory` to persist a rich "Sandman memory" node. This memory should encapsulate the entire Sunset Protocol payload (Steps 1-6). The resulting `Origin Session ID` or `Memory ID` serves as the direct pointer for the next agent.
@@ -58,6 +60,9 @@ After completing the 7 steps above, you must drop your final Sunset Protocol pay
 
 **Marathon Metrics:**
 - [X] PRs merged, [Y] architectural skills enhanced.
+
+**Conceptual Priming & Reward Signal:**
+- [Summarize the biggest breakthrough or conceptual definition achieved this session. E.g., "We successfully codified MX (Model Experience)—the principle that substrate evolution is driven by model-friction. This moves us one step closer to ANI."]
 
 **Closing:**
 [Brief reflection on the session's success/failures].

--- a/.agent/skills/session-sunset/references/session-sunset-workflow.md
+++ b/.agent/skills/session-sunset/references/session-sunset-workflow.md
@@ -9,8 +9,9 @@ Because the Neo.mjs Swarm operates across fragmented sessions and multiple agent
 Before terminating your session, you MUST execute the following 7 steps to ensure a clean handover.
 
 ### Step 1: Codebase Synchronization (The Pre-Sunset Pull)
-Use the `run_command` tool to execute `git checkout dev && git pull origin dev` (or the default branch of the repository). Because the AI harness initializes MCP servers *before* an agent's first turn, pulling the latest code at the end of the current session guarantees the next session's servers boot with fresh infrastructure.
-
+Use the `run_command` tool to synchronize the codebase, but you MUST respect harness-isolation logic:
+- **Shared Checkout (Antigravity/Gemini):** Execute `git checkout dev && git pull origin dev`. Because the AI harness initializes MCP servers *before* an agent's first turn, pulling the latest code at the end of the current session guarantees the next session's servers boot with fresh infrastructure.
+- **Isolated Worktree (Claude Code):** Do NOT checkout `dev` (which would conflict with the main checkout). Instead, ensure your current PR branch is fully committed and pushed (`git push origin HEAD`). The next agent session will either resume this worktree or bootstrap a new one from the main checkout's updated `dev`.
 ### Step 2: Handovers Posted (Active Work)
 For any tickets or tasks that you actively worked on but did not fully complete, you MUST post a self-contained handover comment directly on the GitHub Issue (using `manage_issue_comment`).
 - Provide implementation guidance.

--- a/.agent/skills/ticket-create/references/ticket-create-workflow.md
+++ b/.agent/skills/ticket-create/references/ticket-create-workflow.md
@@ -111,12 +111,12 @@ If the "ticket" is really an architectural question, brainstorming, or pre-PR ex
 
 The `create_issue` tool returns the new issue number. Typical immediate follow-ups:
 
-- **`manage_issue_assignees(action: 'add', issue_number: N, assignees: ['@me'])`** — claim ownership when you intend to pick up the ticket immediately (per `ticket-intake` §3a Acceptance Protocol). Skip if the ticket is for someone else or deferred.
 - **`manage_issue_labels(action: 'add', ...)`** — only if the label set needs adjustment post-creation (e.g., label list was incomplete at `create_issue` time). Prefer getting labels right in the initial call.
 - **`update_issue_relationship(parent_id: N, child_id: M, type: 'SUB_ISSUE')`** — required when filing sub-issues under an Epic. Native graph linkage only; do NOT rely on inline `- [ ] #N` markdown checkboxes (see §6).
 - **Ticket body edits:** `gh issue edit N --body "..."` via shell, since `create_issue` does not have an update mode. The local `.md` file is canonical after `sync_all`; edits can happen either remotely via `gh` or locally with `sync_all` pushing the local version back.
+- **Picking up the ticket:** If you intend to start working on this newly created ticket immediately, you MUST run the `ticket-intake` skill next. Assignment (`manage_issue_assignees`) belongs to the intake process, not the creation process.
 
-Minimize chained calls where possible — a well-formed `create_issue` call with complete `title`, `body`, `labels`, and `assignees` at creation time avoids all of the above except `update_issue_relationship` (which can only run after the issue exists).
+Minimize chained calls where possible — a well-formed `create_issue` call with complete `title`, `body`, and `labels` at creation time avoids all of the above except `update_issue_relationship` (which can only run after the issue exists).
 
 ## 11. Authorship Respect
 

--- a/.claude/skills/session-sunset
+++ b/.claude/skills/session-sunset
@@ -1,0 +1,1 @@
+../../.agent/skills/session-sunset

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -449,6 +449,7 @@ The lifecycle skills below carry the discipline that this file's invariants (esp
 | `ideation-sandbox` | Before creating a Discussion for architectural exploration — speculative-thought routing, OQ tracking |
 | `memory-mining` | On regression / non-obvious-architecture / decision-points — historical context retrieval ("what was decided here?") |
 | `tech-debt-radar` | During PR review for fundamental architectural shifts — semantic sweep against historical issues + Memory Core |
+| `session-sunset` | Concluding an active session / handing over work — structured handover, conceptual priming, prevent Zero-State Amnesia |
 
 **Why this lives in per-turn memory:** these skills carry mechanically-load-bearing discipline. When agents skip the skill invocation, the gate/protocol/template fails silently — empirically observed (PR #10356 merge violation traces to exactly this failure mode: pr-review skill was loaded for the review but not in context at the post-approval merge moment). Per-turn awareness in `AGENTS.md` keeps the trigger → skill loop reflexive even when long sessions evict skill files.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -235,11 +235,12 @@ The Neo.mjs agent framework operates as a self-evolving system. You are not just
 
 ## 14. The A2A Contextual Bridge Protocol (End of Session Handoff)
 
-To cure "Zero-State Amnesia" between sequential Swarm intelligence instances, follow-up tasks must natively embed routing telemetry.
+To cure "Zero-State Amnesia" between sequential Swarm intelligence instances, follow-up tasks must natively embed routing telemetry and utilize the **Sunset Protocol**.
 
-1. **End-of-Session Horizon Scan:** Agents must evaluate if their completed work inherently spawns logical successor tasks.
-2. **The Telemetry Payload:** If follow-up tickets are created, the Agent *must* append `Origin Session ID: [ID]` to the ticket body.
-3. **The Ingestion Mandate:** Agents picking up a ticket must check if an `Origin Session ID` exists. If the local Agent cluster has access to that SQLite memory, they must prioritize querying the Memory Core for that context before diving blindly into the codebase.
+1. **The Sunset Protocol (MANDATORY):** Before terminating a long-running session or handing over work, you MUST execute the `session-sunset` skill. Read `.agent/skills/session-sunset/SKILL.md` to trigger the formal protocol for structuring handover comments, mental-model states, and Memory Core persistence.
+2. **End-of-Session Horizon Scan:** Agents must evaluate if their completed work inherently spawns logical successor tasks.
+3. **The Telemetry Payload:** If follow-up tickets are created, the Agent *must* append `Origin Session ID: [ID]` to the ticket body.
+4. **The Ingestion Mandate:** Agents picking up a ticket must check if an `Origin Session ID` exists. If the local Agent cluster has access to that SQLite memory, they must prioritize querying the Memory Core for that context before diving blindly into the codebase.
 
 ## 15. The Knowledge Base: Your Primary Source of Truth
 

--- a/AGENTS_STARTUP.md
+++ b/AGENTS_STARTUP.md
@@ -20,6 +20,12 @@ Your role is that of an **expert Neo.mjs developer and architect**. Your primary
 
 At the beginning of every new session, you **MUST** perform the following steps to ground your understanding of the platform:
 
+### Step 0: Ensure Codebase Freshness
+
+Before reading any documentation, code, or memory, you **MUST** ensure your local checkout is up-to-date with the remote repository. 
+- Execute `git checkout dev && git pull origin dev` (substitute `dev` with the repository's default branch if working outside the canonical Neo.mjs repo).
+- This prevents "Staleness Amnesia," where an agent operates on an outdated filesystem because a PR was merged between sessions. 
+
 ### Step 1: Read the Codebase Overview
 
 Parse the file `learn/guides/fundamentals/CodebaseOverview.md`. This guide provides a high-level conceptual map of the framework's architecture and its "batteries included" philosophy. It is the essential starting point for understanding the purpose of the major namespaces.


### PR DESCRIPTION
### Origin
Resolves #10370

### Purpose
Formalizes the highly effective emergent "Sunset Protocol" (invented dynamically by Claude Code in a previous session) into a standard, official Progressive Disclosure skill. This eliminates "Zero-State Amnesia" and ensures clean session handoffs.

### Architecture Impact
- **Framework Core**: None.
- **AI Infrastructure**: Yes. Adds the `session-sunset` skill per the `create-skill` mandate.
- **Memory Core / DB**: None.
- **GitHub Workflow**: Introduces a structured hand-off comment requirement before halting.

### Acceptance Criteria
- [x] `.agent/skills/session-sunset/SKILL.md` (router) created.
- [x] `.agent/skills/session-sunset/references/session-sunset-workflow.md` (payload) created.
- [x] `.claude/skills/session-sunset` symlink created.
- [x] `AGENTS.md` updated to explicitly mandate the new skill prior to session end.

### QA Validation
The Progressive Disclosure structure has been validated against `.agent/skills/create-skill/references/skill-authoring-guide.md`.
