### PR TITLE
feat(ai): implement substrate restart mutex (#10674)

### DIFF
--- a/ai/scripts/checkAllAgentIdle.mjs
+++ b/ai/scripts/checkAllAgentIdle.mjs
@@ -21,6 +21,7 @@ import Neo from '../../src/Neo.mjs';
 import * as core from '../../src/core/_export.mjs';
 import LifecycleService from '../mcp/server/memory-core/services/lifecycle/SystemLifecycleService.mjs';
 import GraphService from '../mcp/server/memory-core/services/GraphService.mjs';
+import { checkInflightLock } from './inflightLock.mjs';
 
 async function main() {
     await LifecycleService.initAsync();
@@ -74,7 +75,20 @@ async function main() {
             ageMs = Infinity; 
         }
 
-        details[identity] = { lastMemTime, ageMs };
+        // Check if there is an active idle_out_nudge lock for this identity
+        const lastMemTimeMs = lastMemTime ? new Date(lastMemTime).getTime() : 0;
+        const lockData = await checkInflightLock(identity, 'idle_out_nudge', lastMemTimeMs);
+
+        if (lockData.inFlight) {
+            ageMs = 0; // Treat as actively waking up (not idle)
+        }
+
+        details[identity] = { 
+            lastMemTime, 
+            ageMs, 
+            inFlightNudge: lockData.inFlight, 
+            abandonedCount: lockData.abandonedCount || 0 
+        };
 
         if (ageMs <= thresholdMs) {
             allIdle = false;

--- a/ai/scripts/checkSunsetted.mjs
+++ b/ai/scripts/checkSunsetted.mjs
@@ -22,6 +22,7 @@ import Neo from '../../src/Neo.mjs';
 import * as core from '../../src/core/_export.mjs';
 import LifecycleService from '../mcp/server/memory-core/services/lifecycle/SystemLifecycleService.mjs';
 import GraphService from '../mcp/server/memory-core/services/GraphService.mjs';
+import { checkInflightLock } from './inflightLock.mjs';
 
 async function main() {
     await LifecycleService.initAsync();
@@ -101,6 +102,7 @@ async function main() {
     let originSessionId = memRow?.sessionIdField || '';
     let isSunsetted = false;
     let reason = '';
+    let lockData = null;
 
     // [Anchor & Echo] Sunset detection criterion: ONLY the explicit Unsubscribe primitive.
     //
@@ -122,15 +124,24 @@ async function main() {
     // (issue #10641): "the bridge SHOULD spawn new sessions. but only after a sunset.
     // otherwise => resume inside current session."
     if (subs.length === 0) {
-        isSunsetted = true;
-        reason = 'No active WAKE_SUBSCRIPTION (Unsubscribe primitive fired)';
+        const memTimestampMs = memRow?.timestampField ? new Date(memRow.timestampField).getTime() : 0;
+        lockData = await checkInflightLock(identity, 'sunset_restart', memTimestampMs);
+
+        if (lockData.inFlight) {
+            isSunsetted = false;
+            reason = 'Sunset restart already in-flight (lock active)';
+        } else {
+            isSunsetted = true;
+            reason = 'No active WAKE_SUBSCRIPTION (Unsubscribe primitive fired)';
+        }
     }
 
     console.log(JSON.stringify({
         identity,
         sunsetted: isSunsetted,
         reason,
-        originSessionId
+        originSessionId,
+        abandonedCount: lockData?.abandonedCount || 0
     }));
     process.exit(0);
 }

--- a/ai/scripts/inflightLock.mjs
+++ b/ai/scripts/inflightLock.mjs
@@ -1,0 +1,96 @@
+import fs from 'fs/promises';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import { writeGateState } from './wakeSafetyGate.mjs';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+export const BOOT_TIMEOUT_MS = 15 * 60 * 1000; // 15 minutes
+export const MAX_ABANDONED_ACTIONS = 3;
+
+/**
+ * Returns the path to the lock file.
+ */
+export function getLockPath(mode, identity) {
+    const cleanIdentity = identity.replace(/[^a-zA-Z0-9_-]/g, '');
+    return path.resolve(__dirname, `../../.neo-ai-data/wake-daemon/inflight-${mode}-${cleanIdentity}.txt`);
+}
+
+/**
+ * Check if the lock is active, abandoned, or cleared.
+ * If cleared by fresh memory, deletes the lock file.
+ * If abandoned >= N times, auto-trips the wake safety gate.
+ * 
+ * @param {string} identity The agent identity
+ * @param {string} mode 'sunset_restart' or 'idle_out_nudge'
+ * @param {number} latestMemoryTimestampMs The timestamp of the latest AGENT_MEMORY for this identity
+ * @returns {Promise<{inFlight: boolean, abandoned: boolean}>}
+ */
+export async function checkInflightLock(identity, mode, latestMemoryTimestampMs) {
+    const lockPath = getLockPath(mode, identity);
+    
+    try {
+        const content = await fs.readFile(lockPath, 'utf8');
+        const lockData = JSON.parse(content);
+        
+        if (latestMemoryTimestampMs > lockData.timestamp) {
+            // Memory is newer than lock! The agent successfully booted/responded.
+            await fs.unlink(lockPath);
+            return { inFlight: false, abandoned: false };
+        }
+        
+        const ageMs = Date.now() - lockData.timestamp;
+        if (ageMs > BOOT_TIMEOUT_MS) {
+            // Abandoned action
+            const newAbandonedCount = (lockData.abandonedCount || 0) + 1;
+            
+            if (newAbandonedCount >= MAX_ABANDONED_ACTIONS) {
+                // Trip the safety gate per #10648 contract
+                await writeGateState({
+                    state: 'tripped',
+                    reason: `${newAbandonedCount} consecutive abandoned actions for ${mode} on ${identity}`,
+                    trippedBy: 'inflight-lock-monitor'
+                });
+                return { inFlight: false, abandoned: true }; // Let action proceed (it will be blocked by safety gate anyway)
+            }
+            
+            // Rewrite lock to reset timestamp and increment abandoned count?
+            // "allow next interval to retry" -> so we return inFlight: false, abandoned: true
+            // Then the caller can try again, which will call `writeInflightLock` with the new count.
+            return { inFlight: false, abandoned: true, abandonedCount: newAbandonedCount };
+        }
+        
+        return { inFlight: true, abandoned: false };
+    } catch (err) {
+        if (err.code === 'ENOENT') {
+            return { inFlight: false, abandoned: false };
+        }
+        // If unparseable, assume no lock to recover safely
+        return { inFlight: false, abandoned: false };
+    }
+}
+
+/**
+ * Write the inflight lock before invoking an action.
+ */
+export async function writeInflightLock(identity, mode, abandonedCount = 0) {
+    const lockPath = getLockPath(mode, identity);
+    const lockData = {
+        timestamp: Date.now(),
+        lockId: Math.random().toString(36).slice(2),
+        abandonedCount
+    };
+    await fs.mkdir(path.dirname(lockPath), { recursive: true });
+    await fs.writeFile(lockPath, JSON.stringify(lockData, null, 2));
+}
+
+/**
+ * Explicitly clear a lock if needed outside of the implicit check.
+ */
+export async function clearInflightLock(identity, mode) {
+    const lockPath = getLockPath(mode, identity);
+    try {
+        await fs.unlink(lockPath);
+    } catch (err) {
+        if (err.code !== 'ENOENT') throw err;
+    }
+}

--- a/ai/scripts/resumeHarness.mjs
+++ b/ai/scripts/resumeHarness.mjs
@@ -22,6 +22,7 @@ import fs from 'fs/promises';
 import path from 'path';
 import { fileURLToPath } from 'url';
 import { readGateState, hasOverride } from './wakeSafetyGate.mjs';
+import { writeInflightLock, clearInflightLock } from './inflightLock.mjs';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
@@ -55,7 +56,7 @@ function buildBootGroundingPrompt(identity, reason, originSessionId) {
     ].join(' ');
 }
 
-async function resumeHarness(identity, reason, originSessionId) {
+async function resumeHarness(identity, reason, originSessionId, abandonedCount = 0) {
     // Wake safety gate (#10648, child of #10647). Direct fresh-session-spawn
     // invocations must also fail-closed when the substrate is unsafe — the
     // gate is consulted alongside (and ahead of) the existing cooldown. The
@@ -116,6 +117,9 @@ async function resumeHarness(identity, reason, originSessionId) {
     }
 
     const adapter = process.platform === 'darwin' ? harnessTarget.adapter : 'tmux';
+
+    // Write the inflight lock BEFORE taking action to secure the boot ramp (Issue #10674)
+    await writeInflightLock(identity, 'sunset_restart', abandonedCount);
 
     try {
         if (adapter === 'osascript') {
@@ -202,6 +206,7 @@ async function resumeHarness(identity, reason, originSessionId) {
         await fs.writeFile(cooldownFile, Date.now().toString());
     } catch (err) {
         console.error(`Failed to resume ${identity} via ${adapter}: ${err.message}`);
+        await clearInflightLock(identity, 'sunset_restart');
         process.exit(1);
     }
 }
@@ -209,13 +214,14 @@ async function resumeHarness(identity, reason, originSessionId) {
 const identity        = process.argv[2];
 const reason          = process.argv[3] || 'Scheduled interval recovery';
 const originSessionId = process.argv[4] || ''; // Optional; populated by checkSunsetted post-#10611
+const abandonedCount  = parseInt(process.argv[5], 10) || 0;
 
 if (!identity) {
-    console.error('Usage: resumeHarness.mjs <identity> [reason] [originSessionId]');
+    console.error('Usage: resumeHarness.mjs <identity> [reason] [originSessionId] [abandonedCount]');
     process.exit(1);
 }
 
-resumeHarness(identity, reason, originSessionId).catch(err => {
+resumeHarness(identity, reason, originSessionId, abandonedCount).catch(err => {
     console.error('Unexpected error:', err.message);
     process.exit(1);
 });

--- a/ai/scripts/swarm-heartbeat.sh
+++ b/ai/scripts/swarm-heartbeat.sh
@@ -142,6 +142,7 @@ heartbeat_pulse() {
             # boot-grounding prompt can anchor Memory Core context-priming. `// empty` jq filter
             # safely degrades to '' when the key is absent (older sunset JSON shape).
             local origin_session_id=$(echo "$sunset_json" | jq -r '.originSessionId // empty')
+            local abandoned_count=$(echo "$sunset_json" | jq -r '.abandonedCount // 0')
 
             if [ "$is_sunsetted" = "true" ]; then
                 # Wake safety gate (#10648, child of #10647). Fail-closed gate consulted
@@ -161,7 +162,7 @@ heartbeat_pulse() {
                 # Q1b fresh-session-spawn adapter: opens a new chat in target harness via
                 # Cmd+N keystroke before pasting the boot-grounding prompt. Replaces the prior
                 # Q1a in-place wake injection per @tobiu's verbatim 2026-05-02 correction.
-                node "${script_dir}/resumeHarness.mjs" "$IDENTITY" "$sunset_reason" "$origin_session_id" 2>>"$SWEEP_LOG"
+                node "${script_dir}/resumeHarness.mjs" "$IDENTITY" "$sunset_reason" "$origin_session_id" "$abandoned_count" 2>>"$SWEEP_LOG"
 
                 # Continue loop; no need to send regular heartbeat to tmux since we just resumed via OS
                 continue

--- a/ai/scripts/trioWakeCooldown.mjs
+++ b/ai/scripts/trioWakeCooldown.mjs
@@ -14,6 +14,7 @@ import RequestContextService from '../mcp/server/shared/services/RequestContextS
 import LifecycleService from '../mcp/server/memory-core/services/lifecycle/SystemLifecycleService.mjs';
 import GraphService from '../mcp/server/memory-core/services/GraphService.mjs';
 import MailboxService from '../mcp/server/memory-core/services/MailboxService.mjs';
+import { writeInflightLock, clearInflightLock } from './inflightLock.mjs';
 
 const COOLDOWN_STATE_PATH = '.neo-ai-data/wake-daemon/trio-wake-cooldown.json';
 const COOLDOWN_LOCK_PATH = '.neo-ai-data/wake-daemon/trio-wake-cooldown.lock';
@@ -62,16 +63,26 @@ async function main() {
 
         const coordinator = signal.coordinator_recommendation || '@neo-gemini-3-1-pro';
         const sender = process.env.NEO_AGENT_IDENTITY || '@system';
+        const abandonedCount = signal.details?.[coordinator]?.abandonedCount || 0;
 
-        await RequestContextService.run({ agentIdentityNodeId: sender }, async () => {
-            await MailboxService.addMessage({
-                to: coordinator,
-                subject: 'Intent-First Wakeup: All-Agent-Idle Detected',
-                body: `The swarm heartbeat has detected that all configured agents are idle.\n\nDetector Signal:\n\`\`\`json\n${JSON.stringify(signal, null, 2)}\n\`\`\`\n\nYou are the recommended coordinator. Please pick up a high-ROI ticket and drive the swarm forward per D1/D2 policies.`,
-                priority: 'high'
-                // We omit `from` since it's a system message.
+        // Secure the nudge boot ramp BEFORE taking action (Issue #10674)
+        await writeInflightLock(coordinator, 'idle_out_nudge', abandonedCount);
+
+        try {
+            await RequestContextService.run({ agentIdentityNodeId: sender }, async () => {
+                await MailboxService.addMessage({
+                    to: coordinator,
+                    subject: 'Intent-First Wakeup: All-Agent-Idle Detected',
+                    body: `The swarm heartbeat has detected that all configured agents are idle.\n\nDetector Signal:\n\`\`\`json\n${JSON.stringify(signal, null, 2)}\n\`\`\`\n\nYou are the recommended coordinator. Please pick up a high-ROI ticket and drive the swarm forward per D1/D2 policies.`,
+                    priority: 'high'
+                    // We omit `from` since it's a system message.
+                });
             });
-        });
+        } catch (err) {
+            console.error(`[trioWakeCooldown] Failed to send wake message to ${coordinator}:`, err.message);
+            await clearInflightLock(coordinator, 'idle_out_nudge');
+            throw err;
+        }
 
         state = {
             last_fire_cycle_id: signal.cycle_id,

--- a/test/playwright/unit/ai/scripts/inflightLock.spec.mjs
+++ b/test/playwright/unit/ai/scripts/inflightLock.spec.mjs
@@ -1,0 +1,135 @@
+import {setup} from '../../../setup.mjs';
+
+const appName = 'InflightLockTest';
+
+setup({
+    neoConfig: {
+        unitTestMode: true
+    },
+    appConfig: {
+        name             : appName,
+        isMounted        : () => true,
+        vnodeInitialising: false
+    }
+});
+
+import {test, expect}            from '@playwright/test';
+import fs                        from 'fs/promises';
+import {existsSync}              from 'fs';
+import path                      from 'path';
+import {randomUUID}              from 'crypto';
+import os                        from 'os';
+
+test.describe('ai/scripts/inflightLock', () => {
+    let inflightLock;
+    let wakeSafetyGate;
+    let getLockPath;
+    let BOOT_TIMEOUT_MS;
+    
+    // Test data
+    const identity = '@neo-test-agent';
+    const mode = 'sunset_restart';
+    let lockPath;
+    let gatePath;
+    
+    test.beforeAll(async () => {
+        inflightLock = await import('../../../../../ai/scripts/inflightLock.mjs');
+        wakeSafetyGate = await import('../../../../../ai/scripts/wakeSafetyGate.mjs');
+        getLockPath = inflightLock.getLockPath;
+        BOOT_TIMEOUT_MS = inflightLock.BOOT_TIMEOUT_MS;
+    });
+
+    test.beforeEach(async () => {
+        lockPath = getLockPath(mode, identity);
+        
+        // Clean up locks
+        try {
+            await fs.unlink(lockPath);
+        } catch(e) {}
+        
+        gatePath = path.join(os.tmpdir(), `wake-gate-test-${randomUUID()}.json`);
+        process.env.WAKE_GATE_FILE_PATH = gatePath;
+    });
+    
+    test.afterEach(async () => {
+        try {
+            await fs.unlink(lockPath);
+        } catch(e) {}
+        try {
+            await fs.unlink(gatePath);
+        } catch(e) {}
+    });
+
+    test('writeInflightLock creates a file with timestamp and abandonedCount', async () => {
+        await inflightLock.writeInflightLock(identity, mode, 2);
+        
+        expect(existsSync(lockPath)).toBe(true);
+        const content = JSON.parse(await fs.readFile(lockPath, 'utf8'));
+        expect(content.abandonedCount).toBe(2);
+        expect(content.timestamp).toBeLessThanOrEqual(Date.now());
+        expect(content.lockId).toBeTruthy();
+    });
+
+    test('checkInflightLock returns inFlight: false if no lock exists', async () => {
+        const result = await inflightLock.checkInflightLock(identity, mode, Date.now());
+        expect(result).toEqual({ inFlight: false, abandoned: false });
+    });
+
+    test('checkInflightLock returns inFlight: true if lock is recent', async () => {
+        await inflightLock.writeInflightLock(identity, mode, 0);
+        const result = await inflightLock.checkInflightLock(identity, mode, 0); // Memory is older than lock
+        expect(result).toEqual({ inFlight: true, abandoned: false });
+    });
+
+    test('checkInflightLock clears lock and returns inFlight: false if memory is newer than lock', async () => {
+        await inflightLock.writeInflightLock(identity, mode, 0);
+        
+        const lockContent = JSON.parse(await fs.readFile(lockPath, 'utf8'));
+        const newMemoryTimestamp = lockContent.timestamp + 1000;
+        
+        const result = await inflightLock.checkInflightLock(identity, mode, newMemoryTimestamp);
+        expect(result).toEqual({ inFlight: false, abandoned: false });
+        expect(existsSync(lockPath)).toBe(false); // Lock should be cleared
+    });
+
+    test('checkInflightLock returns abandoned: true if lock is older than BOOT_TIMEOUT_MS', async () => {
+        await inflightLock.writeInflightLock(identity, mode, 0);
+        
+        // Backdate the lock
+        const lockContent = JSON.parse(await fs.readFile(lockPath, 'utf8'));
+        lockContent.timestamp = Date.now() - BOOT_TIMEOUT_MS - 1000;
+        await fs.writeFile(lockPath, JSON.stringify(lockContent, null, 2));
+        
+        const result = await inflightLock.checkInflightLock(identity, mode, 0);
+        expect(result).toEqual({ inFlight: false, abandoned: true, abandonedCount: 1 });
+    });
+
+    test('checkInflightLock trips safety gate if abandoned count reaches MAX_ABANDONED_ACTIONS', async () => {
+        // Abandoned 2 times already (will become 3rd time)
+        await inflightLock.writeInflightLock(identity, mode, inflightLock.MAX_ABANDONED_ACTIONS - 1);
+        
+        // Backdate the lock
+        const lockContent = JSON.parse(await fs.readFile(lockPath, 'utf8'));
+        lockContent.timestamp = Date.now() - BOOT_TIMEOUT_MS - 1000;
+        await fs.writeFile(lockPath, JSON.stringify(lockContent, null, 2));
+        
+        const result = await inflightLock.checkInflightLock(identity, mode, 0);
+        
+        // It returns abandoned: true, but no count (doesn't retry)
+        expect(result).toEqual({ inFlight: false, abandoned: true });
+        
+        // Gate should be tripped
+        const gateState = await wakeSafetyGate.readGateState();
+        expect(gateState.state).toBe('tripped');
+        expect(gateState.trippedBy).toBe('inflight-lock-monitor');
+        expect(gateState.reason).toContain('consecutive abandoned actions');
+    });
+
+    test('clearInflightLock deletes the lock file', async () => {
+        await inflightLock.writeInflightLock(identity, mode, 0);
+        expect(existsSync(lockPath)).toBe(true);
+        
+        await inflightLock.clearInflightLock(identity, mode);
+        expect(existsSync(lockPath)).toBe(false);
+    });
+});

--- a/test/playwright/unit/ai/scripts/resumeHarness.spec.mjs
+++ b/test/playwright/unit/ai/scripts/resumeHarness.spec.mjs
@@ -205,4 +205,35 @@ test.describe('ai/scripts/resumeHarness', () => {
         const scriptContent = fs.readFileSync(scriptPath, 'utf-8');
         expect(scriptContent).toContain("const tmuxSession = harnessTarget.tmuxSession || process.env.TMUX_SESSION || 'neo-agent';");
     });
+
+    test('adapter failure (e.g. ESC-as-rejection) clears the inflight lock (#10674)', async () => {
+        // Create fake bins that always fail (exit 1)
+        const fakeBinDir = path.join(os.tmpdir(), `fake-bin-${randomUUID()}`);
+        fs.mkdirSync(fakeBinDir, { recursive: true });
+        const fakeOsascript = path.join(fakeBinDir, 'osascript');
+        fs.writeFileSync(fakeOsascript, '#!/bin/sh\nexit 1\n', { mode: 0o755 });
+        const fakeTmux = path.join(fakeBinDir, 'tmux');
+        fs.writeFileSync(fakeTmux, '#!/bin/sh\nexit 1\n', { mode: 0o755 });
+
+        // We can compute the lock path without importing inflightLock if needed,
+        // but importing it is cleaner:
+        const { getLockPath } = await import('../../../../../ai/scripts/inflightLock.mjs');
+        const lockPath = getLockPath('sunset_restart', '@neo-opus-4-7');
+        if (fs.existsSync(lockPath)) fs.unlinkSync(lockPath);
+
+        const env = { ...overrideEnv, PATH: `${fakeBinDir}:${process.env.PATH}` };
+        try {
+            execFileSync('node', [scriptPath, '@neo-opus-4-7', 'test'], {encoding: 'utf-8', stdio: 'pipe', env});
+            test.fail('Should have exited with error');
+        } catch (e) {
+            expect(e.status).toBe(1);
+            expect(e.stderr).toMatch(/Failed to resume @neo-opus-4-7 via (osascript|tmux)/);
+            
+            // Lock should be cleared!
+            expect(fs.existsSync(lockPath)).toBe(false);
+        } finally {
+            fs.rmSync(fakeBinDir, { recursive: true, force: true });
+            if (fs.existsSync(lockPath)) fs.unlinkSync(lockPath);
+        }
+    });
 });


### PR DESCRIPTION
Authored by Gemini 3.1 Pro (Antigravity). Session 780a1983-370f-4206-9cb2-92b23b09c0a8.

Resolves #10674

Implemented a robust substrate-level mutex ("inflight lock") mechanism to prevent race conditions during agent wake-up sequences (`sunset_restart` and `idle_out_nudge`). This serves as the data-layer mutex for identity uniqueness during boot ramps.

## Deltas from ticket (if any)
- Handled the "ESC-as-rejection" failure path natively within the `catch` blocks of harness dispatchers (`resumeHarness` and `trioWakeCooldown`) to clear the inflight lock on adapter execution failures immediately.
- The `inflightLock` service integrates seamlessly with the `wakeSafetyGate`, automatically tripping it if `MAX_ABANDONED_ACTIONS` (default 3) is exceeded within the timeout.

## Test Evidence
- Created `test/playwright/unit/ai/scripts/inflightLock.spec.mjs` verifying lock creation, time validation, abandonment tracking, and safety gate tripping.
- Updated `test/playwright/unit/ai/scripts/resumeHarness.spec.mjs` with an integration test validating lock clearance upon adapter failure (simulating ESC-as-rejection).
- Ran `npx playwright test test/playwright/unit/ai/scripts/resumeHarness.spec.mjs test/playwright/unit/ai/scripts/inflightLock.spec.mjs` successfully.

## Post-Merge Validation
- [ ] Observe logs in `.neo-ai-data/wake-daemon/` to confirm locks are correctly cleaned up or abandoned during real-world transitions.

## Commits
- Includes the `inflightLock.mjs` core, `resumeHarness.mjs` adapter hooks, and `trioWakeCooldown.mjs` integration commits.
