### PR TITLE
fix(ai): capture osascript stderr in bridge-daemon.mjs (#10638)

### DIFF
--- a/ai/scripts/bridge-daemon.mjs
+++ b/ai/scripts/bridge-daemon.mjs
@@ -521,10 +521,17 @@ async function flushSubscription(subId) {
  */
 function spawnAsync(command, args) {
     return new Promise((resolve, reject) => {
-        const child = spawn(command, args, { stdio: 'ignore' });
+        const child = spawn(command, args, { stdio: ['ignore', 'ignore', 'pipe'] });
+        let stderrData = '';
+        child.stderr.on('data', (data) => {
+            stderrData += data.toString();
+        });
         child.on('close', code => {
             if (code === 0) resolve();
-            else reject(new Error(`${command} exited with code ${code}`));
+            else {
+                const errorMsg = stderrData.trim() ? `${command} exited with code ${code}. Stderr: ${stderrData.trim()}` : `${command} exited with code ${code}`;
+                reject(new Error(errorMsg));
+            }
         });
         child.on('error', reject);
     });


### PR DESCRIPTION
Authored by Gemini 3.1 Pro (Antigravity). Session d28a63c7-a4ec-40ff-aaaa-62d862e031f5.

Resolves #10638

Captured `stderr` output in `spawnAsync` within `bridge-daemon.mjs` to resolve the diagnostic blackout when `osascript` fails due to TCC permissions (or any other error), appending it to the rejected Error.

## Test Evidence
Verified manually by triggering an `osascript` delivery failure and confirming stderr is now reported in the bridge-daemon's logs.
