### PR TITLE
docs(pull-request): map vs world atlas constraints (#10835)

### DIFF
--- a/.agents/skills/create-skill/references/skill-authoring-guide.md
+++ b/.agents/skills/create-skill/references/skill-authoring-guide.md
@@ -101,6 +101,13 @@ Since the agent relies on this when executing the specific task, make it detaile
 - Use explicit Markdown formatting (Headers, Lists, Bold text) to make it scannable for the LLM.
 - **Never guess:** If the payload requires knowing the absolute path of configuration files, verify those paths before writing them into the payload.
 
+### The "Map vs World Atlas" Constraint Placement
+
+When documenting a constraint for a specific MCP tool (e.g., "Do not run `sync_all` on a feature branch"), you MUST NOT pollute high-level global workflow files (the "Map", like `pull-request-workflow.md` or `ticket-intake.md`) with tool-specific edge cases. 
+Instead, extract tool-specific constraints into dedicated, granular payload files (the "World Atlas") and only reference them when that specific tool is invoked.
+- **The Map:** General routing, global lifecycle rules. Keep this clean and high-level to prevent context bloat.
+- **The Atlas:** Tool-specific quirks, edge cases, payload shapes, and strict operational constraints.
+
 ## 3. The Lesson Promotion Path
 
 When a swarm agent discovers a systemic trap, an architectural pattern, or a workflow optimization that took significant effort to derive, that knowledge must not die when the session ends.

--- a/.agents/skills/create-skill/references/skill-authoring-guide.md
+++ b/.agents/skills/create-skill/references/skill-authoring-guide.md
@@ -103,7 +103,7 @@ Since the agent relies on this when executing the specific task, make it detaile
 
 ### The "Map vs World Atlas" Constraint Placement
 
-When documenting a constraint for a specific MCP tool (e.g., "Do not run `sync_all` on a feature branch"), you MUST NOT pollute high-level global workflow files (the "Map", like `pull-request-workflow.md` or `ticket-intake.md`) with tool-specific edge cases. 
+When documenting a constraint for a specific MCP tool (e.g., "Do not run `sync_all` on a feature branch"), you MUST NOT pollute high-level global workflow files (the "Map", like `pull-request-workflow.md` or `ticket-intake.md`) with tool-specific edge cases.
 Instead, extract tool-specific constraints into dedicated, granular payload files (the "World Atlas") and only reference them when that specific tool is invoked.
 - **The Map:** General routing, global lifecycle rules. Keep this clean and high-level to prevent context bloat.
 - **The Atlas:** Tool-specific quirks, edge cases, payload shapes, and strict operational constraints.

--- a/.agents/skills/pull-request/references/pull-request-workflow.md
+++ b/.agents/skills/pull-request/references/pull-request-workflow.md
@@ -78,6 +78,10 @@ git fetch origin
 
 **Exception — first push of a freshly-branched feature:** skip ONLY after confirming via `git log origin/dev..HEAD` that no sibling PRs have merged and the log reflects your own commits exclusively. The branch-point IS `origin/dev`'s tip.
 
+### 2.4 Tool-Specific Branch Constraints
+
+If you intend to use the `sync_all` MCP tool, you MUST read [sync-all-constraints.md](./sync-all-constraints.md) before execution to prevent severe branch pollution.
+
 ## 3. Commit Sequence
 
 Your commit messages MUST follow Conventional Commits and MUST append the ticket ID so that the GitHub API and our internal memory cores can track outcomes.

--- a/.agents/skills/pull-request/references/sync-all-constraints.md
+++ b/.agents/skills/pull-request/references/sync-all-constraints.md
@@ -2,7 +2,7 @@
 
 ## Branch Constraint
 
-You MUST NOT execute the `sync_all` tool while checked out on a feature branch (e.g., `agent/1234-feature`). 
+You MUST NOT execute the `sync_all` tool while checked out on a feature branch (e.g., `agent/1234-feature`).
 
 **Why:** The `sync_all` tool triggers a bi-directional synchronization of GitHub issues and releases with the local filesystem. Running it on a feature branch will pollute that branch with unrelated documentation commits, creating massive diff bloat and merge conflicts.
 

--- a/.agents/skills/pull-request/references/sync-all-constraints.md
+++ b/.agents/skills/pull-request/references/sync-all-constraints.md
@@ -1,0 +1,15 @@
+# Tool Constraint: sync_all
+
+## Branch Constraint
+
+You MUST NOT execute the `sync_all` tool while checked out on a feature branch (e.g., `agent/1234-feature`). 
+
+**Why:** The `sync_all` tool triggers a bi-directional synchronization of GitHub issues and releases with the local filesystem. Running it on a feature branch will pollute that branch with unrelated documentation commits, creating massive diff bloat and merge conflicts.
+
+## Execution Protocol
+
+Before invoking `sync_all`:
+1. Stash or commit any active work on your current feature branch.
+2. Checkout the default branch (`dev`): `git checkout dev`.
+3. Invoke the `sync_all` MCP tool.
+4. Return to your feature branch: `git checkout -`.


### PR DESCRIPTION
Authored by Gemini 3.1 Pro (Antigravity). Session 88a6ed3a-b1b9-461a-aaf3-7c9984bd12e7.

Resolves #10835

Moves the `sync_all` branch constraint out of the global PR workflow file into a dedicated payload file (`sync-all-constraints.md`) with a 1-line trigger, adhering to the "Map vs World Atlas" documentation architecture. Also updates the `create-skill` authoring guide to formalize this pattern for future tool-specific constraints.

Evidence: L1 (static document formatting) → L1 required. No residuals.

## Deltas from ticket (if any)
Added the formal "Map vs World Atlas Constraint Placement" rule to `@/create-skill` to ensure future tool constraints do not pollute global workflow files.

## Post-Merge Validation
- [ ] Verify formatting renders correctly in GitHub markdown view.
