### PR TITLE
test(mcp/Authorization): align fixture env-vars with #10877 NEO_ rename (#10878)

### DIFF
--- a/test/playwright/unit/ai/mcp/Authorization.spec.mjs
+++ b/test/playwright/unit/ai/mcp/Authorization.spec.mjs
@@ -73,15 +73,15 @@ test.describe('MCP Server OIDC/OAuth 2.1 Authorization (Functional)', () => {
         mcpServerProcess = spawn('node', [SERVER_PATH, '--debug'], {
             env: {
                 ...process.env,
-                TRANSPORT      : 'sse',
-                SSE_PORT       : MCP_SSE_PORT.toString(),
-                AUTO_SYNC      : 'false',
-                AUTO_SUMMARIZE : 'false',
-                AUTH_HOST      : 'localhost',
-                AUTH_PORT      : MOCK_OIDC_PORT.toString(),
-                AUTH_REALM     : 'test',
-                OAUTH_CLIENT_ID: TEST_CLIENT_ID,
-                HOST           : 'localhost'
+                NEO_TRANSPORT     : 'sse',
+                SSE_PORT          : MCP_SSE_PORT.toString(),
+                NEO_AUTO_SYNC     : 'false',
+                NEO_AUTO_SUMMARIZE: 'false',
+                AUTH_HOST         : 'localhost',
+                AUTH_PORT         : MOCK_OIDC_PORT.toString(),
+                AUTH_REALM        : 'test',
+                OAUTH_CLIENT_ID   : TEST_CLIENT_ID,
+                HOST              : 'localhost'
             }
         });
 
@@ -185,13 +185,13 @@ test.describe('MCP Server OIDC/OAuth 2.1 Authorization (Functional)', () => {
         const discoveryProcess = spawn('node', [SERVER_PATH, '--debug'], {
             env: {
                 ...process.env,
-                TRANSPORT      : 'sse',
-                SSE_PORT       : DISCOVERY_MCP_PORT.toString(),
-                AUTO_SYNC      : 'false',
-                AUTO_SUMMARIZE : 'false',
-                AUTH_ISSUER_URL: `http://localhost:${MOCK_OIDC_PORT}/realms/test`,
-                OAUTH_CLIENT_ID: TEST_CLIENT_ID,
-                HOST           : 'localhost'
+                NEO_TRANSPORT     : 'sse',
+                SSE_PORT          : DISCOVERY_MCP_PORT.toString(),
+                NEO_AUTO_SYNC     : 'false',
+                NEO_AUTO_SUMMARIZE: 'false',
+                AUTH_ISSUER_URL   : `http://localhost:${MOCK_OIDC_PORT}/realms/test`,
+                OAUTH_CLIENT_ID   : TEST_CLIENT_ID,
+                HOST              : 'localhost'
             }
         });
 


### PR DESCRIPTION
Authored by Claude Opus 4.7 (Claude Code). Session 78a3272e-847b-4799-ad6c-ce334464844c.

Resolves #10878

Follow-up to PR #10877 (Resolves #10862) which institutionalized the canonical `NEO_` prefix on 13 substrate env vars. PR #10877's AC4 grep was scoped to `ai/` `src/` `buildScripts/` and missed `test/playwright/unit/ai/mcp/Authorization.spec.mjs` — which spawns MCP server processes with bare-name env-var fixtures.

Surfaced post-merge by @tobiu while reviewing what the test suite was doing under the rename.

Evidence: L1 (static rename + ripgrep verification) → L1 required (env-var contract correction; runtime test-pass behavior is independent of this fix per the stale-config issue noted below). No residuals for the contract scope.

## What ships

- All 6 occurrences in two `spawn(...)` env blocks renamed:
  - Line 76, 188: `TRANSPORT` → `NEO_TRANSPORT`
  - Line 78, 190: `AUTO_SYNC` → `NEO_AUTO_SYNC`
  - Line 79, 191: `AUTO_SUMMARIZE` → `NEO_AUTO_SUMMARIZE`
- Block-formatting alignment recalculated to the new longest property name (`NEO_AUTO_SUMMARIZE`, 18 chars) per coding-guideline §8.32.

## Out of Scope

- **SSE_PORT** (legacy alias under #10808 deprecation window — separate concern).
- **AUTH_***, **OAUTH_***, **HOST**: third-party canonical / host-config; correctly NOT prefixed per #10862's out-of-scope policy.
- **Test-pass dependency on operator-side config refresh:** post-#10877 the env-binding tables in `ai/mcp/server/{memory-core,knowledge-base}/config.template.mjs` read NEO_-prefixed names, but operator-side gitignored `ai/mcp/server/{memory-core,knowledge-base}/config.mjs` files retain the OLD bindings until manually refreshed from the template. If the operator's local `config.mjs` is stale, this test will still time out — the server reads `TRANSPORT` (unbound by fixture, defaults to `stdio`), SSE startup log never emits, the 20s timeout fires. This is the known config-drift class anchored in `feedback_defensive_pattern_parity.md` — operator-action concern, not a code bug. Once `config.mjs` is refreshed from `config.template.mjs`, this fixture rename brings the test contract into alignment.

## Test Evidence

- `node --check test/playwright/unit/ai/mcp/Authorization.spec.mjs` — passes.
- `rg -n -P '(?<![A-Z_])(AUTO_SUMMARIZE|AUTO_DREAM|AUTO_GOLDEN_PATH|REAL_TIME_MEMORY_PARSING|AUTO_INGEST_FS|AUTO_SYNC|MEMORY_COLLECTION_NAME|SESSION_COLLECTION_NAME|GRAPH_COLLECTION_NAME|GRAPH_DECAY_FACTOR)\b' test/` returns zero results post-PR — full repo audit (extending #10862's AC4 grep beyond `ai/src/buildScripts`). Use `rg -P` for the lookbehind; `grep -E` does NOT support PCRE lookbehind syntax.
- `npm run test-unit -- test/playwright/unit/ai/mcp/Authorization.spec.mjs` — fails with "MCP Server startup timeout" if operator-side `config.mjs` is stale (server reads `TRANSPORT` binding, ignores fixture-set `NEO_TRANSPORT`, defaults to `stdio`). Refreshing `config.mjs` from `config.template.mjs` resolves the env-binding mismatch; this fixture rename is necessary-but-not-sufficient for end-to-end test pass without that operator action.

## Post-Merge Validation

- [ ] Operator refreshes local `ai/mcp/server/{memory-core,knowledge-base}/config.mjs` from current `config.template.mjs`; full `npm run test-unit` Authorization.spec.mjs path runs to completion.

## Reviewer Note (Lessons Learned)

This PR exists because my Cycle 1 + Cycle 2 reviews of #10877 cited "substrate-contention concern in this active worktree" as rationale for skipping the test-execution step (per pr-review-guide §2.2 Empirical Checkout Mandate). For structural code changes that rename consumed surfaces, running RELATED tests is mandatory regardless of worktree-state concerns. Anchored as memory `feedback_run_related_tests_in_pr_review.md` to prevent recurrence; AC4 grep should also extend to `test/` for env-var-rename PRs (would have caught this pre-merge).

**Cycle 1 review-response correction:** the original PR body and the related ticket #10881 incorrectly framed the remaining timeout as a stdout-only listener bug. @neo-gpt's empirical Cycle 1 review showed the branch already resolves on both stdout AND stderr (lines 90-95 + 96-103) — the actual cause is the stale-config issue noted in Out of Scope above. #10881 closed as `not_planned` with the misdiagnosis withdrawn.

## Commit

- `364202027` — test(mcp/Authorization): align fixture env-vars with #10877 NEO_ rename (#10878)