### PR TITLE
feat(ai): migrate neural-link/Server to extend BaseServer + boot() seam (#10965)

### DIFF
--- a/ai/mcp/server/BaseServer.mjs
+++ b/ai/mcp/server/BaseServer.mjs
@@ -455,14 +455,29 @@ class BaseServer extends Base {
     }
 
     /**
-     * @summary Default canonical async initialization sequence. Subclasses with more complex
-     * bootstrap (e.g. memory-core, neural-link) may override and compose the protected
-     * building blocks in a different order.
+     * @summary Async initialization. Chains into `Neo.core.Base.initAsync()`, then delegates
+     * the boot orchestration to `boot()`. Subclasses should override `boot()` (NOT `initAsync`)
+     * when they need a non-canonical bootstrap order — that keeps the Base class chain
+     * (e.g., reactive config init) wired correctly while letting the subclass freely compose
+     * the protected building blocks (`loadCustomConfig`, `createMcpServer`,
+     * `waitForDependentServices`, `runHealthcheckAndLogStatus`, `connectTransport`).
      * @returns {Promise<void>}
      */
     async initAsync() {
         await super.initAsync();
+        await this.boot();
+    }
 
+    /**
+     * @summary Default canonical bootstrap sequence. Subclasses with custom bootstrap order
+     * (e.g. neural-link's transport-before-services for early MCP-handshake handling, or
+     * memory-core's stdio-identity-resolution between dependent-services and healthcheck)
+     * override this method and call the building blocks (`loadCustomConfig`, `createMcpServer`,
+     * etc.) in their own order. Override does NOT need to call `super.boot()` — the Base
+     * init chain is already handled by `initAsync()`.
+     * @returns {Promise<void>}
+     */
+    async boot() {
         await this.loadCustomConfig();
         await this.beforeMcpServerInit();
 

--- a/ai/mcp/server/neural-link/Server.mjs
+++ b/ai/mcp/server/neural-link/Server.mjs
@@ -1,22 +1,27 @@
-import {McpServer}                                     from '@modelcontextprotocol/sdk/server/mcp.js';
-import {StdioServerTransport}                          from '@modelcontextprotocol/sdk/server/stdio.js';
-import {CallToolRequestSchema, ListToolsRequestSchema} from '@modelcontextprotocol/sdk/types.js';
-import Base                                            from '../../../../src/core/Base.mjs';
-import aiConfig                                        from './config.mjs';
-import logger                                          from './logger.mjs';
-import ConnectionService                               from './services/ConnectionService.mjs';
-import HealthService                                   from './services/HealthService.mjs';
-import {listTools, callTool}                           from './services/toolService.mjs';
+import BaseServer            from '../BaseServer.mjs';
+import aiConfig              from './config.mjs';
+import logger                from './logger.mjs';
+import ConnectionService     from './services/ConnectionService.mjs';
+import HealthService         from './services/HealthService.mjs';
+import {listTools, callTool} from './services/toolService.mjs';
 
 let _turnId = 0;
 
 export const getCurrentTurnId = () => _turnId;
 
 /**
+ * @summary The Neural Link MCP Server application.
+ *
+ * Bridges AI agents to the live browser application via WebSocket. Uses a non-canonical
+ * bootstrap order: the stdio MCP transport is connected EARLY (before `ConnectionService`
+ * is awaited) so the MCP client handshake succeeds even when the Bridge process is down or
+ * still spawning. The Bridge readiness then proceeds asynchronously while the server is
+ * already responsive to MCP-side health and tool inquiries.
+ *
  * @class Neo.ai.mcp.server.neural-link.Server
- * @extends Neo.core.Base
+ * @extends Neo.ai.mcp.server.BaseServer
  */
-class Server extends Base {
+class Server extends BaseServer {
     static config = {
         /**
          * @member {String} className='Neo.ai.mcp.server.neural-link.Server'
@@ -25,78 +30,109 @@ class Server extends Base {
         className: 'Neo.ai.mcp.server.neural-link.Server'
     }
 
+    aiConfig = aiConfig
+    logger   = logger
+
     /**
+     * Bridge daemon working directory; passed via CLI / env. When set, propagated to
+     * `ConnectionService.cwd` before its `ready()` is awaited so the Bridge spawn uses the
+     * correct working tree.
      * @member {String|null} bridgeCwd=null
      */
     bridgeCwd = null
-    /**
-     * Path to a custom configuration file.
-     * @member {String|null} configFile=null
-     */
-    configFile = null
-    /**
-     * @member {McpServer|null} mcpServer=null
-     */
-    mcpServer = null
-    /**
-     * @member {StdioServerTransport|null} transport=null
-     */
-    transport = null
 
-    async initAsync() {
-        await super.initAsync();
-
-        // 1. Load custom configuration if provided
-        if (this.configFile) {
-            try {
-                await aiConfig.load(this.configFile);
-            } catch (error) {
-                logger.error('Failed to load configuration:', error);
-                throw error;
-            }
-        }
-
-        // 2. Initialize MCP Server
-        this.mcpServer = new McpServer({
-            name: 'neo-neural-link',
-            version: '1.0.0'
-        }, {
+    /**
+     * @summary MCP server identity for `createMcpServer()`.
+     * @returns {{name: String, capabilities: Object}}
+     */
+    getServerMetadata() {
+        return {
+            name        : 'neo-neural-link',
+            version     : '1.0.0',
             capabilities: {
-                tools: { listChanged: false }
+                tools: {listChanged: false}
             }
-        });
+        };
+    }
 
-        // 3. Setup Handlers
-        this.setupRequestHandlers();
+    /**
+     * @summary Per-server tool registry for ListTools / CallTool dispatch. Increments the
+     * module-level `_turnId` counter on every CallTool dispatch (consumed by `getCurrentTurnId()`
+     * for transcript-correlation).
+     * @returns {{listTools: Function, callTool: Function}}
+     */
+    getToolService() {
+        return {
+            listTools,
+            callTool: async (name, args) => {
+                _turnId++;
+                return callTool(name, args);
+            }
+        };
+    }
 
-        // 4. Connect Transport (Stdio)
-        // We connect early to ensure the MCP client handshake succeeds even if the Bridge is down.
-        this.transport = new StdioServerTransport();
-        await this.mcpServer.connect(this.transport);
-        logger.info('Neural Link MCP Server transport connected');
+    /**
+     * @summary HealthService for the healthcheck gate + startup-status logging.
+     * @returns {Object}
+     */
+    getHealthService() {
+        return HealthService;
+    }
 
-        // 5. Wait for Connection Service
-        // This might take time if spawning a new Bridge process
+    /**
+     * @summary Tools allowed without the healthcheck gate. `manage_connection` runs while the
+     * Bridge is unhealthy by design — it's the operator's recovery path.
+     * @returns {Array<String>}
+     */
+    getHealthExemptTools() {
+        return ['healthcheck', 'manage_connection'];
+    }
+
+    /**
+     * @summary Custom boot order (override of `BaseServer.boot`): transport connects EARLY
+     * so MCP-client handshake succeeds even when the Bridge is down or still spawning. The
+     * canonical order would await `ConnectionService.ready()` before `connectTransport()`,
+     * which would race against MCP clients trying to connect during Bridge spawn.
+     *
+     * Sequence:
+     * 1. Load custom config
+     * 2. Construct mcpServer + wire request handlers
+     * 3. Connect stdio transport (early — handshake-tolerance for Bridge-down scenarios)
+     * 4. Await ConnectionService.ready (non-fatal: logged but doesn't throw, so the server
+     *    stays alive to report health errors via the MCP healthcheck tool)
+     * 5. Healthcheck + startup-status log
+     *
+     * @returns {Promise<void>}
+     */
+    async boot() {
+        await this.loadCustomConfig();
+
+        this.mcpServer = this.createMcpServer();
+
+        // Connect transport EARLY — see method JSDoc for rationale (#10455 lineage).
+        await this.connectTransport();
+        this.logger.info('Neural Link MCP Server transport connected');
+
+        // ConnectionService — set cwd then ready, with non-fatal error tolerance.
         try {
             if (this.bridgeCwd) {
                 ConnectionService.cwd = this.bridgeCwd;
             }
             await ConnectionService.ready();
         } catch (e) {
-            logger.error('ConnectionService failed to initialize:', e);
-            // We do not throw here, so the server stays alive to report health errors
+            this.logger.error('ConnectionService failed to initialize:', e);
+            // Do not throw — server stays alive to report health errors via MCP healthcheck.
         }
 
-        // 6. Perform Health Check & Log Status
-        const health = await HealthService.healthcheck();
-        this.logStartupStatus(health);
+        await this.runHealthcheckAndLogStatus();
 
-        logger.info('Neural Link MCP Server started');
+        this.logger.info('Neural Link MCP Server started');
     }
 
     /**
-     * Logs the health status of the server during startup.
-     * @param {Object} health The health check result object.
+     * @summary neural-link-specific startup status formatting with session + window counts on
+     * healthy paths.
+     * @param {Object} health
      */
     logStartupStatus(health) {
         if (health.status === 'unhealthy') {
@@ -107,105 +143,6 @@ class Server extends Base {
             logger.info(`   - Active Sessions: ${health.sessions.length}`);
             logger.info(`   - Connected Windows: ${health.windows.length}`);
         }
-    }
-
-    setupRequestHandlers() {
-        // List Tools Handler
-        this.mcpServer.server.setRequestHandler(ListToolsRequestSchema, async (request) => {
-            try {
-                const { cursor, limit } = request.params || {};
-                const { tools, nextCursor } = listTools({ cursor, limit });
-
-                const mcpTools = tools.map(tool => ({
-                    name        : tool.name,
-                    title       : tool.title,
-                    description : tool.description,
-                    inputSchema : tool.inputSchema,
-                    outputSchema: tool.outputSchema,
-                    annotations : tool.annotations
-                }));
-
-                return { tools: mcpTools, nextCursor: nextCursor || undefined };
-            } catch (error) {
-                logger.error('[MCP] Error listing tools:', error);
-                return { tools: [], nextCursor: undefined, error: error.message };
-            }
-        });
-
-        // Call Tool Handler
-        this.mcpServer.server.setRequestHandler(CallToolRequestSchema, async (request) => {
-            _turnId++;
-            const { name, arguments: args } = request.params;
-
-            try {
-                logger.debug(`[MCP] Calling tool: ${name} with params:`, JSON.stringify(request.params));
-
-                // Health Check Gate
-                const exemptFromHealthCheck = ['healthcheck', 'manage_connection'];
-
-                if (!exemptFromHealthCheck.includes(name)) {
-                    const health = await HealthService.healthcheck();
-                    if (health.status !== 'healthy') {
-                        return {
-                            content: [{
-                                type: 'text',
-                                text: `Cannot execute ${name}: Neural Link is unhealthy.\nDetails: ${health.details.join(', ')}`
-                            }],
-                            isError: true
-                        };
-                    }
-                }
-
-                const result = await callTool(name, args);
-
-                let contentBlock;
-                let isError           = false;
-                let structuredContent = null;
-
-                if (Neo.isObject(result)) {
-                    isError = 'error' in result;
-
-                    if (isError) {
-                        contentBlock = {
-                            type: 'text',
-                            text: `Tool Error: ${result.error || 'Unknown Error'}. Message: ${result.message || 'No message provided.'}`
-                        };
-                    } else {
-                        contentBlock = {
-                            type: 'text',
-                            text: JSON.stringify(result, null, 2)
-                        };
-                        structuredContent = result;
-                    }
-                } else {
-                    contentBlock = {
-                        type: 'text',
-                        text: typeof result === 'object' ? JSON.stringify(result, null, 2) : String(result)
-                    };
-                    structuredContent = { result };
-                }
-
-                const response = {
-                    content: [contentBlock],
-                    isError
-                };
-
-                if (structuredContent) {
-                    response.structuredContent = structuredContent;
-                }
-
-                return response;
-            } catch (error) {
-                logger.error(`[MCP] Error executing tool ${name}:`, error);
-                return {
-                    content: [{
-                        type: 'text',
-                        text: `Error: ${error.message}`
-                    }],
-                    isError: true
-                };
-            }
-        });
     }
 }
 

--- a/test/playwright/unit/ai/mcp/server/BaseServer.spec.mjs
+++ b/test/playwright/unit/ai/mcp/server/BaseServer.spec.mjs
@@ -348,6 +348,49 @@ test.describe('Neo.ai.mcp.server.BaseServer — setupRequestHandlers wiring', ()
 });
 
 test.describe('Neo.ai.mcp.server.BaseServer — initAsync canonical sequence', () => {
+    test('subclass overrides boot() to skip canonical sequence', async () => {
+        const calls = [];
+        const id    = ++_testClassCounter;
+        class CustomBootServer extends BaseServer {
+            static config = {className: `Neo.test.mcp.server.CustomBootServer${id}`}
+
+            getServerMetadata() { return {name: 'neo-custom'}; }
+            getToolService()    { return {listTools: () => ({tools: []}), callTool: async () => null}; }
+
+            // Custom boot order: only loadCustomConfig + connectTransport, no canonical
+            async boot() {
+                calls.push('custom-boot-start');
+                await this.loadCustomConfig();
+                calls.push('between-blocks');
+                await this.connectTransport();
+                calls.push('custom-boot-end');
+            }
+
+            // Stubs for the building blocks the override DOES use
+            async loadCustomConfig() { calls.push('loadCustomConfig'); }
+            async connectTransport() { calls.push('connectTransport'); }
+
+            // Stubs for canonical-sequence blocks that should NOT fire
+            async beforeMcpServerInit()      { calls.push('beforeMcpServerInit-SHOULD-NOT-FIRE'); }
+            createMcpServer()                { calls.push('createMcpServer-SHOULD-NOT-FIRE'); return {server: {setRequestHandler: () => {}}}; }
+            async waitForDependentServices() { calls.push('waitForDependentServices-SHOULD-NOT-FIRE'); }
+            async runHealthcheckAndLogStatus() { calls.push('runHealthcheck-SHOULD-NOT-FIRE'); return null; }
+        }
+
+        const Cls    = Neo.setupClass(CustomBootServer);
+        const server = Neo.create(Cls);
+        await server.ready();
+
+        // Only the building blocks the custom boot calls should fire
+        expect(calls).toEqual([
+            'custom-boot-start',
+            'loadCustomConfig',
+            'between-blocks',
+            'connectTransport',
+            'custom-boot-end'
+        ]);
+    });
+
     test('default initAsync calls hooks in canonical order (no health, no transport)', async () => {
         const calls = [];
         const id    = ++_testClassCounter;


### PR DESCRIPTION
Authored by Claude Opus 4.7 (Claude Code). Session 005b6edf-85d8-4980-9e17-486b6b8bed3f.

Refs #10965

PR4 of the M2 series — fourth per-server consumer of the BaseServer scaffold. **Validates the abstraction against a custom-bootstrap-order consumer** (transport-before-services), the case predicted in #10965 to surface design pressure.

Evidence: L1 (static syntax + 27 BaseServer unit tests + 7 neural-link unit tests all passing locally).

## What ships

### `ai/mcp/server/BaseServer.mjs` — `boot()` as overridable seam

`initAsync()` factored to chain `super.initAsync()` + delegate to `boot()`. `boot()` contains the canonical bootstrap sequence and is the override-point for subclasses needing custom order.

- **Backwards-compatible:** existing canonical consumers (knowledge-base PR2 [#10973](https://github.com/neomjs/neo/pull/10973), github-workflow PR3 [#10974](https://github.com/neomjs/neo/pull/10974)) inherit `boot()` unchanged. No diff to those branches needed.
- **Forward-compatible:** memory-core (PR5 forthcoming) will also override `boot()` for its complex stdio-identity-resolution + sibling-concurrency-log + wake-substrate sequence.
- **Why factor `boot()` not `initAsync()`:** `initAsync()` chains via `super.initAsync()` into Neo's `Base.initAsync()` for class-system-level init. Subclasses overriding `initAsync()` and skipping `super.initAsync()` would break the Neo lifecycle. Factoring the bootstrap sequence into a separate `boot()` method preserves the `super` chain while exposing a clean override seam.

### `ai/mcp/server/neural-link/Server.mjs` migration: 212 → 149 lines (~30% reduction)

Less reduction than PR2/PR3 (which were ~50%) because neural-link has irreducible per-server complexity:
- Custom boot order (transport-before-services)
- `getCurrentTurnId()` module-level export consumed by transcript-correlation
- `bridgeCwd` member for `ConnectionService.cwd` assignment

**Custom `boot()` override** (preserved semantic from existing code):
1. `loadCustomConfig()` — standard
2. `createMcpServer()` — standard
3. `connectTransport()` **EARLY** — before ConnectionService. Existing comment: *"We connect early to ensure the MCP client handshake succeeds even if the Bridge is down."* Canonical order would race ConnectionService.ready against client connections during Bridge spawn.
4. `ConnectionService.ready()` with try/catch — non-fatal failure (server stays alive to report via MCP healthcheck tool)
5. `runHealthcheckAndLogStatus()` — standard

**`getToolService()` override** wraps `callTool` to increment `_turnId` per dispatch (preserves the existing transcript-correlation mechanism).

## Tests

- `BaseServer.spec.mjs`: 26 → 27 unit tests; new test for `boot()` override scenario verifies subclass override skips canonical sequence cleanly (`SHOULD-NOT-FIRE` markers on the building blocks confirm only the override-invoked blocks run)
- All 7 existing neural-link unit specs pass post-migration (961ms)
- `node --check` clean on all 3 modified files

## Per-server migration sequence

- ✅ **PR1** [#10966](https://github.com/neomjs/neo/pull/10966) — BaseServer scaffold + tests (merged)
- 🔄 **PR2** [#10973](https://github.com/neomjs/neo/pull/10973) — knowledge-base/Server.mjs (in review by Gemini)
- 🔄 **PR3** [#10974](https://github.com/neomjs/neo/pull/10974) — github-workflow/Server.mjs (in review by GPT)
- 🆕 **PR4 (this)** — neural-link/Server.mjs migration + `boot()` seam
- 🔜 **PR5** — memory-core/Server.mjs migration (580 LOC, most complex — stdio identity resolution, sibling-concurrency log, wake substrate; will use the `boot()` seam introduced here)
- 🔜 **PR6** — file-system/Server.mjs migration (149 LOC, Tier-2 local-only)

## Coordination Notes

- **Independent of PR2 + PR3:** the `boot()` seam is a backwards-compatible refactor; PR2's `onHealthGateFailure` hook addition is orthogonal; PR3 doesn't touch BaseServer at all.
- **PR5 (memory-core) will benefit from this seam** — predicted in #10965 PR plan, validated empirically here.

## Test Evidence

- `node --check ai/mcp/server/BaseServer.mjs` → passed
- `node --check ai/mcp/server/neural-link/Server.mjs` → passed
- `npm run test-unit -- test/playwright/unit/ai/mcp/server/BaseServer.spec.mjs` → 27 passed (866ms)
- `npm run test-unit -- test/playwright/unit/ai/mcp/server/neural-link/` → 7 passed (961ms)

## Post-Merge Validation

- [ ] Neural Link MCP server boots cleanly with the migrated `Server.mjs` extension shape (CI integration row covers; deployment smoke against a Docker-capable runner confirms — but neural-link is local-bridge-oriented so primary validation is local boot).
- [ ] PR5 (memory-core) opens and uses the `boot()` seam for its complex bootstrap order.
