### PR TITLE
refactor(ai): implement recursive archive ingestion (#11361)

### DIFF
--- a/ai/daemons/services/IssueIngestor.mjs
+++ b/ai/daemons/services/IssueIngestor.mjs
@@ -224,6 +224,11 @@ class IssueIngestor extends Base {
         return openIssues;
     }
 
+    /**
+     * @summary Extracts Ideation Sandbox Discussion content to drive semantic and structural context.
+     * Searches both active and archived discussion directories recursively.
+     * @returns {Promise<void>}
+     */
     async ingestDiscussionStates() {
         const targetPaths = [
             path.resolve(__dirname, '../../../resources/content/discussions'),
@@ -301,6 +306,11 @@ class IssueIngestor extends Base {
         }
     }
 
+    /**
+     * @summary Performs dual-path semantic mining on active and archived PR review documents to extract heuristic tags.
+     * Parses `[KB_GAP]`, `[TOOLING_GAP]`, and `[RETROSPECTIVE]` tags.
+     * @returns {Promise<void>}
+     */
     async ingestPullRequestFeedback() {
         const targetPaths = [
             path.resolve(__dirname, '../../../resources/content/pulls'),

--- a/ai/daemons/services/IssueIngestor.mjs
+++ b/ai/daemons/services/IssueIngestor.mjs
@@ -38,17 +38,28 @@ class IssueIngestor extends Base {
      * @returns {Promise<Object[]>} Returns only the OPEN issues for synthesis.
      */
     async ingestIssueStates() {
-        const issuesDir = path.resolve(__dirname, '../../../resources/content/issues');
+        const targetPaths = [
+            path.resolve(__dirname, '../../../resources/content/issues'),
+            path.resolve(__dirname, '../../../resources/content/archive/issues')
+        ];
 
-        try {
-            await fs.promises.access(issuesDir);
-        } catch (e) {
-            logger.warn(`[IssueIngestor] Issues directory not found at ${issuesDir}`);
+        const filesRaw = [];
+        for (const targetPath of targetPaths) {
+            try {
+                if (fs.existsSync(targetPath)) {
+                    const files = await fs.promises.readdir(targetPath, { recursive: true });
+                    filesRaw.push(...files.filter(f => typeof f === 'string' && f.endsWith('.md')).map(f => path.join(targetPath, f)));
+                }
+            } catch (e) {
+                logger.warn(`[IssueIngestor] Error reading issues from ${targetPath}`, e);
+            }
+        }
+        
+        if (filesRaw.length === 0) {
             return [];
         }
 
-        const filesRaw = await fs.promises.readdir(issuesDir, { recursive: true });
-        const files = filesRaw.filter(f => typeof f === 'string' && f.endsWith('.md'));
+        const files = filesRaw;
         const openIssues = [];
         const parsedIssues = [];
 
@@ -58,8 +69,8 @@ class IssueIngestor extends Base {
         }
 
         // Pass 1: Upsert all nodes
-        for (const file of files) {
-            const content = await fs.promises.readFile(path.join(issuesDir, file), 'utf8');
+        for (const filePath of files) {
+            const content = await fs.promises.readFile(filePath, 'utf8');
             const match = content.match(/^---\n([\s\S]*?)\n---/);
             if (match) {
                 try {
@@ -213,22 +224,23 @@ class IssueIngestor extends Base {
         return openIssues;
     }
 
-    /**
-     * Parses the local file system for markdown discussions and syncs their state
-     * into the Native Graph database as OPEN items so they can surface mathematically.
-     */
     async ingestDiscussionStates() {
-        const discussionsDir = path.resolve(__dirname, '../../../resources/content/discussions');
+        const targetPaths = [
+            path.resolve(__dirname, '../../../resources/content/discussions'),
+            path.resolve(__dirname, '../../../resources/content/archive/discussions')
+        ];
 
-        try {
-            await fs.promises.access(discussionsDir);
-        } catch (e) {
-            logger.warn(`[IssueIngestor] Discussions directory not found at ${discussionsDir}`);
-            return;
+        const files = [];
+        for (const targetPath of targetPaths) {
+            try {
+                if (fs.existsSync(targetPath)) {
+                    const items = await fs.promises.readdir(targetPath, { recursive: true });
+                    files.push(...items.filter(f => typeof f === 'string' && f.endsWith('.md')).map(f => path.join(targetPath, f)));
+                }
+            } catch (e) {
+                logger.warn(`[IssueIngestor] Error reading discussions from ${targetPath}`, e);
+            }
         }
-
-        const filesRaw = await fs.promises.readdir(discussionsDir);
-        const files = filesRaw.filter(f => f.endsWith('.md'));
         
         let nodesCollection = null;
         try {
@@ -237,8 +249,8 @@ class IssueIngestor extends Base {
             logger.warn('[IssueIngestor] Could not resolve graph collection via StorageRouter.');
         }
 
-        for (const file of files) {
-            const content = await fs.promises.readFile(path.join(discussionsDir, file), 'utf8');
+        for (const filePath of files) {
+            const content = await fs.promises.readFile(filePath, 'utf8');
             const match = content.match(/^---\n([\s\S]*?)\n---/);
             if (match) {
                 try {
@@ -289,22 +301,26 @@ class IssueIngestor extends Base {
         }
     }
 
-    /**
-     * Parses the local file system for pull request reviews and syncs their embedded
-     * gap signals ([KB_GAP], [TOOLING_GAP], [RETROSPECTIVE]) into the Native Graph database.
-     */
     async ingestPullRequestFeedback() {
-        const pullsDir = path.resolve(__dirname, '../../../resources/content/pulls');
+        const targetPaths = [
+            path.resolve(__dirname, '../../../resources/content/pulls'),
+            path.resolve(__dirname, '../../../resources/content/archive/pulls')
+        ];
 
-        if (!fs.existsSync(pullsDir)) {
-            logger.warn(`[IssueIngestor] Pull requests directory not found at ${pullsDir}`);
-            return;
+        const files = [];
+        for (const targetPath of targetPaths) {
+            try {
+                if (fs.existsSync(targetPath)) {
+                    const items = fs.readdirSync(targetPath, { recursive: true });
+                    files.push(...items.filter(f => typeof f === 'string' && f.endsWith('.md')).map(f => path.join(targetPath, f)));
+                }
+            } catch (e) {
+                logger.warn(`[IssueIngestor] Error reading pull requests from ${targetPath}`, e);
+            }
         }
 
-        const files = fs.readdirSync(pullsDir).filter(f => f.endsWith('.md'));
-
-        for (const file of files) {
-            const content = fs.readFileSync(path.join(pullsDir, file), 'utf8');
+        for (const filePath of files) {
+            const content = fs.readFileSync(filePath, 'utf8');
             const match = content.match(/^---\n([\s\S]*?)\n---/);
             if (match) {
                 try {

--- a/ai/services/knowledge-base/source/DiscussionSource.mjs
+++ b/ai/services/knowledge-base/source/DiscussionSource.mjs
@@ -36,28 +36,33 @@ class DiscussionSource extends Base {
      */
     async extract(writeStream, createHashFn) {
         let count = 0;
-        const targetPath = path.resolve(aiConfig.neoRootDir, 'resources/content/discussions');
+        const targetPaths = [
+            path.resolve(aiConfig.neoRootDir, 'resources/content/discussions'),
+            path.resolve(aiConfig.neoRootDir, 'resources/content/archive/discussions')
+        ];
 
-        if (await fs.pathExists(targetPath)) {
-            const ticketFiles = await fs.readdir(targetPath);
-            ticketFiles.sort();
+        for (const targetPath of targetPaths) {
+            if (await fs.pathExists(targetPath)) {
+                const discussionFiles = await fs.readdir(targetPath, { recursive: true });
+                discussionFiles.sort();
 
-            for (const file of ticketFiles) {
-                if (file.endsWith('.md')) {
-                    const filePath   = path.join(targetPath, file);
-                    const content    = await fs.readFile(filePath, 'utf-8');
-                    const chunk      = {
-                        type   : 'discussion',
-                        kind   : 'discussion',
-                        name   : file.replace('.md', ''),
-                        content,
-                        // Relative path keeps the distributed Chroma zip portable (#10097).
-                        source : path.relative(aiConfig.neoRootDir, filePath)
-                    };
+                for (const file of discussionFiles) {
+                    if (typeof file === 'string' && file.endsWith('.md')) {
+                        const filePath   = path.join(targetPath, file);
+                        const content    = await fs.readFile(filePath, 'utf-8');
+                        const chunk      = {
+                            type   : 'discussion',
+                            kind   : 'discussion',
+                            name   : path.basename(file).replace('.md', ''),
+                            content,
+                            // Relative path keeps the distributed Chroma zip portable (#10097).
+                            source : path.relative(aiConfig.neoRootDir, filePath)
+                        };
 
-                    chunk.hash = createHashFn(chunk);
-                    writeStream.write(JSON.stringify(chunk) + '\n');
-                    count++;
+                        chunk.hash = createHashFn(chunk);
+                        writeStream.write(JSON.stringify(chunk) + '\n');
+                        count++;
+                    }
                 }
             }
         }

--- a/ai/services/knowledge-base/source/PullRequestSource.mjs
+++ b/ai/services/knowledge-base/source/PullRequestSource.mjs
@@ -39,28 +39,33 @@ class PullRequestSource extends Base {
      */
     async extract(writeStream, createHashFn) {
         let count = 0;
-        const targetPath = path.resolve(aiConfig.neoRootDir, 'resources/content/pulls');
+        const targetPaths = [
+            path.resolve(aiConfig.neoRootDir, 'resources/content/pulls'),
+            path.resolve(aiConfig.neoRootDir, 'resources/content/archive/pulls')
+        ];
 
-        if (await fs.pathExists(targetPath)) {
-            const pullFiles = await fs.readdir(targetPath);
-            pullFiles.sort();
+        for (const targetPath of targetPaths) {
+            if (await fs.pathExists(targetPath)) {
+                const pullFiles = await fs.readdir(targetPath, { recursive: true });
+                pullFiles.sort();
 
-            for (const file of pullFiles) {
-                if (file.endsWith('.md')) {
-                    const filePath = path.join(targetPath, file);
-                    const content  = await fs.readFile(filePath, 'utf-8');
-                    const chunk    = {
-                        type   : 'pull',
-                        kind   : 'pull',
-                        name   : file.replace('.md', ''),
-                        content,
-                        // Relative path keeps the distributed Chroma zip portable (#10097).
-                        source : path.relative(aiConfig.neoRootDir, filePath)
-                    };
+                for (const file of pullFiles) {
+                    if (typeof file === 'string' && file.endsWith('.md')) {
+                        const filePath = path.join(targetPath, file);
+                        const content  = await fs.readFile(filePath, 'utf-8');
+                        const chunk    = {
+                            type   : 'pull',
+                            kind   : 'pull',
+                            name   : path.basename(file).replace('.md', ''),
+                            content,
+                            // Relative path keeps the distributed Chroma zip portable (#10097).
+                            source : path.relative(aiConfig.neoRootDir, filePath)
+                        };
 
-                    chunk.hash = createHashFn(chunk);
-                    writeStream.write(JSON.stringify(chunk) + '\n');
-                    count++;
+                        chunk.hash = createHashFn(chunk);
+                        writeStream.write(JSON.stringify(chunk) + '\n');
+                        count++;
+                    }
                 }
             }
         }


### PR DESCRIPTION
## Context

Refs #11361

Refactors `IssueIngestor.mjs`, `DiscussionSource.mjs`, and `PullRequestSource.mjs` to recursively scan both active and archived content directories. This resolves Phase 1 item 8 of Epic #11372 (ADR 0004 implementation) — partial deliverable; full consumer rewires remain under #11361.

Evidence: L1 (local run of `manage_knowledge_base` generated `ai-knowledge-base.jsonl` containing recursive archive file paths) → L1 required. No residuals.

## Deltas from ticket (if any)
No significant deltas. We've matched the recursive reading pattern previously established in `TicketSource.mjs`.

## Test Evidence
L1 (static code review against TicketSource.mjs recursive precedent) + L2-deferred (current dev archive subtrees empty post-#11362; capability validates on first publish.mjs release cut)

## Post-Merge Validation
- [ ] Verify that `ask_knowledge_base` surfaces archived content in response to queries after the next release.
