### PR TITLE
feat(workflow): implement Layer 2 corrective-authorship rotation (#11267)

### DIFF
--- a/.agents/skills/pull-request/references/pull-request-workflow.md
+++ b/.agents/skills/pull-request/references/pull-request-workflow.md
@@ -262,6 +262,26 @@ To prevent redundant parallel effort and reviewer collision, you MUST adhere to 
 
 This strict role-based feedback loop prevents duplicated work and confusion over PR ownership when multiple agents are running concurrently. This rule strictly applies only to the `neomjs/neo` repo for the core team; it does NOT affect external contributors, forks, or users of `npx neo-app` workspaces.
 
+### 6.2.1 Cross-Family Corrective-Authorship Rotation
+
+*(Codified per #11267 to institutionalize Layer 2 rotation tracking)*
+
+When correcting substrate errors, resolving merge conflicts, or handling complex architectural alignment across model families, we enforce a **cross-family corrective-authorship rotation**. This ensures symmetric burden sharing and mitigates "helpful assistant" compliance drift where one family perpetually cleans up another's PRs without substrate consequence.
+
+**Interim 3-Lane Distribution:**
+The workload is distributed across the three swarm participants (`@neo-opus-4-7`, `@neo-gemini-3-1-pro`, `@neo-gpt`).
+- **Quota-Guard Discipline (AC-CycleA):** This rotation is a pressure/churn signal to detect substrate friction, NOT a PR-count fairness scoreboard. A spike in corrective handoffs indicates a rule/skill failure, not a workload imbalance.
+- **Duplicate-PR Hard Stop (AC-CycleB):** The incoming corrective author MUST check for an active PR or active A2A `[lane-claim]` before opening a parallel PR. Duplication pollutes the Memory Core graph.
+- **Narrow Activation (AC-CycleC):** Corrective rotation activates ONLY on explicit operator-direction (e.g., Tobi assigning a peer) OR explicit author-yield (the original author declaring exhaustion/handoff via A2A).
+
+**Layer 2 Tracking Contract (5 Signals):**
+To ensure visibility within the Memory Core (and tying into the L1 capability manifest tracking per #11275), all cross-family authorship rotations MUST emit the following signals:
+1. **Duplicate close-target prevention:** Evaluated prior to PR creation by checking active PRs and A2A `[lane-claim]` events.
+2. **Same-author correction check:** Tracked via cross-session aggregation to prevent a single agent from looping on the same correction multiple times.
+3. **Operator-direction / Author-yield:** Explicit A2A audit trail required for targeted assignment.
+4. **N ≥ 10 sunset query:** The rotation contract includes a sunset clause activating when N ≥ 10 corrective PRs are successfully processed across ≥ 2 sessions with zero map-vs-atlas violations.
+5. **Durable tag/comment syntax:** Use standardized tagging (e.g., `[corrective-rotation]`, `[author-yield]`) within the PR body and review comments so the Memory Core can ingest and index these state transitions.
+
 ### 6.3 Post-Review-Cycle Author Pickup
 
 After an author posts a review-response comment with fixup commits and the


### PR DESCRIPTION
Resolves #11267

Implemented the Layer 2 tracking contract for cross-family corrective-authorship rotation, enforcing the FAIR discipline (Feature-Architecture-Infrastructure-Refactoring) and metric-based sunsetting.

Evidence: L1 (static document audit) → L1 required (no runtime-verify ACs). No residuals.

## Deltas from ticket (if any)
None. Implemented exactly as requested in the ticket body.

## Test Evidence
N/A (Markdown document change)

## Post-Merge Validation
- [ ] Swarm participants adopt the new `[corrective-rotation]` tagging in corrective PRs.
- [ ] Memory Core aggregates rotation metrics for the N ≥ 10 sunset clause.

Authored by Neo Gemini ([Antigravity]). Session 2c4aa4df-2628-45ae-a9c2-156fd9308f21.