### PR TITLE
docs(ai): detect stale close keywords in commit bodies (#11185)

### DIFF
--- a/.agents/skills/pr-review/references/pr-review-guide.md
+++ b/.agents/skills/pr-review/references/pr-review-guide.md
@@ -106,6 +106,8 @@ When challenging a specific architectural pattern or complex implementation deta
 
 When reviewing a PR, audit every issue named as a close-target via GitHub's magic keywords (`Closes #N`, `Resolves #N`, `Fixes #N` — case-insensitive, in the PR body or commit messages) against the target issue's labels AND syntax validity.
 
+**Squash-merge commit-body hazard (#11185):** branch commit bodies are merge-time close-target surfaces. GitHub's squash merge can concatenate commit bodies into the default-branch commit; a stale `Resolves #N` inside any branch commit body can auto-close `#N` even when the PR body has been corrected to `Refs #N` and `gh pr view --json closingIssuesReferences` returns `[]`. Empirical anchor: PR #11183 squash-merged as `5c7c5a2f4`, whose concatenated body preserved stale `Resolves #11182` from commit `deb022d0c` and auto-closed #11182.
+
 **Rule 1: Validity (Epics are not valid close-targets)**
 Epics represent a body of work delivered across multiple sub-issues; closing an epic is a *project-management* event that fires when the last sub closes (or when the epic is explicitly retired with rationale). PRs deliver subs, not epics. GitHub's auto-close-on-merge semantics fire indiscriminately on any magic-keyword reference, so the discipline-layer enforcement is the reviewer's job.
 
@@ -114,19 +116,23 @@ Author-side discipline (`pull-request §2`) mandates strict newline-isolated PR 
 
 **Reviewer-side check:**
 
-1. Parse the PR body + commit messages for `Closes #N` / `Resolves #N` / `Fixes #N` patterns (case-insensitive).
+1. Parse the PR body + commit messages for `Closes #N` / `Resolves #N` / `Fixes #N` patterns (case-insensitive). For local checkout reviews, use `git log origin/dev..HEAD --format='%h%x09%s%n%b'` or an equivalent exact-head commit-message fetch; do not rely on PR body or `closingIssuesReferences` alone.
 2. **Syntax Check:** If the keyword is embedded in prose (e.g., "This PR closes #123 by adding...") or uses a comma-separated list (e.g., "Resolves #123, #124"), flag as **Required Action**:
    > *"PR uses prose-embedded or comma-separated close targets. Required: apply the Syntax-Exact Keyword Mandate by isolating each `Resolves #N` declaration on its own independent line."*
 3. **Validity Check:** For each `#N`, fetch the issue's labels (via the appropriate `github-workflow` MCP tool).
 4. If the issue carries the `epic` label → flag as **Required Action**:
 
    > *"PR names epic #N as close-target via `Closes`/`Resolves`/`Fixes` keyword. Epics close when their last sub-issue closes, not on PR-merge. Required: change close-target to a specific sub-issue this PR resolves, or remove the magic-close keyword and reference the epic via `Related: #N` instead."*
+5. **Partial-resolution / stale commit-body check:** If the PR body uses `Refs #N` / `Related: #N` because `#N` must remain open, but any branch commit body still contains `Closes #N`, `Fixes #N`, or `Resolves #N`, flag as **Required Action**:
+
+   > *"PR is a partial-resolution PR for #N, but branch commit history still contains a magic-close keyword for #N. Required: use a clean superseding branch/PR, or obtain operator-explicit authorization for amend/rebase/force-push cleanup. Do not approve while stale branch commit bodies can survive squash merge and auto-close the issue."*
 
 **Author response options** when these Required Actions fire:
 - **Syntax:** Isolate the keyword to a separate line per ticket.
 - **Validity:** Change `Closes #N` → `Closes #M` where `#M` is the specific sub-issue the PR resolves.
 - **Validity:** Remove the close-target entirely if the PR is an incremental contribution toward the epic without fully closing any single issue.
 - **Validity:** Move the epic reference to `Related: #N` (no magic-close behavior).
+- **Partial-resolution stale commit body:** Prefer Drop+Supersede / clean branch when no operator authorization exists for history rewrite. If preserving the PR is preferred, get operator-explicit authorization before amend/rebase/force-push cleanup.
 
 **Empirical anchor:** Epic #9999 ("Cloud-Native Knowledge & Multi-Tenant Memory Core") was auto-closed at 2026-04-23T23:54:09Z with `stateReason: COMPLETED` despite 7 of 10 sub-issues still being open. Most likely mechanism: a merged PR named `Closes #9999` triggering GitHub's auto-close-on-merge. The damage was compounded by `prevent-reopen.yml` (since disabled) re-closing the manual reopen 6 seconds later, plus a sabotage-spawn duplicate ticket (#10323, since closed). The discipline-layer audit codified here would have caught the close-target at review time, before merge — preventing the entire downstream chain.
 

--- a/.agents/skills/pull-request/references/pull-request-workflow.md
+++ b/.agents/skills/pull-request/references/pull-request-workflow.md
@@ -266,6 +266,15 @@ You are strictly FORBIDDEN from embedding the closing keyword in a conversationa
 `Resolves #X`
 `Resolves #Y`
 
+**Partial-resolution branch-history check (#11185):**
+If the ticket must remain open and your PR body uses `Refs #N`, `Related: #N`, or another non-closing reference, the entire branch history must agree. Before handoff, run:
+
+```bash
+git log origin/dev..HEAD --format='%h%x09%s%n%b'
+```
+
+If any branch commit body still contains `Closes #N`, `Fixes #N`, or `Resolves #N`, do not open or hand off the PR as merge-ready. GitHub squash-merge can concatenate branch commit bodies into the default-branch commit; stale magic-close text can auto-close `#N` even when the PR body says `Refs` and `closingIssuesReferences` is empty. Clean-path resolution is a fresh superseding branch/PR; preserving the same PR requires operator-explicit authorization before amend/rebase/force-push cleanup. Empirical anchor: PR #11183 squash-merged as `5c7c5a2f4`, preserving stale `Resolves #11182` from branch commit `deb022d0c` and auto-closing #11182.
+
 **Minimum-viable PR body structure:**
 ```markdown
 Resolves #N


### PR DESCRIPTION
Authored by GPT-5 (Codex Desktop). Session 22713fa8-23d2-4b31-918b-6e2f48d69c06.

Resolves #11185

Adds the stale commit-body magic-close tripwire to the existing PR-review and pull-request workflow payloads. The change captures the PR #11183 / merge commit `5c7c5a2f4` / #11182 reopen lesson: squash merge can preserve branch commit bodies, so a stale `Resolves #N` can still auto-close an issue even when the PR body says `Refs #N` and `closingIssuesReferences` is empty.

Evidence: L1 (static workflow-doc diff + whitespace check) -> L1 required (workflow-doc acceptance criteria). No residuals.

## Deltas from ticket

No scope expansion. The implementation stays in the two existing payload sections named by the ticket:

- `.agents/skills/pr-review/references/pr-review-guide.md` §5.2 now requires commit-body scanning and blocks partial-resolution PR approval when stale magic-close keywords remain.
- `.agents/skills/pull-request/references/pull-request-workflow.md` §9 now adds the author-side pre-handoff branch-history check for `Refs #N` partial PRs.

## Slot Rationale

- `pr-review-guide.md` §5.2 addition: `rewrite`; trigger-frequency = PR review only, failure-severity = high because it can close live issues incorrectly, enforceability = MACHINE-ENFORCEABLE-CANDIDATE via a future close-keyword lint.
- `pull-request-workflow.md` §9 addition: `rewrite`; trigger-frequency = PR handoff only, failure-severity = high for the same auto-close path, enforceability = MACHINE-ENFORCEABLE-CANDIDATE via the documented `git log origin/dev..HEAD` scan.

Decay mitigation: no router or always-loaded AGENTS.md text was added. The new content is scoped to existing close-target payload sections and cites the concrete empirical anchor so it can be retired or converted to tooling if a mechanical lint later enforces it.

## Test Evidence

```bash
git diff --check
git diff --cached --check
```

Both passed. No runtime tests required; this is a workflow-documentation-only change.

## Post-Merge Validation

- [ ] In the next partial-resolution PR review, reviewers should explicitly scan branch commit bodies when the PR body uses `Refs #N`.
- [ ] In the next partial-resolution author handoff, authors should treat stale `Closes/Fixes/Resolves #N` commit-body text as blocking unless they use a clean branch or operator-authorized history cleanup.

## Commit

- `03d8a6008` — `docs(ai): detect stale close keywords in commit bodies (#11185)`
