### PR TITLE
fix(ai): preserve MCP tool-shape metadata (#10531)

### DIFF
--- a/ai/mcp/server/memory-core/openapi.yaml
+++ b/ai/mcp/server/memory-core/openapi.yaml
@@ -916,6 +916,7 @@ paths:
           description: "Which box to list ('inbox', 'outbox', 'all')"
           schema:
             type: string
+            enum: [inbox, outbox, all]
             default: "inbox"
         - name: status
           in: query
@@ -923,6 +924,7 @@ paths:
           description: "Message read status ('all', 'read', 'unread')"
           schema:
             type: string
+            enum: [all, read, unread]
             default: "all"
         - name: to
           in: query

--- a/ai/mcp/validation/OpenApiValidator.mjs
+++ b/ai/mcp/validation/OpenApiValidator.mjs
@@ -66,8 +66,13 @@ function resolveRef(doc, ref) {
 }
 
 /**
- * Recursively builds a Zod schema from an OpenAPI schema object, handling
- * nested structures and JSON references.
+ * @summary Recursively builds a Zod schema from an OpenAPI schema object.
+ *
+ * The OpenAPI-to-Zod bridge is the Agent OS tool-shape compiler. It must preserve
+ * machine-readable schema metadata such as defaults and numeric bounds so fresh
+ * agents can learn valid MCP tool calls from `tools/list` before hitting runtime
+ * validation errors.
+ *
  * @param {object}  doc             - The full OpenAPI document for reference resolution.
  * @param {object}  schema          - The OpenAPI schema object (or a resolved reference).
  * @param {object}  [opts]          - Optional build context.
@@ -153,8 +158,24 @@ function buildZodSchemaFromNode(doc, schema, opts = {}) {
         }
     } else if (schema.type === 'integer') {
         zodSchema = z.number().int();
+
+        if (typeof schema.minimum === 'number') {
+            zodSchema = zodSchema.min(schema.minimum)
+        }
+
+        if (typeof schema.maximum === 'number') {
+            zodSchema = zodSchema.max(schema.maximum)
+        }
     } else if (schema.type === 'number') {
         zodSchema = z.number();
+
+        if (typeof schema.minimum === 'number') {
+            zodSchema = zodSchema.min(schema.minimum)
+        }
+
+        if (typeof schema.maximum === 'number') {
+            zodSchema = zodSchema.max(schema.maximum)
+        }
     } else if (schema.type === 'boolean') {
         zodSchema = z.boolean();
     } else {
@@ -172,6 +193,10 @@ function buildZodSchemaFromNode(doc, schema, opts = {}) {
 
     if (schema.description) {
         zodSchema = zodSchema.describe(schema.description);
+    }
+
+    if (Object.hasOwn(schema, 'default')) {
+        zodSchema = zodSchema.default(schema.default);
     }
 
     return zodSchema;

--- a/ai/mcp/validation/OpenApiValidator.mjs
+++ b/ai/mcp/validation/OpenApiValidator.mjs
@@ -156,18 +156,12 @@ function buildZodSchemaFromNode(doc, schema, opts = {}) {
         } else {
             zodSchema = z.string();
         }
-    } else if (schema.type === 'integer') {
-        zodSchema = z.number().int();
-
-        if (typeof schema.minimum === 'number') {
-            zodSchema = zodSchema.min(schema.minimum)
-        }
-
-        if (typeof schema.maximum === 'number') {
-            zodSchema = zodSchema.max(schema.maximum)
-        }
-    } else if (schema.type === 'number') {
+    } else if (schema.type === 'integer' || schema.type === 'number') {
         zodSchema = z.number();
+
+        if (schema.type === 'integer') {
+            zodSchema = zodSchema.int()
+        }
 
         if (typeof schema.minimum === 'number') {
             zodSchema = zodSchema.min(schema.minimum)

--- a/test/playwright/unit/ai/mcp/validation/OpenApiValidatorCompliance.spec.mjs
+++ b/test/playwright/unit/ai/mcp/validation/OpenApiValidatorCompliance.spec.mjs
@@ -166,6 +166,34 @@ test.describe('OpenApiValidator: strict-client JSON-Schema compliance', () => {
         expect(schema.properties.action.enum).toEqual(['start', 'stop']);
     });
 
+    /**
+     * Direct regression for https://github.com/neomjs/neo/issues/10531.
+     * The MCP tool-shape compiler must preserve OpenAPI defaults, numeric bounds,
+     * and native choice enums so agents learn valid calls from `tools/list`.
+     */
+    test('memory-core input schemas preserve defaults, bounds, and choice enums (#10531)', async () => {
+        const doc                = yaml.load(fs.readFileSync(path.join(repoRoot, 'ai/mcp/server/memory-core/openapi.yaml'), 'utf8')),
+              addMessageSchema   = zodToJsonSchema(buildZodSchema(doc, doc.paths['/mailbox/messages'].post), {target: 'openApi3', $refStrategy: 'none'}),
+              listMessagesSchema = zodToJsonSchema(buildZodSchema(doc, doc.paths['/mailbox/messages'].get),  {target: 'openApi3', $refStrategy: 'none'}),
+              wakeSchema         = zodToJsonSchema(buildZodSchema(doc, doc.paths['/wake-subscriptions/manage'].post), {target: 'openApi3', $refStrategy: 'none'}),
+              coalesceWindow     = wakeSchema.properties.harnessTargetMetadata.properties.coalesceWindow;
+
+        expect(addMessageSchema.properties.priority.enum).toEqual(['low', 'normal', 'high']);
+        expect(addMessageSchema.properties.priority.default).toBe('normal');
+        expect(addMessageSchema.properties.wakeSuppressed.default).toBe(false);
+
+        expect(listMessagesSchema.properties.box.enum).toEqual(['inbox', 'outbox', 'all']);
+        expect(listMessagesSchema.properties.box.default).toBe('inbox');
+        expect(listMessagesSchema.properties.status.enum).toEqual(['all', 'read', 'unread']);
+        expect(listMessagesSchema.properties.status.default).toBe('all');
+        expect(listMessagesSchema.properties.limit.default).toBe(50);
+        expect(listMessagesSchema.properties.offset.default).toBe(0);
+
+        expect(coalesceWindow.type).toBe('integer');
+        expect(coalesceWindow.minimum).toBe(0);
+        expect(coalesceWindow.maximum).toBe(300);
+    });
+
     for (const server of servers) {
         test(`${server}: every emitted input/output schema has items on array nodes (#10064)`, () => {
             const yamlPath = path.join(repoRoot, 'ai/mcp/server', server, 'openapi.yaml');


### PR DESCRIPTION
Authored by GPT-5 (Codex Desktop). Session af8b6e6f-0b10-43f0-ace4-aa8e8f736428.

Consumes prior GPT-5 handoff context from Origin Session ID: abb9e613-9465-4097-b9a9-30d30f8997a6.

Resolves #10531

Preserves machine-readable OpenAPI metadata in MCP tool shapes so fresh agents can learn defaults, numeric bounds, and choice constraints from `tools/list` before making a bad call. The shared OpenAPI-to-Zod bridge now carries `default`, `minimum`, and `maximum` into generated JSON Schema output, and Memory Core declares native enums for `list_messages.box` / `status` instead of leaving those choices in prose only.

## Deltas from ticket
No broad MCP cleanup was bundled. The patch stays scoped to schema fidelity: converter metadata preservation, two Memory Core YAML enums, and focused compliance coverage.

## Test Evidence
- `npm run test-unit -- test/playwright/unit/ai/mcp/validation/OpenApiValidatorCompliance.spec.mjs` passed: 25 tests.
- Re-ran the same focused test after rebasing onto fresh `origin/dev`: 25 tests passed.
- Live Memory Core `tools/list` probe confirmed `list_messages.box/status` enums and defaults, `add_message.priority/wakeSuppressed` defaults, and `harnessTargetMetadata.coalesceWindow` minimum/maximum.
- `git diff --check` and `git diff --cached --check` passed.
- Pre-push freshness check rebased the branch onto `origin/dev` after upstream advanced by generated ticket sync.

## Post-Merge Validation
- [ ] Fresh `tools/list` from merged `origin/dev` still exposes the same defaults, numeric bounds, and choice enums.

## Commit
- `111392f65` — `fix(ai): preserve MCP tool-shape metadata (#10531)`