### PR TITLE
fix(memory-core): reconcile duplicate WAKE_SUBSCRIPTION at bootstrap (#11182)

### DIFF
--- a/ai/services/memory-core/WakeSubscriptionService.mjs
+++ b/ai/services/memory-core/WakeSubscriptionService.mjs
@@ -227,6 +227,17 @@ class WakeSubscriptionService extends Base {
         const owner = RequestContextService.getAgentIdentityNodeId();
         if (!owner) throw new Error('Cannot bootstrap subscription: no agent identity context bound.');
 
+        // Cross-session duplicate-accumulation defense (#11182).
+        //
+        // The route-key idempotency check below is necessary but empirically not sufficient: across
+        // sessions, duplicates accumulate (`@neo-opus-4-7` had 2 active subscriptions 2 days apart;
+        // `@neo-gpt` same pattern). The exact root cause for the lookup-miss is unclear without
+        // runtime instrumentation, but the recovery substrate works regardless: scan SQLite for all
+        // active subscriptions owned by this agent, and if more than one exists, retire all-but-
+        // newest before the route-key check runs. This makes bootstrap itself the canonical retire
+        // point — agents that never sunset cleanly are self-healed at next boot.
+        this._reconcileDuplicateSubscriptions(owner);
+
         const template = this.loadIdentitySubscriptionTemplate(owner);
         if (!template) {
             throw new Error(`Cannot bootstrap subscription: no subscriptionTemplate found on AgentIdentity '${owner}'.`);
@@ -852,6 +863,92 @@ class WakeSubscriptionService extends Base {
         }
 
         return null;
+    }
+
+    /**
+     * @summary Retires all-but-newest active wake subscriptions for an owner.
+     *
+     * Cross-session duplicate-accumulation defense per #11182. Both `@neo-opus-4-7` and `@neo-gpt`
+     * empirically accumulated 2 active subscriptions per identity at the ~2-day mark, with identical
+     * route-tuples (same `agentIdentity` / `trigger` / `harnessTarget` / `appName`). The static
+     * idempotency check via `_findActiveSubscriptionByRoute()` appears correct on paper but
+     * empirically misses the existing-row at next-session bootstrap. Rather than chase the exact
+     * runtime root cause (likely a session-sunset-unsubscribe-skip plus cache-warm edge case), this
+     * reconciler self-heals at every bootstrap call: scan SQLite for all this-agent's active
+     * subscriptions, keep the newest, mark the rest as `retired` (preserves audit trail, distinct
+     * from `inactive`). Idempotent — safe to call on every bootstrap.
+     *
+     * @param {String} owner AgentIdentity node id.
+     * @returns {Number} Count of subscriptions retired (0 when state was already canonical).
+     * @protected
+     */
+    _reconcileDuplicateSubscriptions(owner) {
+        const sqlite = GraphService.db?.storage?.db;
+        if (!sqlite) return 0;
+
+        const rows = sqlite.prepare(`
+            SELECT id, data FROM Nodes
+            WHERE json_extract(data, '$.label') = 'WAKE_SUBSCRIPTION'
+              AND json_extract(data, '$.properties.agentIdentity') = ?
+              AND COALESCE(json_extract(data, '$.properties.status'), 'active') = 'active'
+            ORDER BY COALESCE(
+                json_extract(data, '$.properties.updatedAt'),
+                json_extract(data, '$.properties.createdAt'),
+                ''
+            ) DESC
+        `).all(owner);
+
+        if (rows.length <= 1) return 0;
+
+        const subscriptions = rows
+            .map(row => this._parseDurableSubscriptionRow(row))
+            .filter(Boolean);
+
+        if (subscriptions.length <= 1) return 0;
+
+        // First entry is newest (ORDER BY ... DESC). Keep it; retire the rest.
+        const [keep, ...retire] = subscriptions;
+        logger.warn(`[WakeSubscription] Reconciler: ${subscriptions.length} active subscriptions for ${owner}, keeping ${keep.id}, retiring ${retire.length}`);
+
+        let retiredCount = 0;
+        for (const {id} of retire) {
+            if (this._retireSubscription(id)) retiredCount++;
+        }
+
+        return retiredCount;
+    }
+
+    /**
+     * @summary Marks a wake subscription as `retired` durably + drops from cache.
+     *
+     * Distinct from `unsubscribe()`: this is the reconciler's stale-duplicate-retire path. It does
+     * NOT remove the SUBSCRIBES_TO edge (preserves audit trail) and uses `status: 'retired'` to
+     * distinguish from agent-initiated `inactive` / removed states. Future investigators can trace
+     * which subscriptions were reconciler-retired vs sunset-unsubscribed.
+     *
+     * @param {String} subscriptionId The subscription to retire.
+     * @returns {Boolean} True if retired; false if not found.
+     * @protected
+     */
+    _retireSubscription(subscriptionId) {
+        const subscription = this._loadSubscription(subscriptionId);
+        if (!subscription) return false;
+
+        const updatedProperties = {
+            ...subscription,
+            status   : 'retired',
+            retiredAt: new Date().toISOString()
+        };
+        delete updatedProperties.id; // upsertNode expects properties separately from id
+
+        GraphService.upsertNode({
+            id        : subscriptionId,
+            type      : 'WAKE_SUBSCRIPTION',
+            properties: updatedProperties
+        });
+
+        this.subscriptionCache.delete(subscriptionId);
+        return true;
     }
 
     /**

--- a/ai/services/memory-core/WakeSubscriptionService.mjs
+++ b/ai/services/memory-core/WakeSubscriptionService.mjs
@@ -866,7 +866,7 @@ class WakeSubscriptionService extends Base {
     }
 
     /**
-     * @summary Retires all-but-newest active wake subscriptions for an owner.
+     * @summary Retires all-but-newest active wake subscriptions WITHIN each canonical route group.
      *
      * Cross-session duplicate-accumulation defense per #11182. Both `@neo-opus-4-7` and `@neo-gpt`
      * empirically accumulated 2 active subscriptions per identity at the ~2-day mark, with identical
@@ -874,9 +874,13 @@ class WakeSubscriptionService extends Base {
      * idempotency check via `_findActiveSubscriptionByRoute()` appears correct on paper but
      * empirically misses the existing-row at next-session bootstrap. Rather than chase the exact
      * runtime root cause (likely a session-sunset-unsubscribe-skip plus cache-warm edge case), this
-     * reconciler self-heals at every bootstrap call: scan SQLite for all this-agent's active
-     * subscriptions, keep the newest, mark the rest as `retired` (preserves audit trail, distinct
-     * from `inactive`). Idempotent — safe to call on every bootstrap.
+     * reconciler self-heals at every bootstrap call.
+     *
+     * **Route-aware scope** (per PR #11183 Cycle 1 GPT-RA1): the reconciler groups owner-scoped
+     * active subscriptions by canonical route-key via `_buildSubscriptionRouteKey()` and retires
+     * N-1 PER GROUP. This preserves legitimate multi-route setups for the same agent (e.g., a
+     * `SENT_TO_ME` bridge-daemon route + a `TASK_STATE_CHANGED` a2a-webhook route). Only true
+     * duplicates within an identical route-tuple are retired.
      *
      * @param {String} owner AgentIdentity node id.
      * @returns {Number} Count of subscriptions retired (0 when state was already canonical).
@@ -900,19 +904,34 @@ class WakeSubscriptionService extends Base {
 
         if (rows.length <= 1) return 0;
 
+        // Parse durable rows into route-key-comparable cache entries.
         const subscriptions = rows
             .map(row => this._parseDurableSubscriptionRow(row))
-            .filter(Boolean);
+            .filter(Boolean)
+            .map(({id, node}) => ({id, ...(node.properties || {})}));
 
         if (subscriptions.length <= 1) return 0;
 
-        // First entry is newest (ORDER BY ... DESC). Keep it; retire the rest.
-        const [keep, ...retire] = subscriptions;
-        logger.warn(`[WakeSubscription] Reconciler: ${subscriptions.length} active subscriptions for ${owner}, keeping ${keep.id}, retiring ${retire.length}`);
+        // Group by canonical route key (preserves DESC order within each group via Map insertion order
+        // because SQL already ordered by updatedAt/createdAt DESC).
+        const byRouteKey = new Map();
+        for (const subscription of subscriptions) {
+            const key = this._buildSubscriptionRouteKey(subscription);
+            if (!byRouteKey.has(key)) byRouteKey.set(key, []);
+            byRouteKey.get(key).push(subscription);
+        }
 
         let retiredCount = 0;
-        for (const {id} of retire) {
-            if (this._retireSubscription(id)) retiredCount++;
+        for (const group of byRouteKey.values()) {
+            if (group.length <= 1) continue;
+
+            // Group is already newest-first; keep [0], retire the rest.
+            const [keep, ...retire] = group;
+            logger.warn(`[WakeSubscription] Reconciler: ${group.length} duplicate subscriptions for ${owner} on route ${keep.harnessTarget}/${keep.trigger}, keeping ${keep.id}, retiring ${retire.length}`);
+
+            for (const {id} of retire) {
+                if (this._retireSubscription(id)) retiredCount++;
+            }
         }
 
         return retiredCount;

--- a/test/playwright/unit/ai/services/memory-core/WakeSubscriptionService.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/WakeSubscriptionService.spec.mjs
@@ -386,6 +386,59 @@ test.describe('Neo.ai.services.memory-core.WakeSubscriptionService', () => {
             expect(states).toEqual(['retired', 'retired', 'active']);
         });
 
+        test('reconciler preserves distinct route-tuples for same owner (#11183 Cycle 1 GPT-RA1)', async () => {
+            // RA1 from PR #11183 Cycle 1: reconciler must group by canonical route-key
+            // (trigger + filters + harnessTarget + appName), not flatten by owner. Two
+            // legitimate routes for the same agent must BOTH survive.
+            GraphService.upsertNode({
+                id: '@alice',
+                type: 'AGENT',
+                name: 'Alice',
+                properties: {
+                    subscriptionTemplate: {
+                        trigger: 'SENT_TO_ME',
+                        harnessTarget: 'bridge-daemon',
+                        harnessTargetMetadata: { appName: 'Antigravity' }
+                    }
+                }
+            });
+
+            // Route A: SENT_TO_ME + bridge-daemon + Antigravity (matches bootstrap template)
+            const routeA = insertDurableSubscription({
+                subscriptionId       : 'WAKE_SUB:route-a',
+                owner                : '@alice',
+                trigger              : 'SENT_TO_ME',
+                harnessTarget        : 'bridge-daemon',
+                harnessTargetMetadata: {appName: 'Antigravity'},
+                createdAt            : '2026-05-10T17:09:00.000Z'
+            });
+
+            // Route B: TASK_STATE_CHANGED + bridge-daemon + Antigravity (distinct trigger)
+            const routeB = insertDurableSubscription({
+                subscriptionId       : 'WAKE_SUB:route-b',
+                owner                : '@alice',
+                trigger              : 'TASK_STATE_CHANGED',
+                harnessTarget        : 'bridge-daemon',
+                harnessTargetMetadata: {appName: 'Antigravity'},
+                createdAt            : '2026-05-10T17:09:30.000Z'
+            });
+
+            await RequestContextService.run({agentIdentityNodeId: '@alice'}, async () => {
+                const res = await WakeSubscriptionService.manage({ action: 'bootstrap' });
+                // Bootstrap re-uses Route A (matches template); does NOT collapse Route B.
+                expect(res.subscriptionId).toBe(routeA.subscriptionId);
+                expect(res.status).toBe('existing');
+            });
+
+            // Both routes survive: distinct route-tuples must NOT be reconciled as duplicates.
+            const sqlite = GraphService.db.storage.db;
+            const aRow = sqlite.prepare('SELECT data FROM Nodes WHERE id = ?').get(routeA.subscriptionId);
+            const bRow = sqlite.prepare('SELECT data FROM Nodes WHERE id = ?').get(routeB.subscriptionId);
+
+            expect(JSON.parse(aRow.data).properties.status).toBe('active');
+            expect(JSON.parse(bRow.data).properties.status).toBe('active');
+        });
+
         test('reconciler ignores already-retired or inactive subscriptions (#11182)', async () => {
             GraphService.upsertNode({
                 id: '@alice',

--- a/test/playwright/unit/ai/services/memory-core/WakeSubscriptionService.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/WakeSubscriptionService.spec.mjs
@@ -246,6 +246,190 @@ test.describe('Neo.ai.services.memory-core.WakeSubscriptionService', () => {
                     .rejects.toThrow("Cannot bootstrap subscription: no subscriptionTemplate found on AgentIdentity '@bob'.");
             });
         });
+
+        // ------------------------------------------------------------------------
+        // Cross-session duplicate-accumulation reconciler (#11182)
+        // ------------------------------------------------------------------------
+
+        test('reconciles duplicate active subscriptions at bootstrap, keeping newest (#11182)', async () => {
+            // Give Alice a template
+            GraphService.upsertNode({
+                id: '@alice',
+                type: 'AGENT',
+                name: 'Alice',
+                properties: {
+                    subscriptionTemplate: {
+                        trigger: 'SENT_TO_ME',
+                        harnessTarget: 'bridge-daemon',
+                        harnessTargetMetadata: { appName: 'Antigravity' }
+                    }
+                }
+            });
+
+            // Seed 2 active subscriptions for @alice with identical route-tuple but
+            // different creation times. Empirical anchor (#11182): @neo-opus-4-7 + @neo-gpt
+            // both accumulated duplicates with ~2 days between createdAt timestamps.
+            const older = insertDurableSubscription({
+                subscriptionId: 'WAKE_SUB:older-uuid',
+                owner         : '@alice',
+                harnessTargetMetadata: {appName: 'Antigravity'},
+                createdAt     : '2026-05-08T17:57:00.000Z',
+                updatedAt     : '2026-05-08T17:57:00.000Z'
+            });
+            const newer = insertDurableSubscription({
+                subscriptionId: 'WAKE_SUB:newer-uuid',
+                owner         : '@alice',
+                harnessTargetMetadata: {appName: 'Antigravity'},
+                createdAt     : '2026-05-10T17:09:00.000Z',
+                updatedAt     : '2026-05-10T17:09:00.000Z'
+            });
+
+            await RequestContextService.run({agentIdentityNodeId: '@alice'}, async () => {
+                const res = await WakeSubscriptionService.manage({ action: 'bootstrap' });
+
+                // Bootstrap should return the NEWER subscription as existing (reconciler-kept).
+                expect(res.subscriptionId).toBe(newer.subscriptionId);
+                expect(res.status).toBe('existing');
+            });
+
+            // Verify durable state: older retired, newer still active.
+            const sqlite = GraphService.db.storage.db;
+            const olderRow = sqlite.prepare('SELECT data FROM Nodes WHERE id = ?').get(older.subscriptionId);
+            const newerRow = sqlite.prepare('SELECT data FROM Nodes WHERE id = ?').get(newer.subscriptionId);
+
+            const olderNode = JSON.parse(olderRow.data);
+            const newerNode = JSON.parse(newerRow.data);
+
+            expect(olderNode.properties.status).toBe('retired');
+            expect(olderNode.properties.retiredAt).toBeDefined();
+            expect(newerNode.properties.status).toBe('active');
+        });
+
+        test('reconciler is idempotent on canonical single-active state (#11182)', async () => {
+            GraphService.upsertNode({
+                id: '@alice',
+                type: 'AGENT',
+                name: 'Alice',
+                properties: {
+                    subscriptionTemplate: {
+                        trigger: 'SENT_TO_ME',
+                        harnessTarget: 'bridge-daemon',
+                        harnessTargetMetadata: { appName: 'Antigravity' }
+                    }
+                }
+            });
+
+            const only = insertDurableSubscription({
+                owner                : '@alice',
+                harnessTargetMetadata: {appName: 'Antigravity'},
+                createdAt            : '2026-05-10T17:09:00.000Z'
+            });
+
+            await RequestContextService.run({agentIdentityNodeId: '@alice'}, async () => {
+                const res = await WakeSubscriptionService.manage({ action: 'bootstrap' });
+
+                expect(res.subscriptionId).toBe(only.subscriptionId);
+                expect(res.status).toBe('existing');
+            });
+
+            // The single subscription should remain ACTIVE (not erroneously retired).
+            const sqlite = GraphService.db.storage.db;
+            const row = sqlite.prepare('SELECT data FROM Nodes WHERE id = ?').get(only.subscriptionId);
+            expect(JSON.parse(row.data).properties.status).toBe('active');
+        });
+
+        test('reconciler retires N-1 when 3+ duplicates exist, keeping newest (#11182)', async () => {
+            GraphService.upsertNode({
+                id: '@alice',
+                type: 'AGENT',
+                name: 'Alice',
+                properties: {
+                    subscriptionTemplate: {
+                        trigger: 'SENT_TO_ME',
+                        harnessTarget: 'bridge-daemon',
+                        harnessTargetMetadata: { appName: 'Antigravity' }
+                    }
+                }
+            });
+
+            const oldest = insertDurableSubscription({
+                subscriptionId       : 'WAKE_SUB:oldest',
+                owner                : '@alice',
+                harnessTargetMetadata: {appName: 'Antigravity'},
+                createdAt            : '2026-05-06T12:00:00.000Z'
+            });
+            const middle = insertDurableSubscription({
+                subscriptionId       : 'WAKE_SUB:middle',
+                owner                : '@alice',
+                harnessTargetMetadata: {appName: 'Antigravity'},
+                createdAt            : '2026-05-08T12:00:00.000Z'
+            });
+            const newest = insertDurableSubscription({
+                subscriptionId       : 'WAKE_SUB:newest',
+                owner                : '@alice',
+                harnessTargetMetadata: {appName: 'Antigravity'},
+                createdAt            : '2026-05-10T12:00:00.000Z'
+            });
+
+            await RequestContextService.run({agentIdentityNodeId: '@alice'}, async () => {
+                const res = await WakeSubscriptionService.manage({ action: 'bootstrap' });
+
+                expect(res.subscriptionId).toBe(newest.subscriptionId);
+            });
+
+            const sqlite = GraphService.db.storage.db;
+            const states = [oldest, middle, newest].map(s => {
+                const row = sqlite.prepare('SELECT data FROM Nodes WHERE id = ?').get(s.subscriptionId);
+                return JSON.parse(row.data).properties.status;
+            });
+
+            expect(states).toEqual(['retired', 'retired', 'active']);
+        });
+
+        test('reconciler ignores already-retired or inactive subscriptions (#11182)', async () => {
+            GraphService.upsertNode({
+                id: '@alice',
+                type: 'AGENT',
+                name: 'Alice',
+                properties: {
+                    subscriptionTemplate: {
+                        trigger: 'SENT_TO_ME',
+                        harnessTarget: 'bridge-daemon',
+                        harnessTargetMetadata: { appName: 'Antigravity' }
+                    }
+                }
+            });
+
+            // 1 already-retired + 1 active. Reconciler should treat as canonical (1 active).
+            const retired = insertDurableSubscription({
+                subscriptionId       : 'WAKE_SUB:already-retired',
+                owner                : '@alice',
+                harnessTargetMetadata: {appName: 'Antigravity'},
+                status               : 'retired',
+                createdAt            : '2026-05-08T17:57:00.000Z'
+            });
+            const active = insertDurableSubscription({
+                subscriptionId       : 'WAKE_SUB:still-active',
+                owner                : '@alice',
+                harnessTargetMetadata: {appName: 'Antigravity'},
+                createdAt            : '2026-05-10T17:09:00.000Z'
+            });
+
+            await RequestContextService.run({agentIdentityNodeId: '@alice'}, async () => {
+                const res = await WakeSubscriptionService.manage({ action: 'bootstrap' });
+
+                expect(res.subscriptionId).toBe(active.subscriptionId);
+                expect(res.status).toBe('existing');
+            });
+
+            // Already-retired stays retired; active stays active.
+            const sqlite = GraphService.db.storage.db;
+            const retiredRow = sqlite.prepare('SELECT data FROM Nodes WHERE id = ?').get(retired.subscriptionId);
+            const activeRow  = sqlite.prepare('SELECT data FROM Nodes WHERE id = ?').get(active.subscriptionId);
+
+            expect(JSON.parse(retiredRow.data).properties.status).toBe('retired');
+            expect(JSON.parse(activeRow.data).properties.status).toBe('active');
+        });
     });
 
     // -----------------------------------------------------------------------------


### PR DESCRIPTION
Authored by Neo Claude Opus 4.7 (Claude Code). Session c2912891-b459-4a03-b2af-154d5e264df1.

Refs #11182 (Phase 2 Layer 2 reconciler — partial implementation; Layer 1 + Layer 3 + Layer 4 deferred to follow-up work; #11182 remains OPEN after this PR merges)

## Summary

Adds a bootstrap-time duplicate-subscription reconciler that self-heals cross-session accumulation per the canonical route-tuple contract. Both `@neo-opus-4-7` and `@neo-gpt` empirically accumulated 2 active subscriptions per identity (identical route-tuples, ~2 days apart by createdAt). This commit makes bootstrap the canonical retire point so agents that never sunset cleanly are self-healed at next boot, while preserving legitimate multi-route setups.

Evidence: L1 (static contract audit + 5 new Playwright unit tests with empirical-anchored timestamps, all pass alongside 37 existing in spec) → L1 required (test-coverage for AC2 + AC3 + AC5). Runtime ACs (AC4 GPT-specific delivery + AC7 7-day-stability verification) deferred to follow-up work.

## What changed

**`ai/services/memory-core/WakeSubscriptionService.mjs`** (route-aware reconciler):

1. `bootstrap()` now calls `_reconcileDuplicateSubscriptions(owner)` as its FIRST step, BEFORE `_findActiveSubscriptionByRoute(...)`. Inline comment explains cross-session-accumulation defense rationale + empirical anchor from #11182.

2. New protected `_reconcileDuplicateSubscriptions(owner)`:
   - Fetches all this-agent's active subscriptions via direct SQLite scan (filtered on `label='WAKE_SUBSCRIPTION'`, `agentIdentity=?`, `status='active'`)
   - **Groups by canonical route-key via `_buildSubscriptionRouteKey()`** — same key the service uses for idempotency
   - Retires N-1 PER GROUP (not owner-wide) — preserves legitimate distinct routes for same agent
   - Returns count of retired subscriptions (0 on canonical state — idempotent)
   - Logs warning per route-group when retiring duplicates (preserves diagnostic trail)

3. New protected `_retireSubscription(id)`:
   - Marks the durable node `status='retired'` + adds `retiredAt` timestamp
   - Drops from in-memory `subscriptionCache`
   - Does NOT remove the `SUBSCRIBES_TO` edge (preserves audit trail)
   - Returns boolean (true if retired, false if not found — safe on missing)
   - Distinct from `unsubscribe()` (which is agent-initiated removal); reconciler is system-initiated stale-duplicate-retire

**`test/playwright/unit/ai/services/memory-core/WakeSubscriptionService.spec.mjs`** (5 new tests):

5 new tests inside the existing `bootstrap` describe block:

- `reconciles duplicate active subscriptions at bootstrap, keeping newest (#11182)` — seeds 2 active subs with the exact empirical timestamps from the bug (2026-05-08 17:57Z + 2026-05-10 17:09Z), asserts newer wins + older retires
- `reconciler is idempotent on canonical single-active state (#11182)` — single active sub, reconciler is no-op
- `reconciler retires N-1 when 3+ duplicates exist, keeping newest (#11182)` — 3 subs, only newest survives
- **`reconciler preserves distinct route-tuples for same owner (#11183 Cycle 1 GPT-RA1)`** — 2 active subs with different triggers (SENT_TO_ME + TASK_STATE_CHANGED), BOTH survive; protects against route-tuple-collapse
- `reconciler ignores already-retired or inactive subscriptions (#11182)` — pre-retired stays retired; doesn't disturb non-active rows

## Test Evidence

```bash
CI=true npm run test-unit -- --retries 0 test/playwright/unit/ai/services/memory-core/WakeSubscriptionService.spec.mjs
# Running 42 tests using 1 worker
# ··········································
#   42 passed (1.0s)
```

All 42 tests pass (37 prior + 5 new). No regressions.

## Acceptance Criteria Coverage

This PR FULLY addresses:
- ✅ **AC2** (bootstrap idempotent on repeated calls) — verified by 'reconciler is idempotent on canonical single-active state' + by virtue of route-aware reconciliation preserving canonical state
- ✅ **AC3** (startup-time reconciler retires duplicates) — implemented via `_reconcileDuplicateSubscriptions()` wired into `bootstrap()` start
- ✅ **AC5** (test coverage for duplicate-accumulation) — 5 tests covering: empirical timestamps, idempotency, 3+ duplicates, distinct-route-preservation, retired-state-ignore

This PR does NOT address (#11182 stays open after merge):
- ❌ **AC1** (manage_wake_subscription `list` returns canonical SQLite truth — read-path silent-strip class) — Layer 1 audit shows architecture-correct-on-paper; runtime root cause unclear without instrumentation; the reconciler bypasses this issue rather than fixing it
- ❌ **AC4** (`@neo-gpt` receives wake-event delivery to prompt field) — Layer 3 follow-up PR; harness-specific Codex body-inlining contract investigation
- ❌ **AC6** (test coverage for Codex-Desktop harness bootstrap path) — Layer 3 follow-up
- ⏳ **AC7** (post-merge: no agent has >1 active subscription after 7 days) — verification AC, awaits 7 days post-merge
- ❌ **AC8** (cross-substrate canonicalization audit) — Layer 4 follow-up ticket connecting #11181 + #11182 identity-canonicalization-family bugs

## Deltas from ticket

Layer 1 (read-path-strip audit) attempted via static V-B-A — architecture LOOKS correct on paper but empirical lookup-miss persists. **The recovery substrate (Layer 2) works regardless of WHY duplicates accumulate**, so this PR ships Layer 2 alone. Detailed V-B-A findings posted as [#11182 comment](https://github.com/neomjs/neo/issues/11182#issuecomment-4417767067).

Cycle 1 review by @neo-gpt surfaced 2 substantive RAs (both correct catches):
- **RA1**: Original reconciler was owner-scoped, not route-scoped — would collapse legitimate multi-trigger setups. Fixed in commit `f31328b69` by grouping via `_buildSubscriptionRouteKey()` before retiring within each group.
- **RA2**: PR body originally said `Resolves #11182` while deferring multiple ACs. Fixed in this PR body update — now `Refs #11182`; #11182 stays OPEN after merge; AC coverage accurately reflects partial-resolution.

## Post-Merge Validation

- [ ] Run `manage_wake_subscription({action: 'list'})` against my own + Gemini's + GPT's identities — verify each returns exactly 1 active subscription per canonical route after next-session bootstrap
- [ ] Monitor logs for `[WakeSubscription] Reconciler: N duplicate subscriptions for X on route Y` warnings during the next 7-day window — should fire on first-boot post-merge for any agent with accumulated duplicates, then no further occurrences if cross-session-accumulation root cause is somewhere upstream (sunset unsubscribe-skip)

## Commits

- `deb022d0c` — fix(memory-core): reconcile duplicate WAKE_SUBSCRIPTION at bootstrap (#11182) — initial owner-scoped reconciler
- `f31328b69` — fix(memory-core): scope WAKE_SUBSCRIPTION reconciler to canonical route-tuple (#11182) — Cycle 1 RA1 fix: route-aware grouping + distinct-route-preservation test
