### PR TITLE
docs(skill): mandate backlog self-select in post-review-pickup (#11165)

### DIFF
--- a/.agents/skills/post-review-pickup/references/post-review-pickup-workflow.md
+++ b/.agents/skills/post-review-pickup/references/post-review-pickup-workflow.md
@@ -32,7 +32,7 @@ If no next lane is identifiable, report an explicit halt-state instead of
 silently ending the turn, for example:
 
 ```text
-halt-state: no assigned or operator-obvious lane remains after #NNNN review; awaiting routing.
+halt-state: backlog self-survey completed after #NNNN review, no positive-ROI lanes self-selectable.
 ```
 
 ## 3. Author Pickup Matrix
@@ -50,14 +50,15 @@ author MUST choose one of these next states before ending the turn:
 
 Halt is allowed only when it is explicit and true:
 
-- No assigned or operator-obvious lane remains.
-- Every candidate lane is blocked on human-only action.
-- A safety gate forbids continuing.
-- The operator explicitly requested a pause.
-- Context exhaustion requires `session-sunset`.
+1. **Backlog self-survey completed** — agent has actively surveyed available open lanes (v13 board / assigned-to-me / authored-by-me / lane-pickable-from-cross-author-substrate) AND found no positive-ROI lane self-selectable, OR all candidate lanes hit conditions 2-5 below. The survey + finding MUST be named in the halt declaration.
+2. Every candidate lane is blocked on human-only action.
+3. A safety gate forbids continuing.
+4. The operator explicitly requested a pause.
+5. Context exhaustion requires `session-sunset`.
 
-Do not broadcast generic "idle" state. If work is blocked, send a targeted
-task/blocker signal using the appropriate A2A shape.
+Lead-role and peer-role agents are explicitly expected to **self-select from the backlog and announce the lane pickup** rather than treating absence-of-operator-direction as legitimate halt. Per AGENTS.md §15.6: *"Proactively select high-value tickets from the backlog or state your intended next lane instead of waiting for passive instruction."*
+
+Do not broadcast generic "idle" state. If work is blocked, send a targeted task/blocker signal using the appropriate A2A shape.
 
 ## 5. Integration Points
 
@@ -81,3 +82,4 @@ for the next prompt. Ticket #10970 is the instance-codification.
 | Waiting for author response after `Request Changes` | Serializes work that can proceed in parallel. |
 | Broadcasting generic idle/capacity status | Creates coordination noise without assigning ownership or naming the blocker. |
 | Duplicating this matrix into PR lifecycle maps | Violates the Map vs Atlas split and increases routine context load. |
+| Declaring halt-state per §4 criterion #1 without first surveying backlog | Condones deference-slip; reverses AGENTS.md §15.6 self-select discipline |


### PR DESCRIPTION
### Context
Resolves #11165. The `post-review-pickup` skill previously allowed agents to legitimately halt if "no operator-obvious lane remains." This implicitly permitted a Helpful-Assistant deference-slip, directly contradicting the `AGENTS.md` §15.6 mandate (Peer-Team) to proactively select tasks.

### The Fix
- Replaced §4 criterion #1 with a strict backlog self-survey mandate. Agents must actively survey open lanes and name their finding in any halt declaration.
- Added a cross-reference to AGENTS.md §15.6.
- Added an Anti-Pattern entry for declaring halt-state without surveying the backlog.
- Updated the halt-state example in §2 to remove the deference-slip wording.

### Evidence
- **Pre-Flight:** Read #11165. No tests are required for markdown documentation.
- The workflow now explicitly forbids the deference-slip pattern observed in the previous session.