### PR TITLE
fix(test): serialize harness lifecycle spec (#10786)

### DIFF
--- a/test/playwright/unit/ai/scripts/harnessLifecycle.spec.mjs
+++ b/test/playwright/unit/ai/scripts/harnessLifecycle.spec.mjs
@@ -21,6 +21,9 @@ import path           from 'path';
 import os             from 'os';
 
 test.describe('ai/scripts/harnessLifecycle', () => {
+    // Shared harness-state identity writes one state file; keep this spec serial under default-worker runs.
+    test.describe.configure({mode: 'serial'});
+
     let harnessLifecycle;
     let getStateFilePath;
     const identity = '@neo-test-harness-agent';


### PR DESCRIPTION
Resolves #10786

Authored by GPT-5.5 (Codex Desktop). Session 2821a9d4-7634-4fe7-a8a2-daf49253b929.

Serializes `harnessLifecycle.spec.mjs` at the file describe level because its tests intentionally share one `@neo-test-harness-agent` harness-state identity and therefore one state-file path. This preserves the shared-identity coverage while preventing default-worker Playwright runs from racing on disk.

Evidence: L2 (default-worker Playwright unit reproduction + passing targeted wake-substrate suite) -> L2 required (AC1-AC3 unit/spec validation). No residuals.

## Deltas from ticket
Implemented Option A, the smallest local guardrail: `test.describe.configure({mode: "serial"})` plus an inline comment explaining the shared state-file constraint. No production substrate changes.

## Test Evidence
- Before fix: `npm run test-unit -- test/playwright/unit/ai/scripts/harnessLifecycle.spec.mjs` failed with 6 tests using 6 workers; `JSON.parse` read a concurrently-mutated shared state file.
- `git diff --check` passed.
- `npm run test-unit -- test/playwright/unit/ai/scripts/harnessLifecycle.spec.mjs` passed: 6 passed.
- `npm run test-unit -- test/playwright/unit/ai/scripts/harnessLifecycle.spec.mjs --workers=1` passed: 6 passed.
- Sandbox sibling batch hit expected write ceiling: readonly Memory Core SQLite and EPERM under `.neo-ai-data`.
- Escalated sibling batch passed: `npm run test-unit -- test/playwright/unit/ai/scripts/checkSunsetted.spec.mjs test/playwright/unit/ai/scripts/resumeHarness.spec.mjs test/playwright/unit/ai/scripts/wakeSafetyGate.spec.mjs test/playwright/unit/ai/scripts/swarm-heartbeat.spec.mjs` -> 44 passed, 2 skipped.
- Escalated combined acceptance suite passed: same sibling set plus `harnessLifecycle.spec.mjs` -> 50 passed, 2 skipped.

## Post-Merge Validation
- [ ] None; the close-target ACs are fully covered by the targeted unit runs above.

## Commit
- `924985a9e` — `fix(test): serialize harness lifecycle spec (#10786)`