### PR TITLE
feat(ai): per-identity idle-out A2A heartbeat nudge dispatcher (#10675)

### DIFF
--- a/ai/scripts/idleOutNudge.mjs
+++ b/ai/scripts/idleOutNudge.mjs
@@ -1,0 +1,164 @@
+#!/usr/bin/env node
+/**
+ * @summary Per-identity idle-out A2A heartbeat nudge dispatcher (Epic #10671, sub #10675).
+ *
+ * Consumed by `swarm-heartbeat.sh` when `checkSunsetted.mjs` (per #10689 detector
+ * contract) emits `recommended_action: 'idle_out_nudge'` for a specific identity.
+ * Sends an A2A heartbeat message via `MailboxService.addMessage` — `bridge-daemon`
+ * delivers via the existing in-place keystroke path. **Zero new transport, no
+ * fresh-session spawn, never opens a new chat.**
+ *
+ * **Distinct from `trioWakeCooldown.mjs`:** trio fires when ALL configured agents
+ * idle simultaneously (swarm-wide signal); this dispatcher fires per-identity
+ * when one specific agent's `AGENT_MEMORY` exceeds the staleness threshold while
+ * the swarm is otherwise active. Both reuse the `idle_out_nudge` lock mode from
+ * `inflightLock.mjs` (#10683) but operate independently — one identity going
+ * idle is not a swarm-wide event.
+ *
+ * **Invariants per #10675:**
+ *
+ * - **Bounded:** the in-flight `idle_out_nudge` lock prevents re-fire within
+ *   `BOOT_TIMEOUT_MS` (default 15 min, per `inflightLock.mjs`). One nudge per
+ *   identity per window — no spam during long deep-thinking turns or rate-limit
+ *   throttle.
+ * - **Non-spawning:** uses the A2A messaging path. The recipient sees this as a
+ *   normal mailbox message that `bridge-daemon` keystroke-injects into their
+ *   active chat tab. No `Cmd+N` spawn; no new harness session.
+ * - **Idempotent:** acquiring the lock is the gate. If a prior nudge is in
+ *   flight (lock held), this invocation is a no-op. The detector contract in
+ *   `checkSunsetted.mjs` ALSO consults the lock and downgrades the
+ *   `recommended_action` to `'no_action'` when held — this dispatcher's
+ *   defensive lock-check is layer-2 against detector-dispatcher race windows.
+ * - **No-destructive-type-into-active-draft:** `bridge-daemon`'s existing
+ *   focus-steal protection (#10422) covers the keystroke delivery; if the
+ *   recipient is mid-typing, the bridge-daemon defers without clobbering input.
+ *
+ * **Safety gate integration:** consults `wakeSafetyGate.mjs` (#10648) before
+ * any action. Operator override `WAKE_GATE_OVERRIDE=1` bypasses the gate. Same
+ * fail-closed pattern as `resumeHarness.mjs`.
+ *
+ * **Lock release path:** the lock is NOT cleared on dispatcher success — it
+ * stays held until `checkInflightLock` (called by `checkSunsetted.mjs` on the
+ * next heartbeat cycle) detects a fresh `AGENT_MEMORY` post-lock-acquire and
+ * clears it. This is the "memory-resolved" release path defined by #10683's
+ * `inflightLock.mjs`. If the recipient never saves a memory (rejection,
+ * sustained rate-limit), the lock ages out at `BOOT_TIMEOUT_MS` and is
+ * cleared as "abandoned" — `MAX_ABANDONED_ACTIONS` triggers the wake safety
+ * gate auto-trip.
+ *
+ * @see ai/scripts/checkSunsetted.mjs    — detector emitting `recommended_action: 'idle_out_nudge'` (#10689)
+ * @see ai/scripts/inflightLock.mjs      — `idle_out_nudge` lock mode (#10683)
+ * @see ai/scripts/swarm-heartbeat.sh    — caller; routes on `recommended_action`
+ * @see ai/scripts/trioWakeCooldown.mjs  — sibling for swarm-wide all-idle case
+ * @see ai/scripts/resumeHarness.mjs     — sibling for sunset-restart case
+ * @see test/playwright/unit/ai/scripts/idleOutNudge.spec.mjs
+ */
+import Neo                       from '../../src/Neo.mjs';
+import * as core                 from '../../src/core/_export.mjs';
+import LifecycleService          from '../mcp/server/memory-core/services/lifecycle/SystemLifecycleService.mjs';
+import GraphService              from '../mcp/server/memory-core/services/GraphService.mjs';
+import MailboxService            from '../mcp/server/memory-core/services/MailboxService.mjs';
+import RequestContextService     from '../mcp/server/shared/services/RequestContextService.mjs';
+import {hasOverride, readGateState} from './wakeSafetyGate.mjs';
+import {writeInflightLock, clearInflightLock, checkInflightLock} from './inflightLock.mjs';
+
+const NUDGE_BODY_TEMPLATE = (identity) =>
+    `Heartbeat nudge for ${identity}: your last AGENT_MEMORY save is older than the idle threshold ` +
+    `(default 10 min, configurable via IDLE_THRESHOLD_MS). The substrate is checking in.\n\n` +
+    `Please consolidate-then-save current progress (per AGENTS.md §4.2), check inbox for unread ` +
+    `messages, and either continue active work or sunset cleanly.\n\n` +
+    `**No action needed if you're mid-turn or rate-limited** — your next add_memory will clear this ` +
+    `nudge automatically (memory-resolved release path per #10683 inflightLock).\n\n` +
+    `This is a bounded, non-spawning, in-place heartbeat. The substrate will not re-fire while the ` +
+    `in-flight idle_out_nudge lock is held (per Epic #10671).`;
+
+/**
+ * @summary Dispatch a single idle-out heartbeat nudge to the target identity.
+ *
+ * Sequence (mirrors `resumeHarness.mjs` defense-in-depth pattern):
+ *   1. Wake safety gate check (with `WAKE_GATE_OVERRIDE` operator bypass)
+ *   2. Initialize Memory Core services
+ *   3. Defensive in-flight lock check (handles detector-dispatcher race window)
+ *   4. Acquire in-flight `idle_out_nudge` lock
+ *   5. Send A2A heartbeat message via `MailboxService.addMessage`
+ *   6. On send error: clear lock + fail loudly (so retry isn't blocked for the
+ *      full `BOOT_TIMEOUT_MS` window)
+ *
+ * Lock is NOT cleared on success — memory-resolved release per #10683.
+ *
+ * @param {string} identity Target agent identity (e.g., '@neo-opus-4-7').
+ * @returns {Promise<void>}
+ */
+async function idleOutNudge(identity) {
+    // 1. Wake safety gate (#10648). Fail-closed; operator override via WAKE_GATE_OVERRIDE=1.
+    if (hasOverride()) {
+        console.error('[OVERRIDE] WAKE_GATE_OVERRIDE set; bypassing wake safety gate for idleOutNudge.');
+    } else {
+        const gate = await readGateState();
+        if (gate.state !== 'enabled') {
+            console.error(`Skipping idle-out nudge for ${identity}: Wake safety gate ${gate.state} (reason: ${gate.reason}). Set WAKE_GATE_OVERRIDE=1 to override.`);
+            return;
+        }
+    }
+
+    // 2. Initialize Memory Core services (mirrors trioWakeCooldown.mjs:61-62 pattern).
+    await LifecycleService.initAsync();
+    await GraphService.initAsync();
+
+    // 3. Defensive in-flight lock check. The detector contract in checkSunsetted.mjs
+    //    SHOULD have already filtered this out — it consults the lock and downgrades
+    //    `recommended_action` to `'no_action'` when held. This dispatcher's check is
+    //    layer-2 against the narrow detector-dispatcher race window where a lock could
+    //    be acquired between detector-emit and dispatcher-execute.
+    //
+    //    `latestMemoryTimestampMs: 0` parameter forces the lock-state check (we can't
+    //    cheaply re-query the latest memory here; the detector already did that work
+    //    upstream and would have downgraded if memory-resolved). Edge case: if a memory
+    //    landed between detector-emit and this check, we'd send an unnecessary nudge —
+    //    bounded harm given the lock immediately blocks the next cycle.
+    const lockCheck = await checkInflightLock(identity, 'idle_out_nudge', 0);
+    if (lockCheck.inFlight) {
+        console.error(`Skipping idle-out nudge for ${identity}: in-flight idle_out_nudge lock already held.`);
+        return;
+    }
+
+    // 4. Acquire the in-flight lock BEFORE sending — secures the nudge bounded window.
+    await writeInflightLock(identity, 'idle_out_nudge', 0);
+
+    const sender = process.env.NEO_AGENT_IDENTITY || '@system';
+
+    // 5. Send the A2A heartbeat message. bridge-daemon delivers via existing in-place
+    //    keystroke path; no spawn semantics. If the recipient is sunsetted (no active
+    //    WAKE_SUBSCRIPTION), bridge-daemon won't deliver — that's the correct behavior:
+    //    a sunset-mode recovery path (per #10676) handles that case via terminal-restart.
+    try {
+        await RequestContextService.run({agentIdentityNodeId: sender}, async () => {
+            await MailboxService.addMessage({
+                to      : identity,
+                subject : '[heartbeat] idle-out nudge',
+                body    : NUDGE_BODY_TEMPLATE(identity),
+                priority: 'normal'
+            });
+        });
+        console.error(`[idleOutNudge] Sent heartbeat nudge to ${identity}`);
+    } catch (err) {
+        // 6. Send-failure path: release the lock so the next interval can retry.
+        //    Without this, a transient MailboxService error would block all idle-out
+        //    nudges for this identity for the full BOOT_TIMEOUT_MS window.
+        console.error(`[idleOutNudge] Failed to send nudge to ${identity}: ${err.message}`);
+        await clearInflightLock(identity, 'idle_out_nudge').catch(() => {});
+        process.exit(1);
+    }
+}
+
+const identity = process.argv[2];
+
+if (!identity) {
+    console.error('Usage: idleOutNudge.mjs <identity>');
+    process.exit(1);
+}
+
+idleOutNudge(identity).catch(err => {
+    console.error('idleOutNudge unexpected error:', err.message);
+    process.exit(1);
+});

--- a/ai/scripts/swarm-heartbeat.sh
+++ b/ai/scripts/swarm-heartbeat.sh
@@ -167,6 +167,32 @@ heartbeat_pulse() {
                 # Continue loop; no need to send regular heartbeat to tmux since we just resumed via OS
                 continue
             fi
+
+            # Per-identity idle-out heartbeat nudge (#10675). When checkSunsetted's
+            # recommended_action is 'idle_out_nudge' (active subscription + stale memory >
+            # IDLE_THRESHOLD_MS), dispatch an in-place A2A nudge via idleOutNudge.mjs.
+            # Distinct from the trio-wide all-agent-idle path below: this fires per-identity
+            # when ONE specific agent is stale while the swarm is otherwise active. Both
+            # reuse the inflightLock.mjs idle_out_nudge mode but operate independently.
+            #
+            # `// "no_action"` jq filter degrades safely on older checkSunsetted output
+            # shape that pre-dates the #10689 detector contract.
+            local recommended_action=$(echo "$sunset_json" | jq -r '.recommended_action // "no_action"')
+            if [ "$recommended_action" = "idle_out_nudge" ]; then
+                # Wake safety gate (#10648, child of #10647). Defense-in-depth: idleOutNudge.mjs
+                # also checks the gate internally (see resumeHarness pattern), but the shell
+                # check skips the Node-process spawn cost when the gate is closed.
+                if ! node "${script_dir}/wakeSafetyGate.mjs" check 2>>"$SWEEP_LOG"; then
+                    local gate_reason=$(node "${script_dir}/wakeSafetyGate.mjs" reason 2>>"$SWEEP_LOG")
+                    echo "[heartbeat $(date -Iseconds)] Wake safety gate closed; skipping idle-out nudge for $IDENTITY. Gate reason: $gate_reason" >&2
+                    continue
+                fi
+
+                echo "[heartbeat $(date -Iseconds)] Idle-out nudge triggered for $IDENTITY" >&2
+                node "${script_dir}/idleOutNudge.mjs" "$IDENTITY" 2>>"$SWEEP_LOG"
+                # Continue loop; nudge dispatched, no need for additional tmux heartbeat
+                continue
+            fi
         fi
 
         # All-agent-idle detection (Phase 3 Substrate Primitive #10625)

--- a/test/playwright/unit/ai/scripts/idleOutNudge.spec.mjs
+++ b/test/playwright/unit/ai/scripts/idleOutNudge.spec.mjs
@@ -1,0 +1,176 @@
+import {setup} from '../../../setup.mjs';
+
+const appName = 'IdleOutNudgeTest';
+
+setup({
+    neoConfig: {
+        unitTestMode: true
+    },
+    appConfig: {
+        name             : appName,
+        isMounted        : () => true,
+        vnodeInitialising: false
+    }
+});
+
+import {test, expect}            from '@playwright/test';
+import {execFileSync, spawnSync} from 'child_process';
+import {randomUUID}              from 'crypto';
+import os                        from 'os';
+import path                      from 'path';
+import fs                        from 'fs';
+import fsp                       from 'fs/promises';
+
+import {getLockPath, writeInflightLock} from '../../../../../ai/scripts/inflightLock.mjs';
+
+/**
+ * @summary Validation for #10675 idle-out A2A nudge dispatcher.
+ *
+ * Mirrors the test pattern in `trioWakeCooldown.spec.mjs`: side-effect
+ * verification (lock file presence/absence) + static script-content checks
+ * for body convention + swarm-heartbeat integration point. The actual A2A
+ * message dispatch goes through real `MailboxService` in unit-test mode (writes
+ * to test-isolated Memory Core SQLite) — no mock needed; the lock-file side
+ * effect is the substrate-level assertion.
+ *
+ * Live-host opt-in (#10681 discipline): no live `osascript` dispatch happens
+ * in this script, so `RUN_LIVE_OSASCRIPT=1` opt-in is NOT required for any
+ * test path here. Tests can run with default env safely.
+ */
+test.describe('ai/scripts/idleOutNudge', () => {
+    const scriptPath  = path.resolve(process.cwd(), 'ai/scripts/idleOutNudge.mjs');
+    const testIdentity = '@neo-idle-out-test';
+    const lockPath    = getLockPath('idle_out_nudge', testIdentity);
+
+    let gatePath, overrideEnv, gateOnlyEnv;
+
+    test.beforeEach(async () => {
+        gatePath    = path.join(os.tmpdir(), `wake-gate-idleout-${randomUUID()}.json`);
+        overrideEnv = {...process.env, WAKE_GATE_FILE_PATH: gatePath, WAKE_GATE_OVERRIDE: '1'};
+        gateOnlyEnv = {...process.env, WAKE_GATE_FILE_PATH: gatePath};
+
+        // Clean any pre-existing lock from prior runs
+        if (fs.existsSync(lockPath)) await fsp.unlink(lockPath);
+    });
+
+    test.afterEach(async () => {
+        if (fs.existsSync(lockPath)) await fsp.unlink(lockPath);
+        if (fs.existsSync(gatePath)) await fsp.unlink(gatePath);
+    });
+
+    test('Unknown identity argument missing → exits with usage error', async () => {
+        try {
+            execFileSync('node', [scriptPath], {encoding: 'utf-8', stdio: 'pipe', env: overrideEnv});
+            test.fail('Should have exited with error');
+        } catch (e) {
+            expect(e.status).toBe(1);
+            expect(e.stderr).toContain('Usage: idleOutNudge.mjs <identity>');
+        }
+    });
+
+    test('Wake safety gate tripped → no nudge dispatched, no lock acquired (#10648 defense)', async () => {
+        // Default-tripped state (no gate file → deny-by-default per wakeSafetyGate.mjs).
+        // idleOutNudge MUST skip BEFORE acquiring the lock — defense-in-depth alongside
+        // the swarm-heartbeat.sh shell-side gate check.
+        const result = spawnSync('node', [scriptPath, testIdentity], {
+            encoding: 'utf-8',
+            env     : gateOnlyEnv  // No WAKE_GATE_OVERRIDE — exercises default-tripped path
+        });
+
+        expect(result.status).toBe(0);
+        expect(result.stderr).toContain(`Skipping idle-out nudge for ${testIdentity}`);
+        expect(result.stderr).toContain('Wake safety gate');
+        expect(result.stderr).toContain('WAKE_GATE_OVERRIDE=1');
+        // Side effect: NO lock file should have been created
+        expect(fs.existsSync(lockPath)).toBe(false);
+    });
+
+    test('In-flight lock already held → nudge skipped, lock unchanged (idempotent invariant #10675)', async () => {
+        // Pre-create a lock as if a prior nudge is in-flight. The dispatcher's defensive
+        // checkInflightLock guard MUST detect the lock and exit without touching it.
+        await writeInflightLock(testIdentity, 'idle_out_nudge', 0);
+        const lockBefore = await fsp.readFile(lockPath, 'utf-8');
+
+        const result = spawnSync('node', [scriptPath, testIdentity], {
+            encoding: 'utf-8',
+            env     : overrideEnv  // Gate-override so the early-skip is the lock guard, not the gate
+        });
+
+        expect(result.status).toBe(0);
+        expect(result.stderr).toContain(`Skipping idle-out nudge for ${testIdentity}`);
+        expect(result.stderr).toContain('lock already held');
+        // Idempotent invariant: the existing lock file MUST be byte-identical (not rewritten).
+        const lockAfter = await fsp.readFile(lockPath, 'utf-8');
+        expect(lockAfter).toBe(lockBefore);
+    });
+
+    test('Static script: nudge body convention contains identity + memory-resolved framing (#10675)', async () => {
+        // Per #10675 invariants, the body must communicate to the recipient:
+        // - Why the nudge fired (idle threshold)
+        // - That no action is needed if mid-turn / rate-limited
+        // - That memory-resolved release path clears the lock automatically
+        // - Bounded / non-spawning / in-place framing
+        const scriptContent = fs.readFileSync(scriptPath, 'utf-8');
+
+        expect(scriptContent).toContain('idle threshold');
+        expect(scriptContent).toContain('AGENTS.md §4.2');
+        expect(scriptContent).toContain('memory-resolved');
+        expect(scriptContent).toContain('non-spawning');
+        expect(scriptContent).toContain('in-place');
+        // The dispatcher consumes the inflightLock primitive
+        expect(scriptContent).toContain("writeInflightLock");
+        expect(scriptContent).toContain("checkInflightLock");
+    });
+
+    test('Static script: defense-in-depth — gate check + lock check before send (#10648, #10675)', async () => {
+        // Verify the dispatcher's safety sequence ordering at the source level.
+        // Order MUST be: gate check → lock check → lock acquire → A2A send.
+        // Use the LAST occurrence of each (the actual call site, not the import).
+        const scriptContent = fs.readFileSync(scriptPath, 'utf-8');
+
+        const gateCheckIndex   = scriptContent.lastIndexOf('readGateState()');
+        const lockCheckIndex   = scriptContent.lastIndexOf('checkInflightLock(identity');
+        const lockWriteIndex   = scriptContent.lastIndexOf('writeInflightLock(identity');
+        const messageSendIndex = scriptContent.lastIndexOf('MailboxService.addMessage');
+
+        expect(gateCheckIndex).toBeGreaterThan(-1);
+        expect(lockCheckIndex).toBeGreaterThan(gateCheckIndex);
+        expect(lockWriteIndex).toBeGreaterThan(lockCheckIndex);
+        expect(messageSendIndex).toBeGreaterThan(lockWriteIndex);
+    });
+
+    test('Static script: send-failure path clears the lock to enable retry (#10675)', async () => {
+        // The catch block on MailboxService.addMessage MUST clear the lock so a transient
+        // send error doesn't block retries for the full BOOT_TIMEOUT_MS window.
+        // Verify the relative ordering: send call → catch block → clearInflightLock call.
+        const scriptContent = fs.readFileSync(scriptPath, 'utf-8');
+
+        const sendIndex            = scriptContent.indexOf('MailboxService.addMessage');
+        const catchIndex           = scriptContent.indexOf('catch (err)', sendIndex);
+        const clearLockOnErrorIndex = scriptContent.indexOf("clearInflightLock(identity, 'idle_out_nudge')", catchIndex);
+
+        expect(sendIndex).toBeGreaterThan(-1);
+        expect(catchIndex).toBeGreaterThan(sendIndex);
+        expect(clearLockOnErrorIndex).toBeGreaterThan(catchIndex);
+    });
+
+    test('swarm-heartbeat.sh integration: routes recommended_action=idle_out_nudge to idleOutNudge.mjs (#10675)', async () => {
+        // Verify the consumer integration: swarm-heartbeat.sh MUST detect the
+        // `recommended_action: 'idle_out_nudge'` signal from checkSunsetted's #10689
+        // detector contract and invoke idleOutNudge.mjs. Order: AFTER the sunsetted-fire
+        // path, BEFORE the all-agent-idle path. Defense-in-depth: gate check at shell
+        // level too.
+        const scriptContent = fs.readFileSync(path.resolve(process.cwd(), 'ai/scripts/swarm-heartbeat.sh'), 'utf-8');
+
+        const sunsettedIndex     = scriptContent.indexOf('Phase 1 Recovery Triggered');
+        const idleOutBranchIndex = scriptContent.indexOf('Idle-out nudge triggered');
+        const allAgentIdleIndex  = scriptContent.indexOf('AllAgentIdle detected');
+
+        expect(sunsettedIndex).toBeGreaterThan(-1);
+        expect(idleOutBranchIndex).toBeGreaterThan(sunsettedIndex);   // After sunset path
+        expect(allAgentIdleIndex).toBeGreaterThan(idleOutBranchIndex); // Before all-idle path
+        // Verifies the jq parse + node invocation
+        expect(scriptContent).toContain("'.recommended_action // \"no_action\"'");
+        expect(scriptContent).toContain('idleOutNudge.mjs');
+    });
+});


### PR DESCRIPTION
Resolves #10675

Authored by Claude Opus 4.7 (Claude Code). Session cce1fea5-32ff-410c-b820-2e9a27b3cd51.

Adds `ai/scripts/idleOutNudge.mjs` — per-identity dispatcher consumed by `swarm-heartbeat.sh` when `checkSunsetted.mjs` (#10689 detector contract) emits `recommended_action: 'idle_out_nudge'` for a specific identity. Reuses the A2A messaging path (`MailboxService.addMessage` → `bridge-daemon` keystroke delivery); zero new transport, no fresh-session spawn.

## What changed

3 files, 366 insertions:

| File | Surface |
|---|---|
| `ai/scripts/idleOutNudge.mjs` | NEW — per-identity dispatcher |
| `ai/scripts/swarm-heartbeat.sh` | +26 — routes `recommended_action: 'idle_out_nudge'` to the new dispatcher |
| `test/playwright/unit/ai/scripts/idleOutNudge.spec.mjs` | NEW — 7 tests |

**Distinct from `trioWakeCooldown.mjs`:** trio-wake fires on the swarm-wide `allIdle` signal (ALL configured agents idle simultaneously); this dispatcher fires when ONE identity is stale while the swarm is otherwise active. Both reuse the `inflightLock.mjs` `idle_out_nudge` mode (#10683) but operate independently.

## Invariants per #10675

- **Bounded:** in-flight `idle_out_nudge` lock prevents re-fire within `BOOT_TIMEOUT_MS` (15 min default per `inflightLock.mjs`). One nudge per identity per window — no spam during long deep-thinking turns or rate-limit throttle.
- **Non-spawning:** uses the A2A messaging path. Recipient sees a normal mailbox message that `bridge-daemon` keystroke-injects into their active chat tab. No `Cmd+N` spawn; no new harness session.
- **Idempotent:** lock-acquire is the gate. Detector contract (#10689) consults the lock and downgrades `recommended_action` to `'no_action'` when held; this dispatcher's defensive `checkInflightLock` is layer-2 against the narrow detector-dispatcher race window.
- **No-destructive-type-into-active-draft:** `bridge-daemon`'s existing focus-steal protection (#10422) covers the keystroke delivery; if the recipient is mid-typing, the bridge-daemon defers without clobbering input.

## Safety sequencing

`idleOutNudge.mjs` follows the resumeHarness defense-in-depth pattern:

1. **Wake safety gate** (#10648) check with `WAKE_GATE_OVERRIDE` operator bypass
2. **Memory Core service initialization** (`LifecycleService` + `GraphService`)
3. **Defensive in-flight lock check** (handles detector-dispatcher race window)
4. **Acquire** in-flight `idle_out_nudge` lock
5. **A2A send** via `MailboxService.addMessage`
6. **On send error:** clear lock so the next interval can retry without waiting for `BOOT_TIMEOUT_MS` expiration

`swarm-heartbeat.sh` shell-side gate check (defense-in-depth) skips the Node-process spawn cost when the gate is closed.

## Lock-release path

Lock is **NOT** cleared on dispatcher success. It stays held until `checkSunsetted.mjs` (next heartbeat cycle) observes a fresh `AGENT_MEMORY` post-lock-acquire and clears it ("memory-resolved" release per #10683). If the recipient never saves a memory (rejection / sustained rate-limit), the lock ages out at `BOOT_TIMEOUT_MS` and gets cleared as "abandoned" — `MAX_ABANDONED_ACTIONS` triggers the wake safety gate auto-trip.

## Test Evidence

`npx playwright test test/playwright/unit/ai/scripts/idleOutNudge.spec.mjs` → **7 passed (1.5s)**

Coverage:
- Usage error on missing identity argument
- Wake safety gate tripped → no nudge dispatched, no lock acquired
- In-flight lock already held → nudge skipped, lock unchanged (idempotent invariant)
- Static body-convention check (identity + memory-resolved framing + bounded/non-spawning/in-place language)
- Static defense-in-depth sequence ordering (gate → lock check → lock acquire → A2A send)
- Static send-failure lock-clear path
- `swarm-heartbeat.sh` integration: routes `recommended_action: 'idle_out_nudge'` AFTER sunset-spawn path, BEFORE all-agent-idle path

Downstream regression check: `swarm-heartbeat.spec.mjs` + `checkSunsetted.spec.mjs` + `inflightLock.spec.mjs` → **23 passed**. No regression in any consumer.

## Post-Merge Validation

- [ ] Observe `swarm-heartbeat.sh` correctly fires `idleOutNudge.mjs` in production cron when an identity has active subscription + stale memory
- [ ] Verify the in-flight lock clears on the recipient's first post-nudge `add_memory` (memory-resolved path)
- [ ] When the wake safety gate auto-trip after N consecutive abandoned `idle_out_nudge` actions fires, surface to operator via the existing gate-trip notification path

## Related

- **Parent epic:** #10671 (substrate-restart recovery, two-mode)
- **Builds on:** #10689 (detector contract — emits `recommended_action: 'idle_out_nudge'`), #10683 (in-flight lock primitive — provides `idle_out_nudge` mode), #10641 (staleness ≠ sunset discipline)
- **Sibling dispatchers:** #10676 (sunset-mode restart substrate, pending) for `recommended_action: 'sunset_restart'`; existing `trioWakeCooldown.mjs` for the swarm-wide all-idle signal
- **Adjacent:** #10422 (`bridge-daemon` focus-steal protection — covers keystroke delivery to active drafts)
- **Forensic context:** PR #10688 (`learn/agentos/incidents/2026-05-04-runaway-spawn-pattern.md`)