### PR TITLE
feat/fix(ai): Support @me addressing in MailboxService and mandate exact PR close syntax (#10426)

### DIFF
--- a/.agent/skills/pr-review/references/pr-review-guide.md
+++ b/.agent/skills/pr-review/references/pr-review-guide.md
@@ -91,22 +91,29 @@ When challenging a specific architectural pattern or complex implementation deta
 
 ### 5.2 Close-Target Audit
 
-When reviewing a PR, audit every issue named as a close-target via GitHub's magic keywords (`Closes #N`, `Resolves #N`, `Fixes #N` — case-insensitive, in the PR body or commit messages) against the target issue's labels.
+When reviewing a PR, audit every issue named as a close-target via GitHub's magic keywords (`Closes #N`, `Resolves #N`, `Fixes #N` — case-insensitive, in the PR body or commit messages) against the target issue's labels AND syntax validity.
 
-**The Rule:** Epics are not valid close-targets for PRs. An epic represents a body of work delivered across multiple sub-issues; closing an epic is a *project-management* event that fires when the last sub closes (or when the epic is explicitly retired with rationale). PRs deliver subs, not epics. GitHub's auto-close-on-merge semantics fire indiscriminately on any magic-keyword reference, so the discipline-layer enforcement is the reviewer's job.
+**Rule 1: Validity (Epics are not valid close-targets)**
+Epics represent a body of work delivered across multiple sub-issues; closing an epic is a *project-management* event that fires when the last sub closes (or when the epic is explicitly retired with rationale). PRs deliver subs, not epics. GitHub's auto-close-on-merge semantics fire indiscriminately on any magic-keyword reference, so the discipline-layer enforcement is the reviewer's job.
+
+**Rule 2: Syntax-Exact Keyword Mandate**
+Author-side discipline (`pull-request §2`) mandates strict newline-isolated PR closing syntax. Prose-embedded closures or comma-separated lists are forbidden. The reviewer MUST enforce this syntax to prevent automated parsing failures during Retrospective ingestion.
 
 **Reviewer-side check:**
 
 1. Parse the PR body + commit messages for `Closes #N` / `Resolves #N` / `Fixes #N` patterns (case-insensitive).
-2. For each `#N`, fetch the issue's labels (via `gh issue view N --json labels` or the `mcp__neo-mjs-github-workflow__get_local_issue_by_id` tool).
-3. If the issue carries the `epic` label → flag as **Required Action**:
+2. **Syntax Check:** If the keyword is embedded in prose (e.g., "This PR closes #123 by adding...") or uses a comma-separated list (e.g., "Resolves #123, #124"), flag as **Required Action**:
+   > *"PR uses prose-embedded or comma-separated close targets. Required: apply the Syntax-Exact Keyword Mandate by isolating each `Resolves #N` declaration on its own independent line."*
+3. **Validity Check:** For each `#N`, fetch the issue's labels (via `gh issue view N --json labels` or the `mcp__neo-mjs-github-workflow__get_local_issue_by_id` tool).
+4. If the issue carries the `epic` label → flag as **Required Action**:
 
    > *"PR names epic #N as close-target via `Closes`/`Resolves`/`Fixes` keyword. Epics close when their last sub-issue closes, not on PR-merge. Required: change close-target to a specific sub-issue this PR resolves, or remove the magic-close keyword and reference the epic via `Related: #N` instead."*
 
-**Author response options** when this Required Action fires:
-- Change `Closes #N` → `Closes #M` where `#M` is the specific sub-issue the PR resolves.
-- Remove the close-target entirely if the PR is an incremental contribution toward the epic without fully closing any single issue.
-- Move the epic reference to `Related: #N` (no magic-close behavior).
+**Author response options** when these Required Actions fire:
+- **Syntax:** Isolate the keyword to a separate line per ticket.
+- **Validity:** Change `Closes #N` → `Closes #M` where `#M` is the specific sub-issue the PR resolves.
+- **Validity:** Remove the close-target entirely if the PR is an incremental contribution toward the epic without fully closing any single issue.
+- **Validity:** Move the epic reference to `Related: #N` (no magic-close behavior).
 
 **Empirical anchor:** Epic #9999 ("Cloud-Native Knowledge & Multi-Tenant Memory Core") was auto-closed at 2026-04-23T23:54:09Z with `stateReason: COMPLETED` despite 7 of 10 sub-issues still being open. Most likely mechanism: a merged PR named `Closes #9999` triggering GitHub's auto-close-on-merge. The damage was compounded by `prevent-reopen.yml` (since disabled) re-closing the manual reopen 6 seconds later, plus a sabotage-spawn duplicate ticket (#10323, since closed). The discipline-layer audit codified here would have caught the close-target at review time, before merge — preventing the entire downstream chain.
 

--- a/.agent/skills/pull-request/references/pull-request-workflow.md
+++ b/.agent/skills/pull-request/references/pull-request-workflow.md
@@ -275,6 +275,9 @@ You are strictly FORBIDDEN from using magic close keywords (e.g., `Closes #N`, `
 **The Syntax-Exact Keyword Mandate (Mandatory):**
 When your PR fully implements a ticket, you MUST use the exact GitHub-supported magic keyword syntax (e.g., `Resolves #N` or `Closes #N`) on its own line. 
 You are strictly FORBIDDEN from embedding the closing keyword in a conversational sentence (e.g., "Closes Sub 3 of Epic #X (#Y)"). GitHub's parser requires strict syntax to establish the automatic close link. If you fail to use the exact syntax, the ticket will remain open after merge.
+**Multiple Tickets Loophole:** While we strive for a 1-Ticket-to-1-PR ratio, if your PR fully resolves multiple tickets, you MUST flag each one individually. Do NOT use comma-separated lists like `Resolves #X, #Y`. Instead, use a distinct line for each ticket:
+`Resolves #X`
+`Resolves #Y`
 
 **Minimum-viable PR body structure:**
 ```markdown

--- a/.agent/skills/pull-request/references/pull-request-workflow.md
+++ b/.agent/skills/pull-request/references/pull-request-workflow.md
@@ -272,6 +272,10 @@ You are strictly FORBIDDEN from using magic close keywords (e.g., `Closes #N`, `
 - If your PR contributes to an epic but does not close it, use `Related: #N` instead.
 - You may only use magic close keywords on leaf sub-issues that the PR fully implements.
 
+**The Syntax-Exact Keyword Mandate (Mandatory):**
+When your PR fully implements a ticket, you MUST use the exact GitHub-supported magic keyword syntax (e.g., `Resolves #N` or `Closes #N`) on its own line. 
+You are strictly FORBIDDEN from embedding the closing keyword in a conversational sentence (e.g., "Closes Sub 3 of Epic #X (#Y)"). GitHub's parser requires strict syntax to establish the automatic close link. If you fail to use the exact syntax, the ticket will remain open after merge.
+
 **Minimum-viable PR body structure:**
 ```markdown
 Resolves #N

--- a/ai/mcp/server/memory-core/services/MailboxService.mjs
+++ b/ai/mcp/server/memory-core/services/MailboxService.mjs
@@ -17,8 +17,9 @@ import SemanticGraphExtractor from '../../../../daemons/services/SemanticGraphEx
  * @returns {String} The canonical address ready for `linkNodes` and permission-check consumption.
  * @private
  */
-function normalizeMailboxTarget(to) {
+function normalizeMailboxTarget(to, sentBy) {
     if (!to) return to;
+    if (to === '@me' && sentBy) return sentBy;
     if (to === 'AGENT:*') return to;                                    // sentinel preserved
     if (to.startsWith('AGENT:')) {
         to = to.slice('AGENT:'.length);
@@ -99,7 +100,7 @@ class MailboxService extends Base {
         // Without this normalization, `GraphService.linkNodes`'s FK guard silently culls the
         // `SENT_TO` edge — the root-cause bug closed by #10174. Permission checks and edge
         // creation below all consume the canonical form from this point on.
-        to = normalizeMailboxTarget(to);
+        to = normalizeMailboxTarget(to, sentBy);
         const postNormalizeTo = to; // Phase 1 #10347 observability
 
         const messageId = `MESSAGE:${crypto.randomUUID()}`;

--- a/ai/mcp/server/memory-core/services/MailboxService.mjs
+++ b/ai/mcp/server/memory-core/services/MailboxService.mjs
@@ -10,7 +10,7 @@ import SemanticGraphExtractor from '../../../../daemons/services/SemanticGraphEx
 /**
  * Normalizes a raw addressing target into its canonical Graph Node ID format.
  * Enforces the unified identity substrate where `@<login>` is canonical for all identities.
- * Preserves the `AGENT:*` sentinel for system-wide broadcasts.
+ * The two recognized recipient-field aliases are `@me` (Future-Self Routing) and `AGENT:*` (system-wide broadcast).
  * Safely strips legacy `AGENT:` prefixes and redundant `@@` prefixes.
  *
  * @param {String} to The raw `to` address as supplied by the caller.

--- a/ai/mcp/server/memory-core/services/MailboxService.mjs
+++ b/ai/mcp/server/memory-core/services/MailboxService.mjs
@@ -14,6 +14,7 @@ import SemanticGraphExtractor from '../../../../daemons/services/SemanticGraphEx
  * Safely strips legacy `AGENT:` prefixes and redundant `@@` prefixes.
  *
  * @param {String} to The raw `to` address as supplied by the caller.
+ * @param {String} [sentBy] The canonical node ID of the sender, used to resolve `@me`.
  * @returns {String} The canonical address ready for `linkNodes` and permission-check consumption.
  * @private
  */

--- a/ai/mcp/server/memory-core/services/MailboxService.mjs
+++ b/ai/mcp/server/memory-core/services/MailboxService.mjs
@@ -14,7 +14,8 @@ import SemanticGraphExtractor from '../../../../daemons/services/SemanticGraphEx
  * Safely strips legacy `AGENT:` prefixes and redundant `@@` prefixes.
  *
  * @param {String} to The raw `to` address as supplied by the caller.
- * @param {String} [sentBy] The canonical node ID of the sender, used to resolve `@me`.
+ * @param {String} [sentBy] The canonical sender identity (from `RequestContextService.getAgentIdentityNodeId()`).
+ *                           Required only when resolving the `@me` alias; ignored for all other inputs.
  * @returns {String} The canonical address ready for `linkNodes` and permission-check consumption.
  * @private
  */

--- a/test/playwright/unit/ai/mcp/server/memory-core/services/MailboxService.spec.mjs
+++ b/test/playwright/unit/ai/mcp/server/memory-core/services/MailboxService.spec.mjs
@@ -669,6 +669,27 @@ test.describe('Neo.ai.mcp.server.memory-core.services.MailboxService', () => {
             expect(inbox.messages.find(m => m.subject === 'double-prefix')).toBeDefined();
         });
 
+        test('`@me` alias normalizes to the sentBy identity (Future-Self Routing)', async () => {
+            let messageId;
+            await RequestContextService.run({ agentIdentityNodeId: '@opus' }, async () => {
+                const res = await MailboxService.addMessage({ to: '@me', subject: 'note to self', body: 'body' });
+                expect(res.status).toBe('sent');
+                messageId = res.messageId;
+
+                const sentToEdge = GraphService.db.edges.items.find(
+                    e => e.source === messageId && e.type === 'SENT_TO'
+                );
+                expect(sentToEdge).toBeDefined();
+                expect(sentToEdge.target).toBe('@opus');
+            });
+
+            // Opus should see their own message in the inbox
+            const inbox = await RequestContextService.run({ agentIdentityNodeId: '@opus' }, async () => {
+                return await MailboxService.listMessages({ box: 'inbox' });
+            });
+            expect(inbox.messages.find(m => m.subject === 'note to self')).toBeDefined();
+        });
+
         test('`AGENT:*` broadcast creates SENT_TO edge to the seeded sentinel and fans out', async () => {
             let messageId;
             await RequestContextService.run({ agentIdentityNodeId: '@opus' }, async () => {

--- a/test/playwright/unit/ai/mcp/server/memory-core/services/MailboxService.spec.mjs
+++ b/test/playwright/unit/ai/mcp/server/memory-core/services/MailboxService.spec.mjs
@@ -690,6 +690,22 @@ test.describe('Neo.ai.mcp.server.memory-core.services.MailboxService', () => {
             expect(inbox.messages.find(m => m.subject === 'note to self')).toBeDefined();
         });
 
+        test('`@me` alias falls through when sentBy is absent', async () => {
+            // Simulate missing identity context. The MailboxService guards against missing context
+            // at the start of addMessage, so we expect an error to be thrown before normalization,
+            // but if that guard is ever removed, the normalization safely falls through.
+            await RequestContextService.run({ agentIdentityNodeId: null }, async () => {
+                let error;
+                try {
+                    await MailboxService.addMessage({ to: '@me', subject: 'fallthrough', body: 'body' });
+                } catch (e) {
+                    error = e;
+                }
+                expect(error).toBeDefined();
+                expect(error.message).toContain('no agent identity context bound');
+            });
+        });
+
         test('`AGENT:*` broadcast creates SENT_TO edge to the seeded sentinel and fans out', async () => {
             let messageId;
             await RequestContextService.run({ agentIdentityNodeId: '@opus' }, async () => {


### PR DESCRIPTION
Authored by Gemini 3.1 Pro (Antigravity). Session 49e9b05a-0581-4fb7-861f-7e4970ea4c2b.

Resolves #10426
Resolves #10428

Adds dynamic resolution for the `@me` address alias within `MailboxService.mjs` to correctly route messages to the sending agent's identity, preventing Native Edge Graph FK guard culls. Additionally, strictly mandates the use of exact keyword syntax for ticket closures in `pull-request-workflow.md` to prevent stranded tickets.

## Deltas from ticket (if any)
None. Both the architectural fix and documentation update align exactly with the ticket prescription.

**Note on backward compatibility**: A scan across the codebase for the literal `'@me'` confirmed zero existing callers using this addressing. The broken substrate behavior (silent failure) was not relied upon by any existing logic.

## Test Evidence
- Extended `MailboxService.spec.mjs` to test `@me` roundtripping (`addMessage` -> edge creation -> `listMessages`).
- Added a fallback test asserting `addMessage` prevents null identity context before it even reaches the fall-through `normalizeMailboxTarget` logic.

## Post-Merge Validation
- [ ] Ensure that subsequent A2A Sunset ping requests addressed to `@me` reach their intended inboxes successfully.

## Commits
- `b699e420a` — fix(memory-core): resolve @me addressing in MailboxService and feat(ai): mandate exact magic keyword syntax in PR bodies
- `0d0e4697c` — Update JSDoc and tests for MailboxService @me routing
