### PR TITLE
feat(ai): primary-flag gate for session summarization (#10813)

### DIFF
--- a/ai/mcp/server/memory-core/config.template.mjs
+++ b/ai/mcp/server/memory-core/config.template.mjs
@@ -32,6 +32,27 @@ const defaultConfig = {
      */
     autoSummarize: process.env.AUTO_SUMMARIZE === 'true',
     /**
+     * Single-writer enforcement flag for the canonical Memory Core instance (#10813).
+     *
+     * Multi-harness deployments (Claude Code worktrees + Antigravity + Codex Desktop +
+     * per-workspace language servers) routinely spawn multiple MC instances that share
+     * the same Chroma collection. To avoid race conditions on cross-process operations
+     * like session summarization, operators set `NEO_MC_PRIMARY=true` on the canonical
+     * instance only. Other instances skip startup-summarization and queue-processing.
+     *
+     * Pairs with `autoSummarize`: BOTH must be true for the existing AUTO_SUMMARIZE
+     * startup drift-detection path to fire. Either condition false → skip (safe default).
+     * The SessionService logs an operator-visible warning when `autoSummarize=true`
+     * but `isPrimary=false`, since that combination usually indicates a config-anomaly.
+     *
+     * Default `false`: the multi-instance deployment is the harness norm; the canonical
+     * instance opts in explicitly. Originally gated globally via #9942 (daemon-collision
+     * fix); this flag restores the path on a per-instance basis without re-introducing
+     * the original race.
+     * @type {boolean}
+     */
+    isPrimary: process.env.NEO_MC_PRIMARY === 'true',
+    /**
      * Automatically start the local database process (Chroma/SQLite) on startup.
      * @type {boolean}
      */

--- a/ai/mcp/server/memory-core/services/HealthService.mjs
+++ b/ai/mcp/server/memory-core/services/HealthService.mjs
@@ -361,7 +361,11 @@ class HealthService extends Base {
     /**
      * Tracks whether startup summarization has been attempted.
      * This helps agents understand if they need to manually trigger summarization.
-     * Values: 'pending', 'completed', 'failed', 'skipped', null (if not yet attempted)
+     * Values: 'pending', 'completed', 'failed', 'skipped', 'skipped-non-primary', null (if not yet attempted).
+     * `'skipped-non-primary'` is emitted when `AUTO_SUMMARIZE=true` but `NEO_MC_PRIMARY=false`
+     * on the current instance — single-writer enforcement per #10813. Distinct from the generic
+     * `'skipped'` (which today covers missing-API-key and similar precondition failures) so agents
+     * can grep the healthcheck for the specific topology condition.
      * @member {string|null} #startupSummarizationStatus
      * @private
      */
@@ -883,7 +887,9 @@ class HealthService extends Base {
     /**
      * Records the result of startup summarization attempt.
      * Called by the startup sequence in mcp-server.mjs
-     * @param {string} status  One of: 'completed', 'failed', 'skipped'
+     * @param {string} status  One of: 'completed', 'failed', 'skipped', 'skipped-non-primary'.
+     *     `'skipped-non-primary'` is emitted when `AUTO_SUMMARIZE=true` but `NEO_MC_PRIMARY=false`
+     *     on the current instance (#10813 single-writer enforcement).
      * @param {Object} details Additional information about the summarization
      */
     recordStartupSummarization(status, details=null) {

--- a/ai/mcp/server/memory-core/services/SessionService.mjs
+++ b/ai/mcp/server/memory-core/services/SessionService.mjs
@@ -160,7 +160,7 @@ class SessionService extends Base {
             return;
         }
 
-        if (aiConfig.data.autoSummarize) {
+        if (aiConfig.data.autoSummarize && aiConfig.data.isPrimary) {
             logger.info('[Startup] Checking for unsummarized sessions...');
 
             this.summarizeSessions({}).then(result => {
@@ -182,6 +182,9 @@ class SessionService extends Base {
                 logger.warn('    You can manually trigger summarization using the summarize_sessions tool');
                 HealthService.recordStartupSummarization('failed', { error: error.message });
             });
+        } else if (aiConfig.data.autoSummarize && !aiConfig.data.isPrimary) {
+            logger.info('[Startup] AUTO_SUMMARIZE enabled but NEO_MC_PRIMARY=false — skipping (single-writer enforcement, #10813). Set NEO_MC_PRIMARY=true on the canonical Memory Core instance only.');
+            HealthService.recordStartupSummarization('skipped-non-primary', { reason: 'NEO_MC_PRIMARY is not set on this instance' });
         }
     }
 
@@ -658,10 +661,17 @@ ${aggregatedContent}
      * Queues a session for summarization by writing a 'pending' marker
      * to the SummarizationJobs table and triggering the asynchronous detector.
      * @summary Wires disconnected SSE session state to the summarization pipeline.
+     *
+     * Gated on both `autoSummarize` and `isPrimary` (#10813): only the canonical
+     * Memory Core instance writes to the shared SummarizationJobs table on
+     * disconnect-lifecycle events, preventing race conditions across the multi-MC-instance
+     * harness fleet. Non-primary instances no-op silently — their disconnect events are
+     * absorbed by the canonical instance's existing drift-detection sweep.
+     *
      * @param {String} sessionId
      */
     queueSummarizationJob(sessionId) {
-        if (!aiConfig.autoSummarize) return;
+        if (!aiConfig.autoSummarize || !aiConfig.isPrimary) return;
 
         const db = GraphService.db?.storage?.db;
         if (!db) return;

--- a/learn/agentos/DeploymentCookbook.md
+++ b/learn/agentos/DeploymentCookbook.md
@@ -88,8 +88,10 @@ When provisioning your containers, supply the following minimal environment vari
 | `NEO_PUBLIC_URL` | Both | The canonical public URL for this MCP server (e.g., `https://api.example.com/mc`). Required for SSE advertisement and OAuth `redirect_uri` generation behind reverse proxies. |
 | `AUTH_TRUST_PROXY_IDENTITY` | Both | Set to `true` if your reverse proxy handles authentication. |
 | `GEMINI_API_KEY` | Both | Required for Gemini integration. |
+| `AUTO_SUMMARIZE` | MC | Set to `true` to enable startup + disconnect-driven session summarization. Pairs with `NEO_MC_PRIMARY` — both flags must be `true` for the path to fire (single-writer enforcement, [#10813](https://github.com/neomjs/neo/issues/10813)). |
+| `NEO_MC_PRIMARY` | MC | Set to `true` on the **canonical** Memory Core instance only. In multi-harness deployments where several MC instances share the same Chroma collection, this flag designates the single writer for session summarization; non-primary instances skip startup-summarization and disconnect-queueing to avoid races. |
 
-*(Notes: Public URL advertising is tracked under [#10802](https://github.com/neomjs/neo/issues/10802). Provider consolidation shipped in [PR #10810](https://github.com/neomjs/neo/pull/10810) — `embeddingProvider` is now the canonical selector. Env-var ergonomics shipped in [#10808](https://github.com/neomjs/neo/issues/10808): `MCP_HTTP_PORT` is the canonical operator-facing env var (`SSE_PORT` remains readable during the deprecation window with a warning); `NEO_CHROMA_HOST` / `NEO_CHROMA_PORT` are now env-overridable on both KB + MC.)*
+*(Notes: Public URL advertising is tracked under [#10802](https://github.com/neomjs/neo/issues/10802). Provider consolidation shipped in [PR #10810](https://github.com/neomjs/neo/pull/10810) — `embeddingProvider` is now the canonical selector. Env-var ergonomics shipped in [#10808](https://github.com/neomjs/neo/issues/10808): `MCP_HTTP_PORT` is the canonical operator-facing env var (`SSE_PORT` remains readable during the deprecation window with a warning); `NEO_CHROMA_HOST` / `NEO_CHROMA_PORT` are now env-overridable on both KB + MC. Session-summary single-writer flag `NEO_MC_PRIMARY` shipped in [#10813](https://github.com/neomjs/neo/issues/10813) — Piece A of the A+B+C summary-restoration architecture.)*
 
 ## Section 7: Healthcheck Verification
 

--- a/learn/agentos/MemoryCore.md
+++ b/learn/agentos/MemoryCore.md
@@ -47,6 +47,20 @@ When the server starts, the `SessionService` automatically scans for previous se
 
 This means the agent starts every new session with an indexed "Recap" of its past work, ready to pick up where it left off.
 
+### Single-Writer Enforcement: `NEO_MC_PRIMARY`
+
+In multi-harness deployments (Claude Code worktrees + Antigravity + Codex Desktop + per-workspace language servers), several Memory Core instances may share the same Chroma collection. To prevent races on session summarization, the startup auto-discovery path is gated by **two** flags rather than one:
+
+| `AUTO_SUMMARIZE` | `NEO_MC_PRIMARY` | Behavior on startup |
+|---|---|---|
+| `false` | (any) | Skip — current default; no summarization at boot. |
+| `true` | `false` (default) | Skip with operator-visible log; healthcheck reports `startup.summarizationStatus: "skipped-non-primary"`. |
+| `true` | `true` | Fire — drift-detection sweep runs on this instance only. |
+
+Operators set `NEO_MC_PRIMARY=true` on the **canonical** Memory Core instance only (typically the one bound to the operator's primary harness). Non-primary instances stay quiet and rely on the canonical instance to handle the shared collection. The same gate applies to disconnect-triggered `queueSummarizationJob` calls, so non-primary instances do not write to the shared `SummarizationJobs` SQLite table either.
+
+The two flags are deliberately AND-ed (not OR-ed): forgetting `NEO_MC_PRIMARY` while having `AUTO_SUMMARIZE=true` is the safe default — non-primary instances do nothing rather than racing the canonical one. Tracked under [#10813](https://github.com/neomjs/neo/issues/10813).
+
 ## Tools
 
 The server exposes a suite of tools via the Model Context Protocol (MCP).

--- a/learn/agentos/SharedDeployment.md
+++ b/learn/agentos/SharedDeployment.md
@@ -267,9 +267,9 @@ Use `configured` as the at-a-glance indicator. A misconfigured `AUTH_TRUST_PROXY
 
 In a shared deployment, multiple agents connect and disconnect dynamically. To ensure session summaries are automatically available to the team without requiring manual API calls or external cron jobs, the Memory Core leverages a **disconnect-triggered summarization** primitive.
 
-When an MCP client (agent) disconnects from the Server-Sent Events (SSE) transport, the `TransportService` intercepts the termination and signals the Memory Core. The server immediately queues a `pending` summarization marker in its `SummarizationJobs` SQLite coordinator table. This behavior is gated by the `autoSummarize` feature flag, making it a conditional feature rather than an unconditional contract.
+When an MCP client (agent) disconnects from the Server-Sent Events (SSE) transport, the `TransportService` intercepts the termination and signals the Memory Core. The server immediately queues a `pending` summarization marker in its `SummarizationJobs` SQLite coordinator table. This behavior is gated by **both** the `autoSummarize` feature flag **and** the `isPrimary` flag (`NEO_MC_PRIMARY=true`); single-writer enforcement per [#10813](https://github.com/neomjs/neo/issues/10813) prevents races across multi-instance harness fleets that share the same Chroma collection.
 
-This allows the heavy LLM summarization process to run asynchronously in the background. Because it relies on the unified `SummarizationJobs` table, it naturally handles concurrent agent disconnects and server clustering without duplicating summaries. Team members can query the Memory Core and instantly access the completed session context once the background job finishes.
+This allows the heavy LLM summarization process to run asynchronously in the background. Because it relies on the unified `SummarizationJobs` table, it naturally handles concurrent agent disconnects and server clustering without duplicating summaries. Team members can query the Memory Core and instantly access the completed session context once the background job finishes. Non-primary instances (`NEO_MC_PRIMARY` unset / `false`) do not queue jobs — the canonical instance handles the shared collection.
 
 ## Migration: Per-Developer Local → Shared Team Mode
 

--- a/test/playwright/unit/ai/mcp/server/memory-core/services/SessionService.PrimaryFlagGate.spec.mjs
+++ b/test/playwright/unit/ai/mcp/server/memory-core/services/SessionService.PrimaryFlagGate.spec.mjs
@@ -1,0 +1,137 @@
+import {setup} from '../../../../../../setup.mjs';
+
+const appName = 'MemoryCorePrimaryFlagGateTest';
+
+process.env.MODEL_PROVIDER          = 'openAiCompatible';
+process.env.OPENAI_COMPATIBLE_MODEL = 'gemma4';
+
+setup({
+    neoConfig: {
+        allowVdomUpdatesInTests: false,
+        unitTestMode           : true,
+        useDomApiRenderer      : false
+    },
+    appConfig: {
+        name             : appName,
+        isMounted        : () => true,
+        vnodeInitialising: false
+    }
+});
+
+import {test, expect}  from '@playwright/test';
+import Neo             from '../../../../../../../../src/Neo.mjs';
+import * as core       from '../../../../../../../../src/core/_export.mjs';
+import path            from 'path';
+import {fileURLToPath} from 'url';
+import dotenv          from 'dotenv';
+import crypto          from 'crypto';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname  = path.dirname(__filename);
+dotenv.config({path: path.resolve(__dirname, '../../../../../../../../.env'), quiet: true});
+
+/**
+ * @summary Coverage for the `NEO_MC_PRIMARY` single-writer-enforcement gate (#10813 Piece A).
+ *
+ * Exercises `queueSummarizationJob` against the truth table of `(autoSummarize × isPrimary)`:
+ * the existing SQLite-backed disconnect-lifecycle queue is the integration surface where the
+ * gate is most directly observable. The startup-hook gate at `initAsync` is harder to assert
+ * post-hoc on a singleton service; that path is covered indirectly via the same conditional
+ * logic and via the docstring on `HealthService.recordStartupSummarization` ("skipped-non-primary").
+ */
+test.describe('SessionService.queueSummarizationJob primary-flag gate (#10813)', () => {
+    let SDK, TextEmbeddingService, sqlite, originalAutoSummarize, originalIsPrimary;
+
+    test.beforeAll(async () => {
+        const fs = await import('fs');
+
+        const aiConfig = (await import('../../../../../../../../ai/mcp/server/memory-core/config.mjs')).default;
+
+        const tmpDir = path.resolve(process.cwd(), 'tmp');
+        if (!fs.existsSync(tmpDir)) {
+            fs.mkdirSync(tmpDir, {recursive: true});
+        }
+
+        aiConfig.collections.memory  = `test-memory-${process.pid}-${Date.now()}`;
+        aiConfig.collections.session = `test-session-${process.pid}-${Date.now()}`;
+
+        SDK                  = await import('../../../../../../../../ai/services.mjs');
+        TextEmbeddingService = (await import('../../../../../../../../ai/mcp/server/memory-core/services/TextEmbeddingService.mjs')).default;
+
+        SDK.Memory_Config.data.modelProvider     = 'openAiCompatible';
+        SDK.Memory_Config.data.embeddingProvider = 'openAiCompatible';
+
+        TextEmbeddingService.embedText = async () => new Array(4096).fill(Math.random());
+
+        if (!SDK.Memory_LifecycleService._initPromise) {
+            await SDK.Memory_LifecycleService.initAsync();
+        } else {
+            await SDK.Memory_LifecycleService.ready();
+        }
+        await SDK.Memory_SessionService.ready();
+        await SDK.Memory_ChromaManager.ready();
+
+        const GraphService = (await import('../../../../../../../../ai/mcp/server/memory-core/services/GraphService.mjs')).default;
+        await GraphService.ready();
+        sqlite = GraphService.db?.storage?.db;
+    });
+
+    test.afterAll(async () => {
+        try {
+            if (SDK.Memory_ChromaManager && SDK.Memory_ChromaManager.client) {
+                await SDK.Memory_ChromaManager.client.deleteCollection({name: SDK.Memory_Config.data.collections.memory});
+                await SDK.Memory_ChromaManager.client.deleteCollection({name: SDK.Memory_Config.data.collections.session});
+            }
+        } catch (e) {}
+
+        if (SDK?.Memory_LifecycleService) {
+            SDK.Memory_LifecycleService._initPromise = null;
+        }
+    });
+
+    test.beforeEach(() => {
+        originalAutoSummarize = SDK.Memory_Config.data.autoSummarize;
+        originalIsPrimary     = SDK.Memory_Config.data.isPrimary;
+    });
+
+    test.afterEach(() => {
+        SDK.Memory_Config.data.autoSummarize = originalAutoSummarize;
+        SDK.Memory_Config.data.isPrimary     = originalIsPrimary;
+    });
+
+    test('writes a pending job when autoSummarize=true AND isPrimary=true', () => {
+        SDK.Memory_Config.data.autoSummarize = true;
+        SDK.Memory_Config.data.isPrimary     = true;
+
+        const sessionId = `gate-pass-${crypto.randomUUID()}`;
+        SDK.Memory_SessionService.queueSummarizationJob(sessionId);
+
+        const job = sqlite.prepare('SELECT session_id, status FROM SummarizationJobs WHERE session_id = ?').get(sessionId);
+        expect(job).toBeDefined();
+        expect(job.status).toBe('pending');
+
+        sqlite.prepare('DELETE FROM SummarizationJobs WHERE session_id = ?').run(sessionId);
+    });
+
+    test('no-ops when autoSummarize=true AND isPrimary=false (single-writer enforcement)', () => {
+        SDK.Memory_Config.data.autoSummarize = true;
+        SDK.Memory_Config.data.isPrimary     = false;
+
+        const sessionId = `gate-skip-non-primary-${crypto.randomUUID()}`;
+        SDK.Memory_SessionService.queueSummarizationJob(sessionId);
+
+        const job = sqlite.prepare('SELECT session_id FROM SummarizationJobs WHERE session_id = ?').get(sessionId);
+        expect(job).toBeUndefined();
+    });
+
+    test('no-ops when autoSummarize=false regardless of isPrimary', () => {
+        SDK.Memory_Config.data.autoSummarize = false;
+        SDK.Memory_Config.data.isPrimary     = true;
+
+        const sessionId = `gate-skip-summarize-off-${crypto.randomUUID()}`;
+        SDK.Memory_SessionService.queueSummarizationJob(sessionId);
+
+        const job = sqlite.prepare('SELECT session_id FROM SummarizationJobs WHERE session_id = ?').get(sessionId);
+        expect(job).toBeUndefined();
+    });
+});


### PR DESCRIPTION
Authored by Claude Opus 4.7 (Claude Code). Session 8b31fd62-6a53-40b5-aae2-c5288f8ced09.

Related: #10813 (Piece A of 3 — does not fully close until Pieces B + C land)

## Outcome

Piece A of the A+B+C session-summary-restoration architecture in #10813. Adds a single-writer-enforcement gate (`NEO_MC_PRIMARY` env var → `aiConfig.isPrimary`) that lets operators designate the canonical Memory Core instance in a multi-instance harness fleet (Claude Code worktrees + Antigravity + Codex Desktop + per-workspace language servers all sharing the same Chroma collection).

Two conditional sites are now AND-gated on `autoSummarize && isPrimary`:

- `SessionService.initAsync()` startup hook — startup drift-detection summarization fires only on the canonical instance. When `AUTO_SUMMARIZE=true` but `NEO_MC_PRIMARY=false`, an operator-visible log surfaces and the healthcheck records `startup.summarizationStatus: "skipped-non-primary"` (distinct from generic `"skipped"` so the topology condition is greppable).
- `SessionService.queueSummarizationJob()` disconnect-lifecycle path — non-primary instances no-op silently, leaving the canonical instance as the single writer to `SummarizationJobs` SQLite.

Defaults preserve current behavior: with `NEO_MC_PRIMARY` unset, all instances skip startup-summarization regardless of `AUTO_SUMMARIZE`. Operators opt in by setting `NEO_MC_PRIMARY=true` on the canonical MC instance only — restoring summary auto-discovery without re-introducing the cross-instance race condition that drove the original [#9942](https://github.com/neomjs/neo/issues/9942) `AUTO_SUMMARIZE=false` default.

Pieces B (sunset-event trigger) and C (periodic safety-net sweep) build on this gate and are owned by @neo-gemini-3-1-pro and @neo-gpt respectively per same-session lane coordination.

Evidence: L2 (gate-behavior unit tests against real SQLite SummarizationJobs table, 3/3 passing in 690ms) → L4 required (AC7 post-merge: agent boots after sunset → `get_all_summaries` returns the just-ended session). Residual: AC7 [#10813]; lands once Piece B trigger ships.

## MCP Config Template Change Summary

Per `.agents/skills/pull-request/references/mcp-config-template-change-guide.md`:

**Changed key in `ai/mcp/server/memory-core/config.template.mjs`:**
- Added `isPrimary: process.env.NEO_MC_PRIMARY === 'true'` (default `false`)

**Local `config.mjs` follow-up:** Required for all clones — gitignored `config.mjs` files must be re-synced to pick up the new `isPrimary` field. The simplest path is `cp config.template.mjs config.mjs` (or apply the diff manually if operator has load-bearing local overrides). Without this update, `aiConfig.isPrimary` reads as `undefined` → `&&` short-circuits as falsy → instances default to non-primary behavior. Functionally safe but the operator-visible log won't fire and the healthcheck status reads stale.

**Harness restart:** Required only for operators wanting to flip `NEO_MC_PRIMARY=true` on their canonical instance — the env var is read at boot. Other operators can leave their MC processes running; they'll continue treating themselves as non-primary (current default behavior).

A2A peer notification will be sent post-PR-open to @neo-gemini-3-1-pro (primary reviewer) per #10813 lane coordination.

## Slot Rationale (§1.1 substrate-mutation pre-flight gate)

This PR mutates three substrate files under `learn/agentos/**`. Per `AGENTS.md §13` decay-mitigation:

| File | Disposition | Trigger × Severity × Enforceability | Rationale |
|---|---|---|---|
| `learn/agentos/MemoryCore.md` | `keep` (extended) | High × Medium × Doc-only | New `### Single-Writer Enforcement: NEO_MC_PRIMARY` subsection inside existing `## Session Summarization (Auto-Discovery)`. Adds one truth-table + 1 paragraph explaining the AND-gate. Net-add ~14 lines; the AUTO_SUMMARIZE concept already lived here, so the substrate cost is purely incremental. Decay-mitigation: when Pieces B + C land, this section absorbs their config additions inline rather than spawning new sections. |
| `learn/agentos/SharedDeployment.md` | `keep` (modified) | High × High × Doc-only | Two-sentence update to the existing `## Asynchronous Session Summarization (Disconnect Trigger)` section noting the gate now requires both flags. Net-add ~2 lines. Decay-mitigation: section already documents disconnect-trigger semantics; this PR keeps the doc accurate without growing it. |
| `learn/agentos/DeploymentCookbook.md` | `keep` (extended) | High × Medium × Doc-only | Two new rows in §6 Environment Variable Inventory table (`AUTO_SUMMARIZE` + `NEO_MC_PRIMARY`) plus footnote update. Net-add ~3 lines. Decay-mitigation: env-var inventory IS the canonical operator-onboarding surface for deployment ergonomics; growing it with each #10808-class shipment is the documented intent of the section. |

No retired or moved sections. Total substrate growth: ~19 lines across 3 doc files vs ~35 lines of net-new code → docs-to-code ratio is intentional given operator-facing surface area.

## Test Evidence

```
$ npm run test-unit -- test/playwright/unit/ai/mcp/server/memory-core/services/SessionService.PrimaryFlagGate.spec.mjs
  3 passed (690ms)
```

Tests cover the truth table at the gate-behavior layer:
- `autoSummarize=true && isPrimary=true` → SQLite job written
- `autoSummarize=true && isPrimary=false` → SQLite untouched (single-writer enforcement)
- `autoSummarize=false` → SQLite untouched regardless of `isPrimary`

Adjacent regression check: `SessionService.spec.mjs` (7/7) and `SessionService.ResumeValidation.spec.mjs` pass in isolation; the only flake is a known pre-existing parallel-execution interleaving when both run in the same worker (singleton state cross-contamination — orthogonal to this PR's scope).

## Post-Merge Validation

- [ ] Each clone (Claude / Gemini / GPT) re-syncs gitignored `memory-core/config.mjs` to pick up `isPrimary` field.
- [ ] On the operator's canonical Memory Core instance, set `NEO_MC_PRIMARY=true` AND `AUTO_SUMMARIZE=true`. Verify `[Startup] Checking for unsummarized sessions...` log fires.
- [ ] On a non-primary clone, set `AUTO_SUMMARIZE=true` only (NEO_MC_PRIMARY unset). Verify `skipped-non-primary` log fires AND healthcheck shows `startup.summarizationStatus: "skipped-non-primary"`.
- [ ] AC7 (post-Piece-B): agent boots after a recent session sunset → `get_all_summaries({limit: 5})` returns the just-ended session as most-recent entry.

## Files Touched

- `ai/mcp/server/memory-core/config.template.mjs` — new `isPrimary` field with full JSDoc
- `ai/mcp/server/memory-core/services/SessionService.mjs` — gate at startup hook + `queueSummarizationJob`
- `ai/mcp/server/memory-core/services/HealthService.mjs` — JSDoc updates documenting `'skipped-non-primary'` enum value
- `learn/agentos/MemoryCore.md` — new single-writer-enforcement subsection
- `learn/agentos/SharedDeployment.md` — disconnect-trigger gate update
- `learn/agentos/DeploymentCookbook.md` — env-var inventory rows + footnote
- `test/playwright/unit/ai/mcp/server/memory-core/services/SessionService.PrimaryFlagGate.spec.mjs` — new gate-behavior spec (3 tests)