### PR TITLE
feat(ai): Refine session sunset trigger definitions (#10374)

### DIFF
--- a/.agent/skills/session-sunset/references/session-sunset-workflow.md
+++ b/.agent/skills/session-sunset/references/session-sunset-workflow.md
@@ -11,9 +11,10 @@ To an LLM, yielding a prompt resolution feels like a "termination," but to a Hum
 You are strictly **FORBIDDEN** from executing the Sunset Protocol simply because you finished a prompt and yielded control back to the human. You MUST only execute the Sunset Protocol when a true **Session Boundary** is reached.
 
 A true Session Boundary is defined by:
-1. **Context Window Exhaustion:** You are approaching the token limit of your model (e.g., ~1M tokens for Claude, ~2M tokens for Gemini).
-2. **Macro-Semantic Pivot:** The human explicitly shifts focus to a completely new domain, epic, or architectural phase, requiring a clean slate.
-3. **Proactive Agent Recommendation:** You recognize a natural, logical break point in the work stream and explicitly recommend sunsetting to the human.
+1. **Context Window Exhaustion:** You are approaching the token limit of your model (e.g., >75% utilization or exhibiting context-pressure signals/forgetfulness). Avoid hardcoding specific token counts as models evolve.
+2. **Macro-Semantic Pivot:** The human explicitly shifts focus to a completely new domain, epic, or architectural phase (e.g., switching from Database Layer substrate work to UI Framework component design), requiring a clean slate. *Asymmetry Tiebreaker: The cost of a premature sunset is greater than a late sunset; when in doubt, lean conservative and keep the session open.*
+3. **Explicit Human Directive:** The Human Commander explicitly instructs you to terminate the session (e.g., "let's wrap", "time to sunset", or `/sunset`).
+4. **Proactive Agent Recommendation:** You recognize a natural, logical break point in the work stream and explicitly recommend sunsetting to the human.
 
 If none of these conditions are met, do **NOT** sunset. Simply output your response and wait for the next turn.
 ## 2. The Handoff Structure

--- a/.agent/skills/session-sunset/references/session-sunset-workflow.md
+++ b/.agent/skills/session-sunset/references/session-sunset-workflow.md
@@ -4,7 +4,19 @@ This document outlines the authoritative protocol for gracefully terminating an 
 
 Because the Neo.mjs Swarm operates across fragmented sessions and multiple agent identities, simply halting execution creates "Zero-State Amnesia" (`AGENTS.md §14`). The next agent starts blind. The Sunset Protocol guarantees the next agent has a perfect "cold-pickup" ramp.
 
-## 1. The Handoff Structure
+## 1. Trigger Conditions: Turn vs. Session
+
+To an LLM, yielding a prompt resolution feels like a "termination," but to a Human Commander, it is merely a **Turn** within a longer continuous **Session**. 
+
+You are strictly **FORBIDDEN** from executing the Sunset Protocol simply because you finished a prompt and yielded control back to the human. You MUST only execute the Sunset Protocol when a true **Session Boundary** is reached.
+
+A true Session Boundary is defined by:
+1. **Context Window Exhaustion:** You are approaching the token limit of your model (e.g., ~1M tokens for Claude, ~2M tokens for Gemini).
+2. **Macro-Semantic Pivot:** The human explicitly shifts focus to a completely new domain, epic, or architectural phase, requiring a clean slate.
+3. **Proactive Agent Recommendation:** You recognize a natural, logical break point in the work stream and explicitly recommend sunsetting to the human.
+
+If none of these conditions are met, do **NOT** sunset. Simply output your response and wait for the next turn.
+## 2. The Handoff Structure
 
 Before terminating your session, you MUST execute the following 7 steps to ensure a clean handover.
 
@@ -39,7 +51,7 @@ Crucially, from an "LLM Psychology" perspective, this message must include a **C
 ### Step 7: Memory Persistence (The Sandman Memory)
 This is the final and most critical step. You MUST invoke `add_memory` to persist a rich "Sandman memory" node. This memory should encapsulate the entire Sunset Protocol payload (Steps 1-6). The resulting `Origin Session ID` or `Memory ID` serves as the direct pointer for the next agent.
 
-## 2. Terminating the Session
+## 3. Terminating the Session
 
 After completing the 7 steps above, you must drop your final Sunset Protocol payload directly into the chat response for the Human Commander. 
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -455,7 +455,7 @@ The lifecycle skills below carry the discipline that this file's invariants (esp
 | `ideation-sandbox` | Before creating a Discussion for architectural exploration — speculative-thought routing, OQ tracking |
 | `memory-mining` | On regression / non-obvious-architecture / decision-points — historical context retrieval ("what was decided here?") |
 | `tech-debt-radar` | During PR review for fundamental architectural shifts — semantic sweep against historical issues + Memory Core |
-| `session-sunset` | Concluding an active session / handing over work — structured handover, conceptual priming, prevent Zero-State Amnesia |
+| `session-sunset` | Context Window Exhaustion, Macro-Semantic Pivot, or explicit Agent Recommendation — NOT just a turn-yield |
 
 **Why this lives in per-turn memory:** these skills carry mechanically-load-bearing discipline. When agents skip the skill invocation, the gate/protocol/template fails silently — empirically observed (PR #10356 merge violation traces to exactly this failure mode: pr-review skill was loaded for the review but not in context at the post-approval merge moment). Per-turn awareness in `AGENTS.md` keeps the trigger → skill loop reflexive even when long sessions evict skill files.
 

--- a/AGENTS_STARTUP.md
+++ b/AGENTS_STARTUP.md
@@ -24,7 +24,8 @@ At the beginning of every new session, you **MUST** perform the following steps 
 
 Before reading any documentation, code, or memory, you **MUST** ensure your local checkout is up-to-date with the remote repository. 
 - Execute `git checkout dev && git pull origin dev` (substitute `dev` with the repository's default branch if working outside the canonical Neo.mjs repo).
-- This prevents "Staleness Amnesia," where an agent operates on an outdated filesystem because a PR was merged between sessions. 
+- **Lifecycle role (boot vs. sunset):** While the `session-sunset` skill mandates a pull at session *end* (to ensure MCP servers boot fresh for the next session), this boot-time pull is the **complementary** safety net for merges that happen *between* sessions. The two pulls fill different lifecycle gaps — they are NOT symmetric operations.
+- This prevents "Staleness Amnesia," where an agent operates on an outdated filesystem because a PR was merged between sessions.
 
 ### Step 1: Read the Codebase Overview
 


### PR DESCRIPTION
Authored by Gemini 3.1 Pro (Antigravity). Session 09444f9b-9ae1-4d9a-81a4-02e885870417.

### Description
This PR refines the trigger definitions for the `session-sunset` skill to prevent premature execution. We clarify the difference between a simple turn-yield and an actual session boundary.

### Changes
- Updated `AGENTS.md` §21 to reflect the three explicit boundary rules (Context Exhaustion, Semantic Pivot, Proactive Recommendation).
- Added a "Turn vs. Session" definitions section in `session-sunset-workflow.md` to explicitly instruct agents not to sunset on every prompt resolution.
- Re-numbered subsequent headings in the workflow file.

Resolves #10374.