### PR TITLE
feat(ai): add wake safety gate and circuit breaker (#10648)

### DIFF
--- a/ai/scripts/resumeHarness.mjs
+++ b/ai/scripts/resumeHarness.mjs
@@ -21,6 +21,7 @@ import { spawn } from 'child_process';
 import fs from 'fs/promises';
 import path from 'path';
 import { fileURLToPath } from 'url';
+import { readGateState, hasOverride } from './wakeSafetyGate.mjs';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
@@ -55,6 +56,21 @@ function buildBootGroundingPrompt(identity, reason, originSessionId) {
 }
 
 async function resumeHarness(identity, reason, originSessionId) {
+    // Wake safety gate (#10648, child of #10647). Direct fresh-session-spawn
+    // invocations must also fail-closed when the substrate is unsafe — the
+    // gate is consulted alongside (and ahead of) the existing cooldown. The
+    // operator override `WAKE_GATE_OVERRIDE=1` bypasses the gate; the
+    // procedure for setting it lives in #10650 restart/incident protocol.
+    if (hasOverride()) {
+        console.error('[OVERRIDE] WAKE_GATE_OVERRIDE set; bypassing wake safety gate for resumeHarness.');
+    } else {
+        const gate = await readGateState();
+        if (gate.state !== 'enabled') {
+            console.error(`Skipping resume for ${identity}: Wake safety gate ${gate.state} (reason: ${gate.reason}). Set WAKE_GATE_OVERRIDE=1 to override.`);
+            return;
+        }
+    }
+
     // Blocker 1: Idempotency (cooldown file + 600s minimum re-fire window)
     // Fix: Resolve from __dirname instead of process.cwd() to support cron/launchd
     const cooldownDir = path.resolve(__dirname, '../../.neo-ai-data/wake-daemon');

--- a/ai/scripts/swarm-heartbeat.sh
+++ b/ai/scripts/swarm-heartbeat.sh
@@ -146,6 +146,15 @@ heartbeat_pulse() {
             if [ "$is_sunsetted" = "true" ]; then
                 echo "[heartbeat $(date -Iseconds)] Phase 1 Recovery Triggered for $IDENTITY. Reason: $sunset_reason" >&2
 
+                # Wake safety gate (#10648, child of #10647). Fail-closed gate consulted
+                # before any high-authority action. Skips fresh-session-spawn when the
+                # substrate is known unsafe; operator override via WAKE_GATE_OVERRIDE=1.
+                if ! node "${script_dir}/wakeSafetyGate.mjs" check 2>>"$SWEEP_LOG"; then
+                    local gate_reason=$(node "${script_dir}/wakeSafetyGate.mjs" reason 2>>"$SWEEP_LOG")
+                    echo "[heartbeat $(date -Iseconds)] Wake safety gate closed; skipping fresh-session-spawn for $IDENTITY. Gate reason: $gate_reason" >&2
+                    continue
+                fi
+
                 # Q1b fresh-session-spawn adapter: opens a new chat in target harness via
                 # Cmd+N keystroke before pasting the boot-grounding prompt. Replaces the prior
                 # Q1a in-place wake injection per @tobiu's verbatim 2026-05-02 correction.
@@ -163,8 +172,16 @@ heartbeat_pulse() {
             local is_all_idle=$(echo "$all_idle_json" | jq -r '.allIdle')
             if [ "$is_all_idle" = "true" ]; then
                 echo "[heartbeat $(date -Iseconds)] AllAgentIdle detected: $all_idle_json" >&2
-                # Dispatch WAKE event if not in cooldown (Phase 4 Substrate Primitive #10626)
-                node "${script_dir}/trioWakeCooldown.mjs" "$all_idle_json" 2>>"$SWEEP_LOG"
+
+                # Wake safety gate (#10648). Trio-wake dispatch is a high-authority action;
+                # gate-closed must skip the cooldown-bounded wake even if all agents are idle.
+                if ! node "${script_dir}/wakeSafetyGate.mjs" check 2>>"$SWEEP_LOG"; then
+                    local gate_reason=$(node "${script_dir}/wakeSafetyGate.mjs" reason 2>>"$SWEEP_LOG")
+                    echo "[heartbeat $(date -Iseconds)] Wake safety gate closed; skipping trio wake dispatch. Gate reason: $gate_reason" >&2
+                else
+                    # Dispatch WAKE event if not in cooldown (Phase 4 Substrate Primitive #10626)
+                    node "${script_dir}/trioWakeCooldown.mjs" "$all_idle_json" 2>>"$SWEEP_LOG"
+                fi
             fi
         fi
 

--- a/ai/scripts/swarm-heartbeat.sh
+++ b/ai/scripts/swarm-heartbeat.sh
@@ -144,16 +144,19 @@ heartbeat_pulse() {
             local origin_session_id=$(echo "$sunset_json" | jq -r '.originSessionId // empty')
 
             if [ "$is_sunsetted" = "true" ]; then
-                echo "[heartbeat $(date -Iseconds)] Phase 1 Recovery Triggered for $IDENTITY. Reason: $sunset_reason" >&2
-
                 # Wake safety gate (#10648, child of #10647). Fail-closed gate consulted
                 # before any high-authority action. Skips fresh-session-spawn when the
                 # substrate is known unsafe; operator override via WAKE_GATE_OVERRIDE=1.
+                # Gate check fires BEFORE the "Phase 1 Recovery Triggered" log so a
+                # gate-skip emits only the gate-closed line, not a misleading "Triggered"
+                # entry that suggests recovery proceeded.
                 if ! node "${script_dir}/wakeSafetyGate.mjs" check 2>>"$SWEEP_LOG"; then
                     local gate_reason=$(node "${script_dir}/wakeSafetyGate.mjs" reason 2>>"$SWEEP_LOG")
-                    echo "[heartbeat $(date -Iseconds)] Wake safety gate closed; skipping fresh-session-spawn for $IDENTITY. Gate reason: $gate_reason" >&2
+                    echo "[heartbeat $(date -Iseconds)] Wake safety gate closed; skipping fresh-session-spawn for $IDENTITY. Sunset reason: $sunset_reason. Gate reason: $gate_reason" >&2
                     continue
                 fi
+
+                echo "[heartbeat $(date -Iseconds)] Phase 1 Recovery Triggered for $IDENTITY. Reason: $sunset_reason" >&2
 
                 # Q1b fresh-session-spawn adapter: opens a new chat in target harness via
                 # Cmd+N keystroke before pasting the boot-grounding prompt. Replaces the prior

--- a/ai/scripts/wakeSafetyGate.mjs
+++ b/ai/scripts/wakeSafetyGate.mjs
@@ -1,0 +1,211 @@
+#!/usr/bin/env node
+/**
+ * @summary Wake Safety Gate / Circuit Breaker (Epic #10647, sub #10648).
+ *
+ * Fail-closed coordination primitive that scheduler/recovery paths
+ * (`swarm-heartbeat.sh`, `resumeHarness.mjs`) MUST consult before taking any
+ * high-authority action (fresh-session-spawn, trio wake dispatch, heartbeat-pulse
+ * delivery to a harness UI). When wake delivery is unsafe or unverified, the
+ * scheduler MUST no-op and report — not spawn, steer, or paste.
+ *
+ * Read the substrate model in #10647 / #10648: the wake substrate has eight
+ * layers (A2A storage, unread/list, bootstrap, coalescing, bridge adapter,
+ * prompt landing, fresh-session recovery, heartbeat). Validating one layer in
+ * isolation does not prove the loop is healthy. The 2026-05-03 regression
+ * cycle (#10641 orphan-spawn, #10644 Antigravity Cmd+L file-write, #10645
+ * AgentIdentity cache miss) compounded because no cross-layer envelope
+ * stopped the scheduler from acting while individual layers were broken.
+ *
+ * The gate state lives in a JSON file under `.neo-ai-data/wake-daemon/` so
+ * operators can inspect / toggle it without running JS. States:
+ *
+ *   - `enabled`  — substrate validated; high-authority actions permitted
+ *   - `disabled` — substrate intentionally taken offline (e.g. operator
+ *                  pause for maintenance); actions denied without override
+ *   - `tripped`  — unsafe signal observed (e.g. orphan spawn, payload
+ *                  landed in editor file, subscription bootstrap stale);
+ *                  actions denied without override; reason recorded
+ *
+ * **Default state when the file is absent: `tripped`** with the
+ * post-incident reason. This honors the deny-by-default discipline:
+ * forgetting to create the file MUST NOT be interpreted as permission
+ * to act. Operators must explicitly write `enabled` after validating
+ * the cross-harness prompt-landing matrix (#10649) or providing an
+ * accepted-risk override per the restart/incident protocol (#10650).
+ *
+ * **Operator override** lives in the `WAKE_GATE_OVERRIDE` environment
+ * variable. When set to `1` (or any truthy non-empty value), consumer
+ * code bypasses the gate check. This is documented as operator-only;
+ * the procedure for setting it lives in #10650.
+ *
+ * @see ai/scripts/swarm-heartbeat.sh    — gate consumer (high-authority dispatch)
+ * @see ai/scripts/resumeHarness.mjs     — gate consumer (direct fresh-session-spawn)
+ * @see ai/scripts/checkSunsetted.mjs    — companion predicate (#10641 / #10642)
+ * @see test/playwright/unit/ai/scripts/wakeSafetyGate.spec.mjs
+ */
+import fs from 'fs/promises';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+/**
+ * Resolve the canonical state-file path under the wake-daemon data directory.
+ * Resolved from `__dirname` rather than `process.cwd()` so the path is stable
+ * under cron / launchd / sub-process invocations that don't inherit the
+ * working directory of the operator's shell.
+ *
+ * Tests may override the path via the `WAKE_GATE_FILE_PATH` environment
+ * variable so parallel specs don't collide on the singleton on-disk state.
+ * Production deployments leave this unset; the canonical path applies.
+ *
+ * @returns {string} Absolute path to the gate state file.
+ */
+export function gateFilePath() {
+    return process.env.WAKE_GATE_FILE_PATH || path.resolve(__dirname, '../../.neo-ai-data/wake-daemon/wake-safety-gate.json');
+}
+
+/**
+ * Default-tripped state returned when the gate file is absent. Deny-by-default
+ * is load-bearing — see file-level Anchor & Echo above.
+ */
+const DEFAULT_TRIPPED = {
+    state    : 'tripped',
+    reason   : 'No gate state file present; defaulting to tripped per deny-by-default discipline (#10648). Operator must explicitly enable after validating substrate.',
+    trippedAt: null,
+    trippedBy: 'default-on-missing-file'
+};
+
+/**
+ * Read the gate state. Returns the default-tripped state if the file is
+ * missing or unreadable — the deny-by-default discipline echoes the file-level
+ * Anchor & Echo: forgetting to create the file MUST NOT be interpreted as
+ * permission to act.
+ * @returns {Promise<{state: string, reason: string, trippedAt: ?string, trippedBy: ?string}>}
+ */
+export async function readGateState() {
+    try {
+        const raw = await fs.readFile(gateFilePath(), 'utf8');
+        const parsed = JSON.parse(raw);
+        if (!parsed || typeof parsed !== 'object' || typeof parsed.state !== 'string') {
+            return {
+                ...DEFAULT_TRIPPED,
+                reason: 'Gate file present but malformed; treating as tripped.',
+                trippedBy: 'malformed-state-file'
+            };
+        }
+        return {
+            state    : parsed.state,
+            reason   : parsed.reason ?? '',
+            trippedAt: parsed.trippedAt ?? null,
+            trippedBy: parsed.trippedBy ?? null
+        };
+    } catch (err) {
+        if (err.code === 'ENOENT') return {...DEFAULT_TRIPPED};
+        return {
+            ...DEFAULT_TRIPPED,
+            reason: `Gate file read error: ${err.message}; treating as tripped.`,
+            trippedBy: 'read-error'
+        };
+    }
+}
+
+/**
+ * Atomic write of the gate state. Writes to a temp file then rename to avoid
+ * scheduler readers seeing a partial write under concurrent operator updates.
+ * @param {{state: string, reason: string, trippedBy?: string}} payload
+ * @returns {Promise<void>}
+ */
+export async function writeGateState(payload) {
+    const filePath = gateFilePath();
+    await fs.mkdir(path.dirname(filePath), {recursive: true});
+    const body = {
+        state    : payload.state,
+        reason   : payload.reason ?? '',
+        trippedAt: payload.state === 'enabled' ? null : new Date().toISOString(),
+        trippedBy: payload.trippedBy ?? null
+    };
+    const tmpPath = `${filePath}.tmp-${process.pid}`;
+    await fs.writeFile(tmpPath, JSON.stringify(body, null, 2) + '\n', 'utf8');
+    await fs.rename(tmpPath, filePath);
+}
+
+/**
+ * Operator override check. The `WAKE_GATE_OVERRIDE` environment variable
+ * bypasses the gate when set to a truthy non-empty value. Documented as
+ * operator-only; procedure lives in #10650 restart/incident protocol.
+ * @returns {boolean}
+ */
+export function hasOverride() {
+    const v = process.env.WAKE_GATE_OVERRIDE;
+    return Boolean(v) && v !== '0' && v !== 'false';
+}
+
+/**
+ * Convenience: is the gate open for high-authority actions? `true` only when
+ * state is explicitly `enabled` OR the operator override is set. All other
+ * states (`disabled`, `tripped`, malformed, missing) return `false`.
+ * @returns {Promise<boolean>}
+ */
+export async function isGateOpen() {
+    if (hasOverride()) return true;
+    const state = await readGateState();
+    return state.state === 'enabled';
+}
+
+// CLI: `node wakeSafetyGate.mjs <command>`
+//
+// Commands:
+//   check    — exit 0 if gate is open (enabled or override), 1 otherwise.
+//              Used by swarm-heartbeat.sh as a `if ! node ...` guard.
+//   reason   — print the current gate-state reason to stdout (single line).
+//   show     — print the full gate state as JSON.
+//   trip     — write tripped state. Reason from --reason= flag or stdin.
+//   disable  — write disabled state. Reason from --reason= flag.
+//   enable   — write enabled state. No reason required (cleared on enable).
+async function main() {
+    const argv = process.argv.slice(2);
+    const cmd = argv[0];
+
+    const flag = name => {
+        const prefix = `--${name}=`;
+        const arg = argv.find(a => a.startsWith(prefix));
+        return arg ? arg.slice(prefix.length) : null;
+    };
+
+    if (cmd === 'check') {
+        const open = await isGateOpen();
+        process.exit(open ? 0 : 1);
+    }
+    if (cmd === 'reason') {
+        const state = await readGateState();
+        process.stdout.write(state.reason + '\n');
+        process.exit(0);
+    }
+    if (cmd === 'show') {
+        const state = await readGateState();
+        process.stdout.write(JSON.stringify(state, null, 2) + '\n');
+        process.exit(0);
+    }
+    if (cmd === 'trip' || cmd === 'disable') {
+        const reason = flag('reason') ?? '';
+        const trippedBy = flag('by') ?? 'cli';
+        await writeGateState({state: cmd === 'trip' ? 'tripped' : 'disabled', reason, trippedBy});
+        process.exit(0);
+    }
+    if (cmd === 'enable') {
+        await writeGateState({state: 'enabled', reason: ''});
+        process.exit(0);
+    }
+    console.error('Usage: wakeSafetyGate.mjs <check|reason|show|trip|disable|enable> [--reason=...] [--by=...]');
+    process.exit(2);
+}
+
+// Only run CLI when invoked as a script, not when imported.
+const isMain = process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url);
+if (isMain) {
+    main().catch(err => {
+        console.error('wakeSafetyGate failed:', err.message);
+        process.exit(2);
+    });
+}

--- a/test/playwright/unit/ai/scripts/resumeHarness.spec.mjs
+++ b/test/playwright/unit/ai/scripts/resumeHarness.spec.mjs
@@ -13,16 +13,37 @@ setup({
     }
 });
 
-import {test, expect} from '@playwright/test';
-import {execFileSync} from 'child_process';
-import path from 'path';
-import fs from 'fs';
+import {test, expect}            from '@playwright/test';
+import {execFileSync, spawnSync} from 'child_process';
+import {randomUUID}              from 'crypto';
+import os                        from 'os';
+import path                      from 'path';
+import fs                        from 'fs';
 
 test.describe('ai/scripts/resumeHarness', () => {
     const scriptPath = path.resolve(process.cwd(), 'ai/scripts/resumeHarness.mjs');
     const cooldownDir = path.resolve(process.cwd(), '.neo-ai-data/wake-daemon');
 
+    /**
+     * Per-test gate-file path via the `WAKE_GATE_FILE_PATH` env-var override
+     * (production unset, tests set explicitly). Avoids the singleton-on-disk
+     * collision when this spec runs in parallel with `wakeSafetyGate.spec.mjs`.
+     *
+     * `overrideEnv` — for tests that pre-date #10648 and just need to exercise
+     * the unknown-identity / cooldown / osascript surfaces without the gate
+     * blocking. Sets both an isolated gate path AND `WAKE_GATE_OVERRIDE=1`.
+     *
+     * `gateOnlyEnv()` — for tests targeting the gate behavior itself; isolates
+     * the gate path but leaves `WAKE_GATE_OVERRIDE` unset so the default-tripped
+     * / explicitly-enabled paths can be exercised.
+     */
+    let gatePath, overrideEnv;
+    const gateOnlyEnv = () => ({...process.env, WAKE_GATE_FILE_PATH: gatePath});
+
     test.beforeEach(() => {
+        gatePath    = path.join(os.tmpdir(), `wake-gate-resumeharness-${randomUUID()}.json`);
+        overrideEnv = {...process.env, WAKE_GATE_FILE_PATH: gatePath, WAKE_GATE_OVERRIDE: '1'};
+
         // Clear cooldown files before each test so they don't skip
         if (fs.existsSync(cooldownDir)) {
             const files = fs.readdirSync(cooldownDir);
@@ -34,9 +55,13 @@ test.describe('ai/scripts/resumeHarness', () => {
         }
     });
 
+    test.afterEach(() => {
+        if (fs.existsSync(gatePath)) fs.unlinkSync(gatePath);
+    });
+
     test('Unknown identity exits with code 1 and unknown message', async () => {
         try {
-            execFileSync('node', [scriptPath, '@neo-unknown', 'test'], { encoding: 'utf-8', stdio: 'pipe' });
+            execFileSync('node', [scriptPath, '@neo-unknown', 'test'], {encoding: 'utf-8', stdio: 'pipe', env: overrideEnv});
             test.fail('Should have exited with error');
         } catch (e) {
             expect(e.status).toBe(1);
@@ -46,7 +71,7 @@ test.describe('ai/scripts/resumeHarness', () => {
 
     test('Opus identity routes to osascript with claude-desktop, freshSessionShortcut n, and tabShortcut 3', async () => {
         try {
-            execFileSync('node', [scriptPath, '@neo-opus-4-7', 'test'], { encoding: 'utf-8', stdio: 'pipe' });
+            execFileSync('node', [scriptPath, '@neo-opus-4-7', 'test'], {encoding: 'utf-8', stdio: 'pipe', env: overrideEnv});
         } catch (e) {
             // It might fail if osascript fails to activate Claude or System Events isn't permitted
             const output = e.stderr + e.stdout;
@@ -58,6 +83,42 @@ test.describe('ai/scripts/resumeHarness', () => {
         const scriptContent = fs.readFileSync(scriptPath, 'utf-8');
         expect(scriptContent).toContain("'claude-desktop':  { appName: 'Claude',      adapter: 'osascript', freshSessionShortcut: 'n', tabShortcut: '3' }");
         expect(scriptContent).toContain("'@neo-opus-4-7': 'claude-desktop'");
+    });
+
+    test('Wake safety gate tripped + no override → resumeHarness skips with explicit stderr (#10648)', async () => {
+        // Default-tripped state (no gate file → deny-by-default per wakeSafetyGate.mjs).
+        // resumeHarness must skip BEFORE any cooldown / harness lookup / osascript work,
+        // and emit a stderr message naming the gate state and the override env-var.
+        // spawnSync (vs execFileSync) captures stderr on success-exit too — gate-skip
+        // is exit 0 (defensive no-op, not an error).
+        const result = spawnSync('node', [scriptPath, '@neo-opus-4-7', 'test'], {
+            encoding: 'utf-8',
+            env     : gateOnlyEnv()  // No WAKE_GATE_OVERRIDE — exercising default-tripped path on isolated gate file
+        });
+        expect(result.status).toBe(0);
+        expect(result.stderr).toContain('Skipping resume for @neo-opus-4-7');
+        expect(result.stderr).toContain('Wake safety gate tripped');
+        expect(result.stderr).toContain('WAKE_GATE_OVERRIDE=1');
+    });
+
+    test('Wake safety gate enabled → resumeHarness proceeds past the gate (#10648)', async () => {
+        // Write enabled gate state on the per-test gate path, then invoke resumeHarness
+        // with a known identity. The gate must NOT short-circuit; resumeHarness proceeds
+        // to harness lookup and osascript dispatch (which may itself fail in test env —
+        // covered by the existing 'Opus identity routes to osascript' test; here we
+        // only verify the gate doesn't pre-empt the path).
+        fs.mkdirSync(path.dirname(gatePath), {recursive: true});
+        fs.writeFileSync(gatePath, JSON.stringify({state: 'enabled', reason: '', trippedAt: null, trippedBy: null}), 'utf-8');
+
+        const result = spawnSync('node', [scriptPath, '@neo-opus-4-7', 'test'], {
+            encoding: 'utf-8',
+            env     : gateOnlyEnv()
+        });
+        const stderrAndStdout = (result.stderr ?? '') + (result.stdout ?? '');
+
+        // Negative assertion: no gate-skip message — the gate let the call through.
+        expect(stderrAndStdout).not.toContain('Wake safety gate tripped');
+        expect(stderrAndStdout).not.toContain('Wake safety gate disabled');
     });
 
     test('Q1b fresh-session-spawn: HARNESS_REGISTRY entries include freshSessionShortcut (#10611 PR-B AC1)', async () => {

--- a/test/playwright/unit/ai/scripts/swarm-heartbeat.spec.mjs
+++ b/test/playwright/unit/ai/scripts/swarm-heartbeat.spec.mjs
@@ -71,6 +71,45 @@ test.describe('ai/scripts/swarm-heartbeat', () => {
         expect(body).toContain('echo "${count:-0}"');
     });
 
+    test('Wake safety gate (#10648) is consulted before high-authority dispatch', () => {
+        // Drift guard for the #10647 epic: the heartbeat MUST consult `wakeSafetyGate.mjs`
+        // before invoking the two high-authority sites — fresh-session-spawn via
+        // `resumeHarness.mjs` and trio-wake dispatch via `trioWakeCooldown.mjs`. If a
+        // future change re-orders the gate check after these calls (or removes it),
+        // orphan-spawn / unsafe wake dispatch can fire again before substrate is healthy.
+
+        // The script must reference the gate primitive at all.
+        expect(scriptSrc).toContain('wakeSafetyGate.mjs');
+
+        // Two high-authority sites are gated. Locate each block and assert its gate
+        // check appears textually before the gated invocation.
+        const resumeIdx = scriptSrc.indexOf('resumeHarness.mjs');
+        const trioIdx   = scriptSrc.indexOf('trioWakeCooldown.mjs');
+        expect(resumeIdx).toBeGreaterThan(-1);
+        expect(trioIdx  ).toBeGreaterThan(-1);
+
+        // For each high-authority site, the most recent `wakeSafetyGate.mjs check`
+        // before it must be within the surrounding control block (heuristic: within
+        // 600 chars upstream — single conditional block scope).
+        const gateCheckPattern = /wakeSafetyGate\.mjs"?\s+check/g;
+        const gateCheckMatches = [...scriptSrc.matchAll(gateCheckPattern)].map(m => m.index);
+        expect(gateCheckMatches.length).toBeGreaterThanOrEqual(2);
+
+        const lastGateBefore = (idx) => {
+            const before = gateCheckMatches.filter(g => g < idx);
+            return before.length > 0 ? before[before.length - 1] : -1;
+        };
+
+        const resumeGate = lastGateBefore(resumeIdx);
+        const trioGate   = lastGateBefore(trioIdx);
+
+        expect(resumeGate, 'gate check missing before resumeHarness.mjs invocation').toBeGreaterThan(-1);
+        expect(resumeIdx - resumeGate, 'gate check too far from resumeHarness.mjs invocation').toBeLessThan(1000);
+
+        expect(trioGate, 'gate check missing before trioWakeCooldown.mjs invocation').toBeGreaterThan(-1);
+        expect(trioIdx - trioGate, 'gate check too far from trioWakeCooldown.mjs invocation').toBeLessThan(1000);
+    });
+
     test.describe('fixture-backed regression coverage (#10622 acceptance)', () => {
         let tmpBase;
         let dbPath;

--- a/test/playwright/unit/ai/scripts/wakeSafetyGate.spec.mjs
+++ b/test/playwright/unit/ai/scripts/wakeSafetyGate.spec.mjs
@@ -1,0 +1,164 @@
+import {setup} from '../../../setup.mjs';
+
+const appName = 'WakeSafetyGateTest';
+
+setup({
+    neoConfig: {
+        unitTestMode: true
+    },
+    appConfig: {
+        name             : appName,
+        isMounted        : () => true,
+        vnodeInitialising: false
+    }
+});
+
+import {test, expect}    from '@playwright/test';
+import {execFileSync}    from 'child_process';
+import {randomUUID}      from 'crypto';
+import fs                from 'fs';
+import os                from 'os';
+import path              from 'path';
+
+/**
+ * @summary Validation for the Wake Safety Gate primitive (#10648, child of #10647).
+ *
+ * Covers the deny-by-default discipline (missing file → tripped), state-file
+ * round-trip (enable / disable / trip), CLI surface (check / reason / show),
+ * and the operator override (`WAKE_GATE_OVERRIDE=1`). The gate is consumed by
+ * `swarm-heartbeat.sh` and `resumeHarness.mjs` — those integrations have their
+ * own specs; this file isolates the gate primitive.
+ */
+test.describe('ai/scripts/wakeSafetyGate', () => {
+    const scriptPath = path.resolve(process.cwd(), 'ai/scripts/wakeSafetyGate.mjs');
+
+    /**
+     * Each test gets its own gate-file path via the `WAKE_GATE_FILE_PATH`
+     * env-var override (production unset, tests set explicitly). This avoids
+     * the singleton on-disk collision that surfaces under Playwright's
+     * fullyParallel mode — peer specs (e.g. `resumeHarness.spec.mjs`) also
+     * touch the gate file and would race against tests in this describe.
+     * Per-test unique tmp paths make the suite hermetic regardless of
+     * worker-level parallelism.
+     */
+    let gatePath, gateEnv;
+
+    test.beforeEach(() => {
+        gatePath = path.join(os.tmpdir(), `wake-gate-test-${randomUUID()}.json`);
+        gateEnv  = {...process.env, WAKE_GATE_FILE_PATH: gatePath};
+    });
+
+    test.afterEach(() => {
+        if (fs.existsSync(gatePath)) fs.unlinkSync(gatePath);
+    });
+
+    /**
+     * Helper: invoke the CLI with the per-test gate-file env-var bound. Captures
+     * stdout, stderr, and exit code so individual tests can assert on whichever
+     * surface they care about. Defaults to `gateEnv` (per-test isolation); tests
+     * that want to layer additional env (e.g. `WAKE_GATE_OVERRIDE`) merge into
+     * `extraEnv`.
+     */
+    const runCli = (args, extraEnv = {}) => {
+        try {
+            const stdout = execFileSync('node', [scriptPath, ...args], {
+                encoding: 'utf-8',
+                stdio   : 'pipe',
+                env     : {...gateEnv, ...extraEnv}
+            });
+            return {status: 0, stdout, stderr: ''};
+        } catch (e) {
+            return {status: e.status, stdout: e.stdout ?? '', stderr: e.stderr ?? ''};
+        }
+    };
+
+    test('CLI check exits 1 when no gate file exists (deny-by-default)', () => {
+        expect(runCli(['check']).status).toBe(1);
+    });
+
+    test('CLI reason explains the default-tripped state when no gate file exists', () => {
+        const {stdout} = runCli(['reason']);
+        expect(stdout).toContain('No gate state file present');
+        expect(stdout).toContain('deny-by-default');
+    });
+
+    test('CLI show emits structured JSON with state=tripped by default', () => {
+        const parsed = JSON.parse(runCli(['show']).stdout);
+        expect(parsed.state).toBe('tripped');
+        expect(parsed.trippedBy).toBe('default-on-missing-file');
+    });
+
+    test('CLI enable writes enabled state and check passes afterwards', () => {
+        expect(runCli(['enable']).status).toBe(0);
+
+        const written = JSON.parse(fs.readFileSync(gatePath, 'utf-8'));
+        expect(written.state).toBe('enabled');
+
+        expect(runCli(['check']).status).toBe(0);
+    });
+
+    test('CLI trip writes tripped state with reason and trippedBy', () => {
+        expect(runCli(['trip', '--reason=test reason text', '--by=spec-runner']).status).toBe(0);
+
+        const written = JSON.parse(fs.readFileSync(gatePath, 'utf-8'));
+        expect(written.state    ).toBe('tripped');
+        expect(written.reason   ).toBe('test reason text');
+        expect(written.trippedBy).toBe('spec-runner');
+        expect(written.trippedAt).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+    });
+
+    test('CLI disable writes disabled state', () => {
+        expect(runCli(['disable', '--reason=maintenance']).status).toBe(0);
+        const written = JSON.parse(fs.readFileSync(gatePath, 'utf-8'));
+        expect(written.state ).toBe('disabled');
+        expect(written.reason).toBe('maintenance');
+    });
+
+    test('CLI check exits 1 when state is tripped', () => {
+        runCli(['trip', '--reason=test']);
+        expect(runCli(['check']).status).toBe(1);
+    });
+
+    test('Operator override WAKE_GATE_OVERRIDE=1 makes check exit 0 even when tripped', () => {
+        runCli(['trip', '--reason=test']);
+        expect(runCli(['check']                                 ).status).toBe(1);
+        expect(runCli(['check'], {WAKE_GATE_OVERRIDE: '1'}      ).status).toBe(0);
+    });
+
+    test('Override sentinel "0" or "false" is treated as not-set', () => {
+        runCli(['trip', '--reason=test']);
+
+        for (const falseyValue of ['0', 'false', '']) {
+            const result = runCli(['check'], {WAKE_GATE_OVERRIDE: falseyValue});
+            expect(result.status, `WAKE_GATE_OVERRIDE=${JSON.stringify(falseyValue)} should NOT bypass`).toBe(1);
+        }
+    });
+
+    test('Malformed gate file is treated as tripped (deny-by-default fallback)', () => {
+        fs.mkdirSync(path.dirname(gatePath), {recursive: true});
+        fs.writeFileSync(gatePath, '{not valid json', 'utf-8');
+
+        const parsed = JSON.parse(runCli(['show']).stdout);
+        expect(parsed.state    ).toBe('tripped');
+        expect(parsed.trippedBy).toBe('read-error');
+    });
+
+    test('Atomic write — partial state file from concurrent operator update is not observable', () => {
+        // The implementation writes to a `.tmp-<pid>` file then renames. After the rename
+        // completes, readers see either the prior state or the new state, never a partial.
+        // This test exercises the round-trip and verifies no temp files leak.
+        runCli(['enable']);
+        runCli(['trip', '--reason=second-write']);
+
+        const finalState = JSON.parse(fs.readFileSync(gatePath, 'utf-8'));
+        expect(finalState.state ).toBe('tripped');
+        expect(finalState.reason).toBe('second-write');
+
+        // No temp files left behind for this gate file's basename
+        const dir         = path.dirname(gatePath);
+        const baseName    = path.basename(gatePath);
+        const files       = fs.readdirSync(dir);
+        const tmpsForThis = files.filter(f => f.startsWith(`${baseName}.tmp`));
+        expect(tmpsForThis).toHaveLength(0);
+    });
+});


### PR DESCRIPTION
Authored by Claude Opus 4.7 (1M context) (Claude Code). Session 9766f91c-51f8-44fe-ac34-d79f61a0e1bf.

Resolves #10648
Related: #10647 (parent epic), #10601 (grandparent epic)

Sub of the Wake Incident Safety Tree (#10647). Adds the fail-closed coordination primitive that scheduler and recovery paths MUST consult before any high-authority action. When wake delivery is unsafe or unverified, the scheduler no-ops and reports — it does not spawn, steer, or paste. This is the cross-layer envelope the 2026-05-03 regression burst exposed as missing: #10641 orphan-spawn, #10644 Antigravity Cmd+L file-write, and #10645 AgentIdentity cache miss all compounded because no gate stopped the scheduler from acting while individual layers were broken.

## Surface

- **`ai/scripts/wakeSafetyGate.mjs`** (new, 192 lines) — module + CLI. States: `enabled` / `disabled` / `tripped`. Default-tripped when no state file present per the deny-by-default discipline (forgetting to create the file MUST NOT be interpreted as permission to act). Atomic write via temp-rename. Operator override via `WAKE_GATE_OVERRIDE=1` env-var, documented as operator-only with procedure in #10650.
- **`ai/scripts/swarm-heartbeat.sh`** — gate consulted at the two high-authority sites:
  - before `resumeHarness.mjs` invocation in the Phase 1 Recovery branch
  - before `trioWakeCooldown.mjs` invocation in the all-agent-idle branch
  - sweep-expired-tasks (read-only) remains unaffected; the gate scopes to harness-side actions only
- **`ai/scripts/resumeHarness.mjs`** — gate check at the top of `resumeHarness()` so direct operator invocations also fail-closed, not just heartbeat-driven ones. Override message logs when `WAKE_GATE_OVERRIDE` is set so the operator-bypass is visible in `sweep-errors.log`.

## Test Evidence

```
$ npx playwright test -c test/playwright/playwright.config.unit.mjs \
    test/playwright/unit/ai/scripts/wakeSafetyGate.spec.mjs \
    test/playwright/unit/ai/scripts/resumeHarness.spec.mjs \
    test/playwright/unit/ai/scripts/swarm-heartbeat.spec.mjs \
    test/playwright/unit/ai/scripts/checkSunsetted.spec.mjs
Running 29 tests using 8 workers
  29 passed (5.0s)
```

New spec coverage:

- **`wakeSafetyGate.spec.mjs`** (10 tests) — default-tripped, CLI surface (check/reason/show/enable/trip/disable), override sentinel semantics (`1` bypasses; `0`/`false`/empty do not), malformed-file fallback to tripped, atomic-write round-trip with no temp-file leakage. Per-test `WAKE_GATE_FILE_PATH` isolation via `os.tmpdir()` UUID-named paths so the spec is hermetic under Playwright `fullyParallel` and doesn't race against `resumeHarness.spec.mjs`.
- **`resumeHarness.spec.mjs`** — 2 new gate-targeted tests:
  - gate-tripped + no override → `Skipping resume for @neo-opus-4-7 ... Wake safety gate tripped ... WAKE_GATE_OVERRIDE=1` stderr
  - gate-enabled → resumeHarness proceeds past the gate (negative assertion: no skip-message)
- **`swarm-heartbeat.spec.mjs`** — static-content drift guard verifying the gate-check pattern appears textually before each high-authority dispatch (`resumeHarness.mjs`, `trioWakeCooldown.mjs`) within the surrounding control block.

Ran the full `test/playwright/unit/ai/scripts/` suite to confirm no regression in adjacent specs from this PR. The pre-existing failures in `trioWakeCooldown.spec.mjs` and `checkAllAgentIdle.spec.mjs` are unrelated environmental data-path issues that reproduce against `origin/dev` directly without my changes — they are out of scope for this PR.

## Deltas from ticket

None — implementation matches #10648's prescribed shape (state file under `.neo-ai-data/wake-daemon/`, scheduler + resumeHarness gate consultation, fail-closed default, operator override).

The ticket's option 4 ("Unsafe signal recording when the bridge or validation path observes...") is intentionally NOT implemented in this PR. The gate primitive supports being tripped via the CLI; the bridge-daemon-writes-on-osascript-non-zero integration and matrix-runner-writes-on-column-6-fail integration belong to #10649 (matrix) and a follow-up bridge ticket. Bundling them here would scope-creep beyond the gate primitive.

## Post-Merge Validation

- [ ] After merge, gate state file is absent on the canonical instance — confirms deny-by-default fires as expected
- [ ] `node ai/scripts/wakeSafetyGate.mjs check` exits 1 by default (deny)
- [ ] `node ai/scripts/wakeSafetyGate.mjs enable` flips state to enabled and `check` exits 0
- [ ] When @tobiu restarts swarm-heartbeat with the merged code AND the gate is `tripped`, no `Phase 1 Recovery Triggered` lines appear in `heartbeat-opus_4_7.log` for any identity (gate-skip log entries appear instead)
- [ ] When the gate is later flipped to `enabled` (post #10649 matrix green or operator override), heartbeat resumes normal operation

## Out of Scope (post-merge follow-ups)

- Bridge-daemon writes to gate on osascript-non-zero — separate sub of #10647
- Matrix-runner writes to gate on prompt-landing-column-6 fail — covered by #10649
- Telemetry / observability for gate state transitions (timestamps, reason transitions, override events) — flagged in the #10647 epic-review (`IC_kwDODSospM8AAAABBEM76A`) as a potential follow-up, not blocking
- Gate-state writer ownership clarification at the implementation level — flagged in same epic-review

## Empirical anchor

The `kill 4390 4395 4401 4409 4413 4417` command @tobiu had me run at 14:07Z to manually-trip orphan-spawn is the failure mode this PR makes architectural. After this lands plus the rest of #10647's safety tree, that emergency-brake reflex becomes a substrate state-flip rather than a process-kill.