### PR TITLE
test(ci): add bucket c clean-ci skip guards (#10903)

### DIFF
--- a/test/playwright/unit/ai/mcp/server/github-workflow/PullRequestService.spec.mjs
+++ b/test/playwright/unit/ai/mcp/server/github-workflow/PullRequestService.spec.mjs
@@ -1,6 +1,7 @@
 import {setup} from '../../../../../setup.mjs';
 
 const appName = 'PullRequestServiceTest';
+const skipCiGitHubAuth = !!process.env.NEO_TEST_SKIP_CI;
 
 setup({
     neoConfig: {
@@ -222,6 +223,8 @@ test.describe('Neo.ai.mcp.server.github-workflow.services.PullRequestService —
 });
 
 test.describe('Neo.ai.mcp.server.github-workflow.services.PullRequestService — getPullRequestDiff (#10748)', () => {
+    test.skip(skipCiGitHubAuth, 'CI-skip: gh CLI auth not configured - bucket C (#10903)');
+
     let PullRequestService;
     let fs;
     let path;
@@ -314,4 +317,3 @@ test.describe('Neo.ai.mcp.server.github-workflow.services.PullRequestService —
         expect(result.code).toBe('SHA_NOT_FOUND');
     });
 });
-

--- a/test/playwright/unit/ai/mcp/server/memory-core/services/QueryReRanker.spec.mjs
+++ b/test/playwright/unit/ai/mcp/server/memory-core/services/QueryReRanker.spec.mjs
@@ -1,6 +1,7 @@
 import {setup} from '../../../../../../setup.mjs';
 
 const appName = 'QueryReRankerTest';
+const skipCiSubstrateData = !!process.env.NEO_TEST_SKIP_CI;
 
 setup({
     neoConfig: {
@@ -28,6 +29,8 @@ const __dirname  = path.dirname(__filename);
 dotenv.config({path: path.resolve(__dirname, '../../../../../../../../.env'), quiet: true});
 
 test.describe('StorageRouter Query Re-Ranker Defensive Handling', () => {
+    test.skip(skipCiSubstrateData, 'CI-skip: Memory Core substrate data not seeded - bucket C (#10903)');
+
     let SDK, TextEmbeddingService, testSessionId;
     const testPid = process.pid;
     const testTs  = Date.now();
@@ -170,6 +173,8 @@ test.describe('StorageRouter Query Re-Ranker Defensive Handling', () => {
 });
 
 test.describe('SessionService Drift Detection — Timestamp Filtering', () => {
+    test.skip(skipCiSubstrateData, 'CI-skip: Memory Core substrate data not seeded - bucket C (#10903)');
+
     let SDK, TextEmbeddingService, driftSessionId;
     const testPid = process.pid;
     const testTs  = Date.now();

--- a/test/playwright/unit/ai/mcp/server/memory-core/services/SessionService.ResumeValidation.spec.mjs
+++ b/test/playwright/unit/ai/mcp/server/memory-core/services/SessionService.ResumeValidation.spec.mjs
@@ -1,6 +1,7 @@
 import {setup} from '../../../../../../setup.mjs';
 
 const appName = 'MemoryCoreSessionResumeValidationTest';
+const skipCiSubstrateData = !!process.env.NEO_TEST_SKIP_CI;
 
 process.env.NEO_MODEL_PROVIDER = 'openAiCompatible';
 process.env.NEO_OPENAI_COMPATIBLE_MODEL = 'gemma4';
@@ -31,6 +32,8 @@ const __dirname  = path.dirname(__filename);
 dotenv.config({path: path.resolve(__dirname, '../../../../../../../../.env'), quiet: true});
 
 test.describe('SessionService validateSessionForResume (#10725)', () => {
+    test.skip(skipCiSubstrateData, 'CI-skip: Memory Core substrate data not seeded - bucket C (#10903)');
+
     let SDK, TextEmbeddingService;
 
     test.beforeAll(async () => {

--- a/test/playwright/unit/ai/mcp/server/memory-core/services/SessionService.spec.mjs
+++ b/test/playwright/unit/ai/mcp/server/memory-core/services/SessionService.spec.mjs
@@ -1,6 +1,7 @@
 import {setup} from '../../../../../../setup.mjs';
 
 const appName = 'MemoryCoreSessionServiceTest';
+const skipCiSubstrateData = !!process.env.NEO_TEST_SKIP_CI;
 
 process.env.NEO_MODEL_PROVIDER        = 'openAiCompatible';
 process.env.NEO_OPENAI_COMPATIBLE_MODEL = 'gemma4';
@@ -30,6 +31,8 @@ const __dirname  = path.dirname(__filename);
 dotenv.config({path: path.resolve(__dirname, '../../../../../../../../.env'), quiet: true});
 
 test.describe('SessionService setSessionId', () => {
+    test.skip(skipCiSubstrateData, 'CI-skip: Memory Core substrate data not seeded - bucket C (#10903)');
+
     let SDK, TextEmbeddingService, dummySessionId;
 
     test.beforeAll(async () => {

--- a/test/playwright/unit/ai/mcp/server/shared/services/DestructiveOperationGuard.spec.mjs
+++ b/test/playwright/unit/ai/mcp/server/shared/services/DestructiveOperationGuard.spec.mjs
@@ -191,6 +191,8 @@ test.describe('Neo.ai.mcp.server.shared.services.DestructiveOperationGuard (#108
 });
 
 test.describe('DestructiveOperationGuard call-site wiring (#10845)', () => {
+    const skipCiSubstrateData = !!process.env.NEO_TEST_SKIP_CI;
+
     test('Memory Core CollectionProxy stops before deleting a production Chroma collection', async () => {
         const proxy = Neo.create(CollectionProxy, {
             collectionType: 'memory'
@@ -220,6 +222,8 @@ test.describe('DestructiveOperationGuard call-site wiring (#10845)', () => {
     });
 
     test('Memory Core graph truncate stops before SQLite deletion on the production graph path', async () => {
+        test.skip(skipCiSubstrateData, 'CI-skip: substrate data not seeded - bucket C (#10903)');
+
         await expect(MemoryDatabaseService.truncateDatabase({
             include: ['graph']
         })).rejects.toMatchObject({

--- a/test/playwright/unit/ai/scripts/checkAllAgentIdle.spec.mjs
+++ b/test/playwright/unit/ai/scripts/checkAllAgentIdle.spec.mjs
@@ -1,6 +1,7 @@
 import {setup} from '../../../setup.mjs';
 
 const appName = 'AllAgentIdleDetectionTest';
+const skipCiSubstrateData = !!process.env.NEO_TEST_SKIP_CI;
 
 setup({
     neoConfig: {
@@ -26,6 +27,8 @@ test.describe('ai/scripts/checkAllAgentIdle', () => {
     const identitiesEnv = '@neo-test-agent-1,@neo-test-agent-2';
 
     test('checkAllAgentIdle.mjs emits positive signal when all configured agents are idle', async () => {
+        test.skip(skipCiSubstrateData, 'CI-skip: substrate data not seeded - bucket C (#10903)');
+
         const GraphService = (await import('../../../../../ai/mcp/server/memory-core/services/GraphService.mjs')).default;
         await GraphService.initAsync();
 
@@ -72,6 +75,8 @@ test.describe('ai/scripts/checkAllAgentIdle', () => {
     });
 
     test('checkAllAgentIdle.mjs emits negative signal when at least one agent is active', async () => {
+        test.skip(skipCiSubstrateData, 'CI-skip: substrate data not seeded - bucket C (#10903)');
+
         const GraphService = (await import('../../../../../ai/mcp/server/memory-core/services/GraphService.mjs')).default;
         await GraphService.initAsync();
 

--- a/test/playwright/unit/ai/scripts/checkSunsetted.spec.mjs
+++ b/test/playwright/unit/ai/scripts/checkSunsetted.spec.mjs
@@ -1,6 +1,7 @@
 import {setup} from '../../../setup.mjs';
 
 const appName = 'SunsetDetectionTest';
+const skipCiSubstrateData = !!process.env.NEO_TEST_SKIP_CI;
 
 setup({
     neoConfig: {
@@ -85,6 +86,8 @@ test.describe('ai/scripts/checkSunsetted', () => {
     });
 
     test('checkSunsetted.mjs update-on-read legacy row migration actually migrates legacy structure', async () => {
+        test.skip(skipCiSubstrateData, 'CI-skip: substrate data not seeded - bucket C (#10903)');
+
         const GraphService = (await import('../../../../../ai/mcp/server/memory-core/services/GraphService.mjs')).default;
         await GraphService.initAsync();
 
@@ -128,6 +131,8 @@ test.describe('ai/scripts/checkSunsetted', () => {
     });
 
     test('checkSunsetted.mjs legacy-row-blocking-fresh-rows regression test (#10643)', async () => {
+        test.skip(skipCiSubstrateData, 'CI-skip: substrate data not seeded - bucket C (#10903)');
+
         // Pre-fix: COALESCE(timestamp, name) sorted 'Memory: 2026-xx' (legacy) > '2026-xx' (fresh pure ISO string)
         // Post-fix: Bulk migration converts legacy rows to pure timestamps, allowing deterministic chronological sorting.
         const GraphService = (await import('../../../../../ai/mcp/server/memory-core/services/GraphService.mjs')).default;
@@ -186,6 +191,8 @@ test.describe('ai/scripts/checkSunsetted', () => {
     });
 
     test('checkSunsetted.mjs does NOT flag sunsetted when subscription exists and AGENT_MEMORY is stale (#10641, #10673)', async () => {
+        test.skip(skipCiSubstrateData, 'CI-skip: substrate data not seeded - bucket C (#10903)');
+
         // Per issue #10641: removing the memory-staleness branch from the sunset predicate.
         // Pre-fix: a 24h-old AGENT_MEMORY would flip `sunsetted=true` even with an active
         // subscription, triggering orphan-session-spawn via `resumeHarness.mjs`.
@@ -255,6 +262,8 @@ test.describe('ai/scripts/checkSunsetted', () => {
     });
 
     test('detector contract: active subscription + fresh memory → no_action (#10673 4-quadrant: F,F)', async () => {
+        test.skip(skipCiSubstrateData, 'CI-skip: substrate data not seeded - bucket C (#10903)');
+
         // Quadrant (sunset=false, idle_out_candidate=false): the no-op case.
         const GraphService = (await import('../../../../../ai/mcp/server/memory-core/services/GraphService.mjs')).default;
         await GraphService.initAsync();
@@ -303,6 +312,8 @@ test.describe('ai/scripts/checkSunsetted', () => {
     });
 
     test('detector contract: subscription_status disambiguation — disabled vs degraded vs missing (#10673 AC1)', async () => {
+        test.skip(skipCiSubstrateData, 'CI-skip: substrate data not seeded - bucket C (#10903)');
+
         // The detector emits structured `subscription_status` with 4 values:
         // 'missing' (no rows) / 'active' / 'degraded' (status=degraded) / 'disabled' (harnessTarget=disabled).
         // Pre-#10673: the original query filtered out disabled+degraded, so all 3 mapped indistinguishably to "no active sub."
@@ -336,6 +347,8 @@ test.describe('ai/scripts/checkSunsetted', () => {
     });
 
     test('detector contract: in-flight sunset_restart lock downgrades sunset signal to false (#10673 AC2)', async () => {
+        test.skip(skipCiSubstrateData, 'CI-skip: substrate data not seeded - bucket C (#10903)');
+
         // When a sunset_restart is already in flight (per inflightLock.mjs), the detector
         // MUST NOT recommend another sunset_restart action. The lock is the data-layer mutex
         // that prevents the runaway-spawn pattern documented in the forensic record.
@@ -398,6 +411,8 @@ test.describe('ai/scripts/checkSunsetted', () => {
     });
 
     test('detector contract: (sunset=T, idle_out=T) is structurally impossible — invariant (#10673 AC4)', async () => {
+        test.skip(skipCiSubstrateData, 'CI-skip: substrate data not seeded - bucket C (#10903)');
+
         // The two signals are mutually exclusive by construction:
         //   - sunset=true requires subscription_active=false
         //   - idle_out_candidate=true requires subscription_active=true

--- a/test/playwright/unit/ai/scripts/resumeHarness.spec.mjs
+++ b/test/playwright/unit/ai/scripts/resumeHarness.spec.mjs
@@ -1,6 +1,7 @@
 import {setup} from '../../../setup.mjs';
 
 const appName = 'ResumeHarnessTest';
+const skipCiSubstrateData = !!process.env.NEO_TEST_SKIP_CI;
 
 setup({
     neoConfig: {
@@ -219,6 +220,7 @@ test.describe('ai/scripts/resumeHarness', () => {
 
     test('Claude CLI: adapter executes <payload> with NO session-id flag via CLAUDE_CLI_PATH (#10677)', async () => {
         test.skip(process.platform !== 'darwin', 'Claude CLI is currently mac-specific (parallel concern to #10684)');
+        test.skip(skipCiSubstrateData, 'CI-skip: substrate data not seeded - bucket C (#10903)');
 
         // Mock claude binary that records argv to a file. Substrate-truth verification: the spawner
         // MUST pass NO `--session-id` flag — fresh `claude <prompt>` invocation creates a fresh
@@ -252,6 +254,7 @@ test.describe('ai/scripts/resumeHarness', () => {
 
     test('harness lifecycle: claude-cli spawn records PID in state-file (#10696 review point 2)', async () => {
         test.skip(process.platform !== 'darwin', 'Claude CLI is currently mac-specific');
+        test.skip(skipCiSubstrateData, 'CI-skip: substrate data not seeded - bucket C (#10903)');
 
         // Verify the cross-adapter cleanup primitive: after a successful claude-cli dispatch,
         // resumeHarness records the spawned process's PID via harnessLifecycle.recordHarnessProcess.
@@ -280,6 +283,7 @@ test.describe('ai/scripts/resumeHarness', () => {
 
     test('harness lifecycle: stale dead PID in state-file is reaped before fresh spawn (#10696 review point 2)', async () => {
         test.skip(process.platform !== 'darwin', 'Claude CLI is currently mac-specific');
+        test.skip(skipCiSubstrateData, 'CI-skip: substrate data not seeded - bucket C (#10903)');
 
         // Pre-populate state file with a clearly-dead PID (well above pid_max), then run
         // resumeHarness. The cleanup primitive should detect ESRCH and proceed with fresh spawn.
@@ -314,6 +318,7 @@ test.describe('ai/scripts/resumeHarness', () => {
 
     test('Antigravity CLI: adapter executes chat -n <payload> via ANTIGRAVITY_CLI_PATH (#10680)', async () => {
         test.skip(process.platform !== 'darwin', 'Antigravity CLI is currently mac-specific (#10684)');
+        test.skip(skipCiSubstrateData, 'CI-skip: substrate data not seeded - bucket C (#10903)');
 
         // Create a mock executable to capture the command shape without launching the real IDE
         const mockPath = path.join(os.tmpdir(), `mock-ag-${randomUUID()}`);
@@ -338,6 +343,7 @@ test.describe('ai/scripts/resumeHarness', () => {
 
     test('Codex app-server: default live-host path fails closed without opt-in or mock (#10679)', async () => {
         test.skip(process.platform !== 'darwin', 'Codex Desktop app-server adapter is currently mac-specific');
+        test.skip(skipCiSubstrateData, 'CI-skip: substrate data not seeded - bucket C (#10903)');
 
         const { getLockPath } = await import('../../../../../ai/scripts/inflightLock.mjs');
         const lockPath = getLockPath('sunset_restart', '@neo-gpt');
@@ -360,6 +366,7 @@ test.describe('ai/scripts/resumeHarness', () => {
 
     test('Codex app-server: adapter executes send-message-v2 <payload> via CODEX_CLI_PATH mock (#10679)', async () => {
         test.skip(process.platform !== 'darwin', 'Codex Desktop app-server adapter is currently mac-specific');
+        test.skip(skipCiSubstrateData, 'CI-skip: substrate data not seeded - bucket C (#10903)');
 
         const mockPath = path.join(os.tmpdir(), `mock-codex-${randomUUID()}`);
         const outPath = path.join(os.tmpdir(), `out-codex-${randomUUID()}`);
@@ -389,6 +396,8 @@ test.describe('ai/scripts/resumeHarness', () => {
     });
 
     test('adapter failure (e.g. ESC-as-rejection) clears the inflight lock (#10674, #10677)', async () => {
+        test.skip(skipCiSubstrateData, 'CI-skip: substrate data not seeded - bucket C (#10903)');
+
         // Substrate-correct lock-clear-on-failure invariant. Post-#10677, claude-desktop
         // routes through the `claude-cli` adapter (no longer osascript), so we exercise
         // the failure path via a fake `claude` binary that always exits 1. The adapter


### PR DESCRIPTION
Related: #10903

Authored by GPT-5.5 (Codex Desktop) consuming Claude Opus 4.7's Bucket C handoff - session A 7e897a0b-33ce-4d6c-b1a9-a1ff93e4e571, session B 297ddedc-6d3f-4ad5-8dbf-d6d562112d06.

Adds `NEO_TEST_SKIP_CI` guards around Bucket C clean-CI-sensitive unit specs: Memory Core substrate data, wake-daemon lock/state substrate, and gh CLI diff-auth surfaces. The guards preserve local developer coverage when the env var is unset, while allowing Lane C to re-enable the unit matrix without requiring seeded `.neo-ai-data` or GitHub auth in clean CI.

Evidence: L2 (targeted unit matrix with `NEO_TEST_SKIP_CI=1` proving guarded pass/skip behavior) -> L3 required (clean GitHub Actions unit row with env wired by Lane C follow-up). Residual: Lane C workflow re-enablement [#10903].

## Deltas from ticket

This implements the operator-green-lit Bucket C skip-guard lane from A2A coordination. It intentionally uses `Related: #10903` rather than a close keyword because #10903 remains the parent audit and sibling buckets are being handled in separate PRs.

## Test Evidence

- `git diff --cached --check` passed before commit.
- `env NEO_TEST_SKIP_CI=1 npm run test-unit -- <8 affected Bucket C specs>` -> 41 passed, 44 skipped.
- `node --check` passed for all 8 modified specs.
- Local no-env comparison: `npm run test-unit -- <8 affected Bucket C specs>` executed with local substrate enabled and produced 79 passed, 2 skipped, 4 existing substrate assertion failures; the new guards did not activate without `NEO_TEST_SKIP_CI`.

## Post-Merge Validation

- [ ] Lane C follow-up sets `NEO_TEST_SKIP_CI=1` on the unit matrix row and confirms clean CI reaches the next bucket boundary.
