### PR TITLE
fix(ai): block graphDigested on ingestion errors (#10460)

### DIFF
--- a/ai/daemons/DreamService.mjs
+++ b/ai/daemons/DreamService.mjs
@@ -133,7 +133,14 @@ class DreamService extends Base {
     }
 
     /**
-     * Pipeline to process undigested sessions.
+     * @summary Runs the REM digest pipeline for sessions that are not yet marked graph-digested.
+     *
+     * The DreamService REM pipeline hydrates raw episodic memories, syncs deterministic
+     * MEMORY/SESSION graph nodes via `MemorySessionIngestor`, then runs Tri-Vector semantic
+     * extraction and ambient graph ingestion. The `graphDigested` marker is only safe after
+     * both the deterministic memory/session ingestion and the semantic extractor complete
+     * without reported errors; otherwise the next REM cycle must retry the partial graph work
+     * instead of hiding missing nodes behind a completed digest flag.
      */
     async processUndigestedSessions() {
         if (this.isProcessing) {
@@ -182,7 +189,7 @@ class DreamService extends Base {
                                 where: { sessionId: session.meta.sessionId },
                                 include: ['documents']
                             });
-                            if (rawMemories && rawMemories.documents && rawMemories.documents.length > 0) {
+                            if (rawMemories?.documents?.length > 0) {
                                 // Send the full raw memory to the LLM. Lossless context tracking is required.
                                 // If local APIs crash, it is a configuration issue with n_ctx, not a client logic error.
                                 rawEpisodicMemory = rawMemories.documents.join('\n\n---\n\n');
@@ -201,8 +208,13 @@ class DreamService extends Base {
                     // Chroma-ID → graph-node mapping; no LLM cost, idempotent via payloadHash.
                     const ingestStart = Date.now();
                     const ingestStats = await MemorySessionIngestor.syncSessionToGraph(session);
+                    const ingestErrors = ingestStats.errors?.length ?? 0;
                     const ingestTime = ((Date.now() - ingestStart) / 1000).toFixed(1);
-                    logger.info(`[DreamService]   -> Memory/Session graph ingestion took: ${ingestTime}s (${ingestStats.memoriesUpserted} upserted, ${ingestStats.memoriesSkipped} skipped)`);
+                    logger.info(`[DreamService]   -> Memory/Session graph ingestion took: ${ingestTime}s (${ingestStats.memoriesUpserted} upserted, ${ingestStats.memoriesSkipped} skipped, ${ingestErrors} errors)`);
+
+                    if (ingestErrors > 0) {
+                        logger.warn(`[DreamService] Session ${session.meta.sessionId} had ${ingestErrors} memory-ingestion error(s); graphDigested will NOT be set this cycle.`);
+                    }
 
                     const startTime = Date.now();
                     const success = await SemanticGraphExtractor.executeTriVectorExtraction(session);
@@ -221,7 +233,7 @@ class DreamService extends Base {
 
                     logger.info(`[DreamService] Total Session Digest Time: ${((Date.now() - startTime) / 1000).toFixed(1)}s`);
 
-                    if (success) {
+                    if (success && ingestErrors === 0) {
                         await this.sessionsCollection.update({
                             ids: [session.id],
                             metadatas: [{ ...session.meta, graphDigested: true }]

--- a/test/playwright/unit/ai/daemons/DreamService.spec.mjs
+++ b/test/playwright/unit/ai/daemons/DreamService.spec.mjs
@@ -25,10 +25,12 @@ test.describe('Neo.ai.mcp.server.memory-core.services.DreamService', () => {
     let GraphService;
     let SystemLifecycleService;
     let DreamService;
+    let MemorySessionIngestor;
     let SemanticGraphExtractor;
     let StorageRouter;
     let OpenAiCompatible;
     let TextEmbeddingService;
+    let logger;
     const testDbName = `memory-core-dream-test-${process.pid}-${Date.now()}.sqlite`;
     let testDbPath; // Reassigned in beforeAll
 
@@ -52,11 +54,13 @@ test.describe('Neo.ai.mcp.server.memory-core.services.DreamService', () => {
 
         GraphService = (await import('../../../../../ai/mcp/server/memory-core/services/GraphService.mjs')).default;
         DreamService = (await import('../../../../../ai/daemons/DreamService.mjs')).default;
+        MemorySessionIngestor = (await import('../../../../../ai/daemons/services/MemorySessionIngestor.mjs')).default;
         SemanticGraphExtractor = (await import('../../../../../ai/daemons/services/SemanticGraphExtractor.mjs')).default;
         StorageRouter = (await import('../../../../../ai/mcp/server/memory-core/managers/StorageRouter.mjs')).default;
         OpenAiCompatible       = (await import('../../../../../ai/provider/OpenAiCompatible.mjs')).default;
         SystemLifecycleService = (await import('../../../../../ai/mcp/server/memory-core/services/lifecycle/SystemLifecycleService.mjs')).default;
         TextEmbeddingService   = (await import('../../../../../ai/mcp/server/memory-core/services/TextEmbeddingService.mjs')).default;
+        logger                 = (await import('../../../../../ai/mcp/server/memory-core/logger.mjs')).default;
 
         if (fs.existsSync(testDbPath)) {
             try {
@@ -525,6 +529,7 @@ test.describe('Neo.ai.mcp.server.memory-core.services.DreamService', () => {
             runGarbageCol      : DreamService.runGarbageCollection,
             synthesizeGolden   : DreamService.synthesizeGoldenPath,
             triVector          : SemanticGraphExtractor.executeTriVectorExtraction,
+            syncSession        : MemorySessionIngestor.syncSessionToGraph,
             syncConcepts       : ConceptIngestor.syncConceptsToGraph,
             syncFs             : FileSystemIngestor.syncWorkspaceToGraph,
             extractTopo        : TopologyInferenceEngine.extractTopology,
@@ -550,6 +555,11 @@ test.describe('Neo.ai.mcp.server.memory-core.services.DreamService', () => {
             SemanticGraphExtractor.executeTriVectorExtraction = async () => ({
                 session_artifact: {graph: {nodes: [], edges: []}}
             });
+            MemorySessionIngestor.syncSessionToGraph = async () => ({
+                errors          : [],
+                memoriesSkipped : 0,
+                memoriesUpserted: 0
+            });
             ConceptIngestor.syncConceptsToGraph     = async () => ({});
             FileSystemIngestor.syncWorkspaceToGraph = async () => {};
             TopologyInferenceEngine.extractTopology = async () => {};
@@ -568,9 +578,108 @@ test.describe('Neo.ai.mcp.server.memory-core.services.DreamService', () => {
             DreamService.runGarbageCollection                 = orig.runGarbageCol;
             DreamService.synthesizeGoldenPath                 = orig.synthesizeGolden;
             SemanticGraphExtractor.executeTriVectorExtraction = orig.triVector;
+            MemorySessionIngestor.syncSessionToGraph          = orig.syncSession;
             ConceptIngestor.syncConceptsToGraph               = orig.syncConcepts;
             FileSystemIngestor.syncWorkspaceToGraph           = orig.syncFs;
             TopologyInferenceEngine.extractTopology           = orig.extractTopo;
+            DreamService.isProcessing                         = orig.isProcessing;
+        }
+    });
+
+    test('processUndigestedSessions does not set graphDigested when memory ingestion reports errors (#10460)', async () => {
+        // Regression guard for #10460: the Tri-Vector extractor can succeed from
+        // `session.document` even when MemorySessionIngestor partially failed to upsert MEMORY
+        // nodes. Keep such sessions undigested so the next REM cycle retries the missing graph
+        // rows instead of permanently masking them behind `graphDigested: true`.
+
+        const aiConfig                = (await import('../../../../../ai/mcp/server/memory-core/config.mjs')).default;
+        const ConceptIngestor         = (await import('../../../../../ai/daemons/services/ConceptIngestor.mjs')).default;
+        const FileSystemIngestor      = (await import('../../../../../ai/mcp/server/memory-core/services/FileSystemIngestor.mjs')).default;
+        const TopologyInferenceEngine = (await import('../../../../../ai/daemons/services/TopologyInferenceEngine.mjs')).default;
+
+        const mockSession = {
+            id      : 'chroma-summary-partial',
+            document: 'mock-document',
+            meta    : {sessionId: 'agent-session-partial', title: 'Partial ingest session'}
+        };
+
+        let testGapCalls     = 0;
+        let conceptGapCalls  = 0;
+        let sessionUpdates   = 0;
+        const infoMessages   = [];
+        const warnMessages   = [];
+
+        const orig = {
+            provider           : aiConfig.modelProvider,
+            findUndigested     : DreamService.findUndigestedSessions,
+            sessionsCollection : DreamService.sessionsCollection,
+            inferTest          : DreamService.inferTestGapsFromSession,
+            inferConcept       : DreamService.inferConceptGraphGaps,
+            runGarbageCol      : DreamService.runGarbageCollection,
+            synthesizeGolden   : DreamService.synthesizeGoldenPath,
+            triVector          : SemanticGraphExtractor.executeTriVectorExtraction,
+            syncSession        : MemorySessionIngestor.syncSessionToGraph,
+            syncConcepts       : ConceptIngestor.syncConceptsToGraph,
+            syncFs             : FileSystemIngestor.syncWorkspaceToGraph,
+            extractTopo        : TopologyInferenceEngine.extractTopology,
+            getMemory          : StorageRouter.getMemoryCollection,
+            loggerInfo         : logger.info,
+            loggerWarn         : logger.warn,
+            isProcessing       : DreamService.isProcessing
+        };
+
+        try {
+            aiConfig.modelProvider    = 'mock-provider';
+            DreamService.isProcessing = false;
+
+            DreamService.findUndigestedSessions = async () => [mockSession];
+            DreamService.sessionsCollection     = {
+                update: async () => { sessionUpdates++; }
+            };
+            DreamService.inferTestGapsFromSession = async () => { testGapCalls++; };
+            DreamService.inferConceptGraphGaps    = async () => { conceptGapCalls++; };
+            DreamService.runGarbageCollection     = async () => {};
+            DreamService.synthesizeGoldenPath     = async () => {};
+
+            SemanticGraphExtractor.executeTriVectorExtraction = async () => ({
+                session_artifact: {graph: {nodes: [], edges: []}}
+            });
+            MemorySessionIngestor.syncSessionToGraph = async () => ({
+                errors          : ['[memory:broken] simulated upsert failure'],
+                memoriesSkipped : 1,
+                memoriesUpserted: 2
+            });
+            ConceptIngestor.syncConceptsToGraph     = async () => ({});
+            FileSystemIngestor.syncWorkspaceToGraph = async () => {};
+            TopologyInferenceEngine.extractTopology = async () => {};
+            StorageRouter.getMemoryCollection       = async () => null;
+
+            logger.info = (...args) => { infoMessages.push(args.join(' ')); };
+            logger.warn = (...args) => { warnMessages.push(args.join(' ')); };
+
+            await DreamService.processUndigestedSessions();
+
+            expect(testGapCalls).toBe(1);
+            expect(conceptGapCalls).toBe(1);
+            expect(sessionUpdates).toBe(0);
+            expect(infoMessages.some(msg => msg.includes('2 upserted, 1 skipped, 1 errors'))).toBe(true);
+            expect(warnMessages.some(msg => msg.includes('agent-session-partial') && msg.includes('graphDigested will NOT be set'))).toBe(true);
+        } finally {
+            aiConfig.modelProvider                            = orig.provider;
+            DreamService.findUndigestedSessions               = orig.findUndigested;
+            DreamService.sessionsCollection                   = orig.sessionsCollection;
+            DreamService.inferTestGapsFromSession             = orig.inferTest;
+            DreamService.inferConceptGraphGaps                = orig.inferConcept;
+            DreamService.runGarbageCollection                 = orig.runGarbageCol;
+            DreamService.synthesizeGoldenPath                 = orig.synthesizeGolden;
+            SemanticGraphExtractor.executeTriVectorExtraction = orig.triVector;
+            MemorySessionIngestor.syncSessionToGraph          = orig.syncSession;
+            ConceptIngestor.syncConceptsToGraph               = orig.syncConcepts;
+            FileSystemIngestor.syncWorkspaceToGraph           = orig.syncFs;
+            TopologyInferenceEngine.extractTopology           = orig.extractTopo;
+            StorageRouter.getMemoryCollection                 = orig.getMemory;
+            logger.info                                      = orig.loggerInfo;
+            logger.warn                                      = orig.loggerWarn;
             DreamService.isProcessing                         = orig.isProcessing;
         }
     });


### PR DESCRIPTION
Resolves #10460

Authored by GPT-5 (Codex Desktop). Session 13545acb-8bf2-4d54-a9b2-2106273f72d1.

DreamService now treats MemorySessionIngestor errors as a hard blocker for `graphDigested: true`. The REM digest pipeline still continues semantic extraction and ambient graph work for partial progress, but sessions with deterministic MEMORY/SESSION ingestion errors remain undigested so the next REM cycle retries the missing graph rows instead of permanently masking them.

## Deltas from Ticket

- Added Anchor & Echo method context to `processUndigestedSessions()` to make the digest gate semantics explicit for future KB ingestion.
- Kept coverage in `DreamService.spec.mjs` rather than `MemorySessionIngestor.spec.mjs`, because the bug is the downstream DreamService propagation gate, not MemorySessionIngestor's stats shape.
- The ticket's runSandman-style empirical check is represented by a deterministic unit simulation: injected `MemorySessionIngestor.syncSessionToGraph()` errors, successful Tri-Vector extraction, and assertion that `sessionsCollection.update()` is not called.

## Test Evidence

- `git diff --check` -> pass.
- `git diff --cached --check` -> pass before commit.
- `npm run test-unit -- test/playwright/unit/ai/daemons/DreamService.spec.mjs -g "processUndigestedSessions does not set graphDigested"` -> 1 passed.
- `npm run test-unit -- test/playwright/unit/ai/daemons/DreamService.spec.mjs -g "hoist contract"` -> 1 passed.
- `npm run test-unit -- test/playwright/unit/ai/daemons/services/MemorySessionIngestor.spec.mjs` -> 13 passed.
- `npm run test-unit -- test/playwright/unit/ai/daemons/DreamService.spec.mjs --workers=1` -> 8 passed, 4 failed in existing concept-gap assertions (`GUIDE_GAP`, `EXAMPLE_GAP`, `ORPHAN_CONCEPT`, combined `GUIDE_GAP` + `ORPHAN_CONCEPT`). Those failures assert `capabilityGap` on concept-gap tests and are outside the #10460 digest-gate surface.

## Post-Merge Validation

- [ ] Run a REM/Sandman cycle with an injected `MemorySessionIngestor` per-memory upsert failure and confirm the session remains undigested, then succeeds on a later retry after the injected failure is removed.

## Commit

- `754a024bb` - `fix(ai): block graphDigested on ingestion errors (#10460)`
