### PR TITLE
chore(ai): add heartbeat token economy baseline (#10318)

### DIFF
--- a/learn/agentos/measurements/heartbeat-token-economy-2026-05.md
+++ b/learn/agentos/measurements/heartbeat-token-economy-2026-05.md
@@ -1,0 +1,119 @@
+# Swarm Heartbeat Token Economy Baseline (May 2026)
+
+This file captures the empirical token-economy anchor for the Track 1 swarm heartbeat under Epic #10311 and
+sub-issue #10318.
+
+## Summary
+
+The confirmed-empty heartbeat path is safe at the current 5 minute default:
+
+- **LLM prompt tokens:** `0`
+- **LLM MCP tool calls:** `0`
+- **Prompt injection:** skipped
+- **Measured token-economy gate latency:** approximately `0.58s` per pulse on this machine
+- **Measured current wrapper-cycle latency:** approximately `0.69s` per pulse including the failing TTL sweeper
+
+The zero-token result is not an estimate. `ai/scripts/swarm-heartbeat.sh` executes the deterministic checks before
+injecting a prompt and returns early when both actionable counters are zero:
+
+1. unread mailbox messages for the target agent identity
+2. open GitHub issues assigned to the active GitHub user
+
+If both counters are `0`, no `[SYSTEM HEARTBEAT]` prompt is sent to the harness. The LLM does not wake and therefore
+does not spend tokens or perform follow-up MCP calls.
+
+## Measurement Environment
+
+| Field | Value |
+| :--- | :--- |
+| Date | 2026-05-01 |
+| Checkout | `df5e33dbd` |
+| Platform | Darwin 25.4.0 arm64 |
+| Node.js | v25.9.0 |
+| SQLite | 3.51.0 |
+| GitHub CLI | 2.89.0 |
+| Ticket state during measurement | #10318 assigned to `@neo-gpt`, so the GitHub query returned one open assigned issue |
+
+The assigned-issue query was measured after claiming #10318. This means the current run did not represent an empty
+GitHub-assignment result, but the query path is the same. The empty-cycle token conclusion comes from the script's
+branch condition, not from the current issue count.
+
+## Component Latency
+
+| Component | Mean latency | Samples | Notes |
+| :--- | ---: | :--- | :--- |
+| Concurrency lock check | `2.9ms` | `5.2ms`, `1.9ms`, `1.6ms` | Lock absent; exit status `1` is expected for the shell `test -f` check. |
+| TTL sweeper invocation | `116.4ms` | `116.4ms` | Direct invocation exits non-zero; see caveat below. |
+| Push-capable subscription bypass query | `5.1ms` | `5.1ms`, `4.8ms`, `5.4ms` | Reads local SQLite `WAKE_SUBSCRIPTION` nodes. |
+| Unread-message query, empty probe identity | `5.3ms` | `5.9ms`, `5.2ms`, `4.9ms` | Reads local SQLite `MESSAGE` + `SENT_TO` graph state. |
+| Assigned-issues query | `564.8ms` | `622.1ms`, `560.7ms`, `513.2ms`, `565.0ms`, `563.0ms` | `gh issue list --assignee @me --state open --json number`; measured outside the sandbox. |
+
+The token-economy gate is dominated by GitHub network latency:
+
+```
+2.9ms + 5.1ms + 5.3ms + 564.8ms = 578.1ms
+```
+
+The current full wrapper cycle adds the failing TTL sweeper:
+
+```
+116.4ms + 578.1ms = 694.5ms
+```
+
+These are wall-clock latencies in the wrapper process, not LLM latency and not token cost.
+
+## TTL Sweeper Caveat
+
+The current heartbeat script also calls `ai/scripts/sweepExpiredTasks.mjs` before the token-economy fast path. Direct
+invocation currently exits non-zero after roughly `116ms` with:
+
+```
+ReferenceError: Neo is not defined
+```
+
+Because `swarm-heartbeat.sh` redirects the sweeper stderr to `/dev/null`, this failure is silent in the heartbeat
+loop and `expired` falls back to `0`. The local graph contained no A2A Task nodes during measurement, so no task state
+was changed by this probe.
+
+This caveat does not change the empty-cycle token budget, but it does mean the TTL sweeper's operational health should
+be fixed or tracked separately from #10318 before relying on heartbeat-driven task expiration.
+
+## Frequency Decision
+
+Keep the fallback heartbeat default at **5 minutes** for now.
+
+At 5 minutes:
+
+- One fallback-served agent can run up to `288` deterministic pulses per day.
+- Two fallback-served agents can run up to `576` deterministic pulses per day.
+- Three fallback-served agents can run up to `864` deterministic pulses per day.
+- Confirmed-empty pulses still cost `0` LLM tokens and `0` LLM MCP calls.
+
+At 15 minutes:
+
+- One fallback-served agent drops to `96` deterministic pulses per day.
+- Three fallback-served agents drop to `288` deterministic pulses per day.
+- The token budget stays `0` for confirmed-empty pulses, but wake latency becomes three times worse.
+
+Given the measured pre-inference latency and the strict zero-inference branch, 15 minutes is only justified when a
+host has GitHub API quota pressure, network constraints, or battery/CPU constraints. It should not become the default
+while heartbeat is still a fallback/watchdog lane.
+
+Do not tighten fallback polling below 5 minutes. ADR 0002 assigns the 30-60 second latency/token trade-off to the
+push-based wake substrate and its coalescing window; polling at that cadence would reintroduce the load pattern the
+push substrate was designed to avoid.
+
+## Architectural Boundary
+
+The heartbeat is not the primary long-term wake substrate. Per ADR 0002 §6.5, push-capable identities should bypass
+heartbeat polling, and the heartbeat should remain:
+
+- a system-level watchdog
+- a fallback for identities with `harnessTarget: 'disabled' | 'none'`
+- a diagnostic override for empirical bisection sessions
+
+The token-economy contract for confirmed-empty fallback pulses is therefore:
+
+```
+empty state -> deterministic wrapper checks only -> no prompt -> zero LLM tokens
+```

--- a/learn/tree.json
+++ b/learn/tree.json
@@ -38,6 +38,7 @@
         {"name": "Code Execution (AI SDK)",                            "parentId": "AgentOS",                                             "id": "agentos/CodeExecution"},
         {"name": "Measurements",                                       "parentId": "AgentOS",                            "isLeaf": false, "id": "AgentOS/Measurements", "collapsed": true},
             {"name": "PR Review Loaded-Surface Baseline (April 2026)", "parentId": "AgentOS/Measurements",                                "id": "agentos/measurements/pr-review-baseline-2026-04"},
+            {"name": "Swarm Heartbeat Token Economy Baseline (May 2026)", "parentId": "AgentOS/Measurements",                             "id": "agentos/measurements/heartbeat-token-economy-2026-05"},
         {"name": "Tooling & Configuration",                            "parentId": "AgentOS",                            "isLeaf": false, "id": "AgentOS/Tooling", "collapsed": true},
             {"name": "Server Authorization",                           "parentId": "AgentOS/Tooling",                                     "id": "agentos/tooling/Authorization"},
             {"name": "Google OAuth Demo",                              "parentId": "AgentOS/Tooling",                                     "id": "agentos/tooling/GoogleAuthDemo"},


### PR DESCRIPTION
Authored by GPT-5.5 (Codex Desktop). Session 8bf3d493-3ea1-4583-a6d6-12ae8347c87e.

Resolves #10318
Related: #10311

Adds a durable Agent OS measurement page for the swarm heartbeat token-economy baseline and wires it into `learn/tree.json` so the Knowledge Base can retrieve it. The measurement documents the confirmed-empty fallback path as zero prompt injection / zero LLM tokens, records local SQLite and GitHub query latency, and preserves the observed `sweepExpiredTasks.mjs` direct-invocation failure as a separate caveat instead of hiding it in the budget.

## Deltas from ticket
The ticket asked for token cost and safe polling frequency. The measurement also documents the architectural boundary from ADR 0002: heartbeat remains fallback/watchdog once push-capable wake delivery exists, not the primary long-term message bus.

## Test Evidence
- `git diff --check`
- `git diff --cached --check`
- `node -e "const fs=require('node:fs'); JSON.parse(fs.readFileSync('learn/tree.json','utf8')); console.log('learn/tree.json OK')"`
- Measured local heartbeat components on 2026-05-01: lock check `2.9ms`, push-bypass SQLite query `5.1ms`, unread SQLite query `5.3ms`, assigned-issues GitHub query `564.8ms` mean.
- Direct `node ai/scripts/sweepExpiredTasks.mjs` currently fails with `ReferenceError: Neo is not defined`; documented as a caveat, not fixed in this ticket.

## Post-Merge Validation
- [ ] Knowledge Base sync indexes `learn/agentos/measurements/heartbeat-token-economy-2026-05.md` and returns it for heartbeat token-economy queries.
- [ ] Decide whether the `sweepExpiredTasks.mjs` direct-invocation failure needs a dedicated follow-up ticket or belongs under existing Track 2C maintenance.

## Commit
- `02b7e9f5e` — `chore(ai): add heartbeat token economy baseline (#10318)`