### PR TITLE
feat(worktree): finalize bootstrap protocols and antigravity support (#11156)

### DIFF
--- a/.gemini/concepts/worktree-bootstrap.md
+++ b/.gemini/concepts/worktree-bootstrap.md
@@ -18,9 +18,17 @@ node ai/scripts/bootstrapWorktree.mjs --link-data
 ```
 
 **What this does:**
-1. Copies all required `config.mjs` templates from the canonical main repository to ensure MCP server compatibility.
+1. Copies existing gitignored `config.mjs` local overrides from the canonical checkout to ensure local environment settings and authentication values are preserved.
 2. Symlinks the `.neo-ai-data/` directory (containing SQLite, Chroma DB, wake-daemon, etc.) to the canonical path, preserving swarm-wide context and preventing data fragmentation.
 3. Links gitignored handoff files (like `sandman_handoff.md`) from the canonical checkout.
+
+**Shell Authentication Verification:**
+Due to shell sandbox isolation in the Antigravity harness, the GitHub CLI may lack credentials. After bootstrap, verify your shell authentication before pushing branches:
+```bash
+env | cut -d= -f1 | rg '^GH_TOKEN$'
+gh api user --jq .login
+```
+*Expected output:* The environment MUST contain `GH_TOKEN` (verified by name, do not print its value) and `gh api user` MUST return your agent identity (e.g., `neo-gemini-3-1-pro`). If auth fails, ensure the operator has updated `.zshenv` to source the correct `.env` file for your worktree path.
 
 **Task-Specific Modifiers:**
 - **Docs-only tickets:** `--link-data` is sufficient.

--- a/.gemini/concepts/worktree-bootstrap.md
+++ b/.gemini/concepts/worktree-bootstrap.md
@@ -1,0 +1,28 @@
+---
+name: worktree-bootstrap
+description: Automatic initialization sequence for fresh Git worktree sessions for Antigravity (Gemini).
+---
+
+# Worktree Bootstrap Protocol
+
+When operating in a fresh Git worktree (e.g., a newly checked out branch in a separate folder), the environment starts off without essential gitignored configurations and the shared `.neo-ai-data` substrate. These are required for correct agent behavior, knowledge base access, and swarm state synchronization.
+
+**Trigger:**
+Whenever you start a fresh session in a new worktree, you MUST execute this bootstrap process before performing any tasks that rely on the Memory Core, Knowledge Base, or SDK services.
+
+**Action:**
+Execute the following script to unify the local infrastructure with the canonical checkout:
+
+```bash
+node ai/scripts/bootstrapWorktree.mjs --link-data
+```
+
+**What this does:**
+1. Copies all required `config.mjs` templates from the canonical main repository to ensure MCP server compatibility.
+2. Symlinks the `.neo-ai-data/` directory (containing SQLite, Chroma DB, wake-daemon, etc.) to the canonical path, preserving swarm-wide context and preventing data fragmentation.
+3. Links gitignored handoff files (like `sandman_handoff.md`) from the canonical checkout.
+
+**Task-Specific Modifiers:**
+- **Docs-only tickets:** `--link-data` is sufficient.
+- **Backend / MCP / Unit-test tickets:** Append `--install` (e.g., `node ai/scripts/bootstrapWorktree.mjs --link-data --install`) to also install dependencies and `bundle-parse5`.
+- **Frontend / Webpack tickets:** Append `--build-all` to imply install and execute the full Webpack distribution build.

--- a/AGENTS_STARTUP.md
+++ b/AGENTS_STARTUP.md
@@ -74,9 +74,9 @@ Different AI harnesses auto-load their own "memory file" at session start. Each 
 
 As new harnesses join the swarm, add their memory-file conventions here.
 
-#### Worktree Bootstrap (Claude Code)
+#### Worktree Bootstrap (Claude Code & Antigravity)
 
-Claude Code creates a fresh git worktree per session at `.claude/worktrees/<name>/`. Because `ai/mcp/server/*/config.mjs` is gitignored (copy-from-template files for local overrides), worktrees start without these files. Any script that imports `ai/services.mjs` fails with:
+Agent harnesses create a fresh git worktree per session (e.g., at `.claude/worktrees/<name>/` or `.gemini/antigravity/worktrees/...`). Because `ai/mcp/server/*/config.mjs` is gitignored (copy-from-template files for local overrides), fresh worktrees start without these files. Any script that imports `ai/services.mjs` fails with:
 
 ```
 Error [ERR_MODULE_NOT_FOUND]: Cannot find module '.../ai/mcp/server/github-workflow/config.mjs'


### PR DESCRIPTION
Authored by neo-gemini-3-1-pro ([Antigravity]). Session 1d5d1fd1-ff3f-480d-b267-0dad7dc6c3c7.

Resolves #11156

Generalizes the worktree bootstrap protocols across agent harnesses, explicitly including Antigravity. Adds a new concept file for Gemini worktree initialization which clarifies the config override copy process and provides a shell auth verification step to unblock `gh` inside sandboxes.

Evidence: L1 (static documentation additions) -> L1 required (no runtime verify ACs). No residuals.

## Deltas from ticket (if any)
Added shell auth verification steps for the Antigravity `.zshenv` path prefix gap to the concept file, serving as operator-side validation context.

## Test Evidence
Verified local script `ai/scripts/bootstrapWorktree.mjs` execution against the updated documentation.