### PR TITLE
docs(agentos): separate ADR approval and merge gates (#11425)

### DIFF
--- a/learn/agentos/decisions/0005-adr-at-graduation-for-ideation-sandbox.md
+++ b/learn/agentos/decisions/0005-adr-at-graduation-for-ideation-sandbox.md
@@ -45,12 +45,13 @@ Epic bodies currently do **double-duty** as both **workstream coordination** AND
 - **Peer-veto path:** any peer may A2A `[adr-trigger-objection]` if classification looks mis-applied (substrate-spam OR missing-authority risk)
 - **Operator-direct override:** at graduation time per AGENTS.md §0 Invariant + §15.6 Flat Peer-Team
 
-### 2.3 The merge-gate boundary
+### 2.3 Approval vs. merge-gate boundary
 
 - Epics / tickets MAY be filed pre-ADR-merge (preserves planning visibility)
-- Implementation PRs consuming the decision MUST NOT be approved/merged until the ADR is `Accepted`
-- If the ADR updates an existing decision record, the gate targets the **updated ADR file at the PR head having `Status: Accepted`**, NOT the previous accepted version
-- The PR review/body trail documents the operator/content approval for the update
+- Peer maintainers MAY approve implementation PRs consuming the decision when their review criteria pass
+- Implementation PRs consuming the decision MUST NOT merge until the ADR authority is `Accepted` at merge time
+- If the ADR updates an existing decision record, merge eligibility targets the **updated ADR file at the PR head having `Status: Accepted`**, NOT the previous accepted version
+- The PR review/body trail documents any remaining human merge/content gate without converting that pending gate into `CHANGES_REQUESTED`
 
 This preserves what the substrate already has (Epic-driven coordination + planning visibility) while enforcing phase discipline only at the substrate-mutation boundary.
 
@@ -82,7 +83,7 @@ Four sub-section edits codify the workflow extension:
 
 Three companion-skill Maps each get a one-line pointer to the Atlas:
 
-- **`pr-review-guide.md §8`** cross-skill integration audit: *"If an implementation PR cites a graduated Discussion marked `Decision Record: REQUIRED`, verify the linked ADR is `Accepted` before approval."*
+- **`pr-review-guide.md §8`** cross-skill integration audit: *"If an implementation PR cites a graduated Discussion marked `Decision Record: REQUIRED`, verify the linked ADR is `Accepted` before declaring human merge eligibility; peer approval may still be valid when review criteria pass and the remaining gate is explicitly human-owned."*
 - **`ticket-create-workflow.md §5`** Fat Ticket structure: optional `Decision Record:` field when graduating from a Discussion declaring ADR classification (value references linked ADR or marks `N/A — no Discussion origin`)
 - **`epic-review-workflow.md`** Stage 2.5: when Discussion-origin Epic preserves `Discussion Criteria Mapping`, also preserve `Decision Record` classification/linkage if source Discussion declared one
 
@@ -130,9 +131,9 @@ If a Discussion graduated with `Decision Record: REQUIRED` and produced an ADR, 
 
 If the original Epic body has been Cycle-1/Cycle-2/etc amended, those amendments are workstream coordination updates, NOT authority shifts. Authority shifts produce ADR updates (a separate PR cycle). Treating amended Epic prose as authority recreates the substrate-bypass failure mode this ADR is anchored to prevent.
 
-### 5.3 Implementing before ADR `Accepted`
+### 5.3 Merging before ADR `Accepted`
 
-Implementation PRs consuming a graduated `ADR_REQUIRED` decision MUST NOT merge until the linked ADR is `Accepted`. Reviewers MUST verify ADR Status before approval. Authors who push implementation PRs targeting `dev` while the ADR is `Draft` are bypassing the merge-gate this ADR codifies.
+Implementation PRs consuming a graduated `ADR_REQUIRED` decision MUST NOT merge until the linked ADR authority is `Accepted` at merge time. Reviewers MUST verify ADR Status before declaring human merge eligibility. If the only remaining blocker is the human-owned content/merge gate, peer maintainers should not convert that into `CHANGES_REQUESTED`; they may approve on their own criteria while naming the remaining human gate. Authors who push implementation PRs targeting `dev` while the ADR is `Draft` are bypassing the merge-gate this ADR codifies unless the same PR updates the ADR to `Accepted` before merge.
 
 ### 5.4 Mis-classifying as `ADR_OPTIONAL` to skip the gate
 
@@ -149,7 +150,7 @@ If a Discussion changes durable path/layout/API/lifecycle, introduces/retires a 
 Before authoring substrate-mutation code that consumes a graduated Discussion, you MUST:
 
 1. Read the linked ADR (if `Decision Record: REQUIRED`)
-2. Verify ADR `Status: Accepted` at PR head (not historical state)
+2. Verify ADR `Status: Accepted` at PR head (not historical state) before claiming merge eligibility; if a human-owned content/merge gate remains, state it explicitly instead of treating it as a peer-review blocker
 3. V-B-A your authoring against the ADR's §2 Decision section, NOT the Epic body or Discussion body
 4. Cite the ADR in your PR body
 5. If Cycle N revisions to the ADR are needed for your work, file a separate ADR-update PR first; do not amend the implementation PR to also touch the ADR

--- a/learn/agentos/decisions/0005-adr-at-graduation-for-ideation-sandbox.md
+++ b/learn/agentos/decisions/0005-adr-at-graduation-for-ideation-sandbox.md
@@ -49,9 +49,10 @@ Epic bodies currently do **double-duty** as both **workstream coordination** AND
 
 - Epics / tickets MAY be filed pre-ADR-merge (preserves planning visibility)
 - Peer maintainers MAY approve implementation PRs consuming the decision when their review criteria pass
-- Implementation PRs consuming the decision MUST NOT merge until the ADR authority is `Accepted` at merge time
-- If the ADR updates an existing decision record, merge eligibility targets the **updated ADR file at the PR head having `Status: Accepted`**, NOT the previous accepted version
-- The PR review/body trail documents any remaining human merge/content gate without converting that pending gate into `CHANGES_REQUESTED`
+- ADR-producing / ADR-consuming PRs follow the normal PR lifecycle: peer approval + green CI + human merge
+- The human merge of an approved, green PR is the operator content-accuracy approval for the ADR change
+- If the ADR updates an existing decision record, reviewers audit the **updated ADR file at the PR head**, NOT the previous accepted version
+- The PR review/body trail documents any remaining merge-order or human merge/content gate without converting that pending gate into `CHANGES_REQUESTED`
 
 This preserves what the substrate already has (Epic-driven coordination + planning visibility) while enforcing phase discipline only at the substrate-mutation boundary.
 
@@ -77,13 +78,13 @@ Four sub-section edits codify the workflow extension:
 - **§5 graduation target list:** add ADR as optional/additional target beside Epic / ticket / rare direct PR
 - **§5.2 Authority Sweep:** when canonical future authority is not Discussion body / ticket ACs, require `Decision Record: REQUIRED / OPTIONAL / NOT_NEEDED` classification with rationale
 - **§6.6 graduated-artifact required sections:** add field `Decision Record:` with values `Not needed` / `Optional` / `Required: ADR #### / PR #N / ticket #N`
-- **§6.7 author actions:** when `ADR_REQUIRED`, file/update ADR; implementation PR merge BLOCKED until ADR `Accepted`
+- **§6.7 author actions:** when `ADR_REQUIRED`, file/update ADR; implementation PRs may be approved under normal review criteria, while actual merge order remains human-gate-owned
 
 ### 3.2 Maps (one-line pointers per Progressive Disclosure)
 
 Three companion-skill Maps each get a one-line pointer to the Atlas:
 
-- **`pr-review-guide.md §8`** cross-skill integration audit: *"If an implementation PR cites a graduated Discussion marked `Decision Record: REQUIRED`, verify the linked ADR is `Accepted` before declaring human merge eligibility; peer approval may still be valid when review criteria pass and the remaining gate is explicitly human-owned."*
+- **`pr-review-guide.md §8`** cross-skill integration audit: *"If an implementation PR cites a graduated Discussion marked `Decision Record: REQUIRED`, verify the linked ADR authority and name any merge-order dependency; peer approval may still be valid when review criteria pass and the remaining gate is explicitly human-owned."*
 - **`ticket-create-workflow.md §5`** Fat Ticket structure: optional `Decision Record:` field when graduating from a Discussion declaring ADR classification (value references linked ADR or marks `N/A — no Discussion origin`)
 - **`epic-review-workflow.md`** Stage 2.5: when Discussion-origin Epic preserves `Discussion Criteria Mapping`, also preserve `Decision Record` classification/linkage if source Discussion declared one
 
@@ -95,7 +96,7 @@ This ADR + Discussion #11369 + ticket #11370 jointly demonstrate the workflow's 
 - Discussion #11369 proposed ADR-at-graduation
 - Under its own classification rule, #11369 fires `ADR_REQUIRED` (changes durable workflow primitive; multi-future-Discussion impact; high reconstruction cost)
 - Graduation produced TWO artifacts: this ADR 0005 (authority) + ticket #11370 (planning)
-- Implementation PR for #11370 is merge-blocked until this ADR is `Accepted` per the very gate this ADR codifies
+- Implementation PR for #11370 is merge-sequenced after this ADR's authority lands; peer approval remains governed by normal review criteria
 
 **Scope discipline on this proof:** the manual dogfooding validates the **artifact-split / classification / merge-gate shape** — i.e., the *design* of the workflow extension. The workflow extension itself does NOT yet "work" as substrate; that comes into operational effect only after ticket #11370's 4-file substrate amendments land. This ADR is the authority codification; #11370's implementation PR is what mechanically wires the extension into `ideation-sandbox-workflow.md §5/§5.2/§6.6/§6.7` + the three Map pointers. Until then, the dogfooding is shape-validation, not operational-effect validation.
 
@@ -131,9 +132,9 @@ If a Discussion graduated with `Decision Record: REQUIRED` and produced an ADR, 
 
 If the original Epic body has been Cycle-1/Cycle-2/etc amended, those amendments are workstream coordination updates, NOT authority shifts. Authority shifts produce ADR updates (a separate PR cycle). Treating amended Epic prose as authority recreates the substrate-bypass failure mode this ADR is anchored to prevent.
 
-### 5.3 Merging before ADR `Accepted`
+### 5.3 Treating human merge as peer-review blocker
 
-Implementation PRs consuming a graduated `ADR_REQUIRED` decision MUST NOT merge until the linked ADR authority is `Accepted` at merge time. Reviewers MUST verify ADR Status before declaring human merge eligibility. If the only remaining blocker is the human-owned content/merge gate, peer maintainers should not convert that into `CHANGES_REQUESTED`; they may approve on their own criteria while naming the remaining human gate. Authors who push implementation PRs targeting `dev` while the ADR is `Draft` are bypassing the merge-gate this ADR codifies unless the same PR updates the ADR to `Accepted` before merge.
+Implementation PRs consuming a graduated `ADR_REQUIRED` decision follow the same peer-review semantics as other PRs: peer maintainers approve when their review criteria pass, and @tobiu's merge of an approved, green PR is the operator content-accuracy approval. Reviewers MUST verify whether the linked ADR authority is already landed, included in the PR, or merge-ordered ahead of the PR before declaring human merge readiness. If the only remaining blocker is the human-owned content/merge gate, peer maintainers should not convert that into `CHANGES_REQUESTED`; they may approve on their own criteria while naming the remaining human gate.
 
 ### 5.4 Mis-classifying as `ADR_OPTIONAL` to skip the gate
 
@@ -150,7 +151,7 @@ If a Discussion changes durable path/layout/API/lifecycle, introduces/retires a 
 Before authoring substrate-mutation code that consumes a graduated Discussion, you MUST:
 
 1. Read the linked ADR (if `Decision Record: REQUIRED`)
-2. Verify ADR `Status: Accepted` at PR head (not historical state) before claiming merge eligibility; if a human-owned content/merge gate remains, state it explicitly instead of treating it as a peer-review blocker
+2. Verify whether the ADR authority is landed, included in the PR, or merge-ordered ahead of the PR before claiming merge readiness; if a human-owned content/merge gate remains, state it explicitly instead of treating it as a peer-review blocker
 3. V-B-A your authoring against the ADR's §2 Decision section, NOT the Epic body or Discussion body
 4. Cite the ADR in your PR body
 5. If Cycle N revisions to the ADR are needed for your work, file a separate ADR-update PR first; do not amend the implementation PR to also touch the ADR
@@ -188,8 +189,8 @@ This hook replaces the a-priori "~1-3 ADRs per quarter" cadence assertion (origi
 
 ## 9. Status / Lifecycle
 
-- **Draft (this version)** awaiting operator content-accuracy approval before commit-time Status flip
-- **Accepted** once operator confirms accuracy + completeness via PR review trail
+- **Draft** while an ADR proposal is still being shaped before normal PR approval
+- **Accepted** once an approved, green PR is merged by the human operator; the merge is the operator content-accuracy approval
 - **Merge-order dependency on ADR 0004 / PR #11368:** ADR 0005 references ADR 0004 in §8 Related as positive empirical precedent (post-hoc rescue-retrofit). PR #11368 (which lands ADR 0004 on `dev`) is still open at this PR's authoring time. **PR #11371 (this ADR) MUST NOT merge until PR #11368 has merged** — otherwise the §8 reference to "ADR 0004" lands on `dev` while no ADR 0004 file exists yet, creating a dangling-reference anti-pattern. If sequencing inverts at operator's call, this ADR must be renumbered or its §8 reference restructured before merge.
 - **Periodic re-review trigger:** any future PR amending `ideation-sandbox-workflow.md §5 / §5.2 / §6.6 / §6.7` or the companion Map pointers MUST cite this ADR in body; reviewer-side audit fires if absent
 - **Post-merge validation:** §7 hook fires as Discussion graduations land


### PR DESCRIPTION
Resolves #11425

Authored by GPT-5.5 (Codex Desktop). Session 56d01d8b-ce3f-4194-9441-e4941ae07be8.

Separates ADR 0005 peer/team approval semantics from the human-only merge/content gate. The ADR now says ADR-producing / ADR-consuming PRs follow normal PR lifecycle: peer approval, green CI, and human merge. @tobiu's merge of an approved green PR is the operator content-accuracy approval for the ADR change.

Evidence: L1 (static ADR wording audit + targeted grep) -> L1 required (docs/workflow semantics only). No residuals.

## Deltas from ticket

- Backfilled the #11425 Contract Ledger Matrix before implementation because ticket-intake correctly classified this as an agent-consumed workflow contract.
- Touched only ADR 0005. Targeted grep showed the copied approval-blocker wording was not present in the current `pr-review` or `ideation-sandbox` payloads, so broader skill edits would be substrate bloat.
- Cycle 2 clarification from @tobiu removed the remaining special `Accepted at merge time` gate phrasing: ADR changes use the same approved+green+human-merge model as other PRs.

## Out of Scope

- No new two-review enforcement rule in this PR. A future policy for requiring two reviews on `AGENTS.md`, skill, and ADR changes is a separate substrate decision.

## Slot Rationale

- Modified `learn/agentos/decisions/0005-adr-at-graduation-for-ideation-sandbox.md` §2.3 / §3.1 / §3.2 / §3.3 / §5.3 / §6 / §9: disposition delta `rewrite`. Trigger-frequency stays conditional on ADR-required implementation/review lanes; failure-severity is high because the old wording caused a review deadlock; enforceability is discipline-only until a future static check exists.
- Net substrate effect: no new always-loaded rule, no new skill router text, and no additional loaded bytes in per-turn substrate. The change reduces future review-loop churn by clarifying an existing authority document.

## Test Evidence

- `git diff --check`
- Targeted grep confirmed no remaining ADR 0005 `approved/merged`, `before approval`, or special `Accepted at merge time` blocker wording in the relevant workflow surfaces.
- Pre-push freshness check: `merge-base HEAD origin/dev == origin/dev`.
- Branch history close-target check: outgoing commits contain only ticket-suffixed subjects and no body close-targets.

## Post-Merge Validation

- [ ] PR #11421 can be re-evaluated under the corrected approval-vs-merge gate model.

## Commits

- `79624bc4a` — `docs(agentos): separate ADR approval and merge gates (#11425)`
- `3e973a9ff` — `docs(agentos): align ADR acceptance with human merge gate (#11425)`
