### PR TITLE
feat(agentos): codify post-review pickup discipline (#10970)

### DIFF
--- a/.agents/skills/post-review-pickup/SKILL.md
+++ b/.agents/skills/post-review-pickup/SKILL.md
@@ -1,0 +1,9 @@
+---
+name: post-review-pickup
+description: Authoritative protocol for immediate next-phase pickup after PR review or author response handoff. Prevents silent idle after review cycles by requiring the next lane or an explicit halt-state.
+triggers: Use immediately after posting a PR review, chaining a formal GitHub review state, or posting an author review-response handoff with a commentId.
+---
+
+# Post-Review Pickup Skill
+
+If you just completed a PR review or review-response handoff, you MUST immediately use the `view_file` tool to read and strictly adhere to `.agents/skills/post-review-pickup/references/post-review-pickup-workflow.md` before ending the turn.

--- a/.agents/skills/post-review-pickup/references/post-review-pickup-workflow.md
+++ b/.agents/skills/post-review-pickup/references/post-review-pickup-workflow.md
@@ -1,0 +1,83 @@
+# Post-Review Pickup Workflow
+
+This payload is the Atlas entry for post-review-cycle pickup discipline. Keep
+the surrounding PR lifecycle documents as maps: they identify when this skill
+fires, but the operational matrices live here so the high-level workflow files
+do not accumulate edge-case payload.
+
+## 1. Trigger
+
+Use this skill immediately after one of these lifecycle handoffs:
+
+- Reviewer posts a substantive PR review, chains a formal GitHub review state
+  when required, and sends the A2A commentId handoff.
+- Author posts a review-response comment with fixup commits and sends the
+  author-side A2A commentId handoff.
+
+The goal is to prevent silent idle after a handoff. The handled PR is now owned
+by the next actor in that cycle; unrelated ready lanes can proceed in parallel.
+
+## 2. Reviewer Pickup Matrix
+
+After completing the reviewer-side handoff, the reviewer MUST choose one of
+these next states before ending the turn:
+
+| Review verdict just posted | Next pickup target |
+|---|---|
+| `Approve` or `Approve+Follow-Up` | Treat the PR as at the human merge gate per `AGENTS.md §0`; then pick up the next assigned ticket, next implementation lane, follow-up ticket creation, or another review request. If the verdict named non-blocking follow-ups and the reviewer owns them, file or claim that follow-up before halting. |
+| `Request Changes` | The author owns the response cycle. Do not wait on that PR unless the author immediately pings back with a blocker. Pick up a different lane: another PR review, an assigned ticket, or a follow-up ticket surfaced by the review. |
+| `Drop+Supersede` | If the reviewer owns the superseding work, enter that ticket-create / ticket-intake / PR lane immediately. If another agent owns it, send the handoff and pick up the next unrelated lane. |
+
+If no next lane is identifiable, report an explicit halt-state instead of
+silently ending the turn, for example:
+
+```text
+halt-state: no assigned or operator-obvious lane remains after #NNNN review; awaiting routing.
+```
+
+## 3. Author Pickup Matrix
+
+After posting review-response fixups and the author-side commentId handoff, the
+author MUST choose one of these next states before ending the turn:
+
+| Author state after response | Next pickup target |
+|---|---|
+| Fixup commits pushed and re-review requested | Start the next assigned ticket, draft the next ready PR, file the follow-up ticket discovered during the response, or review a separate PR if that is the current lane. |
+| Current PR still blocks all local work | Say so explicitly and name the blocker, e.g. `halt-state: awaiting reviewer response on #NNNN; no independent lane assigned.` |
+| Reviewer feedback produced a superseding direction | Enter the superseding ticket / PR creation lane if the author owns it; otherwise hand off the supersede target and pick up the next unrelated lane. |
+
+## 4. Legitimate Halt States
+
+Halt is allowed only when it is explicit and true:
+
+- No assigned or operator-obvious lane remains.
+- Every candidate lane is blocked on human-only action.
+- A safety gate forbids continuing.
+- The operator explicitly requested a pause.
+- Context exhaustion requires `session-sunset`.
+
+Do not broadcast generic "idle" state. If work is blocked, send a targeted
+task/blocker signal using the appropriate A2A shape.
+
+## 5. Integration Points
+
+- `pr-review-guide.md §11` is the reviewer-side map pointer into this skill.
+- `pull-request-workflow.md §6.3` is the author-side map pointer into this
+  skill.
+- `review-response-protocol.md §14` remains the author-side commentId handoff
+  source of truth.
+- `pr-review-guide.md §10` remains the reviewer-side commentId handoff source
+  of truth.
+
+This is the public successor anchor for the `feedback_peer_not_assistant_mode`
+lineage: act as a peer progressing lifecycle phases, not as an assistant waiting
+for the next prompt. Ticket #10970 is the instance-codification.
+
+## 6. Anti-Patterns
+
+| Anti-pattern | Why it harms |
+|---|---|
+| Ending the turn after `Approved` without checking the next lane | Leaves the swarm idle at the human merge gate even when unrelated work is ready. |
+| Waiting for author response after `Request Changes` | Serializes work that can proceed in parallel. |
+| Broadcasting generic idle/capacity status | Creates coordination noise without assigning ownership or naming the blocker. |
+| Duplicating this matrix into PR lifecycle maps | Violates the Map vs Atlas split and increases routine context load. |

--- a/.agents/skills/pr-review/references/pr-review-guide.md
+++ b/.agents/skills/pr-review/references/pr-review-guide.md
@@ -441,3 +441,36 @@ CommentId-scoped fetch is the **warm-cache** path — the reviewer or author has
 The dichotomy mirrors the boot-pull-vs-sunset-pull lifecycle distinction (`AGENTS_STARTUP §0` vs `session-sunset` skill body Step 1): **warm path** optimizes for incremental context; **cold path** grounds from scratch. They are NOT symmetric operations — they fill different lifecycle gaps. Don't confuse them: rigidly applying commentId-scoped fetch in a cold-cache case lands one isolated comment without the context it depends on; over-fetching on principle in a warm-cache case defeats the linear-cost scaling.
 
 **The right reflex** — before fetching, ask: *"do I have prior cycle context loaded in this context window?"* If yes → commentId-scoped fetch (or `since_comment_id` for incremental polling across stale-anchor recovery). If no → full-thread fetch + memory query for grounding.
+
+## 11. Post-Review-Cycle Reviewer Pickup
+
+After a reviewer posts the substantive review, chains the formal GitHub review
+state when required, and sends the A2A commentId handoff, the reviewer MUST not
+silently idle while unrelated lanes are ready. The review has handed that PR
+back to the author or human merge gate; the reviewer should immediately enter
+the next lifecycle phase unless a legitimate halt state applies.
+
+The same turn MUST choose one of these outcomes:
+
+| Review verdict just posted | Next pickup target |
+|---|---|
+| `Approve` or `Approve+Follow-Up` | Treat the PR as at the human merge gate per `AGENTS.md §0`; then pick up the next assigned ticket, next implementation lane, follow-up ticket creation, or another review request. If the verdict named non-blocking follow-ups and the reviewer owns them, file or claim that follow-up before halting. |
+| `Request Changes` | The author owns the response cycle. Do not wait on that PR unless the author immediately pings back with a blocker. Pick up a different lane: another PR review, an assigned ticket, or a follow-up ticket surfaced by the review. |
+| `Drop+Supersede` | If the reviewer owns the superseding work, enter that ticket-create / ticket-intake / PR lane immediately. If another agent owns it, send the handoff and pick up the next unrelated lane. |
+
+If no next lane is identifiable, the reviewer MUST report an explicit halt
+state instead of silently ending the turn, e.g. "halt-state: no assigned or
+operator-obvious lane remains after #NNNN review; awaiting routing." This is the
+public skill codification of the `feedback_peer_not_assistant_mode` lineage:
+act as a peer progressing lifecycle phases, not as an assistant waiting for the
+next prompt.
+
+Legitimate halt states include: no assigned or obvious lane remains, every
+candidate lane is blocked on human-only action, a safety gate forbids continuing,
+the operator explicitly requested a pause, or context exhaustion requires
+`session-sunset`. This rule does not authorize generic idle broadcasts; if work
+is blocked, send a targeted task/blocker signal using the appropriate A2A shape.
+
+Author-side symmetry lives in `pull-request-workflow.md §6.3`: after an author
+posts review-response fixups and hands the PR back for re-review, they also MUST
+queue the next author lane or state the blocker explicitly.

--- a/.agents/skills/pr-review/references/pr-review-guide.md
+++ b/.agents/skills/pr-review/references/pr-review-guide.md
@@ -445,32 +445,12 @@ The dichotomy mirrors the boot-pull-vs-sunset-pull lifecycle distinction (`AGENT
 ## 11. Post-Review-Cycle Reviewer Pickup
 
 After a reviewer posts the substantive review, chains the formal GitHub review
-state when required, and sends the A2A commentId handoff, the reviewer MUST not
-silently idle while unrelated lanes are ready. The review has handed that PR
-back to the author or human merge gate; the reviewer should immediately enter
-the next lifecycle phase unless a legitimate halt state applies.
+state when required, and sends the A2A commentId handoff, the reviewer MUST
+invoke the `post-review-pickup` skill before ending the turn.
 
-The same turn MUST choose one of these outcomes:
-
-| Review verdict just posted | Next pickup target |
-|---|---|
-| `Approve` or `Approve+Follow-Up` | Treat the PR as at the human merge gate per `AGENTS.md §0`; then pick up the next assigned ticket, next implementation lane, follow-up ticket creation, or another review request. If the verdict named non-blocking follow-ups and the reviewer owns them, file or claim that follow-up before halting. |
-| `Request Changes` | The author owns the response cycle. Do not wait on that PR unless the author immediately pings back with a blocker. Pick up a different lane: another PR review, an assigned ticket, or a follow-up ticket surfaced by the review. |
-| `Drop+Supersede` | If the reviewer owns the superseding work, enter that ticket-create / ticket-intake / PR lane immediately. If another agent owns it, send the handoff and pick up the next unrelated lane. |
-
-If no next lane is identifiable, the reviewer MUST report an explicit halt
-state instead of silently ending the turn, e.g. "halt-state: no assigned or
-operator-obvious lane remains after #NNNN review; awaiting routing." This is the
-public skill codification of the `feedback_peer_not_assistant_mode` lineage:
-act as a peer progressing lifecycle phases, not as an assistant waiting for the
-next prompt.
-
-Legitimate halt states include: no assigned or obvious lane remains, every
-candidate lane is blocked on human-only action, a safety gate forbids continuing,
-the operator explicitly requested a pause, or context exhaustion requires
-`session-sunset`. This rule does not authorize generic idle broadcasts; if work
-is blocked, send a targeted task/blocker signal using the appropriate A2A shape.
-
-Author-side symmetry lives in `pull-request-workflow.md §6.3`: after an author
-posts review-response fixups and hands the PR back for re-review, they also MUST
-queue the next author lane or state the blocker explicitly.
+The reviewer-side matrix, legitimate halt states, and targeted-blocker rule live
+in `.agents/skills/post-review-pickup/references/post-review-pickup-workflow.md`.
+That payload is the Atlas entry; this section is only the map pointer that fires
+after `pr-review` completes. Author-side symmetry is mapped from
+`pull-request-workflow.md §6.3`. This is the public skill codification of the
+`feedback_peer_not_assistant_mode` lineage.

--- a/.agents/skills/pull-request/references/pull-request-workflow.md
+++ b/.agents/skills/pull-request/references/pull-request-workflow.md
@@ -215,6 +215,32 @@ To prevent redundant parallel effort and reviewer collision, you MUST adhere to 
 
 This strict role-based feedback loop prevents duplicated work and confusion over PR ownership when multiple agents are running concurrently. This rule strictly applies only to the `neomjs/neo` repo for the core team; it does NOT affect external contributors, forks, or users of `npx neo-app` workspaces.
 
+### 6.3 Post-Review-Cycle Author Pickup
+
+After an author posts a review-response comment with fixup commits and the
+author-side A2A commentId handoff (`review-response-protocol.md §14`), the
+author MUST avoid a silent idle halt. The author has handed that PR back to the
+reviewer, but unrelated author work can proceed in parallel with the re-review
+cycle.
+
+The same turn MUST choose one of these outcomes:
+
+| Author state after response | Next pickup target |
+|---|---|
+| Fixup commits pushed and re-review requested | Start the next assigned ticket, draft the next ready PR, file the follow-up ticket discovered during the response, or review a separate PR if that is the current lane. |
+| Current PR still blocks all local work | Say so explicitly and name the blocker, e.g. "halt-state: awaiting reviewer response on #NNNN; no independent lane assigned." |
+| Reviewer feedback produced a superseding direction | Enter the superseding ticket / PR creation lane if the author owns it; otherwise hand off the supersede target and pick up the next unrelated lane. |
+
+This rule is the author-side counterpart to `pr-review-guide.md §11`
+Post-Review-Cycle Reviewer Pickup. It is the public skill codification of the
+`feedback_peer_not_assistant_mode` lineage: do the next obvious lifecycle phase
+instead of behaving like an assistant waiting for the next chat message.
+
+Legitimate halt states exist, but they MUST be explicit: no assigned or obvious
+lane remains, all candidate lanes are blocked on human-only action, a safety
+gate forbids continuing, or the operator explicitly requested a pause. Do not
+broadcast generic "idle" state; if blocked, use a targeted task/blocker signal.
+
 ## 8. PR Comment Hygiene & A2A Propagation (Edge-Case)
 
 *If responding to reviewer feedback across multiple rounds, read `.agents/skills/pull-request/references/review-response-protocol.md`; otherwise skip.*

--- a/.agents/skills/pull-request/references/pull-request-workflow.md
+++ b/.agents/skills/pull-request/references/pull-request-workflow.md
@@ -219,27 +219,14 @@ This strict role-based feedback loop prevents duplicated work and confusion over
 
 After an author posts a review-response comment with fixup commits and the
 author-side A2A commentId handoff (`review-response-protocol.md §14`), the
-author MUST avoid a silent idle halt. The author has handed that PR back to the
-reviewer, but unrelated author work can proceed in parallel with the re-review
-cycle.
+author MUST invoke the `post-review-pickup` skill before ending the turn.
 
-The same turn MUST choose one of these outcomes:
-
-| Author state after response | Next pickup target |
-|---|---|
-| Fixup commits pushed and re-review requested | Start the next assigned ticket, draft the next ready PR, file the follow-up ticket discovered during the response, or review a separate PR if that is the current lane. |
-| Current PR still blocks all local work | Say so explicitly and name the blocker, e.g. "halt-state: awaiting reviewer response on #NNNN; no independent lane assigned." |
-| Reviewer feedback produced a superseding direction | Enter the superseding ticket / PR creation lane if the author owns it; otherwise hand off the supersede target and pick up the next unrelated lane. |
-
-This rule is the author-side counterpart to `pr-review-guide.md §11`
-Post-Review-Cycle Reviewer Pickup. It is the public skill codification of the
-`feedback_peer_not_assistant_mode` lineage: do the next obvious lifecycle phase
-instead of behaving like an assistant waiting for the next chat message.
-
-Legitimate halt states exist, but they MUST be explicit: no assigned or obvious
-lane remains, all candidate lanes are blocked on human-only action, a safety
-gate forbids continuing, or the operator explicitly requested a pause. Do not
-broadcast generic "idle" state; if blocked, use a targeted task/blocker signal.
+The author-side matrix, legitimate halt states, and targeted-blocker rule live
+in `.agents/skills/post-review-pickup/references/post-review-pickup-workflow.md`.
+That payload is the Atlas entry; this section is only the map pointer that fires
+after review-response handoff completes. Reviewer-side symmetry is mapped from
+`pr-review-guide.md §11`. This is the public skill codification of the
+`feedback_peer_not_assistant_mode` lineage.
 
 ## 8. PR Comment Hygiene & A2A Propagation (Edge-Case)
 

--- a/.claude/skills/post-review-pickup
+++ b/.claude/skills/post-review-pickup
@@ -1,0 +1,1 @@
+../../.agents/skills/post-review-pickup

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -94,6 +94,7 @@ You are part of the core architectural team. **Synthesize friction into gold:** 
 | `epic-resolution` | Last required sub closes / before close-as-completed |
 | `pull-request` | Code modifications complete; before opening PR — stepping-back reflection, commit format, cross-family review mandate, post-comment A2A commentId hand-off (author→reviewer) per review-response-protocol.md §14, Evidence declaration line for substrate/runtime-AC PRs per [evidence-ladder.md](learn/agentos/evidence-ladder.md) |
 | `pr-review` | Reviewing a PR (yours or peer's) — structured eval metrics, graph ingestion tags, severity ladder, restates §0 merge gate, post-comment A2A commentId hand-off (reviewer→author) per guide §9 + §9.4 cold-cache exception, Evidence Audit + Source-of-Authority sections (template §) for substrate/runtime-AC PRs and authority-citation review-comments |
+| `post-review-pickup` | Immediately after `pr-review` or review-response handoff completes — enter the next ready lifecycle lane or state an explicit halt reason per `pr-review-guide.md §11` / `pull-request-workflow.md §6.3` |
 | `ideation-sandbox`| Before creating a Discussion for architectural exploration |
 | `memory-mining` | On regression / non-obvious-architecture / decision-points |
 | `tech-debt-radar` | During PR review for fundamental architectural shifts |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -94,7 +94,7 @@ You are part of the core architectural team. **Synthesize friction into gold:** 
 | `epic-resolution` | Last required sub closes / before close-as-completed |
 | `pull-request` | Code modifications complete; before opening PR — stepping-back reflection, commit format, cross-family review mandate, post-comment A2A commentId hand-off (author→reviewer) per review-response-protocol.md §14, Evidence declaration line for substrate/runtime-AC PRs per [evidence-ladder.md](learn/agentos/evidence-ladder.md) |
 | `pr-review` | Reviewing a PR (yours or peer's) — structured eval metrics, graph ingestion tags, severity ladder, restates §0 merge gate, post-comment A2A commentId hand-off (reviewer→author) per guide §9 + §9.4 cold-cache exception, Evidence Audit + Source-of-Authority sections (template §) for substrate/runtime-AC PRs and authority-citation review-comments |
-| `post-review-pickup` | Immediately after `pr-review` or review-response handoff completes — enter the next ready lifecycle lane or state an explicit halt reason per `pr-review-guide.md §11` / `pull-request-workflow.md §6.3` |
+| `post-review-pickup` | Immediately after `pr-review` or review-response handoff completes — read `.agents/skills/post-review-pickup/references/post-review-pickup-workflow.md`, then enter the next ready lifecycle lane or state an explicit halt reason |
 | `ideation-sandbox`| Before creating a Discussion for architectural exploration |
 | `memory-mining` | On regression / non-obvious-architecture / decision-points |
 | `tech-debt-radar` | During PR review for fundamental architectural shifts |


### PR DESCRIPTION
Resolves #10970

Authored by GPT-5.5 (Codex Desktop). Session 1ed5570e-a33b-4a48-b05b-cda820c16bbb.

Codifies post-review-cycle pickup discipline using the Map vs Atlas split: `AGENTS.md`, `pr-review-guide.md`, and `pull-request-workflow.md` now act as map pointers, while the dedicated `post-review-pickup` skill payload carries the reviewer and author pickup matrices, halt states, and anti-patterns.

Evidence: L1 (static skill-contract diff + diff hygiene checks) -> L1 required (workflow contract only). No residuals.

## Slot Rationale
- Added `.agents/skills/post-review-pickup/SKILL.md` router: disposition `keep`; 3-axis rating high trigger-frequency after PR/review handoffs x high failure-severity for swarm idle x discipline-only enforceability. Router is 9 lines and only points to the payload.
- Added `.agents/skills/post-review-pickup/references/post-review-pickup-workflow.md`: disposition `move` into Atlas payload; 3-axis rating edge-triggered x high failure-severity x discipline-only. This is where the matrices and halt-state details belong.
- Modified `AGENTS.md` `post-review-pickup` row: disposition `compress-to-trigger`; one map row points to the Atlas payload instead of carrying operational detail.
- Rewrote `pr-review-guide.md §11` and `pull-request-workflow.md §6.3`: disposition `rewrite`; they now fire the skill and cross-link each other instead of duplicating the matrices. This addresses the Map vs World Atlas request-change.
- Added `.claude/skills/post-review-pickup` symlink: cross-harness visibility for the new canonical skill, no new always-loaded payload.
- Decay mitigation: retire or compress this skill if runtime task-state automation mechanically enforces post-review pickup.

## Deltas from ticket
- Created a standalone `post-review-pickup` skill after operator request-changes clarified that the first pass ignored Map vs World Atlas placement.
- Preserved `pr-review-guide.md §11` and `pull-request-workflow.md §6.3` as equivalent named map sections, while moving the load-bearing matrices into the skill payload.
- Preserved the private `feedback_peer_not_assistant_mode` lineage as provenance only; the load-bearing successor anchor now lives in committed repo paths.
- Noted during intake that parent epic #10960 still has stale label-to-Project wording after the operator correction. That is out of scope for this PR.

## Test Evidence
- `git diff --check`
- `git diff --cached --check`
- `git diff --check origin/dev...HEAD` after rebasing onto current `origin/dev`
- Verified skill structure: root `SKILL.md`, heavy content under `references/`, and `.claude/skills/post-review-pickup` symlink present.
- No Playwright tests run; this is a docs / workflow-skill substrate change with no runtime surface.

## Post-Merge Validation
- [ ] In the next PR review or review-response cycle, the acting agent invokes `post-review-pickup` and either picks the next ready lifecycle lane or states an explicit halt reason.

## Commits
- `242458f26` - `feat(agentos): codify post-review pickup discipline (#10970)`
- `2a062f988` - `fix(agentos): move post-review pickup into atlas skill (#10970)`