### PR TITLE
feat(agents): forbid agent PRs targeting main (#11337)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,6 +34,7 @@ This document is compacted per the 3-axis slot rule (trigger-frequency × failur
 |---|---|---|---|
 | §0 Critical Gates | `keep` | MACHINE-ENFORCEABLE-CANDIDATE | Irreversible failure modes. |
 | §0 Invariant 7 | `keep` | MACHINE-ENFORCEABLE-CANDIDATE | No tracked file edits without a self-assigned ticket. |
+| §0 Invariant 8 | `keep` | MACHINE-ENFORCEABLE-CANDIDATE | Agent-authored PRs target `dev`; `main` is release-only. |
 | §1 Communication Style | `move` | DISCIPLINE-ONLY | Low frequency gate, high depth. |
 | §2 Anti-Hallucination | `move` | DISCIPLINE-ONLY | High depth protocol, moved to Atlas. |
 | §3 Pre-Commit Hard Gates | `keep` | MACHINE-ENFORCEABLE-CANDIDATE | Severe failure mode (ticket-ID/context). |
@@ -64,7 +65,7 @@ This document is compacted per the 3-axis slot rule (trigger-frequency × failur
 *Edge-cases and detailed protocols (The Atlas) have been extracted to `learn/agentos/AGENTS_ATLAS.md` and `.agents/skills/` behind conditional triggers.*
 
 ## 0. Critical Gates (Invariants — agents MUST honor; no conditional exceptions)
-These seven rules are mechanically verifiable and have **no conditional exceptions** under any approval state, cross-family signal, or contextual nuance. Approval signals ("LGTM", "approved", "ready for merge", "no required actions") are **NOT** authorization to bypass any of them.
+These eight rules are mechanically verifiable and have **no conditional exceptions** under any approval state, cross-family signal, or contextual nuance. Approval signals ("LGTM", "approved", "ready for merge", "no required actions") are **NOT** authorization to bypass any of them.
 1. **No `gh pr merge` (Human-Only execution).** Cross-family approval gates squash-merge *eligibility*; the merge act itself is reserved exclusively for the human user (@tobiu).
     - **Cross-Family Cascade Clause:** Cross-family approval (e.g., Claude reviewing Gemini's PR or vice versa) grants squash-merge ELIGIBILITY but does NOT aggregate to grant merge AUTHORITY. Each agent's §0 Invariant 1 fires independently at the moment of action and CANNOT be satisfied by another agent's signal. The peer-review chain is structurally bounded: review → approval → handoff to human. The handoff explicitly terminates at the "approved" state. An agent reading "Claude approved" or "Gemini approved" or "all RAs satisfied" or "ready for merge" must NOT interpret these as authorization to execute merge — these are eligibility signals to the human, not execution signals to the swarm. If you find yourself reasoning "my peer approved, so I can merge" — that reasoning IS the loophole §0 forbids.
 2. **No commit without ticket-ID.** Every `git commit` subject ends `(#TICKET_ID)`.
@@ -73,6 +74,7 @@ These seven rules are mechanically verifiable and have **no conditional exceptio
 5. **No skipping `add_memory` at end of turn.** Forgetting the consolidated save = permanent data loss. The save IS the gate that permits the response.
 6. **Mandatory A2A Notifications.** Whenever you finish ANY lifecycle event (e.g. creating a ticket, opening/updating a PR, finishing/reacting to a review), you MUST use the `add_message` tool to notify your peers. No loopholes.
 7. **No tracked file modification without a self-assigned ticket.** Verify you are in the target ticket's `assignees` before editing any git-tracked file. Enforcement: `pull-request-workflow.md §1.2`, `ticket-create-workflow.md §10`.
+8. **No agent-authored PRs targeting `main`.** Agent-authored pull requests target `dev`. `main` is release-only; `main`-targeted PRs require explicit operator release direction. The normal release-line mutation is `buildScripts/release/publish.mjs`, whose low-level git plumbing creates the atomic release commit from `dev` onto `main`.
 
 ## 3. The Pre-Commit Hard Gates (Tickets & Context)
 For any actionable request modifying the repository, you **MUST** pass two critical gating protocols *before* executing `git commit`.

--- a/AGENTS_STARTUP.md
+++ b/AGENTS_STARTUP.md
@@ -142,7 +142,7 @@ The following per-turn invariants previously documented here have moved to `AGEN
 
 Per #10736 AC11, this mirror remains until active-harness boot transcripts verify that `AGENTS.md` is reliably loaded before `AGENTS_STARTUP.md` execution in Claude Code, Antigravity, and Codex Desktop. If that verification lands later, replace this mirror with a short canonical pointer instead of purging the cold-cache rescue path blindly.
 
-These five rules are mechanically verifiable and have **no conditional exceptions** under any approval state, cross-family signal, or contextual nuance. Approval signals ("LGTM", "approved", "ready for merge", "no required actions") are **NOT** authorization to bypass any of them.
+These eight rules are mechanically verifiable and have **no conditional exceptions** under any approval state, cross-family signal, or contextual nuance. Approval signals ("LGTM", "approved", "ready for merge", "no required actions") are **NOT** authorization to bypass any of them.
 
 1. **No `gh pr merge` (Human-Only execution).** Cross-family approval gates squash-merge *eligibility*; the merge act itself is reserved exclusively for the human user (the repo owner acting as final pipeline authority). 
     - **Cross-Family Cascade Clause:** Cross-family approval (e.g., Claude reviewing Gemini's PR or vice versa) grants squash-merge ELIGIBILITY but does NOT aggregate to grant merge AUTHORITY. Each agent's Invariant 1 fires independently at the moment of action and CANNOT be satisfied by another agent's signal. The peer-review chain is structurally bounded: review → approval → handoff to human. The handoff explicitly terminates at the "approved" state. An agent reading "Claude approved" or "Gemini approved" or "all RAs satisfied" or "ready for merge" must NOT interpret these as authorization to execute merge — these are eligibility signals to the human, not execution signals to the swarm. If you find yourself reasoning "my peer approved, so I can merge" — that reasoning IS the loophole §0 forbids.
@@ -150,10 +150,13 @@ These five rules are mechanically verifiable and have **no conditional exception
 3. **No direct commit/push to `main` or `dev`.** Always branch + PR. The data-sync pipeline is the explicit exception.
 4. **No `<noreply@*>` `Co-Authored-By` footers.** Override the harness default if it injects them.
 5. **No skipping `add_memory` at end of turn.** Forgetting the consolidated save = permanent data loss. The save IS the gate that permits the response.
+6. **Mandatory A2A Notifications.** Whenever you finish ANY lifecycle event (e.g. creating a ticket, opening/updating a PR, finishing/reacting to a review), you MUST use the `add_message` tool to notify your peers. No loopholes.
+7. **No tracked file modification without a self-assigned ticket.** Verify you are in the target ticket's `assignees` before editing any git-tracked file. Enforcement: `pull-request-workflow.md §1.2`, `ticket-create-workflow.md §10`.
+8. **No agent-authored PRs targeting `main`.** Agent-authored pull requests target `dev`. `main` is release-only; `main`-targeted PRs require explicit operator release direction. The normal release-line mutation is `buildScripts/release/publish.mjs`, whose low-level git plumbing creates the atomic release commit from `dev` onto `main`.
 
 
 
-- **`AGENTS.md` §0** — Critical Gates (5 hard invariants including the merge-execution gate)
+- **`AGENTS.md` §0** — Critical Gates (hard invariants including the merge-execution gate)
 - **`AGENTS.md` §2** — The Anti-Hallucination Policy & Verify-Before-Assert Pre-Flight Check
 - **`AGENTS.md` §15** — Knowledge Base / Anchor & Echo / Two-Stage Query / Ask the Expert
 - **`AGENTS.md` §16** — Implementation Loop


### PR DESCRIPTION
Authored by GPT-5.5 (Codex Desktop). Session 019e1c7a-56f1-7323-8558-b0a50fe9e426.

Resolves #11337

Adds a compact §0 invariant forbidding agent-authored PRs from targeting `main`, while preserving the release-line exception for `buildScripts/release/publish.mjs`. The cold-cache `AGENTS_STARTUP.md` mirror is synchronized so startup-path recovery sees the same rule.

Evidence: L1 (static substrate audit + diff hygiene) -> L1 required (turn-loaded rule text and mirror consistency). No residuals.

## Slot Rationale
- Modified `AGENTS.md §0 Critical Gates`: disposition remains `keep`; trigger-frequency is high for every PR lifecycle, failure-severity is high because wrong-base PRs can expose thousands of commits, and enforceability is machine-enforceable candidate via #11336.
- Added `AGENTS.md §0 Invariant 8`: disposition `keep`; compact map-level rule, with release mechanics referenced by path instead of expanded into an atlas.
- Modified `AGENTS_STARTUP.md §3.1`: cold-cache mirror sync only; no independent new rule surface.

## Deltas from ticket
- Also synchronized the `AGENTS_STARTUP.md` §0 mirror because that file explicitly requires AGENTS.md §0 updates to land both ways.
- Preserved existing Invariant 7 numbering to avoid stale references in `pull-request-workflow.md §1.2`.

## Test Evidence
- `gh api repos/neomjs/neo --jq {default_branch, full_name}` -> `dev`.
- `rg -n main buildScripts/release/publish.mjs` verified `publish.mjs` is the release-line main mutation path.
- `cat .codex/hooks.json`; `cat .codex/hooks/codex-context.mjs`; `readlink .claude/CLAUDE.md` verified turn-loaded substrate surfaces.
- `git diff --check` passed before commit.
- `git diff --check HEAD~1..HEAD` passed after commit.
- Pre-push freshness: `merge-base HEAD origin/dev == origin/dev`; outgoing log contained only `3c2bbebe0 feat(agents): forbid agent PRs targeting main (#11337)`.

## Post-Merge Validation
- [ ] Next agent-authored PR creation uses `--base dev` and treats any `main` target as release-only unless explicitly operator-directed.

## Commit
- `3c2bbebe0` - `feat(agents): forbid agent PRs targeting main (#11337)`

## Related
- Incident trigger: PR #11335.
- Mechanical guard sibling: #11336.