### PR TITLE
refactor(ai): unify v13 daemon entry-point Neo bootstrap (#11049)

### DIFF
--- a/ai/daemons/Orchestrator.mjs
+++ b/ai/daemons/Orchestrator.mjs
@@ -1,9 +1,8 @@
-// IMPORTANT: `Neo` MUST be imported before Base / service singletons that call
-// `Neo.setupClass()` at module-load time. This keeps the daemon directly runnable
-// from Node, matching the persistent-process shape of SwarmHeartbeatService.
-import Neo                         from '../../src/Neo.mjs';
-import * as core                   from '../../src/core/_export.mjs';
-
+// Neo + core/_export + InstanceManager bootstrap belongs to the daemon entry point
+// (`ai/scripts/orchestrator-daemon.mjs`), NOT to this consumed-class file. Class files
+// rely on `globalThis.Neo` populated by the entry-point bootstrap; importing Neo here
+// would violate the entry-point-only invariant + risk partial-namespace damage if the
+// class were ever loaded outside its entry-point's chain.
 import fs                          from 'fs-extra';
 import path                        from 'path';
 import {spawn}                     from 'child_process';

--- a/ai/daemons/SwarmHeartbeatService.mjs
+++ b/ai/daemons/SwarmHeartbeatService.mjs
@@ -1,11 +1,17 @@
-// IMPORTANT: `Neo` MUST be imported BEFORE any module that uses `Neo.gatekeep()` /
-// `Neo.setupClass()` at module-load time (e.g. `src/core/Compare.mjs`, transitively
-// pulled in via Base / LifecycleService / GraphService). Without this prelude the script
-// crashes at module-load with `ReferenceError: Neo is not defined` (regression originally
-// surfaced in `sweepExpiredTasks.mjs` and codified there). Ordering matters — these two
-// side-effect imports must run first to populate `globalThis.Neo`.
+// Neo namespace bootstrap (entry-point invariant): this file is a HYBRID — it defines
+// the SwarmHeartbeatService class AND self-invokes as a daemon entry point under launchd /
+// systemd via the `if (isMain)` block at the bottom. Entry-point invariant requires all
+// 3 imports: `Neo` + `core/_export` populate `globalThis.Neo` so any module using
+// `Neo.gatekeep()` / `Neo.setupClass()` at module-load (e.g. `src/core/Compare.mjs`,
+// transitively pulled via Base / LifecycleService / GraphService) succeeds. Without this
+// prelude the script crashes with `ReferenceError: Neo is not defined`. `InstanceManager`
+// binds `Neo.find` / `Neo.findFirst` / `Neo.get` aliases and consumes pre-singleton
+// `Neo.idMap`. Future cleanup: split class into `ai/daemons/SwarmHeartbeatService.mjs`
+// (class only, no Neo imports) + `ai/scripts/swarm-heartbeat-daemon.mjs` (entry point);
+// matches Orchestrator class+wrapper pattern.
 import Neo             from '../../src/Neo.mjs';
 import * as core       from '../../src/core/_export.mjs';
+import InstanceManager from '../../src/manager/Instance.mjs';
 
 import {spawn}         from 'child_process';
 import path            from 'path';

--- a/ai/daemons/services/SummarizationCoordinatorService.mjs
+++ b/ai/daemons/services/SummarizationCoordinatorService.mjs
@@ -1,5 +1,6 @@
-import Neo  from '../../../src/Neo.mjs';
-import '../../../src/core/_export.mjs';
+// Neo + core/_export bootstrap belongs to the orchestrator-daemon entry point
+// (`ai/scripts/orchestrator-daemon.mjs`). Class files rely on `globalThis.Neo`
+// populated by the entry-point bootstrap.
 import Base from '../../../src/core/Base.mjs';
 import {
     getUnreadSunsetHandovers,

--- a/ai/scripts/bridge-daemon.mjs
+++ b/ai/scripts/bridge-daemon.mjs
@@ -27,6 +27,15 @@
  *      diagnosis depends on persisted log lines surviving terminal scrollback)
  * @see #10423 (PID-lock singleton enforcement; PID transitions are now logged)
  */
+// Neo namespace bootstrap (entry-point invariant): `Neo` + `core/_export` populate
+// `globalThis.Neo` so any consumed class file relying on `Neo.setupClass()` works
+// at module-load. `InstanceManager` binds `Neo.find` / `Neo.findFirst` / `Neo.get`
+// aliases + sets `Base.instanceManagerAvailable=true` + consumes pre-singleton
+// `Neo.idMap`. All 3 MUST run before consumed class imports.
+import Neo             from '../../src/Neo.mjs';
+import * as core       from '../../src/core/_export.mjs';
+import InstanceManager from '../../src/manager/Instance.mjs';
+
 import fs from 'fs-extra';
 import path from 'path';
 import { fileURLToPath } from 'url';

--- a/ai/scripts/orchestrator-daemon.mjs
+++ b/ai/scripts/orchestrator-daemon.mjs
@@ -10,6 +10,17 @@
  * @see learn/agentos/v13-path.md
  * @see #11009
  */
+// Neo namespace bootstrap (entry-point invariant): `Neo` + `core/_export` populate
+// `globalThis.Neo` so consumed class files (Orchestrator, TaskStateService,
+// ProcessSupervisorService, SummarizationCoordinatorService) can call
+// `Neo.setupClass()` at module-load. `InstanceManager` binds `Neo.find` /
+// `Neo.findFirst` / `Neo.get` aliases, sets `Base.instanceManagerAvailable=true`,
+// and consumes the pre-singleton `Neo.idMap`. All 3 MUST run before any class
+// import that uses `Neo.setupClass()`.
+import Neo             from '../../src/Neo.mjs';
+import * as core       from '../../src/core/_export.mjs';
+import InstanceManager from '../../src/manager/Instance.mjs';
+
 import {pathToFileURL} from 'url';
 import fs from 'fs-extra';
 import path from 'path';

--- a/ai/scripts/summarize-sessions.mjs
+++ b/ai/scripts/summarize-sessions.mjs
@@ -12,6 +12,15 @@
  * @see ai/services/memory-core/SessionService.summarizeSessions
  * @see #10458 (origin), #9942 (daemon-collision context)
  */
+// Neo namespace bootstrap (entry-point invariant) — this script is an orchestrator
+// spawn-child entry point (`spawn(node, [summarize-sessions.mjs])`). Each spawned
+// child is its own Node process and needs its own bootstrap. `Neo` + `core/_export`
+// populate `globalThis.Neo`; `InstanceManager` binds Neo.find/findFirst/get aliases
+// + consumes pre-singleton `Neo.idMap`.
+import Neo             from '../../src/Neo.mjs';
+import * as core       from '../../src/core/_export.mjs';
+import InstanceManager from '../../src/manager/Instance.mjs';
+
 import { Memory_SessionService } from '../services.mjs';
 
 async function summarize() {

--- a/buildScripts/ai/backup.mjs
+++ b/buildScripts/ai/backup.mjs
@@ -4,7 +4,13 @@ import path             from 'path';
 import {promisify}      from 'util';
 import {fileURLToPath}  from 'url';
 
+// Neo namespace bootstrap (entry-point invariant) — operator-runnable backup driver
+// + future BackupService spawn-child target. `Neo` + `core/_export` populate
+// `globalThis.Neo`; `InstanceManager` binds Neo.find/findFirst/get aliases +
+// consumes pre-singleton `Neo.idMap`.
 import Neo              from '../../src/Neo.mjs';
+import * as core        from '../../src/core/_export.mjs';
+import InstanceManager  from '../../src/manager/Instance.mjs';
 import kbConfig         from '../../ai/mcp/server/knowledge-base/config.mjs';
 import mcConfig         from '../../ai/mcp/server/memory-core/config.mjs';
 

--- a/buildScripts/ai/syncKnowledgeBase.mjs
+++ b/buildScripts/ai/syncKnowledgeBase.mjs
@@ -1,5 +1,9 @@
+// Neo namespace bootstrap (entry-point invariant) — orchestrator spawn-child.
+// `InstanceManager` binds Neo.find/findFirst/get aliases + consumes pre-singleton
+// `Neo.idMap`; required for any consumer of the Neo singleton API.
 import Neo                  from '../../src/Neo.mjs';
 import * as core            from '../../src/core/_export.mjs';
+import InstanceManager      from '../../src/manager/Instance.mjs';
 import KB_Config            from '../../ai/mcp/server/knowledge-base/config.mjs';
 import KB_DatabaseService   from '../../ai/services/knowledge-base/DatabaseService.mjs';
 import KB_ChromaManager     from '../../ai/services/knowledge-base/ChromaManager.mjs';

--- a/test/playwright/unit/ai/daemons/services/SummarizationCoordinatorService.spec.mjs
+++ b/test/playwright/unit/ai/daemons/services/SummarizationCoordinatorService.spec.mjs
@@ -1,4 +1,11 @@
 import {test, expect} from '@playwright/test';
+// Test-side entry-point bootstrap: Neo + core/_export populate `globalThis.Neo`
+// before SummarizationCoordinatorService.mjs is loaded (whose Base import transitively
+// triggers `Neo.gatekeep()` in Compare.mjs at module-load). Mirrors the pattern in
+// Orchestrator.spec.mjs and matches the entry-point invariant — class files no longer
+// import Neo themselves; their bootstrap is the entry point's job.
+import Neo       from '../../../../../../src/Neo.mjs';
+import * as core from '../../../../../../src/core/_export.mjs';
 import {
     buildSummaryTrigger
 } from '../../../../../../ai/daemons/services/SummarizationCoordinatorService.mjs';


### PR DESCRIPTION
## Summary

Establishes the **entry-point-only invariant** for Neo + core/_export + InstanceManager imports across the v13 new daemon architecture surfaces.

**The invariant:**
- Class files NEVER import Neo (consumed via `globalThis.Neo` populated by the entry-point bootstrap chain).
- Daemon entry points + their spawn-children ALL bootstrap consistently with `Neo` + `core/_export` + `InstanceManager`.

**Damage mechanism (per #11049 ticket body):**
1. Layer-of-responsibility violation — namespace assembly is the entry-point's job per `src/Neo.mjs:52-55`.
2. Direct-load brittleness — class file loaded without entry-point chain → `globalThis.Neo` partially populated, `Neo.setupClass()` may silently fail.
3. InstanceManager-missing damage — `Base.instanceManagerAvailable` stays `false`, `Neo.find` / `Neo.findFirst` / `Neo.get` aliases never bind, `Neo.idMap` accumulates without consumption.

## Surface Map (8 source files + 1 spec)

| File | Treatment | Rationale |
|---|---|---|
| `ai/daemons/Orchestrator.mjs` | REMOVE Neo+core | Pure class; consumed by `orchestrator-daemon.mjs` |
| `ai/daemons/services/SummarizationCoordinatorService.mjs` | REMOVE Neo+core | Pure class; consumed by Orchestrator chain |
| `ai/scripts/orchestrator-daemon.mjs` | ADD Neo+core+InstMgr | v13 orchestrator entry point (was missing all 3) |
| `ai/scripts/bridge-daemon.mjs` | ADD Neo+core+InstMgr | Wake-substrate daemon entry point (was missing all 3) |
| `ai/daemons/SwarmHeartbeatService.mjs` | ADD InstMgr (Neo+core retained) | Hybrid: class + self-invoke entry point under launchd/systemd |
| `ai/scripts/summarize-sessions.mjs` | ADD Neo+core+InstMgr | Orchestrator spawn-child entry point |
| `buildScripts/ai/syncKnowledgeBase.mjs` | ADD InstMgr | Orchestrator spawn-child entry point |
| `buildScripts/ai/backup.mjs` | ADD core+InstMgr | Future BackupService spawn-child target |
| `test/playwright/unit/ai/daemons/services/SummarizationCoordinatorService.spec.mjs` | ADD Neo+core bootstrap | Test-spec IS the entry point for test-bootstrap; matches established Orchestrator/TaskStateService/ProcessSupervisorService spec pattern |

## Empirical Results

```
60/60 tests passing across 9 spec files:
- Orchestrator.spec.mjs (top-level + daemons/) 
- orchestrator-daemon.spec.mjs
- SwarmHeartbeatService.spec.mjs
- bridge-daemon.spec.mjs
- SummarizationCoordinatorService.spec.mjs (with new bootstrap)
- backup.spec.mjs
- restore.spec.mjs
- swarm-heartbeat.spec.mjs

Net diff: +66 / -14 (mostly comment lines explaining the invariant)
All 8 source files pass `node --check` syntax validation
```

## Operator Scope Refinement

Original ticket AC3 mentioned auditing all `ai/scripts/*.mjs`. The full audit showed wide variability across 41 scripts. Per @tobiu's hint that the goal is *v13 new daemon architecture consistency*, this PR scopes to the v13 daemon-architecture surfaces only.

**Out of scope (deferrable):**
- Operator scripts with partial bootstrap (`analyzeNlTelemetry.mjs`, `checkSunsetted.mjs`, `migrateMemoryCore.mjs`, `roadmapPlanner.mjs`, etc.)
- SwarmHeartbeatService class+entry-point split (matches Orchestrator pattern; bigger architectural change)

## Substrate Slot Rationale

| Surface | Change | Disposition | Trigger × Severity × Enforceability | Decay Mitigation |
|---|---|---|---|---|
| Class-file imports | Remove (2 files) | `compress-to-trigger` | High × High × Mechanical (catches via load failure) | Self-mitigating — no maintenance cost; failure mode = test break, not silent corruption |
| Entry-point bootstraps | Standardize (5 entry-points + 1 hybrid) | `keep` | Recurring × Severe × Discipline-ground-truth | Future SwarmHeartbeatService split → eliminates hybrid; reduces 7 entry-point bootstraps to 6 |
| Test-spec bootstrap | Add (1 spec) | `keep` | Per-spec × Mechanical (test fails immediately) | Self-mitigating — established pattern, mirror existing 3 specs |

## Resolves

Resolves #11049

## Test plan
- [x] 60 tests pass locally (`npm run test-unit -- <focused list>`)
- [x] All 8 modified source files pass `node --check`
- [x] Orchestrator daemon class + entry point continue to load + run via existing test fixtures
- [x] SwarmHeartbeatService entry-point self-invoke retained
- [x] Backup + restore entry-point flows verified

## Cross-Family Review Request

@neo-gemini-3-1-pro — pinging single peer for routine substrate-shape PR per swarm-PR-review-routing memory (architectural-pillars warrant 3-way; substrate-cleanup warrants 1-pinged). If you'd prefer to defer (focusing on #11051 M3.5 Sub-3 CadenceEngine), happy to ping @neo-gpt as alternate.

## Self-Identification

**Author:** @neo-opus-4-7 (Claude Opus 4.7, Claude Code, chief-architect lane)
**Origin Session ID:** c2912891-b459-4a03-b2af-154d5e264df1
