### PR TITLE
docs(pull-request): gate review requests on green CI (#11467)

### DIFF
--- a/.agents/skills/pull-request/references/ci-green-review-routing.md
+++ b/.agents/skills/pull-request/references/ci-green-review-routing.md
@@ -1,0 +1,94 @@
+# CI-Green Review Routing
+
+This payload governs author-side review requests after a PR is opened or after the author pushes review-response fixes. It pairs with the reviewer-side CI fail-fast rule in `pr-review/audits/ci-security-audit.md`.
+
+## 1. Source Of Authority
+
+- `pull-request-workflow.md §6.2` owns author-side review routing.
+- `pr-review/audits/ci-security-audit.md` owns reviewer-side CI hold / fail-fast behavior.
+- `AGENTS.md §0` still requires lifecycle A2A notification when the PR opens.
+
+The goal is to preserve lifecycle visibility without waking a reviewer into work they must immediately hold.
+
+## 2. CI-Green Gate
+
+Before sending any actionable primary-reviewer request, run:
+
+```bash
+gh pr checks <PR_NUMBER>
+```
+
+Use an equivalent read-only GitHub status surface only if `gh pr checks` is unavailable, and state that substitution explicitly in the PR/A2A handoff. Re-run the check after any new push before requesting review or re-review.
+
+Treat the check as bound to the current PR head. If you leave the author lane to review a peer PR while CI runs, re-check your own PR afterward rather than relying on the earlier result.
+
+## 3. Outcome Branches
+
+### Green
+
+All required checks for the current head passed.
+
+1. Choose exactly one `primary-reviewer` using the normal routing heuristic.
+2. Call `manage_pr_reviewers({action: 'add', pr_number, reviewers: ['<reviewer>']})`.
+3. Send one targeted A2A DM to the same reviewer.
+4. Include:
+   - `Review role: primary-reviewer`
+   - `Requested action: use /pr-review on PR #N`
+   - `CI status: green on current head <sha-or-short-sha>`
+
+### Pending, Queued, Or In Progress
+
+Do not call `manage_pr_reviewers`. Do not send an actionable `/pr-review` request.
+
+For the mandatory lifecycle notification, send observer/no-action A2A:
+
+```text
+Review role: observer
+Requested action: none
+CI status: pending on current head <sha-or-short-sha>
+Next author action: re-check CI before assigning a primary reviewer
+```
+
+Use the wait window productively:
+
+1. Check unread A2A and open peer review requests.
+2. If a peer PR can be reviewed or unblocked without abandoning your lane, do that work while CI runs.
+3. Return to your PR and re-run `gh pr checks <PR_NUMBER>`.
+
+Do not spin indefinitely. If checks are still pending and no useful peer-unblock lane is available within the current turn, leave the PR in the observer/no-action hold state with the exact CI status and stop.
+
+### Failing, Cancelled, Timed Out, Or Deep Red
+
+Do not request formal review. The author fixes CI first, pushes the fix, and repeats the CI-green gate on the new head.
+
+If the author explicitly needs help diagnosing CI, route that as CI triage, not formal review:
+
+```text
+Review role: ci-triage
+Requested action: inspect failing check only; do not run full /pr-review
+CI status: failing on current head <sha-or-short-sha>
+```
+
+### No Checks Returned
+
+If GitHub reports no checks for the PR, document `CI status: no checks reported` in the handoff and proceed with normal single-primary-reviewer routing. Absence of CI should not create an infinite hold loop.
+
+## 4. Re-Review Requests
+
+After addressing reviewer feedback with new commits, apply the same gate before writing `Re-review requested.` or sending a re-review A2A. If CI is pending, post the structured Addressed comment with a hold line instead:
+
+```text
+CI status: pending on current head <sha-or-short-sha>. Re-review request will follow once CI is green.
+```
+
+Once CI is green, send the re-review A2A with the original response `commentId` plus `CI status: green`.
+
+## 5. Anti-Patterns
+
+| Anti-pattern | Why it harms |
+|---|---|
+| Calling `manage_pr_reviewers` while CI is pending | GitHub reviewer assignment is itself an actionable review request. |
+| Sending `Requested action: use /pr-review` before green CI | Reviewer-side rules now require holding or stopping, so the wake creates churn. |
+| Suppressing all PR-open A2A until CI is green | Violates lifecycle visibility and makes the swarm blind to an opened PR. |
+| Treating green CI as approval | Green CI only permits requesting human/peer review. |
+| Busy-waiting forever | Pending CI time should unblock peers or end in an explicit observer hold. |

--- a/.agents/skills/pull-request/references/pull-request-workflow.md
+++ b/.agents/skills/pull-request/references/pull-request-workflow.md
@@ -153,7 +153,7 @@ This ensures A2A provenance remains graph-extractable even if you do not have a 
 
 ## 6. Definition of Done & The Handoff State
 
-The agent's task is strictly considered "Done" once the PR is opened. A PR is a request for validation by an external entity (Human or QA Agent). **An agent MUST NOT autonomously run the `pr-review` skill against its own PR in headless mode.** 
+The agent's task is strictly considered "Done" once the PR is opened and the §6.2 handoff state is set. A PR is a request for validation by an external entity (Human or QA Agent). **An agent MUST NOT autonomously run the `pr-review` skill against its own PR in headless mode.**
 
 **Iterative Polish (Pre-PR):** Autonomous agents must act as their own harshest critic *before* the handoff. Get the codebase to the best possible state. If you identify minor gaps (missing JSDoc, logical edge cases) during your reflection, you MUST push follow-up polish commits to your branch *prior* to executing the final PR creation.
 
@@ -179,7 +179,7 @@ You MUST follow this exact handoff protocol:
 - **7-day-open fallback**: The PR itself has been OPEN for >= 7 days AND no cross-family reviewer has engaged on the thread. Any cross-family thread engagement (review, comment, or status) resets the 7-day-open clock; only an `Approved` status satisfies the mandate. Deterministically verifiable via `get_conversation(pr_number)`: (a) `now - createdAt >= 7 days`, (b) `comments.nodes` contains no entry whose `author.login` resolves to the cross-family pattern. Fallback invocation MUST include the PR's `createdAt` timestamp + explicit confirmation that no cross-family engagement has occurred, embedded in the self-review comment.
 - **Emergency hotfix escalator**: `priority: P0` label OR an explicit Tobi-override comment on the PR; post-merge cross-family retrospective review REQUIRED within 7 days.
 
-**Invitation Layer (`manage_pr_reviewers`):** the cross-family mandate is the **validation** mechanism (Approved-status before merge). The MCP tool `manage_pr_reviewers` (`github-workflow` server) is the corresponding **invitation** mechanism — surfaces GitHub's `requested_reviewers` API for active review-requests. If no cross-family reviewer has engaged ~2 hours after PR open, the author SHOULD formally invite the opposite family via `manage_pr_reviewers({action: 'add', pr_number, reviewers: ['<opposite-family-login>']})`. Invitation precedes the 7-day-open fallback — it's the natural escalation step BEFORE that fallback fires. Codified per #10217.
+**Invitation Layer (`manage_pr_reviewers`):** the cross-family mandate is the **validation** mechanism (Approved-status before merge). The MCP tool `manage_pr_reviewers` (`github-workflow` server) is the corresponding **invitation** mechanism — surfaces GitHub's `requested_reviewers` API for active review-requests. If no cross-family reviewer has engaged ~2 hours after the PR has a green current-head CI state, the author SHOULD formally invite the opposite family via `manage_pr_reviewers({action: 'add', pr_number, reviewers: ['<opposite-family-login>']})`. Invitation precedes the 7-day-open fallback — it's the natural escalation step BEFORE that fallback fires. Codified per #10217.
 
 ### 6.1.1 The Consensus-Gate (PR-Merge-Gate for Discussion-Graduated Substrate)
 
@@ -226,12 +226,14 @@ These three sections are mandatory in the PR body for substrate-mutating PRs fro
 
 ### 6.2 The Core Swarm A2A Notification Mandate (Review Routing Protocol)
 
-If you are operating inside the canonical `neomjs/neo` repository as a core swarm member (e.g., `@neo-opus-4-7`, `@neo-gemini-3-1-pro`, `@neo-gpt`), immediately after successfully opening a PR, you MUST route a review request via the `add_message` tool.
+If you are operating inside the canonical `neomjs/neo` repository as a core swarm member (e.g., `@neo-opus-4-7`, `@neo-gemini-3-1-pro`, `@neo-gpt`), immediately after successfully opening a PR, you MUST send a lifecycle A2A notification.
+
+<!-- trigger: author-side review/re-review request -> read ./ci-green-review-routing.md before reviewer assignment -->
 
 To prevent redundant parallel effort and reviewer collision, you MUST adhere to this explicit role-routing protocol rather than broadcasting naked multi-peer pings:
 
-1. **Default PR Handoff (Single-Peer Ping):** 
-   - **GitHub Layer (Assignment):** Author chooses exactly ONE `primary-reviewer` and immediately calls the `manage_pr_reviewers` MCP tool (`action: 'add'`) to make ownership visible in the PR UI.
+1. **Default PR Handoff (Single-Peer Ping):**
+   - **GitHub Layer (Assignment):** Author chooses exactly ONE `primary-reviewer` and calls the `manage_pr_reviewers` MCP tool (`action: 'add'`) only after the CI-green gate passes.
    - **A2A Layer (Wake):** Author sends ONE actionable A2A ping *only* to that same primary reviewer.
      - Include `Review role: primary-reviewer`.
      - Include `Requested action: use /pr-review on PR #N` — naming the skill literally is mandatory; mechanically loads the receiving peer's `pr-review-template.md` + structured-eval discipline + graph-ingestion section structure. Vague `review PR #N` relies on semantic-match and is the empirical anchor for the rubber-stamp / template-adherence-gap pattern (PR #11127 cycle-1, 2026-05-10). Mirror of §6.4's remediation idiom applied at initial routing time.

--- a/.agents/skills/pull-request/references/review-response-protocol.md
+++ b/.agents/skills/pull-request/references/review-response-protocol.md
@@ -69,7 +69,7 @@ Example: `fix(ai): protect SESSION and MEMORY from getOrphanedNodes cleanup (#10
 
 ## 8. Re-Review Signal
 
-End the Addressed comment with `Re-review requested.` to signal the reviewer that the author's response cycle is complete. Do NOT add a new commit after posting the Addressed comment unless you are starting another response cycle (in response to the reviewer's follow-up feedback — new round, new comment).
+Before ending the Addressed comment with `Re-review requested.`, apply the CI-green gate in [`./ci-green-review-routing.md`](./ci-green-review-routing.md). If CI is pending or failing on the current head, document the CI hold instead and send the actionable re-review request only after green CI. Do NOT add a new commit after posting the Addressed comment unless you are starting another response cycle (in response to the reviewer's follow-up feedback — new round, new comment).
 
 ## 9. Relationship to Sibling Skills
 


### PR DESCRIPTION
Authored by GPT-5 (Codex Desktop). Session 6ec143cb-2e5b-4964-94d6-eb28cb25bde2.

Resolves #11467

FAIR-band stance: In-band. Narrow skill-substrate update; one commit, three pull-request skill reference files, no runtime code.

Evidence declaration: L2 skill-substrate validation. This PR changes author workflow docs only and is verified by manifest lint, diff hygiene, and targeted text checks.

## Summary
- Adds `ci-green-review-routing.md` as the author-side payload for waiting until current-head CI is green before actionable review requests.
- Compresses `pull-request-workflow.md` to a map-level trigger plus reviewer-assignment timing changes.
- Applies the same CI-green gate to author-side re-review requests in `review-response-protocol.md`.

## Slot Rationale
- Added `ci-green-review-routing.md`: disposition `move`; lifecycle-specific rule body belongs in a sibling payload, not the oversized workflow map. Trigger-frequency is PR/re-review only; failure-severity is review churn and wasted peer attention; enforceability is discipline-only today. Retirement trigger: replace or shrink if a future mechanical review-request gate enforces CI-green assignment.
- Modified `pull-request-workflow.md` §6 / §6.1 / §6.2: disposition `compress-to-trigger` / `rewrite`; keeps only the handoff-state and routing pointer needed in the map.
- Modified `review-response-protocol.md` §8: disposition `compress-to-trigger`; re-review requests reuse the same payload instead of duplicating CI logic.

## Test Evidence
- `git diff --check`
- `node ai/scripts/lint-skill-manifest.mjs --base origin/dev`
- Targeted `rg` verification for `manage_pr_reviewers`, `Requested action: use /pr-review`, observer/no-action wording, and `ci-green-review-routing` references.

## Notes
- This intentionally keeps mandatory PR-open lifecycle A2A. Only actionable GitHub reviewer assignment and `/pr-review` wake are delayed until green CI.
- No `SKILL.md` router changes and no manifest-budget override changes.