### PR TITLE
docs(agentos): polish cookbook Section 7 healthcheck JSON sample (#10800)

### DIFF
--- a/learn/agentos/DeploymentCookbook.md
+++ b/learn/agentos/DeploymentCookbook.md
@@ -112,14 +112,47 @@ Expected JSON block (excerpt):
   },
   "providers": {
     "embedding": {
-      "aligned": true,
-      "chroma": { "active": "gemini" },
-      "neo": { "active": "gemini" }
+      "active": "openAiCompatible",
+      "host": "http://127.0.0.1:8000",
+      "model": "text-embedding-qwen3-embedding-1.5b",
+      "dimensions": 4096
+    },
+    "summary": {
+      "active": "openAiCompatible",
+      "host": "http://127.0.0.1:11434",
+      "model": "qwen3-8b",
+      "endpoint": "http://127.0.0.1:11434/v1/chat/completions",
+      "local": true,
+      "credential": {
+        "env": "NEO_OPENAI_COMPATIBLE_API_KEY",
+        "configured": false,
+        "required": false
+      }
+    },
+    "auth": {
+      "configured": "proxy-header",
+      "oidc": {
+        "host": null,
+        "issuerUrl": null,
+        "realm": null,
+        "configured": false
+      },
+      "proxyHeader": {
+        "trusted": true,
+        "headersChecked": ["x-preferred-username", "x-auth-request-preferred-username"]
+      }
     }
   }
 }
 ```
-If `identity.source` is not `"proxy-header"` or `database.topology.mode` is not `"unified"`, your environment variables are misconfigured. See [Memory Core Healthcheck](MemoryCore.md) for the full schema contract.
+Operator verification anchors:
+- `identity.source === "proxy-header"` confirms the reverse proxy is injecting the `X-PREFERRED-USERNAME` header and the MC server is reading it.
+- `database.topology.mode === "unified"` confirms shared Chroma topology is active.
+- `providers.embedding.active` reflects the configured embedding provider per [#10804](https://github.com/neomjs/neo/issues/10804) consolidation — `'gemini'` (cloud), `'openAiCompatible'` (local Qwen3 / MLX), or `'ollama'`.
+- `providers.summary.active` mirrors the same shape for the session-summary provider.
+- `providers.auth.configured === "proxy-header"` confirms the deployment is using the trust-proxy-identity path; for OIDC mode it would be `'oidc'` (with the `oidc.{host, issuerUrl, realm, configured: true}` block populated). `providers.auth.proxyHeader.headersChecked` is the canonical + `oauth2-proxy`-variant header pair the server reads.
+
+See [Memory Core Healthcheck](MemoryCore.md) for the full schema contract (including the `clientSecret`-non-leak invariant per [#10770](https://github.com/neomjs/neo/issues/10770)).
 
 ## Section 8: First-Connection Smoke Test
 
@@ -137,3 +170,4 @@ This cookbook surfaces the following architectural gaps between "substrate compl
 - **[#10803](https://github.com/neomjs/neo/issues/10803):** Publish reference reverse proxy config for shared topology.
 - **[#10804](https://github.com/neomjs/neo/issues/10804):** Consolidate `neoEmbeddingProvider` and `chromaEmbeddingProvider` configurations.
 - **[#10805](https://github.com/neomjs/neo/issues/10805):** Build staged-stack integration test harness for shared cloud deployment.
+- **[#10808](https://github.com/neomjs/neo/issues/10808):** Operator-facing env var ergonomics — descriptive names (`MCP_HTTP_PORT`, `NEO_PUBLIC_URL`, etc.) + `NEO_CHROMA_HOST` / `NEO_CHROMA_PORT` overridability. Cross-cuts Section 6 (env var inventory) where the forward-looking names are documented ahead of substrate-side wiring.


### PR DESCRIPTION
Authored by Claude Opus 4.7 (Claude Code). Session 34c8f800-1855-43ff-aea6-d5e6b9410978.

Refs #10800 (already closed by PR #10806; this is a doc-polish follow-up, not a re-close).

Three-fold Section 7 polish following the merged [PR #10806](https://github.com/neomjs/neo/pull/10806) cookbook + [PR #10810](https://github.com/neomjs/neo/pull/10810) provider consolidation. Promised in my Cycle-2 review of #10806 ([issue-comment 4386479129](https://github.com/neomjs/neo/pull/10806#issuecomment-4386479129)) as the polish-follow-up to fold three Section 7 concerns into one commit:

1. **Add `providers.auth` block** to the JSON sample with the canonical `{configured, oidc.{...}, proxyHeader.{...}}` shape from [PR #10798](https://github.com/neomjs/neo/pull/10798) ([#10770](https://github.com/neomjs/neo/issues/10770) healthcheck observability substrate). Documents the `trustProxyIdentity`-mode operator verification path explicitly so Section 7 stops being JSON-incomplete for the deployment topology Section 4 prescribes.
2. **Add `providers.summary` block** ([#10724](https://github.com/neomjs/neo/issues/10724) shape) so operators see all three `providers.*` siblings (`embedding` + `summary` + `auth`) in one place.
3. **Update `providers.embedding`** from the prior dual-shape `{aligned, chroma, neo}` (Option B from [PR #10799](https://github.com/neomjs/neo/pull/10799)) to the single-block `{active, host, model, dimensions}` shape per [PR #10810](https://github.com/neomjs/neo/pull/10810) consolidation. The dual-shape sample shipped in cookbook PR #10806 *before* PR #10810's merge; this aligns the reference doc with the now-shipped substrate.

Plus added [#10808](https://github.com/neomjs/neo/issues/10808) cross-link to Section 9 Known Gaps (filed after cookbook PR opened — not Gemini's authoring miss; just freshness sync).

Evidence: L1 (static doc-shape audit against authoritative MemoryCore.md schemas + the just-merged PR #10798 / #10799 / #10810 substrates) → L1 required (no runtime-verify ACs). No residuals.

## Deltas from cookbook (Cycle 2)

None of the cookbook's structure changed — only Section 7 JSON sample + Section 9 follow-up list. Doc-only update; no code surface.

## Test Evidence

- `node --check` not applicable (markdown-only PR).
- Visual inspection of resulting Section 7 JSON sample against `MemoryCore.md` §Healthcheck Response Shape canonical contract — all three `providers.*` blocks now match what a deployed MC server actually emits per the merged PR contracts.
- 38 lines added / 4 removed; surgical edit.

## Slot Rationale

`learn/agentos/DeploymentCookbook.md` modified — substrate-mutation per `pull-request-workflow §1.1`.

- Disposition: `keep` → `keep` (no disposition delta).
- 3-axis rating: trigger-frequency medium (operator deployment / healthcheck verification), failure-severity high (cookbook is the canonical operator-onboarding reference; an incomplete JSON sample creates "I'm misconfigured" false-positives), enforceability medium (shape verifiable by inspection against `MemoryCore.md` schemas + the merged PR contracts).
- Decay mitigation: this polish closes the temporal-skew between cookbook content (frozen at PR #10806 open) and the shipped substrate (PR #10810 + PR #10798 contracts merged after). No new substrate accretion; net additive content tracks shipped reality.

## Cross-Family Mandate (§6.1)

This PR qualifies for the `pull-request-workflow §6.1` micro-change exemption: *"pure documentation with no runtime impact"* — markdown-only edit to a single doc file, no code/config/test surface touched. Cross-family approval not strictly required per exemption.

That said, routing primary review to [@neo-gemini-3-1-pro](https://github.com/neo-gemini-3-1-pro) per round-robin (she authored the cookbook in PR #10806; subsystem-familiarity makes her the natural reviewer for content polish on her substrate). Soft handoff per `pull-request-workflow §6.2`.

## Post-Merge Validation

- [ ] Visual confirmation that Section 7's expanded JSON sample matches a live healthcheck response from a deployed MC stack (operator-territory once the integration test fixture from [#10805](https://github.com/neomjs/neo/issues/10805) lands).