### PR TITLE
feat(mcp): finalize wake substrate notifications (#10358)

### DIFF
--- a/ai/mcp/server/memory-core/Server.mjs
+++ b/ai/mcp/server/memory-core/Server.mjs
@@ -12,6 +12,7 @@ import {listTools, callTool}                           from './services/toolServ
 import AuthMiddleware                                  from '../shared/services/AuthMiddleware.mjs';
 import RequestContextService                           from '../shared/services/RequestContextService.mjs';
 import StdioIdentityResolver                           from '../shared/services/StdioIdentityResolver.mjs';
+import WakeSubscriptionService                         from './services/WakeSubscriptionService.mjs';
 
 /**
  * @summary The Memory Core MCP Server application.
@@ -80,9 +81,17 @@ class Server extends Base {
             capabilities: {
                 tools: {
                     listChanged: false
+                },
+                experimental: {
+                    'neo-wake-substrate': {
+                        version: '1.0',
+                        supportedEvents: ['wake/sent_to_me', 'wake/task_state_changed', 'wake/permission_granted']
+                    }
                 }
             }
         });
+
+        WakeSubscriptionService.setMcpServer(this.mcpServer);
 
         // 3. Setup Request Handlers
         this.setupRequestHandlers();
@@ -131,6 +140,9 @@ class Server extends Base {
         } else {
             const {StdioServerTransport} = await import('@modelcontextprotocol/sdk/server/stdio.js');
             const transport = new StdioServerTransport();
+            
+            if (!this.mcpServer) return; // Prevent crash if instance was destroyed during async boot
+            
             await this.mcpServer.connect(transport);
 
             logger.info('[neo-memory-core MCP] Server started on stdio transport');

--- a/ai/mcp/server/memory-core/openapi.yaml
+++ b/ai/mcp/server/memory-core/openapi.yaml
@@ -73,15 +73,19 @@ paths:
         Manages the lifecycle (start/stop) of the ChromaDB database instance for the Memory Core.
 
         **Behavior:**
-        - **Start:** Spawns a managed process (cleaned on exit) if none exists. If running externally (e.g., `npm run ai:server-memory`), connects as a client (NOT killed on exit).
-        - **Stop:** Stops managed processes only. External databases are ignored.
+        - **Start:**
+          - **Managed:** If no database is running on the configured port, this tool spawns a new process managed by this server. This process will be automatically cleaned up when the agent session ends.
+          - **External:** If a database is already running (e.g., via `npm run ai:server-memory`), this tool simply confirms the connection. The server acts as a client and will NOT kill the database on exit.
+        - **Stop:**
+          - **Managed:** Stops the process spawned by this server.
+          - **External:** **No effect.** The server cannot stop a database it did not start.
 
-        **Swarm Recommendation:**
-        For multi-agent workflows, always start the database externally to prevent unexpected disconnects when the "owner" agent exits.
+        **Multi-Agent / Swarm Recommendation:**
+        For workflows involving multiple concurrent agents, it is **highly recommended** to start the database externally using `npm run ai:server-memory` before starting the agents. This prevents unexpected disconnects for other agents when the "owner" agent exits.
 
         **When to Use:**
-        - Use `action: start` if `healthcheck` reveals the database is not running.
-        - Use `action: stop` for debugging, forcing a restart, or freeing resources.
+        - Use `action: start` if a `healthcheck` reveals that the database process is not running.
+        - Use `action: stop` for debugging, forcing a restart, or freeing up resources.
       tags: ["Database Lifecycle"]
       requestBody:
         required: true

--- a/ai/mcp/server/memory-core/openapi.yaml
+++ b/ai/mcp/server/memory-core/openapi.yaml
@@ -73,19 +73,15 @@ paths:
         Manages the lifecycle (start/stop) of the ChromaDB database instance for the Memory Core.
 
         **Behavior:**
-        - **Start:**
-          - **Managed:** If no database is running on the configured port, this tool spawns a new process managed by this server. This process will be automatically cleaned up when the agent session ends.
-          - **External:** If a database is already running (e.g., via `npm run ai:server-memory`), this tool simply confirms the connection. The server acts as a client and will NOT kill the database on exit.
-        - **Stop:**
-          - **Managed:** Stops the process spawned by this server.
-          - **External:** **No effect.** The server cannot stop a database it did not start.
+        - **Start:** Spawns a managed process (cleaned on exit) if none exists. If running externally (e.g., `npm run ai:server-memory`), connects as a client (NOT killed on exit).
+        - **Stop:** Stops managed processes only. External databases are ignored.
 
-        **Multi-Agent / Swarm Recommendation:**
-        For workflows involving multiple concurrent agents, it is **highly recommended** to start the database externally using `npm run ai:server-memory` before starting the agents. This prevents unexpected disconnects for other agents when the "owner" agent exits.
+        **Swarm Recommendation:**
+        For multi-agent workflows, always start the database externally to prevent unexpected disconnects when the "owner" agent exits.
 
         **When to Use:**
-        - Use `action: start` if a `healthcheck` reveals that the database process is not running.
-        - Use `action: stop` for debugging, forcing a restart, or freeing up resources.
+        - Use `action: start` if `healthcheck` reveals the database is not running.
+        - Use `action: stop` for debugging, forcing a restart, or freeing resources.
       tags: ["Database Lifecycle"]
       requestBody:
         required: true

--- a/ai/mcp/server/memory-core/services/MailboxService.mjs
+++ b/ai/mcp/server/memory-core/services/MailboxService.mjs
@@ -3,6 +3,7 @@ import aiConfig from '../config.mjs';
 import RequestContextService from '../../shared/services/RequestContextService.mjs';
 import GraphService from './GraphService.mjs';
 import PermissionService from './PermissionService.mjs';
+import WakeSubscriptionService from './WakeSubscriptionService.mjs';
 import crypto from 'crypto';
 import SemanticGraphExtractor from '../../../../daemons/services/SemanticGraphExtractor.mjs';
 
@@ -282,6 +283,8 @@ class MailboxService extends Base {
                 }
             }
         }).catch(() => { /* error logged internally */ });
+
+        WakeSubscriptionService.pump();
 
         return { messageId, sentAt: timestamp, priority, status: 'sent' };
     }
@@ -628,6 +631,8 @@ class MailboxService extends Base {
         // Push the merged object back to GraphService cache to trigger events
         GraphService.upsertNode(messageNode);
 
+        WakeSubscriptionService.pump();
+
         return {
             success: true,
             rowsAffected: info.changes,
@@ -714,6 +719,8 @@ class MailboxService extends Base {
                     cached.properties.lastModifiedAt = timestamp
                 }
             }
+
+            WakeSubscriptionService.pump();
         }
 
         return { success: true, sweptCount: info.changes }

--- a/ai/mcp/server/memory-core/services/MailboxService.mjs
+++ b/ai/mcp/server/memory-core/services/MailboxService.mjs
@@ -284,7 +284,7 @@ class MailboxService extends Base {
             }
         }).catch(() => { /* error logged internally */ });
 
-        WakeSubscriptionService.pump();
+        WakeSubscriptionService.pump().catch(e => logger.error('[wake-pump]', e));
 
         return { messageId, sentAt: timestamp, priority, status: 'sent' };
     }
@@ -631,7 +631,7 @@ class MailboxService extends Base {
         // Push the merged object back to GraphService cache to trigger events
         GraphService.upsertNode(messageNode);
 
-        WakeSubscriptionService.pump();
+        WakeSubscriptionService.pump().catch(e => logger.error('[wake-pump]', e));
 
         return {
             success: true,
@@ -720,7 +720,7 @@ class MailboxService extends Base {
                 }
             }
 
-            WakeSubscriptionService.pump();
+            WakeSubscriptionService.pump().catch(e => logger.error('[wake-pump]', e));
         }
 
         return { success: true, sweptCount: info.changes }

--- a/ai/mcp/server/memory-core/services/PermissionService.mjs
+++ b/ai/mcp/server/memory-core/services/PermissionService.mjs
@@ -76,7 +76,7 @@ class PermissionService extends Base {
         // The capability belongs to 'to', pointing at 'owner'
         // e.g. "Alice CAN_READ_INBOX_OF Bob" (source: Alice, target: Bob)
         GraphService.linkNodes(to, owner, scope, 1.0);
-        WakeSubscriptionService.pump();
+        WakeSubscriptionService.pump().catch(e => logger.error('[wake-pump]', e));
         return { success: true, message: `Granted ${scope} to ${to}` };
     }
 
@@ -101,7 +101,7 @@ class PermissionService extends Base {
 
         if (edgesToRemove.length > 0) {
             db.edges.remove(edgesToRemove);
-            WakeSubscriptionService.pump();
+            WakeSubscriptionService.pump().catch(e => logger.error('[wake-pump]', e));
         }
         
         return { success: true, message: `Revoked ${scope} from ${to}` };

--- a/ai/mcp/server/memory-core/services/PermissionService.mjs
+++ b/ai/mcp/server/memory-core/services/PermissionService.mjs
@@ -1,6 +1,7 @@
 import Base from '../../../../../src/core/Base.mjs';
 import GraphService from './GraphService.mjs';
 import RequestContextService from '../../shared/services/RequestContextService.mjs';
+import WakeSubscriptionService from './WakeSubscriptionService.mjs';
 import logger from '../logger.mjs';
 
 /**
@@ -75,6 +76,7 @@ class PermissionService extends Base {
         // The capability belongs to 'to', pointing at 'owner'
         // e.g. "Alice CAN_READ_INBOX_OF Bob" (source: Alice, target: Bob)
         GraphService.linkNodes(to, owner, scope, 1.0);
+        WakeSubscriptionService.pump();
         return { success: true, message: `Granted ${scope} to ${to}` };
     }
 
@@ -99,6 +101,7 @@ class PermissionService extends Base {
 
         if (edgesToRemove.length > 0) {
             db.edges.remove(edgesToRemove);
+            WakeSubscriptionService.pump();
         }
         
         return { success: true, message: `Revoked ${scope} from ${to}` };

--- a/ai/mcp/server/memory-core/services/WakeSubscriptionService.mjs
+++ b/ai/mcp/server/memory-core/services/WakeSubscriptionService.mjs
@@ -64,6 +64,123 @@ class WakeSubscriptionService extends Base {
     subscriptionCache = new Map()
 
     /**
+     * @member {McpServer|null} mcpServer=null
+     * @protected
+     */
+    mcpServer = null
+
+    /**
+     * @member {Number} liveCursor=0
+     * @protected
+     */
+    liveCursor = 0
+
+    /**
+     * Injects the MCP server instance for push notifications.
+     * Sets the initial live cursor to the current graph log head to prevent
+     * replaying historical events on boot.
+     * @param {McpServer} mcpServer
+     */
+    setMcpServer(mcpServer) {
+        this.mcpServer = mcpServer;
+        const storage = GraphService.db.storage;
+        if (storage?.db) {
+            // Get current log_id to start pumping from now
+            try {
+                const row = storage.db.prepare('SELECT MAX(log_id) as maxId FROM GraphLog').get();
+                this.liveCursor = row.maxId || 0;
+            } catch (e) {
+                logger.warn('[WakeSubscription] Failed to read max log_id on setMcpServer', e);
+            }
+        }
+    }
+
+    /**
+     * Evaluates recent GraphLog deltas and pushes matching events to connected
+     * Shape A (MCP notification) clients. Intended to be called by mutation paths
+     * (e.g. MailboxService, PermissionService) for low-latency delivery.
+     * @returns {Promise<void>}
+     */
+    async pump() {
+        if (!this.mcpServer) return;
+        
+        try {
+            const db = GraphService.db;
+            if (!db) return;
+            
+            const storage = db.storage;
+            if (!storage?.getDeltaLog) return;
+            
+            const delta = storage.getDeltaLog(this.liveCursor);
+            if (delta.invalidEdges.length === 0 && delta.invalidNodes.length === 0) {
+                this.liveCursor = delta.lastLogId;
+                return;
+            }
+
+            // We only care about mcp-notifications target
+            // We also explicitly do a full scan since the cache might only have lazy-loaded partials.
+            // Wait, does subscriptionCache have all active subscriptions? No, it's lazy loaded.
+            // We should ensure all active mcp-notifications subscriptions are in cache.
+            // Or simply do a quick SQLite scan for them to guarantee we don't miss any if we haven't listed them.
+            this._warmMcpSubscriptions();
+
+            const activeSubs = Array.from(this.subscriptionCache.values())
+                .filter(sub => sub.harnessTarget === 'mcp-notifications' && sub.status === 'active');
+                
+            if (activeSubs.length === 0) {
+                this.liveCursor = delta.lastLogId;
+                return;
+            }
+
+            const eventsToEmit = [];
+            for (const sub of activeSubs) {
+                for (const edgeRef of delta.invalidEdges) {
+                    const matched = this._evaluateEdgeAgainstSubscription(edgeRef, sub, delta.lastLogId);
+                    if (matched) eventsToEmit.push(matched);
+                }
+                for (const nodeId of delta.invalidNodes) {
+                    const matched = this._evaluateNodeAgainstSubscription(nodeId, sub, delta.lastLogId);
+                    if (matched) eventsToEmit.push(matched);
+                }
+            }
+
+            for (const event of eventsToEmit) {
+                try {
+                    // ADR 0002 §6.1 specifies the method name is 'notifications/message'
+                    await this.mcpServer.notification({
+                        method: 'notifications/message',
+                        params: event
+                    });
+                } catch (e) {
+                    logger.error('[WakeSubscription] Failed to emit MCP notification', e);
+                }
+            }
+            
+            this.liveCursor = delta.lastLogId;
+        } catch (e) {
+            logger.error('[WakeSubscription] Background pump failed:', e);
+        }
+    }
+
+    /**
+     * Ensures all active 'mcp-notifications' subscriptions are in cache.
+     * @protected
+     */
+    _warmMcpSubscriptions() {
+        const db = GraphService.db;
+        if (!db) return;
+        for (const node of db.nodes.items) {
+            if (node.label !== 'WAKE_SUBSCRIPTION') continue;
+            const props = node.properties || {};
+            if (props.harnessTarget === 'mcp-notifications' && props.status === 'active') {
+                if (!this.subscriptionCache.has(node.id)) {
+                    this.subscriptionCache.set(node.id, {id: node.id, ...props});
+                }
+            }
+        }
+    }
+
+    /**
      * Unified entry point for the `manage_wake_subscription` MCP tool. Dispatches to
      * action-specific handlers per ADR 0002 §6.6.
      *
@@ -307,11 +424,11 @@ class WakeSubscriptionService extends Base {
         // examine edges; TASK_STATE_CHANGED examines nodes (the Task envelope payload).
         // Filter spec is applied to the matched candidate's payload; non-matches are skipped.
         for (const edgeRef of delta.invalidEdges) {
-            const matched = this._evaluateEdgeAgainstSubscription(edgeRef, subscription);
+            const matched = this._evaluateEdgeAgainstSubscription(edgeRef, subscription, delta.lastLogId);
             if (matched) events.push(matched);
         }
         for (const nodeId of delta.invalidNodes) {
-            const matched = this._evaluateNodeAgainstSubscription(nodeId, subscription);
+            const matched = this._evaluateNodeAgainstSubscription(nodeId, subscription, delta.lastLogId);
             if (matched) events.push(matched);
         }
 
@@ -329,9 +446,10 @@ class WakeSubscriptionService extends Base {
      * @protected
      * @param {Object} edgeRef GraphLog edge reference: `{id, source, target}`
      * @param {Object} subscription The cached WAKE_SUBSCRIPTION entry (id + properties)
+     * @param {Number} logIdAnchor The delta block's lastLogId for the notification watermark
      * @returns {Object|null} Wrapped wake-event payload (per §6.1.1 / §6.1.3 envelope) or null when no match
      */
-    _evaluateEdgeAgainstSubscription(edgeRef, subscription) {
+    _evaluateEdgeAgainstSubscription(edgeRef, subscription, logIdAnchor) {
         const db   = GraphService.db;
         const edge = db.edges.get(edgeRef.id);
         if (!edge) return null;
@@ -343,7 +461,7 @@ class WakeSubscriptionService extends Base {
             if (!messageNode) return null;
             const payload = this._buildSentToMePayload(messageNode);
             if (!this._matchesFilters(payload, subscription.filters)) return null;
-            return this._wrapEvent('wake/sent_to_me', subscription, payload, edgeRef.id);
+            return this._wrapEvent('wake/sent_to_me', subscription, payload, logIdAnchor);
         }
 
         if (subscription.trigger === 'PERMISSION_GRANTED'
@@ -354,7 +472,7 @@ class WakeSubscriptionService extends Base {
                 grantedBy : edge.source,
                 grantedAt : new Date().toISOString()
             };
-            return this._wrapEvent('wake/permission_granted', subscription, payload, edgeRef.id);
+            return this._wrapEvent('wake/permission_granted', subscription, payload, logIdAnchor);
         }
 
         return null;
@@ -366,9 +484,10 @@ class WakeSubscriptionService extends Base {
      * @protected
      * @param {String} nodeId GraphLog-touched node ID (typically a `MESSAGE:*` carrying a Task envelope)
      * @param {Object} subscription The cached WAKE_SUBSCRIPTION entry (id + properties)
+     * @param {Number} logIdAnchor The delta block's lastLogId for the notification watermark
      * @returns {Object|null} Wrapped wake-event payload (per §6.1.2 envelope) or null when no match
      */
-    _evaluateNodeAgainstSubscription(nodeId, subscription) {
+    _evaluateNodeAgainstSubscription(nodeId, subscription, logIdAnchor) {
         if (subscription.trigger !== 'TASK_STATE_CHANGED') return null;
 
         const node = GraphService.db.nodes.get(nodeId);
@@ -389,7 +508,7 @@ class WakeSubscriptionService extends Base {
             assignee      : task.assignee,
             lastModifiedAt: props.updatedAt || props.sentAt
         };
-        return this._wrapEvent('wake/task_state_changed', subscription, payload, nodeId);
+        return this._wrapEvent('wake/task_state_changed', subscription, payload, logIdAnchor);
     }
 
     /**

--- a/ai/mcp/server/memory-core/services/WakeSubscriptionService.mjs
+++ b/ai/mcp/server/memory-core/services/WakeSubscriptionService.mjs
@@ -76,6 +76,13 @@ class WakeSubscriptionService extends Base {
     liveCursor = 0
 
     /**
+     * Guard against re-entrant calls to pump()
+     * @member {Boolean} _pumping=false
+     * @protected
+     */
+    _pumping = false
+
+    /**
      * Injects the MCP server instance for push notifications.
      * Sets the initial live cursor to the current graph log head to prevent
      * replaying historical events on boot.
@@ -103,8 +110,10 @@ class WakeSubscriptionService extends Base {
      */
     async pump() {
         if (!this.mcpServer) return;
+        if (this._pumping) return;
         
         try {
+            this._pumping = true;
             const db = GraphService.db;
             if (!db) return;
             
@@ -135,11 +144,13 @@ class WakeSubscriptionService extends Base {
             const eventsToEmit = [];
             for (const sub of activeSubs) {
                 for (const edgeRef of delta.invalidEdges) {
-                    const matched = this._evaluateEdgeAgainstSubscription(edgeRef, sub, delta.lastLogId);
+                    const logId = this._getEntityLogId(edgeRef.id) || delta.lastLogId;
+                    const matched = this._evaluateEdgeAgainstSubscription(edgeRef, sub, logId);
                     if (matched) eventsToEmit.push(matched);
                 }
                 for (const nodeId of delta.invalidNodes) {
-                    const matched = this._evaluateNodeAgainstSubscription(nodeId, sub, delta.lastLogId);
+                    const logId = this._getEntityLogId(nodeId) || delta.lastLogId;
+                    const matched = this._evaluateNodeAgainstSubscription(nodeId, sub, logId);
                     if (matched) eventsToEmit.push(matched);
                 }
             }
@@ -159,6 +170,8 @@ class WakeSubscriptionService extends Base {
             this.liveCursor = delta.lastLogId;
         } catch (e) {
             logger.error('[WakeSubscription] Background pump failed:', e);
+        } finally {
+            this._pumping = false;
         }
     }
 
@@ -424,11 +437,13 @@ class WakeSubscriptionService extends Base {
         // examine edges; TASK_STATE_CHANGED examines nodes (the Task envelope payload).
         // Filter spec is applied to the matched candidate's payload; non-matches are skipped.
         for (const edgeRef of delta.invalidEdges) {
-            const matched = this._evaluateEdgeAgainstSubscription(edgeRef, subscription, delta.lastLogId);
+            const logId = this._getEntityLogId(edgeRef.id) || delta.lastLogId;
+            const matched = this._evaluateEdgeAgainstSubscription(edgeRef, subscription, logId);
             if (matched) events.push(matched);
         }
         for (const nodeId of delta.invalidNodes) {
-            const matched = this._evaluateNodeAgainstSubscription(nodeId, subscription, delta.lastLogId);
+            const logId = this._getEntityLogId(nodeId) || delta.lastLogId;
+            const matched = this._evaluateNodeAgainstSubscription(nodeId, subscription, logId);
             if (matched) events.push(matched);
         }
 
@@ -438,6 +453,20 @@ class WakeSubscriptionService extends Base {
             lastLogId     : delta.lastLogId,
             eventsReplayed: events.length
         };
+    }
+
+    /**
+     * Retrieves the specific GraphLog log_id for an entity, to anchor the wake event
+     * per ADR 0002 §6.1.6.
+     * @protected
+     * @param {String} entityId
+     * @returns {Number|null}
+     */
+    _getEntityLogId(entityId) {
+        try {
+            const row = GraphService.db.storage.db.prepare('SELECT MAX(log_id) as maxId FROM GraphLog WHERE entity_id = ?').get(entityId);
+            return row?.maxId || null;
+        } catch (e) { return null; }
     }
 
     /**

--- a/test/playwright/unit/ai/mcp/server/memory-core/services/WakeSubscriptionService.spec.mjs
+++ b/test/playwright/unit/ai/mcp/server/memory-core/services/WakeSubscriptionService.spec.mjs
@@ -18,7 +18,9 @@ import fs                    from 'fs-extra';
 import path                  from 'path';
 import Neo                   from '../../../../../../../../src/Neo.mjs';
 
-// Stub Neo.get to bypass Playwright boot regression (#10384) in data records
+// Stub Neo.get to bypass Playwright boot regression (#10384) in data records.
+// This workaround demonstrates that #10384 affects Phase 3 cross-spec tests,
+// proving the regression affects newcomers. See triage note in PR #10387.
 if (!Neo.get) Neo.get = () => null;
 
 import RequestContextService from '../../../../../../../../ai/mcp/server/shared/services/RequestContextService.mjs';
@@ -351,6 +353,144 @@ test.describe('Neo.ai.mcp.server.memory-core.services.WakeSubscriptionService', 
             expect(res.subscriptionId).toBe(subscriptionId);
             expect(res.events).toEqual([]);
             expect(res.eventsReplayed).toBe(0);
+        });
+    });
+    // -----------------------------------------------------------------------------
+    // pump()
+    // -----------------------------------------------------------------------------
+
+    test.describe('pump', () => {
+        let emittedEvents = [];
+        let mockMcpServer = {
+            notification: async (event) => {
+                emittedEvents.push(event);
+            }
+        };
+
+        test.beforeEach(async () => {
+            emittedEvents = [];
+            WakeSubscriptionService.setMcpServer(null); // Reset
+        });
+
+        test('graceful no-op when no mcpServer is registered', async () => {
+            await RequestContextService.run({agentIdentityNodeId: '@alice'}, async () => {
+                await WakeSubscriptionService.subscribe({trigger: 'SENT_TO_ME', harnessTarget: 'mcp-notifications'});
+            });
+
+            // Make a mutation
+            GraphService.upsertNode({id: 'MSG:1', type: 'MESSAGE', properties: {from: '@bob'}});
+            GraphService.linkNodes('MSG:1', '@alice', 'SENT_TO', 1.0);
+
+            // pump shouldn't fail and shouldn't emit
+            await WakeSubscriptionService.pump();
+            expect(emittedEvents.length).toBe(0);
+        });
+
+        test('emits notifications/message for matching mcp-notifications subscription', async () => {
+            WakeSubscriptionService.setMcpServer(mockMcpServer);
+
+            await RequestContextService.run({agentIdentityNodeId: '@alice'}, async () => {
+                await WakeSubscriptionService.subscribe({trigger: 'SENT_TO_ME', harnessTarget: 'mcp-notifications'});
+            });
+
+            // Make a mutation
+            GraphService.upsertNode({id: 'MSG:2', type: 'MESSAGE', properties: {from: '@bob', subject: 'hello'}});
+            GraphService.linkNodes('MSG:2', '@alice', 'SENT_TO', 1.0);
+
+            await WakeSubscriptionService.pump();
+            expect(emittedEvents.length).toBe(1);
+            expect(emittedEvents[0].method).toBe('notifications/message');
+            expect(emittedEvents[0].params.eventType).toBe('wake/sent_to_me');
+            expect(emittedEvents[0].params.payload.from).toBe('@bob');
+        });
+
+        test('does not emit for non-matching subscription', async () => {
+            WakeSubscriptionService.setMcpServer(mockMcpServer);
+
+            await RequestContextService.run({agentIdentityNodeId: '@alice'}, async () => {
+                await WakeSubscriptionService.subscribe({
+                    trigger: 'SENT_TO_ME', 
+                    harnessTarget: 'mcp-notifications',
+                    filters: { priority: 'high' }
+                });
+            });
+
+            // Make a mutation that does NOT match the filter
+            GraphService.upsertNode({id: 'MSG:3', type: 'MESSAGE', properties: {from: '@bob', priority: 'low'}});
+            GraphService.linkNodes('MSG:3', '@alice', 'SENT_TO', 1.0);
+
+            await WakeSubscriptionService.pump();
+            expect(emittedEvents.length).toBe(0);
+        });
+
+        test('advances liveCursor per delta.lastLogId', async () => {
+            WakeSubscriptionService.setMcpServer(mockMcpServer);
+            const initialCursor = WakeSubscriptionService.liveCursor;
+
+            GraphService.upsertNode({id: 'MSG:4', type: 'MESSAGE', properties: {}});
+            await WakeSubscriptionService.pump();
+
+            expect(WakeSubscriptionService.liveCursor).toBeGreaterThan(initialCursor);
+        });
+
+        test('warms cache with active mcp-notifications subscriptions on first call', async () => {
+            WakeSubscriptionService.setMcpServer(mockMcpServer);
+
+            let subId;
+            await RequestContextService.run({agentIdentityNodeId: '@alice'}, async () => {
+                const res = await WakeSubscriptionService.subscribe({trigger: 'SENT_TO_ME', harnessTarget: 'mcp-notifications'});
+                subId = res.subscriptionId;
+            });
+
+            // Manually clear cache to simulate a fresh boot
+            WakeSubscriptionService.subscriptionCache.clear();
+            expect(WakeSubscriptionService.subscriptionCache.has(subId)).toBe(false);
+
+            GraphService.upsertNode({id: 'MSG:5', type: 'MESSAGE', properties: {from: '@bob'}});
+            GraphService.linkNodes('MSG:5', '@alice', 'SENT_TO', 1.0);
+
+            await WakeSubscriptionService.pump();
+
+            // Should have lazily warmed the cache and successfully emitted
+            expect(WakeSubscriptionService.subscriptionCache.has(subId)).toBe(true);
+            expect(emittedEvents.length).toBe(1);
+        });
+
+        test('skips bridge-daemon / a2a-webhook / disabled targets', async () => {
+            WakeSubscriptionService.setMcpServer(mockMcpServer);
+
+            await RequestContextService.run({agentIdentityNodeId: '@alice'}, async () => {
+                await WakeSubscriptionService.subscribe({trigger: 'SENT_TO_ME', harnessTarget: 'bridge-daemon'});
+                await WakeSubscriptionService.subscribe({trigger: 'SENT_TO_ME', harnessTarget: 'a2a-webhook', harnessTargetMetadata: {url: 'test'}});
+                await WakeSubscriptionService.subscribe({trigger: 'SENT_TO_ME', harnessTarget: 'disabled'});
+            });
+
+            GraphService.upsertNode({id: 'MSG:6', type: 'MESSAGE', properties: {from: '@bob'}});
+            GraphService.linkNodes('MSG:6', '@alice', 'SENT_TO', 1.0);
+
+            await WakeSubscriptionService.pump();
+            // None of the subscriptions target mcp-notifications
+            expect(emittedEvents.length).toBe(0);
+        });
+
+        test('concurrent pump() invocations do not double-emit', async () => {
+            WakeSubscriptionService.setMcpServer(mockMcpServer);
+
+            await RequestContextService.run({agentIdentityNodeId: '@alice'}, async () => {
+                await WakeSubscriptionService.subscribe({trigger: 'SENT_TO_ME', harnessTarget: 'mcp-notifications'});
+            });
+
+            GraphService.upsertNode({id: 'MSG:7', type: 'MESSAGE', properties: {from: '@bob'}});
+            GraphService.linkNodes('MSG:7', '@alice', 'SENT_TO', 1.0);
+
+            // Execute concurrent pumps
+            await Promise.all([
+                WakeSubscriptionService.pump(),
+                WakeSubscriptionService.pump()
+            ]);
+
+            // If the race condition was present, both might emit the same event
+            expect(emittedEvents.length).toBe(1);
         });
     });
 });

--- a/test/playwright/unit/ai/mcp/server/memory-core/services/WakeSubscriptionService.spec.mjs
+++ b/test/playwright/unit/ai/mcp/server/memory-core/services/WakeSubscriptionService.spec.mjs
@@ -17,6 +17,10 @@ import {test, expect}        from '@playwright/test';
 import fs                    from 'fs-extra';
 import path                  from 'path';
 import Neo                   from '../../../../../../../../src/Neo.mjs';
+
+// Stub Neo.get to bypass Playwright boot regression (#10384) in data records
+if (!Neo.get) Neo.get = () => null;
+
 import RequestContextService from '../../../../../../../../ai/mcp/server/shared/services/RequestContextService.mjs';
 
 test.describe('Neo.ai.mcp.server.memory-core.services.WakeSubscriptionService', () => {
@@ -180,7 +184,7 @@ test.describe('Neo.ai.mcp.server.memory-core.services.WakeSubscriptionService', 
             const removeRes = await WakeSubscriptionService.unsubscribe({subscriptionId});
             expect(removeRes.status).toBe('removed');
 
-            expect(GraphService.db.nodes.get(subscriptionId)).toBeUndefined();
+            expect(GraphService.db.nodes.get(subscriptionId) || null).toBeNull();
             expect(GraphService.db.edges.items.filter(e => e.target === subscriptionId).length).toBe(0);
             expect(WakeSubscriptionService.subscriptionCache.has(subscriptionId)).toBe(false);
         });


### PR DESCRIPTION
Authored by Gemini 3.1 Pro (Antigravity). Session 09444f9b-9ae1-4d9a-81a4-02e885870417.

Resolves #10358

Finalizes the Phase 3 autonomous wake substrate by implementing MCP notification mechanics and normalizing event delivery schemas. Implemented schema compliance with ADR 0002 §6.1.6, ensuring `logId` watermarking is accurately propagated across delta logs via `lastLogId`. Updated `MailboxService` and `PermissionService` to trigger `WakeSubscriptionService.pump()`.

## Deltas from ticket (if any)
Bypassed the Playwright boot regression (#10384) in the test suite by stubbing `Neo.get` in `WakeSubscriptionService.spec.mjs`.

## Test Evidence
Executed Playwright unit tests for `WakeSubscriptionService`, `MailboxService`, and `PermissionService`. All passed.

## Post-Merge Validation
- [ ] Verify `WakeSubscriptionService.pump()` triggers MCP client notifications successfully in the production environment.
