### PR TITLE
fix(graph): inject Database context to Store and guard clear() for production SQLite DB (#11140)

### DIFF
--- a/ai/graph/Database.mjs
+++ b/ai/graph/Database.mjs
@@ -214,6 +214,7 @@ class Database extends Base {
         oldValue?.destroy();
         let store = ClassSystemUtil.beforeSetInstance(value, Store, {
             autoInitRecords: false,
+            database       : this,
             indices        : [{property: 'source'}, {property: 'target'}],
             model          : EdgeModel
         });
@@ -234,6 +235,7 @@ class Database extends Base {
         oldValue?.destroy();
         let store = ClassSystemUtil.beforeSetInstance(value, Store, {
             autoInitRecords: false,
+            database       : this,
             model          : NodeModel
         });
 

--- a/ai/graph/Store.mjs
+++ b/ai/graph/Store.mjs
@@ -1,10 +1,11 @@
 import DataStore from '../../src/data/Store.mjs';
+import DestructiveOperationGuard from '../mcp/server/shared/services/DestructiveOperationGuard.mjs';
 
 /**
  * A highly specialized Store natively optimized for the Native Edge Graph Database engine.
  * Extends the framework data collection layer by introducing generic reactive associative map indices,
  * reducing massive O(E) semantic topology loop traversals (GraphRAG mappings) to instantaneous O(1) retrievals.
- * 
+ *
  * @class Neo.ai.graph.Store
  * @extends Neo.data.Store
  */
@@ -45,7 +46,7 @@ class Store extends DataStore {
      */
     afterSetIndices(value, oldValue) {
         let me = this;
-        
+
         if (value && value.length > 0) {
             me.indexMaps = new Map();
 
@@ -105,13 +106,13 @@ class Store extends DataStore {
     /**
      * Extracts exact matching items synchronously from the GraphStore topography in O(1) mapping operations.
      * Assumes `property` exists dynamically within `indices_`.
-     * @param {String} property 
-     * @param {*} value 
+     * @param {String} property
+     * @param {*} value
      * @returns {Object[]}
      */
     getByIndex(property, value) {
         let me = this;
-        
+
         if (me.indexMaps) {
             let propertyMap = me.indexMaps.get(property);
             if (propertyMap) {
@@ -121,7 +122,7 @@ class Store extends DataStore {
                 }
             }
         }
-        
+
         return [];
     }
 
@@ -132,10 +133,17 @@ class Store extends DataStore {
     guardProductionWipe() {
         let me      = this,
             storage = me.database?.storage;
-            
+
         if (storage && storage.dbPath) {
             let path = storage.dbPath;
-            if (!path.includes('tmp') && !path.includes('test') && path !== ':memory:') {
+            try {
+                DestructiveOperationGuard.assertDestructiveTargetAllowedSync({
+                    operation: 'clear',
+                    subsystem: 'Neo.ai.graph.Store',
+                    mode: 'clear',
+                    target: { path }
+                });
+            } catch (e) {
                 throw new Error(`FATAL: Attempted to clear() a Store bound to a non-temporary SQLite database natively! Path: ${path}`);
             }
         }
@@ -180,7 +188,7 @@ class Store extends DataStore {
                     item     = removedItems[i];
                     isRecord = Neo.isRecord(item);
                     val      = isRecord ? item.get(prop) : Neo.ns(prop, false, item) ?? item[prop];
-                    
+
                     if (val != null) {
                         itemSet = propertyMap.get(val);
                         if (itemSet) {
@@ -203,7 +211,7 @@ class Store extends DataStore {
                     item     = addedItems[i];
                     isRecord = Neo.isRecord(item);
                     val      = isRecord ? item.get(prop) : Neo.ns(prop, false, item) ?? item[prop];
-                    
+
                     if (val != null) {
                         itemSet = propertyMap.get(val);
                         if (!itemSet) {

--- a/ai/graph/Store.mjs
+++ b/ai/graph/Store.mjs
@@ -16,6 +16,12 @@ class Store extends DataStore {
          */
         className: 'Neo.ai.graph.Store',
         /**
+         * Reference to the parent Database coordinating this store.
+         * @member {Object|Neo.ai.graph.Database|null} database_=null
+         * @reactive
+         */
+        database_: null,
+        /**
          * Array of secondary index objects. Each object must have a `property` string.
          * Example: `[{property: 'source'}, {property: 'target'}]`
          * @member {Object[]|null} indices_=null
@@ -63,6 +69,8 @@ class Store extends DataStore {
     clear(reset=true) {
         let me = this;
 
+        me.guardProductionWipe();
+
         super.clear(reset);
 
         if (me.indexMaps) {
@@ -80,6 +88,8 @@ class Store extends DataStore {
      */
     clearSilent(reset=true) {
         let me = this;
+
+        me.guardProductionWipe();
 
         super.clearSilent(reset);
 
@@ -113,6 +123,22 @@ class Store extends DataStore {
         }
         
         return [];
+    }
+
+    /**
+     * Prevents unintended wipe cascades by checking if this store is bound to a live production database.
+     * @protected
+     */
+    guardProductionWipe() {
+        let me      = this,
+            storage = me.database?.storage;
+            
+        if (storage && storage.dbPath) {
+            let path = storage.dbPath;
+            if (!path.includes('tmp') && !path.includes('test') && path !== ':memory:') {
+                throw new Error(`FATAL: Attempted to clear() a Store bound to a non-temporary SQLite database natively! Path: ${path}`);
+            }
+        }
     }
 
     /**

--- a/ai/mcp/server/shared/services/DestructiveOperationGuard.mjs
+++ b/ai/mcp/server/shared/services/DestructiveOperationGuard.mjs
@@ -86,7 +86,33 @@ class DestructiveOperationGuard extends Base {
      * @returns {Promise<Object>} An allow result containing classification details.
      * @throws {DestructiveOperationBlockedError} When the target is production-like or unresolved.
      */
-    async assertDestructiveTargetAllowed({
+    async assertDestructiveTargetAllowed(options = {}) {
+        return this.assertDestructiveTargetAllowedSync(options);
+    }
+
+    /**
+     * Synchronous version of assertDestructiveTargetAllowed.
+     * Asserts that a destructive target is disposable, or explicitly operator-confirmed.
+     *
+     * @param {Object}        options
+     * @param {String}        options.operation             Stable operation identifier.
+     * @param {String}        options.subsystem             Owning subsystem.
+     * @param {String}        options.mode                  Destructive mode, e.g. `delete`, `drop`, or `replace`.
+     * @param {Object}        options.target                Target descriptor.
+     * @param {String}       [options.target.path]          Target data path.
+     * @param {String}       [options.target.sqlitePath]    Target SQLite path.
+     * @param {String}       [options.target.bundlePath]    Target backup bundle path when it is the destructive destination.
+     * @param {Object}       [options.target.chroma]        Chroma target descriptor.
+     * @param {String}       [options.target.collectionName] Chroma collection name.
+     * @param {String}       [options.target.repoRoot]      Repository root for `tmp/` allowance.
+     * @param {String[]}     [options.target.disposableRoots] Additional disposable root paths.
+     * @param {Object}       [options.source]               Optional source descriptor for diagnostics.
+     * @param {String|Object} [options.confirmation]         Explicit production confirmation token.
+     * @param {Object}       [options.env=process.env]      Environment map, injectable for tests.
+     * @returns {Object} An allow result containing classification details.
+     * @throws {DestructiveOperationBlockedError} When the target is production-like or unresolved.
+     */
+    assertDestructiveTargetAllowedSync({
         operation,
         subsystem,
         mode,

--- a/test/playwright/unit/ai/graph/StoreSafeguards.spec.mjs
+++ b/test/playwright/unit/ai/graph/StoreSafeguards.spec.mjs
@@ -29,7 +29,7 @@ test.describe('Neo.ai.graph.Store Safeguards', () => {
                 }
             }
         });
-        
+
         let errorThrown = false;
         try {
             store.clear();
@@ -50,7 +50,7 @@ test.describe('Neo.ai.graph.Store Safeguards', () => {
                 }
             }
         });
-        
+
         let errorThrown = false;
         try {
             store.clear();
@@ -66,11 +66,11 @@ test.describe('Neo.ai.graph.Store Safeguards', () => {
             model   : NodeModel,
             database: {
                 storage: {
-                    dbPath: '/Users/user/tmp/test.sqlite'
+                    dbPath: 'tmp/test.sqlite'
                 }
             }
         });
-        
+
         let errorThrown = false;
         try {
             store.clear();
@@ -90,10 +90,52 @@ test.describe('Neo.ai.graph.Store Safeguards', () => {
                 }
             }
         });
-        
+
         let errorThrown = false;
         try {
             store.clearSilent();
+        } catch(e) {
+            errorThrown = true;
+            expect(e.message).toContain('FATAL: Attempted to clear()');
+        }
+        expect(errorThrown).toBe(true);
+        store.destroy();
+    });
+
+    test('should block clear() on a production database path containing tmp substring', async () => {
+        let store = Neo.create(Store, {
+            model   : NodeModel,
+            database: {
+                storage: {
+                    dbPath: '/var/db/tmp-data.sqlite'
+                }
+            }
+        });
+
+        let errorThrown = false;
+        try {
+            store.clear();
+        } catch(e) {
+            errorThrown = true;
+            expect(e.message).toContain('FATAL: Attempted to clear()');
+        }
+        expect(errorThrown).toBe(true);
+        store.destroy();
+    });
+
+    test('should block clear() on a production database path containing test substring', async () => {
+        let store = Neo.create(Store, {
+            model   : NodeModel,
+            database: {
+                storage: {
+                    dbPath: '/var/db/testing.sqlite'
+                }
+            }
+        });
+
+        let errorThrown = false;
+        try {
+            store.clear();
         } catch(e) {
             errorThrown = true;
             expect(e.message).toContain('FATAL: Attempted to clear()');

--- a/test/playwright/unit/ai/graph/StoreSafeguards.spec.mjs
+++ b/test/playwright/unit/ai/graph/StoreSafeguards.spec.mjs
@@ -1,0 +1,104 @@
+import {setup} from '../../../setup.mjs';
+
+const appName = 'AiStoreSafeguardsTest';
+
+setup({
+    neoConfig: {
+        unitTestMode: true
+    },
+    appConfig: {
+        name             : appName,
+        isMounted        : () => true,
+        vnodeInitialising: false
+    }
+});
+
+import {test, expect} from '@playwright/test';
+import Neo            from '../../../../../src/Neo.mjs';
+import Store          from '../../../../../ai/graph/Store.mjs';
+import NodeModel      from '../../../../../ai/graph/NodeModel.mjs';
+
+test.describe('Neo.ai.graph.Store Safeguards', () => {
+
+    test('should block clear() on a production database path', async () => {
+        let store = Neo.create(Store, {
+            model   : NodeModel,
+            database: {
+                storage: {
+                    dbPath: '/Users/user/db/production.sqlite'
+                }
+            }
+        });
+        
+        let errorThrown = false;
+        try {
+            store.clear();
+        } catch(e) {
+            errorThrown = true;
+            expect(e.message).toContain('FATAL: Attempted to clear()');
+        }
+        expect(errorThrown).toBe(true);
+        store.destroy();
+    });
+
+    test('should allow clear() on a memory database path', async () => {
+        let store = Neo.create(Store, {
+            model   : NodeModel,
+            database: {
+                storage: {
+                    dbPath: ':memory:'
+                }
+            }
+        });
+        
+        let errorThrown = false;
+        try {
+            store.clear();
+        } catch(e) {
+            errorThrown = true;
+        }
+        expect(errorThrown).toBe(false);
+        store.destroy();
+    });
+
+    test('should allow clear() on a test database path', async () => {
+        let store = Neo.create(Store, {
+            model   : NodeModel,
+            database: {
+                storage: {
+                    dbPath: '/Users/user/tmp/test.sqlite'
+                }
+            }
+        });
+        
+        let errorThrown = false;
+        try {
+            store.clear();
+        } catch(e) {
+            errorThrown = true;
+        }
+        expect(errorThrown).toBe(false);
+        store.destroy();
+    });
+
+    test('should block clearSilent() on a production database path', async () => {
+        let store = Neo.create(Store, {
+            model   : NodeModel,
+            database: {
+                storage: {
+                    dbPath: '/Users/user/db/production.sqlite'
+                }
+            }
+        });
+        
+        let errorThrown = false;
+        try {
+            store.clearSilent();
+        } catch(e) {
+            errorThrown = true;
+            expect(e.message).toContain('FATAL: Attempted to clear()');
+        }
+        expect(errorThrown).toBe(true);
+        store.destroy();
+    });
+});


### PR DESCRIPTION
Resolves #11140

This PR implements an explicit production safeguard inside `Neo.ai.graph.Store` to prevent bulk wipe operations (`clear()` and `clearSilent()`) from unintentionally wiping the live production graph when running in environments where config drift connects to the live database (e.g. test environments that fail to bind `:memory:` or temporary databases).

Authored by Gemini 3.1 Pro (Antigravity). Session d5ed6767-0292-46bf-9346-439f268048ec.

Evidence: L1 (static validation via Unit Test executing `clear()` operation on non-temporary target) → L1 required (no further host integration effects). No residuals.

## Deltas from ticket (if any)
- The original ticket highlighted `removeNodes` and `removeEdges` in `SQLite` as the cascade vectors. Instead of guarding the low-level physical deletions (which validly process individual removals), we secured the high-level `Store.clear()` semantic action, avoiding performance penalties on individual row deletions.
- Injected `database: this` context from `Database` into `Store`'s `beforeSetEdges`/`beforeSetNodes` hooks.

## Test Evidence
- Created `test/playwright/unit/ai/graph/StoreSafeguards.spec.mjs`.
- Verified `clear()` and `clearSilent()` throw fatal errors for non-temporary endpoints (e.g. `main.sqlite`) and allow operations for explicit `:memory:` endpoints.
- `npm run test-unit` verified working as intended.
