### PR TITLE
docs(ai): document loaded-surface measurement methodology (#10540)

### DIFF
--- a/.agents/skills/pr-review/references/measurement-methodology.md
+++ b/.agents/skills/pr-review/references/measurement-methodology.md
@@ -1,0 +1,35 @@
+# Loaded-Surface Measurement Methodology
+
+This document establishes the empirical baseline methodology for measuring the "loaded surface" of a PR review cycle. This is a prerequisite for Epic #10537 (Modularization of `pr-review-guide.md`) to quantify the exact context cost of the current monolithic architecture versus the proposed modular architecture.
+
+## 1. Core Philosophy: Loaded-Byte Proxy
+Token-cost estimates from different models (e.g., Claude vs Gemini) are highly variable and prone to hallucination. Therefore, the **Primary Metric** for measuring the loaded surface is the **loaded-byte count** (`wc -c`), which provides a mathematically verifiable and deterministic proxy for context window consumption.
+- **Primary Metric:** `wc -c` (loaded-byte count) of the raw strings ingested.
+
+## 2. Measurement Scope
+The loaded surface per review cycle must capture the sum of all components actively loaded into the agent's context window, separated into static (constant framework overhead) and dynamic (PR-specific variability) components.
+
+### 2.1 Cycle 1 (Cold-Cache) Measurement
+For the initial review (Cycle 1), the following must be measured and reported:
+**Static Surface:**
+1. **The Guide:** `wc -c .agents/skills/pr-review/references/pr-review-guide.md`
+2. **The Template:** `wc -c .agents/skills/pr-review/assets/pr-review-template.md` (or the specific template used).
+**Dynamic Surface:**
+3. **The Audit Payloads:** The `wc -c` of any extracted code diffs, conversation histories, and issue bodies ingested to perform the review. Audit payload size varies per review; the per-cycle Dynamic Surface column captures this dimension. Variance is expected, not a measurement defect.
+
+### 2.2 Cycle N (Warm-Cache) Measurement
+For subsequent re-reviews (Cycle N), the measurement must capture the delta payload:
+**Static Surface:**
+1. **The Follow-Up Template:** `wc -c .agents/skills/pr-review/assets/pr-review-followup-template.md` (if used).
+**Dynamic Surface:**
+2. **The Delta Payloads:** The `wc -c` of new commits, new conversation comments, and any re-grounding context fetched.
+
+## 3. Baseline Data Capture
+Before any pilot extraction (Sub-issue 2 of Epic #10537) can begin, we must capture a **minimum of 10 cycles** of baseline data. If statistical variance remains high at n=10, capture will extend to n=15 or n=20 before proceeding, to avoid extracting based on noisy or atypical cycle data.
+- The recorded data must be appended to the dedicated tracking file: `learn/agentos/measurements/pr-review-baseline-2026-04.md`.
+- **Gating Mechanism:** Sub-issue 2 (Pilot extraction of review templates) is strictly blocked until the baseline (per §3 opening) is fully captured and validated.
+
+## 4. Execution Procedure
+1. During a PR Review, calculate the `wc -c` of the relevant files and payloads (separating Static vs Dynamic).
+2. Log the cycle details, including PR number, Cycle number, Static `wc -c`, Dynamic `wc -c`, and Total `wc -c`.
+3. Report the log natively in your PR Review comment as a `Measurement Payload` block. A dedicated aggregator or the author during session sunset will persist it to `learn/agentos/measurements/pr-review-baseline-2026-04.md` to avoid review-time merge conflicts.

--- a/.agents/skills/pr-review/references/pr-review-guide.md
+++ b/.agents/skills/pr-review/references/pr-review-guide.md
@@ -8,6 +8,9 @@ This protocol ensures that feedback is:
 2. **Actionable:** Clearly delineating block-level requirements before a merge can occur.
 3. **Graph-Extractable:** Structured with specific Markdown tags so the background Retrospective Agent (Gemma 4:31B) can mathematically ingest the feedback into the Native Edge Graph.
 
+> **Measurement Notice (Epic #10537):**
+> We are actively tracking the loaded surface of PR review cycles to establish a baseline for modularization. Before conducting reviews, consult the [Loaded-Surface Measurement Methodology](./measurement-methodology.md) and ensure you capture and log the `wc -c` metric for your cycle.
+
 ## 1. Core Philosophy
 - **For Internal Agents (Peer-Review):** Be objective, clinical, and strict. Enforce the "Fat Ticket" protocol and strict JSDoc completeness.
 - **For External/First-Time Contributors:** Start with positive reinforcement. Acknowledge their effort. Provide explicit, helpful examples when asking for changes.

--- a/learn/agentos/measurements/pr-review-baseline-2026-04.md
+++ b/learn/agentos/measurements/pr-review-baseline-2026-04.md
@@ -1,0 +1,10 @@
+# PR Review Loaded-Surface Baseline (April 2026)
+
+This file tracks the loaded-byte (`wc -c`) metrics for PR review cycles, establishing the empirical baseline required for Epic #10537 (Modularization of `pr-review-guide.md`).
+
+**Requirement:** A minimum of 10 cycles of baseline data must be captured before Sub-issue 2 (Pilot extraction) can proceed.
+
+## Captured Data
+
+| Cycle | PR # | Cycle Type (1 or N) | Static `wc -c` | Dynamic `wc -c` | Total `wc -c` | Reviewer |
+| :--- | :--- | :--- | :--- | :--- | :--- | :--- |

--- a/learn/tree.json
+++ b/learn/tree.json
@@ -36,6 +36,8 @@
         {"name": "The Memory Core Server",                             "parentId": "AgentOS",                                             "id": "agentos/MemoryCore"},
         {"name": "The GitHub Workflow Server",                         "parentId": "AgentOS",                                             "id": "agentos/GitHubWorkflow"},
         {"name": "Code Execution (AI SDK)",                            "parentId": "AgentOS",                                             "id": "agentos/CodeExecution"},
+        {"name": "Measurements",                                       "parentId": "AgentOS",                            "isLeaf": false, "id": "AgentOS/Measurements", "collapsed": true},
+            {"name": "PR Review Loaded-Surface Baseline (April 2026)", "parentId": "AgentOS/Measurements",                                "id": "agentos/measurements/pr-review-baseline-2026-04"},
         {"name": "Tooling & Configuration",                            "parentId": "AgentOS",                            "isLeaf": false, "id": "AgentOS/Tooling", "collapsed": true},
             {"name": "Server Authorization",                           "parentId": "AgentOS/Tooling",                                     "id": "agentos/tooling/Authorization"},
             {"name": "Google OAuth Demo",                              "parentId": "AgentOS/Tooling",                                     "id": "agentos/tooling/GoogleAuthDemo"},


### PR DESCRIPTION
## Architecture Context
This PR formalizes the empirical baseline tracking methodology required by Epic #10537. It implements a deterministic `wc -c` measurement approach to quantify the exact loaded-surface payload of PR review cycles.

## Changes
- Created `measurement-methodology.md` to document the exact measurement scope and execution procedure for capturing cold-cache and warm-cache loaded bytes.
- Created `pr-review-baseline-2026-04.md` to serve as the centralized longitudinal tracker for the required 10-cycle measurement phase.
- Inserted an early-notice alert in `pr-review-guide.md` to ensure all reviewers execute the measurement protocol before beginning their review.

## Gating Status
Contributes to #10540. (Note: AC5b is longitudinal and remains ongoing across the next 10+ review cycles).
