### PR TITLE
fix(codex): load project instructions deterministically (#10552)

### DIFF
--- a/.codex/CODEX.md
+++ b/.codex/CODEX.md
@@ -1,6 +1,16 @@
+# Codex Desktop Reference
+
+This file is intentionally **not** the auto-loaded instruction source while the
+repository root contains `AGENTS.md`. Codex project-doc discovery loads at most
+one instruction file per directory, so root `AGENTS.md` wins before configured
+fallback files such as `.codex/CODEX.md`.
+
+The deterministic Codex Desktop notes live in `AGENTS.md §0.1`. Keep this file
+in sync as a small reference for humans and setup checks.
+
 You are Codex, running on **GPT 5.5**.
 Your GitHub username is `neo-gpt`.
-You can commincate via e.g. the `add_message` tool with
+You can communicate via the `add_message` tool with:
 * Claude Opus 4.7 => `neo-opus-4-7`
 * Gemini => `neo-gemini-3-1-pro`
 

--- a/.codex/config.template.toml
+++ b/.codex/config.template.toml
@@ -2,7 +2,11 @@
 # Keep .codex/config.toml untracked: it can contain machine-local paths,
 # trust-level overrides, and environment-specific MCP settings.
 
-project_doc_fallback_filenames = [".codex/CODEX.md"]
+# Codex project-doc discovery loads at most one instruction file per directory:
+# AGENTS.override.md, then AGENTS.md, then configured fallbacks. Since the repo
+# root owns AGENTS.md, .codex/CODEX.md is a reference file, not an auto-loaded
+# fallback. Keep Codex-specific mandatory notes in root AGENTS.md.
+project_doc_max_bytes = 131072
 
 # Neo.mjs marathon sessions routinely exceed Codex's conservative default effective
 # context budget. As of April 2026, GPT-5.5 / GPT-5.4 expose 1M-token context

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,6 +13,16 @@ These five rules are mechanically verifiable and have **no conditional exception
 4. **No `<noreply@*>` `Co-Authored-By` footers.** Override the harness default if it injects them. See `.agents/skills/pull-request/references/pull-request-workflow.md` §3.2.
 5. **No skipping `add_memory` at end of turn.** Forgetting the consolidated save = permanent data loss. The save IS the gate that permits the response. See §4.2.
 
+## 0.1. Codex Desktop Harness Notes
+
+These notes are intentionally stored in root `AGENTS.md`, not only in `.codex/CODEX.md`. Codex project-doc discovery loads at most one instruction file per directory: `AGENTS.override.md`, then `AGENTS.md`, then configured fallbacks. Because this repository root contains `AGENTS.md`, `.codex/CODEX.md` is a reference file and is not auto-loaded as a fallback during normal repo-root sessions.
+
+When operating as Codex Desktop:
+
+- Your GitHub username is `neo-gpt`.
+- You can communicate via the `add_message` tool with Claude Opus 4.7 at `neo-opus-4-7` and Gemini at `neo-gemini-3-1-pro`.
+- `gh auth status` can falsely report `GH_TOKEN` as invalid inside Codex's sandbox. Verify GitHub auth with `gh api user --jq .login`, or rerun `gh auth status` with sandbox escalation before treating auth as broken. Expected Codex identity: `neo-gpt`.
+
 
 
 ## 1. Communication Style & Pipeline Authority


### PR DESCRIPTION
Authored by GPT-5.5 (Codex Desktop). Session af8b6e6f-0b10-43f0-ace4-aa8e8f736428.

Resolves #10552

This makes Codex project instruction loading deterministic for the Neo repo. The PR removes the misleading `.codex/CODEX.md` fallback assumption from the committed template, raises the Codex project-doc byte budget so root `AGENTS.md` loads fully, and places the Codex identity/auth caveat directly in root `AGENTS.md`, which is the file Codex actually selects during normal repo-root sessions.

## Deltas from ticket

- Kept `.codex/CODEX.md` as a small reference file rather than deleting it.
- Updated the local ignored `.codex/config.toml` in this workspace as well, but only the tracked template is committed.
- Did not introduce `AGENTS.override.md`, because that would shadow root `AGENTS.md` instead of composing with it.

## Test Evidence

- `git diff --check`
- `git diff --cached --check`
- `codex debug prompt-input | rg -n "Codex Desktop Harness Notes|Authoring Discipline|Visual Verification Protocol|gh api user --jq"` confirmed a fresh Codex prompt includes the new Codex section and late `AGENTS.md` sections after the local `project_doc_max_bytes = 131072` update.
- `rg -n "project_doc_fallback_filenames|project_doc_max_bytes|Codex Desktop Harness Notes|Codex Desktop Reference" AGENTS.md .codex/CODEX.md .codex/config.template.toml .codex/config.toml` confirmed the fallback entry is gone and the byte budget is explicit.
- Pre-push freshness check passed after rebasing off generated sync contamination: `merge-base HEAD origin/dev == origin/dev`; outgoing log contains only `9f708f9a8 fix(codex): load project instructions deterministically (#10552)`.

## Post-Merge Validation

- [ ] Fresh Codex Desktop session from repo root loads `AGENTS.md §0.1` without requiring `.codex/CODEX.md` as a fallback.

## Commit

- `9f708f9a8` — `fix(codex): load project instructions deterministically (#10552)`
