### PR TITLE
feat(ai-restore): preserve-live merge semantics + per-incident filter/targeting/hooks (#11141)

### DIFF
--- a/ai/services/memory-core/DatabaseService.mjs
+++ b/ai/services/memory-core/DatabaseService.mjs
@@ -249,9 +249,19 @@ class DatabaseService extends Base {
 
         let imported = 0;
 
-        const insertNode = db.prepare('INSERT OR REPLACE INTO Nodes (id, user_id, data) VALUES (?, ?, ?)');
+        // Mode-dependent INSERT semantics (#11141):
+        //   - 'replace' mode: TRUNCATE-then-OR-REPLACE. Conflict impossible after truncate,
+        //     OR REPLACE retained for backward parity. Backup IS the new state.
+        //   - 'merge' mode: OR IGNORE. Preserves live rows when IDs collide; backup-only IDs
+        //     still INSERT; live-only IDs untouched. This is the "merge latest content with
+        //     backup" semantic the runRestore two-mode contract documented (#10871). Pre-#11141,
+        //     merge silently used OR REPLACE — overwriting post-wipe re-ingestion (gh-workflow +
+        //     retrospective daemon) with stale backup versions. The 2026-05-10 graph-wipe incident
+        //     was the empirical anchor that surfaced this gap.
+        const conflictClause = mode === 'replace' ? 'OR REPLACE' : 'OR IGNORE';
+        const insertNode = db.prepare(`INSERT ${conflictClause} INTO Nodes (id, user_id, data) VALUES (?, ?, ?)`);
         const insertEdge = db.prepare(`
-            INSERT OR REPLACE INTO Edges (id, user_id, source, target, type, data)
+            INSERT ${conflictClause} INTO Edges (id, user_id, source, target, type, data)
             VALUES (?, ?, ?, ?, ?, ?)
         `);
 

--- a/ai/services/memory-core/DatabaseService.mjs
+++ b/ai/services/memory-core/DatabaseService.mjs
@@ -265,31 +265,56 @@ class DatabaseService extends Base {
             VALUES (?, ?, ?, ?, ?, ?)
         `);
 
+        // Truthful counters per @neo-gpt's #11141 peer-review (commentId 4416007918):
+        // distinguish inserted (changes === 1) from skippedExisting (changes === 0; OR
+        // IGNORE silently no-op'd) vs failed (exception per-record). Better-sqlite3
+        // exposes this via `stmt.run().changes`.
+        const counts = {
+            nodes: {inserted: 0, skippedExisting: 0, failed: 0},
+            edges: {inserted: 0, skippedExisting: 0, failed: 0}
+        };
+
         // Run within a transaction for speed
         const insertBatch = db.transaction((records) => {
             for (const record of records) {
                 if (record.type === 'node') {
-                    insertNode.run(
-                        record.data.id,
-                        record.data.properties?.userId || record.data.user_id || null,
-                        JSON.stringify(record.data)
-                    );
+                    try {
+                        const result = insertNode.run(
+                            record.data.id,
+                            record.data.properties?.userId || record.data.user_id || null,
+                            JSON.stringify(record.data)
+                        );
+                        if (result.changes === 1) counts.nodes.inserted++;
+                        else                       counts.nodes.skippedExisting++;
+                    } catch (e) {
+                        counts.nodes.failed++;
+                        if (counts.nodes.failed <= 5) logger.warn(`[importGraph] node insert failed for id=${record.data?.id}: ${e.message}`);
+                    }
                 } else if (record.type === 'edge') {
                     const edgeData = record.data;
                     const edgeId   = edgeData.id || `${edgeData.source}->${edgeData.target}:${edgeData.type}`;
 
                     if (!edgeData.source || !edgeData.target || !edgeData.type) {
-                        throw new Error(`Invalid graph edge backup record: source, target, and type are required.`);
+                        counts.edges.failed++;
+                        if (counts.edges.failed <= 5) logger.warn(`[importGraph] edge missing source/target/type: id=${edgeId}`);
+                        continue;
                     }
 
-                    insertEdge.run(
-                        edgeId,
-                        edgeData.properties?.userId || edgeData.user_id || null,
-                        edgeData.source,
-                        edgeData.target,
-                        edgeData.type,
-                        JSON.stringify(edgeData)
-                    );
+                    try {
+                        const result = insertEdge.run(
+                            edgeId,
+                            edgeData.properties?.userId || edgeData.user_id || null,
+                            edgeData.source,
+                            edgeData.target,
+                            edgeData.type,
+                            JSON.stringify(edgeData)
+                        );
+                        if (result.changes === 1) counts.edges.inserted++;
+                        else                       counts.edges.skippedExisting++;
+                    } catch (e) {
+                        counts.edges.failed++;
+                        if (counts.edges.failed <= 5) logger.warn(`[importGraph] edge insert failed for id=${edgeId}: ${e.message}`);
+                    }
                 }
                 imported++;
             }
@@ -309,8 +334,10 @@ class DatabaseService extends Base {
              insertBatch(batch);
         }
 
-        logger.log(`Successfully imported ${imported} graph elements.`);
-        return imported;
+        const summary = `nodes(inserted=${counts.nodes.inserted}, skipped=${counts.nodes.skippedExisting}, failed=${counts.nodes.failed}) ` +
+                        `edges(inserted=${counts.edges.inserted}, skipped=${counts.edges.skippedExisting}, failed=${counts.edges.failed})`;
+        logger.log(`Successfully imported ${imported} graph elements: ${summary}`);
+        return {imported, counts, mode};
     }
 
     /**
@@ -432,8 +459,10 @@ class DatabaseService extends Base {
                 
                 const isGraphBackup = path.basename(filePath).startsWith('graph-backup');
                 if (isGraphBackup) {
-                    const graphImportCount = await this.#importGraph(filePath, mode, confirmation);
-                    totalImported += graphImportCount;
+                    const graphImportResult = await this.#importGraph(filePath, mode, confirmation);
+                    // #11141: #importGraph now returns {imported, counts, mode}; counts
+                    // exposes node/edge inserted/skippedExisting/failed for truthful merge accounting.
+                    totalImported += graphImportResult.imported;
                     continue;
                 }
 

--- a/ai/services/memory-core/DatabaseService.mjs
+++ b/ai/services/memory-core/DatabaseService.mjs
@@ -453,16 +453,22 @@ class DatabaseService extends Base {
 
             let totalImported        = 0;
             let targetCollectionName = '';
+            // #11141: per-substrate truthful counters surface alongside the aggregate so
+            // operator validation can distinguish inserted vs skippedExisting vs failed
+            // post-merge. Currently only graph emits structured counts (`#importGraph`);
+            // memory/summaries upsert path is bulk + adds its count to memoriesInserted.
+            const subsystemCounts = {graph: null, memoriesInserted: 0};
 
             for (const filePath of filesToImport) {
                 logger.log(`Importing: ${filePath}`);
-                
+
                 const isGraphBackup = path.basename(filePath).startsWith('graph-backup');
                 if (isGraphBackup) {
                     const graphImportResult = await this.#importGraph(filePath, mode, confirmation);
                     // #11141: #importGraph now returns {imported, counts, mode}; counts
                     // exposes node/edge inserted/skippedExisting/failed for truthful merge accounting.
                     totalImported += graphImportResult.imported;
+                    subsystemCounts.graph = graphImportResult.counts;
                     continue;
                 }
 
@@ -501,13 +507,18 @@ class DatabaseService extends Base {
                     documents : records.map(r => r.document)
                 });
 
-                totalImported += records.length;
+                totalImported           += records.length;
+                subsystemCounts.memoriesInserted += records.length;
             }
 
             return {
                 message : `Import batch complete. Successfully ingested ${totalImported} records across ${filesToImport.length} file(s).`,
                 imported: totalImported,
-                mode
+                mode,
+                // #11141: structured per-substrate breakdown for operator validation.
+                // `graph` is null when no graph file was imported in this batch; otherwise
+                // exposes {nodes: {inserted,skippedExisting,failed}, edges: {inserted,skippedExisting,failed}}.
+                counts  : subsystemCounts
             };
         } catch (error) {
             logger.error('[DatabaseService] Error importing database:', error);

--- a/buildScripts/ai/restore.mjs
+++ b/buildScripts/ai/restore.mjs
@@ -47,13 +47,26 @@ import {
  *   the restore refuses unless the operator passes `--force-topology-mismatch`.
  *   Bundles without `bundle-meta.json` skip this check with a console warning.
  * - **Two-mode contract:**
- *     - `--mode merge` (default): idempotent. Embedded substrates upsert (no destructive
- *       wipe). Flat substrates skip-if-target-non-empty (preserves operator additions).
- *       No `--force` required.
+ *     - `--mode merge` (default): idempotent. Embedded substrates use `INSERT OR IGNORE` —
+ *       backup-only IDs INSERT; live-existing IDs preserved (post-wipe re-ingestion stays
+ *       authoritative). Flat substrates skip-if-target-non-empty (preserves operator
+ *       additions). No `--force` required. Per-#11141: this preserve-live semantic was
+ *       silently broken pre-#11141 (used `INSERT OR REPLACE`); 2026-05-10 graph-wipe
+ *       incident was the empirical anchor.
  *     - `--mode replace`: gated. Each embedded subsystem fires
  *       `assertDestructiveTargetAllowed()` before truncating + restoring. Flat substrates
  *       fire the guard against the target file/dir path before overwriting. Refuses if
  *       any target is non-empty without `--force`.
+ *
+ * - **Per-incident customization (#11141):**
+ *     - `--filter-labels=<csv>` — drop graph nodes with these labels (orphan-edge guard
+ *       drops edges whose endpoint was filtered). Example: `FILE,DIRECTORY,KB_GAP,TOOLING_GAP`.
+ *     - `--filter-edge-types=<csv>` — drop graph edges with these types. Example:
+ *       `CONTAINS,DISCOVERED_IN,EVALUATED_BY`.
+ *     - `--only-substrate=<csv>` — restrict to listed substrates. Example: `graph` (skips
+ *       kb/mc/concepts/trajectories/mailbox).
+ *     - `--post-restore-hook=<name>` — invoke after restore. Currently: `filesystem-ingestor`
+ *       (regenerates FILE/DIRECTORY/CONTAINS deterministically from current filesystem).
  *
  * ## Intentionally-out-of-scope
  *
@@ -93,8 +106,12 @@ const OPTIONAL_BUNDLE_SUBDIRS = ['mailbox'];
  * @param {String}  [options.conceptsTargetDir]            Override the default concepts target directory.
  * @param {String}  [options.trajectoriesTargetFile]       Override the default trajectories target file.
  * @param {String}  [options.sentToCullTargetFile]         Override the default sent-to-cull target file.
+ * @param {String[]}[options.filterLabels=[]]              Per-incident #11141 customization: drop graph nodes with these labels. Orphan-edge guard auto-fires (drops edges whose endpoint was filtered). Empty list = no filter. Example today's-incident set: `['FILE', 'DIRECTORY', 'KB_GAP', 'TOOLING_GAP']` (FILE/DIRECTORY are regenerable via FileSystemIngestor; KB_GAP/TOOLING_GAP are operator-classified garbage from per-file hallucination).
+ * @param {String[]}[options.filterEdgeTypes=[]]           Per-incident #11141 customization: drop graph edges with these types. Example today's-incident set: `['CONTAINS', 'DISCOVERED_IN', 'EVALUATED_BY']`.
+ * @param {String[]}[options.onlySubstrate=null]           If provided, restore ONLY these substrates (subset of `['kb','mc','graph','concepts','trajectories','mailbox']`). Null = all (existing behavior).
+ * @param {String}  [options.postRestoreHook=null]         Post-restore hook name. Currently supported: `'filesystem-ingestor'` (regenerates FILE/DIRECTORY/CONTAINS deterministically from current filesystem). Null = none.
  * @param {Object}  [options.logger=console]               Log sink; useful for tests.
- * @returns {Promise<{bundleRoot: String, mode: String, subsystems: Object, meta: Object|null, topology: Object}>}
+ * @returns {Promise<{bundleRoot: String, mode: String, subsystems: Object, meta: Object|null, topology: Object, postRestoreHook: Object|null}>}
  */
 export async function runRestore({
     bundleRoot,
@@ -105,6 +122,10 @@ export async function runRestore({
     conceptsTargetDir       = DEFAULT_CONCEPTS_DIR,
     trajectoriesTargetFile  = DEFAULT_TRAJECTORIES_FILE,
     sentToCullTargetFile    = DEFAULT_SENT_TO_CULL_FILE,
+    filterLabels            = [],
+    filterEdgeTypes         = [],
+    onlySubstrate           = null,
+    postRestoreHook         = null,
     logger                  = console
 } = {}) {
     if (!bundleRoot) {
@@ -150,9 +171,21 @@ export async function runRestore({
 
     const subsystems = {};
 
+    // Per-substrate gate (#11141): null `onlySubstrate` = all subsystems (existing behavior).
+    // Non-null array restricts to listed names. Validates against the known substrate set
+    // so typos fail fast instead of silently no-op'ing the entire restore.
+    const ALL_SUBSTRATES   = ['kb', 'mc', 'graph', 'concepts', 'trajectories', 'mailbox'];
+    if (Array.isArray(onlySubstrate)) {
+        const unknown = onlySubstrate.filter(s => !ALL_SUBSTRATES.includes(s));
+        if (unknown.length > 0) {
+            throw new Error(`Unknown substrate(s) in --only-substrate: ${unknown.join(', ')}. Valid: ${ALL_SUBSTRATES.join(', ')}.`);
+        }
+    }
+    const shouldRestore = (substrate) => onlySubstrate === null || onlySubstrate.includes(substrate);
+
     logger.log('[4/6] Restoring embedded substrates (KB, MC memories+summaries, MC graph)...');
 
-    if (await fs.pathExists(layout.kb)) {
+    if (shouldRestore('kb') && await fs.pathExists(layout.kb)) {
         subsystems.kb = await KB_DatabaseService.manageDatabaseBackup({
             action: 'import',
             file  : layout.kb,
@@ -161,7 +194,7 @@ export async function runRestore({
         });
     }
 
-    if (await fs.pathExists(layout.mc)) {
+    if (shouldRestore('mc') && await fs.pathExists(layout.mc)) {
         subsystems.mc = await Memory_DatabaseService.manageDatabaseBackup({
             action: 'import',
             file  : layout.mc,
@@ -170,38 +203,55 @@ export async function runRestore({
         });
     }
 
-    if (await fs.pathExists(layout.graph)) {
+    if (shouldRestore('graph') && await fs.pathExists(layout.graph)) {
+        // Apply per-incident filter (#11141): drop nodes/edges by label/type before SDK import.
+        // Stream-filter into a temp dir matching the bundle layout. Idempotent on re-run.
+        // Empty filter sets short-circuit to original layout.graph (no extra work).
+        const filterStats   = {filteredNodes: 0, filteredEdges: 0, orphanEdges: 0};
+        const graphInputDir = (filterLabels.length || filterEdgeTypes.length)
+            ? await prepareFilteredGraphDir({sourceDir: layout.graph, filterLabels, filterEdgeTypes, stats: filterStats, logger})
+            : layout.graph;
+
         subsystems.graph = await Memory_DatabaseService.manageDatabaseBackup({
             action: 'import',
-            file  : layout.graph,
+            file  : graphInputDir,
             mode,
             confirmation
         });
+
+        if (filterLabels.length || filterEdgeTypes.length) {
+            subsystems.graph.filterStats = filterStats;
+            logger.log(`[Restore][graph] filtered out ${filterStats.filteredNodes} nodes (labels: ${filterLabels.join(',') || '—'}) + ${filterStats.filteredEdges} edges (types: ${filterEdgeTypes.join(',') || '—'}) + ${filterStats.orphanEdges} orphan-endpoint edges before SDK import.`);
+        }
     }
 
     logger.log('[5/6] Restoring flat substrates (concepts, trajectories, mailbox)...');
 
-    subsystems.concepts = await restoreFlatDir({
-        sourceDir : layout.concepts,
-        targetDir : conceptsTargetDir,
-        mode,
-        force,
-        confirmation,
-        subsystem : 'concepts',
-        logger
-    });
+    if (shouldRestore('concepts')) {
+        subsystems.concepts = await restoreFlatDir({
+            sourceDir : layout.concepts,
+            targetDir : conceptsTargetDir,
+            mode,
+            force,
+            confirmation,
+            subsystem : 'concepts',
+            logger
+        });
+    }
 
-    subsystems.trajectories = await restoreFlatFile({
-        sourceDir : layout.trajectories,
-        targetFile: trajectoriesTargetFile,
-        mode,
-        force,
-        confirmation,
-        subsystem : 'trajectories',
-        logger
-    });
+    if (shouldRestore('trajectories')) {
+        subsystems.trajectories = await restoreFlatFile({
+            sourceDir : layout.trajectories,
+            targetFile: trajectoriesTargetFile,
+            mode,
+            force,
+            confirmation,
+            subsystem : 'trajectories',
+            logger
+        });
+    }
 
-    if (await fs.pathExists(layout.mailbox)) {
+    if (shouldRestore('mailbox') && await fs.pathExists(layout.mailbox)) {
         subsystems.mailbox = await restoreFlatFile({
             sourceDir : layout.mailbox,
             targetFile: sentToCullTargetFile,
@@ -213,12 +263,22 @@ export async function runRestore({
         });
     }
 
+    // Post-restore hook dispatch (#11141). Currently supported:
+    //   - 'filesystem-ingestor': regenerates FILE/DIRECTORY/CONTAINS substrate from
+    //     current filesystem state. Idempotent + deterministic. Recommended after a
+    //     graph restore that filtered out FILE/DIRECTORY (avoids stale-path nodes
+    //     for files that no longer exist).
+    let postRestoreHookResult = null;
+    if (postRestoreHook) {
+        postRestoreHookResult = await dispatchPostRestoreHook({hook: postRestoreHook, logger});
+    }
+
     logger.log('[6/6] Restore complete.');
     if (meta) {
         logger.log(`Source bundle: bundleVersion=${meta.bundleVersion ?? '?'}, neoVersion=${meta.neoVersion ?? '?'}, gitSha=${meta.gitSha ?? '?'}, completedAt=${meta.completedAt ?? '?'}`);
     }
 
-    return {bundleRoot: resolvedRoot, mode, subsystems, meta, topology}
+    return {bundleRoot: resolvedRoot, mode, subsystems, meta, topology, postRestoreHook: postRestoreHookResult}
 }
 
 /**
@@ -485,6 +545,112 @@ async function restoreFlatFile({sourceDir, targetFile, mode, force, confirmation
 }
 
 /**
+ * #11141 — Pre-import filter for graph JSONL bundles.
+ *
+ * Stream-reads each `*.jsonl` file under `sourceDir`, drops nodes whose `data.label`
+ * matches `filterLabels` and edges whose `data.type` matches `filterEdgeTypes`. Also
+ * fires the orphan-edge guard: drops edges whose source OR target endpoint was filtered
+ * out (preserves graph integrity post-filter).
+ *
+ * Writes filtered output to a temp dir at `${os.tmpdir()}/neo-restore-graph-<ts>/` mirroring
+ * the source-dir layout. Returns the temp dir path for the SDK import.
+ *
+ * Idempotent + safe per-run: temp dirs are uniquely timestamped; OS cleanup or explicit
+ * caller cleanup handles tear-down. Does NOT mutate the source bundle.
+ *
+ * Empty filter sets short-circuit to source-dir return (no file IO). Caller responsibility
+ * to gate on filter-presence before invoking.
+ *
+ * @param {Object}   options
+ * @param {String}   options.sourceDir       Bundle's `graph/` directory containing JSONL files.
+ * @param {String[]} options.filterLabels    Node labels to drop.
+ * @param {String[]} options.filterEdgeTypes Edge types to drop.
+ * @param {Object}   options.stats           Mutable counters: `{filteredNodes, filteredEdges, orphanEdges}`.
+ * @param {Object}   [options.logger=console]
+ * @returns {Promise<String>} Path to temp dir with filtered JSONL files.
+ */
+async function prepareFilteredGraphDir({sourceDir, filterLabels, filterEdgeTypes, stats, logger = console}) {
+    const os       = (await import('os')).default;
+    const readline = (await import('readline')).default;
+    const labelSet = new Set(filterLabels);
+    const typeSet  = new Set(filterEdgeTypes);
+
+    const tempDir = path.join(os.tmpdir(), `neo-restore-graph-${Date.now()}`);
+    await fs.ensureDir(tempDir);
+
+    const sourceFiles = (await fs.readdir(sourceDir)).filter(f => f.endsWith('.jsonl'));
+    if (sourceFiles.length === 0) return sourceDir; // empty bundle, fall through unchanged
+
+    for (const fileName of sourceFiles) {
+        const inPath  = path.join(sourceDir, fileName);
+        const outPath = path.join(tempDir, fileName);
+
+        // First pass: identify dropped node IDs (orphan-edge guard depends on this set).
+        const droppedNodeIds = new Set();
+        if (labelSet.size > 0) {
+            const rl = readline.createInterface({input: fs.createReadStream(inPath), crlfDelay: Infinity});
+            for await (const line of rl) {
+                if (!line.trim()) continue;
+                try {
+                    const r = JSON.parse(line);
+                    if (r.type === 'node' && labelSet.has(r.data?.label)) {
+                        droppedNodeIds.add(r.data.id);
+                    }
+                } catch (e) { /* skip malformed lines */ }
+            }
+        }
+
+        // Second pass: write filtered output.
+        const rl2  = readline.createInterface({input: fs.createReadStream(inPath), crlfDelay: Infinity});
+        const out  = fs.createWriteStream(outPath);
+        for await (const line of rl2) {
+            if (!line.trim()) continue;
+            try {
+                const r = JSON.parse(line);
+                if (r.type === 'node') {
+                    if (labelSet.has(r.data?.label)) { stats.filteredNodes++; continue; }
+                } else if (r.type === 'edge') {
+                    if (typeSet.has(r.data?.type)) { stats.filteredEdges++; continue; }
+                    if (droppedNodeIds.has(r.data?.source) || droppedNodeIds.has(r.data?.target)) {
+                        stats.orphanEdges++;
+                        continue;
+                    }
+                }
+                out.write(line + '\n');
+            } catch (e) { /* skip malformed lines */ }
+        }
+        await new Promise(resolve => out.end(resolve));
+    }
+
+    logger.log?.(`[Restore][graph] pre-import filter: writing filtered JSONL to ${tempDir}`);
+    return tempDir;
+}
+
+/**
+ * #11141 — Post-restore hook dispatch.
+ *
+ * Currently supported hooks:
+ *   - `'filesystem-ingestor'`: regenerates FILE/DIRECTORY nodes + CONTAINS edges from
+ *     current filesystem state. Idempotent + deterministic. Recommended after restoring
+ *     a graph backup with FILE/DIRECTORY filtered out (avoids stale-path nodes for files
+ *     that no longer exist post-refactor).
+ *
+ * @param {Object} options
+ * @param {String} options.hook   Hook name.
+ * @param {Object} [options.logger=console]
+ * @returns {Promise<{hook: String, result: Object}>}
+ */
+async function dispatchPostRestoreHook({hook, logger = console}) {
+    if (hook === 'filesystem-ingestor') {
+        logger.log(`[Restore] Triggering post-restore hook: filesystem-ingestor (regenerates FILE/DIRECTORY/CONTAINS)...`);
+        const FileSystemIngestor = (await import('../../ai/services/memory-core/FileSystemIngestor.mjs')).default;
+        await FileSystemIngestor.syncWorkspaceToGraph();
+        return {hook, result: {ok: true, message: 'FileSystemIngestor.syncWorkspaceToGraph() completed'}};
+    }
+    throw new Error(`Unknown post-restore hook: ${hook}. Supported: filesystem-ingestor.`);
+}
+
+/**
  * Parses CLI arguments for direct-invocation mode.
  *
  * Shape: `node ./buildScripts/ai/restore.mjs <bundle-path> [--mode merge|replace] [--force] [--force-topology-mismatch]`
@@ -497,6 +663,12 @@ export function parseArgs(argv) {
     let mode                    = 'merge';
     let force                   = false;
     let forceTopologyMismatch   = false;
+    let filterLabels            = [];
+    let filterEdgeTypes         = [];
+    let onlySubstrate           = null;
+    let postRestoreHook         = null;
+
+    const splitCsv = s => String(s).split(',').map(t => t.trim()).filter(Boolean);
 
     for (let i = 0; i < argv.length; i++) {
         const arg = argv[i];
@@ -506,6 +678,22 @@ export function parseArgs(argv) {
             force = true;
         } else if (arg === '--force-topology-mismatch') {
             forceTopologyMismatch = true;
+        } else if (arg === '--filter-labels') {
+            filterLabels = splitCsv(argv[++i]);
+        } else if (arg.startsWith('--filter-labels=')) {
+            filterLabels = splitCsv(arg.slice('--filter-labels='.length));
+        } else if (arg === '--filter-edge-types') {
+            filterEdgeTypes = splitCsv(argv[++i]);
+        } else if (arg.startsWith('--filter-edge-types=')) {
+            filterEdgeTypes = splitCsv(arg.slice('--filter-edge-types='.length));
+        } else if (arg === '--only-substrate') {
+            onlySubstrate = splitCsv(argv[++i]);
+        } else if (arg.startsWith('--only-substrate=')) {
+            onlySubstrate = splitCsv(arg.slice('--only-substrate='.length));
+        } else if (arg === '--post-restore-hook') {
+            postRestoreHook = argv[++i];
+        } else if (arg.startsWith('--post-restore-hook=')) {
+            postRestoreHook = arg.slice('--post-restore-hook='.length);
         } else if (arg.startsWith('--')) {
             throw new Error(`Unknown flag: ${arg}`);
         } else {
@@ -520,7 +708,7 @@ export function parseArgs(argv) {
         throw new Error(`Unexpected positional arguments: ${positional.slice(1).join(' ')}`);
     }
 
-    return {bundleRoot: positional[0], mode, force, forceTopologyMismatch}
+    return {bundleRoot: positional[0], mode, force, forceTopologyMismatch, filterLabels, filterEdgeTypes, onlySubstrate, postRestoreHook}
 }
 
 if (import.meta.url === `file://${process.argv[1]}`) {
@@ -538,6 +726,12 @@ if (import.meta.url === `file://${process.argv[1]}`) {
     } catch (error) {
         console.error(error.message);
         console.error('Usage: node ./buildScripts/ai/restore.mjs <bundle-path> [--mode merge|replace] [--force] [--force-topology-mismatch]');
+        console.error('       [--filter-labels=<csv>] [--filter-edge-types=<csv>] [--only-substrate=<csv>] [--post-restore-hook=<name>]');
+        console.error('Example (today\'s graph wipe restore):');
+        console.error('  npm run ai:restore -- <bundle-path> --mode merge --only-substrate=graph \\');
+        console.error('    --filter-labels=FILE,DIRECTORY,KB_GAP,TOOLING_GAP \\');
+        console.error('    --filter-edge-types=CONTAINS,DISCOVERED_IN,EVALUATED_BY \\');
+        console.error('    --post-restore-hook=filesystem-ingestor');
         process.exit(2);
     }
 }

--- a/buildScripts/ai/restore.mjs
+++ b/buildScripts/ai/restore.mjs
@@ -206,11 +206,25 @@ export async function runRestore({
     if (shouldRestore('graph') && await fs.pathExists(layout.graph)) {
         // Apply per-incident filter (#11141): drop nodes/edges by label/type before SDK import.
         // Stream-filter into a temp dir matching the bundle layout. Idempotent on re-run.
-        // Empty filter sets short-circuit to original layout.graph (no extra work).
-        const filterStats   = {filteredNodes: 0, filteredEdges: 0, orphanEdges: 0};
-        const graphInputDir = (filterLabels.length || filterEdgeTypes.length)
-            ? await prepareFilteredGraphDir({sourceDir: layout.graph, filterLabels, filterEdgeTypes, stats: filterStats, logger})
-            : layout.graph;
+        // Filter goes through the FK-safe Stage-1/2/3 algorithm (per @neo-gpt review).
+        // Empty filter sets short-circuit to original layout.graph (no extra work / no live read).
+        const filterStats   = {filteredNodes: 0, filteredEdges: 0, orphanEdges: 0, acceptedNodes: 0};
+        const filterActive  = filterLabels.length > 0 || filterEdgeTypes.length > 0;
+
+        let graphInputDir = layout.graph;
+        if (filterActive) {
+            // Read-only snapshot of live node IDs (Stage-2 union with accepted-backup IDs).
+            // WAL mode lets us read concurrently with the running MC daemon.
+            const liveNodeIds = await collectLiveGraphNodeIds({dbPath: mcConfig.storagePaths.graph});
+            graphInputDir = await prepareFilteredGraphDir({
+                sourceDir       : layout.graph,
+                filterLabels,
+                filterEdgeTypes,
+                liveNodeIds,
+                stats           : filterStats,
+                logger
+            });
+        }
 
         subsystems.graph = await Memory_DatabaseService.manageDatabaseBackup({
             action: 'import',
@@ -219,9 +233,9 @@ export async function runRestore({
             confirmation
         });
 
-        if (filterLabels.length || filterEdgeTypes.length) {
+        if (filterActive) {
             subsystems.graph.filterStats = filterStats;
-            logger.log(`[Restore][graph] filtered out ${filterStats.filteredNodes} nodes (labels: ${filterLabels.join(',') || '—'}) + ${filterStats.filteredEdges} edges (types: ${filterEdgeTypes.join(',') || '—'}) + ${filterStats.orphanEdges} orphan-endpoint edges before SDK import.`);
+            logger.log(`[Restore][graph] filtered out ${filterStats.filteredNodes} nodes (labels: ${filterLabels.join(',') || '—'}) + ${filterStats.filteredEdges} edges (types: ${filterEdgeTypes.join(',') || '—'}) + ${filterStats.orphanEdges} orphan-endpoint edges before SDK import. Accepted backup nodes: ${filterStats.acceptedNodes}.`);
         }
     }
 
@@ -545,31 +559,39 @@ async function restoreFlatFile({sourceDir, targetFile, mode, force, confirmation
 }
 
 /**
- * #11141 — Pre-import filter for graph JSONL bundles.
+ * #11141 — Pre-import filter for graph JSONL bundles. Three-stage FK-safe shape per
+ * @neo-gpt's peer-review (commentId 4416007918):
  *
- * Stream-reads each `*.jsonl` file under `sourceDir`, drops nodes whose `data.label`
- * matches `filterLabels` and edges whose `data.type` matches `filterEdgeTypes`. Also
- * fires the orphan-edge guard: drops edges whose source OR target endpoint was filtered
- * out (preserves graph integrity post-filter).
+ * **Stage 1** — Read ALL bundle JSONL files, classify each node as accepted (passed
+ * labelSet) or dropped (matched labelSet). Build `acceptedBackupNodeIds` set.
  *
- * Writes filtered output to a temp dir at `${os.tmpdir()}/neo-restore-graph-<ts>/` mirroring
- * the source-dir layout. Returns the temp dir path for the SDK import.
+ * **Stage 2** — Compute `validEndpointIds = acceptedBackupNodeIds ∪ liveNodeIds`. An edge
+ * may safely INSERT only if both endpoints exist in this union (live row OR will-be-inserted
+ * backup row). Otherwise the edge would FK-violate against `Edges.source/target → Nodes(id)`
+ * post-`INSERT OR IGNORE`.
  *
- * Idempotent + safe per-run: temp dirs are uniquely timestamped; OS cleanup or explicit
- * caller cleanup handles tear-down. Does NOT mutate the source bundle.
+ * **Stage 3** — Write filtered output to temp dir. For each backup record:
+ *   - Node: drop if label in `filterLabels` (counter: `filteredNodes`); else keep.
+ *   - Edge: drop if type in `filterEdgeTypes` (counter: `filteredEdges`); drop if either
+ *     endpoint not in `validEndpointIds` (counter: `orphanEdges`); else keep.
  *
- * Empty filter sets short-circuit to source-dir return (no file IO). Caller responsibility
- * to gate on filter-presence before invoking.
+ * Stream-based I/O — constant memory regardless of bundle size. Per-run temp dirs use
+ * timestamped names; OS or caller cleans up. Does NOT mutate source bundle.
+ *
+ * Empty filter sets + empty live snapshot still go through the union check (all backup
+ * edges must reference accepted backup nodes); caller gates on filter-presence to skip
+ * entirely if filtering isn't required.
  *
  * @param {Object}   options
  * @param {String}   options.sourceDir       Bundle's `graph/` directory containing JSONL files.
  * @param {String[]} options.filterLabels    Node labels to drop.
  * @param {String[]} options.filterEdgeTypes Edge types to drop.
- * @param {Object}   options.stats           Mutable counters: `{filteredNodes, filteredEdges, orphanEdges}`.
+ * @param {Set}      options.liveNodeIds     Set of node IDs currently in the live graph SQLite (#11141 / FK-safe edge filter; #11140 review feedback).
+ * @param {Object}   options.stats           Mutable counters: `{filteredNodes, filteredEdges, orphanEdges, acceptedNodes}`.
  * @param {Object}   [options.logger=console]
  * @returns {Promise<String>} Path to temp dir with filtered JSONL files.
  */
-async function prepareFilteredGraphDir({sourceDir, filterLabels, filterEdgeTypes, stats, logger = console}) {
+async function prepareFilteredGraphDir({sourceDir, filterLabels, filterEdgeTypes, liveNodeIds, stats, logger = console}) {
     const os       = (await import('os')).default;
     const readline = (await import('readline')).default;
     const labelSet = new Set(filterLabels);
@@ -581,29 +603,38 @@ async function prepareFilteredGraphDir({sourceDir, filterLabels, filterEdgeTypes
     const sourceFiles = (await fs.readdir(sourceDir)).filter(f => f.endsWith('.jsonl'));
     if (sourceFiles.length === 0) return sourceDir; // empty bundle, fall through unchanged
 
+    // ───── Stage 1: cross-bundle node classification ─────
+    // Walk EVERY JSONL file before filtering edges so that union check sees nodes from
+    // sibling files (e.g., bundle splits node export and edge export). Per-file
+    // classification (the previous shape) would FK-violate on cross-file edges.
+    const acceptedBackupNodeIds = new Set();
+    for (const fileName of sourceFiles) {
+        const rl = readline.createInterface({input: fs.createReadStream(path.join(sourceDir, fileName)), crlfDelay: Infinity});
+        for await (const line of rl) {
+            if (!line.trim()) continue;
+            try {
+                const r = JSON.parse(line);
+                if (r.type === 'node' && r.data?.id && !labelSet.has(r.data?.label)) {
+                    acceptedBackupNodeIds.add(r.data.id);
+                }
+            } catch (e) { /* skip malformed lines */ }
+        }
+    }
+    stats.acceptedNodes = acceptedBackupNodeIds.size;
+
+    // ───── Stage 2: compute valid endpoint set ─────
+    // Edge may insert only if both endpoints exist in (accepted backup ∪ live). Pre-
+    // computing the union keeps Stage 3 to a hot-path Set lookup per endpoint.
+    const validEndpointIds = new Set(liveNodeIds);
+    for (const id of acceptedBackupNodeIds) validEndpointIds.add(id);
+
+    // ───── Stage 3: write filtered output ─────
     for (const fileName of sourceFiles) {
         const inPath  = path.join(sourceDir, fileName);
         const outPath = path.join(tempDir, fileName);
-
-        // First pass: identify dropped node IDs (orphan-edge guard depends on this set).
-        const droppedNodeIds = new Set();
-        if (labelSet.size > 0) {
-            const rl = readline.createInterface({input: fs.createReadStream(inPath), crlfDelay: Infinity});
-            for await (const line of rl) {
-                if (!line.trim()) continue;
-                try {
-                    const r = JSON.parse(line);
-                    if (r.type === 'node' && labelSet.has(r.data?.label)) {
-                        droppedNodeIds.add(r.data.id);
-                    }
-                } catch (e) { /* skip malformed lines */ }
-            }
-        }
-
-        // Second pass: write filtered output.
-        const rl2  = readline.createInterface({input: fs.createReadStream(inPath), crlfDelay: Infinity});
-        const out  = fs.createWriteStream(outPath);
-        for await (const line of rl2) {
+        const rl  = readline.createInterface({input: fs.createReadStream(inPath), crlfDelay: Infinity});
+        const out = fs.createWriteStream(outPath);
+        for await (const line of rl) {
             if (!line.trim()) continue;
             try {
                 const r = JSON.parse(line);
@@ -611,7 +642,7 @@ async function prepareFilteredGraphDir({sourceDir, filterLabels, filterEdgeTypes
                     if (labelSet.has(r.data?.label)) { stats.filteredNodes++; continue; }
                 } else if (r.type === 'edge') {
                     if (typeSet.has(r.data?.type)) { stats.filteredEdges++; continue; }
-                    if (droppedNodeIds.has(r.data?.source) || droppedNodeIds.has(r.data?.target)) {
+                    if (!validEndpointIds.has(r.data?.source) || !validEndpointIds.has(r.data?.target)) {
                         stats.orphanEdges++;
                         continue;
                     }
@@ -622,21 +653,52 @@ async function prepareFilteredGraphDir({sourceDir, filterLabels, filterEdgeTypes
         await new Promise(resolve => out.end(resolve));
     }
 
-    logger.log?.(`[Restore][graph] pre-import filter: writing filtered JSONL to ${tempDir}`);
+    logger.log?.(`[Restore][graph] pre-import filter: ${stats.acceptedNodes} accepted backup nodes, ${liveNodeIds.size} live nodes; writing filtered JSONL to ${tempDir}`);
     return tempDir;
 }
 
 /**
- * #11141 — Post-restore hook dispatch.
+ * #11141 — Read live graph node IDs for FK-safe edge filtering (per @neo-gpt review).
  *
- * Currently supported hooks:
- *   - `'filesystem-ingestor'`: regenerates FILE/DIRECTORY nodes + CONTAINS edges from
- *     current filesystem state. Idempotent + deterministic. Recommended after restoring
- *     a graph backup with FILE/DIRECTORY filtered out (avoids stale-path nodes for files
- *     that no longer exist post-refactor).
+ * Read-only better-sqlite3 access against the live `memory-core-graph.sqlite`. WAL mode
+ * is the default for the live DB so concurrent reads don't block the running MC daemon.
  *
  * @param {Object} options
- * @param {String} options.hook   Hook name.
+ * @param {String} options.dbPath Absolute path to live SQLite (`mcConfig.storagePaths.graph`).
+ * @returns {Promise<Set<String>>} Set of live node IDs.
+ */
+async function collectLiveGraphNodeIds({dbPath}) {
+    const Database = (await import('better-sqlite3')).default;
+    const db       = new Database(dbPath, {readonly: true, fileMustExist: true});
+    try {
+        const rows = db.prepare('SELECT id FROM Nodes').all();
+        return new Set(rows.map(r => r.id));
+    } finally {
+        db.close();
+    }
+}
+
+/**
+ * #11141 — Post-restore hook dispatch. **Narrow allowlist** per @neo-gpt's peer-review
+ * (commentId 4416007918): only deterministic, idempotent, recovery-safe hooks are accepted.
+ *
+ * **ALLOWED:**
+ *   - `'filesystem-ingestor'`: regenerates FILE/DIRECTORY nodes + CONTAINS edges from
+ *     current filesystem state via `FileSystemIngestor.syncWorkspaceToGraph()`.
+ *     Idempotent + deterministic. Recommended after restoring a graph backup with
+ *     FILE/DIRECTORY filtered out (avoids stale-path nodes for files that no longer
+ *     exist post-refactor).
+ *
+ * **EXPLICITLY DISALLOWED (per peer-review):**
+ *   - `'dream-service'`: performs higher-order graph mutation/inference via REM cycle.
+ *     Can blur post-restore validation immediately after recovery. Not equivalent to
+ *     idempotent filesystem regeneration; would need separate AC for safety boundary.
+ *     Defer to a follow-up ticket if needed.
+ *
+ * Unknown / disallowed hook names throw an explicit error rather than no-op silently.
+ *
+ * @param {Object} options
+ * @param {String} options.hook   Hook name (must be in allowlist).
  * @param {Object} [options.logger=console]
  * @returns {Promise<{hook: String, result: Object}>}
  */
@@ -647,7 +709,10 @@ async function dispatchPostRestoreHook({hook, logger = console}) {
         await FileSystemIngestor.syncWorkspaceToGraph();
         return {hook, result: {ok: true, message: 'FileSystemIngestor.syncWorkspaceToGraph() completed'}};
     }
-    throw new Error(`Unknown post-restore hook: ${hook}. Supported: filesystem-ingestor.`);
+    if (hook === 'dream-service') {
+        throw new Error(`Post-restore hook 'dream-service' is intentionally not supported (per #11141 peer-review): REM cycle does graph mutation + inference and can blur recovery validation. File a follow-up ticket if needed.`);
+    }
+    throw new Error(`Unknown post-restore hook: ${hook}. Allowlist: filesystem-ingestor.`);
 }
 
 /**

--- a/buildScripts/ai/restore.mjs
+++ b/buildScripts/ai/restore.mjs
@@ -591,7 +591,7 @@ async function restoreFlatFile({sourceDir, targetFile, mode, force, confirmation
  * @param {Object}   [options.logger=console]
  * @returns {Promise<String>} Path to temp dir with filtered JSONL files.
  */
-async function prepareFilteredGraphDir({sourceDir, filterLabels, filterEdgeTypes, liveNodeIds, stats, logger = console}) {
+export async function prepareFilteredGraphDir({sourceDir, filterLabels, filterEdgeTypes, liveNodeIds, stats, logger = console}) {
     const os       = (await import('os')).default;
     const readline = (await import('readline')).default;
     const labelSet = new Set(filterLabels);
@@ -667,7 +667,7 @@ async function prepareFilteredGraphDir({sourceDir, filterLabels, filterEdgeTypes
  * @param {String} options.dbPath Absolute path to live SQLite (`mcConfig.storagePaths.graph`).
  * @returns {Promise<Set<String>>} Set of live node IDs.
  */
-async function collectLiveGraphNodeIds({dbPath}) {
+export async function collectLiveGraphNodeIds({dbPath}) {
     const Database = (await import('better-sqlite3')).default;
     const db       = new Database(dbPath, {readonly: true, fileMustExist: true});
     try {
@@ -702,7 +702,7 @@ async function collectLiveGraphNodeIds({dbPath}) {
  * @param {Object} [options.logger=console]
  * @returns {Promise<{hook: String, result: Object}>}
  */
-async function dispatchPostRestoreHook({hook, logger = console}) {
+export async function dispatchPostRestoreHook({hook, logger = console}) {
     if (hook === 'filesystem-ingestor') {
         logger.log(`[Restore] Triggering post-restore hook: filesystem-ingestor (regenerates FILE/DIRECTORY/CONTAINS)...`);
         const FileSystemIngestor = (await import('../../ai/services/memory-core/FileSystemIngestor.mjs')).default;

--- a/buildScripts/ai/restore.mjs
+++ b/buildScripts/ai/restore.mjs
@@ -47,12 +47,13 @@ import {
  *   the restore refuses unless the operator passes `--force-topology-mismatch`.
  *   Bundles without `bundle-meta.json` skip this check with a console warning.
  * - **Two-mode contract:**
- *     - `--mode merge` (default): idempotent. Embedded substrates use `INSERT OR IGNORE` —
+ *     - `--mode merge` (default): idempotent. **Graph SQLite** uses `INSERT OR IGNORE` —
  *       backup-only IDs INSERT; live-existing IDs preserved (post-wipe re-ingestion stays
- *       authoritative). Flat substrates skip-if-target-non-empty (preserves operator
- *       additions). No `--force` required. Per-#11141: this preserve-live semantic was
- *       silently broken pre-#11141 (used `INSERT OR REPLACE`); 2026-05-10 graph-wipe
- *       incident was the empirical anchor.
+ *       authoritative). **Memory + summaries (Chroma)** still use `collection.upsert()` —
+ *       preserve-live parity for the Chroma side is tracked at #11144. **Flat substrates**
+ *       skip-if-target-non-empty (preserves operator additions). No `--force` required.
+ *       Per-#11141: graph-side preserve-live semantic was silently broken pre-#11141 (used
+ *       `INSERT OR REPLACE`); 2026-05-10 graph-wipe incident was the empirical anchor.
  *     - `--mode replace`: gated. Each embedded subsystem fires
  *       `assertDestructiveTargetAllowed()` before truncating + restoring. Flat substrates
  *       fire the guard against the target file/dir path before overwriting. Refuses if

--- a/test/playwright/unit/ai/buildScripts/restore-filters.spec.mjs
+++ b/test/playwright/unit/ai/buildScripts/restore-filters.spec.mjs
@@ -15,11 +15,18 @@ setup({
     }
 });
 
-import {test, expect}   from '@playwright/test';
-import fs               from 'fs';
-import fsExtra          from 'fs-extra';
-import os               from 'os';
-import path             from 'path';
+// Bootstrap parity with existing restore.spec.mjs (#11143/RA-2):
+// Importing `restore.mjs` chains to `ai/services.mjs` which loads core classes that
+// require `Neo.gatekeep` (Compare.mjs:166) to be registered. The setup() call only
+// configures Neo; the core augmentation happens via these imports.
+import {test, expect}  from '@playwright/test';
+import Neo             from '../../../../../src/Neo.mjs';
+import * as core       from '../../../../../src/core/_export.mjs';
+import InstanceManager from '../../../../../src/manager/Instance.mjs';
+import fs              from 'fs';
+import fsExtra         from 'fs-extra';
+import os              from 'os';
+import path            from 'path';
 
 /**
  * #11141 — focused unit tests for the new restore.mjs surfaces:
@@ -259,5 +266,154 @@ test.describe('restore.mjs filters + hooks (#11141)', () => {
     test('hook: unknown name rejected with allowlist hint', async () => {
         await expect(dispatchPostRestoreHook({hook: 'mystery-hook', logger: silentLogger}))
             .rejects.toThrow(/Unknown post-restore hook.*Allowlist: filesystem-ingestor/);
+    });
+
+    // ─────────────────────────────────────────────────────────────────────
+    // Row-level INSERT OR IGNORE preserve-live semantics (RA-3 from /pr-review)
+    //
+    // This is the core semantic correction the entire PR exists for: in merge
+    // mode, conflicting graph IDs must preserve the LIVE row (not overwrite
+    // with backup, and crucially NOT cascade-delete live edges via the
+    // DELETE-then-INSERT shape that `INSERT OR REPLACE` produces under SQLite's
+    // implementation).
+    //
+    // Tests use synthetic SQLite (better-sqlite3 directly) with the production
+    // schema shape (Nodes + Edges + ON DELETE CASCADE FK on Edges.source/target).
+    // No dependency on GraphService / Memory_DatabaseService boot lifecycle —
+    // this asserts the SQL primitive directly.
+    // ─────────────────────────────────────────────────────────────────────
+
+    test.describe('graph merge: INSERT OR IGNORE preserves live rows + edges (#11141 core semantic)', () => {
+        let Database;
+
+        test.beforeAll(async () => {
+            const mod = await import('better-sqlite3');
+            Database  = mod.default;
+        });
+
+        async function buildSyntheticGraphDb() {
+            const dbFile = path.join(workRoot, `graph-merge-${Date.now()}-${Math.random().toString(36).slice(2)}.sqlite`);
+            const db     = new Database(dbFile);
+            db.pragma('foreign_keys = ON');
+            db.exec(`
+                CREATE TABLE Nodes (
+                    id      TEXT PRIMARY KEY,
+                    user_id TEXT,
+                    data    TEXT
+                );
+                CREATE TABLE Edges (
+                    id      TEXT PRIMARY KEY,
+                    user_id TEXT,
+                    source  TEXT NOT NULL REFERENCES Nodes(id) ON DELETE CASCADE,
+                    target  TEXT NOT NULL REFERENCES Nodes(id) ON DELETE CASCADE,
+                    type    TEXT NOT NULL,
+                    data    TEXT
+                );
+            `);
+            return {db, dbFile};
+        }
+
+        test('merge mode (OR IGNORE): conflicting node-id keeps live row, no cascade-delete on its edges', () => {
+            const {db, dbFile} = (function () { const r = buildSyntheticGraphDb.bind(null)(); return r; })();
+            try {
+                // Live state: one node + one edge.
+                db.prepare("INSERT INTO Nodes (id, data) VALUES ('n1', 'LIVE-VERSION')").run();
+                db.prepare("INSERT INTO Nodes (id, data) VALUES ('n2', 'live')").run();
+                db.prepare("INSERT INTO Edges (id, source, target, type) VALUES ('e1', 'n1', 'n2', 'LIVE_EDGE')").run();
+
+                // Backup-style import (merge mode = OR IGNORE) for a conflicting node.
+                const insertNodeMerge = db.prepare("INSERT OR IGNORE INTO Nodes (id, user_id, data) VALUES (?, ?, ?)");
+                const result = insertNodeMerge.run('n1', null, 'BACKUP-VERSION-WOULD-OVERWRITE');
+
+                // OR IGNORE must report 0 changes (skipped) for the conflict.
+                expect(result.changes).toBe(0);
+
+                // Live row preserved.
+                const liveData = db.prepare("SELECT data FROM Nodes WHERE id = 'n1'").get();
+                expect(liveData.data).toBe('LIVE-VERSION');
+
+                // Critical: live edge NOT cascade-deleted (this would happen with OR REPLACE
+                // because SQLite implements OR REPLACE as DELETE-then-INSERT, which fires
+                // ON DELETE CASCADE on Edges.source/target → live edge gone).
+                const edge = db.prepare("SELECT id, type FROM Edges WHERE id = 'e1'").get();
+                expect(edge).toBeDefined();
+                expect(edge.type).toBe('LIVE_EDGE');
+            } finally {
+                db.close();
+                fs.unlinkSync(dbFile);
+            }
+        });
+
+        test('replace mode (OR REPLACE): conflicting node-id overwrites + cascade-deletes its edges (DOCUMENTED behavior)', () => {
+            const {db, dbFile} = (function () { const r = buildSyntheticGraphDb.bind(null)(); return r; })();
+            try {
+                // Live state: one node + one edge.
+                db.prepare("INSERT INTO Nodes (id, data) VALUES ('n1', 'LIVE-VERSION')").run();
+                db.prepare("INSERT INTO Nodes (id, data) VALUES ('n2', 'live')").run();
+                db.prepare("INSERT INTO Edges (id, source, target, type) VALUES ('e1', 'n1', 'n2', 'LIVE_EDGE')").run();
+
+                // Replace mode (OR REPLACE).
+                const insertNodeReplace = db.prepare("INSERT OR REPLACE INTO Nodes (id, user_id, data) VALUES (?, ?, ?)");
+                const result = insertNodeReplace.run('n1', null, 'BACKUP-VERSION');
+
+                // OR REPLACE reports 1 changes (replaced).
+                expect(result.changes).toBe(1);
+
+                // Live row replaced.
+                const replacedData = db.prepare("SELECT data FROM Nodes WHERE id = 'n1'").get();
+                expect(replacedData.data).toBe('BACKUP-VERSION');
+
+                // The cascade-delete is the empirical reason merge mode MUST NOT use OR REPLACE:
+                // Edge with source='n1' was destroyed by ON DELETE CASCADE during the implicit
+                // DELETE phase of INSERT OR REPLACE.
+                const edge = db.prepare("SELECT id FROM Edges WHERE id = 'e1'").get();
+                expect(edge).toBeUndefined();
+            } finally {
+                db.close();
+                fs.unlinkSync(dbFile);
+            }
+        });
+
+        test('merge mode (OR IGNORE) on edges: conflicting edge-id preserves live edge data', () => {
+            const {db, dbFile} = (function () { const r = buildSyntheticGraphDb.bind(null)(); return r; })();
+            try {
+                db.prepare("INSERT INTO Nodes (id, data) VALUES ('n1', 'live')").run();
+                db.prepare("INSERT INTO Nodes (id, data) VALUES ('n2', 'live')").run();
+                db.prepare("INSERT INTO Edges (id, source, target, type, data) VALUES ('e1', 'n1', 'n2', 'LIVE_TYPE', 'LIVE-EDGE-DATA')").run();
+
+                const insertEdgeMerge = db.prepare(`INSERT OR IGNORE INTO Edges (id, user_id, source, target, type, data) VALUES (?, ?, ?, ?, ?, ?)`);
+                const result = insertEdgeMerge.run('e1', null, 'n1', 'n2', 'BACKUP_TYPE', 'BACKUP-EDGE-DATA-WOULD-OVERWRITE');
+
+                expect(result.changes).toBe(0);
+
+                const live = db.prepare("SELECT type, data FROM Edges WHERE id = 'e1'").get();
+                expect(live.type).toBe('LIVE_TYPE');
+                expect(live.data).toBe('LIVE-EDGE-DATA');
+            } finally {
+                db.close();
+                fs.unlinkSync(dbFile);
+            }
+        });
+
+        test('merge mode: backup-only IDs INSERT cleanly (changes=1)', () => {
+            const {db, dbFile} = (function () { const r = buildSyntheticGraphDb.bind(null)(); return r; })();
+            try {
+                db.prepare("INSERT INTO Nodes (id, data) VALUES ('live-only', 'live')").run();
+
+                const insertNodeMerge = db.prepare("INSERT OR IGNORE INTO Nodes (id, user_id, data) VALUES (?, ?, ?)");
+                const result = insertNodeMerge.run('backup-only', null, 'BACKUP');
+
+                expect(result.changes).toBe(1);
+
+                const both = db.prepare("SELECT id, data FROM Nodes ORDER BY id").all();
+                expect(both).toEqual([
+                    {id: 'backup-only', data: 'BACKUP'},
+                    {id: 'live-only',   data: 'live'}
+                ]);
+            } finally {
+                db.close();
+                fs.unlinkSync(dbFile);
+            }
+        });
     });
 });

--- a/test/playwright/unit/ai/buildScripts/restore-filters.spec.mjs
+++ b/test/playwright/unit/ai/buildScripts/restore-filters.spec.mjs
@@ -291,7 +291,7 @@ test.describe('restore.mjs filters + hooks (#11141)', () => {
             Database  = mod.default;
         });
 
-        async function buildSyntheticGraphDb() {
+        function buildSyntheticGraphDb() {
             const dbFile = path.join(workRoot, `graph-merge-${Date.now()}-${Math.random().toString(36).slice(2)}.sqlite`);
             const db     = new Database(dbFile);
             db.pragma('foreign_keys = ON');
@@ -314,7 +314,7 @@ test.describe('restore.mjs filters + hooks (#11141)', () => {
         }
 
         test('merge mode (OR IGNORE): conflicting node-id keeps live row, no cascade-delete on its edges', () => {
-            const {db, dbFile} = (function () { const r = buildSyntheticGraphDb.bind(null)(); return r; })();
+            const {db, dbFile} = buildSyntheticGraphDb();
             try {
                 // Live state: one node + one edge.
                 db.prepare("INSERT INTO Nodes (id, data) VALUES ('n1', 'LIVE-VERSION')").run();
@@ -345,7 +345,7 @@ test.describe('restore.mjs filters + hooks (#11141)', () => {
         });
 
         test('replace mode (OR REPLACE): conflicting node-id overwrites + cascade-deletes its edges (DOCUMENTED behavior)', () => {
-            const {db, dbFile} = (function () { const r = buildSyntheticGraphDb.bind(null)(); return r; })();
+            const {db, dbFile} = buildSyntheticGraphDb();
             try {
                 // Live state: one node + one edge.
                 db.prepare("INSERT INTO Nodes (id, data) VALUES ('n1', 'LIVE-VERSION')").run();
@@ -375,7 +375,7 @@ test.describe('restore.mjs filters + hooks (#11141)', () => {
         });
 
         test('merge mode (OR IGNORE) on edges: conflicting edge-id preserves live edge data', () => {
-            const {db, dbFile} = (function () { const r = buildSyntheticGraphDb.bind(null)(); return r; })();
+            const {db, dbFile} = buildSyntheticGraphDb();
             try {
                 db.prepare("INSERT INTO Nodes (id, data) VALUES ('n1', 'live')").run();
                 db.prepare("INSERT INTO Nodes (id, data) VALUES ('n2', 'live')").run();
@@ -396,7 +396,7 @@ test.describe('restore.mjs filters + hooks (#11141)', () => {
         });
 
         test('merge mode: backup-only IDs INSERT cleanly (changes=1)', () => {
-            const {db, dbFile} = (function () { const r = buildSyntheticGraphDb.bind(null)(); return r; })();
+            const {db, dbFile} = buildSyntheticGraphDb();
             try {
                 db.prepare("INSERT INTO Nodes (id, data) VALUES ('live-only', 'live')").run();
 

--- a/test/playwright/unit/ai/buildScripts/restore-filters.spec.mjs
+++ b/test/playwright/unit/ai/buildScripts/restore-filters.spec.mjs
@@ -39,13 +39,17 @@ import path            from 'path';
  *    guard. Tests use synthetic JSONL fixtures (no live SQLite needed).
  * 3. `dispatchPostRestoreHook` — narrow allowlist; explicit reject for
  *    `dream-service`; unknown hook throws.
+ * 4. **Graph merge `INSERT OR IGNORE` row-level semantics** — synthetic SQLite
+ *    + production schema + `ON DELETE CASCADE` FK on Edges. Asserts the SQL
+ *    primitive directly: merge mode preserves live rows + edges; replace mode
+ *    overwrites + cascade-deletes (the documented asymmetry). See the inner
+ *    `test.describe('graph merge: INSERT OR IGNORE preserves live rows + edges')`.
  *
  * NOT in this spec (deferred):
- *   - Full `runRestore` flow with filters (covered in restore.spec.mjs once
- *     #11142 lands and test isolation is hardened).
- *   - `INSERT OR IGNORE` row-level semantics (requires real SQLite; gated on
- *     #11142 wipe-path fix to run safely).
- *   - Chroma-side parity (#11144 follow-up).
+ *   - Full `runRestore` end-to-end flow against live MC services (covered in
+ *     restore.spec.mjs orchestrator-shape tests; live-substrate runs require
+ *     test isolation now that #11140/#11142 wipe-path fix is merged).
+ *   - Chroma-side `#importMemories` preserve-live parity (#11144 follow-up).
  */
 test.describe.configure({mode: 'serial'});
 

--- a/test/playwright/unit/ai/buildScripts/restore-filters.spec.mjs
+++ b/test/playwright/unit/ai/buildScripts/restore-filters.spec.mjs
@@ -1,0 +1,263 @@
+import {setup} from '../../../setup.mjs';
+
+const appName = 'RestoreFiltersTest';
+
+setup({
+    neoConfig: {
+        allowVdomUpdatesInTests: false,
+        unitTestMode           : true,
+        useDomApiRenderer      : false
+    },
+    appConfig: {
+        name             : appName,
+        isMounted        : () => true,
+        vnodeInitialising: false
+    }
+});
+
+import {test, expect}   from '@playwright/test';
+import fs               from 'fs';
+import fsExtra          from 'fs-extra';
+import os               from 'os';
+import path             from 'path';
+
+/**
+ * #11141 — focused unit tests for the new restore.mjs surfaces:
+ *
+ * 1. `parseArgs` — new CLI flags (--filter-labels, --filter-edge-types,
+ *    --only-substrate, --post-restore-hook) in both `=`-suffix and
+ *    space-separated forms; CSV parsing; unknown-flag rejection retained.
+ * 2. `prepareFilteredGraphDir` — three-stage FK-safe filter:
+ *    cross-bundle node classification, live-snapshot union check, orphan-edge
+ *    guard. Tests use synthetic JSONL fixtures (no live SQLite needed).
+ * 3. `dispatchPostRestoreHook` — narrow allowlist; explicit reject for
+ *    `dream-service`; unknown hook throws.
+ *
+ * NOT in this spec (deferred):
+ *   - Full `runRestore` flow with filters (covered in restore.spec.mjs once
+ *     #11142 lands and test isolation is hardened).
+ *   - `INSERT OR IGNORE` row-level semantics (requires real SQLite; gated on
+ *     #11142 wipe-path fix to run safely).
+ *   - Chroma-side parity (#11144 follow-up).
+ */
+test.describe.configure({mode: 'serial'});
+
+test.describe('restore.mjs filters + hooks (#11141)', () => {
+    let parseArgs, prepareFilteredGraphDir, dispatchPostRestoreHook;
+    let workRoot;
+
+    const silentLogger = {log: () => {}, warn: () => {}, error: () => {}};
+
+    test.beforeAll(async () => {
+        const mod = await import('../../../../../buildScripts/ai/restore.mjs');
+        parseArgs               = mod.parseArgs;
+        prepareFilteredGraphDir = mod.prepareFilteredGraphDir;
+        dispatchPostRestoreHook = mod.dispatchPostRestoreHook;
+
+        workRoot = await fsExtra.mkdtemp(path.join(os.tmpdir(), 'restore-filters-spec-'));
+    });
+
+    test.afterAll(async () => {
+        if (workRoot) await fsExtra.remove(workRoot);
+    });
+
+    // ─────────────────────────────────────────────────────────────────────
+    // parseArgs — new flag coverage
+    // ─────────────────────────────────────────────────────────────────────
+
+    test('parseArgs: --filter-labels accepts space-separated CSV', () => {
+        const args = parseArgs(['/tmp/bundle', '--filter-labels', 'FILE,DIRECTORY,KB_GAP']);
+        expect(args.filterLabels).toEqual(['FILE', 'DIRECTORY', 'KB_GAP']);
+    });
+
+    test('parseArgs: --filter-labels=<csv> equals-suffix form', () => {
+        const args = parseArgs(['/tmp/bundle', '--filter-labels=FILE,DIRECTORY']);
+        expect(args.filterLabels).toEqual(['FILE', 'DIRECTORY']);
+    });
+
+    test('parseArgs: --filter-edge-types accepts CSV both forms', () => {
+        const a = parseArgs(['/tmp/bundle', '--filter-edge-types', 'CONTAINS,DISCOVERED_IN']);
+        const b = parseArgs(['/tmp/bundle', '--filter-edge-types=CONTAINS,DISCOVERED_IN']);
+        expect(a.filterEdgeTypes).toEqual(['CONTAINS', 'DISCOVERED_IN']);
+        expect(b.filterEdgeTypes).toEqual(['CONTAINS', 'DISCOVERED_IN']);
+    });
+
+    test('parseArgs: --only-substrate restricts to listed', () => {
+        const args = parseArgs(['/tmp/bundle', '--only-substrate=graph,mc']);
+        expect(args.onlySubstrate).toEqual(['graph', 'mc']);
+    });
+
+    test('parseArgs: --post-restore-hook accepts allowlist name', () => {
+        const args = parseArgs(['/tmp/bundle', '--post-restore-hook=filesystem-ingestor']);
+        expect(args.postRestoreHook).toBe('filesystem-ingestor');
+    });
+
+    test('parseArgs: defaults preserved when new flags absent', () => {
+        const args = parseArgs(['/tmp/bundle']);
+        expect(args.filterLabels).toEqual([]);
+        expect(args.filterEdgeTypes).toEqual([]);
+        expect(args.onlySubstrate).toBeNull();
+        expect(args.postRestoreHook).toBeNull();
+        expect(args.mode).toBe('merge');
+    });
+
+    test('parseArgs: unknown-flag rejection still fires', () => {
+        expect(() => parseArgs(['/tmp/bundle', '--bogus-flag'])).toThrow(/Unknown flag/);
+    });
+
+    test('parseArgs: empty CSV yields empty array (filter inactive)', () => {
+        const args = parseArgs(['/tmp/bundle', '--filter-labels=']);
+        expect(args.filterLabels).toEqual([]);
+    });
+
+    // ─────────────────────────────────────────────────────────────────────
+    // prepareFilteredGraphDir — three-stage FK-safe filter
+    // ─────────────────────────────────────────────────────────────────────
+
+    /**
+     * Builds a synthetic graph JSONL file with the given nodes/edges.
+     * Returns the directory path containing the file.
+     */
+    async function buildSyntheticGraphBundle(testName, nodes, edges) {
+        const dir  = path.join(workRoot, testName);
+        await fsExtra.ensureDir(dir);
+        const file = path.join(dir, 'graph-backup-test.jsonl');
+        const lines = [
+            ...nodes.map(n => JSON.stringify({type: 'node', data: n})),
+            ...edges.map(e => JSON.stringify({type: 'edge', data: e}))
+        ];
+        await fsExtra.writeFile(file, lines.join('\n') + '\n');
+        return dir;
+    }
+
+    async function readJsonlRecords(dir) {
+        const files = (await fsExtra.readdir(dir)).filter(f => f.endsWith('.jsonl'));
+        const records = [];
+        for (const f of files) {
+            const content = await fsExtra.readFile(path.join(dir, f), 'utf8');
+            for (const line of content.split('\n')) {
+                if (line.trim()) records.push(JSON.parse(line));
+            }
+        }
+        return records;
+    }
+
+    test('filter: drops nodes with matching labels', async () => {
+        const sourceDir = await buildSyntheticGraphBundle('label-filter', [
+            {id: 'n1', label: 'CONCEPT', properties: {}},
+            {id: 'n2', label: 'FILE',    properties: {}},
+            {id: 'n3', label: 'CLASS',   properties: {}},
+            {id: 'n4', label: 'KB_GAP',  properties: {}}
+        ], []);
+        const stats = {filteredNodes: 0, filteredEdges: 0, orphanEdges: 0, acceptedNodes: 0};
+
+        const tempDir = await prepareFilteredGraphDir({
+            sourceDir,
+            filterLabels   : ['FILE', 'KB_GAP'],
+            filterEdgeTypes: [],
+            liveNodeIds    : new Set(),
+            stats,
+            logger         : silentLogger
+        });
+
+        expect(stats.filteredNodes).toBe(2);
+        expect(stats.acceptedNodes).toBe(2);
+
+        const records = await readJsonlRecords(tempDir);
+        const ids     = records.filter(r => r.type === 'node').map(r => r.data.id);
+        expect(ids.sort()).toEqual(['n1', 'n3']);
+    });
+
+    test('filter: drops edges with matching types', async () => {
+        const sourceDir = await buildSyntheticGraphBundle('type-filter', [
+            {id: 'a', label: 'CONCEPT', properties: {}},
+            {id: 'b', label: 'CONCEPT', properties: {}}
+        ], [
+            {id: 'e1', source: 'a', target: 'b', type: 'TAGGED_CONCEPT', properties: {}},
+            {id: 'e2', source: 'a', target: 'b', type: 'CONTAINS',       properties: {}},
+            {id: 'e3', source: 'a', target: 'b', type: 'DISCOVERED_IN',  properties: {}}
+        ]);
+        const stats = {filteredNodes: 0, filteredEdges: 0, orphanEdges: 0, acceptedNodes: 0};
+
+        const tempDir = await prepareFilteredGraphDir({
+            sourceDir,
+            filterLabels   : [],
+            filterEdgeTypes: ['CONTAINS', 'DISCOVERED_IN'],
+            liveNodeIds    : new Set(),
+            stats,
+            logger         : silentLogger
+        });
+
+        expect(stats.filteredEdges).toBe(2);
+        const records = await readJsonlRecords(tempDir);
+        const types   = records.filter(r => r.type === 'edge').map(r => r.data.type);
+        expect(types).toEqual(['TAGGED_CONCEPT']);
+    });
+
+    test('filter: orphan-edge guard drops edges whose endpoint was filtered out', async () => {
+        const sourceDir = await buildSyntheticGraphBundle('orphan-edge', [
+            {id: 'concept1', label: 'CONCEPT', properties: {}},
+            {id: 'file1',    label: 'FILE',    properties: {}}  // will be filtered
+        ], [
+            {id: 'edge-to-file', source: 'concept1', target: 'file1', type: 'ORIGINATES_IN', properties: {}}
+        ]);
+        const stats = {filteredNodes: 0, filteredEdges: 0, orphanEdges: 0, acceptedNodes: 0};
+
+        const tempDir = await prepareFilteredGraphDir({
+            sourceDir,
+            filterLabels   : ['FILE'],
+            filterEdgeTypes: [],
+            liveNodeIds    : new Set(),
+            stats,
+            logger         : silentLogger
+        });
+
+        expect(stats.filteredNodes).toBe(1);
+        expect(stats.orphanEdges).toBe(1);
+        const records = await readJsonlRecords(tempDir);
+        // concept1 stays; file1 + ORIGINATES_IN edge dropped
+        expect(records.length).toBe(1);
+        expect(records[0].data.id).toBe('concept1');
+    });
+
+    test('filter: edges to live-only endpoints are preserved (FK-safe via union)', async () => {
+        const sourceDir = await buildSyntheticGraphBundle('live-union', [
+            {id: 'backup-concept', label: 'CONCEPT', properties: {}}
+        ], [
+            // edge to live-existing node — must be preserved
+            {id: 'e-live', source: 'backup-concept', target: 'live-existing-id', type: 'TAGGED_CONCEPT', properties: {}},
+            // edge to nonexistent node — must be dropped
+            {id: 'e-orphan', source: 'backup-concept', target: 'never-existed', type: 'TAGGED_CONCEPT', properties: {}}
+        ]);
+        const stats = {filteredNodes: 0, filteredEdges: 0, orphanEdges: 0, acceptedNodes: 0};
+
+        const tempDir = await prepareFilteredGraphDir({
+            sourceDir,
+            filterLabels   : [],
+            filterEdgeTypes: [],
+            liveNodeIds    : new Set(['live-existing-id']),  // simulates a live node ID
+            stats,
+            logger         : silentLogger
+        });
+
+        expect(stats.orphanEdges).toBe(1);
+        const records = await readJsonlRecords(tempDir);
+        const edges   = records.filter(r => r.type === 'edge');
+        expect(edges.length).toBe(1);
+        expect(edges[0].data.id).toBe('e-live');
+    });
+
+    // ─────────────────────────────────────────────────────────────────────
+    // dispatchPostRestoreHook — narrow allowlist
+    // ─────────────────────────────────────────────────────────────────────
+
+    test('hook: dream-service explicit-reject', async () => {
+        await expect(dispatchPostRestoreHook({hook: 'dream-service', logger: silentLogger}))
+            .rejects.toThrow(/intentionally not supported/);
+    });
+
+    test('hook: unknown name rejected with allowlist hint', async () => {
+        await expect(dispatchPostRestoreHook({hook: 'mystery-hook', logger: silentLogger}))
+            .rejects.toThrow(/Unknown post-restore hook.*Allowlist: filesystem-ingestor/);
+    });
+});

--- a/test/playwright/unit/ai/buildScripts/restore.spec.mjs
+++ b/test/playwright/unit/ai/buildScripts/restore.spec.mjs
@@ -375,23 +375,37 @@ test.describe('restore.mjs orchestrator — bundle-aware substrate restore (#108
     });
 
     test('parseArgs: positional bundle path + --mode + --force + --force-topology-mismatch', () => {
+        // #11141: parseArgs return shape extended with filterLabels/filterEdgeTypes/onlySubstrate/postRestoreHook.
+        // Defaults preserved when those flags are absent (covered separately in restore-filters.spec.mjs).
         expect(parseArgs(['/some/bundle'])).toEqual({
             bundleRoot           : '/some/bundle',
             mode                 : 'merge',
             force                : false,
-            forceTopologyMismatch: false
+            forceTopologyMismatch: false,
+            filterLabels         : [],
+            filterEdgeTypes      : [],
+            onlySubstrate        : null,
+            postRestoreHook      : null
         });
         expect(parseArgs(['/some/bundle', '--mode', 'replace', '--force'])).toEqual({
             bundleRoot           : '/some/bundle',
             mode                 : 'replace',
             force                : true,
-            forceTopologyMismatch: false
+            forceTopologyMismatch: false,
+            filterLabels         : [],
+            filterEdgeTypes      : [],
+            onlySubstrate        : null,
+            postRestoreHook      : null
         });
         expect(parseArgs(['/some/bundle', '--force-topology-mismatch'])).toEqual({
             bundleRoot           : '/some/bundle',
             mode                 : 'merge',
             force                : false,
-            forceTopologyMismatch: true
+            forceTopologyMismatch: true,
+            filterLabels         : [],
+            filterEdgeTypes      : [],
+            onlySubstrate        : null,
+            postRestoreHook      : null
         });
         expect(() => parseArgs([])).toThrow(/Missing required argument/);
         expect(() => parseArgs(['/x', '--unknown-flag'])).toThrow(/Unknown flag/);


### PR DESCRIPTION
Authored by Claude Opus 4.7 (1M context, Claude Code). Origin Session: c2912891-b459-4a03-b2af-154d5e264df1.

Resolves #11141

Companion follow-up: #11144 (Chroma `#importMemories` preserve-live parity).

## Summary

Sharpens `npm run ai:restore`'s **graph-side** merge mode from `INSERT OR REPLACE` to `INSERT OR IGNORE` (preserve-live), adds per-incident customization (filters, targeting, hooks), and surfaces structured per-substrate counters for operator validation. Empirical anchor: 2026-05-10 graph-wipe incident.

**Scope is graph-only.** Memory + summaries (Chroma `collection.upsert()`) preserve-live parity is captured at #11144 as a named follow-up.

## Evidence

- Graph-side preserve-live correction is the **core SQL semantic** flip; locked in by row-level regression tests in `restore-filters.spec.mjs` (synthetic SQLite + production schema + ON DELETE CASCADE FK on Edges).
- 18 unit tests total: 8 parseArgs flag-parsing, 4 filter behavior (label/type/orphan-edge/live-union FK-safe), 2 hook allowlist, 4 row-level INSERT OR IGNORE vs OR REPLACE preserve-live + cascade-delete asymmetry. Local focused run: **29/29 pass** (per @neo-gpt cycle-3 verification on head `3d053eddf`).
- Static syntax check (`node -c`) green on all 4 modified/added files.
- Existing `restore.spec.mjs:378` parseArgs deep-equal extended for the new fields.

**Residuals (gated on this PR landing):**
- Empirical validation against May 10 01:11 backup (live restore) — operator-paced, post-merge.
- Chroma parity (`#importMemories`) — captured at #11144.

## What changed

| File | Change |
|---|---|
| `ai/services/memory-core/DatabaseService.mjs` | `#importGraph`: mode-dependent INSERT clause. `merge` → `INSERT OR IGNORE` (preserve-live for graph rows); `replace` → `INSERT OR REPLACE` (existing destructive). Truthful counters via `stmt.run().changes`: returns `{imported, counts: {nodes, edges}, mode}`. `importDatabase` propagates structured `counts.graph` for operator validation. |
| `buildScripts/ai/restore.mjs` | `runRestore` accepts `filterLabels`, `filterEdgeTypes`, `onlySubstrate`, `postRestoreHook`. New helpers: `prepareFilteredGraphDir` (FK-safe three-stage filter) + `dispatchPostRestoreHook` (allowlist: `filesystem-ingestor` only; `dream-service` explicit-reject) + `collectLiveGraphNodeIds`. `parseArgs` gains the matching CLI flags. JSDoc narrowed to graph-only preserve-live (memory/summaries still Chroma-`upsert()`); helpers exported for testability. |
| `test/playwright/unit/ai/buildScripts/restore-filters.spec.mjs` | New: 18 unit tests including the row-level INSERT OR IGNORE preserve-live regression + cascade-delete asymmetry tests. Bootstrap follows `src/Neo.mjs` + `src/core/_export.mjs` pattern. |
| `test/playwright/unit/ai/buildScripts/restore.spec.mjs` | Existing parseArgs deep-equal extended with default values for new fields. |

**Cumulative (as of `3d053eddf`):** 8 commits, **+804 / -57** across 4 files.

## V-B-A on the gap

Pre-#11141 `Memory_DatabaseService.#importGraph` line 252 used `INSERT OR REPLACE` in BOTH modes — `mode` parameter only controlled the truncate step. SQLite implements `INSERT OR REPLACE` as **DELETE-then-INSERT**, which fires `ON DELETE CASCADE` on `Edges.source/target → Nodes(id)` when a backup node ID collides with a live node — destroying live edges in addition to overwriting rows. Per @neo-gpt's review (commentId 4416007918), the preserve-live correction is also **edge-retention protection**.

Today's empirical anchor: dry-run analysis on May 10 01:11 backup vs live graph found 3,580 already-present rows (post-wipe re-ingestion via gh-workflow + retrospective daemon). Pre-#11141 merge would have OVERWRITTEN those + cascade-deleted their edges.

## Test plan

- [x] Static syntax check passes on all 4 files.
- [x] `git diff --check origin/dev...HEAD` clean (clean cherry-pick lineage post-RA 1).
- [x] parseArgs unit tests (8): all new flags + defaults preserved + unknown-flag rejection.
- [x] `prepareFilteredGraphDir` unit tests (4): label-filter / type-filter / orphan-edge guard / live-union FK-safe.
- [x] `dispatchPostRestoreHook` unit tests (2): `dream-service` reject + unknown-hook reject.
- [x] **Row-level INSERT OR IGNORE regression** (4): merge/replace conflict semantics on synthetic SQLite with FK cascade.
- [x] Bootstrap matches existing AI unit-test pattern (`src/Neo.mjs` + `src/core/_export.mjs`).
- [x] **Local focused run**: 29/29 pass (verified by @neo-gpt at head `3d053eddf`).
- [ ] **CI**: integration-unified pending; expect green.
- [ ] **Empirical validation (operator-paced, post-merge)**: live restore of May 10 01:11 backup via:
      ```
      npm run ai:restore -- <May 10 01:11 backup> --mode merge --only-substrate=graph \
        --filter-labels=FILE,DIRECTORY,KB_GAP,TOOLING_GAP \
        --filter-edge-types=CONTAINS,DISCOVERED_IN,EVALUATED_BY \
        --post-restore-hook=filesystem-ingestor
      ```
      Expected: 11,589 nodes/edges INSERTed; live AGENT_MEMORY 20→4156, CONCEPT 32→4248. Structured counts surface via `runRestore.subsystems.graph.counts`.

## Out of Scope (named follow-ups + explicit boundaries)

- **Chroma `#importMemories` preserve-live parity** → **#11144** (filed; PR after this one). Different API (Chroma HTTP `upsert` vs SQLite `INSERT OR ...`); deserves its own boundary. Per @neo-gpt's `/peer-role` review on #11141.
- **`dream-service` post-restore hook** → explicitly disallowed per `/peer-role` review (REM cycle does graph mutation/inference; can blur recovery validation immediately after restore). Defer to follow-up if/when needed.
- **`KB_GAP` / `TOOLING_GAP` re-classification** → drop-by-default is operator-classified-garbage-per-incident; some real gaps may be valuable. Filter set lives in operator's CLI invocation per-incident, not hardcoded.
- **More post-restore hooks** (e.g., `concept-ingestor`) → hook allowlist is extensible.

## Cross-Family Review

Re-routed to @neo-gpt per @tobiu's substrate-correct ruling on the authorship-boundary cross during cleanup race.

@neo-gpt cycle-1 (commentId 4416083541), cycle-2 (4416108391), and cycle-3 (4416123828) RAs all addressed. Final RA per cycle-3: this PR-body metadata refresh + integration-unified CI green-up.

## Commit history (post cycle-2 cleanup)

| Commit | Summary |
|---|---|
| `3eb1464a9` | feat: semantic flip + filter/targeting/hooks + helpers + JSDoc + usage |
| `a2d72faa8` | refactor: GPT cycle-0 review (FK-safe filter, truthful counters, hook allowlist) + #11144 scope split |
| `82e64707c` | test: parseArgs + filter + hook unit coverage (14 tests) |
| `f87a23ea3` | test: update existing restore.spec.mjs parseArgs deep-equal for new fields |
| `3f1bc894c` | fix: surface graph counts through importDatabase return shape |
| `65d39bdd8` | test: cycle-1 RA 2+3 — fix spec bootstrap + add row-level INSERT OR IGNORE regression (4 new tests) |
| `952d87403` | fix(test): cycle-2 RA — async-bug fix in `buildSyntheticGraphDb` |
| `3d053eddf` | docs(ai-restore): cycle-2 RA — narrow merge-mode prose to graph-only; refresh spec header |
