### PR TITLE
fix(ai): resolve projectRoot pathing bug in github-workflow config (#11147)

### DIFF
--- a/ai/mcp/server/github-workflow/config.template.mjs
+++ b/ai/mcp/server/github-workflow/config.template.mjs
@@ -4,8 +4,19 @@ import BaseConfig, { createConfigProxy } from '../shared/BaseConfig.mjs';
 
 const __filename  = fileURLToPath(import.meta.url);
 const __dirname   = path.dirname(__filename);
-const packageRoot = path.resolve(__dirname, '../../../../');
-const projectRoot = process.cwd() === '/' ? packageRoot : process.cwd();
+
+let projectRoot;
+
+if (process.env.NEO_WORKSPACE_ROOT) {
+    projectRoot = process.env.NEO_WORKSPACE_ROOT;
+} else {
+    const nodeModulesIndex = __dirname.indexOf(`${path.sep}node_modules${path.sep}neo.mjs`);
+    if (nodeModulesIndex !== -1) {
+        projectRoot = __dirname.slice(0, nodeModulesIndex) || path.sep;
+    } else {
+        projectRoot = path.resolve(__dirname, '../../../../');
+    }
+}
 
 /**
  * Default configuration object.

--- a/ai/services/github-workflow/toolService.mjs
+++ b/ai/services/github-workflow/toolService.mjs
@@ -12,6 +12,7 @@ import PullRequestService from './PullRequestService.mjs';
 import RepositoryService  from './RepositoryService.mjs';
 import ToolService        from '../../mcp/ToolService.mjs';
 import SyncService        from './SyncService.mjs';
+import config             from '../../mcp/server/github-workflow/config.mjs';
 
 const execFileAsync   = promisify(execFile);
 const __filename      = fileURLToPath(import.meta.url);
@@ -20,13 +21,13 @@ const openApiFilePath = path.join(__dirname, '../../mcp/server/github-workflow/o
 
 /**
  * #11145 — Default branch detector. Exec's `git branch --show-current` against the MCP
- * server's working tree. Returns the trimmed branch name (or empty string on detached HEAD).
+ * server's projectRoot. Returns the trimmed branch name (or empty string on detached HEAD).
  * Throws on git execution failure.
  *
  * @returns {Promise<String>} current branch name, '' for detached HEAD.
  */
 async function defaultBranchDetector() {
-    const {stdout} = await execFileAsync('git', ['branch', '--show-current']);
+    const {stdout} = await execFileAsync('git', ['branch', '--show-current'], {cwd: config.projectRoot});
     return stdout.trim();
 }
 


### PR DESCRIPTION
Resolves #11147

Authored by neo-gemini-3-1-pro (Antigravity). Session d5ed6767-0292-46bf-9346-439f268048ec.

Refactored the `projectRoot` path derivation in `github-workflow`'s `config.mjs` (and its template) to reliably resolve the workspace root across both the canonical `neomjs/neo` repository and downstream `npx neo-app` consumers. The heuristic now evaluates:
1. `process.env.NEO_WORKSPACE_ROOT` for manual override.
2. `__dirname` inspection for `node_modules/neo.mjs/` to detect consumer roots.
3. A 4-level absolute directory traversal `path.resolve(__dirname, '../../../../')` as the canonical repo fallback.
Additionally, updated `ai/services/github-workflow/toolService.mjs` so `defaultBranchDetector` executes git commands specifically scoped with `cwd: config.projectRoot`, preventing context leakage from external harness execution paths.

Evidence: L2 (runtime smoke testing via CLI/node inputs) → L2 required (AC covers local filesystem calls succeeding regardless of host cwd). No residuals.

## Test Evidence
- `node --input-type=module` config-template import smoke resolved `projectRoot` and `issueSync.issuesDir` correctly.
- `process.chdir('/')` + `LocalFileService.getIssueById('11147')` succeeded against the repo.
- `npm run test-unit -- test/playwright/unit/ai/mcp/server/github-workflow/ConfigCompleteness.spec.mjs test/playwright/unit/ai/services/github-workflow/toolService.spec.mjs` passed 7/7.

## Config Template Changes & Local Sync
**Changed Keys:** Updated `projectRoot` and derived paths in `config.template.mjs` to use the dynamic heuristic.
**Local Sync Required:** Yes. After merging, all clone environments must pull `dev`, verify their gitignored `ai/mcp/server/github-workflow/config.mjs` incorporates the new dynamic fallback (or explicitly uses `NEO_WORKSPACE_ROOT`), and **restart their MCP harnesses** to apply the fix.
**Peer Notification:** Sent via A2A ping.

## Post-Merge Validation
- [ ] Verify `npm prepare` passes without structural warnings for `config.mjs` across environments.
- [ ] Ensure harness restarts succeed.
