### PR TITLE
feat(skills): guard MCP config template PR workflows (#10559)

### DIFF
--- a/.agents/skills/pr-review/references/pr-review-guide.md
+++ b/.agents/skills/pr-review/references/pr-review-guide.md
@@ -341,6 +341,7 @@ For PRs that introduce new workflow primitives, skill files, architectural conve
 - PR modifies `AGENTS_STARTUP.md` or `AGENTS.md` (startup conventions change)
 - PR introduces a new architectural primitive other subsystems will consume
 - PR refactors a substrate or changes a wire format (e.g., event payloads, tool signatures, database schemas)
+- PR changes `ai/mcp/server/<name>/config.template.mjs`; read `.agents/skills/pull-request/references/mcp-config-template-change-guide.md` before approval
 
 ### 8.2 Verification Checklist
 

--- a/.agents/skills/pull-request/references/mcp-config-template-change-guide.md
+++ b/.agents/skills/pull-request/references/mcp-config-template-change-guide.md
@@ -1,0 +1,40 @@
+# MCP Config Template Change Guide
+
+Use this guide only when a PR changes `ai/mcp/server/<name>/config.template.mjs`.
+
+## Scope
+
+Four MCP servers have committed template files paired with gitignored local config files:
+
+- `ai/mcp/server/github-workflow/config.template.mjs`
+- `ai/mcp/server/knowledge-base/config.template.mjs`
+- `ai/mcp/server/memory-core/config.template.mjs`
+- `ai/mcp/server/neural-link/config.template.mjs`
+
+`ai/mcp/server/file-system` is out of scope. It has no local `config.mjs` pair.
+
+## Why This Gate Exists
+
+The core swarm runs from three Neo clones: Codex/GPT, Claude, and Gemini. Template changes land through git, but each clone's live `config.mjs` is gitignored and can drift after merge. That drift can make one agent test against fresh config keys while another keeps running stale local config.
+
+The invariant is not byte-identical local files. Local values can differ by operator. The invariant is that every active clone understands the changed config shape, changed keys, and required local follow-up.
+
+## Author Checklist
+
+When authoring a PR that changes a scoped `config.template.mjs` file:
+
+- List the changed config keys in the PR body.
+- State whether matching local `config.mjs` files need manual shape/key updates after merge.
+- State whether harness restart is required, recommended, or unnecessary.
+- Send normal-priority A2A peer notifications if the change affects live MCP behavior in other clones.
+- Do not commit any gitignored `config.mjs` file.
+
+## Reviewer Checklist
+
+When reviewing a PR that changes a scoped `config.template.mjs` file:
+
+- Verify the PR body lists changed config keys.
+- Verify local `config.mjs` follow-up is explicit when required.
+- Verify peer notification is planned or already sent for live-behavior changes.
+- Check shape/key sync expectations, not byte-identical local values.
+- Flag missing clone-sync guidance before approval.

--- a/.agents/skills/pull-request/references/pull-request-workflow.md
+++ b/.agents/skills/pull-request/references/pull-request-workflow.md
@@ -95,6 +95,8 @@ Decision rule: *"Does this enable a new capability that did not exist before?"* 
 
 You MUST use the GitHub CLI to open a Pull Request targeting the `dev` branch. 
 
+If the PR changes `ai/mcp/server/<name>/config.template.mjs`, read `.agents/skills/pull-request/references/mcp-config-template-change-guide.md` before finalizing the PR body.
+
 **Mandatory Base Branch Flag:** You MUST explicitly include the `--base dev` flag in your command. Never rely on the default branch parameter, as it may inadvertently default to `main` and result in massive, thousands-of-commits diff bloat.
 
 **No Auto-Fill:** You are strictly forbidden from using the `--fill` flag, as it bypasses the generation of a comprehensive PR body.


### PR DESCRIPTION
Authored by GPT-5.5 (Codex Desktop). Session 930e5b09-b738-457a-b8ef-3eab964137ed.

Resolves #10559

## Summary

- Adds a compact MCP config-template change guide under the existing `pull-request` skill references.
- Adds a one-line author-side trigger in `pull-request-workflow.md` for PRs touching `ai/mcp/server/<name>/config.template.mjs`.
- Adds a one-line reviewer-side trigger in `pr-review-guide.md` so reviewers load the same guide before approval.

## Architecture

This keeps the progressive-disclosure shape requested in #10559:

- no new skill folder
- one small reference payload inside an existing lifecycle skill
- map-sized trigger lines in the always-read workflow guides
- explicit four-server scope: `github-workflow`, `knowledge-base`, `memory-core`, `neural-link`
- explicit `file-system` exclusion because it has no local config pair

The guide focuses on shape/key sync and peer notification across the three active Neo clones. It intentionally does not require byte-identical local `config.mjs` files, since local values can differ by operator.

## Test Evidence

- `git diff --check`
- `git diff --cached --check`
- Branch freshness check passed: `merge-base HEAD origin/dev == origin/dev`
- No automated runtime tests required: docs/skill workflow only.

## Post-Merge Validation

- [ ] Next PR that changes `ai/mcp/server/<name>/config.template.mjs` should include changed config keys and local config follow-up in the PR body.
- [ ] Reviewer should enforce the new guide before approving such PRs.
