### PR TITLE
feat(bootstrap): granular per-subdir symlinking in --link-data (#10432)

### DIFF
--- a/ai/scripts/bootstrapWorktree.mjs
+++ b/ai/scripts/bootstrapWorktree.mjs
@@ -1,7 +1,9 @@
 /**
  * @summary Copies gitignored `ai/mcp/server/<name>/config.mjs` files from the main git
- * checkout into the current git worktree, and optionally symlinks the `.neo-ai-data/`
- * data directory so Memory Core substrate is unified across worktree MCP server processes.
+ * checkout into the current git worktree, and optionally symlinks the gitignored
+ * substrate-data subdirs of `.neo-ai-data/` (sqlite, chroma, wake-daemon, etc.) so
+ * Memory Core, knowledge-base, and bridge-daemon state is unified across worktree
+ * MCP server processes — while leaving the git-tracked `concepts/` subdir untouched.
  *
  * **Background (config copy):** `ai/mcp/server/{github-workflow,knowledge-base,memory-core,neural-link}/config.mjs`
  * are gitignored (they are copy-from-template files for local overrides). Fresh git worktrees
@@ -21,32 +23,52 @@
  * paths and throws `Namespace collision in unitTestMode`. For code, config files MUST be
  * real copies with their own canonical path inside the worktree.
  *
- * **Symlinking DATA DIRECTORIES is safe and recommended.** `.neo-ai-data/` contains SQLite
- * DB files (Memory Core graph), Chroma vectors, JSONL backups, concept CSVs — pure data
- * with zero ESM import chains. `better-sqlite3` opens files by path, and `path.resolve`
- * traverses symlinks transparently without canonical-path side effects. Symlinking
- * `.neo-ai-data/` unifies the Memory Core substrate so AgentIdentity nodes seeded once
- * are visible to every worktree's MCP server, and A2A mailbox handoffs span harnesses.
- * This automates the tactical convention codified in ticket #10176 and closes #10224.
- * See {@link symlinkDataDir} for the implementation.
+ * **Symlinking DATA DIRECTORIES is safe and recommended — but only the gitignored ones.**
+ * `.neo-ai-data/` contains SQLite DB files (Memory Core graph), Chroma vectors, JSONL
+ * backups, concept CSVs — pure data with zero ESM import chains. `better-sqlite3` opens
+ * files by path, and `path.resolve` traverses symlinks transparently without canonical-path
+ * side effects.
+ *
+ * **The gitignore boundary inside `.neo-ai-data/` is load-bearing:**
+ *
+ * ```
+ * .neo-ai-data
+ * !.neo-ai-data/concepts/
+ * ```
+ *
+ * Everything inside `.neo-ai-data/` is gitignored EXCEPT `concepts/` which IS git-tracked.
+ * Symlinking the parent `.neo-ai-data/` directory atomically (the pre-#10432 behavior)
+ * hides the worktree's tracked `concepts/` files behind canonical's view; using `--force`
+ * clobbers them entirely. Both outcomes break the worktree-local concepts substrate.
+ *
+ * The granular fix (per #10432): symlink each gitignored substrate-data subdir individually
+ * via the `DATA_SUBDIRS_TO_LINK` allowlist. `concepts/` is never in the allowlist → never
+ * touched. This unifies the Memory Core substrate ({@link symlinkDataDir}) so AgentIdentity
+ * nodes seeded once are visible to every worktree's MCP server, A2A mailbox handoffs span
+ * harnesses, AND the bridge daemon's PID-lock singleton (#10423) plus persistent log
+ * (#10425) span worktrees too — without the tracked `concepts/` clobber risk that
+ * empirically broke 10 of 11 worktrees in the 2026-04-27 cross-process coherence gap
+ * diagnosis.
  *
  * **Usage:**
  * ```
  * node ai/scripts/bootstrapWorktree.mjs              # copy configs only
- * node ai/scripts/bootstrapWorktree.mjs --link-data  # copy configs + symlink .neo-ai-data/
+ * node ai/scripts/bootstrapWorktree.mjs --link-data  # copy configs + symlink data subdirs
  * node ai/scripts/bootstrapWorktree.mjs --link-data --force
- *                                                    # clobber existing worktree-local
- *                                                    # .neo-ai-data/ (data-loss guard
- *                                                    # opt-in; gitignored + session-scoped)
+ *                                                    # clobber any existing real
+ *                                                    # gitignored subdir (data-loss guard
+ *                                                    # opt-in; never touches concepts/)
  * ```
  *
- * Idempotent: files that already exist are skipped; an existing symlink at `.neo-ai-data/`
- * short-circuits to `'already-linked'`. Refuses to run from the main checkout (no-op).
- * Resolves the main checkout via `git worktree list --porcelain` — its first entry is
- * always the primary working tree.
+ * Idempotent: files that already exist are skipped; subdirs already symlinked report
+ * `'already-linked'`. Refuses to run from the main checkout (no-op). Resolves the main
+ * checkout via `git worktree list --porcelain` — its first entry is always the primary
+ * working tree.
  *
  * @see https://github.com/neomjs/neo/issues/10095
- * @see https://github.com/neomjs/neo/issues/10224
+ * @see https://github.com/neomjs/neo/issues/10224 (closed predecessor — coarse-grained symlink)
+ * @see https://github.com/neomjs/neo/issues/10424 (cross-process coherence gap empirically anchored)
+ * @see https://github.com/neomjs/neo/issues/10432 (this granular refinement)
  */
 import {execFile}       from 'child_process';
 import fs               from 'fs/promises';
@@ -61,6 +83,26 @@ export const BOOTSTRAP_CONFIGS = [
     'ai/mcp/server/knowledge-base/config.mjs',
     'ai/mcp/server/memory-core/config.mjs',
     'ai/mcp/server/neural-link/config.mjs'
+];
+
+/**
+ * Allowlist of `.neo-ai-data/` subdirs to symlink to canonical when `--link-data` is set.
+ * All entries are gitignored substrate-data subdirs that benefit from cross-worktree
+ * unification. The git-tracked `concepts/` subdir is deliberately NOT in this list —
+ * symlinking it would hide the worktree's own tracked files; `--force` would clobber them.
+ *
+ * The order is informational (no semantic dependency between subdirs); each is symlinked
+ * independently and per-subdir results are reported separately.
+ *
+ * @see {@link symlinkDataDir} for the per-subdir symlink-or-skip-or-clobber logic.
+ */
+export const DATA_SUBDIRS_TO_LINK = [
+    'sqlite',       // Memory Core graph DB (memory-core-graph.sqlite + WAL/SHM)
+    'chroma',       // Vector DBs (knowledge-base + memory-core)
+    'wake-daemon',  // PID-lock + bridge.log + lastSyncId — unifies #10423 singleton across worktrees
+    'backups',      // JSONL backups (Memory Core message + node history)
+    'datasets',     // Canonical CSVs ingested by knowledge-base sync
+    'neo-sqlite'    // Legacy DB (still referenced by older code paths)
 ];
 
 /**
@@ -135,62 +177,107 @@ async function exists(p) {
 }
 
 /**
- * @summary Creates a worktree→main-checkout symlink for a data directory (default:
- * `.neo-ai-data/`), unifying the Memory Core substrate across concurrent worktree MCP
- * server processes.
+ * @summary Granularly symlinks gitignored substrate-data subdirs of `.neo-ai-data/` to
+ * canonical, unifying the Memory Core substrate across concurrent worktree MCP server
+ * processes while leaving the git-tracked `concepts/` subdir untouched.
+ *
+ * **Why granular per-subdir, not parent-level (per #10432):**
+ *
+ * The `.gitignore` boundary inside `.neo-ai-data/` is `.neo-ai-data` (gitignored) plus
+ * `!.neo-ai-data/concepts/` (tracked exception). Symlinking the parent atomically (the
+ * pre-#10432 behavior) hides the worktree's tracked `concepts/` files behind canonical's
+ * view; `--force` clobbers them entirely. Both outcomes break the worktree-local
+ * concepts substrate.
+ *
+ * This function symlinks each gitignored subdir individually via the `subdirs` allowlist
+ * (default: {@link DATA_SUBDIRS_TO_LINK}). `concepts/` is never in the default allowlist
+ * → never touched, regardless of `--force`. The data-loss guard (refuse-clobber-without-
+ * force) is preserved per-subdir, so a corrupted `sqlite/` can be reset without nuking
+ * everything else.
+ *
+ * **Why this is the right substrate (Anchor & Echo):**
  *
  * Distinct from the "do NOT symlink source code" caveat at the file head — that warning
- * applies exclusively to ESM-imported modules, where Node's resolver walks to the
- * canonical path and causes `Namespace collision in unitTestMode`. Data directories
- * carry no such semantic: `better-sqlite3` opens by path, Chroma dumps read/write through
- * `fs`, and `path.resolve` transparently traverses symlinks without canonical-path side
- * effects. Symlinking `.neo-ai-data/` closes the #10224 data-isolation split by unifying
- * the substrate ADR 0001 §1 assumes exists (one SQLite file shared across N processes).
+ * applies exclusively to ESM-imported modules where Node's resolver walks to the canonical
+ * path and causes `Namespace collision in unitTestMode`. Data directories carry no such
+ * semantic: `better-sqlite3` opens by path, Chroma dumps read/write through `fs`, and
+ * `path.resolve` transparently traverses symlinks without canonical-path side effects.
  *
- * Idempotent by design: `'already-linked'` short-circuits on re-invocation over an
- * existing symlink. Refuses to clobber a real directory without `force: true` — a
- * data-loss guard protecting against cases where a worktree accumulated unique writes
- * before unification was opted-in.
+ * The `wake-daemon/` subdir is critical for PID-lock singleton enforcement (#10423) to
+ * span worktrees — without symlinking, each worktree has its own `bridge-daemon.pid` and
+ * daemons spawned from different worktrees can't see each other's locks. Same logic for
+ * the persistent `bridge.log` substrate (#10425).
  *
- * @param {object}  options
- * @param {string}  options.mainCheckout Absolute path to the primary git checkout.
- * @param {string}  options.projectRoot  Absolute path to the worktree root to link from.
- * @param {string}  [options.dir='.neo-ai-data'] Directory name to link; relative to both roots.
- * @param {boolean} [options.force=false] If true, overwrite an existing non-symlink dir at dst.
+ * Idempotent per-subdir by design: an existing symlink reports `'already-linked'`; a
+ * missing canonical source reports `'skip-no-source'` (graceful for fresh repos that
+ * haven't created the subdir yet); a non-symlink directory throws unless `force=true`.
+ *
+ * @param {object}   options
+ * @param {string}   options.mainCheckout Absolute path to the primary git checkout.
+ * @param {string}   options.projectRoot  Absolute path to the worktree root to link from.
+ * @param {string[]} [options.subdirs]    Allowlist of subdirs to symlink; defaults to {@link DATA_SUBDIRS_TO_LINK}.
+ * @param {boolean}  [options.force=false] If true, clobber existing non-symlink dirs in the allowlist (never touches subdirs not in the allowlist).
  * @param {Function} [options.log=console.log] Logger fn for action diagnostics.
- * @returns {Promise<'main-checkout'|'already-linked'|'linked'>} Action taken.
- * @throws {Error} When dst is a non-symlink directory and `force` is false.
+ * @returns {Promise<{linked: string[], alreadyLinked: string[], clobbered: string[], skippedNoSource: string[], mainCheckout: boolean}>} Per-subdir action map.
+ * @throws {Error} When any subdir's dst is a non-symlink directory and `force` is false. The error message names the offending subdir.
  */
-export async function symlinkDataDir({mainCheckout, projectRoot, dir = '.neo-ai-data', force = false, log = console.log}) {
+export async function symlinkDataDir({
+    mainCheckout,
+    projectRoot,
+    subdirs = DATA_SUBDIRS_TO_LINK,
+    force   = false,
+    log     = console.log
+}) {
+    const result = {linked: [], alreadyLinked: [], clobbered: [], skippedNoSource: [], mainCheckout: false};
+
     if (path.resolve(projectRoot) === path.resolve(mainCheckout)) {
-        log(`symlink skip (main checkout): ${dir}`);
-        return 'main-checkout';
+        log(`symlink skip (main checkout): no per-subdir action`);
+        result.mainCheckout = true;
+        return result;
     }
 
-    const src   = path.join(mainCheckout, dir);
-    const dst   = path.join(projectRoot, dir);
-    const lstat = await fs.lstat(dst).catch(() => null);
+    // Ensure the parent .neo-ai-data/ exists as a regular dir; we never symlink the parent.
+    // This preserves the git-tracked concepts/ subdir already present in the worktree.
+    const parentDst = path.join(projectRoot, '.neo-ai-data');
+    await fs.mkdir(parentDst, {recursive: true});
 
-    if (lstat?.isSymbolicLink()) {
-        log(`symlink skip (already linked): ${dir}`);
-        return 'already-linked';
-    }
+    for (const subdir of subdirs) {
+        const src   = path.join(mainCheckout, '.neo-ai-data', subdir);
+        const dst   = path.join(parentDst, subdir);
+        const lstat = await fs.lstat(dst).catch(() => null);
 
-    if (lstat?.isDirectory()) {
-        if (!force) {
-            throw new Error(
-                `Refusing to replace non-symlink ${dst}; pass force=true (CLI --force) to opt in. ` +
-                `This directory contains local data that would be lost.`
-            );
+        if (lstat?.isSymbolicLink()) {
+            log(`symlink skip (already linked): ${subdir}`);
+            result.alreadyLinked.push(subdir);
+            continue;
         }
-        log(`symlink clobber (force=true): removing ${dir}`);
-        await fs.rm(dst, {recursive: true, force: true});
+
+        // Skip if canonical lacks the subdir — graceful for fresh repos.
+        const srcExists = await exists(src);
+        if (!srcExists) {
+            log(`symlink skip (no source in main checkout): ${subdir}`);
+            result.skippedNoSource.push(subdir);
+            continue;
+        }
+
+        if (lstat?.isDirectory()) {
+            if (!force) {
+                throw new Error(
+                    `Refusing to replace non-symlink ${dst}; pass force=true (CLI --force) to opt in. ` +
+                    `This directory contains local data that would be lost.`
+                );
+            }
+            log(`symlink clobber (force=true): removing ${subdir}`);
+            await fs.rm(dst, {recursive: true, force: true});
+            result.clobbered.push(subdir);
+        }
+
+        await fs.symlink(src, dst, 'dir');
+        log(`symlinked: ${subdir} → ${src}`);
+        result.linked.push(subdir);
     }
 
-    await fs.mkdir(path.dirname(dst), {recursive: true});
-    await fs.symlink(src, dst, 'dir');
-    log(`symlinked: ${dir} → ${src}`);
-    return 'linked';
+    return result;
 }
 
 /**
@@ -299,7 +386,22 @@ if (isMain) {
 
         if (linkData) {
             const symlinkResult = await symlinkDataDir({mainCheckout, projectRoot, force});
-            console.log(`✓ Data symlink: ${symlinkResult}`);
+            if (symlinkResult.mainCheckout) {
+                console.log(`✓ Data symlink: skipped (running in main checkout)`);
+            } else {
+                const linkedN          = symlinkResult.linked.length;
+                const alreadyLinkedN   = symlinkResult.alreadyLinked.length;
+                const clobberedN       = symlinkResult.clobbered.length;
+                const skippedNoSourceN = symlinkResult.skippedNoSource.length;
+                console.log(
+                    `✓ Data symlink: ${linkedN} linked, ${alreadyLinkedN} already-linked, ` +
+                    `${clobberedN} clobbered, ${skippedNoSourceN} skipped-no-source`
+                );
+                if (linkedN          > 0) console.log(`  linked:           ${symlinkResult.linked.join(', ')}`);
+                if (alreadyLinkedN   > 0) console.log(`  already-linked:   ${symlinkResult.alreadyLinked.join(', ')}`);
+                if (clobberedN       > 0) console.log(`  clobbered:        ${symlinkResult.clobbered.join(', ')}`);
+                if (skippedNoSourceN > 0) console.log(`  skipped-no-src:   ${symlinkResult.skippedNoSource.join(', ')}`);
+            }
         }
 
         if (buildAll) {

--- a/test/playwright/unit/ai/scripts/bootstrapWorktree.spec.mjs
+++ b/test/playwright/unit/ai/scripts/bootstrapWorktree.spec.mjs
@@ -34,6 +34,7 @@ test.describe('ai/scripts/bootstrapWorktree', () => {
     let installDependencies;
     let runBuildAll;
     let BOOTSTRAP_CONFIGS;
+    let DATA_SUBDIRS_TO_LINK;
     let fakeMainCheckout;
     let fakeWorktree;
 
@@ -46,11 +47,12 @@ test.describe('ai/scripts/bootstrapWorktree', () => {
 
     test.beforeAll(async () => {
         const mod           = await import('../../../../../ai/scripts/bootstrapWorktree.mjs');
-        bootstrapWorktree   = mod.bootstrapWorktree;
-        symlinkDataDir      = mod.symlinkDataDir;
-        installDependencies = mod.installDependencies;
-        runBuildAll         = mod.runBuildAll;
-        BOOTSTRAP_CONFIGS   = mod.BOOTSTRAP_CONFIGS;
+        bootstrapWorktree    = mod.bootstrapWorktree;
+        symlinkDataDir       = mod.symlinkDataDir;
+        installDependencies  = mod.installDependencies;
+        runBuildAll          = mod.runBuildAll;
+        BOOTSTRAP_CONFIGS    = mod.BOOTSTRAP_CONFIGS;
+        DATA_SUBDIRS_TO_LINK = mod.DATA_SUBDIRS_TO_LINK;
     });
 
     test.beforeEach(async () => {
@@ -149,105 +151,234 @@ test.describe('ai/scripts/bootstrapWorktree', () => {
     });
 
     // --------------------------------------------------------------------------------
-    // #10224 symlinkDataDir — unifies .neo-ai-data across worktree+main checkouts.
+    // #10432 symlinkDataDir — granular per-subdir symlinking of gitignored substrate-data
+    // subdirs of `.neo-ai-data/`, while leaving the git-tracked `concepts/` subdir
+    // untouched. Refines the closed predecessor #10224 (coarse-grained parent-level
+    // symlink) and unblocks the cross-process coherence gap empirically anchored in
+    // #10424.
     //
-    // These tests use a canary file in the main-checkout data dir to prove that the
-    // symlinked worktree path sees the same data, empirically validating the
-    // cross-process substrate unification this helper exists to enable.
+    // These tests use canary files PER SUBDIR in the main-checkout data dir to prove that
+    // each symlinked worktree subdir sees its corresponding main-checkout subdir's data.
+    // The concepts/-untouched test is the load-bearing safety check — the bug class this
+    // refactor exists to prevent.
     // --------------------------------------------------------------------------------
-    test.describe('#10224 symlinkDataDir', () => {
+    test.describe('#10432 symlinkDataDir (granular per-subdir)', () => {
         const dataDir = '.neo-ai-data';
-        let mainDataDir;
+        const fixtureSubdirs = ['sqlite', 'chroma', 'wake-daemon'];
 
-        test.beforeEach(async () => {
-            // Seed the main checkout's .neo-ai-data/ with a canary file so tests can
-            // prove symlink traversal actually reaches it.
-            mainDataDir = path.join(fakeMainCheckout, dataDir);
-            await fs.ensureDir(mainDataDir);
-            await fs.writeFile(path.join(mainDataDir, 'canary.txt'), 'main-checkout-canary\n', 'utf-8');
+        async function seedMainSubdirs(subdirs = fixtureSubdirs) {
+            for (const subdir of subdirs) {
+                const dir = path.join(fakeMainCheckout, dataDir, subdir);
+                await fs.ensureDir(dir);
+                await fs.writeFile(path.join(dir, 'canary.txt'), `main-${subdir}-canary\n`, 'utf-8');
+            }
+        }
+
+        test('exports the canonical DATA_SUBDIRS_TO_LINK list', () => {
+            // The exact list is documented in the source; we assert the load-bearing
+            // invariants rather than the precise sequence (which may evolve).
+            expect(Array.isArray(DATA_SUBDIRS_TO_LINK)).toBe(true);
+            expect(DATA_SUBDIRS_TO_LINK).toContain('sqlite');
+            expect(DATA_SUBDIRS_TO_LINK).toContain('chroma');
+            expect(DATA_SUBDIRS_TO_LINK).toContain('wake-daemon');
+
+            // CRITICAL invariant: concepts/ is git-tracked and MUST NEVER be in the
+            // default allowlist. This is the load-bearing safety check that prevents
+            // the pre-#10432 clobber-bug from regressing.
+            expect(DATA_SUBDIRS_TO_LINK).not.toContain('concepts');
         });
 
-        test('creates a symlink when worktree .neo-ai-data does not exist', async () => {
+        test('symlinks every allowlisted subdir from canonical when none exist in worktree', async () => {
+            await seedMainSubdirs();
+
             const result = await symlinkDataDir({
                 mainCheckout: fakeMainCheckout,
                 projectRoot : fakeWorktree,
+                subdirs     : fixtureSubdirs,
                 log         : () => {}
             });
 
-            expect(result).toBe('linked');
+            expect(result.linked).toEqual(fixtureSubdirs);
+            expect(result.alreadyLinked).toHaveLength(0);
+            expect(result.clobbered).toHaveLength(0);
+            expect(result.skippedNoSource).toHaveLength(0);
+            expect(result.mainCheckout).toBe(false);
 
-            const dst         = path.join(fakeWorktree, dataDir);
-            const lstat       = await fs.lstat(dst);
-            expect(lstat.isSymbolicLink()).toBe(true);
+            // Each subdir is now a symlink, and each canary is reachable via the link.
+            for (const subdir of fixtureSubdirs) {
+                const dst   = path.join(fakeWorktree, dataDir, subdir);
+                const lstat = await fs.lstat(dst);
+                expect(lstat.isSymbolicLink()).toBe(true);
 
-            // Canary reachable via the symlinked path — proves symlink traversal works.
-            const canaryViaLink = await fs.readFile(path.join(dst, 'canary.txt'), 'utf-8');
-            expect(canaryViaLink).toBe('main-checkout-canary\n');
+                const canary = await fs.readFile(path.join(dst, 'canary.txt'), 'utf-8');
+                expect(canary).toBe(`main-${subdir}-canary\n`);
+            }
+
+            // Parent .neo-ai-data/ is a regular directory (not a symlink) — preserves
+            // the worktree's tracked concepts/ subdir if present.
+            const parentLstat = await fs.lstat(path.join(fakeWorktree, dataDir));
+            expect(parentLstat.isDirectory()).toBe(true);
+            expect(parentLstat.isSymbolicLink()).toBe(false);
         });
 
-        test('is idempotent — returns already-linked when dst is already a symlink', async () => {
-            // First call creates the link.
-            await symlinkDataDir({mainCheckout: fakeMainCheckout, projectRoot: fakeWorktree, log: () => {}});
+        test('is idempotent per-subdir — re-running over partial state surfaces alreadyLinked + linked', async () => {
+            await seedMainSubdirs();
 
-            // Second call must short-circuit; no error, no re-link.
+            // First call links all three subdirs.
+            await symlinkDataDir({
+                mainCheckout: fakeMainCheckout,
+                projectRoot : fakeWorktree,
+                subdirs     : fixtureSubdirs,
+                log         : () => {}
+            });
+
+            // Manually unlink one to simulate a partial state.
+            await fs.unlink(path.join(fakeWorktree, dataDir, 'chroma'));
+
+            // Second call: two are alreadyLinked, the unlinked one gets re-linked.
             const result = await symlinkDataDir({
                 mainCheckout: fakeMainCheckout,
                 projectRoot : fakeWorktree,
+                subdirs     : fixtureSubdirs,
                 log         : () => {}
             });
-            expect(result).toBe('already-linked');
+
+            expect(result.alreadyLinked.sort()).toEqual(['sqlite', 'wake-daemon'].sort());
+            expect(result.linked).toEqual(['chroma']);
+            expect(result.clobbered).toHaveLength(0);
+            expect(result.skippedNoSource).toHaveLength(0);
         });
 
-        test('refuses to clobber a non-symlink directory without force', async () => {
-            // Pre-create a real directory with unique content — simulates a worktree
-            // that has accumulated data before symlink unification was opted-in.
-            const worktreeDataDir = path.join(fakeWorktree, dataDir);
-            await fs.ensureDir(worktreeDataDir);
-            await fs.writeFile(path.join(worktreeDataDir, 'local-only.txt'), 'worktree-specific\n', 'utf-8');
+        test('refuses to clobber a non-symlink subdir without force', async () => {
+            await seedMainSubdirs();
+
+            // Pre-create one subdir as a regular dir with unique content — simulates a
+            // worktree that has accumulated data before symlink unification was opted-in.
+            const worktreeSubdir = path.join(fakeWorktree, dataDir, 'sqlite');
+            await fs.ensureDir(worktreeSubdir);
+            await fs.writeFile(path.join(worktreeSubdir, 'local-only.txt'), 'worktree-specific\n', 'utf-8');
 
             await expect(
-                symlinkDataDir({mainCheckout: fakeMainCheckout, projectRoot: fakeWorktree, log: () => {}})
+                symlinkDataDir({
+                    mainCheckout: fakeMainCheckout,
+                    projectRoot : fakeWorktree,
+                    subdirs     : fixtureSubdirs,
+                    log         : () => {}
+                })
             ).rejects.toThrow(/Refusing to replace non-symlink/);
 
             // Local data preserved — guard did its job.
-            const preserved = await fs.readFile(path.join(worktreeDataDir, 'local-only.txt'), 'utf-8');
+            const preserved = await fs.readFile(path.join(worktreeSubdir, 'local-only.txt'), 'utf-8');
             expect(preserved).toBe('worktree-specific\n');
         });
 
-        test('clobbers a non-symlink directory when force=true and creates the link', async () => {
-            const worktreeDataDir = path.join(fakeWorktree, dataDir);
-            await fs.ensureDir(worktreeDataDir);
-            await fs.writeFile(path.join(worktreeDataDir, 'local-only.txt'), 'worktree-specific\n', 'utf-8');
+        test('clobbers per-subdir with force=true and creates the link', async () => {
+            await seedMainSubdirs();
 
+            const worktreeSubdir = path.join(fakeWorktree, dataDir, 'sqlite');
+            await fs.ensureDir(worktreeSubdir);
+            await fs.writeFile(path.join(worktreeSubdir, 'local-only.txt'), 'worktree-specific\n', 'utf-8');
+
+            const result = await symlinkDataDir({
+                mainCheckout: fakeMainCheckout,
+                projectRoot : fakeWorktree,
+                subdirs     : fixtureSubdirs,
+                force       : true,
+                log         : () => {}
+            });
+
+            expect(result.linked).toEqual(fixtureSubdirs);
+            expect(result.clobbered).toEqual(['sqlite']);
+
+            // Clobbered subdir is now a symlink + canary reachable.
+            const lstat = await fs.lstat(worktreeSubdir);
+            expect(lstat.isSymbolicLink()).toBe(true);
+
+            const canary = await fs.readFile(path.join(worktreeSubdir, 'canary.txt'), 'utf-8');
+            expect(canary).toBe('main-sqlite-canary\n');
+        });
+
+        test('gracefully skips subdirs missing in the main checkout', async () => {
+            // Seed only two of three; third (chroma) is absent in the main checkout.
+            await seedMainSubdirs(['sqlite', 'wake-daemon']);
+
+            const result = await symlinkDataDir({
+                mainCheckout: fakeMainCheckout,
+                projectRoot : fakeWorktree,
+                subdirs     : fixtureSubdirs, // includes chroma which isn't in main
+                log         : () => {}
+            });
+
+            expect(result.linked.sort()).toEqual(['sqlite', 'wake-daemon'].sort());
+            expect(result.skippedNoSource).toEqual(['chroma']);
+        });
+
+        test('NEVER touches concepts/ even when present in main checkout and force=true', async () => {
+            // Seed both the allowlisted subdirs AND a concepts/ in main and a regular
+            // (tracked-style) concepts/ in the worktree with unique content.
+            await seedMainSubdirs();
+            await fs.ensureDir(path.join(fakeMainCheckout, dataDir, 'concepts'));
+            await fs.writeFile(
+                path.join(fakeMainCheckout, dataDir, 'concepts', 'main-concept.txt'),
+                'main-concept\n', 'utf-8'
+            );
+
+            const worktreeConceptsDir = path.join(fakeWorktree, dataDir, 'concepts');
+            await fs.ensureDir(worktreeConceptsDir);
+            await fs.writeFile(
+                path.join(worktreeConceptsDir, 'tracked-concept.txt'),
+                'worktree-tracked-concept\n', 'utf-8'
+            );
+
+            // Use the DEFAULT allowlist (which deliberately omits concepts/), and force=true.
             const result = await symlinkDataDir({
                 mainCheckout: fakeMainCheckout,
                 projectRoot : fakeWorktree,
                 force       : true,
                 log         : () => {}
             });
-            expect(result).toBe('linked');
 
-            // Local dir replaced — confirm dst is now a symlink.
-            const lstat = await fs.lstat(worktreeDataDir);
-            expect(lstat.isSymbolicLink()).toBe(true);
+            // concepts/ is NOT in the default allowlist → not in any result bucket.
+            expect(result.linked).not.toContain('concepts');
+            expect(result.alreadyLinked).not.toContain('concepts');
+            expect(result.clobbered).not.toContain('concepts');
 
-            // Canary reachable via the freshly-linked path.
-            const canary = await fs.readFile(path.join(worktreeDataDir, 'canary.txt'), 'utf-8');
-            expect(canary).toBe('main-checkout-canary\n');
+            // The worktree's concepts/ is still a regular dir, with its tracked file intact.
+            const lstat = await fs.lstat(worktreeConceptsDir);
+            expect(lstat.isDirectory()).toBe(true);
+            expect(lstat.isSymbolicLink()).toBe(false);
+
+            const tracked = await fs.readFile(path.join(worktreeConceptsDir, 'tracked-concept.txt'), 'utf-8');
+            expect(tracked).toBe('worktree-tracked-concept\n');
+
+            // The main-checkout's concept file is NOT visible in the worktree's
+            // concepts/ — it remains a regular dir, isolated by design.
+            const mainOnlyExists = await fs.pathExists(path.join(worktreeConceptsDir, 'main-concept.txt'));
+            expect(mainOnlyExists).toBe(false);
         });
 
-        test('returns main-checkout when run from the primary working tree', async () => {
+        test('returns mainCheckout: true when run from the primary working tree', async () => {
+            await seedMainSubdirs();
+
             const result = await symlinkDataDir({
                 mainCheckout: fakeMainCheckout,
                 projectRoot : fakeMainCheckout, // same path = primary working tree
+                subdirs     : fixtureSubdirs,
                 log         : () => {}
             });
-            expect(result).toBe('main-checkout');
 
-            // No link was created (the main checkout's own dataDir stays as a real dir).
-            const lstat = await fs.lstat(path.join(fakeMainCheckout, dataDir));
-            expect(lstat.isDirectory()).toBe(true);
-            expect(lstat.isSymbolicLink()).toBe(false);
+            expect(result.mainCheckout).toBe(true);
+            expect(result.linked).toHaveLength(0);
+            expect(result.alreadyLinked).toHaveLength(0);
+            expect(result.clobbered).toHaveLength(0);
+            expect(result.skippedNoSource).toHaveLength(0);
+
+            // No links were created in the main checkout's own data subdirs.
+            for (const subdir of fixtureSubdirs) {
+                const lstat = await fs.lstat(path.join(fakeMainCheckout, dataDir, subdir));
+                expect(lstat.isDirectory()).toBe(true);
+                expect(lstat.isSymbolicLink()).toBe(false);
+            }
         });
     });
 


### PR DESCRIPTION
Authored by Claude Opus 4.7 (1M context) (Claude Code). Session 594d8e82-3c69-4d66-8038-fcba9a96efa7.

Resolves #10432

Refines the closed predecessor #10224 (coarse-grained parent-level symlink) and unblocks the cross-process coherence gap empirically anchored across the 2026-04-27 session-arc (#10424).

## The Problem

`bootstrapWorktree.mjs --link-data` previously symlinked the entire `.neo-ai-data/` directory atomically. With `--force`, it `fs.rm`d the existing dir recursively before symlinking. This conflicted with the gitignore boundary inside `.neo-ai-data/`:

```
.neo-ai-data
!.neo-ai-data/concepts/
```

Everything is gitignored EXCEPT `concepts/` which IS git-tracked. All-symlink hides the worktree's tracked `concepts/` files; `--force` clobbers them entirely. Both outcomes break the worktree-local concepts substrate.

**Empirical pattern from this session-arc:** 11 worktrees on disk, only 1 correctly symlinked; 10 had regular dirs and isolated DBs invisible to canonical's bridge daemon. MCP servers across worktrees couldn't see each other's writes — exactly the cross-process coherence gap (#10424).

## The Fix

- **`DATA_SUBDIRS_TO_LINK`** — new exported allowlist of gitignored substrate-data subdirs: `sqlite`, `chroma`, `wake-daemon`, `backups`, `datasets`, `neo-sqlite`. `concepts/` is NEVER in the default allowlist → never touched, regardless of `--force`.
- **`symlinkDataDir`** rewritten to iterate per-subdir. Each subdir is independently:
  - Skip if already symlink (`alreadyLinked`)
  - Skip if missing in canonical (`skippedNoSource`)
  - Throw if non-symlink dir + `force=false` (data-loss guard preserved)
  - Clobber + symlink if non-symlink dir + `force=true`
  - Symlink if dst absent
- Returns per-subdir result map: `{linked, alreadyLinked, clobbered, skippedNoSource, mainCheckout}` instead of the previous single string.
- CLI handler updated to print per-subdir result lines.
- Parent `.neo-ai-data/` left as a regular directory (preserves the worktree's tracked `concepts/`).

## Why This Is the Right Substrate

The gitignore boundary is the source of truth for what's safe to symlink. An explicit allowlist captures it transparently in code without coupling the bootstrap to git-tracking introspection at runtime. The data-loss guard is preserved per-subdir so a corrupted `sqlite/` can be reset without nuking everything else.

**`wake-daemon/` symlinking specifically unifies:**
- #10423's PID-lock singleton enforcement across worktrees
- #10425's persistent log substrate across worktrees

Without it, daemons spawned from different worktrees can't see each other's locks.

## Test Evidence

- 13 tests pass in this PR's scope: 5 existing config-copy + 8 new for #10432
- 5 existing #10351 install/build tests unchanged
- Total: 18/18 passing locally (1.1s)
- Coverage: exports invariants (concepts/ NEVER in default allowlist), full symlink flow, per-subdir idempotency over partial state, refuse-clobber-without-force, force-clobber per-subdir, missing-source graceful skip, **NEVER touches concepts/ even with force=true** (the load-bearing safety check), main-checkout mode

## Post-Merge Validation

- [ ] After merge: existing broken worktrees (regular `.neo-ai-data/sqlite/` dirs) can run `node ai/scripts/bootstrapWorktree.mjs --link-data --force` to fix themselves without clobbering `concepts/`
- [ ] Bridge daemon's PID-lock singleton enforcement spans worktrees once they're symlinked (verify via `lsof` on `bridge-daemon.pid`)
- [ ] A2A mailbox messages reach all MCP servers (verify by sending from worktree A, reading from worktree B + canonical)

## Out of Scope

- Auto-discovery via `git check-ignore` per-subdir (deferred — hardcoded allowlist is more conservative; substrate-data subdir set is small + stable; revisit if churn warrants)
- Migration script for existing broken worktrees (manual `rm -rf` + `ln -s` is one-shot; no tooling needed)
- Bridge-daemon-side changes for non-symlinked deployments (out of scope; this fix addresses the substrate, not the consumer)

## Related

- Closes #10432
- Closed predecessor: #10224 (coarse-grained symlink that this refines)
- Related substrate bug: #10424 (cross-process coherence gap that the granular fix unblocks)
- Singleton enforcement that depends on `wake-daemon/` symlinking: #10423
- Persistent log substrate that depends on `wake-daemon/` symlinking: #10425

🤖 Generated with [Claude Code](https://claude.com/claude-code)