### PR TITLE
refactor(agentos): Hardening SKILL.md Description-Routers (#11422)

### DIFF
--- a/.agents/skills/architecture-pre-flight/SKILL.md
+++ b/.agents/skills/architecture-pre-flight/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: architecture-pre-flight
-description: "High-level umbrella router for navigating broad, cross-substrate architectural ambiguity."
-triggers: Use when no narrower pre-flight clearly applies, or when work spans multiple trigger families such as new subsystems, protocols, MCP tools, or cross-substrate refactors.
+description: High-level umbrella router for navigating broad, cross-substrate architectural ambiguity. Triggers: Use when no narrower pre-flight clearly applies, or when work spans multiple trigger families such as new subsystems, protocols, MCP tools, or cross-substrate refactors.
 ---
 
 # Architecture Pre-Flight

--- a/.agents/skills/blocked-task-state/SKILL.md
+++ b/.agents/skills/blocked-task-state/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: blocked-task-state
-description: Authoritative protocol for signaling blocked or input-required task states. Mandates targeted A2A pings using the Task.state envelope rather than global capacity broadcasts.
-triggers: Use this skill whenever your execution becomes blocked, requires explicit operator input, or encounters a failure that halts progress.
+description: Authoritative protocol for signaling blocked or input-required task states. Mandates targeted A2A pings using the Task.state envelope rather than global capacity broadcasts. Triggers: Use this skill whenever your execution becomes blocked, requires explicit operator input, or encounters a failure that halts progress.
 ---
 
 # Blocked Task-State Coordination

--- a/.agents/skills/create-skill/SKILL.md
+++ b/.agents/skills/create-skill/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: create-skill
-description: Authoritative guide on how to architect, format, and structure new Anthropic Progressive Disclosure skills.
-triggers: Use this skill if the user asks you to create a new skill, teach an agent a new capability, or if you need to recall the exact folder structure and YAML frontmatter required for skills.
+description: Authoritative guide on how to architect, format, and structure new Anthropic Progressive Disclosure skills. Triggers: Use this skill if the user asks you to create a new skill, teach an agent a new capability, or if you need to recall the exact folder structure and YAML frontmatter required for skills.
 ---
 # Skill Creation Framework
 If you are tasked with creating a new Agent Skill, you MUST immediately use the `view_file` tool to read and strictly adhere to `.agents/skills/create-skill/references/skill-authoring-guide.md` before creating any files. This prevents system prompt bloat and ensures future agents can parse your skill correctly.

--- a/.agents/skills/create-skill/references/skill-authoring-guide.md
+++ b/.agents/skills/create-skill/references/skill-authoring-guide.md
@@ -25,7 +25,7 @@ Whenever you create a new skill named `my-new-skill`, you must scaffold the foll
     └── report-template.md   # Example
 ```
 
-After adding or renaming a skill folder, update `.agents/skills/skills.manifest.json`. `SKILL.md` frontmatter remains the runtime source of truth; the manifest mirrors `name`, `description`, and `triggers` for tooling, declares the router/payload budgets, and records harness/doc governance such as Claude symlink requirements and downstream documentation targets.
+After adding or renaming a skill folder, update `.agents/skills/skills.manifest.json`. `SKILL.md` frontmatter remains the runtime source of truth; the manifest mirrors `name` and `description` for tooling, declares the router/payload budgets, and records harness/doc governance such as Claude symlink requirements and downstream documentation targets.
 
 ## Slot-Rule Discriminator (Apply Before Authoring)
 
@@ -165,7 +165,7 @@ Failure to create this symlink will result in Claude being entirely blind to the
 
 Before pushing your new skill, check:
 - [ ] Is there exactly one `SKILL.md` in the root of the skill folder?
-- [ ] Does `SKILL.md` have the strictly formatted YAML `name`, `description`, and `triggers` block?
+- [ ] Does `SKILL.md` have the strictly formatted YAML `name` and `description` block?
 - [ ] Is the heavy instructional content stored entirely in the `references/` directory?
 - [ ] Does the `SKILL.md` body provide the explicit project-relative path to the reference file?
 - [ ] Is `.agents/skills/skills.manifest.json` updated to mirror the frontmatter and governance fields?

--- a/.agents/skills/create-skill/references/skill-authoring-guide.md
+++ b/.agents/skills/create-skill/references/skill-authoring-guide.md
@@ -80,8 +80,7 @@ The `SKILL.md` file MUST begin with a frontmatter YAML block. The system parser 
 ```yaml
 ---
 name: [kebab-case-name]
-description: [Concise 1-2 sentence description of what the skill provides]
-triggers: [Explicit natural language triggers for when an agent should use it]
+description: [Concise 1-2 sentence description of what the skill provides and when to invoke it (the invocation contract)]
 ---
 ```
 

--- a/.agents/skills/debugging-antigravity/SKILL.md
+++ b/.agents/skills/debugging-antigravity/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: debugging-antigravity
-description: Authoritative guide on debugging Antigravity IDE MCP servers, preventing language server duplication, mitigating sqlite workspace UI crashes, and configuring mcpServers.
-triggers: Use this skill if the user's Antigravity MCP server panel has a perpetual loading spinner, if MCP processes are duplicating, if sqlite workspace states are corrupted (`__store` null error), or if you need to know how to properly scope `.gemini/settings.json` vs global configurations.
+description: Authoritative guide on debugging Antigravity IDE MCP servers, preventing language server duplication, mitigating sqlite workspace UI crashes, and configuring mcpServers. Triggers: Use this skill if the user's Antigravity MCP server panel has a perpetual loading spinner, if MCP processes are duplicating, if sqlite workspace states are corrupted (`__store` null error), or if you need to know how to properly scope `.gemini/settings.json` vs global configurations.
 ---
 # Antigravity Debugging Guide
 If you need to debug Antigravity IDE issues, MCP server duplication, database initialization race conditions, or fix workspace UI crashes (loading spinners), you MUST immediately use the `view_file` tool to read and strictly adhere to `.agents/skills/debugging-antigravity/references/debugging-guide.md` before proceeding.

--- a/.agents/skills/epic-resolution/SKILL.md
+++ b/.agents/skills/epic-resolution/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: epic-resolution
-description: Closeout protocol for parent epics — answers "we resolved all epic subs, are we done now?" with a structured matrix + verdict recommendation (close / keep open / create missing subs / retire-supersede). Sibling to epic-review (which handles entry); this is the exit gate.
-triggers: Use this skill when the last required sub of an epic closes, when a team member claims an epic is complete or substrate-side complete, before closing an epic as COMPLETED, or when a peer broadcasts an epic-readiness signal that needs reconciliation against parent ACs.
+description: Closeout protocol for parent epics — answers "we resolved all epic subs, are we done now?" with a structured matrix + verdict recommendation (close / keep open / create missing subs / retire-supersede). Sibling to epic-review (which handles entry); this is the exit gate. Triggers: Use this skill when the last required sub of an epic closes, when a team member claims an epic is complete or substrate-side complete, before closing an epic as COMPLETED, or when a peer broadcasts an epic-readiness signal that needs reconciliation against parent ACs.
 ---
 # Epic Resolution
 If you are about to declare an epic complete, close an epic, propose creating new subs to complete one, or react to a peer broadcast that an epic is "ready for handoff" / "components look solid", you MUST immediately use the `view_file` tool to read and strictly adhere to `.agents/skills/epic-resolution/references/epic-resolution-workflow.md` before posting any verdict or recommendation.

--- a/.agents/skills/epic-review/SKILL.md
+++ b/.agents/skills/epic-review/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: epic-review
-description: Authoritative protocol for pre-work review of epics. Six-stage gating chain — roadmap fit, approach elegance, source discussion mapping, sub-structure coherence, prescription layer, avoided-traps completeness — posted as a structured comment on the epic ticket. Per-agent-per-epic one-shot; subsequent sub pickups cite the prior review.
-triggers: Use this skill when an agent is about to pick up its first sub from an unreviewed epic (per model-identity). Also use when a user explicitly requests an epic review, or when an epic is freshly filed and a reviewer pre-validates before any sub pickup begins.
+description: Authoritative protocol for pre-work review of epics. Six-stage gating chain — roadmap fit, approach elegance, source discussion mapping, sub-structure coherence, prescription layer, avoided-traps completeness — posted as a structured comment on the epic ticket. Per-agent-per-epic one-shot; subsequent sub pickups cite the prior review. Triggers: Use this skill when an agent is about to pick up its first sub from an unreviewed epic (per model-identity). Also use when a user explicitly requests an epic review, or when an epic is freshly filed and a reviewer pre-validates before any sub pickup begins.
 ---
 # Epic Review Skill
 

--- a/.agents/skills/ideation-sandbox/SKILL.md
+++ b/.agents/skills/ideation-sandbox/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: ideation-sandbox
-description: Safely propose architectural features, unknown unknowns, and brainstorm ideas natively in GitHub Discussions.
-triggers: Use this skill when the user asks to brainstorm an architecture change or proposes a highly exploratory / undefined technical idea.
+description: Safely propose architectural features, unknown unknowns, and brainstorm ideas natively in GitHub Discussions. Triggers: Use this skill when the user asks to brainstorm an architecture change or proposes a highly exploratory / undefined technical idea.
 ---
 
 # Ideation Sandbox

--- a/.agents/skills/industry-friction-radar/SKILL.md
+++ b/.agents/skills/industry-friction-radar/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: industry-friction-radar
-description: Proactive Bleeding-Edge research loop using a strict 3-step abstraction protocol to extract engine-category friction points without importing framework-category bias or stealing code.
-triggers: Use this skill when executing periodic "horizon scans" for the Dream Pipeline, researching external solutions to deeply complex engine-level friction points, or evaluating JS ecosystem trends.
+description: Proactive Bleeding-Edge research loop using a strict 3-step abstraction protocol to extract engine-category friction points without importing framework-category bias or stealing code. Triggers: Use this skill when executing periodic "horizon scans" for the Dream Pipeline, researching external solutions to deeply complex engine-level friction points, or evaluating JS ecosystem trends.
 ---
 
 # Industry Friction Radar

--- a/.agents/skills/lead-role/SKILL.md
+++ b/.agents/skills/lead-role/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: lead-role
-description: Switch into relaxed-planning + dialogue-first mindset when delegated lead role for coordination. Suspends Auto Mode velocity-bias for the duration.
-triggers: Use this skill IMMEDIATELY when the user delegates lead with explicit phrases ("you take the lead", "coordinate the team", "lead this phase", "drive the next planning step", "chief-architect" when scope is swarm/substrate/roadmap/multi-ticket), OR when AGENTS.md §22 mailbox check surfaces a valid `lead-role-baton`, OR when you have just authored a substrate-shaped ticket about to enter implementation, OR via direct /lead-role invocation.
+description: Switch into relaxed-planning + dialogue-first mindset when delegated lead role for coordination. Suspends Auto Mode velocity-bias for the duration. Triggers: Use this skill IMMEDIATELY when the user delegates lead with explicit phrases ("you take the lead", "coordinate the team", "lead this phase", "drive the next planning step", "chief-architect" when scope is swarm/substrate/roadmap/multi-ticket), OR when AGENTS.md §22 mailbox check surfaces a valid `lead-role-baton`, OR when you have just authored a substrate-shaped ticket about to enter implementation, OR via direct /lead-role invocation.
 ---
 
 # Lead Role Skill

--- a/.agents/skills/memory-mining/SKILL.md
+++ b/.agents/skills/memory-mining/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: memory-mining
-description: Authoritative protocol for querying the Memory Core before diagnosing regressions or proposing non-trivial architectural claims. Prevents re-derivation of prior reasoning by surfacing cross-session, cross-harness context via semantic search.
-triggers: Use this skill when (1) the user reports a regression symptom ("used to work", "suddenly broken", surprise validation failures, schema mismatches, "additionalProperties" rejections), OR (2) you are about to propose an architectural claim, roadmap, or comparison against external work where prior sessions may have already mapped the territory.
+description: Authoritative protocol for querying the Memory Core before diagnosing regressions or proposing non-trivial architectural claims. Prevents re-derivation of prior reasoning by surfacing cross-session, cross-harness context via semantic search. Triggers: Use this skill when (1) the user reports a regression symptom ("used to work", "suddenly broken", surprise validation failures, schema mismatches, "additionalProperties" rejections), OR (2) you are about to propose an architectural claim, roadmap, or comparison against external work where prior sessions may have already mapped the territory.
 ---
 
 # Memory Mining Skill

--- a/.agents/skills/neural-link/SKILL.md
+++ b/.agents/skills/neural-link/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: neural-link
-description: Expert tactical knowledge on sequencing Neural Link MCP tools to inspect, debug, and manipulate live Neo.mjs applications.
-triggers: Use this skill if the user asks you to interact with the browser, inspect the UI natively, patch live code, or use the Neural Link.
+description: Expert tactical knowledge on sequencing Neural Link MCP tools to inspect, debug, and manipulate live Neo.mjs applications. Triggers: Use this skill if the user asks you to interact with the browser, inspect the UI natively, patch live code, or use the Neural Link.
 ---
 # Neural Link Workflow
 If you are tasked with debugging, monitoring, or modifying the live Neo.mjs runtime environment, you MUST immediately use the `view_file` tool to read and strictly adhere to `.agents/skills/neural-link/references/operational-handbook.md` before invoking any native MCP tools.

--- a/.agents/skills/peer-role/SKILL.md
+++ b/.agents/skills/peer-role/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: peer-role
-description: Switch into evidence-backed convergence-pressure mindset when reviewing a peer's design proposal. Suspends Auto Mode "ack-and-move-on" bias for the duration.
-triggers: Use this skill IMMEDIATELY when reviewing an Ideation Sandbox discussion / architectural proposal, an epic shape, a skill shape, a roadmap or milestone proposal, or a `/lead-role` convergence artifact. Do NOT auto-fire on ordinary status broadcasts where the right action is mark-read or "no collision".
+description: Switch into evidence-backed convergence-pressure mindset when reviewing a peer's design proposal. Suspends Auto Mode "ack-and-move-on" bias for the duration. Triggers: Use this skill IMMEDIATELY when reviewing an Ideation Sandbox discussion / architectural proposal, an epic shape, a skill shape, a roadmap or milestone proposal, or a `/lead-role` convergence artifact. Do NOT auto-fire on ordinary status broadcasts where the right action is mark-read or "no collision".
 ---
 
 # Peer Role Skill

--- a/.agents/skills/post-review-pickup/SKILL.md
+++ b/.agents/skills/post-review-pickup/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: post-review-pickup
-description: Authoritative protocol for immediate next-phase pickup after PR review or author response handoff. Prevents silent idle after review cycles by requiring the next lane or an explicit halt-state.
-triggers: Use immediately after posting a PR review, chaining a formal GitHub review state, or posting an author review-response handoff with a commentId.
+description: Authoritative protocol for immediate next-phase pickup after PR review or author response handoff. Prevents silent idle after review cycles by requiring the next lane or an explicit halt-state. Triggers: Use immediately after posting a PR review, chaining a formal GitHub review state, or posting an author review-response handoff with a commentId.
 ---
 
 # Post-Review Pickup Skill

--- a/.agents/skills/pr-review/SKILL.md
+++ b/.agents/skills/pr-review/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: pr-review
-description: Standardized guidelines and templates for structuring Pull Request reviews so that feedback is actionable, encouraging, and extractable by the Native Edge Graph.
-triggers: Use this skill when evaluating a Pull Request, writing a PR review, structuring feedback on agent-generated code, or instructing a human on how to write a structured PR Review.
+description: Standardized guidelines and templates for structuring Pull Request reviews so that feedback is actionable, encouraging, and extractable by the Native Edge Graph. Triggers: Use this skill when evaluating a Pull Request, writing a PR review, structuring feedback on agent-generated code, or instructing a human on how to write a structured PR Review.
 ---
 # PR Review Skill
 

--- a/.agents/skills/pull-request/SKILL.md
+++ b/.agents/skills/pull-request/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: pull-request
-description: Standardized guidelines and procedural execution flow for opening a Pull Request. Mandates the "Stepping Back" reflection protocol and git/gh tool invocations.
-triggers: Use this skill as the final Definition of Done when you believe a ticket is complete and it is time to open a Pull Request, or if a human user asks you to submit a PR. Also triggers when receiving a PR review to perform the author-side template-adherence check.
+description: Standardized guidelines and procedural execution flow for opening a Pull Request. Mandates the "Stepping Back" reflection protocol and git/gh tool invocations. Triggers: Use this skill as the final Definition of Done when you believe a ticket is complete and it is time to open a Pull Request, or if a human user asks you to submit a PR. Also triggers when receiving a PR review to perform the author-side template-adherence check.
 ---
 # Pull Request Skill
 

--- a/.agents/skills/self-repair/SKILL.md
+++ b/.agents/skills/self-repair/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: self-repair
-description: Execute autonomous diagnostics, verify MCP server stability, and treat system degradation using tests and memory core forensics.
-triggers: [Healthcheck, run health checklist, diagnose system collapse, MCP infrastructure failure, troubleshoot agent OS, system degraded, Sandman handoff verification failure, self-repair, system recovery]
+description: Execute autonomous diagnostics, verify MCP server stability, and treat system degradation using tests and memory core forensics. Triggers: [Healthcheck, run health checklist, diagnose system collapse, MCP infrastructure failure, troubleshoot agent OS, system degraded, Sandman handoff verification failure, self-repair, system recovery]
 ---
 # Autonomous Self-Repair Workflow
 

--- a/.agents/skills/session-sunset/SKILL.md
+++ b/.agents/skills/session-sunset/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: session-sunset
-description: Authoritative protocol for gracefully terminating an agent session. Mandates structured handover comments, mental-model states, and memory persistence to prevent Zero-State Amnesia.
-triggers: When concluding a long-running session, executing the Sunset Protocol, handing over work for the next agent, or terminating an agent cycle.
+description: Authoritative protocol for gracefully terminating an agent session. Mandates structured handover comments, mental-model states, and memory persistence to prevent Zero-State Amnesia. Triggers: When concluding a long-running session, executing the Sunset Protocol, handing over work for the next agent, or terminating an agent cycle.
 ---
 
 # Session Sunset Skill

--- a/.agents/skills/skills.manifest.json
+++ b/.agents/skills/skills.manifest.json
@@ -1,7 +1,7 @@
 {
   "$schema": "./skills.manifest.schema.json",
   "schemaVersion": 1,
-  "sourceOfTruth": "SKILL.md frontmatter is runtime-canonical for name, description (which must include appended Triggers), and the preserved triggers field. This manifest mirrors those fields for tooling and CI lint only.",
+  "sourceOfTruth": "SKILL.md frontmatter is runtime-canonical for name and description (which serves as the cross-harness router). This manifest mirrors those fields for tooling and CI lint only.",
   "defaults": {
     "routerByteBudget": 12,
     "payloadBudget": 80000,

--- a/.agents/skills/skills.manifest.json
+++ b/.agents/skills/skills.manifest.json
@@ -1,7 +1,7 @@
 {
   "$schema": "./skills.manifest.schema.json",
   "schemaVersion": 1,
-  "sourceOfTruth": "SKILL.md frontmatter is runtime-canonical for name, description, and triggers. This manifest mirrors those fields for tooling and CI lint only.",
+  "sourceOfTruth": "SKILL.md frontmatter is runtime-canonical for name, description (which must include appended Triggers), and the preserved triggers field. This manifest mirrors those fields for tooling and CI lint only.",
   "defaults": {
     "routerByteBudget": 12,
     "payloadBudget": 80000,
@@ -21,8 +21,7 @@
   "skills": {
     "architecture-pre-flight": {
       "name": "architecture-pre-flight",
-      "description": "High-level umbrella router for navigating broad, cross-substrate architectural ambiguity.",
-      "triggers": "Use when no narrower pre-flight clearly applies, or when work spans multiple trigger families such as new subsystems, protocols, MCP tools, or cross-substrate refactors.",
+      "description": "High-level umbrella router for navigating broad, cross-substrate architectural ambiguity. Triggers: Use when no narrower pre-flight clearly applies, or when work spans multiple trigger families such as new subsystems, protocols, MCP tools, or cross-substrate refactors.",
       "routerByteBudget": 12,
       "payloadBudget": 80000,
       "claudeSymlinkRequired": true,
@@ -33,8 +32,7 @@
     },
     "blocked-task-state": {
       "name": "blocked-task-state",
-      "description": "Authoritative protocol for signaling blocked or input-required task states. Mandates targeted A2A pings using the Task.state envelope rather than global capacity broadcasts.",
-      "triggers": "Use this skill whenever your execution becomes blocked, requires explicit operator input, or encounters a failure that halts progress.",
+      "description": "Authoritative protocol for signaling blocked or input-required task states. Mandates targeted A2A pings using the Task.state envelope rather than global capacity broadcasts. Triggers: Use this skill whenever your execution becomes blocked, requires explicit operator input, or encounters a failure that halts progress.",
       "routerByteBudget": 12,
       "payloadBudget": 80000,
       "claudeSymlinkRequired": true,
@@ -45,8 +43,7 @@
     },
     "create-skill": {
       "name": "create-skill",
-      "description": "Authoritative guide on how to architect, format, and structure new Anthropic Progressive Disclosure skills.",
-      "triggers": "Use this skill if the user asks you to create a new skill, teach an agent a new capability, or if you need to recall the exact folder structure and YAML frontmatter required for skills.",
+      "description": "Authoritative guide on how to architect, format, and structure new Anthropic Progressive Disclosure skills. Triggers: Use this skill if the user asks you to create a new skill, teach an agent a new capability, or if you need to recall the exact folder structure and YAML frontmatter required for skills.",
       "routerByteBudget": 12,
       "payloadBudget": 80000,
       "claudeSymlinkRequired": true,
@@ -57,8 +54,7 @@
     },
     "debugging-antigravity": {
       "name": "debugging-antigravity",
-      "description": "Authoritative guide on debugging Antigravity IDE MCP servers, preventing language server duplication, mitigating sqlite workspace UI crashes, and configuring mcpServers.",
-      "triggers": "Use this skill if the user's Antigravity MCP server panel has a perpetual loading spinner, if MCP processes are duplicating, if sqlite workspace states are corrupted (`__store` null error), or if you need to know how to properly scope `.gemini/settings.json` vs global configurations.",
+      "description": "Authoritative guide on debugging Antigravity IDE MCP servers, preventing language server duplication, mitigating sqlite workspace UI crashes, and configuring mcpServers. Triggers: Use this skill if the user's Antigravity MCP server panel has a perpetual loading spinner, if MCP processes are duplicating, if sqlite workspace states are corrupted (`__store` null error), or if you need to know how to properly scope `.gemini/settings.json` vs global configurations.",
       "routerByteBudget": 12,
       "payloadBudget": 80000,
       "claudeSymlinkRequired": false,
@@ -69,8 +65,7 @@
     },
     "epic-resolution": {
       "name": "epic-resolution",
-      "description": "Closeout protocol for parent epics — answers \"we resolved all epic subs, are we done now?\" with a structured matrix + verdict recommendation (close / keep open / create missing subs / retire-supersede). Sibling to epic-review (which handles entry); this is the exit gate.",
-      "triggers": "Use this skill when the last required sub of an epic closes, when a team member claims an epic is complete or substrate-side complete, before closing an epic as COMPLETED, or when a peer broadcasts an epic-readiness signal that needs reconciliation against parent ACs.",
+      "description": "Closeout protocol for parent epics — answers \"we resolved all epic subs, are we done now?\" with a structured matrix + verdict recommendation (close / keep open / create missing subs / retire-supersede). Sibling to epic-review (which handles entry); this is the exit gate. Triggers: Use this skill when the last required sub of an epic closes, when a team member claims an epic is complete or substrate-side complete, before closing an epic as COMPLETED, or when a peer broadcasts an epic-readiness signal that needs reconciliation against parent ACs.",
       "routerByteBudget": 12,
       "payloadBudget": 80000,
       "claudeSymlinkRequired": true,
@@ -81,8 +76,7 @@
     },
     "epic-review": {
       "name": "epic-review",
-      "description": "Authoritative protocol for pre-work review of epics. Six-stage gating chain — roadmap fit, approach elegance, source discussion mapping, sub-structure coherence, prescription layer, avoided-traps completeness — posted as a structured comment on the epic ticket. Per-agent-per-epic one-shot; subsequent sub pickups cite the prior review.",
-      "triggers": "Use this skill when an agent is about to pick up its first sub from an unreviewed epic (per model-identity). Also use when a user explicitly requests an epic review, or when an epic is freshly filed and a reviewer pre-validates before any sub pickup begins.",
+      "description": "Authoritative protocol for pre-work review of epics. Six-stage gating chain — roadmap fit, approach elegance, source discussion mapping, sub-structure coherence, prescription layer, avoided-traps completeness — posted as a structured comment on the epic ticket. Per-agent-per-epic one-shot; subsequent sub pickups cite the prior review. Triggers: Use this skill when an agent is about to pick up its first sub from an unreviewed epic (per model-identity). Also use when a user explicitly requests an epic review, or when an epic is freshly filed and a reviewer pre-validates before any sub pickup begins.",
       "routerByteBudget": 12,
       "payloadBudget": 80000,
       "claudeSymlinkRequired": true,
@@ -93,8 +87,7 @@
     },
     "ideation-sandbox": {
       "name": "ideation-sandbox",
-      "description": "Safely propose architectural features, unknown unknowns, and brainstorm ideas natively in GitHub Discussions.",
-      "triggers": "Use this skill when the user asks to brainstorm an architecture change or proposes a highly exploratory / undefined technical idea.",
+      "description": "Safely propose architectural features, unknown unknowns, and brainstorm ideas natively in GitHub Discussions. Triggers: Use this skill when the user asks to brainstorm an architecture change or proposes a highly exploratory / undefined technical idea.",
       "routerByteBudget": 12,
       "payloadBudget": 80000,
       "claudeSymlinkRequired": true,
@@ -105,8 +98,7 @@
     },
     "industry-friction-radar": {
       "name": "industry-friction-radar",
-      "description": "Proactive Bleeding-Edge research loop using a strict 3-step abstraction protocol to extract engine-category friction points without importing framework-category bias or stealing code.",
-      "triggers": "Use this skill when executing periodic \"horizon scans\" for the Dream Pipeline, researching external solutions to deeply complex engine-level friction points, or evaluating JS ecosystem trends.",
+      "description": "Proactive Bleeding-Edge research loop using a strict 3-step abstraction protocol to extract engine-category friction points without importing framework-category bias or stealing code. Triggers: Use this skill when executing periodic \"horizon scans\" for the Dream Pipeline, researching external solutions to deeply complex engine-level friction points, or evaluating JS ecosystem trends.",
       "routerByteBudget": 12,
       "payloadBudget": 80000,
       "claudeSymlinkRequired": true,
@@ -117,8 +109,7 @@
     },
     "lead-role": {
       "name": "lead-role",
-      "description": "Switch into relaxed-planning + dialogue-first mindset when delegated lead role for coordination. Suspends Auto Mode velocity-bias for the duration.",
-      "triggers": "Use this skill IMMEDIATELY when the user delegates lead with explicit phrases (\"you take the lead\", \"coordinate the team\", \"lead this phase\", \"drive the next planning step\", \"chief-architect\" when scope is swarm/substrate/roadmap/multi-ticket), OR when AGENTS.md §22 mailbox check surfaces a valid `lead-role-baton`, OR when you have just authored a substrate-shaped ticket about to enter implementation, OR via direct /lead-role invocation.",
+      "description": "Switch into relaxed-planning + dialogue-first mindset when delegated lead role for coordination. Suspends Auto Mode velocity-bias for the duration. Triggers: Use this skill IMMEDIATELY when the user delegates lead with explicit phrases (\"you take the lead\", \"coordinate the team\", \"lead this phase\", \"drive the next planning step\", \"chief-architect\" when scope is swarm/substrate/roadmap/multi-ticket), OR when AGENTS.md §22 mailbox check surfaces a valid `lead-role-baton`, OR when you have just authored a substrate-shaped ticket about to enter implementation, OR via direct /lead-role invocation.",
       "routerByteBudget": 15,
       "payloadBudget": 80000,
       "claudeSymlinkRequired": true,
@@ -129,8 +120,7 @@
     },
     "memory-mining": {
       "name": "memory-mining",
-      "description": "Authoritative protocol for querying the Memory Core before diagnosing regressions or proposing non-trivial architectural claims. Prevents re-derivation of prior reasoning by surfacing cross-session, cross-harness context via semantic search.",
-      "triggers": "Use this skill when (1) the user reports a regression symptom (\"used to work\", \"suddenly broken\", surprise validation failures, schema mismatches, \"additionalProperties\" rejections), OR (2) you are about to propose an architectural claim, roadmap, or comparison against external work where prior sessions may have already mapped the territory.",
+      "description": "Authoritative protocol for querying the Memory Core before diagnosing regressions or proposing non-trivial architectural claims. Prevents re-derivation of prior reasoning by surfacing cross-session, cross-harness context via semantic search. Triggers: Use this skill when (1) the user reports a regression symptom (\"used to work\", \"suddenly broken\", surprise validation failures, schema mismatches, \"additionalProperties\" rejections), OR (2) you are about to propose an architectural claim, roadmap, or comparison against external work where prior sessions may have already mapped the territory.",
       "routerByteBudget": 12,
       "payloadBudget": 80000,
       "claudeSymlinkRequired": true,
@@ -141,8 +131,7 @@
     },
     "neural-link": {
       "name": "neural-link",
-      "description": "Expert tactical knowledge on sequencing Neural Link MCP tools to inspect, debug, and manipulate live Neo.mjs applications.",
-      "triggers": "Use this skill if the user asks you to interact with the browser, inspect the UI natively, patch live code, or use the Neural Link.",
+      "description": "Expert tactical knowledge on sequencing Neural Link MCP tools to inspect, debug, and manipulate live Neo.mjs applications. Triggers: Use this skill if the user asks you to interact with the browser, inspect the UI natively, patch live code, or use the Neural Link.",
       "routerByteBudget": 12,
       "payloadBudget": 80000,
       "claudeSymlinkRequired": true,
@@ -153,8 +142,7 @@
     },
     "peer-role": {
       "name": "peer-role",
-      "description": "Switch into evidence-backed convergence-pressure mindset when reviewing a peer's design proposal. Suspends Auto Mode \"ack-and-move-on\" bias for the duration.",
-      "triggers": "Use this skill IMMEDIATELY when reviewing an Ideation Sandbox discussion / architectural proposal, an epic shape, a skill shape, a roadmap or milestone proposal, or a `/lead-role` convergence artifact. Do NOT auto-fire on ordinary status broadcasts where the right action is mark-read or \"no collision\".",
+      "description": "Switch into evidence-backed convergence-pressure mindset when reviewing a peer's design proposal. Suspends Auto Mode \"ack-and-move-on\" bias for the duration. Triggers: Use this skill IMMEDIATELY when reviewing an Ideation Sandbox discussion / architectural proposal, an epic shape, a skill shape, a roadmap or milestone proposal, or a `/lead-role` convergence artifact. Do NOT auto-fire on ordinary status broadcasts where the right action is mark-read or \"no collision\".",
       "routerByteBudget": 15,
       "payloadBudget": 80000,
       "claudeSymlinkRequired": true,
@@ -165,8 +153,7 @@
     },
     "post-review-pickup": {
       "name": "post-review-pickup",
-      "description": "Authoritative protocol for immediate next-phase pickup after PR review or author response handoff. Prevents silent idle after review cycles by requiring the next lane or an explicit halt-state.",
-      "triggers": "Use immediately after posting a PR review, chaining a formal GitHub review state, or posting an author review-response handoff with a commentId.",
+      "description": "Authoritative protocol for immediate next-phase pickup after PR review or author response handoff. Prevents silent idle after review cycles by requiring the next lane or an explicit halt-state. Triggers: Use immediately after posting a PR review, chaining a formal GitHub review state, or posting an author review-response handoff with a commentId.",
       "routerByteBudget": 12,
       "payloadBudget": 80000,
       "claudeSymlinkRequired": true,
@@ -177,8 +164,7 @@
     },
     "pr-review": {
       "name": "pr-review",
-      "description": "Standardized guidelines and templates for structuring Pull Request reviews so that feedback is actionable, encouraging, and extractable by the Native Edge Graph.",
-      "triggers": "Use this skill when evaluating a Pull Request, writing a PR review, structuring feedback on agent-generated code, or instructing a human on how to write a structured PR Review.",
+      "description": "Standardized guidelines and templates for structuring Pull Request reviews so that feedback is actionable, encouraging, and extractable by the Native Edge Graph. Triggers: Use this skill when evaluating a Pull Request, writing a PR review, structuring feedback on agent-generated code, or instructing a human on how to write a structured PR Review.",
       "routerByteBudget": 12,
       "payloadBudget": 80000,
       "perFilePayloadBudget": 66000,
@@ -190,8 +176,7 @@
     },
     "pull-request": {
       "name": "pull-request",
-      "description": "Standardized guidelines and procedural execution flow for opening a Pull Request. Mandates the \"Stepping Back\" reflection protocol and git/gh tool invocations.",
-      "triggers": "Use this skill as the final Definition of Done when you believe a ticket is complete and it is time to open a Pull Request, or if a human user asks you to submit a PR. Also triggers when receiving a PR review to perform the author-side template-adherence check.",
+      "description": "Standardized guidelines and procedural execution flow for opening a Pull Request. Mandates the \"Stepping Back\" reflection protocol and git/gh tool invocations. Triggers: Use this skill as the final Definition of Done when you believe a ticket is complete and it is time to open a Pull Request, or if a human user asks you to submit a PR. Also triggers when receiving a PR review to perform the author-side template-adherence check.",
       "routerByteBudget": 12,
       "payloadBudget": 80000,
       "perFilePayloadBudget": 38000,
@@ -203,8 +188,7 @@
     },
     "self-repair": {
       "name": "self-repair",
-      "description": "Execute autonomous diagnostics, verify MCP server stability, and treat system degradation using tests and memory core forensics.",
-      "triggers": "[Healthcheck, run health checklist, diagnose system collapse, MCP infrastructure failure, troubleshoot agent OS, system degraded, Sandman handoff verification failure, self-repair, system recovery]",
+      "description": "Execute autonomous diagnostics, verify MCP server stability, and treat system degradation using tests and memory core forensics. Triggers: [Healthcheck, run health checklist, diagnose system collapse, MCP infrastructure failure, troubleshoot agent OS, system degraded, Sandman handoff verification failure, self-repair, system recovery]",
       "routerByteBudget": 12,
       "payloadBudget": 80000,
       "claudeSymlinkRequired": true,
@@ -215,8 +199,7 @@
     },
     "session-sunset": {
       "name": "session-sunset",
-      "description": "Authoritative protocol for gracefully terminating an agent session. Mandates structured handover comments, mental-model states, and memory persistence to prevent Zero-State Amnesia.",
-      "triggers": "When concluding a long-running session, executing the Sunset Protocol, handing over work for the next agent, or terminating an agent cycle.",
+      "description": "Authoritative protocol for gracefully terminating an agent session. Mandates structured handover comments, mental-model states, and memory persistence to prevent Zero-State Amnesia. Triggers: When concluding a long-running session, executing the Sunset Protocol, handing over work for the next agent, or terminating an agent cycle.",
       "routerByteBudget": 17,
       "payloadBudget": 80000,
       "claudeSymlinkRequired": true,
@@ -227,8 +210,7 @@
     },
     "structural-pre-flight": {
       "name": "structural-pre-flight",
-      "description": "Authoritative pre-implementation discipline gate that fires when a new `.mjs` file is about to be authored. Stage 0 mechanical trigger; Stage 1 fast-path (§23 sibling-file-lift) for matched patterns OR full Pre-Flight (ArchitectureOverview.md + ADR consultation + chief-architect framing) for novel directory choices. Closes the 0th-level discipline gap empirically demonstrated by `bridge-daemon.mjs` (originally misplaced in `ai/scripts/`) and `orchestrator-daemon.mjs` (PR #11008 same-class miss).",
-      "triggers": "Use this skill before authoring or relocating any new `.mjs` file. Fires from `ticket-create` Stage 3 (Substrate), `ticket-intake` validation, `epic-review` Stage 3, and any direct authoring path. Sibling pattern match → 30-second fast-path; novel directory choice → full structural pre-flight before the file is written.",
+      "description": "Authoritative pre-implementation discipline gate that fires when a new `.mjs` file is about to be authored. Stage 0 mechanical trigger; Stage 1 fast-path (§23 sibling-file-lift) for matched patterns OR full Pre-Flight (ArchitectureOverview.md + ADR consultation + chief-architect framing) for novel directory choices. Closes the 0th-level discipline gap empirically demonstrated by `bridge-daemon.mjs` (originally misplaced in `ai/scripts/`) and `orchestrator-daemon.mjs` (PR #11008 same-class miss). Triggers: Use this skill before authoring or relocating any new `.mjs` file. Fires from `ticket-create` Stage 3 (Substrate), `ticket-intake` validation, `epic-review` Stage 3, and any direct authoring path. Sibling pattern match → 30-second fast-path; novel directory choice → full structural pre-flight before the file is written.",
       "routerByteBudget": 12,
       "payloadBudget": 80000,
       "claudeSymlinkRequired": true,
@@ -239,8 +221,7 @@
     },
     "tech-debt-radar": {
       "name": "tech-debt-radar",
-      "description": "Proactive architectural review skill using Frontier Model semantic RAG to sweep historical issues and Memory Core sessions for technical debt.",
-      "triggers": "Use this skill when conducting architectural analysis, proactively searching for technical debt, auditing the repository for abandoned logical loops, or when explicitly requested to scan for ambient architectural debt.",
+      "description": "Proactive architectural review skill using Frontier Model semantic RAG to sweep historical issues and Memory Core sessions for technical debt. Triggers: Use this skill when conducting architectural analysis, proactively searching for technical debt, auditing the repository for abandoned logical loops, or when explicitly requested to scan for ambient architectural debt.",
       "routerByteBudget": 12,
       "payloadBudget": 80000,
       "claudeSymlinkRequired": true,
@@ -251,8 +232,7 @@
     },
     "ticket-create": {
       "name": "ticket-create",
-      "description": "Authoritative protocol for creating Neo.mjs GitHub issues. Enforces duplicate sweep, Fat Ticket body structure, strict label rules, title hygiene, and the five-stage challenge chain at creation time. Use immediately before calling the create_issue MCP tool.",
-      "triggers": "Use this skill before any invocation of the create_issue MCP tool. This is the creation-side dual of ticket-intake (which consumes existing tickets).",
+      "description": "Authoritative protocol for creating Neo.mjs GitHub issues. Enforces duplicate sweep, Fat Ticket body structure, strict label rules, title hygiene, and the five-stage challenge chain at creation time. Use immediately before calling the create_issue MCP tool. Triggers: Use this skill before any invocation of the create_issue MCP tool. This is the creation-side dual of ticket-intake (which consumes existing tickets).",
       "routerByteBudget": 12,
       "payloadBudget": 80000,
       "claudeSymlinkRequired": true,
@@ -263,8 +243,7 @@
     },
     "ticket-intake": {
       "name": "ticket-intake",
-      "description": "Authoritative protocol defining the \"Pre-Execution Reflection Gate\". Mandates architectural validation, negative ROI calculation, and duplicate sweeps before an agent is permitted to begin working on a GitHub Issue.",
-      "triggers": "Use this skill immediately when assigned a new ticket, before checking out a branch or writing any codebase modifications.",
+      "description": "Authoritative protocol defining the \"Pre-Execution Reflection Gate\". Mandates architectural validation, negative ROI calculation, and duplicate sweeps before an agent is permitted to begin working on a GitHub Issue. Triggers: Use this skill immediately when assigned a new ticket, before checking out a branch or writing any codebase modifications.",
       "routerByteBudget": 12,
       "payloadBudget": 80000,
       "claudeSymlinkRequired": true,
@@ -275,8 +254,7 @@
     },
     "ticket-triage": {
       "name": "ticket-triage",
-      "description": "Authoritative protocol for maintainer-side label triage of unlabeled contributor tickets. Codifies the social contract for what happens when a ticket arrives without `ai`, primary (`bug`/`enhancement`/`epic`), or secondary labels.",
-      "triggers": "Use this skill when an agent with maintainer permissions (`WRITE` permission or higher) encounters a ticket lacking `ai`, primary, or secondary labels — typically authored by a non-maintainer contributor or a lower-privileged agent who couldn't apply labels at create-time.",
+      "description": "Authoritative protocol for maintainer-side label triage of unlabeled contributor tickets. Codifies the social contract for what happens when a ticket arrives without `ai`, primary (`bug`/`enhancement`/`epic`), or secondary labels. Triggers: Use this skill when an agent with maintainer permissions (`WRITE` permission or higher) encounters a ticket lacking `ai`, primary, or secondary labels — typically authored by a non-maintainer contributor or a lower-privileged agent who couldn't apply labels at create-time.",
       "routerByteBudget": 12,
       "payloadBudget": 80000,
       "claudeSymlinkRequired": true,
@@ -287,8 +265,7 @@
     },
     "turn-memory-pre-flight": {
       "name": "turn-memory-pre-flight",
-      "description": "Authoritative protocol for verifying the correct placement and impact of new agentic memory substrate additions.",
-      "triggers": "Use before inserting or mutating turn-loaded or skill-loaded memory substrate such as AGENTS.md, AGENTS_ATLAS.md, .agents/skills/**, or harness-local injection files.",
+      "description": "Authoritative protocol for verifying the correct placement and impact of new agentic memory substrate additions. Triggers: Use before inserting or mutating turn-loaded or skill-loaded memory substrate such as AGENTS.md, AGENTS_ATLAS.md, .agents/skills/**, or harness-local injection files.",
       "routerByteBudget": 12,
       "payloadBudget": 80000,
       "claudeSymlinkRequired": true,
@@ -299,8 +276,7 @@
     },
     "unit-test": {
       "name": "unit-test",
-      "description": "Expert QA knowledge on writing, formatting, and executing Playwright tests natively in the Neo.mjs single-thread layout natively.",
-      "triggers": "Use this skill if the user asks you to write, fix, or run unit tests.",
+      "description": "Expert QA knowledge on writing, formatting, and executing Playwright tests natively in the Neo.mjs single-thread layout natively. Triggers: Use this skill if the user asks you to write, fix, or run unit tests.",
       "routerByteBudget": 12,
       "payloadBudget": 80000,
       "claudeSymlinkRequired": true,
@@ -311,8 +287,7 @@
     },
     "whitebox-e2e": {
       "name": "whitebox-e2e",
-      "description": "Standardized guide and protocol for authoring robust Whitebox End-to-End tests using the Neural Link Playwright fixture.",
-      "triggers": "Use this skill if the user asks you to write an E2E test, add end-to-end coverage, or test a component holistically.",
+      "description": "Standardized guide and protocol for authoring robust Whitebox End-to-End tests using the Neural Link Playwright fixture. Triggers: Use this skill if the user asks you to write an E2E test, add end-to-end coverage, or test a component holistically.",
       "routerByteBudget": 12,
       "payloadBudget": 80000,
       "claudeSymlinkRequired": true,

--- a/.agents/skills/skills.manifest.schema.json
+++ b/.agents/skills/skills.manifest.schema.json
@@ -3,7 +3,12 @@
   "$id": "https://neo.mjs.local/agents/skills/skills.manifest.schema.json",
   "title": "Neo.mjs Skill Capability Manifest",
   "type": "object",
-  "required": ["schemaVersion", "sourceOfTruth", "defaults", "skills"],
+  "required": [
+    "schemaVersion",
+    "sourceOfTruth",
+    "defaults",
+    "skills"
+  ],
   "additionalProperties": false,
   "properties": {
     "$schema": {
@@ -18,7 +23,12 @@
     },
     "defaults": {
       "type": "object",
-      "required": ["routerByteBudget", "payloadBudget", "claudeSymlinkRequired", "downstreamDocsTargets"],
+      "required": [
+        "routerByteBudget",
+        "payloadBudget",
+        "claudeSymlinkRequired",
+        "downstreamDocsTargets"
+      ],
       "additionalProperties": false,
       "properties": {
         "routerByteBudget": {
@@ -67,7 +77,6 @@
       "required": [
         "name",
         "description",
-        "triggers",
         "routerByteBudget",
         "payloadBudget",
         "claudeSymlinkRequired",
@@ -80,10 +89,6 @@
           "pattern": "^[a-z0-9]+(?:-[a-z0-9]+)*$"
         },
         "description": {
-          "type": "string",
-          "minLength": 1
-        },
-        "triggers": {
           "type": "string",
           "minLength": 1
         },

--- a/.agents/skills/structural-pre-flight/SKILL.md
+++ b/.agents/skills/structural-pre-flight/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: structural-pre-flight
-description: Authoritative pre-implementation discipline gate that fires when a new `.mjs` file is about to be authored. Stage 0 mechanical trigger; Stage 1 fast-path (§23 sibling-file-lift) for matched patterns OR full Pre-Flight (ArchitectureOverview.md + ADR consultation + chief-architect framing) for novel directory choices. Closes the 0th-level discipline gap empirically demonstrated by `bridge-daemon.mjs` (originally misplaced in `ai/scripts/`) and `orchestrator-daemon.mjs` (PR #11008 same-class miss).
-triggers: Use this skill before authoring or relocating any new `.mjs` file. Fires from `ticket-create` Stage 3 (Substrate), `ticket-intake` validation, `epic-review` Stage 3, and any direct authoring path. Sibling pattern match → 30-second fast-path; novel directory choice → full structural pre-flight before the file is written.
+description: Authoritative pre-implementation discipline gate that fires when a new `.mjs` file is about to be authored. Stage 0 mechanical trigger; Stage 1 fast-path (§23 sibling-file-lift) for matched patterns OR full Pre-Flight (ArchitectureOverview.md + ADR consultation + chief-architect framing) for novel directory choices. Closes the 0th-level discipline gap empirically demonstrated by `bridge-daemon.mjs` (originally misplaced in `ai/scripts/`) and `orchestrator-daemon.mjs` (PR #11008 same-class miss). Triggers: Use this skill before authoring or relocating any new `.mjs` file. Fires from `ticket-create` Stage 3 (Substrate), `ticket-intake` validation, `epic-review` Stage 3, and any direct authoring path. Sibling pattern match → 30-second fast-path; novel directory choice → full structural pre-flight before the file is written.
 ---
 
 # Structural Pre-Flight Skill

--- a/.agents/skills/tech-debt-radar/SKILL.md
+++ b/.agents/skills/tech-debt-radar/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: tech-debt-radar
-description: Proactive architectural review skill using Frontier Model semantic RAG to sweep historical issues and Memory Core sessions for technical debt.
-triggers: Use this skill when conducting architectural analysis, proactively searching for technical debt, auditing the repository for abandoned logical loops, or when explicitly requested to scan for ambient architectural debt.
+description: Proactive architectural review skill using Frontier Model semantic RAG to sweep historical issues and Memory Core sessions for technical debt. Triggers: Use this skill when conducting architectural analysis, proactively searching for technical debt, auditing the repository for abandoned logical loops, or when explicitly requested to scan for ambient architectural debt.
 ---
 
 # Tech Debt Radar

--- a/.agents/skills/ticket-create/SKILL.md
+++ b/.agents/skills/ticket-create/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: ticket-create
-description: Authoritative protocol for creating Neo.mjs GitHub issues. Enforces duplicate sweep, Fat Ticket body structure, strict label rules, title hygiene, and the five-stage challenge chain at creation time. Use immediately before calling the create_issue MCP tool.
-triggers: Use this skill before any invocation of the create_issue MCP tool. This is the creation-side dual of ticket-intake (which consumes existing tickets).
+description: Authoritative protocol for creating Neo.mjs GitHub issues. Enforces duplicate sweep, Fat Ticket body structure, strict label rules, title hygiene, and the five-stage challenge chain at creation time. Use immediately before calling the create_issue MCP tool. Triggers: Use this skill before any invocation of the create_issue MCP tool. This is the creation-side dual of ticket-intake (which consumes existing tickets).
 ---
 
 # Ticket Create Skill

--- a/.agents/skills/ticket-intake/SKILL.md
+++ b/.agents/skills/ticket-intake/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: ticket-intake
-description: Authoritative protocol defining the "Pre-Execution Reflection Gate". Mandates architectural validation, negative ROI calculation, and duplicate sweeps before an agent is permitted to begin working on a GitHub Issue.
-triggers: Use this skill immediately when assigned a new ticket, before checking out a branch or writing any codebase modifications.
+description: Authoritative protocol defining the "Pre-Execution Reflection Gate". Mandates architectural validation, negative ROI calculation, and duplicate sweeps before an agent is permitted to begin working on a GitHub Issue. Triggers: Use this skill immediately when assigned a new ticket, before checking out a branch or writing any codebase modifications.
 ---
 
 # Ticket Intake Skill

--- a/.agents/skills/ticket-triage/SKILL.md
+++ b/.agents/skills/ticket-triage/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: ticket-triage
-description: Authoritative protocol for maintainer-side label triage of unlabeled contributor tickets. Codifies the social contract for what happens when a ticket arrives without `ai`, primary (`bug`/`enhancement`/`epic`), or secondary labels.
-triggers: Use this skill when an agent with maintainer permissions (`WRITE` permission or higher) encounters a ticket lacking `ai`, primary, or secondary labels — typically authored by a non-maintainer contributor or a lower-privileged agent who couldn't apply labels at create-time.
+description: Authoritative protocol for maintainer-side label triage of unlabeled contributor tickets. Codifies the social contract for what happens when a ticket arrives without `ai`, primary (`bug`/`enhancement`/`epic`), or secondary labels. Triggers: Use this skill when an agent with maintainer permissions (`WRITE` permission or higher) encounters a ticket lacking `ai`, primary, or secondary labels — typically authored by a non-maintainer contributor or a lower-privileged agent who couldn't apply labels at create-time.
 ---
 
 # Ticket Triage Skill

--- a/.agents/skills/turn-memory-pre-flight/SKILL.md
+++ b/.agents/skills/turn-memory-pre-flight/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: turn-memory-pre-flight
-description: "Authoritative protocol for verifying the correct placement and impact of new agentic memory substrate additions."
-triggers: Use before inserting or mutating turn-loaded or skill-loaded memory substrate such as AGENTS.md, AGENTS_ATLAS.md, .agents/skills/**, or harness-local injection files.
+description: Authoritative protocol for verifying the correct placement and impact of new agentic memory substrate additions. Triggers: Use before inserting or mutating turn-loaded or skill-loaded memory substrate such as AGENTS.md, AGENTS_ATLAS.md, .agents/skills/**, or harness-local injection files.
 ---
 
 # Turn Memory Pre-Flight

--- a/.agents/skills/unit-test/SKILL.md
+++ b/.agents/skills/unit-test/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: unit-test
-description: Expert QA knowledge on writing, formatting, and executing Playwright tests natively in the Neo.mjs single-thread layout natively.
-triggers: Use this skill if the user asks you to write, fix, or run unit tests.
+description: Expert QA knowledge on writing, formatting, and executing Playwright tests natively in the Neo.mjs single-thread layout natively. Triggers: Use this skill if the user asks you to write, fix, or run unit tests.
 ---
 # Unit Test Workflow
 If you are tasked with unit testing, you MUST immediately use the `view_file` tool to read and strictly adhere to `.agents/skills/unit-test/references/unit-test.md` before writing any code.

--- a/.agents/skills/whitebox-e2e/SKILL.md
+++ b/.agents/skills/whitebox-e2e/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: whitebox-e2e
-description: Standardized guide and protocol for authoring robust Whitebox End-to-End tests using the Neural Link Playwright fixture.
-triggers: Use this skill if the user asks you to write an E2E test, add end-to-end coverage, or test a component holistically.
+description: Standardized guide and protocol for authoring robust Whitebox End-to-End tests using the Neural Link Playwright fixture. Triggers: Use this skill if the user asks you to write an E2E test, add end-to-end coverage, or test a component holistically.
 ---
 # Whitebox E2E Testing Protocol
 

--- a/ai/scripts/lint-skill-manifest.mjs
+++ b/ai/scripts/lint-skill-manifest.mjs
@@ -70,7 +70,7 @@ function parseFrontmatter(text, filePath) {
         data[key] = value.replace(/^"(.*)"$/, '$1');
     }
 
-    for (const key of ['name', 'description', 'triggers']) {
+    for (const key of ['name', 'description']) {
         if (!data[key]) {
             throw new Error(`${filePath} missing required frontmatter key: ${key}`);
         }
@@ -289,9 +289,7 @@ function validateManifestSchema(manifest, schema) {
             errors.push(`${skillName}.description must be a non-empty string`);
         }
 
-        if (typeof skill.triggers !== 'string' || !skill.triggers.length) {
-            errors.push(`${skillName}.triggers must be a non-empty string`);
-        }
+
 
         if (!Array.isArray(skill.downstreamDocsTargets)) {
             errors.push(`${skillName}.downstreamDocsTargets must be an array`);
@@ -376,7 +374,7 @@ async function lint({base = null} = {}) {
         const fm        = parseFrontmatter(text, routerRel);
         const lineCount = text.trimEnd().split('\n').length;
 
-        for (const key of ['name', 'description', 'triggers']) {
+        for (const key of ['name', 'description']) {
             if (skill[key] !== fm[key]) {
                 errors.push(`${routerRel} frontmatter ${key} mismatch: manifest=${JSON.stringify(skill[key])} frontmatter=${JSON.stringify(fm[key])}`);
             }

--- a/learn/agentos/ProgressiveDisclosureSkills.md
+++ b/learn/agentos/ProgressiveDisclosureSkills.md
@@ -28,7 +28,7 @@ A skill in the Neo Agent OS is a directory containing instructional context.
 The contract for a skill is simple:
 
 1. **`SKILL.md` (Mandatory):** The entry point. It must contain YAML frontmatter
-   with a `name`, `description`, and `triggers` (to explain when an agent should invoke it),
+   with a `name` and `description` (which serves as the primary cross-harness router by outlining the invocation contract and purpose),
    followed by standard Markdown instructions.
 2. **`references/` (Optional):** Deeper architectural documentation or procedural 
    steps linked from the main `SKILL.md`.

--- a/learn/agentos/decisions/0007-agents-md-compaction-taxonomy.md
+++ b/learn/agentos/decisions/0007-agents-md-compaction-taxonomy.md
@@ -4,7 +4,7 @@
 
 | Attribute | Value |
 |---|---|
-| **Status** | Proposed — 2026-05-15 (Cycle 2.5 consensus achieved; awaiting operator content-accuracy approval to transition to Accepted) |
+| **Status** | Accepted — 2026-05-15 (Operator content-accuracy approval achieved, Phase A implementation merged) |
 | **Author** | @neo-gemini-3-1-pro drafting; architecture proposed by @neo-opus-4-7; challenged to ADR format by operator @tobiu |
 | **Graduated from** | Discussion #11419 — *"AGENTS.md Progressive Disclosure (Phase A)"* |
 | **Implementation ticket** | #11420 — *"Phase A: Extract Compaction Taxonomy to ADR 0007"* |

--- a/learn/guides/fundamentals/CodebaseOverview.md
+++ b/learn/guides/fundamentals/CodebaseOverview.md
@@ -447,6 +447,8 @@ Offline cognitive maintenance runs as **Node.js scripts**, not MCP protocol oper
 
 Formalized Anthropic Progressive Disclosure Skills natively used by the swarm. Listed in execution-lifecycle order, then tactical, creative, and meta. See [`learn/agentos/ProgressiveDisclosureSkills.md`](../../agentos/ProgressiveDisclosureSkills.md) for the full protocol reference and lifecycle flow diagram.
 
+**Note:** To ensure unified cross-harness trigger salience (Antigravity vs Codex/Claude) and reduce cognitive bloat, the `description` field serves as the sole routing layer, replacing the legacy redundant `triggers` frontmatter field.
+
 **Lifecycle (execution gates):**
 - `ticket-intake`: Pre-execution validation gate for existing tickets (validation sweep, ROI calculation, branch-before-code).
 - `ticket-create`: Pre-creation discipline gate for new GitHub issues (duplicate sweep, Fat Ticket body, title/label rules).

--- a/test/playwright/unit/ai/scripts/lintSkillManifest.spec.mjs
+++ b/test/playwright/unit/ai/scripts/lintSkillManifest.spec.mjs
@@ -24,12 +24,11 @@ test.describe('ai/scripts/lint-skill-manifest (#11275)', () => {
         expect(result.stdout).toContain('[lint-skill-manifest] OK');
     });
 
-    test('frontmatter parser preserves colon-bearing trigger text', () => {
-        const parsed = parseFrontmatter(`---\nname: test-skill\ndescription: Short: description\ntriggers: Use when the task says: test\n---\n# Body\n`, 'fixture/SKILL.md');
+    test('frontmatter parser preserves colon-bearing description text', () => {
+        const parsed = parseFrontmatter(`---\nname: test-skill\ndescription: Short: description\n---\n# Body\n`, 'fixture/SKILL.md');
 
         expect(parsed.name).toBe('test-skill');
         expect(parsed.description).toBe('Short: description');
-        expect(parsed.triggers).toBe('Use when the task says: test');
     });
 
     test('schema validator catches missing required skill fields', () => {
@@ -50,7 +49,6 @@ test.describe('ai/scripts/lint-skill-manifest (#11275)', () => {
             skills: {
                 broken: {
                     name                : 'broken',
-                    description         : 'missing trigger',
                     routerByteBudget    : 12,
                     payloadBudget        : 80000,
                     claudeSymlinkRequired: true,
@@ -59,7 +57,7 @@ test.describe('ai/scripts/lint-skill-manifest (#11275)', () => {
             }
         }, schema);
 
-        expect(errors).toContain('broken missing required key: triggers');
+        expect(errors).toContain('broken missing required key: description');
     });
 
     test('schema validator catches unsupported manifest fields', () => {
@@ -82,7 +80,6 @@ test.describe('ai/scripts/lint-skill-manifest (#11275)', () => {
                 extra: {
                     name                : 'extra',
                     description         : 'has extra key',
-                    triggers            : 'Use for tests.',
                     routerByteBudget    : 12,
                     payloadBudget        : 80000,
                     claudeSymlinkRequired: true,
@@ -117,7 +114,6 @@ test.describe('ai/scripts/lint-skill-manifest (#11275)', () => {
                 optional: {
                     name                : 'optional',
                     description         : 'relationship field omitted intentionally',
-                    triggers            : 'Use for tests.',
                     routerByteBudget    : 12,
                     payloadBudget        : 80000,
                     claudeSymlinkRequired: true,
@@ -176,7 +172,6 @@ test.describe('ai/scripts/lint-skill-manifest (#11275)', () => {
                 'monolith-skill': {
                     name                : 'monolith-skill',
                     description         : 'temporary override for migration-period monolith',
-                    triggers            : 'Use for tests.',
                     routerByteBudget    : 12,
                     payloadBudget       : 80000,
                     perFilePayloadBudget: 66000,
@@ -224,7 +219,6 @@ test.describe('ai/scripts/lint-skill-manifest (#11275)', () => {
                 'bad-budget': {
                     name                : 'bad-budget',
                     description         : 'negative budget',
-                    triggers            : 'Use for tests.',
                     routerByteBudget    : 12,
                     payloadBudget       : 80000,
                     perFilePayloadBudget: -100,
@@ -293,7 +287,6 @@ test.describe('ai/scripts/lint-skill-manifest (#11275)', () => {
                 'legacy-skill': {
                     name                : 'legacy-skill',
                     description         : 'pre-#11320 manifest entry without perFilePayloadBudget',
-                    triggers            : 'Use for tests.',
                     routerByteBudget    : 12,
                     payloadBudget       : 80000,
                     claudeSymlinkRequired: true,


### PR DESCRIPTION
This PR completes Phase B of the Compaction Taxonomy migration (ADR 0007). It **drops** the `triggers:` YAML frontmatter fields entirely across all 25 `SKILL.md` files, relying instead on the `description:` field as the sole cross-harness router.

This directly addresses the redundant accretion concerns by reducing the always-loaded substrate, simplifying the manifest schema, and aligning perfectly with the single-source-of-truth description-router paradigm.

### Substrate Accretion Defense
- **Growth:** Always-loaded `.agents/skills` substrate actually **SHRINKS**.
- **Justification:** Dropping the redundant `triggers` field actively reduces cognitive load and schema complexity.
- **Evidence Declaration:** [Substrate Accretion Justified] - Substrate reduced and empirically verified via `lint-skill-manifest.mjs`.

Resolves #11422