### PR TITLE
feat(ai): refine SkillSource trigger-pointer sub-rules (#11334)

### DIFF
--- a/ai/services/knowledge-base/source/SkillSource.mjs
+++ b/ai/services/knowledge-base/source/SkillSource.mjs
@@ -3,13 +3,14 @@ import fs       from 'fs-extra';
 import path     from 'path';
 import fg       from 'fast-glob';
 import aiConfig from '../../../mcp/server/knowledge-base/config.mjs';
+import {parseSectionTriggers} from '../../../scripts/lint-skill-manifest.mjs';
 
 /**
  * @summary Extracts knowledge chunks from Skill Markdown files.
  *
  * This source provider scans the `.agents/skills` directory for Markdown files.
  * It chunks documents by headers and extracts sub-metadata like `skillName`,
- * `sectionAnchor`, and `triggerCondition`.
+ * `sectionAnchor`, `triggerCondition`, and trigger-pointer sub-rule metadata.
  *
  * @class Neo.ai.services.knowledge-base.source.SkillSource
  * @extends Neo.ai.services.knowledge-base.source.Base
@@ -44,13 +45,19 @@ class SkillSource extends Base {
             const pattern = path.join(skillsBasePath, '**/*.md').replace(/\\/g, '/');
             const skillFiles = await fg(pattern);
 
+            const triggerTargetPathsBySkill = await this.collectTriggerTargetPathsBySkill(skillFiles, skillsBasePath);
+
             for (const filePath of skillFiles) {
                 const content = await fs.readFile(filePath, 'utf-8');
                 const relativePath = path.relative(aiConfig.neoRootDir, filePath);
                 const skillRelativePath       = path.relative(skillsBasePath, filePath);
                 const pathParts               = skillRelativePath.split(path.sep);
                 const skillFolder             = pathParts[0];
-                const isAtlasMonolithSubRule  = pathParts.includes('references');
+                const skillTriggerTargets     = triggerTargetPathsBySkill.get(skillFolder);
+                const normalizedSkillPath     = this.normalizeRelativePath(skillRelativePath);
+                const isAtlasMonolithSubRule  = skillTriggerTargets?.size
+                    ? skillTriggerTargets.has(normalizedSkillPath)
+                    : pathParts.includes('references');
 
                 let skillName = skillFolder;
                 let triggerCondition = '';
@@ -106,6 +113,49 @@ class SkillSource extends Base {
         }
 
         return count;
+    }
+
+    /**
+     * Builds a per-skill set of files targeted by trigger-pointer comments.
+     * @param {String[]} skillFiles      Absolute skill markdown file paths.
+     * @param {String}   skillsBasePath Absolute `.agents/skills` path.
+     * @returns {Promise<Map<String, Set<String>>>}
+     */
+    async collectTriggerTargetPathsBySkill(skillFiles, skillsBasePath) {
+        const targetPathsBySkill = new Map();
+
+        for (const filePath of skillFiles) {
+            const skillRelativePath = path.relative(skillsBasePath, filePath);
+            const pathParts         = skillRelativePath.split(path.sep);
+            const skillFolder       = pathParts[0];
+            const content           = await fs.readFile(filePath, 'utf-8');
+            const sectionTriggers   = parseSectionTriggers(content);
+
+            if (!sectionTriggers.length) continue;
+
+            const skillTargets = targetPathsBySkill.get(skillFolder) || new Set();
+            targetPathsBySkill.set(skillFolder, skillTargets);
+
+            for (const {subRulePath} of sectionTriggers) {
+                const targetPath     = path.resolve(path.dirname(filePath), subRulePath);
+                const targetRelative = this.normalizeRelativePath(path.relative(skillsBasePath, targetPath));
+
+                if (!targetRelative.startsWith(`${skillFolder}/`)) continue;
+
+                skillTargets.add(targetRelative);
+            }
+        }
+
+        return targetPathsBySkill;
+    }
+
+    /**
+     * Normalizes relative filesystem paths for trigger-target matching.
+     * @param {String} filePath Relative file path.
+     * @returns {String}
+     */
+    normalizeRelativePath(filePath) {
+        return filePath.split(path.sep).join('/');
     }
 }
 

--- a/test/playwright/unit/ai/services/knowledge-base/source/SkillSource.spec.mjs
+++ b/test/playwright/unit/ai/services/knowledge-base/source/SkillSource.spec.mjs
@@ -41,7 +41,8 @@ test.describe('Neo.ai.services.knowledge-base.source.SkillSource', () => {
         mockRoot = path.join(tmpDir, `skill-source-mock-${process.pid}-${Date.now()}`);
 
         const skillsDir = path.join(mockRoot, '.agents/skills');
-        fs.ensureDirSync(path.join(skillsDir, 'ideation-sandbox/references'));
+        fs.ensureDirSync(path.join(skillsDir, 'ideation-sandbox/references/audits'));
+        fs.ensureDirSync(path.join(skillsDir, 'legacy-skill/references'));
         fs.ensureDirSync(path.join(skillsDir, 'simple-skill'));
 
         // Monolith SKILL.md with YAML frontmatter
@@ -58,17 +59,27 @@ Ideation description.
 1. Do this
 2. Do that`);
 
-        // Sub-rule workflow.md without YAML
+        // Workflow map with a trigger-pointer target
         fs.writeFileSync(path.join(skillsDir, 'ideation-sandbox/references/workflow.md'),
-`# Stage 1
+`## Stage 1
+<!-- trigger: edge-case validation → read ./audits/rare-rule.md -->
 Stage 1 details.
-# Stage 2
+## Stage 2
 Stage 2 details.`);
+
+        fs.writeFileSync(path.join(skillsDir, 'ideation-sandbox/references/audits/rare-rule.md'),
+`# Rare Rule
+Rare rule details.`);
 
         // Simple skill without YAML
         fs.writeFileSync(path.join(skillsDir, 'simple-skill/SKILL.md'),
 `# Simple
 Simple skill contents.`);
+
+        // Legacy reference payload without trigger-pointer metadata keeps fallback behavior.
+        fs.writeFileSync(path.join(skillsDir, 'legacy-skill/references/legacy.md'),
+`# Legacy
+Legacy skill payload.`);
 
         aiConfig.neoRootDir = mockRoot;
     });
@@ -98,9 +109,11 @@ Simple skill contents.`);
 
         // ideation-sandbox SKILL.md -> Overview chunk + Rules chunk (2)
         // ideation-sandbox workflow.md -> Stage 1 + Stage 2 (2)
+        // ideation-sandbox rare-rule.md -> Rare Rule (1)
         // simple-skill SKILL.md -> Simple (1)
-        expect(count).toBe(5);
-        expect(written).toHaveLength(5);
+        // legacy-skill legacy.md -> Legacy (1)
+        expect(count).toBe(7);
+        expect(written).toHaveLength(7);
 
         const ideationChunks = written.filter(w => w.skillName === 'custom-ideation');
         expect(ideationChunks).toHaveLength(2);
@@ -122,12 +135,20 @@ Simple skill contents.`);
         const workflowChunks = written.filter(w => w.skillName === 'ideation-sandbox' && w.sectionAnchor.startsWith('Stage'));
         expect(workflowChunks).toHaveLength(2);
         expect(workflowChunks[0].triggerCondition).toBe('');
-        expect(workflowChunks.every(w => w.isAtlasMonolithSubRule)).toBe(true);
+        expect(workflowChunks.every(w => !w.isAtlasMonolithSubRule)).toBe(true);
+
+        const rareRuleChunk = written.find(w => w.source.endsWith('rare-rule.md'));
+        expect(rareRuleChunk).toBeDefined();
+        expect(rareRuleChunk.isAtlasMonolithSubRule).toBe(true);
 
         const simpleChunk = written.find(w => w.skillName === 'simple-skill');
         expect(simpleChunk).toBeDefined();
         expect(simpleChunk.triggerCondition).toBe('');
         expect(simpleChunk.isAtlasMonolithSubRule).toBe(false);
+
+        const legacyChunk = written.find(w => w.skillName === 'legacy-skill');
+        expect(legacyChunk).toBeDefined();
+        expect(legacyChunk.isAtlasMonolithSubRule).toBe(true);
     });
 
     test('extract() returns 0 and writes nothing when the skills directory is absent', async () => {


### PR DESCRIPTION
Authored by GPT-5.5 (Codex Desktop). Session e03c75a3-6468-4e23-bd05-b1ce8a4a563e.

Resolves #11334

Refines `SkillSource` so `isAtlasMonolithSubRule` no longer treats every `references/**` file as an extracted sub-rule once trigger-pointer metadata exists. The source now reuses the existing `lint-skill-manifest.mjs` section-trigger parser, builds per-skill trigger-target sets, marks only declared trigger-pointer targets as sub-rules, and preserves the conservative `references/**` fallback for legacy skills without trigger pointers.

Related: #11317
Related: #11320

## Deltas From Ticket

- Uses the shipped #11320 parser directly instead of adding a second parser implementation.
- Keeps the first increment to `SkillSource` + focused unit coverage; no broader KB schema or sync changes.

## Test Evidence

- `npm run test-unit -- test/playwright/unit/ai/services/knowledge-base/source/SkillSource.spec.mjs` — 3 passed.
- `git diff --check origin/dev...HEAD` — passed.
- `node ai/scripts/lint-skill-manifest.mjs --base origin/dev` — passed.

## Post-Merge Validation

- [ ] Next `npm run ai:sync-kb` output for skill chunks marks workflow-map reference files as non-sub-rule when trigger-pointer targets exist.
