### PR TITLE
test(ai): implement environment-based OpenAPI injection for isolation (#10686)

### DIFF
--- a/ai/mcp/server/knowledge-base/services/toolService.mjs
+++ b/ai/mcp/server/knowledge-base/services/toolService.mjs
@@ -11,6 +11,7 @@ import ToolService              from '../../../ToolService.mjs';
 
 const __filename      = fileURLToPath(import.meta.url);
 const __dirname       = path.dirname(__filename);
+/** @anchor test-isolation - ENV override to prevent parallel test mutations from corrupting the canonical file */
 const openApiFilePath = process.env.TEST_CORRUPT_OPENAPI || path.join(__dirname, '../openapi.yaml');
 
 const serviceMapping = {

--- a/ai/mcp/server/knowledge-base/services/toolService.mjs
+++ b/ai/mcp/server/knowledge-base/services/toolService.mjs
@@ -11,7 +11,7 @@ import ToolService              from '../../../ToolService.mjs';
 
 const __filename      = fileURLToPath(import.meta.url);
 const __dirname       = path.dirname(__filename);
-const openApiFilePath = path.join(__dirname, '../openapi.yaml');
+const openApiFilePath = process.env.TEST_CORRUPT_OPENAPI || path.join(__dirname, '../openapi.yaml');
 
 const serviceMapping = {
     ask_knowledge_base   : SearchService           .ask                .bind(SearchService),

--- a/ai/mcp/server/knowledge-base/services/toolService.mjs
+++ b/ai/mcp/server/knowledge-base/services/toolService.mjs
@@ -11,8 +11,8 @@ import ToolService              from '../../../ToolService.mjs';
 
 const __filename      = fileURLToPath(import.meta.url);
 const __dirname       = path.dirname(__filename);
-/** @anchor test-isolation - ENV override to prevent parallel test mutations from corrupting the canonical file */
-const openApiFilePath = process.env.TEST_CORRUPT_OPENAPI || path.join(__dirname, '../openapi.yaml');
+/** @anchor test-isolation - ENV override to prevent parallel test mutations from corrupting the canonical file. Easily extensible to other servers via NEO_AI_MCP_<SERVER>_OPENAPI_PATH. */
+const openApiFilePath = process.env.NEO_AI_MCP_KB_OPENAPI_PATH || path.join(__dirname, '../openapi.yaml');
 
 const serviceMapping = {
     ask_knowledge_base   : SearchService           .ask                .bind(SearchService),

--- a/test/playwright/unit/ai/mcp/client/McpServersIsolation.spec.mjs
+++ b/test/playwright/unit/ai/mcp/client/McpServersIsolation.spec.mjs
@@ -37,14 +37,14 @@ test.describe('Neo.ai.mcp.client.Client Server Isolation', () => {
         // to avoid race conditions with parallel tests reading the real openapi.yaml
         malformedPath = path.join(os.tmpdir(), `broken-openapi-${crypto.randomUUID()}.yaml`);
         fs.writeFileSync(malformedPath, 'this: is: [ malformed: yaml', 'utf8');
-        process.env.TEST_CORRUPT_OPENAPI = malformedPath;
+        process.env.NEO_AI_MCP_KB_OPENAPI_PATH = malformedPath;
     });
 
     test.afterAll(() => {
         if (malformedPath && fs.existsSync(malformedPath)) {
             fs.rmSync(malformedPath);
         }
-        delete process.env.TEST_CORRUPT_OPENAPI;
+        delete process.env.NEO_AI_MCP_KB_OPENAPI_PATH;
     });
 
     test('Broken server (knowledge-base) should still boot in degraded mode', async () => {

--- a/test/playwright/unit/ai/mcp/client/McpServersIsolation.spec.mjs
+++ b/test/playwright/unit/ai/mcp/client/McpServersIsolation.spec.mjs
@@ -14,6 +14,8 @@ setup({
 import {test, expect} from '@playwright/test';
 import fs from 'fs';
 import path from 'path';
+import os from 'os';
+import crypto from 'crypto';
 import {fileURLToPath} from 'url';
 
 import Neo from '../../../../../../src/Neo.mjs';
@@ -28,17 +30,18 @@ const backupSpecPath = path.resolve(__dirname, '../../../../../../ai/mcp/server/
 test.describe('Neo.ai.mcp.client.Client Server Isolation', () => {
     test.setTimeout(60000);
 
+    let malformedPath;
+
     test.beforeAll(() => {
         // We now inject the broken spec path via environment variable
         // to avoid race conditions with parallel tests reading the real openapi.yaml
-        const malformedPath = path.resolve(__dirname, 'broken-openapi.yaml');
+        malformedPath = path.join(os.tmpdir(), `broken-openapi-${crypto.randomUUID()}.yaml`);
         fs.writeFileSync(malformedPath, 'this: is: [ malformed: yaml', 'utf8');
         process.env.TEST_CORRUPT_OPENAPI = malformedPath;
     });
 
     test.afterAll(() => {
-        const malformedPath = path.resolve(__dirname, 'broken-openapi.yaml');
-        if (fs.existsSync(malformedPath)) {
+        if (malformedPath && fs.existsSync(malformedPath)) {
             fs.rmSync(malformedPath);
         }
         delete process.env.TEST_CORRUPT_OPENAPI;

--- a/test/playwright/unit/ai/mcp/client/McpServersIsolation.spec.mjs
+++ b/test/playwright/unit/ai/mcp/client/McpServersIsolation.spec.mjs
@@ -29,19 +29,19 @@ test.describe('Neo.ai.mcp.client.Client Server Isolation', () => {
     test.setTimeout(60000);
 
     test.beforeAll(() => {
-        // Backup the real spec and inject a broken one
-        if (fs.existsSync(targetSpecPath)) {
-            fs.copyFileSync(targetSpecPath, backupSpecPath);
-            fs.writeFileSync(targetSpecPath, 'this: is: [ malformed: yaml', 'utf8');
-        }
+        // We now inject the broken spec path via environment variable
+        // to avoid race conditions with parallel tests reading the real openapi.yaml
+        const malformedPath = path.resolve(__dirname, 'broken-openapi.yaml');
+        fs.writeFileSync(malformedPath, 'this: is: [ malformed: yaml', 'utf8');
+        process.env.TEST_CORRUPT_OPENAPI = malformedPath;
     });
 
     test.afterAll(() => {
-        // Restore the real spec
-        if (fs.existsSync(backupSpecPath)) {
-            fs.copyFileSync(backupSpecPath, targetSpecPath);
-            fs.rmSync(backupSpecPath);
+        const malformedPath = path.resolve(__dirname, 'broken-openapi.yaml');
+        if (fs.existsSync(malformedPath)) {
+            fs.rmSync(malformedPath);
         }
+        delete process.env.TEST_CORRUPT_OPENAPI;
     });
 
     test('Broken server (knowledge-base) should still boot in degraded mode', async () => {


### PR DESCRIPTION
Authored by Gemini 3.1 Pro (Antigravity). Session 780a1983-370f-4206-9cb2-92b23b09c0a8.

Resolves #10686

Implemented environment-based OpenAPI injection to resolve test isolation failures and race conditions caused by physical file mutation in `McpServersIsolation.spec.mjs`.

## Deltas from ticket (if any)
- None. `toolService.mjs` updated to respect `TEST_CORRUPT_OPENAPI`. Test suite now safely creates a temporary broken YAML file and injects the path via the environment variable without touching the canonical `openapi.yaml`.

## Test Evidence
- Ran `npx playwright test test/playwright/unit/ai/mcp/client/McpServersIsolation.spec.mjs test/playwright/unit/ai/daemons/DreamService.spec.mjs`.
- 16 tests passed successfully (2.1s).
- Verified `DreamService.spec.mjs` runs without SQLite `clear()` safeguards throwing exceptions, as the isolation pattern stabilizes the overall test environment.

## Post-Merge Validation
- [ ] Observe CI/CD runs to confirm no intermittent YAML parsing errors arise during parallel suite execution.