### PR TITLE
feat(testing): add Docker MCP healthcheck integration slice (#10805)

### DIFF
--- a/ai/deploy/docker-compose.test.yml
+++ b/ai/deploy/docker-compose.test.yml
@@ -1,0 +1,78 @@
+services:
+  chroma:
+    image: chromadb/chroma:1.5.9
+    tmpfs:
+      - /chroma/chroma
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8000/api/v2/heartbeat"]
+      interval: 5s
+      timeout: 5s
+      retries: 12
+    networks:
+      - neo-mcp-test-network
+    ports:
+      - "18080:8000"
+
+  kb-server:
+    build:
+      context: ../..
+      dockerfile: ai/deploy/Dockerfile
+      args:
+        TARGET_SERVER: knowledge-base
+    environment:
+      - NEO_TRANSPORT=sse
+      - NEO_AUTO_SYNC=false
+      - NEO_KB_AUTO_START_DATABASE=false
+      - NEO_CHROMA_UNIFIED=true
+      - NEO_CHROMA_HOST=chroma
+      - NEO_CHROMA_PORT=8000
+      - MCP_HTTP_PORT=3000
+      - NEO_MEMORY_DB_PATH=/tmp/neo-integration/memory-core-graph.sqlite
+      - GEMINI_API_KEY=test-integration-key
+    tmpfs:
+      - /tmp/neo-integration
+    depends_on:
+      chroma:
+        condition: service_healthy
+    networks:
+      - neo-mcp-test-network
+    ports:
+      - "13000:3000"
+
+  mc-server:
+    build:
+      context: ../..
+      dockerfile: ai/deploy/Dockerfile
+      args:
+        TARGET_SERVER: memory-core
+    environment:
+      - NEO_TRANSPORT=sse
+      - NEO_MC_PRIMARY=false
+      - NEO_AUTO_SUMMARIZE=false
+      - NEO_MEM_AUTO_START_DATABASE=false
+      - NEO_MEM_AUTO_START_INFERENCE=false
+      - NEO_AUTO_DREAM=false
+      - NEO_AUTO_GOLDEN_PATH=false
+      - NEO_REAL_TIME_MEMORY_PARSING=false
+      - NEO_AUTO_INGEST_FS=false
+      - NEO_CHROMA_UNIFIED=true
+      - NEO_CHROMA_HOST=chroma
+      - NEO_CHROMA_PORT=8000
+      - MCP_HTTP_PORT=3001
+      - NEO_MEMORY_DB_PATH=/tmp/neo-integration/memory-core-graph.sqlite
+      - NEO_MODEL_PROVIDER=openAiCompatible
+      - NEO_EMBEDDING_PROVIDER=openAiCompatible
+      - NEO_OPENAI_COMPATIBLE_API_KEY=test-integration-key
+    tmpfs:
+      - /tmp/neo-integration
+    depends_on:
+      chroma:
+        condition: service_healthy
+    networks:
+      - neo-mcp-test-network
+    ports:
+      - "13001:3001"
+
+networks:
+  neo-mcp-test-network:
+    driver: bridge

--- a/learn/agentos/DeploymentCookbook.md
+++ b/learn/agentos/DeploymentCookbook.md
@@ -95,7 +95,7 @@ When provisioning your containers, supply the following minimal environment vari
 
 ## Section 7: Healthcheck Verification
 
-Once deployed, verify the stack by querying the healthcheck endpoints (e.g., `https://my-proxy.example.com/mc/health`).
+Once deployed, verify the stack by invoking each server's MCP `healthcheck` tool over its `/mcp` endpoint. The MCP servers do not expose a direct `/healthcheck` HTTP route; use JSON-RPC `tools/call` with `name: "healthcheck"` against the KB and MC MCP URLs.
 
 Expected JSON block (excerpt):
 ```json
@@ -158,6 +158,8 @@ Operator verification anchors:
 See [Memory Core Healthcheck](MemoryCore.md) for the full schema contract (including the `clientSecret`-non-leak invariant per [#10770](https://github.com/neomjs/neo/issues/10770)).
 
 ## Section 8: First-Connection Smoke Test
+
+For the local Dockerized fixture, run `npm run test-integration`. The Playwright integration harness builds `ai/deploy/docker-compose.test.yml`, waits for Chroma + KB + MC readiness, then calls the KB and MC `healthcheck` tools over `/mcp`.
 
 1. Configure your local agent harness (e.g., `claude_desktop_config.json`) to point the `sse` transport URL to your public proxy endpoint.
 2. Ensure you have authenticated with the proxy (e.g., logging in via browser to obtain the session cookie, or injecting a proxy-issued bearer token).

--- a/learn/agentos/SharedDeployment.md
+++ b/learn/agentos/SharedDeployment.md
@@ -198,6 +198,8 @@ See [`MemoryCore.md` §Healthcheck Response Shape](./MemoryCore.md) for the full
 
 The Knowledge Base's healthcheck mirrors the connectivity assertion (collection counts, embedding status). When both servers report `connected: true` against the same shared `{host, port}`, the topology is verified.
 
+The local staged-stack fixture verifies this deployed shape with `npm run test-integration`: Playwright starts `ai/deploy/docker-compose.test.yml`, then calls both servers' MCP `healthcheck` tools over `/mcp`. This is the canonical local smoke path for KB + MC + shared Chroma healthcheck validation.
+
 The Memory Core's healthcheck additionally surfaces active provider observability under `providers.*` (#10723, #10724, #10770):
 
 ```json

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
         "test"                         : "playwright test -c test/playwright/playwright.config.mjs",
         "test-components"              : "playwright test -c test/playwright/playwright.config.component.mjs",
         "test-e2e"                     : "playwright test -c test/playwright/playwright.config.e2e.mjs",
+        "test-integration"             : "playwright test -c test/playwright/playwright.config.integration.mjs",
         "test-unit"                    : "UNIT_TEST_MODE=true playwright test -c test/playwright/playwright.config.unit.mjs",
         "watch-themes"                 : "node ./buildScripts/helpers/watchThemes.mjs"
     },

--- a/test/playwright/integration/fixtures/composeWebServer.mjs
+++ b/test/playwright/integration/fixtures/composeWebServer.mjs
@@ -1,0 +1,163 @@
+import {spawn, spawnSync} from 'node:child_process';
+import http              from 'node:http';
+import net               from 'node:net';
+import path              from 'node:path';
+import {fileURLToPath}   from 'node:url';
+
+const __filename  = fileURLToPath(import.meta.url);
+const __dirname   = path.dirname(__filename);
+const repoRoot    = path.resolve(__dirname, '../../../..');
+const composeFile = path.join(repoRoot, 'ai/deploy/docker-compose.test.yml');
+const projectName = process.env.NEO_INTEGRATION_COMPOSE_PROJECT || 'neo-integration-test';
+const readyPort   = Number(process.env.NEO_INTEGRATION_READY_PORT || 13090);
+
+const state = {
+    dockerAvailable: null,
+    servicesReady  : false,
+    composeStarted : false,
+    reason         : 'Docker compose startup has not completed yet.'
+};
+
+let composeProcess;
+let shuttingDown = false;
+
+function dockerCompose(args, options = {}) {
+    return spawnSync('docker', ['compose', '-p', projectName, '-f', composeFile, ...args], {
+        cwd     : repoRoot,
+        encoding: 'utf8',
+        ...options
+    });
+}
+
+function isDockerAvailable() {
+    const version = spawnSync('docker', ['compose', 'version'], {encoding: 'utf8'});
+
+    if (version.status !== 0) {
+        state.reason = version.error?.message || version.stderr || 'Docker compose is not available.';
+        return false;
+    }
+
+    const info = spawnSync('docker', ['info'], {encoding: 'utf8'});
+
+    if (info.status !== 0) {
+        state.reason = info.error?.message || info.stderr || 'Docker daemon is not reachable.';
+        return false;
+    }
+
+    return true;
+}
+
+function portOpen(port) {
+    return new Promise(resolve => {
+        const socket = net.createConnection({host: '127.0.0.1', port});
+
+        socket.setTimeout(1000);
+        socket.once('connect', () => {
+            socket.destroy();
+            resolve(true);
+        });
+        socket.once('timeout', () => {
+            socket.destroy();
+            resolve(false);
+        });
+        socket.once('error', () => resolve(false));
+    });
+}
+
+async function waitForServices() {
+    const deadline = Date.now() + Number(process.env.NEO_INTEGRATION_STACK_TIMEOUT_MS || 210000);
+
+    while (!shuttingDown && Date.now() < deadline) {
+        try {
+            const [chroma, kbPort, mcPort] = await Promise.all([
+                fetch('http://127.0.0.1:18080/api/v2/heartbeat').then(r => r.ok).catch(() => false),
+                portOpen(13000),
+                portOpen(13001)
+            ]);
+
+            if (chroma && kbPort && mcPort) {
+                state.servicesReady = true;
+                state.reason        = 'Dockerized MCP integration stack is ready.';
+                return;
+            }
+
+            state.reason = `Waiting for stack readiness: chroma=${chroma}, kb=${kbPort}, mc=${mcPort}`;
+        } catch (error) {
+            state.reason = error.message;
+        }
+
+        await new Promise(resolve => setTimeout(resolve, 1000));
+    }
+
+    state.reason = `Timed out waiting for Dockerized MCP integration stack. Last state: ${state.reason}`;
+}
+
+function cleanup() {
+    if (shuttingDown) return;
+
+    shuttingDown = true;
+
+    if (composeProcess && !composeProcess.killed) {
+        composeProcess.kill('SIGTERM');
+    }
+
+    dockerCompose(['down', '--remove-orphans', '--volumes'], {stdio: 'ignore'});
+}
+
+const server = http.createServer((req, res) => {
+    if (req.url !== '/ready') {
+        res.writeHead(404, {'content-type': 'application/json'});
+        res.end(JSON.stringify({error: 'Not found'}));
+        return;
+    }
+
+    const ready = state.dockerAvailable === false || state.servicesReady;
+
+    res.writeHead(ready ? 200 : 503, {'content-type': 'application/json'});
+    res.end(JSON.stringify(state));
+});
+
+server.listen(readyPort, '127.0.0.1', async () => {
+    state.dockerAvailable = isDockerAvailable();
+
+    if (!state.dockerAvailable) {
+        return;
+    }
+
+    dockerCompose(['down', '--remove-orphans', '--volumes'], {stdio: 'ignore'});
+
+    composeProcess = spawn('docker', [
+        'compose',
+        '-p', projectName,
+        '-f', composeFile,
+        'up',
+        '--build',
+        '--remove-orphans'
+    ], {
+        cwd  : repoRoot,
+        stdio: 'inherit'
+    });
+
+    state.composeStarted = true;
+
+    composeProcess.once('exit', code => {
+        if (!shuttingDown) {
+            state.servicesReady = false;
+            state.reason        = `docker compose exited before shutdown with code ${code}.`;
+        }
+    });
+
+    await waitForServices();
+});
+
+process.once('SIGINT', () => {
+    cleanup();
+    process.exit(0);
+});
+
+process.once('SIGTERM', () => {
+    cleanup();
+    process.exit(0);
+});
+
+process.once('exit', cleanup);

--- a/test/playwright/integration/healthcheck.spec.mjs
+++ b/test/playwright/integration/healthcheck.spec.mjs
@@ -1,0 +1,72 @@
+import {test, expect}                   from '@playwright/test';
+import {Client}                         from '@modelcontextprotocol/sdk/client/index.js';
+import {StreamableHTTPClientTransport}  from '@modelcontextprotocol/sdk/client/streamableHttp.js';
+
+const READY_URL = process.env.NEO_INTEGRATION_READY_URL || 'http://127.0.0.1:13090/ready';
+const KB_URL    = process.env.NEO_INTEGRATION_KB_URL    || 'http://127.0.0.1:13000';
+const MC_URL    = process.env.NEO_INTEGRATION_MC_URL    || 'http://127.0.0.1:13001';
+
+async function getReadiness() {
+    const response = await fetch(READY_URL);
+    return response.json();
+}
+
+async function callHealthcheck(baseUrl) {
+    const transport = new StreamableHTTPClientTransport(new URL('/mcp', baseUrl));
+    const client    = new Client({
+        name   : 'neo-integration-healthcheck',
+        version: '1.0.0'
+    }, {
+        capabilities: {}
+    });
+
+    await client.connect(transport);
+
+    try {
+        const result = await client.callTool({name: 'healthcheck', arguments: {}});
+
+        expect(result.isError).not.toBe(true);
+
+        if (result.structuredContent) {
+            return result.structuredContent;
+        }
+
+        const text = result.content?.find(item => item.type === 'text')?.text;
+        expect(text, 'MCP healthcheck should return text content when structuredContent is absent').toBeTruthy();
+
+        return JSON.parse(text);
+    } finally {
+        await client.close();
+    }
+}
+
+test.describe('Dockerized KB/MC MCP healthcheck integration (#10805 Lane A)', () => {
+    test('KB and MC expose healthcheck tool payloads over /mcp', async () => {
+        const readiness = await getReadiness();
+
+        test.skip(readiness.dockerAvailable === false, `Docker unavailable: ${readiness.reason}`);
+
+        expect(readiness.servicesReady, readiness.reason).toBe(true);
+
+        const [kbHealth, mcHealth] = await Promise.all([
+            callHealthcheck(KB_URL),
+            callHealthcheck(MC_URL)
+        ]);
+
+        expect(kbHealth.status).toBe('healthy');
+        expect(kbHealth.database.connection.connected).toBe(true);
+        expect(kbHealth.database.connection.collections.knowledgeBase.exists).toBe(true);
+        expect(kbHealth.features.embedding).toBe(true);
+
+        expect(mcHealth.status).toBe('healthy');
+        expect(mcHealth.database.connection.connected).toBe(true);
+        expect(mcHealth.database.topology.mode).toBe('unified');
+        expect(mcHealth.database.topology.resolvedVia).toBe('engines.kb.chroma');
+        expect(mcHealth.database.connection.collections.memories.exists).toBe(true);
+        expect(mcHealth.database.connection.collections.summaries.exists).toBe(true);
+        expect(mcHealth.providers.embedding.active).toBe('openAiCompatible');
+        expect(mcHealth.providers.embedding.error).toBeUndefined();
+        expect(mcHealth.providers.summary.active).toBe('openAiCompatible');
+        expect(mcHealth.providers.summary.credential.configured).toBe(true);
+    });
+});

--- a/test/playwright/playwright.config.integration.mjs
+++ b/test/playwright/playwright.config.integration.mjs
@@ -1,0 +1,31 @@
+import {defineConfig} from '@playwright/test';
+
+export default defineConfig({
+    testDir      : './integration',
+    outputDir    : './test-results/integration/artifacts',
+    fullyParallel: false,
+    workers      : 1,
+    timeout      : 120000,
+
+    reporter: [
+        ['list'],
+        ['json', {outputFile: 'test-results/integration/results.json'}]
+    ],
+
+    use: {
+        trace: 'on-first-retry'
+    },
+
+    webServer: {
+        command: 'node ./integration/fixtures/composeWebServer.mjs',
+        url: 'http://127.0.0.1:13090/ready',
+        timeout: 240000,
+        reuseExistingServer: false,
+        stdout: 'pipe',
+        stderr: 'pipe',
+        gracefulShutdown: {
+            signal: 'SIGTERM',
+            timeout: 30000
+        }
+    }
+});


### PR DESCRIPTION
Authored by GPT-5 Codex (Codex Desktop). Session 3c145296-4486-4442-9334-2d39e87db23f.

Related: #10805

Adds the first #10805 Lane A vertical slice: a Docker Compose test stack for Chroma + KB + MC, a Playwright integration config and npm run test-integration entry point, and a real MCP-over-HTTP healthcheck spec that calls each server's healthcheck tool via JSON-RPC over /mcp. This intentionally does not close #10805; it establishes the staged-stack substrate and healthcheck test before adding cross-tenant isolation and 401-reject scenarios.

Evidence: L2 (static/syntax checks + Playwright harness execution through Docker-unavailable skip path in this Codex environment) -> L3 required (real Docker build + KB/MC MCP healthcheck calls). Residual: Docker-capable Lane A execution plus cross-tenant isolation, 401-reject, and AC5 deliberate-regression proof [#10805].

## What Ships

- ai/deploy/docker-compose.test.yml: tmpfs Chroma plus KB/MC SSE servers on deterministic host ports.
- test/playwright/playwright.config.integration.mjs: integration suite config with a webServer readiness hook.
- test/playwright/integration/fixtures/composeWebServer.mjs: starts docker compose when available, tears it down, and exposes readiness metadata; if Docker is absent, the suite can skip instead of infrastructure-failing.
- test/playwright/integration/healthcheck.spec.mjs: uses @modelcontextprotocol/sdk Streamable HTTP client against /mcp and calls tools/call healthcheck on KB and MC.
- package.json: adds npm run test-integration.
- Deployment docs now name the real contract: MCP healthcheck tool calls over /mcp, not a direct /healthcheck route.

## Deltas From Ticket

- This PR is Lane A only. It does not implement the cross-tenant alice/bob isolation spec, the 401-without-X-PREFERRED-USERNAME spec, or AC5 deliberate-regression proof.
- The Playwright webServer command uses a small Node wrapper rather than invoking docker compose directly so Docker-unavailable environments get a clean skipped test instead of a failed suite startup.

## Slot Rationale

Substrate-mutation gate fires because this PR modifies learn/agentos/**.

- learn/agentos/DeploymentCookbook.md Section 7/8: disposition keep; 3-axis rating medium trigger-frequency x high failure-severity x disciplinary enforceability. The change removes stale direct-health-route guidance and links the local staged-stack smoke path.
- learn/agentos/SharedDeployment.md Healthcheck Verification: disposition keep; 3-axis rating medium trigger-frequency x high failure-severity x disciplinary enforceability. The added paragraph anchors the new local integration fixture at the existing shared-deployment healthcheck contract.
- Decay mitigation: the docs point at committed script/config paths and the MCP healthcheck tool contract. If the transport changes, the integration spec and docs should co-change in the same PR.

## Test Evidence

```
node --check test/playwright/integration/fixtures/composeWebServer.mjs
node --check test/playwright/integration/healthcheck.spec.mjs
node --check test/playwright/playwright.config.integration.mjs
git diff --cached --check

npm run test-integration -- --reporter=line
  1 skipped
```

Docker is not installed in this Codex environment (docker --version and docker compose version both returned command-not-found), so the integration script validated the intended Docker-unavailable skip path. A Docker-capable machine should report one passing integration test.

## Post-Merge / Reviewer Validation

- [ ] On a Docker-capable machine, run npm run test-integration -- --reporter=line and confirm the Docker image builds, the compose stack boots, and the healthcheck spec passes.
- [ ] Continue #10805 Lane B with cross-tenant isolation and 401-reject specs.
- [ ] Complete #10805 AC5 by inducing a deliberate throwaway regression and proving at least one integration spec catches it.

## Commit

- 5cf25306e — feat(testing): add Docker MCP healthcheck integration slice (#10805)