### PR TITLE
fix(memory-core): stabilize broadcast sentinel permission spec (#10937)

### DIFF
--- a/ai/services/memory-core/GraphService.mjs
+++ b/ai/services/memory-core/GraphService.mjs
@@ -544,13 +544,19 @@ class GraphService extends Base {
         if (!node) {
             return null;
         }
+
+        const
+            nodeId     = node.isRecord ? node.get('id') : node.id,
+            label      = node.isRecord ? node.get('label') : node.label,
+            properties = node.isRecord ? node.get('properties') : node.properties;
+
         return {
-            id              : node.id,
-            type            : node.label,
-            name            : node.properties?.name,
-            description     : node.properties?.description,
-            semanticVectorId: node.properties?.semanticVectorId,
-            state           : node.properties?.state
+            id              : nodeId,
+            type            : label,
+            name            : properties?.name,
+            description     : properties?.description,
+            semanticVectorId: properties?.semanticVectorId,
+            state           : properties?.state
         };
     }
 

--- a/test/playwright/unit/ai/services/memory-core/MailboxService.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/MailboxService.spec.mjs
@@ -100,7 +100,7 @@ test.describe('Neo.ai.services.memory-core.MailboxService', () => {
         // Seed agents
         GraphService.upsertNode({ id: '@alice', type: 'AGENT', name: 'Alice', properties: {} });
         GraphService.upsertNode({ id: '@bob', type: 'AGENT', name: 'Bob', properties: {} });
-        GraphService.upsertNode({ id: 'AGENT:*', type: 'AGENT', name: 'Broadcast', properties: {} });
+        GraphService.upsertNode({ id: 'AGENT:*', type: 'BroadcastSentinel', name: 'Broadcast', properties: {} });
     });
 
     test('addMessage enforces identity and routes correctly', async () => {
@@ -1018,7 +1018,7 @@ test.describe('Neo.ai.services.memory-core.MailboxService — open policy mode (
         GraphService.upsertNode({ id: '@alice', type: 'AGENT', name: 'Alice', properties: {} });
         GraphService.upsertNode({ id: '@bob', type: 'AGENT', name: 'Bob', properties: {} });
         GraphService.upsertNode({ id: '@charlie', type: 'AGENT', name: 'Charlie', properties: {} });
-        GraphService.upsertNode({ id: 'AGENT:*', type: 'AGENT', name: 'Broadcast', properties: {} });
+        GraphService.upsertNode({ id: 'AGENT:*', type: 'BroadcastSentinel', name: 'Broadcast', properties: {} });
     });
 
     test('first-contact DM succeeds without grant or prior history', async () => {
@@ -1279,7 +1279,7 @@ test.describe('Neo.ai.services.memory-core.MailboxService — A2A_TASK (#10338)'
         GraphService.upsertNode({ id: '@alice', type: 'AGENT', name: 'Alice', properties: {} });
         GraphService.upsertNode({ id: '@bob', type: 'AGENT', name: 'Bob', properties: {} });
         GraphService.upsertNode({ id: '@charlie', type: 'AGENT', name: 'Charlie', properties: {} });
-        GraphService.upsertNode({ id: 'AGENT:*', type: 'AGENT', name: 'Broadcast', properties: {} });
+        GraphService.upsertNode({ id: 'AGENT:*', type: 'BroadcastSentinel', name: 'Broadcast', properties: {} });
         
         await RequestContextService.run({ agentIdentityNodeId: '@bob' }, async () => {
             await PermissionService.grantPermission({ to: '@alice', scope: 'CAN_REPLY_TO' });

--- a/test/playwright/unit/ai/services/memory-core/PermissionService.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/PermissionService.spec.mjs
@@ -179,7 +179,6 @@ test.describe('Neo.ai.services.memory-core.PermissionService', () => {
     });
 
     test('grantPermission preserves existing node type and does not overwrite it (resolves #10231)', async () => {
-        test.skip(!!process.env.NEO_TEST_SKIP_CI, 'CI-skip: AGENT:* singleton-data pollution under workers:1 (#10937)');
         // Pre-seed AGENT:* as a BroadcastSentinel
         GraphService.upsertNode({ id: 'AGENT:*', type: 'BroadcastSentinel', name: '*', properties: {} });
 
@@ -189,8 +188,9 @@ test.describe('Neo.ai.services.memory-core.PermissionService', () => {
         });
 
         // Assert type remains 'BroadcastSentinel'
-        const node = GraphService.getNode({ id: 'AGENT:*' });
-        console.log('NODE TYPE IS:', node.type); expect(node.type).toBe('BroadcastSentinel');
+        // A sibling SDK-import path can wrap GraphService methods async inside the same workers:1 process.
+        const node = await GraphService.getNode({ id: 'AGENT:*' });
+        expect(node.type).toBe('BroadcastSentinel');
         
         // Also assert in SQLite
         const rows = GraphService.db.storage.db.prepare('SELECT data FROM Nodes WHERE id = ?').all('AGENT:*');


### PR DESCRIPTION
Resolves #10937

Authored by GPT-5 (Codex Desktop). Session 20a824b0-29d1-4082-ae12-87705ec69c3f.

Stabilizes the PermissionService broadcast sentinel regression under the unit-row `workers:1` substrate. The fix removes the temporary CI skip, aligns MailboxService test seeding with the production `AGENT:*` `BroadcastSentinel` identity, makes `GraphService.getNode()` record-aware after lazy SQLite rehydration, and awaits the `getNode()` assertion because sibling SDK imports can wrap GraphService methods async within the same worker process.

Evidence: L2 (workers:1 Playwright unit reproduction + focused deterministic reruns) -> L2 required (AC1-AC5 unit substrate). No residuals.

## Deltas from ticket

The ticket hypothesis named sibling `AGENT:*` writes as the likely collision. Investigation confirmed MailboxService was seeding `AGENT:*` with `type: AGENT`, but the actual first-attempt flake also required the SDK wrapper path: a sibling import of `ai/services.mjs` can mutate `GraphService.getNode` into an async validated wrapper inside the same `workers:1` process. The test now tolerates sync and wrapped forms, and `GraphService.getNode()` now reads Neo records and plain objects consistently.

## Test Evidence

- Reproduced before fix: `CI=1 npm run test-unit -- test/playwright/unit/ai/services/memory-core/MailboxService.spec.mjs test/playwright/unit/ai/services/memory-core/WriteSideInvariant.spec.mjs test/playwright/unit/ai/services/memory-core/GraphService.spec.mjs test/playwright/unit/ai/services/memory-core/PermissionService.spec.mjs` produced the PermissionService first-attempt flake, then retry pass.
- After fix: same command passed, `78 passed`.
- After fix: five consecutive `CI=1 npm run test-unit -- test/playwright/unit/ai/services/memory-core/PermissionService.spec.mjs` runs passed, `7 passed` each time.
- `git diff --cached --check` passed before commit.

## Post-Merge Validation

- [ ] CI unit row runs without the #10937 `NEO_TEST_SKIP_CI` guard and keeps PermissionService green under `workers:1`.

## Commit

- `b076e81c2` — `fix(memory-core): stabilize broadcast sentinel permission spec (#10937)`