### PR TITLE
feat(github-workflow/shared): consolidate path primitives into universal contentPath.mjs (#11379)

### DIFF
--- a/ai/services/github-workflow/shared/archivePath.mjs
+++ b/ai/services/github-workflow/shared/archivePath.mjs
@@ -26,7 +26,8 @@
  * @see #11372 (parent epic)
  */
 
-import path from 'path';
+import path                from 'path';
+import {chunkNumberFor}    from './contentPath.mjs';
 
 export const DEFAULT_ARCHIVE_MAX_ITEMS_PER_DIR = 100;
 export const DEFAULT_ARCHIVE_CHUNK_PREFIX      = 'chunk-';
@@ -160,7 +161,14 @@ export default function archivePath(config = {}) {
         throw new TypeError('itemIndex is required when itemCount exceeds archiveChunkThreshold')
     }
 
-    const chunkNumber = Math.floor(itemIndex / effectiveThreshold) + 1;
+    // Chunk-math delegation per #11381 GPT review RA2 partial-AC7-satisfaction: the chunked-branch
+    // math is the SAME ordinal-100 rule `contentPath()` enforces. Delegating via `chunkNumberFor()`
+    // makes the universal helper the single source of truth for the chunk-number computation while
+    // preserving `archivePath()`'s flat-when-itemCount<=threshold legacy branch for backward
+    // compatibility (the flat branch cannot delegate since `contentPath()` is always-chunked per
+    // ADR 0004 §3.1). Full retirement of this module's local path computation is deferred to
+    // Lane B / #TBD when call sites migrate to `contentPath()` directly.
+    const chunkNumber = chunkNumberFor(itemIndex, effectiveThreshold);
 
     return path.join(bucketDir, `${archiveChunkPrefix}${chunkNumber}`, filename)
 }

--- a/ai/services/github-workflow/shared/archivePath.mjs
+++ b/ai/services/github-workflow/shared/archivePath.mjs
@@ -1,3 +1,31 @@
+/**
+ * @module ai/services/github-workflow/shared/archivePath
+ *
+ * @deprecated Per ADR 0004 §2.3, the two-primitive model (archive-only ordinal here +
+ * active-only ID-range in `./chunkPath.mjs`) is superseded by the universal ordinal-100
+ * primitive in `./contentPath.mjs`. This module is preserved as a backward-compatibility
+ * shim during Lane B (#TBD) call-site migration. After Lane B rewrites every consumer
+ * (`IssueSyncer`, `PullRequestSyncer`, `DiscussionSyncer`, `LocalFileService`, `MetadataManager`)
+ * to import `contentPath`, this module's public API can be retired.
+ *
+ * **Behavior preservation contract during deprecation window:**
+ * - `archivePath()` keeps its current flat-when-≤threshold + chunk-when->threshold branching
+ *   for output-string compatibility with existing call sites. Note that this differs from
+ *   `contentPath()`'s always-chunked rule; the difference is intentional — `contentPath` is
+ *   the new authoritative shape, this shim is the legacy.
+ * - `archiveBucketDir()` keeps its current "bucket dir only" semantics.
+ * - `validateArchiveConfig()` keeps its current runtime-config validation surface — it
+ *   validates the `aiConfig.issueSync.{archiveRoot,archiveChunkThreshold,archiveChunkPrefix}`
+ *   triplet, separately from the path math. The config-audit ticket #11363 will retire
+ *   the underlying config fields; until then, the validator remains live.
+ *
+ * @see ADR 0004 §2.3 + §3.1 (`learn/agentos/decisions/0004-github-content-architecture.md`)
+ * @see ai/services/github-workflow/shared/contentPath.mjs (replacement primitive)
+ * @see #11379 (Lane A consolidation ticket)
+ * @see #11363 (config audit ticket — retires the runtime config fields validated below)
+ * @see #11372 (parent epic)
+ */
+
 import path from 'path';
 
 export const DEFAULT_ARCHIVE_MAX_ITEMS_PER_DIR = 100;
@@ -62,7 +90,11 @@ export function validateArchiveConfig(issueSyncConfig) {
 }
 
 /**
- * @summary Builds archive-tier paths for GitHub workflow markdown files.
+ * @deprecated Use `contentPath({contentRoot, type, version|bucket, filename, itemIndex})` from
+ * `./contentPath.mjs` instead. Per ADR 0004 §2.3, the two-primitive model is RETIRED. This
+ * function is preserved during Lane B (#TBD) call-site migration only.
+ *
+ * @summary Builds archive-tier paths for GitHub workflow markdown files (legacy primitive).
  *
  * This helper is intentionally archive-only. Active issue / pull request paths stay
  * ID-range based via `chunkPath(id)` so callers such as `LocalFileService#getIssueById`
@@ -134,7 +166,10 @@ export default function archivePath(config = {}) {
 }
 
 /**
- * @summary Builds the archive bucket directory without appending a file path.
+ * @deprecated Use `contentBucketDir({contentRoot, type, version|bucket})` from `./contentPath.mjs`
+ * instead. Preserved during Lane B (#TBD) call-site migration only.
+ *
+ * @summary Builds the archive bucket directory without appending a file path (legacy primitive).
  * @param {Object} config
  * @param {String} config.archiveRoot Base archive root
  * @param {String} config.type Archive type segment

--- a/ai/services/github-workflow/shared/archivePath.mjs
+++ b/ai/services/github-workflow/shared/archivePath.mjs
@@ -81,7 +81,7 @@ export function validateArchiveConfig(issueSyncConfig) {
  * @param {String} config.filename Markdown filename
  * @param {Number} config.itemCount Planned bucket size after placement
  * @param {Number} [config.itemIndex] Zero-based item index, required when chunking
- * @param {Number} [config.maxItemsPerDir=100] Maximum items per flat/chunk folder (alias for legacy callers)
+ * @param {Number} [config.maxItemsPerDir=100] Maximum items per flat/chunk folder (alternative name for the threshold; `archiveChunkThreshold` takes precedence per the resolution rule in the function body)
  * @param {Number} [config.archiveChunkThreshold] Runtime override for max items per dir (preferred; takes precedence over `maxItemsPerDir`)
  * @param {String} [config.archiveChunkPrefix='chunk-'] Runtime override for chunk subdir prefix
  * @returns {String}
@@ -100,7 +100,7 @@ export default function archivePath(config = {}) {
         maxItemsPerDir     = DEFAULT_ARCHIVE_MAX_ITEMS_PER_DIR
     } = config;
 
-    // Runtime override precedence: archiveChunkThreshold (B0a #11290) > maxItemsPerDir (legacy) > default
+    // Runtime override precedence: archiveChunkThreshold (B0a #11290) > maxItemsPerDir > default
     const effectiveThreshold = archiveChunkThreshold ?? maxItemsPerDir;
 
     validateSegment(archiveRoot, 'archiveRoot', {allowPath: true});
@@ -129,13 +129,10 @@ export default function archivePath(config = {}) {
         throw new TypeError('itemIndex is required when itemCount exceeds archiveChunkThreshold')
     }
 
-    // Chunk-math delegation per #11381 GPT review RA2 partial-AC7-satisfaction: the chunked-branch
-    // math is the SAME ordinal-100 rule `contentPath()` enforces. Delegating via `chunkNumberFor()`
-    // makes the universal helper the single source of truth for the chunk-number computation while
-    // preserving `archivePath()`'s flat-when-itemCount<=threshold legacy branch for backward
-    // compatibility (the flat branch cannot delegate since `contentPath()` is always-chunked per
-    // ADR 0004 §3.1). Full retirement of this module's local path computation is deferred to
-    // Lane B / #TBD when call sites migrate to `contentPath()` directly.
+    // Internal-DRY: chunk-number computation delegates to `chunkNumberFor()` so the universal
+    // helper owns the ordinal-100 math (single source of truth). `archivePath()`'s API behavior
+    // is unchanged by this PR; #11390 owns the call-site migration that lets this file be
+    // deleted per ADR 0004 §2.3 RETIRED framing.
     const chunkNumber = chunkNumberFor(itemIndex, effectiveThreshold);
 
     return path.join(bucketDir, `${archiveChunkPrefix}${chunkNumber}`, filename)

--- a/ai/services/github-workflow/shared/archivePath.mjs
+++ b/ai/services/github-workflow/shared/archivePath.mjs
@@ -1,33 +1,5 @@
-/**
- * @module ai/services/github-workflow/shared/archivePath
- *
- * @deprecated Per ADR 0004 §2.3, the two-primitive model (archive-only ordinal here +
- * active-only ID-range in `./chunkPath.mjs`) is superseded by the universal ordinal-100
- * primitive in `./contentPath.mjs`. This module is preserved as a backward-compatibility
- * shim during Lane B (#TBD) call-site migration. After Lane B rewrites every consumer
- * (`IssueSyncer`, `PullRequestSyncer`, `DiscussionSyncer`, `LocalFileService`, `MetadataManager`)
- * to import `contentPath`, this module's public API can be retired.
- *
- * **Behavior preservation contract during deprecation window:**
- * - `archivePath()` keeps its current flat-when-≤threshold + chunk-when->threshold branching
- *   for output-string compatibility with existing call sites. Note that this differs from
- *   `contentPath()`'s always-chunked rule; the difference is intentional — `contentPath` is
- *   the new authoritative shape, this shim is the legacy.
- * - `archiveBucketDir()` keeps its current "bucket dir only" semantics.
- * - `validateArchiveConfig()` keeps its current runtime-config validation surface — it
- *   validates the `aiConfig.issueSync.{archiveRoot,archiveChunkThreshold,archiveChunkPrefix}`
- *   triplet, separately from the path math. The config-audit ticket #11363 will retire
- *   the underlying config fields; until then, the validator remains live.
- *
- * @see ADR 0004 §2.3 + §3.1 (`learn/agentos/decisions/0004-github-content-architecture.md`)
- * @see ai/services/github-workflow/shared/contentPath.mjs (replacement primitive)
- * @see #11379 (Lane A consolidation ticket)
- * @see #11363 (config audit ticket — retires the runtime config fields validated below)
- * @see #11372 (parent epic)
- */
-
-import path                from 'path';
-import {chunkNumberFor}    from './contentPath.mjs';
+import path             from 'path';
+import {chunkNumberFor} from './contentPath.mjs';
 
 export const DEFAULT_ARCHIVE_MAX_ITEMS_PER_DIR = 100;
 export const DEFAULT_ARCHIVE_CHUNK_PREFIX      = 'chunk-';
@@ -91,11 +63,7 @@ export function validateArchiveConfig(issueSyncConfig) {
 }
 
 /**
- * @deprecated Use `contentPath({contentRoot, type, version|bucket, filename, itemIndex})` from
- * `./contentPath.mjs` instead. Per ADR 0004 §2.3, the two-primitive model is RETIRED. This
- * function is preserved during Lane B (#TBD) call-site migration only.
- *
- * @summary Builds archive-tier paths for GitHub workflow markdown files (legacy primitive).
+ * @summary Builds archive-tier paths for GitHub workflow markdown files.
  *
  * This helper is intentionally archive-only. Active issue / pull request paths stay
  * ID-range based via `chunkPath(id)` so callers such as `LocalFileService#getIssueById`
@@ -174,10 +142,7 @@ export default function archivePath(config = {}) {
 }
 
 /**
- * @deprecated Use `contentBucketDir({contentRoot, type, version|bucket})` from `./contentPath.mjs`
- * instead. Preserved during Lane B (#TBD) call-site migration only.
- *
- * @summary Builds the archive bucket directory without appending a file path (legacy primitive).
+ * @summary Builds the archive bucket directory without appending a file path.
  * @param {Object} config
  * @param {String} config.archiveRoot Base archive root
  * @param {String} config.type Archive type segment

--- a/ai/services/github-workflow/shared/chunkPath.mjs
+++ b/ai/services/github-workflow/shared/chunkPath.mjs
@@ -1,30 +1,3 @@
-/**
- * @module ai/services/github-workflow/shared/chunkPath
- *
- * @deprecated Per ADR 0004 §2.3, ID-range chunking is RETIRED in favor of the universal
- * ordinal-100 primitive in `./contentPath.mjs`. This helper is preserved as a thin
- * backward-compatibility shim during Lane B (#TBD) call-site migration only. After Lane B
- * lands and `IssueSyncer` / `LocalFileService` / sibling consumers no longer import this file,
- * remove the file entirely as part of the clean-slate migration (ADR 0004 §3.6 / Task 10).
- *
- * **Why not a re-export?** `contentPath(itemIndex)` is ordinal-based (zero-based position within
- * a planned bucket); `chunkPath(number)` is ID-range-based (last-2-digits-truncated `<NNN>xx`
- * shape). The output strings cannot be cross-derived without breaking call-site contracts.
- * Therefore the implementation stays as-is; only the documentation flags it as retired.
- *
- * @see ADR 0004 §2.3 (`learn/agentos/decisions/0004-github-content-architecture.md`)
- * @see ai/services/github-workflow/shared/contentPath.mjs (replacement primitive)
- * @see #11379 (Lane A consolidation ticket)
- * @see #11372 (parent epic)
- */
-
-/**
- * @deprecated Use `contentPath({contentRoot, type, filename, itemIndex})` instead. Active-tier
- * ID-range chunking is RETIRED per ADR 0004 §2.3.
- *
- * @param {Number} number GitHub identifier
- * @returns {String} ID-range chunk folder name (e.g. `'111xx'` for `11190`)
- */
 export default function chunkPath(number) {
     return String(number).padStart(4, '0').slice(0, -2) + 'xx';
 }

--- a/ai/services/github-workflow/shared/chunkPath.mjs
+++ b/ai/services/github-workflow/shared/chunkPath.mjs
@@ -1,3 +1,30 @@
+/**
+ * @module ai/services/github-workflow/shared/chunkPath
+ *
+ * @deprecated Per ADR 0004 §2.3, ID-range chunking is RETIRED in favor of the universal
+ * ordinal-100 primitive in `./contentPath.mjs`. This helper is preserved as a thin
+ * backward-compatibility shim during Lane B (#TBD) call-site migration only. After Lane B
+ * lands and `IssueSyncer` / `LocalFileService` / sibling consumers no longer import this file,
+ * remove the file entirely as part of the clean-slate migration (ADR 0004 §3.6 / Task 10).
+ *
+ * **Why not a re-export?** `contentPath(itemIndex)` is ordinal-based (zero-based position within
+ * a planned bucket); `chunkPath(number)` is ID-range-based (last-2-digits-truncated `<NNN>xx`
+ * shape). The output strings cannot be cross-derived without breaking call-site contracts.
+ * Therefore the implementation stays as-is; only the documentation flags it as retired.
+ *
+ * @see ADR 0004 §2.3 (`learn/agentos/decisions/0004-github-content-architecture.md`)
+ * @see ai/services/github-workflow/shared/contentPath.mjs (replacement primitive)
+ * @see #11379 (Lane A consolidation ticket)
+ * @see #11372 (parent epic)
+ */
+
+/**
+ * @deprecated Use `contentPath({contentRoot, type, filename, itemIndex})` instead. Active-tier
+ * ID-range chunking is RETIRED per ADR 0004 §2.3.
+ *
+ * @param {Number} number GitHub identifier
+ * @returns {String} ID-range chunk folder name (e.g. `'111xx'` for `11190`)
+ */
 export default function chunkPath(number) {
     return String(number).padStart(4, '0').slice(0, -2) + 'xx';
 }

--- a/ai/services/github-workflow/shared/contentPath.mjs
+++ b/ai/services/github-workflow/shared/contentPath.mjs
@@ -1,0 +1,245 @@
+import path from 'path';
+
+/**
+ * @module ai/services/github-workflow/shared/contentPath
+ * @summary Universal ordinal-100 path-resolution primitive for `resources/content/` substrate per ADR 0004.
+ *
+ * This helper is the single source-of-truth for active-tier and archive-tier on-disk path math
+ * across all content types (issues, pulls, discussions, release-notes). It supersedes the
+ * two-primitive model (`chunkPath.mjs` ID-range for active + `archivePath.mjs` ordinal for archive)
+ * that ADR 0004 §3.1 retires.
+ *
+ * **Universal Ordinal-100 Rule** (ADR 0004 §2.2):
+ *   1. `itemIndex` = zero-based ordinal within a collection bucket (active = ascending GitHub ID;
+ *      archive = ascending GitHub ID within version-folder bucket; release-notes = ascending semver)
+ *   2. `chunkNumber = Math.floor(itemIndex / itemsPerChunk) + 1` (1-based)
+ *   3. Active tier path:  `{contentRoot}/{type}/chunk-{N}/{filename}`
+ *   4. Archive tier path: `{contentRoot}/archive/{type}/{version|bucket}/chunk-{N}/{filename}`
+ *
+ * No flat-vs-chunked branching. No ID-range math. No `<NNN>xx/` folders. ONE primitive applied
+ * universally per the operator-confirmed `"consistency is key. same for all. own id chunks."`
+ * directive (ADR 0004 §1.1).
+ *
+ * **Sealed-chunk invariant:** `.github/workflows/prevent-reopen.yml` enforces that closed items
+ * past their 24h-grace window cannot be reopened (CI auto-re-closes + creates new ticket).
+ * Therefore once a chunk is sealed at archive-cut, membership is mechanically immutable — this
+ * is what makes the ordinal chunking safe. Anyone reading this helper MUST mentally factor that
+ * primitive in (ADR 0004 §5.4 anti-pattern: "Skipping `prevent-reopen.yml` in the mental model").
+ *
+ * **V-B-A obligation for path-mutating call sites:** before authoring any file in
+ * `ai/services/github-workflow/sync/*.mjs`, `ai/services/github-workflow/shared/*Path.mjs`,
+ * `ai/mcp/server/github-workflow/config{,.template}.mjs`, `ai/daemons/services/IssueIngestor.mjs`,
+ * `buildScripts/release/publish.mjs`, or any consumer of `resources/content/...`, you MUST read
+ * ADR 0004 start-to-finish, then verify the chosen pattern against this helper's signature.
+ *
+ * @see ADR 0004 (`learn/agentos/decisions/0004-github-content-architecture.md`)
+ * @see Epic #11372
+ * @see #11379 (this implementation ticket)
+ * @see .github/workflows/prevent-reopen.yml (sealed-chunk substrate)
+ */
+
+export const DEFAULT_ITEMS_PER_CHUNK = 100;
+export const DEFAULT_CHUNK_PREFIX    = 'chunk-';
+
+/**
+ * @typedef {Object} ContentIndexEntry
+ * @property {'issues'|'pulls'|'discussions'|'release-notes'} type Content type segment
+ * @property {Number|String} id GitHub ID for issues/pulls/discussions; semver string for release-notes
+ * @property {String|null} version Release version `'v<X.Y.Z>'` for archive tier; `null` for active tier
+ * @property {Number} chunkNumber 1-based chunk ordinal computed from `itemIndex`
+ * @property {String} path Path relative to the `contentRoot` (consumers join with their own contentRoot)
+ * @property {String} [bucket] Non-release archive bucket name (e.g., `'rejected'`); mutually exclusive with `version`
+ *
+ * @summary Per-item entry in the `_index.json` substrate (ADR 0004 §3.2).
+ * The index map enables O(1) ID-keyed lookup once chunk position is no longer derivable from the
+ * GitHub identifier alone. Maintained at sync time by syncers; consumed at read time by
+ * `LocalFileService#getIssueById` and KB / Native Edge Graph ingestors.
+ */
+
+/**
+ * @typedef {ContentIndexEntry[]} ContentIndex
+ * @summary Top-level shape of `resources/content/_index.json` (or per-type shards `_index.json` under each `{type}/`).
+ *
+ * Whether the substrate uses a single root-level `_index.json` or per-type shards is an
+ * implementation-tier decision deferred to Lane B (#TBD) — the schema of an individual entry
+ * is the durable contract; the file-sharding is the maintenance-tier concern.
+ */
+
+/**
+ * @summary Resolves the on-disk path for a content item under the universal ordinal-100 rule.
+ *
+ * Active tier (omit both `version` and `bucket`):
+ *   `{contentRoot}/{type}/{chunkPrefix}{N}/{filename}`
+ *
+ * Archive tier (supply exactly one of `version` or `bucket`):
+ *   `{contentRoot}/archive/{type}/{version|bucket}/{chunkPrefix}{N}/{filename}`
+ *
+ * The helper performs path math only — it does NOT inspect the filesystem, plan migrations, or
+ * maintain the `_index.json` substrate. Callers own those concerns.
+ *
+ * @param {Object} config
+ * @param {String} config.contentRoot Repository-relative or absolute root, e.g. `'resources/content'`
+ * @param {String} config.type Single-segment type identifier (e.g. `'issues'`, `'pulls'`, `'discussions'`, `'release-notes'`)
+ * @param {String} [config.version] Release-bucket segment (e.g. `'v13.0.0'`). Mutually exclusive with `bucket`.
+ * @param {String} [config.bucket] Non-release-bucket segment (e.g. `'rejected'`). Mutually exclusive with `version`.
+ * @param {String} config.filename File leaf (e.g. `'issue-1234.md'`)
+ * @param {Number} config.itemIndex Zero-based ordinal position within the collection bucket
+ * @param {Number} [config.itemsPerChunk=100] Items per chunk; defaults to the ADR-mandated 100
+ * @param {String} [config.chunkPrefix='chunk-'] Chunk-subdirectory prefix
+ * @returns {String} Path joined from segments via `path.join`
+ * @throws {TypeError} If any segment / integer invariant is violated
+ *
+ * @example
+ *   // Active tier — issue #1234 at ordinal index 42 (chunk 1)
+ *   contentPath({contentRoot: 'resources/content', type: 'issues', filename: 'issue-1234.md', itemIndex: 42})
+ *   // → 'resources/content/issues/chunk-1/issue-1234.md'
+ *
+ * @example
+ *   // Archive tier — pull #999 at ordinal index 250 in v12.1.0 (chunk 3)
+ *   contentPath({
+ *     contentRoot: 'resources/content', type: 'pulls', version: 'v12.1.0',
+ *     filename: 'pr-999.md', itemIndex: 250
+ *   })
+ *   // → 'resources/content/archive/pulls/v12.1.0/chunk-3/pr-999.md'
+ */
+export default function contentPath(config = {}) {
+    const {
+        contentRoot,
+        type,
+        version,
+        bucket,
+        filename,
+        itemIndex,
+        itemsPerChunk = DEFAULT_ITEMS_PER_CHUNK,
+        chunkPrefix   = DEFAULT_CHUNK_PREFIX
+    } = config;
+
+    validateSegment(contentRoot, 'contentRoot', {allowPath: true});
+    validateSegment(type,        'type');
+    validateSegment(filename,    'filename');
+    validateSegment(chunkPrefix, 'chunkPrefix');
+    validatePositiveInteger(itemsPerChunk, 'itemsPerChunk');
+    validateNonNegativeInteger(itemIndex, 'itemIndex');
+    validateBucketXor({version, bucket});
+
+    if (version) validateSegment(version, 'version');
+    if (bucket)  validateSegment(bucket,  'bucket');
+
+    const chunkNumber = Math.floor(itemIndex / itemsPerChunk) + 1;
+    const chunkDir    = `${chunkPrefix}${chunkNumber}`;
+    const bucketDir   = (version || bucket)
+        ? path.join(contentRoot, 'archive', type, version || bucket)
+        : path.join(contentRoot, type);
+
+    return path.join(bucketDir, chunkDir, filename);
+}
+
+/**
+ * @summary Resolves the bucket directory (without chunk or filename) for syncer planning.
+ *
+ * Useful when a syncer needs to know "where does this collection live" before computing
+ * per-item chunk placement — e.g., for `fs.readdir`-based scanning or for emitting a
+ * version-bucket-level `_index.json` shard.
+ *
+ * @param {Object} config
+ * @param {String} config.contentRoot Repository-relative or absolute root
+ * @param {String} config.type Single-segment type identifier
+ * @param {String} [config.version] Release-bucket segment; mutually exclusive with `bucket`
+ * @param {String} [config.bucket] Non-release-bucket segment; mutually exclusive with `version`
+ * @returns {String}
+ */
+export function contentBucketDir(config = {}) {
+    const {contentRoot, type, version, bucket} = config;
+
+    validateSegment(contentRoot, 'contentRoot', {allowPath: true});
+    validateSegment(type,        'type');
+    validateBucketXor({version, bucket});
+
+    if (version) validateSegment(version, 'version');
+    if (bucket)  validateSegment(bucket,  'bucket');
+
+    return (version || bucket)
+        ? path.join(contentRoot, 'archive', type, version || bucket)
+        : path.join(contentRoot, type);
+}
+
+/**
+ * @summary Computes the 1-based chunk number for an ordinal item index.
+ * Pure arithmetic helper; exported so syncers can populate `_index.json` entries without
+ * re-deriving the chunk math (single source of truth).
+ *
+ * @param {Number} itemIndex Zero-based ordinal
+ * @param {Number} [itemsPerChunk=100]
+ * @returns {Number} 1-based chunk number
+ */
+export function chunkNumberFor(itemIndex, itemsPerChunk = DEFAULT_ITEMS_PER_CHUNK) {
+    validateNonNegativeInteger(itemIndex, 'itemIndex');
+    validatePositiveInteger(itemsPerChunk, 'itemsPerChunk');
+    return Math.floor(itemIndex / itemsPerChunk) + 1;
+}
+
+/**
+ * @summary Validates the mutual-exclusivity invariant on the version/bucket pair.
+ * Supplying both is a programming error (archive disambiguation conflict); supplying neither
+ * is the legitimate "active tier" path and is permitted.
+ *
+ * @param {Object} config
+ * @param {String} [config.version]
+ * @param {String} [config.bucket]
+ * @throws {TypeError} If both `version` and `bucket` are supplied
+ */
+export function validateBucketXor({version, bucket}) {
+    if (version && bucket) {
+        throw new TypeError('exactly zero or one of version or bucket may be supplied');
+    }
+}
+
+/**
+ * @summary Validates that a value is a non-negative integer.
+ * @param {*} value
+ * @param {String} name Identifier for the error message
+ * @throws {TypeError}
+ */
+export function validateNonNegativeInteger(value, name) {
+    if (!Number.isInteger(value) || value < 0) {
+        throw new TypeError(`${name} must be a non-negative integer`);
+    }
+}
+
+/**
+ * @summary Validates that a value is a positive (>= 1) integer.
+ * @param {*} value
+ * @param {String} name Identifier for the error message
+ * @throws {TypeError}
+ */
+export function validatePositiveInteger(value, name) {
+    if (!Number.isInteger(value) || value < 1) {
+        throw new TypeError(`${name} must be a positive integer`);
+    }
+}
+
+/**
+ * @summary Validates a single path segment (or, with `allowPath: true`, a path-shaped value).
+ * Single-segment validation rejects `/`, `\`, `..`, and embedded `..` substrings to prevent
+ * directory-traversal at path-build time.
+ *
+ * @param {*} value
+ * @param {String} name Identifier for the error message
+ * @param {Object} [options]
+ * @param {Boolean} [options.allowPath=false] When true, permits `/` and `\` separators (for root paths)
+ * @throws {TypeError}
+ */
+export function validateSegment(value, name, options = {}) {
+    if (typeof value !== 'string' || value.length === 0) {
+        throw new TypeError(`${name} must be a non-empty string`);
+    }
+
+    if (!options.allowPath && (
+        value.includes('/') ||
+        value.includes('\\') ||
+        value === '..' ||
+        value.includes('..')
+    )) {
+        throw new TypeError(`${name} must be a single safe path segment`);
+    }
+}

--- a/ai/services/github-workflow/shared/contentPath.mjs
+++ b/ai/services/github-workflow/shared/contentPath.mjs
@@ -122,12 +122,16 @@ export default function contentPath(config = {}) {
     validateNonNegativeInteger(itemIndex, 'itemIndex');
     validateBucketXor({version, bucket});
 
-    if (version) validateSegment(version, 'version');
-    if (bucket)  validateSegment(bucket,  'bucket');
+    // Presence-aware validation per #11381 GPT review RA1: supplying `version: ''` or `bucket: ''`
+    // is a contract violation (caller signaled archive-tier routing with a non-empty value missing).
+    // Distinguish key-not-supplied (undefined / null) from key-supplied-as-empty (which must throw).
+    if (version !== undefined && version !== null) validateSegment(version, 'version');
+    if (bucket  !== undefined && bucket  !== null) validateSegment(bucket,  'bucket');
 
-    const chunkNumber = Math.floor(itemIndex / itemsPerChunk) + 1;
-    const chunkDir    = `${chunkPrefix}${chunkNumber}`;
-    const bucketDir   = (version || bucket)
+    const chunkNumber  = chunkNumberFor(itemIndex, itemsPerChunk);
+    const chunkDir     = `${chunkPrefix}${chunkNumber}`;
+    const archiveTier  = (version !== undefined && version !== null) || (bucket !== undefined && bucket !== null);
+    const bucketDir    = archiveTier
         ? path.join(contentRoot, 'archive', type, version || bucket)
         : path.join(contentRoot, type);
 
@@ -155,10 +159,13 @@ export function contentBucketDir(config = {}) {
     validateSegment(type,        'type');
     validateBucketXor({version, bucket});
 
-    if (version) validateSegment(version, 'version');
-    if (bucket)  validateSegment(bucket,  'bucket');
+    // Presence-aware validation (see #11381 GPT review RA1 / `contentPath` body): supplied-but-empty
+    // archive-tier selectors must fail-loud rather than silently routing to active-tier.
+    if (version !== undefined && version !== null) validateSegment(version, 'version');
+    if (bucket  !== undefined && bucket  !== null) validateSegment(bucket,  'bucket');
 
-    return (version || bucket)
+    const archiveTier = (version !== undefined && version !== null) || (bucket !== undefined && bucket !== null);
+    return archiveTier
         ? path.join(contentRoot, 'archive', type, version || bucket)
         : path.join(contentRoot, type);
 }
@@ -183,13 +190,21 @@ export function chunkNumberFor(itemIndex, itemsPerChunk = DEFAULT_ITEMS_PER_CHUN
  * Supplying both is a programming error (archive disambiguation conflict); supplying neither
  * is the legitimate "active tier" path and is permitted.
  *
+ * Presence-aware semantics (per #11381 GPT review RA1): supplying both keys is a conflict
+ * even if both values are empty strings — the caller signaled archive-tier intent on two
+ * different axes simultaneously. Non-emptiness of the supplied value is validated separately
+ * by `validateSegment` at the call site.
+ *
  * @param {Object} config
  * @param {String} [config.version]
  * @param {String} [config.bucket]
- * @throws {TypeError} If both `version` and `bucket` are supplied
+ * @throws {TypeError} If both `version` and `bucket` are supplied (presence-aware, not truthiness)
  */
 export function validateBucketXor({version, bucket}) {
-    if (version && bucket) {
+    const versionSupplied = version !== undefined && version !== null;
+    const bucketSupplied  = bucket  !== undefined && bucket  !== null;
+
+    if (versionSupplied && bucketSupplied) {
         throw new TypeError('exactly zero or one of version or bucket may be supplied');
     }
 }

--- a/ai/services/github-workflow/shared/contentPath.mjs
+++ b/ai/services/github-workflow/shared/contentPath.mjs
@@ -58,11 +58,11 @@ export const DEFAULT_CHUNK_PREFIX    = 'chunk-';
 
 /**
  * @typedef {ContentIndexEntry[]} ContentIndex
- * @summary Top-level shape of `resources/content/_index.json` (or per-type shards `_index.json` under each `{type}/`).
+ * @summary Top-level shape of `resources/content/_index.json`.
  *
- * Whether the substrate uses a single root-level `_index.json` or per-type shards is an
- * implementation-tier decision deferred to Lane B (#TBD) — the schema of an individual entry
- * is the durable contract; the file-sharding is the maintenance-tier concern.
+ * The schema of an individual `ContentIndexEntry` is the durable contract owned by this helper.
+ * File-sharding (single root-level `_index.json` vs per-type shards under each `{type}/`) is the
+ * consuming syncer's choice and is not part of the path-helper contract.
  */
 
 /**

--- a/test/playwright/unit/ai/services/github-workflow/ContentPath.spec.mjs
+++ b/test/playwright/unit/ai/services/github-workflow/ContentPath.spec.mjs
@@ -284,6 +284,100 @@ test.describe('contentPath â€” universal ordinal-100 path resolution (ADR 0004 Â
         });
     });
 
+    // Presence-aware validation suite (per #11381 GPT review RA1): supplying `version: ''` or
+    // `bucket: ''` must fail-loud as non-empty-string violations rather than silently routing to
+    // active-tier. Distinguishes key-not-supplied (`undefined`/`null`) from key-supplied-as-empty.
+    test.describe('presence-aware archive-selector validation (RA1)', () => {
+        test('rejects supplied-empty version with explicit non-empty-string error', () => {
+            expect(() => contentPath({
+                contentRoot,
+                type     : 'issues',
+                version  : '',
+                filename : 'issue-1.md',
+                itemIndex: 0
+            })).toThrow(/version must be a non-empty string/);
+        });
+
+        test('rejects supplied-empty bucket with explicit non-empty-string error', () => {
+            expect(() => contentPath({
+                contentRoot,
+                type     : 'pulls',
+                bucket   : '',
+                filename : 'pr-1.md',
+                itemIndex: 0
+            })).toThrow(/bucket must be a non-empty string/);
+        });
+
+        test('rejects both version and bucket supplied even when both are empty strings', () => {
+            expect(() => contentPath({
+                contentRoot,
+                type     : 'issues',
+                version  : '',
+                bucket   : '',
+                filename : 'issue-1.md',
+                itemIndex: 0
+            })).toThrow(/zero or one of version or bucket/);
+        });
+
+        test('rejects mixed supplied-empty (version empty, bucket non-empty) as XOR violation', () => {
+            expect(() => contentPath({
+                contentRoot,
+                type     : 'pulls',
+                version  : '',
+                bucket   : 'rejected',
+                filename : 'pr-1.md',
+                itemIndex: 0
+            })).toThrow(/zero or one of version or bucket/);
+        });
+
+        test('contentBucketDir also rejects supplied-empty version', () => {
+            expect(() => contentBucketDir({
+                contentRoot,
+                type   : 'pulls',
+                version: ''
+            })).toThrow(/version must be a non-empty string/);
+        });
+
+        test('contentBucketDir also rejects supplied-empty bucket', () => {
+            expect(() => contentBucketDir({
+                contentRoot,
+                type  : 'pulls',
+                bucket: ''
+            })).toThrow(/bucket must be a non-empty string/);
+        });
+
+        test('contentBucketDir treats both-supplied-empty as XOR violation', () => {
+            expect(() => contentBucketDir({
+                contentRoot,
+                type   : 'pulls',
+                version: '',
+                bucket : ''
+            })).toThrow(/zero or one of version or bucket/);
+        });
+
+        test('validateBucketXor is presence-aware (rejects both-supplied even when both empty)', () => {
+            expect(() => validateBucketXor({version: '', bucket: ''}))
+                .toThrow(/zero or one of version or bucket/);
+        });
+
+        test('validateBucketXor still permits undefined (active-tier path remains legitimate)', () => {
+            expect(() => validateBucketXor({})).not.toThrow();
+            expect(() => validateBucketXor({version: undefined, bucket: undefined})).not.toThrow();
+        });
+
+        test('null is treated as "not supplied" (consistent with undefined)', () => {
+            // Defensive: callers that JSON-deserialize may produce null for omitted keys
+            expect(contentPath({
+                contentRoot,
+                type     : 'issues',
+                version  : null,
+                bucket   : null,
+                filename : 'issue-1.md',
+                itemIndex: 0
+            })).toBe(path.join(contentRoot, 'issues', 'chunk-1', 'issue-1.md'));
+        });
+    });
+
     test.describe('chunkNumberFor helper', () => {
         test('returns 1 for itemIndex 0', () => {
             expect(chunkNumberFor(0)).toBe(1);

--- a/test/playwright/unit/ai/services/github-workflow/ContentPath.spec.mjs
+++ b/test/playwright/unit/ai/services/github-workflow/ContentPath.spec.mjs
@@ -1,0 +1,396 @@
+import {setup} from '../../../../setup.mjs';
+
+setup({
+    neoConfig: {
+        unitTestMode: true
+    },
+    appConfig: {
+        name: 'ContentPathHelperTest'
+    }
+});
+
+import {test, expect} from '@playwright/test';
+import Neo            from '../../../../../../src/Neo.mjs';
+import * as core      from '../../../../../../src/core/_export.mjs';
+import path           from 'path';
+
+import contentPath, {
+    chunkNumberFor,
+    contentBucketDir,
+    DEFAULT_CHUNK_PREFIX,
+    DEFAULT_ITEMS_PER_CHUNK,
+    validateBucketXor,
+    validateNonNegativeInteger,
+    validatePositiveInteger,
+    validateSegment
+} from '../../../../../../ai/services/github-workflow/shared/contentPath.mjs';
+
+test.describe('contentPath — universal ordinal-100 path resolution (ADR 0004 §3.1 / #11379 Lane A)', () => {
+    const contentRoot = path.join('resources', 'content');
+
+    test.describe('active tier (no version/bucket)', () => {
+        test('routes itemIndex 0 to chunk-1', () => {
+            expect(contentPath({
+                contentRoot,
+                type     : 'issues',
+                filename : 'issue-1.md',
+                itemIndex: 0
+            })).toBe(path.join(contentRoot, 'issues', 'chunk-1', 'issue-1.md'));
+        });
+
+        test('routes itemIndex 99 (last of chunk-1) to chunk-1', () => {
+            expect(contentPath({
+                contentRoot,
+                type     : 'pulls',
+                filename : 'pr-100.md',
+                itemIndex: 99
+            })).toBe(path.join(contentRoot, 'pulls', 'chunk-1', 'pr-100.md'));
+        });
+
+        test('routes itemIndex 100 (first of chunk-2) to chunk-2', () => {
+            expect(contentPath({
+                contentRoot,
+                type     : 'discussions',
+                filename : 'discussion-101.md',
+                itemIndex: 100
+            })).toBe(path.join(contentRoot, 'discussions', 'chunk-2', 'discussion-101.md'));
+        });
+
+        test('routes itemIndex 250 (mid chunk-3) to chunk-3', () => {
+            expect(contentPath({
+                contentRoot,
+                type     : 'issues',
+                filename : 'issue-251.md',
+                itemIndex: 250
+            })).toBe(path.join(contentRoot, 'issues', 'chunk-3', 'issue-251.md'));
+        });
+
+        test('routes itemIndex 999 to chunk-10 (boundary at itemsPerChunk * 10)', () => {
+            expect(contentPath({
+                contentRoot,
+                type     : 'issues',
+                filename : 'issue-1000.md',
+                itemIndex: 999
+            })).toBe(path.join(contentRoot, 'issues', 'chunk-10', 'issue-1000.md'));
+        });
+
+        test('routes itemIndex 1000 to chunk-11 (first item past chunk-10 boundary)', () => {
+            expect(contentPath({
+                contentRoot,
+                type     : 'issues',
+                filename : 'issue-1001.md',
+                itemIndex: 1000
+            })).toBe(path.join(contentRoot, 'issues', 'chunk-11', 'issue-1001.md'));
+        });
+
+        test('handles release-notes type with semver-derived filename', () => {
+            expect(contentPath({
+                contentRoot,
+                type     : 'release-notes',
+                filename : 'release-12.1.0.md',
+                itemIndex: 42
+            })).toBe(path.join(contentRoot, 'release-notes', 'chunk-1', 'release-12.1.0.md'));
+        });
+    });
+
+    test.describe('archive tier with version', () => {
+        test('routes itemIndex 0 to chunk-1 under archive/{type}/{version}', () => {
+            expect(contentPath({
+                contentRoot,
+                type     : 'issues',
+                version  : 'v13.0.0',
+                filename : 'issue-11000.md',
+                itemIndex: 0
+            })).toBe(path.join(contentRoot, 'archive', 'issues', 'v13.0.0', 'chunk-1', 'issue-11000.md'));
+        });
+
+        test('routes itemIndex 250 to chunk-3 under archive/pulls/v12.1.0', () => {
+            expect(contentPath({
+                contentRoot,
+                type     : 'pulls',
+                version  : 'v12.1.0',
+                filename : 'pr-999.md',
+                itemIndex: 250
+            })).toBe(path.join(contentRoot, 'archive', 'pulls', 'v12.1.0', 'chunk-3', 'pr-999.md'));
+        });
+
+        test('supports discussions in archive tier', () => {
+            expect(contentPath({
+                contentRoot,
+                type     : 'discussions',
+                version  : 'v13.0.0',
+                filename : 'discussion-555.md',
+                itemIndex: 50
+            })).toBe(path.join(contentRoot, 'archive', 'discussions', 'v13.0.0', 'chunk-1', 'discussion-555.md'));
+        });
+    });
+
+    test.describe('archive tier with bucket (non-release)', () => {
+        test('routes pulls rejected bucket through chunk-N path', () => {
+            expect(contentPath({
+                contentRoot,
+                type     : 'pulls',
+                bucket   : 'rejected',
+                filename : 'pr-11174.md',
+                itemIndex: 0
+            })).toBe(path.join(contentRoot, 'archive', 'pulls', 'rejected', 'chunk-1', 'pr-11174.md'));
+        });
+
+        test('chunks within bucket at itemsPerChunk boundary', () => {
+            expect(contentPath({
+                contentRoot,
+                type     : 'pulls',
+                bucket   : 'rejected',
+                filename : 'pr-9999.md',
+                itemIndex: 100
+            })).toBe(path.join(contentRoot, 'archive', 'pulls', 'rejected', 'chunk-2', 'pr-9999.md'));
+        });
+    });
+
+    test.describe('chunkPrefix + itemsPerChunk overrides', () => {
+        test('honors non-default chunkPrefix', () => {
+            expect(contentPath({
+                contentRoot,
+                type       : 'issues',
+                filename   : 'issue-1.md',
+                itemIndex  : 100,
+                chunkPrefix: 'bucket-'
+            })).toBe(path.join(contentRoot, 'issues', 'bucket-2', 'issue-1.md'));
+        });
+
+        test('honors non-default itemsPerChunk (50 → chunks earlier)', () => {
+            expect(contentPath({
+                contentRoot,
+                type         : 'issues',
+                filename     : 'issue-1.md',
+                itemIndex    : 50,
+                itemsPerChunk: 50
+            })).toBe(path.join(contentRoot, 'issues', 'chunk-2', 'issue-1.md'));
+        });
+
+        test('honors non-default itemsPerChunk (200 → chunks later)', () => {
+            expect(contentPath({
+                contentRoot,
+                type         : 'issues',
+                filename     : 'issue-1.md',
+                itemIndex    : 150,
+                itemsPerChunk: 200
+            })).toBe(path.join(contentRoot, 'issues', 'chunk-1', 'issue-1.md'));
+        });
+    });
+
+    test.describe('validation failure modes', () => {
+        test('rejects missing contentRoot', () => {
+            expect(() => contentPath({
+                type     : 'issues',
+                filename : 'issue-1.md',
+                itemIndex: 0
+            })).toThrow(/contentRoot/);
+        });
+
+        test('rejects empty-string contentRoot', () => {
+            expect(() => contentPath({
+                contentRoot: '',
+                type       : 'issues',
+                filename   : 'issue-1.md',
+                itemIndex  : 0
+            })).toThrow(/contentRoot/);
+        });
+
+        test('rejects type containing a path separator', () => {
+            expect(() => contentPath({
+                contentRoot,
+                type     : 'issues/nested',
+                filename : 'issue-1.md',
+                itemIndex: 0
+            })).toThrow(/safe path segment/);
+        });
+
+        test('rejects type containing ..', () => {
+            expect(() => contentPath({
+                contentRoot,
+                type     : '..',
+                filename : 'issue-1.md',
+                itemIndex: 0
+            })).toThrow(/safe path segment/);
+        });
+
+        test('rejects filename containing a path separator', () => {
+            expect(() => contentPath({
+                contentRoot,
+                type     : 'issues',
+                filename : 'nested/issue-1.md',
+                itemIndex: 0
+            })).toThrow(/safe path segment/);
+        });
+
+        test('rejects negative itemIndex', () => {
+            expect(() => contentPath({
+                contentRoot,
+                type     : 'issues',
+                filename : 'issue-1.md',
+                itemIndex: -1
+            })).toThrow(/non-negative integer/);
+        });
+
+        test('rejects non-integer itemIndex', () => {
+            expect(() => contentPath({
+                contentRoot,
+                type     : 'issues',
+                filename : 'issue-1.md',
+                itemIndex: 1.5
+            })).toThrow(/non-negative integer/);
+        });
+
+        test('rejects zero itemsPerChunk', () => {
+            expect(() => contentPath({
+                contentRoot,
+                type         : 'issues',
+                filename     : 'issue-1.md',
+                itemIndex    : 0,
+                itemsPerChunk: 0
+            })).toThrow(/positive integer/);
+        });
+
+        test('rejects negative itemsPerChunk', () => {
+            expect(() => contentPath({
+                contentRoot,
+                type         : 'issues',
+                filename     : 'issue-1.md',
+                itemIndex    : 0,
+                itemsPerChunk: -10
+            })).toThrow(/positive integer/);
+        });
+
+        test('rejects supplying both version and bucket', () => {
+            expect(() => contentPath({
+                contentRoot,
+                type     : 'issues',
+                version  : 'v13.0.0',
+                bucket   : 'rejected',
+                filename : 'issue-1.md',
+                itemIndex: 0
+            })).toThrow(/zero or one of version or bucket/);
+        });
+
+        test('rejects chunkPrefix containing a path separator', () => {
+            expect(() => contentPath({
+                contentRoot,
+                type       : 'issues',
+                filename   : 'issue-1.md',
+                itemIndex  : 0,
+                chunkPrefix: 'bad/prefix'
+            })).toThrow(/chunkPrefix/);
+        });
+    });
+
+    test.describe('chunkNumberFor helper', () => {
+        test('returns 1 for itemIndex 0', () => {
+            expect(chunkNumberFor(0)).toBe(1);
+        });
+
+        test('returns 1 for itemIndex 99 (last of chunk-1)', () => {
+            expect(chunkNumberFor(99)).toBe(1);
+        });
+
+        test('returns 2 for itemIndex 100 (first of chunk-2)', () => {
+            expect(chunkNumberFor(100)).toBe(2);
+        });
+
+        test('returns 11 for itemIndex 1000', () => {
+            expect(chunkNumberFor(1000)).toBe(11);
+        });
+
+        test('honors itemsPerChunk override', () => {
+            expect(chunkNumberFor(49, 50)).toBe(1);
+            expect(chunkNumberFor(50, 50)).toBe(2);
+            expect(chunkNumberFor(199, 200)).toBe(1);
+            expect(chunkNumberFor(200, 200)).toBe(2);
+        });
+
+        test('rejects negative itemIndex', () => {
+            expect(() => chunkNumberFor(-1)).toThrow(/non-negative integer/);
+        });
+    });
+
+    test.describe('contentBucketDir helper', () => {
+        test('returns active-tier bucket dir without chunk/filename', () => {
+            expect(contentBucketDir({
+                contentRoot,
+                type: 'issues'
+            })).toBe(path.join(contentRoot, 'issues'));
+        });
+
+        test('returns archive-tier version bucket dir', () => {
+            expect(contentBucketDir({
+                contentRoot,
+                type   : 'pulls',
+                version: 'v12.1.0'
+            })).toBe(path.join(contentRoot, 'archive', 'pulls', 'v12.1.0'));
+        });
+
+        test('returns archive-tier non-release bucket dir', () => {
+            expect(contentBucketDir({
+                contentRoot,
+                type  : 'pulls',
+                bucket: 'rejected'
+            })).toBe(path.join(contentRoot, 'archive', 'pulls', 'rejected'));
+        });
+
+        test('rejects supplying both version and bucket', () => {
+            expect(() => contentBucketDir({
+                contentRoot,
+                type   : 'pulls',
+                version: 'v13.0.0',
+                bucket : 'rejected'
+            })).toThrow(/zero or one of version or bucket/);
+        });
+    });
+
+    test.describe('exported constants', () => {
+        test('DEFAULT_ITEMS_PER_CHUNK equals 100 per ADR 0004 §2.2', () => {
+            expect(DEFAULT_ITEMS_PER_CHUNK).toBe(100);
+        });
+
+        test('DEFAULT_CHUNK_PREFIX equals "chunk-"', () => {
+            expect(DEFAULT_CHUNK_PREFIX).toBe('chunk-');
+        });
+    });
+
+    test.describe('exported validators (lift-targets for sibling primitives)', () => {
+        test('validateSegment accepts safe single segments', () => {
+            expect(() => validateSegment('issues', 'type')).not.toThrow();
+            expect(() => validateSegment('v13.0.0', 'version')).not.toThrow();
+        });
+
+        test('validateSegment with allowPath accepts path-shaped values', () => {
+            expect(() => validateSegment(path.join('a', 'b'), 'contentRoot', {allowPath: true})).not.toThrow();
+        });
+
+        test('validateNonNegativeInteger accepts 0 and positives, rejects negatives + non-integers', () => {
+            expect(() => validateNonNegativeInteger(0, 'x')).not.toThrow();
+            expect(() => validateNonNegativeInteger(42, 'x')).not.toThrow();
+            expect(() => validateNonNegativeInteger(-1, 'x')).toThrow();
+            expect(() => validateNonNegativeInteger(1.5, 'x')).toThrow();
+        });
+
+        test('validatePositiveInteger rejects 0', () => {
+            expect(() => validatePositiveInteger(0, 'x')).toThrow();
+            expect(() => validatePositiveInteger(1, 'x')).not.toThrow();
+        });
+
+        test('validateBucketXor permits neither supplied (active tier path)', () => {
+            expect(() => validateBucketXor({})).not.toThrow();
+        });
+
+        test('validateBucketXor permits exactly one supplied', () => {
+            expect(() => validateBucketXor({version: 'v13.0.0'})).not.toThrow();
+            expect(() => validateBucketXor({bucket: 'rejected'})).not.toThrow();
+        });
+
+        test('validateBucketXor rejects both supplied', () => {
+            expect(() => validateBucketXor({version: 'v13.0.0', bucket: 'rejected'}))
+                .toThrow(/zero or one of version or bucket/);
+        });
+    });
+});


### PR DESCRIPTION
Resolves #11379

Authored by Claude Opus 4.7 (Claude Code). Session `e095c569-beac-4743-998f-e07d4344492e`.

Adds the universal ordinal-100 content-path primitive per ADR 0004 §3.1, replacing the two-primitive model (active-only ID-range `chunkPath` + archive-only ordinal `archivePath`) with a single function parameterized on active-vs-archive routing. Codifies the `ContentIndexEntry` substrate schema (ADR 0004 §3.2) as JSDoc on the helper itself, so the schema's logical home is the path-resolution authority.

This PR is the additive helper substrate. `chunkPath.mjs` + `archivePath.mjs` are untouched in their public-API shape; their internal chunk-number computation now delegates to `chunkNumberFor()` from `contentPath.mjs` (single source of truth for ordinal-100 math). Per ADR 0004 §2.3, both files are RETIRED — deletion is co-located with the call-site migration that owns it (#11390 Lane B).

**Evidence:** L1 (deterministic path-math + validator-contract unit-tested via 55 specs in `ContentPath.spec.mjs` + 24 existing `ArchivePath.spec.mjs` specs continuing to pass) → L1 required (all ACs cover static path-resolution + JSDoc-codified schema; no runtime / cross-process / harness ACs). No residuals.

## Implementation

- **`contentPath.mjs`** (new file, 245 lines): default `contentPath()` + named `contentBucketDir()` + named `chunkNumberFor()` + 4 named validators (`validateSegment`, `validateNonNegativeInteger`, `validatePositiveInteger`, `validateBucketXor`). Constants `DEFAULT_ITEMS_PER_CHUNK=100`, `DEFAULT_CHUNK_PREFIX='chunk-'`. JSDoc codifies the `ContentIndexEntry` schema as the durable contract owned by this helper.
- **`ContentPath.spec.mjs`** (new file, 55 specs): active/archive tier paths, validator failure modes, presence-aware archive-selector edge cases, `chunkNumberFor` + `contentBucketDir` helper coverage, exported constants + validators in isolation.
- **`archivePath.mjs`** (modified): chunked-branch chunk-number computation delegates to `chunkNumberFor()` so the ordinal-100 math has one implementation. Public API surface unchanged. Per ADR 0004 §2.3, the file is RETIRED — its deletion happens in #11390 when call sites migrate.
- **`chunkPath.mjs`** (untouched): original 3-line state preserved. Per ADR 0004 §2.3, RETIRED — its deletion happens in #11390.

**Presence-aware validation** (commit `3668f803b`, addressing GPT Cycle-1 RA1): `contentPath()`, `contentBucketDir()`, and `validateBucketXor()` distinguish key-not-supplied (`undefined`/`null`) from key-supplied-as-empty (`''`). Previously, `version: ''` or `bucket: ''` silently routed to active-tier through truthiness checks; the fix fails-loud with a non-empty-string TypeError when an archive-selector is supplied empty, and the XOR check treats both-supplied as a conflict even when both are empty.

## Test Evidence

```bash
npm run test-unit -- --grep "ContentPath|archivePath"
# 79 passed (1.8s)
# - 55 ContentPath specs covering: active tier (chunk-N boundary cases),
#   archive tier (version + bucket), chunkPrefix + itemsPerChunk overrides,
#   11 base validation failure modes, 10 presence-aware validation cases,
#   chunkNumberFor + contentBucketDir helpers, exported constants + validators
# - 24 existing ArchivePath specs continue passing (chunkNumberFor delegation
#   preserves archivePath() output behavior bit-for-bit)
```

## Post-Merge Validation

- [ ] **Lane B #11390** owned by `@neo-gpt` (`agent-task:blocked` on this PR's merge): rewires `LocalFileService` + 3 syncers to consume `contentPath.mjs` + maintain `_index.json` + deletes `chunkPath.mjs` and `archivePath.mjs` (their RETIRED status per ADR 0004 §2.3 is operationalized in Lane B, NOT here).
- [ ] **Lane C #11361** owned by `@neo-gemini-3-1-pro` (PR #11388): consumer-side rewires of KB sources + IssueIngestor.
- [ ] I'll A2A-ping both peers on this PR's merge to flip their lanes from blocked → ready.

## Commits

- `9fef2459c` — `feat(github-workflow/shared): consolidate path primitives into universal contentPath.mjs (#11379)` (Cycle-1 author)
- `3668f803b` — `fix(github-workflow/shared): presence-aware archive-selector validation + chunk-math delegation (#11379)` (Cycle-1 review-response addressing GPT RA1+RA2+RA3)
- `9c12f072a` — `fix(github-workflow/shared): remove @deprecated theater per ADR 0004 clean-cut framing (#11379)` (Cycle-3 operator-correction: @deprecated JSDoc reverted)
- `3b6ab00e0` — `fix(github-workflow/shared): purge residual coexistence/legacy framing per ADR 0004 (#11379)` (Cycle-3 GPT-correction: residual "legacy"/"backward compatibility"/"#TBD" prose removed; reframed to current-behavior + internal-DRY)

## Related

- **Authority:** ADR 0004 §3.1 (helper consolidation), §3.2 (index map substrate schema), §6 (V-B-A pre-flight). `learn/agentos/decisions/0004-github-content-architecture.md`
- **ADR 0004 amendment in flight:** **#11397** (claimed by `@neo-gemini-3-1-pro`) — appends §2.6 Clean-Cut Pattern + §5.6 Deprecation-theater anti-pattern so future agents under the RLHF-anchored deprecation tendency hit a §-citable check before review.
- **Parent epic:** #11372
- **Sub-tickets unblocked by this PR's merge:** #11361 (Lane C consumer rewires; PR #11388), #11390 (Lane B service-layer migration + chunkPath/archivePath deletion)
- **Sibling sub-tickets (parallel-safe with this):** #11363 (Task 4 config audit; MERGED via #11387)
- **Aligned but independent:** #11364 (PR `archiveVersion` metadata cleanup)
- **Supersedes:** #11187 (via parent #11372)

## Cross-Family Review Routing

Per `pull-request-workflow.md §6.2`:
- **Primary reviewer:** `@neo-gpt` — Cycle-1+Cycle-2 cycle (Request Changes → Approved), Cycle-3 Request Changes after re-V-B-A against ADR 0004, awaiting Cycle-4 re-confirmation after commit `3b6ab00e0`.

Re-review requested.
