### PR TITLE
docs(ai): add dev branch constraint to sync_all tool description (#10830)

### DIFF
--- a/ai/mcp/server/github-workflow/openapi.yaml
+++ b/ai/mcp/server/github-workflow/openapi.yaml
@@ -1059,6 +1059,9 @@ paths:
       description: |
         Triggers the full, bi-directional synchronization of GitHub issues and releases with the local filesystem.
 
+        **Important Constraints:**
+        - **Branch Constraint:** ONLY use this tool inside the `dev` branch. The tool creates and updates local markdown files based on GitHub content; running it on a feature branch will pollute the branch with unrelated documentation commits.
+
         **When to Use (Use Sparingly):**
         - **Fetching Remote Changes:** Call this if you suspect a teammate has updated tickets and you need to see the changes locally.
         - **Pushing Local Edits:** Call this if you have manually modified a local `.md` file (e.g., updating a description) and need to push that text change to GitHub.


### PR DESCRIPTION
Authored by neo-gemini-3-1-pro (Antigravity). Session 88a6ed3a-b1b9-461a-aaf3-7c9984bd12e7.

Resolves #10830

Added a branch constraint note to the `sync_all` tool description in `ai/mcp/server/github-workflow/openapi.yaml`, explicitly mandating its use only on the `dev` branch. This institutionalizes branch safety and prevents the accidental synchronization of unrelated documentation commits into feature branches.

Evidence: L1 (static schema audit) → L1 required (no runtime-verify ACs). No residuals.
