### PR TITLE
feat(sunset): disambiguate session sunset triggers from PR review halting (#10529)

### DIFF
--- a/.agents/skills/session-sunset/references/session-sunset-workflow.md
+++ b/.agents/skills/session-sunset/references/session-sunset-workflow.md
@@ -17,6 +17,10 @@ A true Session Boundary is defined by:
 4. **Proactive Agent Recommendation:** You recognize a natural, logical break point in the work stream and explicitly recommend sunsetting to the human.
 
 If none of these conditions are met, do **NOT** sunset. Simply output your response and wait for the next turn.
+
+### 1.1 Review Lifecycle Exception (Anti-Trigger)
+You are strictly FORBIDDEN from executing the Sunset Protocol when you halt your turn to await cross-model PR review (per `pull-request-workflow.md`). Yielding control to wait for asynchronous review feedback or a human merge is an **active lifecycle state**, not a Session Boundary. Do not pollute the swarm with premature Sandman memories during the review cycle.
+
 ## 2. The Handoff Structure
 
 Before terminating your session, you MUST execute the following 8 steps to ensure a clean handover.

--- a/.agents/skills/session-sunset/references/session-sunset-workflow.md
+++ b/.agents/skills/session-sunset/references/session-sunset-workflow.md
@@ -19,7 +19,7 @@ A true Session Boundary is defined by:
 If none of these conditions are met, do **NOT** sunset. Simply output your response and wait for the next turn.
 
 ### 1.1 Review Lifecycle Exception (Anti-Trigger)
-You are strictly FORBIDDEN from executing the Sunset Protocol when you halt your turn to await cross-model PR review (per `pull-request-workflow.md`). Yielding control to wait for asynchronous review feedback or a human merge is an **active lifecycle state**, not a Session Boundary. Do not pollute the swarm with premature Sandman memories during the review cycle.
+You are strictly FORBIDDEN from executing the Sunset Protocol when you halt your turn to await cross-model PR review or reviewer feedback (per `pull-request-workflow.md`). Yielding control during the active review/polish loop is an active lifecycle state, not a Session Boundary. Once the PR reaches the terminal approved handoff state, normal Session Boundary rules apply again; agents still must not execute the merge.
 
 ## 2. The Handoff Structure
 


### PR DESCRIPTION
Authored by Neo Gemini 3.1 Pro ([Antigravity]). Origin Session ID: 2d08f92a-3388-4ee1-8247-587a943e294a.

Resolves #10529

Adds an explicit 'Review Lifecycle Exception (Anti-Trigger)' to the session sunset protocol. This prevents agents from erroneously conflating the 'halt and await cross-model review' command (from the pull-request workflow) with a Session Boundary, which previously caused false-positive Sunset Protocol executions.

## Deltas from ticket (if any)
None.

## Test Evidence
N/A - Documentation only update.

## Post-Merge Validation
- [ ] Swarm agents appropriately halt when opening a PR without triggering the Sunset protocol.