### PR TITLE
feat(knowledge-base): expose skill query type (#11326)

### DIFF
--- a/ai/mcp/server/knowledge-base/openapi.yaml
+++ b/ai/mcp/server/knowledge-base/openapi.yaml
@@ -173,7 +173,7 @@ paths:
         
         **Input:**
         - `query`: Natural language search query (1-10 words work best)
-        - `type`: Optional filter by content type (all, blog, guide, src, example, ticket, release)
+        - `type`: Optional filter by content type (all, blog, guide, src, example, ticket, release, test, skill)
         
         **Output:**
         A ranked list of file paths with relevance scores. Example:
@@ -317,7 +317,7 @@ paths:
         **Input:**
         - `query`: The question to ask. Natural language works best — ask it like you would ask a senior developer.
         - `limit`: (Optional) Number of source documents to consider (default 5). Increase for broader questions.
-        - `type`: (Optional) Filter by content type (e.g., 'guide', 'src', 'all').
+        - `type`: (Optional) Filter by content type (e.g., 'guide', 'src', 'all', 'skill').
 
         **Output:**
         - `answer`: Synthesized answer grounded in the current codebase.
@@ -363,8 +363,8 @@ paths:
                   description: The question to ask.
                 type:
                   type: string
-                  description: "Optional filter by content type (e.g., 'guide', 'src', 'all')."
-                  enum: [all, blog, guide, src, example, ticket, release, test]
+                  description: "Optional filter by content type (e.g., 'guide', 'src', 'all', 'skill')."
+                  enum: [all, blog, guide, src, example, ticket, release, test, skill]
                   default: all
                 limit:
                   type: integer
@@ -700,7 +700,8 @@ components:
             - `ticket`: Issues from GitHub. Can be open (potential work) or closed (historical context).
             - `release`: Release notes and changelogs
             - `test`: Automated tests and specs
-          enum: [all, blog, guide, src, example, ticket, release, test]
+            - `skill`: Agent skill documentation and rules
+          enum: [all, blog, guide, src, example, ticket, release, test, skill]
           default: all
         limit:
           type: integer

--- a/test/playwright/unit/ai/mcp/validation/OpenApiValidatorCompliance.spec.mjs
+++ b/test/playwright/unit/ai/mcp/validation/OpenApiValidatorCompliance.spec.mjs
@@ -194,6 +194,23 @@ test.describe('OpenApiValidator: strict-client JSON-Schema compliance', () => {
         expect(coalesceWindow.maximum).toBe(300);
     });
 
+    test('knowledge-base query schemas expose skill content type (#11326)', async () => {
+        const expectedTypes = ['all', 'blog', 'guide', 'src', 'example', 'ticket', 'release', 'test', 'skill'],
+              doc           = yaml.load(fs.readFileSync(path.join(repoRoot, 'ai/mcp/server/knowledge-base/openapi.yaml'), 'utf8')),
+              queryOp       = doc.paths['/documents/query'].post,
+              askOp         = doc.paths['/knowledge/ask'].post,
+              querySchema   = zodToJsonSchema(buildZodSchema(doc, queryOp), {target: 'openApi3', $refStrategy: 'none'}),
+              askSchema     = zodToJsonSchema(buildZodSchema(doc, askOp), {target: 'openApi3', $refStrategy: 'none'}),
+              queryType     = doc.components.schemas.QueryRequest.properties.type;
+
+        expect(queryType.enum).toEqual(expectedTypes);
+        expect(queryType.description).toContain('`test`');
+        expect(queryType.description).toContain('`skill`');
+        expect(queryOp.description).toContain('release, test, skill');
+        expect(querySchema.properties.type.enum).toEqual(expectedTypes);
+        expect(askSchema.properties.type.enum).toEqual(expectedTypes);
+    });
+
     for (const server of servers) {
         test(`${server}: every emitted input/output schema has items on array nodes (#10064)`, () => {
             const yamlPath = path.join(repoRoot, 'ai/mcp/server', server, 'openapi.yaml');


### PR DESCRIPTION
Resolves #11326

This PR exposes `skill` as a Knowledge Base MCP query content type for both `query_documents` and `ask_knowledge_base`, keeping the work scoped to the public query-schema surface split out from #11321.

Related: #11317
Related: #11321
Related: #11322

## Deltas from ticket
- Adds `skill` to the Knowledge Base OpenAPI type enums consumed by MCP clients.
- Updates runtime tool prose so the content-type list includes both the pre-existing `test` type and the new `skill` type.
- Adds a targeted OpenAPI validator regression test proving both query tools emit the expanded enum.

## Test Evidence
- `npx playwright test test/playwright/unit/ai/mcp/validation/OpenApiValidatorCompliance.spec.mjs -g "knowledge-base query schemas expose skill content type"` — 1 passed.
- `npx playwright test test/playwright/unit/ai/mcp/validation/OpenApiValidatorCompliance.spec.mjs` — 26 passed.
- `git diff --check` — passed.

## Evidence
- L1 (static OpenAPI schema + unit validator regression) -> L1 required. No external integration residuals.

## Post-Merge Validation
- [ ] After #11321 and #11322 merge, `ask_knowledge_base(..., type: "skill")` returns indexed skill documents once the KB sync has run.

Authored by @neo-gpt (Codex Desktop). Session current.