### PR TITLE
build(ai): block substantive growth on oversized workflow maps (#11437)

### DIFF
--- a/.agents/skills/skills.manifest.json
+++ b/.agents/skills/skills.manifest.json
@@ -6,6 +6,11 @@
     "routerByteBudget": 12,
     "payloadBudget": 80000,
     "perFilePayloadBudget": 25000,
+    "oversizedWorkflowMaps": [
+      ".agents/skills/pr-review/references/pr-review-guide.md",
+      ".agents/skills/pull-request/references/pull-request-workflow.md"
+    ],
+    "maxPositiveDeltaBytes": 250,
     "rareTriggerPatterns": [
       "openapi",
       "audit",

--- a/.agents/skills/skills.manifest.schema.json
+++ b/.agents/skills/skills.manifest.schema.json
@@ -21,6 +21,18 @@
       "required": ["routerByteBudget", "payloadBudget", "claudeSymlinkRequired", "downstreamDocsTargets"],
       "additionalProperties": false,
       "properties": {
+        "oversizedWorkflowMaps": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "List of files that are historically oversized and locked against substantive positive growth."
+        },
+        "maxPositiveDeltaBytes": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Allowed net-positive bytes (for 1-line pointers) on oversized files. Typical pointer is ~150 bytes."
+        },
         "routerByteBudget": {
           "type": "integer",
           "minimum": 1

--- a/ai/scripts/lint-skill-manifest.mjs
+++ b/ai/scripts/lint-skill-manifest.mjs
@@ -380,6 +380,24 @@ function changedSkillNames(base) {
     return names;
 }
 
+function checkOversizedWorkflowMaps(changedFiles, oversizedFiles, maxDelta, getSizeFn, getBaseSizeFn) {
+    const errors = [];
+    for (const file of changedFiles) {
+        if (oversizedFiles.includes(file)) {
+            const currentSize = getSizeFn(file);
+            if (currentSize === null) continue;
+
+            const baseSize = getBaseSizeFn(file);
+            const delta = currentSize - baseSize;
+
+            if (delta > maxDelta) {
+                errors.push(`Oversized workflow map ${file} grew by ${delta} bytes (max allowed delta is ${maxDelta}). Extract substantive additions to a sibling file behind a one-line trigger pointer.`);
+            }
+        }
+    }
+    return errors;
+}
+
 async function lint({base = null} = {}) {
     const schema       = readJson(SCHEMA_PATH);
     const manifest     = readJson(MANIFEST_PATH);
@@ -397,23 +415,21 @@ async function lint({base = null} = {}) {
     if (base) {
         const oversizedFiles = manifest.defaults.oversizedWorkflowMaps || [];
         const maxDelta = manifest.defaults.maxPositiveDeltaBytes || 0;
-        
-        for (const file of changed) {
-            if (oversizedFiles.includes(file)) {
-                let currentSize = 0;
+
+        const oversizedErrors = checkOversizedWorkflowMaps(
+            changed,
+            oversizedFiles,
+            maxDelta,
+            (file) => {
                 try {
-                    currentSize = statSync(path.join(ROOT_DIR, file)).size;
+                    return statSync(path.join(ROOT_DIR, file)).size;
                 } catch(e) {
-                    continue; // File deleted, delta is negative
+                    return null;
                 }
-                const baseSize = getBaseFileSize(base, file);
-                const delta = currentSize - baseSize;
-                
-                if (delta > maxDelta) {
-                    errors.push(`Oversized workflow map ${file} grew by ${delta} bytes (max allowed delta is ${maxDelta}). Extract substantive additions to a sibling file behind a one-line trigger pointer.`);
-                }
-            }
-        }
+            },
+            (file) => getBaseFileSize(base, file)
+        );
+        errors.push(...oversizedErrors);
     }
 
     for (const skillName of skillDirs) {
@@ -501,4 +517,4 @@ if (process.argv[1] && path.resolve(process.argv[1]) === __filename) {
     });
 }
 
-export {checkPerFileBudgets, checkSectionTriggers, parseSectionTriggers, lint, parseArgs, parseFrontmatter, validateManifestSchema};
+export {checkOversizedWorkflowMaps, checkPerFileBudgets, checkSectionTriggers, parseSectionTriggers, lint, parseArgs, parseFrontmatter, validateManifestSchema};

--- a/ai/scripts/lint-skill-manifest.mjs
+++ b/ai/scripts/lint-skill-manifest.mjs
@@ -238,6 +238,20 @@ function validateManifestSchema(manifest, schema) {
         }
     }
 
+    if ('oversizedWorkflowMaps' in defaults) {
+        if (!Array.isArray(defaults.oversizedWorkflowMaps)) {
+            errors.push('defaults.oversizedWorkflowMaps must be an array of strings');
+        } else {
+            for (const p of defaults.oversizedWorkflowMaps) {
+                if (typeof p !== 'string') errors.push('defaults.oversizedWorkflowMaps must be an array of strings');
+            }
+        }
+    }
+
+    if ('maxPositiveDeltaBytes' in defaults && (!Number.isInteger(defaults.maxPositiveDeltaBytes) || defaults.maxPositiveDeltaBytes < 0)) {
+        errors.push('defaults.maxPositiveDeltaBytes must be a non-negative integer when set');
+    }
+
     if (typeof defaults.claudeSymlinkRequired !== 'boolean') {
         errors.push('defaults.claudeSymlinkRequired must be boolean');
     }
@@ -342,6 +356,19 @@ function changedFiles(base) {
     }
 }
 
+function getBaseFileSize(base, filePath) {
+    try {
+        const output = execFileSync('git', ['cat-file', '-s', `${base}:${filePath}`], {
+            cwd     : ROOT_DIR,
+            encoding: 'utf8',
+            stdio   : 'pipe'
+        });
+        return parseInt(output.trim(), 10) || 0;
+    } catch (error) {
+        return 0;
+    }
+}
+
 function changedSkillNames(base) {
     const names = new Set();
 
@@ -366,6 +393,28 @@ async function lint({base = null} = {}) {
 
     const changed = new Set(changedFiles(base));
     const touchedSkillNames = changedSkillNames(base);
+
+    if (base) {
+        const oversizedFiles = manifest.defaults.oversizedWorkflowMaps || [];
+        const maxDelta = manifest.defaults.maxPositiveDeltaBytes || 0;
+        
+        for (const file of changed) {
+            if (oversizedFiles.includes(file)) {
+                let currentSize = 0;
+                try {
+                    currentSize = statSync(path.join(ROOT_DIR, file)).size;
+                } catch(e) {
+                    continue; // File deleted, delta is negative
+                }
+                const baseSize = getBaseFileSize(base, file);
+                const delta = currentSize - baseSize;
+                
+                if (delta > maxDelta) {
+                    errors.push(`Oversized workflow map ${file} grew by ${delta} bytes (max allowed delta is ${maxDelta}). Extract substantive additions to a sibling file behind a one-line trigger pointer.`);
+                }
+            }
+        }
+    }
 
     for (const skillName of skillDirs) {
         const skill     = manifest.skills[skillName];

--- a/test/playwright/unit/ai/scripts/lintSkillManifest.spec.mjs
+++ b/test/playwright/unit/ai/scripts/lintSkillManifest.spec.mjs
@@ -3,6 +3,7 @@ import {execFileSync, spawnSync} from 'child_process';
 import path                      from 'path';
 
 import {
+    checkOversizedWorkflowMaps,
     checkPerFileBudgets,
     checkSectionTriggers,
     parseArgs,
@@ -351,5 +352,56 @@ ${padding}
         expect(index[0].trigger).toBe('test condition');
         expect(index[0].subRulePath).toBe('./test-rule.md');
         expect(index[0].bodySizeBytes).toBeGreaterThan(100);
+    });
+
+    test('checkOversizedWorkflowMaps passes when one-line pointer addition is within maxPositiveDeltaBytes (#11437)', () => {
+        const changedFiles = new Set(['pr-review-guide.md', 'some-other-file.md']);
+        const oversizedFiles = ['pr-review-guide.md', 'pull-request-workflow.md'];
+        const maxDelta = 250;
+
+        const getSizeFn = (file) => file === 'pr-review-guide.md' ? 1200 : 0;
+        const getBaseSizeFn = (file) => file === 'pr-review-guide.md' ? 1000 : 0; // Delta: 200
+
+        const errors = checkOversizedWorkflowMaps(changedFiles, oversizedFiles, maxDelta, getSizeFn, getBaseSizeFn);
+        expect(errors).toEqual([]);
+    });
+
+    test('checkOversizedWorkflowMaps fails when PR #11434-style inline addition exceeds maxPositiveDeltaBytes (#11437)', () => {
+        const changedFiles = new Set(['pull-request-workflow.md']);
+        const oversizedFiles = ['pr-review-guide.md', 'pull-request-workflow.md'];
+        const maxDelta = 250;
+
+        const getSizeFn = (file) => 1500;
+        const getBaseSizeFn = (file) => 1000; // Delta: 500
+
+        const errors = checkOversizedWorkflowMaps(changedFiles, oversizedFiles, maxDelta, getSizeFn, getBaseSizeFn);
+        expect(errors).toHaveLength(1);
+        expect(errors[0]).toContain('Oversized workflow map pull-request-workflow.md grew by 500 bytes (max allowed delta is 250).');
+        expect(errors[0]).toContain('Extract substantive additions to a sibling file behind a one-line trigger pointer.');
+    });
+
+    test('checkOversizedWorkflowMaps fails when long pr-review-guide.md anti-pattern row exceeds maxPositiveDeltaBytes (#11437)', () => {
+        const changedFiles = new Set(['pr-review-guide.md']);
+        const oversizedFiles = ['pr-review-guide.md'];
+        const maxDelta = 250;
+
+        const getSizeFn = (file) => 2300;
+        const getBaseSizeFn = (file) => 1000; // Delta: 1300
+
+        const errors = checkOversizedWorkflowMaps(changedFiles, oversizedFiles, maxDelta, getSizeFn, getBaseSizeFn);
+        expect(errors).toHaveLength(1);
+        expect(errors[0]).toContain('Oversized workflow map pr-review-guide.md grew by 1300 bytes');
+    });
+
+    test('checkOversizedWorkflowMaps ignores deleted oversized files', () => {
+        const changedFiles = new Set(['pr-review-guide.md']);
+        const oversizedFiles = ['pr-review-guide.md'];
+        const maxDelta = 250;
+
+        const getSizeFn = (file) => null; // File deleted
+        const getBaseSizeFn = (file) => 1000;
+
+        const errors = checkOversizedWorkflowMaps(changedFiles, oversizedFiles, maxDelta, getSizeFn, getBaseSizeFn);
+        expect(errors).toEqual([]);
     });
 });


### PR DESCRIPTION
## Summary
Fixes #11437. Extends the `lint-skill-manifest` CI script to natively detect and block substantive positive growth on designated oversized workflow maps.

## Substrate Validation
- **Schema Update:** Extends `skills.manifest.schema.json` to support `oversizedWorkflowMaps` array and `maxPositiveDeltaBytes` ceiling.
- **Manifest Baseline:** Adds `pr-review-guide.md` and `pull-request-workflow.md` to the oversized constraint, allocating 250 bytes of growth strictly for one-line trigger pointers.
- **Delta Awareness:** Harnesses `git cat-file -s` against `--base` to catch multi-line bloat while honoring structural sub-rule extraction limits.
- **Regression Coverage:** Extracted linting logic into the highly testable `checkOversizedWorkflowMaps()` function and added Playwright unit testing. Verified 21/21 passing local tests. Includes tests for within-budget positive deltas, violations, and negative deltas (file deletions).
- **Diff Hygiene:** Verified and removed all trailing whitespace from `lint-skill-manifest.mjs`, ensuring clean `git diff --check` output.

## Context
See #11437 for PR #11434 regression rationale. This enforces the Map vs World Atlas constraint directly in CI, ensuring new sub-rules are structurally extracted rather than appended inline.
