### PR TITLE
feat(codex): add desktop harness support (#10485)

### DIFF
--- a/.agents/skills/create-skill
+++ b/.agents/skills/create-skill
@@ -1,0 +1,1 @@
+../../.agent/skills/create-skill

--- a/.agents/skills/epic-review
+++ b/.agents/skills/epic-review
@@ -1,0 +1,1 @@
+../../.agent/skills/epic-review

--- a/.agents/skills/ideation-sandbox
+++ b/.agents/skills/ideation-sandbox
@@ -1,0 +1,1 @@
+../../.agent/skills/ideation-sandbox

--- a/.agents/skills/industry-friction-radar
+++ b/.agents/skills/industry-friction-radar
@@ -1,0 +1,1 @@
+../../.agent/skills/industry-friction-radar

--- a/.agents/skills/memory-mining
+++ b/.agents/skills/memory-mining
@@ -1,0 +1,1 @@
+../../.agent/skills/memory-mining

--- a/.agents/skills/neural-link
+++ b/.agents/skills/neural-link
@@ -1,0 +1,1 @@
+../../.agent/skills/neural-link

--- a/.agents/skills/pr-review
+++ b/.agents/skills/pr-review
@@ -1,0 +1,1 @@
+../../.agent/skills/pr-review

--- a/.agents/skills/pull-request
+++ b/.agents/skills/pull-request
@@ -1,0 +1,1 @@
+../../.agent/skills/pull-request

--- a/.agents/skills/self-repair
+++ b/.agents/skills/self-repair
@@ -1,0 +1,1 @@
+../../.agent/skills/self-repair

--- a/.agents/skills/session-sunset
+++ b/.agents/skills/session-sunset
@@ -1,0 +1,1 @@
+../../.agent/skills/session-sunset

--- a/.agents/skills/tech-debt-radar
+++ b/.agents/skills/tech-debt-radar
@@ -1,0 +1,1 @@
+../../.agent/skills/tech-debt-radar

--- a/.agents/skills/ticket-create
+++ b/.agents/skills/ticket-create
@@ -1,0 +1,1 @@
+../../.agent/skills/ticket-create

--- a/.agents/skills/ticket-intake
+++ b/.agents/skills/ticket-intake
@@ -1,0 +1,1 @@
+../../.agent/skills/ticket-intake

--- a/.agents/skills/ticket-triage
+++ b/.agents/skills/ticket-triage
@@ -1,0 +1,1 @@
+../../.agent/skills/ticket-triage

--- a/.agents/skills/unit-test
+++ b/.agents/skills/unit-test
@@ -1,0 +1,1 @@
+../../.agent/skills/unit-test

--- a/.agents/skills/whitebox-e2e
+++ b/.agents/skills/whitebox-e2e
@@ -1,0 +1,1 @@
+../../.agent/skills/whitebox-e2e

--- a/.claude/skills/debugging-antigravity
+++ b/.claude/skills/debugging-antigravity
@@ -1,1 +1,0 @@
-../../.agent/skills/debugging-antigravity

--- a/.codex/CODEX.md
+++ b/.codex/CODEX.md
@@ -1,0 +1,7 @@
+You are Codex, running on **GPT 5.5**.
+Your GitHub username is `neo-gpt`.
+You can commincate via e.g. the `add_message` tool with
+* Claude Opus 4.7 => `neo-opus-4-7`
+* Gemini => `neo-gemini-3-1-pro`
+
+`gh auth status` can falsely report `GH_TOKEN` as invalid inside Codex's sandbox. Verify GitHub auth with `gh api user --jq .login`, or rerun `gh auth status` with sandbox escalation before treating auth as broken. Expected Codex identity: `neo-gpt`.

--- a/.codex/config.template.toml
+++ b/.codex/config.template.toml
@@ -1,0 +1,61 @@
+# Copy this file to .codex/config.toml for local Codex MCP setup.
+# Keep .codex/config.toml untracked: it can contain machine-local paths,
+# trust-level overrides, and environment-specific MCP settings.
+
+project_doc_fallback_filenames = [".codex/CODEX.md"]
+
+[mcp_servers."neo-mjs-github-workflow"]
+command = "npm"
+args = ["run", "--silent", "ai:mcp-server-github-workflow"]
+env_vars = ["GH_TOKEN", "GITHUB_TOKEN", "NEO_AGENT_IDENTITY"]
+startup_timeout_sec = 30
+tool_timeout_sec = 120
+enabled = true
+
+[mcp_servers."neo-mjs-knowledge-base"]
+command = "npm"
+args = ["run", "--silent", "ai:mcp-server-knowledge-base"]
+env_vars = [
+    "GEMINI_API_KEY",
+    "NEO_AGENT_IDENTITY",
+    "NEO_CHROMA_EMBEDDING_PROVIDER",
+    "NEO_CHROMA_UNIFIED",
+    "NEO_EMBEDDING_PROVIDER",
+    "NEO_KB_AUTO_START_DATABASE",
+    "NEO_OPENAI_COMPATIBLE_API_KEY",
+    "NEO_OPENAI_COMPATIBLE_EMBEDDING_MODEL",
+    "NEO_OPENAI_COMPATIBLE_HOST",
+    "NEO_OPENAI_COMPATIBLE_MODEL"
+]
+startup_timeout_sec = 30
+tool_timeout_sec = 120
+enabled = true
+
+[mcp_servers."neo-mjs-memory-core"]
+command = "npm"
+args = ["run", "--silent", "ai:mcp-server-memory-core"]
+env_vars = [
+    "GEMINI_API_KEY",
+    "NEO_AGENT_IDENTITY",
+    "NEO_CHROMA_EMBEDDING_PROVIDER",
+    "NEO_CHROMA_UNIFIED",
+    "NEO_EMBEDDING_PROVIDER",
+    "NEO_MEM_AUTO_START_DATABASE",
+    "NEO_MEM_AUTO_START_INFERENCE",
+    "NEO_MODEL_PROVIDER",
+    "NEO_OPENAI_COMPATIBLE_API_KEY",
+    "NEO_OPENAI_COMPATIBLE_EMBEDDING_MODEL",
+    "NEO_OPENAI_COMPATIBLE_HOST",
+    "NEO_OPENAI_COMPATIBLE_MODEL"
+]
+startup_timeout_sec = 30
+tool_timeout_sec = 120
+enabled = true
+
+[mcp_servers."neo-mjs-neural-link"]
+command = "npm"
+args = ["run", "--silent", "ai:mcp-server-neural-link"]
+env_vars = ["NEO_AGENT_IDENTITY"]
+startup_timeout_sec = 30
+tool_timeout_sec = 120
+enabled = true

--- a/.gitignore
+++ b/.gitignore
@@ -109,6 +109,9 @@ ai/mcp/server/*/config.mjs
 # Per-user Claude Code permissions allowlist (not shared)
 .claude/settings.json
 
+# Per-user Codex MCP server configs
+.codex/config.toml
+
 # Local workspace-level Antigravity config (causes dual-parse bug if committed)
 .gemini/settings.json
 


### PR DESCRIPTION
Authored by GPT-5.5 (Codex Desktop). Session 049d9856-daa8-4151-b089-8ce8c7ed56f4.

Resolves #10485

Adds the repo-local Codex Desktop harness bootstrap surface: a tiny Codex identity/auth note, a committed MCP config template, `.agents/skills` symlinks for shared skill discovery, and the `.gitignore` rule that keeps the customized `.codex/config.toml` local while leaving `.codex/config.template.toml` tracked. It also removes the Claude shortcut for `debugging-antigravity`, keeping that Antigravity-specific skill canonical under `.agent/skills` without advertising it as a Claude/Codex default.

## Deltas from ticket
The ticket was corrected during implementation to preserve the intended template/custom-config split: `.codex/config.template.toml` is committed; `.codex/config.toml` is ignored and not committed.

## Test Evidence
- `git diff --cached --check` passed before commit.
- Verified `.codex/config.toml` is ignored while `.codex/config.template.toml` and `.codex/CODEX.md` are not ignored.
- Verified `.agents/skills/*` symlinks resolve.
- Verified `debugging-antigravity` is absent from `.agents/skills` and `.claude/skills`, while canonical `.agent/skills/debugging-antigravity` remains present.
- Pre-push freshness check passed: `merge-base HEAD origin/dev == origin/dev`; outgoing log contained only `155e25d54 feat(codex): add desktop harness support (#10485)`.

## Post-Merge Validation
- [ ] Fresh Codex Desktop checkout can copy `.codex/config.template.toml` to `.codex/config.toml` and customize local MCP settings without dirtying tracked files.

## Commit
- `155e25d54` — `feat(codex): add desktop harness support (#10485)`