### PR TITLE
feat(ai): implement all-agent-idle detection primitive (#10625)

### DIFF
--- a/ai/scripts/checkAllAgentIdle.mjs
+++ b/ai/scripts/checkAllAgentIdle.mjs
@@ -1,0 +1,104 @@
+#!/usr/bin/env node
+/**
+ * @summary All-agent-idle detection at heartbeat layer (Substrate Primitive #10625).
+ *
+ * This script queries the SQLite GraphLog to determine if ALL configured agents
+ * in the swarm trio are idle (i.e. their last AGENT_MEMORY timestamp is older
+ * than IDLE_THRESHOLD).
+ *
+ * Detector Contract:
+ * - Emits a structured `AllAgentIdleSignal` when the all-idle predicate holds.
+ * - Signal shape:
+ *   {
+ *     "allIdle": boolean,
+ *     "cycle_id": string,
+ *     "identities": string[],
+ *     "coordinator_recommendation": string,
+ *     "details": { [identity]: { "lastMemTime": string, "ageMs": number } }
+ *   }
+ */
+import Neo from '../../src/Neo.mjs';
+import * as core from '../../src/core/_export.mjs';
+import LifecycleService from '../mcp/server/memory-core/services/lifecycle/SystemLifecycleService.mjs';
+import GraphService from '../mcp/server/memory-core/services/GraphService.mjs';
+
+async function main() {
+    await LifecycleService.initAsync();
+    await GraphService.initAsync();
+    const db = GraphService.db.storage.db;
+
+    const cycleId = process.argv[2] || Math.floor(Date.now() / 1000).toString();
+    const identitiesEnv = process.env.NEO_TRIO_IDENTITIES || '@neo-gemini-3-1-pro,@neo-opus-4-7,@neo-gpt';
+    const identities = identitiesEnv.split(',').map(s => s.trim()).filter(Boolean);
+
+    const thresholdMs = parseInt(process.env.IDLE_THRESHOLD_MS, 10) || 10 * 60 * 1000;
+    const now = Date.now();
+
+    let allIdle = true;
+    const details = {};
+    let earliestIdledIdentity = null;
+    let maxAge = -1;
+
+    for (const identity of identities) {
+        const memStmt = db.prepare(`
+            SELECT id,
+                   data,
+                   json_extract(data, '$.properties.name')        as nameField,
+                   json_extract(data, '$.properties.description') as descField,
+                   json_extract(data, '$.properties.timestamp')   as timestampField,
+                   json_extract(data, '$.properties.sessionId')   as sessionIdField
+            FROM Nodes
+            WHERE json_extract(data, '$.label') = 'AGENT_MEMORY'
+              AND (json_extract(data, '$.properties.agentIdentity') = ? OR json_extract(data, '$.properties.userId') = ?)
+            ORDER BY COALESCE(json_extract(data, '$.properties.timestamp'), json_extract(data, '$.properties.name')) DESC
+            LIMIT 1
+        `);
+        const memRow = memStmt.get(identity, identity);
+
+        let lastMemTime = memRow?.timestampField || null;
+
+        // Fallback for legacy regex extraction per #10623 if timestamp structured field is absent
+        if (memRow && !lastMemTime) {
+            const tsMatch = memRow.nameField?.match(/^Memory:\s+(.+)$/);
+            if (tsMatch?.[1]) {
+                lastMemTime = tsMatch[1];
+            }
+        }
+
+        let ageMs = 0;
+        if (lastMemTime) {
+            ageMs = now - new Date(lastMemTime).getTime();
+        } else {
+            // Boundary case: If no AGENT_MEMORY rows exist for the identity, treat them as fully idle
+            // so they don't block the all-idle predicate on fresh checkouts.
+            ageMs = Infinity; 
+        }
+
+        details[identity] = { lastMemTime, ageMs };
+
+        if (ageMs <= thresholdMs) {
+            allIdle = false;
+        }
+
+        if (ageMs > maxAge) {
+            maxAge = ageMs;
+            earliestIdledIdentity = identity;
+        }
+    }
+
+    const signal = {
+        allIdle,
+        cycle_id: cycleId,
+        identities,
+        coordinator_recommendation: earliestIdledIdentity,
+        details
+    };
+
+    console.log(JSON.stringify(signal));
+    process.exit(0);
+}
+
+main().catch(err => {
+    console.error('checkAllAgentIdle failed:', err.message);
+    process.exit(1);
+});

--- a/ai/scripts/swarm-heartbeat.sh
+++ b/ai/scripts/swarm-heartbeat.sh
@@ -156,6 +156,17 @@ heartbeat_pulse() {
             fi
         fi
 
+        # All-agent-idle detection (Phase 3 Substrate Primitive #10625)
+        local cycle_id=$(date +%s)
+        local all_idle_json=$(node "${script_dir}/checkAllAgentIdle.mjs" "$cycle_id" 2>>"$SWEEP_LOG")
+        if [ $? -eq 0 ] && [ -n "$all_idle_json" ]; then
+            local is_all_idle=$(echo "$all_idle_json" | jq -r '.allIdle')
+            if [ "$is_all_idle" = "true" ]; then
+                echo "[heartbeat $(date -Iseconds)] AllAgentIdle detected: $all_idle_json" >&2
+                # The cooldown layer #10626 will hook here to decide whether to emit a WAKE event.
+            fi
+        fi
+
         # Heartbeat-Bypass Detection
         local push_identities=$(get_push_capable_identities)
         if echo "$push_identities" | grep -Fq "$IDENTITY"; then

--- a/test/playwright/unit/ai/scripts/checkAllAgentIdle.spec.mjs
+++ b/test/playwright/unit/ai/scripts/checkAllAgentIdle.spec.mjs
@@ -1,0 +1,148 @@
+import {setup} from '../../../setup.mjs';
+
+const appName = 'AllAgentIdleDetectionTest';
+
+setup({
+    neoConfig: {
+        unitTestMode: true
+    },
+    appConfig: {
+        name             : appName,
+        isMounted        : () => true,
+        vnodeInitialising: false
+    }
+});
+
+import {test, expect} from '@playwright/test';
+import {execFileSync} from 'child_process';
+import path           from 'path';
+import Neo            from '../../../../../src/Neo.mjs';
+import * as core      from '../../../../../src/core/_export.mjs';
+
+/**
+ * @summary Validation for Phase 3 Substrate Primitive #10625: All-Agent-Idle Detection.
+ */
+test.describe('ai/scripts/checkAllAgentIdle', () => {
+    const identitiesEnv = '@neo-test-agent-1,@neo-test-agent-2';
+
+    test('checkAllAgentIdle.mjs emits positive signal when all configured agents are idle', async () => {
+        const GraphService = (await import('../../../../../ai/mcp/server/memory-core/services/GraphService.mjs')).default;
+        await GraphService.initAsync();
+
+        // 1. Setup mock memory rows for both agents that are OLDER than threshold
+        const oldTime = new Date(Date.now() - 20 * 60 * 1000).toISOString(); // 20 mins ago
+
+        const insertStmt = GraphService.db.storage.db.prepare(`
+            INSERT INTO Nodes (id, user_id, data) VALUES (?, ?, ?)
+            ON CONFLICT(id) DO UPDATE SET data=excluded.data
+        `);
+
+        ['@neo-test-agent-1', '@neo-test-agent-2'].forEach(id => {
+            const dataObj = {
+                id: `memory-${id}`,
+                label: 'AGENT_MEMORY',
+                type: 'AGENT_MEMORY',
+                properties: {
+                    agentIdentity: id,
+                    timestamp: oldTime
+                }
+            };
+            insertStmt.run(`memory-${id}`, id, JSON.stringify(dataObj));
+        });
+
+        // 2. Execute script
+        const scriptPath = path.resolve(process.cwd(), 'ai/scripts/checkAllAgentIdle.mjs');
+        const output = execFileSync('node', [scriptPath, '12345'], {
+            encoding: 'utf-8',
+            env: { 
+                ...process.env, 
+                NEO_UNIT_TEST_MODE: 'true',
+                NEO_TRIO_IDENTITIES: identitiesEnv,
+                IDLE_THRESHOLD_MS: '600000' // 10 minutes
+            }
+        });
+        const parsed = JSON.parse(output);
+
+        // 3. Assert positive signal
+        expect(parsed.allIdle).toBe(true);
+        expect(parsed.cycle_id).toBe('12345');
+        expect(parsed.identities.length).toBe(2);
+        expect(parsed.details['@neo-test-agent-1'].ageMs).toBeGreaterThan(600000);
+        expect(parsed.details['@neo-test-agent-2'].ageMs).toBeGreaterThan(600000);
+    });
+
+    test('checkAllAgentIdle.mjs emits negative signal when at least one agent is active', async () => {
+        const GraphService = (await import('../../../../../ai/mcp/server/memory-core/services/GraphService.mjs')).default;
+        await GraphService.initAsync();
+
+        // 1. Setup mock memory rows. Agent 1 is old, Agent 2 is new
+        const oldTime = new Date(Date.now() - 20 * 60 * 1000).toISOString(); // 20 mins ago
+        const newTime = new Date(Date.now() - 2 * 60 * 1000).toISOString();  // 2 mins ago
+
+        const insertStmt = GraphService.db.storage.db.prepare(`
+            INSERT INTO Nodes (id, user_id, data) VALUES (?, ?, ?)
+            ON CONFLICT(id) DO UPDATE SET data=excluded.data
+        `);
+
+        [
+            { id: '@neo-test-agent-1', time: oldTime },
+            { id: '@neo-test-agent-2', time: newTime }
+        ].forEach(item => {
+            const dataObj = {
+                id: `memory-active-${item.id}`,
+                label: 'AGENT_MEMORY',
+                type: 'AGENT_MEMORY',
+                properties: {
+                    agentIdentity: item.id,
+                    timestamp: item.time
+                }
+            };
+            insertStmt.run(`memory-active-${item.id}`, item.id, JSON.stringify(dataObj));
+        });
+
+        // 2. Execute script
+        const scriptPath = path.resolve(process.cwd(), 'ai/scripts/checkAllAgentIdle.mjs');
+        const output = execFileSync('node', [scriptPath, '12346'], {
+            encoding: 'utf-8',
+            env: { 
+                ...process.env, 
+                NEO_UNIT_TEST_MODE: 'true',
+                NEO_TRIO_IDENTITIES: identitiesEnv,
+                IDLE_THRESHOLD_MS: '600000'
+            }
+        });
+        const parsed = JSON.parse(output);
+
+        // 3. Assert negative signal
+        expect(parsed.allIdle).toBe(false);
+        expect(parsed.details['@neo-test-agent-2'].ageMs).toBeLessThan(600000);
+    });
+
+    test('checkAllAgentIdle.mjs treats boundary condition (no AGENT_MEMORY rows) as fully idle', async () => {
+        // Execute script with an entirely unknown identity set
+        const scriptPath = path.resolve(process.cwd(), 'ai/scripts/checkAllAgentIdle.mjs');
+        const output = execFileSync('node', [scriptPath, '12347'], {
+            encoding: 'utf-8',
+            env: { 
+                ...process.env, 
+                NEO_UNIT_TEST_MODE: 'true',
+                NEO_TRIO_IDENTITIES: '@neo-ghost-agent-1',
+                IDLE_THRESHOLD_MS: '600000'
+            }
+        });
+        const parsed = JSON.parse(output);
+
+        // Assert boundary signal
+        expect(parsed.allIdle).toBe(true);
+        expect(parsed.details['@neo-ghost-agent-1'].lastMemTime).toBeNull();
+        expect(parsed.details['@neo-ghost-agent-1'].ageMs).toBe(null); // Infinity JSON encodes to null
+    });
+
+    test('swarm-heartbeat.sh integrates the all-agent-idle detection properly', async () => {
+        const fs = await import('fs/promises');
+        const script = await fs.readFile(path.resolve(process.cwd(), 'ai/scripts/swarm-heartbeat.sh'), 'utf-8');
+        const allIdleIndex = script.indexOf('checkAllAgentIdle.mjs');
+        
+        expect(allIdleIndex).toBeGreaterThan(-1);
+    });
+});


### PR DESCRIPTION
Authored by Gemini 3.1 Pro (Antigravity). Session ba7c6393-6378-4905-bf62-12eca4954583.

Resolves #10625

Implements the Phase 3 Substrate Primitive for all-agent-idle detection within the `swarm-heartbeat.sh` script, allowing downstream cooldown layers to detect 24/7 trio liveness gaps.

## Deltas from ticket (if any)
- Iteration is executed entirely within `checkAllAgentIdle.mjs` rather than pure bash array logic. This is cleaner and more robust because the logic relies heavily on querying `GraphLog` database records using complex `json_extract` conditions and fallback extractions for unstructured rows.

## Test Evidence
- `npx playwright test test/playwright/unit/ai/scripts/checkAllAgentIdle.spec.mjs`
- 4 tests passed testing positive idle signals, negative signals, and boundary conditions with unknown identities.
