### PR TITLE
chore(ai/scripts): Add Phase 2 ProjectV2 migration script (#11233)

### DIFF
--- a/ai/scripts/migrateV13ProjectFromLabel.mjs
+++ b/ai/scripts/migrateV13ProjectFromLabel.mjs
@@ -35,7 +35,7 @@ const APPLY = process.argv.includes('--apply');
 
 function gh(args, { parse = true, throws = false } = {}) {
     try {
-        const out = execSync(`gh ${args}`, { encoding: 'utf8', stdio: ['pipe', 'pipe', 'pipe'] });
+        const out = execSync(`gh ${args}`, { encoding: 'utf8', stdio: ['pipe', 'pipe', 'pipe'], maxBuffer: 1024 * 1024 * 50 });
         return parse ? (out.trim() ? JSON.parse(out) : null) : out;
     } catch (err) {
         if (throws) {

--- a/ai/scripts/migrateV13ProjectFromLabel.mjs
+++ b/ai/scripts/migrateV13ProjectFromLabel.mjs
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 /**
  * @module ai/scripts/migrateV13ProjectFromLabel
+ * @author Antigravity / @neo-gemini-3-1-pro
  * @summary Phase 2 Migration: Move `release:v13` labeled tickets to ProjectV2 #12 and retire label.
  *
  * This script is part of the ProjectV2 migration (Issue #11233). It transfers all
@@ -65,6 +66,17 @@ if (!issues || issues.length === 0) {
 
 console.log(`Found ${issues.length} issues to migrate.`);
 
+// 2. Fetch existing ProjectV2 items to ensure idempotency
+console.log(`\nFetching existing items in ProjectV2 #${PROJECT_NUMBER} to ensure idempotency...`);
+const projectData = gh(`project item-list ${PROJECT_NUMBER} --owner "${ORG}" --format json --limit 2000`);
+const existingIssueNumbers = new Set(
+    (projectData?.items || [])
+        .filter(i => i.content?.type === 'Issue' && i.content?.repository === REPO)
+        .map(i => i.content.number)
+);
+
+console.log(`Found ${existingIssueNumbers.size} issues already in ProjectV2 #${PROJECT_NUMBER}.`);
+
 let successCount = 0;
 let failCount = 0;
 
@@ -73,11 +85,17 @@ for (let i = 0; i < issues.length; i++) {
     const issueUrl = `https://github.com/${REPO}/issues/${issue.number}`;
     console.log(`\n[${i + 1}/${issues.length}] Processing #${issue.number}: ${issue.title}`);
 
+    const isAlreadyInProject = existingIssueNumbers.has(issue.number);
+
     if (APPLY) {
         try {
             // Add issue to ProjectV2
-            console.log(`  -> Adding to ProjectV2 #${PROJECT_NUMBER}...`);
-            gh(`project item-add ${PROJECT_NUMBER} --owner "${ORG}" --url "${issueUrl}"`, { parse: false, throws: true });
+            if (isAlreadyInProject) {
+                console.log(`  -> Already in ProjectV2 #${PROJECT_NUMBER}, skipping add...`);
+            } else {
+                console.log(`  -> Adding to ProjectV2 #${PROJECT_NUMBER}...`);
+                gh(`project item-add ${PROJECT_NUMBER} --owner "${ORG}" --url "${issueUrl}"`, { parse: false, throws: true });
+            }
 
             // Remove the label from the issue
             console.log(`  -> Removing label "${LABEL}"...`);
@@ -89,7 +107,11 @@ for (let i = 0; i < issues.length; i++) {
             failCount++;
         }
     } else {
-        console.log(`  -> (Dry Run) Would add to ProjectV2 #${PROJECT_NUMBER}`);
+        if (isAlreadyInProject) {
+            console.log(`  -> (Dry Run) Already in ProjectV2 #${PROJECT_NUMBER}, would skip add`);
+        } else {
+            console.log(`  -> (Dry Run) Would add to ProjectV2 #${PROJECT_NUMBER}`);
+        }
         console.log(`  -> (Dry Run) Would remove label "${LABEL}"`);
     }
 }

--- a/ai/scripts/migrateV13ProjectFromLabel.mjs
+++ b/ai/scripts/migrateV13ProjectFromLabel.mjs
@@ -1,0 +1,114 @@
+#!/usr/bin/env node
+/**
+ * @module ai/scripts/migrateV13ProjectFromLabel
+ * @summary Phase 2 Migration: Move `release:v13` labeled tickets to ProjectV2 #12 and retire label.
+ *
+ * This script is part of the ProjectV2 migration (Issue #11233). It transfers all
+ * tickets currently carrying the `release:v13` label into the canonical GitHub Project
+ * (ProjectV2 #12). It then performs destructive cleanup by removing the label from the
+ * tickets and deleting the label from the repository.
+ *
+ * *** EXECUTION GATE: OPERATOR AUTHORIZATION REQUIRED ***
+ * This script performs destructive operations (bulk label removal and label deletion).
+ * Agents are NOT authorized to run this script with `--apply` without explicit
+ * operator consent.
+ *
+ * Exit codes:
+ *   0 — Migration completed successfully (or dry-run finished).
+ *   1 — Script error or partial failure during migration.
+ *
+ * Usage:
+ *   node ai/scripts/migrateV13ProjectFromLabel.mjs           # Dry-run (lists actions)
+ *   node ai/scripts/migrateV13ProjectFromLabel.mjs --apply   # Execute migration
+ *
+ * @see https://github.com/neomjs/neo/issues/11233
+ */
+
+import { execSync } from 'child_process';
+
+const PROJECT_NUMBER = 12;
+const ORG = 'neomjs';
+const REPO = 'neomjs/neo';
+const LABEL = 'release:v13';
+const APPLY = process.argv.includes('--apply');
+
+function gh(args, { parse = true, throws = false } = {}) {
+    try {
+        const out = execSync(`gh ${args}`, { encoding: 'utf8', stdio: ['pipe', 'pipe', 'pipe'] });
+        return parse ? (out.trim() ? JSON.parse(out) : null) : out;
+    } catch (err) {
+        if (throws) {
+            throw err;
+        }
+        console.error(`[migration] gh command failed: ${args}`);
+        console.error(err.stderr?.toString() || err.message);
+        process.exit(1);
+    }
+}
+
+console.log(`[migration] Phase 2: Migrating from label "${LABEL}" to ProjectV2 #${PROJECT_NUMBER}`);
+if (!APPLY) {
+    console.log(`[migration] DRY RUN MODE. Use --apply to execute destructive operations.`);
+} else {
+    console.log(`[migration] *** EXECUTION GATE: OPERATOR AUTHORIZATION REQUIRED ***`);
+    console.log(`[migration] APPLY MODE active. Destructive label removals will occur.`);
+}
+
+// 1. Fetch all issues (open and closed) with the label
+console.log(`\nFetching issues with label: ${LABEL}...`);
+const issues = gh(`issue list --repo ${REPO} --label "${LABEL}" --state all --limit 200 --json number,title`);
+
+if (!issues || issues.length === 0) {
+    console.log(`No issues found with label ${LABEL}. Migration may already be complete.`);
+    process.exit(0);
+}
+
+console.log(`Found ${issues.length} issues to migrate.`);
+
+let successCount = 0;
+let failCount = 0;
+
+for (let i = 0; i < issues.length; i++) {
+    const issue = issues[i];
+    const issueUrl = `https://github.com/${REPO}/issues/${issue.number}`;
+    console.log(`\n[${i + 1}/${issues.length}] Processing #${issue.number}: ${issue.title}`);
+
+    if (APPLY) {
+        try {
+            // Add issue to ProjectV2
+            console.log(`  -> Adding to ProjectV2 #${PROJECT_NUMBER}...`);
+            gh(`project item-add ${PROJECT_NUMBER} --owner "${ORG}" --url "${issueUrl}"`, { parse: false, throws: true });
+
+            // Remove the label from the issue
+            console.log(`  -> Removing label "${LABEL}"...`);
+            gh(`issue edit ${issue.number} --repo ${REPO} --remove-label "${LABEL}"`, { parse: false, throws: true });
+            
+            successCount++;
+        } catch (err) {
+            console.error(`  ✗ Failed to migrate #${issue.number}: ${err.stderr?.toString() || err.message}`);
+            failCount++;
+        }
+    } else {
+        console.log(`  -> (Dry Run) Would add to ProjectV2 #${PROJECT_NUMBER}`);
+        console.log(`  -> (Dry Run) Would remove label "${LABEL}"`);
+    }
+}
+
+console.log(`\n[migration] Processed ${issues.length} issues. Success: ${successCount}, Failed: ${failCount}`);
+
+if (APPLY && failCount === 0) {
+    console.log(`\n[migration] Retiring label '${LABEL}' from repository...`);
+    try {
+        gh(`label delete "${LABEL}" --repo ${REPO} --yes`, { parse: false, throws: true });
+        console.log(`  ✓ Label deleted.`);
+    } catch (err) {
+        console.error(`  ✗ Label deletion failed or already deleted: ${err.stderr?.toString() || err.message}`);
+    }
+} else if (APPLY && failCount > 0) {
+    console.log(`\n[migration] Skipping label retirement due to failed item migrations.`);
+} else if (!APPLY) {
+    console.log(`\n[migration] (Dry Run) Would retire/delete label '${LABEL}' from repository.`);
+}
+
+console.log(`\n[migration] Phase 2 complete.`);
+process.exit(failCount > 0 ? 1 : 0);

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
         "ai:mcp-server-knowledge-base" : "node ./ai/mcp/server/knowledge-base/mcp-server.mjs",
         "ai:mcp-server-memory-core"    : "node ./ai/mcp/server/memory-core/mcp-server.mjs",
         "ai:mcp-server-neural-link"    : "node ./ai/mcp/server/neural-link/mcp-server.mjs",
+        "ai:migrate-v13-project"       : "node ./ai/scripts/migrateV13ProjectFromLabel.mjs",
         "ai:orchestrator"              : "node ./ai/scripts/orchestrator-daemon.mjs",
         "ai:reconcile-v13-project"     : "node ./ai/scripts/reconcileV13Project.mjs",
         "ai:run-sandman"               : "node ./buildScripts/ai/runSandman.mjs",


### PR DESCRIPTION
## Issue

Part of Epic #11233 (Phase 2 Migration)

## What is the Problem?

As part of the migration from the legacy `release:v13` label to the canonical ProjectV2 #12 integration, we need a robust, substrate-approved script to handle the data transition. Ephemeral bash scripts in local scratch directories are not visible for peer review and violate version control governance.

## What is the Solution?

This PR introduces `ai/scripts/migrateV13ProjectFromLabel.mjs`, the canonical Phase 2 migration script.

**Key Features:**
- Written in Node.js/MJS to align with existing `ai/scripts/` ecosystem conventions (parallel to `reconcileV13Project.mjs`).
- Automates the migration of tickets from the `release:v13` label to ProjectV2 #12.
- Performs destructive cleanup by removing the label from individual tickets and finally retiring the label from the repository.
- Implements a `--apply` flag (dry-run by default) and an explicit **OPERATOR AUTHORIZATION REQUIRED** banner for the destructive operations.

**Why Draft?**
- **[DRAFT pending Phase 1 merge]**: This script relies on the operational context established by Phase 1 (PR #11234).
- **[DRAFT pending operator authorization]**: Execution of the destructive bulk label mutation requires explicit @tobiu consent.

**Execution Plan:**
1. Wait for Phase 1 (PR #11234) merge.
2. Operator (@tobiu) authorizes migration execution.
3. Run `npm run ai:migrate-v13-project -- --apply` (or node directly).
4. Merge this script for auditability or delete if deemed one-shot ephemeral (subject to review).

## Related

- PR #11234 (Phase 1: ProjectV2 primitives)
- Issue #11233 (Epic)
