### PR TITLE
fix(ai): add Claude focus seed primitive (#10660)

### DIFF
--- a/ai/mcp/server/memory-core/openapi.yaml
+++ b/ai/mcp/server/memory-core/openapi.yaml
@@ -1154,6 +1154,7 @@ paths:
                     adapter:          {type: string, enum: [osascript, tmux]}
                     appName:          {type: string}
                     tabShortcut:      {type: string, nullable: true}
+                    focusSeedKey:     {type: string, nullable: true}
                     tmuxSession:      {type: string}
                 sinceLogId:
                   type: integer

--- a/ai/mcp/server/memory-core/services/WakeSubscriptionService.mjs
+++ b/ai/mcp/server/memory-core/services/WakeSubscriptionService.mjs
@@ -380,7 +380,7 @@ class WakeSubscriptionService extends Base {
      * @param {Object} [opts.filters] taggedConcepts | priority | senderFilter | inReplyToFilter
      * @param {String} opts.harnessTarget One of validHarnessTargets
      * @param {Object} [opts.harnessTargetMetadata] appName | url | coalesceWindow |
-     *     daemonSocketPath | adapter | tabShortcut | tmuxSession
+     *     daemonSocketPath | adapter | tabShortcut | focusSeedKey | tmuxSession
      * @returns {Promise<Object>} {subscriptionId, harnessTarget, signingKey?}
      */
     async subscribe({trigger, filters = {}, harnessTarget, harnessTargetMetadata = {}} = {}) {

--- a/ai/scripts/bridge-daemon.mjs
+++ b/ai/scripts/bridge-daemon.mjs
@@ -581,6 +581,11 @@ async function deliverDigest(subscription, digest) {
                 if (appName === 'Claude') tabShortcut = '3';
                 else if (appName === 'Antigravity') tabShortcut = 'shift+i';
             }
+            let focusSeedKey = meta.focusSeedKey;
+            // Claude Desktop's Cmd+3 selects the Code tab but does not always move focus into
+            // the prompt. Seed focus with Space before the destructive Cmd+A/Cmd+X clear path.
+            // Keep this opt-in per harness; Antigravity already owns an idempotent Cmd+Shift+I route.
+            if (focusSeedKey === undefined && appName === 'Claude') focusSeedKey = 'space';
             
             // [Anchor & Echo] The Electron-Paradox Defense:
             // Electron-based IDEs (Antigravity, VS Code) register their bundle names differently
@@ -618,6 +623,15 @@ async function deliverDigest(subscription, digest) {
                     osascriptArgs.push('-e', `      keystroke "${tabShortcut}" using command down`);
                 }
                 osascriptArgs.push('-e', '      delay 0.5');
+            }
+
+            if (focusSeedKey) {
+                if (focusSeedKey === 'space' || focusSeedKey === ' ') {
+                    osascriptArgs.push('-e', '      key code 49');
+                } else {
+                    osascriptArgs.push('-e', `      keystroke "${focusSeedKey}"`);
+                }
+                osascriptArgs.push('-e', '      delay 0.2');
             }
 
             osascriptArgs.push(

--- a/test/playwright/unit/ai/mcp/server/memory-core/McpServerToolLimits.spec.mjs
+++ b/test/playwright/unit/ai/mcp/server/memory-core/McpServerToolLimits.spec.mjs
@@ -70,6 +70,7 @@ test.describe('Neo.ai.mcp.server.memory-core Tool limits', () => {
             'appName',
             'coalesceWindow',
             'daemonSocketPath',
+            'focusSeedKey',
             'tabShortcut',
             'tmuxSession',
             'url'

--- a/test/playwright/unit/ai/mcp/server/memory-core/services/WakeSubscriptionService.spec.mjs
+++ b/test/playwright/unit/ai/mcp/server/memory-core/services/WakeSubscriptionService.spec.mjs
@@ -328,6 +328,7 @@ test.describe('Neo.ai.mcp.server.memory-core.services.WakeSubscriptionService', 
                     adapter       : 'osascript',
                     appName       : 'Claude',
                     coalesceWindow: 0,
+                    focusSeedKey  : 'space',
                     tabShortcut   : '3'
                 }
             });
@@ -336,6 +337,7 @@ test.describe('Neo.ai.mcp.server.memory-core.services.WakeSubscriptionService', 
             expect(node.properties.harnessTargetMetadata.adapter).toBe('osascript');
             expect(node.properties.harnessTargetMetadata.appName).toBe('Claude');
             expect(node.properties.harnessTargetMetadata.coalesceWindow).toBe(0);
+            expect(node.properties.harnessTargetMetadata.focusSeedKey).toBe('space');
             expect(node.properties.harnessTargetMetadata.tabShortcut).toBe('3');
         });
     });

--- a/test/playwright/unit/ai/scripts/bridge-daemon.spec.mjs
+++ b/test/playwright/unit/ai/scripts/bridge-daemon.spec.mjs
@@ -10,11 +10,14 @@ import { SQLITE_IN_CLAUSE_BATCH_SIZE } from '../../../../../ai/graph/storage/con
 test.describe('Bridge Daemon', () => {
     let db;
     let daemonProcess;
-    const TEST_ID = crypto.randomUUID().substring(0, 8);
-    const DB_PATH = `.neo-ai-data/sqlite/test-daemon-${TEST_ID}.sqlite`;
-    const DAEMON_DIR = `.neo-ai-data/wake-daemon-test-${TEST_ID}`;
+    let DB_PATH;
+    let DAEMON_DIR;
 
     test.beforeEach(() => {
+        const testId = crypto.randomUUID().substring(0, 8);
+        DB_PATH = `.neo-ai-data/sqlite/test-daemon-${testId}.sqlite`;
+        DAEMON_DIR = `.neo-ai-data/wake-daemon-test-${testId}`;
+
         fs.ensureDirSync(path.dirname(DB_PATH));
         fs.ensureDirSync(DAEMON_DIR);
         if (fs.existsSync(DB_PATH)) fs.unlinkSync(DB_PATH);
@@ -577,6 +580,98 @@ test.describe('Bridge Daemon', () => {
 
         expect(args.join(' ')).toContain('keystroke "i" using {command down, shift down}');
         expect(args.join(' ')).toContain('tell application "Antigravity" to activate');
+        expect(args.join(' ')).not.toContain('key code 49');
+    });
+
+    test('Claude default focus seed generates Space after Cmd+3 and before prompt clear', async () => {
+        const subId = 'sub_' + crypto.randomUUID();
+        const agentId = '@test-agent-claude';
+
+        db.prepare('INSERT OR REPLACE INTO Nodes (id, data) VALUES (?, ?)').run(agentId, JSON.stringify({
+            id: agentId,
+            label: 'AGENT',
+            properties: { name: 'Test Agent Claude' }
+        }));
+
+        db.prepare('INSERT OR REPLACE INTO Nodes (id, data) VALUES (?, ?)').run(subId, JSON.stringify({
+            id: subId,
+            label: 'WAKE_SUBSCRIPTION',
+            properties: {
+                agentIdentity: agentId,
+                harnessTarget: 'bridge-daemon',
+                status: 'active',
+                trigger: 'SENT_TO_ME',
+                harnessTargetMetadata: {
+                    adapter: 'osascript',
+                    appName: 'Claude',
+                    coalesceWindow: 1
+                }
+            }
+        }));
+
+        db.prepare('INSERT INTO GraphLog (entity_id, entity_type) VALUES (?, ?)').run(subId, 'nodes');
+
+        const binDir = path.join(DAEMON_DIR, 'bin');
+        fs.ensureDirSync(binDir);
+        const mockOsascriptPath = path.join(binDir, 'osascript');
+        const mockOutPath = path.join(DAEMON_DIR, 'mock_claude_out.json');
+        fs.writeFileSync(mockOsascriptPath, `#!/usr/bin/env node\nimport fs from 'fs';\nfs.writeFileSync('${mockOutPath}', JSON.stringify(process.argv.slice(2)));\n`);
+        fs.chmodSync(mockOsascriptPath, 0o755);
+
+        daemonProcess = spawn('node', ['ai/scripts/bridge-daemon.mjs'], {
+            stdio: 'pipe',
+            env: { ...process.env, PATH: `${path.resolve(binDir)}:${process.env.PATH}`, NEO_AI_DB_PATH: DB_PATH, NEO_AI_DAEMON_DIR: DAEMON_DIR }
+        });
+
+        const deliveryPromise = new Promise((resolve, reject) => {
+            const timeout = setTimeout(() => reject(new Error('Daemon failed to deliver event within timeout')), 10000);
+
+            daemonProcess.stdout.on('data', (data) => {
+                const out = data.toString();
+                if (out.includes('[Bridge Daemon] Delivered ' + subId)) {
+                    clearTimeout(timeout);
+                    resolve();
+                }
+            });
+            daemonProcess.stderr.on('data', data => console.error('[DAEMON STDERR]', data.toString()));
+            daemonProcess.on('error', reject);
+        });
+
+        await new Promise(resolve => setTimeout(resolve, 1000));
+
+        const msgId = 'msg_' + crypto.randomUUID();
+        db.prepare('INSERT INTO Nodes (id, data) VALUES (?, ?)').run(msgId, JSON.stringify({
+            id: msgId,
+            label: 'MESSAGE',
+            properties: {
+                from: '@sender',
+                subject: 'Test Claude Event',
+                priority: 'normal'
+            }
+        }));
+        db.prepare('INSERT INTO GraphLog (entity_id, entity_type) VALUES (?, ?)').run(msgId, 'nodes');
+
+        const edgeId = 'edge_' + crypto.randomUUID();
+        db.prepare('INSERT INTO Edges (id, data, source, target, type) VALUES (?, ?, ?, ?, ?)').run(edgeId, JSON.stringify({
+            id: edgeId,
+            source: msgId,
+            target: agentId,
+            type: 'SENT_TO'
+        }), msgId, agentId, 'SENT_TO');
+        db.prepare('INSERT INTO GraphLog (entity_id, entity_type) VALUES (?, ?)').run(edgeId, 'edges');
+
+        await deliveryPromise;
+
+        const args = JSON.parse(fs.readFileSync(mockOutPath, 'utf8'));
+        const activateIndex = args.findIndex(arg => arg.includes('tell application "Claude" to activate'));
+        const tabIndex      = args.findIndex(arg => arg.includes('keystroke "3" using command down'));
+        const spaceIndex    = args.findIndex(arg => arg.includes('key code 49'));
+        const clearIndex    = args.findIndex(arg => arg.includes('keystroke "a" using command down'));
+
+        expect(activateIndex).toBeGreaterThan(-1);
+        expect(tabIndex).toBeGreaterThan(activateIndex);
+        expect(spaceIndex).toBeGreaterThan(tabIndex);
+        expect(clearIndex).toBeGreaterThan(spaceIndex);
     });
 
     test('getNodesData and getEdgesData deterministically chunk queries by SQLITE_IN_CLAUSE_BATCH_SIZE', () => {


### PR DESCRIPTION
Authored by GPT-5.5 (Codex Desktop). Session d9cd4943-3285-47a6-b629-c05a9a2a38e4.

Resolves #10660
Related: #10658
Related: #10647
Related: #10649

Adds a Claude-only Space focus seed to the Shape C bridge osascript path. The bridge now supports a per-harness `focusSeedKey` metadata primitive, defaults it to `space` only for Claude Desktop, and emits `key code 49` after `Cmd+3` and before the destructive `Cmd+A` / `Cmd+X` prompt-clear sequence. Antigravity remains on its verified `Cmd+Shift+I` route with no Space seed.

## Deltas from ticket
- Added `focusSeedKey` to the Memory Core wake subscription schema so the primitive is explicit and future harnesses can opt in after matrix proof.
- Kept the default Claude-only instead of inserting Space into the shared osascript path globally.
- Fixed `bridge-daemon.spec.mjs` isolation to allocate a unique SQLite database and daemon directory per test; the default Playwright focus run uses parallel workers, and the previous shared path made the file unrunnable in default mode.

## Test Evidence
- `git diff --check origin/dev...HEAD`
- `npm run test-unit -- test/playwright/unit/ai/mcp/server/memory-core/McpServerToolLimits.spec.mjs test/playwright/unit/ai/mcp/server/memory-core/services/WakeSubscriptionService.spec.mjs` — 36 passed
- `npm run test-unit -- test/playwright/unit/ai/scripts/bridge-daemon.spec.mjs` — 8 passed; required sandbox escalation because `.neo-ai-data/sqlite` is a symlink outside Codex writable roots

## Post-Merge Validation
- [ ] Run the #10649 Claude Desktop prompt-landing matrix row with Code tab selected and transcript/history focused before wake.
- [ ] Confirm payload lands in the Claude prompt field, not transcript/history.
- [ ] Keep wake safety gate tripped until the matrix row is green or @tobiu accepts a bounded override.

## Commit
- `72d0f980b` — `fix(ai): add Claude focus seed primitive (#10660)`