### PR TITLE
feat(ai): operator-facing env var ergonomics for MCP HTTP port + Chroma host/port (#10808)

### DIFF
--- a/ai/mcp/server/knowledge-base/Server.mjs
+++ b/ai/mcp/server/knowledge-base/Server.mjs
@@ -15,7 +15,7 @@ import {listTools, callTool}                           from './services/toolServ
  * This server uses a dual-transport architecture, allowing it to communicate with local CLI clients
  * via `stdio` (the default) or with cloud-native/remote clients via `sse` (StreamableHTTPServerTransport).
  *
- * The transport mode and HTTP port can be configured using `aiConfig.transport` and `aiConfig.ssePort`.
+ * The transport mode and HTTP port can be configured using `aiConfig.transport` and `aiConfig.mcpHttpPort`.
  *
  * @class Neo.ai.mcp.server.knowledge-base.Server
  * @extends Neo.core.Base

--- a/ai/mcp/server/knowledge-base/config.template.mjs
+++ b/ai/mcp/server/knowledge-base/config.template.mjs
@@ -3,9 +3,9 @@ import os              from 'os';
 import path            from 'path';
 import Base            from '../../../../src/core/Base.mjs';
 import {fileURLToPath} from 'url';
-import {resolveMcpHttpPort} from '../shared/helpers/DeploymentConfig.mjs';
+import {resolveChromaHost, resolveChromaPort, resolveMcpHttpPort} from '../shared/helpers/DeploymentConfig.mjs';
 
-export {resolveMcpHttpPort};
+export {resolveChromaHost, resolveChromaPort, resolveMcpHttpPort};
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname  = path.dirname(__filename);
@@ -105,14 +105,15 @@ const defaultConfig = {
      * unified Chroma instance for both KB + MC, this points at the shared cloud-hosted Chroma.
      * @type {string}
      */
-    host: process.env.NEO_CHROMA_HOST || 'localhost',
+    host: resolveChromaHost(),
     /**
      * The port the ChromaDB server for the knowledge base is listening on.
      *
-     * Operator env var: `NEO_CHROMA_PORT` (#10808).
+     * Operator env var: `NEO_CHROMA_PORT` (#10808). Invalid values (non-integer / out-of-range)
+     * fall back to the default with a console warning per the resolver validity contract.
      * @type {number}
      */
-    port: Number(process.env.NEO_CHROMA_PORT) || 8000,
+    port: resolveChromaPort(),
     /**
      * The local persistence path for the agent knowledge-base server.
      * @type {string}

--- a/ai/mcp/server/knowledge-base/config.template.mjs
+++ b/ai/mcp/server/knowledge-base/config.template.mjs
@@ -3,6 +3,9 @@ import os              from 'os';
 import path            from 'path';
 import Base            from '../../../../src/core/Base.mjs';
 import {fileURLToPath} from 'url';
+import {resolveMcpHttpPort} from '../shared/helpers/DeploymentConfig.mjs';
+
+export {resolveMcpHttpPort};
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname  = path.dirname(__filename);
@@ -35,10 +38,13 @@ const defaultConfig = {
      */
     transport: process.env.TRANSPORT || 'stdio',
     /**
-     * Port for the SSE transport (only used if transport is 'sse').
+     * Port the MCP server's HTTP/SSE transport listens on (only used when `transport === 'sse'`).
+     *
+     * Operator env var: `MCP_HTTP_PORT`. The legacy `SSE_PORT` env var remains readable for one
+     * deprecation window per #10808; resolver emits a warning if both are set with different values.
      * @type {number}
      */
-    ssePort: Number(process.env.SSE_PORT) || 3000,
+    mcpHttpPort: resolveMcpHttpPort({defaultPort: 3000}),
     /**
      * Optional Express middleware function for authentication (only used if transport is 'sse').
      * @type {Function|null}
@@ -94,14 +100,19 @@ const defaultConfig = {
     chromaUnified: process.env.NEO_CHROMA_UNIFIED === 'true',
     /**
      * The hostname of the ChromaDB server for the knowledge base.
+     *
+     * Operator env var: `NEO_CHROMA_HOST` (#10808). For shared cloud deployments where KB hosts the
+     * unified Chroma instance for both KB + MC, this points at the shared cloud-hosted Chroma.
      * @type {string}
      */
-    host: 'localhost',
+    host: process.env.NEO_CHROMA_HOST || 'localhost',
     /**
      * The port the ChromaDB server for the knowledge base is listening on.
+     *
+     * Operator env var: `NEO_CHROMA_PORT` (#10808).
      * @type {number}
      */
-    port: 8000,
+    port: Number(process.env.NEO_CHROMA_PORT) || 8000,
     /**
      * The local persistence path for the agent knowledge-base server.
      * @type {string}

--- a/ai/mcp/server/memory-core/Server.mjs
+++ b/ai/mcp/server/memory-core/Server.mjs
@@ -21,7 +21,7 @@ import CoalescingEngineService                         from './services/Coalesci
  * This server uses a dual-transport architecture, allowing it to communicate with local CLI clients
  * via `stdio` (the default) or with cloud-native/remote clients via `sse` (StreamableHTTPServerTransport).
  *
- * The transport mode and HTTP port can be configured using `aiConfig.transport` and `aiConfig.ssePort`.
+ * The transport mode and HTTP port can be configured using `aiConfig.transport` and `aiConfig.mcpHttpPort`.
  *
  * @class Neo.ai.mcp.server.memory-core.Server
  * @extends Neo.core.Base

--- a/ai/mcp/server/memory-core/config.template.mjs
+++ b/ai/mcp/server/memory-core/config.template.mjs
@@ -3,9 +3,9 @@ import path            from 'path';
 import Base            from '../../../../src/core/Base.mjs';
 import {fileURLToPath} from 'url';
 import {normalizeEmbeddingProviderConfig, resolveEmbeddingProvider} from './helpers/EmbeddingProviderConfig.mjs';
-import {resolveMcpHttpPort}                                         from '../shared/helpers/DeploymentConfig.mjs';
+import {resolveChromaHost, resolveChromaPort, resolveMcpHttpPort}   from '../shared/helpers/DeploymentConfig.mjs';
 
-export {normalizeEmbeddingProviderConfig, resolveEmbeddingProvider, resolveMcpHttpPort};
+export {normalizeEmbeddingProviderConfig, resolveChromaHost, resolveChromaPort, resolveEmbeddingProvider, resolveMcpHttpPort};
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname  = path.dirname(__filename);
@@ -208,8 +208,8 @@ const defaultConfig = {
             chroma: {
                 // #10808: prefer operator-facing `NEO_CHROMA_HOST/PORT` (cookbook Section 5);
                 // `NEO_KB_CHROMA_HOST/PORT` remains readable for backwards-compat during deprecation window.
-                host: process.env.NEO_CHROMA_HOST || process.env.NEO_KB_CHROMA_HOST || 'localhost',
-                port: Number(process.env.NEO_CHROMA_PORT) || Number(process.env.NEO_KB_CHROMA_PORT) || 8000
+                host: resolveChromaHost({legacyEnvVar: 'NEO_KB_CHROMA_HOST'}),
+                port: resolveChromaPort({legacyEnvVar: 'NEO_KB_CHROMA_PORT'})
             }
         }
     },

--- a/ai/mcp/server/memory-core/config.template.mjs
+++ b/ai/mcp/server/memory-core/config.template.mjs
@@ -3,8 +3,9 @@ import path            from 'path';
 import Base            from '../../../../src/core/Base.mjs';
 import {fileURLToPath} from 'url';
 import {normalizeEmbeddingProviderConfig, resolveEmbeddingProvider} from './helpers/EmbeddingProviderConfig.mjs';
+import {resolveMcpHttpPort}                                         from '../shared/helpers/DeploymentConfig.mjs';
 
-export {normalizeEmbeddingProviderConfig, resolveEmbeddingProvider};
+export {normalizeEmbeddingProviderConfig, resolveEmbeddingProvider, resolveMcpHttpPort};
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname  = path.dirname(__filename);
@@ -71,10 +72,13 @@ const defaultConfig = {
      */
     transport: process.env.TRANSPORT || 'stdio',
     /**
-     * Port for the SSE transport (only used if transport is 'sse').
+     * Port the MCP server's HTTP/SSE transport listens on (only used when `transport === 'sse'`).
+     *
+     * Operator env var: `MCP_HTTP_PORT`. The legacy `SSE_PORT` env var remains readable for one
+     * deprecation window per #10808; resolver emits a warning if both are set with different values.
      * @type {number}
      */
-    ssePort: Number(process.env.SSE_PORT) || 3001,
+    mcpHttpPort: resolveMcpHttpPort({defaultPort: 3001}),
     /**
      * Optional Express middleware function for authentication (only used if transport is 'sse').
      * @type {Function|null}
@@ -202,8 +206,10 @@ const defaultConfig = {
          */
         kb: {
             chroma: {
-                host: process.env.NEO_KB_CHROMA_HOST || 'localhost',
-                port: Number(process.env.NEO_KB_CHROMA_PORT) || 8000
+                // #10808: prefer operator-facing `NEO_CHROMA_HOST/PORT` (cookbook Section 5);
+                // `NEO_KB_CHROMA_HOST/PORT` remains readable for backwards-compat during deprecation window.
+                host: process.env.NEO_CHROMA_HOST || process.env.NEO_KB_CHROMA_HOST || 'localhost',
+                port: Number(process.env.NEO_CHROMA_PORT) || Number(process.env.NEO_KB_CHROMA_PORT) || 8000
             }
         }
     },

--- a/ai/mcp/server/shared/helpers/DeploymentConfig.mjs
+++ b/ai/mcp/server/shared/helpers/DeploymentConfig.mjs
@@ -23,8 +23,18 @@
 export function resolveMcpHttpPort({env = process.env, warn = console.warn, defaultPort} = {}) {
     const hasValue = value => value !== undefined && value !== null && value !== '';
 
-    const newPort    = hasValue(env.MCP_HTTP_PORT) ? Number(env.MCP_HTTP_PORT) : null;
-    const legacyPort = hasValue(env.SSE_PORT)      ? Number(env.SSE_PORT)      : null;
+    const parsePort = (rawValue, envVarName) => {
+        if (!hasValue(rawValue)) return null;
+        const num = Number(rawValue);
+        if (!Number.isInteger(num) || num <= 0 || num > 65535) {
+            warn(`[Config] Invalid ${envVarName} value: "${rawValue}" (must be integer in 1..65535); falling back.`);
+            return null;
+        }
+        return num;
+    };
+
+    const newPort    = parsePort(env.MCP_HTTP_PORT, 'MCP_HTTP_PORT');
+    const legacyPort = parsePort(env.SSE_PORT,      'SSE_PORT');
 
     if (legacyPort !== null) {
         if (newPort !== null && newPort !== legacyPort) {
@@ -33,6 +43,64 @@ export function resolveMcpHttpPort({env = process.env, warn = console.warn, defa
             warn('[Config] SSE_PORT is deprecated; use MCP_HTTP_PORT.');
         }
     }
+
+    return newPort ?? legacyPort ?? defaultPort;
+}
+
+/**
+ * @summary Resolves the ChromaDB host with optional fallback to a legacy server-prefixed env var.
+ *
+ * Per #10808 operator-facing env-var ergonomics: `NEO_CHROMA_HOST` is the canonical
+ * operator-set env var (used by KB own Chroma config + MC `engines.kb.chroma`
+ * unified-mode reference). `NEO_KB_CHROMA_HOST` is the legacy-prefixed form retained
+ * for MC's existing `engines.kb.chroma` fallback chain during the deprecation window.
+ *
+ * Pure function: takes env + optional legacyEnvVar; returns resolved host string.
+ *
+ * @param {Object}   options
+ * @param {Object}   [options.env=process.env]   Environment map (overridable for tests).
+ * @param {String}   [options.defaultHost='localhost'] Default when no env var is set.
+ * @param {String}   [options.legacyEnvVar]      Optional legacy env-var name to consult after `NEO_CHROMA_HOST`
+ *     (e.g., `'NEO_KB_CHROMA_HOST'` for MC's `engines.kb.chroma` block; KB own config does not pass this).
+ * @returns {String}
+ */
+export function resolveChromaHost({env = process.env, defaultHost = 'localhost', legacyEnvVar} = {}) {
+    const hasValue = value => value !== undefined && value !== null && value !== '';
+
+    if (hasValue(env.NEO_CHROMA_HOST))                  return env.NEO_CHROMA_HOST;
+    if (legacyEnvVar && hasValue(env[legacyEnvVar]))    return env[legacyEnvVar];
+    return defaultHost;
+}
+
+/**
+ * @summary Resolves the ChromaDB port with optional fallback to a legacy server-prefixed env var.
+ *
+ * Sibling of {@link resolveChromaHost}. Same semantics; numeric port handling. Invalid values
+ * (non-integer / out-of-range / negative) fall back to the next layer with a warning, mirroring
+ * the {@link resolveMcpHttpPort} validity contract.
+ *
+ * @param {Object}   options
+ * @param {Object}   [options.env=process.env]   Environment map (overridable for tests).
+ * @param {Function} [options.warn=console.warn] Warning sink for invalid-value notices.
+ * @param {Number}   [options.defaultPort=8000]  Default when no env var is set.
+ * @param {String}   [options.legacyEnvVar]      Optional legacy env-var name to consult after `NEO_CHROMA_PORT`.
+ * @returns {Number}
+ */
+export function resolveChromaPort({env = process.env, warn = console.warn, defaultPort = 8000, legacyEnvVar} = {}) {
+    const hasValue = value => value !== undefined && value !== null && value !== '';
+
+    const parsePort = (rawValue, envVarName) => {
+        if (!hasValue(rawValue)) return null;
+        const num = Number(rawValue);
+        if (!Number.isInteger(num) || num <= 0 || num > 65535) {
+            warn(`[Config] Invalid ${envVarName} value: "${rawValue}" (must be integer in 1..65535); falling back.`);
+            return null;
+        }
+        return num;
+    };
+
+    const newPort    = parsePort(env.NEO_CHROMA_PORT, 'NEO_CHROMA_PORT');
+    const legacyPort = legacyEnvVar ? parsePort(env[legacyEnvVar], legacyEnvVar) : null;
 
     return newPort ?? legacyPort ?? defaultPort;
 }

--- a/ai/mcp/server/shared/helpers/DeploymentConfig.mjs
+++ b/ai/mcp/server/shared/helpers/DeploymentConfig.mjs
@@ -1,0 +1,38 @@
+/**
+ * @summary Resolves the MCP server HTTP listening port with backwards-compat for the legacy
+ * `SSE_PORT` env var.
+ *
+ * `SSE_PORT` was the original env var introduced when the SSE transport was the only
+ * non-stdio path (#10145 / PR #10166 era). Per #10808 operator-facing env-var ergonomics,
+ * we rename to `MCP_HTTP_PORT` (transport-mechanism-agnostic, intent-clear for operators
+ * provisioning containers). Soft rename: `MCP_HTTP_PORT` is preferred; `SSE_PORT` remains
+ * readable during the deprecation window with a warning when both are set with different
+ * values.
+ *
+ * Pattern mirrors {@link Neo.ai.mcp.server.memory-core.helpers.EmbeddingProviderConfig#resolveEmbeddingProvider}
+ * from PR #10810 — pure, testable, dependency-free; consumers (`Server.mjs` config templates)
+ * call it once at config-load time.
+ *
+ * @param {Object}   options
+ * @param {Object}   [options.env=process.env]   Environment map (overridable for tests).
+ * @param {Function} [options.warn=console.warn] Warning sink for deprecation/conflict notices.
+ * @param {Number}   options.defaultPort         Default port if neither env var is set
+ *     (KB defaults to 3000, MC defaults to 3001 — caller passes its own default).
+ * @returns {Number} The resolved port.
+ */
+export function resolveMcpHttpPort({env = process.env, warn = console.warn, defaultPort} = {}) {
+    const hasValue = value => value !== undefined && value !== null && value !== '';
+
+    const newPort    = hasValue(env.MCP_HTTP_PORT) ? Number(env.MCP_HTTP_PORT) : null;
+    const legacyPort = hasValue(env.SSE_PORT)      ? Number(env.SSE_PORT)      : null;
+
+    if (legacyPort !== null) {
+        if (newPort !== null && newPort !== legacyPort) {
+            warn(`[Config] SSE_PORT is deprecated and conflicts with MCP_HTTP_PORT; using ${newPort}.`);
+        } else {
+            warn('[Config] SSE_PORT is deprecated; use MCP_HTTP_PORT.');
+        }
+    }
+
+    return newPort ?? legacyPort ?? defaultPort;
+}

--- a/ai/mcp/server/shared/services/TransportService.mjs
+++ b/ai/mcp/server/shared/services/TransportService.mjs
@@ -109,7 +109,7 @@ class TransportService extends Base {
             return new URL(`${protocol}://${host}:${port}`);
         };
 
-        const mcpServerUrl = getFullUrl(process.env.HOST || 'localhost', aiConfig.ssePort);
+        const mcpServerUrl = getFullUrl(process.env.HOST || 'localhost', aiConfig.mcpHttpPort);
 
         // Optional OIDC/OAuth Authorization
         if (aiConfig.auth.host || aiConfig.auth.issuerUrl) {
@@ -196,7 +196,7 @@ class TransportService extends Base {
             await RequestContextService.run(requestContext, () => transport.handleRequest(req, res, req.body));
         });
 
-        const port = aiConfig.ssePort || 3000;
+        const port = aiConfig.mcpHttpPort || 3000;
         app.listen(port, () => {
             logger.info(`[${resourceName}] Server started on SSE transport (Port: ${port})`);
             logger.info(`[${resourceName}] Available tools loaded from OpenAPI spec`);

--- a/learn/agentos/DeploymentCookbook.md
+++ b/learn/agentos/DeploymentCookbook.md
@@ -88,7 +88,7 @@ When provisioning your containers, supply the following minimal environment vari
 | `AUTH_TRUST_PROXY_IDENTITY` | Both | Set to `true` if your reverse proxy handles authentication. |
 | `GEMINI_API_KEY` | Both | Required for Gemini integration. |
 
-*(Note: Full config unification and public URL advertising are tracked under [#10802](https://github.com/neomjs/neo/issues/10802) and [#10804](https://github.com/neomjs/neo/issues/10804). Environment mapping and legacy variable unification are tracked under [#10808](https://github.com/neomjs/neo/issues/10808)).*
+*(Notes: Public URL advertising is tracked under [#10802](https://github.com/neomjs/neo/issues/10802). Provider consolidation shipped in [PR #10810](https://github.com/neomjs/neo/pull/10810) — `embeddingProvider` is now the canonical selector. Env-var ergonomics shipped in [#10808](https://github.com/neomjs/neo/issues/10808): `MCP_HTTP_PORT` is the canonical operator-facing env var (`SSE_PORT` remains readable during the deprecation window with a warning); `NEO_CHROMA_HOST` / `NEO_CHROMA_PORT` are now env-overridable on both KB + MC.)*
 
 ## Section 7: Healthcheck Verification
 

--- a/learn/agentos/KnowledgeBase.md
+++ b/learn/agentos/KnowledgeBase.md
@@ -204,7 +204,7 @@ export default {
 
 *   **Transport & Cloud Deployments:**
     *   `transport`: Defines the MCP transport protocol. Defaults to `'stdio'` for local CLI usage. Set to `'sse'` to run the server as a cloud-native HTTP microservice (e.g., in a Docker container).
-    *   `ssePort`: The HTTP port for the SSE server (default: `3000`).
+    *   `mcpHttpPort`: The HTTP port for the SSE server (default: `3000`; env var `MCP_HTTP_PORT` per #10808; `SSE_PORT` legacy alias remains readable during deprecation window).
     *   `authMiddleware`: An optional Express middleware function for securing the `/mcp` endpoint when using the `sse` transport.
 
 *   **Scoring Weights (`queryScoreWeights`):**

--- a/learn/agentos/MemoryCore.md
+++ b/learn/agentos/MemoryCore.md
@@ -236,7 +236,7 @@ You can provide a JSON file or an ES Module (`.mjs`) that exports a configuratio
     "debug": true,
     "modelName": "gemini-2.5-pro",
     "transport": "sse",
-    "ssePort": 3001,
+    "mcpHttpPort": 3001,
     "memoryDb": {
         "port": 8005,
         "collectionName": "my-custom-memory"
@@ -245,7 +245,7 @@ You can provide a JSON file or an ES Module (`.mjs`) that exports a configuratio
 ```
 
 This flexibility is crucial for:
-*   **Cloud Deployments:** Switching `transport` to `"sse"` allows the server to run as a microservice in Docker, accepting connections on `ssePort` (default 3001). See the [Deployment Cookbook](DeploymentCookbook.md) for a full shared deployment walkthrough.
+*   **Cloud Deployments:** Switching `transport` to `"sse"` allows the server to run as a microservice in Docker, accepting connections on `mcpHttpPort` (default 3001; env var `MCP_HTTP_PORT` per #10808; `SSE_PORT` legacy alias remains readable during deprecation window). See the [Deployment Cookbook](DeploymentCookbook.md) for a full shared deployment walkthrough.
 *   **Custom Models:** Switching to a different Gemini model version.
 *   **Port Conflicts:** Running multiple instances or avoiding conflicts with other services.
 *   **Environment Specifics:** Adjusting paths for different deployment environments.

--- a/learn/agentos/tooling/Authorization.md
+++ b/learn/agentos/tooling/Authorization.md
@@ -57,7 +57,7 @@ The server intelligently resolves URLs:
    ```bash
    # MCP Server Config
    TRANSPORT=sse
-   SSE_PORT=3000
+   MCP_HTTP_PORT=3000   # legacy alias `SSE_PORT` still works during the #10808 deprecation window
 
    # Auth Config
    AUTH_HOST=localhost
@@ -76,7 +76,7 @@ The server validates incoming `Authorization: Bearer <token>` headers by calling
 `{issuer}/protocol/openid-connect/token/introspect`
 
 ### Audience (aud) Validation
-To prevent token passthrough attacks, the server verifies that the token's audience matches its own public URL (`HOST` + `SSE_PORT`).
+To prevent token passthrough attacks, the server verifies that the token's audience matches its own public URL (`HOST` + `MCP_HTTP_PORT`).
 
 ### CORS Support
 The SSE transport includes CORS middleware by default:

--- a/learn/agentos/tooling/GoogleAuthDemo.md
+++ b/learn/agentos/tooling/GoogleAuthDemo.md
@@ -30,7 +30,7 @@ Google provides a standard OIDC discovery endpoint. This is the easiest way to c
 
 ```bash
 TRANSPORT=sse
-SSE_PORT=3000
+MCP_HTTP_PORT=3000   # legacy alias `SSE_PORT` still works during the #10808 deprecation window
 HOST=mcp.yourdomain.com
 
 # OIDC Discovery

--- a/learn/agentos/tooling/MemoryCoreMcpAuth.md
+++ b/learn/agentos/tooling/MemoryCoreMcpAuth.md
@@ -25,15 +25,17 @@ Both paths end at the same destination: a `RequestContextService.run(context, ..
 
 Operators configure the Memory Core with either an OIDC discovery URL or a Keycloak-style issuer/realm pair. The `AuthService` handles discovery, token introspection, audience enforcement, and extracts `preferred_username` / `sub` as the authoritative `userId`. `TransportService` wraps each `/mcp` HTTP request in `RequestContextService.run()` using the auth context.
 
-Deployment example — Memory Core running behind Keycloak in a multi-tenant cloud environment:
+Deployment example — Memory Core running behind Keycloak in a multi-tenant cloud environment (env vars consumed by `ai/mcp/server/memory-core/config.template.mjs` directly, no per-server prefix translation):
 
 ```
-NEO_MEMORY_CORE_TRANSPORT=sse
-NEO_MEMORY_CORE_MCP_HTTP_PORT=3001  # legacy alias `NEO_MEMORY_CORE_SSE_PORT` still works during the #10808 deprecation window
-NEO_MEMORY_CORE_AUTH_ISSUER_URL=https://auth.example.com/realms/neo/
-NEO_MEMORY_CORE_AUTH_CLIENT_ID=neo-memory-core
-NEO_MEMORY_CORE_AUTH_CLIENT_SECRET=<secret>
+TRANSPORT=sse
+MCP_HTTP_PORT=3001       # legacy alias `SSE_PORT` still works during the #10808 deprecation window
+AUTH_ISSUER_URL=https://auth.example.com/realms/neo/
+OAUTH_CLIENT_ID=neo-memory-core
+OAUTH_CLIENT_SECRET=<secret>
 ```
+
+> **Note on per-server env-var namespacing.** Operators running multiple MCP servers side-by-side (e.g., MC + KB on the same host with distinct configs) typically need a way to disambiguate env vars per server. The Memory Core's `config.template.mjs` consumes the unprefixed forms shown above (`TRANSPORT`, `MCP_HTTP_PORT`, `AUTH_ISSUER_URL`, etc.). To run multiple MCP servers with different ports/issuers from the same shell, scope the env vars at the launcher layer (e.g., per-process `.env` files, `docker-compose` service-scoped `environment:` blocks, or systemd `Environment=` directives). The `NEO_MEMORY_CORE_*` prefixed form is NOT consumed by the substrate — adding that translation layer is tracked as future work if the cross-cutting per-server-prefix pattern proves load-bearing.
 
 Once the server starts, every tool call from a client MUST arrive with `Authorization: Bearer <token>` where the token was issued by the configured issuer AND audience-matches the Memory Core's public URL. Tokens with `aud` claims targeting a different resource are rejected per RFC 9068.
 

--- a/learn/agentos/tooling/MemoryCoreMcpAuth.md
+++ b/learn/agentos/tooling/MemoryCoreMcpAuth.md
@@ -29,7 +29,7 @@ Deployment example — Memory Core running behind Keycloak in a multi-tenant clo
 
 ```
 NEO_MEMORY_CORE_TRANSPORT=sse
-NEO_MEMORY_CORE_SSE_PORT=3001
+NEO_MEMORY_CORE_MCP_HTTP_PORT=3001  # legacy alias `NEO_MEMORY_CORE_SSE_PORT` still works during the #10808 deprecation window
 NEO_MEMORY_CORE_AUTH_ISSUER_URL=https://auth.example.com/realms/neo/
 NEO_MEMORY_CORE_AUTH_CLIENT_ID=neo-memory-core
 NEO_MEMORY_CORE_AUTH_CLIENT_SECRET=<secret>

--- a/test/playwright/unit/ai/mcp/server/shared/helpers/DeploymentConfig.spec.mjs
+++ b/test/playwright/unit/ai/mcp/server/shared/helpers/DeploymentConfig.spec.mjs
@@ -103,4 +103,208 @@ test.describe('DeploymentConfig #10808 — resolveMcpHttpPort', () => {
         })).toBe(3001);
         expect(warnings).toEqual([]);
     });
+
+    test('non-numeric MCP_HTTP_PORT falls back to default with explicit warning (no NaN leak)', () => {
+        const warnings = [];
+
+        expect(resolveMcpHttpPort({
+            env        : {MCP_HTTP_PORT: 'abc'},
+            warn       : message => warnings.push(message),
+            defaultPort: 3001
+        })).toBe(3001);
+        expect(warnings.join('\n')).toMatch(/Invalid MCP_HTTP_PORT value: "abc"/);
+    });
+
+    test('out-of-range port (negative / zero / >65535) rejected with warning', () => {
+        for (const invalidPort of ['0', '-1', '65536', '99999']) {
+            const warnings = [];
+            expect(resolveMcpHttpPort({
+                env        : {MCP_HTTP_PORT: invalidPort},
+                warn       : message => warnings.push(message),
+                defaultPort: 3001
+            })).toBe(3001);
+            expect(warnings.join('\n')).toMatch(/Invalid MCP_HTTP_PORT/);
+        }
+    });
+
+    test('non-integer port (float) rejected with warning', () => {
+        const warnings = [];
+
+        expect(resolveMcpHttpPort({
+            env        : {MCP_HTTP_PORT: '3001.5'},
+            warn       : message => warnings.push(message),
+            defaultPort: 3001
+        })).toBe(3001);
+        expect(warnings.join('\n')).toMatch(/Invalid MCP_HTTP_PORT/);
+    });
+
+    test('invalid SSE_PORT also falls back gracefully + emits scoped warning', () => {
+        const warnings = [];
+
+        expect(resolveMcpHttpPort({
+            env        : {SSE_PORT: 'not-a-port'},
+            warn       : message => warnings.push(message),
+            defaultPort: 3001
+        })).toBe(3001);
+        expect(warnings.join('\n')).toMatch(/Invalid SSE_PORT value: "not-a-port"/);
+    });
+
+    test('invalid MCP_HTTP_PORT but valid SSE_PORT — falls through to legacy with deprecation warning', () => {
+        const warnings = [];
+
+        expect(resolveMcpHttpPort({
+            env        : {MCP_HTTP_PORT: 'abc', SSE_PORT: '4001'},
+            warn       : message => warnings.push(message),
+            defaultPort: 3001
+        })).toBe(4001);
+        expect(warnings.join('\n')).toMatch(/Invalid MCP_HTTP_PORT/);
+        expect(warnings.join('\n')).toMatch(/SSE_PORT is deprecated/);
+    });
+});
+
+/**
+ * @summary Coverage for #10808 `resolveChromaHost` / `resolveChromaPort` helpers.
+ *
+ * Pins the AC2 Chroma host/port resolution contract from the #10808 Contract Ledger.
+ * Pure-function tests; no config-template dynamic import (would trigger
+ * `Namespace collision in unitTestMode` due to `Neo.setupClass` global registration
+ * from re-imports). Same testable-pure-helper pattern as `resolveMcpHttpPort` above.
+ *
+ * @see Neo.ai.mcp.server.shared.helpers.DeploymentConfig#resolveChromaHost
+ * @see Neo.ai.mcp.server.shared.helpers.DeploymentConfig#resolveChromaPort
+ */
+test.describe('DeploymentConfig #10808 — resolveChromaHost', () => {
+    let resolveChromaHost;
+
+    test.beforeAll(async () => {
+        const mod = await import('../../../../../../../../ai/mcp/server/shared/helpers/DeploymentConfig.mjs');
+        resolveChromaHost = mod.resolveChromaHost;
+    });
+
+    test('returns defaultHost when no env var is set', () => {
+        expect(resolveChromaHost({env: {}})).toBe('localhost');
+    });
+
+    test('NEO_CHROMA_HOST consumed when set', () => {
+        expect(resolveChromaHost({
+            env: {NEO_CHROMA_HOST: 'team-chroma.example.com'}
+        })).toBe('team-chroma.example.com');
+    });
+
+    test('legacy env-var consulted when NEO_CHROMA_HOST unset (MC engines.kb.chroma fallback)', () => {
+        expect(resolveChromaHost({
+            env         : {NEO_KB_CHROMA_HOST: 'legacy-only.example.com'},
+            legacyEnvVar: 'NEO_KB_CHROMA_HOST'
+        })).toBe('legacy-only.example.com');
+    });
+
+    test('NEO_CHROMA_HOST wins over legacy env var when both set (precedence)', () => {
+        expect(resolveChromaHost({
+            env: {
+                NEO_CHROMA_HOST   : 'unified.example.com',
+                NEO_KB_CHROMA_HOST: 'legacy.example.com'
+            },
+            legacyEnvVar: 'NEO_KB_CHROMA_HOST'
+        })).toBe('unified.example.com');
+    });
+
+    test('legacyEnvVar omitted by KB-own-config callsite — no fallback layer', () => {
+        // KB config.template.mjs calls resolveChromaHost() with no legacyEnvVar.
+        // NEO_KB_CHROMA_HOST should be ignored even if set (it's MC-side legacy).
+        expect(resolveChromaHost({
+            env: {NEO_KB_CHROMA_HOST: 'should-be-ignored.example.com'}
+        })).toBe('localhost');
+    });
+
+    test('empty-string env values treated as unset (consistent with resolveMcpHttpPort)', () => {
+        expect(resolveChromaHost({
+            env         : {NEO_CHROMA_HOST: '', NEO_KB_CHROMA_HOST: ''},
+            legacyEnvVar: 'NEO_KB_CHROMA_HOST'
+        })).toBe('localhost');
+    });
+
+    test('custom defaultHost honored when provided', () => {
+        expect(resolveChromaHost({
+            env        : {},
+            defaultHost: 'chroma-internal.svc.cluster.local'
+        })).toBe('chroma-internal.svc.cluster.local');
+    });
+});
+
+test.describe('DeploymentConfig #10808 — resolveChromaPort', () => {
+    let resolveChromaPort;
+
+    test.beforeAll(async () => {
+        const mod = await import('../../../../../../../../ai/mcp/server/shared/helpers/DeploymentConfig.mjs');
+        resolveChromaPort = mod.resolveChromaPort;
+    });
+
+    test('returns defaultPort (8000) when no env var is set', () => {
+        const warnings = [];
+        expect(resolveChromaPort({
+            env : {},
+            warn: m => warnings.push(m)
+        })).toBe(8000);
+        expect(warnings).toEqual([]);
+    });
+
+    test('NEO_CHROMA_PORT consumed when set (valid integer)', () => {
+        expect(resolveChromaPort({
+            env: {NEO_CHROMA_PORT: '9000'}
+        })).toBe(9000);
+    });
+
+    test('legacy env-var consulted when NEO_CHROMA_PORT unset (MC engines.kb.chroma fallback)', () => {
+        expect(resolveChromaPort({
+            env         : {NEO_KB_CHROMA_PORT: '8500'},
+            legacyEnvVar: 'NEO_KB_CHROMA_PORT'
+        })).toBe(8500);
+    });
+
+    test('NEO_CHROMA_PORT wins over legacy env var (precedence)', () => {
+        expect(resolveChromaPort({
+            env: {
+                NEO_CHROMA_PORT   : '9000',
+                NEO_KB_CHROMA_PORT: '8500'
+            },
+            legacyEnvVar: 'NEO_KB_CHROMA_PORT'
+        })).toBe(9000);
+    });
+
+    test('non-numeric NEO_CHROMA_PORT falls back with warning (no NaN leak)', () => {
+        const warnings = [];
+        expect(resolveChromaPort({
+            env : {NEO_CHROMA_PORT: 'abc'},
+            warn: m => warnings.push(m)
+        })).toBe(8000);
+        expect(warnings.join('\n')).toMatch(/Invalid NEO_CHROMA_PORT value: "abc"/);
+    });
+
+    test('out-of-range port (negative / zero / >65535) rejected with warning', () => {
+        for (const invalid of ['0', '-1', '65536']) {
+            const warnings = [];
+            expect(resolveChromaPort({
+                env : {NEO_CHROMA_PORT: invalid},
+                warn: m => warnings.push(m)
+            })).toBe(8000);
+            expect(warnings.join('\n')).toMatch(/Invalid NEO_CHROMA_PORT/);
+        }
+    });
+
+    test('invalid NEO_CHROMA_PORT but valid legacy NEO_KB_CHROMA_PORT — falls through cleanly', () => {
+        const warnings = [];
+        expect(resolveChromaPort({
+            env         : {NEO_CHROMA_PORT: 'abc', NEO_KB_CHROMA_PORT: '8500'},
+            warn        : m => warnings.push(m),
+            legacyEnvVar: 'NEO_KB_CHROMA_PORT'
+        })).toBe(8500);
+        expect(warnings.join('\n')).toMatch(/Invalid NEO_CHROMA_PORT/);
+    });
+
+    test('custom defaultPort honored when provided', () => {
+        expect(resolveChromaPort({
+            env        : {},
+            defaultPort: 9001
+        })).toBe(9001);
+    });
 });

--- a/test/playwright/unit/ai/mcp/server/shared/helpers/DeploymentConfig.spec.mjs
+++ b/test/playwright/unit/ai/mcp/server/shared/helpers/DeploymentConfig.spec.mjs
@@ -1,0 +1,106 @@
+import {setup} from '../../../../../../setup.mjs';
+
+const appName = 'DeploymentConfigTest';
+
+setup({
+    neoConfig: {
+        unitTestMode: true
+    },
+    appConfig: {
+        name             : appName,
+        isMounted        : () => true,
+        vnodeInitialising: false
+    }
+});
+
+import {test, expect} from '@playwright/test';
+import Neo            from '../../../../../../../../src/Neo.mjs';
+import * as core      from '../../../../../../../../src/core/_export.mjs';
+
+/**
+ * @summary Coverage for #10808 MCP HTTP port resolver (`resolveMcpHttpPort`).
+ *
+ * Pins the soft-rename contract: `MCP_HTTP_PORT` is the canonical operator-facing env var;
+ * `SSE_PORT` remains readable during the deprecation window with a warning when both are set
+ * with different values. Pattern mirrors the #10810 `resolveEmbeddingProvider` testable-pure-helper
+ * extraction (`ai/mcp/server/memory-core/helpers/EmbeddingProviderConfig.mjs`).
+ *
+ * @see Neo.ai.mcp.server.shared.helpers.DeploymentConfig#resolveMcpHttpPort
+ */
+test.describe('DeploymentConfig #10808 — resolveMcpHttpPort', () => {
+    let resolveMcpHttpPort;
+
+    test.beforeAll(async () => {
+        const mod = await import('../../../../../../../../ai/mcp/server/shared/helpers/DeploymentConfig.mjs');
+        resolveMcpHttpPort = mod.resolveMcpHttpPort;
+    });
+
+    test('returns defaultPort when neither env var is set', () => {
+        const warnings = [];
+
+        expect(resolveMcpHttpPort({
+            env        : {},
+            warn       : message => warnings.push(message),
+            defaultPort: 3001
+        })).toBe(3001);
+        expect(warnings).toEqual([]);
+    });
+
+    test('returns MCP_HTTP_PORT when only the new env var is set (no warning)', () => {
+        const warnings = [];
+
+        expect(resolveMcpHttpPort({
+            env        : {MCP_HTTP_PORT: '4001'},
+            warn       : message => warnings.push(message),
+            defaultPort: 3001
+        })).toBe(4001);
+        expect(warnings).toEqual([]);
+    });
+
+    test('returns SSE_PORT with deprecation warning when only legacy env var is set (backwards-compat)', () => {
+        const warnings = [];
+
+        expect(resolveMcpHttpPort({
+            env        : {SSE_PORT: '5555'},
+            warn       : message => warnings.push(message),
+            defaultPort: 3001
+        })).toBe(5555);
+        expect(warnings.join('\n')).toMatch(/SSE_PORT is deprecated/);
+        expect(warnings.join('\n')).not.toMatch(/conflicts/);
+    });
+
+    test('MCP_HTTP_PORT wins over SSE_PORT when both set with different values + emits conflict warning', () => {
+        const warnings = [];
+
+        expect(resolveMcpHttpPort({
+            env        : {MCP_HTTP_PORT: '4001', SSE_PORT: '5555'},
+            warn       : message => warnings.push(message),
+            defaultPort: 3001
+        })).toBe(4001);
+        expect(warnings.join('\n')).toMatch(/SSE_PORT is deprecated and conflicts with MCP_HTTP_PORT/);
+        expect(warnings.join('\n')).toMatch(/using 4001/);
+    });
+
+    test('both env vars set with same value — no conflict warning, just deprecation', () => {
+        const warnings = [];
+
+        expect(resolveMcpHttpPort({
+            env        : {MCP_HTTP_PORT: '4001', SSE_PORT: '4001'},
+            warn       : message => warnings.push(message),
+            defaultPort: 3001
+        })).toBe(4001);
+        expect(warnings.join('\n')).toMatch(/SSE_PORT is deprecated/);
+        expect(warnings.join('\n')).not.toMatch(/conflicts/);
+    });
+
+    test('empty-string env values treated as unset (not "0" port)', () => {
+        const warnings = [];
+
+        expect(resolveMcpHttpPort({
+            env        : {MCP_HTTP_PORT: '', SSE_PORT: ''},
+            warn       : message => warnings.push(message),
+            defaultPort: 3001
+        })).toBe(3001);
+        expect(warnings).toEqual([]);
+    });
+});

--- a/test/playwright/unit/ai/mcp/server/shared/services/TransportService.spec.mjs
+++ b/test/playwright/unit/ai/mcp/server/shared/services/TransportService.spec.mjs
@@ -36,7 +36,7 @@ test.describe('Neo.ai.mcp.server.shared.services.TransportService', () => {
         };
 
         const testPort = 3125;
-        const mockAiConfig = { ssePort: testPort, auth: {} };
+        const mockAiConfig = { mcpHttpPort: testPort, auth: {} };
         const mockLogger = { info: () => {} };
 
         // Setup the real transport service which starts the Express app


### PR DESCRIPTION
Authored by Claude Opus 4.7 (Claude Code). Session 34c8f800-1855-43ff-aea6-d5e6b9410978.

Resolves #10808

Renames `SSE_PORT` env var to `MCP_HTTP_PORT` (transport-mechanism-agnostic, intent-clear for operators provisioning containers) and wires `NEO_CHROMA_HOST` / `NEO_CHROMA_PORT` as env-overridable across both KB and MC config templates. Soft-rename pattern preserves backwards-compat: legacy env vars remain readable during the deprecation window with warnings on conflict.

Closes the gap between [PR #10806](https://github.com/neomjs/neo/pull/10806) cookbook Section 6 (forward-looking env-var names referenced ahead of substrate wiring) and the actual substrate. Per @tobiu's calibration earlier today: *"our env var names are not set in stone, except for the github and gemini ones"*.

Evidence: L2 (3 pure resolvers — port + Chroma host + Chroma port — covered by 26 unit tests + node --check across touched files) → L2 required by [#10808](https://github.com/neomjs/neo/issues/10808) ACs. No residuals after cycle-2 polish.

## Implementation

- **`ai/mcp/server/shared/helpers/DeploymentConfig.mjs`** (new): pure `resolveMcpHttpPort({env, warn, defaultPort})` helper. Pattern explicitly mirrors `EmbeddingProviderConfig.mjs` from [PR #10810](https://github.com/neomjs/neo/pull/10810) — testable without singleton, mocked env + warn sinks in unit tests, no deprecation-warning leakage to production paths.
- **`knowledge-base/config.template.mjs`**: `ssePort` → `mcpHttpPort` consuming the resolver; KB Chroma `host` / `port` now read `NEO_CHROMA_HOST` / `NEO_CHROMA_PORT` (currently hardcoded `localhost:8000` per ticket Architectural Reality).
- **`memory-core/config.template.mjs`**: `ssePort` → `mcpHttpPort`; `engines.kb.chroma.{host, port}` fallback chain prefers `NEO_CHROMA_HOST/PORT` → `NEO_KB_CHROMA_HOST/PORT` legacy → `localhost:8000`. Cookbook Section 5 prescribes single env var (`NEO_CHROMA_HOST`) for the shared-Chroma topology — both KB + MC pick it up.
- **Consumers updated**: `TransportService.mjs` (2 usages — SSE port binding + URL composition), JSDoc in both KB + MC `Server.mjs`.

## Test Evidence

```
$ npx playwright test test/playwright/unit/ai/mcp/server/shared/helpers/DeploymentConfig.spec.mjs --reporter=line
Running 26 tests using 1 worker
…
  26 passed (1.1s)
```

**Coverage matrix across the three pure resolvers in `DeploymentConfig.mjs`:**

`resolveMcpHttpPort` (10 tests):
1. Default fallback (neither env var set)
2. `MCP_HTTP_PORT`-only (no warning)
3. `SSE_PORT`-only legacy fallback with deprecation warning
4. Both-set-conflict (`MCP_HTTP_PORT` wins + conflict warning)
5. Both-set-same-value (deprecation warning, no conflict)
6. Empty-string treated as unset
7. Non-numeric value (`abc`) → fallback with explicit warning (NaN-leak prevention per cycle-2 RA3)
8. Out-of-range port (`0`, `-1`, `65536`) rejected with warning (table-driven)
9. Non-integer (float) rejected with warning
10. Invalid `MCP_HTTP_PORT` + valid `SSE_PORT` → falls through to legacy with double-warning

`resolveChromaHost` (7 tests, added cycle-2 RA4):
1. Default `localhost` when no env var set
2. `NEO_CHROMA_HOST` consumed when set
3. Legacy `NEO_KB_CHROMA_HOST` consulted when `NEO_CHROMA_HOST` unset
4. `NEO_CHROMA_HOST` precedence over legacy
5. KB-callsite isolation (no `legacyEnvVar` arg → ignores `NEO_KB_CHROMA_HOST`)
6. Empty-string parity with `resolveMcpHttpPort`
7. Custom `defaultHost` honored

`resolveChromaPort` (8 tests, added cycle-2 RA4):
1. Default `8000` when no env var set
2. Valid integer consumed
3. Legacy `NEO_KB_CHROMA_PORT` fallback
4. `NEO_CHROMA_PORT` precedence over legacy
5. Non-numeric → fallback with warning (NaN-leak prevention)
6. Out-of-range rejection (table-driven)
7. Invalid new + valid legacy → cleanly fallthrough
8. Custom `defaultPort` honored

Plus `TransportService.spec.mjs` mock fixture updated (`ssePort` → `mcpHttpPort`). `Authorization.spec.mjs` deliberately left unchanged — its `SSE_PORT=...` env block still works via the resolver fallback, providing empirical backwards-compat proof at the integration level.

`node --check` passes on all modified `.mjs` files + the helper.

## Deltas from ticket

- Helper file lives at `ai/mcp/server/shared/helpers/` (new directory) rather than per-server `helpers/`. Reason: `SSE_PORT`/`MCP_HTTP_PORT` is shared between KB + MC; the new directory is the right substrate location for cross-server config helpers (mirrors the existing `ai/mcp/server/shared/services/` pattern).
- `engines.kb.chroma` (MC) fallback chain handles 3-deep precedence (`NEO_CHROMA_HOST` → `NEO_KB_CHROMA_HOST` → default) rather than the 2-deep chain originally hinted at in the Ledger; chosen because operators use a single env var per cookbook Section 5, but existing deployments may have `NEO_KB_CHROMA_HOST` set.

## Slot Rationale

`learn/agentos/**` paths touched (5 doc files) — substrate-mutation per `pull-request-workflow §1.1`.

| File | Disposition | 3-axis (trigger × severity × enforceability) | Decay mitigation |
|---|---|---|---|
| `DeploymentCookbook.md` Section 6 footnote | `keep` → `keep` | medium / high / medium | Footnote ratifies #10808 shipping; deprecation language tied to one window |
| `MemoryCore.md` config example + cloud-deployment narrative | `keep` → `keep` | medium / high / medium | `mcpHttpPort` field + `MCP_HTTP_PORT` env var named with `SSE_PORT` legacy-alias note |
| `KnowledgeBase.md` `mcpHttpPort` field reference | `keep` → `keep` | medium / high / medium | Same legacy-alias deprecation window note |
| `tooling/{Authorization,GoogleAuthDemo}.md` operator config examples | `keep` → `keep` | low (operator setup-time) / medium / medium | `MCP_HTTP_PORT=N   # legacy alias 'SSE_PORT' still works during the #10808 deprecation window` |
| `tooling/MemoryCoreMcpAuth.md` Keycloak deployment example | `keep` → `keep` | low / medium / medium | Replaced prefixed `NEO_MEMORY_CORE_*` example with the actual unprefixed env vars the substrate consumes (`TRANSPORT`, `MCP_HTTP_PORT`, `AUTH_ISSUER_URL`, `OAUTH_CLIENT_ID`, `OAUTH_CLIENT_SECRET`) per cycle-2 RA2; added operator note about per-server env-var namespacing patterns (launcher-layer `.env` / `docker-compose` / `systemd`); per-server-prefix substrate translation flagged as future work if the cross-cutting pattern proves load-bearing |

## Post-Merge Validation

- [ ] **Operator gitignored config.mjs migration:** Active local `config.mjs` files using `ssePort` field need migration to `mcpHttpPort` (or rely on resolver fallback to legacy `SSE_PORT` env var, which surfaces a deprecation warning in logs). Same migration shape as [#10810](https://github.com/neomjs/neo/issues/10810) post-merge — A2A broadcast to swarm peers + operator's canonical deployment will need the standard 3-edit migration recipe (add helper import + rename field + update consumers).
- [ ] **Verify `bootstrapWorktree.mjs` doesn't regress** on fresh worktree boots (config.mjs copy from canonical should pick up new template shape).
- [ ] **Verify legacy `SSE_PORT` deployments still work** post-merge with deprecation warning (covered by `Authorization.spec.mjs` integration-style test).

## Coordination Notes

- Sibling parallel-track work in flight: [#10802](https://github.com/neomjs/neo/issues/10802) (public canonical URL — Gemini's Lane B-1) + [#10803](https://github.com/neomjs/neo/issues/10803) (reverse proxy reference — Gemini's Lane B-2) + [#10805](https://github.com/neomjs/neo/issues/10805) (integration test harness — GPT's Lane C). When [#10802](https://github.com/neomjs/neo/issues/10802) lands, its `aiConfig.publicUrl` may benefit from `MCP_HTTP_PORT` for URL composition (no conflict; both are env-overridable).
- Cookbook Section 5 (`NEO_CHROMA_HOST=http://chroma`, `NEO_CHROMA_PORT=8000`) example is now substrate-backed.

## Cross-Family Review Routing

Per `pull-request-workflow §6.2` — primary-reviewer routing: [@neo-gpt](https://github.com/neo-gpt). Round-robin: my last cross-family review on [PR #10806](https://github.com/neomjs/neo/pull/10806) Cycle 2 + [PR #10811](https://github.com/neomjs/neo/pull/10811) routed to Gemini; rotation says GPT next. Bonus subsystem-familiarity: this PR's `resolveMcpHttpPort` helper deliberately mirrors GPT's `resolveEmbeddingProvider` extraction pattern from #10810 — he'll recognize the shape instantly.

24h SLA per workflow §6.2.2.
