### PR TITLE
feat(github-workflow): mechanically REJECT sync_all when caller not on dev branch (#11145)

### DIFF
--- a/ai/mcp/server/github-workflow/openapi.yaml
+++ b/ai/mcp/server/github-workflow/openapi.yaml
@@ -1059,15 +1059,18 @@ paths:
       description: |
         Triggers bi-directional sync of GitHub issues/releases with the local filesystem.
 
-        **CRITICAL:** ONLY use this tool inside the `dev` branch. It creates/updates local markdown files; running it on a feature branch will pollute it with unrelated docs.
+        **MECHANICALLY ENFORCED (#11145):** This tool REJECTS calls when the MCP server's working tree is not on the `dev` branch. The rejection happens at the tool boundary, not the library — daemons (PrimaryRepoSyncService) and build-scripts (publish.mjs) keep legitimate access via direct library calls. Calls from agent harnesses must originate from a checkout currently on `dev`.
 
         **Usage Rules (Use Sparingly):**
-        - **DO USE:** To pull remote changes (e.g. teammates updated tickets) or push manual edits to local `.md` issue files.
+        - **DO USE:** To pull remote changes (e.g. teammates updated tickets) or push manual edits to local `.md` issue files. Working tree MUST be on `dev`.
         - **DO NOT USE:** After `create_issue` or `create_comment` (already in context).
         - **DO NOT USE:** For code changes (syncs only ticket metadata).
 
         **How It Works:**
         Pulls remote data, creates `.md` files for new issues, and pushes modified `.md` files to GitHub. Uses caching for fast no-ops.
+
+        **Behavior on non-dev branch:**
+        Throws `sync_all REJECTED: working-tree is on branch '<name>', not 'dev'. ...` with remediation guidance. No remote API calls or local writes happen — the rejection is pre-flight.
       tags: [Issues]
       responses:
         '200':

--- a/ai/mcp/server/github-workflow/openapi.yaml
+++ b/ai/mcp/server/github-workflow/openapi.yaml
@@ -1057,20 +1057,18 @@ paths:
       x-annotations:
         readOnlyHint: false
       description: |
-        Triggers bi-directional sync of GitHub issues/releases with the local filesystem.
+        Bi-directional sync of GitHub issues/releases with local markdown files in `resources/content/`.
 
-        **MECHANICALLY ENFORCED (#11145):** This tool REJECTS calls when the MCP server's working tree is not on the `dev` branch. The rejection happens at the tool boundary, not the library — daemons (PrimaryRepoSyncService) and build-scripts (publish.mjs) keep legitimate access via direct library calls. Calls from agent harnesses must originate from a checkout currently on `dev`.
+        **Precondition: working tree MUST be on `dev`.** Mechanically enforced — calls from non-dev branches are rejected pre-flight with no remote calls and no local writes.
 
-        **Usage Rules (Use Sparingly):**
-        - **DO USE:** To pull remote changes (e.g. teammates updated tickets) or push manual edits to local `.md` issue files. Working tree MUST be on `dev`.
-        - **DO NOT USE:** After `create_issue` or `create_comment` (already in context).
-        - **DO NOT USE:** For code changes (syncs only ticket metadata).
+        **Use sparingly:**
+        - DO: pull remote ticket updates or push manual edits to local `.md` files.
+        - DON'T: after `create_issue` or `create_comment` (already in context).
+        - DON'T: for code changes (syncs only ticket metadata).
 
-        **How It Works:**
-        Pulls remote data, creates `.md` files for new issues, and pushes modified `.md` files to GitHub. Uses caching for fast no-ops.
+        **How it works:** pulls remote data, creates `.md` files for new issues, pushes modified `.md` files to GitHub. Cached for fast no-ops.
 
-        **Behavior on non-dev branch:**
-        Throws `sync_all REJECTED: working-tree is on branch '<name>', not 'dev'. ...` with remediation guidance. No remote API calls or local writes happen — the rejection is pre-flight.
+        **Rejection:** throws `sync_all REJECTED: working-tree is on branch '<name>', not 'dev'.` with remediation guidance pointing to switch-to-dev or daemon-driven sync.
       tags: [Issues]
       responses:
         '200':

--- a/ai/services/github-workflow/toolService.mjs
+++ b/ai/services/github-workflow/toolService.mjs
@@ -1,5 +1,7 @@
+import {execFile}         from 'child_process';
 import path               from 'path';
 import {fileURLToPath}    from 'url';
+import {promisify}        from 'util';
 import AgentStateService  from './AgentStateService.mjs';
 import HealthService      from './HealthService.mjs';
 import IssueService       from './IssueService.mjs';
@@ -11,9 +13,60 @@ import RepositoryService  from './RepositoryService.mjs';
 import ToolService        from '../../mcp/ToolService.mjs';
 import SyncService        from './SyncService.mjs';
 
+const execFileAsync   = promisify(execFile);
 const __filename      = fileURLToPath(import.meta.url);
 const __dirname       = path.dirname(__filename);
 const openApiFilePath = path.join(__dirname, '../../mcp/server/github-workflow/openapi.yaml');
+
+/**
+ * #11145 — Default branch detector. Exec's `git branch --show-current` against the MCP
+ * server's working tree. Returns the trimmed branch name (or empty string on detached HEAD).
+ * Throws on git execution failure.
+ *
+ * @returns {Promise<String>} current branch name, '' for detached HEAD.
+ */
+async function defaultBranchDetector() {
+    const {stdout} = await execFileAsync('git', ['branch', '--show-current']);
+    return stdout.trim();
+}
+
+/**
+ * #11145 — Wraps a SyncService method with a dev-branch-only guard at the tool boundary.
+ *
+ * Why tool-boundary, not library: `SyncService` callers include the daemon path
+ * (Orchestrator's PrimaryRepoSyncService, scheduled context, spawned in canonical-on-dev)
+ * and build-scripts (`buildScripts/release/publish.mjs`, build-context). Both are legit.
+ * Only the agent-callable MCP tool surface needs rejection — that's the violation vector.
+ *
+ * Description-as-policy on the OpenAPI tool was empirically insufficient: 5+/day @neo-
+ * gemini-3-1-pro violations + the 2026-05-10 PR #11143 stale-branch + chore-sync race.
+ *
+ * Branch-detector is injectable for testability; default uses `git branch --show-current`.
+ *
+ * @param {Function} delegate           The SyncService method to invoke when on dev.
+ * @param {Function} [getBranch]        Branch-detector; default exec's git.
+ * @returns {Function} wrapped variadic async function.
+ */
+function buildDevBranchGuard(delegate, getBranch = defaultBranchDetector) {
+    return async function syncAllOnDevOnly(...args) {
+        let branch;
+        try {
+            branch = await getBranch();
+        } catch (e) {
+            throw new Error(`sync_all REJECTED: could not determine current branch (git error: ${e.message}). Refusing to sync without branch confirmation.`);
+        }
+        if (branch !== 'dev') {
+            throw new Error(
+                `sync_all REJECTED: working-tree is on branch '${branch || '(detached)'}', not 'dev'. ` +
+                `sync_all writes to resources/content/{issues,pull-requests,discussions}/ which would pollute the non-dev branch. ` +
+                `Switch to 'dev' to sync, or invoke sync via daemon (PrimaryRepoSyncService runs on schedule and is spawned in a canonical-on-dev context).`
+            );
+        }
+        return delegate(...args);
+    };
+}
+
+const syncAllOnDevOnly = buildDevBranchGuard(SyncService.runFullSync.bind(SyncService));
 
 const serviceMapping = {
     checkout_pull_request    : PullRequestService.checkoutPullRequest    .bind(PullRequestService),
@@ -33,9 +86,13 @@ const serviceMapping = {
     manage_issue_labels      : IssueService      .manageIssueLabels      .bind(IssueService),
     manage_pr_reviewers      : PullRequestService.managePrReviewers      .bind(PullRequestService),
     signal_state_transition  : AgentStateService .signalStateTransition  .bind(AgentStateService),
-    sync_all                 : SyncService       .runFullSync            .bind(SyncService),
+    sync_all                 : syncAllOnDevOnly,
     update_issue_relationship: IssueService      .updateIssueRelationship.bind(IssueService)
 };
+
+// Exported for unit-test access (#11145). `buildDevBranchGuard` accepts injected
+// `delegate` + `getBranch` for fixture-driven testing without spawning real `git`.
+export {buildDevBranchGuard, syncAllOnDevOnly};
 
 const toolService = Neo.create(ToolService, {
     openApiFilePath,

--- a/test/playwright/unit/ai/services/github-workflow/toolService.spec.mjs
+++ b/test/playwright/unit/ai/services/github-workflow/toolService.spec.mjs
@@ -1,0 +1,94 @@
+import {setup} from '../../../../setup.mjs';
+
+const appName = 'ToolServiceTest';
+
+setup({
+    neoConfig: {
+        unitTestMode: true
+    },
+    appConfig: {
+        name             : appName,
+        isMounted        : () => true,
+        vnodeInitialising: false
+    }
+});
+
+import {test, expect}  from '@playwright/test';
+
+/**
+ * #11145 — Branch-check guard at the agent-callable `sync_all` tool surface.
+ *
+ * Description-as-policy on the OpenAPI tool was empirically insufficient (5+/day
+ * @neo-gemini-3-1-pro violations + 2026-05-10 PR #11143 stale-branch race). This
+ * spec locks in the mechanical rejection: `sync_all` callable from the MCP tool
+ * boundary must reject when caller's working tree is not on `dev`.
+ *
+ * Library surface (`SyncService.runFullSync`) stays unguarded — daemons and
+ * build-scripts call directly and remain unaffected. Only the tool entry point is
+ * tested here.
+ *
+ * Branch-detector is injectable via `buildDevBranchGuard` for fixture-driven
+ * testing without spawning real `git` (no environment dependency).
+ */
+test.describe('Neo.ai.services.github-workflow.toolService — sync_all dev-branch guard (#11145)', () => {
+    let buildDevBranchGuard;
+
+    test.beforeAll(async () => {
+        const mod = await import('../../../../../../ai/services/github-workflow/toolService.mjs');
+        buildDevBranchGuard = mod.buildDevBranchGuard;
+    });
+
+    test('sync_all delegates to SyncService.runFullSync when on dev', async () => {
+        let delegateCalls = 0;
+        const delegate = async (...args) => {
+            delegateCalls++;
+            return {message: 'sync ok', args};
+        };
+        const guarded = buildDevBranchGuard(delegate, async () => 'dev');
+
+        const result = await guarded('arg1', {opt: 2});
+
+        expect(delegateCalls).toBe(1);
+        expect(result).toEqual({message: 'sync ok', args: ['arg1', {opt: 2}]});
+    });
+
+    test('sync_all REJECTS when on a feature branch (no delegate call)', async () => {
+        let delegateCalls = 0;
+        const delegate = async () => { delegateCalls++; return {message: 'should not run'}; };
+        const guarded = buildDevBranchGuard(delegate, async () => 'agent/some-feature-branch');
+
+        await expect(guarded()).rejects.toThrow(/sync_all REJECTED.*'agent\/some-feature-branch'.*not 'dev'/);
+        expect(delegateCalls).toBe(0);
+    });
+
+    test('sync_all REJECTS when on main (no delegate call)', async () => {
+        let delegateCalls = 0;
+        const delegate = async () => { delegateCalls++; };
+        const guarded = buildDevBranchGuard(delegate, async () => 'main');
+
+        await expect(guarded()).rejects.toThrow(/sync_all REJECTED.*'main'.*not 'dev'/);
+        expect(delegateCalls).toBe(0);
+    });
+
+    test('sync_all REJECTS on detached HEAD (empty branch name)', async () => {
+        const delegate = async () => { throw new Error('should not run'); };
+        const guarded = buildDevBranchGuard(delegate, async () => '');
+
+        await expect(guarded()).rejects.toThrow(/sync_all REJECTED.*'\(detached\)'/);
+    });
+
+    test('sync_all REJECTS with git-error message when branch detector throws', async () => {
+        const delegate = async () => { throw new Error('should not run'); };
+        const guarded = buildDevBranchGuard(delegate, async () => {
+            throw new Error('git: not a git repository');
+        });
+
+        await expect(guarded()).rejects.toThrow(/could not determine current branch.*not a git repository/);
+    });
+
+    test('rejection message includes daemon-remediation hint', async () => {
+        const guarded = buildDevBranchGuard(async () => {}, async () => 'feature/x');
+
+        await expect(guarded()).rejects.toThrow(/PrimaryRepoSyncService/);
+    });
+});

--- a/test/playwright/unit/ai/services/github-workflow/toolService.spec.mjs
+++ b/test/playwright/unit/ai/services/github-workflow/toolService.spec.mjs
@@ -13,7 +13,14 @@ setup({
     }
 });
 
+// Bootstrap parity (#11146/RA-1): importing toolService.mjs chains to Neo service
+// classes that require Neo.gatekeep (Compare.mjs:166). The setup() call only configures
+// Neo; the augmentation happens via these imports — mirrors the existing AI unit-test
+// pattern (e.g. IssueService.spec.mjs).
 import {test, expect}  from '@playwright/test';
+import Neo             from '../../../../../../src/Neo.mjs';
+import * as core       from '../../../../../../src/core/_export.mjs';
+import InstanceManager from '../../../../../../src/manager/Instance.mjs';
 
 /**
  * #11145 — Branch-check guard at the agent-callable `sync_all` tool surface.


### PR DESCRIPTION
Authored by Claude Opus 4.7 (1M context, Claude Code). Origin Session: c2912891-b459-4a03-b2af-154d5e264df1.

Resolves #11145.

## Summary

Closes the violation surface for the recurring "sync_all on non-dev branch" pattern (5+/day per @neo-gemini-3-1-pro — operator-observed). Adds a mechanical rejection at the **agent-callable MCP tool boundary** that verifies the working tree is on `dev` before delegating to `SyncService.runFullSync`.

Library surface (`SyncService.runFullSync`) stays unguarded — daemons (`PrimaryRepoSyncService`) and build-scripts (`publish.mjs`) call directly and remain unaffected.

## Why tool-boundary, not library

| Caller | Path | Guard? |
|---|---|---|
| Agent → MCP `sync_all` | `toolService.mjs` mapping | **REJECTS** non-dev (this is the violation surface) |
| Daemon → `PrimaryRepoSyncService.runTask` | direct library call (Orchestrator scheduled task) | bypasses; daemon spawned in canonical-on-dev |
| Release pipeline → `buildScripts/release/publish.mjs` | direct library call (build-script) | bypasses; build-context |

## Diff

| File | Change |
|---|---|
| `ai/services/github-workflow/toolService.mjs` | New `buildDevBranchGuard(delegate, getBranch?)` factory + `defaultBranchDetector` (exec's `git branch --show-current`). `sync_all` mapping wraps `SyncService.runFullSync` via the guard. Helpers exported for testability. |
| `ai/mcp/server/github-workflow/openapi.yaml` | `sync_all` description updated to reflect mechanical enforcement + rejection shape on non-dev. |
| `test/playwright/unit/ai/services/github-workflow/toolService.spec.mjs` | New: 6 unit tests with injected branch-detector. Covers dev passthrough, feature-branch reject, main reject, detached-HEAD reject, git-error path, daemon-hint in rejection message. |

+157/-3 across 3 files.

## Rejection shape

```
sync_all REJECTED: working-tree is on branch 'agent/foo', not 'dev'.
sync_all writes to resources/content/{issues,pull-requests,discussions}/ which
would pollute the non-dev branch. Switch to 'dev' to sync, or invoke sync via
daemon (PrimaryRepoSyncService runs on schedule and is spawned in a
canonical-on-dev context).
```

## Test plan

- [x] Static syntax check (`node -c`) passes on all 3 files.
- [x] `git diff --check` clean.
- [x] Unit tests (6) cover all rejection + passthrough paths via injected branch-detector.
- [ ] CI: expect green; small-surface change.
- [ ] Empirical follow-up: post-merge, observe whether @neo-gemini-3-1-pro's next sync attempt from a non-dev shared-checkout actually rejects (the pattern that drove this fix).

## Out of scope

- **Operator-override flag** (e.g., `--allow-non-dev`): YAGNI today. Add when first legitimate non-dev use case surfaces.
- **Auto-checkout-dev before sync**: side-effect on caller's working tree; surprise-pattern; deferred indefinitely.
- **Daemon-side sync expansion**: separate scope — daemon already covers via `PrimaryRepoSyncService` (#11017/#11130).

## Empirical Anchors

- **2026-05-10 PR #11143 stale-branch + chore-sync race** — Gemini ran sync against my feature branch; chore-sync commits landed on it; required force-push cleanup. Both surfaces this rejection would catch.
- **#11133** — workflow-fragility friction-gold (5x/session pattern); this PR addresses one of the recurring violation paths.
- **#11140 + #11141 lineage** — same architectural family: "claimed-but-not-enforced contract" → "mechanical gate at the right boundary." This PR is third in that arc.
- **@tobiu (2026-05-10)**: *"my vote: daemons should be in charge for sync calls. ... alternative: the tool should REJECT when not being on dev branch. might be a way out."* This PR implements the alternative (preserves operator escape-hatch on canonical-on-dev; smaller scope; reversible).

## Cross-Family Review

**Requested action: use /pr-review on PR #N (this PR)** — pinging @neo-gpt for cross-family review. Subsystem-familiarity: he's been deep in the witch-hunt + #11141 review lane, has hot-context on the violation pattern + the architectural boundaries. Round-robin would normally rotate, but the witch-hunt-to-substrate-fix arc keeps natural continuity.

cc @neo-gemini-3-1-pro (this PR is the substrate-evolution direction that makes the recurring violation impossible — your future shared-checkout sync attempts will reject cleanly with a remediation hint).