### PR TITLE
feat(ai): consolidate embedding provider config (#10804)

### DIFF
--- a/ai/daemons/services/GoldenPathSynthesizer.mjs
+++ b/ai/daemons/services/GoldenPathSynthesizer.mjs
@@ -78,7 +78,7 @@ class GoldenPathSynthesizer extends Base {
             }
 
             logger.debug('[GoldenPathSynthesizer] Computing Frontier Baseline Vector...');
-            frontierEmbedding = await TextEmbeddingService.embedText(frontierText, aiConfig.neoEmbeddingProvider);
+            frontierEmbedding = await TextEmbeddingService.embedText(frontierText, aiConfig.embeddingProvider);
         } catch (e) {
             logger.warn('[GoldenPathSynthesizer] Failed to generate Frontier Baseline Vector. Aborting Hybrid route.', e);
             return;

--- a/ai/mcp/server/knowledge-base/services/QueryService.mjs
+++ b/ai/mcp/server/knowledge-base/services/QueryService.mjs
@@ -110,7 +110,7 @@ class QueryService extends Base {
         }
 
         const collection           = await ChromaManager.getKnowledgeBaseCollection();
-        const queryEmbeddingValues = await TextEmbeddingService.embedText(query, mcConfig.chromaEmbeddingProvider);
+        const queryEmbeddingValues = await TextEmbeddingService.embedText(query, mcConfig.embeddingProvider);
         const queryLower     = query.toLowerCase();
 
         const whereClause = (type && type !== 'all') ? { type } : {};

--- a/ai/mcp/server/knowledge-base/services/VectorService.mjs
+++ b/ai/mcp/server/knowledge-base/services/VectorService.mjs
@@ -220,7 +220,7 @@ class VectorService extends Base {
             return errorPayload;
         }
 
-        logger.log(`Using TextEmbeddingService with provider: ${mcConfig.chromaEmbeddingProvider}.`);
+        logger.log(`Using TextEmbeddingService with provider: ${mcConfig.embeddingProvider}.`);
 
         logger.log('Embedding chunks...');
         const {batchSize, batchDelay, maxRetries} = aiConfig;
@@ -238,7 +238,7 @@ class VectorService extends Base {
 
             while (retries < maxRetries && !success) {
                 try {
-                    const embeddings = await TextEmbeddingService.embedTexts(textsToEmbed, mcConfig.chromaEmbeddingProvider);
+                    const embeddings = await TextEmbeddingService.embedTexts(textsToEmbed, mcConfig.embeddingProvider);
 
                     const metadatas = batch.map(chunk => {
                         const metadata = {};

--- a/ai/mcp/server/memory-core/config.template.mjs
+++ b/ai/mcp/server/memory-core/config.template.mjs
@@ -2,6 +2,9 @@ import fs              from 'fs/promises';
 import path            from 'path';
 import Base            from '../../../../src/core/Base.mjs';
 import {fileURLToPath} from 'url';
+import {normalizeEmbeddingProviderConfig, resolveEmbeddingProvider} from './helpers/EmbeddingProviderConfig.mjs';
+
+export {normalizeEmbeddingProviderConfig, resolveEmbeddingProvider};
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname  = path.dirname(__filename);
@@ -98,17 +101,14 @@ const defaultConfig = {
      */
     modelProvider: process.env.NEO_MODEL_PROVIDER || 'gemini',
     /**
-     * Explicit override provider for the SQLite Native Database Engine.
+     * Canonical embedding provider for Memory Core and Knowledge Base embedding callsites.
      * Supported values: 'gemini', 'ollama', 'openAiCompatible'
+     *
+     * `NEO_CHROMA_EMBEDDING_PROVIDER` remains readable for one deprecation window but emits
+     * a warning and feeds this unified selector.
      * @type {String}
      */
-    neoEmbeddingProvider: process.env.NEO_EMBEDDING_PROVIDER || 'gemini',
-    /**
-     * Explicit override provider for the ChromaDB Engine.
-     * Supported values: 'gemini', 'ollama', 'openAiCompatible'
-     * @type {String}
-     */
-    chromaEmbeddingProvider: process.env.NEO_CHROMA_EMBEDDING_PROVIDER || 'gemini',
+    embeddingProvider: resolveEmbeddingProvider(),
     /**
      * Settings for the Ollama integration
      */
@@ -406,6 +406,7 @@ class Config extends Base {
 
             // Deep merge custom config into the data object
             Neo.merge(this.data, customConfig);
+            normalizeEmbeddingProviderConfig(this.data, process.env, console.warn, customConfig);
 
             console.error(`[Config] Loaded custom configuration from ${absolutePath}`);
 

--- a/ai/mcp/server/memory-core/helpers/EmbeddingProviderConfig.mjs
+++ b/ai/mcp/server/memory-core/helpers/EmbeddingProviderConfig.mjs
@@ -1,0 +1,46 @@
+/**
+ * @summary Resolves the canonical embedding provider for all embedding callsites.
+ *
+ * Resolves the canonical embedding provider from the unified selector plus the legacy
+ * Chroma-side env/config selector kept during the #10804 deprecation window.
+ * @param {Object} options
+ * @param {Object} [options.config={}] Config object, including custom config overrides after load().
+ * @param {Object} [options.env=process.env] Environment map.
+ * @param {Function} [options.warn=console.warn] Warning sink for deprecation/conflict notices.
+ * @returns {String} The provider key consumed by all embedding callsites.
+ */
+export function resolveEmbeddingProvider({config = {}, env = process.env, warn = console.warn} = {}) {
+    const hasValue     = value => value !== undefined && value !== null && value !== '';
+    const unified      = hasValue(config.embeddingProvider) ? config.embeddingProvider : env.NEO_EMBEDDING_PROVIDER;
+    const legacyChroma = hasValue(config.chromaEmbeddingProvider) ? config.chromaEmbeddingProvider : env.NEO_CHROMA_EMBEDDING_PROVIDER;
+    const legacyNeo    = hasValue(config.neoEmbeddingProvider) ? config.neoEmbeddingProvider : null;
+
+    if (hasValue(legacyChroma)) {
+        if (hasValue(unified) && legacyChroma !== unified) {
+            warn(`[Config] NEO_CHROMA_EMBEDDING_PROVIDER/chromaEmbeddingProvider is deprecated and conflicts with embeddingProvider; using ${unified}.`);
+        } else {
+            warn('[Config] NEO_CHROMA_EMBEDDING_PROVIDER/chromaEmbeddingProvider is deprecated; use NEO_EMBEDDING_PROVIDER/embeddingProvider.');
+        }
+    }
+
+    if (hasValue(legacyNeo) && hasValue(unified) && legacyNeo !== unified) {
+        warn(`[Config] neoEmbeddingProvider is deprecated and conflicts with embeddingProvider; using ${unified}.`);
+    }
+
+    return unified || legacyNeo || legacyChroma || 'gemini';
+}
+
+/**
+ * @summary Normalizes the mutable Memory Core config to the canonical embedding provider key.
+ *
+ * Normalizes a mutable config object after custom overrides are merged.
+ * @param {Object} config Config object to normalize in place.
+ * @param {Object} [env=process.env] Environment map.
+ * @param {Function} [warn=console.warn] Warning sink.
+ * @param {Object} [sourceConfig=config] Raw override object used for provider resolution.
+ * @returns {Object} The same config object for chaining.
+ */
+export function normalizeEmbeddingProviderConfig(config, env = process.env, warn = console.warn, sourceConfig = config) {
+    config.embeddingProvider = resolveEmbeddingProvider({config: sourceConfig, env, warn});
+    return config;
+}

--- a/ai/mcp/server/memory-core/managers/ChromaManager.mjs
+++ b/ai/mcp/server/memory-core/managers/ChromaManager.mjs
@@ -200,7 +200,7 @@ class ChromaManager extends AbstractVectorManager {
             generate   : async (texts) => {
                 // Pass arrays of texts sequentially or via promise.all to TextEmbeddingService
                 const {default: TextEmbeddingService} = await import('../services/TextEmbeddingService.mjs');
-                const provider                        = aiConfig.chromaEmbeddingProvider;
+                const provider                        = aiConfig.embeddingProvider;
                 const vectors                         = await Promise.all(texts.map(text => TextEmbeddingService.embedText(text, provider)));
                 return vectors;
             },

--- a/ai/mcp/server/memory-core/services/HealthService.mjs
+++ b/ai/mcp/server/memory-core/services/HealthService.mjs
@@ -101,43 +101,33 @@ export function buildTopologyBlock(cfg) {
 
 /**
  * @summary Projects the active embedding-provider configuration into the healthcheck `providers.embedding`
- *          observability block (#10723, #10773).
+ *          observability block (#10723, #10773, #10804).
  *
- * Pure function: takes an `aiConfig`-shaped input and returns both active embedding providers with
+ * Pure function: takes an `aiConfig`-shaped input and returns the active embedding provider with
  * their host, model, and configured vector dimension. Mirrors the {@link buildTopologyBlock} precedent
  * for module-scope pure projections.
  *
  * **Why this block exists:** Operators deploying the shared MC/KB topology against a local-model stack
  * (e.g., MLX-served Qwen3 embedding model) need an observable surface confirming WHICH Chroma-side
  * and SQLite-side embedding providers are currently active and WHICH model + endpoint is in use.
- * Without this, a misconfigured `NEO_CHROMA_EMBEDDING_PROVIDER` or `NEO_EMBEDDING_PROVIDER` env var
+ * Without this, a misconfigured `NEO_EMBEDDING_PROVIDER` env var
  * (silently defaulting to Gemini cloud while the operator believes a local provider is wired) is
  * undetectable until cross-tenant retrieval drift emerges.
  *
- * **What this block reports:**
- * - `aligned`: whether ChromaDB and SQLite Native Edge Graph embedding provider keys match
- * - `chroma`: provider projection for ChromaDB embedding generation
- * - `neo`: provider projection for SQLite Native Edge Graph embedding generation
+ * **What this block reports:** single-provider projection for every embedding callsite after #10804
+ * consolidated ChromaDB and SQLite Native Edge Graph provider selection into `embeddingProvider`.
  *
- * **Defensive fallback:** if either provider key isn't recognized, its sub-block surfaces
+ * **Defensive fallback:** if the provider key isn't recognized, the block surfaces
  * `{active: <unknown-key>, host: null, model: null, dimensions: <vectorDimension>, error: <msg>}`
  * so operators see the misconfig directly. Aligns with "surface, don't obscure" (PR #10227).
  *
- * @param {Object} cfg aiConfig-shaped input. Reads `cfg.chromaEmbeddingProvider`, `cfg.neoEmbeddingProvider`,
- *     `cfg.openAiCompatible.{host, embeddingModel}`, `cfg.ollama.{host, embeddingModel}`,
- *     `cfg.embeddingModel` (Gemini path), `cfg.vectorDimension`.
- * @returns {{aligned: Boolean, chroma: Object, neo: Object}}
+ * @param {Object} cfg aiConfig-shaped input. Reads `cfg.embeddingProvider`, `cfg.openAiCompatible.{host, embeddingModel}`,
+ *     `cfg.ollama.{host, embeddingModel}`, `cfg.embeddingModel` (Gemini path), `cfg.vectorDimension`.
+ * @returns {{active: String, host: String|null, model: String|null, dimensions: Number, error?: String}}
  * @see learn/agentos/SharedDeployment.md
  */
 export function buildEmbeddingProviderBlock(cfg) {
-    const chromaActive = cfg.chromaEmbeddingProvider;
-    const neoActive    = cfg.neoEmbeddingProvider || 'gemini';
-
-    return {
-        aligned: chromaActive === neoActive,
-        chroma : buildSingleEmbeddingProviderBlock(cfg, chromaActive, 'chromaEmbeddingProvider'),
-        neo    : buildSingleEmbeddingProviderBlock(cfg, neoActive, 'neoEmbeddingProvider')
-    }
+    return buildSingleEmbeddingProviderBlock(cfg, cfg.embeddingProvider || 'gemini', 'embeddingProvider');
 }
 
 /**
@@ -639,7 +629,7 @@ class HealthService extends Base {
         const architecture = aiConfig.architecture || 'hybrid';
 
         if (architecture === 'chroma' || architecture === 'hybrid') {
-            providers.push(aiConfig.chromaEmbeddingProvider);
+            providers.push(aiConfig.embeddingProvider);
         }
 
         const needsGemini = providers.some(p => p === 'gemini');

--- a/ai/mcp/server/memory-core/services/TextEmbeddingService.mjs
+++ b/ai/mcp/server/memory-core/services/TextEmbeddingService.mjs
@@ -4,6 +4,17 @@ import Base                 from '../../../../../src/core/Base.mjs';
 import logger               from '../logger.mjs';
 
 /**
+ * Determines whether TextEmbeddingService needs a Gemini embedding client for the active provider.
+ * Kept pure so #10804 config-consolidation tests can pin the single-provider gate without
+ * constructing the singleton or requiring a live `GEMINI_API_KEY`.
+ * @param {Object} cfg aiConfig-shaped input.
+ * @returns {Boolean}
+ */
+export function shouldInitializeGeminiEmbeddingClient(cfg = aiConfig) {
+    return cfg.embeddingProvider === 'gemini';
+}
+
+/**
  * @summary Service for creating embedding vectors for text.
  *
  * This wrapper service interfaces with the Google Generative AI API (Gemini) to generate vector embeddings
@@ -40,7 +51,7 @@ class TextEmbeddingService extends Base {
     construct(config) {
         super.construct(config);
 
-        if (aiConfig.chromaEmbeddingProvider === 'gemini' || aiConfig.neoEmbeddingProvider === 'gemini') {
+        if (shouldInitializeGeminiEmbeddingClient()) {
             const apiKey = process.env.GEMINI_API_KEY;
             if (!apiKey) {
                 logger.warn('⚠️  [TextEmbeddingService] GEMINI_API_KEY not set. Semantic search features with Gemini will be unavailable.');

--- a/learn/agentos/MemoryCore.md
+++ b/learn/agentos/MemoryCore.md
@@ -111,19 +111,10 @@ Operators running `healthcheck` (via MCP, or via the SSE `/healthcheck` endpoint
     "migration": { "memory": 0, "session": 0, "total": 0, "available": true },
     "providers": {
         "embedding": {
-            "aligned": true,
-            "chroma": {
-                "active": "openAiCompatible",
-                "host": "http://127.0.0.1:8000",
-                "model": "text-embedding-qwen3-embedding-1.5b",
-                "dimensions": 4096
-            },
-            "neo": {
-                "active": "openAiCompatible",
-                "host": "http://127.0.0.1:8000",
-                "model": "text-embedding-qwen3-embedding-1.5b",
-                "dimensions": 4096
-            }
+            "active": "openAiCompatible",
+            "host": "http://127.0.0.1:8000",
+            "model": "text-embedding-qwen3-embedding-1.5b",
+            "dimensions": 4096
         },
         "summary": {
             "active": "openAiCompatible",
@@ -173,19 +164,19 @@ Introduced in #10017 (see `learn/agentos/tooling/MultiTenantMigrationGuide.md`).
 
 A zero `total` is the signal operators watch for to flip the `memorySharing` default from `'legacy'` to `'private'`.
 
-### `providers.embedding` — Active Embedding Model Routes
+### `providers.embedding` — Active Embedding Model Route
 
-Introduced for Chroma-side local embedding-provider validation (#10723) and expanded for SQLite-side embedding observability (#10773). The block surfaces both embedding paths so operators can verify whether ChromaDB retrieval and SQLite Native Edge Graph operations share the same provider intentionally:
+Introduced for Chroma-side local embedding-provider validation (#10723), expanded for SQLite-side embedding observability (#10773), then consolidated to one provider selector by #10804. The block surfaces the single embedding route used by ChromaDB retrieval and SQLite Native Edge Graph operations:
 
 | Field | Type | Meaning |
 |---|---|---|
-| `aligned` | `boolean` | `true` when `chroma.active` and `neo.active` match. `false` is valid for intentional split-engine deployments, but otherwise indicates config drift between `NEO_CHROMA_EMBEDDING_PROVIDER` and `NEO_EMBEDDING_PROVIDER`. |
-| `chroma.active` | `'gemini' \| 'openAiCompatible' \| 'ollama' \| string` | Provider selected for ChromaDB embedding generation. |
-| `neo.active` | `'gemini' \| 'openAiCompatible' \| 'ollama' \| string` | Provider selected for SQLite Native Edge Graph embedding operations. Defaults to `'gemini'` when `NEO_EMBEDDING_PROVIDER` is unset. |
-| `chroma.host` / `neo.host` | `string \| null` | Embedding provider host for local providers; `null` for Gemini. |
-| `chroma.model` / `neo.model` | `string \| null` | Configured embedding model name. |
-| `chroma.dimensions` / `neo.dimensions` | `number` | Configured `vectorDimension`; must match the embedding model's actual output dimension. |
-| `chroma.error` / `neo.error` | `string` (optional) | Present only when that provider key is unrecognized; healthcheck surfaces the misconfig instead of throwing. |
+| `active` | `'gemini' \| 'openAiCompatible' \| 'ollama' \| string` | Provider selected for every embedding consumer. Controlled by `embeddingProvider` / `NEO_EMBEDDING_PROVIDER`. |
+| `host` | `string \| null` | Embedding provider host for local providers; `null` for Gemini. |
+| `model` | `string \| null` | Configured embedding model name. |
+| `dimensions` | `number` | Configured `vectorDimension`; must match the embedding model's actual output dimension. |
+| `error` | `string` (optional) | Present only when the provider key is unrecognized; healthcheck surfaces the misconfig instead of throwing. |
+
+`NEO_CHROMA_EMBEDDING_PROVIDER` remains readable during the #10804 deprecation window and feeds the unified selector with a warning. Operators should use `NEO_EMBEDDING_PROVIDER` for new deployments.
 
 ### `providers.summary` — Active Summary Model Route
 

--- a/learn/agentos/SharedDeployment.md
+++ b/learn/agentos/SharedDeployment.md
@@ -49,16 +49,16 @@ In unified mode, the Memory Core's `ChromaClient` targets the Knowledge Base's C
 
 ### Embedding provider
 
-ChromaDB's embedding generation is provider-pluggable. The active provider is controlled by `NEO_CHROMA_EMBEDDING_PROVIDER`; supported values are `'gemini'` (default, cloud), `'ollama'` (local), and `'openAiCompatible'` (local OpenAI-format servers including MLX-served Qwen3 models, llama.cpp, LM Studio, etc.).
+Embedding generation is provider-pluggable. The active provider is controlled by `NEO_EMBEDDING_PROVIDER`; supported values are `'gemini'` (default, cloud), `'ollama'` (local), and `'openAiCompatible'` (local OpenAI-format servers including MLX-served Qwen3 models, llama.cpp, LM Studio, etc.). The same selector drives ChromaDB retrieval and SQLite Native Edge Graph operations so both engines generate comparable vectors.
 
 ```bash
 # Default: Google Gemini cloud embedding (gemini-embedding-001):
-unset NEO_CHROMA_EMBEDDING_PROVIDER
+unset NEO_EMBEDDING_PROVIDER
 # or
-export NEO_CHROMA_EMBEDDING_PROVIDER=gemini
+export NEO_EMBEDDING_PROVIDER=gemini
 
 # Local OpenAI-compatible embedding (e.g. Qwen3 family via MLX):
-export NEO_CHROMA_EMBEDDING_PROVIDER=openAiCompatible
+export NEO_EMBEDDING_PROVIDER=openAiCompatible
 export NEO_OPENAI_COMPATIBLE_HOST=http://127.0.0.1:8000              # MLX server endpoint
 export NEO_OPENAI_COMPATIBLE_EMBEDDING_MODEL=text-embedding-qwen3-embedding-1.5b  # Qwen3-1.5B variant
 # OR for the 8B variant:
@@ -66,7 +66,7 @@ export NEO_OPENAI_COMPATIBLE_EMBEDDING_MODEL=text-embedding-qwen3-embedding-1.5b
 export NEO_OPENAI_COMPATIBLE_API_KEY=                                # leave empty for local servers
 
 # Local Ollama embedding:
-export NEO_CHROMA_EMBEDDING_PROVIDER=ollama
+export NEO_EMBEDDING_PROVIDER=ollama
 export NEO_OLLAMA_HOST=http://127.0.0.1:11434
 export NEO_OLLAMA_EMBEDDING_MODEL=qwen3-embedding
 ```
@@ -82,7 +82,7 @@ export NEO_VECTOR_DIMENSION=3072
 export NEO_VECTOR_DIMENSION=768
 ```
 
-A sibling override `NEO_EMBEDDING_PROVIDER` controls the SQLite-side embedding path (`neoEmbeddingProvider`) for native-edge-graph operations; in most shared deployments it should match `NEO_CHROMA_EMBEDDING_PROVIDER` for consistency, but it can diverge when the SQLite and ChromaDB engines use different providers intentionally.
+`NEO_CHROMA_EMBEDDING_PROVIDER` remains readable during the #10804 deprecation window and feeds the unified selector with a warning. New deployments should use `NEO_EMBEDDING_PROVIDER` only.
 
 **Substrate observation (#10723):** the OpenAI-compatible embedding path is implemented inside `ai/mcp/server/memory-core/services/TextEmbeddingService.mjs#embedText[s]` (POST to `${host}/v1/embeddings` with `{model, input}` payload, parsing `result.data[*].embedding`). It is NOT routed through the `Neo.ai.provider.OpenAiCompatible` class — that class currently exposes `generate` / `stream` (chat completions) but no `embed` method. This means the embedding-provider abstraction is functional but not yet symmetric with the chat-provider abstraction. Future hardening should consolidate the embedding path into the provider class hierarchy; out of scope for #10723 itself.
 
@@ -190,19 +190,10 @@ The Memory Core's healthcheck additionally surfaces active provider observabilit
 ```json
 "providers": {
     "embedding": {
-        "aligned": true,
-        "chroma": {
-            "active": "openAiCompatible",
-            "host": "http://127.0.0.1:8000",
-            "model": "text-embedding-qwen3-embedding-1.5b",
-            "dimensions": 4096
-        },
-        "neo": {
-            "active": "openAiCompatible",
-            "host": "http://127.0.0.1:8000",
-            "model": "text-embedding-qwen3-embedding-1.5b",
-            "dimensions": 4096
-        }
+        "active": "openAiCompatible",
+        "host": "http://127.0.0.1:8000",
+        "model": "text-embedding-qwen3-embedding-1.5b",
+        "dimensions": 4096
     },
     "summary": {
         "active": "openAiCompatible",
@@ -233,14 +224,12 @@ The Memory Core's healthcheck additionally surfaces active provider observabilit
 ```
 
 Embedding diagnostic fields:
-- `aligned`: whether the ChromaDB and SQLite Native Edge Graph embedding paths use the same provider key. `false` is valid only when the operator intentionally splits engines; otherwise it points to a drifted `NEO_CHROMA_EMBEDDING_PROVIDER` / `NEO_EMBEDDING_PROVIDER` setup.
-- `chroma.active`: the provider key selected for ChromaDB embedding generation (`'gemini'` | `'openAiCompatible'` | `'ollama'`). Mismatch between operator intent (e.g. expected local Qwen3) and observed value (e.g. silent fallback to `'gemini'` because `NEO_CHROMA_EMBEDDING_PROVIDER` was unset) is the load-bearing diagnostic.
-- `neo.active`: the provider key selected for SQLite Native Edge Graph embedding operations. If `NEO_EMBEDDING_PROVIDER` is unset, this defaults to `'gemini'`.
-- `chroma.host` / `neo.host`: provider endpoint URL when applicable (`null` for cloud `gemini`).
-- `chroma.model` / `neo.model`: resolved embedding model name. Operators verify this matches the model running on the local server.
-- `chroma.dimensions` / `neo.dimensions`: configured `vectorDimension`. Must match the embedding model's actual output dimension; mismatch is silent in collection writes but breaks retrieval.
+- `active`: the provider key selected for embedding generation (`'gemini'` | `'openAiCompatible'` | `'ollama'`). Mismatch between operator intent (e.g. expected local Qwen3) and observed value (e.g. silent fallback to `'gemini'` because `NEO_EMBEDDING_PROVIDER` was unset) is the load-bearing diagnostic.
+- `host`: provider endpoint URL when applicable (`null` for cloud `gemini`).
+- `model`: resolved embedding model name. Operators verify this matches the model running on the local server.
+- `dimensions`: configured `vectorDimension`. Must match the embedding model's actual output dimension; mismatch is silent in collection writes but breaks retrieval.
 
-If either embedding provider key resolves to an unrecognized value, that sub-block additionally surfaces an `error` field naming the misconfig directly without making healthcheck throw.
+If the embedding provider key resolves to an unrecognized value, the block additionally surfaces an `error` field naming the misconfig directly without making healthcheck throw.
 
 Summary diagnostic fields:
 - `active`: the provider key currently selected for session summarization (`'gemini'` | `'openAiCompatible'` | string).

--- a/test/playwright/unit/ai/mcp/server/memory-core/config.spec.mjs
+++ b/test/playwright/unit/ai/mcp/server/memory-core/config.spec.mjs
@@ -1,0 +1,101 @@
+import {setup} from '../../../../../setup.mjs';
+
+const appName = 'MemoryCoreConfigProviderTest';
+
+setup({
+    neoConfig: {
+        unitTestMode: true
+    },
+    appConfig: {
+        name             : appName,
+        isMounted        : () => true,
+        vnodeInitialising: false
+    }
+});
+
+import {test, expect} from '@playwright/test';
+import Neo            from '../../../../../../../src/Neo.mjs';
+import * as core      from '../../../../../../../src/core/_export.mjs';
+
+/**
+ * @summary Coverage for #10804 embedding-provider config consolidation.
+ *
+ * The runtime config object is a Neo singleton, so these tests pin the standalone pure resolver
+ * rather than importing the singleton. This covers the legacy
+ * `NEO_CHROMA_EMBEDDING_PROVIDER` fallback/deprecation contract while keeping embedding
+ * callsites on the unified `embeddingProvider` selector.
+ *
+ * @see Neo.ai.mcp.server.memory-core.Config#resolveEmbeddingProvider
+ */
+test.describe('Memory Core config #10804 — resolveEmbeddingProvider', () => {
+    let resolveEmbeddingProvider, normalizeEmbeddingProviderConfig;
+
+    test.beforeAll(async () => {
+        const mod = await import('../../../../../../../ai/mcp/server/memory-core/helpers/EmbeddingProviderConfig.mjs');
+        resolveEmbeddingProvider = mod.resolveEmbeddingProvider;
+        normalizeEmbeddingProviderConfig = mod.normalizeEmbeddingProviderConfig;
+    });
+
+    test('defaults to gemini when no provider selector is configured', () => {
+        const warnings = [];
+
+        expect(resolveEmbeddingProvider({
+            env : {},
+            warn: message => warnings.push(message)
+        })).toBe('gemini');
+        expect(warnings).toEqual([]);
+    });
+
+    test('unified env selector wins over conflicting legacy Chroma selector', () => {
+        const warnings = [];
+
+        expect(resolveEmbeddingProvider({
+            env : {
+                NEO_EMBEDDING_PROVIDER       : 'openAiCompatible',
+                NEO_CHROMA_EMBEDDING_PROVIDER: 'gemini'
+            },
+            warn: message => warnings.push(message)
+        })).toBe('openAiCompatible');
+        expect(warnings.join('\n')).toMatch(/deprecated and conflicts/);
+    });
+
+    test('legacy Chroma env selector still feeds the unified provider with deprecation warning', () => {
+        const warnings = [];
+
+        expect(resolveEmbeddingProvider({
+            env : {
+                NEO_CHROMA_EMBEDDING_PROVIDER: 'ollama'
+            },
+            warn: message => warnings.push(message)
+        })).toBe('ollama');
+        expect(warnings.join('\n')).toMatch(/deprecated/);
+    });
+
+    test('custom config normalization preserves explicit embeddingProvider over legacy config fields', () => {
+        const config = {
+            embeddingProvider      : 'openAiCompatible',
+            chromaEmbeddingProvider: 'ollama',
+            neoEmbeddingProvider   : 'gemini'
+        };
+        const warnings = [];
+
+        expect(normalizeEmbeddingProviderConfig(config, {}, message => warnings.push(message))).toBe(config);
+        expect(config.embeddingProvider).toBe('openAiCompatible');
+        expect(warnings.join('\n')).toMatch(/chromaEmbeddingProvider is deprecated and conflicts/);
+        expect(warnings.join('\n')).toMatch(/neoEmbeddingProvider is deprecated and conflicts/);
+    });
+
+    test('custom legacy Chroma config overrides the default when unified selector is absent', () => {
+        const defaults = {
+            embeddingProvider: 'gemini'
+        };
+        const customConfig = {
+            chromaEmbeddingProvider: 'openAiCompatible'
+        };
+        const warnings = [];
+
+        expect(normalizeEmbeddingProviderConfig(defaults, {}, message => warnings.push(message), customConfig)).toBe(defaults);
+        expect(defaults.embeddingProvider).toBe('openAiCompatible');
+        expect(warnings.join('\n')).toMatch(/deprecated/);
+    });
+});

--- a/test/playwright/unit/ai/mcp/server/memory-core/services/HealthService.spec.mjs
+++ b/test/playwright/unit/ai/mcp/server/memory-core/services/HealthService.spec.mjs
@@ -209,10 +209,10 @@ test.describe('HealthService #10127 — buildTopologyBlock', () => {
 });
 
 /**
- * @summary Coverage for the #10723/#10773 embedding-provider observability block in the healthcheck payload.
+ * @summary Coverage for the #10723/#10773/#10804 embedding-provider observability block in the healthcheck payload.
  *
  * Pins the pure-projection contract of `buildEmbeddingProviderBlock` — the module-scope function
- * that extracts active Chroma-side and SQLite-side embedding-provider state from `aiConfig` for the
+ * that extracts active embedding-provider state from `aiConfig` for the
  * healthcheck `providers.embedding` field. Integration correctness (live provider request) is
  * operator-territory L3 validation against a running local-model server; this spec covers the L1-L2
  * substrate shape that operators rely on to verify the provider configured matches the provider
@@ -220,7 +220,7 @@ test.describe('HealthService #10127 — buildTopologyBlock', () => {
  *
  * @see Neo.ai.mcp.server.memory-core.services.HealthService#buildEmbeddingProviderBlock
  */
-test.describe('HealthService #10723/#10773 — buildEmbeddingProviderBlock', () => {
+test.describe('HealthService #10723/#10773/#10804 — buildEmbeddingProviderBlock', () => {
     let buildEmbeddingProviderBlock;
 
     test.beforeAll(async () => {
@@ -228,161 +228,99 @@ test.describe('HealthService #10723/#10773 — buildEmbeddingProviderBlock', () 
         buildEmbeddingProviderBlock = mod.buildEmbeddingProviderBlock;
     });
 
-    test('same openAiCompatible providers surface chroma + neo sub-blocks and aligned=true', () => {
+    test('openAiCompatible provider surfaces single provider block', () => {
         const cfg = {
-            chromaEmbeddingProvider: 'openAiCompatible',
-            neoEmbeddingProvider   : 'openAiCompatible',
-            vectorDimension        : 4096,
-            openAiCompatible       : {
+            embeddingProvider: 'openAiCompatible',
+            vectorDimension  : 4096,
+            openAiCompatible : {
                 host          : 'http://127.0.0.1:8000',
                 embeddingModel: 'text-embedding-qwen3-embedding-1.5b'
             }
         };
         expect(buildEmbeddingProviderBlock(cfg)).toEqual({
-            aligned: true,
-            chroma : {
-                active    : 'openAiCompatible',
-                host      : 'http://127.0.0.1:8000',
-                model     : 'text-embedding-qwen3-embedding-1.5b',
-                dimensions: 4096
-            },
-            neo: {
-                active    : 'openAiCompatible',
-                host      : 'http://127.0.0.1:8000',
-                model     : 'text-embedding-qwen3-embedding-1.5b',
-                dimensions: 4096
-            }
+            active    : 'openAiCompatible',
+            host      : 'http://127.0.0.1:8000',
+            model     : 'text-embedding-qwen3-embedding-1.5b',
+            dimensions: 4096
         });
     });
 
-    test('diverged providers surface mismatch at-a-glance', () => {
+    test('gemini provider surfaces cloud model + dimensions', () => {
         const cfg = {
-            chromaEmbeddingProvider: 'gemini',
-            neoEmbeddingProvider   : 'openAiCompatible',
-            vectorDimension        : 4096,
-            embeddingModel         : 'gemini-embedding-001',
-            openAiCompatible       : {
-                host          : 'http://127.0.0.1:8000',
-                embeddingModel: 'text-embedding-qwen3-embedding-8b'
-            }
+            embeddingProvider: 'gemini',
+            vectorDimension  : 3072,
+            embeddingModel   : 'gemini-embedding-001'
         };
         expect(buildEmbeddingProviderBlock(cfg)).toEqual({
-            aligned: false,
-            chroma : {
-                active    : 'gemini',
-                host      : null,
-                model     : 'gemini-embedding-001',
-                dimensions: 4096
-            },
-            neo: {
-                active    : 'openAiCompatible',
-                host      : 'http://127.0.0.1:8000',
-                model     : 'text-embedding-qwen3-embedding-8b',
-                dimensions: 4096
-            }
+            active    : 'gemini',
+            host      : null,
+            model     : 'gemini-embedding-001',
+            dimensions: 3072
         });
     });
 
-    test('ollama provider surfaces host + embeddingModel + dimensions for both engines', () => {
+    test('ollama provider surfaces host + embeddingModel + dimensions', () => {
         const cfg = {
-            chromaEmbeddingProvider: 'ollama',
-            neoEmbeddingProvider   : 'ollama',
-            vectorDimension        : 4096,
-            ollama                 : {
+            embeddingProvider: 'ollama',
+            vectorDimension  : 4096,
+            ollama           : {
                 host          : 'http://127.0.0.1:11434',
                 embeddingModel: 'qwen3-embedding'
             }
         };
         expect(buildEmbeddingProviderBlock(cfg)).toEqual({
-            aligned: true,
-            chroma : {
-                active    : 'ollama',
-                host      : 'http://127.0.0.1:11434',
-                model     : 'qwen3-embedding',
-                dimensions: 4096
-            },
-            neo: {
-                active    : 'ollama',
-                host      : 'http://127.0.0.1:11434',
-                model     : 'qwen3-embedding',
-                dimensions: 4096
-            }
+            active    : 'ollama',
+            host      : 'http://127.0.0.1:11434',
+            model     : 'qwen3-embedding',
+            dimensions: 4096
         });
     });
 
-    test('unset neoEmbeddingProvider defaults SQLite-side provider to gemini', () => {
+    test('unset embeddingProvider defaults provider to gemini', () => {
         const cfg = {
-            chromaEmbeddingProvider: 'gemini',
-            vectorDimension        : 3072,
-            embeddingModel         : 'gemini-embedding-001'
+            vectorDimension: 3072,
+            embeddingModel : 'gemini-embedding-001'
         };
         expect(buildEmbeddingProviderBlock(cfg)).toEqual({
-            aligned: true,
-            chroma : {
-                active    : 'gemini',
-                host      : null,
-                model     : 'gemini-embedding-001',
-                dimensions: 3072
-            },
-            neo: {
-                active    : 'gemini',
-                host      : null,
-                model     : 'gemini-embedding-001',
-                dimensions: 3072
-            }
+            active    : 'gemini',
+            host      : null,
+            model     : 'gemini-embedding-001',
+            dimensions: 3072
         });
     });
 
-    test('unrecognized providers surface scoped error fields, do not throw', () => {
+    test('unrecognized provider surfaces scoped error field, does not throw', () => {
         const cfg = {
-            chromaEmbeddingProvider: 'fooProvider',
-            neoEmbeddingProvider   : 'barProvider',
-            vectorDimension        : 4096
+            embeddingProvider: 'fooProvider',
+            vectorDimension  : 4096
         };
         const result = buildEmbeddingProviderBlock(cfg);
-        expect(result.aligned).toBe(false);
-        expect(result.chroma.active).toBe('fooProvider');
-        expect(result.chroma.host).toBeNull();
-        expect(result.chroma.model).toBeNull();
-        expect(result.chroma.dimensions).toBe(4096);
-        expect(result.chroma.error).toMatch(/Unrecognized chromaEmbeddingProvider/);
-        expect(result.neo.active).toBe('barProvider');
-        expect(result.neo.host).toBeNull();
-        expect(result.neo.model).toBeNull();
-        expect(result.neo.dimensions).toBe(4096);
-        expect(result.neo.error).toMatch(/Unrecognized neoEmbeddingProvider/);
+        expect(result.active).toBe('fooProvider');
+        expect(result.host).toBeNull();
+        expect(result.model).toBeNull();
+        expect(result.dimensions).toBe(4096);
+        expect(result.error).toMatch(/Unrecognized embeddingProvider/);
     });
 
-    test('openAiCompatible without nested config surfaces null host + null model + dimensions for both engines', () => {
+    test('openAiCompatible without nested config surfaces null host + null model + dimensions', () => {
         const cfg = {
-            chromaEmbeddingProvider: 'openAiCompatible',
-            neoEmbeddingProvider   : 'openAiCompatible',
-            vectorDimension        : 4096
+            embeddingProvider: 'openAiCompatible',
+            vectorDimension  : 4096
             // openAiCompatible config block deliberately absent — defensive against incomplete config
         };
         expect(buildEmbeddingProviderBlock(cfg)).toEqual({
-            aligned: true,
-            chroma : {
-                active    : 'openAiCompatible',
-                host      : null,
-                model     : null,
-                dimensions: 4096
-            },
-            neo: {
-                active    : 'openAiCompatible',
-                host      : null,
-                model     : null,
-                dimensions: 4096
-            }
+            active    : 'openAiCompatible',
+            host      : null,
+            model     : null,
+            dimensions: 4096
         });
     });
 
     test('dimensions fields always reflect vectorDimension regardless of provider', () => {
         for (const provider of ['gemini', 'openAiCompatible', 'ollama', 'unrecognized']) {
-            const cfg = {chromaEmbeddingProvider: provider, neoEmbeddingProvider: provider, vectorDimension: 768};
+            const cfg = {embeddingProvider: provider, vectorDimension: 768};
             const result = buildEmbeddingProviderBlock(cfg);
-            expect(result.chroma.dimensions).toBe(768);
-            expect(result.neo.dimensions).toBe(768);
+            expect(result.dimensions).toBe(768);
         }
     });
 });

--- a/test/playwright/unit/ai/mcp/server/memory-core/services/QueryReRanker.spec.mjs
+++ b/test/playwright/unit/ai/mcp/server/memory-core/services/QueryReRanker.spec.mjs
@@ -43,8 +43,7 @@ test.describe('StorageRouter Query Re-Ranker Defensive Handling', () => {
         TextEmbeddingService = (await import('../../../../../../../../ai/mcp/server/memory-core/services/TextEmbeddingService.mjs')).default;
 
         // Force offline mode — mock embeddings with deterministic 4096D vectors
-        SDK.Memory_Config.data.chromaEmbeddingProvider = 'openAiCompatible';
-        SDK.Memory_Config.data.neoEmbeddingProvider    = 'openAiCompatible';
+        SDK.Memory_Config.data.embeddingProvider       = 'openAiCompatible';
         SDK.Memory_Config.data.autoSummarize           = false;
 
         TextEmbeddingService.embedText = async () => new Array(4096).fill(Math.random());
@@ -192,8 +191,7 @@ test.describe('SessionService Drift Detection — Timestamp Filtering', () => {
         SDK                  = await import('../../../../../../../../ai/services.mjs');
         TextEmbeddingService = (await import('../../../../../../../../ai/mcp/server/memory-core/services/TextEmbeddingService.mjs')).default;
 
-        SDK.Memory_Config.data.chromaEmbeddingProvider = 'openAiCompatible';
-        SDK.Memory_Config.data.neoEmbeddingProvider    = 'openAiCompatible';
+        SDK.Memory_Config.data.embeddingProvider       = 'openAiCompatible';
         SDK.Memory_Config.data.autoSummarize           = false;
 
         TextEmbeddingService.embedText = async () => new Array(4096).fill(Math.random());

--- a/test/playwright/unit/ai/mcp/server/memory-core/services/SessionService.ResumeValidation.spec.mjs
+++ b/test/playwright/unit/ai/mcp/server/memory-core/services/SessionService.ResumeValidation.spec.mjs
@@ -50,8 +50,7 @@ test.describe('SessionService validateSessionForResume (#10725)', () => {
         TextEmbeddingService = (await import('../../../../../../../../ai/mcp/server/memory-core/services/TextEmbeddingService.mjs')).default;
 
         SDK.Memory_Config.data.modelProvider           = 'openAiCompatible';
-        SDK.Memory_Config.data.neoEmbeddingProvider    = 'openAiCompatible';
-        SDK.Memory_Config.data.chromaEmbeddingProvider = 'openAiCompatible';
+        SDK.Memory_Config.data.embeddingProvider       = 'openAiCompatible';
         SDK.Memory_Config.data.autoSummarize           = false;
 
         TextEmbeddingService.embedText = async () => new Array(4096).fill(Math.random());

--- a/test/playwright/unit/ai/mcp/server/memory-core/services/SessionService.spec.mjs
+++ b/test/playwright/unit/ai/mcp/server/memory-core/services/SessionService.spec.mjs
@@ -57,8 +57,7 @@ test.describe('SessionService setSessionId', () => {
         TextEmbeddingService = (await import('../../../../../../../../ai/mcp/server/memory-core/services/TextEmbeddingService.mjs')).default;
 
         SDK.Memory_Config.data.modelProvider         = 'openAiCompatible';
-        SDK.Memory_Config.data.neoEmbeddingProvider  = 'openAiCompatible';
-        SDK.Memory_Config.data.chromaEmbeddingProvider = 'openAiCompatible';
+        SDK.Memory_Config.data.embeddingProvider     = 'openAiCompatible';
         SDK.Memory_Config.data.autoSummarize         = false;
 
         TextEmbeddingService.embedText = async () => new Array(4096).fill(Math.random());
@@ -293,4 +292,3 @@ test.describe('SessionService setSessionId', () => {
         expect(sharedMemories.memories.length).toBe(1);
     });
 });
-

--- a/test/playwright/unit/ai/mcp/server/memory-core/services/SessionSummarization.spec.mjs
+++ b/test/playwright/unit/ai/mcp/server/memory-core/services/SessionSummarization.spec.mjs
@@ -65,8 +65,7 @@ test.describe('Memory Core Offline Summarization', () => {
 
         // Force 'openAiCompatible' routing for this test
         SDK.Memory_Config.data.modelProvider         = 'openAiCompatible';
-        SDK.Memory_Config.data.neoEmbeddingProvider  = 'openAiCompatible';
-        SDK.Memory_Config.data.chromaEmbeddingProvider = 'openAiCompatible';
+        SDK.Memory_Config.data.embeddingProvider     = 'openAiCompatible';
         SDK.Memory_Config.data.openAiCompatible.host           = 'http://127.0.0.1:1234';
         SDK.Memory_Config.data.openAiCompatible.model          = 'gemma-4-31b-it';
         SDK.Memory_Config.data.openAiCompatible.embeddingModel = 'text-embedding-qwen3-embedding-8b';

--- a/test/playwright/unit/ai/mcp/server/memory-core/services/TextEmbeddingService.spec.mjs
+++ b/test/playwright/unit/ai/mcp/server/memory-core/services/TextEmbeddingService.spec.mjs
@@ -1,0 +1,50 @@
+import {setup} from '../../../../../../setup.mjs';
+
+const appName = 'TextEmbeddingServiceProviderTest';
+
+setup({
+    neoConfig: {
+        unitTestMode: true
+    },
+    appConfig: {
+        name             : appName,
+        isMounted        : () => true,
+        vnodeInitialising: false
+    }
+});
+
+import {test, expect} from '@playwright/test';
+import Neo            from '../../../../../../../../src/Neo.mjs';
+import * as core      from '../../../../../../../../src/core/_export.mjs';
+
+/**
+ * @summary Coverage for the #10804 TextEmbeddingService Gemini-init gate.
+ *
+ * #9719 removed implicit provider fallback inside TextEmbeddingService. #10804 keeps that
+ * deterministic routing: the singleton only initializes a Gemini embedding client when the
+ * single canonical `embeddingProvider` selector is `gemini`.
+ *
+ * @see Neo.ai.mcp.server.memory-core.services.TextEmbeddingService#shouldInitializeGeminiEmbeddingClient
+ */
+test.describe('TextEmbeddingService #10804 — shouldInitializeGeminiEmbeddingClient', () => {
+    let shouldInitializeGeminiEmbeddingClient;
+
+    test.beforeAll(async () => {
+        const mod = await import('../../../../../../../../ai/mcp/server/memory-core/services/TextEmbeddingService.mjs');
+        shouldInitializeGeminiEmbeddingClient = mod.shouldInitializeGeminiEmbeddingClient;
+    });
+
+    test('returns true only for the unified gemini embedding provider', () => {
+        expect(shouldInitializeGeminiEmbeddingClient({embeddingProvider: 'gemini'})).toBe(true);
+        expect(shouldInitializeGeminiEmbeddingClient({embeddingProvider: 'openAiCompatible'})).toBe(false);
+        expect(shouldInitializeGeminiEmbeddingClient({embeddingProvider: 'ollama'})).toBe(false);
+    });
+
+    test('does not consult removed Chroma/SQLite provider selectors', () => {
+        expect(shouldInitializeGeminiEmbeddingClient({
+            embeddingProvider      : 'openAiCompatible',
+            chromaEmbeddingProvider: 'gemini',
+            neoEmbeddingProvider   : 'gemini'
+        })).toBe(false);
+    });
+});


### PR DESCRIPTION
Authored by GPT-5.5 (Codex Desktop). Session 1a17d733-39b5-464e-ad23-6b93bdd2446e.

Resolves #10804

Consolidates the Memory Core / Knowledge Base embedding-provider surface to one canonical `embeddingProvider` selector, while preserving a deprecation fallback for `NEO_CHROMA_EMBEDDING_PROVIDER` / legacy config fields. The healthcheck `providers.embedding` payload is now a single `{active, host, model, dimensions, error?}` block again, matching the single-route runtime contract.

Evidence: L2 (pure resolver coverage + focused Playwright provider/healthcheck unit tests) -> L2 required by #10804. No residuals.

## Deltas from Ticket

- Added `EmbeddingProviderConfig.mjs` so config normalization is testable without constructing the singleton or requiring live provider credentials.
- Preserved the #9719 routing constraint: callsites pass the explicit provider into `TextEmbeddingService`; no hidden fallback was reintroduced inside the embedding service.
- `NEO_CHROMA_EMBEDDING_PROVIDER` remains readable for one deprecation window and warns; when the unified selector conflicts with a legacy selector, the unified value wins.
- `learn/agentos/DeploymentCookbook.md` is not present on current `origin/dev`; cookbook updates remain coordinated through the cookbook branch / sibling tickets after that doc lands.

## Config Template Change

Changed keys in `ai/mcp/server/memory-core/config.template.mjs`:

- Added `embeddingProvider`
- Removed template defaults for `chromaEmbeddingProvider`
- Removed template defaults for `neoEmbeddingProvider`

Local clone follow-up: active, gitignored `ai/mcp/server/memory-core/config.mjs` files should migrate to `embeddingProvider` after merge. Legacy keys keep working during the deprecation window, but will emit warnings. Harness restart is recommended for already-running MCP servers so they reload the config shape and healthcheck projection. The A2A reviewer handoff includes this clone-sync note.

## Slot Rationale

Modified `learn/agentos/MemoryCore.md` and `learn/agentos/SharedDeployment.md`.

Disposition delta: keep -> keep. The modified provider sections remain loaded operator contract docs, but the content now removes the obsolete dual-provider split. 3-axis rating: trigger-frequency medium (deployment / healthcheck diagnosis), failure-severity high (silent embedding-route drift corrupts retrieval assumptions), enforceability medium (shape is covered by unit tests and reviewable healthcheck samples). Decay mitigation: deprecation language names the legacy env var and constrains it to a one-window compatibility path instead of permanently expanding the config surface.

## Test Evidence

- `node --check ai/mcp/server/memory-core/helpers/EmbeddingProviderConfig.mjs`
- `node --check ai/mcp/server/memory-core/config.template.mjs`
- `git diff --check`
- `git diff --check origin/dev...HEAD`
- `npm run test-unit -- test/playwright/unit/ai/mcp/server/memory-core/config.spec.mjs test/playwright/unit/ai/mcp/server/memory-core/services/TextEmbeddingService.spec.mjs test/playwright/unit/ai/mcp/server/memory-core/services/HealthService.spec.mjs` -> 31 passed
- Broader `npm run test-unit -- test/playwright/unit/ai/mcp/server/memory-core/` was attempted before finalization and exposed existing local substrate failures (`readonly database`, Chroma connection failures, and ignored local config drift); the provider-focused L2 surface above is green.

## Post-Merge Validation

- [ ] Restart active MCP servers / clones that rely on local `config.mjs`, then verify `healthcheck.providers.embedding` returns the single-block shape.
- [ ] Confirm local deployments have migrated from `NEO_CHROMA_EMBEDDING_PROVIDER` to `NEO_EMBEDDING_PROVIDER`.

## Commit

- `01785bb9f` - `feat(ai): consolidate embedding provider config (#10804)`
