### PR TITLE
feat(ai): suppress self-wakes for AGENT:* broadcasts (#10668)

### DIFF
--- a/ai/scripts/bridge-daemon.mjs
+++ b/ai/scripts/bridge-daemon.mjs
@@ -316,6 +316,16 @@ function evaluateSubscription(sub, trace, entity, nodesMap, edgesMap) {
             if (messageNode && messageNode.label === 'MESSAGE') {
                 if (messageNode.properties?.wakeSuppressed) return null;
 
+                // Suppress same-sender broadcast wakes (#10668). The sender already has the
+                // broadcast in active context, so wake-as-interrupt carries no new information
+                // and inflates unread/no-op load during coordination loops. Audit/outbox
+                // visibility is preserved by MailboxService listings — this gates wake
+                // delivery only, not graph storage. Direct self-DMs (target === agentIdentity
+                // AND from === agentIdentity) remain delivered for deliberate self-handoff flows.
+                if (entity.target === 'AGENT:*' && messageNode.properties?.from === agentIdentity) {
+                    return null;
+                }
+
                 // Apply filters
                 if (filters.priority && messageNode.properties?.priority !== filters.priority) return null;
                 if (filters.senderFilter && !filters.senderFilter.includes(messageNode.properties?.from)) return null;

--- a/test/playwright/unit/ai/scripts/bridge-daemon.spec.mjs
+++ b/test/playwright/unit/ai/scripts/bridge-daemon.spec.mjs
@@ -914,4 +914,149 @@ test.describe('Bridge Daemon', () => {
         expect(paramsLength).toEqual([SQLITE_IN_CLAUSE_BATCH_SIZE, overflowAmount]);
         expect(edgeResults.length).toBe(totalItems);
     });
+
+    test('suppresses wake for sender of AGENT:* broadcast and delivers to peers (#10668)', async () => {
+        const senderId    = '@test-agent-sender';
+        const peerId      = '@test-agent-peer';
+        const senderSubId = 'sub_' + crypto.randomUUID();
+        const peerSubId   = 'sub_' + crypto.randomUUID();
+
+        // Two agents subscribed to the same bridge-daemon test adapter — the broadcast
+        // sender and a peer receiver. The fix's contract is: sender's own broadcast
+        // does NOT wake them, but the peer's wake delivery is unaffected.
+        for (const [agentId, subId] of [[senderId, senderSubId], [peerId, peerSubId]]) {
+            db.prepare('INSERT OR REPLACE INTO Nodes (id, data) VALUES (?, ?)').run(agentId, JSON.stringify({
+                id        : agentId,
+                label     : 'AGENT',
+                properties: {name: agentId}
+            }));
+            db.prepare('INSERT OR REPLACE INTO Nodes (id, data) VALUES (?, ?)').run(subId, JSON.stringify({
+                id        : subId,
+                label     : 'WAKE_SUBSCRIPTION',
+                properties: {
+                    agentIdentity        : agentId,
+                    harnessTarget        : 'bridge-daemon',
+                    status               : 'active',
+                    trigger              : 'SENT_TO_ME',
+                    harnessTargetMetadata: {adapter: 'test', coalesceWindow: 1}
+                }
+            }));
+            db.prepare('INSERT INTO GraphLog (entity_id, entity_type) VALUES (?, ?)').run(subId, 'nodes');
+        }
+
+        daemonProcess = spawn('node', ['ai/scripts/bridge-daemon.mjs'], {
+            stdio: 'pipe',
+            env  : {...process.env, NEO_AI_DB_PATH: DB_PATH, NEO_AI_DAEMON_DIR: DAEMON_DIR}
+        });
+
+        let senderDeliveryCount = 0;
+        let peerDeliveryCount   = 0;
+        daemonProcess.stdout.on('data', (data) => {
+            const out = data.toString();
+            if (out.includes(`[Bridge Daemon Test Adapter] Delivered ${senderSubId}`)) senderDeliveryCount++;
+            if (out.includes(`[Bridge Daemon Test Adapter] Delivered ${peerSubId}`))   peerDeliveryCount++;
+        });
+
+        await new Promise(resolve => setTimeout(resolve, 1000));
+
+        // Sender broadcasts to AGENT:*: from === senderId, edge target === 'AGENT:*'.
+        const msgId = 'msg_' + crypto.randomUUID();
+        db.prepare('INSERT INTO Nodes (id, data) VALUES (?, ?)').run(msgId, JSON.stringify({
+            id        : msgId,
+            label     : 'MESSAGE',
+            properties: {
+                from   : senderId,
+                to     : 'AGENT:*',
+                subject: 'Cross-family broadcast'
+            }
+        }));
+        db.prepare('INSERT INTO GraphLog (entity_id, entity_type) VALUES (?, ?)').run(msgId, 'nodes');
+
+        const edgeId = 'edge_' + crypto.randomUUID();
+        db.prepare('INSERT INTO Edges (id, data, source, target, type) VALUES (?, ?, ?, ?, ?)').run(edgeId, JSON.stringify({
+            id    : edgeId,
+            source: msgId,
+            target: 'AGENT:*',
+            type  : 'SENT_TO'
+        }), msgId, 'AGENT:*', 'SENT_TO');
+        db.prepare('INSERT INTO GraphLog (entity_id, entity_type) VALUES (?, ?)').run(edgeId, 'edges');
+
+        // Coalesce window 1s + safety margin matches the wakeSuppressed-test pattern.
+        await new Promise(resolve => setTimeout(resolve, 5500));
+
+        // Same-sender broadcast must NOT wake the sender (the #10668 bug).
+        expect(senderDeliveryCount).toBe(0);
+        // Cross-sender broadcast must still wake the peer (preserves broadcast value).
+        expect(peerDeliveryCount).toBe(1);
+    });
+
+    test('preserves wake delivery for direct self-DM addressed to self (#10668)', async () => {
+        // The #10668 fix gates on `entity.target === 'AGENT:*'` to suppress only broadcast
+        // self-fanout. Direct self-DMs (target === agentIdentity AND from === agentIdentity)
+        // remain delivered for deliberate self-handoff flows like sunset protocol DMs.
+        const subId   = 'sub_' + crypto.randomUUID();
+        const agentId = '@test-agent-self-dm';
+
+        db.prepare('INSERT OR REPLACE INTO Nodes (id, data) VALUES (?, ?)').run(agentId, JSON.stringify({
+            id        : agentId,
+            label     : 'AGENT',
+            properties: {name: agentId}
+        }));
+        db.prepare('INSERT OR REPLACE INTO Nodes (id, data) VALUES (?, ?)').run(subId, JSON.stringify({
+            id        : subId,
+            label     : 'WAKE_SUBSCRIPTION',
+            properties: {
+                agentIdentity        : agentId,
+                harnessTarget        : 'bridge-daemon',
+                status               : 'active',
+                trigger              : 'SENT_TO_ME',
+                harnessTargetMetadata: {adapter: 'test', coalesceWindow: 1}
+            }
+        }));
+        db.prepare('INSERT INTO GraphLog (entity_id, entity_type) VALUES (?, ?)').run(subId, 'nodes');
+
+        daemonProcess = spawn('node', ['ai/scripts/bridge-daemon.mjs'], {
+            stdio: 'pipe',
+            env  : {...process.env, NEO_AI_DB_PATH: DB_PATH, NEO_AI_DAEMON_DIR: DAEMON_DIR}
+        });
+
+        const deliveryPromise = new Promise((resolve, reject) => {
+            const timeout = setTimeout(() => reject(new Error('Daemon failed to deliver self-DM wake within timeout')), 10000);
+            daemonProcess.stdout.on('data', (data) => {
+                const out = data.toString();
+                if (out.includes(`[Bridge Daemon Test Adapter] Delivered ${subId}`)) {
+                    clearTimeout(timeout);
+                    resolve(out);
+                }
+            });
+            daemonProcess.on('error', reject);
+        });
+
+        await new Promise(resolve => setTimeout(resolve, 1000));
+
+        // Direct self-DM: from === agentId AND target === agentId (NOT AGENT:*).
+        const msgId = 'msg_' + crypto.randomUUID();
+        db.prepare('INSERT INTO Nodes (id, data) VALUES (?, ?)').run(msgId, JSON.stringify({
+            id        : msgId,
+            label     : 'MESSAGE',
+            properties: {
+                from   : agentId,
+                to     : agentId,
+                subject: 'Deliberate self-handoff'
+            }
+        }));
+        db.prepare('INSERT INTO GraphLog (entity_id, entity_type) VALUES (?, ?)').run(msgId, 'nodes');
+
+        const edgeId = 'edge_' + crypto.randomUUID();
+        db.prepare('INSERT INTO Edges (id, data, source, target, type) VALUES (?, ?, ?, ?, ?)').run(edgeId, JSON.stringify({
+            id    : edgeId,
+            source: msgId,
+            target: agentId,
+            type  : 'SENT_TO'
+        }), msgId, agentId, 'SENT_TO');
+        db.prepare('INSERT INTO GraphLog (entity_id, entity_type) VALUES (?, ?)').run(edgeId, 'edges');
+
+        const output = await deliveryPromise;
+        expect(output).toContain('Deliberate self-handoff');
+    });
 });


### PR DESCRIPTION
Resolves #10668

Authored by Claude Opus 4.7 (Claude Code). Session `7e52099b-9632-4c67-a2a1-4e1a1ad1c414`.

Suppresses wake delivery to the sender of an `AGENT:*` broadcast. The sender already has the broadcast in active context, so wake-as-interrupt carries no new information; the previous default fired self-wakes and inflated unread/no-op load during coordination loops (empirically reproduced this session during the #10703 graduation thread).

The fix gates strictly on broadcast targets: when `entity.target === 'AGENT:*'` AND `messageNode.properties.from === agentIdentity`, the wake is suppressed. Audit/outbox visibility is preserved by `MailboxService` listings (separate concern; not touched). Direct self-DMs (target === agentIdentity AND from === agentIdentity) remain delivered for deliberate self-handoff flows like sunset protocol DMs.

Evidence: L2 (real `bridge-daemon.mjs` subprocess + test adapter dispatch on synthetic SQLite, 3/3 stable runs at ~11.2s each) → L2 required (all decision-logic ACs are runtime evaluation contract). AC3 (sender outbox visibility) is L1 — verified by fix-scope inspection that `MailboxService` is not touched. No L4 residuals.

## Implementation

Single-conditional addition in `bridge-daemon.mjs:evaluateSubscription()` after the existing `wakeSuppressed` early-return — same shape, same insertion point. The `messageNode.properties.from` check matches `MailboxService`'s canonical write contract (verified at `MailboxService.mjs:213,411,492`).

`WakeSubscriptionService._evaluateEdgeAgainstSubscription()` was inspected and intentionally not modified — it strictly checks `edge.target === owner`, so broadcast wakes don't flow through the Shape A MCP-notifications path. Single-location fix.

## Test Evidence

`test/playwright/unit/ai/scripts/bridge-daemon.spec.mjs` adds two regression tests:

- **`suppresses wake for sender of AGENT:* broadcast and delivers to peers (#10668)`** — two agents, two subscriptions; sender broadcasts; asserts `senderDeliveryCount === 0` AND `peerDeliveryCount === 1`. Covers AC1 (sender suppression) + AC2 (cross-sender delivery) + AC5 (regression coverage) in one assertion pair.
- **`preserves wake delivery for direct self-DM addressed to self (#10668)`** — single agent self-DMs (target === agentId, NOT AGENT:*); asserts wake is delivered. Covers AC4 (deliberate self-handoff flows preserved).

3 consecutive runs of the full spec passed at ~11.2s each (12/12 tests, no regressions on existing 10).

## Out of Scope

- No opt-in `wakeSelf` / `includeSender` flag added — the ticket marks it "only if needed"; current consumers (sender already has broadcast in context) have no need. Trivially additive in a follow-up if required.
- `WakeSubscriptionService.mjs` not modified — broadcast wakes don't flow through Shape A MCP-notifications by design.
- `MailboxService.mjs` not modified — audit/outbox listing is a separate concern preserved by ticket scope.

## Related

- Predecessor empirical anchor: 2026-05-03 #10666 cleanup lane (originally surfaced by @neo-gpt) + 2026-05-04 #10703 graduation thread (re-surfaced this session).
- Adjacent: #10174 (broadcast sentinel seeding) and #10179 (broadcast reachability) — both intentionally out of scope per ticket.