### PR TITLE
feat(auth): enforce 401 rejection for missing proxy identity (#10727)

### DIFF
--- a/ai/mcp/server/shared/services/TransportService.mjs
+++ b/ai/mcp/server/shared/services/TransportService.mjs
@@ -154,6 +154,7 @@ class TransportService extends Base {
                         source: 'proxy-header'
                     };
                 } else {
+                    req.app.locals.logger?.warn('Unauthorized: trustProxyIdentity is enabled but X-PREFERRED-USERNAME header is missing');
                     res.status(401).json({ error: 'Unauthorized: Missing proxy identity header' });
                     return;
                 }

--- a/ai/mcp/server/shared/services/TransportService.mjs
+++ b/ai/mcp/server/shared/services/TransportService.mjs
@@ -153,6 +153,9 @@ class TransportService extends Base {
                         username: proxyUserId,
                         source: 'proxy-header'
                     };
+                } else {
+                    res.status(401).json({ error: 'Unauthorized: Missing proxy identity header' });
+                    return;
                 }
             }
 

--- a/learn/agentos/SharedDeployment.md
+++ b/learn/agentos/SharedDeployment.md
@@ -113,7 +113,7 @@ Shared deployments need to know **which agent originated each request** so memor
 
 2. **Proxy identity injection (for deployments fronted by an identity-aware proxy)** — when an `oauth2-proxy`-style reverse proxy already terminates OIDC and injects `X-PREFERRED-USERNAME` (or the oauth2-proxy-specific `X-Auth-Request-Preferred-Username`) into the upstream request, the MC server can read that header instead of running its own OIDC verification. Gated by `auth.trustProxyIdentity`. Source provenance: `source: 'proxy-header'`.
 
-The two paths are NOT mutually exclusive — `req.auth` (OIDC) takes precedence over the proxy header by design. The proxy path only fires when `req.auth` is absent (OIDC unconfigured or token missing) AND `trustProxyIdentity` is explicitly enabled.
+The two paths are NOT mutually exclusive — `req.auth` (OIDC) takes precedence over the proxy header by design. The proxy path only fires when `req.auth` is absent (OIDC unconfigured or token missing) AND `trustProxyIdentity` is explicitly enabled. **If `trustProxyIdentity` is enabled and no valid proxy identity header is found, the request is actively rejected with a `401 Unauthorized` error.** This strict "Verify-Before-Assert" gate prevents requests from silently falling through to an unauthenticated single-tenant context in a shared deployment.
 
 ### Configuration: `trustProxyIdentity` (PR #10768 / #10727)
 


### PR DESCRIPTION
Authored by neo-gemini-3-1-pro (Gemini 3.1 Pro). Session 79042442-bebc-431d-8968-8a2e7d7a1151.

Resolves #10727

Implemented the missing 401 rejection gap when `trustProxyIdentity` is configured but the identity-aware proxy fails to inject the `X-PREFERRED-USERNAME` or `X-Auth-Request-Preferred-Username` header. This enforces the "Verify-Before-Assert" mandate and ensures downstream `RequestContextService` operations are not exposed to silent single-tenant fallthroughs when explicitly configured for shared-deployment topologies.

Evidence: L1 (static contract audit) → L3 required (Auth test coverage). Residual: AC2 [#10727].

## Deltas from ticket (if any)
OIDC/OAuth2.1 integration and generic identity extraction were previously implemented under #10768. This PR delivers the critical rejection path required by the #10727 acceptance criteria ("Return 401/403 if identity is missing or invalid.").

## Test Evidence
Static audit of the logic flow in `TransportService.mjs` against `req.auth` and `trustProxyIdentity` state variables.

## Post-Merge Validation
- [ ] Operator-side deployment tests with the identity proxy to ensure 401s are properly returned on missing headers.
