### PR TITLE
feat(ai/backup): extend bundle-meta + integrity check + mailbox (#10871)

### DIFF
--- a/buildScripts/ai/backup.mjs
+++ b/buildScripts/ai/backup.mjs
@@ -1,6 +1,11 @@
+import {execFile}       from 'child_process';
 import fs               from 'fs-extra';
 import path             from 'path';
+import {promisify}      from 'util';
 import {fileURLToPath}  from 'url';
+
+import kbConfig         from '../../ai/mcp/server/knowledge-base/config.mjs';
+import mcConfig         from '../../ai/mcp/server/memory-core/config.mjs';
 
 import {
     KB_DatabaseService,
@@ -8,6 +13,8 @@ import {
     Memory_DatabaseService,
     Memory_LifecycleService
 } from '../../ai/services.mjs';
+
+const execFileAsync = promisify(execFile);
 
 /**
  * @module buildScripts/ai/backup
@@ -59,8 +66,30 @@ import {
  * `defragChromaDB.cleanOldBackups` against `dist/chromadb-backups/<target>/`. No automated
  * migration is provided — the archives are cheap and the manual decision is low-risk.
  *
+ * ## Intentionally-Excluded Substrate (Per #10871)
+ *
+ * The following `.neo-ai-data/` paths are **NOT** included in the bundle by design:
+ *
+ * - `.neo-ai-data/neo-sqlite/memory-core.sqlite` — legacy combined vector+graph store from the
+ *   pre-#9922 Two-Pillar RAG architecture (last-written 2026-04-15). Replaced by the canonical
+ *   `.neo-ai-data/sqlite/memory-core-graph.sqlite` (graph via `better-sqlite3`) +
+ *   `.neo-ai-data/chroma/memory-core/` (vectors via Chroma). The `SQLiteVectorManager` that
+ *   wrote it has zero production callers (only `AbstractVectorManager` parent + the legacy
+ *   one-off `importBackupToSQLite.mjs`); `defragSQLiteDB.mjs` targets a different filename
+ *   (`knowledge-graph.sqlite`) and never touches this file. `bootstrapWorktree.mjs` symlinks
+ *   the directory across worktrees for backward-compat, but no production code reads or writes
+ *   it. Operator may `rm -rf .neo-ai-data/neo-sqlite/` to reclaim ~329 MB at any time.
+ * - `.neo-ai-data/wake-daemon/{bridge.log,inflight-*.txt,lastSyncId,heartbeat-*.log,sweep-errors.log}`
+ *   — operational / process state owned by the bridge daemon and heartbeat substrate; classified
+ *   as live-orchestration recovery, not substrate backup. Distinct backup track if needed.
+ * - Physical Chroma data directories (`.neo-ai-data/chroma/{kb,mc}/`) — the bundle captures the
+ *   logical state via JSONL exports, not the on-disk HNSW indexes. Restore re-ingests via the
+ *   canonical `manageDatabaseImport` SDK path. Physical pre-nuke snapshots remain
+ *   `defragChromaDB.mjs`-exclusive at `dist/chromadb-backups/`.
+ *
  * @see buildScripts/ai/defragChromaDB.mjs
  * @see https://github.com/neomjs/neo/issues/10129
+ * @see https://github.com/neomjs/neo/issues/10871
  */
 
 const __filename   = fileURLToPath(import.meta.url);
@@ -69,6 +98,7 @@ const PROJECT_ROOT = path.resolve(__dirname, '../..');
 
 const DEFAULT_CONCEPTS_DIR      = path.join(PROJECT_ROOT, '.neo-ai-data', 'concepts');
 const DEFAULT_TRAJECTORIES_FILE = path.join(PROJECT_ROOT, '.neo-ai-data', 'datasets', 'rlaif', 'trajectories.jsonl');
+const DEFAULT_SENT_TO_CULL_FILE = path.join(path.dirname(mcConfig.storagePaths.graph), 'sent-to-cull.jsonl');
 const DEFAULT_BACKUP_ROOT       = path.join(PROJECT_ROOT, '.neo-ai-data', 'backups');
 
 /**
@@ -85,6 +115,7 @@ export async function runBackup({
     bundleRoot             = null,
     conceptsSourceDir      = DEFAULT_CONCEPTS_DIR,
     trajectoriesSourceFile = DEFAULT_TRAJECTORIES_FILE,
+    sentToCullSourceFile   = DEFAULT_SENT_TO_CULL_FILE,
     logger                 = console
 } = {}) {
     const timestamp    = new Date().toISOString().replace(/:/g, '-');
@@ -95,7 +126,8 @@ export async function runBackup({
         mc          : path.join(resolvedRoot, 'mc'),
         graph       : path.join(resolvedRoot, 'graph'),
         concepts    : path.join(resolvedRoot, 'concepts'),
-        trajectories: path.join(resolvedRoot, 'trajectories')
+        trajectories: path.join(resolvedRoot, 'trajectories'),
+        mailbox     : path.join(resolvedRoot, 'mailbox')
     };
 
     await Promise.all(Object.values(layout).map(dir => fs.ensureDir(dir)));
@@ -107,41 +139,186 @@ export async function runBackup({
 
     const subsystems = {};
 
-    logger.log('[1/5] Exporting Knowledge Base...');
+    logger.log('[1/7] Exporting Knowledge Base...');
     subsystems.kb = await KB_DatabaseService.manageDatabaseBackup({
         action    : 'export',
         backupPath: layout.kb
     });
 
-    logger.log('[2/5] Exporting Memory Core (memories + summaries)...');
+    logger.log('[2/7] Exporting Memory Core (memories + summaries)...');
     subsystems.mc = await Memory_DatabaseService.manageDatabaseBackup({
         action    : 'export',
         include   : ['memories', 'summaries'],
         backupPath: layout.mc
     });
 
-    logger.log('[3/5] Exporting Memory Core graph...');
+    logger.log('[3/7] Exporting Memory Core graph...');
     subsystems.graph = await Memory_DatabaseService.manageDatabaseBackup({
         action    : 'export',
         include   : ['graph'],
         backupPath: layout.graph
     });
 
-    logger.log('[4/5] Copying Concept Ontology...');
-    subsystems.concepts = await copyJsonlSource(conceptsSourceDir, layout.concepts);
+    logger.log('[4/7] Copying Concept Ontology...');
+    subsystems.concepts = await copyJsonlSource(conceptsSourceDir, layout.concepts, logger);
 
-    logger.log('[5/5] Copying RLAIF trajectories...');
-    subsystems.trajectories = await copyJsonlSource(trajectoriesSourceFile, layout.trajectories);
+    logger.log('[5/7] Copying RLAIF trajectories...');
+    subsystems.trajectories = await copyJsonlSource(trajectoriesSourceFile, layout.trajectories, logger);
 
-    logger.log('[6/6] Applying retention sweep...');
+    logger.log('[6/7] Copying mailbox sent-to-cull archive...');
+    subsystems.mailbox = await copyJsonlSource(sentToCullSourceFile, layout.mailbox, logger);
+
+    logger.log('[7/7] Applying retention sweep...');
     await cleanOldBackups(DEFAULT_BACKUP_ROOT, logger);
 
+    logger.log('Verifying bundle integrity (row-count parity)...');
+    const integrity = await verifyBundleIntegrity(layout, subsystems);
+    const failedChecks = integrity.filter(check => check.status === 'fail');
+    if (failedChecks.length > 0) {
+        throw new Error(
+            `Bundle integrity check failed for ${failedChecks.length} subsystem(s):\n` +
+            failedChecks.map(c => `  - ${c.subsystem}: ${c.reason}`).join('\n')
+        );
+    }
+
     const completedAt = new Date().toISOString();
-    const meta = { timestamp, completedAt, subsystems };
+    const topology    = buildTopologyDescriptor();
+    const versionInfo = await buildVersionDescriptor(PROJECT_ROOT, logger);
+    const meta = {
+        bundleVersion: 1,
+        timestamp,
+        completedAt,
+        subsystems,
+        integrity,
+        topology,
+        ...versionInfo
+    };
     await fs.writeJson(path.join(resolvedRoot, 'bundle-meta.json'), meta, { spaces: 2 });
 
     logger.log(`✅ Backup complete: ${resolvedRoot}`);
-    return {bundleRoot: resolvedRoot, timestamp, completedAt, subsystems};
+    return {bundleRoot: resolvedRoot, timestamp, completedAt, subsystems, meta};
+}
+
+/**
+ * Verifies row-count parity between source collections and the JSONL files written into the
+ * bundle. For subsystems whose `manageDatabaseBackup({action: 'export'})` SDK call returns a
+ * numeric count (KB, MC memories+summaries, MC graph), this function counts non-empty lines
+ * in the bundle's JSONL files and compares — mismatch indicates a partial/torn write that the
+ * caller treats as a fail-the-bundle condition.
+ *
+ * For file-copy subsystems (concepts, trajectories, mailbox) the source side has no
+ * authoritative count to compare against — `copyJsonlSource`'s reported `copied` field
+ * already covers the file-presence check, so these are skipped with `status: 'skipped'`.
+ *
+ * @param {Object} layout     The bundle's per-subsystem destination directory map.
+ * @param {Object} subsystems The runBackup `subsystems` map of SDK return values.
+ * @returns {Promise<Array<{subsystem: String, status: 'pass'|'fail'|'skipped', sourceCount?: Number, bundleCount?: Number, reason?: String}>>}
+ */
+export async function verifyBundleIntegrity(layout, subsystems) {
+    const verifiable = ['kb', 'mc', 'graph'];
+    const checks     = [];
+
+    for (const subsystem of verifiable) {
+        const raw         = subsystems[subsystem];
+        const sourceCount = typeof raw === 'number' ? raw : raw?.count;
+
+        if (typeof sourceCount !== 'number') {
+            checks.push({subsystem, status: 'skipped', reason: 'no numeric source count returned by SDK'});
+            continue;
+        }
+
+        const dir = layout[subsystem];
+
+        if (!await fs.pathExists(dir)) {
+            checks.push({subsystem, status: 'fail', sourceCount, bundleCount: 0, reason: `bundle directory missing: ${dir}`});
+            continue;
+        }
+
+        const files = (await fs.readdir(dir)).filter(f => f.endsWith('.jsonl'));
+        let bundleCount = 0;
+
+        for (const file of files) {
+            const content = await fs.readFile(path.join(dir, file), 'utf8');
+            bundleCount += content.split('\n').filter(line => line.trim()).length;
+        }
+
+        if (bundleCount === sourceCount) {
+            checks.push({subsystem, status: 'pass', sourceCount, bundleCount});
+        } else {
+            checks.push({
+                subsystem,
+                status: 'fail',
+                sourceCount,
+                bundleCount,
+                reason: `row-count mismatch: source=${sourceCount}, bundle=${bundleCount} (delta ${bundleCount - sourceCount})`
+            });
+        }
+    }
+
+    return checks
+}
+
+/**
+ * Builds the topology descriptor block for `bundle-meta.json`. Captures the federated-vs-unified
+ * Chroma topology + KB/MC coordinates at backup time so a restore consumer can detect topology
+ * mismatch (`bundle-meta.topology.chromaUnified` vs current `aiConfig.chromaUnified`) and refuse
+ * to clobber a target whose deployment shape diverged from the bundle source.
+ *
+ * Forward-compat extension point for #10871 AC-B (`buildScripts/ai/restore.mjs`).
+ *
+ * @returns {{chromaUnified: Boolean, kbChromaCoords: Object, mcChromaCoords: Object}}
+ */
+function buildTopologyDescriptor() {
+    return {
+        chromaUnified : Boolean(mcConfig.chromaUnified),
+        kbChromaCoords: {
+            host: kbConfig.host    ?? null,
+            port: kbConfig.port    ?? null,
+            path: kbConfig.path    ?? null
+        },
+        mcChromaCoords: {
+            host   : mcConfig.engines?.chroma?.host    ?? null,
+            port   : mcConfig.engines?.chroma?.port    ?? null,
+            dataDir: mcConfig.engines?.chroma?.dataDir ?? null
+        }
+    }
+}
+
+/**
+ * Builds the version descriptor block for `bundle-meta.json`. Captures `neoVersion` from
+ * `package.json` and `gitSha` from the working tree's HEAD so a restore consumer can flag
+ * cross-version restores (e.g. backup taken under v12.0, restoring under v12.2 with schema
+ * migrations applied).
+ *
+ * Both fields are best-effort — missing `git` binary or unreadable `package.json` degrades to
+ * `null` rather than failing the bundle.
+ *
+ * @param {String} projectRoot Absolute repo root.
+ * @param {Object} logger      Log sink for non-fatal warnings.
+ * @returns {Promise<{neoVersion: String|null, gitSha: String|null}>}
+ */
+async function buildVersionDescriptor(projectRoot, logger) {
+    let neoVersion = process.env.npm_package_version ?? null;
+
+    if (!neoVersion) {
+        try {
+            const pkg = await fs.readJson(path.join(projectRoot, 'package.json'));
+            neoVersion = pkg.version ?? null;
+        } catch (err) {
+            logger.warn?.(`[Backup] failed to read package.json for neoVersion: ${err.message}`);
+        }
+    }
+
+    let gitSha = null;
+
+    try {
+        const {stdout} = await execFileAsync('git', ['rev-parse', 'HEAD'], {cwd: projectRoot});
+        gitSha = stdout.trim() || null;
+    } catch (err) {
+        logger.warn?.(`[Backup] failed to capture gitSha: ${err.message}`);
+    }
+
+    return {neoVersion, gitSha}
 }
 
 /**
@@ -211,14 +388,21 @@ async function cleanOldBackups(backupRoot, logger) {
 
 /**
  * Copies JSONL data from a source (either a directory of JSONL files or a single JSONL file)
- * into the destination directory. Missing sources are reported, not fatal — concepts and
- * trajectories may legitimately not exist in fresh environments.
+ * into the destination directory. Missing sources are reported via `note`, not fatal — concepts
+ * and trajectories may legitimately not exist in fresh environments.
  *
- * @param {String} source  Absolute path to a JSONL file or a directory containing JSONL files.
- * @param {String} destDir Absolute path to the target subfolder inside the bundle.
+ * **Empty-source observability (#10871):** when the source PATH exists but yields zero bytes
+ * of bundle-able data (directory with no `.jsonl` files, OR a 0-byte file), the function emits
+ * a warning via `logger.warn(...)` so silent-empty subsystems are visible during backup.
+ * Source-absent (path does not exist) remains silent — fresh-environment fixtures legitimately
+ * lack concepts/trajectories.
+ *
+ * @param {String} source         Absolute path to a JSONL file or a directory containing JSONL files.
+ * @param {String} destDir        Absolute path to the target subfolder inside the bundle.
+ * @param {Object} [logger=console] Log sink; receives `.warn(message)` calls for empty sources.
  * @returns {Promise<{copied: Number, note?: String}>}
  */
-async function copyJsonlSource(source, destDir) {
+async function copyJsonlSource(source, destDir, logger=console) {
     if (!await fs.pathExists(source)) {
         return {copied: 0, note: `source not present: ${source}`};
     }
@@ -229,11 +413,21 @@ async function copyJsonlSource(source, destDir) {
         const entries    = await fs.readdir(source);
         const jsonlFiles = entries.filter(f => f.endsWith('.jsonl'));
 
+        if (jsonlFiles.length === 0) {
+            logger.warn(`[Backup] source directory exists but contains no .jsonl files: ${source}`);
+        }
+
         await Promise.all(jsonlFiles.map(f =>
             fs.copy(path.join(source, f), path.join(destDir, f))
         ));
 
         return {copied: jsonlFiles.length};
+    }
+
+    if (stat.size === 0) {
+        logger.warn(`[Backup] source file is 0 bytes: ${source}`);
+        await fs.copy(source, path.join(destDir, path.basename(source)));
+        return {copied: 0, note: 'source file empty'};
     }
 
     await fs.copy(source, path.join(destDir, path.basename(source)));

--- a/test/playwright/unit/buildScripts/ai/backup.spec.mjs
+++ b/test/playwright/unit/buildScripts/ai/backup.spec.mjs
@@ -48,9 +48,11 @@ test.describe('backup.mjs orchestrator — atomic bundle assembly (#10129 Phase 
         }
     });
 
+    let verifyBundleIntegrity;
+
     test.beforeAll(async () => {
         SDK                   = await import('../../../../../ai/services.mjs');
-        ({runBackup}          = await import('../../../../../buildScripts/ai/backup.mjs'));
+        ({runBackup, verifyBundleIntegrity} = await import('../../../../../buildScripts/ai/backup.mjs'));
         KB_ChromaManager      = SDK.KB_ChromaManager;
         Memory_StorageRouter  = SDK.Memory_StorageRouter;
 
@@ -154,5 +156,117 @@ test.describe('backup.mjs orchestrator — atomic bundle assembly (#10129 Phase 
         // KB + MC still run — bundle is valid even without optional sources.
         expect(fs.existsSync(path.join(altBundleRoot, 'kb'))).toBe(true);
         expect(fs.existsSync(path.join(altBundleRoot, 'mc'))).toBe(true);
+    });
+
+    test('mailbox: copies sent-to-cull.jsonl when source exists (#10871)', async () => {
+        const silentLogger     = {log: () => {}, error: () => {}};
+        const altBundleRoot    = path.join(workRoot, 'bundle-mailbox-present');
+        const sentToCullSource = path.join(workRoot, 'mailbox-source', 'sent-to-cull.jsonl');
+
+        fs.mkdirSync(path.dirname(sentToCullSource), {recursive: true});
+        fs.writeFileSync(sentToCullSource, '{"culled":"msg-1"}\n{"culled":"msg-2"}\n');
+
+        const result = await runBackup({
+            bundleRoot            : altBundleRoot,
+            conceptsSourceDir,
+            trajectoriesSourceFile,
+            sentToCullSourceFile  : sentToCullSource,
+            logger                : silentLogger
+        });
+
+        expect(fs.existsSync(path.join(altBundleRoot, 'mailbox'))).toBe(true);
+        expect(fs.readdirSync(path.join(altBundleRoot, 'mailbox'))).toEqual(['sent-to-cull.jsonl']);
+        expect(result.subsystems.mailbox.copied).toBe(1);
+    });
+
+    test('writes bundle-meta.json with bundleVersion/timestamp/completedAt/topology/integrity/version (#10871)', async () => {
+        const silentLogger  = {log: () => {}, error: () => {}};
+        const altBundleRoot = path.join(workRoot, 'bundle-meta-schema');
+
+        await runBackup({
+            bundleRoot            : altBundleRoot,
+            conceptsSourceDir,
+            trajectoriesSourceFile,
+            sentToCullSourceFile  : path.join(workRoot, 'does-not-exist-cull.jsonl'),
+            logger                : silentLogger
+        });
+
+        const metaPath = path.join(altBundleRoot, 'bundle-meta.json');
+        expect(fs.existsSync(metaPath)).toBe(true);
+
+        const meta = JSON.parse(fs.readFileSync(metaPath, 'utf8'));
+
+        expect(meta.bundleVersion).toBe(1);
+        expect(meta.timestamp).toBeTruthy();
+        expect(meta.completedAt).toBeTruthy();
+        expect(meta.subsystems).toBeDefined();
+        expect(meta.integrity).toBeInstanceOf(Array);
+
+        expect(meta.topology).toBeDefined();
+        expect(typeof meta.topology.chromaUnified).toBe('boolean');
+        expect(meta.topology.kbChromaCoords).toBeDefined();
+        expect(meta.topology.mcChromaCoords).toBeDefined();
+        expect('host' in meta.topology.kbChromaCoords).toBe(true);
+        expect('port' in meta.topology.kbChromaCoords).toBe(true);
+        expect('path' in meta.topology.kbChromaCoords).toBe(true);
+        expect('host' in meta.topology.mcChromaCoords).toBe(true);
+        expect('port' in meta.topology.mcChromaCoords).toBe(true);
+        expect('dataDir' in meta.topology.mcChromaCoords).toBe(true);
+
+        expect('neoVersion' in meta).toBe(true);
+        expect('gitSha' in meta).toBe(true);
+    });
+
+    test('verifyBundleIntegrity: pass when bundle row count matches source count (#10871)', async () => {
+        const tempRoot = path.join(workRoot, 'integrity-pass');
+        const kbDir    = path.join(tempRoot, 'kb');
+
+        fs.mkdirSync(kbDir, {recursive: true});
+        fs.writeFileSync(path.join(kbDir, 'kb-data.jsonl'), '{"id":"1"}\n{"id":"2"}\n{"id":"3"}\n');
+
+        const checks = await verifyBundleIntegrity(
+            {kb: kbDir, mc: path.join(tempRoot, 'mc-missing'), graph: path.join(tempRoot, 'graph-missing')},
+            {kb: 3}
+        );
+
+        const kb = checks.find(c => c.subsystem === 'kb');
+        expect(kb.status).toBe('pass');
+        expect(kb.sourceCount).toBe(3);
+        expect(kb.bundleCount).toBe(3);
+    });
+
+    test('verifyBundleIntegrity: fail when bundle row count diverges from source count (#10871)', async () => {
+        const tempRoot = path.join(workRoot, 'integrity-fail');
+        const kbDir    = path.join(tempRoot, 'kb');
+
+        fs.mkdirSync(kbDir, {recursive: true});
+        fs.writeFileSync(path.join(kbDir, 'kb-data.jsonl'), '{"id":"1"}\n');
+
+        const checks = await verifyBundleIntegrity(
+            {kb: kbDir, mc: path.join(tempRoot, 'mc-missing'), graph: path.join(tempRoot, 'graph-missing')},
+            {kb: 5}
+        );
+
+        const kb = checks.find(c => c.subsystem === 'kb');
+        expect(kb.status).toBe('fail');
+        expect(kb.sourceCount).toBe(5);
+        expect(kb.bundleCount).toBe(1);
+        expect(kb.reason).toMatch(/row-count mismatch/);
+    });
+
+    test('verifyBundleIntegrity: skipped when source count is non-numeric (#10871)', async () => {
+        const tempRoot = path.join(workRoot, 'integrity-skipped');
+        const mcDir    = path.join(tempRoot, 'mc');
+
+        fs.mkdirSync(mcDir, {recursive: true});
+
+        const checks = await verifyBundleIntegrity(
+            {kb: path.join(tempRoot, 'kb-missing'), mc: mcDir, graph: path.join(tempRoot, 'graph-missing')},
+            {mc: {memories: 1, summaries: 1}}
+        );
+
+        const mc = checks.find(c => c.subsystem === 'mc');
+        expect(mc.status).toBe('skipped');
+        expect(mc.reason).toMatch(/no numeric source count/);
     });
 });


### PR DESCRIPTION
Authored by Claude Opus 4.7 (Claude Code). Session 78a3272e-847b-4799-ad6c-ce334464844c.

Related: #10871

AC-A scope of #10871 — backup-side enhancements building atop #10872's substrate (#10844 daily-snapshot pipeline) and complementing #10845's destructive-op guard. AC-B (`buildScripts/ai/restore.mjs`) deferred to a separate follow-up PR.

Evidence: L2 (Playwright unit cov for the new helpers + bundle-meta schema + integrity check pass/fail/skipped) → L2 required (pure-projection helpers + file shapes; production-runtime healthcheck consumption is L3 already owned by Gemini's #10872 `buildBackupStateBlock` test coverage and not re-verified here). No residuals for AC-A scope.

## What ships

- **`bundle-meta.json` schema extended additively**: `bundleVersion: 1`, `topology` block (`chromaUnified` + KB/MC chroma coords from `aiConfig`), `neoVersion` (from `package.json` fallback), `gitSha` (best-effort via `git rev-parse HEAD`). Backward-compat — existing healthcheck `buildBackupStateBlock` reads `completedAt` unchanged.
- **Post-write integrity check** (`verifyBundleIntegrity`): row-count parity for KB / MC / graph subsystems. Status per subsystem (`pass` / `fail` / `skipped`) recorded in `bundle-meta.integrity`. Failed bundles throw — no `bundle-meta.json` written for torn writes, so `healthcheck.backup.lastSuccessful` never surfaces a partial bundle.
- **mailbox/sent-to-cull.jsonl coverage**: prior session's wipe-forensic gap (operator audit flagged this as missing from the bundle layout). Bundled via `copyJsonlSource` — handles missing source gracefully on fresh envs.
- **`copyJsonlSource` empty-source warnings**: silent `{copied: 0}` was too quiet. Now emits `logger.warn` when source dir exists but contains no JSONL files, OR source file is 0 bytes. Source-absent (path doesn't exist) remains silent — fresh-environment fixtures legitimately lack concepts/trajectories.
- **JSDoc documents intentionally-excluded substrate**: `neo-sqlite/` legacy (pre-#9922 vector+graph split, zero production callers — `SQLiteVectorManager` only consumed by `AbstractVectorManager` parent + legacy one-off `importBackupToSQLite.mjs`); `wake-daemon/` operational state (live-orchestration recovery, separate concern); physical Chroma data dirs (logical JSONL exports already capture the state per #10129 peer-architecture).
- **Step numbering normalized to `[N/7]`** (was `[N/5]` for steps 1-5 + `[6/6]` for retention; cosmetic but consistent).

## Deltas from ticket

- AC-A retention policy item: ceded to #10872 (Gemini already shipped K=3 / N=7 default + per-bundle try-catch). My ticket body's AC-A item 6 deferred per Cycle 2 review.
- AC-A `bundle-meta.json` writer: extended Gemini's minimal schema (`{timestamp, completedAt, subsystems}`) additively, didn't replace.
- AC-B `ai:restore`: deferred to a follow-up PR after this one merges. Substrate guard `Shared_DestructiveOperationGuard` from #10845 now consumable on `dev`, no stub layer needed.

## Test Evidence

- `npm run test-unit -- test/playwright/unit/buildScripts/ai/backup.spec.mjs` — 7 passed in 0.83s (2 existing + 5 new).
- `node --check buildScripts/ai/backup.mjs` — passes.

New test cases:
- `mailbox: copies sent-to-cull.jsonl when source exists`
- `writes bundle-meta.json with bundleVersion/timestamp/completedAt/topology/integrity/version`
- `verifyBundleIntegrity: pass when bundle row count matches source count`
- `verifyBundleIntegrity: fail when bundle row count diverges from source count`
- `verifyBundleIntegrity: skipped when source count is non-numeric`

## Post-Merge Validation

- [ ] Verify `bundle-meta.topology.chromaUnified` reflects current deployment topology after a fresh `npm run ai:backup`.
- [ ] Verify integrity check fails loudly on a torn write (e.g. partial Chroma export interrupted mid-flight) — destructive verification deferred to operator-side.

## Commits

- `5529c2fca` — feat(ai/backup): extend bundle-meta + integrity check + mailbox (#10871)