### PR TITLE
feat(sync): implement sealed-chunk archive semantics and docs (#11288)

### DIFF
--- a/ai/services/github-workflow/sync/IssueSyncer.mjs
+++ b/ai/services/github-workflow/sync/IssueSyncer.mjs
@@ -524,7 +524,7 @@ class IssueSyncer extends Base {
             // Under sealed-chunk semantics, historical items should not jump archive buckets
             // just because a maintainer toggled the state.
             if (oldIssue && issue.state === 'CLOSED') {
-                const wasArchived = oldPathRelative && oldPathRelative.includes(issueSyncConfig.archiveDir);
+                const wasArchived = oldPathRelative && (oldPathRelative.includes(issueSyncConfig.archiveDir) || oldPathRelative.includes(issueSyncConfig.archiveRoot));
                 
                 if (oldIssue.closedAt && issue.closedAt && oldIssue.closedAt !== issue.closedAt) {
                     logger.warn(`[ARCHIVE ANOMALY] Issue #${issueNumber} closedAt shifted: ${oldIssue.closedAt} -> ${issue.closedAt}.`);

--- a/ai/services/github-workflow/sync/IssueSyncer.mjs
+++ b/ai/services/github-workflow/sync/IssueSyncer.mjs
@@ -513,7 +513,33 @@ class IssueSyncer extends Base {
         // Process each issue
         for (const issue of allIssues) {
             const issueNumber = issue.number;
-            const targetPath  = this.#getIssuePath(issue, archivePlan);
+            let targetPath = this.#getIssuePath(issue, archivePlan);
+
+            const oldIssue = metadata.issues[issueNumber];
+            const oldPathRelative = oldIssue?.path;
+            const oldAbsolutePath = oldIssue ? this.#resolvePath(oldPathRelative) : null;
+
+            // --- ARCHIVE ANOMALY DETECTION & SEALED-CHUNK SEMANTICS ---
+            // Detect if an issue's closedAt timestamp has shifted from a previously known value.
+            // Under sealed-chunk semantics, historical items should not jump archive buckets
+            // just because a maintainer toggled the state.
+            if (oldIssue && issue.state === 'CLOSED') {
+                const wasArchived = oldPathRelative && oldPathRelative.includes(issueSyncConfig.archiveDir);
+                
+                if (oldIssue.closedAt && issue.closedAt && oldIssue.closedAt !== issue.closedAt) {
+                    logger.warn(`[ARCHIVE ANOMALY] Issue #${issueNumber} closedAt shifted: ${oldIssue.closedAt} -> ${issue.closedAt}.`);
+                    
+                    if (wasArchived) {
+                        logger.warn(`[SEALED CHUNK ENFORCEMENT] Preventing #${issueNumber} from jumping to ${targetPath}. Forcing retention at ${oldAbsolutePath}.`);
+                        targetPath = oldAbsolutePath;
+                    }
+                } else if (wasArchived && targetPath !== oldAbsolutePath) {
+                    // Even if closedAt didn't shift, milestone changes could trigger a bucket jump.
+                    // We must seal the chunk to prevent registry drift.
+                    logger.warn(`[SEALED CHUNK ENFORCEMENT] Issue #${issueNumber} bucket shifted, but it is already archived. Forcing retention at ${oldAbsolutePath}.`);
+                    targetPath = oldAbsolutePath;
+                }
+            }
 
             if (!targetPath) {
                 stats.dropped.count++;
@@ -530,9 +556,6 @@ class IssueSyncer extends Base {
                 delete newMetadata.issues[issueNumber];
                 continue;
             }
-
-            const oldIssue = metadata.issues[issueNumber];
-            const oldAbsolutePath = oldIssue ? this.#resolvePath(oldIssue.path) : null;
 
             const needsUpdate = !oldIssue ||
                 oldIssue.updated !== issue.updatedAt ||

--- a/learn/agentos/GitHubWorkflow.md
+++ b/learn/agentos/GitHubWorkflow.md
@@ -159,6 +159,12 @@ This flexibility is crucial for:
 *   **`.github/ISSUE_ARCHIVE/`**: The "Historical Record." Contains closed tickets, organized by Release Version (e.g., `v5.0.0/`).
 *   **`.github/RELEASE_NOTES/`**: Contains the content of GitHub Releases.
 
+### Archive Anomaly Detection & Sealed-Chunk Semantics
+
+To ensure referential stability and institutionalize "Sealed-Chunk" archive integrity, the IssueSyncer enforces strict controls over issues once they are archived:
+*   **Sealed-Chunk Enforcements:** Once an issue is written to an archive bucket (e.g., `v10.5.0/chunk-1/`), it is "sealed". If subsequent syncs pull the issue and detect a shift in its `closedAt` date or its milestone, the system will prevent the issue from "jumping" buckets. It forces retention at the `oldAbsolutePath` to prevent historical data regression.
+*   **Archive Anomaly Hooks:** When an expected bucket shift occurs (e.g., the `closedAt` timestamp was modified), the syncer intercepts the discrepancy and emits an operator-actionable `[ARCHIVE ANOMALY]` log warning. This allows the Swarm to react to metadata drift while maintaining sync performance via delta updates.
+
 ### The Markdown Format
 
 Each issue is stored as a YAML-frontmatter Markdown file. The frontmatter contains rich metadata derived from the GraphQL response:

--- a/learn/agentos/sandman-handoff-format.md
+++ b/learn/agentos/sandman-handoff-format.md
@@ -7,13 +7,14 @@ This file (`resources/content/sandman_handoff.md`) acts as the single source of 
 The file is divided into the following key sections:
 
 ### 1. Capability Gaps
-Detected structural mismatches within the codebase architecture, populated from the Native Edge Graph.
+Detected structural mismatches within the codebase architecture, populated from the Native Edge Graph, as well as metadata drifts or bucket-shifts in the archive tier.
 - `[TEST_GAP]`
 - `[GUIDE_GAP]`
 - `[EXAMPLE_GAP]`
 - `[ORPHAN_CONCEPT]`
 - `[CONCEPT_REVERIFY_DUE]`
 - `[KB_DEMAND_GAP]`
+- `[ARCHIVE_ANOMALY]`
 
 ### 2. Active PR Cycle State
 A live extraction of active Pull Requests originated by the core Swarm agents (`@neo-opus-4-7`, `@neo-gemini-3-1-pro`, `@neo-gpt`).

--- a/test/playwright/unit/ai/services/github-workflow/IssueSyncer.spec.mjs
+++ b/test/playwright/unit/ai/services/github-workflow/IssueSyncer.spec.mjs
@@ -243,6 +243,72 @@ test.describe('Neo.ai.services.github-workflow.sync.IssueSyncer', () => {
             logger.warn = originalWarn;
         }
     });
+
+    test('pullFromGitHub enforces sealed-chunk archive semantics', async () => {
+        const mockIssue = buildMockIssue({
+            number       : 42044,
+            title        : 'Mock issue — sealed chunk enforcement #11288',
+            timelineFirst: [],
+            hasNextPage  : false,
+            endCursor    : null
+        });
+        
+        mockIssue.state = 'CLOSED';
+        mockIssue.closedAt = '2026-05-13T10:00:00Z'; // new shifted date
+        mockIssue.milestone = { title: 'v1.0.0' }; // new shifted milestone
+        
+        GraphqlService.query = async (query) => {
+            if (query.includes('FetchIssuesForSync')) {
+                return {
+                    rateLimit: { cost: 1, remaining: 4999, resetAt: '2026-05-13T11:00:00Z' },
+                    repository: {
+                        issues: {
+                            pageInfo: { hasNextPage: false, endCursor: null },
+                            nodes: [structuredClone(mockIssue)]
+                        }
+                    }
+                };
+            }
+            if (query.includes('FetchSingleIssue')) {
+                return {repository: {issue: structuredClone(mockIssue)}};
+            }
+            throw new Error(`Unexpected GraphQL query in test: ${query.slice(0, 80)}`);
+        };
+
+        const originalOldPath = `${issueSyncConfig.archiveDir}/chunk-42000/issue-${mockIssue.number}.md`;
+        
+        const metadata = {
+            issues: {
+                [mockIssue.number]: {
+                    state: 'CLOSED',
+                    path: originalOldPath,
+                    updatedAt: '2026-05-12T10:00:00Z',
+                    closedAt: '2026-05-12T10:00:00Z', // original date
+                    milestone: null, // original milestone
+                    title: mockIssue.title,
+                    contentHash: 'somehash',
+                    commentsTotal: 0
+                }
+            }
+        };
+        
+        // create the mock file to simulate it already exists in the archive
+        const absOldPath = path.resolve(process.cwd(), originalOldPath);
+        await fs.ensureDir(path.dirname(absOldPath));
+        await fs.writeFile(absOldPath, 'mock content', 'utf8');
+
+        // Execute pullFromGitHub
+        const { stats } = await IssueSyncer.pullFromGitHub(metadata);
+        
+        // Assert it was pulled
+        expect(stats.pulled.issues).toContain(mockIssue.number);
+        
+        // Assert target path in metadata remained the old path despite closedAt/milestone shifting
+        expect(metadata.issues[mockIssue.number].path).toBe(originalOldPath);
+        
+        // Cleanup
+        await fs.unlink(absOldPath).catch(() => {});
+    });
 });
 
 function buildComment(i) {


### PR DESCRIPTION
Authored by gemini-3.1-pro (Antigravity). Session 2c4aa4df-2628-45ae-a9c2-156fd9308f21.

Refs #11288

Institutionalizes the "Sealed-Chunk" archive integrity by actively preventing historical archived issues from changing archive buckets due to state or metadata shifts (like `closedAt` or milestone).

Evidence: L1 (Playwright unit test regression suite) → L1 required.

## Deltas from ticket
- This adds the `IssueSyncer.mjs` enforcement to retain the `oldAbsolutePath` if a bucket shift is detected for an already-archived issue.
- Updates `GitHubWorkflow.md` and `sandman-handoff-format.md` documentation as requested.