### PR TITLE
feat(memory-core): surface sqlite embedding provider in healthcheck (#10773)

### DIFF
--- a/ai/mcp/server/memory-core/services/HealthService.mjs
+++ b/ai/mcp/server/memory-core/services/HealthService.mjs
@@ -101,38 +101,53 @@ export function buildTopologyBlock(cfg) {
 
 /**
  * @summary Projects the active embedding-provider configuration into the healthcheck `providers.embedding`
- *          observability block (#10723).
+ *          observability block (#10723, #10773).
  *
- * Pure function: takes an `aiConfig`-shaped input and returns the active embedding provider with
- * its host, model, and configured vector dimension. Mirrors the {@link buildTopologyBlock} precedent
+ * Pure function: takes an `aiConfig`-shaped input and returns both active embedding providers with
+ * their host, model, and configured vector dimension. Mirrors the {@link buildTopologyBlock} precedent
  * for module-scope pure projections.
  *
  * **Why this block exists:** Operators deploying the shared MC/KB topology against a local-model stack
- * (e.g., MLX-served Qwen3 embedding model) need an observable surface confirming WHICH embedding
- * provider is currently active and WHICH model + endpoint is in use. Without this, a misconfigured
- * `NEO_CHROMA_EMBEDDING_PROVIDER` env var (silently defaulting to Gemini cloud while the operator
- * believes a local provider is wired) is undetectable until cross-tenant retrieval drift emerges.
+ * (e.g., MLX-served Qwen3 embedding model) need an observable surface confirming WHICH Chroma-side
+ * and SQLite-side embedding providers are currently active and WHICH model + endpoint is in use.
+ * Without this, a misconfigured `NEO_CHROMA_EMBEDDING_PROVIDER` or `NEO_EMBEDDING_PROVIDER` env var
+ * (silently defaulting to Gemini cloud while the operator believes a local provider is wired) is
+ * undetectable until cross-tenant retrieval drift emerges.
  *
  * **What this block reports:**
- * - `active`: which provider key is currently selected for ChromaDB embedding generation
- *   (`'gemini'` | `'openAiCompatible'` | `'ollama'`)
- * - `host`: resolved provider endpoint URL (when applicable; `null` for cloud providers)
- * - `model`: resolved embedding model name
- * - `dimensions`: configured vector dimension (`vectorDimension` config; load-bearing because
- *   ChromaDB collections are pinned to dimensions at creation, mismatch causes silent insert failures)
+ * - `aligned`: whether ChromaDB and SQLite Native Edge Graph embedding provider keys match
+ * - `chroma`: provider projection for ChromaDB embedding generation
+ * - `neo`: provider projection for SQLite Native Edge Graph embedding generation
  *
- * **Defensive fallback:** if the active provider key isn't recognized, the block surfaces
+ * **Defensive fallback:** if either provider key isn't recognized, its sub-block surfaces
  * `{active: <unknown-key>, host: null, model: null, dimensions: <vectorDimension>, error: <msg>}`
  * so operators see the misconfig directly. Aligns with "surface, don't obscure" (PR #10227).
  *
- * @param {Object} cfg aiConfig-shaped input. Reads `cfg.chromaEmbeddingProvider`,
+ * @param {Object} cfg aiConfig-shaped input. Reads `cfg.chromaEmbeddingProvider`, `cfg.neoEmbeddingProvider`,
  *     `cfg.openAiCompatible.{host, embeddingModel}`, `cfg.ollama.{host, embeddingModel}`,
  *     `cfg.embeddingModel` (Gemini path), `cfg.vectorDimension`.
- * @returns {{active: String, host: String|null, model: String|null, dimensions: Number, error?: String}}
+ * @returns {{aligned: Boolean, chroma: Object, neo: Object}}
  * @see learn/agentos/SharedDeployment.md
  */
 export function buildEmbeddingProviderBlock(cfg) {
-    const active     = cfg.chromaEmbeddingProvider;
+    const chromaActive = cfg.chromaEmbeddingProvider;
+    const neoActive    = cfg.neoEmbeddingProvider || 'gemini';
+
+    return {
+        aligned: chromaActive === neoActive,
+        chroma : buildSingleEmbeddingProviderBlock(cfg, chromaActive, 'chromaEmbeddingProvider'),
+        neo    : buildSingleEmbeddingProviderBlock(cfg, neoActive, 'neoEmbeddingProvider')
+    }
+}
+
+/**
+ * Projects one embedding provider selector into the common healthcheck sub-block shape.
+ * @param {Object} cfg aiConfig-shaped input.
+ * @param {String} active The selected provider key.
+ * @param {String} configName The aiConfig key name used in scoped error messages.
+ * @returns {{active: String, host: String|null, model: String|null, dimensions: Number, error?: String}}
+ */
+function buildSingleEmbeddingProviderBlock(cfg, active, configName) {
     const dimensions = cfg.vectorDimension;
 
     switch (active) {
@@ -163,7 +178,7 @@ export function buildEmbeddingProviderBlock(cfg) {
                 host      : null,
                 model     : null,
                 dimensions,
-                error     : `Unrecognized chromaEmbeddingProvider: '${active}'. Expected 'gemini' | 'openAiCompatible' | 'ollama'.`
+                error     : `Unrecognized ${configName}: '${active}'. Expected 'gemini' | 'openAiCompatible' | 'ollama'.`
             };
     }
 }

--- a/learn/agentos/MemoryCore.md
+++ b/learn/agentos/MemoryCore.md
@@ -111,10 +111,19 @@ Operators running `healthcheck` (via MCP, or via the SSE `/healthcheck` endpoint
     "migration": { "memory": 0, "session": 0, "total": 0, "available": true },
     "providers": {
         "embedding": {
-            "active": "openAiCompatible",
-            "host": "http://127.0.0.1:8000",
-            "model": "text-embedding-qwen3-embedding-1.5b",
-            "dimensions": 4096
+            "aligned": true,
+            "chroma": {
+                "active": "openAiCompatible",
+                "host": "http://127.0.0.1:8000",
+                "model": "text-embedding-qwen3-embedding-1.5b",
+                "dimensions": 4096
+            },
+            "neo": {
+                "active": "openAiCompatible",
+                "host": "http://127.0.0.1:8000",
+                "model": "text-embedding-qwen3-embedding-1.5b",
+                "dimensions": 4096
+            }
         },
         "summary": {
             "active": "openAiCompatible",
@@ -163,6 +172,20 @@ Introduced in #10017 (see `learn/agentos/tooling/MultiTenantMigrationGuide.md`).
 - `available`: `false` if the SQLite graph is not yet mounted (substrate-readiness signal, not a migration error).
 
 A zero `total` is the signal operators watch for to flip the `memorySharing` default from `'legacy'` to `'private'`.
+
+### `providers.embedding` — Active Embedding Model Routes
+
+Introduced for Chroma-side local embedding-provider validation (#10723) and expanded for SQLite-side embedding observability (#10773). The block surfaces both embedding paths so operators can verify whether ChromaDB retrieval and SQLite Native Edge Graph operations share the same provider intentionally:
+
+| Field | Type | Meaning |
+|---|---|---|
+| `aligned` | `boolean` | `true` when `chroma.active` and `neo.active` match. `false` is valid for intentional split-engine deployments, but otherwise indicates config drift between `NEO_CHROMA_EMBEDDING_PROVIDER` and `NEO_EMBEDDING_PROVIDER`. |
+| `chroma.active` | `'gemini' \| 'openAiCompatible' \| 'ollama' \| string` | Provider selected for ChromaDB embedding generation. |
+| `neo.active` | `'gemini' \| 'openAiCompatible' \| 'ollama' \| string` | Provider selected for SQLite Native Edge Graph embedding operations. Defaults to `'gemini'` when `NEO_EMBEDDING_PROVIDER` is unset. |
+| `chroma.host` / `neo.host` | `string \| null` | Embedding provider host for local providers; `null` for Gemini. |
+| `chroma.model` / `neo.model` | `string \| null` | Configured embedding model name. |
+| `chroma.dimensions` / `neo.dimensions` | `number` | Configured `vectorDimension`; must match the embedding model's actual output dimension. |
+| `chroma.error` / `neo.error` | `string` (optional) | Present only when that provider key is unrecognized; healthcheck surfaces the misconfig instead of throwing. |
 
 ### `providers.summary` — Active Summary Model Route
 

--- a/learn/agentos/SharedDeployment.md
+++ b/learn/agentos/SharedDeployment.md
@@ -190,10 +190,19 @@ The Memory Core's healthcheck additionally surfaces active provider observabilit
 ```json
 "providers": {
     "embedding": {
-        "active": "openAiCompatible",
-        "host": "http://127.0.0.1:8000",
-        "model": "text-embedding-qwen3-embedding-1.5b",
-        "dimensions": 4096
+        "aligned": true,
+        "chroma": {
+            "active": "openAiCompatible",
+            "host": "http://127.0.0.1:8000",
+            "model": "text-embedding-qwen3-embedding-1.5b",
+            "dimensions": 4096
+        },
+        "neo": {
+            "active": "openAiCompatible",
+            "host": "http://127.0.0.1:8000",
+            "model": "text-embedding-qwen3-embedding-1.5b",
+            "dimensions": 4096
+        }
     },
     "summary": {
         "active": "openAiCompatible",
@@ -211,12 +220,14 @@ The Memory Core's healthcheck additionally surfaces active provider observabilit
 ```
 
 Embedding diagnostic fields:
-- `active`: the provider key currently selected for ChromaDB embedding generation (`'gemini'` | `'openAiCompatible'` | `'ollama'`). Mismatch between operator intent (e.g. expected local Qwen3) and observed value (e.g. silent fallback to `'gemini'` because `NEO_CHROMA_EMBEDDING_PROVIDER` was unset) is the load-bearing diagnostic.
-- `host`: provider endpoint URL when applicable (`null` for cloud `gemini`).
-- `model`: resolved embedding model name. Operators verify this matches the model running on the local server.
-- `dimensions`: configured `vectorDimension`. Must match the embedding model's actual output dimension; mismatch is silent in collection writes but breaks retrieval.
+- `aligned`: whether the ChromaDB and SQLite Native Edge Graph embedding paths use the same provider key. `false` is valid only when the operator intentionally splits engines; otherwise it points to a drifted `NEO_CHROMA_EMBEDDING_PROVIDER` / `NEO_EMBEDDING_PROVIDER` setup.
+- `chroma.active`: the provider key selected for ChromaDB embedding generation (`'gemini'` | `'openAiCompatible'` | `'ollama'`). Mismatch between operator intent (e.g. expected local Qwen3) and observed value (e.g. silent fallback to `'gemini'` because `NEO_CHROMA_EMBEDDING_PROVIDER` was unset) is the load-bearing diagnostic.
+- `neo.active`: the provider key selected for SQLite Native Edge Graph embedding operations. If `NEO_EMBEDDING_PROVIDER` is unset, this defaults to `'gemini'`.
+- `chroma.host` / `neo.host`: provider endpoint URL when applicable (`null` for cloud `gemini`).
+- `chroma.model` / `neo.model`: resolved embedding model name. Operators verify this matches the model running on the local server.
+- `chroma.dimensions` / `neo.dimensions`: configured `vectorDimension`. Must match the embedding model's actual output dimension; mismatch is silent in collection writes but breaks retrieval.
 
-If `active` resolves to an unrecognized value, the block additionally surfaces an `error` field naming the misconfig directly.
+If either embedding provider key resolves to an unrecognized value, that sub-block additionally surfaces an `error` field naming the misconfig directly without making healthcheck throw.
 
 Summary diagnostic fields:
 - `active`: the provider key currently selected for session summarization (`'gemini'` | `'openAiCompatible'` | string).

--- a/test/playwright/unit/ai/mcp/server/memory-core/services/HealthService.spec.mjs
+++ b/test/playwright/unit/ai/mcp/server/memory-core/services/HealthService.spec.mjs
@@ -209,17 +209,18 @@ test.describe('HealthService #10127 — buildTopologyBlock', () => {
 });
 
 /**
- * @summary Coverage for the #10723 embedding-provider observability block in the healthcheck payload.
+ * @summary Coverage for the #10723/#10773 embedding-provider observability block in the healthcheck payload.
  *
  * Pins the pure-projection contract of `buildEmbeddingProviderBlock` — the module-scope function
- * that extracts active embedding-provider state from `aiConfig` for the healthcheck `providers.embedding`
- * field. Integration correctness (live provider request) is operator-territory L3 validation against
- * a running local-model server; this spec covers the L1-L2 substrate shape that operators rely on
- * to verify the provider configured matches the provider actually selected at boot.
+ * that extracts active Chroma-side and SQLite-side embedding-provider state from `aiConfig` for the
+ * healthcheck `providers.embedding` field. Integration correctness (live provider request) is
+ * operator-territory L3 validation against a running local-model server; this spec covers the L1-L2
+ * substrate shape that operators rely on to verify the provider configured matches the provider
+ * actually selected at boot.
  *
  * @see Neo.ai.mcp.server.memory-core.services.HealthService#buildEmbeddingProviderBlock
  */
-test.describe('HealthService #10723 — buildEmbeddingProviderBlock', () => {
+test.describe('HealthService #10723/#10773 — buildEmbeddingProviderBlock', () => {
     let buildEmbeddingProviderBlock;
 
     test.beforeAll(async () => {
@@ -227,9 +228,10 @@ test.describe('HealthService #10723 — buildEmbeddingProviderBlock', () => {
         buildEmbeddingProviderBlock = mod.buildEmbeddingProviderBlock;
     });
 
-    test('openAiCompatible provider surfaces host + embeddingModel + dimensions', () => {
+    test('same openAiCompatible providers surface chroma + neo sub-blocks and aligned=true', () => {
         const cfg = {
             chromaEmbeddingProvider: 'openAiCompatible',
+            neoEmbeddingProvider   : 'openAiCompatible',
             vectorDimension        : 4096,
             openAiCompatible       : {
                 host          : 'http://127.0.0.1:8000',
@@ -237,16 +239,54 @@ test.describe('HealthService #10723 — buildEmbeddingProviderBlock', () => {
             }
         };
         expect(buildEmbeddingProviderBlock(cfg)).toEqual({
-            active    : 'openAiCompatible',
-            host      : 'http://127.0.0.1:8000',
-            model     : 'text-embedding-qwen3-embedding-1.5b',
-            dimensions: 4096
+            aligned: true,
+            chroma : {
+                active    : 'openAiCompatible',
+                host      : 'http://127.0.0.1:8000',
+                model     : 'text-embedding-qwen3-embedding-1.5b',
+                dimensions: 4096
+            },
+            neo: {
+                active    : 'openAiCompatible',
+                host      : 'http://127.0.0.1:8000',
+                model     : 'text-embedding-qwen3-embedding-1.5b',
+                dimensions: 4096
+            }
         });
     });
 
-    test('ollama provider surfaces host + embeddingModel + dimensions', () => {
+    test('diverged providers surface mismatch at-a-glance', () => {
+        const cfg = {
+            chromaEmbeddingProvider: 'gemini',
+            neoEmbeddingProvider   : 'openAiCompatible',
+            vectorDimension        : 4096,
+            embeddingModel         : 'gemini-embedding-001',
+            openAiCompatible       : {
+                host          : 'http://127.0.0.1:8000',
+                embeddingModel: 'text-embedding-qwen3-embedding-8b'
+            }
+        };
+        expect(buildEmbeddingProviderBlock(cfg)).toEqual({
+            aligned: false,
+            chroma : {
+                active    : 'gemini',
+                host      : null,
+                model     : 'gemini-embedding-001',
+                dimensions: 4096
+            },
+            neo: {
+                active    : 'openAiCompatible',
+                host      : 'http://127.0.0.1:8000',
+                model     : 'text-embedding-qwen3-embedding-8b',
+                dimensions: 4096
+            }
+        });
+    });
+
+    test('ollama provider surfaces host + embeddingModel + dimensions for both engines', () => {
         const cfg = {
             chromaEmbeddingProvider: 'ollama',
+            neoEmbeddingProvider   : 'ollama',
             vectorDimension        : 4096,
             ollama                 : {
                 host          : 'http://127.0.0.1:11434',
@@ -254,58 +294,95 @@ test.describe('HealthService #10723 — buildEmbeddingProviderBlock', () => {
             }
         };
         expect(buildEmbeddingProviderBlock(cfg)).toEqual({
-            active    : 'ollama',
-            host      : 'http://127.0.0.1:11434',
-            model     : 'qwen3-embedding',
-            dimensions: 4096
+            aligned: true,
+            chroma : {
+                active    : 'ollama',
+                host      : 'http://127.0.0.1:11434',
+                model     : 'qwen3-embedding',
+                dimensions: 4096
+            },
+            neo: {
+                active    : 'ollama',
+                host      : 'http://127.0.0.1:11434',
+                model     : 'qwen3-embedding',
+                dimensions: 4096
+            }
         });
     });
 
-    test('gemini provider surfaces null host + embeddingModel + dimensions', () => {
+    test('unset neoEmbeddingProvider defaults SQLite-side provider to gemini', () => {
         const cfg = {
             chromaEmbeddingProvider: 'gemini',
             vectorDimension        : 3072,
             embeddingModel         : 'gemini-embedding-001'
         };
         expect(buildEmbeddingProviderBlock(cfg)).toEqual({
-            active    : 'gemini',
-            host      : null,
-            model     : 'gemini-embedding-001',
-            dimensions: 3072
+            aligned: true,
+            chroma : {
+                active    : 'gemini',
+                host      : null,
+                model     : 'gemini-embedding-001',
+                dimensions: 3072
+            },
+            neo: {
+                active    : 'gemini',
+                host      : null,
+                model     : 'gemini-embedding-001',
+                dimensions: 3072
+            }
         });
     });
 
-    test('unrecognized provider surfaces error field, does not throw', () => {
+    test('unrecognized providers surface scoped error fields, do not throw', () => {
         const cfg = {
             chromaEmbeddingProvider: 'fooProvider',
+            neoEmbeddingProvider   : 'barProvider',
             vectorDimension        : 4096
         };
         const result = buildEmbeddingProviderBlock(cfg);
-        expect(result.active).toBe('fooProvider');
-        expect(result.host).toBeNull();
-        expect(result.model).toBeNull();
-        expect(result.dimensions).toBe(4096);
-        expect(result.error).toMatch(/Unrecognized chromaEmbeddingProvider/);
+        expect(result.aligned).toBe(false);
+        expect(result.chroma.active).toBe('fooProvider');
+        expect(result.chroma.host).toBeNull();
+        expect(result.chroma.model).toBeNull();
+        expect(result.chroma.dimensions).toBe(4096);
+        expect(result.chroma.error).toMatch(/Unrecognized chromaEmbeddingProvider/);
+        expect(result.neo.active).toBe('barProvider');
+        expect(result.neo.host).toBeNull();
+        expect(result.neo.model).toBeNull();
+        expect(result.neo.dimensions).toBe(4096);
+        expect(result.neo.error).toMatch(/Unrecognized neoEmbeddingProvider/);
     });
 
-    test('openAiCompatible without nested config surfaces null host + null model + dimensions', () => {
+    test('openAiCompatible without nested config surfaces null host + null model + dimensions for both engines', () => {
         const cfg = {
             chromaEmbeddingProvider: 'openAiCompatible',
+            neoEmbeddingProvider   : 'openAiCompatible',
             vectorDimension        : 4096
             // openAiCompatible config block deliberately absent — defensive against incomplete config
         };
         expect(buildEmbeddingProviderBlock(cfg)).toEqual({
-            active    : 'openAiCompatible',
-            host      : null,
-            model     : null,
-            dimensions: 4096
+            aligned: true,
+            chroma : {
+                active    : 'openAiCompatible',
+                host      : null,
+                model     : null,
+                dimensions: 4096
+            },
+            neo: {
+                active    : 'openAiCompatible',
+                host      : null,
+                model     : null,
+                dimensions: 4096
+            }
         });
     });
 
-    test('dimensions field always reflects vectorDimension regardless of provider', () => {
+    test('dimensions fields always reflect vectorDimension regardless of provider', () => {
         for (const provider of ['gemini', 'openAiCompatible', 'ollama', 'unrecognized']) {
-            const cfg = {chromaEmbeddingProvider: provider, vectorDimension: 768};
-            expect(buildEmbeddingProviderBlock(cfg).dimensions).toBe(768);
+            const cfg = {chromaEmbeddingProvider: provider, neoEmbeddingProvider: provider, vectorDimension: 768};
+            const result = buildEmbeddingProviderBlock(cfg);
+            expect(result.chroma.dimensions).toBe(768);
+            expect(result.neo.dimensions).toBe(768);
         }
     });
 });


### PR DESCRIPTION
Authored by GPT-5.5 (Codex Desktop). Session cbd9b1c1-84ba-448e-971f-dba00660506e.

Resolves #10773
Related: #10721

Restructures the Memory Core healthcheck `providers.embedding` block around the Option B contract from #10773: `providers.embedding` now reports `aligned`, plus `chroma` and `neo` sub-blocks for the ChromaDB and SQLite Native Edge Graph embedding paths. This makes intentional divergence visible and catches silent fallback drift between `NEO_CHROMA_EMBEDDING_PROVIDER` and `NEO_EMBEDDING_PROVIDER`.

Evidence: L2 (module-scope projection tests + syntax/diff gates + committed docs contract) -> L2 required for #10773 ACs. Residual: none. Optional post-merge L3 live healthcheck smoke remains operator-side.

## Deltas from Ticket

- Chose Option B explicitly, matching the Contract Ledger.
- Updated `learn/agentos/MemoryCore.md` in addition to `learn/agentos/SharedDeployment.md`, because `SharedDeployment.md` points to `MemoryCore.md` as the full healthcheck payload contract.
- Kept `providers.summary` unchanged and left #10770 free to add `providers.auth` as a sibling block.

## Test Evidence

- `node --check ai/mcp/server/memory-core/services/HealthService.mjs` passed.
- `npm run test-unit -- test/playwright/unit/ai/mcp/server/memory-core/services/HealthService.spec.mjs` passed after rebase: 18 passed.
- `git diff --check origin/dev...HEAD` passed.
- Pre-push freshness passed: `merge-base HEAD origin/dev == origin/dev`; outgoing log contained only `9d66238f1 feat(memory-core): surface sqlite embedding provider in healthcheck (#10773)`.

## Slot Rationale

- Added `learn/agentos/MemoryCore.md` section `providers.embedding` - disposition `keep`; 3-axis: trigger-frequency medium, failure-severity high, enforceability high. Rationale: this is the canonical healthcheck response contract; without updating it, #10773 would create stale operator docs.
- Modified `learn/agentos/SharedDeployment.md` healthcheck subsection - disposition `keep`; 3-axis: trigger-frequency medium, failure-severity high, enforceability medium. Rationale: shared-deployment operators use this path to verify provider routing, and the old flat sample would cause configuration drift.

## Post-Merge Validation

- [ ] Restart Memory Core MCP and confirm live `healthcheck.providers.embedding` includes `aligned`, `chroma`, and `neo`.
- [ ] If #10770 merges after this PR, confirm `providers.auth` remains a sibling under `providers`, not nested under `providers.embedding`.

## Commit

- `9d66238f1` - `feat(memory-core): surface sqlite embedding provider in healthcheck (#10773)`