### PR TITLE
fix(graph): set Gemini's identity-root appName to 'Antigravity' (#10440)

### DIFF
--- a/ai/graph/identityRoots.mjs
+++ b/ai/graph/identityRoots.mjs
@@ -45,7 +45,12 @@ export const IDENTITIES = [
                 trigger: 'SENT_TO_ME',
                 harnessTarget: 'bridge-daemon',
                 harnessTargetMetadata: {
-                    appName: 'Cursor',
+                    // Per #10440: the macOS app is `Antigravity` (Google's IDE forked from
+                    // Cursor; CFBundleName + CFBundleDisplayName: 'Antigravity'). Empirically
+                    // verified via `osascript -e 'tell application "Antigravity" to activate'`
+                    // → exit 0; the prior `'Cursor'` placeholder failed with `Can't get
+                    // application "Cursor". (-1728)` exit 1.
+                    appName: 'Antigravity',
                     tabShortcut: null
                 }
             },


### PR DESCRIPTION
Authored by Claude Opus 4.7 (1M context) (Claude Code). Session c68a7d4b-909a-4965-9bf9-116906d271a3.

Resolves #10440

## The Problem

Surfaced during post-#10438 end-to-end wake-substrate validation. Wake delivery is asymmetric:

- ✅ **Gemini → Claude**: WAKE event delivered via osascript to \`Claude\` app
- ❌ **Claude → Gemini**: \`[Bridge Daemon] Failed to deliver via osascript: osascript exited with code 1\`

@tobiu's bridge daemon log:
\`\`\`
[2026-04-27T19:28:05Z] [INFO] Delivered WAKE_SUB:4f5ba204-... via osascript to Claude
[2026-04-27T19:29:18Z] [ERROR] Failed to deliver via osascript: osascript exited with code 1
\`\`\`

## Root Cause

\`ai/graph/identityRoots.mjs:48\` sets \`@neo-gemini-3-1-pro\`'s \`subscriptionTemplate.harnessTargetMetadata.appName = 'Cursor'\`. But the actual macOS app is **Antigravity**:

| Probe | Result |
|---|---|
| \`/Applications/Cursor.app\` | Does not exist |
| \`/Applications/Antigravity.app\` | Exists |
| \`CFBundleName\` | \`Antigravity\` |
| \`CFBundleDisplayName\` | \`Antigravity\` |
| \`CFBundleIdentifier\` | \`com.google.antigravity\` |
| \`osascript -e 'tell application "Cursor" to activate'\` | \`Can't get application "Cursor". (-1728)\` exit 1 |
| \`osascript -e 'tell application "Antigravity" to activate'\` | exit 0 |

Antigravity is Google's IDE forked from Cursor, but the macOS app's identity is \`Antigravity\`. The \`'Cursor'\` placeholder was set at #10404 merge time and never empirically validated end-to-end until today's auto-bootstrap (#10437/#10438) made wake delivery testable.

## The Fix

One-line correction in \`ai/graph/identityRoots.mjs:48\`. Inline comment captures the empirical-anchor reasoning so future template edits don't regress.

## Live-Data Follow-Up (NOT Included in This PR)

The existing \`@neo-gemini-3-1-pro\` AgentIdentity node + her current \`WAKE_SUB:de10611c\` were created from the bad template and contain the cached wrong \`appName\`. Two paths post-merge:

1. **Re-seed** via \`seedAgentIdentities.mjs\` (touches all identities — safe but broad)
2. **Targeted SQL UPDATE** on the two affected nodes (minimal, reversible):
   \`\`\`sql
   -- Patch AgentIdentity template
   UPDATE Nodes SET data = json_replace(data, '\$.properties.subscriptionTemplate.harnessTargetMetadata.appName', 'Antigravity')
   WHERE id = '@neo-gemini-3-1-pro';

   -- Patch existing WAKE_SUB metadata (one-shot copied from template at subscribe-time)
   UPDATE Nodes SET data = json_replace(data, '\$.properties.harnessTargetMetadata.appName', 'Antigravity')
   WHERE id = 'WAKE_SUB:de10611c-bd3a-4ec4-8dc0-49c487a4f5c2';
   \`\`\`

Awaiting @tobiu's authorization on which option + execution.

## Test Evidence

No test file for \`identityRoots.mjs\` (static data module). The AC is empirically validated post-merge.

## Post-Merge Validation

- [ ] Apply live-data patch (re-seed OR targeted SQL UPDATE per @tobiu's choice)
- [ ] Send Claude → Gemini A2A test ping
- [ ] Verify bridge daemon log shows \`Delivered WAKE_SUB:de10611c-... via osascript to Antigravity\`
- [ ] Verify \`[WAKE]\` event injection in Gemini's harness console

## Out of Scope

- Adding \`Antigravity\` to \`bridge-daemon.mjs:506\` default \`tabShortcut\` mapping (Gemini's template explicitly sets \`tabShortcut: null\`, so the fallback never fires for her)
- Auditing other identity-root templates for similar app-name placeholders (none currently exist)
- Runtime validator for \`tell application <appName> to exists\` before delivery (architecturally cleaner but bigger scope; #10425's persistent log already enables post-hoc diagnosis)

## Related

- Surfaced by: #10437 / PR #10438 (auto-bootstrap shipped → end-to-end wake delivery testable for first time)
- Original template author: #10404 (closed #10402 with \`'Cursor'\` placeholder)
- Persistent log substrate that captured the failure: #10419 / PR #10425

🤖 Generated with [Claude Code](https://claude.com/claude-code)