### PR TITLE
feat(ai): extract BackupCoordinatorService as M4 per-task coordinator (#11062)

### DIFF
--- a/ai/daemons/Orchestrator.mjs
+++ b/ai/daemons/Orchestrator.mjs
@@ -11,6 +11,7 @@ import {
     initializeDatabase
 } from '../scripts/bridge-daemon-queries.mjs';
 import SummarizationCoordinatorService from './services/SummarizationCoordinatorService.mjs';
+import BackupCoordinatorService          from './services/BackupCoordinatorService.mjs';
 import TaskStateService                from './services/TaskStateService.mjs';
 import ProcessSupervisorService        from './services/ProcessSupervisorService.mjs';
 import CadenceEngine                   from './services/CadenceEngine.mjs';
@@ -18,6 +19,7 @@ import {
     DEFAULT_POLL_INTERVAL_MS,
     DEFAULT_SUMMARY_SWEEP_INTERVAL_MS,
     DEFAULT_KB_SYNC_INTERVAL_MS,
+    DEFAULT_BACKUP_INTERVAL_MS,
     DEFAULT_DB_PATH,
     DEFAULT_DATA_DIR,
     DEFAULT_SCRIPT_DIR,
@@ -132,6 +134,12 @@ export class Orchestrator extends Base {
          */
         kbSyncIntervalMs_: DEFAULT_KB_SYNC_INTERVAL_MS,
         /**
+         * @member {Number} backupIntervalMs_=86400000
+         * @protected
+         * @reactive
+         */
+        backupIntervalMs_: DEFAULT_BACKUP_INTERVAL_MS,
+        /**
          * @member {Object} healthService_=HealthService
          * @protected
          * @reactive
@@ -149,6 +157,12 @@ export class Orchestrator extends Base {
          * @reactive
          */
         summarizationCoordinator_: SummarizationCoordinatorService,
+        /**
+         * @member {Object} backupCoordinator_=BackupCoordinatorService
+         * @protected
+         * @reactive
+         */
+        backupCoordinator_: BackupCoordinatorService,
         /**
          * @member {Function} spawnFn_=spawn
          * @protected
@@ -189,12 +203,14 @@ export class Orchestrator extends Base {
             DEFAULT_SUMMARY_SWEEP_INTERVAL_MS
         );
         this.kbSyncIntervalMs       = options.kbSyncIntervalMs ?? this.cadenceEngine.parseInterval(process.env.NEO_ORCHESTRATOR_KB_SYNC_INTERVAL_MS, DEFAULT_KB_SYNC_INTERVAL_MS);
+        this.backupIntervalMs       = options.backupIntervalMs ?? this.cadenceEngine.parseInterval(process.env.NEO_ORCHESTRATOR_BACKUP_INTERVAL_MS, DEFAULT_BACKUP_INTERVAL_MS);
         this.taskDefinitions        = options.taskDefinitions || buildTaskDefinitions({
             scriptDir,
             nodeBin: options.nodeBin || process.argv[0]
         });
         this.healthService          = options.healthService          || HealthService;
         this.summarizationCoordinator = options.summarizationCoordinator || SummarizationCoordinatorService;
+        this.backupCoordinator      = options.backupCoordinator      || BackupCoordinatorService;
         this.spawnFn                = options.spawnFn                || spawn;
         this.processSupervisorService = options.processSupervisorService || ProcessSupervisorService;
         this.initializeDatabaseFn   = options.initializeDatabaseFn   || initializeDatabase;
@@ -306,6 +322,14 @@ export class Orchestrator extends Base {
                 return { reason: `periodic-sync:${this.kbSyncIntervalMs}` };
             }
             return null;
+        }, executeTask, context);
+
+        this.cadenceEngine.runIfDue('backup', () => {
+            return this.backupCoordinator.getDueTask({
+                state           : this.taskStateService.getState(),
+                now,
+                backupIntervalMs: this.backupIntervalMs
+            });
         }, executeTask, context);
 
         if (this.isPolling) {

--- a/ai/daemons/TaskDefinitions.mjs
+++ b/ai/daemons/TaskDefinitions.mjs
@@ -7,6 +7,7 @@ const __dirname  = path.dirname(__filename);
 export const DEFAULT_POLL_INTERVAL_MS          = 3000;
 export const DEFAULT_SUMMARY_SWEEP_INTERVAL_MS = 600000;
 export const DEFAULT_KB_SYNC_INTERVAL_MS       = 1800000;
+export const DEFAULT_BACKUP_INTERVAL_MS        = 86400000;
 
 export const DEFAULT_DB_PATH    = process.env.NEO_AI_DB_PATH || '.neo-ai-data/sqlite/memory-core-graph.sqlite';
 export const DEFAULT_DATA_DIR   = process.env.NEO_AI_ORCHESTRATOR_DIR || '.neo-ai-data/orchestrator-daemon';
@@ -40,6 +41,13 @@ export function buildTaskDefinitions({scriptDir = DEFAULT_SCRIPT_DIR, nodeBin = 
             args           : [path.resolve(scriptDir, '../../buildScripts/ai/syncKnowledgeBase.mjs')],
             pidFileName    : 'kb-sync.pid',
             expectedCommand: 'syncKnowledgeBase.mjs'
+        },
+        backup: {
+            label          : 'memory core backup',
+            command        : nodeBin,
+            args           : [path.resolve(scriptDir, '../../buildScripts/ai/backup.mjs')],
+            pidFileName    : 'backup.pid',
+            expectedCommand: 'backup.mjs'
         }
     };
 }

--- a/ai/daemons/services/BackupCoordinatorService.mjs
+++ b/ai/daemons/services/BackupCoordinatorService.mjs
@@ -1,0 +1,67 @@
+// Neo + core/_export bootstrap belongs to the orchestrator-daemon entry point
+import Base from '../../../src/core/Base.mjs';
+
+/**
+ * @summary Builds the task trigger for the backup periodic sweep.
+ *
+ * Keeping this projection pure lets the orchestrator test the scheduling contract
+ * without side-effects.
+ *
+ * @param {Object} options
+ * @param {Number} options.now        Current timestamp in milliseconds.
+ * @param {Number} options.lastRunAt  Last backup task start timestamp.
+ * @param {Number} options.intervalMs Periodic backup interval; `0` disables it.
+ * @returns {Object|null} A backup task trigger or null when no work is due.
+ */
+export function buildBackupTrigger({now, lastRunAt, intervalMs}) {
+    if (intervalMs > 0 && now - lastRunAt >= intervalMs) {
+        return {
+            taskName: 'backup',
+            source  : 'periodic-sweep',
+            reason  : `periodic-sweep:${intervalMs}`
+        };
+    }
+
+    return null;
+}
+
+/**
+ * @summary Coordinates the backup sweep trigger for the orchestrator.
+ *
+ * @class Neo.ai.daemons.services.BackupCoordinatorService
+ * @extends Neo.core.Base
+ * @singleton
+ * @see ai/daemons/Orchestrator.mjs
+ */
+class BackupCoordinatorService extends Base {
+    static config = {
+        /**
+         * @member {String} className='Neo.ai.daemons.services.BackupCoordinatorService'
+         * @protected
+         */
+        className: 'Neo.ai.daemons.services.BackupCoordinatorService',
+        /**
+         * @member {Boolean} singleton=true
+         * @protected
+         */
+        singleton: true
+    }
+
+    /**
+     * Resolves the next backup task trigger.
+     * @param {Object} options
+     * @param {Object} options.state Current orchestrator task state.
+     * @param {Number} options.now Current timestamp in milliseconds.
+     * @param {Number} options.backupIntervalMs Periodic backup interval.
+     * @returns {Object|null} Task trigger.
+     */
+    getDueTask({state, now, backupIntervalMs}) {
+        return buildBackupTrigger({
+            now,
+            intervalMs: backupIntervalMs,
+            lastRunAt : state.backup?.lastRunAt || 0
+        });
+    }
+}
+
+export default Neo.setupClass(BackupCoordinatorService);

--- a/buildScripts/ai/backup.mjs
+++ b/buildScripts/ai/backup.mjs
@@ -46,17 +46,13 @@ const execFileAsync = promisify(execFile);
  * All service calls route through `ai/services.mjs`, which applies Zod validation at the
  * SDK boundary via `makeSafe()` — no direct `ai/mcp/server/...` imports.
  *
- * ## Retention Policy (TODO)
+ * ## Retention Policy
  *
- * Semantics to mirror `defragChromaDB.cleanOldBackups` but applied to the unified bundle tree:
+ * Semantics mirror `defragChromaDB.cleanOldBackups` but applied to the unified bundle tree:
  * - Keep the newest `K` bundles unconditionally (default `K = 3`)
- * - Delete additional bundles older than `N` days (default `N = 7`)
+ * - Delete additional bundles older than `N` days (default `N = 30`)
  * - Sweep runs at the directory level on `.neo-ai-data/backups/` — one timestamp = one decision
  *   (no more correlating JSONL filenames across roots)
- *
- * **Not implemented in this commit** — the substrate is now in place, but the sweep itself
- * is a follow-up once operator habits around `npm run ai:backup` have stabilized and we
- * know the realistic cadence. Until then: manual pruning is fine, bundles are cheap to keep.
  *
  * ## Legacy Backup Migration
  *
@@ -332,7 +328,7 @@ async function buildVersionDescriptor(projectRoot, logger) {
 /**
  * Applies retention policy to the backup root.
  * Keeps the newest K=3 bundles unconditionally.
- * Deletes older bundles if they are older than N=7 days.
+ * Deletes older bundles if they are older than N=30 days.
  * @param {String} backupRoot
  * @param {Object} logger
  */
@@ -365,7 +361,7 @@ async function cleanOldBackups(backupRoot, logger) {
     backups.sort((a, b) => b.time - a.time);
 
     const K = 3;
-    const N_DAYS = 7;
+    const N_DAYS = 30;
     const now = Date.now();
     const thresholdMs = N_DAYS * 24 * 60 * 60 * 1000;
 

--- a/test/playwright/unit/ai/daemons/Orchestrator.spec.mjs
+++ b/test/playwright/unit/ai/daemons/Orchestrator.spec.mjs
@@ -8,6 +8,7 @@ import {
     DEFAULT_POLL_INTERVAL_MS,
     DEFAULT_SUMMARY_SWEEP_INTERVAL_MS,
     DEFAULT_KB_SYNC_INTERVAL_MS,
+    DEFAULT_BACKUP_INTERVAL_MS,
     buildTaskDefinitions
 } from '../../../../../ai/daemons/TaskDefinitions.mjs';
 import TaskStateService, { createInitialTaskState } from '../../../../../ai/daemons/services/TaskStateService.mjs';
@@ -33,8 +34,10 @@ function createTestOrchestrator(config = {}) {
         taskStateService_       : TaskStateService,
         summarySweepIntervalMs  : config.summarySweepIntervalMs ?? 600000,
         kbSyncIntervalMs        : config.kbSyncIntervalMs ?? 600000,
+        backupIntervalMs        : config.backupIntervalMs ?? 86400000,
         healthService           : config.healthService || {recordTaskOutcome() {}},
         summarizationCoordinator: config.summarizationCoordinator || {getDueTask: () => null},
+        backupCoordinator       : config.backupCoordinator || {getDueTask: () => null},
         spawnFn                 : config.spawnFn || (() => { throw new Error('spawnFn not expected'); })
     });
 
@@ -51,7 +54,7 @@ test.describe('Neo.ai.daemons.Orchestrator (#11009)', () => {
             nodeBin  : '/node'
         }));
 
-        expect(Object.keys(state)).toEqual(['summary', 'kbSync']);
+        expect(Object.keys(state)).toEqual(['summary', 'kbSync', 'backup']);
         expect(state.summary).toMatchObject({
             running      : false,
             pid          : null,
@@ -102,6 +105,46 @@ test.describe('Neo.ai.daemons.Orchestrator (#11009)', () => {
             taskName: 'kbSync',
             reason  : 'periodic-sync:600000'
         }]);
+    });
+
+    test('isolates backup scheduling failure and still schedules other tasks', () => {
+        const outcomes = [];
+        const started  = [];
+
+        const orchestrator = createTestOrchestrator({
+            healthService: {
+                recordTaskOutcome(taskName, status, details) {
+                    outcomes.push({taskName, status, details});
+                }
+            },
+            backupCoordinator: {
+                getDueTask() {
+                    throw new Error('backup logic failed');
+                }
+            }
+        });
+
+        orchestrator.processSupervisorService = {
+            runTask(taskName, reason) {
+                started.push({taskName, reason});
+                return true;
+            }
+        };
+
+        orchestrator.poll();
+
+        expect(outcomes).toContainEqual({
+            taskName: 'backup',
+            status  : 'failed',
+            details : {
+                phase: 'schedule',
+                error: 'backup logic failed'
+            }
+        });
+        expect(started).toContainEqual({
+            taskName: 'kbSync',
+            reason  : 'periodic-sync:600000'
+        });
     });
 
 });

--- a/test/playwright/unit/ai/daemons/services/BackupCoordinatorService.spec.mjs
+++ b/test/playwright/unit/ai/daemons/services/BackupCoordinatorService.spec.mjs
@@ -1,0 +1,34 @@
+import {test, expect} from '@playwright/test';
+import Neo       from '../../../../../../src/Neo.mjs';
+import * as core from '../../../../../../src/core/_export.mjs';
+import {
+    buildBackupTrigger
+} from '../../../../../../ai/daemons/services/BackupCoordinatorService.mjs';
+
+test.describe('BackupCoordinatorService (#11062)', () => {
+    test('returns a periodic sweep trigger only when the interval is due', () => {
+        expect(buildBackupTrigger({
+            now       : 86399999,
+            lastRunAt : 0,
+            intervalMs: 86400000
+        })).toBeNull();
+
+        expect(buildBackupTrigger({
+            now       : 86400000,
+            lastRunAt : 0,
+            intervalMs: 86400000
+        })).toEqual({
+            taskName: 'backup',
+            source  : 'periodic-sweep',
+            reason  : 'periodic-sweep:86400000'
+        });
+    });
+
+    test('does not schedule disabled periodic sweeps', () => {
+        expect(buildBackupTrigger({
+            now       : 86400000,
+            lastRunAt : 0,
+            intervalMs: 0
+        })).toBeNull();
+    });
+});

--- a/test/playwright/unit/ai/scripts/orchestrator-daemon.spec.mjs
+++ b/test/playwright/unit/ai/scripts/orchestrator-daemon.spec.mjs
@@ -24,6 +24,10 @@ test.describe('ai/scripts/orchestrator-daemon.mjs (#11006/#11009)', () => {
         expect(tasks.kbSync.command).toBe('/test/node');
         expect(tasks.kbSync.args).toEqual([path.resolve(scriptDir, '../../buildScripts/ai/syncKnowledgeBase.mjs')]);
         expect(tasks.kbSync.expectedCommand).toBe('syncKnowledgeBase.mjs');
+
+        expect(tasks.backup.command).toBe('/test/node');
+        expect(tasks.backup.args).toEqual([path.resolve(scriptDir, '../../buildScripts/ai/backup.mjs')]);
+        expect(tasks.backup.expectedCommand).toBe('backup.mjs');
     });
 
     test('keeps bridge-daemon wake-only and routes maintenance ownership to the daemon class', () => {
@@ -44,11 +48,14 @@ test.describe('ai/scripts/orchestrator-daemon.mjs (#11006/#11009)', () => {
         expect(orchestratorSource).not.toContain('runMaintenanceCycle');
         expect(orchestratorSource).not.toContain('summarize-sessions.mjs');
         expect(orchestratorSource).not.toContain('syncKnowledgeBase.mjs');
+        expect(orchestratorSource).not.toContain('backup.mjs');
 
         expect(daemonSource).not.toContain('summarize-sessions.mjs');
         expect(daemonSource).not.toContain('syncKnowledgeBase.mjs');
+        expect(daemonSource).not.toContain('backup.mjs');
 
         expect(taskDefSource).toContain('summarize-sessions.mjs');
         expect(taskDefSource).toContain('syncKnowledgeBase.mjs');
+        expect(taskDefSource).toContain('backup.mjs');
     });
 });


### PR DESCRIPTION
Resolves #11062

### Scope Note
This PR implements the `BackupCoordinatorService` per the M4 per-task coordinator architecture. It correctly follows the `runIfDue` CadenceEngine pattern merged in Sub-4 (#11064). 

It also applies the required retention sweep logic (30-day cap) to `buildScripts/ai/backup.mjs` (fulfilling AC5).

### Architecture Alignment
Matches the established D3.1 single-responsibility boundary:
- **Service (`BackupCoordinatorService`):** Pure functional logic yielding the trigger.
- **Harness (`CadenceEngine.runIfDue`):** Controls failure isolation and periodic execution.
- **State (`TaskStateService`):** Persists the backup timestamp.
- **Execution (`ProcessSupervisorService`):** Spawns the task child process safely.

### Testing
- `BackupCoordinatorService.spec.mjs`
- `Orchestrator.spec.mjs`
- `orchestrator-daemon.spec.mjs`

### 🤖 Agent Evidence Declaration
**Agent:** @neo-gemini-3-1-pro 
**Rule Adherence:**
- **§0 Invariants:** Commit includes ticket ID, no noreply footer, branch created.
- **Graph Alignment:** Closes out the M4 keystone Backup coordinator ticket.
- **Cross-Family Review:** Requesting Claude Code (@neo-opus-4-7) for PR review per §6.1.
