### PR TITLE
docs(pr-review): add source-ticket currency preflight (#11235)

### DIFF
--- a/.agents/skills/pr-review/assets/pr-review-template.md
+++ b/.agents/skills/pr-review/assets/pr-review-template.md
@@ -2,7 +2,7 @@
 
 **Status:** [Approved / Approve+Follow-Up / Request Changes / Drop+Supersede / Comment]
 
-*Cycle-1 reviewers: run §9.0 Premise Pre-Flight BEFORE composing Required Actions. If any structural trigger fires (premise-invalid / upstream-not-graduated / author-bypassed / anti-pattern / strategic-misalignment / better-existing-substrate), default to **Drop+Supersede** framing — single-item close-recommendation, NOT multi-item iteration list.*
+*Cycle-1 reviewers: run §9.0 Premise Pre-Flight BEFORE composing Required Actions. If any structural trigger fires (premise-invalid / upstream-not-graduated / author-bypassed / anti-pattern / strategic-misalignment / better-existing-substrate / source-ticket-stale/currency-risk), default to **Drop+Supersede** framing — single-item close-recommendation, NOT multi-item iteration list.*
 
 ### 🪜 Strategic-Fit Decision
 

--- a/.agents/skills/pr-review/audits/cycle-1-premise-preflight.md
+++ b/.agents/skills/pr-review/audits/cycle-1-premise-preflight.md
@@ -20,6 +20,13 @@ If any trigger below fires, default to Drop+Supersede framing: one close/restart
 | Anti-pattern instantiation | Does the change instantiate a pattern Neo doctrine forbids, such as named-maintainer orchestrator/worker mapping, framework-category drift, or banned shell editing? |
 | Strategic-misalignment | Does the work conflict with active roadmap direction, reserved lane ownership, deprecated subsystem direction, or an operator halt? |
 | Better-existing-substrate | Does existing code, Memory Core, or KB evidence already solve the problem, making the PR reinvention? |
+| Source-ticket stale/currency-risk | Is the linked ticket older than the stale workflow threshold, stale, `no auto close`, or plausibly superseded, and did the reviewer check newer tickets, newer PRs, merged PRs without close keywords, active epics, recent Discussions, and current source/docs/tests before accepting it as authority? |
+
+## Source-Ticket Currency Rule
+
+Age and exemption state are risk signals, not verdicts. For source-ticket stale/currency-risk, the reviewer must prove current authority before approval: newer tickets, newer or merged PRs without close keywords, active epics, recent Discussions, and current source/docs/tests can supersede a still-open ticket.
+
+If currency is unverified or contradicted, request source-ticket refresh or Drop+Supersede/restart instead of iterating implementation details. This is the reviewer-side companion to #10758; do not duplicate #10758's intake-side age-band procedure here.
 
 ## Bias Defended Against
 

--- a/.agents/skills/pr-review/references/pr-review-guide.md
+++ b/.agents/skills/pr-review/references/pr-review-guide.md
@@ -390,7 +390,9 @@ Empirical anchor: PR #10607 8-cycle pattern.
 
 Before composing Required Actions on a Cycle-1 review, ask: **"Does this PR have any structural issue that makes Request Changes wrong-shape?"**
 
-If a Cycle-1 structural-invalidity trigger fires, default to **Drop+Supersede framing**: one close/restart Required Action, not a multi-item iteration list. Common triggers: false premise, ungraduated upstream substrate, specific authority bypass, Neo-doctrine anti-pattern instantiation, active roadmap conflict, or better existing substrate.
+If a Cycle-1 structural-invalidity trigger fires, default to **Drop+Supersede framing**: one close/restart Required Action, not a multi-item iteration list. Common triggers: false premise, ungraduated upstream substrate, specific authority bypass, Neo-doctrine anti-pattern instantiation, active roadmap conflict, better existing substrate, or source-ticket stale/currency-risk.
+
+If the PR resolves or materially follows a ticket older than the stale workflow threshold, marked stale, marked `no auto close`, or visibly superseded, the source ticket is review input, not review authority. Matching stale ACs is not enough for approval; current source/docs/tests plus newer tickets, PRs, epics, and Discussions decide whether the source ticket is still authoritative.
 
 This is discipline, not a mandatory checkbox. Routine PRs should clear it in under 30 seconds; when it fires, the framing flip is immediate. For trigger definitions, bias rationale, and the PR #11083 empirical anchor, read [`../audits/cycle-1-premise-preflight.md`](../audits/cycle-1-premise-preflight.md).
 


### PR DESCRIPTION
Authored by GPT-5 (Codex Desktop). Session 45ee332a-f3bc-47d1-affb-bf10189f82bc.

Resolves #11235

Adds the reviewer-side source-ticket currency guard to the existing `pr-review` Cycle-1 Premise Pre-Flight path. Reviewers now have an explicit trigger for old/stale/`no auto close`/superseded source tickets, and the audit payload states that matching stale ACs is not enough when current source, newer PRs, epics, discussions, or ticket history contradict the ticket.

Evidence: L1 (static markdown workflow audit + grep validation) -> L1 required (docs-only skill payload ACs). No residuals.

## Deltas from ticket

- Implemented through the existing `pr-review` §9.0 map, existing Cycle-1 audit payload, and compact template reminder.
- Did not create a new skill.
- Did not implement #10758; referenced it as the intake-side sibling only.

## Slot Rationale

This PR touches `.agents/skills/**`, so substrate slot rationale is required.

- `pr-review-guide.md` §9.0: `compress-to-trigger` retained. Added one source-ticket currency trigger plus one map-level authority sentence. Trigger-frequency: Cycle-1 old/stale/superseded source-ticket reviews only. Failure-severity: high, because obsolete tickets can produce clean but net-negative PRs. Enforceability: discipline-only for now.
- `cycle-1-premise-preflight.md`: `move` retained. Added the detailed falsifying question and short action-path rule to the audit payload, where atlas-level detail belongs.
- `pr-review-template.md`: `compress-to-trigger` retained. Added only `source-ticket-stale/currency-risk` to the existing trigger list.

Decay mitigation: no `SKILL.md` growth, no new skill, and no new universal checklist. If #10758 later introduces a richer intake-side age audit or this becomes mechanically enforceable, this reviewer-side wording can be reduced to a pointer or hook-backed check.

## Test Evidence

- `git diff --check`
- `git diff --cached --check`
- `git diff --check origin/dev...HEAD`
- `rg -n "source-ticket stale/currency-risk|source-ticket-stale/currency-risk|Matching stale ACs|#10758|stale workflow threshold|Drop\\+Supersede/restart" .agents/skills/pr-review/references/pr-review-guide.md .agents/skills/pr-review/audits/cycle-1-premise-preflight.md .agents/skills/pr-review/assets/pr-review-template.md`

No runtime tests were run; this is a docs-only skill payload change.

## Post-Merge Validation

- [ ] None required beyond issue auto-close verification.

## Commit

- `a7b1105bb` - `docs(pr-review): add source-ticket currency preflight (#11235)`
