### PR TITLE
fix(test): harden integration skip gates (#10952)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,9 +23,7 @@ jobs:
         # Bucket A-F audit (#10903) closed via #10907/#10921/#10910/#10919/#10920.
         # Bucket G (#10924) substrate fixes landed via #10940 (TestLifecycleHelper
         # primitive + daemon-spec migration) + open trackers for residual flakes
-        # (#10941/#10936/#10937/#10946 — all skip-guarded via NEO_TEST_SKIP_CI).
-        # NEO_TEST_SKIP_CI=true (env below) activates the canonical bucket-skip
-        # pattern; specs check process.env.NEO_TEST_SKIP_CI and skip cleanly.
+        # (#10941/#10936/#10937/#10946 — all unit-skip-guarded via NEO_TEST_SKIP_CI).
         suite: [integration, unit]
 
     steps:
@@ -57,11 +55,8 @@ jobs:
         run: npm run test-${{ matrix.suite }}
         env:
           NEO_INTEGRATION_STACK_TIMEOUT_MS: '240000'
-          # Activates the canonical bucket-skip pattern for tests that gate on
-          # CI substrate (heavy SLM, grid WIP, application-spec deferrals).
-          # Test specs check `process.env.NEO_TEST_SKIP_CI` and skip cleanly.
-          # See #10903 (unit-suite buckets A-E) + #10917/#10918 (bucket F).
-          NEO_TEST_SKIP_CI: 'true'
+          # Keep the unit residual skip guards active without gating integration specs.
+          NEO_TEST_SKIP_CI: ${{ matrix.suite == 'unit' && 'true' || '' }}
 
       - name: Upload test artifacts on failure
         if: failure()

--- a/test/playwright/integration/HeartbeatPropagation.integration.spec.mjs
+++ b/test/playwright/integration/HeartbeatPropagation.integration.spec.mjs
@@ -9,17 +9,14 @@ test.describe('Heartbeat Propagation Integration (#10896 Lane B)', () => {
     test.setTimeout(120000); // Allow enough time for 30s window and startup
 
     test('Sustained healthcheck property assertions (30s window)', async () => {
-        // Bucket F (#10918): consecutive healthcheck samples report identical process.uptime()
-        // values, breaking the strict toBeGreaterThan monotonic check. Two hypotheses (per-session
-        // McpServer regression from #10916 vs test-spec strictness) — diagnostic Phase 1 needed
-        // before fix shape is decided. Deferred to unblock Lane C #10897 close.
-        test.skip(!!process.env.NEO_TEST_SKIP_CI, 'CI-skip: bucket F application-spec deferral — see #10918');
-
         const readiness = await getReadiness();
         test.skip(readiness.dockerAvailable === false, `Docker unavailable: ${readiness.reason}`);
         expect(readiness.servicesReady, readiness.reason).toBe(true);
 
         const checkProperties = (sample, previousSamples) => {
+            expect(sample.status).toBe('healthy');
+            expect(typeof sample.uptime).toBe('number');
+
             if (previousSamples.length > 1) {
                 const prev = previousSamples[previousSamples.length - 2];
                 // Monotonic uptime

--- a/test/playwright/integration/fixtures/composeWebServer.mjs
+++ b/test/playwright/integration/fixtures/composeWebServer.mjs
@@ -29,6 +29,35 @@ function dockerCompose(args, options = {}) {
     });
 }
 
+/**
+ * @summary Writes captured Docker CLI output to stderr when it is non-empty.
+ * @param {String} label  Human-readable command label.
+ * @param {Object} result The spawnSync result from a Docker command.
+ * @returns {void}
+ */
+function writeProcessOutput(label, result) {
+    const output = [
+        result.stdout?.trim(),
+        result.stderr?.trim()
+    ].filter(Boolean).join('\n');
+
+    if (output) {
+        console.error(`[composeWebServer] ${label}\n${output}`);
+    }
+}
+
+/**
+ * @summary Emits Docker Compose process and log diagnostics for failed startup.
+ * @param {String} reason The failure reason that triggered diagnostics.
+ * @returns {void}
+ */
+function writeComposeDiagnostics(reason) {
+    console.error(`[composeWebServer] ${reason}`);
+
+    writeProcessOutput('docker compose ps -a', dockerCompose(['ps', '-a']));
+    writeProcessOutput('docker compose logs --tail 200', dockerCompose(['logs', '--no-color', '--tail', '200']));
+}
+
 function isDockerAvailable() {
     const version = spawnSync('docker', ['compose', 'version'], {encoding: 'utf8'});
 
@@ -90,6 +119,7 @@ async function waitForServices() {
     }
 
     state.reason = `Timed out waiting for Dockerized MCP integration stack. Last state: ${state.reason}`;
+    writeComposeDiagnostics(state.reason);
 }
 
 function cleanup() {
@@ -144,6 +174,7 @@ server.listen(readyPort, '127.0.0.1', async () => {
         if (!shuttingDown) {
             state.servicesReady = false;
             state.reason        = `docker compose exited before shutdown with code ${code}.`;
+            writeComposeDiagnostics(state.reason);
         }
     });
 


### PR DESCRIPTION
Resolves #10952

Related: #10945

Authored by GPT-5.5 (Codex Desktop). Session 019e06c5-f9f4-7e13-9237-76f3269070a9.

This hardens the Memory Core deployment integration row by removing the stale integration skip path for closed #10917/#10918 work, while preserving the freshly re-added unit-suite residual skip guards from #10939. Integration now gets an empty `NEO_TEST_SKIP_CI` value, so the deployed specs cannot be skipped by that broad gate; unit keeps `NEO_TEST_SKIP_CI=true` for its live residual trackers.

Evidence: L1 (static workflow/spec audit, syntax/YAML checks, and local Playwright discovery of all integration specs) -> L2 required (CI integration row executes Docker-backed deployment assertions on a Docker-capable runner). Residual: full L2 execution awaits GitHub Actions Docker environment [#10952].

## Deltas from ticket

- Rebased over #10953, which re-added the `unit` matrix row. The final workflow deliberately scopes `NEO_TEST_SKIP_CI` to `matrix.suite == 'unit'` instead of removing it globally.
- Strengthened the heartbeat integration assertion by checking every sustained sample reports `status === "healthy"` and a numeric `uptime`, before the monotonic uptime check.
- Added failure-only Docker Compose diagnostics in `composeWebServer.mjs`: on stack timeout or premature compose exit, stderr now includes `docker compose ps -a` plus the last 200 compose log lines.

## Test Evidence

- `git diff --check origin/dev...HEAD` passed.
- `node --check test/playwright/integration/HeartbeatPropagation.integration.spec.mjs` passed.
- `node --check test/playwright/integration/fixtures/composeWebServer.mjs` passed.
- `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/test.yml'); puts 'yaml ok'"` passed.
- `rg -n "NEO_TEST_SKIP_CI|10917|10918|CI-skip|process\\.env\\.NEO_TEST_SKIP_CI" test/playwright/integration -S` returned no matches.
- Escalated `npm run test-integration` started Playwright and discovered all 5 integration tests; this Codex host has no Docker CLI, so all 5 were skipped with `Docker unavailable: spawnSync docker ENOENT`.

Skipped vs unskipped after this change:
- `AuthRejection.integration.spec.mjs` — not gated by `NEO_TEST_SKIP_CI`; local run skipped only because Docker CLI is absent.
- `CrossTenantIsolation.integration.spec.mjs` — not gated by `NEO_TEST_SKIP_CI`; local run skipped only because Docker CLI is absent.
- `healthcheck.spec.mjs` / healthcheck payload test — not gated by `NEO_TEST_SKIP_CI`; local run skipped only because Docker CLI is absent.
- `healthcheck.spec.mjs` / sustained liveness helper test — not gated by `NEO_TEST_SKIP_CI`; local run skipped only because Docker CLI is absent.
- `HeartbeatPropagation.integration.spec.mjs` — stale #10918 `NEO_TEST_SKIP_CI` gate removed; local run skipped only because Docker CLI is absent.

## Post-Merge Validation

- [ ] GitHub Actions `integration` matrix row runs without `NEO_TEST_SKIP_CI=true` and executes the 5 Docker-backed integration tests on the Docker-capable runner.
- [ ] GitHub Actions `unit` matrix row still honors the live Bucket G residual skip guards for #10941/#10936/#10937/#10946.

## Commit

- `9348d44ea` — `fix(test): harden integration skip gates (#10952)`
