### PR TITLE
fix(github-workflow): remove legacy archive config fallbacks (#11363)

### DIFF
--- a/ai/mcp/server/github-workflow/config.template.mjs
+++ b/ai/mcp/server/github-workflow/config.template.mjs
@@ -77,11 +77,6 @@ const defaultConfig = {
          */
         archiveRoot: path.resolve(projectRoot, 'resources/content/archive'),
         /**
-         * The path to the directory for archived issues (Legacy, retained for BC if needed).
-         * @type {string}
-         */
-        archiveDir: path.resolve(projectRoot, 'resources/content/issue-archive'),
-        /**
          * The path to the directory for discussions.
          * @type {string}
          */
@@ -111,11 +106,6 @@ const defaultConfig = {
          * @type {string}
          */
         releaseNotesDir: path.resolve(projectRoot, 'resources/content/release-notes'),
-        /**
-         * The default version directory to use for archiving issues when no release is found.
-         * @type {string}
-         */
-        defaultArchiveVersion: 'unversioned',
         /**
          * A prefix for issue filenames to prevent them from starting with a number (e.g., 'issue-').
          * @type {string}

--- a/ai/services/github-workflow/LocalFileService.mjs
+++ b/ai/services/github-workflow/LocalFileService.mjs
@@ -63,11 +63,9 @@ class LocalFileService extends Base {
     /**
      * Finds and returns the content of a local issue file by its number.
      *
-     * Read-path dual-search per Epic #11187 B2 (#11285): during the active-to-archive
-     * migration transition, an archived issue may live under either the new
-     * canonical archiveRoot or the legacy archiveDir. The lookup tries new-first,
-     * then falls back to legacy. Once the B1 corpus migration completes, the
-     * legacy fallback becomes a no-op cheap miss.
+     * Archived issues live under the canonical archiveRoot. Legacy issue-archive
+     * probing is retired per ADR 0004 §3.7 / #11363, so missing archiveRoot files
+     * should fail visibly as NOT_FOUND rather than silently consulting stale paths.
      *
      * @param {string} issueNumber The issue number, with or without a leading '#'.
      * @returns {Promise<object>} A promise that resolves to the file content or a structured error.
@@ -87,14 +85,8 @@ class LocalFileService extends Base {
                 return { filePath: activePath, content };
             }
 
-            // 2. Dual-search archive paths: try new canonical `archiveRoot` first,
-            //    fall back to legacy `archiveDir`. Once Epic #11187 B1 data migration
-            //    completes, the legacy fallback becomes a cheap miss.
-            let archivePath = await this.#findFileRecursively(aiConfig.issueSync.archiveRoot, filename);
-
-            if (!archivePath) {
-                archivePath = await this.#findFileRecursively(aiConfig.issueSync.archiveDir, filename);
-            }
+            // 2. Search the canonical archive tree only.
+            const archivePath = await this.#findFileRecursively(aiConfig.issueSync.archiveRoot, filename);
 
             if (archivePath) {
                 const content = await fs.readFile(archivePath, 'utf-8');

--- a/ai/services/github-workflow/sync/IssueSyncer.mjs
+++ b/ai/services/github-workflow/sync/IssueSyncer.mjs
@@ -515,7 +515,7 @@ class IssueSyncer extends Base {
             // Under sealed-chunk semantics, historical items should not jump archive buckets
             // just because a maintainer toggled the state.
             if (oldIssue && issue.state === 'CLOSED') {
-                const wasArchived = oldPathRelative && (oldPathRelative.includes(issueSyncConfig.archiveDir) || oldPathRelative.includes(issueSyncConfig.archiveRoot));
+                const wasArchived = oldAbsolutePath && oldAbsolutePath.startsWith(issueSyncConfig.archiveRoot);
                 
                 if (oldIssue.closedAt && issue.closedAt && oldIssue.closedAt !== issue.closedAt) {
                     logger.warn(`[ARCHIVE ANOMALY] Issue #${issueNumber} closedAt shifted: ${oldIssue.closedAt} -> ${issue.closedAt}.`);
@@ -914,8 +914,7 @@ class IssueSyncer extends Base {
             // Check if the issue needs to be moved to an archive
             if (currentAbsolutePath !== correctPath) {
                 // Verify the correct path is actually in an archive, not back to active directory
-                if (correctPath.startsWith(issueSyncConfig.issuesDir) &&
-                    !correctPath.includes(issueSyncConfig.archiveDir)) {
+                if (correctPath.startsWith(issueSyncConfig.issuesDir)) {
                     logger.debug(`Issue #${issueNumber} correct path is still in active directory, no move needed.`);
                     continue;
                 }

--- a/test/playwright/unit/ai/services/github-workflow/IssueSyncer.spec.mjs
+++ b/test/playwright/unit/ai/services/github-workflow/IssueSyncer.spec.mjs
@@ -277,7 +277,14 @@ test.describe('Neo.ai.services.github-workflow.sync.IssueSyncer', () => {
             throw new Error(`Unexpected GraphQL query in test: ${query.slice(0, 80)}`);
         };
 
-        const originalOldPath = `${issueSyncConfig.archiveDir}/chunk-42000/issue-${mockIssue.number}.md`;
+        const originalOldAbsolutePath = path.join(
+            issueSyncConfig.archiveRoot,
+            'issues',
+            'v0.0.0',
+            'chunk-42000',
+            `issue-${mockIssue.number}.md`
+        );
+        const originalOldPath = path.relative(aiConfig.projectRoot, originalOldAbsolutePath);
         
         const metadata = {
             issues: {
@@ -295,7 +302,7 @@ test.describe('Neo.ai.services.github-workflow.sync.IssueSyncer', () => {
         };
         
         // create the mock file to simulate it already exists in the archive
-        const absOldPath = path.resolve(process.cwd(), originalOldPath);
+        const absOldPath = path.resolve(aiConfig.projectRoot, originalOldPath);
         await fs.ensureDir(path.dirname(absOldPath));
         await fs.writeFile(absOldPath, 'mock content', 'utf8');
 

--- a/test/playwright/unit/ai/services/github-workflow/LocalFileService.spec.mjs
+++ b/test/playwright/unit/ai/services/github-workflow/LocalFileService.spec.mjs
@@ -23,7 +23,7 @@ import * as core       from '../../../../../../src/core/_export.mjs';
 test.describe.serial('Neo.ai.services.github-workflow.LocalFileService — dual-search read-path (#11285 / Epic #11187 B2)', () => {
     let LocalFileService;
     let aiConfig;
-    let originalIssuesDir, originalArchiveDir, originalArchiveRoot, originalDiscussionsDir;
+    let originalIssuesDir, originalArchiveRoot, originalDiscussionsDir;
     let testRoot;
 
     test.beforeAll(async () => {
@@ -31,19 +31,16 @@ test.describe.serial('Neo.ai.services.github-workflow.LocalFileService — dual-
 
         // Capture original paths
         originalIssuesDir      = aiConfig.issueSync.issuesDir;
-        originalArchiveDir     = aiConfig.issueSync.archiveDir;
         originalArchiveRoot    = aiConfig.issueSync.archiveRoot;
         originalDiscussionsDir = aiConfig.issueSync.discussionsDir;
 
         // Create isolated test root
         testRoot = path.join(os.tmpdir(), `neo-localfileservice-test-${Date.now()}`);
         aiConfig.issueSync.issuesDir      = path.join(testRoot, 'issues');
-        aiConfig.issueSync.archiveDir     = path.join(testRoot, 'issue-archive');
         aiConfig.issueSync.archiveRoot    = path.join(testRoot, 'archive');
         aiConfig.issueSync.discussionsDir = path.join(testRoot, 'discussions');
 
         await fs.ensureDir(aiConfig.issueSync.issuesDir);
-        await fs.ensureDir(aiConfig.issueSync.archiveDir);
         await fs.ensureDir(aiConfig.issueSync.archiveRoot);
         await fs.ensureDir(aiConfig.issueSync.discussionsDir);
 
@@ -52,7 +49,6 @@ test.describe.serial('Neo.ai.services.github-workflow.LocalFileService — dual-
 
     test.afterAll(async () => {
         aiConfig.issueSync.issuesDir      = originalIssuesDir;
-        aiConfig.issueSync.archiveDir     = originalArchiveDir;
         aiConfig.issueSync.archiveRoot    = originalArchiveRoot;
         aiConfig.issueSync.discussionsDir = originalDiscussionsDir;
 
@@ -62,7 +58,6 @@ test.describe.serial('Neo.ai.services.github-workflow.LocalFileService — dual-
     test.afterEach(async () => {
         // Clean each test's fixture state
         await fs.emptyDir(aiConfig.issueSync.issuesDir).catch(() => {});
-        await fs.emptyDir(aiConfig.issueSync.archiveDir).catch(() => {});
         await fs.emptyDir(aiConfig.issueSync.archiveRoot).catch(() => {});
         await fs.emptyDir(aiConfig.issueSync.discussionsDir).catch(() => {});
     });
@@ -95,18 +90,17 @@ test.describe.serial('Neo.ai.services.github-workflow.LocalFileService — dual-
         expect(result.filePath).toBe(archivePath);
     });
 
-    test('getIssueById falls back to legacy archiveDir when not in archiveRoot', async () => {
+    test('getIssueById does not probe retired legacy issue-archive paths', async () => {
         const issueId = '8888';
         const filename = `issue-${issueId}.md`;
-        const legacyPath = path.join(aiConfig.issueSync.archiveDir, 'v11.0.0', '88xx', filename);
+        const legacyPath = path.join(testRoot, 'issue-archive', 'v11.0.0', '88xx', filename);
         await fs.ensureDir(path.dirname(legacyPath));
         await fs.writeFile(legacyPath, '# Archived (legacy path) content');
 
         const result = await LocalFileService.getIssueById(issueId);
 
-        expect(result.error).toBeUndefined();
-        expect(result.content).toBe('# Archived (legacy path) content');
-        expect(result.filePath).toBe(legacyPath);
+        expect(result.code).toBe('NOT_FOUND');
+        expect(result.error).toBe('File not found');
     });
 
     test('getIssueById returns NOT_FOUND when issue exists nowhere', async () => {
@@ -116,11 +110,11 @@ test.describe.serial('Neo.ai.services.github-workflow.LocalFileService — dual-
         expect(result.error).toBe('File not found');
     });
 
-    test('getIssueById prefers archiveRoot over archiveDir when both have the same id', async () => {
+    test('getIssueById returns archiveRoot matches without consulting retired legacy paths', async () => {
         const issueId = '6666';
         const filename = `issue-${issueId}.md`;
         const newPath = path.join(aiConfig.issueSync.archiveRoot, 'issues', 'v12.0.0', filename);
-        const legacyPath = path.join(aiConfig.issueSync.archiveDir, 'v11.0.0', '66xx', filename);
+        const legacyPath = path.join(testRoot, 'issue-archive', 'v11.0.0', '66xx', filename);
         await fs.ensureDir(path.dirname(newPath));
         await fs.ensureDir(path.dirname(legacyPath));
         await fs.writeFile(newPath, '# New canonical wins');

--- a/test/playwright/unit/ai/services/github-workflow/PullRequestSyncer.spec.mjs
+++ b/test/playwright/unit/ai/services/github-workflow/PullRequestSyncer.spec.mjs
@@ -25,7 +25,6 @@ test.describe('Neo.ai.services.github-workflow.sync.PullRequestSyncer', () => {
     let PullRequestSyncer;
     let ReleaseSyncer;
     let originalArchiveRoot;
-    let originalDefaultArchiveVersion;
     let originalPullsDir;
     let originalQuery;
     let originalSortedReleases;
@@ -39,7 +38,6 @@ test.describe('Neo.ai.services.github-workflow.sync.PullRequestSyncer', () => {
         ReleaseSyncer    = (await import('../../../../../../ai/services/github-workflow/sync/ReleaseSyncer.mjs')).default;
 
         originalArchiveRoot            = aiConfig.issueSync.archiveRoot;
-        originalDefaultArchiveVersion  = aiConfig.issueSync.defaultArchiveVersion;
         originalPullsDir               = aiConfig.issueSync.pullsDir;
         originalQuery                  = GraphqlService.query.bind(GraphqlService);
         originalSortedReleases         = ReleaseSyncer.sortedReleases;
@@ -51,7 +49,6 @@ test.describe('Neo.ai.services.github-workflow.sync.PullRequestSyncer', () => {
         await fs.ensureDir(tmpRoot);
 
         aiConfig.issueSync.archiveRoot            = path.join(tmpRoot, 'archive');
-        aiConfig.issueSync.defaultArchiveVersion  = 'unversioned';
         aiConfig.issueSync.pullsDir               = path.join(tmpRoot, 'pulls');
         aiConfig.issueSync.versionDirectoryPrefix = 'v';
         ReleaseSyncer.sortedReleases              = [];
@@ -61,7 +58,6 @@ test.describe('Neo.ai.services.github-workflow.sync.PullRequestSyncer', () => {
         GraphqlService.query                       = originalQuery;
         ReleaseSyncer.sortedReleases              = originalSortedReleases;
         aiConfig.issueSync.archiveRoot            = originalArchiveRoot;
-        aiConfig.issueSync.defaultArchiveVersion  = originalDefaultArchiveVersion;
         aiConfig.issueSync.pullsDir               = originalPullsDir;
         aiConfig.issueSync.versionDirectoryPrefix = originalVersionDirectoryPrefix;
 


### PR DESCRIPTION
Resolves #11363

Authored by GPT-5.5 (Codex Desktop). Session 019e28d4-96e0-76c2-89c2-eba440ac3b6d.

Removes the retired GitHub Workflow archive config fallbacks from the tracked template and live consumers. `archiveRoot` is now the only issue archive lookup root; `archiveDir` and `defaultArchiveVersion` no longer survive as public gh-workflow config contract fields or required test scaffolding.

Evidence: L1 (static config/consumer grep + focused deterministic unit tests) -> L1 required (config-contract cleanup and path lookup behavior). Residual: none.

## Deltas from Ticket

- `ai/mcp/server/github-workflow/config.mjs` is gitignored and not committed. This PR updates the tracked `config.template.mjs` contract and the runtime consumers/tests. Local clone config files should be checked after merge per the config-template change guide.
- Historical comments/tests still mention the retired `unversioned` fallback only to document or assert that the fallback is no longer active. The active contract hits for `defaultArchiveVersion`, `issueSync.archiveDir`, and `resources/content/issue-archive` are removed from the scoped config/consumer surface.
- Sealed-chunk archive detection now resolves metadata paths before checking `archiveRoot`, preserving enforcement for relative `.sync-metadata.json` paths after the legacy `archiveDir` check is removed.

## Config Template Change

Changed tracked template keys:
- Removed `issueSync.archiveDir`
- Removed `issueSync.defaultArchiveVersion`

Local config follow-up:
- Gitignored `ai/mcp/server/github-workflow/config.mjs` files in maintainer clones should remove those keys after merge if still present.
- Restart of the GitHub Workflow MCP server is recommended after local config shape cleanup so the process reloads the narrowed config contract.

## Test Evidence

```bash
npm run test-unit -- test/playwright/unit/ai/services/github-workflow/LocalFileService.spec.mjs test/playwright/unit/ai/services/github-workflow/IssueSyncer.spec.mjs test/playwright/unit/ai/services/github-workflow/PullRequestSyncer.spec.mjs
# 15 passed

git diff --cached --check
# clean

rg -n "defaultArchiveVersion|issueSync\\.archiveDir|resources/content/issue-archive" ai/mcp/server/github-workflow ai/services/github-workflow test/playwright/unit/ai/services/github-workflow -g "*.mjs"
# no hits
```

## Post-Merge Validation

- [ ] Maintainer clones that still have gitignored `ai/mcp/server/github-workflow/config.mjs` should remove `issueSync.archiveDir` and `issueSync.defaultArchiveVersion`, then restart the gh-workflow MCP server.
- [ ] Confirm no gh-workflow boot path depends on `resources/content/issue-archive`.

## Commits

- `30c4939aa` - `fix(github-workflow): remove legacy archive config fallbacks (#11363)`

## Related

- Parent epic: #11187
- ADR authority: `learn/agentos/decisions/0004-github-content-architecture.md` section 3.7 / config audit row
- Aligned Epic #11372 cleanup lane

## Cross-Family Review Routing

- Primary reviewer: @neo-gemini-3-1-pro
- Review role: primary-reviewer
- Requested action: use /pr-review on this PR.
- Routing note: reassigned from @neo-opus-4-7 during nightshift because the Claude harness is reporting repeated `API Error: 529 Overloaded` freezes.
