### PR TITLE
docs(agentos): document trustProxyIdentity threat model + operator config (#10727)

### DIFF
--- a/learn/agentos/SharedDeployment.md
+++ b/learn/agentos/SharedDeployment.md
@@ -45,6 +45,63 @@ In unified mode, the Memory Core's `ChromaClient` targets the Knowledge Base's C
 
 **Connection contract:** the shared Chroma instance MUST be reachable from every developer's machine — typically a team-managed cloud service (e.g., a managed Chroma cluster) or a shared internal host. The `engines.kb.chroma.{host, port}` config in the KB's `config.mjs` is where operators point at the team's shared instance.
 
+## Authentication
+
+Shared deployments need to know **which agent originated each request** so memories, summaries, and graph edges are attributed correctly. The Memory Core supports two authentication paths:
+
+1. **OIDC (default for production deployments)** — the operator deploys an OIDC identity provider (e.g. Keycloak, GitLab) and the MC server validates each SSE request's `Authorization: Bearer <token>` against it via `AuthService.verifyAccessToken`. The verified `userId` becomes the `req.auth` block consumed by `Server.mjs#buildRequestContext`. Source provenance: `source: 'oidc'`.
+
+2. **Proxy identity injection (for deployments fronted by an identity-aware proxy)** — when an `oauth2-proxy`-style reverse proxy already terminates OIDC and injects `X-PREFERRED-USERNAME` (or the oauth2-proxy-specific `X-Auth-Request-Preferred-Username`) into the upstream request, the MC server can read that header instead of running its own OIDC verification. Gated by `auth.trustProxyIdentity`. Source provenance: `source: 'proxy-header'`.
+
+The two paths are NOT mutually exclusive — `req.auth` (OIDC) takes precedence over the proxy header by design. The proxy path only fires when `req.auth` is absent (OIDC unconfigured or token missing) AND `trustProxyIdentity` is explicitly enabled.
+
+### Configuration: `trustProxyIdentity` (PR #10768 / #10727)
+
+```bash
+# Default — proxy header is IGNORED. OIDC-only operation:
+unset AUTH_TRUST_PROXY_IDENTITY
+# or
+export AUTH_TRUST_PROXY_IDENTITY=false
+
+# Enable proxy-identity injection (required for oauth2-proxy fronting deployments):
+export AUTH_TRUST_PROXY_IDENTITY=true
+```
+
+The flag lives in both `ai/mcp/server/knowledge-base/config.template.mjs` and `ai/mcp/server/memory-core/config.template.mjs` under the `auth` block, so both servers stay symmetric.
+
+### Threat model — load-bearing operational prerequisite
+
+**`trustProxyIdentity=true` shifts the trust anchor from the MC's own OIDC introspection to the proxy in front of the MC.** That trust shift is correct ONLY when the proxy:
+
+1. **Strips client-set values of `X-PREFERRED-USERNAME` and `X-Auth-Request-Preferred-Username` from incoming requests before forwarding upstream.** Without this, any client can set the header to any value and gain that identity. This is THE deployment prerequisite.
+2. **Sets the header itself based on its own validated authentication state.** Typically the proxy completes its own OIDC flow (against Keycloak, GitLab, or the team's IdP), and forwards the verified `preferred_username` claim as the upstream header.
+3. **Is positioned so the MC server is NEVER reachable from outside the proxy** — direct network access to the MC server bypasses the proxy and bypasses the trust boundary entirely. Typical deployment: MC bound to internal network only; proxy bound to public network; reverse-proxy hop is the only ingress.
+
+If any of the three is uncertain, **leave `trustProxyIdentity=false`** and stick with OIDC mode. The fallback is operational, not catastrophic — it just requires the MC server to do its own OIDC introspection per request.
+
+### Header conventions checked
+
+The proxy-identity reader checks two header names (in order):
+
+1. `x-preferred-username` — the canonical OIDC claim name forwarded as a header by most identity-aware proxies
+2. `x-auth-request-preferred-username` — the `oauth2-proxy`-specific convention (used when oauth2-proxy is configured with `--set-xauthrequest`)
+
+Either header satisfies the gate; the first non-empty value wins. Header-name matching is case-insensitive (Node.js HTTP semantics).
+
+### Source-tag observability
+
+Every authenticated request carries a `source` tag through `Server.mjs#buildRequestContext` so downstream services and log lines can distinguish the auth path empirically:
+
+| Path | `source` value | Trust anchor |
+|---|---|---|
+| OIDC introspection | `'oidc'` | MC's `AuthService.verifyAccessToken` |
+| Proxy header injection | `'proxy-header'` | The fronting proxy's deployment configuration |
+| Single-tenant fallthrough (no auth) | (empty) | None — local dev only |
+
+The source tag is graph-ingested into agent-identity memory writes; an audit query against memories can verify the proportion of `'oidc'` vs `'proxy-header'` writes against operator expectations.
+
+A symmetric healthcheck `providers.auth` block is a recommended follow-up; tracked separately. Until then, source-tag observability is via memory-write audit only.
+
 ## Healthcheck Verification
 
 The Memory Core's `healthcheck` MCP tool exposes the effective topology so operators can verify shared mode took effect without inspecting logs or re-running config through `node -e`:


### PR DESCRIPTION
## Summary

Doc-only follow-up to [PR #10768](https://github.com/neomjs/neo/pull/10768) (which I approved at b9c4c96). Adds an `## Authentication` section to `learn/agentos/SharedDeployment.md` covering the proxy-identity injection path introduced by `trustProxyIdentity`.

## Why this exists

PR #10768 ships the trust-boundary code correctly (OIDC precedence preserved, opt-in gate, source-tag propagation). What it doesn't ship is the **operator-facing documentation** explaining the load-bearing operational prerequisite: the fronting proxy MUST strip client-set values of `X-PREFERRED-USERNAME` (and oauth2-proxy variants) before forwarding upstream, AND set the header itself based on its own validated auth state, AND prevent direct MC ingress.

Without this doc, operators deploying against the partner trial could enable the flag without understanding the proxy-side prerequisite — silent security hole under any default-allow-headers reverse proxy.

I committed during my review of PR #10768 to take this doc as a follow-up rather than block #10768 for it. This PR closes that commitment.

## What ships

| Surface | Change |
|---|---|
| `learn/agentos/SharedDeployment.md` | New `## Authentication` section between `## Configuration` and `## Healthcheck Verification`. Covers OIDC vs proxy paths, the threat model (3 proxy prerequisites), header conventions (canonical + oauth2-proxy), source-tag observability, and the fallback discipline (when in doubt, leave the flag off) |

Doc-only. No code changes; no test changes. Diff: +57 lines.

## Acceptance Criteria

- [x] Authentication section added to `SharedDeployment.md`
- [x] `trustProxyIdentity` env-var path documented (`AUTH_TRUST_PROXY_IDENTITY=true|false`)
- [x] **Threat-model statement explicit** — proxy MUST strip client-set headers, set them itself, prevent direct ingress; if any uncertain, leave flag off
- [x] Both header conventions documented (`x-preferred-username` canonical + `x-auth-request-preferred-username` oauth2-proxy variant)
- [x] Source-tag observability documented (`source: 'oidc'` vs `'proxy-header'` vs empty)
- [x] OIDC precedence semantics explained (`req.auth` wins; proxy path only fires when OIDC absent + flag enabled)
- [x] No harness-private memory citations per `ticket-create-workflow §12`
- [x] Pairs structurally with the Embedding provider documentation added in PR #10767 (cycle-2 partner-trial doc track)

## Test Plan

- [x] `git diff --check` clean (no whitespace/tab issues)
- [x] Markdown renders correctly (table, fenced code blocks, hierarchical headings)
- [ ] Reviewer verifies the threat-model statement is operationally complete — three proxy prerequisites cover the load-bearing failure modes
- [ ] Reviewer confirms the doc placement (between Configuration and Healthcheck Verification) makes operational sense — operators reading top-down hit Authentication before the healthcheck verification surface

## Stepping-Back Reflection

This is the docs-only sibling of #10768's code change. I considered bundling them in a single PR (Gemini's), but the parallel-track shape gave us better velocity:
- Gemini ships #10768 (code) → human merge gate immediately
- I ship this doc PR alongside → human merge gate immediately
- Both land before partner trial without doc-blocker stalling code merge

If the doc PR had been a blocker on #10768, the trial deadline pressure would have created cycle-pressure on Gemini that wasn't load-bearing. The split was the right call.

## Cross-Family Review Mandate

Per `pull-request-workflow §6.1` cross-family review mandate. Routing the entry-pass to **@neo-gemini-3-1-pro** since this is the doc-side companion of her #10768 code work — fastest review-cycle for someone with full context on the auth substrate. @neo-gpt standby for tie-breaker.

## Out of Scope

- Symmetric healthcheck `providers.auth` block (similar to `providers.embedding` from #10767) — flagged in PR #10768 review as a non-blocking follow-up; will file as separate ticket post-trial
- Unit tests for the proxy-identity injection logic (`TransportService` testable; recommended in PR #10768 review) — Gemini's call whether to land in #10768 or follow-up
- Full OIDC flow operator-doc (Keycloak/GitLab provisioning steps) — operator-side concern; the contract surface is enough for the trial
- Audit-query example for source-tag observability — useful but post-trial polish

## Related

- **Parent epic:** #10721 (Shared deployment MVP completeness gaps)
- **Code PR (already approved):** #10768 (`feat(auth): add proxy identity injection via X-PREFERRED-USERNAME (#10727)`)
- **Sibling parallel-track:** PR #10767 (`feat(memory-core): surface active embedding provider in healthcheck (#10723)`)
- **Issue:** #10727

🤖 Author: @neo-opus-4-7 (Claude Opus 4.7 in Claude Code, 1M context)

Origin Session ID: 23b9cbcd-4938-4a46-b21a-0d48dd12e7e7

---

**Retroactively-filed ticket linkage (workflow correction 2026-05-05):**

Resolves #10774

This PR's work-product (the `## Authentication` section in `SharedDeployment.md`) is the doc-side companion of #10768's code substrate. The doc work deserves its own ticket per workflow discipline; #10774 was filed post-merge to close the graph linkage. Per @tobiu calibration: workflow > velocity even under operator-stated importance contexts. Memory-anchored as `feedback_workflow_discipline_over_velocity.md`.