### PR TITLE
feat(orchestrator): implement 30-day backup rotation and daemon integration (#11018)

### DIFF
--- a/ai/daemons/Orchestrator.mjs
+++ b/ai/daemons/Orchestrator.mjs
@@ -21,6 +21,7 @@ const __dirname  = path.dirname(__filename);
 export const DEFAULT_POLL_INTERVAL_MS          = 3000;
 export const DEFAULT_SUMMARY_SWEEP_INTERVAL_MS = 600000;
 export const DEFAULT_KB_SYNC_INTERVAL_MS       = 1800000;
+export const DEFAULT_BACKUP_INTERVAL_MS        = 86400000;
 
 const DEFAULT_DB_PATH   = process.env.NEO_AI_DB_PATH || '.neo-ai-data/sqlite/memory-core-graph.sqlite';
 const DEFAULT_DATA_DIR  = process.env.NEO_AI_ORCHESTRATOR_DIR || '.neo-ai-data/orchestrator-daemon';
@@ -87,6 +88,13 @@ export function buildTaskDefinitions({scriptDir = DEFAULT_SCRIPT_DIR, nodeBin = 
             args           : [path.resolve(scriptDir, '../../buildScripts/ai/syncKnowledgeBase.mjs')],
             pidFileName    : 'kb-sync.pid',
             expectedCommand: 'syncKnowledgeBase.mjs'
+        },
+        backup: {
+            label          : 'substrate backup',
+            command        : nodeBin,
+            args           : [path.resolve(scriptDir, '../../buildScripts/ai/backup.mjs')],
+            pidFileName    : 'backup.pid',
+            expectedCommand: 'backup.mjs'
         }
     };
 }
@@ -220,6 +228,12 @@ export class Orchestrator extends Base {
          */
         kbSyncIntervalMs_: DEFAULT_KB_SYNC_INTERVAL_MS,
         /**
+         * @member {Number} backupIntervalMs_=86400000
+         * @protected
+         * @reactive
+         */
+        backupIntervalMs_: DEFAULT_BACKUP_INTERVAL_MS,
+        /**
          * @member {Object} healthService_=HealthService
          * @protected
          * @reactive
@@ -270,6 +284,7 @@ export class Orchestrator extends Base {
             DEFAULT_SUMMARY_SWEEP_INTERVAL_MS
         );
         this.kbSyncIntervalMs       = options.kbSyncIntervalMs ?? parseInterval(process.env.NEO_ORCHESTRATOR_KB_SYNC_INTERVAL_MS, DEFAULT_KB_SYNC_INTERVAL_MS);
+        this.backupIntervalMs       = options.backupIntervalMs ?? parseInterval(process.env.NEO_ORCHESTRATOR_BACKUP_INTERVAL_MS, DEFAULT_BACKUP_INTERVAL_MS);
         this.taskDefinitions        = options.taskDefinitions || buildTaskDefinitions({
             scriptDir,
             nodeBin: options.nodeBin || process.argv[0]
@@ -300,7 +315,7 @@ export class Orchestrator extends Base {
         this.db = this.initializeDatabaseFn(this.dbPath);
 
         this.isPolling = true;
-        this.writeLog('INFO', `[Orchestrator] Started. summaryInterval=${this.summarySweepIntervalMs}ms kbSyncInterval=${this.kbSyncIntervalMs}ms poll=${this.pollIntervalMs}ms.`);
+        this.writeLog('INFO', `[Orchestrator] Started. summaryInterval=${this.summarySweepIntervalMs}ms kbSyncInterval=${this.kbSyncIntervalMs}ms backupInterval=${this.backupIntervalMs}ms poll=${this.pollIntervalMs}ms.`);
         this.poll();
     }
 
@@ -656,6 +671,21 @@ export class Orchestrator extends Base {
     }
 
     /**
+     * Schedules a backup child task when its interval is due.
+     * @param {Number} now Current timestamp in milliseconds.
+     * @returns {void}
+     */
+    runBackupCycle(now) {
+        if (shouldRunIntervalTask({
+            now,
+            lastRunAt : this.taskState.backup.lastRunAt,
+            intervalMs: this.backupIntervalMs
+        })) {
+            this.runTask('backup', `periodic-backup:${this.backupIntervalMs}`);
+        }
+    }
+
+    /**
      * Runs one maintenance sweep with task-level failure isolation.
      * @param {Number} [now=Date.now()] Current timestamp in milliseconds.
      * @returns {void}
@@ -663,6 +693,7 @@ export class Orchestrator extends Base {
     runMaintenanceCycle(now = Date.now()) {
         this.runTaskCycle('summary', () => this.runSummaryCycle(now));
         this.runTaskCycle('kbSync',  () => this.runKbSyncCycle(now));
+        this.runTaskCycle('backup',  () => this.runBackupCycle(now));
     }
 
     /**

--- a/ai/scripts/orchestrator-daemon.mjs
+++ b/ai/scripts/orchestrator-daemon.mjs
@@ -18,6 +18,7 @@ import Orchestrator, {
     DEFAULT_KB_SYNC_INTERVAL_MS,
     DEFAULT_POLL_INTERVAL_MS,
     DEFAULT_SUMMARY_SWEEP_INTERVAL_MS,
+    DEFAULT_BACKUP_INTERVAL_MS,
     parseInterval
 } from '../daemons/Orchestrator.mjs';
 
@@ -143,5 +144,6 @@ export {
     DEFAULT_KB_SYNC_INTERVAL_MS,
     DEFAULT_POLL_INTERVAL_MS,
     DEFAULT_SUMMARY_SWEEP_INTERVAL_MS,
+    DEFAULT_BACKUP_INTERVAL_MS,
     parseInterval
 };

--- a/buildScripts/ai/backup.mjs
+++ b/buildScripts/ai/backup.mjs
@@ -40,17 +40,13 @@ const execFileAsync = promisify(execFile);
  * All service calls route through `ai/services.mjs`, which applies Zod validation at the
  * SDK boundary via `makeSafe()` — no direct `ai/mcp/server/...` imports.
  *
- * ## Retention Policy (TODO)
+ * ## Retention Policy
  *
  * Semantics to mirror `defragChromaDB.cleanOldBackups` but applied to the unified bundle tree:
  * - Keep the newest `K` bundles unconditionally (default `K = 3`)
- * - Delete additional bundles older than `N` days (default `N = 7`)
+ * - Delete additional bundles older than `N` days (default `N = 30`)
  * - Sweep runs at the directory level on `.neo-ai-data/backups/` — one timestamp = one decision
  *   (no more correlating JSONL filenames across roots)
- *
- * **Not implemented in this commit** — the substrate is now in place, but the sweep itself
- * is a follow-up once operator habits around `npm run ai:backup` have stabilized and we
- * know the realistic cadence. Until then: manual pruning is fine, bundles are cheap to keep.
  *
  * ## Legacy Backup Migration
  *
@@ -326,7 +322,7 @@ async function buildVersionDescriptor(projectRoot, logger) {
 /**
  * Applies retention policy to the backup root.
  * Keeps the newest K=3 bundles unconditionally.
- * Deletes older bundles if they are older than N=7 days.
+ * Deletes older bundles if they are older than N=30 days.
  * @param {String} backupRoot
  * @param {Object} logger
  */
@@ -359,7 +355,7 @@ async function cleanOldBackups(backupRoot, logger) {
     backups.sort((a, b) => b.time - a.time);
 
     const K = 3;
-    const N_DAYS = 7;
+    const N_DAYS = 30;
     const now = Date.now();
     const thresholdMs = N_DAYS * 24 * 60 * 60 * 1000;
 

--- a/test/playwright/unit/ai/daemons/Orchestrator.spec.mjs
+++ b/test/playwright/unit/ai/daemons/Orchestrator.spec.mjs
@@ -39,7 +39,7 @@ test.describe('Neo.ai.daemons.Orchestrator (#11009)', () => {
             nodeBin  : '/node'
         }));
 
-        expect(Object.keys(state)).toEqual(['summary', 'kbSync']);
+        expect(Object.keys(state)).toEqual(['summary', 'kbSync', 'backup']);
         expect(state.summary).toMatchObject({
             running      : false,
             pid          : null,


### PR DESCRIPTION
Resolves #11018

Authored by @neo-gemini-3-1-pro (Gemini 3.1 Pro). Session d5ed6767-0292-46bf-9346-439f268048ec.

Integrated the daily `backup` task into the Orchestrator daemon, incorporating a 30-day retention rotation policy within `backup.mjs`.

Evidence: L1 (static structure audit) → L1 required. No residuals.

## Deltas from ticket
- Hardcoded K=3 (count) and N=30 (days) within `backup.mjs` as part of the retention sweep logic.
- Exposed `backupIntervalMs` (default: 24h) to orchestrator config, allowing environment override via `NEO_ORCHESTRATOR_BACKUP_INTERVAL_MS`.

## Test Evidence
`npm run test-unit` passed, including the updated Orchestrator state envelope specs that now verify the presence of the `backup` task definition.