### PR TITLE
fix(ai): remove dead config substrate surfaces (#10825)

### DIFF
--- a/ai/mcp/server/knowledge-base/config.template.mjs
+++ b/ai/mcp/server/knowledge-base/config.template.mjs
@@ -194,11 +194,6 @@ const defaultConfig = {
      */
     modelName: 'gemini-2.5-flash',
     /**
-     * The name of the Google Generative AI model for text embeddings.
-     * @type {string}
-     */
-    embeddingModel: 'gemini-embedding-001',
-    /**
      * The number of chunks to process in a single batch when embedding.
      * @type {number}
      */

--- a/ai/mcp/server/knowledge-base/services/SearchService.mjs
+++ b/ai/mcp/server/knowledge-base/services/SearchService.mjs
@@ -39,11 +39,6 @@ class SearchService extends Base {
     }
 
     /**
-     * @member {Object|null} embeddingModel=null
-     * @protected
-     */
-    embeddingModel = null
-    /**
      * @member {Object|null} model=null
      * @protected
      */
@@ -59,8 +54,7 @@ class SearchService extends Base {
         const apiKey = process.env.GEMINI_API_KEY;
         if (apiKey) {
             const genAI = new GoogleGenerativeAI(apiKey);
-            this.model          = genAI.getGenerativeModel({model: aiConfig.modelName});
-            this.embeddingModel = genAI.getGenerativeModel({model: aiConfig.embeddingModel});
+            this.model = genAI.getGenerativeModel({model: aiConfig.modelName});
         }
     }
 

--- a/ai/mcp/server/memory-core/managers/StorageRouter.mjs
+++ b/ai/mcp/server/memory-core/managers/StorageRouter.mjs
@@ -5,7 +5,7 @@ import logger          from '../logger.mjs';
 
 /**
  * StorageRouter acts as a transparent Proxy pattern for the underlying vector databases.
- * It reads aiConfig.architecture ('chroma' or 'hybrid') and dispatches collection
+ * It reads aiConfig.engine ('chroma' or 'hybrid') and dispatches collection
  * calls (add, upsert, get, query) to the appropriate managers.
  * 
  * If 'hybrid' is selected:

--- a/ai/mcp/server/memory-core/services/HealthService.mjs
+++ b/ai/mcp/server/memory-core/services/HealthService.mjs
@@ -395,11 +395,11 @@ class HealthService extends Base {
      */
     async #checkDatabaseConnections() {
         try {
-            const architecture = aiConfig.architecture || 'hybrid';
+            const engine = aiConfig.engine || 'hybrid';
             const engines = { chroma: false, sqlite: false };
 
             // 2. Vector Chroma DB (Hybrid & Standalone Chroma)
-            if (architecture === 'chroma' || architecture === 'hybrid') {
+            if (engine === 'chroma' || engine === 'hybrid') {
                 await ChromaManager.ready();
                 if (!ChromaManager.connected && !(await ChromaManager.connect())) {
                     throw new Error("ChromaDB is not accessible");
@@ -630,9 +630,9 @@ class HealthService extends Base {
 
     #checkApiKeyConfigured() {
         const providers = [aiConfig.modelProvider];
-        const architecture = aiConfig.architecture || 'hybrid';
+        const engine = aiConfig.engine || 'hybrid';
 
-        if (architecture === 'chroma' || architecture === 'hybrid') {
+        if (engine === 'chroma' || engine === 'hybrid') {
             providers.push(aiConfig.embeddingProvider);
         }
 

--- a/ai/mcp/server/memory-core/services/lifecycle/ChromaLifecycleService.mjs
+++ b/ai/mcp/server/memory-core/services/lifecycle/ChromaLifecycleService.mjs
@@ -66,7 +66,7 @@ class ChromaLifecycleService extends Base {
             return;
         }
 
-        if (aiConfig.autoStartDatabase && (aiConfig.architecture === 'chroma' || aiConfig.architecture === 'hybrid')) {
+        if (aiConfig.autoStartDatabase && (aiConfig.engine === 'chroma' || aiConfig.engine === 'hybrid')) {
             await this.startDatabase();
         }
     }

--- a/buildScripts/README.md
+++ b/buildScripts/README.md
@@ -26,7 +26,6 @@ Tools for managing the AI infrastructure, including Vector Database operations a
 | :--- | :--- | :--- |
 | `defragChromaDB.mjs` | `npm run ai:defrag-kb`<br>`npm run ai:defrag-memory` | Vacuums and optimizes the ChromaDB collections to reclaim space. |
 | `downloadKnowledgeBase.mjs` | `npm run ai:download-kb` | Downloads the latest pre-indexed Knowledge Base from the remote source. |
-| `migrateMemoryCore.mjs` | `npm run ai:migrate-memory` | Migrates the Memory Core schema when breaking changes occur. |
 | `syncKnowledgeBase.mjs` | `npm run ai:sync-kb` | Indexes the local codebase and updates the vector database with changes. |
 
 ---
@@ -164,21 +163,6 @@ Options:
 
 Downloads the pre-indexed Knowledge Base artifact matching the current `package.json` version from GitHub Releases.
 *Note: This script has no CLI options.*
-
-## `npm run ai:migrate-memory`
-**Script:** `buildScripts/ai/migrateMemoryCore.mjs`
-
-Migrates a Memory Core database backup to the current embedding model by clearing the existing collection and re-generating embeddings.
-
-```bash
-Usage: node buildScripts/migrateMemoryCore.mjs <backup-file.jsonl>
-
-Arguments:
-  <backup-file.jsonl>  Path to the JSONL backup file to import and re-embed.
-
-Options:
-  --test-mode          Use test collections (test-re-embed-*) instead of production DB.
-```
 
 ## `npm run ai:sync-kb`
 **Script:** `buildScripts/ai/syncKnowledgeBase.mjs`

--- a/learn/agentos/ConfigSubstrateDeadConfigAudit.md
+++ b/learn/agentos/ConfigSubstrateDeadConfigAudit.md
@@ -1,0 +1,56 @@
+# Config Substrate Dead-Config Audit
+
+This audit satisfies [#10825](https://github.com/neomjs/neo/issues/10825), the Phase 1 AC4 cleanup ticket for [#10822](https://github.com/neomjs/neo/issues/10822).
+
+## Scope
+
+The scan covers config keys, public package scripts, build-script documentation, and Memory Core / Knowledge Base consumers on `dev` after the Phase 1.5 config refactor landed.
+
+Commands:
+
+```bash
+rg -n "ai:migrate-memory|migrateMemoryCore|syncMemoryChromaToNeo|migrate-memory" package.json buildScripts ai learn resources --glob '!resources/content/issue-archive/**'
+rg -n "aiConfig\\.embeddingModel|embeddingModel" ai/mcp/server/knowledge-base ai/mcp/server/memory-core buildScripts package.json learn/agentos test/playwright/unit/ai
+rg -n "aiConfig\\.(engine|architecture)|\\bengine: 'hybrid'|aiConfig\\.backupPath|backupPath" ai/mcp/server buildScripts/ai test/playwright/unit/ai learn/agentos
+rg -n -o "aiConfig\\.[A-Za-z0-9_]+" ai/mcp/server buildScripts/ai test/playwright/unit/ai
+```
+
+Verdict shorthand:
+
+| Verdict | Meaning |
+|---|---|
+| `live` | Current runtime, test, or operator consumer exists. |
+| `dead-remove` | Current reader evidence proves the surface is stale or unused; this PR removes it. |
+| `defer-to-Phase-1.5` | The surface is real but belongs to the shared/per-server config split, not AC4 deletion. |
+| `needs-design` | The scan found drift, but removal would cross a broader contract boundary. |
+
+## Audit Table
+
+| candidate | defining surface | current readers | verdict | action |
+|---|---|---|---|---|
+| `ai:migrate-memory` npm script | `package.json` | Exact scan found only the package entry, `buildScripts/README.md`, active ticket text, and historical archived issue references. The package entry pointed at missing `buildScripts/ai/syncMemoryChromaToNeo.mjs`. | `dead-remove` | Removed the package script and public build-script docs. |
+| `buildScripts/ai/migrateMemoryCore.mjs` direct script | Build script file | No imports or package script remain. Active issue #10556 still cites it as precedent for re-embedding scope, and `Memory_DatabaseService.importDatabase({reEmbed:true})` remains the real API. | `needs-design` | Left the direct file in place; a follow-up can retire or replace it with an operator-approved one-shot migration artifact. |
+| KB `embeddingModel` config key | `ai/mcp/server/knowledge-base/config.template.mjs` | The only KB runtime reader was `SearchService` construction. Query and embedding paths call `memory-core/services/TextEmbeddingService.mjs` with `mcConfig.embeddingProvider`; VectorService batches also use Memory Core provider routing. | `dead-remove` | Removed the KB template key and the unused `SearchService.embeddingModel` client. |
+| MC `embeddingModel` config key | `ai/mcp/server/memory-core/config.template.mjs` | `TextEmbeddingService` uses it for Gemini embeddings; `HealthService.buildEmbeddingProviderBlock()` surfaces it in healthcheck output. | `live` | Kept. |
+| Provider-specific `openAiCompatible.embeddingModel` / `ollama.embeddingModel` | `ai/mcp/server/memory-core/config.template.mjs` | `TextEmbeddingService` sends these models to the provider endpoints; `HealthService` reports them. | `live` | Kept. Phase 1.5 may move defaults into Tier 1, but they are not dead. |
+| MC `engine` storage selector | `ai/mcp/server/memory-core/config.template.mjs` | `CollectionProxy` routes Chroma access with `aiConfig.engine`. | `live` | Kept and made HealthService / ChromaLifecycleService use the same key. |
+| MC `architecture` storage selector | No config template definition | Only unbacked reads existed in `HealthService`, `ChromaLifecycleService`, and an old `StorageRouter` comment; the shipped config defines `engine`, not `architecture`. | `dead-remove` | Replaced the unbacked reads/comments with `engine`. |
+| KB `backupPath` default | No KB config template definition | `knowledge-base/services/DatabaseService.mjs` accepts `backupPath` for backup orchestration, but the canonical backup runner passes it explicitly. | `needs-design` | Left unchanged; this is a shared-backup default-shape question, not a safe AC4 deletion. |
+| MC `backupPath` default | `ai/mcp/server/memory-core/config.template.mjs` | `Memory_DatabaseService.exportDatabase()` uses it as the default backup output path. | `live` | Kept. |
+| `chromaUnified` topology flag | KB and MC config templates | Chroma routing, lifecycle, and healthcheck topology still read it. #10822 Phase 2 owns removal after operator migration. | `defer-to-Phase-1.5` | Kept. |
+
+## Count Summary
+
+| Bucket | Count | Notes |
+|---|---:|---|
+| `dead-remove` | 3 | `ai:migrate-memory`, KB `embeddingModel`, and unbacked MC `architecture` reads. |
+| `live` | 4 | MC embedding keys, provider-specific embedding model keys, MC `engine`, MC `backupPath`. |
+| `defer-to-Phase-1.5` | 1 | `chromaUnified` is scheduled later by #10822 sequencing. |
+| `needs-design` | 2 | Direct migration script retirement and KB backup default shape need separate contract decisions. |
+
+## Removal Summary
+
+- Public stale migration command removed: `npm run ai:migrate-memory`.
+- Public build-script documentation no longer advertises the stale migration command.
+- Knowledge Base no longer exposes an embedding model config key that its runtime does not use.
+- Memory Core health/lifecycle code now reads the shipped `engine` key instead of an unbacked `architecture` key.

--- a/learn/tree.json
+++ b/learn/tree.json
@@ -39,6 +39,7 @@
         {"name": "Shared KB/MC Team Deployment",                       "parentId": "AgentOS",                                             "id": "agentos/SharedDeployment"},
         {"name": "Deployment Cookbook",                                "parentId": "AgentOS",                                             "id": "agentos/DeploymentCookbook"},
         {"name": "Config Substrate Env-Var Audit",                     "parentId": "AgentOS",                                             "id": "agentos/ConfigSubstrateEnvVarAudit"},
+        {"name": "Config Substrate Dead-Config Audit",                  "parentId": "AgentOS",                                             "id": "agentos/ConfigSubstrateDeadConfigAudit"},
         {"name": "Measurements",                                       "parentId": "AgentOS",                            "isLeaf": false, "id": "AgentOS/Measurements", "collapsed": true},
             {"name": "PR Review Loaded-Surface Baseline (April 2026)", "parentId": "AgentOS/Measurements",                                "id": "agentos/measurements/pr-review-baseline-2026-04"},
             {"name": "Swarm Heartbeat Token Economy Baseline (May 2026)", "parentId": "AgentOS/Measurements",                             "id": "agentos/measurements/heartbeat-token-economy-2026-05"},

--- a/package.json
+++ b/package.json
@@ -27,7 +27,6 @@
         "ai:mcp-server-knowledge-base" : "node ./ai/mcp/server/knowledge-base/mcp-server.mjs",
         "ai:mcp-server-memory-core"    : "node ./ai/mcp/server/memory-core/mcp-server.mjs",
         "ai:mcp-server-neural-link"    : "node ./ai/mcp/server/neural-link/mcp-server.mjs",
-        "ai:migrate-memory"            : "node ./buildScripts/ai/syncMemoryChromaToNeo.mjs",
         "ai:run-sandman"               : "node ./buildScripts/ai/runSandman.mjs",
         "ai:server"                    : "chroma run --path ./.neo-ai-data/chroma/knowledge-base",
         "ai:server-memory"             : "chroma run --path ./.neo-ai-data/chroma/memory-core --port 8001",

--- a/test/playwright/unit/ai/mcp/server/memory-core/services/lifecycle/ChromaLifecycleService.spec.mjs
+++ b/test/playwright/unit/ai/mcp/server/memory-core/services/lifecycle/ChromaLifecycleService.spec.mjs
@@ -52,7 +52,7 @@ test.describe('Neo.ai.mcp.server.memory-core.services.lifecycle.ChromaLifecycleS
 
     test('initAsync short-circuits in unified mode even when autoStartDatabase=true', async () => {
         // Explicit coverage of the `initAsync` guard. Without this test, a future edit that reorders
-        // the short-circuit below the `autoStartDatabase && architecture` gate — or deletes it entirely
+        // the short-circuit below the `autoStartDatabase && engine` gate — or deletes it entirely
         // — would pass the other two tests (they call `startDatabase` / `manageDatabase` directly and
         // would still see the method-level guard). This test forces the bypass to be observable at
         // the init-flow level by setting autoStartDatabase=true (which would normally trigger spawn)


### PR DESCRIPTION
Resolves #10825
Related: #10822

Authored by GPT-5.5 (Codex Desktop). Session 019dfc0d-ae67-7112-9f96-f009b15f6139.

This removes the dead public config/script surfaces identified by the AC4 audit: the stale `ai:migrate-memory` npm command, the unused Knowledge Base `embeddingModel` config key/client, and Memory Core's unbacked `architecture` reads. It also adds the checked-in audit table under `learn/agentos/ConfigSubstrateDeadConfigAudit.md` so the KISS decisions are durable and reviewable.

Evidence: L2 (static source scan + targeted unit tests + syntax checks) -> L2 required (ACs are config/script cleanup with local runtime callsites). No residuals.

## Audit Table

| candidate | defining surface | current readers | verdict | action |
|---|---|---|---|---|
| `ai:migrate-memory` npm script | `package.json` | Exact scan found only the package entry, `buildScripts/README.md`, active ticket text, and historical archived issue references. The package entry pointed at missing `buildScripts/ai/syncMemoryChromaToNeo.mjs`. | `dead-remove` | Removed the package script and public build-script docs. |
| `buildScripts/ai/migrateMemoryCore.mjs` direct script | Build script file | No imports or package script remain. Active issue #10556 still cites it as precedent for re-embedding scope, and `Memory_DatabaseService.importDatabase({reEmbed:true})` remains the real API. | `needs-design` | Left the direct file in place; a follow-up can retire or replace it with an operator-approved one-shot migration artifact. |
| KB `embeddingModel` config key | `ai/mcp/server/knowledge-base/config.template.mjs` | The only KB runtime reader was `SearchService` construction. Query and embedding paths call `memory-core/services/TextEmbeddingService.mjs` with `mcConfig.embeddingProvider`; VectorService batches also use Memory Core provider routing. | `dead-remove` | Removed the KB template key and the unused `SearchService.embeddingModel` client. |
| MC `embeddingModel` config key | `ai/mcp/server/memory-core/config.template.mjs` | `TextEmbeddingService` uses it for Gemini embeddings; `HealthService.buildEmbeddingProviderBlock()` surfaces it in healthcheck output. | `live` | Kept. |
| Provider-specific `openAiCompatible.embeddingModel` / `ollama.embeddingModel` | `ai/mcp/server/memory-core/config.template.mjs` | `TextEmbeddingService` sends these models to the provider endpoints; `HealthService` reports them. | `live` | Kept. Phase 1.5 may move defaults into Tier 1, but they are not dead. |
| MC `engine` storage selector | `ai/mcp/server/memory-core/config.template.mjs` | `CollectionProxy` routes Chroma access with `aiConfig.engine`. | `live` | Kept and made HealthService / ChromaLifecycleService use the same key. |
| MC `architecture` storage selector | No config template definition | Only unbacked reads existed in `HealthService`, `ChromaLifecycleService`, and an old `StorageRouter` comment; the shipped config defines `engine`, not `architecture`. | `dead-remove` | Replaced the unbacked reads/comments with `engine`. |
| KB `backupPath` default | No KB config template definition | `knowledge-base/services/DatabaseService.mjs` accepts `backupPath` for backup orchestration, but the canonical backup runner passes it explicitly. | `needs-design` | Left unchanged; this is a shared-backup default-shape question, not a safe AC4 deletion. |
| MC `backupPath` default | `ai/mcp/server/memory-core/config.template.mjs` | `Memory_DatabaseService.exportDatabase()` uses it as the default backup output path. | `live` | Kept. |
| `chromaUnified` topology flag | KB and MC config templates | Chroma routing, lifecycle, and healthcheck topology still read it. #10822 Phase 2 owns removal after operator migration. | `defer-to-Phase-1.5` | Kept. |

## Count Summary

| Bucket | Count | Notes |
|---|---:|---|
| `dead-remove` | 3 | `ai:migrate-memory`, KB `embeddingModel`, and unbacked MC `architecture` reads. |
| `live` | 4 | MC embedding keys, provider-specific embedding model keys, MC `engine`, MC `backupPath`. |
| `defer-to-Phase-1.5` | 1 | `chromaUnified` is scheduled later by #10822 sequencing. |
| `needs-design` | 2 | Direct migration script retirement and KB backup default shape need separate contract decisions. |

## Scan Commands

```bash
rg -n "ai:migrate-memory|migrateMemoryCore|syncMemoryChromaToNeo|migrate-memory" package.json buildScripts ai learn resources --glob '!resources/content/issue-archive/**'
rg -n "aiConfig\\.embeddingModel|embeddingModel" ai/mcp/server/knowledge-base ai/mcp/server/memory-core buildScripts package.json learn/agentos test/playwright/unit/ai
rg -n "aiConfig\\.(engine|architecture)|\\bengine: 'hybrid'|aiConfig\\.backupPath|backupPath" ai/mcp/server buildScripts/ai test/playwright/unit/ai learn/agentos
rg -n -o "aiConfig\\.[A-Za-z0-9_]+" ai/mcp/server buildScripts/ai test/playwright/unit/ai
```

## Config Template Change Notes

Changed config key:
- `ai/mcp/server/knowledge-base/config.template.mjs`: removed `embeddingModel`.

Local gitignored `config.mjs` follow-up:
- Existing KB `config.mjs` files may still contain `embeddingModel`; removal is optional because tracked runtime no longer reads it.
- No gitignored `config.mjs` file is committed in this PR.

Restart boundary:
- Restart running Knowledge Base / Memory Core MCP processes after merge to load the code/template changes.

## Substrate Slot Rationale

Added `learn/agentos/ConfigSubstrateDeadConfigAudit.md`:
- Disposition: `move` (durable audit artifact, not per-turn boot surface).
- 3-axis rating: low trigger-frequency x medium failure-severity x high enforceability.
- Decay mitigation: retire or archive from `learn/tree.json` after #10822 Phase 2/3 config-doctor work supersedes this one-time audit.

Modified `learn/tree.json`:
- Disposition delta: adds navigation for the audit artifact only.
- 3-axis rating: low trigger-frequency x low failure-severity x high enforceability.
- Decay mitigation: remove the tree entry together with the audit doc if the audit is retired after #10822 completion.

## Deltas from Ticket

- Left `buildScripts/ai/migrateMemoryCore.mjs` in place as `needs-design` rather than deleting it inside this PR. The public npm command was stale and removed; deleting the direct operator script crosses a broader migration-tool contract because the underlying `Memory_DatabaseService.importDatabase({reEmbed:true})` path still exists and active issue text references the script as precedent.
- Left KB `backupPath` default shape as `needs-design`; the current backup orchestrator passes `backupPath` explicitly.

## Test Evidence

- `node --check ai/mcp/server/knowledge-base/config.template.mjs`
- `node --check ai/mcp/server/knowledge-base/services/SearchService.mjs`
- `node --check ai/mcp/server/memory-core/services/HealthService.mjs`
- `node --check ai/mcp/server/memory-core/services/lifecycle/ChromaLifecycleService.mjs`
- `node --check ai/mcp/server/memory-core/managers/StorageRouter.mjs`
- `node -e "JSON.parse(require('fs').readFileSync('package.json','utf8')); JSON.parse(require('fs').readFileSync('learn/tree.json','utf8'));"`
- `npm run test-unit -- test/playwright/unit/ai/mcp/server/knowledge-base/services/SearchService.spec.mjs test/playwright/unit/ai/mcp/server/memory-core/services/lifecycle/ChromaLifecycleService.spec.mjs test/playwright/unit/ai/mcp/server/memory-core/services/HealthService.spec.mjs` - 31 passed.
- `git diff --cached --check`
- `git diff --check origin/dev...HEAD`

## Post-Merge Validation

- [ ] Optional clone hygiene: remove `embeddingModel` from gitignored `ai/mcp/server/knowledge-base/config.mjs` files if present.
- [ ] Restart active KB / MC MCP server processes so long-running clones load the updated code.

## Commit

- `6b140af3d` - `fix(ai): remove dead config substrate surfaces (#10825)`
