### PR TITLE
feat(ai): add ADR and concept KB sources (#11373)

### DIFF
--- a/ai/mcp/server/knowledge-base/openapi.yaml
+++ b/ai/mcp/server/knowledge-base/openapi.yaml
@@ -173,7 +173,7 @@ paths:
         
         **Input:**
         - `query`: Natural language search query (1-10 words work best)
-        - `type`: Optional filter by content type (all, blog, guide, src, example, ticket, release, test, skill)
+        - `type`: Optional filter by content type (all, blog, guide, src, example, ticket, release, test, skill, adr, concept)
         
         **Output:**
         A ranked list of file paths with relevance scores. Example:
@@ -317,7 +317,7 @@ paths:
         **Input:**
         - `query`: The question to ask. Natural language works best — ask it like you would ask a senior developer.
         - `limit`: (Optional) Number of source documents to consider (default 5). Increase for broader questions.
-        - `type`: (Optional) Filter by content type (e.g., 'guide', 'src', 'all', 'skill').
+        - `type`: (Optional) Filter by content type (e.g., 'guide', 'src', 'all', 'skill', 'adr', 'concept').
 
         **Output:**
         - `answer`: Synthesized answer grounded in the current codebase.
@@ -363,8 +363,8 @@ paths:
                   description: The question to ask.
                 type:
                   type: string
-                  description: "Optional filter by content type (e.g., 'guide', 'src', 'all', 'skill')."
-                  enum: [all, blog, guide, src, example, ticket, release, test, skill]
+                  description: "Optional filter by content type (e.g., 'guide', 'src', 'all', 'skill', 'adr', 'concept')."
+                  enum: [all, blog, guide, src, example, ticket, release, test, skill, adr, concept]
                   default: all
                 limit:
                   type: integer
@@ -701,7 +701,9 @@ components:
             - `release`: Release notes and changelogs
             - `test`: Automated tests and specs
             - `skill`: Agent skill documentation and rules
-          enum: [all, blog, guide, src, example, ticket, release, test, skill]
+            - `adr`: Architecture Decision Records
+            - `concept`: Architectural concepts and primitives
+          enum: [all, blog, guide, src, example, ticket, release, test, skill, adr, concept]
           default: all
         limit:
           type: integer

--- a/ai/services/knowledge-base/DatabaseService.mjs
+++ b/ai/services/knowledge-base/DatabaseService.mjs
@@ -3,6 +3,7 @@ import Base                      from '../../../src/core/Base.mjs';
 import ChromaManager             from './ChromaManager.mjs';
 import DestructiveOperationGuard from '../../mcp/server/shared/services/DestructiveOperationGuard.mjs';
 import VectorService             from './VectorService.mjs';
+import AdrSource                 from './source/AdrSource.mjs';
 import ApiSource                 from './source/ApiSource.mjs';
 import ConceptSource             from './source/ConceptSource.mjs';
 import DiscussionSource          from './source/DiscussionSource.mjs';
@@ -457,6 +458,7 @@ class DatabaseService extends Base {
         let totalChunks   = 0;
 
         const sources = [
+            AdrSource,
             ApiSource,
             ConceptSource,
             DiscussionSource,

--- a/ai/services/knowledge-base/source/AdrSource.mjs
+++ b/ai/services/knowledge-base/source/AdrSource.mjs
@@ -1,0 +1,69 @@
+import Base from './Base.mjs';
+import fs   from 'fs-extra';
+import path from 'path';
+import aiConfig from '../../../mcp/server/knowledge-base/config.mjs';
+
+/**
+ * @summary Extracts knowledge chunks from Architecture Decision Records (ADRs).
+ *
+ * This source provider reads `learn/agentos/decisions/0NNN-*.md`.
+ * Each ADR file is treated as a single knowledge chunk.
+ *
+ * @class Neo.ai.services.knowledge-base.source.AdrSource
+ * @extends Neo.ai.services.knowledge-base.source.Base
+ * @singleton
+ */
+class AdrSource extends Base {
+    static config = {
+        /**
+         * @member {String} className='Neo.ai.services.knowledge-base.source.AdrSource'
+         * @protected
+         */
+        className: 'Neo.ai.services.knowledge-base.source.AdrSource',
+        /**
+         * @member {Boolean} singleton=true
+         * @protected
+         */
+        singleton: true
+    }
+
+    /**
+     * Extracts knowledge chunks from ADR markdown files.
+     * @param {Object}   writeStream  The JSONL write stream.
+     * @param {Function} createHashFn Function to create content hash.
+     * @returns {Promise<Number>} The number of chunks extracted.
+     */
+    async extract(writeStream, createHashFn) {
+        let count = 0;
+        const adrDir = path.resolve(aiConfig.neoRootDir, 'learn/agentos/decisions');
+
+        if (await fs.pathExists(adrDir)) {
+            const files = await fs.readdir(adrDir);
+            files.sort();
+
+            for (const file of files) {
+                // Match the 0NNN-*.md pattern
+                if (!file.match(/^\d{4}-.*\.md$/)) continue;
+
+                const filePath = path.join(adrDir, file);
+                const rawContent = await fs.readFile(filePath, 'utf-8');
+
+                const chunk = {
+                    type   : 'adr',
+                    kind   : 'adr',
+                    name   : path.basename(file, '.md'),
+                    content: rawContent.trim(),
+                    source : path.relative(aiConfig.neoRootDir, filePath)
+                };
+
+                chunk.hash = createHashFn(chunk);
+                writeStream.write(JSON.stringify(chunk) + '\n');
+                count++;
+            }
+        }
+
+        return count;
+    }
+}
+
+export default Neo.setupClass(AdrSource);

--- a/ai/services/knowledge-base/source/ConceptSource.mjs
+++ b/ai/services/knowledge-base/source/ConceptSource.mjs
@@ -1,13 +1,14 @@
 import Base from './Base.mjs';
 import fs   from 'fs-extra';
 import path from 'path';
+import matter from 'gray-matter';
 import aiConfig from '../../../mcp/server/knowledge-base/config.mjs';
 
 /**
- * @summary Extracts knowledge chunks from Concept Ontology nodes.
+ * @summary Extracts knowledge chunks from Concept Ontology markdown files.
  *
- * This source provider reads `.neo-ai-data/concepts/nodes.jsonl`.
- * Each concept node is treated as a single knowledge chunk.
+ * This source provider reads `resources/content/concepts/*.md`.
+ * Each concept file is treated as a single knowledge chunk.
  *
  * @class Neo.ai.services.knowledge-base.source.ConceptSource
  * @extends Neo.ai.services.knowledge-base.source.Base
@@ -28,29 +29,34 @@ class ConceptSource extends Base {
     }
 
     /**
-     * Extracts knowledge chunks from concept nodes.
+     * Extracts knowledge chunks from concept markdown files.
      * @param {Object}   writeStream  The JSONL write stream.
      * @param {Function} createHashFn Function to create content hash.
      * @returns {Promise<Number>} The number of chunks extracted.
      */
     async extract(writeStream, createHashFn) {
         let count = 0;
-        const nodesPath = path.resolve(aiConfig.neoRootDir, '.neo-ai-data/concepts/nodes.jsonl');
+        const conceptsDir = path.resolve(aiConfig.neoRootDir, 'resources/content/concepts');
 
-        if (await fs.pathExists(nodesPath)) {
-            const content = await fs.readFile(nodesPath, 'utf-8');
-            const lines = content.split('\n').filter(line => line.trim() !== '');
+        if (await fs.pathExists(conceptsDir)) {
+            const files = await fs.readdir(conceptsDir);
+            files.sort();
 
-            for (const line of lines) {
-                const node = JSON.parse(line);
+            for (const file of files) {
+                if (!file.endsWith('.md')) continue;
+
+                const filePath = path.join(conceptsDir, file);
+                const rawContent = await fs.readFile(filePath, 'utf-8');
+                const parsed = matter(rawContent);
+
                 const chunk = {
                     type       : 'concept',
                     kind       : 'concept',
-                    name       : node.name,
-                    tier       : node.tier,
-                    description: node.description,
-                    content    : `${node.name}: ${node.description}`,
-                    source     : path.relative(aiConfig.neoRootDir, nodesPath)
+                    name       : parsed.data.name || path.basename(file, '.md'),
+                    tier       : parsed.data.tier || 0,
+                    description: parsed.content.trim(),
+                    content    : `${parsed.data.name || path.basename(file, '.md')}: ${parsed.content.trim()}`,
+                    source     : path.relative(aiConfig.neoRootDir, filePath)
                 };
 
                 chunk.hash = createHashFn(chunk);

--- a/resources/content/concepts/agent-os.md
+++ b/resources/content/concepts/agent-os.md
@@ -1,0 +1,11 @@
+---
+name: "AI-Native Architecture (Agent OS)"
+tier: 1
+uniqueToNeo: true
+tags:
+  - "agent-os"
+  - "ai"
+verifiedAt: null
+---
+
+Neo.mjs includes a full AI agent infrastructure: 4 MCP servers (Knowledge Base, Memory Core, GitHub Workflow, Neural Link), a Dream Pipeline for strategic forecasting, and a Swarm Intelligence delegation model. The framework is self-improving.

--- a/resources/content/concepts/asymmetric-vdom-updates.md
+++ b/resources/content/concepts/asymmetric-vdom-updates.md
@@ -1,0 +1,12 @@
+---
+name: "Asymmetric VDOM Updates"
+tier: 1
+uniqueToNeo: true
+tags:
+  - "architecture"
+  - "vdom"
+  - "performance"
+verifiedAt: null
+---
+
+Components can surgically update individual VDOM nodes without re-rendering the full tree. Using vdom path accessors, a single property change can target a specific nested element, enabling fine-grained reactivity.

--- a/resources/content/concepts/build-architecture.md
+++ b/resources/content/concepts/build-architecture.md
@@ -1,0 +1,11 @@
+---
+name: "Build Architecture & Service Workers"
+tier: 3
+uniqueToNeo: false
+tags:
+  - "build"
+  - "deployment"
+verifiedAt: null
+---
+
+Production builds use webpack to bundle, tree-shake, and optimize the application. Service Workers enable offline capability and caching. Four build environments are supported: development, dist/development, dist/production, and test.

--- a/resources/content/concepts/canvas-architecture.md
+++ b/resources/content/concepts/canvas-architecture.md
@@ -1,0 +1,12 @@
+---
+name: "Canvas Architecture (Zero-Allocation)"
+tier: 2
+uniqueToNeo: true
+tags:
+  - "canvas"
+  - "performance"
+  - "workers"
+verifiedAt: null
+---
+
+OffscreenCanvas rendering runs in a dedicated Canvas Worker, achieving zero main-thread allocation for complex visualizations. The canvas uses a scene-graph model with JSON-described render instructions.

--- a/resources/content/concepts/class-based-components.md
+++ b/resources/content/concepts/class-based-components.md
@@ -1,0 +1,11 @@
+---
+name: "Class-Based Components"
+tier: 2
+uniqueToNeo: false
+tags:
+  - "components"
+  - "class-system"
+verifiedAt: null
+---
+
+Components defined as classes extending Neo.component.Base. They declare their UI via a static _vdom config, respond to state changes via lifecycle hooks, and can contain child components via the items config.

--- a/resources/content/concepts/class-system.md
+++ b/resources/content/concepts/class-system.md
@@ -1,0 +1,11 @@
+---
+name: "Class System & Compilation"
+tier: 1
+uniqueToNeo: true
+tags:
+  - "architecture"
+  - "class-system"
+verifiedAt: null
+---
+
+Neo.mjs enhances JavaScript classes with a reactive config system, automatic namespace registration, mixin support, and a prototype-chain-based inheritance model. All classes are processed via Neo.setupClass().

--- a/resources/content/concepts/component-architecture.md
+++ b/resources/content/concepts/component-architecture.md
@@ -1,0 +1,11 @@
+---
+name: "Component Architecture"
+tier: 1
+uniqueToNeo: false
+tags:
+  - "components"
+  - "ui"
+verifiedAt: null
+---
+
+Neo.mjs components are JSON-described UI building blocks managed by the App Worker. They support class-based and functional paradigms, reactive configs, container composition, and cross-thread rendering via the VDOM protocol.

--- a/resources/content/concepts/component-composition.md
+++ b/resources/content/concepts/component-composition.md
@@ -1,0 +1,11 @@
+---
+name: "Component Composition (Containers & Items)"
+tier: 2
+uniqueToNeo: false
+tags:
+  - "components"
+  - "containers"
+verifiedAt: null
+---
+
+Containers (Neo.container.Base) hold child components in their items array. Composition replaces inheritance for building complex UIs — a Panel contains a Toolbar and a Body, rather than extending both.

--- a/resources/content/concepts/config-descriptors.md
+++ b/resources/content/concepts/config-descriptors.md
@@ -1,0 +1,12 @@
+---
+name: "Config Descriptors & Merge Strategies"
+tier: 2
+uniqueToNeo: true
+tags:
+  - "reactivity"
+  - "config"
+  - "inheritance"
+verifiedAt: null
+---
+
+Configs can use descriptor objects with metadata controlling inheritance behavior. The 'merge' property supports 'shallow' and 'deep' strategies for hierarchical config merging across the prototype chain.

--- a/resources/content/concepts/config-system-deep-dive.md
+++ b/resources/content/concepts/config-system-deep-dive.md
@@ -1,0 +1,12 @@
+---
+name: "Config System Deep Dive"
+tier: 2
+uniqueToNeo: true
+tags:
+  - "config"
+  - "class-system"
+  - "inheritance"
+verifiedAt: null
+---
+
+The complete config inheritance system: static class-level configs, prototype chain merging, descriptor-based merge strategies, the configSymbol holding zone during construction, and the relationship between class configs and instance configs.

--- a/resources/content/concepts/cross-thread-communication.md
+++ b/resources/content/concepts/cross-thread-communication.md
@@ -1,0 +1,12 @@
+---
+name: "Cross-Thread Communication"
+tier: 1
+uniqueToNeo: true
+tags:
+  - "architecture"
+  - "workers"
+  - "rpc"
+verifiedAt: null
+---
+
+Workers communicate via structured postMessage RPC calls. The framework provides a transparent promise-based API that makes cross-thread calls look like synchronous local calls, hiding the async boundary.

--- a/resources/content/concepts/data-layer.md
+++ b/resources/content/concepts/data-layer.md
@@ -1,0 +1,11 @@
+---
+name: "Data Layer"
+tier: 1
+uniqueToNeo: false
+tags:
+  - "data"
+  - "state"
+verifiedAt: null
+---
+
+Neo.mjs provides Records, Stores, Collections, and State Providers for managing application data. Records use factory-based lazy instantiation. Stores handle filtering, sorting, and remote data loading. State Providers enable hierarchical shared state.

--- a/resources/content/concepts/data-pipelines.md
+++ b/resources/content/concepts/data-pipelines.md
@@ -1,0 +1,11 @@
+---
+name: "Data Pipelines"
+tier: 2
+uniqueToNeo: true
+tags:
+  - "data"
+  - "networking"
+verifiedAt: null
+---
+
+A declarative system for defining request/response transformation chains. Pipelines compose middleware-like stages for API communication, including serialization, authentication, error handling, and caching.

--- a/resources/content/concepts/declarative-vdom.md
+++ b/resources/content/concepts/declarative-vdom.md
@@ -1,0 +1,11 @@
+---
+name: "Declarative Component Trees vs Imperative VDOM"
+tier: 2
+uniqueToNeo: true
+tags:
+  - "vdom"
+  - "components"
+verifiedAt: null
+---
+
+Neo.mjs supports two VDOM authoring modes: declarative (nested component items arrays) and imperative (direct VDOM JSON manipulation). Declarative is preferred for composition; imperative is used for fine-grained control.

--- a/resources/content/concepts/delta-updates.md
+++ b/resources/content/concepts/delta-updates.md
@@ -1,0 +1,12 @@
+---
+name: "Delta Update Pipeline"
+tier: 1
+uniqueToNeo: true
+tags:
+  - "architecture"
+  - "vdom"
+  - "performance"
+verifiedAt: null
+---
+
+The VDom Worker compares old and new VDOM trees, computes a minimal set of DOM operations (deltas), and sends only those operations to the main thread. This minimizes main-thread work and eliminates full re-renders.

--- a/resources/content/concepts/drag-and-drop.md
+++ b/resources/content/concepts/drag-and-drop.md
@@ -1,0 +1,11 @@
+---
+name: "Drag and Drop"
+tier: 3
+uniqueToNeo: false
+tags:
+  - "interaction"
+  - "ui"
+verifiedAt: null
+---
+
+The DragZone and DropZone system provides configurable drag-and-drop with visual feedback, proxy elements, and cross-component data transfer. Works within the worker architecture via DOM event delegation.

--- a/resources/content/concepts/dream-pipeline.md
+++ b/resources/content/concepts/dream-pipeline.md
@@ -1,0 +1,15 @@
+---
+name: "Dream Pipeline (REM / Sandman)"
+tier: 2
+uniqueToNeo: true
+tags:
+  - "agent-os"
+  - "forecasting"
+aliases:
+  - "sandman"
+  - "REM pipeline"
+  - "DreamService"
+verifiedAt: null
+---
+
+The DreamService processes undigested session memories through 6 phases: Workspace Ingestion, Tri-Vector Extraction, Topological Conflict Detection, Capability Gap Inference, Garbage Collection, and Golden Path Synthesis.

--- a/resources/content/concepts/focus-management.md
+++ b/resources/content/concepts/focus-management.md
@@ -1,0 +1,11 @@
+---
+name: "Focus Management"
+tier: 3
+uniqueToNeo: false
+tags:
+  - "accessibility"
+  - "interaction"
+verifiedAt: null
+---
+
+The FocusManager tracks focus across the component tree, providing keyboard navigation, focus trapping for dialogs, and cross-component focus coordination — all managed from the App Worker.

--- a/resources/content/concepts/forms-engine.md
+++ b/resources/content/concepts/forms-engine.md
@@ -1,0 +1,11 @@
+---
+name: "Forms Engine"
+tier: 1
+uniqueToNeo: true
+tags:
+  - "forms"
+  - "ui"
+verifiedAt: null
+---
+
+Neo.mjs supports true nested forms (impossible in native HTML), detached validation, and 20+ field types. Form containers can nest arbitrarily deep while maintaining a single validation context.

--- a/resources/content/concepts/four-environments.md
+++ b/resources/content/concepts/four-environments.md
@@ -1,0 +1,11 @@
+---
+name: "4 Environments"
+tier: 2
+uniqueToNeo: true
+tags:
+  - "build"
+  - "environments"
+verifiedAt: null
+---
+
+Neo.mjs supports four runtime environments: development (raw ES modules), dist/development (bundled, unminified), dist/production (bundled, minified, optimized), and a dedicated test environment for Playwright.

--- a/resources/content/concepts/functional-components.md
+++ b/resources/content/concepts/functional-components.md
@@ -1,0 +1,11 @@
+---
+name: "Functional Components"
+tier: 2
+uniqueToNeo: true
+tags:
+  - "components"
+  - "effects"
+verifiedAt: null
+---
+
+Lightweight components defined as functions that return VDOM JSON objects. They use Effects for reactivity instead of class-based lifecycle hooks, providing a simpler API for stateless or self-contained UI elements.

--- a/resources/content/concepts/golden-path.md
+++ b/resources/content/concepts/golden-path.md
@@ -1,0 +1,12 @@
+---
+name: "Golden Path Synthesis"
+tier: 2
+uniqueToNeo: true
+tags:
+  - "agent-os"
+  - "forecasting"
+  - "prioritization"
+verifiedAt: null
+---
+
+A forecasting algorithm that combines semantic distance (ChromaDB vector proximity to the current work frontier) with structural weight (accumulated graph edge weights) to mathematically rank which tasks the swarm should work on next.

--- a/resources/content/concepts/grid-component.md
+++ b/resources/content/concepts/grid-component.md
@@ -1,0 +1,12 @@
+---
+name: "Grid Component"
+tier: 2
+uniqueToNeo: false
+tags:
+  - "components"
+  - "data"
+  - "grid"
+verifiedAt: null
+---
+
+A high-performance data grid supporting buffered rendering, virtual scrolling, column locking, cell editing, row selection, and multi-body architecture. Handles 50,000+ rows via viewport-aware rendering.

--- a/resources/content/concepts/instance-lifecycle.md
+++ b/resources/content/concepts/instance-lifecycle.md
@@ -1,0 +1,11 @@
+---
+name: "Instance Lifecycle"
+tier: 1
+uniqueToNeo: true
+tags:
+  - "class-system"
+  - "lifecycle"
+verifiedAt: null
+---
+
+The lifecycle of a Neo.mjs instance: construct() → config application → onConstructed() → initAsync() (if defined). The constructor phase is synchronous; initAsync() provides a hook for async initialization that runs after the instance is fully configured.

--- a/resources/content/concepts/json-first-vdom.md
+++ b/resources/content/concepts/json-first-vdom.md
@@ -1,0 +1,15 @@
+---
+name: "JSON-First VDOM Protocol"
+tier: 1
+uniqueToNeo: true
+tags:
+  - "architecture"
+  - "vdom"
+  - "rendering"
+aliases:
+  - "JSON VDOM"
+  - "JSON-based virtual DOM"
+verifiedAt: null
+---
+
+UI descriptions are plain JSON objects, not a compiled template language. Components define their VDOM as nested JSON structures, enabling programmatic manipulation, serialization, and cross-thread transfer without parsing.

--- a/resources/content/concepts/knowledge-base.md
+++ b/resources/content/concepts/knowledge-base.md
@@ -1,0 +1,12 @@
+---
+name: "Knowledge Base (Semantic RAG)"
+tier: 2
+uniqueToNeo: true
+tags:
+  - "agent-os"
+  - "rag"
+  - "vector-db"
+verifiedAt: null
+---
+
+An MCP server backed by ChromaDB that provides semantic search over the entire indexed codebase (source, guides, examples, tickets, releases). It performs ETL from source to JSONL to vector embeddings, with class-hierarchy boosting.

--- a/resources/content/concepts/layout-system.md
+++ b/resources/content/concepts/layout-system.md
@@ -1,0 +1,11 @@
+---
+name: "Layout System"
+tier: 2
+uniqueToNeo: false
+tags:
+  - "layout"
+  - "ui"
+verifiedAt: null
+---
+
+Containers use layout managers to arrange child components. Built-in layouts include Base, Card, Flexbox (HBox, VBox), Grid (CSS Grid), Accordion, and Fit. Layouts are applied via the container's layout config.

--- a/resources/content/concepts/lifecycle-hooks.md
+++ b/resources/content/concepts/lifecycle-hooks.md
@@ -1,0 +1,12 @@
+---
+name: "Lifecycle Hooks (beforeSet / afterSet / beforeGet)"
+tier: 2
+uniqueToNeo: true
+tags:
+  - "reactivity"
+  - "config"
+  - "lifecycle"
+verifiedAt: null
+---
+
+Reactive configs support three lifecycle hooks: beforeSet (validation/transformation), afterSet (side effects like VDOM updates), and beforeGet (lazy computation). The naming convention is method-level: beforeSetMyConfig(), afterSetMyConfig().

--- a/resources/content/concepts/memory-core.md
+++ b/resources/content/concepts/memory-core.md
@@ -1,0 +1,12 @@
+---
+name: "Memory Core (Episodic Memory)"
+tier: 2
+uniqueToNeo: true
+tags:
+  - "agent-os"
+  - "memory"
+  - "graph"
+verifiedAt: null
+---
+
+An MCP server providing persistent episodic memory for AI agents. Stores raw agent interactions, generates session summaries, and maintains a Native Edge Graph (SQLite) for structural knowledge and Hebbian decay.

--- a/resources/content/concepts/mixin-architecture.md
+++ b/resources/content/concepts/mixin-architecture.md
@@ -1,0 +1,11 @@
+---
+name: "Mixin Architecture"
+tier: 2
+uniqueToNeo: true
+tags:
+  - "class-system"
+  - "inheritance"
+verifiedAt: null
+---
+
+Neo.mjs supports multiple inheritance via mixins. Mixins are applied during setupClass(), copying methods and reactive configs from mixin prototypes to the target class. Conflict detection prevents silent overwrites.

--- a/resources/content/concepts/multi-threading.md
+++ b/resources/content/concepts/multi-threading.md
@@ -1,0 +1,15 @@
+---
+name: "Multi-Threading Architecture"
+tier: 1
+uniqueToNeo: true
+tags:
+  - "architecture"
+  - "workers"
+  - "performance"
+aliases:
+  - "multi-worker architecture"
+  - "worker-based threading"
+verifiedAt: null
+---
+
+Neo.mjs distributes application logic across dedicated Web Workers (App, VDom, Data, Canvas, Task), keeping the main thread reserved exclusively for DOM updates. This is the platform's defining architectural decision.

--- a/resources/content/concepts/multi-window.md
+++ b/resources/content/concepts/multi-window.md
@@ -1,0 +1,11 @@
+---
+name: "Multi-Window Applications"
+tier: 1
+uniqueToNeo: true
+tags:
+  - "architecture"
+  - "multi-window"
+verifiedAt: null
+---
+
+Neo.mjs natively supports applications that span multiple browser windows, sharing state, stores, and components across windows via SharedWorkers. Components can be moved between windows at runtime.

--- a/resources/content/concepts/native-edge-graph.md
+++ b/resources/content/concepts/native-edge-graph.md
@@ -1,0 +1,12 @@
+---
+name: "Native Edge Graph"
+tier: 2
+uniqueToNeo: true
+tags:
+  - "agent-os"
+  - "graph"
+  - "memory"
+verifiedAt: null
+---
+
+A SQLite-backed knowledge graph maintained by the Memory Core. Stores typed nodes (CLASS, METHOD, FILE, ISSUE, CONCEPT) with weighted edges. Supports Hebbian decay, topological traversal, and orphan pruning.

--- a/resources/content/concepts/neo-mjs.md
+++ b/resources/content/concepts/neo-mjs.md
@@ -1,0 +1,11 @@
+---
+name: "Neo.mjs"
+tier: 0
+uniqueToNeo: true
+tags:
+  - "system-anchor"
+  - "platform"
+verifiedAt: null
+---
+
+The Neo.mjs Application Engine — a multi-threaded, JSON-first UI framework with an AI-native Agent OS. The system anchor for the entire concept ontology.

--- a/resources/content/concepts/neural-link.md
+++ b/resources/content/concepts/neural-link.md
@@ -1,0 +1,11 @@
+---
+name: "Neural Link (WebSocket Bridge)"
+tier: 2
+uniqueToNeo: true
+tags:
+  - "agent-os"
+  - "debugging"
+verifiedAt: null
+---
+
+A WebSocket-based MCP server that bridges LLM agents to live Neo.mjs applications. Agents can inspect component trees, modify state, simulate events, and hot-patch code at runtime — providing full-stack application mutability.

--- a/resources/content/concepts/object-permanence.md
+++ b/resources/content/concepts/object-permanence.md
@@ -1,0 +1,11 @@
+---
+name: "Object Permanence"
+tier: 1
+uniqueToNeo: true
+tags:
+  - "architecture"
+  - "components"
+verifiedAt: null
+---
+
+Component instances persist in the App Worker's memory regardless of DOM visibility. Removing a component from a view does not destroy it — it can be re-inserted elsewhere, even in a different window, with its full state intact.

--- a/resources/content/concepts/observable-event-system.md
+++ b/resources/content/concepts/observable-event-system.md
@@ -1,0 +1,11 @@
+---
+name: "Observable Mixin & Event System"
+tier: 2
+uniqueToNeo: false
+tags:
+  - "events"
+  - "mixins"
+verifiedAt: null
+---
+
+The Observable mixin provides a DOM-style event system for non-DOM objects. Classes marked as static observable = true gain addListener/fireEvent/on APIs. Event delegation in the VDOM maps DOM events to component methods.

--- a/resources/content/concepts/off-main-thread.md
+++ b/resources/content/concepts/off-main-thread.md
@@ -1,0 +1,15 @@
+---
+name: "Off-Main-Thread Execution"
+tier: 1
+uniqueToNeo: true
+tags:
+  - "architecture"
+  - "workers"
+  - "performance"
+aliases:
+  - "off the main thread"
+  - "OMT"
+verifiedAt: null
+---
+
+Application business logic runs inside a dedicated App Worker, not on the main thread. The main thread only receives minimal DOM-delta payloads, eliminating jank and enabling true parallelism.

--- a/resources/content/concepts/progressive-disclosure-skills.md
+++ b/resources/content/concepts/progressive-disclosure-skills.md
@@ -1,0 +1,11 @@
+---
+name: "Progressive Disclosure Skills"
+tier: 2
+uniqueToNeo: true
+tags:
+  - "agent-os"
+  - "skills"
+verifiedAt: null
+---
+
+Agent skills are folder-based instruction sets (.agent/skills/) that extend agent capabilities. They follow a SKILL.md + references pattern, loading detailed instructions only when triggered — preventing context window bloat.

--- a/resources/content/concepts/pull-reactivity.md
+++ b/resources/content/concepts/pull-reactivity.md
@@ -1,0 +1,11 @@
+---
+name: "Pull-Based Reactivity (Effects)"
+tier: 1
+uniqueToNeo: true
+tags:
+  - "reactivity"
+  - "effects"
+verifiedAt: null
+---
+
+Effect instances automatically track which reactive configs they read and re-execute when any dependency changes. This provides computed-property-like behavior without explicit dependency declarations.

--- a/resources/content/concepts/push-reactivity.md
+++ b/resources/content/concepts/push-reactivity.md
@@ -1,0 +1,12 @@
+---
+name: "Push-Based Reactivity (Config System)"
+tier: 1
+uniqueToNeo: true
+tags:
+  - "reactivity"
+  - "config"
+  - "lifecycle"
+verifiedAt: null
+---
+
+Reactive properties defined with a trailing underscore (e.g., myConfig_) trigger explicit lifecycle hooks (beforeSet, afterSet, beforeGet) when changed. This is the primary reactivity model, providing full control over change propagation.

--- a/resources/content/concepts/reactive-configs.md
+++ b/resources/content/concepts/reactive-configs.md
@@ -1,0 +1,15 @@
+---
+name: "Reactive Configs (Trailing Underscore)"
+tier: 2
+uniqueToNeo: true
+tags:
+  - "reactivity"
+  - "config"
+aliases:
+  - "trailing underscore"
+  - "trailing underscore convention"
+  - "reactive config syntax"
+verifiedAt: null
+---
+
+Properties declared with a trailing underscore in the static config block (e.g., text_: 'Hello') automatically generate getter/setter pairs with beforeSet/afterSet hooks. The underscore is a compile-time signal to Neo.setupClass().

--- a/resources/content/concepts/records.md
+++ b/resources/content/concepts/records.md
@@ -1,0 +1,11 @@
+---
+name: "Records & RecordFactory"
+tier: 2
+uniqueToNeo: true
+tags:
+  - "data"
+  - "records"
+verifiedAt: null
+---
+
+Data records are created via RecordFactory for lazy instantiation. Fields are defined with types and default values. Records track dirty state and can serialize to JSON for network transport.

--- a/resources/content/concepts/routing.md
+++ b/resources/content/concepts/routing.md
@@ -1,0 +1,11 @@
+---
+name: "Routing"
+tier: 3
+uniqueToNeo: false
+tags:
+  - "navigation"
+  - "url"
+verifiedAt: null
+---
+
+URL hash-based routing maps URL patterns to application states. The HashHistory class parses hash fragments into key-value pairs that drive component visibility and tabbed navigation.

--- a/resources/content/concepts/rpc-layer.md
+++ b/resources/content/concepts/rpc-layer.md
@@ -1,0 +1,12 @@
+---
+name: "RPC Layer"
+tier: 2
+uniqueToNeo: true
+tags:
+  - "architecture"
+  - "workers"
+  - "rpc"
+verifiedAt: null
+---
+
+A transparent promise-based Remote Procedure Call system that enables cross-worker method invocation. The App Worker can call methods on components in the VDom Worker as if they were local, with the framework handling serialization and routing.

--- a/resources/content/concepts/setup-class.md
+++ b/resources/content/concepts/setup-class.md
@@ -1,0 +1,14 @@
+---
+name: "Neo.setupClass() (The Gatekeeper)"
+tier: 1
+uniqueToNeo: true
+tags:
+  - "class-system"
+  - "compilation"
+aliases:
+  - "setupClass"
+  - "the gatekeeper"
+verifiedAt: null
+---
+
+The central class registration function. It traverses the prototype chain, merges static configs from all ancestors, generates reactive getter/setter pairs, applies mixins, registers the class in the global namespace, and handles singleton instantiation.

--- a/resources/content/concepts/shared-worker-mode.md
+++ b/resources/content/concepts/shared-worker-mode.md
@@ -1,0 +1,12 @@
+---
+name: "SharedWorker Mode"
+tier: 1
+uniqueToNeo: true
+tags:
+  - "architecture"
+  - "workers"
+  - "multi-window"
+verifiedAt: null
+---
+
+Neo.mjs can run its worker infrastructure inside SharedWorkers, allowing multiple browser tabs or windows to share state, components, and communication channels — enabling true multi-window applications.

--- a/resources/content/concepts/state-provider.md
+++ b/resources/content/concepts/state-provider.md
@@ -1,0 +1,12 @@
+---
+name: "State Provider (Hierarchical State Management)"
+tier: 2
+uniqueToNeo: true
+tags:
+  - "data"
+  - "state"
+  - "binding"
+verifiedAt: null
+---
+
+State Providers implement hierarchical shared state. Child components inherit and can bind to parent state. Changes propagate through the component tree. This replaces external state management libraries.

--- a/resources/content/concepts/stores-collections.md
+++ b/resources/content/concepts/stores-collections.md
@@ -1,0 +1,11 @@
+---
+name: "Stores & Collections"
+tier: 2
+uniqueToNeo: false
+tags:
+  - "data"
+  - "stores"
+verifiedAt: null
+---
+
+Stores extend Collection to manage arrays of Records with built-in filtering, sorting, and grouping. Remote stores handle API communication. Collections provide a reactive, observable data container.

--- a/resources/content/concepts/streaming-data.md
+++ b/resources/content/concepts/streaming-data.md
@@ -1,0 +1,12 @@
+---
+name: "Streaming Data & Progressive Rendering"
+tier: 2
+uniqueToNeo: true
+tags:
+  - "data"
+  - "performance"
+  - "streaming"
+verifiedAt: null
+---
+
+Stores can incrementally receive and render data as it arrives from streaming APIs. Combined with buffered grid rendering, this enables real-time data visualization without blocking the UI.

--- a/resources/content/concepts/swarm-intelligence.md
+++ b/resources/content/concepts/swarm-intelligence.md
@@ -1,0 +1,11 @@
+---
+name: "Swarm Intelligence"
+tier: 2
+uniqueToNeo: true
+tags:
+  - "agent-os"
+  - "multi-agent"
+verifiedAt: null
+---
+
+Multi-agent delegation model where an Orchestrator assigns tasks from the Golden Path to autonomous agents. Fat Tickets carry rich architectural context. Stigmergic coordination via the shared Native Edge Graph.

--- a/resources/content/concepts/theming-engine.md
+++ b/resources/content/concepts/theming-engine.md
@@ -1,0 +1,11 @@
+---
+name: "Theming Engine"
+tier: 2
+uniqueToNeo: false
+tags:
+  - "theming"
+  - "css"
+verifiedAt: null
+---
+
+Themes are built with SCSS and exposed via CSS custom properties. Components consume theme tokens rather than hard-coded values. The build system generates optimized theme maps. Dark mode and glassmorphism are first-class supported patterns.

--- a/resources/content/concepts/tree-store.md
+++ b/resources/content/concepts/tree-store.md
@@ -1,0 +1,11 @@
+---
+name: "TreeStore & Hierarchical Data"
+tier: 3
+uniqueToNeo: false
+tags:
+  - "data"
+  - "tree"
+verifiedAt: null
+---
+
+A specialized store for tree-structured data. Manages parent-child relationships, expansion state, and lazy loading of child nodes. Powers TreeList and other hierarchical components.

--- a/resources/content/concepts/two-tier-reactivity.md
+++ b/resources/content/concepts/two-tier-reactivity.md
@@ -1,0 +1,11 @@
+---
+name: "Two-Tier Reactivity"
+tier: 1
+uniqueToNeo: true
+tags:
+  - "architecture"
+  - "reactivity"
+verifiedAt: null
+---
+
+Neo.mjs provides two complementary reactivity models: push-based reactivity via the Config System (explicit lifecycle hooks) and pull-based reactivity via Effects (automatic dependency tracking). Developers choose the right model for each use case.

--- a/resources/content/concepts/undefined-sentinel.md
+++ b/resources/content/concepts/undefined-sentinel.md
@@ -1,0 +1,11 @@
+---
+name: "The undefined Sentinel Value"
+tier: 2
+uniqueToNeo: true
+tags:
+  - "reactivity"
+  - "config"
+verifiedAt: null
+---
+
+When a reactive config is set to the literal value undefined, Neo.mjs interprets this as 'do not apply this config'. This allows subclasses to selectively opt out of inherited default values without triggering afterSet hooks.

--- a/resources/content/concepts/vdom-as-ipc.md
+++ b/resources/content/concepts/vdom-as-ipc.md
@@ -1,0 +1,12 @@
+---
+name: "VDOM as IPC Layer"
+tier: 1
+uniqueToNeo: true
+tags:
+  - "architecture"
+  - "vdom"
+  - "workers"
+verifiedAt: null
+---
+
+The JSON-based virtual DOM doubles as the inter-process communication format between the App Worker and VDom Worker. State changes are expressed as VDOM mutations, serialized to postMessage, then delta-computed in the VDom Worker.

--- a/resources/content/concepts/vdom-teleportation.md
+++ b/resources/content/concepts/vdom-teleportation.md
@@ -1,0 +1,11 @@
+---
+name: "VDOM Teleportation"
+tier: 2
+uniqueToNeo: true
+tags:
+  - "vdom"
+  - "multi-window"
+verifiedAt: null
+---
+
+Components can be moved between windows at runtime by serializing their VDOM JSON to a different browser context. The component's state persists in the App Worker — only the rendering target changes.

--- a/resources/content/concepts/worker-isolation.md
+++ b/resources/content/concepts/worker-isolation.md
@@ -1,0 +1,11 @@
+---
+name: "Worker Isolation"
+tier: 1
+uniqueToNeo: true
+tags:
+  - "architecture"
+  - "workers"
+verifiedAt: null
+---
+
+Each worker type (App, VDom, Data, Canvas, Task) has a dedicated responsibility. App Workers run component logic; VDom Workers compute deltas; Data Workers handle network I/O; Canvas Workers handle OffscreenCanvas rendering.

--- a/resources/content/concepts/zero-build-dev.md
+++ b/resources/content/concepts/zero-build-dev.md
@@ -1,0 +1,11 @@
+---
+name: "Zero-Build Development Mode"
+tier: 1
+uniqueToNeo: true
+tags:
+  - "architecture"
+  - "development"
+verifiedAt: null
+---
+
+In development mode, Neo.mjs runs directly from native ES modules — no bundler, no transpiler, no build step. The browser imports source files directly. Production builds use webpack for optimization but are not required during development.

--- a/test/playwright/unit/ai/mcp/validation/OpenApiValidatorCompliance.spec.mjs
+++ b/test/playwright/unit/ai/mcp/validation/OpenApiValidatorCompliance.spec.mjs
@@ -194,8 +194,8 @@ test.describe('OpenApiValidator: strict-client JSON-Schema compliance', () => {
         expect(coalesceWindow.maximum).toBe(300);
     });
 
-    test('knowledge-base query schemas expose skill content type (#11326)', async () => {
-        const expectedTypes = ['all', 'blog', 'guide', 'src', 'example', 'ticket', 'release', 'test', 'skill'],
+    test('knowledge-base query schemas expose skill, adr, and concept content types', async () => {
+        const expectedTypes = ['all', 'blog', 'guide', 'src', 'example', 'ticket', 'release', 'test', 'skill', 'adr', 'concept'],
               doc           = yaml.load(fs.readFileSync(path.join(repoRoot, 'ai/mcp/server/knowledge-base/openapi.yaml'), 'utf8')),
               queryOp       = doc.paths['/documents/query'].post,
               askOp         = doc.paths['/knowledge/ask'].post,
@@ -206,7 +206,8 @@ test.describe('OpenApiValidator: strict-client JSON-Schema compliance', () => {
         expect(queryType.enum).toEqual(expectedTypes);
         expect(queryType.description).toContain('`test`');
         expect(queryType.description).toContain('`skill`');
-        expect(queryOp.description).toContain('release, test, skill');
+        expect(queryType.description).toContain('`adr`');
+        expect(queryType.description).toContain('`concept`');
         expect(querySchema.properties.type.enum).toEqual(expectedTypes);
         expect(askSchema.properties.type.enum).toEqual(expectedTypes);
     });

--- a/test/playwright/unit/ai/services/knowledge-base/DatabaseService.sync.spec.mjs
+++ b/test/playwright/unit/ai/services/knowledge-base/DatabaseService.sync.spec.mjs
@@ -19,18 +19,18 @@ test.describe('Neo.ai.services.knowledge-base.DatabaseService sync', () => {
     test('createKnowledgeBase() emits type: adr chunks', async () => {
         const originalDataPath = aiConfig.dataPath;
         const testDataPath = path.join(aiConfig.neoRootDir, 'dist', 'test-ai-knowledge-base.jsonl');
-        
+
         try {
             aiConfig.dataPath = testDataPath;
-            
+
             // Generate the knowledge base
             const result = await DatabaseService.createKnowledgeBase();
             expect(result.message).toMatch(/created with \d+ chunks/);
-            
+
             // Read the output
             expect(fs.existsSync(testDataPath)).toBe(true);
             const content = await fs.readFile(testDataPath, 'utf8');
-            
+
             // Assert that ADR chunks were emitted
             const lines = content.trim().split('\n');
             const adrChunks = lines.filter(line => {
@@ -38,7 +38,7 @@ test.describe('Neo.ai.services.knowledge-base.DatabaseService sync', () => {
                 const chunk = JSON.parse(line);
                 return chunk.type === 'adr';
             });
-            
+
             expect(adrChunks.length).toBeGreaterThan(0);
         } finally {
             aiConfig.dataPath = originalDataPath;

--- a/test/playwright/unit/ai/services/knowledge-base/DatabaseService.sync.spec.mjs
+++ b/test/playwright/unit/ai/services/knowledge-base/DatabaseService.sync.spec.mjs
@@ -1,0 +1,50 @@
+import {setup} from '../../../../setup.mjs';
+setup({neoConfig: {unitTestMode: true}});
+
+import {test, expect}  from '@playwright/test';
+import Neo             from '../../../../../../src/Neo.mjs';
+import * as core       from '../../../../../../src/core/_export.mjs';
+import fs from 'fs-extra';
+import path from 'path';
+
+test.describe('Neo.ai.services.knowledge-base.DatabaseService sync', () => {
+    let DatabaseService;
+    let aiConfig;
+
+    test.beforeAll(async () => {
+        aiConfig = (await import('../../../../../../ai/mcp/server/knowledge-base/config.mjs')).default;
+        DatabaseService = (await import('../../../../../../ai/services.mjs')).KB_DatabaseService;
+    });
+
+    test('createKnowledgeBase() emits type: adr chunks', async () => {
+        const originalDataPath = aiConfig.dataPath;
+        const testDataPath = path.join(aiConfig.neoRootDir, 'dist', 'test-ai-knowledge-base.jsonl');
+        
+        try {
+            aiConfig.dataPath = testDataPath;
+            
+            // Generate the knowledge base
+            const result = await DatabaseService.createKnowledgeBase();
+            expect(result.message).toMatch(/created with \d+ chunks/);
+            
+            // Read the output
+            expect(fs.existsSync(testDataPath)).toBe(true);
+            const content = await fs.readFile(testDataPath, 'utf8');
+            
+            // Assert that ADR chunks were emitted
+            const lines = content.trim().split('\n');
+            const adrChunks = lines.filter(line => {
+                if (!line) return false;
+                const chunk = JSON.parse(line);
+                return chunk.type === 'adr';
+            });
+            
+            expect(adrChunks.length).toBeGreaterThan(0);
+        } finally {
+            aiConfig.dataPath = originalDataPath;
+            if (fs.existsSync(testDataPath)) {
+                await fs.unlink(testDataPath);
+            }
+        }
+    });
+});

--- a/test/playwright/unit/ai/services/knowledge-base/source/AdrSource.spec.mjs
+++ b/test/playwright/unit/ai/services/knowledge-base/source/AdrSource.spec.mjs
@@ -1,0 +1,91 @@
+import {setup} from '../../../../../setup.mjs';
+
+const appName = 'AdrSourceTest';
+
+setup({
+    neoConfig: {
+        unitTestMode: true
+    },
+    appConfig: {
+        name             : appName,
+        isMounted        : () => true,
+        vnodeInitialising: false
+    }
+});
+
+import {test, expect}  from '@playwright/test';
+import fs              from 'fs-extra';
+import path            from 'path';
+import {fileURLToPath} from 'url';
+import Neo             from '../../../../../../../src/Neo.mjs';
+import * as core       from '../../../../../../../src/core/_export.mjs';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname  = path.dirname(__filename);
+const repoRoot   = path.resolve(__dirname, '../../../../../../..');
+
+test.describe('Neo.ai.services.knowledge-base.source.AdrSource', () => {
+    let AdrSource;
+    let aiConfig;
+    let originalRoot;
+    let mockRoot;
+
+    test.beforeAll(async () => {
+        aiConfig    = (await import('../../../../../../../ai/mcp/server/knowledge-base/config.mjs')).default;
+        AdrSource = (await import('../../../../../../../ai/services/knowledge-base/source/AdrSource.mjs')).default;
+
+        originalRoot = aiConfig.neoRootDir;
+
+        const tmpDir = path.resolve(process.cwd(), 'tmp');
+        fs.ensureDirSync(tmpDir);
+        mockRoot = path.join(tmpDir, `adr-source-mock-${process.pid}-${Date.now()}`);
+
+        const adrDir = path.join(mockRoot, 'learn/agentos/decisions');
+        fs.ensureDirSync(adrDir);
+
+        fs.writeFileSync(path.join(adrDir, '0001-example-adr.md'),
+`# ADR 1
+Example decision.`);
+
+        fs.writeFileSync(path.join(adrDir, 'not-an-adr.md'),
+`# Not an ADR
+This should be skipped.`);
+
+        aiConfig.neoRootDir = mockRoot;
+    });
+
+    test.afterAll(() => {
+        aiConfig.neoRootDir = originalRoot;
+        if (mockRoot && fs.existsSync(mockRoot)) fs.removeSync(mockRoot);
+    });
+
+    test('is a Neo.setupClass singleton with the expected className and extract() method', () => {
+        expect(AdrSource, 'default export must resolve').toBeDefined();
+        expect(AdrSource.className).toBe('Neo.ai.services.knowledge-base.source.AdrSource');
+        expect(typeof AdrSource.extract).toBe('function');
+    });
+
+    test('extract() emits correctly typed and chunked ADRs, skipping non-matching files', async () => {
+        const written = [];
+        const writeStream = {
+            write(chunkStr) {
+                written.push(JSON.parse(chunkStr.trim()));
+                return true;
+            }
+        };
+        const createHashFn = chunk => 'hash:' + chunk.name;
+
+        const count = await AdrSource.extract(writeStream, createHashFn);
+
+        expect(count).toBe(1);
+        expect(written).toHaveLength(1);
+
+        const chunk = written[0];
+        expect(chunk).toMatchObject({
+            type: 'adr',
+            kind: 'adr',
+            name: '0001-example-adr',
+            content: '# ADR 1\nExample decision.'
+        });
+    });
+});

--- a/test/playwright/unit/ai/services/knowledge-base/source/ConceptSource.spec.mjs
+++ b/test/playwright/unit/ai/services/knowledge-base/source/ConceptSource.spec.mjs
@@ -1,0 +1,93 @@
+import {setup} from '../../../../../setup.mjs';
+
+const appName = 'ConceptSourceTest';
+
+setup({
+    neoConfig: {
+        unitTestMode: true
+    },
+    appConfig: {
+        name             : appName,
+        isMounted        : () => true,
+        vnodeInitialising: false
+    }
+});
+
+import {test, expect}  from '@playwright/test';
+import fs              from 'fs-extra';
+import path            from 'path';
+import {fileURLToPath} from 'url';
+import Neo             from '../../../../../../../src/Neo.mjs';
+import * as core       from '../../../../../../../src/core/_export.mjs';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname  = path.dirname(__filename);
+const repoRoot   = path.resolve(__dirname, '../../../../../../..');
+
+test.describe('Neo.ai.services.knowledge-base.source.ConceptSource', () => {
+    let ConceptSource;
+    let aiConfig;
+    let originalRoot;
+    let mockRoot;
+
+    test.beforeAll(async () => {
+        aiConfig    = (await import('../../../../../../../ai/mcp/server/knowledge-base/config.mjs')).default;
+        ConceptSource = (await import('../../../../../../../ai/services/knowledge-base/source/ConceptSource.mjs')).default;
+
+        originalRoot = aiConfig.neoRootDir;
+
+        const tmpDir = path.resolve(process.cwd(), 'tmp');
+        fs.ensureDirSync(tmpDir);
+        mockRoot = path.join(tmpDir, `concept-source-mock-${process.pid}-${Date.now()}`);
+
+        const conceptsDir = path.join(mockRoot, 'resources/content/concepts');
+        fs.ensureDirSync(conceptsDir);
+
+        fs.writeFileSync(path.join(conceptsDir, 'multi-threading.md'),
+`---
+name: "Multi-Threading Architecture"
+tier: 1
+---
+
+Neo.mjs distributes application logic across dedicated Web Workers.`);
+
+        aiConfig.neoRootDir = mockRoot;
+    });
+
+    test.afterAll(() => {
+        aiConfig.neoRootDir = originalRoot;
+        if (mockRoot && fs.existsSync(mockRoot)) fs.removeSync(mockRoot);
+    });
+
+    test('is a Neo.setupClass singleton with the expected className and extract() method', () => {
+        expect(ConceptSource, 'default export must resolve').toBeDefined();
+        expect(ConceptSource.className).toBe('Neo.ai.services.knowledge-base.source.ConceptSource');
+        expect(typeof ConceptSource.extract).toBe('function');
+    });
+
+    test('extract() emits correctly typed and chunked concepts', async () => {
+        const written = [];
+        const writeStream = {
+            write(chunkStr) {
+                written.push(JSON.parse(chunkStr.trim()));
+                return true;
+            }
+        };
+        const createHashFn = chunk => 'hash:' + chunk.name;
+
+        const count = await ConceptSource.extract(writeStream, createHashFn);
+
+        expect(count).toBe(1);
+        expect(written).toHaveLength(1);
+
+        const chunk = written[0];
+        expect(chunk).toMatchObject({
+            type: 'concept',
+            kind: 'concept',
+            name: 'Multi-Threading Architecture',
+            tier: 1,
+            description: 'Neo.mjs distributes application logic across dedicated Web Workers.',
+            content: 'Multi-Threading Architecture: Neo.mjs distributes application logic across dedicated Web Workers.'
+        });
+    });
+});


### PR DESCRIPTION
Resolves #11373

This PR implements the new `AdrSource` and `ConceptSource` KB extraction paths and integrates them into the production `DatabaseService.createKnowledgeBase()` registry.

### Changes
- Implemented `AdrSource` and `ConceptSource` adhering to the `BaseSource` contract.
- Wired `AdrSource` and `ConceptSource` into `ai/services/knowledge-base/DatabaseService.mjs` source registry.
- Updated `OpenApiValidatorCompliance.spec.mjs` for `adr` and `concept` chunks.
- Added `DatabaseService.sync.spec.mjs` to prove `adr` chunk emission from the build path.

### Evidence
- **Hygiene**: PR is clean, rebased onto `dev` without any stacked commits. `nodes.jsonl` deletion was reverted to preserve the original Graph substrate.
- **Testing**: Focused unit and integration tests are green. Trailing whitespaces fixed.
