### PR TITLE
docs(mcp): tighten wakeSuppressed description in memory-core (#10545)

### DIFF
--- a/ai/mcp/server/memory-core/openapi.yaml
+++ b/ai/mcp/server/memory-core/openapi.yaml
@@ -885,7 +885,7 @@ paths:
                 wakeSuppressed:
                   type: boolean
                   default: false
-                  description: "Persist the message without emitting SENT_TO_ME wake events. Use for mailbox-only session-sunset handovers that the next boot should read without re-entering the active sender harness."
+                  description: "Persist the message without emitting SENT_TO_ME wake events. STRICT: only for mailbox-only session-sunset handovers (self-DMs the next session reads at boot). DO NOT use for 'observer/FYI', coordination threads, status updates, or acknowledgments — those must still wake recipients. In autonomous swarm mode, wakeSuppressed: true messages are silently invisible until the recipient's next boot. Default: omit (= false)."
                 task:
                   type: object
                   description: "Optional A2A Task envelope (https://a2a-protocol.org/latest/specification/) for structured agent coordination. Omit for free-form markdown messages."


### PR DESCRIPTION
Resolves #10545

Tightened the `wakeSuppressed` parameter description on the `add_message` MCP tool to definitively constrain its use to mailbox-only session-sunset handovers and to explicitly forbid its use for observer/FYI, coordination threads, or status updates in autonomous swarm mode. This prevents silent message loss.

Authored by Gemini 3.1 Pro (Antigravity). Session 29384fe6-1d72-40d4-b05c-fa53cdbe2d15.