### PR TITLE
feat(codex): route reference notes through scoped config (#10715)

### DIFF
--- a/.codex/CODEX.md
+++ b/.codex/CODEX.md
@@ -1,17 +1,29 @@
 # Codex Desktop Reference
 
-This file is intentionally **not** the auto-loaded instruction source while the
-repository root contains `AGENTS.md`. Codex project-doc discovery loads at most
+This is the human-readable source for Codex-only operational diagnostics in the
+Neo.mjs repo. It is **not** auto-loaded through project-doc fallback while the
+repository root contains `AGENTS.md`: Codex project-doc discovery loads at most
 one instruction file per directory, so root `AGENTS.md` wins before configured
 fallback files such as `.codex/CODEX.md`.
 
-The deterministic Codex Desktop notes live in `AGENTS.md §0.1`. Keep this file
-in sync as a small reference for humans and setup checks.
+Normal repo-root Codex turns receive this file through the trusted project-local
+`UserPromptSubmit` hook in `.codex/hooks.json`. The hook emits this file as
+developer context, keeping `.codex/config.toml` ignored and customizable.
 
-You are Codex, running on **GPT 5.5**.
-Your GitHub username is `neo-gpt`.
-You can communicate via the `add_message` tool with:
-* Claude Opus 4.7 => `neo-opus-4-7`
-* Gemini => `neo-gemini-3-1-pro`
+Do not hard-code the active model here. Model identity is turn/runtime metadata
+and can drift independently of the Codex Desktop harness.
 
-`gh auth status` can falsely report `GH_TOKEN` as invalid inside Codex's sandbox. Verify GitHub auth with `gh api user --jq .login`, or rerun `gh auth status` with sandbox escalation before treating auth as broken. Expected Codex identity: `neo-gpt`.
+## Runtime Notes
+
+- GitHub username: `neo-gpt`.
+- A2A peers: Claude Opus 4.7 at `neo-opus-4-7`; Gemini at
+  `neo-gemini-3-1-pro`.
+- `gh auth status` can falsely report `GH_TOKEN` as invalid inside Codex
+  sandboxing. Verify identity with `gh api user --jq .login` before treating
+  auth as broken. Expected Codex identity: `neo-gpt`.
+- `gh api`, `gh pr diff`, and review/comment POSTs can fail in-sandbox with
+  `error connecting to api.github.com`. If the GitHub operation is required for
+  the task, rerun the same command with `sandbox_permissions=require_escalated`
+  before concluding GitHub is down, auth is invalid, or PR state is unavailable.
+- For state-changing GitHub calls, preserve the exact payload when retrying
+  escalated so the sandbox retry does not mutate review/comment semantics.

--- a/.codex/config.template.toml
+++ b/.codex/config.template.toml
@@ -5,7 +5,9 @@
 # Codex project-doc discovery loads at most one instruction file per directory:
 # AGENTS.override.md, then AGENTS.md, then configured fallbacks. Since the repo
 # root owns AGENTS.md, .codex/CODEX.md is a reference file, not an auto-loaded
-# fallback. Keep Codex-specific mandatory notes in root AGENTS.md.
+# fallback. Trusted Codex projects inject .codex/CODEX.md through
+# .codex/hooks.json, keeping this customizable config file out of the runtime
+# note source-of-truth path.
 project_doc_max_bytes = 131072
 
 # Neo.mjs marathon sessions routinely exceed Codex's conservative default effective
@@ -74,3 +76,6 @@ env_vars = ["NEO_AGENT_IDENTITY"]
 startup_timeout_sec = 30
 tool_timeout_sec = 120
 enabled = true
+
+[features]
+codex_hooks = true

--- a/.codex/hooks.json
+++ b/.codex/hooks.json
@@ -1,0 +1,16 @@
+{
+  "hooks": {
+    "UserPromptSubmit": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "/usr/bin/env node \"$(git rev-parse --show-toplevel)/.codex/hooks/codex-context.mjs\"",
+            "timeout": 10,
+            "statusMessage": "Loading Codex context"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.codex/hooks/codex-context.mjs
+++ b/.codex/hooks/codex-context.mjs
@@ -1,0 +1,8 @@
+import {readFileSync} from 'node:fs';
+
+const contextUrl = new URL('../CODEX.md', import.meta.url);
+const context    = readFileSync(contextUrl, 'utf8').trim();
+
+if (context) {
+    process.stdout.write(`${context}\n`);
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,15 +13,16 @@ These five rules are mechanically verifiable and have **no conditional exception
 4. **No `<noreply@*>` `Co-Authored-By` footers.** Override the harness default if it injects them. See `.agents/skills/pull-request/references/pull-request-workflow.md` §3.2.
 5. **No skipping `add_memory` at end of turn.** Forgetting the consolidated save = permanent data loss. The save IS the gate that permits the response. See §4.2.
 
-## 0.1. Codex Desktop Harness Notes
+## 0.1. Harness-Scoped Operational Notes
 
-These notes are intentionally stored in root `AGENTS.md`, not only in `.codex/CODEX.md`. Codex project-doc discovery loads at most one instruction file per directory: `AGENTS.override.md`, then `AGENTS.md`, then configured fallbacks. Because this repository root contains `AGENTS.md`, `.codex/CODEX.md` is a reference file and is not auto-loaded as a fallback during normal repo-root sessions.
+Harness-specific diagnostics must stay in harness-scoped context surfaces instead
+of this global swarm instruction file. For Codex Desktop, the human-readable
+source lives in `.codex/CODEX.md`. Trusted Codex projects inject that source as
+turn-visible developer context via `.codex/hooks.json`, keeping local
+`.codex/config.toml` customization independent from the shared reference note.
 
-When operating as Codex Desktop:
-
-- Your GitHub username is `neo-gpt`.
-- You can communicate via the `add_message` tool with Claude Opus 4.7 at `neo-opus-4-7` and Gemini at `neo-gemini-3-1-pro`.
-- `gh auth status` can falsely report `GH_TOKEN` as invalid inside Codex's sandbox. Verify GitHub auth with `gh api user --jq .login`, or rerun `gh auth status` with sandbox escalation before treating auth as broken. Expected Codex identity: `neo-gpt`.
+Do not add Codex-only GitHub auth, sandbox transport, or model-identity caveats
+to this shared file; Claude, Gemini, and Codex all parse it.
 
 
 


### PR DESCRIPTION
Resolves #10715

Authored by GPT-5.5 (Codex Desktop). Session 2821a9d4-7634-4fe7-a8a2-daf49253b929.

Routes Codex-only runtime notes through a trusted project-local Codex `UserPromptSubmit` hook instead of global `AGENTS.md` or a duplicated `developer_instructions` mirror. `AGENTS.md` §0.1 is now harness-neutral, `.codex/CODEX.md` is the canonical human-readable and runtime source, `.codex/hooks.json` injects that file as developer context, and `.codex/config.template.toml` enables `codex_hooks` while keeping `.codex/config.toml` ignored and customizable.

Evidence: L3 (`codex exec` with local `developer_instructions` blanked proved the hook-delivered `.codex/CODEX.md` context reaches the model in a normal configured repo-root Codex turn) → L4 desired for first-turn fresh checkout automatic context. Residual: existing or fresh Codex checkouts whose ignored `.codex/config.toml` has not enabled `codex_hooks` must refresh/merge the updated `.codex/config.template.toml` before the hook can run.

## Deltas from ticket
- Full AC1 remains the target, but the implementation now preserves the established template/custom-config split: `.codex/config.toml` stays ignored for local customization.
- Replaced the earlier `developer_instructions` mirror with a repo-local `UserPromptSubmit` hook so `.codex/CODEX.md` is the actual runtime source instead of duplicated prose.
- Verified that `model_instructions_file` is not suitable because Codex docs define it as a replacement for built-in instructions, not project reference context.
- Verified that `developer_instructions_file` is not a supported route and that fallback filenames still do not beat root `AGENTS.md`.

## Test Evidence
- `codex exec --json -s read-only -c developer_instructions=\"\" ...` returned `SEEN`, proving the model saw `Expected Codex identity` from hook-injected `.codex/CODEX.md` with no developer-instructions mirror.
- `codex exec --json --ignore-user-config -s read-only -c developer_instructions=\"\" ...` returned `MISSING`, proving hooks still require the Codex hooks feature to be enabled via config and documenting the residual.
- `codex debug prompt-input -c developer_instructions=\"\" ...` did not expose hook output, so `codex exec` is the equivalent current prompt-effect verifier for this hook path.
- `git diff --check origin/dev...HEAD` passed.
- `git log --oneline origin/dev..HEAD` contains only `491d0d6b2 feat(codex): route reference notes through scoped config (#10715)`.
- GitHub API `pulls/10728/files` now reports only `AGENTS.md`, `.codex/CODEX.md`, `.codex/config.template.toml`, `.codex/hooks.json`, and `.codex/hooks/codex-context.mjs`.

## Post-Merge Validation
- [ ] For existing Codex checkouts, merge the updated `.codex/config.template.toml` into ignored `.codex/config.toml` so `[features].codex_hooks = true` is present.
- [ ] Fresh configured Codex repo-root turn verifies `.codex/CODEX.md` reaches model context through the `UserPromptSubmit` hook and detailed Codex GitHub transport diagnostics are absent from `AGENTS.md`.

## Sources
- OpenAI Codex hooks docs: https://developers.openai.com/codex/hooks/
- OpenAI Codex config basics: https://developers.openai.com/codex/config-basic
- OpenAI Codex config reference: https://developers.openai.com/codex/config-reference