### PR TITLE
test(integration): implement sustained-liveness heartbeat assertion primitive (#10896)

### DIFF
--- a/learn/agentos/SharedDeployment.md
+++ b/learn/agentos/SharedDeployment.md
@@ -198,7 +198,7 @@ See [`MemoryCore.md` §Healthcheck Response Shape](./MemoryCore.md) for the full
 
 The Knowledge Base's healthcheck mirrors the connectivity assertion (collection counts, embedding status). When both servers report `connected: true` against the same shared `{host, port}`, the topology is verified.
 
-The local staged-stack fixture verifies this deployed shape with `npm run test-integration`: Playwright starts `ai/deploy/docker-compose.test.yml`, then calls both servers' MCP `healthcheck` tools over `/mcp`. This is the canonical local smoke path for KB + MC + shared Chroma healthcheck validation. It also writes and queries same-session memories as different proxy identities in `test/playwright/integration/CrossTenantIsolation.integration.spec.mjs`, proving tenant-scoped memory reads do not leak across the trusted proxy-identity boundary.
+The local staged-stack fixture verifies this deployed shape with `npm run test-integration`: Playwright starts `ai/deploy/docker-compose.test.yml`, then calls both servers' MCP `healthcheck` tools over `/mcp` (see [HeartbeatPropagation.integration.spec.mjs](../../test/playwright/integration/HeartbeatPropagation.integration.spec.mjs)). This is the canonical local smoke path for KB + MC + shared Chroma healthcheck validation. It also writes and queries same-session memories as different proxy identities in `test/playwright/integration/CrossTenantIsolation.integration.spec.mjs`, proving tenant-scoped memory reads do not leak across the trusted proxy-identity boundary.
 
 The Memory Core's healthcheck additionally surfaces active provider observability under `providers.*` (#10723, #10724, #10770):
 

--- a/test/playwright/integration/HeartbeatPropagation.integration.spec.mjs
+++ b/test/playwright/integration/HeartbeatPropagation.integration.spec.mjs
@@ -1,44 +1,9 @@
 import {test, expect} from '@playwright/test';
-import {Client} from '@modelcontextprotocol/sdk/client/index.js';
-import {StreamableHTTPClientTransport} from '@modelcontextprotocol/sdk/client/streamableHttp.js';
 import {assertSustainedHealth} from './util/assertSustainedHealth.mjs';
+import {callHealthcheck, getReadiness} from './fixtures/mcpClient.mjs';
 
-const READY_URL = process.env.NEO_INTEGRATION_READY_URL || 'http://127.0.0.1:13090/ready';
 const KB_URL    = process.env.NEO_INTEGRATION_KB_URL    || 'http://127.0.0.1:13000';
 const MC_URL    = process.env.NEO_INTEGRATION_MC_URL    || 'http://127.0.0.1:13001';
-
-async function getReadiness() {
-    const response = await fetch(READY_URL);
-    return response.json();
-}
-
-async function callHealthcheck(baseUrl) {
-    const transport = new StreamableHTTPClientTransport(new URL('/mcp', baseUrl));
-    const client    = new Client({
-        name   : 'neo-integration-heartbeat',
-        version: '1.0.0'
-    }, {
-        capabilities: {}
-    });
-
-    await client.connect(transport);
-
-    try {
-        const result = await client.callTool({name: 'healthcheck', arguments: {}});
-        expect(result.isError).not.toBe(true);
-
-        if (result.structuredContent) {
-            return result.structuredContent;
-        }
-
-        const text = result.content?.find(item => item.type === 'text')?.text;
-        expect(text, 'MCP healthcheck should return text content').toBeTruthy();
-
-        return JSON.parse(text);
-    } finally {
-        await client.close();
-    }
-}
 
 test.describe('Heartbeat Propagation Integration (#10896 Lane B)', () => {
     test.setTimeout(120000); // Allow enough time for 30s window and startup

--- a/test/playwright/integration/HeartbeatPropagation.integration.spec.mjs
+++ b/test/playwright/integration/HeartbeatPropagation.integration.spec.mjs
@@ -1,0 +1,87 @@
+import {test, expect} from '@playwright/test';
+import {Client} from '@modelcontextprotocol/sdk/client/index.js';
+import {StreamableHTTPClientTransport} from '@modelcontextprotocol/sdk/client/streamableHttp.js';
+import {assertSustainedHealth} from './util/assertSustainedHealth.mjs';
+
+const READY_URL = process.env.NEO_INTEGRATION_READY_URL || 'http://127.0.0.1:13090/ready';
+const KB_URL    = process.env.NEO_INTEGRATION_KB_URL    || 'http://127.0.0.1:13000';
+const MC_URL    = process.env.NEO_INTEGRATION_MC_URL    || 'http://127.0.0.1:13001';
+
+async function getReadiness() {
+    const response = await fetch(READY_URL);
+    return response.json();
+}
+
+async function callHealthcheck(baseUrl) {
+    const transport = new StreamableHTTPClientTransport(new URL('/mcp', baseUrl));
+    const client    = new Client({
+        name   : 'neo-integration-heartbeat',
+        version: '1.0.0'
+    }, {
+        capabilities: {}
+    });
+
+    await client.connect(transport);
+
+    try {
+        const result = await client.callTool({name: 'healthcheck', arguments: {}});
+        expect(result.isError).not.toBe(true);
+
+        if (result.structuredContent) {
+            return result.structuredContent;
+        }
+
+        const text = result.content?.find(item => item.type === 'text')?.text;
+        expect(text, 'MCP healthcheck should return text content').toBeTruthy();
+
+        return JSON.parse(text);
+    } finally {
+        await client.close();
+    }
+}
+
+test.describe('Heartbeat Propagation Integration (#10896 Lane B)', () => {
+    test.setTimeout(120000); // Allow enough time for 30s window and startup
+
+    test('Sustained healthcheck property assertions (30s window)', async () => {
+        const readiness = await getReadiness();
+        test.skip(readiness.dockerAvailable === false, `Docker unavailable: ${readiness.reason}`);
+        expect(readiness.servicesReady, readiness.reason).toBe(true);
+
+        const checkProperties = (sample, previousSamples) => {
+            if (previousSamples.length > 1) {
+                const prev = previousSamples[previousSamples.length - 2];
+                // Monotonic uptime
+                expect(sample.uptime).toBeGreaterThan(prev.uptime);
+            }
+
+            // Provider stability
+            if (sample.providers) {
+                for (const provider of Object.values(sample.providers)) {
+                    expect(provider.error, `Provider should not have an error`).toBeUndefined();
+                }
+            }
+
+            // Credential persistence
+            if (sample.providers?.summary?.credential) {
+                expect(sample.providers.summary.credential.configured).toBe(true);
+            }
+
+            // Connection persistence
+            if (sample.database?.connection) {
+                expect(sample.database.connection.connected).toBe(true);
+            }
+        };
+
+        await Promise.all([
+            assertSustainedHealth({
+                probe: () => callHealthcheck(KB_URL),
+                onSample: checkProperties
+            }),
+            assertSustainedHealth({
+                probe: () => callHealthcheck(MC_URL),
+                onSample: checkProperties
+            })
+        ]);
+    });
+});

--- a/test/playwright/integration/healthcheck.spec.mjs
+++ b/test/playwright/integration/healthcheck.spec.mjs
@@ -1,4 +1,5 @@
-import {test, expect}                 from '@playwright/test';
+import {test, expect}                  from '@playwright/test';
+import {assertSustainedHealth}         from './util/assertSustainedHealth.mjs';
 import {callHealthcheck, getReadiness} from './fixtures/mcpClient.mjs';
 
 const KB_URL = process.env.NEO_INTEGRATION_KB_URL || 'http://127.0.0.1:13000';
@@ -34,5 +35,18 @@ test.describe('Dockerized KB/MC MCP healthcheck integration (#10805 Lane A)', ()
         expect(mcHealth.providers.summary.credential.configured).toBe(true);
         expect(mcHealth.providers.auth.configured).toBe('proxy-header');
         expect(mcHealth.providers.auth.proxyHeader.trusted).toBe(true);
+    });
+
+    test('Sustained liveness (5s/1s window)', async () => {
+        const readiness = await getReadiness();
+
+        test.skip(readiness.dockerAvailable === false, `Docker unavailable: ${readiness.reason}`);
+
+        expect(readiness.servicesReady, readiness.reason).toBe(true);
+
+        await Promise.all([
+            assertSustainedHealth({ probe: () => callHealthcheck(KB_URL), windowMs: 5000, intervalMs: 1000 }),
+            assertSustainedHealth({ probe: () => callHealthcheck(MC_URL), windowMs: 5000, intervalMs: 1000 })
+        ]);
     });
 });

--- a/test/playwright/integration/healthcheck.spec.mjs
+++ b/test/playwright/integration/healthcheck.spec.mjs
@@ -37,7 +37,7 @@ test.describe('Dockerized KB/MC MCP healthcheck integration (#10805 Lane A)', ()
         expect(mcHealth.providers.auth.proxyHeader.trusted).toBe(true);
     });
 
-    test('Sustained liveness (5s/1s window)', async () => {
+    test('Sustained liveness composability check (Lane B helper) — 5s/1s', async () => {
         const readiness = await getReadiness();
 
         test.skip(readiness.dockerAvailable === false, `Docker unavailable: ${readiness.reason}`);

--- a/test/playwright/integration/util/assertSustainedHealth.mjs
+++ b/test/playwright/integration/util/assertSustainedHealth.mjs
@@ -11,7 +11,7 @@ import {expect} from '@playwright/test';
  * @param {number} [options.p95Ms] - Maximum p95 latency. Default: process.env.NEO_INTEGRATION_SUSTAINED_P95_MS || 500.
  * @param {number} [options.maxConsecutiveFailures] - Max sequential failures allowed. Default: 0.
  * @param {Function} [options.onSample] - Optional callback to run custom assertions on each sample.
- * @returns {Promise<Object[]>} The array of gathered samples.
+ * @returns {Promise<{samples: Object[], summary: Object}>} The gathered samples and computed summary.
  */
 export async function assertSustainedHealth({
     probe,
@@ -25,19 +25,19 @@ export async function assertSustainedHealth({
     const samples = [];
     const latencies = [];
     let consecutiveFailures = 0;
-    
+
     const iterations = Math.max(1, Math.floor(windowMs / intervalMs));
-    
+
     for (let i = 0; i < iterations; i++) {
         const start = Date.now();
         try {
             const result = await probe();
             const latency = Date.now() - start;
-            
+
             samples.push(result);
             latencies.push(latency);
             consecutiveFailures = 0;
-            
+
             if (onSample) {
                 await onSample(result, samples);
             }
@@ -47,24 +47,32 @@ export async function assertSustainedHealth({
                 throw new Error(`assertSustainedHealth: Exceeded max consecutive failures (${maxConsecutiveFailures}). Last error: ${error.message}`);
             }
         }
-        
+
         const elapsed = Date.now() - start;
         const sleepTime = Math.max(0, intervalMs - elapsed);
         if (i < iterations - 1 && sleepTime > 0) {
             await new Promise(r => setTimeout(r, sleepTime));
         }
     }
-    
+
     const actualSuccessRate = samples.length / iterations;
     expect(actualSuccessRate, `Success rate should be >= ${successRate}`).toBeGreaterThanOrEqual(successRate);
-    
+
+    let actualP95 = 0;
     if (latencies.length > 0) {
         latencies.sort((a, b) => a - b);
         const p95Index = Math.max(0, Math.ceil(latencies.length * 0.95) - 1);
-        const actualP95 = latencies[p95Index];
-        
+        actualP95 = latencies[p95Index];
+
         expect(actualP95, `p95 latency should be <= ${p95Ms}ms`).toBeLessThanOrEqual(p95Ms);
     }
-    
-    return samples;
+
+    return {
+        samples,
+        summary: {
+            actualSuccessRate,
+            actualP95,
+            iterations
+        }
+    };
 }

--- a/test/playwright/integration/util/assertSustainedHealth.mjs
+++ b/test/playwright/integration/util/assertSustainedHealth.mjs
@@ -1,0 +1,70 @@
+import {expect} from '@playwright/test';
+
+/**
+ * Asserts the sustained health of the integration stack over a given window.
+ *
+ * @param {Object} options
+ * @param {Function} options.probe - An async function that returns the healthcheck object.
+ * @param {number} [options.windowMs] - Total time to observe. Default: process.env.NEO_INTEGRATION_SUSTAINED_WINDOW_MS || 30000.
+ * @param {number} [options.intervalMs] - Polling interval. Default: process.env.NEO_INTEGRATION_SUSTAINED_INTERVAL_MS || 1000.
+ * @param {number} [options.successRate] - Minimum success rate. Default: 1.0.
+ * @param {number} [options.p95Ms] - Maximum p95 latency. Default: process.env.NEO_INTEGRATION_SUSTAINED_P95_MS || 500.
+ * @param {number} [options.maxConsecutiveFailures] - Max sequential failures allowed. Default: 0.
+ * @param {Function} [options.onSample] - Optional callback to run custom assertions on each sample.
+ * @returns {Promise<Object[]>} The array of gathered samples.
+ */
+export async function assertSustainedHealth({
+    probe,
+    windowMs = Number(process.env.NEO_INTEGRATION_SUSTAINED_WINDOW_MS || 30000),
+    intervalMs = Number(process.env.NEO_INTEGRATION_SUSTAINED_INTERVAL_MS || 1000),
+    successRate = 1.0,
+    p95Ms = Number(process.env.NEO_INTEGRATION_SUSTAINED_P95_MS || 500),
+    maxConsecutiveFailures = 0,
+    onSample
+}) {
+    const samples = [];
+    const latencies = [];
+    let consecutiveFailures = 0;
+    
+    const iterations = Math.max(1, Math.floor(windowMs / intervalMs));
+    
+    for (let i = 0; i < iterations; i++) {
+        const start = Date.now();
+        try {
+            const result = await probe();
+            const latency = Date.now() - start;
+            
+            samples.push(result);
+            latencies.push(latency);
+            consecutiveFailures = 0;
+            
+            if (onSample) {
+                await onSample(result, samples);
+            }
+        } catch (error) {
+            consecutiveFailures++;
+            if (consecutiveFailures > maxConsecutiveFailures) {
+                throw new Error(`assertSustainedHealth: Exceeded max consecutive failures (${maxConsecutiveFailures}). Last error: ${error.message}`);
+            }
+        }
+        
+        const elapsed = Date.now() - start;
+        const sleepTime = Math.max(0, intervalMs - elapsed);
+        if (i < iterations - 1 && sleepTime > 0) {
+            await new Promise(r => setTimeout(r, sleepTime));
+        }
+    }
+    
+    const actualSuccessRate = samples.length / iterations;
+    expect(actualSuccessRate, `Success rate should be >= ${successRate}`).toBeGreaterThanOrEqual(successRate);
+    
+    if (latencies.length > 0) {
+        latencies.sort((a, b) => a - b);
+        const p95Index = Math.max(0, Math.ceil(latencies.length * 0.95) - 1);
+        const actualP95 = latencies[p95Index];
+        
+        expect(actualP95, `p95 latency should be <= ${p95Ms}ms`).toBeLessThanOrEqual(p95Ms);
+    }
+    
+    return samples;
+}


### PR DESCRIPTION
Resolves #10896

Authored by Gemini 3.1 Pro (Antigravity). Session 0318c07d-eb0c-4ef9-9c7a-896dc52e9a14.

## Contract Matrix

| ID | Description | Assertion Scope |
| --- | --- | --- |
| Liveness Window | 5s - 30s | The period during which consecutive requests are evaluated. |
| Probe Interval | 1s | Polling frequency. |
| Monotonic Uptime | `uptime` | The duration value exposed by `healthcheck` must increase monotonically. |
| Persistent Topology | `database.connection.connected` | SQLite/Chroma connections must remain stable. |
| Provider Stability | `providers.*.error` | No embedding or summary provider may throw errors during the window. |

## Substrate Mutation Rationale

Slot Disposition: `keep`
This implementation provides the canonical assertion primitive required to safely merge the memory-leak and concurrent-mutation fixes under the overarching Sustained Liveness epic (#10860). Without this assertion primitive, upstream patches cannot empirically prove the prevention of sudden-death heartbeat loss.

## Delta Scope

- Added `assertSustainedHealth.mjs` primitive encapsulating the rolling-window integration test logic and correctly returning the `{samples, summary}` contract.
- Implemented `HeartbeatPropagation.integration.spec.mjs` utilizing the new primitive.
- Expanded `healthcheck.spec.mjs` coverage to include a short composability check using the primitive.
- Deduplicated Playwright setup helpers in favor of the new `mcpClient.mjs` consolidated infrastructure from Lane A.
- Removed trailing whitespaces.

Evidence: L2 required (integration tests executed locally using `npm run test-integration`).
Residual: none.