### PR TITLE
feat(ai-daemons): SwarmHeartbeatService Neo-singleton heartbeat (#10789)

### DIFF
--- a/ai/daemons/SwarmHeartbeatService.mjs
+++ b/ai/daemons/SwarmHeartbeatService.mjs
@@ -430,7 +430,7 @@ class SwarmHeartbeatService extends Base {
     /**
      * Spawn a node subprocess for the named script and return its stdout.
      * Used for CLI-shape recovery scripts that haven't been refactored to
-     * dual-mode export (#10790).
+     * dual-mode export (#10795).
      * @param {String} scriptName Name of script under `ai/scripts/`
      * @param {String[]} [args=[]]
      * @returns {Promise<String>} stdout content

--- a/ai/daemons/SwarmHeartbeatService.mjs
+++ b/ai/daemons/SwarmHeartbeatService.mjs
@@ -1,0 +1,510 @@
+// IMPORTANT: `Neo` MUST be imported BEFORE any module that uses `Neo.gatekeep()` /
+// `Neo.setupClass()` at module-load time (e.g. `src/core/Compare.mjs`, transitively
+// pulled in via Base / LifecycleService / GraphService). Without this prelude the script
+// crashes at module-load with `ReferenceError: Neo is not defined` (regression originally
+// surfaced in `sweepExpiredTasks.mjs` and codified there). Ordering matters — these two
+// side-effect imports must run first to populate `globalThis.Neo`.
+import Neo             from '../../src/Neo.mjs';
+import * as core       from '../../src/core/_export.mjs';
+
+import {spawn}         from 'child_process';
+import path            from 'path';
+import {fileURLToPath} from 'url';
+import Base            from '../../src/core/Base.mjs';
+import {
+    Memory_GraphService     as GraphService,
+    Memory_LifecycleService as LifecycleService
+}                    from '../services.mjs';
+import MailboxService from '../mcp/server/memory-core/services/MailboxService.mjs';
+import logger        from '../mcp/server/memory-core/logger.mjs';
+import {
+    isGateOpen,
+    readGateState
+} from '../scripts/wakeSafetyGate.mjs';
+import {
+    inspectHeartbeatLock,
+    releaseHeartbeatLock,
+    HEARTBEAT_LOCK_PATH
+} from '../scripts/heartbeatLock.mjs';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname  = path.dirname(__filename);
+
+const DEFAULT_POLL_INTERVAL_MS = 5 * 60 * 1000;
+const DEFAULT_IDENTITY         = '@neo-gemini-3-1-pro';
+
+/**
+ * @summary Neo-singleton heartbeat daemon for the Phase 1/3 wake substrate.
+ *
+ * Replaces the bash-shape `ai/scripts/swarm-heartbeat.sh#heartbeat_pulse` loop with the
+ * canonical Neo-class shape that already houses `DreamService` and the 10+ services under
+ * `ai/daemons/services/`. The bash script remains in place for the developer-interactive
+ * agent-wrapper case (`AGENT_CMD="claude"` wrapper loop, ctrl-C-bound to operator session);
+ * this singleton handles the **persistent-process** case where launchd / systemd keeps the
+ * daemon alive across operator sleep + system reboot so autonomous recovery can fire.
+ *
+ * **Where direct module imports replace subprocess invocations** (#10789 AC3, "where feasible"):
+ *
+ *   - `MailboxService.sweepExpiredTasks()` — the expired-task sweep was previously a `node
+ *     ai/scripts/sweepExpiredTasks.mjs` subprocess; calling MailboxService directly removes the
+ *     ~2s Node-startup hop on every poll cycle.
+ *   - `wakeSafetyGate.mjs` exports (`isGateOpen`, `readGateState`) — the bash `if ! node
+ *     wakeSafetyGate.mjs check` shell-out is replaced with direct function calls.
+ *   - `heartbeatLock.mjs` exports (`inspectHeartbeatLock`, `releaseHeartbeatLock`) — the bash
+ *     stat-based concurrency-lock check is replaced with the JS implementation already shared
+ *     with the producer side (#10319 `withHeartbeatLock`).
+ *
+ * **Where subprocess invocation is preserved** (out-of-scope for v1; follow-up extracted as
+ * #10790): `checkSunsetted.mjs`, `resumeHarness.mjs`, `checkAllAgentIdle.mjs`,
+ * `idleOutNudge.mjs`, `trioWakeCooldown.mjs` are CLI-shape (no exported function entrypoint)
+ * and converting each to dual-mode (CLI + module-export) is sibling work. Their subprocess
+ * cost (~2-5s per cycle, fires every 5min) is operationally tolerable.
+ *
+ * **Persistent-process management:** the file's bottom self-invoke pattern lets launchd /
+ * systemd run `node ai/daemons/SwarmHeartbeatService.mjs` directly. SIGTERM / SIGINT trigger
+ * a clean stop so operator `launchctl bootout` doesn't leave dangling timers.
+ *
+ * **Coexistence with `swarm-heartbeat.sh`:** the singleton and the shell wrapper share the
+ * concurrency lock at `.neo-ai-data/heartbeat-concurrency.lock` (#10319), but operators must
+ * not run BOTH at the same time — the lock prevents *agent-work-overlapping-with-pulse*, not
+ * *two pulse producers*. Operator-territory: pick one or the other.
+ *
+ * @class Neo.ai.daemons.SwarmHeartbeatService
+ * @extends Neo.core.Base
+ * @singleton
+ * @see ai/scripts/swarm-heartbeat.sh           — sibling bash daemon (developer-interactive shape, preserved per AC10)
+ * @see ai/scripts/checkSunsetted.mjs           — sunset detector (subprocess)
+ * @see ai/scripts/resumeHarness.mjs            — fresh-session-spawn dispatcher (subprocess)
+ * @see ai/scripts/wakeSafetyGate.mjs           — fail-closed safety gate (direct import)
+ * @see ai/scripts/heartbeatLock.mjs            — concurrency-lock primitive (direct import)
+ * @see learn/agentos/wake-substrate/PersistentProcessManagement.md
+ */
+class SwarmHeartbeatService extends Base {
+    static config = {
+        /**
+         * @member {String} className='Neo.ai.daemons.SwarmHeartbeatService'
+         * @protected
+         */
+        className: 'Neo.ai.daemons.SwarmHeartbeatService',
+        /**
+         * @member {Boolean} singleton=true
+         * @protected
+         */
+        singleton: true,
+        /**
+         * Whether the poll loop is running.
+         * @member {Boolean} isPolling_=false
+         * @protected
+         * @reactive
+         */
+        isPolling_: false,
+        /**
+         * Active setTimeout handle for the next pulse; null when not scheduled.
+         * @member {Object|null} pollHandle_=null
+         * @protected
+         */
+        pollHandle_: null,
+        /**
+         * Identity this daemon polls for (e.g. `@neo-gemini-3-1-pro`).
+         * @member {String|null} identity_=null
+         * @protected
+         */
+        identity_: null,
+        /**
+         * Interval between pulses in milliseconds.
+         * @member {Number} pollIntervalMs_=300000
+         * @protected
+         */
+        pollIntervalMs_: DEFAULT_POLL_INTERVAL_MS
+    }
+
+    /**
+     * Start the heartbeat poll loop. Idempotent — calling start() while already
+     * polling is a no-op. Boots the LifecycleService + GraphService once before
+     * scheduling the first pulse so SQLite queries on subsequent cycles can run
+     * without per-cycle init overhead.
+     * @param {Object} [options]
+     * @param {String} [options.identity] Agent identity (defaults to NEO_AGENT_IDENTITY env or @neo-gemini-3-1-pro)
+     * @param {Number} [options.pollIntervalMs] Poll interval in ms (defaults to POLL_INTERVAL env*1000 or 5min)
+     * @returns {Promise<void>}
+     */
+    async start({identity, pollIntervalMs} = {}) {
+        if (this.isPolling) {
+            logger.debug('[SwarmHeartbeatService] Already polling; start() is a no-op.');
+            return;
+        }
+
+        this.identity = identity
+            || process.env.NEO_AGENT_IDENTITY
+            || DEFAULT_IDENTITY;
+
+        const envInterval = parseInt(process.env.POLL_INTERVAL, 10);
+        this.pollIntervalMs = pollIntervalMs
+            || (Number.isFinite(envInterval) && envInterval > 0 ? envInterval * 1000 : DEFAULT_POLL_INTERVAL_MS);
+
+        await LifecycleService.initAsync();
+        await GraphService.initAsync();
+
+        this.isPolling = true;
+        logger.info(`[SwarmHeartbeatService] Starting heartbeat for ${this.identity} (interval: ${this.pollIntervalMs}ms)`);
+
+        this.scheduleNext()
+    }
+
+    /**
+     * Stop the heartbeat poll loop. Idempotent. Cancels any pending setTimeout
+     * so a clean SIGTERM under launchd doesn't leave timers wedging the event loop.
+     * @returns {void}
+     */
+    stop() {
+        if (this.pollHandle) {
+            clearTimeout(this.pollHandle);
+            this.pollHandle = null
+        }
+        this.isPolling = false;
+        logger.info('[SwarmHeartbeatService] Heartbeat stopped.')
+    }
+
+    /**
+     * Schedule the next pulse. Called after each pulse completes (success or failure)
+     * so a single thrown error doesn't break the loop.
+     * @protected
+     */
+    scheduleNext() {
+        if (!this.isPolling) return;
+        this.pollHandle = setTimeout(() => this.pulse().catch(err => {
+            logger.error('[SwarmHeartbeatService] Pulse threw uncaught error:', err);
+            this.scheduleNext()
+        }), this.pollIntervalMs)
+    }
+
+    /**
+     * Execute one heartbeat pulse. Mirrors `swarm-heartbeat.sh#heartbeat_pulse` step-for-step:
+     *
+     *   1. Concurrency-lock skip (active lock = expensive work in flight, skip pulse;
+     *      stale lock = clear and continue per #10319).
+     *   2. TTL sweep (`MailboxService.sweepExpiredTasks` — direct call, no subprocess).
+     *   3. Sunset detection via `checkSunsetted.mjs` subprocess.
+     *      - sunset=true + gate-open → fresh-session-spawn via `resumeHarness.mjs`.
+     *      - sunset=true + gate-closed → log + skip (no spawn).
+     *      - recommended_action=idle_out_nudge + gate-open → `idleOutNudge.mjs`.
+     *   4. All-agent-idle detection via `checkAllAgentIdle.mjs`.
+     *      - allIdle=true + gate-open → `trioWakeCooldown.mjs`.
+     *   5. Heartbeat-bypass detection: identities with push-capable subscriptions
+     *      (mcp-notifications / a2a-webhook) skip the token-economy fast-path because
+     *      they receive wakes via push.
+     *   6. Token-economy gate: skip pulse if mailbox unread + open issues both zero.
+     *   7. Tmux-inject pulse prompt to `$TMUX_SESSION` (preserved from shell shape).
+     *
+     * Wraps the entire body in try/finally so `scheduleNext()` always fires — a
+     * single-cycle failure must not stop the daemon.
+     * @returns {Promise<void>}
+     */
+    async pulse() {
+        try {
+            const lockState = await this.checkHeartbeatLock();
+            if (lockState.active) {
+                return
+            }
+            if (lockState.stale) {
+                logger.warn(`[SwarmHeartbeatService] Clearing stale concurrency lock (${lockState.ageMs}ms old)`);
+                await this.clearHeartbeatLock()
+            }
+
+            // Step 2: TTL sweep — direct MailboxService call (was subprocess in bash shape).
+            // Substrate maintenance: fires every cycle regardless of token-economy gate.
+            let expired = 0;
+            try {
+                const result = await this.sweepExpiredTasks();
+                expired = result?.sweptCount || 0;
+                if (expired > 0) {
+                    logger.info(`[SwarmHeartbeatService] sweep: ${expired} task(s) transitioned to Expired`)
+                }
+            } catch (err) {
+                logger.error('[SwarmHeartbeatService] sweepExpiredTasks failed:', err)
+            }
+
+            // Step 3: Sunset detection (subprocess — checkSunsetted.mjs is CLI-shape).
+            const sunsetJson = await this.runScriptJson('checkSunsetted.mjs', [this.identity]);
+            if (sunsetJson?.sunsetted) {
+                if (!await this.checkGateOpen()) {
+                    const gateState = await this.readGate();
+                    logger.warn(`[SwarmHeartbeatService] Wake safety gate closed; skipping fresh-session-spawn for ${this.identity}. Sunset reason: ${sunsetJson.reason}. Gate reason: ${gateState.reason}`);
+                    return
+                }
+                logger.info(`[SwarmHeartbeatService] Phase 1 Recovery Triggered for ${this.identity}. Reason: ${sunsetJson.reason}`);
+                await this.runScript('resumeHarness.mjs', [
+                    this.identity,
+                    sunsetJson.reason || '',
+                    sunsetJson.originSessionId || '',
+                    String(sunsetJson.abandonedCount || 0)
+                ]);
+                return
+            }
+
+            const recommendedAction = sunsetJson?.recommended_action || 'no_action';
+            if (recommendedAction === 'idle_out_nudge') {
+                if (!await this.checkGateOpen()) {
+                    const gateState = await this.readGate();
+                    logger.warn(`[SwarmHeartbeatService] Wake safety gate closed; skipping idle-out nudge for ${this.identity}. Gate reason: ${gateState.reason}`);
+                    return
+                }
+                logger.info(`[SwarmHeartbeatService] Idle-out nudge triggered for ${this.identity}`);
+                await this.runScript('idleOutNudge.mjs', [this.identity]);
+                return
+            }
+
+            // Step 4: All-agent-idle detection (subprocess).
+            const cycleId = String(Math.floor(Date.now() / 1000));
+            const allIdleJson = await this.runScriptJson('checkAllAgentIdle.mjs', [cycleId]);
+            if (allIdleJson?.allIdle) {
+                logger.info(`[SwarmHeartbeatService] AllAgentIdle detected: ${JSON.stringify(allIdleJson)}`);
+                if (!await this.checkGateOpen()) {
+                    const gateState = await this.readGate();
+                    logger.warn(`[SwarmHeartbeatService] Wake safety gate closed; skipping trio wake dispatch. Gate reason: ${gateState.reason}`)
+                } else {
+                    await this.runScript('trioWakeCooldown.mjs', [JSON.stringify(allIdleJson)])
+                }
+            }
+
+            // Step 5: Heartbeat-bypass detection.
+            if (await this.isPushCapable(this.identity)) {
+                return
+            }
+
+            // Step 6: Token-economy gate. Skip pulse-injection if no actionable state.
+            const unread = await this.getUnreadCount();
+            const issues = await this.getIssuesCount();
+            if (unread === 0 && issues === 0) {
+                return
+            }
+
+            // Step 7: Tmux-inject the pulse prompt.
+            const minutes = Math.round(this.pollIntervalMs / 60000);
+            let prompt = `[SYSTEM HEARTBEAT] Last wake: T-${minutes}min. Mailbox unread: ${unread}. Open issues assigned: ${issues}.`;
+            if (expired > 0) {
+                prompt += ` Tasks expired this cycle: ${expired}.`
+            }
+            await this.injectTmux(prompt)
+        } finally {
+            this.scheduleNext()
+        }
+    }
+
+    /**
+     * Test-stubbable seam over the module-level `inspectHeartbeatLock` import. ES module
+     * bindings can't be reassigned at import-site, so unit tests stub via instance-method
+     * override (`this.checkHeartbeatLock = async () => ({...})`). Production path is a
+     * direct passthrough.
+     * @returns {Promise<{active: Boolean, stale: Boolean, ageMs: Number|null}>}
+     * @protected
+     */
+    async checkHeartbeatLock() {
+        return inspectHeartbeatLock()
+    }
+
+    /**
+     * Test-stubbable seam over `releaseHeartbeatLock`.
+     * @returns {Promise<void>}
+     * @protected
+     */
+    async clearHeartbeatLock() {
+        return releaseHeartbeatLock()
+    }
+
+    /**
+     * Test-stubbable seam over `MailboxService.sweepExpiredTasks`.
+     * @returns {Promise<{success: Boolean, sweptCount: Number}>}
+     * @protected
+     */
+    async sweepExpiredTasks() {
+        return MailboxService.sweepExpiredTasks()
+    }
+
+    /**
+     * Test-stubbable seam over `wakeSafetyGate.isGateOpen`.
+     * @returns {Promise<Boolean>}
+     * @protected
+     */
+    async checkGateOpen() {
+        return isGateOpen()
+    }
+
+    /**
+     * Test-stubbable seam over `wakeSafetyGate.readGateState`.
+     * @returns {Promise<{state: String, reason: String, trippedAt: ?String, trippedBy: ?String}>}
+     * @protected
+     */
+    async readGate() {
+        return readGateState()
+    }
+
+    /**
+     * SQLite query: count of unread MESSAGE-label nodes addressed to the polled identity
+     * or AGENT:* broadcast. Mirrors `swarm-heartbeat.sh#get_unread_count` 1:1.
+     * @returns {Promise<Number>}
+     * @protected
+     */
+    async getUnreadCount() {
+        try {
+            const db = GraphService.db.storage.db;
+            const stmt = db.prepare(`
+                SELECT count(DISTINCT n.id) as count
+                FROM Nodes n
+                JOIN Edges e ON n.id = e.source AND e.type = 'SENT_TO'
+                WHERE json_extract(n.data, '$.label') = 'MESSAGE'
+                  AND json_extract(n.data, '$.properties.readAt') IS NULL
+                  AND e.target IN (?, 'AGENT:*')
+            `);
+            const row = stmt.get(this.identity);
+            return row?.count || 0
+        } catch (err) {
+            logger.error('[SwarmHeartbeatService] getUnreadCount failed:', err);
+            return 0
+        }
+    }
+
+    /**
+     * Issue-count via `gh issue list --assignee @me`. Subprocess — gh is the only
+     * authoritative source for `@me`-resolution; not feasible to inline.
+     * @returns {Promise<Number>}
+     * @protected
+     */
+    async getIssuesCount() {
+        try {
+            const output = await this.runCmd('gh', ['issue', 'list', '--assignee', '@me', '--state', 'open', '--json', 'number']);
+            const parsed = JSON.parse(output || '[]');
+            return Array.isArray(parsed) ? parsed.length : 0
+        } catch {
+            return 0
+        }
+    }
+
+    /**
+     * Check whether the polled identity has a push-capable subscription
+     * (`harnessTarget IN ('mcp-notifications', 'a2a-webhook')` and not `degraded`).
+     * @param {String} identity
+     * @returns {Promise<Boolean>}
+     * @protected
+     */
+    async isPushCapable(identity) {
+        try {
+            const db = GraphService.db.storage.db;
+            const stmt = db.prepare(`
+                SELECT count(*) as count
+                FROM Nodes
+                WHERE json_extract(data, '$.label') = 'WAKE_SUBSCRIPTION'
+                  AND json_extract(data, '$.properties.agentIdentity') = ?
+                  AND json_extract(data, '$.properties.harnessTarget') IN ('mcp-notifications', 'a2a-webhook')
+                  AND COALESCE(json_extract(data, '$.properties.status'), 'active') != 'degraded'
+            `);
+            const row = stmt.get(identity);
+            return (row?.count || 0) > 0
+        } catch (err) {
+            logger.error('[SwarmHeartbeatService] isPushCapable query failed:', err);
+            return false
+        }
+    }
+
+    /**
+     * Inject the pulse prompt into the configured tmux session. No-op when tmux
+     * is not running OR `$TMUX_SESSION` doesn't exist.
+     * @param {String} prompt
+     * @returns {Promise<void>}
+     * @protected
+     */
+    async injectTmux(prompt) {
+        const session = process.env.TMUX_SESSION || 'neo-agent';
+        try {
+            // tmux has-session exits 0 if session exists, 1 otherwise
+            await this.runCmd('tmux', ['has-session', '-t', session]);
+            await this.runCmd('tmux', ['send-keys', '-t', session, prompt, 'C-m'])
+        } catch {
+            // Session absent or tmux unavailable — silently no-op (matches shell behavior)
+        }
+    }
+
+    /**
+     * Spawn a node subprocess for the named script and return its stdout.
+     * Used for CLI-shape recovery scripts that haven't been refactored to
+     * dual-mode export (#10790).
+     * @param {String} scriptName Name of script under `ai/scripts/`
+     * @param {String[]} [args=[]]
+     * @returns {Promise<String>} stdout content
+     * @protected
+     */
+    async runScript(scriptName, args = []) {
+        const scriptPath = path.resolve(__dirname, '../scripts', scriptName);
+        return this.runCmd('node', [scriptPath, ...args])
+    }
+
+    /**
+     * Spawn a node subprocess for the named script, parse its stdout as JSON,
+     * and return the parsed object (or null on parse failure).
+     * @param {String} scriptName
+     * @param {String[]} [args=[]]
+     * @returns {Promise<Object|null>}
+     * @protected
+     */
+    async runScriptJson(scriptName, args = []) {
+        try {
+            const stdout = await this.runScript(scriptName, args);
+            if (!stdout || !stdout.trim()) return null;
+            return JSON.parse(stdout.trim())
+        } catch (err) {
+            logger.error(`[SwarmHeartbeatService] ${scriptName} failed:`, err.message);
+            return null
+        }
+    }
+
+    /**
+     * Generic subprocess runner. Resolves with stdout on exit code 0; rejects otherwise.
+     * Stderr is captured for diagnostics but not parsed.
+     * @param {String} command
+     * @param {String[]} [args=[]]
+     * @returns {Promise<String>}
+     * @protected
+     */
+    runCmd(command, args = []) {
+        return new Promise((resolve, reject) => {
+            const child = spawn(command, args, {stdio: ['ignore', 'pipe', 'pipe']});
+            let stdout = '';
+            let stderr = '';
+            child.stdout.on('data', chunk => { stdout += chunk.toString() });
+            child.stderr.on('data', chunk => { stderr += chunk.toString() });
+            child.on('error', reject);
+            child.on('exit', code => {
+                if (code === 0) {
+                    resolve(stdout)
+                } else {
+                    reject(new Error(`${command} exited with code ${code}: ${stderr.trim() || '(no stderr)'}`))
+                }
+            })
+        })
+    }
+}
+
+const SwarmHeartbeatServiceSingleton = Neo.setupClass(SwarmHeartbeatService);
+export default SwarmHeartbeatServiceSingleton;
+
+// Self-invoke entrypoint (#10789 AC4): `node ai/daemons/SwarmHeartbeatService.mjs` under
+// launchd / systemd directly drives the daemon. SIGTERM / SIGINT trigger a clean stop so
+// `launchctl bootout` / `systemctl stop` don't leave dangling timers. The setTimeout chain
+// keeps the event loop alive between pulses; no explicit keepalive primitive needed.
+const isMain = process.argv[1] && fileURLToPath(import.meta.url) === path.resolve(process.argv[1]);
+if (isMain) {
+    const cleanShutdown = signal => {
+        logger.info(`[SwarmHeartbeatService] Received ${signal}; stopping.`);
+        SwarmHeartbeatServiceSingleton.stop();
+        process.exit(0)
+    };
+    process.on('SIGTERM', () => cleanShutdown('SIGTERM'));
+    process.on('SIGINT',  () => cleanShutdown('SIGINT'));
+
+    SwarmHeartbeatServiceSingleton.start().catch(err => {
+        logger.error('[SwarmHeartbeatService] Daemon start failed:', err);
+        process.exit(1)
+    })
+}
+
+export {HEARTBEAT_LOCK_PATH, DEFAULT_POLL_INTERVAL_MS, DEFAULT_IDENTITY};

--- a/ai/daemons/SwarmHeartbeatService.mjs
+++ b/ai/daemons/SwarmHeartbeatService.mjs
@@ -54,8 +54,8 @@ const DEFAULT_IDENTITY         = '@neo-gemini-3-1-pro';
  *     stat-based concurrency-lock check is replaced with the JS implementation already shared
  *     with the producer side (#10319 `withHeartbeatLock`).
  *
- * **Where subprocess invocation is preserved** (out-of-scope for v1; follow-up extracted as
- * #10790): `checkSunsetted.mjs`, `resumeHarness.mjs`, `checkAllAgentIdle.mjs`,
+ * **Where subprocess invocation is preserved** (out-of-scope for v1; follow-up tracked as
+ * #10795): `checkSunsetted.mjs`, `resumeHarness.mjs`, `checkAllAgentIdle.mjs`,
  * `idleOutNudge.mjs`, `trioWakeCooldown.mjs` are CLI-shape (no exported function entrypoint)
  * and converting each to dual-mode (CLI + module-export) is sibling work. Their subprocess
  * cost (~2-5s per cycle, fires every 5min) is operationally tolerable.
@@ -102,18 +102,21 @@ class SwarmHeartbeatService extends Base {
          * Active setTimeout handle for the next pulse; null when not scheduled.
          * @member {Object|null} pollHandle_=null
          * @protected
+         * @reactive
          */
         pollHandle_: null,
         /**
          * Identity this daemon polls for (e.g. `@neo-gemini-3-1-pro`).
          * @member {String|null} identity_=null
          * @protected
+         * @reactive
          */
         identity_: null,
         /**
          * Interval between pulses in milliseconds.
          * @member {Number} pollIntervalMs_=300000
          * @protected
+         * @reactive
          */
         pollIntervalMs_: DEFAULT_POLL_INTERVAL_MS
     }

--- a/learn/agentos/wake-substrate/PersistentProcessManagement.md
+++ b/learn/agentos/wake-substrate/PersistentProcessManagement.md
@@ -40,11 +40,21 @@ which node sqlite3 gh tmux
 # 3. The .neo-ai-data dir tree exists (will be created if not, but worth pre-checking)
 ls -la .neo-ai-data/wake-daemon/ .neo-ai-data/sqlite/
 
-# 4. Manual one-shot execution works (macOS native timeout alternative)
-NEO_AGENT_IDENTITY="@your-identity" POLL_INTERVAL=10 perl -e 'alarm shift; exec @ARGV' 30 \
-   node ai/daemons/SwarmHeartbeatService.mjs
-# (should produce "Starting heartbeat for @your-identity (interval: 10000ms)" log line + at least
-#  one pulse cycle + exit cleanly when alarm hits; no errors in output)
+# 4. Manual one-shot execution works — exercises the SIGTERM clean-shutdown path the
+#    daemon's signal handlers (SwarmHeartbeatService.mjs) implement.
+NEO_AGENT_IDENTITY="@your-identity" POLL_INTERVAL=10 \
+   node ai/daemons/SwarmHeartbeatService.mjs &
+DAEMON_PID=$!
+sleep 30
+kill -TERM "$DAEMON_PID"
+wait "$DAEMON_PID" 2>/dev/null
+# Expected:
+#   1. "Starting heartbeat for @your-identity (interval: 10000ms)" log line on launch
+#   2. At least one pulse cycle (10s interval × ~3 pulses in 30s window)
+#   3. "Received SIGTERM; stopping." + "Heartbeat stopped." log lines on shutdown
+#   4. wait exits 0 (clean shutdown via the handler's process.exit(0))
+# A SIGALRM-shape recipe (perl alarm) would terminate by signal, NOT through the
+# clean-shutdown handler — the daemon only catches SIGTERM/SIGINT.
 ```
 
 If any of these fails, **fix the underlying issue first**. launchd will faithfully reproduce whatever runtime environment problem the manual execution surfaces.
@@ -96,17 +106,30 @@ launchctl list | grep com.neomjs
 ### 3d. Verify execution
 
 ```bash
-# Watch the daemon's stdout — should show "Starting heartbeat for ..." + pulse activity
+# Initial verify: the startup line MUST appear within seconds of bootstrap
 tail -f .neo-ai-data/wake-daemon/heartbeat.stdout.log
+# Expected first line: "[SwarmHeartbeatService] Starting heartbeat for <identity> (interval: 300000ms)"
 
 # Watch the daemon's stderr — should be empty during normal operation
 tail -f .neo-ai-data/wake-daemon/heartbeat.stderr.log
-
-# Watch the concurrency lock — touched on each successful poll if expensive work fires
-ls -la .neo-ai-data/heartbeat-concurrency.lock
 ```
 
-If no log lines appear after 10 minutes, the daemon is loaded but not polling. Common causes: `WorkingDirectory` mis-substituted (script can't find `.neo-ai-data/`), `PATH` missing critical CLI tool (sqlite3, node, gh), or the script crashed (check `heartbeat.stderr.log`).
+The daemon emits `INFO`-level log lines only when something happens — these are the durable observability signals:
+
+- **Startup:** `Starting heartbeat for <identity> (interval: <ms>)` — fires once on launch.
+- **Stale lock cleared:** `Clearing stale concurrency lock (<age>ms old)` — only when a producer-side lock outlived its TTL.
+- **TTL sweep:** `sweep: <N> task(s) transitioned to Expired` — only when N > 0.
+- **Sunset recovery:** `Phase 1 Recovery Triggered for <identity>. Reason: ...` — only when the sunset detector fires.
+- **Idle-out nudge:** `Idle-out nudge triggered for <identity>` — only when the per-identity idle threshold trips.
+- **All-agent-idle:** `AllAgentIdle detected: <signal>` — only when the trio-wide idle predicate holds.
+- **Gate-closed:** `Wake safety gate closed; skipping ...` — only when a high-authority dispatch was suppressed.
+- **Shutdown:** `Received SIGTERM; stopping.` + `Heartbeat stopped.` — fires on `launchctl bootout`.
+
+A healthy idle daemon may emit nothing for many cycles in a row (no expired tasks, no sunset, no idle-out, no all-idle, no gate-closed). The startup line + an empty stderr log is the steady-state proof of life. **Do not infer "daemon stopped polling" from log silence past startup** — silence during agent-active periods is the token-economy gate working as designed.
+
+> ⚠️ **Lock-as-evidence anti-pattern:** the file `.neo-ai-data/heartbeat-concurrency.lock` is **producer-side state** — created by `acquireHeartbeatLock` when expensive agent work starts (#10319 `withHeartbeatLock`), removed when that work finishes. The heartbeat daemon only *inspects + releases stale locks*, never touches it on healthy idle pulses. **Do not watch the lock's mtime as a polling-health indicator** — a healthy daemon may go hours without touching it.
+
+If the startup log line never appears, the daemon failed to launch. Common causes: `WorkingDirectory` mis-substituted (script can't find `.neo-ai-data/`), `PATH` missing critical CLI tool (sqlite3, node, gh), or the script crashed at module-load (check `heartbeat.stderr.log` for `ReferenceError: Neo is not defined` or similar).
 
 ## 4. Uninstall procedure
 

--- a/learn/agentos/wake-substrate/PersistentProcessManagement.md
+++ b/learn/agentos/wake-substrate/PersistentProcessManagement.md
@@ -1,0 +1,194 @@
+# Persistent-Process Management for SwarmHeartbeatService
+
+This document covers operator-side installation, verification, and uninstallation of `ai/daemons/SwarmHeartbeatService.mjs` as a persistent daemon process. Required for autonomous **night-shift mode** operation — without persistent-process management, the heartbeat singleton only runs when an operator manually invokes the bash wrapper (`ai/scripts/swarm-heartbeat.sh`) interactively and keeps the terminal open.
+
+> **Verify-before-assert notice:** the plist template in this directory (`com.neomjs.swarm-heartbeat.plist.template`) is **author-side draft**. Correctness on a given operator's macOS install is operator-territory L3 verification. Do NOT install the template as-is without running the verification commands in §3 below.
+
+## Compaction Taxonomy (3-Axis Slot Rule)
+**Disposition:** `keep` (External Operator Guide; not injected into active agent context).
+**Rationale:** Low-frequency (run once per host setup), high-severity (macOS `launchd` failure isolates the swarm), non-machine-enforceable (operator-territory CLI execution).
+
+## 1. Why this exists
+
+The wake substrate (Epic [#10671](https://github.com/neomjs/neo/issues/10671)) ships:
+
+- `ai/daemons/SwarmHeartbeatService.mjs` — Neo-singleton heartbeat daemon (5-minute poll by default; #10789)
+- `ai/scripts/swarm-heartbeat.sh` — sibling bash wrapper for **developer-interactive** use (preserved per #10789 AC10; not the persistent-process target)
+- `ai/scripts/checkSunsetted.mjs` — sunset / idle-out detector consumed by the daemon
+- `ai/scripts/resumeHarness.mjs` — recovery dispatcher invoked when a sunsetted agent is detected
+- `ai/scripts/wakeSafetyGate.mjs` — fail-closed safety gate consulted before any high-authority recovery action
+
+`SwarmHeartbeatService` runs `await this.scheduleNext()` in a setTimeout chain (5-minute default cadence). It must run as a long-lived process. macOS's native primitive for long-lived per-user daemons is **launchd LaunchAgent** (per-user, lives in `~/Library/LaunchAgents/`). Linux's analog is **systemd user service** (typically `~/.config/systemd/user/`); a sibling shape is sketched in §5 below but committed-template is macOS-only for v1.
+
+**Why the singleton replaces the bash wrapper as the persistent-process target:**
+
+- Architectural pattern compliance — `ai/daemons/` already houses Neo-class services (`DreamService.mjs` + 10+ under `ai/daemons/services/`); a bash daemon would have introduced architectural debt.
+- Direct module imports for `wakeSafetyGate.mjs`, `heartbeatLock.mjs`, and `MailboxService.sweepExpiredTasks` remove three subprocess hops per cycle.
+- Persistent-singleton state lets future work (gauge, observability, backpressure) live on the class instance instead of bash-shell environment variables.
+
+## 2. Operator empirical-prerequisites
+
+Before installing, verify on your local environment:
+
+```bash
+# 1. The daemon entrypoint exists
+test -f ai/daemons/SwarmHeartbeatService.mjs && echo "OK" || echo "FAIL: did you check out the #10789 branch?"
+
+# 2. Required tools are reachable
+which node sqlite3 gh tmux
+
+# 3. The .neo-ai-data dir tree exists (will be created if not, but worth pre-checking)
+ls -la .neo-ai-data/wake-daemon/ .neo-ai-data/sqlite/
+
+# 4. Manual one-shot execution works (macOS native timeout alternative)
+NEO_AGENT_IDENTITY="@your-identity" POLL_INTERVAL=10 perl -e 'alarm shift; exec @ARGV' 30 \
+   node ai/daemons/SwarmHeartbeatService.mjs
+# (should produce "Starting heartbeat for @your-identity (interval: 10000ms)" log line + at least
+#  one pulse cycle + exit cleanly when alarm hits; no errors in output)
+```
+
+If any of these fails, **fix the underlying issue first**. launchd will faithfully reproduce whatever runtime environment problem the manual execution surfaces.
+
+## 3. macOS launchd installation procedure
+
+### 3a. Substitute the template
+
+```bash
+# From repo root, copy the template + substitute placeholders
+cp learn/agentos/wake-substrate/com.neomjs.swarm-heartbeat.plist.template \
+   ~/Library/LaunchAgents/com.neomjs.swarm-heartbeat.plist
+
+# Substitute repo-root path (this assumes you run this command FROM the repo root)
+sed -i '' "s|\[OPERATOR_SUBSTITUTE_REPO_ROOT\]|$(pwd)|g" \
+   ~/Library/LaunchAgents/com.neomjs.swarm-heartbeat.plist
+
+# Substitute agent identity (replace with your actual identity, e.g. "@neo-opus-4-7")
+sed -i '' "s|\[OPERATOR_SUBSTITUTE_AGENT_IDENTITY\]|@your-identity|g" \
+   ~/Library/LaunchAgents/com.neomjs.swarm-heartbeat.plist
+
+# Verify substitution succeeded — should be ZERO matches remaining
+grep -c "OPERATOR_SUBSTITUTE" ~/Library/LaunchAgents/com.neomjs.swarm-heartbeat.plist
+# expected output: 0
+```
+
+### 3b. Lint the plist syntax
+
+```bash
+plutil -lint ~/Library/LaunchAgents/com.neomjs.swarm-heartbeat.plist
+# expected output: <path>: OK
+```
+
+If `plutil` reports a syntax error, **do not proceed**. Common causes:
+- Unescaped `<` / `>` / `&` in your repo path or agent identity (sed `|` delimiter avoids this for `/`-laden paths but still surfaces if your path has special XML chars)
+- Substitution missed a placeholder (zero `OPERATOR_SUBSTITUTE` matches confirmed via §3a final check)
+
+### 3c. Install + start
+
+```bash
+# Bootstrap (load + start) the LaunchAgent
+launchctl bootstrap gui/$(id -u) ~/Library/LaunchAgents/com.neomjs.swarm-heartbeat.plist
+
+# Verify load
+launchctl list | grep com.neomjs
+# expected output: a line with PID + label "com.neomjs.swarm-heartbeat"
+```
+
+### 3d. Verify execution
+
+```bash
+# Watch the daemon's stdout — should show "Starting heartbeat for ..." + pulse activity
+tail -f .neo-ai-data/wake-daemon/heartbeat.stdout.log
+
+# Watch the daemon's stderr — should be empty during normal operation
+tail -f .neo-ai-data/wake-daemon/heartbeat.stderr.log
+
+# Watch the concurrency lock — touched on each successful poll if expensive work fires
+ls -la .neo-ai-data/heartbeat-concurrency.lock
+```
+
+If no log lines appear after 10 minutes, the daemon is loaded but not polling. Common causes: `WorkingDirectory` mis-substituted (script can't find `.neo-ai-data/`), `PATH` missing critical CLI tool (sqlite3, node, gh), or the script crashed (check `heartbeat.stderr.log`).
+
+## 4. Uninstall procedure
+
+```bash
+# Bootout (stop + unload) the LaunchAgent — sends SIGTERM, which the singleton
+# handles via clean shutdown (clearTimeout on the next pulse + process.exit(0))
+launchctl bootout gui/$(id -u)/com.neomjs.swarm-heartbeat
+
+# Verify unload
+launchctl list | grep com.neomjs
+# expected output: empty (no matches)
+
+# Optional: remove the plist
+rm ~/Library/LaunchAgents/com.neomjs.swarm-heartbeat.plist
+```
+
+The daemon stops cleanly without state damage; the SQLite DB, ChromaDB, and Memory Core data are unaffected by daemon lifecycle.
+
+## 5. Linux systemd sibling (out-of-scope-for-v1 sketch)
+
+The Linux analog uses systemd's user-service substrate. **Not committed as a template in v1** because no operator has empirically validated against a Linux deployment yet. Future ticket should produce a committed `.service` file once a Linux operator validates.
+
+Sketch shape:
+
+```ini
+# ~/.config/systemd/user/swarm-heartbeat.service
+[Unit]
+Description=Neo.mjs SwarmHeartbeatService
+After=network.target
+
+[Service]
+Type=simple
+WorkingDirectory=/path/to/repo
+ExecStart=/usr/bin/env node /path/to/repo/ai/daemons/SwarmHeartbeatService.mjs
+Restart=always
+RestartSec=10
+Environment="NEO_AGENT_IDENTITY=@your-identity"
+Environment="PATH=/usr/local/bin:/usr/bin:/bin"
+StandardOutput=append:/path/to/repo/.neo-ai-data/wake-daemon/heartbeat.stdout.log
+StandardError=append:/path/to/repo/.neo-ai-data/wake-daemon/heartbeat.stderr.log
+
+[Install]
+WantedBy=default.target
+```
+
+Loaded via `systemctl --user daemon-reload && systemctl --user enable --now swarm-heartbeat.service`. Verified via `systemctl --user status swarm-heartbeat.service`.
+
+## 6. Troubleshooting (common gotchas observed in launchd-daemon authoring)
+
+| Symptom | Likely cause | Fix |
+|---|---|---|
+| Daemon "loaded" but no log lines | `WorkingDirectory` placeholder unsubstituted OR substituted to wrong path | Re-run §3a sed with correct repo root; `launchctl bootout` + `bootstrap` to reload |
+| `node: command not found` in stderr log | `PATH` env var doesn't include node's location | Add node's actual install dir to the plist `EnvironmentVariables.PATH` (check via `which node` in your interactive shell) |
+| `gh: command not found` in stderr log | Same — Homebrew's `gh` not in default launchd PATH | Add `/opt/homebrew/bin` (Apple Silicon) or `/usr/local/bin` (Intel) to plist PATH |
+| `tmux: command not found` | Same PATH issue; tmux-injection is best-effort and silently no-ops if absent | Add tmux's install dir to plist PATH OR accept the no-op (heartbeat still runs) |
+| `ReferenceError: Neo is not defined` | Module-load ordering broke the Neo prelude | File a bug — `SwarmHeartbeatService.mjs` should always import `Neo` + `core/_export` first; regressions here have a documented anchor |
+| `KeepAlive` causing rapid relaunch loop | Script crashes on startup (config error, missing dependency) | Check `heartbeat.stderr.log` for the actual crash; FIX the crash before lengthening `ThrottleInterval` (do not paper over real bugs) |
+| Daemon runs but doesn't trigger recovery wakes | `wakeSafetyGate.json` is `tripped` (deny-by-default) | Operator-territory: `node ai/scripts/wakeSafetyGate.mjs enable --reason "validated post-#10671"` AFTER end-to-end validation per [Epic #10671](https://github.com/neomjs/neo/issues/10671) |
+| Two heartbeat pulse producers firing | Both `swarm-heartbeat.sh` AND launchd-loaded `SwarmHeartbeatService` running | Pick one. The shell wrapper is for developer-interactive use; launchd is for night-shift / persistent-process. Don't run both. |
+
+## 7. Relationship to operator-territory steps (#10671 epic-finish)
+
+Persistent-process management (THIS doc) is one of three integration steps for night-shift readiness:
+
+1. **Persistent-process management** (this doc) — install + verify launchd plist for `SwarmHeartbeatService.mjs`
+2. **`wakeSafetyGate` untrip** — `node ai/scripts/wakeSafetyGate.mjs enable --reason "..."` after empirical validation that the cross-harness prompt-landing matrix (#10649) holds
+3. **End-to-end validation** — simulate mutual-idle scenario; verify recovery wake fires correctly to a healthy peer; confirm fresh-session-spawn lands cleanly without runaway-spawn pattern from 2026-05-03
+
+All three must complete for the swarm to operate continuously during operator-offline (night-shift) hours.
+
+## 8. Pre-run discipline reminder
+
+Per [#10780](https://github.com/neomjs/neo/issues/10780): before re-enabling DreamMode/Sandman (separate substrate from the heartbeat daemon — `autoDream` / `autoGoldenPath` config flags currently disabled in operator-local `config.mjs`), **always run `npm run ai:backup` first.** The backup primitive captures atomic-bundle state across KB + MC + graph + concepts + trajectories. DreamMode regressions can produce graph state that's expensive to recover from without a backup. The heartbeat daemon itself does NOT trigger DreamMode; it triggers recovery wakes for sunsetted agents — but the discipline applies to the broader Dream Pipeline substrate they're part of.
+
+## 9. Related substrate
+
+- **Daemon source:** `ai/daemons/SwarmHeartbeatService.mjs` (Neo-singleton; #10789)
+- **Sibling bash wrapper:** `ai/scripts/swarm-heartbeat.sh` (developer-interactive, NOT the persistent-process target; preserved per #10789 AC10)
+- **Daemon dependencies:** `checkSunsetted.mjs`, `resumeHarness.mjs`, `wakeSafetyGate.mjs`, `sweepExpiredTasks.mjs`, `heartbeatLock.mjs`, `idleOutNudge.mjs`, `checkAllAgentIdle.mjs`, `trioWakeCooldown.mjs`
+- **Parent epic:** [#10671](https://github.com/neomjs/neo/issues/10671) — Substrate-restart recovery (two-mode: idle-out + sunset)
+- **Implementation ticket:** [#10789](https://github.com/neomjs/neo/issues/10789) — SwarmHeartbeatService Neo-singleton replacement
+- **Closed-not-planned predecessors:** [#10781](https://github.com/neomjs/neo/issues/10781), [#10787](https://github.com/neomjs/neo/issues/10787), PR [#10782](https://github.com/neomjs/neo/pull/10782) — bash-shape attempt; closed for architectural pattern violation
+- **Sub-tickets resolved by this substrate:** [#10396](https://github.com/neomjs/neo/issues/10396), [#10399](https://github.com/neomjs/neo/issues/10399), [#10633](https://github.com/neomjs/neo/issues/10633)
+- **Sibling discipline:** [#10780](https://github.com/neomjs/neo/issues/10780) — Backup-first before DreamMode/Sandman; [`learn/agentos/DreamPipeline.md`](../DreamPipeline.md) for DreamMode-specific operational discipline
+- **Adjacent observability gap:** healthcheck `features.wake` block (gate-state + daemon-running-state + last-pulse timestamp) — currently neither healthcheck-surfaced nor ticketed; sibling-fileable extension of [#10779](https://github.com/neomjs/neo/issues/10779) (`features.dream` healthcheck)

--- a/learn/agentos/wake-substrate/com.neomjs.swarm-heartbeat.plist.template
+++ b/learn/agentos/wake-substrate/com.neomjs.swarm-heartbeat.plist.template
@@ -1,0 +1,106 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!--
+    com.neomjs.swarm-heartbeat — launchd plist TEMPLATE for SwarmHeartbeatService.
+
+    THIS IS A TEMPLATE. Operator MUST substitute the [OPERATOR_SUBSTITUTE_*] markers
+    below with values matching the operator's local environment, then verify the
+    plist on a real macOS install BEFORE relying on it for night-shift operation.
+
+    DO NOT install this template as-is. The substitution markers are deliberate.
+
+    See learn/agentos/wake-substrate/PersistentProcessManagement.md for the full
+    install procedure, verification commands, and troubleshooting gotchas.
+
+    Target: ai/daemons/SwarmHeartbeatService.mjs (Neo-singleton; #10789).
+    Replaced an earlier draft (#10781 / PR #10782) that targeted a bash daemon under
+    ai/scripts/ — wrong-pattern per Neo-class architectural convention; closed not-planned.
+-->
+<plist version="1.0">
+<dict>
+    <!-- Reverse-DNS label MUST match the plist filename (com.neomjs.swarm-heartbeat.plist).
+         launchd uses this label internally for `launchctl list / bootout / kickstart`. -->
+    <key>Label</key>
+    <string>com.neomjs.swarm-heartbeat</string>
+
+    <!-- ProgramArguments: absolute path to node + absolute path to the .mjs entrypoint.
+         launchd does NOT inherit the operator's interactive shell PATH; binaries must
+         be reachable via the EnvironmentVariables.PATH below OR specified absolutely. -->
+    <key>ProgramArguments</key>
+    <array>
+        <string>/usr/bin/env</string>
+        <string>node</string>
+        <string>[OPERATOR_SUBSTITUTE_REPO_ROOT]/ai/daemons/SwarmHeartbeatService.mjs</string>
+    </array>
+
+    <!-- WorkingDirectory: SwarmHeartbeatService uses RELATIVE paths via fs-extra
+         (e.g. `.neo-ai-data/heartbeat-concurrency.lock`, `.neo-ai-data/wake-daemon/`).
+         Without this, launchd runs the script with cwd=/ and relative paths resolve
+         to /.neo-ai-data/... which doesn't exist — the daemon silently no-ops. -->
+    <key>WorkingDirectory</key>
+    <string>[OPERATOR_SUBSTITUTE_REPO_ROOT]</string>
+
+    <!-- RunAtLoad: start the daemon immediately when the plist loads (login + reboot). -->
+    <key>RunAtLoad</key>
+    <true/>
+
+    <!-- KeepAlive: launchd auto-restarts the daemon if it exits.
+         Boolean form (`<true/>`) restarts unconditionally, even on clean exit.
+         The setTimeout chain inside SwarmHeartbeatService keeps the event loop alive
+         indefinitely; clean exit is unexpected (signals or fatal error only).
+
+         GOTCHA: if the script crashes IMMEDIATELY on start (config error, missing
+         dependency), launchd's throttle interval (default 10s) prevents tight-loop
+         crash. If you see KeepAlive thrashing in Console.app, fix the script-side
+         crash first (check StandardErrorPath); do NOT lengthen the throttle. -->
+    <key>KeepAlive</key>
+    <true/>
+
+    <!-- ThrottleInterval: minimum seconds between daemon launches (crash-loop guard).
+         Default 10s; SwarmHeartbeatService startup includes LifecycleService.initAsync
+         + GraphService.initAsync (~2-5s); 10s is comfortably above that floor. -->
+    <key>ThrottleInterval</key>
+    <integer>10</integer>
+
+    <!-- StandardOutPath / StandardErrorPath: per-launchd stdout/stderr capture.
+         Co-located with the daemon's logger output inside .neo-ai-data/wake-daemon/
+         for log-cohesion. Operator should rotate these periodically. -->
+    <key>StandardOutPath</key>
+    <string>[OPERATOR_SUBSTITUTE_REPO_ROOT]/.neo-ai-data/wake-daemon/heartbeat.stdout.log</string>
+    <key>StandardErrorPath</key>
+    <string>[OPERATOR_SUBSTITUTE_REPO_ROOT]/.neo-ai-data/wake-daemon/heartbeat.stderr.log</string>
+
+    <!-- EnvironmentVariables: launchd is environment-isolated. The daemon needs:
+           PATH: must include node, sqlite3, gh, tmux, and any other CLI tools used.
+                 The default /usr/bin:/bin:/usr/sbin:/sbin does NOT include
+                 Homebrew-installed `gh` (typically /opt/homebrew/bin or /usr/local/bin)
+                 nor Node version managers (nvm, fnm) — operator MUST list every
+                 directory containing required tools. Verify each via `which <tool>`.
+           NEO_AGENT_IDENTITY: which agent identity this daemon-instance polls for.
+                 Default in service is `@neo-gemini-3-1-pro`; operator should set
+                 to the actual identity the daemon serves.
+           POLL_INTERVAL: optional override; default 300s (5 min). Lower for testing
+                 (e.g. `60`), longer for production. Specified in seconds. -->
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>PATH</key>
+        <string>/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin</string>
+        <key>NEO_AGENT_IDENTITY</key>
+        <string>[OPERATOR_SUBSTITUTE_AGENT_IDENTITY]</string>
+        <!-- Uncomment to override the 5-minute default poll interval (seconds):
+        <key>POLL_INTERVAL</key>
+        <string>300</string>
+        -->
+    </dict>
+
+    <!-- ProcessType: Background — appropriate for long-running daemons that
+         shouldn't compete with foreground UI processes for resources. -->
+    <key>ProcessType</key>
+    <string>Background</string>
+
+    <!-- Nice: lower priority slightly so the daemon doesn't impact foreground work.
+         Range -20 (highest) to 19 (lowest); 5 is a moderate background level. -->
+    <key>Nice</key>
+    <integer>5</integer>
+</dict>
+</plist>

--- a/test/playwright/unit/ai/daemons/SwarmHeartbeatService.spec.mjs
+++ b/test/playwright/unit/ai/daemons/SwarmHeartbeatService.spec.mjs
@@ -1,0 +1,335 @@
+import {setup} from '../../../setup.mjs';
+
+const appName = 'SwarmHeartbeatServiceTest';
+
+setup({
+    neoConfig: {
+        unitTestMode: true
+    },
+    appConfig: {
+        name             : appName,
+        isMounted        : () => true,
+        vnodeInitialising: false
+    }
+});
+
+import {test, expect} from '@playwright/test';
+
+/**
+ * @summary Unit coverage for `ai/daemons/SwarmHeartbeatService.mjs` (#10789 AC6).
+ *
+ * Covers: poll-loop scheduling, idempotent start/stop, concurrency-lock skip-vs-clear,
+ * sunset-detection-routes-to-resumeHarness, gate-tripped blocks high-authority dispatch,
+ * idle-out-nudge routing, push-capable bypass, fault-tolerant rescheduling.
+ *
+ * Stubbing strategy: SwarmHeartbeatService exposes test-stubbable instance-method seams
+ * (`checkHeartbeatLock`, `clearHeartbeatLock`, `sweepExpiredTasks`, `checkGateOpen`,
+ * `readGate`, `runScript`, `runScriptJson`, `runCmd`, `getUnreadCount`, `getIssuesCount`,
+ * `isPushCapable`, `injectTmux`) precisely so unit tests can override them without going
+ * through the heavy substrate. Module-binding imports (e.g. `isGateOpen`) cannot be
+ * reassigned at import-site in ES modules — instance methods are the seam that works.
+ *
+ * Each test stubs only what it needs; `afterEach` stops the daemon and resets singleton
+ * state so cases don't bleed.
+ */
+test.describe('Neo.ai.daemons.SwarmHeartbeatService', () => {
+    let SwarmHeartbeatService;
+    let originalLifecycleInit;
+    let originalGraphServiceInit;
+
+    test.beforeAll(async () => {
+        SwarmHeartbeatService = (await import('../../../../../ai/daemons/SwarmHeartbeatService.mjs')).default;
+
+        const services = await import('../../../../../ai/services.mjs');
+        const LifecycleService = services.Memory_LifecycleService;
+        const GraphService     = services.Memory_GraphService;
+
+        originalLifecycleInit    = LifecycleService.initAsync;
+        originalGraphServiceInit = GraphService.initAsync;
+
+        // Stub heavy boot — pulse logic uses only `GraphService.db.storage.db`,
+        // which the per-test stubs override at the method level.
+        LifecycleService.initAsync = async () => {};
+        GraphService.initAsync     = async () => {};
+    });
+
+    test.afterAll(async () => {
+        const services = await import('../../../../../ai/services.mjs');
+        services.Memory_LifecycleService.initAsync = originalLifecycleInit;
+        services.Memory_GraphService.initAsync     = originalGraphServiceInit;
+    });
+
+    /**
+     * Apply a default no-op stub set so every test starts from a deterministic baseline.
+     * Individual tests override the seams they care about.
+     */
+    function applyDefaultStubs() {
+        SwarmHeartbeatService.checkHeartbeatLock = async () => ({active: false, stale: false, ageMs: 0});
+        SwarmHeartbeatService.clearHeartbeatLock = async () => {};
+        SwarmHeartbeatService.sweepExpiredTasks  = async () => ({sweptCount: 0});
+        SwarmHeartbeatService.checkGateOpen      = async () => true;
+        SwarmHeartbeatService.readGate           = async () => ({state: 'enabled', reason: '', trippedAt: null, trippedBy: null});
+        SwarmHeartbeatService.runScriptJson      = async () => null;
+        SwarmHeartbeatService.runScript          = async () => '';
+        SwarmHeartbeatService.runCmd             = async () => '[]';
+        SwarmHeartbeatService.getUnreadCount     = async () => 0;
+        SwarmHeartbeatService.getIssuesCount     = async () => 0;
+        SwarmHeartbeatService.isPushCapable      = async () => false;
+        SwarmHeartbeatService.injectTmux         = async () => {};
+        SwarmHeartbeatService.scheduleNext       = function () {};
+        SwarmHeartbeatService.identity           = '@test';
+    }
+
+    test.afterEach(async () => {
+        SwarmHeartbeatService.stop();
+        SwarmHeartbeatService.isPolling      = false;
+        SwarmHeartbeatService.identity       = null;
+        SwarmHeartbeatService.pollIntervalMs = 5 * 60 * 1000;
+    });
+
+    test('start() is idempotent — calling twice does not stack timers', async () => {
+        applyDefaultStubs();
+        let scheduleCount = 0;
+        SwarmHeartbeatService.scheduleNext = function () { scheduleCount++ };
+
+        await SwarmHeartbeatService.start({identity: '@test', pollIntervalMs: 60_000});
+        expect(SwarmHeartbeatService.isPolling).toBe(true);
+        expect(scheduleCount).toBe(1);
+
+        await SwarmHeartbeatService.start({identity: '@test', pollIntervalMs: 60_000});
+        // Second start() is a no-op — scheduleNext NOT called again.
+        expect(scheduleCount).toBe(1);
+    });
+
+    test('start() picks identity from explicit arg, then env, then default', async () => {
+        applyDefaultStubs();
+        SwarmHeartbeatService.scheduleNext = function () {};
+
+        // Explicit arg wins.
+        await SwarmHeartbeatService.start({identity: '@explicit', pollIntervalMs: 60_000});
+        expect(SwarmHeartbeatService.identity).toBe('@explicit');
+        SwarmHeartbeatService.stop();
+        SwarmHeartbeatService.isPolling = false;
+
+        // Env-var falls in when arg absent.
+        const original = process.env.NEO_AGENT_IDENTITY;
+        process.env.NEO_AGENT_IDENTITY = '@from-env';
+        try {
+            await SwarmHeartbeatService.start({pollIntervalMs: 60_000});
+            expect(SwarmHeartbeatService.identity).toBe('@from-env');
+        } finally {
+            if (original === undefined) delete process.env.NEO_AGENT_IDENTITY;
+            else                        process.env.NEO_AGENT_IDENTITY = original;
+        }
+    });
+
+    test('stop() clears the active poll handle and is idempotent', async () => {
+        applyDefaultStubs();
+        SwarmHeartbeatService.scheduleNext = function () {
+            // Set a real timeout so stop() has something to clear.
+            this.pollHandle = setTimeout(() => {}, 60_000);
+        };
+        await SwarmHeartbeatService.start({identity: '@test', pollIntervalMs: 60_000});
+        expect(SwarmHeartbeatService.pollHandle).not.toBeNull();
+
+        SwarmHeartbeatService.stop();
+        expect(SwarmHeartbeatService.pollHandle).toBeNull();
+        expect(SwarmHeartbeatService.isPolling).toBe(false);
+
+        // Second stop() does not throw.
+        expect(() => SwarmHeartbeatService.stop()).not.toThrow();
+    });
+
+    test('pulse() skips when concurrency lock is active', async () => {
+        applyDefaultStubs();
+        SwarmHeartbeatService.checkHeartbeatLock = async () => ({active: true, stale: false, ageMs: 1000});
+
+        const sweepCalls = [];
+        SwarmHeartbeatService.sweepExpiredTasks = async () => { sweepCalls.push(Date.now()); return {sweptCount: 0} };
+
+        await SwarmHeartbeatService.pulse();
+
+        expect(sweepCalls.length).toBe(0); // Active lock → early return; no sweep dispatched.
+    });
+
+    test('pulse() clears stale lock and continues to sweep', async () => {
+        applyDefaultStubs();
+        let releaseCalled = false;
+        SwarmHeartbeatService.checkHeartbeatLock = async () => ({active: false, stale: true, ageMs: 999_999});
+        SwarmHeartbeatService.clearHeartbeatLock = async () => { releaseCalled = true };
+
+        const sweepCalls = [];
+        SwarmHeartbeatService.sweepExpiredTasks = async () => { sweepCalls.push(Date.now()); return {sweptCount: 0} };
+
+        await SwarmHeartbeatService.pulse();
+
+        expect(releaseCalled).toBe(true);
+        expect(sweepCalls.length).toBe(1);
+    });
+
+    test('pulse() skips fresh-session-spawn when wake safety gate is closed', async () => {
+        applyDefaultStubs();
+        SwarmHeartbeatService.checkGateOpen = async () => false;
+        SwarmHeartbeatService.readGate      = async () => ({state: 'tripped', reason: 'test-tripped', trippedAt: null, trippedBy: 'test'});
+
+        const dispatched = [];
+        SwarmHeartbeatService.runScriptJson = async (name) => {
+            if (name === 'checkSunsetted.mjs') {
+                return {
+                    sunsetted          : true,
+                    reason             : 'No active WAKE_SUBSCRIPTION',
+                    originSessionId    : 'sid-123',
+                    abandonedCount     : 0,
+                    recommended_action : 'sunset_restart'
+                };
+            }
+            return null;
+        };
+        SwarmHeartbeatService.runScript = async (name, args) => { dispatched.push({name, args}); return '' };
+
+        await SwarmHeartbeatService.pulse();
+
+        // Gate closed → no resumeHarness dispatch.
+        const resumeCalls = dispatched.filter(d => d.name === 'resumeHarness.mjs');
+        expect(resumeCalls.length).toBe(0);
+    });
+
+    test('pulse() routes sunset to resumeHarness when gate is open', async () => {
+        applyDefaultStubs();
+        const dispatched = [];
+        SwarmHeartbeatService.runScriptJson = async (name) => {
+            if (name === 'checkSunsetted.mjs') {
+                return {
+                    sunsetted          : true,
+                    reason             : 'Subscription missing',
+                    originSessionId    : 'sid-456',
+                    abandonedCount     : 2,
+                    recommended_action : 'sunset_restart'
+                };
+            }
+            return null;
+        };
+        SwarmHeartbeatService.runScript = async (name, args) => { dispatched.push({name, args}); return '' };
+
+        await SwarmHeartbeatService.pulse();
+
+        const resumeCalls = dispatched.filter(d => d.name === 'resumeHarness.mjs');
+        expect(resumeCalls.length).toBe(1);
+        expect(resumeCalls[0].args).toEqual(['@test', 'Subscription missing', 'sid-456', '2']);
+    });
+
+    test('pulse() routes idle_out_nudge when gate is open and recommendation matches', async () => {
+        applyDefaultStubs();
+        const dispatched = [];
+        SwarmHeartbeatService.runScriptJson = async (name) => {
+            if (name === 'checkSunsetted.mjs') {
+                return {
+                    sunsetted          : false,
+                    recommended_action : 'idle_out_nudge'
+                };
+            }
+            return null;
+        };
+        SwarmHeartbeatService.runScript = async (name, args) => { dispatched.push({name, args}); return '' };
+
+        await SwarmHeartbeatService.pulse();
+
+        const nudgeCalls = dispatched.filter(d => d.name === 'idleOutNudge.mjs');
+        expect(nudgeCalls.length).toBe(1);
+        expect(nudgeCalls[0].args).toEqual(['@test']);
+    });
+
+    test('pulse() skips idle_out_nudge when gate is closed', async () => {
+        applyDefaultStubs();
+        SwarmHeartbeatService.checkGateOpen = async () => false;
+
+        const dispatched = [];
+        SwarmHeartbeatService.runScriptJson = async (name) => {
+            if (name === 'checkSunsetted.mjs') {
+                return {sunsetted: false, recommended_action: 'idle_out_nudge'};
+            }
+            return null;
+        };
+        SwarmHeartbeatService.runScript = async (name, args) => { dispatched.push({name, args}); return '' };
+
+        await SwarmHeartbeatService.pulse();
+
+        const nudgeCalls = dispatched.filter(d => d.name === 'idleOutNudge.mjs');
+        expect(nudgeCalls.length).toBe(0);
+    });
+
+    test('pulse() routes allIdle to trioWakeCooldown when gate is open', async () => {
+        applyDefaultStubs();
+        const dispatched = [];
+        SwarmHeartbeatService.runScriptJson = async (name) => {
+            if (name === 'checkAllAgentIdle.mjs') return {allIdle: true, cycle_id: '1', identities: ['@a', '@b']};
+            return null;
+        };
+        SwarmHeartbeatService.runScript = async (name, args) => { dispatched.push({name, args}); return '' };
+
+        await SwarmHeartbeatService.pulse();
+
+        const trioCalls = dispatched.filter(d => d.name === 'trioWakeCooldown.mjs');
+        expect(trioCalls.length).toBe(1);
+        // arg[0] is the JSON-stringified signal
+        expect(JSON.parse(trioCalls[0].args[0]).allIdle).toBe(true);
+    });
+
+    test('pulse() reschedules from finally block even when sweep throws', async () => {
+        applyDefaultStubs();
+        SwarmHeartbeatService.sweepExpiredTasks = async () => { throw new Error('substrate down') };
+
+        let rescheduled = 0;
+        SwarmHeartbeatService.scheduleNext = function () { rescheduled++ };
+
+        await SwarmHeartbeatService.pulse();
+        // Sweep throws but is caught locally; pulse continues; finally fires scheduleNext.
+        expect(rescheduled).toBe(1);
+    });
+
+    test('pulse() injects tmux prompt only when actionable state exists', async () => {
+        applyDefaultStubs();
+
+        const injected = [];
+        SwarmHeartbeatService.injectTmux = async (prompt) => { injected.push(prompt) };
+
+        // Case 1: no unread, no issues — no injection.
+        await SwarmHeartbeatService.pulse();
+        expect(injected.length).toBe(0);
+
+        // Case 2: unread present — inject.
+        SwarmHeartbeatService.getUnreadCount = async () => 3;
+
+        await SwarmHeartbeatService.pulse();
+        expect(injected.length).toBe(1);
+        expect(injected[0]).toContain('Mailbox unread: 3');
+        expect(injected[0]).toContain('Open issues assigned: 0');
+    });
+
+    test('pulse() respects heartbeat-bypass for push-capable identities', async () => {
+        applyDefaultStubs();
+        SwarmHeartbeatService.isPushCapable  = async () => true;
+        SwarmHeartbeatService.getUnreadCount = async () => 99;
+        SwarmHeartbeatService.getIssuesCount = async () => 99;
+
+        const injected = [];
+        SwarmHeartbeatService.injectTmux = async (p) => { injected.push(p) };
+
+        await SwarmHeartbeatService.pulse();
+        // Push-capable bypass — no tmux injection even with high unread count.
+        expect(injected.length).toBe(0);
+    });
+
+    test('pulse() includes expired-count in prompt when sweep yields > 0', async () => {
+        applyDefaultStubs();
+        SwarmHeartbeatService.sweepExpiredTasks = async () => ({sweptCount: 5});
+        SwarmHeartbeatService.getUnreadCount    = async () => 1;
+
+        const injected = [];
+        SwarmHeartbeatService.injectTmux = async (p) => { injected.push(p) };
+
+        await SwarmHeartbeatService.pulse();
+        expect(injected.length).toBe(1);
+        expect(injected[0]).toContain('Tasks expired this cycle: 5');
+    });
+});


### PR DESCRIPTION
Authored by Claude Opus 4.7 (Claude Code). Session 23b9cbcd-4938-4a46-b21a-0d48dd12e7e7.

Resolves #10789

Neo-singleton heartbeat daemon for the Phase 1/3 wake substrate. Replaces the bash-shape persistent-process attempt that was closed not-planned via PR #10782 (architectural pattern violation: bash daemon in `ai/scripts/` when canonical pattern is Neo-class `.mjs` in `ai/daemons/`). Original `swarm-heartbeat.sh` preserved per AC10 for developer-interactive use; this singleton is the launchd / systemd target for autonomous night-shift readiness.

Evidence: L2 (module-load + 14 unit-spec stubs covering pulse-loop branches) → L3 required (AC10 launchd-loaded long-running daemon under operator host). Residual: AC10 [#10671] (operator-territory plist install + 5+ minute live-poll observation; documented in `PersistentProcessManagement.md` §3-§4).

## What shipped

- `ai/daemons/SwarmHeartbeatService.mjs` — Neo-singleton extending `Base`, `static config = { className: 'Neo.ai.daemons.SwarmHeartbeatService', singleton: true, ... }`. Self-invoke entrypoint at file bottom for `node ai/daemons/SwarmHeartbeatService.mjs` direct invocation under launchd; SIGTERM / SIGINT clean shutdown.
- `learn/agentos/wake-substrate/com.neomjs.swarm-heartbeat.plist.template` — launchd plist template targeting the `.mjs` entrypoint (`/usr/bin/env node` + absolute path to service).
- `learn/agentos/wake-substrate/PersistentProcessManagement.md` — operator doc with empirical-prerequisites, install/verify/uninstall procedures, Linux systemd sketch, troubleshooting matrix (8 common gotchas), relationship to #10671 epic-finish.
- `test/playwright/unit/ai/daemons/SwarmHeartbeatService.spec.mjs` — 14 unit tests covering AC6's full surface (poll-loop scheduling, idempotent start/stop, concurrency-lock skip-vs-clear, sunset-detection routing to resumeHarness, gate-tripped blocks high-authority dispatch, idle-out-nudge routing, allIdle → trioWakeCooldown, push-capable bypass, fault-tolerant rescheduling, expired-count-in-prompt).

## Architectural shape

**Direct module imports (subprocess hop removed):**
- `MailboxService.sweepExpiredTasks()` — was a `node ai/scripts/sweepExpiredTasks.mjs` subprocess; now a direct call.
- `wakeSafetyGate.mjs` exports (`isGateOpen`, `readGateState`) — was `node ai/scripts/wakeSafetyGate.mjs check` subprocess; now direct function calls.
- `heartbeatLock.mjs` exports (`inspectHeartbeatLock`, `releaseHeartbeatLock`) — was bash `stat`-based check; now JS implementation shared with the producer side (#10319 `withHeartbeatLock`).

**Subprocess preserved (CLI-shape, out-of-scope for v1):** `checkSunsetted.mjs`, `resumeHarness.mjs`, `checkAllAgentIdle.mjs`, `idleOutNudge.mjs`, `trioWakeCooldown.mjs`. Each is `process.argv` + `console.log` + `process.exit` shape; converting to dual-mode (CLI + module-export) is sibling work. Their subprocess cost (~2-5s × 5 scripts × every 5min) is operationally tolerable.

**Test-stubbable seams:** ES module-binding imports (e.g. `isGateOpen`) cannot be reassigned at import-site. The service exposes thin instance-method wrappers (`checkGateOpen`, `checkHeartbeatLock`, `sweepExpiredTasks`, etc.) precisely so unit tests can override the seam without touching the heavy substrate. Same shape lets future operator extensions inject custom probes via subclass.

## Deltas from ticket

- **AC3 hedge ("where feasible") expanded into a documented split:** PR-body "Architectural shape" section above + module-level JSDoc on `SwarmHeartbeatService.mjs` enumerate which calls are direct vs subprocess, and why. Sibling follow-up #10790-class refactor is referenced in the source comment.
- **Test-stubbable instance-method wrappers added** beyond what AC was strict about. Without these, the AC6 unit-test surface would have collapsed to integration scope (real Memory Core boot per case). The 14 unit tests now run in 1.4s with full singleton-state isolation.
- **Coexistence note added to operator doc §6** — operator-territory: don't run both `swarm-heartbeat.sh` (interactive) AND launchd-loaded SwarmHeartbeatService at the same time. The concurrency lock prevents agent-work-overlapping-with-pulse, NOT two pulse producers.

## Test Evidence

```
$ npx playwright test test/playwright/unit/ai/daemons/SwarmHeartbeatService.spec.mjs --reporter=list
14 passed (1.4s)
```

All 14 cases pass on first run. Coverage:
- start() idempotency
- start() identity precedence (arg > env > default)
- stop() handle-clear + idempotency
- pulse() lock-active skip
- pulse() lock-stale clear-and-continue
- pulse() sunset + gate-closed → skip resumeHarness
- pulse() sunset + gate-open → resumeHarness with full args (identity, reason, originSessionId, abandonedCount)
- pulse() idle_out_nudge + gate-open → idleOutNudge dispatch
- pulse() idle_out_nudge + gate-closed → skip
- pulse() allIdle + gate-open → trioWakeCooldown with stringified signal
- pulse() finally-block reschedule even when sweep throws
- pulse() tmux-inject only when actionable state exists
- pulse() push-capable identity bypass
- pulse() expired-count-in-prompt formatting

Module-load smoke test:
```
$ node -e "import('./ai/daemons/SwarmHeartbeatService.mjs').then(m => console.log('default:', m.default.constructor.name))"
default: SwarmHeartbeatService
```

plist syntax:
```
$ plutil -lint learn/agentos/wake-substrate/com.neomjs.swarm-heartbeat.plist.template
learn/agentos/wake-substrate/com.neomjs.swarm-heartbeat.plist.template: OK
```

## Post-Merge Validation

- [ ] Operator-territory: substitute plist template + `launchctl bootstrap` + verify daemon emits "Starting heartbeat for ..." log line within 30s of load (per `PersistentProcessManagement.md` §3d).
- [ ] Operator-territory: 30-minute live-poll observation — verify pulse cycle fires, lock mtime advances, no `heartbeat.stderr.log` activity.
- [ ] Operator-territory: SIGTERM clean shutdown verified via `launchctl bootout` (no orphaned timers, log line "Received SIGTERM; stopping.").
- [ ] Operator-territory (#10671 epic-finish): `wakeSafetyGate enable` after substrate validation; observe a real recovery wake fire end-to-end.

## Cross-family Review Routing (#10789 AC9)

Per the ticket, **cross-family review by @neo-gpt only** (Gemini observer-only — pre-empted via direct commits on the prior PR #10782 attempt; cross-family-review independence requires a model that hasn't authored this substrate). A2A primary-reviewer ping follows immediately after this PR opens.

## Related

- **Parent epic:** #10671 (substrate-restart recovery, two-mode: idle-out + sunset)
- **Closed-not-planned predecessors:** #10781, #10787, PR #10782
- **Sibling #10790-class follow-up:** convert remaining wake-substrate scripts to dual-mode (CLI + module-export) so SwarmHeartbeatService can replace the remaining subprocess hops with direct module imports.
- **Canonical Neo-class precedent:** `ai/daemons/DreamService.mjs`