### PR TITLE
feat(memory-core): surface active auth provider in healthcheck (#10770)

### DIFF
--- a/ai/mcp/server/memory-core/services/HealthService.mjs
+++ b/ai/mcp/server/memory-core/services/HealthService.mjs
@@ -218,6 +218,67 @@ export function buildSummaryProviderBlock(cfg, env = process.env) {
 }
 
 /**
+ * @summary Projects the active authentication-provider configuration into the healthcheck
+ *          `providers.auth` observability block (#10770).
+ *
+ * Operators deploying the shared MC/KB topology with multi-tenant identity isolation need an
+ * observable surface confirming WHICH auth path is currently primary at boot — OIDC introspection
+ * vs proxy-header injection vs single-tenant fallthrough. Without this, a misconfigured
+ * `AUTH_TRUST_PROXY_IDENTITY=true` set without a fronting proxy actually being deployed is
+ * undetectable until requests start failing in non-obvious ways. Mirrors the
+ * {@link buildEmbeddingProviderBlock} + {@link buildSummaryProviderBlock} precedents for
+ * module-scope pure projections of provider state.
+ *
+ * **Path precedence (matches `Server.mjs#buildRequestContext` runtime semantics):**
+ * - `'oidc'` — `aiConfig.auth.host` AND `aiConfig.auth.issuerUrl` are both populated. The MC
+ *   server runs its own OIDC introspection. Takes precedence over proxy-header even when
+ *   `trustProxyIdentity` is also true (req.auth wins by design — see SharedDeployment.md).
+ * - `'proxy-header'` — OIDC unconfigured AND `trustProxyIdentity=true`. The MC server reads
+ *   `X-PREFERRED-USERNAME` (or the `oauth2-proxy`-specific `X-Auth-Request-Preferred-Username`)
+ *   from the upstream request and trusts the fronting proxy's identity assertion. Per
+ *   PR #10785, requests missing the proxy header in this mode are actively rejected with 401.
+ * - `'unconfigured'` — neither path active. Single-tenant fallthrough (local development).
+ *
+ * **Security: clientSecret never leaks.** This block intentionally omits the OAuth `clientSecret`
+ * field even when OIDC is configured. Healthcheck output is operator-readable and may surface in
+ * logs / monitoring dashboards; the secret value belongs only in the gitignored `config.mjs`.
+ *
+ * @param {Object} cfg aiConfig-shaped input. Reads `cfg.auth.{host, issuerUrl, realm, trustProxyIdentity}`.
+ * @returns {{configured: String, oidc: Object, proxyHeader: Object}}
+ * @see learn/agentos/SharedDeployment.md
+ * @see Neo.ai.mcp.server.memory-core.Server#buildRequestContext
+ */
+export function buildAuthProviderBlock(cfg) {
+    const auth           = cfg.auth || {};
+    const oidcConfigured = !!(auth.host && auth.issuerUrl);
+    const proxyTrusted   = auth.trustProxyIdentity === true;
+
+    let configured;
+
+    if (oidcConfigured) {
+        configured = 'oidc';
+    } else if (proxyTrusted) {
+        configured = 'proxy-header';
+    } else {
+        configured = 'unconfigured';
+    }
+
+    return {
+        configured,
+        oidc: {
+            host      : auth.host || null,
+            issuerUrl : auth.issuerUrl || null,
+            realm     : auth.realm || null,
+            configured: oidcConfigured
+        },
+        proxyHeader: {
+            trusted       : proxyTrusted,
+            headersChecked: ['x-preferred-username', 'x-auth-request-preferred-username']
+        }
+    };
+}
+
+/**
  * @summary Monitors and validates the ChromaDB dependency for the Memory Core MCP server.
  *
  * This service acts as a gatekeeper, ensuring that ChromaDB is properly running,
@@ -624,7 +685,8 @@ class HealthService extends Base {
             migration: await this.#checkMigrationState(),
             providers: {
                 embedding: buildEmbeddingProviderBlock(aiConfig),
-                summary  : buildSummaryProviderBlock(aiConfig)
+                summary  : buildSummaryProviderBlock(aiConfig),
+                auth     : buildAuthProviderBlock(aiConfig)
             },
             details  : [],
             version  : process.env.npm_package_version || '1.0.0',

--- a/learn/agentos/SharedDeployment.md
+++ b/learn/agentos/SharedDeployment.md
@@ -160,7 +160,7 @@ Every authenticated request carries a `source` tag through `Server.mjs#buildRequ
 
 The source tag is graph-ingested into agent-identity memory writes; an audit query against memories can verify the proportion of `'oidc'` vs `'proxy-header'` writes against operator expectations.
 
-A symmetric healthcheck `providers.auth` block is a recommended follow-up tracked under #10770. Until then, source-tag observability is via memory-write audit only.
+A symmetric healthcheck `providers.auth` block is shipped under [#10770](https://github.com/neomjs/neo/issues/10770) — see [Healthcheck Verification](#healthcheck-verification) below. The block provides static-config observability of the active auth path (OIDC vs proxy-header vs unconfigured) at boot; per-request source-tag observability remains via memory-write audit.
 
 ## Healthcheck Verification
 
@@ -185,7 +185,7 @@ See [`MemoryCore.md` §Healthcheck Response Shape](./MemoryCore.md) for the full
 
 The Knowledge Base's healthcheck mirrors the connectivity assertion (collection counts, embedding status). When both servers report `connected: true` against the same shared `{host, port}`, the topology is verified.
 
-The Memory Core's healthcheck additionally surfaces active provider observability under `providers.*` (#10723, #10724):
+The Memory Core's healthcheck additionally surfaces active provider observability under `providers.*` (#10723, #10724, #10770):
 
 ```json
 "providers": {
@@ -205,6 +205,19 @@ The Memory Core's healthcheck additionally surfaces active provider observabilit
             "env": "NEO_OPENAI_COMPATIBLE_API_KEY",
             "configured": false,
             "required": false
+        }
+    },
+    "auth": {
+        "configured": "oidc",
+        "oidc": {
+            "host": "http://127.0.0.1:8180",
+            "issuerUrl": "http://127.0.0.1:8180/realms/master",
+            "realm": "master",
+            "configured": true
+        },
+        "proxyHeader": {
+            "trusted": false,
+            "headersChecked": ["x-preferred-username", "x-auth-request-preferred-username"]
         }
     }
 }
@@ -227,6 +240,15 @@ Summary diagnostic fields:
 - `credential`: env var name plus `configured` / `required` booleans; secret values are never exposed.
 
 For disconnect-triggered summarization, keep `AUTO_SUMMARIZE=true` only after the local model is reachable and healthcheck shows the intended provider/model. If the local chat API is unavailable, Memory Core logs the summarization failure and keeps raw memories intact so the operator can retry.
+
+Auth diagnostic fields:
+- `configured`: which auth path is primary at boot — `'oidc'`, `'proxy-header'`, or `'unconfigured'`. OIDC takes precedence when both are configured (matches `Server.mjs#buildRequestContext` runtime semantics — `req.auth` wins over the proxy header by design).
+- `oidc.{host, issuerUrl, realm}`: introspection-relevant config visibility (never the `clientSecret`).
+- `oidc.configured`: `true` only when both `host` AND `issuerUrl` are populated.
+- `proxyHeader.trusted`: whether `auth.trustProxyIdentity` is enabled in config.
+- `proxyHeader.headersChecked`: the canonical (`x-preferred-username`) and `oauth2-proxy`-specific (`x-auth-request-preferred-username`) header keys the server reads in proxy-header mode.
+
+Use `configured` as the at-a-glance indicator. A misconfigured `AUTH_TRUST_PROXY_IDENTITY=true` without OIDC and without a fronting proxy actually deployed will surface here as `'proxy-header'`; if requests then fail with `401`, that's the runtime gate ([PR #10785](https://github.com/neomjs/neo/pull/10785)) rejecting missing proxy headers per the [Authentication](#authentication) threat model. The healthcheck shows the *configured* posture; the 401 confirms the gate fires when the prerequisite is absent.
 
 ## Asynchronous Session Summarization (Disconnect Trigger)
 

--- a/test/playwright/unit/ai/mcp/server/memory-core/services/HealthService.spec.mjs
+++ b/test/playwright/unit/ai/mcp/server/memory-core/services/HealthService.spec.mjs
@@ -371,3 +371,140 @@ test.describe('HealthService #10724 — buildSummaryProviderBlock', () => {
         });
     });
 });
+
+/**
+ * @summary Coverage for the #10770 auth-provider observability block in the healthcheck payload.
+ *
+ * Pins the pure-projection contract of `buildAuthProviderBlock` — operators deploying the shared
+ * MC/KB topology with multi-tenant identity isolation rely on this block to verify which auth
+ * path is primary at boot (OIDC vs proxy-header vs single-tenant fallthrough). The runtime
+ * precedence semantics are owned by `Server.mjs#buildRequestContext`; this spec covers the
+ * static-config projection that operators observe via healthcheck without bouncing requests
+ * through the server. Includes a defense-in-depth `clientSecret`-leak guard.
+ *
+ * @see Neo.ai.mcp.server.memory-core.services.HealthService#buildAuthProviderBlock
+ */
+test.describe('HealthService #10770 — buildAuthProviderBlock', () => {
+    let buildAuthProviderBlock;
+
+    test.beforeAll(async () => {
+        const mod = await import('../../../../../../../../ai/mcp/server/memory-core/services/HealthService.mjs');
+        buildAuthProviderBlock = mod.buildAuthProviderBlock;
+    });
+
+    test('OIDC-only config surfaces oidc primary path with full block', () => {
+        const result = buildAuthProviderBlock({
+            auth: {
+                host              : 'http://127.0.0.1:8180',
+                issuerUrl         : 'http://127.0.0.1:8180/realms/master',
+                realm             : 'master',
+                clientId          : 'memory-core',
+                clientSecret      : 'should-never-leak',
+                trustProxyIdentity: false
+            }
+        });
+
+        expect(result).toEqual({
+            configured: 'oidc',
+            oidc      : {
+                host      : 'http://127.0.0.1:8180',
+                issuerUrl : 'http://127.0.0.1:8180/realms/master',
+                realm     : 'master',
+                configured: true
+            },
+            proxyHeader: {
+                trusted       : false,
+                headersChecked: ['x-preferred-username', 'x-auth-request-preferred-username']
+            }
+        });
+    });
+
+    test('proxy-header-only config surfaces proxy-header primary path with OIDC unconfigured', () => {
+        const result = buildAuthProviderBlock({
+            auth: {
+                host              : null,
+                issuerUrl         : null,
+                clientId          : null,
+                clientSecret      : '',
+                trustProxyIdentity: true
+            }
+        });
+
+        expect(result).toEqual({
+            configured: 'proxy-header',
+            oidc      : {
+                host      : null,
+                issuerUrl : null,
+                realm     : null,
+                configured: false
+            },
+            proxyHeader: {
+                trusted       : true,
+                headersChecked: ['x-preferred-username', 'x-auth-request-preferred-username']
+            }
+        });
+    });
+
+    test('both configured — OIDC wins per Server.mjs#buildRequestContext precedence', () => {
+        const result = buildAuthProviderBlock({
+            auth: {
+                host              : 'http://127.0.0.1:8180',
+                issuerUrl         : 'http://127.0.0.1:8180/realms/master',
+                realm             : 'master',
+                trustProxyIdentity: true
+            }
+        });
+
+        expect(result.configured).toBe('oidc');
+        expect(result.oidc.configured).toBe(true);
+        expect(result.proxyHeader.trusted).toBe(true);
+    });
+
+    test('unconfigured fallthrough — single-tenant local-dev shape', () => {
+        const result = buildAuthProviderBlock({});
+
+        expect(result).toEqual({
+            configured: 'unconfigured',
+            oidc      : {
+                host      : null,
+                issuerUrl : null,
+                realm     : null,
+                configured: false
+            },
+            proxyHeader: {
+                trusted       : false,
+                headersChecked: ['x-preferred-username', 'x-auth-request-preferred-username']
+            }
+        });
+    });
+
+    test('clientSecret never leaks into the healthcheck payload (security guard)', () => {
+        const result = buildAuthProviderBlock({
+            auth: {
+                host              : 'http://127.0.0.1:8180',
+                issuerUrl         : 'http://127.0.0.1:8180/realms/master',
+                clientSecret      : 'super-secret-value-that-must-never-leak',
+                trustProxyIdentity: false
+            }
+        });
+
+        const serialized = JSON.stringify(result);
+
+        expect(serialized).not.toContain('super-secret-value-that-must-never-leak');
+        expect(serialized).not.toContain('clientSecret');
+        expect(result.oidc).not.toHaveProperty('clientSecret');
+    });
+
+    test('partial OIDC (host without issuerUrl) projects to unconfigured', () => {
+        const result = buildAuthProviderBlock({
+            auth: {
+                host              : 'http://127.0.0.1:8180',
+                issuerUrl         : null,
+                trustProxyIdentity: false
+            }
+        });
+
+        expect(result.configured).toBe('unconfigured');
+        expect(result.oidc.configured).toBe(false);
+    });
+});


### PR DESCRIPTION
Authored by Claude Opus 4.7 (Claude Code). Session 34c8f800-1855-43ff-aea6-d5e6b9410978.

Resolves #10770

Adds the `providers.auth` healthcheck observability block — the symmetric counterpart to `providers.embedding` (#10723, [PR #10767](https://github.com/neomjs/neo/pull/10767)) and `providers.summary` (#10724) for the auth dimension introduced by #10727 / [PR #10768](https://github.com/neomjs/neo/pull/10768) (`auth.trustProxyIdentity`). Operators can now verify which auth path is primary at boot (OIDC vs proxy-header vs unconfigured) without inspecting logs or re-running config through `node -e`.

Evidence: L2 (HealthService unit-test contract pinning across 6 config modes) → L3 required for AC4 docs ([SharedDeployment.md](learn/agentos/SharedDeployment.md) extended). Residual: AC7 end-to-end dry-run — operator-gated multi-host probe, parent epic [#10721](https://github.com/neomjs/neo/issues/10721) close-target.

## Implementation

- `ai/mcp/server/memory-core/services/HealthService.mjs` — new `buildAuthProviderBlock(cfg)` module-scope pure projection (~67 lines + JSDoc) wired into the healthcheck payload at `providers.auth`. Mirrors the precedent shape of `buildEmbeddingProviderBlock` + `buildSummaryProviderBlock` (sibling pure projections; no class-state coupling).
- Path precedence (`'oidc'` wins when both configured) matches `Server.mjs#buildRequestContext` runtime semantics — `req.auth` takes precedence over the proxy header by design ([SharedDeployment.md L116](learn/agentos/SharedDeployment.md#authentication)).
- `clientSecret` intentionally omitted from the projection. Healthcheck output is operator-readable and may surface in monitoring dashboards; secret values stay only in gitignored `config.mjs`. Verified at runtime via JSON.stringify probe + property-check in tests.

## Deltas from ticket

None. Implementation matches the prescription in #10770 exactly. Contract Ledger T3 matrix added to ticket body 2026-05-06 in response to [@neo-gpt's hand-back](https://github.com/neomjs/neo/issues/10770#issuecomment-4385829393); GPT's suggested row encoded verbatim with minor editorial adjustments to surface evidence anchors.

## Test Evidence

```
$ npx playwright test test/playwright/unit/ai/mcp/server/memory-core/services/HealthService.spec.mjs --reporter=line
Running 23 tests using 1 worker
…
  23 passed (1.4s)
```

6 new tests added under `describe('HealthService #10770 — buildAuthProviderBlock', ...)`:
- `OIDC-only config surfaces oidc primary path with full block`
- `proxy-header-only config surfaces proxy-header primary path with OIDC unconfigured`
- `both configured — OIDC wins per Server.mjs#buildRequestContext precedence`
- `unconfigured fallthrough — single-tenant local-dev shape`
- `clientSecret never leaks into the healthcheck payload (security guard)`
- `partial OIDC (host without issuerUrl) projects to unconfigured`

Plus 17 pre-existing tests in the same file (buildIdentityBlock #10176, buildTopologyBlock #10127, buildEmbeddingProviderBlock #10723, buildSummaryProviderBlock #10724) — all still passing post-change. No regression surface.

## Post-Merge Validation

- [ ] Live healthcheck via `healthcheck` MCP tool against a deployment with OIDC configured (Keycloak) — verify `providers.auth.configured === 'oidc'`, `oidc.{host,issuerUrl,realm}` populated, `proxyHeader.trusted === false`.
- [ ] Live healthcheck against `AUTH_TRUST_PROXY_IDENTITY=true` deployment without OIDC — verify `providers.auth.configured === 'proxy-header'`, `proxyHeader.trusted === true`.
- [ ] Live healthcheck against local-dev (no auth env) — verify `providers.auth.configured === 'unconfigured'`.
- [ ] No `clientSecret` value visible in any operational healthcheck capture (logs, monitoring dashboards, screenshots).

## Coordination Notes

- Sibling parallel-track PR(s) for parent epic [#10721](https://github.com/neomjs/neo/issues/10721) — [PR #10797](https://github.com/neomjs/neo/pull/10797) (`@neo-gemini-3-1-pro`, #10772 TransportService proxy-identity tests) is already open. [#10773](https://github.com/neomjs/neo/issues/10773) (`@neo-gpt` lane, `providers.neoEmbedding` SQLite-side restructure) Contract Ledger now in place — GPT unblocked.
- Trivial rebase potential with #10773 PR when it lands (both touch the `providers:` payload assembly in `HealthService.mjs`); whichever lands second resolves a 1-line conflict.

## Related

- Parent epic: [#10721](https://github.com/neomjs/neo/issues/10721) (Shared deployment MVP completeness gaps) — 6/10 closed pre-PR; this PR brings 7/10.
- Adjacent shipped: [PR #10767](https://github.com/neomjs/neo/pull/10767) (`providers.embedding` precedent), [PR #10768](https://github.com/neomjs/neo/pull/10768) (auth proxy-identity injection — the substrate this observes), [PR #10769](https://github.com/neomjs/neo/pull/10769) (auth threat-model docs), [PR #10785](https://github.com/neomjs/neo/pull/10785) (401 gate for missing proxy identity).
- Pattern precedents: [#10176](https://github.com/neomjs/neo/issues/10176) (`buildIdentityBlock`), [#10127](https://github.com/neomjs/neo/issues/10127) (`buildTopologyBlock`).