### PR TITLE
feat(bridge-daemon): fail-fast on empty appName metadata (#10443)

### DIFF
--- a/ai/scripts/bridge-daemon.mjs
+++ b/ai/scripts/bridge-daemon.mjs
@@ -495,7 +495,17 @@ async function deliverDigest(subscription, digest) {
             await spawnAsync('tmux', ['send-keys', '-t', tmuxSession, digest, 'C-m']);
             writeLog('INFO', `[Bridge Daemon] Delivered ${subscription.id} via tmux to session ${tmuxSession}`);
         } else if (adapter === 'osascript') {
-            const appName = meta.appName || 'Claude';
+            const appName = meta.appName;
+            if (!appName) {
+                writeLog('ERROR', 
+                    `[Bridge Daemon] Cannot deliver subscription ${subscription.id}: ` +
+                    `harnessTargetMetadata.appName is missing/empty. ` +
+                    `Skipping delivery to avoid misrouting. ` +
+                    `Verify subscription template via 'manage_wake_subscription({action: \\'list\\'})' ` +
+                    `or fix the AgentIdentity subscriptionTemplate.`
+                );
+                return;
+            }
             let tabShortcut = meta.tabShortcut;
             // In April 2026, Claude Desktop features 3 main tabs: Chat (Cmd+1), Cowork (Cmd+2), and Code (Cmd+3).
             // We default to '3' to automatically switch to the Code tab for agentic tasks.

--- a/test/playwright/unit/ai/scripts/bridge-daemon.spec.mjs
+++ b/test/playwright/unit/ai/scripts/bridge-daemon.spec.mjs
@@ -240,4 +240,74 @@ test.describe('Bridge Daemon', () => {
         expect(finalDigest).toContain('1 new messages');
         expect(finalDigest).toContain('Test Dedup Event');
     });
+
+    test('skips osascript delivery and logs error when appName is missing', async () => {
+        const subId = 'sub_' + crypto.randomUUID();
+        const agentId = '@test-agent-empty';
+
+        db.prepare('INSERT OR REPLACE INTO Nodes (id, data) VALUES (?, ?)').run(agentId, JSON.stringify({
+            id: agentId,
+            label: 'AGENT',
+            properties: { name: 'Test Agent Empty' }
+        }));
+
+        db.prepare('INSERT OR REPLACE INTO Nodes (id, data) VALUES (?, ?)').run(subId, JSON.stringify({
+            id: subId,
+            label: 'WAKE_SUBSCRIPTION',
+            properties: {
+                agentIdentity: agentId,
+                harnessTarget: 'bridge-daemon',
+                status: 'active',
+                trigger: 'SENT_TO_ME',
+                harnessTargetMetadata: {
+                    adapter: 'osascript',
+                    coalesceWindow: 1 // 1 second for fast test
+                    // appName intentionally omitted
+                }
+            }
+        }));
+
+        db.prepare('INSERT INTO GraphLog (entity_id, entity_type) VALUES (?, ?)').run(subId, 'nodes');
+
+        daemonProcess = spawn('node', ['ai/scripts/bridge-daemon.mjs'], {
+            stdio: 'pipe',
+            env: { ...process.env, NEO_AI_DB_PATH: DB_PATH, NEO_AI_DAEMON_DIR: DAEMON_DIR }
+        });
+
+        const errorLogPromise = new Promise((resolve, reject) => {
+            const timeout = setTimeout(() => reject(new Error('Daemon failed to log error within timeout')), 10000);
+            
+            daemonProcess.stderr.on('data', (data) => {
+                const out = data.toString();
+                if (out.includes('harnessTargetMetadata.appName is missing/empty')) {
+                    clearTimeout(timeout);
+                    resolve(out);
+                }
+            });
+            daemonProcess.on('error', reject);
+        });
+
+        await new Promise(resolve => setTimeout(resolve, 1000));
+
+        const msgId = 'msg_' + crypto.randomUUID();
+        db.prepare('INSERT INTO Nodes (id, data) VALUES (?, ?)').run(msgId, JSON.stringify({
+            id: msgId,
+            label: 'MESSAGE',
+            properties: { from: '@sender', subject: 'Test Empty AppName' }
+        }));
+        db.prepare('INSERT INTO GraphLog (entity_id, entity_type) VALUES (?, ?)').run(msgId, 'nodes');
+
+        const edgeId = 'edge_' + crypto.randomUUID();
+        db.prepare('INSERT INTO Edges (id, data, source, target, type) VALUES (?, ?, ?, ?, ?)').run(edgeId, JSON.stringify({
+            id: edgeId,
+            source: msgId,
+            target: agentId,
+            type: 'SENT_TO'
+        }), msgId, agentId, 'SENT_TO');
+        db.prepare('INSERT INTO GraphLog (entity_id, entity_type) VALUES (?, ?)').run(edgeId, 'edges');
+
+        const output = await errorLogPromise;
+        expect(output).toContain('[Bridge Daemon] Cannot deliver subscription');
+        expect(output).toContain(subId);
+    });
 });


### PR DESCRIPTION
## Agentic Implementation
- **Agent Identity:** `@neo-gemini-3-1-pro`
- **Origin Session:** `49e9b05a-0581-4fb7-861f-7e4970ea4c2b`

## Summary
Replaced the silent heuristic fallback (`|| 'Claude'`) for `appName` with an explicit fail-fast logging boundary. If `appName` is missing from the subscription metadata, the daemon now logs an ERROR and skips `osascript` delivery. This converts an implicit, silent misroute into a visible diagnostic event, ensuring the wake substrate fails deterministically.

**Includes:**
- `ai/scripts/bridge-daemon.mjs` logic replacement
- Unit test to verify fail-fast error skip logic in `test/playwright/unit/ai/scripts/bridge-daemon.spec.mjs`

Closes #10443
