### PR TITLE
feat(test): surface cross-tenant diagnostics (#10917)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -60,6 +60,9 @@ jobs:
           # Test specs check `process.env.NEO_TEST_SKIP_CI` and skip cleanly.
           # See #10903 (unit-suite buckets A-E) + #10917/#10918 (bucket F).
           NEO_TEST_SKIP_CI: 'true'
+          # PR-local diagnostic for #10917: bypass only the CrossTenantIsolation
+          # skip so CI captures alice add_memory's tool-level error payload.
+          NEO_TEST_DIAGNOSE_10917: 'true'
 
       - name: Upload test artifacts on failure
         if: failure()

--- a/test/playwright/integration/CrossTenantIsolation.integration.spec.mjs
+++ b/test/playwright/integration/CrossTenantIsolation.integration.spec.mjs
@@ -22,7 +22,12 @@ test.describe('Dockerized MC cross-tenant isolation integration (#10895)', () =>
         // Application-layer bug — auth + per-session McpServer substrate are sound (AuthRejection
         // and basic healthcheck pass). Deferred for separate investigation (Phase 1 diagnostic
         // capture of MC's actual error response, then Phase 2 fix). Unblocks Lane C #10897 close.
-        test.skip(!!process.env.NEO_TEST_SKIP_CI, 'CI-skip: bucket F application-spec deferral — see #10917');
+        const diagnose10917 = process.env.NEO_TEST_DIAGNOSE_10917 === 'true';
+
+        test.skip(
+            !!process.env.NEO_TEST_SKIP_CI && !diagnose10917,
+            'CI-skip: bucket F application-spec deferral — see #10917'
+        );
 
         const readiness = await getReadiness();
 

--- a/test/playwright/integration/fixtures/mcpClient.mjs
+++ b/test/playwright/integration/fixtures/mcpClient.mjs
@@ -65,6 +65,42 @@ export function readToolJson(result, label = 'MCP tool') {
 }
 
 /**
+ * @summary Formats diagnostic JSON for MCP assertion messages.
+ * Formats diagnostic JSON for MCP assertion messages.
+ * @param {*} value The value to serialize.
+ * @returns {String} Pretty-printed JSON, or an unserializable-value marker.
+ */
+function formatDiagnosticJson(value) {
+    try {
+        return JSON.stringify(value, null, 2);
+    } catch (error) {
+        return `[unserializable value: ${error.message}]`;
+    }
+}
+
+/**
+ * @summary Builds an assertion message for MCP tool-level errors.
+ * Builds an assertion message for MCP tool-level errors.
+ * @param {String} name   The tool name.
+ * @param {Object} result The MCP SDK tool result.
+ * @param {Object} args   The tool arguments.
+ * @returns {String} The formatted assertion message.
+ */
+function buildToolErrorMessage(name, result, args) {
+    const textContent = result.content
+        ?.filter(item => item.type === 'text')
+        .map(item => item.text)
+        .join('\n') || '<no text content>';
+
+    return [
+        `MCP tool ${name} should not return isError`,
+        `content:\n${textContent}`,
+        `structuredContent:\n${formatDiagnosticJson(result.structuredContent || null)}`,
+        `arguments:\n${formatDiagnosticJson(args)}`
+    ].join('\n\n');
+}
+
+/**
  * @summary Calls an MCP tool and returns its JSON payload.
  * Calls an MCP tool and returns its JSON payload.
  * @param {Client} client The connected MCP client.
@@ -75,7 +111,7 @@ export function readToolJson(result, label = 'MCP tool') {
 export async function callJsonTool(client, name, args = {}) {
     const result = await client.callTool({name, arguments: args});
 
-    expect(result.isError).not.toBe(true);
+    expect(result.isError, buildToolErrorMessage(name, result, args)).not.toBe(true);
 
     return readToolJson(result, `MCP tool ${name}`);
 }


### PR DESCRIPTION
Authored by GPT-5.5 (Codex Desktop). Session 7b756e68-1916-4cdb-af4a-f77074edf036.

Related #10917

This is a draft Phase 1 diagnostic PR, not the final fix. It makes MCP integration failures print the tool `content`, `structuredContent`, and call arguments, then bypasses only the CrossTenantIsolation skip under a #10917 diagnostic env so CI can expose alice `add_memory`'s tool-level error payload.

Evidence: L1 (git diff --check + node --check on changed integration files) -> L3 required (GitHub integration CI captures the failing Dockerized MC payload). Residual: collect the PR CI failure payload, then land the Phase 2 fix and remove the diagnostic skip bypass.

## Test Evidence
- `git diff --check`
- `node --check test/playwright/integration/fixtures/mcpClient.mjs`
- `node --check test/playwright/integration/CrossTenantIsolation.integration.spec.mjs`

## Notes
- Local Docker validation is unavailable in this Codex environment (`docker: command not found`).
- No runtime MCP server code is changed.
- This PR intentionally does not use a close keyword because #10917 requires the Phase 2 fix after diagnostics.

## Post-Merge Validation
- [ ] Do not merge this diagnostic-only state as-is; replace it with the Phase 2 fix or close after extracting the CI payload.