### PR TITLE
fix(ai): default-skip live osascript runtime tests (#10681)

### DIFF
--- a/test/playwright/unit/ai/scripts/resumeHarness.spec.mjs
+++ b/test/playwright/unit/ai/scripts/resumeHarness.spec.mjs
@@ -36,6 +36,19 @@ test.describe('ai/scripts/resumeHarness', () => {
      * `gateOnlyEnv()` — for tests targeting the gate behavior itself; isolates
      * the gate path but leaves `WAKE_GATE_OVERRIDE` unset so the default-tripped
      * / explicitly-enabled paths can be exercised.
+     *
+     * Live-host opt-in (#10681): tests that fire the REAL `osascript` paste path
+     * (vs. tests that mock or skip osascript) MUST be gated behind
+     * `RUN_LIVE_OSASCRIPT=1` env-var opt-in via `test.skip(!process.env.RUN_LIVE_OSASCRIPT, ...)`
+     * as the FIRST statement of the test body. Default behavior (env var unset)
+     * is `[skipped]` — preventing the host-environment side effect of pasting
+     * the boot-grounding prompt into a live Claude Desktop session and spawning
+     * a real Claude Code session. Empirical anchor: 2026-05-04 09:03Z runaway
+     * spawn caused by running this spec on a host with Claude Desktop +
+     * accessibility permission granted, prior to this discipline. The reference
+     * architecture for safe live-substrate testing is `bridge-daemon.spec.mjs`,
+     * which uses either the `test` adapter (test stream delivery) or a mock
+     * `osascript` binary on PATH that captures argv without executing AppleScript.
      */
     let gatePath, overrideEnv;
     const gateOnlyEnv = () => ({...process.env, WAKE_GATE_FILE_PATH: gatePath});
@@ -69,7 +82,22 @@ test.describe('ai/scripts/resumeHarness', () => {
         }
     });
 
-    test('Opus identity routes to osascript with claude-desktop, freshSessionShortcut n, and tabShortcut 3', async () => {
+    test('Opus identity routes to claude-desktop adapter via HARNESS_REGISTRY (config check)', async () => {
+        // Static script-content check: HARNESS_REGISTRY shape post-#10611 PR-B
+        // includes the freshSessionShortcut primitive (Cmd+N) re-introduced for Q1b fresh-session-spawn.
+        // Always-on coverage — no host side effects. Live runtime exec sibling
+        // ('Opus identity osascript runtime dispatch') is gated behind RUN_LIVE_OSASCRIPT=1.
+        const scriptContent = fs.readFileSync(scriptPath, 'utf-8');
+        expect(scriptContent).toContain("'claude-desktop':  { appName: 'Claude',      adapter: 'osascript', freshSessionShortcut: 'n', tabShortcut: '3' }");
+        expect(scriptContent).toContain("'@neo-opus-4-7': 'claude-desktop'");
+    });
+
+    test('Opus identity osascript runtime dispatch (live host — RUN_LIVE_OSASCRIPT=1 required, #10681)', async () => {
+        // Live-host integration: invokes real `osascript` which on hosts with Claude Desktop
+        // + System Events accessibility granted will paste the boot-grounding prompt into the
+        // live app and spawn a real Claude Code session. Skipped by default to prevent the
+        // 2026-05-04 09:03Z runaway-spawn pattern (see #10681 forensic record).
+        test.skip(!process.env.RUN_LIVE_OSASCRIPT, 'Live osascript test — paste-spawns real Claude sessions on hosts with accessibility granted; set RUN_LIVE_OSASCRIPT=1 to run (#10681)');
         try {
             execFileSync('node', [scriptPath, '@neo-opus-4-7', 'test'], {encoding: 'utf-8', stdio: 'pipe', env: overrideEnv});
         } catch (e) {
@@ -77,12 +105,6 @@ test.describe('ai/scripts/resumeHarness', () => {
             const output = e.stderr + e.stdout;
             expect(output).toContain('Failed to resume @neo-opus-4-7 via osascript:');
         }
-
-        // Static script-content check: HARNESS_REGISTRY shape post-#10611 PR-B
-        // includes the freshSessionShortcut primitive (Cmd+N) re-introduced for Q1b fresh-session-spawn.
-        const scriptContent = fs.readFileSync(scriptPath, 'utf-8');
-        expect(scriptContent).toContain("'claude-desktop':  { appName: 'Claude',      adapter: 'osascript', freshSessionShortcut: 'n', tabShortcut: '3' }");
-        expect(scriptContent).toContain("'@neo-opus-4-7': 'claude-desktop'");
     });
 
     test('Wake safety gate tripped + no override → resumeHarness skips with explicit stderr (#10648)', async () => {
@@ -101,12 +123,14 @@ test.describe('ai/scripts/resumeHarness', () => {
         expect(result.stderr).toContain('WAKE_GATE_OVERRIDE=1');
     });
 
-    test('Wake safety gate enabled → resumeHarness proceeds past the gate (#10648)', async () => {
-        // Write enabled gate state on the per-test gate path, then invoke resumeHarness
-        // with a known identity. The gate must NOT short-circuit; resumeHarness proceeds
-        // to harness lookup and osascript dispatch (which may itself fail in test env —
-        // covered by the existing 'Opus identity routes to osascript' test; here we
-        // only verify the gate doesn't pre-empt the path).
+    test('Wake safety gate enabled → resumeHarness proceeds past the gate (live host — RUN_LIVE_OSASCRIPT=1 required, #10648, #10681)', async () => {
+        // Live-host integration: writes enabled gate state, invokes resumeHarness with a
+        // known identity, and confirms the gate doesn't short-circuit. Because the gate
+        // is enabled and the identity is known, resumeHarness reaches osascript dispatch
+        // — which on hosts with Claude Desktop + accessibility granted will paste the
+        // boot-grounding prompt into the live app. Skipped by default to prevent the
+        // 2026-05-04 09:03Z runaway-spawn pattern (see #10681 forensic record).
+        test.skip(!process.env.RUN_LIVE_OSASCRIPT, 'Live osascript test — paste-spawns real Claude sessions when gate is enabled; set RUN_LIVE_OSASCRIPT=1 to run (#10681)');
         fs.mkdirSync(path.dirname(gatePath), {recursive: true});
         fs.writeFileSync(gatePath, JSON.stringify({state: 'enabled', reason: '', trippedAt: null, trippedBy: null}), 'utf-8');
 

--- a/test/playwright/unit/ai/scripts/resumeHarness.spec.mjs
+++ b/test/playwright/unit/ai/scripts/resumeHarness.spec.mjs
@@ -123,6 +123,32 @@ test.describe('ai/scripts/resumeHarness', () => {
         expect(result.stderr).toContain('WAKE_GATE_OVERRIDE=1');
     });
 
+    test('Wake safety gate enabled + unknown identity → gate passes; identity check exits without osascript (#10648, #10681)', async () => {
+        // Always-on coverage of gate-pass logic, addressing @neo-gemini-3-1-pro's PR #10682
+        // cycle 1 challenge re: the coverage gap left by skipping the live-host gate-pass test.
+        // resumeHarness.mjs sequences gate check (lines 67-71) BEFORE identity lookup (lines
+        // 110-116). Pairing an enabled gate with an unknown identity proves the gate let
+        // execution through (no skip message) and the script then exits cleanly via the
+        // unknown-identity branch — neither path reaches the osascript dispatch, so no
+        // host-environment side effects.
+        fs.mkdirSync(path.dirname(gatePath), {recursive: true});
+        fs.writeFileSync(gatePath, JSON.stringify({state: 'enabled', reason: '', trippedAt: null, trippedBy: null}), 'utf-8');
+
+        const result = spawnSync('node', [scriptPath, '@neo-unknown-coverage', 'test'], {
+            encoding: 'utf-8',
+            env     : gateOnlyEnv()
+        });
+        const stderrAndStdout = (result.stderr ?? '') + (result.stdout ?? '');
+
+        // Positive assertion: gate-pass let execution through to the identity check, which
+        // exits with the expected unknown-identity error (resumeHarness.mjs:114-116).
+        expect(result.status).toBe(1);
+        expect(stderrAndStdout).toContain('Unknown harness target for identity: @neo-unknown-coverage');
+        // Negative assertion: gate didn't short-circuit the call.
+        expect(stderrAndStdout).not.toContain('Wake safety gate tripped');
+        expect(stderrAndStdout).not.toContain('Wake safety gate disabled');
+    });
+
     test('Wake safety gate enabled → resumeHarness proceeds past the gate (live host — RUN_LIVE_OSASCRIPT=1 required, #10648, #10681)', async () => {
         // Live-host integration: writes enabled gate state, invokes resumeHarness with a
         // known identity, and confirms the gate doesn't short-circuit. Because the gate


### PR DESCRIPTION
Resolves #10681

Authored by Claude Opus 4.7 (Claude Code). Session cce1fea5-32ff-410c-b820-2e9a27b3cd51.

Splits the live-osascript runtime tests in `test/playwright/unit/ai/scripts/resumeHarness.spec.mjs` into static-config-check (always-on, preserves coverage) + live-host-runtime (skipped by default behind `RUN_LIVE_OSASCRIPT=1` env var). Prevents the 2026-05-04 09:03Z runaway-spawn pattern where running this spec on a host with Claude Desktop + accessibility permission granted pasted the boot-grounding prompt into the live app and spawned real Claude Code sessions.

## Deltas from ticket

- **Test split** — the body proposed adding a single `test.skip()` guard to the original `Opus identity routes to osascript ...` test. That test mixes a live `execFileSync` (lines 73-79 pre-fix) with a static script-content check (lines 81-85 pre-fix). Adding a skip guard to the whole test would have skipped the static check too — losing always-on coverage. Instead the test is split: `Opus identity routes to claude-desktop adapter via HARNESS_REGISTRY (config check)` (always-on, retains static coverage) + `Opus identity osascript runtime dispatch (live host — RUN_LIVE_OSASCRIPT=1 required, #10681)` (skipped by default).
- **`bridge-daemon.spec.mjs` audit** — already safe; no changes needed. All bridge-daemon delivery paths use either `adapter: 'test'` (test stream) or a mock `osascript` binary on PATH that captures argv without executing AppleScript. Documented as the reference architecture for safe live-substrate testing in the new header comment block.
- **Header documentation** — added a comment block in the `describe` scope explaining the `RUN_LIVE_OSASCRIPT` discipline + the empirical anchor + the bridge-daemon reference pattern, satisfying AC4 (test invariant documented).

## Test Evidence

- `node --check test/playwright/unit/ai/scripts/resumeHarness.spec.mjs` passes
- `git diff --stat origin/dev`: 1 file changed, 37 insertions, 13 deletions

**Live verification skipped intentionally** — running `npm run test-unit test/playwright/unit/ai/scripts/resumeHarness.spec.mjs` on this host would trigger the very bug being fixed. Reviewer should run with default env (`RUN_LIVE_OSASCRIPT` unset) on a Mac with Claude Desktop + accessibility permission granted to confirm `[skipped]` reasons appear in the test report and no Claude Desktop sessions spawn.

## Post-Merge Validation

- [ ] `@neo-gemini-3-1-pro` re-runs `npm run test-unit test/playwright/unit/ai/scripts/resumeHarness.spec.mjs` (the original 09:03Z trigger) on her host with default env; confirms `[skipped]` lines + zero Claude Desktop spawns
- [ ] Verify the `RUN_LIVE_OSASCRIPT=1` opt-in path still works — explicit env-var-set run should execute both live-host tests and report `[passed]` or `[failed]` with the original assertions
- [ ] `#10676` sunset-mode restart substrate work (when it lands) extends this discipline with `RUN_LIVE_KILL_OPS=1` per the operator's "we do not want to kill real sessions for testing" warning ([#10676 substrate-truth comment](https://github.com/neomjs/neo/issues/10676#issuecomment-4369768782))

## Related

- **Parent epic:** #10671 (substrate-restart recovery — two-mode)
- **Sibling forensic:** #10672 (runaway-spawn forensic record — this PR's empirical anchor)
- **Empirical trigger:** PR #10680 (`@neo-gemini-3-1-pro`'s #10678 Antigravity track) — running `resumeHarness.spec.mjs` during her implementation work caused the 2026-05-04 09:03Z spawn event
- **Operator framing:** "imagine a real night shift. one of you starts 'all' unit tests and game over." (chat 2026-05-04, session `cce1fea5-32ff-410c-b820-2e9a27b3cd51`)