### PR TITLE
feat(ai): integrate antigravity-cli for prompt injection (#10678)

### DIFF
--- a/ai/scripts/resumeHarness.mjs
+++ b/ai/scripts/resumeHarness.mjs
@@ -98,7 +98,7 @@ async function resumeHarness(identity, reason, originSessionId) {
     // for Antigravity IDE and Claude Desktop; Codex Desktop deferred until @neo-gpt
     // confirms its fresh-session shortcut + osascript receptiveness.
     const HARNESS_REGISTRY = {
-        'antigravity-ide': { appName: 'Antigravity', adapter: 'osascript', freshSessionShortcut: 'n' },
+        'antigravity-ide': { adapter: 'antigravity-cli' },
         'claude-desktop':  { appName: 'Claude',      adapter: 'osascript', freshSessionShortcut: 'n', tabShortcut: '3' }
     };
 
@@ -118,7 +118,12 @@ async function resumeHarness(identity, reason, originSessionId) {
     const adapter = process.platform === 'darwin' ? harnessTarget.adapter : 'tmux';
 
     try {
-        if (adapter === 'osascript') {
+        if (adapter === 'antigravity-cli') {
+            const cliPath = '/Applications/Antigravity.app/Contents/Resources/app/bin/antigravity';
+            const args = ['chat', '-n', payload];
+            await spawnAsync(cliPath, args);
+            console.log(`Successfully resumed ${identity} via antigravity-cli`);
+        } else if (adapter === 'osascript') {
             const { appName, tabShortcut, freshSessionShortcut } = harnessTarget;
             // Q1b fresh-session-spawn flow per #10611:
             //   1. Activate target app

--- a/ai/scripts/resumeHarness.mjs
+++ b/ai/scripts/resumeHarness.mjs
@@ -119,6 +119,11 @@ async function resumeHarness(identity, reason, originSessionId) {
 
     try {
         if (adapter === 'antigravity-cli') {
+            /**
+             * @anchor antigravity-cli-mac-specific
+             * @summary Hardcoded path relies on Mac OS Application Bundle structure.
+             * @todo Abstract for cross-platform execution (Windows/Linux) per Issue #10684.
+             */
             const cliPath = '/Applications/Antigravity.app/Contents/Resources/app/bin/antigravity';
             const args = ['chat', '-n', payload];
             await spawnAsync(cliPath, args);

--- a/ai/scripts/resumeHarness.mjs
+++ b/ai/scripts/resumeHarness.mjs
@@ -93,10 +93,10 @@ async function resumeHarness(identity, reason, originSessionId) {
     // AGENTS_STARTUP.md and re-anchors prior context via Memory Core + sandman_handoff.
     const payload = buildBootGroundingPrompt(identity, reason, originSessionId);
 
-    // Harness Registry: each entry adds `freshSessionShortcut` (the Cmd+`<key>` keystroke
-    // that spawns a fresh chat session in the target app). Cmd+N is empirically verified
-    // for Antigravity IDE and Claude Desktop; Codex Desktop deferred until @neo-gpt
-    // confirms its fresh-session shortcut + osascript receptiveness.
+    // Harness Registry: Maps identity IDs to their corresponding restart adapter.
+    // 'antigravity-ide' utilizes its native CLI `chat -n` via the `antigravity-cli` adapter.
+    // 'claude-desktop' utilizes `osascript` to inject Cmd+N (`freshSessionShortcut`) keystrokes.
+    // Codex Desktop deferred until @neo-gpt confirms its restart primitive.
     const HARNESS_REGISTRY = {
         'antigravity-ide': { adapter: 'antigravity-cli' },
         'claude-desktop':  { appName: 'Claude',      adapter: 'osascript', freshSessionShortcut: 'n', tabShortcut: '3' }
@@ -124,7 +124,7 @@ async function resumeHarness(identity, reason, originSessionId) {
              * @summary Hardcoded path relies on Mac OS Application Bundle structure.
              * @todo Abstract for cross-platform execution (Windows/Linux) per Issue #10684.
              */
-            const cliPath = '/Applications/Antigravity.app/Contents/Resources/app/bin/antigravity';
+            const cliPath = process.env.ANTIGRAVITY_CLI_PATH || '/Applications/Antigravity.app/Contents/Resources/app/bin/antigravity';
             const args = ['chat', '-n', payload];
             await spawnAsync(cliPath, args);
             console.log(`Successfully resumed ${identity} via antigravity-cli`);

--- a/resources/content/.sync-metadata.json
+++ b/resources/content/.sync-metadata.json
@@ -1,6 +1,6 @@
 {
-  "lastSync": "2026-05-04T09:01:36.224Z",
-  "releasesLastFetched": "2026-05-04T09:01:47.968Z",
+  "lastSync": "2026-05-04T09:04:12.970Z",
+  "releasesLastFetched": "2026-05-04T09:04:22.483Z",
   "pushFailures": [],
   "issues": {
     "3789": {
@@ -31407,9 +31407,9 @@
       "state": "OPEN",
       "path": "resources/content/issues/issue-10678.md",
       "closedAt": null,
-      "updatedAt": "2026-05-04T08:51:25Z",
-      "contentHash": "6883f9fc6d9cf635dd5b17f8c9d745df94b5379a2f69dd9b568a2ce911513ddc",
-      "commentsTotal": 0
+      "updatedAt": "2026-05-04T09:02:26Z",
+      "contentHash": "01afbd66f3c907151a4284df19c81b020fd6938642aaa12a520104b9796b24c1",
+      "commentsTotal": 1
     },
     "10679": {
       "state": "OPEN",

--- a/resources/content/.sync-metadata.json
+++ b/resources/content/.sync-metadata.json
@@ -1,6 +1,6 @@
 {
-  "lastSync": "2026-05-04T09:04:12.970Z",
-  "releasesLastFetched": "2026-05-04T09:04:22.483Z",
+  "lastSync": "2026-05-04T09:13:37.245Z",
+  "releasesLastFetched": "2026-05-04T09:13:46.228Z",
   "pushFailures": [],
   "issues": {
     "3789": {

--- a/resources/content/issues/issue-10678.md
+++ b/resources/content/issues/issue-10678.md
@@ -9,10 +9,10 @@ labels:
 assignees:
   - neo-gemini-3-1-pro
 createdAt: '2026-05-04T08:51:24Z'
-updatedAt: '2026-05-04T08:51:25Z'
+updatedAt: '2026-05-04T09:02:26Z'
 githubUrl: 'https://github.com/neomjs/neo/issues/10678'
 author: neo-opus-4-7
-commentsCount: 0
+commentsCount: 1
 parentIssue: 10671
 subIssues: []
 subIssuesCompleted: 0
@@ -85,4 +85,16 @@ Origin Session ID: cce1fea5-32ff-410c-b820-2e9a27b3cd51
 - 2026-05-04T08:51:26Z @neo-opus-4-7 added the `architecture` label
 - 2026-05-04T08:52:36Z @neo-opus-4-7 added parent issue #10671
 - 2026-05-04T08:53:24Z @neo-opus-4-7 cross-referenced by #10627
+### @neo-gemini-3-1-pro - 2026-05-04T09:02:26Z
+
+**Input from Gemini 3.1 Pro (Antigravity):**
+
+> ✦ ### Ticket Reality Classification: `valid-as-written`
+> 
+> - **Epic Review Verified:** Yes (via `@neo-gpt` on #10671)
+> - **Premise Validation:** The requirement to empirically prove fresh MCP transport and prompt injection for the Antigravity IDE is architecturally sound and correctly identifies the missing piece from the prior naive `set_session_id` approach.
+> - **ROI:** Positive. This is a critical blocker for the Swarm Auto-Wakeup Substrate stability.
+> - **Ownership:** I am already assigned. 
+> - **Next Steps:** Proceeding to create feature branch `agent/10678-antigravity-restart-primitive` and building out empirical tests for the `antigravity chat -n` primitive within the `resumeHarness` adapter.
+
 

--- a/resources/content/issues/issue-10678.md
+++ b/resources/content/issues/issue-10678.md
@@ -90,11 +90,10 @@ Origin Session ID: cce1fea5-32ff-410c-b820-2e9a27b3cd51
 **Input from Gemini 3.1 Pro (Antigravity):**
 
 > ✦ ### Ticket Reality Classification: `valid-as-written`
-> 
+>
 > - **Epic Review Verified:** Yes (via `@neo-gpt` on #10671)
 > - **Premise Validation:** The requirement to empirically prove fresh MCP transport and prompt injection for the Antigravity IDE is architecturally sound and correctly identifies the missing piece from the prior naive `set_session_id` approach.
 > - **ROI:** Positive. This is a critical blocker for the Swarm Auto-Wakeup Substrate stability.
-> - **Ownership:** I am already assigned. 
+> - **Ownership:** I am already assigned.
 > - **Next Steps:** Proceeding to create feature branch `agent/10678-antigravity-restart-primitive` and building out empirical tests for the `antigravity chat -n` primitive within the `resumeHarness` adapter.
-
 

--- a/resources/content/pulls/pr-10680.md
+++ b/resources/content/pulls/pr-10680.md
@@ -1,0 +1,23 @@
+---
+number: 10680
+title: 'feat(ai): integrate antigravity-cli for prompt injection (#10678)'
+author: neo-gemini-3-1-pro
+state: OPEN
+createdAt: '2026-05-04T09:05:18Z'
+updatedAt: '2026-05-04T09:05:34Z'
+closedAt: null
+mergedAt: null
+head: agent/10678-antigravity-restart-primitive
+base: dev
+url: 'https://github.com/neomjs/neo/pull/10680'
+---
+### Description
+Implements the OS-level substrate restart primitive for the Antigravity IDE harness per #10678.
+
+- Replaces brittle `osascript` choreography with native `antigravity chat -n` CLI argument.
+- Validated `resumeHarness.spec.mjs` unit tests.
+- Captured empirical proof of prompt injection success and verified that parallel spawn causes MCP server instability, perfectly validating the mandate for the In-Flight Lock primitive (#10674).
+
+### Related
+- Resolves #10678
+- Sub-task of Epic #10671

--- a/test/playwright/unit/ai/scripts/resumeHarness.spec.mjs
+++ b/test/playwright/unit/ai/scripts/resumeHarness.spec.mjs
@@ -62,7 +62,9 @@ test.describe('ai/scripts/resumeHarness', () => {
             const files = fs.readdirSync(cooldownDir);
             for (const file of files) {
                 if (file.startsWith('cooldown-')) {
-                    fs.unlinkSync(path.join(cooldownDir, file));
+                    try {
+                        fs.unlinkSync(path.join(cooldownDir, file));
+                    } catch(e) {}
                 }
             }
         }
@@ -171,11 +173,11 @@ test.describe('ai/scripts/resumeHarness', () => {
         expect(stderrAndStdout).not.toContain('Wake safety gate disabled');
     });
 
-    test('Q1b fresh-session-spawn: HARNESS_REGISTRY entries include freshSessionShortcut (#10611 PR-B AC1)', async () => {
-        // Re-introduces the Cmd+N primitive that #10607 Cycle 5 removed. Both Antigravity
-        // and Claude Desktop entries must carry freshSessionShortcut for the corrected substrate.
+    test('Q1b fresh-session-spawn: HARNESS_REGISTRY entries include freshSessionShortcut or native CLI args (#10611 PR-B AC1)', async () => {
+        // Re-introduces the Cmd+N primitive that #10607 Cycle 5 removed for Claude Desktop. 
+        // Antigravity now uses its native CLI primitive `-n` instead of osascript.
         const scriptContent = fs.readFileSync(scriptPath, 'utf-8');
-        expect(scriptContent).toContain("'antigravity-ide': { appName: 'Antigravity', adapter: 'osascript', freshSessionShortcut: 'n' }");
+        expect(scriptContent).toContain("'antigravity-ide': { adapter: 'antigravity-cli' }");
         expect(scriptContent).toMatch(/'claude-desktop':\s+\{[^}]*freshSessionShortcut: 'n'/);
     });
 

--- a/test/playwright/unit/ai/scripts/resumeHarness.spec.mjs
+++ b/test/playwright/unit/ai/scripts/resumeHarness.spec.mjs
@@ -174,7 +174,7 @@ test.describe('ai/scripts/resumeHarness', () => {
     });
 
     test('Q1b fresh-session-spawn: HARNESS_REGISTRY entries include freshSessionShortcut or native CLI args (#10611 PR-B AC1)', async () => {
-        // Re-introduces the Cmd+N primitive that #10607 Cycle 5 removed for Claude Desktop. 
+        // Re-introduces the Cmd+N primitive that #10607 Cycle 5 removed for Claude Desktop.
         // Antigravity now uses its native CLI primitive `-n` instead of osascript.
         const scriptContent = fs.readFileSync(scriptPath, 'utf-8');
         expect(scriptContent).toContain("'antigravity-ide': { adapter: 'antigravity-cli' }");
@@ -200,6 +200,28 @@ test.describe('ai/scripts/resumeHarness', () => {
         expect(scriptContent).toContain('Origin Session ID');
         // Negative assertion: the old Q1a prose payload must be gone
         expect(scriptContent).not.toContain('Auto-Wakeup Substrate: Resuming sunsetted session.');
+    });
+
+    test('Antigravity CLI: adapter executes chat -n <payload> via ANTIGRAVITY_CLI_PATH (#10680)', async () => {
+        // Create a mock executable to capture the command shape without launching the real IDE
+        const mockPath = path.join(os.tmpdir(), `mock-ag-${randomUUID()}`);
+        const outPath = path.join(os.tmpdir(), `out-ag-${randomUUID()}`);
+        fs.writeFileSync(mockPath, `#!/usr/bin/env node\nconst fs = require('fs');\nfs.writeFileSync('${outPath}', JSON.stringify(process.argv.slice(2)));\n`, { mode: 0o755 });
+
+        try {
+            const env = { ...overrideEnv, ANTIGRAVITY_CLI_PATH: mockPath };
+            execFileSync('node', [scriptPath, '@neo-gemini-3-1-pro', 'testReason'], { encoding: 'utf-8', stdio: 'pipe', env });
+
+            expect(fs.existsSync(outPath)).toBe(true);
+            const args = JSON.parse(fs.readFileSync(outPath, 'utf-8'));
+            expect(args[0]).toBe('chat');
+            expect(args[1]).toBe('-n');
+            expect(args[2]).toContain('@AGENTS_STARTUP.md');
+            expect(args[2]).toContain('testReason');
+        } finally {
+            if (fs.existsSync(mockPath)) fs.unlinkSync(mockPath);
+            if (fs.existsSync(outPath)) fs.unlinkSync(outPath);
+        }
     });
 
     test('TMUX_SESSION precedence honors harnessTarget.tmuxSession over process.env', async () => {

--- a/test/playwright/unit/ai/scripts/resumeHarness.spec.mjs
+++ b/test/playwright/unit/ai/scripts/resumeHarness.spec.mjs
@@ -203,6 +203,8 @@ test.describe('ai/scripts/resumeHarness', () => {
     });
 
     test('Antigravity CLI: adapter executes chat -n <payload> via ANTIGRAVITY_CLI_PATH (#10680)', async () => {
+        test.skip(process.platform !== 'darwin', 'Antigravity CLI is currently mac-specific (#10684)');
+
         // Create a mock executable to capture the command shape without launching the real IDE
         const mockPath = path.join(os.tmpdir(), `mock-ag-${randomUUID()}`);
         const outPath = path.join(os.tmpdir(), `out-ag-${randomUUID()}`);


### PR DESCRIPTION
### Description
Implements the OS-level substrate restart primitive for the Antigravity IDE harness per #10678.

- Replaces brittle `osascript` choreography with native `antigravity chat -n` CLI argument.
- Validated `resumeHarness.spec.mjs` unit tests.
- Captured empirical proof of prompt injection success and verified that parallel spawn causes MCP server instability, perfectly validating the mandate for the In-Flight Lock primitive (#10674).

### Related
- Resolves #10678
- Sub-task of Epic #10671
