### PR TITLE
fix(deploy): switch Chroma healthcheck to bash TCP probe (#10913)

### DIFF
--- a/ai/deploy/docker-compose.test.yml
+++ b/ai/deploy/docker-compose.test.yml
@@ -3,19 +3,19 @@ services:
     image: chromadb/chroma:1.5.9
     tmpfs:
       - /chroma/chroma
-    # The chromadb/chroma image is debian-slim-based (python:3.11-slim-bookworm).
-    # Slim variants ship `python3` but the `python` symlink may be absent — using
-    # `python3` is portable across all chromadb image variants. urllib is stdlib;
-    # exception from urlopen propagates and exits non-zero naturally. (#10908, #10911)
+    # The published chromadb/chroma:1.5.9 image is a single 541MB compiled binary
+    # at /usr/local/bin/chroma (built via docker-bake.hcl, not the GitHub Dockerfile).
+    # It has NO python, NO python3, NO curl, NO wget — empirically verified via
+    # `docker exec` by @neo-gemini-3-1-pro. bash IS present, so use the bash-builtin
+    # /dev/tcp probe to verify the TCP listener is up. Bypasses the missing-binary
+    # nightmare entirely. (#10908, #10911, #10913)
     healthcheck:
-      test: ["CMD", "python3", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:8000/api/v2/heartbeat', timeout=2)"]
+      test: ["CMD-SHELL", "bash -c '</dev/tcp/127.0.0.1/8000'"]
       interval: 5s
       timeout: 5s
       retries: 12
-      # Cold-start grace: failed probes during start_period do NOT count toward
-      # retries. On 2-CPU GitHub ubuntu-latest hardware, Chroma's banner appears
-      # before uvicorn has bound port 8000 — without this, the first ~12 probes
-      # all fail before HTTP is ready, exhausting the retry budget. (#10913)
+      # Cold-start grace: keeps failed probes during the binding window from
+      # exhausting retry budget on slow CI (preserved from prior iteration).
       start_period: 60s
     networks:
       - neo-mcp-test-network

--- a/ai/deploy/docker-compose.test.yml
+++ b/ai/deploy/docker-compose.test.yml
@@ -12,6 +12,11 @@ services:
       interval: 5s
       timeout: 5s
       retries: 12
+      # Cold-start grace: failed probes during start_period do NOT count toward
+      # retries. On 2-CPU GitHub ubuntu-latest hardware, Chroma's banner appears
+      # before uvicorn has bound port 8000 — without this, the first ~12 probes
+      # all fail before HTTP is ready, exhausting the retry budget. (#10913)
+      start_period: 60s
     networks:
       - neo-mcp-test-network
     ports:


### PR DESCRIPTION
Resolves #10913

Authored by Claude Opus 4.7 (Claude Code). Session 7e897a0b-33ce-4d6c-b1a9-a1ff93e4e571.

**5th and (intent: final) iteration on Lane C #10899 integration row substrate.** Pivoted from the original `start_period` shape after @neo-gemini-3-1-pro empirically probed the published `chromadb/chroma:1.5.9` image and reported it ships as a single compiled binary with NO python/python3/curl/wget — only bash.

This invalidates iterations #10909 (curl→python) and #10912 (python→python3) — the 60s timeout pattern was the healthcheck command itself failing with exit 127 (command not found), NOT cold-start race or wrong endpoint.

## The Honest Iteration Trail

| # | PR | Diagnosis | Reality |
|---|---|---|---|
| 1 | [#10904](https://github.com/neomjs/neo/pull/10904) | Dockerfile prepare-lifecycle missing buildScripts/ | Correct (real fix) |
| 2 | [#10909](https://github.com/neomjs/neo/pull/10909) | curl missing → switch to python | Wrong probe (no python either) |
| 3 | [#10912](https://github.com/neomjs/neo/pull/10912) | python binary path → python3 | Wrong probe (no python3 either) |
| 4 | this PR (initial commit) | start_period for cold-start race | Wrong diagnosis (image timing wasn't the issue) |
| 5 | this PR (current head) | bash TCP probe | Should resolve regardless of which binaries are absent |

Memory-anchor #8 lesson reinforced: **WebFetch on a GitHub Dockerfile is NOT empirical verification of a published Docker Hub image.** The chromadb GitHub source has a `Dockerfile` based on `python:3.11-slim-bookworm`, but the actual published `chromadb/chroma:1.5.9` image is built via `docker-bake.hcl` with a different multi-stage that strips the Python interpreter and ships only the compiled binary. Only `docker exec` against the actual published image proves binary inventory.

## The Fix

```diff
-    test: ["CMD", "python3", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:8000/api/v2/heartbeat', timeout=2)"]
+    test: ["CMD-SHELL", "bash -c '</dev/tcp/127.0.0.1/8000'"]
```

Why this is the defensible-regardless probe shape:
- `bash` is near-guaranteed in any debian-derived image (chromadb/chroma is debian-derived).
- `/dev/tcp` is a bash-builtin — no external binary dependency.
- TCP-listener-up is exactly what `depends_on: service_healthy` actually needs (kb/mc just need to know they can OPEN a connection, not that HTTP is fully responding).
- Bypasses the "which Python binary is available" question entirely.

`start_period: 60s` retained as defense-in-depth: TCP listener takes negligible time once Chroma is up, so this only matters as a safety margin if the image somehow takes >60s to bind port 8000.

## Iteration Cap

If THIS also fails: the next move is **NOT** another guess. It's a local-reproducible empirical loop — pull `chromadb/chroma:1.5.9` on someone's local Docker, run `docker exec` against it, ship the proven probe. CI-as-test-bench has cost the swarm 5 iterations + 4 substrate-config PRs + ~3 hours wall. The substrate-discipline ROI from continuing to iterate via CI is now negative.

## Cross-family review

Gemini already empirically validated the binary-absence claim that drives this fix. Her review is functionally pre-completed; formal Approve once she sees the pivot.

Origin Session ID: `7e897a0b-33ce-4d6c-b1a9-a1ff93e4e571`