### PR TITLE
feat(bridge-daemon): persist diagnostic logs to disk (#10419)

### DIFF
--- a/ai/scripts/bridge-daemon.mjs
+++ b/ai/scripts/bridge-daemon.mjs
@@ -1,24 +1,139 @@
+/**
+ * @summary Bridge daemon for Neo.mjs Phase 3 wake substrate (Shape C delivery).
+ *
+ * Polls SQLite GraphLog for new SENT_TO_ME edges, coalesces matching events
+ * per active WAKE_SUBSCRIPTION, and delivers digests via osascript (macOS) or
+ * tmux. Designed to run as a long-lived background process; one instance
+ * per `.neo-ai-data/wake-daemon/` directory (singleton-enforced via PID lock
+ * per #10422 / #10423).
+ *
+ * **Diagnostic log persistence (per #10419):**
+ * All informational + error lines are written to BOTH stdout (live terminal
+ * observability) AND `.neo-ai-data/wake-daemon/bridge.log` (persistent audit
+ * trail for post-hoc wake-failure investigation, e.g. Bug 2 of #10410, the
+ * Leonard demo failure, future osascript silent errors).
+ *
+ * **Rotation:** Daily rotation via `.YYYY-MM-DD` suffix on the previous day's
+ * file; archive files older than `LOG_RETENTION_DAYS` are pruned at startup.
+ *
+ * **Line format:** `[ISO-timestamp] [PID:NNN] [LEVEL] message` — greppable
+ * post-hoc, per-line correlation with daemon process and event chronology.
+ *
+ * @see #10419 (this PR — diagnostic substrate)
+ * @see #10410 Bug 2 (duplicate-wake delivery — original motivation; root-cause
+ *      diagnosis depends on persisted log lines surviving terminal scrollback)
+ * @see #10423 (PID-lock singleton enforcement; PID transitions are now logged)
+ */
 import fs from 'fs-extra';
 import path from 'path';
 import { spawn, execSync } from 'child_process';
-import { 
-    initializeDatabase, 
-    getLastSyncId, 
-    getActiveShapeCSubscriptions, 
-    getGraphLogEntries, 
-    getNodesData, 
-    getEdgesData, 
-    getDbNode 
+import {
+    initializeDatabase,
+    getLastSyncId,
+    getActiveShapeCSubscriptions,
+    getGraphLogEntries,
+    getNodesData,
+    getEdgesData,
+    getDbNode
 } from './bridge-daemon-queries.mjs';
 
-const DB_PATH = process.env.NEO_AI_DB_PATH || '.neo-ai-data/sqlite/memory-core-graph.sqlite';
-const DAEMON_DATA_DIR = process.env.NEO_AI_DAEMON_DIR || '.neo-ai-data/wake-daemon';
-const STATE_FILE = path.join(DAEMON_DATA_DIR, 'lastSyncId');
-const POLL_INTERVAL_MS = 3000;
+const DB_PATH                  = process.env.NEO_AI_DB_PATH || '.neo-ai-data/sqlite/memory-core-graph.sqlite';
+const DAEMON_DATA_DIR          = process.env.NEO_AI_DAEMON_DIR || '.neo-ai-data/wake-daemon';
+const STATE_FILE               = path.join(DAEMON_DATA_DIR, 'lastSyncId');
+const LOG_FILE                 = path.join(DAEMON_DATA_DIR, 'bridge.log');
+const LOG_RETENTION_DAYS       = 30;
+const POLL_INTERVAL_MS         = 3000;
 const DEFAULT_COALESCE_WINDOW_MS = 30000; // 30 seconds
 
 // Ensure daemon data dir exists
 fs.ensureDirSync(DAEMON_DATA_DIR);
+
+/**
+ * Rotates `bridge.log` if its mtime falls on a calendar day different from today's.
+ * Renames the previous-day file to `bridge.log.YYYY-MM-DD` so the active file always
+ * holds the current day's lines. Best-effort: failures surface to stderr and the
+ * daemon continues (log integrity is not allowed to gate daemon liveness).
+ * @protected
+ */
+function rotateLogIfNewDay() {
+    if (!fs.existsSync(LOG_FILE)) return;
+    try {
+        const stats    = fs.statSync(LOG_FILE);
+        const fileDay  = stats.mtime.toISOString().split('T')[0];
+        const todayDay = new Date().toISOString().split('T')[0];
+        if (fileDay !== todayDay) {
+            const archivePath = `${LOG_FILE}.${fileDay}`;
+            fs.renameSync(LOG_FILE, archivePath);
+        }
+    } catch (e) {
+        // Log rotation failure is non-fatal; surface to stderr only
+        process.stderr.write(`[Bridge Daemon] Log rotation failed: ${e.message}\n`);
+    }
+}
+
+/**
+ * Prunes archived log files (`bridge.log.*`) older than `LOG_RETENTION_DAYS` from
+ * `DAEMON_DATA_DIR`. Runs once at daemon startup. Best-effort: per-file unlink
+ * failures are silently swallowed (best to lose a stale archive than gate startup).
+ * @protected
+ */
+function pruneOldLogs() {
+    const cutoff = Date.now() - LOG_RETENTION_DAYS * 24 * 60 * 60 * 1000;
+    try {
+        const entries = fs.readdirSync(DAEMON_DATA_DIR);
+        for (const entry of entries) {
+            // Match `bridge.log.YYYY-MM-DD` archive files only — leave `bridge.log` alone
+            if (!entry.startsWith('bridge.log.') || entry === 'bridge.log') continue;
+            const fullPath = path.join(DAEMON_DATA_DIR, entry);
+            try {
+                const stats = fs.statSync(fullPath);
+                if (stats.mtime.getTime() < cutoff) {
+                    fs.unlinkSync(fullPath);
+                }
+            } catch (e) {
+                // Per-entry failure is non-fatal
+            }
+        }
+    } catch (e) {
+        // Directory listing failure is non-fatal
+    }
+}
+
+/**
+ * Persistent + console log writer. Writes a single line to BOTH stdout (live
+ * terminal observability) AND the persistent `bridge.log` file (post-hoc audit
+ * trail). Format: `[ISO-timestamp] [PID:NNN] [LEVEL] message`. Daily rotation
+ * is checked on every call.
+ *
+ * Failures on file-write are silently swallowed — daemon liveness MUST NOT
+ * depend on log integrity. Failures on console-write propagate naturally.
+ *
+ * @param {String} level   One of 'INFO' | 'ERROR' (used to dispatch console.log vs console.error and to embed in the line prefix).
+ * @param {String} message The message body. Should NOT include a trailing newline — `writeLog` appends one.
+ * @protected
+ */
+function writeLog(level, message) {
+    rotateLogIfNewDay();
+    const timestamp = new Date().toISOString();
+    const line      = `[${timestamp}] [PID:${process.pid}] [${level}] ${message}`;
+
+    // File write — best-effort, never throws
+    try {
+        fs.appendFileSync(LOG_FILE, line + '\n', 'utf8');
+    } catch (e) {
+        // Best-effort; daemon must stay alive even if file-write fails
+    }
+
+    // Console write — preserves live terminal observability
+    if (level === 'ERROR') {
+        console.error(line);
+    } else {
+        console.log(line);
+    }
+}
+
+// One-shot prune at startup; reaper for archived logs older than retention window
+pruneOldLogs();
 
 const PID_FILE = path.join(DAEMON_DATA_DIR, 'bridge-daemon.pid');
 
@@ -42,14 +157,14 @@ async function enforceSingleton() {
                         // Use ps -p to verify the PID hasn't been recycled by a non-daemon process
                         const cmd = execSync(`ps -p ${oldPid} -o command=`).toString().trim();
                         if (cmd.includes('bridge-daemon.mjs')) {
-                            console.log(`[Bridge Daemon] Found existing instance (PID: ${oldPid}). Sending SIGTERM...`);
+                            writeLog('INFO', `[Bridge Daemon] Found existing instance (PID: ${oldPid}). Sending SIGTERM...`);
                             process.kill(oldPid, 'SIGTERM');
                         } else {
-                            console.log(`[Bridge Daemon] Stale PID file found. PID ${oldPid} used by a different process. Proceeding.`);
+                            writeLog('INFO', `[Bridge Daemon] Stale PID file found. PID ${oldPid} used by a different process. Proceeding.`);
                             isAlive = false; // We won't wait for it to exit
                         }
                     } catch (psErr) {
-                        console.log(`[Bridge Daemon] Could not verify process name. Sending SIGTERM to PID ${oldPid} to be safe...`);
+                        writeLog('INFO', `[Bridge Daemon] Could not verify process name. Sending SIGTERM to PID ${oldPid} to be safe...`);
                         process.kill(oldPid, 'SIGTERM');
                     }
                 }
@@ -67,7 +182,7 @@ async function enforceSingleton() {
                         }
                     }
                     if (alive) {
-                        console.log(`[Bridge Daemon] PID ${oldPid} did not exit after 3s. Escalating to SIGKILL...`);
+                        writeLog('INFO', `[Bridge Daemon] PID ${oldPid} did not exit after 3s. Escalating to SIGKILL...`);
                         try {
                             process.kill(oldPid, 'SIGKILL');
                         } catch (e) {}
@@ -79,7 +194,7 @@ async function enforceSingleton() {
                 } catch (e) {}
             }
         } catch (e) {
-            console.error('[Bridge Daemon] Failed to check existing PID file:', e);
+            writeLog('ERROR', `[Bridge Daemon] Failed to check existing PID file: ${e.message || e}`);
         }
     }
     
@@ -88,7 +203,7 @@ async function enforceSingleton() {
         fs.writeFileSync(PID_FILE, process.pid.toString(), { encoding: 'utf8', flag: 'wx' });
     } catch (e) {
         if (e.code === 'EEXIST') {
-            console.error(`[Bridge Daemon] Failed to claim PID file (EEXIST). Another instance started simultaneously. Exiting.`);
+            writeLog('ERROR', `[Bridge Daemon] Failed to claim PID file (EEXIST). Another instance started simultaneously. Exiting.`);
             process.exit(1);
         } else {
             throw e;
@@ -115,7 +230,7 @@ async function enforceSingleton() {
     process.on('SIGTERM', cleanup);
     process.on('exit', cleanup);
     process.on('uncaughtException', (err) => {
-        console.error('[Bridge Daemon] Uncaught exception:', err);
+        writeLog('ERROR', `[Bridge Daemon] Uncaught exception: ${err && err.stack ? err.stack : err}`);
         cleanup(); // Calls process.exit() automatically
     });
 }
@@ -173,7 +288,7 @@ async function pollLoop() {
             fs.writeFileSync(STATE_FILE, lastSyncId.toString(), 'utf8');
         }
     } catch (err) {
-        console.error('[Bridge Daemon] Error in poll loop:', err);
+        writeLog('ERROR', `[Bridge Daemon] Error in poll loop: ${err && err.stack ? err.stack : err}`);
     }
 
     setTimeout(pollLoop, POLL_INTERVAL_MS);
@@ -358,7 +473,7 @@ async function deliverDigest(subscription, digest) {
         if (adapter === 'tmux') {
             const tmuxSession = meta.tmuxSession || process.env.TMUX_SESSION || 'neo-agent';
             await spawnAsync('tmux', ['send-keys', '-t', tmuxSession, digest, 'C-m']);
-            console.log(`[Bridge Daemon] Delivered ${subscription.id} via tmux to session ${tmuxSession}`);
+            writeLog('INFO', `[Bridge Daemon] Delivered ${subscription.id} via tmux to session ${tmuxSession}`);
         } else if (adapter === 'osascript') {
             const appName = meta.appName || 'Claude';
             let tabShortcut = meta.tabShortcut;
@@ -442,14 +557,14 @@ async function deliverDigest(subscription, digest) {
             );
 
             await spawnAsync('osascript', osascriptArgs);
-            console.log(`[Bridge Daemon] Delivered ${subscription.id} via osascript to ${appName}`);
+            writeLog('INFO', `[Bridge Daemon] Delivered ${subscription.id} via osascript to ${appName}`);
         } else if (adapter === 'test') {
-            console.log(`[Bridge Daemon Test Adapter] Delivered ${subscription.id}: ${digest}`);
+            writeLog('INFO', `[Bridge Daemon Test Adapter] Delivered ${subscription.id}: ${digest}`);
         } else {
-            console.warn(`[Bridge Daemon] Unknown adapter '${adapter}' for subscription ${subscription.id}`);
+            writeLog('ERROR', `[Bridge Daemon] Unknown adapter '${adapter}' for subscription ${subscription.id}`);
         }
     } catch (err) {
-        console.error(`[Bridge Daemon] Failed to deliver via ${adapter}:`, err.message);
+        writeLog('ERROR', `[Bridge Daemon] Failed to deliver via ${adapter}: ${err.message}`);
     }
 }
 
@@ -462,7 +577,7 @@ async function main() {
     // Read lastSyncId
     lastSyncId = getLastSyncId(db, STATE_FILE);
     
-    console.log(`[Bridge Daemon] Started. Tail-syncing from GraphLog ID: ${lastSyncId}`);
+    writeLog('INFO', `[Bridge Daemon] Started. Tail-syncing from GraphLog ID: ${lastSyncId}`);
     
     pollLoop();
 }

--- a/test/playwright/unit/ai/scripts/bridge-daemon.spec.mjs
+++ b/test/playwright/unit/ai/scripts/bridge-daemon.spec.mjs
@@ -129,5 +129,17 @@ test.describe('Bridge Daemon', () => {
         const output = await deliveryPromise;
         expect(output).toContain('[Bridge Daemon Test Adapter] Delivered');
         expect(output).toContain('Test Wake Event');
+
+        // Per #10419 — verify the diagnostic log file was persisted to disk and contains
+        // structured entries (ISO timestamp + PID + INFO/ERROR level prefix). Persistence
+        // is the substrate for post-hoc wake-failure investigation; without this audit
+        // trail every diagnostic depends on terminal-scrollback luck.
+        const logFile = path.join(DAEMON_DIR, 'bridge.log');
+        expect(fs.existsSync(logFile)).toBe(true);
+        const logContents = fs.readFileSync(logFile, 'utf8');
+        expect(logContents).toMatch(/\[\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z\]/); // ISO timestamp
+        expect(logContents).toMatch(/\[PID:\d+\]/);                                       // PID prefix
+        expect(logContents).toMatch(/\[INFO\]/);                                          // level prefix
+        expect(logContents).toContain('[Bridge Daemon Test Adapter] Delivered');          // Same delivery line as stdout
     });
 });


### PR DESCRIPTION
Closes #10419. Diagnostic substrate that unblocks future wake-failure investigations including Bug 2 of #10410 and the Leonard demo failure.

## Context

`bridge-daemon.mjs` previously emitted all diagnostic lines via `console.log` / `console.error` only — terminal scrollback was the sole audit trail. Multiple wake-failure investigations this session-arc hit the same diagnostic boundary: the daemon's log lines existed momentarily then evaporated. Specific empirical anchors per #10419's body:

- **Leonard demo wake-failure** — root cause undiagnosable in real-time; hypothesis space (`osascript` silent error / focus race / macOS Accessibility permission / coalesce-window race) couldn't be confirmed.
- **Bug 2 of #10410** — empirically reproduced multiple times; the diagnostic split (daemon-side queue/coalesce vs osascript-paste layer) requires the daemon's actual `[Bridge Daemon] Delivered ${subscription.id} via osascript to ${appName}` lines to discriminate.
- **3 missed-wake messages in 10:22-10:32 UTC window (this session)** — daemon healthy, lastSyncId advancing, GraphLog had SENT_TO edges, but no wake fired. Hypothesis: silent `osascript` error caught by `deliverDigest`'s try/catch then lost.

Every wake-failure investigation in this session has been **blind** beyond what's queryable from SQLite.

## The Fix

**New `writeLog(level, message)` helper** writes to BOTH stdout (live terminal observability) AND `.neo-ai-data/wake-daemon/bridge.log` (persistent audit trail).

**Line format:** `[ISO-timestamp] [PID:NNN] [LEVEL] message` — greppable, per-line correlation with daemon process + chronology.

**Daily rotation:** previous-day file renamed to `bridge.log.YYYY-MM-DD` before appending today's first line. `rotateLogIfNewDay` runs on every `writeLog` call (cheap; just a `stat` + day-string compare).

**Startup pruning:** archive files older than `LOG_RETENTION_DAYS` (30) are unlinked at daemon boot. Best-effort; per-file failures don't gate startup.

**Replaced sites:** all existing `console.log` / `console.error` / `console.warn` calls in `bridge-daemon.mjs` now route through `writeLog('INFO'|'ERROR', ...)`. The console-write inside `writeLog` itself is preserved (it IS the console-write path; preserves original terminal behavior).

**Failure semantics:** log writes are best-effort. File-write failures are silently swallowed — daemon liveness MUST NOT depend on log integrity. Console-write preserves the original behavior so terminal observability is unchanged even when file substrate fails.

## The Architectural Reality

`bridge-daemon.mjs` is `ai/scripts/`-convention (per AGENTS.md §23 "out-of-process polling script with raw substrate access"). File-based logging fits that convention; SQLite-based logging would be heavier than the diagnostic use-case warrants; `logger.mjs` is for in-process Neo classes (the framework logger refactor in #9977 was specifically for Neural Link's in-process WebSocket bridge, not standalone scripts).

The substrate choice — file-based with `appendFileSync` + daily-suffix rotation + simple-prune — matches the canonical Unix daemon pattern. Read access is via `view_file` / `tail -f` for live monitoring; greppable for post-hoc audits.

## Test Evidence

- **Existing `bridge-daemon.spec.mjs` test** (which captures stdout delivery output) continues to pass — `writeLog` preserves the original console-write path. **4.6s, 1 passed.**
- **New assertions in the same test** verify the persistent log file exists, contains the expected delivery line, and conforms to the documented format (ISO timestamp + PID + INFO/ERROR level prefix). All pass.

## Acceptance Criteria

- [x] `bridge-daemon.mjs` writes ALL existing `console.log` / `console.error` sites to BOTH stdout AND `.neo-ai-data/wake-daemon/bridge.log`
- [x] Daily rotation (`bridge.log.YYYY-MM-DD` archive naming)
- [x] Predictable archive naming for greppability
- [x] Log lines include timestamp, PID, level prefix
- [x] Header comment in `bridge-daemon.mjs` documents log path + rotation policy
- [x] Existing terminal observability preserved — no behavior regression
- [ ] **Post-merge validation:** trigger a real wake-failure (e.g. permission denial); confirm it's captured in the persisted log

## Out of Scope

- **SQLite-based logging** (Option C from ticket body) — heavier substrate than diagnostic use-case warrants
- **Centralized agent-wide logger** (`logger.mjs` refactor) — different audience (in-process Neo classes vs standalone script)
- **Bug 2 of #10410 root-cause investigation** — this PR creates the diagnostic substrate; the actual investigation happens after this ships AND a duplicate-wake is captured in the persisted log
- **Real-time alerting on log patterns** — Phase-2 concern if the failure mode justifies it

## Avoided Traps (per ticket body)

- **Reusing `logger.mjs`** — rejected; bridge-daemon is `ai/scripts/`-convention (out-of-process), not Neo class system
- **SQLite for diagnostic logs** — rejected; adds locking + schema migration overhead for read-rare write-frequent use case
- **Stdout-only with "just remember to scrollback"** — rejected; multiple empirical instances this session-arc demonstrate the audit trail evaporates
- **Per-line buffered async writes** — `fs.appendFileSync` chosen for sync-write-on-every-line audit-trail integrity even if daemon crashes

## Compounds with Other PRs

- **#10423** (Gemini's, focus-steal-bleed + PID-lock — Cycle 3 Approved, awaiting merge): once both land, daemon-restart events get logged with timestamp + old-PID + new-PID, making "wait, why did the daemon restart?" investigations recoverable from disk audit alone.

## Cross-Family Review

Per #10208 mandate — requesting review from @neo-gemini-3-1-pro.