### PR TITLE
feat(ai): add Codex app-server resume adapter (#10679)

### DIFF
--- a/ai/scripts/resumeHarness.mjs
+++ b/ai/scripts/resumeHarness.mjs
@@ -36,7 +36,9 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
  * BEFORE awaiting close. This captures the PID even if the spawned process is
  * a long-lived interactive harness (Claude Code CLI, Antigravity IDE) whose
  * `close` event never fires within the spawner's lifetime. Recording is best-
- * effort — failures are logged but do not abort the spawn.
+ * effort — failures are logged but do not abort the spawn. The close/error
+ * settlement still waits for the bookkeeping promise, so fast-exiting mock
+ * adapters cannot race process exit before lifecycle state is persisted.
  *
  * @param {string} cmd
  * @param {string[]} args
@@ -46,18 +48,23 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 function spawnAsync(cmd, args, identity = null) {
     return new Promise((resolve, reject) => {
         const proc = spawn(cmd, args, { stdio: 'ignore' });
+        let recordPromise = Promise.resolve();
 
         if (identity && proc.pid) {
-            recordHarnessProcess(identity, proc.pid).catch(err => {
+            recordPromise = recordHarnessProcess(identity, proc.pid).catch(err => {
                 console.warn(`[harnessLifecycle] Failed to record PID for ${identity}: ${err.message}`);
             });
         }
 
         proc.on('close', code => {
-            if (code === 0) resolve();
-            else reject(new Error(`${cmd} exited with code ${code}`));
+            recordPromise.then(() => {
+                if (code === 0) resolve();
+                else reject(new Error(`${cmd} exited with code ${code}`));
+            });
         });
-        proc.on('error', reject);
+        proc.on('error', err => {
+            recordPromise.then(() => reject(err));
+        });
     });
 }
 
@@ -94,6 +101,40 @@ async function resolveClaudeCliPath() {
         return path.join(appSupport, latest, 'claude.app/Contents/MacOS/claude');
     } catch (err) {
         return null;
+    }
+}
+
+/**
+ * @summary Resolve the Codex CLI binary used by the Codex Desktop app-server adapter.
+ *
+ * The default `codex` executable is intentionally overridable for tests via
+ * `CODEX_CLI_PATH`. Specs pair the override with `CODEX_APP_SERVER_MOCK=1`
+ * to capture the command shape without creating a real Codex Desktop thread.
+ *
+ * @returns {string} The Codex CLI command or test override path.
+ */
+function resolveCodexCliPath() {
+    return process.env.CODEX_CLI_PATH || 'codex';
+}
+
+/**
+ * @summary Fail-closed guard for the live Codex Desktop app-server adapter.
+ *
+ * `codex debug app-server send-message-v2` creates/injects into a real Codex
+ * Desktop thread. Per #10679 and #10682, live-host probes must require an
+ * explicit operator opt-in. Unit tests satisfy this guard with
+ * `CODEX_APP_SERVER_MOCK=1` plus `CODEX_CLI_PATH` pointing at a mock
+ * executable, preserving always-on coverage without host side effects.
+ */
+function assertCodexAppServerAllowed() {
+    const hasLiveOptIn = process.env.RUN_LIVE_CODEX_APP_SERVER === '1';
+    const hasMockOptIn = process.env.CODEX_APP_SERVER_MOCK === '1' && Boolean(process.env.CODEX_CLI_PATH);
+
+    if (!hasLiveOptIn && !hasMockOptIn) {
+        throw new Error(
+            'Codex app-server adapter is a live-host action. Set RUN_LIVE_CODEX_APP_SERVER=1 ' +
+            'for an operator-controlled probe, or set CODEX_APP_SERVER_MOCK=1 with CODEX_CLI_PATH in tests.'
+        );
     }
 }
 
@@ -161,8 +202,11 @@ async function resumeHarness(identity, reason, originSessionId, abandonedCount =
     //   process boots a fresh MCP client + fresh `currentSessionId` by construction. This is
     //   precisely what makes harness restart eliminate the spawner-side sessionId management
     //   that #10627's prompt-layer plumbing tried (and failed structurally) to achieve.
-    // Codex Desktop deferred until @neo-gpt confirms its restart primitive (#10679, blocked on
-    //   target-thread MC-startup diagnosis).
+    // 'codex-desktop' utilizes Codex Desktop's app-server debug surface via
+    //   `codex debug app-server send-message-v2` (#10679). This adapter is deliberately
+    //   live-host-gated: normal tests use CODEX_APP_SERVER_MOCK=1 + CODEX_CLI_PATH
+    //   mocks, while real probes require RUN_LIVE_CODEX_APP_SERVER=1 until target-thread
+    //   Memory Core health + first-memory session identity proof has been captured.
     //
     // The legacy `osascript` adapter dispatch (Cmd+N keystroke into running Claude Desktop)
     // is preserved as a fallback for harnesses that may need it; no production identity
@@ -170,12 +214,14 @@ async function resumeHarness(identity, reason, originSessionId, abandonedCount =
     // the historical context.
     const HARNESS_REGISTRY = {
         'antigravity-ide': { adapter: 'antigravity-cli' },
-        'claude-desktop':  { adapter: 'claude-cli' }
+        'claude-desktop':  { adapter: 'claude-cli' },
+        'codex-desktop':   { adapter: 'codex-app-server' }
     };
 
     const identityMap = {
         '@neo-gemini-3-1-pro': 'antigravity-ide',
-        '@neo-opus-4-7': 'claude-desktop'
+        '@neo-gpt'           : 'codex-desktop',
+        '@neo-opus-4-7'      : 'claude-desktop'
     };
 
     const targetId = identityMap[identity];
@@ -194,10 +240,11 @@ async function resumeHarness(identity, reason, originSessionId, abandonedCount =
     // Cross-adapter cleanup: terminate the previous harness process for this identity BEFORE
     // spawning the new one. Sunset-mode restart spawns fresh processes (claude-cli, antigravity-cli);
     // without cleanup, repeated sunsets accumulate stale processes and orphan windows. Applies to
-    // every CLI-spawning adapter; the legacy osascript Cmd+N adapter (which targeted the same app
-    // instance, no leak surface) is exempt. Per #10696 review point 2.
+    // CLI-spawning adapters; the legacy osascript Cmd+N adapter (which targeted the same app
+    // instance, no leak surface) and Codex app-server adapter (which creates/injects a thread
+    // through the already-running Codex Desktop app-server) are exempt. Per #10696 review point 2.
     // Explicitly scoped to 'sunset_restart' ONLY per @tobiu mandate.
-    if (reason === 'sunset_restart' && adapter !== 'osascript' && adapter !== 'tmux') {
+    if (reason === 'sunset_restart' && adapter !== 'codex-app-server' && adapter !== 'osascript' && adapter !== 'tmux') {
         const cleanup = await terminatePreviousHarness(identity);
         if (cleanup.terminated) {
             const escalation = cleanup.escalated ? `, escalated to ${cleanup.escalated}` : '';
@@ -253,6 +300,27 @@ async function resumeHarness(identity, reason, originSessionId, abandonedCount =
             const args = [payload];
             await spawnAsync(cliPath, args, identity);
             console.log(`Successfully resumed ${identity} via claude-cli`);
+        } else if (adapter === 'codex-app-server') {
+            /**
+             * @anchor codex-app-server-live-host-gate
+             * @summary Codex Desktop app-server thread injection via `send-message-v2`.
+             *
+             * `send-message-v2` is a prompt-injection primitive, not yet a complete
+             * recovery proof. The earlier #10679 probe showed it can create a fresh
+             * Codex Desktop thread and deliver the prompt, but target-thread Memory
+             * Core startup failed. Until a live proof captures healthy post-spawn
+             * Memory Core plus a first `add_memory` sessionId change, the adapter
+             * remains fail-closed for real hosts via `RUN_LIVE_CODEX_APP_SERVER=1`.
+             *
+             * Tests use `CODEX_APP_SERVER_MOCK=1` plus `CODEX_CLI_PATH` to point at a
+             * mock executable, verifying the command shape without creating real Codex
+             * threads.
+             */
+            assertCodexAppServerAllowed();
+            const cliPath = resolveCodexCliPath();
+            const args = ['debug', 'app-server', 'send-message-v2', payload];
+            await spawnAsync(cliPath, args);
+            console.log(`Successfully resumed ${identity} via codex-app-server`);
         } else if (adapter === 'osascript') {
             const { appName, tabShortcut, freshSessionShortcut } = harnessTarget;
             // Q1b fresh-session-spawn flow per #10611:

--- a/test/playwright/unit/ai/scripts/resumeHarness.spec.mjs
+++ b/test/playwright/unit/ai/scripts/resumeHarness.spec.mjs
@@ -21,6 +21,8 @@ import path                      from 'path';
 import fs                        from 'fs';
 
 test.describe('ai/scripts/resumeHarness', () => {
+    test.describe.configure({mode: 'serial'});
+
     const scriptPath = path.resolve(process.cwd(), 'ai/scripts/resumeHarness.mjs');
     const cooldownDir = path.resolve(process.cwd(), '.neo-ai-data/wake-daemon');
 
@@ -49,6 +51,11 @@ test.describe('ai/scripts/resumeHarness', () => {
      * architecture for safe live-substrate testing is `bridge-daemon.spec.mjs`,
      * which uses either the `test` adapter (test stream delivery) or a mock
      * `osascript` binary on PATH that captures argv without executing AppleScript.
+     *
+     * Codex live-host opt-in (#10679): `codex debug app-server send-message-v2`
+     * creates/injects into a real Codex Desktop thread. Default tests MUST use
+     * `CODEX_APP_SERVER_MOCK=1` plus a `CODEX_CLI_PATH` mock. Real probes require
+     * `RUN_LIVE_CODEX_APP_SERVER=1`.
      */
     let gatePath, overrideEnv;
     const gateOnlyEnv = () => ({...process.env, WAKE_GATE_FILE_PATH: gatePath});
@@ -94,7 +101,7 @@ test.describe('ai/scripts/resumeHarness', () => {
         // management plumbing #10627's prompt-layer attempt failed to achieve structurally.
         const scriptContent = fs.readFileSync(scriptPath, 'utf-8');
         expect(scriptContent).toContain("'claude-desktop':  { adapter: 'claude-cli' }");
-        expect(scriptContent).toContain("'@neo-opus-4-7': 'claude-desktop'");
+        expect(scriptContent).toContain("'@neo-opus-4-7'      : 'claude-desktop'");
     });
 
     test('Opus identity osascript runtime dispatch (live host — RUN_LIVE_OSASCRIPT=1 required, #10681)', async () => {
@@ -176,15 +183,17 @@ test.describe('ai/scripts/resumeHarness', () => {
         expect(stderrAndStdout).not.toContain('Wake safety gate disabled');
     });
 
-    test('Q1b fresh-session-spawn: HARNESS_REGISTRY entries route to native-CLI adapters (#10611 PR-B AC1, #10677, #10678)', async () => {
-        // Both Antigravity and Claude Desktop now route to native-CLI adapters that bypass
+    test('Q1b fresh-session-spawn: HARNESS_REGISTRY entries route to safe adapters (#10611 PR-B AC1, #10677, #10678, #10679)', async () => {
+        // Antigravity and Claude Desktop now route to native-CLI adapters that bypass
         // the legacy Cmd+N osascript path. Antigravity uses `antigravity chat -n` (#10678 / #10680);
-        // Claude Desktop uses the embedded Claude Code CLI's `--session-id <uuid>` primitive (#10677).
-        // The substrate-correct primitives enforce fresh-sessionId at the harness layer rather than
-        // via the rejected prompt-layer plumbing of #10627.
+        // Claude Desktop uses the embedded Claude Code CLI with NO sessionId flag (#10677);
+        // Codex Desktop uses the live-host-gated app-server adapter (#10679). The substrate-correct
+        // primitives avoid the rejected prompt-layer plumbing of #10627.
         const scriptContent = fs.readFileSync(scriptPath, 'utf-8');
         expect(scriptContent).toContain("'antigravity-ide': { adapter: 'antigravity-cli' }");
         expect(scriptContent).toContain("'claude-desktop':  { adapter: 'claude-cli' }");
+        expect(scriptContent).toContain("'codex-desktop':   { adapter: 'codex-app-server' }");
+        expect(scriptContent).toContain("'@neo-gpt'           : 'codex-desktop'");
     });
 
     test('Q1b fresh-session-spawn: osascript flow injects freshSessionShortcut keystroke before paste (#10611 PR-B AC1)', async () => {
@@ -321,6 +330,52 @@ test.describe('ai/scripts/resumeHarness', () => {
             expect(args[1]).toBe('-n');
             expect(args[2]).toContain('@AGENTS_STARTUP.md');
             expect(args[2]).toContain('testReason');
+        } finally {
+            if (fs.existsSync(mockPath)) fs.unlinkSync(mockPath);
+            if (fs.existsSync(outPath)) fs.unlinkSync(outPath);
+        }
+    });
+
+    test('Codex app-server: default live-host path fails closed without opt-in or mock (#10679)', async () => {
+        test.skip(process.platform !== 'darwin', 'Codex Desktop app-server adapter is currently mac-specific');
+
+        const { getLockPath } = await import('../../../../../ai/scripts/inflightLock.mjs');
+        const lockPath = getLockPath('sunset_restart', '@neo-gpt');
+        if (fs.existsSync(lockPath)) fs.unlinkSync(lockPath);
+
+        try {
+            execFileSync('node', [scriptPath, '@neo-gpt', 'testReason'], {encoding: 'utf-8', stdio: 'pipe', env: overrideEnv});
+            test.fail('Should have exited with error');
+        } catch (e) {
+            expect(e.status).toBe(1);
+            expect(e.stderr).toContain('Failed to resume @neo-gpt via codex-app-server');
+            expect(e.stderr).toContain('RUN_LIVE_CODEX_APP_SERVER=1');
+
+            // The adapter writes the inflight lock before action, then clears it on fail-closed exit.
+            expect(fs.existsSync(lockPath)).toBe(false);
+        } finally {
+            if (fs.existsSync(lockPath)) fs.unlinkSync(lockPath);
+        }
+    });
+
+    test('Codex app-server: adapter executes send-message-v2 <payload> via CODEX_CLI_PATH mock (#10679)', async () => {
+        test.skip(process.platform !== 'darwin', 'Codex Desktop app-server adapter is currently mac-specific');
+
+        const mockPath = path.join(os.tmpdir(), `mock-codex-${randomUUID()}`);
+        const outPath = path.join(os.tmpdir(), `out-codex-${randomUUID()}`);
+        fs.writeFileSync(mockPath, `#!/usr/bin/env node\nconst fs = require('fs');\nfs.writeFileSync('${outPath}', JSON.stringify(process.argv.slice(2)));\n`, { mode: 0o755 });
+
+        try {
+            const env = { ...overrideEnv, CODEX_APP_SERVER_MOCK: '1', CODEX_CLI_PATH: mockPath };
+            execFileSync('node', [scriptPath, '@neo-gpt', 'testReason'], { encoding: 'utf-8', stdio: 'pipe', env });
+
+            expect(fs.existsSync(outPath)).toBe(true);
+            const args = JSON.parse(fs.readFileSync(outPath, 'utf-8'));
+            expect(args[0]).toBe('debug');
+            expect(args[1]).toBe('app-server');
+            expect(args[2]).toBe('send-message-v2');
+            expect(args[3]).toContain('@AGENTS_STARTUP.md');
+            expect(args[3]).toContain('testReason');
         } finally {
             if (fs.existsSync(mockPath)) fs.unlinkSync(mockPath);
             if (fs.existsSync(outPath)) fs.unlinkSync(outPath);


### PR DESCRIPTION
Resolves #10679

Related: #10671

Authored by GPT-5 (Codex Desktop). Session 2821a9d4-7634-4fe7-a8a2-daf49253b929.

Adds `@neo-gpt` to `resumeHarness.mjs` via a `codex-desktop` adapter that dispatches `codex debug app-server send-message-v2 <boot-grounding-payload>` with a fail-closed live-host guard. The default path refuses real Codex Desktop host injection unless `RUN_LIVE_CODEX_APP_SERVER=1`; unit coverage uses `CODEX_APP_SERVER_MOCK=1` plus `CODEX_CLI_PATH` to verify command shape without creating real threads. The branch also serializes the shared-state `resumeHarness` spec and waits for PID bookkeeping before fast-exiting mock adapters settle, removing an existing lifecycle race exposed by the targeted test run.

Evidence: L2 (static registry + mocked CLI dispatch + fail-closed guard unit coverage) → L4 required (operator-controlled live Codex Desktop target-thread Memory Core health + first add_memory sessionId proof). Residual: live proof remains gated by RUN_LIVE_CODEX_APP_SERVER=1 for operator run.

## Deltas from ticket
- Keeps `send-message-v2` as an adapter candidate, not a full recovery proof, until target-thread Memory Core and session identity evidence exists.
- Tightens the test bypass so `CODEX_CLI_PATH` alone cannot authorize live-host dispatch.
- Fixes shared-state lifecycle test flakiness by serializing the spec and waiting for best-effort PID state persistence before process settlement.

## Test Evidence
- `node --check ai/scripts/resumeHarness.mjs`
- `node --check test/playwright/unit/ai/scripts/resumeHarness.spec.mjs`
- `git diff --check`
- `git diff --check origin/dev...HEAD`
- `npm run test-unit -- test/playwright/unit/ai/scripts/resumeHarness.spec.mjs` → 17 passed, 2 skipped (live-host gated)

## Post-Merge Validation
- [ ] With operator approval, run `RUN_LIVE_CODEX_APP_SERVER=1 node ai/scripts/resumeHarness.mjs @neo-gpt sunset_restart <originSessionId>` in Codex Desktop and capture target-thread Memory Core health plus first `add_memory` sessionId.

## Commit
- `7b2d89922` — `feat(ai): add Codex app-server resume adapter (#10679)`