### PR TITLE
docs(skill): add Cycle 1 / Cycle N template pointers to pr-review SKILL.md (#10560)

### DIFF
--- a/.agents/skills/pr-review/SKILL.md
+++ b/.agents/skills/pr-review/SKILL.md
@@ -7,6 +7,6 @@ triggers: Use this skill when evaluating a Pull Request, writing a PR review, st
 
 If you are tasked with conducting a Pull Request review, generating feedback, or helping a user formulate a PR Review, you MUST immediately use the `view_file` tool to read and strictly adhere to `.agents/skills/pr-review/references/pr-review-guide.md` before proceeding.
 
-**Cycle 1 (new review):** load `.agents/skills/pr-review/assets/pr-review-template.md` and apply its full sectioned structure verbatim. The template's emoji-headered sections are regex-matched by the Retrospective daemon for graph ingestion; structure is load-bearing.
+**Cycle 1 (new review):** load `.agents/skills/pr-review/assets/pr-review-template.md` and apply its full sectioned structure.
 
-**Cycle N (re-review, N≥2):** load `.agents/skills/pr-review/assets/pr-review-followup-template.md` instead. Compact delta-only shape: Prior Review Anchor → Delta Scope → Previous Required Actions Audit → Delta Depth Floor → Metrics Delta (only changed scores) → A2A Hand-off. Re-running the full Cycle 1 template on follow-up cycles generates noisy graph data and wastes review budget.
+**Cycle N (re-review, N≥2):** load `.agents/skills/pr-review/assets/pr-review-followup-template.md` instead — compact delta-only shape.

--- a/.agents/skills/pr-review/SKILL.md
+++ b/.agents/skills/pr-review/SKILL.md
@@ -6,3 +6,7 @@ triggers: Use this skill when evaluating a Pull Request, writing a PR review, st
 # PR Review Skill
 
 If you are tasked with conducting a Pull Request review, generating feedback, or helping a user formulate a PR Review, you MUST immediately use the `view_file` tool to read and strictly adhere to `.agents/skills/pr-review/references/pr-review-guide.md` before proceeding.
+
+**Cycle 1 (new review):** load `.agents/skills/pr-review/assets/pr-review-template.md` and apply its full sectioned structure verbatim. The template's emoji-headered sections are regex-matched by the Retrospective daemon for graph ingestion; structure is load-bearing.
+
+**Cycle N (re-review, N≥2):** load `.agents/skills/pr-review/assets/pr-review-followup-template.md` instead. Compact delta-only shape: Prior Review Anchor → Delta Scope → Previous Required Actions Audit → Delta Depth Floor → Metrics Delta (only changed scores) → A2A Hand-off. Re-running the full Cycle 1 template on follow-up cycles generates noisy graph data and wastes review budget.


### PR DESCRIPTION
## Summary
- Adds two trigger lines to `.agents/skills/pr-review/SKILL.md` mapping review-cycle to template asset: Cycle 1 → `pr-review-template.md` (full sectioned), Cycle N → `pr-review-followup-template.md` (compact delta-only).
- Sub-issue of Epic #10537. Scope-guarded per swarm coordination 2026-05-01 — router-level pointers ONLY; zero guide-body modularization.
- Empirical anchor: PR #10558 cycles 2+3 (this morning) re-ran the full Cycle-1 template on follow-up reviews instead of using the dedicated followup template. The trigger→template mapping previously lived only in agent memory, not in the skill's discoverable surface.

## Diff
1 file (`.agents/skills/pr-review/SKILL.md`); router-shaped prose addition.

## Acceptance Criteria (from #10560)
- [x] AC1: SKILL.md adds two pointer lines mapping cycle-class to template asset
- [x] AC2: Progressive Disclosure preserved — SKILL.md remains the router; templates remain in `assets/`; guide remains in `references/`
- [x] AC3: No guide-body expansion — `pr-review-guide.md` unchanged
- [x] AC4: Native parent-child link to #10537 — set via `update_issue_relationship` at ticket creation
- [x] AC5: Existing template files unchanged

## Test plan
- [x] Diff verified: only `.agents/skills/pr-review/SKILL.md` changed
- [x] No `.md` lint changes; no `.mjs` changes
- [ ] Visual review of SKILL.md in the GitHub diff viewer

Closes #10560
Related: #10537

🤖 Generated with [Claude Code](https://claude.com/claude-code)