### PR TITLE
fix(ai): replace Claude wake Space seed (#10987)

### DIFF
--- a/ai/scripts/bridge-daemon.mjs
+++ b/ai/scripts/bridge-daemon.mjs
@@ -719,11 +719,17 @@ async function deliverDigest(subscription, digest) {
                 if (appName === 'Claude') tabShortcut = '3';
                 else if (appName === 'Antigravity') tabShortcut = 'shift+i';
             }
-            let focusSeedKey = meta.focusSeedKey;
+            let focusSeedKey      = meta.focusSeedKey;
+            let focusSeedSequence = meta.focusSeedSequence;
             // Claude Desktop's Cmd+3 selects the Code tab but does not always move focus into
-            // the prompt. Seed focus with Space before the destructive Cmd+A/Cmd+X clear path.
-            // Keep this opt-in per harness; Antigravity already owns an idempotent Cmd+Shift+I route.
-            if (focusSeedKey === undefined && appName === 'Claude') focusSeedKey = 'space';
+            // the prompt. Space used to be the non-mutating seed (#10660), but the 2026-05-08
+            // Claude Desktop UI made chat-history tool-call summaries focusable; Space can now
+            // expand/collapse those summaries instead of focusing the prompt. Use an explicit
+            // probe-and-undo sequence before the destructive Cmd+A/Cmd+X clear path (#10987).
+            // Keep this per harness; Antigravity already owns an idempotent Cmd+Shift+I route.
+            if (focusSeedSequence === undefined && focusSeedKey === undefined && appName === 'Claude') {
+                focusSeedSequence = 'r-undo';
+            }
 
             // [Anchor & Echo] Codex fail-closed (#10664) — empirical disproval 2026-05-03:
             //
@@ -814,7 +820,12 @@ async function deliverDigest(subscription, digest) {
                 osascriptArgs.push('-e', '      delay 0.5');
             }
 
-            if (focusSeedKey) {
+            if (focusSeedSequence === 'r-undo') {
+                osascriptArgs.push('-e', '      keystroke "r"');
+                osascriptArgs.push('-e', '      delay 0.2');
+                osascriptArgs.push('-e', '      keystroke "z" using command down');
+                osascriptArgs.push('-e', '      delay 0.2');
+            } else if (focusSeedKey) {
                 if (focusSeedKey === 'space' || focusSeedKey === ' ') {
                     osascriptArgs.push('-e', '      key code 49');
                 } else {

--- a/test/playwright/unit/ai/scripts/bridge-daemon.spec.mjs
+++ b/test/playwright/unit/ai/scripts/bridge-daemon.spec.mjs
@@ -583,7 +583,7 @@ test.describe('Bridge Daemon', () => {
         expect(args.join(' ')).not.toContain('key code 49');
     });
 
-    test('Claude default focus seed generates Space after Cmd+3 and before prompt clear', async () => {
+    test('Claude default focus seed emits r -> Cmd+Z before prompt clear (#10987)', async () => {
         const subId = 'sub_' + crypto.randomUUID();
         const agentId = '@test-agent-claude';
 
@@ -662,16 +662,20 @@ test.describe('Bridge Daemon', () => {
 
         await deliveryPromise;
 
-        const args = JSON.parse(fs.readFileSync(mockOutPath, 'utf8'));
-        const activateIndex = args.findIndex(arg => arg.includes('tell application "Claude" to activate'));
-        const tabIndex      = args.findIndex(arg => arg.includes('keystroke "3" using command down'));
-        const spaceIndex    = args.findIndex(arg => arg.includes('key code 49'));
-        const clearIndex    = args.findIndex(arg => arg.includes('keystroke "a" using command down'));
+        const args          = JSON.parse(fs.readFileSync(mockOutPath, 'utf8'));
+        const scriptContent = args.filter((_, i) => args[i - 1] === '-e').join('\n');
+        const activateIndex = scriptContent.indexOf('tell application "Claude" to activate');
+        const tabIndex      = scriptContent.indexOf('keystroke "3" using command down');
+        const rIndex        = scriptContent.indexOf('keystroke "r"');
+        const zIndex        = scriptContent.indexOf('keystroke "z" using command down');
+        const clearIndex    = scriptContent.indexOf('keystroke "a" using command down');
 
         expect(activateIndex).toBeGreaterThan(-1);
         expect(tabIndex).toBeGreaterThan(activateIndex);
-        expect(spaceIndex).toBeGreaterThan(tabIndex);
-        expect(clearIndex).toBeGreaterThan(spaceIndex);
+        expect(rIndex).toBeGreaterThan(tabIndex);
+        expect(zIndex).toBeGreaterThan(rIndex);
+        expect(clearIndex).toBeGreaterThan(zIndex);
+        expect(scriptContent).not.toContain('key code 49');
     });
 
     test('Codex UI wake fails closed when no validated focusSeedKey is configured (#10664)', async () => {


### PR DESCRIPTION
Resolves #10987

Authored by GPT-5.5 (Codex Desktop). Session 1ed5570e-a33b-4a48-b05b-cda820c16bbb.

Replaces Claude Desktop wake seeding from Space to an explicit `r -> Cmd+Z` probe-and-undo sequence before the destructive clear/paste path. This keeps `meta.focusSeedKey` distinct from the new multi-step default sequence, leaves Codex and Antigravity behavior unchanged, and updates the bridge-daemon unit coverage so Claude no longer emits `key code 49` by default.

Evidence: L2 (mock osascript argv capture + focused Playwright bridge-daemon unit file) -> L4 required (manual Claude Desktop focus-state matrix against the real 2026-05-08 UI). Residual: host-side manual matrix validation [#10987].

## Deltas from ticket

- Implemented Claude default via internal `focusSeedSequence = r-undo` rather than a bare `focusSeedKey: r` value.
- Kept existing Codex `focusSeedKey: r` cleanup path unchanged to avoid widening the urgent fix.
- Preserved Antigravity shortcut behavior.

## Test Evidence

- `node --check ai/scripts/bridge-daemon.mjs`
- `node --check test/playwright/unit/ai/scripts/bridge-daemon.spec.mjs`
- `git diff --check`
- `git diff --cached --check`
- `npm run test-unit -- test/playwright/unit/ai/scripts/bridge-daemon.spec.mjs` -> first sandboxed run failed before assertions because `.neo-ai-data/sqlite` symlinks outside the writable root; rerun with approved escalation passed: 13 passed in 11.2s.

## Post-Merge Validation

- [ ] Validate Claude Desktop real UI states: prompt focused empty, prompt focused with draft, prompt unfocused empty, prompt unfocused with draft, and chat-history/tool-call-summary focused.
- [ ] Confirm tool-call summaries do not expand or collapse during wake delivery.
- [ ] Confirm wake payload lands in the Claude prompt and submits.

## Commit

- `ce0c6fbb4` — `fix(ai): replace Claude wake Space seed (#10987)`
