### PR TITLE
feat(buildScripts/ai): add ai:sync-github-workflow CLI script (#11469)

### DIFF
--- a/buildScripts/ai/syncGithubWorkflow.mjs
+++ b/buildScripts/ai/syncGithubWorkflow.mjs
@@ -1,11 +1,4 @@
-// Neo namespace bootstrap (entry-point invariant) — required for any consumer
-// of the Neo singleton API. `InstanceManager` binds Neo.find/findFirst/get aliases
-// and consumes pre-singleton `Neo.idMap`. Symmetric with `syncKnowledgeBase.mjs`.
-import Neo               from '../../src/Neo.mjs';
-import * as core         from '../../src/core/_export.mjs';
-import InstanceManager   from '../../src/manager/Instance.mjs';
-import GH_Config         from '../../ai/mcp/server/github-workflow/config.mjs';
-import GH_SyncService    from '../../ai/services/github-workflow/SyncService.mjs';
+import {GH_Config, GH_SyncService} from '../../ai/services.mjs';
 
 /**
  * @module buildScripts/ai/syncGithubWorkflow
@@ -30,9 +23,12 @@ import GH_SyncService    from '../../ai/services/github-workflow/SyncService.mjs
  * - leaves the underlying service untouched (no special-case "full vs delta"
  *   code path — the same `runFullSync()` runs in both invocations)
  *
- * **Pattern parallel:** `buildScripts/ai/syncKnowledgeBase.mjs` — same shape
- * (Neo namespace bootstrap + service singleton + `.runFullSync()` analog +
- * exit-on-completion).
+ * **SDK boundary**: imports route through `ai/services.mjs` (the canonical SDK
+ * entry point per `Neo.ai.services`), which handles Neo namespace bootstrap +
+ * auto-disables sync-on-startup side-effects + applies Zod validation at the
+ * service boundary. Mirrors the pattern established by `backup.mjs`,
+ * `defragChromaDB.mjs`, and other operator-runnable CLI scripts. No direct
+ * `ai/mcp/server/...` or `ai/services/...` deep imports.
  *
  * **Authority anchors:**
  * - ADR 0004 §1.3 (regeneratable cache) + §3.6 (clean-slate purge) — the workflow

--- a/buildScripts/ai/syncGithubWorkflow.mjs
+++ b/buildScripts/ai/syncGithubWorkflow.mjs
@@ -1,0 +1,65 @@
+// Neo namespace bootstrap (entry-point invariant) — required for any consumer
+// of the Neo singleton API. `InstanceManager` binds Neo.find/findFirst/get aliases
+// and consumes pre-singleton `Neo.idMap`. Symmetric with `syncKnowledgeBase.mjs`.
+import Neo               from '../../src/Neo.mjs';
+import * as core         from '../../src/core/_export.mjs';
+import InstanceManager   from '../../src/manager/Instance.mjs';
+import GH_Config         from '../../ai/mcp/server/github-workflow/config.mjs';
+import GH_SyncService    from '../../ai/services/github-workflow/SyncService.mjs';
+
+/**
+ * @module buildScripts/ai/syncGithubWorkflow
+ * @summary CLI wrapper invoking `GH_SyncService.runFullSync()` for full
+ * issue / PR / discussion / release-notes substrate emission into
+ * `resources/content/`.
+ *
+ * **Why a CLI dual to the MCP `sync_all` tool exists:**
+ *
+ * Both invocation surfaces resolve to the same `GH_SyncService.runFullSync()`
+ * orchestration entry point (referenced at `ai/services/github-workflow/SyncService.mjs`
+ * + delegated to by `ai/services/github-workflow/toolService.mjs`'s `sync_all`
+ * MCP handler). The MCP path is bound to MCP-request-response timing — fine for
+ * delta-syncs (the "cached for fast no-ops" path) but inadequate for clean-slate
+ * full emission post-ADR-0004 §3.6 purge (~8.5k issues + ~2.8k PRs + ~165
+ * discussions + ~166 release notes via GraphQL pagination = many minutes).
+ *
+ * The CLI dual:
+ * - bypasses the MCP request-timeout ceiling
+ * - surfaces full stderr/stdout progress (each syncer logs phase-by-phase via
+ *   `ai/mcp/server/github-workflow/logger.mjs`)
+ * - leaves the underlying service untouched (no special-case "full vs delta"
+ *   code path — the same `runFullSync()` runs in both invocations)
+ *
+ * **Pattern parallel:** `buildScripts/ai/syncKnowledgeBase.mjs` — same shape
+ * (Neo namespace bootstrap + service singleton + `.runFullSync()` analog +
+ * exit-on-completion).
+ *
+ * **Authority anchors:**
+ * - ADR 0004 §1.3 (regeneratable cache) + §3.6 (clean-slate purge) — the workflow
+ *   this script enables
+ * - #11451 / PR #11461 — Phase 1 Task 10 close-out that surfaced the CLI gap
+ * - #11469 — this ticket
+ *
+ * @example
+ *   npm run ai:sync-github-workflow
+ *
+ *   # Full output streamed to stdout/stderr (no MCP timeout ceiling).
+ *   # Exit code 0 on success / 1 on failure.
+ */
+
+async function syncGithubWorkflow() {
+    GH_Config.data.debug = true;
+
+    console.log('🔄 Starting full GitHub Workflow sync via GH_SyncService.runFullSync()...');
+
+    try {
+        const result = await GH_SyncService.runFullSync();
+        console.log('✅ Sync complete:', result);
+        process.exit(0);
+    } catch (e) {
+        console.error('❌ Sync failed:', e);
+        process.exit(1);
+    }
+}
+
+syncGithubWorkflow();

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
         "ai:server"                    : "chroma run --path ./.neo-ai-data/chroma/knowledge-base",
         "ai:server-neural-link"        : "node ./ai/mcp/server/neural-link/run-bridge.mjs",
         "ai:summarize-sessions"        : "node ./ai/scripts/summarize-sessions.mjs",
+        "ai:sync-github-workflow"      : "node ./buildScripts/ai/syncGithubWorkflow.mjs",
         "ai:sync-kb"                   : "node ./buildScripts/ai/syncKnowledgeBase.mjs",
         "build-all"                    : "node ./buildScripts/build/all.mjs -f -n",
         "build-all-questions"          : "node ./buildScripts/build/all.mjs -f",


### PR DESCRIPTION
Authored by Claude Opus 4.7 (Claude Code). Session 0064efde-455e-4ecd-a26f-574381b3766a.

**FAIR-band stance**: in-band — quick-win enabler ticket filed + self-assigned + implemented in one tight loop per operator's "minor quick win" framing (2026-05-16 post-#11461 merge). MX-friction-reduction shape.

**Evidence**: L2 (file mirrors `syncKnowledgeBase.mjs` pattern exactly — sibling-file-lift fast-path verified; package.json entry alphabetically placed; static-validated structure) → L4 required (operator runs `npm run ai:sync-github-workflow` post-merge to verify end-to-end CLI invocation produces expected sync output with no MCP timeout). Residual: post-merge runtime verification by operator — annotated on #11469's AC list as third checkbox.

## Summary

Adds `ai:sync-github-workflow` npm script + `buildScripts/ai/syncGithubWorkflow.mjs` CLI wrapper for `GH_SyncService.runFullSync()`. Enables full clean-slate gh-workflow sync invocation without the MCP request-response timeout ceiling.

**Naming rationale** (per operator correction 2026-05-16): scoped to gh-workflow-server specifically, NOT "all substrates" (which would imply KB + memory-core too). `ai:sync-github-workflow` parallels existing `ai:mcp-server-github-workflow` naming.

## Empirical motivation

Post-#11461-merge attempt to invoke `sync_all` via MCP tool: request timed out before sync emission began. The MCP request-response model is fine for delta-syncs (the "cached for fast no-ops" path per the tool's own description) but inadequate for clean-slate full emission (~8.5k issues + ~2.8k PRs + ~165 discussions + ~166 release notes via GraphQL pagination = many minutes per ADR 0004 §3.6 clean-slate purge state).

The CLI dual:
- bypasses MCP request-timeout ceiling
- surfaces full stderr/stdout progress (each syncer logs phase-by-phase via the gh-workflow logger)
- leaves underlying `GH_SyncService.runFullSync()` untouched — same orchestration entry point, just a second transport surface

## What changed

| File | Type | Delta |
|------|------|-------|
| `buildScripts/ai/syncGithubWorkflow.mjs` | New | 65 lines (incl. JSDoc header with rationale + authority anchors) |
| `package.json` | Modified | +1 line: `"ai:sync-github-workflow": "node ./buildScripts/ai/syncGithubWorkflow.mjs"` |

Total: 2 files, +66/-0 lines.

## Structural pre-flight (§23 sibling-file-lift fast-path)

New file `buildScripts/ai/syncGithubWorkflow.mjs` is a direct sibling-pattern parallel to existing `buildScripts/ai/syncKnowledgeBase.mjs`:
- Same directory (`buildScripts/ai/`)
- Same import shape (Neo namespace bootstrap + InstanceManager + service singleton)
- Same execution shape (async function + try/catch + exit code)
- Same naming convention (domain-named module)

No novel directory choice; full Pre-Flight (ArchitectureOverview.md / ADR consultation) not required per Stage 1 fast-path.

## Authority anchors

- **ADR 0004 §1.3 Regeneratable-Cache Strategic Principle**: `resources/content/` is a fully-regeneratable cache; sync_all is the canonical path back to a clean state. This script enables that path from CLI.
- **ADR 0004 §3.6 clean-slate purge**: the workflow this script enables operator-side post-purge.
- **Architectural parallel**: `buildScripts/ai/syncKnowledgeBase.mjs` (the established pattern + `ai:sync-kb` npm script)

## Avoided traps

- **Naming `ai:sync-all`**: rejected per operator 2026-05-16 — scope is gh-workflow only, not all substrates. Corrected to `ai:sync-github-workflow`.
- **Adding the script to the daemon's scheduled sweeps**: rejected — sync should remain operator-on-demand. Periodic daemon sync would defeat the regeneratable-cache principle by re-emitting unchanged corpus repeatedly.
- **Using the Agent SDK pattern**: surveyed `runAgent.mjs` — that's the full agent harness, not service-method invocation. `syncKnowledgeBase.mjs` is the correct architectural parallel.
- **Adding a branch-guard mirroring the MCP tool's dev-branch precondition**: rejected — CLI invocation is operator-side and trusted (the MCP branch-guard protects against agents invoking from feature-branch worktrees; CLI doesn't have that exposure).
- **Adding a `--type` filter flag**: deferred per "Out of Scope" on #11469 — defer until empirical demand surfaces.

## Test plan

- [x] File created with correct sibling-pattern shape.
- [x] `package.json` entry alphabetically placed (between `ai:summarize-sessions` and `ai:sync-kb`).
- [x] JSDoc module header documents dual-invocation rationale + cites authority anchors.
- [x] Branch-from-`origin/dev`-tip freshness check passed per pull-request-workflow §2.3.1.
- [ ] Cross-family review APPROVED.
- [ ] `@tobiu` merge.
- [ ] Post-merge: operator runs `npm run ai:sync-github-workflow` to verify CLI invocation produces expected output.

## Related

- **Resolves**: #11469
- **Parent context**: ADR 0004 Phase 1 Task 10 close-out (#11451 / merged via PR #11461)
- **Authority artifact**: `learn/agentos/decisions/0004-github-content-architecture.md`
- **Architectural parallel**: `buildScripts/ai/syncKnowledgeBase.mjs` (`ai:sync-kb`)
- **MCP tool dual**: `mcp__neo-mjs-github-workflow__sync_all` (existing invocation surface)