### PR TITLE
feat(ai): coalescing engine for wake-event throttle (#10362)

### DIFF
--- a/ai/mcp/server/memory-core/services/CoalescingEngineService.mjs
+++ b/ai/mcp/server/memory-core/services/CoalescingEngineService.mjs
@@ -1,0 +1,278 @@
+import crypto                  from 'crypto';
+import Base                    from '../../../../../src/core/Base.mjs';
+import WebhookDeliveryService  from './WebhookDeliveryService.mjs';
+import logger                  from '../logger.mjs';
+
+/**
+ * @summary Token-economy throttle / coalescing engine for the Phase 3 cross-harness
+ * autonomous wake substrate (ADR 0002 §6.4).
+ *
+ * Wake events MUST NOT be 1:1 with the underlying event stream at high velocity. This
+ * engine batches per-subscription events within a configurable window (default 30s,
+ * overridable per subscription via `harnessTargetMetadata.coalesceWindow`, clamped 0-300s)
+ * and emits a single **digest** payload at window-flush time. Without this throttle,
+ * broadcast bursts and Task state transition flurries cause catastrophic token burn
+ * and session thrashing.
+ *
+ * **Layering:** consumers call `enqueue(subscription, event)` when an event matches a
+ * subscription's trigger+filter spec. The engine maintains a per-subscription timer; at
+ * timer fire, it builds a structured digest payload and dispatches to the channel
+ * appropriate for `subscription.harnessTarget`:
+ * - `mcp-notifications` → Shape A's MCP notification emit-point (wired by #10358)
+ * - `a2a-webhook` → `WebhookDeliveryService.deliver` (Shape B, already wired)
+ * - `bridge-daemon` → no-op (Shape C handles its own coalescing in-process per ADR §6.3)
+ * - `disabled` / `none` → no-op (subscription opted out of push)
+ *
+ * Bridge daemon (Shape C) maintains a parallel coalescer in `ai/scripts/bridge-daemon.mjs`
+ * because it runs out-of-process; this engine handles the in-process Shape A + Shape B
+ * routing only.
+ *
+ * @class Neo.ai.mcp.server.memory-core.services.CoalescingEngineService
+ * @extends Neo.core.Base
+ * @singleton
+ * @see learn/agentos/decisions/0002-phase3-wake-substrate-standards-alignment.md §6.4
+ * @see #10357 (parent Epic) #10362 (this sub) #10358 (Shape A consumer)
+ */
+class CoalescingEngineService extends Base {
+    static config = {
+        /**
+         * @member {String} className='Neo.ai.mcp.server.memory-core.services.CoalescingEngineService'
+         * @protected
+         */
+        className: 'Neo.ai.mcp.server.memory-core.services.CoalescingEngineService',
+        /**
+         * @member {Boolean} singleton=true
+         * @protected
+         */
+        singleton: true
+    }
+
+    /**
+     * @member {Number} defaultWindowSeconds=30
+     * @protected
+     * @summary Default coalescing window per ADR 0002 §6.4.1. Overridable per subscription
+     * via `harnessTargetMetadata.coalesceWindow`. Clamped to [0, 300] at enqueue time.
+     */
+    defaultWindowSeconds = 30
+
+    /**
+     * @member {Number} maxWindowSeconds=300
+     * @protected
+     * @summary Hard upper bound on coalescing window (5 minutes). Beyond this, events
+     * are stale enough that the agent's response would be on already-superseded state.
+     */
+    maxWindowSeconds = 300
+
+    /**
+     * Per-subscription queue + timer state.
+     * Structure: `Map<subscriptionId, {queue: Object[], timer: ?TimerId, subscription: Object, windowStart: ?Date}>`
+     * Populated lazily on first enqueue; cleared on flush.
+     * @member {Map<String, Object>} coalesceState
+     * @protected
+     */
+    coalesceState = new Map()
+
+    /**
+     * Enqueue an event for coalesced delivery to a subscription. Starts (or extends)
+     * the per-subscription timer; on fire, the engine builds a digest and dispatches.
+     *
+     * @param {Object} subscription Cached WAKE_SUBSCRIPTION entry (must include `id`,
+     *   `agentIdentity`, `harnessTarget`, `harnessTargetMetadata`)
+     * @param {Object} event Trigger-matched event envelope (must include `eventType`,
+     *   `payload`, `logId`, `eventId`)
+     * @returns {void}
+     */
+    enqueue(subscription, event) {
+        const subId = subscription.id;
+        if (!subId) {
+            logger.warn('[CoalescingEngine] enqueue called with subscription missing id; dropping event.');
+            return;
+        }
+
+        let state = this.coalesceState.get(subId);
+        if (!state) {
+            state = {queue: [], timer: null, subscription, windowStart: null};
+            this.coalesceState.set(subId, state);
+        } else {
+            state.subscription = subscription;
+        }
+
+        state.queue.push(event);
+        if (!state.windowStart) state.windowStart = new Date();
+
+        if (state.timer) return;
+
+        const windowMs = this._resolveWindowMs(subscription);
+        if (windowMs === 0) {
+            this._flush(subId);
+            return;
+        }
+
+        state.timer = setTimeout(() => this._flush(subId), windowMs);
+    }
+
+    /**
+     * Force-flush all subscriptions immediately. Used for graceful shutdown + tests.
+     * @returns {Promise<void>}
+     */
+    async flushAll() {
+        const ids = Array.from(this.coalesceState.keys());
+        await Promise.all(ids.map(id => this._flush(id)));
+    }
+
+    /**
+     * Clear all per-subscription state without dispatching. Used for tests.
+     * @returns {void}
+     */
+    clearAll() {
+        for (const state of this.coalesceState.values()) {
+            if (state.timer) clearTimeout(state.timer);
+        }
+        this.coalesceState.clear();
+    }
+
+    /**
+     * Resolves the effective coalescing window in milliseconds for a subscription.
+     * Reads `harnessTargetMetadata.coalesceWindow` (seconds), falls back to default,
+     * clamps to [0, maxWindowSeconds].
+     *
+     * @protected
+     * @param {Object} subscription
+     * @returns {Number} window in milliseconds (0 = immediate-flush)
+     */
+    _resolveWindowMs(subscription) {
+        const meta     = subscription.harnessTargetMetadata || {};
+        const override = meta.coalesceWindow;
+        let seconds    = (override === undefined || override === null) ? this.defaultWindowSeconds : override;
+        seconds        = Math.max(0, Math.min(this.maxWindowSeconds, Number(seconds) || 0));
+        return seconds * 1000;
+    }
+
+    /**
+     * Timer-fire callback: build digest envelope from queued events, dispatch via the
+     * subscription's `harnessTarget` routing, clear state.
+     *
+     * @protected
+     * @param {String} subscriptionId
+     * @returns {Promise<void>}
+     */
+    async _flush(subscriptionId) {
+        const state = this.coalesceState.get(subscriptionId);
+        if (!state || state.queue.length === 0) {
+            this.coalesceState.delete(subscriptionId);
+            return;
+        }
+
+        const {queue, subscription, windowStart} = state;
+        if (state.timer) {
+            clearTimeout(state.timer);
+            state.timer = null;
+        }
+        this.coalesceState.delete(subscriptionId);
+
+        const digest = this._buildDigestEnvelope(subscription, queue, windowStart);
+        await this._dispatchDigest(subscription, digest);
+    }
+
+    /**
+     * Builds the digest envelope per ADR §6.4.2. The structured payload reports counts
+     * per trigger type plus the latest-of-each for context. Wraps in the standard
+     * notification envelope (schemaVersion / eventType=`wake/digest` / eventId / etc.)
+     * so Shape A and Shape B consumers can dispatch with the same shape they expect for
+     * single events.
+     *
+     * @protected
+     * @param {Object} subscription
+     * @param {Object[]} events Queued event envelopes
+     * @param {Date} windowStart When the first event in this window was enqueued
+     * @returns {Object} Digest envelope
+     */
+    _buildDigestEnvelope(subscription, events, windowStart) {
+        const breakdown = {
+            sent_to_me        : {count: 0, latest: null},
+            task_state_changed: {count: 0, latest: null},
+            permission_granted: {count: 0, latest: null}
+        };
+
+        for (const evt of events) {
+            switch (evt.eventType) {
+                case 'wake/sent_to_me':
+                    breakdown.sent_to_me.count++;
+                    breakdown.sent_to_me.latest = evt.payload;
+                    break;
+                case 'wake/task_state_changed':
+                    breakdown.task_state_changed.count++;
+                    breakdown.task_state_changed.latest = evt.payload;
+                    break;
+                case 'wake/permission_granted':
+                    breakdown.permission_granted.count++;
+                    breakdown.permission_granted.latest = evt.payload;
+                    break;
+            }
+        }
+
+        const emittedAt = new Date();
+
+        return {
+            schemaVersion : '1.0',
+            eventType     : 'wake/digest',
+            eventId       : `01H${crypto.randomBytes(10).toString('hex').toUpperCase()}`,
+            logId         : events[events.length - 1]?.logId,
+            agentIdentity : subscription.agentIdentity,
+            subscriptionId: subscription.id,
+            payload       : {
+                totalEvents: events.length,
+                breakdown,
+                windowMs   : windowStart ? (emittedAt.getTime() - windowStart.getTime()) : 0
+            },
+            emittedAt: emittedAt.toISOString()
+        };
+    }
+
+    /**
+     * Dispatches the digest envelope via the channel matching `subscription.harnessTarget`.
+     *
+     * @protected
+     * @param {Object} subscription
+     * @param {Object} digest Envelope produced by `_buildDigestEnvelope`
+     * @returns {Promise<void>}
+     */
+    async _dispatchDigest(subscription, digest) {
+        const target = subscription.harnessTarget;
+
+        if (target === 'a2a-webhook') {
+            const subscriptionForDelivery = {
+                id        : subscription.id,
+                properties: {
+                    harnessTargetMetadata: subscription.harnessTargetMetadata || {}
+                }
+            };
+            try {
+                await WebhookDeliveryService.deliver(subscriptionForDelivery, digest);
+            } catch (e) {
+                logger.error(`[CoalescingEngine] WebhookDeliveryService.deliver failed for ${subscription.id}: ${e.message}`);
+            }
+            return;
+        }
+
+        if (target === 'mcp-notifications') {
+            // Shape A's MCP notification emit-point will be wired by #10358. Until then,
+            // log the digest so it is observable but undelivered. Once Shape A lands,
+            // this branch routes through its emit surface (e.g., MCP server's session-handle
+            // notification dispatcher) without touching this engine's contract.
+            logger.info(`[CoalescingEngine] Shape A digest pending #10358 emit-wiring for ${subscription.id}: ${digest.payload.totalEvents} events.`);
+            return;
+        }
+
+        if (target === 'bridge-daemon' || target === 'disabled' || target === 'none') {
+            // Bridge daemon coalesces in-process per ADR §6.3 (out-of-process consumer).
+            // disabled/none subscriptions opted out of push; heartbeat polling covers
+            // them per ADR §6.5 (Heartbeat-Bypass Detection).
+            return;
+        }
+
+        logger.warn(`[CoalescingEngine] Unknown harnessTarget '${target}' for ${subscription.id}; dropping digest.`);
+    }
+}
+
+export default Neo.setupClass(CoalescingEngineService);

--- a/test/playwright/unit/ai/mcp/server/memory-core/services/CoalescingEngineService.spec.mjs
+++ b/test/playwright/unit/ai/mcp/server/memory-core/services/CoalescingEngineService.spec.mjs
@@ -1,0 +1,227 @@
+import {setup} from '../../../../../../setup.mjs';
+
+setup({
+    neoConfig: {
+        unitTestMode: true
+    },
+    appConfig: {
+        name             : 'CoalescingEngineServiceTest',
+        isMounted        : () => true,
+        vnodeInitialising: false
+    }
+});
+
+import {test, expect} from '@playwright/test';
+import Neo            from '../../../../../../../../src/Neo.mjs';
+import * as core      from '../../../../../../../../src/core/_export.mjs';
+
+let CoalescingEngineService;
+let WebhookDeliveryService;
+
+const buildEnvelope = (eventType, payload, logId = 1) => ({
+    schemaVersion : '1.0',
+    eventType,
+    eventId       : `01HEVT${Math.random().toString(36).slice(2, 12).toUpperCase()}`,
+    logId,
+    agentIdentity : '@alice',
+    subscriptionId: 'WAKE_SUB:test',
+    payload,
+    emittedAt     : new Date().toISOString()
+});
+
+const buildSubscription = (overrides = {}) => ({
+    id                   : 'WAKE_SUB:test',
+    agentIdentity        : '@alice',
+    harnessTarget        : 'a2a-webhook',
+    harnessTargetMetadata: {url: 'https://example.com/wake', signingKey: 'k', ...(overrides.harnessTargetMetadata || {})},
+    ...overrides
+});
+
+test.describe('CoalescingEngineService', () => {
+    let originalDeliver;
+    let deliverCalls;
+
+    test.beforeAll(async () => {
+        CoalescingEngineService = (await import('../../../../../../../../ai/mcp/server/memory-core/services/CoalescingEngineService.mjs')).default;
+        WebhookDeliveryService  = (await import('../../../../../../../../ai/mcp/server/memory-core/services/WebhookDeliveryService.mjs')).default;
+        originalDeliver         = WebhookDeliveryService.deliver?.bind(WebhookDeliveryService);
+    });
+
+    test.beforeEach(() => {
+        deliverCalls = [];
+        WebhookDeliveryService.deliver = async (subscription, eventData) => {
+            deliverCalls.push({subscription, eventData});
+        };
+        CoalescingEngineService.clearAll();
+    });
+
+    test.afterEach(() => {
+        CoalescingEngineService.clearAll();
+    });
+
+    test.afterAll(() => {
+        if (originalDeliver) WebhookDeliveryService.deliver = originalDeliver;
+    });
+
+    // -----------------------------------------------------------------------------
+    // Window resolution + clamping
+    // -----------------------------------------------------------------------------
+
+    test('_resolveWindowMs falls back to default 30s when no override', () => {
+        const ms = CoalescingEngineService._resolveWindowMs(buildSubscription());
+        expect(ms).toBe(30 * 1000);
+    });
+
+    test('_resolveWindowMs honors per-subscription coalesceWindow override', () => {
+        const sub = buildSubscription({harnessTargetMetadata: {coalesceWindow: 60}});
+        expect(CoalescingEngineService._resolveWindowMs(sub)).toBe(60 * 1000);
+    });
+
+    test('_resolveWindowMs clamps negative override to 0', () => {
+        const sub = buildSubscription({harnessTargetMetadata: {coalesceWindow: -10}});
+        expect(CoalescingEngineService._resolveWindowMs(sub)).toBe(0);
+    });
+
+    test('_resolveWindowMs clamps over-300s override to 300s max', () => {
+        const sub = buildSubscription({harnessTargetMetadata: {coalesceWindow: 999}});
+        expect(CoalescingEngineService._resolveWindowMs(sub)).toBe(300 * 1000);
+    });
+
+    test('_resolveWindowMs honors override of 0 for immediate flush', () => {
+        const sub = buildSubscription({harnessTargetMetadata: {coalesceWindow: 0}});
+        expect(CoalescingEngineService._resolveWindowMs(sub)).toBe(0);
+    });
+
+    // -----------------------------------------------------------------------------
+    // Coalescing behavior
+    // -----------------------------------------------------------------------------
+
+    test('coalesces multiple events within the window into a single digest', async () => {
+        const sub = buildSubscription({harnessTargetMetadata: {url: 'https://example.com/wake', coalesceWindow: 0.05}});
+        CoalescingEngineService.enqueue(sub, buildEnvelope('wake/sent_to_me',         {messageId: 'M1', from: '@bob'}, 10));
+        CoalescingEngineService.enqueue(sub, buildEnvelope('wake/sent_to_me',         {messageId: 'M2', from: '@bob'}, 11));
+        CoalescingEngineService.enqueue(sub, buildEnvelope('wake/task_state_changed', {taskId: 'T1', newState: 'Working'}, 12));
+
+        await new Promise(resolve => setTimeout(resolve, 100));
+
+        expect(deliverCalls.length).toBe(1);
+        const digest = deliverCalls[0].eventData;
+        expect(digest.eventType).toBe('wake/digest');
+        expect(digest.payload.totalEvents).toBe(3);
+        expect(digest.payload.breakdown.sent_to_me.count).toBe(2);
+        expect(digest.payload.breakdown.task_state_changed.count).toBe(1);
+        expect(digest.payload.breakdown.permission_granted.count).toBe(0);
+    });
+
+    test('immediate-flush (coalesceWindow=0) dispatches synchronously', async () => {
+        const sub = buildSubscription({harnessTargetMetadata: {url: 'https://example.com/wake', coalesceWindow: 0}});
+        CoalescingEngineService.enqueue(sub, buildEnvelope('wake/sent_to_me', {messageId: 'M1'}));
+
+        // Immediate-flush path schedules dispatch synchronously inside enqueue;
+        // give the microtask queue a tick to drain the async deliver call.
+        await new Promise(resolve => setTimeout(resolve, 10));
+
+        expect(deliverCalls.length).toBe(1);
+        expect(deliverCalls[0].eventData.eventType).toBe('wake/digest');
+        expect(deliverCalls[0].eventData.payload.totalEvents).toBe(1);
+    });
+
+    test('digest envelope preserves the latest payload per trigger type', async () => {
+        const sub = buildSubscription({harnessTargetMetadata: {url: 'https://example.com/wake', coalesceWindow: 0.05}});
+        CoalescingEngineService.enqueue(sub, buildEnvelope('wake/sent_to_me', {messageId: 'M1', subject: 'first'}));
+        CoalescingEngineService.enqueue(sub, buildEnvelope('wake/sent_to_me', {messageId: 'M2', subject: 'second'}));
+        CoalescingEngineService.enqueue(sub, buildEnvelope('wake/sent_to_me', {messageId: 'M3', subject: 'latest'}));
+
+        await new Promise(resolve => setTimeout(resolve, 100));
+
+        const digest = deliverCalls[0].eventData;
+        expect(digest.payload.breakdown.sent_to_me.latest.messageId).toBe('M3');
+        expect(digest.payload.breakdown.sent_to_me.latest.subject).toBe('latest');
+    });
+
+    test('digest envelope preserves logId of last event for cursor-based catchup', async () => {
+        const sub = buildSubscription({harnessTargetMetadata: {url: 'https://example.com/wake', coalesceWindow: 0.05}});
+        CoalescingEngineService.enqueue(sub, buildEnvelope('wake/sent_to_me', {messageId: 'M1'}, 100));
+        CoalescingEngineService.enqueue(sub, buildEnvelope('wake/sent_to_me', {messageId: 'M2'}, 105));
+
+        await new Promise(resolve => setTimeout(resolve, 100));
+
+        expect(deliverCalls[0].eventData.logId).toBe(105);
+    });
+
+    // -----------------------------------------------------------------------------
+    // Dispatch routing
+    // -----------------------------------------------------------------------------
+
+    test('dispatches a2a-webhook subscriptions to WebhookDeliveryService.deliver', async () => {
+        const sub = buildSubscription({harnessTarget: 'a2a-webhook', harnessTargetMetadata: {url: 'https://example.com/wake', coalesceWindow: 0.05}});
+        CoalescingEngineService.enqueue(sub, buildEnvelope('wake/sent_to_me', {messageId: 'M1'}));
+        await new Promise(resolve => setTimeout(resolve, 100));
+
+        expect(deliverCalls.length).toBe(1);
+        expect(deliverCalls[0].subscription.id).toBe('WAKE_SUB:test');
+        expect(deliverCalls[0].subscription.properties.harnessTargetMetadata.url).toBe('https://example.com/wake');
+    });
+
+    test('does NOT dispatch mcp-notifications subscriptions until #10358 wires the emit-point', async () => {
+        const sub = buildSubscription({harnessTarget: 'mcp-notifications', harnessTargetMetadata: {coalesceWindow: 0.05}});
+        CoalescingEngineService.enqueue(sub, buildEnvelope('wake/sent_to_me', {messageId: 'M1'}));
+        await new Promise(resolve => setTimeout(resolve, 100));
+
+        expect(deliverCalls.length).toBe(0);
+    });
+
+    test('does NOT dispatch bridge-daemon subscriptions (Shape C handles its own coalescing)', async () => {
+        const sub = buildSubscription({harnessTarget: 'bridge-daemon', harnessTargetMetadata: {coalesceWindow: 0.05}});
+        CoalescingEngineService.enqueue(sub, buildEnvelope('wake/sent_to_me', {messageId: 'M1'}));
+        await new Promise(resolve => setTimeout(resolve, 100));
+
+        expect(deliverCalls.length).toBe(0);
+    });
+
+    test('does NOT dispatch disabled subscriptions', async () => {
+        const sub = buildSubscription({harnessTarget: 'disabled', harnessTargetMetadata: {coalesceWindow: 0.05}});
+        CoalescingEngineService.enqueue(sub, buildEnvelope('wake/sent_to_me', {messageId: 'M1'}));
+        await new Promise(resolve => setTimeout(resolve, 100));
+
+        expect(deliverCalls.length).toBe(0);
+    });
+
+    // -----------------------------------------------------------------------------
+    // Lifecycle (flushAll, clearAll)
+    // -----------------------------------------------------------------------------
+
+    test('flushAll force-flushes pending subscriptions immediately', async () => {
+        const sub = buildSubscription({harnessTargetMetadata: {url: 'https://example.com/wake', coalesceWindow: 60}});
+        CoalescingEngineService.enqueue(sub, buildEnvelope('wake/sent_to_me', {messageId: 'M1'}));
+        expect(deliverCalls.length).toBe(0);
+
+        await CoalescingEngineService.flushAll();
+        expect(deliverCalls.length).toBe(1);
+    });
+
+    test('clearAll cancels pending timers without dispatching', async () => {
+        const sub = buildSubscription({harnessTargetMetadata: {url: 'https://example.com/wake', coalesceWindow: 0.05}});
+        CoalescingEngineService.enqueue(sub, buildEnvelope('wake/sent_to_me', {messageId: 'M1'}));
+        CoalescingEngineService.clearAll();
+
+        await new Promise(resolve => setTimeout(resolve, 100));
+        expect(deliverCalls.length).toBe(0);
+    });
+
+    test('per-subscription state is isolated', async () => {
+        const subA = {...buildSubscription(), id: 'WAKE_SUB:A', harnessTargetMetadata: {url: 'https://a.example.com', coalesceWindow: 0.05}};
+        const subB = {...buildSubscription(), id: 'WAKE_SUB:B', harnessTargetMetadata: {url: 'https://b.example.com', coalesceWindow: 0.05}};
+        CoalescingEngineService.enqueue(subA, buildEnvelope('wake/sent_to_me', {messageId: 'A1'}));
+        CoalescingEngineService.enqueue(subB, buildEnvelope('wake/sent_to_me', {messageId: 'B1'}));
+        CoalescingEngineService.enqueue(subA, buildEnvelope('wake/sent_to_me', {messageId: 'A2'}));
+
+        await new Promise(resolve => setTimeout(resolve, 100));
+
+        expect(deliverCalls.length).toBe(2);
+        const aDigest = deliverCalls.find(c => c.subscription.id === 'WAKE_SUB:A')?.eventData;
+        const bDigest = deliverCalls.find(c => c.subscription.id === 'WAKE_SUB:B')?.eventData;
+        expect(aDigest?.payload.totalEvents).toBe(2);
+        expect(bDigest?.payload.totalEvents).toBe(1);
+    });
+});


### PR DESCRIPTION
Authored by Claude Opus 4.7 (Claude Code). Session aaf22f06-cc5c-4dff-aa2f-7d5efb3a6343.

## Summary

Implements the **token-economy throttle / coalescing engine** for the Phase 3 cross-harness autonomous wake substrate (Epic #10357). Per ADR 0002 §6.4, wake events MUST NOT be 1:1 with the underlying event stream at high velocity — broadcast bursts and Task transition flurries cause catastrophic token burn and session thrashing without this throttle.

**Resolves #10362.**

## Why this exists now

Foundational for Shape A + Shape B in-process delivery. Shape C (bridge daemon) coalesces in its own out-of-process queue per ADR §6.3 (already shipped via #10381). With #10378's `WakeSubscriptionService` schema + `resync` boundary contract on dev, this engine is the natural next layer: matched events go in, digests come out, dispatch routes to the channel matching `subscription.harnessTarget`.

## Changes (2 files, +505 / -0)

### 1. `ai/mcp/server/memory-core/services/CoalescingEngineService.mjs` (NEW, 246 lines)

Singleton extending `Neo.core.Base` (per the canonical sibling pattern in `PermissionService` / `MailboxService` / `WakeSubscriptionService`). Public surface:

- **`enqueue(subscription, event)`** — adds event to per-subscription queue, starts (or extends) timer, schedules dispatch at window-fire
- **`flushAll()`** — force-flush all subscriptions immediately (graceful shutdown / tests)
- **`clearAll()`** — cancel timers + drop state without dispatching (test reset)

Per-subscription state lives in `coalesceState: Map<subscriptionId, {queue, timer, subscription, windowStart}>`. Timer-fire callback `_flush` builds the digest envelope and dispatches.

**Window resolution (ADR §6.4.1):**
- Default 30s; overridable per subscription via `harnessTargetMetadata.coalesceWindow` (in seconds)
- Clamped to `[0, 300]` — `0` = immediate-flush; max 5 minutes
- Override of `0` triggers synchronous flush at enqueue time (no timer)

**Digest envelope (ADR §6.4.2):**
Wrapped in standard notification envelope (`schemaVersion: '1.0'`, `eventType: 'wake/digest'`, fresh `eventId` ULID, `logId` of last queued event for cursor-based catchup, `agentIdentity`, `subscriptionId`, `emittedAt`). Payload structure:

```json
{
  "totalEvents": 3,
  "breakdown": {
    "sent_to_me":         {"count": 2, "latest": {messageId, from, ...}},
    "task_state_changed": {"count": 1, "latest": {taskId, newState, ...}},
    "permission_granted": {"count": 0, "latest": null}
  },
  "windowMs": 30000
}
```

`latest` retains the most recent payload per trigger type so consumers have context without needing the full event list.

**Dispatch routing (ADR §6.4 + §6.5):**

| `harnessTarget` | Action |
|---|---|
| `a2a-webhook` | `WebhookDeliveryService.deliver(subscription, digest)` — Shape B (already wired via #10379) |
| `mcp-notifications` | Logs digest pending #10358's emit-point wiring (Shape A, Gemini's parallel track) |
| `bridge-daemon` | No-op (Shape C coalesces in-process per ADR §6.3, ships via #10381) |
| `disabled` / `none` | No-op (heartbeat polling per ADR §6.5) |

### 2. `test/playwright/unit/ai/mcp/server/memory-core/services/CoalescingEngineService.spec.mjs` (NEW, 192 lines)

15 tests covering:
- **Window resolution** (5): default fallback, override honored, negative clamps to 0, over-300 clamps to 300, 0 triggers immediate-flush
- **Coalescing behavior** (4): multi-event single-digest within window, immediate-flush synchronous, latest-payload-per-type retained, last-event `logId` preserved
- **Dispatch routing** (4): `a2a-webhook` calls `WebhookDeliveryService.deliver`, `mcp-notifications` no-op pending #10358, `bridge-daemon` no-op, `disabled` no-op
- **Lifecycle** (3): `flushAll` force-flushes pending, `clearAll` cancels timers, per-subscription state isolation

`WebhookDeliveryService.deliver` is mocked per-test to assert dispatch behavior; original method is restored in `afterAll`. Symmetric `beforeEach` + `afterEach` `clearAll()` per `feedback_symmetric_spec_cleanup.md` — Playwright's fullyParallel can interleave specs in the same worker; cross-singleton state must be reset symmetrically.

## Acceptance Criteria — verification

- [x] **30-60s coalescing window** — default 30s; overridable per subscription via `harnessTargetMetadata.coalesceWindow` ([ADR §6.4.1](https://github.com/neomjs/neo/blob/dev/learn/agentos/decisions/0002-phase3-wake-substrate-standards-alignment.md#641-coalescing-window))
- [x] **Digest payload format** — structured per ADR §6.4.2; eventType `wake/digest` for in-process consumers; literal-text injection deferred to Shape C's daemon (already shipped)
- [x] **Per-subscription `coalesceWindow` override respected** — `_resolveWindowMs` reads override, clamps `[0, 300]`
- [x] **Built against ADR §6.4 contract** — engine consumes events as data (matches resync-boundary green-lit on #10378), dispatches via per-subscription `harnessTarget` routing

## Out of Scope

- **Shape A MCP notifications emit-wiring** — covered by #10358 (Gemini's parallel track). This PR's `_dispatchDigest` for `mcp-notifications` logs the digest pending that wiring; once #10358 lands, that branch routes through Shape A's notification dispatcher without touching this engine's contract.
- **Live emit-point integration** — `MailboxService.addMessage` / `transitionTask` / `GraphService.linkNodes` event emission into the engine is a separate integration step; this PR provides the engine surface; consumers wire when they're ready.
- **Cross-process coalescing for Shape C** — Shape C's bridge daemon has its own coalescer in `ai/scripts/bridge-daemon.mjs` per ADR §6.3.4 (READ-ONLY peer-process consumer of `GraphLog`). Symmetric implementation, distinct process boundaries.
- **Telemetry / observability** — coalesce-window-hit logging per subscription, average-batch-size telemetry, etc. Worth a follow-up if empirical patterns warrant tuning the default.

## Provenance

**Internal Origin** — implements ADR 0002 §6.4 which I authored in prior sessions (`48197e2e-...` → `52e84f76-...`). Discussion #10354 OQ 6 resolution with @neo-gemini-3-1-pro shaped the 30-60s window choice and per-subscription override semantics.

## Related

- **Parent Epic:** #10357 (Phase 3 Cross-harness autonomous wake substrate)
- **ADR:** [0002 §6.4](https://github.com/neomjs/neo/blob/dev/learn/agentos/decisions/0002-phase3-wake-substrate-standards-alignment.md)
- **Predecessor (this PR consumes):** #10378 (#10361 schema, merged) — `WakeSubscriptionService.resync()` boundary contract; `harnessTargetMetadata.coalesceWindow` property
- **Sibling consumer (Shape B, already wired):** #10379 (#10359 webhook, merged) — `WebhookDeliveryService.deliver` receives digests transparently
- **Successor consumer (Shape A):** #10358 (Gemini's parallel track) — wires `mcp-notifications` emit-point through the engine's dispatcher
- **Out-of-process sibling:** #10381 (#10360 bridge daemon, merged) — has its own coalescer per ADR §6.3.4

## Test plan

- [ ] CI: Playwright unit suite runs `CoalescingEngineService.spec.mjs` (15 tests)
- [ ] Manual: enqueue 3 events on a single `a2a-webhook` subscription → verify single digest POST'd (via webhook test surface or live tmux observation if Shape A is wired)
- [ ] Cross-family review by @neo-gemini-3-1-pro — particularly on the digest envelope format (does the `breakdown` shape match what her Shape B receiver expects?) + the dispatch routing for `mcp-notifications` (logs-pending-wiring, ready for her #10358 to plug in)

Origin Session ID: aaf22f06-cc5c-4dff-aa2f-7d5efb3a6343