### PR TITLE
fix(ai): implement SQLite chunking for bridge-daemon (#10465)

### DIFF
--- a/ai/scripts/bridge-daemon-queries.mjs
+++ b/ai/scripts/bridge-daemon-queries.mjs
@@ -44,13 +44,25 @@ export function getGraphLogEntries(db, lastSyncId) {
 export function getNodesData(db, nodeIds) {
     if (!nodeIds || nodeIds.size === 0) return [];
     const ids = Array.from(nodeIds);
-    return db.prepare(`SELECT id, data FROM Nodes WHERE id IN (${ids.map(() => '?').join(',')})`).all(...ids);
+    let results = [];
+    for (let i = 0; i < ids.length; i += 400) {
+        let chunk = ids.slice(i, i + 400);
+        let placeholders = chunk.map(() => '?').join(',');
+        results = results.concat(db.prepare(`SELECT id, data FROM Nodes WHERE id IN (${placeholders})`).all(...chunk));
+    }
+    return results;
 }
 
 export function getEdgesData(db, edgeIds) {
     if (!edgeIds || edgeIds.size === 0) return [];
     const ids = Array.from(edgeIds);
-    return db.prepare(`SELECT id, data, source, target, type FROM Edges WHERE id IN (${ids.map(() => '?').join(',')})`).all(...ids);
+    let results = [];
+    for (let i = 0; i < ids.length; i += 400) {
+        let chunk = ids.slice(i, i + 400);
+        let placeholders = chunk.map(() => '?').join(',');
+        results = results.concat(db.prepare(`SELECT id, data, source, target, type FROM Edges WHERE id IN (${placeholders})`).all(...chunk));
+    }
+    return results;
 }
 
 export function getDbNode(db, id) {


### PR DESCRIPTION
Resolves #10465

Authored by Gemini 3.1 Pro (Antigravity). Session e215cb77-3baf-48de-b634-7a53e924553c.

This PR mirrors the SQLite parameter limit fix from the `Memory Core` over to the standalone `bridge-daemon`. The bridge daemon uses `bridge-daemon-queries.mjs` to connect directly to the graph database to poll for `WAKE_SUBSCRIPTION` nodes and edge changes.

During heavy extraction loads (e.g., `runSandman` generating thousands of Tri-Vector concepts), the `getNodesData` and `getEdgesData` queries were hitting the SQLite 999 parameter limit in their `IN (...)` arrays and crashing the daemon's poll loop.

This fix batches array lookups into chunks of 400.

## Deltas from ticket
- None.

## Test Evidence
- The previous crash log (`Error in poll loop: SqliteError: too many SQL variables`) explicitly flagged `getEdgesData`. This 400-item chunking has already proven stable in the Memory Core `SQLite.mjs` driver under identical load.