### PR TITLE
feat(ci): test matrix workflow gating PRs on unit + integration suites (#10897)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -55,6 +55,11 @@ jobs:
         run: npm run test-${{ matrix.suite }}
         env:
           NEO_INTEGRATION_STACK_TIMEOUT_MS: '240000'
+          # Activates the canonical bucket-skip pattern for tests that gate on
+          # CI substrate (heavy SLM, grid WIP, application-spec deferrals).
+          # Test specs check `process.env.NEO_TEST_SKIP_CI` and skip cleanly.
+          # See #10903 (unit-suite buckets A-E) + #10917/#10918 (bucket F).
+          NEO_TEST_SKIP_CI: 'true'
 
       - name: Upload test artifacts on failure
         if: failure()

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,7 +20,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        suite: [unit, integration]
+        # `unit` deferred until #10903 substrate-audit completes (~30 unit
+        # tests fail in clean CI env due to substrate-data + browser gaps —
+        # pre-existing, not caused by this workflow). Re-add via follow-up
+        # PR once per-bucket fixes land.
+        suite: [integration]
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,61 @@
+name: Tests
+
+on:
+  pull_request:
+    branches: [dev]
+  push:
+    branches: [dev]
+
+concurrency:
+  group: tests-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
+jobs:
+  test:
+    name: ${{ matrix.suite }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        suite: [unit, integration]
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '22'
+          cache: 'npm'
+
+      # Pre-create .neo-ai-data so the `prepare` lifecycle's downloadKnowledgeBase
+      # short-circuits via its existing-dir guard. Integration tests use a tmpfs
+      # Chroma per `ai/deploy/docker-compose.test.yml`; unit tests are mocked.
+      # Neither suite needs the canonical KB artifact in CI.
+      - name: Skip Knowledge Base download in prepare lifecycle
+        run: mkdir -p .neo-ai-data
+
+      - name: Install dependencies
+        run: npm ci
+
+      # Required for the unit-test runner per bootstrapWorktree.mjs precedent.
+      # Harmless for the integration suite.
+      - name: Bundle parse5
+        run: npm run bundle-parse5
+
+      - name: Run ${{ matrix.suite }} tests
+        run: npm run test-${{ matrix.suite }}
+        env:
+          NEO_INTEGRATION_STACK_TIMEOUT_MS: '240000'
+
+      - name: Upload test artifacts on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-results-${{ matrix.suite }}-${{ github.run_id }}
+          path: test/playwright/test-results/
+          retention-days: 14


### PR DESCRIPTION
Resolves #10897

Authored by Claude Opus 4.7 (Claude Code). Session 7e897a0b-33ce-4d6c-b1a9-a1ff93e4e571.

Adds `.github/workflows/test.yml` — a single matrix-on-suite workflow that runs `npm run test-integration` on PR-to-`dev` and push-to-`dev`. Closes the explicitly-deferred CI execution gap from [#10805](https://github.com/neomjs/neo/issues/10805). Activates the canonical `NEO_TEST_SKIP_CI=true` env at the workflow level for the bucket-skip pattern shared across unit-suite + integration-suite test corpus.

Evidence: L3 (CI green on PR head `c846f2db7`: Analyze 1m31s ✓ + CodeQL 2s ✓ + integration 1m59s ✓; run [25513120737](https://github.com/neomjs/neo/actions/runs/25513120737) shows 5 integration specs = 3 pass + 2 skip via `NEO_TEST_SKIP_CI=true`). No residuals.

## What ships

Single new file (`.github/workflows/test.yml`, 71 lines) with:
- Matrix dimension: `suite: [integration]` (unit deferred until #10903 substrate-audit completes; re-add via tiny followup PR once Bucket B+D lands).
- `fail-fast: false` for parallel diagnostic visibility.
- `concurrency.group` + `cancel-in-progress: true` for superseded-PR cancellation.
- `actions/checkout@v6` + `actions/setup-node@v6` (mirroring `data-sync-pipeline.yml` precedent).
- Pre-create empty `.neo-ai-data/` to short-circuit `prepare` lifecycle's KB download.
- `NEO_TEST_SKIP_CI: 'true'` env activation for canonical bucket-skip pattern.
- `NEO_INTEGRATION_STACK_TIMEOUT_MS: '240000'` for cold-CI Docker headroom.
- `actions/upload-artifact@v4` on failure for reviewer-side inspection.
- Triggers on `pull_request: branches: [dev]` AND `push: branches: [dev]` (per data-sync-pipeline precedent).

## Substrate-cascade context (the hard work behind the green CI)

Lane C's first CI run revealed a cascade of pre-existing substrate-config bugs hidden by local-dev Docker layer caching + accumulated state. Six substrate fixes shipped before integration row could pass cleanly:

1. [#10902](https://github.com/neomjs/neo/issues/10902) → [#10904](https://github.com/neomjs/neo/pull/10904) — Dockerfile prepare-lifecycle (`npm ci` + missing `buildScripts/`).
2. [#10908](https://github.com/neomjs/neo/issues/10908) → [#10909](https://github.com/neomjs/neo/pull/10909) — Chroma healthcheck curl missing → python urllib (incomplete).
3. [#10911](https://github.com/neomjs/neo/issues/10911) → [#10912](https://github.com/neomjs/neo/pull/10912) — python → python3 (slim image binary path).
4. [#10913](https://github.com/neomjs/neo/issues/10913) → [#10914](https://github.com/neomjs/neo/pull/10914) — bash TCP probe (image is single-binary, no python interpreter).
5. [#10915](https://github.com/neomjs/neo/issues/10915) → [#10916](https://github.com/neomjs/neo/pull/10916) — per-session McpServer factory + NEO_AUTH_* env binding (Streamable HTTP SDK invariant).
6. [#10917](https://github.com/neomjs/neo/issues/10917) + [#10918](https://github.com/neomjs/neo/issues/10918) → [#10919](https://github.com/neomjs/neo/pull/10919) — Bucket F application-spec deferrals (CrossTenantIsolation isError + HeartbeatPropagation uptime equality).

Lane C IS the workflow that surfaced all six. The MX flywheel turned tightly: empirical CI failure → ticket → fix → strengthened substrate. Tickets #10917 + #10918 stay open for separate Phase 1 diagnostic + Phase 2 fix cycles.

## Lane context

Lane C of a 3-lane parallel coordination cycle on the deployment-pipeline + heartbeat integration test surface @tobiu flagged on 2026-05-07:
- **Lane A** [#10895](https://github.com/neomjs/neo/issues/10895) → [#10901](https://github.com/neomjs/neo/pull/10901) — Identity fixture + tenant-isolation + auth-rejection specs (@neo-gpt). MERGED.
- **Lane B** [#10896](https://github.com/neomjs/neo/issues/10896) → [#10898](https://github.com/neomjs/neo/pull/10898) — Sustained-liveness helper + heartbeat propagation spec (@neo-gemini-3-1-pro). MERGED.
- **Lane C** (this PR) — CI test-matrix workflow. THIS.

## Test Evidence

L3 (achieved):
- CI run [25513120737](https://github.com/neomjs/neo/actions/runs/25513120737) at head `c846f2db7`:
  - `Analyze (javascript)` ✓ pass 1m31s
  - `CodeQL` ✓ pass 2s
  - `Tests / integration` ✓ pass 1m59s
- Job [74876878293](https://github.com/neomjs/neo/actions/runs/25513120737/job/74876878293): 5 integration specs = 3 pass + 2 skip via `NEO_TEST_SKIP_CI=true` (deferred specs cite #10917 / #10918 in skip-message strings).
- Cross-family review: @neo-gpt formal Approved at [pullrequestreview-4246543481](https://github.com/neomjs/neo/pull/10899#pullrequestreview-4246543481) post-rebase + post-CI-green.

## Post-Merge Validation

- [ ] Configure branch protection on `dev` requiring `Tests / integration` check. *(Repo-admin operation — not a code change. Filed separately if needed.)*
- [ ] Once [#10903](https://github.com/neomjs/neo/issues/10903) Bucket B+D lands, follow-up PR adds `unit` row to matrix. Workflow's `NEO_TEST_SKIP_CI=true` env already activates the unit-suite skip-guards merged via #10907 + #10910 (and Gemini's pending Bucket B+D). ~5-line followup.
- [ ] Observe CI behavior on next 3-5 cross-family PRs to confirm no false-positive failures.

## Commits

- `65bcdf471` (squashed) — Initial: `.github/workflows/test.yml` matrix(unit, integration), 61 lines.
- `b087b817b` — Scope reduction: drop `unit` from matrix per #10903 investigation-first shape.
- `094c3e712` — Activate NEO_TEST_SKIP_CI=true env (per @neo-gpt RA on #10919: skip-guards inert without env activation).

## Cross-family review

- Cycle 1: @neo-gpt requested changes (CI red → required substrate fixes + skip-activation).
- Substrate cascade landed independently (6 PRs: #10904, #10909, #10912, #10914, #10916, #10919).
- Cycle 2 / re-review: @neo-gpt formal Approved post-rebase + post-CI-green at [pullrequestreview-4246543481](https://github.com/neomjs/neo/pull/10899#pullrequestreview-4246543481). Verified empirically: 5 specs = 3 pass + 2 skip.

Origin Session ID: `7e897a0b-33ce-4d6c-b1a9-a1ff93e4e571`