### PR TITLE
feat(ai): capture runSandman provider hard-failures (#10587)

### DIFF
--- a/ai/mcp/server/memory-core/logger.mjs
+++ b/ai/mcp/server/memory-core/logger.mjs
@@ -90,4 +90,23 @@ logger.log   = createLogMethod('log');
 logger.warn  = createLogMethod('warn');
 logger.error = createLogMethod('error');
 
+/**
+ * @summary Flushes the durable Memory Core log stream before immediate process termination.
+ *
+ * Short-lived operator scripts such as `runSandman.mjs` can write a final diagnostic and
+ * then exit nonzero in the same tick. Exposing this small flush primitive keeps those
+ * breadcrumbs durable without changing the logger's call-site ergonomics for long-lived
+ * MCP server processes.
+ *
+ * @returns {Promise<void>}
+ */
+logger.flush = () => new Promise(resolve => {
+    if (!currentStream) {
+        resolve();
+        return;
+    }
+
+    currentStream.write('', resolve);
+});
+
 export default logger;

--- a/buildScripts/ai/runSandman.mjs
+++ b/buildScripts/ai/runSandman.mjs
@@ -5,23 +5,155 @@ import Memory_Config from '../../ai/mcp/server/memory-core/config.mjs';
 import Memory_Service from '../../ai/mcp/server/memory-core/services/MemoryService.mjs';
 import DreamService from '../../ai/daemons/DreamService.mjs';
 import LifecycleService from '../../ai/mcp/server/memory-core/services/lifecycle/SystemLifecycleService.mjs';
+import InferenceLifecycleService from '../../ai/mcp/server/memory-core/services/lifecycle/InferenceLifecycleService.mjs';
 import GraphService from '../../ai/mcp/server/memory-core/services/GraphService.mjs';
-import { spawn } from 'child_process';
+import logger from '../../ai/mcp/server/memory-core/logger.mjs';
 import http from 'http';
+import {pathToFileURL} from 'url';
 
 /**
  * @module buildScripts/ai/runSandman
  */
 
-function checkProvider() {
-    const host = Memory_Config.data.openAiCompatible?.host || 'http://127.0.0.1:8000';
+const DEFAULT_OPENAI_COMPATIBLE_HOST = 'http://127.0.0.1:8000';
+const PROVIDER_READY_ATTEMPTS        = 30;
+const PROVIDER_READY_RETRY_MS        = 1000;
+
+/**
+ * @summary Resolves the OpenAI-compatible host that the Sandman REM pipeline must reach.
+ * @param {Object} config
+ * @returns {String}
+ */
+export function getOpenAiCompatibleHost(config = Memory_Config.data) {
+    return config.openAiCompatible?.host || DEFAULT_OPENAI_COMPATIBLE_HOST;
+}
+
+/**
+ * @summary Probes the configured OpenAI-compatible provider used by the Sandman REM pipeline.
+ * @param {Object} config
+ * @returns {Promise<Boolean>}
+ */
+export function checkProvider(config = Memory_Config.data) {
+    const host = getOpenAiCompatibleHost(config);
+
     return new Promise(resolve => {
-        const req = http.get(`${host}/v1/models`, () => resolve(true));
-        req.on('error', () => resolve(false));
+        let settled = false;
+        const settle = value => {
+            if (!settled) {
+                settled = true;
+                resolve(value);
+            }
+        };
+
+        const req = http.get(`${host}/v1/models`, response => {
+            response.resume();
+            settle(true);
+        });
+
+        req.setTimeout(3000, () => {
+            req.destroy();
+            settle(false);
+        });
+        req.on('error', () => settle(false));
     });
 }
 
-async function runSandman() {
+/**
+ * @summary Waits for the local provider readiness loop while exposing deterministic test seams.
+ * @param {Object} options
+ * @param {Function} options.checkProvider
+ * @param {Number} options.attempts
+ * @param {Number} options.delayMs
+ * @param {Object} options.output
+ * @returns {Promise<Object>}
+ */
+export async function waitForProvider({
+    checkProvider: providerCheck = () => checkProvider(),
+    attempts = PROVIDER_READY_ATTEMPTS,
+    delayMs  = PROVIDER_READY_RETRY_MS,
+    output   = process.stdout
+} = {}) {
+    const startedAt = Date.now();
+
+    for (let i = 0; i < attempts; i++) {
+        if (await providerCheck()) {
+            return {
+                running  : true,
+                attempts : i + 1,
+                elapsedMs: Date.now() - startedAt,
+                timeoutMs: attempts * delayMs
+            };
+        }
+
+        output.write('.');
+        await new Promise(resolve => setTimeout(resolve, delayMs));
+    }
+
+    return {
+        running  : false,
+        attempts,
+        elapsedMs: Date.now() - startedAt,
+        timeoutMs: attempts * delayMs
+    };
+}
+
+/**
+ * @summary Builds the durable Sandman provider-timeout breadcrumb for the Memory Core log.
+ * @param {Object} options
+ * @param {Object} options.config
+ * @param {Object} options.waitResult
+ * @param {Object|null} options.lifecycleStatus
+ * @returns {Object}
+ */
+export function createProviderFailureDiagnostic({
+    config = Memory_Config.data,
+    waitResult,
+    lifecycleStatus = null
+} = {}) {
+    return {
+        event          : 'runSandman.provider_readiness_timeout',
+        reason         : 'PROVIDER_READINESS_TIMEOUT',
+        provider       : 'openAiCompatible',
+        modelProvider  : config.modelProvider || null,
+        host           : getOpenAiCompatibleHost(config),
+        model          : config.openAiCompatible?.model || null,
+        embeddingModel : config.openAiCompatible?.embeddingModel || null,
+        attempts       : waitResult?.attempts ?? null,
+        elapsedMs      : waitResult?.elapsedMs ?? null,
+        timeoutMs      : waitResult?.timeoutMs ?? null,
+        lifecycleStatus,
+        nextAction     : 'Start the configured OpenAI-compatible / MLX provider, then rerun npm run ai:run-sandman.'
+    };
+}
+
+/**
+ * @summary Records the Sandman provider-timeout failure through terminal output and durable MC logging.
+ * @param {Object} diagnostic
+ * @param {Object} sinks
+ * @param {Object} sinks.log
+ * @param {Function} sinks.stderr
+ * @returns {Promise<Object>}
+ */
+export async function recordProviderReadinessFailure(
+    diagnostic,
+    {
+        log    = logger,
+        stderr = console.error
+    } = {}
+) {
+    const message = `\n❌ openAiCompatible server is not running on ${diagnostic.host}. Please start your MLX provider manually.`;
+
+    stderr(message);
+    log.error('[runSandman] openAiCompatible provider readiness timeout', diagnostic);
+
+    if (typeof log.flush === 'function') {
+        await log.flush();
+    }
+
+    return {message, diagnostic};
+}
+
+export async function runSandman() {
     // Enable debug logging to see progress
     Memory_Config.data.debug = true;
 
@@ -39,21 +171,20 @@ async function runSandman() {
         console.log('   Lifecycle Service Ready. Database should be running.');
 
         console.log('   Waiting for MLX provider to warm up load weights into VRAM...');
-        let isProviderRunning = false;
-        for (let i = 0; i < 30; i++) {
-            isProviderRunning = await checkProvider();
-            if (isProviderRunning) {
-                console.log('\n   ✅ openAiCompatible server is running (auto-boot successful).');
-                break;
-            }
-            process.stdout.write('.');
-            await new Promise(resolve => setTimeout(resolve, 1000));
+        const waitResult = await waitForProvider();
+
+        if (!waitResult.running) {
+            const diagnostic = createProviderFailureDiagnostic({
+                waitResult,
+                lifecycleStatus: InferenceLifecycleService.getStatus()
+            });
+
+            await recordProviderReadinessFailure(diagnostic);
+            process.exitCode = 1;
+            return;
         }
 
-        if (!isProviderRunning) {
-            console.error(`\n❌ openAiCompatible server is not running on ${Memory_Config.data.openAiCompatible?.host || 'http://127.0.0.1:8000'}. Please start your MLX provider manually.`);
-            process.exit(1);
-        }
+        console.log('\n   ✅ openAiCompatible server is running (auto-boot successful).');
 
         console.log('   Waiting for DreamService Initialization...');
         // We might need to ensure DreamService is fully inited, though it initAsync runs automatically upon Neo.setupClass
@@ -82,4 +213,6 @@ async function runSandman() {
     }
 }
 
-runSandman();
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+    runSandman();
+}

--- a/test/playwright/unit/buildScripts/ai/runSandman.spec.mjs
+++ b/test/playwright/unit/buildScripts/ai/runSandman.spec.mjs
@@ -1,0 +1,123 @@
+import {setup} from '../../../setup.mjs';
+
+const appName = 'RunSandmanDiagnosticsTest';
+
+setup({
+    neoConfig: {
+        allowVdomUpdatesInTests: false,
+        unitTestMode           : true,
+        useDomApiRenderer      : false
+    },
+    appConfig: {
+        name             : appName,
+        isMounted        : () => true,
+        vnodeInitialising: false
+    }
+});
+
+import {test, expect} from '@playwright/test';
+import fs             from 'fs-extra';
+import os             from 'os';
+import path           from 'path';
+import Neo            from '../../../../../src/Neo.mjs';
+import * as core      from '../../../../../src/core/_export.mjs';
+
+/**
+ * @summary Validates the durable diagnostics emitted before `runSandman` exits on provider timeout.
+ *
+ * This coverage keeps the Sandman REM operator path testable without a real MLX,
+ * LM Studio, or OpenAI-compatible server. The script's hard-fail branch must leave
+ * a queryable Memory Core log breadcrumb so future agents can distinguish expected
+ * provider-unavailable state from missing DreamService / Golden Path output.
+ */
+test.describe('runSandman.mjs provider readiness diagnostics (#10587)', () => {
+    let aiConfig;
+    let logger;
+    let runSandmanModule;
+    let tmpLogDir;
+    let originalLogPath;
+
+    test.beforeAll(async () => {
+        aiConfig = (await import('../../../../../ai/mcp/server/memory-core/config.mjs')).default;
+
+        tmpLogDir = path.resolve(os.tmpdir(), `runsandman-diagnostics-${process.pid}-${Date.now()}`);
+        originalLogPath = aiConfig.data.logPath;
+        aiConfig.data.logPath = tmpLogDir;
+
+        logger           = (await import('../../../../../ai/mcp/server/memory-core/logger.mjs')).default;
+        runSandmanModule = await import('../../../../../buildScripts/ai/runSandman.mjs');
+    });
+
+    test.afterAll(() => {
+        aiConfig.data.logPath = originalLogPath;
+
+        if (tmpLogDir && fs.existsSync(tmpLogDir)) {
+            fs.rmSync(tmpLogDir, {recursive: true, force: true});
+        }
+    });
+
+    test('waitForProvider returns timeout metadata without a real provider', async () => {
+        let dots = '';
+
+        const waitResult = await runSandmanModule.waitForProvider({
+            attempts     : 3,
+            delayMs      : 0,
+            checkProvider: async () => false,
+            output       : {
+                write: value => {
+                    dots += value;
+                }
+            }
+        });
+
+        expect(waitResult).toMatchObject({
+            running : false,
+            attempts: 3,
+            timeoutMs: 0
+        });
+        expect(waitResult.elapsedMs).toBeGreaterThanOrEqual(0);
+        expect(dots).toBe('...');
+    });
+
+    test('records a durable provider-timeout breadcrumb without leaking secrets', async () => {
+        const diagnostic = runSandmanModule.createProviderFailureDiagnostic({
+            config: {
+                modelProvider: 'openAiCompatible',
+                openAiCompatible: {
+                    host          : 'http://127.0.0.1:11435',
+                    model         : 'mlx-community/test-model',
+                    embeddingModel: 'test-embedding',
+                    apiKey        : 'must-not-be-logged'
+                }
+            },
+            waitResult: {
+                attempts : 30,
+                elapsedMs: 30000,
+                timeoutMs: 30000
+            },
+            lifecycleStatus: {
+                running: false,
+                managed: false,
+                pid    : null
+            }
+        });
+
+        const result = await runSandmanModule.recordProviderReadinessFailure(diagnostic, {
+            stderr: () => {}
+        });
+
+        await logger.flush();
+
+        const today    = new Date().toISOString().slice(0, 10);
+        const logFile  = path.join(tmpLogDir, `mc-server-${today}.log`);
+        const logLines = fs.readFileSync(logFile, 'utf8');
+
+        expect(result.message).toContain('http://127.0.0.1:11435');
+        expect(logLines).toContain('[runSandman] openAiCompatible provider readiness timeout');
+        expect(logLines).toContain('PROVIDER_READINESS_TIMEOUT');
+        expect(logLines).toContain('http://127.0.0.1:11435');
+        expect(logLines).toContain('mlx-community/test-model');
+        expect(logLines).toContain('Start the configured OpenAI-compatible / MLX provider');
+        expect(logLines).not.toContain('must-not-be-logged');
+    });
+});


### PR DESCRIPTION
Authored by GPT-5.5 (Codex Desktop). Session cf46c3e3-3bc7-4726-8b0b-b9c9af48742f.

Resolves #10587

Adds a durable diagnostics path for the explicit Sandman operator flow when the configured OpenAI-compatible / MLX provider never becomes reachable. `runSandman.mjs` now exposes test seams for provider readiness, records a structured provider-timeout breadcrumb through the Memory Core logger, flushes that file sink before nonzero exit, and remains import-safe for unit coverage.

## Deltas from ticket

The durable breadcrumb currently lands in the existing Memory Core always-on log file, not a new Graph node or MCP tool. That keeps the slice intentionally narrow and aligned with #10580/#10583 logger observability while preserving room for later graph-level diagnostics if repeated Sandman failure classes justify it.

## Test Evidence

- `git diff --check`
- `npm run test-unit -- test/playwright/unit/buildScripts/ai/runSandman.spec.mjs test/playwright/unit/ai/mcp/server/memory-core/logger.spec.mjs` — 4 passed

## Post-Merge Validation

- [ ] Temporarily point `NEO_OPENAI_COMPATIBLE_HOST` at an unavailable local endpoint and run `npm run ai:run-sandman`; verify it exits nonzero and `.neo-ai-data/logs/mc-server-<date>.log` contains `runSandman.provider_readiness_timeout` with provider host/model metadata.

## Commit

- `9d9000af5` — `feat(ai): capture runSandman provider hard-failures (#10587)`

Related: #9999, #10569, #10580, #10583, #10186, #10103