### PR TITLE
refactor(neural-link): migrate services to flat SDK boundary (#10994)

### DIFF
--- a/ai/mcp/server/neural-link/Server.mjs
+++ b/ai/mcp/server/neural-link/Server.mjs
@@ -1,9 +1,9 @@
 import BaseServer            from '../BaseServer.mjs';
 import aiConfig              from './config.mjs';
 import logger                from './logger.mjs';
-import ConnectionService     from './services/ConnectionService.mjs';
-import HealthService         from './services/HealthService.mjs';
-import {listTools, callTool} from './services/toolService.mjs';
+import ConnectionService     from '../../../services/neural-link/ConnectionService.mjs';
+import HealthService         from '../../../services/neural-link/HealthService.mjs';
+import {listTools, callTool} from '../../../services/neural-link/toolService.mjs';
 
 let _turnId = 0;
 

--- a/ai/mcp/server/neural-link/test_connection_service.mjs
+++ b/ai/mcp/server/neural-link/test_connection_service.mjs
@@ -1,6 +1,6 @@
 import Neo from '../../../../src/Neo.mjs';
 import * as core from '../../../../src/core/_export.mjs';
-import ConnectionService from './services/ConnectionService.mjs';
+import ConnectionService from '../../../services/neural-link/ConnectionService.mjs';
 
 console.log('ConnectionService imported');
 console.log('Is instance?', ConnectionService instanceof Neo.core.Base);

--- a/ai/services.mjs
+++ b/ai/services.mjs
@@ -59,13 +59,13 @@ Memory_Config.data.autoStartDatabase = false;
 Memory_Config.data.autoStartInference = false;
 
 // --- Neural Link Services ---
-import NeuralLink_ComponentService   from './mcp/server/neural-link/services/ComponentService.mjs';
-import NeuralLink_ConnectionService  from './mcp/server/neural-link/services/ConnectionService.mjs';
-import NeuralLink_DataService        from './mcp/server/neural-link/services/DataService.mjs';
-import NeuralLink_HealthService      from './mcp/server/neural-link/services/HealthService.mjs';
-import NeuralLink_InstanceService    from './mcp/server/neural-link/services/InstanceService.mjs';
-import NeuralLink_InteractionService from './mcp/server/neural-link/services/InteractionService.mjs';
-import NeuralLink_RuntimeService     from './mcp/server/neural-link/services/RuntimeService.mjs';
+import NeuralLink_ComponentService   from './services/neural-link/ComponentService.mjs';
+import NeuralLink_ConnectionService  from './services/neural-link/ConnectionService.mjs';
+import NeuralLink_DataService        from './services/neural-link/DataService.mjs';
+import NeuralLink_HealthService      from './services/neural-link/HealthService.mjs';
+import NeuralLink_InstanceService    from './services/neural-link/InstanceService.mjs';
+import NeuralLink_InteractionService from './services/neural-link/InteractionService.mjs';
+import NeuralLink_RuntimeService     from './services/neural-link/RuntimeService.mjs';
 import NeuralLink_Config             from './mcp/server/neural-link/config.mjs';
 
 NeuralLink_Config.data.autoConnect = false;

--- a/ai/services/neural-link/ComponentService.mjs
+++ b/ai/services/neural-link/ComponentService.mjs
@@ -1,4 +1,4 @@
-import Base              from '../../../../../src/core/Base.mjs';
+import Base              from '../../../src/core/Base.mjs';
 import ConnectionService from './ConnectionService.mjs';
 
 /**

--- a/ai/services/neural-link/ConnectionService.mjs
+++ b/ai/services/neural-link/ConnectionService.mjs
@@ -1,10 +1,10 @@
-import aiConfig  from '../config.mjs';
+import aiConfig  from '../../mcp/server/neural-link/config.mjs';
 import {spawn}   from 'child_process';
 import crypto    from 'crypto';
 import fs        from 'fs';
 import WebSocket from 'ws';
-import Base      from '../../../../../src/core/Base.mjs';
-import logger    from '../logger.mjs';
+import Base      from '../../../src/core/Base.mjs';
+import logger    from '../../mcp/server/neural-link/logger.mjs';
 
 /**
  * @summary Manages the connection to the Neural Link Bridge and orchestrates RPC calls.

--- a/ai/services/neural-link/DataService.mjs
+++ b/ai/services/neural-link/DataService.mjs
@@ -1,4 +1,4 @@
-import Base              from '../../../../../src/core/Base.mjs';
+import Base              from '../../../src/core/Base.mjs';
 import ConnectionService from './ConnectionService.mjs';
 
 /**

--- a/ai/services/neural-link/HealthService.mjs
+++ b/ai/services/neural-link/HealthService.mjs
@@ -1,6 +1,6 @@
-import Base              from '../../../../../src/core/Base.mjs';
+import Base              from '../../../src/core/Base.mjs';
 import ConnectionService from './ConnectionService.mjs';
-import logger            from '../logger.mjs';
+import logger            from '../../mcp/server/neural-link/logger.mjs';
 
 /**
  * @summary Monitors the health of the Neural Link MCP Server.

--- a/ai/services/neural-link/InstanceService.mjs
+++ b/ai/services/neural-link/InstanceService.mjs
@@ -1,4 +1,4 @@
-import Base              from '../../../../../src/core/Base.mjs';
+import Base              from '../../../src/core/Base.mjs';
 import ConnectionService from './ConnectionService.mjs';
 
 /**

--- a/ai/services/neural-link/InteractionService.mjs
+++ b/ai/services/neural-link/InteractionService.mjs
@@ -1,4 +1,4 @@
-import Base              from '../../../../../src/core/Base.mjs';
+import Base              from '../../../src/core/Base.mjs';
 import ConnectionService from './ConnectionService.mjs';
 
 /**

--- a/ai/services/neural-link/RecorderService.mjs
+++ b/ai/services/neural-link/RecorderService.mjs
@@ -1,9 +1,9 @@
 import crypto from 'crypto';
 import fs     from 'fs-extra';
 import path   from 'path';
-import Base   from '../../../../../src/core/Base.mjs';
-import config from '../config.mjs';
-import logger from '../logger.mjs';
+import Base   from '../../../src/core/Base.mjs';
+import config from '../../mcp/server/neural-link/config.mjs';
+import logger from '../../mcp/server/neural-link/logger.mjs';
 
 const MS_PER_DAY = 24 * 60 * 60 * 1000;
 

--- a/ai/services/neural-link/RuntimeService.mjs
+++ b/ai/services/neural-link/RuntimeService.mjs
@@ -1,4 +1,4 @@
-import Base              from '../../../../../src/core/Base.mjs';
+import Base              from '../../../src/core/Base.mjs';
 import ConnectionService from './ConnectionService.mjs';
 
 /**

--- a/ai/services/neural-link/toolService.mjs
+++ b/ai/services/neural-link/toolService.mjs
@@ -1,6 +1,6 @@
 import path               from 'path';
 import {fileURLToPath}    from 'url';
-import ToolService        from '../../../ToolService.mjs';
+import ToolService        from '../../mcp/ToolService.mjs';
 import ComponentService   from './ComponentService.mjs';
 import ConnectionService  from './ConnectionService.mjs';
 import DataService        from './DataService.mjs';
@@ -11,9 +11,9 @@ import RuntimeService     from './RuntimeService.mjs';
 
 const __filename      = fileURLToPath(import.meta.url);
 const __dirname       = path.dirname(__filename);
-const openApiFilePath = path.join(__dirname, '../openapi.yaml');
+const openApiFilePath = path.join(__dirname, '../../mcp/server/neural-link/openapi.yaml');
 
-import {getCurrentTurnId} from '../Server.mjs';
+import {getCurrentTurnId} from '../../mcp/server/neural-link/Server.mjs';
 import RecorderService    from './RecorderService.mjs';
 
 const serviceMapping = {

--- a/test/playwright/unit/ai/services/neural-link/RecorderService.spec.mjs
+++ b/test/playwright/unit/ai/services/neural-link/RecorderService.spec.mjs
@@ -1,4 +1,4 @@
-import {setup} from '../../../../../setup.mjs';
+import {setup} from '../../../../setup.mjs';
 
 const appName = 'RecorderServiceTest';
 
@@ -14,8 +14,8 @@ setup({
 });
 
 import {test, expect} from '@playwright/test';
-import Neo            from '../../../../../../../src/Neo.mjs';
-import * as core      from '../../../../../../../src/core/_export.mjs';
+import Neo            from '../../../../../../src/Neo.mjs';
+import * as core      from '../../../../../../src/core/_export.mjs';
 import fs             from 'fs';
 import path           from 'path';
 
@@ -26,8 +26,8 @@ test.describe('Neo.ai.mcp.server.neural-link.services.RecorderService', () => {
     let testDbPath;
     
     test.beforeAll(async () => {
-        config = (await import('../../../../../../../ai/mcp/server/neural-link/config.mjs')).default;
-        RecorderService = (await import('../../../../../../../ai/mcp/server/neural-link/services/RecorderService.mjs')).default;
+        config = (await import('../../../../../../ai/mcp/server/neural-link/config.mjs')).default;
+        RecorderService = (await import('../../../../../../ai/services/neural-link/RecorderService.mjs')).default;
         
         const tmpDir = path.resolve(process.cwd(), 'tmp');
         if (!fs.existsSync(tmpDir)) {


### PR DESCRIPTION
Resolves #10994

Authored by Claude Opus 4.7 (Claude Code). Session 33ed57b5-10ed-491d-8b8f-ce5f1223ec38.

Migrates 9 entities from `ai/mcp/server/neural-link/services/` to the canonical `ai/services/neural-link/` flat SDK boundary, mirroring KB (#10995) and GH-WF (#10997) M6 patterns. The 7 currently-aliased `NeuralLink_*` services preserved at `ai/services.mjs` so all consumers (operator scripts, daemons, tests) work unchanged via the alias contract.

Evidence: L1 (static config-shape audit + local test runner verification — `npm run test-unit` against migrated specs) → L1 required (no runtime-verify ACs beyond unit + integration coverage). No residuals.

## Diff Summary Table (#10994 AC12)

| Metric | Count |
|---|---|
| Service files migrated | 9 (Component / Connection / Data / Health / Instance / Interaction / Recorder / Runtime / tool) |
| `NeuralLink_*` SDK aliases preserved at `ai/services.mjs` | 7 (RecorderService + toolService remain internal) |
| Consumer-side breakage delta | 0 (aliases hold; no consumer code changes required) |
| Internal cross-references updated | 18 import-paths across 9 services (Base.mjs 5→3 levels; `../config.mjs` / `../logger.mjs` rerouted) |
| Special-case path edits in `toolService.mjs` | 3 (`ToolService.mjs` at `ai/mcp/`; `getCurrentTurnId` from NL Server.mjs; `openapi.yaml` `path.join`) |
| `Server.mjs` import-path edits | 3 (ConnectionService + HealthService + toolService) |
| Test spec relocations | 1 (`RecorderService.spec.mjs` to canonical SDK location) |
| Tracked helpers updated post-migration | 1 (`test_connection_service.mjs` — caught by Cycle 1 review) |

## Deltas from ticket (if any)

None — scope matches #10994 body exactly. NL is the cleanest M6 sub-issue (no sibling subdirs; just `services/`).

**Distinct architectural concerns covered:**
- AC11 transport-before-services boot order semantic preserved per [#10975](https://github.com/neomjs/neo/pull/10975) — Server.mjs custom `boot()` override service-imports updated to new SDK paths but the order is unchanged
- AC10 `bridgeCwd` member + `_turnId` counter + `getCurrentTurnId()` export semantics preserved (Server.mjs members untouched)
- toolService.mjs has 3 non-standard imports requiring careful path math (see Diff Summary Table)

## Test Evidence

- 1 unit spec (`RecorderService.spec.mjs`) moved from `test/playwright/unit/ai/mcp/server/neural-link/` to `test/playwright/unit/ai/services/neural-link/` matching new SDK shape
- Test path math: 7→6 `../` for src+ai imports + 5→4 `../` for setup.mjs
- `logger.spec.mjs` retained at original location (server-level test, not service)

**Local empirical run (canonical evidence per pr-review §7.5):**

```
npm run test-unit -- test/playwright/unit/ai/services/neural-link/ \
                     test/playwright/unit/ai/mcp/server/neural-link/logger.spec.mjs

7 passed (736ms)
```

## Architectural Notes

**`ConnectionService` + `RecorderService`** retain their `aiConfig`/`logger` imports, now via the longer relative path back to the OLD config.mjs/logger.mjs locations (per parent epic Out-of-Scope: config + logger files stay at MCP server root).

**Custom-boot-order preservation per #10975 + #10994 AC11** — Server.mjs `boot()` override sequences:
1. loadCustomConfig
2. createMcpServer
3. connectTransport (EARLY — pre-services per Bridge-down/spawn rationale)
4. ConnectionService.ready (non-fatal try/catch)
5. healthcheck + log

This semantic is unchanged by the migration; only import paths rotated to new SDK locations.

**`getCurrentTurnId` export** continues to live in `ai/mcp/server/neural-link/Server.mjs` (Server.mjs members are not migration scope). NL's `toolService.mjs` now imports it via the explicit longer path (`'../../mcp/server/neural-link/Server.mjs'`). Pattern preserved.

**Cycle 1 review correction (RA1):** caught a stale tracked helper at `ai/mcp/server/neural-link/test_connection_service.mjs:3` that still imported `'./services/ConnectionService.mjs'` (path removed by migration). Fixed in commit `d17da57d2` by routing via `'../../../services/neural-link/ConnectionService.mjs'`. Ref [comment IC_kwDODSospM8AAAABBuG1CQ](https://github.com/neomjs/neo/pull/10998#issuecomment-4410422537).

**Linear-cadence reminder** (per parent epic [#10986](https://github.com/neomjs/neo/issues/10986)): MC ([#10996](https://github.com/neomjs/neo/issues/10996)) is the final M6 sub in sequence; will pickup once this PR merges.

## Post-Merge Validation

- [ ] Operator scripts (`ai:summarize-sessions`, `ai:run-sandman`, etc.) work unchanged via the preserved `NeuralLink_*` aliases — verifiable empirically post-merge.
- [ ] `getCurrentTurnId` increment-per-CallTool-dispatch behavior preserved (manual verification via NL tool invocation post-merge if desired).
- [ ] M6 sub-4 MC implementation lane unblocked (linear sequencing per #10986).

## Commits

- `5197f99ce` — refactor(neural-link): migrate services to flat SDK boundary (#10994)
- `d17da57d2` — fix(neural-link): update test_connection_service.mjs import path post-migration (#10994)

Co-Authored-By: Claude Opus 4.7 <neo-opus-4-7@neomjs.com>