### PR TITLE
docs(agents): soften §9 corruption framing for frontier-context models (#10083)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -225,15 +225,14 @@ During continuous agent sessions, any interrupting user prompt or A2A message ca
 **The Mandate:**
 After any user prompt or A2A message reaches the agent during an active ticket lifecycle, resume that lifecycle and check the PR Definition of Done before halting. Ask: *"Did this interruption distract me from opening the Pull Request?"*
 
-## 9. Preventing Context Corruption (State Management)
+## 9. Reading Modified Files Efficiently (State Management)
 
-Working on the Neo platform requires long, complex sessions. To prevent your context window from becoming corrupted with multiple competing versions of the same file after several edits, you MUST adhere to this protocol:
+Working on the Neo platform requires long, complex sessions. When you've modified a file multiple times and need to verify its current state, use the cheapest authoritative source rather than a full re-read. The discipline is *efficiency-first* — universal across models — with an additional correctness consideration on smaller-context harnesses:
 
-1. **The Single Full-Read Rule:** You should generally only perform a full `read_file` on a specific file *once* per session to establish your baseline understanding.
-2. **Never Re-Read Modified Files:** If you have modified a file multiple times using `replace` and lose track of its exact current state, **DO NOT** perform a full `read_file` to refresh your memory. This causes catastrophic context corruption by introducing competing realities.
-3. **Use `git diff` for Reconciliation:** If you are unsure of the current state of a file you have modified, use `run_shell_command` with `git diff HEAD <file_path>` (or `--staged`). This provides the exact delta without polluting the context with duplicate code.
-4. **Use `grep_search` for Method Verification:** If you need to verify the current state of a specific method after changes, use `grep_search` with the `context` parameter to surgically extract only that method.
-5. **No Shell Fallbacks:** You are strictly forbidden from using `cat` or `grep` via `run_shell_command` to read files. Always use the native `read_file` or `grep_search` tools.
+1. **The Single Full-Read Rule (Efficiency-First):** Prefer `git diff` or surgical `grep_search` with context over a full re-read when verifying the state of a file you've modified. Full re-reads after several edits are wasteful when a delta is available. On smaller-context models, they additionally risk "competing realities" confusion when multiple file versions live in the window; on larger-context models the cost is wasted attention rather than correctness — the efficiency case holds regardless.
+2. **Use `git diff` for Reconciliation:** If you are unsure of the current state of a file you have modified, use `run_shell_command` with `git diff HEAD <file_path>` (or `--staged`). This provides the exact delta without polluting the context with duplicate code.
+3. **Use `grep_search` for Method Verification:** If you need to verify the current state of a specific method after changes, use `grep_search` with the `context` parameter to surgically extract only that method.
+4. **No Shell Fallbacks:** You are strictly forbidden from using `cat` or `grep` via `run_shell_command` to read files. Always use the native `read_file` or `grep_search` tools.
 
 ## 10. Testing and Validation Protocol
 


### PR DESCRIPTION
Resolves #10083

Authored by Claude Opus 4.7 (Claude Code). Session \`7e52099b-9632-4c67-a2a1-4e1a1ad1c414\`.

Reframes \`AGENTS.md §9\` from \"Preventing Context Corruption\" to \"Reading Modified Files Efficiently\" per the ticket's Option A direction. The efficiency discipline (prefer \`git diff\` / \`grep_search\` over full re-reads) was correct under both context-scarcity-era and frontier-context-era assumptions; the \"catastrophic context corruption\" framing was scarcity-era thinking that overstated correctness risk for frontier models (Opus 4.7 1M, Sonnet 4.6, Gemini 3.1 Pro empirically disambiguate multiple file versions by context ordering).

Evidence: L1 (static doc-prose change; AGENTS.md §9 framing only, no behavioral contract change for any swarm-discipline rule) → L1 required (no runtime-verify ACs). No residuals.

## What changed

- **Heading reframed:** \"Preventing Context Corruption (State Management)\" → \"Reading Modified Files Efficiently (State Management)\".
- **Intro reframed:** \"To prevent your context window from becoming corrupted...\" → \"use the cheapest authoritative source rather than a full re-read. The discipline is *efficiency-first* — universal across models — with an additional correctness consideration on smaller-context harnesses.\"
- **Rules 1+2 of original combined** into a single \"Single Full-Read Rule (Efficiency-First)\" that:
  - Frames efficiency as the universal motivation.
  - Notes the additional \"competing realities\" correctness risk on smaller-context models *without naming specific model versions* (per Option A's lean — capability-aware framing without naming specific models that age with the lineup).
  - Removes \"catastrophic\" language; on larger-context models the cost is \"wasted attention rather than correctness.\"
- **Rules 3-5 (renumbered to 2-4)** preserved verbatim: \`git diff\` for Reconciliation, \`grep_search\` for Method Verification, No Shell Fallbacks. Per AC3, those remain universally correct.

## AC coverage

- [x] AC1: efficiency discipline (preserved, universal) separated from corruption framing (softened, capability-aware) — see intro paragraph + new rule 1 wording.
- [x] AC2: \"catastrophic context corruption\" removed; \"competing realities\" scoped to smaller-context models with an explicit larger-context counterpart noting wasted-attention-not-correctness.
- [x] AC3: rules \`git diff\` / \`grep_search\` / No Shell Fallbacks not touched (renumbered only).
- [ ] AC4: cross-reference in durable feedback memory chain — handled post-PR via memory file update (harness-private substrate, not part of the PR diff per AGENTS.md §11 Substrate Awareness).

## Contract Ledger

| Target Surface | Source of Authority | Proposed Behavior | Fallback / Edge Case | Docs | Evidence |
|---|---|---|---|---|---|
| AGENTS.md §9 framing | Issue #10083 + @tobiu's challenge note (2026-04-19) | Reframe corruption-prevention → efficiency-first; capability-aware language | Action contract preserved (rules 2-4 verbatim); no agent behavior change | Yes (this is the doc) | Before/after diff inspection |

Trigger fit per \`contract-ledger.md\`: borderline — swarm-discipline doc with framing change but no observable action-contract change. Including a minimal matrix to satisfy the gate without bloat. Tier elevation: T1 → T3 (the rule was implicit; now it's an Explicit Matrix-backed contract).

## Out of Scope

- Other AGENTS.md rules (25-turn guardrail, §0 Critical Gates, etc.) — audited in #10083's surfacing session and confirmed still-correct across model eras.
- Per-skill context-budget guidance (e.g., \`neural-link/operational-handbook.md\` depth limits) — those are API-response-size pragmatic defaults, not context-era rules.
- Compression of AGENTS.md as a whole — separate strategic concern (#10537 family + future epic).

## Avoided Traps

- **Rejected: Option B (named-model split).** Per ticket lean — naming specific model versions (Opus 4.7, Sonnet 4.6, Gemini 3.1 Pro) ages poorly with the lineup. Option A's capability-aware framing without specific model names is durable.
- **Rejected: blanket relaxation.** Smaller-context harnesses (e.g., \`gemma4-31b\` via MLX per AGENTS_STARTUP.md §7) genuinely benefit from strict re-read avoidance. The fix retains the discipline; it just stops overstating the severity for larger-context models.
- **Rejected: rule deletion.** The action contract is correct on all model tiers; only the framing was scarcity-era. Deleting the rule would lose the genuine efficiency discipline.

## Test Evidence

This is a doc-only change to AGENTS.md prose. No tests required; no code paths change. Verified via \`git diff AGENTS.md\` — 1 file changed, 6 insertions, 7 deletions, all within §9.

## Related

- Originating issue: #10083
- Strategic context: compression / context-budget work prioritized after #10691 production lifecycle (current session direction per @tobiu).
- Adjacent compression epic: #10537 (Map vs World Atlas / pr-review modularization) — different surface (skill content vs AGENTS.md), same family.
- Predecessor compression pass: #10511 (CLOSED) — AGENTS.md compaction.