### PR TITLE
fix(graph): enable foreign_keys pragma for cascade integrity (#10856)

### DIFF
--- a/ai/graph/storage/SQLite.mjs
+++ b/ai/graph/storage/SQLite.mjs
@@ -47,6 +47,7 @@ class SQLite extends Base {
         me.db = new Database(me.dbPath, { verbose: null });
         me.db.pragma('journal_mode = WAL');
         me.db.pragma('busy_timeout = 5000');
+        me.db.pragma('foreign_keys = ON'); // honor schema-declared `Edges` ON DELETE CASCADE per #10856
 
         try {
             const rcs = await import('../../mcp/server/shared/services/RequestContextService.mjs');

--- a/learn/agentos/MemoryCore.md
+++ b/learn/agentos/MemoryCore.md
@@ -11,7 +11,7 @@ Without memory, every session is a blank slate. An agent fixing a bug today has 
 
 ## Architecture
 
-The server is built on a modular service architecture, extending `Neo.core.Base`. It uses **ChromaDB** as the vector database for semantic search and **Google Gemini** for text embeddings and summarization.
+The server is built on a modular service architecture, extending `Neo.core.Base`. It uses **ChromaDB** as the vector database for semantic search and **Google Gemini** for text embeddings and summarization. The Native Edge Graph persists in SQLite via `ai/graph/storage/SQLite.mjs`, which sets `PRAGMA foreign_keys=ON` at connection time so the schema-declared `Edges` `ON DELETE CASCADE` fires on Node deletion (#10856).
 
 ### Key Services
 

--- a/test/playwright/unit/ai/graph/Database.spec.mjs
+++ b/test/playwright/unit/ai/graph/Database.spec.mjs
@@ -144,6 +144,34 @@ test.describe('Neo.ai.graph.Database', () => {
         reloadDb.destroy();
     });
 
+    test('SQLite storage enables foreign_keys pragma so Edges cascade-delete with referenced Nodes (#10856)', async () => {
+        if (fs.existsSync(dbPath)) fs.unlinkSync(dbPath);
+
+        let storage = Neo.create(SQLite, { dbPath });
+        await storage.initAsync();
+
+        // The pragma must be ON for the schema-declared `Edges` ON DELETE CASCADE to fire.
+        // SQLite default is OFF; explicit init pragma is the only enable path per-connection.
+        const pragmaState = storage.db.pragma('foreign_keys', { simple: true });
+        expect(pragmaState).toBe(1);
+
+        // Direct-SQL fixture (bypasses application-layer edge cleanup so we test FK cascade specifically).
+        storage.db.prepare('INSERT INTO Nodes (id, data) VALUES (?, ?)').run('cascade-source', '{}');
+        storage.db.prepare('INSERT INTO Nodes (id, data) VALUES (?, ?)').run('cascade-target', '{}');
+        storage.db.prepare('INSERT INTO Edges (id, source, target, type, data) VALUES (?, ?, ?, ?, ?)')
+            .run('cascade-edge', 'cascade-source', 'cascade-target', 'KNOWS', '{}');
+
+        expect(storage.db.prepare('SELECT COUNT(*) as c FROM Edges').get().c).toBe(1);
+
+        // Direct-SQL delete of the source Node — only the FK ON DELETE CASCADE can remove the edge here.
+        storage.db.prepare('DELETE FROM Nodes WHERE id = ?').run('cascade-source');
+
+        expect(storage.db.prepare('SELECT COUNT(*) as c FROM Edges').get().c).toBe(0);
+        expect(storage.db.prepare('SELECT COUNT(*) as c FROM Nodes').get().c).toBe(1);
+
+        storage.destroy();
+    });
+
     test('should execute graph mutations synchronously within an atomic transaction', async () => {
         if (fs.existsSync(dbPath)) fs.unlinkSync(dbPath);
         

--- a/test/playwright/unit/ai/graph/Database.spec.mjs
+++ b/test/playwright/unit/ai/graph/Database.spec.mjs
@@ -144,7 +144,7 @@ test.describe('Neo.ai.graph.Database', () => {
         reloadDb.destroy();
     });
 
-    test('SQLite storage enables foreign_keys pragma so Edges cascade-delete with referenced Nodes (#10856)', async () => {
+    test('SQLite storage enables foreign_keys pragma — source-side Edges cascade-delete (#10856)', async () => {
         if (fs.existsSync(dbPath)) fs.unlinkSync(dbPath);
 
         let storage = Neo.create(SQLite, { dbPath });
@@ -165,6 +165,33 @@ test.describe('Neo.ai.graph.Database', () => {
 
         // Direct-SQL delete of the source Node — only the FK ON DELETE CASCADE can remove the edge here.
         storage.db.prepare('DELETE FROM Nodes WHERE id = ?').run('cascade-source');
+
+        expect(storage.db.prepare('SELECT COUNT(*) as c FROM Edges').get().c).toBe(0);
+        expect(storage.db.prepare('SELECT COUNT(*) as c FROM Nodes').get().c).toBe(1);
+
+        storage.destroy();
+    });
+
+    test('SQLite storage enables foreign_keys pragma — target-side Edges cascade-delete (#10856)', async () => {
+        if (fs.existsSync(dbPath)) fs.unlinkSync(dbPath);
+
+        let storage = Neo.create(SQLite, { dbPath });
+        await storage.initAsync();
+
+        // Mirror of the source-side test. The schema declares both source AND target FKs with
+        // ON DELETE CASCADE; this test asserts the target-side cascade fires equivalently.
+        const pragmaState = storage.db.pragma('foreign_keys', { simple: true });
+        expect(pragmaState).toBe(1);
+
+        storage.db.prepare('INSERT INTO Nodes (id, data) VALUES (?, ?)').run('cascade-source', '{}');
+        storage.db.prepare('INSERT INTO Nodes (id, data) VALUES (?, ?)').run('cascade-target', '{}');
+        storage.db.prepare('INSERT INTO Edges (id, source, target, type, data) VALUES (?, ?, ?, ?, ?)')
+            .run('cascade-edge', 'cascade-source', 'cascade-target', 'KNOWS', '{}');
+
+        expect(storage.db.prepare('SELECT COUNT(*) as c FROM Edges').get().c).toBe(1);
+
+        // Direct-SQL delete of the TARGET Node — target-side FK ON DELETE CASCADE.
+        storage.db.prepare('DELETE FROM Nodes WHERE id = ?').run('cascade-target');
 
         expect(storage.db.prepare('SELECT COUNT(*) as c FROM Edges').get().c).toBe(0);
         expect(storage.db.prepare('SELECT COUNT(*) as c FROM Nodes').get().c).toBe(1);


### PR DESCRIPTION
Resolves #10856

Authored by Claude Opus 4.7 (Claude Code). Session 8b31fd62-6a53-40b5-aae2-c5288f8ced09.

The Native Edge Graph SQLite schema (`ai/graph/storage/SQLite.mjs`) declares `FOREIGN KEY (source) REFERENCES Nodes(id) ON DELETE CASCADE` AND `FOREIGN KEY (target) REFERENCES Nodes(id) ON DELETE CASCADE` on the Edges table — but SQLite's `PRAGMA foreign_keys` defaults to OFF per-connection, so the schema-declared cascade was non-functional at runtime. Direct-SQL deletion of either a source-referenced or target-referenced Node would silently leave dependent Edges as orphans referencing non-existent IDs. This PR adds `me.db.pragma('foreign_keys = ON')` to the SQLite storage init alongside the existing `journal_mode` and `busy_timeout` pragmas.

Evidence: L1 (static config-shape audit + targeted unit tests covering both source-side and target-side cascade) → L1 required (no runtime-verify ACs). No residuals.

## Substrate Mutation Slot Rationale

This PR touches `learn/agentos/MemoryCore.md` (sentence appended to the Architecture paragraph noting the FK PRAGMA behavior + ticket cross-reference).

| Surface | Disposition | 3-axis (frequency × severity × enforceability) | Rationale |
|---|---|---|---|
| `learn/agentos/MemoryCore.md` Architecture paragraph (one-sentence addition) | `keep` | low × medium × discipline (manual) | Substrate behavior anchor for operators reading the doc; references the ticket so the rationale is recoverable. Decay risk minimal — sentence is locked to a structural fact (pragma is set) that won't drift. |

## Test Evidence

Added two new specs to `test/playwright/unit/ai/graph/Database.spec.mjs` covering both FK-cascade directions explicitly:

1. `SQLite storage enables foreign_keys pragma — source-side Edges cascade-delete (#10856)` — asserts `db.pragma('foreign_keys', { simple: true }) === 1`, inserts two Nodes + one Edge via direct SQL, deletes the SOURCE Node via direct SQL, asserts the Edge is gone (cascade fired) and the target Node is preserved.
2. `SQLite storage enables foreign_keys pragma — target-side Edges cascade-delete (#10856)` — mirror of #1: same fixture, deletes the TARGET Node via direct SQL, asserts the Edge is gone via the schema's target-side `ON DELETE CASCADE` foreign-key clause.

```text
$ npx playwright test test/playwright/unit/ai/graph/Database.spec.mjs --reporter=list
Running 13 tests using 1 worker

  ✓   1 should add and retrieve a node correctly (4ms)
  ✓   2 should add an edge correctly (1ms)
  ✓   3 should traverse adjacent nodes (outbound) (1ms)
  ✓   4 should cascade delete edges when a node is removed (3ms)
  ✓   5 should persist nodes and edges properly using SQLite storage adapter (33ms)
  ✓   6 SQLite storage enables foreign_keys pragma — source-side Edges cascade-delete (#10856) (3ms)
  ✓   7 SQLite storage enables foreign_keys pragma — target-side Edges cascade-delete (#10856) (3ms)
  ✓   8 should execute graph mutations synchronously within an atomic transaction (7ms)
  ✓   9 should instantly rollback Memory Collections if transaction boundary throws (2ms)
  ✓  10 should enforce Cache Coherence flushing stale footprints dynamically (6ms)
  ✓  11 should replay GraphLog mutations even on fresh boot when lastSyncId is 0 (8ms)
  ✓  12 should not mark vicinityLoadedNodes if lazy load returns empty (2ms)
  ✓  13 should invalidate vicinity of both endpoints when syncCache invalidates edges (6ms)

  13 passed (1.2s)
```

The pre-existing application-layer cascade test (#4 above) continues to pass — `Database.removeNode` performs its own edge cleanup at the JS layer, which is why the orphan-edge gap was previously invisible from the test surface. Tests #6 and #7 exercise direct-SQL deletion specifically to validate both directions of the SQLite-layer cascade.

## Commits

- `49b8e0f1a` — fix(graph): enable foreign_keys pragma for cascade integrity (#10856)
- `44ddd79c4` — test(graph): add target-side cascade-delete coverage (#10856)