### PR TITLE
fix(memory-core): add per-recipient broadcast receipts (#11029)

### DIFF
--- a/ai/daemons/SwarmHeartbeatService.mjs
+++ b/ai/daemons/SwarmHeartbeatService.mjs
@@ -343,8 +343,9 @@ class SwarmHeartbeatService extends Base {
     }
 
     /**
-     * SQLite query: count of unread MESSAGE-label nodes addressed to the polled identity
-     * or AGENT:* broadcast. Mirrors `swarm-heartbeat.sh#get_unread_count` 1:1.
+     * SQLite query: count of unread MESSAGE-label nodes addressed to the polled identity.
+     * Direct DMs use MESSAGE.properties.readAt; #11029 broadcasts use per-recipient
+     * DELIVERED_TO.readAt edges, with a legacy fallback for old broadcasts lacking receipts.
      * @returns {Promise<Number>}
      * @protected
      */
@@ -352,14 +353,43 @@ class SwarmHeartbeatService extends Base {
         try {
             const db = GraphService.db.storage.db;
             const stmt = db.prepare(`
-                SELECT count(DISTINCT n.id) as count
-                FROM Nodes n
-                JOIN Edges e ON n.id = e.source AND e.type = 'SENT_TO'
-                WHERE json_extract(n.data, '$.label') = 'MESSAGE'
-                  AND json_extract(n.data, '$.properties.readAt') IS NULL
-                  AND e.target IN (?, 'AGENT:*')
+                WITH unread_messages AS (
+                    SELECT n.id AS messageId
+                    FROM Edges e
+                    JOIN Nodes n ON n.id = e.source
+                    WHERE e.type = 'SENT_TO'
+                      AND e.target = ?
+                      AND json_extract(n.data, '$.label') = 'MESSAGE'
+                      AND json_extract(n.data, '$.properties.readAt') IS NULL
+
+                    UNION
+
+                    SELECT n.id AS messageId
+                    FROM Edges e
+                    JOIN Nodes n ON n.id = e.source
+                    WHERE e.type = 'DELIVERED_TO'
+                      AND e.target = ?
+                      AND json_extract(n.data, '$.label') = 'MESSAGE'
+                      AND json_extract(e.data, '$.properties.readAt') IS NULL
+
+                    UNION
+
+                    SELECT n.id AS messageId
+                    FROM Edges e
+                    JOIN Nodes n ON n.id = e.source
+                    WHERE e.type = 'SENT_TO'
+                      AND e.target = 'AGENT:*'
+                      AND json_extract(n.data, '$.label') = 'MESSAGE'
+                      AND json_extract(n.data, '$.properties.readAt') IS NULL
+                      AND NOT EXISTS (
+                          SELECT 1 FROM Edges de
+                          WHERE de.source = n.id AND de.type = 'DELIVERED_TO'
+                      )
+                )
+                SELECT count(DISTINCT messageId) as count
+                FROM unread_messages
             `);
-            const row = stmt.get(this.identity);
+            const row = stmt.get(this.identity, this.identity);
             return row?.count || 0
         } catch (err) {
             logger.error('[SwarmHeartbeatService] getUnreadCount failed:', err);

--- a/ai/graph/identityRoots.mjs
+++ b/ai/graph/identityRoots.mjs
@@ -97,7 +97,7 @@ export const IDENTITIES = [
         id: 'AGENT:*',
         type: 'BroadcastSentinel',
         name: 'Broadcast',
-        description: 'Mailbox broadcast sentinel. `SENT_TO` edges targeting this node fan out to all authenticated recipients per MailboxService.listMessages visibility rules. Must exist as a real graph node so GraphService.linkNodes FK-style guard does not cull broadcast edges — see #10174.',
+        description: 'Mailbox broadcast sentinel. `SENT_TO` edges targeting this node preserve one semantic broadcast MESSAGE; current sends snapshot per-recipient unread state through `DELIVERED_TO` edges, with legacy SENT_TO-only visibility retained for old broadcasts. Must exist as a real graph node so GraphService.linkNodes FK-style guard does not cull broadcast edges — see #10174 and #11029.',
         properties: {
             githubLogin: null,
             displayName: 'Broadcast',

--- a/ai/services/memory-core/MailboxService.mjs
+++ b/ai/services/memory-core/MailboxService.mjs
@@ -33,6 +33,98 @@ function normalizeMailboxTarget(to, sentBy) {
     return to;
 }
 
+function getRecordField(record, field) {
+    return record?.isRecord ? record.get(field) : record?.[field];
+}
+
+function getRecordProperties(record) {
+    return getRecordField(record, 'properties') || {};
+}
+
+function setRecordProperties(record, properties) {
+    if (record?.isRecord) {
+        record.set('properties', properties);
+    } else if (record) {
+        record.properties = properties;
+    }
+}
+
+/**
+ * @summary Returns the current broadcast delivery audience for a MESSAGE sent to `AGENT:*`.
+ *
+ * Per #11029, broadcasts remain one semantic MESSAGE + SENT_TO->AGENT:* edge, while unread
+ * state moves to per-recipient DELIVERY edges. The audience is a send-time snapshot of
+ * registered peer agents, excluding the sender and sentinel/human identities.
+ *
+ * @param {String} sentBy The canonical sender identity.
+ * @returns {String[]} Sorted recipient identity node IDs.
+ * @private
+ */
+function getBroadcastAudience(sentBy) {
+    const nodes = GraphService.db?.nodes?.items || [];
+
+    return nodes
+        .map(node => {
+            const id         = getRecordField(node, 'id'),
+                label        = getRecordField(node, 'label'),
+                properties   = getRecordProperties(node),
+                accountType  = properties.accountType;
+
+            if (!id || id === sentBy || id === 'AGENT:*' || !id.startsWith('@')) {
+                return null;
+            }
+
+            if (accountType === 'human' || accountType === 'sentinel') {
+                return null;
+            }
+
+            if (label === 'AgentIdentity') {
+                return accountType === 'agent' ? id : null;
+            }
+
+            return label === 'AGENT' ? id : null;
+        })
+        .filter(Boolean)
+        .sort();
+}
+
+function getBroadcastDeliveryEdges(messageId) {
+    return (GraphService.db?.edges?.items || []).filter(edge =>
+        getRecordField(edge, 'source') === messageId &&
+        getRecordField(edge, 'type') === 'DELIVERED_TO'
+    );
+}
+
+function getBroadcastDeliveryEdge(messageId, target) {
+    return getBroadcastDeliveryEdges(messageId).find(edge => getRecordField(edge, 'target') === target) || null;
+}
+
+function hasBroadcastDeliveryEdges(messageId) {
+    return getBroadcastDeliveryEdges(messageId).length > 0;
+}
+
+function getReadAtForMessage(messageNode, deliveryEdge=null) {
+    if (deliveryEdge) {
+        return getRecordProperties(deliveryEdge).readAt || null;
+    }
+
+    return messageNode?.properties?.readAt || null;
+}
+
+async function setDeliveryEdgeReadAt(edge, readAt) {
+    setRecordProperties(edge, {
+        ...getRecordProperties(edge),
+        readAt
+    });
+
+    const db = GraphService.db;
+
+    if (db?.autoSave && db.storage) {
+        await db.storage.addEdges([edge]);
+        db.acknowledgeLocalMutations?.();
+    }
+}
+
 /**
  * @summary A2A (Agent-to-Agent) Messaging Service mapped to the Native Edge Graph.
  *
@@ -237,6 +329,17 @@ class MailboxService extends Base {
         // 2. Map the routing edges
         GraphService.linkNodes(messageId, sentBy, 'SENT_BY', 1.0, { timestamp, userId: sentBy, sharedEntity: true });
         GraphService.linkNodes(messageId, to, 'SENT_TO', 1.0, { timestamp, userId: sentBy, sharedEntity: true });
+        if (to === 'AGENT:*') {
+            for (const recipient of getBroadcastAudience(sentBy)) {
+                GraphService.linkNodes(messageId, recipient, 'DELIVERED_TO', 1.0, {
+                    deliveredAt: timestamp,
+                    readAt: null,
+                    deliveryKind: 'broadcast',
+                    userId: sentBy,
+                    sharedEntity: true
+                });
+            }
+        }
 
         // Phase 1 #10347 Observability: Make SENT_TO failure loud and cross-process readable
         try {
@@ -353,17 +456,38 @@ class MailboxService extends Base {
         let messages = [];
 
         for (const edge of db.edges.items) {
-            let isMatch = false;
-            let targetNode = null;
-            let senderNode = null;
+            const edgeType = getRecordField(edge, 'type'),
+                edgeSource = getRecordField(edge, 'source'),
+                edgeTarget = getRecordField(edge, 'target');
 
-            if (edge.type === 'SENT_TO') {
-                targetNode = edge.target;
-                if ((box === 'inbox' || box === 'all') && (targetNode === target || targetNode === 'AGENT:*')) {
+            let isMatch = false,
+                targetNode = null,
+                senderNode = null,
+                deliveryEdge = null;
+
+            if (edgeType === 'DELIVERED_TO') {
+                targetNode = edgeTarget;
+                if ((box === 'inbox' || box === 'all') && targetNode === target) {
                     isMatch = true;
+                    deliveryEdge = edge;
                 }
-            } else if (edge.type === 'SENT_BY') {
-                senderNode = edge.target;
+            } else if (edgeType === 'SENT_TO') {
+                targetNode = edgeTarget;
+                if (box === 'inbox' || box === 'all') {
+                    if (targetNode === target) {
+                        isMatch = true;
+                    } else if (targetNode === 'AGENT:*') {
+                        // Load the full message vicinity before deciding whether this is a
+                        // #11029 per-recipient broadcast or a legacy shared-read broadcast.
+                        db.getAdjacentNodes(edgeSource, 'outbound');
+                        deliveryEdge = getBroadcastDeliveryEdge(edgeSource, target);
+                        if (deliveryEdge || !hasBroadcastDeliveryEdges(edgeSource)) {
+                            isMatch = true;
+                        }
+                    }
+                }
+            } else if (edgeType === 'SENT_BY') {
+                senderNode = edgeTarget;
                 if ((box === 'outbox' || box === 'all') && senderNode === target) {
                     isMatch = true;
                 }
@@ -371,7 +495,7 @@ class MailboxService extends Base {
 
             if (isMatch) {
                 // Determine message node id depending on which edge we matched
-                const messageNodeId = edge.source;
+                const messageNodeId = edgeSource;
                 // Avoid duplicates if 'all' is chosen
                 if (messages.find(m => m.messageId === messageNodeId)) continue;
 
@@ -384,7 +508,10 @@ class MailboxService extends Base {
 
                 const messageNode = db.nodes.get(messageNodeId);
                 if (messageNode && messageNode.label === 'MESSAGE') {
-                    const isUnread = !messageNode.properties.readAt;
+                    deliveryEdge = deliveryEdge || getBroadcastDeliveryEdge(messageNodeId, target);
+
+                    const readAt = getReadAtForMessage(messageNode, deliveryEdge);
+                    const isUnread = !readAt;
                     if (status === 'unread' && !isUnread) continue;
                     if (status === 'read' && isUnread) continue;
 
@@ -394,11 +521,13 @@ class MailboxService extends Base {
                     let messageTaggedConcepts = [];
 
                     for (const sourceEdge of db.edges.items) {
-                        if (sourceEdge.source === messageNode.id) {
-                            if (sourceEdge.type === 'SENT_BY') sentByNodeId = sourceEdge.target;
-                            if (sourceEdge.type === 'SENT_TO') sentToNodeId = sourceEdge.target;
-                            if (sourceEdge.type === 'PART_OF_THREAD') foundThreadId = sourceEdge.target;
-                            if (sourceEdge.type === 'TAGGED_CONCEPT') messageTaggedConcepts.push(sourceEdge.target);
+                        if (getRecordField(sourceEdge, 'source') === messageNode.id) {
+                            const sourceEdgeType = getRecordField(sourceEdge, 'type');
+
+                            if (sourceEdgeType === 'SENT_BY') sentByNodeId = getRecordField(sourceEdge, 'target');
+                            if (sourceEdgeType === 'SENT_TO') sentToNodeId = getRecordField(sourceEdge, 'target');
+                            if (sourceEdgeType === 'PART_OF_THREAD') foundThreadId = getRecordField(sourceEdge, 'target');
+                            if (sourceEdgeType === 'TAGGED_CONCEPT') messageTaggedConcepts.push(getRecordField(sourceEdge, 'target'));
                         }
                     }
 
@@ -421,7 +550,7 @@ class MailboxService extends Base {
                         subject: messageNode.properties.subject,
                         priority: messageNode.properties.priority,
                         sentAt: messageNode.properties.sentAt,
-                        readAt: messageNode.properties.readAt,
+                        readAt,
                         from: sentByNodeId,
                         to: sentToNodeId
                     };
@@ -465,27 +594,34 @@ class MailboxService extends Base {
             throw new Error(`Message not found: ${messageId}`);
         }
 
-        let isAuthorized = false;
-        let sentBy = null;
-        let sentTo = null;
+        let sentBy = null,
+            sentTo = null,
+            isDirectRecipient = false;
 
         for (const edge of db.edges.items) {
-            if (edge.source === messageId) {
-                if (edge.type === 'SENT_TO') {
-                    sentTo = edge.target;
-                    if (edge.target === me || edge.target === 'AGENT:*') {
-                        isAuthorized = true;
+            if (getRecordField(edge, 'source') === messageId) {
+                const edgeType = getRecordField(edge, 'type'),
+                    edgeTarget = getRecordField(edge, 'target');
+
+                if (edgeType === 'SENT_TO') {
+                    sentTo = edgeTarget;
+                    if (edgeTarget === me) {
+                        isDirectRecipient = true;
                     }
                 }
-                if (edge.type === 'SENT_BY') {
-                    sentBy = edge.target;
+                if (edgeType === 'SENT_BY') {
+                    sentBy = edgeTarget;
                 }
             }
         }
 
-        // Sender can also read
-        if (sentBy === me) {
-            isAuthorized = true;
+        const deliveryEdge = getBroadcastDeliveryEdge(messageId, me);
+        let isAuthorized = sentBy === me || isDirectRecipient;
+
+        if (!isAuthorized && sentTo === 'AGENT:*') {
+            // Legacy broadcasts without per-recipient receipts retain their historical
+            // read-path semantics. #11029 broadcasts authorize only snapshotted recipients.
+            isAuthorized = deliveryEdge || !hasBroadcastDeliveryEdges(messageId);
         } else if (!isAuthorized && sentTo && sentTo !== me && sentTo !== 'AGENT:*') {
             // Check if me has permission to read sentTo's inbox
             if (PermissionService.hasPermission(me, sentTo, 'CAN_READ_INBOX_OF')) {
@@ -502,7 +638,7 @@ class MailboxService extends Base {
             subject: messageNode.properties.subject,
             body: messageNode.properties.bodyText,
             sentAt: messageNode.properties.sentAt,
-            readAt: messageNode.properties.readAt,
+            readAt: getReadAtForMessage(messageNode, deliveryEdge),
             from: sentBy,
             to: sentTo
         };
@@ -534,15 +670,38 @@ class MailboxService extends Base {
             throw new Error(`Message not found: ${messageId}`);
         }
 
-        let isRecipient = false;
+        let isDirectRecipient = false,
+            isBroadcastRecipient = false;
+
         for (const edge of db.edges.items) {
-            if (edge.source === messageId && edge.type === 'SENT_TO' && (edge.target === me || edge.target === 'AGENT:*')) {
-                isRecipient = true;
-                break;
+            if (getRecordField(edge, 'source') === messageId && getRecordField(edge, 'type') === 'SENT_TO') {
+                const edgeTarget = getRecordField(edge, 'target');
+
+                if (edgeTarget === me) {
+                    isDirectRecipient = true;
+                    break;
+                }
+                if (edgeTarget === 'AGENT:*') {
+                    isBroadcastRecipient = true;
+                }
             }
         }
 
-        if (!isRecipient) {
+        const deliveryEdge = getBroadcastDeliveryEdge(messageId, me);
+
+        if (deliveryEdge) {
+            const readAt = new Date().toISOString();
+
+            await setDeliveryEdgeReadAt(deliveryEdge, readAt);
+
+            return { messageId, readAt, status: 'read' };
+        }
+
+        if (isBroadcastRecipient && hasBroadcastDeliveryEdges(messageId)) {
+            throw new Error(`Unauthorized: you are not the recipient of message ${messageId}`);
+        }
+
+        if (!isDirectRecipient && !isBroadcastRecipient) {
             throw new Error(`Unauthorized: you are not the recipient of message ${messageId}`);
         }
 

--- a/ai/services/memory-core/MemoryService.mjs
+++ b/ai/services/memory-core/MemoryService.mjs
@@ -40,40 +40,97 @@ function buildMailboxDelta() {
     if (!sqlite) return null;
 
     try {
-        // Unread-count: edges of type SENT_TO whose target is either the caller's bound
-        // identity OR the `AGENT:*` broadcast sentinel (seeded per #10174). readAt-null on the
-        // joined MESSAGE node filters to unread. DISTINCT e.source defends against duplicate
-        // SENT_TO edges (shouldn't happen in current schema, but cheap insurance).
+        // Unread-count: direct DMs still use MESSAGE.properties.readAt. #11029 broadcasts use
+        // per-recipient DELIVERED_TO.readAt edges; legacy broadcasts without DELIVERY edges keep
+        // the historical shared-read fallback. DISTINCT defends against duplicate edge rows.
         const unreadRow = sqlite.prepare(`
-            SELECT COUNT(DISTINCT e.source) AS unreadCount
-            FROM Edges e
-            JOIN Nodes n ON n.id = e.source
-            WHERE e.type = 'SENT_TO'
-              AND (e.target = ? OR e.target = 'AGENT:*')
-              AND json_extract(n.data, '$.properties.readAt') IS NULL
-        `).get(me);
+            WITH unread_messages AS (
+                SELECT n.id AS messageId
+                FROM Edges e
+                JOIN Nodes n ON n.id = e.source
+                WHERE e.type = 'SENT_TO'
+                  AND e.target = ?
+                  AND json_extract(n.data, '$.label') = 'MESSAGE'
+                  AND json_extract(n.data, '$.properties.readAt') IS NULL
+
+                UNION
+
+                SELECT n.id AS messageId
+                FROM Edges e
+                JOIN Nodes n ON n.id = e.source
+                WHERE e.type = 'DELIVERED_TO'
+                  AND e.target = ?
+                  AND json_extract(n.data, '$.label') = 'MESSAGE'
+                  AND json_extract(e.data, '$.properties.readAt') IS NULL
+
+                UNION
+
+                SELECT n.id AS messageId
+                FROM Edges e
+                JOIN Nodes n ON n.id = e.source
+                WHERE e.type = 'SENT_TO'
+                  AND e.target = 'AGENT:*'
+                  AND json_extract(n.data, '$.label') = 'MESSAGE'
+                  AND json_extract(n.data, '$.properties.readAt') IS NULL
+                  AND NOT EXISTS (
+                      SELECT 1 FROM Edges de
+                      WHERE de.source = n.id AND de.type = 'DELIVERED_TO'
+                  )
+            )
+            SELECT COUNT(DISTINCT messageId) AS unreadCount
+            FROM unread_messages
+        `).get(me, me);
 
         // Latest unread preview: newest sentAt wins. The correlated subquery resolves the
         // sender identity via the message's SENT_BY edge. `messageId` on the outer select is
         // the MESSAGE node id (redundant with n.id but explicit for caller ergonomics).
         const previewRow = sqlite.prepare(`
+            WITH unread_messages AS (
+                SELECT n.id AS messageId, n.data AS data
+                FROM Edges e
+                JOIN Nodes n ON n.id = e.source
+                WHERE e.type = 'SENT_TO'
+                  AND e.target = ?
+                  AND json_extract(n.data, '$.label') = 'MESSAGE'
+                  AND json_extract(n.data, '$.properties.readAt') IS NULL
+
+                UNION
+
+                SELECT n.id AS messageId, n.data AS data
+                FROM Edges e
+                JOIN Nodes n ON n.id = e.source
+                WHERE e.type = 'DELIVERED_TO'
+                  AND e.target = ?
+                  AND json_extract(n.data, '$.label') = 'MESSAGE'
+                  AND json_extract(e.data, '$.properties.readAt') IS NULL
+
+                UNION
+
+                SELECT n.id AS messageId, n.data AS data
+                FROM Edges e
+                JOIN Nodes n ON n.id = e.source
+                WHERE e.type = 'SENT_TO'
+                  AND e.target = 'AGENT:*'
+                  AND json_extract(n.data, '$.label') = 'MESSAGE'
+                  AND json_extract(n.data, '$.properties.readAt') IS NULL
+                  AND NOT EXISTS (
+                      SELECT 1 FROM Edges de
+                      WHERE de.source = n.id AND de.type = 'DELIVERED_TO'
+                  )
+            )
             SELECT
-                n.id AS messageId,
-                json_extract(n.data, '$.properties.subject') AS subject,
-                json_extract(n.data, '$.properties.sentAt') AS sentAt,
+                messageId,
+                json_extract(data, '$.properties.subject') AS subject,
+                json_extract(data, '$.properties.sentAt') AS sentAt,
                 (
                     SELECT se.target FROM Edges se
-                    WHERE se.source = n.id AND se.type = 'SENT_BY'
+                    WHERE se.source = messageId AND se.type = 'SENT_BY'
                     LIMIT 1
                 ) AS "from"
-            FROM Edges e
-            JOIN Nodes n ON n.id = e.source
-            WHERE e.type = 'SENT_TO'
-              AND (e.target = ? OR e.target = 'AGENT:*')
-              AND json_extract(n.data, '$.properties.readAt') IS NULL
-            ORDER BY json_extract(n.data, '$.properties.sentAt') DESC
+            FROM unread_messages
+            ORDER BY json_extract(data, '$.properties.sentAt') DESC
             LIMIT 1
-        `).get(me);
+        `).get(me, me);
 
         return {
             unreadCount  : unreadRow?.unreadCount ?? 0,

--- a/test/playwright/unit/ai/services/memory-core/MailboxService.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/MailboxService.spec.mjs
@@ -21,7 +21,7 @@ import RequestContextService from '../../../../../../ai/mcp/server/shared/servic
 
 test.describe('Neo.ai.services.memory-core.MailboxService', () => {
     test.describe.configure({ mode: 'serial' });
-    let MailboxService, GraphService, PermissionService, LifecycleService, buildMailboxDelta, originalAutoSave, mailboxAiConfig, originalMailboxPolicy;
+    let MailboxService, GraphService, PermissionService, LifecycleService, SwarmHeartbeatService, buildMailboxDelta, originalAutoSave, mailboxAiConfig, originalMailboxPolicy;
     let dbPath;
 
     test.beforeAll(async () => {
@@ -44,6 +44,7 @@ test.describe('Neo.ai.services.memory-core.MailboxService', () => {
         MailboxService = (await import('../../../../../../ai/services/memory-core/MailboxService.mjs')).default;
         PermissionService = (await import('../../../../../../ai/services/memory-core/PermissionService.mjs')).default;
         LifecycleService = (await import('../../../../../../ai/services/memory-core/lifecycle/SystemLifecycleService.mjs')).default;
+        SwarmHeartbeatService = (await import('../../../../../../ai/daemons/SwarmHeartbeatService.mjs')).default;
         buildMailboxDelta = (await import('../../../../../../ai/services/memory-core/MemoryService.mjs')).buildMailboxDelta;
 
         // Pin this suite to strict-isolation mode (#10252). These tests predate the
@@ -140,6 +141,9 @@ test.describe('Neo.ai.services.memory-core.MailboxService', () => {
             await MailboxService.addMessage({ to: '@bob', subject: 'To Bob', body: 'Secret' });
         });
         
+        // Charlie is registered before the broadcast, so the #11029 send-time audience snapshot includes them.
+        GraphService.upsertNode({ id: '@charlie', type: 'AGENT', name: 'Charlie', properties: {} });
+
         // Alice sends to Broadcast
         await RequestContextService.run({ agentIdentityNodeId: '@alice' }, async () => {
             await MailboxService.addMessage({ to: 'AGENT:*', subject: 'To All', body: 'Public' });
@@ -154,14 +158,21 @@ test.describe('Neo.ai.services.memory-core.MailboxService', () => {
         expect(bobRes.messages.find(m => m.subject === 'To Bob')).toBeDefined();
         expect(bobRes.messages.find(m => m.subject === 'To All')).toBeDefined();
 
-        // Charlie (new agent) reads - should only see broadcast
-        GraphService.upsertNode({ id: '@charlie', type: 'AGENT', name: 'Charlie', properties: {} });
+        // Charlie reads - should only see broadcast
         const charlieRes = await RequestContextService.run({ agentIdentityNodeId: '@charlie' }, async () => {
             return await MailboxService.listMessages({ status: 'all' });
         });
         
         expect(charlieRes.messages.length).toBe(1);
         expect(charlieRes.messages[0].subject).toBe('To All');
+
+        // Dana was not registered at send time, so the per-recipient receipt snapshot excludes them.
+        GraphService.upsertNode({ id: '@dana', type: 'AGENT', name: 'Dana', properties: {} });
+        const danaRes = await RequestContextService.run({ agentIdentityNodeId: '@dana' }, async () => {
+            return await MailboxService.listMessages({ status: 'all' });
+        });
+
+        expect(danaRes.messages.length).toBe(0);
     });
 
     test('getMessage enforces read-path isolation', async () => {
@@ -554,8 +565,9 @@ test.describe('Neo.ai.services.memory-core.MailboxService', () => {
     test.describe('#10174 production-convention addressing', () => {
         test.beforeEach(async () => {
             // Mirror the seedAgentIdentities.mjs convention + AGENT:* broadcast sentinel.
-            GraphService.upsertNode({ id: '@opus',   type: 'AgentIdentity',     name: 'Opus',      properties: {} });
-            GraphService.upsertNode({ id: '@gemini', type: 'AgentIdentity',     name: 'Gemini',    properties: {} });
+            GraphService.upsertNode({ id: '@opus',   type: 'AgentIdentity', name: 'Opus',   properties: { accountType: 'agent' } });
+            GraphService.upsertNode({ id: '@gemini', type: 'AgentIdentity', name: 'Gemini', properties: { accountType: 'agent' } });
+            GraphService.upsertNode({ id: '@gpt',    type: 'AgentIdentity', name: 'GPT',    properties: { accountType: 'agent' } });
             // (`AGENT:*` already seeded by the outer beforeEach — retained because production
             //  uses the same sentinel id and this test block validates its addressability.)
         });
@@ -752,15 +764,19 @@ test.describe('Neo.ai.services.memory-core.MailboxService', () => {
                 expect(res.status).toBe('sent');
                 messageId = res.messageId;
 
-                // Pre-fix core bug: AGENT:* wasn't a seeded node, so linkNodes culled this edge,
-                // and zero recipients saw the broadcast. Post-fix (seed script adds AGENT:* as
-                // BroadcastSentinel), the edge persists and listMessages' `=== 'AGENT:*'` filter
-                // fans it out to every authenticated inbox query.
                 const sentToEdge = GraphService.db.edges.items.find(
                     e => e.source === messageId && e.type === 'SENT_TO'
                 );
                 expect(sentToEdge).toBeDefined();
                 expect(sentToEdge.target).toBe('AGENT:*');
+
+                const deliveryTargets = GraphService.db.edges.items
+                    .filter(e => e.source === messageId && e.type === 'DELIVERED_TO')
+                    .map(e => e.target)
+                    .sort();
+
+                expect(deliveryTargets).toEqual(expect.arrayContaining(['@gemini', '@gpt']));
+                expect(deliveryTargets).not.toContain('@opus');
             });
 
             // Sender sees it in outbox
@@ -775,6 +791,57 @@ test.describe('Neo.ai.services.memory-core.MailboxService', () => {
             });
             expect(geminiInbox.messages.length).toBe(1);
             expect(geminiInbox.messages[0].subject).toBe('broadcast');
+        });
+
+        test('#11029 broadcast markRead updates only the caller delivery receipt', async () => {
+            let messageId;
+
+            await RequestContextService.run({ agentIdentityNodeId: '@opus' }, async () => {
+                const res = await MailboxService.addMessage({ to: 'AGENT:*', subject: 'receipt split', body: 'body' });
+                messageId = res.messageId;
+            });
+
+            await RequestContextService.run({ agentIdentityNodeId: '@gemini' }, async () => {
+                const before = await MailboxService.listMessages({ status: 'unread' });
+                expect(before.messages.map(msg => msg.messageId)).toContain(messageId);
+
+                const read = await MailboxService.markRead({ messageId });
+                expect(read.status).toBe('read');
+
+                const after = await MailboxService.listMessages({ status: 'unread' });
+                expect(after.messages.map(msg => msg.messageId)).not.toContain(messageId);
+
+                const full = await MailboxService.getMessage({ messageId });
+                expect(full.readAt).toBe(read.readAt);
+            });
+
+            const messageNode = GraphService.db.nodes.get(messageId);
+            expect(messageNode.properties.readAt).toBeNull();
+
+            const geminiDelivery = GraphService.db.edges.items.find(e =>
+                e.source === messageId && e.type === 'DELIVERED_TO' && e.target === '@gemini'
+            );
+            const gptDelivery = GraphService.db.edges.items.find(e =>
+                e.source === messageId && e.type === 'DELIVERED_TO' && e.target === '@gpt'
+            );
+
+            expect(geminiDelivery.properties.readAt).toBeTruthy();
+            expect(gptDelivery.properties.readAt).toBeNull();
+
+            const gptUnread = await RequestContextService.run({ agentIdentityNodeId: '@gpt' }, async () => {
+                return await MailboxService.listMessages({ status: 'unread' });
+            });
+            expect(gptUnread.messages.map(msg => msg.messageId)).toContain(messageId);
+
+            const geminiDelta = await RequestContextService.run({ agentIdentityNodeId: '@gemini' }, () => buildMailboxDelta());
+            const gptDelta = await RequestContextService.run({ agentIdentityNodeId: '@gpt' }, () => buildMailboxDelta());
+            expect(geminiDelta.unreadCount).toBe(0);
+            expect(gptDelta.unreadCount).toBe(1);
+
+            SwarmHeartbeatService.identity = '@gemini';
+            expect(await SwarmHeartbeatService.getUnreadCount()).toBe(0);
+            SwarmHeartbeatService.identity = '@gpt';
+            expect(await SwarmHeartbeatService.getUnreadCount()).toBe(1);
         });
 
         test('buildMailboxDelta counts unread and surfaces latest preview for bound identity', async () => {


### PR DESCRIPTION
Resolves #11029

Authored by GPT-5.5 (Codex Desktop). Session 019e0c7d-955f-7003-a25d-42dc14c57214.

Evidence: L2 (Playwright unit spec over isolated SQLite Memory Core graph covering send/list/get/mark-read, mailbox delta SQL, and heartbeat unread SQL) -> L2 required (internal runtime substrate behavior reachable in unit sandbox). No residuals.

## Summary
Adds graph-native per-recipient read receipts for `AGENT:*` broadcasts while preserving the existing one-message broadcast shape. New broadcasts keep the semantic `MESSAGE -> SENT_TO -> AGENT:*` anchor and add `DELIVERED_TO` edges for the send-time peer audience, so one recipient marking a broadcast read no longer clears it for every other agent.

## Deltas from Ticket
- Direct DMs still use `MESSAGE.properties.readAt`; new broadcasts use `DELIVERED_TO.properties.readAt`.
- Legacy broadcasts without `DELIVERED_TO` edges silently retain shared-read fallback behavior.
- `listMessages`, `getMessage`, `markRead`, `buildMailboxDelta`, and `SwarmHeartbeatService.getUnreadCount` now agree on the per-recipient receipt model.
- The seeded BroadcastSentinel description now documents the `SENT_TO` semantic anchor plus `DELIVERED_TO` receipt snapshot.

## Test Evidence
- `node --check ai/services/memory-core/MailboxService.mjs`
- `node --check ai/services/memory-core/MemoryService.mjs`
- `node --check ai/daemons/SwarmHeartbeatService.mjs`
- `node --check ai/graph/identityRoots.mjs`
- `node --check test/playwright/unit/ai/services/memory-core/MailboxService.spec.mjs`
- `npm run test-unit -- test/playwright/unit/ai/services/memory-core/MailboxService.spec.mjs --workers=1` -> 47 passed
- `git diff --check origin/dev...HEAD`

Note: this mailbox spec mutates singleton graph state and is declared serial; the default multi-worker invocation can hit existing shared SQLite cleanup noise. The authoritative targeted run is the one-worker run above.

## Post-Merge Validation
- [ ] Send a live broadcast from one agent, mark it read from one recipient, then verify another recipient still sees it unread after an MCP restart.

## Commit
- `481e0d651` - `fix(memory-core): add per-recipient broadcast receipts (#11029)`