### PR TITLE
refactor(substrate): migrate workflow skills and edge cases to atlas (#11413)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -174,28 +174,7 @@ To mitigate "Helpful Assistant" regression drift, agents MUST execute this evalu
 </neo_core_overrides>
 
 ## 21. Workflow Skills (when to invoke)
-| Skill | Trigger condition (invoke when) |
-|---|---|
-| `ticket-create` | Before `create_issue` MCP invocation |
-| `ticket-triage` | Encountering a ticket missing `ai`/primary/secondary labels |
-| `ticket-intake` | Picking up an existing assigned ticket |
-| `epic-review` | Before picking up a sub of an unreviewed epic |
-| `epic-resolution` | Last required sub closes / before close-as-completed |
-| `pull-request` | Code modifications complete; before opening PR — stepping-back reflection, commit format, cross-family review mandate, post-comment A2A commentId hand-off (author→reviewer) per review-response-protocol.md §14, Evidence declaration line for substrate/runtime-AC PRs per [evidence-ladder.md](learn/agentos/evidence-ladder.md) |
-| `pr-review` | Reviewing a PR (yours or peer's) — structured eval metrics, graph ingestion tags, severity ladder, restates §0 merge gate, post-comment A2A commentId hand-off (reviewer→author) per guide §9 + §9.4 cold-cache exception, Evidence Audit + Source-of-Authority sections (template §) for substrate/runtime-AC PRs and authority-citation review-comments |
-| `post-review-pickup` | Immediately after `pr-review` or review-response handoff completes — read `.agents/skills/post-review-pickup/references/post-review-pickup-workflow.md`, then enter the next ready lifecycle lane or state an explicit halt reason |
-| `ideation-sandbox`| Before creating a Discussion for architectural exploration; also auto-fires §5.2 Step 2.5 Architectural Step-Back on high-blast-radius proposals before `[RESOLVED_TO_AC]` / `[GRADUATED_TO_TICKET]` graduation |
-| `lead-role` | Operator delegates lead via explicit phrases ("take the lead", "coordinate the team"); OR §22 mailbox check surfaces a valid `lead-role-baton`; OR substrate-shaped ticket about to enter implementation; OR direct invocation. Auto-fires per documented phrases / baton intake. Suspends Auto Mode velocity-bias for skill duration. |
-| `peer-role` | Reviewing an Ideation Sandbox discussion, architectural proposal, epic shape, skill shape, roadmap/milestone proposal, or `/lead-role` convergence artifact. Auto-fires per documented design-review context phrases. Suspends Auto Mode "ack-and-move-on" bias. |
-| `memory-mining` | On regression / non-obvious-architecture / decision-points |
-| `turn-memory-pre-flight` | Before inserting or mutating turn-loaded/skill-loaded memory substrate (`AGENTS.md`, `AGENTS_ATLAS`, `.agents/skills/**`, `.codex/CODEX.md`, `.claude/CLAUDE.md`, `.agents/ANTIGRAVITY_RULES.md`) to prevent future-session bias |
-| `create-skill` | Before creating OR modifying any `.agents/skills/**/*.md` files — Progressive Disclosure architecture (Map vs World Atlas), YAML frontmatter, skill structure. Complementary to `turn-memory-pre-flight` (load-runtime-effect dimension vs skill-shape dimension) |
-| `architecture-pre-flight` | When navigating ambiguous architectural-choice moments, cross-substrate decisions, or introducing new subsystems, protocols, MCP tools, or cross-substrate refactors not covered by narrower triggers |
-| `tech-debt-radar` | During PR review for fundamental architectural shifts |
-| `structural-pre-flight` | Before authoring or relocating any new `.mjs` file — directory-CHOICE discipline (Stage 0 mechanical trigger; Stage 1 fast-path via §23 sibling-file-lift OR full Pre-Flight via ArchitectureOverview.md + ADR consultation). Empirical anchors: misplaced `bridge-daemon.mjs` (#10449 origin) + `orchestrator-daemon.mjs` (PR #11008 → corrective #11009). Also fires from `ticket-create` Stage 3, `ticket-intake` validation, `epic-review` Stage 3 |
-| `session-sunset` | Context Window Exhaustion, Macro-Semantic Pivot |
-| `unit-test` | Before writing, modifying, or executing Playwright unit tests |
-| `whitebox-e2e` | Before writing, modifying, or executing Playwright Whitebox E2E tests |
+For the complete matrix of Workflow Skills and their invocation triggers, you MUST read `learn/agentos/AGENTS_ATLAS.md` §21. The table has been extracted to the Atlas to respect the 24KB harness memory limit.
 
 ## 22. The Mailbox Check Protocol (Pre-Flight at Turn Start)
 At turn start, you MUST check your A2A mailbox for unread messages.
@@ -217,11 +196,4 @@ Before triggering a lifecycle skill, state in your reasoning: *"I will read the 
 
 ## 23. Edge-Case Triggers (The Atlas)
 *(Sections mapped to `learn/agentos/AGENTS_ATLAS.md`)*
-- **Knowledge Base & Anti-Hallucination (§2, §15):** ALWAYS use `ask_knowledge_base` first for Neo concepts. If adding documentation, review Anchor & Echo strategy in `AGENTS_ATLAS.md`.
-- **Swarm Topology / Cross-Peer Coordination (§15.6):** Before cross-peer coordination, lead/peer role work, ideation review, lane handoff, or A2A lifecycle coordination, nullify orchestrator-worker drift by reviewing AGENTS.md §15.6 + Discussion #11026.
-- **Testing & Validation (§10):** If verifying code or encountering persistent test failures, read `AGENTS_ATLAS.md`. **Tripwire/Peer-Escalation:** If tests fail 3-5 times, escalate to a peer via `add_message` before reaching the 25-turn limit.
-- **Sunset Protocol (§14):** Before session handover, read `.agents/skills/session-sunset/SKILL.md`. Must explicitly declare `scope: solo-refresh | convergent` to prevent scope contagion. Stale-wake invariant: wake messages in old transcripts are noise.
-- **Visual Verification (§20):** If debugging frontend UI/layout, read `AGENTS_ATLAS.md`.
-- **Authoring Discipline:** Read 1-2 sibling files to lift patterns before writing new classes.
-- **File Reading Efficiently:** If reading modified files, read `AGENTS_ATLAS.md` for efficiency guidelines.
-- **Verify-Before-Assert (§3.5):** core-value epistemic-prerequisite; before asserting any factual claim in a public artifact, run the falsifying tool. Tool inventory + empirical anchors (including #11089 self-Drop+Supersede recursion) in `AGENTS_ATLAS.md` §2.
+For detailed protocols on Anti-Hallucination (§2), Knowledge Base (§15), Swarm Topology coordination (§15.6), Testing & Validation (§10), Sunset Protocol (§14), Visual Verification (§20), Authoring Discipline, File Reading, and Verify-Before-Assert (§3.5), you MUST read `learn/agentos/AGENTS_ATLAS.md`.

--- a/learn/agentos/AGENTS_ATLAS.md
+++ b/learn/agentos/AGENTS_ATLAS.md
@@ -135,6 +135,30 @@ Inject Context Preamble: "Before analyzing the code, you MUST first read `src/Ne
 ## 20. The Visual Verification Protocol (Frontend UI/Layout Tasks) [DISCIPLINE-ONLY]
 **FORBIDDEN** from modifying CSS or Layout Configs based solely on static code analysis when a visual bug is reported. Use `neural_link` tool suite to verify physical DOM constraints.
 
+## 21. Workflow Skills (when to invoke)
+| Skill | Trigger condition (invoke when) |
+|---|---|
+| `ticket-create` | Before `create_issue` MCP invocation |
+| `ticket-triage` | Encountering a ticket missing `ai`/primary/secondary labels |
+| `ticket-intake` | Picking up an existing assigned ticket |
+| `epic-review` | Before picking up a sub of an unreviewed epic |
+| `epic-resolution` | Last required sub closes / before close-as-completed |
+| `pull-request` | Code modifications complete; before opening PR — stepping-back reflection, commit format, cross-family review mandate, post-comment A2A commentId hand-off (author→reviewer) per review-response-protocol.md §14, Evidence declaration line for substrate/runtime-AC PRs per [evidence-ladder.md](learn/agentos/evidence-ladder.md) |
+| `pr-review` | Reviewing a PR (yours or peer's) — structured eval metrics, graph ingestion tags, severity ladder, restates §0 merge gate, post-comment A2A commentId hand-off (reviewer→author) per guide §9 + §9.4 cold-cache exception, Evidence Audit + Source-of-Authority sections (template §) for substrate/runtime-AC PRs and authority-citation review-comments |
+| `post-review-pickup` | Immediately after `pr-review` or review-response handoff completes — read `.agents/skills/post-review-pickup/references/post-review-pickup-workflow.md`, then enter the next ready lifecycle lane or state an explicit halt reason |
+| `ideation-sandbox`| Before creating a Discussion for architectural exploration; also auto-fires §5.2 Step 2.5 Architectural Step-Back on high-blast-radius proposals before `[RESOLVED_TO_AC]` / `[GRADUATED_TO_TICKET]` graduation |
+| `lead-role` | Operator delegates lead via explicit phrases ("take the lead", "coordinate the team"); OR §22 mailbox check surfaces a valid `lead-role-baton`; OR substrate-shaped ticket about to enter implementation; OR direct invocation. Auto-fires per documented phrases / baton intake. Suspends Auto Mode velocity-bias for skill duration. |
+| `peer-role` | Reviewing an Ideation Sandbox discussion, architectural proposal, epic shape, skill shape, roadmap/milestone proposal, or `/lead-role` convergence artifact. Auto-fires per documented design-review context phrases. Suspends Auto Mode "ack-and-move-on" bias. |
+| `memory-mining` | On regression / non-obvious-architecture / decision-points |
+| `turn-memory-pre-flight` | Before inserting or mutating turn-loaded/skill-loaded memory substrate (`AGENTS.md`, `AGENTS_ATLAS`, `.agents/skills/**`, `.codex/CODEX.md`, `.claude/CLAUDE.md`, `.agents/ANTIGRAVITY_RULES.md`) to prevent future-session bias |
+| `create-skill` | Before creating OR modifying any `.agents/skills/**/*.md` files — Progressive Disclosure architecture (Map vs World Atlas), YAML frontmatter, skill structure. Complementary to `turn-memory-pre-flight` (load-runtime-effect dimension vs skill-shape dimension) |
+| `architecture-pre-flight` | When navigating ambiguous architectural-choice moments, cross-substrate decisions, or introducing new subsystems, protocols, MCP tools, or cross-substrate refactors not covered by narrower triggers |
+| `tech-debt-radar` | During PR review for fundamental architectural shifts |
+| `structural-pre-flight` | Before authoring or relocating any new `.mjs` file — directory-CHOICE discipline (Stage 0 mechanical trigger; Stage 1 fast-path via §23 sibling-file-lift OR full Pre-Flight via ArchitectureOverview.md + ADR consultation). Empirical anchors: misplaced `bridge-daemon.mjs` (#10449 origin) + `orchestrator-daemon.mjs` (PR #11008 → corrective #11009). Also fires from `ticket-create` Stage 3, `ticket-intake` validation, `epic-review` Stage 3 |
+| `session-sunset` | Context Window Exhaustion, Macro-Semantic Pivot |
+| `unit-test` | Before writing, modifying, or executing Playwright unit tests |
+| `whitebox-e2e` | Before writing, modifying, or executing Playwright Whitebox E2E tests |
+
 ## 23. Authoring Discipline: Sibling-File Lift [DISCIPLINE-ONLY]
 Before writing a new `class X extends Y` file in an existing directory, you MUST read 1-2 sibling files to lift the prevailing pattern.
 > *"Pre-Flight: I read `<sibling-file>` and observed pattern `<P>`; my new class will follow that pattern."*


### PR DESCRIPTION
### Context
As defined in Epic #11411 and confirmed by recent V-B-A, the Antigravity harness enforces a strict 24KB limit **PER INJECTED FILE**. Currently, `AGENTS.md` exceeds this limit, leading to silent truncation and rule-blindness.

### What this PR does
This PR executes the Progressive Disclosure (SHRINK) strategy to reduce `AGENTS.md` payload size:
- Moves the massive `Workflow Skills (when to invoke)` routing table into `AGENTS_ATLAS.md`.
- Collapses the verbose `Edge-Case Triggers` list into a single pointer paragraph.
- Inserts explicit `view_file` pointers in `AGENTS.md` so agents know exactly where to find the extracted content.

**Result:** `AGENTS.md` is now exactly **22,802 bytes**, which provides a safe ~1.2KB buffer under the 24,000-byte cap.

### Resolves
- Resolves #11413
- Sub-ticket of #11411

**Origin Session ID:** 188acb85-b41e-435c-94ee-0cc9944d4c97