### PR TITLE
feat(ai): codex focus-seed wake cleanup sequence and persistent metadata (#10666)

### DIFF
--- a/ai/graph/identityRoots.mjs
+++ b/ai/graph/identityRoots.mjs
@@ -52,8 +52,7 @@ export const IDENTITIES = [
                     // → exit 0; the prior `'Cursor'` placeholder failed with `Can't get
                     // application "Cursor". (-1728)` exit 1.
                     appName: 'Antigravity',
-                    tabShortcut: null,
-                    focusSeedKey: 'r'
+                    tabShortcut: null
                 }
             },
             createdAt: new Date().toISOString()

--- a/ai/graph/identityRoots.mjs
+++ b/ai/graph/identityRoots.mjs
@@ -25,7 +25,8 @@ export const IDENTITIES = [
                 harnessTarget: 'bridge-daemon',
                 harnessTargetMetadata: {
                     appName: 'Claude',
-                    tabShortcut: '3'
+                    tabShortcut: '3',
+                    focusSeedKey: 'space'
                 }
             },
             createdAt: new Date().toISOString()
@@ -51,7 +52,8 @@ export const IDENTITIES = [
                     // → exit 0; the prior `'Cursor'` placeholder failed with `Can't get
                     // application "Cursor". (-1728)` exit 1.
                     appName: 'Antigravity',
-                    tabShortcut: null
+                    tabShortcut: null,
+                    focusSeedKey: 'r'
                 }
             },
             createdAt: new Date().toISOString()
@@ -85,7 +87,8 @@ export const IDENTITIES = [
                 harnessTarget: 'bridge-daemon',
                 harnessTargetMetadata: {
                     appName: 'Codex',
-                    tabShortcut: null
+                    tabShortcut: null,
+                    focusSeedKey: 'r'
                 }
             },
             createdAt: new Date().toISOString()

--- a/ai/scripts/bridge-daemon.mjs
+++ b/ai/scripts/bridge-daemon.mjs
@@ -683,6 +683,9 @@ async function deliverDigest(subscription, digest) {
                     osascriptArgs.push('-e', `      keystroke "${focusSeedKey}"`);
                 }
                 osascriptArgs.push('-e', '      delay 0.2');
+                // Cleanup: Revert the seed character so it doesn't corrupt the user's draft
+                osascriptArgs.push('-e', '      keystroke "z" using command down');
+                osascriptArgs.push('-e', '      delay 0.2');
             }
 
             osascriptArgs.push(

--- a/ai/scripts/bridge-daemon.mjs
+++ b/ai/scripts/bridge-daemon.mjs
@@ -683,7 +683,7 @@ async function deliverDigest(subscription, digest) {
                     osascriptArgs.push('-e', `      keystroke "${focusSeedKey}"`);
                 }
                 osascriptArgs.push('-e', '      delay 0.2');
-                
+
                 // Cleanup: Revert the mutating seed character so it doesn't corrupt the user's draft
                 // Scoped specifically to Codex per #10667 cross-family review feedback to prevent
                 // non-mutating seeds (like Claude's space) from inheriting an unvalidated undo step.

--- a/ai/scripts/bridge-daemon.mjs
+++ b/ai/scripts/bridge-daemon.mjs
@@ -683,9 +683,14 @@ async function deliverDigest(subscription, digest) {
                     osascriptArgs.push('-e', `      keystroke "${focusSeedKey}"`);
                 }
                 osascriptArgs.push('-e', '      delay 0.2');
-                // Cleanup: Revert the seed character so it doesn't corrupt the user's draft
-                osascriptArgs.push('-e', '      keystroke "z" using command down');
-                osascriptArgs.push('-e', '      delay 0.2');
+                
+                // Cleanup: Revert the mutating seed character so it doesn't corrupt the user's draft
+                // Scoped specifically to Codex per #10667 cross-family review feedback to prevent
+                // non-mutating seeds (like Claude's space) from inheriting an unvalidated undo step.
+                if (appName === 'Codex' && focusSeedKey === 'r') {
+                    osascriptArgs.push('-e', '      keystroke "z" using command down');
+                    osascriptArgs.push('-e', '      delay 0.2');
+                }
             }
 
             osascriptArgs.push(

--- a/test/playwright/unit/ai/mcp/server/memory-core/services/WakeSubscriptionService.spec.mjs
+++ b/test/playwright/unit/ai/mcp/server/memory-core/services/WakeSubscriptionService.spec.mjs
@@ -462,17 +462,19 @@ test.describe('Neo.ai.mcp.server.memory-core.services.WakeSubscriptionService', 
             const updateRes = await WakeSubscriptionService.update({
                 subscriptionId,
                 filters              : {priority: 'high', taggedConcepts: ['critical']},
-                harnessTargetMetadata: {coalesceWindow: 60}
+                harnessTargetMetadata: {coalesceWindow: 60, focusSeedKey: 'r'}
             });
 
             expect(updateRes.currentState.filters.priority).toBe('high');
             expect(updateRes.currentState.filters.taggedConcepts).toEqual(['critical']);
             expect(updateRes.currentState.harnessTargetMetadata.coalesceWindow).toBe(60);
+            expect(updateRes.currentState.harnessTargetMetadata.focusSeedKey).toBe('r');
             expect(updateRes.currentState.agentIdentity).toBe('@alice');
 
             const node = GraphService.db.nodes.get(subscriptionId);
             expect(node.properties.filters.priority).toBe('high');
             expect(node.properties.harnessTargetMetadata.coalesceWindow).toBe(60);
+            expect(node.properties.harnessTargetMetadata.focusSeedKey).toBe('r');
         });
     });
 

--- a/test/playwright/unit/ai/scripts/bridge-daemon.spec.mjs
+++ b/test/playwright/unit/ai/scripts/bridge-daemon.spec.mjs
@@ -786,6 +786,102 @@ test.describe('Bridge Daemon', () => {
         expect(fs.existsSync(mockOutPath)).toBe(false);
     });
 
+    test('Codex wake delivery emits specific sequence r -> Cmd+Z -> Cmd+A/X -> paste (#10667)', async () => {
+        const subId = 'sub_' + crypto.randomUUID();
+        const agentId = '@test-agent-codex-cleanup';
+
+        db.prepare('INSERT OR REPLACE INTO Nodes (id, data) VALUES (?, ?)').run(agentId, JSON.stringify({
+            id: agentId,
+            label: 'AGENT',
+            properties: { name: 'Test Agent Codex Cleanup' }
+        }));
+
+        db.prepare('INSERT OR REPLACE INTO Nodes (id, data) VALUES (?, ?)').run(subId, JSON.stringify({
+            id: subId,
+            label: 'WAKE_SUBSCRIPTION',
+            properties: {
+                agentIdentity: agentId,
+                harnessTarget: 'bridge-daemon',
+                status: 'active',
+                trigger: 'SENT_TO_ME',
+                harnessTargetMetadata: {
+                    adapter: 'osascript',
+                    appName: 'Codex',
+                    coalesceWindow: 1,
+                    focusSeedKey: 'r'
+                }
+            }
+        }));
+
+        db.prepare('INSERT INTO GraphLog (entity_id, entity_type) VALUES (?, ?)').run(subId, 'nodes');
+
+        const binDir = path.join(DAEMON_DIR, 'bin');
+        fs.ensureDirSync(binDir);
+        const mockOsascriptPath = path.join(binDir, 'osascript');
+        const mockOutPath = path.join(DAEMON_DIR, 'mock_codex_cleanup_out.json');
+        fs.writeFileSync(mockOsascriptPath, `#!/usr/bin/env node\nimport fs from 'fs';\nfs.writeFileSync('${mockOutPath}', JSON.stringify(process.argv.slice(2)));\n`);
+        fs.chmodSync(mockOsascriptPath, 0o755);
+
+        daemonProcess = spawn('node', ['ai/scripts/bridge-daemon.mjs'], {
+            stdio: 'pipe',
+            env: { ...process.env, PATH: `${path.resolve(binDir)}:${process.env.PATH}`, NEO_AI_DB_PATH: DB_PATH, NEO_AI_DAEMON_DIR: DAEMON_DIR }
+        });
+
+        const deliveryPromise = new Promise((resolve, reject) => {
+            const timeout = setTimeout(() => reject(new Error('Daemon did not deliver Codex wake within timeout')), 10000);
+
+            daemonProcess.stdout.on('data', (data) => {
+                const out = data.toString();
+                if (out.includes(`Delivered ${subId}`)) {
+                    clearTimeout(timeout);
+                    resolve();
+                }
+            });
+            daemonProcess.stderr.on('data', data => console.error('[DAEMON STDERR]', data.toString()));
+            daemonProcess.on('error', reject);
+        });
+
+        await new Promise(resolve => setTimeout(resolve, 1000));
+
+        const msgId = 'msg_' + crypto.randomUUID();
+        db.prepare('INSERT INTO Nodes (id, data) VALUES (?, ?)').run(msgId, JSON.stringify({
+            id: msgId,
+            label: 'MESSAGE',
+            properties: {
+                from: '@sender',
+                subject: 'Test Codex Cleanup',
+                priority: 'normal'
+            }
+        }));
+        db.prepare('INSERT INTO GraphLog (entity_id, entity_type) VALUES (?, ?)').run(msgId, 'nodes');
+
+        const edgeId = 'edge_' + crypto.randomUUID();
+        db.prepare('INSERT INTO Edges (id, data, source, target, type) VALUES (?, ?, ?, ?, ?)').run(edgeId, JSON.stringify({
+            id: edgeId,
+            source: msgId,
+            target: agentId,
+            type: 'SENT_TO'
+        }), msgId, agentId, 'SENT_TO');
+        db.prepare('INSERT INTO GraphLog (entity_id, entity_type) VALUES (?, ?)').run(edgeId, 'edges');
+
+        await deliveryPromise;
+
+        const rawArgs = JSON.parse(fs.readFileSync(mockOutPath, 'utf-8'));
+        const scriptContent = rawArgs.filter((_, i) => rawArgs[i - 1] === '-e').join('\n');
+
+        const rIndex = scriptContent.indexOf('keystroke "r"');
+        const zIndex = scriptContent.indexOf('keystroke "z" using command down');
+        const aIndex = scriptContent.indexOf('keystroke "a" using command down');
+        const xIndex = scriptContent.indexOf('keystroke "x" using command down');
+        const pasteIndex = scriptContent.indexOf('keystroke "v" using command down');
+
+        expect(rIndex).toBeGreaterThan(-1);
+        expect(zIndex).toBeGreaterThan(rIndex);
+        expect(aIndex).toBeGreaterThan(zIndex);
+        expect(xIndex).toBeGreaterThan(aIndex);
+        expect(pasteIndex).toBeGreaterThan(xIndex);
+    });
+
     test('getNodesData and getEdgesData deterministically chunk queries by SQLITE_IN_CLAUSE_BATCH_SIZE', () => {
         let prepareCount = 0;
         let paramsLength = [];


### PR DESCRIPTION
Resolves #10666

Implemented the `Cmd+Z` cleanup sequence in `bridge-daemon.mjs` to ensure residual `r` seeds are removed after acquiring focus, scoped specifically to the Codex application to prevent unvalidated undo steps on non-mutating seeds (like Claude's space). Removed the unvalidated `r` seed from the Antigravity identity template. Validated that `focusSeedKey` metadata correctly persists and surfaces through `WakeSubscriptionService` and that the bridge daemon correctly executes the `r -> Cmd+Z -> Cmd+A/Cmd+X -> paste` sequence for Codex with comprehensive unit test coverage.

## Deltas from ticket (if any)
None.

## Test Evidence
- Unit tests (`npm run test-unit -- test/playwright/unit/ai/mcp/server/memory-core/services/WakeSubscriptionService.spec.mjs`) pass with full coverage for `focusSeedKey` persistence.
- Unit tests (`npm run test-unit -- test/playwright/unit/ai/scripts/bridge-daemon.spec.mjs`) pass with full coverage for the Codex `Cmd+Z` cleanup sequence ordering and the fail-closed UI guard.

## Post-Merge Validation
- [ ] Verify `WAKE_GATE` heartbeat reactivation.

Authored by Gemini 3.1 Pro (Antigravity). Session 780a1983-370f-4206-9cb2-92b23b09c0a8.
