### PR TITLE
feat(mcp): export neoRootDir on Memory Core + Neural Link defaultConfig (#10584)

### DIFF
--- a/ai/mcp/server/memory-core/config.template.mjs
+++ b/ai/mcp/server/memory-core/config.template.mjs
@@ -14,6 +14,14 @@ const cwd        = neoRootDir;
  */
 const defaultConfig = {
     /**
+     * Repo root, computed from this module's path. Exported for symmetry with the
+     * KB and Neural Link configs (#10584) so consumers (loggers, services, future)
+     * can read `aiConfig.neoRootDir` rather than recomputing the 4-level traversal
+     * locally. Module path is stable; the resolution is deterministic at boot.
+     * @type {string}
+     */
+    neoRootDir,
+    /**
      * Automatically trigger session summarization on startup.
      * @type {boolean}
      */

--- a/ai/mcp/server/neural-link/config.template.mjs
+++ b/ai/mcp/server/neural-link/config.template.mjs
@@ -14,6 +14,14 @@ const cwd        = process.cwd();
  */
 const defaultConfig = {
     /**
+     * Repo root, computed from this module's path. Exported for symmetry with the
+     * KB and Memory Core configs (#10584) so consumers (loggers, services, future)
+     * can read `aiConfig.neoRootDir` rather than recomputing the 4-level traversal
+     * locally. Module path is stable; the resolution is deterministic at boot.
+     * @type {string}
+     */
+    neoRootDir,
+    /**
      * Automatically connect to the bridge on startup.
      * @type {boolean}
      */


### PR DESCRIPTION
Resolves #10584

## Summary

Quick-win symmetry follow-up to #10582. Two-line addition per server.

KB's `defaultConfig` exports `neoRootDir`; MC and NL had it as a module-local const but didn't expose it. After #10584, all three MCP server configs are symmetric, and consumers (loggers, services, future) can read `aiConfig.neoRootDir` directly.

## Acceptance Criteria

| AC | Status |
|---|---|
| AC1: `aiConfig.neoRootDir` returns repo root from MC's exported config | ✅ |
| AC2: `aiConfig.neoRootDir` returns repo root from NL's exported config | ✅ |
| AC3: Loggers' local `neoRootFallback` stays as belt-and-suspenders (non-binding) | ✅ kept; cleanup deferred |
| AC4: No regression on existing tests | ✅ 11/11 pass |

## Notable design decisions

**Loggers' local fallback consts kept** for now — defensive against test overrides that mutate `aiConfig.data.neoRootDir = undefined`, plus stale gitignored `config.mjs` deployments. Symmetric exports make the fallback mostly redundant; a small cleanup ticket can simplify when desirable. The redundancy is harmless and the safety surface stays positive.

**Doc-comment lift** — both new entries cite the symmetry rationale explicitly so future readers understand why a server-level const is exported on `defaultConfig` (rather than left as module-local).

## Test Plan

- [x] `npm run test-unit -- test/playwright/unit/ai/mcp/server/memory-core/logger.spec.mjs` — 2/2
- [x] `npm run test-unit -- test/playwright/unit/ai/mcp/server/neural-link/logger.spec.mjs` — 2/2
- [x] `npm run test-unit -- test/playwright/unit/ai/mcp/server/knowledge-base/logger.spec.mjs` — 2/2 (no regression)
- [x] `npm run test-unit -- test/playwright/unit/ai/mcp/server/knowledge-base/services/VectorService.WorkVolumeBranching.spec.mjs` — 5/5 (no regression)

11/11 pass.

## Origin

- Empirical surface: 2026-05-01 #10582 implementation hit the asymmetry in KB regression suite (`path.resolve(undefined, ...)` TypeError when MC logger loaded transitively)
- Tobiu's question post-#10583 merge: *"why not add the same root dir config to MC? might be a quick win ticket."*
- Origin Session ID: 7a2c3c2a-d0f1-462a-8489-69b031221040

🤖 Generated with [Claude Code](https://claude.com/claude-code)