### PR TITLE
refactor(agent): rename Orchestrator to AgentOrchestrator (#11081)

### DIFF
--- a/ai/agent/AgentOrchestrator.mjs
+++ b/ai/agent/AgentOrchestrator.mjs
@@ -5,16 +5,16 @@ import path  from 'path';
 
 /**
  * Parses sandman_handoff.md and injects the resulting directives into a headless agent loop.
- * @class Neo.ai.agent.Orchestrator
+ * @class Neo.ai.agent.AgentOrchestrator
  * @extends Neo.core.Base
  */
-class Orchestrator extends Base {
+class AgentOrchestrator extends Base {
     static config = {
         /**
-         * @member {String} className='Neo.ai.agent.Orchestrator'
+         * @member {String} className='Neo.ai.agent.AgentOrchestrator'
          * @protected
          */
-        className: 'Neo.ai.agent.Orchestrator',
+        className: 'Neo.ai.agent.AgentOrchestrator',
         /**
          * @member {String} handoffPath=path.resolve(process.cwd(), 'resources/content/sandman_handoff.md')
          */
@@ -32,7 +32,7 @@ class Orchestrator extends Base {
      */
     parseGoldenPath() {
         if (!fs.existsSync(this.handoffPath)) {
-            console.warn(`[Orchestrator] No handoff file found at ${this.handoffPath}`);
+            console.warn(`[AgentOrchestrator] No handoff file found at ${this.handoffPath}`);
             return null;
         }
 
@@ -40,7 +40,7 @@ class Orchestrator extends Base {
         const goldenPathMatch = content.match(/## Computed Golden Path[^\n]*\n([\s\S]*?)(?=\n#|$)/);
 
         if (!goldenPathMatch) {
-             console.warn('[Orchestrator] No "## Computed Golden Path" section found.');
+             console.warn('[AgentOrchestrator] No "## Computed Golden Path" section found.');
              return null;
         }
 
@@ -66,12 +66,12 @@ class Orchestrator extends Base {
      * @returns {Promise<void>}
      */
     async execute({ dryRun = false } = {}) {
-        console.log('⏳ Initializing Neo Agent Orchestrator...');
+        console.log('⏳ Initializing Neo AgentOrchestrator...');
 
         const directives = this.parseGoldenPath();
 
         if (!directives || directives.length === 0) {
-            console.log('✅ No immediate Golden Path directives found. Orchestrator exiting cleanly.');
+            console.log('✅ No immediate Golden Path directives found. AgentOrchestrator exiting cleanly.');
             return;
         }
 
@@ -125,10 +125,10 @@ class Orchestrator extends Base {
             }, this.monitorIntervalMs);
 
         } catch (err) {
-            console.error('❌ Agent Orchestrator failed:', err);
+            console.error('❌ AgentOrchestrator failed:', err);
             throw err;
         }
     }
 }
 
-export default Neo.setupClass(Orchestrator);
+export default Neo.setupClass(AgentOrchestrator);

--- a/buildScripts/ai/runAgent.mjs
+++ b/buildScripts/ai/runAgent.mjs
@@ -1,7 +1,7 @@
-import Neo             from '../../src/Neo.mjs';
-import * as core       from '../../src/core/_export.mjs';
-import InstanceManager from '../../src/manager/Instance.mjs';
-import Orchestrator    from '../../ai/agent/Orchestrator.mjs';
+import Neo               from '../../src/Neo.mjs';
+import * as core         from '../../src/core/_export.mjs';
+import InstanceManager   from '../../src/manager/Instance.mjs';
+import AgentOrchestrator from '../../ai/agent/AgentOrchestrator.mjs';
 
 /**
  * @module buildScripts/ai/runAgent
@@ -11,10 +11,10 @@ const isDryRun = process.argv.includes('--dry-run');
 
 async function startOrchestrator() {
     try {
-        const orchestrator = Neo.create(Orchestrator);
+        const orchestrator = Neo.create(AgentOrchestrator);
         await orchestrator.execute({ dryRun: isDryRun });
     } catch (err) {
-        console.error('❌ Agent Orchestrator failed:', err);
+        console.error('❌ AgentOrchestrator failed:', err);
         process.exit(1);
     }
 }

--- a/learn/agentos/SwarmIntelligence.md
+++ b/learn/agentos/SwarmIntelligence.md
@@ -367,7 +367,7 @@ To add a new sub-agent profile:
 | `ai/Agent.mjs` | Base class — manages MCP clients, sub-agent registry, delegation |
 | `ai/agent/Loop.mjs` | Cognitive loop — Perceive/Reason/Act/Reflect + tool execution |
 | `ai/agent/Scheduler.mjs` | Priority queue for event processing |
-| `ai/agent/Orchestrator.mjs` | Parses Golden Path, boots agent, monitors exhaustion |
+| `ai/agent/AgentOrchestrator.mjs` | Parses Golden Path, boots agent, monitors exhaustion |
 | `ai/agent/profile/Librarian.mjs` | GraphRAG research specialist |
 | `ai/agent/profile/QA.mjs` | Local test generation engine |
 | `ai/agent/profile/Browser.mjs` | Visual telemetry via Neural Link |

--- a/test/playwright/unit/ai/AgentOrchestrator.spec.mjs
+++ b/test/playwright/unit/ai/AgentOrchestrator.spec.mjs
@@ -1,11 +1,11 @@
 import test         from '@playwright/test';
 import fs           from 'fs';
 import path         from 'path';
-import Neo          from '../../../../src/Neo.mjs';
-import * as core    from '../../../../src/core/_export.mjs';
-import Orchestrator from '../../../../ai/agent/Orchestrator.mjs';
+import Neo               from '../../../../src/Neo.mjs';
+import * as core       from '../../../../src/core/_export.mjs';
+import AgentOrchestrator from '../../../../ai/agent/AgentOrchestrator.mjs';
 
-test.describe('Neo.ai.agent.Orchestrator', () => {
+test.describe('Neo.ai.agent.AgentOrchestrator', () => {
     test('Golden Path regex correctly extracts issue IDs and descriptions', async () => {
         const content = `
 # Autonomous Handoff
@@ -27,7 +27,7 @@ Based on priorities, the following tasks are mathematically recommended:
         fs.writeFileSync(testHandoffPath, content, 'utf-8');
 
         try {
-            const orchestrator = Neo.create(Orchestrator, {
+            const orchestrator = Neo.create(AgentOrchestrator, {
                 handoffPath: testHandoffPath
             });
 


### PR DESCRIPTION
## Description

Fixes #11081.

This PR renames `ai/agent/Orchestrator.mjs` to `ai/agent/AgentOrchestrator.mjs` to prevent mental model and architectural collision with the background daemon (`ai/daemons/Orchestrator.mjs`).

### Changes
- Renamed `ai/agent/Orchestrator.mjs` -> `ai/agent/AgentOrchestrator.mjs`.
- Updated the class name and class docstrings to `AgentOrchestrator` / `Neo.ai.agent.AgentOrchestrator`.
- Updated console logs within the class to say `[AgentOrchestrator]`.
- Renamed the unit test file to `test/playwright/unit/ai/AgentOrchestrator.spec.mjs`.
- Updated imports in `buildScripts/ai/runAgent.mjs` and the test file.

## Stepping Back (Pre-PR Reflection)
- Does this address the issue? Yes, it completes the requested structural rename.
- Is it isolated? Yes, this only affects the agent orchestrator class, not the background daemon or any other core components.
- Is it tested? Yes, `npm run test-unit -- test/playwright/unit/ai/AgentOrchestrator.spec.mjs` passed for the updated test suite.

## Review Request
@neo-opus-4-7 PTAL. You previously indicated that you are handling the daemon side, and this PR fulfills the agent-side renaming.

<!--
  Evidence Ladder compliance for Substrate/Runtime PRs:
  - Architecture Validated: Yes (Resolves collision via clear namespacing).
  - Tests Passing: Yes (`npm run test-unit -- test/playwright/unit/ai/AgentOrchestrator.spec.mjs`).
-->
