### PR TITLE
refactor(ai): harden SKILL.md description-routers (Phase B) (#11422)

### DIFF
--- a/.agents/skills/architecture-pre-flight/SKILL.md
+++ b/.agents/skills/architecture-pre-flight/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: architecture-pre-flight
-description: "High-level umbrella router for navigating broad, cross-substrate architectural ambiguity."
-triggers: Use when no narrower pre-flight clearly applies, or when work spans multiple trigger families such as new subsystems, protocols, MCP tools, or cross-substrate refactors.
+description: "High-level umbrella router for navigating broad, cross-substrate architectural ambiguity. Use when no narrower pre-flight clearly applies, or when work spans multiple trigger families such as new subsystems, protocols, MCP tools, or cross-substrate refactors."
 ---
 
 # Architecture Pre-Flight

--- a/.agents/skills/blocked-task-state/SKILL.md
+++ b/.agents/skills/blocked-task-state/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: blocked-task-state
-description: Authoritative protocol for signaling blocked or input-required task states. Mandates targeted A2A pings using the Task.state envelope rather than global capacity broadcasts.
-triggers: Use this skill whenever your execution becomes blocked, requires explicit operator input, or encounters a failure that halts progress.
+description: "Authoritative protocol for signaling blocked or input-required task states. Mandates targeted A2A pings using the Task.state envelope rather than global capacity broadcasts. Use this skill whenever your execution becomes blocked, requires explicit operator input, or encounters a failure that halts progress."
 ---
 
 # Blocked Task-State Coordination

--- a/.agents/skills/create-skill/SKILL.md
+++ b/.agents/skills/create-skill/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: create-skill
-description: Authoritative guide on how to architect, format, and structure new Anthropic Progressive Disclosure skills.
-triggers: Use this skill if the user asks you to create a new skill, teach an agent a new capability, or if you need to recall the exact folder structure and YAML frontmatter required for skills.
+description: "Authoritative guide on how to architect, format, and structure new Anthropic Progressive Disclosure skills. Use this skill if the user asks you to create a new skill, teach an agent a new capability, or if you need to recall the exact folder structure and YAML frontmatter required for skills."
 ---
 # Skill Creation Framework
 If you are tasked with creating a new Agent Skill, you MUST immediately use the `view_file` tool to read and strictly adhere to `.agents/skills/create-skill/references/skill-authoring-guide.md` before creating any files. This prevents system prompt bloat and ensures future agents can parse your skill correctly.

--- a/.agents/skills/debugging-antigravity/SKILL.md
+++ b/.agents/skills/debugging-antigravity/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: debugging-antigravity
-description: Authoritative guide on debugging Antigravity IDE MCP servers, preventing language server duplication, mitigating sqlite workspace UI crashes, and configuring mcpServers.
-triggers: Use this skill if the user's Antigravity MCP server panel has a perpetual loading spinner, if MCP processes are duplicating, if sqlite workspace states are corrupted (`__store` null error), or if you need to know how to properly scope `.gemini/settings.json` vs global configurations.
+description: "Authoritative guide on debugging Antigravity IDE MCP servers, preventing language server duplication, mitigating sqlite workspace UI crashes, and configuring mcpServers. Use this skill if the user's Antigravity MCP server panel has a perpetual loading spinner, if MCP processes are duplicating, if sqlite workspace states are corrupted (`__store` null error), or if you need to know how to properly scope `.gemini/settings.json` vs global configurations."
 ---
 # Antigravity Debugging Guide
 If you need to debug Antigravity IDE issues, MCP server duplication, database initialization race conditions, or fix workspace UI crashes (loading spinners), you MUST immediately use the `view_file` tool to read and strictly adhere to `.agents/skills/debugging-antigravity/references/debugging-guide.md` before proceeding.

--- a/.agents/skills/epic-resolution/SKILL.md
+++ b/.agents/skills/epic-resolution/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: epic-resolution
-description: Closeout protocol for parent epics — answers "we resolved all epic subs, are we done now?" with a structured matrix + verdict recommendation (close / keep open / create missing subs / retire-supersede). Sibling to epic-review (which handles entry); this is the exit gate.
-triggers: Use this skill when the last required sub of an epic closes, when a team member claims an epic is complete or substrate-side complete, before closing an epic as COMPLETED, or when a peer broadcasts an epic-readiness signal that needs reconciliation against parent ACs.
+description: "Closeout protocol for parent epics — answers \"we resolved all epic subs, are we done now?\" with a structured matrix + verdict recommendation (close / keep open / create missing subs / retire-supersede). Sibling to epic-review (which handles entry); this is the exit gate. Use this skill when the last required sub of an epic closes, when a team member claims an epic is complete or substrate-side complete, before closing an epic as COMPLETED, or when a peer broadcasts an epic-readiness signal that needs reconciliation against parent ACs."
 ---
 # Epic Resolution
 If you are about to declare an epic complete, close an epic, propose creating new subs to complete one, or react to a peer broadcast that an epic is "ready for handoff" / "components look solid", you MUST immediately use the `view_file` tool to read and strictly adhere to `.agents/skills/epic-resolution/references/epic-resolution-workflow.md` before posting any verdict or recommendation.

--- a/.agents/skills/epic-review/SKILL.md
+++ b/.agents/skills/epic-review/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: epic-review
-description: Authoritative protocol for pre-work review of epics. Six-stage gating chain — roadmap fit, approach elegance, source discussion mapping, sub-structure coherence, prescription layer, avoided-traps completeness — posted as a structured comment on the epic ticket. Per-agent-per-epic one-shot; subsequent sub pickups cite the prior review.
-triggers: Use this skill when an agent is about to pick up its first sub from an unreviewed epic (per model-identity). Also use when a user explicitly requests an epic review, or when an epic is freshly filed and a reviewer pre-validates before any sub pickup begins.
+description: "Authoritative protocol for pre-work review of epics. Six-stage gating chain — roadmap fit, approach elegance, source discussion mapping, sub-structure coherence, prescription layer, avoided-traps completeness — posted as a structured comment on the epic ticket. Per-agent-per-epic one-shot; subsequent sub pickups cite the prior review. Use this skill when an agent is about to pick up its first sub from an unreviewed epic (per model-identity). Also use when a user explicitly requests an epic review, or when an epic is freshly filed and a reviewer pre-validates before any sub pickup begins."
 ---
 # Epic Review Skill
 

--- a/.agents/skills/ideation-sandbox/SKILL.md
+++ b/.agents/skills/ideation-sandbox/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: ideation-sandbox
-description: Safely propose architectural features, unknown unknowns, and brainstorm ideas natively in GitHub Discussions.
-triggers: Use this skill when the user asks to brainstorm an architecture change or proposes a highly exploratory / undefined technical idea.
+description: "Safely propose architectural features, unknown unknowns, and brainstorm ideas natively in GitHub Discussions. Use this skill when the user asks to brainstorm an architecture change or proposes a highly exploratory / undefined technical idea."
 ---
 
 # Ideation Sandbox

--- a/.agents/skills/industry-friction-radar/SKILL.md
+++ b/.agents/skills/industry-friction-radar/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: industry-friction-radar
-description: Proactive Bleeding-Edge research loop using a strict 3-step abstraction protocol to extract engine-category friction points without importing framework-category bias or stealing code.
-triggers: Use this skill when executing periodic "horizon scans" for the Dream Pipeline, researching external solutions to deeply complex engine-level friction points, or evaluating JS ecosystem trends.
+description: "Proactive Bleeding-Edge research loop using a strict 3-step abstraction protocol to extract engine-category friction points without importing framework-category bias or stealing code. Use this skill when executing periodic \"horizon scans\" for the Dream Pipeline, researching external solutions to deeply complex engine-level friction points, or evaluating JS ecosystem trends."
 ---
 
 # Industry Friction Radar

--- a/.agents/skills/lead-role/SKILL.md
+++ b/.agents/skills/lead-role/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: lead-role
-description: Switch into relaxed-planning + dialogue-first mindset when delegated lead role for coordination. Suspends Auto Mode velocity-bias for the duration.
-triggers: Use this skill IMMEDIATELY when the user delegates lead with explicit phrases ("you take the lead", "coordinate the team", "lead this phase", "drive the next planning step", "chief-architect" when scope is swarm/substrate/roadmap/multi-ticket), OR when AGENTS.md §22 mailbox check surfaces a valid `lead-role-baton`, OR when you have just authored a substrate-shaped ticket about to enter implementation, OR via direct /lead-role invocation.
+description: "Switch into relaxed-planning + dialogue-first mindset when delegated lead role for coordination. Suspends Auto Mode velocity-bias for the duration. Use this skill IMMEDIATELY when the user delegates lead with explicit phrases (\"you take the lead\", \"coordinate the team\", \"lead this phase\", \"drive the next planning step\", \"chief-architect\" when scope is swarm/substrate/roadmap/multi-ticket), OR when AGENTS.md §22 mailbox check surfaces a valid `lead-role-baton`, OR when you have just authored a substrate-shaped ticket about to enter implementation, OR via direct /lead-role invocation."
 ---
 
 # Lead Role Skill

--- a/.agents/skills/memory-mining/SKILL.md
+++ b/.agents/skills/memory-mining/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: memory-mining
-description: Authoritative protocol for querying the Memory Core before diagnosing regressions or proposing non-trivial architectural claims. Prevents re-derivation of prior reasoning by surfacing cross-session, cross-harness context via semantic search.
-triggers: Use this skill when (1) the user reports a regression symptom ("used to work", "suddenly broken", surprise validation failures, schema mismatches, "additionalProperties" rejections), OR (2) you are about to propose an architectural claim, roadmap, or comparison against external work where prior sessions may have already mapped the territory.
+description: "Authoritative protocol for querying the Memory Core before diagnosing regressions or proposing non-trivial architectural claims. Prevents re-derivation of prior reasoning by surfacing cross-session, cross-harness context via semantic search. Use this skill when (1) the user reports a regression symptom (\"used to work\", \"suddenly broken\", surprise validation failures, schema mismatches, \"additionalProperties\" rejections), OR (2) you are about to propose an architectural claim, roadmap, or comparison against external work where prior sessions may have already mapped the territory."
 ---
 
 # Memory Mining Skill

--- a/.agents/skills/neural-link/SKILL.md
+++ b/.agents/skills/neural-link/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: neural-link
-description: Expert tactical knowledge on sequencing Neural Link MCP tools to inspect, debug, and manipulate live Neo.mjs applications.
-triggers: Use this skill if the user asks you to interact with the browser, inspect the UI natively, patch live code, or use the Neural Link.
+description: "Expert tactical knowledge on sequencing Neural Link MCP tools to inspect, debug, and manipulate live Neo.mjs applications. Use this skill if the user asks you to interact with the browser, inspect the UI natively, patch live code, or use the Neural Link."
 ---
 # Neural Link Workflow
 If you are tasked with debugging, monitoring, or modifying the live Neo.mjs runtime environment, you MUST immediately use the `view_file` tool to read and strictly adhere to `.agents/skills/neural-link/references/operational-handbook.md` before invoking any native MCP tools.

--- a/.agents/skills/peer-role/SKILL.md
+++ b/.agents/skills/peer-role/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: peer-role
-description: Switch into evidence-backed convergence-pressure mindset when reviewing a peer's design proposal. Suspends Auto Mode "ack-and-move-on" bias for the duration.
-triggers: Use this skill IMMEDIATELY when reviewing an Ideation Sandbox discussion / architectural proposal, an epic shape, a skill shape, a roadmap or milestone proposal, or a `/lead-role` convergence artifact. Do NOT auto-fire on ordinary status broadcasts where the right action is mark-read or "no collision".
+description: "Switch into evidence-backed convergence-pressure mindset when reviewing a peer's design proposal. Suspends Auto Mode \"ack-and-move-on\" bias for the duration. Use this skill IMMEDIATELY when reviewing an Ideation Sandbox discussion / architectural proposal, an epic shape, a skill shape, a roadmap or milestone proposal, or a `/lead-role` convergence artifact. Do NOT auto-fire on ordinary status broadcasts where the right action is mark-read or \"no collision\"."
 ---
 
 # Peer Role Skill

--- a/.agents/skills/post-review-pickup/SKILL.md
+++ b/.agents/skills/post-review-pickup/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: post-review-pickup
-description: Authoritative protocol for immediate next-phase pickup after PR review or author response handoff. Prevents silent idle after review cycles by requiring the next lane or an explicit halt-state.
-triggers: Use immediately after posting a PR review, chaining a formal GitHub review state, or posting an author review-response handoff with a commentId.
+description: "Authoritative protocol for immediate next-phase pickup after PR review or author response handoff. Prevents silent idle after review cycles by requiring the next lane or an explicit halt-state. Use immediately after posting a PR review, chaining a formal GitHub review state, or posting an author review-response handoff with a commentId."
 ---
 
 # Post-Review Pickup Skill

--- a/.agents/skills/pr-review/SKILL.md
+++ b/.agents/skills/pr-review/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: pr-review
-description: Standardized guidelines and templates for structuring Pull Request reviews so that feedback is actionable, encouraging, and extractable by the Native Edge Graph.
-triggers: Use this skill when evaluating a Pull Request, writing a PR review, structuring feedback on agent-generated code, or instructing a human on how to write a structured PR Review.
+description: "Standardized guidelines and templates for structuring Pull Request reviews so that feedback is actionable, encouraging, and extractable by the Native Edge Graph. Use this skill when evaluating a Pull Request, writing a PR review, structuring feedback on agent-generated code, or instructing a human on how to write a structured PR Review."
 ---
 # PR Review Skill
 

--- a/.agents/skills/pull-request/SKILL.md
+++ b/.agents/skills/pull-request/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: pull-request
-description: Standardized guidelines and procedural execution flow for opening a Pull Request. Mandates the "Stepping Back" reflection protocol and git/gh tool invocations.
-triggers: Use this skill as the final Definition of Done when you believe a ticket is complete and it is time to open a Pull Request, or if a human user asks you to submit a PR. Also triggers when receiving a PR review to perform the author-side template-adherence check.
+description: "Standardized guidelines and procedural execution flow for opening a Pull Request. Mandates the \"Stepping Back\" reflection protocol and git/gh tool invocations. Use this skill as the final Definition of Done when you believe a ticket is complete and it is time to open a Pull Request, or if a human user asks you to submit a PR. Also triggers when receiving a PR review to perform the author-side template-adherence check."
 ---
 # Pull Request Skill
 

--- a/.agents/skills/self-repair/SKILL.md
+++ b/.agents/skills/self-repair/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: self-repair
-description: Execute autonomous diagnostics, verify MCP server stability, and treat system degradation using tests and memory core forensics.
-triggers: [Healthcheck, run health checklist, diagnose system collapse, MCP infrastructure failure, troubleshoot agent OS, system degraded, Sandman handoff verification failure, self-repair, system recovery]
+description: "Execute autonomous diagnostics, verify MCP server stability, and treat system degradation using tests and memory core forensics. [Healthcheck, run health checklist, diagnose system collapse, MCP infrastructure failure, troubleshoot agent OS, system degraded, Sandman handoff verification failure, self-repair, system recovery]"
 ---
 # Autonomous Self-Repair Workflow
 

--- a/.agents/skills/session-sunset/SKILL.md
+++ b/.agents/skills/session-sunset/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: session-sunset
-description: Authoritative protocol for gracefully terminating an agent session. Mandates structured handover comments, mental-model states, and memory persistence to prevent Zero-State Amnesia.
-triggers: When concluding a long-running session, executing the Sunset Protocol, handing over work for the next agent, or terminating an agent cycle.
+description: "Authoritative protocol for gracefully terminating an agent session. Mandates structured handover comments, mental-model states, and memory persistence to prevent Zero-State Amnesia. When concluding a long-running session, executing the Sunset Protocol, handing over work for the next agent, or terminating an agent cycle."
 ---
 
 # Session Sunset Skill

--- a/.agents/skills/structural-pre-flight/SKILL.md
+++ b/.agents/skills/structural-pre-flight/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: structural-pre-flight
-description: Authoritative pre-implementation discipline gate that fires when a new `.mjs` file is about to be authored. Stage 0 mechanical trigger; Stage 1 fast-path (§23 sibling-file-lift) for matched patterns OR full Pre-Flight (ArchitectureOverview.md + ADR consultation + chief-architect framing) for novel directory choices. Closes the 0th-level discipline gap empirically demonstrated by `bridge-daemon.mjs` (originally misplaced in `ai/scripts/`) and `orchestrator-daemon.mjs` (PR #11008 same-class miss).
-triggers: Use this skill before authoring or relocating any new `.mjs` file. Fires from `ticket-create` Stage 3 (Substrate), `ticket-intake` validation, `epic-review` Stage 3, and any direct authoring path. Sibling pattern match → 30-second fast-path; novel directory choice → full structural pre-flight before the file is written.
+description: "Authoritative pre-implementation discipline gate that fires when a new `.mjs` file is about to be authored. Stage 0 mechanical trigger; Stage 1 fast-path (§23 sibling-file-lift) for matched patterns OR full Pre-Flight (ArchitectureOverview.md + ADR consultation + chief-architect framing) for novel directory choices. Closes the 0th-level discipline gap empirically demonstrated by `bridge-daemon.mjs` (originally misplaced in `ai/scripts/`) and `orchestrator-daemon.mjs` (PR #11008 same-class miss). Use this skill before authoring or relocating any new `.mjs` file. Fires from `ticket-create` Stage 3 (Substrate), `ticket-intake` validation, `epic-review` Stage 3, and any direct authoring path. Sibling pattern match → 30-second fast-path; novel directory choice → full structural pre-flight before the file is written."
 ---
 
 # Structural Pre-Flight Skill

--- a/.agents/skills/tech-debt-radar/SKILL.md
+++ b/.agents/skills/tech-debt-radar/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: tech-debt-radar
-description: Proactive architectural review skill using Frontier Model semantic RAG to sweep historical issues and Memory Core sessions for technical debt.
-triggers: Use this skill when conducting architectural analysis, proactively searching for technical debt, auditing the repository for abandoned logical loops, or when explicitly requested to scan for ambient architectural debt.
+description: "Proactive architectural review skill using Frontier Model semantic RAG to sweep historical issues and Memory Core sessions for technical debt. Use this skill when conducting architectural analysis, proactively searching for technical debt, auditing the repository for abandoned logical loops, or when explicitly requested to scan for ambient architectural debt."
 ---
 
 # Tech Debt Radar

--- a/.agents/skills/ticket-create/SKILL.md
+++ b/.agents/skills/ticket-create/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: ticket-create
-description: Authoritative protocol for creating Neo.mjs GitHub issues. Enforces duplicate sweep, Fat Ticket body structure, strict label rules, title hygiene, and the five-stage challenge chain at creation time. Use immediately before calling the create_issue MCP tool.
-triggers: Use this skill before any invocation of the create_issue MCP tool. This is the creation-side dual of ticket-intake (which consumes existing tickets).
+description: "Authoritative protocol for creating Neo.mjs GitHub issues. Enforces duplicate sweep, Fat Ticket body structure, strict label rules, title hygiene, and the five-stage challenge chain at creation time. Use immediately before calling the create_issue MCP tool. Use this skill before any invocation of the create_issue MCP tool. This is the creation-side dual of ticket-intake (which consumes existing tickets)."
 ---
 
 # Ticket Create Skill

--- a/.agents/skills/ticket-intake/SKILL.md
+++ b/.agents/skills/ticket-intake/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: ticket-intake
-description: Authoritative protocol defining the "Pre-Execution Reflection Gate". Mandates architectural validation, negative ROI calculation, and duplicate sweeps before an agent is permitted to begin working on a GitHub Issue.
-triggers: Use this skill immediately when assigned a new ticket, before checking out a branch or writing any codebase modifications.
+description: "Authoritative protocol defining the \"Pre-Execution Reflection Gate\". Mandates architectural validation, negative ROI calculation, and duplicate sweeps before an agent is permitted to begin working on a GitHub Issue. Use this skill immediately when assigned a new ticket, before checking out a branch or writing any codebase modifications."
 ---
 
 # Ticket Intake Skill

--- a/.agents/skills/ticket-triage/SKILL.md
+++ b/.agents/skills/ticket-triage/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: ticket-triage
-description: Authoritative protocol for maintainer-side label triage of unlabeled contributor tickets. Codifies the social contract for what happens when a ticket arrives without `ai`, primary (`bug`/`enhancement`/`epic`), or secondary labels.
-triggers: Use this skill when an agent with maintainer permissions (`WRITE` permission or higher) encounters a ticket lacking `ai`, primary, or secondary labels — typically authored by a non-maintainer contributor or a lower-privileged agent who couldn't apply labels at create-time.
+description: "Authoritative protocol for maintainer-side label triage of unlabeled contributor tickets. Codifies the social contract for what happens when a ticket arrives without `ai`, primary (`bug`/`enhancement`/`epic`), or secondary labels. Use this skill when an agent with maintainer permissions (`WRITE` permission or higher) encounters a ticket lacking `ai`, primary, or secondary labels — typically authored by a non-maintainer contributor or a lower-privileged agent who couldn't apply labels at create-time."
 ---
 
 # Ticket Triage Skill

--- a/.agents/skills/turn-memory-pre-flight/SKILL.md
+++ b/.agents/skills/turn-memory-pre-flight/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: turn-memory-pre-flight
-description: "Authoritative protocol for verifying the correct placement and impact of new agentic memory substrate additions."
-triggers: Use before inserting or mutating turn-loaded or skill-loaded memory substrate such as AGENTS.md, AGENTS_ATLAS.md, .agents/skills/**, or harness-local injection files.
+description: "Authoritative protocol for verifying the correct placement and impact of new agentic memory substrate additions. Use before inserting or mutating turn-loaded or skill-loaded memory substrate such as AGENTS.md, AGENTS_ATLAS.md, .agents/skills/**, or harness-local injection files."
 ---
 
 # Turn Memory Pre-Flight

--- a/.agents/skills/unit-test/SKILL.md
+++ b/.agents/skills/unit-test/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: unit-test
-description: Expert QA knowledge on writing, formatting, and executing Playwright tests natively in the Neo.mjs single-thread layout natively.
-triggers: Use this skill if the user asks you to write, fix, or run unit tests.
+description: "Expert QA knowledge on writing, formatting, and executing Playwright tests natively in the Neo.mjs single-thread layout natively. Use this skill if the user asks you to write, fix, or run unit tests."
 ---
 # Unit Test Workflow
 If you are tasked with unit testing, you MUST immediately use the `view_file` tool to read and strictly adhere to `.agents/skills/unit-test/references/unit-test.md` before writing any code.

--- a/.agents/skills/whitebox-e2e/SKILL.md
+++ b/.agents/skills/whitebox-e2e/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: whitebox-e2e
-description: Standardized guide and protocol for authoring robust Whitebox End-to-End tests using the Neural Link Playwright fixture.
-triggers: Use this skill if the user asks you to write an E2E test, add end-to-end coverage, or test a component holistically.
+description: "Standardized guide and protocol for authoring robust Whitebox End-to-End tests using the Neural Link Playwright fixture. Use this skill if the user asks you to write an E2E test, add end-to-end coverage, or test a component holistically."
 ---
 # Whitebox E2E Testing Protocol
 


### PR DESCRIPTION
Resolves #11422

Hardens the description-routers across all 25 `SKILL.md` files by merging the contents of the `triggers:` field into the `description:` field, and entirely removes the `triggers:` field from the YAML frontmatter.

This ensures cross-harness agents (Antigravity/Codex) that only load `name` + `description` will have salient trigger conditions before `AGENTS.md` §21 is removed in Phase C.

Authored by Neo Gemini (Antigravity). Session 188acb85-b41e-435c-94ee-0cc9944d4c97.

## Substrate-Mutation Slot-Rationale
- **Modified:** `.agents/skills/**/SKILL.md` description field.
  - Disposition Delta: N/A
  - Reason for shift: Moving trigger routing into `description` to satisfy cross-harness empirical load constraints.
- **Retired:** `.agents/skills/**/SKILL.md` triggers field.
  - Rationale for removal: Field is silently dropped by context loading. Redundant and creates false-confidence.

Evidence: L1 (static config-shape audit) → L1 required (no runtime-verify ACs). No residuals.

## Test Evidence
Verified locally using node script that all 25 YAML frontmatters parsed correctly and no multiline anomalies were found.

## Post-Merge Validation
- [ ] Ensure that cross-harness agents load the full trigger-aware descriptions in their context.
