### PR TITLE
docs(skills): compress pr-review premise pre-flight (#11090)

### DIFF
--- a/.agents/skills/pr-review/audits/cycle-1-premise-preflight.md
+++ b/.agents/skills/pr-review/audits/cycle-1-premise-preflight.md
@@ -1,0 +1,47 @@
+# Cycle-1 Premise Pre-Flight Audit
+
+Use this audit only when the map trigger in `pr-review-guide.md` §9.0 fires or a Cycle-1 PR feels structurally non-iterable. The purpose is to decide whether `Request Changes` would wrongly normalize an unmergeable premise as an iterative path.
+
+## Why This Exists
+
+The four Strategic-Fit outcomes in `pr-review-guide.md` §9 were originally anchored on after-N-cycles failures such as PR #10610 -> #10611 and the PR #10607 eight-cycle pattern. Those anchors catch sunk-cost iteration after review churn has already happened.
+
+PR #11083 exposed the missing Cycle-1 case: the wrong premise was visible before any iteration. The Cycle-1 review used Request Changes with five iterative Required Actions, even though the substrate-correct shape was a single Drop+Supersede close recommendation. RA1 ("upstream Discussion needs author-graduation") was structurally not-iterable on the PR; that self-contradiction is the diagnostic.
+
+## Trigger Catalog
+
+If any trigger below fires, default to Drop+Supersede framing: one close/restart Required Action, not a multi-item iteration list.
+
+| Trigger | Diagnostic question |
+|---|---|
+| Premise-invalid | Is the PR's stated premise false, such as claiming to resolve a ticket or implement a feature whose substrate has a different shape? |
+| Upstream not graduated | Does the PR depend on a Discussion, parent ticket, or Epic that has not reached its required graduation or closure state? |
+| Author bypassed | Did the author bypass a specific authority boundary, such as self-marking another peer's Discussion as graduated or crossing `peer-role` non-execution without handoff? |
+| Anti-pattern instantiation | Does the change instantiate a pattern Neo doctrine forbids, such as named-maintainer orchestrator/worker mapping, framework-category drift, or banned shell editing? |
+| Strategic-misalignment | Does the work conflict with active roadmap direction, reserved lane ownership, deprecated subsystem direction, or an operator halt? |
+| Better-existing-substrate | Does existing code, Memory Core, or KB evidence already solve the problem, making the PR reinvention? |
+
+## Bias Defended Against
+
+Velocity-Preservation Bias: preferring iterative paths that salvage work-already-done over decisive restart paths, even when restart is substrate-correct.
+
+Amplifiers:
+
+- Auto Mode "prefer action over planning" reads as "iterate now."
+- `peer-role` pressure reads as "find things to fix."
+- Green CI makes merge feel proximate.
+- Partial correctness makes salvage feel efficient.
+
+The cost is normalizing process violations as iteratable rather than abandonable.
+
+## Empirical Anchor
+
+PR #11083, closed unmerged on 2026-05-10, is the anchor. Review comment `IC_kwDODSospM8AAAABBxjTZw` documented five iterative Required Actions, while RA1 pointed at upstream Discussion graduation. That mismatch between RA shape and Request Changes framing is what this audit prevents.
+
+## Disposition
+
+- `pr-review-guide.md` §9.0: `compress-to-trigger`
+- This file: `move`
+- Tag: `DISCIPLINE-ONLY`
+
+This keeps the loaded map short while preserving the case study, trigger catalog, and bias rationale for reviewers who actually hit the edge case.

--- a/.agents/skills/pr-review/references/pr-review-guide.md
+++ b/.agents/skills/pr-review/references/pr-review-guide.md
@@ -370,26 +370,11 @@ Empirical anchor: PR #10607 8-cycle pattern.
 
 ### 9.0 Cycle-1 Premise Pre-Flight (Decisiveness-Before-Iteration)
 
-The 4-option Step-Back above was empirically anchored on **after-N-cycles** failure modes (PR #10610 → #10611, #10607 8-cycle pattern). All three Drop+Supersede triggers in §9 option 4 assume iteration has already sunk effort. **PR #11083** (closed unmerged 2026-05-10) demonstrated the missing case: wrong-premise visible at Cycle 1, before any iteration. The Cycle-1 reviewer framed the review as Request Changes with 5 iterative Required Actions — when the substrate-correct shape was a single Drop+Supersede close-recommendation. The framing miss normalized "fix-these-5" as a valid merge path even though no version of the PR was mergeable until upstream substrate graduated. The reviewer's own RA1 ("upstream Discussion needs author-graduation") was structurally not-iterable on the PR; that self-contradiction is the diagnostic.
+Before composing Required Actions on a Cycle-1 review, ask: **"Does this PR have any structural issue that makes Request Changes wrong-shape?"**
 
-**Run this pre-flight BEFORE composing Required Actions on a Cycle-1 review.** Ask:
+If a Cycle-1 structural-invalidity trigger fires, default to **Drop+Supersede framing**: one close/restart Required Action, not a multi-item iteration list. Common triggers: false premise, ungraduated upstream substrate, specific authority bypass, Neo-doctrine anti-pattern instantiation, active roadmap conflict, or better existing substrate.
 
-> *"Does this PR have any structural issue that makes Request Changes wrong-shape?"*
-
-If any of the following triggers fire, default to **Drop+Supersede framing** — single-item "close + restart" Required Action, NOT a multi-item iteration list:
-
-1. **Premise-invalid**: PR's stated premise (resolves #X / implements feature Y / cycle-N-of-Discussion-Z) is FALSE — the upstream substrate the PR claims to work from doesn't exist or has different shape than claimed.
-2. **Upstream not graduated**: PR depends on a Discussion / parent ticket / Epic that hasn't reached its required graduation / closure state. Per `ideation-sandbox-workflow.md` §5, only the Discussion author can mark `GRADUATED`; a non-author opening an implementation PR before that is a premise violation.
-3. **Author bypassed**: PR author lacks **specific authority** for the change — narrow patterns of authority-bypass, NOT generic file-ownership policing. Examples: self-marking graduation on a Discussion authored by another peer; crossing peer-role §9 Non-Execution Boundary without explicit lead hand-off; modifying agent-skill substrate without lead/operator concurrence on the amendment direction. Cross-cutting refactors and code-level changes that touch files authored by other agents are routine peer collaboration, NOT trigger 3.
-4. **Anti-pattern instantiation**: change instantiates a pattern Neo doctrine forbids (e.g., orchestrator-worker mapping for named maintainers per AGENTS.md §15.6; framework-category drift per §15.5; bash redirection for file edits per §11).
-5. **Strategic-misalignment**: work conflicts with active roadmap direction the author wasn't aware of (e.g., implementation lane reserved for a peer; deprecated subsystem; lane explicitly halted by operator).
-6. **Better-existing-substrate**: there's already a substrate that solves the problem; PR is reinventing. Memory Core / KB query before review surfaces this.
-
-**Bias defended against — Velocity-Preservation Bias**: preferring iterative paths that salvage work-already-done over decisive paths requiring restart, even when restart is substrate-correct. Companion to Claude over-rigor (§7.2) — same family (mis-weighting at review-decision time), different surface. Amplifiers: Auto Mode "prefer action over planning" reads as "iterate now"; peer-role's "produce evidence-backed pressure" reads as "find things to fix"; CI-green makes merge feel proximate; partial-correctness (e.g., 60% of substantive content right) makes salvage feel efficient. The cost is normalizing process violations as iteratable rather than abandonable.
-
-**Discipline, not gate.** Per AGENTS.md §13 substrate-accretion defense: this is a per-turn self-asked question, not a mandatory checkbox. Runs in <30 seconds for routine PRs (no triggers fire); when any trigger fires, the framing flip is immediate and the review collapses to a short close-recommendation rather than a long iterative-RA list. Companion to verify-before-assert (claudeMd §23 atlas) and §13 substrate-accretion defense.
-
-**Empirical anchor (PR #11083, 2026-05-10)**: review comment `IC_kwDODSospM8AAAABBxjTZw` documented 5 iterative Required Actions; RA1 ("@neo-gpt formally graduates #11079") pointed at upstream Discussion graduation, structurally not-iterable on the PR. The mismatch between RA1's structural shape and the Request Changes framing is the diagnostic that pre-flight would have caught. Operator (@tobiu) surfaced the calibration miss; this subsection encodes the fix.
+This is discipline, not a mandatory checkbox. Routine PRs should clear it in under 30 seconds; when it fires, the framing flip is immediate. For trigger definitions, bias rationale, and the PR #11083 empirical anchor, read [`../audits/cycle-1-premise-preflight.md`](../audits/cycle-1-premise-preflight.md).
 
 ### 9.1 Reviewer-Yield Protocol (Deadlock Prevention)
 


### PR DESCRIPTION
Resolves #11090

Authored by GPT-5.5 (Codex Desktop). Session 019e0c7d-955f-7003-a25d-42dc14c57214.

Compresses the newly added PR #11085 Cycle-1 premise pre-flight from a long inline `pr-review-guide.md` section into a concise map trigger plus a granular audit payload. Behavior is preserved: Cycle-1 reviewers still get the decisive Drop+Supersede trigger in the main guide, while the case study, trigger catalog, bias rationale, and disposition metadata now live behind an on-demand Atlas link.

Evidence: L1 (skill-doc rule + static cross-link; docs-only sandbox ceiling) → L1 required (#11090 map/atlas compression ACs). Residual: #11086/PR #11095 content is intentionally not included because #11095 is still under review and not merged.

## Deltas from ticket

- Scope is explicitly #11085-only. #11090 allows this when #11086 has not merged; PR #11095 currently has requested changes, so its Double Diamond skill additions are not a stable compression target yet.
- No top-level `SKILL.md` router content changed.

## Slot Rationale

- Modified `pr-review-guide.md` §9.0: `compress-to-trigger`; trigger-frequency high for PR reviews, failure-severity medium/high when it fires, enforceability discipline-only. The guide keeps the self-question, decision rule, common trigger names, and link.
- Added `pr-review/audits/cycle-1-premise-preflight.md`: `move`; trigger-frequency rare, failure-severity high for wrong-premise PRs, enforceability discipline-only. The moved payload preserves the detailed trigger catalog, bias explanation, empirical anchor, and disposition notes.

## Byte Measurements

Before:

- `pr-review-guide.md`: 52,296 bytes

After:

- `pr-review-guide.md`: 48,656 bytes
- `cycle-1-premise-preflight.md`: 3,209 bytes
- Combined map + new Atlas payload: 51,865 bytes

Delta:

- Loaded map: -3,640 bytes
- Combined total vs previous guide alone: -431 bytes

## Test Evidence

- `git diff --check` passed before staging.
- `git diff --cached --check` passed after staging.
- Manual review confirmed the remaining §9.0 map still exposes the Cycle-1 self-question, Drop+Supersede framing rule, common trigger names, and relative Atlas link.
- Automated tests not run: docs-only skill payload movement.

## Post-Merge Validation

- [ ] When #11095/#11086 lands, re-evaluate whether its new Double Diamond skill additions need a separate compression pass or whether they already satisfy the Map vs Atlas budget.

## Commits

- `b6706f7fc` — `docs(skills): compress pr-review premise pre-flight (#11090)`
