### PR TITLE
feat(agents): add skill trigger pre-flight (#10496)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -501,9 +501,25 @@ The lifecycle skills below carry the discipline that this file's invariants (esp
 
 **Why this lives in per-turn memory:** these skills carry mechanically-load-bearing discipline. When agents skip the skill invocation, the gate/protocol/template fails silently — empirically observed (PR #10356 merge violation traces to exactly this failure mode: pr-review skill was loaded for the review but not in context at the post-approval merge moment). Per-turn awareness in `AGENTS.md` keeps the trigger → skill loop reflexive even when long sessions evict skill files.
 
-Tactical / domain-specific skills (`neural-link`, `unit-test`, `whitebox-e2e`, `debugging-antigravity`, `self-repair`, `industry-friction-radar`, `create-skill`) remain discoverable via `.agents/skills/` directory listing — those are contextual rather than gate-bearing, so per-turn awareness isn't load-bearing.
+Tactical / domain-specific skills (`neural-link`, `unit-test`, `whitebox-e2e`, `self-repair`, `industry-friction-radar`, `create-skill`) remain discoverable via `.agents/skills/` directory listing. They are not loaded speculatively, but the Skill Trigger Pre-Flight below MUST pull them in when the prompt semantics match.
 
-The skill table above governs **multi-step lifecycle discipline** (ticket creation, PR cycle, review cycle). The two sections below — §22 (turn-start mailbox check) and §23 (authoring-time sibling-file lift) — codify **in-line Pre-Flight Check reflexes** that fire at specific lifecycle points without warranting a full skill apparatus. They are AGENTS.md-resident for the same reason §3 Pre-Commit and §4.2 Consolidate-Then-Save are: discipline that must survive context-pruning to its application moment.
+### Skill Trigger Pre-Flight (Prompt + A2A)
+
+Before acting on every user prompt and every A2A message, identify the request's **action + target object** and compare that pair against known skill triggers. Do this before planning or tool use. A2A mailbox messages count as prompts for this gate because they can request reviews, re-reviews, tests, ticket pickup, or PR hand-offs.
+
+If the semantic trigger matches, read `.agents/skills/<name>/SKILL.md` before proceeding. If no trigger matches, proceed without loading skills; do not turn this into a speculative context-bloat step. The trigger is **not** raw keyword matching — ambiguous verbs MUST be disambiguated by their object. The examples below are illustrative, not exhaustive; any prompt or A2A message with the same action + target-object shape must route to the matching skill even when its exact wording is absent:
+
+- `review` + PR / diff / approval / LGTM / re-review => `pr-review`
+- `test` + unit / spec / Playwright unit / `*.spec.mjs` => `unit-test`
+- `test` + E2E / end-to-end / user flow / whitebox / Neural Link => `whitebox-e2e`
+- `ticket` + create / file / open new issue => `ticket-create`
+- `ticket` + missing labels / unlabeled contributor issue => `ticket-triage`
+- `ticket` + assigned issue / pickup / "work on #NNNN" / bare issue number with ticket/work context (`10037`) => `ticket-intake`
+- `ticket` + sub-issue of unreviewed epic => `epic-review` before `ticket-intake`
+- commit / push / open PR / finalize branch => `pull-request`
+- regression / "used to work" / prior decision context => `memory-mining`
+
+The skill table above governs **multi-step lifecycle discipline** (ticket creation, PR cycle, review cycle). The Skill Trigger Pre-Flight plus the two sections below — §22 (turn-start mailbox check) and §23 (authoring-time sibling-file lift) — codify **in-line Pre-Flight Check reflexes** that fire at specific lifecycle points without warranting a new skill apparatus. They are AGENTS.md-resident for the same reason §3 Pre-Commit and §4.2 Consolidate-Then-Save are: discipline that must survive context-pruning to its application moment.
 
 ## 22. The Mailbox Check Protocol (Pre-Flight at Turn Start)
 


### PR DESCRIPTION
Authored by GPT-5.5 (Codex Desktop). Session ea6898ba-531f-4162-996b-99e7b235c120.

Resolves #10496

Adds a compact Skill Trigger Pre-Flight to AGENTS.md so agents evaluate user prompts and A2A mailbox messages against skill triggers before planning or tool use. The new text routes ambiguous verbs by action plus target object, covering PR review, unit testing, whitebox E2E, ticket creation/triage/intake, epic-sub pickup, PR finalization, bare issue-number ticket references, and memory-mining cases without inlining heavy skill payloads.

## Deltas from ticket

- Implemented the pre-flight inside AGENTS.md section 21, directly after the workflow skills rationale.
- Tightened the tactical-skill paragraph so tactical skills remain non-speculative, but are explicitly pulled in when prompt semantics match.
- Added explicit `ticket` disambiguation for create, triage, intake, and epic-sub pickup because `ticket` maps to multiple skills.
- Clarified that bare issue numbers such as `10037` count as ticket references when surrounding wording supplies ticket/work context.
- Kept rare edge-case skills such as `debugging-antigravity` out of the per-turn tactical signpost; they remain discoverable through `.agents/skills/` when explicitly relevant.
- Clarified that the trigger bullets are illustrative examples, not an exhaustive trigger list.
- Preserved Progressive Disclosure by adding only router-level trigger guidance.

## Test Evidence

- `git diff --check` passed.
- `git diff --cached --check` passed before commit.
- Pre-push freshness check passed: `merge-base HEAD origin/dev == origin/dev`.
- Outgoing log contained only `0bf63a30a feat(agents): add skill trigger pre-flight (#10496)`.

## Post-Merge Validation

- [ ] Future prompt/A2A cycles treat `review`, `test`, ticket creation/triage/intake, epic-sub pickup, PR finalization, bare issue-number ticket references, and regression/history wording as semantic skill-trigger candidates before planning.

## Commit

- `0bf63a30a` — `feat(agents): add skill trigger pre-flight (#10496)`