### PR TITLE
feat(ai): migrate github-workflow/Server to extend BaseServer (#10965)

### DIFF
--- a/ai/mcp/server/github-workflow/Server.mjs
+++ b/ai/mcp/server/github-workflow/Server.mjs
@@ -1,25 +1,22 @@
-import {McpServer}                                     from '@modelcontextprotocol/sdk/server/mcp.js';
-import {StdioServerTransport}                          from '@modelcontextprotocol/sdk/server/stdio.js';
-import {CallToolRequestSchema, ListToolsRequestSchema} from '@modelcontextprotocol/sdk/types.js';
-import Base                                            from '../../../../src/core/Base.mjs';
-import aiConfig                                        from './config.mjs';
-import logger                                          from './logger.mjs';
-import HealthService                                   from './services/HealthService.mjs';
-import RepositoryService                               from './services/RepositoryService.mjs';
-import SyncService                                     from './services/SyncService.mjs';
-import {listTools, callTool}                           from './services/toolService.mjs';
+import BaseServer            from '../BaseServer.mjs';
+import aiConfig              from './config.mjs';
+import logger                from './logger.mjs';
+import HealthService         from './services/HealthService.mjs';
+import RepositoryService     from './services/RepositoryService.mjs';
+import SyncService           from './services/SyncService.mjs';
+import {listTools, callTool} from './services/toolService.mjs';
 
 /**
  * @summary The GitHub Workflow MCP Server application.
  *
- * Handles initialization, configuration, and lifecycle management for the MCP server.
+ * Handles initialization, configuration, and lifecycle management for the GitHub Workflow MCP server.
  * It sets up the MCP server instance, connects the stdio transport, registers tool handlers,
  * and performs initial health checks and permission validation.
  *
  * @class Neo.ai.mcp.server.github-workflow.Server
- * @extends Neo.core.Base
+ * @extends Neo.ai.mcp.server.BaseServer
  */
-class Server extends Base {
+class Server extends BaseServer {
     static config = {
         /**
          * @member {String} className='Neo.ai.mcp.server.github-workflow.Server'
@@ -28,81 +25,73 @@ class Server extends Base {
         className: 'Neo.ai.mcp.server.github-workflow.Server'
     }
 
-    /**
-     * Path to a custom configuration file.
-     * @member {String|null} configFile=null
-     */
-    configFile = null
-    /**
-     * The MCP Server instance.
-     * @member {McpServer|null} mcpServer=null
-     * @protected
-     */
-    mcpServer = null
-    /**
-     * The Transport instance.
-     * @member {StdioServerTransport|null} transport=null
-     * @protected
-     */
-    transport = null
+    aiConfig = aiConfig
+    logger   = logger
 
     /**
-     * Async initialization sequence.
-     * Replaces the main() function of the previous procedural implementation.
-     * @returns {Promise<void>}
+     * @summary MCP server identity for `createMcpServer()`.
+     * @returns {{name: String, version: String, capabilities: Object}}
      */
-    async initAsync() {
-        await super.initAsync();
-
-        // 1. Load custom configuration if provided
-        if (this.configFile) {
-            try {
-                await aiConfig.load(this.configFile);
-            } catch (error) {
-                logger.error('Failed to load configuration:', error);
-                throw error; // Re-throw to trigger ready() catch block in runner
-            }
-        }
-
-        // 2. Initialize MCP Server instance
-        this.mcpServer = new McpServer({
-            name   : 'neo-github-workflow',
-            version: process.env.npm_package_version || '1.0.0',
-        }, {
+    getServerMetadata() {
+        return {
+            name        : 'neo-github-workflow',
+            version     : process.env.npm_package_version || '1.0.0',
             capabilities: {
-                tools: {
-                    listChanged: false
-                }
+                tools: {listChanged: false}
             }
-        });
-
-        // 3. Setup Request Handlers
-        this.setupRequestHandlers();
-
-        // 4. Perform Health Check & Log Status
-        const health = await HealthService.healthcheck();
-        this.logStartupStatus(health);
-
-        if (health.status !== 'unhealthy') {
-            // Proactively fetch and cache viewer permission
-            await RepositoryService.fetchAndCacheViewerPermission();
-        }
-
-        // 5. Wait for dependent services
-        // SyncService (singleton) might be performing a startup sync. We wait for it to be ready.
-        await SyncService.ready();
-
-        // 6. Connect Transport
-        this.transport = new StdioServerTransport();
-        await this.mcpServer.connect(this.transport);
-
-        logger.info('[neo-github-workflow MCP] Server started on stdio transport');
-        logger.info('[neo-github-workflow MCP] Available tools loaded from OpenAPI spec');
+        };
     }
 
     /**
-     * Logs the health status of the server during startup.
-     * @param {Object} health The health check result object.
+     * @summary Per-server tool registry for ListTools / CallTool dispatch.
+     * @returns {{listTools: Function, callTool: Function}}
+     */
+    getToolService() {
+        return {listTools, callTool};
+    }
+
+    /**
+     * @summary Singleton services to await ready() before transport-connect. SyncService runs
+     * a startup sync against GitHub; we wait for it to settle before announcing the server ready.
+     * @returns {Array<Object>}
+     */
+    getDependentServices() {
+        return [SyncService];
+    }
+
+    /**
+     * @summary HealthService for the healthcheck gate + startup-status logging.
+     * @returns {Object}
+     */
+    getHealthService() {
+        return HealthService;
+    }
+
+    /**
+     * @summary Tools allowed without the healthcheck gate. The github-workflow OpenAPI spec
+     * declares a single canonical `healthcheck` operation; matches the original substring-based
+     * exemption (`name.includes('healthcheck')`) since no other tool name contains it.
+     * @returns {Array<String>}
+     */
+    getHealthExemptTools() {
+        return ['healthcheck'];
+    }
+
+    /**
+     * @summary Post-healthcheck hook: pre-fetches and caches the GitHub viewer permission so
+     * subsequent tool calls don't pay the per-call API cost. Skipped when health is unhealthy
+     * because the underlying `gh` CLI / API is unavailable.
+     * @param {Object} health
+     */
+    async afterHealthcheck(health) {
+        if (health?.status !== 'unhealthy') {
+            await RepositoryService.fetchAndCacheViewerPermission();
+        }
+    }
+
+    /**
+     * @summary github-workflow-specific startup status formatting with `gh` CLI tip on unhealthy.
+     * @param {Object} health
      */
     logStartupStatus(health) {
         if (health.status === 'unhealthy') {
@@ -115,111 +104,6 @@ class Server extends Base {
         } else {
             logger.info('✅ [Startup] GitHub CLI health check passed');
         }
-    }
-
-    /**
-     * Wires up the MCP request handlers for listing and calling tools.
-     */
-    setupRequestHandlers() {
-        // List Tools Handler
-        this.mcpServer.server.setRequestHandler(ListToolsRequestSchema, async (request) => {
-            try {
-                const { cursor, limit } = request.params || {};
-                const { tools, nextCursor } = listTools({ cursor, limit });
-
-                const mcpTools = tools.map(tool => ({
-                    name        : tool.name,
-                    title       : tool.title,
-                    description : tool.description,
-                    inputSchema : tool.inputSchema,
-                    outputSchema: tool.outputSchema,
-                    annotations : tool.annotations
-                }));
-
-                const result = { tools: mcpTools };
-
-                if (nextCursor) {
-                    result.nextCursor = nextCursor;
-                }
-                return result;
-            } catch (error) {
-                return { tools: [], nextCursor: undefined, error: error.message };
-            }
-        });
-
-        // Call Tool Handler
-        this.mcpServer.server.setRequestHandler(CallToolRequestSchema, async (request) => {
-            const { name, arguments: args } = request.params;
-
-            try {
-                logger.debug(`[MCP] Calling tool: ${name} with args:`, JSON.stringify(args));
-
-                if (!name.includes('healthcheck')) {
-                    try {
-                        await HealthService.ensureHealthy();
-                    } catch (healthError) {
-                        logger.error(`[MCP] Health check failed for tool ${name}:`, healthError.message);
-                        return {
-                            content: [{
-                                type: 'text',
-                                text: `Cannot execute ${name}: ${healthError.message}`
-                            }],
-                            isError: true
-                        };
-                    }
-                }
-
-                const result = await callTool(name, args);
-
-                let contentBlock;
-                let isError           = false;
-                let structuredContent = null;
-
-                if (Neo.isObject(result)) {
-                    isError = 'error' in result;
-
-                    if (isError) {
-                        contentBlock = {
-                            type: 'text',
-                            text: `Tool Error: ${result.error || 'Unknown Error'}. Message: ${result.message || 'No message provided.'}`
-                        };
-                    } else {
-                        contentBlock = {
-                            type: 'text',
-                            text: JSON.stringify(result, null, 2)
-                        };
-                        structuredContent = result;
-                    }
-                } else {
-                    contentBlock = {
-                        type: 'text',
-                        text: typeof result === 'object' ? JSON.stringify(result, null, 2) : String(result)
-                    };
-                    structuredContent = { result };
-                }
-
-                const response = {
-                    content: [contentBlock],
-                    isError
-                };
-
-                if (structuredContent) {
-                    response.structuredContent = structuredContent;
-                }
-
-                return response;
-            } catch (error) {
-                logger.error(`[MCP] Error executing tool ${name}:`, error);
-
-                return {
-                    content: [{
-                        type: 'text',
-                        text: `Error executing ${name}: ${error.message}`
-                    }],
-                    isError: true
-                };
-            }
-        });
     }
 }
 


### PR DESCRIPTION
Authored by Claude Opus 4.7 (Claude Code). Session 005b6edf-85d8-4980-9e17-486b6b8bed3f.

Refs #10965

PR3 of the M2 series — third per-server consumer of the BaseServer scaffold (after PR1 [#10966](https://github.com/neomjs/neo/pull/10966) merged and PR2 [#10973](https://github.com/neomjs/neo/pull/10973) in review).

Evidence: L1 (static syntax + 39 existing github-workflow unit tests all passing locally in 1.6s).

## What ships

### `ai/mcp/server/github-workflow/Server.mjs` migration: 226 → 110 lines (~51% reduction)

**Removed (inherited from BaseServer):**
- `setupRequestHandlers()` — full ListTools/CallTool/result-formatting boilerplate (~100 lines)
- `initAsync()` boilerplate — uses default canonical sequence
- Inline `mcpServer` construction → uses BaseServer `createMcpServer()` driven by `getServerMetadata()`
- Transport stdio connect — inherited

**Kept (github-workflow-specific overrides):**
- `logStartupStatus(health)` — gh-CLI-tip on unhealthy + degraded/healthy paths
- `afterHealthcheck(health)` — conditionally pre-fetches + caches GitHub viewer permission when health is not unhealthy

**Added (BaseServer override hooks):**
- `getServerMetadata()` → `{name: 'neo-github-workflow', version, capabilities}`
- `getToolService()` → `{listTools, callTool}` from `services/toolService.mjs`
- `getDependentServices()` → `[SyncService]`
- `getHealthService()` → `HealthService`
- `getHealthExemptTools()` → `['healthcheck']`

## Cleaner than PR2

PR2 (knowledge-base) needed a new BaseServer hook (`onHealthGateFailure`) for KBRecorderService telemetry preservation. PR3 (github-workflow) needs **no new hooks** — the existing override surface covers all per-server semantics:

- Health-exempt list: github-workflow openapi.yaml declares one canonical `/healthcheck` operation; `getHealthExemptTools()` returning `['healthcheck']` is equivalent to the original substring match (`name.includes('healthcheck')`).
- Permission-fetch order: `afterHealthcheck(health)` hook fires after healthcheck and before `connectTransport`; preserves the original `if (health.status !== 'unhealthy') { await RepositoryService.fetchAndCacheViewerPermission(); }` semantic exactly.

This validates that the abstraction designed in PR1 holds up across consumers with different telemetry-shape requirements.

## Per-server migration sequence

- ✅ **PR1** [#10966](https://github.com/neomjs/neo/pull/10966) — BaseServer scaffold + tests (merged)
- 🔄 **PR2** [#10973](https://github.com/neomjs/neo/pull/10973) — knowledge-base/Server.mjs migration (in review)
- 🆕 **PR3 (this)** — github-workflow/Server.mjs migration
- 🔜 **PR4** — neural-link/Server.mjs migration (212 LOC; transport-before-services order — likely surfaces another hook)
- 🔜 **PR5** — memory-core/Server.mjs migration (580 LOC, most complex — stdio identity resolution, sibling-concurrency log, wake substrate)
- 🔜 **PR6** — file-system/Server.mjs migration (149 LOC, Tier-2 local-only)

## Test Evidence

- `node --check ai/mcp/server/github-workflow/Server.mjs` → passed
- `npm run test-unit -- test/playwright/unit/ai/mcp/server/github-workflow/ --reporter=list` → 39 passed (1.6s)

## Coordination Notes

- This PR depends on PR1 (#10966 BaseServer scaffold, merged in `dev`). Independent of PR2 — github-workflow doesn't need the `onHealthGateFailure` hook PR2 adds.
- If PR2 lands first, PR3 has access to the additional hook (unused, harmless). If PR3 lands first, PR2's hook addition still applies cleanly to its branch.

## Post-Merge Validation

- [ ] github-workflow MCP server boots cleanly with the migrated `Server.mjs` extension shape (CI integration row covers; deployment smoke against a Docker-capable runner confirms).
