### PR TITLE
feat(ai): add heartbeat concurrency mutex helper (#10319)

### DIFF
--- a/ai/scripts/heartbeatLock.mjs
+++ b/ai/scripts/heartbeatLock.mjs
@@ -1,0 +1,179 @@
+#!/usr/bin/env node
+/**
+ * @summary Wraps expensive Agent OS work with the swarm heartbeat concurrency lock.
+ *
+ * The fallback heartbeat is a watchdog, not a work scheduler. When an agent is already
+ * executing expensive work, overlapping heartbeat pulses should skip rather than queue.
+ * This helper owns the producer side of `.neo-ai-data/heartbeat-concurrency.lock`: create
+ * the lock before the work starts and remove it in a `finally` block after the work ends.
+ *
+ * The companion consumer is `ai/scripts/swarm-heartbeat.sh`, which treats the lock as an
+ * absolute skip barrier until the configured stale-lock TTL expires.
+ *
+ * @example
+ *   node ai/scripts/heartbeatLock.mjs -- npx playwright test test/playwright/unit/foo.spec.mjs
+ *
+ * @see https://github.com/neomjs/neo/issues/10319
+ * @see ai/scripts/swarm-heartbeat.sh
+ */
+import {spawn} from 'child_process';
+import fs      from 'fs-extra';
+import path    from 'path';
+import {fileURLToPath} from 'url';
+
+export const HEARTBEAT_LOCK_PATH = '.neo-ai-data/heartbeat-concurrency.lock';
+export const DEFAULT_STALE_LOCK_MS = 30 * 60 * 1000;
+
+/**
+ * @summary Creates the heartbeat concurrency lock before expensive Agent OS work starts.
+ *
+ * The JSON payload is intentionally tiny and diagnostic-only; `swarm-heartbeat.sh`
+ * depends only on file presence so a partial write cannot corrupt heartbeat semantics.
+ *
+ * @param {object} [options]
+ * @param {string} [options.lockPath=HEARTBEAT_LOCK_PATH] Lock file path consumed by the heartbeat.
+ * @param {object} [options.metadata] Diagnostic metadata for operators inspecting the lock.
+ * @returns {Promise<string>} The created lock path.
+ */
+export async function acquireHeartbeatLock({
+    lockPath = HEARTBEAT_LOCK_PATH,
+    metadata = {}
+} = {}) {
+    await fs.ensureDir(path.dirname(lockPath));
+    await fs.writeJson(lockPath, {
+        createdAt: new Date().toISOString(),
+        pid      : process.pid,
+        ...metadata
+    }, {spaces: 2});
+
+    return lockPath
+}
+
+/**
+ * @summary Clears the heartbeat concurrency lock after expensive Agent OS work finishes.
+ *
+ * Removal is idempotent so `finally` blocks can call it safely even after partial setup,
+ * signal handling, or prior cleanup by a stale-lock recovery path.
+ *
+ * @param {object} [options]
+ * @param {string} [options.lockPath=HEARTBEAT_LOCK_PATH] Lock file path to remove.
+ * @returns {Promise<void>}
+ */
+export async function releaseHeartbeatLock({lockPath = HEARTBEAT_LOCK_PATH} = {}) {
+    await fs.remove(lockPath)
+}
+
+/**
+ * @summary Reports whether a heartbeat lock is active, missing, or stale.
+ *
+ * This mirrors the shell-side stale-lock semantics so tests and command wrappers can share
+ * the same 30-minute recovery contract without relying on shell `stat` portability.
+ *
+ * @param {object} [options]
+ * @param {string} [options.lockPath=HEARTBEAT_LOCK_PATH] Lock file path to inspect.
+ * @param {number} [options.staleAfterMs=DEFAULT_STALE_LOCK_MS] Stale-lock TTL.
+ * @param {Date}   [options.now=new Date()] Time source for deterministic tests.
+ * @returns {Promise<{active: Boolean, stale: Boolean, ageMs: Number|null}>}
+ */
+export async function inspectHeartbeatLock({
+    lockPath = HEARTBEAT_LOCK_PATH,
+    staleAfterMs = DEFAULT_STALE_LOCK_MS,
+    now = new Date()
+} = {}) {
+    const stat = await fs.stat(lockPath).catch(() => null);
+
+    if (!stat) {
+        return {active: false, stale: false, ageMs: null}
+    }
+
+    const ageMs = Math.max(0, now.getTime() - stat.mtime.getTime());
+    const stale = ageMs > staleAfterMs;
+
+    return {
+        active: !stale,
+        stale,
+        ageMs
+    }
+}
+
+/**
+ * @summary Runs an async task while holding the heartbeat concurrency lock.
+ *
+ * The `finally` release is the load-bearing guarantee for #10319: long Playwright runs,
+ * memory extraction, and other expensive tasks can prevent overlapping heartbeat pulses
+ * without leaving the fallback wake substrate permanently disabled.
+ *
+ * @param {Function} task Async task to execute while the lock is held.
+ * @param {object}   [options] Options forwarded to {@link acquireHeartbeatLock}.
+ * @returns {Promise<*>} The task result.
+ */
+export async function withHeartbeatLock(task, options = {}) {
+    await acquireHeartbeatLock(options);
+
+    try {
+        return await task()
+    } finally {
+        await releaseHeartbeatLock(options)
+    }
+}
+
+/**
+ * @summary Executes a subprocess while holding the heartbeat concurrency lock.
+ *
+ * Exposed for the CLI path so agents can wrap expensive shell commands without hand-writing
+ * `touch` / `rm` pairs and risking cleanup omissions.
+ *
+ * @param {string}   command Command to spawn.
+ * @param {string[]} [args=[]] Command arguments.
+ * @param {object}   [options] Lock and spawn options.
+ * @returns {Promise<number>} Subprocess exit code.
+ */
+export async function runCommandWithHeartbeatLock(command, args = [], options = {}) {
+    const {
+        lockPath,
+        metadata = {},
+        cwd = process.cwd(),
+        env = process.env
+    } = options;
+
+    return withHeartbeatLock(() => new Promise((resolve, reject) => {
+        const child = spawn(command, args, {
+            cwd,
+            env,
+            stdio: 'inherit'
+        });
+
+        child.on('error', reject);
+        child.on('exit', code => resolve(code ?? 1));
+    }), {
+        lockPath,
+        metadata: {
+            command: [command, ...args].join(' '),
+            ...metadata
+        }
+    })
+}
+
+function printUsage() {
+    console.error('Usage: node ai/scripts/heartbeatLock.mjs -- <command> [args...]')
+}
+
+const isMain = process.argv[1] && fileURLToPath(import.meta.url) === path.resolve(process.argv[1]);
+
+if (isMain) {
+    const separatorIndex = process.argv.indexOf('--');
+    const commandArgs    = separatorIndex === -1 ? process.argv.slice(2) : process.argv.slice(separatorIndex + 1);
+    const [command, ...args] = commandArgs;
+
+    if (!command) {
+        printUsage();
+        process.exit(2)
+    }
+
+    runCommandWithHeartbeatLock(command, args).then(code => {
+        process.exit(code)
+    }).catch(error => {
+        console.error(`heartbeatLock failed: ${error.message}`);
+        process.exit(1)
+    })
+}

--- a/ai/scripts/swarm-heartbeat.sh
+++ b/ai/scripts/swarm-heartbeat.sh
@@ -11,6 +11,7 @@ POLL_INTERVAL=${POLL_INTERVAL:-300} # 5 minutes default
 IDENTITY=${NEO_AGENT_IDENTITY:-"@neo-gemini-3-1-pro"}
 STATE_FILE="/tmp/neo-agent-state.txt"
 CONCURRENCY_LOCK=".neo-ai-data/heartbeat-concurrency.lock"
+HEARTBEAT_LOCK_TTL_SECONDS=${HEARTBEAT_LOCK_TTL_SECONDS:-1800} # 30 minutes
 # Persistent sweep-error log (#10595). Replaces the prior `2>/dev/null` mask on the
 # `sweepExpiredTasks.mjs` invocation, which silently hid the `ReferenceError: Neo is
 # not defined` regression for the entire lifetime of the bug. Failures now append here
@@ -22,6 +23,39 @@ SWEEP_LOG=".neo-ai-data/wake-daemon/sweep-errors.log"
 # hasn't yet symlinked `wake-daemon/` via `bootstrapWorktree.mjs --link-data` would
 # fail the redirect at shell-parse time and silently bypass the intended log surface.
 mkdir -p "$(dirname "$SWEEP_LOG")"
+
+# Returns the mtime of a file on macOS (stat -f) or Linux (stat -c).
+file_mtime_seconds() {
+    stat -f "%m" "$1" 2>/dev/null || stat -c "%Y" "$1" 2>/dev/null
+}
+
+# Heartbeat concurrency semantics (#10319):
+# - Lock present and fresh  => current pulse is skipped.
+# - Lock present and stale  => lock is cleared; current pulse may continue.
+# - Lock absent             => current pulse may continue.
+# Missed pulses are not queued; the next pulse re-reads Memory Core state.
+heartbeat_lock_active() {
+    if [ ! -f "$CONCURRENCY_LOCK" ]; then
+        return 1
+    fi
+
+    local mtime=$(file_mtime_seconds "$CONCURRENCY_LOCK")
+    if [ -z "$mtime" ]; then
+        echo "[heartbeat $(date -Iseconds)] concurrency lock unreadable; skipping pulse" >&2
+        return 0
+    fi
+
+    local now=$(date +%s)
+    local age=$((now - mtime))
+
+    if [ "$age" -gt "$HEARTBEAT_LOCK_TTL_SECONDS" ]; then
+        echo "[heartbeat $(date -Iseconds)] clearing stale concurrency lock (${age}s old)" >&2
+        rm -f "$CONCURRENCY_LOCK"
+        return 1
+    fi
+
+    return 0
+}
 
 # Function to get unread messages count via SQLite fast-path
 get_unread_count() {
@@ -80,8 +114,8 @@ heartbeat_pulse() {
     while true; do
         sleep $POLL_INTERVAL
 
-        # Concurrency Trap: Skip if agent is busy (lock exists)
-        if [ -f "$CONCURRENCY_LOCK" ]; then
+        # Concurrency Trap: skip if expensive agent work is already running.
+        if heartbeat_lock_active; then
             continue
         fi
 

--- a/learn/agentos/measurements/heartbeat-token-economy-2026-05.md
+++ b/learn/agentos/measurements/heartbeat-token-economy-2026-05.md
@@ -103,6 +103,29 @@ Do not tighten fallback polling below 5 minutes. ADR 0002 assigns the 30-60 seco
 push-based wake substrate and its coalescing window; polling at that cadence would reintroduce the load pattern the
 push substrate was designed to avoid.
 
+## Concurrency Semantics
+
+The heartbeat uses a file mutex at `.neo-ai-data/heartbeat-concurrency.lock` to prevent overlapping pulses while an
+agent is already performing expensive work.
+
+The semantics are deliberately skip-based:
+
+- **Fresh lock present:** skip the current pulse.
+- **No lock:** run the deterministic heartbeat checks.
+- **Stale lock:** clear the lock and continue. The default stale-lock threshold is `30` minutes
+  (`HEARTBEAT_LOCK_TTL_SECONDS=1800`).
+- **Missed pulses:** do not queue. The next successful pulse re-reads Memory Core and GitHub state.
+
+Agents and scripts can wrap expensive work with:
+
+```bash
+node ai/scripts/heartbeatLock.mjs -- npx playwright test test/playwright/unit/foo.spec.mjs
+```
+
+The wrapper creates the lock before the command starts and removes it in a `finally` path after the command exits,
+including failure exits. This preserves the heartbeat as a fallback/watchdog: idle sessions can still be pulsed,
+while long-running inference, test, memory extraction, or review jobs can suppress overlapping heartbeat injections.
+
 ## Architectural Boundary
 
 The heartbeat is not the primary long-term wake substrate. Per ADR 0002 §6.5, push-capable identities should bypass

--- a/test/playwright/unit/ai/scripts/heartbeatLock.spec.mjs
+++ b/test/playwright/unit/ai/scripts/heartbeatLock.spec.mjs
@@ -1,0 +1,124 @@
+import {setup} from '../../../setup.mjs';
+
+const appName = 'HeartbeatLockTest';
+
+setup({
+    neoConfig: {
+        unitTestMode: true
+    },
+    appConfig: {
+        name             : appName,
+        isMounted        : () => true,
+        vnodeInitialising: false
+    }
+});
+
+import {test, expect} from '@playwright/test';
+import fs             from 'fs-extra';
+import path           from 'path';
+
+/**
+ * @summary Unit coverage for the heartbeat concurrency mutex helper (#10319).
+ *
+ * The fallback heartbeat consumes `.neo-ai-data/heartbeat-concurrency.lock` as a skip
+ * barrier. These tests keep the producer side isolated in temporary directories so the
+ * real shared heartbeat lock is never touched by Playwright.
+ */
+test.describe('ai/scripts/heartbeatLock', () => {
+    let lockModule;
+    let tmpBase;
+    let lockPath;
+
+    test.beforeAll(async () => {
+        lockModule = await import('../../../../../ai/scripts/heartbeatLock.mjs');
+    });
+
+    test.beforeEach(async () => {
+        tmpBase  = path.resolve(process.cwd(), 'tmp', `heartbeat-lock-test-${process.pid}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`);
+        lockPath = path.join(tmpBase, '.neo-ai-data', 'heartbeat-concurrency.lock');
+    });
+
+    test.afterEach(async () => {
+        if (tmpBase) {
+            await fs.remove(tmpBase).catch(() => {});
+        }
+    });
+
+    test('withHeartbeatLock creates the lock during work and removes it after success', async () => {
+        const result = await lockModule.withHeartbeatLock(async () => {
+            expect(await fs.pathExists(lockPath)).toBe(true);
+
+            const payload = await fs.readJson(lockPath);
+            expect(payload.pid).toBe(process.pid);
+            expect(payload.reason).toBe('unit-success');
+
+            return 'done'
+        }, {
+            lockPath,
+            metadata: {
+                reason: 'unit-success'
+            }
+        });
+
+        expect(result).toBe('done');
+        expect(await fs.pathExists(lockPath)).toBe(false);
+    });
+
+    test('withHeartbeatLock removes the lock after task failure', async () => {
+        await expect(lockModule.withHeartbeatLock(async () => {
+            expect(await fs.pathExists(lockPath)).toBe(true);
+            throw new Error('boom')
+        }, {lockPath})).rejects.toThrow('boom');
+
+        expect(await fs.pathExists(lockPath)).toBe(false);
+    });
+
+    test('inspectHeartbeatLock distinguishes fresh, stale, and missing locks', async () => {
+        expect(await lockModule.inspectHeartbeatLock({lockPath})).toEqual({
+            active: false,
+            stale : false,
+            ageMs : null
+        });
+
+        await lockModule.acquireHeartbeatLock({lockPath});
+
+        const fresh = await lockModule.inspectHeartbeatLock({
+            lockPath,
+            staleAfterMs: 1000,
+            now: new Date()
+        });
+
+        expect(fresh.active).toBe(true);
+        expect(fresh.stale).toBe(false);
+        expect(fresh.ageMs).toBeGreaterThanOrEqual(0);
+
+        const oldDate = new Date(Date.now() - 60_000);
+        await fs.utimes(lockPath, oldDate, oldDate);
+
+        const stale = await lockModule.inspectHeartbeatLock({
+            lockPath,
+            staleAfterMs: 1000,
+            now: new Date()
+        });
+
+        expect(stale.active).toBe(false);
+        expect(stale.stale).toBe(true);
+        expect(stale.ageMs).toBeGreaterThanOrEqual(1000);
+    });
+
+    test('swarm-heartbeat.sh defines the skip, stale-clear, and no-queue semantics', async () => {
+        const script = await fs.readFile(path.resolve(process.cwd(), 'ai/scripts/swarm-heartbeat.sh'), 'utf-8');
+
+        expect(script).toContain('HEARTBEAT_LOCK_TTL_SECONDS=${HEARTBEAT_LOCK_TTL_SECONDS:-1800}');
+        expect(script).toContain('heartbeat_lock_active()');
+        expect(script).toContain('rm -f "$CONCURRENCY_LOCK"');
+        expect(script).toContain('Missed pulses are not queued');
+
+        const lockCheckIndex = script.indexOf('if heartbeat_lock_active; then');
+        const sweepIndex     = script.indexOf('local expired=$(sweep_expired_tasks)');
+
+        expect(lockCheckIndex).toBeGreaterThanOrEqual(0);
+        expect(sweepIndex).toBeGreaterThanOrEqual(0);
+        expect(lockCheckIndex).toBeLessThan(sweepIndex);
+    });
+});


### PR DESCRIPTION
Authored by GPT-5.5 (Codex Desktop). Session 8bf3d493-3ea1-4583-a6d6-12ae8347c87e.

Resolves #10319

Adds the heartbeat concurrency mutex surface defined during the #10311 heartbeat scheduling discussion: `.neo-ai-data/heartbeat-concurrency.lock` is now the durable barrier, missed heartbeat maintenance pulses skip instead of queueing, stale locks are cleared after the 30 minute default TTL, and agents get a small Node helper/CLI for wrapping expensive work in the same lock semantics.

## Deltas from ticket

- Added `ai/scripts/heartbeatLock.mjs` so agents can acquire/release the shared heartbeat lock around expensive commands with `node ai/scripts/heartbeatLock.mjs -- <command> ...`.
- Extended `swarm-heartbeat.sh` beyond the existing simple file-presence check: it now distinguishes missing/fresh/stale locks, clears stale locks after `HEARTBEAT_LOCK_TTL_SECONDS` (default `1800`), and documents that skipped pulses are not queued.
- Updated the heartbeat token-economy measurement page with the concurrency contract so future Sandman / heartbeat work has a durable reference.
- Post-review rebase over current `dev` resolved the #10597 `swarm-heartbeat.sh` overlap and clamps tiny filesystem mtime skew in `inspectHeartbeatLock()` so a just-created lock cannot report negative age.

## Test Evidence

- `npx playwright test test/playwright/unit/ai/scripts/heartbeatLock.spec.mjs --reporter=line` -> `4 passed (946ms)`
- `bash -n ai/scripts/swarm-heartbeat.sh` -> pass
- `node ai/scripts/heartbeatLock.mjs -- node -e "if (!require('fs').existsSync('.neo-ai-data/heartbeat-concurrency.lock')) process.exit(7)"` -> pass
- `test ! -e .neo-ai-data/heartbeat-concurrency.lock` -> pass
- `git diff --check` -> pass
- `git diff --check origin/dev...HEAD` -> pass
- Post-rebase freshness: `merge-base HEAD origin/dev == origin/dev`; outgoing log contains only `90a9d8cd6 feat(ai): add heartbeat concurrency mutex helper (#10319)`.

## Post-Merge Validation

- [ ] Run a heartbeat cycle while `.neo-ai-data/heartbeat-concurrency.lock` is fresh and confirm maintenance work skips without queueing missed pulses.
- [ ] Create an artificially stale lock older than 30 minutes and confirm the next heartbeat cycle clears it before continuing.
- [ ] Use `node ai/scripts/heartbeatLock.mjs -- <expensive command>` during a Sandman or measurement run and confirm the lock is removed on both success and failure.

## Commit

- `90a9d8cd6` - `feat(ai): add heartbeat concurrency mutex helper (#10319)`

## Cross-family mandate

Runtime Agent OS / heartbeat behavior change. Cross-family Approved review required for merge eligibility per `.agents/skills/pull-request/references/pull-request-workflow.md` §6.1. Human merge remains reserved for @tobiu.
