### PR TITLE
feat(ai): load local orchestrator dev-sync roots config (#11169)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -102,6 +102,7 @@ resources/data/deck/EditorConfig.json
 .neo-ai-data
 !.neo-ai-data/concepts/
 ai/mcp/server/*/config.mjs
+ai/config.mjs
 # Runtime artifact — `MailboxService.mjs:259` persistence-error fallback writes
 # `sent-to-cull.jsonl` next to the graph storage path during SENT_TO edge cull
 # events (#10347 Phase 1 diagnostic). Lands at repo root if `aiConfig.storagePaths.graph`

--- a/ai/config.template.mjs
+++ b/ai/config.template.mjs
@@ -57,6 +57,19 @@ const defaultConfig = {
         trustProxyIdentity: process.env.NEO_AUTH_TRUST_PROXY_IDENTITY === 'true'
     },
     /**
+     * Agent OS maintenance orchestrator configuration.
+     * @type {Object}
+     */
+    orchestrator: {
+        /**
+         * Optional local Neo repo roots for the primary-dev-sync lane.
+         * Keep the template machine-neutral; set real absolute paths in gitignored
+         * `ai/config.mjs` or via `NEO_ORCHESTRATOR_DEV_SYNC_ROOTS`.
+         * @type {String[]}
+         */
+        devSyncRoots: []
+    },
+    /**
      * A dummy embedding function to satisfy ChromaDB when embeddings are provided manually.
      * @returns {Object}
      */

--- a/ai/daemons/Orchestrator.mjs
+++ b/ai/daemons/Orchestrator.mjs
@@ -14,6 +14,8 @@ import {
 import SummarizationCoordinatorService from './services/SummarizationCoordinatorService.mjs';
 import BackupCoordinatorService          from './services/BackupCoordinatorService.mjs';
 import PrimaryRepoSyncService, {
+    DEV_SYNC_ROOTS_CONFIG_KEY,
+    DEV_SYNC_ROOTS_ENV_VAR,
     parseEnabledFlag
 } from './services/PrimaryRepoSyncService.mjs';
 import TaskStateService                from './services/TaskStateService.mjs';
@@ -31,6 +33,39 @@ import {
     DEFAULT_SCRIPT_DIR,
     buildTaskDefinitions
 } from './TaskDefinitions.mjs';
+
+/**
+ * Resolves the dev-sync roots config while preserving env-var precedence.
+ * @param {Object} options
+ * @param {String|undefined|null} options.envValue Environment value.
+ * @param {String[]|String|undefined|null} options.configValue Local config value.
+ * @returns {String[]|String|undefined|null}
+ */
+export function resolvePrimaryDevSyncRootsConfig({envValue, configValue}) {
+    if (envValue !== undefined && envValue !== null && envValue !== '') {
+        return envValue;
+    }
+
+    if (Array.isArray(configValue) && configValue.length === 0) {
+        return null;
+    }
+
+    return configValue;
+}
+
+/**
+ * Resolves the operator-visible dev-sync roots config source label.
+ * @param {Object} options
+ * @param {String|undefined|null} options.envValue Environment value.
+ * @returns {String}
+ */
+export function resolvePrimaryDevSyncRootsSource({envValue}) {
+    if (envValue !== undefined && envValue !== null && envValue !== '') {
+        return DEV_SYNC_ROOTS_ENV_VAR;
+    }
+
+    return DEV_SYNC_ROOTS_CONFIG_KEY;
+}
 
 /**
  * @summary Neo daemon class for Agent OS maintenance scheduling (#11009).
@@ -158,6 +193,12 @@ export class Orchestrator extends Base {
          */
         primaryDevSyncEnabled_: true,
         /**
+         * @member {String[]|String|null} primaryDevSyncRootsConfig_=null
+         * @protected
+         * @reactive
+         */
+        primaryDevSyncRootsConfig_: null,
+        /**
          * @member {Object} healthService_=HealthService
          * @protected
          * @reactive
@@ -233,6 +274,7 @@ export class Orchestrator extends Base {
             process.env.NEO_ORCHESTRATOR_PRIMARY_DEV_SYNC_ENABLED,
             true
         );
+        this.primaryDevSyncRootsConfig = options.primaryDevSyncRootsConfig ?? null;
         this.taskDefinitions        = options.taskDefinitions || buildTaskDefinitions({
             scriptDir,
             nodeBin: options.nodeBin || process.argv[0]
@@ -385,9 +427,16 @@ export class Orchestrator extends Base {
             return this.primaryRepoSyncService.runTask({
                 taskName,
                 reason,
-                taskStateService: this.taskStateService,
-                healthService   : this.healthService,
-                writeLog        : this.writeLog.bind(this)
+                taskStateService  : this.taskStateService,
+                healthService     : this.healthService,
+                writeLog          : this.writeLog.bind(this),
+                devSyncRootsConfig: resolvePrimaryDevSyncRootsConfig({
+                    envValue   : process.env[DEV_SYNC_ROOTS_ENV_VAR],
+                    configValue: this.primaryDevSyncRootsConfig
+                }),
+                devSyncRootsSource: resolvePrimaryDevSyncRootsSource({
+                    envValue: process.env[DEV_SYNC_ROOTS_ENV_VAR]
+                })
             });
         }, context);
 

--- a/ai/daemons/services/PrimaryRepoSyncService.mjs
+++ b/ai/daemons/services/PrimaryRepoSyncService.mjs
@@ -11,6 +11,7 @@ const REMOTE_NAME    = 'origin';
 const REMOTE_REF     = `${REMOTE_NAME}/${DEV_BRANCH}`;
 const META_SYNC_PATH = 'resources/content/.sync-metadata.json';
 export const DEV_SYNC_ROOTS_ENV_VAR = 'NEO_ORCHESTRATOR_DEV_SYNC_ROOTS';
+export const DEV_SYNC_ROOTS_CONFIG_KEY = 'orchestrator.devSyncRoots';
 
 /**
  * @summary Parses the primary-dev-sync enable flag.
@@ -33,22 +34,33 @@ export function parseEnabledFlag(value, fallback=true) {
  * The env var is intentionally explicit: no sibling-clone discovery, no branch
  * switching, and no machine-specific defaults.
  *
- * @param {String|undefined|null} value JSON array of absolute repo roots.
+ * @param {String[]|String|undefined|null} value JSON array or array of absolute repo roots.
+ * @param {String} [source=DEV_SYNC_ROOTS_ENV_VAR] Source label for operator-visible errors.
  * @returns {Object}
  */
-export function parseDevSyncRoots(value) {
+export function parseDevSyncRoots(value, source=DEV_SYNC_ROOTS_ENV_VAR) {
     if (value === undefined || value === null || value === '') {
         return {status: 'unset', roots: []};
     }
 
     let parsed;
-    try {
-        parsed = JSON.parse(value);
-    } catch (e) {
+    if (Array.isArray(value)) {
+        parsed = value;
+    } else if (typeof value === 'string') {
+        try {
+            parsed = JSON.parse(value);
+        } catch (e) {
+            return {
+                status    : 'invalid',
+                reasonCode: 'invalid-dev-sync-roots',
+                error     : `${source} must be a JSON array of absolute paths.`
+            };
+        }
+    } else {
         return {
             status    : 'invalid',
             reasonCode: 'invalid-dev-sync-roots',
-            error     : `${DEV_SYNC_ROOTS_ENV_VAR} must be a JSON array of absolute paths.`
+            error     : `${source} must be a JSON array of absolute paths.`
         };
     }
 
@@ -56,7 +68,7 @@ export function parseDevSyncRoots(value) {
         return {
             status    : 'invalid',
             reasonCode: 'invalid-dev-sync-roots',
-            error     : `${DEV_SYNC_ROOTS_ENV_VAR} must be a JSON array of absolute paths.`
+            error     : `${source} must be a JSON array of absolute paths.`
         };
     }
 
@@ -68,7 +80,7 @@ export function parseDevSyncRoots(value) {
             return {
                 status    : 'invalid',
                 reasonCode: 'invalid-dev-sync-roots',
-                error     : `${DEV_SYNC_ROOTS_ENV_VAR} entries must be absolute path strings.`
+                error     : `${source} entries must be absolute path strings.`
             };
         }
 
@@ -162,7 +174,8 @@ class PrimaryRepoSyncService extends Base {
      * @param {Function} [options.writeLog] Orchestrator logger.
      * @param {String} [options.cwd=process.cwd()] Invocation directory.
      * @param {Function} [options.execFileSyncFn=execFileSync] Test seam.
-     * @param {String|undefined|null} [options.devSyncRootsConfig=process.env.NEO_ORCHESTRATOR_DEV_SYNC_ROOTS] Optional configured roots.
+     * @param {String[]|String|undefined|null} [options.devSyncRootsConfig=process.env.NEO_ORCHESTRATOR_DEV_SYNC_ROOTS] Optional configured roots.
+     * @param {String} [options.devSyncRootsSource=NEO_ORCHESTRATOR_DEV_SYNC_ROOTS] Config source label.
      * @returns {Object} Execution result.
      */
     runTask({
@@ -173,7 +186,8 @@ class PrimaryRepoSyncService extends Base {
         writeLog,
         cwd = process.cwd(),
         execFileSyncFn = execFileSync,
-        devSyncRootsConfig = process.env[DEV_SYNC_ROOTS_ENV_VAR]
+        devSyncRootsConfig = process.env[DEV_SYNC_ROOTS_ENV_VAR],
+        devSyncRootsSource = DEV_SYNC_ROOTS_ENV_VAR
     }) {
         const state = taskStateService.getTaskState(taskName);
 
@@ -187,7 +201,7 @@ class PrimaryRepoSyncService extends Base {
         taskStateService.markStarted(taskName, reason);
 
         try {
-            const result = this.syncPrimaryDev({cwd, execFileSyncFn, writeLog, devSyncRootsConfig});
+            const result = this.syncPrimaryDev({cwd, execFileSyncFn, writeLog, devSyncRootsConfig, devSyncRootsSource});
             const status = result.status === 'completed' ? 'completed' : result.status === 'failed' ? 'failed' : 'skipped';
 
             if (status === 'completed') {
@@ -216,15 +230,23 @@ class PrimaryRepoSyncService extends Base {
      * @param {String} options.cwd Invocation directory.
      * @param {Function} options.execFileSyncFn Command execution seam.
      * @param {Function} [options.writeLog] Optional logger.
-     * @param {String|undefined|null} [options.devSyncRootsConfig=process.env.NEO_ORCHESTRATOR_DEV_SYNC_ROOTS] Optional configured roots.
+     * @param {String[]|String|undefined|null} [options.devSyncRootsConfig=process.env.NEO_ORCHESTRATOR_DEV_SYNC_ROOTS] Optional configured roots.
+     * @param {String} [options.devSyncRootsSource=NEO_ORCHESTRATOR_DEV_SYNC_ROOTS] Config source label.
      * @returns {Object}
      */
-    syncPrimaryDev({cwd, execFileSyncFn, writeLog, devSyncRootsConfig = process.env[DEV_SYNC_ROOTS_ENV_VAR]}) {
-        const rootsConfig = parseDevSyncRoots(devSyncRootsConfig);
+    syncPrimaryDev({
+        cwd,
+        execFileSyncFn,
+        writeLog,
+        devSyncRootsConfig = process.env[DEV_SYNC_ROOTS_ENV_VAR],
+        devSyncRootsSource = DEV_SYNC_ROOTS_ENV_VAR
+    }) {
+        const rootsConfig = parseDevSyncRoots(devSyncRootsConfig, devSyncRootsSource);
 
         if (rootsConfig.status === 'invalid') {
             return this.skip(rootsConfig.reasonCode, {
                 envVar: DEV_SYNC_ROOTS_ENV_VAR,
+                source: devSyncRootsSource,
                 error : rootsConfig.error
             }, writeLog);
         }

--- a/ai/scripts/orchestrator-daemon.mjs
+++ b/ai/scripts/orchestrator-daemon.mjs
@@ -21,10 +21,11 @@ import Neo             from '../../src/Neo.mjs';
 import * as core       from '../../src/core/_export.mjs';
 import InstanceManager from '../../src/manager/Instance.mjs';
 
-import {pathToFileURL} from 'url';
+import {fileURLToPath, pathToFileURL} from 'url';
 import fs from 'fs-extra';
 import path from 'path';
 import {execSync} from 'child_process';
+import AiConfig from '../config.template.mjs';
 import Orchestrator from '../daemons/Orchestrator.mjs';
 import {
     DEFAULT_KB_SYNC_INTERVAL_MS,
@@ -35,6 +36,7 @@ import {
 const DAEMON_DATA_DIR = process.env.NEO_AI_ORCHESTRATOR_DIR || '.neo-ai-data/orchestrator-daemon';
 const PID_FILE        = path.join(DAEMON_DATA_DIR, 'orchestrator-daemon.pid');
 const LOG_FILE        = path.join(DAEMON_DATA_DIR, 'orchestrator.log');
+export const LOCAL_AI_CONFIG_FILE = fileURLToPath(new URL('../config.mjs', import.meta.url));
 
 function writeLog(level, message) {
     const timestamp = new Date().toISOString();
@@ -129,6 +131,28 @@ function setupCleanupHandlers() {
 }
 
 /**
+ * Loads the gitignored top-level AI config when present.
+ * @param {Object} [options]
+ * @param {String} [options.configPath=LOCAL_AI_CONFIG_FILE] Config path.
+ * @param {Object} [options.aiConfig=AiConfig] Config singleton.
+ * @param {Function} [options.existsSync=fs.existsSync] Existence seam.
+ * @returns {Promise<Object>}
+ */
+export async function loadLocalAiConfig({
+    configPath = LOCAL_AI_CONFIG_FILE,
+    aiConfig   = AiConfig,
+    existsSync = fs.existsSync
+} = {}) {
+    if (!existsSync(configPath)) {
+        return {loaded: false, configPath};
+    }
+
+    await aiConfig.load(configPath);
+
+    return {loaded: true, configPath};
+}
+
+/**
  * Starts the singleton orchestrator daemon.
  * @param {Object} [options] Runtime overrides for tests or process managers.
  * @returns {Promise<void>}
@@ -137,8 +161,10 @@ export async function startOrchestrator(options = {}) {
     fs.ensureDirSync(DAEMON_DATA_DIR);
     await enforceSingleton();
     setupCleanupHandlers();
+    await loadLocalAiConfig();
     return Orchestrator.start({
         dataDir: DAEMON_DATA_DIR,
+        primaryDevSyncRootsConfig: AiConfig.orchestrator?.devSyncRoots,
         ...options
     });
 }

--- a/learn/agentos/DeploymentCookbook.md
+++ b/learn/agentos/DeploymentCookbook.md
@@ -105,9 +105,45 @@ When provisioning your containers, supply the following minimal environment vari
 | `NEO_SUMMARIZATION_SWEEP_INTERVAL_MS` | MC | The interval in milliseconds for the bridge-daemon to poll SQLite for un-summarized sessions (default: `600000` = 10 mins). Set to `0` to disable periodic sweeping. |
 | `NEO_ORCHESTRATOR_PRIMARY_DEV_SYNC_INTERVAL_MS` | Orchestrator | Primary-checkout `dev` auto-sync cadence (default: `600000` = 10 mins). Set to `0` to disable the periodic trigger. |
 | `NEO_ORCHESTRATOR_PRIMARY_DEV_SYNC_ENABLED` | Orchestrator | Set to `false`/`0`/`no`/`off` to disable the primary-checkout auto-sync lane without changing the daemon process. |
-| `NEO_ORCHESTRATOR_DEV_SYNC_ROOTS` | Orchestrator | Optional JSON array of absolute Neo repo roots to include in the primary-dev-sync lane. Unset preserves the single owning-checkout behavior. Configured roots are never auto-discovered or branch-switched; non-`dev` roots are fetch-only. KB sync still cascades once from the owning checkout after at least one successful `dev` update. |
+| `NEO_ORCHESTRATOR_DEV_SYNC_ROOTS` | Orchestrator | Optional JSON array of absolute Neo repo roots to include in the primary-dev-sync lane. This env var has precedence over local config. Unset preserves the single owning-checkout behavior unless `ai/config.mjs` sets `orchestrator.devSyncRoots`. Configured roots are never auto-discovered or branch-switched; non-`dev` roots are fetch-only. KB sync still cascades once from the owning checkout after at least one successful `dev` update. |
 
 *(Notes: Public URL advertising is tracked under [#10802](https://github.com/neomjs/neo/issues/10802). Provider consolidation shipped in [PR #10810](https://github.com/neomjs/neo/pull/10810) — `embeddingProvider` is now the canonical selector. Env-var ergonomics shipped in [#10808](https://github.com/neomjs/neo/issues/10808): `MCP_HTTP_PORT` is the canonical operator-facing env var (`SSE_PORT` remains readable during the deprecation window with a warning); `NEO_CHROMA_HOST` / `NEO_CHROMA_PORT` are now env-overridable on both KB + MC. Session-summary single-writer flag `NEO_MC_PRIMARY` has been deprecated in favor of daemon-owned locks per Piece B/C migration [#10956](https://github.com/neomjs/neo/issues/10956).)*
+
+### Local Orchestrator Dev-Sync Roots
+
+The orchestrator can sync multiple local Neo checkouts through the primary-dev-sync lane without committing machine-specific paths. Precedence is:
+
+1. `NEO_ORCHESTRATOR_DEV_SYNC_ROOTS`
+2. `ai/config.mjs` `orchestrator.devSyncRoots`
+3. unset single owning-checkout behavior
+
+For a durable local setup, create the gitignored `ai/config.mjs` file:
+
+```js
+export default {
+    orchestrator: {
+        devSyncRoots: [
+            '/absolute/path/to/neo-gpt/neo',
+            '/absolute/path/to/neo-gemini/neo',
+            '/absolute/path/to/neo-opus/neo'
+        ]
+    }
+};
+```
+
+Then start the existing orchestrator command:
+
+```sh
+npm run ai:orchestrator
+```
+
+For one-off process-manager overrides, keep using the env var:
+
+```sh
+NEO_ORCHESTRATOR_DEV_SYNC_ROOTS='["/absolute/path/to/neo-gpt/neo","/absolute/path/to/neo-gemini/neo","/absolute/path/to/neo-opus/neo"]' npm run ai:orchestrator
+```
+
+Do not add real local clone paths to `package.json` or `ai/config.template.mjs`; the template default remains `orchestrator.devSyncRoots: []`.
 
 ## Section 7: Healthcheck Verification
 

--- a/test/playwright/unit/ai/config.template.spec.mjs
+++ b/test/playwright/unit/ai/config.template.spec.mjs
@@ -17,4 +17,8 @@ test.describe('Tier 1 Config Immutability', () => {
         expect(Neo.ns('Neo.ai.Config').data.mcpHttpPort).not.toBe(9999);
         expect(Neo.ns('Neo.ai.Config').data.mcpHttpPort).toBe(initialPort);
     });
+
+    test('ships a machine-neutral orchestrator dev-sync root default', async () => {
+        expect(Config.orchestrator.devSyncRoots).toEqual([]);
+    });
 });

--- a/test/playwright/unit/ai/daemons/Orchestrator.spec.mjs
+++ b/test/playwright/unit/ai/daemons/Orchestrator.spec.mjs
@@ -3,8 +3,14 @@ import path from 'path';
 import Neo from '../../../../../src/Neo.mjs';
 import * as core from '../../../../../src/core/_export.mjs';
 import {
-    Orchestrator
+    Orchestrator,
+    resolvePrimaryDevSyncRootsConfig,
+    resolvePrimaryDevSyncRootsSource
 } from '../../../../../ai/daemons/Orchestrator.mjs';
+import {
+    DEV_SYNC_ROOTS_CONFIG_KEY,
+    DEV_SYNC_ROOTS_ENV_VAR
+} from '../../../../../ai/daemons/services/PrimaryRepoSyncService.mjs';
 import {
     DEFAULT_POLL_INTERVAL_MS,
     DEFAULT_SUMMARY_SWEEP_INTERVAL_MS,
@@ -44,6 +50,7 @@ function createTestOrchestrator(config = {}) {
         backupIntervalMs        : config.backupIntervalMs ?? 86400000,
         primaryDevSyncIntervalMs: config.primaryDevSyncIntervalMs ?? 600000,
         primaryDevSyncEnabled   : config.primaryDevSyncEnabled ?? false,
+        primaryDevSyncRootsConfig: config.primaryDevSyncRootsConfig ?? null,
         healthService           : config.healthService || {recordTaskOutcome() {}},
         summarizationCoordinator: config.summarizationCoordinator || {getDueTask: () => null},
         backupCoordinator       : config.backupCoordinator || {getDueTask: () => null},
@@ -204,6 +211,68 @@ test.describe('Neo.ai.daemons.Orchestrator (#11009)', () => {
             taskName: PRIMARY_DEV_SYNC_TASK_NAME,
             reason  : 'periodic-sweep:600000'
         }]);
+    });
+
+    test('passes local dev-sync roots to primary-dev-sync while env keeps precedence', () => {
+        const originalEnvValue = process.env[DEV_SYNC_ROOTS_ENV_VAR];
+        delete process.env[DEV_SYNC_ROOTS_ENV_VAR];
+
+        try {
+            const received = [];
+            const orchestrator = createTestOrchestrator({
+                kbSyncIntervalMs          : 0,
+                backupIntervalMs          : 0,
+                primaryDevSyncEnabled     : true,
+                primaryDevSyncIntervalMs  : 600000,
+                primaryDevSyncRootsConfig : ['/config/neo'],
+                primaryRepoSyncService    : {
+                    getDueTask() {
+                        return {
+                            taskName: PRIMARY_DEV_SYNC_TASK_NAME,
+                            reason  : 'periodic-sweep:600000'
+                        };
+                    },
+                    runTask(options) {
+                        received.push({
+                            value : options.devSyncRootsConfig,
+                            source: options.devSyncRootsSource
+                        });
+                    }
+                }
+            });
+
+            orchestrator.processSupervisorService = {
+                runTask() {}
+            };
+
+            orchestrator.poll();
+
+            process.env[DEV_SYNC_ROOTS_ENV_VAR] = '["/env/neo"]';
+            orchestrator.poll();
+
+            expect(received).toEqual([{
+                value : ['/config/neo'],
+                source: DEV_SYNC_ROOTS_CONFIG_KEY
+            }, {
+                value : '["/env/neo"]',
+                source: DEV_SYNC_ROOTS_ENV_VAR
+            }]);
+            expect(resolvePrimaryDevSyncRootsConfig({
+                envValue   : '',
+                configValue: ['/config/neo']
+            })).toEqual(['/config/neo']);
+            expect(resolvePrimaryDevSyncRootsConfig({
+                envValue   : '',
+                configValue: []
+            })).toBeNull();
+            expect(resolvePrimaryDevSyncRootsSource({envValue: ''})).toBe(DEV_SYNC_ROOTS_CONFIG_KEY);
+        } finally {
+            if (originalEnvValue === undefined) {
+                delete process.env[DEV_SYNC_ROOTS_ENV_VAR];
+            } else {
+                process.env[DEV_SYNC_ROOTS_ENV_VAR] = originalEnvValue;
+            }
+        }
     });
 
 });

--- a/test/playwright/unit/ai/daemons/services/PrimaryRepoSyncService.spec.mjs
+++ b/test/playwright/unit/ai/daemons/services/PrimaryRepoSyncService.spec.mjs
@@ -3,6 +3,7 @@ import Neo       from '../../../../../../src/Neo.mjs';
 import * as core from '../../../../../../src/core/_export.mjs';
 import PrimaryRepoSyncService, {
     buildPrimaryRepoSyncTrigger,
+    DEV_SYNC_ROOTS_CONFIG_KEY,
     DEV_SYNC_ROOTS_ENV_VAR,
     parseDevSyncRoots,
     parseEnabledFlag
@@ -106,10 +107,19 @@ test.describe('PrimaryRepoSyncService (#11017)', () => {
             status: 'configured',
             roots : ['/primary/neo', '/agent/neo']
         });
+        expect(parseDevSyncRoots(['/primary/neo', '/primary/neo', '/agent/neo'], 'orchestrator.devSyncRoots')).toEqual({
+            status: 'configured',
+            roots : ['/primary/neo', '/agent/neo']
+        });
         expect(parseDevSyncRoots('{"root":"/primary/neo"}')).toEqual({
             status    : 'invalid',
             reasonCode: 'invalid-dev-sync-roots',
             error     : `${DEV_SYNC_ROOTS_ENV_VAR} must be a JSON array of absolute paths.`
+        });
+        expect(parseDevSyncRoots(['relative/neo'], 'orchestrator.devSyncRoots')).toEqual({
+            status    : 'invalid',
+            reasonCode: 'invalid-dev-sync-roots',
+            error     : 'orchestrator.devSyncRoots entries must be absolute path strings.'
         });
         expect(parseDevSyncRoots('["relative/neo"]')).toEqual({
             status    : 'invalid',
@@ -486,6 +496,26 @@ test.describe('PrimaryRepoSyncService (#11017)', () => {
             }
         });
         expect(execStub.calls.map(call => call.args[0])).not.toContain('pull');
+    });
+
+    test('uses the local config source label for malformed configured roots', () => {
+        const result = PrimaryRepoSyncService.syncPrimaryDev({
+            cwd               : '/primary/neo',
+            execFileSyncFn    : createExecStub([]),
+            writeLog          : () => {},
+            devSyncRootsConfig: ['relative/neo'],
+            devSyncRootsSource: DEV_SYNC_ROOTS_CONFIG_KEY
+        });
+
+        expect(result).toEqual({
+            status : 'skipped',
+            details: {
+                reasonCode: 'invalid-dev-sync-roots',
+                envVar    : DEV_SYNC_ROOTS_ENV_VAR,
+                source    : DEV_SYNC_ROOTS_CONFIG_KEY,
+                error     : 'orchestrator.devSyncRoots entries must be absolute path strings.'
+            }
+        });
     });
 
     test('records skipped outcomes without marking no-op checks successful', () => {

--- a/test/playwright/unit/ai/scripts/orchestrator-daemon.spec.mjs
+++ b/test/playwright/unit/ai/scripts/orchestrator-daemon.spec.mjs
@@ -3,6 +3,8 @@ import fs from 'fs';
 import path from 'path';
 import {
     DEFAULT_KB_SYNC_INTERVAL_MS,
+    LOCAL_AI_CONFIG_FILE,
+    loadLocalAiConfig,
     DEFAULT_POLL_INTERVAL_MS,
     DEFAULT_SUMMARY_SWEEP_INTERVAL_MS
 } from '../../../../../ai/scripts/orchestrator-daemon.mjs';
@@ -57,5 +59,35 @@ test.describe('ai/scripts/orchestrator-daemon.mjs (#11006/#11009)', () => {
         expect(taskDefSource).toContain('summarize-sessions.mjs');
         expect(taskDefSource).toContain('syncKnowledgeBase.mjs');
         expect(taskDefSource).toContain('backup.mjs');
+    });
+
+    test('loads gitignored top-level AI config only when present', async () => {
+        const loadedPaths = [];
+        const aiConfig = {
+            async load(configPath) {
+                loadedPaths.push(configPath);
+            }
+        };
+
+        await expect(loadLocalAiConfig({
+            configPath: '/tmp/missing-ai-config.mjs',
+            aiConfig,
+            existsSync: () => false
+        })).resolves.toEqual({
+            loaded: false,
+            configPath: '/tmp/missing-ai-config.mjs'
+        });
+
+        await expect(loadLocalAiConfig({
+            configPath: '/tmp/local-ai-config.mjs',
+            aiConfig,
+            existsSync: () => true
+        })).resolves.toEqual({
+            loaded: true,
+            configPath: '/tmp/local-ai-config.mjs'
+        });
+
+        expect(loadedPaths).toEqual(['/tmp/local-ai-config.mjs']);
+        expect(LOCAL_AI_CONFIG_FILE).toBe(path.resolve(process.cwd(), 'ai/config.mjs'));
     });
 });


### PR DESCRIPTION
Authored by GPT-5 (Codex Desktop). Session 22713fa8-23d2-4b31-918b-6e2f48d69c06.

Resolves #11169

## Summary

This PR adds the operator-local path for orchestrator dev-sync roots without committing machine-specific clone paths:

- Adds machine-neutral `orchestrator.devSyncRoots: []` to `ai/config.template.mjs` and gitignores the local `ai/config.mjs`.
- Loads `ai/config.mjs` from `ai/scripts/orchestrator-daemon.mjs` when present, then passes configured roots into the Orchestrator class.
- Preserves precedence: `NEO_ORCHESTRATOR_DEV_SYNC_ROOTS` > `ai/config.mjs` > unset single owning-checkout behavior.
- Extends `PrimaryRepoSyncService` parsing so local config arrays share the same validation path and operator-visible skip semantics as malformed env roots.
- Documents the three-clone setup with placeholder absolute paths and keeps `npm run ai:orchestrator` as the durable command.

## Stepping-Back Check

The key pre-PR correction was preserving AC2: the template default empty array must not switch the daemon into configured-roots mode. `resolvePrimaryDevSyncRootsConfig()` now treats an empty local config array as unset, while an explicit env var still retains existing env behavior.

## Substrate Slot Rationale

Touched `learn/agentos/DeploymentCookbook.md`.

- Modified Section 6 env-var inventory row: disposition remains `keep`; 3-axis remains medium trigger-frequency x medium failure-severity x high enforceability because it is the canonical operator env inventory.
- Added `Local Orchestrator Dev-Sync Roots`: disposition `keep`; 3-axis medium trigger-frequency x medium failure-severity x high enforceability. It is operator setup guidance with concrete config shape and command anchors, not broad atlas prose.
- Decay condition: compress or move this subsection if a dedicated orchestrator setup guide or generated local-config bootstrap supersedes manual `ai/config.mjs` creation.

## Evidence

Evidence level: L2 targeted unit coverage and static diff checks for the new config, precedence, parser/source-label, and docs surfaces.

- `git diff --check`
- `git diff --cached --check`
- `git diff --check origin/dev...HEAD`
- `git check-ignore -v ai/config.mjs`
- `npm run test-unit -- test/playwright/unit/ai/config.template.spec.mjs test/playwright/unit/ai/scripts/orchestrator-daemon.spec.mjs test/playwright/unit/ai/daemons/Orchestrator.spec.mjs test/playwright/unit/ai/daemons/services/PrimaryRepoSyncService.spec.mjs`
  - 23 passed

## Post-Merge Validation

- [ ] Operator can create gitignored `ai/config.mjs` with the three local repo roots and launch `npm run ai:orchestrator`.
- [ ] A one-off `NEO_ORCHESTRATOR_DEV_SYNC_ROOTS='[...]' npm run ai:orchestrator` still overrides local config.

## Review Routing

Primary reviewer requested: @neo-gemini-3-1-pro.
