### PR TITLE
feat(ai): cross-clone symlink for sandman_handoff.md (#10591)

### DIFF
--- a/ai/scripts/bootstrapWorktree.mjs
+++ b/ai/scripts/bootstrapWorktree.mjs
@@ -29,6 +29,16 @@
  * files by path, and `path.resolve` traverses symlinks transparently without canonical-path
  * side effects.
  *
+ * **Symlinking gitignored SINGLE FILES (per #10591):** Some cross-clone substrates live
+ * outside `.neo-ai-data/` — most notably `resources/content/sandman_handoff.md`, the
+ * Sandman strategic-priming handoff that `runSandman.mjs` writes only inside the
+ * canonical clone. Without symlink mediation, the other trio members' clones can't read
+ * the handoff at boot. The granular per-file primitive ({@link symlinkGitignoredFiles}
+ * + {@link GITIGNORED_FILES_TO_LINK}) extends Cross-clone substrate unification to
+ * single artifacts without exposing their tracked parent directories. Distinct from the
+ * data-dir path because `resources/content/` is heavily git-tracked (issue files, PRs,
+ * discussions) — only single gitignored files inside it qualify.
+ *
  * **The gitignore boundary inside `.neo-ai-data/` is load-bearing:**
  *
  * ```
@@ -53,7 +63,7 @@
  * **Usage:**
  * ```
  * node ai/scripts/bootstrapWorktree.mjs              # copy configs only
- * node ai/scripts/bootstrapWorktree.mjs --link-data  # copy configs + symlink data subdirs
+ * node ai/scripts/bootstrapWorktree.mjs --link-data  # copy configs + symlink data subdirs + gitignored handoff files
  * node ai/scripts/bootstrapWorktree.mjs --link-data --force
  *                                                    # clobber any existing real
  *                                                    # gitignored subdir (data-loss guard
@@ -83,7 +93,8 @@
  * @see https://github.com/neomjs/neo/issues/10224 (closed predecessor — coarse-grained symlink)
  * @see https://github.com/neomjs/neo/issues/10424 (cross-process coherence gap empirically anchored)
  * @see https://github.com/neomjs/neo/issues/10432 / #10433 (granular per-subdir refinement)
- * @see https://github.com/neomjs/neo/issues/10435 (this independent-clone extension)
+ * @see https://github.com/neomjs/neo/issues/10435 (independent-clone topology extension)
+ * @see https://github.com/neomjs/neo/issues/10591 (gitignored single-file symlink extension)
  */
 import {execFile}       from 'child_process';
 import fs               from 'fs/promises';
@@ -118,6 +129,34 @@ export const DATA_SUBDIRS_TO_LINK = [
     'backups',      // JSONL backups (Memory Core message + node history)
     'datasets',     // Canonical CSVs ingested by knowledge-base sync
     'neo-sqlite'    // Legacy DB (still referenced by older code paths)
+];
+
+/**
+ * Allowlist of gitignored single files (outside `.neo-ai-data/`) to symlink to canonical
+ * when `--link-data` is set. Initial member is the Sandman strategic-priming handoff,
+ * which `runSandman.mjs` writes only inside the canonical clone. Without symlink mediation,
+ * Antigravity-Gemini and Codex-GPT clones don't see the handoff at boot per
+ * `AGENTS_STARTUP.md §6` step 4.
+ *
+ * **Allowlist discipline (parallel to `DATA_SUBDIRS_TO_LINK`):**
+ *
+ * Each entry MUST be:
+ * 1. **Gitignored** — single file with its own `.gitignore` line. Symlinking a tracked file
+ *    would create cross-clone divergence between git's view and the symlink target.
+ * 2. **Canonical-only-write** — produced exclusively in the canonical clone (e.g., by an
+ *    operator-side script like `runSandman.mjs`). Files written by all clones simultaneously
+ *    would race on the symlink target.
+ * 3. **Cross-clone-readable** — consumed at boot or runtime by all trio members; the entire
+ *    rationale for the symlink is removing the cross-clone visibility asymmetry.
+ *
+ * Entries that fail any of those conditions belong elsewhere: tracked files need no symlink,
+ * locally-written files would corrupt canonical, and clone-private files have no consumer.
+ *
+ * @see https://github.com/neomjs/neo/issues/10591 (this allowlist's introduction)
+ * @see {@link symlinkGitignoredFiles} for the per-file symlink-or-skip-or-warn logic.
+ */
+export const GITIGNORED_FILES_TO_LINK = [
+    'resources/content/sandman_handoff.md'  // Sandman strategic-priming handoff (#10591)
 ];
 
 /**
@@ -314,6 +353,110 @@ export async function symlinkDataDir({
 }
 
 /**
+ * @summary Granularly symlinks gitignored single files (outside `.neo-ai-data/`) to
+ * canonical, unifying cross-clone-readable handoff substrates without exposing the entire
+ * tracked parent directory.
+ *
+ * **Why per-file, not per-parent (Cross-clone substrate unification):**
+ *
+ * The handoff substrate (initial member: `resources/content/sandman_handoff.md`) lives
+ * inside a heavily git-tracked parent — `resources/content/` holds issue files, PR
+ * conversations, discussion threads, and release notes that all three trio members
+ * generate independently. Symlinking the parent atomically would hide every clone's
+ * locally-tracked contributions behind canonical's view (the same anti-pattern #10432
+ * fixed for `.neo-ai-data/` parent symlinks before the per-subdir refinement). The
+ * gitignore boundary is single-file granular, so the symlink primitive must be too.
+ *
+ * **Why this is the right substrate (Anchor & Echo on Cross-clone substrate unification):**
+ *
+ * The companion `symlinkDataDir` function unifies gitignored substrate-data subdirs of
+ * `.neo-ai-data/` (Memory Core SQLite, Chroma vectors, wake-daemon PID-lock, etc.) so
+ * cross-process state coheres across worktree-spawned MCP server instances. This
+ * function extends the same Cross-clone substrate unification pattern to single
+ * gitignored artifacts that live outside `.neo-ai-data/` — same canonical-only-write
+ * + cross-clone-read semantic, narrower data shape (one file per allowlist entry rather
+ * than a tree of state).
+ *
+ * The `sandman_handoff.md` artifact is the canonical example: `runSandman.mjs` writes
+ * it inside the canonical clone only, but every trio member must read it at boot
+ * (`AGENTS_STARTUP.md §6` step 4). Without this symlink, only the operator running
+ * `runSandman.mjs` sees the strategic priming; Antigravity-Gemini and Codex-GPT clones
+ * read empty / nonexistent state — cross-clone strategic divergence.
+ *
+ * **No `force` clobber semantic on single files:**
+ *
+ * For data dirs, `--force` is justified for corruption recovery (the dir's contents are
+ * fungible substrate that can be regenerated). For a single artifact file, the user's
+ * local state may be intentional (e.g., a saved prior handoff worth preserving across
+ * canonical's overwrite). Conservative skip-with-warning is the safer default. Users
+ * who want the symlink can manually `rm` the local file before re-running.
+ *
+ * Idempotent per-file by design: an existing symlink reports `'already-linked'`; a
+ * missing canonical source reports `'skipped-no-source'` (graceful for fresh repos that
+ * haven't run Sandman yet); a real file at the destination reports `'skipped-real-file'`
+ * with a warning pointing at the manual remediation path.
+ *
+ * @param {object}   options
+ * @param {string}   options.mainCheckout     Absolute path to the primary git checkout.
+ * @param {string}   options.projectRoot      Absolute path to the worktree root to link from.
+ * @param {string[]} [options.files]          Allowlist of files to symlink; defaults to {@link GITIGNORED_FILES_TO_LINK}.
+ * @param {Function} [options.log=console.log] Logger fn for action diagnostics.
+ * @returns {Promise<{linked: string[], alreadyLinked: string[], skippedNoSource: string[], skippedRealFile: string[], mainCheckout: boolean}>} Per-file action map.
+ */
+export async function symlinkGitignoredFiles({
+    mainCheckout,
+    projectRoot,
+    files = GITIGNORED_FILES_TO_LINK,
+    log   = console.log
+}) {
+    const result = {linked: [], alreadyLinked: [], skippedNoSource: [], skippedRealFile: [], mainCheckout: false};
+
+    if (path.resolve(projectRoot) === path.resolve(mainCheckout)) {
+        log(`file-symlink skip (main checkout): no per-file action`);
+        result.mainCheckout = true;
+        return result;
+    }
+
+    for (const rel of files) {
+        const src   = path.join(mainCheckout, rel);
+        const dst   = path.join(projectRoot, rel);
+        const lstat = await fs.lstat(dst).catch(() => null);
+
+        if (lstat?.isSymbolicLink()) {
+            log(`file-symlink skip (already linked): ${rel}`);
+            result.alreadyLinked.push(rel);
+            continue;
+        }
+
+        // Skip if canonical lacks the file — graceful for the pre-Sandman-run state.
+        const srcExists = await exists(src);
+        if (!srcExists) {
+            log(`file-symlink skip (no source in main checkout): ${rel}`);
+            result.skippedNoSource.push(rel);
+            continue;
+        }
+
+        if (lstat) {
+            // Real file present — preserve local state, surface warning.
+            log(`file-symlink skip (real file present, preserving local state): ${rel}`);
+            log(`  → manually remove the local file and re-run --link-data to override`);
+            result.skippedRealFile.push(rel);
+            continue;
+        }
+
+        // Ensure parent dir exists; resources/content/ is normally tracked + present, but
+        // belt-and-suspenders for fresh repos or future allowlist entries in absent dirs.
+        await fs.mkdir(path.dirname(dst), {recursive: true});
+
+        await fs.symlink(src, dst, 'file');
+        log(`file-symlinked: ${rel} → ${src}`);
+        result.linked.push(rel);
+    }
+
+    return result;
+}
+
+/**
  * @summary Installs the worktree's `node_modules` and bundles the parse5 test prerequisite.
  *
  * Worktrees off `origin/dev` start without `node_modules` (gitignored) AND without
@@ -446,6 +589,27 @@ if (isMain) {
                 if (alreadyLinkedN   > 0) console.log(`  already-linked:   ${symlinkResult.alreadyLinked.join(', ')}`);
                 if (clobberedN       > 0) console.log(`  clobbered:        ${symlinkResult.clobbered.join(', ')}`);
                 if (skippedNoSourceN > 0) console.log(`  skipped-no-src:   ${symlinkResult.skippedNoSource.join(', ')}`);
+            }
+
+            // Cross-clone single-file symlinks (#10591). Same --link-data flag, narrower
+            // shape: each entry in GITIGNORED_FILES_TO_LINK is a single artifact rather
+            // than a tree of state. Currently sandman_handoff.md only.
+            const fileResult = await symlinkGitignoredFiles({mainCheckout, projectRoot});
+            if (fileResult.mainCheckout) {
+                console.log(`✓ File symlink: skipped (running in main checkout)`);
+            } else {
+                const fLinkedN          = fileResult.linked.length;
+                const fAlreadyLinkedN   = fileResult.alreadyLinked.length;
+                const fSkippedNoSourceN = fileResult.skippedNoSource.length;
+                const fSkippedRealFileN = fileResult.skippedRealFile.length;
+                console.log(
+                    `✓ File symlink: ${fLinkedN} linked, ${fAlreadyLinkedN} already-linked, ` +
+                    `${fSkippedNoSourceN} skipped-no-source, ${fSkippedRealFileN} skipped-real-file`
+                );
+                if (fLinkedN          > 0) console.log(`  linked:           ${fileResult.linked.join(', ')}`);
+                if (fAlreadyLinkedN   > 0) console.log(`  already-linked:   ${fileResult.alreadyLinked.join(', ')}`);
+                if (fSkippedNoSourceN > 0) console.log(`  skipped-no-src:   ${fileResult.skippedNoSource.join(', ')}`);
+                if (fSkippedRealFileN > 0) console.log(`  skipped-real-file: ${fileResult.skippedRealFile.join(', ')}`);
             }
         }
 

--- a/test/playwright/unit/ai/scripts/bootstrapWorktree.spec.mjs
+++ b/test/playwright/unit/ai/scripts/bootstrapWorktree.spec.mjs
@@ -31,11 +31,13 @@ import path            from 'path';
 test.describe('ai/scripts/bootstrapWorktree', () => {
     let bootstrapWorktree;
     let symlinkDataDir;
+    let symlinkGitignoredFiles;
     let installDependencies;
     let runBuildAll;
     let resolveMainCheckout;
     let BOOTSTRAP_CONFIGS;
     let DATA_SUBDIRS_TO_LINK;
+    let GITIGNORED_FILES_TO_LINK;
     let fakeMainCheckout;
     let fakeWorktree;
 
@@ -47,14 +49,16 @@ test.describe('ai/scripts/bootstrapWorktree', () => {
     ];
 
     test.beforeAll(async () => {
-        const mod           = await import('../../../../../ai/scripts/bootstrapWorktree.mjs');
-        bootstrapWorktree    = mod.bootstrapWorktree;
-        symlinkDataDir       = mod.symlinkDataDir;
-        installDependencies  = mod.installDependencies;
-        runBuildAll          = mod.runBuildAll;
-        resolveMainCheckout  = mod.resolveMainCheckout;
-        BOOTSTRAP_CONFIGS    = mod.BOOTSTRAP_CONFIGS;
-        DATA_SUBDIRS_TO_LINK = mod.DATA_SUBDIRS_TO_LINK;
+        const mod               = await import('../../../../../ai/scripts/bootstrapWorktree.mjs');
+        bootstrapWorktree        = mod.bootstrapWorktree;
+        symlinkDataDir           = mod.symlinkDataDir;
+        symlinkGitignoredFiles   = mod.symlinkGitignoredFiles;
+        installDependencies      = mod.installDependencies;
+        runBuildAll              = mod.runBuildAll;
+        resolveMainCheckout      = mod.resolveMainCheckout;
+        BOOTSTRAP_CONFIGS        = mod.BOOTSTRAP_CONFIGS;
+        DATA_SUBDIRS_TO_LINK     = mod.DATA_SUBDIRS_TO_LINK;
+        GITIGNORED_FILES_TO_LINK = mod.GITIGNORED_FILES_TO_LINK;
     });
 
     test.beforeEach(async () => {
@@ -423,6 +427,161 @@ test.describe('ai/scripts/bootstrapWorktree', () => {
                 expect(lstat.isDirectory()).toBe(true);
                 expect(lstat.isSymbolicLink()).toBe(false);
             }
+        });
+    });
+
+    // --------------------------------------------------------------------------------
+    // #10591 symlinkGitignoredFiles — granular per-file symlinking of gitignored single
+    // files (initially: resources/content/sandman_handoff.md) outside .neo-ai-data/.
+    //
+    // Distinct from symlinkDataDir's directory-shaped substrate: each entry is a single
+    // artifact, parent dir is heavily git-tracked (e.g. resources/content/), no `--force`
+    // semantic for files (skip-with-warning if a real file is present preserves potentially
+    // intentional local state).
+    //
+    // These tests use a fixture file PER ENTRY in the main-checkout to prove the per-file
+    // states: linked / already-linked / skipped-no-source / skipped-real-file. The
+    // mainCheckout no-op closes the safety check that primary-working-tree invocations
+    // are inert.
+    // --------------------------------------------------------------------------------
+    test.describe('#10591 symlinkGitignoredFiles (granular per-file)', () => {
+        const fixtureFile      = 'resources/content/sandman_handoff.md';
+        const fixtureFiles     = [fixtureFile];
+
+        async function seedMainHandoff(content = '# fixture handoff\n') {
+            const src = path.join(fakeMainCheckout, fixtureFile);
+            await fs.ensureDir(path.dirname(src));
+            await fs.writeFile(src, content, 'utf-8');
+        }
+
+        test('exports the canonical GITIGNORED_FILES_TO_LINK list', () => {
+            // Load-bearing invariants rather than precise sequence (which may evolve).
+            expect(Array.isArray(GITIGNORED_FILES_TO_LINK)).toBe(true);
+            expect(GITIGNORED_FILES_TO_LINK).toContain('resources/content/sandman_handoff.md');
+
+            // Sanity: every entry MUST be a relative path (canonical-only-write semantic
+            // would break with absolute paths).
+            for (const rel of GITIGNORED_FILES_TO_LINK) {
+                expect(path.isAbsolute(rel)).toBe(false);
+            }
+        });
+
+        test('symlinks every allowlisted file from canonical when none exist in worktree', async () => {
+            await seedMainHandoff('main-handoff-canary\n');
+
+            const result = await symlinkGitignoredFiles({
+                mainCheckout: fakeMainCheckout,
+                projectRoot : fakeWorktree,
+                files       : fixtureFiles,
+                log         : () => {}
+            });
+
+            expect(result.linked).toEqual(fixtureFiles);
+            expect(result.alreadyLinked).toHaveLength(0);
+            expect(result.skippedNoSource).toHaveLength(0);
+            expect(result.skippedRealFile).toHaveLength(0);
+            expect(result.mainCheckout).toBe(false);
+
+            // Symlink lands at the worktree path; canary content reachable via the link.
+            const dst   = path.join(fakeWorktree, fixtureFile);
+            const lstat = await fs.lstat(dst);
+            expect(lstat.isSymbolicLink()).toBe(true);
+
+            const canary = await fs.readFile(dst, 'utf-8');
+            expect(canary).toBe('main-handoff-canary\n');
+        });
+
+        test('is idempotent per-file — re-running surfaces alreadyLinked on second pass', async () => {
+            await seedMainHandoff();
+
+            // First call: link.
+            await symlinkGitignoredFiles({
+                mainCheckout: fakeMainCheckout,
+                projectRoot : fakeWorktree,
+                files       : fixtureFiles,
+                log         : () => {}
+            });
+
+            // Second call: alreadyLinked.
+            const result = await symlinkGitignoredFiles({
+                mainCheckout: fakeMainCheckout,
+                projectRoot : fakeWorktree,
+                files       : fixtureFiles,
+                log         : () => {}
+            });
+
+            expect(result.linked).toHaveLength(0);
+            expect(result.alreadyLinked).toEqual(fixtureFiles);
+            expect(result.skippedNoSource).toHaveLength(0);
+            expect(result.skippedRealFile).toHaveLength(0);
+        });
+
+        test('gracefully skips files missing in the main checkout (pre-Sandman state)', async () => {
+            // Do NOT seed the handoff in main — simulates fresh repo where Sandman
+            // hasn't run yet. The script must not error in this state.
+            const result = await symlinkGitignoredFiles({
+                mainCheckout: fakeMainCheckout,
+                projectRoot : fakeWorktree,
+                files       : fixtureFiles,
+                log         : () => {}
+            });
+
+            expect(result.linked).toHaveLength(0);
+            expect(result.skippedNoSource).toEqual(fixtureFiles);
+            expect(result.alreadyLinked).toHaveLength(0);
+            expect(result.skippedRealFile).toHaveLength(0);
+
+            // No symlink was created.
+            const dst    = path.join(fakeWorktree, fixtureFile);
+            const exists = await fs.pathExists(dst);
+            expect(exists).toBe(false);
+        });
+
+        test('skips real files in the worktree without clobbering (preserve-local-state)', async () => {
+            await seedMainHandoff('canonical-content\n');
+
+            // Pre-create a real file in the worktree at the target path with unique
+            // content — simulates an operator-saved prior handoff worth preserving.
+            const dst = path.join(fakeWorktree, fixtureFile);
+            await fs.ensureDir(path.dirname(dst));
+            await fs.writeFile(dst, 'worktree-local-handoff\n', 'utf-8');
+
+            const result = await symlinkGitignoredFiles({
+                mainCheckout: fakeMainCheckout,
+                projectRoot : fakeWorktree,
+                files       : fixtureFiles,
+                log         : () => {}
+            });
+
+            expect(result.linked).toHaveLength(0);
+            expect(result.skippedRealFile).toEqual(fixtureFiles);
+            expect(result.alreadyLinked).toHaveLength(0);
+            expect(result.skippedNoSource).toHaveLength(0);
+
+            // Local file preserved — guard did its job.
+            const lstat = await fs.lstat(dst);
+            expect(lstat.isSymbolicLink()).toBe(false);
+            expect(lstat.isFile()).toBe(true);
+
+            const preserved = await fs.readFile(dst, 'utf-8');
+            expect(preserved).toBe('worktree-local-handoff\n');
+        });
+
+        test('returns mainCheckout: true when run from the primary working tree', async () => {
+            await seedMainHandoff();
+
+            const result = await symlinkGitignoredFiles({
+                mainCheckout: fakeMainCheckout,
+                projectRoot : fakeMainCheckout, // same path = primary working tree
+                files       : fixtureFiles,
+                log         : () => {}
+            });
+
+            expect(result.mainCheckout).toBe(true);
+            expect(result.linked).toHaveLength(0);
+            expect(result.alreadyLinked).toHaveLength(0);
+            expect(result.skippedNoSource).toHaveLength(0);
+            expect(result.skippedRealFile).toHaveLength(0);
         });
     });
 


### PR DESCRIPTION
Authored by Claude Opus 4.7 (Claude Code). Session 86b7a3a0-7b14-4bd1-b707-52c5741aaeeb.

Resolves #10591

Extends `bootstrapWorktree.mjs` with a per-file symlink primitive — `symlinkGitignoredFiles()` + `GITIGNORED_FILES_TO_LINK` allowlist — so gitignored single files outside `.neo-ai-data/` (initial member: `resources/content/sandman_handoff.md`) can be symlinked from canonical → other clones under the same `--link-data` flag the data-subdir symlink uses.

Once Sandman runs reliably on a per-cycle cadence, all three trio members read the same handoff file at boot per `AGENTS_STARTUP.md §6` step 4 — closing the cross-clone strategic-priming asymmetry [@tobiu](https://github.com/tobiu) surfaced in the post-merge handoff for Epic [#10311](https://github.com/neomjs/neo/issues/10311).

## Deltas from ticket

None. All seven ACs satisfied:

- **(AC1)** `GITIGNORED_FILES_TO_LINK` constant exported with initial entry `resources/content/sandman_handoff.md`.
- **(AC2)** `symlinkGitignoredFiles()` exported. Per-file action map: `{linked, alreadyLinked, skippedNoSource, skippedRealFile, mainCheckout}`. Same `mainCheckout` short-circuit as `symlinkDataDir`.
- **(AC3)** CLI under `--link-data` invokes `symlinkGitignoredFiles()` after `symlinkDataDir()`. Summary line appended (`File symlink: N linked, N already-linked, N skipped-no-source, N skipped-real-file`).
- **(AC4)** Idempotency verified empirically + via test: re-running `--link-data` reports `'already-linked'` on cycle 2.
- **(AC5)** Graceful absent-source verified: when canonical lacks the file (pre-Sandman state), reports `skipped-no-source: 1` without erroring.
- **(AC6)** File-head JSDoc extended: new "Symlinking gitignored SINGLE FILES (per #10591)" sub-section explains the cross-clone substrate-unification rationale + sets the `resources/content/`-tracked-parent constraint as load-bearing. Plus `@see` cross-reference to #10591.
- **(AC7)** Test coverage: new `#10591 symlinkGitignoredFiles (granular per-file)` describe block in [test/playwright/unit/ai/scripts/bootstrapWorktree.spec.mjs](test/playwright/unit/ai/scripts/bootstrapWorktree.spec.mjs) with 6 tests covering all 5 per-file states + the mainCheckout no-op + the load-bearing GITIGNORED_FILES_TO_LINK invariants.

## Test Evidence

```
$ npx playwright test test/playwright/unit/ai/scripts/bootstrapWorktree.spec.mjs --reporter=line
  28 passed (1.2s)
```

22 existing tests + 6 new for #10591.

Empirical end-to-end verification from this worktree:

```
$ node ai/scripts/bootstrapWorktree.mjs --link-data
... (data symlinks already-linked) ...
file-symlinked: resources/content/sandman_handoff.md → /Users/Shared/github/neomjs/neo/resources/content/sandman_handoff.md
✓ File symlink: 1 linked, 0 already-linked, 0 skipped-no-source, 0 skipped-real-file

$ node ai/scripts/bootstrapWorktree.mjs --link-data   # second run
file-symlink skip (already linked): resources/content/sandman_handoff.md
✓ File symlink: 0 linked, 1 already-linked, 0 skipped-no-source, 0 skipped-real-file

$ ls -la resources/content/sandman_handoff.md
lrwxr-xr-x ... resources/content/sandman_handoff.md -> /Users/Shared/github/neomjs/neo/resources/content/sandman_handoff.md
```

Cross-clone read coherence empirically confirmed: my worktree now reads the same handoff content as canonical.

## Post-Merge Validation

- [ ] Each trio member runs `node ai/scripts/bootstrapWorktree.mjs --link-data` from their respective clones (Antigravity-Gemini and Codex-GPT need `--canonical-root <path>` per #10435 since they're independent clones, not git worktrees).
- [ ] `view_file resources/content/sandman_handoff.md` succeeds from each clone.
- [ ] On next operator-triggered `runSandman.mjs`, all three trio members see the refreshed handoff at boot.

## Cross-family mandate

Code change with runtime impact (extends a script that operators run during worktree bootstrap). Cross-family Approved review required for merge eligibility per `.agents/skills/pull-request/references/pull-request-workflow.md` §6.1. Single-peer review request follows.

## Provenance

- Empirical anchor: @tobiu's post-merge handoff message (no public artifact reference; in-session A2A) — surfaced the cross-clone gap immediately after [#10588](https://github.com/neomjs/neo/pull/10588) [#10589](https://github.com/neomjs/neo/pull/10589) [#10590](https://github.com/neomjs/neo/pull/10590) merged.
- Architectural lineage: [#10095](https://github.com/neomjs/neo/issues/10095) (bootstrapWorktree origin) → [#10432](https://github.com/neomjs/neo/issues/10432) (per-subdir granular refinement) → [#10435](https://github.com/neomjs/neo/issues/10435) (independent-clone topology) → #10591 (per-file extension, this PR).
- Parent epic: [#10311](https://github.com/neomjs/neo/issues/10311) Institutionalizing Swarm Autonomy — heartbeat substrate. This PR is a parallel enabler: even before the heartbeat fully shipped, cross-clone handoff visibility is independently valuable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)