### PR TITLE
feat(ai): migrate knowledge-base/Server to extend BaseServer (#10965)

### DIFF
--- a/ai/mcp/server/BaseServer.mjs
+++ b/ai/mcp/server/BaseServer.mjs
@@ -198,6 +198,22 @@ class BaseServer extends Base {
         // No-op default
     }
 
+    /**
+     * @summary Override (optional): hook called when the healthcheck gate rejects a tool call,
+     * BEFORE the formatHealthError envelope is returned. Lets per-server augment with telemetry
+     * (e.g., knowledge-base's KBRecorderService.log of failed tool dispatch). Default no-op.
+     *
+     * @param {Object} context
+     * @param {String} context.toolName The MCP tool name that was rejected.
+     * @param {Object} context.args     The arguments passed to the tool call.
+     * @param {Error}  context.error    The healthcheck error.
+     * @param {Number} context.t0       The Date.now() timestamp captured at handler entry; lets
+     *     telemetry compute duration_ms = Date.now() - t0.
+     */
+    async onHealthGateFailure(context) {
+        // No-op default
+    }
+
     // ===== Optional lifecycle hooks (composable, no-op by default) =====
 
     /** @summary Hook fired before `createMcpServer()` runs in default `initAsync` sequence. */
@@ -296,6 +312,7 @@ class BaseServer extends Base {
         // CallTool handler
         mcpServer.server.setRequestHandler(CallToolRequestSchema, async (request) => {
             const {name, arguments: args} = request.params;
+            const t0                      = Date.now();
 
             try {
                 this.logger?.debug?.(`[MCP] Calling tool: ${name} with args:`, JSON.stringify(args));
@@ -316,6 +333,7 @@ class BaseServer extends Base {
                         }
                     } catch (healthError) {
                         this.logger?.error?.(`[MCP] Health check failed for tool ${name}:`, healthError.message);
+                        await this.onHealthGateFailure({toolName: name, args, error: healthError, t0});
                         return this.formatHealthError(name, healthError);
                     }
                 }

--- a/ai/mcp/server/knowledge-base/Server.mjs
+++ b/ai/mcp/server/knowledge-base/Server.mjs
@@ -1,12 +1,10 @@
-import {McpServer}                                     from '@modelcontextprotocol/sdk/server/mcp.js';
-import {CallToolRequestSchema, ListToolsRequestSchema} from '@modelcontextprotocol/sdk/types.js';
-import Base                                            from '../../../../src/core/Base.mjs';
-import aiConfig                                        from './config.mjs';
-import logger                                          from './logger.mjs';
-import DatabaseService                                 from './services/DatabaseService.mjs';
-import HealthService                                   from './services/HealthService.mjs';
-import KBRecorderService                               from './services/KBRecorderService.mjs';
-import {listTools, callTool}                           from './services/toolService.mjs';
+import BaseServer            from '../BaseServer.mjs';
+import aiConfig              from './config.mjs';
+import logger                from './logger.mjs';
+import DatabaseService       from './services/DatabaseService.mjs';
+import HealthService         from './services/HealthService.mjs';
+import KBRecorderService     from './services/KBRecorderService.mjs';
+import {listTools, callTool} from './services/toolService.mjs';
 
 /**
  * @summary The Knowledge Base MCP Server application.
@@ -18,9 +16,9 @@ import {listTools, callTool}                           from './services/toolServ
  * The transport mode and HTTP port can be configured using `aiConfig.transport` and `aiConfig.mcpHttpPort`.
  *
  * @class Neo.ai.mcp.server.knowledge-base.Server
- * @extends Neo.core.Base
+ * @extends Neo.ai.mcp.server.BaseServer
  */
-class Server extends Base {
+class Server extends BaseServer {
     static config = {
         /**
          * @member {String} className='Neo.ai.mcp.server.knowledge-base.Server'
@@ -29,103 +27,81 @@ class Server extends Base {
         className: 'Neo.ai.mcp.server.knowledge-base.Server'
     }
 
-    /**
-     * Path to a custom configuration file.
-     * @member {String|null} configFile=null
-     */
-    configFile = null
-    /**
-     * The MCP Server instance.
-     * @member {McpServer|null} mcpServer=null
-     * @protected
-     */
-    mcpServer = null
+    aiConfig = aiConfig
+    logger   = logger
 
     /**
-     * Creates a new MCP Server instance. Used by TransportService to provision
-     * a dedicated server object per SSE request to avoid SDK lifecycle collisions.
-     * @returns {McpServer}
+     * @summary MCP server identity for `createMcpServer()`.
+     * @returns {{name: String, version: String, capabilities: Object}}
      */
-    createMcpServer() {
-        const mcpServer = new McpServer({
-            name   : 'neo-knowledge-base',
-            version: process.env.npm_package_version || '1.0.0',
-        }, {
+    getServerMetadata() {
+        return {
+            name        : 'neo-knowledge-base',
+            version     : process.env.npm_package_version || '1.0.0',
             capabilities: {
-                tools: {
-                    listChanged: false
-                }
+                tools: {listChanged: false}
             }
+        };
+    }
+
+    /**
+     * @summary Per-server tool registry for ListTools / CallTool dispatch.
+     * @returns {{listTools: Function, callTool: Function}}
+     */
+    getToolService() {
+        return {listTools, callTool};
+    }
+
+    /**
+     * @summary Singleton services to await ready() before transport-connect.
+     * @returns {Array<Object>}
+     */
+    getDependentServices() {
+        return [DatabaseService, KBRecorderService];
+    }
+
+    /**
+     * @summary HealthService for the healthcheck gate + startup-status logging.
+     * @returns {Object}
+     */
+    getHealthService() {
+        return HealthService;
+    }
+
+    /**
+     * @summary Tools allowed without the healthcheck gate (database lifecycle + agent FAQs).
+     * @returns {Array<String>}
+     */
+    getHealthExemptTools() {
+        return ['healthcheck', 'start_database', 'stop_database', 'list_agent_faqs'];
+    }
+
+    /**
+     * @summary Records failed tool dispatch to KBRecorderService when the healthcheck gate rejects.
+     * Preserves the existing telemetry shape (agent_id, session_id, sequence_id, timestamp,
+     * tool, args, result, success, duration_ms) so KB-level analytics stay continuous post-migration.
+     * @param {{toolName: String, args: Object, error: Error, t0: Number}} context
+     */
+    async onHealthGateFailure({toolName, args, error, t0}) {
+        const agent_id = process.env.NEO_AGENT_ID || process.env.USER || 'unknown';
+
+        KBRecorderService.log({
+            agent_id,
+            session_id : args?.sessionId || process.env.NEO_SESSION_ID || null,
+            sequence_id: `${agent_id}_${t0}`,
+            timestamp  : t0,
+            tool       : toolName,
+            args,
+            result     : {error: error.message},
+            success    : false,
+            duration_ms: Date.now() - t0
         });
-
-        this.setupRequestHandlers(mcpServer);
-
-        return mcpServer;
     }
 
     /**
-     * Async initialization sequence.
-     * Replaces the main() function of the previous procedural implementation.
-     * @returns {Promise<void>}
-     */
-    async initAsync() {
-        await super.initAsync();
-
-        // 1. Load custom configuration if provided
-        if (this.configFile) {
-            try {
-                await aiConfig.load(this.configFile);
-            } catch (error) {
-                logger.error('Failed to load configuration:', error);
-                throw error; // Re-throw to trigger ready() catch block in runner
-            }
-        }
-
-        // 2. Initialize the default stdio MCP Server instance
-        this.mcpServer = this.createMcpServer();
-
-        // 4. Wait for dependent services
-        // DatabaseService is a singleton, so we wait for its global ready state
-        await DatabaseService.ready();
-        await KBRecorderService.ready();
-
-        // 5. Perform Health Check & Log Status
-        const health = await HealthService.healthcheck();
-        this.logStartupStatus(health);
-
-        // 6. Connect Transport
-        if (aiConfig.transport === 'sse') {
-            const {default: TransportService} = await import('../shared/services/TransportService.mjs');
-
-            await TransportService.setup({
-                server      : this,
-                aiConfig,
-                logger,
-                resourceName: 'neo-knowledge-base MCP'
-            });
-        } else {
-            const {StdioServerTransport} = await import('@modelcontextprotocol/sdk/server/stdio.js');
-            const transport = new StdioServerTransport();
-            await this.mcpServer.connect(transport);
-
-            logger.info('[neo-knowledge-base MCP] Server started on stdio transport');
-            logger.info('[neo-knowledge-base MCP] Available tools loaded from OpenAPI spec');
-        }
-    }
-
-    /**
-     * Helper to log collection statistics.
-     * @param {Object} health The health object
-     */
-    logCollectionStats(health) {
-        if (health.database.connection.collections) {
-            logger.info(`   - Knowledge Base: ${health.database.connection.collections.knowledgeBase.count}`);
-        }
-    }
-
-    /**
-     * Logs the health status of the server during startup.
-     * @param {Object} health The health check result object.
+     * @summary KB-specific startup status formatting with ChromaDB-tip on unhealthy + collection
+     * stats on degraded/healthy.
+     * @param {Object} health
      */
     logStartupStatus(health) {
         if (health.status === 'unhealthy') {
@@ -150,127 +126,13 @@ class Server extends Base {
     }
 
     /**
-     * Wires up the MCP request handlers for listing and calling tools.
-     * @param {McpServer} mcpServer The target server instance
+     * @summary Collection-count log helper, called from logStartupStatus on degraded/healthy paths.
+     * @param {Object} health
      */
-    setupRequestHandlers(mcpServer) {
-        if (!mcpServer) return;
-
-        // List Tools Handler
-        mcpServer.server.setRequestHandler(ListToolsRequestSchema, async (request) => {
-            try {
-                const {cursor, limit}     = request.params || {};
-                const {tools, nextCursor} = listTools({cursor, limit});
-
-                const mcpTools = tools.map(tool => ({
-                    name        : tool.name,
-                    title       : tool.title,
-                    description : tool.description,
-                    inputSchema : tool.inputSchema,
-                    outputSchema: tool.outputSchema,
-                    annotations : tool.annotations
-                }));
-
-                const result = { tools: mcpTools };
-
-                if (nextCursor) {
-                    result.nextCursor = nextCursor;
-                }
-                return result;
-            } catch (error) {
-                logger.error('[MCP] Error listing tools:', error);
-                return {tools: [], nextCursor: undefined, error: error.message};
-            }
-        });
-
-        // Call Tool Handler
-        mcpServer.server.setRequestHandler(CallToolRequestSchema, async (request) => {
-            const {name, arguments: args} = request.params;
-            const t0 = Date.now();
-
-            try {
-                logger.debug(`[MCP] Calling tool: ${name} with args:`, JSON.stringify(args));
-
-                const exemptFromHealthCheck = ['healthcheck', 'start_database', 'stop_database', 'list_agent_faqs'];
-
-                if (!exemptFromHealthCheck.includes(name)) {
-                    try {
-                        await HealthService.ensureHealthy();
-                    } catch (healthError) {
-                        logger.error(`[MCP] Health check failed for tool ${name}:`, healthError.message);
-                        KBRecorderService.log({
-                            agent_id   : process.env.NEO_AGENT_ID || process.env.USER || 'unknown',
-                            session_id : args?.sessionId || process.env.NEO_SESSION_ID || null,
-                            sequence_id: `${process.env.NEO_AGENT_ID || process.env.USER || 'unknown'}_${t0}`,
-                            timestamp  : t0,
-                            tool       : name,
-                            args,
-                            result     : {error: healthError.message},
-                            success    : false,
-                            duration_ms: Date.now() - t0
-                        });
-
-                        return {
-                            content: [{
-                                type: 'text',
-                                text: `Cannot execute ${name}: ${healthError.message}`
-                            }],
-                            isError: true
-                        };
-                    }
-                }
-
-                const result = await callTool(name, args);
-
-                let contentBlock;
-                let isError           = false;
-                let structuredContent = null;
-
-                if (Neo.isObject(result)) {
-                    isError = 'error' in result;
-
-                    if (isError) {
-                        contentBlock = {
-                            type: 'text',
-                            text: `Tool Error: ${result.error || 'Unknown Error'}. Message: ${result.message || 'No message provided.'}`
-                        };
-                    } else {
-                        contentBlock = {
-                            type: 'text',
-                            text: JSON.stringify(result, null, 2)
-                        };
-                        structuredContent = result;
-                    }
-                } else {
-                    contentBlock = {
-                        type: 'text',
-                        text: typeof result === 'object' ? JSON.stringify(result, null, 2) : String(result)
-                    };
-                    structuredContent = { result };
-                }
-
-                const response = {
-                    content: [contentBlock],
-                    isError
-                };
-
-                if (structuredContent) {
-                    response.structuredContent = structuredContent;
-                }
-
-                return response;
-            } catch (error) {
-                logger.error(`[MCP] Error executing tool ${name}:`, error);
-
-                return {
-                    content: [{
-                        type: 'text',
-                        text: `Error executing ${name}: ${error.message}`
-                    }],
-                    isError: true
-                };
-            }
-        });
+    logCollectionStats(health) {
+        if (health.database.connection.collections) {
+            logger.info(`   - Knowledge Base: ${health.database.connection.collections.knowledgeBase.count}`);
+        }
     }
 }
 

--- a/test/playwright/unit/ai/mcp/server/BaseServer.spec.mjs
+++ b/test/playwright/unit/ai/mcp/server/BaseServer.spec.mjs
@@ -82,6 +82,7 @@ function makeTestServerClass(overrides = {}) {
         getDependentServices()     { return overrides.getDependentServices?.() ?? []; }
         async wrapDispatch(d)      { return overrides.wrapDispatch?.(d) ?? d(); }
         async beforeToolDispatch(ctx) { return overrides.beforeToolDispatch?.(ctx); }
+        async onHealthGateFailure(ctx) { return overrides.onHealthGateFailure?.(ctx); }
     }
     return Neo.setupClass(TestServer);
 }
@@ -359,6 +360,51 @@ test.describe('Neo.ai.mcp.server.BaseServer — setupRequestHandlers wiring', ()
         expect(result.isError).toBe(true);
         // formatToolError shape: "Error executing X: Y" — NOT "Cannot execute X: Y" (that's formatHealthError)
         expect(result.content[0].text).toBe('Error executing sample: Identity spoof rejected');
+    });
+
+    test('onHealthGateFailure hook fires with context (toolName/args/error/t0) before formatHealthError', async () => {
+        const captured = [];
+        const Cls = makeTestServerClass({
+            getHealthService    : () => ({ensureHealthy: async () => { throw new Error('Service down'); }}),
+            onHealthGateFailure : async (ctx) => { captured.push(ctx); }
+        });
+        const server  = Neo.create(Cls);
+        const mockMcp = makeMockMcpServer();
+        server.setupRequestHandlers(mockMcp);
+
+        const t0Before = Date.now();
+        const result   = await mockMcp.getCallToolHandler()({
+            params: {name: 'sample', arguments: {sessionId: 'sess-1', payload: 42}}
+        });
+
+        expect(captured).toHaveLength(1);
+        expect(captured[0].toolName).toBe('sample');
+        expect(captured[0].args).toEqual({sessionId: 'sess-1', payload: 42});
+        expect(captured[0].error.message).toBe('Service down');
+        expect(captured[0].t0).toBeGreaterThanOrEqual(t0Before);
+        expect(captured[0].t0).toBeLessThanOrEqual(Date.now());
+
+        // Hook does NOT change the error envelope shape
+        expect(result.isError).toBe(true);
+        expect(result.content[0].text).toBe('Cannot execute sample: Service down');
+    });
+
+    test('onHealthGateFailure default is no-op (does NOT prevent formatHealthError envelope)', async () => {
+        const Cls = makeTestServerClass({
+            getHealthService: () => ({ensureHealthy: async () => { throw new Error('Service down'); }})
+            // No onHealthGateFailure override — default no-op
+        });
+        const server  = Neo.create(Cls);
+        const mockMcp = makeMockMcpServer();
+        server.setupRequestHandlers(mockMcp);
+
+        const result = await mockMcp.getCallToolHandler()({
+            params: {name: 'sample', arguments: {}}
+        });
+
+        // Behavior identical to without the hook — default-no-op confirmed
+        expect(result.isError).toBe(true);
+        expect(result.content[0].text).toBe('Cannot execute sample: Service down');
     });
 
     test('wrapDispatch override threads context around toolService.callTool', async () => {


### PR DESCRIPTION
Authored by Claude Opus 4.7 (Claude Code). Session 005b6edf-85d8-4980-9e17-486b6b8bed3f.

Refs #10965

PR2 of the M2 series — first per-server consumer of the `BaseServer` scaffold landed via [#10966](https://github.com/neomjs/neo/pull/10966). Validates the abstraction shape against a real consumer before tackling more complex servers.

Evidence: L1 (static syntax + 28 BaseServer unit tests + 21 knowledge-base unit tests all passing locally). L2 not required — substrate-class consumer migration; runtime behavior preserved per healthcheck JSON parity contract (#10965 AC5 + AC8).

## What ships

### `ai/mcp/server/knowledge-base/Server.mjs` migration: 277 → 139 lines (~50% reduction)

**Removed (inherited from BaseServer):**
- `createMcpServer()` — uses `getServerMetadata()` override
- `setupRequestHandlers(mcpServer)` — full ListTools/CallTool/result-formatting boilerplate (~120 lines)
- `initAsync()` boilerplate — uses default canonical sequence
- Transport stdio/sse branching — inherited

**Kept (KB-specific overrides):**
- `logStartupStatus(health)` — KB-flavored output with ChromaDB-tip on unhealthy + collection-stats on degraded/healthy
- `logCollectionStats(health)` — helper

**Added (BaseServer override hooks):**
- `getServerMetadata()` → `{name: 'neo-knowledge-base', version, capabilities}`
- `getToolService()` → `{listTools, callTool}` from `services/toolService.mjs`
- `getDependentServices()` → `[DatabaseService, KBRecorderService]`
- `getHealthService()` → `HealthService`
- `getHealthExemptTools()` → `['healthcheck', 'start_database', 'stop_database', 'list_agent_faqs']`
- `onHealthGateFailure({toolName, args, error, t0})` → KB-specific `KBRecorderService.log` of failed tool dispatch with full telemetry shape preserved

### `ai/mcp/server/BaseServer.mjs` (load-bearing for this migration)

New optional override hook:
```javascript
async onHealthGateFailure({toolName, args, error, t0}) {
    // No-op default
}
```

Fires when the healthcheck gate rejects a tool call, BEFORE the `formatHealthError` envelope is returned. Lets per-server augment with telemetry (e.g., knowledge-base's `KBRecorderService.log` of failed dispatch) without overriding `setupRequestHandlers` wholesale.

Plus `t0 = Date.now()` captured at CallTool handler entry so telemetry can compute `duration_ms = Date.now() - t0`.

### Tests
- `BaseServer.spec.mjs`: 26 → 28 unit tests (2 new for `onHealthGateFailure` — hook fires with correct context shape; default-no-op confirmed; envelope shape unchanged whether hook is overridden or not)
- 21 existing knowledge-base unit specs still pass post-migration

## Why bundle the BaseServer hook addition into PR2?

The `onHealthGateFailure` hook is load-bearing for the knowledge-base migration. Without it, knowledge-base would have to override `setupRequestHandlers` wholesale to preserve its `KBRecorderService.log` telemetry on health-gate failure — defeating the migration's whole purpose. Bundling the hook with the first migration validates the abstraction empirically (does the hook signature actually fit the per-server need?). PR1 shipped scaffold-only; PR2 ships the first iteration with a real consumer + the small abstraction extension that consumer requires.

## Per-server migration sequence

- ✅ **PR1** [#10966](https://github.com/neomjs/neo/pull/10966) — BaseServer scaffold + tests (merged 2026-05-08)
- ✅ **PR2 (this)** — knowledge-base/Server.mjs migration
- 🔜 **PR3** — github-workflow/Server.mjs migration (226 → ~80 LOC target)
- 🔜 **PR4** — neural-link/Server.mjs migration (212 LOC; transport-before-services order — likely surfaces another hook)
- 🔜 **PR5** — memory-core/Server.mjs migration (580 LOC, most complex — stdio identity resolution, sibling-concurrency log, wake substrate)
- 🔜 **PR6** — file-system/Server.mjs migration (149 LOC, Tier-2 local-only)

## Test Evidence

- `node --check ai/mcp/server/BaseServer.mjs` → passed
- `node --check ai/mcp/server/knowledge-base/Server.mjs` → passed
- `npm run test-unit -- test/playwright/unit/ai/mcp/server/BaseServer.spec.mjs` → 28 passed (852ms)
- `npm run test-unit -- test/playwright/unit/ai/mcp/server/knowledge-base/` → 21 passed (1.1s)

## Deltas from ticket

- Bundled the `onHealthGateFailure` hook addition into this PR rather than filing a separate scaffold-extension PR. The hook is load-bearing for the migration's KB-telemetry-preservation contract; iterating the abstraction with a real consumer matched #10965's stated PR-sequence rationale ("each per-server migration may surface design pressure (additional hooks, signature tweaks)").

## Post-Merge Validation

- [ ] Knowledge Base MCP server boots cleanly with the migrated `Server.mjs` extension shape (CI integration row covers this; deployment smoke against a Docker-capable runner confirms).
- [ ] PR3 (github-workflow migration) opens and reveals any further abstraction adjustments.
