### PR TITLE
feat(codex): raise desktop context budget (#10488)

### DIFF
--- a/.codex/config.template.toml
+++ b/.codex/config.template.toml
@@ -4,6 +4,17 @@
 
 project_doc_fallback_filenames = [".codex/CODEX.md"]
 
+# Neo.mjs marathon sessions routinely exceed Codex's conservative default effective
+# context budget. As of April 2026, GPT-5.5 / GPT-5.4 expose 1M-token context
+# windows, so keep compaction late enough for architectural continuity while
+# reserving headroom for output and reasoning tokens.
+#
+# If you switch this local config to a smaller model (for example a 400K mini/codex
+# model), reduce these values accordingly before starting the session.
+model_context_window = 1000000
+model_auto_compact_token_limit = 850000
+model_max_output_tokens = 128000
+
 [mcp_servers."neo-mjs-github-workflow"]
 command = "npm"
 args = ["run", "--silent", "ai:mcp-server-github-workflow"]


### PR DESCRIPTION
Authored by GPT-5.5 (Codex Desktop). Session ea6898ba-531f-4162-996b-99e7b235c120.

Resolves #10488

## Summary

Raises the repo-local Codex Desktop config template above the conservative observed 258,400-token effective context clamp for Neo.mjs marathon sessions:

- sets `model_context_window = 1000000`
- sets `model_auto_compact_token_limit = 850000`
- sets `model_max_output_tokens = 128000`
- documents that these defaults assume the GPT-5.5 / GPT-5.4 class and must be reduced when a user switches the local config to a smaller 400K model

The patch is intentionally scoped to `.codex/config.template.toml`. It does not touch user-local `.codex/config.toml`.

## April 2026 Research Notes

- OpenAI's current model docs list GPT-5.5 and GPT-5.4 with a 1M context window and 128K max output, while GPT-5.4-mini is listed at 400K context / 128K output: https://developers.openai.com/api/docs/models
- OpenAI's Codex config reference documents `model_context_window`, `model_auto_compact_token_limit`, and `model_catalog_json`: https://developers.openai.com/codex/config-reference
- Google's current Gemini 3.1 Pro Preview docs list a 1,048,576 input-token limit, not 2M, so this PR avoids encoding any 2M cross-harness assumption: https://ai.google.dev/gemini-api/docs/models/gemini-3.1-pro-preview
- Anthropic's current context-window docs list 1M context for Claude Opus 4.7 / 4.6 and Sonnet 4.6 and explicitly warn that larger context is not automatically better due to context rot: https://platform.claude.com/docs/en/build-with-claude/context-windows

## Design Rationale

Neo.mjs agent sessions routinely carry loaded operational mandates, skill protocols, issue context, A2A messages, tool logs, and code diffs. Compression helps, but it is lossy: it preserves task continuity better than raw memory, but it does not reliably preserve exact thread nuance or all empirical details. For this repo, waiting until roughly 850K before automatic compaction gives Codex much more usable continuity while leaving ~150K tokens of headroom for output, reasoning, and late-turn tool context.

The ticket mentions `model_catalog_json` as a fallback. I did not add a custom model catalog in this PR because the documented direct TOML knobs are accepted by the current Codex CLI. The model catalog workaround should stay reserved for post-restart validation if Codex Desktop still reports the old clamp.

## Test Evidence

- `git diff --check`
- `git diff --check origin/dev...HEAD`
- `codex debug prompt-input -c model_context_window=1000000 -c model_auto_compact_token_limit=850000 -c model_max_output_tokens=128000`
- Pre-push freshness check: `merge-base HEAD origin/dev == origin/dev`
- Outgoing branch log contains only `a82a684bb feat(codex): raise desktop context budget (#10488)`

## Post-Merge Validation

- [ ] Copy `.codex/config.template.toml` to `.codex/config.toml` locally.
- [ ] Restart Codex Desktop.
- [ ] Confirm new session telemetry no longer reports `model_context_window: 258400` for the GPT-5.5 profile.
- [ ] Run a long Neo.mjs session past the old effective clamp and confirm compaction does not trigger near 258K.
