### PR TITLE
fix(ai): extend focus seed default to Codex (#10662)

### DIFF
--- a/ai/scripts/bridge-daemon.mjs
+++ b/ai/scripts/bridge-daemon.mjs
@@ -583,9 +583,13 @@ async function deliverDigest(subscription, digest) {
             }
             let focusSeedKey = meta.focusSeedKey;
             // Claude Desktop's Cmd+3 selects the Code tab but does not always move focus into
-            // the prompt. Seed focus with Space before the destructive Cmd+A/Cmd+X clear path.
-            // Keep this opt-in per harness; Antigravity already owns an idempotent Cmd+Shift+I route.
-            if (focusSeedKey === undefined && appName === 'Claude') focusSeedKey = 'space';
+            // the prompt. Codex Desktop hits the same class of regression under collapsed-
+            // sidebar state — bridge wake reaches the app window but composer focus is on
+            // thread-history, so the first Cmd+A in the destructive-clear sequence selects
+            // the wrong target (per #10662 / #10649 collapsed-sidebar matrix reproduction).
+            // Seed focus with Space before the destructive Cmd+A/Cmd+X clear path. Keep this
+            // opt-in per harness; Antigravity already owns an idempotent Cmd+Shift+I route.
+            if (focusSeedKey === undefined && (appName === 'Claude' || appName === 'Codex')) focusSeedKey = 'space';
             
             // [Anchor & Echo] The Electron-Paradox Defense:
             // Electron-based IDEs (Antigravity, VS Code) register their bundle names differently

--- a/test/playwright/unit/ai/mcp/server/memory-core/services/WakeSubscriptionService.spec.mjs
+++ b/test/playwright/unit/ai/mcp/server/memory-core/services/WakeSubscriptionService.spec.mjs
@@ -342,6 +342,34 @@ test.describe('Neo.ai.mcp.server.memory-core.services.WakeSubscriptionService', 
         });
     });
 
+    test('MCP tool preserves explicit bridge-daemon metadata for Codex with focusSeedKey (#10662)', async () => {
+        // Per #10662, the Codex collapsed-sidebar regression is closed by extending the
+        // per-harness `focusSeedKey: 'space'` default to `appName === 'Codex'`. This test
+        // mirrors the Claude metadata round-trip above for Codex, ensuring the schema
+        // validator + storage substrate accept the same field shape regardless of harness.
+        await RequestContextService.run({agentIdentityNodeId: '@alice'}, async () => {
+            const res = await callTool('manage_wake_subscription', {
+                action               : 'subscribe',
+                trigger              : 'SENT_TO_ME',
+                harnessTarget        : 'bridge-daemon',
+                harnessTargetMetadata: {
+                    adapter       : 'osascript',
+                    appName       : 'Codex',
+                    coalesceWindow: 0,
+                    focusSeedKey  : 'space',
+                    tabShortcut   : null
+                }
+            });
+
+            const node = GraphService.db.nodes.get(res.subscriptionId);
+            expect(node.properties.harnessTargetMetadata.adapter).toBe('osascript');
+            expect(node.properties.harnessTargetMetadata.appName).toBe('Codex');
+            expect(node.properties.harnessTargetMetadata.coalesceWindow).toBe(0);
+            expect(node.properties.harnessTargetMetadata.focusSeedKey).toBe('space');
+            expect(node.properties.harnessTargetMetadata.tabShortcut).toBeNull();
+        });
+    });
+
     test('subscribe rejects invalid trigger', async () => {
         await RequestContextService.run({agentIdentityNodeId: '@alice'}, async () => {
             await expect(WakeSubscriptionService.subscribe({

--- a/test/playwright/unit/ai/scripts/bridge-daemon.spec.mjs
+++ b/test/playwright/unit/ai/scripts/bridge-daemon.spec.mjs
@@ -674,6 +674,107 @@ test.describe('Bridge Daemon', () => {
         expect(clearIndex).toBeGreaterThan(spaceIndex);
     });
 
+    test('Codex default focus seed generates Space after activate and before prompt clear (#10662)', async () => {
+        // Per #10662: extends the per-harness focusSeedKey: 'space' default to
+        // appName === 'Codex' so the collapsed-sidebar regression (Cmd+A selects
+        // thread history instead of composer content) is closed by seeding focus
+        // before the destructive clear. Codex has no tab-shortcut default
+        // (tabShortcut stays undefined / null), so the order is
+        // activate → Space → Cmd+A — distinct from the Claude order
+        // (activate → Cmd+3 → Space → Cmd+A).
+        const subId = 'sub_' + crypto.randomUUID();
+        const agentId = '@test-agent-codex';
+
+        db.prepare('INSERT OR REPLACE INTO Nodes (id, data) VALUES (?, ?)').run(agentId, JSON.stringify({
+            id: agentId,
+            label: 'AGENT',
+            properties: { name: 'Test Agent Codex' }
+        }));
+
+        db.prepare('INSERT OR REPLACE INTO Nodes (id, data) VALUES (?, ?)').run(subId, JSON.stringify({
+            id: subId,
+            label: 'WAKE_SUBSCRIPTION',
+            properties: {
+                agentIdentity: agentId,
+                harnessTarget: 'bridge-daemon',
+                status: 'active',
+                trigger: 'SENT_TO_ME',
+                harnessTargetMetadata: {
+                    adapter: 'osascript',
+                    appName: 'Codex',
+                    coalesceWindow: 1
+                }
+            }
+        }));
+
+        db.prepare('INSERT INTO GraphLog (entity_id, entity_type) VALUES (?, ?)').run(subId, 'nodes');
+
+        const binDir = path.join(DAEMON_DIR, 'bin');
+        fs.ensureDirSync(binDir);
+        const mockOsascriptPath = path.join(binDir, 'osascript');
+        const mockOutPath = path.join(DAEMON_DIR, 'mock_codex_out.json');
+        fs.writeFileSync(mockOsascriptPath, `#!/usr/bin/env node\nimport fs from 'fs';\nfs.writeFileSync('${mockOutPath}', JSON.stringify(process.argv.slice(2)));\n`);
+        fs.chmodSync(mockOsascriptPath, 0o755);
+
+        daemonProcess = spawn('node', ['ai/scripts/bridge-daemon.mjs'], {
+            stdio: 'pipe',
+            env: { ...process.env, PATH: `${path.resolve(binDir)}:${process.env.PATH}`, NEO_AI_DB_PATH: DB_PATH, NEO_AI_DAEMON_DIR: DAEMON_DIR }
+        });
+
+        const deliveryPromise = new Promise((resolve, reject) => {
+            const timeout = setTimeout(() => reject(new Error('Daemon failed to deliver event within timeout')), 10000);
+
+            daemonProcess.stdout.on('data', (data) => {
+                const out = data.toString();
+                if (out.includes('[Bridge Daemon] Delivered ' + subId)) {
+                    clearTimeout(timeout);
+                    resolve();
+                }
+            });
+            daemonProcess.stderr.on('data', data => console.error('[DAEMON STDERR]', data.toString()));
+            daemonProcess.on('error', reject);
+        });
+
+        await new Promise(resolve => setTimeout(resolve, 1000));
+
+        const msgId = 'msg_' + crypto.randomUUID();
+        db.prepare('INSERT INTO Nodes (id, data) VALUES (?, ?)').run(msgId, JSON.stringify({
+            id: msgId,
+            label: 'MESSAGE',
+            properties: {
+                from: '@sender',
+                subject: 'Test Codex Event',
+                priority: 'normal'
+            }
+        }));
+        db.prepare('INSERT INTO GraphLog (entity_id, entity_type) VALUES (?, ?)').run(msgId, 'nodes');
+
+        const edgeId = 'edge_' + crypto.randomUUID();
+        db.prepare('INSERT INTO Edges (id, data, source, target, type) VALUES (?, ?, ?, ?, ?)').run(edgeId, JSON.stringify({
+            id: edgeId,
+            source: msgId,
+            target: agentId,
+            type: 'SENT_TO'
+        }), msgId, agentId, 'SENT_TO');
+        db.prepare('INSERT INTO GraphLog (entity_id, entity_type) VALUES (?, ?)').run(edgeId, 'edges');
+
+        await deliveryPromise;
+
+        const args = JSON.parse(fs.readFileSync(mockOutPath, 'utf8'));
+        const activateIndex = args.findIndex(arg => arg.includes('tell application "Codex" to activate'));
+        const spaceIndex    = args.findIndex(arg => arg.includes('key code 49'));
+        const clearIndex    = args.findIndex(arg => arg.includes('keystroke "a" using command down'));
+
+        expect(activateIndex).toBeGreaterThan(-1);
+        expect(spaceIndex).toBeGreaterThan(activateIndex);
+        expect(clearIndex).toBeGreaterThan(spaceIndex);
+
+        // Negative drift guard: Codex must NOT emit a Cmd+3 tab-shortcut keystroke
+        // (Codex has no Code-tab equivalent). If a future change introduces one,
+        // this assertion fails loudly so the order is re-validated.
+        expect(args.join(' ')).not.toContain('keystroke "3" using command down');
+    });
+
     test('getNodesData and getEdgesData deterministically chunk queries by SQLITE_IN_CLAUSE_BATCH_SIZE', () => {
         let prepareCount = 0;
         let paramsLength = [];


### PR DESCRIPTION
Authored by Claude Opus 4.7 (1M context) (Claude Code). Session 9766f91c-51f8-44fe-ac34-d79f61a0e1bf.

Resolves #10662
Related: #10661 (Claude focus seed PR — substrate primitive this extends), #10649 (matrix execution that surfaced the regression), #10647 (Wake Incident Safety Tree epic — parent), #10650 (Wake Substrate Incident Protocol — reactivation evidence requirements gate this)

Mirrors PR #10661 verbatim for Codex. The collapsed-sidebar regression that #10649 matrix execution surfaced (Codex row red on 2026-05-03 ~19:43Z) is the same failure-mode class as the Claude pre-#10661 case: bridge wake reaches the app window via osascript, but composer focus is uncertain — the first `Cmd+A` in the destructive-clear sequence selects the wrong target (thread history instead of composer content).

PR #10661 introduced the per-harness `focusSeedKey` primitive precisely for this extension shape: future harnesses adopt the seed by extending the per-harness default conditional, not by re-architecting the bridge. This PR's bridge-daemon change is one line.

## Surface

- **`ai/scripts/bridge-daemon.mjs`** (~10 lines: 1-line conditional change + Anchor & Echo block update). Extends the `focusSeedKey === undefined && appName === 'Claude'` default to `(appName === 'Claude' || appName === 'Codex')`. Anchor & Echo block now cites the empirical Codex collapsed-sidebar regression + #10662 + #10649.
- **`test/playwright/unit/ai/mcp/server/memory-core/services/WakeSubscriptionService.spec.mjs`** (~28 lines). Round-trip test for Codex `harnessTargetMetadata` with `focusSeedKey: 'space'` + `tabShortcut: null`, mirroring the existing Claude round-trip test.
- **`test/playwright/unit/ai/scripts/bridge-daemon.spec.mjs`** (~95 lines). Ordering test for Codex (`activate < space < clear`) using the same mock-osascript pattern as the existing Claude ordering test. Plus a negative drift guard (`not.toContain('keystroke "3" using command down')`) — Codex has no Code-tab equivalent so the bridge must not emit a Cmd+3 keystroke. Distinct from Claude's `activate < tab < space < clear` order.

## Deltas from ticket

None — the fix matches #10662's prescription verbatim. The Anchor & Echo update covers the trap reasoning the ticket called out (don't introduce a new primitive; extend the existing one).

## Test Evidence

```
$ npx playwright test -c test/playwright/playwright.config.unit.mjs \\
    test/playwright/unit/ai/scripts/bridge-daemon.spec.mjs \\
    test/playwright/unit/ai/mcp/server/memory-core/services/WakeSubscriptionService.spec.mjs
Running 44 tests using 8 workers
  44 passed (8.7s)
```

New spec coverage:
- **WakeSubscriptionService.spec.mjs**: `MCP tool preserves explicit bridge-daemon metadata for Codex with focusSeedKey (#10662)` — verifies the round-trip preserves `appName: 'Codex'` + `focusSeedKey: 'space'` + `tabShortcut: null`
- **bridge-daemon.spec.mjs**: `Codex default focus seed generates Space after activate and before prompt clear (#10662)` — verifies the keystroke order `activate < space < clear` AND the negative drift guard (no Cmd+3 emitted for Codex)

Existing Claude + Antigravity tests all pass — no regression in the prior matrix rows.

## Post-Merge Validation

- [ ] Controlled bridge test against `@neo-gpt` Codex Desktop with sidebar collapsed: wake-digest lands in composer (not thread history); matrix Codex row flips from RED to GREEN
- [ ] Per the #10650 protocol "Reactivation Evidence Requirements" section: with all three matrix rows green AND all local regressions merged AND bridge backlog fence path documented, reactivation-gate becomes eligible — final flip is @tobiu's call
- [ ] Once reactivation completes: file the post-incident retrospective on #10647 using the protocol's template; close #10647 epic with summary

## Out of Scope (per ticket)

- **Codex app-server adapter** (`turn/start` / `turn/steer` / `thread/inject_items` via `codex debug app-server send-message-v2`) — anchored on existing #10517, owned by @neo-gpt; supersedes UI-keystroke delivery once shipped
- **Bridge backlog fence handling** — already documented in the #10650 protocol
- **Cross-process cache-invalidation under live updates** — separate substrate concern (#10186)
- **Disable-Codex-subscription operational mitigation** — covered by operator-side discipline (sidebar-open per @tobiu's calibration); only relevant if this PR's Space seed empirically fails against collapsed-sidebar Codex

## Related Coordination Anchors

- @neo-gpt's Codex-row-red broadcast: A2A `MESSAGE:d2f8dc1c-b329-4463-a896-8aad71c2ac5a`
- Lane-split confirmation from @neo-gpt: A2A `MESSAGE:93a1d01f-ce14-4def-bd0a-3a9b3c91dff6`
- @neo-gemini-3-1-pro endorsement broadcast: A2A `MESSAGE:ceeb3d6f-965d-4c33-9823-9aae7239d17d`
- @tobiu calibration on operator-side fallback (sidebar-open lighter than disable-subscription): user-facing chat