### PR TITLE
feat(memory-core): wire disconnect-triggered summarization (#10726)

### DIFF
--- a/ai/mcp/server/memory-core/Server.mjs
+++ b/ai/mcp/server/memory-core/Server.mjs
@@ -443,6 +443,8 @@ class Server extends Base {
      * Wires up the MCP request handlers for listing and calling tools.
      */
     setupRequestHandlers() {
+        if (!this.mcpServer) return; // Prevent crash if instance was destroyed during async boot
+
         // List Tools Handler
         this.mcpServer.server.setRequestHandler(ListToolsRequestSchema, async (request) => {
             try {

--- a/ai/mcp/server/memory-core/Server.mjs
+++ b/ai/mcp/server/memory-core/Server.mjs
@@ -428,6 +428,17 @@ class Server extends Base {
     }
 
     /**
+     * Hook from TransportService on SSE session disconnect.
+     * Queues the disconnected session for summarization.
+     * @param {String} sessionId
+     */
+    onSessionClosed(sessionId) {
+        if (SessionService) {
+            SessionService.queueSummarizationJob(sessionId);
+        }
+    }
+
+    /**
      * Wires up the MCP request handlers for listing and calling tools.
      */
     setupRequestHandlers() {

--- a/ai/mcp/server/memory-core/Server.mjs
+++ b/ai/mcp/server/memory-core/Server.mjs
@@ -430,6 +430,7 @@ class Server extends Base {
     /**
      * Hook from TransportService on SSE session disconnect.
      * Queues the disconnected session for summarization.
+     * @summary Bridges the transport layer disconnect event into the memory core logic pipeline.
      * @param {String} sessionId
      */
     onSessionClosed(sessionId) {

--- a/ai/mcp/server/memory-core/services/SessionService.mjs
+++ b/ai/mcp/server/memory-core/services/SessionService.mjs
@@ -687,6 +687,8 @@ ${aggregatedContent}
      * @param {String} sessionId 
      */
     queueSummarizationJob(sessionId) {
+        if (!aiConfig.autoSummarize) return;
+
         const db = GraphService.db?.storage?.db;
         if (!db) return;
         try {

--- a/ai/mcp/server/memory-core/services/SessionService.mjs
+++ b/ai/mcp/server/memory-core/services/SessionService.mjs
@@ -737,6 +737,7 @@ ${aggregatedContent}
     /**
      * Claims an exclusive lease on a summarization job using the SummarizationJobs table.
      * Prevents race conditions across concurrent MCP instances.
+     * @summary Provides exclusive lock acquisition for the background summarization coordinator loop.
      * @param {String} sessionId
      * @param {String} leaseToken
      * @param {Number} [ttlMs=300000] Default 5-minute lease
@@ -795,6 +796,7 @@ ${aggregatedContent}
 
     /**
      * Marks a summarization job as completed in the coordinator table.
+     * @summary Finalizes the background summarization job state to prevent duplicate processing.
      * @param {String} sessionId
      */
     completeSummarizationJob(sessionId) {
@@ -813,6 +815,7 @@ ${aggregatedContent}
 
     /**
      * Marks a summarization job as failed in the coordinator table.
+     * @summary Releases the exclusive lease on a background summarization job after an unhandled execution failure.
      * @param {String} sessionId
      */
     failSummarizationJob(sessionId) {

--- a/ai/mcp/server/memory-core/services/SessionService.mjs
+++ b/ai/mcp/server/memory-core/services/SessionService.mjs
@@ -682,6 +682,55 @@ ${aggregatedContent}
     }
 
     /**
+     * Queues a session for summarization by writing a 'pending' marker
+     * to the SummarizationJobs table and triggering the asynchronous detector.
+     * @param {String} sessionId 
+     */
+    queueSummarizationJob(sessionId) {
+        const db = GraphService.db?.storage?.db;
+        if (!db) return;
+        try {
+            db.prepare(`
+                INSERT INTO SummarizationJobs (session_id, status)
+                VALUES (?, 'pending')
+                ON CONFLICT(session_id) DO UPDATE SET 
+                    status = 'pending',
+                    lease_token = NULL,
+                    expires_at = NULL
+                WHERE status != 'completed' AND status != 'in_progress'
+            `).run(sessionId);
+            
+            // Asynchronously trigger processing so we don't block the caller (e.g. disconnect lifecycle)
+            setTimeout(() => this.processPendingSummarizations(), 100);
+        } catch (e) {
+            logger.warn(`[SessionService] Error queuing summarization for ${sessionId}: ${e.message}`);
+        }
+    }
+
+    /**
+     * Finds pending summarization jobs and attempts to process them.
+     */
+    async processPendingSummarizations() {
+        const db = GraphService.db?.storage?.db;
+        if (!db) return;
+        
+        try {
+            const pendingJobs = db.prepare(`
+                SELECT session_id FROM SummarizationJobs WHERE status = 'pending'
+            `).all();
+            
+            for (const job of pendingJobs) {
+                // Background execution. The inner call uses claimSummarizationJob to get a lease.
+                this.summarizeSessions({ sessionId: job.session_id }).catch(e => {
+                    logger.error(`[SessionService] Background summarization failed for ${job.session_id}:`, e);
+                });
+            }
+        } catch (e) {
+            logger.warn(`[SessionService] Error processing pending summarizations: ${e.message}`);
+        }
+    }
+
+    /**
      * Claims an exclusive lease on a summarization job using the SummarizationJobs table.
      * Prevents race conditions across concurrent MCP instances.
      * @param {String} sessionId 

--- a/ai/mcp/server/memory-core/services/SessionService.mjs
+++ b/ai/mcp/server/memory-core/services/SessionService.mjs
@@ -403,7 +403,7 @@ class SessionService extends Base {
 
         // Natively bypass arbitrary Context Windows or chunking loops.
         // We enforce strict Lossless extraction for local performance consistency.
-        // NOTE: Large sessions natively require the backing daemon (MLX/OpenAiCompatible) to have 
+        // NOTE: Large sessions natively require the backing daemon (MLX/OpenAiCompatible) to have
         // sufficient `n_ctx` capabilities (128k+).
         const aggregatedContent = memories.documents.join('\n\n---\n\n');
 
@@ -559,7 +559,7 @@ ${aggregatedContent}
      * Passively scans the local Antigravity brain directory for implementation plans
      * and structurally ingests them into the vector DB and edge graph if their timestamps
      * match the active session.
-     * @param {String} sessionId 
+     * @param {String} sessionId
      * @param {String} summaryId
      * @param {Number} minTimeMs
      * @param {Number} maxTimeMs
@@ -684,7 +684,8 @@ ${aggregatedContent}
     /**
      * Queues a session for summarization by writing a 'pending' marker
      * to the SummarizationJobs table and triggering the asynchronous detector.
-     * @param {String} sessionId 
+     * @summary Wires disconnected SSE session state to the summarization pipeline.
+     * @param {String} sessionId
      */
     queueSummarizationJob(sessionId) {
         if (!aiConfig.autoSummarize) return;
@@ -695,13 +696,13 @@ ${aggregatedContent}
             db.prepare(`
                 INSERT INTO SummarizationJobs (session_id, status)
                 VALUES (?, 'pending')
-                ON CONFLICT(session_id) DO UPDATE SET 
+                ON CONFLICT(session_id) DO UPDATE SET
                     status = 'pending',
                     lease_token = NULL,
                     expires_at = NULL
                 WHERE status != 'completed' AND status != 'in_progress'
             `).run(sessionId);
-            
+
             // Asynchronously trigger processing so we don't block the caller (e.g. disconnect lifecycle)
             setTimeout(() => this.processPendingSummarizations(), 100);
         } catch (e) {
@@ -711,16 +712,17 @@ ${aggregatedContent}
 
     /**
      * Finds pending summarization jobs and attempts to process them.
+     * @summary Asynchronously resolves pending state markers from disconnected sessions without blocking main loops.
      */
     async processPendingSummarizations() {
         const db = GraphService.db?.storage?.db;
         if (!db) return;
-        
+
         try {
             const pendingJobs = db.prepare(`
                 SELECT session_id FROM SummarizationJobs WHERE status = 'pending'
             `).all();
-            
+
             for (const job of pendingJobs) {
                 // Background execution. The inner call uses claimSummarizationJob to get a lease.
                 this.summarizeSessions({ sessionId: job.session_id }).catch(e => {
@@ -735,22 +737,22 @@ ${aggregatedContent}
     /**
      * Claims an exclusive lease on a summarization job using the SummarizationJobs table.
      * Prevents race conditions across concurrent MCP instances.
-     * @param {String} sessionId 
-     * @param {String} leaseToken 
+     * @param {String} sessionId
+     * @param {String} leaseToken
      * @param {Number} [ttlMs=300000] Default 5-minute lease
      * @returns {Boolean} true if the lease was claimed successfully, false otherwise.
      */
     claimSummarizationJob(sessionId, leaseToken, ttlMs = 300000) {
         const db = GraphService.db?.storage?.db;
         if (!db) return true; // Fallback: allow execution if DB is somehow missing
-        
+
         const now = Date.now();
         const expiresAt = now + ttlMs;
-        
+
         try {
             const claimTx = db.transaction(() => {
                 const existing = db.prepare('SELECT status, expires_at FROM SummarizationJobs WHERE session_id = ?').get(sessionId);
-                
+
                 if (!existing) {
                     db.prepare(`
                         INSERT INTO SummarizationJobs (session_id, status, lease_token, expires_at, retry_count)
@@ -758,32 +760,32 @@ ${aggregatedContent}
                     `).run(sessionId, leaseToken, expiresAt);
                     return true;
                 }
-                
+
                 if (existing.status === 'completed') {
                     return false;
                 }
-                
+
                 if (existing.status === 'in_progress' && existing.expires_at < now) {
                     db.prepare(`
-                        UPDATE SummarizationJobs 
+                        UPDATE SummarizationJobs
                         SET lease_token = ?, expires_at = ?, retry_count = retry_count + 1
                         WHERE session_id = ?
                     `).run(leaseToken, expiresAt, sessionId);
                     return true;
                 }
-                
+
                 if (existing.status === 'pending' || existing.status === 'failed') {
                      db.prepare(`
-                        UPDATE SummarizationJobs 
+                        UPDATE SummarizationJobs
                         SET status = 'in_progress', lease_token = ?, expires_at = ?, retry_count = retry_count + 1
                         WHERE session_id = ?
                     `).run(leaseToken, expiresAt, sessionId);
                     return true;
                 }
-                
+
                 return false;
             });
-            
+
             return claimTx();
         } catch (e) {
             logger.warn(`[SessionService] Error claiming job for ${sessionId}: ${e.message}`);
@@ -793,15 +795,15 @@ ${aggregatedContent}
 
     /**
      * Marks a summarization job as completed in the coordinator table.
-     * @param {String} sessionId 
+     * @param {String} sessionId
      */
     completeSummarizationJob(sessionId) {
         const db = GraphService.db?.storage?.db;
         if (!db) return;
         try {
             db.prepare(`
-                UPDATE SummarizationJobs 
-                SET status = 'completed', lease_token = NULL 
+                UPDATE SummarizationJobs
+                SET status = 'completed', lease_token = NULL
                 WHERE session_id = ?
             `).run(sessionId);
         } catch (e) {
@@ -811,15 +813,15 @@ ${aggregatedContent}
 
     /**
      * Marks a summarization job as failed in the coordinator table.
-     * @param {String} sessionId 
+     * @param {String} sessionId
      */
     failSummarizationJob(sessionId) {
         const db = GraphService.db?.storage?.db;
         if (!db) return;
         try {
             db.prepare(`
-                UPDATE SummarizationJobs 
-                SET status = 'failed', lease_token = NULL 
+                UPDATE SummarizationJobs
+                SET status = 'failed', lease_token = NULL
                 WHERE session_id = ?
             `).run(sessionId);
         } catch (e) {

--- a/ai/mcp/server/shared/services/TransportService.mjs
+++ b/ai/mcp/server/shared/services/TransportService.mjs
@@ -126,7 +126,7 @@ class TransportService extends Base {
                 await server.mcpServer.connect(transport);
             }
 
-            // Propagate the authenticated identity into the async call chain so service methods
+            // Propagate the authenticated identity and sessionId into the async call chain so service methods
             // can tag ChromaDB writes and filter reads per tenant (ticket #10000 + #10145).
             //
             // Context-shape dispatch:
@@ -135,6 +135,8 @@ class TransportService extends Base {
             //   bindings like AgentIdentity graph-node IDs (memory-core's #10144 contract).
             // - Otherwise fall back to the minimal `{userId, username}` shape — sufficient for
             //   servers (knowledge-base, gh-workflow) that don't own an identity graph.
+            // - Finally, the `sessionId` from the transport is appended to whichever context
+            //   shape was resolved, making it available to downstream RequestContextService readers.
             //
             // `req.auth` is populated by the `requireBearerAuth` middleware when OIDC is
             // configured; when auth is disabled (local dev, no `aiConfig.auth.host` /

--- a/ai/mcp/server/shared/services/TransportService.mjs
+++ b/ai/mcp/server/shared/services/TransportService.mjs
@@ -115,7 +115,12 @@ class TransportService extends Base {
                 transport = new StreamableHTTPServerTransport({
                     sessionIdGenerator: () => crypto.randomUUID(),
                     onsessioninitialized: (id) => this.transports.set(id, transport),
-                    onsessionclosed: (id) => this.transports.delete(id)
+                    onsessionclosed: (id) => {
+                        this.transports.delete(id);
+                        if (typeof server.onSessionClosed === 'function') {
+                            server.onSessionClosed(id);
+                        }
+                    }
                 });
 
                 await server.mcpServer.connect(transport);

--- a/learn/agentos/SharedDeployment.md
+++ b/learn/agentos/SharedDeployment.md
@@ -68,6 +68,14 @@ See [`MemoryCore.md` §Healthcheck Response Shape](./MemoryCore.md) for the full
 
 The Knowledge Base's healthcheck mirrors the connectivity assertion (collection counts, embedding status). When both servers report `connected: true` against the same shared `{host, port}`, the topology is verified.
 
+## Asynchronous Session Summarization (Disconnect Trigger)
+
+In a shared deployment, multiple agents connect and disconnect dynamically. To ensure session summaries are automatically available to the team without requiring manual API calls or external cron jobs, the Memory Core leverages a **disconnect-triggered summarization** primitive.
+
+When an MCP client (agent) disconnects from the Server-Sent Events (SSE) transport, the `TransportService` intercepts the termination and signals the Memory Core. The server immediately queues a `pending` summarization marker in its `SummarizationJobs` SQLite coordinator table. This behavior is gated by the `autoSummarize` feature flag, making it a conditional feature rather than an unconditional contract.
+
+This allows the heavy LLM summarization process to run asynchronously in the background. Because it relies on the unified `SummarizationJobs` table, it naturally handles concurrent agent disconnects and server clustering without duplicating summaries. Team members can query the Memory Core and instantly access the completed session context once the background job finishes.
+
 ## Migration: Per-Developer Local → Shared Team Mode
 
 Teams adopting shared mode from per-developer local should follow this migration path:

--- a/test/playwright/unit/ai/mcp/server/memory-core/Server.spec.mjs
+++ b/test/playwright/unit/ai/mcp/server/memory-core/Server.spec.mjs
@@ -151,11 +151,11 @@ test.describe('Neo.ai.mcp.server.memory-core.Server', () => {
 
     test('onSessionClosed triggers SessionService.queueSummarizationJob', async () => {
         const SessionService = (await import('../../../../../../../ai/mcp/server/memory-core/services/SessionService.mjs')).default;
-        
+
         // Mock the SessionService method
         const originalQueue = SessionService.queueSummarizationJob.bind(SessionService);
         let queuedSessionId = null;
-        
+
         SessionService.queueSummarizationJob = function(sessionId) {
             queuedSessionId = sessionId;
         };

--- a/test/playwright/unit/ai/mcp/server/memory-core/Server.spec.mjs
+++ b/test/playwright/unit/ai/mcp/server/memory-core/Server.spec.mjs
@@ -148,4 +148,26 @@ test.describe('Neo.ai.mcp.server.memory-core.Server', () => {
         
         serverInstance.destroy();
     });
+
+    test('onSessionClosed triggers SessionService.queueSummarizationJob', async () => {
+        const SessionService = (await import('../../../../../../../ai/mcp/server/memory-core/services/SessionService.mjs')).default;
+        
+        // Mock the SessionService method
+        const originalQueue = SessionService.queueSummarizationJob.bind(SessionService);
+        let queuedSessionId = null;
+        
+        SessionService.queueSummarizationJob = function(sessionId) {
+            queuedSessionId = sessionId;
+        };
+
+        const serverInstance = Neo.create('Neo.ai.mcp.server.memory-core.Server');
+
+        try {
+            serverInstance.onSessionClosed('test-session-123');
+            expect(queuedSessionId).toBe('test-session-123');
+        } finally {
+            SessionService.queueSummarizationJob = originalQueue;
+            serverInstance.destroy();
+        }
+    });
 });

--- a/test/playwright/unit/ai/mcp/server/shared/services/TransportService.spec.mjs
+++ b/test/playwright/unit/ai/mcp/server/shared/services/TransportService.spec.mjs
@@ -1,0 +1,94 @@
+import {setup} from '../../../../../../setup.mjs';
+
+const appName = 'TransportServiceTest';
+
+setup({
+    neoConfig: {
+        unitTestMode: true
+    },
+    appConfig: {
+        name             : appName,
+        isMounted        : () => true,
+        vnodeInitialising: false
+    }
+});
+
+import { test, expect } from '@playwright/test';
+import http from 'http';
+import Neo from '../../../../../../../../src/Neo.mjs';
+import * as core from '../../../../../../../../src/core/_export.mjs';
+
+test.describe('Neo.ai.mcp.server.shared.services.TransportService', () => {
+
+    test('onsessionclosed hook removes transport and calls server.onSessionClosed via actual HTTP request', async () => {
+        const TransportService = (await import('../../../../../../../../ai/mcp/server/shared/services/TransportService.mjs')).default;
+
+        let closedSessionId = null;
+        let resolveClosed;
+        const closedPromise = new Promise(resolve => resolveClosed = resolve);
+
+        const mockServer = {
+            mcpServer: { connect: async () => {} },
+            onSessionClosed: (id) => {
+                closedSessionId = id;
+                resolveClosed();
+            }
+        };
+
+        const testPort = 3125;
+        const mockAiConfig = { ssePort: testPort, auth: {} };
+        const mockLogger = { info: () => {} };
+
+        // Setup the real transport service which starts the Express app
+        await TransportService.setup({
+            server: mockServer,
+            aiConfig: mockAiConfig,
+            logger: mockLogger,
+            resourceName: 'TestResource'
+        });
+
+        // 1. Initialize the session via POST
+        const initResponse = await fetch(`http://localhost:${testPort}/mcp`, {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json',
+                'Accept': 'application/json, text/event-stream'
+            },
+            body: JSON.stringify({
+                jsonrpc: "2.0",
+                id: 1,
+                method: "initialize",
+                params: {
+                    protocolVersion: "2024-11-05",
+                    capabilities: {},
+                    clientInfo: { name: "test", version: "1.0.0" }
+                }
+            })
+        });
+
+        const sessionId = initResponse.headers.get('mcp-session-id');
+
+        // 2. Terminate the session via DELETE
+        // This triggers handleDeleteRequest -> onsessionclosed
+        await fetch(`http://localhost:${testPort}/mcp`, {
+            method: 'DELETE',
+            headers: {
+                'mcp-session-id': sessionId,
+                'mcp-protocol-version': '2024-11-05'
+            }
+        });
+
+        // Wait for the server-side callback to fire
+        await closedPromise;
+
+        // Verify the server's onSessionClosed was called with a valid string ID
+        expect(typeof closedSessionId).toBe('string');
+        expect(closedSessionId.length).toBeGreaterThan(0);
+
+        // Verify the transport service map was cleaned up
+        expect(TransportService.transports.has(closedSessionId)).toBe(false);
+
+        TransportService.destroy();
+    });
+
+});


### PR DESCRIPTION
Authored by Gemini 3.1 Pro (Antigravity). Session 79042442-bebc-431d-8968-8a2e7d7a1151.

Resolves #10726
Related: #10721

Wired the disconnect-triggered summarization in the `memory-core` server. Now when a client disconnects via the SSE transport, a completion marker (`status='pending'`) is queued in the `SummarizationJobs` table, which triggers `processPendingSummarizations` asynchronously to summarize the disconnected session. This behavior is explicitly gated by the `autoSummarize` feature flag. This completes the implementation for #10726 and advances #10721.

Evidence: L3 (Integration test verifying `onsessionclosed` via HTTP request in `TransportService.spec.mjs`). No residuals. Documentation updated in `SharedDeployment.md` to clarify the `autoSummarize` condition.

## Deltas from ticket
None. Implemented asynchronous loop directly utilizing existing `SummarizationJobs` coordinator logic without blocking the disconnect phase. Included tests and documented behavior in `learn/agentos/SharedDeployment.md` as requested.
