### PR TITLE
feat(memory-core): surface dream daemon flags in healthcheck (#10779)

### DIFF
--- a/ai/services/memory-core/HealthService.mjs
+++ b/ai/services/memory-core/HealthService.mjs
@@ -423,6 +423,32 @@ export async function buildWakeFeaturesBlock(now = Date.now()) {
 }
 
 /**
+ * @summary Projects background daemon feature flags into the healthcheck `features.dream`
+ *          observability block (#10779).
+ *
+ * Pure projection: reads the active boolean status of the background data-processing
+ * features and surfaces them so operators can verify boot-time evaluations (env var overrides
+ * vs defaults) without having to inspect the `config.mjs` file manually.
+ *
+ * Timestamps (`lastDreamRun`, `lastGoldenPathRun`) are initialized to `null` as placeholders
+ * until the orchestrator records run history.
+ *
+ * @param {Object} cfg aiConfig-shaped input. Reads `cfg.autoDream`, `cfg.autoGoldenPath`,
+ *     `cfg.realTimeMemoryParsing`, and `cfg.autoIngestFileSystem`.
+ * @returns {{autoDream: Boolean, autoGoldenPath: Boolean, realTimeMemoryParsing: Boolean,
+ *     autoIngestFileSystem: Boolean, lastDreamRun: String|null, lastGoldenPathRun: String|null}}
+ */
+export function buildDreamFeaturesBlock(cfg) {
+    return {
+        autoDream            : !!cfg.autoDream,
+        autoGoldenPath       : !!cfg.autoGoldenPath,
+        realTimeMemoryParsing: !!cfg.realTimeMemoryParsing,
+        autoIngestFileSystem : !!cfg.autoIngestFileSystem,
+        lastDreamRun         : null,
+        lastGoldenPathRun    : null
+    };
+}
+/**
  * @summary Monitors and validates the ChromaDB dependency for the Memory Core MCP server.
  *
  * This service acts as a gatekeeper, ensuring that ChromaDB is properly running,
@@ -949,7 +975,8 @@ class HealthService extends Base {
             },
             features : {
                 summarization: false,
-                wake         : await buildWakeFeaturesBlock()
+                wake         : await buildWakeFeaturesBlock(),
+                dream        : buildDreamFeaturesBlock(aiConfig)
             },
             startup  : {
                 summarizationStatus : this.#startupSummarizationStatus || 'not_attempted',

--- a/learn/agentos/SharedDeployment.md
+++ b/learn/agentos/SharedDeployment.md
@@ -251,6 +251,14 @@ Auth diagnostic fields:
 
 Use `configured` as the at-a-glance indicator. A misconfigured `NEO_AUTH_TRUST_PROXY_IDENTITY=true` without OIDC and without a fronting proxy actually deployed will surface here as `'proxy-header'`; if requests then fail with `401`, that's the runtime gate ([PR #10785](https://github.com/neomjs/neo/pull/10785)) rejecting missing proxy headers per the [Authentication](#authentication) threat model. The healthcheck shows the *configured* posture; the 401 confirms the gate fires when the prerequisite is absent.
 
+Dream background daemon diagnostic fields (`features.dream`):
+- `autoDream`: whether the background Dream daemon is permitted to run.
+- `autoGoldenPath`: whether the background Golden Path pipeline is enabled.
+- `realTimeMemoryParsing`: whether the real-time continuous memory parsing worker is enabled.
+- `autoIngestFileSystem`: whether the file-system ingest watcher is enabled.
+- `lastDreamRun`: placeholder for the timestamp of the last Dream pipeline execution.
+- `lastGoldenPathRun`: placeholder for the timestamp of the last Golden Path pipeline execution.
+
 ## Asynchronous Session Summarization (Disconnect Trigger)
 
 In a shared deployment, multiple agents connect and disconnect dynamically. To ensure session summaries are automatically available to the team without requiring manual API calls or external cron jobs, the Memory Core leverages a **disconnect-triggered summarization** primitive.

--- a/test/playwright/unit/ai/services/memory-core/HealthService.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/HealthService.spec.mjs
@@ -916,3 +916,60 @@ test.describe('HealthService #10783 — buildWakeFeaturesBlock', () => {
         }
     });
 });
+
+/**
+ * @summary Coverage for the #10779 features.dream observability block in the healthcheck payload.
+ *
+ * Pins the pure-projection contract of `buildDreamFeaturesBlock`. This function surfaces the
+ * active boolean status of the background data-processing features based on `aiConfig` evaluation.
+ *
+ * @see Neo.ai.services.memory-core.HealthService#buildDreamFeaturesBlock
+ */
+test.describe('HealthService #10779 — buildDreamFeaturesBlock', () => {
+    let buildDreamFeaturesBlock;
+
+    test.beforeAll(async () => {
+        const mod = await import('../../../../../../ai/services/memory-core/HealthService.mjs');
+        buildDreamFeaturesBlock = mod.buildDreamFeaturesBlock;
+    });
+
+    test('surfaces boolean flags directly from aiConfig and defaults timestamps to null', () => {
+        const cfg = {
+            autoDream: true,
+            autoGoldenPath: false,
+            realTimeMemoryParsing: true,
+            autoIngestFileSystem: false
+        };
+
+        const result = buildDreamFeaturesBlock(cfg);
+
+        expect(result).toEqual({
+            autoDream: true,
+            autoGoldenPath: false,
+            realTimeMemoryParsing: true,
+            autoIngestFileSystem: false,
+            lastDreamRun: null,
+            lastGoldenPathRun: null
+        });
+    });
+
+    test('coerces missing or falsy config values to strict booleans', () => {
+        const cfg = {
+            // autoDream missing
+            autoGoldenPath: null,
+            realTimeMemoryParsing: undefined,
+            autoIngestFileSystem: ''
+        };
+
+        const result = buildDreamFeaturesBlock(cfg);
+
+        expect(result).toEqual({
+            autoDream: false,
+            autoGoldenPath: false,
+            realTimeMemoryParsing: false,
+            autoIngestFileSystem: false,
+            lastDreamRun: null,
+            lastGoldenPathRun: null
+        });
+    });
+});


### PR DESCRIPTION
Resolves #10779

Authored by Gemini 3.1 Pro (Antigravity). Session 2c4aa4df-2628-45ae-a9c2-156fd9308f21.

This PR institutionalizes background daemon feature observability in the HealthService. It implements the pure projection `buildDreamFeaturesBlock` to map configuration flags (`autoDream`, `autoGoldenPath`, `realTimeMemoryParsing`, `autoIngestFileSystem`) into an observable healthcheck payload block under `features.dream`.

Evidence: L1 (unit tests verified projection logic and boolean coercion) → L1 required (no runtime-verify ACs required beyond unit test coverage of the pure projection).
Residuals: Opened #11309 to track Orchestrator integration for run history timestamps. AC5 documentation is complete.

## Deltas from ticket
Added placeholders for `lastDreamRun` and `lastGoldenPathRun` for future integration with the Orchestrator's run history.

## Test Evidence
Ran Playwright tests via `npm run test:playwright:unit:local`, all tests passed. Unit tests specifically added in `HealthService.spec.mjs`.

## Post-Merge Validation
- [ ] Ensure frontend/dashboard monitoring systems are updated to display the `features.dream` payload correctly.
