### PR TITLE
feat(docs): ADR-link enrichment for Structural Inventory (#10449 sub-2)

### DIFF
--- a/learn/benefits/ArchitectureOverview.md
+++ b/learn/benefits/ArchitectureOverview.md
@@ -351,34 +351,53 @@ complete organism where the codebase and the agent co-evolve.
 
 ### Runtime Engine (Browser)
 
-| Package | Purpose | Key Classes |
-|---|---|---|
-| `src/core/` | Class system, Observable, Logger | `Base`, `Observable` |
-| `src/component/` | UI primitives | `Base`, `Wrapper` |
-| `src/container/` | Layout containers | `Base`, `Viewport` |
-| `src/grid/` | Buffered data grids | `Container`, `View` |
-| `src/data/` | Data layer | `Store`, `Model`, `RecordFactory` |
-| `src/state/` | State management | `Provider` |
-| `src/worker/` | Thread management | `App`, `VDom`, `Data`, `Manager` |
-| `src/vdom/` | Virtual DOM engine | `Helper` |
-| `src/main/` | Main thread addons | `DomEvents`, `DomAccess` |
-| `src/ai/` | Neural Link client | `Client` |
+| Package | Purpose | Key Classes | Decisions |
+|---|---|---|---|
+| `src/core/` | Class system, Observable, Logger | `Base`, `Observable` | — |
+| `src/component/` | UI primitives | `Base`, `Wrapper` | — |
+| `src/container/` | Layout containers | `Base`, `Viewport` | — |
+| `src/grid/` | Buffered data grids | `Container`, `View` | — |
+| `src/data/` | Data layer | `Store`, `Model`, `RecordFactory` | — |
+| `src/state/` | State management | `Provider` | — |
+| `src/worker/` | Thread management | `App`, `VDom`, `Data`, `Manager` | — |
+| `src/vdom/` | Virtual DOM engine | `Helper` | — |
+| `src/main/` | Main thread addons | `DomEvents`, `DomAccess` | — |
+| `src/ai/` | Neural Link client | `Client` | — |
 
 ### Agent OS (Node.js)
 
-| Package | Purpose | Key Classes |
-|---|---|---|
-| `ai/Agent.mjs` | Agent base class | `Agent` |
-| `ai/agent/` | Cognitive runtime | `Loop`, `Orchestrator`, `Scheduler` |
-| `ai/context/` | Context window management | `Assembler` |
-| `ai/provider/` | LLM abstraction | `Gemini`, `Ollama`, `OpenAiCompatible` |
-| `ai/services.mjs` | SDK with Zod validation | — |
-| `ai/daemons/` | Background daemons | `DreamService` |
-| `ai/graph/` | Native Edge Graph | `Database`, `Store`, `NodeModel` |
-| `ai/mcp/server/knowledge-base/` | Semantic RAG | `QueryService`, `SearchService` |
-| `ai/mcp/server/memory-core/` | Episodic memory | `MemoryService`, `SessionService` |
-| `ai/mcp/server/github-workflow/` | Issue/PR management | `IssueService`, `SyncService` |
-| `ai/mcp/server/neural-link/` | Live app bridge | `ConnectionService`, `Bridge` |
+Post-M6 ([#10986](https://github.com/neomjs/neo/issues/10986)) the per-MCP-server services were lifted from `ai/mcp/server/<name>/services/` into the flat SDK boundary at `ai/services/<name>/`. The `ai/mcp/server/<name>/` directories now host only the server entry-point (`Server.mjs`), config templates, logger, and shared helpers; the service implementations live under `ai/services/<name>/`. Both rows are listed below for navigability.
+
+| Package | Purpose | Key Classes | Decisions |
+|---|---|---|---|
+| `ai/Agent.mjs` | Agent base class | `Agent` | — |
+| `ai/agent/` | Cognitive runtime | `Loop`, `Orchestrator`, `Scheduler` | — |
+| `ai/context/` | Context window management | `Assembler` | — |
+| `ai/provider/` | LLM abstraction | `Gemini`, `Ollama`, `OpenAiCompatible` | — |
+| `ai/services.mjs` | SDK with Zod validation aggregator | — | — |
+| `ai/services/knowledge-base/` | Semantic RAG services (post-M6 SDK location) | `QueryService`, `SearchService`, `KBRecorderService` | — |
+| `ai/services/memory-core/` | Episodic memory services (post-M6 SDK location) | `MemoryService`, `SessionService`, `GraphService`, `MailboxService` | [ADR 0001](../agentos/decisions/0001-cross-process-cache-coherence.md), [ADR 0002](../agentos/decisions/0002-phase3-wake-substrate-standards-alignment.md) |
+| `ai/services/github-workflow/` | Issue/PR management services (post-M6 SDK location) | `IssueService`, `SyncService`, `LabelService` | — |
+| `ai/services/neural-link/` | Live app bridge services (post-M6 SDK location) | `ConnectionService`, `RecorderService` | — |
+| `ai/scripts/` | One-shot operator scripts + thin daemon boot wrappers | `bridge-daemon.mjs`, `orchestrator-daemon.mjs` | [ADR 0002](../agentos/decisions/0002-phase3-wake-substrate-standards-alignment.md) |
+| `ai/daemons/` | Long-running daemon classes | `DreamService` | [ADR 0002](../agentos/decisions/0002-phase3-wake-substrate-standards-alignment.md) |
+| `ai/graph/` | Native Edge Graph (SQLite-backed knowledge graph) | `Database`, `Store`, `NodeModel` | [ADR 0001](../agentos/decisions/0001-cross-process-cache-coherence.md) |
+| `ai/mcp/server/knowledge-base/` | KB MCP-server entry point + config | `Server`, `config` | — |
+| `ai/mcp/server/memory-core/` | MC MCP-server entry point + config | `Server`, `config` | [ADR 0001](../agentos/decisions/0001-cross-process-cache-coherence.md) |
+| `ai/mcp/server/github-workflow/` | GH-WF MCP-server entry point + config | `Server`, `config` | — |
+| `ai/mcp/server/neural-link/` | NL MCP-server entry point + config | `Server`, `config` | — |
+| `ai/mcp/server/shared/` | Cross-cutting MCP infrastructure | `BaseServer`, `AuthMiddleware`, `RequestContextService`, `TransportService` | — |
+
+## Architectural Decision Records
+
+The Agent OS subsystem records its load-bearing architectural trade-offs in [`learn/agentos/decisions/`](../agentos/decisions/). Every cross-system trade-off — i.e. one that touches multiple subsystems, sets a precedent for future code, or affects load-bearing invariants — earns an ADR (per the `structural-pre-flight` skill's Strategy-vs-Tactics threshold). Per-class localized constraints stay inline as Anchor & Echo guards instead.
+
+The map-as-pointer principle: the Structural Inventory above links each subsystem row to its relevant ADRs so readers who follow the map naturally encounter the architectural-decision substrate without needing to remember to consult `decisions/` separately. Authors of new ADRs MUST add the link to the affected Structural Inventory rows in the same PR (per [#10449](https://github.com/neomjs/neo/issues/10449) Sub-Issue 2 / `structural-pre-flight` map-maintenance discipline).
+
+| ADR | Subject | Subsystems Affected | Status |
+|---|---|---|---|
+| [0001](../agentos/decisions/0001-cross-process-cache-coherence.md) | Cross-Process Cache Coherence for Memory Core Graph | `ai/services/memory-core/`, `ai/graph/`, `ai/mcp/server/memory-core/` | Proposed (#10186 / #10189) |
+| [0002](../agentos/decisions/0002-phase3-wake-substrate-standards-alignment.md) | Phase 3 Wake-Substrate Standards Alignment (MCP + A2A schema mappings) | `ai/scripts/` (bridge-daemon), `ai/daemons/`, `ai/services/memory-core/` (MailboxService A2A primitives) | Proposed (#10311 / #10355) |
 
 ## Next Steps
 

--- a/learn/benefits/ArchitectureOverview.md
+++ b/learn/benefits/ArchitectureOverview.md
@@ -380,7 +380,7 @@ Post-M6 ([#10986](https://github.com/neomjs/neo/issues/10986)) the per-MCP-serve
 | `ai/services/github-workflow/` | Issue/PR management services (post-M6 SDK location) | `IssueService`, `SyncService`, `LabelService` | — |
 | `ai/services/neural-link/` | Live app bridge services (post-M6 SDK location) | `ConnectionService`, `RecorderService` | — |
 | `ai/scripts/` | One-shot operator scripts + thin daemon boot wrappers | `bridge-daemon.mjs`, `orchestrator-daemon.mjs` | [ADR 0002](../agentos/decisions/0002-phase3-wake-substrate-standards-alignment.md) |
-| `ai/daemons/` | Long-running daemon classes | `DreamService` | [ADR 0002](../agentos/decisions/0002-phase3-wake-substrate-standards-alignment.md) |
+| `ai/daemons/` | Long-running daemon classes | `DreamService`, `SwarmHeartbeatService` | [ADR 0002](../agentos/decisions/0002-phase3-wake-substrate-standards-alignment.md) |
 | `ai/graph/` | Native Edge Graph (SQLite-backed knowledge graph) | `Database`, `Store`, `NodeModel` | [ADR 0001](../agentos/decisions/0001-cross-process-cache-coherence.md) |
 | `ai/mcp/server/knowledge-base/` | KB MCP-server entry point + config | `Server`, `config` | — |
 | `ai/mcp/server/memory-core/` | MC MCP-server entry point + config | `Server`, `config` | [ADR 0001](../agentos/decisions/0001-cross-process-cache-coherence.md) |


### PR DESCRIPTION
Closes Sub-Issue 2 of #10449 (Architecture Pre-Flight Skill epic). Sub-1 already merged via [#11010](https://github.com/neomjs/neo/pull/11010).

Authored by Claude Opus 4.7 (Claude Code 1M-context). Session `c2912891-b459-4a03-b2af-154d5e264df1`.

Implements the OQ5 self-eviction defense from Discussion [#10447](https://github.com/orgs/neomjs/discussions/10447). The new `structural-pre-flight` skill's "read the map" mandate now propagates via graph traversal: readers following `ArchitectureOverview.md` Structural Inventory naturally encounter relevant ADRs without needing to remember to consult `learn/agentos/decisions/` separately.

Evidence: L1 (docs-only enrichment + ADR-link verification + render check) → L1 required (no runtime contracts changed). No residuals.

## Diff Summary

| Change | Why |
|---|---|
| Add "Decisions" column to BOTH Structural Inventory tables (Runtime Engine + Agent OS) | Map-as-pointer mechanism — every subsystem row exposes its relevant ADR(s) |
| Update Agent OS Inventory to reflect post-M6 SDK migration ([#10986](https://github.com/neomjs/neo/issues/10986)) | Services moved from `ai/mcp/server/<name>/services/` → `ai/services/<name>/`. Inventory was stale on this paths split. |
| Add `ai/scripts/`, `ai/daemons/`, `ai/mcp/server/shared/` rows | Previously implicit; daemon and shared-infrastructure ADR links need explicit substrate rows |
| Map ADR 0001 (cache coherence) → MC services + graph + MC server entry-point rows | Per ADR 0001's stated subsystems |
| Map ADR 0002 (wake substrate) → scripts (bridge-daemon) + daemons + MC services (MailboxService A2A) | Per ADR 0002's stated subsystems |
| New "## Architectural Decision Records" section with ADR index table + map-as-pointer authoring discipline | OQ5 self-eviction defense + future-ADR-author authoring discipline |

## Authoring discipline established

The new ADR section captures the discipline that closes the self-eviction loop:

> Authors of new ADRs MUST add the link to the affected Structural Inventory rows in the same PR (per [#10449](https://github.com/neomjs/neo/issues/10449) Sub-Issue 2 / `structural-pre-flight` map-maintenance discipline).

This means the next ADR author (e.g., @neo-gemini-3-1-pro authoring `0003-chroma-topology-unified-only.md` under [#11011](https://github.com/neomjs/neo/issues/11011)) is on the hook to update the MC + KB Inventory rows + the ADR index table when the new ADR lands. That's a one-line addition per affected row + one new ADR-index-table row.

## Cross-Family Review Routing

Per `pull-request §6.1` Exceptions Matrix:

> **Micro-change exemption:** Commit type `chore` AND `< 20 lines` changed, OR pure documentation with no runtime impact.

This PR is **pure documentation with no runtime impact** (no `.mjs` / `.json` / runtime code touched; the only file changed is `learn/benefits/ArchitectureOverview.md`). Qualifies for the micro-change exemption from the cross-family Approved-status mandate.

@tobiu can merge directly without a cross-family review chain. Happy to add @neo-gpt or @neo-gemini-3-1-pro as observer-reviewer if you want a courtesy spot-check, but per §6.1 it's not gating.

## ACs Closeout

- [x] **AC1** ([#10449](https://github.com/neomjs/neo/issues/10449) Sub-2 stated): explicit ADR links per subsystem in `ArchitectureOverview.md` — landed via Structural Inventory "Decisions" column + new ADR index section.
- [x] **AC2** (implicit per OQ5): map-as-pointer mechanism — readers traversing the map now reach ADRs naturally.
- [x] **AC3** (authoring discipline): future-ADR-authors on the hook for inventory linkage in same PR — captured in the new ADR section's discipline note.
- [x] **AC4** (substrate consistency): post-M6 SDK paths reflected in Inventory; previously stale on `ai/services/<name>/` rows.

## Post-Merge Validation

- [ ] Once [#11011](https://github.com/neomjs/neo/issues/11011) (chromaUnified retirement) merges with its `0003-chroma-topology-unified-only.md` ADR, verify the inventory linkage discipline fires — the new ADR row should land in the same PR per the discipline this PR establishes. If it doesn't, that's a calibration miss for me to flag in review.
- [ ] Future ADRs follow the same discipline.

## Commits

- `f72d0c785` — `feat(docs): ADR-link enrichment for Structural Inventory (#10449 sub-2)` — initial enrichment: Decisions column added to both Structural Inventory tables, post-M6 SDK paths reflected, new "Architectural Decision Records" section with map-as-pointer authoring discipline
- `68395b83a` — `fix(docs): add SwarmHeartbeatService to ai/daemons/ Inventory row (#10449 sub-2)` — Cycle 1 RA fix per @neo-gpt: `ai/daemons/` Key Classes column expanded from `DreamService` to `DreamService`, `SwarmHeartbeatService` (verified empirically via `ls ai/daemons/` + className declaration). ADR 0002 link in Decisions column unchanged.

**Post-#11016-merge follow-up:** once orchestrator class extraction merges, a tiny rebase-or-follow-up commit will add `Orchestrator` to the same `ai/daemons/` row's Key Classes column (per @neo-gpt's Cycle 1 RA sequencing note).
