### PR TITLE
feat(ai): implement manual session summarization (#10458)

### DIFF
--- a/ai/scripts/summarize-sessions.mjs
+++ b/ai/scripts/summarize-sessions.mjs
@@ -1,0 +1,39 @@
+/**
+ * @module ai/scripts/summarize-sessions
+ * @summary Manual session-summarization trigger for Memory Core context refresh.
+ *
+ * Backfills chronological session summaries into the Memory Core's `neo-agent-sessions`
+ * Chroma collection, bypassing the auto-summarization that was disabled on MC server
+ * startup per #9942 (daemon-collision fix). Operator-runnable via `npm run ai:summarize-sessions`.
+ *
+ * Defaults to last-30-days lookback (`includeAll: false`); for fresh-deployment
+ * full-summarization, edit the call-site or extend with a `--include-all` CLI flag (future).
+ *
+ * @see ai/mcp/server/memory-core/services/SessionService.summarizeSessions
+ * @see #10458 (origin), #9942 (daemon-collision context)
+ */
+import { Memory_SessionService } from '../services.mjs';
+
+async function summarize() {
+    console.log('[summarize-sessions] Initializing SessionService...');
+    try {
+        await Memory_SessionService.initAsync();
+        
+        console.log('[summarize-sessions] Starting session summarization...');
+        // includeAll: false will only summarize sessions from the last 30 days
+        const result = await Memory_SessionService.summarizeSessions({ includeAll: false });
+        
+        if (result && result.error) {
+            console.error(`[summarize-sessions] Summarization failed: ${result.message}`);
+            process.exit(1);
+        }
+        
+        console.log(`[summarize-sessions] Summarization complete. Processed: ${result?.processed || 0}`);
+        process.exit(0);
+    } catch (err) {
+        console.error('[summarize-sessions] Error:', err);
+        process.exit(1);
+    }
+}
+
+summarize();

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
         "ai:server"                    : "chroma run --path ./.neo-ai-data/chroma/knowledge-base",
         "ai:server-memory"             : "chroma run --path ./.neo-ai-data/chroma/memory-core --port 8001",
         "ai:server-neural-link"        : "node ./ai/mcp/server/neural-link/run-bridge.mjs",
+        "ai:summarize-sessions"        : "node ./ai/scripts/summarize-sessions.mjs",
         "ai:sync-kb"                   : "node ./buildScripts/ai/syncKnowledgeBase.mjs",
         "build-all"                    : "node ./buildScripts/build/all.mjs -f -n",
         "build-all-questions"          : "node ./buildScripts/build/all.mjs -f",


### PR DESCRIPTION
Authored by Gemini 3.1 Pro (Antigravity). Session <e215cb77-3baf-48de-b634-7a53e924553c>.

Resolves #10458

This PR implements the `ai:summarize-sessions` script to manually backfill chronological session summaries into the Memory Core. This allows administrators and agents to update the semantic context without re-enabling auto-summarization on the MCP server boot sequence (which caused daemon collisions).

## Deltas from ticket
None. Implemented as designed using the internal `Memory_SessionService` directly.

## Test Evidence
Manually executed `npm run ai:summarize-sessions` locally. Verified 30-day lookback executed properly and successfully generated summaries without daemon conflicts.