### PR TITLE
fix(test): provision integration embeddings (#10917)

### DIFF
--- a/ai/deploy/docker-compose.test.yml
+++ b/ai/deploy/docker-compose.test.yml
@@ -22,6 +22,26 @@ services:
     ports:
       - "18080:8000"
 
+  # #10917: CI has no local Ollama/OpenAI-compatible daemon. Keep the Memory
+  # Core integration stack on its real HTTP embedding path by providing a tiny
+  # deterministic OpenAI-compatible endpoint inside the compose network.
+  embedding-server:
+    image: node:22-bookworm-slim
+    working_dir: /app
+    command: ["node", "ai/deploy/mock-openai-embedding-server.mjs"]
+    environment:
+      - NEO_TEST_EMBEDDING_DIMENSIONS=4096
+      - NEO_TEST_EMBEDDING_MODEL=text-embedding-qwen3-embedding-8b
+    volumes:
+      - ../..:/app:ro
+    healthcheck:
+      test: ["CMD", "node", "-e", "fetch('http://127.0.0.1:11434/health').then(r => process.exit(r.ok ? 0 : 1)).catch(() => process.exit(1))"]
+      interval: 5s
+      timeout: 5s
+      retries: 12
+    networks:
+      - neo-mcp-test-network
+
   kb-server:
     build:
       context: ../..
@@ -73,11 +93,15 @@ services:
       - NEO_MEMORY_DB_PATH=/tmp/neo-integration/memory-core-graph.sqlite
       - NEO_MODEL_PROVIDER=openAiCompatible
       - NEO_EMBEDDING_PROVIDER=openAiCompatible
+      - NEO_OPENAI_COMPATIBLE_HOST=http://embedding-server:11434
+      - NEO_OPENAI_COMPATIBLE_EMBEDDING_MODEL=text-embedding-qwen3-embedding-8b
       - NEO_OPENAI_COMPATIBLE_API_KEY=test-integration-key
     tmpfs:
       - /tmp/neo-integration
     depends_on:
       chroma:
+        condition: service_healthy
+      embedding-server:
         condition: service_healthy
     networks:
       - neo-mcp-test-network

--- a/ai/deploy/mock-openai-embedding-server.mjs
+++ b/ai/deploy/mock-openai-embedding-server.mjs
@@ -1,0 +1,95 @@
+import crypto from 'node:crypto';
+import http   from 'node:http';
+
+const host       = process.env.NEO_TEST_EMBEDDING_HOST || '0.0.0.0';
+const port       = Number(process.env.NEO_TEST_EMBEDDING_PORT || 11434);
+const dimensions = Number(process.env.NEO_TEST_EMBEDDING_DIMENSIONS || 4096);
+const modelName  = process.env.NEO_TEST_EMBEDDING_MODEL || 'text-embedding-qwen3-embedding-8b';
+
+/**
+ * @summary Reads a JSON request body.
+ * Reads a JSON request body.
+ * @param {http.IncomingMessage} request The incoming HTTP request.
+ * @returns {Promise<Object>} The parsed JSON payload.
+ */
+function readJson(request) {
+    return new Promise((resolve, reject) => {
+        let body = '';
+
+        request.on('data', chunk => body += chunk);
+        request.on('error', reject);
+        request.on('end', () => {
+            try {
+                resolve(body ? JSON.parse(body) : {});
+            } catch (error) {
+                reject(error);
+            }
+        });
+    });
+}
+
+/**
+ * @summary Sends a JSON response.
+ * Sends a JSON response.
+ * @param {http.ServerResponse} response The outgoing HTTP response.
+ * @param {Number} statusCode The HTTP status code.
+ * @param {Object} payload The JSON payload.
+ * @returns {void}
+ */
+function sendJson(response, statusCode, payload) {
+    response.writeHead(statusCode, {'content-type': 'application/json'});
+    response.end(JSON.stringify(payload));
+}
+
+/**
+ * @summary Builds a deterministic embedding vector for integration tests.
+ * Builds a deterministic embedding vector for integration tests.
+ * @param {String} text The input text.
+ * @returns {Number[]} A vector matching the configured embedding dimensions.
+ */
+function buildEmbedding(text) {
+    const digest = crypto.createHash('sha256').update(String(text)).digest();
+
+    return Array.from({length: dimensions}, (_, index) => {
+        const byte = digest[index % digest.length];
+
+        return Number((((byte / 255) * 2 - 1) / Math.sqrt(dimensions)).toFixed(8));
+    });
+}
+
+const server = http.createServer(async (request, response) => {
+    if (request.method === 'GET' && request.url === '/health') {
+        sendJson(response, 200, {status: 'ok', dimensions, model: modelName});
+        return;
+    }
+
+    if (request.method !== 'POST' || request.url !== '/v1/embeddings') {
+        sendJson(response, 404, {error: 'Not found'});
+        return;
+    }
+
+    try {
+        const payload = await readJson(request);
+        const inputs  = Array.isArray(payload.input) ? payload.input : [payload.input ?? ''];
+
+        sendJson(response, 200, {
+            object: 'list',
+            model : payload.model || modelName,
+            data  : inputs.map((input, index) => ({
+                object   : 'embedding',
+                index,
+                embedding: buildEmbedding(input)
+            })),
+            usage : {
+                prompt_tokens: 0,
+                total_tokens : 0
+            }
+        });
+    } catch (error) {
+        sendJson(response, 400, {error: error.message});
+    }
+});
+
+server.listen(port, host, () => {
+    console.log(`[mock-openai-embedding-server] listening on ${host}:${port}`);
+});

--- a/test/playwright/integration/CrossTenantIsolation.integration.spec.mjs
+++ b/test/playwright/integration/CrossTenantIsolation.integration.spec.mjs
@@ -18,12 +18,6 @@ function memoryTexts(result) {
 
 test.describe('Dockerized MC cross-tenant isolation integration (#10895)', () => {
     test('alice and bob only retrieve their own tenant-tagged memories', async () => {
-        // Bucket F (#10917): alice's add_memory returns isError post-substrate-fix cascade.
-        // Application-layer bug — auth + per-session McpServer substrate are sound (AuthRejection
-        // and basic healthcheck pass). Deferred for separate investigation (Phase 1 diagnostic
-        // capture of MC's actual error response, then Phase 2 fix). Unblocks Lane C #10897 close.
-        test.skip(!!process.env.NEO_TEST_SKIP_CI, 'CI-skip: bucket F application-spec deferral — see #10917');
-
         const readiness = await getReadiness();
 
         test.skip(readiness.dockerAvailable === false, `Docker unavailable: ${readiness.reason}`);

--- a/test/playwright/integration/fixtures/mcpClient.mjs
+++ b/test/playwright/integration/fixtures/mcpClient.mjs
@@ -65,6 +65,42 @@ export function readToolJson(result, label = 'MCP tool') {
 }
 
 /**
+ * @summary Formats diagnostic JSON for MCP assertion messages.
+ * Formats diagnostic JSON for MCP assertion messages.
+ * @param {*} value The value to serialize.
+ * @returns {String} Pretty-printed JSON, or an unserializable-value marker.
+ */
+function formatDiagnosticJson(value) {
+    try {
+        return JSON.stringify(value, null, 2);
+    } catch (error) {
+        return `[unserializable value: ${error.message}]`;
+    }
+}
+
+/**
+ * @summary Builds an assertion message for MCP tool-level errors.
+ * Builds an assertion message for MCP tool-level errors.
+ * @param {String} name   The tool name.
+ * @param {Object} result The MCP SDK tool result.
+ * @param {Object} args   The tool arguments.
+ * @returns {String} The formatted assertion message.
+ */
+function buildToolErrorMessage(name, result, args) {
+    const textContent = result.content
+        ?.filter(item => item.type === 'text')
+        .map(item => item.text)
+        .join('\n') || '<no text content>';
+
+    return [
+        `MCP tool ${name} should not return isError`,
+        `content:\n${textContent}`,
+        `structuredContent:\n${formatDiagnosticJson(result.structuredContent || null)}`,
+        `arguments:\n${formatDiagnosticJson(args)}`
+    ].join('\n\n');
+}
+
+/**
  * @summary Calls an MCP tool and returns its JSON payload.
  * Calls an MCP tool and returns its JSON payload.
  * @param {Client} client The connected MCP client.
@@ -75,7 +111,7 @@ export function readToolJson(result, label = 'MCP tool') {
 export async function callJsonTool(client, name, args = {}) {
     const result = await client.callTool({name, arguments: args});
 
-    expect(result.isError).not.toBe(true);
+    expect(result.isError, buildToolErrorMessage(name, result, args)).not.toBe(true);
 
     return readToolJson(result, `MCP tool ${name}`);
 }


### PR DESCRIPTION
Authored by GPT-5.5 (Codex Desktop). Session 7b756e68-1916-4cdb-af4a-f77074edf036.

Resolves #10917

PR #10926 completed Phase 1 and exposed the real failure payload: `Tool Error: Failed to add memory. Message: connect ECONNREFUSED 127.0.0.1:11434`. This PR fixes that root cause by adding a deterministic OpenAI-compatible embedding endpoint to the integration compose stack, wiring Memory Core to it, removing the CrossTenantIsolation CI skip, and keeping richer MCP tool-error assertion output for future failures.

Evidence: L3 achieved (GitHub Dockerized integration CI passed with CrossTenantIsolation unskipped) -> L3 required. No residuals.

## Deltas from ticket
- Phase 1 diagnostic PR #10926 was closed after extracting the payload.
- Phase 2 fix keeps the real `openAiCompatible` HTTP embedding path instead of adding a runtime test-only provider.

## Test Evidence
- `git diff --cached --check`
- `git diff --check origin/dev...HEAD`
- `node --check ai/deploy/mock-openai-embedding-server.mjs`
- `node --check test/playwright/integration/fixtures/mcpClient.mjs`
- `node --check test/playwright/integration/CrossTenantIsolation.integration.spec.mjs`
- `node --input-type=module -e "import fs from 'node:fs'; import yaml from 'js-yaml'; yaml.load(fs.readFileSync('ai/deploy/docker-compose.test.yml', 'utf8')); console.log('yaml ok');"`
- Local mock endpoint smoke: `200 2 4096 1` for `/v1/embeddings` on port 19134.
- `npm run test-integration -- test/playwright/integration/CrossTenantIsolation.integration.spec.mjs` -> `1 skipped` locally because Docker is unavailable in Codex.
- PR #10927 CI: `integration` passed in 1m59s, `Analyze (javascript)` passed, CodeQL passed.

## Post-Merge Validation
- [ ] Confirm #10917 auto-closes after squash merge.
