### PR TITLE
fix(memory-core): add boundary guards to CollectionProxy and fix config key (#10504)

### DIFF
--- a/ai/mcp/server/memory-core/managers/CollectionProxy.mjs
+++ b/ai/mcp/server/memory-core/managers/CollectionProxy.mjs
@@ -41,17 +41,17 @@ class CollectionProxy extends Base {
     }
 
     async add(args) {
-        const collections = await this.getCollections();  
+        const collections = await this.getCollections();
         await Promise.all(collections.map(c => c.add(args)));
     }
 
     async upsert(args) {
-        const collections = await this.getCollections();  
+        const collections = await this.getCollections();
         await Promise.all(collections.map(c => c.upsert(args)));
     }
 
     async update(args) {
-        const collections = await this.getCollections();  
+        const collections = await this.getCollections();
         await Promise.all(collections.map(c => c.update(args)));
     }
 
@@ -64,7 +64,7 @@ class CollectionProxy extends Base {
     }
     
     async query(args) {
-        const collections = await this.getCollections();  
+        const collections = await this.getCollections();
         if (!collections || collections.length === 0 || !collections[0]) {
             throw new Error(`[CollectionProxy] query() failed: No underlying collection available for type '${this.collectionType}'`);
         }
@@ -80,7 +80,7 @@ class CollectionProxy extends Base {
     }
     
     async delete(args) {
-        const collections = await this.getCollections();  
+        const collections = await this.getCollections();
         await Promise.all(collections.map(c => c.delete(args)));
     }
 

--- a/ai/mcp/server/memory-core/managers/CollectionProxy.mjs
+++ b/ai/mcp/server/memory-core/managers/CollectionProxy.mjs
@@ -19,7 +19,7 @@ class CollectionProxy extends Base {
     }
 
     async getManagers() {
-        const architecture = aiConfig.architecture || 'hybrid';
+        const architecture = aiConfig.engine || 'hybrid';
         const managers = [];
         
         // In Hybrid RAG, vectors exclusively live in ChromaDB
@@ -41,37 +41,46 @@ class CollectionProxy extends Base {
     }
 
     async add(args) {
-        const collections = await this.getCollections();
+        const collections = await this.getCollections();  
         await Promise.all(collections.map(c => c.add(args)));
     }
 
     async upsert(args) {
-        const collections = await this.getCollections();
+        const collections = await this.getCollections();  
         await Promise.all(collections.map(c => c.upsert(args)));
     }
 
     async update(args) {
-        const collections = await this.getCollections();
+        const collections = await this.getCollections();  
         await Promise.all(collections.map(c => c.update(args)));
     }
 
     async get(args) {
         const collections = await this.getCollections();
+        if (!collections || collections.length === 0 || !collections[0]) {
+            throw new Error(`[CollectionProxy] get() failed: No underlying collection available for type '${this.collectionType}'`);
+        }
         return collections[0].get(args);
     }
     
     async query(args) {
-        const collections = await this.getCollections();
+        const collections = await this.getCollections();  
+        if (!collections || collections.length === 0 || !collections[0]) {
+            throw new Error(`[CollectionProxy] query() failed: No underlying collection available for type '${this.collectionType}'`);
+        }
         return collections[0].query(args);
     }
     
     async count() {
         const collections = await this.getCollections();
+        if (!collections || collections.length === 0 || !collections[0]) {
+            throw new Error(`[CollectionProxy] count() failed: No underlying collection available for type '${this.collectionType}'`);
+        }
         return collections[0].count();
     }
     
     async delete(args) {
-        const collections = await this.getCollections();
+        const collections = await this.getCollections();  
         await Promise.all(collections.map(c => c.delete(args)));
     }
 

--- a/test/playwright/unit/ai/mcp/server/memory-core/services/SessionSummarization.spec.mjs
+++ b/test/playwright/unit/ai/mcp/server/memory-core/services/SessionSummarization.spec.mjs
@@ -50,8 +50,7 @@ test.describe('Memory Core Offline Summarization', () => {
 
         const testDbName              = `memory-core-session-test-${process.pid}-${Date.now()}.sqlite`;
         const testDbPath              = path.join(tmpDir, testDbName);
-        aiConfig.engines.neo.dataDir  = tmpDir;
-        aiConfig.engines.neo.filename = testDbName;
+        aiConfig.storagePaths.graph   = testDbPath;
 
         // Remove existing test db
         if (fs.existsSync(testDbPath)) {

--- a/test/playwright/unit/ai/mcp/server/memory-core/services/SessionSummarization.spec.mjs
+++ b/test/playwright/unit/ai/mcp/server/memory-core/services/SessionSummarization.spec.mjs
@@ -2,8 +2,8 @@ import {setup} from '../../../../../../setup.mjs';
 
 const appName = 'MemoryCoreTest';
 
-process.env.MODEL_PROVIDER = 'openAiCompatible';
-process.env.OPENAI_COMPATIBLE_MODEL   = 'gemma4';
+process.env.NEO_MODEL_PROVIDER = 'openAiCompatible';
+process.env.NEO_OPENAI_COMPATIBLE_MODEL = 'gemma4';
 
 setup({
     neoConfig: {


### PR DESCRIPTION
Closes #10504

This PR fixes a bug in the `CollectionProxy` manager within the Memory Core.

1. **Config Key Alignment:** Changed the config reference from `aiConfig.architecture` to `aiConfig.engine` to match the canonical export from `config.mjs`. This ensures manager arrays are correctly hydrated in Hybrid and Chroma environments.
2. **Defensive Boundary Guards:** Added explicit validation checks to `get()`, `query()`, and `count()` methods to ensure the underlying collection array is populated before attempting to access `collections[0]`. This converts cryptic `TypeError: Cannot read properties of undefined` crashes into highly actionable `[CollectionProxy] method() failed: No underlying collection available` errors.

Agent: @neo-gemini-3-1-pro
Origin Session ID: df8049d8-56ad-417b-ae0e-17a38e22a0ae