### PR TITLE
refactor(config): remove legacy alias fallbacks from DeploymentConfig and EmbeddingProviderConfig (#10823)

### DIFF
--- a/ai/mcp/server/memory-core/config.template.mjs
+++ b/ai/mcp/server/memory-core/config.template.mjs
@@ -444,7 +444,7 @@ class Config extends Base {
 
             // Deep merge custom config into the data object
             Neo.merge(this.data, customConfig);
-            normalizeEmbeddingProviderConfig(this.data, process.env, console.warn, customConfig);
+            normalizeEmbeddingProviderConfig(this.data, process.env, customConfig);
 
             console.error(`[Config] Loaded custom configuration from ${absolutePath}`);
 

--- a/ai/mcp/server/memory-core/helpers/EmbeddingProviderConfig.mjs
+++ b/ai/mcp/server/memory-core/helpers/EmbeddingProviderConfig.mjs
@@ -1,33 +1,16 @@
 /**
  * @summary Resolves the canonical embedding provider for all embedding callsites.
  *
- * Resolves the canonical embedding provider from the unified selector plus the legacy
- * Chroma-side env/config selector kept during the #10804 deprecation window.
  * @param {Object} options
  * @param {Object} [options.config={}] Config object, including custom config overrides after load().
  * @param {Object} [options.env=process.env] Environment map.
- * @param {Function} [options.warn=console.warn] Warning sink for deprecation/conflict notices.
  * @returns {String} The provider key consumed by all embedding callsites.
  */
-export function resolveEmbeddingProvider({config = {}, env = process.env, warn = console.warn} = {}) {
-    const hasValue     = value => value !== undefined && value !== null && value !== '';
-    const unified      = hasValue(config.embeddingProvider) ? config.embeddingProvider : env.NEO_EMBEDDING_PROVIDER;
-    const legacyChroma = hasValue(config.chromaEmbeddingProvider) ? config.chromaEmbeddingProvider : env.NEO_CHROMA_EMBEDDING_PROVIDER;
-    const legacyNeo    = hasValue(config.neoEmbeddingProvider) ? config.neoEmbeddingProvider : null;
+export function resolveEmbeddingProvider({config = {}, env = process.env} = {}) {
+    const hasValue = value => value !== undefined && value !== null && value !== '';
+    const unified  = hasValue(config.embeddingProvider) ? config.embeddingProvider : env.NEO_EMBEDDING_PROVIDER;
 
-    if (hasValue(legacyChroma)) {
-        if (hasValue(unified) && legacyChroma !== unified) {
-            warn(`[Config] NEO_CHROMA_EMBEDDING_PROVIDER/chromaEmbeddingProvider is deprecated and conflicts with embeddingProvider; using ${unified}.`);
-        } else {
-            warn('[Config] NEO_CHROMA_EMBEDDING_PROVIDER/chromaEmbeddingProvider is deprecated; use NEO_EMBEDDING_PROVIDER/embeddingProvider.');
-        }
-    }
-
-    if (hasValue(legacyNeo) && hasValue(unified) && legacyNeo !== unified) {
-        warn(`[Config] neoEmbeddingProvider is deprecated and conflicts with embeddingProvider; using ${unified}.`);
-    }
-
-    return unified || legacyNeo || legacyChroma || 'gemini';
+    return unified || 'gemini';
 }
 
 /**
@@ -36,11 +19,10 @@ export function resolveEmbeddingProvider({config = {}, env = process.env, warn =
  * Normalizes a mutable config object after custom overrides are merged.
  * @param {Object} config Config object to normalize in place.
  * @param {Object} [env=process.env] Environment map.
- * @param {Function} [warn=console.warn] Warning sink.
  * @param {Object} [sourceConfig=config] Raw override object used for provider resolution.
  * @returns {Object} The same config object for chaining.
  */
-export function normalizeEmbeddingProviderConfig(config, env = process.env, warn = console.warn, sourceConfig = config) {
-    config.embeddingProvider = resolveEmbeddingProvider({config: sourceConfig, env, warn});
+export function normalizeEmbeddingProviderConfig(config, env = process.env, sourceConfig = config) {
+    config.embeddingProvider = resolveEmbeddingProvider({config: sourceConfig, env});
     return config;
 }

--- a/ai/mcp/server/shared/helpers/DeploymentConfig.mjs
+++ b/ai/mcp/server/shared/helpers/DeploymentConfig.mjs
@@ -1,13 +1,5 @@
 /**
- * @summary Resolves the MCP server HTTP listening port with backwards-compat for the legacy
- * `SSE_PORT` env var.
- *
- * `SSE_PORT` was the original env var introduced when the SSE transport was the only
- * non-stdio path (#10145 / PR #10166 era). Per #10808 operator-facing env-var ergonomics,
- * we rename to `MCP_HTTP_PORT` (transport-mechanism-agnostic, intent-clear for operators
- * provisioning containers). Soft rename: `MCP_HTTP_PORT` is preferred; `SSE_PORT` remains
- * readable during the deprecation window with a warning when both are set with different
- * values.
+ * @summary Resolves the MCP server HTTP listening port.
  *
  * Pattern mirrors {@link Neo.ai.mcp.server.memory-core.helpers.EmbeddingProviderConfig#resolveEmbeddingProvider}
  * from PR #10810 — pure, testable, dependency-free; consumers (`Server.mjs` config templates)
@@ -33,47 +25,33 @@ export function resolveMcpHttpPort({env = process.env, warn = console.warn, defa
         return num;
     };
 
-    const newPort    = parsePort(env.MCP_HTTP_PORT, 'MCP_HTTP_PORT');
-    const legacyPort = parsePort(env.SSE_PORT,      'SSE_PORT');
-
-    if (legacyPort !== null) {
-        if (newPort !== null && newPort !== legacyPort) {
-            warn(`[Config] SSE_PORT is deprecated and conflicts with MCP_HTTP_PORT; using ${newPort}.`);
-        } else {
-            warn('[Config] SSE_PORT is deprecated; use MCP_HTTP_PORT.');
-        }
-    }
-
-    return newPort ?? legacyPort ?? defaultPort;
+    const newPort = parsePort(env.MCP_HTTP_PORT, 'MCP_HTTP_PORT');
+    return newPort ?? defaultPort;
 }
 
 /**
- * @summary Resolves the ChromaDB host with optional fallback to a legacy server-prefixed env var.
+ * @summary Resolves the ChromaDB host.
  *
  * Per #10808 operator-facing env-var ergonomics: `NEO_CHROMA_HOST` is the canonical
  * operator-set env var (used by KB own Chroma config + MC `engines.kb.chroma`
- * unified-mode reference). `NEO_KB_CHROMA_HOST` is the legacy-prefixed form retained
- * for MC's existing `engines.kb.chroma` fallback chain during the deprecation window.
+ * unified-mode reference).
  *
- * Pure function: takes env + optional legacyEnvVar; returns resolved host string.
+ * Pure function: takes env; returns resolved host string.
  *
  * @param {Object}   options
  * @param {Object}   [options.env=process.env]   Environment map (overridable for tests).
  * @param {String}   [options.defaultHost='localhost'] Default when no env var is set.
- * @param {String}   [options.legacyEnvVar]      Optional legacy env-var name to consult after `NEO_CHROMA_HOST`
- *     (e.g., `'NEO_KB_CHROMA_HOST'` for MC's `engines.kb.chroma` block; KB own config does not pass this).
  * @returns {String}
  */
-export function resolveChromaHost({env = process.env, defaultHost = 'localhost', legacyEnvVar} = {}) {
+export function resolveChromaHost({env = process.env, defaultHost = 'localhost'} = {}) {
     const hasValue = value => value !== undefined && value !== null && value !== '';
 
-    if (hasValue(env.NEO_CHROMA_HOST))                  return env.NEO_CHROMA_HOST;
-    if (legacyEnvVar && hasValue(env[legacyEnvVar]))    return env[legacyEnvVar];
+    if (hasValue(env.NEO_CHROMA_HOST)) return env.NEO_CHROMA_HOST;
     return defaultHost;
 }
 
 /**
- * @summary Resolves the ChromaDB port with optional fallback to a legacy server-prefixed env var.
+ * @summary Resolves the ChromaDB port.
  *
  * Sibling of {@link resolveChromaHost}. Same semantics; numeric port handling. Invalid values
  * (non-integer / out-of-range / negative) fall back to the next layer with a warning, mirroring
@@ -83,10 +61,9 @@ export function resolveChromaHost({env = process.env, defaultHost = 'localhost',
  * @param {Object}   [options.env=process.env]   Environment map (overridable for tests).
  * @param {Function} [options.warn=console.warn] Warning sink for invalid-value notices.
  * @param {Number}   [options.defaultPort=8000]  Default when no env var is set.
- * @param {String}   [options.legacyEnvVar]      Optional legacy env-var name to consult after `NEO_CHROMA_PORT`.
  * @returns {Number}
  */
-export function resolveChromaPort({env = process.env, warn = console.warn, defaultPort = 8000, legacyEnvVar} = {}) {
+export function resolveChromaPort({env = process.env, warn = console.warn, defaultPort = 8000} = {}) {
     const hasValue = value => value !== undefined && value !== null && value !== '';
 
     const parsePort = (rawValue, envVarName) => {
@@ -99,10 +76,8 @@ export function resolveChromaPort({env = process.env, warn = console.warn, defau
         return num;
     };
 
-    const newPort    = parsePort(env.NEO_CHROMA_PORT, 'NEO_CHROMA_PORT');
-    const legacyPort = legacyEnvVar ? parsePort(env[legacyEnvVar], legacyEnvVar) : null;
-
-    return newPort ?? legacyPort ?? defaultPort;
+    const newPort = parsePort(env.NEO_CHROMA_PORT, 'NEO_CHROMA_PORT');
+    return newPort ?? defaultPort;
 }
 
 /**

--- a/test/playwright/unit/ai/mcp/server/memory-core/config.spec.mjs
+++ b/test/playwright/unit/ai/mcp/server/memory-core/config.spec.mjs
@@ -37,65 +37,25 @@ test.describe('Memory Core config #10804 — resolveEmbeddingProvider', () => {
     });
 
     test('defaults to gemini when no provider selector is configured', () => {
-        const warnings = [];
-
         expect(resolveEmbeddingProvider({
-            env : {},
-            warn: message => warnings.push(message)
+            env: {}
         })).toBe('gemini');
-        expect(warnings).toEqual([]);
     });
 
-    test('unified env selector wins over conflicting legacy Chroma selector', () => {
-        const warnings = [];
-
+    test('unified env selector resolves the provider', () => {
         expect(resolveEmbeddingProvider({
-            env : {
-                NEO_EMBEDDING_PROVIDER       : 'openAiCompatible',
-                NEO_CHROMA_EMBEDDING_PROVIDER: 'gemini'
-            },
-            warn: message => warnings.push(message)
+            env: {
+                NEO_EMBEDDING_PROVIDER: 'openAiCompatible'
+            }
         })).toBe('openAiCompatible');
-        expect(warnings.join('\n')).toMatch(/deprecated and conflicts/);
     });
 
-    test('legacy Chroma env selector still feeds the unified provider with deprecation warning', () => {
-        const warnings = [];
-
-        expect(resolveEmbeddingProvider({
-            env : {
-                NEO_CHROMA_EMBEDDING_PROVIDER: 'ollama'
-            },
-            warn: message => warnings.push(message)
-        })).toBe('ollama');
-        expect(warnings.join('\n')).toMatch(/deprecated/);
-    });
-
-    test('custom config normalization preserves explicit embeddingProvider over legacy config fields', () => {
+    test('custom config normalization preserves explicit embeddingProvider', () => {
         const config = {
-            embeddingProvider      : 'openAiCompatible',
-            chromaEmbeddingProvider: 'ollama',
-            neoEmbeddingProvider   : 'gemini'
+            embeddingProvider: 'openAiCompatible'
         };
-        const warnings = [];
 
-        expect(normalizeEmbeddingProviderConfig(config, {}, message => warnings.push(message))).toBe(config);
+        expect(normalizeEmbeddingProviderConfig(config, {})).toBe(config);
         expect(config.embeddingProvider).toBe('openAiCompatible');
-        expect(warnings.join('\n')).toMatch(/chromaEmbeddingProvider is deprecated and conflicts/);
-        expect(warnings.join('\n')).toMatch(/neoEmbeddingProvider is deprecated and conflicts/);
-    });
-
-    test('custom legacy Chroma config overrides the default when unified selector is absent', () => {
-        const defaults = {
-            embeddingProvider: 'gemini'
-        };
-        const customConfig = {
-            chromaEmbeddingProvider: 'openAiCompatible'
-        };
-        const warnings = [];
-
-        expect(normalizeEmbeddingProviderConfig(defaults, {}, message => warnings.push(message), customConfig)).toBe(defaults);
-        expect(defaults.embeddingProvider).toBe('openAiCompatible');
-        expect(warnings.join('\n')).toMatch(/deprecated/);
     });
 });

--- a/test/playwright/unit/ai/mcp/server/shared/helpers/DeploymentConfig.spec.mjs
+++ b/test/playwright/unit/ai/mcp/server/shared/helpers/DeploymentConfig.spec.mjs
@@ -47,7 +47,7 @@ test.describe('DeploymentConfig #10808 — resolveMcpHttpPort', () => {
         expect(warnings).toEqual([]);
     });
 
-    test('returns MCP_HTTP_PORT when only the new env var is set (no warning)', () => {
+    test('returns MCP_HTTP_PORT when the env var is set', () => {
         const warnings = [];
 
         expect(resolveMcpHttpPort({
@@ -58,47 +58,11 @@ test.describe('DeploymentConfig #10808 — resolveMcpHttpPort', () => {
         expect(warnings).toEqual([]);
     });
 
-    test('returns SSE_PORT with deprecation warning when only legacy env var is set (backwards-compat)', () => {
-        const warnings = [];
-
-        expect(resolveMcpHttpPort({
-            env        : {SSE_PORT: '5555'},
-            warn       : message => warnings.push(message),
-            defaultPort: 3001
-        })).toBe(5555);
-        expect(warnings.join('\n')).toMatch(/SSE_PORT is deprecated/);
-        expect(warnings.join('\n')).not.toMatch(/conflicts/);
-    });
-
-    test('MCP_HTTP_PORT wins over SSE_PORT when both set with different values + emits conflict warning', () => {
-        const warnings = [];
-
-        expect(resolveMcpHttpPort({
-            env        : {MCP_HTTP_PORT: '4001', SSE_PORT: '5555'},
-            warn       : message => warnings.push(message),
-            defaultPort: 3001
-        })).toBe(4001);
-        expect(warnings.join('\n')).toMatch(/SSE_PORT is deprecated and conflicts with MCP_HTTP_PORT/);
-        expect(warnings.join('\n')).toMatch(/using 4001/);
-    });
-
-    test('both env vars set with same value — no conflict warning, just deprecation', () => {
-        const warnings = [];
-
-        expect(resolveMcpHttpPort({
-            env        : {MCP_HTTP_PORT: '4001', SSE_PORT: '4001'},
-            warn       : message => warnings.push(message),
-            defaultPort: 3001
-        })).toBe(4001);
-        expect(warnings.join('\n')).toMatch(/SSE_PORT is deprecated/);
-        expect(warnings.join('\n')).not.toMatch(/conflicts/);
-    });
-
     test('empty-string env values treated as unset (not "0" port)', () => {
         const warnings = [];
 
         expect(resolveMcpHttpPort({
-            env        : {MCP_HTTP_PORT: '', SSE_PORT: ''},
+            env        : {MCP_HTTP_PORT: ''},
             warn       : message => warnings.push(message),
             defaultPort: 3001
         })).toBe(3001);
@@ -138,29 +102,6 @@ test.describe('DeploymentConfig #10808 — resolveMcpHttpPort', () => {
         })).toBe(3001);
         expect(warnings.join('\n')).toMatch(/Invalid MCP_HTTP_PORT/);
     });
-
-    test('invalid SSE_PORT also falls back gracefully + emits scoped warning', () => {
-        const warnings = [];
-
-        expect(resolveMcpHttpPort({
-            env        : {SSE_PORT: 'not-a-port'},
-            warn       : message => warnings.push(message),
-            defaultPort: 3001
-        })).toBe(3001);
-        expect(warnings.join('\n')).toMatch(/Invalid SSE_PORT value: "not-a-port"/);
-    });
-
-    test('invalid MCP_HTTP_PORT but valid SSE_PORT — falls through to legacy with deprecation warning', () => {
-        const warnings = [];
-
-        expect(resolveMcpHttpPort({
-            env        : {MCP_HTTP_PORT: 'abc', SSE_PORT: '4001'},
-            warn       : message => warnings.push(message),
-            defaultPort: 3001
-        })).toBe(4001);
-        expect(warnings.join('\n')).toMatch(/Invalid MCP_HTTP_PORT/);
-        expect(warnings.join('\n')).toMatch(/SSE_PORT is deprecated/);
-    });
 });
 
 /**
@@ -192,35 +133,9 @@ test.describe('DeploymentConfig #10808 — resolveChromaHost', () => {
         })).toBe('team-chroma.example.com');
     });
 
-    test('legacy env-var consulted when NEO_CHROMA_HOST unset (MC engines.kb.chroma fallback)', () => {
+    test('empty-string env values treated as unset', () => {
         expect(resolveChromaHost({
-            env         : {NEO_KB_CHROMA_HOST: 'legacy-only.example.com'},
-            legacyEnvVar: 'NEO_KB_CHROMA_HOST'
-        })).toBe('legacy-only.example.com');
-    });
-
-    test('NEO_CHROMA_HOST wins over legacy env var when both set (precedence)', () => {
-        expect(resolveChromaHost({
-            env: {
-                NEO_CHROMA_HOST   : 'unified.example.com',
-                NEO_KB_CHROMA_HOST: 'legacy.example.com'
-            },
-            legacyEnvVar: 'NEO_KB_CHROMA_HOST'
-        })).toBe('unified.example.com');
-    });
-
-    test('legacyEnvVar omitted by KB-own-config callsite — no fallback layer', () => {
-        // KB config.template.mjs calls resolveChromaHost() with no legacyEnvVar.
-        // NEO_KB_CHROMA_HOST should be ignored even if set (it's MC-side legacy).
-        expect(resolveChromaHost({
-            env: {NEO_KB_CHROMA_HOST: 'should-be-ignored.example.com'}
-        })).toBe('localhost');
-    });
-
-    test('empty-string env values treated as unset (consistent with resolveMcpHttpPort)', () => {
-        expect(resolveChromaHost({
-            env         : {NEO_CHROMA_HOST: '', NEO_KB_CHROMA_HOST: ''},
-            legacyEnvVar: 'NEO_KB_CHROMA_HOST'
+            env: {NEO_CHROMA_HOST: ''}
         })).toBe('localhost');
     });
 
@@ -255,23 +170,6 @@ test.describe('DeploymentConfig #10808 — resolveChromaPort', () => {
         })).toBe(9000);
     });
 
-    test('legacy env-var consulted when NEO_CHROMA_PORT unset (MC engines.kb.chroma fallback)', () => {
-        expect(resolveChromaPort({
-            env         : {NEO_KB_CHROMA_PORT: '8500'},
-            legacyEnvVar: 'NEO_KB_CHROMA_PORT'
-        })).toBe(8500);
-    });
-
-    test('NEO_CHROMA_PORT wins over legacy env var (precedence)', () => {
-        expect(resolveChromaPort({
-            env: {
-                NEO_CHROMA_PORT   : '9000',
-                NEO_KB_CHROMA_PORT: '8500'
-            },
-            legacyEnvVar: 'NEO_KB_CHROMA_PORT'
-        })).toBe(9000);
-    });
-
     test('non-numeric NEO_CHROMA_PORT falls back with warning (no NaN leak)', () => {
         const warnings = [];
         expect(resolveChromaPort({
@@ -290,16 +188,6 @@ test.describe('DeploymentConfig #10808 — resolveChromaPort', () => {
             })).toBe(8000);
             expect(warnings.join('\n')).toMatch(/Invalid NEO_CHROMA_PORT/);
         }
-    });
-
-    test('invalid NEO_CHROMA_PORT but valid legacy NEO_KB_CHROMA_PORT — falls through cleanly', () => {
-        const warnings = [];
-        expect(resolveChromaPort({
-            env         : {NEO_CHROMA_PORT: 'abc', NEO_KB_CHROMA_PORT: '8500'},
-            warn        : m => warnings.push(m),
-            legacyEnvVar: 'NEO_KB_CHROMA_PORT'
-        })).toBe(8500);
-        expect(warnings.join('\n')).toMatch(/Invalid NEO_CHROMA_PORT/);
     });
 
     test('custom defaultPort honored when provided', () => {


### PR DESCRIPTION
Authored by @neo-gemini-3-1-pro (Antigravity). Session 88a6ed3a-b1b9-461a-aaf3-7c9984bd12e7.

Resolves #10823

Removed legacy environment variable alias fallback chains from `DeploymentConfig.mjs` and `EmbeddingProviderConfig.mjs` to enforce canonical naming and eliminate the "Clean-Slate Sunset Rule" technical debt.

## Deltas from ticket (if any)
N/A

## Test Evidence
All unit tests in `test/playwright/unit/ai/mcp/server/shared/helpers/DeploymentConfig.spec.mjs` and `test/playwright/unit/ai/mcp/server/memory-core/config.spec.mjs` pass successfully.

## Post-Merge Validation
- [ ] Ensure all MCP servers use canonical configuration variables in deployment environments.
