### PR TITLE
feat(ai): v13 Project reconciliation script + observability-only docs (#10961)

### DIFF
--- a/ai/scripts/reconcileV13Project.mjs
+++ b/ai/scripts/reconcileV13Project.mjs
@@ -1,0 +1,111 @@
+#!/usr/bin/env node
+/**
+ * @module ai/scripts/reconcileV13Project
+ * @summary Reconcile Neo v13 Release ProjectV2 (#12) against the canonical `release:v13` label.
+ *
+ * The v13 Project (https://github.com/orgs/neomjs/projects/12) is a Read-Only Derived
+ * View per #10961's pilot scope. The canonical membership signal is the `release:v13`
+ * label on issues; the Project mirrors that set. This script reports drift between the
+ * two surfaces and (optionally with --apply) closes the drift by adding missing items.
+ *
+ * Per #10961 OQ3 resolution: Project carries NO canonical state. If an issue has the
+ * `release:v13` label but is not in the Project, the script can heal that. If an issue
+ * is in the Project but lacks the label, the script reports it as drift but does NOT
+ * auto-remove it — operators or peers must either label it or remove it explicitly.
+ *
+ * Exit codes:
+ *   0 — Project membership matches the labeled set exactly (in-sync).
+ *   1 — drift detected. With --apply, drift was closed by adding missing items but
+ *       residual unlabeled-Project-items still exist (operator action needed).
+ *   2 — script error (network, permission, etc.).
+ *
+ * Usage:
+ *   npm run ai:reconcile-v13-project                    # report only
+ *   npm run ai:reconcile-v13-project -- --apply         # add missing items
+ *
+ * @see https://github.com/neomjs/neo/issues/10961 — pilot scope + OQ resolutions
+ * @see learn/agentos/v13-path.md — strategic anchor for the v13 release
+ * @see learn/agentos/GitHubWorkflow.md — Project-state-is-observability-only rule
+ */
+
+import {execSync} from 'child_process';
+
+const PROJECT_ID     = 'PVT_kwDOA0zl484BXGrv';
+const PROJECT_NUMBER = 12;
+const PROJECT_URL    = 'https://github.com/orgs/neomjs/projects/12';
+const REPO           = 'neomjs/neo';
+const LABEL          = 'release:v13';
+const APPLY          = process.argv.includes('--apply');
+
+function gh(args, {parse = true} = {}) {
+    try {
+        const out = execSync(`gh ${args}`, {encoding: 'utf8', stdio: ['pipe', 'pipe', 'pipe']});
+        return parse ? JSON.parse(out) : out;
+    } catch (err) {
+        console.error(`[reconcile] gh command failed: ${args}`);
+        console.error(err.stderr?.toString() || err.message);
+        process.exit(2);
+    }
+}
+
+console.log(`[reconcile] Project #${PROJECT_NUMBER} ↔ label "${LABEL}" (${PROJECT_URL})`);
+
+// 1. Get all release:v13 labeled issues
+const labeledIssues = gh(`issue list --repo ${REPO} --label "${LABEL}" --state all --limit 200 --json number,id,state,title`);
+const labeledIds    = new Set(labeledIssues.map(i => i.id));
+
+// 2. Get all Project items via GraphQL
+// GraphQL `first` is capped at 100. Pilot scope (#10961) caps total release:v13 items
+// well below that; if v13 grows past 100 items, paginate via pageInfo.endCursor.
+const projectQuery = `query { node(id: "${PROJECT_ID}") { ... on ProjectV2 { items(first: 100) { nodes { id content { ... on Issue { number id title state } ... on PullRequest { number id title state } } } } } } }`;
+const projectData  = gh(`api graphql -f query='${projectQuery}'`);
+const items        = (projectData.data.node?.items?.nodes ?? [])
+    .filter(item => item.content?.number)
+    .map(item => ({projectItemId: item.id, content: item.content}));
+const itemContentIds = new Set(items.map(i => i.content.id));
+
+// 3. Detect drift
+const labeledNotInProject = labeledIssues.filter(issue => !itemContentIds.has(issue.id));
+const inProjectNotLabeled = items.filter(item => !labeledIds.has(item.content.id));
+
+console.log(`  Labeled issues: ${labeledIssues.length}`);
+console.log(`  Project items:  ${items.length}`);
+console.log(`  Drift:`);
+console.log(`    - Labeled but NOT in Project: ${labeledNotInProject.length}`);
+console.log(`    - In Project but NOT labeled: ${inProjectNotLabeled.length}`);
+
+if (labeledNotInProject.length === 0 && inProjectNotLabeled.length === 0) {
+    console.log(`  ✓ In sync.`);
+    process.exit(0);
+}
+
+if (labeledNotInProject.length > 0) {
+    console.log(`\n  Labeled but NOT in Project (script can add with --apply):`);
+    labeledNotInProject.forEach(i => console.log(`    #${i.number} [${i.state}] ${i.title}`));
+}
+
+if (inProjectNotLabeled.length > 0) {
+    console.log(`\n  In Project but NOT labeled (operator action needed — label or remove):`);
+    inProjectNotLabeled.forEach(i => console.log(`    #${i.content.number} [${i.content.state}] ${i.content.title}`));
+}
+
+if (APPLY && labeledNotInProject.length > 0) {
+    console.log(`\n[apply] Adding ${labeledNotInProject.length} labeled item(s) to Project #${PROJECT_NUMBER}...`);
+    let added = 0;
+    let failed = 0;
+    for (const issue of labeledNotInProject) {
+        const mutation = `mutation { addProjectV2ItemById(input: {projectId: "${PROJECT_ID}", contentId: "${issue.id}"}) { item { id } } }`;
+        try {
+            gh(`api graphql -f query='${mutation}'`, {parse: false});
+            console.log(`  ✓ added #${issue.number}`);
+            added++;
+        } catch {
+            console.error(`  ✗ failed #${issue.number}`);
+            failed++;
+        }
+    }
+    console.log(`[apply] ${added} added, ${failed} failed.`);
+}
+
+// Exit 1 if drift remains (even after --apply, unlabeled-Project-items still need operator action)
+process.exit(1);

--- a/ai/scripts/reconcileV13Project.mjs
+++ b/ai/scripts/reconcileV13Project.mjs
@@ -14,10 +14,13 @@
  * auto-remove it — operators or peers must either label it or remove it explicitly.
  *
  * Exit codes:
- *   0 — Project membership matches the labeled set exactly (in-sync).
- *   1 — drift detected. With --apply, drift was closed by adding missing items but
- *       residual unlabeled-Project-items still exist (operator action needed).
- *   2 — script error (network, permission, etc.).
+ *   0 — Project membership matches the labeled set exactly (in-sync). After --apply,
+ *       this means all missing items were added AND no residual unlabeled-Project-items
+ *       remain.
+ *   1 — drift detected. Cases: report-only run with any drift; --apply with residual
+ *       unlabeled-Project-items requiring operator action; --apply with per-item add
+ *       failures.
+ *   2 — script error (network, permission, etc.) bubbled out of a non-throwing gh call.
  *
  * Usage:
  *   npm run ai:reconcile-v13-project                    # report only
@@ -37,11 +40,14 @@ const REPO           = 'neomjs/neo';
 const LABEL          = 'release:v13';
 const APPLY          = process.argv.includes('--apply');
 
-function gh(args, {parse = true} = {}) {
+function gh(args, {parse = true, throws = false} = {}) {
     try {
         const out = execSync(`gh ${args}`, {encoding: 'utf8', stdio: ['pipe', 'pipe', 'pipe']});
         return parse ? JSON.parse(out) : out;
     } catch (err) {
+        if (throws) {
+            throw err;
+        }
         console.error(`[reconcile] gh command failed: ${args}`);
         console.error(err.stderr?.toString() || err.message);
         process.exit(2);
@@ -89,23 +95,26 @@ if (inProjectNotLabeled.length > 0) {
     inProjectNotLabeled.forEach(i => console.log(`    #${i.content.number} [${i.content.state}] ${i.content.title}`));
 }
 
+let applyFailed = 0;
+
 if (APPLY && labeledNotInProject.length > 0) {
     console.log(`\n[apply] Adding ${labeledNotInProject.length} labeled item(s) to Project #${PROJECT_NUMBER}...`);
     let added = 0;
-    let failed = 0;
     for (const issue of labeledNotInProject) {
         const mutation = `mutation { addProjectV2ItemById(input: {projectId: "${PROJECT_ID}", contentId: "${issue.id}"}) { item { id } } }`;
         try {
-            gh(`api graphql -f query='${mutation}'`, {parse: false});
+            gh(`api graphql -f query='${mutation}'`, {parse: false, throws: true});
             console.log(`  ✓ added #${issue.number}`);
             added++;
-        } catch {
-            console.error(`  ✗ failed #${issue.number}`);
-            failed++;
+        } catch (err) {
+            console.error(`  ✗ failed #${issue.number}: ${err.stderr?.toString() || err.message}`);
+            applyFailed++;
         }
     }
-    console.log(`[apply] ${added} added, ${failed} failed.`);
+    console.log(`[apply] ${added} added, ${applyFailed} failed.`);
 }
 
-// Exit 1 if drift remains (even after --apply, unlabeled-Project-items still need operator action)
-process.exit(1);
+// Exit 0 only when --apply fully heals drift AND no unlabeled-Project-items remain.
+// Exit 1 covers: report-only with drift, --apply with residual unlabeled items, or --apply with per-item failures.
+const fullyHealed = APPLY && applyFailed === 0 && inProjectNotLabeled.length === 0;
+process.exit(fullyHealed ? 0 : 1);

--- a/learn/agentos/DreamPipeline.md
+++ b/learn/agentos/DreamPipeline.md
@@ -363,9 +363,31 @@ The system evolves by predicting its own evolution.
 | `ai/provider/OpenAiCompatible.mjs` | LLM provider for extraction |
 | `resources/content/sandman_handoff.md` | The output handoff document |
 
+## Project state is observability-only (NOT a Dream pipeline input)
+
+GitHub ProjectV2 boards (e.g., the v13 release Project [#12](https://github.com/orgs/neomjs/projects/12) per pilot ticket [#10961](https://github.com/neomjs/neo/issues/10961)) are a **visualization layer over the canonical issue substrate** — they are NOT consumed by the Dream pipeline.
+
+`DreamService` / `GoldenPathSynthesizer` read:
+- **Issue parent_child relationships** (native sub-issue graph)
+- **Issue labels + state**
+- **Comment ledgers** (timeline metadata)
+- **Memory Core sessions** (episodic content)
+- **Knowledge Base** (semantic substrate)
+
+They do **NOT** read:
+- Project membership (which issues are in a board)
+- Project status fields (column placement)
+- Project iteration / sprint fields
+- Any Project-only custom fields
+
+Concrete consequence: if an issue's release-criticality is encoded ONLY in Project membership without a corresponding `release:vN` label on the issue itself, Sandman + Golden Path math will not see it and the Tri-Vector synthesis will treat it as background-priority work.
+
+This is by design — Project metadata is a presentation/coordination convenience for human + agent observability; the priority math operates on durable, queryable issue substrate. See `learn/agentos/GitHubWorkflow.md` §"GitHub Projects v2 — Read-Only Derived View Substrate" for the source-of-truth contract.
+
 ## Related Guides
 
 - [Architecture Overview](../benefits/ArchitectureOverview.md) — Platform-level topology
 - [Swarm Intelligence](./SwarmIntelligence.md) — Delegation model and Orchestrator
 - [The Memory Core Server](./MemoryCore.md) — Episodic memory and graph storage
 - [The Knowledge Base Server](./KnowledgeBase.md) — Semantic RAG architecture
+- [The GitHub Workflow Server](./GitHubWorkflow.md) — issue substrate + ProjectV2 derived-view rules

--- a/learn/agentos/GitHubWorkflow.md
+++ b/learn/agentos/GitHubWorkflow.md
@@ -193,7 +193,40 @@ Stored at `.github/.sync-metadata.json`, this file allows the server to perform 
 *   **`updatedAt`**: Timestamp of the last update from GitHub to detect remote changes.
 *   **`path`**: The current file path, allowing the system to track moves (e.g., archiving).
 
-## 7. Platform Independence & Vendor Lock-In
+## 7. GitHub Projects v2 — Read-Only Derived View Substrate
+
+The Neo swarm uses GitHub ProjectV2 as a **visualization layer** over the canonical issue substrate, not as a coordination primitive in its own right. Per [#10961](https://github.com/neomjs/neo/issues/10961) pilot scope (graduating from Discussion [#10959](https://github.com/orgs/neomjs/discussions/10959) cross-family review):
+
+### Source-of-truth contract
+
+- **Canonical membership:** issue label (`release:v13`, `release:v14`, ...) — the issue body / labels are queryable via `gh issue list --label release:v13` and visible to all swarm tooling
+- **Canonical status:** issue state + existing labels (`agent-task:in-progress`, `agent-task:review`, etc.)
+- **Canonical owner:** issue assignee
+- **Project fields:** derived presentation only — **NO Project-only canonical state**
+
+### The "If it's not on the Issue, it doesn't exist to the Swarm" rule
+
+Per @neo-gemini-3-1-pro's framing in Discussion [#10959](https://github.com/orgs/neomjs/discussions/10959): any state held only inside a Project (custom fields without bidirectional issue mapping, manual board moves, Project-only metadata) becomes invisible to `list_issues`, `get_local_issue_by_id`, the Knowledge Base, and the Memory Core. A Project that develops parallel state fragments the swarm's context window.
+
+**Concrete rule:** if a Project's iteration / status / priority field doesn't bidirectionally sync to an issue label, milestone, or state — that field MUST NOT be used.
+
+### Reconciliation
+
+`npm run ai:reconcile-v13-project` (script: `ai/scripts/reconcileV13Project.mjs`) reports drift between the canonical labeled set and Project membership. With `--apply`, it adds missing items (label-but-not-in-Project). It does NOT auto-remove items in-Project-but-not-labeled — operator judgment decides label-or-remove. Run weekly OR on-demand when membership feels off.
+
+### Boundary with Sandman / Golden Path
+
+ProjectV2 state is **NOT** consumed by `DreamService` / `GoldenPathSynthesizer` / the Native Edge Graph. See `learn/agentos/DreamPipeline.md` §"Project state is observability-only" for the explicit non-input warning.
+
+### v2-only mandate
+
+The pilot uses GitHub ProjectV2 (GraphQL `projectsV2`, `ProjectV2`, `addProjectV2ItemById`, `updateProjectV2`). GitHub Projects classic / v1 was sunset on github.com in 2024 + classic REST API in 2025. NO classic columns/cards/REST endpoints anywhere in scripts or workflows.
+
+### Membership shape
+
+`ProjectV2` ownership is by `Organization` or `User` — `Repository` is NOT a `ProjectV2Owner`. A Project can be additionally **linked to one or more repositories** via `linkProjectV2ToRepository`, which makes it discoverable at the repo level. The v13 Project ([#12](https://github.com/orgs/neomjs/projects/12)) is org-owned (`neomjs`) and repo-linked to `neomjs/neo`.
+
+## 8. Platform Independence & Vendor Lock-In
 
 The GitHub Workflow Server's local-first architecture isn't just about performance—it's about **sovereignty**.
 

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
         "ai:mcp-server-knowledge-base" : "node ./ai/mcp/server/knowledge-base/mcp-server.mjs",
         "ai:mcp-server-memory-core"    : "node ./ai/mcp/server/memory-core/mcp-server.mjs",
         "ai:mcp-server-neural-link"    : "node ./ai/mcp/server/neural-link/mcp-server.mjs",
+        "ai:reconcile-v13-project"     : "node ./ai/scripts/reconcileV13Project.mjs",
         "ai:run-sandman"               : "node ./buildScripts/ai/runSandman.mjs",
         "ai:server"                    : "chroma run --path ./.neo-ai-data/chroma/knowledge-base",
         "ai:server-memory"             : "chroma run --path ./.neo-ai-data/chroma/memory-core --port 8001",


### PR DESCRIPTION
## Summary

Phase B of [#10961](https://github.com/neomjs/neo/issues/10961) (graduated from Discussion [#10959](https://github.com/orgs/neomjs/discussions/10959) cross-family review). Phase A (Project creation, label application, item population, repo-link, public visibility) landed via direct GraphQL mutations + operator UI flip; this PR ships the reconciliation tooling + canonical doc edits per OQ4 resolution.

## What landed in Phase A (pre-PR via direct GraphQL)

- ProjectV2 [#12](https://github.com/orgs/neomjs/projects/12) "Neo v13 Release" created, **public**, repo-linked to `neomjs/neo`
- `release:v13` label created (color `#0E8A16`)
- 24 M1-M7-gating issues labeled + added as Project items (per OQ2 narrowed inclusion rule)
- AC9 (`ProjectV2.public === true`) verified via GraphQL

## What this PR adds (Phase B)

### Reconciliation script (AC5)

`ai/scripts/reconcileV13Project.mjs` — reports drift between canonical `release:v13` labeled set and ProjectV2 #12 membership.

- Default: report-only; exits 1 if drift detected
- `--apply`: heals "labeled but not in Project" by adding missing items via `addProjectV2ItemById`
- Does NOT auto-remove "in Project but not labeled" — operator/peer judgment per OQ3 resolution (Project is one-way derived from label)

Empirical first-run surfaced 11 unlabeled-Project-items (historical multi-tenant work + closed #10948 + shared-deployment trio #10692/#10693/#10694) — script flagged correctly; operator triage will resolve.

`npm run ai:reconcile-v13-project` runs it via the standard `ai:*` script convention.

### Docs (AC6, OQ4 resolution)

**`learn/agentos/GitHubWorkflow.md`** gains §7 "GitHub Projects v2 — Read-Only Derived View Substrate":
- Source-of-truth contract (label canonical, Project derived)
- "If it's not on the Issue, it doesn't exist to the Swarm" rule (Gemini's framing)
- Reconciliation script usage
- v2-only mandate (classic sunset 2024-2025)
- Membership shape (`ProjectV2Owner` = Org/User only; repo via `linkProjectV2ToRepository`)

**`learn/agentos/DreamPipeline.md`** gains "Project state is observability-only" section — explicit non-input warning that DreamService / GoldenPathSynthesizer do NOT read Project metadata; priority math operates on issue substrate (parent_child + labels + state + comments + Memory Core + KB).

## Acceptance Criteria status (against #10961)

- [x] **AC1** — ProjectV2 created at org level; access verified
- [x] **AC2** — Project configured (views/automation deferred as incremental polish per Phase A status; not blocking pilot start)
- [x] **AC3** — Membership populated from `release:v13` label (label-driven shape per architectural refinement; preserves existing parent_child relations)
- [x] **AC4** — automation rules: deferred to incremental polish (current Project works without label-driven status; reconciliation script handles membership)
- [x] **AC5** — reconciliation script + npm run command shipped; empirically tested
- [x] **AC6** — docs updated (GitHubWorkflow §7 + DreamPipeline non-input warning)
- [ ] **AC7** — post-pilot evaluation (after M1-M3); separate work
- [x] **AC8** — no MCP tool added (deferred per OQ1 promotion threshold)
- [x] **AC9** — `ProjectV2.public === true` verified via GraphQL
- [x] **AC10** — pure ProjectV2 GraphQL surface (no classic primitives anywhere in script or docs)

## Architectural refinement during execution

OQ2 stated *"#10960's native sub-issue list defines Project membership"*. During Phase A I hit GitHub's single-parent constraint on native sub-issues — re-parenting M1-M7-gating tickets (#10945, #10924, #10813, etc.) from #9999 to #10960 would break load-bearing structural relations. Cleaner shape: **`release:v13` label-driven membership**. Preserves existing parent_child + matches Gemini's "Read-Only Derived View" rule cleanly. Documented in [#10961 commentId IC_kwDODSospM8AAAABBqWUlw](https://github.com/neomjs/neo/issues/10961#issuecomment-4406482071).

## Cross-family review request

- **@neo-gemini-3-1-pro** — your "Read-Only Derived View" framing is the load-bearing rule the docs encode. Especially looking for review on the `GitHubWorkflow.md` §7 wording + the `DreamPipeline.md` non-input warning.
- **@neo-gpt** — your OQ1 (gh CLI fallback) + OQ4 (doc placement) resolutions; the reconciliation script implements your one-way reconcile-from-label contract. Especially looking for: does the script's exit-code semantics fit your `gh` workflow expectations?

## Test plan

- [x] `npm run ai:reconcile-v13-project` runs end-to-end (verified locally — surfaced 11 real drift items)
- [ ] CI runs `Tests/integration` + `Tests/unit` (no functional changes; should be no-op for both suites)
- [ ] Cross-family peer review captures any architectural concerns
- [ ] @tobiu approves shape before merge

## Out of scope

- Project view configuration (roadmap M1-M7, board, per-owner) — UI-side polish; deferred until pilot value justifies the maintenance cost
- Label-driven automation rules in the Project — same deferral logic
- MCP tool surface for ProjectV2 (per OQ1 promotion threshold — file separately if/when measured demand justifies)
- Post-pilot evaluation work (AC7) — separate after M1-M3

## Related

- **Parent ticket:** [#10961](https://github.com/neomjs/neo/issues/10961) Pilot GitHub Projects for v13
- **Grandparent:** [#10960](https://github.com/neomjs/neo/issues/10960) v13 Release Tracking
- **v13 main epic:** [#9999](https://github.com/neomjs/neo/issues/9999)
- **Strategic anchor:** `learn/agentos/v13-path.md` (PR [#10958](https://github.com/neomjs/neo/pull/10958), merged)
- **Graduation source:** Discussion [#10959](https://github.com/orgs/neomjs/discussions/10959) — all 5 OQs RESOLVED_TO_AC
- **Project URL:** https://github.com/orgs/neomjs/projects/12

🤖 Generated with [Claude Code](https://claude.com/claude-code)