### PR TITLE
fix(bridge): Serialize osascript execution to prevent concurrent injection collisions (#10577)

### DIFF
--- a/ai/scripts/bridge-daemon.mjs
+++ b/ai/scripts/bridge-daemon.mjs
@@ -531,6 +531,12 @@ function spawnAsync(command, args) {
 }
 
 /**
+ * Global mutex for serializing adapter deliveries. 
+ * Prevents concurrent osascript calls from colliding when multiple agents wake simultaneously.
+ */
+let deliveryPromise = Promise.resolve();
+
+/**
  * Delivers the digest to the correct adapter (tmux or osascript).
  */
 async function deliverDigest(subscription, digest) {
@@ -538,6 +544,9 @@ async function deliverDigest(subscription, digest) {
     // Fall back to osascript on macOS by default, tmux otherwise
     const defaultAdapter = process.platform === 'darwin' ? 'osascript' : 'tmux';
     const adapter = meta.adapter || defaultAdapter;
+
+    // Serialize execution to prevent focus collisions (Electron-Paradox defense)
+    deliveryPromise = deliveryPromise.then(async () => {
 
     try {
         if (adapter === 'tmux') {
@@ -649,6 +658,9 @@ async function deliverDigest(subscription, digest) {
     } catch (err) {
         writeLog('ERROR', `[Bridge Daemon] Failed to deliver via ${adapter}: ${err.message}`);
     }
+    });
+
+    return deliveryPromise;
 }
 
 // Start loop


### PR DESCRIPTION
Authored by Gemini 3.1 Pro (Antigravity). Session 7f5dd104-283b-4c52-96d3-8ca4a9e7353e.

Resolves #10577

This PR implements an asynchronous Promise mutex inside the bridge daemon's `deliverDigest` function. It forces macOS `osascript` keystroke injections to execute strictly sequentially rather than concurrently, preventing the "Electron-Paradox" focus-collision data leakage.

## Deltas from ticket
None. The human focus-switching edge case remains out-of-scope but manageable.

## Test Evidence
Verified manually in this very session! Broadcast WAKEs were observed being delivered sequentially.

## Commits
- eb32db7 — fix(bridge): enforce sequential osascript delivery (#10577)