### PR TITLE
fix(ai): classify orchestrator child logs (#11459)

### DIFF
--- a/ai/daemons/services/ProcessSupervisorService.mjs
+++ b/ai/daemons/services/ProcessSupervisorService.mjs
@@ -182,6 +182,77 @@ export class ProcessSupervisorService extends Base {
     }
 
     /**
+     * Clears the duplicate-running log guard for a task once it starts or exits.
+     * @param {String} taskName Task key.
+     * @returns {void}
+     */
+    clearRunningSkipLogState(taskName) {
+        if (!this.runningSkipLogKeys) {
+            return;
+        }
+
+        const prefix = `${taskName}:`;
+
+        for (const key of this.runningSkipLogKeys) {
+            if (key.startsWith(prefix)) {
+                this.runningSkipLogKeys.delete(key);
+            }
+        }
+    }
+
+    /**
+     * Determines whether an already-running skip should be logged.
+     * @param {String} taskName Task key.
+     * @param {String} reason Scheduling reason.
+     * @param {Number|null} pid Running child process ID.
+     * @returns {Boolean}
+     */
+    shouldLogRunningSkip(taskName, reason, pid) {
+        this.runningSkipLogKeys ??= new Set();
+
+        const key = `${taskName}:${pid ?? 'unknown'}:${reason}`;
+
+        if (this.runningSkipLogKeys.has(key)) {
+            return false;
+        }
+
+        this.runningSkipLogKeys.add(key);
+
+        return true;
+    }
+
+    /**
+     * Maps child-process stderr log prefixes to daemon log severities.
+     * @param {String} line Child stderr line.
+     * @returns {String}
+     */
+    getChildLogLevel(line) {
+        if (/^\[(LOG|INFO)\](?:\s|$)/.test(line)) {
+            return 'INFO';
+        }
+
+        if (/^\[WARN\](?:\s|$)/.test(line)) {
+            return 'WARN';
+        }
+
+        return 'ERROR';
+    }
+
+    /**
+     * Writes child stderr lines using their child-provided severity prefix.
+     * @param {Object} task Task definition.
+     * @param {Buffer|String} data Stderr chunk.
+     * @returns {void}
+     */
+    writeChildStderr(task, data) {
+        const lines = data.toString().split(/\r?\n/).map(line => line.trim()).filter(Boolean);
+
+        for (const line of lines) {
+            this.writeLog?.(this.getChildLogLevel(line), `[ProcessSupervisor] ${task.label} stderr: ${line}`);
+        }
+    }
+
+    /**
      * Starts a child task and wires completion status back into task state and HealthService.
      * @param {String} taskName Task key.
      * @param {String} reason Scheduling reason.
@@ -193,11 +264,14 @@ export class ProcessSupervisorService extends Base {
         const state = this.taskStateService.getTaskState(taskName);
 
         if (state.running) {
-            this.writeLog?.('INFO', `[ProcessSupervisor] Skipping ${task.label}; task already running (PID: ${state.pid}).`);
+            if (this.shouldLogRunningSkip(taskName, reason, state.pid)) {
+                this.writeLog?.('INFO', `[ProcessSupervisor] Skipping ${task.label}; task already running (PID: ${state.pid}).`);
+            }
             this.recordTaskOutcome(taskName, 'skipped', {reason, pid: state.pid, skippedAt: new Date().toISOString()});
             return false;
         }
 
+        this.clearRunningSkipLogState(taskName);
         this.taskStateService.markStarted(taskName, reason);
 
         this.writeLog?.('INFO', `[ProcessSupervisor] Starting ${task.label} (${reason}).`);
@@ -207,7 +281,7 @@ export class ProcessSupervisorService extends Base {
             child = this.spawnFn(task.command, task.args, {stdio: ['ignore', 'ignore', 'pipe']});
 
             child.stderr?.on('data', data => {
-                this.writeLog?.('ERROR', `[ProcessSupervisor] ${task.label} stderr: ${data.toString().trim()}`);
+                this.writeChildStderr(task, data);
             });
         } catch (e) {
             this.taskStateService.markSpawnFailed(taskName);
@@ -241,6 +315,7 @@ export class ProcessSupervisorService extends Base {
                     fs.unlinkSync(pidFile);
                 }
             } catch (e) {}
+            this.clearRunningSkipLogState(taskName);
 
             if (error) {
                 this.taskStateService.markFailed(taskName, null);

--- a/test/playwright/unit/ai/daemons/services/ProcessSupervisorService.spec.mjs
+++ b/test/playwright/unit/ai/daemons/services/ProcessSupervisorService.spec.mjs
@@ -8,6 +8,8 @@ import { ProcessSupervisorService } from '../../../../../../ai/daemons/services/
 function createTestService() {
     const dataDir = `/tmp/process-supervisor-service-test-${Date.now()}-${Math.random()}`;
     fs.ensureDirSync(dataDir);
+    const logEntries = [];
+    const taskOutcomes = [];
     
     const taskDefinitions = {
         mockTask: {
@@ -31,7 +33,7 @@ function createTestService() {
     };
 
     const mockHealthService = {
-        recordTaskOutcome: () => {}
+        recordTaskOutcome: (taskName, status, details) => taskOutcomes.push({details, status, taskName})
     };
 
     const service = Neo.create(ProcessSupervisorService, {
@@ -39,12 +41,12 @@ function createTestService() {
         taskDefinitions,
         taskStateService: mockTaskStateService,
         healthService: mockHealthService,
-        writeLog: () => {},
+        writeLog: (level, message) => logEntries.push({level, message}),
         spawnFn: () => ({ pid: 1234, on: () => {} }),
         processCommand: (pid) => 'echo hello'
     });
     
-    return { service, dataDir, mockTaskStateService };
+    return { service, dataDir, logEntries, mockTaskStateService, taskOutcomes };
 }
 
 test.describe('Neo.ai.daemons.services.ProcessSupervisorService', () => {
@@ -94,5 +96,52 @@ test.describe('Neo.ai.daemons.services.ProcessSupervisorService', () => {
         
         expect(result).toBe(false);
         expect(spawnCalled).toBe(false);
+    });
+
+    test('runTask classifies child stderr log prefixes', () => {
+        const { service, logEntries } = createTestService();
+        let stderrHandler;
+
+        service.spawnFn = () => ({
+            pid   : 9999,
+            stderr: {
+                on: (eventName, handler) => {
+                    if (eventName === 'data') {
+                        stderrHandler = handler;
+                    }
+                }
+            },
+            on: () => {}
+        });
+
+        service.runTask('mockTask', 'test-reason');
+
+        stderrHandler(Buffer.from([
+            '[LOG] Processed and embedded batch 83 of 237',
+            '[INFO] Sync still running',
+            '[WARN] Slow embedding batch',
+            '[ERROR] Failed embedding batch',
+            'plain stderr output'
+        ].join('\n')));
+
+        const stderrLogs = logEntries.filter(entry => entry.message.includes('stderr:'));
+
+        expect(stderrLogs.map(entry => entry.level)).toEqual(['INFO', 'INFO', 'WARN', 'ERROR', 'ERROR']);
+    });
+
+    test('runTask dedupes repeated already-running skip logs', () => {
+        const { service, logEntries, taskOutcomes } = createTestService();
+
+        service.taskStateService.getTaskState = () => ({ running: true, pid: 1234 });
+
+        service.runTask('mockTask', 'same-reason');
+        service.runTask('mockTask', 'same-reason');
+        service.runTask('mockTask', 'different-reason');
+
+        const skipLogs = logEntries.filter(entry => entry.message.includes('task already running'));
+        const skippedOutcomes = taskOutcomes.filter(entry => entry.status === 'skipped');
+
+        expect(skipLogs.length).toBe(2);
+        expect(skippedOutcomes.length).toBe(3);
     });
 });


### PR DESCRIPTION
Resolves #11459

Authored by GPT-5 (Codex Desktop). Session 6ec143cb-2e5b-4964-94d6-eb28cb25bde2.
FAIR-band: under-target [5/30] — Self-Selection Rule 1 fires (under-band → bias toward author lane)

This fixes the orchestrator daemon logging boundary for child task output. `ProcessSupervisorService` now classifies child stderr lines with explicit `[LOG]`, `[INFO]`, `[WARN]`, and `[ERROR]` prefixes before writing daemon logs, so normal KB sync progress no longer appears as daemon-level errors. It also dedupes repeated already-running skip logs per task/PID/reason while preserving skipped health outcomes.

Evidence: L2 (focused unit coverage for supervisor severity mapping + skip dedupe) → L2 required. Residual: full-suite environment failures unrelated to #11459.

## Deltas From Ticket

No scope expansion. The implementation keeps stderr piping intact and only changes the daemon supervisor's interpretation of child log prefixes.

## Test Evidence

- `npm run test-unit -- test/playwright/unit/ai/daemons/services/ProcessSupervisorService.spec.mjs` → 5 passed.
- `git diff --check` → passed.
- `git diff --cached --check` → passed before commit.
- `npm run test-unit` → attempted full suite; failed with 81 unrelated existing environment failures, dominated by Chroma/localhost `EPERM` and production-DB guard failures. The focused #11459 spec passed in isolation.

## Post-Merge Validation

- [ ] Run `npm run ai:orchestrator` during an active KB sync and confirm `[LOG] Processed and embedded batch ...` is written as daemon INFO, not ERROR.
- [ ] Confirm repeated already-running KB sync polls do not spam identical skip log lines.

## Commits

- `4e5678f6c` — `fix(ai): classify orchestrator child logs (#11459)`
