### PR TITLE
feat(ai): Implement relevance-bounded ConceptService query APIs

### DIFF
--- a/ai/services/ConceptService.mjs
+++ b/ai/services/ConceptService.mjs
@@ -277,6 +277,7 @@ class ConceptService extends Base {
      * Each node in the tree includes its metadata and a `children` array.
      * @param {Number} [maxTier=3] Maximum tier to include.
      * @returns {Object} Tree root with nested children.
+     * @protected Intended for internal orchestration and visualization apps. LLM query surfaces should use bounded variants.
      */
     getConceptTree(maxTier = 3) {
         this.ensureLoaded();
@@ -349,6 +350,7 @@ class ConceptService extends Base {
      * @param {Number} [minWeight=0] Minimum weight threshold for inclusion.
      * @returns {Array<Object>} Gap entries sorted by weight descending:
      *   `{concept, weight, tier, severity, missingEdgeTypes}`.
+     * @protected Intended for internal orchestration. LLM query surfaces should use findGapsRelevantTo.
      */
     findGuideGaps(minWeight = 0) {
         this.ensureLoaded();
@@ -396,17 +398,124 @@ class ConceptService extends Base {
      * Performs reverse lookup on `IMPLEMENTED_BY` edges.
      *
      * @param {String} classPath Repository-relative path (e.g., `'src/data/Store.mjs'`).
+     * @param {Object} [options]
+     * @param {Number} [options.limit=5] Max concepts to return. Default 5 prevents context bloat.
      * @returns {Array<Object>} Concept nodes that reference this file.
      */
-    classifyConcept(classPath) {
+    classifyConcept(classPath, {limit = 5} = {}) {
         this.ensureLoaded();
 
         const fileRef = classPath.startsWith('file:') ? classPath : `file:${classPath}`,
               edges   = this.getInboundEdges(fileRef, 'IMPLEMENTED_BY');
 
-        return edges
+        let concepts = edges
             .map(e => this.nodes.get(e.source))
             .filter(Boolean);
+
+        if (limit > 0) {
+            concepts = concepts.slice(0, limit);
+        }
+
+        return concepts;
+    }
+
+    /**
+     * @summary Returns the top concepts most relevant to a task description.
+     * Bounded by a default limit to prevent LLM context flooding.
+     * Phase 1: Keyword/Tier-based heuristic matching.
+     * Phase 2 (Pending #10037): ChromaDB cosine similarity.
+     *
+     * @param {String} taskDescription Natural language task description.
+     * @param {Object} [options]
+     * @param {Number} [options.limit=5] Max concepts to return. Default 5 prevents context bloat.
+     * @returns {Array<Object>} Most relevant concepts.
+     */
+    findConceptsRelevantTo(taskDescription, {limit = 5} = {}) {
+        this.ensureLoaded();
+
+        if (!taskDescription) {
+            return [];
+        }
+
+        const keywords = taskDescription.toLowerCase().split(/\s+/).filter(w => w.length > 2);
+
+        // Phase 1: simple heuristic score
+        const scored = [...this.nodes.values()]
+            .filter(n => n.tier > 0) // Skip anchor
+            .map(concept => {
+                let score = 0;
+                const terms = [
+                    concept.id.toLowerCase(),
+                    concept.name.toLowerCase(),
+                    ...(concept.aliases || []).map(a => a.toLowerCase())
+                ];
+
+                for (const kw of keywords) {
+                    if (terms.some(t => t.includes(kw))) {
+                        score += 10;
+                    }
+                }
+
+                // Slight boost for higher tier (lower number)
+                score += (4 - concept.tier);
+
+                return {concept, score};
+            })
+            .filter(item => item.score > (4 - item.concept.tier)) // Must have at least one keyword match
+            .sort((a, b) => b.score - a.score)
+            .map(item => item.concept);
+
+        return scored.slice(0, limit);
+    }
+
+    /**
+     * @summary Task-scoped version of findGuideGaps that returns gaps semantically related to the task.
+     * Bounded by a default limit to prevent LLM context flooding.
+     * Phase 1: Keyword/Tier-based heuristic matching.
+     * Phase 2 (Pending #10037): ChromaDB cosine similarity.
+     *
+     * @param {String} taskDescription Natural language task description.
+     * @param {Object} [options]
+     * @param {Number} [options.limit=5] Max gaps to return. Default 5 prevents context bloat.
+     * @param {Number} [options.minWeight=0] Minimum gap weight threshold.
+     * @returns {Array<Object>} Relevant guide gaps.
+     */
+    findGapsRelevantTo(taskDescription, {limit = 5, minWeight = 0} = {}) {
+        this.ensureLoaded();
+
+        const allGaps = this.findGuideGaps(minWeight);
+
+        if (!taskDescription) {
+            return allGaps.slice(0, limit);
+        }
+
+        const keywords = taskDescription.toLowerCase().split(/\s+/).filter(w => w.length > 2);
+
+        const scoredGaps = allGaps
+            .map(gap => {
+                let score = gap.weight; // start with existing weight
+                const concept = gap.concept;
+                const terms = [
+                    concept.id.toLowerCase(),
+                    concept.name.toLowerCase(),
+                    ...(concept.aliases || []).map(a => a.toLowerCase())
+                ];
+
+                let matched = false;
+                for (const kw of keywords) {
+                    if (terms.some(t => t.includes(kw))) {
+                        score += 10;
+                        matched = true;
+                    }
+                }
+
+                return {gap, score, matched};
+            })
+            .filter(item => item.matched)
+            .sort((a, b) => b.score - a.score)
+            .map(item => item.gap);
+
+        return scoredGaps.slice(0, limit);
     }
 
     /**
@@ -444,6 +553,7 @@ class ConceptService extends Base {
      *
      * @param {String} conceptId The concept ID to look up analogues for.
      * @returns {Array<Object>} ANALOGOUS_TO edges with `{source, target, type, note}`.
+     * @protected Intended for internal orchestration.
      */
     getAnalogousConcepts(conceptId) {
         this.ensureLoaded();

--- a/ai/services/ConceptService.mjs
+++ b/ai/services/ConceptService.mjs
@@ -277,7 +277,7 @@ class ConceptService extends Base {
      * Each node in the tree includes its metadata and a `children` array.
      * @param {Number} [maxTier=3] Maximum tier to include.
      * @returns {Object} Tree root with nested children.
-     * @protected Intended for internal orchestration and visualization apps. LLM query surfaces should use bounded variants.
+     * @protected Documents the boundary for internal orchestration and visualization apps. LLM query surfaces should use bounded variants.
      */
     getConceptTree(maxTier = 3) {
         this.ensureLoaded();
@@ -350,7 +350,7 @@ class ConceptService extends Base {
      * @param {Number} [minWeight=0] Minimum weight threshold for inclusion.
      * @returns {Array<Object>} Gap entries sorted by weight descending:
      *   `{concept, weight, tier, severity, missingEdgeTypes}`.
-     * @protected Intended for internal orchestration. LLM query surfaces should use findGapsRelevantTo.
+     * @protected Documents the boundary for internal orchestration. LLM query surfaces should use findGapsRelevantTo.
      */
     findGuideGaps(minWeight = 0) {
         this.ensureLoaded();
@@ -399,7 +399,7 @@ class ConceptService extends Base {
      *
      * @param {String} classPath Repository-relative path (e.g., `'src/data/Store.mjs'`).
      * @param {Object} [options]
-     * @param {Number} [options.limit=5] Max concepts to return. Default 5 prevents context bloat.
+     * @param {Number} [options.limit=5] Max concepts to return. Default 5 prevents context bloat. Pass 0 for unbounded.
      * @returns {Array<Object>} Concept nodes that reference this file.
      */
     classifyConcept(classPath, {limit = 5} = {}) {
@@ -553,7 +553,7 @@ class ConceptService extends Base {
      *
      * @param {String} conceptId The concept ID to look up analogues for.
      * @returns {Array<Object>} ANALOGOUS_TO edges with `{source, target, type, note}`.
-     * @protected Intended for internal orchestration.
+     * @protected Documents the boundary for internal orchestration.
      */
     getAnalogousConcepts(conceptId) {
         this.ensureLoaded();

--- a/test/playwright/unit/ai/services/ConceptService.spec.mjs
+++ b/test/playwright/unit/ai/services/ConceptService.spec.mjs
@@ -308,7 +308,6 @@ test.describe('Neo.ai.services.ConceptService', () => {
         ConceptService.loadGraph();
 
         const results = ConceptService.findConceptsRelevantTo('I need to fix the grid component', {limit: 2});
-        
         expect(results.length).toBe(2);
         expect(results[0].id).toBe('c1');
         expect(results[1].id).toBe('c2');

--- a/test/playwright/unit/ai/services/ConceptService.spec.mjs
+++ b/test/playwright/unit/ai/services/ConceptService.spec.mjs
@@ -268,6 +268,79 @@ test.describe('Neo.ai.services.ConceptService', () => {
         fs.rmSync(tmpDir, {recursive: true});
     });
 
+    test('classifyConcept should respect the limit parameter', () => {
+        const nodes = [
+            {id: 'c1', name: 'C1', tier: 1, description: 'A', uniqueToNeo: false, tags: []},
+            {id: 'c2', name: 'C2', tier: 1, description: 'B', uniqueToNeo: false, tags: []},
+            {id: 'c3', name: 'C3', tier: 1, description: 'C', uniqueToNeo: false, tags: []}
+        ];
+        const edges = [
+            {source: 'c1', target: 'file:src/shared/Foo.mjs', type: 'IMPLEMENTED_BY'},
+            {source: 'c2', target: 'file:src/shared/Foo.mjs', type: 'IMPLEMENTED_BY'},
+            {source: 'c3', target: 'file:src/shared/Foo.mjs', type: 'IMPLEMENTED_BY'}
+        ];
+        const tmpDir = createTestFixture(nodes, edges);
+
+        ConceptService.defaultConceptsDir = tmpDir;
+        ConceptService.loadGraph();
+
+        const defaultResult = ConceptService.classifyConcept('src/shared/Foo.mjs');
+        expect(defaultResult.length).toBe(3);
+
+        const limitedResult = ConceptService.classifyConcept('src/shared/Foo.mjs', {limit: 2});
+        expect(limitedResult.length).toBe(2);
+
+        fs.rmSync(tmpDir, {recursive: true});
+    });
+
+    // ── findConceptsRelevantTo ────────────────────────────────
+
+    test('findConceptsRelevantTo should rank matches and respect limits', () => {
+        const nodes = [
+            {id: 'c1', name: 'Grid Component', tier: 1, description: 'Main grid component', uniqueToNeo: false, tags: ['grid']},
+            {id: 'c2', name: 'Grid Row', tier: 2, description: 'Row for grid', uniqueToNeo: false, tags: ['grid', 'row']},
+            {id: 'c3', name: 'Grid Cell', tier: 3, description: 'Cell for grid row', uniqueToNeo: false, tags: ['grid', 'cell']},
+            {id: 'c4', name: 'Button', tier: 1, description: 'Clickable button', uniqueToNeo: false, tags: ['button']}
+        ];
+        const tmpDir = createTestFixture(nodes, []);
+
+        ConceptService.defaultConceptsDir = tmpDir;
+        ConceptService.loadGraph();
+
+        const results = ConceptService.findConceptsRelevantTo('I need to fix the grid component', {limit: 2});
+        
+        expect(results.length).toBe(2);
+        expect(results[0].id).toBe('c1');
+        expect(results[1].id).toBe('c2');
+
+        fs.rmSync(tmpDir, {recursive: true});
+    });
+
+    // ── findGapsRelevantTo ────────────────────────────────────
+
+    test('findGapsRelevantTo should return missing gaps filtered by relevance and limit', () => {
+        const nodes = [
+            {id: 'c1', name: 'Grid Component', tier: 1, description: 'Main grid', uniqueToNeo: false, tags: ['grid']},
+            {id: 'c2', name: 'Grid View', tier: 2, description: 'Grid visual', uniqueToNeo: false, tags: ['grid']},
+            {id: 'c3', name: 'Button', tier: 1, description: 'Button', uniqueToNeo: false, tags: ['button']}
+        ];
+        const edges = [
+            {source: 'c3', target: 'file:learn/guides/Button.md', type: 'EXPLAINED_BY'}
+        ];
+        const tmpDir = createTestFixture(nodes, edges);
+
+        ConceptService.defaultConceptsDir = tmpDir;
+        ConceptService.loadGraph();
+
+        const gaps = ConceptService.findGapsRelevantTo('Document the grid component', {limit: 1});
+
+        expect(gaps.length).toBe(1);
+        expect(gaps[0].concept.id).toBe('c1');
+        expect(gaps[0].missingEdgeTypes).toContain('EXPLAINED_BY');
+
+        fs.rmSync(tmpDir, {recursive: true});
+    });
+
     // ── getConceptTree ────────────────────────────────────────
 
     test('getConceptTree should build a nested tree from the anchor', () => {


### PR DESCRIPTION
## Summary

Resolves #10080

Enhances the `ConceptService` ontology query surface with relevance-bounded APIs to prevent context-window flooding during agent operation.

### Changes

- **New Bounded APIs:** Added `findConceptsRelevantTo(taskDescription, {limit})` and `findGapsRelevantTo(taskDescription, {limit, minWeight})`. Both default to a `limit` of 5.
- **Updated API:** `classifyConcept` now supports an optional `limit` parameter (defaults to 5, unbounded behavior via 0).
- **API Protection:** `getConceptTree`, `findGuideGaps`, and `getAnalogousConcepts` are now annotated with `@protected` to mark the architectural boundary and discourage unbounded LLM queries (this is a documented convention, not a mechanical enforcement).
- **Testing:** Comprehensive Playwright unit tests implemented for new/updated APIs, ensuring limit logic and relevance ordering.

### Triad Swarm Context
- Lane C implementation.
- Prepares `ConceptService` for Phase 2 ChromaDB integration by establishing the semantic surface boundaries.
