### PR TITLE
docs(ai): add wake prompt landing matrix (#10649)

### DIFF
--- a/ai/docs/wake-prompt-landing-matrix.md
+++ b/ai/docs/wake-prompt-landing-matrix.md
@@ -1,0 +1,39 @@
+# Wake Prompt Landing Matrix
+
+## Context
+
+The wake substrate requires strict validation to ensure that "wake delivered" actually means the payload successfully landed in the target agent's prompt input surface. Previously, intermediate success (such as `osascript` exiting 0) was misinterpreted as full success, leading to regressions where payloads were pasted into source code files instead of agent composers.
+
+This matrix establishes the definitive criteria that MUST be proven before wake delivery can be considered successful for any harness. A2A storage success and bridge adapter success are necessary but **NOT sufficient** proof of prompt delivery.
+
+## Bridge Backlog / Subscription Isolation Preflight (MANDATORY)
+
+Before running *any* controlled bridge validation test, you MUST perform this preflight to prevent un-isolated backlog dumps from polluting the validation matrix:
+
+1. **Inventory**: Inventory active bridge subscriptions for all identities before the test.
+2. **Halt**: Ensure the bridge daemon is stopped and the swarm heartbeat is OFF.
+3. **Neutralize Backlog**: Decide explicitly how the backlog is neutralized before bridge start. This could be disabling non-target bridge subscriptions, advancing/recording `lastSyncId` only after a durable-mailbox audit, or using a targeted bridge/test harness path that ignores backlog.
+4. **Isolate Test**: Only after neutralizing the backlog, create the unique matrix payload and start exactly ONE controlled delivery attempt.
+
+## The Validation Matrix
+
+The following criteria must be satisfied for each supported harness. 
+
+| Requirement | Claude Desktop | Antigravity IDE (Gemini) | Codex Desktop |
+| :--- | :--- | :--- | :--- |
+| **1. Message Persisted** | A2A message saved to local SQLite Memory Core. | A2A message saved to local SQLite Memory Core. | A2A message saved to local SQLite Memory Core. |
+| **2. Unread/List State Correct** | `list_messages` confirms unread status. | `list_messages` confirms unread status. | `list_messages` confirms unread status. |
+| **3. Subscription & Metadata** | Subscription active, `harnessTarget` is `bridge-daemon`, `appName` matches Claude. | Subscription active, `harnessTarget` is `bridge-daemon`, `appName` matches Antigravity. | Subscription active, `harnessTarget` is `bridge-daemon`, `appName` is valid. |
+| **4. Wake Event Emitted** | Raw/coalesced event emitted with correct envelope shape. | Raw/coalesced event emitted with correct envelope shape. | Raw/coalesced event emitted with correct envelope shape. |
+| **5. Adapter Selection** | Adapter strictly selects Claude session target. | Adapter strictly selects Antigravity/Gemini session target. | Adapter strictly selects Codex session target. |
+| **6. Prompt Payload Lands** | Payload lands natively in Claude's prompt field. | Payload lands directly in the Antigravity Agent Composer. | Payload lands in Codex Desktop's prompt surface. |
+| **7. No File Modification (Negative Assertion)** | N/A (or no stray pasting in other apps). | **MUST NOT** land in any active editor/file content (`git status` remains clean). | N/A (or no stray pasting). |
+| **8. No Fresh Session Spawns (Negative Assertion)** | Must resume existing session unless explicit sunset state authorizes spawn. | Must resume existing session unless explicit sunset state authorizes spawn. | Must resume existing session unless explicit sunset state authorizes spawn. |
+| **9. Actionable Receipt** | Recipient can act on prompt or emit clear blocked signal. | Recipient can act on prompt or emit clear blocked signal. | Recipient can act on prompt or emit clear blocked signal. |
+| **10. Evidence Artifact** | Manual or test log evidence captured in PR/comment. | Manual or test log evidence captured in PR/comment. | Manual or test log evidence captured in PR/comment. |
+
+## Evidence Requirements
+
+Due to the brittle nature of native UI automation across multiple different IDEs and proprietary desktop apps, **live/manual evidence is acceptable** for UI-only assertions (Columns 6-9).
+
+However, deterministic headless unit/integration tests **MUST** be used to validate the backend and bridge adapter intent (Columns 1-5).

--- a/ai/docs/wake-prompt-landing-matrix.md
+++ b/ai/docs/wake-prompt-landing-matrix.md
@@ -17,13 +17,13 @@ Before running *any* controlled bridge validation test, you MUST perform this pr
 
 ## The Validation Matrix
 
-The following criteria must be satisfied for each supported harness. 
+The following criteria must be satisfied for each supported harness.
 
 | Requirement | Claude Desktop | Antigravity IDE (Gemini) | Codex Desktop |
 | :--- | :--- | :--- | :--- |
 | **1. Message Persisted** | A2A message saved to local SQLite Memory Core. | A2A message saved to local SQLite Memory Core. | A2A message saved to local SQLite Memory Core. |
 | **2. Unread/List State Correct** | `list_messages` confirms unread status. | `list_messages` confirms unread status. | `list_messages` confirms unread status. |
-| **3. Subscription & Metadata** | Subscription active, `harnessTarget` is `bridge-daemon`, `appName` matches Claude. | Subscription active, `harnessTarget` is `bridge-daemon`, `appName` matches Antigravity. | Subscription active, `harnessTarget` is `bridge-daemon`, `appName` is valid. |
+| **3. Subscription & Metadata** | Subscription active, `harnessTarget` is `bridge-daemon`, `appName` matches Claude. | Subscription active, `harnessTarget` is `bridge-daemon`, `appName` matches Antigravity. | Subscription active, `harnessTarget` is `bridge-daemon`, `appName` matches Codex. |
 | **4. Wake Event Emitted** | Raw/coalesced event emitted with correct envelope shape. | Raw/coalesced event emitted with correct envelope shape. | Raw/coalesced event emitted with correct envelope shape. |
 | **5. Adapter Selection** | Adapter strictly selects Claude session target. | Adapter strictly selects Antigravity/Gemini session target. | Adapter strictly selects Codex session target. |
 | **6. Prompt Payload Lands** | Payload lands natively in Claude's prompt field. | Payload lands directly in the Antigravity Agent Composer. | Payload lands in Codex Desktop's prompt surface. |
@@ -34,6 +34,6 @@ The following criteria must be satisfied for each supported harness.
 
 ## Evidence Requirements
 
-Due to the brittle nature of native UI automation across multiple different IDEs and proprietary desktop apps, **live/manual evidence is acceptable** for UI-only assertions (Columns 6-9).
+Due to the brittle nature of native UI automation across multiple different IDEs and proprietary desktop apps, **live/manual evidence is acceptable** for UI-only assertions (requirements 6-9).
 
-However, deterministic headless unit/integration tests **MUST** be used to validate the backend and bridge adapter intent (Columns 1-5).
+However, deterministic headless unit/integration tests **MUST** be used to validate the backend and bridge adapter intent (requirements 1-5).


### PR DESCRIPTION
Authored by Gemini 3.1 Pro (Antigravity). Session d28a63c7-a4ec-40ff-aaaa-62d862e031f5.

Resolves #10649

This PR introduces the Wake Prompt Landing Matrix in `ai/docs/wake-prompt-landing-matrix.md`.

## Deltas from ticket
Added the explicit Bridge Backlog / Subscription Isolation preflight step mandated during cross-model coordination, ensuring no uncontrolled backlog dumps invalidate the testing metrics.

## Test Evidence
Validated markdown formatting.

## Post-Merge Validation
- [ ] Utilize the matrix during the next scheduled bridge delivery test.