### PR TITLE
feat(agentos): manifest lint section-trigger heuristic (#11320)

### DIFF
--- a/.agents/skills/create-skill/references/skill-authoring-guide.md
+++ b/.agents/skills/create-skill/references/skill-authoring-guide.md
@@ -129,6 +129,7 @@ Map vs World Atlas applies **recursively**. A workflow file (`references/<workfl
 - `perFilePayloadBudget` per-skill (or `defaults.perFilePayloadBudget`) — lint fails any individual file in `references/` exceeding the cap
 - Default: 25,000 bytes (25 KB) — empirical-floor for clean skills
 - Temporary per-skill overrides for migration-period monoliths (e.g., `pr-review` at 66000, `pull-request` at 38000) — to be tightened as Sub-B+ migrations land
+- `checkSectionTriggers` heuristic: sections larger than 5,000 bytes declaring a rare-firing trigger (e.g., 'openapi', 'audit', 'deprecation', 'edge-case') are flagged for extraction to a sibling file.
 
 **Empirical precedent:**
 - `pull-request` skill: workflow + 4 sub-rule siblings (`env-var-rename-rule.md`, `mcp-config-template-change-guide.md`, `sync-all-constraints.md`, `review-response-protocol.md`) — each conditionally loaded per workflow body trigger pointer

--- a/.agents/skills/skills.manifest.json
+++ b/.agents/skills/skills.manifest.json
@@ -6,6 +6,12 @@
     "routerByteBudget": 12,
     "payloadBudget": 80000,
     "perFilePayloadBudget": 25000,
+    "rareTriggerPatterns": [
+      "openapi",
+      "audit",
+      "edge-case",
+      "deprecation"
+    ],
     "claudeSymlinkRequired": true,
     "downstreamDocsTargets": [
       "learn/agentos/ProgressiveDisclosureSkills.md",

--- a/.agents/skills/skills.manifest.schema.json
+++ b/.agents/skills/skills.manifest.schema.json
@@ -34,6 +34,13 @@
           "minimum": 1,
           "description": "Optional per-individual-file byte ceiling within references/. Defaults to disabled when omitted. Recursive Map vs World Atlas enforcement per #11314 / #11319 / #11320."
         },
+        "rareTriggerPatterns": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Optional list of substrings that classify a section-trigger as rare-firing for lint heuristics."
+        },
         "claudeSymlinkRequired": {
           "type": "boolean"
         },

--- a/ai/scripts/lint-skill-manifest.mjs
+++ b/ai/scripts/lint-skill-manifest.mjs
@@ -138,8 +138,8 @@ function checkPerFileBudgets(files, perFileBudget) {
     return errors;
 }
 
-function checkSectionTriggers(filePath, text, rarePatterns = []) {
-    const errors = [];
+function parseSectionTriggers(text) {
+    const index = [];
     const sections = text.split(/^(?=#{2,6}\s)/m);
 
     for (const section of sections) {
@@ -153,18 +153,32 @@ function checkSectionTriggers(filePath, text, rarePatterns = []) {
 
         const triggerMatch = section.match(/^<!-- trigger:\s+(.+?)\s+→\s+read\s+(.+?\.md)\s*-->$/m);
         if (triggerMatch) {
-            const trigger = triggerMatch[1].trim();
+            index.push({
+                anchor,
+                trigger: triggerMatch[1].trim(),
+                subRulePath: triggerMatch[2].trim(),
+                bodySizeBytes
+            });
+        }
+    }
 
-            if (bodySizeBytes > 5000) {
-                const isRare = rarePatterns.some(p => trigger.toLowerCase().includes(p.toLowerCase()));
-                if (isRare) {
-                    errors.push(`${path.relative(ROOT_DIR, filePath)} ${anchor} is ${bodySizeBytes} bytes with declared trigger '${trigger}' (rare-firing class). Extract to sub-rule sibling file behind one-line trigger pointer per skill-authoring-guide.md §Map vs World Atlas. Reduce workflow body to: section header + <!-- trigger: ... --> pointer line.`);
-                }
+    return index;
+}
+
+function checkSectionTriggers(filePath, text, rarePatterns = []) {
+    const errors = [];
+    const index = parseSectionTriggers(text);
+
+    for (const entry of index) {
+        if (entry.bodySizeBytes > 5000) {
+            const isRare = rarePatterns.some(p => entry.trigger.toLowerCase().includes(p.toLowerCase()));
+            if (isRare) {
+                errors.push(`${path.relative(ROOT_DIR, filePath)} ${entry.anchor} is ${entry.bodySizeBytes} bytes with declared trigger '${entry.trigger}' (rare-firing class). Extract to sub-rule sibling file behind one-line trigger pointer per skill-authoring-guide.md §Map vs World Atlas. Reduce workflow body to: section header + <!-- trigger: ... --> pointer line.`);
             }
         }
     }
 
-    return errors;
+    return {errors, index};
 }
 
 function validateManifestSchema(manifest, schema) {
@@ -388,7 +402,8 @@ async function lint({base = null} = {}) {
         const rarePatterns = manifest.defaults.rareTriggerPatterns || ['openapi', 'audit', 'edge-case', 'deprecation'];
         for (const {path: filePath} of files) {
             const text = requireText(filePath);
-            errors.push(...checkSectionTriggers(filePath, text, rarePatterns));
+            const result = checkSectionTriggers(filePath, text, rarePatterns);
+            errors.push(...result.errors);
         }
 
         if (skill.claudeSymlinkRequired) {
@@ -437,4 +452,4 @@ if (process.argv[1] && path.resolve(process.argv[1]) === __filename) {
     });
 }
 
-export {checkPerFileBudgets, checkSectionTriggers, lint, parseArgs, parseFrontmatter, validateManifestSchema};
+export {checkPerFileBudgets, checkSectionTriggers, parseSectionTriggers, lint, parseArgs, parseFrontmatter, validateManifestSchema};

--- a/ai/scripts/lint-skill-manifest.mjs
+++ b/ai/scripts/lint-skill-manifest.mjs
@@ -138,6 +138,35 @@ function checkPerFileBudgets(files, perFileBudget) {
     return errors;
 }
 
+function checkSectionTriggers(filePath, text, rarePatterns = []) {
+    const errors = [];
+    const sections = text.split(/^(?=#{2,6}\s)/m);
+
+    for (const section of sections) {
+        if (!section.trim()) continue;
+
+        const headerMatch = section.match(/^(#{2,6})\s+([^\n]+)/);
+        if (!headerMatch) continue;
+
+        const anchor = headerMatch[2].trim();
+        const bodySizeBytes = Buffer.byteLength(section, 'utf8');
+
+        const triggerMatch = section.match(/^<!-- trigger:\s+(.+?)\s+→\s+read\s+(.+?\.md)\s*-->$/m);
+        if (triggerMatch) {
+            const trigger = triggerMatch[1].trim();
+
+            if (bodySizeBytes > 5000) {
+                const isRare = rarePatterns.some(p => trigger.toLowerCase().includes(p.toLowerCase()));
+                if (isRare) {
+                    errors.push(`${path.relative(ROOT_DIR, filePath)} ${anchor} is ${bodySizeBytes} bytes with declared trigger '${trigger}' (rare-firing class). Extract to sub-rule sibling file behind one-line trigger pointer per skill-authoring-guide.md §Map vs World Atlas. Reduce workflow body to: section header + <!-- trigger: ... --> pointer line.`);
+                }
+            }
+        }
+    }
+
+    return errors;
+}
+
 function validateManifestSchema(manifest, schema) {
     const errors = [];
     const rootKeys = new Set([...schema.required, '$schema']);
@@ -183,6 +212,16 @@ function validateManifestSchema(manifest, schema) {
 
     if ('perFilePayloadBudget' in defaults && (!Number.isInteger(defaults.perFilePayloadBudget) || defaults.perFilePayloadBudget < 1)) {
         errors.push('defaults.perFilePayloadBudget must be a positive integer when set');
+    }
+
+    if ('rareTriggerPatterns' in defaults) {
+        if (!Array.isArray(defaults.rareTriggerPatterns)) {
+            errors.push('defaults.rareTriggerPatterns must be an array of strings');
+        } else {
+            for (const p of defaults.rareTriggerPatterns) {
+                if (typeof p !== 'string') errors.push('defaults.rareTriggerPatterns must be an array of strings');
+            }
+        }
     }
 
     if (typeof defaults.claudeSymlinkRequired !== 'boolean') {
@@ -340,10 +379,16 @@ async function lint({base = null} = {}) {
         }
 
         const perFileBudget = skill.perFilePayloadBudget ?? manifest.defaults.perFilePayloadBudget;
+        const files = await payloadFileSizes(skillName);
 
         if (Number.isInteger(perFileBudget) && perFileBudget > 0) {
-            const files = await payloadFileSizes(skillName);
             errors.push(...checkPerFileBudgets(files, perFileBudget));
+        }
+
+        const rarePatterns = manifest.defaults.rareTriggerPatterns || ['openapi', 'audit', 'edge-case', 'deprecation'];
+        for (const {path: filePath} of files) {
+            const text = requireText(filePath);
+            errors.push(...checkSectionTriggers(filePath, text, rarePatterns));
         }
 
         if (skill.claudeSymlinkRequired) {
@@ -392,4 +437,4 @@ if (process.argv[1] && path.resolve(process.argv[1]) === __filename) {
     });
 }
 
-export {checkPerFileBudgets, lint, parseArgs, parseFrontmatter, validateManifestSchema};
+export {checkPerFileBudgets, checkSectionTriggers, lint, parseArgs, parseFrontmatter, validateManifestSchema};

--- a/test/playwright/unit/ai/scripts/lintSkillManifest.spec.mjs
+++ b/test/playwright/unit/ai/scripts/lintSkillManifest.spec.mjs
@@ -7,6 +7,7 @@ import {
     checkSectionTriggers,
     parseArgs,
     parseFrontmatter,
+    parseSectionTriggers,
     validateManifestSchema
 } from '../../../../../ai/scripts/lint-skill-manifest.mjs';
 
@@ -310,7 +311,7 @@ test.describe('ai/scripts/lint-skill-manifest (#11275)', () => {
 <!-- trigger: this is an edge-case → read ./sub-rule.md -->
 Just a short body, well under 5000 bytes.
         `;
-        expect(checkSectionTriggers('test.md', text, ['edge-case'])).toEqual([]);
+        expect(checkSectionTriggers('test.md', text, ['edge-case']).errors).toEqual([]);
     });
 
     test('checkSectionTriggers returns no errors for large sections without rare triggers (#11320)', () => {
@@ -320,7 +321,7 @@ Just a short body, well under 5000 bytes.
 <!-- trigger: always relevant → read ./sub-rule.md -->
 ${padding}
         `;
-        expect(checkSectionTriggers('test.md', text, ['edge-case', 'openapi'])).toEqual([]);
+        expect(checkSectionTriggers('test.md', text, ['edge-case', 'openapi']).errors).toEqual([]);
     });
 
     test('checkSectionTriggers returns error for large sections with rare triggers (#11320)', () => {
@@ -330,10 +331,25 @@ ${padding}
 <!-- trigger: modifies openapi.yaml → read ./openapi-audit.md -->
 ${padding}
         `;
-        const errors = checkSectionTriggers('.agents/skills/example/references/test.md', text, ['edge-case', 'openapi']);
+        const {errors} = checkSectionTriggers('.agents/skills/example/references/test.md', text, ['edge-case', 'openapi']);
         expect(errors).toHaveLength(1);
         expect(errors[0]).toContain('.agents/skills/example/references/test.md §3 OpenAPI Edge Case is ');
         expect(errors[0]).toContain("bytes with declared trigger 'modifies openapi.yaml' (rare-firing class)");
         expect(errors[0]).toContain("Extract to sub-rule sibling file behind one-line trigger pointer per skill-authoring-guide.md §Map vs World Atlas.");
+    });
+
+    test('parseSectionTriggers extracts anchor, trigger, subRulePath, and body size (#11320)', () => {
+        const padding = 'C'.repeat(100);
+        const text = `
+## §4 Test Section
+<!-- trigger: test condition → read ./test-rule.md -->
+${padding}
+        `;
+        const index = parseSectionTriggers(text);
+        expect(index).toHaveLength(1);
+        expect(index[0].anchor).toBe('§4 Test Section');
+        expect(index[0].trigger).toBe('test condition');
+        expect(index[0].subRulePath).toBe('./test-rule.md');
+        expect(index[0].bodySizeBytes).toBeGreaterThan(100);
     });
 });

--- a/test/playwright/unit/ai/scripts/lintSkillManifest.spec.mjs
+++ b/test/playwright/unit/ai/scripts/lintSkillManifest.spec.mjs
@@ -4,6 +4,7 @@ import path                      from 'path';
 
 import {
     checkPerFileBudgets,
+    checkSectionTriggers,
     parseArgs,
     parseFrontmatter,
     validateManifestSchema
@@ -301,5 +302,38 @@ test.describe('ai/scripts/lint-skill-manifest (#11275)', () => {
         }, schema);
 
         expect(errors).toEqual([]);
+    });
+
+    test('checkSectionTriggers returns no errors for sections without triggers or below size threshold (#11320)', () => {
+        const text = `
+## §1 Short Section
+<!-- trigger: this is an edge-case → read ./sub-rule.md -->
+Just a short body, well under 5000 bytes.
+        `;
+        expect(checkSectionTriggers('test.md', text, ['edge-case'])).toEqual([]);
+    });
+
+    test('checkSectionTriggers returns no errors for large sections without rare triggers (#11320)', () => {
+        const padding = 'A'.repeat(6000);
+        const text = `
+## §2 Large Common Section
+<!-- trigger: always relevant → read ./sub-rule.md -->
+${padding}
+        `;
+        expect(checkSectionTriggers('test.md', text, ['edge-case', 'openapi'])).toEqual([]);
+    });
+
+    test('checkSectionTriggers returns error for large sections with rare triggers (#11320)', () => {
+        const padding = 'B'.repeat(6000);
+        const text = `
+## §3 OpenAPI Edge Case
+<!-- trigger: modifies openapi.yaml → read ./openapi-audit.md -->
+${padding}
+        `;
+        const errors = checkSectionTriggers('.agents/skills/example/references/test.md', text, ['edge-case', 'openapi']);
+        expect(errors).toHaveLength(1);
+        expect(errors[0]).toContain('.agents/skills/example/references/test.md §3 OpenAPI Edge Case is ');
+        expect(errors[0]).toContain("bytes with declared trigger 'modifies openapi.yaml' (rare-firing class)");
+        expect(errors[0]).toContain("Extract to sub-rule sibling file behind one-line trigger pointer per skill-authoring-guide.md §Map vs World Atlas.");
     });
 });


### PR DESCRIPTION
Resolves #11320 (Sub-A of Epic #11319).

This implements the mechanical-enforcement substrate for Trigger-Aware Workflows (Map vs World Atlas discipline).

### Changes (Deltas from #11320 ACs)
- **AC1, AC2, AC3, AC8:** The base `perFilePayloadBudget` fields, config overrides, omitting-semantics, and lint checks (`checkPerFileBudgets`) were already satisfied by the prior manifest state (introduced in earlier PRs). The current manifest correctly configures the baseline budget (25000 bytes) with temporary calibration overrides for monoliths (`pr-review` at 66000, `pull-request` at 38000).
- **AC4:** Implemented section-trigger parsing (`checkSectionTriggers`) in `lint-skill-manifest.mjs` using regex against HTML comments (`<!-- trigger: ... -->`).
- **AC5:** Added the frequency × size heuristic. Sections > 5000 bytes declaring rare triggers (configurable via `rareTriggerPatterns`) are flagged for extraction. Added `rareTriggerPatterns` to `skills.manifest.schema.json` and the `skills.manifest.json` defaults.
- **AC6:** Appended the frequency heuristic explanation to the `Recursive Application` mechanical enforcement section in `skill-authoring-guide.md`.
- **AC7:** PR diff strictly touches manifest, schema, lint script, and `skill-authoring-guide.md`.
- **AC9:** Added Playwright unit test coverage for `checkSectionTriggers` in `lintSkillManifest.spec.mjs`. Tests confirm happy paths, size thresholds, and rare-trigger extraction triggers.
- **AC10:** Notified @neo-gpt for Epic Review gatekeeping.

### Evidence
- **Test/CI:** Unit tests pass locally.
- **Lint:** `node ai/scripts/lint-skill-manifest.mjs --base origin/dev` passes with no regressions.