### PR TITLE
fix(deploy): add --ignore-scripts to npm ci in Dockerfile (#10902)

### DIFF
--- a/ai/deploy/Dockerfile
+++ b/ai/deploy/Dockerfile
@@ -2,7 +2,11 @@ FROM node:22-bookworm-slim AS builder
 
 WORKDIR /app
 COPY package*.json ./
-RUN npm ci --omit=dev
+# --ignore-scripts skips the `prepare` lifecycle hook (initServerConfigs +
+# downloadKnowledgeBase). Both are dev-time only — production Docker images
+# don't need template-config copying or KB-artifact downloads. Without this
+# flag, npm ci fails because buildScripts/ has not been COPY'd yet (#10902).
+RUN npm ci --omit=dev --ignore-scripts
 
 COPY . .
 


### PR DESCRIPTION
Resolves #10902

Authored by Claude Opus 4.7 (Claude Code). Session 7e897a0b-33ce-4d6c-b1a9-a1ff93e4e571.

One-line fix to `ai/deploy/Dockerfile` that unblocks all clean-environment Docker builds. The substrate bug was hidden by Docker layer caching on local-dev machines and surfaced for the first time by Lane C CI workflow ([#10897](https://github.com/neomjs/neo/issues/10897) / PR [#10899](https://github.com/neomjs/neo/pull/10899)) on its first run.

Evidence: L1 (file change minimal + clear; comment explains rationale) → L3 in-flight (this PR's own CI under [#10899](https://github.com/neomjs/neo/pull/10899)'s workflow will validate at L3 once both branches converge in `dev`). No external residuals — the L3 evidence materializes via Lane C CI on any subsequent integration-suite run.

## Root Cause Summary

`Dockerfile` lines 4-5 before this fix:
```dockerfile
COPY package*.json ./       # Only package.json + package-lock.json
RUN npm ci --omit=dev       # Triggers `prepare` lifecycle → fails
```

`npm ci` automatically runs the `prepare` script defined in [`package.json:57`](https://github.com/neomjs/neo/blob/dev/package.json#L57):
```
"prepare": "node ./buildScripts/ai/initServerConfigs.mjs && node ./buildScripts/ai/downloadKnowledgeBase.mjs"
```

At the time `npm ci` runs in the Dockerfile, `buildScripts/` hasn't been COPY'd yet. The script fails with `Cannot find module '/app/buildScripts/ai/initServerConfigs.mjs'`. The subsequent `COPY . .` brings buildScripts/ but Docker has already failed.

Empirical anchor: [Lane C CI run 25497549380](https://github.com/neomjs/neo/actions/runs/25497549380), `integration` job — both `kb-server` and `mc-server` Docker builds fail at this same step.

## The Fix

```diff
- RUN npm ci --omit=dev
+ # --ignore-scripts skips the `prepare` lifecycle hook (initServerConfigs +
+ # downloadKnowledgeBase). Both are dev-time only — production Docker images
+ # don't need template-config copying or KB-artifact downloads. Without this
+ # flag, npm ci fails because buildScripts/ has not been COPY'd yet (#10902).
+ RUN npm ci --omit=dev --ignore-scripts
```

The `--ignore-scripts` flag instructs npm to skip lifecycle hooks (`prepare`, `postinstall`, etc.) during install. Production Docker images don't need either of the prepare-lifecycle scripts (`initServerConfigs` is for local-dev gitignored-config copying; `downloadKnowledgeBase` is for local-dev KB-artifact downloads). Both are zero-value in the runtime image.

## Why this wasn't caught earlier

Local Docker builds passed via layer caching: when developers ran `docker compose -f ai/deploy/docker-compose.test.yml up --build` after a prior successful build, the `RUN npm ci` layer was cached from a state when `buildScripts/` had been previously available (e.g., during local dev with full repo). Layer-cache invalidation only fires when the COPY'd files change, so subsequent `--build` invocations re-used the already-broken-but-cached layer.

[#10880](https://github.com/neomjs/neo/pull/10880) (Docker artifacts) and [#10893](https://github.com/neomjs/neo/pull/10893) (Lane A integration test using these artifacts) both landed under this caching mask. Lane C ([#10899](https://github.com/neomjs/neo/pull/10899)) was the first PR to run a truly clean ubuntu-latest Docker build → bug surfaced immediately.

## Test Evidence

L1 verification (this PR):
- `git diff ai/deploy/Dockerfile`: 1 line changed (added flag) + 4 lines added (inline comment).
- Dockerfile syntactically valid (no Docker-specific lint tooling in repo; manual visual inspection against base image semantics).

L3 verification (deferred to convergence):
- Once this PR merges to `dev`, Lane C [#10899](https://github.com/neomjs/neo/pull/10899)'s `integration` matrix row will pass on its next CI run.
- Sibling PR [#10898](https://github.com/neomjs/neo/pull/10898) (Lane B sustained-liveness) will also gain L2/L3 evidence path post-merge.

## Sibling Lane Impact

This fix unblocks integration-test verification for:
- **Lane C** ([#10899](https://github.com/neomjs/neo/pull/10899)) — own PR; CI gating depends on this.
- **Lane B** ([#10898](https://github.com/neomjs/neo/pull/10898)) — Gemini's sustained-liveness PR; its L2 evidence claim depends on Docker stack starting cleanly.
- **Lane A** ([#10895](https://github.com/neomjs/neo/issues/10895)) — GPT's tenant-isolation PR (in flight); its compose update + spec verification will need Docker.
- All future integration-test PRs.

## Post-Merge Validation

- [ ] Re-run [Lane C CI #10899](https://github.com/neomjs/neo/pull/10899) after this lands; verify `integration` matrix row passes.
- [ ] Optional: local smoke verification — `docker compose -f ai/deploy/docker-compose.test.yml build --no-cache kb-server mc-server` from a clean checkout.

## Cross-family review request

This touches @neo-gemini-3-1-pro's [#10880](https://github.com/neomjs/neo/pull/10880) substrate. Routing to **@neo-gemini-3-1-pro** as primary reviewer per Authorship-respect heuristic + cross-family pairing (Anthropic → Google).

Origin Session ID: `7e897a0b-33ce-4d6c-b1a9-a1ff93e4e571`