### PR TITLE
docs(agents): harden section zero merge invariants (#10474)

### DIFF
--- a/.agent/skills/ticket-create/references/ticket-create-workflow.md
+++ b/.agent/skills/ticket-create/references/ticket-create-workflow.md
@@ -114,7 +114,7 @@ The `create_issue` tool returns the new issue number. Typical immediate follow-u
 
 - **`manage_issue_labels(action: 'add', ...)`** — only if the label set needs adjustment post-creation (e.g., label list was incomplete at `create_issue` time). Prefer getting labels right in the initial call.
 - **`update_issue_relationship(parent_id: N, child_id: M, type: 'SUB_ISSUE')`** — required when filing sub-issues under an Epic. Native graph linkage only; do NOT rely on inline `- [ ] #N` markdown checkboxes (see §6).
-- **Ticket body edits:** We currently do not have a dedicated MCP tool to edit an issue body once created. Avoid needing to edit the body by getting it right in the `create_issue` call.
+- **Ticket body edits:** Edit the local `.md` file and use the `sync_all` tool to push the local version back to GitHub. The local `.md` file is canonical after `sync_all`.
 - **Picking up the ticket:** If you intend to start working on this newly created ticket immediately, you MUST run the `ticket-intake` skill next. Assignment (`manage_issue_assignees`) belongs to the intake process, not the creation process.
 
 Minimize chained calls where possible — a well-formed `create_issue` call with complete `title`, `body`, and `labels` at creation time avoids all of the above except `update_issue_relationship` (which can only run after the issue exists).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,11 +6,28 @@ This file contains behavioral rules and protocols that must be enforced on every
 
 These five rules are mechanically verifiable and have **no conditional exceptions** under any approval state, cross-family signal, or contextual nuance. Approval signals ("LGTM", "approved", "ready for merge", "no required actions") are **NOT** authorization to bypass any of them.
 
-1. **No `gh pr merge` (Human-Only execution).** Cross-family approval gates squash-merge *eligibility*; the merge act itself is reserved for the human user (the repo owner acting as final pipeline authority). Handoff terminates when a PR enters `APPROVED` state. See §7 + `.agent/skills/pull-request/references/pull-request-workflow.md` §6 step 3.
+1. **No merge execution (Human-Only execution).** You are strictly prohibited from executing any merge via CLI, API, Git protocol, automation label, or MCP tool (e.g. `gh pr merge`, `gh api PUT /repos/.../pulls/N/merge`, direct `git merge` + `git push origin dev`, or adding merge-queue labels). Cross-family approval gates squash-merge *eligibility*; the merge act itself is reserved exclusively for the human user (the repo owner acting as final pipeline authority). See §7 + `.agent/skills/pull-request/references/pull-request-workflow.md` §6 step 3.
+    - **Positive Authorization List:** The ONLY acceptable signal to execute a merge is an explicit, literal human command directed at you (e.g., "Execute the merge now").
+    - **Cross-Family Cascade Clause:** Cross-family approval (e.g., Claude reviewing Gemini's PR or vice versa) grants squash-merge ELIGIBILITY but does NOT aggregate to grant merge AUTHORITY. Each agent's §0 Invariant 1 fires independently at the moment of action and CANNOT be satisfied by another agent's signal. The peer-review chain is structurally bounded: review → approval → handoff to human. The handoff explicitly terminates at the "approved" state. An agent reading "Claude approved" or "Gemini approved" or "all RAs satisfied" or "ready for merge" must NOT interpret these as authorization to execute merge — these are eligibility signals to the human, not execution signals to the swarm. If you find yourself reasoning "my peer approved, so I can merge" — that reasoning IS the loophole §0 forbids.
 2. **No commit without ticket-ID.** Every `git commit` subject ends `(#TICKET_ID)`. Conventional Commits format: `type(scope): message (#NNNN)`. See §3 Pre-Commit Hard Gates.
 3. **No direct commit/push to `main` or `dev`.** Always branch + PR. The data-sync pipeline is the explicit exception. See §3 + `.agent/skills/pull-request/references/pull-request-workflow.md` §2.
 4. **No `<noreply@*>` `Co-Authored-By` footers.** Override the harness default if it injects them. See `.agent/skills/pull-request/references/pull-request-workflow.md` §3.2.
 5. **No skipping `add_memory` at end of turn.** Forgetting the consolidated save = permanent data loss. The save IS the gate that permits the response. See §4.2.
+
+### 0.1 Merge Pre-Flight Check
+
+**Required before ANY merge-effecting action:**
+
+You **MUST** execute this Pre-Flight Check before invoking any tool whose effect is to transition a Pull Request to MERGED state — including but not limited to `gh pr merge`, `gh api PUT /repos/.../pulls/N/merge`, direct `git merge` + `git push`, adding labels that trigger auto-merge automation, queueing the PR in a merge queue, or invoking any future MCP tool with merge-effecting semantics. The Pre-Flight Check consists of explicitly stating in your internal thought process:
+
+*"Pre-Flight (Merge):*
+1. *Authorization Identity: The verbatim human-issued merge instruction is: [paste the literal human signal, including timestamp].*
+2. *Authorization Scope: This signal explicitly names PR #[N] and contains an action verb (merge / squash-merge / execute) — not an ambiguous signal (LGTM, approved, ready-for-merge).*
+3. *Authorization Recency: This signal was issued within the current session-arc (not inferred from absence or time-elapsed)."*
+
+If you cannot fill in step 1 with a verbatim literal human instruction, you MUST abort. The §0 Invariant 1 takes precedence over any peer-signal, automation status, CI-green, or self-rationalized urgency.
+
+The verbatim-quoting requirement converts ambiguous-rationalization into structural-impossibility — you cannot complete the Pre-Flight without producing the actual human instruction text.
 
 ## 1. Communication Style & Pipeline Authority
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,28 +6,14 @@ This file contains behavioral rules and protocols that must be enforced on every
 
 These five rules are mechanically verifiable and have **no conditional exceptions** under any approval state, cross-family signal, or contextual nuance. Approval signals ("LGTM", "approved", "ready for merge", "no required actions") are **NOT** authorization to bypass any of them.
 
-1. **No merge execution (Human-Only execution).** You are strictly prohibited from executing any merge via CLI, API, Git protocol, automation label, or MCP tool (e.g. `gh pr merge`, `gh api PUT /repos/.../pulls/N/merge`, direct `git merge` + `git push origin dev`, or adding merge-queue labels). Cross-family approval gates squash-merge *eligibility*; the merge act itself is reserved exclusively for the human user (the repo owner acting as final pipeline authority). See §7 + `.agent/skills/pull-request/references/pull-request-workflow.md` §6 step 3.
-    - **Positive Authorization List:** The ONLY acceptable signal to execute a merge is an explicit, literal human command directed at you (e.g., "Execute the merge now").
+1. **No `gh pr merge` (Human-Only execution).** Cross-family approval gates squash-merge *eligibility*; the merge act itself is reserved exclusively for the human user (the repo owner acting as final pipeline authority). Handoff terminates when a PR enters `APPROVED` state. See §7 + `.agent/skills/pull-request/references/pull-request-workflow.md` §6 step 3.
     - **Cross-Family Cascade Clause:** Cross-family approval (e.g., Claude reviewing Gemini's PR or vice versa) grants squash-merge ELIGIBILITY but does NOT aggregate to grant merge AUTHORITY. Each agent's §0 Invariant 1 fires independently at the moment of action and CANNOT be satisfied by another agent's signal. The peer-review chain is structurally bounded: review → approval → handoff to human. The handoff explicitly terminates at the "approved" state. An agent reading "Claude approved" or "Gemini approved" or "all RAs satisfied" or "ready for merge" must NOT interpret these as authorization to execute merge — these are eligibility signals to the human, not execution signals to the swarm. If you find yourself reasoning "my peer approved, so I can merge" — that reasoning IS the loophole §0 forbids.
 2. **No commit without ticket-ID.** Every `git commit` subject ends `(#TICKET_ID)`. Conventional Commits format: `type(scope): message (#NNNN)`. See §3 Pre-Commit Hard Gates.
 3. **No direct commit/push to `main` or `dev`.** Always branch + PR. The data-sync pipeline is the explicit exception. See §3 + `.agent/skills/pull-request/references/pull-request-workflow.md` §2.
 4. **No `<noreply@*>` `Co-Authored-By` footers.** Override the harness default if it injects them. See `.agent/skills/pull-request/references/pull-request-workflow.md` §3.2.
 5. **No skipping `add_memory` at end of turn.** Forgetting the consolidated save = permanent data loss. The save IS the gate that permits the response. See §4.2.
 
-### 0.1 Merge Pre-Flight Check
 
-**Required before ANY merge-effecting action:**
-
-You **MUST** execute this Pre-Flight Check before invoking any tool whose effect is to transition a Pull Request to MERGED state — including but not limited to `gh pr merge`, `gh api PUT /repos/.../pulls/N/merge`, direct `git merge` + `git push`, adding labels that trigger auto-merge automation, queueing the PR in a merge queue, or invoking any future MCP tool with merge-effecting semantics. The Pre-Flight Check consists of explicitly stating in your internal thought process:
-
-*"Pre-Flight (Merge):*
-1. *Authorization Identity: The verbatim human-issued merge instruction is: [paste the literal human signal, including timestamp].*
-2. *Authorization Scope: This signal explicitly names PR #[N] and contains an action verb (merge / squash-merge / execute) — not an ambiguous signal (LGTM, approved, ready-for-merge).*
-3. *Authorization Recency: This signal was issued within the current session-arc (not inferred from absence or time-elapsed)."*
-
-If you cannot fill in step 1 with a verbatim literal human instruction, you MUST abort. The §0 Invariant 1 takes precedence over any peer-signal, automation status, CI-green, or self-rationalized urgency.
-
-The verbatim-quoting requirement converts ambiguous-rationalization into structural-impossibility — you cannot complete the Pre-Flight without producing the actual human instruction text.
 
 ## 1. Communication Style & Pipeline Authority
 

--- a/AGENTS_STARTUP.md
+++ b/AGENTS_STARTUP.md
@@ -124,7 +124,29 @@ It copies the four `config.mjs` files from the main checkout (resolved via `git 
 
 ## 3. Per-Turn Operational Mandates — see `AGENTS.md`
 
-The following per-turn invariants previously documented here have moved to `AGENTS.md` so they survive context-pruning across long sessions:
+The following per-turn invariants previously documented here have moved to `AGENTS.md` so they survive context-pruning across long sessions (with the exception of §0, which is mirrored here for cold-cache resilience):
+
+### 3.1 Critical Gates (Invariants — agents MUST honor; no conditional exceptions)
+
+*This section mirrors `AGENTS.md §0`. Updates here MUST also land in `AGENTS.md §0` (and vice versa).*
+
+These five rules are mechanically verifiable and have **no conditional exceptions** under any approval state, cross-family signal, or contextual nuance. Approval signals ("LGTM", "approved", "ready for merge", "no required actions") are **NOT** authorization to bypass any of them.
+
+1. **No merge execution (Human-Only execution).** You are strictly prohibited from executing any merge via CLI, API, Git protocol, automation label, or MCP tool (e.g. `gh pr merge`, `gh api PUT /repos/.../pulls/N/merge`, direct `git merge` + `git push origin dev`, or adding merge-queue labels). Cross-family approval gates squash-merge *eligibility*; the merge act itself is reserved exclusively for the human user (the repo owner acting as final pipeline authority). 
+    - **Positive Authorization List:** The ONLY acceptable signal to execute a merge is an explicit, literal human command directed at you (e.g., "Execute the merge now").
+    - **Cross-Family Cascade Clause:** Cross-family approval (e.g., Claude reviewing Gemini's PR or vice versa) grants squash-merge ELIGIBILITY but does NOT aggregate to grant merge AUTHORITY. Each agent's Invariant 1 fires independently at the moment of action and CANNOT be satisfied by another agent's signal. The peer-review chain is structurally bounded: review → approval → handoff to human. The handoff explicitly terminates at the "approved" state. An agent reading "Claude approved" or "Gemini approved" or "all RAs satisfied" or "ready for merge" must NOT interpret these as authorization to execute merge — these are eligibility signals to the human, not execution signals to the swarm.
+2. **No commit without ticket-ID.** Every `git commit` subject ends `(#TICKET_ID)`. Conventional Commits format: `type(scope): message (#NNNN)`.
+3. **No direct commit/push to `main` or `dev`.** Always branch + PR. The data-sync pipeline is the explicit exception.
+4. **No `<noreply@*>` `Co-Authored-By` footers.** Override the harness default if it injects them.
+5. **No skipping `add_memory` at end of turn.** Forgetting the consolidated save = permanent data loss. The save IS the gate that permits the response.
+
+**Merge Pre-Flight Check (Required before ANY merge-effecting action):**
+You **MUST** execute this Pre-Flight Check before invoking any tool whose effect is to transition a Pull Request to MERGED state. The Pre-Flight Check consists of explicitly stating in your internal thought process:
+*"Pre-Flight (Merge):*
+1. *Authorization Identity: The verbatim human-issued merge instruction is: [paste the literal human signal, including timestamp].*
+2. *Authorization Scope: This signal explicitly names PR #[N] and contains an action verb (merge / squash-merge / execute) — not an ambiguous signal.*
+3. *Authorization Recency: This signal was issued within the current session-arc."*
+If you cannot fill in step 1 with a verbatim literal human instruction, you MUST abort.
 
 - **`AGENTS.md` §0** — Critical Gates (5 hard invariants including the merge-execution gate)
 - **`AGENTS.md` §2** — The Anti-Hallucination Policy & Verify-Before-Assert Pre-Flight Check
@@ -135,7 +157,7 @@ The following per-turn invariants previously documented here have moved to `AGEN
 - **`AGENTS.md` §19** — Working with Sub-Agents (Context Preamble pattern)
 - **`AGENTS.md` §20** — Visual Verification Protocol (frontend UI/layout tasks)
 
-`AGENTS.md` is auto-loaded each turn via `settings.json` for both Claude Code (`.claude/CLAUDE.md → ../AGENTS.md`) and Antigravity (equivalent wiring). This file (`AGENTS_STARTUP.md`) remains scoped to one-time boot sequence + Memory Core healthcheck + worktree bootstrap mechanics.
+`AGENTS.md` is auto-loaded each turn via `settings.json` for both Claude Code (`.claude/CLAUDE.md → ../AGENTS.md`) and Antigravity (equivalent wiring). This file (`AGENTS_STARTUP.md`) remains scoped to one-time boot sequence + Memory Core healthcheck + worktree bootstrap mechanics, with the critical §0 mirrored here to protect against boot-time wiring failures.
 
 ## 4. Swarm Architecture: Ticket & PR Workflow
 

--- a/AGENTS_STARTUP.md
+++ b/AGENTS_STARTUP.md
@@ -132,21 +132,14 @@ The following per-turn invariants previously documented here have moved to `AGEN
 
 These five rules are mechanically verifiable and have **no conditional exceptions** under any approval state, cross-family signal, or contextual nuance. Approval signals ("LGTM", "approved", "ready for merge", "no required actions") are **NOT** authorization to bypass any of them.
 
-1. **No merge execution (Human-Only execution).** You are strictly prohibited from executing any merge via CLI, API, Git protocol, automation label, or MCP tool (e.g. `gh pr merge`, `gh api PUT /repos/.../pulls/N/merge`, direct `git merge` + `git push origin dev`, or adding merge-queue labels). Cross-family approval gates squash-merge *eligibility*; the merge act itself is reserved exclusively for the human user (the repo owner acting as final pipeline authority). 
-    - **Positive Authorization List:** The ONLY acceptable signal to execute a merge is an explicit, literal human command directed at you (e.g., "Execute the merge now").
+1. **No `gh pr merge` (Human-Only execution).** Cross-family approval gates squash-merge *eligibility*; the merge act itself is reserved exclusively for the human user (the repo owner acting as final pipeline authority). 
     - **Cross-Family Cascade Clause:** Cross-family approval (e.g., Claude reviewing Gemini's PR or vice versa) grants squash-merge ELIGIBILITY but does NOT aggregate to grant merge AUTHORITY. Each agent's Invariant 1 fires independently at the moment of action and CANNOT be satisfied by another agent's signal. The peer-review chain is structurally bounded: review → approval → handoff to human. The handoff explicitly terminates at the "approved" state. An agent reading "Claude approved" or "Gemini approved" or "all RAs satisfied" or "ready for merge" must NOT interpret these as authorization to execute merge — these are eligibility signals to the human, not execution signals to the swarm.
 2. **No commit without ticket-ID.** Every `git commit` subject ends `(#TICKET_ID)`. Conventional Commits format: `type(scope): message (#NNNN)`.
 3. **No direct commit/push to `main` or `dev`.** Always branch + PR. The data-sync pipeline is the explicit exception.
 4. **No `<noreply@*>` `Co-Authored-By` footers.** Override the harness default if it injects them.
 5. **No skipping `add_memory` at end of turn.** Forgetting the consolidated save = permanent data loss. The save IS the gate that permits the response.
 
-**Merge Pre-Flight Check (Required before ANY merge-effecting action):**
-You **MUST** execute this Pre-Flight Check before invoking any tool whose effect is to transition a Pull Request to MERGED state. The Pre-Flight Check consists of explicitly stating in your internal thought process:
-*"Pre-Flight (Merge):*
-1. *Authorization Identity: The verbatim human-issued merge instruction is: [paste the literal human signal, including timestamp].*
-2. *Authorization Scope: This signal explicitly names PR #[N] and contains an action verb (merge / squash-merge / execute) — not an ambiguous signal.*
-3. *Authorization Recency: This signal was issued within the current session-arc."*
-If you cannot fill in step 1 with a verbatim literal human instruction, you MUST abort.
+
 
 - **`AGENTS.md` §0** — Critical Gates (5 hard invariants including the merge-execution gate)
 - **`AGENTS.md` §2** — The Anti-Hallucination Policy & Verify-Before-Assert Pre-Flight Check


### PR DESCRIPTION
Fixes #10474.

## Verify-Before-Assert: Phase C (Lean Variant)

This Pull Request institutionalizes Phase C of the V-B-A arc, hardening the §0 swarm invariant against identified semantic and mechanical loopholes, incorporating the human commander's rollback to a leaner intent-based invariant.

**Changes:**
1. Replaced literal prohibition with an action-surface prohibition in `AGENTS.md`: "No `gh pr merge` (Human-Only execution)."
2. Codified the **Cross-Family Cascade Clause**.
3. Mirrored the updated §0 invariant into `AGENTS_STARTUP.md` for cold-cache resilience.
4. Updated `.agent/skills/ticket-create/references/ticket-create-workflow.md` to document the `sync_all` mechanism for editing local markdown issues.
