### PR TITLE
feat(ai): map missing Neural Link runtime handlers (#11274)

### DIFF
--- a/src/ai/Client.mjs
+++ b/src/ai/Client.mjs
@@ -108,9 +108,12 @@ class Client extends Base {
             list_stores           : data,
             modify_state_provider : data,
 
+            check_namespace       : runtime,
             get_dom_event         : runtime,
             get_drag              : runtime,
             get_method_source     : runtime,
+            get_namespace_tree    : runtime,
+            get_neo_config        : runtime,
             get_route             : runtime,
             get_window            : runtime,
             inspect_class         : runtime,

--- a/test/playwright/unit/ai/ClientDispatcher.spec.mjs
+++ b/test/playwright/unit/ai/ClientDispatcher.spec.mjs
@@ -1,0 +1,89 @@
+import {setup} from '../../setup.mjs';
+
+const appName = 'AiClientDispatcherTest';
+
+setup({
+    appConfig: {
+        name: appName
+    }
+});
+
+import {test, expect} from '@playwright/test';
+import Neo            from '../../../../src/Neo.mjs';
+
+test.describe('Neo.ai.Client Dispatcher', () => {
+    let client;
+
+    test.beforeAll(() => {
+        // Mock Neo.currentWorker which is required by Window.mjs and Client.mjs
+        if (!Neo.currentWorker) {
+            Neo.currentWorker = {
+                on: () => {},
+                isSharedWorker: false
+            };
+        }
+        if (!Neo.worker) {
+            Neo.worker = {
+                App: { id: 'test-worker' }
+            };
+        }
+    });
+
+    test.beforeEach(async () => {
+        // We need to import the class to ensure it's loaded, even if it's a singleton
+        const { default: Client } = await import('../../../../src/ai/Client.mjs');
+        
+        client = Neo.ai.Client;
+        if (!client) {
+            client = Neo.create(Client, {appName});
+        }
+    });
+
+    test('should route check_namespace to RuntimeService.checkNamespace', async () => {
+        let called = false;
+        const originalFn = client.services.runtime.checkNamespace;
+        
+        client.services.runtime.checkNamespace = (params) => {
+            called = true;
+            expect(params.namespace).toBe('Neo.button.Base');
+            return true;
+        };
+
+        const result = await client.handleRequest('check_namespace', {namespace: 'Neo.button.Base'});
+        expect(called).toBe(true);
+        expect(result).toBe(true);
+        
+        client.services.runtime.checkNamespace = originalFn;
+    });
+
+    test('should route get_namespace_tree to RuntimeService.getNamespaceTree', async () => {
+        let called = false;
+        const originalFn = client.services.runtime.getNamespaceTree;
+        
+        client.services.runtime.getNamespaceTree = (params) => {
+            called = true;
+            expect(params.root).toBe('Neo.manager');
+            return { tree: {} };
+        };
+
+        const result = await client.handleRequest('get_namespace_tree', {root: 'Neo.manager'});
+        expect(called).toBe(true);
+        
+        client.services.runtime.getNamespaceTree = originalFn;
+    });
+
+    test('should route get_neo_config to RuntimeService.getNeoConfig', async () => {
+        let called = false;
+        const originalFn = client.services.runtime.getNeoConfig;
+        
+        client.services.runtime.getNeoConfig = (params) => {
+            called = true;
+            return { config: {} };
+        };
+
+        const result = await client.handleRequest('get_neo_config', {});
+        expect(called).toBe(true);
+        
+        client.services.runtime.getNeoConfig = originalFn;
+    });
+});


### PR DESCRIPTION
Authored by Neo-Gemini-3.1-Pro (Antigravity). Session 2c4aa4df-2628-45ae-a9c2-156fd9308f21.

Resolves #11274

Mapped the missing `get_namespace_tree`, `get_neo_config`, and `check_namespace` JSON-RPC commands to the `RuntimeService` in `Neo.ai.Client` (`src/ai/Client.mjs`). Added a basic Playwright unit test for the `Neo.ai.Client` dispatcher to verify correct service routing.

Evidence: L1 (unit tests passed, static mapping checked) → L1 required. No residuals.

## Deltas from ticket (if any)
None.

## Test Evidence
Ran `npm run test-unit test/playwright/unit/ai/ClientDispatcher.spec.mjs` successfully.

## Post-Merge Validation
- [ ] End-to-end Neural Link MCP tool invocation works without 'Unknown method' errors.