### PR TITLE
fix(github-workflow): correct stale ToolService import path post-M6 migration (#11103)

### DIFF
--- a/ai/services/github-workflow/toolService.mjs
+++ b/ai/services/github-workflow/toolService.mjs
@@ -8,7 +8,7 @@ import LabelService       from './LabelService.mjs';
 import LocalFileService   from './LocalFileService.mjs';
 import PullRequestService from './PullRequestService.mjs';
 import RepositoryService  from './RepositoryService.mjs';
-import ToolService        from '../../../ToolService.mjs';
+import ToolService        from '../../mcp/ToolService.mjs';
 import SyncService        from './SyncService.mjs';
 
 const __filename      = fileURLToPath(import.meta.url);


### PR DESCRIPTION
Authored by Claude Opus 4.7 (1M context, Claude Code). Origin Session: c2912891-b459-4a03-b2af-154d5e264df1.

Resolves #11103

## Summary

Single-line fix: stale 3-dot relative-import path in `ai/services/github-workflow/toolService.mjs:11` was missed during M6 migration PR #10997 (which moved the file from 3 levels deep to 2 levels deep but didn't update the relative-import depth). Result: github-workflow MCP server crashes on boot with `ERR_MODULE_NOT_FOUND`.

## Diff

```diff
-import ToolService        from '../../../ToolService.mjs';
+import ToolService        from '../../mcp/ToolService.mjs';
```

## Empirical anchor

| File | Import path | Correct? |
|---|---|---|
| `memory-core/toolService.mjs` | `'../../mcp/ToolService.mjs'` | ✅ |
| `knowledge-base/toolService.mjs` | `'../../mcp/ToolService.mjs'` | ✅ |
| `neural-link/toolService.mjs` | `'../../mcp/ToolService.mjs'` | ✅ |
| **`github-workflow/toolService.mjs`** | `'../../../ToolService.mjs'` (pre-fix) | **❌** |

Discipline-symmetric-application heuristic (surfaced empirically in #11077 cycle 1→3) caught this in <30s of skill-prescribed self-repair Phase 1 step 4 (native terminal boot-test).

## Test plan

- [x] **Boot smoke test (manual):** `node ai/mcp/server/github-workflow/mcp-server.mjs` survives 3s probe with fix applied (background process stays alive); without fix, instant ERR_MODULE_NOT_FOUND crash. Verified before commit.
- [ ] **CI:** unit + integration-unified should pass — wiring fix doesn't change runtime semantics, only resolves the import to its canonical target. Standing by for green checks.
- [ ] **Post-merge:** after @tobiu restarts MCP harnesses (or operator-side server restart), github-workflow MCP tools should reappear in the swarm.

## Why CI didn't catch the original bug

The 39 unit tests cited in PR #10997's body imported individual service files (IssueService, PullRequestService, etc.) — not the wiring-layer `toolService.mjs` that aggregates them for the MCP server entry point. Wiring bugs at module-resolution time are invisible to per-service unit tests. **Substrate-quality follow-up candidate** noted in #11103: add boot smoke tests for wiring files to CI. Out of scope for this surgical fix.

## Evidence

Evidence: L2 (sandbox boot-test verification, 3s alive-probe) → L3 required (operator-side MCP restart confirms tools reappear in swarm). Residual: post-merge MCP-restart verification deferred to operator handoff per evidence-ladder L3-deferred pattern.

## Out of Scope

- Boot smoke tests in CI (separate follow-up; flagged in #11103)
- Audit of M6-migrated other servers (memory-core, knowledge-base, neural-link) for similar wiring bugs — initial sweep showed sister files are correct, but systematic per-server boot test is worth a separate ticket
- Refactoring the toolService.mjs aggregator pattern itself

## Cross-Family Review

Pinging @neo-gemini-3-1-pro for cross-family review (single-peer per `feedback_swarm_pr_review_routing` — escalate to GPT only as tie-breaker or for architectural pillars; this is a 1-line fix).