### PR TITLE
feat(ai): migrate memory-core/Server to extend BaseServer + beforeToolDispatch hook (#10965)

### DIFF
--- a/ai/mcp/server/BaseServer.mjs
+++ b/ai/mcp/server/BaseServer.mjs
@@ -183,6 +183,21 @@ class BaseServer extends Base {
         // No-op default
     }
 
+    /**
+     * @summary Override (optional): pre-dispatch validation hook fired BEFORE the healthcheck
+     * gate. Throw to reject the request — the outer CallTool try/catch routes the error to
+     * `formatToolError`. Used by memory-core for `AuthMiddleware.validateNoIdentitySpoof(args)`
+     * which must fail-fast on identity-spoofing requests before any other processing.
+     * Default no-op.
+     *
+     * @param {Object} context
+     * @param {String} context.toolName The MCP tool name being invoked.
+     * @param {Object} context.args     The arguments passed to the tool call.
+     */
+    async beforeToolDispatch(context) {
+        // No-op default
+    }
+
     // ===== Optional lifecycle hooks (composable, no-op by default) =====
 
     /** @summary Hook fired before `createMcpServer()` runs in default `initAsync` sequence. */
@@ -284,6 +299,10 @@ class BaseServer extends Base {
 
             try {
                 this.logger?.debug?.(`[MCP] Calling tool: ${name} with args:`, JSON.stringify(args));
+
+                // Pre-dispatch validation hook (e.g., memory-core's identity-spoof guard).
+                // Throws bubble to the outer catch and route to formatToolError.
+                await this.beforeToolDispatch({toolName: name, args});
 
                 if (healthService && !exemptTools.includes(name)) {
                     try {

--- a/ai/mcp/server/memory-core/Server.mjs
+++ b/ai/mcp/server/memory-core/Server.mjs
@@ -1,19 +1,18 @@
-import {execSync}                                      from 'node:child_process';
-import {McpServer}                                     from '@modelcontextprotocol/sdk/server/mcp.js';
-import {CallToolRequestSchema, ListToolsRequestSchema} from '@modelcontextprotocol/sdk/types.js';
-import Base                                            from '../../../../src/core/Base.mjs';
-import aiConfig                                        from './config.mjs';
-import logger                                          from './logger.mjs';
-import GraphService                                    from './services/GraphService.mjs';
-import HealthService                                   from './services/HealthService.mjs';
-import SessionService                                  from './services/SessionService.mjs';
-import InferenceLifecycleService                       from './services/lifecycle/InferenceLifecycleService.mjs';
-import {listTools, callTool}                           from './services/toolService.mjs';
-import AuthMiddleware                                  from '../shared/services/AuthMiddleware.mjs';
-import RequestContextService                           from '../shared/services/RequestContextService.mjs';
-import StdioIdentityResolver                           from '../shared/services/StdioIdentityResolver.mjs';
-import WakeSubscriptionService                         from './services/WakeSubscriptionService.mjs';
-import CoalescingEngineService                         from './services/CoalescingEngineService.mjs';
+import {execSync}                  from 'node:child_process';
+import BaseServer                  from '../BaseServer.mjs';
+import aiConfig                    from './config.mjs';
+import logger                      from './logger.mjs';
+import GraphService                from './services/GraphService.mjs';
+import HealthService               from './services/HealthService.mjs';
+import SessionService              from './services/SessionService.mjs';
+import InferenceLifecycleService   from './services/lifecycle/InferenceLifecycleService.mjs';
+import {listTools, callTool}       from './services/toolService.mjs';
+import AuthMiddleware              from '../shared/services/AuthMiddleware.mjs';
+import RequestContextService       from '../shared/services/RequestContextService.mjs';
+import StdioIdentityResolver       from '../shared/services/StdioIdentityResolver.mjs';
+import WakeSubscriptionService     from './services/WakeSubscriptionService.mjs';
+import CoalescingEngineService     from './services/CoalescingEngineService.mjs';
+
 /**
  * @summary The Memory Core MCP Server application.
  *
@@ -24,9 +23,9 @@ import CoalescingEngineService                         from './services/Coalesci
  * The transport mode and HTTP port can be configured using `aiConfig.transport` and `aiConfig.mcpHttpPort`.
  *
  * @class Neo.ai.mcp.server.memory-core.Server
- * @extends Neo.core.Base
+ * @extends Neo.ai.mcp.server.BaseServer
  */
-class Server extends Base {
+class Server extends BaseServer {
     static config = {
         /**
          * @member {String} className='Neo.ai.mcp.server.memory-core.Server'
@@ -35,21 +34,13 @@ class Server extends Base {
         className: 'Neo.ai.mcp.server.memory-core.Server'
     }
 
+    aiConfig = aiConfig
+    logger   = logger
+
     /**
-     * Path to a custom configuration file.
-     * @member {String|null} configFile=null
-     */
-    configFile = null
-    /**
-     * The MCP Server instance.
-     * @member {McpServer|null} mcpServer=null
-     * @protected
-     */
-    mcpServer = null
-    /**
-     * Resolved agent identity for stdio transport sessions (ticket #10145). Populated at
-     * `initAsync()` time via `StdioIdentityResolver` + AgentIdentity graph-node binding. Null
-     * when running under SSE transport (identity flows per-request via `AuthService` /
+     * Resolved agent identity for stdio transport sessions (ticket #10145). Populated by
+     * `boot()` via `StdioIdentityResolver` + AgentIdentity graph-node binding. Null when
+     * running under SSE transport (identity flows per-request via `AuthService` /
      * `RequestContextService` instead) or when stdio resolution yielded no identity.
      * @member {Object|null} stdioIdentity=null
      * @protected
@@ -57,19 +48,16 @@ class Server extends Base {
     stdioIdentity = null
 
     /**
-     * Creates a new MCP Server instance. Used by TransportService to provision
-     * a dedicated server object per SSE request to avoid SDK lifecycle collisions.
-     * @returns {McpServer}
+     * @summary MCP server identity for `createMcpServer()`. Includes the experimental
+     * `neo-wake-substrate` capability that surfaces wake events for connected clients (#10437).
+     * @returns {{name: String, version: String, capabilities: Object}}
      */
-    createMcpServer() {
-        const mcpServer = new McpServer({
-            name   : 'neo-memory-core',
-            version: process.env.npm_package_version || '1.0.0',
-        }, {
+    getServerMetadata() {
+        return {
+            name        : 'neo-memory-core',
+            version     : process.env.npm_package_version || '1.0.0',
             capabilities: {
-                tools: {
-                    listChanged: false
-                },
+                tools: {listChanged: false},
                 experimental: {
                     'neo-wake-substrate': {
                         version: '1.0',
@@ -77,90 +65,106 @@ class Server extends Base {
                     }
                 }
             }
-        });
+        };
+    }
 
-        this.setupRequestHandlers(mcpServer);
+    /**
+     * @summary Per-server tool registry for ListTools / CallTool dispatch.
+     * @returns {{listTools: Function, callTool: Function}}
+     */
+    getToolService() {
+        return {listTools, callTool};
+    }
+
+    /**
+     * @summary HealthService for the healthcheck gate + startup-status logging.
+     * @returns {Object}
+     */
+    getHealthService() {
+        return HealthService;
+    }
+
+    /**
+     * @summary Tools allowed without the healthcheck gate. Database lifecycle tools must
+     * remain reachable while ChromaDB is unavailable so operators can recover.
+     * @returns {Array<String>}
+     */
+    getHealthExemptTools() {
+        return ['healthcheck', 'start_database', 'stop_database'];
+    }
+
+    /**
+     * @summary Pre-dispatch identity-spoof guard (#10145). Rejects any tool-call argument
+     * that would let the client override server-stamped identity. No-op on existing tool
+     * schemas; activates once Mailbox (#10139) adds `from` fields. Throws bubble to the
+     * outer CallTool try/catch and route to `formatToolError`.
+     * @param {{toolName: String, args: Object}} context
+     */
+    async beforeToolDispatch({args}) {
+        AuthMiddleware.validateNoIdentitySpoof(args);
+    }
+
+    /**
+     * @summary Wraps tool dispatch in `RequestContextService.run()` when stdio identity is
+     * resolved (ticket #10145). Establishes the AsyncLocalStorage-scoped context that
+     * `MemoryService.addMemory`, etc. read via `getUserId()` to tag ChromaDB writes per
+     * tenant. SSE mode leaves `stdioIdentity` null because `TransportService` already wraps
+     * the `/mcp` request with per-request OIDC identity — re-wrapping here would clobber
+     * that context.
+     * @param {Function} dispatch
+     */
+    async wrapDispatch(dispatch) {
+        return this.stdioIdentity
+            ? RequestContextService.run(this.stdioIdentity, dispatch)
+            : dispatch();
+    }
+
+    /**
+     * @summary Override of `BaseServer.createMcpServer` — chains super then registers the
+     * mcpServer instance with `CoalescingEngineService` so it can broadcast wake events to
+     * the SDK's `experimental.neo-wake-substrate` capability subscribers. Used both at boot
+     * and per-request (SSE mode) to provision dedicated server objects per connection.
+     * @returns {McpServer}
+     */
+    createMcpServer() {
+        const mcpServer = super.createMcpServer();
         CoalescingEngineService.addMcpServer(mcpServer);
-
         return mcpServer;
     }
 
     /**
-     * Async initialization sequence.
+     * @summary Custom boot order (override of `BaseServer.boot`). Memory Core's bootstrap
+     * has three constraints that the canonical sequence doesn't satisfy:
+     *
+     * 1. `WakeSubscriptionService.init()` must complete BEFORE `createMcpServer()` so the
+     *    experimental wake-substrate capability has its substrate ready when clients connect.
+     * 2. Stdio identity resolution must complete BEFORE healthcheck, so the boot-time
+     *    healthcheck snapshot reflects the bound identity state (#10249).
+     * 3. The wake-subscription auto-bootstrap is fire-and-forget within an async IIFE for
+     *    single-error-boundary discipline (#10438) — must run AFTER stdio identity is bound.
+     *
      * @returns {Promise<void>}
      */
-    async initAsync() {
-        await super.initAsync();
+    async boot() {
+        await this.loadCustomConfig();
 
-        // 1. Load custom configuration if provided
-        if (this.configFile) {
-            try {
-                await aiConfig.load(this.configFile);
-            } catch (error) {
-                logger.error('Failed to load configuration:', error);
-                throw error; // Re-throw to trigger ready() catch block in runner
-            }
-        }
-
+        // Pre-mcpServer init: WakeSubscriptionService substrate ready (#10437).
         await WakeSubscriptionService.init();
 
-        // 2. Initialize the default stdio MCP Server instance
         this.mcpServer = this.createMcpServer();
 
-        // 3. Wait for dependent services
-        // SessionService is a singleton, so we wait for its global ready state
+        // Wait for dependent services.
         await InferenceLifecycleService.ready();
         await SessionService.ready();
 
-        // 5. Resolve stdio identity (if applicable) BEFORE the boot-time healthcheck snapshot
-        // (#10249). Elevated out of the stdio transport-connect branch so the initial telemetry
-        // logged by `logStartupStatus` reflects the bound identity state, not the pre-bind null.
-        // Runtime MCP healthcheck tool-dispatch already reads `#stdioIdentityState` live per call,
-        // so this reorder affects boot-log observability only — not runtime correctness.
+        // Stdio identity resolution BEFORE healthcheck snapshot (#10249).
         if (aiConfig.transport !== 'sse') {
-            // Resolve stdio identity before connecting the transport (ticket #10145). The
-            // resolved context is cached on this.stdioIdentity and wrapped around every
-            // CallToolRequestSchema dispatch so downstream services (e.g. MemoryService) read
-            // a consistent identity via RequestContextService.getUserId(). SSE mode skips
-            // this path — TransportService performs the equivalent wrap per-request using
-            // OIDC-derived identity.
             this.stdioIdentity = await this.resolveStdioIdentity();
-
-            // Surface stdio identity state for healthcheck observability (#10176). The block
-            // is informational-only — unbound identity does NOT flip healthcheck status to
-            // unhealthy because mailbox is an optional feature and single-tenant fallthrough
-            // is a valid operational mode (see MemoryCoreMcpAuth.md contract).
             HealthService.setStdioIdentityState(this.stdioIdentity);
 
-            // Auto-invoke wake subscription bootstrap (per #10437; closes the missing AC from
-            // #10402 Phase 1). Without this, every new session boots with zero active
-            // WAKE_SUBSCRIPTION nodes for the bound identity until an agent manually calls
-            // `manage_wake_subscription({action: 'bootstrap'})` — a discipline burden that
-            // does not survive context-pruning. The substrate-level auto-invoke makes the
-            // wake-substrate genuinely self-healing, mirroring the #10181/#10182 dispatch-time
-            // identity-binding self-heal pattern.
-            //
-            // **Single-error-boundary design:** wrapping the entire `RequestContextService.run()`
-            // call inside an async IIFE's try/catch unifies error handling across all failure
-            // sources — synchronous throws during `RequestContextService.run()` setup, synchronous
-            // throws inside `bootstrap()`'s setup before its first `await` (e.g., the
-            // identity-binding guard at WakeSubscriptionService.mjs:209), and asynchronous
-            // rejections from `bootstrap()`'s SQLite/GraphService awaits all converge on the same
-            // catch. Fire-and-forget by not awaiting the IIFE — boot continues unconditionally
-            // (per @neo-gemini-3-1-pro's PR #10438 cycle 1 challenge: tightens the dual-catch
-            // pattern that the original implementation used; the IIFE's try/catch is the
-            // canonical single error boundary for fire-and-forget async operations).
-            //
-            // **`RequestContextService.run()` rationale:** `bootstrap()` calls
-            // `RequestContextService.getAgentIdentityNodeId()` (line 208 of WakeSubscriptionService),
-            // which throws unless executed inside a `run()` scope — so the wrap is required, not
-            // ceremonial. The identity context shape `{userId, username, agentIdentityNodeId, source}`
-            // is the same one the per-tool dispatch wrap consumes downstream.
-            //
-            // **Idempotency:** safe to repeat across restarts per #10412's raw-SQL idempotency
-            // check — already-existing subs return `status: 'existing'` rather than creating
-            // duplicates. Missing-template throws are caught + logged at warn level (legitimate
-            // single-tenant fallthrough; not a fatal boot error).
+            // Auto-bootstrap wake subscription per #10437 (single-error-boundary IIFE per #10438).
+            // Fire-and-forget: server boot continues unconditionally; wake-substrate self-heals
+            // even if the bootstrap operation hits transient errors.
             if (this.stdioIdentity?.agentIdentityNodeId) {
                 (async () => {
                     try {
@@ -176,89 +180,26 @@ class Server extends Base {
             }
         }
 
-        // 6. Perform Health Check & Log Status (sees populated stdioIdentityState post-reorder)
-        const health = await HealthService.healthcheck();
-        this.logStartupStatus(health);
+        // Healthcheck (sees populated stdioIdentityState post-reorder).
+        await this.runHealthcheckAndLogStatus();
         this.logSiblingConcurrency();
 
-        // 7. Connect Transport
-        if (aiConfig.transport === 'sse') {
-            const {default: TransportService} = await import('../shared/services/TransportService.mjs');
+        await this.connectTransport();
 
-            await TransportService.setup({
-                server      : this,
-                aiConfig,
-                logger,
-                resourceName: 'neo-memory-core MCP'
-            });
-        } else {
-            const {StdioServerTransport} = await import('@modelcontextprotocol/sdk/server/stdio.js');
-            const transport = new StdioServerTransport();
-            
-            if (!this.mcpServer) return; // Prevent crash if instance was destroyed during async boot
-            
-            await this.mcpServer.connect(transport);
-
-            logger.info('[neo-memory-core MCP] Server started on stdio transport');
-            logger.info('[neo-memory-core MCP] Available tools loaded from OpenAPI spec');
+        if (aiConfig.transport !== 'sse') {
             this.logIdentityStatus();
         }
     }
 
     /**
-     * Resolves the active stdio agent identity and binds it to its AgentIdentity graph node.
-     *
-     * Composes three steps: (1) `StdioIdentityResolver.resolve()` returns the GitHub identity
-     * via the env-var → gh-CLI chain; (2) `GraphService.getNode({id: '@' + githubLogin})`
-     * looks up the matching seeded AgentIdentity node (#10144 convention); (3) the composite
-     * is shaped for `RequestContextService.run()` consumption.
-     *
-     * Missing graph node is non-fatal: the identity still flows as `userId` tag, but
-     * `agentIdentityNodeId` is null. Unseeded agents can write memories — they just can't yet
-     * terminate `AUTHORED_BY` edges on a graph node until someone adds them via
-     * `seedAgentIdentities.mjs`.
-     *
-     * @returns {Promise<Object|null>} Context object for `RequestContextService.run()`, or
-     *     `null` when resolution yielded no identity (single-tenant fallthrough).
-     * @protected
-     */
-    async resolveStdioIdentity() {
-        const resolved = await StdioIdentityResolver.resolve();
-
-        if (!resolved.githubLogin) {
-            return null;
-        }
-
-        const agentIdentityNodeId = await this.bindAgentIdentity(resolved.githubLogin);
-
-        return {
-            userId             : resolved.githubLogin,
-            username           : resolved.username,
-            agentIdentityNodeId,
-            source             : resolved.source
-        };
-    }
-
-    /**
-     * Builds the RequestContext for an SSE-transport request. Invoked by `TransportService.setup`
-     * via duck-typed hook — shared transport code checks `typeof server.buildRequestContext ===
-     * 'function'` and calls it once the OIDC-introspected `req.auth` is available. Returning
-     * `{}` when no identity is present preserves the single-tenant fallthrough semantics.
-     *
-     * This is the SSE analog of `resolveStdioIdentity()` — both paths end at a context shape
-     * `RequestContextService.run()` accepts, both bind `agentIdentityNodeId` via the same
-     * `bindAgentIdentity()` helper, and both tag the `source` provenance field.
-     *
-     * @param {Object|undefined} reqAuth The auth context populated by `AuthService.verifyAccessToken`.
-     *     Keys: `{userId, username, source: 'oidc', ...}`. Undefined when the SSE request
-     *     arrived with OIDC disabled (local dev).
-     * @returns {Promise<Object>} RequestContext shape; `{}` when no identity is resolvable.
-     * @protected
+     * @summary SSE-only hook: builds RequestContext for a `/mcp` request from `req.auth`.
+     * Invoked by `TransportService.setup` via duck-typed hook. Returns `{}` when no identity
+     * is present to preserve single-tenant fallthrough.
+     * @param {Object|undefined} reqAuth
+     * @returns {Promise<Object>}
      */
     async buildRequestContext(reqAuth) {
-        if (!reqAuth?.userId) {
-            return {};
-        }
+        if (!reqAuth?.userId) return {};
 
         const agentIdentityNodeId = await this.bindAgentIdentity(reqAuth.userId);
 
@@ -271,55 +212,95 @@ class Server extends Base {
     }
 
     /**
-     * Resolves a bare GitHub login to its seeded AgentIdentity graph node ID (per ticket
-     * #10144's `@`-prefixed ID convention). Shared between `resolveStdioIdentity` (stdio boot)
-     * and `buildRequestContext` (per-SSE-request) so both transports reach the same node
-     * lookup behavior.
+     * @summary SSE-only hook fired by `TransportService` on session disconnect. Queues the
+     * disconnected session for summarization and removes the per-session McpServer from
+     * `CoalescingEngineService`'s broadcast set (counterpart to `createMcpServer`'s
+     * `addMcpServer` registration).
+     * @param {String} sessionId
+     * @param {Object} mcpServerInstance
+     */
+    onSessionClosed(sessionId, mcpServerInstance) {
+        if (SessionService) {
+            SessionService.queueSummarizationJob(sessionId);
+        }
+        if (mcpServerInstance) {
+            CoalescingEngineService.removeMcpServer(mcpServerInstance);
+        }
+    }
+
+    /**
+     * @summary Resolves the active stdio agent identity and binds it to its AgentIdentity
+     * graph node. Composes three steps: (1) `StdioIdentityResolver.resolve()` returns the
+     * GitHub identity via the env-var → gh-CLI chain; (2) `GraphService.getNode({id: '@' +
+     * githubLogin})` looks up the matching seeded AgentIdentity node (#10144 convention); (3)
+     * the composite is shaped for `RequestContextService.run()` consumption.
+     *
+     * Missing graph node is non-fatal: the identity still flows as `userId` tag, but
+     * `agentIdentityNodeId` is null. Unseeded agents can write memories — they just can't yet
+     * terminate `AUTHORED_BY` edges on a graph node until someone adds them via
+     * `seedAgentIdentities.mjs`.
+     *
+     * @returns {Promise<Object|null>}
+     * @protected
+     */
+    async resolveStdioIdentity() {
+        const resolved = await StdioIdentityResolver.resolve();
+
+        if (!resolved.githubLogin) return null;
+
+        const agentIdentityNodeId = await this.bindAgentIdentity(resolved.githubLogin);
+
+        return {
+            userId             : resolved.githubLogin,
+            username           : resolved.username,
+            agentIdentityNodeId,
+            source             : resolved.source
+        };
+    }
+
+    /**
+     * @summary Resolves a bare GitHub login to its seeded AgentIdentity graph node ID
+     * (per ticket #10144's `@`-prefixed ID convention). Shared between `resolveStdioIdentity`
+     * (stdio boot) and `buildRequestContext` (per-SSE-request) so both transports reach the
+     * same node lookup behavior.
      *
      * Missing node is non-fatal: returns `null`. Downstream services that build `AUTHORED_BY`
-     * graph edges treat `null` as "skip edge creation for this write" rather than failing
-     * the write — unseeded agents can still accumulate memories.
+     * graph edges treat `null` as "skip edge creation for this write" rather than failing the
+     * write.
      *
-     * @param {String|undefined|null} userId The bare GitHub login (no `@` prefix).
-     * @returns {Promise<String|null>} The AgentIdentity node ID or `null` if unresolvable.
+     * Retries up to 3 times with vicinity-cache eviction between attempts to handle the
+     * #10241 boot-time race where a stuck cache from concurrent boot lock could miss seeded
+     * identity nodes.
+     *
+     * @param {String|undefined|null} userId
+     * @returns {Promise<String|null>}
      * @protected
      */
     async bindAgentIdentity(userId) {
-        if (!userId) {
-            return null;
-        }
+        if (!userId) return null;
 
         const graphNodeId = '@' + userId;
 
         try {
-            // Ensure the graph is fully loaded before the lookup. Without this await a
-            // cold-boot race would silently miss seeded identity nodes.
             await GraphService.ready();
-            
-            // `GraphService.getNode` returns a Promise (Neo's singleton method wrapper);
-            // awaiting it unpacks to the `{id, type, name, ...}` shape. Without `await`,
-            // `node.id` on the Promise object is `undefined`, causing bind to silently
-            // return `undefined` — the true root cause of the #10241 boot-time bind failure
-            // that busy_timeout/retry/reorder patches only partially masked.
+
             let retries = 3;
             let node = null;
-            
+
             while (retries > 0) {
                 node = await GraphService.getNode({id: graphNodeId});
                 if (node) {
                     return node.id;
                 }
-                
-                // If not found, it might be due to a stuck vicinity cache from a concurrent boot lock.
-                // Clear the specific node from the cache and try again.
+
                 if (GraphService.db && GraphService.db.vicinityLoadedNodes) {
                     GraphService.db.vicinityLoadedNodes.delete(graphNodeId);
                 }
-                
+
                 await new Promise(resolve => setTimeout(resolve, 50));
                 retries--;
             }
-            
+
             logger.warn(`[neo-memory-core MCP] AgentIdentity graph lookup failed for ${graphNodeId}: Node not found in database`);
             return null;
         } catch (error) {
@@ -329,7 +310,7 @@ class Server extends Base {
     }
 
     /**
-     * Logs the resolved stdio identity state during startup for operator visibility.
+     * @summary Logs the resolved stdio identity state during startup for operator visibility.
      * @protected
      */
     logIdentityStatus() {
@@ -339,14 +320,14 @@ class Server extends Base {
         }
 
         const {userId, agentIdentityNodeId, source} = this.stdioIdentity;
-        const bound                                 = agentIdentityNodeId ? `bound to ${agentIdentityNodeId}` : 'unbound (no matching AgentIdentity node)';
+        const bound = agentIdentityNodeId ? `bound to ${agentIdentityNodeId}` : 'unbound (no matching AgentIdentity node)';
 
         logger.info(`[neo-memory-core MCP] Identity: ${userId} via ${source} — ${bound}`);
     }
 
     /**
-     * Helper to log collection statistics.
-     * @param {Object} health The health check result object.
+     * @summary Helper to log Memory Core collection statistics from healthcheck output.
+     * @param {Object} health
      */
     logCollectionStats(health) {
         if (health.database.connection.collections) {
@@ -356,8 +337,9 @@ class Server extends Base {
     }
 
     /**
-     * Logs the health status of the server during startup.
-     * @param {Object} health The health check result object.
+     * @summary Memory Core-specific startup status formatting with ChromaDB-tip on unhealthy
+     * + collection-stats on degraded/healthy.
+     * @param {Object} health
      */
     logStartupStatus(health) {
         if (health.status === 'unhealthy') {
@@ -382,13 +364,10 @@ class Server extends Base {
     }
 
     /**
-     * @summary Boot-time diagnostic that invokes `lsof` to detect SQLite file contention.
-     * Checks for sibling MCP server processes holding the memory-core SQLite files
-     * and logs them for visibility (ticket #10188).
-     * 
-     * Uses the same empirical `lsof` + PID walk pattern established in 
-     * @see {file} ../../../scripts/diagnoseMcpConcurrency.mjs
-     * 
+     * @summary Boot-time diagnostic: invokes `lsof` to detect SQLite file contention from
+     * sibling MCP server processes holding the memory-core SQLite files (ticket #10188).
+     * Uses the same empirical `lsof` + PID walk pattern established in
+     * `ai/scripts/diagnoseMcpConcurrency.mjs`.
      * @protected
      */
     logSiblingConcurrency() {
@@ -398,27 +377,24 @@ class Server extends Base {
         const files = [dbPath, `${dbPath}-wal`, `${dbPath}-shm`];
 
         try {
-            // lsof -F pcn will list PID, command name, and file path for holding processes.
             const raw = execSync(`lsof -F pcn -- ${files.map(f => `'${f}'`).join(' ')}`, {
                 encoding: 'utf8',
                 stdio: ['ignore', 'pipe', 'pipe']
             });
 
-            // Parse output:
             let current = null;
             const records = [];
             for (const line of raw.split('\n')) {
                 if (!line) continue;
                 if (line[0] === 'p') {
                     if (current && current.pid !== process.pid) records.push(current);
-                    current = { pid: parseInt(line.slice(1), 10) };
+                    current = {pid: parseInt(line.slice(1), 10)};
                 } else if (current && line[0] === 'c') {
                     current.command = line.slice(1);
                 }
             }
             if (current && current.pid !== process.pid) records.push(current);
 
-            // Deduplicate by PID
             const uniquePids = new Set();
             const siblings = records.filter(r => {
                 if (uniquePids.has(r.pid)) return false;
@@ -435,145 +411,6 @@ class Server extends Base {
                 logger.debug(`[Startup] Failed to check sibling concurrency: ${error.message}`);
             }
         }
-    }
-
-    /**
-     * Hook from TransportService on SSE session disconnect.
-     * Queues the disconnected session for summarization.
-     * @summary Bridges the transport layer disconnect event into the memory core logic pipeline.
-     * @param {String} sessionId
-     */
-    onSessionClosed(sessionId, mcpServerInstance) {
-        if (SessionService) {
-            SessionService.queueSummarizationJob(sessionId);
-        }
-        if (mcpServerInstance) {
-            CoalescingEngineService.removeMcpServer(mcpServerInstance);
-        }
-    }
-
-    /**
-     * Wires up the MCP request handlers for listing and calling tools.
-     * @param {McpServer} mcpServer The target server instance
-     */
-    setupRequestHandlers(mcpServer) {
-        if (!mcpServer) return; // Prevent crash if instance was destroyed during async boot
-
-        // List Tools Handler
-        mcpServer.server.setRequestHandler(ListToolsRequestSchema, async (request) => {
-            try {
-                const { cursor, limit } = request.params || {};
-                const { tools, nextCursor } = listTools({ cursor, limit });
-
-                const mcpTools = tools.map(tool => ({
-                    name        : tool.name,
-                    title       : tool.title,
-                    description : tool.description,
-                    inputSchema : tool.inputSchema,
-                    outputSchema: tool.outputSchema,
-                    annotations : tool.annotations
-                }));
-
-                const result = { tools: mcpTools };
-
-                if (nextCursor) {
-                    result.nextCursor = nextCursor;
-                }
-                return result;
-            } catch (error) {
-                return { tools: [], nextCursor: undefined, error: error.message };
-            }
-        });
-
-        // Call Tool Handler
-        mcpServer.server.setRequestHandler(CallToolRequestSchema, async (request) => {
-            const { name, arguments: args } = request.params;
-
-            try {
-                logger.debug(`[MCP] Calling tool: ${name} with args:`, JSON.stringify(args));
-
-                // Anti-spoof guard (ticket #10145): reject any tool-call argument that would
-                // let the client override server-stamped identity. No-op on existing tool
-                // schemas; activates once Mailbox (#10139) adds `from` fields.
-                AuthMiddleware.validateNoIdentitySpoof(args);
-
-                const exemptFromHealthCheck = ['healthcheck', 'start_database', 'stop_database'];
-
-                if (!exemptFromHealthCheck.includes(name)) {
-                    try {
-                        await HealthService.ensureHealthy();
-                    } catch (healthError) {
-                        logger.error(`[MCP] Health check failed for tool ${name}:`, healthError.message);
-                        return {
-                            content: [{
-                                type: 'text',
-                                text: `Cannot execute ${name}: ${healthError.message}`
-                            }],
-                            isError: true
-                        };
-                    }
-                }
-
-                // Wrap the tool dispatch in RequestContextService.run() when a stdio identity
-                // was resolved (ticket #10145). This establishes the AsyncLocalStorage-scoped
-                // context that MemoryService.addMemory, etc. read via getUserId() to tag
-                // ChromaDB writes per tenant. SSE mode leaves stdioIdentity null because
-                // TransportService has already wrapped the /mcp request with per-request OIDC
-                // identity — re-wrapping here would clobber that context.
-                const dispatch = () => callTool(name, args);
-                const result   = this.stdioIdentity
-                    ? await RequestContextService.run(this.stdioIdentity, dispatch)
-                    : await dispatch();
-
-                let contentBlock;
-                let isError           = false;
-                let structuredContent = null;
-
-                if (Neo.isObject(result)) {
-                    isError = 'error' in result;
-
-                    if (isError) {
-                        contentBlock = {
-                            type: 'text',
-                            text: `Tool Error: ${result.error || 'Unknown Error'}. Message: ${result.message || 'No message provided.'}`
-                        };
-                    } else {
-                        contentBlock = {
-                            type: 'text',
-                            text: JSON.stringify(result, null, 2)
-                        };
-                        structuredContent = result;
-                    }
-                } else {
-                    contentBlock = {
-                        type: 'text',
-                        text: typeof result === 'object' ? JSON.stringify(result, null, 2) : String(result)
-                    };
-                    structuredContent = { result };
-                }
-
-                const response = {
-                    content: [contentBlock],
-                    isError
-                };
-
-                if (structuredContent) {
-                    response.structuredContent = structuredContent;
-                }
-
-                return response;
-            } catch (error) {
-                logger.error(`[MCP] Error executing tool ${name}:`, error);
-
-                return {
-                    content: [{
-                        type: 'text',
-                        text: `Error executing ${name}: ${error.message}`
-                    }],
-                    isError: true
-                };
-            }
-        });
     }
 }
 

--- a/test/playwright/unit/ai/mcp/server/BaseServer.spec.mjs
+++ b/test/playwright/unit/ai/mcp/server/BaseServer.spec.mjs
@@ -81,6 +81,7 @@ function makeTestServerClass(overrides = {}) {
         getHealthExemptTools()     { return overrides.getHealthExemptTools?.() ?? ['healthcheck']; }
         getDependentServices()     { return overrides.getDependentServices?.() ?? []; }
         async wrapDispatch(d)      { return overrides.wrapDispatch?.(d) ?? d(); }
+        async beforeToolDispatch(ctx) { return overrides.beforeToolDispatch?.(ctx); }
     }
     return Neo.setupClass(TestServer);
 }
@@ -322,6 +323,42 @@ test.describe('Neo.ai.mcp.server.BaseServer — setupRequestHandlers wiring', ()
 
         expect(result.isError).toBe(true);
         expect(result.content[0].text).toBe('Cannot execute sample: Service down');
+    });
+
+    test('beforeToolDispatch hook fires BEFORE health gate with toolName + args', async () => {
+        const order = [];
+        const Cls = makeTestServerClass({
+            getHealthService    : () => ({ensureHealthy: async () => { order.push('healthGate'); }}),
+            beforeToolDispatch  : async ({toolName, args}) => { order.push(`beforeToolDispatch:${toolName}:${args.x}`); }
+        });
+        const server  = Neo.create(Cls);
+        const mockMcp = makeMockMcpServer();
+        server.setupRequestHandlers(mockMcp);
+
+        await mockMcp.getCallToolHandler()({
+            params: {name: 'sample', arguments: {x: 99}}
+        });
+
+        // Hook fires BEFORE health gate, then dispatch
+        expect(order).toEqual(['beforeToolDispatch:sample:99', 'healthGate']);
+    });
+
+    test('beforeToolDispatch throw routes to formatToolError envelope (not formatHealthError)', async () => {
+        const Cls = makeTestServerClass({
+            getHealthService    : () => ({ensureHealthy: async () => {}}),
+            beforeToolDispatch  : async () => { throw new Error('Identity spoof rejected'); }
+        });
+        const server  = Neo.create(Cls);
+        const mockMcp = makeMockMcpServer();
+        server.setupRequestHandlers(mockMcp);
+
+        const result = await mockMcp.getCallToolHandler()({
+            params: {name: 'sample', arguments: {}}
+        });
+
+        expect(result.isError).toBe(true);
+        // formatToolError shape: "Error executing X: Y" — NOT "Cannot execute X: Y" (that's formatHealthError)
+        expect(result.content[0].text).toBe('Error executing sample: Identity spoof rejected');
     });
 
     test('wrapDispatch override threads context around toolService.callTool', async () => {


### PR DESCRIPTION
Authored by Claude Opus 4.7 (Claude Code). Session 005b6edf-85d8-4980-9e17-486b6b8bed3f.

Refs #10965

PR5 of the M2 series — most complex per-server consumer migration; closes the M2 abstraction-validation cycle across 5 different consumer-shapes (memory-core stresses every BaseServer hook). M2 substrate fully complete after this **plus** PR6 ([#10976](https://github.com/neomjs/neo/pull/10976)) both land.

Evidence: L1 (static syntax + 28 BaseServer unit tests + 258 memory-core unit specs all passing locally; 5 pre-existing Bucket G residual flakes unrelated to migration — `GraphService` #10941, `PermissionService` #10937, `SessionSummarization`).

## What ships

### `ai/mcp/server/memory-core/Server.mjs` migration: 580 → 417 lines (~28% reduction)

Less reduction than other migrations because of **irreducible per-server complexity** (preserved verbatim):
- `resolveStdioIdentity()` + `bindAgentIdentity()` — #10145 + #10144 lineage with #10241 boot-time-race retry pattern
- `logSiblingConcurrency()` — #10188 lsof-based SQLite-contention diagnostic
- `logIdentityStatus()` + `logCollectionStats()` — Memory-Core-flavored startup logs
- Custom boot order — stdio-identity-resolution between dependent-services and healthcheck per #10249
- Wake-subscription auto-bootstrap fire-and-forget IIFE per #10437 (#10438 single-error-boundary)

### `ai/mcp/server/BaseServer.mjs` (load-bearing extension)

New optional override hook:
```javascript
async beforeToolDispatch({toolName, args}) {
    // No-op default
}
```

Fires **BEFORE** the healthcheck gate in the CallTool handler. Throws bubble to the outer try/catch and route to `formatToolError` (NOT `formatHealthError` — semantic distinction matters: identity-spoof rejection is a tool-error, not a health-state issue).

Memory Core uses it for `AuthMiddleware.validateNoIdentitySpoof(args)` per ticket #10145 — must fail-fast on identity-spoofing requests before any other processing.

### memory-core's `boot()` override

Preserves all 7 original initAsync semantics:
1. `loadCustomConfig`
2. `WakeSubscriptionService.init()` — pre-mcpServer per #10437
3. `createMcpServer` (override chains `super` + `CoalescingEngineService.addMcpServer` for experimental `neo-wake-substrate` broadcast)
4. `InferenceLifecycleService.ready()` + `SessionService.ready()`
5. **Stdio identity resolution + `HealthService.setStdioIdentityState` + wake-subscription auto-bootstrap** — BEFORE healthcheck so the boot snapshot reflects bound identity state per #10249
6. `runHealthcheckAndLogStatus()` + `logSiblingConcurrency()`
7. `connectTransport()` + `logIdentityStatus()` (stdio only)

### Hooks used by memory-core

| Hook | Purpose |
|---|---|
| `getServerMetadata` | name + version + capabilities (with experimental `neo-wake-substrate`) |
| `getToolService` | `{listTools, callTool}` |
| `getHealthService` | `HealthService` |
| `getHealthExemptTools` | `['healthcheck', 'start_database', 'stop_database']` |
| `createMcpServer` (override) | chains super + CoalescingEngineService binding |
| `wrapDispatch` | `RequestContextService.run(stdioIdentity, dispatch)` for tenant-tagged ChromaDB writes |
| `beforeToolDispatch` (NEW) | `AuthMiddleware.validateNoIdentitySpoof(args)` |
| `buildRequestContext` | SSE-per-request OIDC binding |
| `onSessionClosed` | SSE: `queueSummarizationJob` + CoalescingEngine cleanup |
| `logStartupStatus` | Memory-Core-flavored output (ChromaDB-tip on unhealthy + collection-stats) |

## Tests

- `BaseServer.spec.mjs`: 27 → 28 unit tests; 1 new for `beforeToolDispatch`:
  - Verifies hook fires BEFORE health gate (call ordering)
  - Verifies hook throws route to `formatToolError` envelope (NOT `formatHealthError` — different semantic class)
- 258 existing memory-core unit specs pass; 5 pre-existing Bucket G residual flakes unrelated to migration

## Per-server migration sequence — current state

- ✅ **PR1** [#10966](https://github.com/neomjs/neo/pull/10966) — BaseServer scaffold + tests (merged)
- ✅ **PR2** [#10973](https://github.com/neomjs/neo/pull/10973) — knowledge-base/Server.mjs (Gemini approved; eligible-for-merge)
- ✅ **PR3** [#10974](https://github.com/neomjs/neo/pull/10974) — github-workflow/Server.mjs (GPT approved; eligible-for-merge)
- ✅ **PR4** [#10975](https://github.com/neomjs/neo/pull/10975) — neural-link/Server.mjs + `boot()` seam (Gemini approved; eligible-for-merge)
- 🆕 **PR5 (this)** — memory-core/Server.mjs + `beforeToolDispatch` hook (in review by Gemini)
- 🔄 **PR6** [#10976](https://github.com/neomjs/neo/pull/10976) — file-system/Server.mjs (in review by GPT)

**M2 substrate is fully complete only after both PR5 and PR6 land in `dev`.** At that point all 5 MCP servers extend `BaseServer` uniformly, unblocking M6 SDK migration downstream.

## Coordination Notes

- **Independent of PR2-PR4 + PR6:** the `beforeToolDispatch` hook is a backwards-compatible BaseServer extension; pre-existing consumers (PR2/PR3/PR4/PR6) don't override it.
- **Largest single migration in the series** by absolute LOC delta (-352 lines from 580 = -163 net) but lowest percentage reduction because of preserved memory-core-specific helpers.
- **All abstraction-validation done:** memory-core stresses every hook the BaseServer offers (createMcpServer override, custom boot, wrapDispatch, beforeToolDispatch, buildRequestContext, onSessionClosed, logStartupStatus).

## Test Evidence

- `node --check ai/mcp/server/BaseServer.mjs` → passed
- `node --check ai/mcp/server/memory-core/Server.mjs` → passed
- `npm run test-unit -- test/playwright/unit/ai/mcp/server/BaseServer.spec.mjs` → 28 passed (858ms)
- `npm run test-unit -- test/playwright/unit/ai/mcp/server/memory-core/` → 258 passed, 5 pre-existing Bucket G flakes (11.9s)

## Post-Merge Validation

- [ ] Memory Core MCP server boots cleanly with the migrated `Server.mjs` extension shape (CI integration row covers; deployment smoke against a Docker-capable runner confirms — memory-core is the most-tested MCP server in production due to multi-tenant complexity).
- [ ] Stdio identity resolution + wake-subscription auto-bootstrap fire correctly post-boot (CI integration validates via the seeded `@neo-opus-4-7` agent's runtime behavior).

