### PR TITLE
test(ai): guard dynamic fs-extra import shape (#11204)

### DIFF
--- a/test/playwright/unit/ai/DynamicImportShape.spec.mjs
+++ b/test/playwright/unit/ai/DynamicImportShape.spec.mjs
@@ -1,0 +1,135 @@
+import {setup} from '../../setup.mjs';
+
+setup({
+    appConfig: {
+        name: 'DynamicImportShapeTest'
+    }
+});
+
+import {test, expect}     from '@playwright/test';
+import {parse}            from 'acorn';
+import fs                 from 'node:fs/promises';
+import path               from 'node:path';
+import {fileURLToPath}    from 'node:url';
+import Neo                from '../../../../src/Neo.mjs';
+import * as core          from '../../../../src/core/_export.mjs';
+
+const
+    __filename = fileURLToPath(import.meta.url),
+    __dirname  = path.dirname(__filename),
+    repoRoot   = path.resolve(__dirname, '../../../..');
+
+async function listMjsFiles(dir) {
+    const out = [];
+
+    for (const entry of await fs.readdir(dir, {withFileTypes: true})) {
+        const fullPath = path.join(dir, entry.name);
+
+        if (entry.isDirectory()) {
+            out.push(...await listMjsFiles(fullPath));
+        } else if (entry.isFile() && entry.name.endsWith('.mjs')) {
+            out.push(fullPath);
+        }
+    }
+
+    return out;
+}
+
+function hasDefaultBinding(pattern) {
+    return pattern?.type === 'ObjectPattern' && pattern.properties.some(property => {
+        const key = property.key;
+        return (key?.type === 'Identifier' && key.name === 'default') ||
+            (key?.type === 'Literal' && key.value === 'default');
+    });
+}
+
+function isDefaultBoundaryImport(ancestors) {
+    const
+        parent      = ancestors.at(-1),
+        grandparent = ancestors.at(-2);
+
+    if (parent?.type !== 'AwaitExpression') {
+        return false;
+    }
+
+    if (grandparent?.type === 'MemberExpression') {
+        return grandparent.property?.type === 'Identifier' && grandparent.property.name === 'default';
+    }
+
+    if (grandparent?.type === 'VariableDeclarator') {
+        return hasDefaultBinding(grandparent.id);
+    }
+
+    return false;
+}
+
+function walk(node, visitor, ancestors = []) {
+    if (!node || typeof node.type !== 'string') {
+        return;
+    }
+
+    visitor(node, ancestors);
+
+    for (const [key, value] of Object.entries(node)) {
+        if (key === 'loc' || key === 'range') {
+            continue;
+        }
+
+        if (Array.isArray(value)) {
+            value.forEach(child => walk(child, visitor, [...ancestors, node]));
+        } else if (value && typeof value.type === 'string') {
+            walk(value, visitor, [...ancestors, node]);
+        }
+    }
+}
+
+function findFsExtraDynamicImportViolations(source, filePath) {
+    const ast = parse(source, {
+        allowHashBang: true,
+        ecmaVersion  : 'latest',
+        locations    : true,
+        sourceType   : 'module'
+    });
+
+    const violations = [];
+
+    walk(ast, (node, ancestors) => {
+        if (node.type === 'ImportExpression' && node.source?.value === 'fs-extra' && !isDefaultBoundaryImport(ancestors)) {
+            violations.push(`${path.relative(repoRoot, filePath)}:${node.loc.start.line}`);
+        }
+    });
+
+    return violations;
+}
+
+/**
+ * @summary Regression coverage for #11204 dynamic ESM import shape boundaries.
+ *
+ * Node's `await import('fs-extra')` returns a module namespace wrapper. Some helpers are mirrored
+ * as named exports while inherited/native fs methods, e.g. `createWriteStream`, only live on
+ * `default`. This pins the runtime shape and statically guards AI-side dynamic call sites from
+ * consuming the wrapper directly.
+ */
+test.describe('AI dynamic ESM import shape (#11204)', () => {
+    test('fs-extra dynamic import returns a wrapper; default is the runtime API', async () => {
+        const fsExtraModule = await import('fs-extra');
+
+        expect(fsExtraModule.default).toBeTruthy();
+        expect(typeof fsExtraModule.pathExists).toBe('function');
+        expect(fsExtraModule.pathExists).toBe(fsExtraModule.default.pathExists);
+        expect(fsExtraModule.createWriteStream).toBeUndefined();
+        expect(typeof fsExtraModule.default.createWriteStream).toBe('function');
+    });
+
+    test('AI-side fs-extra dynamic imports unwrap the default boundary', async () => {
+        const files = await listMjsFiles(path.join(repoRoot, 'ai'));
+        const violations = [];
+
+        for (const filePath of files) {
+            const source = await fs.readFile(filePath, 'utf8');
+            violations.push(...findFsExtraDynamicImportViolations(source, filePath));
+        }
+
+        expect(violations).toEqual([]);
+    });
+});


### PR DESCRIPTION
Authored by GPT-5.5 (Codex Desktop). Session 019e0c7d-955f-7003-a25d-42dc14c57214.

Resolves #11204

## Summary
- Adds a targeted Playwright unit spec for the `fs-extra` dynamic ESM import shape.
- Pins the runtime behavior that `await import('fs-extra')` returns a namespace wrapper and the full API lives on `.default`.
- Adds a static AI-side guard so dynamic `fs-extra` imports under `ai/` must unwrap the default boundary instead of consuming the wrapper directly.

## Evidence
Evidence tier: L2 targeted regression test and changed-surface validation.

Verification run:
- `npm run test-unit -- test/playwright/unit/ai/DynamicImportShape.spec.mjs` -> 2 passed
- `npm run test-unit -- test/playwright/unit/ai/DynamicImportShape.spec.mjs test/playwright/unit/ai/services/memory-core/HealthService.spec.mjs` -> 42 passed
- `git diff --check origin/dev...HEAD` -> passed

Runtime shape verified during implementation:
- `typeof (await import('fs-extra')).pathExists === 'function'`
- `typeof (await import('fs-extra')).createWriteStream === 'undefined'`
- `typeof (await import('fs-extra')).default.createWriteStream === 'function'`

## Structural Pre-Flight
New file placement uses the existing Playwright unit-test surface:
- `test/playwright/unit/ai/DynamicImportShape.spec.mjs`

Sibling-file lift:
- `test/playwright/unit/ai/AgentOrchestrator.spec.mjs`
- `test/playwright/unit/ai/buildScripts/initServerConfigs.spec.mjs`

This is a narrow regression-harness addition, not a new runtime service or directory pattern.

## Related
- Builds on the runtime fix from #11201 / PR #11203.
- Out of scope: rewriting every dynamic import pattern outside the `fs-extra` boundary implicated by #11204.
