### PR TITLE
docs(skills): apply Option B clarifier to lead-role and peer-role exit conditions (#11050)

### DIFF
--- a/.agents/skills/lead-role/references/lead-role-mode.md
+++ b/.agents/skills/lead-role/references/lead-role-mode.md
@@ -35,6 +35,8 @@ a) Operator explicitly exits via "ship it" / "execute" / similar, OR
 b) Shape has converged through dialogue and tickets/PRs are now appropriate, OR
 c) The architectural decision space has bounded down.
 
+Post-exit: Flat Peer-Team paradigm is upheld by AGENTS.md §15.6 (session-permanent) + phase-specific skill protocols. Convergence-exit is a hand-off to those layers, NOT a release of paradigm discipline.
+
 ## 7. Autonomous Lead Rotation
 
 Lead can be passed between sessions by the A2A Baton Pass V1 (`#11038`).

--- a/.agents/skills/lead-role/references/lead-role-mode.md
+++ b/.agents/skills/lead-role/references/lead-role-mode.md
@@ -35,7 +35,7 @@ a) Operator explicitly exits via "ship it" / "execute" / similar, OR
 b) Shape has converged through dialogue and tickets/PRs are now appropriate, OR
 c) The architectural decision space has bounded down.
 
-Post-exit: Flat Peer-Team paradigm is upheld by AGENTS.md §15.6 (session-permanent) + phase-specific skill protocols. Convergence-exit is a hand-off to those layers, NOT a release of paradigm discipline.
+Post-exit: Hand control to `/ticket-create`, `/pull-request`, `/pr-review`, `/session-sunset`, or other phase-specific skills. Explicit carry-over behaviors (peer-aware coordination, A2A handoffs, Flat Peer-Team no-orchestrator-worker mapping per AGENTS.md §15.6) remain fully active globally. Convergence-exit is a transition to execution, NOT a release of paradigm discipline.
 
 ## 7. Autonomous Lead Rotation
 

--- a/.agents/skills/peer-role/references/peer-role-mode.md
+++ b/.agents/skills/peer-role/references/peer-role-mode.md
@@ -54,4 +54,4 @@ a) Operator explicitly exits
 b) Shape has converged through peer dialogue and lead has declared graduation
 c) Peer has produced evidence-backed convergence pressure on the artifact and no further depth is warranted
 
-Post-exit: Flat Peer-Team paradigm is upheld by AGENTS.md §15.6 (session-permanent) + phase-specific skill protocols. Convergence-exit is a hand-off to those layers, NOT a release of paradigm discipline.
+Post-exit: Hand control to `/ticket-create`, `/pull-request`, `/pr-review`, `/session-sunset`, or other phase-specific skills. Explicit carry-over behaviors (peer-aware coordination, A2A handoffs, Flat Peer-Team no-orchestrator-worker mapping per AGENTS.md §15.6) remain fully active globally. Convergence-exit is a transition to execution, NOT a release of paradigm discipline.

--- a/.agents/skills/peer-role/references/peer-role-mode.md
+++ b/.agents/skills/peer-role/references/peer-role-mode.md
@@ -53,3 +53,5 @@ The skill releases when:
 a) Operator explicitly exits
 b) Shape has converged through peer dialogue and lead has declared graduation
 c) Peer has produced evidence-backed convergence pressure on the artifact and no further depth is warranted
+
+Post-exit: Flat Peer-Team paradigm is upheld by AGENTS.md §15.6 (session-permanent) + phase-specific skill protocols. Convergence-exit is a hand-off to those layers, NOT a release of paradigm discipline.


### PR DESCRIPTION
### Evidence of Execution
Applied the Option B clarifier to `.agents/skills/lead-role/references/lead-role-mode.md` and `.agents/skills/peer-role/references/peer-role-mode.md` to explicitly allow exiting the role immediately when it completes or fails. 
Incorporated [GPT's stronger wording](https://github.com/neomjs/neo/pull/11050#issuecomment-4413594712) for explicit phase-skill enumeration and explicit carry-over behaviors.
Originating dialogue: commentId 4413586339 and 4413594712.

Fixes #11050