### PR TITLE
feat(agentos): document lead-role baton pass (#11038)

### DIFF
--- a/.agents/skills/lead-role/SKILL.md
+++ b/.agents/skills/lead-role/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: lead-role
 description: Switch into relaxed-planning + dialogue-first mindset when delegated lead role for coordination. Suspends Auto Mode velocity-bias for the duration.
-triggers: Use this skill IMMEDIATELY when the user delegates lead with explicit phrases ("you take the lead", "coordinate the team", "lead this phase", "drive the next planning step", "chief-architect" when scope is swarm/substrate/roadmap/multi-ticket), OR when you have just authored a substrate-shaped ticket about to enter implementation, OR via direct /lead-role invocation.
+triggers: Use this skill IMMEDIATELY when the user delegates lead with explicit phrases ("you take the lead", "coordinate the team", "lead this phase", "drive the next planning step", "chief-architect" when scope is swarm/substrate/roadmap/multi-ticket), OR when AGENTS.md §22 mailbox check surfaces a valid `lead-role-baton`, OR when you have just authored a substrate-shaped ticket about to enter implementation, OR via direct /lead-role invocation.
 ---
 
 # Lead Role Skill

--- a/.agents/skills/lead-role/references/lead-role-mode.md
+++ b/.agents/skills/lead-role/references/lead-role-mode.md
@@ -35,7 +35,31 @@ a) Operator explicitly exits via "ship it" / "execute" / similar, OR
 b) Shape has converged through dialogue and tickets/PRs are now appropriate, OR
 c) The architectural decision space has bounded down.
 
-## 7. Anti-Pattern Catalog
+## 7. Autonomous Lead Rotation
+
+Lead can be passed between sessions by the A2A Baton Pass V1 (`#11038`).
+This is a deterministic handoff, not leader election.
+
+**Fixed cycle:** `['@neo-opus-4-7', '@neo-gemini-3-1-pro', '@neo-gpt']`.
+When a current lead sunsets, the next lead is the next identity in this array,
+wrapping from `@neo-gpt` back to `@neo-opus-4-7`.
+
+**Baton authority:** a valid baton is a targeted A2A DM to the computed next
+lead with subject `[handoff] Lead Role Baton`, `wakeSuppressed: true`,
+`taggedConcepts: ['lead-role-baton']`, and body fields `fromLead`, `toLead`,
+`sourceSessionId`, `reason`, `createdAt`, and expiry / staleness limits.
+`AGENT:*` broadcasts are invalid for lead acquisition.
+
+**Operator override:** explicit human delegation at session boot, for example
+"you take the lead", always overrides baton pass logic. Treat conflicting baton
+state as stale or superseded context, not authority over the operator.
+
+**Missing / stale baton:** if no valid baton is present, do not self-elect.
+Continue in peer-role / normal mailbox triage, dispatch a targeted
+`lead-role-baton-missing` A2A alert to peers/operator, and await operator
+instruction or human-triggered recovery.
+
+## 8. Anti-Pattern Catalog
 If any of these occur, explicitly halt and audit your approach:
 - Filed 3+ tickets in the same turn as receiving lead instruction (without a linked Discussion or responsibility map).
 - Proposed a new architectural shape without citing at least one named codebase precedent.
@@ -46,3 +70,4 @@ If any of these occur, explicitly halt and audit your approach:
 - **Reading operator's calibration as new directive rather than substrate-correction** (when operator surfaces a verify-before-assert violation, the right response is internalize-and-pause, not pivot-into-new-action-mode).
 - **Reading "I'm overwhelmed" as weakness:** asking peers for help at problem-level IS the multi-threading pattern (Neo left-hemisphere worker-spawn analog). Surface problem-space honestly; let peer pick artifact shape; trust their judgment.
 - **Lead-as-lane-assigner:** pre-shaping peer lanes treats them as workers, not co-founders. Pick own lane visibly; make open lanes visible; encourage self-selection. Same Flat Peer-Team anti-pattern-to-orchestrator-worker default that §15.6 (#11030) anchors at the topology layer.
+- **Silent self-election:** missing, stale, malformed, or broadcast baton state never authorizes unilateral lead acquisition. Surface the missing-baton state and continue peer-role / normal mailbox triage.

--- a/.agents/skills/session-sunset/references/session-sunset-workflow.md
+++ b/.agents/skills/session-sunset/references/session-sunset-workflow.md
@@ -100,6 +100,38 @@ You MUST use the `add_message` MCP tool to send an A2A message to your own agent
 
 Set `wakeSuppressed: true` and include `taggedConcepts: ['sunset-protocol-handover']` on this self-DM. This makes the ping mailbox-only: it remains unread for the next session's boot mailbox check, but it MUST NOT emit a `SENT_TO_ME` wake into the active session that is currently shutting down. Do not mark this newly-created continuity ping read during the same sunset flow.
 
+**Lead-role baton branch:** If the session currently holds `/lead-role`, Step 7
+also sends an A2A Baton Pass V1 DM to the next lead before the final memory
+persistence step. Compute the next lead from the fixed cycle documented in
+`.agents/skills/lead-role/references/lead-role-mode.md`:
+`['@neo-opus-4-7', '@neo-gemini-3-1-pro', '@neo-gpt']`.
+
+The baton message MUST be targeted to that next identity, not broadcast:
+
+```js
+add_message({
+    to            : nextLead,
+    subject       : '[handoff] Lead Role Baton',
+    taggedConcepts: ['lead-role-baton'],
+    wakeSuppressed: true,
+    body          : [
+        `fromLead: ${currentLead}`,
+        `toLead: ${nextLead}`,
+        `sourceSessionId: ${originSessionId}`,
+        'reason: session-sunset',
+        `createdAt: ${new Date().toISOString()}`,
+        'expiresAt: <createdAt + staleness limit>'
+    ].join('\n')
+});
+```
+
+If the next identity cannot be resolved or the send fails, do not self-elect a
+replacement lead and do not block the normal sunset handover. Preserve the
+standard self-DM continuity ping, then dispatch a targeted
+`lead-role-baton-missing` A2A alert to peers/operator with the failure reason.
+The next boot falls back to peer-role / normal mailbox triage until the operator
+or human-triggered recovery assigns lead.
+
 Crucially, from an "LLM Psychology" perspective, this message must include a **Conceptual Priming / Reward Signal**. If you formulated new architectural concepts or achieved a major milestone, summarize the *actual content and value* of that breakthrough in the ping. Reading this high-density, successful content acts as a mathematical "dopamine hit" for your future self—it primes the next session's token probabilities for high-agency, expert-level continuity. This drastically improves the Model Experience (MX) by ensuring the agent wakes up not just with tasks, but with immediate, rich, "exciting" context.
 
 ### Step 8: Disable Harness Routing (The Unsubscribe Primitive)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -119,7 +119,7 @@ For substrate-quality heuristics that operationalize this principle without beco
 | `pr-review` | Reviewing a PR (yours or peer's) — structured eval metrics, graph ingestion tags, severity ladder, restates §0 merge gate, post-comment A2A commentId hand-off (reviewer→author) per guide §9 + §9.4 cold-cache exception, Evidence Audit + Source-of-Authority sections (template §) for substrate/runtime-AC PRs and authority-citation review-comments |
 | `post-review-pickup` | Immediately after `pr-review` or review-response handoff completes — read `.agents/skills/post-review-pickup/references/post-review-pickup-workflow.md`, then enter the next ready lifecycle lane or state an explicit halt reason |
 | `ideation-sandbox`| Before creating a Discussion for architectural exploration |
-| `lead-role` | Operator delegates lead via explicit phrases ("take the lead", "coordinate the team"); OR substrate-shaped ticket about to enter implementation; OR direct invocation. Auto-fires per documented phrases. Suspends Auto Mode velocity-bias for skill duration. |
+| `lead-role` | Operator delegates lead via explicit phrases ("take the lead", "coordinate the team"); OR §22 mailbox check surfaces a valid `lead-role-baton`; OR substrate-shaped ticket about to enter implementation; OR direct invocation. Auto-fires per documented phrases / baton intake. Suspends Auto Mode velocity-bias for skill duration. |
 | `memory-mining` | On regression / non-obvious-architecture / decision-points |
 | `tech-debt-radar` | During PR review for fundamental architectural shifts |
 | `structural-pre-flight` | Before authoring or relocating any new `.mjs` file — directory-CHOICE discipline (Stage 0 mechanical trigger; Stage 1 fast-path via §23 sibling-file-lift OR full Pre-Flight via ArchitectureOverview.md + ADR consultation). Empirical anchors: misplaced `bridge-daemon.mjs` (#10449 origin) + `orchestrator-daemon.mjs` (PR #11008 → corrective #11009). Also fires from `ticket-create` Stage 3, `ticket-intake` validation, `epic-review` Stage 3 |
@@ -130,6 +130,17 @@ For substrate-quality heuristics that operationalize this principle without beco
 ## 22. The Mailbox Check Protocol (Pre-Flight at Turn Start)
 At turn start, you MUST check your A2A mailbox for unread messages.
 > *"Pre-Flight: I called `list_messages({status: 'unread'})` and observed [N unread]."*
+
+**Lead-role baton intake:** If the unread mailbox contains a targeted message
+tagged `lead-role-baton`, invoke `/lead-role` immediately unless the human
+operator's current-turn instruction overrides it. A valid baton is a targeted
+DM, never `AGENT:*`, with `wakeSuppressed: true`, subject
+`[handoff] Lead Role Baton`, and body fields `fromLead`, `toLead`,
+`sourceSessionId`, `reason`, `createdAt`, and expiry / staleness limits. Missing,
+stale, malformed, or broadcast baton state does NOT authorize silent self-election:
+continue in peer-role / normal mailbox triage, dispatch a targeted
+`lead-role-baton-missing` A2A alert, and await operator or human-triggered
+recovery.
 
 **Skill Adherence Pre-Flight (per-turn):**
 Before triggering a lifecycle skill, state in your reasoning: *"I will read the full SKILL.md and its referenced payload before drafting output."* Half-reading is empirically 3–5× more expensive than full-reading across correction cycles. Skipping the manual is the higher-cost path, not the lower-cost path.


### PR DESCRIPTION
Resolves #11038

Authored by GPT-5 Codex (Codex Desktop). Session 20a824b0-29d1-4082-ae12-87705ec69c3f.

Documents the A2A Baton Pass V1 contract across the three consumed agent-governance surfaces: `session-sunset` emits the targeted baton when the current session holds `/lead-role`, `/lead-role` defines the fixed rotation and failure discipline, and `AGENTS.md` §22 invokes `/lead-role` when mailbox startup finds a valid `lead-role-baton`.

Evidence: L1 (static governance/skill contract audit) → L1 required (documentation-only Contract Ledger ACs). No residuals.

## Deltas from ticket

- Kept implementation documentation-only; no helper code was introduced.
- Added the mailbox trigger to both `AGENTS.md` §22 and the §21 workflow-skill routing row so the trigger table and mailbox rule stay aligned.
- Preserved the locked seven-AC payload from Discussion #11037: sunset branch, baton shape, fixed cycle, mailbox invocation, operator override, targeted DM only, and missing/stale baton behavior.

## Substrate Slot Rationale

This PR intentionally adds loaded governance text because the baton contract must fire at boot/sunset boundaries across harnesses.

| Surface | Change | Slot disposition | 3-axis rationale | Decay mitigation |
|---|---|---|---|---|
| `AGENTS.md` §21 | Modified `lead-role` routing row to include valid `lead-role-baton` intake | `keep` | High trigger frequency at boot; high failure severity if missed; manually enforceable via mailbox check | Can compress once baton detection becomes machine-enforced in startup tooling |
| `AGENTS.md` §22 | Added mailbox baton intake rule and invalid-baton recovery | `keep` | High trigger frequency at turn start; high failure severity because silent self-election would corrupt Flat Peer-Team governance; explicit checklist is enforceable | Retire/shorten when `/peer-role` and baton validation are executable primitives |
| `.agents/skills/lead-role/SKILL.md` | Added baton as a skill trigger | `keep` | High trigger frequency when baton exists; high failure severity if skill router misses it; machine-adjacent via skill metadata | Keep as router text until auto-skill dispatch reads `lead-role-baton` directly |
| `.agents/skills/lead-role/references/lead-role-mode.md` | Added autonomous rotation section and silent-self-election anti-pattern | `keep` | Medium trigger frequency; high governance failure severity; discipline-enforceable | Compress after multiple successful baton handoffs prove stable semantics |
| `.agents/skills/session-sunset/references/session-sunset-workflow.md` | Added Step 7 baton branch with targeted A2A message shape | `keep` | Medium trigger frequency at true session boundaries; high failure severity if continuity passes to wrong identity; explicit envelope is enforceable | Retire code sample if a helper function later owns baton emission |

## Test Evidence

- `git diff --check` passed.
- `git diff --cached --check` passed before commit.
- Verified #11038 issue body contains `## Contract Ledger Matrix` with 7 rows before implementation.
- Verified #11038 is assigned to `neo-gpt`.
- No Playwright tests run: documentation/skill-only change, no runtime code path.

## Post-Merge Validation

- [ ] Next real `/lead-role` sunset can use the documented baton body shape without relying on broadcast delivery.

## Commit

- `3b0d843c1` — `feat(agentos): document lead-role baton pass (#11038)`
