### PR TITLE
feat(ai): migrate file-system/Server to extend BaseServer (#10965)

### DIFF
--- a/ai/mcp/server/file-system/Server.mjs
+++ b/ai/mcp/server/file-system/Server.mjs
@@ -1,148 +1,60 @@
-import {McpServer}                                     from '@modelcontextprotocol/sdk/server/mcp.js';
-import {CallToolRequestSchema, ListToolsRequestSchema} from '@modelcontextprotocol/sdk/types.js';
-import Base                                            from '../../../../src/core/Base.mjs';
-import {listTools, callTool}                           from './services/toolService.mjs';
+import BaseServer            from '../BaseServer.mjs';
+import {listTools, callTool} from './services/toolService.mjs';
+
+/**
+ * @summary Minimal stderr-only logger shim for file-system MCP server. Routes all log levels
+ * to `console.error` so log output never collides with the stdio MCP protocol channel
+ * (stdout). file-system has no dedicated logger module — unlike the cloud-native Tier-1
+ * servers — so this shim provides the BaseServer-expected logger interface.
+ */
+const stderrLogger = {
+    debug: () => {},
+    info : (...args) => console.error(...args),
+    warn : (...args) => console.error(...args),
+    error: (...args) => console.error(...args)
+};
 
 /**
  * @summary The File System MCP Server application.
  *
- * Handles initialization, configuration, and lifecycle management for the file-system MCP server.
  * Provides restricted, sandboxed file operations and execution feedback for agents.
+ * Tier-2 local-only server (gemma4-style local-agent surface) — NOT a deployment target.
+ * Stdio transport only; no aiConfig load, no health service, no dependent services.
  *
- * @class Neo.ai.mcp.server.fileSystem.Server
- * @extends Neo.core.Base
+ * @class Neo.ai.mcp.server.file-system.Server
+ * @extends Neo.ai.mcp.server.BaseServer
  */
-class Server extends Base {
+class Server extends BaseServer {
     static config = {
         /**
-         * @member {String} className='Neo.ai.mcp.server.fileSystem.Server'
+         * @member {String} className='Neo.ai.mcp.server.file-system.Server'
          * @protected
          */
-        className: 'Neo.ai.mcp.server.fileSystem.Server'
+        className: 'Neo.ai.mcp.server.file-system.Server'
     }
 
-    /**
-     * The MCP Server instance.
-     * @member {McpServer|null} mcpServer=null
-     * @protected
-     */
-    mcpServer = null
+    logger = stderrLogger
 
     /**
-     * Async initialization sequence.
-     * @returns {Promise<void>}
+     * @summary MCP server identity for `createMcpServer()`.
+     * @returns {{name: String, version: String, capabilities: Object}}
      */
-    async initAsync() {
-        await super.initAsync();
-
-        // 1. Initialize MCP Server instance
-        this.mcpServer = new McpServer({
-            name   : 'neo-file-system',
-            version: process.env.npm_package_version || '1.0.0',
-        }, {
+    getServerMetadata() {
+        return {
+            name        : 'neo-file-system',
+            version     : process.env.npm_package_version || '1.0.0',
             capabilities: {
-                tools: {
-                    listChanged: false
-                }
+                tools: {listChanged: false}
             }
-        });
-
-        // 2. Setup Request Handlers
-        this.setupRequestHandlers();
-
-        // 3. Connect Transport (Only stdio supported for file-system currently)
-        const {StdioServerTransport} = await import('@modelcontextprotocol/sdk/server/stdio.js');
-        const transport = new StdioServerTransport();
-        await this.mcpServer.connect(transport);
-
-        console.error('[neo-file-system MCP] Server started on stdio transport');
+        };
     }
 
     /**
-     * Wires up the MCP request handlers for listing and calling tools.
+     * @summary Per-server tool registry for ListTools / CallTool dispatch.
+     * @returns {{listTools: Function, callTool: Function}}
      */
-    setupRequestHandlers() {
-        // List Tools Handler
-        this.mcpServer.server.setRequestHandler(ListToolsRequestSchema, async (request) => {
-            try {
-                const {cursor, limit}     = request.params || {};
-                const {tools, nextCursor} = listTools({cursor, limit});
-
-                const mcpTools = tools.map(tool => ({
-                    name        : tool.name,
-                    title       : tool.title,
-                    description : tool.description,
-                    inputSchema : tool.inputSchema,
-                    outputSchema: tool.outputSchema,
-                    annotations : tool.annotations
-                }));
-
-                const result = { tools: mcpTools };
-
-                if (nextCursor) {
-                    result.nextCursor = nextCursor;
-                }
-                return result;
-            } catch (error) {
-                console.error('[MCP] Error listing tools:', error);
-                return {tools: [], nextCursor: undefined, error: error.message};
-            }
-        });
-
-        // Call Tool Handler
-        this.mcpServer.server.setRequestHandler(CallToolRequestSchema, async (request) => {
-            const {name, arguments: args} = request.params;
-
-            try {
-                const result = await callTool(name, args);
-
-                let contentBlock;
-                let isError           = false;
-                let structuredContent = null;
-
-                if (Neo.isObject(result)) {
-                    isError = 'error' in result;
-
-                    if (isError) {
-                        contentBlock = {
-                            type: 'text',
-                            text: `Tool Error: ${result.error || 'Unknown Error'}. Message: ${result.message || 'No message provided.'}`
-                        };
-                    } else {
-                        contentBlock = {
-                            type: 'text',
-                            text: JSON.stringify(result, null, 2)
-                        };
-                        structuredContent = result;
-                    }
-                } else {
-                    contentBlock = {
-                        type: 'text',
-                        text: typeof result === 'object' ? JSON.stringify(result, null, 2) : String(result)
-                    };
-                    structuredContent = { result };
-                }
-
-                const response = {
-                    content: [contentBlock],
-                    isError
-                };
-
-                if (structuredContent) {
-                    response.structuredContent = structuredContent;
-                }
-
-                return response;
-            } catch (error) {
-                return {
-                    content: [{
-                        type: 'text',
-                        text: `Error executing ${name}: ${error.message}`
-                    }],
-                    isError: true
-                };
-            }
-        });
+    getToolService() {
+        return {listTools, callTool};
     }
 }
 


### PR DESCRIPTION
Authored by Claude Opus 4.7 (Claude Code). Session 005b6edf-85d8-4980-9e17-486b6b8bed3f.

Refs #10965

PR6 of six M2 PRs (one of five per-server consumer migrations; PR1 was the BaseServer scaffold, not a consumer). file-system migration; Tier-2 local-only server (gemma4-style local-agent surface, NOT a deployment target per #10965 server inventory). Sequence completes when this **plus** PR5 ([#10977](https://github.com/neomjs/neo/pull/10977)) both land.

Evidence: L1 (static syntax check on the migrated file). No unit specs exist for file-system (no test/playwright/unit/ai/mcp/server/file-system directory).

## What ships

### `ai/mcp/server/file-system/Server.mjs` migration: 149 → 61 lines (~60% reduction — biggest of the M2 migrations)

**Why the largest reduction:** file-system has no:
- `aiConfig` (no runtime config to load)
- dedicated `logger` module
- `HealthService`
- dependent services
- SSE transport

It's the simplest of the 5 servers — just 2 required override hooks (`getServerMetadata`, `getToolService`) and a 5-line `stderrLogger` shim.

### `stderrLogger` shim

```javascript
const stderrLogger = {
    debug: () => {},
    info : (...args) => console.error(...args),
    warn : (...args) => console.error(...args),
    error: (...args) => console.error(...args)
};
```

Routes all log levels to `console.error`. Required because:
- file-system has no dedicated logger module (unlike Tier-1 servers which import `./logger.mjs`)
- BaseServer's default canonical sequence calls `this.logger?.info?.(...)` for "Server started" messages
- stdio MCP protocol requires log output on stderr — stdout is the JSON-RPC channel, contamination would break the protocol

The shim provides the BaseServer-expected logger interface while preserving file-system's existing console.error-only behavior.

## Per-server migration sequence — current state

- ✅ **PR1** [#10966](https://github.com/neomjs/neo/pull/10966) — BaseServer scaffold + tests (merged)
- ✅ **PR2** [#10973](https://github.com/neomjs/neo/pull/10973) — knowledge-base (Gemini approved; eligible-for-merge)
- ✅ **PR3** [#10974](https://github.com/neomjs/neo/pull/10974) — github-workflow (GPT approved; eligible-for-merge)
- ✅ **PR4** [#10975](https://github.com/neomjs/neo/pull/10975) — neural-link + `boot()` seam (Gemini approved; eligible-for-merge)
- 🔄 **PR5** [#10977](https://github.com/neomjs/neo/pull/10977) — memory-core + `beforeToolDispatch` hook (in review by Gemini)
- 🆕 **PR6 (this)** — file-system migration (in review by GPT)

**M2 substrate is fully complete only after both PR5 and PR6 land in `dev`.** Once that happens, all 5 MCP servers extend `BaseServer` uniformly and M6 SDK migration becomes unblocked downstream.

## Tier-2 vs Tier-1 distinction (per #10965)

file-system is the only Tier-2 server: local-only, NOT a deployment target. Migrating it for **substrate consistency** — uniform base class across all 5 servers, lower per-server-author cognitive load. M6 SDK migration scope remains Tier-1-only.

## Test Evidence

- `node --check ai/mcp/server/file-system/Server.mjs` → passed
- No existing unit specs for file-system (no test/playwright/unit/ai/mcp/server/file-system directory) — migration is structural-only, semantic-equivalence verified by static audit + the BaseServer abstraction's invariants (the same invariants validated empirically by PR1's 26-test suite + PR2's KB-spec parity + PR3's github-workflow-spec parity + PR4's neural-link-spec parity).

## Coordination Notes

- **Independent of PR2-PR5:** file-system uses BaseServer's default canonical sequence (no `boot()` override needed, no `onHealthGateFailure` needed, no `beforeToolDispatch` needed). Lands cleanly regardless of merge order across the M2 series.
- **stderrLogger shim** is local to file-system Server.mjs — could be promoted to `shared/helpers/` if a future Tier-2 server needs the same pattern, but YAGNI for now.

## Cycle 1 → Cycle 2 (correction per @neo-gpt's review)

**Original PR body** claimed "M2 per-server migration sequence — M2 complete" while explicitly listing PR5 (memory-core) as pending. That was rhetorical drift / overclaim — flagged correctly as `feedback_verify_written_claims_against_precedent`-shape miss. Body corrected to accurately frame PR6 as one of six in-flight migrations; M2 series complete only after both PR5+PR6 land.

The code path itself was validated clean in Cycle 1 — no code rework needed.

## Post-Merge Validation

- [ ] file-system MCP server boots cleanly with the migrated `Server.mjs` extension shape (validated locally by `npm run ai:mcp-server-file-system` if needed; no CI integration row covers Tier-2 servers).
