### PR TITLE
fix(memory-core): auto-invoke wake subscription bootstrap on MCP server boot (#10437)

### DIFF
--- a/ai/mcp/server/memory-core/Server.mjs
+++ b/ai/mcp/server/memory-core/Server.mjs
@@ -121,6 +121,37 @@ class Server extends Base {
             // unhealthy because mailbox is an optional feature and single-tenant fallthrough
             // is a valid operational mode (see MemoryCoreMcpAuth.md contract).
             HealthService.setStdioIdentityState(this.stdioIdentity);
+
+            // Auto-invoke wake subscription bootstrap (per #10437; closes the missing AC from
+            // #10402 Phase 1). Without this, every new session boots with zero active
+            // WAKE_SUBSCRIPTION nodes for the bound identity until an agent manually calls
+            // `manage_wake_subscription({action: 'bootstrap'})` — a discipline burden that
+            // does not survive context-pruning. The substrate-level auto-invoke makes the
+            // wake-substrate genuinely self-healing, mirroring the #10181/#10182 dispatch-time
+            // identity-binding self-heal pattern.
+            //
+            // Fire-and-forget: bootstrap failure must not gate boot. `WakeSubscriptionService.bootstrap()`
+            // throws when the bound identity lacks a `subscriptionTemplate` — that's a legitimate
+            // configuration state for unseeded identities (single-tenant fallthrough), not a fatal
+            // error. Caught + logged at warn level. `RequestContextService.run()` is required so
+            // that `bootstrap()`'s `getAgentIdentityNodeId()` resolves to the bound identity.
+            //
+            // Safe to repeat across restarts per #10412's raw-SQL idempotency check — already-
+            // existing subs return `status: 'existing'` rather than creating duplicates.
+            if (this.stdioIdentity?.agentIdentityNodeId) {
+                RequestContextService.run(this.stdioIdentity, async () => {
+                    try {
+                        const result = await WakeSubscriptionService.bootstrap();
+                        logger.info(`[neo-memory-core MCP] Wake subscription auto-bootstrap: ${result.status} (${result.subscriptionId})`);
+                    } catch (err) {
+                        logger.warn(`[neo-memory-core MCP] Wake subscription auto-bootstrap skipped (non-fatal): ${err.message}`);
+                    }
+                }).catch(err => {
+                    // Defensive guard — RequestContextService.run() shouldn't itself throw, but
+                    // never let auto-invoke leak an unhandled rejection up to the boot path.
+                    logger.warn(`[neo-memory-core MCP] Wake subscription auto-bootstrap context error (non-fatal): ${err.message}`);
+                });
+            }
         }
 
         // 6. Perform Health Check & Log Status (sees populated stdioIdentityState post-reorder)

--- a/ai/mcp/server/memory-core/Server.mjs
+++ b/ai/mcp/server/memory-core/Server.mjs
@@ -130,27 +130,39 @@ class Server extends Base {
             // wake-substrate genuinely self-healing, mirroring the #10181/#10182 dispatch-time
             // identity-binding self-heal pattern.
             //
-            // Fire-and-forget: bootstrap failure must not gate boot. `WakeSubscriptionService.bootstrap()`
-            // throws when the bound identity lacks a `subscriptionTemplate` — that's a legitimate
-            // configuration state for unseeded identities (single-tenant fallthrough), not a fatal
-            // error. Caught + logged at warn level. `RequestContextService.run()` is required so
-            // that `bootstrap()`'s `getAgentIdentityNodeId()` resolves to the bound identity.
+            // **Single-error-boundary design:** wrapping the entire `RequestContextService.run()`
+            // call inside an async IIFE's try/catch unifies error handling across all failure
+            // sources — synchronous throws during `RequestContextService.run()` setup, synchronous
+            // throws inside `bootstrap()`'s setup before its first `await` (e.g., the
+            // identity-binding guard at WakeSubscriptionService.mjs:209), and asynchronous
+            // rejections from `bootstrap()`'s SQLite/GraphService awaits all converge on the same
+            // catch. Fire-and-forget by not awaiting the IIFE — boot continues unconditionally
+            // (per @neo-gemini-3-1-pro's PR #10438 cycle 1 challenge: tightens the dual-catch
+            // pattern that the original implementation used; the IIFE's try/catch is the
+            // canonical single error boundary for fire-and-forget async operations).
             //
-            // Safe to repeat across restarts per #10412's raw-SQL idempotency check — already-
-            // existing subs return `status: 'existing'` rather than creating duplicates.
+            // **`RequestContextService.run()` rationale:** `bootstrap()` calls
+            // `RequestContextService.getAgentIdentityNodeId()` (line 208 of WakeSubscriptionService),
+            // which throws unless executed inside a `run()` scope — so the wrap is required, not
+            // ceremonial. The identity context shape `{userId, username, agentIdentityNodeId, source}`
+            // is the same one the per-tool dispatch wrap consumes downstream.
+            //
+            // **Idempotency:** safe to repeat across restarts per #10412's raw-SQL idempotency
+            // check — already-existing subs return `status: 'existing'` rather than creating
+            // duplicates. Missing-template throws are caught + logged at warn level (legitimate
+            // single-tenant fallthrough; not a fatal boot error).
             if (this.stdioIdentity?.agentIdentityNodeId) {
-                RequestContextService.run(this.stdioIdentity, async () => {
+                (async () => {
                     try {
-                        const result = await WakeSubscriptionService.bootstrap();
+                        const result = await RequestContextService.run(
+                            this.stdioIdentity,
+                            () => WakeSubscriptionService.bootstrap()
+                        );
                         logger.info(`[neo-memory-core MCP] Wake subscription auto-bootstrap: ${result.status} (${result.subscriptionId})`);
                     } catch (err) {
                         logger.warn(`[neo-memory-core MCP] Wake subscription auto-bootstrap skipped (non-fatal): ${err.message}`);
                     }
-                }).catch(err => {
-                    // Defensive guard — RequestContextService.run() shouldn't itself throw, but
-                    // never let auto-invoke leak an unhandled rejection up to the boot path.
-                    logger.warn(`[neo-memory-core MCP] Wake subscription auto-bootstrap context error (non-fatal): ${err.message}`);
-                });
+                })();
             }
         }
 


### PR DESCRIPTION
Authored by Claude Opus 4.7 (1M context) (Claude Code). Session b3c0bfb8-44e1-4646-9c62-110ef16b0fad.

Resolves #10437

Closes the missing AC from #10402 (Phase 1 wake substrate self-healing). The merged implementation (#10404 + #10412) delivered the bootstrap mechanism — idempotent, restart-safe, identity-template-driven — but never wired up the auto-trigger.

## The Problem

Every new agent session today silently has zero `WAKE_SUBSCRIPTION` nodes for the bound identity until someone manually calls `manage_wake_subscription({action: 'bootstrap'})`. Without the auto-invoke, the bridge daemon polls but has nothing to deliver to → no `[WAKE]` events → silent wake-substrate degradation.

**Empirical anchor (2026-04-27, this session):** post-#10433 merge + harness restart, my MCP server bound `@neo-opus-4-7` and ran for ~2 hours with zero WAKE_SUB for the bound identity. Bridge daemon (PID 12039) was running healthy in canonical, polling, but had nothing to deliver to. A2A read/write paths verified working; wake delivery silently broken until the gap was diagnosed.

**The original #10402 AC was explicit about this:**
> *"AGENTS_STARTUP.md boot sequence invokes `bootstrap` so new sessions self-heal to a known-good subscription"*
> *"Post-merge validation: new session boots auto-bootstrap their subscription... Verify by terminating + restarting both harnesses; both wake substrates should self-heal without manual scratch-script intervention."*

The implementation closed #10402 prematurely with this AC item unshipped.

## The Fix

After `StdioIdentityResolver` binds identity at MCP server boot (`Server.mjs:117`), fire-and-forget `WakeSubscriptionService.bootstrap()` wrapped in `RequestContextService.run()` so `getAgentIdentityNodeId()` resolves to the bound identity. Failure is logged at warn level + boot continues — bootstrap legitimately throws when the identity lacks a `subscriptionTemplate` (single-tenant fallthrough is a valid mode).

```javascript
if (this.stdioIdentity?.agentIdentityNodeId) {
    RequestContextService.run(this.stdioIdentity, async () => {
        try {
            const result = await WakeSubscriptionService.bootstrap();
            logger.info(`[neo-memory-core MCP] Wake subscription auto-bootstrap: ${result.status} (${result.subscriptionId})`);
        } catch (err) {
            logger.warn(`[neo-memory-core MCP] Wake subscription auto-bootstrap skipped (non-fatal): ${err.message}`);
        }
    }).catch(err => {
        logger.warn(`[neo-memory-core MCP] Wake subscription auto-bootstrap context error (non-fatal): ${err.message}`);
    });
}
```

## Why Server-Side (Not Doc-Only AGENTS_STARTUP.md)

Discipline-layer mandates depend on agent compliance + survive context-pruning poorly. Per **#10181/#10182 precedent** (identity-binding self-heal at dispatch level), the right answer for lifecycle-gap class problems is substrate-level auto-trigger.

The doc-only fix would be a half-measure: future sessions wouldn't know about it, and the substrate must self-heal regardless. Per @tobiu's framing: *"this affects every new session, and future you won't know about it."*

## Safety Properties

| Property | Mechanism |
|---|---|
| Idempotent | Per #10412's raw-SQL fix — safe to repeat across restarts; existing subs return `status: 'existing'` not duplicates |
| Boot-safe | Fire-and-forget — bootstrap failure does not gate boot |
| Identity-aware | Wrapped in `RequestContextService.run()` so `bootstrap()` resolves the bound identity |
| Crash-safe | Defensive `.catch()` on outer promise — never leaks unhandled rejection |
| Single-tenant compatible | Skips silently when `stdioIdentity?.agentIdentityNodeId` is null |

## Test Evidence

All 25 existing `WakeSubscriptionService.spec.mjs` tests pass — the auto-invoke uses well-tested primitives (`bootstrap()` template-creation + idempotency + missing-template throw paths are all covered).

The new behavior is the call-site wiring in `Server.mjs`, which has no direct test surface (server.mjs has many init side-effects + transport binding that resist isolated unit-testing). AC includes a manual post-merge validation step.

## Post-Merge Validation

- [ ] Terminate + restart harnesses + bridge daemon
- [ ] Verify `[neo-memory-core MCP] Wake subscription auto-bootstrap: created (WAKE_SUB:...)` log line appears at server boot for both `@neo-opus-4-7` and `@neo-gemini-3-1-pro`
- [ ] Verify `SELECT * FROM Nodes WHERE label='WAKE_SUBSCRIPTION'` shows auto-seeded subs for both identities
- [ ] Verify `[WAKE]` injection fires on next A2A message in receiver harness — without any manual `manage_wake_subscription` call

## Out of Scope

- **OIDC-mode dispatch-time self-heal** — defer; stdio is the dominant swarm path today; file as follow-up if/when OIDC mode is exercised
- **AGENTS_STARTUP.md mandate** — the original #10402 AC item; can be added as defense-in-depth in a tiny follow-up; not blocking; the substrate-level auto-invoke is the load-bearing fix per #10181/#10182 precedent

## Avoided Traps

- **Trap:** Doc-only mandate in AGENTS_STARTUP.md. **Avoided:** lifecycle-gap problems require substrate-level fixes per #10181/#10182 precedent.
- **Trap:** Synchronous boot-await on bootstrap. **Avoided:** bootstrap can fail (no template, GraphService not ready); fire-and-forget keeps boot resilient.
- **Trap:** Re-derive subscription metadata from env vars / IDE-detection inside auto-invoke. **Avoided:** that's exactly the footgun #10402 closed by introducing `subscriptionTemplate` as canonical.

## Related

- Predecessor (closed prematurely): #10402 (Phase 1 wake substrate self-healing — original scope included this auto-trigger)
- Implementation PR that closed #10402 without this AC: #10404
- Idempotency fix on top: #10412 — makes auto-invoke safe to repeat
- Architectural precedent for substrate-level auto-heal: #10181 / #10182
- Cross-process coherence root cause that exposed this gap: #10424
- Substrate-level fix that restored coherence: #10433 / #10436

🤖 Generated with [Claude Code](https://claude.com/claude-code)