### PR TITLE
fix(memory-core): share core swarm summaries (#11181)

### DIFF
--- a/ai/mcp/server/shared/services/RequestContextService.mjs
+++ b/ai/mcp/server/shared/services/RequestContextService.mjs
@@ -9,14 +9,42 @@ import Base from '../../../../../src/core/Base.mjs';
  * granting every authenticated tenant access to their own data PLUS the shared baseline.
  * The migration runner (`ai/scripts/backfillChromaSharedUserId.mjs`, #10556) tags any
  * pre-#10145 ChromaDB records lacking a `userId` key with this sentinel so the additive
- * read filter can return them. New writes always tag with the resolved per-tenant userId,
- * never with `SHARED_USER_ID`.
+ * read filter can return them. New raw-memory writes tag with the resolved per-tenant userId;
+ * session summaries involving named core swarm maintainers intentionally use `SHARED_USER_ID`
+ * so the compressed navigation artifact remains visible to every named peer (#11181).
  *
  * @member {String}
  * @see #10556 — chromadb metadata backfill that introduces this sentinel
  * @see #10017 — adjacent SQLite Native Edge Graph migration (different storage layer, gradual)
  */
 export const SHARED_USER_ID = 'shared';
+
+/**
+ * @summary Canonical userIds for Neo's named core swarm maintainers.
+ *
+ * Session summaries that involve any of these agents are part of the shared
+ * swarm memory substrate, even when a single harness performed the summarization
+ * write. Without this list, restored summaries can be tagged to only one peer
+ * (`neo-gemini-3-1-pro`, etc.) and silently disappear for the other two peers'
+ * tenant-aware summary reads.
+ *
+ * @member {String[]}
+ * @see #11181 — restored summary visibility regression
+ */
+export const CORE_SWARM_USER_IDS = Object.freeze([
+    'neo-opus-4-7',
+    'neo-gemini-3-1-pro',
+    'neo-gpt'
+]);
+
+/**
+ * @summary AgentIdentity node-id form for {@link CORE_SWARM_USER_IDS}.
+ * @member {String[]}
+ * @see #11181
+ */
+export const CORE_SWARM_AGENT_IDS = Object.freeze(
+    CORE_SWARM_USER_IDS.map(userId => `@${userId}`)
+);
 
 /**
  * @summary Strips the `@`-prefix from AgentIdentity-style identifiers so userId comparisons
@@ -42,6 +70,61 @@ export function normalizeUserId(input) {
 }
 
 /**
+ * @summary Parses comma-separated or array-form agent identifiers into canonical userIds.
+ *
+ * Summary metadata stores `participatingAgents` as a comma-separated string. Tool-call and
+ * restore paths may hand us arrays or prefixed AgentIdentity node ids. This helper is the
+ * normalization boundary for all of those shapes.
+ *
+ * @param {String|String[]|null|undefined} input Agent list to normalize.
+ * @returns {String[]} Canonical userIds with empty entries removed.
+ * @see #11181
+ */
+export function parseAgentList(input) {
+    if (input == null) return [];
+
+    const values = Array.isArray(input) ? input : String(input).split(',');
+    return values
+        .map(value => normalizeUserId(String(value).trim()))
+        .filter(Boolean);
+}
+
+/**
+ * @summary Returns true when a participating-agent list includes a named core swarm peer.
+ *
+ * @param {String|String[]|null|undefined} participatingAgents Summary metadata participant list.
+ * @returns {Boolean}
+ * @see #11181
+ */
+export function hasCoreSwarmParticipant(participatingAgents) {
+    const participants = new Set(parseAgentList(participatingAgents));
+    return CORE_SWARM_USER_IDS.some(userId => participants.has(userId));
+}
+
+/**
+ * @summary Resolves the Chroma `userId` tag for session-summary writes.
+ *
+ * Raw memories remain owned by the active tenant. Session summaries are different: they are
+ * compressed cross-turn navigation artifacts. If a summary involves any named core swarm
+ * maintainer, tagging it to the single summarizing harness hides the artifact from the other
+ * peers after tenant-aware reads. Core-swarm summaries therefore use the shared sentinel;
+ * all other summaries retain the active request userId.
+ *
+ * @param {Object} input
+ * @param {String|null|undefined} input.userId Active request userId.
+ * @param {String|String[]|null|undefined} input.participatingAgents Summary participant metadata.
+ * @returns {String|undefined} `shared`, a normalized userId, or undefined for single-tenant fallthrough.
+ * @see #11181
+ */
+export function resolveSummaryVisibilityUserId({userId, participatingAgents} = {}) {
+    if (hasCoreSwarmParticipant(participatingAgents)) {
+        return SHARED_USER_ID;
+    }
+
+    return normalizeUserId(userId);
+}
+
+/**
  * @summary Request-scoped context propagation for MCP servers.
  *
  * Bridges the gap between the Express / MCP transport layer (where per-request auth claims
@@ -53,6 +136,7 @@ export function normalizeUserId(input) {
  * **Module-level exports:**
  * - {@link SHARED_USER_ID} — sentinel value for legacy/commons records (#10556)
  * - {@link normalizeUserId} — `@`-prefix stripping boundary helper (#10556)
+ * - {@link resolveSummaryVisibilityUserId} — summary visibility resolver for core-swarm artifacts (#11181)
  *
  * **Identity flow (Epic #9999, sub-epic #10016, tickets #10000 + #10145):**
  *
@@ -70,9 +154,11 @@ export function normalizeUserId(input) {
  *    transport.
  * 3. **Service-layer consumption:** `MemoryService.addMemory`, `SummaryService.querySummaries`,
  *    etc. call `RequestContextService.getUserId()` and either tag ChromaDB writes with
- *    `metadata.userId` or apply `where: {userId}` filters on reads. Graph-edge-writing services
- *    additionally call `getAgentIdentityNodeId()` to terminate `AUTHORED_BY` / `OWNED_BY` edges
- *    on the correct identity node.
+ *    `metadata.userId` or apply `where: {userId}` filters on reads. Summary writes additionally
+ *    route through {@link resolveSummaryVisibilityUserId} so core-swarm summaries become shared
+ *    artifacts instead of single-peer private rows. Graph-edge-writing services additionally call
+ *    `getAgentIdentityNodeId()` to terminate `AUTHORED_BY` / `OWNED_BY` edges on the correct
+ *    identity node.
  * 4. **Unresolved-identity fallthrough:** when neither transport resolves a userId (stdio with
  *    neither env-var nor authenticated `gh` CLI, offline daemon contexts), `getUserId()` returns
  *    `undefined` and services fall back to **single-tenant mode** — no tag on writes, no filter

--- a/ai/scripts/backfillChromaSharedUserId.mjs
+++ b/ai/scripts/backfillChromaSharedUserId.mjs
@@ -1,8 +1,8 @@
 #!/usr/bin/env node
 /**
  * @summary One-shot migration script that backfills `userId: 'shared'` metadata on
- * pre-#10145 ChromaDB records lacking the `userId` key, restoring tenant-aware read
- * access to the legacy commons.
+ * pre-#10145 ChromaDB records lacking the `userId` key, and promotes core-swarm session
+ * summaries to the shared visibility contract.
  *
  * Context: #10556. The Multi-Tenant Identity rollout (#10145, #10000) added
  * `where: {userId}` filters to all reads in `SummaryService` and `MemoryService`.
@@ -16,12 +16,13 @@
  * Without running this script, the new filter is functionally a no-op against
  * existing untagged data — same zero-results behavior as today.
  *
- * **Idempotent.** Safe to run multiple times. Records that already have a `userId`
- * key (any value) are skipped. Re-running tags only newly-arrived untagged records,
- * if any.
+ * **Idempotent.** Safe to run multiple times. Memory records that already have a `userId`
+ * key are skipped. Session-summary records are updated when they either lack `userId` OR
+ * list a named core-swarm maintainer in `participatingAgents` but are not already tagged
+ * as shared. Re-running tags only newly-arrived migration debt, if any.
  *
  * **Metadata-only.** No re-embedding. Embeddings are preserved as-is. Only the
- * `userId` metadata key is added.
+ * `userId` metadata key is added or updated.
  *
  * **Operates on both memory and summary collections.** Default config targets the
  * unified ChromaDB instance (port 8000).
@@ -54,6 +55,14 @@ const __dirname  = path.dirname(__filename);
 // which reads this script as text + regex-extracts the constant + compares against the import.
 const SHARED_USER_ID = 'shared';
 
+// MUST match `CORE_SWARM_USER_IDS` exported from RequestContextService. Duplicated here for
+// the same no-Neo-bootstrap reason as SHARED_USER_ID above; unit tests enforce the sync.
+const CORE_SWARM_USER_IDS = Object.freeze([
+    'neo-opus-4-7',
+    'neo-gemini-3-1-pro',
+    'neo-gpt'
+]);
+
 const COLLECTION_MEMORY  = 'neo-agent-memory';
 const COLLECTION_SESSION = 'neo-agent-sessions';
 const BATCH_SIZE         = 500;
@@ -62,8 +71,8 @@ function parseArgs(argv) {
     const args = {
         apply       : false,
         help        : false,
-        host        : 'localhost',
-        port        : 8000,
+        host        : process.env.NEO_CHROMA_HOST || process.env.NEO_KB_CHROMA_HOST || 'localhost',
+        port        : Number(process.env.NEO_CHROMA_PORT || process.env.NEO_KB_CHROMA_PORT || 8000),
         memoryOnly  : false,
         sessionOnly : false
     };
@@ -93,29 +102,67 @@ userId key, restoring tenant-aware read access to legacy data.
 Options:
   (no flags)         Dry-run mode — print the migration plan without committing
   --apply            Commit the migration (calls collection.update on all matched ids)
-  --host <host>      Override ChromaDB host (default: localhost)
-  --port <port>      Override ChromaDB port (default: 8000)
+  --host <host>      Override ChromaDB host (default: NEO_CHROMA_HOST, fallback localhost)
+  --port <port>      Override ChromaDB port (default: NEO_CHROMA_PORT, fallback 8000)
   --memory-only      Tag only the neo-agent-memory collection
   --session-only     Tag only the neo-agent-sessions collection
   --help             Print this usage message
 
-Idempotent: records with any existing userId value are skipped.
+Idempotent: memory records with any existing userId value are skipped; session
+summaries involving core swarm peers are promoted to userId='${SHARED_USER_ID}'.
 Metadata-only: no re-embedding; existing embeddings are preserved.
 `);
 }
 
 /**
- * Iterates a Chroma collection in batches, accumulating ids of records that lack
- * a `userId` metadata key.
+ * @param {String|null|undefined} input
+ * @returns {String|undefined}
+ */
+function normalizeUserId(input) {
+    if (input == null) return undefined;
+    const str = String(input);
+    return str.startsWith('@') ? str.slice(1) : str;
+}
+
+/**
+ * @param {String|String[]|null|undefined} input
+ * @returns {String[]}
+ */
+function parseAgentList(input) {
+    if (input == null) return [];
+
+    const values = Array.isArray(input) ? input : String(input).split(',');
+    return values
+        .map(value => normalizeUserId(String(value).trim()))
+        .filter(Boolean);
+}
+
+/**
+ * @param {String|String[]|null|undefined} participatingAgents
+ * @returns {Boolean}
+ */
+function hasCoreSwarmParticipant(participatingAgents) {
+    const participants = new Set(parseAgentList(participatingAgents));
+    return CORE_SWARM_USER_IDS.some(userId => participants.has(userId));
+}
+
+/**
+ * Iterates a Chroma collection in batches, accumulating ids of records that need
+ * the `userId: shared` metadata tag.
  *
  * @param {Object} collection ChromaDB collection wrapper
- * @returns {Promise<{untaggedIds: String[], totalScanned: Number, alreadyTagged: Number}>}
+ * @param {Object} options
+ * @param {Boolean} [options.promoteCoreSwarmSummaries=false]
+ * @returns {Promise<{tagRecords: Object[], totalScanned: Number, alreadyTagged: Number, untagged: Number, alreadyShared: Number, coreSwarmParticipant: Number}>}
  */
-async function findUntaggedRecords(collection) {
-    const untaggedIds = [];
-    let totalScanned  = 0;
-    let alreadyTagged = 0;
-    let batchOffset   = 0;
+async function findRecordsToTag(collection, {promoteCoreSwarmSummaries = false} = {}) {
+    const tagRecords           = [];
+    let totalScanned           = 0;
+    let alreadyTagged          = 0;
+    let untagged               = 0;
+    let alreadyShared          = 0;
+    let coreSwarmParticipant   = 0;
+    let batchOffset            = 0;
 
     while (true) {
         const batch = await collection.get({
@@ -133,10 +180,25 @@ async function findUntaggedRecords(collection) {
             // Treat both missing key AND empty-string as untagged. Mirrors the
             // COALESCE(...) IS NULL OR = '' pattern in HealthService graph-side checker.
             const userId = metadata && metadata.userId;
-            if (userId === undefined || userId === null || userId === '') {
-                untaggedIds.push(id);
+            const normalizedUserId = normalizeUserId(userId);
+            const missingUserId = userId === undefined || userId === null || userId === '';
+            const hasCorePeer = promoteCoreSwarmSummaries && hasCoreSwarmParticipant(metadata?.participatingAgents);
+
+            if (missingUserId) {
+                untagged++;
             } else {
                 alreadyTagged++;
+            }
+
+            if (normalizedUserId === SHARED_USER_ID) {
+                alreadyShared++;
+            }
+            if (hasCorePeer) {
+                coreSwarmParticipant++;
+            }
+
+            if (normalizedUserId !== SHARED_USER_ID && (missingUserId || hasCorePeer)) {
+                tagRecords.push({id, metadata: metadata || {}});
             }
         });
 
@@ -144,29 +206,31 @@ async function findUntaggedRecords(collection) {
         batchOffset += BATCH_SIZE;
     }
 
-    return {untaggedIds, totalScanned, alreadyTagged};
+    return {tagRecords, totalScanned, alreadyTagged, untagged, alreadyShared, coreSwarmParticipant};
 }
 
 /**
- * Tags the given record ids with `userId: SHARED_USER_ID`. Metadata-only update;
- * embeddings are preserved by ChromaDB's `update` semantics.
+ * Tags the given records with `userId: SHARED_USER_ID`. Metadata-only update;
+ * embeddings are preserved by ChromaDB's `update` semantics, and all existing
+ * metadata keys are preserved in the update payload.
  *
  * @param {Object}   collection ChromaDB collection wrapper
- * @param {String[]} ids        Record ids to tag
+ * @param {Object[]} records    Records to tag: `{id, metadata}`
  * @returns {Promise<Number>} Count of tagged records
  */
-async function tagRecords(collection, ids) {
-    if (ids.length === 0) return 0;
+async function tagRecords(collection, records) {
+    if (records.length === 0) return 0;
 
     // Update in batches to stay under any chroma payload limits + give visible progress.
     let tagged = 0;
-    for (let i = 0; i < ids.length; i += BATCH_SIZE) {
-        const slice    = ids.slice(i, i + BATCH_SIZE);
-        const metadatas = slice.map(() => ({userId: SHARED_USER_ID}));
+    for (let i = 0; i < records.length; i += BATCH_SIZE) {
+        const slice     = records.slice(i, i + BATCH_SIZE);
+        const ids       = slice.map(record => record.id);
+        const metadatas = slice.map(record => ({...record.metadata, userId: SHARED_USER_ID}));
 
-        await collection.update({ids: slice, metadatas});
+        await collection.update({ids, metadatas});
         tagged += slice.length;
-        process.stdout.write(`\r    tagged ${tagged}/${ids.length}`);
+        process.stdout.write(`\r    tagged ${tagged}/${records.length}`);
     }
     process.stdout.write('\n');
     return tagged;
@@ -195,24 +259,32 @@ async function processCollection(client, collectionName, apply) {
         const total = await collection.count();
         console.log(`  total records: ${total}`);
 
-        const {untaggedIds, totalScanned, alreadyTagged} = await findUntaggedRecords(collection);
-        console.log(`  scanned:       ${totalScanned}`);
-        console.log(`  already tagged: ${alreadyTagged}`);
-        console.log(`  to tag:        ${untaggedIds.length}`);
+        const promoteCoreSwarmSummaries = collectionName === COLLECTION_SESSION;
+        const {tagRecords, totalScanned, alreadyTagged, untagged, alreadyShared, coreSwarmParticipant} = await findRecordsToTag(collection, {
+            promoteCoreSwarmSummaries
+        });
+        console.log(`  scanned:                  ${totalScanned}`);
+        console.log(`  already tagged:           ${alreadyTagged}`);
+        console.log(`  already shared:           ${alreadyShared}`);
+        console.log(`  untagged:                 ${untagged}`);
+        if (promoteCoreSwarmSummaries) {
+            console.log(`  core swarm participants:  ${coreSwarmParticipant}`);
+        }
+        console.log(`  to tag:                   ${tagRecords.length}`);
 
-        if (untaggedIds.length === 0) {
+        if (tagRecords.length === 0) {
             console.log(`  → no work needed for this collection`);
-            return {totalScanned, alreadyTagged, tagged: 0, plannedTags: 0};
+            return {totalScanned, alreadyTagged, alreadyShared, untagged, coreSwarmParticipant, tagged: 0, plannedTags: 0};
         }
 
         if (!apply) {
-            console.log(`  → DRY-RUN: would tag ${untaggedIds.length} records with userId='${SHARED_USER_ID}'`);
-            return {totalScanned, alreadyTagged, tagged: 0, plannedTags: untaggedIds.length};
+            console.log(`  → DRY-RUN: would tag ${tagRecords.length} records with userId='${SHARED_USER_ID}'`);
+            return {totalScanned, alreadyTagged, alreadyShared, untagged, coreSwarmParticipant, tagged: 0, plannedTags: tagRecords.length};
         }
 
-        console.log(`  → APPLY: tagging ${untaggedIds.length} records...`);
-        const tagged = await tagRecords(collection, untaggedIds);
-        return {totalScanned, alreadyTagged, tagged, plannedTags: untaggedIds.length};
+        console.log(`  → APPLY: tagging ${tagRecords.length} records...`);
+        const tagged = await tagRecords(collection, tagRecords);
+        return {totalScanned, alreadyTagged, alreadyShared, untagged, coreSwarmParticipant, tagged, plannedTags: tagRecords.length};
     } finally {
         console.warn = origWarn;
     }
@@ -258,7 +330,7 @@ async function main() {
         console.log(`  memory:  scanned=${summary.memory.totalScanned}, already=${summary.memory.alreadyTagged}, ${args.apply ? `tagged=${summary.memory.tagged}` : `would-tag=${summary.memory.plannedTags}`}`);
     }
     if (summary.session) {
-        console.log(`  session: scanned=${summary.session.totalScanned}, already=${summary.session.alreadyTagged}, ${args.apply ? `tagged=${summary.session.tagged}` : `would-tag=${summary.session.plannedTags}`}`);
+        console.log(`  session: scanned=${summary.session.totalScanned}, already=${summary.session.alreadyTagged}, core-swarm=${summary.session.coreSwarmParticipant}, ${args.apply ? `tagged=${summary.session.tagged}` : `would-tag=${summary.session.plannedTags}`}`);
     }
 
     if (!args.apply) {

--- a/ai/services/memory-core/HealthService.mjs
+++ b/ai/services/memory-core/HealthService.mjs
@@ -8,6 +8,11 @@ import StorageRouter            from './managers/StorageRouter.mjs';
 import ChromaLifecycleService   from './lifecycle/ChromaLifecycleService.mjs';
 import logger                   from '../../mcp/server/memory-core/logger.mjs';
 import {readGateState}          from '../../scripts/wakeSafetyGate.mjs';
+import {
+    SHARED_USER_ID,
+    hasCoreSwarmParticipant,
+    normalizeUserId
+} from '../../mcp/server/shared/services/RequestContextService.mjs';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
@@ -496,6 +501,67 @@ export async function buildBackupStateBlock(backupPath, fs, path) {
     }
 }
 
+/**
+ * @summary Projects Chroma metadata into actionable tenant-migration counters (#11181).
+ *
+ * Chroma's where-filter vocabulary cannot ask for "metadata key is missing" reliably, so
+ * healthcheck migration observability must inspect returned metadata, not infer from `$ne`.
+ * For the summary collection, this also counts core-swarm participant summaries that are
+ * tagged to one peer instead of the shared sentinel — the restored-data visibility failure
+ * that triggered #11181.
+ *
+ * @param {Object[]} metadatas Chroma metadata records.
+ * @param {Object} [options]
+ * @param {Boolean} [options.summaryCollection=false] Whether to apply summary-specific checks.
+ * @returns {Object}
+ * @see ai/scripts/backfillChromaSharedUserId.mjs
+ */
+export function buildChromaMigrationStats(metadatas, {summaryCollection = false} = {}) {
+    const stats = {
+        totalRecords              : 0,
+        tagged                    : 0,
+        missingUserId             : 0,
+        shared                    : 0,
+        migrationDebt             : 0,
+        coreSwarmParticipant      : 0,
+        coreSwarmParticipantHidden: 0,
+        perUserId                 : {}
+    };
+
+    (metadatas || []).forEach(metadata => {
+        stats.totalRecords++;
+
+        const rawUserId = metadata?.userId;
+        const missingUserId = rawUserId === undefined || rawUserId === null || rawUserId === '';
+        const userId = normalizeUserId(rawUserId);
+        const hasCorePeer = summaryCollection && hasCoreSwarmParticipant(metadata?.participatingAgents);
+
+        if (missingUserId) {
+            stats.missingUserId++;
+        } else {
+            stats.tagged++;
+            stats.perUserId[userId] = (stats.perUserId[userId] || 0) + 1;
+        }
+
+        if (userId === SHARED_USER_ID) {
+            stats.shared++;
+        }
+
+        if (hasCorePeer) {
+            stats.coreSwarmParticipant++;
+            if (userId !== SHARED_USER_ID) {
+                stats.coreSwarmParticipantHidden++;
+            }
+        }
+
+        if (missingUserId || (hasCorePeer && userId !== SHARED_USER_ID)) {
+            stats.migrationDebt++;
+        }
+    });
+
+    return stats;
+}
+
 class HealthService extends Base {
     static config = {
         /**
@@ -734,21 +800,21 @@ class HealthService extends Base {
     }
 
     /**
-     * Computes the chromadb-side untagged-record counts for the multi-tenant migration
-     * observability surface (#10556 — companion to the SQLite graph-side counter at
+     * Computes the ChromaDB-side actionable migration-debt counts for the multi-tenant
+     * observability surface (#10556, #11181 — companion to the SQLite graph-side counter at
      * {@link HealthService##checkMigrationState}).
      *
-     * Pre-#10145 records lack the `userId` metadata key entirely. ChromaDB's where-vocabulary
-     * has no `$exists` operator and its `$ne` operator skips records with missing keys, so
-     * untagged records are unreachable via filtered reads — they're invisible to all stdio
-     * agents until the backfill runner (`ai/scripts/backfillChromaSharedUserId.mjs`) tags
-     * them with `userId: 'shared'`. This method exposes the remaining untagged volume so
-     * operators can verify migration completeness.
+     * Pre-#10145 records lack the `userId` metadata key entirely, and restored session summaries
+     * can also be tagged to one summarizing peer while `participatingAgents` names a different
+     * core-swarm peer. Both shapes are invisible to the intended tenant-aware reads until the
+     * backfill runner (`ai/scripts/backfillChromaSharedUserId.mjs`) tags them with
+     * `userId: 'shared'`. Chroma where-filters cannot reliably falsify absent metadata-key cases
+     * across versions, so this method scans metadata directly instead of inferring from `$ne`.
      *
      * Returns `{available: false, ...zeros}` when the ChromaDB client is unreachable
      * (substrate-readiness signal, not a migration error).
      *
-     * @returns {Promise<{memory: Number, session: Number, total: Number, available: Boolean, error: String|undefined}>}
+     * @returns {Promise<Object>} Actionable debt plus untagged and summary-visibility details.
      * @see ai/scripts/backfillChromaSharedUserId.mjs — the runner that tags untagged records
      * @see #10556 — the Fat Ticket establishing the additive-tenant-isolation read shape
      * @private
@@ -762,30 +828,31 @@ class HealthService extends Base {
             const memoryCollection  = await StorageRouter.getMemoryCollection();
             const summaryCollection = await StorageRouter.getSummaryCollection();
 
-            // ChromaDB's `.count()` does not accept a `where` filter; only the unfiltered total
-            // is available natively. To compute untagged-count, we use the `$ne` operator's
-            // documented behavior of skipping records where the metadata key is absent — so
-            // `where: {userId: {$ne: <unused-sentinel>}}` returns ALL tagged records (any
-            // userId value), and `total - tagged = untagged`. Cheaper than scanning every
-            // record's metadata to test `userId` presence in code.
-            const sentinelValueNeverUsed = '__neomjs_migration_probe__';
-            const taggedFilter = {userId: {$ne: sentinelValueNeverUsed}};
-
-            const [memoryTotal, memoryTagged, sessionTotal, sessionTagged] = await Promise.all([
-                memoryCollection.count(),
-                this.#countWhere(memoryCollection, taggedFilter),
-                summaryCollection.count(),
-                this.#countWhere(summaryCollection, taggedFilter)
+            const [memoryStats, sessionStats] = await Promise.all([
+                this.#scanChromaMetadata(memoryCollection),
+                this.#scanChromaMetadata(summaryCollection, {summaryCollection: true})
             ]);
 
-            const memoryUntagged  = Math.max(0, memoryTotal  - memoryTagged);
-            const sessionUntagged = Math.max(0, sessionTotal - sessionTagged);
-
             return {
-                memory   : memoryUntagged,
-                session  : sessionUntagged,
-                total    : memoryUntagged + sessionUntagged,
-                available: true
+                memory   : memoryStats.migrationDebt,
+                session  : sessionStats.migrationDebt,
+                total    : memoryStats.migrationDebt + sessionStats.migrationDebt,
+                available: true,
+                untagged : {
+                    memory : memoryStats.missingUserId,
+                    session: sessionStats.missingUserId,
+                    total  : memoryStats.missingUserId + sessionStats.missingUserId
+                },
+                visibility: {
+                    sessions: {
+                        coreSwarmParticipant      : sessionStats.coreSwarmParticipant,
+                        coreSwarmParticipantHidden: sessionStats.coreSwarmParticipantHidden
+                    }
+                },
+                details: {
+                    memory : memoryStats,
+                    session: sessionStats
+                }
             };
         } catch (e) {
             return {
@@ -799,28 +866,28 @@ class HealthService extends Base {
     }
 
     /**
-     * Counts records matching a `where` clause via paginated `.get()` sweeps. Used by
-     * {@link HealthService##checkChromaMigrationState} because ChromaDB's `.count()` does
-     * not accept a `where` filter — only the unfiltered total is available natively.
+     * Scans Chroma collection metadata in batches and projects migration counters.
      *
      * @param {Object} collection ChromaDB collection wrapper
-     * @param {Object} where      ChromaDB where-clause filter
-     * @returns {Promise<Number>}
+     * @param {Object} [options]
+     * @param {Boolean} [options.summaryCollection=false]
+     * @returns {Promise<Object>}
      * @private
      */
-    async #countWhere(collection, where) {
+    async #scanChromaMetadata(collection, options = {}) {
         const batchSize = 2000;
-        let total       = 0;
+        let metadatas   = [];
         let offset      = 0;
 
         while (true) {
-            const batch = await collection.get({limit: batchSize, offset, where, include: []});
+            const batch = await collection.get({limit: batchSize, offset, include: ['metadatas']});
             const n     = batch.ids?.length || 0;
-            total += n;
+            metadatas = metadatas.concat(batch.metadatas || []);
             if (n < batchSize) break;
             offset += batchSize;
         }
-        return total;
+
+        return buildChromaMigrationStats(metadatas, options);
     }
 
 

--- a/ai/services/memory-core/SessionService.mjs
+++ b/ai/services/memory-core/SessionService.mjs
@@ -11,7 +11,11 @@ import fs from 'fs';
 import path from 'path';
 import os from 'os';
 import logger from '../../mcp/server/memory-core/logger.mjs';
-import RequestContextService, {SHARED_USER_ID, normalizeUserId} from '../../mcp/server/shared/services/RequestContextService.mjs';
+import RequestContextService, {
+    SHARED_USER_ID,
+    normalizeUserId,
+    resolveSummaryVisibilityUserId
+} from '../../mcp/server/shared/services/RequestContextService.mjs';
 
 /**
  * @summary Service for handling session summarization and drift detection.
@@ -470,10 +474,13 @@ ${aggregatedContent}
 
         const summaryId = `summary_${sessionId}`;
 
-        // Multi-tenant isolation tag (#10000): attach the active user's id when a request
-        // context is present so `SummaryService.{listSummaries, querySummaries}` tenant-filters
-        // can observe this summary. Undefined in stdio mode = legacy unfiltered single-tenant.
-        const userId = RequestContextService.getUserId();
+        // Multi-tenant isolation tag (#10000, #11181): private summaries keep the active
+        // request userId; core-swarm summaries use the shared sentinel so every named peer can
+        // observe the compressed navigation artifact after tenant-aware reads are applied.
+        const userId = resolveSummaryVisibilityUserId({
+            userId: RequestContextService.getUserId(),
+            participatingAgents
+        });
 
         const summaryMetadata = {
             sessionId, timestamp: lastActivity, memoryCount: memories.ids.length,

--- a/test/playwright/unit/ai/mcp/server/shared/services/RequestContextService.spec.mjs
+++ b/test/playwright/unit/ai/mcp/server/shared/services/RequestContextService.spec.mjs
@@ -16,7 +16,14 @@ setup({
 import {test, expect}         from '@playwright/test';
 import Neo                    from '../../../../../../../../src/Neo.mjs';
 import * as core              from '../../../../../../../../src/core/_export.mjs';
-import RequestContextService, {SHARED_USER_ID, normalizeUserId}  from '../../../../../../../../ai/mcp/server/shared/services/RequestContextService.mjs';
+import RequestContextService, {
+    CORE_SWARM_AGENT_IDS,
+    CORE_SWARM_USER_IDS,
+    SHARED_USER_ID,
+    hasCoreSwarmParticipant,
+    normalizeUserId,
+    resolveSummaryVisibilityUserId
+} from '../../../../../../../../ai/mcp/server/shared/services/RequestContextService.mjs';
 
 test.describe('Neo.ai.mcp.server.shared.services.RequestContextService (#10000)', () => {
     test('get/getUserId/getUsername return undefined when no context is active', () => {
@@ -97,7 +104,7 @@ test.describe('Neo.ai.mcp.server.shared.services.RequestContextService (#10000)'
     });
 });
 
-test.describe('Module-scope exports: SHARED_USER_ID + normalizeUserId (#10556)', () => {
+test.describe('Module-scope exports: SHARED_USER_ID + normalizeUserId (#10556, #11181)', () => {
     test('SHARED_USER_ID is the string `shared`', () => {
         // The sentinel value the migration runner tags legacy records with, and the read-side
         // $or filter grants additive access to.
@@ -125,6 +132,29 @@ test.describe('Module-scope exports: SHARED_USER_ID + normalizeUserId (#10556)',
         const match = source.match(/^const\s+SHARED_USER_ID\s*=\s*['"](.+?)['"]\s*;?\s*$/m);
         expect(match, 'expected `const SHARED_USER_ID = ...` in migration runner script').not.toBeNull();
         expect(match[1]).toBe(SHARED_USER_ID);
+    });
+
+    test('CORE_SWARM_USER_IDS is in sync with the migration runner script\'s hardcoded copy', async () => {
+        const fs   = await import('fs');
+        const path = await import('path');
+
+        const repoRoot   = path.resolve(path.dirname(new URL(import.meta.url).pathname), '../../../../../../../..');
+        const scriptPath = path.join(repoRoot, 'ai/scripts/backfillChromaSharedUserId.mjs');
+        const source     = fs.readFileSync(scriptPath, 'utf-8');
+
+        const match = source.match(/^const\s+CORE_SWARM_USER_IDS\s*=\s*Object\.freeze\(\s*\[([\s\S]+?)\]\s*\)\s*;?\s*$/m);
+        expect(match, 'expected `const CORE_SWARM_USER_IDS = Object.freeze([...])` in migration runner script').not.toBeNull();
+
+        const scriptUserIds = match[1]
+            .split(',')
+            .map(value => value.trim().replace(/^['"]|['"]$/g, ''))
+            .filter(Boolean);
+
+        expect(scriptUserIds).toEqual(CORE_SWARM_USER_IDS);
+    });
+
+    test('CORE_SWARM_AGENT_IDS mirrors user ids in AgentIdentity form', () => {
+        expect(CORE_SWARM_AGENT_IDS).toEqual(CORE_SWARM_USER_IDS.map(userId => `@${userId}`));
     });
 
     test('normalizeUserId strips `@`-prefix at the AgentIdentity ↔ userId boundary', () => {
@@ -173,5 +203,35 @@ test.describe('Module-scope exports: SHARED_USER_ID + normalizeUserId (#10556)',
         // `userId: '@x'` — the silent-self-filter trap.
         expect(normalizeUserId('@x')).toBe(normalizeUserId('x'));
         expect(normalizeUserId('@neo-opus-4-7')).toBe(normalizeUserId('neo-opus-4-7'));
+    });
+
+    test('hasCoreSwarmParticipant detects comma-separated and array-form agent lists', () => {
+        expect(hasCoreSwarmParticipant('@neo-gpt')).toBe(true);
+        expect(hasCoreSwarmParticipant('@alice, @neo-opus-4-7')).toBe(true);
+        expect(hasCoreSwarmParticipant(['neo-gemini-3-1-pro', '@alice'])).toBe(true);
+        expect(hasCoreSwarmParticipant('@alice,@bob')).toBe(false);
+        expect(hasCoreSwarmParticipant(undefined)).toBe(false);
+    });
+
+    test('resolveSummaryVisibilityUserId promotes core-swarm summaries to shared', () => {
+        expect(resolveSummaryVisibilityUserId({
+            userId: 'neo-gemini-3-1-pro',
+            participatingAgents: '@neo-gpt'
+        })).toBe(SHARED_USER_ID);
+
+        expect(resolveSummaryVisibilityUserId({
+            userId: undefined,
+            participatingAgents: '@neo-opus-4-7'
+        })).toBe(SHARED_USER_ID);
+
+        expect(resolveSummaryVisibilityUserId({
+            userId: '@alice',
+            participatingAgents: '@alice'
+        })).toBe('alice');
+
+        expect(resolveSummaryVisibilityUserId({
+            userId: undefined,
+            participatingAgents: ''
+        })).toBeUndefined();
     });
 });

--- a/test/playwright/unit/ai/services/memory-core/HealthService.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/HealthService.spec.mjs
@@ -157,6 +157,59 @@ test.describe('HealthService #11009 — buildTaskOutcomesBlock', () => {
 });
 
 /**
+ * @summary Coverage for Chroma migration observability after #11181.
+ *
+ * The live regression was not just "missing userId"; restored session summaries also had
+ * single-peer userIds while `participatingAgents` named another core swarm maintainer. This
+ * pure projection pins both counters without requiring a live ChromaDB instance.
+ *
+ * @see Neo.ai.services.memory-core.HealthService#buildChromaMigrationStats
+ */
+test.describe('HealthService #11181 — buildChromaMigrationStats', () => {
+    let buildChromaMigrationStats;
+
+    test.beforeAll(async () => {
+        const mod = await import('../../../../../../ai/services/memory-core/HealthService.mjs');
+        buildChromaMigrationStats = mod.buildChromaMigrationStats;
+    });
+
+    test('memory metadata counts missing userId as migration debt', () => {
+        const result = buildChromaMigrationStats([
+            {},
+            {userId: ''},
+            {userId: 'shared'},
+            {userId: 'neo-gpt'}
+        ]);
+
+        expect(result.totalRecords).toBe(4);
+        expect(result.missingUserId).toBe(2);
+        expect(result.shared).toBe(1);
+        expect(result.migrationDebt).toBe(2);
+        expect(result.perUserId).toEqual({
+            shared   : 1,
+            'neo-gpt': 1
+        });
+    });
+
+    test('summary metadata flags core-swarm participants not shared as visibility debt', () => {
+        const result = buildChromaMigrationStats([
+            {},
+            {userId: 'neo-gemini-3-1-pro', participatingAgents: '@neo-gpt'},
+            {userId: 'shared', participatingAgents: '@neo-opus-4-7'},
+            {userId: 'alice', participatingAgents: '@alice'},
+            {userId: '', participatingAgents: '@neo-gemini-3-1-pro'}
+        ], {summaryCollection: true});
+
+        expect(result.totalRecords).toBe(5);
+        expect(result.missingUserId).toBe(2);
+        expect(result.shared).toBe(1);
+        expect(result.coreSwarmParticipant).toBe(3);
+        expect(result.coreSwarmParticipantHidden).toBe(2);
+        expect(result.migrationDebt).toBe(3);
+    });
+});
+
+/**
  * @summary Coverage for the #10127 topology observability block in the healthcheck payload.
  *
  * Mirrors the #10176 precedent above: the end-to-end integration path requires a live ChromaDB


### PR DESCRIPTION
Resolves #11181

Authored by GPT-5 (Codex Desktop). Session 22713fa8-23d2-4b31-918b-6e2f48d69c06.

Restores restored-summary visibility for named core swarm identities. Future session summaries involving @neo-opus-4-7, @neo-gemini-3-1-pro, or @neo-gpt now write userId=shared; the Chroma backfill runner can promote historical core-swarm summary rows to the same contract while preserving existing metadata; and healthcheck no longer relies on the stale NE shortcut that reported zero Chroma debt while missing metadata still existed.

Evidence: L2 (focused unit tests + script syntax + diff hygiene) -> L4 required (post-merge Chroma apply against canonical restored data, then get_all_summaries / query_summaries visible from each core identity). Residual: post-merge validation checklist below.

## Deltas from ticket

- Adds CORE_SWARM_USER_IDS, participant parsing, and resolveSummaryVisibilityUserId() in RequestContextService as the shared contract surface.
- Routes SessionService.summarizeSession() through that resolver so core-swarm summaries are shared by write-time contract, not by one-off restore luck.
- Extends ai/scripts/backfillChromaSharedUserId.mjs so summary rows are tagged shared when they lack userId or include a core-swarm participant but are tagged to a single peer.
- Preserves existing Chroma metadata during backfill updates by spreading the current metadata and changing only userId.
- Replaces the healthcheck Chroma migration shortcut with a paginated metadata scan that reports missing userId plus core-swarm summary visibility debt.
- Makes the backfill runner respect NEO_CHROMA_HOST / NEO_CHROMA_PORT defaults, with legacy KB env fallback.

## Test Evidence

- git diff --check passed.
- git diff --cached --check passed.
- node --check ai/scripts/backfillChromaSharedUserId.mjs passed.
- npm run test-unit -- test/playwright/unit/ai/mcp/server/shared/services/RequestContextService.spec.mjs test/playwright/unit/ai/services/memory-core/HealthService.spec.mjs passed: 58 passed.
- Live pre-fix symptom rechecked through MCP: healthcheck reports 980 summary records, while get_all_summaries({limit:5}) and query_summaries("Memory Core restored summaries shared visibility") both return zero for @neo-gpt.

## Post-Merge Validation

- [ ] Restart/reload Memory Core so the new healthcheck projection is active.
- [ ] Run node ai/scripts/backfillChromaSharedUserId.mjs --session-only --port <canonical-port> and confirm the dry-run reports summary rows to tag.
- [ ] Run the same command with --apply after operator approval.
- [ ] Verify get_all_summaries({limit:5}) returns non-empty for @neo-gpt.
- [ ] Verify query_summaries(...) returns restored summaries for each named core swarm identity.

## Commit

- 7812247ec - fix(memory-core): share core swarm summaries (#11181)

## Notes

I attempted the local non-mutating Chroma dry-run from this Codex shell against ports 8001 and 8000. Both failed to connect inside the sandbox, and two escalated retries timed out in the approval reviewer. I did not run --apply; no live Chroma data was mutated.