### PR TITLE
feat(sunset): Add scope-conditional skip-clause to sunset protocol (#11389)

### DIFF
--- a/.agents/skills/session-sunset/references/session-sunset-workflow.md
+++ b/.agents/skills/session-sunset/references/session-sunset-workflow.md
@@ -86,7 +86,14 @@ When `BEHIND == 0`, suppress the block — no handover-comment noise on a fresh 
 **Why this lives at sunset rather than mid-session:** sunset is the natural Operator Synchronization Point — the agent is already drafting handover prose, and the operator is the next active actor between sessions. Mid-session staleness is unaddressed by this probe; the daemon-driven Shape A solution under #11013's follow-up will register a `primary-dev-sync` periodic task in the `orchestrator-daemon` (post-#11009 `Orchestrator.mjs` class extraction) to close that gap with an automatic `git pull --ff-only`.
 
 ### Step 2: Refresh Active PR Cycle State (The Pre-Sunset Capture)
-You MUST execute `npm run ai:run-sandman` via the `run_command` tool. This forces the \`GoldenPathSynthesizer\` (the canonical writer) to query GitHub and emit the \`## Active PR Cycle State\` into \`sandman_handoff.md\`. Do NOT attempt to edit \`sandman_handoff.md\` manually, as it will be overwritten by the daemon.
+
+**Scope-conditional execution:**
+
+- **`scope: solo-refresh`** (single-agent sunset, daemon-driven path unavailable or stale): You MUST execute `npm run ai:run-sandman` via the `run_command` tool. This forces the `GoldenPathSynthesizer` (the canonical writer) to query GitHub and emit the `## Active PR Cycle State` into `sandman_handoff.md`.
+
+- **`scope: convergent`** (multi-agent coordinated sunset event): **SKIP** this step. Three parallel `ai:run-sandman` invocations against the shared SQLite + Chroma substrate produce ≈45min of contention serialization (3× the solo cost) and overwrite each other's output — only the last write survives. The orchestrator-daemon's `dream` + `golden-path` periodic service-tasks (`ai/daemons/TaskDefinitions.mjs#L85-95`) cover the same artifact emission automatically on hourly cadence; the daemon-driven path is the canonical writer for convergent-scope events. The lead-role agent (per `lead-role-mode.md`) MAY exceptionally run `ai:run-sandman` once on behalf of the swarm if the daemon path is empirically stale (e.g., `sandman_handoff.md` mtime > 4h or the daemon process is verified dead) — declare the exception in the sunset payload Step 5 if exercised.
+
+Do NOT attempt to edit `sandman_handoff.md` manually under any scope — it is overwritten by the canonical writer (daemon OR `ai:run-sandman`).
 
 ### Step 3: Handovers Posted (Active Work)
 For any tickets or tasks that you actively worked on but did not fully complete, you MUST post a self-contained handover comment directly on the GitHub Issue (using `manage_issue_comment`).


### PR DESCRIPTION
Resolves #11389

This PR updates the session sunset skill to make the `ai:run-sandman` execution scope-conditional. It prevents the 45-minute contention serialization that occurs when multiple agents attempt to write to the Golden Path concurrently during a coordinated swarm sunset.

### Changes (Deltas from #11389 ACs)
- **AC1:** Replaced the unconditional Step 2 mandate with a scope-conditional execution path (`solo-refresh` vs. `convergent`).
- **AC2:** Added explicit **SKIP** instruction for `scope: convergent` (multi-agent coordinated sunset) to avoid SQLite + Chroma lock contention.
- **AC3:** Delegated canonical write responsibility for convergent events to the orchestrator-daemon's `dream` + `golden-path` periodic service-tasks.
- **AC4:** Codified the exceptional lead-role override, permitting a single manual `ai:run-sandman` if the daemon path is empirically stale (>4h).
- **AC5:** Retained the unconditional prohibition against manual edits to `sandman_handoff.md`, and explicitly made NO changes to Steps 1 or 3-10.
- **AC6:** Documented empirical-anchor citation mapping to #11372 (see below).

### Empirical Anchor (AC6)
During Epic #11372, the swarm executed a synchronized session sunset. All three agents simultaneously invoked `npm run ai:run-sandman`. Because the Golden Path synthesizer writes to a shared SQLite + Chroma substrate, this produced strict serialization lock contention, turning a 15-minute sunset process into a 45-minute delay where agents repeatedly queued, failed, and retried their writes, only for the final agent to overwrite the prior two. Per operator direction, concurrent sunset events MUST yield to the orchestrator-daemon's automated hourly sync to prevent this anti-pattern.

### Evidence
- **Test/CI:** Local documentation linting passed. No runtime code changes. CI runs green.
- **Hygiene:** Branch rebased cleanly onto `origin/dev` to remove the extraneous file diffs from previous PR cycles.