### PR TITLE
test(github-workflow): isolate config template namespace (#10924)

### DIFF
--- a/test/playwright/unit/ai/mcp/server/github-workflow/ConfigCompleteness.spec.mjs
+++ b/test/playwright/unit/ai/mcp/server/github-workflow/ConfigCompleteness.spec.mjs
@@ -17,10 +17,39 @@ setup({
 const __filename = fileURLToPath(import.meta.url);
 const __dirname  = path.dirname(__filename);
 const templatePath = path.resolve(__dirname, '../../../../../../../ai/mcp/server/github-workflow/config.template.mjs');
+const templateClassName = 'Neo.ai.mcp.server.github-workflow.Config';
+
+/**
+ * @summary Imports the copyable GitHub workflow config template under a unit-test-only namespace.
+ *
+ * The template intentionally uses the production config class name so users can copy it to
+ * `config.mjs`. In a single Playwright worker, importing both files would otherwise trigger
+ * Neo's `unitTestMode` namespace-collision guard.
+ */
+async function importTemplateConfig() {
+    const originalSetupClass = Neo.setupClass;
+
+    try {
+        Neo.setupClass = cls => {
+            if (cls?.config?.className === templateClassName) {
+                cls.config = {
+                    ...cls.config,
+                    className: 'Neo.ai.mcp.server.github-workflow.ConfigTemplateCompletenessTest'
+                };
+            }
+
+            return originalSetupClass.call(Neo, cls);
+        };
+
+        return await import(templatePath);
+    } finally {
+        Neo.setupClass = originalSetupClass;
+    }
+}
 
 test.describe('GitHub Workflow MCP Server Config Completeness', () => {
     test('config.template.mjs contains all required path definitions', async () => {
-        const configModule = await import(templatePath);
+        const configModule = await importTemplateConfig();
         const config = configModule.default;
 
         expect(config.issueSync).toBeDefined();


### PR DESCRIPTION
Related: #10924

Authored by GPT-5.5 (Codex Desktop). Session b9ebc51d-8c61-42a4-be5a-8878c0e7453d.

This closes the G4 namespace-collision lane by making `ConfigCompleteness` import the copyable github-workflow config template under a test-only class name. The production config/template files remain unchanged; the test wrapper restores `Neo.setupClass` immediately after import so downstream service specs can load production `config.mjs` in the same CI worker.

Evidence: L2 (CI-mode Playwright unit reproduction and targeted single-worker fix) -> L2 required (unit-test substrate failure). Residual: non-G4 PullRequestService getPullRequestDiff failures remain separately classified under Bucket G/G6.

## Deltas from ticket
- Scoped to G4 plus the G5#1 DiscussionService cascade only.
- Avoids closing the broader Bucket G tracker until post-G4 monitoring confirms the remaining rows.

## Test Evidence
- Baseline before patch: `CI=true npm run test-unit -- test/playwright/unit/ai/mcp/server/github-workflow` reproduced `Namespace collision in unitTestMode for Neo.ai.mcp.server.github-workflow.Config` when `DiscussionService` loaded after `ConfigCompleteness`.
- `CI=true npm run test-unit -- test/playwright/unit/ai/mcp/server/github-workflow/ConfigCompleteness.spec.mjs test/playwright/unit/ai/mcp/server/github-workflow/DiscussionService.spec.mjs` -> 7 passed (one worker).
- `CI=true npm run test-unit -- test/playwright/unit/ai/mcp/server/github-workflow` -> G4 namespace failure gone; 36 passed, 3 PullRequestService getPullRequestDiff failures remain outside this lane.
- `git diff --check origin/dev...HEAD` -> clean.

## Post-Merge Validation
- [ ] Re-run the Bucket G unit matrix and classify whether any non-G4 PullRequestService failures remain under the CI env gates.

## Commit
- `c465339b6` — `test(github-workflow): isolate config template namespace (#10924)`