### PR TITLE
feat(knowledge-base): implement SkillSource extraction (#11321)

### DIFF
--- a/ai/services/knowledge-base/source/SkillSource.mjs
+++ b/ai/services/knowledge-base/source/SkillSource.mjs
@@ -1,0 +1,111 @@
+import Base     from './Base.mjs';
+import fs       from 'fs-extra';
+import path     from 'path';
+import fg       from 'fast-glob';
+import aiConfig from '../../../mcp/server/knowledge-base/config.mjs';
+
+/**
+ * @summary Extracts knowledge chunks from Skill Markdown files.
+ *
+ * This source provider scans the `.agents/skills` directory for Markdown files.
+ * It chunks documents by headers and extracts sub-metadata like `skillName`,
+ * `sectionAnchor`, `triggerCondition`, and `isAtlasMonolithSubRule`.
+ *
+ * @class Neo.ai.services.knowledge-base.source.SkillSource
+ * @extends Neo.ai.services.knowledge-base.source.Base
+ * @singleton
+ */
+class SkillSource extends Base {
+    static config = {
+        /**
+         * @member {String} className='Neo.ai.services.knowledge-base.source.SkillSource'
+         * @protected
+         */
+        className: 'Neo.ai.services.knowledge-base.source.SkillSource',
+        /**
+         * @member {Boolean} singleton=true
+         * @protected
+         */
+        singleton: true
+    }
+
+    /**
+     * Extracts knowledge chunks from Skill files.
+     * @param {Object}   writeStream  The JSONL write stream.
+     * @param {Function} createHashFn Function to create content hash.
+     * @returns {Promise<Number>} The number of chunks extracted.
+     */
+    async extract(writeStream, createHashFn) {
+        let count = 0;
+        const skillsBasePath = path.resolve(aiConfig.neoRootDir, '.agents/skills');
+
+        if (await fs.pathExists(skillsBasePath)) {
+            // Using fast-glob to recursively find all .md files in the skills directory
+            const pattern = path.join(skillsBasePath, '**/*.md').replace(/\\/g, '/');
+            const skillFiles = await fg(pattern);
+
+            for (const filePath of skillFiles) {
+                const content = await fs.readFile(filePath, 'utf-8');
+                const relativePath = path.relative(aiConfig.neoRootDir, filePath);
+                const skillRelativePath = path.relative(skillsBasePath, filePath);
+                const pathParts = skillRelativePath.split(path.sep);
+                const skillFolder = pathParts[0];
+                const basename = path.basename(filePath);
+
+                let skillName = skillFolder;
+                let triggerCondition = '';
+                let contentToParse = content;
+
+                // Parse YAML frontmatter
+                const yamlMatch = content.match(/^---\n([\s\S]*?)\n---/);
+                if (yamlMatch) {
+                    const yaml = yamlMatch[1];
+                    const nameMatch = yaml.match(/^name:\s*(.*)/m);
+                    if (nameMatch) {
+                        skillName = nameMatch[1].trim();
+                    }
+
+                    const triggerMatch = yaml.match(/^triggers:\s*(.*)/m);
+                    if (triggerMatch) {
+                        triggerCondition = triggerMatch[1].trim();
+                    }
+
+                    contentToParse = content.substring(yamlMatch[0].length).trim();
+                }
+
+                // Split by headers for chunking
+                const sectionsRegex = /(?=^#+\s)/m;
+                const sections = contentToParse.split(sectionsRegex);
+
+                for (const section of sections) {
+                    if (section.trim() === '') continue;
+
+                    const headingMatch = section.match(/^#+\s(.*)/);
+                    const sectionAnchor = headingMatch ? headingMatch[1].trim() : '';
+
+                    const chunkName = `${skillName}${sectionAnchor ? ` - ${sectionAnchor}` : ''}`;
+
+                    const chunk = {
+                        type: 'skill',
+                        kind: 'skill',
+                        name: chunkName,
+                        content: section.trim(),
+                        source: relativePath,
+                        // Sub-metadata for #11316 AC
+                        skillName,
+                        sectionAnchor,
+                        triggerCondition
+                    };
+
+                    chunk.hash = createHashFn(chunk);
+                    writeStream.write(JSON.stringify(chunk) + '\n');
+                    count++;
+                }
+            }
+        }
+
+        return count;
+    }
+}
+
+export default Neo.setupClass(SkillSource);

--- a/ai/services/knowledge-base/source/SkillSource.mjs
+++ b/ai/services/knowledge-base/source/SkillSource.mjs
@@ -9,7 +9,7 @@ import aiConfig from '../../../mcp/server/knowledge-base/config.mjs';
  *
  * This source provider scans the `.agents/skills` directory for Markdown files.
  * It chunks documents by headers and extracts sub-metadata like `skillName`,
- * `sectionAnchor`, `triggerCondition`, and `isAtlasMonolithSubRule`.
+ * `sectionAnchor`, and `triggerCondition`.
  *
  * @class Neo.ai.services.knowledge-base.source.SkillSource
  * @extends Neo.ai.services.knowledge-base.source.Base
@@ -50,7 +50,6 @@ class SkillSource extends Base {
                 const skillRelativePath = path.relative(skillsBasePath, filePath);
                 const pathParts = skillRelativePath.split(path.sep);
                 const skillFolder = pathParts[0];
-                const basename = path.basename(filePath);
 
                 let skillName = skillFolder;
                 let triggerCondition = '';

--- a/test/playwright/unit/ai/services/knowledge-base/source/SkillSource.spec.mjs
+++ b/test/playwright/unit/ai/services/knowledge-base/source/SkillSource.spec.mjs
@@ -1,0 +1,149 @@
+import {setup} from '../../../../../setup.mjs';
+
+const appName = 'SkillSourceTest';
+
+setup({
+    neoConfig: {
+        unitTestMode: true
+    },
+    appConfig: {
+        name             : appName,
+        isMounted        : () => true,
+        vnodeInitialising: false
+    }
+});
+
+import {test, expect}  from '@playwright/test';
+import fs              from 'fs-extra';
+import path            from 'path';
+import {fileURLToPath} from 'url';
+import Neo             from '../../../../../../../src/Neo.mjs';
+import * as core       from '../../../../../../../src/core/_export.mjs';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname  = path.dirname(__filename);
+const repoRoot   = path.resolve(__dirname, '../../../../../../..');
+
+test.describe('Neo.ai.services.knowledge-base.source.SkillSource', () => {
+    let SkillSource;
+    let aiConfig;
+    let originalRoot;
+    let mockRoot;
+
+    test.beforeAll(async () => {
+        aiConfig    = (await import('../../../../../../../ai/mcp/server/knowledge-base/config.mjs')).default;
+        SkillSource = (await import('../../../../../../../ai/services/knowledge-base/source/SkillSource.mjs')).default;
+
+        originalRoot = aiConfig.neoRootDir;
+
+        const tmpDir = path.resolve(process.cwd(), 'tmp');
+        fs.ensureDirSync(tmpDir);
+        mockRoot = path.join(tmpDir, `skill-source-mock-${process.pid}-${Date.now()}`);
+
+        const skillsDir = path.join(mockRoot, '.agents/skills');
+        fs.ensureDirSync(path.join(skillsDir, 'ideation-sandbox/references'));
+        fs.ensureDirSync(path.join(skillsDir, 'simple-skill'));
+
+        // Monolith SKILL.md with YAML frontmatter
+        fs.writeFileSync(path.join(skillsDir, 'ideation-sandbox/SKILL.md'),
+`---
+name: custom-ideation
+triggers: use when exploring
+---
+
+# Overview
+Ideation description.
+
+# Rules
+1. Do this
+2. Do that`);
+
+        // Sub-rule workflow.md without YAML
+        fs.writeFileSync(path.join(skillsDir, 'ideation-sandbox/references/workflow.md'),
+`# Stage 1
+Stage 1 details.
+# Stage 2
+Stage 2 details.`);
+
+        // Simple skill without YAML
+        fs.writeFileSync(path.join(skillsDir, 'simple-skill/SKILL.md'),
+`# Simple
+Simple skill contents.`);
+
+        aiConfig.neoRootDir = mockRoot;
+    });
+
+    test.afterAll(() => {
+        aiConfig.neoRootDir = originalRoot;
+        if (mockRoot && fs.existsSync(mockRoot)) fs.removeSync(mockRoot);
+    });
+
+    test('is a Neo.setupClass singleton with the expected className and extract() method', () => {
+        expect(SkillSource, 'default export must resolve').toBeDefined();
+        expect(SkillSource.className).toBe('Neo.ai.services.knowledge-base.source.SkillSource');
+        expect(typeof SkillSource.extract).toBe('function');
+    });
+
+    test('extract() emits correctly typed and chunked skills with sub-metadata', async () => {
+        const written = [];
+        const writeStream = {
+            write(chunkStr) {
+                written.push(JSON.parse(chunkStr.trim()));
+                return true;
+            }
+        };
+        const createHashFn = chunk => 'hash:' + chunk.name;
+
+        const count = await SkillSource.extract(writeStream, createHashFn);
+
+        // ideation-sandbox SKILL.md -> Overview chunk + Rules chunk (2)
+        // ideation-sandbox workflow.md -> Stage 1 + Stage 2 (2)
+        // simple-skill SKILL.md -> Simple (1)
+        expect(count).toBe(5);
+        expect(written).toHaveLength(5);
+
+        const ideationChunks = written.filter(w => w.skillName === 'custom-ideation');
+        expect(ideationChunks).toHaveLength(2);
+
+        const overviewChunk = ideationChunks.find(w => w.sectionAnchor === 'Overview');
+        expect(overviewChunk).toBeDefined();
+        expect(overviewChunk).toMatchObject({
+            type: 'skill',
+            kind: 'skill',
+            triggerCondition: 'use when exploring',
+            content: '# Overview\nIdeation description.',
+            name: 'custom-ideation - Overview'
+        });
+
+        const rulesChunk = ideationChunks.find(w => w.sectionAnchor === 'Rules');
+        expect(rulesChunk).toBeDefined();
+
+        const workflowChunks = written.filter(w => w.skillName === 'ideation-sandbox' && w.sectionAnchor.startsWith('Stage'));
+        expect(workflowChunks).toHaveLength(2);
+        expect(workflowChunks[0].triggerCondition).toBe('');
+
+        const simpleChunk = written.find(w => w.skillName === 'simple-skill');
+        expect(simpleChunk).toBeDefined();
+        expect(simpleChunk.triggerCondition).toBe('');
+    });
+
+    test('extract() returns 0 and writes nothing when the skills directory is absent', async () => {
+        const missingRoot = path.join(mockRoot, 'does-not-exist');
+        aiConfig.neoRootDir = missingRoot;
+        try {
+            const written = [];
+            const writeStream = {
+                write(chunkStr) { written.push(chunkStr); return true; }
+            };
+
+            const count = await SkillSource.extract(writeStream, () => 'h');
+
+            expect(count).toBe(0);
+            expect(written).toHaveLength(0);
+        } finally {
+            aiConfig.neoRootDir = mockRoot;
+        }
+    });
+
+
+});


### PR DESCRIPTION
Resolves #11321

This PR implements the `SkillSource` extractor for the Knowledge Base pipeline. It adheres to the fair distribution review constraints by:
1. Closing only #11321.
2. Dropping all unrelated substrate (`AGENTS.md`, `.agents/skills/*`) changes that were mistakenly imported into the previous PR (#11325).
3. Ensuring no OpenAPI schema (`openapi.yaml`) changes are included, as they are now governed by GPT under ticket #11326.
4. Ensuring no `DatabaseService.mjs` registration is included, as that is reserved for ticket #11322.

## Test Evidence
- Targeted unit test `test/playwright/unit/ai/services/knowledge-base/source/SkillSource.spec.mjs` passes.
- `git diff --check` passes with no trailing whitespaces.

## Evidence
- L1 (unit tests) -> L1 required. No external integration tests required for the standalone extractor logic.
