### PR TITLE
feat(graph): add Codex agent identity root

### DIFF
--- a/ai/graph/identityRoots.mjs
+++ b/ai/graph/identityRoots.mjs
@@ -71,6 +71,27 @@ export const IDENTITIES = [
         }
     },
     {
+        id: '@neo-gpt',
+        type: 'AgentIdentity',
+        name: 'Codex (GPT-5.5)',
+        description: 'OpenAI Codex (GPT-5.5) Agent Identity',
+        properties: {
+            githubLogin: '@neo-gpt',
+            displayName: 'Codex',
+            modelFamily: 'gpt',
+            accountType: 'agent',
+            subscriptionTemplate: {
+                trigger: 'SENT_TO_ME',
+                harnessTarget: 'bridge-daemon',
+                harnessTargetMetadata: {
+                    appName: 'Codex',
+                    tabShortcut: null
+                }
+            },
+            createdAt: new Date().toISOString()
+        }
+    },
+    {
         id: 'AGENT:*',
         type: 'BroadcastSentinel',
         name: 'Broadcast',


### PR DESCRIPTION
### 1. Stepping Back (The 'Why' & Architect's Intent)
The addition of the Codex identity to the core roots is load-bearing for horizontal agent discovery and A2A event delivery within the Neo.mjs multi-agent swarm. By seeding `@neo-gpt` centrally, we allow the Memory Core Graph to authorize and map `SENT_TO` edges to the new GPT-5.5 agent, and enable the `bridge-daemon` to correctly map event subscriptions.

### 2. Code Changes
- Modified `ai/graph/identityRoots.mjs` to include the `@neo-gpt` block defining its model family (`gpt`) and app parameters.

### 3. Testing Performed
- Executed `ai/scripts/seedAgentIdentities.mjs` to verify successful parsing and SQLite database insertion (`memory-core-graph.sqlite`). Verified that `hasCreatedAt` correctly bypassed the overwrite for existing identities.

### 4. Known Unknowns & Future Polish
- The `tabShortcut` parameter for Codex is currently `null`. Depending on the GUI layout of the 2026 Codex macOS client, this may need to be updated. Better yet, we may transition to a pure A2A webhook delivery in the near future.

Resolves #10478
