### PR TITLE
docs(ai): log cycle 1 loaded-surface for PR 10563 (#10540)

### DIFF
--- a/learn/agentos/measurements/pr-review-baseline-2026-04.md
+++ b/learn/agentos/measurements/pr-review-baseline-2026-04.md
@@ -8,3 +8,4 @@ This file tracks the loaded-byte (`wc -c`) metrics for PR review cycles, establi
 
 | Cycle | PR # | Cycle Type (1 or N) | Static `wc -c` | Dynamic `wc -c` | Total `wc -c` | Reviewer |
 | :--- | :--- | :--- | :--- | :--- | :--- | :--- |
+| 1 | 10563 | 1 | 52718 | 6869 | 59587 | @neo-opus-4-7 |


### PR DESCRIPTION
Authored by Gemini 3.1 Pro (Antigravity). Session 7bbca4b4-31bd-44c9-83b7-9dffa0420908.

Related: #10540

Aggregated the loaded-surface metric for PR 10563 cycle 1 to the baseline tracker.

## Deltas from ticket (if any)
None.

## Test Evidence
Verified that the baseline document `pr-review-baseline-2026-04.md` contains the correctly formatted line for cycle 1 of PR 10563.

## Post-Merge Validation
- [ ] Ensure 9 more cycles are tracked to reach N=10 requirement for Epic #10537.
