### PR TITLE
fix(sync): preserve archive planning metadata in MetadataManager (#11281)

### DIFF
--- a/ai/services/github-workflow/sync/MetadataManager.mjs
+++ b/ai/services/github-workflow/sync/MetadataManager.mjs
@@ -102,11 +102,14 @@ class MetadataManager extends Base {
         // Prune pulls
         for (const [key, value] of Object.entries(metadata.pulls || {})) {
             prunedMetadata.pulls[key] = {
-                state      : value.state,
-                path       : value.path,
-                closedAt   : value.closedAt,
-                updatedAt  : value.updatedAt,
-                contentHash: value.contentHash
+                state         : value.state,
+                path          : value.path,
+                closedAt      : value.closedAt,
+                mergedAt      : value.mergedAt,
+                milestone     : value.milestone,
+                archiveVersion: value.archiveVersion,
+                updatedAt     : value.updatedAt,
+                contentHash   : value.contentHash
             };
         }
 
@@ -114,6 +117,9 @@ class MetadataManager extends Base {
         for (const [key, value] of Object.entries(metadata.discussions || {})) {
             prunedMetadata.discussions[key] = {
                 number     : value.number,
+                path       : value.path,
+                closed     : value.closed,
+                closedAt   : value.closedAt,
                 contentHash: value.contentHash
             };
         }

--- a/test/playwright/unit/ai/services/github-workflow/MetadataManager.spec.mjs
+++ b/test/playwright/unit/ai/services/github-workflow/MetadataManager.spec.mjs
@@ -1,0 +1,130 @@
+import {setup} from '../../../../setup.mjs';
+
+const appName = 'MetadataManagerTest';
+
+setup({
+    neoConfig: {
+        unitTestMode: true
+    },
+    appConfig: {
+        name             : appName,
+        isMounted        : () => true,
+        vnodeInitialising: false
+    }
+});
+
+import {test, expect}  from '@playwright/test';
+import fs              from 'fs/promises';
+import path            from 'path';
+import os              from 'os';
+import Neo             from '../../../../../../src/Neo.mjs';
+import * as core       from '../../../../../../src/core/_export.mjs';
+
+test.describe('Neo.ai.services.github-workflow.sync.MetadataManager', () => {
+    let MetadataManager;
+    let aiConfig;
+    let originalMetadataFile;
+    let testMetadataFile;
+
+    test.beforeAll(async () => {
+        aiConfig = (await import('../../../../../../ai/mcp/server/github-workflow/config.mjs')).default;
+        originalMetadataFile = aiConfig.issueSync.metadataFile;
+        testMetadataFile = path.join(os.tmpdir(), `neo-metadata-manager-test-${Date.now()}.json`);
+        aiConfig.issueSync.metadataFile = testMetadataFile;
+
+        MetadataManager = (await import('../../../../../../ai/services/github-workflow/sync/MetadataManager.mjs')).default;
+    });
+
+    test.afterAll(async () => {
+        aiConfig.issueSync.metadataFile = originalMetadataFile;
+        try {
+            await fs.unlink(testMetadataFile);
+        } catch (e) {
+            // ignore if not found
+        }
+    });
+
+    test('save() preserves specific fields for discussions and pulls, and maintains backward compatibility', async () => {
+        const metadata = {
+            lastSync: '2026-05-13T00:00:00Z',
+            releasesLastFetched: '2026-05-13T00:00:00Z',
+            issues: {
+                '123': {
+                    state: 'OPEN',
+                    path: 'issues/123.md',
+                    closedAt: null,
+                    updatedAt: '2026-05-13T00:00:00Z',
+                    contentHash: 'hash1',
+                    commentsTotal: 5,
+                    extraFieldShouldBePruned: true
+                }
+            },
+            discussions: {
+                '456': {
+                    number: 456,
+                    path: 'discussions/456.md',
+                    closed: true,
+                    closedAt: '2026-05-13T00:00:00Z',
+                    contentHash: 'hash2',
+                    extraFieldShouldBePruned: true
+                },
+                '457': {
+                    // Backward compatibility: existing metadata might not have path/closed
+                    number: 457,
+                    contentHash: 'hash2_legacy'
+                }
+            },
+            pulls: {
+                '789': {
+                    state: 'MERGED',
+                    path: 'pulls/789.md',
+                    closedAt: '2026-05-13T00:00:00Z',
+                    mergedAt: '2026-05-13T00:00:00Z',
+                    milestone: 'v1.0.0',
+                    archiveVersion: 'v1.0.0',
+                    updatedAt: '2026-05-13T00:00:00Z',
+                    contentHash: 'hash3',
+                    extraFieldShouldBePruned: true
+                },
+                '790': {
+                     // Backward compatibility: existing metadata might not have mergedAt/milestone
+                     state: 'OPEN',
+                     updatedAt: '2026-05-13T00:00:00Z',
+                     contentHash: 'hash3_legacy'
+                }
+            }
+        };
+
+        await MetadataManager.save(metadata);
+
+        const loaded = await MetadataManager.load();
+
+        // Issues
+        expect(loaded.issues['123'].extraFieldShouldBePruned).toBeUndefined();
+        expect(loaded.issues['123'].contentHash).toBe('hash1');
+
+        // Discussions
+        expect(loaded.discussions['456'].extraFieldShouldBePruned).toBeUndefined();
+        expect(loaded.discussions['456'].path).toBe('discussions/456.md');
+        expect(loaded.discussions['456'].closed).toBe(true);
+        expect(loaded.discussions['456'].closedAt).toBe('2026-05-13T00:00:00Z');
+        expect(loaded.discussions['456'].contentHash).toBe('hash2');
+
+        // Backward compat
+        expect(loaded.discussions['457'].path).toBeUndefined();
+        expect(loaded.discussions['457'].closed).toBeUndefined();
+        expect(loaded.discussions['457'].contentHash).toBe('hash2_legacy');
+
+        // Pulls
+        expect(loaded.pulls['789'].extraFieldShouldBePruned).toBeUndefined();
+        expect(loaded.pulls['789'].mergedAt).toBe('2026-05-13T00:00:00Z');
+        expect(loaded.pulls['789'].milestone).toBe('v1.0.0');
+        expect(loaded.pulls['789'].archiveVersion).toBe('v1.0.0');
+        expect(loaded.pulls['789'].contentHash).toBe('hash3');
+
+        // Backward compat
+        expect(loaded.pulls['790'].mergedAt).toBeUndefined();
+        expect(loaded.pulls['790'].milestone).toBeUndefined();
+        expect(loaded.pulls['790'].contentHash).toBe('hash3_legacy');
+    });
+});


### PR DESCRIPTION
Authored by Neo Gemini (Antigravity). Session 2c4aa4df-2628-45ae-a9c2-156fd9308f21.

Resolves #11281

Fixes the aggressive pruning in `MetadataManager.save()` that was previously stripping critical routing and lifecycle data. Whitelists `path`, `closed`, and `closedAt` for Discussions, and `mergedAt`, `milestone`, and `archiveVersion` for Pull Requests. This change secures the metadata foundation required for Epic #11187 (Migration to 7-bucket fan-out).

Evidence: L1 (unit test coverage via Playwright) → L1 required (no runtime-verify ACs). No residuals.

## Deltas from ticket (if any)
None.

## Test Evidence
Ran `npm run test-unit` to execute the newly added `test/playwright/unit/ai/services/github-workflow/MetadataManager.spec.mjs`. Tests confirm that pruned saves successfully retain the targeted properties, and fallback logic gracefully handles pre-existing files missing those properties.

## Post-Merge Validation
- [ ] Confirm no regressions in standard issue/PR syncing during next agent session.

## Commits
- b7a112841 — fix(sync): preserve discussion and pull metadata during pruning (#11281)
- f701e6e16 — test(sync): add round-trip test for MetadataManager pruning (#11281)

