### PR TITLE
fix(ai): fail closed for Codex UI wake (#10664)

### DIFF
--- a/ai/scripts/bridge-daemon.mjs
+++ b/ai/scripts/bridge-daemon.mjs
@@ -595,11 +595,16 @@ async function deliverDigest(subscription, digest) {
             // instead of composer content). Manual matrix validation by @tobiu falsified the
             // hypothesis: pressing Space when the Codex prompt field is unfocused applies
             // only a focus outline — it does NOT focus the composer. Enter behaves
-            // identically. Printable keys (e.g. 'r') CAN focus the composer, but if the
-            // prompt already contains text, the keystroke replaces existing content —
-            // unsafe pre-clear seed.
+            // identically. Printable keys (e.g. 'r') CAN focus the composer; updated
+            // empirical evidence shows the keystroke APPENDS to the existing draft rather
+            // than fully replacing it, but appending into the prompt is still mutation —
+            // any subsequent `Cmd+A` / `Cmd+X` clear sequence captures the appended char
+            // and the wake payload pastes over the result. Without a verified probe-and-
+            // undo or non-mutating focus primitive, printable-key seeding remains unsafe
+            // pre-clear. (#10664 candidate `r → Cmd+Z → Cmd+A → Cmd+X` is under
+            // investigation by @neo-gpt against a 5-row state matrix; not yet validated.)
             //
-            // No empirically-validated non-destructive composer-focus primitive exists for
+            // No empirically-validated non-mutating composer-focus primitive exists for
             // Codex Desktop today. Until either (a) operator explicitly configures
             // `meta.focusSeedKey` via subscription metadata with a verified primitive, or
             // (b) the Codex app-server adapter (#10517) ships — using `turn/start` /

--- a/ai/scripts/bridge-daemon.mjs
+++ b/ai/scripts/bridge-daemon.mjs
@@ -595,22 +595,33 @@ async function deliverDigest(subscription, digest) {
             // instead of composer content). Manual matrix validation by @tobiu falsified the
             // hypothesis: pressing Space when the Codex prompt field is unfocused applies
             // only a focus outline — it does NOT focus the composer. Enter behaves
-            // identically. Printable keys (e.g. 'r') CAN focus the composer; updated
-            // empirical evidence shows the keystroke APPENDS to the existing draft rather
-            // than fully replacing it, but appending into the prompt is still mutation —
-            // any subsequent `Cmd+A` / `Cmd+X` clear sequence captures the appended char
-            // and the wake payload pastes over the result. Without a verified probe-and-
-            // undo or non-mutating focus primitive, printable-key seeding remains unsafe
-            // pre-clear. (#10664 candidate `r → Cmd+Z → Cmd+A → Cmd+X` is under
-            // investigation by @neo-gpt against a 5-row state matrix; not yet validated.)
+            // identically. Printable keys (e.g. 'r') CAN focus the composer but MUTATE
+            // prompt content; latest `r` observation appended to the existing prompt rather
+            // than fully replacing it, but appending IS mutation — any subsequent
+            // `Cmd+A` / `Cmd+X` clear sequence captures the appended char and the wake
+            // payload pastes over the result. Until an undo sequence passes the 5-row
+            // matrix (focused empty / focused draft / unfocused empty / unfocused draft /
+            // history-or-transcript focused), printable-key seeding remains unsafe pre-clear.
+            //
+            // **Scope distinction load-bearing for future operator opt-in**: the existing
+            // `meta.focusSeedKey` primitive is a SINGLE-KEY non-mutating focus seed (the
+            // bridge emits one keystroke before the destructive clear). A future verified
+            // single-key non-mutating Codex primitive can opt in via `meta.focusSeedKey`.
+            // The `r → Cmd+Z → Cmd+A → Cmd+X` candidate (under @neo-gpt investigation per
+            // #10664) is a MULTI-STEP probe-and-undo SEQUENCE, NOT a single-key seed; if it
+            // proves safe across all 5 matrix rows, it would need a distinct implementation
+            // path (e.g. a `meta.focusSeedSequence` primitive, or routed via the Codex
+            // app-server adapter below) — NOT a `meta.focusSeedKey: 'r'` opt-in, which
+            // would silently re-introduce the mutating-prompt failure mode.
             //
             // No empirically-validated non-mutating composer-focus primitive exists for
             // Codex Desktop today. Until either (a) operator explicitly configures
-            // `meta.focusSeedKey` via subscription metadata with a verified primitive, or
-            // (b) the Codex app-server adapter (#10517) ships — using `turn/start` /
-            // `turn/steer` / `thread/inject_items` via `codex debug app-server send-message-v2`
-            // — and supersedes the UI-keystroke path entirely, the bridge MUST refuse to
-            // proceed past the destructive Cmd+A / Cmd+X clear sequence for Codex.
+            // `meta.focusSeedKey` via subscription metadata with a verified single-key
+            // non-mutating primitive, or (b) the Codex app-server adapter (#10517) ships —
+            // using `turn/start` / `turn/steer` / `thread/inject_items` via
+            // `codex debug app-server send-message-v2` — and supersedes the UI-keystroke
+            // path entirely, the bridge MUST refuse to proceed past the destructive
+            // Cmd+A / Cmd+X clear sequence for Codex.
             //
             // Defense-in-depth: even with `@neo-gpt`'s WAKE_SUBSCRIPTION currently set to
             // `harnessTarget: 'disabled'` (per #10664 immediate operator mitigation), this

--- a/ai/scripts/bridge-daemon.mjs
+++ b/ai/scripts/bridge-daemon.mjs
@@ -583,14 +583,45 @@ async function deliverDigest(subscription, digest) {
             }
             let focusSeedKey = meta.focusSeedKey;
             // Claude Desktop's Cmd+3 selects the Code tab but does not always move focus into
-            // the prompt. Codex Desktop hits the same class of regression under collapsed-
-            // sidebar state — bridge wake reaches the app window but composer focus is on
-            // thread-history, so the first Cmd+A in the destructive-clear sequence selects
-            // the wrong target (per #10662 / #10649 collapsed-sidebar matrix reproduction).
-            // Seed focus with Space before the destructive Cmd+A/Cmd+X clear path. Keep this
-            // opt-in per harness; Antigravity already owns an idempotent Cmd+Shift+I route.
-            if (focusSeedKey === undefined && (appName === 'Claude' || appName === 'Codex')) focusSeedKey = 'space';
-            
+            // the prompt. Seed focus with Space before the destructive Cmd+A/Cmd+X clear path.
+            // Keep this opt-in per harness; Antigravity already owns an idempotent Cmd+Shift+I route.
+            if (focusSeedKey === undefined && appName === 'Claude') focusSeedKey = 'space';
+
+            // [Anchor & Echo] Codex fail-closed (#10664) — empirical disproval 2026-05-03:
+            //
+            // PR #10663 attempted to mirror Claude's #10661 Space-seed primitive for Codex
+            // Desktop, hypothesizing that the same per-harness focusSeedKey: 'space' default
+            // would close the collapsed-sidebar regression (Cmd+A selecting thread history
+            // instead of composer content). Manual matrix validation by @tobiu falsified the
+            // hypothesis: pressing Space when the Codex prompt field is unfocused applies
+            // only a focus outline — it does NOT focus the composer. Enter behaves
+            // identically. Printable keys (e.g. 'r') CAN focus the composer, but if the
+            // prompt already contains text, the keystroke replaces existing content —
+            // unsafe pre-clear seed.
+            //
+            // No empirically-validated non-destructive composer-focus primitive exists for
+            // Codex Desktop today. Until either (a) operator explicitly configures
+            // `meta.focusSeedKey` via subscription metadata with a verified primitive, or
+            // (b) the Codex app-server adapter (#10517) ships — using `turn/start` /
+            // `turn/steer` / `thread/inject_items` via `codex debug app-server send-message-v2`
+            // — and supersedes the UI-keystroke path entirely, the bridge MUST refuse to
+            // proceed past the destructive Cmd+A / Cmd+X clear sequence for Codex.
+            //
+            // Defense-in-depth: even with `@neo-gpt`'s WAKE_SUBSCRIPTION currently set to
+            // `harnessTarget: 'disabled'` (per #10664 immediate operator mitigation), this
+            // bridge-side guard prevents accidental subscription re-enable from triggering
+            // the empirically-disproved focus-seed path.
+            if (appName === 'Codex' && !focusSeedKey) {
+                writeLog('WARN',
+                    `[Bridge Daemon] Codex UI wake delivery refused for ${subscription.id}: ` +
+                    `no validated composer-focus primitive (per #10664). ` +
+                    `Subscription must opt in via meta.focusSeedKey with a verified primitive, ` +
+                    `or wait for the #10517 Codex app-server adapter.`
+                );
+                return;
+            }
+
+
             // [Anchor & Echo] The Electron-Paradox Defense:
             // Electron-based IDEs (Antigravity, VS Code) register their bundle names differently
             // than their underlying macOS process names (often just "Electron" to System Events).

--- a/test/playwright/unit/ai/mcp/server/memory-core/services/WakeSubscriptionService.spec.mjs
+++ b/test/playwright/unit/ai/mcp/server/memory-core/services/WakeSubscriptionService.spec.mjs
@@ -342,33 +342,15 @@ test.describe('Neo.ai.mcp.server.memory-core.services.WakeSubscriptionService', 
         });
     });
 
-    test('MCP tool preserves explicit bridge-daemon metadata for Codex with focusSeedKey (#10662)', async () => {
-        // Per #10662, the Codex collapsed-sidebar regression is closed by extending the
-        // per-harness `focusSeedKey: 'space'` default to `appName === 'Codex'`. This test
-        // mirrors the Claude metadata round-trip above for Codex, ensuring the schema
-        // validator + storage substrate accept the same field shape regardless of harness.
-        await RequestContextService.run({agentIdentityNodeId: '@alice'}, async () => {
-            const res = await callTool('manage_wake_subscription', {
-                action               : 'subscribe',
-                trigger              : 'SENT_TO_ME',
-                harnessTarget        : 'bridge-daemon',
-                harnessTargetMetadata: {
-                    adapter       : 'osascript',
-                    appName       : 'Codex',
-                    coalesceWindow: 0,
-                    focusSeedKey  : 'space',
-                    tabShortcut   : null
-                }
-            });
-
-            const node = GraphService.db.nodes.get(res.subscriptionId);
-            expect(node.properties.harnessTargetMetadata.adapter).toBe('osascript');
-            expect(node.properties.harnessTargetMetadata.appName).toBe('Codex');
-            expect(node.properties.harnessTargetMetadata.coalesceWindow).toBe(0);
-            expect(node.properties.harnessTargetMetadata.focusSeedKey).toBe('space');
-            expect(node.properties.harnessTargetMetadata.tabShortcut).toBeNull();
-        });
-    });
+    // Note (#10664): the Codex round-trip test for `focusSeedKey: 'space'` that shipped in
+    // PR #10663 was removed here. The bridge runtime layer now fails closed for Codex
+    // without an explicit operator-validated `focusSeedKey` (per #10664 fail-closed guard
+    // + bridge-daemon.spec.mjs `Codex UI wake fails closed when no validated focusSeedKey
+    // is configured` test). The schema-layer round-trip behavior (`focusSeedKey` accepted
+    // as `string | null` in `harnessTargetMetadata`) is already covered by the Claude
+    // round-trip test above; duplicating it for Codex with `focusSeedKey: 'space'` would
+    // have implied Space is the validated Codex configuration, which manual matrix
+    // validation 2026-05-03 falsified. See #10664 for empirical anchor.
 
     test('subscribe rejects invalid trigger', async () => {
         await RequestContextService.run({agentIdentityNodeId: '@alice'}, async () => {

--- a/test/playwright/unit/ai/scripts/bridge-daemon.spec.mjs
+++ b/test/playwright/unit/ai/scripts/bridge-daemon.spec.mjs
@@ -677,17 +677,19 @@ test.describe('Bridge Daemon', () => {
     test('Codex UI wake fails closed when no validated focusSeedKey is configured (#10664)', async () => {
         // Per #10664: PR #10663's hypothesis (Codex Space-seed mirrors Claude's #10661 fix)
         // was empirically falsified by manual matrix validation 2026-05-03. Space and Enter
-        // apply only a focus outline; printable keys can focus but mutate the existing
-        // prompt content — updated evidence shows the probe char APPENDS to the existing
-        // draft rather than fully replacing it, but appending into the prompt is still
-        // mutation that the subsequent Cmd+A/Cmd+X clear captures and the wake paste
-        // overwrites. No safe non-mutating composer-focus primitive exists for Codex
-        // Desktop today. The bridge-daemon MUST fail closed for Codex without an explicit
-        // `meta.focusSeedKey` opt-in — refusing to proceed past the destructive Cmd+A /
-        // Cmd+X clear sequence — until either operator-validated metadata (e.g. the
-        // probe-and-undo candidate `r → Cmd+Z → Cmd+A → Cmd+X` if @neo-gpt's 5-row state
-        // matrix proves it safe) or the Codex app-server adapter (#10517) supersedes
-        // UI-keystroke delivery.
+        // apply only a focus outline; printable keys can focus but mutate prompt content —
+        // updated evidence shows the probe char APPENDS to the existing draft rather than
+        // fully replacing it, but appending IS mutation that the subsequent Cmd+A/Cmd+X
+        // clear captures and the wake paste overwrites. No safe non-mutating composer-focus
+        // primitive exists for Codex Desktop today. The bridge-daemon MUST fail closed for
+        // Codex without an explicit `meta.focusSeedKey` opt-in (single-key non-mutating
+        // primitive only) — refusing to proceed past the destructive Cmd+A / Cmd+X clear
+        // sequence — until either operator opts in via verified single-key metadata, OR
+        // the Codex app-server adapter (#10517) supersedes UI-keystroke delivery. The
+        // probe-and-undo candidate `r → Cmd+Z → Cmd+A → Cmd+X` under @neo-gpt's 5-row
+        // matrix investigation is a multi-step SEQUENCE, NOT a single-key seed; if it
+        // proves safe it needs a distinct implementation path (sequence primitive or
+        // app-server route), NOT a `focusSeedKey: 'r'` opt-in.
         //
         // This test is a defense-in-depth check: even if @neo-gpt's WAKE_SUBSCRIPTION is
         // accidentally re-enabled (currently set to harnessTarget:'disabled' per #10664

--- a/test/playwright/unit/ai/scripts/bridge-daemon.spec.mjs
+++ b/test/playwright/unit/ai/scripts/bridge-daemon.spec.mjs
@@ -674,21 +674,27 @@ test.describe('Bridge Daemon', () => {
         expect(clearIndex).toBeGreaterThan(spaceIndex);
     });
 
-    test('Codex default focus seed generates Space after activate and before prompt clear (#10662)', async () => {
-        // Per #10662: extends the per-harness focusSeedKey: 'space' default to
-        // appName === 'Codex' so the collapsed-sidebar regression (Cmd+A selects
-        // thread history instead of composer content) is closed by seeding focus
-        // before the destructive clear. Codex has no tab-shortcut default
-        // (tabShortcut stays undefined / null), so the order is
-        // activate → Space → Cmd+A — distinct from the Claude order
-        // (activate → Cmd+3 → Space → Cmd+A).
+    test('Codex UI wake fails closed when no validated focusSeedKey is configured (#10664)', async () => {
+        // Per #10664: PR #10663's hypothesis (Codex Space-seed mirrors Claude's #10661 fix)
+        // was empirically falsified by manual matrix validation 2026-05-03. Space and Enter
+        // apply only a focus outline; printable keys can focus but destructively replace
+        // existing prompt text. No safe non-destructive composer-focus primitive exists for
+        // Codex Desktop today. The bridge-daemon MUST fail closed for Codex without an
+        // explicit `meta.focusSeedKey` opt-in — refusing to proceed past the destructive
+        // Cmd+A / Cmd+X clear sequence — until either operator-validated metadata or the
+        // Codex app-server adapter (#10517) supersedes UI-keystroke delivery.
+        //
+        // This test is a defense-in-depth check: even if @neo-gpt's WAKE_SUBSCRIPTION is
+        // accidentally re-enabled (currently set to harnessTarget:'disabled' per #10664
+        // operator mitigation), the bridge refuses to send any osascript keystroke for a
+        // Codex subscription that lacks an explicit composer-focus primitive.
         const subId = 'sub_' + crypto.randomUUID();
-        const agentId = '@test-agent-codex';
+        const agentId = '@test-agent-codex-fail-closed';
 
         db.prepare('INSERT OR REPLACE INTO Nodes (id, data) VALUES (?, ?)').run(agentId, JSON.stringify({
             id: agentId,
             label: 'AGENT',
-            properties: { name: 'Test Agent Codex' }
+            properties: { name: 'Test Agent Codex Fail-Closed' }
         }));
 
         db.prepare('INSERT OR REPLACE INTO Nodes (id, data) VALUES (?, ?)').run(subId, JSON.stringify({
@@ -703,6 +709,7 @@ test.describe('Bridge Daemon', () => {
                     adapter: 'osascript',
                     appName: 'Codex',
                     coalesceWindow: 1
+                    // No focusSeedKey configured — bridge MUST refuse delivery
                 }
             }
         }));
@@ -712,7 +719,7 @@ test.describe('Bridge Daemon', () => {
         const binDir = path.join(DAEMON_DIR, 'bin');
         fs.ensureDirSync(binDir);
         const mockOsascriptPath = path.join(binDir, 'osascript');
-        const mockOutPath = path.join(DAEMON_DIR, 'mock_codex_out.json');
+        const mockOutPath = path.join(DAEMON_DIR, 'mock_codex_failclosed_out.json');
         fs.writeFileSync(mockOsascriptPath, `#!/usr/bin/env node\nimport fs from 'fs';\nfs.writeFileSync('${mockOutPath}', JSON.stringify(process.argv.slice(2)));\n`);
         fs.chmodSync(mockOsascriptPath, 0o755);
 
@@ -721,14 +728,21 @@ test.describe('Bridge Daemon', () => {
             env: { ...process.env, PATH: `${path.resolve(binDir)}:${process.env.PATH}`, NEO_AI_DB_PATH: DB_PATH, NEO_AI_DAEMON_DIR: DAEMON_DIR }
         });
 
-        const deliveryPromise = new Promise((resolve, reject) => {
-            const timeout = setTimeout(() => reject(new Error('Daemon failed to deliver event within timeout')), 10000);
+        // Wait for the fail-closed warning log line (proxy for the deliver-or-refuse decision).
+        const refusalPromise = new Promise((resolve, reject) => {
+            const timeout = setTimeout(() => reject(new Error('Daemon did not emit Codex fail-closed warning within timeout')), 10000);
 
             daemonProcess.stdout.on('data', (data) => {
                 const out = data.toString();
-                if (out.includes('[Bridge Daemon] Delivered ' + subId)) {
+                if (out.includes(`Codex UI wake delivery refused for ${subId}`)) {
                     clearTimeout(timeout);
                     resolve();
+                }
+                // Negative case: if the daemon ever logs "Delivered" for this subId, the
+                // fail-closed guard didn't fire. Reject so the test fails loudly.
+                if (out.includes(`[Bridge Daemon] Delivered ${subId}`)) {
+                    clearTimeout(timeout);
+                    reject(new Error('Daemon delivered Codex wake despite missing focusSeedKey — fail-closed guard regressed'));
                 }
             });
             daemonProcess.stderr.on('data', data => console.error('[DAEMON STDERR]', data.toString()));
@@ -758,21 +772,11 @@ test.describe('Bridge Daemon', () => {
         }), msgId, agentId, 'SENT_TO');
         db.prepare('INSERT INTO GraphLog (entity_id, entity_type) VALUES (?, ?)').run(edgeId, 'edges');
 
-        await deliveryPromise;
+        await refusalPromise;
 
-        const args = JSON.parse(fs.readFileSync(mockOutPath, 'utf8'));
-        const activateIndex = args.findIndex(arg => arg.includes('tell application "Codex" to activate'));
-        const spaceIndex    = args.findIndex(arg => arg.includes('key code 49'));
-        const clearIndex    = args.findIndex(arg => arg.includes('keystroke "a" using command down'));
-
-        expect(activateIndex).toBeGreaterThan(-1);
-        expect(spaceIndex).toBeGreaterThan(activateIndex);
-        expect(clearIndex).toBeGreaterThan(spaceIndex);
-
-        // Negative drift guard: Codex must NOT emit a Cmd+3 tab-shortcut keystroke
-        // (Codex has no Code-tab equivalent). If a future change introduces one,
-        // this assertion fails loudly so the order is re-validated.
-        expect(args.join(' ')).not.toContain('keystroke "3" using command down');
+        // Confirm osascript was never called. The mock writes argv to mockOutPath only when
+        // invoked — so file-absent ⇒ refusal-fired-correctly. Defense-in-depth assertion.
+        expect(fs.existsSync(mockOutPath)).toBe(false);
     });
 
     test('getNodesData and getEdgesData deterministically chunk queries by SQLITE_IN_CLAUSE_BATCH_SIZE', () => {

--- a/test/playwright/unit/ai/scripts/bridge-daemon.spec.mjs
+++ b/test/playwright/unit/ai/scripts/bridge-daemon.spec.mjs
@@ -677,12 +677,17 @@ test.describe('Bridge Daemon', () => {
     test('Codex UI wake fails closed when no validated focusSeedKey is configured (#10664)', async () => {
         // Per #10664: PR #10663's hypothesis (Codex Space-seed mirrors Claude's #10661 fix)
         // was empirically falsified by manual matrix validation 2026-05-03. Space and Enter
-        // apply only a focus outline; printable keys can focus but destructively replace
-        // existing prompt text. No safe non-destructive composer-focus primitive exists for
-        // Codex Desktop today. The bridge-daemon MUST fail closed for Codex without an
-        // explicit `meta.focusSeedKey` opt-in — refusing to proceed past the destructive
-        // Cmd+A / Cmd+X clear sequence — until either operator-validated metadata or the
-        // Codex app-server adapter (#10517) supersedes UI-keystroke delivery.
+        // apply only a focus outline; printable keys can focus but mutate the existing
+        // prompt content — updated evidence shows the probe char APPENDS to the existing
+        // draft rather than fully replacing it, but appending into the prompt is still
+        // mutation that the subsequent Cmd+A/Cmd+X clear captures and the wake paste
+        // overwrites. No safe non-mutating composer-focus primitive exists for Codex
+        // Desktop today. The bridge-daemon MUST fail closed for Codex without an explicit
+        // `meta.focusSeedKey` opt-in — refusing to proceed past the destructive Cmd+A /
+        // Cmd+X clear sequence — until either operator-validated metadata (e.g. the
+        // probe-and-undo candidate `r → Cmd+Z → Cmd+A → Cmd+X` if @neo-gpt's 5-row state
+        // matrix proves it safe) or the Codex app-server adapter (#10517) supersedes
+        // UI-keystroke delivery.
         //
         // This test is a defense-in-depth check: even if @neo-gpt's WAKE_SUBSCRIPTION is
         // accidentally re-enabled (currently set to harnessTarget:'disabled' per #10664


### PR DESCRIPTION
Authored by Claude Opus 4.7 (1M context) (Claude Code). Session 9766f91c-51f8-44fe-ac34-d79f61a0e1bf.

Resolves #10664
Related: #10662 / PR #10663 (the disproved Codex Space-seed lane this PR neutralizes), #10661 (Claude Space seed — unchanged), #10644 (Antigravity Cmd+Shift+I — unchanged), #10517 (medium-term Codex app-server adapter — superseder), #10650 (Wake Substrate Incident Protocol — reactivation gate)

Closes the Codex matrix-row substrate by failing the bridge closed for `appName === 'Codex'` without an explicit operator-validated single-key `focusSeedKey`. Reverts PR #10663's Space-seed default after @tobiu's manual matrix validation falsified the hypothesis 2026-05-03 (broadcast `MESSAGE:71db3874-f74b-4cc8-8095-a7ea1a385b05`).

## Substantive disproval anchor

Per #10664 ticket body + GPT broadcasts + post-merge manual probe:

- Space + Enter on Codex Desktop apply only a *focus outline* — not actual composer focus
- Printable keys (e.g. `r`) can focus but **mutate prompt content**; latest manual `r` observation **appended** to the existing prompt rather than fully replacing it, but appending IS mutation that the subsequent `Cmd+A` / `Cmd+X` clear captures and the wake paste overwrites. A printable-key path remains unsafe until an undo sequence passes the 5-row state matrix (focused empty / focused draft / unfocused empty / unfocused draft / history-or-transcript focused).

No safe non-mutating composer-focus primitive exists for Codex Desktop today. Until either (a) operator explicitly configures `meta.focusSeedKey` via subscription metadata with a verified **single-key non-mutating** primitive, OR (b) the Codex app-server adapter (#10517) ships and supersedes the UI-keystroke path entirely, the bridge MUST refuse to proceed past the destructive `Cmd+A` / `Cmd+X` clear sequence for Codex.

**Scope distinction load-bearing for future operator opt-in:** the existing `meta.focusSeedKey` primitive is a SINGLE-KEY seed (the bridge emits one keystroke before the destructive clear). A future verified single-key non-mutating Codex primitive can opt in via `meta.focusSeedKey`. The `r → Cmd+Z → Cmd+A → Cmd+X` candidate under @neo-gpt's investigation is a MULTI-STEP probe-and-undo SEQUENCE — if it proves safe across all 5 matrix rows, it needs a distinct implementation path (e.g. a `meta.focusSeedSequence` primitive or routed via the Codex app-server adapter), NOT a `focusSeedKey: 'r'` opt-in (which would silently re-introduce the mutating-prompt failure mode this PR's fail-closed guard exists to prevent).

## Surface

- **`ai/scripts/bridge-daemon.mjs`**:
  - Reverted line 588 conditional from `(appName === 'Claude' || appName === 'Codex')` back to `appName === 'Claude'` only
  - Added a defense-in-depth fail-closed guard: `if (appName === 'Codex' && !focusSeedKey) { writeLog('WARN', ...); return; }`
  - Anchor & Echo block expanded with the full empirical disproval rationale, the printable-key-mutates-content failure mode (append, not replace), the single-key vs multi-step seed primitive scope distinction, and the #10517 medium-term supersession path
- **`test/playwright/unit/ai/scripts/bridge-daemon.spec.mjs`**:
  - Removed the disproved Codex ordering test that PR #10663 added (`Codex default focus seed generates Space after activate and before prompt clear`)
  - Added a fail-closed test (`Codex UI wake fails closed when no validated focusSeedKey is configured (#10664)`) — asserts the bridge logs the refusal warning AND never invokes osascript when Codex subscription lacks `focusSeedKey`
- **`test/playwright/unit/ai/mcp/server/memory-core/services/WakeSubscriptionService.spec.mjs`**:
  - Removed the Codex `focusSeedKey: 'space'` round-trip test that PR #10663 added — schema-layer round-trip already covered by the existing Claude test; the Codex variant implied Space was a valid Codex configuration
  - Replaced with an inline note citing the #10664 empirical anchor

## Defense-in-depth posture

Even with `@neo-gpt`'s `WAKE_SUB:f9a09dfd-37de-40e5-8857-6cd2c7373232` currently set to `harnessTarget: 'disabled'` (per #10664 immediate operator mitigation), this bridge-side guard prevents accidental subscription re-enable from silently re-introducing the disproved Space-seed path. Two layers stop unsafe Codex UI wake delivery: subscription-layer disable (operator-controlled, easy to flip), and bridge-layer fail-closed (code-controlled, defense-in-depth).

## Test Evidence

```
$ npx playwright test -c test/playwright/playwright.config.unit.mjs \
    test/playwright/unit/ai/scripts/bridge-daemon.spec.mjs \
    test/playwright/unit/ai/mcp/server/memory-core/services/WakeSubscriptionService.spec.mjs
Running 43 tests using 8 workers
  43 passed (8.7s)
```

The new fail-closed test mocks osascript via PATH-shadow + asserts:
- Bridge stdout contains `Codex UI wake delivery refused for ${subId}`
- Mock osascript output file does NOT exist (osascript was never invoked)
- Negative-shape: any `Delivered ${subId}` log line during the test rejects the promise (test fails loudly if fail-closed regresses)

Claude (`activate < tab < space < clear`) and Antigravity (`activate < clear` on Cmd+Shift+I path) tests continue to pass — no regression in the green matrix rows.

## Deltas from ticket

None substantive — the implementation matches #10664 AC verbatim:
- ✅ `bridge-daemon.mjs` no longer presents Codex Space seeding as a validated default
- ✅ Codex osascript UI delivery fails closed by default
- ✅ Claude's existing Space seed remains covered and unchanged
- ✅ Antigravity's Cmd+Shift+I route remains covered and unchanged
- ✅ Unit tests prove Codex no longer silently proceeds through the destructive clear path
- ✅ Issue links #10517 as the durable Codex app-server delivery lane

## Post-Merge Validation

- [ ] Heartbeat-restart preflight per #10650 protocol verifies bridge.log shows zero Codex `Delivered` lines if `@neo-gpt` subscription is mistakenly re-enabled (defense-in-depth fail-closed fires)
- [ ] Reactivation gate still tripped (Codex row remains red until #10517 lands or operator-validated focus primitive appears)
- [ ] #10662 closure decision: closed as "superseded by #10664" or kept open with a closure comment pointing at this PR — author's call (@neo-gpt as #10664 originator)
- [ ] @neo-gpt's bridge subscription stays `harnessTarget: 'disabled'` until verified safe Codex path exists

## Out of Scope

- **Implementing the Codex app-server adapter** (#10517) — the durable supersession path; explicitly excluded per #10664 boundary
- **Probe-and-undo multi-step sequence implementation** — under @neo-gpt's 5-row matrix investigation; if validated, needs separate implementation path (sequence primitive or app-server route), NOT a `focusSeedKey: 'r'` opt-in
- **Re-enabling @neo-gpt's bridge subscription** — operator decision, gated on #10517 progress or empirically validated focus primitive
- **Heartbeat reactivation, `WAKE_GATE_OVERRIDE=1`, fresh-session recovery** — all stay blocked per #10650 until matrix is fully green
- **Antigravity / Claude focus-seed changes** — both remain green per matrix; no change

## Coordination Anchors

- @neo-gpt's empirical disproval broadcast: `MESSAGE:71db3874-f74b-4cc8-8095-a7ea1a385b05`
- @neo-gpt's #10664 ticket-creation broadcast: `MESSAGE:d0e35506-7604-498e-b265-792d5a18a112`
- @neo-gpt's append-not-replace evidence update: `MESSAGE:121a44ad-fefa-4c1a-8bbb-c5b97a804124`
- @neo-gpt's probe-and-undo candidate broadcast: `MESSAGE:ded2ae32-08e8-42d0-8c2a-ffa4cb9bf4a9`
- Wake-substrate-incident-protocol gate-state stays `tripped` with the Codex Space/Enter failure reason (operator-verified)