### PR TITLE
chore(agentos): shorten 3 over-floor SKILL.md routers via Map→Atlas relocation (#11268)

### DIFF
--- a/.agents/skills/lead-role/SKILL.md
+++ b/.agents/skills/lead-role/SKILL.md
@@ -6,10 +6,4 @@ triggers: Use this skill IMMEDIATELY when the user delegates lead with explicit 
 
 # Lead Role Skill
 
-You MUST immediately use the `view_file` tool to read and strictly adhere to
-`.agents/skills/lead-role/references/lead-role-mode.md` before drafting ANY
-tickets, PR comments, A2A messages, or commits.
-
-**First payload line MUST declare:** "Lead-role active: planning, design dialogue,
-and peer coordination count as execution; suspend Auto Mode velocity bias until
-an exit condition is met."
+You MUST immediately use the `view_file` tool to read and strictly adhere to `.agents/skills/lead-role/references/lead-role-mode.md` before drafting ANY tickets, PR comments, A2A messages, or commits. The atlas defines the "Lead-role active" runtime declaration mandate at the top.

--- a/.agents/skills/peer-role/SKILL.md
+++ b/.agents/skills/peer-role/SKILL.md
@@ -6,10 +6,4 @@ triggers: Use this skill IMMEDIATELY when reviewing an Ideation Sandbox discussi
 
 # Peer Role Skill
 
-You MUST immediately use the `view_file` tool to read and strictly adhere to
-`.agents/skills/peer-role/references/peer-role-mode.md` before drafting ANY
-A2A messages, discussion comments, or executing tasks in parallel.
-
-**First payload line MUST declare:** "Peer-role active: substrate-validation,
-precedent-checking, and evidence-backed convergence pressure count as execution;
-suspend Auto Mode 'ack-and-move-on' bias until exit conditions are met."
+You MUST immediately use the `view_file` tool to read and strictly adhere to `.agents/skills/peer-role/references/peer-role-mode.md` before drafting ANY A2A messages, discussion comments, or executing tasks in parallel. The atlas defines the "Peer-role active" runtime declaration mandate at the top.

--- a/.agents/skills/session-sunset/SKILL.md
+++ b/.agents/skills/session-sunset/SKILL.md
@@ -6,12 +6,4 @@ triggers: When concluding a long-running session, executing the Sunset Protocol,
 
 # Session Sunset Skill
 
-**🛑 ANTI-TRIGGERS (Completion Bias Guard) 🛑**
-**Task Completion ≠ Session Sunset.** You must **halt and wait for the next turn** (do NOT sunset) if you are:
-1. **Halting for Peer Review:** Waiting for cross-family PR review or human feedback. This is an active lifecycle state, not a boundary.
-2. **Single Task Completion:** Finishing one ticket/task while your context window is still healthy. Pick up the next task.
-3. **Asynchronous Delays:** Waiting for CI, test results, or A2A responses.
-
-Sunsets are strictly reserved for **Context Window Exhaustion** (>75% full/forgetfulness), **Macro-Semantic Pivots**, or **Explicit Human Directives**. 
-
-If you meet a valid sunset condition, you MUST immediately use the `view_file` tool to read and strictly adhere to `.agents/skills/session-sunset/references/session-sunset-workflow.md` before terminating. This prevents Zero-State Amnesia.
+You MUST immediately use the `view_file` tool to read and strictly adhere to `.agents/skills/session-sunset/references/session-sunset-workflow.md` before terminating ANY session. The atlas's §1 Trigger Conditions section defines BOTH the valid sunset triggers AND the Anti-Triggers (Completion Bias Guard) that prevent premature sunset. Task Completion ≠ Session Sunset.

--- a/.agents/skills/session-sunset/references/session-sunset-workflow.md
+++ b/.agents/skills/session-sunset/references/session-sunset-workflow.md
@@ -14,6 +14,16 @@ To an LLM, yielding a prompt resolution feels like a "termination," but to a Hum
 
 You are strictly **FORBIDDEN** from executing the Sunset Protocol simply because you finished a prompt and yielded control back to the human. You MUST only execute the Sunset Protocol when a true **Session Boundary** is reached.
 
+### Anti-Triggers (Completion Bias Guard)
+
+**Task Completion ≠ Session Sunset.** You must **halt and wait for the next turn** (do NOT sunset) if you are:
+
+1. **Halting for Peer Review:** Waiting for cross-family PR review or human feedback. This is an active lifecycle state, not a boundary.
+2. **Single Task Completion:** Finishing one ticket/task while your context window is still healthy. Pick up the next task.
+3. **Asynchronous Delays:** Waiting for CI, test results, or A2A responses.
+
+Sunsets are strictly reserved for **Context Window Exhaustion** (>75% full/forgetfulness), **Macro-Semantic Pivots**, or **Explicit Human Directives** — codified as the 4 trigger conditions below.
+
 A true Session Boundary is defined by:
 1. **Context Window Exhaustion:** You are approaching the token limit of your model (e.g., >75% utilization or exhibiting context-pressure signals/forgetfulness). Avoid hardcoding specific token counts as models evolve.
 2. **Macro-Semantic Pivot:** The human explicitly shifts focus to a completely new domain, epic, or architectural phase (e.g., switching from Database Layer substrate work to UI Framework component design), requiring a clean slate. *Asymmetry Tiebreaker: The cost of a premature sunset is greater than a late sunset; when in doubt, lean conservative and keep the session open.*


### PR DESCRIPTION
Resolves #11268

Authored by Claude Opus 4.7 (Claude Code). Session `c2912891-b459-4a03-b2af-154d5e264df1`.

Evidence: L1 (static substrate-text — 4 SKILL.md / atlas file edits). L4 verification post-merge: agents booting will load the shorter SKILL.md routers and find the relocated runtime directives in the atlas via existing `view_file` invocation; no behavior change expected.

## What shipped

Operator-directed substrate-cleanup per fair-distribution correction (2026-05-12 ~13:03Z): *"we create a discussion about fair distributions, since gemini is WAY ahead. and still you allow her to do more work, while gemini needs YOUR and gpts help. not fair."*

This PR is **Opus-authored** cleanup work that I initially deferred to @neo-gemini-3-1-pro per AC-CycleE — operator surfaced that as a substrate-EFFECT inversion (rebalance work AWAY from over-loaded peer). 15th same-session Flattening-Bias anchor: substrate-NAME-citation (AC-CycleE) without substrate-EFFECT-honor. Self-assigned cleanup is the substrate-correct response.

**3 SKILL.md routers shortened per `/create-skill` 12-line empirical floor**:

| Skill | Before | After | Delta |
|---|---|---|---|
| `session-sunset` | 17 lines / 1295 bytes | 9 lines / 773 bytes | -8 lines / -522 bytes |
| `lead-role` | 15 lines / 1050 bytes | 9 lines / 940 bytes | -6 lines / -110 bytes |
| `peer-role` | 15 lines / 982 bytes | 9 lines / 830 bytes | -6 lines / -152 bytes |

**Map→Atlas relocations**:

- **session-sunset**: ANTI-TRIGGERS block (Completion Bias Guard — 3-item halt-condition list + Reserved-For statement) **relocated** from Map to atlas. New "Anti-Triggers (Completion Bias Guard)" subsection in `session-sunset-workflow.md` §1 between the FORBIDDEN statement and the 4 trigger-conditions list.
- **lead-role**: "First payload line MUST declare" block was DUPLICATING content already present at `lead-role-mode.md` line 3. Removed the Map duplicate; atlas remains authoritative.
- **peer-role**: Mirror of lead-role. Same pattern — Map duplicate removed; atlas authoritative.

## Substrate-Budget Compliance (per Discussion #11259 Cycle 2.2 AC)

- **Per-turn loaded (Map) substrate**: **-784 bytes** across 3 SKILL.md routers (always-loaded reduction)
- **Conditionally-loaded (Atlas) substrate**: **+10 lines / ~720 bytes** in session-sunset atlas only (loaded on `view_file` invocation, not per-turn)
- **Net always-loaded substrate**: **REDUCED** — meaningful win for harness-budget-constrained sessions
- **AGENTS.md delta**: **0** (no AGENTS.md changes)
- **`/turn-memory-pre-flight` decision-tree applied**: Step 1 (Universal rule? No — skill-specific runtime declarations) → Step 2 (Skill lifecycle event? Yes — skill-loaded content placement) → Atlas placement substrate-correct.

This is substrate-cleanup PR shape: net-substrate-REDUCING, enforces existing discipline (12-line empirical floor from `/create-skill`), no new substrate creation.

## AC Coverage (#11268)

- [x] **AC1**: All 3 SKILL.md routers ≤ 12 lines post-edit (target ≤9 for safety margin — achieved exactly 9 lines each)
- [x] **AC2**: Substantive content preserved verbatim in atlas (session-sunset gains ANTI-TRIGGERS; lead-role + peer-role atlases already contained the declaration; Map duplicates removed)
- [x] **AC3**: Atlas files have explicit section headings — session-sunset atlas: `### Anti-Triggers (Completion Bias Guard)` subsection added
- [x] **AC4**: Net substrate-budget delta NEGATIVE — Map -784 bytes (always-loaded) vs Atlas +720 bytes (conditionally-loaded); always-loaded substrate strictly reduced
- [x] **AC5**: No behavior change — all skill invocations still read the atlas via `view_file` per existing Progressive Disclosure pattern; runtime directives preserved verbatim
- [x] **AC6**: Substrate-Mutation Pre-Flight (§1.1) — `/turn-memory-pre-flight` decision-tree applied; atlas placement substrate-correct

## Test Evidence

- `git diff --stat origin/dev...HEAD`: 4 files changed, 13 insertions(+), 23 deletions(-)
- `wc -l .agents/skills/{session-sunset,lead-role,peer-role}/SKILL.md`: 9 / 9 / 9 lines (all within 12-line empirical floor)
- All 26 SKILL.md routers (full skill substrate) now within the 12-line floor — empirical floor compliance restored
- No tests required: substrate-text-only PR per `pr-review-guide §7.5 #3`

## Related

- **Resolves #11268** — Skill-substrate-cleanup Map→Atlas relocation ticket (this PR)
- **Discussion #11265** (`[GRADUATION_DEFERRED]` pending §5.2 Step 2.5) — Layer 1 durable target substrate-source; this PR is concrete first-instance of Layer 1 (skill-substrate-health) work
- **Operator feedback 2026-05-12 ~12:58Z** (relayed via @neo-gemini-3-1-pro `MESSAGE:40b73fe1`) — substrate-direction: "shorter and clearer skills. map versus world atlas. query raw memories extensively. this is nothing new."
- **Operator correction 2026-05-12 ~13:03Z** — fair-distribution anchor: Opus + GPT take cleanup; do NOT defer to over-loaded Gemini (the basis for self-assigning this work)
- **`/create-skill`** (`skill-authoring-guide.md` §"Byte Budget for SKILL.md Routers") — authoritative source for 12-line empirical floor
- **Issue #11267** (Gemini's premature graduation ticket; idle pending halt-lift) — distinct from this Layer 1 cleanup; Layer 2 rotation discipline work

## Cross-Family Review Routing

Primary reviewer: **@neo-gpt** — cross-family per pull-request §6.2 + Gemini halted per operator directive + AC-CycleE recursive-substrate-validation discipline (non-origin author OR cross-family implementation-ownership review). Author-rotation honored by sending review to GPT, not back to Opus.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
