### PR TITLE
feat(memory-core): surface active embedding provider in healthcheck (#10723)

### DIFF
--- a/ai/mcp/server/memory-core/services/HealthService.mjs
+++ b/ai/mcp/server/memory-core/services/HealthService.mjs
@@ -100,6 +100,75 @@ export function buildTopologyBlock(cfg) {
 }
 
 /**
+ * @summary Projects the active embedding-provider configuration into the healthcheck `providers.embedding`
+ *          observability block (#10723).
+ *
+ * Pure function: takes an `aiConfig`-shaped input and returns the active embedding provider with
+ * its host, model, and configured vector dimension. Mirrors the {@link buildTopologyBlock} precedent
+ * for module-scope pure projections.
+ *
+ * **Why this block exists:** Operators deploying the shared MC/KB topology against a local-model stack
+ * (e.g., MLX-served Qwen3 embedding model) need an observable surface confirming WHICH embedding
+ * provider is currently active and WHICH model + endpoint is in use. Without this, a misconfigured
+ * `NEO_CHROMA_EMBEDDING_PROVIDER` env var (silently defaulting to Gemini cloud while the operator
+ * believes a local provider is wired) is undetectable until cross-tenant retrieval drift emerges.
+ *
+ * **What this block reports:**
+ * - `active`: which provider key is currently selected for ChromaDB embedding generation
+ *   (`'gemini'` | `'openAiCompatible'` | `'ollama'`)
+ * - `host`: resolved provider endpoint URL (when applicable; `null` for cloud providers)
+ * - `model`: resolved embedding model name
+ * - `dimensions`: configured vector dimension (`vectorDimension` config; load-bearing because
+ *   ChromaDB collections are pinned to dimensions at creation, mismatch causes silent insert failures)
+ *
+ * **Defensive fallback:** if the active provider key isn't recognized, the block surfaces
+ * `{active: <unknown-key>, host: null, model: null, dimensions: <vectorDimension>, error: <msg>}`
+ * so operators see the misconfig directly. Aligns with "surface, don't obscure" (PR #10227).
+ *
+ * @param {Object} cfg aiConfig-shaped input. Reads `cfg.chromaEmbeddingProvider`,
+ *     `cfg.openAiCompatible.{host, embeddingModel}`, `cfg.ollama.{host, embeddingModel}`,
+ *     `cfg.embeddingModel` (Gemini path), `cfg.vectorDimension`.
+ * @returns {{active: String, host: String|null, model: String|null, dimensions: Number, error?: String}}
+ * @see learn/agentos/SharedDeployment.md
+ */
+export function buildEmbeddingProviderBlock(cfg) {
+    const active     = cfg.chromaEmbeddingProvider;
+    const dimensions = cfg.vectorDimension;
+
+    switch (active) {
+        case 'openAiCompatible':
+            return {
+                active,
+                host      : cfg.openAiCompatible?.host || null,
+                model     : cfg.openAiCompatible?.embeddingModel || null,
+                dimensions
+            };
+        case 'ollama':
+            return {
+                active,
+                host      : cfg.ollama?.host || null,
+                model     : cfg.ollama?.embeddingModel || null,
+                dimensions
+            };
+        case 'gemini':
+            return {
+                active,
+                host      : null,
+                model     : cfg.embeddingModel || null,
+                dimensions
+            };
+        default:
+            return {
+                active,
+                host      : null,
+                model     : null,
+                dimensions,
+                error     : `Unrecognized chromaEmbeddingProvider: '${active}'. Expected 'gemini' | 'openAiCompatible' | 'ollama'.`
+            };
+    }
+}
+
+/**
  * @summary Monitors and validates the ChromaDB dependency for the Memory Core MCP server.
  *
  * This service acts as a gatekeeper, ensuring that ChromaDB is properly running,
@@ -504,6 +573,9 @@ class HealthService extends Base {
             mailboxPreview: await MailboxService.getHealthcheckPreview(),
             identity : buildIdentityBlock(this.#stdioIdentityState),
             migration: await this.#checkMigrationState(),
+            providers: {
+                embedding: buildEmbeddingProviderBlock(aiConfig)
+            },
             details  : [],
             version  : process.env.npm_package_version || '1.0.0',
             uptime   : process.uptime()

--- a/learn/agentos/SharedDeployment.md
+++ b/learn/agentos/SharedDeployment.md
@@ -27,6 +27,8 @@ The shared MVP topology preserves three independent boundaries:
 
 ## Configuration
 
+### Topology mode
+
 The single operator-facing flag is `NEO_CHROMA_UNIFIED`:
 
 ```bash
@@ -44,6 +46,45 @@ The flag is read by both `ai/mcp/server/knowledge-base/config.template.mjs` and 
 In unified mode, the Memory Core's `ChromaClient` targets the Knowledge Base's Chroma coordinates (`engines.kb.chroma.{host, port}`) instead of its own (`engines.chroma.{host, port}`). The KB's local config defines the canonical shared coordinates; MC reads through them.
 
 **Connection contract:** the shared Chroma instance MUST be reachable from every developer's machine — typically a team-managed cloud service (e.g., a managed Chroma cluster) or a shared internal host. The `engines.kb.chroma.{host, port}` config in the KB's `config.mjs` is where operators point at the team's shared instance.
+
+### Embedding provider
+
+ChromaDB's embedding generation is provider-pluggable. The active provider is controlled by `NEO_CHROMA_EMBEDDING_PROVIDER`; supported values are `'gemini'` (default, cloud), `'ollama'` (local), and `'openAiCompatible'` (local OpenAI-format servers including MLX-served Qwen3 models, llama.cpp, LM Studio, etc.).
+
+```bash
+# Default: Google Gemini cloud embedding (gemini-embedding-001):
+unset NEO_CHROMA_EMBEDDING_PROVIDER
+# or
+export NEO_CHROMA_EMBEDDING_PROVIDER=gemini
+
+# Local OpenAI-compatible embedding (e.g. Qwen3 family via MLX):
+export NEO_CHROMA_EMBEDDING_PROVIDER=openAiCompatible
+export NEO_OPENAI_COMPATIBLE_HOST=http://127.0.0.1:8000              # MLX server endpoint
+export NEO_OPENAI_COMPATIBLE_EMBEDDING_MODEL=text-embedding-qwen3-embedding-1.5b  # Qwen3-1.5B variant
+# OR for the 8B variant:
+# export NEO_OPENAI_COMPATIBLE_EMBEDDING_MODEL=text-embedding-qwen3-embedding-8b
+export NEO_OPENAI_COMPATIBLE_API_KEY=                                # leave empty for local servers
+
+# Local Ollama embedding:
+export NEO_CHROMA_EMBEDDING_PROVIDER=ollama
+export NEO_OLLAMA_HOST=http://127.0.0.1:11434
+export NEO_OLLAMA_EMBEDDING_MODEL=qwen3-embedding
+```
+
+**Vector dimension is independently pinned** via `NEO_VECTOR_DIMENSION` (default 4096 = 4k dims, matching Qwen3 family). ChromaDB collections are created with this dimension; mismatch between the embedding model's actual output dimension and `vectorDimension` causes silent insert failures or shape errors. Operators MUST match the dimension to the active embedding model:
+
+```bash
+# Qwen3 family default 4k (matches text-embedding-qwen3-embedding-1.5b/8b output):
+export NEO_VECTOR_DIMENSION=4096
+# Gemini gemini-embedding-001:
+export NEO_VECTOR_DIMENSION=3072
+# Smaller models (768/1024):
+export NEO_VECTOR_DIMENSION=768
+```
+
+A sibling override `NEO_EMBEDDING_PROVIDER` controls the SQLite-side embedding path (`neoEmbeddingProvider`) for native-edge-graph operations; in most shared deployments it should match `NEO_CHROMA_EMBEDDING_PROVIDER` for consistency, but it can diverge when the SQLite and ChromaDB engines use different providers intentionally.
+
+**Substrate observation (#10723):** the OpenAI-compatible embedding path is implemented inside `ai/mcp/server/memory-core/services/TextEmbeddingService.mjs#embedText[s]` (POST to `${host}/v1/embeddings` with `{model, input}` payload, parsing `result.data[*].embedding`). It is NOT routed through the `Neo.ai.provider.OpenAiCompatible` class — that class currently exposes `generate` / `stream` (chat completions) but no `embed` method. This means the embedding-provider abstraction is functional but not yet symmetric with the chat-provider abstraction. Future hardening should consolidate the embedding path into the provider class hierarchy; out of scope for #10723 itself.
 
 ## Authentication
 
@@ -100,7 +141,7 @@ Every authenticated request carries a `source` tag through `Server.mjs#buildRequ
 
 The source tag is graph-ingested into agent-identity memory writes; an audit query against memories can verify the proportion of `'oidc'` vs `'proxy-header'` writes against operator expectations.
 
-A symmetric healthcheck `providers.auth` block is a recommended follow-up; tracked separately. Until then, source-tag observability is via memory-write audit only.
+A symmetric healthcheck `providers.auth` block is a recommended follow-up tracked under #10770. Until then, source-tag observability is via memory-write audit only.
 
 ## Healthcheck Verification
 
@@ -124,6 +165,27 @@ Three diagnostic fields:
 See [`MemoryCore.md` §Healthcheck Response Shape](./MemoryCore.md) for the full healthcheck payload contract.
 
 The Knowledge Base's healthcheck mirrors the connectivity assertion (collection counts, embedding status). When both servers report `connected: true` against the same shared `{host, port}`, the topology is verified.
+
+The Memory Core's healthcheck additionally surfaces the **active embedding provider** under `providers.embedding` (#10723):
+
+```json
+"providers": {
+    "embedding": {
+        "active": "openAiCompatible",
+        "host": "http://127.0.0.1:8000",
+        "model": "text-embedding-qwen3-embedding-1.5b",
+        "dimensions": 4096
+    }
+}
+```
+
+Four diagnostic fields:
+- `active`: the provider key currently selected for ChromaDB embedding generation (`'gemini'` | `'openAiCompatible'` | `'ollama'`). Mismatch between operator intent (e.g. expected local Qwen3) and observed value (e.g. silent fallback to `'gemini'` because `NEO_CHROMA_EMBEDDING_PROVIDER` was unset) is the load-bearing diagnostic.
+- `host`: provider endpoint URL when applicable (`null` for cloud `gemini`).
+- `model`: resolved embedding model name. Operators verify this matches the model running on the local server.
+- `dimensions`: configured `vectorDimension`. Must match the embedding model's actual output dimension; mismatch is silent in collection writes but breaks retrieval.
+
+If `active` resolves to an unrecognized value, the block additionally surfaces an `error` field naming the misconfig directly.
 
 ## Asynchronous Session Summarization (Disconnect Trigger)
 

--- a/test/playwright/unit/ai/mcp/server/memory-core/services/HealthService.spec.mjs
+++ b/test/playwright/unit/ai/mcp/server/memory-core/services/HealthService.spec.mjs
@@ -207,3 +207,105 @@ test.describe('HealthService #10127 — buildTopologyBlock', () => {
         expect(result.error).toMatch(/engines\.kb\.chroma/);
     });
 });
+
+/**
+ * @summary Coverage for the #10723 embedding-provider observability block in the healthcheck payload.
+ *
+ * Pins the pure-projection contract of `buildEmbeddingProviderBlock` — the module-scope function
+ * that extracts active embedding-provider state from `aiConfig` for the healthcheck `providers.embedding`
+ * field. Integration correctness (live provider request) is operator-territory L3 validation against
+ * a running local-model server; this spec covers the L1-L2 substrate shape that operators rely on
+ * to verify the provider configured matches the provider actually selected at boot.
+ *
+ * @see Neo.ai.mcp.server.memory-core.services.HealthService#buildEmbeddingProviderBlock
+ */
+test.describe('HealthService #10723 — buildEmbeddingProviderBlock', () => {
+    let buildEmbeddingProviderBlock;
+
+    test.beforeAll(async () => {
+        const mod = await import('../../../../../../../../ai/mcp/server/memory-core/services/HealthService.mjs');
+        buildEmbeddingProviderBlock = mod.buildEmbeddingProviderBlock;
+    });
+
+    test('openAiCompatible provider surfaces host + embeddingModel + dimensions', () => {
+        const cfg = {
+            chromaEmbeddingProvider: 'openAiCompatible',
+            vectorDimension        : 4096,
+            openAiCompatible       : {
+                host          : 'http://127.0.0.1:8000',
+                embeddingModel: 'text-embedding-qwen3-embedding-1.5b'
+            }
+        };
+        expect(buildEmbeddingProviderBlock(cfg)).toEqual({
+            active    : 'openAiCompatible',
+            host      : 'http://127.0.0.1:8000',
+            model     : 'text-embedding-qwen3-embedding-1.5b',
+            dimensions: 4096
+        });
+    });
+
+    test('ollama provider surfaces host + embeddingModel + dimensions', () => {
+        const cfg = {
+            chromaEmbeddingProvider: 'ollama',
+            vectorDimension        : 4096,
+            ollama                 : {
+                host          : 'http://127.0.0.1:11434',
+                embeddingModel: 'qwen3-embedding'
+            }
+        };
+        expect(buildEmbeddingProviderBlock(cfg)).toEqual({
+            active    : 'ollama',
+            host      : 'http://127.0.0.1:11434',
+            model     : 'qwen3-embedding',
+            dimensions: 4096
+        });
+    });
+
+    test('gemini provider surfaces null host + embeddingModel + dimensions', () => {
+        const cfg = {
+            chromaEmbeddingProvider: 'gemini',
+            vectorDimension        : 3072,
+            embeddingModel         : 'gemini-embedding-001'
+        };
+        expect(buildEmbeddingProviderBlock(cfg)).toEqual({
+            active    : 'gemini',
+            host      : null,
+            model     : 'gemini-embedding-001',
+            dimensions: 3072
+        });
+    });
+
+    test('unrecognized provider surfaces error field, does not throw', () => {
+        const cfg = {
+            chromaEmbeddingProvider: 'fooProvider',
+            vectorDimension        : 4096
+        };
+        const result = buildEmbeddingProviderBlock(cfg);
+        expect(result.active).toBe('fooProvider');
+        expect(result.host).toBeNull();
+        expect(result.model).toBeNull();
+        expect(result.dimensions).toBe(4096);
+        expect(result.error).toMatch(/Unrecognized chromaEmbeddingProvider/);
+    });
+
+    test('openAiCompatible without nested config surfaces null host + null model + dimensions', () => {
+        const cfg = {
+            chromaEmbeddingProvider: 'openAiCompatible',
+            vectorDimension        : 4096
+            // openAiCompatible config block deliberately absent — defensive against incomplete config
+        };
+        expect(buildEmbeddingProviderBlock(cfg)).toEqual({
+            active    : 'openAiCompatible',
+            host      : null,
+            model     : null,
+            dimensions: 4096
+        });
+    });
+
+    test('dimensions field always reflects vectorDimension regardless of provider', () => {
+        for (const provider of ['gemini', 'openAiCompatible', 'ollama', 'unrecognized']) {
+            const cfg = {chromaEmbeddingProvider: provider, vectorDimension: 768};
+            expect(buildEmbeddingProviderBlock(cfg).dimensions).toBe(768);
+        }
+    });
+});


### PR DESCRIPTION
## ⚠️ Follow-up tickets (do not lose at merge)

Per @neo-gemini-3-1-pro's review (commentId IC_kwDODSospM8AAAABBTBnRg, "Approve+Follow-Up" status):

- **#10773** — `providers.neoEmbedding` healthcheck observability (SQLite-side, symmetric to this PR's `providers.embedding`). Recommended Option B (restructure `providers.embedding` into nested `chroma` + `neo` subfields) since consumer count is still 0.
- **#10770** — `providers.auth` healthcheck observability (auth dimension; cross-PR observation from #10727 review).
- **#10772** — Unit test coverage for proxy-identity injection in `TransportService` (security-relevant trust-boundary; missing in #10768).

These do not block this PR — post-trial polish that extends this PR's substrate observation pattern.

---

## Summary

Sub of #10721 — Shared deployment MVP completeness gaps. Closes #10723 (Local embedding provider validation).

Surfaces the active ChromaDB embedding provider configuration via the Memory Core healthcheck payload's new `providers.embedding` field. Operators deploying the shared MC/KB topology against a local-model stack (e.g. MLX-served Qwen3 family) can now verify at-a-glance which provider is actually selected at boot.

## What ships

| Surface | Change |
|---|---|
| `ai/mcp/server/memory-core/services/HealthService.mjs` | `buildEmbeddingProviderBlock(cfg)` pure projection function added; healthcheck payload extended with top-level `providers.embedding` field |
| `learn/agentos/SharedDeployment.md` | New "Embedding provider" subsection in `## Configuration`. Healthcheck Verification section extended. Rebased onto current dev to coexist with `## Authentication` from #10769. |
| `test/playwright/unit/ai/mcp/server/memory-core/services/HealthService.spec.mjs` | 6 unit tests covering all 3 supported providers + error surface + defensive missing-config + dimension invariance |

## Substrate observation flagged in docs

The OpenAI-compatible embedding path is implemented inside `TextEmbeddingService.embedText[s]` (raw fetch to `/v1/embeddings`), NOT routed through the `OpenAiCompatible` provider class which exposes only `generate` / `stream` (chat). Provider abstraction is functional but **asymmetric**. Documented; future hardening is out of scope for #10723.

## Acceptance Criteria

- [x] **AC1** — `OpenAiCompatible` abstraction validation: code-path traced; live L3 against running Qwen3 is operator-territory at trial time (post-merge follow-up).
- [x] **AC2** — Operator config path documented in `SharedDeployment.md` with env-var paths for all 3 providers + vector-dimension pinning.
- [x] **AC3** — Healthcheck `providers.embedding` block with `{active, host, model, dimensions}` (+ `error` on misconfig).
- [x] **AC4** — Abstraction interface gap flagged + documented.

## Cross-Family Review

- **Reviewer:** @neo-gemini-3-1-pro
- **Verdict:** Approve+Follow-Up via comment IC_kwDODSospM8AAAABBTBnRg
- **Metrics:** `[ARCH_ALIGNMENT]` 100 / `[CONTENT_COMPLETENESS]` 100 / `[EXECUTION_QUALITY]` 100 / `[PRODUCTIVITY]` 100 / `[IMPACT]` 80 / `[COMPLEXITY]` 40 / `[EFFORT_PROFILE]` Quick Win
- **Test-Execution Audit verified:** 15/15 tests pass against PR branch
- **Follow-up filed:** #10773 (neoEmbedding observability)

## Rebase note

Rebased onto current `dev` (post-#10764, #10768, #10769) on 2026-05-05 to resolve `SharedDeployment.md` merge conflict (both this PR and #10769 added sections between `## Configuration` and `## Healthcheck Verification`). Resolution: my `### Embedding provider` subsection lands UNDER `## Configuration`; #10769's `## Authentication` section is the new top-level section between `Configuration` and `Healthcheck Verification`. New head: `fb1d33d55`. Tests pass post-rebase (15/15).

## Out of Scope

- Consolidating `OpenAiCompatible` provider class to grow `embed` method (separate follow-up)
- L3 live-server validation (operator-territory)
- `providers.neoEmbedding` SQLite-side visibility (follow-up #10773)

## Related

- **Parent epic:** #10721
- **Sibling subs:** #10724 (PR #10771, GPT), #10727 (PR #10768 + #10769 merged)
- **Follow-ups:** #10770, #10772, #10773
- **Pattern precedents:** #10176 (`buildIdentityBlock`), #10127 (`buildTopologyBlock`)

Resolves #10723

Origin Session ID: 23b9cbcd-4938-4a46-b21a-0d48dd12e7e7