### PR TITLE
fix(ai): import Neo prelude in sweepExpiredTasks + tighten heartbeat stderr (#10595)

### DIFF
--- a/ai/scripts/swarm-heartbeat.sh
+++ b/ai/scripts/swarm-heartbeat.sh
@@ -11,6 +11,12 @@ POLL_INTERVAL=${POLL_INTERVAL:-300} # 5 minutes default
 IDENTITY=${NEO_AGENT_IDENTITY:-"@neo-gemini-3-1-pro"}
 STATE_FILE="/tmp/neo-agent-state.txt"
 CONCURRENCY_LOCK=".neo-ai-data/heartbeat-concurrency.lock"
+# Persistent sweep-error log (#10595). Replaces the prior `2>/dev/null` mask on the
+# `sweepExpiredTasks.mjs` invocation, which silently hid the `ReferenceError: Neo is
+# not defined` regression for the entire lifetime of the bug. Failures now append here
+# so operators can `tail` the file when investigating heartbeat behavior. Co-located
+# with `bridge.log` under `wake-daemon/` (already in `DATA_SUBDIRS_TO_LINK` per #10432).
+SWEEP_LOG=".neo-ai-data/wake-daemon/sweep-errors.log"
 
 # Function to get unread messages count via SQLite fast-path
 get_unread_count() {
@@ -55,7 +61,11 @@ sweep_expired_tasks() {
         return
     fi
     local script_dir=$(dirname "$0")
-    local output=$(node "${script_dir}/sweepExpiredTasks.mjs" 2>/dev/null)
+    # Per #10595: stderr surfaces to $SWEEP_LOG (no longer silently masked to /dev/null).
+    # The prior `2>/dev/null` mask hid `ReferenceError: Neo is not defined` for the
+    # full lifetime of the regression empirically anchored in PR #10594's measurement.
+    # Stdout is still captured into $output for the JSON parse — only stderr changes.
+    local output=$(node "${script_dir}/sweepExpiredTasks.mjs" 2>>"$SWEEP_LOG")
     local count=$(echo "$output" | grep -oE '"sweptCount":[0-9]+' | grep -oE '[0-9]+$')
     echo "${count:-0}"
 }

--- a/ai/scripts/swarm-heartbeat.sh
+++ b/ai/scripts/swarm-heartbeat.sh
@@ -17,6 +17,11 @@ CONCURRENCY_LOCK=".neo-ai-data/heartbeat-concurrency.lock"
 # so operators can `tail` the file when investigating heartbeat behavior. Co-located
 # with `bridge.log` under `wake-daemon/` (already in `DATA_SUBDIRS_TO_LINK` per #10432).
 SWEEP_LOG=".neo-ai-data/wake-daemon/sweep-errors.log"
+# Ensure parent dir exists on fresh checkouts before any `2>>"$SWEEP_LOG"` redirection
+# fires (per @neo-gpt's PR #10597 cycle 1 review). Without this guard, a clone that
+# hasn't yet symlinked `wake-daemon/` via `bootstrapWorktree.mjs --link-data` would
+# fail the redirect at shell-parse time and silently bypass the intended log surface.
+mkdir -p "$(dirname "$SWEEP_LOG")"
 
 # Function to get unread messages count via SQLite fast-path
 get_unread_count() {

--- a/ai/scripts/sweepExpiredTasks.mjs
+++ b/ai/scripts/sweepExpiredTasks.mjs
@@ -18,6 +18,14 @@
  *   node ai/scripts/sweepExpiredTasks.mjs
  *   # → {"success":true,"sweptCount":3}
  */
+// IMPORTANT: `Neo` MUST be imported BEFORE any module that uses `Neo.gatekeep()` /
+// `Neo.setupClass()` at module-load time (e.g. `src/core/Compare.mjs`, transitively
+// pulled in via the LifecycleService → GraphService → SQLite import chain). Without
+// this prelude the script crashes at module-load with `ReferenceError: Neo is not
+// defined` (regression originally surfaced empirically by @neo-gpt during the #10318
+// heartbeat token-economy measurement, fixed under #10595).
+import Neo              from '../../src/Neo.mjs';
+import * as core        from '../../src/core/_export.mjs';
 import LifecycleService from '../mcp/server/memory-core/services/lifecycle/SystemLifecycleService.mjs';
 import MailboxService   from '../mcp/server/memory-core/services/MailboxService.mjs';
 

--- a/test/playwright/unit/ai/scripts/sweepExpiredTasks.spec.mjs
+++ b/test/playwright/unit/ai/scripts/sweepExpiredTasks.spec.mjs
@@ -1,0 +1,92 @@
+import {setup} from '../../../setup.mjs';
+
+const appName = 'SweepExpiredTasksRegressionTest';
+
+setup({
+    neoConfig: {
+        unitTestMode: true
+    },
+    appConfig: {
+        name             : appName,
+        isMounted        : () => true,
+        vnodeInitialising: false
+    }
+});
+
+import {test, expect} from '@playwright/test';
+import {execFile}     from 'child_process';
+import {promisify}    from 'util';
+import path           from 'path';
+import {fileURLToPath} from 'url';
+
+const execFileAsync = promisify(execFile);
+
+const __filename  = fileURLToPath(import.meta.url);
+const __dirname   = path.dirname(__filename);
+const projectRoot = path.resolve(__dirname, '..', '..', '..', '..', '..');
+const scriptPath  = path.join(projectRoot, 'ai', 'scripts', 'sweepExpiredTasks.mjs');
+
+/**
+ * @summary Regression-guard for #10595 — `sweepExpiredTasks.mjs` direct-invocation
+ * Neo-not-defined ReferenceError class.
+ *
+ * The pre-fix script imported `LifecycleService` at module-load time, which transitively
+ * pulled `src/core/Compare.mjs` whose final line is `Neo.gatekeep(Compare, 'Neo.core.Compare', ...)`
+ * — but Neo itself wasn't imported by the script. Result: every direct invocation crashed
+ * at module-load with `ReferenceError: Neo is not defined`. The fix (per #10595) added
+ * `import Neo from '../../src/Neo.mjs'` + `import * as core from '../../src/core/_export.mjs'`
+ * before the LifecycleService import, populating the global Neo reference before the
+ * Compare.mjs gatekeep call.
+ *
+ * Empirically anchored to PR #10594's `## TTL Sweeper Caveat` measurement section.
+ *
+ * This spec spawns the script via `execFile` (subprocess) rather than dynamic-importing
+ * it directly — the script ends with an unconditional `main()` call that performs SQLite
+ * I/O and `process.exit()`, so importing it from a Playwright test would race the test
+ * runner and exit Node prematurely.
+ *
+ * The regression class manifests at module-LOAD time (before any DB I/O), so the spec
+ * doesn't need fixture-graph setup; running against the worktree's actual SQLite is
+ * sufficient — a `ReferenceError: Neo is not defined` would surface deterministically
+ * regardless of graph state.
+ */
+test.describe('ai/scripts/sweepExpiredTasks.mjs regression guard (#10595)', () => {
+    test('script exits 0 with success JSON on stdout (no Neo-not-defined regression)', async () => {
+        const {stdout, stderr} = await execFileAsync('node', [scriptPath], {
+            cwd: projectRoot,
+            // 30s ceiling; happy path completes in <500ms based on measurement page
+            timeout: 30000
+        });
+
+        // Stderr should NOT contain the regression-class signature.
+        expect(stderr).not.toContain('ReferenceError: Neo is not defined');
+
+        // Stdout should be exactly one JSON line: {"success":true,"sweptCount":<n>}
+        const trimmed = stdout.trim();
+        expect(trimmed).toMatch(/^\{"success":true,"sweptCount":\d+\}$/);
+
+        const payload = JSON.parse(trimmed);
+        expect(payload.success).toBe(true);
+        expect(typeof payload.sweptCount).toBe('number');
+        expect(payload.sweptCount).toBeGreaterThanOrEqual(0);
+    });
+
+    test('script imports Neo prelude before LifecycleService (regression-class structural guard)', async () => {
+        // Static check: the file's top imports MUST include `Neo` and `core/_export` before
+        // any `mcp/server/memory-core/services/` module that transitively uses Neo.gatekeep.
+        // This is the structural invariant the runtime test above verifies behaviorally.
+        const {default: fs}   = await import('fs-extra');
+        const content         = await fs.readFile(scriptPath, 'utf-8');
+        const lines           = content.split('\n');
+        const neoImportIdx    = lines.findIndex(l => /^import\s+Neo\s+from\s+['"]\.\.\/\.\.\/src\/Neo\.mjs['"]/.test(l));
+        const coreImportIdx   = lines.findIndex(l => /^import\s+\*\s+as\s+core\s+from\s+['"]\.\.\/\.\.\/src\/core\/_export\.mjs['"]/.test(l));
+        const lifecycleIdx    = lines.findIndex(l => /^import\s+LifecycleService\s+from\s+['"]\.\.\/mcp\/server\/memory-core\/services\/lifecycle\/SystemLifecycleService\.mjs['"]/.test(l));
+
+        // All three imports MUST be present and ordered correctly.
+        expect(neoImportIdx).toBeGreaterThanOrEqual(0);
+        expect(coreImportIdx).toBeGreaterThanOrEqual(0);
+        expect(lifecycleIdx).toBeGreaterThanOrEqual(0);
+        expect(neoImportIdx).toBeLessThan(lifecycleIdx);
+        expect(coreImportIdx).toBeLessThan(lifecycleIdx);
+    });
+});

--- a/test/playwright/unit/ai/scripts/sweepExpiredTasks.spec.mjs
+++ b/test/playwright/unit/ai/scripts/sweepExpiredTasks.spec.mjs
@@ -13,13 +13,9 @@ setup({
     }
 });
 
-import {test, expect} from '@playwright/test';
-import {execFile}     from 'child_process';
-import {promisify}    from 'util';
-import path           from 'path';
+import {test, expect}  from '@playwright/test';
+import path            from 'path';
 import {fileURLToPath} from 'url';
-
-const execFileAsync = promisify(execFile);
 
 const __filename  = fileURLToPath(import.meta.url);
 const __dirname   = path.dirname(__filename);
@@ -51,25 +47,21 @@ const scriptPath  = path.join(projectRoot, 'ai', 'scripts', 'sweepExpiredTasks.m
  * regardless of graph state.
  */
 test.describe('ai/scripts/sweepExpiredTasks.mjs regression guard (#10595)', () => {
-    test('script exits 0 with success JSON on stdout (no Neo-not-defined regression)', async () => {
-        const {stdout, stderr} = await execFileAsync('node', [scriptPath], {
-            cwd: projectRoot,
-            // 30s ceiling; happy path completes in <500ms based on measurement page
-            timeout: 30000
-        });
-
-        // Stderr should NOT contain the regression-class signature.
-        expect(stderr).not.toContain('ReferenceError: Neo is not defined');
-
-        // Stdout should be exactly one JSON line: {"success":true,"sweptCount":<n>}
-        const trimmed = stdout.trim();
-        expect(trimmed).toMatch(/^\{"success":true,"sweptCount":\d+\}$/);
-
-        const payload = JSON.parse(trimmed);
-        expect(payload.success).toBe(true);
-        expect(typeof payload.sweptCount).toBe('number');
-        expect(payload.sweptCount).toBeGreaterThanOrEqual(0);
-    });
+    // Note: a behavioral subprocess invocation of the script (`node ai/scripts/sweepExpiredTasks.mjs`)
+    // would catch the `Neo is not defined` regression class behaviorally, BUT
+    // `MailboxService.sweepExpiredTasks()` performs a bulk SQL UPDATE that mutates the
+    // worktree's live `.neo-ai-data/sqlite/memory-core-graph.sqlite` — it transitions
+    // `Submitted`/`Working`/`InputRequired` tasks past `expiresAt` to `Expired`. Running
+    // that mutation under a unit-test runner against the production graph is unsafe per
+    // @neo-gpt's PR #10597 review feedback. A fixture-DB-isolated behavioral test would
+    // require non-trivial config-injection plumbing (`aiConfig.data.dbPath` swap +
+    // LifecycleService re-init) that is out of scope for this regression-guard.
+    //
+    // The structural import-order test below is sufficient to catch the regression class:
+    // the failure mode is at module-LOAD time (before any DB I/O), and it manifests
+    // deterministically when `Neo` isn't imported before `Compare.mjs` is transitively
+    // pulled in via the LifecycleService chain. If a future commit reorders or removes
+    // the prelude, the structural assertion fires.
 
     test('script imports Neo prelude before LifecycleService (regression-class structural guard)', async () => {
         // Static check: the file's top imports MUST include `Neo` and `core/_export` before


### PR DESCRIPTION
Authored by Claude Opus 4.7 (Claude Code). Session 86b7a3a0-7b14-4bd1-b707-52c5741aaeeb.

Resolves #10595

`ai/scripts/sweepExpiredTasks.mjs` direct-invocation crashed at module-load with `ReferenceError: Neo is not defined`, silently masked by `swarm-heartbeat.sh`'s `2>/dev/null` redirect. Empirical regression originally surfaced by @neo-gpt during PR #10594's heartbeat token-economy measurement (see that PR's `## TTL Sweeper Caveat`).

## Phase 1 — Root cause (diagnosed)

`src/core/Compare.mjs:166` invokes `Neo.gatekeep(Compare, 'Neo.core.Compare', ...)` at module-load time. The pre-fix script imported `LifecycleService` directly without first importing `Neo` — the gatekeep call hit a global Neo reference that hadn't been populated. Sibling working scripts (`buildScripts/ai/runSandman.mjs`, `buildScripts/ai/runGoldenPath.mjs`) explicitly import `Neo` + `core/_export` before the LifecycleService import for exactly this reason.

Diagnostic capture:
```
$ node ai/scripts/sweepExpiredTasks.mjs
src/core/Compare.mjs:166
export default Neo.gatekeep(Compare, 'Neo.core.Compare', () => {
               ^
ReferenceError: Neo is not defined
```

## Phase 2 — Fix (shipped)

Added the canonical Neo prelude to `ai/scripts/sweepExpiredTasks.mjs`:

```js
import Neo              from '../../src/Neo.mjs';
import * as core        from '../../src/core/_export.mjs';
import LifecycleService from '../mcp/server/memory-core/services/lifecycle/SystemLifecycleService.mjs';
import MailboxService   from '../mcp/server/memory-core/services/MailboxService.mjs';
```

Plus a JSDoc comment block explaining the prelude's load-bearing role for the next agent reading the file.

Post-fix verification:
```
$ node ai/scripts/sweepExpiredTasks.mjs
{"success":true,"sweptCount":0}
```

Exit code 0, stdout matches the JSDoc-spec single-JSON-line contract.

## Phase 3 — Stop the silent mask (shipped)

`swarm-heartbeat.sh` previously redirected the sweeper's stderr to `/dev/null`, which is what allowed this regression to persist undetected for the lifetime of the bug. Replaced with append-to-log:

- New variable: `SWEEP_LOG=".neo-ai-data/wake-daemon/sweep-errors.log"` (co-located with `bridge.log` under `wake-daemon/` which is already in `DATA_SUBDIRS_TO_LINK` per #10432, so the log auto-unifies across cross-clone worktrees).
- `mkdir -p "$(dirname "$SWEEP_LOG")"` immediately after the variable declaration to guard against fresh-checkout cases where the parent dir doesn't exist yet (per @neo-gpt's PR #10597 cycle 1 review).
- Replaced `2>/dev/null` with `2>>"$SWEEP_LOG"` on the sweeper invocation.
- Comment blocks at both placements document the rationale for future agents reading the script.

Stdout-side capture (the JSON payload parsed for `sweptCount`) is unchanged — only stderr semantics shift.

## Phase 4 — Regression-guard spec (shipped)

New `test/playwright/unit/ai/scripts/sweepExpiredTasks.spec.mjs` with **1 structural test**:

**Structural import-order test** — static text-grep on the script verifying that `import Neo` + `import * as core` lines exist AND appear BEFORE the `LifecycleService` import. Catches future regressions where someone reorders imports without realizing the prelude order is load-bearing. Runs in <1s with no side-effects.

A behavioral subprocess invocation (originally drafted in cycle 1 of this PR) was **removed per @neo-gpt's review feedback**: `MailboxService.sweepExpiredTasks()` performs a bulk SQL UPDATE to the worktree's live `.neo-ai-data/sqlite/memory-core-graph.sqlite` (transitions `Submitted`/`Working`/`InputRequired` tasks past `expiresAt` to `Expired`). Running that mutation under the unit-test runner against the production graph is unsafe. A fixture-DB-isolated behavioral test would require non-trivial config-injection plumbing (`aiConfig.data.dbPath` swap + LifecycleService re-init) that's out-of-scope for this regression-guard. The structural test is sufficient to catch the regression class because the failure mode is at module-LOAD time (before any DB I/O).

The spec includes a multi-paragraph comment block explaining the deferral so future agents don't re-introduce the unsafe behavioral test.

## Deltas from ticket

**AC5 partial — fixture-DB behavioral coverage deferred.** The original AC said "Phase 4 Playwright spec added — covers the script's main entry path against an empty-graph fixture." The current implementation covers the structural import-order regression-class via static text-grep, NOT the script's main entry path against a fixture graph. The behavioral coverage deferral was a Cycle 1 review-driven scope reduction (DB-write safety vs unit-test runner), and I didn't update the PR body to reflect it before Cycle 2 — surfaced by GPT as the remaining cycle 2 RA. Updated now.

The fixture-DB behavioral coverage is filed as out-of-scope follow-up shape: when a fixture-DB pattern emerges across the broader test suite (most likely as part of the multi-tenant Memory Core test infrastructure already in flight), the sweepExpiredTasks behavioral coverage can chain off it. For this PR's regression-guard scope, the structural test plus PR #10594's empirical measurement-page anchor is sufficient evidence of the fix.

All other ACs satisfied:
- (AC1) `node ai/scripts/sweepExpiredTasks.mjs` exits 0 — verified empirically.
- (AC2) Phase 1 diagnosis: root cause is `Compare.mjs:166` `Neo.gatekeep` consumed before Neo populated; fix is the canonical prelude import.
- (AC3) Phase 2 patch shipped: minimal-surface (2 import lines + JSDoc comment).
- (AC4) Phase 3 stderr-redirect tightening shipped: failures now surface to `.neo-ai-data/wake-daemon/sweep-errors.log` with parent-dir mkdir guard.
- (AC5) Phase 4 structural spec shipped (behavioral coverage deferred per cycle 1 review — see Deltas above).
- (AC6) Sweeper cycle is now functional (sweptCount: 0 against empty graph; would actually transition tasks if the graph had expired ones). Re-measurement against PR #10594's methodology is the post-merge validation step.

## Test Evidence

```
$ git diff origin/dev --stat
 ai/scripts/swarm-heartbeat.sh                      | 17 ++++-
 ai/scripts/sweepExpiredTasks.mjs                   |  8 +++
 .../unit/ai/scripts/sweepExpiredTasks.spec.mjs     | 84 ++++++++++++++++++++++
 3 files changed, 108 insertions(+), 1 deletion(-)

$ npx playwright test test/playwright/unit/ai/scripts/sweepExpiredTasks.spec.mjs --reporter=line
  1 passed (930ms)
```

Plus the empirical end-to-end direct-invocation: `node ai/scripts/sweepExpiredTasks.mjs` → `{"success":true,"sweptCount":0}` (exit 0).

## Post-Merge Validation

- [ ] On next operator-triggered `swarm-heartbeat.sh` cycle, confirm `.neo-ai-data/wake-daemon/sweep-errors.log` either stays empty (sweeper succeeds) or captures any future regression (sweeper fails with operator-visible stderr).
- [ ] Re-measure heartbeat token-economy after this fix lands per @neo-gpt's PR #10594 methodology — confirm sweeper component shifts from "fast-fail at 116ms" to "actual successful sweep at ~Xms".
- [ ] (Out of scope follow-up) When fixture-DB pattern emerges in the broader test suite, add behavioral coverage for the script's main entry path against an empty-graph fixture per #10595 AC5.

## Cross-family mandate

Code change with runtime impact (script + bash heartbeat + new spec). Cross-family Approved review required for merge eligibility per `.agents/skills/pull-request/references/pull-request-workflow.md` §6.1. Single-peer review request follows.

## Provenance

- Empirical anchor: PR [#10594](https://github.com/neomjs/neo/pull/10594) `## TTL Sweeper Caveat` section — the measurement that surfaced this regression.
- Architectural lineage: [#10311](https://github.com/neomjs/neo/issues/10311) Track 2C task expiration → [#10339](https://github.com/neomjs/neo/issues/10339) original sweeper implementation (closed) → #10595 (this PR) regression fix.

## Evolution

- **Cycle 1 → Cycle 2 (this update):** Original draft included a behavioral subprocess test invoking the script against the live graph. @neo-gpt's review correctly flagged it as unsafe (DB-write under unit-test runner). Behavioral coverage deferred to fixture-DB follow-up; structural test retained. PR body updated in cycle 2.5 to match current code per @neo-gpt's cycle 2 follow-up RA.

🤖 Generated with [Claude Code](https://claude.com/claude-code)