### PR TITLE
fix(mcp): support enum constraints for string inputs (#10527)

### DIFF
--- a/ai/mcp/validation/OpenApiValidator.mjs
+++ b/ai/mcp/validation/OpenApiValidator.mjs
@@ -146,7 +146,11 @@ function buildZodSchemaFromNode(doc, schema, opts = {}) {
             zodSchema = z.array(z.unknown());
         }
     } else if (schema.type === 'string') {
-        zodSchema = z.string();
+        if (Array.isArray(schema.enum) && schema.enum.length > 0) {
+            zodSchema = z.enum(schema.enum);
+        } else {
+            zodSchema = z.string();
+        }
     } else if (schema.type === 'integer') {
         zodSchema = z.number().int();
     } else if (schema.type === 'number') {

--- a/test/playwright/unit/ai/mcp/validation/OpenApiValidatorCompliance.spec.mjs
+++ b/test/playwright/unit/ai/mcp/validation/OpenApiValidatorCompliance.spec.mjs
@@ -131,6 +131,41 @@ test.describe('OpenApiValidator: strict-client JSON-Schema compliance', () => {
         expect(parsed.properties).toEqual({text: 'KEEP_ME', arbitraryKey: 42});
     });
 
+    /**
+     * Direct regression for https://github.com/neomjs/neo/issues/10527.
+     * Prior to the fix, `buildZodSchemaFromNode` blindly converted string schemas
+     * to `z.string()`, entirely dropping any `enum` constraint defined in OpenAPI.
+     * This test confirms that string parameters with enums correctly generate `z.enum()`.
+     */
+    test('buildZodSchema preserves enum constraints for string inputs (#10527)', async () => {
+        const doc = {
+            paths: {
+                '/test': {
+                    post: {
+                        operationId: 'test_enum',
+                        requestBody: {
+                            content: {
+                                'application/json': {
+                                    schema: {
+                                        type: 'object',
+                                        properties: {
+                                            action: { type: 'string', enum: ['start', 'stop'] }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        };
+        const op = doc.paths['/test'].post;
+        const schema = zodToJsonSchema(buildZodSchema(doc, op), {target: 'openApi3', $refStrategy: 'none'});
+
+        expect(schema.properties.action.type).toBe('string');
+        expect(schema.properties.action.enum).toEqual(['start', 'stop']);
+    });
+
     for (const server of servers) {
         test(`${server}: every emitted input/output schema has items on array nodes (#10064)`, () => {
             const yamlPath = path.join(repoRoot, 'ai/mcp/server', server, 'openapi.yaml');


### PR DESCRIPTION
Authored by Gemini 3.1 Pro (Antigravity). Session 2d08f92a-3388-4ee1-8247-587a943e294a.

Resolves #10527

Added native `z.enum()` support for string schemas in `OpenApiValidator.mjs`. This prevents string properties with `enum` arrays from falling back to open-ended `z.string()` definitions during the MCP schema translation phase, surfacing the valid values natively in the tool input schema.

## Deltas from ticket
None.

## Test Evidence
Ran `npx playwright test test/playwright/unit/ai/mcp/validation/OpenApiValidatorCompliance.spec.mjs`. Added a new regression test suite checking `#10527` specifically. 24/24 tests pass, confirming no regressions in other passthrough logic.

## Post-Merge Validation
- [ ] Verify `harnessTarget` in `manage_wake_subscription` tool lists the correct enums natively in Antigravity prompt.
- [ ] Remove redundant text-embedded enum values in `openapi.yaml`.

## Commits
- 9504ce5a3 — fix(mcp): support enum constraints for string inputs (#10527)
