### PR TITLE
fix(ai): bulk migrate legacy memory rows to fix staleness bug (#10643)

### DIFF
--- a/ai/scripts/checkSunsetted.mjs
+++ b/ai/scripts/checkSunsetted.mjs
@@ -43,15 +43,52 @@ async function main() {
     `);
     const subs = subStmt.all(identity);
 
-    // 2. Find last AGENT_MEMORY for this identity + extract origin session ID.
-    //    rows are `AGENT_MEMORY` (not `MEMORY`); identity tracks via `properties.userId`.
-    //    Legacy rows missing structured fields are migrated via update-on-read.
-    const memStmt = db.prepare(`
+    // [Anchor & Echo] Option A: Upfront Bulk Migration for Legacy Rows
+    // Legacy AGENT_MEMORY rows lack a structured 'timestamp' property (time was embedded in 'name').
+    // If not migrated, 'ORDER BY COALESCE(timestamp, name)' falls back to 'name', and lexical
+    // sorting ('Memory: 2026-05...') always places legacy rows above fresh rows (which have pure ISO strings).
+    // Instead of probabilistic update-on-read (which blocks on the top-1 legacy row infinitely),
+    // we perform a deterministic bulk-migration of ALL legacy rows for the target identity before querying.
+    const legacyStmt = db.prepare(`
         SELECT id,
                data,
                json_extract(data, '$.properties.name')        as nameField,
-               json_extract(data, '$.properties.description') as descField,
-               json_extract(data, '$.properties.timestamp')   as timestampField,
+               json_extract(data, '$.properties.description') as descField
+        FROM Nodes
+        WHERE json_extract(data, '$.label') = 'AGENT_MEMORY'
+          AND (json_extract(data, '$.properties.agentIdentity') = ? OR json_extract(data, '$.properties.userId') = ?)
+          AND json_extract(data, '$.properties.timestamp') IS NULL
+    `);
+    const legacyRows = legacyStmt.all(identity, identity);
+    
+    if (legacyRows.length > 0) {
+        const updateStmt = db.prepare(`UPDATE Nodes SET data = ? WHERE id = ?`);
+        db.transaction((rows) => {
+            for (const row of rows) {
+                const tsMatch  = row.nameField?.match(/^Memory:\s+(.+)$/);
+                const sidMatch = row.descField?.match(/inside session ([a-f0-9-]+)/);
+                
+                if (tsMatch && sidMatch) {
+                    try {
+                        const dataObj = JSON.parse(row.data);
+                        dataObj.properties = dataObj.properties || {};
+                        dataObj.properties.timestamp = tsMatch[1];
+                        dataObj.properties.sessionId = sidMatch[1];
+                        dataObj.properties.agentIdentity = identity;
+                        updateStmt.run(JSON.stringify(dataObj), row.id);
+                    } catch (err) {
+                        // Ignore unparseable legacy rows
+                    }
+                }
+            }
+        })(legacyRows);
+    }
+
+    // 2. Find last AGENT_MEMORY for this identity + extract origin session ID.
+    //    rows are `AGENT_MEMORY` (not `MEMORY`); identity tracks via `properties.userId`.
+    //    Now that legacy rows are migrated, ORDER BY timestamp works deterministically.
+    const memStmt = db.prepare(`
+        SELECT json_extract(data, '$.properties.timestamp')   as timestampField,
                json_extract(data, '$.properties.sessionId')   as sessionIdField
         FROM Nodes
         WHERE json_extract(data, '$.label') = 'AGENT_MEMORY'
@@ -61,37 +98,9 @@ async function main() {
     `);
     const memRow = memStmt.get(identity, identity);
 
-    let lastMemTime = memRow?.timestampField || null;
     let originSessionId = memRow?.sessionIdField || '';
     let isSunsetted = false;
     let reason = '';
-
-    // Update-on-read migration for legacy AGENT_MEMORY rows
-    if (memRow && (!lastMemTime || !originSessionId)) {
-        try {
-            const tsMatch     = memRow.nameField?.match(/^Memory:\s+(.+)$/);
-            const sidMatch    = memRow.descField?.match(/inside session ([a-f0-9-]+)/);
-
-            const migratedTime = tsMatch?.[1];
-            const migratedSessionId = sidMatch?.[1];
-
-            if (migratedTime && migratedSessionId) {
-                lastMemTime = migratedTime;
-                originSessionId = migratedSessionId;
-
-                const dataObj = JSON.parse(memRow.data);
-                dataObj.properties = dataObj.properties || {};
-                dataObj.properties.timestamp = migratedTime;
-                dataObj.properties.sessionId = migratedSessionId;
-                dataObj.properties.agentIdentity = identity;
-
-                const updateStmt = db.prepare(`UPDATE Nodes SET data = ? WHERE id = ?`);
-                updateStmt.run(JSON.stringify(dataObj), memRow.id);
-            }
-        } catch (err) {
-            // Ignore migration errors on read path
-        }
-    }
 
     // [Anchor & Echo] Sunset detection criterion: ONLY the explicit Unsubscribe primitive.
     //

--- a/test/playwright/unit/ai/scripts/checkSunsetted.spec.mjs
+++ b/test/playwright/unit/ai/scripts/checkSunsetted.spec.mjs
@@ -103,6 +103,64 @@ test.describe('ai/scripts/checkSunsetted', () => {
         expect(migratedData.properties.agentIdentity).toBe('@neo-legacy-test');
     });
 
+    test('checkSunsetted.mjs legacy-row-blocking-fresh-rows regression test (#10643)', async () => {
+        // Pre-fix: COALESCE(timestamp, name) sorted 'Memory: 2026-xx' (legacy) > '2026-xx' (fresh pure ISO string)
+        // Post-fix: Bulk migration converts legacy rows to pure timestamps, allowing deterministic chronological sorting.
+        const GraphService = (await import('../../../../../ai/mcp/server/memory-core/services/GraphService.mjs')).default;
+        await GraphService.initAsync();
+        const db = GraphService.db.storage.db;
+
+        const testIdentity = '@neo-blocking-test';
+        
+        // 1. Insert Legacy Row (Old)
+        const legacyId = 'blocking-legacy-mem';
+        const legacyTime = new Date(Date.now() - 48 * 3600 * 1000).toISOString();
+        const legacySession = '11111111-1111-1111-1111-111111111111';
+        const legacyData = {
+            id: legacyId, label: 'AGENT_MEMORY', type: 'AGENT_MEMORY',
+            properties: {
+                userId: testIdentity,
+                name: `Memory: ${legacyTime}`,
+                description: `Agent thought flow inside session ${legacySession}.`
+            }
+        };
+
+        // 2. Insert Fresh Row (New)
+        const freshId = 'blocking-fresh-mem';
+        const freshTime = new Date().toISOString();
+        const freshSession = '22222222-2222-2222-2222-222222222222';
+        const freshData = {
+            id: freshId, label: 'AGENT_MEMORY', type: 'AGENT_MEMORY',
+            properties: {
+                agentIdentity: testIdentity,
+                timestamp: freshTime,
+                sessionId: freshSession,
+                name: `Memory: ${freshTime}`,
+                description: `Agent thought flow inside session ${freshSession}.`
+            }
+        };
+
+        const insertStmt = db.prepare(`INSERT INTO Nodes (id, user_id, data) VALUES (?, ?, ?) ON CONFLICT(id) DO UPDATE SET data=excluded.data`);
+        insertStmt.run(legacyId, testIdentity, JSON.stringify(legacyData));
+        insertStmt.run(freshId, testIdentity, JSON.stringify(freshData));
+
+        try {
+            const scriptPath = path.resolve(process.cwd(), 'ai/scripts/checkSunsetted.mjs');
+            const output     = execFileSync('node', [scriptPath, testIdentity], {
+                encoding: 'utf-8',
+                env     : { ...process.env, NEO_UNIT_TEST_MODE: 'true' }
+            });
+            const parsed     = JSON.parse(output);
+
+            expect(parsed.identity).toBe(testIdentity);
+            // The origin session ID should match the NEWER fresh row, not the legacy row.
+            expect(parsed.originSessionId).toBe(freshSession);
+        } finally {
+            db.prepare('DELETE FROM Nodes WHERE id = ?').run(legacyId);
+            db.prepare('DELETE FROM Nodes WHERE id = ?').run(freshId);
+        }
+    });
+
     test('checkSunsetted.mjs does NOT flag sunsetted when subscription exists and AGENT_MEMORY is stale (#10641)', async () => {
         // Per issue #10641: removing the memory-staleness branch from the predicate.
         // Pre-fix: a 24h-old AGENT_MEMORY would flip `sunsetted=true` even with an active


### PR DESCRIPTION
Resolves #10643.

**Implementation details:**
- Replaces the top-1 'update-on-read' strategy with an upfront bulk migration of ALL legacy rows for the target identity.
- Preserves the semantic 'timestamp' information natively, preventing the fallback lexical sorting of 'name' from placing legacy rows above fresh rows.
- Includes Anchor & Echo documentation.