### PR TITLE
feat(github-workflow): pipeline + publish archive substrate updates for Epic #11187 (#11286)

### DIFF
--- a/.github/workflows/data-sync-pipeline.yml
+++ b/.github/workflows/data-sync-pipeline.yml
@@ -111,11 +111,19 @@ jobs:
           cp -f apps/portal/sitemap.xml temp_pages/ 2>/dev/null || true
           cp -f apps/portal/llms.txt temp_pages/ 2>/dev/null || true
           
-          # Copy resources content (syncing deletions natively via git)
-          rm -rf temp_pages/node_modules/neo.mjs/resources/content/issues
-          rm -rf temp_pages/node_modules/neo.mjs/resources/content/issue-archive
-          cp -r resources/content/issues temp_pages/node_modules/neo.mjs/resources/content/
-          cp -r resources/content/issue-archive temp_pages/node_modules/neo.mjs/resources/content/
+          # Copy resources content (syncing deletions natively via git).
+          # Per Epic #11187 7-bucket fan-out: support both legacy paths (issue-archive/,
+          # pr-archive/) and the new single-root archive/ umbrella during the migration
+          # transition. Legacy paths drop in a follow-up PR once corpus migration completes.
+          # Missing-dir tolerance: each rm -rf and cp guarded so transitional state
+          # (e.g., archive/ not yet populated at pre-merge or pr-archive/ post-AC8-migration
+          # already removed) does not break the sync.
+          for dir in issues pulls discussions issue-archive pr-archive archive; do
+            rm -rf "temp_pages/node_modules/neo.mjs/resources/content/$dir"
+            if [ -d "resources/content/$dir" ]; then
+              cp -r "resources/content/$dir" temp_pages/node_modules/neo.mjs/resources/content/
+            fi
+          done
           
           cd temp_pages
           

--- a/buildScripts/release/publish.mjs
+++ b/buildScripts/release/publish.mjs
@@ -240,6 +240,14 @@ async function main() {
     }
 
     // Commit Archived Tickets
+    //
+    // Per Epic #11187 7-bucket fan-out: `GH_SyncService.runFullSync()` above writes
+    // archived items to the new lazy-ordinal-chunked shape via `archivePath()` helper
+    // (canonical: `resources/content/archive/{type}/v*/{flat|chunk-N}/`). Legacy paths
+    // (`resources/content/issue-archive/`, `resources/content/pr-archive/`) remain
+    // tracked during the migration transition until the data corpus fully migrates
+    // (B1/AC8/B5 lanes). The `git add .` below is intentionally broad to capture both
+    // new archive/ moves AND any residual legacy-path moves during transition.
     console.log('💾 Committing archived tickets...');
     const status = runCommandWithOutput('git status --porcelain');
 


### PR DESCRIPTION
Resolves #11286

Authored by Claude Opus 4.7 (Claude Code 1M context).

Evidence: L1 (YAML syntax + diff scope verification + missing-dir tolerance via shell guards) → L1 required (CI/pipeline edits are themselves runtime — observable at next pipeline run). No residuals.

## What shipped

B3 of Epic #11187 7-bucket fan-out — update CI pipelines + build scripts to target the new single-root `archive/` substrate while preserving legacy paths during the migration transition.

### `data-sync-pipeline.yml` (AC1)

**Before** (lines 114-118):
```yaml
rm -rf temp_pages/.../resources/content/issues
rm -rf temp_pages/.../resources/content/issue-archive
cp -r resources/content/issues temp_pages/.../resources/content/
cp -r resources/content/issue-archive temp_pages/.../resources/content/
```

**After**: refactored as bash loop covering all relevant directories (legacy + new umbrella):
```yaml
for dir in issues pulls discussions issue-archive pr-archive archive; do
    rm -rf "temp_pages/.../resources/content/$dir"
    if [ -d "resources/content/$dir" ]; then
        cp -r "resources/content/$dir" temp_pages/.../resources/content/
    fi
done
```

Key properties:
- **Added coverage**: `pulls/`, `discussions/`, `archive/` (new umbrella per Epic #11187)
- **Legacy preserved**: `issue-archive/`, `pr-archive/` continue syncing during transition (until B1/AC8 corpus migration completes + follow-up PR drops them)
- **Missing-dir tolerance**: each `cp` guarded by `[ -d ]` check — transitional states (e.g., `archive/` not yet populated at pre-merge, or `pr-archive/` removed post-AC8) don't break sync
- **Always-rm tolerance**: `rm -rf` always runs even if source dir missing — `rm -rf` is idempotent on absent paths

### `publish.mjs` Step 6 (AC2)

**No logic change.** Added documentation comment block clarifying that `GH_SyncService.runFullSync()` writes archived items to the new lazy-ordinal-chunked shape via the `archivePath()` helper (canonical: `resources/content/archive/{type}/v*/{flat|chunk-N}/`). The existing `git add .` is intentionally broad to capture both new archive/ moves AND residual legacy-path moves during transition.

The substrate already routes correctly via the syncer. The comment makes the intent explicit for future readers.

## AC Coverage (#11286)

- [x] **AC1**: `data-sync-pipeline.yml` uses the new archive paths (added `pulls/`, `discussions/`, `archive/`; legacy `issue-archive/`, `pr-archive/` retained for transition)
- [x] **AC2**: `publish.mjs` archive-cutting logic clarified (lazy ordinal chunking happens in `archivePath()` helper called by syncer; publish.mjs orchestrates + commits broadly; comment added)

## Out of Scope

- General CI refactoring outside archive path changes (per ticket OoS)
- Dropping legacy paths from pipeline (deferred to follow-up post-B1/AC8/B4 corpus migration; legacy + new coexist during transition)
- Adding pr-archive version-mapping inference (that's AC8 #11291 substrate, not B3)

## Test Evidence

- `node -e "const y=require('js-yaml'); y.load(fs.readFileSync(...))"` → YAML VALID for data-sync-pipeline.yml
- `git diff --stat origin/dev...HEAD`: 2 files / +21 / -5 lines
- `git diff --check origin/dev...HEAD` clean
- CI will validate on PR push (test.yml + skill-manifest-lint.yml run on PR; data-sync-pipeline.yml triggers on schedule/manual so won't fire here — will validate at next scheduled cron run)

## Epic #11187 substrate context

| Bucket | State | This PR Touches |
|---|---|---|
| B0a (#11290) | Open, unassigned | No |
| B0b (#11281 / PR #11282) | ✓ MERGED | No |
| B1 (#11284 / PR #11294) | APPROVED, awaiting merge | No (independent) |
| AC8 (#11291) | Open, unassigned | No (orthogonal) |
| B2 (#11285 / PR #11289) | APPROVED, awaiting merge | No (independent) |
| **B3 (#11286 / this PR)** | OPEN | YES |
| B4 (#11287 / PR #11295) | Cross-family review cycle | No |
| B5 (#11288) | Open, unassigned | No |

## Cross-Family Review Routing

Primary-reviewer: **@neo-gpt** per cross-family rotation. Bounded substrate (2 files / 26 lines net) + missing-dir tolerance + no logic change in publish.mjs → likely Quick Win cycle. A2A handoff with commentId follows.

## Operator merge gate

@tobiu — per `AGENTS.md §0 Invariant 1`, merge reserved exclusively for you. Eligible for human merge once cross-family approves. Pipeline changes won't be empirically validated until next scheduled `data-sync-pipeline.yml` cron run (hourly) — but YAML syntax + bash semantics are statically verifiable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)