### PR TITLE
docs(pr-review): add CI fail-fast review gate (#11465)

### DIFF
--- a/.agents/skills/pr-review/assets/pr-review-followup-template.md
+++ b/.agents/skills/pr-review/assets/pr-review-followup-template.md
@@ -82,11 +82,10 @@ This is the follow-up form of the Depth Floor. Do not omit it because the prior 
 *(Required per guide §7.6. Reviewers MUST verify automated GitHub Actions before assigning an `[EXECUTION_QUALITY]` score.)*
 
 - [ ] Ran `gh pr checks <N>` to empirically verify CI status.
-- [ ] Confirmed no checks are pending/in-progress (Hold review if unfinished).
-- [ ] Confirmed no "deep red" critical failures (e.g., CodeQL, Security, core build).
-- [ ] If checks are failing, flagged them in Required Actions to block approval.
+- [ ] Confirmed no checks are pending/in-progress. If unfinished, STOP and hold review.
+- [ ] Confirmed no checks are failing. If failing, STOP before formal review and send a CI fail-fast deferral or limited CI-triage note instead.
 
-**Findings:** [Pass - all checks green / Pending - review held / Failures flagged in Required Actions / N/A - no CI triggered]
+**Findings:** [Pass - all checks green / Pending - review held before formal review / CI-failed - formal review deferred; author fixes first / N/A - no CI triggered]
 
 ---
 

--- a/.agents/skills/pr-review/assets/pr-review-template.md
+++ b/.agents/skills/pr-review/assets/pr-review-template.md
@@ -194,11 +194,10 @@ For every modified or added OpenAPI tool description:
 *(Required per guide §7.6. Reviewers MUST verify automated GitHub Actions before assigning an `[EXECUTION_QUALITY]` score.)*
 
 - [ ] Ran `gh pr checks <N>` to empirically verify CI status.
-- [ ] Confirmed no checks are pending/in-progress (Hold review if unfinished).
-- [ ] Confirmed no "deep red" critical failures (e.g., CodeQL, Security, core build).
-- [ ] If checks are failing, flagged them in Required Actions to block approval.
+- [ ] Confirmed no checks are pending/in-progress. If unfinished, STOP and hold review.
+- [ ] Confirmed no checks are failing. If failing, STOP before formal review and send a CI fail-fast deferral or limited CI-triage note instead.
 
-**Findings:** [Pass - all checks green / Pending - review held / Failures flagged in Required Actions / N/A - no CI triggered]
+**Findings:** [Pass - all checks green / Pending - review held before formal review / CI-failed - formal review deferred; author fixes first / N/A - no CI triggered]
 
 ---
 

--- a/.agents/skills/pr-review/audits/ci-security-audit.md
+++ b/.agents/skills/pr-review/audits/ci-security-audit.md
@@ -1,27 +1,27 @@
 # CI / Security Checks Audit
 
-Before granting approval on **any** Pull Request, you MUST empirically verify the status of GitHub Actions and CI checks. Security bots (like CodeQL) and automated test workflows run asynchronously on GitHub. A static diff review *cannot* catch what these automated tools find. Approving a PR with failing or incomplete CI checks is a critical safety violation.
+Before conducting or posting a formal Pull Request review, you MUST empirically verify the status of GitHub Actions and CI checks. Security bots (like CodeQL) and automated test workflows run asynchronously on GitHub. A static diff review *cannot* catch what these automated tools find. Spending a full review cycle while required CI is failing or incomplete creates avoidable re-review churn.
 
 ## The Verification Protocol
 
 1. **Empirical Verification:**
-   You must run `gh pr checks <N>` to view the status of all checks for the PR.
+   You must run `gh pr checks <N>` to view the status of all checks for the PR before reading the full diff, scoring metrics, or drafting a substantive formal review. If the command is temporarily unavailable, use an equivalent read-only GitHub status surface and say so explicitly.
 
 2. **Pending/In-Progress Checks:**
-   If any checks are pending, queued, or in-progress, you **MUST HOLD** your review. You cannot approve a PR until all critical checks have finished running.
+   If any checks are pending, queued, or in-progress, you **MUST HOLD** your review. Do not spend or post the full review while the result is unstable. Send a lightweight A2A/PR note only when coordination needs the hold reason.
 
-3. **Failure Handling ("Deep Red" Rule):**
-   If any critical checks (especially CodeQL, Security, or main build tests) are failing or marked "deep red", you **MUST NOT** approve the PR.
+3. **Failure Handling (Fail-Fast Rule):**
+   If any check returned by `gh pr checks <N>` is failing, cancelled, timed out, or marked "deep red", you **MUST STOP BEFORE FORMAL REVIEW**. Do not post `APPROVED`, `REQUEST_CHANGES`, or a full-template `COMMENT` review. The author must fix CI first and re-request review on a green head.
 
-4. **Required Action Assignment:**
-   If checks are failing, flag the specific failing checks as a **Required Action** in your review. Instruct the author to fix the vulnerabilities or test failures before re-requesting review.
+4. **Triage Exception:**
+   If the author explicitly asks for CI triage, or the failure is plausibly infrastructure/flaky rather than branch-caused, you may post a limited CI-triage note naming the failing check and next evidence needed. Do not score the diff, audit unrelated surfaces, or treat that note as the formal review cycle.
 
 5. **Approval Block:**
    A PR with failing security or build checks is fundamentally unsafe and cannot be approved, regardless of how clean the diff looks to you.
 
 ## Documentation Requirement
 
-When completing the `[EXECUTION_QUALITY]` section of the PR review template, you MUST explicitly document that you ran `gh pr checks <N>` and confirm the checks passed or are appropriately handled.
+When completing the `[EXECUTION_QUALITY]` section of the PR review template, you MUST explicitly document that you ran `gh pr checks <N>` and confirm the checks passed. If checks are pending or failing, do not complete the formal review template; document the hold or fail-fast deferral instead.
 
 **Example Review Commentary:**
-> ✅ **CI / Security Audit:** Ran `gh pr checks 1234`. All workflows (CodeQL, Unit Tests) pass successfully. No deep red flags.
+> CI / Security Audit: Ran `gh pr checks 1234`. All workflows (CodeQL, Unit Tests) pass successfully. No deep red flags.


### PR DESCRIPTION
Authored by GPT-5.5 (Codex Desktop). Session 019e30ef-4702-73d1-a74f-b3321a13ba38.

**FAIR-band**: under-target [5/30] — Self-Selection Rule 1 fires (under-band -> bias toward author lane). Verifier: `gh search prs --merged --repo neomjs/neo --limit 30 --sort updated --json author` returned @neo-gpt 5, @neo-opus-4-7 6, @neo-gemini-3-1-pro 19.

**Evidence**: L2 — skill substrate lint + static diff hygiene. This is a docs/skill-template change; no runtime unit tests required.

## Summary

Adds a fail-fast gate to the `pr-review` CI audit: reviewers now verify CI before spending a full formal review cycle, hold while checks are pending, and stop before formal review when any check is failing, cancelled, timed out, or deep red.

## Why

The previous `pr-review` CI audit only blocked approval on failing CI and told reviewers to put failing checks into Required Actions. That still encouraged a full formal review on a branch the author already has to fix. The operator surfaced the stronger rule during the current review queue: no first review or re-review is needed on red CI; the author fixes CI first, then asks again.

This reduces wasted review cycles and keeps the review thread focused on code or substrate concerns after the branch is mechanically reviewable.

## What changed

- `.agents/skills/pr-review/audits/ci-security-audit.md`
  - Moves CI verification before full diff review, metric scoring, or substantive review drafting.
  - Holds on pending/queued/in-progress checks.
  - Stops before formal review when any `gh pr checks <N>` check fails, is cancelled, times out, or is deep red.
  - Preserves a narrow CI-triage exception for explicit author triage requests or plausible infra/flaky failures.
- `.agents/skills/pr-review/assets/pr-review-template.md`
  - Replaces the old "flag failures in Required Actions" checkbox with fail-fast deferral wording.
- `.agents/skills/pr-review/assets/pr-review-followup-template.md`
  - Mirrors the same fail-fast wording for warm-cache review cycles.

## Slot Rationale

This PR mutates skill substrate under the existing `pr-review` skill.

| Surface | Disposition | Trigger Frequency | Failure Severity | Enforceability | Rationale |
|---|---|---|---|---|---|
| `pr-review/audits/ci-security-audit.md` | `rewrite` | PR-review only | High: red-CI formal reviews waste reviewer cycles and create avoidable re-review churn | Discipline-only with empirical `gh pr checks` command | Existing World Atlas payload is the correct slot; no new always-loaded substrate needed |
| `pr-review-template.md` CI checklist | `rewrite` | Cycle-1 formal review only | Medium-high: template contradicted fail-fast by directing failures into Required Actions | Discipline-only | Template must not instruct a formal review shape when CI should stop the review |
| `pr-review-followup-template.md` CI checklist | `rewrite` | Cycle-N formal review only | Medium-high: same contradiction in re-review cycles | Discipline-only | Keeps first-review and follow-up review behavior symmetric |

Net substrate effect: 3 existing files touched, no new files, no new `AGENTS.md` trigger, no new always-loaded skill router content, and the diff is net smaller by line count.

## Validation

- `node ai/scripts/lint-skill-manifest.mjs --base origin/dev` -> OK
- `git diff --check` -> OK
- `git diff --cached --check` -> OK before commit

## Related

Resolves #11465
