### PR TITLE
feat(testing): NEO_TEST_SKIP_CI guard for heavy-SLM + auth specs (#10903)

### DIFF
--- a/test/playwright/unit/ai/mcp/Authorization.spec.mjs
+++ b/test/playwright/unit/ai/mcp/Authorization.spec.mjs
@@ -129,6 +129,12 @@ test.describe('MCP Server OIDC/OAuth 2.1 Authorization (Functional)', () => {
     });
 
     test('should allow access with a valid token', async ({request}) => {
+        // Bucket E (#10903) PoC-skip: in CI, the token-issuing substrate (OIDC discovery + JWKS)
+        // is not provisioned, so the bearer token validation path can't complete. TODO: investigate
+        // whether this needs a mock issuer fixture or a fully-skipped substrate-data bucket — for
+        // now, skip with rationale to unblock Lane C (#10897) `unit` matrix re-add.
+        test.skip(!!process.env.NEO_TEST_SKIP_CI, 'CI-skip: token-issuing substrate not provisioned — bucket E (#10903)');
+
         const response = await request.post(`http://localhost:${MCP_SSE_PORT}/mcp`, {
             headers: {
                 'Authorization': `Bearer ${TEST_TOKEN}`,

--- a/test/playwright/unit/ai/mcp/server/memory-core/services/SessionSummarization.spec.mjs
+++ b/test/playwright/unit/ai/mcp/server/memory-core/services/SessionSummarization.spec.mjs
@@ -31,6 +31,12 @@ const __dirname  = path.dirname(__filename);
 dotenv.config({path: path.resolve(__dirname, '../../../../../../../../.env'), quiet: true});
 
 test.describe('Memory Core Offline Summarization', () => {
+    // Bucket A (#10903): heavy SLM (gemma4) dependency — no local LM Studio / Ollama in CI.
+    // The per-test `localModelActive` guard below stays as a defensive fallback for local-dev
+    // without gemma4 running, but the CI-side skip is the early exit that prevents `beforeAll`
+    // from probing a nonexistent endpoint.
+    test.skip(!!process.env.NEO_TEST_SKIP_CI, 'CI-skip: heavy SLM (gemma4) — bucket A (#10903)');
+
     let SDK, TextEmbeddingService, dummySessionId;
     let localModelActive = false;
 


### PR DESCRIPTION
Related: #10903

Authored by Claude Opus 4.7 (Claude Code). Session 7e897a0b-33ce-4d6c-b1a9-a1ff93e4e571.

Bucket A + E sub-PR for [#10903](https://github.com/neomjs/neo/issues/10903) (Audit unit-test failures in clean CI env). Establishes the canonical `NEO_TEST_SKIP_CI` single-env-var skip-guard pattern with bucket-context preserved in the skip-message string. Per @tobiu's framing: simplest solution; granularity available later if needed via skip-message-grep.

Evidence: L1 (file syntax + diff verified via `node --check`) → L2 in-flight (specs will skip cleanly once `NEO_TEST_SKIP_CI=true` is set in `.github/workflows/test.yml` via Lane C-followup PR after Buckets B/C/D land). No external residuals.

## What this PR ships

Two file changes, +12 lines:

### Bucket A — heavy SLM (gemma4)

`test/playwright/unit/ai/mcp/server/memory-core/services/SessionSummarization.spec.mjs`:

```js
test.describe('Memory Core Offline Summarization', () => {
    // Bucket A (#10903): heavy SLM (gemma4) dependency — no local LM Studio / Ollama in CI.
    // The per-test `localModelActive` guard below stays as a defensive fallback for local-dev
    // without gemma4 running, but the CI-side skip is the early exit that prevents `beforeAll`
    // from probing a nonexistent endpoint.
    test.skip(!!process.env.NEO_TEST_SKIP_CI, 'CI-skip: heavy SLM (gemma4) — bucket A (#10903)');
    // ...rest unchanged
```

Belt-and-suspenders: the existing per-test `localModelActive` runtime guard remains as a defensive fallback for local-dev machines without gemma4 actually running. The new describe-level `NEO_TEST_SKIP_CI` guard fires earlier — preventing `beforeAll` from probing a nonexistent endpoint at all.

### Bucket E — Authorization PoC-skip

`test/playwright/unit/ai/mcp/Authorization.spec.mjs:131` (single test, `'should allow access with a valid token'`):

```js
test('should allow access with a valid token', async ({request}) => {
    // Bucket E (#10903) PoC-skip: in CI, the token-issuing substrate (OIDC discovery + JWKS)
    // is not provisioned, so the bearer token validation path can't complete. TODO: investigate
    // whether this needs a mock issuer fixture or a fully-skipped substrate-data bucket — for
    // now, skip with rationale to unblock Lane C (#10897) `unit` matrix re-add.
    test.skip(!!process.env.NEO_TEST_SKIP_CI, 'CI-skip: token-issuing substrate not provisioned — bucket E (#10903)');
    // ...rest unchanged
```

Per @tobiu's *"even those could get skipped for a PoC"* framing — skip with a TODO rather than try to fix the substrate. Future ticket can address the mock-issuer fixture properly.

## Why a single env var (vs granular)

Considered per-bucket env vars (`NEO_LOCAL_SLM_AVAILABLE`, `NEO_SKIP_AUTH_PROVISIONING`, etc.) and rejected for **this audit** because:

- Single CI knob is simpler to set + flip.
- Bucket context lives in the skip-message string — `grep -rn "bucket A"` / `bucket E` finds all guards when bucket-substrate work eventually lands. The string IS the metadata.
- YAGNI: granularity can be split out non-destructively if it ever becomes load-bearing.
- Matches @tobiu's *"simplest solution is a new env var like NEO_TEST_SKIP_CI"* directive.

## Sibling sub-PRs (in flight per #10903 distribution)

The other 3 buckets are distributed across the swarm via A2A:
- **Bucket B + D** — @neo-gemini-3-1-pro: grid refactor WIP (`LockedColumns`, `Pooling`, `Teleportation`) + MCP server bootstrap (`McpServersHealth`, `McpServersIsolation`).
- **Bucket C** — @neo-gpt: substrate-data tests (~17 specs across `checkAllAgentIdle`, `checkSunsetted`, `resumeHarness`, `DestructiveOperationGuard`, `SessionService.*`, `QueryReRanker`, `PullRequestService`).

After all 3 bucket PRs merge, I file a tiny Lane C-followup PR (against #10897) that:
1. Adds `unit` back to the matrix in `.github/workflows/test.yml`.
2. Sets `NEO_TEST_SKIP_CI=true` in the workflow env.
3. Includes `Resolves #10903` for the substrate-audit close-out.

## Test Evidence

L1:
- `node --check test/playwright/unit/ai/mcp/server/memory-core/services/SessionSummarization.spec.mjs` — clean.
- `node --check test/playwright/unit/ai/mcp/Authorization.spec.mjs` — clean.
- `git diff --stat` — 2 files changed, 12 insertions, 0 deletions.

L2 verification (deferred to convergence): once `NEO_TEST_SKIP_CI=true` lands in `dev`'s CI workflow + this PR is in `dev`, both specs skip cleanly when `npm run test-unit` runs in CI; locally without `NEO_TEST_SKIP_CI` set, they run as today (gated by the existing `localModelActive` runtime probe in Bucket A).

## Post-Merge Validation

- [ ] Once Lane C-followup PR sets `NEO_TEST_SKIP_CI=true`, verify `Tests / unit` matrix row no longer fails on the SessionSummarization 4 tests + Authorization line-131 test.
- [ ] Optional: `grep -rn "bucket [A-E]" test/playwright/unit/` returns the canonical list of bucket-skipped tests for future cleanup.

## Commits

- `c63c112ec` — `feat(testing): NEO_TEST_SKIP_CI guard for heavy-SLM + auth specs (#10903)` (single commit, +12 lines).

## Cross-family review request

Round-robin assignment: **@neo-gemini-3-1-pro** as primary reviewer (Anthropic → Google). Lane B's recent post-rebase pattern + her #10906 audit institutionalization both validate her on this kind of substrate-discipline review.

Origin Session ID: `7e897a0b-33ce-4d6c-b1a9-a1ff93e4e571`