### PR TITLE
feat(github-workflow): add archive path helper (#11190)

### DIFF
--- a/ai/services/github-workflow/shared/archivePath.mjs
+++ b/ai/services/github-workflow/shared/archivePath.mjs
@@ -1,0 +1,121 @@
+import path from 'path';
+
+export const DEFAULT_ARCHIVE_MAX_ITEMS_PER_DIR = 100;
+
+/**
+ * @summary Builds archive-tier paths for GitHub workflow markdown files.
+ *
+ * This helper is intentionally archive-only. Active issue / pull request paths stay
+ * ID-range based via `chunkPath(id)` so callers such as `LocalFileService#getIssueById`
+ * can keep deterministic lookup from the item number.
+ *
+ * `itemCount` is the planned total size of the archive bucket after the item is
+ * placed. `itemIndex` is zero-based within that planned bucket order. The helper
+ * does not inspect the filesystem; callers own any sync or migration planning.
+ *
+ * @param {Object} config
+ * @param {String} config.archiveRoot Base archive root, e.g. `resources/content/archive`
+ * @param {String} config.type Archive type segment, e.g. `issues`, `pulls`, `discussions`
+ * @param {String} [config.version] Release bucket, e.g. `v13.0.0`
+ * @param {String} [config.bucket] Non-release bucket, e.g. `rejected`
+ * @param {String} config.filename Markdown filename
+ * @param {Number} config.itemCount Planned bucket size after placement
+ * @param {Number} [config.itemIndex] Zero-based item index, required when chunking
+ * @param {Number} [config.maxItemsPerDir=100] Maximum items per flat/chunk folder
+ * @returns {String}
+ */
+export default function archivePath(config = {}) {
+    const {
+        archiveRoot,
+        type,
+        version,
+        bucket,
+        filename,
+        itemCount,
+        itemIndex,
+        maxItemsPerDir = DEFAULT_ARCHIVE_MAX_ITEMS_PER_DIR
+    } = config;
+
+    validateSegment(archiveRoot, 'archiveRoot', {allowPath: true});
+    validateSegment(type,        'type');
+    validateSegment(filename,    'filename');
+    validateBucket({version, bucket});
+    validatePositiveInteger(maxItemsPerDir, 'maxItemsPerDir');
+    validateNonNegativeInteger(itemCount, 'itemCount');
+
+    const bucketDir = path.join(archiveRoot, type, version || bucket);
+
+    if (itemIndex !== undefined) {
+        validateNonNegativeInteger(itemIndex, 'itemIndex');
+
+        if (itemIndex >= itemCount) {
+            throw new RangeError('itemIndex must be smaller than itemCount')
+        }
+    }
+
+    if (itemCount <= maxItemsPerDir) {
+        return path.join(bucketDir, filename)
+    }
+
+    if (itemIndex === undefined) {
+        throw new TypeError('itemIndex is required when itemCount exceeds maxItemsPerDir')
+    }
+
+    const chunkNumber = Math.floor(itemIndex / maxItemsPerDir) + 1;
+
+    return path.join(bucketDir, `chunk-${chunkNumber}`, filename)
+}
+
+/**
+ * @summary Builds the archive bucket directory without appending a file path.
+ * @param {Object} config
+ * @param {String} config.archiveRoot Base archive root
+ * @param {String} config.type Archive type segment
+ * @param {String} [config.version] Release bucket
+ * @param {String} [config.bucket] Non-release bucket
+ * @returns {String}
+ */
+export function archiveBucketDir(config = {}) {
+    const {archiveRoot, type, version, bucket} = config;
+
+    validateSegment(archiveRoot, 'archiveRoot', {allowPath: true});
+    validateSegment(type,        'type');
+    validateBucket({version, bucket});
+
+    return path.join(archiveRoot, type, version || bucket)
+}
+
+function validateBucket({version, bucket}) {
+    if ((version && bucket) || (!version && !bucket)) {
+        throw new TypeError('exactly one of version or bucket is required')
+    }
+
+    validateSegment(version || bucket, version ? 'version' : 'bucket')
+}
+
+function validateNonNegativeInteger(value, name) {
+    if (!Number.isInteger(value) || value < 0) {
+        throw new TypeError(`${name} must be a non-negative integer`)
+    }
+}
+
+function validatePositiveInteger(value, name) {
+    if (!Number.isInteger(value) || value < 1) {
+        throw new TypeError(`${name} must be a positive integer`)
+    }
+}
+
+function validateSegment(value, name, options = {}) {
+    if (typeof value !== 'string' || value.length === 0) {
+        throw new TypeError(`${name} must be a non-empty string`)
+    }
+
+    if (!options.allowPath && (
+        value.includes('/') ||
+        value.includes('\\') ||
+        value === '..' ||
+        value.includes('..')
+    )) {
+        throw new TypeError(`${name} must be a single safe path segment`)
+    }
+}

--- a/test/playwright/unit/ai/services/github-workflow/ArchivePath.spec.mjs
+++ b/test/playwright/unit/ai/services/github-workflow/ArchivePath.spec.mjs
@@ -1,0 +1,138 @@
+import {setup} from '../../../../setup.mjs';
+
+setup({
+    neoConfig: {
+        unitTestMode: true
+    },
+    appConfig: {
+        name: 'ArchivePathHelperTest'
+    }
+});
+
+import {test, expect} from '@playwright/test';
+import Neo            from '../../../../../../src/Neo.mjs';
+import * as core      from '../../../../../../src/core/_export.mjs';
+import path           from 'path';
+
+import archivePath, {
+    archiveBucketDir,
+    DEFAULT_ARCHIVE_MAX_ITEMS_PER_DIR
+} from '../../../../../../ai/services/github-workflow/shared/archivePath.mjs';
+import chunkPath from '../../../../../../ai/services/github-workflow/shared/chunkPath.mjs';
+
+test.describe('GitHub workflow archivePath helper', () => {
+    const archiveRoot = path.join('resources', 'content', 'archive');
+
+    test('keeps empty and small release buckets flat through 100 items', () => {
+        expect(archivePath({
+            archiveRoot,
+            type     : 'issues',
+            version  : 'v13.0.0',
+            filename : 'issue-empty.md',
+            itemCount: 0
+        })).toBe(path.join(archiveRoot, 'issues', 'v13.0.0', 'issue-empty.md'));
+
+        expect(archivePath({
+            archiveRoot,
+            type     : 'issues',
+            version  : 'v13.0.0',
+            filename : 'issue-1.md',
+            itemCount: 1
+        })).toBe(path.join(archiveRoot, 'issues', 'v13.0.0', 'issue-1.md'));
+
+        expect(archivePath({
+            archiveRoot,
+            type     : 'issues',
+            version  : 'v13.0.0',
+            filename : 'issue-11190.md',
+            itemCount: 100
+        })).toBe(path.join(archiveRoot, 'issues', 'v13.0.0', 'issue-11190.md'));
+    });
+
+    test('routes ordinal archive chunks when the planned bucket exceeds 100 items', () => {
+        expect(archivePath({
+            archiveRoot,
+            type     : 'issues',
+            version  : 'v13.0.0',
+            filename : 'issue-11000.md',
+            itemCount: 101,
+            itemIndex: 0
+        })).toBe(path.join(archiveRoot, 'issues', 'v13.0.0', 'chunk-1', 'issue-11000.md'));
+
+        expect(archivePath({
+            archiveRoot,
+            type     : 'issues',
+            version  : 'v13.0.0',
+            filename : 'issue-11100.md',
+            itemCount: 101,
+            itemIndex: 100
+        })).toBe(path.join(archiveRoot, 'issues', 'v13.0.0', 'chunk-2', 'issue-11100.md'));
+    });
+
+    test('supports non-release archive buckets such as rejected pull requests', () => {
+        expect(archivePath({
+            archiveRoot,
+            type     : 'pulls',
+            bucket   : 'rejected',
+            filename : 'pr-11174.md',
+            itemCount: 1
+        })).toBe(path.join(archiveRoot, 'pulls', 'rejected', 'pr-11174.md'));
+    });
+
+    test('builds archive bucket directories without filenames', () => {
+        expect(archiveBucketDir({
+            archiveRoot,
+            type   : 'discussions',
+            version: 'v13.0.0'
+        })).toBe(path.join(archiveRoot, 'discussions', 'v13.0.0'));
+    });
+
+    test('rejects ambiguous or unsafe inputs', () => {
+        expect(() => archivePath({
+            archiveRoot,
+            type     : 'issues',
+            version  : 'v13.0.0',
+            bucket   : 'rejected',
+            filename : 'issue-1.md',
+            itemCount: 1
+        })).toThrow(/exactly one/);
+
+        expect(() => archivePath({
+            archiveRoot,
+            type     : 'issues/nested',
+            version  : 'v13.0.0',
+            filename : 'issue-1.md',
+            itemCount: 1
+        })).toThrow(/safe path segment/);
+
+        expect(() => archivePath({
+            archiveRoot,
+            type     : 'issues',
+            version  : 'v13.0.0',
+            filename : 'issue-1.md',
+            itemCount: DEFAULT_ARCHIVE_MAX_ITEMS_PER_DIR + 1
+        })).toThrow(/itemIndex/);
+
+        expect(() => archivePath({
+            archiveRoot,
+            type     : 'issues',
+            version  : 'v13.0.0',
+            filename : 'issue-1.md',
+            itemCount: 1,
+            itemIndex: 1
+        })).toThrow(/smaller than itemCount/);
+    });
+
+    test('does not alter active-tier ID-range chunking semantics', () => {
+        expect(chunkPath(11190)).toBe('111xx');
+
+        expect(archivePath({
+            archiveRoot,
+            type     : 'issues',
+            version  : 'v13.0.0',
+            filename : 'issue-11190.md',
+            itemCount: 101,
+            itemIndex: 100
+        })).toContain(`${path.sep}chunk-2${path.sep}`);
+    });
+});


### PR DESCRIPTION
Authored by GPT-5 (Codex Desktop). Session 22713fa8-23d2-4b31-918b-6e2f48d69c06.

Resolves #11190

Adds the archive-tier-only `archivePath()` helper for Epic #11187 Phase 1 AC2. The helper formats paths under `archive/{type}/{version-or-bucket}/`, keeps buckets flat through the configured 100-item threshold, switches to sealed ordinal `chunk-N/` folders above the threshold, and leaves active-tier `chunkPath(id)` ID-range semantics untouched.

Evidence: L1 (unit-tested pure path helper) -> L1 required (path contract ACs only). No residuals.

## Deltas from ticket (if any)

None. The implementation follows the ticket's explicit caller-owned bucket-state shape and avoids filesystem scans inside the formatter.

## Test Evidence

- `npm run test-unit -- test/playwright/unit/ai/services/github-workflow/ArchivePath.spec.mjs` -> 6 passed
- `git diff --cached --check` -> passed before commit
- `git diff --check origin/dev...HEAD` -> passed before push

## Post-Merge Validation

- [ ] AC3-AC5 service refactors consume `archivePath()` for archive-write paths while preserving active `chunkPath(id)` lookup semantics.

## Related

- Parent Epic: #11187
- AC1 Config lane: #11189 / PR #11191
- Discussion: #11180

## Commit

- `21219bd8e` — `feat(github-workflow): add archive path helper (#11190)`
