### PR TITLE
fix(mcp): migrate CoalescingEngine tests to multi-server API (#10923)

### DIFF
--- a/ai/mcp/server/memory-core/services/CoalescingEngineService.mjs
+++ b/ai/mcp/server/memory-core/services/CoalescingEngineService.mjs
@@ -102,6 +102,13 @@ class CoalescingEngineService extends Base {
     }
 
     /**
+     * @summary Clears all registered MCP server instances.
+     */
+    clearMcpServers() {
+        this.mcpServers.clear();
+    }
+
+    /**
      * Enqueue an event for coalesced delivery to a subscription. Starts (or extends)
      * the per-subscription timer; on fire, the engine builds a digest and dispatches.
      *

--- a/test/playwright/unit/ai/mcp/server/memory-core/services/CoalescingEngineService.spec.mjs
+++ b/test/playwright/unit/ai/mcp/server/memory-core/services/CoalescingEngineService.spec.mjs
@@ -172,7 +172,7 @@ test.describe('CoalescingEngineService', () => {
 
     test('dispatches mcp-notifications subscriptions via mcpServer.notification', async () => {
         let notificationCalledWith = null;
-        CoalescingEngineService.setMcpServer({
+        CoalescingEngineService.addMcpServer({
             notification: async (args) => {
                 notificationCalledWith = args;
             }
@@ -189,7 +189,7 @@ test.describe('CoalescingEngineService', () => {
         expect(notificationCalledWith.params.payload.messageId).toBe('M1');
 
         // cleanup
-        CoalescingEngineService.setMcpServer(null);
+        CoalescingEngineService.clearMcpServers();
     });
 
     test('does NOT dispatch bridge-daemon subscriptions (Shape C handles its own coalescing)', async () => {

--- a/test/playwright/unit/ai/mcp/server/memory-core/services/WakeSubscriptionService.spec.mjs
+++ b/test/playwright/unit/ai/mcp/server/memory-core/services/WakeSubscriptionService.spec.mjs
@@ -741,7 +741,7 @@ test.describe('Neo.ai.mcp.server.memory-core.services.WakeSubscriptionService', 
 
         test.beforeEach(async () => {
             emittedEvents = [];
-            CoalescingEngineService.setMcpServer(null);
+            CoalescingEngineService.clearMcpServers();
             CoalescingEngineService.clearAll();
         });
 
@@ -761,7 +761,7 @@ test.describe('Neo.ai.mcp.server.memory-core.services.WakeSubscriptionService', 
         });
 
         test('emits raw event for matching mcp-notifications subscription (bypass coalescing) after pump', async () => {
-            CoalescingEngineService.setMcpServer(mockMcpServer);
+            CoalescingEngineService.addMcpServer(mockMcpServer);
 
             await RequestContextService.run({agentIdentityNodeId: '@alice'}, async () => {
                 // mcp-notifications bypasses coalescing window and pushes immediately
@@ -793,7 +793,7 @@ test.describe('Neo.ai.mcp.server.memory-core.services.WakeSubscriptionService', 
         });
 
         test('does not emit SENT_TO_ME wake for wakeSuppressed mailbox-only messages', async () => {
-            CoalescingEngineService.setMcpServer(mockMcpServer);
+            CoalescingEngineService.addMcpServer(mockMcpServer);
 
             await RequestContextService.run({agentIdentityNodeId: '@alice'}, async () => {
                 await WakeSubscriptionService.subscribe({
@@ -824,7 +824,7 @@ test.describe('Neo.ai.mcp.server.memory-core.services.WakeSubscriptionService', 
         });
 
         test('does not emit for non-matching subscription', async () => {
-            CoalescingEngineService.setMcpServer(mockMcpServer);
+            CoalescingEngineService.addMcpServer(mockMcpServer);
 
             await RequestContextService.run({agentIdentityNodeId: '@alice'}, async () => {
                 await WakeSubscriptionService.subscribe({
@@ -844,7 +844,7 @@ test.describe('Neo.ai.mcp.server.memory-core.services.WakeSubscriptionService', 
         });
 
         test('advances liveCursor per delta.lastLogId', async () => {
-            CoalescingEngineService.setMcpServer(mockMcpServer);
+            CoalescingEngineService.addMcpServer(mockMcpServer);
             const initialCursor = WakeSubscriptionService.liveCursor;
 
             GraphService.upsertNode({id: 'MSG:4', type: 'MESSAGE', properties: {}});
@@ -854,7 +854,7 @@ test.describe('Neo.ai.mcp.server.memory-core.services.WakeSubscriptionService', 
         });
 
         test('warms cache with active mcp-notifications subscriptions on first call', async () => {
-            CoalescingEngineService.setMcpServer(mockMcpServer);
+            CoalescingEngineService.addMcpServer(mockMcpServer);
 
             let subId;
             await RequestContextService.run({agentIdentityNodeId: '@alice'}, async () => {
@@ -878,7 +878,7 @@ test.describe('Neo.ai.mcp.server.memory-core.services.WakeSubscriptionService', 
         });
 
         test('skips bridge-daemon / a2a-webhook / disabled targets', async () => {
-            CoalescingEngineService.setMcpServer(mockMcpServer);
+            CoalescingEngineService.addMcpServer(mockMcpServer);
 
             await RequestContextService.run({agentIdentityNodeId: '@alice'}, async () => {
                 await WakeSubscriptionService.subscribe({
@@ -900,7 +900,7 @@ test.describe('Neo.ai.mcp.server.memory-core.services.WakeSubscriptionService', 
         });
 
         test('concurrent pump() invocations do not double-emit', async () => {
-            CoalescingEngineService.setMcpServer(mockMcpServer);
+            CoalescingEngineService.addMcpServer(mockMcpServer);
 
             await RequestContextService.run({agentIdentityNodeId: '@alice'}, async () => {
                 await WakeSubscriptionService.subscribe({trigger: 'SENT_TO_ME', harnessTarget: 'mcp-notifications'});


### PR DESCRIPTION
Authored by Gemini 3.1 Pro (Antigravity). Session 0318c07d-eb0c-4ef9-9c7a-896dc52e9a14.

Resolves #10923

Mechanically migrated test call sites from `setMcpServer` to the new `addMcpServer` and `clearMcpServers` primitives as mandated by the multi-server design shift, resolving the CI regression from #10916. Also implemented the missing `clearMcpServers` method on `CoalescingEngineService` to complete the required API surface.

Evidence: L1 (static unit test pass locally) → L1 required. No residuals.

## Deltas from ticket (if any)
Added `clearMcpServers` to `CoalescingEngineService` which was missing but implicitly required by the refactor to properly clear state between tests.

## Test Evidence
Ran `npx playwright test test/playwright/unit/ai/mcp/server/memory-core/services/CoalescingEngineService.spec.mjs test/playwright/unit/ai/mcp/server/memory-core/services/WakeSubscriptionService.spec.mjs`. All 53 tests passed locally.
