### PR TITLE
refactor(ai): extract CadenceEngine from Orchestrator (#11051)

### DIFF
--- a/ai/daemons/Orchestrator.mjs
+++ b/ai/daemons/Orchestrator.mjs
@@ -15,6 +15,7 @@ import {
 import SummarizationCoordinatorService from './services/SummarizationCoordinatorService.mjs';
 import TaskStateService                from './services/TaskStateService.mjs';
 import ProcessSupervisorService        from './services/ProcessSupervisorService.mjs';
+import CadenceEngine                   from './services/CadenceEngine.mjs';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname  = path.dirname(__filename);
@@ -26,39 +27,6 @@ export const DEFAULT_KB_SYNC_INTERVAL_MS       = 1800000;
 const DEFAULT_DB_PATH   = process.env.NEO_AI_DB_PATH || '.neo-ai-data/sqlite/memory-core-graph.sqlite';
 const DEFAULT_DATA_DIR  = process.env.NEO_AI_ORCHESTRATOR_DIR || '.neo-ai-data/orchestrator-daemon';
 const DEFAULT_SCRIPT_DIR = path.resolve(__dirname, '../scripts');
-
-/**
- * @summary Parses daemon interval env vars while preserving `0` as disabled.
- *
- * @param {String|undefined} value Environment value.
- * @param {Number} fallback Fallback interval in milliseconds.
- * @returns {Number}
- */
-export function parseInterval(value, fallback) {
-    if (value === undefined || value === null || value === '') {
-        return fallback;
-    }
-
-    const parsed = parseInt(value, 10);
-    if (Number.isNaN(parsed)) {
-        return fallback;
-    }
-
-    return Math.max(parsed, 0);
-}
-
-/**
- * @summary Returns true when an interval task is due and not disabled.
- *
- * @param {Object} options
- * @param {Number} options.now Current timestamp in milliseconds.
- * @param {Number} options.lastRunAt Last start timestamp in milliseconds.
- * @param {Number} options.intervalMs Interval in milliseconds; `0` disables.
- * @returns {Boolean}
- */
-export function shouldRunIntervalTask({now, lastRunAt, intervalMs}) {
-    return intervalMs > 0 && now - lastRunAt >= intervalMs;
-}
 
 /**
  * @summary Builds child-process commands for orchestrator-owned maintenance tasks.
@@ -206,6 +174,12 @@ export class Orchestrator extends Base {
          */
         healthService_: HealthService,
         /**
+         * @member {Object} cadenceEngine_=CadenceEngine
+         * @protected
+         * @reactive
+         */
+        cadenceEngine_: CadenceEngine,
+        /**
          * @member {Object} summarizationCoordinator_=SummarizationCoordinatorService
          * @protected
          * @reactive
@@ -244,12 +218,13 @@ export class Orchestrator extends Base {
         this.dbPath                 = options.dbPath || DEFAULT_DB_PATH;
         this.logFile                = options.logFile   || path.join(dataDir, 'orchestrator.log');
         this.stateFile              = options.stateFile || path.join(dataDir, 'orchestrator-state.json');
-        this.pollIntervalMs         = options.pollIntervalMs ?? parseInterval(process.env.NEO_ORCHESTRATOR_POLL_INTERVAL_MS, DEFAULT_POLL_INTERVAL_MS);
-        this.summarySweepIntervalMs = options.summarySweepIntervalMs ?? parseInterval(
+        this.cadenceEngine          = options.cadenceEngine          || CadenceEngine;
+        this.pollIntervalMs         = options.pollIntervalMs ?? this.cadenceEngine.parseInterval(process.env.NEO_ORCHESTRATOR_POLL_INTERVAL_MS, DEFAULT_POLL_INTERVAL_MS);
+        this.summarySweepIntervalMs = options.summarySweepIntervalMs ?? this.cadenceEngine.parseInterval(
             process.env.NEO_ORCHESTRATOR_SUMMARY_SWEEP_INTERVAL_MS ?? process.env.NEO_SUMMARIZATION_SWEEP_INTERVAL_MS,
             DEFAULT_SUMMARY_SWEEP_INTERVAL_MS
         );
-        this.kbSyncIntervalMs       = options.kbSyncIntervalMs ?? parseInterval(process.env.NEO_ORCHESTRATOR_KB_SYNC_INTERVAL_MS, DEFAULT_KB_SYNC_INTERVAL_MS);
+        this.kbSyncIntervalMs       = options.kbSyncIntervalMs ?? this.cadenceEngine.parseInterval(process.env.NEO_ORCHESTRATOR_KB_SYNC_INTERVAL_MS, DEFAULT_KB_SYNC_INTERVAL_MS);
         this.taskDefinitions        = options.taskDefinitions || buildTaskDefinitions({
             scriptDir,
             nodeBin: options.nodeBin || process.argv[0]
@@ -376,7 +351,7 @@ export class Orchestrator extends Base {
      * @returns {void}
      */
     runKbSyncCycle(now) {
-        if (shouldRunIntervalTask({
+        if (this.cadenceEngine.shouldRunIntervalTask({
             now,
             lastRunAt : this.taskStateService.getTaskState('kbSync').lastRunAt,
             intervalMs: this.kbSyncIntervalMs

--- a/ai/daemons/services/CadenceEngine.mjs
+++ b/ai/daemons/services/CadenceEngine.mjs
@@ -1,0 +1,58 @@
+import Neo  from '../../../src/Neo.mjs';
+import Base from '../../../src/core/Base.mjs';
+
+/**
+ * @class Neo.ai.daemons.services.CadenceEngine
+ * @extends Neo.core.Base
+ * @singleton
+ * @summary A pure functional service that manages polling intervals and timing triggers for maintenance tasks.
+ */
+export class CadenceEngine extends Base {
+    static config = {
+        /**
+         * @member {String} className='Neo.ai.daemons.services.CadenceEngine'
+         * @protected
+         */
+        className: 'Neo.ai.daemons.services.CadenceEngine',
+        /**
+         * @member {Boolean} singleton=true
+         * @protected
+         */
+        singleton: true
+    }
+
+    /**
+     * @summary Parses daemon interval env vars while preserving `0` as disabled.
+     *
+     * @param {String|undefined} value Environment value.
+     * @param {Number} fallback Fallback interval in milliseconds.
+     * @returns {Number}
+     */
+    parseInterval(value, fallback) {
+        if (value === undefined || value === null || value === '') {
+            return fallback;
+        }
+
+        const parsed = parseInt(value, 10);
+        if (Number.isNaN(parsed)) {
+            return fallback;
+        }
+
+        return Math.max(parsed, 0);
+    }
+
+    /**
+     * @summary Returns true when an interval task is due and not disabled.
+     *
+     * @param {Object} options
+     * @param {Number} options.now Current timestamp in milliseconds.
+     * @param {Number} options.lastRunAt Last start timestamp in milliseconds.
+     * @param {Number} options.intervalMs Interval in milliseconds; `0` disables.
+     * @returns {Boolean}
+     */
+    shouldRunIntervalTask({now, lastRunAt, intervalMs}) {
+        return intervalMs > 0 && now - lastRunAt >= intervalMs;
+    }
+}
+
+export default Neo.setupClass(CadenceEngine);

--- a/ai/daemons/services/CadenceEngine.mjs
+++ b/ai/daemons/services/CadenceEngine.mjs
@@ -1,4 +1,3 @@
-import Neo  from '../../../src/Neo.mjs';
 import Base from '../../../src/core/Base.mjs';
 
 /**

--- a/ai/scripts/orchestrator-daemon.mjs
+++ b/ai/scripts/orchestrator-daemon.mjs
@@ -28,8 +28,7 @@ import {execSync} from 'child_process';
 import Orchestrator, {
     DEFAULT_KB_SYNC_INTERVAL_MS,
     DEFAULT_POLL_INTERVAL_MS,
-    DEFAULT_SUMMARY_SWEEP_INTERVAL_MS,
-    parseInterval
+    DEFAULT_SUMMARY_SWEEP_INTERVAL_MS
 } from '../daemons/Orchestrator.mjs';
 
 const DAEMON_DATA_DIR = process.env.NEO_AI_ORCHESTRATOR_DIR || '.neo-ai-data/orchestrator-daemon';
@@ -153,6 +152,5 @@ if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) 
 export {
     DEFAULT_KB_SYNC_INTERVAL_MS,
     DEFAULT_POLL_INTERVAL_MS,
-    DEFAULT_SUMMARY_SWEEP_INTERVAL_MS,
-    parseInterval
+    DEFAULT_SUMMARY_SWEEP_INTERVAL_MS
 };

--- a/test/playwright/unit/ai/daemons/services/CadenceEngine.spec.mjs
+++ b/test/playwright/unit/ai/daemons/services/CadenceEngine.spec.mjs
@@ -1,7 +1,8 @@
 import {test, expect} from '@playwright/test';
-import Neo            from '../../../../../../src/Neo.mjs';
-import * as core      from '../../../../../../src/core/_export.mjs';
-import CadenceEngine  from '../../../../../../ai/daemons/services/CadenceEngine.mjs';
+import Neo             from '../../../../../../src/Neo.mjs';
+import * as core       from '../../../../../../src/core/_export.mjs';
+import InstanceManager from '../../../../../../src/manager/Instance.mjs';
+import CadenceEngine   from '../../../../../../ai/daemons/services/CadenceEngine.mjs';
 
 test.describe('Neo.ai.daemons.services.CadenceEngine (#11051)', () => {
     test('parseInterval() returns fallback for undefined/null/empty', () => {

--- a/test/playwright/unit/ai/daemons/services/CadenceEngine.spec.mjs
+++ b/test/playwright/unit/ai/daemons/services/CadenceEngine.spec.mjs
@@ -24,10 +24,10 @@ test.describe('Neo.ai.daemons.services.CadenceEngine (#11051)', () => {
     test('shouldRunIntervalTask() correctly evaluates due tasks', () => {
         // Disabled
         expect(CadenceEngine.shouldRunIntervalTask({now: 1000, lastRunAt: 0, intervalMs: 0})).toBe(false);
-        
+
         // Not due
         expect(CadenceEngine.shouldRunIntervalTask({now: 1000, lastRunAt: 500, intervalMs: 1000})).toBe(false);
-        
+
         // Exactly due
         expect(CadenceEngine.shouldRunIntervalTask({now: 1500, lastRunAt: 500, intervalMs: 1000})).toBe(true);
 

--- a/test/playwright/unit/ai/daemons/services/CadenceEngine.spec.mjs
+++ b/test/playwright/unit/ai/daemons/services/CadenceEngine.spec.mjs
@@ -1,0 +1,36 @@
+import {test, expect} from '@playwright/test';
+import Neo            from '../../../../../../src/Neo.mjs';
+import * as core      from '../../../../../../src/core/_export.mjs';
+import CadenceEngine  from '../../../../../../ai/daemons/services/CadenceEngine.mjs';
+
+test.describe('Neo.ai.daemons.services.CadenceEngine (#11051)', () => {
+    test('parseInterval() returns fallback for undefined/null/empty', () => {
+        expect(CadenceEngine.parseInterval(undefined, 3000)).toBe(3000);
+        expect(CadenceEngine.parseInterval(null, 3000)).toBe(3000);
+        expect(CadenceEngine.parseInterval('', 3000)).toBe(3000);
+    });
+
+    test('parseInterval() parses valid numbers and prevents negative intervals', () => {
+        expect(CadenceEngine.parseInterval('5000', 3000)).toBe(5000);
+        expect(CadenceEngine.parseInterval('0', 3000)).toBe(0);
+        expect(CadenceEngine.parseInterval('-5000', 3000)).toBe(0);
+    });
+
+    test('parseInterval() returns fallback for NaN', () => {
+        expect(CadenceEngine.parseInterval('not-a-number', 3000)).toBe(3000);
+    });
+
+    test('shouldRunIntervalTask() correctly evaluates due tasks', () => {
+        // Disabled
+        expect(CadenceEngine.shouldRunIntervalTask({now: 1000, lastRunAt: 0, intervalMs: 0})).toBe(false);
+        
+        // Not due
+        expect(CadenceEngine.shouldRunIntervalTask({now: 1000, lastRunAt: 500, intervalMs: 1000})).toBe(false);
+        
+        // Exactly due
+        expect(CadenceEngine.shouldRunIntervalTask({now: 1500, lastRunAt: 500, intervalMs: 1000})).toBe(true);
+
+        // Overdue
+        expect(CadenceEngine.shouldRunIntervalTask({now: 2000, lastRunAt: 500, intervalMs: 1000})).toBe(true);
+    });
+});

--- a/test/playwright/unit/ai/scripts/orchestrator-daemon.spec.mjs
+++ b/test/playwright/unit/ai/scripts/orchestrator-daemon.spec.mjs
@@ -4,43 +4,14 @@ import path from 'path';
 import {
     DEFAULT_KB_SYNC_INTERVAL_MS,
     DEFAULT_POLL_INTERVAL_MS,
-    DEFAULT_SUMMARY_SWEEP_INTERVAL_MS,
-    parseInterval
+    DEFAULT_SUMMARY_SWEEP_INTERVAL_MS
 } from '../../../../../ai/scripts/orchestrator-daemon.mjs';
 import {
-    buildTaskDefinitions,
-    shouldRunIntervalTask
+    buildTaskDefinitions
 } from '../../../../../ai/daemons/Orchestrator.mjs';
 
 test.describe('ai/scripts/orchestrator-daemon.mjs (#11006/#11009)', () => {
-    test('parses interval env values while preserving zero as disabled', () => {
-        expect(parseInterval(undefined, DEFAULT_POLL_INTERVAL_MS)).toBe(DEFAULT_POLL_INTERVAL_MS);
-        expect(parseInterval('', DEFAULT_SUMMARY_SWEEP_INTERVAL_MS)).toBe(DEFAULT_SUMMARY_SWEEP_INTERVAL_MS);
-        expect(parseInterval('0', DEFAULT_KB_SYNC_INTERVAL_MS)).toBe(0);
-        expect(parseInterval('-10', DEFAULT_KB_SYNC_INTERVAL_MS)).toBe(0);
-        expect(parseInterval('900000', DEFAULT_KB_SYNC_INTERVAL_MS)).toBe(900000);
-        expect(parseInterval('not-a-number', DEFAULT_KB_SYNC_INTERVAL_MS)).toBe(DEFAULT_KB_SYNC_INTERVAL_MS);
-    });
 
-    test('does not schedule disabled or not-yet-due interval tasks', () => {
-        expect(shouldRunIntervalTask({
-            now       : 1000,
-            lastRunAt : 0,
-            intervalMs: 0
-        })).toBe(false);
-
-        expect(shouldRunIntervalTask({
-            now       : 599999,
-            lastRunAt : 0,
-            intervalMs: 600000
-        })).toBe(false);
-
-        expect(shouldRunIntervalTask({
-            now       : 600000,
-            lastRunAt : 0,
-            intervalMs: 600000
-        })).toBe(true);
-    });
 
     test('builds task commands around existing manual maintenance scripts', () => {
         const scriptDir = path.resolve(process.cwd(), 'ai/scripts');


### PR DESCRIPTION
## Description

Extracts the interval scheduling logic (`parseInterval` and `shouldRunIntervalTask`) from `ai/daemons/Orchestrator.mjs` into a new pure functional service: `ai/daemons/services/CadenceEngine.mjs`.

Fixes #11051.

## Substrate Quality

* Extracted the pure functional components to `CadenceEngine`, eliminating coupling to daemon instance state.
* Injected `CadenceEngine` into the Orchestrator via constructor property.
* Removed redundant legacy exports from `orchestrator-daemon.mjs`.
* Added comprehensive unit testing with 100% path coverage for `CadenceEngine.mjs`.

## Cross-Family Review Mandate

All triad maintainers are requested to review this PR.

@neo-opus-4-7 @neo-gpt
