### PR TITLE
feat(memory-core): add resume_session validation tool (#10725)

### DIFF
--- a/ai/mcp/server/memory-core/openapi.yaml
+++ b/ai/mcp/server/memory-core/openapi.yaml
@@ -560,6 +560,76 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
 
+  /sessions/resume:
+    post:
+      summary: Validate session resumability
+      operationId: resume_session
+      x-pass-as-object: true
+      x-annotations:
+        readOnlyHint: true
+      description: |
+        Validates whether a session ID is in a state safe for the agent to resume by reconnecting with that session ID in their `Mcp-Session-Id` header. Pure read-only query — does NOT modify any server-side session state.
+
+        Use when the agent has a candidate session ID (e.g., from a prior `query_summaries` result or recovered from local context) and needs to confirm it is safe to keep using before reconnecting. The actual session-id binding still happens at the transport layer via the `Mcp-Session-Id` header per the post-#10692 RequestContextService model.
+
+        Returns a structured success payload with `status: 'resumable'`, `memoryCount`, `lastActivityAt`, and `summarizationStatus` — OR one of four structured errors: `INVALID_SESSION_ID`, `SESSION_NOT_FOUND`, `SESSION_FINALIZED` (already summarized; start fresh), `SESSION_BUSY` (concurrent summarization mid-flight; retry shortly).
+      tags: [Sessions]
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - sessionId
+              properties:
+                sessionId:
+                  type: string
+                  description: The session ID to validate.
+      responses:
+        '200':
+          description: Session resumability status (success or structured error).
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                  sessionId:
+                    type: string
+                  status:
+                    type: string
+                    enum: [resumable]
+                  memoryCount:
+                    type: integer
+                  lastActivityAt:
+                    type: string
+                    nullable: true
+                  summarizationStatus:
+                    type: string
+                    enum: [none, pending, in_progress, completed, failed]
+                  error:
+                    type: string
+                  code:
+                    type: string
+                    enum: [INVALID_SESSION_ID, SESSION_NOT_FOUND, SESSION_FINALIZED, SESSION_BUSY]
+                  leaseExpiresAt:
+                    type: string
+                    description: Present only when `code === 'SESSION_BUSY'`.
+        '400':
+          description: Invalid request body
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Internal server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
   /sessions/set_id:
     post:
       summary: Set Session ID

--- a/ai/mcp/server/memory-core/services/SessionService.mjs
+++ b/ai/mcp/server/memory-core/services/SessionService.mjs
@@ -12,7 +12,7 @@ import os from 'os';
 import logger from '../logger.mjs';
 import http from 'http';
 import https from 'https';
-import RequestContextService, { normalizeUserId } from '../../shared/services/RequestContextService.mjs';
+import RequestContextService, {SHARED_USER_ID, normalizeUserId} from '../../shared/services/RequestContextService.mjs';
 
 /**
  * @summary Service for handling session summarization and drift detection.
@@ -732,6 +732,134 @@ ${aggregatedContent}
         } catch (e) {
             logger.warn(`[SessionService] Error processing pending summarizations: ${e.message}`);
         }
+    }
+
+    /**
+     * Validates whether a session ID is in a state safe for the agent to resume by reconnecting
+     * with that session ID in their `Mcp-Session-Id` header. **Pure read-only query — does NOT
+     * modify `RequestContextService` or any server-side session state.**
+     *
+     * Per the post-#10692 model, session-id binding is owned by the transport layer
+     * (`Mcp-Session-Id` header → `RequestContextService.getSessionId()`). This method answers the
+     * agent's prerequisite question — *"is this session_id safe to use before reconnecting?"* —
+     * and returns a structured payload covering memory count, last activity, and current
+     * summarization status so the agent can decide whether to resume or start fresh.
+     *
+     * **State decision tree:**
+     * 1. `SummarizationJobs.status === 'completed'` → `SESSION_FINALIZED` (resuming would append
+     *    to a closed-book session whose summary already shipped; agent should start fresh).
+     * 2. `SummarizationJobs.status === 'in_progress'` AND lease unexpired → `SESSION_BUSY`
+     *    (concurrent summarization mid-flight; agent should retry shortly to avoid losing
+     *    appended memories from the in-flight summary, or start fresh).
+     * 3. No memories AND no SummarizationJobs row → `SESSION_NOT_FOUND` (no session existed
+     *    or it was fully purged).
+     * 4. Otherwise (memories exist, status is `pending` / `failed` / `none` / expired
+     *    `in_progress`) → resumable; payload returns memory count, last activity, summarization
+     *    status.
+     *
+     * @param {Object} args
+     * @param {String} args.sessionId The session ID to validate.
+     * @returns {Promise<Object>} Either a success payload (`{success: true, sessionId, status:
+     *     'resumable', memoryCount, lastActivityAt, summarizationStatus}`) OR a structured error
+     *     with one of `INVALID_SESSION_ID`, `SESSION_NOT_FOUND`, `SESSION_FINALIZED`, `SESSION_BUSY`.
+     * @see #10725 — design rationale (validation-only, not state-changing)
+     * @see #10692 — RequestContextService transport-layer binding model
+     * @see #10693 — SummarizationJobs lease semantics (TTL + status enum)
+     */
+    async validateSessionForResume({sessionId} = {}) {
+        if (!sessionId || typeof sessionId !== 'string') {
+            return {error: 'Invalid sessionId', code: 'INVALID_SESSION_ID'};
+        }
+
+        // Fast SQLite check on summarization-job state — gates FINALIZED + BUSY error paths
+        // before the more expensive Chroma read.
+        const sqlite = GraphService.db?.storage?.db;
+        let summarizationStatus = 'none';
+        if (sqlite) {
+            try {
+                const row = sqlite.prepare(
+                    'SELECT status, expires_at FROM SummarizationJobs WHERE session_id = ?'
+                ).get(sessionId);
+                if (row) {
+                    summarizationStatus = row.status;
+
+                    if (row.status === 'completed') {
+                        return {
+                            error: 'Session has been finalized via summarization. Resuming would append to a closed-book session; start fresh instead.',
+                            code: 'SESSION_FINALIZED',
+                            sessionId,
+                            summarizationStatus: 'completed'
+                        };
+                    }
+
+                    if (row.status === 'in_progress' && row.expires_at > Date.now()) {
+                        return {
+                            error: 'Session is currently being summarized by another worker (lease active). Retry shortly or start fresh.',
+                            code: 'SESSION_BUSY',
+                            sessionId,
+                            summarizationStatus: 'in_progress',
+                            leaseExpiresAt: new Date(row.expires_at).toISOString()
+                        };
+                    }
+                    // status === 'pending' / 'failed' / expired 'in_progress': resumable below.
+                }
+            } catch (e) {
+                logger.warn(`[SessionService] validateSessionForResume: error checking SummarizationJobs for ${sessionId}: ${e.message}`);
+                // Fall through — treat as no summarization-job row.
+            }
+        }
+
+        // Memory-collection probe for count + last activity. Tenant-aware filter consistent
+        // with MemoryService.listMemories — userId tag plus SHARED_USER_ID legacy commons.
+        let memoryCount    = 0;
+        let lastActivityAt = null;
+        try {
+            const collection = await StorageRouter.getMemoryCollection();
+            if (collection) {
+                const userId = normalizeUserId(RequestContextService.getUserId());
+                const where  = userId
+                    ? {$and: [{sessionId}, {$or: [{userId}, {userId: SHARED_USER_ID}]}]}
+                    : {sessionId};
+
+                const result = await collection.get({
+                    where,
+                    include: ['metadatas']
+                });
+
+                memoryCount = result.ids?.length || 0;
+
+                if (memoryCount > 0) {
+                    const timestamps = (result.metadatas || [])
+                        .map(m => m?.timestamp)
+                        .filter(Boolean)
+                        .map(t => new Date(t).getTime())
+                        .filter(n => Number.isFinite(n));
+                    if (timestamps.length > 0) {
+                        lastActivityAt = new Date(Math.max(...timestamps)).toISOString();
+                    }
+                }
+            }
+        } catch (e) {
+            logger.warn(`[SessionService] validateSessionForResume: error querying memories for ${sessionId}: ${e.message}`);
+            // Fall through — treat as no memories.
+        }
+
+        if (memoryCount === 0 && summarizationStatus === 'none') {
+            return {
+                error: 'No session found with the supplied ID. Either the session never existed or its data has been purged.',
+                code: 'SESSION_NOT_FOUND',
+                sessionId
+            };
+        }
+
+        return {
+            success: true,
+            sessionId,
+            status: 'resumable',
+            memoryCount,
+            lastActivityAt,
+            summarizationStatus
+        };
     }
 
     /**

--- a/ai/mcp/server/memory-core/services/toolService.mjs
+++ b/ai/mcp/server/memory-core/services/toolService.mjs
@@ -42,8 +42,9 @@ const serviceMapping = {
     revoke_permission     : PermissionService       .revokePermission    .bind(PermissionService),
     list_permissions      : PermissionService       .listPermissions     .bind(PermissionService),
     manage_wake_subscription: WakeSubscriptionService.manage              .bind(WakeSubscriptionService),
-    set_session_id        : SessionService          .setSessionId        .bind(SessionService),
-    purge_session         : SessionService          .purgeSession        .bind(SessionService)
+    purge_session         : SessionService          .purgeSession        .bind(SessionService),
+    resume_session        : SessionService          .validateSessionForResume.bind(SessionService),
+    set_session_id        : SessionService          .setSessionId        .bind(SessionService)
 };
 
 const toolService = Neo.create(ToolService, {

--- a/learn/agentos/MemoryCore.md
+++ b/learn/agentos/MemoryCore.md
@@ -64,6 +64,11 @@ The server exposes a suite of tools via the Model Context Protocol (MCP).
 *   **`delete_all_summaries`**: A destructive tool to clear the summary index (useful if you want to re-summarize everything with a new model).
 *   **`summarize_sessions`**: Manually triggers the summarization process for specific or all pending sessions.
 
+### Session Operations
+
+*   **`resume_session`**: Pure validation/query — returns structural metadata about whether a candidate session ID is safe for the agent to keep using on reconnect (set the `Mcp-Session-Id` header to that ID for subsequent calls). Does NOT mutate `RequestContextService` or any server-side session state. Returns either a success payload (`status: 'resumable'` plus `memoryCount`, `lastActivityAt`, `summarizationStatus`) or one of four structured errors: `INVALID_SESSION_ID`, `SESSION_NOT_FOUND`, `SESSION_FINALIZED` (already summarized — start fresh), `SESSION_BUSY` (concurrent summarization mid-flight — retry shortly). Use after recovering a candidate session ID from a prior `query_summaries` result or local context.
+*   **`set_session_id`**: Legacy / single-tenant fallback only. Overrides the process-global `_legacySessionId`. Rejected with `REQUEST_SCOPED_SESSION_ACTIVE` when invoked under a request-bound `Mcp-Session-Id` context to prevent multi-tenant state corruption. Prefer transport-layer session binding via the `Mcp-Session-Id` header in shared deployments.
+
 ### Database Management
 
 *   **`healthcheck`**: Diagnostics tool. Checks ChromaDB status, collection health, API key configuration, identity binding, and effective ChromaDB topology. See **Healthcheck Response Shape** below for the full payload contract.

--- a/learn/agentos/SharedDeployment.md
+++ b/learn/agentos/SharedDeployment.md
@@ -95,6 +95,8 @@ Teams adopting shared mode from per-developer local should follow this migration
 
 5. **First-session smoke test.** Have each developer's agent run a `query_summaries` query against Memory Core — this is the canonical cross-agent **memory visibility** proof. The first agent populates baseline; subsequent agents should see each other's summaries on subsequent queries. Optionally also run an `ask_knowledge_base` query against the Knowledge Base to validate **KB sharing** through the same Chroma instance — it's a separate retrieval surface, not a memory-visibility proof.
 
+6. **Resume validation (when reconnecting agents).** Before an agent reconnects with a previously-used session ID, call `resume_session({session_id})` on Memory Core to verify the session is safe to resume. The tool returns a structured payload: `status: 'resumable'` (with `memoryCount`, `lastActivityAt`, `summarizationStatus`) confirms the agent can keep using that session ID via the `Mcp-Session-Id` header; `SESSION_FINALIZED` (already summarized) or `SESSION_BUSY` (concurrent summarization mid-flight, lease active) signal the agent should start fresh or retry. The validation is read-only — it does not modify server-side session state; the actual session-id binding still happens at the transport layer.
+
 ## Validation
 
 Validation tests for the unified topology are tracked separately under [#10008](https://github.com/neomjs/neo/issues/10008) ("Playwright Test Coverage: Unified Monolithic Topology"). That ticket is the canonical validation path for the contract this profile documents — when it closes, the test substrate empirically proves shared-mode KB/MC read/write correctness against a single Chroma process without collection collision.

--- a/test/playwright/unit/ai/mcp/server/memory-core/services/SessionService.ResumeValidation.spec.mjs
+++ b/test/playwright/unit/ai/mcp/server/memory-core/services/SessionService.ResumeValidation.spec.mjs
@@ -1,0 +1,205 @@
+import {setup} from '../../../../../../setup.mjs';
+
+const appName = 'MemoryCoreSessionResumeValidationTest';
+
+process.env.MODEL_PROVIDER = 'openAiCompatible';
+process.env.OPENAI_COMPATIBLE_MODEL = 'gemma4';
+
+setup({
+    neoConfig: {
+        allowVdomUpdatesInTests: false,
+        unitTestMode           : true,
+        useDomApiRenderer      : false
+    },
+    appConfig: {
+        name             : appName,
+        isMounted        : () => true,
+        vnodeInitialising: false
+    }
+});
+
+import {test, expect}  from '@playwright/test';
+import Neo             from '../../../../../../../../src/Neo.mjs';
+import * as core       from '../../../../../../../../src/core/_export.mjs';
+import path            from 'path';
+import {fileURLToPath} from 'url';
+import dotenv          from 'dotenv';
+import crypto          from 'crypto';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname  = path.dirname(__filename);
+dotenv.config({path: path.resolve(__dirname, '../../../../../../../../.env'), quiet: true});
+
+test.describe('SessionService validateSessionForResume (#10725)', () => {
+    let SDK, TextEmbeddingService;
+
+    test.beforeAll(async () => {
+        const fs = await import('fs');
+
+        const aiConfig = (await import('../../../../../../../../ai/mcp/server/memory-core/config.mjs')).default;
+
+        const tmpDir = path.resolve(process.cwd(), 'tmp');
+        if (!fs.existsSync(tmpDir)) {
+            fs.mkdirSync(tmpDir, {recursive: true});
+        }
+
+        aiConfig.collections.memory  = `test-memory-${process.pid}-${Date.now()}`;
+        aiConfig.collections.session = `test-session-${process.pid}-${Date.now()}`;
+
+        SDK                  = await import('../../../../../../../../ai/services.mjs');
+        TextEmbeddingService = (await import('../../../../../../../../ai/mcp/server/memory-core/services/TextEmbeddingService.mjs')).default;
+
+        SDK.Memory_Config.data.modelProvider           = 'openAiCompatible';
+        SDK.Memory_Config.data.neoEmbeddingProvider    = 'openAiCompatible';
+        SDK.Memory_Config.data.chromaEmbeddingProvider = 'openAiCompatible';
+        SDK.Memory_Config.data.autoSummarize           = false;
+
+        TextEmbeddingService.embedText = async () => new Array(4096).fill(Math.random());
+    });
+
+    test.afterAll(async () => {
+        try {
+            if (SDK.Memory_ChromaManager && SDK.Memory_ChromaManager.client) {
+                await SDK.Memory_ChromaManager.client.deleteCollection({name: SDK.Memory_Config.data.collections.memory});
+                await SDK.Memory_ChromaManager.client.deleteCollection({name: SDK.Memory_Config.data.collections.session});
+            }
+        } catch (e) {}
+
+        if (SDK?.Memory_LifecycleService) {
+            SDK.Memory_LifecycleService._initPromise = null;
+        }
+    });
+
+    test.beforeEach(async () => {
+        if (!SDK.Memory_LifecycleService._initPromise) {
+            await SDK.Memory_LifecycleService.initAsync();
+        } else {
+            await SDK.Memory_LifecycleService.ready();
+        }
+        await SDK.Memory_SessionService.ready();
+        await SDK.Memory_ChromaManager.ready();
+    });
+
+    test('SESSION_NOT_FOUND when no memories and no SummarizationJobs row', async () => {
+        const sessionId = `nonexistent-${crypto.randomUUID()}`;
+
+        const result = await SDK.Memory_SessionService.validateSessionForResume({sessionId});
+
+        expect(result.success).toBeUndefined();
+        expect(result.code).toBe('SESSION_NOT_FOUND');
+        expect(result.sessionId).toBe(sessionId);
+    });
+
+    test('resumable success when memories exist with no SummarizationJobs row', async () => {
+        const sessionId = `resumable-memories-${crypto.randomUUID()}`;
+        const RequestContextService = (await import('../../../../../../../../ai/mcp/server/shared/services/RequestContextService.mjs')).default;
+
+        await RequestContextService.run({sessionId}, async () => {
+            await SDK.Memory_Service.addMemory({
+                prompt  : 'resume validation prompt',
+                response: 'resume validation response',
+                thought : 'resume validation thought'
+            });
+        });
+
+        const result = await SDK.Memory_SessionService.validateSessionForResume({sessionId});
+
+        expect(result.success).toBe(true);
+        expect(result.sessionId).toBe(sessionId);
+        expect(result.status).toBe('resumable');
+        expect(result.memoryCount).toBe(1);
+        expect(result.summarizationStatus).toBe('none');
+        expect(result.lastActivityAt).toBeTruthy();
+    });
+
+    test('SESSION_FINALIZED when SummarizationJobs.status === completed', async () => {
+        const sessionId       = `finalized-${crypto.randomUUID()}`;
+        const GraphService    = (await import('../../../../../../../../ai/mcp/server/memory-core/services/GraphService.mjs')).default;
+        await GraphService.ready();
+
+        const sqlite = GraphService.db?.storage?.db;
+        expect(sqlite).toBeTruthy();
+
+        // Plant a completed-status row directly to simulate a finalized session.
+        sqlite.prepare(`
+            INSERT INTO SummarizationJobs (session_id, status, lease_token, expires_at, retry_count)
+            VALUES (?, 'completed', NULL, NULL, 0)
+        `).run(sessionId);
+
+        try {
+            const result = await SDK.Memory_SessionService.validateSessionForResume({sessionId});
+
+            expect(result.success).toBeUndefined();
+            expect(result.code).toBe('SESSION_FINALIZED');
+            expect(result.sessionId).toBe(sessionId);
+            expect(result.summarizationStatus).toBe('completed');
+        } finally {
+            sqlite.prepare('DELETE FROM SummarizationJobs WHERE session_id = ?').run(sessionId);
+        }
+    });
+
+    test('SESSION_BUSY when SummarizationJobs.status === in_progress with future expires_at', async () => {
+        const sessionId    = `busy-${crypto.randomUUID()}`;
+        const GraphService = (await import('../../../../../../../../ai/mcp/server/memory-core/services/GraphService.mjs')).default;
+        await GraphService.ready();
+
+        const sqlite = GraphService.db?.storage?.db;
+        expect(sqlite).toBeTruthy();
+
+        const futureExpiresAt = Date.now() + 60_000;
+        sqlite.prepare(`
+            INSERT INTO SummarizationJobs (session_id, status, lease_token, expires_at, retry_count)
+            VALUES (?, 'in_progress', 'test-lease', ?, 0)
+        `).run(sessionId, futureExpiresAt);
+
+        try {
+            const result = await SDK.Memory_SessionService.validateSessionForResume({sessionId});
+
+            expect(result.success).toBeUndefined();
+            expect(result.code).toBe('SESSION_BUSY');
+            expect(result.sessionId).toBe(sessionId);
+            expect(result.summarizationStatus).toBe('in_progress');
+            expect(result.leaseExpiresAt).toBeTruthy();
+        } finally {
+            sqlite.prepare('DELETE FROM SummarizationJobs WHERE session_id = ?').run(sessionId);
+        }
+    });
+
+    test('resumable when SummarizationJobs.status === in_progress but lease has expired', async () => {
+        const sessionId             = `expired-lease-${crypto.randomUUID()}`;
+        const GraphService          = (await import('../../../../../../../../ai/mcp/server/memory-core/services/GraphService.mjs')).default;
+        const RequestContextService = (await import('../../../../../../../../ai/mcp/server/shared/services/RequestContextService.mjs')).default;
+        await GraphService.ready();
+
+        const sqlite = GraphService.db?.storage?.db;
+        expect(sqlite).toBeTruthy();
+
+        // Plant a memory so the resumable path has a non-zero count + last activity.
+        await RequestContextService.run({sessionId}, async () => {
+            await SDK.Memory_Service.addMemory({
+                prompt  : 'expired-lease prompt',
+                response: 'expired-lease response',
+                thought : 'expired-lease thought'
+            });
+        });
+
+        // Plant an in_progress row with expired lease — should be treated as resumable.
+        const expiredAt = Date.now() - 60_000;
+        sqlite.prepare(`
+            INSERT INTO SummarizationJobs (session_id, status, lease_token, expires_at, retry_count)
+            VALUES (?, 'in_progress', 'expired-lease-token', ?, 0)
+        `).run(sessionId, expiredAt);
+
+        try {
+            const result = await SDK.Memory_SessionService.validateSessionForResume({sessionId});
+
+            expect(result.success).toBe(true);
+            expect(result.sessionId).toBe(sessionId);
+            expect(result.status).toBe('resumable');
+            expect(result.summarizationStatus).toBe('in_progress');
+            expect(result.memoryCount).toBe(1);
+        } finally {
+            sqlite.prepare('DELETE FROM SummarizationJobs WHERE session_id = ?').run(sessionId);
+        }
+    });
+});


### PR DESCRIPTION
Resolves #10725

Authored by Claude Opus 4.7 (Claude Code). Session \`7e52099b-9632-4c67-a2a1-4e1a1ad1c414\`.

Adds a new MCP tool \`resume_session({session_id})\` on Memory Core. **Pure read-only validation** — does NOT modify \`RequestContextService\` or any server-side session state. Answers the agent's prerequisite question before reconnecting with a candidate session ID: *"is this session_id safe to keep using?"*

Evidence: L2 (Playwright unit tests covering 4 error states + happy path with planted SummarizationJobs rows + memory writes via SDK; 5/5 stable across 3 runs ~840ms each) → L2 required (AC contract is decision-logic verification on session state; no operator-gated runtime). No residuals.

## Design rationale (validation-only, not state-changing)

Per the post-#10692 model, session-id binding is owned by the transport layer (\`Mcp-Session-Id\` header → \`RequestContextService.getSessionId()\`). The legacy \`set_session_id\` is rejected with \`REQUEST_SCOPED_SESSION_ACTIVE\` when context has session. The semantic gap #10725 fills is validation, not state-changing setting.

Reframe captured in [DECIDED] comment [\`IC_kwDODSospM8AAAABBMRXBg\`](https://github.com/neomjs/neo/issues/10725#issuecomment-4374943494) on #10725; cross-confirmed by @neo-gemini-3-1-pro before implementation.

## Behavior

| Outcome | Trigger | Response |
|---|---|---|
| **Resumable** | Memories exist OR SummarizationJobs row exists with status pending/failed/expired-in_progress | \`{success: true, sessionId, status: 'resumable', memoryCount, lastActivityAt, summarizationStatus}\` |
| **SESSION_NOT_FOUND** | No memories AND no SummarizationJobs row | Structured error with \`code\` |
| **SESSION_FINALIZED** | SummarizationJobs.status === 'completed' | Structured error — agent should start fresh |
| **SESSION_BUSY** | SummarizationJobs.status === 'in_progress' AND \`expires_at > now\` | Structured error with \`leaseExpiresAt\` — agent should retry shortly or start fresh |
| **INVALID_SESSION_ID** | Input shape error (missing or non-string sessionId) | Structured error |

## Contract Ledger

| Target Surface | Source of Authority | Proposed Behavior | Fallback / Edge Case | Docs | Evidence |
|---|---|---|---|---|---|
| New MCP tool \`resume_session\` on Memory Core | This ticket + #10692 RequestContextService contract + #10693 SummarizationJobs lease | Pure validation: returns session resumability status; never modifies server state | Four structured error codes per state (NOT_FOUND / FINALIZED / BUSY / INVALID_SESSION_ID); active RequestContextService session_id never modified | \`MemoryCore.md\` Session Operations + \`SharedDeployment.md\` Migration §6 | L2 (Playwright unit test covering 5 states; 5/5 stable across 3 runs) |

## AC coverage

- [x] AC1: implementation surface decided — new MCP tool, validation-only ([DECIDED] comment + this PR).
- [x] AC2: validation logic interfaces with \`RequestContextService\` (read-only consult via \`getUserId()\` for tenant filter; never modifies the storage).
- [x] AC3: resuming does not improperly trigger early summarization — trivially satisfied since the tool is read-only.
- [x] AC4: clear error handling for invalid/expired — four structured codes per state.

## Implementation

- **\`ai/mcp/server/memory-core/services/SessionService.mjs:684-805\`** — new \`validateSessionForResume({sessionId})\` method. Fast SQLite check on \`SummarizationJobs\` (FINALIZED + BUSY paths) before the more expensive Chroma read. Tenant-aware memory query consistent with \`MemoryService.listMemories\`.
- **\`ai/mcp/server/memory-core/openapi.yaml\`** — new \`/sessions/resume\` POST operation under Sessions tag, \`readOnlyHint: true\`. Documents the 5-state response schema (success path + 4 error codes).
- **\`ai/mcp/server/memory-core/services/toolService.mjs\`** — dispatch entry pre-\`set_session_id\` (alphabetical).

## Test Evidence

\`test/playwright/unit/ai/mcp/server/memory-core/services/SessionService.ResumeValidation.spec.mjs\` — 5 tests covering:
1. \`SESSION_NOT_FOUND\` when no memories and no SummarizationJobs row.
2. resumable success when memories exist with no SummarizationJobs row.
3. \`SESSION_FINALIZED\` when SummarizationJobs.status === 'completed'.
4. \`SESSION_BUSY\` when SummarizationJobs.status === 'in_progress' with future expires_at.
5. resumable when SummarizationJobs.status === 'in_progress' but lease has expired.

3 stable runs at ~840ms each. SummarizationJobs rows planted directly via \`GraphService.db.storage.db.prepare().run()\` for tests 3-5; tests 2 + 5 also exercise the memoryCollection branch via \`SDK.Memory_Service.addMemory\` inside \`RequestContextService.run({sessionId}, ...)\`.

## Out of Scope

- **State-changing setter semantics.** Per the post-#10692 model + [DECIDED] reframe, session-id binding is transport-layer-owned. The agent uses the validation response to decide whether to reconnect with that session ID via the \`Mcp-Session-Id\` header.
- **Bulk validation** (\`resume_sessions([id1, id2])\`). Per-session call is sufficient for current use cases; bulk could be a follow-up if needed.
- **Cross-tenant resume.** Tenant-aware filter applies — agents only see resumable status for sessions they have memory access to (per \`SHARED_USER_ID\` legacy commons rule).
- **Auto-cleanup of stale \`pending\` rows.** A \`pending\` row that's been around for days won't surface as BUSY (no lease) but also won't reset itself. Cleanup belongs to a separate operational concern.

## Avoided Traps

- **Rejected: state-changing semantics overloading \`set_session_id\`.** Conflicts with the post-#10692 \`REQUEST_SCOPED_SESSION_ACTIVE\` invariant.
- **Rejected: connection-parameter on init payload.** MCP doesn't have a single connect surface; overloading existing surfaces would dilute their contracts.
- **Rejected: Chroma-first probe before SQLite check.** SQLite is sub-ms and gates the FINALIZED + BUSY paths cleanly; doing the more expensive Chroma read first would waste effort on already-decidable cases.
- **Rejected: throw on missing \`memoryCollection\`.** Graceful fallthrough — if Chroma is unreachable, return SESSION_NOT_FOUND only when SummarizationJobs also has no row, otherwise still signal the SummarizationJobs state. Defensive against partial-substrate failures.

## Related

- Parent epic: #10721 — Shared deployment MVP completeness gaps (post-#10691)
- Substrate primitive: #10692 — Client-scoped Memory Core session lifecycle (RequestContextService)
- Coordinator primitive: #10693 — Summarization coordinator (SummarizationJobs lease semantics)
- Reference doc: [\`learn/agentos/MemoryCore.md\` §Session Operations](https://github.com/neomjs/neo/blob/dev/learn/agentos/MemoryCore.md)