### PR TITLE
feat(skill): session-sunset primary-checkout staleness probe (#11013)

### DIFF
--- a/.agents/skills/session-sunset/references/session-sunset-workflow.md
+++ b/.agents/skills/session-sunset/references/session-sunset-workflow.md
@@ -42,6 +42,37 @@ Use the `run_command` tool to synchronize the codebase, but you MUST respect har
 - **Shared Checkout (Antigravity/Gemini):** Execute `git checkout dev && git pull origin dev`. Because the AI harness initializes MCP servers *before* an agent's first turn, pulling the latest code at the end of the current session guarantees the next session's servers boot with fresh infrastructure.
 - **Isolated Worktree (Claude Code):** Do NOT checkout `dev` (which would conflict with the main checkout). Instead, ensure your current PR branch is fully committed and pushed (`git push origin HEAD`). The next agent session will either resume this worktree or bootstrap a new one from the main checkout's updated `dev`.
 
+#### Primary-Checkout Staleness Probe (Isolated Worktree only) — per #11013
+
+The "main checkout's updated `dev`" assumption above only holds if the operator has actually pulled origin/dev into the primary checkout. In practice, primary's `dev` can fall arbitrarily behind because:
+
+- Worktree agents (correctly per the Isolated-Worktree rule above) do NOT pull dev into primary.
+- Operators don't always run `git pull origin dev` between sunset events.
+- Daemons running from primary (`bridge-daemon`, `DreamService`, future `orchestrator-daemon` post-#11009, KB sync pipeline) silently read pre-merge code when primary is stale.
+
+**Mandatory sunset probe (Isolated Worktree branch only):**
+
+```bash
+# Resolve primary-checkout path from the shared .git/ common dir.
+# git rev-parse --git-common-dir returns "<primary>/.git" from any worktree.
+PRIMARY_DOT_GIT=$(git rev-parse --git-common-dir)
+PRIMARY_ROOT=$(cd "$PRIMARY_DOT_GIT/.." && pwd)
+
+# Refresh remote refs so the count is accurate.
+git -C "$PRIMARY_ROOT" fetch origin dev --quiet 2>/dev/null
+
+# Count commits primary's local dev is behind origin/dev.
+BEHIND=$(git -C "$PRIMARY_ROOT" rev-list --count dev..origin/dev 2>/dev/null || echo 0)
+```
+
+**Conditional handover-comment block (fire only when `BEHIND > 0`):**
+
+> ⚠️ **Primary-checkout reminder:** the operator's primary checkout (`<PRIMARY_ROOT>`) `dev` branch is **`<BEHIND>` commits behind `origin/dev`**. Daemons running from the primary (`bridge-daemon`, `DreamService`, `orchestrator-daemon`, KB sync pipeline) read pre-merge code until refresh. Run `git -C <PRIMARY_ROOT> pull origin dev` in your main checkout to refresh downstream daemon state.
+
+When `BEHIND == 0`, suppress the block — no handover-comment noise on a fresh primary.
+
+**Why this lives at sunset rather than mid-session:** sunset is the natural Operator Synchronization Point — the agent is already drafting handover prose, and the operator is the next active actor between sessions. Mid-session staleness is unaddressed by this probe; the daemon-driven Shape A solution under #11013's follow-up (post-#11009 orchestrator-daemon task) will close that gap with a periodic auto-pull.
+
 ### Step 2: Handovers Posted (Active Work)
 For any tickets or tasks that you actively worked on but did not fully complete, you MUST post a self-contained handover comment directly on the GitHub Issue (using `manage_issue_comment`).
 - Provide implementation guidance.

--- a/.agents/skills/session-sunset/references/session-sunset-workflow.md
+++ b/.agents/skills/session-sunset/references/session-sunset-workflow.md
@@ -48,7 +48,7 @@ The "main checkout's updated `dev`" assumption above only holds if the operator 
 
 - Worktree agents (correctly per the Isolated-Worktree rule above) do NOT pull dev into primary.
 - Operators don't always run `git pull origin dev` between sunset events.
-- Daemons running from primary (`bridge-daemon`, `DreamService`, future `orchestrator-daemon` post-#11009, KB sync pipeline) silently read pre-merge code when primary is stale.
+- Daemons running from primary — `orchestrator-daemon` (the canonical Agent OS scheduled-maintenance daemon per `learn/agentos/v13-path.md` M3; currently MVP-shape via #11008, full class extraction in flight under #11009) plus its current and future siblings (`bridge-daemon` for wake delivery, `DreamService` for ingestion, KB sync pipeline) — silently read pre-merge code when primary is stale.
 
 **Mandatory sunset probe (Isolated Worktree branch only):**
 
@@ -67,11 +67,11 @@ BEHIND=$(git -C "$PRIMARY_ROOT" rev-list --count dev..origin/dev 2>/dev/null || 
 
 **Conditional handover-comment block (fire only when `BEHIND > 0`):**
 
-> ⚠️ **Primary-checkout reminder:** the operator's primary checkout (`<PRIMARY_ROOT>`) `dev` branch is **`<BEHIND>` commits behind `origin/dev`**. Daemons running from the primary (`bridge-daemon`, `DreamService`, `orchestrator-daemon`, KB sync pipeline) read pre-merge code until refresh. Run `git -C <PRIMARY_ROOT> pull origin dev` in your main checkout to refresh downstream daemon state.
+> ⚠️ **Primary-checkout reminder:** the operator's primary checkout (`<PRIMARY_ROOT>`) `dev` branch is **`<BEHIND>` commits behind `origin/dev`**. The `orchestrator-daemon` (Agent OS canonical scheduled-maintenance daemon) and its siblings (`bridge-daemon`, `DreamService`, KB sync pipeline) read pre-merge code until refresh. Run `git -C <PRIMARY_ROOT> pull origin dev` in your main checkout to refresh `orchestrator-daemon` and downstream-daemon state.
 
 When `BEHIND == 0`, suppress the block — no handover-comment noise on a fresh primary.
 
-**Why this lives at sunset rather than mid-session:** sunset is the natural Operator Synchronization Point — the agent is already drafting handover prose, and the operator is the next active actor between sessions. Mid-session staleness is unaddressed by this probe; the daemon-driven Shape A solution under #11013's follow-up (post-#11009 orchestrator-daemon task) will close that gap with a periodic auto-pull.
+**Why this lives at sunset rather than mid-session:** sunset is the natural Operator Synchronization Point — the agent is already drafting handover prose, and the operator is the next active actor between sessions. Mid-session staleness is unaddressed by this probe; the daemon-driven Shape A solution under #11013's follow-up will register a `primary-dev-sync` periodic task in the `orchestrator-daemon` (post-#11009 `Orchestrator.mjs` class extraction) to close that gap with an automatic `git pull --ff-only`.
 
 ### Step 2: Handovers Posted (Active Work)
 For any tickets or tasks that you actively worked on but did not fully complete, you MUST post a self-contained handover comment directly on the GitHub Issue (using `manage_issue_comment`).


### PR DESCRIPTION
Resolves #11013

Authored by Claude Opus 4.7 (Claude Code 1M-context). Session \`c2912891-b459-4a03-b2af-154d5e264df1\`.

Implements Shape B from a daemon-coordination brainstorm with @tobiu. Closes the discipline-only gap in the Isolated Worktree branch of the session-sunset Step 1 (Codebase Synchronization). The skill correctly forbids worktree agents from pulling \`dev\` into primary (would conflict with the main checkout), but assumes "main checkout's updated \`dev\`" without defining the trigger. In practice, primary's \`dev\` can fall arbitrarily behind origin/dev between sunset events, so daemons running from primary (\`bridge-daemon\`, \`DreamService\`, future orchestrator-daemon post-#11009, KB sync pipeline) silently read pre-merge code.

Evidence: L1 (skill-payload addition + path-detection mechanism documented) → L1 required (no runtime contracts changed; discipline-only path). No residuals.

## What ships

A new subsection under Step 1 of the session-sunset workflow (Isolated Worktree branch only): **Primary-Checkout Staleness Probe (Isolated Worktree only) — per #11013**

The probe:

1. Resolves primary-checkout path via \`git rev-parse --git-common-dir\` (returns \`<primary>/.git\` from any worktree, working from the shared \`.git/\` structure git worktrees mandate).
2. Fetches origin/dev refs to ensure the count is accurate.
3. Counts commits primary's \`dev\` is behind origin/dev via \`rev-list --count dev..origin/dev\`.
4. Conditionally emits a \`⚠️ Primary-checkout reminder\` block in the handover comment when \`BEHIND > 0\`; suppresses when \`BEHIND == 0\`.

When the reminder fires, it instructs the operator to run \`git -C <primary> pull origin dev\` and explains the daemon-state rationale.

## Why this lives at sunset rather than mid-session

Sunset is the natural Operator Synchronization Point — the agent is already drafting handover prose, and the operator is the next active actor between sessions. Mid-session staleness is unaddressed by this probe.

The daemon-driven Shape A solution (registered \`primary-dev-sync\` task in \`Orchestrator.mjs\` post-#11009) will close the mid-session gap with a periodic auto-pull. That follow-up is tracked in #11013's Out of Scope section + will be filed as a separate ticket once #11009 lands the Orchestrator class extraction.

## ACs Closeout

- [x] **AC1** — Session-sunset Isolated Worktree branch extended with primary-checkout staleness check (\`rev-list --count dev..origin/dev\`).
- [x] **AC2** — Conditional \`⚠️\` block fires when \`BEHIND > 0\`; suppressed when \`BEHIND == 0\`.
- [x] **AC3** — Reminder text directs operator to run \`git -C <primary> pull origin dev\` with explicit daemon-state rationale.
- [x] **AC4** — Path-detection mechanism documented (\`git rev-parse --git-common-dir\` from any worktree returns \`<primary>/.git\`).
- [x] **AC5** — Shared Checkout branch unchanged (auto-pull discipline already covers that harness class).
- [x] **AC6** — Skill payload remains within Progressive Disclosure byte budget. Addition is +31 lines to \`session-sunset-workflow.md\`; deeper payload, not the always-loaded SKILL.md router.

## Cross-Family Review Routing

Per \`pull-request §6.1\` Exceptions Matrix:

> **Micro-change exemption:** Commit type \`chore\` AND \`< 20 lines\` changed, OR pure documentation with no runtime impact.

This PR is **pure documentation with no runtime impact** — only file changed is \`.agents/skills/session-sunset/references/session-sunset-workflow.md\`. Qualifies for the micro-change exemption from cross-family Approved-status mandate.

@tobiu can merge directly without a cross-family review chain. Happy for any peer to do a courtesy spot-check (especially since this enhances the discipline they'll all consume at sunset), but per §6.1 it's not gating.

## Post-Merge Validation

- [ ] Empirical verification: next sunset event on a stale-primary worktree confirms the conditional fires correctly.
- [ ] Shape A follow-up ticket filed once #11009 (Orchestrator class extraction) merges, registering \`primary-dev-sync\` periodic task in \`Orchestrator.mjs\`.