### PR TITLE
docs(codex): document harness restart recovery (#10864)

### DIFF
--- a/.codex/CODEX.md
+++ b/.codex/CODEX.md
@@ -27,3 +27,4 @@ and can drift independently of the Codex Desktop harness.
   before concluding GitHub is down, auth is invalid, or PR state is unavailable.
 - For state-changing GitHub calls, preserve the exact payload when retrying
   escalated so the sandbox retry does not mutate review/comment semantics.
+- Mid-session harness restart: read `.codex/HARNESS_RESTART.md` before diagnosing MCP, Chroma, GitHub, or wake-state failures.

--- a/.codex/HARNESS_RESTART.md
+++ b/.codex/HARNESS_RESTART.md
@@ -1,0 +1,56 @@
+# Mid-Session Harness Restart
+
+Use this file only when the Codex Desktop harness, MCP servers, or local
+substrate services were restarted while the session was still active.
+
+## First Checks
+
+1. Check unread A2A mail before acting:
+   `list_messages({status: 'unread'})`.
+2. Read and mark real messages. Treat old pre-restart self-wake messages as
+   expected noise unless they contain fresh handoff content.
+3. Verify the checkout before changing files:
+   `git status --short --branch`.
+4. Re-read the newest user prompt and prefer it over older wake text.
+
+## Localhost And Chroma
+
+Codex has two different paths to local services:
+
+- Native MCP tools can be healthy and able to save memory.
+- Shell commands inside the Codex sandbox can still fail against `localhost` or
+  `127.0.0.1`.
+
+If a sandboxed `curl`, `npm run ai:mcp-client`, GitHub call, or localhost check
+fails, do not immediately diagnose Chroma, Memory Core, GitHub auth, or MCP as
+broken. Re-run the same required check escalated first.
+
+Useful external-Chroma proof:
+
+```sh
+curl -L -sS http://localhost:8001/api/v2/heartbeat
+```
+
+Then use the native Memory Core `healthcheck` or a native `add_memory` call as
+the higher-signal proof for the active Codex session.
+
+## Memory Save
+
+End the turn with native `add_memory`. If a shell-based Memory Core client
+cannot reach localhost, that is not enough reason to skip the native MCP save.
+
+## GitHub Calls
+
+`gh auth status` can lie inside Codex sandboxing. Use:
+
+```sh
+gh api user --jq .login
+```
+
+If GitHub network calls fail in-sandbox and the task requires them, retry the
+same command escalated and preserve the exact payload for state-changing calls.
+
+## Keep This Small
+
+This is a Codex-only edge-case card. Do not move broad repo policy, normal MCP
+autoload behavior, or shared agent rules into this file.


### PR DESCRIPTION
Resolves #10864

Authored by GPT-5 (Codex Desktop). Session 441c9fbc-2742-4b52-b371-77247e101f08.

Adds a Codex-only mid-session harness restart card and keeps the always-injected Codex reference to a single trigger line. The goal is to turn the recent restart / localhost / Chroma / GitHub sandbox confusion into a narrow runbook without expanding global agent rules or bloating `.codex/CODEX.md`.

Evidence: L1 (static docs diff + markdown hygiene check) -> L1 required (documentation-only Codex harness recovery card). No residuals.

## Deltas From Ticket

No functional deltas. The implementation matches the ticket:

- `.codex/HARNESS_RESTART.md` contains the focused restart checklist.
- `.codex/CODEX.md` adds exactly one trigger line pointing to the card.

## Slot / Decay Rationale

| Surface | Disposition | 3-axis (frequency x severity x enforceability) | Rationale |
|---|---|---|---|
| `.codex/CODEX.md` trigger line | `compress-to-trigger` | medium x medium x discipline | This file is injected every Codex turn, so it gets one routing line only. |
| `.codex/HARNESS_RESTART.md` | `keep` | low x medium x discipline | Restart failures are episodic but expensive when they occur; the separate card avoids always-loaded manual bloat. |

## Test Evidence

- `git diff --check -- .codex/CODEX.md .codex/HARNESS_RESTART.md`
- `git diff --check origin/dev...HEAD`
- Verified branch freshness before push: `HEAD...origin/dev` was `1 0`

## Post-Merge Validation

- [ ] Next Codex harness restart can route to `.codex/HARNESS_RESTART.md` from the one-line `.codex/CODEX.md` trigger.

## Commit

- `abf4c164e` — `docs(codex): document harness restart recovery (#10864)`
