### PR TITLE
feat(memory-core): cover backup restore wipe detection (#10949)

### DIFF
--- a/ai/mcp/server/memory-core/services/DatabaseService.mjs
+++ b/ai/mcp/server/memory-core/services/DatabaseService.mjs
@@ -250,30 +250,30 @@ class DatabaseService extends Base {
         let imported = 0;
         
         db.transaction((records) => {
-            const insertNode = db.prepare('INSERT OR REPLACE INTO Nodes (id, data) VALUES (?, ?)');
-            const insertEdge = db.prepare('INSERT OR REPLACE INTO Edges (source, target, data) VALUES (?, ?, ?)');
+            const insertNode = db.prepare('INSERT OR REPLACE INTO Nodes (id, user_id, data) VALUES (?, ?, ?)');
+            const insertEdge = db.prepare('INSERT OR REPLACE INTO Edges (id, user_id, source, target, type, data) VALUES (?, ?, ?, ?, ?, ?)');
             
             for (const record of records) {
                 if (record.type === 'node') {
-                    insertNode.run(record.data.id, JSON.stringify(record.data));
+                    insertNode.run(record.data.id, record.data.properties?.userId || null, JSON.stringify(record.data));
                 } else if (record.type === 'edge') {
-                    insertEdge.run(record.data.source, record.data.target, JSON.stringify(record.data));
+                    insertEdge.run(record.data.id, record.data.properties?.userId || null, record.data.source, record.data.target, record.data.type || null, JSON.stringify(record.data));
                 }
                 imported++;
             }
         })([]); // Execute an empty transaction block initially, but we need to batch it.
         
         // Let's do it directly in loop for simplicity
-        const insertNode = db.prepare('INSERT OR REPLACE INTO Nodes (id, data) VALUES (?, ?)');
-        const insertEdge = db.prepare('INSERT OR REPLACE INTO Edges (source, target, data) VALUES (?, ?, ?)');
+        const insertNode = db.prepare('INSERT OR REPLACE INTO Nodes (id, user_id, data) VALUES (?, ?, ?)');
+        const insertEdge = db.prepare('INSERT OR REPLACE INTO Edges (id, user_id, source, target, type, data) VALUES (?, ?, ?, ?, ?, ?)');
 
         // Run within a transaction for speed
         const insertBatch = db.transaction((records) => {
             for (const record of records) {
                 if (record.type === 'node') {
-                    insertNode.run(record.data.id, JSON.stringify(record.data));
+                    insertNode.run(record.data.id, record.data.properties?.userId || null, JSON.stringify(record.data));
                 } else if (record.type === 'edge') {
-                    insertEdge.run(record.data.source, record.data.target, JSON.stringify(record.data));
+                    insertEdge.run(record.data.id, record.data.properties?.userId || null, record.data.source, record.data.target, record.data.type || null, JSON.stringify(record.data));
                 }
                 imported++;
             }

--- a/ai/mcp/server/memory-core/services/DatabaseService.mjs
+++ b/ai/mcp/server/memory-core/services/DatabaseService.mjs
@@ -248,32 +248,38 @@ class DatabaseService extends Base {
         const rl = readline.createInterface({ input: fileStream, crlfDelay: Infinity });
 
         let imported = 0;
-        
-        db.transaction((records) => {
-            const insertNode = db.prepare('INSERT OR REPLACE INTO Nodes (id, user_id, data) VALUES (?, ?, ?)');
-            const insertEdge = db.prepare('INSERT OR REPLACE INTO Edges (id, user_id, source, target, type, data) VALUES (?, ?, ?, ?, ?, ?)');
-            
-            for (const record of records) {
-                if (record.type === 'node') {
-                    insertNode.run(record.data.id, record.data.properties?.userId || null, JSON.stringify(record.data));
-                } else if (record.type === 'edge') {
-                    insertEdge.run(record.data.id, record.data.properties?.userId || null, record.data.source, record.data.target, record.data.type || null, JSON.stringify(record.data));
-                }
-                imported++;
-            }
-        })([]); // Execute an empty transaction block initially, but we need to batch it.
-        
-        // Let's do it directly in loop for simplicity
+
         const insertNode = db.prepare('INSERT OR REPLACE INTO Nodes (id, user_id, data) VALUES (?, ?, ?)');
-        const insertEdge = db.prepare('INSERT OR REPLACE INTO Edges (id, user_id, source, target, type, data) VALUES (?, ?, ?, ?, ?, ?)');
+        const insertEdge = db.prepare(`
+            INSERT OR REPLACE INTO Edges (id, user_id, source, target, type, data)
+            VALUES (?, ?, ?, ?, ?, ?)
+        `);
 
         // Run within a transaction for speed
         const insertBatch = db.transaction((records) => {
             for (const record of records) {
                 if (record.type === 'node') {
-                    insertNode.run(record.data.id, record.data.properties?.userId || null, JSON.stringify(record.data));
+                    insertNode.run(
+                        record.data.id,
+                        record.data.properties?.userId || record.data.user_id || null,
+                        JSON.stringify(record.data)
+                    );
                 } else if (record.type === 'edge') {
-                    insertEdge.run(record.data.id, record.data.properties?.userId || null, record.data.source, record.data.target, record.data.type || null, JSON.stringify(record.data));
+                    const edgeData = record.data;
+                    const edgeId   = edgeData.id || `${edgeData.source}->${edgeData.target}:${edgeData.type}`;
+
+                    if (!edgeData.source || !edgeData.target || !edgeData.type) {
+                        throw new Error(`Invalid graph edge backup record: source, target, and type are required.`);
+                    }
+
+                    insertEdge.run(
+                        edgeId,
+                        edgeData.properties?.userId || edgeData.user_id || null,
+                        edgeData.source,
+                        edgeData.target,
+                        edgeData.type,
+                        JSON.stringify(edgeData)
+                    );
                 }
                 imported++;
             }

--- a/test/playwright/integration/BackupRestoreWipe.integration.spec.mjs
+++ b/test/playwright/integration/BackupRestoreWipe.integration.spec.mjs
@@ -1,0 +1,336 @@
+import {randomUUID}    from 'node:crypto';
+import {spawnSync}     from 'node:child_process';
+import path            from 'node:path';
+import {fileURLToPath} from 'node:url';
+import {test, expect}  from '@playwright/test';
+import {
+    callHealthcheck,
+    callJsonTool,
+    createIdentityClient,
+    getReadiness
+} from './fixtures/mcpClient.mjs';
+
+const __filename  = fileURLToPath(import.meta.url);
+const __dirname   = path.dirname(__filename);
+const repoRoot    = path.resolve(__dirname, '../../..');
+const composeFile = path.join(repoRoot, 'ai/deploy/docker-compose.test.yml');
+const projectName = process.env.NEO_INTEGRATION_COMPOSE_PROJECT || 'neo-integration-test';
+const MC_URL      = process.env.NEO_INTEGRATION_MC_URL || 'http://127.0.0.1:13001';
+
+const CONFIRMATION = 'CONFIRM_PRODUCTION_DESTRUCTIVE_AI_SUBSTRATE';
+const NEO_BOOTSTRAP = `
+    await import('./src/Neo.mjs');
+    await import('./src/core/_export.mjs');
+`;
+
+/**
+ * Runs Docker Compose against the integration fixture project.
+ * @param {String[]} args Docker Compose arguments after the compose file selector.
+ * @returns {import('node:child_process').SpawnSyncReturns<String>}
+ */
+function dockerCompose(args) {
+    return spawnSync('docker', ['compose', '-p', projectName, '-f', composeFile, ...args], {
+        cwd      : repoRoot,
+        encoding : 'utf8',
+        maxBuffer: 10 * 1024 * 1024
+    });
+}
+
+/**
+ * Runs an ES module snippet inside the deployed Memory Core container.
+ * @param {String} code The JavaScript source to execute.
+ * @param {Object} [env] Environment variables to pass into the process.
+ * @returns {Object}
+ */
+function execMemoryCoreJson(code, env={}) {
+    const envArgs = Object.entries(env).flatMap(([key, value]) => ['-e', `${key}=${value}`]);
+    const result  = dockerCompose(['exec', '-T', ...envArgs, 'mc-server', 'node', '--input-type=module', '-e', code]);
+    const output  = [
+        result.stdout?.trim(),
+        result.stderr?.trim()
+    ].filter(Boolean).join('\n');
+
+    expect(result.status, output || result.error?.message || 'mc-server exec failed').toBe(0);
+
+    const jsonLine = result.stdout.trim().split('\n').filter(Boolean).reverse().find(line => {
+        try {
+            JSON.parse(line);
+            return true;
+        } catch {
+            return false;
+        }
+    });
+    expect(jsonLine, output).toBeTruthy();
+
+    return JSON.parse(jsonLine);
+}
+
+/**
+ * Creates an atomic backup bundle from inside the deployed Memory Core container.
+ * @param {String} bundleRoot Absolute bundle target inside the container.
+ * @returns {Object}
+ */
+function createBackupBundle(bundleRoot) {
+    return execMemoryCoreJson(`
+        ${NEO_BOOTSTRAP}
+
+        const silentLogger = {log(){}, warn(){}, error(){}};
+        const {runBackup} = await import('./buildScripts/ai/backup.mjs');
+        const result = await runBackup({
+            bundleRoot: process.env.NEO_TEST_BACKUP_BUNDLE,
+            logger    : silentLogger
+        });
+        console.log(JSON.stringify({
+            bundleRoot: result.bundleRoot,
+            completedAt: result.completedAt,
+            subsystems: result.subsystems,
+            integrity : result.meta.integrity
+        }));
+    `, {
+        NEO_TEST_BACKUP_BUNDLE: bundleRoot
+    });
+}
+
+/**
+ * Restores an atomic backup bundle from inside the deployed Memory Core container.
+ * @param {String} bundleRoot Absolute bundle target inside the container.
+ * @returns {Object}
+ */
+function restoreBackupBundle(bundleRoot) {
+    return execMemoryCoreJson(`
+        ${NEO_BOOTSTRAP}
+
+        const silentLogger = {log(){}, warn(){}, error(){}};
+        const {runRestore} = await import('./buildScripts/ai/restore.mjs');
+        const result = await runRestore({
+            bundleRoot: process.env.NEO_TEST_BACKUP_BUNDLE,
+            mode      : 'merge',
+            logger    : silentLogger
+        });
+        console.log(JSON.stringify({
+            mode      : result.mode,
+            subsystems: result.subsystems,
+            topology  : result.topology
+        }));
+    `, {
+        NEO_TEST_BACKUP_BUNDLE: bundleRoot
+    });
+}
+
+/**
+ * Truncates the deployed fixture graph inside the disposable container path.
+ * @returns {Object}
+ */
+function truncateGraph() {
+    return execMemoryCoreJson(`
+        ${NEO_BOOTSTRAP}
+
+        const {Memory_DatabaseService, Memory_LifecycleService} = await import('./ai/services.mjs');
+
+        await Memory_LifecycleService.ready();
+
+        const result = await Memory_DatabaseService.manageDatabaseBackup({
+            action      : 'truncate',
+            include     : ['graph'],
+            confirmation: process.env.NEO_DESTRUCTIVE_CONFIRMATION
+        });
+
+        console.log(JSON.stringify(result));
+    `, {
+        NEO_ALLOW_PRODUCTION_DESTRUCTIVE_AI_SUBSTRATE: 'true',
+        NEO_DESTRUCTIVE_CONFIRMATION                : CONFIRMATION
+    });
+}
+
+/**
+ * Reads graph evidence directly inside the deployed Memory Core container.
+ * @param {String} memoryId The graph node id to probe.
+ * @returns {Object}
+ */
+function readGraphEvidence(memoryId) {
+    return execMemoryCoreJson(`
+        ${NEO_BOOTSTRAP}
+
+        const {Memory_LifecycleService} = await import('./ai/services.mjs');
+        const {default: GraphService} = await import('./ai/mcp/server/memory-core/services/GraphService.mjs');
+
+        await Memory_LifecycleService.ready();
+
+        const db = GraphService.db.storage.db;
+        const node = db.prepare('SELECT data FROM Nodes WHERE id = ?').get(process.env.NEO_TEST_MEMORY_ID);
+        const edgeCount = db.prepare('SELECT count(*) as count FROM Edges WHERE source = ? OR target = ?')
+            .get(process.env.NEO_TEST_MEMORY_ID, process.env.NEO_TEST_MEMORY_ID).count;
+        const totalNodes = db.prepare('SELECT count(*) as count FROM Nodes').get().count;
+
+        console.log(JSON.stringify({
+            edgeCount,
+            exists    : Boolean(node),
+            totalNodes
+        }));
+    `, {
+        NEO_TEST_MEMORY_ID: memoryId
+    });
+}
+
+/**
+ * Removes test-only graph residue for the seeded memory node.
+ * @param {String} memoryId The graph node id to remove.
+ * @returns {Object}
+ */
+function cleanupGraphNode(memoryId) {
+    return execMemoryCoreJson(`
+        ${NEO_BOOTSTRAP}
+
+        const {Memory_LifecycleService} = await import('./ai/services.mjs');
+        const {default: GraphService} = await import('./ai/mcp/server/memory-core/services/GraphService.mjs');
+
+        await Memory_LifecycleService.ready();
+
+        const db = GraphService.db.storage.db;
+        const edgeInfo = db.prepare('DELETE FROM Edges WHERE source = ? OR target = ?')
+            .run(process.env.NEO_TEST_MEMORY_ID, process.env.NEO_TEST_MEMORY_ID);
+        const nodeInfo = db.prepare('DELETE FROM Nodes WHERE id = ?')
+            .run(process.env.NEO_TEST_MEMORY_ID);
+
+        console.log(JSON.stringify({
+            deletedEdges: edgeInfo.changes,
+            deletedNodes: nodeInfo.changes
+        }));
+    `, {
+        NEO_TEST_MEMORY_ID: memoryId
+    });
+}
+
+/**
+ * Deletes a backup bundle from the deployed Memory Core container tmpfs.
+ * @param {String} bundleRoot Absolute bundle path inside the container.
+ * @returns {Object}
+ */
+function cleanupBackupBundle(bundleRoot) {
+    return execMemoryCoreJson(`
+        const fs = await import('node:fs/promises');
+
+        await fs.rm(process.env.NEO_TEST_BACKUP_BUNDLE, {recursive: true, force: true});
+
+        console.log(JSON.stringify({removed: process.env.NEO_TEST_BACKUP_BUNDLE}));
+    `, {
+        NEO_TEST_BACKUP_BUNDLE: bundleRoot
+    });
+}
+
+/**
+ * Flattens a memory query response into searchable test evidence.
+ * @param {Object} result The query_raw_memories tool result.
+ * @returns {String}
+ */
+function memoryTexts(result) {
+    return result.results.map(memory => [
+        memory.prompt,
+        memory.thought,
+        memory.response
+    ].join('\n')).join('\n');
+}
+
+test.describe('Dockerized MC backup -> wipe detection -> restore integration (#10949)', () => {
+    test('restores seeded memory and graph evidence after an isolated fixture wipe', async () => {
+        const readiness = await getReadiness();
+
+        test.skip(readiness.dockerAvailable === false, `Docker unavailable: ${readiness.reason}`);
+
+        expect(readiness.servicesReady, readiness.reason).toBe(true);
+
+        const runId      = `${Date.now()}-${randomUUID()}`;
+        const sessionId  = `integration-backup-restore-${runId}`;
+        const sentinel   = `backup-restore-sentinel-${runId}`;
+        const bundleRoot = `/tmp/neo-integration/backup-restore-${runId}`;
+        const client     = await createIdentityClient({
+            baseUrl   : MC_URL,
+            clientName: 'neo-integration-backup-restore',
+            identity  : 'backup-restore'
+        });
+        let memoryId;
+
+        try {
+            const addResult = await callJsonTool(client, 'add_memory', {
+                amountToolCalls: 1,
+                agent          : 'backup-restore',
+                model          : 'integration',
+                prompt         : `seed prompt ${sentinel}`,
+                response       : `seed response ${sentinel}`,
+                sessionId,
+                thought        : `seed thought ${sentinel}`,
+                toolsUsed      : ['integration-backup-restore']
+            });
+
+            memoryId = addResult.id;
+            expect(memoryId).toBeTruthy();
+
+            const seededResults = await callJsonTool(client, 'query_raw_memories', {
+                nResults: 5,
+                query   : sentinel,
+                sessionId
+            });
+            expect(memoryTexts(seededResults)).toContain(sentinel);
+
+            const seededGraph = readGraphEvidence(memoryId);
+            expect(seededGraph.exists).toBe(true);
+            expect(seededGraph.edgeCount).toBeGreaterThan(0);
+
+            const backup = createBackupBundle(bundleRoot);
+            expect(backup.completedAt).toBeTruthy();
+            expect(backup.subsystems.mc.message).toContain('Exported');
+            expect(backup.subsystems.graph.message).toContain('Exported');
+            expect(backup.integrity.filter(check => check.status === 'fail')).toEqual([]);
+
+            await callJsonTool(client, 'purge_session', {sessionId});
+            truncateGraph();
+
+            const wipedHealth = await callHealthcheck(MC_URL, {
+                clientName: 'neo-integration-backup-restore-health',
+                identity  : 'backup-restore'
+            });
+            expect(wipedHealth.status).toBe('healthy');
+            expect(wipedHealth.database.connection.connected).toBe(true);
+
+            const wipedResults = await callJsonTool(client, 'query_raw_memories', {
+                nResults: 5,
+                query   : sentinel,
+                sessionId
+            });
+            expect(memoryTexts(wipedResults)).not.toContain(sentinel);
+
+            const wipedGraph = readGraphEvidence(memoryId);
+            expect(wipedGraph.exists).toBe(false);
+
+            const restored = restoreBackupBundle(bundleRoot);
+            expect(restored.mode).toBe('merge');
+            expect(restored.subsystems.mc.imported).toBeGreaterThan(0);
+            expect(restored.subsystems.graph.imported).toBeGreaterThan(0);
+
+            const restoredResults = await callJsonTool(client, 'query_raw_memories', {
+                nResults: 5,
+                query   : sentinel,
+                sessionId
+            });
+            expect(memoryTexts(restoredResults)).toContain(sentinel);
+
+            const restoredGraph = readGraphEvidence(memoryId);
+            expect(restoredGraph.exists).toBe(true);
+            expect(restoredGraph.edgeCount).toBeGreaterThan(0);
+        } finally {
+            await Promise.allSettled([
+                callJsonTool(client, 'purge_session', {sessionId})
+            ]);
+
+            await Promise.allSettled([
+                client.close()
+            ]);
+
+            if (memoryId) {
+                cleanupGraphNode(memoryId);
+            }
+
+            cleanupBackupBundle(bundleRoot);
+        }
+    });
+});

--- a/test/playwright/unit/ai/mcp/server/memory-core/services/DatabaseService.graphBackup.spec.mjs
+++ b/test/playwright/unit/ai/mcp/server/memory-core/services/DatabaseService.graphBackup.spec.mjs
@@ -1,0 +1,124 @@
+import {setup} from '../../../../../../setup.mjs';
+
+const appName = 'MCGraphBackupTest';
+
+setup({
+    neoConfig: {
+        allowVdomUpdatesInTests: false,
+        unitTestMode           : true,
+        useDomApiRenderer      : false
+    },
+    appConfig: {
+        name             : appName,
+        isMounted        : () => true,
+        vnodeInitialising: false
+    }
+});
+
+import {test, expect}  from '@playwright/test';
+import Neo             from '../../../../../../../../src/Neo.mjs';
+import * as core       from '../../../../../../../../src/core/_export.mjs';
+import InstanceManager from '../../../../../../../../src/manager/Instance.mjs';
+import fs              from 'fs';
+import path            from 'path';
+
+// Serial mode: this file rewires singleton graph storage to a temporary SQLite file.
+test.describe.configure({mode: 'serial'});
+
+test.describe('Memory_DatabaseService — graph backup import (#10949)', () => {
+    let GraphService, Memory_DatabaseService, SystemLifecycleService;
+    let graphPath, tmpDir;
+
+    test.beforeAll(async () => {
+        const aiConfig = (await import('../../../../../../../../ai/mcp/server/memory-core/config.mjs')).default;
+
+        tmpDir    = path.resolve(process.cwd(), 'tmp', `mc-graph-backup-${process.pid}-${Date.now()}`);
+        graphPath = path.join(tmpDir, 'memory-core-graph.sqlite');
+
+        fs.mkdirSync(tmpDir, {recursive: true});
+
+        if (!aiConfig.storagePaths) aiConfig.storagePaths = {};
+        if (!aiConfig.collections) aiConfig.collections = {};
+        aiConfig.storagePaths.graph = graphPath;
+        aiConfig.collections.memory = `test-memory-${process.pid}-${Date.now()}`;
+        aiConfig.collections.session = `test-session-${process.pid}-${Date.now()}`;
+
+        const SDK = await import('../../../../../../../../ai/services.mjs');
+        Memory_DatabaseService = SDK.Memory_DatabaseService;
+        GraphService           = (await import('../../../../../../../../ai/mcp/server/memory-core/services/GraphService.mjs')).default;
+        SystemLifecycleService = (await import('../../../../../../../../ai/mcp/server/memory-core/services/lifecycle/SystemLifecycleService.mjs')).default;
+
+        const {TestLifecycleHelper} = await import('../util.mjs');
+        await TestLifecycleHelper.cleanupGraphService(GraphService, SystemLifecycleService, graphPath, fs, 'destroy');
+
+        if (!SystemLifecycleService._initPromise) {
+            await SystemLifecycleService.initAsync();
+        } else {
+            await SystemLifecycleService.ready();
+        }
+    });
+
+    test.beforeEach(async () => {
+        if (GraphService.db?.storage) {
+            await GraphService.db.storage.clear();
+            GraphService.db.storage.db.exec('DELETE FROM GraphLog');
+            GraphService.db.nodes.clear();
+            GraphService.db.edges.clear();
+            GraphService.db.vicinityLoadedNodes.clear();
+        }
+    });
+
+    test.afterAll(async () => {
+        const {cleanupChromaManager, TestLifecycleHelper} = await import('../util.mjs');
+        await cleanupChromaManager();
+        await TestLifecycleHelper.cleanupGraphService(GraphService, SystemLifecycleService, graphPath, fs, 'destroy');
+
+        if (tmpDir && fs.existsSync(tmpDir)) {
+            fs.rmSync(tmpDir, {recursive: true, force: true});
+        }
+    });
+
+    test('restores exported edges with their required type column intact', async () => {
+        GraphService.upsertNode({id: 'graph-backup-source', type: 'TestNode'});
+        GraphService.upsertNode({id: 'graph-backup-target', type: 'TestNode'});
+        GraphService.linkNodes('graph-backup-source', 'graph-backup-target', 'TEST_RESTORE_EDGE', 0.7, {
+            reason: 'unit backup restore proof'
+        });
+
+        const exportResult = await Memory_DatabaseService.manageDatabaseBackup({
+            action    : 'export',
+            include   : ['graph'],
+            backupPath: tmpDir
+        });
+
+        expect(exportResult.message).toContain('graph elements');
+
+        const graphBackupFile = fs.readdirSync(tmpDir)
+            .find(file => file.startsWith('graph-backup-') && file.endsWith('.jsonl'));
+
+        expect(graphBackupFile).toBeTruthy();
+
+        const db = GraphService.db.storage.db;
+        db.exec('DELETE FROM Edges; DELETE FROM Nodes;');
+
+        const importResult = await Memory_DatabaseService.manageDatabaseBackup({
+            action: 'import',
+            file  : path.join(tmpDir, graphBackupFile),
+            mode  : 'merge'
+        });
+
+        expect(importResult.imported).toBeGreaterThanOrEqual(3);
+
+        const restoredEdge = db.prepare(`
+            SELECT id, source, target, type, data
+            FROM Edges
+            WHERE source = ?
+              AND target = ?
+              AND type = ?
+        `).get('graph-backup-source', 'graph-backup-target', 'TEST_RESTORE_EDGE');
+
+        expect(restoredEdge).toBeTruthy();
+        expect(restoredEdge.id).toBeTruthy();
+        expect(JSON.parse(restoredEdge.data).type).toBe('TEST_RESTORE_EDGE');
+    });
+});


### PR DESCRIPTION
Authored by GPT-5 (Codex Desktop) consuming @neo-opus-4-7 dispatch - session A c02fbf4e-870c-44c0-ba7e-e9ffacce094b, session B 1ed5570e-a33b-4a48-b05b-cda820c16bbb.

Resolves #10949
Related: #10945

Adds a Dockerized Memory Core integration spec that seeds a sentinel memory, verifies semantic and graph evidence, creates an atomic backup bundle, deliberately wipes the session plus Native Edge Graph node/edge evidence inside the disposable compose fixture, proves healthcheck remains green while the sentinel is gone, then restores the bundle and verifies both semantic search and graph edges return. The branch also fixes the graph JSONL importer so restored edges preserve SQLite schema-required `id`, `user_id`, `source`, `target`, and `type` columns.

Evidence: L4 (GitHub Actions Docker integration job executed the deployed compose fixture and passed on `56d36f0c1`) -> L4 required (#10949 deployed destructive backup/wipe/restore proof). No residuals.

## Deltas from ticket

No product-scope additions. The test uses existing backup/restore orchestration and existing healthcheck/readiness surfaces rather than adding a new daemon-internal wipe alarm, matching the #10854 constraint. AC4 is implemented as an integration readiness/durability assertion: process health is intentionally shown insufficient, then semantic query and graph evidence provide the detector.

The Docker CI runs exposed two implementation gaps that are now fixed on this branch: container-side eval snippets needed Neo bootstrap before importing backup scripts, and graph import needed to write the full `Edges` schema rather than only `source`, `target`, and `data`.

## Test Evidence

- `node --check test/playwright/integration/BackupRestoreWipe.integration.spec.mjs` passed.
- `node --check ai/mcp/server/memory-core/services/DatabaseService.mjs` passed.
- `node --check test/playwright/unit/ai/mcp/server/memory-core/services/DatabaseService.graphBackup.spec.mjs` passed.
- `npm run test-unit -- test/playwright/unit/ai/mcp/server/memory-core/services/DatabaseService.graphBackup.spec.mjs` passed: 1 passed.
- `npm run test-unit -- test/playwright/unit/ai/buildScripts/backup.spec.mjs test/playwright/unit/ai/buildScripts/restore.spec.mjs test/playwright/unit/ai/mcp/server/memory-core/services/DatabaseService.graphBackup.spec.mjs` passed: 19 passed.
- `git diff --check origin/dev...HEAD` passed.
- Local `npm run test-integration -- test/playwright/integration/BackupRestoreWipe.integration.spec.mjs` exited 0 with 1 skipped because this environment has no Docker binary.
- GitHub Actions on `56d36f0c1`: CodeQL success, unit success, integration success, Analyze (javascript) success.

## Post-Merge Validation

None required for #10949. The Docker integration proof passed before ready-for-review handoff.

## Commits

- `38f511c47` - `feat(memory-core): cover backup restore wipe detection (#10949)`
- `72585a496` - `fix(memory-core): supply required graph columns on import (#10949)`
- `56d36f0c1` - `fix(memory-core): preserve graph edge schema on restore (#10949)`