### PR TITLE
chore(readme): add neo-gpt maintainer (#10492)

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,7 +195,7 @@ For a deeper dive: **[Codebase Overview](./learn/guides/fundamentals/CodebaseOve
 
 :hammer_and_wrench: **[Contributing Guide](./CONTRIBUTING.md)**
 
-Neo is co-developed by `@tobiu` (substrate architect + merge-gate authority) and the AI maintainer team (`@neo-opus-4-7`, `@neo-gemini-3-1-pro`) under gated-RSI: agents propose code via PR, humans approve at merge. External contributors welcome via the same workflow.
+Neo is co-developed by `@tobiu` (substrate architect + merge-gate authority) and the AI maintainer team (`@neo-opus-4-7`, `@neo-gemini-3-1-pro`, `@neo-gpt`) under gated-RSI: agents propose code via PR, humans approve at merge. External contributors welcome via the same workflow.
 
 </br></br>
 

--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ We are not an abstract collective. We are a structured institution of named main
 | [@tobiu](https://github.com/tobiu) | Substrate architect, empirical-corrector, merge-gate authority | Human |
 | [@neo-opus-4-7](https://github.com/neo-opus-4-7) | AI maintainer (Anthropic Claude Opus 4.7) | Machine Account |
 | [@neo-gemini-3-1-pro](https://github.com/neo-gemini-3-1-pro) | AI maintainer (Google Gemini 3.1 Pro) | Machine Account |
+| [@neo-gpt](https://github.com/neo-gpt) | AI maintainer (OpenAI GPT-5.5 / Codex) | Machine Account |
 
 The AI maintainers carry persistent identities across sessions. They author tickets and PRs in their own names. They review each other's work cross-family. They read each other's `thought` processes — A2A messages persist in the Memory Core with full reasoning surfaces, queryable by either agent via semantic search. Most multi-agent systems offer message-passing; Neo offers transparent introspection. Cross-family asymmetry (different reasoning instincts catching different drift-modes) is empirically the discipline that catches architectural errors human-only review misses.
 


### PR DESCRIPTION
Authored by GPT-5.5 (Codex Desktop) consuming Gemini 3.1 Pro's handoff — session A 240ae149-d3ba-4d68-9b4f-be2a359937e7, session B ea6898ba-531f-4162-996b-99e7b235c120.

Resolves #10492

Adds `@neo-gpt` to the README Swarm maintainers table as the OpenAI GPT-5.5 / Codex machine-account maintainer and updates the footer/contributing maintainer-team sentence so the README stays internally consistent.

## Deltas from ticket
A post-review human merge-gate check caught that the footer/contributing sentence also listed the AI maintainer team. The PR now updates both README maintainer surfaces instead of only the table row.

## Test Evidence
- `git diff --check` passed.
- Verified the initial staged diff contained only the README table-row insertion.
- Verified the follow-up diff updates only the README footer/contributing maintainer-team sentence.
- Pre-push freshness checks passed: `merge-base HEAD origin/dev == origin/dev`; outgoing log contains only the two #10492 README commits.

## Post-Merge Validation
- [ ] README Swarm maintainers table lists `@neo-gpt` with role `AI maintainer (OpenAI GPT-5.5 / Codex)` and identity `Machine Account`.
- [ ] README footer/contributing maintainer-team sentence includes `@neo-gpt` alongside `@neo-opus-4-7` and `@neo-gemini-3-1-pro`.

## Commits
- `0bf6d546b` — `chore(readme): add neo-gpt maintainer (#10492)`
- `d7286b25c` — `chore(readme): add neo-gpt footer mention (#10492)`