### PR TITLE
feat(ai): refactor consumer ingestion pipelines for ADR 0004 (#11361)

### DIFF
--- a/ai/daemons/services/IssueIngestor.mjs
+++ b/ai/daemons/services/IssueIngestor.mjs
@@ -11,6 +11,28 @@ import logger from '../../mcp/server/memory-core/logger.mjs';
 const __filename = fileURLToPath(import.meta.url);
 const __dirname  = path.dirname(__filename);
 
+const loadIndexMap = async (neoRootDir, type) => {
+    const map = new Map();
+    const typeIndex = path.resolve(neoRootDir, `resources/content/${type}/_index.json`);
+    const rootIndex = path.resolve(neoRootDir, 'resources/content/_index.json');
+
+    let entries = [];
+    if (fs.existsSync(typeIndex)) {
+        entries = JSON.parse(await fs.promises.readFile(typeIndex, 'utf-8'));
+    } else if (fs.existsSync(rootIndex)) {
+        const rootEntries = JSON.parse(await fs.promises.readFile(rootIndex, 'utf-8'));
+        entries = rootEntries.filter(e => e.type === type);
+    }
+
+    for (const entry of entries) {
+        if (entry.path) {
+            map.set(path.normalize(entry.path), entry.id);
+        }
+    }
+
+    return map;
+};
+
 /**
  * @class Neo.ai.daemons.services.IssueIngestor
  * @extends Neo.core.Base
@@ -54,7 +76,7 @@ class IssueIngestor extends Base {
                 logger.warn(`[IssueIngestor] Error reading issues from ${targetPath}`, e);
             }
         }
-        
+
         if (filesRaw.length === 0) {
             return [];
         }
@@ -62,6 +84,10 @@ class IssueIngestor extends Base {
         const files = filesRaw;
         const openIssues = [];
         const parsedIssues = [];
+
+        const neoRootDir = path.resolve(__dirname, '../../..');
+        const contentRoot = path.join(neoRootDir, 'resources/content');
+        const indexMap = await loadIndexMap(neoRootDir, 'issues');
 
         let nodesCollection = null;
         if (StorageRouter) {
@@ -76,7 +102,12 @@ class IssueIngestor extends Base {
                 try {
                     const meta = yaml.load(match[1]);
                     if (meta && meta.state) {
-                        const issueId = 'issue-' + (meta.id || path.basename(file).replace(/\.md$/, ''));
+                        const relativeToContent = path.relative(contentRoot, filePath);
+                        let id = indexMap.get(relativeToContent);
+                        if (id === undefined) {
+                            id = meta.id || path.basename(filePath).replace(/\.md$/, '').replace(/^issue-/, '');
+                        }
+                        const issueId = 'issue-' + id;
 
                         GraphService.upsertNode({
                             id: issueId,
@@ -90,10 +121,10 @@ class IssueIngestor extends Base {
                             updatedAt: meta.updatedAt || meta.createdAt
                         });
 
-                        parsedIssues.push({ issueId, meta, content, file });
+                        parsedIssues.push({ issueId, meta, content, filePath });
                     }
                 } catch (e) {
-                    logger.warn(`[IssueIngestor] Failed to parse frontmatter for ${file}`, e);
+                    logger.warn(`[IssueIngestor] Failed to parse frontmatter for ${filePath}`, e);
                 }
             }
         }
@@ -105,7 +136,7 @@ class IssueIngestor extends Base {
             return m ? `issue-${m[1]}` : null;
         };
 
-        for (const { issueId, meta, content, file } of parsedIssues) {
+        for (const { issueId, meta, content, filePath } of parsedIssues) {
             try {
                 if (meta.parentIssue) {
                     const parentId = extractIssueId(meta.parentIssue);
@@ -211,13 +242,15 @@ class IssueIngestor extends Base {
                     }
 
                     openIssues.push({
+                        sourceType: 'ISSUE',
+                        issueId: issueId || meta.id || path.basename(filePath).replace(/\.md$/, ''),
+                        createdAt: meta.createdAt,
                         title: meta.title,
-                        issueId: meta.id || path.basename(file).replace(/\.md$/, ''),
                         body
                     });
                 }
             } catch (e) {
-                logger.warn(`[IssueIngestor] Failed to link edges for ${file}`, e);
+                logger.warn(`[IssueIngestor] Failed to link edges for ${filePath}`, e);
             }
         }
 
@@ -246,7 +279,11 @@ class IssueIngestor extends Base {
                 logger.warn(`[IssueIngestor] Error reading discussions from ${targetPath}`, e);
             }
         }
-        
+
+        const neoRootDir = path.resolve(__dirname, '../../..');
+        const contentRoot = path.join(neoRootDir, 'resources/content');
+        const indexMap = await loadIndexMap(neoRootDir, 'discussions');
+
         let nodesCollection = null;
         try {
             nodesCollection = await StorageRouter.getGraphCollection();
@@ -260,8 +297,13 @@ class IssueIngestor extends Base {
             if (match) {
                 try {
                     const meta = yaml.load(match[1]);
-                    if (meta && meta.number) {
-                        const discussionId = `discussion-${meta.number}`;
+                    if (meta) {
+                        const relativeToContent = path.relative(contentRoot, filePath);
+                        let id = indexMap.get(relativeToContent);
+                        if (id === undefined) {
+                            id = meta.number || path.basename(filePath).replace(/\.md$/, '').replace(/^discussion-/, '');
+                        }
+                        const discussionId = `discussion-${id}`;
 
                         GraphService.upsertNode({
                             id: discussionId,
@@ -300,7 +342,7 @@ class IssueIngestor extends Base {
                         }
                     }
                 } catch (e) {
-                    logger.warn(`[IssueIngestor] Failed to parse frontmatter for ${file}`, e);
+                    logger.warn(`[IssueIngestor] Failed to parse frontmatter for ${filePath}`, e);
                 }
             }
         }
@@ -329,14 +371,23 @@ class IssueIngestor extends Base {
             }
         }
 
+        const neoRootDir = path.resolve(__dirname, '../../..');
+        const contentRoot = path.join(neoRootDir, 'resources/content');
+        const indexMap = await loadIndexMap(neoRootDir, 'pulls');
+
         for (const filePath of files) {
             const content = fs.readFileSync(filePath, 'utf8');
             const match = content.match(/^---\n([\s\S]*?)\n---/);
             if (match) {
                 try {
                     const meta = yaml.load(match[1]);
-                    if (meta && meta.number) {
-                        const prId = `pr-${meta.number}`;
+                    if (meta) {
+                        const relativeToContent = path.relative(contentRoot, filePath);
+                        let id = indexMap.get(relativeToContent);
+                        if (id === undefined) {
+                            id = meta.number || path.basename(filePath).replace(/\.md$/, '').replace(/^pr-/, '');
+                        }
+                        const prId = `pr-${id}`;
 
                         // Upsert the PR node structurally
                         GraphService.upsertNode({
@@ -354,7 +405,7 @@ class IssueIngestor extends Base {
                             if (gapMatch) {
                                 const gapType = gapMatch[1]; // KB_GAP, TOOLING_GAP, RETROSPECTIVE
                                 const gapContent = gapMatch[2].replace(/^[\`\*:\s]+/, '').trim();
-                                
+
                                 if (!gapContent) continue;
 
                                 // Generate deterministic ID based on PR and Gap Content
@@ -365,7 +416,7 @@ class IssueIngestor extends Base {
                                 GraphService.upsertNode({
                                     id: gapNodeId,
                                     type: gapType,
-                                    name: `${gapType} from PR #${meta.number}`,
+                                    name: `${gapType} from PR #${id}`,
                                     description: gapContent,
                                     properties: {
                                         sourcePr: prId,
@@ -375,12 +426,12 @@ class IssueIngestor extends Base {
 
                                 // Create Hebbian edges
                                 GraphService.linkNodes(gapNodeId, prId, 'DISCOVERED_IN', 1.0, {
-                                    justification: `Extracted from PR #${meta.number} feedback.`
+                                    justification: `Extracted from PR #${id} feedback.`
                                 });
                                 GraphService.linkNodes(prId, gapNodeId, 'EVALUATED_BY', 1.0, {
-                                    justification: `Gap evaluated during PR #${meta.number} review.`
+                                    justification: `Gap evaluated during PR #${id} review.`
                                 });
-                                
+
                                 logger.debug(`[IssueIngestor] Ingested ${gapType} from ${prId}: ${gapNodeId}`);
                             }
                         }
@@ -393,14 +444,14 @@ class IssueIngestor extends Base {
 
                             // Create Hebbian edge for PR resolving Issue
                             GraphService.linkNodes(prId, issueNodeId, 'RESOLVES', 1.0, {
-                                justification: `PR #${meta.number} explicitly resolves Issue #${issueNumber}.`
+                                justification: `PR #${id} explicitly resolves Issue #${issueNumber}.`
                             });
 
                             logger.debug(`[IssueIngestor] Linked PR ${prId} as resolving ${issueNodeId}`);
                         }
                     }
                 } catch (e) {
-                    logger.warn(`[IssueIngestor] Failed to process pull request feedback for ${file}`, e);
+                    logger.warn(`[IssueIngestor] Failed to process pull request feedback for ${filePath}`, e);
                 }
             }
         }

--- a/ai/services/knowledge-base/source/DiscussionSource.mjs
+++ b/ai/services/knowledge-base/source/DiscussionSource.mjs
@@ -14,6 +14,28 @@ import aiConfig from '../../../mcp/server/knowledge-base/config.mjs';
  * @extends Neo.ai.services.knowledge-base.source.Base
  * @singleton
  */
+const loadIndexMap = async (neoRootDir, type) => {
+    const map = new Map();
+    const typeIndex = path.resolve(neoRootDir, `resources/content/${type}/_index.json`);
+    const rootIndex = path.resolve(neoRootDir, 'resources/content/_index.json');
+
+    let entries = [];
+    if (await fs.pathExists(typeIndex)) {
+        entries = JSON.parse(await fs.readFile(typeIndex, 'utf-8'));
+    } else if (await fs.pathExists(rootIndex)) {
+        const rootEntries = JSON.parse(await fs.readFile(rootIndex, 'utf-8'));
+        entries = rootEntries.filter(e => e.type === type);
+    }
+
+    for (const entry of entries) {
+        if (entry.path) {
+            map.set(path.normalize(entry.path), entry.id);
+        }
+    }
+
+    return map;
+};
+
 class DiscussionSource extends Base {
     static config = {
         /**
@@ -41,6 +63,9 @@ class DiscussionSource extends Base {
             path.resolve(aiConfig.neoRootDir, 'resources/content/archive/discussions')
         ];
 
+        const indexMap = await loadIndexMap(aiConfig.neoRootDir, 'discussions');
+        const contentRoot = path.resolve(aiConfig.neoRootDir, 'resources/content');
+
         for (const targetPath of targetPaths) {
             if (await fs.pathExists(targetPath)) {
                 const discussionFiles = await fs.readdir(targetPath, { recursive: true });
@@ -49,11 +74,18 @@ class DiscussionSource extends Base {
                 for (const file of discussionFiles) {
                     if (typeof file === 'string' && file.endsWith('.md')) {
                         const filePath   = path.join(targetPath, file);
+                        const relativeToContent = path.relative(contentRoot, filePath);
+
+                        let id = indexMap.get(relativeToContent);
+                        if (id === undefined) {
+                            id = path.basename(file).replace('.md', '').replace(/^discussion-/, '');
+                        }
+
                         const content    = await fs.readFile(filePath, 'utf-8');
                         const chunk      = {
                             type   : 'discussion',
                             kind   : 'discussion',
-                            name   : path.basename(file).replace('.md', ''),
+                            name   : `discussion-${id}`,
                             content,
                             // Relative path keeps the distributed Chroma zip portable (#10097).
                             source : path.relative(aiConfig.neoRootDir, filePath)

--- a/ai/services/knowledge-base/source/PullRequestSource.mjs
+++ b/ai/services/knowledge-base/source/PullRequestSource.mjs
@@ -17,6 +17,28 @@ import aiConfig from '../../../mcp/server/knowledge-base/config.mjs';
  * @extends Neo.ai.services.knowledge-base.source.Base
  * @singleton
  */
+const loadIndexMap = async (neoRootDir, type) => {
+    const map = new Map();
+    const typeIndex = path.resolve(neoRootDir, `resources/content/${type}/_index.json`);
+    const rootIndex = path.resolve(neoRootDir, 'resources/content/_index.json');
+
+    let entries = [];
+    if (await fs.pathExists(typeIndex)) {
+        entries = JSON.parse(await fs.readFile(typeIndex, 'utf-8'));
+    } else if (await fs.pathExists(rootIndex)) {
+        const rootEntries = JSON.parse(await fs.readFile(rootIndex, 'utf-8'));
+        entries = rootEntries.filter(e => e.type === type);
+    }
+
+    for (const entry of entries) {
+        if (entry.path) {
+            map.set(path.normalize(entry.path), entry.id);
+        }
+    }
+
+    return map;
+};
+
 class PullRequestSource extends Base {
     static config = {
         /**
@@ -44,6 +66,9 @@ class PullRequestSource extends Base {
             path.resolve(aiConfig.neoRootDir, 'resources/content/archive/pulls')
         ];
 
+        const indexMap = await loadIndexMap(aiConfig.neoRootDir, 'pulls');
+        const contentRoot = path.resolve(aiConfig.neoRootDir, 'resources/content');
+
         for (const targetPath of targetPaths) {
             if (await fs.pathExists(targetPath)) {
                 const pullFiles = await fs.readdir(targetPath, { recursive: true });
@@ -52,11 +77,18 @@ class PullRequestSource extends Base {
                 for (const file of pullFiles) {
                     if (typeof file === 'string' && file.endsWith('.md')) {
                         const filePath = path.join(targetPath, file);
+                        const relativeToContent = path.relative(contentRoot, filePath);
+
+                        let id = indexMap.get(relativeToContent);
+                        if (id === undefined) {
+                            id = path.basename(file).replace('.md', '').replace(/^pr-/, '');
+                        }
+
                         const content  = await fs.readFile(filePath, 'utf-8');
                         const chunk    = {
                             type   : 'pull',
                             kind   : 'pull',
-                            name   : path.basename(file).replace('.md', ''),
+                            name   : `pr-${id}`,
                             content,
                             // Relative path keeps the distributed Chroma zip portable (#10097).
                             source : path.relative(aiConfig.neoRootDir, filePath)

--- a/ai/services/knowledge-base/source/TicketSource.mjs
+++ b/ai/services/knowledge-base/source/TicketSource.mjs
@@ -15,6 +15,30 @@ import aiConfig from '../../../mcp/server/knowledge-base/config.mjs';
  * @extends Neo.ai.services.knowledge-base.source.Base
  * @singleton
  */
+const loadIndexMap = async (neoRootDir, type) => {
+    const map = new Map();
+    const typeIndex = path.resolve(neoRootDir, `resources/content/${type}/_index.json`);
+    const rootIndex = path.resolve(neoRootDir, 'resources/content/_index.json');
+
+    let entries = [];
+    if (await fs.pathExists(typeIndex)) {
+        entries = JSON.parse(await fs.readFile(typeIndex, 'utf-8'));
+    } else if (await fs.pathExists(rootIndex)) {
+        const rootEntries = JSON.parse(await fs.readFile(rootIndex, 'utf-8'));
+        entries = rootEntries.filter(e => e.type === type);
+    }
+
+    for (const entry of entries) {
+        if (entry.path) {
+            // entry.path is relative to contentRoot (e.g., 'issues/chunk-1/issue-1234.md')
+            // Normalize it to match the suffix we check against
+            map.set(path.normalize(entry.path), entry.id);
+        }
+    }
+
+    return map;
+};
+
 class TicketSource extends Base {
     static config = {
         /**
@@ -42,6 +66,9 @@ class TicketSource extends Base {
             path.resolve(aiConfig.neoRootDir, 'resources/content/archive/issues')
         ];
 
+        const indexMap = await loadIndexMap(aiConfig.neoRootDir, 'issues');
+        const contentRoot = path.resolve(aiConfig.neoRootDir, 'resources/content');
+
         for (const targetPath of targetPaths) {
             if (await fs.pathExists(targetPath)) {
                 const ticketFiles = await fs.readdir(targetPath, { recursive: true });
@@ -50,11 +77,19 @@ class TicketSource extends Base {
                 for (const file of ticketFiles) {
                     if (typeof file === 'string' && file.endsWith('.md')) {
                         const filePath   = path.join(targetPath, file);
+                        const relativeToContent = path.relative(contentRoot, filePath);
+
+                        let id = indexMap.get(relativeToContent);
+                        if (id === undefined) {
+                            // Fallback if not in index map
+                            id = path.basename(file).replace('.md', '').replace(/^issue-/, '');
+                        }
+
                         const content    = await fs.readFile(filePath, 'utf-8');
                         const chunk      = {
                             type   : 'ticket',
                             kind   : 'ticket',
-                            name   : path.basename(file).replace('.md', ''),
+                            name   : `issue-${id}`,
                             content,
                             // Relative path keeps the distributed Chroma zip portable (#10097).
                             source : path.relative(aiConfig.neoRootDir, filePath)

--- a/test/playwright/unit/ai/daemons/services/IssueIngestor.spec.mjs
+++ b/test/playwright/unit/ai/daemons/services/IssueIngestor.spec.mjs
@@ -1,0 +1,128 @@
+import {setup} from '../../../../setup.mjs';
+
+const appName = 'IssueIngestorTest';
+
+setup({
+    neoConfig: { unitTestMode: true },
+    appConfig: { name: appName, isMounted: () => true, vnodeInitialising: false }
+});
+
+import {test, expect}  from '@playwright/test';
+import fs              from 'fs';
+import path            from 'path';
+import {fileURLToPath} from 'url';
+import Neo             from '../../../../../../src/Neo.mjs';
+import * as core       from '../../../../../../src/core/_export.mjs';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname  = path.dirname(__filename);
+const repoRoot   = path.resolve(__dirname, '../../../../../../..');
+
+test.describe('Neo.ai.daemons.services.IssueIngestor', () => {
+    let IssueIngestor;
+    let _originalExistsSync;
+    let _originalReaddir;
+    let _originalReadFile;
+    let GraphService;
+    let _originalGraphDb;
+
+    // We will use a mock index.json and mock markdown files
+    const mockIndexMap = [
+        { type: 'issues', id: 2001, path: 'issues/issue-2001.md' },
+        { type: 'issues', id: 2002, path: 'archive/issues/v1.0.0/issue-2002.md' }
+    ];
+
+    const mockFiles = {
+        'resources/content/issues/issue-2001.md': '---\nstate: OPEN\n---\n# Active Issue',
+        'resources/content/archive/issues/v1.0.0/issue-2002.md': '---\nstate: CLOSED\n---\n# Archive Issue',
+        'resources/content/_index.json': JSON.stringify(mockIndexMap)
+    };
+
+    test.beforeAll(async () => {
+        IssueIngestor = (await import('../../../../../../ai/daemons/services/IssueIngestor.mjs')).default;
+        GraphService = (await import('../../../../../../ai/services.mjs')).Memory_GraphService;
+
+        _originalGraphDb = GraphService.db;
+        GraphService.db = {
+            nodes: { get: () => null },
+            edges: { items: [] },
+            getAdjacentNodes: () => {},
+            addNode: () => {},
+            updateNode: () => {}
+        };
+
+        _originalExistsSync = fs.existsSync;
+        _originalReaddir = fs.promises.readdir;
+        _originalReadFile = fs.promises.readFile;
+
+        fs.existsSync = (p) => {
+            if (typeof p === 'string' && p.includes('resources/content')) {
+                const normPath = p.replace(/\\/g, '/');
+                for (const key of Object.keys(mockFiles)) {
+                    if (normPath.endsWith(key)) return true;
+                }
+                if (p.endsWith('.md')) return true;
+                if (!p.endsWith('.json')) return true; // Pretend directories exist
+                return false;
+            }
+            return _originalExistsSync(p);
+        };
+
+        fs.promises.readdir = async (dirPath, options) => {
+            if (typeof dirPath === 'string' && dirPath.includes('resources/content/archive/issues')) {
+                return ['v1.0.0/issue-2002.md'];
+            }
+            if (typeof dirPath === 'string' && dirPath.includes('resources/content/issues')) {
+                return ['issue-2001.md'];
+            }
+            if (typeof dirPath === 'string' && dirPath.includes('resources/content/discussions') || dirPath.includes('resources/content/pulls')) {
+                return [];
+            }
+            return _originalReaddir.call(fs.promises, dirPath, options);
+        };
+
+        fs.promises.readFile = async (filePath, encoding) => {
+            if (typeof filePath === 'string') {
+                const normPath = filePath.replace(/\\/g, '/');
+                for (const key of Object.keys(mockFiles)) {
+                    if (normPath.endsWith(key)) {
+                        return mockFiles[key];
+                    }
+                }
+                console.log('Not mocked:', normPath);
+            }
+            return _originalReadFile.call(fs.promises, filePath, encoding);
+        };
+    });
+
+    test.afterAll(() => {
+        fs.existsSync = _originalExistsSync;
+        fs.promises.readdir = _originalReaddir;
+        fs.promises.readFile = _originalReadFile;
+        if (GraphService) {
+            GraphService.db = _originalGraphDb;
+        }
+    });
+
+    test('ingestIssueStates() maps issues correctly through _index.json', async () => {
+        const { Memory_StorageRouter: StorageRouter } = await import('../../../../../../ai/services.mjs');
+        const _originalGetGraphCollection = StorageRouter.getGraphCollection;
+        StorageRouter.getGraphCollection = async () => ({
+            upsert: async () => {},
+            get: async () => ({ ids: [], metadatas: [], documents: [] }),
+            add: async () => {}
+        });
+
+        try {
+            // Mock out global StorageRouter if it exists, but the ingestor doesn't throw if null
+            // we will just see what comes out as returned open issues
+            const result = await IssueIngestor.ingestIssueStates();
+
+            // Verify that open issue was identified
+            expect(result.length).toBe(1);
+            expect(result[0].issueId).toBe('issue-2001');
+        } finally {
+            StorageRouter.getGraphCollection = _originalGetGraphCollection;
+        }
+    });
+});

--- a/test/playwright/unit/ai/services/knowledge-base/source/DiscussionSource.spec.mjs
+++ b/test/playwright/unit/ai/services/knowledge-base/source/DiscussionSource.spec.mjs
@@ -1,6 +1,6 @@
 import {setup} from '../../../../../setup.mjs';
 
-const appName = 'PullRequestSourceTest';
+const appName = 'DiscussionSourceTest';
 
 setup({
     neoConfig: { unitTestMode: true },
@@ -18,37 +18,37 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname  = path.dirname(__filename);
 const repoRoot   = path.resolve(__dirname, '../../../../../../..');
 
-test.describe('Neo.ai.services.knowledge-base.source.PullRequestSource', () => {
-    let PullRequestSource;
+test.describe('Neo.ai.services.knowledge-base.source.DiscussionSource', () => {
+    let DiscussionSource;
     let aiConfig;
     let originalRoot;
     let mockRoot;
 
     test.beforeAll(async () => {
         aiConfig = (await import('../../../../../../../ai/mcp/server/knowledge-base/config.mjs')).default;
-        PullRequestSource = (await import('../../../../../../../ai/services/knowledge-base/source/PullRequestSource.mjs')).default;
+        DiscussionSource = (await import('../../../../../../../ai/services/knowledge-base/source/DiscussionSource.mjs')).default;
 
         originalRoot = aiConfig.neoRootDir;
 
         const tmpDir = path.resolve(process.cwd(), 'tmp');
         fs.ensureDirSync(tmpDir);
-        mockRoot = path.join(tmpDir, 'pullrequestsource-mock-' + process.pid + '-' + Date.now());
+        mockRoot = path.join(tmpDir, 'discussionsource-mock-' + process.pid + '-' + Date.now());
 
-        const activeDir = path.join(mockRoot, 'resources/content/pulls/chunk-1');
-        const archiveDir = path.join(mockRoot, 'resources/content/archive/pulls/v1.0.0/chunk-2');
+        const activeDir = path.join(mockRoot, 'resources/content/discussions/chunk-1');
+        const archiveDir = path.join(mockRoot, 'resources/content/archive/discussions/v1.0.0/chunk-2');
 
         fs.ensureDirSync(activeDir);
         fs.ensureDirSync(archiveDir);
 
-        fs.writeFileSync(path.join(activeDir, 'pr-1001.md'), '# First');
-        fs.writeFileSync(path.join(archiveDir, 'pr-1002.md'), '# Second');
+        fs.writeFileSync(path.join(activeDir, 'discussion-1001.md'), '# First');
+        fs.writeFileSync(path.join(archiveDir, 'discussion-1002.md'), '# Second');
 
         const indexMap = [
-            { type: 'pulls', id: 1001, path: 'pulls/chunk-1/pr-1001.md' },
-            { type: 'pulls', id: 1002, path: 'archive/pulls/v1.0.0/chunk-2/pr-1002.md' }
+            { type: 'discussions', id: 1001, path: 'discussions/chunk-1/discussion-1001.md' },
+            { type: 'discussions', id: 1002, path: 'archive/discussions/v1.0.0/chunk-2/discussion-1002.md' }
         ];
 
-        fs.writeFileSync(path.join(mockRoot, 'resources/content/pulls/_index.json'), JSON.stringify(indexMap));
+        fs.writeFileSync(path.join(mockRoot, 'resources/content/discussions/_index.json'), JSON.stringify(indexMap));
 
         aiConfig.neoRootDir = mockRoot;
     });
@@ -62,11 +62,11 @@ test.describe('Neo.ai.services.knowledge-base.source.PullRequestSource', () => {
         const written = [];
         const writeStream = { write(str) { written.push(JSON.parse(str.trim())); return true; } };
 
-        const count = await PullRequestSource.extract(writeStream, chunk => 'hash');
+        const count = await DiscussionSource.extract(writeStream, chunk => 'hash');
 
         expect(count).toBe(2);
 
         const ids = written.map(w => w.name).sort();
-        expect(ids).toEqual(['pr-1001', 'pr-1002']);
+        expect(ids).toEqual(['discussion-1001', 'discussion-1002']);
     });
 });

--- a/test/playwright/unit/ai/services/knowledge-base/source/TicketSource.spec.mjs
+++ b/test/playwright/unit/ai/services/knowledge-base/source/TicketSource.spec.mjs
@@ -1,6 +1,6 @@
 import {setup} from '../../../../../setup.mjs';
 
-const appName = 'PullRequestSourceTest';
+const appName = 'TicketSourceTest';
 
 setup({
     neoConfig: { unitTestMode: true },
@@ -18,37 +18,37 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname  = path.dirname(__filename);
 const repoRoot   = path.resolve(__dirname, '../../../../../../..');
 
-test.describe('Neo.ai.services.knowledge-base.source.PullRequestSource', () => {
-    let PullRequestSource;
+test.describe('Neo.ai.services.knowledge-base.source.TicketSource', () => {
+    let TicketSource;
     let aiConfig;
     let originalRoot;
     let mockRoot;
 
     test.beforeAll(async () => {
         aiConfig = (await import('../../../../../../../ai/mcp/server/knowledge-base/config.mjs')).default;
-        PullRequestSource = (await import('../../../../../../../ai/services/knowledge-base/source/PullRequestSource.mjs')).default;
+        TicketSource = (await import('../../../../../../../ai/services/knowledge-base/source/TicketSource.mjs')).default;
 
         originalRoot = aiConfig.neoRootDir;
 
         const tmpDir = path.resolve(process.cwd(), 'tmp');
         fs.ensureDirSync(tmpDir);
-        mockRoot = path.join(tmpDir, 'pullrequestsource-mock-' + process.pid + '-' + Date.now());
+        mockRoot = path.join(tmpDir, 'ticketsource-mock-' + process.pid + '-' + Date.now());
 
-        const activeDir = path.join(mockRoot, 'resources/content/pulls/chunk-1');
-        const archiveDir = path.join(mockRoot, 'resources/content/archive/pulls/v1.0.0/chunk-2');
+        const activeDir = path.join(mockRoot, 'resources/content/issues/chunk-1');
+        const archiveDir = path.join(mockRoot, 'resources/content/archive/issues/v1.0.0/chunk-2');
 
         fs.ensureDirSync(activeDir);
         fs.ensureDirSync(archiveDir);
 
-        fs.writeFileSync(path.join(activeDir, 'pr-1001.md'), '# First');
-        fs.writeFileSync(path.join(archiveDir, 'pr-1002.md'), '# Second');
+        fs.writeFileSync(path.join(activeDir, 'issue-1001.md'), '# First');
+        fs.writeFileSync(path.join(archiveDir, 'issue-1002.md'), '# Second');
 
         const indexMap = [
-            { type: 'pulls', id: 1001, path: 'pulls/chunk-1/pr-1001.md' },
-            { type: 'pulls', id: 1002, path: 'archive/pulls/v1.0.0/chunk-2/pr-1002.md' }
+            { type: 'issues', id: 1001, path: 'issues/chunk-1/issue-1001.md' },
+            { type: 'issues', id: 1002, path: 'archive/issues/v1.0.0/chunk-2/issue-1002.md' }
         ];
 
-        fs.writeFileSync(path.join(mockRoot, 'resources/content/pulls/_index.json'), JSON.stringify(indexMap));
+        fs.writeFileSync(path.join(mockRoot, 'resources/content/issues/_index.json'), JSON.stringify(indexMap));
 
         aiConfig.neoRootDir = mockRoot;
     });
@@ -62,11 +62,11 @@ test.describe('Neo.ai.services.knowledge-base.source.PullRequestSource', () => {
         const written = [];
         const writeStream = { write(str) { written.push(JSON.parse(str.trim())); return true; } };
 
-        const count = await PullRequestSource.extract(writeStream, chunk => 'hash');
+        const count = await TicketSource.extract(writeStream, chunk => 'hash');
 
         expect(count).toBe(2);
 
         const ids = written.map(w => w.name).sort();
-        expect(ids).toEqual(['pr-1001', 'pr-1002']);
+        expect(ids).toEqual(['issue-1001', 'issue-1002']);
     });
 });


### PR DESCRIPTION
Resolves #11361

This PR introduces the consumer ingestion pipeline, allowing `TicketSource`, `DiscussionSource`, `PullRequestSource`, and `IssueIngestor` to query and parse stored GitHub data efficiently.

### Changes
- Implemented robust `fs` and `GraphService` mocks for isolated unit testing.
- Fixed `_index.json` resolution in `IssueIngestor.mjs` to properly identify issue IDs.
- Validated `TicketSource` and `DiscussionSource` integration.

### Evidence
- **Hygiene**: PR is completely squashed into a single commit with the `(#11361)` suffix. It is properly rebased onto current `dev` without any old stacked commit artifacts.
- **Testing**: Local `IssueIngestor` tests pass and are fully isolated.