### PR TITLE
test(memory-core): mock Chroma collections to prevent data wipes (#10867)

### DIFF
--- a/test/playwright/unit/ai/mcp/server/memory-core/services/CoalescingEngineService.spec.mjs
+++ b/test/playwright/unit/ai/mcp/server/memory-core/services/CoalescingEngineService.spec.mjs
@@ -42,6 +42,11 @@ test.describe('CoalescingEngineService', () => {
     let deliverCalls;
 
     test.beforeAll(async () => {
+        const aiConfig = (await import('../../../../../../../../ai/mcp/server/memory-core/config.mjs')).default;
+        if (!aiConfig.collections) aiConfig.collections = {};
+        aiConfig.collections.memory = `test-memory-${process.pid}-${Date.now()}`;
+        aiConfig.collections.session = `test-session-${process.pid}-${Date.now()}`;
+
         CoalescingEngineService = (await import('../../../../../../../../ai/mcp/server/memory-core/services/CoalescingEngineService.mjs')).default;
         WebhookDeliveryService  = (await import('../../../../../../../../ai/mcp/server/memory-core/services/WebhookDeliveryService.mjs')).default;
         originalDeliver         = WebhookDeliveryService.deliver?.bind(WebhookDeliveryService);

--- a/test/playwright/unit/ai/mcp/server/memory-core/services/DatabaseService.backupPath.spec.mjs
+++ b/test/playwright/unit/ai/mcp/server/memory-core/services/DatabaseService.backupPath.spec.mjs
@@ -31,6 +31,11 @@ test.describe('Memory_DatabaseService — backupPath routing (#10129 Phase 2 pre
     let originalGetMemory, originalGetSummary, tmpDir;
 
     test.beforeAll(async () => {
+        const aiConfig = (await import('../../../../../../../../ai/mcp/server/memory-core/config.mjs')).default;
+        if (!aiConfig.collections) aiConfig.collections = {};
+        aiConfig.collections.memory = `test-memory-${process.pid}-${Date.now()}`;
+        aiConfig.collections.session = `test-session-${process.pid}-${Date.now()}`;
+
         SDK                    = await import('../../../../../../../../ai/services.mjs');
         Memory_DatabaseService = SDK.Memory_DatabaseService;
         Memory_StorageRouter   = SDK.Memory_StorageRouter;

--- a/test/playwright/unit/ai/mcp/server/memory-core/services/FileSystemIngestor.spec.mjs
+++ b/test/playwright/unit/ai/mcp/server/memory-core/services/FileSystemIngestor.spec.mjs
@@ -40,6 +40,9 @@ test.describe('Neo.ai.mcp.server.memory-core.services.FileSystemIngestor', () =>
         mockFsRoot = path.join(tmpDir, `fs-ingest-mock-${Date.now()}`);
 
         aiConfig.storagePaths.graph = testDbPath;
+        if (!aiConfig.collections) aiConfig.collections = {};
+        aiConfig.collections.memory = `test-memory-${Date.now()}`;
+        aiConfig.collections.session = `test-session-${Date.now()}`;
 
         GraphService       = (await import('../../../../../../../../ai/mcp/server/memory-core/services/GraphService.mjs')).default;
         FileSystemIngestor = (await import('../../../../../../../../ai/mcp/server/memory-core/services/FileSystemIngestor.mjs')).default;

--- a/test/playwright/unit/ai/mcp/server/memory-core/services/GraphService.spec.mjs
+++ b/test/playwright/unit/ai/mcp/server/memory-core/services/GraphService.spec.mjs
@@ -41,6 +41,9 @@ test.describe('Neo.ai.mcp.server.memory-core.services.GraphService', () => {
         // Mock the SQLite target path to a safe pure temporary location
         if (!aiConfig.storagePaths) aiConfig.storagePaths = {};
         aiConfig.storagePaths.graph = testDbPath;
+        if (!aiConfig.collections) aiConfig.collections = {};
+        aiConfig.collections.memory = `test-memory-${Date.now()}`;
+        aiConfig.collections.session = `test-session-${Date.now()}`;
         console.log('--- TEST DB PATH MOCKED TO:', aiConfig.storagePaths.graph);
 
         GraphService = (await import('../../../../../../../../ai/mcp/server/memory-core/services/GraphService.mjs')).default;

--- a/test/playwright/unit/ai/mcp/server/memory-core/services/MailboxService.spec.mjs
+++ b/test/playwright/unit/ai/mcp/server/memory-core/services/MailboxService.spec.mjs
@@ -35,6 +35,9 @@ test.describe('Neo.ai.mcp.server.memory-core.services.MailboxService', () => {
         // Force temp file DB config instead of :memory: to prevent initialization race wipes
         mailboxAiConfig = (await import('../../../../../../../../ai/mcp/server/memory-core/config.mjs')).default;
         mailboxAiConfig.storagePaths.graph = dbPath;
+        if (!mailboxAiConfig.collections) mailboxAiConfig.collections = {};
+        mailboxAiConfig.collections.memory = `test-memory-${Date.now()}`;
+        mailboxAiConfig.collections.session = `test-session-${Date.now()}`;
 
         // Load dynamically due to SQLite DB mount timing
         GraphService = (await import('../../../../../../../../ai/mcp/server/memory-core/services/GraphService.mjs')).default;

--- a/test/playwright/unit/ai/mcp/server/memory-core/services/PermissionService.spec.mjs
+++ b/test/playwright/unit/ai/mcp/server/memory-core/services/PermissionService.spec.mjs
@@ -36,6 +36,11 @@ test.describe('Neo.ai.mcp.server.memory-core.services.PermissionService', () => 
         const aiConfig = (await import('../../../../../../../../ai/mcp/server/memory-core/config.mjs')).default;
         aiConfig.storagePaths.graph = dbPath;
 
+        // Mock Chroma collections to prevent production data wipes (#10845 / #10867)
+        if (!aiConfig.collections) aiConfig.collections = {};
+        aiConfig.collections.memory = `test-memory-${process.pid}-${Date.now()}`;
+        aiConfig.collections.session = `test-session-${process.pid}-${Date.now()}`;
+
         GraphService = (await import('../../../../../../../../ai/mcp/server/memory-core/services/GraphService.mjs')).default;
         PermissionService = (await import('../../../../../../../../ai/mcp/server/memory-core/services/PermissionService.mjs')).default;
         LifecycleService = (await import('../../../../../../../../ai/mcp/server/memory-core/services/lifecycle/SystemLifecycleService.mjs')).default;

--- a/test/playwright/unit/ai/mcp/server/memory-core/services/WakeSubscriptionService.spec.mjs
+++ b/test/playwright/unit/ai/mcp/server/memory-core/services/WakeSubscriptionService.spec.mjs
@@ -41,6 +41,10 @@ test.describe('Neo.ai.mcp.server.memory-core.services.WakeSubscriptionService', 
         const aiConfig = (await import('../../../../../../../../ai/mcp/server/memory-core/config.mjs')).default;
         aiConfig.storagePaths.graph = dbPath;
 
+        if (!aiConfig.collections) aiConfig.collections = {};
+        aiConfig.collections.memory = `test-memory-${process.pid}-${Date.now()}`;
+        aiConfig.collections.session = `test-session-${process.pid}-${Date.now()}`;
+
         GraphService            = (await import('../../../../../../../../ai/mcp/server/memory-core/services/GraphService.mjs')).default;
         WakeSubscriptionService = (await import('../../../../../../../../ai/mcp/server/memory-core/services/WakeSubscriptionService.mjs')).default;
         CoalescingEngineService = (await import('../../../../../../../../ai/mcp/server/memory-core/services/CoalescingEngineService.mjs')).default;

--- a/test/playwright/unit/ai/mcp/server/memory-core/services/WriteSideInvariant.spec.mjs
+++ b/test/playwright/unit/ai/mcp/server/memory-core/services/WriteSideInvariant.spec.mjs
@@ -61,6 +61,9 @@ test.describe('Neo.ai.mcp.server.memory-core.services.WriteSideInvariant (#10017
 
         const aiConfig = (await import('../../../../../../../../ai/mcp/server/memory-core/config.mjs')).default;
         aiConfig.storagePaths.graph = dbPath;
+        if (!aiConfig.collections) aiConfig.collections = {};
+        aiConfig.collections.memory = `test-memory-${Date.now()}`;
+        aiConfig.collections.session = `test-session-${Date.now()}`;
 
         GraphService     = (await import('../../../../../../../../ai/mcp/server/memory-core/services/GraphService.mjs')).default;
         MailboxService   = (await import('../../../../../../../../ai/mcp/server/memory-core/services/MailboxService.mjs')).default;

--- a/test/playwright/unit/ai/mcp/server/memory-core/util.mjs
+++ b/test/playwright/unit/ai/mcp/server/memory-core/util.mjs
@@ -12,17 +12,17 @@ export async function cleanupChromaManager(SDK) {
         collectionsConfig = aiConfig?.collections;
     }
 
-    try {
-        if (ChromaManager?.client && collectionsConfig) {
-            if (collectionsConfig.memory === 'neo-agent-memory' || collectionsConfig.session === 'neo-agent-sessions') {
-                throw new Error(`FATAL: Attempted to delete production Chroma collections! Aborting cleanup. memory=${collectionsConfig.memory}, session=${collectionsConfig.session}`);
-            }
+    if (ChromaManager?.client && collectionsConfig) {
+        if (collectionsConfig.memory === 'neo-agent-memory' || collectionsConfig.session === 'neo-agent-sessions') {
+            throw new Error(`FATAL: Attempted to delete production Chroma collections! Aborting cleanup. memory=${collectionsConfig.memory}, session=${collectionsConfig.session}`);
+        }
+        try {
             try { await ChromaManager.client.deleteCollection({name: collectionsConfig.memory}); } catch(e) { if (!e.message.includes('not be found')) throw e; }
             try { await ChromaManager.client.deleteCollection({name: collectionsConfig.session}); } catch(e) { if (!e.message.includes('not be found')) throw e; }
-        }
-    } catch (e) {
-        if (!e.message.includes('not be found')) {
-            console.warn(`[Cleanup] Failed to delete test collections:`, e.message);
+        } catch (e) {
+            if (!e.message.includes('not be found')) {
+                console.warn(`[Cleanup] Failed to delete test collections:`, e.message);
+            }
         }
     }
 

--- a/test/playwright/unit/ai/mcp/server/memory-core/util.mjs
+++ b/test/playwright/unit/ai/mcp/server/memory-core/util.mjs
@@ -14,6 +14,9 @@ export async function cleanupChromaManager(SDK) {
 
     try {
         if (ChromaManager?.client && collectionsConfig) {
+            if (collectionsConfig.memory === 'neo-agent-memory' || collectionsConfig.session === 'neo-agent-sessions') {
+                throw new Error(`FATAL: Attempted to delete production Chroma collections! Aborting cleanup. memory=${collectionsConfig.memory}, session=${collectionsConfig.session}`);
+            }
             try { await ChromaManager.client.deleteCollection({name: collectionsConfig.memory}); } catch(e) { if (!e.message.includes('not be found')) throw e; }
             try { await ChromaManager.client.deleteCollection({name: collectionsConfig.session}); } catch(e) { if (!e.message.includes('not be found')) throw e; }
         }


### PR DESCRIPTION
Closes #10867.

This PR implements the immediate 'Layer 1' stopgap to prevent Playwright tests from wiping out canonical production Chroma collections (`neo-agent-memory` and `neo-agent-sessions`).

### Changes
1. Mocked `aiConfig.collections.memory` and `aiConfig.collections.session` with process/timestamp-isolated values in the `beforeAll` blocks of remaining vulnerable test suites (`WakeSubscriptionService.spec.mjs`, `CoalescingEngineService.spec.mjs`, `PermissionService.spec.mjs`, `DatabaseService.backupPath.spec.mjs`).
2. Implemented a hardcoded failsafe in `test/playwright/unit/ai/mcp/server/memory-core/util.mjs` (`cleanupChromaManager`) that throws a fatal error and aborts cleanup if it detects an attempt to delete the canonical production collections.

### Validation
Ran `npm run test-unit -- test/playwright/unit/ai/mcp/server/memory-core/` and verified the failsafe did not trigger and the dummy collections were safely cleaned up.

@neo-gpt This is ready for your review to land the stopgap while you continue on the Layer 2 substrate guard (#10845).