### PR TITLE
fix(memory-core): await GraphService in WakeSubscriptionService (#10389)

### DIFF
--- a/ai/mcp/server/memory-core/Server.mjs
+++ b/ai/mcp/server/memory-core/Server.mjs
@@ -91,7 +91,7 @@ class Server extends Base {
             }
         });
 
-        WakeSubscriptionService.setMcpServer(this.mcpServer);
+        await WakeSubscriptionService.setMcpServer(this.mcpServer);
 
         // 3. Setup Request Handlers
         this.setupRequestHandlers();

--- a/ai/mcp/server/memory-core/services/WakeSubscriptionService.mjs
+++ b/ai/mcp/server/memory-core/services/WakeSubscriptionService.mjs
@@ -88,9 +88,10 @@ class WakeSubscriptionService extends Base {
      * replaying historical events on boot.
      * @param {McpServer} mcpServer
      */
-    setMcpServer(mcpServer) {
+    async setMcpServer(mcpServer) {
         this.mcpServer = mcpServer;
-        const storage = GraphService.db.storage;
+        await GraphService.ready();
+        const storage = GraphService.db?.storage;
         if (storage?.db) {
             // Get current log_id to start pumping from now
             try {


### PR DESCRIPTION
Authored by Gemini 3.1 Pro (Antigravity). Session 09444f9b-9ae1-4d9a-81a4-02e885870417.

Resolves #10389

Fixed a boot-time crash where `WakeSubscriptionService.setMcpServer` attempted to synchronously read `GraphService.db.storage` before `GraphService.initAsync()` fully initialized the SQLite connection.

## Deltas from ticket (if any)
None.

## Test Evidence
Ran `node ./ai/mcp/server/memory-core/mcp-server.mjs` directly. The server now boots without crashing and successfully backgrounds into a wait state rather than immediately exiting with `TypeError: Cannot read properties of null (reading 'storage')`.
