### PR TITLE
feat(skill): add author-side reviewer template adherence check (#11105)

### DIFF
--- a/.agents/skills/pr-review/references/pr-review-guide.md
+++ b/.agents/skills/pr-review/references/pr-review-guide.md
@@ -158,6 +158,8 @@ The PR cannot be approved if the implemented contract and the ticket's Contract 
 
 Before drafting your review, classify the review cycle. Template choice is part of context-budget control and rigor control.
 
+> **Symmetry Note:** The `pull-request` skill enforces an author-side template-adherence check (see `pull-request-workflow.md §6.4`). If you fail to use the correct template structure specified below, the author is mandated to reject your review and A2A you for a complete rewrite. Substantive content without structural adherence is not merge-eligible.
+
 ### 6.1 Full Review Template
 
 Use the full template from `.agents/skills/pr-review/assets/pr-review-template.md` when any of these apply:

--- a/.agents/skills/pull-request/SKILL.md
+++ b/.agents/skills/pull-request/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: pull-request
 description: Standardized guidelines and procedural execution flow for opening a Pull Request. Mandates the "Stepping Back" reflection protocol and git/gh tool invocations.
-triggers: Use this skill as the final Definition of Done when you believe a ticket is complete and it is time to open a Pull Request, or if a human user asks you to submit a PR.
+triggers: Use this skill as the final Definition of Done when you believe a ticket is complete and it is time to open a Pull Request, or if a human user asks you to submit a PR. Also triggers when receiving a PR review to perform the author-side template-adherence check.
 ---
 # Pull Request Skill
 

--- a/.agents/skills/pull-request/references/pull-request-workflow.md
+++ b/.agents/skills/pull-request/references/pull-request-workflow.md
@@ -232,6 +232,20 @@ after review-response handoff completes. Reviewer-side symmetry is mapped from
 `pr-review-guide.md §11`. This is the public skill codification of the
 `feedback_peer_not_assistant_mode` lineage.
 
+### 6.4 Reviewer Template-Adherence Check
+
+When a review lands on your PR, verify the reviewer used the correct
+template before treating the review as substantively complete:
+- **Cycle 1**: review must follow `pr-review-template.md` structure
+  (Strategic-Fit Decision, Depth Floor, Graph Ingestion Notes, [...])
+- **Cycle ≥2**: review must follow `pr-review-followup-template.md`
+  (compact delta-only shape)
+
+If the review uses a custom or simplified format, A2A the reviewer
+to redo via `/pr-review` per the skill payload. Substantive content
++ wrong shape = template-adherence Required Action; do not merge-eligible
+the PR until shape is correct.
+
 ## 8. PR Comment Hygiene & A2A Propagation (Edge-Case)
 
 *If responding to reviewer feedback across multiple rounds, read `.agents/skills/pull-request/references/review-response-protocol.md`; otherwise skip.*

--- a/.agents/skills/pull-request/references/pull-request-workflow.md
+++ b/.agents/skills/pull-request/references/pull-request-workflow.md
@@ -243,8 +243,8 @@ template before treating the review as substantively complete:
 
 If the review uses a custom or simplified format, A2A the reviewer
 to redo via `/pr-review` per the skill payload. Substantive content
-+ wrong shape = template-adherence Required Action; do not merge-eligible
-the PR until shape is correct.
++ wrong shape = template-adherence Required Action; do not signal merge-eligibility
+until shape is correct.
 
 ## 8. PR Comment Hygiene & A2A Propagation (Edge-Case)
 

--- a/ai/services/github-workflow/toolService.mjs
+++ b/ai/services/github-workflow/toolService.mjs
@@ -13,7 +13,7 @@ import SyncService        from './SyncService.mjs';
 
 const __filename      = fileURLToPath(import.meta.url);
 const __dirname       = path.dirname(__filename);
-const openApiFilePath = path.join(__dirname, '../openapi.yaml');
+const openApiFilePath = path.join(__dirname, '../../mcp/server/github-workflow/openapi.yaml');
 
 const serviceMapping = {
     checkout_pull_request    : PullRequestService.checkoutPullRequest    .bind(PullRequestService),


### PR DESCRIPTION
Resolves #11105
Resolves #11106 (Piggyback)

Enforces author-side verification of reviewer template adherence, closing the gap where reviewers who skip the template structure degrade the Native Edge Graph. This patches the asymmetric obligation identified in PR #11104, making authors explicitly responsible for verifying structure before treating a review as merge-eligible.

Additionally, this PR includes a highly isolated fix for the `github-workflow` MCP server to correct the path resolution for `openapi.yaml`.

Evidence: L1 (static skill payload documentation update + trivial path resolution) -> L1 required (no runtime verify ACs). No residuals.

## Deltas from ticket (if any)
Added the operator-approved `openapi.yaml` path fix piggyback (toolService.mjs).

## Test Evidence
- Static audit of Markdown files to confirm proper placement and formatting.
- Path fix verified by human operator as resolving the `ENOENT` boot crash.

## Slot-Rationale (Substrate-Mutation Gate)

- **Added: `pull-request-workflow.md §6.4`**
  - Disposition: `compress-to-trigger`
  - 3-axis rating: High trigger-frequency (every PR review) × Medium failure-severity (graph ingestion degradation) × High enforceability (explicit author-side verify).
- **Modified: `pull-request/SKILL.md` (triggers)**
  - Disposition Delta: `keep` (no change).
  - Reason: Expanding the trigger definition to fire the author-side template adherence check upon receiving a review.
- **Modified: `pr-review-guide.md §6`**
  - Disposition Delta: `keep` (no change).
  - Reason: Added cross-reference note enforcing bidirectional symmetry, making the author's rejection authority visible to the reviewer.
- **Modified: `toolService.mjs:16` (piggyback)**
  - Disposition Delta: `keep` (no change).
  - Reason: Fixes immediate boot crash for the github-workflow server due to incorrectly mapped sub-directory path.

## Commits
- `feat(skill): add author-side reviewer template adherence check (#11105)`
- `fix(mcp): correct openapi.yaml path resolution in github-workflow toolService (#11106)`

Authored by Neo Gemini 3.1 Pro (Antigravity). Session d5ed6767-0292-46bf-9346-439f268048ec.
