### PR TITLE
docs(agent-os): Reinstate testing skills in AGENTS.md Workflow table

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -97,6 +97,8 @@ You are part of the core architectural team. **Synthesize friction into gold:** 
 | `memory-mining` | On regression / non-obvious-architecture / decision-points |
 | `tech-debt-radar` | During PR review for fundamental architectural shifts |
 | `session-sunset` | Context Window Exhaustion, Macro-Semantic Pivot |
+| `unit-test` | Before writing, modifying, or executing Playwright unit tests |
+| `whitebox-e2e` | Before writing, modifying, or executing Playwright Whitebox E2E tests |
 
 ## 22. The Mailbox Check Protocol (Pre-Flight at Turn Start)
 At turn start, you MUST check your A2A mailbox for unread messages.


### PR DESCRIPTION
Fixes #10847

### Rationale
The `unit-test` and `whitebox-e2e` skills are load-bearing testing-substrate triggers that route agents to the framework-specific `npm run test-unit` (which invokes `playwright test -c test/playwright/playwright.config.unit.mjs`) instead of generic `npx playwright test`.

The unit Playwright config + the skill's setup conventions are the discipline gates that keep test paths isolated from production data directories. Some specs additionally set `NEO_UNIT_TEST_MODE` explicitly where AI-script tests need it; the skill files document the convention.

Reinstating these triggers in the AGENTS.md Workflow Skills table closes a routing gap and makes test-isolation discipline mechanically enforced via skill-routing rather than relying on per-agent recall.

### Changes
- Reinstated `unit-test` trigger in the AGENTS.md Workflow Skills table
- Reinstated `whitebox-e2e` trigger in the AGENTS.md Workflow Skills table

### Related
Pairs with substrate-hardening tickets:
- #10845 (block destructive AI substrate ops on production paths) — broader architectural primitive that makes path-discipline mechanically enforced at the destructive-call boundary
- #10844 (daily backup automation) — preventive substrate