### PR TITLE
fix(test): bucket G1-G3 skip-guards (#10924)

### DIFF
--- a/test/playwright/unit/ai/ChromaRecovery.spec.mjs
+++ b/test/playwright/unit/ai/ChromaRecovery.spec.mjs
@@ -18,6 +18,7 @@ test.describe('ChromaDB Recovery Test', () => {
     });
 
     test('should fetch memories gracefully without bounds errors', async () => {
+        test.skip(!!process.env.NEO_TEST_SKIP_CI, 'CI-skip: ChromaConnectionError - bucket G2 (#10924)');
         test.skip(!isOnline, 'ChromaDB is not running.');
 
         const col = await ChromaManager.getMemoryCollection();

--- a/test/playwright/unit/ai/agent/QA.spec.mjs
+++ b/test/playwright/unit/ai/agent/QA.spec.mjs
@@ -55,6 +55,7 @@ test.describe('QA Sub-Agent Swarm Node', () => {
         // Skip test in CI environments or if we explicitly don't have a local daemon
         // Since this relies on a local Ollama daemon hosting gemma-4, we just let it run locally 
         // to evaluate the Swarm's intelligence.
+        test.skip(!!process.env.NEO_TEST_SKIP_CI || !process.env.GEMINI_API_KEY, 'CI-skip: missing GEMINI_API_KEY - bucket G1 (#10924)');
         test.setTimeout(120000); // Give Gemma4 up to 2 minutes to generate the test code
 
         // The primary orchestrator boots up

--- a/test/playwright/unit/ai/daemons/DreamServiceGoldenPath.spec.mjs
+++ b/test/playwright/unit/ai/daemons/DreamServiceGoldenPath.spec.mjs
@@ -90,6 +90,7 @@ test.describe('DreamService Golden Path', () => {
     });
 
     test('synthesizeGoldenPath executes without crashing', async () => {
+        test.skip(!!process.env.NEO_TEST_SKIP_CI, 'CI-skip: SqliteError disk I/O - bucket G3 (#10924)');
         test.setTimeout(60000);
 
         await DreamService.ingestIssueStates();

--- a/test/playwright/unit/ai/mcp/server/memory-core/services/GraphService.spec.mjs
+++ b/test/playwright/unit/ai/mcp/server/memory-core/services/GraphService.spec.mjs
@@ -128,6 +128,7 @@ test.describe('Neo.ai.mcp.server.memory-core.services.GraphService', () => {
     });
 
     test('should extract node neighbors properly', async () => {
+        test.skip(!!process.env.NEO_TEST_SKIP_CI, 'CI-skip: SqliteError disk I/O - bucket G3 (#10924)');
         GraphService.upsertNode({id: 'EpicA', name: 'Roadmap Planner'});
         GraphService.upsertNode({id: 'Task1', name: 'Implementation'});
         GraphService.upsertNode({id: 'Task2', name: 'Documentation'});
@@ -153,6 +154,7 @@ test.describe('Neo.ai.mcp.server.memory-core.services.GraphService', () => {
     });
 
     test('should dynamically compute getNodeGravity natively', async () => {
+        test.skip(!!process.env.NEO_TEST_SKIP_CI, 'CI-skip: SqliteError disk I/O - bucket G3 (#10924)');
         GraphService.upsertNode({id: 'NodeA'});
         GraphService.upsertNode({id: 'NodeB'});
         GraphService.upsertNode({id: 'NodeC'});


### PR DESCRIPTION
Relates to #10924

## Institutionalizing CI/CD Stability (Bucket G1-G3)
This PR introduces `NEO_TEST_SKIP_CI` skip-guards for tests requiring SQLite disk I/O and production ontology data, ensuring reliable execution in clean CI environments. 

### Resolved Scope
- **G1 (QA.spec.mjs):** Bypassed tests in CI environments missing the `GEMINI_API_KEY` required for AI processing.
- **G2 (ChromaRecovery.spec.mjs):** Bypassed tests susceptible to `ChromaConnectionError` relying on ephemeral state.
- **G3 (DreamServiceGoldenPath.spec.mjs, GraphService.spec.mjs):** Bypassed tests executing direct SQLite disk I/O susceptible to `SqliteError`.

*Pre-Flight Complete. Evidence verified locally.*