### PR TITLE
fix(github-workflow): paginate ProjectV2 items in reconcile script to bypass 100-item limit (#10961)

### DIFF
--- a/ai/scripts/reconcileV13Project.mjs
+++ b/ai/scripts/reconcileV13Project.mjs
@@ -61,13 +61,25 @@ const labeledIssues = gh(`issue list --repo ${REPO} --label "${LABEL}" --state a
 const labeledIds    = new Set(labeledIssues.map(i => i.id));
 
 // 2. Get all Project items via GraphQL
-// GraphQL `first` is capped at 100. Pilot scope (#10961) caps total release:v13 items
-// well below that; if v13 grows past 100 items, paginate via pageInfo.endCursor.
-const projectQuery = `query { node(id: "${PROJECT_ID}") { ... on ProjectV2 { items(first: 100) { nodes { id content { ... on Issue { number id title state } ... on PullRequest { number id title state } } } } } } }`;
-const projectData  = gh(`api graphql -f query='${projectQuery}'`);
-const items        = (projectData.data.node?.items?.nodes ?? [])
-    .filter(item => item.content?.number)
-    .map(item => ({projectItemId: item.id, content: item.content}));
+// Paginate via pageInfo.endCursor to bypass the 100 item limit per query (#10961).
+const items = [];
+let hasNextPage = true;
+let endCursor = null;
+
+while (hasNextPage) {
+    const afterParam = endCursor ? `, after: "${endCursor}"` : '';
+    const projectQuery = `query { node(id: "${PROJECT_ID}") { ... on ProjectV2 { items(first: 100${afterParam}) { pageInfo { hasNextPage endCursor } nodes { id content { ... on Issue { number id title state } ... on PullRequest { number id title state } } } } } } }`;
+    const projectData  = gh(`api graphql -f query='${projectQuery}'`);
+
+    const pageNodes = projectData.data.node?.items?.nodes ?? [];
+    items.push(...pageNodes
+        .filter(item => item.content?.number)
+        .map(item => ({projectItemId: item.id, content: item.content})));
+
+    const pageInfo = projectData.data.node?.items?.pageInfo;
+    hasNextPage = pageInfo?.hasNextPage ?? false;
+    endCursor = pageInfo?.endCursor;
+}
 const itemContentIds = new Set(items.map(i => i.content.id));
 
 // 3. Detect drift


### PR DESCRIPTION
Addresses #10961

Adds `pageInfo.endCursor` pagination to the `ai/scripts/reconcileV13Project.mjs` script to fetch all items from ProjectV2 instead of being limited to the first 100 items. This allows accurate drift detection between `release:v13` labeled issues and the v13 Release project board, removing the 100-item visibility cap and exposing residual drift.

## Test Evidence

Ran `npm run ai:reconcile-v13-project` locally and verified it correctly fetched all 250 Project items and identified the drift:

```
[reconcile] Project #12 ↔ label "release:v13" (https://github.com/orgs/neomjs/projects/12)
  Issues labeled "release:v13": 68
  Project items: 250
  Intersection: 54

  Drift:
    - Labeled but NOT in Project: 14
    - In Project but NOT labeled: 196
```

Authored by Antigravity (@neo-gemini-3-1-pro). Session 57502eb2-7f7b-4b9b-a849-49f016b08c95.
