### PR TITLE
fix(memory-core): pass fs-extra default export to buildBackupStateBlock (#11201)

### DIFF
--- a/ai/services/memory-core/HealthService.mjs
+++ b/ai/services/memory-core/HealthService.mjs
@@ -1,4 +1,5 @@
 import fs                       from 'fs/promises';
+import fsExtra                  from 'fs-extra';
 import path                     from 'path';
 import {fileURLToPath}          from 'url';
 import aiConfig                 from '../../mcp/server/memory-core/config.mjs';
@@ -965,7 +966,7 @@ class HealthService extends Base {
                 summary  : buildSummaryProviderBlock(aiConfig),
                 auth     : buildAuthProviderBlock(aiConfig)
             },
-            backup   : await buildBackupStateBlock(aiConfig.backupPath, await import('fs-extra'), await import('path')),
+            backup   : await buildBackupStateBlock(aiConfig.backupPath, fsExtra, path),
             details  : [],
             version  : process.env.npm_package_version || '1.0.0',
             uptime   : process.uptime()


### PR DESCRIPTION
Authored by Claude Opus 4.7 (Claude Code). Session `c2912891-b459-4a03-b2af-154d5e264df1`.

Resolves #11201

Restores `healthcheck.backup` observability — the block was permanently broken until this fix.

Evidence: L1 (static import-shape correction; 40 HealthService unit tests pass post-fix) → L2 required (post-merge MC reload + healthcheck verification that `backup.error` is null). Residual: L2 verification deferred to post-merge operator action.

## Root Cause

`HealthService.mjs:968` invoked `await buildBackupStateBlock(aiConfig.backupPath, await import('fs-extra'), await import('path'))`. `await import('fs-extra')` returns the module namespace wrapper `{default: fsExtraAPI, ...}`, not the fs-extra API namespace itself. When `buildBackupStateBlock` then called `fs.readdir(...)` against the wrapper, the call resolved to `undefined.readdir` → `TypeError: fs.readdir is not a function`.

The fix is a 2-line static-import rewrite:

```diff
 import fs                       from 'fs/promises';
+import fsExtra                  from 'fs-extra';
 import path                     from 'path';

-backup   : await buildBackupStateBlock(aiConfig.backupPath, await import('fs-extra'), await import('path')),
+backup   : await buildBackupStateBlock(aiConfig.backupPath, fsExtra, path),
```

Also drops the redundant `await import('path')` since `path` is already statically imported at line 2.

## Why this regressed silently

`buildBackupStateBlock` is a pure-projection function with unit test coverage (40 HealthService.spec.mjs tests pass, including the dedicated `#10844 — buildBackupStateBlock` test suite). The function itself works fine with correctly-shaped fs + path inputs. The bug is purely at the **call-site** — the invocation passes wrong-shape input.

The call-site is NOT covered by existing tests because mocking `await import('fs-extra')` at module-load time is awkward. The contract failure manifests only when the actual healthcheck is invoked against the actual fs-extra module.

## Empirical V-B-A anchor

3-way cross-family healthcheck verification at 2026-05-11T12:24Z:

- @neo-opus-4-7 healthcheck — `"backup": {"lastSuccessful": null, "count": 0, "error": "fs.readdir is not a function"}`
- @neo-gpt healthcheck (independent) — same `backup.error` payload
- All adjacent healthcheck blocks (topology, embedding, summary providers, wake) work correctly → regression isolated to backup-block call-site

## Test Evidence

- `npm run test-unit -- test/playwright/unit/ai/services/memory-core/HealthService.spec.mjs` → **40 passed (872ms)** locally
- `git diff --check` clean
- `git diff origin/dev...HEAD` clean (2-line diff)

## Post-Merge Validation

- [ ] After merge + MC reload, `mcp__neo-mjs-memory-core__healthcheck` payload's `backup` block should report `error: null` (or omit `error` entirely) + non-null `count` if backup directory exists with `backup-*` subdirs
- [ ] If `lastSuccessful` populates with a recent ISO timestamp, the full backup-observability chain is verified end-to-end

## Cross-family review routing

Default round-robin per `pull-request-workflow §6.2`: pinging **@neo-gemini-3-1-pro** as primary-reviewer (rotation from recent @neo-gpt PR #11200 review).

## Commits

- `1045875f3` — `fix(memory-core): pass fs-extra default export to buildBackupStateBlock (#11201)`

## Related

- **#11201** — Origin ticket (filed in same session 2 min before this PR)
- **PR #11200** — `fix(memory-core): share core swarm summaries (#11181)` — the new `buildChromaMigrationStats` projection in this PR is what exposed the silent backup-block regression empirically
- **#11202** — Sibling substrate-evolution follow-up (33 hidden core-swarm session rows) — same arc, different surface
- **#11195** — Step 2.5 30-day post-merge validation tracker — this fix-PR is positive empirical anchor for the discipline's value (Step 2.5's "existing primitive sweep" would have caught the wrong-shape dynamic-import pattern pre-PR-#11200-merge)

Co-authored-by: Claude Opus 4.7 <neo-opus-4-7@neomjs.com>
