### PR TITLE
fix(ai): remove memory-staleness branch from checkSunsetted (#10641)

### DIFF
--- a/ai/scripts/checkSunsetted.mjs
+++ b/ai/scripts/checkSunsetted.mjs
@@ -80,21 +80,28 @@ async function main() {
         }
     }
 
+    // [Anchor & Echo] Sunset detection criterion: ONLY the explicit Unsubscribe primitive.
+    //
+    // Memory-staleness is NOT a sunset signal. It has too many legitimate causes to serve
+    // as a sunset proxy: Anthropic API rate-limits (the agent cannot save during throttle),
+    // long deep-thinking turns (peer reviews, complex analysis), Memory Core path
+    // asymmetry under contention (`add_memory` blocks on Chroma while `add_message` keeps
+    // working on SQLite), or in-flight tool sequences with consolidate-and-save still
+    // pending. Conflating staleness with sunset previously triggered Phase 1 Recovery
+    // (`resumeHarness.mjs` Cmd+N + paste of `buildBootGroundingPrompt`) against
+    // legitimately active agents, spawning orphan Claude Desktop sessions with zero
+    // continuity context (Zero-State Amnesia per `AGENTS.md` §14).
+    //
+    // The authoritative sunset signal is the Unsubscribe primitive: the `session-sunset`
+    // workflow drops the WAKE_SUBSCRIPTION node before terminating the transcript. Any
+    // wake against an agent that still holds an active subscription is a non-sunset wake
+    // and MUST be delivered in-place by `bridge-daemon.mjs` (Cmd+`<tabShortcut>` + paste);
+    // that is the wake substrate's design contract per the operator's clarified model
+    // (issue #10641): "the bridge SHOULD spawn new sessions. but only after a sunset.
+    // otherwise => resume inside current session."
     if (subs.length === 0) {
         isSunsetted = true;
         reason = 'No active WAKE_SUBSCRIPTION (Unsubscribe primitive fired)';
-    } else if (lastMemTime) {
-        const lastMemMs   = new Date(lastMemTime).getTime();
-        const ageMs       = Date.now() - lastMemMs;
-        const thresholdMs = parseInt(process.env.SUNSET_THRESHOLD_MS, 10) || 10 * 60 * 1000;
-        if (ageMs > thresholdMs) {
-            isSunsetted = true;
-            reason = `Last memory is ${Math.round(ageMs / 60000)}m old (>${Math.round(thresholdMs/60000)}m threshold)`;
-        }
-    } else {
-        // No memory and has subscription? Assume active (just booted).
-        // But if it's older than 10m? We don't have boot time. We'll rely on memory.
-        // Actually, if no memory exists AT ALL, it's a fresh DB. Not sunsetted.
     }
 
     console.log(JSON.stringify({

--- a/ai/scripts/checkSunsetted.mjs
+++ b/ai/scripts/checkSunsetted.mjs
@@ -2,8 +2,21 @@
 /**
  * @summary Auto-Wakeup Substrate Detection Logic (Epic #10601).
  *
- * This script queries the SQLite GraphLog to determine if an agent is sunsetted
- * based on missing WAKE_SUBSCRIPTION nodes or inactivity exceeding the threshold.
+ * This script queries the SQLite GraphLog to determine if an agent is sunsetted.
+ * The authoritative sunset signal is the Unsubscribe primitive: the
+ * `session-sunset` workflow drops the agent's active WAKE_SUBSCRIPTION node
+ * before terminating the transcript, so a missing subscription is the only
+ * condition that flips `sunsetted=true`.
+ *
+ * `AGENT_MEMORY` rows are read for origin-session extraction (so the
+ * fresh-session-spawn boot prompt can carry the prior session ID for Memory
+ * Core context-priming) and for update-on-read migration of legacy rows
+ * lacking structured `timestamp` / `sessionId` / `agentIdentity` fields.
+ * Memory freshness is intentionally NOT a sunset proxy — it has too many
+ * legitimate non-sunset causes (rate-limit, long deep-thinking turns,
+ * Memory Core path asymmetry under Chroma contention, in-flight tool
+ * sequences). See the Anchor & Echo block on the predicate for the full
+ * rationale and the operator-clarified substrate model from issue #10641.
  */
 import Neo from '../../src/Neo.mjs';
 import * as core from '../../src/core/_export.mjs';

--- a/test/playwright/unit/ai/scripts/checkSunsetted.spec.mjs
+++ b/test/playwright/unit/ai/scripts/checkSunsetted.spec.mjs
@@ -89,7 +89,7 @@ test.describe('ai/scripts/checkSunsetted', () => {
         const scriptPath = path.resolve(process.cwd(), 'ai/scripts/checkSunsetted.mjs');
         const output     = execFileSync('node', [scriptPath, '@neo-legacy-test'], {
             encoding: 'utf-8',
-            env: { ...process.env, NEO_UNIT_TEST_MODE: 'true', SUNSET_THRESHOLD_MS: '600000' }
+            env: { ...process.env, NEO_UNIT_TEST_MODE: 'true' }
         });
         const parsed     = JSON.parse(output);
 
@@ -101,6 +101,65 @@ test.describe('ai/scripts/checkSunsetted', () => {
         expect(migratedData.properties.timestamp).toBe(legacyTime);
         expect(migratedData.properties.sessionId).toBe(legacySession);
         expect(migratedData.properties.agentIdentity).toBe('@neo-legacy-test');
+    });
+
+    test('checkSunsetted.mjs does NOT flag sunsetted when subscription exists and AGENT_MEMORY is stale (#10641)', async () => {
+        // Per issue #10641: removing the memory-staleness branch from the predicate.
+        // Pre-fix: a 24h-old AGENT_MEMORY would flip `sunsetted=true` even with an active
+        // subscription, triggering orphan-session-spawn via `resumeHarness.mjs`.
+        // Post-fix: subscription presence is the authoritative signal; staleness is ignored.
+        const GraphService = (await import('../../../../../ai/mcp/server/memory-core/services/GraphService.mjs')).default;
+        await GraphService.initAsync();
+
+        const testIdentity   = '@neo-staleness-test';
+        const staleMemId     = 'stale-memory-test-anchor';
+        const subId          = 'sub-staleness-test';
+        const staleTimestamp = new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString();
+
+        const memData = {
+            id        : staleMemId,
+            label     : 'AGENT_MEMORY',
+            type      : 'AGENT_MEMORY',
+            properties: {
+                userId        : testIdentity,
+                agentIdentity : testIdentity,
+                timestamp     : staleTimestamp,
+                sessionId     : '99999999-9999-9999-9999-999999999999',
+                name          : `Memory: ${staleTimestamp}`,
+                description   : 'Agent thought flow inside session 99999999-9999-9999-9999-999999999999.'
+            }
+        };
+
+        const subData = {
+            id        : subId,
+            label     : 'WAKE_SUBSCRIPTION',
+            type      : 'WAKE_SUBSCRIPTION',
+            properties: {
+                agentIdentity : testIdentity,
+                harnessTarget : 'claude-desktop',
+                status        : 'active'
+            }
+        };
+
+        const db         = GraphService.db.storage.db;
+        const insertStmt = db.prepare(`INSERT INTO Nodes (id, user_id, data) VALUES (?, ?, ?) ON CONFLICT(id) DO UPDATE SET data=excluded.data`);
+        insertStmt.run(staleMemId, testIdentity, JSON.stringify(memData));
+        insertStmt.run(subId,      testIdentity, JSON.stringify(subData));
+
+        try {
+            const scriptPath = path.resolve(process.cwd(), 'ai/scripts/checkSunsetted.mjs');
+            const output     = execFileSync('node', [scriptPath, testIdentity], {
+                encoding: 'utf-8',
+                env     : { ...process.env, NEO_UNIT_TEST_MODE: 'true' }
+            });
+            const parsed     = JSON.parse(output);
+
+            expect(parsed.sunsetted).toBe(false);
+            expect(parsed.reason).toBe('');
+        } finally {
+            db.prepare('DELETE FROM Nodes WHERE id = ?').run(staleMemId);
+            db.prepare('DELETE FROM Nodes WHERE id = ?').run(subId);
+        }
     });
 
     test('swarm-heartbeat.sh integrates the sunset detection properly before the bypass', async () => {


### PR DESCRIPTION
Authored by Claude Opus 4.7 (1M context) (Claude Code). Session 9766f91c-51f8-44fe-ac34-d79f61a0e1bf.

Resolves #10641
Related: #10601

`checkSunsetted.mjs` was treating any `AGENT_MEMORY` older than 10 minutes as a sunset signal, which triggered `resumeHarness.mjs` (Cmd+N + paste of `buildBootGroundingPrompt`) against agents that still held active WAKE_SUBSCRIPTION nodes. During an Anthropic API rate-limit window on `@neo-opus-4-7` this morning, the heuristic fired four times in 30 minutes and spawned three orphan Claude Desktop sessions. This PR removes the staleness branch — the Unsubscribe primitive becomes the only authoritative sunset signal, and non-sunset wakes flow through the existing in-place delivery path in `bridge-daemon.mjs`.

## Deltas from ticket
None — Fix scope matches the ticket prescription verbatim. The Anchor & Echo block on the predicate now carries the full rationale (rate-limit, deep-thinking, Memory Core path asymmetry, in-flight tool sequences) so the next agent reading this code does not re-derive why staleness was rejected as a sunset proxy.

## Test Evidence

```
$ npx playwright test -c test/playwright/playwright.config.unit.mjs \
    test/playwright/unit/ai/scripts/checkSunsetted.spec.mjs
Running 5 tests using 5 workers
  5 passed (1.1s)
```

New spec coverage at `test/playwright/unit/ai/scripts/checkSunsetted.spec.mjs:106`:
- **Negative-case anchor:** active WAKE_SUBSCRIPTION + 24h-old AGENT_MEMORY → `sunsetted=false` (would have been `true` pre-fix)

Existing spec coverage retained:
- Unknown agent (no subscription) → `sunsetted=true` with reason `No active WAKE_SUBSCRIPTION` (genuine sunset path unchanged)
- Legacy AGENT_MEMORY row migration (now without the dead `SUNSET_THRESHOLD_MS=600000` env var)
- `swarm-heartbeat.sh` integration sequence (sunset check before bypass)
- `originSessionId` extraction for `@neo-opus-4-7`

## Post-Merge Validation

- [ ] `heartbeat-opus_4_7.log` shows zero `Last memory is N m old (>10m threshold)` entries over a 30-minute window with all three identities idle
- [ ] No new orphan Claude Desktop sessions spawn during the next sustained rate-limit window
- [ ] Sunset-driven recovery (explicit `session-sunset` workflow) continues to fire correctly via the WAKE_SUBSCRIPTION unsubscribe path

## Out of Scope (for follow-up tickets)

- `Unknown harness target for identity: neo-opus-4-7` (no `@` prefix) bug in `resumeHarness.mjs` `identityMap` — observed in `sweep-errors.log` during this session, distinct from the predicate fix
- The 2 orphan Claude Desktop sessions still floating from the earlier spawns at 15:22 and 15:32 — operator-action, not codebase-action