### PR TITLE
feat(ci): add mechanical PR base branch guard (#11336)

### DIFF
--- a/.agents/skills/pull-request/references/pull-request-workflow.md
+++ b/.agents/skills/pull-request/references/pull-request-workflow.md
@@ -123,7 +123,7 @@ You MUST use the GitHub CLI to open a Pull Request targeting the `dev` branch.
 
 If the PR changes `ai/mcp/server/<name>/config.template.mjs`, read `.agents/skills/pull-request/references/mcp-config-template-change-guide.md` before finalizing the PR body.
 
-**Mandatory Base Branch Flag:** You MUST explicitly include the `--base dev` flag in your command. Never rely on the default branch parameter, as it may inadvertently default to `main` and result in massive, thousands-of-commits diff bloat.
+**Mandatory Base Branch Flag:** You MUST explicitly include the `--base dev` flag in your command. Never rely on the `gh` default behavior or assume the target without verifying, as it may inadvertently target `main` (e.g., due to local caching or CLI behavior) and result in massive, thousands-of-commits diff bloat.
 
 **No Auto-Fill:** You are strictly forbidden from using the `--fill` flag, as it bypasses the generation of a comprehensive PR body.
 

--- a/.github/workflows/pr-base-guard.yml
+++ b/.github/workflows/pr-base-guard.yml
@@ -1,0 +1,65 @@
+name: PR Base Branch Guard
+on:
+  pull_request:
+    types: [opened, edited, synchronize]
+    branches:
+      - main
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
+jobs:
+  enforce-dev-base:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Enforce dev base for agents
+        uses: actions/github-script@v8
+        with:
+          script: |
+            const pr = context.payload.pull_request;
+            const author = pr.user.login;
+            
+            // Only allow repo owner or authorized release accounts to target main
+            const allowedUsers = ['tobiu'];
+            
+            if (!allowedUsers.includes(author)) {
+              console.log(`❌ Unauthorized PR targeting 'main' from '${author}'. Attempting to change base to 'dev'.`);
+              
+              try {
+                // Attempt to automatically fix the base branch
+                await github.rest.pulls.update({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  pull_number: pr.number,
+                  base: 'dev'
+                });
+                
+                await github.rest.issues.createComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: pr.number,
+                  body: `⚠️ **PR Base Branch Guard Action**\n\nPRs targeting \`main\` are restricted to release operations. I have automatically changed the base branch of this PR to \`dev\`.\n\nPlease ensure your commits were branched from \`dev\`. If not, you may need to rebase your branch.`
+                });
+              } catch (e) {
+                console.error("Failed to automatically change base branch:", e);
+                
+                await github.rest.issues.createComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: pr.number,
+                  body: `❌ **PR Base Branch Guard Violation**\n\nPRs targeting \`main\` are restricted to authorized maintainers. I could not automatically change the base branch to \`dev\`.\n\nThis PR has been closed. Please change your base branch to \`dev\` and reopen it, or open a new PR targeting \`dev\`.`
+                });
+                
+                // Fallback: close the PR to prevent base-main blowups
+                await github.rest.pulls.update({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  pull_number: pr.number,
+                  state: 'closed'
+                });
+                
+                core.setFailed("PR targets main but author is not authorized. PR has been closed.");
+              }
+            } else {
+              console.log("✅ Authorized user targeting main. Allowing.");
+            }

--- a/.github/workflows/pr-base-guard.yml
+++ b/.github/workflows/pr-base-guard.yml
@@ -11,6 +11,9 @@ env:
 jobs:
   enforce-dev-base:
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+      issues: write
     steps:
       - name: Enforce dev base for agents
         uses: actions/github-script@v8


### PR DESCRIPTION
Resolves #11336

Authored by Gemini 3.1 Pro (Antigravity). Session 2c4aa4df-2628-45ae-a9c2-156fd9308f21.

This PR implements a mechanical base-branch guard using GitHub Actions to prevent agent-authored PRs from accidentally targeting the \`main\` branch. It checks the PR target and author; if an unauthorized agent targets \`main\`, it attempts to automatically change the base branch to \`dev\`. If that fails, it closes the PR and fails the check.

Evidence: L1 (static GitHub Action structure audit) -> L4 required (AC3 verify the guard halts or rejects main-targeted PRs). Residual: AC3 [#11336]. The exact validation requires an actual PR creation against main in the repo to see the Action fire, which is out-of-scope for the sandbox environment, but the workflow uses standard \`github-script\` API methods.

## Deltas from ticket (if any)
Added automatic \`base: 'dev'\` reassignment before falling back to closing the PR. This creates a much smoother experience if an agent accidentally opens a PR against \`main\`—it immediately corrects the base branch and diff without manual intervention.

## Test Evidence
Verified the GitHub Action syntax and \`actions/github-script@v8\` API usage.

## Substrate Mutation Rationale
Modified \`.agents/skills/pull-request/references/pull-request-workflow.md\`.
- Section modified: Base Branch Flag explanation.
- Disposition delta: None (remains \`keep\` within the reference payload).
- Reason for shift: Corrected the prose to clarify that targeting \`main\` is a CLI behavior/caching issue, not because \`main\` is the default branch (the repo default is \`dev\`).

## Post-Merge Validation
- [ ] Verify that a test PR from an agent against \`main\` triggers the workflow and corrects to \`dev\`.

## Commits
- 9df2d76 — feat(ci): add mechanical PR base branch guard (#11336)
