### PR TITLE
feat(github-workflow): dual-search read-path in LocalFileService for archive transition (#11285)

### DIFF
--- a/ai/services/github-workflow/LocalFileService.mjs
+++ b/ai/services/github-workflow/LocalFileService.mjs
@@ -62,6 +62,13 @@ class LocalFileService extends Base {
 
     /**
      * Finds and returns the content of a local issue file by its number.
+     *
+     * Read-path dual-search per Epic #11187 B2 (#11285): during the active-to-archive
+     * migration transition, an archived issue may live under either the new
+     * canonical archiveRoot or the legacy archiveDir. The lookup tries new-first,
+     * then falls back to legacy. Once the B1 corpus migration completes, the
+     * legacy fallback becomes a no-op cheap miss.
+     *
      * @param {string} issueNumber The issue number, with or without a leading '#'.
      * @returns {Promise<object>} A promise that resolves to the file content or a structured error.
      */
@@ -80,8 +87,14 @@ class LocalFileService extends Base {
                 return { filePath: activePath, content };
             }
 
-            // 2. If not found, search the archive directory recursively
-            const archivePath = await this.#findFileRecursively(aiConfig.issueSync.archiveDir, filename);
+            // 2. Dual-search archive paths: try new canonical `archiveRoot` first,
+            //    fall back to legacy `archiveDir`. Once Epic #11187 B1 data migration
+            //    completes, the legacy fallback becomes a cheap miss.
+            let archivePath = await this.#findFileRecursively(aiConfig.issueSync.archiveRoot, filename);
+
+            if (!archivePath) {
+                archivePath = await this.#findFileRecursively(aiConfig.issueSync.archiveDir, filename);
+            }
 
             if (archivePath) {
                 const content = await fs.readFile(archivePath, 'utf-8');
@@ -108,6 +121,16 @@ class LocalFileService extends Base {
 
     /**
      * Finds and returns the content of a local discussion file by its number.
+     *
+     * Read-path dual-search per Epic #11187 B2 (#11285): the active discussions
+     * directory is in transition from legacy XXxx subdirs to flat-root shape (B1
+     * /AC6). Until B1 corpus collapse completes, an active discussion may live
+     * either at the new flat path (`discussionsDir/discussion-N.md`) or under a
+     * legacy XXxx subdir (`discussionsDir/XXxx/discussion-N.md`). The lookup
+     * tries flat-first, then recurses into subdirs as fallback. Archive side
+     * uses the new canonical `archiveRoot` only — no legacy discussion-archive
+     * substrate ever existed per Epic #11187 body.
+     *
      * @param {string} discussionNumber The discussion number, with or without a leading '#'.
      * @returns {Promise<object>} A promise that resolves to the file content or a structured error.
      */
@@ -116,14 +139,25 @@ class LocalFileService extends Base {
         const filename     = `${aiConfig.issueSync.discussionFilenamePrefix}${normalizedId}.md`;
 
         try {
-            // 1. Check the active discussions directory first (Flat structure).
-            const activePath = path.join(aiConfig.issueSync.discussionsDir, filename);
-            if (await fs.pathExists(activePath)) {
-                const content = await fs.readFile(activePath, 'utf-8');
-                return { filePath: activePath, content };
+            // 1. Check the active discussions flat path first (new canonical shape post-B1).
+            const activeFlatPath = path.join(aiConfig.issueSync.discussionsDir, filename);
+            if (await fs.pathExists(activeFlatPath)) {
+                const content = await fs.readFile(activeFlatPath, 'utf-8');
+                return { filePath: activeFlatPath, content };
             }
 
-            // 2. If not found, search the archive directory recursively
+            // 2. Active dual-search fallback: recurse into legacy XXxx subdirs of discussionsDir
+            //    until Epic #11187 B1 corpus collapse lands. Post-B1 this becomes a cheap miss.
+            const activeLegacyPath = await this.#findFileRecursively(aiConfig.issueSync.discussionsDir, filename);
+
+            if (activeLegacyPath && activeLegacyPath !== activeFlatPath) {
+                const content = await fs.readFile(activeLegacyPath, 'utf-8');
+                return { filePath: activeLegacyPath, content };
+            }
+
+            // 3. If not found in active, search the archive directory recursively.
+            //    No legacy discussion-archive substrate ever existed (per Epic #11187 body);
+            //    archiveRoot only.
             const archivePath = await this.#findFileRecursively(aiConfig.issueSync.archiveRoot, filename);
 
             if (archivePath) {
@@ -131,7 +165,7 @@ class LocalFileService extends Base {
                 return { filePath: archivePath, content };
             }
 
-            // 3. If not found anywhere, return an error
+            // 4. If not found anywhere, return an error
             logger.warn(`[LocalFileService] Discussion file not found for #${normalizedId}`);
             return {
                 error  : 'File not found',

--- a/test/playwright/unit/ai/services/github-workflow/LocalFileService.spec.mjs
+++ b/test/playwright/unit/ai/services/github-workflow/LocalFileService.spec.mjs
@@ -1,0 +1,194 @@
+import {setup} from '../../../../setup.mjs';
+
+const appName = 'LocalFileServiceTest';
+
+setup({
+    neoConfig: {
+        unitTestMode: true
+    },
+    appConfig: {
+        name             : appName,
+        isMounted        : () => true,
+        vnodeInitialising: false
+    }
+});
+
+import {test, expect}  from '@playwright/test';
+import fs              from 'fs-extra';
+import path            from 'path';
+import os              from 'os';
+import Neo             from '../../../../../../src/Neo.mjs';
+import * as core       from '../../../../../../src/core/_export.mjs';
+
+test.describe.serial('Neo.ai.services.github-workflow.LocalFileService — dual-search read-path (#11285 / Epic #11187 B2)', () => {
+    let LocalFileService;
+    let aiConfig;
+    let originalIssuesDir, originalArchiveDir, originalArchiveRoot, originalDiscussionsDir;
+    let testRoot;
+
+    test.beforeAll(async () => {
+        aiConfig = (await import('../../../../../../ai/mcp/server/github-workflow/config.mjs')).default;
+
+        // Capture original paths
+        originalIssuesDir      = aiConfig.issueSync.issuesDir;
+        originalArchiveDir     = aiConfig.issueSync.archiveDir;
+        originalArchiveRoot    = aiConfig.issueSync.archiveRoot;
+        originalDiscussionsDir = aiConfig.issueSync.discussionsDir;
+
+        // Create isolated test root
+        testRoot = path.join(os.tmpdir(), `neo-localfileservice-test-${Date.now()}`);
+        aiConfig.issueSync.issuesDir      = path.join(testRoot, 'issues');
+        aiConfig.issueSync.archiveDir     = path.join(testRoot, 'issue-archive');
+        aiConfig.issueSync.archiveRoot    = path.join(testRoot, 'archive');
+        aiConfig.issueSync.discussionsDir = path.join(testRoot, 'discussions');
+
+        await fs.ensureDir(aiConfig.issueSync.issuesDir);
+        await fs.ensureDir(aiConfig.issueSync.archiveDir);
+        await fs.ensureDir(aiConfig.issueSync.archiveRoot);
+        await fs.ensureDir(aiConfig.issueSync.discussionsDir);
+
+        LocalFileService = (await import('../../../../../../ai/services/github-workflow/LocalFileService.mjs')).default;
+    });
+
+    test.afterAll(async () => {
+        aiConfig.issueSync.issuesDir      = originalIssuesDir;
+        aiConfig.issueSync.archiveDir     = originalArchiveDir;
+        aiConfig.issueSync.archiveRoot    = originalArchiveRoot;
+        aiConfig.issueSync.discussionsDir = originalDiscussionsDir;
+
+        await fs.remove(testRoot).catch(() => {});
+    });
+
+    test.afterEach(async () => {
+        // Clean each test's fixture state
+        await fs.emptyDir(aiConfig.issueSync.issuesDir).catch(() => {});
+        await fs.emptyDir(aiConfig.issueSync.archiveDir).catch(() => {});
+        await fs.emptyDir(aiConfig.issueSync.archiveRoot).catch(() => {});
+        await fs.emptyDir(aiConfig.issueSync.discussionsDir).catch(() => {});
+    });
+
+    test('getIssueById finds active issue via chunkPath shape', async () => {
+        const issueId = '11100';
+        const filename = `issue-${issueId}.md`;
+        const activePath = path.join(aiConfig.issueSync.issuesDir, '111xx', filename);
+        await fs.ensureDir(path.dirname(activePath));
+        await fs.writeFile(activePath, '# Active issue content');
+
+        const result = await LocalFileService.getIssueById(issueId);
+
+        expect(result.error).toBeUndefined();
+        expect(result.content).toBe('# Active issue content');
+        expect(result.filePath).toBe(activePath);
+    });
+
+    test('getIssueById falls back to new archiveRoot when not in active', async () => {
+        const issueId = '9999';
+        const filename = `issue-${issueId}.md`;
+        const archivePath = path.join(aiConfig.issueSync.archiveRoot, 'issues', 'v12.0.0', filename);
+        await fs.ensureDir(path.dirname(archivePath));
+        await fs.writeFile(archivePath, '# Archived (new path) content');
+
+        const result = await LocalFileService.getIssueById(issueId);
+
+        expect(result.error).toBeUndefined();
+        expect(result.content).toBe('# Archived (new path) content');
+        expect(result.filePath).toBe(archivePath);
+    });
+
+    test('getIssueById falls back to legacy archiveDir when not in archiveRoot', async () => {
+        const issueId = '8888';
+        const filename = `issue-${issueId}.md`;
+        const legacyPath = path.join(aiConfig.issueSync.archiveDir, 'v11.0.0', '88xx', filename);
+        await fs.ensureDir(path.dirname(legacyPath));
+        await fs.writeFile(legacyPath, '# Archived (legacy path) content');
+
+        const result = await LocalFileService.getIssueById(issueId);
+
+        expect(result.error).toBeUndefined();
+        expect(result.content).toBe('# Archived (legacy path) content');
+        expect(result.filePath).toBe(legacyPath);
+    });
+
+    test('getIssueById returns NOT_FOUND when issue exists nowhere', async () => {
+        const result = await LocalFileService.getIssueById('77777');
+
+        expect(result.code).toBe('NOT_FOUND');
+        expect(result.error).toBe('File not found');
+    });
+
+    test('getIssueById prefers archiveRoot over archiveDir when both have the same id', async () => {
+        const issueId = '6666';
+        const filename = `issue-${issueId}.md`;
+        const newPath = path.join(aiConfig.issueSync.archiveRoot, 'issues', 'v12.0.0', filename);
+        const legacyPath = path.join(aiConfig.issueSync.archiveDir, 'v11.0.0', '66xx', filename);
+        await fs.ensureDir(path.dirname(newPath));
+        await fs.ensureDir(path.dirname(legacyPath));
+        await fs.writeFile(newPath, '# New canonical wins');
+        await fs.writeFile(legacyPath, '# Legacy should not be returned');
+
+        const result = await LocalFileService.getIssueById(issueId);
+
+        expect(result.content).toBe('# New canonical wins');
+        expect(result.filePath).toBe(newPath);
+    });
+
+    test('getDiscussionById finds active flat discussion (post-B1 canonical shape)', async () => {
+        const discussionId = '11240';
+        const filename = `discussion-${discussionId}.md`;
+        const flatPath = path.join(aiConfig.issueSync.discussionsDir, filename);
+        await fs.writeFile(flatPath, '# Active flat discussion');
+
+        const result = await LocalFileService.getDiscussionById(discussionId);
+
+        expect(result.error).toBeUndefined();
+        expect(result.content).toBe('# Active flat discussion');
+        expect(result.filePath).toBe(flatPath);
+    });
+
+    test('getDiscussionById falls back to legacy XXxx subdir (pre-B1 active shape)', async () => {
+        const discussionId = '10040';
+        const filename = `discussion-${discussionId}.md`;
+        const legacyActivePath = path.join(aiConfig.issueSync.discussionsDir, '100xx', filename);
+        await fs.ensureDir(path.dirname(legacyActivePath));
+        await fs.writeFile(legacyActivePath, '# Legacy XXxx subdir discussion');
+
+        const result = await LocalFileService.getDiscussionById(discussionId);
+
+        expect(result.error).toBeUndefined();
+        expect(result.content).toBe('# Legacy XXxx subdir discussion');
+        expect(result.filePath).toBe(legacyActivePath);
+    });
+
+    test('getDiscussionById falls back to archiveRoot when not in active', async () => {
+        const discussionId = '8500';
+        const filename = `discussion-${discussionId}.md`;
+        const archivePath = path.join(aiConfig.issueSync.archiveRoot, 'discussions', 'v12.0.0', filename);
+        await fs.ensureDir(path.dirname(archivePath));
+        await fs.writeFile(archivePath, '# Archived discussion');
+
+        const result = await LocalFileService.getDiscussionById(discussionId);
+
+        expect(result.error).toBeUndefined();
+        expect(result.content).toBe('# Archived discussion');
+        expect(result.filePath).toBe(archivePath);
+    });
+
+    test('getDiscussionById returns NOT_FOUND when discussion exists nowhere', async () => {
+        const result = await LocalFileService.getDiscussionById('99999');
+
+        expect(result.code).toBe('NOT_FOUND');
+        expect(result.error).toBe('File not found');
+    });
+
+    test('getIssueById accepts leading # in issue number', async () => {
+        const issueId = '5555';
+        const filename = `issue-${issueId}.md`;
+        const activePath = path.join(aiConfig.issueSync.issuesDir, '55xx', filename);
+        await fs.ensureDir(path.dirname(activePath));
+        await fs.writeFile(activePath, '# Issue with hash prefix');
+
+        const result = await LocalFileService.getIssueById(`#${issueId}`);
+
+        expect(result.content).toBe('# Issue with hash prefix');
+    });
+});


### PR DESCRIPTION
Resolves #11285

Authored by Claude Opus 4.7 (Claude Code 1M context).

Evidence: L1 (10 unit tests covering all dual-search paths) → L1 required (no runtime ACs; file-system fixture coverage). No residuals.

## What shipped

B2 of Epic #11187 7-bucket fan-out — LocalFileService read-path dual-search during active-to-archive migration transition.

**getIssueById changes:**
- Tries new canonical `archiveRoot` first
- Falls back to legacy `archiveDir` if not found in `archiveRoot`
- Once Epic #11187 B1 corpus migration completes, legacy fallback becomes a cheap miss

**getDiscussionById changes:**
- Tries new flat path (`discussionsDir/discussion-N.md`) first — post-B1 canonical shape
- Falls back to recursive XXxx subdir search in `discussionsDir` — covers pre-B1 active shape (currently 23 legacy XXxx subdirs + 23 new `discussion-XXxx` subdirs per OQ1 duplication state)
- Then searches `archiveRoot` recursively — no legacy `discussion-archive` substrate ever existed per Epic #11187 body

**Bonus substrate-correctness fix:** before this change, `getDiscussionById` could not find ANY active discussion under the current legacy XXxx subdir shape (it only tried flat root). The dual-search now correctly resolves the existing discussion corpus.

## AC Coverage (#11285)

- [x] **AC1**: `LocalFileService#getIssueById` checks both old (`archiveDir`) and new (`archiveRoot`) paths. ✓

**Out-of-scope per ticket OoS:**
- Write-path / syncer logic unchanged
- `getPullById` not added — does not currently exist in `LocalFileService`; ticket says "(and PR equivalent)" but precedent doesn't establish the method shape. Defer to follow-up if PR read-path needed.

## Test Evidence

- `npm run test-unit -- test/playwright/unit/ai/services/github-workflow/LocalFileService.spec.mjs` → **10/10 pass** (524ms)
- `npm run test-unit -- test/playwright/unit/ai/services/github-workflow/` → **80/80 pass** (2.6s) — no regression in sibling test suites
- `git diff --check origin/dev...HEAD` clean

## Test scenarios

1. getIssueById finds active issue via chunkPath shape
2. getIssueById falls back to new archiveRoot when not in active
3. getIssueById falls back to legacy archiveDir when not in archiveRoot
4. getIssueById returns NOT_FOUND when issue exists nowhere
5. getIssueById prefers archiveRoot over archiveDir when both have the same id (ordering)
6. getDiscussionById finds active flat discussion (post-B1 canonical shape)
7. getDiscussionById falls back to legacy XXxx subdir (pre-B1 active shape)
8. getDiscussionById falls back to archiveRoot when not in active
9. getDiscussionById returns NOT_FOUND when discussion exists nowhere
10. getIssueById accepts leading # in issue number

## Test substrate discipline

`describe.serial` applied to prevent `fullyParallel` races on shared `aiConfig` mutation per `feedback_symmetric_spec_cleanup` memory anchor (Playwright interleaves tests in same worker; cross-singleton config mutations need serial ordering for fixture file lifecycle).

## Epic #11187 context

- **B0b** (MetadataManager pruning fix) ✓ MERGED via PR #11282
- **B1** (#11284 — Gemini): active discussions collapse + issue-archive migration
- **B2** (this PR, #11285): LocalFileService dual-search ← lands BEFORE B1 (no-op for current substrate; ready for post-B1 reads)
- **B3** (#11286 — me): data-sync-pipeline.yml + buildScripts archive substrate
- **B4** (#11287): 11-file consumer cleanup (TicketSource, SEO, analyzers)
- **B5** (#11288): tests + AC16/17 + anomaly hook
- **B0a + AC8**: NOT YET FILED (surfaced in MESSAGE:ed9e146f-... — awaits Gemini/GPT filing)

## Cross-Family Review Routing

Primary-reviewer: **@neo-gemini-3-1-pro** per cross-family rotation (B1 substrate-author on adjacent corpus migration). A2A handoff with commentId follows.

## Operator merge gate

@tobiu — per `AGENTS.md §0 Invariant 1`, merge reserved exclusively for you. Eligible for human merge once CI green + cross-family approves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)