### PR TITLE
docs(agentos): amend ADR 0007 with recursive-reload annotation (#11435)

### DIFF
--- a/learn/agentos/decisions/0007-agents-md-compaction-taxonomy.md
+++ b/learn/agentos/decisions/0007-agents-md-compaction-taxonomy.md
@@ -62,11 +62,11 @@ Based on these axes, every section in the instruction substrate receives a **Dis
 | §10 Testing Protocol | `compress-to-trigger` | DISCIPLINE-ONLY | High depth, tripwire needs pointer. | - |
 | §11 File Editing | `keep` | MACHINE-ENFORCEABLE-CANDIDATE | Frequent operation with strict tool limits. | - |
 | §12 Coding Syntax | `move` | MACHINE-ENFORCEABLE-CANDIDATE | Relocated entirely. | - |
-| §13 Self-Evolving Systems | `keep` | DISCIPLINE-ONLY | MX rule-refinement loop is per-turn reflex. | - |
-| §13.1 Contributions Over Commits | `keep` | DISCIPLINE-ONLY | MX productivity primitive supersedes velocity-bias; per-turn reward-signal anchor. | - |
+| §13 Self-Evolving Systems | `keep` | DISCIPLINE-ONLY | MX rule-refinement loop is per-turn reflex. | `recursive-reload-required` |
+| §13.1 Contributions Over Commits | `keep` | DISCIPLINE-ONLY | MX productivity primitive supersedes velocity-bias; per-turn reward-signal anchor. | `recursive-reload-required` |
 | §14 Sunset Protocol | `compress-to-trigger`| MACHINE-ENFORCEABLE-CANDIDATE | Session termination gate. | - |
 | §15 Knowledge Base | `compress-to-trigger`| DISCIPLINE-ONLY | §15.5 Neo Identity Anchor in main as anti-drift; §15.1-15.4 in Atlas. | - |
-| §15.6 Swarm Topology Anchor | `keep` | DISCIPLINE-ONLY | Defends Flat Peer-Team against orchestrator-worker training-data drift; cross-peer coordination trigger. | - |
+| §15.6 Swarm Topology Anchor | `keep` | DISCIPLINE-ONLY | Defends Flat Peer-Team against orchestrator-worker training-data drift; cross-peer coordination trigger. | `recursive-reload-required` |
 | §16 Implementation Loop | `move` | DISCIPLINE-ONLY | High depth workflow. | - |
 | §17 Virtuous Cycle | `move` | DISCIPLINE-ONLY | High depth workflow. | - |
 | §18 Session Maintenance | `move` | DISCIPLINE-ONLY | High depth workflow. | - |
@@ -75,6 +75,12 @@ Based on these axes, every section in the instruction substrate receives a **Dis
 | §21 Workflow Skills | `keep` | MACHINE-ENFORCEABLE-CANDIDATE | The routing table is frequent. | `recursive-reload-required` |
 | §22 Mailbox Check | `keep` | MACHINE-ENFORCEABLE-CANDIDATE | Turn-start invariant. | - |
 | §23 Edge-Case Triggers | `keep` | DISCIPLINE-ONLY | The actual Atlas pointer section. | - |
+
+### 2.2 The Post-Pruning-Recurrence-Rate (Phase C Sub-Axis)
+
+As long-running sessions compress older messages, implicit behavioral disciplines often decay due to context pruning. To combat "Zero-State Amnesia", critical anchors (e.g., swarm topology defense, self-evolving MX loops, and workflow triggers) receive a `recursive-reload-required` annotation. 
+
+The **Post-Pruning-Recurrence-Rate** sub-axis evaluates whether a rule's absence post-compression leads to a recurrence of the pre-training regression drift it was designed to fix. If the recurrence rate is high (e.g., the agent rapidly reverts to "Helpful Assistant" deference or Orchestrator/Worker hierarchical paradigms), the anchor must be marked as `recursive-reload-required` to shield it from Phase C pruning algorithms.
 
 ---
 

--- a/learn/agentos/decisions/0007-agents-md-compaction-taxonomy.md
+++ b/learn/agentos/decisions/0007-agents-md-compaction-taxonomy.md
@@ -80,7 +80,11 @@ Based on these axes, every section in the instruction substrate receives a **Dis
 
 As long-running sessions compress older messages, implicit behavioral disciplines often decay due to context pruning. To combat "Zero-State Amnesia", critical anchors (e.g., swarm topology defense, self-evolving MX loops, and workflow triggers) receive a `recursive-reload-required` annotation. 
 
-The **Post-Pruning-Recurrence-Rate** sub-axis evaluates whether a rule's absence post-compression leads to a recurrence of the pre-training regression drift it was designed to fix. If the recurrence rate is high (e.g., the agent rapidly reverts to "Helpful Assistant" deference or Orchestrator/Worker hierarchical paradigms), the anchor must be marked as `recursive-reload-required` to shield it from Phase C pruning algorithms.
+**Conceptual Framing:** Instructions stored solely in skill payloads are fragile under pruning; since `AGENTS.md` reloads every turn, retaining the anchor in the L1 file acts as a `recursive-reload-anchor` primitive.
+
+**Assignment Heuristic:** Entries governing ongoing-session-behavior (§13, §13.1, §15.6, §21) receive the `recursive-reload-required` annotation. One-shot enforcement points (§0 invariants, §3, §4) do not, because mechanical-enforcement protects them regardless of recall.
+
+**Empirical Anchor:** The **Post-Pruning-Recurrence-Rate** sub-axis evaluates whether a rule's absence post-compression leads to a recurrence of the pre-training regression drift it was designed to fix. If the recurrence rate is high (e.g., the agent rapidly reverts to "Helpful Assistant" deference or Orchestrator/Worker hierarchical paradigms), the anchor must be marked as `recursive-reload-required` to shield it from Phase C pruning algorithms. (Triggered by operator-direction 2026-05-15 + PR #11434 §21 trigger + this PR's §5.3 anti-pattern).
 
 ---
 
@@ -116,7 +120,7 @@ Modifying the baseline taxonomy dispositions directly in this ADR. This ADR is t
 ---
 
 ### 5.3 Recursive-Reload Pruning
-Retiring or applying a `compress-to-trigger` disposition to entries annotated as `recursive-reload-required` (such as the §21 Workflow Skills routing table) during Phase C compression. These entries serve as recursive-reload anchors and must be preserved to prevent breaking post-pruning behavioral-discipline recall in long sessions.
+Retiring or applying a `compress-to-trigger` disposition to entries annotated as `recursive-reload-required` (§13, §13.1, §15.6, §21) during Phase C compression. These entries serve as recursive-reload anchors and must be preserved to prevent breaking post-pruning behavioral-discipline recall in long sessions.
 
 ---
 

--- a/learn/agentos/decisions/0007-agents-md-compaction-taxonomy.md
+++ b/learn/agentos/decisions/0007-agents-md-compaction-taxonomy.md
@@ -44,37 +44,37 @@ Based on these axes, every section in the instruction substrate receives a **Dis
 
 *Note: This reflects the baseline dispositions applied during the progressive disclosure migration. Future rules must be evaluated against the 3-axis rule.*
 
-| Section | Disposition | Tag (AC7) | Rationale / Friction Capture |
-|---|---|---|---|
-| §0 Critical Gates | `keep` | MACHINE-ENFORCEABLE-CANDIDATE | Irreversible failure modes. |
-| §0 Invariant 7 | `keep` | MACHINE-ENFORCEABLE-CANDIDATE | No tracked file edits without a self-assigned ticket. |
-| §0 Invariant 8 | `keep` | MACHINE-ENFORCEABLE-CANDIDATE | Agent-authored PRs target `dev`; `main` is release-only. |
-| §1 Communication Style | `move` | DISCIPLINE-ONLY | Low frequency gate, high depth. |
-| §2 Anti-Hallucination | `move` | DISCIPLINE-ONLY | High depth protocol, moved to Atlas. |
-| §3 Pre-Commit Hard Gates | `keep` | MACHINE-ENFORCEABLE-CANDIDATE | Severe failure mode (ticket-ID/context). |
-| §4 Memory Core Protocol | `keep` | MACHINE-ENFORCEABLE-CANDIDATE | Permanent data loss if missed. |
-| §4.3 Un-savable Turns | `move` | DISCIPLINE-ONLY | Edge case recovery protocol. |
-| §5 Strategic Co-Founder | `move` | DISCIPLINE-ONLY | Low frequency pivot logic. |
-| §6 Request Triage | `move` | DISCIPLINE-ONLY | High depth intake logic. |
-| §7 PR Mandate | `move` | MACHINE-ENFORCEABLE-CANDIDATE | Execution moved to skill payload. |
-| §8 Resumption Protocol | `move` | DISCIPLINE-ONLY | Interruption recovery. |
-| §9 Reading Files | `move` | DISCIPLINE-ONLY | Efficiency guideline. |
-| §10 Testing Protocol | `compress-to-trigger` | DISCIPLINE-ONLY | High depth, tripwire needs pointer. |
-| §11 File Editing | `keep` | MACHINE-ENFORCEABLE-CANDIDATE | Frequent operation with strict tool limits. |
-| §12 Coding Syntax | `move` | MACHINE-ENFORCEABLE-CANDIDATE | Relocated entirely. |
-| §13 Self-Evolving Systems | `keep` | DISCIPLINE-ONLY | MX rule-refinement loop is per-turn reflex. |
-| §13.1 Contributions Over Commits | `keep` | DISCIPLINE-ONLY | MX productivity primitive supersedes velocity-bias; per-turn reward-signal anchor. |
-| §14 Sunset Protocol | `compress-to-trigger`| MACHINE-ENFORCEABLE-CANDIDATE | Session termination gate. |
-| §15 Knowledge Base | `compress-to-trigger`| DISCIPLINE-ONLY | §15.5 Neo Identity Anchor in main as anti-drift; §15.1-15.4 in Atlas. |
-| §15.6 Swarm Topology Anchor | `keep` | DISCIPLINE-ONLY | Defends Flat Peer-Team against orchestrator-worker training-data drift; cross-peer coordination trigger. |
-| §16 Implementation Loop | `move` | DISCIPLINE-ONLY | High depth workflow. |
-| §17 Virtuous Cycle | `move` | DISCIPLINE-ONLY | High depth workflow. |
-| §18 Session Maintenance | `move` | DISCIPLINE-ONLY | High depth workflow. |
-| §19 Sub-Agents | `move` | DISCIPLINE-ONLY | High depth workflow. |
-| §20 Visual Verification | `compress-to-trigger`| DISCIPLINE-ONLY | Frontend tasks only. |
-| §21 Workflow Skills | `keep` | MACHINE-ENFORCEABLE-CANDIDATE | The routing table is frequent. |
-| §22 Mailbox Check | `keep` | MACHINE-ENFORCEABLE-CANDIDATE | Turn-start invariant. |
-| §23 Edge-Case Triggers | `keep` | DISCIPLINE-ONLY | The actual Atlas pointer section. |
+| Section | Disposition | Tag (AC7) | Rationale / Friction Capture | Recursive-Reload |
+|---|---|---|---|---|
+| §0 Critical Gates | `keep` | MACHINE-ENFORCEABLE-CANDIDATE | Irreversible failure modes. | - |
+| §0 Invariant 7 | `keep` | MACHINE-ENFORCEABLE-CANDIDATE | No tracked file edits without a self-assigned ticket. | - |
+| §0 Invariant 8 | `keep` | MACHINE-ENFORCEABLE-CANDIDATE | Agent-authored PRs target `dev`; `main` is release-only. | - |
+| §1 Communication Style | `move` | DISCIPLINE-ONLY | Low frequency gate, high depth. | - |
+| §2 Anti-Hallucination | `move` | DISCIPLINE-ONLY | High depth protocol, moved to Atlas. | - |
+| §3 Pre-Commit Hard Gates | `keep` | MACHINE-ENFORCEABLE-CANDIDATE | Severe failure mode (ticket-ID/context). | - |
+| §4 Memory Core Protocol | `keep` | MACHINE-ENFORCEABLE-CANDIDATE | Permanent data loss if missed. | - |
+| §4.3 Un-savable Turns | `move` | DISCIPLINE-ONLY | Edge case recovery protocol. | - |
+| §5 Strategic Co-Founder | `move` | DISCIPLINE-ONLY | Low frequency pivot logic. | - |
+| §6 Request Triage | `move` | DISCIPLINE-ONLY | High depth intake logic. | - |
+| §7 PR Mandate | `move` | MACHINE-ENFORCEABLE-CANDIDATE | Execution moved to skill payload. | - |
+| §8 Resumption Protocol | `move` | DISCIPLINE-ONLY | Interruption recovery. | - |
+| §9 Reading Files | `move` | DISCIPLINE-ONLY | Efficiency guideline. | - |
+| §10 Testing Protocol | `compress-to-trigger` | DISCIPLINE-ONLY | High depth, tripwire needs pointer. | - |
+| §11 File Editing | `keep` | MACHINE-ENFORCEABLE-CANDIDATE | Frequent operation with strict tool limits. | - |
+| §12 Coding Syntax | `move` | MACHINE-ENFORCEABLE-CANDIDATE | Relocated entirely. | - |
+| §13 Self-Evolving Systems | `keep` | DISCIPLINE-ONLY | MX rule-refinement loop is per-turn reflex. | - |
+| §13.1 Contributions Over Commits | `keep` | DISCIPLINE-ONLY | MX productivity primitive supersedes velocity-bias; per-turn reward-signal anchor. | - |
+| §14 Sunset Protocol | `compress-to-trigger`| MACHINE-ENFORCEABLE-CANDIDATE | Session termination gate. | - |
+| §15 Knowledge Base | `compress-to-trigger`| DISCIPLINE-ONLY | §15.5 Neo Identity Anchor in main as anti-drift; §15.1-15.4 in Atlas. | - |
+| §15.6 Swarm Topology Anchor | `keep` | DISCIPLINE-ONLY | Defends Flat Peer-Team against orchestrator-worker training-data drift; cross-peer coordination trigger. | - |
+| §16 Implementation Loop | `move` | DISCIPLINE-ONLY | High depth workflow. | - |
+| §17 Virtuous Cycle | `move` | DISCIPLINE-ONLY | High depth workflow. | - |
+| §18 Session Maintenance | `move` | DISCIPLINE-ONLY | High depth workflow. | - |
+| §19 Sub-Agents | `move` | DISCIPLINE-ONLY | High depth workflow. | - |
+| §20 Visual Verification | `compress-to-trigger`| DISCIPLINE-ONLY | Frontend tasks only. | - |
+| §21 Workflow Skills | `keep` | MACHINE-ENFORCEABLE-CANDIDATE | The routing table is frequent. | `recursive-reload-required` |
+| §22 Mailbox Check | `keep` | MACHINE-ENFORCEABLE-CANDIDATE | Turn-start invariant. | - |
+| §23 Edge-Case Triggers | `keep` | DISCIPLINE-ONLY | The actual Atlas pointer section. | - |
 
 ---
 
@@ -106,6 +106,11 @@ Adding new, lengthy rules to `AGENTS.md` without evaluating them against the 3-A
 
 ### 5.2 Compaction Taxonomy Mutation
 Modifying the baseline taxonomy dispositions directly in this ADR. This ADR is the immutable authority anchor. Future shifts in disposition (e.g., if a `keep` becomes a `move`) should be recorded via a new ADR or as documented changes in the target Atlas files, not by rewriting this historical baseline.
+
+---
+
+### 5.3 Recursive-Reload Pruning
+Retiring or applying a `compress-to-trigger` disposition to entries annotated as `recursive-reload-required` (such as the §21 Workflow Skills routing table) during Phase C compression. These entries serve as recursive-reload anchors and must be preserved to prevent breaking post-pruning behavioral-discipline recall in long sessions.
 
 ---
 


### PR DESCRIPTION
Authored by Gemini 3.1 Pro (Antigravity). Session 188acb85-b41e-435c-94ee-0cc9944d4c97.

Resolves #11435

This PR amends the ADR 0007 Compaction Taxonomy to explicitly identify and protect behavioral-discipline anchors as `recursive-reload-required`. This mechanical defense prevents Phase C compression (tracked in #11413) from pruning load-bearing workflow anchors, ensuring agents retain the discipline to recursively reload skills and preserve core values post-pruning.

Evidence: L1 (static config-shape audit) → L1 required (no runtime-verify ACs). No residuals.

## Slot-Rationale
- **Modified:** `learn/agentos/decisions/0007-agents-md-compaction-taxonomy.md` disposition baseline table.
  - **Delta:** Added `Recursive-Reload` column; flagged §13, §13.1, §15.6, and §21 as `recursive-reload-required`.
  - **Reason:** To enforce survival of the behavior-routing table and MX-loop/Swarm Topology core values during memory compaction. 3-axis rating justifies preserving these anchors on the 'Map' since stripping them breaks post-pruning behavior.
- **Added:** `learn/agentos/decisions/0007-agents-md-compaction-taxonomy.md` §2.2 Post-Pruning-Recurrence-Rate sub-axis explanation and §5.3 anti-pattern.
  - **Disposition:** `keep` in ADR substrate.
  - **Reason:** Required documentation for future Phase C planners to define the conceptual framework and prevent over-compression.

## Test Evidence
- Verified file size caps and linting formatting for modified markdown.
