### PR TITLE
fix(memory-core): preserve wake metadata shape (#10407)

### DIFF
--- a/ai/mcp/server/memory-core/openapi.yaml
+++ b/ai/mcp/server/memory-core/openapi.yaml
@@ -1143,11 +1143,16 @@ paths:
                   description: Required for subscribe; specifies how wake events are delivered.
                 harnessTargetMetadata:
                   type: object
-                  description: Channel-specific metadata. url required for a2a-webhook; coalesceWindow optional override; daemonSocketPath for bridge-daemon.
+                  description: Channel-specific metadata. appName is required so fresh agents always provide the bridge-daemon/osascript routing target; url is required for a2a-webhook; coalesceWindow is an optional override.
+                  required: [appName]
                   properties:
-                    url:               {type: string}
-                    coalesceWindow:    {type: integer, minimum: 0, maximum: 300}
-                    daemonSocketPath:  {type: string}
+                    url:              {type: string}
+                    coalesceWindow:   {type: integer, minimum: 0, maximum: 300}
+                    daemonSocketPath: {type: string}
+                    adapter:          {type: string, enum: [osascript, tmux]}
+                    appName:          {type: string}
+                    tabShortcut:      {type: string, nullable: true}
+                    tmuxSession:      {type: string}
                 sinceLogId:
                   type: integer
                   description: Required for resync. GraphLog watermark; client-tracked.

--- a/ai/mcp/server/memory-core/services/WakeSubscriptionService.mjs
+++ b/ai/mcp/server/memory-core/services/WakeSubscriptionService.mjs
@@ -291,7 +291,8 @@ class WakeSubscriptionService extends Base {
      * @param {String} opts.trigger One of validTriggers
      * @param {Object} [opts.filters] taggedConcepts | priority | senderFilter | inReplyToFilter
      * @param {String} opts.harnessTarget One of validHarnessTargets
-     * @param {Object} [opts.harnessTargetMetadata] url | coalesceWindow | daemonSocketPath
+     * @param {Object} [opts.harnessTargetMetadata] appName | url | coalesceWindow |
+     *     daemonSocketPath | adapter | tabShortcut | tmuxSession
      * @returns {Promise<Object>} {subscriptionId, harnessTarget, signingKey?}
      */
     async subscribe({trigger, filters = {}, harnessTarget, harnessTargetMetadata = {}} = {}) {
@@ -320,6 +321,7 @@ class WakeSubscriptionService extends Base {
             signingKey              = crypto.randomBytes(32).toString('hex');
             finalMetadata.signingKey = signingKey;
         }
+        this.validateHarnessTargetMetadata(harnessTarget, finalMetadata);
 
         const properties = {
             agentIdentity: owner,
@@ -418,6 +420,7 @@ class WakeSubscriptionService extends Base {
         if (filters               !== undefined) updated.filters               = filters;
         if (harnessTarget         !== undefined) updated.harnessTarget         = harnessTarget;
         if (harnessTargetMetadata !== undefined) updated.harnessTargetMetadata = {...subscription.harnessTargetMetadata, ...harnessTargetMetadata};
+        this.validateHarnessTargetMetadata(updated.harnessTarget, updated.harnessTargetMetadata || {});
         updated.updatedAt = new Date().toISOString();
 
         const {id, ...properties} = updated;
@@ -430,6 +433,28 @@ class WakeSubscriptionService extends Base {
         this.subscriptionCache.set(subscriptionId, updated);
 
         return {subscriptionId, currentState: updated};
+    }
+
+    /**
+     * @summary Validates channel metadata for the WAKE_SUBSCRIPTION lifecycle before
+     * graph persistence.
+     *
+     * This service-side guard complements the `manage_wake_subscription` MCP tool shape:
+     * the schema teaches fresh agents to pass the bridge-daemon routing fields, while
+     * this check protects bootstrap and programmatic paths that bypass MCP Zod parsing.
+     * The explicit `appName` requirement intentionally echoes the bridge-daemon/osascript
+     * routing contract so malformed subscriptions fail before the daemon can only log a
+     * missed wake.
+     *
+     * @param {String} harnessTarget The wake delivery channel.
+     * @param {Object} metadata Channel-specific harnessTargetMetadata.
+     * @throws {Error} When required metadata is missing.
+     * @protected
+     */
+    validateHarnessTargetMetadata(harnessTarget, metadata = {}) {
+        if (harnessTarget === 'bridge-daemon' && !metadata.appName) {
+            throw new Error('Shape C (bridge-daemon) requires harnessTargetMetadata.appName.');
+        }
     }
 
     /**

--- a/test/playwright/unit/ai/mcp/server/memory-core/McpServerToolLimits.spec.mjs
+++ b/test/playwright/unit/ai/mcp/server/memory-core/McpServerToolLimits.spec.mjs
@@ -58,4 +58,22 @@ test.describe('Neo.ai.mcp.server.memory-core Tool limits', () => {
             }
         }
     });
+
+    test('manage_wake_subscription surfaces bridge metadata contract', async () => {
+        const { tools } = await toolService.listTools();
+        const tool = tools.find(item => item.name === 'manage_wake_subscription');
+        const metadata = tool.inputSchema.properties.harnessTargetMetadata;
+
+        expect(metadata.required).toContain('appName');
+        expect(Object.keys(metadata.properties)).toEqual(expect.arrayContaining([
+            'adapter',
+            'appName',
+            'coalesceWindow',
+            'daemonSocketPath',
+            'tabShortcut',
+            'tmuxSession',
+            'url'
+        ]));
+        expect(metadata.properties.adapter.enum).toEqual(['osascript', 'tmux']);
+    });
 });

--- a/test/playwright/unit/ai/mcp/server/memory-core/services/WakeSubscriptionService.spec.mjs
+++ b/test/playwright/unit/ai/mcp/server/memory-core/services/WakeSubscriptionService.spec.mjs
@@ -27,7 +27,7 @@ import RequestContextService from '../../../../../../../../ai/mcp/server/shared/
 
 test.describe('Neo.ai.mcp.server.memory-core.services.WakeSubscriptionService', () => {
     test.describe.configure({mode: 'serial'});
-    let WakeSubscriptionService, GraphService, LifecycleService, CoalescingEngineService, originalAutoSave;
+    let WakeSubscriptionService, GraphService, LifecycleService, CoalescingEngineService, callTool, originalAutoSave;
     let dbPath;
 
     test.beforeAll(async () => {
@@ -44,6 +44,7 @@ test.describe('Neo.ai.mcp.server.memory-core.services.WakeSubscriptionService', 
         WakeSubscriptionService = (await import('../../../../../../../../ai/mcp/server/memory-core/services/WakeSubscriptionService.mjs')).default;
         CoalescingEngineService = (await import('../../../../../../../../ai/mcp/server/memory-core/services/CoalescingEngineService.mjs')).default;
         LifecycleService        = (await import('../../../../../../../../ai/mcp/server/memory-core/services/lifecycle/SystemLifecycleService.mjs')).default;
+        ({callTool}             = await import('../../../../../../../../ai/mcp/server/memory-core/services/toolService.mjs'));
 
         const GraphMaintenanceService = (await import('../../../../../../../../ai/daemons/services/GraphMaintenanceService.mjs')).default;
         globalThis.GraphMaintenanceService = GraphMaintenanceService;
@@ -224,6 +225,37 @@ test.describe('Neo.ai.mcp.server.memory-core.services.WakeSubscriptionService', 
                 trigger      : 'SENT_TO_ME',
                 harnessTarget: 'a2a-webhook'
             })).rejects.toThrow('Shape B (a2a-webhook) requires harnessTargetMetadata.url');
+        });
+    });
+
+    test('subscribe with bridge-daemon but no appName throws', async () => {
+        await RequestContextService.run({agentIdentityNodeId: '@alice'}, async () => {
+            await expect(WakeSubscriptionService.subscribe({
+                trigger      : 'SENT_TO_ME',
+                harnessTarget: 'bridge-daemon'
+            })).rejects.toThrow('Shape C (bridge-daemon) requires harnessTargetMetadata.appName');
+        });
+    });
+
+    test('MCP tool preserves explicit bridge-daemon metadata fields', async () => {
+        await RequestContextService.run({agentIdentityNodeId: '@alice'}, async () => {
+            const res = await callTool('manage_wake_subscription', {
+                action               : 'subscribe',
+                trigger              : 'SENT_TO_ME',
+                harnessTarget        : 'bridge-daemon',
+                harnessTargetMetadata: {
+                    adapter       : 'osascript',
+                    appName       : 'Claude',
+                    coalesceWindow: 0,
+                    tabShortcut   : '3'
+                }
+            });
+
+            const node = GraphService.db.nodes.get(res.subscriptionId);
+            expect(node.properties.harnessTargetMetadata.adapter).toBe('osascript');
+            expect(node.properties.harnessTargetMetadata.appName).toBe('Claude');
+            expect(node.properties.harnessTargetMetadata.coalesceWindow).toBe(0);
+            expect(node.properties.harnessTargetMetadata.tabShortcut).toBe('3');
         });
     });
 
@@ -621,7 +653,11 @@ test.describe('Neo.ai.mcp.server.memory-core.services.WakeSubscriptionService', 
             CoalescingEngineService.setMcpServer(mockMcpServer);
 
             await RequestContextService.run({agentIdentityNodeId: '@alice'}, async () => {
-                await WakeSubscriptionService.subscribe({trigger: 'SENT_TO_ME', harnessTarget: 'bridge-daemon'});
+                await WakeSubscriptionService.subscribe({
+                    trigger              : 'SENT_TO_ME',
+                    harnessTarget        : 'bridge-daemon',
+                    harnessTargetMetadata: {appName: 'Claude'}
+                });
                 await WakeSubscriptionService.subscribe({trigger: 'SENT_TO_ME', harnessTarget: 'a2a-webhook', harnessTargetMetadata: {url: 'test'}});
                 await WakeSubscriptionService.subscribe({trigger: 'SENT_TO_ME', harnessTarget: 'disabled'});
             });


### PR DESCRIPTION
Authored by GPT-5 (Codex Desktop). Session abb9e613-9465-4097-b9a9-30d30f8997a6.

Resolves #10407

This tightens the `manage_wake_subscription` MCP contract for wake routing metadata. The tool schema now exposes the known `harnessTargetMetadata` fields used by the bridge/webhook paths and marks `appName` required so fresh agent sessions learn the desktop bridge-daemon routing contract before they create an undeliverable subscription. `WakeSubscriptionService` also validates bridge-daemon metadata before graph persistence, covering bootstrap and programmatic paths that bypass MCP Zod parsing.

## Deltas from ticket
The original ticket allowed either pass-through metadata or explicit known fields. This PR chooses explicit known fields plus a required `appName`, per the later #10407 comment: the current MC server auto-subscribes on boot, so direct tool use is already an edge case, and passing one extra routing field is cheaper than repeated fresh-session misuse. A future node-script replacement or discriminated metadata union remains out of scope.

## Test Evidence
- `echo '{"jsonrpc": "2.0", "id": 1, "method": "tools/list"}' | node ai/mcp/server/memory-core/mcp-server.mjs` showed `harnessTargetMetadata.required: ["appName"]` and the expanded metadata properties.\n- `npm run test-unit -- test/playwright/unit/ai/mcp/server/memory-core/McpServerToolLimits.spec.mjs test/playwright/unit/ai/mcp/server/memory-core/services/WakeSubscriptionService.spec.mjs` passed: 31 tests.\n- `git diff --check` and `git diff --cached --check` passed.\n\n## Post-Merge Validation\n- [ ] Start a fresh Memory Core MCP server and verify `tools/list` exposes `harnessTargetMetadata.appName` as required for `manage_wake_subscription`.\n- [ ] Confirm a direct bridge-daemon subscription created through the MCP tool preserves `appName`, `adapter`, `tabShortcut`, and `coalesceWindow`.\n\n## Commit\n- `7b0bbe320` — `fix(memory-core): preserve wake metadata shape (#10407)`