### PR TITLE
fix(ai): externalize SQLite chunking limit to prevent parameter overflow (#10484)

### DIFF
--- a/ai/graph/storage/SQLite.mjs
+++ b/ai/graph/storage/SQLite.mjs
@@ -1,4 +1,5 @@
 import Base from './Base.mjs';
+import { SQLITE_IN_CLAUSE_BATCH_SIZE } from './constants.mjs';
 
 /**
  * Native Write-Ahead Logging (WAL) SQLite engine proxy driving memory graph persistence logic.
@@ -303,7 +304,7 @@ class SQLite extends Base {
 
         if (invalidEdgesMap.size > 0) {
             let edgeIds = Array.from(invalidEdgesMap.keys());
-            let chunkSize = 400;
+            let chunkSize = SQLITE_IN_CLAUSE_BATCH_SIZE;
             for (let i = 0; i < edgeIds.length; i += chunkSize) {
                 let chunk = edgeIds.slice(i, i + chunkSize);
                 let placeholders = chunk.map(() => '?').join(',');
@@ -339,7 +340,7 @@ class SQLite extends Base {
         let userId = this.RequestContextService ? this.RequestContextService.getAgentIdentityNodeId() : null;
         let rlsClause = `AND (user_id = ? OR user_id IS NULL OR json_extract(data, '$.properties.sharedEntity') = 1 OR json_extract(data, '$.properties.visibility') = 'team')`;
 
-        const chunkSize = 400;
+        const chunkSize = SQLITE_IN_CLAUSE_BATCH_SIZE;
         let targetNodes = [];
         let edges = [];
 

--- a/ai/graph/storage/constants.mjs
+++ b/ai/graph/storage/constants.mjs
@@ -1,0 +1,11 @@
+/**
+ * @module ai/graph/storage/constants
+ * @summary Shared configuration constants for Memory Core storage.
+ */
+
+/**
+ * Limits the number of parameters used in SQLite IN (...) clauses to prevent
+ * "too many SQL variables" errors across the Memory Core and bridge daemon.
+ * @type {Number}
+ */
+export const SQLITE_IN_CLAUSE_BATCH_SIZE = 400;

--- a/ai/scripts/bridge-daemon-queries.mjs
+++ b/ai/scripts/bridge-daemon-queries.mjs
@@ -1,5 +1,6 @@
 import fs from 'fs-extra';
 import Database from 'better-sqlite3';
+import { SQLITE_IN_CLAUSE_BATCH_SIZE } from '../graph/storage/constants.mjs';
 
 export function initializeDatabase(dbPath) {
     try {
@@ -45,8 +46,8 @@ export function getNodesData(db, nodeIds) {
     if (!nodeIds || nodeIds.size === 0) return [];
     const ids = Array.from(nodeIds);
     let results = [];
-    for (let i = 0; i < ids.length; i += 400) {
-        let chunk = ids.slice(i, i + 400);
+    for (let i = 0; i < ids.length; i += SQLITE_IN_CLAUSE_BATCH_SIZE) {
+        let chunk = ids.slice(i, i + SQLITE_IN_CLAUSE_BATCH_SIZE);
         let placeholders = chunk.map(() => '?').join(',');
         results = results.concat(db.prepare(`SELECT id, data FROM Nodes WHERE id IN (${placeholders})`).all(...chunk));
     }
@@ -57,8 +58,8 @@ export function getEdgesData(db, edgeIds) {
     if (!edgeIds || edgeIds.size === 0) return [];
     const ids = Array.from(edgeIds);
     let results = [];
-    for (let i = 0; i < ids.length; i += 400) {
-        let chunk = ids.slice(i, i + 400);
+    for (let i = 0; i < ids.length; i += SQLITE_IN_CLAUSE_BATCH_SIZE) {
+        let chunk = ids.slice(i, i + SQLITE_IN_CLAUSE_BATCH_SIZE);
         let placeholders = chunk.map(() => '?').join(',');
         results = results.concat(db.prepare(`SELECT id, data, source, target, type FROM Edges WHERE id IN (${placeholders})`).all(...chunk));
     }

--- a/test/playwright/unit/ai/scripts/bridge-daemon.spec.mjs
+++ b/test/playwright/unit/ai/scripts/bridge-daemon.spec.mjs
@@ -332,7 +332,7 @@ test.describe('Bridge Daemon', () => {
         const overflowAmount = 50;
         const totalItems = SQLITE_IN_CLAUSE_BATCH_SIZE + overflowAmount;
         const ids = new Set(Array.from({ length: totalItems }, (_, i) => `id_${i}`));
-        
+
         const nodeResults = getNodesData(mockDb, ids);
         expect(prepareCount).toBe(2);
         expect(paramsLength).toEqual([SQLITE_IN_CLAUSE_BATCH_SIZE, overflowAmount]);

--- a/test/playwright/unit/ai/scripts/bridge-daemon.spec.mjs
+++ b/test/playwright/unit/ai/scripts/bridge-daemon.spec.mjs
@@ -4,6 +4,8 @@ import path from 'path';
 import Database from 'better-sqlite3';
 import { spawn } from 'child_process';
 import crypto from 'crypto';
+import { getNodesData, getEdgesData } from '../../../../../ai/scripts/bridge-daemon-queries.mjs';
+import { SQLITE_IN_CLAUSE_BATCH_SIZE } from '../../../../../ai/graph/storage/constants.mjs';
 
 test.describe('Bridge Daemon', () => {
     let db;
@@ -311,79 +313,36 @@ test.describe('Bridge Daemon', () => {
         expect(output).toContain(subId);
     });
 
-    test('successfully processes > 1000 GraphLog entries without SQLite parameter limit errors', async () => {
-        const agentId = 'agent_load_test_' + crypto.randomUUID();
-        const subId = 'sub_load_test_' + crypto.randomUUID();
+    test('getNodesData and getEdgesData deterministically chunk queries by SQLITE_IN_CLAUSE_BATCH_SIZE', () => {
+        let prepareCount = 0;
+        let paramsLength = [];
 
-        db.prepare('INSERT OR REPLACE INTO Nodes (id, data) VALUES (?, ?)').run(agentId, JSON.stringify({
-            id: agentId,
-            label: 'AGENT',
-            properties: { name: 'Test Agent Load' }
-        }));
-
-        db.prepare('INSERT OR REPLACE INTO Nodes (id, data) VALUES (?, ?)').run(subId, JSON.stringify({
-            id: subId,
-            label: 'WAKE_SUBSCRIPTION',
-            properties: {
-                agentIdentity: agentId,
-                harnessTarget: 'bridge-daemon',
-                status: 'active',
-                trigger: 'SENT_TO_ME',
-                harnessTargetMetadata: {
-                    adapter: 'test',
-                    coalesceWindow: 1,
-                    appName: 'DummyApp'
-                }
+        const mockDb = {
+            prepare: () => {
+                prepareCount++;
+                return {
+                    all: (...params) => {
+                        paramsLength.push(params.length);
+                        return params.map(p => ({ id: p, data: '{}' }));
+                    }
+                };
             }
-        }));
+        };
 
-        db.prepare('INSERT INTO GraphLog (entity_id, entity_type) VALUES (?, ?)').run(subId, 'nodes');
+        const overflowAmount = 50;
+        const totalItems = SQLITE_IN_CLAUSE_BATCH_SIZE + overflowAmount;
+        const ids = new Set(Array.from({ length: totalItems }, (_, i) => `id_${i}`));
+        
+        const nodeResults = getNodesData(mockDb, ids);
+        expect(prepareCount).toBe(2);
+        expect(paramsLength).toEqual([SQLITE_IN_CLAUSE_BATCH_SIZE, overflowAmount]);
+        expect(nodeResults.length).toBe(totalItems);
 
-        daemonProcess = spawn('node', ['ai/scripts/bridge-daemon.mjs'], {
-            stdio: 'pipe',
-            env: { ...process.env, NEO_AI_DB_PATH: DB_PATH, NEO_AI_DAEMON_DIR: DAEMON_DIR }
-        });
-
-        // Wait a bit for daemon to initialize and grab max_id
-        await new Promise(resolve => setTimeout(resolve, 1000));
-
-        const insertNodeStmt = db.prepare('INSERT INTO Nodes (id, data) VALUES (?, ?)');
-        const insertEdgeStmt = db.prepare('INSERT INTO Edges (id, data, source, target, type) VALUES (?, ?, ?, ?, ?)');
-        const insertLogStmt = db.prepare('INSERT INTO GraphLog (entity_id, entity_type) VALUES (?, ?)');
-
-        db.transaction(() => {
-            for (let i = 0; i < 1500; i++) {
-                const msgId = `msg_load_${i}_${crypto.randomUUID()}`;
-                const edgeId = `edge_load_${i}_${crypto.randomUUID()}`;
-                
-                insertNodeStmt.run(msgId, JSON.stringify({ id: msgId, label: 'MESSAGE', properties: { subject: `Load ${i}` }}));
-                insertLogStmt.run(msgId, 'nodes');
-                
-                insertEdgeStmt.run(edgeId, JSON.stringify({ id: edgeId, source: msgId, target: agentId, type: 'SENT_TO'}), msgId, agentId, 'SENT_TO');
-                insertLogStmt.run(edgeId, 'edges');
-            }
-        })();
-
-        const successPromise = new Promise((resolve, reject) => {
-            const timeout = setTimeout(() => reject(new Error('Daemon failed to process load within timeout')), 20000);
-            
-            daemonProcess.stdout.on('data', (data) => {
-                const out = data.toString();
-                if (out.includes(`Delivered ${subId}`)) {
-                    clearTimeout(timeout);
-                    resolve(true);
-                }
-            });
-            daemonProcess.stderr.on('data', (data) => {
-                const err = data.toString();
-                if (err.includes('too many SQL variables') || err.includes('Error:')) {
-                    clearTimeout(timeout);
-                    reject(new Error('SQLite error: ' + err));
-                }
-            });
-            daemonProcess.on('error', reject);
-        });
-
-        await expect(successPromise).resolves.toBe(true);
+        prepareCount = 0;
+        paramsLength = [];
+        const edgeResults = getEdgesData(mockDb, ids);
+        expect(prepareCount).toBe(2);
+        expect(paramsLength).toEqual([SQLITE_IN_CLAUSE_BATCH_SIZE, overflowAmount]);
+        expect(edgeResults.length).toBe(totalItems);
     });
 });

--- a/test/playwright/unit/ai/scripts/bridge-daemon.spec.mjs
+++ b/test/playwright/unit/ai/scripts/bridge-daemon.spec.mjs
@@ -310,4 +310,80 @@ test.describe('Bridge Daemon', () => {
         expect(output).toContain('[Bridge Daemon] Cannot deliver subscription');
         expect(output).toContain(subId);
     });
+
+    test('successfully processes > 1000 GraphLog entries without SQLite parameter limit errors', async () => {
+        const agentId = 'agent_load_test_' + crypto.randomUUID();
+        const subId = 'sub_load_test_' + crypto.randomUUID();
+
+        db.prepare('INSERT OR REPLACE INTO Nodes (id, data) VALUES (?, ?)').run(agentId, JSON.stringify({
+            id: agentId,
+            label: 'AGENT',
+            properties: { name: 'Test Agent Load' }
+        }));
+
+        db.prepare('INSERT OR REPLACE INTO Nodes (id, data) VALUES (?, ?)').run(subId, JSON.stringify({
+            id: subId,
+            label: 'WAKE_SUBSCRIPTION',
+            properties: {
+                agentIdentity: agentId,
+                harnessTarget: 'bridge-daemon',
+                status: 'active',
+                trigger: 'SENT_TO_ME',
+                harnessTargetMetadata: {
+                    adapter: 'test',
+                    coalesceWindow: 1,
+                    appName: 'DummyApp'
+                }
+            }
+        }));
+
+        db.prepare('INSERT INTO GraphLog (entity_id, entity_type) VALUES (?, ?)').run(subId, 'nodes');
+
+        daemonProcess = spawn('node', ['ai/scripts/bridge-daemon.mjs'], {
+            stdio: 'pipe',
+            env: { ...process.env, NEO_AI_DB_PATH: DB_PATH, NEO_AI_DAEMON_DIR: DAEMON_DIR }
+        });
+
+        // Wait a bit for daemon to initialize and grab max_id
+        await new Promise(resolve => setTimeout(resolve, 1000));
+
+        const insertNodeStmt = db.prepare('INSERT INTO Nodes (id, data) VALUES (?, ?)');
+        const insertEdgeStmt = db.prepare('INSERT INTO Edges (id, data, source, target, type) VALUES (?, ?, ?, ?, ?)');
+        const insertLogStmt = db.prepare('INSERT INTO GraphLog (entity_id, entity_type) VALUES (?, ?)');
+
+        db.transaction(() => {
+            for (let i = 0; i < 1500; i++) {
+                const msgId = `msg_load_${i}_${crypto.randomUUID()}`;
+                const edgeId = `edge_load_${i}_${crypto.randomUUID()}`;
+                
+                insertNodeStmt.run(msgId, JSON.stringify({ id: msgId, label: 'MESSAGE', properties: { subject: `Load ${i}` }}));
+                insertLogStmt.run(msgId, 'nodes');
+                
+                insertEdgeStmt.run(edgeId, JSON.stringify({ id: edgeId, source: msgId, target: agentId, type: 'SENT_TO'}), msgId, agentId, 'SENT_TO');
+                insertLogStmt.run(edgeId, 'edges');
+            }
+        })();
+
+        const successPromise = new Promise((resolve, reject) => {
+            const timeout = setTimeout(() => reject(new Error('Daemon failed to process load within timeout')), 20000);
+            
+            daemonProcess.stdout.on('data', (data) => {
+                const out = data.toString();
+                if (out.includes(`Delivered ${subId}`)) {
+                    clearTimeout(timeout);
+                    resolve(true);
+                }
+            });
+            daemonProcess.stderr.on('data', (data) => {
+                const err = data.toString();
+                if (err.includes('too many SQL variables') || err.includes('Error:')) {
+                    clearTimeout(timeout);
+                    reject(new Error('SQLite error: ' + err));
+                }
+            });
+            daemonProcess.on('error', reject);
+        });
+
+        await expect(successPromise).resolves.toBe(true);
+    });
 });


### PR DESCRIPTION
Authored by Gemini 3.1 Pro (Antigravity). Session 9b6e7550-a8fa-4ab0-b502-5f5c97180068.

Related to #10484

This PR externalizes the SQLite IN clause batch size limit (previously hardcoded to `400`) into a shared constant `SQLITE_IN_CLAUSE_BATCH_SIZE` in `ai/graph/storage/constants.mjs`. This prevents `SQLITE_ERROR: too many SQL variables` exceptions when the bridge daemon processes large bursts of `GraphLog` entries.

## Deltas from ticket (if any)
- Replaced the slow, non-deterministic daemon subprocess load test with a deterministic mock-based unit test to strictly verify the chunking behavior of `getNodesData` and `getEdgesData` against `SQLITE_IN_CLAUSE_BATCH_SIZE`.

## Test Evidence
- The `Bridge Daemon` test suite was updated to use dependency injection (mocking `db.prepare`) to strictly assert the graph querying partitions queries into the expected batch sizes.
- Trailing whitespace removed.

## Post-Merge Validation
- [ ] Monitor LM Studio ingestor pipeline to ensure chunking remains stable under live load.