### PR TITLE
refactor(ai): move orchestrator logic into daemon class (#11009)

### DIFF
--- a/ai/daemons/Orchestrator.mjs
+++ b/ai/daemons/Orchestrator.mjs
@@ -1,0 +1,682 @@
+// IMPORTANT: `Neo` MUST be imported before Base / service singletons that call
+// `Neo.setupClass()` at module-load time. This keeps the daemon directly runnable
+// from Node, matching the persistent-process shape of SwarmHeartbeatService.
+import Neo                         from '../../src/Neo.mjs';
+import * as core                   from '../../src/core/_export.mjs';
+
+import fs                          from 'fs-extra';
+import path                        from 'path';
+import {spawn, execSync}           from 'child_process';
+import {fileURLToPath}             from 'url';
+import Base                        from '../../src/core/Base.mjs';
+import HealthService               from '../services/memory-core/HealthService.mjs';
+import {
+    initializeDatabase
+} from '../scripts/bridge-daemon-queries.mjs';
+import SummarizationCoordinatorService from './services/SummarizationCoordinatorService.mjs';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname  = path.dirname(__filename);
+
+export const DEFAULT_POLL_INTERVAL_MS          = 3000;
+export const DEFAULT_SUMMARY_SWEEP_INTERVAL_MS = 600000;
+export const DEFAULT_KB_SYNC_INTERVAL_MS       = 1800000;
+
+const DEFAULT_DB_PATH   = process.env.NEO_AI_DB_PATH || '.neo-ai-data/sqlite/memory-core-graph.sqlite';
+const DEFAULT_DATA_DIR  = process.env.NEO_AI_ORCHESTRATOR_DIR || '.neo-ai-data/orchestrator-daemon';
+const DEFAULT_SCRIPT_DIR = path.resolve(__dirname, '../scripts');
+
+/**
+ * @summary Parses daemon interval env vars while preserving `0` as disabled.
+ *
+ * @param {String|undefined} value Environment value.
+ * @param {Number} fallback Fallback interval in milliseconds.
+ * @returns {Number}
+ */
+export function parseInterval(value, fallback) {
+    if (value === undefined || value === null || value === '') {
+        return fallback;
+    }
+
+    const parsed = parseInt(value, 10);
+    if (Number.isNaN(parsed)) {
+        return fallback;
+    }
+
+    return Math.max(parsed, 0);
+}
+
+/**
+ * @summary Returns true when an interval task is due and not disabled.
+ *
+ * @param {Object} options
+ * @param {Number} options.now Current timestamp in milliseconds.
+ * @param {Number} options.lastRunAt Last start timestamp in milliseconds.
+ * @param {Number} options.intervalMs Interval in milliseconds; `0` disables.
+ * @returns {Boolean}
+ */
+export function shouldRunIntervalTask({now, lastRunAt, intervalMs}) {
+    return intervalMs > 0 && now - lastRunAt >= intervalMs;
+}
+
+/**
+ * @summary Builds child-process commands for orchestrator-owned maintenance tasks.
+ *
+ * The orchestrator intentionally shells out to existing manual maintenance scripts for
+ * Piece C instead of reimplementing their internals. This keeps orchestration separate
+ * from summarization / KB-sync business logic and gives operators the same scripts for
+ * manual recovery.
+ *
+ * @param {Object} [options]
+ * @param {String} [options.scriptDir] Script directory.
+ * @param {String} [options.nodeBin] Node executable.
+ * @returns {Object}
+ */
+export function buildTaskDefinitions({scriptDir = DEFAULT_SCRIPT_DIR, nodeBin = process.argv[0]} = {}) {
+    return {
+        summary: {
+            label          : 'session summarization',
+            command        : nodeBin,
+            args           : [path.join(scriptDir, 'summarize-sessions.mjs')],
+            pidFileName    : 'summarization.pid',
+            expectedCommand: 'summarize-sessions.mjs'
+        },
+        kbSync: {
+            label          : 'knowledge base sync',
+            command        : nodeBin,
+            args           : [path.resolve(scriptDir, '../../buildScripts/ai/syncKnowledgeBase.mjs')],
+            pidFileName    : 'kb-sync.pid',
+            expectedCommand: 'syncKnowledgeBase.mjs'
+        }
+    };
+}
+
+/**
+ * @summary Creates the persisted state envelope for orchestrator task tracking.
+ *
+ * @param {Object} taskDefinitions Task-definition map.
+ * @returns {Object}
+ */
+export function createInitialTaskState(taskDefinitions) {
+    return Object.keys(taskDefinitions).reduce((state, taskName) => {
+        state[taskName] = {
+            running      : false,
+            pid          : null,
+            lastRunAt    : 0,
+            lastSuccessAt: null,
+            lastErrorAt  : null,
+            lastExitCode : null,
+            lastReason   : null
+        };
+        return state;
+    }, {});
+}
+
+/**
+ * @summary Neo daemon class for Agent OS maintenance scheduling (#11009).
+ *
+ * `ai/scripts/orchestrator-daemon.mjs` owns the Node-process boot wrapper:
+ * PID file, lifecycle traps, and fatal-start isolation. This class owns the
+ * actual maintenance loop, task-state persistence, subprocess execution,
+ * recovery of already-running child tasks, and task outcome reporting through
+ * `HealthService.recordTaskOutcome(...)`.
+ *
+ * Failure isolation is per task: summary scheduling and KB-sync scheduling are
+ * wrapped independently so a thrown sunset-handover read or summary success hook
+ * cannot stop the KB-sync lane, and a KB-sync failure cannot stop the next summary
+ * sweep.
+ *
+ * @class Neo.ai.daemons.Orchestrator
+ * @extends Neo.core.Base
+ * @singleton
+ * @see ai/scripts/orchestrator-daemon.mjs
+ * @see ai/daemons/services/SummarizationCoordinatorService.mjs
+ * @see ai/services/memory-core/HealthService.mjs#recordTaskOutcome
+ * @see learn/agentos/v13-path.md
+ * @see #11009
+ */
+export class Orchestrator extends Base {
+    static config = {
+        /**
+         * @member {String} className='Neo.ai.daemons.Orchestrator'
+         * @protected
+         */
+        className: 'Neo.ai.daemons.Orchestrator',
+        /**
+         * @member {Boolean} singleton=true
+         * @protected
+         */
+        singleton: true,
+        /**
+         * @member {Boolean} isPolling_=false
+         * @protected
+         * @reactive
+         */
+        isPolling_: false,
+        /**
+         * @member {Object|null} pollHandle_=null
+         * @protected
+         * @reactive
+         */
+        pollHandle_: null,
+        /**
+         * @member {Object|null} db_=null
+         * @protected
+         * @reactive
+         */
+        db_: null,
+        /**
+         * @member {Object|null} taskState_=null
+         * @protected
+         * @reactive
+         */
+        taskState_: null,
+        /**
+         * @member {Object|null} taskDefinitions_=null
+         * @protected
+         * @reactive
+         */
+        taskDefinitions_: null,
+        /**
+         * @member {String} dataDir_='.neo-ai-data/orchestrator-daemon'
+         * @protected
+         * @reactive
+         */
+        dataDir_: DEFAULT_DATA_DIR,
+        /**
+         * @member {String} dbPath_='.neo-ai-data/sqlite/memory-core-graph.sqlite'
+         * @protected
+         * @reactive
+         */
+        dbPath_: DEFAULT_DB_PATH,
+        /**
+         * @member {String|null} logFile_=null
+         * @protected
+         * @reactive
+         */
+        logFile_: null,
+        /**
+         * @member {String|null} stateFile_=null
+         * @protected
+         * @reactive
+         */
+        stateFile_: null,
+        /**
+         * @member {Number} pollIntervalMs_=3000
+         * @protected
+         * @reactive
+         */
+        pollIntervalMs_: DEFAULT_POLL_INTERVAL_MS,
+        /**
+         * @member {Number} summarySweepIntervalMs_=600000
+         * @protected
+         * @reactive
+         */
+        summarySweepIntervalMs_: DEFAULT_SUMMARY_SWEEP_INTERVAL_MS,
+        /**
+         * @member {Number} kbSyncIntervalMs_=1800000
+         * @protected
+         * @reactive
+         */
+        kbSyncIntervalMs_: DEFAULT_KB_SYNC_INTERVAL_MS,
+        /**
+         * @member {Object} healthService_=HealthService
+         * @protected
+         * @reactive
+         */
+        healthService_: HealthService,
+        /**
+         * @member {Object} summarizationCoordinator_=SummarizationCoordinatorService
+         * @protected
+         * @reactive
+         */
+        summarizationCoordinator_: SummarizationCoordinatorService,
+        /**
+         * @member {Function} spawnFn_=spawn
+         * @protected
+         * @reactive
+         */
+        spawnFn_: spawn,
+        /**
+         * @member {Function} processCommandFn_=null
+         * @protected
+         * @reactive
+         */
+        processCommandFn_: null,
+        /**
+         * @member {Function} initializeDatabaseFn_=initializeDatabase
+         * @protected
+         * @reactive
+         */
+        initializeDatabaseFn_: initializeDatabase
+    }
+
+    /**
+     * Applies runtime settings from the wrapper or tests.
+     * @param {Object} [options]
+     * @returns {void}
+     */
+    configure(options = {}) {
+        const scriptDir = options.scriptDir || DEFAULT_SCRIPT_DIR;
+        const dataDir   = options.dataDir   || DEFAULT_DATA_DIR;
+
+        this.dataDir                = dataDir;
+        this.dbPath                 = options.dbPath || DEFAULT_DB_PATH;
+        this.logFile                = options.logFile   || path.join(dataDir, 'orchestrator.log');
+        this.stateFile              = options.stateFile || path.join(dataDir, 'orchestrator-state.json');
+        this.pollIntervalMs         = options.pollIntervalMs ?? parseInterval(process.env.NEO_ORCHESTRATOR_POLL_INTERVAL_MS, DEFAULT_POLL_INTERVAL_MS);
+        this.summarySweepIntervalMs = options.summarySweepIntervalMs ?? parseInterval(
+            process.env.NEO_ORCHESTRATOR_SUMMARY_SWEEP_INTERVAL_MS ?? process.env.NEO_SUMMARIZATION_SWEEP_INTERVAL_MS,
+            DEFAULT_SUMMARY_SWEEP_INTERVAL_MS
+        );
+        this.kbSyncIntervalMs       = options.kbSyncIntervalMs ?? parseInterval(process.env.NEO_ORCHESTRATOR_KB_SYNC_INTERVAL_MS, DEFAULT_KB_SYNC_INTERVAL_MS);
+        this.taskDefinitions        = options.taskDefinitions || buildTaskDefinitions({
+            scriptDir,
+            nodeBin: options.nodeBin || process.argv[0]
+        });
+        this.healthService          = options.healthService          || HealthService;
+        this.summarizationCoordinator = options.summarizationCoordinator || SummarizationCoordinatorService;
+        this.spawnFn                = options.spawnFn                || spawn;
+        this.processCommandFn       = options.processCommandFn       || this.processCommand.bind(this);
+        this.initializeDatabaseFn   = options.initializeDatabaseFn   || initializeDatabase;
+    }
+
+    /**
+     * Starts the orchestrator process loop after the wrapper has selected this process.
+     * @param {Object} [options] Runtime overrides from the boot wrapper.
+     * @returns {Promise<void>}
+     */
+    async start(options = {}) {
+        if (this.isPolling) {
+            this.writeLog('INFO', '[Orchestrator] Already polling; start() is a no-op.');
+            return;
+        }
+
+        this.configure(options);
+
+        fs.ensureDirSync(this.dataDir);
+        this.taskState = this.readState();
+        this.recoverTasks();
+        this.db = this.initializeDatabaseFn(this.dbPath);
+
+        this.isPolling = true;
+        this.writeLog('INFO', `[Orchestrator] Started. summaryInterval=${this.summarySweepIntervalMs}ms kbSyncInterval=${this.kbSyncIntervalMs}ms poll=${this.pollIntervalMs}ms.`);
+        this.poll();
+    }
+
+    /**
+     * Stops the polling loop.
+     * @returns {void}
+     */
+    stop() {
+        if (this.pollHandle) {
+            clearTimeout(this.pollHandle);
+            this.pollHandle = null;
+        }
+
+        this.isPolling = false;
+    }
+
+    /**
+     * Appends a daemon log line to disk and mirrors it to stdout/stderr.
+     * @param {String} level Log level.
+     * @param {String} message Log message.
+     * @returns {void}
+     */
+    writeLog(level, message) {
+        const timestamp = new Date().toISOString();
+        const line      = `[${timestamp}] [PID:${process.pid}] [${level}] ${message}`;
+
+        try {
+            if (this.logFile) {
+                fs.appendFileSync(this.logFile, line + '\n', 'utf8');
+            }
+        } catch (e) {}
+
+        if (level === 'ERROR') {
+            console.error(line);
+        } else {
+            console.log(line);
+        }
+    }
+
+    /**
+     * Reads persisted task state, clearing stale in-process fields on boot.
+     * @returns {Object}
+     */
+    readState() {
+        const fallback = createInitialTaskState(this.taskDefinitions);
+
+        if (!fs.existsSync(this.stateFile)) {
+            return fallback;
+        }
+
+        try {
+            const data = JSON.parse(fs.readFileSync(this.stateFile, 'utf8'));
+            return Object.keys(fallback).reduce((state, taskName) => {
+                state[taskName] = {...fallback[taskName], ...(data[taskName] || {})};
+                state[taskName].running = false;
+                state[taskName].pid     = null;
+                return state;
+            }, {});
+        } catch (e) {
+            this.writeLog('ERROR', `[Orchestrator] Failed to read state file: ${e.message}`);
+            return fallback;
+        }
+    }
+
+    /**
+     * Persists the current task-state envelope.
+     * @returns {void}
+     */
+    writeState() {
+        try {
+            fs.writeFileSync(this.stateFile, JSON.stringify(this.taskState, null, 2), 'utf8');
+        } catch (e) {
+            this.writeLog('ERROR', `[Orchestrator] Failed to write state file: ${e.message}`);
+        }
+    }
+
+    /**
+     * Resolves the PID file path for a child task.
+     * @param {String} taskName Task key.
+     * @returns {String}
+     */
+    getTaskPidFile(taskName) {
+        return path.join(this.dataDir, this.taskDefinitions[taskName].pidFileName);
+    }
+
+    /**
+     * Reads the command line for a process ID.
+     * @param {Number} pid Process ID.
+     * @returns {String}
+     */
+    processCommand(pid) {
+        return execSync(`ps -p ${pid} -o command=`).toString().trim();
+    }
+
+    /**
+     * Clears adopted child state after the recovered process exits.
+     * @param {String} taskName Task key.
+     * @param {Number} pid Process ID.
+     * @returns {void}
+     */
+    clearRecoveredTask(taskName, pid) {
+        const task    = this.taskDefinitions[taskName];
+        const state   = this.taskState[taskName];
+        const pidFile = this.getTaskPidFile(taskName);
+
+        if (state.pid !== pid) {
+            return;
+        }
+
+        state.running      = false;
+        state.pid          = null;
+        state.lastExitCode = null;
+
+        try {
+            if (fs.existsSync(pidFile) && parseInt(fs.readFileSync(pidFile, 'utf8'), 10) === pid) {
+                fs.unlinkSync(pidFile);
+            }
+        } catch (e) {}
+
+        this.writeLog('INFO', `[Orchestrator] Recovered ${task.label} process (PID: ${pid}) exited; clearing running state.`);
+        this.writeState();
+    }
+
+    /**
+     * Watches a recovered child process so the persisted running flag does not stick forever.
+     * @param {String} taskName Task key.
+     * @param {Number} pid Process ID.
+     * @returns {void}
+     */
+    watchRecoveredTask(taskName, pid) {
+        const watcher = setInterval(() => {
+            try {
+                process.kill(pid, 0);
+            } catch (e) {
+                clearInterval(watcher);
+                this.clearRecoveredTask(taskName, pid);
+            }
+        }, 1000);
+
+        watcher.unref?.();
+    }
+
+    /**
+     * Adopts or clears an existing child-task PID file during daemon boot.
+     * @param {String} taskName Task key.
+     * @returns {void}
+     */
+    recoverTask(taskName) {
+        const task    = this.taskDefinitions[taskName];
+        const pidFile = this.getTaskPidFile(taskName);
+
+        if (!fs.existsSync(pidFile)) {
+            return;
+        }
+
+        try {
+            const pid = parseInt(fs.readFileSync(pidFile, 'utf8'), 10);
+            if (Number.isNaN(pid) || pid <= 0) {
+                fs.unlinkSync(pidFile);
+                return;
+            }
+
+            process.kill(pid, 0);
+            const cmd = this.processCommandFn(pid);
+
+            if (cmd.includes(task.expectedCommand)) {
+                this.taskState[taskName].running = true;
+                this.taskState[taskName].pid     = pid;
+                this.watchRecoveredTask(taskName, pid);
+                this.writeLog('INFO', `[Orchestrator] Found running ${task.label} process (PID: ${pid}). Adopting.`);
+            } else {
+                fs.unlinkSync(pidFile);
+                this.writeLog('INFO', `[Orchestrator] Stale ${task.label} PID ${pid} reused by another process. Unlinking.`);
+            }
+        } catch (e) {
+            try {
+                fs.unlinkSync(pidFile);
+            } catch (unlinkErr) {}
+        }
+    }
+
+    /**
+     * Recovers all child task PID files on boot.
+     * @returns {void}
+     */
+    recoverTasks() {
+        for (const taskName of Object.keys(this.taskDefinitions)) {
+            this.recoverTask(taskName);
+        }
+    }
+
+    /**
+     * Records task status into HealthService without letting observability failures break the loop.
+     * @param {String} taskName Task key.
+     * @param {String} status Outcome status.
+     * @param {Object|null} [details=null] Outcome details.
+     * @returns {void}
+     */
+    recordTaskOutcome(taskName, status, details = null) {
+        try {
+            this.healthService?.recordTaskOutcome?.(taskName, status, details);
+        } catch (e) {
+            this.writeLog('ERROR', `[Orchestrator] Failed to record ${taskName} outcome: ${e.message}`);
+        }
+    }
+
+    /**
+     * Starts a child task and wires completion status back into task state and HealthService.
+     * @param {String} taskName Task key.
+     * @param {String} reason Scheduling reason.
+     * @param {Function} [onSuccess] Optional success hook.
+     * @returns {Boolean} True when a child was started.
+     */
+    runTask(taskName, reason, onSuccess) {
+        const task  = this.taskDefinitions[taskName];
+        const state = this.taskState[taskName];
+
+        if (state.running) {
+            this.writeLog('INFO', `[Orchestrator] Skipping ${task.label}; task already running (PID: ${state.pid}).`);
+            this.recordTaskOutcome(taskName, 'skipped', {reason, pid: state.pid, skippedAt: new Date().toISOString()});
+            return false;
+        }
+
+        state.running    = true;
+        state.lastRunAt  = Date.now();
+        state.lastReason = reason;
+        this.writeState();
+
+        this.writeLog('INFO', `[Orchestrator] Starting ${task.label} (${reason}).`);
+
+        let child;
+        try {
+            child = this.spawnFn(task.command, task.args, {stdio: 'ignore'});
+        } catch (e) {
+            state.running    = false;
+            state.pid        = null;
+            state.lastErrorAt = new Date().toISOString();
+            this.writeLog('ERROR', `[Orchestrator] ${task.label} failed to start: ${e.message}`);
+            this.writeState();
+            this.recordTaskOutcome(taskName, 'failed', {reason, phase: 'spawn', error: e.message});
+            return false;
+        }
+
+        const pidFile = this.getTaskPidFile(taskName);
+
+        if (child.pid) {
+            state.pid = child.pid;
+            try {
+                fs.writeFileSync(pidFile, child.pid.toString(), 'utf8');
+            } catch (e) {
+                this.writeLog('ERROR', `[Orchestrator] Failed to write ${task.label} PID: ${e.message}`);
+            }
+        }
+
+        this.recordTaskOutcome(taskName, 'running', {reason, pid: child.pid || null, startedAt: new Date().toISOString()});
+
+        let cleared = false;
+        const clear = (code, error) => {
+            if (cleared) {
+                return;
+            }
+            cleared = true;
+
+            state.running      = false;
+            state.pid          = null;
+            state.lastExitCode = code;
+
+            try {
+                if (fs.existsSync(pidFile)) {
+                    fs.unlinkSync(pidFile);
+                }
+            } catch (e) {}
+
+            if (error) {
+                state.lastErrorAt = new Date().toISOString();
+                this.writeLog('ERROR', `[Orchestrator] ${task.label} failed to start: ${error.message}`);
+                this.recordTaskOutcome(taskName, 'failed', {reason, phase: 'start', error: error.message});
+            } else if (code === 0) {
+                try {
+                    const completedAt = new Date().toISOString();
+                    onSuccess?.();
+                    state.lastSuccessAt = completedAt;
+                    this.writeLog('INFO', `[Orchestrator] ${task.label} completed successfully.`);
+                    this.recordTaskOutcome(taskName, 'completed', {reason, code, completedAt});
+                } catch (e) {
+                    state.lastErrorAt = new Date().toISOString();
+                    this.writeLog('ERROR', `[Orchestrator] ${task.label} success hook failed: ${e.message}`);
+                    this.recordTaskOutcome(taskName, 'failed', {reason, phase: 'success-hook', error: e.message});
+                }
+            } else {
+                state.lastErrorAt = new Date().toISOString();
+                this.writeLog('ERROR', `[Orchestrator] ${task.label} exited with code ${code}.`);
+                this.recordTaskOutcome(taskName, 'failed', {reason, code, failedAt: state.lastErrorAt});
+            }
+
+            this.writeState();
+        };
+
+        child.on('close', code => clear(code));
+        child.on('error', err => clear(null, err));
+
+        this.writeState();
+        return true;
+    }
+
+    /**
+     * Runs one named scheduling lane with its own error boundary.
+     * @param {String} taskName Task key.
+     * @param {Function} fn Scheduling function.
+     * @returns {void}
+     */
+    runTaskCycle(taskName, fn) {
+        try {
+            fn();
+        } catch (e) {
+            this.writeLog('ERROR', `[Orchestrator] ${taskName} scheduling failed: ${e.message}`);
+            this.recordTaskOutcome(taskName, 'failed', {phase: 'schedule', error: e.message});
+        }
+    }
+
+    /**
+     * Schedules a summary child task when the coordinator reports due work.
+     * @param {Number} now Current timestamp in milliseconds.
+     * @returns {void}
+     */
+    runSummaryCycle(now) {
+        const trigger = this.summarizationCoordinator.getDueTask({
+            db                    : this.db,
+            state                 : this.taskState,
+            now,
+            summarySweepIntervalMs: this.summarySweepIntervalMs,
+            log                   : this.writeLog.bind(this)
+        });
+
+        if (trigger) {
+            this.runTask('summary', trigger.reason, trigger.onSuccess);
+        }
+    }
+
+    /**
+     * Schedules a KB sync child task when its interval is due.
+     * @param {Number} now Current timestamp in milliseconds.
+     * @returns {void}
+     */
+    runKbSyncCycle(now) {
+        if (shouldRunIntervalTask({
+            now,
+            lastRunAt : this.taskState.kbSync.lastRunAt,
+            intervalMs: this.kbSyncIntervalMs
+        })) {
+            this.runTask('kbSync', `periodic-sync:${this.kbSyncIntervalMs}`);
+        }
+    }
+
+    /**
+     * Runs one maintenance sweep with task-level failure isolation.
+     * @param {Number} [now=Date.now()] Current timestamp in milliseconds.
+     * @returns {void}
+     */
+    runMaintenanceCycle(now = Date.now()) {
+        this.runTaskCycle('summary', () => this.runSummaryCycle(now));
+        this.runTaskCycle('kbSync',  () => this.runKbSyncCycle(now));
+    }
+
+    /**
+     * Executes a sweep and schedules the next poll when the daemon remains active.
+     * @returns {void}
+     */
+    poll() {
+        this.runMaintenanceCycle();
+
+        if (this.isPolling) {
+            this.pollHandle = setTimeout(() => this.poll(), this.pollIntervalMs);
+        }
+    }
+}
+
+const OrchestratorSingleton = Neo.setupClass(Orchestrator);
+export default OrchestratorSingleton;

--- a/ai/daemons/services/SummarizationCoordinatorService.mjs
+++ b/ai/daemons/services/SummarizationCoordinatorService.mjs
@@ -1,0 +1,121 @@
+import Neo  from '../../../src/Neo.mjs';
+import '../../../src/core/_export.mjs';
+import Base from '../../../src/core/Base.mjs';
+import {
+    getUnreadSunsetHandovers,
+    markNodesAsRead
+} from '../../scripts/bridge-daemon-queries.mjs';
+
+/**
+ * @summary Builds the task trigger for the summarization sweep lane (#11009).
+ *
+ * The summarization lane has two wake-up sources: unread sunset handovers get priority
+ * because they unblock the next agent boot, and the interval sweep is the fallback that
+ * catches ordinary unsummarized sessions. Keeping this projection pure lets the
+ * orchestrator test the scheduling contract without mounting the SQLite graph.
+ *
+ * @param {Object} options
+ * @param {Number} options.now        Current timestamp in milliseconds.
+ * @param {Number} options.lastRunAt  Last summary task start timestamp.
+ * @param {Number} options.intervalMs Periodic sweep interval; `0` disables the interval source.
+ * @param {Object[]} [options.handovers=[]] Unread sunset-handover message nodes.
+ * @returns {Object|null} A summary task trigger or null when no work is due.
+ */
+export function buildSummaryTrigger({now, lastRunAt, intervalMs, handovers = []}) {
+    if (handovers.length > 0) {
+        return {
+            taskName     : 'summary',
+            source       : 'sunset-handover',
+            reason       : `sunset-handover:${handovers.length}`,
+            handoverCount: handovers.length
+        };
+    }
+
+    if (intervalMs > 0 && now - lastRunAt >= intervalMs) {
+        return {
+            taskName: 'summary',
+            source  : 'periodic-sweep',
+            reason  : `periodic-sweep:${intervalMs}`
+        };
+    }
+
+    return null;
+}
+
+/**
+ * @summary Coordinates the Piece C summarization sweep trigger for the v13 orchestrator (#11009).
+ *
+ * This service owns the summarization-specific decision tree that was incorrectly embedded
+ * in `ai/scripts/orchestrator-daemon.mjs` by #11008. The `Orchestrator` daemon asks this
+ * service whether a summary task is due; the service returns a trigger object plus a success
+ * hook for marking sunset-handover messages as read only after the summarizer exits cleanly.
+ *
+ * @class Neo.ai.daemons.services.SummarizationCoordinatorService
+ * @extends Neo.core.Base
+ * @singleton
+ * @see ai/daemons/Orchestrator.mjs
+ * @see ai/scripts/bridge-daemon-queries.mjs#getUnreadSunsetHandovers
+ * @see #11009
+ */
+class SummarizationCoordinatorService extends Base {
+    static config = {
+        /**
+         * @member {String} className='Neo.ai.daemons.services.SummarizationCoordinatorService'
+         * @protected
+         */
+        className: 'Neo.ai.daemons.services.SummarizationCoordinatorService',
+        /**
+         * @member {Boolean} singleton=true
+         * @protected
+         */
+        singleton: true
+    }
+
+    /**
+     * Resolves the next summary task trigger, including the post-success handover mark-read hook.
+     * @param {Object} options
+     * @param {Object} options.db SQLite database handle.
+     * @param {Object} options.state Current orchestrator task state.
+     * @param {Number} options.now Current timestamp in milliseconds.
+     * @param {Number} options.summarySweepIntervalMs Periodic summary sweep interval.
+     * @param {Function} [options.getUnreadSunsetHandoversFn] Test seam for handover reads.
+     * @param {Function} [options.markNodesAsReadFn] Test seam for handover mark-read writes.
+     * @param {Function} [options.log] Optional orchestrator log function.
+     * @returns {Object|null} Task trigger with optional `onSuccess` callback.
+     */
+    getDueTask({
+        db,
+        state,
+        now,
+        summarySweepIntervalMs,
+        getUnreadSunsetHandoversFn = getUnreadSunsetHandovers,
+        markNodesAsReadFn          = markNodesAsRead,
+        log
+    }) {
+        const handovers = getUnreadSunsetHandoversFn(db);
+        const trigger   = buildSummaryTrigger({
+            now,
+            handovers,
+            intervalMs: summarySweepIntervalMs,
+            lastRunAt : state.summary?.lastRunAt || 0
+        });
+
+        if (!trigger) {
+            return null;
+        }
+
+        if (trigger.source === 'sunset-handover') {
+            return {
+                ...trigger,
+                onSuccess: () => {
+                    markNodesAsReadFn(db, handovers);
+                    log?.('INFO', `[Orchestrator] Marked ${handovers.length} sunset handovers as read.`);
+                }
+            };
+        }
+
+        return trigger;
+    }
+}
+
+export default Neo.setupClass(SummarizationCoordinatorService);

--- a/ai/scripts/orchestrator-daemon.mjs
+++ b/ai/scripts/orchestrator-daemon.mjs
@@ -1,118 +1,29 @@
 /**
  * @module ai/scripts/orchestrator-daemon
- * @summary Per-host maintenance orchestrator for existing Agent OS refresh tasks.
+ * @summary Thin Node-process boot wrapper for the Agent OS maintenance orchestrator.
  *
- * The bridge daemon owns wake delivery. This sibling daemon owns scheduled
- * maintenance triggers that keep agent boot context fresh: session summaries and
- * Knowledge Base delta sync. It deliberately shells out to the existing scripts
- * instead of reimplementing their logic.
+ * Process ownership stays here: PID-file directory creation, CLI entrypoint, and
+ * fatal-start error isolation. Scheduling, child-task state, and per-task health
+ * reporting live in `Neo.ai.daemons.Orchestrator`.
  *
- * @see ai/scripts/summarize-sessions.mjs
- * @see buildScripts/ai/syncKnowledgeBase.mjs
- * @see #11006
+ * @see ai/daemons/Orchestrator.mjs
+ * @see learn/agentos/v13-path.md
+ * @see #11009
  */
+import {pathToFileURL} from 'url';
 import fs from 'fs-extra';
 import path from 'path';
-import {spawn, execSync} from 'child_process';
-import {fileURLToPath, pathToFileURL} from 'url';
-import {
-    initializeDatabase,
-    getUnreadSunsetHandovers,
-    markNodesAsRead
-} from './bridge-daemon-queries.mjs';
+import {execSync} from 'child_process';
+import Orchestrator, {
+    DEFAULT_KB_SYNC_INTERVAL_MS,
+    DEFAULT_POLL_INTERVAL_MS,
+    DEFAULT_SUMMARY_SWEEP_INTERVAL_MS,
+    parseInterval
+} from '../daemons/Orchestrator.mjs';
 
-const __filename = fileURLToPath(import.meta.url);
-const __dirname  = path.dirname(__filename);
-
-export const DEFAULT_POLL_INTERVAL_MS = 3000;
-export const DEFAULT_SUMMARY_SWEEP_INTERVAL_MS = 600000;
-export const DEFAULT_KB_SYNC_INTERVAL_MS = 1800000;
-
-const DB_PATH         = process.env.NEO_AI_DB_PATH || '.neo-ai-data/sqlite/memory-core-graph.sqlite';
 const DAEMON_DATA_DIR = process.env.NEO_AI_ORCHESTRATOR_DIR || '.neo-ai-data/orchestrator-daemon';
 const PID_FILE        = path.join(DAEMON_DATA_DIR, 'orchestrator-daemon.pid');
 const LOG_FILE        = path.join(DAEMON_DATA_DIR, 'orchestrator.log');
-const STATE_FILE      = path.join(DAEMON_DATA_DIR, 'orchestrator-state.json');
-
-const POLL_INTERVAL_MS = parseInterval(
-    process.env.NEO_ORCHESTRATOR_POLL_INTERVAL_MS,
-    DEFAULT_POLL_INTERVAL_MS
-);
-
-const SUMMARY_SWEEP_INTERVAL_MS = parseInterval(
-    process.env.NEO_ORCHESTRATOR_SUMMARY_SWEEP_INTERVAL_MS ?? process.env.NEO_SUMMARIZATION_SWEEP_INTERVAL_MS,
-    DEFAULT_SUMMARY_SWEEP_INTERVAL_MS
-);
-
-const KB_SYNC_INTERVAL_MS = parseInterval(
-    process.env.NEO_ORCHESTRATOR_KB_SYNC_INTERVAL_MS,
-    DEFAULT_KB_SYNC_INTERVAL_MS
-);
-
-let db;
-let taskState;
-
-/**
- * @summary Parses daemon interval env vars while preserving `0` as disabled.
- *
- * @param {String|undefined} value    Environment value.
- * @param {Number}           fallback Fallback interval in milliseconds.
- * @returns {Number}
- */
-export function parseInterval(value, fallback) {
-    if (value === undefined || value === null || value === '') {
-        return fallback;
-    }
-
-    const parsed = parseInt(value, 10);
-    if (Number.isNaN(parsed)) {
-        return fallback;
-    }
-
-    return Math.max(parsed, 0);
-}
-
-/**
- * @summary Returns true when an interval task is due and not disabled.
- *
- * @param {Object} options
- * @param {Number} options.now        Current timestamp in milliseconds.
- * @param {Number} options.lastRunAt  Last start timestamp in milliseconds.
- * @param {Number} options.intervalMs Interval in milliseconds; 0 disables.
- * @returns {Boolean}
- */
-export function shouldRunIntervalTask({now, lastRunAt, intervalMs}) {
-    return intervalMs > 0 && now - lastRunAt >= intervalMs;
-}
-
-/**
- * @summary Builds child-process commands for the orchestrator-owned tasks.
- *
- * @param {Object} [options]
- * @param {String} [options.scriptDir] Script directory.
- * @param {String} [options.nodeBin]   Node executable.
- * @returns {Object}
- */
-export function buildTaskDefinitions({scriptDir = __dirname, nodeBin = process.argv[0]} = {}) {
-    return {
-        summary: {
-            label          : 'session summarization',
-            command        : nodeBin,
-            args           : [path.join(scriptDir, 'summarize-sessions.mjs')],
-            pidFileName    : 'summarization.pid',
-            expectedCommand: 'summarize-sessions.mjs'
-        },
-        kbSync: {
-            label          : 'knowledge base sync',
-            command        : nodeBin,
-            args           : [path.resolve(scriptDir, '../../buildScripts/ai/syncKnowledgeBase.mjs')],
-            pidFileName    : 'kb-sync.pid',
-            expectedCommand: 'syncKnowledgeBase.mjs'
-        }
-    };
-}
-
-const TASK_DEFINITIONS = buildTaskDefinitions();
 
 function writeLog(level, message) {
     const timestamp = new Date().toISOString();
@@ -129,129 +40,31 @@ function writeLog(level, message) {
     }
 }
 
-function readState() {
-    const fallback = {};
-
-    for (const taskName of Object.keys(TASK_DEFINITIONS)) {
-        fallback[taskName] = {
-            running      : false,
-            pid          : null,
-            lastRunAt    : 0,
-            lastSuccessAt: null,
-            lastErrorAt  : null,
-            lastExitCode : null,
-            lastReason   : null
-        };
-    }
-
-    if (!fs.existsSync(STATE_FILE)) {
-        return fallback;
-    }
-
-    try {
-        const data = JSON.parse(fs.readFileSync(STATE_FILE, 'utf8'));
-        return Object.keys(fallback).reduce((state, taskName) => {
-            state[taskName] = {...fallback[taskName], ...(data[taskName] || {})};
-            state[taskName].running = false;
-            state[taskName].pid     = null;
-            return state;
-        }, {});
-    } catch (e) {
-        writeLog('ERROR', `[Orchestrator] Failed to read state file: ${e.message}`);
-        return fallback;
-    }
-}
-
-function writeState() {
-    try {
-        fs.writeFileSync(STATE_FILE, JSON.stringify(taskState, null, 2), 'utf8');
-    } catch (e) {
-        writeLog('ERROR', `[Orchestrator] Failed to write state file: ${e.message}`);
-    }
-}
-
-function getTaskPidFile(taskName) {
-    return path.join(DAEMON_DATA_DIR, TASK_DEFINITIONS[taskName].pidFileName);
-}
-
 function processCommand(pid) {
     return execSync(`ps -p ${pid} -o command=`).toString().trim();
 }
 
-function clearRecoveredTask(taskName, pid) {
-    const task    = TASK_DEFINITIONS[taskName];
-    const state   = taskState[taskName];
-    const pidFile = getTaskPidFile(taskName);
+async function waitForExit(pid, timeoutMs) {
+    const start = Date.now();
 
-    if (state.pid !== pid) {
-        return;
-    }
-
-    state.running      = false;
-    state.pid          = null;
-    state.lastExitCode = null;
-
-    try {
-        if (fs.existsSync(pidFile) && parseInt(fs.readFileSync(pidFile, 'utf8'), 10) === pid) {
-            fs.unlinkSync(pidFile);
-        }
-    } catch (e) {}
-
-    writeLog('INFO', `[Orchestrator] Recovered ${task.label} process (PID: ${pid}) exited; clearing running state.`);
-    writeState();
-}
-
-function watchRecoveredTask(taskName, pid) {
-    const watcher = setInterval(() => {
+    while (Date.now() - start < timeoutMs) {
         try {
             process.kill(pid, 0);
         } catch (e) {
-            clearInterval(watcher);
-            clearRecoveredTask(taskName, pid);
+            return true;
         }
-    }, 1000);
-
-    watcher.unref?.();
-}
-
-function recoverTask(taskName) {
-    const task    = TASK_DEFINITIONS[taskName];
-    const pidFile = getTaskPidFile(taskName);
-
-    if (!fs.existsSync(pidFile)) {
-        return;
+        await new Promise(resolve => setTimeout(resolve, 250));
     }
 
+    return false;
+}
+
+function removePidFile() {
     try {
-        const pid = parseInt(fs.readFileSync(pidFile, 'utf8'), 10);
-        if (Number.isNaN(pid) || pid <= 0) {
-            fs.unlinkSync(pidFile);
-            return;
+        if (fs.existsSync(PID_FILE) && parseInt(fs.readFileSync(PID_FILE, 'utf8'), 10) === process.pid) {
+            fs.unlinkSync(PID_FILE);
         }
-
-        process.kill(pid, 0);
-        const cmd = processCommand(pid);
-
-        if (cmd.includes(task.expectedCommand)) {
-            taskState[taskName].running = true;
-            taskState[taskName].pid     = pid;
-            watchRecoveredTask(taskName, pid);
-            writeLog('INFO', `[Orchestrator] Found running ${task.label} process (PID: ${pid}). Adopting.`);
-        } else {
-            fs.unlinkSync(pidFile);
-            writeLog('INFO', `[Orchestrator] Stale ${task.label} PID ${pid} reused by another process. Unlinking.`);
-        }
-    } catch (e) {
-        try {
-            fs.unlinkSync(pidFile);
-        } catch (unlinkErr) {}
-    }
-}
-
-function recoverTasks() {
-    for (const taskName of Object.keys(TASK_DEFINITIONS)) {
-        recoverTask(taskName);
-    }
+    } catch (e) {}
 }
 
 async function enforceSingleton() {
@@ -288,163 +101,35 @@ async function enforceSingleton() {
     fs.writeFileSync(PID_FILE, process.pid.toString(), 'utf8');
 }
 
-async function waitForExit(pid, timeoutMs) {
-    const start = Date.now();
-
-    while (Date.now() - start < timeoutMs) {
-        try {
-            process.kill(pid, 0);
-        } catch (e) {
-            return true;
-        }
-        await new Promise(resolve => setTimeout(resolve, 250));
-    }
-
-    return false;
-}
-
 function setupCleanupHandlers() {
     const cleanup = () => {
-        try {
-            if (fs.existsSync(PID_FILE) && parseInt(fs.readFileSync(PID_FILE, 'utf8'), 10) === process.pid) {
-                fs.unlinkSync(PID_FILE);
-            }
-        } catch (e) {}
+        Orchestrator.stop();
+        removePidFile();
         process.exit();
     };
 
     process.on('SIGINT', cleanup);
     process.on('SIGTERM', cleanup);
-    process.on('exit', () => {
-        try {
-            if (fs.existsSync(PID_FILE) && parseInt(fs.readFileSync(PID_FILE, 'utf8'), 10) === process.pid) {
-                fs.unlinkSync(PID_FILE);
-            }
-        } catch (e) {}
-    });
-    process.on('uncaughtException', (err) => {
+    process.on('exit', removePidFile);
+    process.on('uncaughtException', err => {
         writeLog('ERROR', `[Orchestrator] Uncaught exception: ${err && err.stack ? err.stack : err}`);
         cleanup();
     });
 }
 
-function runTask(taskName, reason, onSuccess) {
-    const task  = TASK_DEFINITIONS[taskName];
-    const state = taskState[taskName];
-
-    if (state.running) {
-        writeLog('INFO', `[Orchestrator] Skipping ${task.label}; task already running (PID: ${state.pid}).`);
-        return false;
-    }
-
-    state.running    = true;
-    state.lastRunAt  = Date.now();
-    state.lastReason = reason;
-    writeState();
-
-    writeLog('INFO', `[Orchestrator] Starting ${task.label} (${reason}).`);
-    const child = spawn(task.command, task.args, {stdio: 'ignore'});
-    const pidFile = getTaskPidFile(taskName);
-
-    if (child.pid) {
-        state.pid = child.pid;
-        try {
-            fs.writeFileSync(pidFile, child.pid.toString(), 'utf8');
-        } catch (e) {
-            writeLog('ERROR', `[Orchestrator] Failed to write ${task.label} PID: ${e.message}`);
-        }
-    }
-
-    let cleared = false;
-    const clear = (code, error) => {
-        if (cleared) {
-            return;
-        }
-        cleared = true;
-
-        state.running     = false;
-        state.pid         = null;
-        state.lastExitCode = code;
-
-        try {
-            if (fs.existsSync(pidFile)) {
-                fs.unlinkSync(pidFile);
-            }
-        } catch (e) {}
-
-        if (error) {
-            state.lastErrorAt = new Date().toISOString();
-            writeLog('ERROR', `[Orchestrator] ${task.label} failed to start: ${error.message}`);
-        } else if (code === 0) {
-            state.lastSuccessAt = new Date().toISOString();
-            writeLog('INFO', `[Orchestrator] ${task.label} completed successfully.`);
-            if (onSuccess) {
-                try {
-                    onSuccess();
-                } catch (e) {
-                    writeLog('ERROR', `[Orchestrator] ${task.label} success hook failed: ${e.message}`);
-                }
-            }
-        } else {
-            state.lastErrorAt = new Date().toISOString();
-            writeLog('ERROR', `[Orchestrator] ${task.label} exited with code ${code}.`);
-        }
-
-        writeState();
-    };
-
-    child.on('close', code => clear(code));
-    child.on('error', err => clear(null, err));
-
-    writeState();
-    return true;
-}
-
-function runMaintenanceCycle(now = Date.now()) {
-    try {
-        const handovers = getUnreadSunsetHandovers(db);
-
-        if (handovers.length > 0) {
-            runTask('summary', `sunset-handover:${handovers.length}`, () => {
-                markNodesAsRead(db, handovers);
-                writeLog('INFO', `[Orchestrator] Marked ${handovers.length} sunset handovers as read.`);
-            });
-        } else if (shouldRunIntervalTask({
-            now,
-            lastRunAt : taskState.summary.lastRunAt,
-            intervalMs: SUMMARY_SWEEP_INTERVAL_MS
-        })) {
-            runTask('summary', `periodic-sweep:${SUMMARY_SWEEP_INTERVAL_MS}`);
-        }
-
-        if (shouldRunIntervalTask({
-            now,
-            lastRunAt : taskState.kbSync.lastRunAt,
-            intervalMs: KB_SYNC_INTERVAL_MS
-        })) {
-            runTask('kbSync', `periodic-sync:${KB_SYNC_INTERVAL_MS}`);
-        }
-    } catch (e) {
-        writeLog('ERROR', `[Orchestrator] Maintenance cycle failed: ${e.message}`);
-    }
-}
-
-function pollLoop() {
-    runMaintenanceCycle();
-    setTimeout(pollLoop, POLL_INTERVAL_MS);
-}
-
-export async function startOrchestrator() {
+/**
+ * Starts the singleton orchestrator daemon.
+ * @param {Object} [options] Runtime overrides for tests or process managers.
+ * @returns {Promise<void>}
+ */
+export async function startOrchestrator(options = {}) {
     fs.ensureDirSync(DAEMON_DATA_DIR);
     await enforceSingleton();
     setupCleanupHandlers();
-
-    taskState = readState();
-    recoverTasks();
-    db = initializeDatabase(DB_PATH);
-
-    writeLog('INFO', `[Orchestrator] Started. summaryInterval=${SUMMARY_SWEEP_INTERVAL_MS}ms kbSyncInterval=${KB_SYNC_INTERVAL_MS}ms poll=${POLL_INTERVAL_MS}ms.`);
-    pollLoop();
+    return Orchestrator.start({
+        dataDir: DAEMON_DATA_DIR,
+        ...options
+    });
 }
 
 if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
@@ -453,3 +138,10 @@ if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) 
         process.exit(1);
     });
 }
+
+export {
+    DEFAULT_KB_SYNC_INTERVAL_MS,
+    DEFAULT_POLL_INTERVAL_MS,
+    DEFAULT_SUMMARY_SWEEP_INTERVAL_MS,
+    parseInterval
+};

--- a/ai/services/memory-core/HealthService.mjs
+++ b/ai/services/memory-core/HealthService.mjs
@@ -85,6 +85,26 @@ export function buildIdentityBlock(stdioIdentityState) {
 }
 
 /**
+ * @summary Projects orchestrator task outcomes into the healthcheck `orchestrator.tasks`
+ *          observability block (#11009).
+ *
+ * The task outcome map is updated by `Neo.ai.daemons.Orchestrator` after each child-task
+ * lifecycle event. Returning a shallow clone prevents healthcheck callers from mutating
+ * the cached singleton state while keeping the payload direct enough for operators to
+ * inspect `summary` and `kbSync` independently.
+ *
+ * @param {Object} taskOutcomes Last-known outcome by task name.
+ * @returns {Object}
+ * @see Neo.ai.daemons.Orchestrator#recordTaskOutcome
+ */
+export function buildTaskOutcomesBlock(taskOutcomes) {
+    return Object.entries(taskOutcomes || {}).reduce((out, [taskName, outcome]) => {
+        out[taskName] = {...outcome};
+        return out;
+    }, {});
+}
+
+/**
  * @summary Projects the effective ChromaDB topology resolution into the healthcheck `database.topology`
  *          observability block (#10127).
  *
@@ -569,6 +589,13 @@ class HealthService extends Base {
     #startupSummarizationDetails = null;
 
     /**
+     * Last-known outcomes for orchestrator-owned maintenance tasks.
+     * @member {Object} #taskOutcomes
+     * @private
+     */
+    #taskOutcomes = {};
+
+    /**
      * Cached stdio identity state for the healthcheck `identity` observability block (#10176).
      * Populated by `Server.mjs` post-`resolveStdioIdentity()` via {@link HealthService#setStdioIdentityState}.
      * Null when the setter hasn't fired yet (SSE transport, pre-boot, or timing races — all of
@@ -882,6 +909,9 @@ class HealthService extends Base {
                 summarizationStatus : this.#startupSummarizationStatus || 'not_attempted',
                 summarizationDetails: this.#startupSummarizationDetails
             },
+            orchestrator: {
+                tasks: buildTaskOutcomesBlock(this.#taskOutcomes)
+            },
             mailboxPreview: await MailboxService.getHealthcheckPreview(),
             identity : buildIdentityBlock(this.#stdioIdentityState),
             migration: await this.#checkMigrationState(),
@@ -1087,6 +1117,24 @@ class HealthService extends Base {
     recordStartupSummarization(status, details=null) {
         this.#startupSummarizationStatus  = status;
         this.#startupSummarizationDetails = details;
+
+        // Clear the cache to ensure next healthcheck returns updated info
+        this.clearCache();
+    }
+
+    /**
+     * Records the result of an orchestrator-owned maintenance task.
+     * Called by `Neo.ai.daemons.Orchestrator` after each child-task lifecycle event.
+     * @param {String} taskName Stable orchestrator task name.
+     * @param {String} status One of: 'running', 'completed', 'failed', 'skipped'.
+     * @param {Object|null} details Additional information about the task outcome.
+     */
+    recordTaskOutcome(taskName, status, details=null) {
+        this.#taskOutcomes[taskName] = {
+            status,
+            details,
+            recordedAt: new Date().toISOString()
+        };
 
         // Clear the cache to ensure next healthcheck returns updated info
         this.clearCache();

--- a/learn/agentos/v13-path.md
+++ b/learn/agentos/v13-path.md
@@ -147,7 +147,7 @@ Build `ai/mcp/server/shared/Server.mjs` (D2). Migrate one MCP server (smallest f
 ### M3 — Orchestrator Daemon Skeleton + Piece C
 Build `ai/daemons/Orchestrator.mjs` + `ai/scripts/orchestrator-daemon.mjs` boot wrapper (D3). First task: `SummarizationCoordinatorService` running drift-detection sweep on configurable cadence. Strip the in-process `runPeriodicSummarizationSweep` from `SessionService` (which I added in PR [#10954](https://github.com/neomjs/neo/pull/10954) — wrong-substrate; reshape to Orchestrator).
 
-**MVP split:** [#11006](https://github.com/neomjs/neo/issues/11006) moves existing summary + KB sync triggers out of `bridge-daemon.mjs` and into a sibling `ai/scripts/orchestrator-daemon.mjs` runner first. The full Neo class (`ai/daemons/Orchestrator.mjs`), healthcheck surface, and richer task model remain the M3 completion target.
+**MVP split:** [#11006](https://github.com/neomjs/neo/issues/11006) moved existing summary + KB sync triggers out of `bridge-daemon.mjs`. PR #11008 initially concentrated too much scheduling logic inside `ai/scripts/orchestrator-daemon.mjs`; [#11009](https://github.com/neomjs/neo/issues/11009) corrects that by restoring the intended shape: the script is a thin boot wrapper, `ai/daemons/Orchestrator.mjs` owns task scheduling and failure isolation, `SummarizationCoordinatorService` owns Piece C trigger selection, and `HealthService.recordTaskOutcome(...)` exposes per-task outcomes.
 
 **Exit gate:** orchestrator daemon runs on the operator's host; summarization sweep fires automatically on cadence; healthcheck observability in place; PR #10954 closed in favor of corrected-substrate successor.
 

--- a/test/playwright/unit/ai/daemons/Orchestrator.spec.mjs
+++ b/test/playwright/unit/ai/daemons/Orchestrator.spec.mjs
@@ -1,0 +1,142 @@
+import {test, expect} from '@playwright/test';
+import Neo from '../../../../../src/Neo.mjs';
+import * as core from '../../../../../src/core/_export.mjs';
+import {
+    Orchestrator,
+    buildTaskDefinitions,
+    createInitialTaskState
+} from '../../../../../ai/daemons/Orchestrator.mjs';
+
+function createTestOrchestrator(config = {}) {
+    const taskDefinitions = config.taskDefinitions || buildTaskDefinitions({
+        scriptDir: '/repo/ai/scripts',
+        nodeBin  : '/node'
+    });
+
+    const orchestrator = Neo.create(Orchestrator, {
+        dataDir                 : '/tmp/orchestrator-test',
+        stateFile               : '/tmp/orchestrator-test/state.json',
+        logFile                 : null,
+        taskDefinitions,
+        taskState               : createInitialTaskState(taskDefinitions),
+        summarySweepIntervalMs  : config.summarySweepIntervalMs ?? 600000,
+        kbSyncIntervalMs        : config.kbSyncIntervalMs ?? 600000,
+        healthService           : config.healthService || {recordTaskOutcome() {}},
+        summarizationCoordinator: config.summarizationCoordinator || {getDueTask: () => null},
+        spawnFn                 : config.spawnFn || (() => { throw new Error('spawnFn not expected'); })
+    });
+
+    orchestrator.writeLog  = () => {};
+    orchestrator.writeState = () => {};
+
+    return orchestrator;
+}
+
+test.describe('Neo.ai.daemons.Orchestrator (#11009)', () => {
+    test('creates an isolated persisted-state envelope per task', () => {
+        const state = createInitialTaskState(buildTaskDefinitions({
+            scriptDir: '/repo/ai/scripts',
+            nodeBin  : '/node'
+        }));
+
+        expect(Object.keys(state)).toEqual(['summary', 'kbSync']);
+        expect(state.summary).toMatchObject({
+            running      : false,
+            pid          : null,
+            lastRunAt    : 0,
+            lastSuccessAt: null,
+            lastErrorAt  : null,
+            lastExitCode : null,
+            lastReason   : null
+        });
+        expect(state.kbSync).not.toBe(state.summary);
+    });
+
+    test('isolates summary scheduling failure and still schedules due KB sync', () => {
+        const outcomes = [];
+        const started  = [];
+
+        const orchestrator = createTestOrchestrator({
+            healthService: {
+                recordTaskOutcome(taskName, status, details) {
+                    outcomes.push({taskName, status, details});
+                }
+            },
+            summarizationCoordinator: {
+                getDueTask() {
+                    throw new Error('summary read failed');
+                }
+            }
+        });
+
+        orchestrator.runTask = (taskName, reason) => {
+            started.push({taskName, reason});
+            return true;
+        };
+
+        orchestrator.runMaintenanceCycle(600000);
+
+        expect(outcomes).toEqual([{
+            taskName: 'summary',
+            status  : 'failed',
+            details : {
+                phase: 'schedule',
+                error: 'summary read failed'
+            }
+        }]);
+        expect(started).toEqual([{
+            taskName: 'kbSync',
+            reason  : 'periodic-sync:600000'
+        }]);
+    });
+
+    test('records success-hook failures without throwing out of task cleanup', () => {
+        const outcomes = [];
+        let closeHandler;
+
+        const orchestrator = createTestOrchestrator({
+            healthService: {
+                recordTaskOutcome(taskName, status, details) {
+                    outcomes.push({taskName, status, details});
+                }
+            },
+            spawnFn: () => ({
+                pid: 123,
+                on(eventName, handler) {
+                    if (eventName === 'close') {
+                        closeHandler = handler;
+                    }
+                }
+            })
+        });
+
+        orchestrator.getTaskPidFile = () => '/tmp/orchestrator-test/summary.pid';
+
+        expect(orchestrator.runTask('summary', 'sunset-handover:1', () => {
+            throw new Error('mark read failed');
+        })).toBe(true);
+
+        closeHandler(0);
+
+        expect(outcomes[0]).toMatchObject({
+            taskName: 'summary',
+            status  : 'running',
+            details : {
+                reason: 'sunset-handover:1',
+                pid   : 123
+            }
+        });
+        expect(outcomes[1]).toEqual({
+            taskName: 'summary',
+            status  : 'failed',
+            details : {
+                reason: 'sunset-handover:1',
+                phase : 'success-hook',
+                error : 'mark read failed'
+            }
+        });
+        expect(orchestrator.taskState.summary.running).toBe(false);
+        expect(orchestrator.taskState.summary.lastErrorAt).toEqual(expect.any(String));
+        expect(orchestrator.taskState.summary.lastSuccessAt).toBeNull();
+    });
+});

--- a/test/playwright/unit/ai/daemons/services/SummarizationCoordinatorService.spec.mjs
+++ b/test/playwright/unit/ai/daemons/services/SummarizationCoordinatorService.spec.mjs
@@ -1,0 +1,49 @@
+import {test, expect} from '@playwright/test';
+import {
+    buildSummaryTrigger
+} from '../../../../../../ai/daemons/services/SummarizationCoordinatorService.mjs';
+
+test.describe('SummarizationCoordinatorService (#11009)', () => {
+    test('prioritizes unread sunset handovers over the periodic sweep', () => {
+        expect(buildSummaryTrigger({
+            now       : 1200000,
+            lastRunAt : 0,
+            intervalMs: 600000,
+            handovers : [{id: 'MESSAGE:1'}, {id: 'MESSAGE:2'}]
+        })).toEqual({
+            taskName     : 'summary',
+            source       : 'sunset-handover',
+            reason       : 'sunset-handover:2',
+            handoverCount: 2
+        });
+    });
+
+    test('returns a periodic sweep trigger only when the interval is due', () => {
+        expect(buildSummaryTrigger({
+            now       : 599999,
+            lastRunAt : 0,
+            intervalMs: 600000,
+            handovers : []
+        })).toBeNull();
+
+        expect(buildSummaryTrigger({
+            now       : 600000,
+            lastRunAt : 0,
+            intervalMs: 600000,
+            handovers : []
+        })).toEqual({
+            taskName: 'summary',
+            source  : 'periodic-sweep',
+            reason  : 'periodic-sweep:600000'
+        });
+    });
+
+    test('does not schedule disabled periodic sweeps', () => {
+        expect(buildSummaryTrigger({
+            now       : 600000,
+            lastRunAt : 0,
+            intervalMs: 0,
+            handovers : []
+        })).toBeNull();
+    });
+});

--- a/test/playwright/unit/ai/scripts/orchestrator-daemon.spec.mjs
+++ b/test/playwright/unit/ai/scripts/orchestrator-daemon.spec.mjs
@@ -5,12 +5,14 @@ import {
     DEFAULT_KB_SYNC_INTERVAL_MS,
     DEFAULT_POLL_INTERVAL_MS,
     DEFAULT_SUMMARY_SWEEP_INTERVAL_MS,
-    buildTaskDefinitions,
-    parseInterval,
-    shouldRunIntervalTask
+    parseInterval
 } from '../../../../../ai/scripts/orchestrator-daemon.mjs';
+import {
+    buildTaskDefinitions,
+    shouldRunIntervalTask
+} from '../../../../../ai/daemons/Orchestrator.mjs';
 
-test.describe('ai/scripts/orchestrator-daemon.mjs (#11006)', () => {
+test.describe('ai/scripts/orchestrator-daemon.mjs (#11006/#11009)', () => {
     test('parses interval env values while preserving zero as disabled', () => {
         expect(parseInterval(undefined, DEFAULT_POLL_INTERVAL_MS)).toBe(DEFAULT_POLL_INTERVAL_MS);
         expect(parseInterval('', DEFAULT_SUMMARY_SWEEP_INTERVAL_MS)).toBe(DEFAULT_SUMMARY_SWEEP_INTERVAL_MS);
@@ -53,15 +55,25 @@ test.describe('ai/scripts/orchestrator-daemon.mjs (#11006)', () => {
         expect(tasks.kbSync.expectedCommand).toBe('syncKnowledgeBase.mjs');
     });
 
-    test('keeps bridge-daemon wake-only and routes maintenance ownership to orchestrator', () => {
+    test('keeps bridge-daemon wake-only and routes maintenance ownership to the daemon class', () => {
         const bridgeSource       = fs.readFileSync(path.resolve(process.cwd(), 'ai/scripts/bridge-daemon.mjs'), 'utf8');
         const orchestratorSource = fs.readFileSync(path.resolve(process.cwd(), 'ai/scripts/orchestrator-daemon.mjs'), 'utf8');
+        const daemonSource       = fs.readFileSync(path.resolve(process.cwd(), 'ai/daemons/Orchestrator.mjs'), 'utf8');
 
         expect(bridgeSource).not.toContain('summarize-sessions.mjs');
         expect(bridgeSource).not.toContain('Piece C periodic summarization sweep');
         expect(bridgeSource).not.toContain('checkSummarizationLifecycle');
 
-        expect(orchestratorSource).toContain('summarize-sessions.mjs');
-        expect(orchestratorSource).toContain('syncKnowledgeBase.mjs');
+        expect(orchestratorSource).toContain('../daemons/Orchestrator.mjs');
+        expect(orchestratorSource).toContain('orchestrator-daemon.pid');
+        expect(orchestratorSource).toContain('setupCleanupHandlers');
+        expect(orchestratorSource).toContain('enforceSingleton');
+        expect(orchestratorSource).not.toContain('buildTaskDefinitions');
+        expect(orchestratorSource).not.toContain('runMaintenanceCycle');
+        expect(orchestratorSource).not.toContain('summarize-sessions.mjs');
+        expect(orchestratorSource).not.toContain('syncKnowledgeBase.mjs');
+
+        expect(daemonSource).toContain('summarize-sessions.mjs');
+        expect(daemonSource).toContain('syncKnowledgeBase.mjs');
     });
 });

--- a/test/playwright/unit/ai/services/memory-core/HealthService.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/HealthService.spec.mjs
@@ -123,6 +123,40 @@ test.describe('HealthService #10176 — buildIdentityBlock', () => {
 });
 
 /**
+ * @summary Coverage for the #11009 orchestrator task outcome projection.
+ *
+ * The end-to-end healthcheck path requires mounted Memory Core dependencies. This spec
+ * pins the pure projection used by `HealthService.recordTaskOutcome()` so operators get
+ * an immutable per-task view under `healthcheck.orchestrator.tasks`.
+ *
+ * @see Neo.ai.services.memory-core.HealthService#buildTaskOutcomesBlock
+ */
+test.describe('HealthService #11009 — buildTaskOutcomesBlock', () => {
+    let buildTaskOutcomesBlock;
+
+    test.beforeAll(async () => {
+        const mod = await import('../../../../../../ai/services/memory-core/HealthService.mjs');
+        buildTaskOutcomesBlock = mod.buildTaskOutcomesBlock;
+    });
+
+    test('clones task outcomes for healthcheck callers', () => {
+        const source = {
+            summary: {
+                status    : 'completed',
+                details   : {reason: 'periodic-sweep:600000'},
+                recordedAt: '2026-05-09T12:00:00.000Z'
+            }
+        };
+
+        const block = buildTaskOutcomesBlock(source);
+
+        expect(block).toEqual(source);
+        expect(block).not.toBe(source);
+        expect(block.summary).not.toBe(source.summary);
+    });
+});
+
+/**
  * @summary Coverage for the #10127 topology observability block in the healthcheck payload.
  *
  * Mirrors the #10176 precedent above: the end-to-end integration path requires a live ChromaDB


### PR DESCRIPTION
Resolves #11009

Authored by GPT-5 (Codex Desktop). Session 20a824b0-29d1-4082-ae12-87705ec69c3f.

Moves the #11008 orchestrator implementation back into the v13-path shape: `ai/scripts/orchestrator-daemon.mjs` now owns only Node-process boot responsibilities, `ai/daemons/Orchestrator.mjs` owns scheduling / child task state / per-task failure isolation, and `ai/daemons/services/SummarizationCoordinatorService.mjs` owns the Piece C summary trigger decision. `HealthService.recordTaskOutcome(...)` now exposes per-task orchestrator outcomes under `healthcheck.orchestrator.tasks`.

Evidence: L2 (unit-tested scheduler, trigger selection, health projection, and static wrapper-ownership grep) -> L2 required (class/service ownership and per-task failure-isolation ACs). Residual: none.

## Deltas from ticket

- Kept PID file, singleton process enforcement, signal cleanup, and fatal-start isolation in `ai/scripts/orchestrator-daemon.mjs` per `learn/agentos/v13-path.md`.
- Moved task definitions, persisted child-task state, child process recovery, scheduling, and task outcome recording into `Neo.ai.daemons.Orchestrator`.
- Added `SummarizationCoordinatorService` for unread sunset-handover priority plus periodic summary sweep fallback.
- Updated `learn/agentos/v13-path.md` to record the #11008 -> #11009 correction instead of leaving the MVP split stale.

## Slot Rationale

- Modified `learn/agentos/v13-path.md` M3 MVP split: disposition `keep` unchanged; trigger-frequency medium, failure-severity high, enforceability medium. Reason: the section is the active architectural source of truth for v13 daemon placement, and the #11008 script/body drift already produced a correction cycle. Decay mitigation: retire or compress this landed-history note once M3 closes and the v13 path is superseded by release docs.

## Test Evidence

- `npm run test-unit -- test/playwright/unit/ai/scripts/orchestrator-daemon.spec.mjs test/playwright/unit/ai/daemons/Orchestrator.spec.mjs test/playwright/unit/ai/daemons/services/SummarizationCoordinatorService.spec.mjs test/playwright/unit/ai/services/memory-core/HealthService.spec.mjs` -> 49 passed.
- `git diff --cached --check` -> passed.
- `rg -n "buildTaskDefinitions|runMaintenanceCycle|summarize-sessions|syncKnowledgeBase" ai/scripts/orchestrator-daemon.mjs` -> no matches.
- Pre-push freshness check: `merge-base HEAD origin/dev == origin/dev`; outgoing log contained only `9caf1d5ae refactor(ai): move orchestrator logic into daemon class (#11009)`.

## Post-Merge Validation

- [ ] Run the orchestrator daemon on the operator host and confirm `healthcheck.orchestrator.tasks.summary` / `kbSync` update after a scheduled child task lifecycle.
- [ ] Confirm the bridge daemon remains wake-only while the orchestrator owns summary and KB-sync maintenance scheduling.

## Commit

- `9caf1d5ae` - `refactor(ai): move orchestrator logic into daemon class (#11009)`
