### PR TITLE
feat(ai): add orchestrator maintenance daemon (#11006)

### DIFF
--- a/ai/scripts/bridge-daemon.mjs
+++ b/ai/scripts/bridge-daemon.mjs
@@ -7,6 +7,9 @@
  * per `.neo-ai-data/wake-daemon/` directory (singleton-enforced via PID lock
  * per #10422 / #10423).
  *
+ * Scheduled Agent OS maintenance triggers belong to `orchestrator-daemon.mjs`
+ * per #11006. Keep this daemon focused on wake delivery only.
+ *
  * **Diagnostic log persistence (per #10419):**
  * All informational + error lines are written to BOTH stdout (live terminal
  * observability) AND `.neo-ai-data/wake-daemon/bridge.log` (persistent audit
@@ -38,9 +41,7 @@ import {
     getGraphLogEntries,
     getNodesData,
     getEdgesData,
-    getDbNode,
-    getUnreadSunsetHandovers,
-    markNodesAsRead
+    getDbNode
 } from './bridge-daemon-queries.mjs';
 
 const DB_PATH                  = process.env.NEO_AI_DB_PATH || '.neo-ai-data/sqlite/memory-core-graph.sqlite';
@@ -147,8 +148,6 @@ function writeLog(level, message) {
 pruneOldLogs();
 
 const PID_FILE = path.join(DAEMON_DATA_DIR, 'bridge-daemon.pid');
-const SUMMARIZATION_PID_FILE = path.join(DAEMON_DATA_DIR, 'summarization.pid');
-
 const wait = (ms) => new Promise(resolve => setTimeout(resolve, ms));
 
 async function enforceSingleton() {
@@ -254,124 +253,6 @@ let lastSyncId;
 // Structure: { [subscriptionId]: { timer: Timeout, queue: [events], subscription: {...} } }
 const coalesceState = {};
 
-let lastSummarizationSweep = Date.now();
-const SWEEP_INTERVAL_MS = parseInt(process.env.NEO_SUMMARIZATION_SWEEP_INTERVAL_MS || '600000', 10);
-let summarizationRunning = false;
-let summarizationPid = null;
-
-function checkSummarizationLifecycle() {
-    // 1. Recover/Verify State from PID file
-    if (fs.existsSync(SUMMARIZATION_PID_FILE)) {
-        try {
-            const pid = parseInt(fs.readFileSync(SUMMARIZATION_PID_FILE, 'utf8'), 10);
-            if (!isNaN(pid) && pid > 0) {
-                try {
-                    process.kill(pid, 0); // Is it alive?
-                    
-                    if (!summarizationRunning) {
-                        // Orphan discovery: verify it's the actual process before adopting
-                        const cmd = execSync(`ps -p ${pid} -o command=`).toString().trim();
-                        if (cmd.includes('summarize-sessions')) {
-                            writeLog('INFO', `[Bridge Daemon] Found orphaned summarization process (PID: ${pid}). Adopting.`);
-                            summarizationRunning = true;
-                            summarizationPid = pid;
-                        } else {
-                            writeLog('INFO', `[Bridge Daemon] Stale summarization PID ${pid} reused by another process. Unlinking.`);
-                            fs.unlinkSync(SUMMARIZATION_PID_FILE);
-                        }
-                    } else if (summarizationPid !== pid) {
-                        // PID file changed while running
-                        summarizationPid = pid;
-                    }
-                } catch (e) {
-                    // Process not alive. Cleanup.
-                    fs.unlinkSync(SUMMARIZATION_PID_FILE);
-                    summarizationRunning = false;
-                    summarizationPid = null;
-                }
-            } else {
-                fs.unlinkSync(SUMMARIZATION_PID_FILE);
-                summarizationRunning = false;
-            }
-        } catch (e) {
-            writeLog('ERROR', `[Bridge Daemon] Failed to read summarization PID file: ${e.message}`);
-        }
-    } else {
-        // No file means not running
-        summarizationRunning = false;
-        summarizationPid = null;
-    }
-
-    if (summarizationRunning) return;
-
-    try {
-        const handovers = getUnreadSunsetHandovers(db);
-        let shouldRun = false;
-
-        if (handovers.length > 0) {
-            writeLog('INFO', `[Bridge Daemon] Found ${handovers.length} unread sunset handovers. Triggering Piece B summarization.`);
-            shouldRun = true;
-        }
-
-        if (!shouldRun && SWEEP_INTERVAL_MS > 0 && Date.now() - lastSummarizationSweep > SWEEP_INTERVAL_MS) {
-            writeLog('INFO', `[Bridge Daemon] Triggering Piece C periodic summarization sweep (Interval: ${SWEEP_INTERVAL_MS}ms).`);
-            shouldRun = true;
-        }
-
-        if (shouldRun) {
-            summarizationRunning = true;
-            lastSummarizationSweep = Date.now();
-
-            const p = spawn(process.argv[0], [path.join(__dirname, 'summarize-sessions.mjs')], {
-                stdio: 'ignore'
-            });
-
-            if (p.pid) {
-                summarizationPid = p.pid;
-                try {
-                    fs.writeFileSync(SUMMARIZATION_PID_FILE, p.pid.toString(), { encoding: 'utf8', flag: 'w' });
-                } catch (e) {
-                    writeLog('ERROR', `[Bridge Daemon] Failed to write summarization PID: ${e.message}`);
-                }
-            }
-
-            p.on('close', (code) => {
-                summarizationRunning = false;
-                summarizationPid = null;
-                try {
-                    if (fs.existsSync(SUMMARIZATION_PID_FILE)) {
-                        fs.unlinkSync(SUMMARIZATION_PID_FILE);
-                    }
-                } catch(e) {}
-
-                if (code === 0 && handovers.length > 0) {
-                    try {
-                        markNodesAsRead(db, handovers);
-                        writeLog('INFO', `[Bridge Daemon] Successfully marked ${handovers.length} sunset handovers as read.`);
-                    } catch (e) {
-                        writeLog('ERROR', `[Bridge Daemon] Failed to mark handovers as read: ${e.message}`);
-                    }
-                } else if (code !== 0) {
-                    writeLog('ERROR', `[Bridge Daemon] summarize-sessions.mjs exited with code ${code}.`);
-                }
-            });
-
-            p.on('error', (err) => {
-                summarizationRunning = false;
-                summarizationPid = null;
-                try {
-                    if (fs.existsSync(SUMMARIZATION_PID_FILE)) {
-                        fs.unlinkSync(SUMMARIZATION_PID_FILE);
-                    }
-                } catch(e) {}
-                writeLog('ERROR', `[Bridge Daemon] Failed to spawn summarize-sessions: ${err.message}`);
-            });
-        }
-    } catch (e) {
-        writeLog('ERROR', `[Bridge Daemon] Error in checkSummarizationLifecycle: ${e.message}`);
-    }
-}
-
 /**
  * Main polling loop
  */
@@ -418,8 +299,6 @@ async function pollLoop() {
             fs.writeFileSync(STATE_FILE, lastSyncId.toString(), 'utf8');
         }
 
-        // Run daemon-managed summarization lifecycle (Piece B & C)
-        checkSummarizationLifecycle();
     } catch (err) {
         writeLog('ERROR', `[Bridge Daemon] Error in poll loop: ${err && err.stack ? err.stack : err}`);
     }

--- a/ai/scripts/orchestrator-daemon.mjs
+++ b/ai/scripts/orchestrator-daemon.mjs
@@ -1,0 +1,455 @@
+/**
+ * @module ai/scripts/orchestrator-daemon
+ * @summary Per-host maintenance orchestrator for existing Agent OS refresh tasks.
+ *
+ * The bridge daemon owns wake delivery. This sibling daemon owns scheduled
+ * maintenance triggers that keep agent boot context fresh: session summaries and
+ * Knowledge Base delta sync. It deliberately shells out to the existing scripts
+ * instead of reimplementing their logic.
+ *
+ * @see ai/scripts/summarize-sessions.mjs
+ * @see buildScripts/ai/syncKnowledgeBase.mjs
+ * @see #11006
+ */
+import fs from 'fs-extra';
+import path from 'path';
+import {spawn, execSync} from 'child_process';
+import {fileURLToPath, pathToFileURL} from 'url';
+import {
+    initializeDatabase,
+    getUnreadSunsetHandovers,
+    markNodesAsRead
+} from './bridge-daemon-queries.mjs';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname  = path.dirname(__filename);
+
+export const DEFAULT_POLL_INTERVAL_MS = 3000;
+export const DEFAULT_SUMMARY_SWEEP_INTERVAL_MS = 600000;
+export const DEFAULT_KB_SYNC_INTERVAL_MS = 1800000;
+
+const DB_PATH         = process.env.NEO_AI_DB_PATH || '.neo-ai-data/sqlite/memory-core-graph.sqlite';
+const DAEMON_DATA_DIR = process.env.NEO_AI_ORCHESTRATOR_DIR || '.neo-ai-data/orchestrator-daemon';
+const PID_FILE        = path.join(DAEMON_DATA_DIR, 'orchestrator-daemon.pid');
+const LOG_FILE        = path.join(DAEMON_DATA_DIR, 'orchestrator.log');
+const STATE_FILE      = path.join(DAEMON_DATA_DIR, 'orchestrator-state.json');
+
+const POLL_INTERVAL_MS = parseInterval(
+    process.env.NEO_ORCHESTRATOR_POLL_INTERVAL_MS,
+    DEFAULT_POLL_INTERVAL_MS
+);
+
+const SUMMARY_SWEEP_INTERVAL_MS = parseInterval(
+    process.env.NEO_ORCHESTRATOR_SUMMARY_SWEEP_INTERVAL_MS ?? process.env.NEO_SUMMARIZATION_SWEEP_INTERVAL_MS,
+    DEFAULT_SUMMARY_SWEEP_INTERVAL_MS
+);
+
+const KB_SYNC_INTERVAL_MS = parseInterval(
+    process.env.NEO_ORCHESTRATOR_KB_SYNC_INTERVAL_MS,
+    DEFAULT_KB_SYNC_INTERVAL_MS
+);
+
+let db;
+let taskState;
+
+/**
+ * @summary Parses daemon interval env vars while preserving `0` as disabled.
+ *
+ * @param {String|undefined} value    Environment value.
+ * @param {Number}           fallback Fallback interval in milliseconds.
+ * @returns {Number}
+ */
+export function parseInterval(value, fallback) {
+    if (value === undefined || value === null || value === '') {
+        return fallback;
+    }
+
+    const parsed = parseInt(value, 10);
+    if (Number.isNaN(parsed)) {
+        return fallback;
+    }
+
+    return Math.max(parsed, 0);
+}
+
+/**
+ * @summary Returns true when an interval task is due and not disabled.
+ *
+ * @param {Object} options
+ * @param {Number} options.now        Current timestamp in milliseconds.
+ * @param {Number} options.lastRunAt  Last start timestamp in milliseconds.
+ * @param {Number} options.intervalMs Interval in milliseconds; 0 disables.
+ * @returns {Boolean}
+ */
+export function shouldRunIntervalTask({now, lastRunAt, intervalMs}) {
+    return intervalMs > 0 && now - lastRunAt >= intervalMs;
+}
+
+/**
+ * @summary Builds child-process commands for the orchestrator-owned tasks.
+ *
+ * @param {Object} [options]
+ * @param {String} [options.scriptDir] Script directory.
+ * @param {String} [options.nodeBin]   Node executable.
+ * @returns {Object}
+ */
+export function buildTaskDefinitions({scriptDir = __dirname, nodeBin = process.argv[0]} = {}) {
+    return {
+        summary: {
+            label          : 'session summarization',
+            command        : nodeBin,
+            args           : [path.join(scriptDir, 'summarize-sessions.mjs')],
+            pidFileName    : 'summarization.pid',
+            expectedCommand: 'summarize-sessions.mjs'
+        },
+        kbSync: {
+            label          : 'knowledge base sync',
+            command        : nodeBin,
+            args           : [path.resolve(scriptDir, '../../buildScripts/ai/syncKnowledgeBase.mjs')],
+            pidFileName    : 'kb-sync.pid',
+            expectedCommand: 'syncKnowledgeBase.mjs'
+        }
+    };
+}
+
+const TASK_DEFINITIONS = buildTaskDefinitions();
+
+function writeLog(level, message) {
+    const timestamp = new Date().toISOString();
+    const line      = `[${timestamp}] [PID:${process.pid}] [${level}] ${message}`;
+
+    try {
+        fs.appendFileSync(LOG_FILE, line + '\n', 'utf8');
+    } catch (e) {}
+
+    if (level === 'ERROR') {
+        console.error(line);
+    } else {
+        console.log(line);
+    }
+}
+
+function readState() {
+    const fallback = {};
+
+    for (const taskName of Object.keys(TASK_DEFINITIONS)) {
+        fallback[taskName] = {
+            running      : false,
+            pid          : null,
+            lastRunAt    : 0,
+            lastSuccessAt: null,
+            lastErrorAt  : null,
+            lastExitCode : null,
+            lastReason   : null
+        };
+    }
+
+    if (!fs.existsSync(STATE_FILE)) {
+        return fallback;
+    }
+
+    try {
+        const data = JSON.parse(fs.readFileSync(STATE_FILE, 'utf8'));
+        return Object.keys(fallback).reduce((state, taskName) => {
+            state[taskName] = {...fallback[taskName], ...(data[taskName] || {})};
+            state[taskName].running = false;
+            state[taskName].pid     = null;
+            return state;
+        }, {});
+    } catch (e) {
+        writeLog('ERROR', `[Orchestrator] Failed to read state file: ${e.message}`);
+        return fallback;
+    }
+}
+
+function writeState() {
+    try {
+        fs.writeFileSync(STATE_FILE, JSON.stringify(taskState, null, 2), 'utf8');
+    } catch (e) {
+        writeLog('ERROR', `[Orchestrator] Failed to write state file: ${e.message}`);
+    }
+}
+
+function getTaskPidFile(taskName) {
+    return path.join(DAEMON_DATA_DIR, TASK_DEFINITIONS[taskName].pidFileName);
+}
+
+function processCommand(pid) {
+    return execSync(`ps -p ${pid} -o command=`).toString().trim();
+}
+
+function clearRecoveredTask(taskName, pid) {
+    const task    = TASK_DEFINITIONS[taskName];
+    const state   = taskState[taskName];
+    const pidFile = getTaskPidFile(taskName);
+
+    if (state.pid !== pid) {
+        return;
+    }
+
+    state.running      = false;
+    state.pid          = null;
+    state.lastExitCode = null;
+
+    try {
+        if (fs.existsSync(pidFile) && parseInt(fs.readFileSync(pidFile, 'utf8'), 10) === pid) {
+            fs.unlinkSync(pidFile);
+        }
+    } catch (e) {}
+
+    writeLog('INFO', `[Orchestrator] Recovered ${task.label} process (PID: ${pid}) exited; clearing running state.`);
+    writeState();
+}
+
+function watchRecoveredTask(taskName, pid) {
+    const watcher = setInterval(() => {
+        try {
+            process.kill(pid, 0);
+        } catch (e) {
+            clearInterval(watcher);
+            clearRecoveredTask(taskName, pid);
+        }
+    }, 1000);
+
+    watcher.unref?.();
+}
+
+function recoverTask(taskName) {
+    const task    = TASK_DEFINITIONS[taskName];
+    const pidFile = getTaskPidFile(taskName);
+
+    if (!fs.existsSync(pidFile)) {
+        return;
+    }
+
+    try {
+        const pid = parseInt(fs.readFileSync(pidFile, 'utf8'), 10);
+        if (Number.isNaN(pid) || pid <= 0) {
+            fs.unlinkSync(pidFile);
+            return;
+        }
+
+        process.kill(pid, 0);
+        const cmd = processCommand(pid);
+
+        if (cmd.includes(task.expectedCommand)) {
+            taskState[taskName].running = true;
+            taskState[taskName].pid     = pid;
+            watchRecoveredTask(taskName, pid);
+            writeLog('INFO', `[Orchestrator] Found running ${task.label} process (PID: ${pid}). Adopting.`);
+        } else {
+            fs.unlinkSync(pidFile);
+            writeLog('INFO', `[Orchestrator] Stale ${task.label} PID ${pid} reused by another process. Unlinking.`);
+        }
+    } catch (e) {
+        try {
+            fs.unlinkSync(pidFile);
+        } catch (unlinkErr) {}
+    }
+}
+
+function recoverTasks() {
+    for (const taskName of Object.keys(TASK_DEFINITIONS)) {
+        recoverTask(taskName);
+    }
+}
+
+async function enforceSingleton() {
+    if (fs.existsSync(PID_FILE)) {
+        try {
+            const oldPid = parseInt(fs.readFileSync(PID_FILE, 'utf8'), 10);
+            if (!Number.isNaN(oldPid) && oldPid > 0 && oldPid !== process.pid) {
+                let isAlive = false;
+
+                try {
+                    process.kill(oldPid, 0);
+                    isAlive = true;
+                } catch (e) {}
+
+                if (isAlive) {
+                    const cmd = processCommand(oldPid);
+
+                    if (cmd.includes('orchestrator-daemon.mjs')) {
+                        writeLog('INFO', `[Orchestrator] Found existing instance (PID: ${oldPid}). Sending SIGTERM...`);
+                        process.kill(oldPid, 'SIGTERM');
+                        if (!await waitForExit(oldPid, 5000)) {
+                            throw new Error(`Existing orchestrator process ${oldPid} did not exit within 5000ms`);
+                        }
+                    } else {
+                        writeLog('INFO', `[Orchestrator] Stale PID file found for PID ${oldPid}; proceeding.`);
+                    }
+                }
+            }
+        } catch (e) {
+            writeLog('ERROR', `[Orchestrator] Failed singleton check: ${e.message}`);
+        }
+    }
+
+    fs.writeFileSync(PID_FILE, process.pid.toString(), 'utf8');
+}
+
+async function waitForExit(pid, timeoutMs) {
+    const start = Date.now();
+
+    while (Date.now() - start < timeoutMs) {
+        try {
+            process.kill(pid, 0);
+        } catch (e) {
+            return true;
+        }
+        await new Promise(resolve => setTimeout(resolve, 250));
+    }
+
+    return false;
+}
+
+function setupCleanupHandlers() {
+    const cleanup = () => {
+        try {
+            if (fs.existsSync(PID_FILE) && parseInt(fs.readFileSync(PID_FILE, 'utf8'), 10) === process.pid) {
+                fs.unlinkSync(PID_FILE);
+            }
+        } catch (e) {}
+        process.exit();
+    };
+
+    process.on('SIGINT', cleanup);
+    process.on('SIGTERM', cleanup);
+    process.on('exit', () => {
+        try {
+            if (fs.existsSync(PID_FILE) && parseInt(fs.readFileSync(PID_FILE, 'utf8'), 10) === process.pid) {
+                fs.unlinkSync(PID_FILE);
+            }
+        } catch (e) {}
+    });
+    process.on('uncaughtException', (err) => {
+        writeLog('ERROR', `[Orchestrator] Uncaught exception: ${err && err.stack ? err.stack : err}`);
+        cleanup();
+    });
+}
+
+function runTask(taskName, reason, onSuccess) {
+    const task  = TASK_DEFINITIONS[taskName];
+    const state = taskState[taskName];
+
+    if (state.running) {
+        writeLog('INFO', `[Orchestrator] Skipping ${task.label}; task already running (PID: ${state.pid}).`);
+        return false;
+    }
+
+    state.running    = true;
+    state.lastRunAt  = Date.now();
+    state.lastReason = reason;
+    writeState();
+
+    writeLog('INFO', `[Orchestrator] Starting ${task.label} (${reason}).`);
+    const child = spawn(task.command, task.args, {stdio: 'ignore'});
+    const pidFile = getTaskPidFile(taskName);
+
+    if (child.pid) {
+        state.pid = child.pid;
+        try {
+            fs.writeFileSync(pidFile, child.pid.toString(), 'utf8');
+        } catch (e) {
+            writeLog('ERROR', `[Orchestrator] Failed to write ${task.label} PID: ${e.message}`);
+        }
+    }
+
+    let cleared = false;
+    const clear = (code, error) => {
+        if (cleared) {
+            return;
+        }
+        cleared = true;
+
+        state.running     = false;
+        state.pid         = null;
+        state.lastExitCode = code;
+
+        try {
+            if (fs.existsSync(pidFile)) {
+                fs.unlinkSync(pidFile);
+            }
+        } catch (e) {}
+
+        if (error) {
+            state.lastErrorAt = new Date().toISOString();
+            writeLog('ERROR', `[Orchestrator] ${task.label} failed to start: ${error.message}`);
+        } else if (code === 0) {
+            state.lastSuccessAt = new Date().toISOString();
+            writeLog('INFO', `[Orchestrator] ${task.label} completed successfully.`);
+            if (onSuccess) {
+                try {
+                    onSuccess();
+                } catch (e) {
+                    writeLog('ERROR', `[Orchestrator] ${task.label} success hook failed: ${e.message}`);
+                }
+            }
+        } else {
+            state.lastErrorAt = new Date().toISOString();
+            writeLog('ERROR', `[Orchestrator] ${task.label} exited with code ${code}.`);
+        }
+
+        writeState();
+    };
+
+    child.on('close', code => clear(code));
+    child.on('error', err => clear(null, err));
+
+    writeState();
+    return true;
+}
+
+function runMaintenanceCycle(now = Date.now()) {
+    try {
+        const handovers = getUnreadSunsetHandovers(db);
+
+        if (handovers.length > 0) {
+            runTask('summary', `sunset-handover:${handovers.length}`, () => {
+                markNodesAsRead(db, handovers);
+                writeLog('INFO', `[Orchestrator] Marked ${handovers.length} sunset handovers as read.`);
+            });
+        } else if (shouldRunIntervalTask({
+            now,
+            lastRunAt : taskState.summary.lastRunAt,
+            intervalMs: SUMMARY_SWEEP_INTERVAL_MS
+        })) {
+            runTask('summary', `periodic-sweep:${SUMMARY_SWEEP_INTERVAL_MS}`);
+        }
+
+        if (shouldRunIntervalTask({
+            now,
+            lastRunAt : taskState.kbSync.lastRunAt,
+            intervalMs: KB_SYNC_INTERVAL_MS
+        })) {
+            runTask('kbSync', `periodic-sync:${KB_SYNC_INTERVAL_MS}`);
+        }
+    } catch (e) {
+        writeLog('ERROR', `[Orchestrator] Maintenance cycle failed: ${e.message}`);
+    }
+}
+
+function pollLoop() {
+    runMaintenanceCycle();
+    setTimeout(pollLoop, POLL_INTERVAL_MS);
+}
+
+export async function startOrchestrator() {
+    fs.ensureDirSync(DAEMON_DATA_DIR);
+    await enforceSingleton();
+    setupCleanupHandlers();
+
+    taskState = readState();
+    recoverTasks();
+    db = initializeDatabase(DB_PATH);
+
+    writeLog('INFO', `[Orchestrator] Started. summaryInterval=${SUMMARY_SWEEP_INTERVAL_MS}ms kbSyncInterval=${KB_SYNC_INTERVAL_MS}ms poll=${POLL_INTERVAL_MS}ms.`);
+    pollLoop();
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+    startOrchestrator().catch(err => {
+        console.error(`[Orchestrator] Failed to start: ${err && err.stack ? err.stack : err}`);
+        process.exit(1);
+    });
+}

--- a/learn/agentos/v13-path.md
+++ b/learn/agentos/v13-path.md
@@ -147,6 +147,8 @@ Build `ai/mcp/server/shared/Server.mjs` (D2). Migrate one MCP server (smallest f
 ### M3 — Orchestrator Daemon Skeleton + Piece C
 Build `ai/daemons/Orchestrator.mjs` + `ai/scripts/orchestrator-daemon.mjs` boot wrapper (D3). First task: `SummarizationCoordinatorService` running drift-detection sweep on configurable cadence. Strip the in-process `runPeriodicSummarizationSweep` from `SessionService` (which I added in PR [#10954](https://github.com/neomjs/neo/pull/10954) — wrong-substrate; reshape to Orchestrator).
 
+**MVP split:** [#11006](https://github.com/neomjs/neo/issues/11006) moves existing summary + KB sync triggers out of `bridge-daemon.mjs` and into a sibling `ai/scripts/orchestrator-daemon.mjs` runner first. The full Neo class (`ai/daemons/Orchestrator.mjs`), healthcheck surface, and richer task model remain the M3 completion target.
+
 **Exit gate:** orchestrator daemon runs on the operator's host; summarization sweep fires automatically on cadence; healthcheck observability in place; PR #10954 closed in favor of corrected-substrate successor.
 
 ### M4 — Migrate Decomposed Daemon Services to Orchestrator

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
         "ai:mcp-server-knowledge-base" : "node ./ai/mcp/server/knowledge-base/mcp-server.mjs",
         "ai:mcp-server-memory-core"    : "node ./ai/mcp/server/memory-core/mcp-server.mjs",
         "ai:mcp-server-neural-link"    : "node ./ai/mcp/server/neural-link/mcp-server.mjs",
+        "ai:orchestrator"              : "node ./ai/scripts/orchestrator-daemon.mjs",
         "ai:reconcile-v13-project"     : "node ./ai/scripts/reconcileV13Project.mjs",
         "ai:run-sandman"               : "node ./buildScripts/ai/runSandman.mjs",
         "ai:server"                    : "chroma run --path ./.neo-ai-data/chroma/knowledge-base",

--- a/test/playwright/unit/ai/scripts/orchestrator-daemon.spec.mjs
+++ b/test/playwright/unit/ai/scripts/orchestrator-daemon.spec.mjs
@@ -1,0 +1,67 @@
+import {test, expect} from '@playwright/test';
+import fs from 'fs';
+import path from 'path';
+import {
+    DEFAULT_KB_SYNC_INTERVAL_MS,
+    DEFAULT_POLL_INTERVAL_MS,
+    DEFAULT_SUMMARY_SWEEP_INTERVAL_MS,
+    buildTaskDefinitions,
+    parseInterval,
+    shouldRunIntervalTask
+} from '../../../../../ai/scripts/orchestrator-daemon.mjs';
+
+test.describe('ai/scripts/orchestrator-daemon.mjs (#11006)', () => {
+    test('parses interval env values while preserving zero as disabled', () => {
+        expect(parseInterval(undefined, DEFAULT_POLL_INTERVAL_MS)).toBe(DEFAULT_POLL_INTERVAL_MS);
+        expect(parseInterval('', DEFAULT_SUMMARY_SWEEP_INTERVAL_MS)).toBe(DEFAULT_SUMMARY_SWEEP_INTERVAL_MS);
+        expect(parseInterval('0', DEFAULT_KB_SYNC_INTERVAL_MS)).toBe(0);
+        expect(parseInterval('-10', DEFAULT_KB_SYNC_INTERVAL_MS)).toBe(0);
+        expect(parseInterval('900000', DEFAULT_KB_SYNC_INTERVAL_MS)).toBe(900000);
+        expect(parseInterval('not-a-number', DEFAULT_KB_SYNC_INTERVAL_MS)).toBe(DEFAULT_KB_SYNC_INTERVAL_MS);
+    });
+
+    test('does not schedule disabled or not-yet-due interval tasks', () => {
+        expect(shouldRunIntervalTask({
+            now       : 1000,
+            lastRunAt : 0,
+            intervalMs: 0
+        })).toBe(false);
+
+        expect(shouldRunIntervalTask({
+            now       : 599999,
+            lastRunAt : 0,
+            intervalMs: 600000
+        })).toBe(false);
+
+        expect(shouldRunIntervalTask({
+            now       : 600000,
+            lastRunAt : 0,
+            intervalMs: 600000
+        })).toBe(true);
+    });
+
+    test('builds task commands around existing manual maintenance scripts', () => {
+        const scriptDir = path.resolve(process.cwd(), 'ai/scripts');
+        const tasks     = buildTaskDefinitions({scriptDir, nodeBin: '/test/node'});
+
+        expect(tasks.summary.command).toBe('/test/node');
+        expect(tasks.summary.args).toEqual([path.join(scriptDir, 'summarize-sessions.mjs')]);
+        expect(tasks.summary.expectedCommand).toBe('summarize-sessions.mjs');
+
+        expect(tasks.kbSync.command).toBe('/test/node');
+        expect(tasks.kbSync.args).toEqual([path.resolve(scriptDir, '../../buildScripts/ai/syncKnowledgeBase.mjs')]);
+        expect(tasks.kbSync.expectedCommand).toBe('syncKnowledgeBase.mjs');
+    });
+
+    test('keeps bridge-daemon wake-only and routes maintenance ownership to orchestrator', () => {
+        const bridgeSource       = fs.readFileSync(path.resolve(process.cwd(), 'ai/scripts/bridge-daemon.mjs'), 'utf8');
+        const orchestratorSource = fs.readFileSync(path.resolve(process.cwd(), 'ai/scripts/orchestrator-daemon.mjs'), 'utf8');
+
+        expect(bridgeSource).not.toContain('summarize-sessions.mjs');
+        expect(bridgeSource).not.toContain('Piece C periodic summarization sweep');
+        expect(bridgeSource).not.toContain('checkSummarizationLifecycle');
+
+        expect(orchestratorSource).toContain('summarize-sessions.mjs');
+        expect(orchestratorSource).toContain('syncKnowledgeBase.mjs');
+    });
+});


### PR DESCRIPTION
Authored by GPT-5.5 (Codex Desktop). Session 019e08bd-e125-7fd2-b00b-c8279702ad03.

Resolves #11006

Adds a sibling `ai/scripts/orchestrator-daemon.mjs` runner for Agent OS maintenance triggers, moves the existing summary sweep out of `bridge-daemon.mjs`, and schedules Knowledge Base delta sync through the same per-host singleton boundary. The bridge daemon now remains focused on wake delivery only.

Evidence: L2 (static contract checks + unit-validated task wiring + bridge wake regression suite with spawned daemon fixtures) -> L2 required (MVP ownership split and existing-script orchestration). No residual ticket ACs.

## Deltas from ticket

- Keeps `NEO_SUMMARIZATION_SWEEP_INTERVAL_MS` as a compatibility alias while adding `NEO_ORCHESTRATOR_SUMMARY_SWEEP_INTERVAL_MS`.
- Adds `NEO_ORCHESTRATOR_KB_SYNC_INTERVAL_MS` and `NEO_ORCHESTRATOR_POLL_INTERVAL_MS`.
- Adds an M3 MVP split note to `learn/agentos/v13-path.md`; the full Neo `ai/daemons/Orchestrator.mjs` class and healthcheck surface remain future M3 completion work.

## Slot Rationale

- Added M3 MVP split note in `learn/agentos/v13-path.md`: disposition `keep` until the full M3 orchestrator class lands, then `rewrite` or retire into milestone history. 3-axis rating: trigger-frequency low, failure-severity medium, enforceability low. Future-decay mitigation: the paragraph names #11006 as an MVP bridge and explicitly preserves the later full-Orchestrator completion target, so it should not accrete into a permanent duplicate roadmap layer.

## Test Evidence

- `node --check ai/scripts/orchestrator-daemon.mjs`
- `node --check ai/scripts/bridge-daemon.mjs`
- `git diff --check`
- `rg -n "Piece C|summarize-sessions|summarization.pid|NEO_SUMMARIZATION_SWEEP_INTERVAL_MS|checkSummarizationLifecycle|getUnreadSunsetHandovers|markNodesAsRead" ai/scripts/bridge-daemon.mjs ai/scripts/orchestrator-daemon.mjs package.json test/playwright/unit/ai/scripts learn/agentos/v13-path.md`
- `npm run test-unit -- test/playwright/unit/ai/scripts/orchestrator-daemon.spec.mjs test/playwright/unit/ai/scripts/bridge-daemon-queries.spec.mjs` — 10 passed.
- `npm run test-unit -- --workers=1 test/playwright/unit/ai/scripts/orchestrator-daemon.spec.mjs test/playwright/unit/ai/scripts/bridge-daemon-queries.spec.mjs test/playwright/unit/ai/scripts/bridge-daemon.spec.mjs` — 23 passed. Ran outside the sandbox because this checkout's `.neo-ai-data/sqlite` is a symlink to the shared Git checkout path.

## Post-Merge Validation

- [ ] Restart the bridge daemon and confirm it no longer logs `Triggering Piece C periodic summarization sweep`.
- [ ] Start `npm run ai:orchestrator` on the operator host and confirm `.neo-ai-data/orchestrator-daemon/orchestrator.log` records summary and KB sync task ownership.
- [ ] Optionally use short `NEO_ORCHESTRATOR_SUMMARY_SWEEP_INTERVAL_MS` / `NEO_ORCHESTRATOR_KB_SYNC_INTERVAL_MS` values once to confirm cadence behavior without waiting for default intervals.

## Commit

- `c8d2ad1b6` — `feat(ai): add orchestrator maintenance daemon (#11006)`
