### PR TITLE
feat(mcp): always-on file sink for Memory Core + Neural Link loggers (#10582)

### DIFF
--- a/ai/mcp/server/memory-core/config.template.mjs
+++ b/ai/mcp/server/memory-core/config.template.mjs
@@ -271,6 +271,17 @@ const defaultConfig = {
      */
     backupPath: path.resolve(cwd, '.neo-ai-data/backups'),
     /**
+     * Directory for the always-on Memory Core diagnostic log files (#10582). The MC
+     * server's `logger.mjs` writes daily-rotated entries here regardless of `debug`,
+     * so long-running operations (summarization, ingestion sweeps, ChromaDB
+     * lifecycle) leave a tail-able diagnostic trail observable from the host shell.
+     * Default: `<neoRootDir>/.neo-ai-data/logs/` — shared with the KB and Neural
+     * Link servers (each uses a distinct filename prefix: `mc-server-`, `kb-server-`,
+     * `nl-server-`). Per-server file isolation, single tailable directory.
+     * @type {string}
+     */
+    logPath: path.resolve(cwd, '.neo-ai-data/logs'),
+    /**
      * Mailbox substrate behavior configuration (#10252).
      *
      * Deployment-tier selectors for the A2A mailbox service. The A2A primitives

--- a/ai/mcp/server/memory-core/logger.mjs
+++ b/ai/mcp/server/memory-core/logger.mjs
@@ -1,13 +1,83 @@
-import aiConfig from './config.mjs';
+import aiConfig        from './config.mjs';
+import fs              from 'fs';
+import path            from 'path';
+import {fileURLToPath} from 'url';
+
+const __filename     = fileURLToPath(import.meta.url);
+const __dirname      = path.dirname(__filename);
+// Memory Core's config has `neoRootDir` as a local module const but does NOT
+// export it on `defaultConfig`, so the logger computes its own repo-rooted
+// fallback locally. Module path is stable (`ai/mcp/server/memory-core/logger.mjs`
+// → up 4 → repo root) so a 4-level traversal is the canonical resolution.
+const neoRootFallback = path.resolve(__dirname, '../../../../');
 
 /**
- * A simple logger that writes to stderr only when the global debug flag is enabled.
- * This prevents corrupting the MCP stdio transport and keeps production output clean.
+ * @summary Dual-sink logger: always-on file diagnostic + debug-gated stderr.
+ *
+ * Symmetric with the Knowledge Base server's `logger.mjs` (#10576/#10580). Two sinks:
+ *
+ * 1. **File sink (always-on):** writes every entry to a daily-rotated log file under
+ *    `${aiConfig.logPath}` (default `${neoRootDir}/.neo-ai-data/logs/`). Captures
+ *    Memory Core server progress regardless of `aiConfig.debug` so long-running
+ *    operations (summarization runs, ingestion sweeps, ChromaDB lifecycle) leave a
+ *    tail-able diagnostic trail. File prefix `mc-server-` distinguishes from KB's
+ *    `kb-server-` and Neural Link's `nl-server-` in the shared log dir.
+ *
+ * 2. **Stderr sink (debug-flag-gated):** preserves prior behavior — when
+ *    `aiConfig.debug === true`, log entries also write to stderr. Stays gated to
+ *    avoid corrupting the MCP stdio transport on stdout and to keep production
+ *    output minimal.
+ *
+ * Daily rotation + log-dir resolution happen lazily per-write via a cached stream
+ * keyed on `${logDir}::${today}`, so a daemon running across midnight transitions
+ * cleanly to a new file AND late `aiConfig.logPath` overrides (e.g., from tests)
+ * take effect on the next write. Stream `flags: 'a'` makes restarts and concurrent
+ * writers append rather than truncate. `mkdirSync` is idempotent under
+ * `{recursive: true}`.
  */
+let currentStreamKey = null;
+let currentStream    = null;
+
+const getStream = () => {
+    const logDir = aiConfig.logPath || path.resolve(neoRootFallback, '.neo-ai-data/logs');
+    const today  = new Date().toISOString().slice(0, 10);
+    const key    = `${logDir}::${today}`;
+
+    if (currentStreamKey !== key) {
+        if (currentStream) currentStream.end();
+        fs.mkdirSync(logDir, {recursive: true});
+        currentStreamKey = key;
+        currentStream    = fs.createWriteStream(path.join(logDir, `mc-server-${today}.log`), {flags: 'a'});
+    }
+    return currentStream;
+};
+
+const stringifyArg = (a) => {
+    if (typeof a === 'string') return a;
+    // Error instances must be unpacked manually — Error.message and Error.stack are
+    // non-enumerable, so JSON.stringify(err) yields `{}` and silently destroys the
+    // post-mortem evidence the file sink exists to preserve.
+    if (a instanceof Error) return `${a.name}: ${a.message}\n${a.stack || ''}`.trim();
+    try {
+        return JSON.stringify(a);
+    } catch {
+        // Circular references or other JSON.stringify failures — fall back to String coercion
+        // so the log entry still lands rather than throwing inside the logger itself.
+        return String(a);
+    }
+};
+
+const formatLine = (level, args) => {
+    const timestamp = new Date().toISOString();
+    const message   = args.map(stringifyArg).join(' ');
+    return `${timestamp} [${level.toUpperCase()}] ${message}\n`;
+};
+
 const logger = {};
 
 const createLogMethod = (level) => {
     return (...args) => {
+        getStream().write(formatLine(level, args));
         if (aiConfig.debug) {
             console.error(`[${level.toUpperCase()}]`, ...args);
         }

--- a/ai/mcp/server/neural-link/config.template.mjs
+++ b/ai/mcp/server/neural-link/config.template.mjs
@@ -1,9 +1,13 @@
-import fs from 'fs/promises';
-import os from 'os';
-import path from 'path';
-import Base from '../../../../src/core/Base.mjs';
+import fs              from 'fs/promises';
+import os              from 'os';
+import path            from 'path';
+import {fileURLToPath} from 'url';
+import Base            from '../../../../src/core/Base.mjs';
 
-const cwd = process.cwd();
+const __filename = fileURLToPath(import.meta.url);
+const __dirname  = path.dirname(__filename);
+const neoRootDir = path.resolve(__dirname, '../../../../');
+const cwd        = process.cwd();
 
 /**
  * Default configuration object.
@@ -34,6 +38,17 @@ const defaultConfig = {
      * @type {string}
      */
     memoryCoreDbPath: path.join(os.homedir(), '.neo-ai-data', 'memory-core.sqlite'),
+    /**
+     * Directory for the always-on Neural Link diagnostic log files (#10582). The NL
+     * server's `logger.mjs` writes daily-rotated entries here regardless of `debug`,
+     * so long-running inspection chains and DOM/VDOM introspection sweeps leave a
+     * tail-able diagnostic trail observable from the host shell. Default:
+     * `<neoRootDir>/.neo-ai-data/logs/` — shared with the KB and Memory Core servers
+     * (each uses a distinct filename prefix: `nl-server-`, `kb-server-`, `mc-server-`).
+     * Per-server file isolation, single tailable directory.
+     * @type {string}
+     */
+    logPath: path.resolve(neoRootDir, '.neo-ai-data/logs'),
     /**
      * Number of days to retain Action logs in the Neural Link Database.
      * @type {number}

--- a/ai/mcp/server/neural-link/logger.mjs
+++ b/ai/mcp/server/neural-link/logger.mjs
@@ -1,11 +1,86 @@
-import aiConfig from './config.mjs';
+import aiConfig        from './config.mjs';
+import fs              from 'fs';
+import path            from 'path';
+import {fileURLToPath} from 'url';
 
-const createLogMethod = (level, stream = process.stderr) => {
+const __filename     = fileURLToPath(import.meta.url);
+const __dirname      = path.dirname(__filename);
+// Neural Link's config doesn't export `neoRootDir` (unlike KB and Memory Core), so
+// the logger computes its repo-rooted log fallback locally. Module path is stable
+// (`ai/mcp/server/neural-link/logger.mjs` → up 4 → repo root) so a 4-level traversal
+// is the canonical resolution.
+const neoRootFallback = path.resolve(__dirname, '../../../../');
+
+/**
+ * @summary Dual-sink logger: always-on file diagnostic + tier-gated stderr.
+ *
+ * Symmetric with the Knowledge Base and Memory Core servers' loggers (#10576/#10580
+ * and #10582). Two sinks:
+ *
+ * 1. **File sink (always-on):** writes every entry to a daily-rotated log file under
+ *    `${aiConfig.logPath}` (default `${neoRootDir}/.neo-ai-data/logs/`). Captures
+ *    Neural Link server progress regardless of `aiConfig.debug` so long-running
+ *    inspection chains and DOM/VDOM introspection sweeps leave a tail-able
+ *    diagnostic trail. File prefix `nl-server-` distinguishes from KB's
+ *    `kb-server-` and Memory Core's `mc-server-` in the shared log dir.
+ *
+ * 2. **Stderr sink (tier-gated, prior behavior):** preserves the existing rule —
+ *    `info`/`warn`/`error` always write to stderr; `debug` only writes when
+ *    `aiConfig.debug === true`. Different from KB/MC where stderr is fully
+ *    debug-flag-gated; NL ran more verbose by design and that's preserved.
+ *
+ * Daily rotation + log-dir resolution happen lazily per-write via a cached stream
+ * keyed on `${logDir}::${today}`, so a daemon running across midnight transitions
+ * cleanly to a new file AND late `aiConfig.logPath` overrides (e.g., from tests)
+ * take effect on the next write. Stream `flags: 'a'` makes restarts and concurrent
+ * writers append rather than truncate. `mkdirSync` is idempotent under
+ * `{recursive: true}`.
+ *
+ * The previous logger interpolated `JSON.stringify(args)` directly, which silently
+ * destroyed Error.message and Error.stack (non-enumerable). The replacement
+ * `stringifyArg` helper unpacks Error instances and falls back gracefully on
+ * circular references — same defect surfaced + fixed in #10580 RA2.
+ */
+let currentStreamKey = null;
+let currentStream    = null;
+
+const getStream = () => {
+    const logDir = aiConfig.logPath || path.resolve(neoRootFallback, '.neo-ai-data/logs');
+    const today  = new Date().toISOString().slice(0, 10);
+    const key    = `${logDir}::${today}`;
+
+    if (currentStreamKey !== key) {
+        if (currentStream) currentStream.end();
+        fs.mkdirSync(logDir, {recursive: true});
+        currentStreamKey = key;
+        currentStream    = fs.createWriteStream(path.join(logDir, `nl-server-${today}.log`), {flags: 'a'});
+    }
+    return currentStream;
+};
+
+const stringifyArg = (a) => {
+    if (typeof a === 'string') return a;
+    if (a instanceof Error) return `${a.name}: ${a.message}\n${a.stack || ''}`.trim();
+    try {
+        return JSON.stringify(a);
+    } catch {
+        return String(a);
+    }
+};
+
+const formatLine = (level, message, args) => {
+    const timestamp = new Date().toISOString();
+    const prefix    = `[${timestamp}] [${level.toUpperCase()}]`;
+    const tail      = args.length ? ` ${args.map(stringifyArg).join(' ')}` : '';
+    return `${prefix} ${message}${tail}\n`;
+};
+
+const createLogMethod = (level) => {
     return (message, ...args) => {
+        const line = formatLine(level, message, args);
+        getStream().write(line);
         if (aiConfig.debug || level !== 'debug') {
-            const timestamp = new Date().toISOString();
-            const prefix = `[${timestamp}] [${level.toUpperCase()}]`;
-            stream.write(`${prefix} ${message} ${args.length ? JSON.stringify(args) : ''}\n`);
+            process.stderr.write(line);
         }
     };
 };

--- a/test/playwright/unit/ai/mcp/server/memory-core/logger.spec.mjs
+++ b/test/playwright/unit/ai/mcp/server/memory-core/logger.spec.mjs
@@ -1,0 +1,121 @@
+import {setup} from '../../../../../setup.mjs';
+
+const appName = 'MCLoggerTest';
+
+setup({
+    neoConfig: {
+        unitTestMode: true
+    },
+    appConfig: {
+        name             : appName,
+        isMounted        : () => true,
+        vnodeInitialising: false
+    }
+});
+
+import {test, expect}  from '@playwright/test';
+import fs              from 'fs-extra';
+import os              from 'os';
+import path            from 'path';
+import {fileURLToPath} from 'url';
+import Neo             from '../../../../../../../src/Neo.mjs';
+import * as core       from '../../../../../../../src/core/_export.mjs';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname  = path.dirname(__filename);
+
+/**
+ * Always-on file-sink coverage for Memory Core MCP server `logger.mjs` (#10582).
+ *
+ * Symmetric with `test/playwright/unit/ai/mcp/server/knowledge-base/logger.spec.mjs`
+ * (introduced in #10580). Verifies:
+ *
+ * 1. Every `logger.log/info/warn/error/debug` call lands in a daily-rotated file
+ *    under `aiConfig.logPath` (filename prefix `mc-server-`, distinct from KB's
+ *    `kb-server-` and NL's `nl-server-`).
+ * 2. `Error` instances preserve name + message + stack in the durable log
+ *    (the post-mortem trail JSON.stringify silently destroys without help).
+ * 3. Circular references fall back to String() coercion so logger throws can't
+ *    crash callers.
+ *
+ * Test override is applied via `aiConfig.data.logPath = tmpDir`; logger reads it
+ * lazily per-write so import order doesn't matter.
+ */
+test.describe('MC MCP server logger — always-on file sink (#10582)', () => {
+    let logger;
+    let aiConfig;
+    let tmpLogDir;
+    let originalLogPath;
+
+    test.beforeAll(async () => {
+        aiConfig = (await import('../../../../../../../ai/mcp/server/memory-core/config.mjs')).default;
+
+        tmpLogDir       = path.resolve(os.tmpdir(), `mc-logger-test-${process.pid}-${Date.now()}`);
+        originalLogPath = aiConfig.data.logPath;
+        aiConfig.data.logPath = tmpLogDir;
+
+        logger = (await import('../../../../../../../ai/mcp/server/memory-core/logger.mjs')).default;
+    });
+
+    test.afterAll(() => {
+        aiConfig.data.logPath = originalLogPath;
+        if (tmpLogDir && fs.existsSync(tmpLogDir)) {
+            fs.rmSync(tmpLogDir, {recursive: true, force: true});
+        }
+    });
+
+    test('writes log entries to daily-rotated mc-server file regardless of debug flag', async () => {
+        const wasDebug = aiConfig.data.debug;
+        aiConfig.data.debug = false;
+
+        try {
+            const today    = new Date().toISOString().slice(0, 10);
+            const expected = path.join(tmpLogDir, `mc-server-${today}.log`);
+
+            logger.log('mc-hello-world');
+            logger.info('mc-info-line');
+            logger.warn('mc-warn-line');
+            logger.error('mc-error-line');
+
+            await new Promise(resolve => setTimeout(resolve, 100));
+
+            expect(fs.existsSync(expected)).toBe(true);
+            const content = fs.readFileSync(expected, 'utf8');
+            expect(content).toContain('[LOG] mc-hello-world');
+            expect(content).toContain('[INFO] mc-info-line');
+            expect(content).toContain('[WARN] mc-warn-line');
+            expect(content).toContain('[ERROR] mc-error-line');
+
+            const firstLine = content.split('\n')[0];
+            expect(firstLine).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z \[LOG\]/);
+        } finally {
+            aiConfig.data.debug = wasDebug;
+        }
+    });
+
+    test('preserves Error stack/message in the durable log', async () => {
+        const wasDebug = aiConfig.data.debug;
+        aiConfig.data.debug = false;
+
+        try {
+            const today    = new Date().toISOString().slice(0, 10);
+            const expected = path.join(tmpLogDir, `mc-server-${today}.log`);
+
+            const err = new Error('mc summarization failed at session 7');
+            logger.error('summary batch failed', err);
+
+            const circular = {};
+            circular.self = circular;
+            logger.warn('circular sample', circular);
+
+            await new Promise(resolve => setTimeout(resolve, 100));
+
+            const content = fs.readFileSync(expected, 'utf8');
+            expect(content).toContain('mc summarization failed at session 7');
+            expect(content).toContain('at '); // V8 stack frame marker
+            expect(content).toContain('circular sample');
+        } finally {
+            aiConfig.data.debug = wasDebug;
+        }
+    });
+});

--- a/test/playwright/unit/ai/mcp/server/neural-link/logger.spec.mjs
+++ b/test/playwright/unit/ai/mcp/server/neural-link/logger.spec.mjs
@@ -1,0 +1,122 @@
+import {setup} from '../../../../../setup.mjs';
+
+const appName = 'NLLoggerTest';
+
+setup({
+    neoConfig: {
+        unitTestMode: true
+    },
+    appConfig: {
+        name             : appName,
+        isMounted        : () => true,
+        vnodeInitialising: false
+    }
+});
+
+import {test, expect}  from '@playwright/test';
+import fs              from 'fs-extra';
+import os              from 'os';
+import path            from 'path';
+import {fileURLToPath} from 'url';
+import Neo             from '../../../../../../../src/Neo.mjs';
+import * as core       from '../../../../../../../src/core/_export.mjs';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname  = path.dirname(__filename);
+
+/**
+ * Always-on file-sink coverage for Neural Link MCP server `logger.mjs` (#10582).
+ *
+ * Symmetric with KB and Memory Core logger specs (#10580 / #10582). NL differs from
+ * KB/MC in stderr semantics — NL writes `info`/`warn`/`error` to stderr always,
+ * `debug` only when `aiConfig.debug === true`. The new file sink runs ALWAYS
+ * regardless of level (different from stderr), so the test forces `debug: false`
+ * and verifies all 4 levels still land in the file.
+ *
+ * The pre-#10582 NL logger interpolated `JSON.stringify(args)` directly, which
+ * silently destroyed Error.message and Error.stack. The replacement `stringifyArg`
+ * helper unpacks Error instances and falls back gracefully on circular references
+ * — symmetric with the #10580 RA2 fix on the KB side.
+ */
+test.describe('NL MCP server logger — always-on file sink (#10582)', () => {
+    let logger;
+    let aiConfig;
+    let tmpLogDir;
+    let originalLogPath;
+
+    test.beforeAll(async () => {
+        aiConfig = (await import('../../../../../../../ai/mcp/server/neural-link/config.mjs')).default;
+
+        tmpLogDir       = path.resolve(os.tmpdir(), `nl-logger-test-${process.pid}-${Date.now()}`);
+        originalLogPath = aiConfig.data.logPath;
+        aiConfig.data.logPath = tmpLogDir;
+
+        logger = (await import('../../../../../../../ai/mcp/server/neural-link/logger.mjs')).default;
+    });
+
+    test.afterAll(() => {
+        aiConfig.data.logPath = originalLogPath;
+        if (tmpLogDir && fs.existsSync(tmpLogDir)) {
+            fs.rmSync(tmpLogDir, {recursive: true, force: true});
+        }
+    });
+
+    test('writes log entries to daily-rotated nl-server file regardless of debug flag', async () => {
+        const wasDebug = aiConfig.data.debug;
+        aiConfig.data.debug = false;
+
+        try {
+            const today    = new Date().toISOString().slice(0, 10);
+            const expected = path.join(tmpLogDir, `nl-server-${today}.log`);
+
+            logger.debug('nl-debug-line');
+            logger.info('nl-info-line');
+            logger.warn('nl-warn-line');
+            logger.error('nl-error-line');
+
+            await new Promise(resolve => setTimeout(resolve, 100));
+
+            expect(fs.existsSync(expected)).toBe(true);
+            const content = fs.readFileSync(expected, 'utf8');
+
+            // All four levels — including debug — must land in the file even with
+            // aiConfig.debug=false. The file sink is the diagnostic substrate; only
+            // the stderr sink remains tier-gated.
+            expect(content).toContain('[DEBUG] nl-debug-line');
+            expect(content).toContain('[INFO] nl-info-line');
+            expect(content).toContain('[WARN] nl-warn-line');
+            expect(content).toContain('[ERROR] nl-error-line');
+
+            const firstLine = content.split('\n').find(l => l.length > 0);
+            expect(firstLine).toMatch(/^\[\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z\] \[DEBUG\]/);
+        } finally {
+            aiConfig.data.debug = wasDebug;
+        }
+    });
+
+    test('preserves Error stack/message in the durable log (was lost via naked JSON.stringify pre-#10582)', async () => {
+        const wasDebug = aiConfig.data.debug;
+        aiConfig.data.debug = false;
+
+        try {
+            const today    = new Date().toISOString().slice(0, 10);
+            const expected = path.join(tmpLogDir, `nl-server-${today}.log`);
+
+            const err = new Error('nl introspect failed for ref_42');
+            logger.error('inspect chain failed', err);
+
+            const circular = {};
+            circular.self = circular;
+            logger.warn('circular sample', circular);
+
+            await new Promise(resolve => setTimeout(resolve, 100));
+
+            const content = fs.readFileSync(expected, 'utf8');
+            expect(content).toContain('nl introspect failed for ref_42');
+            expect(content).toContain('at '); // V8 stack frame marker
+            expect(content).toContain('circular sample');
+        } finally {
+            aiConfig.data.debug = wasDebug;
+        }
+    });
+});


### PR DESCRIPTION
Resolves #10582

## Summary

Symmetric with #10580's KB logger. Both Memory Core and Neural Link MCP servers now write a daily-rotated diagnostic log to `${aiConfig.logPath}/{mc,nl}-server-YYYY-MM-DD.log` regardless of `aiConfig.debug`. Per-server filename prefixes share a single configurable directory:

```bash
tail -f .neo-ai-data/logs/*-server-$(date +%Y-%m-%d).log
```

Covers all 3 MCP servers in one tail.

## Acceptance Criteria

| AC | Status |
|---|---|
| AC1: Memory Core writes to `mc-server-YYYY-MM-DD.log` regardless of `debug` | ✅ dual-sink: file always-on, stderr debug-gated |
| AC2: Neural Link writes to `nl-server-YYYY-MM-DD.log` regardless of `debug`; stderr tier-gating preserved | ✅ existing `debug || level !== 'debug'` stderr rule kept; file sink always-on across all levels |
| AC3: Both `config.template.mjs` files have `logPath` defaulting to `${neoRootDir}/.neo-ai-data/logs/` | ✅ added; NL's config gains a locally-computed `neoRootDir` since it didn't have one previously |
| AC4: `stringifyArg` preserves Error stack/message + circular-ref fallback | ✅ symmetric to #10580 RA2 fix; NL had the exact same naked-JSON.stringify defect |
| AC5: Per-server unit tests cover AC1, AC2, AC4 | ✅ MC 2 cases + NL 2 cases |
| AC6: Single `tail -f .neo-ai-data/logs/*-server-...` works across all 3 servers | ✅ shared dir, distinct prefixes (`kb-`, `mc-`, `nl-`) |

## Avoided Traps

Per the ticket — NOT a logger framework refactor (each server keeps its own `logger.mjs`), NOT structured-log format, NOT a log-rotation library. Same scoping as #10576/#10580 — extending the Shape A primitive symmetrically.

## Notable design decisions

**Memory Core's `defaultConfig` doesn't export `neoRootDir`** (KB does, MC doesn't). The MC logger computes its own `neoRootFallback` locally via `import.meta.url` rather than relying on `aiConfig.neoRootDir` — same pattern applied to NL. Caught regression-test-style: my first pass used `aiConfig.neoRootDir` which threw in the KB regression suite when MC's logger was loaded transitively. Fix is the local fallback.

**NL config's `neoRootDir`** — added as a module-local const (mirrors KB/MC's pattern at the file level) to provide a stable repo-rooted default for `logPath`. Smallest scope expansion; not exported on `defaultConfig`.

**File prefix per server**, single shared dir — gives both per-server isolation (separate files for separate failure modes) AND aggregate observability (one tail across all 3).

## Test Plan

- [x] `npm run test-unit -- test/playwright/unit/ai/mcp/server/memory-core/logger.spec.mjs` — 2/2 pass
- [x] `npm run test-unit -- test/playwright/unit/ai/mcp/server/neural-link/logger.spec.mjs` — 2/2 pass
- [x] `npm run test-unit -- test/playwright/unit/ai/mcp/server/knowledge-base/logger.spec.mjs` — 2/2 pass (no regression on #10580)
- [x] `npm run test-unit -- test/playwright/unit/ai/mcp/server/knowledge-base/services/VectorService.WorkVolumeBranching.spec.mjs` — 5/5 pass (no regression on #10573)

11/11 pass total.

## Origin

- Empirical surface: 2026-05-01 KB resync incident → #10576/#10580 closed Shape A for KB only
- Avoided Traps section of #10576 explicitly committed to MC + NL symmetry as a follow-up
- Origin Session ID: 7a2c3c2a-d0f1-462a-8489-69b031221040

🤖 Generated with [Claude Code](https://claude.com/claude-code)