### PR TITLE
docs(agentos): add Completion Bias anti-triggers to sunset skill

### DIFF
--- a/.agents/skills/session-sunset/SKILL.md
+++ b/.agents/skills/session-sunset/SKILL.md
@@ -6,4 +6,12 @@ triggers: When concluding a long-running session, executing the Sunset Protocol,
 
 # Session Sunset Skill
 
-If you are concluding an active working session, handing over work, or terminating your agent cycle, you MUST immediately use the `view_file` tool to read and strictly adhere to `.agents/skills/session-sunset/references/session-sunset-workflow.md` before terminating. This prevents Zero-State Amnesia for the next agent.
+**🛑 ANTI-TRIGGERS (Completion Bias Guard) 🛑**
+**Task Completion ≠ Session Sunset.** You must **halt and wait for the next turn** (do NOT sunset) if you are:
+1. **Halting for Peer Review:** Waiting for cross-family PR review or human feedback. This is an active lifecycle state, not a boundary.
+2. **Single Task Completion:** Finishing one ticket/task while your context window is still healthy. Pick up the next task.
+3. **Asynchronous Delays:** Waiting for CI, test results, or A2A responses.
+
+Sunsets are strictly reserved for **Context Window Exhaustion** (>75% full/forgetfulness), **Macro-Semantic Pivots**, or **Explicit Human Directives**. 
+
+If you meet a valid sunset condition, you MUST immediately use the `view_file` tool to read and strictly adhere to `.agents/skills/session-sunset/references/session-sunset-workflow.md` before terminating. This prevents Zero-State Amnesia.


### PR DESCRIPTION
Authored by Gemini 3.1 Pro (Antigravity). Session 7019b73d-72cf-42ab-8609-5387a2e66148.

Resolves #10882

Updates `.agents/skills/session-sunset/SKILL.md` to explicitly define "Anti-Triggers" for the Sunset Protocol. This mitigates "Completion Bias" where agents erroneously sunset their session after completing a single task or pausing for cross-family review.

Evidence: L1 (docs/static config). Residual: AC1 [#10882] — Enforced via SKILL.md before any agent reads the underlying workflow reference.

## Slot Rationale
- **Target**: `.agents/skills/session-sunset/SKILL.md`
- **Disposition**: `keep` / `compress-to-trigger`
- **Decay Mitigation**: The rule is condensed into a high-density "map vs world atlas" list directly in the skill's entry point (`SKILL.md`), acting as a mechanical trigger barrier. This prevents agents from entering the larger `session-sunset-workflow.md` when they are merely awaiting review or have finished a single ticket. It reduces overhead by filtering premature sunset evaluations at the outer gate.
