### PR TITLE
refactor(orchestrator): extract TaskStateService from Orchestrator

### DIFF
--- a/ai/daemons/Orchestrator.mjs
+++ b/ai/daemons/Orchestrator.mjs
@@ -14,6 +14,7 @@ import {
     initializeDatabase
 } from '../scripts/bridge-daemon-queries.mjs';
 import SummarizationCoordinatorService from './services/SummarizationCoordinatorService.mjs';
+import TaskStateService                from './services/TaskStateService.mjs';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname  = path.dirname(__filename);
@@ -92,27 +93,6 @@ export function buildTaskDefinitions({scriptDir = DEFAULT_SCRIPT_DIR, nodeBin = 
 }
 
 /**
- * @summary Creates the persisted state envelope for orchestrator task tracking.
- *
- * @param {Object} taskDefinitions Task-definition map.
- * @returns {Object}
- */
-export function createInitialTaskState(taskDefinitions) {
-    return Object.keys(taskDefinitions).reduce((state, taskName) => {
-        state[taskName] = {
-            running      : false,
-            pid          : null,
-            lastRunAt    : 0,
-            lastSuccessAt: null,
-            lastErrorAt  : null,
-            lastExitCode : null,
-            lastReason   : null
-        };
-        return state;
-    }, {});
-}
-
-/**
  * @summary Neo daemon class for Agent OS maintenance scheduling (#11009).
  *
  * `ai/scripts/orchestrator-daemon.mjs` owns the Node-process boot wrapper:
@@ -166,11 +146,11 @@ export class Orchestrator extends Base {
          */
         db_: null,
         /**
-         * @member {Object|null} taskState_=null
+         * @member {Object} taskStateService_=TaskStateService
          * @protected
          * @reactive
          */
-        taskState_: null,
+        taskStateService_: TaskStateService,
         /**
          * @member {Object|null} taskDefinitions_=null
          * @protected
@@ -295,7 +275,11 @@ export class Orchestrator extends Base {
         this.configure(options);
 
         fs.ensureDirSync(this.dataDir);
-        this.taskState = this.readState();
+        this.taskStateService.configure({
+            stateFile      : this.stateFile,
+            taskDefinitions: this.taskDefinitions,
+            writeLogFn     : this.writeLog.bind(this)
+        });
         this.recoverTasks();
         this.db = this.initializeDatabaseFn(this.dbPath);
 
@@ -340,42 +324,7 @@ export class Orchestrator extends Base {
         }
     }
 
-    /**
-     * Reads persisted task state, clearing stale in-process fields on boot.
-     * @returns {Object}
-     */
-    readState() {
-        const fallback = createInitialTaskState(this.taskDefinitions);
 
-        if (!fs.existsSync(this.stateFile)) {
-            return fallback;
-        }
-
-        try {
-            const data = JSON.parse(fs.readFileSync(this.stateFile, 'utf8'));
-            return Object.keys(fallback).reduce((state, taskName) => {
-                state[taskName] = {...fallback[taskName], ...(data[taskName] || {})};
-                state[taskName].running = false;
-                state[taskName].pid     = null;
-                return state;
-            }, {});
-        } catch (e) {
-            this.writeLog('ERROR', `[Orchestrator] Failed to read state file: ${e.message}`);
-            return fallback;
-        }
-    }
-
-    /**
-     * Persists the current task-state envelope.
-     * @returns {void}
-     */
-    writeState() {
-        try {
-            fs.writeFileSync(this.stateFile, JSON.stringify(this.taskState, null, 2), 'utf8');
-        } catch (e) {
-            this.writeLog('ERROR', `[Orchestrator] Failed to write state file: ${e.message}`);
-        }
-    }
 
     /**
      * Resolves the PID file path for a child task.
@@ -403,16 +352,11 @@ export class Orchestrator extends Base {
      */
     clearRecoveredTask(taskName, pid) {
         const task    = this.taskDefinitions[taskName];
-        const state   = this.taskState[taskName];
         const pidFile = this.getTaskPidFile(taskName);
 
-        if (state.pid !== pid) {
+        if (!this.taskStateService.clearRecovered(taskName, pid)) {
             return;
         }
-
-        state.running      = false;
-        state.pid          = null;
-        state.lastExitCode = null;
 
         try {
             if (fs.existsSync(pidFile) && parseInt(fs.readFileSync(pidFile, 'utf8'), 10) === pid) {
@@ -421,7 +365,6 @@ export class Orchestrator extends Base {
         } catch (e) {}
 
         this.writeLog('INFO', `[Orchestrator] Recovered ${task.label} process (PID: ${pid}) exited; clearing running state.`);
-        this.writeState();
     }
 
     /**
@@ -467,8 +410,7 @@ export class Orchestrator extends Base {
             const cmd = this.processCommandFn(pid);
 
             if (cmd.includes(task.expectedCommand)) {
-                this.taskState[taskName].running = true;
-                this.taskState[taskName].pid     = pid;
+                this.taskStateService.adoptRunning(taskName, pid);
                 this.watchRecoveredTask(taskName, pid);
                 this.writeLog('INFO', `[Orchestrator] Found running ${task.label} process (PID: ${pid}). Adopting.`);
             } else {
@@ -516,7 +458,7 @@ export class Orchestrator extends Base {
      */
     runTask(taskName, reason, onSuccess) {
         const task  = this.taskDefinitions[taskName];
-        const state = this.taskState[taskName];
+        const state = this.taskStateService.getTaskState(taskName);
 
         if (state.running) {
             this.writeLog('INFO', `[Orchestrator] Skipping ${task.label}; task already running (PID: ${state.pid}).`);
@@ -524,10 +466,7 @@ export class Orchestrator extends Base {
             return false;
         }
 
-        state.running    = true;
-        state.lastRunAt  = Date.now();
-        state.lastReason = reason;
-        this.writeState();
+        this.taskStateService.markStarted(taskName, reason);
 
         this.writeLog('INFO', `[Orchestrator] Starting ${task.label} (${reason}).`);
 
@@ -535,11 +474,8 @@ export class Orchestrator extends Base {
         try {
             child = this.spawnFn(task.command, task.args, {stdio: 'ignore'});
         } catch (e) {
-            state.running    = false;
-            state.pid        = null;
-            state.lastErrorAt = new Date().toISOString();
+            this.taskStateService.markSpawnFailed(taskName);
             this.writeLog('ERROR', `[Orchestrator] ${task.label} failed to start: ${e.message}`);
-            this.writeState();
             this.recordTaskOutcome(taskName, 'failed', {reason, phase: 'spawn', error: e.message});
             return false;
         }
@@ -547,7 +483,7 @@ export class Orchestrator extends Base {
         const pidFile = this.getTaskPidFile(taskName);
 
         if (child.pid) {
-            state.pid = child.pid;
+            this.taskStateService.markSpawned(taskName, child.pid);
             try {
                 fs.writeFileSync(pidFile, child.pid.toString(), 'utf8');
             } catch (e) {
@@ -564,10 +500,6 @@ export class Orchestrator extends Base {
             }
             cleared = true;
 
-            state.running      = false;
-            state.pid          = null;
-            state.lastExitCode = code;
-
             try {
                 if (fs.existsSync(pidFile)) {
                     fs.unlinkSync(pidFile);
@@ -575,34 +507,31 @@ export class Orchestrator extends Base {
             } catch (e) {}
 
             if (error) {
-                state.lastErrorAt = new Date().toISOString();
+                this.taskStateService.markFailed(taskName, null);
                 this.writeLog('ERROR', `[Orchestrator] ${task.label} failed to start: ${error.message}`);
                 this.recordTaskOutcome(taskName, 'failed', {reason, phase: 'start', error: error.message});
             } else if (code === 0) {
                 try {
                     const completedAt = new Date().toISOString();
                     onSuccess?.();
-                    state.lastSuccessAt = completedAt;
+                    this.taskStateService.markCompleted(taskName);
                     this.writeLog('INFO', `[Orchestrator] ${task.label} completed successfully.`);
                     this.recordTaskOutcome(taskName, 'completed', {reason, code, completedAt});
                 } catch (e) {
-                    state.lastErrorAt = new Date().toISOString();
+                    this.taskStateService.markFailed(taskName, null);
                     this.writeLog('ERROR', `[Orchestrator] ${task.label} success hook failed: ${e.message}`);
                     this.recordTaskOutcome(taskName, 'failed', {reason, phase: 'success-hook', error: e.message});
                 }
             } else {
-                state.lastErrorAt = new Date().toISOString();
+                this.taskStateService.markFailed(taskName, code);
                 this.writeLog('ERROR', `[Orchestrator] ${task.label} exited with code ${code}.`);
-                this.recordTaskOutcome(taskName, 'failed', {reason, code, failedAt: state.lastErrorAt});
+                this.recordTaskOutcome(taskName, 'failed', {reason, code, failedAt: new Date().toISOString()});
             }
-
-            this.writeState();
         };
 
         child.on('close', code => clear(code));
         child.on('error', err => clear(null, err));
 
-        this.writeState();
         return true;
     }
 
@@ -629,7 +558,7 @@ export class Orchestrator extends Base {
     runSummaryCycle(now) {
         const trigger = this.summarizationCoordinator.getDueTask({
             db                    : this.db,
-            state                 : this.taskState,
+            state                 : this.taskStateService.getState(),
             now,
             summarySweepIntervalMs: this.summarySweepIntervalMs,
             log                   : this.writeLog.bind(this)
@@ -648,7 +577,7 @@ export class Orchestrator extends Base {
     runKbSyncCycle(now) {
         if (shouldRunIntervalTask({
             now,
-            lastRunAt : this.taskState.kbSync.lastRunAt,
+            lastRunAt : this.taskStateService.getTaskState('kbSync').lastRunAt,
             intervalMs: this.kbSyncIntervalMs
         })) {
             this.runTask('kbSync', `periodic-sync:${this.kbSyncIntervalMs}`);

--- a/ai/daemons/Orchestrator.mjs
+++ b/ai/daemons/Orchestrator.mjs
@@ -607,5 +607,4 @@ export class Orchestrator extends Base {
     }
 }
 
-const OrchestratorSingleton = Neo.setupClass(Orchestrator);
-export default OrchestratorSingleton;
+export default Neo.setupClass(Orchestrator);

--- a/ai/daemons/SwarmHeartbeatService.mjs
+++ b/ai/daemons/SwarmHeartbeatService.mjs
@@ -487,8 +487,7 @@ class SwarmHeartbeatService extends Base {
     }
 }
 
-const SwarmHeartbeatServiceSingleton = Neo.setupClass(SwarmHeartbeatService);
-export default SwarmHeartbeatServiceSingleton;
+export default Neo.setupClass(SwarmHeartbeatService);
 
 // Self-invoke entrypoint (#10789 AC4): `node ai/daemons/SwarmHeartbeatService.mjs` under
 // launchd / systemd directly drives the daemon. SIGTERM / SIGINT trigger a clean stop so
@@ -498,13 +497,13 @@ const isMain = process.argv[1] && fileURLToPath(import.meta.url) === path.resolv
 if (isMain) {
     const cleanShutdown = signal => {
         logger.info(`[SwarmHeartbeatService] Received ${signal}; stopping.`);
-        SwarmHeartbeatServiceSingleton.stop();
+        Neo.ai.daemons.SwarmHeartbeatService.stop();
         process.exit(0)
     };
     process.on('SIGTERM', () => cleanShutdown('SIGTERM'));
     process.on('SIGINT',  () => cleanShutdown('SIGINT'));
 
-    SwarmHeartbeatServiceSingleton.start().catch(err => {
+    Neo.ai.daemons.SwarmHeartbeatService.start().catch(err => {
         logger.error('[SwarmHeartbeatService] Daemon start failed:', err);
         process.exit(1)
     })

--- a/ai/daemons/services/TaskStateService.mjs
+++ b/ai/daemons/services/TaskStateService.mjs
@@ -1,0 +1,262 @@
+import fs   from 'fs-extra';
+import Base from '../../../src/core/Base.mjs';
+import Neo  from '../../../src/Neo.mjs';
+
+/**
+ * @summary Creates the persisted state envelope for orchestrator task tracking.
+ *
+ * @param {Object} taskDefinitions Task-definition map.
+ * @returns {Object}
+ */
+export function createInitialTaskState(taskDefinitions) {
+    return Object.keys(taskDefinitions).reduce((state, taskName) => {
+        state[taskName] = {
+            running      : false,
+            pid          : null,
+            lastRunAt    : 0,
+            lastSuccessAt: null,
+            lastErrorAt  : null,
+            lastExitCode : null,
+            lastReason   : null
+        };
+        return state;
+    }, {});
+}
+
+/**
+ * @summary Manages persistence and runtime state tracking for Daemon child processes.
+ *
+ * @class Neo.ai.daemons.services.TaskStateService
+ * @extends Neo.core.Base
+ * @singleton
+ */
+export class TaskStateService extends Base {
+    static config = {
+        /**
+         * @member {String} className='Neo.ai.daemons.services.TaskStateService'
+         * @protected
+         */
+        className: 'Neo.ai.daemons.services.TaskStateService',
+        /**
+         * @member {Boolean} singleton=true
+         * @protected
+         */
+        singleton: true,
+        /**
+         * @member {String|null} stateFile_=null
+         * @protected
+         * @reactive
+         */
+        stateFile_: null,
+        /**
+         * @member {Object|null} taskDefinitions_=null
+         * @protected
+         * @reactive
+         */
+        taskDefinitions_: null,
+        /**
+         * @member {Object|null} taskState_=null
+         * @protected
+         * @reactive
+         */
+        taskState_: null,
+        /**
+         * @member {Function|null} writeLogFn_=null
+         * @protected
+         * @reactive
+         */
+        writeLogFn_: null
+    }
+
+    /**
+     * @param {Object} config
+     * @returns {void}
+     */
+    construct(config) {
+        super.construct(config);
+    }
+
+    /**
+     * Configures the service and reads the initial state.
+     * @param {Object} options
+     * @param {String} options.stateFile
+     * @param {Object} options.taskDefinitions
+     * @param {Function} [options.writeLogFn]
+     * @returns {void}
+     */
+    configure(options) {
+        this.stateFile       = options.stateFile;
+        this.taskDefinitions = options.taskDefinitions;
+        this.writeLogFn      = options.writeLogFn || (() => {});
+        this.taskState       = this.readState();
+    }
+
+    /**
+     * Reads persisted task state, clearing stale in-process fields on boot.
+     * @returns {Object}
+     */
+    readState() {
+        const fallback = createInitialTaskState(this.taskDefinitions);
+
+        if (!fs.existsSync(this.stateFile)) {
+            return fallback;
+        }
+
+        try {
+            const data = JSON.parse(fs.readFileSync(this.stateFile, 'utf8'));
+            return Object.keys(fallback).reduce((state, taskName) => {
+                state[taskName] = {...fallback[taskName], ...(data[taskName] || {})};
+                state[taskName].running = false;
+                state[taskName].pid     = null;
+                return state;
+            }, {});
+        } catch (e) {
+            this.writeLog('ERROR', `[TaskStateService] Failed to read state file: ${e.message}`);
+            return fallback;
+        }
+    }
+
+    /**
+     * Persists the current task-state envelope.
+     * @returns {void}
+     */
+    writeState() {
+        try {
+            fs.writeFileSync(this.stateFile, JSON.stringify(this.taskState, null, 2), 'utf8');
+        } catch (e) {
+            this.writeLog('ERROR', `[TaskStateService] Failed to write state file: ${e.message}`);
+        }
+    }
+
+    /**
+     * Gets the full task state.
+     * @returns {Object}
+     */
+    getState() {
+        return this.taskState;
+    }
+
+    /**
+     * Gets the state for a specific task.
+     * @param {String} taskName
+     * @returns {Object}
+     */
+    getTaskState(taskName) {
+        return this.taskState[taskName];
+    }
+
+    /**
+     * Marks a task as running (pre-spawn) and persists the state.
+     * @param {String} taskName
+     * @param {String} reason
+     * @returns {void}
+     */
+    markStarted(taskName, reason) {
+        const state = this.taskState[taskName];
+        state.running    = true;
+        state.lastRunAt  = Date.now();
+        state.lastReason = reason;
+        this.writeState();
+    }
+
+    /**
+     * Marks a task as successfully spawned, assigning its PID and persisting the state.
+     * @param {String} taskName
+     * @param {Number|null} pid
+     * @returns {void}
+     */
+    markSpawned(taskName, pid) {
+        const state = this.taskState[taskName];
+        state.pid = pid;
+        this.writeState();
+    }
+
+    /**
+     * Marks a task as having failed to spawn (e.g., spawn threw synchronously).
+     * @param {String} taskName
+     * @returns {void}
+     */
+    markSpawnFailed(taskName) {
+        const state = this.taskState[taskName];
+        state.running      = false;
+        state.pid          = null;
+        state.lastErrorAt  = new Date().toISOString();
+        this.writeState();
+    }
+
+    /**
+     * Marks a task as successfully completed.
+     * @param {String} taskName
+     * @returns {void}
+     */
+    markCompleted(taskName) {
+        const state = this.taskState[taskName];
+        state.running       = false;
+        state.pid           = null;
+        state.lastExitCode  = 0;
+        state.lastSuccessAt = new Date().toISOString();
+        this.writeState();
+    }
+
+    /**
+     * Marks a task as failed.
+     * @param {String} taskName
+     * @param {Number|null} code
+     * @returns {void}
+     */
+    markFailed(taskName, code) {
+        const state = this.taskState[taskName];
+        state.running      = false;
+        state.pid          = null;
+        state.lastExitCode = code;
+        state.lastErrorAt  = new Date().toISOString();
+        this.writeState();
+    }
+
+    /**
+     * Adopts a previously running process.
+     * @param {String} taskName
+     * @param {Number} pid
+     * @returns {void}
+     */
+    adoptRunning(taskName, pid) {
+        const state = this.taskState[taskName];
+        state.running = true;
+        state.pid     = pid;
+        // Don't call writeState here; recoverTasks in Orchestrator didn't write it immediately.
+    }
+
+    /**
+     * Clears running state for a recovered task when it exits.
+     * @param {String} taskName
+     * @param {Number} pid
+     * @returns {Boolean} True if the state was cleared.
+     */
+    clearRecovered(taskName, pid) {
+        const state = this.taskState[taskName];
+        if (state.pid !== pid) {
+            return false;
+        }
+
+        state.running      = false;
+        state.pid          = null;
+        state.lastExitCode = null;
+        this.writeState();
+        return true;
+    }
+
+    /**
+     * Helper to call the injected log function.
+     * @param {String} level
+     * @param {String} message
+     * @returns {void}
+     */
+    writeLog(level, message) {
+        if (this.writeLogFn) {
+            this.writeLogFn(level, message);
+        }
+    }
+}
+
+const TaskStateServiceSingleton = Neo.setupClass(TaskStateService);
+export default TaskStateServiceSingleton;

--- a/ai/daemons/services/TaskStateService.mjs
+++ b/ai/daemons/services/TaskStateService.mjs
@@ -258,5 +258,4 @@ export class TaskStateService extends Base {
     }
 }
 
-const TaskStateServiceSingleton = Neo.setupClass(TaskStateService);
-export default TaskStateServiceSingleton;
+export default Neo.setupClass(TaskStateService);

--- a/test/playwright/unit/ai/daemons/Orchestrator.spec.mjs
+++ b/test/playwright/unit/ai/daemons/Orchestrator.spec.mjs
@@ -3,9 +3,9 @@ import Neo from '../../../../../src/Neo.mjs';
 import * as core from '../../../../../src/core/_export.mjs';
 import {
     Orchestrator,
-    buildTaskDefinitions,
-    createInitialTaskState
+    buildTaskDefinitions
 } from '../../../../../ai/daemons/Orchestrator.mjs';
+import TaskStateService, { createInitialTaskState } from '../../../../../ai/daemons/services/TaskStateService.mjs';
 
 function createTestOrchestrator(config = {}) {
     const taskDefinitions = config.taskDefinitions || buildTaskDefinitions({
@@ -13,12 +13,19 @@ function createTestOrchestrator(config = {}) {
         nodeBin  : '/node'
     });
 
+    TaskStateService.configure({
+        stateFile      : '/tmp/orchestrator-test/state.json',
+        taskDefinitions: taskDefinitions,
+        writeLogFn     : () => {}
+    });
+    TaskStateService.taskState = createInitialTaskState(taskDefinitions);
+
     const orchestrator = Neo.create(Orchestrator, {
         dataDir                 : '/tmp/orchestrator-test',
         stateFile               : '/tmp/orchestrator-test/state.json',
         logFile                 : null,
         taskDefinitions,
-        taskState               : createInitialTaskState(taskDefinitions),
+        taskStateService_       : TaskStateService,
         summarySweepIntervalMs  : config.summarySweepIntervalMs ?? 600000,
         kbSyncIntervalMs        : config.kbSyncIntervalMs ?? 600000,
         healthService           : config.healthService || {recordTaskOutcome() {}},
@@ -27,7 +34,7 @@ function createTestOrchestrator(config = {}) {
     });
 
     orchestrator.writeLog  = () => {};
-    orchestrator.writeState = () => {};
+    // orchestrator.writeState = () => {};
 
     return orchestrator;
 }
@@ -135,8 +142,10 @@ test.describe('Neo.ai.daemons.Orchestrator (#11009)', () => {
                 error : 'mark read failed'
             }
         });
-        expect(orchestrator.taskState.summary.running).toBe(false);
-        expect(orchestrator.taskState.summary.lastErrorAt).toEqual(expect.any(String));
-        expect(orchestrator.taskState.summary.lastSuccessAt).toBeNull();
+        
+        const state = orchestrator.taskStateService.getTaskState('summary');
+        expect(state.running).toBe(false);
+        expect(state.lastErrorAt).toEqual(expect.any(String));
+        expect(state.lastSuccessAt).toBeNull();
     });
 });

--- a/test/playwright/unit/ai/daemons/services/TaskStateService.spec.mjs
+++ b/test/playwright/unit/ai/daemons/services/TaskStateService.spec.mjs
@@ -1,0 +1,126 @@
+import {test, expect} from '@playwright/test';
+import fs from 'fs-extra';
+import path from 'path';
+import Neo from '../../../../../../src/Neo.mjs';
+import * as core from '../../../../../../src/core/_export.mjs';
+import { TaskStateService, createInitialTaskState } from '../../../../../../ai/daemons/services/TaskStateService.mjs';
+
+function createTestService() {
+    const dataDir = `/tmp/task-state-service-test-${Date.now()}-${Math.random()}`;
+    fs.ensureDirSync(dataDir);
+    
+    const stateFile = path.join(dataDir, 'state.json');
+    const taskDefinitions = {
+        mockTask: {
+            name: 'mockTask',
+            scriptPath: '/mock/script.mjs'
+        }
+    };
+
+    const service = Neo.create(TaskStateService, {
+        stateFile,
+        taskDefinitions,
+        writeLogFn: () => {}
+    });
+    
+    service.configure({
+        stateFile,
+        taskDefinitions,
+        writeLogFn: () => {}
+    });
+
+    return { service, stateFile };
+}
+
+test.describe('Neo.ai.daemons.services.TaskStateService', () => {
+    test('initializes with default state when no file exists', () => {
+        const { service } = createTestService();
+        const state = service.getTaskState('mockTask');
+        
+        expect(state).toMatchObject({
+            running      : false,
+            pid          : null,
+            lastRunAt    : 0,
+            lastSuccessAt: null,
+            lastErrorAt  : null,
+            lastExitCode : null,
+            lastReason   : null
+        });
+    });
+
+    test('state transitions trigger file writes correctly', () => {
+        const { service, stateFile } = createTestService();
+        
+        // Test markStarted
+        service.markStarted('mockTask', 'test-run');
+        let stateData = JSON.parse(fs.readFileSync(stateFile, 'utf8'));
+        expect(stateData.mockTask.running).toBe(true);
+        expect(stateData.mockTask.lastReason).toBe('test-run');
+        
+        // Test markSpawned
+        service.markSpawned('mockTask', 1234);
+        stateData = JSON.parse(fs.readFileSync(stateFile, 'utf8'));
+        expect(stateData.mockTask.pid).toBe(1234);
+        expect(service.getTaskState('mockTask').pid).toBe(1234);
+
+        // Test markCompleted
+        service.markCompleted('mockTask');
+        stateData = JSON.parse(fs.readFileSync(stateFile, 'utf8'));
+        expect(stateData.mockTask.running).toBe(false);
+        expect(stateData.mockTask.pid).toBe(null);
+        expect(stateData.mockTask.lastExitCode).toBe(0);
+        expect(stateData.mockTask.lastSuccessAt).toEqual(expect.any(String));
+
+        // Test markStarted again
+        service.markStarted('mockTask', 'retry');
+        
+        // Test markFailed
+        service.markFailed('mockTask', 1);
+        stateData = JSON.parse(fs.readFileSync(stateFile, 'utf8'));
+        expect(stateData.mockTask.running).toBe(false);
+        expect(stateData.mockTask.pid).toBe(null);
+        expect(stateData.mockTask.lastExitCode).toBe(1);
+        expect(stateData.mockTask.lastErrorAt).toEqual(expect.any(String));
+        
+        // Test markSpawnFailed
+        service.markStarted('mockTask', 'fail-spawn');
+        service.markSpawnFailed('mockTask');
+        stateData = JSON.parse(fs.readFileSync(stateFile, 'utf8'));
+        expect(stateData.mockTask.running).toBe(false);
+        expect(stateData.mockTask.pid).toBe(null);
+        expect(stateData.mockTask.lastErrorAt).toEqual(expect.any(String));
+    });
+
+    test('adoptRunning sets state without immediately writing to disk', () => {
+        const { service, stateFile } = createTestService();
+        
+        service.adoptRunning('mockTask', 5678);
+        const state = service.getTaskState('mockTask');
+        
+        expect(state.running).toBe(true);
+        expect(state.pid).toBe(5678);
+        
+        // state file should not be updated yet
+        expect(fs.existsSync(stateFile)).toBe(false);
+    });
+
+    test('clearRecovered correctly clears and writes state if PID matches', () => {
+        const { service, stateFile } = createTestService();
+        
+        service.adoptRunning('mockTask', 5678);
+        
+        // Trying to clear with wrong PID should return false and not change running state
+        expect(service.clearRecovered('mockTask', 9999)).toBe(false);
+        expect(service.getTaskState('mockTask').running).toBe(true);
+        
+        // Correct PID should clear state and write to disk
+        expect(service.clearRecovered('mockTask', 5678)).toBe(true);
+        const state = service.getTaskState('mockTask');
+        expect(state.running).toBe(false);
+        expect(state.pid).toBe(null);
+        expect(state.lastExitCode).toBe(null);
+        
+        const stateData = JSON.parse(fs.readFileSync(stateFile, 'utf8'));
+        expect(stateData.mockTask.running).toBe(false);
+    });
+});


### PR DESCRIPTION
Resolves #11039

**Description**
Extracts the task-state persistence and tracking logic out of the `Orchestrator` class into a new `TaskStateService`. 
This is a foundational sub-task for Epic #11022, providing a hardened, granular state mutation API to decouple state management from execution context before the `ProcessSupervisorService` extraction.

**Evidence Checklist**
- [x] Extracted `TaskStateService.mjs` with a hardened `markStarted`, `markSpawned`, `markCompleted`, `markFailed` API.
- [x] Injected `TaskStateService` into `Orchestrator.mjs`.
- [x] Unit tests updated and passing.