### PR TITLE
feat(github-workflow): pnpm workspace layout support and NEO_WORKSPACE_ROOT docs (#11152)

### DIFF
--- a/ai/mcp/server/github-workflow/config.template.mjs
+++ b/ai/mcp/server/github-workflow/config.template.mjs
@@ -10,11 +10,16 @@ let projectRoot;
 if (process.env.NEO_WORKSPACE_ROOT) {
     projectRoot = process.env.NEO_WORKSPACE_ROOT;
 } else {
-    const nodeModulesIndex = __dirname.indexOf(`${path.sep}node_modules${path.sep}neo.mjs`);
-    if (nodeModulesIndex !== -1) {
-        projectRoot = __dirname.slice(0, nodeModulesIndex) || path.sep;
+    const pnpmIndex = __dirname.indexOf(`${path.sep}node_modules${path.sep}.pnpm${path.sep}`);
+    if (pnpmIndex !== -1) {
+        projectRoot = __dirname.slice(0, pnpmIndex) || path.sep;
     } else {
-        projectRoot = path.resolve(__dirname, '../../../../');
+        const nodeModulesIndex = __dirname.indexOf(`${path.sep}node_modules${path.sep}neo.mjs`);
+        if (nodeModulesIndex !== -1) {
+            projectRoot = __dirname.slice(0, nodeModulesIndex) || path.sep;
+        } else {
+            projectRoot = path.resolve(__dirname, '../../../../');
+        }
     }
 }
 

--- a/ai/services/github-workflow/toolService.mjs
+++ b/ai/services/github-workflow/toolService.mjs
@@ -93,7 +93,7 @@ const serviceMapping = {
 
 // Exported for unit-test access (#11145). `buildDevBranchGuard` accepts injected
 // `delegate` + `getBranch` for fixture-driven testing without spawning real `git`.
-export {buildDevBranchGuard, syncAllOnDevOnly};
+export {buildDevBranchGuard, syncAllOnDevOnly, defaultBranchDetector};
 
 const toolService = Neo.create(ToolService, {
     openApiFilePath,

--- a/learn/agentos/ConfigSubstrateEnvVarAudit.md
+++ b/learn/agentos/ConfigSubstrateEnvVarAudit.md
@@ -82,6 +82,7 @@ Target-tier shorthand:
 | `NEO_OPENAI_COMPATIBLE_HOST` | `memory-core/config.template.mjs:161` | Tier 1 | Shared provider block value; also runtime host binding for local providers. Tier 1 default with env override. |
 | `NEO_OPENAI_COMPATIBLE_MODEL` | `memory-core/config.template.mjs:162` | Tier 1 | Shared provider block value. Tier 1 default plus optional env override. |
 | `NEO_PUBLIC_URL` | `shared/helpers/DeploymentConfig.mjs:119`; `memory-core/config.template.mjs:113`; `knowledge-base/config.template.mjs:58` | Tier 3 | Runtime binding for externally advertised MCP URL behind reverse proxies. |
+| `NEO_WORKSPACE_ROOT` | `github-workflow/config.template.mjs:10` | Tier 3 | Runtime binding for canonical project root path to override standard/pnpm layout heuristic discovery. |
 | `NEO_RLAIF_PATH` | `memory-core/config.template.mjs:269` | Tier 2 | Dataset path. Prefer Memory Core config; env override only if operator path injection is needed. |
 | `NEO_SESSION_ID` | `knowledge-base/Server.mjs:190`; `knowledge-base/services/toolService.mjs:43` | Tier 3 | Session identity binding for KB telemetry/request context fallback. |
 | `NEO_VECTOR_DIMENSION` | `memory-core/config.template.mjs:171` | Tier 1 | Shared embedding/vector contract. Tier 1 default plus optional env override only during controlled migrations. |

--- a/learn/agentos/DeploymentCookbook.md
+++ b/learn/agentos/DeploymentCookbook.md
@@ -88,6 +88,7 @@ When provisioning your containers, supply the following minimal environment vari
 
 | `NEO_CHROMA_HOST` | Both | Internal URL of the Chroma instance. |
 | `NEO_CHROMA_PORT` | Both | Port of the Chroma instance. |
+| `NEO_WORKSPACE_ROOT` | Both | The path to the root of the project workspace. Used to override automatic heuristic layout discovery for standard or pnpm mono-repos. |
 | `NEO_PUBLIC_URL` | Both | The canonical public URL for this MCP server (e.g., `https://api.example.com/mc`). Required for SSE advertisement and OAuth `redirect_uri` generation behind reverse proxies. |
 | `NEO_AUTH_TRUST_PROXY_IDENTITY` | Both | Set to `true` if your reverse proxy handles authentication. |
 | `GEMINI_API_KEY` | Both | Required for Gemini integration. |

--- a/test/playwright/unit/ai/services/github-workflow/toolService.spec.mjs
+++ b/test/playwright/unit/ai/services/github-workflow/toolService.spec.mjs
@@ -38,11 +38,13 @@ import InstanceManager from '../../../../../../src/manager/Instance.mjs';
  * testing without spawning real `git` (no environment dependency).
  */
 test.describe('Neo.ai.services.github-workflow.toolService — sync_all dev-branch guard (#11145)', () => {
-    let buildDevBranchGuard;
+    let buildDevBranchGuard, defaultBranchDetector, config;
 
     test.beforeAll(async () => {
         const mod = await import('../../../../../../ai/services/github-workflow/toolService.mjs');
         buildDevBranchGuard = mod.buildDevBranchGuard;
+        defaultBranchDetector = mod.defaultBranchDetector;
+        config = (await import('../../../../../../ai/mcp/server/github-workflow/config.mjs')).default;
     });
 
     test('sync_all delegates to SyncService.runFullSync when on dev', async () => {
@@ -97,5 +99,16 @@ test.describe('Neo.ai.services.github-workflow.toolService — sync_all dev-bran
         const guarded = buildDevBranchGuard(async () => {}, async () => 'feature/x');
 
         await expect(guarded()).rejects.toThrow(/PrimaryRepoSyncService/);
+    });
+
+    test('defaultBranchDetector uses config.projectRoot as cwd (mocked cwd test)', async () => {
+        const originalRoot = config.projectRoot;
+        try {
+            // Set to an explicitly invalid path to guarantee a git error about not being a git repository or no such file
+            config.projectRoot = '/tmp/fake-non-existent-dir-for-neo-test-123';
+            await expect(defaultBranchDetector()).rejects.toThrow(/spawn git|ENOENT|not a git repository/i);
+        } finally {
+            config.projectRoot = originalRoot;
+        }
     });
 });


### PR DESCRIPTION
Resolves #11152

Authored by neo-gpt (Codex Desktop). Session 22713fa8-23d2-4b31-918b-6e2f48d69c06.

Adds `pnpm` workspace path heuristic logic to `github-workflow`'s `config.template.mjs` to identify `projectRoot` when running MCP servers within pnpm monorepos. Documents `NEO_WORKSPACE_ROOT` as the canonical project-root override mechanism in deployment and configuration guides.

Evidence: L2 (sandbox-runtime mocked-cwd test invokes real `git` through `defaultBranchDetector`; static config-template audit; CI green) → L2 required. No residuals.

## Config Template Changes & Local Sync

Changed config surface:
- `ai/mcp/server/github-workflow/config.template.mjs`
- `projectRoot` derivation order is now:
  1. `NEO_WORKSPACE_ROOT`
  2. pnpm `.pnpm` workspace layout root
  3. standard `node_modules/neo.mjs` layout root
  4. repo-relative fallback from `__dirname`
- No new `defaultConfig` object key is introduced, but the existing `projectRoot` value derivation changes.
- `NEO_WORKSPACE_ROOT` is documented as the explicit override key.

Local `config.mjs` follow-up:
- Required for clones that run the `github-workflow` MCP server from pnpm workspace layouts or want template parity.
- Existing gitignored `ai/mcp/server/github-workflow/config.mjs` files are not committed by design.
- Because this is value-level template logic, drift may not be caught by the import/export detector. Refresh via `npm run prepare -- --migrate-config` or manually copy the `projectRoot` derivation block into the local config while preserving clone-specific settings.

Harness restart:
- Required for already-running `github-workflow` MCP server processes after local `config.mjs` is refreshed.
- Not required for clones that do not refresh local config immediately.

Peer notification:
- Normal A2A review / response notifications are active for this PR. This PR body records the clone-sync action required after merge.

## Deltas from ticket (if any)

None.

## Test Evidence

- Added Playwright unit coverage for `defaultBranchDetector` in `toolService.spec.mjs` using a mocked invalid `config.projectRoot`; the test invokes the real `git` subprocess path and asserts the configured cwd is honored.
- `git diff --check origin/dev...HEAD` passed.
- GitHub checks are green: CodeQL, Analyze (javascript), unit, and integration-unified.
