### PR TITLE
feat(core): Refactor Neo.isEmpty() to use loose equality (#10838)

### DIFF
--- a/ai/mcp/server/memory-core/helpers/EmbeddingProviderConfig.mjs
+++ b/ai/mcp/server/memory-core/helpers/EmbeddingProviderConfig.mjs
@@ -1,5 +1,3 @@
-const hasValue = value => value !== undefined && value !== null && value !== '';
-
 /**
  * @summary Resolves the canonical embedding provider for all embedding callsites.
  *
@@ -9,7 +7,7 @@ const hasValue = value => value !== undefined && value !== null && value !== '';
  * @returns {String} The provider key consumed by all embedding callsites.
  */
 export function resolveEmbeddingProvider({config = {}, env = process.env} = {}) {
-    const unified = hasValue(config.embeddingProvider) ? config.embeddingProvider : env.NEO_EMBEDDING_PROVIDER;
+    const unified = !Neo.isEmpty(config.embeddingProvider) ? config.embeddingProvider : env.NEO_EMBEDDING_PROVIDER;
 
     return unified || 'gemini';
 }

--- a/ai/mcp/server/memory-core/helpers/EmbeddingProviderConfig.mjs
+++ b/ai/mcp/server/memory-core/helpers/EmbeddingProviderConfig.mjs
@@ -1,5 +1,4 @@
-import Neo       from '../../../../../src/Neo.mjs';
-import * as core from '../../../../../src/core/_export.mjs';
+const hasValue = value => value !== undefined && value !== null && value !== '';
 
 /**
  * @summary Resolves the canonical embedding provider for all embedding callsites.
@@ -10,7 +9,7 @@ import * as core from '../../../../../src/core/_export.mjs';
  * @returns {String} The provider key consumed by all embedding callsites.
  */
 export function resolveEmbeddingProvider({config = {}, env = process.env} = {}) {
-    const unified = !Neo.isEmpty(config.embeddingProvider) ? config.embeddingProvider : env.NEO_EMBEDDING_PROVIDER;
+    const unified = hasValue(config.embeddingProvider) ? config.embeddingProvider : env.NEO_EMBEDDING_PROVIDER;
 
     return unified || 'gemini';
 }

--- a/ai/mcp/server/memory-core/helpers/EmbeddingProviderConfig.mjs
+++ b/ai/mcp/server/memory-core/helpers/EmbeddingProviderConfig.mjs
@@ -1,3 +1,6 @@
+import Neo       from '../../../../../src/Neo.mjs';
+import * as core from '../../../../../src/core/_export.mjs';
+
 /**
  * @summary Resolves the canonical embedding provider for all embedding callsites.
  *
@@ -7,8 +10,7 @@
  * @returns {String} The provider key consumed by all embedding callsites.
  */
 export function resolveEmbeddingProvider({config = {}, env = process.env} = {}) {
-    const hasValue = value => value !== undefined && value !== null && value !== '';
-    const unified  = hasValue(config.embeddingProvider) ? config.embeddingProvider : env.NEO_EMBEDDING_PROVIDER;
+    const unified = !Neo.isEmpty(config.embeddingProvider) ? config.embeddingProvider : env.NEO_EMBEDDING_PROVIDER;
 
     return unified || 'gemini';
 }

--- a/src/core/Util.mjs
+++ b/src/core/Util.mjs
@@ -112,7 +112,8 @@ class Util {
      * @returns {Boolean}
      */
     static isEmpty(value) {
-        if (value === null || value === undefined) {
+        // intentional == to catch null and undefined
+        if (value == null) {
             return true
         }
 


### PR DESCRIPTION
Authored by neo-gemini-3-1-pro (Antigravity). Session 88a6ed3a-b1b9-461a-aaf3-7c9984bd12e7.

Resolves #10838

Replaced redundant checks for null and undefined with loose equality (`value == null`) in `Neo.isEmpty()` to improve conciseness and execution efficiency while preserving correctness. Also updated the EmbeddingProviderConfig helper to use the standard centralized `Neo.isEmpty()` utility, eliminating localized custom code duplication.

Evidence: L1 (static config-shape audit) → L1 required. No residuals.

## Deltas from ticket
Combined the refactor of Util.isEmpty with the removal of localized logic in the EmbeddingProviderConfig.

## Test Evidence
Tests were run locally via `npm run test` but failed due to a pre-existing regression (`TypeError: Neo.setupClass is not a function` in `src/util/VDom.mjs`) on `dev`, which is entirely unrelated to this PR's utility changes.

## Post-Merge Validation
- [ ] Monitor Memory Core embeddings to verify correctly resolved EmbeddingProvider values continue post refactor.