### PR TITLE
build(release): integrate PR sync into publish workflow (#11131)

### DIFF
--- a/buildScripts/release/publish.mjs
+++ b/buildScripts/release/publish.mjs
@@ -231,6 +231,9 @@ async function main() {
         await GH_SyncService.runFullSync();
         console.log('✅ Sync complete.');
 
+        console.log('🔄 Syncing Pull Requests...');
+        runCommand('npm run ai:sync-prs', 'Failed to sync pull requests');
+
         // Regenerate ticket index to reflect moves (active -> archive)
         console.log('🔄 Regenerating Ticket Index...');
         runCommand('node buildScripts/docs/index/tickets.mjs', 'Failed to regenerate ticket index');
@@ -239,14 +242,14 @@ async function main() {
         // Don't exit, try to commit what we have
     }
 
-    // Commit Archived Tickets
-    console.log('💾 Committing archived tickets...');
+    // Commit Synced Content (Archived Tickets & PRs)
+    console.log('💾 Committing synced GitHub state...');
     const status = runCommandWithOutput('git status --porcelain');
 
     if (status) {
-        runCommand('git add .', 'Failed to stage archive changes');
-        runCommand(`git commit -m "chore: Archive tickets for v${newVersion}"`, 'Failed to commit archive changes');
-        runCommand('git push origin dev', 'Failed to push archive changes');
+        runCommand('git add .', 'Failed to stage synced changes');
+        runCommand(`git commit -m "chore: Sync GitHub state (archive tickets, sync PRs) for v${newVersion}"`, 'Failed to commit synced changes');
+        runCommand('git push origin dev', 'Failed to push synced changes');
     } else {
         console.log('No changes to archive.');
     }


### PR DESCRIPTION
Authored by Gemini 3.1 Pro (Antigravity). Session d5ed6767-0292-46bf-9346-439f268048ec.

Resolves #11131

Integrated the PR synchronization script (`npm run ai:sync-prs`) directly into the `Post-Release Cleanup` phase of `buildScripts/release/publish.mjs`. 
This ensures that when a new release is published, the GitHub pull request markdown representations are automatically synchronized to the local `resources/content/pull-requests/` directory, directly alongside the existing issue archiver logic, capturing the PRs merged into that exact release.

Evidence: L1 (static config-shape audit) → L1 required (no runtime-verify ACs). No residuals.

## Deltas from ticket (if any)
Also updated the logging and git commit messages in the script to reflect that it now commits synced GitHub state (both archived tickets and synced PRs).

## Post-Merge Validation
- [ ] Run a manual dummy release cycle or observe the next official release to verify PRs sync and get committed automatically.