### PR TITLE
feat(github-workflow): enrich healthcheck with notificationPreview (#10218)

### DIFF
--- a/ai/mcp/server/github-workflow/openapi.yaml
+++ b/ai/mcp/server/github-workflow/openapi.yaml
@@ -1088,6 +1088,30 @@ components:
               type: array
               items:
                 type: string
+        notificationPreview:
+          type: object
+          description: A passive inbox preview of unread GitHub notifications. Present only if authenticated.
+          properties:
+            unreadCount:
+              type: integer
+              description: Total number of unread notifications.
+              example: 3
+            latest:
+              type: array
+              description: The 5 most recent unread notifications.
+              items:
+                type: object
+                properties:
+                  id:
+                    type: string
+                  reason:
+                    type: string
+                  type:
+                    type: string
+                  title:
+                    type: string
+                  url:
+                    type: string
 
     Label:
       type: object

--- a/ai/mcp/server/github-workflow/services/HealthService.mjs
+++ b/ai/mcp/server/github-workflow/services/HealthService.mjs
@@ -361,6 +361,26 @@ class HealthService extends Base {
             payload.status = 'unhealthy';
             payload.githubCli.details.push(authCheck.error);
             logger.info('[HealthService] gh-status: unauthenticated');
+        } else {
+            // Step 3: Enrich with Notifications (Passive Inbox) if authenticated
+            try {
+                const { stdout } = await execAsync('gh api notifications');
+                const notifications = JSON.parse(stdout);
+                
+                payload.notificationPreview = {
+                    unreadCount: notifications.length,
+                    latest: notifications.slice(0, 5).map(n => ({
+                        id: n.id,
+                        reason: n.reason,
+                        type: n.subject?.type,
+                        title: n.subject?.title,
+                        url: n.subject?.url
+                    }))
+                };
+            } catch (e) {
+                logger.warn(`[HealthService] Failed to fetch notifications for preview: ${e.message}`);
+                // Don't fail the healthcheck if notifications fail, just omit the preview
+            }
         }
 
         // If we made it here with no issues, everything is healthy

--- a/ai/mcp/server/github-workflow/services/HealthService.mjs
+++ b/ai/mcp/server/github-workflow/services/HealthService.mjs
@@ -366,10 +366,11 @@ class HealthService extends Base {
             try {
                 const { stdout } = await execAsync('gh api notifications');
                 const notifications = JSON.parse(stdout);
+                const mentions = notifications.filter(n => n.reason === 'mention');
                 
                 payload.notificationPreview = {
-                    unreadCount: notifications.length,
-                    latest: notifications.slice(0, 5).map(n => ({
+                    unreadCount: mentions.length,
+                    latest: mentions.slice(0, 5).map(n => ({
                         id: n.id,
                         reason: n.reason,
                         type: n.subject?.type,


### PR DESCRIPTION
Authored by Gemini 3.1 Pro (Antigravity). Session 7a2db6c6-5b4d-4870-91ea-9dfcbd4514ec. Resolves #10218. Added gh api notifications to healthcheck for passive inbox capability.