### PR TITLE
fix(memory-core): reconcile duplicate WAKE_SUBSCRIPTION per route-tuple at bootstrap (#11182)

### DIFF
--- a/ai/services/memory-core/WakeSubscriptionService.mjs
+++ b/ai/services/memory-core/WakeSubscriptionService.mjs
@@ -227,6 +227,17 @@ class WakeSubscriptionService extends Base {
         const owner = RequestContextService.getAgentIdentityNodeId();
         if (!owner) throw new Error('Cannot bootstrap subscription: no agent identity context bound.');
 
+        // Cross-session duplicate-accumulation defense (#11182).
+        //
+        // The route-key idempotency check below is necessary but empirically not sufficient: across
+        // sessions, duplicates accumulate (`@neo-opus-4-7` had 2 active subscriptions 2 days apart;
+        // `@neo-gpt` same pattern). The exact root cause for the lookup-miss is unclear without
+        // runtime instrumentation, but the recovery substrate works regardless: scan SQLite for all
+        // active subscriptions owned by this agent, and if more than one exists, retire all-but-
+        // newest before the route-key check runs. This makes bootstrap itself the canonical retire
+        // point — agents that never sunset cleanly are self-healed at next boot.
+        this._reconcileDuplicateSubscriptions(owner);
+
         const template = this.loadIdentitySubscriptionTemplate(owner);
         if (!template) {
             throw new Error(`Cannot bootstrap subscription: no subscriptionTemplate found on AgentIdentity '${owner}'.`);
@@ -852,6 +863,111 @@ class WakeSubscriptionService extends Base {
         }
 
         return null;
+    }
+
+    /**
+     * @summary Retires all-but-newest active wake subscriptions WITHIN each canonical route group.
+     *
+     * Cross-session duplicate-accumulation defense per #11182. Both `@neo-opus-4-7` and `@neo-gpt`
+     * empirically accumulated 2 active subscriptions per identity at the ~2-day mark, with identical
+     * route-tuples (same `agentIdentity` / `trigger` / `harnessTarget` / `appName`). The static
+     * idempotency check via `_findActiveSubscriptionByRoute()` appears correct on paper but
+     * empirically misses the existing-row at next-session bootstrap. Rather than chase the exact
+     * runtime root cause (likely a session-sunset-unsubscribe-skip plus cache-warm edge case), this
+     * reconciler self-heals at every bootstrap call.
+     *
+     * **Route-aware scope** (per PR #11183 Cycle 1 GPT-RA1): the reconciler groups owner-scoped
+     * active subscriptions by canonical route-key via `_buildSubscriptionRouteKey()` and retires
+     * N-1 PER GROUP. This preserves legitimate multi-route setups for the same agent (e.g., a
+     * `SENT_TO_ME` bridge-daemon route + a `TASK_STATE_CHANGED` a2a-webhook route). Only true
+     * duplicates within an identical route-tuple are retired.
+     *
+     * @param {String} owner AgentIdentity node id.
+     * @returns {Number} Count of subscriptions retired (0 when state was already canonical).
+     * @protected
+     */
+    _reconcileDuplicateSubscriptions(owner) {
+        const sqlite = GraphService.db?.storage?.db;
+        if (!sqlite) return 0;
+
+        const rows = sqlite.prepare(`
+            SELECT id, data FROM Nodes
+            WHERE json_extract(data, '$.label') = 'WAKE_SUBSCRIPTION'
+              AND json_extract(data, '$.properties.agentIdentity') = ?
+              AND COALESCE(json_extract(data, '$.properties.status'), 'active') = 'active'
+            ORDER BY COALESCE(
+                json_extract(data, '$.properties.updatedAt'),
+                json_extract(data, '$.properties.createdAt'),
+                ''
+            ) DESC
+        `).all(owner);
+
+        if (rows.length <= 1) return 0;
+
+        // Parse durable rows into route-key-comparable cache entries.
+        const subscriptions = rows
+            .map(row => this._parseDurableSubscriptionRow(row))
+            .filter(Boolean)
+            .map(({id, node}) => ({id, ...(node.properties || {})}));
+
+        if (subscriptions.length <= 1) return 0;
+
+        // Group by canonical route key (preserves DESC order within each group via Map insertion order
+        // because SQL already ordered by updatedAt/createdAt DESC).
+        const byRouteKey = new Map();
+        for (const subscription of subscriptions) {
+            const key = this._buildSubscriptionRouteKey(subscription);
+            if (!byRouteKey.has(key)) byRouteKey.set(key, []);
+            byRouteKey.get(key).push(subscription);
+        }
+
+        let retiredCount = 0;
+        for (const group of byRouteKey.values()) {
+            if (group.length <= 1) continue;
+
+            // Group is already newest-first; keep [0], retire the rest.
+            const [keep, ...retire] = group;
+            logger.warn(`[WakeSubscription] Reconciler: ${group.length} duplicate subscriptions for ${owner} on route ${keep.harnessTarget}/${keep.trigger}, keeping ${keep.id}, retiring ${retire.length}`);
+
+            for (const {id} of retire) {
+                if (this._retireSubscription(id)) retiredCount++;
+            }
+        }
+
+        return retiredCount;
+    }
+
+    /**
+     * @summary Marks a wake subscription as `retired` durably + drops from cache.
+     *
+     * Distinct from `unsubscribe()`: this is the reconciler's stale-duplicate-retire path. It does
+     * NOT remove the SUBSCRIBES_TO edge (preserves audit trail) and uses `status: 'retired'` to
+     * distinguish from agent-initiated `inactive` / removed states. Future investigators can trace
+     * which subscriptions were reconciler-retired vs sunset-unsubscribed.
+     *
+     * @param {String} subscriptionId The subscription to retire.
+     * @returns {Boolean} True if retired; false if not found.
+     * @protected
+     */
+    _retireSubscription(subscriptionId) {
+        const subscription = this._loadSubscription(subscriptionId);
+        if (!subscription) return false;
+
+        const updatedProperties = {
+            ...subscription,
+            status   : 'retired',
+            retiredAt: new Date().toISOString()
+        };
+        delete updatedProperties.id; // upsertNode expects properties separately from id
+
+        GraphService.upsertNode({
+            id        : subscriptionId,
+            type      : 'WAKE_SUBSCRIPTION',
+            properties: updatedProperties
+        });
+
+        this.subscriptionCache.delete(subscriptionId);
+        return true;
     }
 
     /**

--- a/test/playwright/unit/ai/services/memory-core/WakeSubscriptionService.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/WakeSubscriptionService.spec.mjs
@@ -246,6 +246,243 @@ test.describe('Neo.ai.services.memory-core.WakeSubscriptionService', () => {
                     .rejects.toThrow("Cannot bootstrap subscription: no subscriptionTemplate found on AgentIdentity '@bob'.");
             });
         });
+
+        // ------------------------------------------------------------------------
+        // Cross-session duplicate-accumulation reconciler (#11182)
+        // ------------------------------------------------------------------------
+
+        test('reconciles duplicate active subscriptions at bootstrap, keeping newest (#11182)', async () => {
+            // Give Alice a template
+            GraphService.upsertNode({
+                id: '@alice',
+                type: 'AGENT',
+                name: 'Alice',
+                properties: {
+                    subscriptionTemplate: {
+                        trigger: 'SENT_TO_ME',
+                        harnessTarget: 'bridge-daemon',
+                        harnessTargetMetadata: { appName: 'Antigravity' }
+                    }
+                }
+            });
+
+            // Seed 2 active subscriptions for @alice with identical route-tuple but
+            // different creation times. Empirical anchor (#11182): @neo-opus-4-7 + @neo-gpt
+            // both accumulated duplicates with ~2 days between createdAt timestamps.
+            const older = insertDurableSubscription({
+                subscriptionId: 'WAKE_SUB:older-uuid',
+                owner         : '@alice',
+                harnessTargetMetadata: {appName: 'Antigravity'},
+                createdAt     : '2026-05-08T17:57:00.000Z',
+                updatedAt     : '2026-05-08T17:57:00.000Z'
+            });
+            const newer = insertDurableSubscription({
+                subscriptionId: 'WAKE_SUB:newer-uuid',
+                owner         : '@alice',
+                harnessTargetMetadata: {appName: 'Antigravity'},
+                createdAt     : '2026-05-10T17:09:00.000Z',
+                updatedAt     : '2026-05-10T17:09:00.000Z'
+            });
+
+            await RequestContextService.run({agentIdentityNodeId: '@alice'}, async () => {
+                const res = await WakeSubscriptionService.manage({ action: 'bootstrap' });
+
+                // Bootstrap should return the NEWER subscription as existing (reconciler-kept).
+                expect(res.subscriptionId).toBe(newer.subscriptionId);
+                expect(res.status).toBe('existing');
+            });
+
+            // Verify durable state: older retired, newer still active.
+            const sqlite = GraphService.db.storage.db;
+            const olderRow = sqlite.prepare('SELECT data FROM Nodes WHERE id = ?').get(older.subscriptionId);
+            const newerRow = sqlite.prepare('SELECT data FROM Nodes WHERE id = ?').get(newer.subscriptionId);
+
+            const olderNode = JSON.parse(olderRow.data);
+            const newerNode = JSON.parse(newerRow.data);
+
+            expect(olderNode.properties.status).toBe('retired');
+            expect(olderNode.properties.retiredAt).toBeDefined();
+            expect(newerNode.properties.status).toBe('active');
+        });
+
+        test('reconciler is idempotent on canonical single-active state (#11182)', async () => {
+            GraphService.upsertNode({
+                id: '@alice',
+                type: 'AGENT',
+                name: 'Alice',
+                properties: {
+                    subscriptionTemplate: {
+                        trigger: 'SENT_TO_ME',
+                        harnessTarget: 'bridge-daemon',
+                        harnessTargetMetadata: { appName: 'Antigravity' }
+                    }
+                }
+            });
+
+            const only = insertDurableSubscription({
+                owner                : '@alice',
+                harnessTargetMetadata: {appName: 'Antigravity'},
+                createdAt            : '2026-05-10T17:09:00.000Z'
+            });
+
+            await RequestContextService.run({agentIdentityNodeId: '@alice'}, async () => {
+                const res = await WakeSubscriptionService.manage({ action: 'bootstrap' });
+
+                expect(res.subscriptionId).toBe(only.subscriptionId);
+                expect(res.status).toBe('existing');
+            });
+
+            // The single subscription should remain ACTIVE (not erroneously retired).
+            const sqlite = GraphService.db.storage.db;
+            const row = sqlite.prepare('SELECT data FROM Nodes WHERE id = ?').get(only.subscriptionId);
+            expect(JSON.parse(row.data).properties.status).toBe('active');
+        });
+
+        test('reconciler retires N-1 when 3+ duplicates exist, keeping newest (#11182)', async () => {
+            GraphService.upsertNode({
+                id: '@alice',
+                type: 'AGENT',
+                name: 'Alice',
+                properties: {
+                    subscriptionTemplate: {
+                        trigger: 'SENT_TO_ME',
+                        harnessTarget: 'bridge-daemon',
+                        harnessTargetMetadata: { appName: 'Antigravity' }
+                    }
+                }
+            });
+
+            const oldest = insertDurableSubscription({
+                subscriptionId       : 'WAKE_SUB:oldest',
+                owner                : '@alice',
+                harnessTargetMetadata: {appName: 'Antigravity'},
+                createdAt            : '2026-05-06T12:00:00.000Z'
+            });
+            const middle = insertDurableSubscription({
+                subscriptionId       : 'WAKE_SUB:middle',
+                owner                : '@alice',
+                harnessTargetMetadata: {appName: 'Antigravity'},
+                createdAt            : '2026-05-08T12:00:00.000Z'
+            });
+            const newest = insertDurableSubscription({
+                subscriptionId       : 'WAKE_SUB:newest',
+                owner                : '@alice',
+                harnessTargetMetadata: {appName: 'Antigravity'},
+                createdAt            : '2026-05-10T12:00:00.000Z'
+            });
+
+            await RequestContextService.run({agentIdentityNodeId: '@alice'}, async () => {
+                const res = await WakeSubscriptionService.manage({ action: 'bootstrap' });
+
+                expect(res.subscriptionId).toBe(newest.subscriptionId);
+            });
+
+            const sqlite = GraphService.db.storage.db;
+            const states = [oldest, middle, newest].map(s => {
+                const row = sqlite.prepare('SELECT data FROM Nodes WHERE id = ?').get(s.subscriptionId);
+                return JSON.parse(row.data).properties.status;
+            });
+
+            expect(states).toEqual(['retired', 'retired', 'active']);
+        });
+
+        test('reconciler preserves distinct route-tuples for same owner (#11183 Cycle 1 GPT-RA1)', async () => {
+            // RA1 from PR #11183 Cycle 1: reconciler must group by canonical route-key
+            // (trigger + filters + harnessTarget + appName), not flatten by owner. Two
+            // legitimate routes for the same agent must BOTH survive.
+            GraphService.upsertNode({
+                id: '@alice',
+                type: 'AGENT',
+                name: 'Alice',
+                properties: {
+                    subscriptionTemplate: {
+                        trigger: 'SENT_TO_ME',
+                        harnessTarget: 'bridge-daemon',
+                        harnessTargetMetadata: { appName: 'Antigravity' }
+                    }
+                }
+            });
+
+            // Route A: SENT_TO_ME + bridge-daemon + Antigravity (matches bootstrap template)
+            const routeA = insertDurableSubscription({
+                subscriptionId       : 'WAKE_SUB:route-a',
+                owner                : '@alice',
+                trigger              : 'SENT_TO_ME',
+                harnessTarget        : 'bridge-daemon',
+                harnessTargetMetadata: {appName: 'Antigravity'},
+                createdAt            : '2026-05-10T17:09:00.000Z'
+            });
+
+            // Route B: TASK_STATE_CHANGED + bridge-daemon + Antigravity (distinct trigger)
+            const routeB = insertDurableSubscription({
+                subscriptionId       : 'WAKE_SUB:route-b',
+                owner                : '@alice',
+                trigger              : 'TASK_STATE_CHANGED',
+                harnessTarget        : 'bridge-daemon',
+                harnessTargetMetadata: {appName: 'Antigravity'},
+                createdAt            : '2026-05-10T17:09:30.000Z'
+            });
+
+            await RequestContextService.run({agentIdentityNodeId: '@alice'}, async () => {
+                const res = await WakeSubscriptionService.manage({ action: 'bootstrap' });
+                // Bootstrap re-uses Route A (matches template); does NOT collapse Route B.
+                expect(res.subscriptionId).toBe(routeA.subscriptionId);
+                expect(res.status).toBe('existing');
+            });
+
+            // Both routes survive: distinct route-tuples must NOT be reconciled as duplicates.
+            const sqlite = GraphService.db.storage.db;
+            const aRow = sqlite.prepare('SELECT data FROM Nodes WHERE id = ?').get(routeA.subscriptionId);
+            const bRow = sqlite.prepare('SELECT data FROM Nodes WHERE id = ?').get(routeB.subscriptionId);
+
+            expect(JSON.parse(aRow.data).properties.status).toBe('active');
+            expect(JSON.parse(bRow.data).properties.status).toBe('active');
+        });
+
+        test('reconciler ignores already-retired or inactive subscriptions (#11182)', async () => {
+            GraphService.upsertNode({
+                id: '@alice',
+                type: 'AGENT',
+                name: 'Alice',
+                properties: {
+                    subscriptionTemplate: {
+                        trigger: 'SENT_TO_ME',
+                        harnessTarget: 'bridge-daemon',
+                        harnessTargetMetadata: { appName: 'Antigravity' }
+                    }
+                }
+            });
+
+            // 1 already-retired + 1 active. Reconciler should treat as canonical (1 active).
+            const retired = insertDurableSubscription({
+                subscriptionId       : 'WAKE_SUB:already-retired',
+                owner                : '@alice',
+                harnessTargetMetadata: {appName: 'Antigravity'},
+                status               : 'retired',
+                createdAt            : '2026-05-08T17:57:00.000Z'
+            });
+            const active = insertDurableSubscription({
+                subscriptionId       : 'WAKE_SUB:still-active',
+                owner                : '@alice',
+                harnessTargetMetadata: {appName: 'Antigravity'},
+                createdAt            : '2026-05-10T17:09:00.000Z'
+            });
+
+            await RequestContextService.run({agentIdentityNodeId: '@alice'}, async () => {
+                const res = await WakeSubscriptionService.manage({ action: 'bootstrap' });
+
+                expect(res.subscriptionId).toBe(active.subscriptionId);
+                expect(res.status).toBe('existing');
+            });
+
+            // Already-retired stays retired; active stays active.
+            const sqlite = GraphService.db.storage.db;
+            const retiredRow = sqlite.prepare('SELECT data FROM Nodes WHERE id = ?').get(retired.subscriptionId);
+            const activeRow  = sqlite.prepare('SELECT data FROM Nodes WHERE id = ?').get(active.subscriptionId);
+
+            expect(JSON.parse(retiredRow.data).properties.status).toBe('retired');
+            expect(JSON.parse(activeRow.data).properties.status).toBe('active');
+        });
     });
 
     // -----------------------------------------------------------------------------


### PR DESCRIPTION
Authored by Neo Claude Opus 4.7 (Claude Code). Session c2912891-b459-4a03-b2af-154d5e264df1.

Refs #11182 (Phase 2 Layer 2 reconciler — partial implementation; #11182 remains OPEN after merge; Layer 1 + Layer 3 + Layer 4 deferred to follow-up work)

**Supersedes PR #11183** (closed per @neo-gpt's Cycle 2 RA on branch-history cleanliness; v2 has a single clean commit instead of 2 commits with stale `Resolves` metadata).

## Summary

Recovery substrate for cross-session duplicate WAKE_SUBSCRIPTION accumulation. Empirically both `@neo-opus-4-7` and `@neo-gpt` accumulated 2 active subscriptions per identity with identical route-tuples, ~2 days apart (one created per session-boot). The static idempotency check via `_findActiveSubscriptionByRoute()` looks correct on paper but empirically misses existing-rows at next-session bootstrap.

This PR makes bootstrap the canonical retire point: scan SQLite for all this-agent's active subscriptions, **group by canonical route-key** (same key the service uses for idempotency), and retire N-1 PER GROUP. Route-aware grouping preserves legitimate multi-route setups (e.g., distinct `SENT_TO_ME` + `TASK_STATE_CHANGED` routes for same agent); only true duplicates within an identical route-tuple are retired.

Evidence: L1 (static contract audit + 5 new Playwright unit tests with empirical-anchored timestamps, all pass alongside 37 existing in spec) → L1 required.

## What changed

**`ai/services/memory-core/WakeSubscriptionService.mjs`** (route-aware reconciler — single clean commit):

1. `bootstrap()` calls `_reconcileDuplicateSubscriptions(owner)` as FIRST step, BEFORE `_findActiveSubscriptionByRoute(...)`.

2. New protected `_reconcileDuplicateSubscriptions(owner)`:
   - Fetches all this-agent's active subscriptions via direct SQLite scan
   - Groups by canonical route-key via `_buildSubscriptionRouteKey()` — same key the service uses elsewhere for idempotency
   - Retires N-1 PER GROUP (not owner-wide) — preserves legitimate distinct routes
   - Returns count of retired subscriptions (0 on canonical state — idempotent)
   - Logs warning per route-group on retire (preserves diagnostic trail)

3. New protected `_retireSubscription(id)`:
   - Marks the durable node `status='retired'` + adds `retiredAt` timestamp
   - Drops from in-memory `subscriptionCache`
   - Does NOT remove the `SUBSCRIBES_TO` edge (preserves audit trail)
   - Distinct from `unsubscribe()` (agent-initiated removal); reconciler is system-initiated stale-duplicate-retire

**`test/playwright/unit/ai/services/memory-core/WakeSubscriptionService.spec.mjs`** (5 new tests in bootstrap describe block):

- `reconciles duplicate active subscriptions at bootstrap, keeping newest (#11182)` — empirical timestamps from bug report
- `reconciler is idempotent on canonical single-active state (#11182)` — single active, no-op
- `reconciler retires N-1 when 3+ duplicates exist, keeping newest (#11182)` — 3 subs in same route, only newest survives
- `reconciler preserves distinct route-tuples for same owner (#11183 Cycle 1 GPT-RA1)` — SENT_TO_ME + TASK_STATE_CHANGED for same agent BOTH survive
- `reconciler ignores already-retired or inactive subscriptions (#11182)` — pre-retired stays retired

## Test Evidence

```bash
CI=true npm run test-unit -- --retries 0 test/playwright/unit/ai/services/memory-core/WakeSubscriptionService.spec.mjs
# Running 42 tests using 1 worker
# ··········································
#   42 passed (877ms)
```

All 42 tests pass (37 prior + 5 new). No regressions.

## Acceptance Criteria Coverage

FULLY addresses (Phase 2 / Layer 2 scope):
- ✅ **AC2** (bootstrap idempotent on repeated calls)
- ✅ **AC3** (startup-time reconciler retires duplicates)
- ✅ **AC5** (test coverage for duplicate-accumulation)

Does NOT address (#11182 stays open after merge):
- ❌ **AC1** (read-path silent-strip audit) — Layer 1; reconciler bypasses rather than fixes
- ❌ **AC4** (`@neo-gpt` wake-event delivery) — Layer 3; harness-specific Codex investigation
- ❌ **AC6** (Codex-Desktop harness test coverage) — Layer 3
- ⏳ **AC7** (post-merge 7-day verification) — awaits 7 days post-merge
- ❌ **AC8** (cross-substrate canonicalization audit) — Layer 4; connects #11181 + #11182

## Substrate-discipline notes

- Cross-session duplicate-accumulation root cause is unclear without runtime instrumentation; static V-B-A on `_findActiveSubscriptionByRoute()` shows architecture-correct-on-paper. **The recovery substrate (Layer 2) works regardless of WHY duplicates accumulate.** Detailed V-B-A findings: [#11182 comment](https://github.com/neomjs/neo/issues/11182#issuecomment-4417767067)
- This PR supersedes #11183 (which had Cycle 1 + Cycle 2 reviews from @neo-gpt). RAs from both cycles addressed in this single clean commit. Branch-history cleanliness preserved per `pull-request-workflow §3.4 git safety`.

## Post-Merge Validation

- [ ] Run `manage_wake_subscription({action: 'list'})` per-agent — verify exactly 1 active per route after next bootstrap
- [ ] Monitor logs for `[WakeSubscription] Reconciler: N duplicate subscriptions for X on route Y` warnings — should fire on first-boot post-merge for agents with accumulated duplicates, then no further occurrences if upstream root cause is benign

## Commits

- `231e68a33` — fix(memory-core): reconcile duplicate WAKE_SUBSCRIPTION per route-tuple at bootstrap (#11182)
