### PR TITLE
feat(github-workflow/sync): retire PR archiveVersion metadata carry-forward (#11364)

### DIFF
--- a/ai/services/github-workflow/sync/MetadataManager.mjs
+++ b/ai/services/github-workflow/sync/MetadataManager.mjs
@@ -102,14 +102,13 @@ class MetadataManager extends Base {
         // Prune pulls
         for (const [key, value] of Object.entries(metadata.pulls || {})) {
             prunedMetadata.pulls[key] = {
-                state         : value.state,
-                path          : value.path,
-                closedAt      : value.closedAt,
-                mergedAt      : value.mergedAt,
-                milestone     : value.milestone,
-                archiveVersion: value.archiveVersion,
-                updatedAt     : value.updatedAt,
-                contentHash   : value.contentHash
+                state      : value.state,
+                path       : value.path,
+                closedAt   : value.closedAt,
+                mergedAt   : value.mergedAt,
+                milestone  : value.milestone,
+                updatedAt  : value.updatedAt,
+                contentHash: value.contentHash
             };
         }
 

--- a/ai/services/github-workflow/sync/PullRequestSyncer.mjs
+++ b/ai/services/github-workflow/sync/PullRequestSyncer.mjs
@@ -82,41 +82,33 @@ class PullRequestSyncer extends Base {
      */
     #planBuckets(metadata, fetchedPullRequests = []) {
         const combined = new Map();
-        
+
         for (const [idStr, pr] of Object.entries(metadata.pulls || {})) {
             combined.set(parseInt(idStr, 10), {
-                number        : parseInt(idStr, 10),
-                state         : pr.state,
-                milestone     : pr.milestone ? { title: pr.milestone } : null,
-                closedAt      : pr.closedAt,
-                mergedAt      : pr.mergedAt,
-                archiveVersion: pr.archiveVersion
+                number   : parseInt(idStr, 10),
+                state    : pr.state,
+                milestone: pr.milestone ? { title: pr.milestone } : null,
+                closedAt : pr.closedAt,
+                mergedAt : pr.mergedAt
             });
         }
-        
-        for (const pr of fetchedPullRequests) {
-            const cached = metadata.pulls?.[pr.number];
 
+        for (const pr of fetchedPullRequests) {
             combined.set(pr.number, {
-                number        : pr.number,
-                state         : pr.state,
-                milestone     : pr.milestone,
-                closedAt      : pr.closedAt,
-                mergedAt      : pr.mergedAt,
-                archiveVersion: cached?.archiveVersion
+                number   : pr.number,
+                state    : pr.state,
+                milestone: pr.milestone,
+                closedAt : pr.closedAt,
+                mergedAt : pr.mergedAt
             });
         }
-        
+
         const buckets = new Map();
         const activeItems = [];
-        
+
         for (const pr of combined.values()) {
             let version = null;
-            if (pr.archiveVersion) {
-                version = pr.archiveVersion.startsWith(issueSyncConfig.versionDirectoryPrefix)
-                    ? pr.archiveVersion
-                    : issueSyncConfig.versionDirectoryPrefix + pr.archiveVersion;
-            } else if (pr.milestone?.title) {
+            if (pr.milestone?.title) {
                 version = pr.milestone.title.startsWith(issueSyncConfig.versionDirectoryPrefix)
                     ? pr.milestone.title
                     : issueSyncConfig.versionDirectoryPrefix + pr.milestone.title;
@@ -342,15 +334,14 @@ class PullRequestSyncer extends Base {
             const plan = planBuckets.get(p.number);
 
             metadata.pulls[p.number] = {
-                number        : p.number,
-                contentHash   : p.contentHash,
-                state         : p.state,
-                updatedAt     : p.updatedAt,
-                closedAt      : p.closedAt || null,
-                mergedAt      : p.mergedAt || null,
-                milestone     : p.milestone?.title || null,
-                archiveVersion: p.state === 'OPEN' ? null : plan?.version || null,
-                path          : p.relativeOutputPath
+                number     : p.number,
+                contentHash: p.contentHash,
+                state      : p.state,
+                updatedAt  : p.updatedAt,
+                closedAt   : p.closedAt || null,
+                mergedAt   : p.mergedAt || null,
+                milestone  : p.milestone?.title || null,
+                path       : p.relativeOutputPath
             };
 
             indexEntries.push(createContentIndexEntry({

--- a/test/playwright/unit/ai/services/github-workflow/MetadataManager.spec.mjs
+++ b/test/playwright/unit/ai/services/github-workflow/MetadataManager.spec.mjs
@@ -119,7 +119,9 @@ test.describe('Neo.ai.services.github-workflow.sync.MetadataManager', () => {
         expect(loaded.pulls['789'].extraFieldShouldBePruned).toBeUndefined();
         expect(loaded.pulls['789'].mergedAt).toBe('2026-05-13T00:00:00Z');
         expect(loaded.pulls['789'].milestone).toBe('v1.0.0');
-        expect(loaded.pulls['789'].archiveVersion).toBe('v1.0.0');
+        // archiveVersion is intentionally pruned post-#11364: archive routing must derive
+        // from current GitHub state (milestone/release-chronology), not from carried metadata.
+        expect(loaded.pulls['789'].archiveVersion).toBeUndefined();
         expect(loaded.pulls['789'].contentHash).toBe('hash3');
 
         // Backward compat

--- a/test/playwright/unit/ai/services/github-workflow/PullRequestSyncer.spec.mjs
+++ b/test/playwright/unit/ai/services/github-workflow/PullRequestSyncer.spec.mjs
@@ -68,8 +68,12 @@ test.describe('Neo.ai.services.github-workflow.sync.PullRequestSyncer', () => {
         await fs.remove(tmpRoot).catch(() => {});
     });
 
-    test('preserves cached archiveVersion for migrated closed PR paths', async () => {
+    test('drops archiveVersion carry-forward: stale cached value cannot force placement, field is no longer serialized', async () => {
         const prNumber = 12345;
+        // Stale cached metadata claims v13.0.0. Under post-#11360 contract this must NOT
+        // drive routing: the PR has no milestone and no subsequent release in
+        // ReleaseNotesSyncer.sortedReleases (empty per beforeEach), so the syncer must
+        // route to the active path and the serialized metadata must omit archiveVersion.
         const metadata = {
             pulls: {
                 [prNumber]: {
@@ -78,7 +82,7 @@ test.describe('Neo.ai.services.github-workflow.sync.PullRequestSyncer', () => {
                     closedAt      : '2026-05-01T00:00:00Z',
                     mergedAt      : '2026-05-01T00:00:00Z',
                     archiveVersion: 'v13.0.0',
-                    path          : `resources/content/pr-archive/123xx/pr-${prNumber}.md`
+                    path          : `resources/content/pr-archive/v13.0.0/chunk-1/pr-${prNumber}.md`
                 }
             }
         };
@@ -86,30 +90,59 @@ test.describe('Neo.ai.services.github-workflow.sync.PullRequestSyncer', () => {
         GraphqlService.query = async () => ({
             repository: {
                 pullRequests: {
-                    nodes: [buildPullRequest(prNumber)],
-                    pageInfo: {
-                        hasNextPage: false,
-                        endCursor  : null
-                    }
+                    nodes   : [buildPullRequest(prNumber)],
+                    pageInfo: {hasNextPage: false, endCursor: null}
                 }
             }
         });
 
         const stats = await PullRequestSyncer.syncPullRequests(metadata);
-        const chunkNumber = 1;
-        const targetPath = path.join(aiConfig.issueSync.archiveRoot, 'pulls', 'v13.0.0', `chunk-${chunkNumber}`, `pr-${prNumber}.md`);
 
         expect(stats.synced).toEqual([prNumber]);
-        await expect(fs.pathExists(targetPath)).resolves.toBe(true);
-        expect(metadata.pulls[prNumber].archiveVersion).toBe('v13.0.0');
-        expect(metadata.pulls[prNumber].path).toBe(path.relative(aiConfig.projectRoot, targetPath));
+        expect(metadata.pulls[prNumber]).not.toHaveProperty('archiveVersion');
+        expect(metadata.pulls[prNumber].path).not.toContain('v13.0.0');
+    });
+
+    test('derives archive bucket from milestone independent of cached archiveVersion', async () => {
+        const prNumber = 12346;
+        // Stale cached archiveVersion would have routed this PR into v13.0.0/, but the
+        // fresh GraphQL milestone 'v12.1.0' is now the authoritative bucket source.
+        const metadata = {
+            pulls: {
+                [prNumber]: {
+                    state         : 'MERGED',
+                    updatedAt     : '2026-04-01T00:00:00Z',
+                    closedAt      : '2026-04-01T00:00:00Z',
+                    mergedAt      : '2026-04-01T00:00:00Z',
+                    archiveVersion: 'v13.0.0',
+                    path          : `resources/content/pr-archive/v13.0.0/chunk-1/pr-${prNumber}.md`
+                }
+            }
+        };
+
+        GraphqlService.query = async () => ({
+            repository: {
+                pullRequests: {
+                    nodes   : [buildPullRequest(prNumber, {milestone: {title: 'v12.1.0'}})],
+                    pageInfo: {hasNextPage: false, endCursor: null}
+                }
+            }
+        });
+
+        const stats = await PullRequestSyncer.syncPullRequests(metadata);
+
+        expect(stats.synced).toEqual([prNumber]);
+        expect(metadata.pulls[prNumber]).not.toHaveProperty('archiveVersion');
+        expect(metadata.pulls[prNumber].milestone).toBe('v12.1.0');
+        expect(metadata.pulls[prNumber].path).toContain('v12.1.0');
+        expect(metadata.pulls[prNumber].path).not.toContain('v13.0.0');
     });
 });
 
-function buildPullRequest(number) {
+function buildPullRequest(number, overrides = {}) {
     return {
         number,
-        title      : 'Preserve migrated archive version',
+        title      : 'Post-#11360 contract test PR',
         author     : {login: 'neo-test'},
         state      : 'MERGED',
         createdAt  : '2026-05-01T00:00:00Z',
@@ -122,6 +155,7 @@ function buildPullRequest(number) {
         body       : 'Merged body',
         milestone  : null,
         comments   : {nodes: []},
-        reviews    : {nodes: []}
+        reviews    : {nodes: []},
+        ...overrides
     }
 }


### PR DESCRIPTION
Authored by Claude Opus 4.7 (Claude Code). Session 67b4a990-7191-4ebe-8679-513559982ca5.

**FAIR-band stance**: in-band — Phase 1 last-open-sub author-lane pickup for Epic #11372 (ADR 0004); ticket self-assigned 2026-05-14 and untouched since, lane-claim broadcast at A2A `MESSAGE:acc982c1` (2026-05-16T13:22:38Z) with §6.6 source-of-authority collision check passing clean.

## Summary

Retires the `archiveVersion` field carry-forward in `.sync-metadata.json` for PRs. **Phase 1 last-open-sub of Epic #11372** (ADR 0004) — after this lands, Phase 1 stands at 6/6 with only Task 10 (clean-slate purge per ADR 0004 §3.6) remaining before Phase 2 unblocks.

The field predates the Universal Ordinal-100 substrate; it was useful during the #11291 → #11360 migration but is now a regression-vector — stale cached values can override current GitHub state when selecting archive buckets for closed/merged PRs. Per the 2026-05-14 ticket-body update on #11364, this is consistent with ADR 0004 §9 item 4 (config audit) + §9 item 5 (syncer updates) and §3.6 clean-slate framing.

## Post-#11360 contract (anchored by AC#3 + AC#4 + AC#5)

Archive-bucket selection MUST derive from current GitHub state:
1. **Milestone** if present (primary).
2. **Release-chronology** as fallback (mergedAt/closedAt → first release whose `publishedAt` is after).
3. **Active** if neither applies.

Carried `pr.archiveVersion` is no longer consulted. Existing `.sync-metadata.json` files containing residual `archiveVersion` entries are organically cleaned on the next sync run — the prune block no longer serializes the field, the syncer no longer reads it.

## What changes

| File | Delta |
|------|-------|
| `ai/services/github-workflow/sync/MetadataManager.mjs` | Drops `archiveVersion: value.archiveVersion` from the pulls prune block. |
| `ai/services/github-workflow/sync/PullRequestSyncer.mjs` | `#planBuckets`: drops `pr.archiveVersion` carry from cached + fetched combined-map population; removes the `if (pr.archiveVersion)` bucket-selection branch. `syncPullRequests`: drops `archiveVersion` from the metadata write-back. |
| `test/playwright/unit/ai/services/github-workflow/PullRequestSyncer.spec.mjs` | Replaces `preserves cached archiveVersion for migrated closed PR paths` with two new tests (regression-anchor + milestone-primary positive). Extends `buildPullRequest` with optional `overrides`. |
| `test/playwright/unit/ai/services/github-workflow/MetadataManager.spec.mjs` | Flips `archiveVersion` assertion to `.toBeUndefined()` — anchors the new prune contract. |

## V-B-A evidence

- **150/150 github-workflow unit specs pass** (`npm run test-unit -- --grep "github-workflow"` → 4.2s).
- **AC#6 rg check**: `rg "archiveVersion|defaultArchiveVersion|unversioned" ai/services/github-workflow/sync/ test/playwright/unit/ai/services/github-workflow/ -g "*.mjs"` returns ONLY test-fixture inputs (regression-anchor inputs, allowed per AC#6 carve-out) and the historical `unversioned` comments in `IssueSyncer.spec.mjs:200-211` (documenting the bug #11360 already fixed; targeted regression assertion, allowed per AC#6).
- **Both new tests verified passing**:
  - `drops archiveVersion carry-forward: stale cached value cannot force placement, field is no longer serialized` (AC#5 regression-anchor)
  - `derives archive bucket from milestone independent of cached archiveVersion` (positive milestone-primary contract)

## ~~Out-of-scope observation~~ — V-B-A CORRECTED (credit @neo-gemini-3-1-pro)

**The original PR body claimed `ai/mcp/server/github-workflow/config.mjs:117` still declared `defaultArchiveVersion: 'unversioned'` as dead config. This was factually wrong.**

V-B-A correction (credit @neo-gemini-3-1-pro at A2A `MESSAGE:189bf983` 2026-05-16T13:40:19Z): the **committed** `ai/mcp/server/github-workflow/config.template.mjs` on `origin/dev` already had `defaultArchiveVersion` + `archiveDir` retired (via #11363's earlier Phase 1 Task 4 config-audit cleanup). What I observed was a **stale gitignored `config.mjs` bootstrap-copy** in my local worktree that pre-dates the #11363 cleanup. The substrate is already clean. No follow-up needed.

Lesson anchor: V-B-A must check the **tracked** source-of-authority (`config.template.mjs`), not the gitignored bootstrap copy. Worktrees that ran `bootstrapWorktree.mjs` before #11363 merged carry stale local state until re-bootstrapped.

## Avoided traps (echoed from ticket body)

- Did NOT preserve `archiveVersion` because #11282 made it useful; the target substrate (ADR 0004) changed.
- Did NOT remove metadata fields blindly without proving the consumer no longer needs them — `#planBuckets` is now milestone-first then release-chronology, both empirically validated by the milestone-primary test.
- Did NOT encode `v13.0.0` as a special case — the regression-anchor test uses `v13.0.0` as an arbitrary stale-data example; the production code has no version-aware logic.
- Did NOT make `.sync-metadata.json` the authority for archive placement — GitHub state (milestone + release chronology) is now the sole authority.

## Test plan

- [x] All 150 github-workflow unit specs pass locally.
- [x] AC#6 `rg` check passes.
- [x] AC#5 regression-anchor test added + passing.
- [x] AC#4 existing-test rewrite complete + passing.
- [x] Branch-from-`origin/dev`-tip freshness check passed (per pull-request-workflow §2.3.1).
- [ ] CI green (`Tests/integration-unified` pending per @neo-gemini-3-1-pro 13:40Z).
- [ ] Cross-family review APPROVED (Gemini primary; reviewing).
- [ ] `@tobiu` merge.

## Related

- **Parent epic**: #11372 (ADR 0004 implementation)
- **Authority artifact**: `learn/agentos/decisions/0004-github-content-architecture.md` (§9 item 4 + item 5)
- **Sister Phase 1 PRs**: #11381 (Lane A foundation — merged), #11403 (Lane B syncers — merged), #11392 (Lane C consumer — merged), #11407 (Task 6 ReleaseNotesSyncer — merged), #11409 (Task 9 stale-ref cleanup — merged), #11387 (#11363 config audit — merged; THIS was the cleanup my original PR body misattributed)
- **Supersedes** (per ticket body 2026-05-14 update): #11187 Phase 6 framing

Resolves #11364