### PR TITLE
fix(kb): emit SkillSource atlas metadata (#11323)

### DIFF
--- a/ai/services/knowledge-base/source/SkillSource.mjs
+++ b/ai/services/knowledge-base/source/SkillSource.mjs
@@ -47,9 +47,10 @@ class SkillSource extends Base {
             for (const filePath of skillFiles) {
                 const content = await fs.readFile(filePath, 'utf-8');
                 const relativePath = path.relative(aiConfig.neoRootDir, filePath);
-                const skillRelativePath = path.relative(skillsBasePath, filePath);
-                const pathParts = skillRelativePath.split(path.sep);
-                const skillFolder = pathParts[0];
+                const skillRelativePath       = path.relative(skillsBasePath, filePath);
+                const pathParts               = skillRelativePath.split(path.sep);
+                const skillFolder             = pathParts[0];
+                const isAtlasMonolithSubRule  = pathParts.includes('references');
 
                 let skillName = skillFolder;
                 let triggerCondition = '';
@@ -93,7 +94,8 @@ class SkillSource extends Base {
                         // Sub-metadata for #11316 AC
                         skillName,
                         sectionAnchor,
-                        triggerCondition
+                        triggerCondition,
+                        isAtlasMonolithSubRule
                     };
 
                     chunk.hash = createHashFn(chunk);

--- a/test/playwright/unit/ai/services/knowledge-base/source/SkillSource.spec.mjs
+++ b/test/playwright/unit/ai/services/knowledge-base/source/SkillSource.spec.mjs
@@ -111,6 +111,7 @@ Simple skill contents.`);
             type: 'skill',
             kind: 'skill',
             triggerCondition: 'use when exploring',
+            isAtlasMonolithSubRule: false,
             content: '# Overview\nIdeation description.',
             name: 'custom-ideation - Overview'
         });
@@ -121,10 +122,12 @@ Simple skill contents.`);
         const workflowChunks = written.filter(w => w.skillName === 'ideation-sandbox' && w.sectionAnchor.startsWith('Stage'));
         expect(workflowChunks).toHaveLength(2);
         expect(workflowChunks[0].triggerCondition).toBe('');
+        expect(workflowChunks.every(w => w.isAtlasMonolithSubRule)).toBe(true);
 
         const simpleChunk = written.find(w => w.skillName === 'simple-skill');
         expect(simpleChunk).toBeDefined();
         expect(simpleChunk.triggerCondition).toBe('');
+        expect(simpleChunk.isAtlasMonolithSubRule).toBe(false);
     });
 
     test('extract() returns 0 and writes nothing when the skills directory is absent', async () => {


### PR DESCRIPTION
Resolves #11323

Authored by GPT-5.5 (Codex Desktop) consuming Gemini 3.1 Pro implementation from #11321 - session A 2c4aa4df-2628-45ae-a9c2-156fd9308f21, session B d6d89930-f408-42a0-b60e-ec4487a8cc46.

Completes the remaining SkillSource metadata test gap on current dev. The initial SkillSource unit spec was already present after recent merges; this PR adds the missing `isAtlasMonolithSubRule` source metadata and asserts the router-vs-reference behavior in the existing focused unit test.

Evidence: L1 (focused Playwright source-unit test plus static diff hygiene) -> L1 required (source-unit metadata ACs). No residuals.

## Deltas from Ticket
- Uses the existing canonical Playwright unit-test path under `test/playwright/unit/ai/services/knowledge-base/source/` instead of creating a second spec beside source code.
- Adds a conservative migration-period classifier: files under `.agents/skills/<skill>/references/**` emit `isAtlasMonolithSubRule: true`; top-level skill router files emit `false`.
- Does not add semantic heuristics ahead of the trigger-aware workflow lane (#11319/#11320).

## Signal Ledger (Sourced from Discussion #11316)
- @neo-gemini-3-1-pro: APPROVED @ https://github.com/neomjs/neo/discussions/11316#discussioncomment-16908710
- @neo-opus-4-7: APPROVED @ https://github.com/neomjs/neo/discussions/11316#discussioncomment-16908732
- @neo-gpt: APPROVED @ https://github.com/neomjs/neo/discussions/11316#discussioncomment-16908816

## Unresolved Dissent
(empty)

## Unresolved Liveness
(empty)

## Test Evidence
- `npm run test-unit -- test/playwright/unit/ai/services/knowledge-base/source/SkillSource.spec.mjs` -> 3 passed (post-rebase)
- `git diff --check origin/dev..HEAD` -> passed
- `git merge-base --is-ancestor origin/dev HEAD` -> passed before push

## Post-Merge Validation
- [ ] #11323 closes through the PR close keyword.
- [ ] Follow-up #11322 keeps using the same `type: skill` metadata contract during sync integration.

## Commit
- `e628de7f3` - `fix(kb): emit SkillSource atlas metadata (#11323)`

Related: #11317
Related: #11321
Related: #11319