### PR TITLE
feat(ai): add team-private retrieval integration proof (#10951)

### DIFF
--- a/test/playwright/integration/TeamPrivateRetrieval.integration.spec.mjs
+++ b/test/playwright/integration/TeamPrivateRetrieval.integration.spec.mjs
@@ -1,0 +1,555 @@
+import {randomUUID}    from 'node:crypto';
+import {spawnSync}     from 'node:child_process';
+import path            from 'node:path';
+import {fileURLToPath} from 'node:url';
+import {test, expect}  from '@playwright/test';
+import {
+    callJsonTool,
+    createIdentityClient,
+    getReadiness
+} from './fixtures/mcpClient.mjs';
+
+const __filename  = fileURLToPath(import.meta.url);
+const __dirname   = path.dirname(__filename);
+const repoRoot    = path.resolve(__dirname, '../../..');
+const composeFile = path.join(repoRoot, 'ai/deploy/docker-compose.test.yml');
+const projectName = process.env.NEO_INTEGRATION_COMPOSE_PROJECT || 'neo-integration-test';
+const MC_URL      = process.env.NEO_INTEGRATION_MC_URL || 'http://127.0.0.1:13001';
+
+const NEO_BOOTSTRAP = `
+    await import('./src/Neo.mjs');
+    await import('./src/core/_export.mjs');
+`;
+
+/**
+ * Runs Docker Compose against the integration fixture project.
+ * @param {String[]} args Docker Compose arguments after the compose file selector.
+ * @returns {import('node:child_process').SpawnSyncReturns<String>}
+ */
+function dockerCompose(args) {
+    return spawnSync('docker', ['compose', '-p', projectName, '-f', composeFile, ...args], {
+        cwd      : repoRoot,
+        encoding : 'utf8',
+        maxBuffer: 10 * 1024 * 1024
+    });
+}
+
+/**
+ * Runs an ES module snippet inside the deployed Memory Core container.
+ * @param {String} code The JavaScript source to execute.
+ * @param {Object} [payload] JSON payload exposed as NEO_TEST_PAYLOAD.
+ * @returns {Object}
+ */
+function execMemoryCoreJson(code, payload={}) {
+    const result = dockerCompose([
+        'exec',
+        '-T',
+        '-e',
+        `NEO_TEST_PAYLOAD=${JSON.stringify(payload)}`,
+        'mc-server',
+        'node',
+        '--input-type=module',
+        '-e',
+        code
+    ]);
+    const output = [
+        result.stdout?.trim(),
+        result.stderr?.trim()
+    ].filter(Boolean).join('\n');
+
+    expect(result.status, output || result.error?.message || 'mc-server exec failed').toBe(0);
+
+    const jsonLine = result.stdout.trim().split('\n').filter(Boolean).reverse().find(line => {
+        try {
+            JSON.parse(line);
+            return true;
+        } catch {
+            return false;
+        }
+    });
+    expect(jsonLine, output).toBeTruthy();
+
+    return JSON.parse(jsonLine);
+}
+
+/**
+ * Seeds Chroma records that are not writable through the current public MCP tools.
+ * @param {Object} payload Seed payload.
+ * @returns {Object}
+ */
+function seedChromaRecords(payload) {
+    return execMemoryCoreJson(`
+        ${NEO_BOOTSTRAP}
+
+        const payload = JSON.parse(process.env.NEO_TEST_PAYLOAD);
+        const {Memory_LifecycleService} = await import('./ai/services.mjs');
+        const StorageRouter = (await import('./ai/services/memory-core/managers/StorageRouter.mjs')).default;
+
+        await Memory_LifecycleService.ready();
+
+        const memoryCollection = await StorageRouter.getMemoryCollection();
+        const summaryCollection = await StorageRouter.getSummaryCollection();
+        const now = Date.now();
+
+        await memoryCollection.add({
+            ids: [payload.sharedMemoryId],
+            metadatas: [{
+                agent          : 'shared-team',
+                amountToolCalls: 0,
+                model          : 'integration',
+                prompt         : 'shared prompt ' + payload.sharedMemorySentinel,
+                response       : 'shared response ' + payload.sharedMemorySentinel,
+                sessionId      : payload.sessionId,
+                thought        : 'shared thought ' + payload.sharedMemorySentinel,
+                timestamp      : now,
+                type           : 'agent-interaction',
+                userId         : 'shared'
+            }],
+            documents: [
+                'User Prompt: shared prompt ' + payload.sharedMemorySentinel + '\\n' +
+                'Agent Thought: shared thought ' + payload.sharedMemorySentinel + '\\n' +
+                'Agent Response: shared response ' + payload.sharedMemorySentinel
+            ]
+        });
+
+        await summaryCollection.add({
+            ids: [
+                payload.sharedSummaryId,
+                payload.ownerSummaryId,
+                payload.peerSummaryId
+            ],
+            metadatas: [
+                {
+                    category    : 'integration',
+                    complexity  : 1,
+                    impact      : 1,
+                    memoryCount : 1,
+                    productivity: 1,
+                    quality     : 1,
+                    sessionId   : payload.sessionId,
+                    technologies: 'integration',
+                    timestamp   : now + 1,
+                    title       : 'shared summary ' + payload.sharedSummarySentinel,
+                    userId      : 'shared'
+                },
+                {
+                    category    : 'integration',
+                    complexity  : 1,
+                    impact      : 1,
+                    memoryCount : 1,
+                    productivity: 1,
+                    quality     : 1,
+                    sessionId   : payload.sessionId,
+                    technologies: 'integration',
+                    timestamp   : now + 2,
+                    title       : 'owner private summary ' + payload.ownerSummarySentinel,
+                    userId      : payload.ownerIdentity
+                },
+                {
+                    category    : 'integration',
+                    complexity  : 1,
+                    impact      : 1,
+                    memoryCount : 1,
+                    productivity: 1,
+                    quality     : 1,
+                    sessionId   : payload.sessionId,
+                    technologies: 'integration',
+                    timestamp   : now + 3,
+                    title       : 'peer private summary ' + payload.peerSummarySentinel,
+                    userId      : payload.peerIdentity
+                }
+            ],
+            documents: [
+                'shared summary body ' + payload.sharedSummarySentinel,
+                'owner private summary body ' + payload.ownerSummarySentinel,
+                'peer private summary body ' + payload.peerSummarySentinel
+            ]
+        });
+
+        console.log(JSON.stringify({
+            memoryIds: [payload.sharedMemoryId],
+            summaryIds: [payload.sharedSummaryId, payload.ownerSummaryId, payload.peerSummaryId]
+        }));
+    `, payload);
+}
+
+/**
+ * Seeds Native Edge Graph nodes that exercise private vs team visibility through MCP search.
+ * @param {Object} payload Seed payload.
+ * @returns {Object}
+ */
+function seedGraphRecords(payload) {
+    return execMemoryCoreJson(`
+        ${NEO_BOOTSTRAP}
+
+        const payload = JSON.parse(process.env.NEO_TEST_PAYLOAD);
+        const {Memory_LifecycleService} = await import('./ai/services.mjs');
+        const RequestContextService = (await import('./ai/mcp/server/shared/services/RequestContextService.mjs')).default;
+        const GraphService = (await import('./ai/services/memory-core/GraphService.mjs')).default;
+
+        await Memory_LifecycleService.ready();
+
+        await RequestContextService.run({
+            agentIdentityNodeId: '@' + payload.ownerIdentity,
+            source             : 'integration',
+            userId             : payload.ownerIdentity,
+            username           : payload.ownerIdentity
+        }, async () => {
+            GraphService.upsertNode({
+                id         : payload.privateNodeId,
+                type       : 'INTEGRATION_TEST',
+                name       : 'private graph node ' + payload.privateGraphSentinel,
+                description: 'private graph description ' + payload.privateGraphSentinel
+            });
+
+            GraphService.upsertNode({
+                id         : payload.teamNodeId,
+                type       : 'INTEGRATION_TEST',
+                name       : 'team graph node ' + payload.teamGraphSentinel,
+                description: 'team graph description ' + payload.teamGraphSentinel,
+                properties : {
+                    visibility: 'team'
+                }
+            });
+        });
+
+        console.log(JSON.stringify({
+            nodeIds: [payload.privateNodeId, payload.teamNodeId]
+        }));
+    `, payload);
+}
+
+/**
+ * Removes directly-seeded Chroma records.
+ * @param {Object} payload Cleanup payload.
+ * @returns {Object}
+ */
+function cleanupChromaRecords(payload) {
+    return execMemoryCoreJson(`
+        ${NEO_BOOTSTRAP}
+
+        const payload = JSON.parse(process.env.NEO_TEST_PAYLOAD);
+        const {Memory_LifecycleService} = await import('./ai/services.mjs');
+        const StorageRouter = (await import('./ai/services/memory-core/managers/StorageRouter.mjs')).default;
+
+        await Memory_LifecycleService.ready();
+
+        const memoryCollection = await StorageRouter.getMemoryCollection();
+        const summaryCollection = await StorageRouter.getSummaryCollection();
+
+        if (payload.memoryIds.length > 0) {
+            await memoryCollection.delete({ids: payload.memoryIds});
+        }
+
+        if (payload.summaryIds.length > 0) {
+            await summaryCollection.delete({ids: payload.summaryIds});
+        }
+
+        console.log(JSON.stringify({
+            deletedMemoryIds : payload.memoryIds,
+            deletedSummaryIds: payload.summaryIds
+        }));
+    `, payload);
+}
+
+/**
+ * Removes directly-seeded graph records.
+ * @param {Object} payload Cleanup payload.
+ * @returns {Object}
+ */
+function cleanupGraphRecords(payload) {
+    return execMemoryCoreJson(`
+        ${NEO_BOOTSTRAP}
+
+        const payload = JSON.parse(process.env.NEO_TEST_PAYLOAD);
+        const {Memory_LifecycleService} = await import('./ai/services.mjs');
+        const GraphService = (await import('./ai/services/memory-core/GraphService.mjs')).default;
+
+        await Memory_LifecycleService.ready();
+
+        const db = GraphService.db.storage.db;
+        const deleteEdges = db.prepare('DELETE FROM Edges WHERE source = ? OR target = ?');
+        const deleteNode = db.prepare('DELETE FROM Nodes WHERE id = ?');
+
+        for (const id of payload.nodeIds) {
+            deleteEdges.run(id, id);
+            deleteNode.run(id);
+        }
+
+        GraphService.db.nodes.clearSilent();
+        GraphService.db.edges.clearSilent();
+        GraphService.db.vicinityLoadedNodes.clear();
+
+        console.log(JSON.stringify({deletedNodeIds: payload.nodeIds}));
+    `, payload);
+}
+
+/**
+ * Flattens a memory query response into searchable test evidence.
+ * @param {Object} result The query_raw_memories tool result.
+ * @returns {String}
+ */
+function memoryTexts(result) {
+    return result.results.map(memory => [
+        memory.prompt,
+        memory.thought,
+        memory.response
+    ].join('\n')).join('\n');
+}
+
+/**
+ * Flattens a summary query response into searchable test evidence.
+ * @param {Object} result The query_summaries tool result.
+ * @returns {String}
+ */
+function summaryTexts(result) {
+    return result.results.map(summary => [
+        summary.title,
+        summary.summary
+    ].join('\n')).join('\n');
+}
+
+/**
+ * Flattens a graph search response into searchable test evidence.
+ * @param {Object} result The search_nodes tool result.
+ * @returns {String}
+ */
+function nodeTexts(result) {
+    return result.nodes.map(node => [
+        node.id,
+        node.name,
+        node.description
+    ].join('\n')).join('\n');
+}
+
+test.describe('Dockerized MC team/private retrieval integration (#10951)', () => {
+    test('retrieves shared Chroma commons while preserving private tenant boundaries', async () => {
+        const readiness = await getReadiness();
+
+        test.skip(readiness.dockerAvailable === false, `Docker unavailable: ${readiness.reason}`);
+
+        expect(readiness.servicesReady, readiness.reason).toBe(true);
+
+        const runId                 = `${Date.now()}-${randomUUID()}`;
+        const sessionId             = `integration-team-private-${runId}`;
+        const ownerIdentity         = 'neo-gpt';
+        const peerIdentity          = 'neo-opus-4-7';
+        const unrelatedIdentity     = 'neo-gemini-3-1-pro';
+        const ownerMemorySentinel   = `owner-private-memory-${runId}`;
+        const peerMemorySentinel    = `peer-private-memory-${runId}`;
+        const sharedMemorySentinel  = `shared-memory-${runId}`;
+        const ownerSummarySentinel  = `owner-private-summary-${runId}`;
+        const peerSummarySentinel   = `peer-private-summary-${runId}`;
+        const sharedSummarySentinel = `shared-summary-${runId}`;
+        const directSeedPayload     = {
+            ownerIdentity,
+            ownerSummaryId: `summary-owner-${runId}`,
+            ownerSummarySentinel,
+            peerIdentity,
+            peerSummaryId: `summary-peer-${runId}`,
+            peerSummarySentinel,
+            sessionId,
+            sharedMemoryId: `memory-shared-${runId}`,
+            sharedMemorySentinel,
+            sharedSummaryId: `summary-shared-${runId}`,
+            sharedSummarySentinel
+        };
+        const owner = await createIdentityClient({
+            baseUrl   : MC_URL,
+            clientName: 'neo-integration-team-private-owner',
+            identity  : ownerIdentity
+        });
+        const peer = await createIdentityClient({
+            baseUrl   : MC_URL,
+            clientName: 'neo-integration-team-private-peer',
+            identity  : peerIdentity
+        });
+        const unrelated = await createIdentityClient({
+            baseUrl   : MC_URL,
+            clientName: 'neo-integration-team-private-unrelated',
+            identity  : unrelatedIdentity
+        });
+
+        try {
+            await callJsonTool(owner, 'add_memory', {
+                amountToolCalls: 0,
+                agent          : ownerIdentity,
+                model          : 'integration',
+                prompt         : `owner prompt ${ownerMemorySentinel}`,
+                response       : `owner response ${ownerMemorySentinel}`,
+                sessionId,
+                thought        : `owner thought ${ownerMemorySentinel}`,
+                toolsUsed      : []
+            });
+            await callJsonTool(peer, 'add_memory', {
+                amountToolCalls: 0,
+                agent          : peerIdentity,
+                model          : 'integration',
+                prompt         : `peer prompt ${peerMemorySentinel}`,
+                response       : `peer response ${peerMemorySentinel}`,
+                sessionId,
+                thought        : `peer thought ${peerMemorySentinel}`,
+                toolsUsed      : []
+            });
+
+            seedChromaRecords(directSeedPayload);
+
+            const ownerPrivate = await callJsonTool(owner, 'query_raw_memories', {
+                nResults: 10,
+                query   : ownerMemorySentinel,
+                sessionId
+            });
+            const peerPrivate = await callJsonTool(peer, 'query_raw_memories', {
+                nResults: 10,
+                query   : peerMemorySentinel,
+                sessionId
+            });
+            const unrelatedOwnerPrivate = await callJsonTool(unrelated, 'query_raw_memories', {
+                nResults: 10,
+                query   : ownerMemorySentinel,
+                sessionId
+            });
+            const ownerSharedMemory = await callJsonTool(owner, 'query_raw_memories', {
+                nResults: 10,
+                query   : sharedMemorySentinel,
+                sessionId
+            });
+            const peerSharedMemory = await callJsonTool(peer, 'query_raw_memories', {
+                nResults: 10,
+                query   : sharedMemorySentinel,
+                sessionId
+            });
+            const unrelatedSharedMemory = await callJsonTool(unrelated, 'query_raw_memories', {
+                nResults: 10,
+                query   : sharedMemorySentinel,
+                sessionId
+            });
+
+            expect(memoryTexts(ownerPrivate)).toContain(ownerMemorySentinel);
+            expect(memoryTexts(ownerPrivate)).not.toContain(peerMemorySentinel);
+            expect(memoryTexts(peerPrivate)).toContain(peerMemorySentinel);
+            expect(memoryTexts(peerPrivate)).not.toContain(ownerMemorySentinel);
+            expect(memoryTexts(unrelatedOwnerPrivate)).not.toContain(ownerMemorySentinel);
+            expect(memoryTexts(unrelatedOwnerPrivate)).not.toContain(peerMemorySentinel);
+            expect(memoryTexts(ownerSharedMemory)).toContain(sharedMemorySentinel);
+            expect(memoryTexts(peerSharedMemory)).toContain(sharedMemorySentinel);
+            expect(memoryTexts(unrelatedSharedMemory)).toContain(sharedMemorySentinel);
+
+            const ownerSharedSummary = await callJsonTool(owner, 'query_summaries', {
+                nResults: 10,
+                query   : sharedSummarySentinel
+            });
+            const peerSharedSummary = await callJsonTool(peer, 'query_summaries', {
+                nResults: 10,
+                query   : sharedSummarySentinel
+            });
+            const unrelatedOwnerSummary = await callJsonTool(unrelated, 'query_summaries', {
+                nResults: 10,
+                query   : ownerSummarySentinel
+            });
+
+            expect(summaryTexts(ownerSharedSummary)).toContain(sharedSummarySentinel);
+            expect(summaryTexts(ownerSharedSummary)).not.toContain(peerSummarySentinel);
+            expect(summaryTexts(peerSharedSummary)).toContain(sharedSummarySentinel);
+            expect(summaryTexts(peerSharedSummary)).not.toContain(ownerSummarySentinel);
+            expect(summaryTexts(unrelatedOwnerSummary)).not.toContain(ownerSummarySentinel);
+            expect(summaryTexts(unrelatedOwnerSummary)).not.toContain(peerSummarySentinel);
+        } finally {
+            await Promise.allSettled([
+                callJsonTool(owner,     'purge_session', {sessionId}),
+                callJsonTool(peer,      'purge_session', {sessionId}),
+                callJsonTool(unrelated, 'purge_session', {sessionId})
+            ]);
+            cleanupChromaRecords({
+                memoryIds : [directSeedPayload.sharedMemoryId],
+                summaryIds: [
+                    directSeedPayload.sharedSummaryId,
+                    directSeedPayload.ownerSummaryId,
+                    directSeedPayload.peerSummaryId
+                ]
+            });
+            await Promise.allSettled([
+                owner.close(),
+                peer.close(),
+                unrelated.close()
+            ]);
+        }
+    });
+
+    test('searches graph nodes by private owner boundary and current team visibility semantics', async () => {
+        const readiness = await getReadiness();
+
+        test.skip(readiness.dockerAvailable === false, `Docker unavailable: ${readiness.reason}`);
+
+        expect(readiness.servicesReady, readiness.reason).toBe(true);
+
+        const runId                 = `${Date.now()}-${randomUUID()}`;
+        const ownerIdentity         = 'neo-gpt';
+        const peerIdentity          = 'neo-opus-4-7';
+        const unrelatedIdentity     = 'neo-gemini-3-1-pro';
+        const privateGraphSentinel  = `private-graph-${runId}`;
+        const teamGraphSentinel     = `team-graph-${runId}`;
+        const graphPayload          = {
+            ownerIdentity,
+            peerIdentity,
+            privateGraphSentinel,
+            privateNodeId: `graph-private-${runId}`,
+            teamGraphSentinel,
+            teamNodeId: `graph-team-${runId}`,
+            unrelatedIdentity
+        };
+        const owner = await createIdentityClient({
+            baseUrl   : MC_URL,
+            clientName: 'neo-integration-team-private-graph-owner',
+            identity  : ownerIdentity
+        });
+        const peer = await createIdentityClient({
+            baseUrl   : MC_URL,
+            clientName: 'neo-integration-team-private-graph-peer',
+            identity  : peerIdentity
+        });
+        const unrelated = await createIdentityClient({
+            baseUrl   : MC_URL,
+            clientName: 'neo-integration-team-private-graph-unrelated',
+            identity  : unrelatedIdentity
+        });
+
+        try {
+            seedGraphRecords(graphPayload);
+
+            const ownerPrivate = await callJsonTool(owner, 'search_nodes', {
+                query: privateGraphSentinel
+            });
+            const peerPrivate = await callJsonTool(peer, 'search_nodes', {
+                query: privateGraphSentinel
+            });
+            const ownerTeam = await callJsonTool(owner, 'search_nodes', {
+                query: teamGraphSentinel
+            });
+            const peerTeam = await callJsonTool(peer, 'search_nodes', {
+                query: teamGraphSentinel
+            });
+            const unrelatedTeam = await callJsonTool(unrelated, 'search_nodes', {
+                query: teamGraphSentinel
+            });
+
+            expect(nodeTexts(ownerPrivate)).toContain(privateGraphSentinel);
+            expect(nodeTexts(peerPrivate)).not.toContain(privateGraphSentinel);
+            expect(nodeTexts(ownerTeam)).toContain(teamGraphSentinel);
+            expect(nodeTexts(peerTeam)).toContain(teamGraphSentinel);
+
+            // Current #10011 substrate models `visibility: "team"` as broad team-visible graph
+            // RLS bypass. Membership-qualified team authorization remains #10010/#10011 scope.
+            expect(nodeTexts(unrelatedTeam)).toContain(teamGraphSentinel);
+        } finally {
+            cleanupGraphRecords({
+                nodeIds: [graphPayload.privateNodeId, graphPayload.teamNodeId]
+            });
+            await Promise.allSettled([
+                owner.close(),
+                peer.close(),
+                unrelated.close()
+            ]);
+        }
+    });
+});


### PR DESCRIPTION
Resolves #10951

Authored by GPT-5 (Codex Desktop). Session 20a824b0-29d1-4082-ae12-87705ec69c3f.

Adds a Dockerized Memory Core integration spec for the team/private retrieval lane. The new coverage seeds private owner/peer memories through real MCP calls, directly seeds current shared Chroma commons records, and verifies owner/peer/unrelated read behavior through MCP `query_raw_memories`, `query_summaries`, and `search_nodes`.

Evidence: L1 (static syntax/import-path audit + Docker-unavailable skip-path run) -> L3 required (deployed MCP calls in Dockerized integration stack). Residual: CI or a Docker-equipped maintainer must execute the two non-skipped integration cases for #10951.

## Deltas from ticket

- Uses direct container-side seeding for shared memory and summary records because the public `add_memory` MCP tool intentionally tags writes with the caller identity.
- Documents current Native Edge Graph `visibility: "team"` behavior as broad team-visible RLS bypass. Membership-qualified team authorization remains #10010/#10011 scope.
- Keeps the integration proof in the existing `test/playwright/integration/` fixture instead of adding a new harness.

## Test Evidence

- `node --check test/playwright/integration/TeamPrivateRetrieval.integration.spec.mjs` passed.
- `git diff --cached --check` passed.
- `npm run test-integration-unified -- TeamPrivateRetrieval.integration.spec.mjs` exited 0 with 2 skipped because Docker is not installed in this Codex environment (`docker not found`).

## Post-Merge Validation

- [ ] CI or a Docker-equipped maintainer run executes both new integration tests without the Docker-unavailable skip.
- [ ] If #10010/#10011 later add membership-qualified team authorization, update the broad `visibility: "team"` assertion to the new policy.

## Commit

- `c6f634378` - `feat(ai): add team-private retrieval integration proof (#10951)`
