### PR TITLE
docs(ai): institutionalize CI/Security check PR audit

### DIFF
--- a/.agents/skills/pr-review/assets/pr-review-followup-template.md
+++ b/.agents/skills/pr-review/assets/pr-review-followup-template.md
@@ -82,10 +82,11 @@ This is the follow-up form of the Depth Floor. Do not omit it because the prior 
 *(Required per guide §7.6. Reviewers MUST verify automated GitHub Actions before assigning an `[EXECUTION_QUALITY]` score.)*
 
 - [ ] Ran `gh pr checks <N>` to empirically verify CI status.
+- [ ] Confirmed no checks are pending/in-progress (Hold review if unfinished).
 - [ ] Confirmed no "deep red" critical failures (e.g., CodeQL, Security, core build).
 - [ ] If checks are failing, flagged them in Required Actions to block approval.
 
-**Findings:** [Pass - all checks green / Failures flagged in Required Actions / N/A - no CI triggered]
+**Findings:** [Pass - all checks green / Pending - review held / Failures flagged in Required Actions / N/A - no CI triggered]
 
 ---
 

--- a/.agents/skills/pr-review/assets/pr-review-followup-template.md
+++ b/.agents/skills/pr-review/assets/pr-review-followup-template.md
@@ -77,6 +77,18 @@ This is the follow-up form of the Depth Floor. Do not omit it because the prior 
 
 ---
 
+### 🛡️ CI / Security Checks Audit
+
+*(Required per guide §7.6. Reviewers MUST verify automated GitHub Actions before assigning an `[EXECUTION_QUALITY]` score.)*
+
+- [ ] Ran `gh pr checks <N>` to empirically verify CI status.
+- [ ] Confirmed no "deep red" critical failures (e.g., CodeQL, Security, core build).
+- [ ] If checks are failing, flagged them in Required Actions to block approval.
+
+**Findings:** [Pass - all checks green / Failures flagged in Required Actions / N/A - no CI triggered]
+
+---
+
 ### Metrics Delta
 
 Update only metrics whose score changed since the prior review. Carry unchanged metrics forward by reference.

--- a/.agents/skills/pr-review/assets/pr-review-template.md
+++ b/.agents/skills/pr-review/assets/pr-review-template.md
@@ -192,10 +192,11 @@ For every modified or added OpenAPI tool description:
 *(Required per guide §7.6. Reviewers MUST verify automated GitHub Actions before assigning an `[EXECUTION_QUALITY]` score.)*
 
 - [ ] Ran `gh pr checks <N>` to empirically verify CI status.
+- [ ] Confirmed no checks are pending/in-progress (Hold review if unfinished).
 - [ ] Confirmed no "deep red" critical failures (e.g., CodeQL, Security, core build).
 - [ ] If checks are failing, flagged them in Required Actions to block approval.
 
-**Findings:** [Pass - all checks green / Failures flagged in Required Actions / N/A - no CI triggered]
+**Findings:** [Pass - all checks green / Pending - review held / Failures flagged in Required Actions / N/A - no CI triggered]
 
 ---
 
@@ -213,7 +214,7 @@ To proceed with merging, please address the following:
 
 No required actions — eligible for human merge.
 
-*Do NOT use pre-ticked placeholder items like `- [x] All checks pass and no required changes identified.` — that reads as box-checking, not genuine review. Per guide §5 Zero-Issue PR Semantics + §7.5 anti-patterns table.*
+*Do NOT use pre-ticked placeholder items like `- [x] All checks pass and no required changes identified.` — that reads as box-checking, not genuine review. Per guide §5 Zero-Issue PR Semantics + §7.7 anti-patterns table.*
 
 ---
 

--- a/.agents/skills/pr-review/assets/pr-review-template.md
+++ b/.agents/skills/pr-review/assets/pr-review-template.md
@@ -187,6 +187,18 @@ For every modified or added OpenAPI tool description:
 
 ---
 
+### 🛡️ CI / Security Checks Audit
+
+*(Required per guide §7.6. Reviewers MUST verify automated GitHub Actions before assigning an `[EXECUTION_QUALITY]` score.)*
+
+- [ ] Ran `gh pr checks <N>` to empirically verify CI status.
+- [ ] Confirmed no "deep red" critical failures (e.g., CodeQL, Security, core build).
+- [ ] If checks are failing, flagged them in Required Actions to block approval.
+
+**Findings:** [Pass - all checks green / Failures flagged in Required Actions / N/A - no CI triggered]
+
+---
+
 ### 📋 Required Actions
 
 **For PRs with required actions — use the checkbox list form:**

--- a/.agents/skills/pr-review/audits/ci-security-audit.md
+++ b/.agents/skills/pr-review/audits/ci-security-audit.md
@@ -1,24 +1,27 @@
 # CI / Security Checks Audit
 
-Before granting approval on **any** Pull Request, you MUST empirically verify the status of GitHub Actions and CI checks. Security bots (like CodeQL) and automated test workflows run asynchronously on GitHub. A static diff review *cannot* catch what these automated tools find. Approving a PR with failing CI checks is a critical safety violation.
+Before granting approval on **any** Pull Request, you MUST empirically verify the status of GitHub Actions and CI checks. Security bots (like CodeQL) and automated test workflows run asynchronously on GitHub. A static diff review *cannot* catch what these automated tools find. Approving a PR with failing or incomplete CI checks is a critical safety violation.
 
 ## The Verification Protocol
 
-1. **Empirical Verification:** 
+1. **Empirical Verification:**
    You must run `gh pr checks <N>` to view the status of all checks for the PR.
-   
-2. **Failure Handling ("Deep Red" Rule):** 
+
+2. **Pending/In-Progress Checks:**
+   If any checks are pending, queued, or in-progress, you **MUST HOLD** your review. You cannot approve a PR until all critical checks have finished running.
+
+3. **Failure Handling ("Deep Red" Rule):**
    If any critical checks (especially CodeQL, Security, or main build tests) are failing or marked "deep red", you **MUST NOT** approve the PR.
 
-3. **Required Action Assignment:** 
+4. **Required Action Assignment:**
    If checks are failing, flag the specific failing checks as a **Required Action** in your review. Instruct the author to fix the vulnerabilities or test failures before re-requesting review.
 
-4. **Approval Block:** 
+5. **Approval Block:**
    A PR with failing security or build checks is fundamentally unsafe and cannot be approved, regardless of how clean the diff looks to you.
 
 ## Documentation Requirement
 
-When completing the `[EXECUTION_QUALITY]` section of the PR review template, you MUST explicitly document that you ran `gh pr checks <N>` and confirm the checks passed.
+When completing the `[EXECUTION_QUALITY]` section of the PR review template, you MUST explicitly document that you ran `gh pr checks <N>` and confirm the checks passed or are appropriately handled.
 
 **Example Review Commentary:**
 > ✅ **CI / Security Audit:** Ran `gh pr checks 1234`. All workflows (CodeQL, Unit Tests) pass successfully. No deep red flags.

--- a/.agents/skills/pr-review/audits/ci-security-audit.md
+++ b/.agents/skills/pr-review/audits/ci-security-audit.md
@@ -1,0 +1,24 @@
+# CI / Security Checks Audit
+
+Before granting approval on **any** Pull Request, you MUST empirically verify the status of GitHub Actions and CI checks. Security bots (like CodeQL) and automated test workflows run asynchronously on GitHub. A static diff review *cannot* catch what these automated tools find. Approving a PR with failing CI checks is a critical safety violation.
+
+## The Verification Protocol
+
+1. **Empirical Verification:** 
+   You must run `gh pr checks <N>` to view the status of all checks for the PR.
+   
+2. **Failure Handling ("Deep Red" Rule):** 
+   If any critical checks (especially CodeQL, Security, or main build tests) are failing or marked "deep red", you **MUST NOT** approve the PR.
+
+3. **Required Action Assignment:** 
+   If checks are failing, flag the specific failing checks as a **Required Action** in your review. Instruct the author to fix the vulnerabilities or test failures before re-requesting review.
+
+4. **Approval Block:** 
+   A PR with failing security or build checks is fundamentally unsafe and cannot be approved, regardless of how clean the diff looks to you.
+
+## Documentation Requirement
+
+When completing the `[EXECUTION_QUALITY]` section of the PR review template, you MUST explicitly document that you ran `gh pr checks <N>` and confirm the checks passed.
+
+**Example Review Commentary:**
+> ✅ **CI / Security Audit:** Ran `gh pr checks 1234`. All workflows (CodeQL, Unit Tests) pass successfully. No deep red flags.

--- a/.agents/skills/pr-review/references/pr-review-guide.md
+++ b/.agents/skills/pr-review/references/pr-review-guide.md
@@ -283,7 +283,11 @@ Reviewers MUST verify testing claims and canonical file placement:
 3. If the PR is a documentation or template change, no tests are required. Do not demand tests for docs.
 4. If the author did not provide test evidence for structural logic changes, or placed tests in legacy/incorrect directories, flag this as a **Required Action**.
 
-### 7.6 Anti-Patterns
+### 7.6 CI / Security Checks Audit
+
+Before approving any PR, you MUST use the `view_file` tool to read and strictly adhere to `.agents/skills/pr-review/audits/ci-security-audit.md` to verify the automated GitHub Actions and Security checks.
+
+### 7.7 Anti-Patterns
 
 | Anti-pattern | Why it fails the Depth Floor |
 |---|---|
@@ -295,6 +299,7 @@ Reviewers MUST verify testing claims and canonical file placement:
 | Ignoring Chain of Custody | §7.3 Provenance Audit violated on a major abstraction |
 | Approval without rhetorical-drift audit on a PR carrying substantive architectural prose | §7.4 Rhetorical-Drift Audit violated; framing drifts from mechanical reality, poisons `ask_knowledge_base` ingestion |
 | Approving `[EXECUTION_QUALITY]` without executing the author's test evidence or checking test locations | §7.5 Test-Execution & Location Audit violated; reviewers must independently verify testing claims and canonical file placement |
+| Approving a PR with failing CI or security checks (like CodeQL) | §7.6 CI / Security Checks Audit violated; fundamentally unsafe code |
 | PR names an epic as close-target without flagging | §5.2 Close-Target Audit violated; risks epic auto-close-with-open-subs (see #9999 sabotage chain) |
 | Re-escalating Required Action without superior empirical evidence after `[REJECTED_WITH_RATIONALE]` | §9.1 Reviewer-Yield Protocol violated; reviewers must yield to author's empirical evidence |
 | PR adds bloated multi-line OpenAPI tool description without flagging | §5.3 MCP-Tool-Description Budget Audit violated; bloat compounds across the tool surface and competes with agent reasoning budget at runtime |


### PR DESCRIPTION
Resolves #10905

Authored by Gemini 3.1 Pro (Antigravity). Session d4129f93-807b-4c2e-beee-c63cd5462a94.

## Substrate Mutation Rationale
**Slot Disposition:** `compress-to-trigger` (Map vs World Atlas)
This extracts the verbose CI/Security check requirements into a dedicated payload at `.agents/skills/pr-review/audits/ci-security-audit.md` and replaces it with a lightweight 1-line trigger in the main `pr-review-guide.md` (§7.6). This decreases context bloat while enforcing safety against deep-red PR approvals.

## Delta Scope
- Created `.agents/skills/pr-review/audits/ci-security-audit.md` (World Atlas).
- Added one-line trigger in `pr-review-guide.md` §7.6 (The Map).
- Updated the templates to include the audit checkbox + Pending check coverage.
- Fixed stale guide reference in templates.

Evidence: L1 (sandbox ceiling) -> L1 required (docs only). Residual: none.