### PR TITLE
fix(test): restore singleton state in DreamService.spec afterAll + getContextFrontier patch (#10946)

### DIFF
--- a/test/playwright/unit/ai/daemons/DreamService.spec.mjs
+++ b/test/playwright/unit/ai/daemons/DreamService.spec.mjs
@@ -150,7 +150,12 @@ test.describe('Neo.ai.services.memory-core.DreamService', () => {
     });
 
     test.afterAll(async () => {
-        await TestLifecycleHelper.cleanupGraphService(GraphService, SystemLifecycleService, testDbPath, fs, 'clear');
+        // 'destroy' (not 'clear') so SystemLifecycleService._initPromise is reset to null.
+        // Otherwise sibling specs (e.g. DreamServiceGoldenPath) hit
+        //   `if (!_initPromise) initAsync() else ready()`
+        // → take the `ready()` branch → never honor their own `aiConfig.storagePaths.graph`
+        // → real `getContextFrontier()` returns null. Empirically traced via #10946 bisection.
+        await TestLifecycleHelper.cleanupGraphService(GraphService, SystemLifecycleService, testDbPath, fs, 'destroy');
 
         if (KBRecorderService?.db) {
             KBRecorderService.db.exec('DELETE FROM kb_query_log; DELETE FROM kb_query_faqs;');
@@ -854,8 +859,9 @@ test.describe('Neo.ai.services.memory-core.DreamService', () => {
         GraphService.db.edges.getByIndex = (idx, val) => {
             return GraphService.db.edges.items.filter(e => e[idx] === val);
         };
-        const originalLinkNodes = GraphService.linkNodes;
-        GraphService.linkNodes = () => {};
+        const originalLinkNodes          = GraphService.linkNodes;
+        const originalGetContextFrontier = GraphService.getContextFrontier;
+        GraphService.linkNodes          = () => {};
         GraphService.getContextFrontier = () => ({ nodes: [], edges: [] });
 
         const baseGenerate = OpenAiCompatible.prototype.generate;
@@ -918,7 +924,8 @@ test.describe('Neo.ai.services.memory-core.DreamService', () => {
         } else {
              delete GraphService.db.storage.db.prepare;
         }
-        GraphService.linkNodes = originalLinkNodes;
+        GraphService.linkNodes          = originalLinkNodes;
+        GraphService.getContextFrontier = originalGetContextFrontier;
     });
 
     test('should retry extraction on malformed JSON payload up to 3 times to fix #9913', async () => {


### PR DESCRIPTION
Authored by Neo Claude Opus 4.7 (Claude Code). Session c2912891-b459-4a03-b2af-154d5e264df1.

Resolves #10946

Restores symmetric polluter-side cleanup in `test/playwright/unit/ai/daemons/DreamService.spec.mjs` so the `DreamServiceGoldenPath` sibling spec receives a clean singleton state instead of two leaked mutations from the `synthesizeGoldenPath` mock test + the `afterAll` clear-strategy `_initPromise` retention.

Evidence: L1 (static spec audit + empirical pair-test + full-bucket × 5 isolation runs at `--retries 0`) → L1 required (test-isolation regression with deterministic empirical reproduction). No residuals.

## What changed

Two polluter-side cleanup gaps in `DreamService.spec.mjs`, both surfaced via the #10946 bisection protocol (Step 1: isolated spec 5/5 PASS → Step 2: full ai/daemons/ bucket 1 FAIL → Step 3: minimal pair-test reproduction → Step 4: code-read).

**Gap 1 — monkey-patch asymmetry (lines 859, 911-921):**
The `synthesizeGoldenPath should mathematically select and inject Golden Path` test monkey-patches `GraphService.getContextFrontier = () => ({ nodes: [], edges: [] })` but its companion restore block at the end of the test does NOT include a matching restore. The sibling patches (`originalLinkNodes`, `originalGenerate`, `originalAppendFile`, `originalPrepare`) are all captured + restored symmetrically; `getContextFrontier` was the asymmetry. Subsequent specs (notably `DreamServiceGoldenPath.spec`) then receive `{ nodes: [], edges: [] }` from the leaked patch instead of the real method's topology → `topology.frontier` becomes undefined → assertion at `DreamServiceGoldenPath.spec.mjs:86` fires with `Cannot read properties of undefined (reading 'id')` (matches the original ticket body's failure-mode anchor).

Fix: capture `originalGetContextFrontier` symmetrically to `originalLinkNodes`, restore in cleanup block.

**Gap 2 — afterAll clear-vs-destroy strategy (lines 152-153):**
`afterAll` uses `cleanupGraphService(..., 'clear')` which only clears `nodes/edges/vicinityLoadedNodes/storage` but does NOT reset `SystemLifecycleService._initPromise`. Sibling specs that check `if (!_initPromise) initAsync() else ready()` then take the `else ready()` branch — never honoring their own `aiConfig.storagePaths.graph`. Real `getContextFrontier()` then returns null (no frontier node ever upserted in the wrong-DB state).

Fix: switch to `cleanupGraphService(..., 'destroy')` — already-supported by `TestLifecycleHelper` — which resets `_initPromise`, destroys `db`, and deletes the SQLite file + WAL + SHM. Sibling specs then take the `initAsync()` branch and run with their own config.

Both fixes are polluter-side per `feedback_symmetric_spec_cleanup.md` discipline. No consumer-side changes; no skip-guards added; no spec-level settle-patterns introduced.

## V-B-A trail (substrate hygiene)

The original ticket body framed the race-surface as Promise-unsettlement between synthesizeGoldenPath() and getContextFrontier(). V-B-A revealed all relevant methods (`linkNodes`, `upsertNode`, `getContextFrontier`, `Database.getAdjacentNodes`) are SYNCHRONOUS (better-sqlite3 + in-memory collections). The race is NOT async-Promise-class but workers:1 sibling-spec singleton-pollution — captured in [prior ticket comment](https://github.com/neomjs/neo/issues/10946#issuecomment-corrections) (V-B-A 2026-05-10). This PR concludes the investigation lane with the empirically-traced fix.

## Test Evidence

Empirical reproduction + fix verification, all with `--retries 0` (overriding `CI=true`'s default retries=2 to detect first-attempt-only flake):

- **Step 1 baseline** — isolated `DreamServiceGoldenPath.spec.mjs` × 5 runs: **5/5 PASS** (4-6s each) — confirms sibling-pollution hypothesis
- **Step 2 bisection** — full `test/playwright/unit/ai/daemons/` bucket: **97/98 PASS, 1 FAIL** (the deterministic flake) — confirms within-bucket pollution
- **Step 3 minimal-pair pre-fix** — `DreamService.spec → DreamServiceGoldenPath.spec`: **14/15 PASS, 1 FAIL** — minimal reproduction
- **Step 4 minimal-pair post-fix** — `DreamService.spec → DreamServiceGoldenPath.spec`: **15/15 PASS** — fix verified
- **Step 5 AC4 verification** — full `test/playwright/unit/ai/daemons/` bucket × 5 iterations post-fix: **98/98 PASS each run, 5/5 runs PASS** — deterministic stability achieved

Commands used:
```bash
CI=true npm run test-unit -- --retries 0 test/playwright/unit/ai/daemons/DreamService.spec.mjs test/playwright/unit/ai/daemons/DreamServiceGoldenPath.spec.mjs
CI=true npm run test-unit -- --retries 0 test/playwright/unit/ai/daemons/
```

## Acceptance Criteria Closure

- [x] **AC1 (empirical reproduction)** — Step 2 above: full bucket reproduces 1/98 deterministic fail at `--retries 0`
- [x] **AC2 (identify race surface)** — `getContextFrontier` monkey-patch leak + `_initPromise` retention in afterAll. Both empirically confirmed via minimal-pair bisection.
- [x] **AC3 (choose fix path + rationale)** — Polluter-side over consumer-side (matches `feedback_symmetric_spec_cleanup.md` symmetric cleanup discipline; doesn't add defensive code to every consumer)
- [x] **AC4 (5x deterministic runs)** — Step 5 above: 5/5 runs PASS, 98/98 tests per run
- [x] **AC5 (skip-guard removal)** — None to remove. The `test.skip(!!process.env.NEO_TEST_SKIP_CI, ...)` guard at `DreamServiceGoldenPath.spec.mjs:78` was already removed in PR #10940; the comment text was left as historical context. Could optionally clean up the stale skip-comment in a follow-up; non-blocking.

## Commits
- `72f4f15c9` — fix(test): restore singleton state in DreamService.spec afterAll + getContextFrontier patch (#10946)
