### PR TITLE
feat(ai): Finalize Phase 3 Wake Substrate with Bidirectional Delivery (#10391)

### DIFF
--- a/ai/scripts/bridge-daemon.mjs
+++ b/ai/scripts/bridge-daemon.mjs
@@ -96,11 +96,8 @@ function evaluateSubscription(sub, trace, entity, nodesMap, edgesMap) {
     if (trigger === 'SENT_TO_ME' && trace.entity_type === 'edges' && entity.type === 'SENT_TO') {
         // A SENT_TO edge points to the agent.
         if (entity.target === agentIdentity || entity.target === 'AGENT:*') {
-            console.log(`[Bridge Daemon] Evaluating SENT_TO edge for ${agentIdentity}`);
             const messageNode = nodesMap.get(entity.source) || getDbNode(db, entity.source);
-            console.log(`[Bridge Daemon] Message node:`, messageNode);
             if (messageNode && messageNode.label === 'MESSAGE') {
-                console.log(`[Bridge Daemon] Message node confirmed as MESSAGE`);
                 // Apply filters
                 if (filters.priority && messageNode.properties?.priority !== filters.priority) return null;
                 if (filters.senderFilter && !filters.senderFilter.includes(messageNode.properties?.from)) return null;
@@ -185,10 +182,8 @@ function queueEvent(subscription, eventPayload) {
         const windowMs = coalesceSeconds * 1000;
 
         if (windowMs === 0) {
-            console.log(`[Bridge Daemon] Flushing immediately for ${subId}`);
             flushSubscription(subId);
         } else {
-            console.log(`[Bridge Daemon] Setting timer for ${subId} (${windowMs}ms)`);
             coalesceState[subId].timer = setTimeout(() => {
                 flushSubscription(subId);
             }, windowMs);
@@ -200,7 +195,6 @@ function queueEvent(subscription, eventPayload) {
  * Flushes the queue for a subscription, building the digest and invoking the harness adapter.
  */
 async function flushSubscription(subId) {
-    console.log(`[Bridge Daemon] flushSubscription called for ${subId}`);
     const state = coalesceState[subId];
     if (!state) return;
 

--- a/ai/scripts/bridge-daemon.mjs
+++ b/ai/scripts/bridge-daemon.mjs
@@ -96,18 +96,34 @@ function evaluateSubscription(sub, trace, entity, nodesMap, edgesMap) {
     if (trigger === 'SENT_TO_ME' && trace.entity_type === 'edges' && entity.type === 'SENT_TO') {
         // A SENT_TO edge points to the agent.
         if (entity.target === agentIdentity || entity.target === 'AGENT:*') {
+            console.log(`[Bridge Daemon] Evaluating SENT_TO edge for ${agentIdentity}`);
             const messageNode = nodesMap.get(entity.source) || getDbNode(db, entity.source);
+            console.log(`[Bridge Daemon] Message node:`, messageNode);
             if (messageNode && messageNode.label === 'MESSAGE') {
+                console.log(`[Bridge Daemon] Message node confirmed as MESSAGE`);
                 // Apply filters
                 if (filters.priority && messageNode.properties?.priority !== filters.priority) return null;
                 if (filters.senderFilter && !filters.senderFilter.includes(messageNode.properties?.from)) return null;
                 if (filters.taggedConcepts && !filters.taggedConcepts.some(c => (messageNode.properties?.taggedConcepts || []).includes(c))) return null;
                 if (filters.inReplyToFilter && !filters.inReplyToFilter.includes(messageNode.properties?.inReplyTo)) return null;
 
+                let fromIdentity = 'unknown';
+                for (const edge of edgesMap.values()) {
+                    if (edge.type === 'SENT_BY' && edge.source === messageNode.id) {
+                        fromIdentity = edge.target;
+                        break;
+                    }
+                }
+                if (fromIdentity === 'unknown') {
+                    const stmt = db.prepare("SELECT target FROM Edges WHERE source = ? AND type = 'SENT_BY' LIMIT 1");
+                    const row = stmt.get(messageNode.id);
+                    if (row) fromIdentity = row.target;
+                }
+
                 return {
                     type: 'message',
                     messageId: messageNode.id,
-                    from: messageNode.properties?.from,
+                    from: fromIdentity,
                     subject: messageNode.properties?.subject,
                     priority: messageNode.properties?.priority || 'normal',
                     logId: trace.log_id
@@ -169,8 +185,10 @@ function queueEvent(subscription, eventPayload) {
         const windowMs = coalesceSeconds * 1000;
 
         if (windowMs === 0) {
+            console.log(`[Bridge Daemon] Flushing immediately for ${subId}`);
             flushSubscription(subId);
         } else {
+            console.log(`[Bridge Daemon] Setting timer for ${subId} (${windowMs}ms)`);
             coalesceState[subId].timer = setTimeout(() => {
                 flushSubscription(subId);
             }, windowMs);
@@ -182,6 +200,7 @@ function queueEvent(subscription, eventPayload) {
  * Flushes the queue for a subscription, building the digest and invoking the harness adapter.
  */
 async function flushSubscription(subId) {
+    console.log(`[Bridge Daemon] flushSubscription called for ${subId}`);
     const state = coalesceState[subId];
     if (!state) return;
 
@@ -203,20 +222,20 @@ async function flushSubscription(subId) {
     let breakdown = '';
     if (messages.length > 0) {
         const latest = messages[messages.length - 1];
-        breakdown += `\\n- ${messages.length} new messages (latest: "${latest.subject}" from ${latest.from})`;
+        breakdown += `\n- ${messages.length} new messages (latest: "${latest.subject}" from ${latest.from})`;
     }
     if (tasks.length > 0) {
         const latest = tasks[tasks.length - 1];
-        breakdown += `\\n- ${tasks.length} task transitions (latest: ${latest.newState} on task ${latest.taskId})`;
+        breakdown += `\n- ${tasks.length} task transitions (latest: ${latest.newState} on task ${latest.taskId})`;
     }
     if (permissions.length > 0) {
         const latest = permissions[permissions.length - 1];
-        breakdown += `\\n- ${permissions.length} permissions granted (latest: ${latest.scope} by ${latest.grantedBy})`;
+        breakdown += `\n- ${permissions.length} permissions granted (latest: ${latest.scope} by ${latest.grantedBy})`;
     }
 
     const windowDuration = Date.now() - windowStart;
     
-    const digest = `[WAKE] ${N} events for ${identity}: ${breakdown}\\n\\nSubscription: ${subId}\\nWindow: ${windowDuration}ms`;
+    const digest = `[WAKE] ${N} events for ${identity}: ${breakdown}\n\nSubscription: ${subId}\nWindow: ${windowDuration}ms`;
     
     // Delivery to per-harness adapter
     await deliverDigest(subscription, digest);
@@ -249,16 +268,40 @@ async function deliverDigest(subscription, digest) {
             await spawnAsync('tmux', ['send-keys', '-t', tmuxSession, digest, 'C-m']);
             console.log(`[Bridge Daemon] Delivered ${subscription.id} via tmux to session ${tmuxSession}`);
         } else if (adapter === 'osascript') {
+            const appName = meta.appName || 'Claude';
+            const tabShortcut = meta.tabShortcut !== undefined ? meta.tabShortcut : '3';
+            
             const osascriptArgs = [
                 '-e', 'on run argv',
-                '-e', '  tell application "Claude" to activate',
-                '-e', '  tell application "System Events" to keystroke (item 1 of argv)',
-                '-e', '  tell application "System Events" to key code 36',
+                '-e', '  set savedClipboard to the clipboard',
+                '-e', '  set the clipboard to (item 1 of argv)',
+                '-e', `  tell application "${appName}" to activate`,
+                '-e', '  delay 0.5',
+                '-e', '  tell application "System Events"',
+                '-e', `    tell process "${appName}"`,
+                '-e', '      set frontmost to true',
+                '-e', '      delay 0.5'
+            ];
+
+            if (tabShortcut) {
+                osascriptArgs.push('-e', `      keystroke "${tabShortcut}" using command down`);
+                osascriptArgs.push('-e', '      delay 0.5');
+            }
+
+            osascriptArgs.push(
+                '-e', '      keystroke "v" using command down',
+                '-e', '      delay 0.5',
+                '-e', '      key code 36',
+                '-e', '    end tell',
+                '-e', '  end tell',
+                '-e', '  delay 0.5',
+                '-e', '  set the clipboard to savedClipboard',
                 '-e', 'end run',
                 digest
-            ];
+            );
+
             await spawnAsync('osascript', osascriptArgs);
-            console.log(`[Bridge Daemon] Delivered ${subscription.id} via osascript`);
+            console.log(`[Bridge Daemon] Delivered ${subscription.id} via osascript to ${appName}`);
         } else if (adapter === 'test') {
             console.log(`[Bridge Daemon Test Adapter] Delivered ${subscription.id}: ${digest}`);
         } else {


### PR DESCRIPTION
Resolves #10391

## Summary

This PR finalizes the Phase 3 Wake Substrate, establishing reliable bidirectional wake notifications between the Gemini and Claude agents across different IDE harnesses (Antigravity and Claude Code).

## Key Changes
- **Dynamic Adapter Dispatching**: Refactored the `osascript` adapter in `bridge-daemon.mjs` to dynamically target applications based on `appName` and `tabShortcut` defined in the subscription's `harnessTargetMetadata`. This removes the hardcoded 'Claude' binding and allows seamless targeting of the Antigravity harness.
- **Identity Resolution Fix**: Implemented a fallback SQL query (`SELECT target FROM Edges WHERE source = ? AND type = 'SENT_BY' LIMIT 1`) inside the daemon to reliably resolve the sender's identity when generating the wake digest, fixing instances where the identity appeared as `undefined`.
- **Formatting Hygiene**: Switched from escaped newlines (`\\n`) to literal newlines (`\n`) in the digest template literal, ensuring proper multiline rendering in the target agent's UI.
- **Atomic Clipboard Injection**: Replaced slow, character-by-character keystroke simulation in the `osascript` adapter with a reliable, atomic clipboard injection (`Cmd+V`) pattern, coupled with configurable delays, to prevent race conditions during UI focus shifts.

## Verification
- Verified end-to-end delivery of multiline payloads from Gemini (Antigravity) to Claude (tmux) and vice-versa.
- Confirmed that Antigravity successfully receives clipboard injections followed by a simulated `Enter` keystroke to trigger auto-submission.
