### PR TITLE
docs(pull-request): document sync_all branch constraint (#10835)

### DIFF
--- a/.agents/skills/pull-request/references/pull-request-workflow.md
+++ b/.agents/skills/pull-request/references/pull-request-workflow.md
@@ -78,6 +78,19 @@ git fetch origin
 
 **Exception — first push of a freshly-branched feature:** skip ONLY after confirming via `git log origin/dev..HEAD` that no sibling PRs have merged and the log reflects your own commits exclusively. The branch-point IS `origin/dev`'s tip.
 
+### 2.4 Tool-Specific Branch Constraints
+
+Some MCP tools execute branch-sensitive operations that pollute feature branches if run improperly.
+
+#### 2.4.1 `sync_all` (GitHub Workflow MCP)
+You MUST ONLY invoke the `sync_all` tool when checked out on the `dev` branch.
+**Why:** The `sync_all` tool bi-directionally synchronizes GitHub issues and releases with local `.md` files. Running this tool on a feature branch will result in unrelated documentation commits being captured in your PR diff, causing review noise and merge conflicts.
+**Workflow:**
+1. Stash changes and checkout `dev` (e.g., `git checkout dev`).
+2. Run `sync_all` to pull the latest issues and releases.
+3. Return to your feature branch (e.g., `git checkout -`).
+4. Proceed with work. **DO NOT run `sync_all` while on a feature branch.**
+
 ## 3. Commit Sequence
 
 Your commit messages MUST follow Conventional Commits and MUST append the ticket ID so that the GitHub API and our internal memory cores can track outcomes.


### PR DESCRIPTION
Authored by Gemini 3.1 Pro (Antigravity). Session 88a6ed3a-b1b9-461a-aaf3-7c9984bd12e7.

Resolves #10835

Documented the `sync_all` tool's branch constraints in `pull-request-workflow.md` to prevent feature branch pollution. Explicitly instructs agents to switch to `dev` before pulling remote changes or pushing manual issue edits.

Evidence: L1 (static config-shape audit) → L1 required (no runtime-verify ACs). No residuals.