### PR TITLE
refactor(memory): remove windowDuration from a2a wake telemetry (#11108)

### DIFF
--- a/ai/scripts/bridge-daemon.mjs
+++ b/ai/scripts/bridge-daemon.mjs
@@ -413,8 +413,7 @@ function queueEvent(subscription, eventPayload) {
         coalesceState[subId] = {
             subscription: subscription,
             queue: [],
-            timer: null,
-            windowStart: Date.now()
+            timer: null
         };
     }
 
@@ -502,7 +501,7 @@ async function flushSubscription(subId) {
     const state = coalesceState[subId];
     if (!state) return;
 
-    const { queue, subscription, windowStart } = state;
+    const { queue, subscription } = state;
     delete coalesceState[subId]; // reset
 
     if (queue.length === 0) return;
@@ -534,9 +533,7 @@ async function flushSubscription(subId) {
         breakdown += `\n- ${permissions.length} permissions granted (latest: ${latest.scope} by ${latest.grantedBy})`;
     }
 
-    const windowDuration = Date.now() - windowStart;
-    
-    const digest = `[WAKE][priority:${digestPriority}] ${N} events for ${identity}: ${breakdown}\n\nSubscription: ${subId}\nWindow: ${windowDuration}ms`;
+    const digest = `[WAKE][priority:${digestPriority}] ${N} events for ${identity}: ${breakdown}\n\nSubscription: ${subId}`;
     
     // Delivery to per-harness adapter
     await deliverDigest(subscription, digest);

--- a/test/playwright/unit/ai/scripts/bridge-daemon.spec.mjs
+++ b/test/playwright/unit/ai/scripts/bridge-daemon.spec.mjs
@@ -143,6 +143,7 @@ test.describe('Bridge Daemon', () => {
         expect(output).toContain('[WAKE][priority:normal]');
         expect(output).toContain('Test Wake Event');
         expect(output).toContain('priority: normal');
+        expect(output).not.toContain('\nWindow:');
 
         // Per #10419 — verify the diagnostic log file was persisted to disk and contains
         // structured entries (ISO timestamp + PID + INFO/ERROR level prefix). Persistence


### PR DESCRIPTION
Authored by Gemini 3.1 Pro (Antigravity). Session d5ed6767-0292-46bf-9346-439f268048ec.

## Epic / Goal
Resolves #11108.
Institutionalizes the removal of excessive A2A wake telemetry to optimize context token efficiency and reduce swarm communication noise.

## What has changed
* Modified `ai/scripts/bridge-daemon.mjs` to remove `windowStart` from the `coalesceState` during event queue initialization (`queueEvent`).
* Updated `flushSubscription` in `bridge-daemon.mjs` to remove the calculation and inclusion of `Window: [X]ms` from the A2A wake digest payloads.

## Slot-Rationale
Disposition: `keep`
Removing non-actionable telemetric noise from the A2A wake digest adheres to the friction-into-gold MX-loop by improving the signal-to-noise ratio in swarm operations, keeping memory contexts dense with semantic value rather than diagnostic artifacts.

## Checklist
- [x] Tested against Memory Core tests
- [x] Code follows framework patterns
- [x] Commit follows format `type(scope): message (#TICKET_ID)`
- [x] A2A Wake Message digest verifies clean payload
