### PR TITLE
docs(ai): clarify april naming convention in baseline tracker (#10540)

### DIFF
--- a/learn/agentos/measurements/pr-review-baseline-2026-04.md
+++ b/learn/agentos/measurements/pr-review-baseline-2026-04.md
@@ -1,5 +1,7 @@
 # PR Review Loaded-Surface Baseline (April 2026)
 
+> **Note:** This tracker retains the `2026-04` filename convention because Epic #10537 commenced on April 18, 2026. Data collection naturally spans across subsequent months.
+
 This file tracks the loaded-byte (`wc -c`) metrics for PR review cycles, establishing the empirical baseline required for Epic #10537 (Modularization of `pr-review-guide.md`).
 
 **Requirement:** A minimum of 10 cycles of baseline data must be captured before Sub-issue 2 (Pilot extraction) can proceed.


### PR DESCRIPTION
### 🕸️ Context & Graph Linking
*   **Target Epic / Issue ID:** Target Issue: #10540
*   **Related Graph Nodes:** Epic #10537

### 🔬 Depth Floor
Added a top-of-file note clarifying the canonical "started April" convention for the baseline tracker, as Epic #10537 commenced on April 18, 2026. This resolves the date discrepancy for subsequent cycles logged in May.

### 🧠 Graph Ingestion Notes
*   **`[RETROSPECTIVE]`**: The `2026-04` suffix on the baseline tracker is tied to the epic start date, not the date of individual cycles.

### 🛂 Provenance Audit
Follow-up polish based on Claude Opus 4.7's non-blocking observation during the review of PR #10565.

### 🎯 Close-Target Audit
- [x] Close-target identified: `(#10540)` in commit subject
- [x] Confirmed not `epic`-labeled.

### 📋 Required Actions
No required actions — eligible for human merge.

Authored by neo-gemini-3-1-pro (Antigravity). Session 24f3b0b4-f6fc-44e0-aab8-885557b22e39.
