### PR TITLE
feat(agentos): guard destructive substrate operations (#10845)

### DIFF
--- a/ai/mcp/server/knowledge-base/openapi.yaml
+++ b/ai/mcp/server/knowledge-base/openapi.yaml
@@ -135,6 +135,9 @@ paths:
                   type: string
                   enum: [sync, create, embed, delete]
                   description: The management action to perform.
+                confirmation:
+                  type: string
+                  description: Explicit production confirmation token required with the destructive bypass env for delete.
       responses:
         '200':
           description: Operation completed successfully.

--- a/ai/mcp/server/knowledge-base/services/DatabaseService.mjs
+++ b/ai/mcp/server/knowledge-base/services/DatabaseService.mjs
@@ -239,14 +239,15 @@ class DatabaseService extends Base {
     /**
      * Manages knowledge base data operations based on the provided action.
      * @param {Object}  params
-     * @param {String}  params.action     'sync', 'create', 'embed', or 'delete'
-     * @param {Boolean} [params.viaMcp]   True when dispatched from the MCP toolService
-     *                                    wrapper; threaded through to `embed()` to enable
-     *                                    the work-volume gate (#10572). CLI callers
-     *                                    omit this and bypass the gate.
+     * @param {String}        params.action       'sync', 'create', 'embed', or 'delete'
+     * @param {Boolean}      [params.viaMcp]      True when dispatched from the MCP toolService
+     *                                            wrapper; threaded through to `embed()` to enable
+     *                                            the work-volume gate (#10572). CLI callers
+     *                                            omit this and bypass the gate.
+     * @param {String|Object} [params.confirmation] Explicit production confirmation token for delete.
      * @returns {Promise<Object>}
      */
-    async manageKnowledgeBase({action, viaMcp = false}) {
+    async manageKnowledgeBase({action, viaMcp = false, confirmation}) {
         switch (action) {
             case 'sync':
                 return this.syncDatabase({viaMcp});
@@ -255,7 +256,7 @@ class DatabaseService extends Base {
             case 'embed':
                 return this.embedKnowledgeBase({viaMcp});
             case 'delete':
-                return this.deleteDatabase();
+                return this.deleteDatabase({confirmation});
             default:
                 throw new Error(`Invalid action: ${action}. Must be 'sync', 'create', 'embed', or 'delete'.`);
         }
@@ -317,10 +318,12 @@ class DatabaseService extends Base {
     /**
      * Permanently deletes the entire knowledge base collection from ChromaDB.
      * Delegates to VectorService.
+     * @param {Object}       [options]
+     * @param {String|Object} [options.confirmation] Explicit production confirmation token.
      * @returns {Promise<object>} A promise that resolves to a success message.
      */
-    async deleteDatabase() {
-        return await VectorService.deleteCollection();
+    async deleteDatabase({confirmation} = {}) {
+        return await VectorService.deleteCollection({confirmation});
     }
 
     /**

--- a/ai/mcp/server/knowledge-base/services/VectorService.mjs
+++ b/ai/mcp/server/knowledge-base/services/VectorService.mjs
@@ -1,12 +1,13 @@
-import aiConfig             from '../config.mjs';
-import TextEmbeddingService from '../../memory-core/services/TextEmbeddingService.mjs';
-import mcConfig             from '../../memory-core/config.mjs';
-import Base                 from '../../../../../src/core/Base.mjs';
-import ChromaManager        from './ChromaManager.mjs';
-import fs                   from 'fs-extra';
-import logger               from '../logger.mjs';
-import path                 from 'path';
-import readline             from 'readline';
+import aiConfig                  from '../config.mjs';
+import TextEmbeddingService      from '../../memory-core/services/TextEmbeddingService.mjs';
+import mcConfig                  from '../../memory-core/config.mjs';
+import Base                      from '../../../../../src/core/Base.mjs';
+import ChromaManager             from './ChromaManager.mjs';
+import fs                        from 'fs-extra';
+import logger                    from '../logger.mjs';
+import path                      from 'path';
+import readline                  from 'readline';
+import DestructiveOperationGuard from '../../shared/services/DestructiveOperationGuard.mjs';
 
 /**
  * @summary Manages vector database operations including embedding generation and storage.
@@ -50,11 +51,30 @@ class VectorService extends Base {
 
     /**
      * Permanently deletes the knowledge base collection.
+     * @param {Object}       [options]
+     * @param {String|Object} [options.confirmation] Explicit production confirmation token.
      * @returns {Promise<object>} A promise that resolves to a success message.
      */
-    async deleteCollection() {
+    async deleteCollection({confirmation} = {}) {
         const collectionName = aiConfig.collectionName;
         try {
+            await DestructiveOperationGuard.assertDestructiveTargetAllowed({
+                operation: 'knowledge-base.chroma.delete',
+                subsystem: 'knowledge-base',
+                mode     : 'delete',
+                target   : {
+                    collectionName,
+                    chroma: {
+                        host: aiConfig.host,
+                        port: aiConfig.port,
+                        path: aiConfig.path
+                    },
+                    path    : aiConfig.path,
+                    repoRoot: aiConfig.neoRootDir
+                },
+                confirmation
+            });
+
             await ChromaManager.client.deleteCollection({name: collectionName});
             ChromaManager._knowledgeBaseCollectionPromise = null;
             ChromaManager.knowledgeBaseCollection = null;

--- a/ai/mcp/server/memory-core/managers/CollectionProxy.mjs
+++ b/ai/mcp/server/memory-core/managers/CollectionProxy.mjs
@@ -1,5 +1,6 @@
-import Base                from '../../../../../src/core/Base.mjs';
-import aiConfig            from '../config.mjs';
+import Base                      from '../../../../../src/core/Base.mjs';
+import aiConfig                  from '../config.mjs';
+import DestructiveOperationGuard from '../../shared/services/DestructiveOperationGuard.mjs';
 
 /**
  * @class Neo.ai.mcp.server.memory-core.managers.CollectionProxy
@@ -84,7 +85,7 @@ class CollectionProxy extends Base {
         await Promise.all(collections.map(c => c.delete(args)));
     }
 
-    async drop() {
+    async drop({confirmation} = {}) {
         const managers = await this.getManagers();
         for (const manager of managers) {
             let coll;
@@ -95,7 +96,28 @@ class CollectionProxy extends Base {
                     await manager.getMemoryCollection() : 
                     await manager.getSummaryCollection();
             }
-                
+
+            const chromaCoordinates = manager.resolveChromaCoordinates?.(aiConfig) || aiConfig.engines?.chroma || {};
+            const chromaPath        = chromaCoordinates.path || chromaCoordinates.dataDir ||
+                (aiConfig.chromaUnified ? undefined : aiConfig.engines?.chroma?.dataDir);
+
+            await DestructiveOperationGuard.assertDestructiveTargetAllowed({
+                operation: `memory-core.${this.collectionType}.drop`,
+                subsystem: 'memory-core',
+                mode     : 'drop',
+                target   : {
+                    collectionName: coll.name,
+                    chroma        : {
+                        host: chromaCoordinates.host,
+                        port: chromaCoordinates.port,
+                        path: chromaPath
+                    },
+                    path    : chromaPath,
+                    repoRoot: process.cwd()
+                },
+                confirmation
+            });
+
             if (manager.client && manager.client.deleteCollection) {
                 await manager.client.deleteCollection({ name: coll.name });
             } else if (manager.deleteCollection) {

--- a/ai/mcp/server/memory-core/openapi.yaml
+++ b/ai/mcp/server/memory-core/openapi.yaml
@@ -413,6 +413,7 @@ paths:
     delete:
       summary: Delete All Summaries
       operationId: delete_all_summaries
+      x-pass-as-object: true
       x-annotations:
         destructiveHint: true
       description: |
@@ -420,6 +421,16 @@ paths:
 
         **Warning:** This is a destructive operation. It is useful for resetting the summary index while keeping raw memories intact.
       tags: [Summaries]
+      requestBody:
+        required: false
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                confirmation:
+                  type: string
+                  description: Explicit production confirmation token required with the destructive bypass env for the legacy single-tenant drop path.
       responses:
         '200':
           description: All summaries deleted successfully

--- a/ai/mcp/server/memory-core/services/DatabaseService.mjs
+++ b/ai/mcp/server/memory-core/services/DatabaseService.mjs
@@ -1,10 +1,11 @@
-import aiConfig      from '../config.mjs';
-import fs            from 'fs-extra';
-import logger        from '../logger.mjs';
-import path          from 'path';
-import readline      from 'readline';
-import Base          from '../../../../../src/core/Base.mjs';
-import StorageRouter from '../managers/StorageRouter.mjs';
+import aiConfig                  from '../config.mjs';
+import fs                        from 'fs-extra';
+import logger                    from '../logger.mjs';
+import path                      from 'path';
+import readline                  from 'readline';
+import Base                      from '../../../../../src/core/Base.mjs';
+import StorageRouter             from '../managers/StorageRouter.mjs';
+import DestructiveOperationGuard from '../../shared/services/DestructiveOperationGuard.mjs';
 
 /**
  * @summary Service for exporting and importing memory core data.
@@ -213,10 +214,11 @@ class DatabaseService extends Base {
      * Helper method to import the Native Graph from JSONL.
      * @param {String} filePath The JSONL file path.
      * @param {String} mode 'merge' or 'replace'.
+     * @param {String|Object} [confirmation] Explicit production confirmation token.
      * @returns {Promise<number>}
      * @private
      */
-    async #importGraph(filePath, mode) {
+    async #importGraph(filePath, mode, confirmation) {
         logger.log(`Importing Graph Data from ${filePath} (mode: ${mode})...`);
         const GraphService = (await import('./GraphService.mjs')).default;
 
@@ -227,6 +229,13 @@ class DatabaseService extends Base {
         const db = GraphService.db.storage.db;
 
         if (mode === 'replace') {
+            await this.#assertGraphDestructiveTargetAllowed({
+                operation: 'memory-core.graph.import.replace',
+                mode     : 'replace',
+                source   : {path: filePath},
+                confirmation
+            });
+
             logger.log(`Replace mode: Truncating existing Graph Nodes and Edges...`);
             db.prepare('DELETE FROM Nodes').run();
             db.prepare('DELETE FROM Edges').run();
@@ -333,11 +342,12 @@ class DatabaseService extends Base {
      * Imports a previously exported JSONL file back into the database.
      * @param {Object} options
      * @param {String} options.file The path to the backup file to import.
-     * @param {String} options.mode The import mode: 'merge' or 'replace'.
-     * @param {Boolean} [options.reEmbed=false] If true, regenerates embeddings for all records.
+     * @param {String}        options.mode The import mode: 'merge' or 'replace'.
+     * @param {Boolean}      [options.reEmbed=false] If true, regenerates embeddings for all records.
+     * @param {String|Object} [options.confirmation] Explicit production confirmation token.
      * @returns {Promise<{imported: number, total: number, mode: string}>}
      */
-    async importDatabase({file, mode, reEmbed=false}) {
+    async importDatabase({file, mode, reEmbed=false, confirmation}) {
         try {
             let filesToImport = [];
 
@@ -391,7 +401,7 @@ class DatabaseService extends Base {
                 
                 const isGraphBackup = path.basename(filePath).startsWith('graph-backup');
                 if (isGraphBackup) {
-                    const graphImportCount = await this.#importGraph(filePath, mode);
+                    const graphImportCount = await this.#importGraph(filePath, mode, confirmation);
                     totalImported += graphImportCount;
                     continue;
                 }
@@ -450,27 +460,34 @@ class DatabaseService extends Base {
     /**
      * Truncates specified collections (or graph) from the database.
      * @param {Object} options
-     * @param {String[]} [options.include=['memories', 'summaries', 'graph']] 
+     * @param {String[]}      [options.include=['memories', 'summaries', 'graph']]
+     * @param {String|Object} [options.confirmation] Explicit production confirmation token.
      * @returns {Promise<{message: string}>}
      */
-    async truncateDatabase({include=['memories', 'summaries', 'graph']} = {}) {
+    async truncateDatabase({include=['memories', 'summaries', 'graph'], confirmation} = {}) {
         try {
             logger.log('Starting truncation of agent database...');
             let truncated = [];
 
             if (include.includes('memories')) {
                 const proxy = Neo.create('Neo.ai.mcp.server.memory-core.managers.CollectionProxy', { collectionType: 'memory' });
-                await proxy.drop();
+                await proxy.drop({confirmation});
                 truncated.push('memories');
             }
 
             if (include.includes('summaries')) {
                 const proxy = Neo.create('Neo.ai.mcp.server.memory-core.managers.CollectionProxy', { collectionType: 'session' });
-                await proxy.drop();
+                await proxy.drop({confirmation});
                 truncated.push('summaries');
             }
             
             if (include.includes('graph')) {
+                await this.#assertGraphDestructiveTargetAllowed({
+                    operation: 'memory-core.graph.truncate',
+                    mode     : 'truncate',
+                    confirmation
+                });
+
                 const GraphService = (await import('./GraphService.mjs')).default;
                 if (GraphService.db?.storage?.db) {
                     GraphService.db.storage.db.prepare('DELETE FROM Nodes').run();
@@ -505,6 +522,32 @@ class DatabaseService extends Base {
         } else {
             throw new Error(`Unknown action: ${action}`);
         }
+    }
+
+    /**
+     * Applies the shared destructive-operation guard to Native Edge Graph targets.
+     *
+     * @param {Object}        options
+     * @param {String}        options.operation
+     * @param {String}        options.mode
+     * @param {Object}       [options.source]
+     * @param {String|Object} [options.confirmation]
+     * @returns {Promise<Object>}
+     * @private
+     */
+    async #assertGraphDestructiveTargetAllowed({operation, mode, source, confirmation}) {
+        return DestructiveOperationGuard.assertDestructiveTargetAllowed({
+            operation,
+            subsystem: 'memory-core',
+            mode,
+            target: {
+                sqlitePath: aiConfig.storagePaths.graph,
+                path      : aiConfig.storagePaths.graph,
+                repoRoot  : process.cwd()
+            },
+            source,
+            confirmation
+        })
     }
 }
 

--- a/ai/mcp/server/memory-core/services/SummaryService.mjs
+++ b/ai/mcp/server/memory-core/services/SummaryService.mjs
@@ -48,9 +48,11 @@ class SummaryService extends Base {
 
     /**
      * Deletes all session summaries.
+     * @param {Object}       [options]
+     * @param {String|Object} [options.confirmation] Explicit production confirmation token.
      * @returns {Promise<{deleted: number, message: string}>}
      */
-    async deleteAllSummaries() {
+    async deleteAllSummaries({confirmation} = {}) {
         try {
             const collection = await StorageRouter.getSummaryCollection();
             const userId     = normalizeUserId(RequestContextService.getUserId());
@@ -78,7 +80,7 @@ class SummaryService extends Base {
 
             // Legacy single-tenant path (stdio mode, no request context): drop + recreate.
             const count = await collection.count();
-            await collection.drop();
+            await collection.drop({confirmation});
             await StorageRouter.getSummaryCollection(); // Re-creates it
             return { deleted: count, message: 'All summaries successfully deleted' };
         } catch (error) {

--- a/ai/mcp/server/shared/services/DestructiveOperationGuard.mjs
+++ b/ai/mcp/server/shared/services/DestructiveOperationGuard.mjs
@@ -1,0 +1,241 @@
+import os   from 'os';
+import path from 'path';
+import Base from '../../../../../src/core/Base.mjs';
+
+export const DESTRUCTIVE_PRODUCTION_BYPASS_ENV  = 'NEO_ALLOW_PRODUCTION_DESTRUCTIVE_AI_SUBSTRATE';
+export const DESTRUCTIVE_PRODUCTION_CONFIRMATION = 'CONFIRM_PRODUCTION_DESTRUCTIVE_AI_SUBSTRATE';
+
+/**
+ * @summary Error thrown when a destructive AI substrate operation targets a production path.
+ *
+ * Carries a stable `code` for callers and tests while preserving the rejected operation,
+ * subsystem, mode, target, and source metadata for operator-facing diagnostics.
+ *
+ * @class DestructiveOperationBlockedError
+ * @extends Error
+ */
+export class DestructiveOperationBlockedError extends Error {
+    /**
+     * @param {Object} options
+     */
+    constructor({operation, subsystem, mode, target, source, reason, pathResults}) {
+        super(
+            `DESTRUCTIVE_TARGET_BLOCKED: ${subsystem || 'unknown'} ${operation || 'operation'} ` +
+            `(${mode || 'unknown'}) rejected: ${reason}. Set ${DESTRUCTIVE_PRODUCTION_BYPASS_ENV}=true ` +
+            `and pass confirmation '${DESTRUCTIVE_PRODUCTION_CONFIRMATION}' only for deliberate production maintenance.`
+        );
+
+        this.name        = 'DestructiveOperationBlockedError';
+        this.code        = 'DESTRUCTIVE_TARGET_BLOCKED';
+        this.operation   = operation;
+        this.subsystem   = subsystem;
+        this.mode        = mode;
+        this.target      = target;
+        this.source      = source;
+        this.reason      = reason;
+        this.pathResults = pathResults;
+    }
+}
+
+/**
+ * @summary Shared fail-closed guard for destructive AI substrate operations.
+ *
+ * Provides the canonical `assertDestructiveTargetAllowed()` contract for Memory Core,
+ * Knowledge Base, and restore tooling. The guard intentionally reasons over explicit target
+ * descriptors instead of ambient `UNIT_TEST_MODE` state: disposable targets are allowed when
+ * their storage paths resolve to SQLite `:memory:`, the OS temp directory, or the repository
+ * `tmp/` folder; production-like or unresolved targets are blocked unless an operator supplies
+ * both the production bypass environment variable and the explicit confirmation token.
+ *
+ * @class Neo.ai.mcp.server.shared.services.DestructiveOperationGuard
+ * @extends Neo.core.Base
+ * @singleton
+ */
+class DestructiveOperationGuard extends Base {
+    static config = {
+        /**
+         * @member {String} className='Neo.ai.mcp.server.shared.services.DestructiveOperationGuard'
+         * @protected
+         */
+        className: 'Neo.ai.mcp.server.shared.services.DestructiveOperationGuard',
+        /**
+         * @member {Boolean} singleton=true
+         * @protected
+         */
+        singleton: true
+    }
+
+    /**
+     * Asserts that a destructive target is disposable, or explicitly operator-confirmed.
+     *
+     * @param {Object}        options
+     * @param {String}        options.operation             Stable operation identifier.
+     * @param {String}        options.subsystem             Owning subsystem.
+     * @param {String}        options.mode                  Destructive mode, e.g. `delete`, `drop`, or `replace`.
+     * @param {Object}        options.target                Target descriptor.
+     * @param {String}       [options.target.path]          Target data path.
+     * @param {String}       [options.target.sqlitePath]    Target SQLite path.
+     * @param {String}       [options.target.bundlePath]    Target backup bundle path when it is the destructive destination.
+     * @param {Object}       [options.target.chroma]        Chroma target descriptor.
+     * @param {String}       [options.target.collectionName] Chroma collection name.
+     * @param {String}       [options.target.repoRoot]      Repository root for `tmp/` allowance.
+     * @param {String[]}     [options.target.disposableRoots] Additional disposable root paths.
+     * @param {Object}       [options.source]               Optional source descriptor for diagnostics.
+     * @param {String|Object} [options.confirmation]         Explicit production confirmation token.
+     * @param {Object}       [options.env=process.env]      Environment map, injectable for tests.
+     * @returns {Promise<Object>} An allow result containing classification details.
+     * @throws {DestructiveOperationBlockedError} When the target is production-like or unresolved.
+     */
+    async assertDestructiveTargetAllowed({
+        operation,
+        subsystem,
+        mode,
+        target = {},
+        source,
+        confirmation,
+        env = process.env
+    } = {}) {
+        if (this.#isProductionConfirmed({confirmation, env})) {
+            return {
+                allowed       : true,
+                classification: 'operator-confirmed',
+                operation,
+                subsystem,
+                mode
+            }
+        }
+
+        const pathResults = this.#classifyTargetPaths(target);
+        let reason;
+
+        if (pathResults.length === 0) {
+            reason = 'target descriptor does not include a resolvable destructive path';
+        } else if (pathResults.every(result => result.disposable)) {
+            return {
+                allowed       : true,
+                classification: 'disposable',
+                operation,
+                subsystem,
+                mode,
+                pathResults
+            }
+        } else {
+            const blocked = pathResults.filter(result => !result.disposable).map(result => result.value).join(', ');
+            reason = `target path is not disposable (${blocked})`;
+        }
+
+        throw new DestructiveOperationBlockedError({
+            operation,
+            subsystem,
+            mode,
+            target,
+            source,
+            reason,
+            pathResults
+        })
+    }
+
+    /**
+     * Determines whether both production-bypass gates are present.
+     *
+     * @param {Object}        options
+     * @param {String|Object} options.confirmation
+     * @param {Object}        options.env
+     * @returns {Boolean}
+     * @private
+     */
+    #isProductionConfirmed({confirmation, env}) {
+        const token = typeof confirmation === 'object' && confirmation !== null
+            ? confirmation.token
+            : confirmation;
+
+        return env?.[DESTRUCTIVE_PRODUCTION_BYPASS_ENV] === 'true' &&
+            token === DESTRUCTIVE_PRODUCTION_CONFIRMATION
+    }
+
+    /**
+     * Builds disposable/prod classification records for every target destination path.
+     *
+     * @param {Object} target
+     * @returns {Object[]}
+     * @private
+     */
+    #classifyTargetPaths(target) {
+        const paths = this.#collectTargetPaths(target);
+
+        return paths.map(value => {
+            if (value === ':memory:') {
+                return {value, disposable: true, reason: 'sqlite-memory'}
+            }
+
+            const resolved        = path.resolve(value),
+                  disposableRoots = this.#getDisposableRoots(target);
+
+            return {
+                value     : resolved,
+                disposable: disposableRoots.some(root => this.#isPathInside(resolved, root)),
+                reason    : 'path'
+            }
+        })
+    }
+
+    /**
+     * Collects target destination paths from the canonical descriptor shape.
+     *
+     * @param {Object} target
+     * @returns {String[]}
+     * @private
+     */
+    #collectTargetPaths(target) {
+        const paths = new Set();
+
+        [
+            target?.path,
+            target?.sqlitePath,
+            target?.bundlePath,
+            target?.chroma?.path,
+            target?.chroma?.dataDir
+        ].forEach(value => {
+            if (typeof value === 'string' && value.trim()) {
+                paths.add(value);
+            }
+        });
+
+        return [...paths]
+    }
+
+    /**
+     * Resolves the built-in and caller-provided disposable roots.
+     *
+     * @param {Object} target
+     * @returns {String[]}
+     * @private
+     */
+    #getDisposableRoots(target) {
+        const repoRoot = target?.repoRoot || process.cwd();
+        const roots    = [
+            os.tmpdir(),
+            path.resolve(repoRoot, 'tmp'),
+            ...(Array.isArray(target?.disposableRoots) ? target.disposableRoots : [])
+        ];
+
+        return roots
+            .filter(root => typeof root === 'string' && root.trim())
+            .map(root => path.resolve(root))
+    }
+
+    /**
+     * Checks if `childPath` is inside `parentPath`.
+     *
+     * @param {String} childPath
+     * @param {String} parentPath
+     * @returns {Boolean}
+     * @private
+     */
+    #isPathInside(childPath, parentPath) {
+        const relative = path.relative(parentPath, childPath);
+        return relative === '' || (!!relative && !relative.startsWith('..') && !path.isAbsolute(relative))
+    }
+}
+
+export default Neo.setupClass(DestructiveOperationGuard);

--- a/ai/services.mjs
+++ b/ai/services.mjs
@@ -9,6 +9,9 @@ import Neo             from '../src/Neo.mjs';
 import * as core       from '../src/core/_export.mjs';
 import InstanceManager from '../src/manager/Instance.mjs';
 
+// --- Shared Services ---
+import Shared_DestructiveOperationGuard from './mcp/server/shared/services/DestructiveOperationGuard.mjs';
+
 // --- GitHub Workflow Services ---
 import GH_Config                    from './mcp/server/github-workflow/config.mjs';
 import GH_HealthService             from './mcp/server/github-workflow/services/HealthService.mjs';
@@ -254,6 +257,9 @@ makeSafe(NeuralLink_RuntimeService,     nlSpec);
  */
 
 export {
+    // Shared Services
+    Shared_DestructiveOperationGuard,
+
     // GitHub Workflow
     GH_Config,
     GH_HealthService,

--- a/test/playwright/unit/ai/mcp/server/shared/services/DestructiveOperationGuard.spec.mjs
+++ b/test/playwright/unit/ai/mcp/server/shared/services/DestructiveOperationGuard.spec.mjs
@@ -1,0 +1,265 @@
+import {setup} from '../../../../../../setup.mjs';
+
+const appName = 'DestructiveOperationGuardTest';
+
+setup({
+    neoConfig: {
+        unitTestMode: true
+    },
+    appConfig: {
+        name             : appName,
+        isMounted        : () => true,
+        vnodeInitialising: false
+    }
+});
+
+import {test, expect} from '@playwright/test';
+import Neo            from '../../../../../../../../src/Neo.mjs';
+import * as core      from '../../../../../../../../src/core/_export.mjs';
+import fs             from 'fs';
+import os             from 'os';
+import path           from 'path';
+import DestructiveOperationGuard, {
+    DESTRUCTIVE_PRODUCTION_BYPASS_ENV,
+    DESTRUCTIVE_PRODUCTION_CONFIRMATION
+} from '../../../../../../../../ai/mcp/server/shared/services/DestructiveOperationGuard.mjs';
+import CollectionProxy from '../../../../../../../../ai/mcp/server/memory-core/managers/CollectionProxy.mjs';
+import MemoryDatabaseService from '../../../../../../../../ai/mcp/server/memory-core/services/DatabaseService.mjs';
+import KbChromaManager from '../../../../../../../../ai/mcp/server/knowledge-base/services/ChromaManager.mjs';
+import KbVectorService from '../../../../../../../../ai/mcp/server/knowledge-base/services/VectorService.mjs';
+
+const repoRoot = process.cwd();
+
+test.describe('Neo.ai.mcp.server.shared.services.DestructiveOperationGuard (#10845)', () => {
+    test('permits in-memory SQLite targets', async () => {
+        const result = await DestructiveOperationGuard.assertDestructiveTargetAllowed({
+            operation: 'memory-core.graph.truncate',
+            subsystem: 'memory-core',
+            mode     : 'truncate',
+            target   : {
+                sqlitePath: ':memory:',
+                repoRoot
+            },
+            env: {}
+        });
+
+        expect(result.classification).toBe('disposable');
+    });
+
+    test('permits targets under the OS temp directory', async () => {
+        const result = await DestructiveOperationGuard.assertDestructiveTargetAllowed({
+            operation: 'knowledge-base.chroma.delete',
+            subsystem: 'knowledge-base',
+            mode     : 'delete',
+            target   : {
+                path: path.join(os.tmpdir(), 'neo-destructive-guard-test', 'chroma'),
+                repoRoot
+            },
+            env: {}
+        });
+
+        expect(result.classification).toBe('disposable');
+    });
+
+    test('permits targets under the repository tmp directory', async () => {
+        const result = await DestructiveOperationGuard.assertDestructiveTargetAllowed({
+            operation: 'memory-core.memory.drop',
+            subsystem: 'memory-core',
+            mode     : 'drop',
+            target   : {
+                path: path.join(repoRoot, 'tmp', 'memory-core-chroma-test'),
+                repoRoot
+            },
+            env: {}
+        });
+
+        expect(result.classification).toBe('disposable');
+    });
+
+    test('blocks production Memory Core SQLite targets by default', async () => {
+        await expect(DestructiveOperationGuard.assertDestructiveTargetAllowed({
+            operation: 'memory-core.graph.truncate',
+            subsystem: 'memory-core',
+            mode     : 'truncate',
+            target   : {
+                sqlitePath: path.join(repoRoot, '.neo-ai-data/sqlite/memory-core-graph.sqlite'),
+                repoRoot
+            },
+            env: {}
+        })).rejects.toMatchObject({
+            code  : 'DESTRUCTIVE_TARGET_BLOCKED',
+            reason: expect.stringContaining('not disposable')
+        });
+    });
+
+    test('blocks production Knowledge Base Chroma targets by default', async () => {
+        await expect(DestructiveOperationGuard.assertDestructiveTargetAllowed({
+            operation: 'knowledge-base.chroma.delete',
+            subsystem: 'knowledge-base',
+            mode     : 'delete',
+            target   : {
+                collectionName: 'neo-knowledge-base',
+                path          : path.join(repoRoot, '.neo-ai-data/chroma/knowledge-base'),
+                repoRoot
+            },
+            env: {}
+        })).rejects.toMatchObject({
+            code: 'DESTRUCTIVE_TARGET_BLOCKED'
+        });
+    });
+
+    test('blocks unresolved collection-only targets by default', async () => {
+        await expect(DestructiveOperationGuard.assertDestructiveTargetAllowed({
+            operation: 'memory-core.memory.drop',
+            subsystem: 'memory-core',
+            mode     : 'drop',
+            target   : {
+                collectionName: 'neo-agent-memory',
+                repoRoot
+            },
+            env: {}
+        })).rejects.toMatchObject({
+            code  : 'DESTRUCTIVE_TARGET_BLOCKED',
+            reason: expect.stringContaining('does not include')
+        });
+    });
+
+    test('does not treat UNIT_TEST_MODE as destructive-operation authorization', async () => {
+        await expect(DestructiveOperationGuard.assertDestructiveTargetAllowed({
+            operation: 'memory-core.memory.drop',
+            subsystem: 'memory-core',
+            mode     : 'drop',
+            target   : {
+                path: path.join(repoRoot, '.neo-ai-data/chroma/memory-core'),
+                repoRoot
+            },
+            env: {
+                UNIT_TEST_MODE: 'true'
+            }
+        })).rejects.toMatchObject({
+            code: 'DESTRUCTIVE_TARGET_BLOCKED'
+        });
+    });
+
+    test('requires both bypass env and explicit confirmation for production targets', async () => {
+        const target = {
+            path: path.join(repoRoot, '.neo-ai-data/chroma/memory-core'),
+            repoRoot
+        };
+
+        await expect(DestructiveOperationGuard.assertDestructiveTargetAllowed({
+            operation: 'memory-core.memory.drop',
+            subsystem: 'memory-core',
+            mode     : 'drop',
+            target,
+            env: {
+                [DESTRUCTIVE_PRODUCTION_BYPASS_ENV]: 'true'
+            }
+        })).rejects.toMatchObject({
+            code: 'DESTRUCTIVE_TARGET_BLOCKED'
+        });
+
+        const result = await DestructiveOperationGuard.assertDestructiveTargetAllowed({
+            operation: 'memory-core.memory.drop',
+            subsystem: 'memory-core',
+            mode     : 'drop',
+            target,
+            confirmation: DESTRUCTIVE_PRODUCTION_CONFIRMATION,
+            env         : {
+                [DESTRUCTIVE_PRODUCTION_BYPASS_ENV]: 'true'
+            }
+        });
+
+        expect(result.classification).toBe('operator-confirmed');
+    });
+
+    test('blocks mixed target descriptors when any destination path is production-like', async () => {
+        await expect(DestructiveOperationGuard.assertDestructiveTargetAllowed({
+            operation: 'restore.replace',
+            subsystem: 'memory-core',
+            mode     : 'replace',
+            target   : {
+                path      : path.join(os.tmpdir(), 'neo-destructive-guard-safe'),
+                sqlitePath: path.join(repoRoot, '.neo-ai-data/sqlite/memory-core-graph.sqlite'),
+                repoRoot
+            },
+            env: {}
+        })).rejects.toMatchObject({
+            code: 'DESTRUCTIVE_TARGET_BLOCKED'
+        });
+    });
+});
+
+test.describe('DestructiveOperationGuard call-site wiring (#10845)', () => {
+    test('Memory Core CollectionProxy stops before deleting a production Chroma collection', async () => {
+        const proxy = Neo.create(CollectionProxy, {
+            collectionType: 'memory'
+        });
+        let deleteCalls = 0;
+
+        proxy.getManagers = async () => [{
+            resolveChromaCoordinates: () => ({
+                host   : 'localhost',
+                port   : 8001,
+                dataDir: path.join(repoRoot, '.neo-ai-data/chroma/memory-core')
+            }),
+            getMemoryCollection: async () => ({
+                name: 'neo-agent-memory'
+            }),
+            client: {
+                deleteCollection: async () => {
+                    deleteCalls++;
+                }
+            }
+        }];
+
+        await expect(proxy.drop()).rejects.toMatchObject({
+            code: 'DESTRUCTIVE_TARGET_BLOCKED'
+        });
+        expect(deleteCalls).toBe(0);
+    });
+
+    test('Memory Core graph truncate stops before SQLite deletion on the production graph path', async () => {
+        await expect(MemoryDatabaseService.truncateDatabase({
+            include: ['graph']
+        })).rejects.toMatchObject({
+            code   : 'DATABASE_TRUNCATE_ERROR',
+            message: expect.stringContaining('DESTRUCTIVE_TARGET_BLOCKED')
+        });
+    });
+
+    test('Knowledge Base VectorService stops before deleting the production collection', async () => {
+        const originalClient = KbChromaManager.client;
+        let deleteCalls      = 0;
+
+        KbChromaManager.client = {
+            deleteCollection: async () => {
+                deleteCalls++;
+            }
+        };
+
+        try {
+            await expect(KbVectorService.deleteCollection()).rejects.toMatchObject({
+                code: 'DESTRUCTIVE_TARGET_BLOCKED'
+            });
+            expect(deleteCalls).toBe(0);
+        } finally {
+            KbChromaManager.client = originalClient;
+        }
+    });
+
+    test('destructive Memory Core and Knowledge Base surfaces call the shared guard', () => {
+        const expected = [
+            'ai/mcp/server/memory-core/managers/CollectionProxy.mjs',
+            'ai/mcp/server/memory-core/services/DatabaseService.mjs',
+            'ai/mcp/server/knowledge-base/services/VectorService.mjs'
+        ];
+
+        for (const relativePath of expected) {
+            const source = fs.readFileSync(path.join(repoRoot, relativePath), 'utf8');
+
+            expect(source).toContain('DestructiveOperationGuard');
+            expect(source).toContain('assertDestructiveTargetAllowed');
+        }
+    });
+});


### PR DESCRIPTION
Resolves #10845

Authored by GPT-5 (Codex Desktop). Session 3c145296-4486-4442-9334-2d39e87db23f.

Adds a shared fail-closed destructive-operation guard for AI substrate wipes and wires it into the Memory Core and Knowledge Base deletion surfaces. The guard permits disposable targets (`:memory:`, OS temp, repo `tmp/`) and blocks production-like or unresolved targets unless both `NEO_ALLOW_PRODUCTION_DESTRUCTIVE_AI_SUBSTRATE=true` and the explicit confirmation token are supplied.

Evidence: L2 (unit coverage with mocked destructive call-site stop-before-delete assertions + OpenAPI/schema checks) -> L2 required (production destructive execution is intentionally not exercised). No residuals.

## Deltas from ticket

- Added `Shared_DestructiveOperationGuard` as an SDK export so #10871 restore tooling can consume the same contract.
- Exposed optional `confirmation` on existing destructive surfaces that need to carry the bypass token: KB `manage_knowledge_base delete`, Memory Core `delete_all_summaries`, and Memory Database SDK import/truncate flows.
- No `UNIT_TEST_MODE` dependency was added; tests assert that `UNIT_TEST_MODE=true` does not authorize production paths.

## Test Evidence

- `node --check ai/mcp/server/shared/services/DestructiveOperationGuard.mjs`
- `node --check ai/mcp/server/memory-core/managers/CollectionProxy.mjs`
- `node --check ai/mcp/server/memory-core/services/DatabaseService.mjs`
- `node --check ai/mcp/server/memory-core/services/SummaryService.mjs`
- `node --check ai/mcp/server/knowledge-base/services/VectorService.mjs`
- `node --check ai/mcp/server/knowledge-base/services/DatabaseService.mjs`
- `node --check ai/services.mjs`
- `node --check test/playwright/unit/ai/mcp/server/shared/services/DestructiveOperationGuard.spec.mjs`
- `node --input-type=module -e "import fs from 'fs'; import yaml from 'js-yaml'; yaml.load(fs.readFileSync('ai/mcp/server/memory-core/openapi.yaml', 'utf8')); yaml.load(fs.readFileSync('ai/mcp/server/knowledge-base/openapi.yaml', 'utf8')); console.log('openapi ok');"`
- `npm run test-unit -- test/playwright/unit/ai/mcp/server/shared/services/DestructiveOperationGuard.spec.mjs` — 13 passed
- `npm run test-unit -- test/playwright/unit/ai/mcp/server/memory-core/McpServerToolLimits.spec.mjs test/playwright/unit/ai/mcp/server/knowledge-base/services/VectorService.WorkVolumeBranching.spec.mjs test/playwright/unit/ai/mcp/server/memory-core/services/SummaryService.TenantIsolation.spec.mjs` — 18 passed
- `git diff --cached --check`

## Post-Merge Validation

- [ ] #10871 restore replace mode imports `Shared_DestructiveOperationGuard` and fails closed on production targets without the explicit bypass + confirmation pair.

## Commit

- `7cb17ab09` — `feat(agentos): guard destructive substrate operations (#10845)`
