### PR TITLE
fix(memory-core): use canonical NEO_ prefixes in SessionService specs (#10884)

### DIFF
--- a/test/playwright/unit/ai/mcp/server/memory-core/services/SessionService.PrimaryFlagGate.spec.mjs
+++ b/test/playwright/unit/ai/mcp/server/memory-core/services/SessionService.PrimaryFlagGate.spec.mjs
@@ -2,8 +2,8 @@ import {setup} from '../../../../../../setup.mjs';
 
 const appName = 'MemoryCorePrimaryFlagGateTest';
 
-process.env.MODEL_PROVIDER          = 'openAiCompatible';
-process.env.OPENAI_COMPATIBLE_MODEL = 'gemma4';
+process.env.NEO_MODEL_PROVIDER          = 'openAiCompatible';
+process.env.NEO_OPENAI_COMPATIBLE_MODEL = 'gemma4';
 
 setup({
     neoConfig: {

--- a/test/playwright/unit/ai/mcp/server/memory-core/services/SessionService.ResumeValidation.spec.mjs
+++ b/test/playwright/unit/ai/mcp/server/memory-core/services/SessionService.ResumeValidation.spec.mjs
@@ -2,8 +2,8 @@ import {setup} from '../../../../../../setup.mjs';
 
 const appName = 'MemoryCoreSessionResumeValidationTest';
 
-process.env.MODEL_PROVIDER = 'openAiCompatible';
-process.env.OPENAI_COMPATIBLE_MODEL = 'gemma4';
+process.env.NEO_MODEL_PROVIDER = 'openAiCompatible';
+process.env.NEO_OPENAI_COMPATIBLE_MODEL = 'gemma4';
 
 setup({
     neoConfig: {

--- a/test/playwright/unit/ai/mcp/server/memory-core/services/SessionService.SunsetPoller.spec.mjs
+++ b/test/playwright/unit/ai/mcp/server/memory-core/services/SessionService.SunsetPoller.spec.mjs
@@ -2,8 +2,8 @@ import {setup} from '../../../../../../setup.mjs';
 
 const appName = 'MemoryCoreSunsetPollerTest';
 
-process.env.MODEL_PROVIDER          = 'openAiCompatible';
-process.env.OPENAI_COMPATIBLE_MODEL = 'gemma4';
+process.env.NEO_MODEL_PROVIDER          = 'openAiCompatible';
+process.env.NEO_OPENAI_COMPATIBLE_MODEL = 'gemma4';
 
 setup({
     neoConfig: {

--- a/test/playwright/unit/ai/mcp/server/memory-core/services/SessionService.spec.mjs
+++ b/test/playwright/unit/ai/mcp/server/memory-core/services/SessionService.spec.mjs
@@ -2,8 +2,8 @@ import {setup} from '../../../../../../setup.mjs';
 
 const appName = 'MemoryCoreSessionServiceTest';
 
-process.env.MODEL_PROVIDER = 'openAiCompatible';
-process.env.OPENAI_COMPATIBLE_MODEL   = 'gemma4';
+process.env.NEO_MODEL_PROVIDER        = 'openAiCompatible';
+process.env.NEO_OPENAI_COMPATIBLE_MODEL = 'gemma4';
 
 setup({
     neoConfig: {


### PR DESCRIPTION
Resolves #10884

Authored by neo-gemini-3-1-pro (Antigravity). Session 7019b73d-72cf-42ab-8609-5387a2e66148.

Updated the remaining four `SessionService` test specifications to use the canonical `NEO_MODEL_PROVIDER` and `NEO_OPENAI_COMPATIBLE_MODEL` environment variable names instead of the old bare names. This ensures the tests accurately mock the environment variables consumed by the current `ai/mcp/server/memory-core/config.template.mjs`.

Evidence: L1 (static config-shape audit) -> L1 required (no runtime-verify ACs). No residuals.

## Deltas from ticket (if any)
None. Only the four identified files were modified, replacing the two targeted variables exactly as specified.

## Test Evidence
`node --check` passed for all 4 modified spec files.
`npm run test-unit` against the 4 spec files passed successfully (16/16 tests passing).

## Post-Merge Validation
- [ ] Ensure CI pipeline remains green for `test-unit`.

## Commits (if multi-commit)
- fix(memory-core): use canonical NEO_ prefixes in SessionService specs (#10884)
