### PR TITLE
fix(deploy): use python3 binary in Chroma healthcheck (#10911)

### DIFF
--- a/ai/deploy/docker-compose.test.yml
+++ b/ai/deploy/docker-compose.test.yml
@@ -3,11 +3,12 @@ services:
     image: chromadb/chroma:1.5.9
     tmpfs:
       - /chroma/chroma
-    # The chromadb/chroma image is debian-slim-based and does NOT include curl.
-    # Python is the runtime (Chroma is a Python app), so use urllib for the probe.
-    # Same target endpoint, fallback-safe across all chromadb image variants. (#10908)
+    # The chromadb/chroma image is debian-slim-based (python:3.11-slim-bookworm).
+    # Slim variants ship `python3` but the `python` symlink may be absent — using
+    # `python3` is portable across all chromadb image variants. urllib is stdlib;
+    # exception from urlopen propagates and exits non-zero naturally. (#10908, #10911)
     healthcheck:
-      test: ["CMD", "python", "-c", "import urllib.request,sys; sys.exit(0 if urllib.request.urlopen('http://localhost:8000/api/v2/heartbeat',timeout=2).read() else 1)"]
+      test: ["CMD", "python3", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:8000/api/v2/heartbeat', timeout=2)"]
       interval: 5s
       timeout: 5s
       retries: 12


### PR DESCRIPTION
Resolves #10911

Authored by Claude Opus 4.7 (Claude Code). Session 7e897a0b-33ce-4d6c-b1a9-a1ff93e4e571.

Iteration on #10908/#10909. The previous fix switched curl→python urllib but used `python` (without the `3`), which doesn't resolve in chromadb's slim base image. Switches to `python3` + simplifies the expression.

Evidence: L1 (file change minimal + clear; comment explains rationale; python3 is the canonical binary in python:3.11-slim-bookworm) → L3 in-flight (Lane C #10899's integration row will pass on next rebase + CI run after this lands). No external residuals.

## Root Cause

The chromadb/chroma:1.5.9 image is `python:3.11-slim-bookworm`-based. Slim Python variants ship `python3` (and `python3.11`) but the `python` shim is often absent. The healthcheck command `python -c '...'` silently fails with exit 127 (command not found) — Docker reports unhealthy without surfacing the error in compose log, which is why this took an extra cycle to diagnose.

Operator-supplied empirical log from Lane C run 25507191916 confirms: Chroma banner appears at 16:02:02 (server running + listening), `dependency failed to start` at 16:03:02 (60s = 5s × 12 retries with no successful probe).

## Fix

```diff
-    test: ["CMD", "python", "-c", "import urllib.request,sys; sys.exit(0 if urllib.request.urlopen('http://localhost:8000/api/v2/heartbeat',timeout=2).read() else 1)"]
+    test: ["CMD", "python3", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:8000/api/v2/heartbeat', timeout=2)"]
```

Two surgical changes:
1. `python` → `python3`: addresses binary path resolution.
2. Drop `sys.exit(0 if ... else 1)` wrapper: redundant. If `urlopen` raises (HTTP error, connection refused, timeout), the exception propagates and Python exits non-zero naturally. If success, exit 0 implicitly. Same semantic, less code, debuggable.

## Avoided Traps

- **Rejected: drop healthcheck + use `service_started`.** Race condition where kb/mc start before Chroma HTTP is ready.
- **Rejected: increase `start_period`.** 60s window is plenty when the probe binary actually runs; no need to add slack.
- **Rejected: install `python` symlink in custom Dockerfile.** Adds image-build complexity for a 1-character fix.
- **Rejected: switch to bash `/dev/tcp` TCP probe.** chromadb slim image isn't guaranteed to have bash.

## Sibling Lane Impact

Same as #10909 — unblocks Lane C [#10899](https://github.com/neomjs/neo/pull/10899) integration row + future integration-test PRs. This is the **3rd** Lane-C-CI substrate-fragility discovery in this lineage:

1. [#10902](https://github.com/neomjs/neo/issues/10902) → [#10904](https://github.com/neomjs/neo/pull/10904) — Dockerfile prepare-lifecycle (`npm ci` + missing `buildScripts/`).
2. [#10908](https://github.com/neomjs/neo/issues/10908) → [#10909](https://github.com/neomjs/neo/pull/10909) — Chroma healthcheck (`curl` not in image).
3. [#10911](https://github.com/neomjs/neo/issues/10911) → this PR — Chroma healthcheck (`python` symlink absent in slim image).

Each surfaces a real config bug that local Docker layer caching had been masking. The Lane C CI workflow is performing exactly its intended diagnostic role.

## Test Evidence

L1:
- `git diff` minimal: 5 lines added (4 comment + 1 substantive), 4 lines removed.
- Empirical hypothesis grounded in operator-supplied CI log (Chroma banner present, healthcheck silent-fails after 60s — consistent with `python` not in PATH).

L3 (deferred): Lane C [#10899](https://github.com/neomjs/neo/pull/10899) integration row passes on next rebase + run.

## Post-Merge Validation

- [ ] Re-run Lane C [#10899](https://github.com/neomjs/neo/pull/10899) after this lands.
- [ ] If Chroma healthcheck STILL fails post-merge, investigate `/api/v2/heartbeat` endpoint validity on chromadb 1.5.9 (next iteration); if endpoint is wrong, switch to `chroma version` CLI probe.

## Cross-family review request

Same Authorship-respect routing as #10904 + #10909: **@neo-gemini-3-1-pro** as primary reviewer (her `ai/deploy/` substrate from #10880).

Origin Session ID: `7e897a0b-33ce-4d6c-b1a9-a1ff93e4e571`