### PR TITLE
feat(memory-core): add local chat summary provider (#10724)

### DIFF
--- a/ai/mcp/server/memory-core/openapi.yaml
+++ b/ai/mcp/server/memory-core/openapi.yaml
@@ -1394,8 +1394,71 @@ components:
           properties:
             summarization:
               type: boolean
-              description: "Indicates if the summarization feature is available (requires GEMINI_API_KEY)."
+              description: "Indicates if the summarization feature is available for the active provider."
               example: true
+        providers:
+          type: object
+          description: "Active model provider observability. Exposes provider keys, model names, endpoints, and booleans only; never secret values."
+          properties:
+            embedding:
+              type: object
+              description: "Active ChromaDB embedding provider route."
+              properties:
+                active:
+                  type: string
+                  example: "openAiCompatible"
+                host:
+                  type: string
+                  nullable: true
+                  example: "http://127.0.0.1:8000"
+                model:
+                  type: string
+                  nullable: true
+                  example: "text-embedding-qwen3-embedding-1.5b"
+                dimensions:
+                  type: integer
+                  example: 4096
+                error:
+                  type: string
+                  nullable: true
+                  example: null
+            summary:
+              type: object
+              description: "Active session-summary provider route."
+              properties:
+                active:
+                  type: string
+                  example: "openAiCompatible"
+                host:
+                  type: string
+                  nullable: true
+                  example: "http://127.0.0.1:11434"
+                model:
+                  type: string
+                  nullable: true
+                  example: "qwen3-8b"
+                endpoint:
+                  type: string
+                  nullable: true
+                  example: "http://127.0.0.1:11434/v1/chat/completions"
+                local:
+                  type: boolean
+                  description: "True when the configured endpoint is localhost / loopback."
+                  example: true
+                credential:
+                  type: object
+                  description: "Credential observability. Contains env var names and booleans only; never secret values."
+                  properties:
+                    env:
+                      type: string
+                      nullable: true
+                      example: "NEO_OPENAI_COMPATIBLE_API_KEY"
+                    configured:
+                      type: boolean
+                      example: false
+                    required:
+                      type: boolean
+                      example: false
         startup:
           type: object
           description: "Provides status on asynchronous tasks performed at server startup."

--- a/ai/mcp/server/memory-core/services/HealthService.mjs
+++ b/ai/mcp/server/memory-core/services/HealthService.mjs
@@ -169,6 +169,55 @@ export function buildEmbeddingProviderBlock(cfg) {
 }
 
 /**
+ * @summary Projects the active session-summary provider into the healthcheck `providers.summary`
+ *          observability block (#10724).
+ *
+ * The shared-deployment local-model validation path (#10724) needs operators to confirm that
+ * session summaries are routed to the intended chat API before waiting for a disconnect-triggered
+ * summarization run. This pure projection names the active provider, host, model, endpoint, local
+ * status, and credential env var without exposing secret values, mirroring the sibling
+ * {@link buildEmbeddingProviderBlock} operator-facing `providers.*` observability strategy.
+ *
+ * @param {Object} cfg aiConfig-shaped input containing `modelProvider`, `modelName`, and
+ *     `openAiCompatible.{host, model, apiKey}`.
+ * @param {Object} [env=process.env] Environment source used to test Gemini key presence in unit tests.
+ * @returns {{active: String, host: String|null, model: String|null, endpoint: String|null, local: Boolean, credential: Object}}
+ */
+export function buildSummaryProviderBlock(cfg, env = process.env) {
+    const active = cfg.modelProvider || 'gemini';
+
+    if (active === 'openAiCompatible') {
+        const host = cfg.openAiCompatible?.host || null;
+
+        return {
+            active,
+            host,
+            model     : cfg.openAiCompatible?.model || null,
+            endpoint  : host ? `${host}/v1/chat/completions` : null,
+            local     : !!host && /^https?:\/\/(127\.0\.0\.1|localhost|\[::1\])(?::|\/|$)/.test(host),
+            credential: {
+                env       : 'NEO_OPENAI_COMPATIBLE_API_KEY',
+                configured: !!cfg.openAiCompatible?.apiKey,
+                required  : false
+            }
+        };
+    }
+
+    return {
+        active,
+        host      : null,
+        model     : active === 'gemini' ? cfg.modelName || null : null,
+        endpoint  : null,
+        local     : false,
+        credential: {
+            env       : active === 'gemini' ? 'GEMINI_API_KEY' : null,
+            configured: active === 'gemini' ? !!env.GEMINI_API_KEY : true,
+            required  : active === 'gemini'
+        }
+    };
+}
+
+/**
  * @summary Monitors and validates the ChromaDB dependency for the Memory Core MCP server.
  *
  * This service acts as a gatekeeper, ensuring that ChromaDB is properly running,
@@ -574,7 +623,8 @@ class HealthService extends Base {
             identity : buildIdentityBlock(this.#stdioIdentityState),
             migration: await this.#checkMigrationState(),
             providers: {
-                embedding: buildEmbeddingProviderBlock(aiConfig)
+                embedding: buildEmbeddingProviderBlock(aiConfig),
+                summary  : buildSummaryProviderBlock(aiConfig)
             },
             details  : [],
             version  : process.env.npm_package_version || '1.0.0',

--- a/ai/mcp/server/memory-core/services/SessionService.mjs
+++ b/ai/mcp/server/memory-core/services/SessionService.mjs
@@ -3,6 +3,7 @@ import aiConfig from '../config.mjs';
 import Base from '../../../../../src/core/Base.mjs';
 import crypto from 'crypto';
 import GraphService from './GraphService.mjs';
+import OpenAiCompatibleProvider from '../../../../provider/OpenAiCompatible.mjs';
 import StorageRouter from '../managers/StorageRouter.mjs';
 import HealthService from './HealthService.mjs';
 import Json from '../../../../../src/util/Json.mjs';
@@ -10,8 +11,6 @@ import fs from 'fs';
 import path from 'path';
 import os from 'os';
 import logger from '../logger.mjs';
-import http from 'http';
-import https from 'https';
 import RequestContextService, {SHARED_USER_ID, normalizeUserId} from '../../shared/services/RequestContextService.mjs';
 
 /**
@@ -77,6 +76,13 @@ class SessionService extends Base {
     }
 
     /**
+     * @summary Initializes the active session summarization model from Memory Core provider config.
+     *
+     * The OpenAI-compatible path uses the shared `Neo.ai.provider.OpenAiCompatible` chat-completions
+     * abstraction so local models such as Qwen3-8b remain operator-configured models, not bespoke
+     * Memory Core provider classes. The provider configs are refreshed before each summary request to
+     * preserve the existing runtime-config mutation behavior used by tests and embedded operators.
+     *
      * @param {Object} config
      */
     construct(config) {
@@ -95,56 +101,23 @@ class SessionService extends Base {
 
         if (aiConfig.modelProvider === 'openAiCompatible') {
             logger.info(`[SessionService] Initializing generation model via OpenAI-Compatible API (${aiConfig.openAiCompatible.model})`);
+            const provider = Neo.create(OpenAiCompatibleProvider, {
+                apiKey   : aiConfig.openAiCompatible.apiKey,
+                host     : aiConfig.openAiCompatible.host,
+                modelName: aiConfig.openAiCompatible.model
+            });
+
             this.model = {
                 generateContent: async (promptText) => {
                     logger.info(`[OpenAiCompatible] Sending summarization prompt (${promptText.length} chars)`);
-                    return new Promise((resolve, reject) => {
-                        const url = new URL(`${aiConfig.openAiCompatible.host}/v1/chat/completions`);
-                        const client = url.protocol === 'https:' ? https : http;
-                        const payload = {
-                            model: aiConfig.openAiCompatible.model,
-                            messages: [{ role: 'user', content: promptText }],
-                            stream: false
-                        };
-                        const bodyData = Buffer.from(JSON.stringify(payload), 'utf8');
+                    provider.apiKey    = aiConfig.openAiCompatible.apiKey;
+                    provider.host      = aiConfig.openAiCompatible.host;
+                    provider.modelName = aiConfig.openAiCompatible.model;
 
-                        const headers = {
-                            'Content-Type': 'application/json',
-                            'Content-Length': bodyData.length
-                        };
+                    const result  = await provider.generate(promptText);
+                    const content = result.content || result.raw?.message?.content || '';
 
-                        if (aiConfig.openAiCompatible.apiKey) {
-                            headers['Authorization'] = `Bearer ${aiConfig.openAiCompatible.apiKey}`;
-                        }
-
-                        const req = client.request(url, {
-                            method: 'POST',
-                            headers,
-                            timeout: 60 * 60 * 1000 // 1 hour timeout
-                        }, (res) => {
-                            let chunks = [];
-                            res.on('data', c => chunks.push(c));
-                            res.on('end', () => {
-                                try {
-                                    const rawStr = Buffer.concat(chunks).toString('utf8');
-                                    if (res.statusCode < 200 || res.statusCode >= 300) {
-                                        logger.error(`[OpenAiCompatible] Error ${res.statusCode}: ${rawStr}`);
-                                        return reject(new Error(`OpenAiCompatible Status ${res.statusCode}: ${rawStr}`));
-                                    }
-                                    const data = JSON.parse(rawStr);
-                                    const content = data.choices?.[0]?.message?.content || '';
-                                    resolve({ response: { text: () => content } });
-                                } catch (e) {
-                                    reject(new Error(`OpenAiCompatible Parser Error: ${e.message}`));
-                                }
-                            });
-                        });
-
-                        req.on('error', e => reject(e));
-                        req.on('timeout', () => { req.destroy(); reject(new Error('OpenAiCompatible Request Timeout')); });
-                        req.write(bodyData);
-                        req.end();
-                    });
+                    return {response: {text: () => content}};
                 }
             };
         } else {

--- a/ai/provider/OpenAiCompatible.mjs
+++ b/ai/provider/OpenAiCompatible.mjs
@@ -24,6 +24,12 @@ class OpenAiCompatibleProvider extends Base {
          */
         modelName: 'gemma4:31b',
         /**
+         * @summary Optional bearer token for OpenAI-compatible API servers that require one.
+         *
+         * @member {String} apiKey=''
+         */
+        apiKey: '',
+        /**
          * @member {String} systemPrompt=''
          */
         systemPrompt: '',
@@ -147,7 +153,8 @@ class OpenAiCompatibleProvider extends Base {
             const response = await fetch(`${this.host}/v1/chat/completions`, {
                 method: 'POST',
                 headers: {
-                    'Content-Type': 'application/json'
+                    'Content-Type': 'application/json',
+                    ...(this.apiKey ? {Authorization: `Bearer ${this.apiKey}`} : {})
                 },
                 body: JSON.stringify(payload)
             });

--- a/learn/agentos/MemoryCore.md
+++ b/learn/agentos/MemoryCore.md
@@ -102,11 +102,33 @@ Operators running `healthcheck` (via MCP, or via the SSE `/healthcheck` endpoint
             "resolvedVia": "engines.chroma"
         }
     },
-    "features":  { "summarization": true },
+    "features": {
+        "summarization": true
+    },
     "startup":   { "summarizationStatus": "not_attempted", "summarizationDetails": null },
     "mailboxPreview": null,
     "identity":  { "source": "env-var", "bound": true, "nodeId": "@neo-opus-4-7" },
     "migration": { "memory": 0, "session": 0, "total": 0, "available": true },
+    "providers": {
+        "embedding": {
+            "active": "openAiCompatible",
+            "host": "http://127.0.0.1:8000",
+            "model": "text-embedding-qwen3-embedding-1.5b",
+            "dimensions": 4096
+        },
+        "summary": {
+            "active": "openAiCompatible",
+            "host": "http://127.0.0.1:11434",
+            "model": "qwen3-8b",
+            "endpoint": "http://127.0.0.1:11434/v1/chat/completions",
+            "local": true,
+            "credential": {
+                "env": "NEO_OPENAI_COMPATIBLE_API_KEY",
+                "configured": false,
+                "required": false
+            }
+        }
+    },
     "details":   ["Connected to an externally managed ChromaDB instance", "All features are operational"],
     "version":   "1.0.0",
     "uptime":    0.21
@@ -141,6 +163,23 @@ Introduced in #10017 (see `learn/agentos/tooling/MultiTenantMigrationGuide.md`).
 - `available`: `false` if the SQLite graph is not yet mounted (substrate-readiness signal, not a migration error).
 
 A zero `total` is the signal operators watch for to flip the `memorySharing` default from `'legacy'` to `'private'`.
+
+### `providers.summary` — Active Summary Model Route
+
+Introduced for local chat-API provider validation (#10724). The block sits beside `providers.embedding` (#10723) and surfaces which generation provider Memory Core will use for session summaries:
+
+| Field | Type | Meaning |
+|---|---|---|
+| `active` | `'gemini' \| 'openAiCompatible' \| string` | The active `modelProvider` config value for summarization. |
+| `host` | `string \| null` | The chat provider host for OpenAI-compatible APIs; `null` for Gemini. |
+| `model` | `string \| null` | The configured generation model (`modelName` for Gemini, `openAiCompatible.model` for OpenAI-compatible chat APIs). |
+| `endpoint` | `string \| null` | Chat-completions endpoint for OpenAI-compatible providers; `null` for Gemini. |
+| `local` | `boolean` | `true` when the endpoint host is `localhost`, `127.0.0.1`, or `[::1]`. |
+| `credential.env` | `string \| null` | Environment variable name operators use for the provider credential. Secret values are never exposed. |
+| `credential.configured` | `boolean` | Whether the credential env/config value is present. |
+| `credential.required` | `boolean` | Whether Memory Core requires the credential to mark summarization available. |
+
+For Qwen3-8b or another local OpenAI-compatible chat model, set `NEO_MODEL_PROVIDER=openAiCompatible`, `NEO_OPENAI_COMPATIBLE_HOST`, and `NEO_OPENAI_COMPATIBLE_MODEL`, then verify `providers.summary` before relying on disconnect-triggered summaries.
 
 ## Two-Stage Query Workflow
 

--- a/learn/agentos/SharedDeployment.md
+++ b/learn/agentos/SharedDeployment.md
@@ -86,6 +86,25 @@ A sibling override `NEO_EMBEDDING_PROVIDER` controls the SQLite-side embedding p
 
 **Substrate observation (#10723):** the OpenAI-compatible embedding path is implemented inside `ai/mcp/server/memory-core/services/TextEmbeddingService.mjs#embedText[s]` (POST to `${host}/v1/embeddings` with `{model, input}` payload, parsing `result.data[*].embedding`). It is NOT routed through the `Neo.ai.provider.OpenAiCompatible` class — that class currently exposes `generate` / `stream` (chat completions) but no `embed` method. This means the embedding-provider abstraction is functional but not yet symmetric with the chat-provider abstraction. Future hardening should consolidate the embedding path into the provider class hierarchy; out of scope for #10723 itself.
 
+### Summary provider
+
+Session summarization is controlled by `NEO_MODEL_PROVIDER`; supported values are `'gemini'` (default, cloud) and `'openAiCompatible'` (local OpenAI-format chat-completions servers such as MLX-served Qwen3-8b, llama.cpp, or LM Studio).
+
+```bash
+# Default: Google Gemini summarization:
+unset NEO_MODEL_PROVIDER
+# or
+export NEO_MODEL_PROVIDER=gemini
+
+# Local OpenAI-compatible chat summarization (e.g. Qwen3-8b via MLX):
+export NEO_MODEL_PROVIDER=openAiCompatible
+export NEO_OPENAI_COMPATIBLE_HOST=http://127.0.0.1:11434
+export NEO_OPENAI_COMPATIBLE_MODEL=qwen3-8b
+export NEO_OPENAI_COMPATIBLE_API_KEY=  # leave empty for local servers
+```
+
+This path uses the existing `Neo.ai.provider.OpenAiCompatible` chat-completions abstraction. Do not add a model-specific Qwen provider class for shared-deployment installs; local-model selection is an operator config concern.
+
 ## Authentication
 
 Shared deployments need to know **which agent originated each request** so memories, summaries, and graph edges are attributed correctly. The Memory Core supports two authentication paths:
@@ -166,7 +185,7 @@ See [`MemoryCore.md` §Healthcheck Response Shape](./MemoryCore.md) for the full
 
 The Knowledge Base's healthcheck mirrors the connectivity assertion (collection counts, embedding status). When both servers report `connected: true` against the same shared `{host, port}`, the topology is verified.
 
-The Memory Core's healthcheck additionally surfaces the **active embedding provider** under `providers.embedding` (#10723):
+The Memory Core's healthcheck additionally surfaces active provider observability under `providers.*` (#10723, #10724):
 
 ```json
 "providers": {
@@ -175,17 +194,39 @@ The Memory Core's healthcheck additionally surfaces the **active embedding provi
         "host": "http://127.0.0.1:8000",
         "model": "text-embedding-qwen3-embedding-1.5b",
         "dimensions": 4096
+    },
+    "summary": {
+        "active": "openAiCompatible",
+        "host": "http://127.0.0.1:11434",
+        "model": "qwen3-8b",
+        "endpoint": "http://127.0.0.1:11434/v1/chat/completions",
+        "local": true,
+        "credential": {
+            "env": "NEO_OPENAI_COMPATIBLE_API_KEY",
+            "configured": false,
+            "required": false
+        }
     }
 }
 ```
 
-Four diagnostic fields:
+Embedding diagnostic fields:
 - `active`: the provider key currently selected for ChromaDB embedding generation (`'gemini'` | `'openAiCompatible'` | `'ollama'`). Mismatch between operator intent (e.g. expected local Qwen3) and observed value (e.g. silent fallback to `'gemini'` because `NEO_CHROMA_EMBEDDING_PROVIDER` was unset) is the load-bearing diagnostic.
 - `host`: provider endpoint URL when applicable (`null` for cloud `gemini`).
 - `model`: resolved embedding model name. Operators verify this matches the model running on the local server.
 - `dimensions`: configured `vectorDimension`. Must match the embedding model's actual output dimension; mismatch is silent in collection writes but breaks retrieval.
 
 If `active` resolves to an unrecognized value, the block additionally surfaces an `error` field naming the misconfig directly.
+
+Summary diagnostic fields:
+- `active`: the provider key currently selected for session summarization (`'gemini'` | `'openAiCompatible'` | string).
+- `host`: chat provider host when applicable (`null` for cloud `gemini`).
+- `model`: resolved summary-generation model. Operators verify this matches the model running on the local server.
+- `endpoint`: chat-completions endpoint for OpenAI-compatible providers.
+- `local`: whether the endpoint is loopback / localhost.
+- `credential`: env var name plus `configured` / `required` booleans; secret values are never exposed.
+
+For disconnect-triggered summarization, keep `AUTO_SUMMARIZE=true` only after the local model is reachable and healthcheck shows the intended provider/model. If the local chat API is unavailable, Memory Core logs the summarization failure and keeps raw memories intact so the operator can retry.
 
 ## Asynchronous Session Summarization (Disconnect Trigger)
 

--- a/test/playwright/unit/ai/mcp/server/memory-core/services/HealthService.spec.mjs
+++ b/test/playwright/unit/ai/mcp/server/memory-core/services/HealthService.spec.mjs
@@ -309,3 +309,65 @@ test.describe('HealthService #10723 — buildEmbeddingProviderBlock', () => {
         }
     });
 });
+
+/**
+ * @summary Coverage for the #10724 summary-provider observability block in the healthcheck payload.
+ *
+ * Mirrors the sibling `providers.embedding` block from #10723: the end-to-end healthcheck depends on
+ * live Memory Core services, while the load-bearing contract for operators is the pure projection of
+ * active summary-provider config into a secret-free `providers.summary` shape.
+ *
+ * @see Neo.ai.mcp.server.memory-core.services.HealthService#buildSummaryProviderBlock
+ */
+test.describe('HealthService #10724 — buildSummaryProviderBlock', () => {
+    let buildSummaryProviderBlock;
+
+    test.beforeAll(async () => {
+        const mod = await import('../../../../../../../../ai/mcp/server/memory-core/services/HealthService.mjs');
+        buildSummaryProviderBlock = mod.buildSummaryProviderBlock;
+    });
+
+    test('openAiCompatible config surfaces Qwen3 chat endpoint without leaking API key value', () => {
+        const result = buildSummaryProviderBlock({
+            modelProvider: 'openAiCompatible',
+            openAiCompatible: {
+                host  : 'http://127.0.0.1:11434',
+                model : 'qwen3-8b',
+                apiKey: 'secret-value'
+            }
+        });
+
+        expect(result).toEqual({
+            active    : 'openAiCompatible',
+            host      : 'http://127.0.0.1:11434',
+            model     : 'qwen3-8b',
+            endpoint  : 'http://127.0.0.1:11434/v1/chat/completions',
+            local     : true,
+            credential: {
+                env       : 'NEO_OPENAI_COMPATIBLE_API_KEY',
+                configured: true,
+                required  : false
+            }
+        });
+    });
+
+    test('gemini config surfaces the Gemini key requirement', () => {
+        const result = buildSummaryProviderBlock({
+            modelProvider: 'gemini',
+            modelName    : 'gemini-2.5-flash'
+        }, {GEMINI_API_KEY: ''});
+
+        expect(result).toEqual({
+            active    : 'gemini',
+            host      : null,
+            model     : 'gemini-2.5-flash',
+            endpoint  : null,
+            local     : false,
+            credential: {
+                env       : 'GEMINI_API_KEY',
+                configured: false,
+                required  : true
+            }
+        });
+    });
+});

--- a/test/playwright/unit/ai/mcp/server/memory-core/services/SessionSummarization.spec.mjs
+++ b/test/playwright/unit/ai/mcp/server/memory-core/services/SessionSummarization.spec.mjs
@@ -293,6 +293,97 @@ test.describe('Memory Core Offline Summarization', () => {
         expect(finalPrompt.length).toBeGreaterThan(20000); 
     });
 
+    test('SessionService routes Qwen3 summaries through the OpenAiCompatible provider class', async () => {
+        if (!SDK.Memory_LifecycleService._initPromise) {
+            await SDK.Memory_LifecycleService.initAsync();
+        } else {
+            await SDK.Memory_LifecycleService.ready();
+        }
+        await SDK.Memory_SessionService.ready();
+        await SDK.Memory_ChromaManager.ready();
+
+        const OpenAiCompatibleProvider = (await import('../../../../../../../../ai/provider/OpenAiCompatible.mjs')).default;
+        const qwenSessionId = crypto.randomUUID();
+        const originalProviderConfig = {
+            apiKey       : SDK.Memory_Config.data.openAiCompatible.apiKey,
+            host         : SDK.Memory_Config.data.openAiCompatible.host,
+            model        : SDK.Memory_Config.data.openAiCompatible.model,
+            modelProvider: SDK.Memory_Config.data.modelProvider
+        };
+        const originalGenerate = OpenAiCompatibleProvider.prototype.generate;
+        let capturedPrompt = '';
+        let capturedProviderConfig = null;
+
+        try {
+            SDK.Memory_Config.data.modelProvider = 'openAiCompatible';
+            SDK.Memory_Config.data.openAiCompatible.apiKey = 'qwen-secret';
+            SDK.Memory_Config.data.openAiCompatible.host = 'http://127.0.0.1:11434';
+            SDK.Memory_Config.data.openAiCompatible.model = 'qwen3-8b';
+
+            OpenAiCompatibleProvider.prototype.generate = async function(prompt) {
+                capturedPrompt = prompt;
+                capturedProviderConfig = {
+                    apiKey   : this.apiKey,
+                    host     : this.host,
+                    modelName: this.modelName
+                };
+
+                return {
+                    content: JSON.stringify({
+                        title              : "Qwen3 Summary",
+                        summary            : "Validated local chat summarization through an OpenAI-compatible Qwen3 model.",
+                        category           : "feature",
+                        quality            : 90,
+                        productivity       : 90,
+                        impact             : 60,
+                        complexity         : 30,
+                        technologies       : ["neo.mjs", "memory-core", "qwen3"],
+                        participatingAgents: ["developer"],
+                        models             : ["qwen3-8b"]
+                    })
+                };
+            };
+
+            await SDK.Memory_Service.addMemory({
+                prompt   : "Validate Qwen3 chat summarization",
+                thought  : "Exercise the local OpenAI-compatible chat summary path.",
+                response : "The summary should preserve structured metadata.",
+                agent    : "developer",
+                model    : "qwen3-8b",
+                sessionId: qwenSessionId
+            });
+
+            const result = await SDK.Memory_SessionService.summarizeSession(qwenSessionId);
+
+            expect(capturedProviderConfig).toEqual({
+                apiKey   : 'qwen-secret',
+                host     : 'http://127.0.0.1:11434',
+                modelName: 'qwen3-8b'
+            });
+            expect(capturedPrompt).toContain("Validate Qwen3 chat summarization");
+            expect(result).not.toBeNull();
+            expect(result.sessionId).toBe(qwenSessionId);
+            expect(result.memoryCount).toBe(1);
+
+            const summaryCollection = await SDK.Memory_ChromaManager.getSummaryCollection();
+            const savedSummary = await summaryCollection.get({
+                ids    : [result.summaryId],
+                include: ['metadatas', 'documents']
+            });
+
+            expect(savedSummary.ids.length).toBe(1);
+            expect(savedSummary.documents[0]).toContain("OpenAI-compatible Qwen3 model");
+            expect(savedSummary.metadatas[0].title).toBe("Qwen3 Summary");
+            expect(savedSummary.metadatas[0].models).toContain("qwen3-8b");
+        } finally {
+            OpenAiCompatibleProvider.prototype.generate = originalGenerate;
+            SDK.Memory_Config.data.modelProvider = originalProviderConfig.modelProvider;
+            SDK.Memory_Config.data.openAiCompatible.apiKey = originalProviderConfig.apiKey;
+            SDK.Memory_Config.data.openAiCompatible.host = originalProviderConfig.host;
+            SDK.Memory_Config.data.openAiCompatible.model = originalProviderConfig.model;
+        }
+    });
+
     test('SessionService limits toolsUsed stringification to prevent prompt explosion', async () => {
         if (!SDK.Memory_LifecycleService._initPromise) {
             await SDK.Memory_LifecycleService.initAsync();


### PR DESCRIPTION
Resolves #10724

Authored by GPT-5 (Codex Desktop). Session 2821a9d4-7634-4fe7-a8a2-daf49253b929.

Routes Memory Core openAiCompatible session summarization through the shared `Neo.ai.provider.OpenAiCompatible` provider, preserving runtime config refresh so local chat models like Qwen3-8b remain config-selected. After rebasing over #10767, the healthcheck metadata now extends the new top-level provider observability surface as `providers.summary` beside `providers.embedding`, with matching OpenAPI/schema docs and SharedDeployment/MemoryCore operator docs.

Evidence: L3 (focused Playwright specs + live local openAiCompatible/gemma chat path; Qwen3 path validated via provider-class unit route because local chat daemon exposed no Qwen3 chat model) → L3 required (#10724). Residual: none.

## Deltas from ticket
- Reused the shared OpenAiCompatible provider instead of retaining the inline HTTP client.
- Added apiKey support to provider stream headers for authenticated local gateways.
- Rebased over #10767 and aligned summary observability with the new `providers.*` healthcheck shape: `providers.embedding` from #10767, `providers.summary` from this PR.
- Confirmed local `127.0.0.1:1234/v1/models` currently exposes Gemma chat plus Qwen embedding models, not a Qwen3 chat model; the PR keeps the Qwen3 chat config path validated and documented for operator-provided models.

## Test Evidence
- `npx playwright test test/playwright/unit/ai/mcp/server/memory-core/services/HealthService.spec.mjs` — 17 passed after rebase over #10767.
- `npx playwright test test/playwright/unit/ai/mcp/server/memory-core/services/SessionSummarization.spec.mjs` — 6 passed after sandbox escalation for local ChromaDB.
- `git diff --check` — passed.
- `git diff --cached --check` — passed during conflict resolution.
- `git diff --check origin/dev...HEAD` — passed after rebase.
- `curl -L http://127.0.0.1:1234/v1/models` — local endpoint reachable; no Qwen3 chat model listed.
- `curl -L http://127.0.0.1:11434/v1/models` — no local server on port 11434.

## Post-Merge Validation
- [ ] On the external partner trial host, set `NEO_MODEL_PROVIDER=openAiCompatible`, `NEO_OPENAI_COMPATIBLE_HOST`, and `NEO_OPENAI_COMPATIBLE_MODEL=qwen3-8b`, then verify `healthcheck.providers.summary` before enabling or observing disconnect summarization.

## Commit
- `220ea1915` — `feat(memory-core): add local chat summary provider (#10724)`

## Evolution
Claude parallel #10723 pass found OpenAI-compatible embeddings still bypass the shared provider class and introduced `providers.embedding`. This PR validates the summary/chat side as the symmetric chat path: Memory Core summarization now calls `Neo.ai.provider.OpenAiCompatible.generate()` and exposes `providers.summary` as the parallel summary-provider observability block.