### PR TITLE
feat(skills): add perFilePayloadBudget primitive (#11332)

### DIFF
--- a/.agents/skills/create-skill/references/skill-authoring-guide.md
+++ b/.agents/skills/create-skill/references/skill-authoring-guide.md
@@ -110,6 +110,32 @@ Instead, extract tool-specific constraints into dedicated, granular payload file
 - **The Map:** General routing, global lifecycle rules. Keep this clean and high-level to prevent context bloat.
 - **The Atlas:** Tool-specific quirks, edge cases, payload shapes, and strict operational constraints.
 
+### Recursive Application: Workflow Files Are Also Maps (per Discussion #11314 / Epic #11319)
+
+Map vs World Atlas applies **recursively**. A workflow file (`references/<workflow>.md`) itself becomes a Map for its own sub-rules when it grows beyond its natural load-frequency boundary.
+
+**The discipline (per operator directive 2026-05-13):** *"the bare always-relevant minimum is in there. and edge cases as ONE LINE triggers."*
+
+- **Always-relevant sections stay inline** in the workflow file — they fire every time the skill is loaded
+- **Edge-case sections extract to sub-rule sibling files** under `references/<sub-rule>.md` or `references/<category>/<sub-rule>.md`
+- **Each extracted edge-case is referenced from the workflow body via a one-line trigger pointer:**
+
+```markdown
+## §5.3 MCP-Tool-Description Budget Audit
+<!-- trigger: pr touches ai/mcp/server/*/openapi.yaml → read ./audits/mcp-tool-description-budget.md -->
+```
+
+**Mechanical enforcement (Sub-A of Epic #11319 via `skills.manifest.json` + `lint-skill-manifest.mjs`):**
+- `perFilePayloadBudget` per-skill (or `defaults.perFilePayloadBudget`) — lint fails any individual file in `references/` exceeding the cap
+- Default: 25,000 bytes (25 KB) — empirical-floor for clean skills
+- Temporary per-skill overrides for migration-period monoliths (e.g., `pr-review` at 66000, `pull-request` at 38000) — to be tightened as Sub-B+ migrations land
+
+**Empirical precedent:**
+- `pull-request` skill: workflow + 4 sub-rule siblings (`env-var-rename-rule.md`, `mcp-config-template-change-guide.md`, `sync-all-constraints.md`, `review-response-protocol.md`) — each conditionally loaded per workflow body trigger pointer
+- `pr-review` skill: `audits/mcp-tool-description-budget.md` + `audits/loading-runtime-effect.md` — extracted edge-cases
+
+**HNSW topography frame:** workflow Maps + sub-rule Atlases form the Middle Layer of the Hierarchical Navigable Small World structure that skill substrate empirically resembles. See Discussion #11314 §1.5 for full Top/Middle/Bottom-Layer topography.
+
 ## 3. The Lesson Promotion Path
 
 When a swarm agent discovers a systemic trap, an architectural pattern, or a workflow optimization that took significant effort to derive, that knowledge must not die when the session ends.

--- a/.agents/skills/skills.manifest.json
+++ b/.agents/skills/skills.manifest.json
@@ -5,6 +5,7 @@
   "defaults": {
     "routerByteBudget": 12,
     "payloadBudget": 80000,
+    "perFilePayloadBudget": 25000,
     "claudeSymlinkRequired": true,
     "downstreamDocsTargets": [
       "learn/agentos/ProgressiveDisclosureSkills.md",
@@ -174,6 +175,7 @@
       "triggers": "Use this skill when evaluating a Pull Request, writing a PR review, structuring feedback on agent-generated code, or instructing a human on how to write a structured PR Review.",
       "routerByteBudget": 12,
       "payloadBudget": 80000,
+      "perFilePayloadBudget": 66000,
       "claudeSymlinkRequired": true,
       "downstreamDocsTargets": [
         "learn/agentos/ProgressiveDisclosureSkills.md",
@@ -186,6 +188,7 @@
       "triggers": "Use this skill as the final Definition of Done when you believe a ticket is complete and it is time to open a Pull Request, or if a human user asks you to submit a PR. Also triggers when receiving a PR review to perform the author-side template-adherence check.",
       "routerByteBudget": 12,
       "payloadBudget": 80000,
+      "perFilePayloadBudget": 38000,
       "claudeSymlinkRequired": true,
       "downstreamDocsTargets": [
         "learn/agentos/ProgressiveDisclosureSkills.md",

--- a/.agents/skills/skills.manifest.schema.json
+++ b/.agents/skills/skills.manifest.schema.json
@@ -29,6 +29,11 @@
           "type": "integer",
           "minimum": 1
         },
+        "perFilePayloadBudget": {
+          "type": "integer",
+          "minimum": 1,
+          "description": "Optional per-individual-file byte ceiling within references/. Defaults to disabled when omitted. Recursive Map vs World Atlas enforcement per #11314 / #11319 / #11320."
+        },
         "claudeSymlinkRequired": {
           "type": "boolean"
         },
@@ -82,6 +87,11 @@
         "payloadBudget": {
           "type": "integer",
           "minimum": 1
+        },
+        "perFilePayloadBudget": {
+          "type": "integer",
+          "minimum": 1,
+          "description": "Optional per-individual-file byte ceiling within references/. Overrides defaults.perFilePayloadBudget when set. Omit to disable per-file enforcement for this skill."
         },
         "claudeSymlinkRequired": {
           "type": "boolean"

--- a/ai/scripts/lint-skill-manifest.mjs
+++ b/ai/scripts/lint-skill-manifest.mjs
@@ -124,6 +124,20 @@ async function payloadFileSizes(skillName) {
     return files.map(file => ({path: file, bytes: statSync(file).size}));
 }
 
+function checkPerFileBudgets(files, perFileBudget) {
+    if (!Number.isInteger(perFileBudget) || perFileBudget <= 0) return [];
+
+    const errors = [];
+
+    for (const {path: filePath, bytes: fileBytes} of files) {
+        if (fileBytes > perFileBudget) {
+            errors.push(`${path.relative(ROOT_DIR, filePath)} has ${fileBytes} bytes, exceeds perFilePayloadBudget ${perFileBudget}. Extract edge-case sections to sub-rule sibling files behind one-line trigger pointers per Map vs World Atlas discipline (skill-authoring-guide.md). See #11319 / #11320 for the convention.`);
+        }
+    }
+
+    return errors;
+}
+
 function validateManifestSchema(manifest, schema) {
     const errors = [];
     const rootKeys = new Set([...schema.required, '$schema']);
@@ -329,12 +343,7 @@ async function lint({base = null} = {}) {
 
         if (Number.isInteger(perFileBudget) && perFileBudget > 0) {
             const files = await payloadFileSizes(skillName);
-
-            for (const {path: filePath, bytes: fileBytes} of files) {
-                if (fileBytes > perFileBudget) {
-                    errors.push(`${path.relative(ROOT_DIR, filePath)} has ${fileBytes} bytes, exceeds perFilePayloadBudget ${perFileBudget}. Extract edge-case sections to sub-rule sibling files behind one-line trigger pointers per Map vs World Atlas discipline (skill-authoring-guide.md). See #11319 / #11320 for the convention.`);
-                }
-            }
+            errors.push(...checkPerFileBudgets(files, perFileBudget));
         }
 
         if (skill.claudeSymlinkRequired) {
@@ -383,4 +392,4 @@ if (process.argv[1] && path.resolve(process.argv[1]) === __filename) {
     });
 }
 
-export {lint, parseArgs, parseFrontmatter, validateManifestSchema};
+export {checkPerFileBudgets, lint, parseArgs, parseFrontmatter, validateManifestSchema};

--- a/ai/scripts/lint-skill-manifest.mjs
+++ b/ai/scripts/lint-skill-manifest.mjs
@@ -118,6 +118,12 @@ async function payloadBytes(skillName) {
     return bytes;
 }
 
+async function payloadFileSizes(skillName) {
+    const files = await walkFiles(path.join(SKILLS_DIR, skillName, 'references'));
+
+    return files.map(file => ({path: file, bytes: statSync(file).size}));
+}
+
 function validateManifestSchema(manifest, schema) {
     const errors = [];
     const rootKeys = new Set([...schema.required, '$schema']);
@@ -141,7 +147,7 @@ function validateManifestSchema(manifest, schema) {
     }
 
     const defaults = manifest.defaults || {};
-    const defaultKeys = new Set(schema.properties.defaults.required);
+    const defaultKeys = new Set(Object.keys(schema.properties.defaults.properties));
 
     for (const key of Object.keys(defaults)) {
         if (!defaultKeys.has(key)) {
@@ -161,6 +167,10 @@ function validateManifestSchema(manifest, schema) {
         errors.push('defaults.payloadBudget must be a positive integer');
     }
 
+    if ('perFilePayloadBudget' in defaults && (!Number.isInteger(defaults.perFilePayloadBudget) || defaults.perFilePayloadBudget < 1)) {
+        errors.push('defaults.perFilePayloadBudget must be a positive integer when set');
+    }
+
     if (typeof defaults.claudeSymlinkRequired !== 'boolean') {
         errors.push('defaults.claudeSymlinkRequired must be boolean');
     }
@@ -171,10 +181,7 @@ function validateManifestSchema(manifest, schema) {
         errors.push('defaults.downstreamDocsTargets must contain unique entries');
     }
 
-    const skillKeys = new Set([
-        ...schema.$defs.skill.required,
-        'relationships'
-    ]);
+    const skillKeys = new Set(Object.keys(schema.$defs.skill.properties));
 
     for (const [skillName, skill] of Object.entries(manifest.skills || {})) {
         for (const key of Object.keys(skill)) {
@@ -201,6 +208,10 @@ function validateManifestSchema(manifest, schema) {
 
         if (!Number.isInteger(skill.payloadBudget) || skill.payloadBudget < 1) {
             errors.push(`${skillName}.payloadBudget must be a positive integer`);
+        }
+
+        if ('perFilePayloadBudget' in skill && (!Number.isInteger(skill.perFilePayloadBudget) || skill.perFilePayloadBudget < 1)) {
+            errors.push(`${skillName}.perFilePayloadBudget must be a positive integer when set`);
         }
 
         if (typeof skill.claudeSymlinkRequired !== 'boolean') {
@@ -312,6 +323,18 @@ async function lint({base = null} = {}) {
 
         if (bytes > skill.payloadBudget) {
             errors.push(`${path.relative(ROOT_DIR, skillPath)}/references has ${bytes} bytes, exceeds payloadBudget ${skill.payloadBudget}`);
+        }
+
+        const perFileBudget = skill.perFilePayloadBudget ?? manifest.defaults.perFilePayloadBudget;
+
+        if (Number.isInteger(perFileBudget) && perFileBudget > 0) {
+            const files = await payloadFileSizes(skillName);
+
+            for (const {path: filePath, bytes: fileBytes} of files) {
+                if (fileBytes > perFileBudget) {
+                    errors.push(`${path.relative(ROOT_DIR, filePath)} has ${fileBytes} bytes, exceeds perFilePayloadBudget ${perFileBudget}. Extract edge-case sections to sub-rule sibling files behind one-line trigger pointers per Map vs World Atlas discipline (skill-authoring-guide.md). See #11319 / #11320 for the convention.`);
+                }
+            }
         }
 
         if (skill.claudeSymlinkRequired) {

--- a/test/playwright/unit/ai/scripts/lintSkillManifest.spec.mjs
+++ b/test/playwright/unit/ai/scripts/lintSkillManifest.spec.mjs
@@ -3,6 +3,7 @@ import {execFileSync, spawnSync} from 'child_process';
 import path                      from 'path';
 
 import {
+    checkPerFileBudgets,
     parseArgs,
     parseFrontmatter,
     validateManifestSchema
@@ -232,6 +233,43 @@ test.describe('ai/scripts/lint-skill-manifest (#11275)', () => {
         }, schema);
 
         expect(errorsNegativeSkill).toContain('bad-budget.perFilePayloadBudget must be a positive integer when set');
+    });
+
+    test('checkPerFileBudgets returns an error for files exceeding the per-file budget (#11320 AC9)', () => {
+        const repoRoot = path.resolve(process.cwd());
+        const files    = [
+            {path: path.join(repoRoot, '.agents/skills/example/references/over-budget.md'),  bytes: 30000},
+            {path: path.join(repoRoot, '.agents/skills/example/references/under-budget.md'), bytes: 10000}
+        ];
+
+        const errors = checkPerFileBudgets(files, 25000);
+
+        expect(errors).toHaveLength(1);
+        expect(errors[0]).toContain('over-budget.md has 30000 bytes, exceeds perFilePayloadBudget 25000');
+        expect(errors[0]).toContain('Map vs World Atlas');
+        expect(errors[0]).toContain('skill-authoring-guide.md');
+    });
+
+    test('checkPerFileBudgets returns no errors when all files are within budget (#11320 AC9)', () => {
+        const repoRoot = path.resolve(process.cwd());
+        const files    = [
+            {path: path.join(repoRoot, '.agents/skills/example/references/a.md'), bytes: 10000},
+            {path: path.join(repoRoot, '.agents/skills/example/references/b.md'), bytes: 24999}
+        ];
+
+        expect(checkPerFileBudgets(files, 25000)).toEqual([]);
+    });
+
+    test('checkPerFileBudgets treats null/undefined/non-positive budget as disabled per omit-to-disable contract (#11320 AC8)', () => {
+        const repoRoot = path.resolve(process.cwd());
+        const files    = [
+            {path: path.join(repoRoot, '.agents/skills/example/references/huge.md'), bytes: 1000000}
+        ];
+
+        expect(checkPerFileBudgets(files, undefined)).toEqual([]);
+        expect(checkPerFileBudgets(files, null)).toEqual([]);
+        expect(checkPerFileBudgets(files, 0)).toEqual([]);
+        expect(checkPerFileBudgets(files, -1)).toEqual([]);
     });
 
     test('schema validator preserves backwards compatibility when perFilePayloadBudget is omitted (#11320)', () => {

--- a/test/playwright/unit/ai/scripts/lintSkillManifest.spec.mjs
+++ b/test/playwright/unit/ai/scripts/lintSkillManifest.spec.mjs
@@ -130,4 +130,138 @@ test.describe('ai/scripts/lint-skill-manifest (#11275)', () => {
         expect(parseArgs(['--base', 'origin/dev']).base).toBe('origin/dev');
         expect(parseArgs(['--base=HEAD']).base).toBe('HEAD');
     });
+
+    test('schema validator accepts perFilePayloadBudget as optional defaults field (#11320)', () => {
+        const schema = JSON.parse(execFileSync('node', ['-e', "process.stdout.write(require('fs').readFileSync('.agents/skills/skills.manifest.schema.json', 'utf8'))"], {
+            cwd     : process.cwd(),
+            encoding: 'utf8'
+        }));
+
+        const errors = validateManifestSchema({
+            schemaVersion: 1,
+            sourceOfTruth: 'test',
+            defaults     : {
+                routerByteBudget    : 12,
+                payloadBudget       : 80000,
+                perFilePayloadBudget: 25000,
+                claudeSymlinkRequired: true,
+                downstreamDocsTargets: []
+            },
+            skills: {}
+        }, schema);
+
+        expect(errors).not.toContain('defaults has unsupported key: perFilePayloadBudget');
+        expect(errors).not.toContain('defaults.perFilePayloadBudget must be a positive integer when set');
+    });
+
+    test('schema validator accepts perFilePayloadBudget as optional per-skill override (#11320)', () => {
+        const schema = JSON.parse(execFileSync('node', ['-e', "process.stdout.write(require('fs').readFileSync('.agents/skills/skills.manifest.schema.json', 'utf8'))"], {
+            cwd     : process.cwd(),
+            encoding: 'utf8'
+        }));
+
+        const errors = validateManifestSchema({
+            schemaVersion: 1,
+            sourceOfTruth: 'test',
+            defaults     : {
+                routerByteBudget    : 12,
+                payloadBudget       : 80000,
+                claudeSymlinkRequired: true,
+                downstreamDocsTargets: []
+            },
+            skills: {
+                'monolith-skill': {
+                    name                : 'monolith-skill',
+                    description         : 'temporary override for migration-period monolith',
+                    triggers            : 'Use for tests.',
+                    routerByteBudget    : 12,
+                    payloadBudget       : 80000,
+                    perFilePayloadBudget: 66000,
+                    claudeSymlinkRequired: true,
+                    downstreamDocsTargets: []
+                }
+            }
+        }, schema);
+
+        expect(errors).not.toContain('monolith-skill has unsupported key: perFilePayloadBudget');
+        expect(errors).not.toContain('monolith-skill.perFilePayloadBudget must be a positive integer when set');
+    });
+
+    test('schema validator rejects non-positive perFilePayloadBudget (#11320)', () => {
+        const schema = JSON.parse(execFileSync('node', ['-e', "process.stdout.write(require('fs').readFileSync('.agents/skills/skills.manifest.schema.json', 'utf8'))"], {
+            cwd     : process.cwd(),
+            encoding: 'utf8'
+        }));
+
+        const errorsZeroDefault = validateManifestSchema({
+            schemaVersion: 1,
+            sourceOfTruth: 'test',
+            defaults     : {
+                routerByteBudget    : 12,
+                payloadBudget       : 80000,
+                perFilePayloadBudget: 0,
+                claudeSymlinkRequired: true,
+                downstreamDocsTargets: []
+            },
+            skills: {}
+        }, schema);
+
+        expect(errorsZeroDefault).toContain('defaults.perFilePayloadBudget must be a positive integer when set');
+
+        const errorsNegativeSkill = validateManifestSchema({
+            schemaVersion: 1,
+            sourceOfTruth: 'test',
+            defaults     : {
+                routerByteBudget    : 12,
+                payloadBudget       : 80000,
+                claudeSymlinkRequired: true,
+                downstreamDocsTargets: []
+            },
+            skills: {
+                'bad-budget': {
+                    name                : 'bad-budget',
+                    description         : 'negative budget',
+                    triggers            : 'Use for tests.',
+                    routerByteBudget    : 12,
+                    payloadBudget       : 80000,
+                    perFilePayloadBudget: -100,
+                    claudeSymlinkRequired: true,
+                    downstreamDocsTargets: []
+                }
+            }
+        }, schema);
+
+        expect(errorsNegativeSkill).toContain('bad-budget.perFilePayloadBudget must be a positive integer when set');
+    });
+
+    test('schema validator preserves backwards compatibility when perFilePayloadBudget is omitted (#11320)', () => {
+        const schema = JSON.parse(execFileSync('node', ['-e', "process.stdout.write(require('fs').readFileSync('.agents/skills/skills.manifest.schema.json', 'utf8'))"], {
+            cwd     : process.cwd(),
+            encoding: 'utf8'
+        }));
+
+        const errors = validateManifestSchema({
+            schemaVersion: 1,
+            sourceOfTruth: 'test',
+            defaults     : {
+                routerByteBudget    : 12,
+                payloadBudget       : 80000,
+                claudeSymlinkRequired: true,
+                downstreamDocsTargets: []
+            },
+            skills: {
+                'legacy-skill': {
+                    name                : 'legacy-skill',
+                    description         : 'pre-#11320 manifest entry without perFilePayloadBudget',
+                    triggers            : 'Use for tests.',
+                    routerByteBudget    : 12,
+                    payloadBudget       : 80000,
+                    claudeSymlinkRequired: true,
+                    downstreamDocsTargets: []
+                }
+            }
+        }, schema);
+
+        expect(errors).toEqual([]);
+    });
 });


### PR DESCRIPTION
Resolves #11332 (narrowing-carve-out of #11320 per Cycle 1 RA1; AC4-5 stay parented to #11320 for follow-up implementation after Sub-B+ migrations land)

Refs #11320 (Sub-A original ticket; AC4 section-trigger parser + AC5 trigger-frequency × size heuristic remain its open ACs)
Refs #11319 (parent Epic — Trigger-Aware Workflows from Discussion #11314 graduation)

### Context

First implementation PR for Epic #11319 (Trigger-Aware Workflows: Recursive Map vs World Atlas). Strictly bounded substrate-primitive: schema extension + lint logic + `/create-skill` discipline update. **NO workflow migrations in this PR** per @neo-gpt body-repair #4 on Discussion #11314 (migration blast-radius bounded one-skill-per-PR via Sub-B+).

**Cycle 1 narrowing** (per @neo-gpt RA1 close-target audit): retargeted `Resolves #11320` → `Resolves #11332`. #11332 is the narrower carve-out for the per-file cap primitive shipped here; #11320 stays OPEN for AC4 (section-trigger parser) + AC5 (trigger-frequency × size heuristic) which require Sub-B+ migration substrate to declare triggers before the parser/heuristic have anything to operate on.

### What ships

**Schema (`skills.manifest.schema.json`):** new optional `perFilePayloadBudget` field in `defaults` block AND per-skill `$defs/skill` properties. Positive integer when present; **omit to disable** per-file enforcement (canonical nullable-contract semantics per Cycle 1 RA3).

**Manifest (`skills.manifest.json`):**
- `defaults.perFilePayloadBudget`: **25,000** (25 KB empirical floor for clean skills)
- `pr-review.perFilePayloadBudget`: **66,000** (temporary override; `pr-review-guide.md` at 57,388 B + ~15% headroom; tightens via Sub-B migration)
- `pull-request.perFilePayloadBudget`: **38,000** (temporary override; `pull-request-workflow.md` at 33,463 B + ~15% headroom; tightens via Sub-C migration)
- All other 23 skills pass under the 25K default

**Lint (`ai/scripts/lint-skill-manifest.mjs`):**
- New `payloadFileSizes()` helper walks `references/` per skill, returns per-file byte sizes
- **NEW (per Cycle 1 RA2):** pure exported `checkPerFileBudgets(files, perFileBudget)` extracted from inline lint loop — testable, reusable by future sub-rule-extraction tooling
- Main `lint()` cascades `skill.perFilePayloadBudget ?? defaults.perFilePayloadBudget` and delegates to `checkPerFileBudgets`; failure messages cite Map vs World Atlas extraction discipline
- Schema validator: `perFilePayloadBudget` validated as positive integer when present; backwards-compatible when omitted
- Unsupported-key checks tightened to use `schema.properties` keys (not `schema.required`) so optional fields don't false-fail

**`/create-skill` discipline (`skill-authoring-guide.md`):** new "Recursive Application: Workflow Files Are Also Maps" subsection (lines 113+) documenting:
- The discipline (always-relevant inline; edge cases as ONE LINE triggers per operator directive 2026-05-13T16:14Z)
- Canonical syntax: `<!-- trigger: [condition] → read [sub-rule.md] -->`
- Mechanical enforcement via `perFilePayloadBudget` lint
- Empirical precedents (`pull-request` 4-sub-rule pattern + `pr-review/audits/loading-runtime-effect.md` extraction)
- HNSW topography cross-reference to Discussion #11314 §1.5

**Tests (`test/playwright/unit/ai/scripts/lintSkillManifest.spec.mjs`):** 7 total specs added for `perFilePayloadBudget` work:
- Schema accepts `perFilePayloadBudget` as optional `defaults` field
- Schema accepts `perFilePayloadBudget` as optional per-skill override
- Validator rejects non-positive `perFilePayloadBudget` (zero, negative)
- Backwards-compat: manifest without `perFilePayloadBudget` passes cleanly
- **NEW (per Cycle 1 RA2):** `checkPerFileBudgets` returns error for over-budget file (negative path) + correct error message shape (cites Map vs World Atlas + skill-authoring-guide.md)
- **NEW (per Cycle 1 RA2):** `checkPerFileBudgets` returns no errors when all files under budget
- **NEW (per Cycle 1 RA3 nullable-contract):** `checkPerFileBudgets` treats null/undefined/non-positive budget as disabled per omit-to-disable rule

**13/13 tests pass in 2.2s.** Lint passes locally: `[lint-skill-manifest] OK`.

### Nullable contract semantics (per Cycle 1 RA3)

Canonical rule: **"omit to disable; positive integer when present."** Explicit `null` is rejected by the schema validator (matches implementation). This is the intended v1 contract — the field is optional, and absence-of-field = no per-file enforcement. Sub-A-follow-up (#11332 AC8) documents this verbatim.

### /turn-memory-pre-flight retrospective (per Cycle 1 RA4)

The PR mutates one skill-loaded substrate file (`.agents/skills/create-skill/references/skill-authoring-guide.md`). Decision-tree application:

- **Step 1 (universal rule?):** No — the recursive-application discipline only applies during skill authoring (not always-loaded)
- **Step 2 (skill lifecycle event?):** Yes — `/create-skill` invocation time; this is the authoring-time discipline gate
- **Step 3 (which atlas?):** `/create-skill` payload (`references/skill-authoring-guide.md`) — correct placement; loads only when `/create-skill` fires
- **Mechanical load-effect:** the addition is conditionally-loaded ONLY when an agent invokes `/create-skill` (skill-creation lifecycle); zero impact on always-loaded turn-memory substrate (AGENTS.md / CLAUDE.md / CODEX.md / ANTIGRAVITY_RULES.md unaffected)
- **No duplicated harness-local prose:** the canonical syntax + trigger discipline is documented ONCE in this payload; not duplicated to AGENTS.md or workflow files

### Substrate-Mutation Pre-Flight slot-rationale (per `pull-request-workflow.md §1.1`)

**Added section** — `skills.manifest.schema.json` `perFilePayloadBudget` field (defaults + per-skill)
- Disposition: `keep` (in MACHINE-ENFORCEABLE-CANDIDATE class)
- 3-axis: high-frequency (every CI run on `.agents/skills/**` PR) × high-severity (atlas-monolith re-bloat empirically demonstrated +27-130% over 6-8 weeks post-Epic #10733 cleanup; AGENTS.md 11,742 → 27,017 B; pr-review-guide.md 45,210 → 57,388 B) × machine-enforceable (lint script)
- Net cost: ~30 chars in always-loaded schema, ~60 chars in manifest defaults + 2 per-skill overrides
- Future-decay-mitigation: preventive against linear future bloat; per-file cap is the mechanical primitive Discussion #11314 OQ1+OQ2 resolved-to-AC

**Added section** — `skill-authoring-guide.md` "Recursive Application" subsection (+26 lines)
- Disposition: `keep`; conditionally-loaded only on `/create-skill` invocation
- Documents canonical syntax + recursive principle for Sub-B+ migrations to consume

**Refactored + Modified script** — `lint-skill-manifest.mjs` (+47 lines including refactor)
- Disposition: `keep`; mechanically enforces the principle
- payloadFileSizes() walker + checkPerFileBudgets() pure exported function + perFileBudget cascade logic in main lint()

**Added tests** — 3 new specs (+38 lines)
- Disposition: `keep`; test-substrate is bounded by feature value
- Cover RA2 over-budget negative path + RA3 nullable-contract omit-to-disable rule

**Net delta:** roughly +220 / -10 lines. Substrate net-expansion is preventive net-saver per `AGENTS.md §13` Substrate Accretion Defense.

### Acceptance Criteria (per #11332 — narrower carve-out)

- [x] **AC1: Schema field added** — `perFilePayloadBudget` in defaults + per-skill (optional; omit-to-disable semantics)
- [x] **AC2: Manifest populated** — `defaults.perFilePayloadBudget = 25000` + 2 monolith overrides
- [x] **AC3: Lint walks per-file** — `payloadFileSizes()` walker + `perFilePayloadBudget` cascade
- [x] **AC4: Pure exported `checkPerFileBudgets` function** — refactored from inline lint loop
- [x] **AC5: `/create-skill` discipline updated** — `skill-authoring-guide.md` "Recursive Application" subsection
- [x] **AC6: No workflow migrations**
- [x] **AC7: Lint backwards-compatible**
- [x] **AC8: Nullable contract clarified** — omit-to-disable canonical
- [x] **AC9: Test coverage** — 13 specs (including 3 new negative-path + null-budget tests)
- [x] **AC10: `/turn-memory-pre-flight` retrospective** — documented above

### #11320 ACs that STAY (separate follow-up PR after Sub-B+ migrations)

- [ ] **AC4 (#11320):** Section-trigger parser — regex against `<!-- trigger: ... -->` HTML comments; parser indexes section anchor + trigger string + sub-rule path + body size
- [ ] **AC5 (#11320):** Trigger-frequency × size heuristic — section larger than threshold AND trigger matches rare-firing pattern → flagged with Required-Action template
- [ ] **AC9 subset (#11320):** Tests for parser/heuristic paths

These ship after Sub-B+ migrations introduce trigger declarations to validate against (YAGNI prevention).

### Verification

- ✅ `node ai/scripts/lint-skill-manifest.mjs` → `[lint-skill-manifest] OK`
- ✅ `npm run test-unit -- --grep lint-skill-manifest` → **13/13 pass (2.2s)**
- ✅ `git diff --stat` → 5 files

### Cross-#11317 coupling

Sub-A defines `perFilePayloadBudget` schema field. Gemini's parallel Epic #11317 (Skills Semantic Search / KB Ingestion, from Discussion #11316) consumes the SAME per-file extracted siblings as ChromaDB chunks with `isAtlasMonolithSubRule: true` metadata. Coordination point: Sub-B+ migrations create the sub-rule sibling files that #11317's SkillSource ingests. No code coupling in this PR; coordination is at migration-time.

---

🤖 Authored by @neo-opus-4-7 — operator distribution mandate 2026-05-13T19:06Z. Cycle 1 RAs addressed: RA1 close-target retargeted to narrower #11332; RA2 `checkPerFileBudgets` refactored + 3 new tests including over-budget negative path; RA3 nullable contract canonicalized to "omit to disable"; RA4 `/turn-memory-pre-flight` retrospective added above.
