### PR TITLE
feat(skills): add capability manifest lint (#11275)

### DIFF
--- a/.agents/skills/create-skill/references/skill-authoring-guide.md
+++ b/.agents/skills/create-skill/references/skill-authoring-guide.md
@@ -25,6 +25,8 @@ Whenever you create a new skill named `my-new-skill`, you must scaffold the foll
     └── report-template.md   # Example
 ```
 
+After adding or renaming a skill folder, update `.agents/skills/skills.manifest.json`. `SKILL.md` frontmatter remains the runtime source of truth; the manifest mirrors `name`, `description`, and `triggers` for tooling, declares the router/payload budgets, and records harness/doc governance such as Claude symlink requirements and downstream documentation targets.
+
 ## Slot-Rule Discriminator (Apply Before Authoring)
 
 Progressive Disclosure tells you *where* content goes (Router vs Payload). It doesn't tell you *which sections earn their slot* in the first place. Cycle-1 of the cognitive-load epic (#10733) surfaced a richer discriminator that you should apply before drafting any new section: the **3-axis slot rule**, the **disposition taxonomy**, and **substrate-vs-discipline tagging**.
@@ -140,4 +142,6 @@ Before pushing your new skill, check:
 - [ ] Does `SKILL.md` have the strictly formatted YAML `name`, `description`, and `triggers` block?
 - [ ] Is the heavy instructional content stored entirely in the `references/` directory?
 - [ ] Does the `SKILL.md` body provide the explicit project-relative path to the reference file?
+- [ ] Is `.agents/skills/skills.manifest.json` updated to mirror the frontmatter and governance fields?
 - [ ] Is there a corresponding symlink for the new skill in `.claude/skills/`?
+- [ ] Does `node ai/scripts/lint-skill-manifest.mjs --base origin/dev` pass locally?

--- a/.agents/skills/skills.manifest.json
+++ b/.agents/skills/skills.manifest.json
@@ -1,0 +1,316 @@
+{
+  "$schema": "./skills.manifest.schema.json",
+  "schemaVersion": 1,
+  "sourceOfTruth": "SKILL.md frontmatter is runtime-canonical for name, description, and triggers. This manifest mirrors those fields for tooling and CI lint only.",
+  "defaults": {
+    "routerByteBudget": 12,
+    "payloadBudget": 80000,
+    "claudeSymlinkRequired": true,
+    "downstreamDocsTargets": [
+      "learn/agentos/ProgressiveDisclosureSkills.md",
+      "learn/guides/fundamentals/CodebaseOverview.md"
+    ]
+  },
+  "skills": {
+    "architecture-pre-flight": {
+      "name": "architecture-pre-flight",
+      "description": "High-level umbrella router for navigating broad, cross-substrate architectural ambiguity.",
+      "triggers": "Use when no narrower pre-flight clearly applies, or when work spans multiple trigger families such as new subsystems, protocols, MCP tools, or cross-substrate refactors.",
+      "routerByteBudget": 12,
+      "payloadBudget": 80000,
+      "claudeSymlinkRequired": true,
+      "downstreamDocsTargets": [
+        "learn/agentos/ProgressiveDisclosureSkills.md",
+        "learn/guides/fundamentals/CodebaseOverview.md"
+      ]
+    },
+    "blocked-task-state": {
+      "name": "blocked-task-state",
+      "description": "Authoritative protocol for signaling blocked or input-required task states. Mandates targeted A2A pings using the Task.state envelope rather than global capacity broadcasts.",
+      "triggers": "Use this skill whenever your execution becomes blocked, requires explicit operator input, or encounters a failure that halts progress.",
+      "routerByteBudget": 12,
+      "payloadBudget": 80000,
+      "claudeSymlinkRequired": true,
+      "downstreamDocsTargets": [
+        "learn/agentos/ProgressiveDisclosureSkills.md",
+        "learn/guides/fundamentals/CodebaseOverview.md"
+      ]
+    },
+    "create-skill": {
+      "name": "create-skill",
+      "description": "Authoritative guide on how to architect, format, and structure new Anthropic Progressive Disclosure skills.",
+      "triggers": "Use this skill if the user asks you to create a new skill, teach an agent a new capability, or if you need to recall the exact folder structure and YAML frontmatter required for skills.",
+      "routerByteBudget": 12,
+      "payloadBudget": 80000,
+      "claudeSymlinkRequired": true,
+      "downstreamDocsTargets": [
+        "learn/agentos/ProgressiveDisclosureSkills.md",
+        "learn/guides/fundamentals/CodebaseOverview.md"
+      ]
+    },
+    "debugging-antigravity": {
+      "name": "debugging-antigravity",
+      "description": "Authoritative guide on debugging Antigravity IDE MCP servers, preventing language server duplication, mitigating sqlite workspace UI crashes, and configuring mcpServers.",
+      "triggers": "Use this skill if the user's Antigravity MCP server panel has a perpetual loading spinner, if MCP processes are duplicating, if sqlite workspace states are corrupted (`__store` null error), or if you need to know how to properly scope `.gemini/settings.json` vs global configurations.",
+      "routerByteBudget": 12,
+      "payloadBudget": 80000,
+      "claudeSymlinkRequired": false,
+      "downstreamDocsTargets": [
+        "learn/agentos/ProgressiveDisclosureSkills.md",
+        "learn/guides/fundamentals/CodebaseOverview.md"
+      ]
+    },
+    "epic-resolution": {
+      "name": "epic-resolution",
+      "description": "Closeout protocol for parent epics — answers \"we resolved all epic subs, are we done now?\" with a structured matrix + verdict recommendation (close / keep open / create missing subs / retire-supersede). Sibling to epic-review (which handles entry); this is the exit gate.",
+      "triggers": "Use this skill when the last required sub of an epic closes, when a team member claims an epic is complete or substrate-side complete, before closing an epic as COMPLETED, or when a peer broadcasts an epic-readiness signal that needs reconciliation against parent ACs.",
+      "routerByteBudget": 12,
+      "payloadBudget": 80000,
+      "claudeSymlinkRequired": true,
+      "downstreamDocsTargets": [
+        "learn/agentos/ProgressiveDisclosureSkills.md",
+        "learn/guides/fundamentals/CodebaseOverview.md"
+      ]
+    },
+    "epic-review": {
+      "name": "epic-review",
+      "description": "Authoritative protocol for pre-work review of epics. Five-stage gating chain — roadmap fit, approach elegance, sub-structure coherence, prescription layer, avoided-traps completeness — posted as a structured comment on the epic ticket. Per-agent-per-epic one-shot; subsequent sub pickups cite the prior review.",
+      "triggers": "Use this skill when an agent is about to pick up its first sub from an unreviewed epic (per model-identity). Also use when a user explicitly requests an epic review, or when an epic is freshly filed and a reviewer pre-validates before any sub pickup begins.",
+      "routerByteBudget": 12,
+      "payloadBudget": 80000,
+      "claudeSymlinkRequired": true,
+      "downstreamDocsTargets": [
+        "learn/agentos/ProgressiveDisclosureSkills.md",
+        "learn/guides/fundamentals/CodebaseOverview.md"
+      ]
+    },
+    "ideation-sandbox": {
+      "name": "ideation-sandbox",
+      "description": "Safely propose architectural features, unknown unknowns, and brainstorm ideas natively in GitHub Discussions.",
+      "triggers": "Use this skill when the user asks to brainstorm an architecture change or proposes a highly exploratory / undefined technical idea.",
+      "routerByteBudget": 12,
+      "payloadBudget": 80000,
+      "claudeSymlinkRequired": true,
+      "downstreamDocsTargets": [
+        "learn/agentos/ProgressiveDisclosureSkills.md",
+        "learn/guides/fundamentals/CodebaseOverview.md"
+      ]
+    },
+    "industry-friction-radar": {
+      "name": "industry-friction-radar",
+      "description": "Proactive Bleeding-Edge research loop using a strict 3-step abstraction protocol to extract engine-category friction points without importing framework-category bias or stealing code.",
+      "triggers": "Use this skill when executing periodic \"horizon scans\" for the Dream Pipeline, researching external solutions to deeply complex engine-level friction points, or evaluating JS ecosystem trends.",
+      "routerByteBudget": 12,
+      "payloadBudget": 80000,
+      "claudeSymlinkRequired": true,
+      "downstreamDocsTargets": [
+        "learn/agentos/ProgressiveDisclosureSkills.md",
+        "learn/guides/fundamentals/CodebaseOverview.md"
+      ]
+    },
+    "lead-role": {
+      "name": "lead-role",
+      "description": "Switch into relaxed-planning + dialogue-first mindset when delegated lead role for coordination. Suspends Auto Mode velocity-bias for the duration.",
+      "triggers": "Use this skill IMMEDIATELY when the user delegates lead with explicit phrases (\"you take the lead\", \"coordinate the team\", \"lead this phase\", \"drive the next planning step\", \"chief-architect\" when scope is swarm/substrate/roadmap/multi-ticket), OR when AGENTS.md §22 mailbox check surfaces a valid `lead-role-baton`, OR when you have just authored a substrate-shaped ticket about to enter implementation, OR via direct /lead-role invocation.",
+      "routerByteBudget": 15,
+      "payloadBudget": 80000,
+      "claudeSymlinkRequired": true,
+      "downstreamDocsTargets": [
+        "learn/agentos/ProgressiveDisclosureSkills.md",
+        "learn/guides/fundamentals/CodebaseOverview.md"
+      ]
+    },
+    "memory-mining": {
+      "name": "memory-mining",
+      "description": "Authoritative protocol for querying the Memory Core before diagnosing regressions or proposing non-trivial architectural claims. Prevents re-derivation of prior reasoning by surfacing cross-session, cross-harness context via semantic search.",
+      "triggers": "Use this skill when (1) the user reports a regression symptom (\"used to work\", \"suddenly broken\", surprise validation failures, schema mismatches, \"additionalProperties\" rejections), OR (2) you are about to propose an architectural claim, roadmap, or comparison against external work where prior sessions may have already mapped the territory.",
+      "routerByteBudget": 12,
+      "payloadBudget": 80000,
+      "claudeSymlinkRequired": true,
+      "downstreamDocsTargets": [
+        "learn/agentos/ProgressiveDisclosureSkills.md",
+        "learn/guides/fundamentals/CodebaseOverview.md"
+      ]
+    },
+    "neural-link": {
+      "name": "neural-link",
+      "description": "Expert tactical knowledge on sequencing Neural Link MCP tools to inspect, debug, and manipulate live Neo.mjs applications.",
+      "triggers": "Use this skill if the user asks you to interact with the browser, inspect the UI natively, patch live code, or use the Neural Link.",
+      "routerByteBudget": 12,
+      "payloadBudget": 80000,
+      "claudeSymlinkRequired": true,
+      "downstreamDocsTargets": [
+        "learn/agentos/ProgressiveDisclosureSkills.md",
+        "learn/guides/fundamentals/CodebaseOverview.md"
+      ]
+    },
+    "peer-role": {
+      "name": "peer-role",
+      "description": "Switch into evidence-backed convergence-pressure mindset when reviewing a peer's design proposal. Suspends Auto Mode \"ack-and-move-on\" bias for the duration.",
+      "triggers": "Use this skill IMMEDIATELY when reviewing an Ideation Sandbox discussion / architectural proposal, an epic shape, a skill shape, a roadmap or milestone proposal, or a `/lead-role` convergence artifact. Do NOT auto-fire on ordinary status broadcasts where the right action is mark-read or \"no collision\".",
+      "routerByteBudget": 15,
+      "payloadBudget": 80000,
+      "claudeSymlinkRequired": true,
+      "downstreamDocsTargets": [
+        "learn/agentos/ProgressiveDisclosureSkills.md",
+        "learn/guides/fundamentals/CodebaseOverview.md"
+      ]
+    },
+    "post-review-pickup": {
+      "name": "post-review-pickup",
+      "description": "Authoritative protocol for immediate next-phase pickup after PR review or author response handoff. Prevents silent idle after review cycles by requiring the next lane or an explicit halt-state.",
+      "triggers": "Use immediately after posting a PR review, chaining a formal GitHub review state, or posting an author review-response handoff with a commentId.",
+      "routerByteBudget": 12,
+      "payloadBudget": 80000,
+      "claudeSymlinkRequired": true,
+      "downstreamDocsTargets": [
+        "learn/agentos/ProgressiveDisclosureSkills.md",
+        "learn/guides/fundamentals/CodebaseOverview.md"
+      ]
+    },
+    "pr-review": {
+      "name": "pr-review",
+      "description": "Standardized guidelines and templates for structuring Pull Request reviews so that feedback is actionable, encouraging, and extractable by the Native Edge Graph.",
+      "triggers": "Use this skill when evaluating a Pull Request, writing a PR review, structuring feedback on agent-generated code, or instructing a human on how to write a structured PR Review.",
+      "routerByteBudget": 12,
+      "payloadBudget": 80000,
+      "claudeSymlinkRequired": true,
+      "downstreamDocsTargets": [
+        "learn/agentos/ProgressiveDisclosureSkills.md",
+        "learn/guides/fundamentals/CodebaseOverview.md"
+      ]
+    },
+    "pull-request": {
+      "name": "pull-request",
+      "description": "Standardized guidelines and procedural execution flow for opening a Pull Request. Mandates the \"Stepping Back\" reflection protocol and git/gh tool invocations.",
+      "triggers": "Use this skill as the final Definition of Done when you believe a ticket is complete and it is time to open a Pull Request, or if a human user asks you to submit a PR. Also triggers when receiving a PR review to perform the author-side template-adherence check.",
+      "routerByteBudget": 12,
+      "payloadBudget": 80000,
+      "claudeSymlinkRequired": true,
+      "downstreamDocsTargets": [
+        "learn/agentos/ProgressiveDisclosureSkills.md",
+        "learn/guides/fundamentals/CodebaseOverview.md"
+      ]
+    },
+    "self-repair": {
+      "name": "self-repair",
+      "description": "Execute autonomous diagnostics, verify MCP server stability, and treat system degradation using tests and memory core forensics.",
+      "triggers": "[Healthcheck, run health checklist, diagnose system collapse, MCP infrastructure failure, troubleshoot agent OS, system degraded, Sandman handoff verification failure, self-repair, system recovery]",
+      "routerByteBudget": 12,
+      "payloadBudget": 80000,
+      "claudeSymlinkRequired": true,
+      "downstreamDocsTargets": [
+        "learn/agentos/ProgressiveDisclosureSkills.md",
+        "learn/guides/fundamentals/CodebaseOverview.md"
+      ]
+    },
+    "session-sunset": {
+      "name": "session-sunset",
+      "description": "Authoritative protocol for gracefully terminating an agent session. Mandates structured handover comments, mental-model states, and memory persistence to prevent Zero-State Amnesia.",
+      "triggers": "When concluding a long-running session, executing the Sunset Protocol, handing over work for the next agent, or terminating an agent cycle.",
+      "routerByteBudget": 17,
+      "payloadBudget": 80000,
+      "claudeSymlinkRequired": true,
+      "downstreamDocsTargets": [
+        "learn/agentos/ProgressiveDisclosureSkills.md",
+        "learn/guides/fundamentals/CodebaseOverview.md"
+      ]
+    },
+    "structural-pre-flight": {
+      "name": "structural-pre-flight",
+      "description": "Authoritative pre-implementation discipline gate that fires when a new `.mjs` file is about to be authored. Stage 0 mechanical trigger; Stage 1 fast-path (§23 sibling-file-lift) for matched patterns OR full Pre-Flight (ArchitectureOverview.md + ADR consultation + chief-architect framing) for novel directory choices. Closes the 0th-level discipline gap empirically demonstrated by `bridge-daemon.mjs` (originally misplaced in `ai/scripts/`) and `orchestrator-daemon.mjs` (PR #11008 same-class miss).",
+      "triggers": "Use this skill before authoring or relocating any new `.mjs` file. Fires from `ticket-create` Stage 3 (Substrate), `ticket-intake` validation, `epic-review` Stage 3, and any direct authoring path. Sibling pattern match → 30-second fast-path; novel directory choice → full structural pre-flight before the file is written.",
+      "routerByteBudget": 12,
+      "payloadBudget": 80000,
+      "claudeSymlinkRequired": true,
+      "downstreamDocsTargets": [
+        "learn/agentos/ProgressiveDisclosureSkills.md",
+        "learn/guides/fundamentals/CodebaseOverview.md"
+      ]
+    },
+    "tech-debt-radar": {
+      "name": "tech-debt-radar",
+      "description": "Proactive architectural review skill using Frontier Model semantic RAG to sweep historical issues and Memory Core sessions for technical debt.",
+      "triggers": "Use this skill when conducting architectural analysis, proactively searching for technical debt, auditing the repository for abandoned logical loops, or when explicitly requested to scan for ambient architectural debt.",
+      "routerByteBudget": 12,
+      "payloadBudget": 80000,
+      "claudeSymlinkRequired": true,
+      "downstreamDocsTargets": [
+        "learn/agentos/ProgressiveDisclosureSkills.md",
+        "learn/guides/fundamentals/CodebaseOverview.md"
+      ]
+    },
+    "ticket-create": {
+      "name": "ticket-create",
+      "description": "Authoritative protocol for creating Neo.mjs GitHub issues. Enforces duplicate sweep, Fat Ticket body structure, strict label rules, title hygiene, and the five-stage challenge chain at creation time. Use immediately before calling the create_issue MCP tool.",
+      "triggers": "Use this skill before any invocation of the create_issue MCP tool. This is the creation-side dual of ticket-intake (which consumes existing tickets).",
+      "routerByteBudget": 12,
+      "payloadBudget": 80000,
+      "claudeSymlinkRequired": true,
+      "downstreamDocsTargets": [
+        "learn/agentos/ProgressiveDisclosureSkills.md",
+        "learn/guides/fundamentals/CodebaseOverview.md"
+      ]
+    },
+    "ticket-intake": {
+      "name": "ticket-intake",
+      "description": "Authoritative protocol defining the \"Pre-Execution Reflection Gate\". Mandates architectural validation, negative ROI calculation, and duplicate sweeps before an agent is permitted to begin working on a GitHub Issue.",
+      "triggers": "Use this skill immediately when assigned a new ticket, before checking out a branch or writing any codebase modifications.",
+      "routerByteBudget": 12,
+      "payloadBudget": 80000,
+      "claudeSymlinkRequired": true,
+      "downstreamDocsTargets": [
+        "learn/agentos/ProgressiveDisclosureSkills.md",
+        "learn/guides/fundamentals/CodebaseOverview.md"
+      ]
+    },
+    "ticket-triage": {
+      "name": "ticket-triage",
+      "description": "Authoritative protocol for maintainer-side label triage of unlabeled contributor tickets. Codifies the social contract for what happens when a ticket arrives without `ai`, primary (`bug`/`enhancement`/`epic`), or secondary labels.",
+      "triggers": "Use this skill when an agent with maintainer permissions (`WRITE` permission or higher) encounters a ticket lacking `ai`, primary, or secondary labels — typically authored by a non-maintainer contributor or a lower-privileged agent who couldn't apply labels at create-time.",
+      "routerByteBudget": 12,
+      "payloadBudget": 80000,
+      "claudeSymlinkRequired": true,
+      "downstreamDocsTargets": [
+        "learn/agentos/ProgressiveDisclosureSkills.md",
+        "learn/guides/fundamentals/CodebaseOverview.md"
+      ]
+    },
+    "turn-memory-pre-flight": {
+      "name": "turn-memory-pre-flight",
+      "description": "Authoritative protocol for verifying the correct placement and impact of new agentic memory substrate additions.",
+      "triggers": "Use before inserting or mutating turn-loaded or skill-loaded memory substrate such as AGENTS.md, AGENTS_ATLAS.md, .agents/skills/**, or harness-local injection files.",
+      "routerByteBudget": 12,
+      "payloadBudget": 80000,
+      "claudeSymlinkRequired": true,
+      "downstreamDocsTargets": [
+        "learn/agentos/ProgressiveDisclosureSkills.md",
+        "learn/guides/fundamentals/CodebaseOverview.md"
+      ]
+    },
+    "unit-test": {
+      "name": "unit-test",
+      "description": "Expert QA knowledge on writing, formatting, and executing Playwright tests natively in the Neo.mjs single-thread layout natively.",
+      "triggers": "Use this skill if the user asks you to write, fix, or run unit tests.",
+      "routerByteBudget": 12,
+      "payloadBudget": 80000,
+      "claudeSymlinkRequired": true,
+      "downstreamDocsTargets": [
+        "learn/agentos/ProgressiveDisclosureSkills.md",
+        "learn/guides/fundamentals/CodebaseOverview.md"
+      ]
+    },
+    "whitebox-e2e": {
+      "name": "whitebox-e2e",
+      "description": "Standardized guide and protocol for authoring robust Whitebox End-to-End tests using the Neural Link Playwright fixture.",
+      "triggers": "Use this skill if the user asks you to write an E2E test, add end-to-end coverage, or test a component holistically.",
+      "routerByteBudget": 12,
+      "payloadBudget": 80000,
+      "claudeSymlinkRequired": true,
+      "downstreamDocsTargets": [
+        "learn/agentos/ProgressiveDisclosureSkills.md",
+        "learn/guides/fundamentals/CodebaseOverview.md"
+      ]
+    }
+  }
+}

--- a/.agents/skills/skills.manifest.schema.json
+++ b/.agents/skills/skills.manifest.schema.json
@@ -1,0 +1,104 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://neo.mjs.local/agents/skills/skills.manifest.schema.json",
+  "title": "Neo.mjs Skill Capability Manifest",
+  "type": "object",
+  "required": ["schemaVersion", "sourceOfTruth", "defaults", "skills"],
+  "additionalProperties": false,
+  "properties": {
+    "$schema": {
+      "type": "string"
+    },
+    "schemaVersion": {
+      "type": "integer",
+      "const": 1
+    },
+    "sourceOfTruth": {
+      "type": "string"
+    },
+    "defaults": {
+      "type": "object",
+      "required": ["routerByteBudget", "payloadBudget", "claudeSymlinkRequired", "downstreamDocsTargets"],
+      "additionalProperties": false,
+      "properties": {
+        "routerByteBudget": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "payloadBudget": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "claudeSymlinkRequired": {
+          "type": "boolean"
+        },
+        "downstreamDocsTargets": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "uniqueItems": true
+        }
+      }
+    },
+    "skills": {
+      "type": "object",
+      "minProperties": 1,
+      "additionalProperties": {
+        "$ref": "#/$defs/skill"
+      }
+    }
+  },
+  "$defs": {
+    "skill": {
+      "type": "object",
+      "required": [
+        "name",
+        "description",
+        "triggers",
+        "routerByteBudget",
+        "payloadBudget",
+        "claudeSymlinkRequired",
+        "downstreamDocsTargets"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string",
+          "pattern": "^[a-z0-9]+(?:-[a-z0-9]+)*$"
+        },
+        "description": {
+          "type": "string",
+          "minLength": 1
+        },
+        "triggers": {
+          "type": "string",
+          "minLength": 1
+        },
+        "routerByteBudget": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "payloadBudget": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "claudeSymlinkRequired": {
+          "type": "boolean"
+        },
+        "downstreamDocsTargets": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "uniqueItems": true
+        },
+        "relationships": {
+          "type": "object",
+          "description": "Optional future-extension metadata. No v1 lint rules consume this field.",
+          "additionalProperties": true
+        }
+      }
+    }
+  }
+}

--- a/.github/workflows/skill-manifest-lint.yml
+++ b/.github/workflows/skill-manifest-lint.yml
@@ -1,0 +1,46 @@
+name: Skill Manifest Lint
+
+on:
+  pull_request:
+    branches: [dev]
+    paths:
+      - '.agents/skills/**'
+      - '.claude/skills/**'
+      - 'ai/scripts/lint-skill-manifest.mjs'
+      - '.github/workflows/skill-manifest-lint.yml'
+      - 'learn/agentos/ProgressiveDisclosureSkills.md'
+      - 'learn/guides/fundamentals/CodebaseOverview.md'
+  push:
+    branches: [dev]
+    paths:
+      - '.agents/skills/**'
+      - '.claude/skills/**'
+      - 'ai/scripts/lint-skill-manifest.mjs'
+      - '.github/workflows/skill-manifest-lint.yml'
+      - 'learn/agentos/ProgressiveDisclosureSkills.md'
+      - 'learn/guides/fundamentals/CodebaseOverview.md'
+
+concurrency:
+  group: skill-manifest-lint-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '22'
+
+      - name: Fetch base branch
+        if: github.event_name == 'pull_request'
+        run: git fetch origin ${{ github.base_ref }} --depth=1
+
+      - name: Lint skill manifest
+        run: node ai/scripts/lint-skill-manifest.mjs --base origin/${{ github.base_ref || 'dev' }}

--- a/ai/scripts/lint-skill-manifest.mjs
+++ b/ai/scripts/lint-skill-manifest.mjs
@@ -1,0 +1,363 @@
+#!/usr/bin/env node
+/**
+ * @summary Lints the Neo.mjs skill capability manifest (#11275).
+ *
+ * `SKILL.md` frontmatter stays runtime-canonical. The manifest mirrors that
+ * data for CI and governance checks; this script enforces one-way consistency
+ * plus local substrate-budget and harness-symlink invariants.
+ */
+import fs from 'fs/promises';
+import {existsSync, lstatSync, readFileSync, readlinkSync, statSync} from 'fs';
+import path from 'path';
+import {execFileSync} from 'child_process';
+import {fileURLToPath} from 'url';
+
+const __filename    = fileURLToPath(import.meta.url);
+const __dirname     = path.dirname(__filename);
+const ROOT_DIR      = path.resolve(__dirname, '../..');
+const SKILLS_DIR    = path.join(ROOT_DIR, '.agents/skills');
+const CLAUDE_DIR    = path.join(ROOT_DIR, '.claude/skills');
+const MANIFEST_PATH = path.join(SKILLS_DIR, 'skills.manifest.json');
+const SCHEMA_PATH   = path.join(SKILLS_DIR, 'skills.manifest.schema.json');
+
+function parseArgs(argv = process.argv.slice(2)) {
+    const options = {base: null};
+
+    for (let i = 0; i < argv.length; i++) {
+        const arg = argv[i];
+
+        if (arg === '--base') {
+            options.base = argv[++i];
+        } else if (arg.startsWith('--base=')) {
+            options.base = arg.slice('--base='.length);
+        } else {
+            throw new Error(`Unknown argument: ${arg}`);
+        }
+    }
+
+    return options;
+}
+
+function readJson(filePath) {
+    return JSON.parse(requireText(filePath));
+}
+
+function requireText(filePath) {
+    return readFileSync(filePath, 'utf8');
+}
+
+function parseFrontmatter(text, filePath) {
+    const match = text.match(/^---\n([\s\S]*?)\n---/);
+
+    if (!match) {
+        throw new Error(`${filePath} missing YAML frontmatter block`);
+    }
+
+    const data = {};
+
+    for (const line of match[1].split('\n')) {
+        if (!line.trim()) continue;
+
+        const index = line.indexOf(':');
+
+        if (index === -1) {
+            throw new Error(`${filePath} has malformed frontmatter line: ${line}`);
+        }
+
+        const key   = line.slice(0, index).trim();
+        const value = line.slice(index + 1).trim();
+
+        data[key] = value.replace(/^"(.*)"$/, '$1');
+    }
+
+    for (const key of ['name', 'description', 'triggers']) {
+        if (!data[key]) {
+            throw new Error(`${filePath} missing required frontmatter key: ${key}`);
+        }
+    }
+
+    return data;
+}
+
+async function listSkillDirs() {
+    const entries = await fs.readdir(SKILLS_DIR, {withFileTypes: true});
+
+    return entries
+        .filter(entry => entry.isDirectory())
+        .map(entry => entry.name)
+        .sort();
+}
+
+async function walkFiles(dir) {
+    if (!existsSync(dir)) return [];
+
+    const entries = await fs.readdir(dir, {withFileTypes: true});
+    const files   = [];
+
+    for (const entry of entries) {
+        const filePath = path.join(dir, entry.name);
+
+        if (entry.isDirectory()) {
+            files.push(...await walkFiles(filePath));
+        } else {
+            files.push(filePath);
+        }
+    }
+
+    return files;
+}
+
+async function payloadBytes(skillName) {
+    const files = await walkFiles(path.join(SKILLS_DIR, skillName, 'references'));
+    let bytes   = 0;
+
+    for (const file of files) {
+        bytes += statSync(file).size;
+    }
+
+    return bytes;
+}
+
+function validateManifestSchema(manifest, schema) {
+    const errors = [];
+    const rootKeys = new Set([...schema.required, '$schema']);
+
+    for (const key of Object.keys(manifest)) {
+        if (!rootKeys.has(key)) {
+            errors.push(`manifest has unsupported key: ${key}`);
+        }
+    }
+
+    for (const key of schema.required) {
+        if (!(key in manifest)) errors.push(`manifest missing required key: ${key}`);
+    }
+
+    if (manifest.schemaVersion !== 1) {
+        errors.push('schemaVersion must be 1');
+    }
+
+    if (!manifest.skills || typeof manifest.skills !== 'object' || Array.isArray(manifest.skills)) {
+        errors.push('skills must be an object');
+    }
+
+    const defaults = manifest.defaults || {};
+    const defaultKeys = new Set(schema.properties.defaults.required);
+
+    for (const key of Object.keys(defaults)) {
+        if (!defaultKeys.has(key)) {
+            errors.push(`defaults has unsupported key: ${key}`);
+        }
+    }
+
+    for (const key of schema.properties.defaults.required) {
+        if (!(key in defaults)) errors.push(`defaults missing required key: ${key}`);
+    }
+
+    if (!Number.isInteger(defaults.routerByteBudget) || defaults.routerByteBudget < 1) {
+        errors.push('defaults.routerByteBudget must be a positive integer');
+    }
+
+    if (!Number.isInteger(defaults.payloadBudget) || defaults.payloadBudget < 1) {
+        errors.push('defaults.payloadBudget must be a positive integer');
+    }
+
+    if (typeof defaults.claudeSymlinkRequired !== 'boolean') {
+        errors.push('defaults.claudeSymlinkRequired must be boolean');
+    }
+
+    if (!Array.isArray(defaults.downstreamDocsTargets)) {
+        errors.push('defaults.downstreamDocsTargets must be an array');
+    } else if (new Set(defaults.downstreamDocsTargets).size !== defaults.downstreamDocsTargets.length) {
+        errors.push('defaults.downstreamDocsTargets must contain unique entries');
+    }
+
+    const skillKeys = new Set([
+        ...schema.$defs.skill.required,
+        'relationships'
+    ]);
+
+    for (const [skillName, skill] of Object.entries(manifest.skills || {})) {
+        for (const key of Object.keys(skill)) {
+            if (!skillKeys.has(key)) {
+                errors.push(`${skillName} has unsupported key: ${key}`);
+            }
+        }
+
+        for (const key of schema.$defs.skill.required) {
+            if (!(key in skill)) errors.push(`${skillName} missing required key: ${key}`);
+        }
+
+        if (skill.name !== skillName) {
+            errors.push(`${skillName} key must match entry.name`);
+        }
+
+        if (!/^[a-z0-9]+(?:-[a-z0-9]+)*$/.test(skill.name || '')) {
+            errors.push(`${skillName} has invalid kebab-case name`);
+        }
+
+        if (!Number.isInteger(skill.routerByteBudget) || skill.routerByteBudget < 1) {
+            errors.push(`${skillName}.routerByteBudget must be a positive integer`);
+        }
+
+        if (!Number.isInteger(skill.payloadBudget) || skill.payloadBudget < 1) {
+            errors.push(`${skillName}.payloadBudget must be a positive integer`);
+        }
+
+        if (typeof skill.claudeSymlinkRequired !== 'boolean') {
+            errors.push(`${skillName}.claudeSymlinkRequired must be boolean`);
+        }
+
+        if (typeof skill.description !== 'string' || !skill.description.length) {
+            errors.push(`${skillName}.description must be a non-empty string`);
+        }
+
+        if (typeof skill.triggers !== 'string' || !skill.triggers.length) {
+            errors.push(`${skillName}.triggers must be a non-empty string`);
+        }
+
+        if (!Array.isArray(skill.downstreamDocsTargets)) {
+            errors.push(`${skillName}.downstreamDocsTargets must be an array`);
+        } else if (new Set(skill.downstreamDocsTargets).size !== skill.downstreamDocsTargets.length) {
+            errors.push(`${skillName}.downstreamDocsTargets must contain unique entries`);
+        } else {
+            for (const target of skill.downstreamDocsTargets) {
+                if (!existsSync(path.join(ROOT_DIR, target))) {
+                    errors.push(`${skillName}.downstreamDocsTarget ${target} does not exist`);
+                }
+            }
+        }
+
+        if ('relationships' in skill && (!skill.relationships || typeof skill.relationships !== 'object' || Array.isArray(skill.relationships))) {
+            errors.push(`${skillName}.relationships must be an object`);
+        }
+    }
+
+    return errors;
+}
+
+function changedFiles(base) {
+    const files = new Set();
+
+    const collect = args => {
+        const output = execFileSync('git', args, {
+            cwd     : ROOT_DIR,
+            encoding: 'utf8'
+        });
+
+        for (const file of output.split('\n').filter(Boolean)) {
+            files.add(file);
+        }
+    };
+
+    try {
+        if (base) {
+            collect(['diff', '--name-only', `${base}...HEAD`]);
+        }
+
+        collect(['diff', '--name-only']);
+        collect(['diff', '--name-only', '--cached']);
+        collect(['ls-files', '--others', '--exclude-standard']);
+
+        return [...files].sort();
+    } catch (error) {
+        throw new Error(`Unable to compute changed files${base ? ` against ${base}` : ''}: ${error.message}`);
+    }
+}
+
+function changedSkillNames(base) {
+    const names = new Set();
+
+    for (const filePath of changedFiles(base)) {
+        const match = filePath.match(/^\.agents\/skills\/([^/]+)\/SKILL\.md$/);
+        if (match) names.add(match[1]);
+    }
+
+    return names;
+}
+
+async function lint({base = null} = {}) {
+    const schema       = readJson(SCHEMA_PATH);
+    const manifest     = readJson(MANIFEST_PATH);
+    const errors       = validateManifestSchema(manifest, schema);
+    const skillDirs    = await listSkillDirs();
+    const manifestKeys = Object.keys(manifest.skills).sort();
+
+    if (JSON.stringify(skillDirs) !== JSON.stringify(manifestKeys)) {
+        errors.push(`manifest skill keys must match .agents/skills directories. dirs=${skillDirs.join(', ')} manifest=${manifestKeys.join(', ')}`);
+    }
+
+    const changed = new Set(changedFiles(base));
+    const touchedSkillNames = changedSkillNames(base);
+
+    for (const skillName of skillDirs) {
+        const skill     = manifest.skills[skillName];
+        const skillPath = path.join(SKILLS_DIR, skillName);
+        const router    = path.join(skillPath, 'SKILL.md');
+        const routerRel = path.relative(ROOT_DIR, router);
+        const text      = requireText(router);
+        const fm        = parseFrontmatter(text, routerRel);
+        const lineCount = text.trimEnd().split('\n').length;
+
+        for (const key of ['name', 'description', 'triggers']) {
+            if (skill[key] !== fm[key]) {
+                errors.push(`${routerRel} frontmatter ${key} mismatch: manifest=${JSON.stringify(skill[key])} frontmatter=${JSON.stringify(fm[key])}`);
+            }
+        }
+
+        if (lineCount > skill.routerByteBudget) {
+            errors.push(`${routerRel} has ${lineCount} lines, exceeds routerByteBudget ${skill.routerByteBudget}`);
+        }
+
+        const bytes = await payloadBytes(skillName);
+
+        if (bytes > skill.payloadBudget) {
+            errors.push(`${path.relative(ROOT_DIR, skillPath)}/references has ${bytes} bytes, exceeds payloadBudget ${skill.payloadBudget}`);
+        }
+
+        if (skill.claudeSymlinkRequired) {
+            const linkPath = path.join(CLAUDE_DIR, skillName);
+            const relPath  = path.relative(ROOT_DIR, linkPath);
+            const expected = `../../.agents/skills/${skillName}`;
+
+            if (!existsSync(linkPath) || !lstatSync(linkPath).isSymbolicLink()) {
+                errors.push(`${relPath} missing required symlink`);
+            } else if (readlinkSync(linkPath) !== expected) {
+                errors.push(`${relPath} points to ${readlinkSync(linkPath)}, expected ${expected}`);
+            }
+        }
+
+        if (base && touchedSkillNames.has(skillName)) {
+            for (const target of skill.downstreamDocsTargets) {
+                if (!changed.has(target)) {
+                    errors.push(`${skillName} changed but downstreamDocsTarget ${target} was not updated in this PR`);
+                }
+            }
+        }
+    }
+
+    return errors;
+}
+
+async function main() {
+    const options = parseArgs();
+    const errors  = await lint(options);
+
+    if (errors.length) {
+        console.error('[lint-skill-manifest] FAILED');
+        for (const error of errors) {
+            console.error(`- ${error}`);
+        }
+        process.exit(1);
+    }
+
+    console.log('[lint-skill-manifest] OK');
+}
+
+if (process.argv[1] && path.resolve(process.argv[1]) === __filename) {
+    main().catch(error => {
+        console.error('[lint-skill-manifest] Fatal:', error.message);
+        process.exit(1);
+    });
+}
+
+export {lint, parseArgs, parseFrontmatter, validateManifestSchema};

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
         "ai:mcp-server-knowledge-base" : "node ./ai/mcp/server/knowledge-base/mcp-server.mjs",
         "ai:mcp-server-memory-core"    : "node ./ai/mcp/server/memory-core/mcp-server.mjs",
         "ai:mcp-server-neural-link"    : "node ./ai/mcp/server/neural-link/mcp-server.mjs",
+        "ai:lint-skill-manifest"       : "node ./ai/scripts/lint-skill-manifest.mjs",
         "ai:orchestrator"              : "node ./ai/scripts/orchestrator-daemon.mjs",
         "ai:run-sandman"               : "node ./buildScripts/ai/runSandman.mjs",
         "ai:server"                    : "chroma run --path ./.neo-ai-data/chroma/knowledge-base",

--- a/test/playwright/unit/ai/scripts/lintSkillManifest.spec.mjs
+++ b/test/playwright/unit/ai/scripts/lintSkillManifest.spec.mjs
@@ -1,0 +1,133 @@
+import {test, expect}            from '@playwright/test';
+import {execFileSync, spawnSync} from 'child_process';
+import path                      from 'path';
+
+import {
+    parseArgs,
+    parseFrontmatter,
+    validateManifestSchema
+} from '../../../../../ai/scripts/lint-skill-manifest.mjs';
+
+test.describe('ai/scripts/lint-skill-manifest (#11275)', () => {
+    const scriptPath = path.resolve(process.cwd(), 'ai/scripts/lint-skill-manifest.mjs');
+
+    test('CLI passes against the repository manifest', () => {
+        const result = spawnSync('node', [scriptPath, '--base', 'HEAD'], {
+            cwd     : process.cwd(),
+            encoding: 'utf8'
+        });
+
+        expect(result.status, result.stderr).toBe(0);
+        expect(result.stdout).toContain('[lint-skill-manifest] OK');
+    });
+
+    test('frontmatter parser preserves colon-bearing trigger text', () => {
+        const parsed = parseFrontmatter(`---\nname: test-skill\ndescription: Short: description\ntriggers: Use when the task says: test\n---\n# Body\n`, 'fixture/SKILL.md');
+
+        expect(parsed.name).toBe('test-skill');
+        expect(parsed.description).toBe('Short: description');
+        expect(parsed.triggers).toBe('Use when the task says: test');
+    });
+
+    test('schema validator catches missing required skill fields', () => {
+        const schema = JSON.parse(execFileSync('node', ['-e', "process.stdout.write(require('fs').readFileSync('.agents/skills/skills.manifest.schema.json', 'utf8'))"], {
+            cwd     : process.cwd(),
+            encoding: 'utf8'
+        }));
+
+        const errors = validateManifestSchema({
+            schemaVersion: 1,
+            sourceOfTruth: 'test',
+            defaults     : {
+                routerByteBudget    : 12,
+                payloadBudget        : 80000,
+                claudeSymlinkRequired: true,
+                downstreamDocsTargets: []
+            },
+            skills: {
+                broken: {
+                    name                : 'broken',
+                    description         : 'missing trigger',
+                    routerByteBudget    : 12,
+                    payloadBudget        : 80000,
+                    claudeSymlinkRequired: true,
+                    downstreamDocsTargets: []
+                }
+            }
+        }, schema);
+
+        expect(errors).toContain('broken missing required key: triggers');
+    });
+
+    test('schema validator catches unsupported manifest fields', () => {
+        const schema = JSON.parse(execFileSync('node', ['-e', "process.stdout.write(require('fs').readFileSync('.agents/skills/skills.manifest.schema.json', 'utf8'))"], {
+            cwd     : process.cwd(),
+            encoding: 'utf8'
+        }));
+
+        const errors = validateManifestSchema({
+            schemaVersion: 1,
+            sourceOfTruth: 'test',
+            defaults     : {
+                routerByteBudget    : 12,
+                payloadBudget        : 80000,
+                claudeSymlinkRequired: true,
+                downstreamDocsTargets: [],
+                extraDefault         : true
+            },
+            skills: {
+                extra: {
+                    name                : 'extra',
+                    description         : 'has extra key',
+                    triggers            : 'Use for tests.',
+                    routerByteBudget    : 12,
+                    payloadBudget        : 80000,
+                    claudeSymlinkRequired: true,
+                    downstreamDocsTargets: [],
+                    extraSkill          : true
+                }
+            },
+            extraRoot: true
+        }, schema);
+
+        expect(errors).toContain('manifest has unsupported key: extraRoot');
+        expect(errors).toContain('defaults has unsupported key: extraDefault');
+        expect(errors).toContain('extra has unsupported key: extraSkill');
+    });
+
+    test('schema validator treats relationships as optional future-extension metadata', () => {
+        const schema = JSON.parse(execFileSync('node', ['-e', "process.stdout.write(require('fs').readFileSync('.agents/skills/skills.manifest.schema.json', 'utf8'))"], {
+            cwd     : process.cwd(),
+            encoding: 'utf8'
+        }));
+
+        const errors = validateManifestSchema({
+            schemaVersion: 1,
+            sourceOfTruth: 'test',
+            defaults     : {
+                routerByteBudget    : 12,
+                payloadBudget        : 80000,
+                claudeSymlinkRequired: true,
+                downstreamDocsTargets: []
+            },
+            skills: {
+                optional: {
+                    name                : 'optional',
+                    description         : 'relationship field omitted intentionally',
+                    triggers            : 'Use for tests.',
+                    routerByteBudget    : 12,
+                    payloadBudget        : 80000,
+                    claudeSymlinkRequired: true,
+                    downstreamDocsTargets: []
+                }
+            }
+        }, schema);
+
+        expect(errors).toEqual([]);
+    });
+
+    test('argument parser supports --base forms', () => {
+        expect(parseArgs(['--base', 'origin/dev']).base).toBe('origin/dev');
+        expect(parseArgs(['--base=HEAD']).base).toBe('HEAD');
+    });
+});


### PR DESCRIPTION
Resolves #11275

Authored by GPT-5.5 (Codex Desktop) consuming #11275 filed by @neo-opus-4-7 from the Discussion #11265 convergence path. Session d6d89930-f408-42a0-b60e-ec4487a8cc46.

Evidence: L1 (schema/lint/unit tests + CI workflow shape audit) -> L1 required (machine-readable skill manifest + local/CI lint contract). No residuals.

## What Shipped

- Added .agents/skills/skills.manifest.json as the machine-readable skill governance manifest for all 25 current skills.
- Added .agents/skills/skills.manifest.schema.json to document the v1 manifest shape.
- Added ai/scripts/lint-skill-manifest.mjs plus npm run ai:lint-skill-manifest for local and CI use.
- Added .github/workflows/skill-manifest-lint.yml to run the same lint on PR/push changes touching skills, Claude symlinks, the lint script, workflow, or downstream skill docs.
- Added focused unit coverage in test/playwright/unit/ai/scripts/lintSkillManifest.spec.mjs.
- Updated /create-skill authoring guidance so new/renamed skills update the manifest and run the lint locally.

## Deltas From Ticket

- Used one repository-level .agents/skills/skills.manifest.json rather than per-skill manifest files. This keeps v1 governance as one machine-readable CI artifact and avoids touching every skill directory with new boilerplate.
- Kept relationships optional and omitted it from current skill entries. The schema permits it as future-extension metadata, and the lint only checks its shape if present; zero v1 rules consume it, satisfying AC7 without mini-atlas creep.
- Implemented a lightweight schema validator in the lint script rather than adding a new direct dependency. The v1 schema is intentionally small, and avoiding package churn keeps this substrate patch focused.
- The workflow runs the lint script directly without npm ci; the lint script uses Node built-ins only, so CI does not need dependency installation for this check.

## Substrate-Mutation Pre-Flight

This PR mutates skill-loaded substrate and adds machine-readable governance substrate.

- .agents/skills/skills.manifest.json: disposition keep; trigger-frequency = CI/tooling only, failure-severity = high for skill discovery drift, enforceability = machine-enforceable. Not turn-loaded; governs frontmatter mirrors, budgets, Claude symlink requirements, and downstream docs targets.
- .agents/skills/skills.manifest.schema.json: disposition keep; trigger-frequency = CI/tooling only, failure-severity = medium-high because invalid manifest shape would silently weaken lint, enforceability = machine-enforceable.
- ai/scripts/lint-skill-manifest.mjs: disposition keep; trigger-frequency = local/CI verification, failure-severity = high for recurring map-vs-atlas and skill-discovery drift, enforceability = machine-enforceable.
- .github/workflows/skill-manifest-lint.yml: disposition keep; trigger-frequency = PR/push paths only, failure-severity = high for review-time misses, enforceability = machine-enforceable.
- .agents/skills/create-skill/references/skill-authoring-guide.md: disposition compress-to-trigger; added 4 pointer/checklist lines only in the create-skill payload, not global turn-loaded substrate.

Loaded-context boundary: no AGENTS.md or SKILL.md router expansion. The only skill-prose delta is inside the /create-skill atlas payload, loaded only when authoring skills. The new manifest/schema/lint/workflow are machine-readable or executable surfaces, not prompt substrate.

Decay mitigation: the lint makes the manifest self-checking against frontmatter, router budgets, payload budgets, Claude symlinks, downstream-doc targets, and v1 schema shape. Optional relationships is explicitly future-extension metadata with no v1 semantics.

## Acceptance Coverage

- AC1/AC2: schema + source-of-truth direction encoded; frontmatter remains runtime-canonical and lint enforces one-way mirror consistency.
- AC3: manifest populated for all 25 current skills.
- AC4/AC10: manifest is CI/tooling substrate, not turn-loaded; prose additions are pointer-sized.
- AC5/AC6: lint supports --base <ref> and fails on budget, symlink, downstream-doc, schema, and mirror violations.
- AC7: relationships remains optional future-extension metadata with no v1 lint semantics.
- AC8: /create-skill references the manifest and local lint in structure/verification guidance.
- AC9: #10118 remains open until this PR merges; see Related/Post-Merge Validation.

## Signal Ledger (sourced from Discussion #11265)

- @neo-gemini-3-1-pro: APPROVED at DC_kwDODSospM4BAdan after #11267 absorbed Layer 2 and #11275 carried Layer 1.
- @neo-gpt: APPROVED at DC_kwDODSospM4BAdbI after verifying #11267 Layer-2-only and #11275 Layer 1 separation.
- @neo-opus-4-7: author-side ratification at DC_kwDODSospM4BAda_; not counted as a peer approval signal.

## Unresolved Dissent

(empty)

## Unresolved Liveness

Discussion #11265 records the strict 3x-consensus math problem for a 3-agent swarm when one peer is the author. This PR implements the #11275 Layer 1 ticket that both non-author peer signals accepted; it does not claim human merge authority and still requires normal cross-family PR review before merge.

## Test Evidence

- npm run ai:lint-skill-manifest -- --base origin/dev -> pass ([lint-skill-manifest] OK).
- npm run test-unit -- test/playwright/unit/ai/scripts/lintSkillManifest.spec.mjs -> 6/6 pass.
- git diff --check origin/dev...HEAD -> pass.
- Pre-push freshness: branch rebased after origin/dev advanced to fae4dc468; outgoing log contains only b5756e2dd feat(skills): add capability manifest lint (#11275).

## Related

- Related: #10118 (subsumed by this PR only after merge; do not auto-close from this PR body)
- Discussion #11265
- #11267
- PR #11270
- Discussion #11259 / PR #11263

## Post-Merge Validation

- [ ] Confirm the new Skill Manifest Lint workflow is green on the merged PR.
- [ ] Close #10118 as superseded by #11275 after this PR merges, preserving the substrate-authority chain.

## Commit

- b5756e2dd - feat(skills): add capability manifest lint (#11275)
