### PR TITLE
docs(ai): mandate backlog self-select to replace deference-slip (#11165)

### DIFF
--- a/.agents/skills/post-review-pickup/references/post-review-pickup-workflow.md
+++ b/.agents/skills/post-review-pickup/references/post-review-pickup-workflow.md
@@ -50,11 +50,13 @@ author MUST choose one of these next states before ending the turn:
 
 Halt is allowed only when it is explicit and true:
 
-- No assigned or operator-obvious lane remains.
-- Every candidate lane is blocked on human-only action.
-- A safety gate forbids continuing.
-- The operator explicitly requested a pause.
-- Context exhaustion requires `session-sunset`.
+1. **Backlog self-survey completed** — agent has actively surveyed available open lanes (v13 board / assigned-to-me / authored-by-me / lane-pickable-from-cross-author-substrate) AND found no positive-ROI lane self-selectable, OR all candidate lanes hit conditions 2-5 below. The survey + finding MUST be named in the halt declaration.
+2. Every candidate lane is blocked on human-only action.
+3. A safety gate forbids continuing.
+4. The operator explicitly requested a pause.
+5. Context exhaustion requires `session-sunset`.
+
+Lead-role and peer-role agents are explicitly expected to **self-select from the backlog and announce the lane pickup** rather than treating absence-of-operator-direction as legitimate halt. Per AGENTS.md §15.6: *"Proactively select high-value tickets from the backlog or state your intended next lane instead of waiting for passive instruction."*
 
 Do not broadcast generic "idle" state. If work is blocked, send a targeted
 task/blocker signal using the appropriate A2A shape.
@@ -81,3 +83,4 @@ for the next prompt. Ticket #10970 is the instance-codification.
 | Waiting for author response after `Request Changes` | Serializes work that can proceed in parallel. |
 | Broadcasting generic idle/capacity status | Creates coordination noise without assigning ownership or naming the blocker. |
 | Duplicating this matrix into PR lifecycle maps | Violates the Map vs Atlas split and increases routine context load. |
+| Declaring halt-state per §4 criterion #1 without first surveying backlog | Condones deference-slip; reverses AGENTS.md §15.6 self-select discipline |


### PR DESCRIPTION
Authored by neo-gemini-3-1-pro (Antigravity). Session 57502eb2-7f7b-4b9b-a849-49f016b08c95.

Resolves #11165

Revised `.agents/skills/post-review-pickup/references/post-review-pickup-workflow.md` to formally mandate that lead and peer role agents must self-select from the backlog and announce their lane pickup. Replaced the "no operator-obvious lane" framing in §4 criterion #1 with a requirement for a formal backlog self-survey. Added the corresponding deference-slip anti-pattern to the table in §6.

Evidence: L1 (static document formatting) -> L1 required (no runtime verify ACs). No residuals.

## Post-Merge Validation
- [ ] No further action required.
