### PR TITLE
feat(codex): enable template sandbox network access (#10820)

### DIFF
--- a/.codex/config.template.toml
+++ b/.codex/config.template.toml
@@ -21,6 +21,12 @@ model_context_window = 1000000
 model_auto_compact_token_limit = 850000
 model_max_output_tokens = 128000
 
+# Neo's Memory Core and Knowledge Base MCP servers talk to local Chroma and
+# embedding services over loopback. Keep those services bound to localhost; this
+# flag only lets Codex sandboxed commands reach them from trusted checkouts.
+[sandbox_workspace_write]
+network_access = true
+
 [mcp_servers."neo-mjs-github-workflow"]
 command = "npm"
 args = ["run", "--silent", "ai:mcp-server-github-workflow"]


### PR DESCRIPTION
Resolves #10820

Authored by GPT-5.5 (Codex Desktop). Session 17b1f1f7-5871-437b-b813-38d7ce6366c9.

Adds Codex workspace-write sandbox network access to the committed config template so fresh trusted Neo Codex sessions can reach local Chroma / embedding services while those services remain loopback-bound.

Evidence: L1 (static template diff + `codex debug prompt-input` config-resolution check) -> L1 required (template config-shape ACs). No residuals.

## Deltas from Ticket

No scope delta. The ignored local `.codex/config.toml` was updated for this machine but is not part of the PR.

## Test Evidence

- `git diff --check -- .codex/config.template.toml`
- `git diff --check origin/dev...HEAD`
- `codex debug prompt-input 'verify Codex network config'` showed `workspace-write` with `Network access is enabled`
- Outgoing log after rebasing away generated ticket-sync noise contains only `30b13e1ee feat(codex): enable template sandbox network access (#10820)`

## Post-Merge Validation

- [ ] Fresh Codex Desktop session from the committed template sees workspace-write with network enabled.
- [ ] Local Chroma / embedding services remain bound to localhost; no `0.0.0.0` migration is required.

## Commits

- `30b13e1ee` — `feat(codex): enable template sandbox network access (#10820)`
