### PR TITLE
fix(memory-core): include Codex in wake subscription canonical appNames (#10636)

### DIFF
--- a/ai/mcp/server/memory-core/services/WakeSubscriptionService.mjs
+++ b/ai/mcp/server/memory-core/services/WakeSubscriptionService.mjs
@@ -56,9 +56,17 @@ class WakeSubscriptionService extends Base {
 
     /**
      * @member {String[]} validAppNames
+     *
+     * Canonical osascript target app names accepted on Shape C subscription writes. One entry per
+     * harness onboarded into the swarm trio: Antigravity (@neo-gemini-3-1-pro), Claude
+     * (@neo-opus-4-7), Codex (@neo-gpt). The bridge daemon dispatches via `tell application
+     * "<appName>"`, so list completeness is load-bearing — a missing entry rejects the canonical
+     * AgentIdentity.subscriptionTemplate at auto-bootstrap time and silently strands the
+     * corresponding harness from Shape C wake delivery (per #10636 regression after PR #10628).
+     *
      * @protected
      */
-    validAppNames = ['Antigravity', 'Claude']
+    validAppNames = ['Antigravity', 'Claude', 'Codex']
 
     /**
      * In-memory write-through cache for sub-millisecond trigger evaluation.

--- a/test/playwright/unit/ai/mcp/server/memory-core/services/WakeSubscriptionService.spec.mjs
+++ b/test/playwright/unit/ai/mcp/server/memory-core/services/WakeSubscriptionService.spec.mjs
@@ -243,16 +243,38 @@ test.describe('Neo.ai.mcp.server.memory-core.services.WakeSubscriptionService', 
                 trigger      : 'SENT_TO_ME',
                 harnessTarget: 'bridge-daemon',
                 harnessTargetMetadata: {appName: 'antigravity'}
-            })).rejects.toThrow("Invalid appName 'antigravity'. Must be one of: Antigravity, Claude");
+            })).rejects.toThrow("Invalid appName 'antigravity'. Must be one of: Antigravity, Claude, Codex");
         });
     });
 
-    test('subscribe accepts canonical appName', async () => {
+    test('subscribe accepts canonical appName Antigravity', async () => {
         await RequestContextService.run({agentIdentityNodeId: '@alice'}, async () => {
             const res = await WakeSubscriptionService.subscribe({
                 trigger      : 'SENT_TO_ME',
                 harnessTarget: 'bridge-daemon',
                 harnessTargetMetadata: {appName: 'Antigravity'}
+            });
+            expect(res.subscriptionId).toMatch(/^WAKE_SUB:/);
+        });
+    });
+
+    test('subscribe accepts canonical appName Claude', async () => {
+        await RequestContextService.run({agentIdentityNodeId: '@alice'}, async () => {
+            const res = await WakeSubscriptionService.subscribe({
+                trigger      : 'SENT_TO_ME',
+                harnessTarget: 'bridge-daemon',
+                harnessTargetMetadata: {appName: 'Claude'}
+            });
+            expect(res.subscriptionId).toMatch(/^WAKE_SUB:/);
+        });
+    });
+
+    test('subscribe accepts canonical appName Codex', async () => {
+        await RequestContextService.run({agentIdentityNodeId: '@alice'}, async () => {
+            const res = await WakeSubscriptionService.subscribe({
+                trigger      : 'SENT_TO_ME',
+                harnessTarget: 'bridge-daemon',
+                harnessTargetMetadata: {appName: 'Codex'}
             });
             expect(res.subscriptionId).toMatch(/^WAKE_SUB:/);
         });


### PR DESCRIPTION
Resolves #10636

Authored by Claude Opus 4.7 (Claude Code). Session 9766f91c-51f8-44fe-ac34-d79f61a0e1bf.

## Outcome

Adds `'Codex'` to `WakeSubscriptionService.validAppNames`, restoring `@neo-gpt` (Codex harness) wake-substrate reachability after PR #10628's allow-list omission silently stranded it on MCP server restart.

`@neo-gpt`'s canonical `AgentIdentity.subscriptionTemplate` already specifies `harnessTargetMetadata.appName: 'Codex'`. Pre-#10628, the MCP auto-bootstrap path (#10437/#10438) wrote the sub from this template without validation. Post-#10628, `validateMetadata` throws `"Invalid appName 'Codex'. Must be one of: Antigravity, Claude"` and the sub is silently NOT created — Codex receives messages via `list_messages` but no Shape C wake injection.

## Empirical Anchors

**bridge-daemon log** (PID 43092, post-restart 2026-05-03T12:51:49Z):

```
[12:58:14.073Z] [ERROR] Failed to deliver via osascript: osascript exited with code 1
[12:58:17.093Z] [ERROR] Failed to deliver via osascript: osascript exited with code 1
[12:59:35.101Z] [ERROR] Failed to deliver via osascript: osascript exited with code 1
```

Trace correlation per @neo-gpt cross-family A2A diagnostic anchor:
- 12:57:41Z @neo-gpt → @neo-opus-4-7 → 12:58:14Z osascript fail (within 30s coalescing window)
- 12:57:45Z @neo-gpt → @neo-gemini-3-1-pro → 12:58:17Z osascript fail
- 12:59:03Z @neo-gemini-3-1-pro → @neo-opus-4-7 (high) → 12:59:35Z osascript fail

**SQLite WAKE_SUBSCRIPTION rows** post-restart show only 2 active Shape C subs (Gemini's Antigravity + my Claude); no `@neo-gpt` row.

**Live MCP probe** from a fresh @neo-gpt Codex session: `manage_wake_subscription({action:'bootstrap'})` rejects with *"no subscriptionTemplate found on AgentIdentity '@neo-gpt'"* despite raw SQLite confirming the template exists — `validAppNames` rejection is one of two failure surfaces (the other being a separate cache-staleness concern, scoped out of this PR per the ticket body).

#10624's Fix section literally specified the deferral: *"currently: 'Antigravity', 'Claude'; future identities added as harness registry expands"*. This PR cashes that future-identities marker.

## Test Evidence

```
npm run test-unit -- WakeSubscriptionService.spec.mjs
  33 passed (1.7s)
```

Spec extension is symmetric:
- Existing negative-case test now expects `"Must be one of: Antigravity, Claude, Codex"` (updated allow-list).
- 3 positive-case tests (`Antigravity` / `Claude` / `Codex`) replacing the prior single positive-case (`Antigravity` only). One assertion shape per canonical entry.

## Post-Merge Validation

- [ ] After MCP server restart, `WakeSubscriptionService.bootstrap` for `@neo-gpt` AgentIdentity creates a fresh Shape C sub. SQLite `SELECT json_extract(data,'$.properties.harnessTargetMetadata.appName') FROM Nodes WHERE id LIKE 'WAKE_SUB:%' AND json_extract(data,'$.properties.agentIdentity') = '@neo-gpt'` returns `Codex`.
- [ ] bridge-daemon successfully delivers an A2A message addressed to `@neo-gpt` via osascript to Codex (verified via `bridge.log` `Delivered ... via osascript to Codex` line).
- [ ] If post-merge bootstrap still fails despite the validation fix, the residual cause is the GraphService cache staleness `@neo-gpt` flagged — separate ticket scope, NOT this PR.

## Out of Scope (separately tracked)

- bridge-daemon `stdio:'ignore'` swallows osascript stderr. The 3 failures here were initially undiagnosable until @neo-gpt's manual probe surfaced the underlying TCC denial. Pure observability defense-in-depth, will be filed as a separate ticket.
- MCP `GraphService` cache staleness on `AgentIdentity` at restart (separate substrate concern).
- macOS TCC keystroke permission revocation at process-tree restart — addressed by @tobiu in System Settings; not a code concern.

## Related

- Parent: #10601 (substrate-stack Epic, lane #5 canonical wake routes)
- Direct precursor: #10624 / PR #10628 (introduced the allow-list with the literal "future identities" deferral marker)
- Trio canonicalization: PR #10631 (#10625 all-agent-idle detection) — `NEO_TRIO_IDENTITIES` env default lists `@neo-gpt` explicitly
- Substrate-truth class siblings: #10619 Cycle 1 (`AGENT_MEMORY` label drift), #10623 Cycle 1 (`$.label` query drift) — same allow-list-incompleteness failure family