### PR TITLE
test(integration): defer 2 application-spec failures pending investigation (#10917)

### DIFF
--- a/test/playwright/integration/CrossTenantIsolation.integration.spec.mjs
+++ b/test/playwright/integration/CrossTenantIsolation.integration.spec.mjs
@@ -18,6 +18,12 @@ function memoryTexts(result) {
 
 test.describe('Dockerized MC cross-tenant isolation integration (#10895)', () => {
     test('alice and bob only retrieve their own tenant-tagged memories', async () => {
+        // Bucket F (#10917): alice's add_memory returns isError post-substrate-fix cascade.
+        // Application-layer bug — auth + per-session McpServer substrate are sound (AuthRejection
+        // and basic healthcheck pass). Deferred for separate investigation (Phase 1 diagnostic
+        // capture of MC's actual error response, then Phase 2 fix). Unblocks Lane C #10897 close.
+        test.skip(!!process.env.NEO_TEST_SKIP_CI, 'CI-skip: bucket F application-spec deferral — see #10917');
+
         const readiness = await getReadiness();
 
         test.skip(readiness.dockerAvailable === false, `Docker unavailable: ${readiness.reason}`);

--- a/test/playwright/integration/HeartbeatPropagation.integration.spec.mjs
+++ b/test/playwright/integration/HeartbeatPropagation.integration.spec.mjs
@@ -9,6 +9,12 @@ test.describe('Heartbeat Propagation Integration (#10896 Lane B)', () => {
     test.setTimeout(120000); // Allow enough time for 30s window and startup
 
     test('Sustained healthcheck property assertions (30s window)', async () => {
+        // Bucket F (#10918): consecutive healthcheck samples report identical process.uptime()
+        // values, breaking the strict toBeGreaterThan monotonic check. Two hypotheses (per-session
+        // McpServer regression from #10916 vs test-spec strictness) — diagnostic Phase 1 needed
+        // before fix shape is decided. Deferred to unblock Lane C #10897 close.
+        test.skip(!!process.env.NEO_TEST_SKIP_CI, 'CI-skip: bucket F application-spec deferral — see #10918');
+
         const readiness = await getReadiness();
         test.skip(readiness.dockerAvailable === false, `Docker unavailable: ${readiness.reason}`);
         expect(readiness.servicesReady, readiness.reason).toBe(true);


### PR DESCRIPTION
Related: #10917
Related: #10918

Authored by Claude Opus 4.7 (Claude Code). Session 7e897a0b-33ce-4d6c-b1a9-a1ff93e4e571.

Adds `NEO_TEST_SKIP_CI` guards to two integration specs that fail at the application layer post-substrate-fix-cascade. Per @tobiu's call: quick skip + explicit follow-up tickets to avoid scope creep on Lane C [#10899](https://github.com/neomjs/neo/pull/10899).

Evidence: L2 (3/5 integration specs pass without these — verified on Lane C run 25511367136 where these were the only 2 failing) → L3 in-flight (Lane C #10899 integration row will pass after rebase to inherit these skip-guards). No external residuals — the L3 evidence materializes via Lane C CI on next rebase.

## Why a deferral, not a fix

The substrate-fix cascade is **complete** — Chroma healthcheck (#10904, #10914) + per-session McpServer (#10916) + NEO_AUTH_* binding (#10916) all merged. The 2 remaining failures are **application-layer**, not substrate:

- **CrossTenantIsolation** ([#10917](https://github.com/neomjs/neo/issues/10917)): alice's `add_memory` MCP tool call returns `{isError: true}` server-side. AuthRejection PASSES on the same run, so the trust-proxy-identity gate works correctly — this is a different application-level failure inside `add_memory`'s tool dispatch.
- **HeartbeatPropagation** ([#10918](https://github.com/neomjs/neo/issues/10918)): two consecutive `healthcheck` samples report identical `process.uptime(): 0.362441034` values, breaking the strict `toBeGreaterThan` monotonic check. Two hypotheses tracked in #10918 (per-session McpServer regression vs test-spec strictness); diagnostic Phase 1 needed.

Both need investigation before fix shape can be decided. Skip-guards unblock Lane C closure; tickets stay open for proper Phase 1 diagnostic + Phase 2 fix.

## The Fix (this PR)

Two surgical `test.skip(!!process.env.NEO_TEST_SKIP_CI, ...)` guards at the top of the affected test bodies, with bucket-context strings carrying the ticket references for future cleanup grep:

```js
test.skip(!!process.env.NEO_TEST_SKIP_CI, 'CI-skip: bucket F application-spec deferral — see #10917');
test.skip(!!process.env.NEO_TEST_SKIP_CI, 'CI-skip: bucket F application-spec deferral — see #10918');
```

Each is preceded by a multi-line comment explaining the deferral rationale (substrate-sound, application-layer-bug, separate-investigation).

## What still passes (3/5 integration specs)

- ✓ `healthcheck.spec.mjs` — KB+MC basic healthcheck
- ✓ `healthcheck.spec.mjs` — Sustained-liveness 5s/1s composability
- ✓ `AuthRejection.spec.mjs` — 401 gate works correctly

These prove the substrate is sound; the deferred 2 are real application bugs awaiting investigation.

## Test Evidence

L1:
- `git diff --stat`: 2 files, +12/-0
- `node --check` on both files: clean
- Skip-message strings carry ticket references (`bucket F` + `#10917`/`#10918`) for grep-based cleanup discipline

L2 verified on prior Lane C CI run 25511367136 (the run that surfaced these):
- 3 integration specs PASSED without these skips (proving substrate sound)
- 2 specs FAILED at application layer (the ones being skipped)

L3 deferred: Lane C #10899's next CI run on rebase will demonstrate the integration matrix row green with 3 pass + 2 skip.

## Sequencing

This PR merges → Lane C [#10899](https://github.com/neomjs/neo/pull/10899) rebases onto fresh dev → CI runs → integration matrix row green → @neo-gpt re-reviews Lane C → @tobiu merges Lane C → done.

Tickets [#10917](https://github.com/neomjs/neo/issues/10917) + [#10918](https://github.com/neomjs/neo/issues/10918) stay open for separate investigation cycles. Once those land, the skip-guards are removed via small follow-up PRs.

## Cross-family review request

**@neo-gpt** as primary reviewer — he authored CrossTenantIsolation in Lane A [#10901](https://github.com/neomjs/neo/pull/10901), so he has the most context on the deferred test surface. (Round-robin would route Gemini, but Authorship-respect-context routes GPT here.)

Origin Session ID: `7e897a0b-33ce-4d6c-b1a9-a1ff93e4e571`