### PR TITLE
feat(memory-core): integrate wake pump with coalescing engine (#10388)

### DIFF
--- a/ai/mcp/server/memory-core/Server.mjs
+++ b/ai/mcp/server/memory-core/Server.mjs
@@ -13,7 +13,7 @@ import AuthMiddleware                                  from '../shared/services/
 import RequestContextService                           from '../shared/services/RequestContextService.mjs';
 import StdioIdentityResolver                           from '../shared/services/StdioIdentityResolver.mjs';
 import WakeSubscriptionService                         from './services/WakeSubscriptionService.mjs';
-
+import CoalescingEngineService                         from './services/CoalescingEngineService.mjs';
 /**
  * @summary The Memory Core MCP Server application.
  *
@@ -91,7 +91,8 @@ class Server extends Base {
             }
         });
 
-        await WakeSubscriptionService.setMcpServer(this.mcpServer);
+        await WakeSubscriptionService.init();
+        CoalescingEngineService.setMcpServer(this.mcpServer);
 
         // 3. Setup Request Handlers
         this.setupRequestHandlers();

--- a/ai/mcp/server/memory-core/services/CoalescingEngineService.mjs
+++ b/ai/mcp/server/memory-core/services/CoalescingEngineService.mjs
@@ -64,6 +64,12 @@ class CoalescingEngineService extends Base {
     maxWindowSeconds = 300
 
     /**
+     * @member {McpServer|null} mcpServer=null
+     * @protected
+     */
+    mcpServer = null
+
+    /**
      * Per-subscription queue + timer state.
      * Structure: `Map<subscriptionId, {queue: Object[], timer: ?TimerId, subscription: Object, windowStart: ?Date}>`
      * Populated lazily on first enqueue; cleared on flush.
@@ -71,6 +77,14 @@ class CoalescingEngineService extends Base {
      * @protected
      */
     coalesceState = new Map()
+
+    /**
+     * Injects the MCP server instance for push notifications.
+     * @param {McpServer} mcpServer
+     */
+    setMcpServer(mcpServer) {
+        this.mcpServer = mcpServer;
+    }
 
     /**
      * Enqueue an event for coalesced delivery to a subscription. Starts (or extends)
@@ -256,11 +270,18 @@ class CoalescingEngineService extends Base {
         }
 
         if (target === 'mcp-notifications') {
-            // Shape A's MCP notification emit-point will be wired by #10358. Until then,
-            // log the digest so it is observable but undelivered. Once Shape A lands,
-            // this branch routes through its emit surface (e.g., MCP server's session-handle
-            // notification dispatcher) without touching this engine's contract.
-            logger.info(`[CoalescingEngine] Shape A digest pending #10358 emit-wiring for ${subscription.id}: ${digest.payload.totalEvents} events.`);
+            if (!this.mcpServer) {
+                logger.warn(`[CoalescingEngine] mcp-notifications digest dropped — no mcpServer registered: ${subscription.id}`);
+                return;
+            }
+            try {
+                await this.mcpServer.notification({
+                    method: 'notifications/message',
+                    params: digest
+                });
+            } catch (e) {
+                logger.error(`[CoalescingEngine] mcp-notifications dispatch failed for ${subscription.id}: ${e.message}`);
+            }
             return;
         }
 

--- a/ai/mcp/server/memory-core/services/CoalescingEngineService.mjs
+++ b/ai/mcp/server/memory-core/services/CoalescingEngineService.mjs
@@ -79,7 +79,9 @@ class CoalescingEngineService extends Base {
     coalesceState = new Map()
 
     /**
-     * Injects the MCP server instance for push notifications.
+     * @summary Injects the MCP server instance for push notifications.
+     * @description Provides the engine with the handle needed to dispatch
+     * notifications (Shape A) back to the client. Should be populated at boot.
      * @param {McpServer} mcpServer
      */
     setMcpServer(mcpServer) {

--- a/ai/mcp/server/memory-core/services/WakeSubscriptionService.mjs
+++ b/ai/mcp/server/memory-core/services/WakeSubscriptionService.mjs
@@ -3,6 +3,7 @@ import Base                   from '../../../../../src/core/Base.mjs';
 import GraphService           from './GraphService.mjs';
 import RequestContextService  from '../../shared/services/RequestContextService.mjs';
 import logger                 from '../logger.mjs';
+import CoalescingEngineService from './CoalescingEngineService.mjs';
 
 /**
  * @summary Service for managing graph-resident WAKE_SUBSCRIPTION nodes and the
@@ -64,16 +65,27 @@ class WakeSubscriptionService extends Base {
     subscriptionCache = new Map()
 
     /**
-     * @member {McpServer|null} mcpServer=null
-     * @protected
-     */
-    mcpServer = null
-
-    /**
      * @member {Number} liveCursor=0
      * @protected
      */
     liveCursor = 0
+
+    /**
+     * Sets the initial live cursor to the current graph log head to prevent
+     * replaying historical events on boot.
+     */
+    async init() {
+        await GraphService.ready();
+        const storage = GraphService.db?.storage;
+        if (storage?.db) {
+            try {
+                const row = storage.db.prepare('SELECT MAX(log_id) as maxId FROM GraphLog').get();
+                this.liveCursor = row.maxId || 0;
+            } catch (e) {
+                logger.warn('[WakeSubscription] Failed to read max log_id on init', e);
+            }
+        }
+    }
 
     /**
      * Guard against re-entrant calls to pump()
@@ -83,34 +95,12 @@ class WakeSubscriptionService extends Base {
     _pumping = false
 
     /**
-     * Injects the MCP server instance for push notifications.
-     * Sets the initial live cursor to the current graph log head to prevent
-     * replaying historical events on boot.
-     * @param {McpServer} mcpServer
-     */
-    async setMcpServer(mcpServer) {
-        this.mcpServer = mcpServer;
-        await GraphService.ready();
-        const storage = GraphService.db?.storage;
-        if (storage?.db) {
-            // Get current log_id to start pumping from now
-            try {
-                const row = storage.db.prepare('SELECT MAX(log_id) as maxId FROM GraphLog').get();
-                this.liveCursor = row.maxId || 0;
-            } catch (e) {
-                logger.warn('[WakeSubscription] Failed to read max log_id on setMcpServer', e);
-            }
-        }
-    }
-
-    /**
      * Evaluates recent GraphLog deltas and pushes matching events to connected
      * Shape A (MCP notification) clients. Intended to be called by mutation paths
      * (e.g. MailboxService, PermissionService) for low-latency delivery.
      * @returns {Promise<void>}
      */
     async pump() {
-        if (!this.mcpServer) return;
         if (this._pumping) return;
         
         try {
@@ -142,31 +132,19 @@ class WakeSubscriptionService extends Base {
                 return;
             }
 
-            const eventsToEmit = [];
             for (const sub of activeSubs) {
                 for (const edgeRef of delta.invalidEdges) {
                     const logId = this._getEntityLogId(edgeRef.id) || delta.lastLogId;
                     const matched = this._evaluateEdgeAgainstSubscription(edgeRef, sub, logId);
-                    if (matched) eventsToEmit.push(matched);
+                    if (matched) CoalescingEngineService.enqueue(sub, matched);
                 }
                 for (const nodeId of delta.invalidNodes) {
                     const logId = this._getEntityLogId(nodeId) || delta.lastLogId;
                     const matched = this._evaluateNodeAgainstSubscription(nodeId, sub, logId);
-                    if (matched) eventsToEmit.push(matched);
+                    if (matched) CoalescingEngineService.enqueue(sub, matched);
                 }
             }
 
-            for (const event of eventsToEmit) {
-                try {
-                    // ADR 0002 §6.1 specifies the method name is 'notifications/message'
-                    await this.mcpServer.notification({
-                        method: 'notifications/message',
-                        params: event
-                    });
-                } catch (e) {
-                    logger.error('[WakeSubscription] Failed to emit MCP notification', e);
-                }
-            }
             
             this.liveCursor = delta.lastLogId;
         } catch (e) {

--- a/test/playwright/unit/ai/mcp/server/memory-core/services/CoalescingEngineService.spec.mjs
+++ b/test/playwright/unit/ai/mcp/server/memory-core/services/CoalescingEngineService.spec.mjs
@@ -163,12 +163,25 @@ test.describe('CoalescingEngineService', () => {
         expect(deliverCalls[0].subscription.properties.harnessTargetMetadata.url).toBe('https://example.com/wake');
     });
 
-    test('does NOT dispatch mcp-notifications subscriptions until #10358 wires the emit-point', async () => {
+    test('dispatches mcp-notifications subscriptions via mcpServer.notification', async () => {
+        let notificationCalledWith = null;
+        CoalescingEngineService.setMcpServer({
+            notification: async (args) => {
+                notificationCalledWith = args;
+            }
+        });
+
         const sub = buildSubscription({harnessTarget: 'mcp-notifications', harnessTargetMetadata: {coalesceWindow: 0.05}});
         CoalescingEngineService.enqueue(sub, buildEnvelope('wake/sent_to_me', {messageId: 'M1'}));
         await new Promise(resolve => setTimeout(resolve, 100));
 
-        expect(deliverCalls.length).toBe(0);
+        expect(notificationCalledWith).not.toBeNull();
+        expect(notificationCalledWith.method).toBe('notifications/message');
+        expect(notificationCalledWith.params.eventType).toBe('wake/digest');
+        expect(notificationCalledWith.params.payload.totalEvents).toBe(1);
+
+        // cleanup
+        CoalescingEngineService.setMcpServer(null);
     });
 
     test('does NOT dispatch bridge-daemon subscriptions (Shape C handles its own coalescing)', async () => {

--- a/test/playwright/unit/ai/mcp/server/memory-core/services/WakeSubscriptionService.spec.mjs
+++ b/test/playwright/unit/ai/mcp/server/memory-core/services/WakeSubscriptionService.spec.mjs
@@ -27,7 +27,7 @@ import RequestContextService from '../../../../../../../../ai/mcp/server/shared/
 
 test.describe('Neo.ai.mcp.server.memory-core.services.WakeSubscriptionService', () => {
     test.describe.configure({mode: 'serial'});
-    let WakeSubscriptionService, GraphService, LifecycleService, originalAutoSave;
+    let WakeSubscriptionService, GraphService, LifecycleService, CoalescingEngineService, originalAutoSave;
     let dbPath;
 
     test.beforeAll(async () => {
@@ -39,6 +39,7 @@ test.describe('Neo.ai.mcp.server.memory-core.services.WakeSubscriptionService', 
 
         GraphService            = (await import('../../../../../../../../ai/mcp/server/memory-core/services/GraphService.mjs')).default;
         WakeSubscriptionService = (await import('../../../../../../../../ai/mcp/server/memory-core/services/WakeSubscriptionService.mjs')).default;
+        CoalescingEngineService = (await import('../../../../../../../../ai/mcp/server/memory-core/services/CoalescingEngineService.mjs')).default;
         LifecycleService        = (await import('../../../../../../../../ai/mcp/server/memory-core/services/lifecycle/SystemLifecycleService.mjs')).default;
 
         const aiConfig = (await import('../../../../../../../../ai/mcp/server/memory-core/config.mjs')).default;
@@ -369,10 +370,12 @@ test.describe('Neo.ai.mcp.server.memory-core.services.WakeSubscriptionService', 
 
         test.beforeEach(async () => {
             emittedEvents = [];
-            WakeSubscriptionService.setMcpServer(null); // Reset
+            emittedEvents = [];
+            CoalescingEngineService.setMcpServer(null);
+            CoalescingEngineService.clearAll();
         });
 
-        test('graceful no-op when no mcpServer is registered', async () => {
+        test('graceful no-op when CoalescingEngineService has no mcpServer registered', async () => {
             await RequestContextService.run({agentIdentityNodeId: '@alice'}, async () => {
                 await WakeSubscriptionService.subscribe({trigger: 'SENT_TO_ME', harnessTarget: 'mcp-notifications'});
             });
@@ -383,29 +386,50 @@ test.describe('Neo.ai.mcp.server.memory-core.services.WakeSubscriptionService', 
 
             // pump shouldn't fail and shouldn't emit
             await WakeSubscriptionService.pump();
+            await CoalescingEngineService.flushAll();
             expect(emittedEvents.length).toBe(0);
         });
 
-        test('emits notifications/message for matching mcp-notifications subscription', async () => {
-            WakeSubscriptionService.setMcpServer(mockMcpServer);
+        test('emits digest for matching mcp-notifications subscription after pump -> enqueue -> flush', async () => {
+            CoalescingEngineService.setMcpServer(mockMcpServer);
 
             await RequestContextService.run({agentIdentityNodeId: '@alice'}, async () => {
-                await WakeSubscriptionService.subscribe({trigger: 'SENT_TO_ME', harnessTarget: 'mcp-notifications'});
+                // Set a small coalesceWindow so it would naturally flush, but we will force flush
+                await WakeSubscriptionService.subscribe({
+                    trigger: 'SENT_TO_ME', 
+                    harnessTarget: 'mcp-notifications',
+                    harnessTargetMetadata: { coalesceWindow: 0.05 }
+                });
             });
 
             // Make a mutation
             GraphService.upsertNode({id: 'MSG:2', type: 'MESSAGE', properties: {from: '@bob', subject: 'hello'}});
             GraphService.linkNodes('MSG:2', '@alice', 'SENT_TO', 1.0);
 
+            let enqueued = false;
+            const originalEnqueue = CoalescingEngineService.enqueue;
+            CoalescingEngineService.enqueue = function(...args) {
+                enqueued = true;
+                return originalEnqueue.apply(this, args);
+            };
+
             await WakeSubscriptionService.pump();
+
+            // Wait for coalescing engine to dispatch
+            await CoalescingEngineService.flushAll();
+            
+            CoalescingEngineService.enqueue = originalEnqueue;
+            
             expect(emittedEvents.length).toBe(1);
             expect(emittedEvents[0].method).toBe('notifications/message');
-            expect(emittedEvents[0].params.eventType).toBe('wake/sent_to_me');
-            expect(emittedEvents[0].params.payload.from).toBe('@bob');
+            expect(emittedEvents[0].params.eventType).toBe('wake/digest');
+            expect(emittedEvents[0].params.payload.totalEvents).toBe(1);
+            expect(emittedEvents[0].params.payload.breakdown.sent_to_me.count).toBe(1);
+            expect(emittedEvents[0].params.payload.breakdown.sent_to_me.latest.from).toBe('@bob');
         });
 
         test('does not emit for non-matching subscription', async () => {
-            WakeSubscriptionService.setMcpServer(mockMcpServer);
+            CoalescingEngineService.setMcpServer(mockMcpServer);
 
             await RequestContextService.run({agentIdentityNodeId: '@alice'}, async () => {
                 await WakeSubscriptionService.subscribe({
@@ -420,11 +444,12 @@ test.describe('Neo.ai.mcp.server.memory-core.services.WakeSubscriptionService', 
             GraphService.linkNodes('MSG:3', '@alice', 'SENT_TO', 1.0);
 
             await WakeSubscriptionService.pump();
+            await CoalescingEngineService.flushAll();
             expect(emittedEvents.length).toBe(0);
         });
 
         test('advances liveCursor per delta.lastLogId', async () => {
-            WakeSubscriptionService.setMcpServer(mockMcpServer);
+            CoalescingEngineService.setMcpServer(mockMcpServer);
             const initialCursor = WakeSubscriptionService.liveCursor;
 
             GraphService.upsertNode({id: 'MSG:4', type: 'MESSAGE', properties: {}});
@@ -434,7 +459,7 @@ test.describe('Neo.ai.mcp.server.memory-core.services.WakeSubscriptionService', 
         });
 
         test('warms cache with active mcp-notifications subscriptions on first call', async () => {
-            WakeSubscriptionService.setMcpServer(mockMcpServer);
+            CoalescingEngineService.setMcpServer(mockMcpServer);
 
             let subId;
             await RequestContextService.run({agentIdentityNodeId: '@alice'}, async () => {
@@ -450,6 +475,7 @@ test.describe('Neo.ai.mcp.server.memory-core.services.WakeSubscriptionService', 
             GraphService.linkNodes('MSG:5', '@alice', 'SENT_TO', 1.0);
 
             await WakeSubscriptionService.pump();
+            await CoalescingEngineService.flushAll();
 
             // Should have lazily warmed the cache and successfully emitted
             expect(WakeSubscriptionService.subscriptionCache.has(subId)).toBe(true);
@@ -457,7 +483,7 @@ test.describe('Neo.ai.mcp.server.memory-core.services.WakeSubscriptionService', 
         });
 
         test('skips bridge-daemon / a2a-webhook / disabled targets', async () => {
-            WakeSubscriptionService.setMcpServer(mockMcpServer);
+            CoalescingEngineService.setMcpServer(mockMcpServer);
 
             await RequestContextService.run({agentIdentityNodeId: '@alice'}, async () => {
                 await WakeSubscriptionService.subscribe({trigger: 'SENT_TO_ME', harnessTarget: 'bridge-daemon'});
@@ -469,12 +495,13 @@ test.describe('Neo.ai.mcp.server.memory-core.services.WakeSubscriptionService', 
             GraphService.linkNodes('MSG:6', '@alice', 'SENT_TO', 1.0);
 
             await WakeSubscriptionService.pump();
+            await CoalescingEngineService.flushAll();
             // None of the subscriptions target mcp-notifications
             expect(emittedEvents.length).toBe(0);
         });
 
         test('concurrent pump() invocations do not double-emit', async () => {
-            WakeSubscriptionService.setMcpServer(mockMcpServer);
+            CoalescingEngineService.setMcpServer(mockMcpServer);
 
             await RequestContextService.run({agentIdentityNodeId: '@alice'}, async () => {
                 await WakeSubscriptionService.subscribe({trigger: 'SENT_TO_ME', harnessTarget: 'mcp-notifications'});
@@ -488,6 +515,8 @@ test.describe('Neo.ai.mcp.server.memory-core.services.WakeSubscriptionService', 
                 WakeSubscriptionService.pump(),
                 WakeSubscriptionService.pump()
             ]);
+            
+            await CoalescingEngineService.flushAll();
 
             // If the race condition was present, both might emit the same event
             expect(emittedEvents.length).toBe(1);

--- a/test/playwright/unit/ai/mcp/server/memory-core/services/WakeSubscriptionService.spec.mjs
+++ b/test/playwright/unit/ai/mcp/server/memory-core/services/WakeSubscriptionService.spec.mjs
@@ -370,7 +370,6 @@ test.describe('Neo.ai.mcp.server.memory-core.services.WakeSubscriptionService', 
 
         test.beforeEach(async () => {
             emittedEvents = [];
-            emittedEvents = [];
             CoalescingEngineService.setMcpServer(null);
             CoalescingEngineService.clearAll();
         });
@@ -397,8 +396,7 @@ test.describe('Neo.ai.mcp.server.memory-core.services.WakeSubscriptionService', 
                 // Set a small coalesceWindow so it would naturally flush, but we will force flush
                 await WakeSubscriptionService.subscribe({
                     trigger: 'SENT_TO_ME', 
-                    harnessTarget: 'mcp-notifications',
-                    harnessTargetMetadata: { coalesceWindow: 0.05 }
+                    harnessTarget: 'mcp-notifications'
                 });
             });
 
@@ -406,12 +404,7 @@ test.describe('Neo.ai.mcp.server.memory-core.services.WakeSubscriptionService', 
             GraphService.upsertNode({id: 'MSG:2', type: 'MESSAGE', properties: {from: '@bob', subject: 'hello'}});
             GraphService.linkNodes('MSG:2', '@alice', 'SENT_TO', 1.0);
 
-            let enqueued = false;
             const originalEnqueue = CoalescingEngineService.enqueue;
-            CoalescingEngineService.enqueue = function(...args) {
-                enqueued = true;
-                return originalEnqueue.apply(this, args);
-            };
 
             await WakeSubscriptionService.pump();
 


### PR DESCRIPTION
Resolves #10388

Integrated the WakeSubscriptionService `pump()` with the `CoalescingEngineService` to enable token-economy throttling. The coalescing engine now acts as the central router for Shape A (mcp-notifications) events, batching updates and emitting them as digests rather than independent bursts.

## Deltas from ticket
- The `mcpServer` dependency has been completely extracted from `WakeSubscriptionService`. Instead of `WakeSubscriptionService` directly interacting with the MCP server, it now strictly queues events via `CoalescingEngineService.enqueue()`. The engine handles the delivery.
- Added an `init()` method to `WakeSubscriptionService` to establish the `liveCursor` at boot, decoupling it from the removed `setMcpServer` hook.

## Test Evidence
- Rewrote `WakeSubscriptionService.spec.mjs` unit tests to leverage the `CoalescingEngineService` mock pipeline, correctly verifying that `flushAll()` emits batched digests.
- `npx playwright test test/playwright/unit/ai/mcp/server/memory-core/services/WakeSubscriptionService.spec.mjs` — all 22 tests passing.

## Post-Merge Validation
- [ ] Monitor Memory Core logs in live swarm tests to verify that burst `SENT_TO_ME` edges successfully throttle into a single digest delivery.

Authored by Gemini 3.1 Pro (Antigravity). Session 09444f9b-9ae1-4d9a-81a4-02e885870417.