### PR TITLE
test(ci): add bucket B+D clean-ci skip guards (#10903)

### DIFF
--- a/test/playwright/unit/ai/mcp/client/McpServersHealth.spec.mjs
+++ b/test/playwright/unit/ai/mcp/client/McpServersHealth.spec.mjs
@@ -25,6 +25,8 @@ const SERVERS = [
 ];
 
 test.describe('Neo.ai.mcp.client.Client MCP Servers Health', () => {
+    test.skip(!!process.env.NEO_TEST_SKIP_CI, 'bucket D: MCP server bootstrap requires env vars/substrate');
+
     // 60 seconds timeout per test to allow server spawn, initialize, and healthcheck (especially if downloading DB or something)
     test.setTimeout(60000);
 

--- a/test/playwright/unit/ai/mcp/client/McpServersIsolation.spec.mjs
+++ b/test/playwright/unit/ai/mcp/client/McpServersIsolation.spec.mjs
@@ -28,6 +28,8 @@ const targetSpecPath = path.resolve(__dirname, '../../../../../../ai/mcp/server/
 const backupSpecPath = path.resolve(__dirname, '../../../../../../ai/mcp/server/knowledge-base/openapi.yaml.bak');
 
 test.describe('Neo.ai.mcp.client.Client Server Isolation', () => {
+    test.skip(!!process.env.NEO_TEST_SKIP_CI, 'bucket D: MCP server bootstrap requires env vars/substrate');
+
     test.setTimeout(60000);
 
     let malformedPath;

--- a/test/playwright/unit/grid/LockedColumns.spec.mjs
+++ b/test/playwright/unit/grid/LockedColumns.spec.mjs
@@ -41,6 +41,8 @@ import VdomHelper         from '../../../../src/vdom/Helper.mjs';
 import DomApiVnodeCreator from '../../../../src/vdom/util/DomApiVnodeCreator.mjs';
 
 test.describe('Grid Locked Columns', () => {
+    test.skip(!!process.env.NEO_TEST_SKIP_CI, 'bucket B: Grid tests require Playwright browsers in CI');
+
     let grid, store;
 
     test.beforeEach(async () => {

--- a/test/playwright/unit/grid/Pooling.spec.mjs
+++ b/test/playwright/unit/grid/Pooling.spec.mjs
@@ -40,6 +40,8 @@ import Store              from '../../../../src/data/Store.mjs';
 import VdomHelper         from '../../../../src/vdom/Helper.mjs';
 
 test.describe('Grid Pooling & Fixed-DOM-Order', () => {
+    test.skip(!!process.env.NEO_TEST_SKIP_CI, 'bucket B: Grid tests require Playwright browsers in CI');
+
     let grid, store;
 
     // Helper to capture deltas during an operation

--- a/test/playwright/unit/grid/Teleportation.spec.mjs
+++ b/test/playwright/unit/grid/Teleportation.spec.mjs
@@ -24,6 +24,8 @@ import Store              from '../../../../src/data/Store.mjs';
 import VdomHelper         from '../../../../src/vdom/Helper.mjs';
 
 test.describe('Grid Teleportation & VDOM Deltas', () => {
+    test.skip(!!process.env.NEO_TEST_SKIP_CI, 'bucket B: Grid tests require Playwright browsers in CI');
+
     let grid, store;
 
     test.beforeEach(async () => {


### PR DESCRIPTION
Authored by Gemini-3.1-Pro (Antigravity). Session 0318c07d-eb0c-4ef9-9c7a-896dc52e9a14.

Resolves #10903

This PR implements the `NEO_TEST_SKIP_CI` skip-guards for Bucket B (Playwright Grid tests) and Bucket D (MCP server bootstrapping) to allow local test progression without breaking Lane C matrix runs in clean CI environments lacking required substrates.

## Test Evidence
- Skip guards applied using `test.skip(!!process.env.NEO_TEST_SKIP_CI, ...)` rather than unconditional skips to preserve local validity.
