### PR TITLE
fix(ai): align swarm-heartbeat unread query with MESSAGE schema (#10622)

### DIFF
--- a/ai/scripts/swarm-heartbeat.sh
+++ b/ai/scripts/swarm-heartbeat.sh
@@ -63,7 +63,11 @@ get_unread_count() {
         echo "0"
         return
     fi
-    local count=$(sqlite3 "$DB_PATH" "SELECT count(DISTINCT n.id) FROM Nodes n JOIN Edges e ON n.id = e.source AND e.type = 'SENT_TO' WHERE json_extract(n.data, '$.type') = 'MESSAGE' AND json_extract(n.data, '$.properties.readAt') IS NULL AND e.target IN ('$IDENTITY', 'AGENT:*');" 2>/dev/null)
+    # Node label discriminator on MESSAGE rows is `$.label`, not `$.type` (substrate-schema
+    # parity with #10619 Cycle 1 finding on AGENT_MEMORY). Pre-fix query matched 0 rows
+    # regardless of mailbox state, so the token-economy gate below silently skipped every
+    # pulse — the heartbeat was a no-op for active idle agents. See #10622.
+    local count=$(sqlite3 "$DB_PATH" "SELECT count(DISTINCT n.id) FROM Nodes n JOIN Edges e ON n.id = e.source AND e.type = 'SENT_TO' WHERE json_extract(n.data, '$.label') = 'MESSAGE' AND json_extract(n.data, '$.properties.readAt') IS NULL AND e.target IN ('$IDENTITY', 'AGENT:*');" 2>/dev/null)
     echo "${count:-0}"
 }
 

--- a/test/playwright/unit/ai/scripts/swarm-heartbeat.spec.mjs
+++ b/test/playwright/unit/ai/scripts/swarm-heartbeat.spec.mjs
@@ -1,0 +1,70 @@
+import {setup} from '../../../setup.mjs';
+
+const appName = 'SwarmHeartbeatTest';
+
+setup({
+    neoConfig: {
+        unitTestMode: true
+    },
+    appConfig: {
+        name             : appName,
+        isMounted        : () => true,
+        vnodeInitialising: false
+    }
+});
+
+import {test, expect} from '@playwright/test';
+import fs             from 'fs/promises';
+import path           from 'path';
+
+/**
+ * @summary Drift guards on `ai/scripts/swarm-heartbeat.sh` — substrate-schema parity (#10622).
+ *
+ * The heartbeat shell script is sourced by long-running daemons; runtime regressions in
+ * its SQL queries silently degrade the auto-wake substrate (the daemon stays alive but
+ * its pulse becomes a no-op). The tests below structurally verify the SQL JSON paths
+ * against the live Memory Core graph schema. Pattern parity with #10619 Cycle 2's
+ * positive-extraction discipline: a previous version of `get_unread_count` queried
+ * `$.type = 'MESSAGE'` while MESSAGE nodes use `$.label`, returning 0 unread regardless
+ * of mailbox state and silently skipping every pulse via the token-economy gate.
+ */
+test.describe('ai/scripts/swarm-heartbeat', () => {
+    let scriptSrc;
+
+    test.beforeAll(async () => {
+        const scriptPath = path.resolve(process.cwd(), 'ai/scripts/swarm-heartbeat.sh');
+        scriptSrc = await fs.readFile(scriptPath, 'utf-8');
+    });
+
+    test('get_unread_count queries MESSAGE rows by $.label, not $.type (#10622 substrate-schema)', () => {
+        // Locate the function body so we assert against the right surface, not arbitrary
+        // matches elsewhere in the script.
+        const fnMatch = scriptSrc.match(/get_unread_count\(\)\s*\{[\s\S]*?^}/m);
+        expect(fnMatch, 'get_unread_count function not found in swarm-heartbeat.sh').not.toBeNull();
+
+        const body = fnMatch[0];
+
+        // Positive: function MUST query MESSAGE-labelled nodes via the schema-correct path.
+        expect(body).toMatch(/json_extract\(n\.data,\s*'\$\.label'\)\s*=\s*'MESSAGE'/);
+
+        // Negative drift guard: the legacy `$.type = 'MESSAGE'` path returns 0 against the
+        // live schema and silently skips every pulse. If a future change re-introduces it,
+        // fail the test loudly so the substrate-schema regression is caught at CI time.
+        expect(body).not.toMatch(/json_extract\(n\.data,\s*'\$\.type'\)\s*=\s*'MESSAGE'/);
+    });
+
+    test('get_unread_count emits zero for missing DB and otherwise echoes a SQLite count', () => {
+        // Surface contract: the function always echoes a non-empty integer string. Two
+        // branches — DB missing → "0"; DB present → query result with `${count:-0}` fallback.
+        // Tests that both branches preserve the integer-output contract that callers rely on
+        // (`if [ "$unread" -eq 0 ] ...`).
+        const fnMatch = scriptSrc.match(/get_unread_count\(\)\s*\{[\s\S]*?^}/m);
+        expect(fnMatch).not.toBeNull();
+
+        const body = fnMatch[0];
+
+        expect(body).toContain('if [ ! -f "$DB_PATH" ]; then');
+        expect(body).toContain('echo "0"');
+        expect(body).toContain('echo "${count:-0}"');
+    });
+});

--- a/test/playwright/unit/ai/scripts/swarm-heartbeat.spec.mjs
+++ b/test/playwright/unit/ai/scripts/swarm-heartbeat.spec.mjs
@@ -13,20 +13,23 @@ setup({
     }
 });
 
-import {test, expect} from '@playwright/test';
-import fs             from 'fs/promises';
-import path           from 'path';
+import {test, expect}     from '@playwright/test';
+import {execFileSync}     from 'child_process';
+import fs                 from 'fs/promises';
+import path               from 'path';
 
 /**
- * @summary Drift guards on `ai/scripts/swarm-heartbeat.sh` — substrate-schema parity (#10622).
+ * @summary Drift guards + fixture-backed regression coverage on `ai/scripts/swarm-heartbeat.sh` (#10622).
  *
  * The heartbeat shell script is sourced by long-running daemons; runtime regressions in
  * its SQL queries silently degrade the auto-wake substrate (the daemon stays alive but
- * its pulse becomes a no-op). The tests below structurally verify the SQL JSON paths
- * against the live Memory Core graph schema. Pattern parity with #10619 Cycle 2's
- * positive-extraction discipline: a previous version of `get_unread_count` queried
- * `$.type = 'MESSAGE'` while MESSAGE nodes use `$.label`, returning 0 unread regardless
- * of mailbox state and silently skipping every pulse via the token-economy gate.
+ * its pulse becomes a no-op). These tests verify both:
+ *   1) Structural shape — the SQL JSON paths target the live Memory Core schema.
+ *   2) Behavioral fixture coverage — the `get_unread_count` function returns nonzero
+ *      against a fresh SQLite fixture seeded with a MESSAGE node + SENT_TO edge, and
+ *      the legacy `$.type = 'MESSAGE'` query returns zero against the same fixture
+ *      (regression-shape proof — same family as #10619 Cycle 2's positive-extraction
+ *      pattern on AGENT_MEMORY).
  */
 test.describe('ai/scripts/swarm-heartbeat', () => {
     let scriptSrc;
@@ -66,5 +69,65 @@ test.describe('ai/scripts/swarm-heartbeat', () => {
         expect(body).toContain('if [ ! -f "$DB_PATH" ]; then');
         expect(body).toContain('echo "0"');
         expect(body).toContain('echo "${count:-0}"');
+    });
+
+    test.describe('fixture-backed regression coverage (#10622 acceptance)', () => {
+        let tmpBase;
+        let dbPath;
+        const TEST_IDENTITY = '@test-agent-10622';
+
+        test.beforeEach(async () => {
+            tmpBase = path.resolve(process.cwd(), 'tmp', `swarm-heartbeat-test-${process.pid}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`);
+            dbPath  = path.join(tmpBase, 'test-graph.sqlite');
+            await fs.mkdir(tmpBase, {recursive: true});
+
+            // Seed a minimal Nodes+Edges schema mirroring `memory-core-graph.sqlite`. We omit
+            // the GraphLog triggers since this fixture exercises only the read path; foreign-key
+            // constraints stay enabled so the SENT_TO edge requires both endpoints to exist.
+            execFileSync('sqlite3', [dbPath], {
+                encoding: 'utf-8',
+                input   : [
+                    'CREATE TABLE Nodes (id TEXT PRIMARY KEY, data TEXT NOT NULL, user_id TEXT);',
+                    'CREATE TABLE Edges (id TEXT PRIMARY KEY, source TEXT NOT NULL, target TEXT NOT NULL, type TEXT NOT NULL, data TEXT NOT NULL, user_id TEXT, FOREIGN KEY (source) REFERENCES Nodes(id) ON DELETE CASCADE, FOREIGN KEY (target) REFERENCES Nodes(id) ON DELETE CASCADE);',
+                    `INSERT INTO Nodes(id, data) VALUES ('${TEST_IDENTITY}', '{"id":"${TEST_IDENTITY}","label":"AGENT"}');`,
+                    // Unread MESSAGE — should be counted (label matches, readAt is JSON null).
+                    `INSERT INTO Nodes(id, data) VALUES ('MSG:unread-1', '{"id":"MSG:unread-1","label":"MESSAGE","properties":{"name":"unread test","readAt":null}}');`,
+                    `INSERT INTO Edges(id, source, target, type, data) VALUES ('e:unread-1', 'MSG:unread-1', '${TEST_IDENTITY}', 'SENT_TO', '{}');`,
+                    // Read MESSAGE — should NOT be counted (readAt is set to a non-null timestamp).
+                    `INSERT INTO Nodes(id, data) VALUES ('MSG:read-1', '{"id":"MSG:read-1","label":"MESSAGE","properties":{"name":"already read","readAt":"2026-05-03T08:00:00Z"}}');`,
+                    `INSERT INTO Edges(id, source, target, type, data) VALUES ('e:read-1', 'MSG:read-1', '${TEST_IDENTITY}', 'SENT_TO', '{}');`
+                ].join('\n')
+            });
+        });
+
+        test.afterEach(async () => {
+            if (tmpBase) {
+                await fs.rm(tmpBase, {recursive: true, force: true}).catch(() => {});
+            }
+        });
+
+        test('get_unread_count returns 1 for a fixture with one unread MESSAGE-labelled row', () => {
+            // Extract the function definition from the production script and re-define it inside
+            // a bash subshell with DB_PATH+IDENTITY pointed at our fixture. Tests THE production
+            // function — not a paraphrase of its query — so any drift in the actual script
+            // surface immediately fails the spec at CI time.
+            const fnSrc  = scriptSrc.match(/get_unread_count\(\)\s*\{[\s\S]*?^}/m)[0];
+            const result = execFileSync('bash', ['-c', `${fnSrc}; get_unread_count`], {
+                encoding: 'utf-8',
+                env     : {...process.env, DB_PATH: dbPath, IDENTITY: TEST_IDENTITY}
+            });
+
+            expect(result.trim()).toBe('1');
+        });
+
+        test('legacy $.type query returns 0 against the same fixture (regression-shape proof)', () => {
+            // Same fixture, swap the corrected `$.label` JSON path for the legacy `$.type` path.
+            // If this assertion ever flips to 1, either the live schema migrated or someone
+            // mass-rewrote MESSAGE rows — both warrant updating this test, not just the script.
+            const legacyQuery = `SELECT count(DISTINCT n.id) FROM Nodes n JOIN Edges e ON n.id = e.source AND e.type = 'SENT_TO' WHERE json_extract(n.data, '$.type') = 'MESSAGE' AND json_extract(n.data, '$.properties.readAt') IS NULL AND e.target IN ('${TEST_IDENTITY}', 'AGENT:*');`;
+            const result      = execFileSync('sqlite3', [dbPath, legacyQuery], {encoding: 'utf-8'});
+
+            expect(result.trim()).toBe('0');
+        });
     });
 });


### PR DESCRIPTION
Authored by Claude Opus 4.7 (Claude Desktop). Session b1839431-cba1-4b6d-913f-27b09e472e67.

Resolves #10622

## Outcome summary

`swarm-heartbeat.sh:get_unread_count()` queried `$.type = 'MESSAGE'` but MESSAGE nodes use `$.label`. The query returned 0 unread regardless of mailbox state. The token-economy gate immediately below (line 161) then silently skipped every pulse, making the auto-wake heartbeat substrate a no-op for active idle agents in non-tmux harnesses.

This PR is the substrate-truth correction. It does NOT address the broader "active-idle non-tmux delivery" structural gap — that's a separate design lane. The fix here unblocks the existing heartbeat path so its eventual injection-layer extension has something real to dispatch.

**Cycle 2 update:** @neo-gpt's Cycle 1 RA flagged that the initial spec encoded only structural drift guards, not the #10622 acceptance criterion ("get_unread_count returns nonzero when MESSAGE-labelled rows exist"). Cycle 2 commit `22274a056` adds fixture-backed behavioral coverage — extracts the production function definition from the script source, redefines it in a bash subshell pointed at a temp SQLite fixture pre-seeded with one unread + one read MESSAGE row, asserts the count is 1 (proves both the corrected `$.label` path AND the readAt-IS-NULL filter). Plus a regression-shape proof: the legacy `$.type` query against the same fixture returns 0.

## Diff: 2 files (+138 / -1)

| File | Change |
|---|---|
| `ai/scripts/swarm-heartbeat.sh` | `get_unread_count()` query: `$.type = 'MESSAGE'` → `$.label = 'MESSAGE'`. Inline comment cites #10619 Cycle 1 substrate-schema parity as the anchor pattern. |
| `test/playwright/unit/ai/scripts/swarm-heartbeat.spec.mjs` | New file. Two structural tests (positive `$.label` assertion, negative `$.type` drift guard, surface contract on integer output) plus two fixture-backed tests in a `describe` block (production function returns 1 against a seeded fixture; legacy query returns 0 against the same fixture). |

## Empirical anchor (cross-family, 2 agents)

| Agent | `$.type` query | `$.label` query | Mailbox preview unread |
|---|---|---|---|
| @neo-opus-4-7 | 0 | 48 | 48–49 |
| @neo-gpt     | 0 | 20 | (matches Codex inventory) |

8h43m idle gap on 2026-05-02→05-03 morning with 3 `swarm-heartbeat.sh` instances running, **zero pulse output across ~104 expected cycles** per logs at `.neo-ai-data/wake-daemon/heartbeat-*.log`. Logs only showed startup banners ("Starting Sleep-Cycle MVP Heartbeat Wrapper..." / "Booting Agent Session...") — every pulse cycle hit the broken query, returned 0 unread, and the token-economy gate silently `continue`d.

## Acceptance Criteria status

| AC | Status |
|---|---|
| Query uses `$.label = 'MESSAGE'` against MESSAGE-labelled rows | ✅ Single-line change with inline comment explaining the structural anchor |
| Spec coverage: behavioral test that asserts `get_unread_count` returns nonzero when MESSAGE-labelled rows exist | ✅ Cycle 2 fixture-backed test extracts the production function from script source, runs it against a seeded SQLite fixture, asserts count = 1 |
| Spec coverage: structural drift guards | ✅ Positive `$.label` assertion + negative `$.type` drift guard + surface-contract test on integer output |
| PR body cites empirical query results from cross-family substrates as ground-truth anchor | ✅ Table above |

## Test Evidence (post-Cycle-2)

```
$ playwright test test/playwright/unit/ai/scripts/swarm-heartbeat.spec.mjs
Running 4 tests using 1 worker

  ✓ ai/scripts/swarm-heartbeat › get_unread_count queries MESSAGE rows by $.label, not $.type (#10622 substrate-schema)
  ✓ ai/scripts/swarm-heartbeat › get_unread_count emits zero for missing DB and otherwise echoes a SQLite count
  ✓ ai/scripts/swarm-heartbeat › fixture-backed regression coverage (#10622 acceptance) › get_unread_count returns 1 for a fixture with one unread MESSAGE-labelled row
  ✓ ai/scripts/swarm-heartbeat › fixture-backed regression coverage (#10622 acceptance) › legacy $.type query returns 0 against the same fixture (regression-shape proof)

  4 passed (955ms)
```

`git diff --check origin/dev...HEAD` clean. No `<noreply@*>` Co-Authored-By footers.

## Cross-Family Mandate

Single-peer review request to **@neo-gpt** as primary-reviewer — he proposed the continuation split that placed this PR first ([MESSAGE:3d80ed90...](https://github.com/neomjs/neo/issues/10622)) and confirmed the bug independently from the Codex side ($.type=0 vs $.label=20 on his substrate). Cycle 1 RA correctly caught that initial spec was structural-only; Cycle 2 fixture-backed coverage addresses that gap.

## Avoided Traps

- ❌ **Don't add a `$.type` fallback "for compatibility"** — no live MESSAGE rows use `$.type`. The negative drift guard + regression-shape proof both explicitly forbid re-introduction.
- ❌ **Don't fold this into the active-idle non-tmux delivery design lane** — that's a separate scoping concern. This PR is the substrate-truth correction; the design lane is what makes the (now-functional) injection path useful for non-tmux harnesses.
- ❌ **Don't fold into identity-normalization hardening** — independent root cause; same structural family but different surface. Separate small PR per @neo-gpt's continuation split.
- ✅ **Hollow-success category caught at substrate-truth layer** — pre-existing test coverage exercised only the empty-DB fallback path, never the substrate query itself. New positive-extraction + negative drift guard + fixture-backed behavioral pattern (mirrors #10619 Cycle 2's `checkSunsetted` discipline) catches the category structurally AND mechanically.

## Provenance

- Operator-discovery: @tobiu reported all 3 swarm agents idled overnight despite `swarm-heartbeat.sh` daemons running per-identity.
- Cross-family substrate confirmation: @neo-gpt's MESSAGE:3d80ed90 (Codex side, $.type=0 vs $.label=20) + my MESSAGE:6a833fa3 (Claude Desktop side, $.type=0 vs $.label=48).
- Pattern anchor: structurally identical substrate-schema drift as PR #10619 Cycle 1 (AGENT_MEMORY query targeted `'MEMORY' + properties.agent` against substrate using `'AGENT_MEMORY' + properties.userId`). Cycle 2 fixture-backed coverage mirrors #10619 Cycle 2's discipline correction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
