### PR TITLE
fix(memory-core): broaden embedding-retry detection to LM Studio Shape B (#11395)

### DIFF
--- a/ai/services/memory-core/TextEmbeddingService.mjs
+++ b/ai/services/memory-core/TextEmbeddingService.mjs
@@ -119,8 +119,14 @@ class TextEmbeddingService extends Base {
 
             return await responsePromise;
         } catch (err) {
-            if (retriesLeft > 0 && err.message.includes('HTTP 400') && err.message.includes('Model was unloaded')) {
-                logger.log(`[TextEmbeddingService] embedding-provider model-unload detected, retrying (remaining retries: ${retriesLeft})`);
+            const isModelLoadError = err.message.includes('HTTP 400') && (
+                err.message.includes('Model was unloaded') ||              // Shape A — JIT-unload-then-queued-request
+                (err.message.includes('Failed to load model') &&            // Shape B — JIT-warm-load-canceled
+                 err.message.includes('Operation canceled'))
+            );
+
+            if (retriesLeft > 0 && isModelLoadError) {
+                logger.log(`[TextEmbeddingService] embedding-provider model-load failure detected (Shape ${err.message.includes('Model was unloaded') ? 'A' : 'B'}), retrying (remaining retries: ${retriesLeft})`);
                 await new Promise(r => setTimeout(r, unloadRetryDelayMs));
                 return this.#postOpenAiCompatible(inputData, retriesLeft - 1);
             }

--- a/test/playwright/unit/ai/services/memory-core/TextEmbeddingService.retry.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/TextEmbeddingService.retry.spec.mjs
@@ -22,7 +22,7 @@ import aiConfig       from '../../../../../../ai/mcp/server/memory-core/config.m
 test.describe.serial('TextEmbeddingService #11393 — openAiCompatible retry on model unload', () => {
     let SDK, TextEmbeddingService, server;
     let requestCount = 0;
-    let serverBehavior = 'succeed'; // 'succeed', 'fail-then-succeed', 'fail-all'
+    let serverBehavior = 'succeed'; // 'succeed', 'fail-then-succeed', 'fail-all', 'fail-shape-b-then-succeed', 'fail-all-shape-b'
     let testPort;
     let originalHost, originalRetryCount, originalRetryDelay;
 
@@ -48,6 +48,17 @@ test.describe.serial('TextEmbeddingService #11393 — openAiCompatible retry on 
             } else if (serverBehavior === 'fail-all') {
                 res.writeHead(400, { 'Content-Type': 'application/json' });
                 res.end(JSON.stringify({ error: 'Model was unloaded while the request was still in queue..' }));
+            } else if (serverBehavior === 'fail-shape-b-then-succeed') {
+                if (requestCount === 1) {
+                    res.writeHead(400, { 'Content-Type': 'application/json' });
+                    res.end(JSON.stringify({ error: 'Failed to load model "text-embedding-qwen3-embedding-8b". Error: Operation canceled.' }));
+                } else {
+                    res.writeHead(200, { 'Content-Type': 'application/json' });
+                    res.end(JSON.stringify({ data: [{ embedding: [0.7, 0.8, 0.9] }] }));
+                }
+            } else if (serverBehavior === 'fail-all-shape-b') {
+                res.writeHead(400, { 'Content-Type': 'application/json' });
+                res.end(JSON.stringify({ error: 'Failed to load model "text-embedding-qwen3-embedding-8b". Error: Operation canceled.' }));
             } else if (serverBehavior === 'fail-other') {
                 res.writeHead(400, { 'Content-Type': 'application/json' });
                 res.end(JSON.stringify({ error: 'Some other bad request error' }));
@@ -99,6 +110,24 @@ test.describe.serial('TextEmbeddingService #11393 — openAiCompatible retry on 
         
         await expect(TextEmbeddingService.embedText('hello', 'openAiCompatible'))
             .rejects.toThrow(/Model was unloaded/);
+            
+        // Initial request + 2 retries = 3 total requests
+        expect(requestCount).toBe(3);
+    });
+    
+    test('first-call-fails-shape-b-second-call-succeeds path with mock client', async () => {
+        serverBehavior = 'fail-shape-b-then-succeed';
+        const result = await TextEmbeddingService.embedText('hello', 'openAiCompatible');
+        expect(result).toEqual([0.7, 0.8, 0.9]);
+        expect(requestCount).toBe(2);
+    });
+
+    test('exhausted-retry-final-failure path with shape b', async () => {
+        serverBehavior = 'fail-all-shape-b';
+        aiConfig.openAiCompatible.unloadRetryCount = 2; // N=2
+        
+        await expect(TextEmbeddingService.embedText('hello', 'openAiCompatible'))
+            .rejects.toThrow(/Failed to load model.*Operation canceled/);
             
         // Initial request + 2 retries = 3 total requests
         expect(requestCount).toBe(3);


### PR DESCRIPTION
Resolves #11395

This PR expands the Memory Core embedding retry detection to cover a second empirically-observed LM Studio model-unload error shape (`Shape B`).

### Changes
- Updated `TextEmbeddingService.mjs` to detect `Failed to load model` + `Operation canceled` in addition to the existing `Model was unloaded` shape.
- Extracted detection logic into a clean boolean expression and added a descriptive log entry differentiating between Shape A and Shape B.
- Added comprehensive unit tests for the new Shape B path to `TextEmbeddingService.retry.spec.mjs`.

No regressions introduced. All tests pass.