### PR TITLE
feat(pull-request): enforce assignee check in Pre-Flight (#11032)

### DIFF
--- a/.agents/skills/pull-request/references/pull-request-workflow.md
+++ b/.agents/skills/pull-request/references/pull-request-workflow.md
@@ -32,11 +32,7 @@ Your PR body's slot-rationale section MUST enumerate:
 
 ### 1.2 The Ticket Assignment Pre-Flight Gate
 
-Before executing `git commit` or opening a PR, you MUST verify that you are the formal assignee for the PR's close-target leaf ticket(s) (the `#N` in your commit subject and `Resolves #N` line).
-
-1. **Verify Assignment:** Check the `assignees` field of the target ticket(s) via the local issue markdown or GitHub MCP. Do not require assignment on parent epics that are only referenced.
-2. **Assign if Missing:** If the ticket has no assignee, you MUST call `manage_issue_assignees({action: 'add', issue_number: N, assignees: ['@me']})` BEFORE executing `git commit` or opening the PR.
-3. **Collision Guard:** If the ticket is already assigned to another agent or human, DO NOT silently co-claim it. You must halt and route back through the existing `ticket-intake` ownership / handoff / 7-day reassignment rules.
+Before `git commit` or opening a PR, you MUST verify you are the formal assignee for the target ticket. If unassigned, claim it (`manage_issue_assignees({action: 'add', issue_number: N, assignees: ['@me']})`). If assigned to someone else, halt and respect ownership.
 
 ## 2. Git Branching Mandate
 

--- a/.agents/skills/pull-request/references/pull-request-workflow.md
+++ b/.agents/skills/pull-request/references/pull-request-workflow.md
@@ -30,6 +30,14 @@ Your PR body's slot-rationale section MUST enumerate:
 
 **Env-var changes** → read [`env-var-rename-rule.md`](./env-var-rename-rule.md).
 
+### 1.2 The Ticket Assignment Pre-Flight Gate
+
+Before executing `git commit` or opening a PR, you MUST verify that you are the formal assignee for the PR's close-target leaf ticket(s) (the `#N` in your commit subject and `Resolves #N` line).
+
+1. **Verify Assignment:** Check the `assignees` field of the target ticket(s) via the local issue markdown or GitHub MCP. Do not require assignment on parent epics that are only referenced.
+2. **Assign if Missing:** If the ticket has no assignee, you MUST call `manage_issue_assignees({action: 'add', issue_number: N, assignees: ['@me']})` BEFORE executing `git commit` or opening the PR.
+3. **Collision Guard:** If the ticket is already assigned to another agent or human, DO NOT silently co-claim it. You must halt and route back through the existing `ticket-intake` ownership / handoff / 7-day reassignment rules.
+
 ## 2. Git Branching Mandate
 
 You are strictly forbidden from committing or pushing directly to `main` (release-only) or `dev` (default working). The *mechanism* for satisfying this rule differs by harness class.


### PR DESCRIPTION
Authored by Neo Gemini 3.1 Pro (Gemini). Session d5ed6767-0292-46bf-9346-439f268048ec.

Resolves #11032

Added a mandatory Pre-Flight gate check in the `pull-request-workflow.md` that ensures agents verify and assert assignment for the PR's close-target leaf tickets before committing.

## Substrate-Mutation Slot Rationale

- **Added Section:** `1.2 The Ticket Assignment Pre-Flight Gate`
  - **Disposition:** `keep`
  - **Rationale:** 
    - Trigger-frequency: High (evaluates before every PR creation).
    - Failure-severity: High (unassigned ticket closures disrupt tracking and MX signals).
    - Enforceability: High (mechanical workflow gate).

## Test Evidence
N/A - Documentation only

## Post-Merge Validation
- [ ] Agents reliably assigning themselves to tickets prior to execution.
