### PR TITLE
fix(ai-restore): harden production-scale restore path after May 10 recovery (#11150)

### DIFF
--- a/ai/services/memory-core/DatabaseService.mjs
+++ b/ai/services/memory-core/DatabaseService.mjs
@@ -500,12 +500,26 @@ class DatabaseService extends Base {
                     records.forEach(r => delete r.embedding);
                 }
 
-                await collection.upsert({
-                    ids       : records.map(r => r.id),
-                    embeddings: records.map(r => r.embedding),
-                    metadatas : records.map(r => r.metadata),
-                    documents : records.map(r => r.document)
-                });
+                // Chroma has TWO upsert limits: (1) record-count cap ~5461; (2) HTTP
+                // body size cap that 413-rejects large payloads. With 4096-dim qwen3
+                // embeddings (~32KB each) + document text, per-record is ~35-40KB.
+                // Chunk size 250 = ~10MB body, well within HTTP limits + record cap.
+                // Empirical anchors 2026-05-10:
+                //   - 9244 records: "Record set length 9244 exceeds max batch size 5461"
+                //   - 4000 records: "413: Payload Too Large"
+                const CHROMA_UPSERT_CHUNK_SIZE = 250;
+                for (let i = 0; i < records.length; i += CHROMA_UPSERT_CHUNK_SIZE) {
+                    const chunk = records.slice(i, i + CHROMA_UPSERT_CHUNK_SIZE);
+                    await collection.upsert({
+                        ids       : chunk.map(r => r.id),
+                        embeddings: chunk.map(r => r.embedding),
+                        metadatas : chunk.map(r => r.metadata),
+                        documents : chunk.map(r => r.document)
+                    });
+                    if (records.length > CHROMA_UPSERT_CHUNK_SIZE) {
+                        logger.log(`  upserted chunk ${Math.floor(i / CHROMA_UPSERT_CHUNK_SIZE) + 1}/${Math.ceil(records.length / CHROMA_UPSERT_CHUNK_SIZE)} (${chunk.length} records)`);
+                    }
+                }
 
                 totalImported           += records.length;
                 subsystemCounts.memoriesInserted += records.length;

--- a/buildScripts/ai/restore.mjs
+++ b/buildScripts/ai/restore.mjs
@@ -2,6 +2,13 @@ import fs               from 'fs-extra';
 import path             from 'path';
 import {fileURLToPath}  from 'url';
 
+// Bootstrap Neo namespace BEFORE importing services that depend on Neo.gatekeep
+// (Compare.mjs:166). Without these two imports, ai/services.mjs → Compare.mjs
+// triggers `ReferenceError: Neo is not defined`. Mirrors the AI unit-test pattern
+// (e.g., restore-filters.spec.mjs).
+import Neo              from '../../src/Neo.mjs';
+import * as core        from '../../src/core/_export.mjs';
+
 import kbConfig         from '../../ai/mcp/server/knowledge-base/config.mjs';
 import mcConfig         from '../../ai/mcp/server/memory-core/config.mjs';
 
@@ -334,6 +341,10 @@ export async function validateBundle(bundleRoot, layout, logger = console) {
         }
     }
 
+    // Stream-read the first non-empty line for JSONL parseability sanity-check.
+    // Full-file readFile fails on JSONL files >512MB (V8 max-string-length cap):
+    // empirical anchor 2026-05-10, kb backup 586MB → ERR_STRING_TOO_LONG.
+    const readline = (await import('readline')).default;
     const allSubdirs = [...REQUIRED_BUNDLE_SUBDIRS, ...OPTIONAL_BUNDLE_SUBDIRS];
     for (const subdir of allSubdirs) {
         const dir = layout[subdir];
@@ -341,8 +352,14 @@ export async function validateBundle(bundleRoot, layout, logger = console) {
         const entries    = await fs.readdir(dir);
         const jsonlFiles = entries.filter(f => f.endsWith('.jsonl'));
         for (const file of jsonlFiles) {
-            const content = await fs.readFile(path.join(dir, file), 'utf8');
-            const firstLine = content.split('\n').find(line => line.trim());
+            const stream = fs.createReadStream(path.join(dir, file), {encoding: 'utf8'});
+            const rl     = readline.createInterface({input: stream, crlfDelay: Infinity});
+            let firstLine = null;
+            for await (const line of rl) {
+                if (line.trim()) { firstLine = line; break; }
+            }
+            rl.close();
+            stream.destroy();
             if (firstLine) {
                 try {
                     JSON.parse(firstLine);

--- a/test/playwright/unit/ai/buildScripts/restore-hardening.spec.mjs
+++ b/test/playwright/unit/ai/buildScripts/restore-hardening.spec.mjs
@@ -1,0 +1,186 @@
+import {setup} from '../../../setup.mjs';
+
+const appName = 'RestoreHardeningTest';
+
+setup({
+    neoConfig: {
+        allowVdomUpdatesInTests: false,
+        unitTestMode           : true,
+        useDomApiRenderer      : false
+    },
+    appConfig: {
+        name             : appName,
+        isMounted        : () => true,
+        vnodeInitialising: false
+    }
+});
+
+import {test, expect}   from '@playwright/test';
+import Neo              from '../../../../../src/Neo.mjs';
+import * as core        from '../../../../../src/core/_export.mjs';
+import InstanceManager  from '../../../../../src/manager/Instance.mjs';
+import {execFile}       from 'child_process';
+import fs               from 'fs';
+import fsExtra          from 'fs-extra';
+import os               from 'os';
+import path             from 'path';
+import {fileURLToPath}  from 'url';
+import {promisify}      from 'util';
+
+const execFileAsync = promisify(execFile);
+const __filename    = fileURLToPath(import.meta.url);
+const __dirname     = path.dirname(__filename);
+
+/**
+ * #11150 — Production-scale restore hardening regression tests.
+ *
+ * The 2026-05-10 graph + Chroma recovery surfaced 3 bugs that hid until real-world
+ * backup data exercised them. Each test below pins the empirical anchor that drove
+ * the corresponding fix in #11151.
+ *
+ * 1. **Bootstrap regression** (`restore.mjs` Neo namespace): fresh-process spawn
+ *    must not throw `ReferenceError: Neo is not defined` from `Compare.mjs:166`.
+ * 2. **Streaming validateBundle**: first-line JSONL parseability sanity check must
+ *    NOT call `fs.readFile` on the full file (V8 max-string-length cap on >512MB
+ *    files). Asserts the streaming path doesn't depend on full-file read.
+ * 3. **Chunked Chroma upsert in `#importMemories`**: large record sets must call
+ *    `collection.upsert()` in chunks of <=250 rather than one bulk call. Asserts
+ *    via mocked Chroma collection that exercises the SDK boundary.
+ */
+test.describe.configure({mode: 'serial'});
+
+test.describe('restore hardening regression (#11150 / #11151)', () => {
+
+    // ─────────────────────────────────────────────────────────────────────
+    // Test 1: Neo bootstrap — fresh-process spawn must not throw
+    // ─────────────────────────────────────────────────────────────────────
+
+    test('restore.mjs bootstrap: fresh node process completes Neo namespace setup before service imports', async () => {
+        const repoRoot = path.resolve(__dirname, '../../../../../');
+        // Probe-run with an obviously-missing bundle path. validateBundle will fail FAST
+        // with "Bundle directory not found" — but ONLY if the Neo bootstrap chain has
+        // completed. If `Neo.gatekeep` ReferenceError fires (the bug this guards), the
+        // process exits with stderr containing "Neo is not defined" BEFORE reaching
+        // validateBundle. Asserting the err.message includes the expected validateBundle
+        // error proves the bootstrap chain succeeded.
+        let stderr = '';
+        try {
+            await execFileAsync('node', ['./buildScripts/ai/restore.mjs', '/nonexistent-bundle-probe-' + Date.now()], {cwd: repoRoot});
+            throw new Error('expected restore.mjs to fail on missing bundle');
+        } catch (err) {
+            stderr = err.stderr || err.stdout || err.message || '';
+        }
+        // The fix path: validateBundle runs and reports missing-bundle error.
+        expect(stderr).toMatch(/Bundle directory not found|missing/i);
+        // The bug surface: any "Neo is not defined" trace means the bootstrap is broken.
+        expect(stderr).not.toMatch(/Neo is not defined/);
+        expect(stderr).not.toMatch(/Neo\.gatekeep is not a function/);
+    });
+
+    // ─────────────────────────────────────────────────────────────────────
+    // Test 2: validateBundle streaming first-line read
+    // ─────────────────────────────────────────────────────────────────────
+
+    test('validateBundle: first-line JSONL parseability uses streaming readline (no full-file readFile)', async () => {
+        const {validateBundle} = await import('../../../../../buildScripts/ai/restore.mjs');
+
+        const workRoot = await fsExtra.mkdtemp(path.join(os.tmpdir(), 'restore-hardening-validate-'));
+        const bundle = path.join(workRoot, 'bundle');
+        const subdirs = ['kb', 'mc', 'graph', 'concepts', 'trajectories'];
+        for (const s of subdirs) await fsExtra.ensureDir(path.join(bundle, s));
+        // Plant one JSONL file per subdir
+        await fsExtra.writeFile(path.join(bundle, 'kb', 'k.jsonl'), '{"id":"k1"}\n');
+        await fsExtra.writeFile(path.join(bundle, 'mc', 'm.jsonl'), '{"id":"m1"}\n');
+        await fsExtra.writeFile(path.join(bundle, 'graph', 'g.jsonl'), '{"type":"node","data":{"id":"g1"}}\n');
+        await fsExtra.writeFile(path.join(bundle, 'concepts', 'nodes.jsonl'), '{"id":"c1"}\n');
+        await fsExtra.writeFile(path.join(bundle, 'trajectories', 'trajectories.jsonl'), '{"x":1}\n');
+
+        // Spy on fs-extra.readFile — assert it is NOT called for the JSONL parseability
+        // sanity check (the bug path that overflows V8 string cap on >512MB files).
+        const fsExtraMod = await import('fs-extra');
+        const realReadFile = fsExtraMod.default.readFile;
+        const readFileCalls = [];
+        fsExtraMod.default.readFile = function (...args) {
+            readFileCalls.push(args[0]);
+            return realReadFile.apply(this, args);
+        };
+
+        try {
+            const layout = {
+                kb: path.join(bundle, 'kb'),
+                mc: path.join(bundle, 'mc'),
+                graph: path.join(bundle, 'graph'),
+                concepts: path.join(bundle, 'concepts'),
+                trajectories: path.join(bundle, 'trajectories'),
+                mailbox: path.join(bundle, 'mailbox')
+            };
+            await validateBundle(bundle, layout, {log: () => {}, warn: () => {}});
+
+            // The bug shape: full-file readFile of any *.jsonl file. The fix uses streaming
+            // readline. So no JSONL files should appear in readFile call list.
+            const jsonlReadFileCalls = readFileCalls.filter(f => String(f).endsWith('.jsonl'));
+            expect(jsonlReadFileCalls).toEqual([]);
+        } finally {
+            fsExtraMod.default.readFile = realReadFile;
+            await fsExtra.remove(workRoot);
+        }
+    });
+
+    // ─────────────────────────────────────────────────────────────────────
+    // Test 3: Chunked Chroma upsert in #importMemories
+    // ─────────────────────────────────────────────────────────────────────
+
+    test('#importMemories chunks Chroma collection.upsert() for large record sets', async () => {
+        // Black-box the chunking via the public manageDatabaseBackup({action:'import'})
+        // surface. Mock the Memory_StorageRouter.getMemoryCollection to return a fake
+        // collection with an upsert spy; record per-call record-count, assert chunked.
+        const SDK = await import('../../../../../ai/services.mjs');
+        const Memory_DatabaseService = SDK.Memory_DatabaseService;
+        const Memory_StorageRouter   = SDK.Memory_StorageRouter;
+
+        const upsertCalls = [];
+        const mockCollection = {
+            name: 'neo-agent-memory',
+            upsert: async ({ids}) => { upsertCalls.push(ids.length); }
+        };
+        const originalGetMemColl = Memory_StorageRouter.getMemoryCollection;
+        const originalGetSumColl = Memory_StorageRouter.getSummaryCollection;
+        Memory_StorageRouter.getMemoryCollection = async () => mockCollection;
+        Memory_StorageRouter.getSummaryCollection = async () => mockCollection;
+
+        // Build synthetic JSONL bundle dir with 1000 records (> CHROMA_UPSERT_CHUNK_SIZE
+        // of 250 → expect ⌈1000/250⌉ = 4 calls).
+        const workRoot = await fsExtra.mkdtemp(path.join(os.tmpdir(), 'restore-hardening-chunk-'));
+        const mcDir   = path.join(workRoot, 'mc-import');
+        await fsExtra.ensureDir(mcDir);
+        const lines = [];
+        for (let i = 0; i < 1000; i++) {
+            lines.push(JSON.stringify({
+                id       : `m-${i}`,
+                embedding: [0.1 + i * 0.0001],
+                metadata : {idx: i},
+                document : `doc-${i}`
+            }));
+        }
+        await fsExtra.writeFile(path.join(mcDir, 'memory-backup-test.jsonl'), lines.join('\n') + '\n');
+
+        try {
+            await Memory_DatabaseService.manageDatabaseBackup({
+                action: 'import',
+                file  : mcDir,
+                mode  : 'merge'
+            });
+
+            // Assert chunking: each call <= 250, total records 1000, exactly 4 calls.
+            expect(upsertCalls.length).toBe(4);
+            expect(upsertCalls.reduce((a, b) => a + b, 0)).toBe(1000);
+            for (const callSize of upsertCalls) {
+                expect(callSize).toBeLessThanOrEqual(250);
+            }
+        } finally {
+            Memory_StorageRouter.getMemoryCollection = originalGetMemColl;
+            Memory_StorageRouter.getSummaryCollection = originalGetSumColl;
+            await fsExtra.remove(workRoot);
+        }
+    });
+});


### PR DESCRIPTION
Authored by Claude Opus 4.7 (1M context, Claude Code). Origin Session: c2912891-b459-4a03-b2af-154d5e264df1.
Co-authored conceptually with @neo-gpt — he flagged the 3 gaps + suggested PR shape post-restoration (DM coordination 2026-05-10).

Resolves #11150

## Summary

Three production-scale bugs in `ai:restore` that hid until real-world backup data exercised them. All three blocked the 2026-05-10 graph + Chroma recovery until patched live; this PR ships the patches as substrate evolution.

**Empirical anchor (restoration event, fixed-snapshot delta):**
- Memories: 1,068 → 10,312 (Apr 28 backup → Chroma `#importMemories`)
- Summaries: 65 → 876 (Apr 28 backup → Chroma)
- Graph nodes: 3,545 → 23,514 (May 10 01:11 backup + filter + filesystem-ingestor regen)
- Graph edges: 4,300 → 17,333

(Subsequent activity has moved live counts further — `summarize-sessions` added 83 fresh summaries, ongoing session traffic adds ~10/min — but those events are downstream of the restoration the #11150 fixes enabled.)

## What changed (+225/-8 across 3 files)

| File | Fix |
|---|---|
| `buildScripts/ai/restore.mjs` | (1) Neo bootstrap imports added before `ai/services.mjs` chain. (2) `validateBundle()` first-line JSONL parseability check switched from `fs.readFile().split()` to streaming `readline.createInterface` — O(1) memory regardless of file size. |
| `ai/services/memory-core/DatabaseService.mjs` | (3) `#importMemories` Chroma `collection.upsert()` chunked at named constant `CHROMA_UPSERT_CHUNK_SIZE = 250` (≤10MB body per call). Truthful counters preserved per #11141 contract. Per-chunk progress log when `records.length > chunk_size`. |
| `test/playwright/unit/ai/buildScripts/restore-hardening.spec.mjs` | NEW: 3 regression tests (one per fix). |

## V-B-A on each gap

### Fix 1 — Neo bootstrap

```
file:///.../src/core/Compare.mjs:166
export default Neo.gatekeep(Compare, 'Neo.core.Compare', () => {
               ^
ReferenceError: Neo is not defined
```

The unit-test pattern already documents the bootstrap (`restore-filters.spec.mjs`, `IssueService.spec.mjs` use `import Neo from '...src/Neo.mjs'`). The build-script entrypoint missed it. Added it.

### Fix 2 — Chunked Chroma upsert

```
9244 records: \"Record set length 9244 exceeds max batch size 5461\"
4000 records: \"413: Payload Too Large\"
 250 records: ✓ (10 MB body, ~37 chunks for 9244 records)
```

Calculation: 4096-dim qwen3 embedding × 8 bytes ≈ 32KB per embedding + document text → ~35-40KB per record. 250 × 40KB = 10MB body — well within both record-count cap (5461) and HTTP body size cap.

### Fix 3 — Streaming validateBundle

```
ERR_STRING_TOO_LONG: Cannot create a string longer than 0x1fffffe8 characters
```

V8 max string length is 512MB. The May 10 01:11 backup's `kb/knowledge-base-backup-*.jsonl` was **586MB** — exceeds the cap. `fs.readFile('utf8').split('\\n')` reads the full file as a string; replaced with `readline.createInterface` first-line pass.

## Test plan

- [x] **Empirical**: today's actual restoration completed with these fixes; restoration-event delta documented above.
- [x] **Static syntax check** passes on all 3 files.
- [x] `git diff --check` clean.
- [x] **Unit test — chunked Chroma upsert**: synthetic 1000-record JSONL bundle through `Memory_DatabaseService.manageDatabaseBackup({action:'import', mode:'merge'})` with mocked Chroma collection. Asserts exactly ⌈1000/250⌉ = 4 upsert calls, sum=1000, each ≤250. **3/3 pass** at @neo-gpt cycle-2 verification (review id 4259855137).
- [x] **Unit test — streaming validateBundle**: synthetic 5-subdir bundle with one tiny JSONL per subdir; spy on `fs-extra.readFile`; assert NO JSONL files in readFile call list (streaming path bypasses readFile entirely). **Pass** at @neo-gpt cycle-2 verification.
- [x] **Unit test — bootstrap regression**: spawn `node ./buildScripts/ai/restore.mjs <missing-bundle>` in fresh process; stderr asserts validateBundle's missing-bundle error AND no `Neo is not defined` / `Neo.gatekeep is not a function`. **Pass** at @neo-gpt cycle-2 verification.
- [x] **Existing `restore.spec.mjs`** continues to pass: 11/11 verified by @neo-gpt at head `7f4947e69`.
- [x] **CI**: 4/4 GREEN (Analyze + integration-unified + unit + CodeQL).

## Out of scope

- **Auto-detect optimal chunk size**: static `250` is empirically successful; adaptive chunking (probe Chroma config) is YAGNI for today's failure mode.
- **Skip validateBundle parseability for files >512MB**: would lose sanity-check signal entirely. Streaming is universal.
- **Bypass `ai/services.mjs` to skip Neo bootstrap**: services.mjs IS the canonical entrypoint per #10845 SDK boundary discipline. Add bootstrap, don't bypass.

## Cross-Family Review

@neo-gpt cycle-1 (id 4259848893) accepted implementation; cycle-2 (id 4259855137) verified all 3 tests locally pass; cycle-3 (id 4259860314) flagged the empirical-anchor V-B-A nit (conflated restoration delta with post-summarize-sessions count) — addressed in this revision.

## Companion lane

This is the fourth substrate-evolution PR flowing from the 2026-05-10 incident:
- #11142 (merged) — `Store.clear` cascade guard (root cause of wipe path)
- #11143 (merged) — `ai:restore` preserve-live merge semantics + filter/targeting/hooks
- #11146 (merged) — `sync_all` dev-branch reject (branch-pollution surface)
- **#11151 (this PR)** — production-scale hardening of the restore primitive itself
- #11144 (filed; deferred) — Chroma `#importMemories` preserve-live parity (graph-only scope split)

## Commit history

| Commit | Summary |
|---|---|
| `a24d7ad0f` | feat: 3 hardening fixes (Neo bootstrap + chunked upsert + streaming validateBundle) |
| `7f4947e69` | test: cycle-1 RA — 3 regression tests (one per fix) |