### PR TITLE
refactor(memory-core): shrink manage_database MCP tool description (#10506)

### DIFF
--- a/ai/mcp/server/memory-core/openapi.yaml
+++ b/ai/mcp/server/memory-core/openapi.yaml
@@ -69,23 +69,20 @@ paths:
     post:
       summary: Manage Database
       operationId: manage_database
-      description: |
+      x-pass-as-object: true
+      description: >
         Manages the lifecycle (start/stop) of the ChromaDB database instance for the Memory Core.
 
         **Behavior:**
-        - **Start:**
-          - **Managed:** If no database is running on the configured port, this tool spawns a new process managed by this server. This process will be automatically cleaned up when the agent session ends.
-          - **External:** If a database is already running (e.g., via `npm run ai:server-memory`), this tool simply confirms the connection. The server acts as a client and will NOT kill the database on exit.
-        - **Stop:**
-          - **Managed:** Stops the process spawned by this server.
-          - **External:** **No effect.** The server cannot stop a database it did not start.
+        - **Start:** Spawns a new process if none runs on the configured port. This process cleans up on exit. If already running (e.g., via `npm run ai:server-memory`), simply confirms connection (acts as client, won't kill on exit).
+        - **Stop:** Stops the spawned process. No effect on externally started databases.
 
-        **Multi-Agent / Swarm Recommendation:**
-        For workflows involving multiple concurrent agents, it is **highly recommended** to start the database externally using `npm run ai:server-memory` before starting the agents. This prevents unexpected disconnects for other agents when the "owner" agent exits.
+        **Multi-Agent Recommendation:**
+        For concurrent agents, start the database externally using `npm run ai:server-memory` before starting agents to prevent disconnects.
 
         **When to Use:**
-        - Use `action: start` if a `healthcheck` reveals that the database process is not running.
-        - Use `action: stop` for debugging, forcing a restart, or freeing up resources.
+        - `action: start` if `healthcheck` shows it's not running.
+        - `action: stop` for debugging, forcing restarts, or freeing resources.
       tags: ["Database Lifecycle"]
       requestBody:
         required: true


### PR DESCRIPTION
Closes #10506

This PR applies the MCP-Tool-Description Budget Audit standard to the `manage_database` tool in the Memory Core. By condensing the verbose behavioral conditionals into shorter sentences and adding `x-pass-as-object: true`, we free up reasoning tokens in the agent's context window.

Agent: @neo-gemini-3-1-pro
Origin Session ID: df8049d8-56ad-417b-ae0e-17a38e22a0ae