### PR TITLE
feat(ai): integrate ConceptSource embedding pipeline and validation (#10037)

### DIFF
--- a/ai/mcp/server/knowledge-base/config.template.mjs
+++ b/ai/mcp/server/knowledge-base/config.template.mjs
@@ -181,6 +181,7 @@ const defaultConfig = {
         fileNameMatch    : 30,
         classNameMatch   : 20,
         guideMatch       : 50,
+        conceptMatch     : 15,
         blogMatch        : 5,
         namePartMatch    : 30,
         ticketPenalty    : -70,

--- a/ai/mcp/server/knowledge-base/services/DatabaseService.mjs
+++ b/ai/mcp/server/knowledge-base/services/DatabaseService.mjs
@@ -3,6 +3,7 @@ import Base               from '../../../../../src/core/Base.mjs';
 import ChromaManager      from './ChromaManager.mjs';
 import VectorService      from './VectorService.mjs';
 import ApiSource          from '../source/ApiSource.mjs';
+import ConceptSource      from '../source/ConceptSource.mjs';
 import DiscussionSource   from '../source/DiscussionSource.mjs';
 import LearningSource     from '../source/LearningSource.mjs';
 import PullRequestSource  from '../source/PullRequestSource.mjs';
@@ -285,6 +286,7 @@ class DatabaseService extends Base {
 
         const sources = [
             ApiSource,
+            ConceptSource,
             DiscussionSource,
             LearningSource,
             PullRequestSource,

--- a/ai/mcp/server/knowledge-base/services/QueryService.mjs
+++ b/ai/mcp/server/knowledge-base/services/QueryService.mjs
@@ -158,6 +158,7 @@ class QueryService extends Base {
                     }
 
                     if (metadata.type === 'guide') score += queryScoreWeights.guideMatch;
+                    if (metadata.type === 'concept') score += queryScoreWeights.conceptMatch;
                     if (metadata.type === 'blog') {
                         score += queryScoreWeights.blogMatch;
                         if (nameLower.includes(keywordSingular)) score += queryScoreWeights.guideMatch;

--- a/ai/mcp/server/knowledge-base/source/ConceptSource.mjs
+++ b/ai/mcp/server/knowledge-base/source/ConceptSource.mjs
@@ -1,0 +1,66 @@
+import Base from './Base.mjs';
+import fs   from 'fs-extra';
+import path from 'path';
+import aiConfig from '../config.mjs';
+
+/**
+ * @summary Extracts knowledge chunks from Concept Ontology nodes.
+ *
+ * This source provider reads `.neo-ai-data/concepts/nodes.jsonl`.
+ * Each concept node is treated as a single knowledge chunk.
+ *
+ * @class Neo.ai.mcp.server.knowledge-base.source.ConceptSource
+ * @extends Neo.ai.mcp.server.knowledge-base.source.Base
+ * @singleton
+ */
+class ConceptSource extends Base {
+    static config = {
+        /**
+         * @member {String} className='Neo.ai.mcp.server.knowledge-base.source.ConceptSource'
+         * @protected
+         */
+        className: 'Neo.ai.mcp.server.knowledge-base.source.ConceptSource',
+        /**
+         * @member {Boolean} singleton=true
+         * @protected
+         */
+        singleton: true
+    }
+
+    /**
+     * Extracts knowledge chunks from concept nodes.
+     * @param {Object}   writeStream  The JSONL write stream.
+     * @param {Function} createHashFn Function to create content hash.
+     * @returns {Promise<Number>} The number of chunks extracted.
+     */
+    async extract(writeStream, createHashFn) {
+        let count = 0;
+        const nodesPath = path.resolve(aiConfig.neoRootDir, '.neo-ai-data/concepts/nodes.jsonl');
+
+        if (await fs.pathExists(nodesPath)) {
+            const content = await fs.readFile(nodesPath, 'utf-8');
+            const lines = content.split('\n').filter(line => line.trim() !== '');
+
+            for (const line of lines) {
+                const node = JSON.parse(line);
+                const chunk = {
+                    type       : 'concept',
+                    kind       : 'concept',
+                    name       : node.name,
+                    tier       : node.tier,
+                    description: node.description,
+                    content    : `${node.name}: ${node.description}`,
+                    source     : path.relative(aiConfig.neoRootDir, nodesPath)
+                };
+
+                chunk.hash = createHashFn(chunk);
+                writeStream.write(JSON.stringify(chunk) + '\n');
+                count++;
+            }
+        }
+
+        return count;
+    }
+}
+
+export default Neo.setupClass(ConceptSource);

--- a/ai/scripts/validateConceptEdges.mjs
+++ b/ai/scripts/validateConceptEdges.mjs
@@ -1,0 +1,89 @@
+import 'dotenv/config';
+import fs from 'fs/promises';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import { KB_QueryService } from '../services.mjs';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const ROOT_DIR = path.resolve(__dirname, '../../');
+const EDGES_PATH = path.join(ROOT_DIR, '.neo-ai-data/concepts/edges.jsonl');
+const NODES_PATH = path.join(ROOT_DIR, '.neo-ai-data/concepts/nodes.jsonl');
+
+async function run() {
+    console.log('[validateConceptEdges] Loading concept ontology...');
+    const nodesRaw = await fs.readFile(NODES_PATH, 'utf-8');
+    const conceptMap = new Map();
+    for (const line of nodesRaw.split('\n')) {
+        if (!line.trim()) continue;
+        const node = JSON.parse(line);
+        conceptMap.set(node.id, node);
+    }
+
+    const edgesRaw = await fs.readFile(EDGES_PATH, 'utf-8');
+    const explainedByEdges = [];
+    for (const line of edgesRaw.split('\n')) {
+        if (!line.trim()) continue;
+        const edge = JSON.parse(line);
+        if (edge.type === 'EXPLAINED_BY') {
+            explainedByEdges.push(edge);
+        }
+    }
+
+    console.log(`[validateConceptEdges] Found ${explainedByEdges.length} EXPLAINED_BY edges.`);
+    
+    let anomaliesCount = 0;
+    
+    for (const edge of explainedByEdges) {
+        const conceptId = edge.source;
+        const targetStr = edge.target; 
+        
+        const concept = conceptMap.get(conceptId);
+        if (!concept) {
+            console.warn(`[validateConceptEdges] Concept ${conceptId} not found.`);
+            continue;
+        }
+
+        if (!targetStr.startsWith('file:')) {
+            console.log(`[validateConceptEdges] Skipping non-file target: ${targetStr}`);
+            continue;
+        }
+
+        // Expected source path in ChromaDB (relative to neoRootDir)
+        const expectedSource = targetStr.substring('file:'.length);
+        const conceptText = `${concept.name}: ${concept.description}`;
+
+        try {
+            const queryRes = await KB_QueryService.queryDocuments({
+                query: conceptText,
+                type: 'guide',
+                limit: 10
+            });
+
+            const results = queryRes.results || [];
+            const foundIndex = results.findIndex(r => r.source === expectedSource);
+
+            console.log(`Evaluating: [${conceptId}] -> [${expectedSource}]`);
+            
+            if (foundIndex === -1) {
+                console.warn(`  --> ⚠️  SEMANTIC ANOMALY: Guide '${expectedSource}' not in top 10 results for concept '${concept.name}'`);
+                anomaliesCount++;
+            } else {
+                console.log(`  --> ✅  Valid edge (Ranked #${foundIndex + 1})`);
+            }
+        } catch (err) {
+            console.error(`[validateConceptEdges] Error querying ChromaDB for edge ${conceptId} -> ${targetStr}:`, err);
+        }
+        
+        // Minor delay to avoid rate limiting if hitting external APIs
+        await new Promise(r => setTimeout(r, 100)); 
+    }
+    
+    console.log(`[validateConceptEdges] Validation complete. Found ${anomaliesCount} potential anomalies.`);
+    process.exit(0);
+}
+
+run().catch(err => {
+    console.error('[validateConceptEdges] Fatal:', err);
+    process.exit(1);
+});


### PR DESCRIPTION
Authored by Gemini 3.1 Pro (Antigravity). Session 503befa0-e808-444c-ad32-1056e2c63b58.

Resolves #10037

Integrated the concept ontology embedding pipeline into the chroma knowledge base ETL. Modified `QueryService` to respect conceptMatch query scores and finalized the semantic edge validation script.

## Deltas from ticket (if any)
- `conceptMatch: 15` was already present in `config.mjs`, so I directly implemented its application inside `QueryService.mjs` weighting logic.
- `validateConceptEdges.mjs` was refactored to query ChromaDB (`KB_QueryService.queryDocuments`) rather than computing embeddings and cosine similarity directly on the fly. This ensures it assesses exactly what the RAG engine sees.

## Test Evidence
- Verified parsing of `edges.jsonl` and ChromaDB API calls via `node ai/scripts/validateConceptEdges.mjs`.
- Registered `ConceptSource` successfully in `DatabaseService.mjs`.

## Post-Merge Validation
- [ ] Execute `npm run ai:sync-kb` natively without agent/browser overhead to complete the 2000+ chunk ingestion.
- [ ] Run `validateConceptEdges.mjs` to flag the anomalous edges.
