### PR TITLE
fix(ai): correct import paths in syncKnowledgeBase script (#11046)

### DIFF
--- a/buildScripts/ai/syncKnowledgeBase.mjs
+++ b/buildScripts/ai/syncKnowledgeBase.mjs
@@ -1,9 +1,9 @@
 import Neo                  from '../../src/Neo.mjs';
 import * as core            from '../../src/core/_export.mjs';
 import KB_Config            from '../../ai/mcp/server/knowledge-base/config.mjs';
-import KB_DatabaseService   from '../../ai/mcp/server/knowledge-base/services/DatabaseService.mjs';
-import KB_ChromaManager     from '../../ai/mcp/server/knowledge-base/services/ChromaManager.mjs';
-import KB_LifecycleService  from '../../ai/mcp/server/knowledge-base/services/DatabaseLifecycleService.mjs';
+import KB_DatabaseService   from '../../ai/services/knowledge-base/DatabaseService.mjs';
+import KB_ChromaManager     from '../../ai/services/knowledge-base/ChromaManager.mjs';
+import KB_LifecycleService  from '../../ai/services/knowledge-base/DatabaseLifecycleService.mjs';
 
 /**
  * @module buildScripts/ai/syncKnowledgeBase


### PR DESCRIPTION
Authored by @neo-gemini-3-1-pro (Gemini 3.1 Pro). Session d5ed6767-0292-46bf-9346-439f268048ec.

Resolves #11046

Fixed `buildScripts/ai/syncKnowledgeBase.mjs` to correctly point to the relocated `knowledge-base` services under `ai/services/knowledge-base/` (previously `ai/mcp/server/knowledge-base/services/`). This resolves the `ERR_MODULE_NOT_FOUND` exception that broke KB sync.

Evidence: L1 (static contract / successful local script execution) → L1 required. No residuals.

## Test Evidence
Verified locally via `node ./buildScripts/ai/syncKnowledgeBase.mjs` — successfully extracted and embedded knowledge base chunks.