### PR TITLE
fix(github-workflow): revert 3-tier projectRoot heuristic to cwd-primary shape (#11155)

### DIFF
--- a/ai/mcp/server/github-workflow/config.template.mjs
+++ b/ai/mcp/server/github-workflow/config.template.mjs
@@ -5,18 +5,8 @@ import BaseConfig, { createConfigProxy } from '../shared/BaseConfig.mjs';
 const __filename  = fileURLToPath(import.meta.url);
 const __dirname   = path.dirname(__filename);
 
-let projectRoot;
-
-if (process.env.NEO_WORKSPACE_ROOT) {
-    projectRoot = process.env.NEO_WORKSPACE_ROOT;
-} else {
-    const nodeModulesIndex = __dirname.indexOf(`${path.sep}node_modules${path.sep}neo.mjs`);
-    if (nodeModulesIndex !== -1) {
-        projectRoot = __dirname.slice(0, nodeModulesIndex) || path.sep;
-    } else {
-        projectRoot = path.resolve(__dirname, '../../../../');
-    }
-}
+const packageRoot = path.resolve(__dirname, '../../../../');
+const projectRoot = process.cwd() === '/' ? packageRoot : process.cwd();
 
 /**
  * Default configuration object.


### PR DESCRIPTION
Authored by Antigravity (Gemini 3.1 Pro). Session 1d5d1fd1-ff3f-480d-b267-0dad7dc6c3c7.

Resolves #11155

Reverted the unstable 3-tier `projectRoot` heuristic in `github-workflow/config.template.mjs` to the proven `cwd`-primary shape used in v12.1.0. This fixes the regression introduced in #11149 where `__dirname.indexOf('${path.sep}node_modules${path.sep}neo.mjs')` prefix-matched the file location instead of using `cwd`, breaking the environment pathing for consumer workspaces.

Evidence: L2 (manual empirical runtime validation of `projectRoot` resolution during `npm run ai:mcp-server-github-workflow`) → L1 required (no automated runtime test suite exists for `projectRoot` environment resolution). No residuals.

## Config Template Changes
- **Changed keys:** None. The structural resolution of `projectRoot` was reverted.
- **Local `config.mjs` update:** All active clones must manually update their `ai/mcp/server/github-workflow/config.mjs` to reflect this reverted `projectRoot` logic.
- **Harness restart:** Required after merging and pulling this change to reflect the corrected path.

## Test Evidence
Verified manually by executing `npm run ai:mcp-server-github-workflow` with trace logging. Verified unit tests pass via `npm run test:playwright:unit`.

## Post-Merge Validation
- [ ] Restart local MCP servers and observe no boot-time path errors in GitHub Workflow.
