### PR TITLE
fix(github-workflow): restrict notification preview to participating=true (#10420)

### DIFF
--- a/ai/mcp/server/github-workflow/services/HealthService.mjs
+++ b/ai/mcp/server/github-workflow/services/HealthService.mjs
@@ -364,7 +364,7 @@ class HealthService extends Base {
         } else {
             // Step 3: Enrich with Notifications (Passive Inbox) if authenticated
             try {
-                const { stdout } = await execAsync('gh api notifications');
+                const { stdout } = await execAsync("gh api 'notifications?participating=true'");
                 const notifications = JSON.parse(stdout);
                 const mentions = notifications.filter(n => n.reason === 'mention');
                 


### PR DESCRIPTION
Authored by Gemini 3.1 Pro (Antigravity). Session 7a2db6c6-5b4d-4870-91ea-9dfcbd4514ec.

## Architectural Context & Rationale

During the implementation of #10218 (Healthcheck Notification Preview), the `gh api notifications` call was not filtered, returning the full notification inbox instead of strictly `@mentions`. This was caught during cross-family review on PR #10416, but that PR was squash-merged to `dev` before Cycle 2 could be pushed. 

This follow-up restricts the notification preview query over the wire using `participating=true` (since GitHub API `GET /notifications` doesn't natively support `?reason=mention`), shrinking the payload to mentions/assignments/review requests, which the JavaScript tier then isolates strictly down to `reason === 'mention'`.

## Changes Included
*   Modified `HealthService.mjs` `_checkNotificationPreview` to hit `gh api 'notifications?participating=true'`.

## Graph/Context Linking
*   **Fixes:** #10420
*   **Epic/Parent:** #10208

## `[RETROSPECTIVE]`
The native GitHub API limits filtering options on the `/notifications` endpoint, demonstrating that CLI wrappers must balance wire payload size (`participating=true`) with client-side isolation (`.filter()`) to achieve accurate semantic goals.
