### PR TITLE
fix(ai): restore missing path import and default script resolution in Orchestrator daemon (#11080)

### DIFF
--- a/ai/daemons/DreamService.mjs
+++ b/ai/daemons/DreamService.mjs
@@ -85,11 +85,6 @@ class DreamService extends Base {
             logger.info('[Startup] DreamService: Checking for undigested session memories...');
             this.processUndigestedSessions().catch(e => logger.error('[Startup] DreamService failed:', e));
         }
-
-        if (aiConfig.data.autoGoldenPath) {
-            logger.info('[Startup] DreamService: Synthesizing Golden Path into handoff file...');
-            this.synthesizeGoldenPath().catch(e => logger.error('[Startup] Golden Path generation failed:', e));
-        }
     }
 
     /**
@@ -97,40 +92,40 @@ class DreamService extends Base {
      * @returns {Promise<Object[]>} List of metadata objects for undigested sessions
      */
     async findUndigestedSessions() {
-        // Since ChromaDB filtering on missing attributes can be tricky depending on version,
-        // we'll fetch recent sessions and filter in memory if the dataset is reasonable.
-        // For production, we will just query specifically.
-        const limit = aiConfig.summarizationBatchLimit || 2000;
-        const maxToProcess = aiConfig.remSleepBatchLimit || 10;
+            // Since ChromaDB filtering on missing attributes can be tricky depending on version,
+            // we'll fetch recent sessions and filter in memory if the dataset is reasonable.
+            // For production, we will just query specifically.
+            const limit = aiConfig.summarizationBatchLimit || 2000;
+            const maxToProcess = aiConfig.remSleepBatchLimit || 10;
 
-        try {
-            const batch = await this.sessionsCollection.get({
-                include: ['metadatas', 'documents'],
-                limit
-            });
+            try {
+                const batch = await this.sessionsCollection.get({
+                    include: ['metadatas', 'documents'],
+                    limit
+                });
 
-            if (!batch || !batch.ids.length) {
+                if (!batch || !batch.ids.length) {
+                    return [];
+                }
+
+                const undigested = [];
+                for (let i = 0; i < batch.ids.length; i++) {
+                    const meta = batch.metadatas[i];
+                    if (meta && meta.graphDigested !== true && meta.graphDigested !== 'true') {
+                        undigested.push({
+                            id: batch.ids[i],
+                            document: batch.documents[i],
+                            meta
+                        });
+                    }
+                }
+
+                return undigested.slice(0, maxToProcess);
+            } catch (error) {
+                logger.error('[DreamService] Error querying undigested sessions:', error);
                 return [];
             }
-
-            const undigested = [];
-            for (let i = 0; i < batch.ids.length; i++) {
-                const meta = batch.metadatas[i];
-                if (meta && meta.graphDigested !== true && meta.graphDigested !== 'true') {
-                    undigested.push({
-                        id: batch.ids[i],
-                        document: batch.documents[i],
-                        meta
-                    });
-                }
-            }
-
-            return undigested.slice(0, maxToProcess);
-        } catch (error) {
-            logger.error('[DreamService] Error querying undigested sessions:', error);
-            return [];
         }
-    }
 
     /**
      * @summary Runs the REM digest pipeline for sessions that are not yet marked graph-digested.
@@ -143,126 +138,123 @@ class DreamService extends Base {
      * instead of hiding missing nodes behind a completed digest flag.
      */
     async processUndigestedSessions() {
-        if (this.isProcessing) {
-            logger.debug('[DreamService] REM pipeline is already running. Skipping trigger.');
-            return;
-        }
-
-        this.isProcessing = true;
-
-        if (aiConfig.modelProvider === 'openAiCompatible') {
-            try {
-                const url = new URL('/v1/models', aiConfig.openAiCompatible.host || 'http://127.0.0.1:8000');
-                const ping = await fetch(url.toString(), { method: 'GET', signal: AbortSignal.timeout(5000) });
-                if (!ping.ok) throw new Error('API provider not running');
-            } catch (e) {
-                logger.error('[DreamService] API provider service is unreachable. Aborting REM pipeline to prevent queue failures.');
-                this.isProcessing = false;
+            if (this.isProcessing) {
+                logger.debug('[DreamService] REM pipeline is already running. Skipping trigger.');
                 return;
             }
-        }
 
-        try {
-            const sessions = await this.findUndigestedSessions();
-            if (sessions.length === 0) {
-                logger.info('[DreamService] No undigested session memories found. Proceeding to ambient task execution.');
-            } else {
-                logger.info(`[DreamService] Found ${sessions.length} undigested session(s). Beginning REM pipeline...`);
+            this.isProcessing = true;
 
-                // Phase 0: Ingest the version-controlled Concept Ontology (.neo-ai-data/concepts/*.jsonl)
-                // into the Native Edge Graph as first-class CONCEPT nodes + typed edges. Runs BEFORE
-                // FileSystemIngestor so downstream gap inference can traverse concept-graph relationships
-                // deterministically instead of regex-matching token lists against file paths.
-                await ConceptIngestor.syncConceptsToGraph();
-
-                // Phase 1: Ingest Live Workspace Files for Gap Analysis context mapping
-                await FileSystemIngestor.syncWorkspaceToGraph();
-
-                for (const session of sessions) {
-                    logger.info(`[DreamService] Preparing session ${session.meta.sessionId} ("${session.meta.title}") for REM extraction.`);
-
-                    let rawEpisodicMemory = session.document;
-                    try {
-                        const memoryCollection = await StorageRouter.getMemoryCollection();
-                        if (memoryCollection) {
-                            const rawMemories = await memoryCollection.get({
-                                where: { sessionId: session.meta.sessionId },
-                                include: ['documents']
-                            });
-                            if (rawMemories?.documents?.length > 0) {
-                                // Send the full raw memory to the LLM. Lossless context tracking is required.
-                                // If local APIs crash, it is a configuration issue with n_ctx, not a client logic error.
-                                rawEpisodicMemory = rawMemories.documents.join('\n\n---\n\n');
-                            }
-                        }
-                    } catch (e) {
-                        logger.warn(`[DreamService] Could not fetch raw memories for ${session.meta.sessionId}`, e);
-                    }
-
-                    session.document = rawEpisodicMemory;
-                    logger.info(`[DreamService]   -> Payload size (chars): ${session.document.length}`);
-
-                    // Phase 2a: Memory/Session graph ingestion — runs BEFORE SemanticGraphExtractor
-                    // so future provenance edges (#10152) from extracted entities attach to real
-                    // MEMORY/SESSION nodes rather than dangling at `sessionId` scalars. Deterministic
-                    // Chroma-ID → graph-node mapping; no LLM cost, idempotent via payloadHash.
-                    const ingestStart = Date.now();
-                    const ingestStats = await MemorySessionIngestor.syncSessionToGraph(session);
-                    const ingestErrors = ingestStats.errors?.length ?? 0;
-                    const ingestTime = ((Date.now() - ingestStart) / 1000).toFixed(1);
-                    logger.info(`[DreamService]   -> Memory/Session graph ingestion took: ${ingestTime}s (${ingestStats.memoriesUpserted} upserted, ${ingestStats.memoriesSkipped} skipped, ${ingestErrors} errors)`);
-
-                    if (ingestErrors > 0) {
-                        logger.warn(`[DreamService] Session ${session.meta.sessionId} had ${ingestErrors} memory-ingestion error(s); graphDigested will NOT be set this cycle.`);
-                    }
-
-                    const startTime = Date.now();
-                    const success = await SemanticGraphExtractor.executeTriVectorExtraction(session);
-                    const triVectorTime = ((Date.now() - startTime) / 1000).toFixed(1);
-                    logger.info(`[DreamService]   -> Tri-Vector Synthesis took: ${triVectorTime}s`);
-
-                    const topoStart = Date.now();
-                    await TopologyInferenceEngine.extractTopology(session.document, session.meta.sessionId);
-                    const topoTime = ((Date.now() - topoStart) / 1000).toFixed(1);
-                    logger.info(`[DreamService]   -> Topological Conflicts took: ${topoTime}s`);
-
-                    const capStart = Date.now();
-                    await this.inferTestGapsFromSession(success);
-                    const capTime = ((Date.now() - capStart) / 1000).toFixed(1);
-                    logger.info(`[DreamService]   -> Session TEST_GAP Inference took: ${capTime}s`);
-
-                    logger.info(`[DreamService] Total Session Digest Time: ${((Date.now() - startTime) / 1000).toFixed(1)}s`);
-
-                    if (success && ingestErrors === 0) {
-                        await this.sessionsCollection.update({
-                            ids: [session.id],
-                            metadatas: [{ ...session.meta, graphDigested: true }]
-                        });
-                        logger.info(`[DreamService] Session ${session.meta.sessionId} marked as graphDigested in Memory Core.`);
-                    }
+            if (aiConfig.modelProvider === 'openAiCompatible') {
+                try {
+                    const url = new URL('/v1/models', aiConfig.openAiCompatible.host || 'http://127.0.0.1:8000');
+                    const ping = await fetch(url.toString(), { method: 'GET', signal: AbortSignal.timeout(5000) });
+                    if (!ping.ok) throw new Error('API provider not running');
+                } catch (e) {
+                    logger.error('[DreamService] API provider service is unreachable. Aborting REM pipeline to prevent queue failures.');
+                    this.isProcessing = false;
+                    return;
                 }
-
-                // Hoisted from the per-session loop (#10085): concept-graph gap inference is
-                // ontology-scoped — same output every invocation within a single REM cycle — so
-                // running it once after the session loop replaces N redundant traversals.
-                const conceptGapStart = Date.now();
-                await this.inferConceptGraphGaps();
-                logger.info(`[DreamService] Cycle-scope GUIDE_GAP / EXAMPLE_GAP Inference took: ${((Date.now() - conceptGapStart) / 1000).toFixed(1)}s`);
             }
 
-            // Universal Fade (Garbage Collection)
-            await this.runGarbageCollection();
+            try {
+                const sessions = await this.findUndigestedSessions();
+                if (sessions.length === 0) {
+                    logger.info('[DreamService] No undigested session memories found. Proceeding to ambient task execution.');
+                } else {
+                    logger.info(`[DreamService] Found ${sessions.length} undigested session(s). Beginning REM pipeline...`);
 
-            // After extraction pipeline and decay are done, synthesize strategic roadmap
-            await this.synthesizeGoldenPath();
+                    // Phase 0: Ingest the version-controlled Concept Ontology (.neo-ai-data/concepts/*.jsonl)
+                    // into the Native Edge Graph as first-class CONCEPT nodes + typed edges. Runs BEFORE
+                    // FileSystemIngestor so downstream gap inference can traverse concept-graph relationships
+                    // deterministically instead of regex-matching token lists against file paths.
+                    await ConceptIngestor.syncConceptsToGraph();
 
-            logger.info('[DreamService] REM pipeline completed.');
-        } catch (error) {
-            logger.error('[DreamService] Failed to process undigested sessions:', error);
-        } finally {
-            this.isProcessing = false;
+                    // Phase 1: Ingest Live Workspace Files for Gap Analysis context mapping
+                    await FileSystemIngestor.syncWorkspaceToGraph();
+
+                    for (const session of sessions) {
+                        logger.info(`[DreamService] Preparing session ${session.meta.sessionId} ("${session.meta.title}") for REM extraction.`);
+
+                        let rawEpisodicMemory = session.document;
+                        try {
+                            const memoryCollection = await StorageRouter.getMemoryCollection();
+                            if (memoryCollection) {
+                                const rawMemories = await memoryCollection.get({
+                                    where: { sessionId: session.meta.sessionId },
+                                    include: ['documents']
+                                });
+                                if (rawMemories?.documents?.length > 0) {
+                                    // Send the full raw memory to the LLM. Lossless context tracking is required.
+                                    // If local APIs crash, it is a configuration issue with n_ctx, not a client logic error.
+                                    rawEpisodicMemory = rawMemories.documents.join('\n\n---\n\n');
+                                }
+                            }
+                        } catch (e) {
+                            logger.warn(`[DreamService] Could not fetch raw memories for ${session.meta.sessionId}`, e);
+                        }
+
+                        session.document = rawEpisodicMemory;
+                        logger.info(`[DreamService]   -> Payload size (chars): ${session.document.length}`);
+
+                        // Phase 2a: Memory/Session graph ingestion — runs BEFORE SemanticGraphExtractor
+                        // so future provenance edges (#10152) from extracted entities attach to real
+                        // MEMORY/SESSION nodes rather than dangling at `sessionId` scalars. Deterministic
+                        // Chroma-ID → graph-node mapping; no LLM cost, idempotent via payloadHash.
+                        const ingestStart = Date.now();
+                        const ingestStats = await MemorySessionIngestor.syncSessionToGraph(session);
+                        const ingestErrors = ingestStats.errors?.length ?? 0;
+                        const ingestTime = ((Date.now() - ingestStart) / 1000).toFixed(1);
+                        logger.info(`[DreamService]   -> Memory/Session graph ingestion took: ${ingestTime}s (${ingestStats.memoriesUpserted} upserted, ${ingestStats.memoriesSkipped} skipped, ${ingestErrors} errors)`);
+
+                        if (ingestErrors > 0) {
+                            logger.warn(`[DreamService] Session ${session.meta.sessionId} had ${ingestErrors} memory-ingestion error(s); graphDigested will NOT be set this cycle.`);
+                        }
+
+                        const startTime = Date.now();
+                        const success = await SemanticGraphExtractor.executeTriVectorExtraction(session);
+                        const triVectorTime = ((Date.now() - startTime) / 1000).toFixed(1);
+                        logger.info(`[DreamService]   -> Tri-Vector Synthesis took: ${triVectorTime}s`);
+
+                        const topoStart = Date.now();
+                        await TopologyInferenceEngine.extractTopology(session.document, session.meta.sessionId);
+                        const topoTime = ((Date.now() - topoStart) / 1000).toFixed(1);
+                        logger.info(`[DreamService]   -> Topological Conflicts took: ${topoTime}s`);
+
+                        const capStart = Date.now();
+                        await this.inferTestGapsFromSession(success);
+                        const capTime = ((Date.now() - capStart) / 1000).toFixed(1);
+                        logger.info(`[DreamService]   -> Session TEST_GAP Inference took: ${capTime}s`);
+
+                        logger.info(`[DreamService] Total Session Digest Time: ${((Date.now() - startTime) / 1000).toFixed(1)}s`);
+
+                        if (success && ingestErrors === 0) {
+                            await this.sessionsCollection.update({
+                                ids: [session.id],
+                                metadatas: [{ ...session.meta, graphDigested: true }]
+                            });
+                            logger.info(`[DreamService] Session ${session.meta.sessionId} marked as graphDigested in Memory Core.`);
+                        }
+                    }
+
+                    // Hoisted from the per-session loop (#10085): concept-graph gap inference is
+                    // ontology-scoped — same output every invocation within a single REM cycle — so
+                    // running it once after the session loop replaces N redundant traversals.
+                    const conceptGapStart = Date.now();
+                    await this.inferConceptGraphGaps();
+                    logger.info(`[DreamService] Cycle-scope GUIDE_GAP / EXAMPLE_GAP Inference took: ${((Date.now() - conceptGapStart) / 1000).toFixed(1)}s`);
+                }
+
+                // Universal Fade (Garbage Collection)
+                await this.runGarbageCollection();
+
+                logger.info('[DreamService] REM pipeline completed.');
+            } catch (error) {
+                logger.error('[DreamService] Failed to process undigested sessions:', error);
+            } finally {
+                this.isProcessing = false;
+            }
         }
-    }
 
     /**
      * Cycle-scoped GUIDE_GAP / EXAMPLE_GAP inference entry point. Delegates to
@@ -272,8 +264,8 @@ class DreamService extends Base {
      * Paired with `inferTestGapsFromSession` (session-scoped). See #10085 for the scope split.
      */
     async inferConceptGraphGaps() {
-        return GapInferenceEngine.inferConceptGraphGaps();
-    }
+            return GapInferenceEngine.inferConceptGraphGaps();
+        }
 
     /**
      * Session-scoped TEST_GAP inference entry point. Delegates to `GapInferenceEngine` for
@@ -283,8 +275,8 @@ class DreamService extends Base {
      * @param {Object} payload The parsed Tri-Vector schema from `SemanticGraphExtractor`
      */
     async inferTestGapsFromSession(payload) {
-        return GapInferenceEngine.inferTestGapsFromSession(payload);
-    }
+            return GapInferenceEngine.inferTestGapsFromSession(payload);
+        }
 
     /**
      * Concept discovery entry point (#10036). Delegates to `ConceptDiscoveryService` to mine
@@ -299,8 +291,8 @@ class DreamService extends Base {
      * @returns {Promise<Object>} `{candidatesAdded, candidates}`
      */
     async runConceptDiscovery() {
-        return ConceptDiscoveryService.runDiscoveryCycle();
-    }
+            return ConceptDiscoveryService.runDiscoveryCycle();
+        }
 
     /**
      * @summary Parses the local file system for markdown files and explicitly syncs their state
@@ -310,40 +302,40 @@ class DreamService extends Base {
      * @returns {Promise<Object[]>} Returns only the OPEN issues for synthesis.
      */
     async ingestIssueStates() {
-        return IssueIngestor.ingestIssueStates();
-    }
+            return IssueIngestor.ingestIssueStates();
+        }
 
     /**
      * Parses the local file system for markdown discussions and syncs their state
      * into the Native Graph database as OPEN items so they can surface mathematically.
      */
     async ingestDiscussionStates() {
-        return IssueIngestor.ingestDiscussionStates();
-    }
+            return IssueIngestor.ingestDiscussionStates();
+        }
 
     /**
      * Parses the local file system for pull request reviews and syncs their embedded
      * gap signals ([KB_GAP], [TOOLING_GAP], [RETROSPECTIVE]) into the Native Graph database.
      */
     async ingestPullRequestFeedback() {
-        return IssueIngestor.ingestPullRequestFeedback();
-    }
+            return IssueIngestor.ingestPullRequestFeedback();
+        }
 
     /**
      * Executes the global "Fade" algorithm across all Native Graph edges,
      * then executes Vector Apoptosis to clean up resulting orphaned nodes from the hybrid semantic space.
      */
     async runGarbageCollection() {
-        return GraphMaintenanceService.runGarbageCollection();
-    }
+            return GraphMaintenanceService.runGarbageCollection();
+        }
 
     /**
      * Synthesizes the Golden Path (strategic priorities) deterministically by analyzing Graph topology
      * combined with Vector Similarity (Hybrid GraphRAG).
      */
     async synthesizeGoldenPath() {
-        return GoldenPathSynthesizer.synthesizeGoldenPath();
+            return GoldenPathSynthesizer.synthesizeGoldenPath();
+        }
     }
-}
 
 export default Neo.setupClass(DreamService);

--- a/ai/daemons/DreamService.mjs
+++ b/ai/daemons/DreamService.mjs
@@ -85,6 +85,11 @@ class DreamService extends Base {
             logger.info('[Startup] DreamService: Checking for undigested session memories...');
             this.processUndigestedSessions().catch(e => logger.error('[Startup] DreamService failed:', e));
         }
+
+        if (aiConfig.data.autoGoldenPath) {
+            logger.info('[Startup] DreamService: Synthesizing Golden Path into handoff file...');
+            this.synthesizeGoldenPath().catch(e => logger.error('[Startup] Golden Path generation failed:', e));
+        }
     }
 
     /**
@@ -92,40 +97,40 @@ class DreamService extends Base {
      * @returns {Promise<Object[]>} List of metadata objects for undigested sessions
      */
     async findUndigestedSessions() {
-            // Since ChromaDB filtering on missing attributes can be tricky depending on version,
-            // we'll fetch recent sessions and filter in memory if the dataset is reasonable.
-            // For production, we will just query specifically.
-            const limit = aiConfig.summarizationBatchLimit || 2000;
-            const maxToProcess = aiConfig.remSleepBatchLimit || 10;
+        // Since ChromaDB filtering on missing attributes can be tricky depending on version,
+        // we'll fetch recent sessions and filter in memory if the dataset is reasonable.
+        // For production, we will just query specifically.
+        const limit = aiConfig.summarizationBatchLimit || 2000;
+        const maxToProcess = aiConfig.remSleepBatchLimit || 10;
 
-            try {
-                const batch = await this.sessionsCollection.get({
-                    include: ['metadatas', 'documents'],
-                    limit
-                });
+        try {
+            const batch = await this.sessionsCollection.get({
+                include: ['metadatas', 'documents'],
+                limit
+            });
 
-                if (!batch || !batch.ids.length) {
-                    return [];
-                }
-
-                const undigested = [];
-                for (let i = 0; i < batch.ids.length; i++) {
-                    const meta = batch.metadatas[i];
-                    if (meta && meta.graphDigested !== true && meta.graphDigested !== 'true') {
-                        undigested.push({
-                            id: batch.ids[i],
-                            document: batch.documents[i],
-                            meta
-                        });
-                    }
-                }
-
-                return undigested.slice(0, maxToProcess);
-            } catch (error) {
-                logger.error('[DreamService] Error querying undigested sessions:', error);
+            if (!batch || !batch.ids.length) {
                 return [];
             }
+
+            const undigested = [];
+            for (let i = 0; i < batch.ids.length; i++) {
+                const meta = batch.metadatas[i];
+                if (meta && meta.graphDigested !== true && meta.graphDigested !== 'true') {
+                    undigested.push({
+                        id: batch.ids[i],
+                        document: batch.documents[i],
+                        meta
+                    });
+                }
+            }
+
+            return undigested.slice(0, maxToProcess);
+        } catch (error) {
+            logger.error('[DreamService] Error querying undigested sessions:', error);
+            return [];
         }
+    }
 
     /**
      * @summary Runs the REM digest pipeline for sessions that are not yet marked graph-digested.
@@ -138,123 +143,126 @@ class DreamService extends Base {
      * instead of hiding missing nodes behind a completed digest flag.
      */
     async processUndigestedSessions() {
-            if (this.isProcessing) {
-                logger.debug('[DreamService] REM pipeline is already running. Skipping trigger.');
+        if (this.isProcessing) {
+            logger.debug('[DreamService] REM pipeline is already running. Skipping trigger.');
+            return;
+        }
+
+        this.isProcessing = true;
+
+        if (aiConfig.modelProvider === 'openAiCompatible') {
+            try {
+                const url = new URL('/v1/models', aiConfig.openAiCompatible.host || 'http://127.0.0.1:8000');
+                const ping = await fetch(url.toString(), { method: 'GET', signal: AbortSignal.timeout(5000) });
+                if (!ping.ok) throw new Error('API provider not running');
+            } catch (e) {
+                logger.error('[DreamService] API provider service is unreachable. Aborting REM pipeline to prevent queue failures.');
+                this.isProcessing = false;
                 return;
             }
+        }
 
-            this.isProcessing = true;
+        try {
+            const sessions = await this.findUndigestedSessions();
+            if (sessions.length === 0) {
+                logger.info('[DreamService] No undigested session memories found. Proceeding to ambient task execution.');
+            } else {
+                logger.info(`[DreamService] Found ${sessions.length} undigested session(s). Beginning REM pipeline...`);
 
-            if (aiConfig.modelProvider === 'openAiCompatible') {
-                try {
-                    const url = new URL('/v1/models', aiConfig.openAiCompatible.host || 'http://127.0.0.1:8000');
-                    const ping = await fetch(url.toString(), { method: 'GET', signal: AbortSignal.timeout(5000) });
-                    if (!ping.ok) throw new Error('API provider not running');
-                } catch (e) {
-                    logger.error('[DreamService] API provider service is unreachable. Aborting REM pipeline to prevent queue failures.');
-                    this.isProcessing = false;
-                    return;
-                }
-            }
+                // Phase 0: Ingest the version-controlled Concept Ontology (.neo-ai-data/concepts/*.jsonl)
+                // into the Native Edge Graph as first-class CONCEPT nodes + typed edges. Runs BEFORE
+                // FileSystemIngestor so downstream gap inference can traverse concept-graph relationships
+                // deterministically instead of regex-matching token lists against file paths.
+                await ConceptIngestor.syncConceptsToGraph();
 
-            try {
-                const sessions = await this.findUndigestedSessions();
-                if (sessions.length === 0) {
-                    logger.info('[DreamService] No undigested session memories found. Proceeding to ambient task execution.');
-                } else {
-                    logger.info(`[DreamService] Found ${sessions.length} undigested session(s). Beginning REM pipeline...`);
+                // Phase 1: Ingest Live Workspace Files for Gap Analysis context mapping
+                await FileSystemIngestor.syncWorkspaceToGraph();
 
-                    // Phase 0: Ingest the version-controlled Concept Ontology (.neo-ai-data/concepts/*.jsonl)
-                    // into the Native Edge Graph as first-class CONCEPT nodes + typed edges. Runs BEFORE
-                    // FileSystemIngestor so downstream gap inference can traverse concept-graph relationships
-                    // deterministically instead of regex-matching token lists against file paths.
-                    await ConceptIngestor.syncConceptsToGraph();
+                for (const session of sessions) {
+                    logger.info(`[DreamService] Preparing session ${session.meta.sessionId} ("${session.meta.title}") for REM extraction.`);
 
-                    // Phase 1: Ingest Live Workspace Files for Gap Analysis context mapping
-                    await FileSystemIngestor.syncWorkspaceToGraph();
-
-                    for (const session of sessions) {
-                        logger.info(`[DreamService] Preparing session ${session.meta.sessionId} ("${session.meta.title}") for REM extraction.`);
-
-                        let rawEpisodicMemory = session.document;
-                        try {
-                            const memoryCollection = await StorageRouter.getMemoryCollection();
-                            if (memoryCollection) {
-                                const rawMemories = await memoryCollection.get({
-                                    where: { sessionId: session.meta.sessionId },
-                                    include: ['documents']
-                                });
-                                if (rawMemories?.documents?.length > 0) {
-                                    // Send the full raw memory to the LLM. Lossless context tracking is required.
-                                    // If local APIs crash, it is a configuration issue with n_ctx, not a client logic error.
-                                    rawEpisodicMemory = rawMemories.documents.join('\n\n---\n\n');
-                                }
-                            }
-                        } catch (e) {
-                            logger.warn(`[DreamService] Could not fetch raw memories for ${session.meta.sessionId}`, e);
-                        }
-
-                        session.document = rawEpisodicMemory;
-                        logger.info(`[DreamService]   -> Payload size (chars): ${session.document.length}`);
-
-                        // Phase 2a: Memory/Session graph ingestion — runs BEFORE SemanticGraphExtractor
-                        // so future provenance edges (#10152) from extracted entities attach to real
-                        // MEMORY/SESSION nodes rather than dangling at `sessionId` scalars. Deterministic
-                        // Chroma-ID → graph-node mapping; no LLM cost, idempotent via payloadHash.
-                        const ingestStart = Date.now();
-                        const ingestStats = await MemorySessionIngestor.syncSessionToGraph(session);
-                        const ingestErrors = ingestStats.errors?.length ?? 0;
-                        const ingestTime = ((Date.now() - ingestStart) / 1000).toFixed(1);
-                        logger.info(`[DreamService]   -> Memory/Session graph ingestion took: ${ingestTime}s (${ingestStats.memoriesUpserted} upserted, ${ingestStats.memoriesSkipped} skipped, ${ingestErrors} errors)`);
-
-                        if (ingestErrors > 0) {
-                            logger.warn(`[DreamService] Session ${session.meta.sessionId} had ${ingestErrors} memory-ingestion error(s); graphDigested will NOT be set this cycle.`);
-                        }
-
-                        const startTime = Date.now();
-                        const success = await SemanticGraphExtractor.executeTriVectorExtraction(session);
-                        const triVectorTime = ((Date.now() - startTime) / 1000).toFixed(1);
-                        logger.info(`[DreamService]   -> Tri-Vector Synthesis took: ${triVectorTime}s`);
-
-                        const topoStart = Date.now();
-                        await TopologyInferenceEngine.extractTopology(session.document, session.meta.sessionId);
-                        const topoTime = ((Date.now() - topoStart) / 1000).toFixed(1);
-                        logger.info(`[DreamService]   -> Topological Conflicts took: ${topoTime}s`);
-
-                        const capStart = Date.now();
-                        await this.inferTestGapsFromSession(success);
-                        const capTime = ((Date.now() - capStart) / 1000).toFixed(1);
-                        logger.info(`[DreamService]   -> Session TEST_GAP Inference took: ${capTime}s`);
-
-                        logger.info(`[DreamService] Total Session Digest Time: ${((Date.now() - startTime) / 1000).toFixed(1)}s`);
-
-                        if (success && ingestErrors === 0) {
-                            await this.sessionsCollection.update({
-                                ids: [session.id],
-                                metadatas: [{ ...session.meta, graphDigested: true }]
+                    let rawEpisodicMemory = session.document;
+                    try {
+                        const memoryCollection = await StorageRouter.getMemoryCollection();
+                        if (memoryCollection) {
+                            const rawMemories = await memoryCollection.get({
+                                where: { sessionId: session.meta.sessionId },
+                                include: ['documents']
                             });
-                            logger.info(`[DreamService] Session ${session.meta.sessionId} marked as graphDigested in Memory Core.`);
+                            if (rawMemories?.documents?.length > 0) {
+                                // Send the full raw memory to the LLM. Lossless context tracking is required.
+                                // If local APIs crash, it is a configuration issue with n_ctx, not a client logic error.
+                                rawEpisodicMemory = rawMemories.documents.join('\n\n---\n\n');
+                            }
                         }
+                    } catch (e) {
+                        logger.warn(`[DreamService] Could not fetch raw memories for ${session.meta.sessionId}`, e);
                     }
 
-                    // Hoisted from the per-session loop (#10085): concept-graph gap inference is
-                    // ontology-scoped — same output every invocation within a single REM cycle — so
-                    // running it once after the session loop replaces N redundant traversals.
-                    const conceptGapStart = Date.now();
-                    await this.inferConceptGraphGaps();
-                    logger.info(`[DreamService] Cycle-scope GUIDE_GAP / EXAMPLE_GAP Inference took: ${((Date.now() - conceptGapStart) / 1000).toFixed(1)}s`);
+                    session.document = rawEpisodicMemory;
+                    logger.info(`[DreamService]   -> Payload size (chars): ${session.document.length}`);
+
+                    // Phase 2a: Memory/Session graph ingestion — runs BEFORE SemanticGraphExtractor
+                    // so future provenance edges (#10152) from extracted entities attach to real
+                    // MEMORY/SESSION nodes rather than dangling at `sessionId` scalars. Deterministic
+                    // Chroma-ID → graph-node mapping; no LLM cost, idempotent via payloadHash.
+                    const ingestStart = Date.now();
+                    const ingestStats = await MemorySessionIngestor.syncSessionToGraph(session);
+                    const ingestErrors = ingestStats.errors?.length ?? 0;
+                    const ingestTime = ((Date.now() - ingestStart) / 1000).toFixed(1);
+                    logger.info(`[DreamService]   -> Memory/Session graph ingestion took: ${ingestTime}s (${ingestStats.memoriesUpserted} upserted, ${ingestStats.memoriesSkipped} skipped, ${ingestErrors} errors)`);
+
+                    if (ingestErrors > 0) {
+                        logger.warn(`[DreamService] Session ${session.meta.sessionId} had ${ingestErrors} memory-ingestion error(s); graphDigested will NOT be set this cycle.`);
+                    }
+
+                    const startTime = Date.now();
+                    const success = await SemanticGraphExtractor.executeTriVectorExtraction(session);
+                    const triVectorTime = ((Date.now() - startTime) / 1000).toFixed(1);
+                    logger.info(`[DreamService]   -> Tri-Vector Synthesis took: ${triVectorTime}s`);
+
+                    const topoStart = Date.now();
+                    await TopologyInferenceEngine.extractTopology(session.document, session.meta.sessionId);
+                    const topoTime = ((Date.now() - topoStart) / 1000).toFixed(1);
+                    logger.info(`[DreamService]   -> Topological Conflicts took: ${topoTime}s`);
+
+                    const capStart = Date.now();
+                    await this.inferTestGapsFromSession(success);
+                    const capTime = ((Date.now() - capStart) / 1000).toFixed(1);
+                    logger.info(`[DreamService]   -> Session TEST_GAP Inference took: ${capTime}s`);
+
+                    logger.info(`[DreamService] Total Session Digest Time: ${((Date.now() - startTime) / 1000).toFixed(1)}s`);
+
+                    if (success && ingestErrors === 0) {
+                        await this.sessionsCollection.update({
+                            ids: [session.id],
+                            metadatas: [{ ...session.meta, graphDigested: true }]
+                        });
+                        logger.info(`[DreamService] Session ${session.meta.sessionId} marked as graphDigested in Memory Core.`);
+                    }
                 }
 
-                // Universal Fade (Garbage Collection)
-                await this.runGarbageCollection();
-
-                logger.info('[DreamService] REM pipeline completed.');
-            } catch (error) {
-                logger.error('[DreamService] Failed to process undigested sessions:', error);
-            } finally {
-                this.isProcessing = false;
+                // Hoisted from the per-session loop (#10085): concept-graph gap inference is
+                // ontology-scoped — same output every invocation within a single REM cycle — so
+                // running it once after the session loop replaces N redundant traversals.
+                const conceptGapStart = Date.now();
+                await this.inferConceptGraphGaps();
+                logger.info(`[DreamService] Cycle-scope GUIDE_GAP / EXAMPLE_GAP Inference took: ${((Date.now() - conceptGapStart) / 1000).toFixed(1)}s`);
             }
+
+            // Universal Fade (Garbage Collection)
+            await this.runGarbageCollection();
+
+            // After extraction pipeline and decay are done, synthesize strategic roadmap
+            await this.synthesizeGoldenPath();
+
+            logger.info('[DreamService] REM pipeline completed.');
+        } catch (error) {
+            logger.error('[DreamService] Failed to process undigested sessions:', error);
+        } finally {
+            this.isProcessing = false;
         }
+    }
 
     /**
      * Cycle-scoped GUIDE_GAP / EXAMPLE_GAP inference entry point. Delegates to
@@ -264,8 +272,8 @@ class DreamService extends Base {
      * Paired with `inferTestGapsFromSession` (session-scoped). See #10085 for the scope split.
      */
     async inferConceptGraphGaps() {
-            return GapInferenceEngine.inferConceptGraphGaps();
-        }
+        return GapInferenceEngine.inferConceptGraphGaps();
+    }
 
     /**
      * Session-scoped TEST_GAP inference entry point. Delegates to `GapInferenceEngine` for
@@ -275,8 +283,8 @@ class DreamService extends Base {
      * @param {Object} payload The parsed Tri-Vector schema from `SemanticGraphExtractor`
      */
     async inferTestGapsFromSession(payload) {
-            return GapInferenceEngine.inferTestGapsFromSession(payload);
-        }
+        return GapInferenceEngine.inferTestGapsFromSession(payload);
+    }
 
     /**
      * Concept discovery entry point (#10036). Delegates to `ConceptDiscoveryService` to mine
@@ -291,8 +299,8 @@ class DreamService extends Base {
      * @returns {Promise<Object>} `{candidatesAdded, candidates}`
      */
     async runConceptDiscovery() {
-            return ConceptDiscoveryService.runDiscoveryCycle();
-        }
+        return ConceptDiscoveryService.runDiscoveryCycle();
+    }
 
     /**
      * @summary Parses the local file system for markdown files and explicitly syncs their state
@@ -302,40 +310,40 @@ class DreamService extends Base {
      * @returns {Promise<Object[]>} Returns only the OPEN issues for synthesis.
      */
     async ingestIssueStates() {
-            return IssueIngestor.ingestIssueStates();
-        }
+        return IssueIngestor.ingestIssueStates();
+    }
 
     /**
      * Parses the local file system for markdown discussions and syncs their state
      * into the Native Graph database as OPEN items so they can surface mathematically.
      */
     async ingestDiscussionStates() {
-            return IssueIngestor.ingestDiscussionStates();
-        }
+        return IssueIngestor.ingestDiscussionStates();
+    }
 
     /**
      * Parses the local file system for pull request reviews and syncs their embedded
      * gap signals ([KB_GAP], [TOOLING_GAP], [RETROSPECTIVE]) into the Native Graph database.
      */
     async ingestPullRequestFeedback() {
-            return IssueIngestor.ingestPullRequestFeedback();
-        }
+        return IssueIngestor.ingestPullRequestFeedback();
+    }
 
     /**
      * Executes the global "Fade" algorithm across all Native Graph edges,
      * then executes Vector Apoptosis to clean up resulting orphaned nodes from the hybrid semantic space.
      */
     async runGarbageCollection() {
-            return GraphMaintenanceService.runGarbageCollection();
-        }
+        return GraphMaintenanceService.runGarbageCollection();
+    }
 
     /**
      * Synthesizes the Golden Path (strategic priorities) deterministically by analyzing Graph topology
      * combined with Vector Similarity (Hybrid GraphRAG).
      */
     async synthesizeGoldenPath() {
-            return GoldenPathSynthesizer.synthesizeGoldenPath();
-        }
+        return GoldenPathSynthesizer.synthesizeGoldenPath();
     }
+}
 
 export default Neo.setupClass(DreamService);

--- a/ai/daemons/Orchestrator.mjs
+++ b/ai/daemons/Orchestrator.mjs
@@ -5,6 +5,7 @@
 // class were ever loaded outside its entry-point's chain.
 import fs                          from 'fs-extra';
 import {spawn}                     from 'child_process';
+import path                        from 'path';
 import Base                        from '../../src/core/Base.mjs';
 import HealthService               from '../services/memory-core/HealthService.mjs';
 import {

--- a/ai/daemons/TaskDefinitions.mjs
+++ b/ai/daemons/TaskDefinitions.mjs
@@ -11,7 +11,7 @@ export const DEFAULT_BACKUP_INTERVAL_MS        = 86400000;
 
 export const DEFAULT_DB_PATH    = process.env.NEO_AI_DB_PATH || '.neo-ai-data/sqlite/memory-core-graph.sqlite';
 export const DEFAULT_DATA_DIR   = process.env.NEO_AI_ORCHESTRATOR_DIR || '.neo-ai-data/orchestrator-daemon';
-export const DEFAULT_SCRIPT_DIR = path.resolve(__dirname, '../../scripts');
+export const DEFAULT_SCRIPT_DIR = path.resolve(__dirname, '../scripts');
 
 /**
  * @summary Builds child-process commands for orchestrator-owned maintenance tasks.

--- a/test/playwright/unit/ai/daemons/Orchestrator.spec.mjs
+++ b/test/playwright/unit/ai/daemons/Orchestrator.spec.mjs
@@ -1,4 +1,5 @@
 import {test, expect} from '@playwright/test';
+import path from 'path';
 import Neo from '../../../../../src/Neo.mjs';
 import * as core from '../../../../../src/core/_export.mjs';
 import {
@@ -145,6 +146,23 @@ test.describe('Neo.ai.daemons.Orchestrator (#11009)', () => {
             taskName: 'kbSync',
             reason  : 'periodic-sync:600000'
         });
+    });
+
+    test('resolves default paths correctly without configuration overrides', () => {
+        const orchestrator = Neo.create(Orchestrator);
+        const dataDir = '/tmp/orchestrator-test-defaults';
+        
+        expect(() => orchestrator.configure({ dataDir })).not.toThrow();
+        
+        expect(orchestrator.logFile).toBe(path.join(dataDir, 'orchestrator.log'));
+        expect(orchestrator.stateFile).toBe(path.join(dataDir, 'orchestrator-state.json'));
+        
+        const repoRoot = path.resolve(process.cwd());
+        const expectedSummaryScript = path.resolve(repoRoot, 'ai/scripts/summarize-sessions.mjs');
+        const expectedKbSyncScript = path.resolve(repoRoot, 'buildScripts/ai/syncKnowledgeBase.mjs');
+        
+        expect(orchestrator.taskDefinitions.summary.args[0]).toBe(expectedSummaryScript);
+        expect(orchestrator.taskDefinitions.kbSync.args[0]).toBe(expectedKbSyncScript);
     });
 
 });


### PR DESCRIPTION
Authored by Gemini 3.1 Pro (Antigravity). Session d5ed6767-0292-46bf-9346-439f268048ec.

Resolves #11080

Restores the `path` module import in `ai/daemons/Orchestrator.mjs` and fixes the `DEFAULT_SCRIPT_DIR` resolution in `ai/daemons/TaskDefinitions.mjs` to properly point to `../scripts` relative to `ai/daemons`.

Evidence: L1 (unit test coverage and daemon startup validation) → L1 required. No residuals.

## Test Evidence
- Added regression unit tests to `test/playwright/unit/ai/daemons/Orchestrator.spec.mjs` to test production path defaults.
- Verified successful daemon boot via `npm run ai:orchestrator` locally.
- Verified backup scripts and summary scripts run cleanly.

## Commits
- 16d50a166 — fix(ai): restore missing path import and default script resolution in Orchestrator daemon (#11080)
