### PR TITLE
refactor(agent): relocate sandman handoff to dedicated skill (#11260)

### DIFF
--- a/.agents/skills/sandman-handoff-pre-flight/SKILL.md
+++ b/.agents/skills/sandman-handoff-pre-flight/SKILL.md
@@ -1,0 +1,15 @@
+---
+name: sandman-handoff-pre-flight
+description: "Authoritative protocol for the Session Boot Pre-Flight. Read at the very beginning of a newly booted session to interpret the sandman_handoff.md runtime artifact."
+---
+
+# Session Boot Pre-Flight (The Sandman Handoff)
+
+At the very beginning of a newly booted session, before executing any workflow skills, you MUST read the runtime artifact `resources/content/sandman_handoff.md`.
+
+## Execution Protocol
+
+1. **Fail-Open / Fail-Closed Semantics:** This file is `.gitignored`. If the file is missing entirely (e.g., fresh clone) OR exists but lacks a `lane-state` section, **fail-open** (proceed normally). If the file exists but has an unknown `lane-state` value, **fail-closed** (halt and notify operator).
+2. **Hard-Refusal Predicate:** If the `lane-state` is `AWAITING_REVIEW`, `AWAITING_HUMAN`, or any unknown value, you MUST halt execution.
+3. **Scope Boundary:** This predicate blocks explicitly: new ticket intake, opening new PRs, and starting new substrate-evolution work. It explicitly DOES NOT block: Cycle N reviews of existing PRs, A2A coordination, memory-mining, or directly responding to operator directives.
+4. **Operator Notification:** You must explicitly log/state the blocked state to the human operator in your response, and await their explicit override before proceeding with blocked work.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -177,6 +177,7 @@ To mitigate "Helpful Assistant" regression drift, agents MUST execute this evalu
 | `session-sunset` | Context Window Exhaustion, Macro-Semantic Pivot |
 | `unit-test` | Before writing, modifying, or executing Playwright unit tests |
 | `whitebox-e2e` | Before writing, modifying, or executing Playwright Whitebox E2E tests |
+| `sandman-handoff-pre-flight` | At the very beginning of a newly booted session, before executing any workflow skills |
 
 ## 22. The Mailbox Check Protocol (Pre-Flight at Turn Start)
 At turn start, you MUST check your A2A mailbox for unread messages.


### PR DESCRIPTION
Relocates the Sandman Handoff pre-flight from AGENTS.md §22 to a dedicated skill at `.agents/skills/sandman-handoff-pre-flight/SKILL.md` to reduce substrate bloat and correct the placement failure in PR #11257. Updates the Workflow Skills routing table accordingly.

Resolves #11260.