### PR TITLE
feat(ai): WAKE_SUBSCRIPTION schema + tool surface (#10361)

### DIFF
--- a/ai/mcp/server/memory-core/openapi.yaml
+++ b/ai/mcp/server/memory-core/openapi.yaml
@@ -1101,6 +1101,82 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
 
+  /wake-subscriptions/manage:
+    post:
+      summary: Manage WAKE_SUBSCRIPTION
+      operationId: manage_wake_subscription
+      x-pass-as-object: true
+      description: |
+        Unified surface for the Phase 3 wake-substrate subscription lifecycle. Subscribe to graph events (SENT_TO_ME / TASK_STATE_CHANGED / PERMISSION_GRANTED) with optional filters; route delivery via mcp-notifications, a2a-webhook, or bridge-daemon (Shape A/B/C per ADR 0002).
+      tags: [WakeSubscriptions]
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - action
+              properties:
+                action:
+                  type: string
+                  enum: [subscribe, unsubscribe, update, list, resync]
+                  description: Lifecycle action to perform on the subscription.
+                subscriptionId:
+                  type: string
+                  description: Required for unsubscribe / update / resync; optional for list (single).
+                trigger:
+                  type: string
+                  enum: [SENT_TO_ME, TASK_STATE_CHANGED, PERMISSION_GRANTED]
+                  description: Required for subscribe.
+                filters:
+                  type: object
+                  description: Optional AND-conjunctive filters over the trigger.
+                  properties:
+                    taggedConcepts:  {type: array, items: {type: string}}
+                    priority:        {type: string, enum: [high, normal, low]}
+                    senderFilter:    {type: array, items: {type: string}}
+                    inReplyToFilter: {type: array, items: {type: string}}
+                harnessTarget:
+                  type: string
+                  enum: [mcp-notifications, a2a-webhook, bridge-daemon, disabled, none]
+                  description: Required for subscribe; specifies how wake events are delivered.
+                harnessTargetMetadata:
+                  type: object
+                  description: Channel-specific metadata. url required for a2a-webhook; coalesceWindow optional override; daemonSocketPath for bridge-daemon.
+                  properties:
+                    url:               {type: string}
+                    coalesceWindow:    {type: integer, minimum: 0, maximum: 300}
+                    daemonSocketPath:  {type: string}
+                sinceLogId:
+                  type: integer
+                  description: Required for resync. GraphLog watermark; client-tracked.
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+        '400':
+          description: Bad Request (invalid action / parameter)
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '403':
+          description: Permission denied (subscription owned by a different identity)
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
 components:
   schemas:
     HealthCheckResponse:

--- a/ai/mcp/server/memory-core/openapi.yaml
+++ b/ai/mcp/server/memory-core/openapi.yaml
@@ -1106,8 +1106,7 @@ paths:
       summary: Manage WAKE_SUBSCRIPTION
       operationId: manage_wake_subscription
       x-pass-as-object: true
-      description: |
-        Unified surface for the Phase 3 wake-substrate subscription lifecycle. Subscribe to graph events (SENT_TO_ME / TASK_STATE_CHANGED / PERMISSION_GRANTED) with optional filters; route delivery via mcp-notifications, a2a-webhook, or bridge-daemon (Shape A/B/C per ADR 0002).
+      description: Subscribe / unsubscribe / update / list / resync agent wake-event subscriptions with trigger types (SENT_TO_ME, TASK_STATE_CHANGED, PERMISSION_GRANTED), optional AND-conjunctive filters, and harness target routing.
       tags: [WakeSubscriptions]
       requestBody:
         required: true

--- a/ai/mcp/server/memory-core/services/WakeSubscriptionService.mjs
+++ b/ai/mcp/server/memory-core/services/WakeSubscriptionService.mjs
@@ -327,6 +327,9 @@ class WakeSubscriptionService extends Base {
      * Evaluates a GraphLog edge entry against a subscription's trigger+filter spec.
      * Returns the wake-event payload if matched, null otherwise.
      * @protected
+     * @param {Object} edgeRef GraphLog edge reference: `{id, source, target}`
+     * @param {Object} subscription The cached WAKE_SUBSCRIPTION entry (id + properties)
+     * @returns {Object|null} Wrapped wake-event payload (per §6.1.1 / §6.1.3 envelope) or null when no match
      */
     _evaluateEdgeAgainstSubscription(edgeRef, subscription) {
         const db   = GraphService.db;
@@ -361,6 +364,9 @@ class WakeSubscriptionService extends Base {
      * Evaluates a GraphLog node entry against TASK_STATE_CHANGED triggers.
      * Returns the wake-event payload if matched, null otherwise.
      * @protected
+     * @param {String} nodeId GraphLog-touched node ID (typically a `MESSAGE:*` carrying a Task envelope)
+     * @param {Object} subscription The cached WAKE_SUBSCRIPTION entry (id + properties)
+     * @returns {Object|null} Wrapped wake-event payload (per §6.1.2 envelope) or null when no match
      */
     _evaluateNodeAgainstSubscription(nodeId, subscription) {
         if (subscription.trigger !== 'TASK_STATE_CHANGED') return null;
@@ -389,6 +395,8 @@ class WakeSubscriptionService extends Base {
     /**
      * Builds the wake/sent_to_me payload from a MESSAGE node.
      * @protected
+     * @param {Object} messageNode Graph node with `properties` (from / subject / priority / taggedConcepts / inReplyTo / to)
+     * @returns {{messageId:String,from:String,subject:String,priority:String,taggedConcepts:String[],isReplyTo:?String,isBroadcast:Boolean}}
      */
     _buildSentToMePayload(messageNode) {
         const props = messageNode.properties || {};
@@ -406,6 +414,11 @@ class WakeSubscriptionService extends Base {
     /**
      * Wraps a payload in the standard wake notification envelope per ADR 0002 §6.1.1-§6.1.3.
      * @protected
+     * @param {String} eventType One of `wake/sent_to_me`, `wake/task_state_changed`, `wake/permission_granted`
+     * @param {Object} subscription Cached WAKE_SUBSCRIPTION entry (provides `id` + `agentIdentity`)
+     * @param {Object} payload Trigger-specific inner payload built by the matching `_build*Payload` helper
+     * @param {String|Number} logIdAnchor GraphLog `log_id` anchor preserved across re-emissions for cursor-based catchup
+     * @returns {Object} Full notification envelope (`schemaVersion`, `eventType`, `eventId`, `logId`, `agentIdentity`, `subscriptionId`, `payload`, `emittedAt`)
      */
     _wrapEvent(eventType, subscription, payload, logIdAnchor) {
         return {
@@ -424,6 +437,9 @@ class WakeSubscriptionService extends Base {
      * Applies optional filter spec (taggedConcepts, priority, senderFilter, inReplyToFilter)
      * to a sent_to_me payload. Returns true if all configured filters pass.
      * @protected
+     * @param {Object} payload The `_buildSentToMePayload` output to evaluate
+     * @param {Object} [filters={}] Subscription filter spec (taggedConcepts / priority / senderFilter / inReplyToFilter)
+     * @returns {Boolean} `true` if every configured filter passes (AND-conjunctive); `false` otherwise
      */
     _matchesFilters(payload, filters = {}) {
         if (filters.priority && payload.priority !== filters.priority) return false;
@@ -446,6 +462,8 @@ class WakeSubscriptionService extends Base {
      * Loads a subscription by id, preferring the in-memory cache and falling back to
      * SQLite. Cache-warms on miss.
      * @protected
+     * @param {String} subscriptionId The `WAKE_SUB:<uuid>` identifier
+     * @returns {Object|null} Cached entry (`{id, ...properties}`) or null if no matching node exists
      */
     _loadSubscription(subscriptionId) {
         if (this.subscriptionCache.has(subscriptionId)) return this.subscriptionCache.get(subscriptionId);

--- a/ai/mcp/server/memory-core/services/WakeSubscriptionService.mjs
+++ b/ai/mcp/server/memory-core/services/WakeSubscriptionService.mjs
@@ -1,0 +1,462 @@
+import crypto                 from 'crypto';
+import Base                   from '../../../../../src/core/Base.mjs';
+import GraphService           from './GraphService.mjs';
+import RequestContextService  from '../../shared/services/RequestContextService.mjs';
+import logger                 from '../logger.mjs';
+
+/**
+ * @summary Service for managing graph-resident WAKE_SUBSCRIPTION nodes and the
+ * `manage_wake_subscription` MCP tool surface — the foundational substrate for the
+ * Phase 3 cross-harness autonomous wake substrate (ADR 0002).
+ *
+ * Subscriptions are graph-resident (durable across MCP server restarts per ADR 0002 §6.6.2)
+ * with a write-through in-memory cache for sub-millisecond trigger evaluation.
+ * Per-agent ownership is enforced via `RequestContextService.getAgentIdentityNodeId()`
+ * and an explicit `SUBSCRIBES_TO` edge from the AgentIdentity node to the WAKE_SUBSCRIPTION
+ * node.
+ *
+ * The service implements the discipline-layer surface; channel-specific event delivery
+ * (Shape A MCP notifications, Shape B A2A webhook, Shape C bridge daemon) is wired
+ * by the consuming sub-tickets #10358 / #10359 / #10360. The `resync` action queries
+ * `GraphLog` deltas and returns the event-payload list; channel dispatch is the
+ * consumer's responsibility.
+ *
+ * @class Neo.ai.mcp.server.memory-core.services.WakeSubscriptionService
+ * @extends Neo.core.Base
+ * @singleton
+ * @see learn/agentos/decisions/0002-phase3-wake-substrate-standards-alignment.md §6.6
+ * @see #10357 (parent Epic) #10361 (this sub) #10358/#10359/#10360 (channel consumers)
+ */
+class WakeSubscriptionService extends Base {
+    static config = {
+        /**
+         * @member {String} className='Neo.ai.mcp.server.memory-core.services.WakeSubscriptionService'
+         * @protected
+         */
+        className: 'Neo.ai.mcp.server.memory-core.services.WakeSubscriptionService',
+        /**
+         * @member {Boolean} singleton=true
+         * @protected
+         */
+        singleton: true
+    }
+
+    /**
+     * @member {String[]} validTriggers
+     * @protected
+     */
+    validTriggers = ['SENT_TO_ME', 'TASK_STATE_CHANGED', 'PERMISSION_GRANTED']
+
+    /**
+     * @member {String[]} validHarnessTargets
+     * @protected
+     */
+    validHarnessTargets = ['mcp-notifications', 'a2a-webhook', 'bridge-daemon', 'disabled', 'none']
+
+    /**
+     * In-memory write-through cache for sub-millisecond trigger evaluation.
+     * Keyed by subscriptionId; values are the full WAKE_SUBSCRIPTION node payload.
+     * Populated lazily on `list` and on every mutation; rebuilt at boot from graph state
+     * if the service is reinitialized (durable layer is the source of truth).
+     * @member {Map<String, Object>} subscriptionCache
+     * @protected
+     */
+    subscriptionCache = new Map()
+
+    /**
+     * Unified entry point for the `manage_wake_subscription` MCP tool. Dispatches to
+     * action-specific handlers per ADR 0002 §6.6.
+     *
+     * @param {Object} opts
+     * @param {String} opts.action One of 'subscribe' | 'unsubscribe' | 'update' | 'list' | 'resync'
+     * @param {Object} [opts.rest] Action-specific parameters (see individual methods)
+     * @returns {Promise<Object>}
+     */
+    async manage(opts = {}) {
+        const {action, ...rest} = opts;
+        switch (action) {
+            case 'subscribe'  : return this.subscribe  (rest);
+            case 'unsubscribe': return this.unsubscribe(rest);
+            case 'update'     : return this.update     (rest);
+            case 'list'       : return this.list       (rest);
+            case 'resync'     : return this.resync     (rest);
+            default:
+                throw new Error(
+                    `Invalid action '${action}'. Must be one of: subscribe, unsubscribe, update, list, resync.`
+                );
+        }
+    }
+
+    /**
+     * Creates a new subscription. Generates a fresh subscriptionId, persists the
+     * WAKE_SUBSCRIPTION node + SUBSCRIBES_TO edge, and populates the cache.
+     * For Shape B (`a2a-webhook`), generates an HMAC signing key and returns it once.
+     *
+     * @param {Object} opts
+     * @param {String} opts.trigger One of validTriggers
+     * @param {Object} [opts.filters] taggedConcepts | priority | senderFilter | inReplyToFilter
+     * @param {String} opts.harnessTarget One of validHarnessTargets
+     * @param {Object} [opts.harnessTargetMetadata] url | coalesceWindow | daemonSocketPath
+     * @returns {Promise<Object>} {subscriptionId, harnessTarget, signingKey?}
+     */
+    async subscribe({trigger, filters = {}, harnessTarget, harnessTargetMetadata = {}} = {}) {
+        const owner = RequestContextService.getAgentIdentityNodeId();
+        if (!owner) throw new Error('Cannot create subscription: no agent identity context bound.');
+
+        if (!this.validTriggers.includes(trigger)) {
+            throw new Error(`Invalid trigger '${trigger}'. Must be one of: ${this.validTriggers.join(', ')}`);
+        }
+        if (!this.validHarnessTargets.includes(harnessTarget)) {
+            throw new Error(`Invalid harnessTarget '${harnessTarget}'. Must be one of: ${this.validHarnessTargets.join(', ')}`);
+        }
+
+        const subscriptionId = `WAKE_SUB:${crypto.randomUUID()}`;
+        const now            = new Date().toISOString();
+        const finalMetadata  = {...harnessTargetMetadata};
+
+        // Shape B requires an HMAC signing key for webhook authenticity.
+        // Per ADR 0002 §6.2.3 the server generates and returns it once at subscribe-time;
+        // it is stored in the node's harnessTargetMetadata for subsequent verification.
+        let signingKey;
+        if (harnessTarget === 'a2a-webhook') {
+            if (!finalMetadata.url) {
+                throw new Error("Shape B (a2a-webhook) requires harnessTargetMetadata.url.");
+            }
+            signingKey              = crypto.randomBytes(32).toString('hex');
+            finalMetadata.signingKey = signingKey;
+        }
+
+        const properties = {
+            agentIdentity: owner,
+            trigger,
+            filters,
+            harnessTarget,
+            harnessTargetMetadata: finalMetadata,
+            createdAt    : now,
+            updatedAt    : now,
+            userId       : owner,
+            sharedEntity : false,
+            status       : 'active'
+        };
+
+        GraphService.upsertNode({
+            id  : subscriptionId,
+            type: 'WAKE_SUBSCRIPTION',
+            properties
+        });
+
+        // SUBSCRIBES_TO edge: AgentIdentity --SUBSCRIBES_TO--> WAKE_SUBSCRIPTION
+        GraphService.linkNodes(owner, subscriptionId, 'SUBSCRIBES_TO', 1.0);
+
+        const cacheEntry = {id: subscriptionId, ...properties};
+        this.subscriptionCache.set(subscriptionId, cacheEntry);
+
+        logger.info(`[WakeSubscription] subscribed ${subscriptionId} for ${owner} (trigger=${trigger}, harness=${harnessTarget})`);
+
+        const result = {subscriptionId, harnessTarget};
+        if (signingKey) result.signingKey = signingKey;
+        return result;
+    }
+
+    /**
+     * Removes a subscription. Caller must own it.
+     *
+     * @param {Object} opts
+     * @param {String} opts.subscriptionId
+     * @returns {Promise<Object>} {subscriptionId, status: 'removed'}
+     */
+    async unsubscribe({subscriptionId} = {}) {
+        const caller = RequestContextService.getAgentIdentityNodeId();
+        if (!caller) throw new Error('Cannot unsubscribe: no agent identity context bound.');
+        if (!subscriptionId) throw new Error("Missing 'subscriptionId' parameter.");
+
+        const subscription = this._loadSubscription(subscriptionId);
+        if (!subscription) throw new Error(`Subscription not found: ${subscriptionId}`);
+        if (subscription.agentIdentity !== caller) {
+            throw new Error(`Permission denied: subscription ${subscriptionId} is owned by ${subscription.agentIdentity}, not ${caller}.`);
+        }
+
+        const db           = GraphService.db;
+        const edgesToRemove = [];
+        for (const edge of db.edges.items) {
+            if (edge.target === subscriptionId && edge.type === 'SUBSCRIBES_TO') {
+                edgesToRemove.push(edge);
+            }
+        }
+        if (edgesToRemove.length > 0) db.edges.remove(edgesToRemove);
+
+        db.removeNode(subscriptionId);
+        this.subscriptionCache.delete(subscriptionId);
+
+        logger.info(`[WakeSubscription] unsubscribed ${subscriptionId} for ${caller}`);
+
+        return {subscriptionId, status: 'removed'};
+    }
+
+    /**
+     * Mutates subscription properties. Filters/harnessTarget/harnessTargetMetadata are
+     * the typical update targets. agentIdentity is immutable; createdAt is immutable.
+     *
+     * @param {Object} opts
+     * @param {String} opts.subscriptionId
+     * @param {Object} [opts.filters]
+     * @param {String} [opts.harnessTarget]
+     * @param {Object} [opts.harnessTargetMetadata]
+     * @returns {Promise<Object>} {subscriptionId, currentState}
+     */
+    async update({subscriptionId, filters, harnessTarget, harnessTargetMetadata} = {}) {
+        const caller = RequestContextService.getAgentIdentityNodeId();
+        if (!caller) throw new Error('Cannot update subscription: no agent identity context bound.');
+        if (!subscriptionId) throw new Error("Missing 'subscriptionId' parameter.");
+
+        const subscription = this._loadSubscription(subscriptionId);
+        if (!subscription) throw new Error(`Subscription not found: ${subscriptionId}`);
+        if (subscription.agentIdentity !== caller) {
+            throw new Error(`Permission denied: subscription ${subscriptionId} is owned by ${subscription.agentIdentity}, not ${caller}.`);
+        }
+
+        if (harnessTarget !== undefined && !this.validHarnessTargets.includes(harnessTarget)) {
+            throw new Error(`Invalid harnessTarget '${harnessTarget}'. Must be one of: ${this.validHarnessTargets.join(', ')}`);
+        }
+
+        const updated = {...subscription};
+        if (filters               !== undefined) updated.filters               = filters;
+        if (harnessTarget         !== undefined) updated.harnessTarget         = harnessTarget;
+        if (harnessTargetMetadata !== undefined) updated.harnessTargetMetadata = {...subscription.harnessTargetMetadata, ...harnessTargetMetadata};
+        updated.updatedAt = new Date().toISOString();
+
+        const {id, ...properties} = updated;
+        GraphService.upsertNode({
+            id  : subscriptionId,
+            type: 'WAKE_SUBSCRIPTION',
+            properties
+        });
+
+        this.subscriptionCache.set(subscriptionId, updated);
+
+        return {subscriptionId, currentState: updated};
+    }
+
+    /**
+     * Lists subscriptions owned by the calling agent identity, or a single subscription
+     * if `subscriptionId` is provided.
+     *
+     * @param {Object} opts
+     * @param {String} [opts.subscriptionId]
+     * @returns {Promise<Object>} {subscriptions: [...]}
+     */
+    async list({subscriptionId} = {}) {
+        const caller = RequestContextService.getAgentIdentityNodeId();
+        if (!caller) throw new Error('Cannot list subscriptions: no agent identity context bound.');
+
+        if (subscriptionId) {
+            const subscription = this._loadSubscription(subscriptionId);
+            if (!subscription)                           return {subscriptions: []};
+            if (subscription.agentIdentity !== caller)   return {subscriptions: []};
+            return {subscriptions: [subscription]};
+        }
+
+        // Full scan for caller-owned subscriptions. The cache may be partial (lazy-loaded);
+        // walk SQLite directly for completeness, then warm the cache as a side effect.
+        const subscriptions = [];
+        const db            = GraphService.db;
+        for (const node of db.nodes.items) {
+            if (node.label !== 'WAKE_SUBSCRIPTION') continue;
+            const props = node.properties || {};
+            if (props.agentIdentity !== caller)     continue;
+            const entry = {id: node.id, ...props};
+            this.subscriptionCache.set(node.id, entry);
+            subscriptions.push(entry);
+        }
+        return {subscriptions};
+    }
+
+    /**
+     * Replays GraphLog deltas matching the subscription's current trigger+filter spec,
+     * starting from `sinceLogId`. Returns the matching event payloads as data; the
+     * channel-specific re-emission (MCP notifications / webhook POST / daemon dispatch)
+     * is the responsibility of Shape A/B/C consumers wiring this output to their
+     * delivery surfaces. Per ADR 0002 §6.1.6 + §6.6.2.
+     *
+     * @param {Object} opts
+     * @param {String} opts.subscriptionId
+     * @param {Number} [opts.sinceLogId=0] GraphLog watermark; client-tracked
+     * @returns {Promise<Object>} {subscriptionId, events: [...], lastLogId, eventsReplayed}
+     */
+    async resync({subscriptionId, sinceLogId = 0} = {}) {
+        const caller = RequestContextService.getAgentIdentityNodeId();
+        if (!caller) throw new Error('Cannot resync: no agent identity context bound.');
+        if (!subscriptionId) throw new Error("Missing 'subscriptionId' parameter.");
+
+        const subscription = this._loadSubscription(subscriptionId);
+        if (!subscription) throw new Error(`Subscription not found: ${subscriptionId}`);
+        if (subscription.agentIdentity !== caller) {
+            throw new Error(`Permission denied: subscription ${subscriptionId} is owned by ${subscription.agentIdentity}, not ${caller}.`);
+        }
+
+        const storage = GraphService.db.storage;
+        if (!storage?.getDeltaLog) {
+            logger.warn('[WakeSubscription] resync called but GraphLog storage unavailable; returning empty replay.');
+            return {subscriptionId, events: [], lastLogId: sinceLogId, eventsReplayed: 0};
+        }
+
+        const delta  = storage.getDeltaLog(sinceLogId);
+        const events = [];
+
+        // Trigger evaluation walks the delta entities. SENT_TO_ME / PERMISSION_GRANTED
+        // examine edges; TASK_STATE_CHANGED examines nodes (the Task envelope payload).
+        // Filter spec is applied to the matched candidate's payload; non-matches are skipped.
+        for (const edgeRef of delta.invalidEdges) {
+            const matched = this._evaluateEdgeAgainstSubscription(edgeRef, subscription);
+            if (matched) events.push(matched);
+        }
+        for (const nodeId of delta.invalidNodes) {
+            const matched = this._evaluateNodeAgainstSubscription(nodeId, subscription);
+            if (matched) events.push(matched);
+        }
+
+        return {
+            subscriptionId,
+            events,
+            lastLogId     : delta.lastLogId,
+            eventsReplayed: events.length
+        };
+    }
+
+    /**
+     * Evaluates a GraphLog edge entry against a subscription's trigger+filter spec.
+     * Returns the wake-event payload if matched, null otherwise.
+     * @protected
+     */
+    _evaluateEdgeAgainstSubscription(edgeRef, subscription) {
+        const db   = GraphService.db;
+        const edge = db.edges.get(edgeRef.id);
+        if (!edge) return null;
+
+        const owner = subscription.agentIdentity;
+
+        if (subscription.trigger === 'SENT_TO_ME' && edge.type === 'SENT_TO' && edge.target === owner) {
+            const messageNode = db.nodes.get(edge.source);
+            if (!messageNode) return null;
+            const payload = this._buildSentToMePayload(messageNode);
+            if (!this._matchesFilters(payload, subscription.filters)) return null;
+            return this._wrapEvent('wake/sent_to_me', subscription, payload, edgeRef.id);
+        }
+
+        if (subscription.trigger === 'PERMISSION_GRANTED'
+            && ['CAN_REPLY_TO', 'CAN_READ_INBOX_OF', 'CAN_READ_MEMORIES_OF'].includes(edge.type)
+            && edge.target === owner) {
+            const payload = {
+                scope     : edge.type,
+                grantedBy : edge.source,
+                grantedAt : new Date().toISOString()
+            };
+            return this._wrapEvent('wake/permission_granted', subscription, payload, edgeRef.id);
+        }
+
+        return null;
+    }
+
+    /**
+     * Evaluates a GraphLog node entry against TASK_STATE_CHANGED triggers.
+     * Returns the wake-event payload if matched, null otherwise.
+     * @protected
+     */
+    _evaluateNodeAgainstSubscription(nodeId, subscription) {
+        if (subscription.trigger !== 'TASK_STATE_CHANGED') return null;
+
+        const node = GraphService.db.nodes.get(nodeId);
+        if (!node || node.label !== 'MESSAGE') return null;
+
+        const props = node.properties || {};
+        const task  = props.task;
+        if (!task || !task.state) return null;
+
+        const owner = subscription.agentIdentity;
+        if (props.from !== owner && task.assignee !== owner) return null;
+
+        const payload = {
+            taskId        : nodeId,
+            previousState : null,                          // Not retained in node properties; resync semantics return current state only.
+            newState      : task.state,
+            originator    : props.from,
+            assignee      : task.assignee,
+            lastModifiedAt: props.updatedAt || props.sentAt
+        };
+        return this._wrapEvent('wake/task_state_changed', subscription, payload, nodeId);
+    }
+
+    /**
+     * Builds the wake/sent_to_me payload from a MESSAGE node.
+     * @protected
+     */
+    _buildSentToMePayload(messageNode) {
+        const props = messageNode.properties || {};
+        return {
+            messageId     : messageNode.id,
+            from          : props.from,
+            subject       : (props.subject || '').slice(0, 200),
+            priority      : props.priority || 'normal',
+            taggedConcepts: props.taggedConcepts || [],
+            isReplyTo     : props.inReplyTo || null,
+            isBroadcast   : props.to === 'AGENT:*'
+        };
+    }
+
+    /**
+     * Wraps a payload in the standard wake notification envelope per ADR 0002 §6.1.1-§6.1.3.
+     * @protected
+     */
+    _wrapEvent(eventType, subscription, payload, logIdAnchor) {
+        return {
+            schemaVersion : '1.0',
+            eventType,
+            eventId       : `01H${crypto.randomBytes(10).toString('hex').toUpperCase()}`,
+            logId         : logIdAnchor,
+            agentIdentity : subscription.agentIdentity,
+            subscriptionId: subscription.id,
+            payload,
+            emittedAt     : new Date().toISOString()
+        };
+    }
+
+    /**
+     * Applies optional filter spec (taggedConcepts, priority, senderFilter, inReplyToFilter)
+     * to a sent_to_me payload. Returns true if all configured filters pass.
+     * @protected
+     */
+    _matchesFilters(payload, filters = {}) {
+        if (filters.priority && payload.priority !== filters.priority) return false;
+
+        if (Array.isArray(filters.senderFilter) && filters.senderFilter.length > 0
+            && !filters.senderFilter.includes(payload.from)) return false;
+
+        if (Array.isArray(filters.inReplyToFilter) && filters.inReplyToFilter.length > 0
+            && !filters.inReplyToFilter.includes(payload.isReplyTo)) return false;
+
+        if (Array.isArray(filters.taggedConcepts) && filters.taggedConcepts.length > 0) {
+            const hasMatch = (payload.taggedConcepts || []).some(c => filters.taggedConcepts.includes(c));
+            if (!hasMatch) return false;
+        }
+
+        return true;
+    }
+
+    /**
+     * Loads a subscription by id, preferring the in-memory cache and falling back to
+     * SQLite. Cache-warms on miss.
+     * @protected
+     */
+    _loadSubscription(subscriptionId) {
+        if (this.subscriptionCache.has(subscriptionId)) return this.subscriptionCache.get(subscriptionId);
+
+        const node = GraphService.db.nodes.get(subscriptionId);
+        if (!node || node.label !== 'WAKE_SUBSCRIPTION') return null;
+
+        const entry = {id: node.id, ...(node.properties || {})};
+        this.subscriptionCache.set(subscriptionId, entry);
+        return entry;
+    }
+}
+
+export default Neo.setupClass(WakeSubscriptionService);

--- a/ai/mcp/server/memory-core/services/toolService.mjs
+++ b/ai/mcp/server/memory-core/services/toolService.mjs
@@ -10,6 +10,7 @@ import SessionService           from './SessionService.mjs';
 import SummaryService           from './SummaryService.mjs';
 import MailboxService           from './MailboxService.mjs';
 import PermissionService        from './PermissionService.mjs';
+import WakeSubscriptionService  from './WakeSubscriptionService.mjs';
 
 const __filename      = fileURLToPath(import.meta.url);
 const __dirname       = path.dirname(__filename);
@@ -40,6 +41,7 @@ const serviceMapping = {
     grant_permission      : PermissionService       .grantPermission     .bind(PermissionService),
     revoke_permission     : PermissionService       .revokePermission    .bind(PermissionService),
     list_permissions      : PermissionService       .listPermissions     .bind(PermissionService),
+    manage_wake_subscription: WakeSubscriptionService.manage              .bind(WakeSubscriptionService),
     set_session_id        : SessionService          .setSessionId        .bind(SessionService)
 };
 

--- a/test/playwright/unit/ai/mcp/server/memory-core/services/WakeSubscriptionService.spec.mjs
+++ b/test/playwright/unit/ai/mcp/server/memory-core/services/WakeSubscriptionService.spec.mjs
@@ -1,0 +1,352 @@
+import {setup} from '../../../../../../setup.mjs';
+
+const appName = 'WakeSubscriptionServiceTest';
+
+setup({
+    neoConfig: {
+        unitTestMode: true
+    },
+    appConfig: {
+        name             : appName,
+        isMounted        : () => true,
+        vnodeInitialising: false
+    }
+});
+
+import {test, expect}        from '@playwright/test';
+import fs                    from 'fs-extra';
+import path                  from 'path';
+import Neo                   from '../../../../../../../../src/Neo.mjs';
+import RequestContextService from '../../../../../../../../ai/mcp/server/shared/services/RequestContextService.mjs';
+
+test.describe('Neo.ai.mcp.server.memory-core.services.WakeSubscriptionService', () => {
+    test.describe.configure({mode: 'serial'});
+    let WakeSubscriptionService, GraphService, LifecycleService, originalAutoSave;
+    let dbPath;
+
+    test.beforeAll(async () => {
+        const tmpDir = path.resolve(process.cwd(), 'tmp');
+        if (!fs.existsSync(tmpDir)) {
+            fs.mkdirSync(tmpDir, {recursive: true});
+        }
+        dbPath = path.join(tmpDir, `neo-wake-subscription-test-${Date.now()}-${Math.random().toString(36).substring(7)}.db`);
+
+        GraphService            = (await import('../../../../../../../../ai/mcp/server/memory-core/services/GraphService.mjs')).default;
+        WakeSubscriptionService = (await import('../../../../../../../../ai/mcp/server/memory-core/services/WakeSubscriptionService.mjs')).default;
+        LifecycleService        = (await import('../../../../../../../../ai/mcp/server/memory-core/services/lifecycle/SystemLifecycleService.mjs')).default;
+
+        const aiConfig = (await import('../../../../../../../../ai/mcp/server/memory-core/config.mjs')).default;
+        aiConfig.storagePaths.graph = dbPath;
+
+        if (!LifecycleService._initPromise) {
+            await LifecycleService.initAsync();
+        } else {
+            await LifecycleService.ready();
+        }
+
+        originalAutoSave         = GraphService.db.autoSave;
+        GraphService.db.autoSave = true;
+    });
+
+    test.afterAll(async () => {
+        GraphService.db.autoSave = originalAutoSave;
+        if (fs.existsSync(dbPath)) {
+            try { fs.unlinkSync(dbPath); }            catch (e) {}
+            try { fs.unlinkSync(dbPath + '-wal'); }   catch (e) {}
+            try { fs.unlinkSync(dbPath + '-shm'); }   catch (e) {}
+        }
+    });
+
+    test.beforeEach(async () => {
+        if (GraphService.db) {
+            GraphService.db.nodes.clear();
+            GraphService.db.edges.clear();
+            GraphService.db.vicinityLoadedNodes.clear();
+
+            if (GraphService.db.storage?.db) {
+                await GraphService.db.storage.clear();
+                GraphService.db.storage.db.exec('DELETE FROM GraphLog');
+            }
+        }
+
+        // Symmetric afterEach via beforeEach idempotence: also clear the in-memory cache
+        // (per `feedback_symmetric_spec_cleanup.md` — Playwright fullyParallel can interleave
+        // sibling specs in the same worker, so cross-singleton state must be reset).
+        WakeSubscriptionService.subscriptionCache.clear();
+
+        GraphService.upsertNode({id: '@alice', type: 'AGENT', name: 'Alice', properties: {}});
+        GraphService.upsertNode({id: '@bob',   type: 'AGENT', name: 'Bob',   properties: {}});
+    });
+
+    test.afterEach(async () => {
+        WakeSubscriptionService.subscriptionCache.clear();
+    });
+
+    // -----------------------------------------------------------------------------
+    // subscribe
+    // -----------------------------------------------------------------------------
+
+    test('subscribe creates a WAKE_SUBSCRIPTION node + SUBSCRIBES_TO edge for the caller', async () => {
+        await RequestContextService.run({agentIdentityNodeId: '@alice'}, async () => {
+            const res = await WakeSubscriptionService.subscribe({
+                trigger      : 'SENT_TO_ME',
+                harnessTarget: 'mcp-notifications'
+            });
+
+            expect(res.subscriptionId).toMatch(/^WAKE_SUB:[0-9a-f-]{36}$/);
+            expect(res.harnessTarget).toBe('mcp-notifications');
+            expect(res.signingKey).toBeUndefined(); // Only Shape B gets one
+
+            const node = GraphService.db.nodes.get(res.subscriptionId);
+            expect(node).toBeDefined();
+            expect(node.label).toBe('WAKE_SUBSCRIPTION');
+            expect(node.properties.agentIdentity).toBe('@alice');
+            expect(node.properties.trigger).toBe('SENT_TO_ME');
+            expect(node.properties.harnessTarget).toBe('mcp-notifications');
+            expect(node.properties.status).toBe('active');
+
+            const edges = GraphService.db.edges.items.filter(e => e.type === 'SUBSCRIBES_TO');
+            expect(edges.length).toBe(1);
+            expect(edges[0].source).toBe('@alice');
+            expect(edges[0].target).toBe(res.subscriptionId);
+
+            expect(WakeSubscriptionService.subscriptionCache.has(res.subscriptionId)).toBe(true);
+        });
+    });
+
+    test('subscribe with a2a-webhook generates an HMAC signing key', async () => {
+        await RequestContextService.run({agentIdentityNodeId: '@alice'}, async () => {
+            const res = await WakeSubscriptionService.subscribe({
+                trigger              : 'TASK_STATE_CHANGED',
+                harnessTarget        : 'a2a-webhook',
+                harnessTargetMetadata: {url: 'https://example.com/wake'}
+            });
+
+            expect(res.signingKey).toMatch(/^[0-9a-f]{64}$/); // 32 bytes hex
+
+            const node = GraphService.db.nodes.get(res.subscriptionId);
+            expect(node.properties.harnessTargetMetadata.signingKey).toBe(res.signingKey);
+            expect(node.properties.harnessTargetMetadata.url).toBe('https://example.com/wake');
+        });
+    });
+
+    test('subscribe with a2a-webhook but no url throws', async () => {
+        await RequestContextService.run({agentIdentityNodeId: '@alice'}, async () => {
+            await expect(WakeSubscriptionService.subscribe({
+                trigger      : 'SENT_TO_ME',
+                harnessTarget: 'a2a-webhook'
+            })).rejects.toThrow('Shape B (a2a-webhook) requires harnessTargetMetadata.url');
+        });
+    });
+
+    test('subscribe rejects invalid trigger', async () => {
+        await RequestContextService.run({agentIdentityNodeId: '@alice'}, async () => {
+            await expect(WakeSubscriptionService.subscribe({
+                trigger      : 'INVALID',
+                harnessTarget: 'mcp-notifications'
+            })).rejects.toThrow("Invalid trigger 'INVALID'");
+        });
+    });
+
+    test('subscribe rejects invalid harnessTarget', async () => {
+        await RequestContextService.run({agentIdentityNodeId: '@alice'}, async () => {
+            await expect(WakeSubscriptionService.subscribe({
+                trigger      : 'SENT_TO_ME',
+                harnessTarget: 'invalid-target'
+            })).rejects.toThrow("Invalid harnessTarget 'invalid-target'");
+        });
+    });
+
+    test('subscribe throws without an agent identity context', async () => {
+        await expect(WakeSubscriptionService.subscribe({
+            trigger      : 'SENT_TO_ME',
+            harnessTarget: 'mcp-notifications'
+        })).rejects.toThrow('no agent identity context bound');
+    });
+
+    // -----------------------------------------------------------------------------
+    // unsubscribe
+    // -----------------------------------------------------------------------------
+
+    test('unsubscribe removes the WAKE_SUBSCRIPTION node + SUBSCRIBES_TO edge', async () => {
+        let subscriptionId;
+        await RequestContextService.run({agentIdentityNodeId: '@alice'}, async () => {
+            const res = await WakeSubscriptionService.subscribe({
+                trigger      : 'SENT_TO_ME',
+                harnessTarget: 'mcp-notifications'
+            });
+            subscriptionId = res.subscriptionId;
+
+            const removeRes = await WakeSubscriptionService.unsubscribe({subscriptionId});
+            expect(removeRes.status).toBe('removed');
+
+            expect(GraphService.db.nodes.get(subscriptionId)).toBeUndefined();
+            expect(GraphService.db.edges.items.filter(e => e.target === subscriptionId).length).toBe(0);
+            expect(WakeSubscriptionService.subscriptionCache.has(subscriptionId)).toBe(false);
+        });
+    });
+
+    test('unsubscribe denies cross-owner access', async () => {
+        let subscriptionId;
+        await RequestContextService.run({agentIdentityNodeId: '@alice'}, async () => {
+            ({subscriptionId} = await WakeSubscriptionService.subscribe({
+                trigger      : 'SENT_TO_ME',
+                harnessTarget: 'mcp-notifications'
+            }));
+        });
+
+        await RequestContextService.run({agentIdentityNodeId: '@bob'}, async () => {
+            await expect(WakeSubscriptionService.unsubscribe({subscriptionId}))
+                .rejects.toThrow('Permission denied');
+        });
+
+        // Subscription still exists
+        expect(GraphService.db.nodes.get(subscriptionId)).toBeDefined();
+    });
+
+    // -----------------------------------------------------------------------------
+    // update
+    // -----------------------------------------------------------------------------
+
+    test('update mutates filters + harnessTargetMetadata, preserves agentIdentity', async () => {
+        await RequestContextService.run({agentIdentityNodeId: '@alice'}, async () => {
+            const {subscriptionId} = await WakeSubscriptionService.subscribe({
+                trigger              : 'SENT_TO_ME',
+                harnessTarget        : 'mcp-notifications',
+                harnessTargetMetadata: {coalesceWindow: 30}
+            });
+
+            const updateRes = await WakeSubscriptionService.update({
+                subscriptionId,
+                filters              : {priority: 'high', taggedConcepts: ['critical']},
+                harnessTargetMetadata: {coalesceWindow: 60}
+            });
+
+            expect(updateRes.currentState.filters.priority).toBe('high');
+            expect(updateRes.currentState.filters.taggedConcepts).toEqual(['critical']);
+            expect(updateRes.currentState.harnessTargetMetadata.coalesceWindow).toBe(60);
+            expect(updateRes.currentState.agentIdentity).toBe('@alice');
+
+            const node = GraphService.db.nodes.get(subscriptionId);
+            expect(node.properties.filters.priority).toBe('high');
+            expect(node.properties.harnessTargetMetadata.coalesceWindow).toBe(60);
+        });
+    });
+
+    test('update denies cross-owner access', async () => {
+        let subscriptionId;
+        await RequestContextService.run({agentIdentityNodeId: '@alice'}, async () => {
+            ({subscriptionId} = await WakeSubscriptionService.subscribe({
+                trigger      : 'SENT_TO_ME',
+                harnessTarget: 'mcp-notifications'
+            }));
+        });
+
+        await RequestContextService.run({agentIdentityNodeId: '@bob'}, async () => {
+            await expect(WakeSubscriptionService.update({
+                subscriptionId,
+                filters: {priority: 'high'}
+            })).rejects.toThrow('Permission denied');
+        });
+    });
+
+    // -----------------------------------------------------------------------------
+    // list
+    // -----------------------------------------------------------------------------
+
+    test('list returns only the caller-owned subscriptions', async () => {
+        await RequestContextService.run({agentIdentityNodeId: '@alice'}, async () => {
+            await WakeSubscriptionService.subscribe({trigger: 'SENT_TO_ME',         harnessTarget: 'mcp-notifications'});
+            await WakeSubscriptionService.subscribe({trigger: 'TASK_STATE_CHANGED', harnessTarget: 'disabled'});
+        });
+        await RequestContextService.run({agentIdentityNodeId: '@bob'}, async () => {
+            await WakeSubscriptionService.subscribe({trigger: 'SENT_TO_ME', harnessTarget: 'mcp-notifications'});
+        });
+
+        await RequestContextService.run({agentIdentityNodeId: '@alice'}, async () => {
+            const res = await WakeSubscriptionService.list();
+            expect(res.subscriptions.length).toBe(2);
+            for (const sub of res.subscriptions) {
+                expect(sub.agentIdentity).toBe('@alice');
+            }
+        });
+
+        await RequestContextService.run({agentIdentityNodeId: '@bob'}, async () => {
+            const res = await WakeSubscriptionService.list();
+            expect(res.subscriptions.length).toBe(1);
+            expect(res.subscriptions[0].agentIdentity).toBe('@bob');
+        });
+    });
+
+    test('list with subscriptionId returns single subscription if owned, empty otherwise', async () => {
+        let aliceSubId;
+        await RequestContextService.run({agentIdentityNodeId: '@alice'}, async () => {
+            ({subscriptionId: aliceSubId} = await WakeSubscriptionService.subscribe({
+                trigger      : 'SENT_TO_ME',
+                harnessTarget: 'mcp-notifications'
+            }));
+        });
+
+        await RequestContextService.run({agentIdentityNodeId: '@alice'}, async () => {
+            const res = await WakeSubscriptionService.list({subscriptionId: aliceSubId});
+            expect(res.subscriptions.length).toBe(1);
+            expect(res.subscriptions[0].id).toBe(aliceSubId);
+        });
+
+        await RequestContextService.run({agentIdentityNodeId: '@bob'}, async () => {
+            const res = await WakeSubscriptionService.list({subscriptionId: aliceSubId});
+            expect(res.subscriptions.length).toBe(0);
+        });
+    });
+
+    // -----------------------------------------------------------------------------
+    // manage dispatcher
+    // -----------------------------------------------------------------------------
+
+    test('manage dispatches to the correct action handler', async () => {
+        await RequestContextService.run({agentIdentityNodeId: '@alice'}, async () => {
+            const res = await WakeSubscriptionService.manage({
+                action       : 'subscribe',
+                trigger      : 'SENT_TO_ME',
+                harnessTarget: 'disabled'
+            });
+            expect(res.subscriptionId).toMatch(/^WAKE_SUB:/);
+
+            const listRes = await WakeSubscriptionService.manage({action: 'list'});
+            expect(listRes.subscriptions.length).toBe(1);
+
+            const removeRes = await WakeSubscriptionService.manage({action: 'unsubscribe', subscriptionId: res.subscriptionId});
+            expect(removeRes.status).toBe('removed');
+        });
+    });
+
+    test('manage rejects invalid action', async () => {
+        await RequestContextService.run({agentIdentityNodeId: '@alice'}, async () => {
+            await expect(WakeSubscriptionService.manage({action: 'nonexistent'}))
+                .rejects.toThrow("Invalid action 'nonexistent'");
+        });
+    });
+
+    // -----------------------------------------------------------------------------
+    // resync (basic structural — full GraphLog-replay correctness deferred to Shape A/B/C subs)
+    // -----------------------------------------------------------------------------
+
+    test('resync returns empty events when GraphLog has no matching deltas after sinceLogId', async () => {
+        await RequestContextService.run({agentIdentityNodeId: '@alice'}, async () => {
+            const {subscriptionId} = await WakeSubscriptionService.subscribe({
+                trigger      : 'SENT_TO_ME',
+                harnessTarget: 'mcp-notifications'
+            });
+
+            // Use a very high sinceLogId so no entries match
+            const res = await WakeSubscriptionService.resync({
+                subscriptionId,
+                sinceLogId: 999999
+            });
+
+            expect(res.subscriptionId).toBe(subscriptionId);
+            expect(res.events).toEqual([]);
+            expect(res.eventsReplayed).toBe(0);
+        });
+    });
+});


### PR DESCRIPTION
Authored by Claude Opus 4.7 (Claude Code). Session aaf22f06-cc5c-4dff-aa2f-7d5efb3a6343.

## Summary

Foundational implementation for the Phase 3 cross-harness autonomous wake substrate (Epic #10357). Lands the graph-resident `WAKE_SUBSCRIPTION` node + `manage_wake_subscription` MCP tool — the primitive that Shape A (#10358), Shape B (#10359), and Shape C (#10360) consumers will subscribe to. Per ADR 0002 §6.6.

**Resolves #10361.**

## Why this exists now

Epic #10357 was reviewed and greenlit this session ([epic-review comment](https://github.com/neomjs/neo/issues/10357#issuecomment-4322315396)). Coordination with @neo-gemini-3-1-pro split the work: Claude takes the foundation (#10361 + #10362) + Shape A (#10358); Gemini takes Shape B/C (#10359/#10360) + Heartbeat-Bypass (#10363). #10361 + #10362 land first; everything else depends on the schema + tool surface this PR provides.

## Changes (4 files, +892 lines)

### 1. `ai/mcp/server/memory-core/services/WakeSubscriptionService.mjs` (NEW, 462 lines)

Singleton service implementing the 5 subscription lifecycle actions per ADR §6.6.2:

| Action | Purpose | Returns |
|---|---|---|
| `subscribe` | Create graph node + SUBSCRIBES_TO edge + cache write-through; for Shape B, generates 32-byte HMAC signing key | `{subscriptionId, harnessTarget, signingKey?}` |
| `unsubscribe` | Remove node/edge + cache evict; cross-owner access denied | `{subscriptionId, status: 'removed'}` |
| `update` | Mutate `filters` / `harnessTarget` / `harnessTargetMetadata`; `agentIdentity` and `createdAt` immutable | `{subscriptionId, currentState}` |
| `list` | Return caller-owned subscriptions; full SQLite scan with cache-warm side effect | `{subscriptions: [...]}` |
| `resync` | Query `GraphLog` from `sinceLogId`, evaluate trigger+filter spec, return matching events as data | `{subscriptionId, events, lastLogId, eventsReplayed}` |

**Key implementation choices:**
- **Write-through in-memory cache** (`subscriptionCache: Map<id, entry>`) for sub-millisecond trigger evaluation, with SQLite as durable source of truth (per ADR §6.6.2 + the `vicinityLoadedNodes` pattern from `Database.mjs`).
- **Per-owner RBAC** via `RequestContextService.getAgentIdentityNodeId()` — agents can only manage their own subscriptions; cross-owner access throws permission-denied.
- **Resync separation of concerns** — this PR's `resync` returns the matching event payloads as data; channel-specific re-emission (MCP notification / webhook POST / daemon dispatch) is wired by Shape A/B/C consumers in #10358/#10359/#10360. Clean boundary; no premature coupling.
- **HMAC signing key** for Shape B generated server-side via `crypto.randomBytes(32).toString('hex')`, stored in `harnessTargetMetadata.signingKey` and returned once at subscribe-time. Pre-#9999 multi-tenant transition uses plaintext-at-rest in per-tenant SQLite; envelope encryption follows the broader #9999 work.

### 2. `ai/mcp/server/memory-core/openapi.yaml` (+76 lines)

New `/wake-subscriptions/manage` POST endpoint registering the `manage_wake_subscription` tool. Single unified surface with `action` enum dispatch (mirrors `manage_issue_assignees` / `manage_issue_labels` pattern). Description budget compliant per `pr-review-guide §5.3` — single-line action enums, no internal cross-refs in the YAML payload (architectural narrative lives in service JSDoc + this PR body).

### 3. `ai/mcp/server/memory-core/services/toolService.mjs` (+2 lines)

Imports `WakeSubscriptionService` and registers the `manage_wake_subscription` mapping in `serviceMapping`.

### 4. `test/playwright/unit/ai/mcp/server/memory-core/services/WakeSubscriptionService.spec.mjs` (NEW, 352 lines)

15 tests mirroring `PermissionService.spec.mjs` structure:

- **subscribe**: node + edge creation, cache populated, HMAC key for Shape B, validation rejections, identity-context requirement
- **unsubscribe**: node/edge removal + cache evict, cross-owner permission denial
- **update**: properties mutation + cache write-through, agentIdentity immutability, cross-owner denial
- **list**: caller-scoped enumeration, single-subscription lookup with cross-owner returns-empty
- **manage** dispatcher: action routing + invalid-action rejection
- **resync**: structural test on empty-delta path (full GraphLog-replay correctness deferred to Shape A/B/C subs which exercise the channel-specific re-emit hook)

Symmetric `beforeEach` + `afterEach` cache cleanup per [`feedback_symmetric_spec_cleanup.md`](file:///Users/tobiasuhlig/.claude/projects/-Users-Shared-github-neomjs-neo/memory/feedback_symmetric_spec_cleanup.md) — Playwright fullyParallel can interleave sibling specs in the same worker; cross-singleton state must be reset symmetrically.

## Acceptance Criteria — verification

- [x] `WAKE_SUBSCRIPTION` graph-resident node schema defined with all properties per ADR §6.6.1 (`id, agentIdentity, trigger, filters, harnessTarget, harnessTargetMetadata, createdAt, updatedAt, userId, sharedEntity, status`)
- [x] `manage_wake_subscription` MCP tool surface implemented with all 5 actions (`subscribe / unsubscribe / update / list / resync`)
- [x] Subscription capability detection routes correctly to `harnessTarget` (validated against `validHarnessTargets` enum: `mcp-notifications | a2a-webhook | bridge-daemon | disabled | none`)
- [x] Built against contract defined in [ADR 0002 §6.6](https://github.com/neomjs/neo/blob/dev/learn/agentos/decisions/0002-phase3-wake-substrate-standards-alignment.md)

## Out of Scope (per Epic #10357 work-split + ADR §6.6.3 deferrals)

- **Channel-specific event delivery (Shape A/B/C transports)** — covered by #10358 / #10359 / #10360. This PR provides the `resync` action's GraphLog query + payload construction; channel dispatch is consumer responsibility.
- **Boot-time MCP capability negotiation** (`experimental.neo-wake-substrate` declaration at `initialize`) — covered by Shape A sub #10358 per Stage 3 Flag 2 from epic-review.
- **Coalescing engine / token-economy throttle** (#10362) — separate foundational sub I'm taking next; this PR's subscribe/update accept `harnessTargetMetadata.coalesceWindow` as a stored override but the engine itself lives in #10362.
- **Multi-agent shared subscriptions** (e.g., team-level wake) — deferred per Discussion #10354 OQ 3 out-of-scope; would require a `CAN_MANAGE_SUBSCRIPTIONS_OF` permission scope.
- **Webhook signing-key rotation API** — Shape B can rotate via `manage_wake_subscription({action: 'update', harnessTargetMetadata: {signingKey: <new>}})` but a dedicated `rotate-key` action is deferred to a follow-up if usage warrants.

## Provenance

**Internal Origin** — implements ADR 0002 §6.6 which I authored in prior sessions `48197e2e-3e95-47eb-9eb8-bbb032948845` → `52e84f76-2d4f-41cc-a42e-9d1d3fcaa381`. Discussion #10354 cross-family iteration with @neo-gemini-3-1-pro (sessions `b9be53b7-e7b6-4613-8bbf-48b8e88623a9`) shaped the OQ 2 trigger primitives and OQ 3 graph-resident subscription state. No external framework borrowing.

## Branch naming note

Branch is `agent/10361-claude-foundation` rather than `agent/10361-wake-subscription-schema-tool` — the latter name was already locked by another worktree at the time I tried to create it. Functionally equivalent; commit content is what matters.

## Related

- **Parent Epic:** #10357 (Phase 3 Cross-harness autonomous wake substrate)
- **ADR:** [0002](https://github.com/neomjs/neo/blob/dev/learn/agentos/decisions/0002-phase3-wake-substrate-standards-alignment.md)
- **Predecessor (substrate prereq):** #10334, #10342, #10353 (all merged)
- **Successors (consume this surface):** #10358 (Shape A) blocked_by THIS, #10359 (Shape B) blocked_by THIS, #10360 (Shape C) blocked_by THIS, #10362 (coalescer) sibling foundation, #10363 (heartbeat-bypass) blocked_by THIS

## Test plan

- [ ] CI: Playwright unit suite runs `WakeSubscriptionService.spec.mjs` (15 tests)
- [ ] Manual: invoke `manage_wake_subscription({action:'subscribe',trigger:'SENT_TO_ME',harnessTarget:'disabled'})` via MCP client; verify node+edge in SQLite via `gh issue view --json` style query
- [ ] Cross-family review by @neo-gemini-3-1-pro — particularly on the `resync` channel-emit boundary (does the data-only return match Shape A/B/C consumer expectations? Worth a sanity-check while she's mid-flight on those subs)

Origin Session ID: aaf22f06-cc5c-4dff-aa2f-7d5efb3a6343