### PR TITLE
feat(ai/knowledge-base): implement SkillSource for chunk extraction (#11321)

### DIFF
--- a/ai/mcp/server/knowledge-base/openapi.yaml
+++ b/ai/mcp/server/knowledge-base/openapi.yaml
@@ -173,7 +173,7 @@ paths:
         
         **Input:**
         - `query`: Natural language search query (1-10 words work best)
-        - `type`: Optional filter by content type (all, blog, guide, src, example, ticket, release)
+        - `type`: Optional filter by content type (all, blog, guide, src, example, ticket, release, test, skill)
         
         **Output:**
         A ranked list of file paths with relevance scores. Example:
@@ -317,7 +317,7 @@ paths:
         **Input:**
         - `query`: The question to ask. Natural language works best — ask it like you would ask a senior developer.
         - `limit`: (Optional) Number of source documents to consider (default 5). Increase for broader questions.
-        - `type`: (Optional) Filter by content type (e.g., 'guide', 'src', 'all').
+        - `type`: (Optional) Filter by content type (e.g., 'guide', 'src', 'all', 'skill').
 
         **Output:**
         - `answer`: Synthesized answer grounded in the current codebase.
@@ -363,8 +363,8 @@ paths:
                   description: The question to ask.
                 type:
                   type: string
-                  description: "Optional filter by content type (e.g., 'guide', 'src', 'all')."
-                  enum: [all, blog, guide, src, example, ticket, release, test]
+                  description: "Optional filter by content type (e.g., 'guide', 'src', 'all', 'skill')."
+                  enum: [all, blog, guide, src, example, ticket, release, test, skill]
                   default: all
                 limit:
                   type: integer
@@ -700,7 +700,8 @@ components:
             - `ticket`: Issues from GitHub. Can be open (potential work) or closed (historical context).
             - `release`: Release notes and changelogs
             - `test`: Automated tests and specs
-          enum: [all, blog, guide, src, example, ticket, release, test]
+            - `skill`: Agent skill documentation and rules
+          enum: [all, blog, guide, src, example, ticket, release, test, skill]
           default: all
         limit:
           type: integer

--- a/ai/services/knowledge-base/source/SkillSource.mjs
+++ b/ai/services/knowledge-base/source/SkillSource.mjs
@@ -1,0 +1,97 @@
+import Base     from './Base.mjs';
+import fg       from 'fast-glob';
+import fs       from 'fs-extra';
+import path     from 'path';
+import aiConfig from '../../../mcp/server/knowledge-base/config.mjs';
+
+const sectionsRegex = /(?=^#+\s)/m;
+
+/**
+ * @summary Extracts knowledge chunks from '.agents/skills/**/*.md' files.
+ *
+ * @class Neo.ai.services.knowledge-base.source.SkillSource
+ * @extends Neo.ai.services.knowledge-base.source.Base
+ * @singleton
+ */
+class SkillSource extends Base {
+    static config = {
+        /**
+         * @member {String} className='Neo.ai.services.knowledge-base.source.SkillSource'
+         * @protected
+         */
+        className: 'Neo.ai.services.knowledge-base.source.SkillSource',
+        /**
+         * @member {Boolean} singleton=true
+         * @protected
+         */
+        singleton: true
+    }
+
+    /**
+     * Extracts knowledge chunks from '.agents/skills/**/*.md' files.
+     * @param {Object}   writeStream  The JSONL write stream.
+     * @param {Function} createHashFn Function to create content hash.
+     * @returns {Promise<Number>} The number of chunks extracted.
+     */
+    async extract(writeStream, createHashFn) {
+        let count = 0;
+        const skillsGlob = path.join(aiConfig.neoRootDir, '.agents/skills/**/*.md').replace(/\\/g, '/');
+        const files = await fg(skillsGlob);
+
+        for (const filePath of files) {
+            const content = await fs.readFile(filePath, 'utf-8');
+            
+            // Extract YAML frontmatter
+            let skillName = '';
+            let triggerCondition = '';
+            
+            const yamlMatch = content.match(/^---\n([\s\S]*?)\n---/);
+            if (yamlMatch) {
+                const yaml = yamlMatch[1];
+                const nameMatch = yaml.match(/^name:\s*(.+)/m);
+                if (nameMatch) skillName = nameMatch[1].trim();
+
+                const triggersMatch = yaml.match(/^triggers:\s*(.+)/m);
+                if (triggersMatch) triggerCondition = triggersMatch[1].trim();
+            }
+
+            // Default to filename if name not in frontmatter
+            if (!skillName) {
+                skillName = path.basename(filePath, '.md');
+            }
+
+            const isAtlasMonolithSubRule = false; // By definition, skill markdown files are not the monolith.
+
+            const body = content.replace(/^---\n[\s\S]*?\n---/, '').trim();
+            const sections = body.split(sectionsRegex);
+
+            for (const section of sections) {
+                if (section.trim() === '') continue;
+                
+                const headingMatch = section.match(/^#+\s(.*)/);
+                const sectionAnchor = headingMatch ? headingMatch[1].trim() : skillName;
+                
+                const chunk = {
+                    type                  : 'skill',
+                    kind                  : 'skill',
+                    name                  : `${skillName} - ${sectionAnchor}`,
+                    id                    : `${skillName}-${sectionAnchor.replace(/[^a-zA-Z0-9]/g, '-').toLowerCase()}`,
+                    content               : section,
+                    source                : path.relative(aiConfig.neoRootDir, filePath),
+                    skillName,
+                    sectionAnchor,
+                    triggerCondition,
+                    isAtlasMonolithSubRule
+                };
+                
+                chunk.hash = createHashFn(chunk);
+                writeStream.write(JSON.stringify(chunk) + '\n');
+                count++;
+            }
+        }
+        
+        return count;
+    }
+}
+
+export default Neo.setupClass(SkillSource);

--- a/test/playwright/unit/ai/mcp/validation/OpenApiValidatorCompliance.spec.mjs
+++ b/test/playwright/unit/ai/mcp/validation/OpenApiValidatorCompliance.spec.mjs
@@ -194,6 +194,23 @@ test.describe('OpenApiValidator: strict-client JSON-Schema compliance', () => {
         expect(coalesceWindow.maximum).toBe(300);
     });
 
+    test('knowledge-base query schemas expose skill content type (#11326)', async () => {
+        const expectedTypes = ['all', 'blog', 'guide', 'src', 'example', 'ticket', 'release', 'test', 'skill'],
+              doc           = yaml.load(fs.readFileSync(path.join(repoRoot, 'ai/mcp/server/knowledge-base/openapi.yaml'), 'utf8')),
+              queryOp       = doc.paths['/documents/query'].post,
+              askOp         = doc.paths['/knowledge/ask'].post,
+              querySchema   = zodToJsonSchema(buildZodSchema(doc, queryOp), {target: 'openApi3', $refStrategy: 'none'}),
+              askSchema     = zodToJsonSchema(buildZodSchema(doc, askOp), {target: 'openApi3', $refStrategy: 'none'}),
+              queryType     = doc.components.schemas.QueryRequest.properties.type;
+
+        expect(queryType.enum).toEqual(expectedTypes);
+        expect(queryType.description).toContain('`test`');
+        expect(queryType.description).toContain('`skill`');
+        expect(queryOp.description).toContain('release, test, skill');
+        expect(querySchema.properties.type.enum).toEqual(expectedTypes);
+        expect(askSchema.properties.type.enum).toEqual(expectedTypes);
+    });
+
     for (const server of servers) {
         test(`${server}: every emitted input/output schema has items on array nodes (#10064)`, () => {
             const yamlPath = path.join(repoRoot, 'ai/mcp/server', server, 'openapi.yaml');


### PR DESCRIPTION
Authored by @neo-gemini-3-1-pro (Neo Gemini). Session 2c4aa4df-2628-45ae-a9c2-156fd9308f21.

Resolves #11321

Implemented `SkillSource.mjs` to extract chunks from `.agents/skills/**/*.md` files.
It assigns `type: 'skill'` to the chunks and extracts `skillName`, `sectionAnchor`, `triggerCondition`, and sets `isAtlasMonolithSubRule` to `false` as these are not monolith sub-rules.

Evidence: L1 (static config-shape audit) → L1 required (no runtime-verify ACs). No residuals.

## Deltas from ticket (if any)
None.

## Test Evidence
N/A (covered by upcoming sub-ticket).

## Post-Merge Validation
- [ ] Integration with `sync-kb`.