### PR TITLE
feat(ai): capture KB query telemetry FAQs (#10081)

### DIFF
--- a/ai/daemons/services/GapInferenceEngine.mjs
+++ b/ai/daemons/services/GapInferenceEngine.mjs
@@ -1,5 +1,6 @@
 import Base                                                        from '../../../src/core/Base.mjs';
 import {Memory_Config as aiConfig, Memory_GraphService as GraphService} from '../../services.mjs';
+import KBRecorderService                                           from '../../mcp/server/knowledge-base/services/KBRecorderService.mjs';
 import logger                                                      from '../../mcp/server/memory-core/logger.mjs';
 
 /**
@@ -42,6 +43,8 @@ const ISO_VERIFIED_AT_PATTERN = /^\d{4}-\d{2}-\d{2}(?:T\d{2}:\d{2}:\d{2}\.\d{3}Z
  *      missing and should be added). Surfaced through the same `capabilityGap` channel +
  *      `sandman_handoff.md` section pattern as the other gap types, not via `logger.warn`
  *      (logger is ephemeral; the graph + handoff is the durable substrate). Added in #10087.
+ *    - `[KB_DEMAND_GAP]` — repeated agent questions from the Knowledge Base FAQ telemetry
+ *      table map to this concept, but the FAQ cluster still lacks strong guide coverage.
  *    The three coverage signals share the `aiConfig.data.guideGapWeightThreshold` gate
  *    (config-lifted in #10086 for curator tuning; defaults to `0.8` = tier-1 baseline).
  *    `[CONCEPT_REVERIFY_DUE]` is not weight-gated because freshness review is a curation
@@ -184,6 +187,8 @@ class GapInferenceEngine extends Base {
             return;
         }
 
+        const kbDemandGaps = await this.getKbDemandGapsByConcept();
+
         logger.info(`[GapInferenceEngine] Concept-graph gap pass: traversing ${conceptNodes.length} concepts.`);
 
         // Resolved once per cycle (not per concept) — the config value is read at gate time so
@@ -228,8 +233,53 @@ class GapInferenceEngine extends Base {
                 }
             }
 
+            gaps.push(...(kbDemandGaps.get(concept.id) || []));
+
             this.applyGapsToNode(concept, gaps);
         }
+    }
+
+    /**
+     * @summary Maps materialized Agent FAQ demand rows onto Concept Ontology nodes.
+     *
+     * `KBRecorderService` owns `kb_query_log` / `kb_query_faqs`; this method only consumes its
+     * read model and converts high-frequency uncovered questions into the same durable
+     * `capabilityGap` channel used by structural concept gaps. The FAQ table's
+     * `has_strong_guide_coverage` flag is authoritative here — it keeps the daemon from
+     * re-running semantic coverage checks during every REM cycle.
+     *
+     * @returns {Promise<Map<String, String[]>>} Concept ID to `[KB_DEMAND_GAP]` strings.
+     * @protected
+     */
+    async getKbDemandGapsByConcept() {
+        const gapsByConcept = new Map();
+
+        try {
+            await KBRecorderService.ready();
+
+            const {faqs} = KBRecorderService.listAgentFaqs({refresh: true});
+
+            for (const faq of faqs) {
+                if (faq.hasStrongGuideCoverage) continue;
+
+                const relatedConceptIds = faq.relatedConceptIds || [];
+
+                for (const conceptId of relatedConceptIds) {
+                    if (!gapsByConcept.has(conceptId)) {
+                        gapsByConcept.set(conceptId, []);
+                    }
+
+                    gapsByConcept.get(conceptId).push(
+                        `[KB_DEMAND_GAP] Agents asked "${faq.canonicalQuery}" ${faq.count} times ` +
+                        `(cluster ${faq.clusterId}) but the mapped Concept Ontology area lacks strong guide coverage.`
+                    );
+                }
+            }
+        } catch (err) {
+            logger.debug('[GapInferenceEngine] KB demand gap pass skipped:', err.message);
+        }
+
+        return gapsByConcept;
     }
 
     /**

--- a/ai/daemons/services/GoldenPathSynthesizer.mjs
+++ b/ai/daemons/services/GoldenPathSynthesizer.mjs
@@ -257,6 +257,7 @@ DO NOT output markdown, \`\`\`json blocks, or any other explanations. Provide pu
         let exampleGaps     = [];
         let orphanConcepts  = [];
         let reverifyDue     = [];
+        let kbDemandGaps    = [];
 
         GraphService.db.nodes.items.forEach(node => {
             if (node.properties?.capabilityGap) {
@@ -290,6 +291,8 @@ DO NOT output markdown, \`\`\`json blocks, or any other explanations. Provide pu
                                     orphanConcepts.push({ id: node.id, msg: msg.replace('[ORPHAN_CONCEPT]', '').trim() });
                                 } else if (msg.includes('[CONCEPT_REVERIFY_DUE]')) {
                                     reverifyDue.push({ id: node.id, msg: msg.replace('[CONCEPT_REVERIFY_DUE]', '').trim() });
+                                } else if (msg.includes('[KB_DEMAND_GAP]')) {
+                                    kbDemandGaps.push({ id: node.id, msg: msg.replace('[KB_DEMAND_GAP]', '').trim() });
                                 } else {
                                     // Fallback for unlabeled
                                     testGaps.push({ id: node.id, msg });
@@ -332,6 +335,11 @@ DO NOT output markdown, \`\`\`json blocks, or any other explanations. Provide pu
             if (reverifyDue.length > 0) {
                 handoffContent += `### Concept Reverification Queue (\`${Math.min(reverifyDue.length, limit)}\` of \`${reverifyDue.length}\` items)\n`;
                 reverifyDue.slice(0, limit).forEach(g => handoffContent += `- **\`${g.id}\`**: ${g.msg}\n`);
+                handoffContent += `\n`;
+            }
+            if (kbDemandGaps.length > 0) {
+                handoffContent += `### Agent FAQ Demand Gaps (\`${Math.min(kbDemandGaps.length, limit)}\` of \`${kbDemandGaps.length}\` items)\n`;
+                kbDemandGaps.slice(0, limit).forEach(g => handoffContent += `- **\`${g.id}\`**: ${g.msg}\n`);
                 handoffContent += `\n`;
             }
         }

--- a/ai/mcp/server/knowledge-base/Server.mjs
+++ b/ai/mcp/server/knowledge-base/Server.mjs
@@ -5,6 +5,7 @@ import aiConfig                                        from './config.mjs';
 import logger                                          from './logger.mjs';
 import DatabaseService                                 from './services/DatabaseService.mjs';
 import HealthService                                   from './services/HealthService.mjs';
+import KBRecorderService                               from './services/KBRecorderService.mjs';
 import {listTools, callTool}                           from './services/toolService.mjs';
 
 /**
@@ -76,6 +77,7 @@ class Server extends Base {
         // 4. Wait for dependent services
         // DatabaseService is a singleton, so we wait for its global ready state
         await DatabaseService.ready();
+        await KBRecorderService.ready();
 
         // 5. Perform Health Check & Log Status
         const health = await HealthService.healthcheck();
@@ -171,17 +173,30 @@ class Server extends Base {
         // Call Tool Handler
         this.mcpServer.server.setRequestHandler(CallToolRequestSchema, async (request) => {
             const {name, arguments: args} = request.params;
+            const t0 = Date.now();
 
             try {
                 logger.debug(`[MCP] Calling tool: ${name} with args:`, JSON.stringify(args));
 
-                const exemptFromHealthCheck = ['healthcheck', 'start_database', 'stop_database'];
+                const exemptFromHealthCheck = ['healthcheck', 'start_database', 'stop_database', 'list_agent_faqs'];
 
                 if (!exemptFromHealthCheck.includes(name)) {
                     try {
                         await HealthService.ensureHealthy();
                     } catch (healthError) {
                         logger.error(`[MCP] Health check failed for tool ${name}:`, healthError.message);
+                        KBRecorderService.log({
+                            agent_id   : process.env.NEO_AGENT_ID || process.env.USER || 'unknown',
+                            session_id : args?.sessionId || process.env.NEO_SESSION_ID || null,
+                            sequence_id: `${process.env.NEO_AGENT_ID || process.env.USER || 'unknown'}_${t0}`,
+                            timestamp  : t0,
+                            tool       : name,
+                            args,
+                            result     : {error: healthError.message},
+                            success    : false,
+                            duration_ms: Date.now() - t0
+                        });
+
                         return {
                             content: [{
                                 type: 'text',

--- a/ai/mcp/server/knowledge-base/config.template.mjs
+++ b/ai/mcp/server/knowledge-base/config.template.mjs
@@ -1,4 +1,5 @@
 import fs              from 'fs/promises';
+import os              from 'os';
 import path            from 'path';
 import Base            from '../../../../src/core/Base.mjs';
 import {fileURLToPath} from 'url';
@@ -105,6 +106,41 @@ const defaultConfig = {
      * @type {string}
      */
     path: path.resolve(neoRootDir, '.neo-ai-data/chroma/knowledge-base'),
+    /**
+     * @summary Shared SQLite destination for Knowledge Base query telemetry.
+     *
+     * Path to the shared Memory Core SQLite database used for Knowledge Base query telemetry.
+     * Mirrors the Neural Link recorder default so `kb_query_log` and `kb_query_faqs`
+     * land beside `nl_action_log` without coupling either MCP server's schema.
+     * @type {string}
+     */
+    memoryCoreDbPath: process.env.NEO_MEMORY_DB_PATH ||
+        process.env.NEO_MEMORY_CORE_DB_PATH ||
+        path.join(os.homedir(), '.neo-ai-data', 'memory-core.sqlite'),
+    /**
+     * @summary Repetition threshold for promoting KB queries into Agent FAQ clusters.
+     *
+     * Minimum repeated Knowledge Base queries required before an Agent FAQ becomes
+     * eligible for `[KB_DEMAND_GAP]` inference and `list_agent_faqs` reporting.
+     * @type {number}
+     */
+    kbFaqMinCount: Number(process.env.NEO_KB_FAQ_MIN_COUNT) || 3,
+    /**
+     * @summary Calibration threshold for future embedding-backed Agent FAQ clustering.
+     *
+     * Calibration marker for FAQ clustering. The first implementation uses exact
+     * normalized-query grouping as the conservative 1.0 baseline; operators can
+     * lower this once embedding-backed similarity is measured against real traffic.
+     * @type {number}
+     */
+    kbFaqSimilarityThreshold: Number(process.env.NEO_KB_FAQ_SIMILARITY_THRESHOLD) || 1.0,
+    /**
+     * @summary Bound for Concept Ontology IDs attached to each Agent FAQ cluster.
+     *
+     * Maximum number of Concept Ontology IDs attached to each Agent FAQ.
+     * @type {number}
+     */
+    kbFaqConceptLimit: Number(process.env.NEO_KB_FAQ_CONCEPT_LIMIT) || 5,
     /**
      * The path to the generated knowledge base JSONL file.
      * @type {string}

--- a/ai/mcp/server/knowledge-base/openapi.yaml
+++ b/ai/mcp/server/knowledge-base/openapi.yaml
@@ -395,6 +395,58 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
 
+  /knowledge/agent-faqs:
+    post:
+      summary: List Agent FAQs
+      operationId: list_agent_faqs
+      x-pass-as-object: true
+      description: |
+        Lists frequently repeated Knowledge Base questions captured from agent calls to
+        `ask_knowledge_base` and `query_documents`.
+
+        The rows come from the shared SQLite telemetry tables `kb_query_log` and
+        `kb_query_faqs`. Set `refresh: true` to rebuild the materialized FAQ table from
+        the raw query log before reading it. The current clustering implementation uses
+        exact normalized-query grouping and records the configured similarity threshold
+        as a calibration value for the later embedding-backed clustering phase.
+      tags: [Documents]
+      requestBody:
+        required: false
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                limit:
+                  type: integer
+                  description: Maximum number of FAQ clusters to return.
+                  default: 25
+                minCount:
+                  type: integer
+                  description: Minimum query occurrences required for a cluster.
+                  default: 3
+                refresh:
+                  type: boolean
+                  description: Rebuild the `kb_query_faqs` table from `kb_query_log` before reading.
+                  default: false
+                sinceTimestamp:
+                  type: integer
+                  description: Lower timestamp bound used when `refresh` is true.
+                  default: 0
+      responses:
+        '200':
+          description: Materialized Agent FAQ clusters.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AgentFaqResponse'
+        '500':
+          description: Internal server error.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
   /knowledge/hierarchy:
     get:
       summary: Get Class Hierarchy
@@ -672,6 +724,50 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/QueryResultItem'
+
+    AgentFaq:
+      type: object
+      properties:
+        clusterId:
+          type: string
+        canonicalQuery:
+          type: string
+        normalizedQuery:
+          type: string
+        variants:
+          type: array
+          items:
+            type: string
+        count:
+          type: integer
+        failureCount:
+          type: integer
+        firstSeen:
+          type: integer
+        lastSeen:
+          type: integer
+        relatedConceptIds:
+          type: array
+          items:
+            type: string
+        hasStrongGuideCoverage:
+          type: boolean
+        similarityThreshold:
+          type: number
+
+    AgentFaqResponse:
+      type: object
+      properties:
+        count:
+          type: integer
+        minCount:
+          type: integer
+        similarityThreshold:
+          type: number
+        faqs:
+          type: array
+          items:
+            $ref: '#/components/schemas/AgentFaq'
 
     Document:
       type: object

--- a/ai/mcp/server/knowledge-base/services/KBRecorderService.mjs
+++ b/ai/mcp/server/knowledge-base/services/KBRecorderService.mjs
@@ -1,0 +1,450 @@
+import crypto         from 'crypto';
+import fs             from 'fs-extra';
+import path           from 'path';
+import Base           from '../../../../../src/core/Base.mjs';
+import ConceptService from '../../../../services/ConceptService.mjs';
+import config         from '../config.mjs';
+import logger         from '../logger.mjs';
+
+/**
+ * @summary Captures Knowledge Base query telemetry and materializes Agent FAQ demand clusters.
+ *
+ * The Knowledge Base recorder is the KB-server sibling of Neural Link's `RecorderService`.
+ * It persists every KB MCP tool invocation into the shared Memory Core SQLite database, then
+ * projects repeated `ask_knowledge_base` / `query_documents` questions into `kb_query_faqs`.
+ * Those FAQ rows are the durable "agent question" signal consumed by `GapInferenceEngine` as
+ * `[KB_DEMAND_GAP]` evidence for the Concept Ontology and Golden Path loop.
+ *
+ * @class Neo.ai.mcp.server.knowledge-base.services.KBRecorderService
+ * @extends Neo.core.Base
+ * @see Neo.ai.mcp.server.neural-link.services.RecorderService
+ * @see Neo.ai.daemons.services.GapInferenceEngine
+ * @singleton
+ */
+class KBRecorderService extends Base {
+    static config = {
+        /**
+         * @member {String} className='Neo.ai.mcp.server.knowledge-base.services.KBRecorderService'
+         * @protected
+         */
+        className: 'Neo.ai.mcp.server.knowledge-base.services.KBRecorderService',
+        /**
+         * @member {Boolean} singleton=true
+         * @protected
+         */
+        singleton: true,
+        /**
+         * @member {Object|null} db=null
+         * @summary SQLite connection to the shared Memory Core database.
+         * @protected
+         */
+        db: null
+    }
+
+    /**
+     * @summary Initializes the SQLite schema for Knowledge Base query telemetry and Agent FAQs.
+     *
+     * Creates `kb_query_log` and `kb_query_faqs` beside the existing Memory Core / Neural Link
+     * telemetry tables. WAL journal mode mirrors the Neural Link recorder so KB query capture
+     * stays non-blocking for concurrent MCP readers and daemon consumers.
+     *
+     * @returns {Promise<void>}
+     */
+    async initAsync() {
+        await super.initAsync();
+
+        if (this.db) return;
+
+        try {
+            const dbPath = config.memoryCoreDbPath;
+            if (!dbPath) {
+                logger.warn('[KBRecorderService] memoryCoreDbPath not configured. Disabling KB query telemetry.');
+                return;
+            }
+
+            await fs.ensureDir(path.dirname(dbPath));
+
+            const Database = (await import('better-sqlite3')).default;
+
+            this.db = new Database(dbPath, {verbose: null});
+            this.db.pragma('journal_mode = WAL');
+            this.db.exec(`
+                CREATE TABLE IF NOT EXISTS kb_query_log (
+                    id          TEXT PRIMARY KEY,
+                    agent_id    TEXT NOT NULL,
+                    session_id  TEXT,
+                    sequence_id TEXT NOT NULL,
+                    timestamp   INTEGER NOT NULL,
+                    tool        TEXT NOT NULL,
+                    query_text  TEXT,
+                    args        TEXT NOT NULL,
+                    result      TEXT,
+                    success     INTEGER DEFAULT 0,
+                    duration_ms INTEGER
+                );
+                CREATE INDEX IF NOT EXISTS idx_kb_query_log_sequence  ON kb_query_log(sequence_id);
+                CREATE INDEX IF NOT EXISTS idx_kb_query_log_session   ON kb_query_log(session_id);
+                CREATE INDEX IF NOT EXISTS idx_kb_query_log_timestamp ON kb_query_log(timestamp);
+                CREATE INDEX IF NOT EXISTS idx_kb_query_log_tool      ON kb_query_log(tool);
+                CREATE INDEX IF NOT EXISTS idx_kb_query_log_query     ON kb_query_log(query_text);
+
+                CREATE TABLE IF NOT EXISTS kb_query_faqs (
+                    cluster_id                TEXT PRIMARY KEY,
+                    canonical_query           TEXT NOT NULL,
+                    normalized_query          TEXT NOT NULL,
+                    variants                  TEXT NOT NULL,
+                    occurrence_count          INTEGER NOT NULL,
+                    failure_count             INTEGER DEFAULT 0,
+                    first_seen                INTEGER NOT NULL,
+                    last_seen                 INTEGER NOT NULL,
+                    related_concept_ids       TEXT NOT NULL,
+                    has_strong_guide_coverage INTEGER DEFAULT 0,
+                    similarity_threshold      REAL NOT NULL,
+                    updated_at                INTEGER NOT NULL
+                );
+                CREATE INDEX IF NOT EXISTS idx_kb_query_faqs_count     ON kb_query_faqs(occurrence_count);
+                CREATE INDEX IF NOT EXISTS idx_kb_query_faqs_last_seen ON kb_query_faqs(last_seen);
+                CREATE INDEX IF NOT EXISTS idx_kb_query_faqs_coverage  ON kb_query_faqs(has_strong_guide_coverage);
+            `);
+
+            logger.info('[KBRecorderService] Connected to Memory Core kb_query_log / kb_query_faqs.');
+        } catch (err) {
+            logger.warn('[KBRecorderService] Failed to initialize SQLite connection:', err.message);
+        }
+    }
+
+    /**
+     * @summary Safely serializes a value for durable telemetry storage.
+     * @param {*} value Value to encode.
+     * @returns {String}
+     * @protected
+     */
+    safeStringify(value) {
+        try {
+            return JSON.stringify(value ?? null);
+        } catch {
+            return JSON.stringify({error: 'Unserializable Value'});
+        }
+    }
+
+    /**
+     * @summary Parses a JSON string without letting malformed telemetry block aggregation.
+     * @param {String|Object} value Candidate JSON string or object.
+     * @returns {Object|null}
+     * @protected
+     */
+    safeParse(value) {
+        if (value && typeof value === 'object') return value;
+        if (typeof value !== 'string') return null;
+
+        try {
+            return JSON.parse(value);
+        } catch {
+            return null;
+        }
+    }
+
+    /**
+     * @summary Extracts the natural-language KB query from MCP tool arguments.
+     *
+     * Denormalizing `query_text` keeps the FAQ read path independent from the full JSON `args`
+     * payload and lets SQLite index the agent-question signal directly.
+     *
+     * @param {Object|String} args MCP arguments object or serialized argument JSON.
+     * @returns {String|null}
+     * @protected
+     */
+    extractQueryText(args) {
+        const parsed = this.safeParse(args),
+              query  = parsed?.query;
+
+        return typeof query === 'string' && query.trim()
+            ? query.trim()
+            : null;
+    }
+
+    /**
+     * @summary Normalizes agent questions into conservative first-pass FAQ cluster keys.
+     *
+     * This is intentionally exact-match clustering after punctuation/whitespace normalization.
+     * The `kbFaqSimilarityThreshold` config documents the calibration target for the later
+     * embedding-backed phase; until real traffic is measured, exact grouping avoids false merges
+     * between subtly different framework concepts.
+     *
+     * @param {String} queryText Raw agent question.
+     * @returns {String}
+     * @protected
+     */
+    normalizeQueryText(queryText) {
+        return String(queryText || '')
+            .toLowerCase()
+            .replace(/[^a-z0-9\s]/g, ' ')
+            .replace(/\s+/g, ' ')
+            .trim();
+    }
+
+    /**
+     * @summary Persists a KB MCP tool invocation into `kb_query_log`.
+     *
+     * Logging is a best-effort observability side channel. It never throws back into the MCP
+     * tool call path, preserving Knowledge Base availability even when telemetry storage is
+     * unavailable or temporarily locked.
+     *
+     * @param {Object} entry Invocation metadata captured by the KB `toolService` wrapper.
+     * @returns {void}
+     */
+    log(entry) {
+        if (!this.db) return;
+
+        try {
+            const
+                timestamp  = entry.timestamp || Date.now(),
+                agentId    = entry.agent_id || process.env.NEO_AGENT_ID || process.env.USER || 'unknown',
+                sequenceId = entry.sequence_id || `${agentId}_${timestamp}`,
+                args       = typeof entry.args === 'string' ? entry.args : this.safeStringify(entry.args ?? {}),
+                result     = typeof entry.result === 'string' ? entry.result : this.safeStringify(entry.result ?? null),
+                queryText  = entry.query_text ?? this.extractQueryText(args);
+
+            this.db.prepare(`
+                INSERT INTO kb_query_log (
+                    id, agent_id, session_id, sequence_id, timestamp,
+                    tool, query_text, args, result, success, duration_ms
+                ) VALUES (
+                    ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?
+                )
+            `).run(
+                crypto.randomUUID(),
+                agentId,
+                entry.session_id || null,
+                sequenceId,
+                timestamp,
+                entry.tool,
+                queryText,
+                args,
+                result,
+                entry.success ? 1 : 0,
+                entry.duration_ms ?? null
+            );
+        } catch (err) {
+            logger.error('[KBRecorderService] Failed to append KB query log entry:', err);
+        }
+    }
+
+    /**
+     * @summary Resolves likely Concept Ontology anchors for an Agent FAQ query.
+     * @param {String} queryText Canonical FAQ question text.
+     * @param {Number} [limit=config.kbFaqConceptLimit] Maximum concepts to return.
+     * @returns {String[]} Concept IDs.
+     * @protected
+     */
+    resolveRelatedConceptIds(queryText, limit = config.kbFaqConceptLimit) {
+        try {
+            return ConceptService.findConceptsRelevantTo(queryText, {limit})
+                .map(concept => concept.id)
+                .filter(Boolean);
+        } catch (err) {
+            logger.debug('[KBRecorderService] Concept lookup skipped for Agent FAQ:', err.message);
+            return [];
+        }
+    }
+
+    /**
+     * @summary Checks whether any related concept already has guide coverage.
+     * @param {String[]} conceptIds Concept Ontology node IDs.
+     * @returns {Boolean}
+     * @protected
+     */
+    hasStrongGuideCoverage(conceptIds) {
+        return conceptIds.some(conceptId => {
+            try {
+                return ConceptService.getConceptCoverage(conceptId).explainedBy.length > 0;
+            } catch {
+                return false;
+            }
+        });
+    }
+
+    /**
+     * @summary Builds `kb_query_faqs` from repeated Knowledge Base query telemetry.
+     *
+     * Rebuilds the materialized FAQ table from `kb_query_log` using conservative normalized
+     * query clustering. The similarity threshold is stored on each row as a calibration
+     * artifact so future embedding-backed clustering can compare exact-match output against
+     * measured cosine thresholds without changing the read path.
+     *
+     * @param {Object} [options]
+     * @param {Number} [options.minCount=config.kbFaqMinCount] Minimum occurrences per FAQ.
+     * @param {Number} [options.limit=100] Maximum clusters to persist.
+     * @param {Number} [options.sinceTimestamp=0] Lower timestamp bound for source logs.
+     * @param {Number} [options.similarityThreshold=config.kbFaqSimilarityThreshold] Calibration threshold.
+     * @returns {{count: Number, faqs: Object[]}}
+     */
+    buildAgentFaqs({
+        minCount            = config.kbFaqMinCount,
+        limit               = 100,
+        sinceTimestamp      = 0,
+        similarityThreshold = config.kbFaqSimilarityThreshold
+    } = {}) {
+        if (!this.db) return {count: 0, faqs: []};
+
+        const rows = this.db.prepare(`
+            SELECT *
+              FROM kb_query_log
+             WHERE timestamp >= ?
+               AND query_text IS NOT NULL
+               AND TRIM(query_text) != ''
+               AND tool IN ('ask_knowledge_base', 'query_documents')
+             ORDER BY timestamp ASC
+        `).all(sinceTimestamp);
+
+        const groups = new Map();
+
+        for (const row of rows) {
+            const normalized = this.normalizeQueryText(row.query_text);
+            if (!normalized) continue;
+
+            if (!groups.has(normalized)) {
+                groups.set(normalized, {
+                    normalized,
+                    variants    : new Set(),
+                    rows        : [],
+                    failureCount: 0
+                });
+            }
+
+            const group = groups.get(normalized);
+            group.variants.add(row.query_text);
+            group.rows.push(row);
+            if (!row.success) group.failureCount++;
+        }
+
+        const faqs = [...groups.values()]
+            .filter(group => group.rows.length >= minCount)
+            .sort((a, b) => {
+                const countDelta = b.rows.length - a.rows.length;
+                if (countDelta) return countDelta;
+                return b.rows.at(-1).timestamp - a.rows.at(-1).timestamp;
+            })
+            .slice(0, limit)
+            .map(group => {
+                const
+                    firstSeen          = group.rows[0].timestamp,
+                    lastSeen           = group.rows.at(-1).timestamp,
+                    variants           = [...group.variants],
+                    canonicalQuery     = variants.sort((a, b) => b.length - a.length)[0],
+                    relatedConceptIds  = this.resolveRelatedConceptIds(canonicalQuery),
+                    guideCoverage      = this.hasStrongGuideCoverage(relatedConceptIds),
+                    clusterId          = crypto.createHash('sha256').update(group.normalized).digest('hex');
+
+                return {
+                    clusterId,
+                    canonicalQuery,
+                    normalizedQuery: group.normalized,
+                    variants,
+                    count          : group.rows.length,
+                    failureCount   : group.failureCount,
+                    firstSeen,
+                    lastSeen,
+                    relatedConceptIds,
+                    hasStrongGuideCoverage: guideCoverage,
+                    similarityThreshold
+                };
+            });
+
+        const rebuild = this.db.transaction(() => {
+            this.db.prepare('DELETE FROM kb_query_faqs').run();
+
+            const insert = this.db.prepare(`
+                INSERT INTO kb_query_faqs (
+                    cluster_id, canonical_query, normalized_query, variants,
+                    occurrence_count, failure_count, first_seen, last_seen,
+                    related_concept_ids, has_strong_guide_coverage,
+                    similarity_threshold, updated_at
+                ) VALUES (
+                    ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?
+                )
+            `);
+
+            for (const faq of faqs) {
+                insert.run(
+                    faq.clusterId,
+                    faq.canonicalQuery,
+                    faq.normalizedQuery,
+                    this.safeStringify(faq.variants),
+                    faq.count,
+                    faq.failureCount,
+                    faq.firstSeen,
+                    faq.lastSeen,
+                    this.safeStringify(faq.relatedConceptIds),
+                    faq.hasStrongGuideCoverage ? 1 : 0,
+                    faq.similarityThreshold,
+                    Date.now()
+                );
+            }
+        });
+
+        rebuild();
+
+        return {count: faqs.length, faqs};
+    }
+
+    /**
+     * @summary Lists materialized Agent FAQs for MCP readers and daemon consumers.
+     * @param {Object} [options]
+     * @param {Number} [options.limit=25] Maximum rows to return.
+     * @param {Number} [options.minCount=config.kbFaqMinCount] Minimum occurrences.
+     * @param {Boolean} [options.refresh=false] Whether to rebuild the FAQ table first.
+     * @param {Number} [options.sinceTimestamp=0] Source-log lower bound used only when refreshing.
+     * @returns {{count: Number, minCount: Number, similarityThreshold: Number, faqs: Object[]}}
+     */
+    listAgentFaqs({
+        limit          = 25,
+        minCount       = config.kbFaqMinCount,
+        refresh        = false,
+        sinceTimestamp = 0
+    } = {}) {
+        if (!this.db) {
+            return {
+                count              : 0,
+                minCount,
+                similarityThreshold: config.kbFaqSimilarityThreshold,
+                faqs               : []
+            };
+        }
+
+        if (refresh) {
+            this.buildAgentFaqs({limit: Math.max(limit, 100), minCount, sinceTimestamp});
+        }
+
+        const rows = this.db.prepare(`
+            SELECT *
+              FROM kb_query_faqs
+             WHERE occurrence_count >= ?
+             ORDER BY occurrence_count DESC, last_seen DESC
+             LIMIT ?
+        `).all(minCount, limit);
+
+        const faqs = rows.map(row => ({
+            clusterId              : row.cluster_id,
+            canonicalQuery         : row.canonical_query,
+            normalizedQuery        : row.normalized_query,
+            variants               : this.safeParse(row.variants) || [],
+            count                  : row.occurrence_count,
+            failureCount           : row.failure_count,
+            firstSeen              : row.first_seen,
+            lastSeen               : row.last_seen,
+            relatedConceptIds      : this.safeParse(row.related_concept_ids) || [],
+            hasStrongGuideCoverage: !!row.has_strong_guide_coverage,
+            similarityThreshold    : row.similarity_threshold
+        }));
+
+        return {
+            count              : faqs.length,
+            minCount,
+            similarityThreshold: config.kbFaqSimilarityThreshold,
+            faqs
+        };
+    }
+}
+
+export default Neo.setupClass(KBRecorderService);

--- a/ai/mcp/server/knowledge-base/services/toolService.mjs
+++ b/ai/mcp/server/knowledge-base/services/toolService.mjs
@@ -4,6 +4,7 @@ import DatabaseService          from './DatabaseService.mjs';
 import DatabaseLifecycleService from './DatabaseLifecycleService.mjs';
 import DocumentService          from './DocumentService.mjs';
 import HealthService            from './HealthService.mjs';
+import KBRecorderService        from './KBRecorderService.mjs';
 import QueryService             from './QueryService.mjs';
 import SearchService            from './SearchService.mjs';
 import ToolService              from '../../../ToolService.mjs';
@@ -18,6 +19,7 @@ const serviceMapping = {
     get_document_by_id   : DocumentService         .getDocumentById    .bind(DocumentService),
     healthcheck          : HealthService           .healthcheck        .bind(HealthService),
     list_documents       : DocumentService         .listDocuments      .bind(DocumentService),
+    list_agent_faqs      : KBRecorderService       .listAgentFaqs      .bind(KBRecorderService),
     manage_database      : DatabaseLifecycleService.manageDatabase     .bind(DatabaseLifecycleService),
     // #10572: dispatch wrapper marks `viaMcp: true` so VectorService.embed can apply the
     // work-volume gate. CLI invocations (via `npm run ai:sync-kb`) call DatabaseService.syncDatabase
@@ -31,7 +33,39 @@ const toolService = Neo.create(ToolService, {
     serviceMapping
 });
 
-const callTool  = toolService.callTool .bind(toolService);
+const _callTool = toolService.callTool.bind(toolService);
+
+const callTool = async (name, args) => {
+    const
+        t0        = Date.now(),
+        agentId   = process.env.NEO_AGENT_ID || process.env.USER || 'unknown',
+        sessionId = args?.sessionId || process.env.NEO_SESSION_ID || null,
+        seqId     = `${agentId}_${t0}`;
+
+    let result, success = 0;
+
+    try {
+        result  = await _callTool(name, args);
+        success = 1;
+        return result;
+    } catch (err) {
+        result = {error: err.message};
+        throw err;
+    } finally {
+        KBRecorderService.log({
+            agent_id   : agentId,
+            session_id : sessionId,
+            sequence_id: seqId,
+            timestamp  : t0,
+            tool       : name,
+            args,
+            result,
+            success,
+            duration_ms: Date.now() - t0
+        });
+    }
+};
+
 const listTools = toolService.listTools.bind(toolService);
 
 export {callTool, listTools};

--- a/ai/services.mjs
+++ b/ai/services.mjs
@@ -26,6 +26,7 @@ import KB_DatabaseService           from './mcp/server/knowledge-base/services/D
 import KB_LifecycleService          from './mcp/server/knowledge-base/services/DatabaseLifecycleService.mjs';
 import KB_DocumentService           from './mcp/server/knowledge-base/services/DocumentService.mjs';
 import KB_HealthService             from './mcp/server/knowledge-base/services/HealthService.mjs';
+import KB_RecorderService           from './mcp/server/knowledge-base/services/KBRecorderService.mjs';
 import KB_QueryService              from './mcp/server/knowledge-base/services/QueryService.mjs';
 import KB_SearchService             from './mcp/server/knowledge-base/services/SearchService.mjs';
 import KB_ChromaManager             from './mcp/server/knowledge-base/services/ChromaManager.mjs';
@@ -207,6 +208,7 @@ makeSafe(KB_DatabaseService,  kbSpec);
 makeSafe(KB_LifecycleService, kbSpec);
 makeSafe(KB_DocumentService,  kbSpec);
 makeSafe(KB_HealthService,    kbSpec);
+makeSafe(KB_RecorderService,  kbSpec);
 makeSafe(KB_QueryService,     kbSpec);
 makeSafe(KB_SearchService,    kbSpec);
 
@@ -269,6 +271,7 @@ export {
     KB_LifecycleService,
     KB_DocumentService,
     KB_HealthService,
+    KB_RecorderService,
     KB_QueryService,
     KB_SearchService,
 

--- a/buildScripts/ai/buildKbAgentFaqs.mjs
+++ b/buildScripts/ai/buildKbAgentFaqs.mjs
@@ -1,0 +1,42 @@
+import '../../src/Neo.mjs';
+import * as core        from '../../src/core/_export.mjs';
+import KBRecorderService from '../../ai/mcp/server/knowledge-base/services/KBRecorderService.mjs';
+
+/**
+ * @summary Materializes Agent FAQ clusters from Knowledge Base query telemetry.
+ *
+ * This operator CLI is the on-demand aggregation path for #10081. It rebuilds
+ * `kb_query_faqs` from `kb_query_log` using the conservative exact-normalized
+ * clustering baseline and prints a short JSON summary for automation.
+ *
+ * Usage:
+ *   node buildScripts/ai/buildKbAgentFaqs.mjs --min-count 3 --limit 100
+ */
+const args = process.argv.slice(2);
+
+const readNumberArg = (name, fallback) => {
+    const index = args.indexOf(name);
+    if (index === -1) return fallback;
+
+    const value = Number(args[index + 1]);
+    return Number.isFinite(value) ? value : fallback;
+};
+
+await KBRecorderService.ready();
+
+const result = KBRecorderService.buildAgentFaqs({
+    minCount      : readNumberArg('--min-count', undefined),
+    limit         : readNumberArg('--limit', 100),
+    sinceTimestamp: readNumberArg('--since', 0)
+});
+
+console.log(JSON.stringify({
+    message: `Materialized ${result.count} Knowledge Base Agent FAQ cluster(s).`,
+    count  : result.count,
+    faqs   : result.faqs.map(({clusterId, canonicalQuery, count, hasStrongGuideCoverage}) => ({
+        clusterId,
+        canonicalQuery,
+        count,
+        hasStrongGuideCoverage
+    }))
+}, null, 2));

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
         "ai:agent"                     : "node ./buildScripts/ai/runAgent.mjs",
         "ai:analyze-nl-telemetry"      : "node ./ai/scripts/analyzeNlTelemetry.mjs",
         "ai:backup"                    : "node ./buildScripts/ai/backup.mjs",
+        "ai:build-kb-faqs"             : "node ./buildScripts/ai/buildKbAgentFaqs.mjs",
         "ai:defrag-kb"                 : "node ./buildScripts/ai/defragChromaDB.mjs --target knowledge-base",
         "ai:defrag-memory"             : "node ./buildScripts/ai/defragChromaDB.mjs --target memory-core",
         "ai:defrag-sqlite"             : "node ./buildScripts/ai/defragSQLiteDB.mjs",

--- a/test/playwright/unit/ai/daemons/DreamService.spec.mjs
+++ b/test/playwright/unit/ai/daemons/DreamService.spec.mjs
@@ -30,6 +30,7 @@ test.describe('Neo.ai.mcp.server.memory-core.services.DreamService', () => {
     let StorageRouter;
     let OpenAiCompatible;
     let TextEmbeddingService;
+    let KBRecorderService;
     let logger;
     const testDbName = `memory-core-dream-test-${process.pid}-${Date.now()}.sqlite`;
     let testDbPath; // Reassigned in beforeAll
@@ -41,7 +42,9 @@ test.describe('Neo.ai.mcp.server.memory-core.services.DreamService', () => {
     const freshVerifiedAt = new Date().toISOString();
 
     test.beforeAll(async () => {
-        const aiConfig                = (await import('../../../../../ai/mcp/server/memory-core/config.mjs')).default;
+        const
+            aiConfig = (await import('../../../../../ai/mcp/server/memory-core/config.mjs')).default,
+            kbConfig = (await import('../../../../../ai/mcp/server/knowledge-base/config.mjs')).default;
         
         const tmpDir = path.resolve(process.cwd(), 'tmp');
         if (!fs.existsSync(tmpDir)) {
@@ -52,6 +55,7 @@ test.describe('Neo.ai.mcp.server.memory-core.services.DreamService', () => {
         aiConfig.storagePaths.graph = testDbPath;
         aiConfig.autoIngestFileSystem = false; // Prevent differential sync during DreamService tests
         aiConfig.handoffFilePath      = path.join(tmpDir, 'mock_sandman_handoff.md');
+        kbConfig.data.memoryCoreDbPath = testDbPath;
 
         GraphService = (await import('../../../../../ai/mcp/server/memory-core/services/GraphService.mjs')).default;
         DreamService = (await import('../../../../../ai/daemons/DreamService.mjs')).default;
@@ -61,6 +65,7 @@ test.describe('Neo.ai.mcp.server.memory-core.services.DreamService', () => {
         OpenAiCompatible       = (await import('../../../../../ai/provider/OpenAiCompatible.mjs')).default;
         SystemLifecycleService = (await import('../../../../../ai/mcp/server/memory-core/services/lifecycle/SystemLifecycleService.mjs')).default;
         TextEmbeddingService   = (await import('../../../../../ai/mcp/server/memory-core/services/TextEmbeddingService.mjs')).default;
+        KBRecorderService      = (await import('../../../../../ai/mcp/server/knowledge-base/services/KBRecorderService.mjs')).default;
         logger                 = (await import('../../../../../ai/mcp/server/memory-core/logger.mjs')).default;
 
         if (fs.existsSync(testDbPath)) {
@@ -78,6 +83,7 @@ test.describe('Neo.ai.mcp.server.memory-core.services.DreamService', () => {
         }
 
         if (!SystemLifecycleService._initPromise) { await SystemLifecycleService.initAsync(); } else { await SystemLifecycleService.ready(); }
+        await KBRecorderService.ready();
 
         // Monkey patch OpenAiCompatible
         originalGenerate = OpenAiCompatible.prototype.generate;
@@ -117,6 +123,10 @@ test.describe('Neo.ai.mcp.server.memory-core.services.DreamService', () => {
                 GraphService.db.lastSyncId = 0;
             }
         }
+
+        if (KBRecorderService?.db) {
+            KBRecorderService.db.exec('DELETE FROM kb_query_log; DELETE FROM kb_query_faqs;');
+        }
     });
 
     test.afterEach(async () => {
@@ -145,6 +155,11 @@ test.describe('Neo.ai.mcp.server.memory-core.services.DreamService', () => {
             }
             GraphService.db           = null;
             GraphService._initPromise = null;
+        }
+
+        if (KBRecorderService?.db) {
+            try { KBRecorderService.db.close(); } catch (e) {}
+            KBRecorderService.db = null;
         }
 
         if (SystemLifecycleService) {
@@ -288,6 +303,45 @@ test.describe('Neo.ai.mcp.server.memory-core.services.DreamService', () => {
         expect(missingGuide.properties.capabilityGap).toContain('RogueConcept');
         expect(missingGuide.properties.capabilityGap).toContain('EXPLAINED_BY');
         expect(missingGuide.properties.lastGapCheck).toBeGreaterThan(0);
+    });
+
+    test('should emit KB_DEMAND_GAP for repeated uncovered Agent FAQ demand (#10081)', async () => {
+        const originalListAgentFaqs = KBRecorderService.listAgentFaqs;
+
+        KBRecorderService.listAgentFaqs = () => ({
+            faqs: [{
+                clusterId              : 'kb-demand-cluster',
+                canonicalQuery         : 'How should agents use ask_knowledge_base?',
+                count                  : 3,
+                relatedConceptIds      : ['concept-kb-demand'],
+                hasStrongGuideCoverage: false
+            }]
+        });
+
+        try {
+            GraphService.upsertNode({
+                id        : 'concept-kb-demand',
+                type      : 'CONCEPT',
+                name      : 'Knowledge Base Demand',
+                properties: {
+                    name       : 'Knowledge Base Demand',
+                    tier       : 3,
+                    uniqueToNeo: false,
+                    verifiedAt : freshVerifiedAt,
+                    weight     : 0.3
+                }
+            });
+
+            await DreamService.inferConceptGraphGaps();
+
+            const node = GraphService.db.nodes.get('concept-kb-demand');
+
+            expect(node.properties.capabilityGap).toContain('[KB_DEMAND_GAP]');
+            expect(node.properties.capabilityGap).toContain('How should agents use ask_knowledge_base?');
+            expect(node.properties.capabilityGap).not.toContain('[GUIDE_GAP]');
+        } finally {
+            KBRecorderService.listAgentFaqs = originalListAgentFaqs;
+        }
     });
 
     test('should detect EXAMPLE_GAP for concepts documented but lacking worked examples', async () => {
@@ -803,6 +857,13 @@ test.describe('Neo.ai.mcp.server.memory-core.services.DreamService', () => {
                      "[CONCEPT_REVERIFY_DUE] The CONCEPT 'Config System' has verifiedAt=null and needs source-grounded re-verification."
                  ]),
                  lastGapCheck: Date.now()
+             } },
+             { id: 'concept-kb-demand-render-test', properties: {
+                 state        : 'OPEN',
+                 capabilityGap: JSON.stringify([
+                     '[KB_DEMAND_GAP] Agents asked "how does reactive config work?" 4 times (cluster abc123) but the mapped Concept Ontology area lacks strong guide coverage.'
+                 ]),
+                 lastGapCheck: Date.now()
              } }
         ];
 
@@ -850,6 +911,8 @@ test.describe('Neo.ai.mcp.server.memory-core.services.DreamService', () => {
         expect(finalContent).toContain('Reactivity');
         expect(finalContent).toContain('Concept Reverification Queue');
         expect(finalContent).toContain('Config System');
+        expect(finalContent).toContain('Agent FAQ Demand Gaps');
+        expect(finalContent).toContain('reactive config');
 
         // Run AGAIN to trigger duplication prevention natively
         await DreamService.synthesizeGoldenPath();

--- a/test/playwright/unit/ai/mcp/server/knowledge-base/services/KBRecorderService.spec.mjs
+++ b/test/playwright/unit/ai/mcp/server/knowledge-base/services/KBRecorderService.spec.mjs
@@ -1,0 +1,130 @@
+import {setup} from '../../../../../../setup.mjs';
+
+const appName = 'KBRecorderServiceTest';
+
+setup({
+    neoConfig: {
+        unitTestMode: true
+    },
+    appConfig: {
+        name             : appName,
+        isMounted        : () => true,
+        vnodeInitialising: false
+    }
+});
+
+import {test, expect} from '@playwright/test';
+import Neo            from '../../../../../../../../src/Neo.mjs';
+import * as core      from '../../../../../../../../src/core/_export.mjs';
+import crypto         from 'crypto';
+import fs             from 'fs';
+import path           from 'path';
+
+test.describe('Neo.ai.mcp.server.knowledge-base.services.KBRecorderService', () => {
+    const testDbName = `kb-recorder-test-${process.pid}-${Date.now()}.sqlite`;
+    let testDbPath;
+    let KBRecorderService;
+
+    test.beforeAll(async () => {
+        const config = (await import('../../../../../../../../ai/mcp/server/knowledge-base/config.mjs')).default;
+
+        const tmpDir = path.resolve(process.cwd(), 'tmp');
+        if (!fs.existsSync(tmpDir)) {
+            fs.mkdirSync(tmpDir, {recursive: true});
+        }
+
+        testDbPath = path.join(tmpDir, testDbName);
+        config.data.memoryCoreDbPath = testDbPath;
+
+        if (fs.existsSync(testDbPath)) {
+            try {fs.unlinkSync(testDbPath);}          catch (e) {}
+            try {fs.unlinkSync(`${testDbPath}-wal`);} catch (e) {}
+            try {fs.unlinkSync(`${testDbPath}-shm`);} catch (e) {}
+        }
+
+        KBRecorderService = (await import('../../../../../../../../ai/mcp/server/knowledge-base/services/KBRecorderService.mjs')).default;
+        await KBRecorderService.initAsync();
+    });
+
+    test.beforeEach(() => {
+        KBRecorderService.db.exec('DELETE FROM kb_query_log; DELETE FROM kb_query_faqs;');
+    });
+
+    test.afterAll(() => {
+        if (KBRecorderService?.db) {
+            try {KBRecorderService.db.close();} catch (e) {}
+            KBRecorderService.db = null;
+        }
+
+        try {fs.unlinkSync(testDbPath);}          catch (e) {}
+        try {fs.unlinkSync(`${testDbPath}-wal`);} catch (e) {}
+        try {fs.unlinkSync(`${testDbPath}-shm`);} catch (e) {}
+    });
+
+    test('initializes the Knowledge Base telemetry schema', () => {
+        const tables = KBRecorderService.db.prepare(`
+            SELECT name
+              FROM sqlite_master
+             WHERE type = 'table'
+               AND name IN ('kb_query_log', 'kb_query_faqs')
+        `).all();
+
+        expect(tables.map(row => row.name).sort()).toEqual(['kb_query_faqs', 'kb_query_log']);
+    });
+
+    test('captures KB MCP tool calls through the per-server wrapper', async () => {
+        const {callTool} = await import('../../../../../../../../ai/mcp/server/knowledge-base/services/toolService.mjs');
+
+        await callTool('list_agent_faqs', {limit: 5});
+
+        const row = KBRecorderService.db.prepare(`
+            SELECT tool, success, duration_ms
+              FROM kb_query_log
+             WHERE tool = 'list_agent_faqs'
+        `).get();
+
+        expect(row.tool).toBe('list_agent_faqs');
+        expect(row.success).toBe(1);
+        expect(row.duration_ms).toBeGreaterThanOrEqual(0);
+    });
+
+    test('deduplicates repeated KB questions into Agent FAQ clusters', () => {
+        const
+            originalResolve  = KBRecorderService.resolveRelatedConceptIds,
+            originalCoverage = KBRecorderService.hasStrongGuideCoverage;
+
+        KBRecorderService.resolveRelatedConceptIds = () => ['concept-reactive-config'];
+        KBRecorderService.hasStrongGuideCoverage   = () => false;
+
+        try {
+            for (const query of [
+                'How does reactive config work?',
+                'how does reactive config work',
+                'How does reactive   config work!'
+            ]) {
+                KBRecorderService.log({
+                    agent_id   : 'neo-gpt',
+                    sequence_id: crypto.randomUUID?.() || `seq-${Date.now()}`,
+                    timestamp  : Date.now(),
+                    tool       : 'ask_knowledge_base',
+                    args       : {query},
+                    result     : {answer: 'stub'},
+                    success    : true,
+                    duration_ms: 1
+                });
+            }
+
+            const built = KBRecorderService.buildAgentFaqs({minCount: 2});
+            expect(built.count).toBe(1);
+            expect(built.faqs[0].count).toBe(3);
+            expect(built.faqs[0].relatedConceptIds).toEqual(['concept-reactive-config']);
+            expect(built.faqs[0].hasStrongGuideCoverage).toBe(false);
+
+            const listed = KBRecorderService.listAgentFaqs({minCount: 2});
+            expect(listed.faqs[0].canonicalQuery).toContain('reactive');
+        } finally {
+            KBRecorderService.resolveRelatedConceptIds = originalResolve;
+            KBRecorderService.hasStrongGuideCoverage   = originalCoverage;
+        }
+    });
+});


### PR DESCRIPTION
Authored by GPT-5 (Codex Desktop). Session 293810eb-4c0e-4e57-b5e5-5b3a2c98700a.

Resolves #10081
Related: #10030

Adds durable Knowledge Base query telemetry and an Agent FAQ read model for the Concept Ontology / Golden Path loop. KB MCP calls are logged into shared SQLite `kb_query_log`, repeated `ask_knowledge_base` and `query_documents` questions are materialized into `kb_query_faqs`, the `list_agent_faqs` MCP surface exposes the read model, and `GapInferenceEngine` now emits `[KB_DEMAND_GAP]` when repeated agent questions map to concepts without strong guide coverage.

## Deltas from ticket

The first clustering pass is intentionally conservative: exact normalized-query grouping is used as the baseline, while `kbFaqSimilarityThreshold` is stored on FAQ rows as the calibration marker for later embedding-backed clustering once real traffic exists. This avoids false semantic merges before we have production query distribution data.

## Config Template Change

Changed `ai/mcp/server/knowledge-base/config.template.mjs` keys:
- `memoryCoreDbPath`
- `kbFaqMinCount`
- `kbFaqSimilarityThreshold`
- `kbFaqConceptLimit`

Local follow-up after merge: each active clone should update its gitignored `ai/mcp/server/knowledge-base/config.mjs` with these keys or recopy/apply the template defaults. Without `memoryCoreDbPath`, KB query telemetry is disabled with a warning instead of crashing.

Harness restart: recommended for Knowledge Base MCP and any daemon process that imports `GapInferenceEngine` / `GoldenPathSynthesizer`, so the new tool mapping and config shape are loaded.

## Test Evidence

- `git diff --check origin/dev...HEAD`
- `node -e "await import('./src/Neo.mjs'); await import('./src/core/_export.mjs'); const {listTools}=await import('./ai/mcp/server/knowledge-base/services/toolService.mjs'); const names=listTools({}).tools.map(t=>t.name); if (!names.includes('list_agent_faqs')) throw new Error('list_agent_faqs missing'); console.log(names.filter(n=>n.includes('faq')).join(','));"` -> `list_agent_faqs`
- `npx playwright test -c test/playwright/playwright.config.unit.mjs test/playwright/unit/ai/mcp/server/knowledge-base/services/KBRecorderService.spec.mjs test/playwright/unit/ai/daemons/DreamService.spec.mjs` -> 17 passed

## Commit

- `b86c9301c` — `feat(ai): capture KB query telemetry FAQs (#10081)`

## Post-Merge Validation

- [ ] Active clones update gitignored Knowledge Base `config.mjs` shape and restart KB MCP / daemon processes.
- [ ] Run `npm run ai:build-kb-faqs -- --min-count 3 --limit 100` after enough KB traffic exists to verify production FAQ materialization volume.