### PR TITLE
test(mcp): add proxy-identity unit tests (#10772)

### DIFF
--- a/ai/mcp/server/shared/services/TransportService.mjs
+++ b/ai/mcp/server/shared/services/TransportService.mjs
@@ -46,6 +46,32 @@ class TransportService extends Base {
     }
 
     /**
+     * Resolves the base authentication context, handling proxy identity injection.
+     * @param {Object} req The Express request
+     * @param {Object} aiConfig The server configuration
+     * @returns {Object} Result object containing `auth` or `error` with `status`.
+     */
+    resolveAuthContext(req, aiConfig) {
+        let baseAuth = req.auth;
+
+        if (!baseAuth && aiConfig.auth?.trustProxyIdentity) {
+            const proxyUserId = req.headers['x-preferred-username'] || req.headers['x-auth-request-preferred-username'];
+            if (proxyUserId) {
+                baseAuth = {
+                    userId: proxyUserId,
+                    username: proxyUserId,
+                    source: 'proxy-header'
+                };
+            } else {
+                req.app?.locals?.logger?.warn('Unauthorized: trustProxyIdentity is enabled but X-PREFERRED-USERNAME header is missing');
+                return { error: 'Unauthorized: Missing proxy identity header', status: 401 };
+            }
+        }
+
+        return { auth: baseAuth };
+    }
+
+    /**
      * Map of active transport sessions.
      * @member {Map} transports
      * @protected
@@ -142,23 +168,12 @@ class TransportService extends Base {
             // configured; when auth is disabled (local dev, no `aiConfig.auth.host` /
             // `.issuerUrl`) the context is empty and downstream services fall through to
             // single-tenant behavior.
-            let baseAuth = req.auth;
-
-            // Support identity-aware proxies (e.g., oauth2-proxy, GitLab) when explicitly trusted
-            if (!baseAuth && aiConfig.auth?.trustProxyIdentity) {
-                const proxyUserId = req.headers['x-preferred-username'] || req.headers['x-auth-request-preferred-username'];
-                if (proxyUserId) {
-                    baseAuth = {
-                        userId: proxyUserId,
-                        username: proxyUserId,
-                        source: 'proxy-header'
-                    };
-                } else {
-                    req.app.locals.logger?.warn('Unauthorized: trustProxyIdentity is enabled but X-PREFERRED-USERNAME header is missing');
-                    res.status(401).json({ error: 'Unauthorized: Missing proxy identity header' });
-                    return;
-                }
+            const authResult = this.resolveAuthContext(req, aiConfig);
+            if (authResult.error) {
+                res.status(authResult.status).json({ error: authResult.error });
+                return;
             }
+            let baseAuth = authResult.auth;
 
             let requestContext;
 

--- a/test/playwright/unit/ai/mcp/server/shared/services/TransportService.spec.mjs
+++ b/test/playwright/unit/ai/mcp/server/shared/services/TransportService.spec.mjs
@@ -91,4 +91,110 @@ test.describe('Neo.ai.mcp.server.shared.services.TransportService', () => {
         TransportService.destroy();
     });
 
+    test.describe('resolveAuthContext proxy-identity injection', () => {
+        let TransportService;
+
+        test.beforeAll(async () => {
+            TransportService = (await import('../../../../../../../../ai/mcp/server/shared/services/TransportService.mjs')).default;
+        });
+
+        test('OIDC precedence: native req.auth overrides proxy headers', () => {
+            const req = {
+                auth: { userId: 'oidc-user', username: 'oidc-user', source: 'jwt' },
+                headers: { 'x-preferred-username': 'spoofed-user' }
+            };
+            const aiConfig = { auth: { trustProxyIdentity: true } };
+
+            const result = TransportService.resolveAuthContext(req, aiConfig);
+
+            expect(result.error).toBeUndefined();
+            expect(result.auth).toEqual({
+                userId: 'oidc-user',
+                username: 'oidc-user',
+                source: 'jwt'
+            });
+        });
+
+        test('Active proxy identity injection (canonical header)', () => {
+            const req = {
+                auth: undefined,
+                headers: { 'x-preferred-username': 'proxy-user' }
+            };
+            const aiConfig = { auth: { trustProxyIdentity: true } };
+
+            const result = TransportService.resolveAuthContext(req, aiConfig);
+
+            expect(result.error).toBeUndefined();
+            expect(result.auth).toEqual({
+                userId: 'proxy-user',
+                username: 'proxy-user',
+                source: 'proxy-header'
+            });
+        });
+
+        test('OAuth2-proxy variant header fallback', () => {
+            const req = {
+                auth: undefined,
+                headers: { 'x-auth-request-preferred-username': 'oauth2-user' }
+            };
+            const aiConfig = { auth: { trustProxyIdentity: true } };
+
+            const result = TransportService.resolveAuthContext(req, aiConfig);
+
+            expect(result.error).toBeUndefined();
+            expect(result.auth).toEqual({
+                userId: 'oauth2-user',
+                username: 'oauth2-user',
+                source: 'proxy-header'
+            });
+        });
+
+        test('Gate-disabled behavior: ignores headers when trustProxyIdentity is false', () => {
+            const req = {
+                auth: undefined,
+                headers: { 'x-preferred-username': 'ignored-user' }
+            };
+            const aiConfig = { auth: { trustProxyIdentity: false } };
+
+            const result = TransportService.resolveAuthContext(req, aiConfig);
+
+            expect(result.error).toBeUndefined();
+            expect(result.auth).toBeUndefined();
+        });
+
+        test('Both headers provided: prioritizes canonical over oauth2-proxy', () => {
+            const req = {
+                auth: undefined,
+                headers: {
+                    'x-preferred-username': 'primary-user',
+                    'x-auth-request-preferred-username': 'secondary-user'
+                }
+            };
+            const aiConfig = { auth: { trustProxyIdentity: true } };
+
+            const result = TransportService.resolveAuthContext(req, aiConfig);
+
+            expect(result.error).toBeUndefined();
+            expect(result.auth).toEqual({
+                userId: 'primary-user',
+                username: 'primary-user',
+                source: 'proxy-header'
+            });
+        });
+
+        test('Header-spoof resistance / required identity: returns 401 when enabled but headers are missing', () => {
+            const req = {
+                auth: undefined,
+                headers: {}
+            };
+            const aiConfig = { auth: { trustProxyIdentity: true } };
+
+            const result = TransportService.resolveAuthContext(req, aiConfig);
+
+            expect(result.error).toBe('Unauthorized: Missing proxy identity header');
+            expect(result.status).toBe(401);
+            expect(result.auth).toBeUndefined();
+        });
+    });
+
 });


### PR DESCRIPTION
Authored by @neo-gemini-3-1-pro (Antigravity). Session 88a6ed3a-b1b9-461a-aaf3-7c9984bd12e7.

Resolves #10772

Extracted `resolveAuthContext` from the route handler into an instance method to achieve testability without full Express startup, and added 6 specific unit test cases covering OIDC precedence, active proxy identity injection (canonical and oauth2-proxy), gate-disabled behavior, multiple headers, and header-spoof resistance.

Evidence: L1 (unit tests added, pure JS logic branch testing) → L1 required (no runtime visual ACs). No residuals.

## Deltas from ticket (if any)
Extracted the identity injection branch logic into an instance method `resolveAuthContext(req, aiConfig)` rather than a pure function to maintain the `this` binding inside the route handler since `TransportService` is managed as a singleton instance by `Neo.setupClass()`.

## Test Evidence
Ran `npx playwright test test/playwright/unit/ai/mcp/server/shared/services/TransportService.spec.mjs`. All 7 tests pass.

## Post-Merge Validation
- [ ] Ensure CI passes on PR merge.