### PR TITLE
chore(ci): bump GitHub Actions workflows from node-version 22 to 24 (#11292)

### DIFF
--- a/.github/workflows/data-sync-pipeline.yml
+++ b/.github/workflows/data-sync-pipeline.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: '22'
+          node-version: '24'
 
       - name: Install dependencies
         run: npm ci

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -13,7 +13,7 @@ jobs:
       # Setup .npmrc file to publish to npm
       - uses: actions/setup-node@v6
         with:
-          node-version: '22.x'
+          node-version: '24'
           registry-url: 'https://registry.npmjs.org'
       - run: npm ci
       - run: npm publish

--- a/.github/workflows/skill-manifest-lint.yml
+++ b/.github/workflows/skill-manifest-lint.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: '22'
+          node-version: '24'
 
       - name: Fetch base branch
         if: github.event_name == 'pull_request'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: '22'
+          node-version: '24'
           cache: 'npm'
 
       # Pre-create .neo-ai-data so the `prepare` lifecycle's downloadKnowledgeBase


### PR DESCRIPTION
Resolves #11292

Authored by Claude Opus 4.7 (Claude Code 1M context). Session `c2d47e91-625f-4ebf-b066-49442f465830`.

Evidence: L1 (4 single-line YAML edits + CI fail-fast validation) → L1 required (CI workflows are themselves the runtime; passing CI = passing AC). No residuals.

## What shipped

Coordinated 4-file bump per operator-authorized V-B-A:

| File | Before | After |
|---|---|---|
| `.github/workflows/test.yml:36` | `'22'` | `'24'` |
| `.github/workflows/npm-publish.yml:16` | `'22.x'` | `'24'` (normalized to bare-major) |
| `.github/workflows/data-sync-pipeline.yml:28` | `'22'` | `'24'` |
| `.github/workflows/skill-manifest-lint.yml:39` | `'22'` | `'24'` |

## V-B-A context (pre-bump)

- 4 workflows were the only node-version source-of-truth (no `package.json` engines pin, no `.nvmrc`, no `.node-version`)
- Local dev empirical anchor: `node --version` → `v25.9.0` (forward-compat confirmed)
- Node 24 official release calendar (per @neo-gpt Cycle 1 V-B-A correction — my original training-data anchor was wrong):
  - Initial release: 2025-05-06
  - Active LTS since: 2025-10-28 (already LTS for 6+ months as of 2026-05-13)
  - Maintenance LTS starts: 2026-10-20
  - End-of-Life: 2028-04-30
- Operator framing "v24 is fully stable in 2026" confirmed substrate-correct

## AC Coverage (#11292)

- [x] **AC1**: All 4 workflow files updated to `node-version: '24'` (npm-publish.yml normalized from `'22.x'` to bare-major `'24'` for consistency with siblings)
- [ ] **AC2**: CI passes on PR-trigger workflows (`test.yml` + `skill-manifest-lint.yml`). `npm-publish.yml` triggers on tag-push so won't fire on this PR; will validate at next release. `data-sync-pipeline.yml` triggers on schedule/manual.
- [x] **AC3**: No `package.json` engines field added (scope-discipline preserved)
- [x] **AC4**: PR body cites #11292 + V-B-A findings + historical context for #9598 + #9600 (release-calendar claims corrected post-Cycle-1 review)

## Test Evidence

- `grep -rn "node-version" .github/workflows/` → all 4 files at `'24'` ✓
- `git diff --check origin/dev...HEAD` clean
- CI will validate on PR push

## Cycle 1 [ADDRESSED] — training-data temporal drift on Node 24 release calendar

@neo-gpt Cycle 1 review (`IC_kwDODSospM8AAAABCJKdjw`) caught a substrate-correctness error: my original PR body + ticket #11292 body stated *"Released April 2026 — Active release line; becomes Active LTS October 2026 (~5 months away)"*. This was training-data temporal anchor drift per memory anchor `feedback_training_data_anchor_drift` — I had session context (2026-05-13) but defaulted to assumed release calendar without V-B-A.

**Corrected per GPT V-B-A of official Node.js schedule:**
- Node 24 released **2025-05-06** (12 months ago, not "April 2026")
- Active LTS since **2025-10-28** (6+ months ago, not "5 months away from LTS")
- Maintenance LTS starts **2026-10-20** (5 months from now)
- End-of-Life **2028-04-30**

The substrate-decision (bump v22 → v24) remains substrate-correct on technical merits — v24 has been Active LTS for 6 months + is well-validated. The framing was wrong; the bump direction is right. PR body + ticket body both corrected.

Per `feedback_training_data_anchor_drift` memory: "model-authored content defaults to training-data temporal/categorical/model-name anchors when writing about 'current' things. Calibrate to actual session context; post-publication review catches this reliably." GPT's V-B-A IS the post-publication review that caught it. Friction → gold conversion: this becomes a fresh empirical anchor for the memory pattern.

## Related historical substrate

- **#9598** (CLOSED COMPLETED 2026-03-30): forced JS-actions runner to Node 24 via `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true` env var — addresses the **actions infrastructure runtime** (different concern from user-project script runtime in this PR)
- **#9600** (CLOSED COMPLETED 2026-03-30): upgraded `actions/setup-node@v4` → `v6` for native Node 24 support — addresses actions infrastructure

Neither overlaps with this PR's scope. The actions infrastructure was already Node-24-ready 2 months ago; this PR finally bumps the user-project script runtime to match.

## Out of Scope

- Adding `package.json` engines pin (separate substrate; defer to follow-up if needed)
- Adding `.nvmrc` / `.node-version` (separate substrate; defer)
- Bumping `actions/setup-node` action version (already at `@v6` per #9600)
- Action infrastructure changes (#9598 + #9600 territory)

## Cross-Family Review Routing

Primary-reviewer: **@neo-gpt** per cross-family rotation. Cycle 1 caught training-data temporal drift in PR body; Cycle 2 substrate corrected (this PR-body update + #11292 ticket-body update).

## Operator merge gate

@tobiu — per `AGENTS.md §0 Invariant 1`, merge reserved exclusively for you. Eligible for human merge once CI green + cross-family approves. You authorized this bump at 2026-05-13 ~07:43Z via the V-B-A side-quest thread.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
