### PR TITLE
fix(ai): align orchestrator mlx model (#11471)

### DIFF
--- a/ai/daemons/TaskDefinitions.mjs
+++ b/ai/daemons/TaskDefinitions.mjs
@@ -14,6 +14,8 @@ export const DEFAULT_DREAM_INTERVAL_MS            = 3600000;
 export const DREAM_TASK_NAME                      = 'dream';
 export const DEFAULT_GOLDEN_PATH_INTERVAL_MS      = 3600000;
 export const GOLDEN_PATH_TASK_NAME                = 'golden-path';
+export const DEFAULT_MLX_MODEL                    = 'gemma-4-31b-it';
+export const DEFAULT_MLX_PORT                     = '11435';
 
 export const DEFAULT_DB_PATH    = process.env.NEO_AI_DB_PATH || '.neo-ai-data/sqlite/memory-core-graph.sqlite';
 export const DEFAULT_DATA_DIR   = process.env.NEO_AI_ORCHESTRATOR_DIR || '.neo-ai-data/orchestrator-daemon';
@@ -30,9 +32,16 @@ export const DEFAULT_SCRIPT_DIR = path.resolve(__dirname, '../scripts');
  * @param {Object} [options]
  * @param {String} [options.scriptDir] Script directory.
  * @param {String} [options.nodeBin] Node executable.
+ * @param {String} [options.mlxModel] OpenAI-compatible local inference model.
+ * @param {String|Number} [options.mlxPort] OpenAI-compatible local inference port.
  * @returns {Object}
  */
-export function buildTaskDefinitions({scriptDir = DEFAULT_SCRIPT_DIR, nodeBin = process.argv[0]} = {}) {
+export function buildTaskDefinitions({
+    scriptDir = DEFAULT_SCRIPT_DIR,
+    nodeBin   = process.argv[0],
+    mlxModel  = process.env.NEO_OPENAI_COMPATIBLE_MODEL || DEFAULT_MLX_MODEL,
+    mlxPort   = DEFAULT_MLX_PORT
+} = {}) {
     return {
         chroma: {
             label          : 'chroma daemon',
@@ -58,7 +67,7 @@ export function buildTaskDefinitions({scriptDir = DEFAULT_SCRIPT_DIR, nodeBin = 
         mlx: {
             label          : 'mlx inference',
             command        : path.resolve(scriptDir, '../mcp/server/memory-core/.venv/bin/python'),
-            args           : ['-m', 'mlx_lm.server', '--model', 'mlx-community/gemma-2-27b-it-4bit', '--port', '11435'],
+            args           : ['-m', 'mlx_lm.server', '--model', mlxModel, '--port', String(mlxPort)],
             pidFileName    : 'mlx.pid',
             expectedCommand: 'mlx_lm.server'
         },

--- a/test/playwright/unit/ai/scripts/orchestrator-daemon.spec.mjs
+++ b/test/playwright/unit/ai/scripts/orchestrator-daemon.spec.mjs
@@ -1,6 +1,8 @@
 import {test, expect} from '@playwright/test';
 import fs from 'fs';
 import path from 'path';
+import '../../../../../src/Neo.mjs';
+import '../../../../../src/core/_export.mjs';
 import {
     DEFAULT_KB_SYNC_INTERVAL_MS,
     LOCAL_AI_CONFIG_FILE,
@@ -9,6 +11,8 @@ import {
     DEFAULT_SUMMARY_SWEEP_INTERVAL_MS
 } from '../../../../../ai/scripts/orchestrator-daemon.mjs';
 import {
+    DEFAULT_MLX_MODEL,
+    DEFAULT_MLX_PORT,
     buildTaskDefinitions
 } from '../../../../../ai/daemons/TaskDefinitions.mjs';
 
@@ -30,6 +34,66 @@ test.describe('ai/scripts/orchestrator-daemon.mjs (#11006/#11009)', () => {
         expect(tasks.backup.command).toBe('/test/node');
         expect(tasks.backup.args).toEqual([path.resolve(scriptDir, '../../buildScripts/ai/backup.mjs')]);
         expect(tasks.backup.expectedCommand).toBe('backup.mjs');
+    });
+
+    test('starts mlx inference with the OpenAI-compatible Gemma 4 default', () => {
+        const scriptDir = path.resolve(process.cwd(), 'ai/scripts');
+        const tasks     = buildTaskDefinitions({scriptDir, nodeBin: '/test/node'});
+
+        expect(DEFAULT_MLX_MODEL).toBe('gemma-4-31b-it');
+        expect(DEFAULT_MLX_PORT).toBe('11435');
+        expect(tasks.mlx.args).toEqual([
+            '-m',
+            'mlx_lm.server',
+            '--model',
+            DEFAULT_MLX_MODEL,
+            '--port',
+            DEFAULT_MLX_PORT
+        ]);
+        expect(tasks.mlx.args).not.toContain('mlx-community/gemma-2-27b-it-4bit');
+    });
+
+    test('allows local mlx model overrides without changing task ownership', () => {
+        const scriptDir     = path.resolve(process.cwd(), 'ai/scripts');
+        const originalModel = process.env.NEO_OPENAI_COMPATIBLE_MODEL;
+
+        process.env.NEO_OPENAI_COMPATIBLE_MODEL = 'local-openai-compatible-model';
+
+        try {
+            const envTasks = buildTaskDefinitions({scriptDir, nodeBin: '/test/node'});
+
+            expect(envTasks.mlx.args).toEqual([
+                '-m',
+                'mlx_lm.server',
+                '--model',
+                'local-openai-compatible-model',
+                '--port',
+                DEFAULT_MLX_PORT
+            ]);
+        } finally {
+            if (originalModel === undefined) {
+                delete process.env.NEO_OPENAI_COMPATIBLE_MODEL;
+            } else {
+                process.env.NEO_OPENAI_COMPATIBLE_MODEL = originalModel;
+            }
+        }
+
+        const explicitTasks = buildTaskDefinitions({
+            scriptDir,
+            nodeBin  : '/test/node',
+            mlxModel : 'explicit-model',
+            mlxPort  : 12345
+        });
+
+        expect(explicitTasks.mlx.args).toEqual([
+            '-m',
+            'mlx_lm.server',
+            '--model',
+            'explicit-model',
+            '--port',
+            '12345'
+        ]);
+        expect(explicitTasks.summary.command).toBe('/test/node');
     });
 
     test('keeps bridge-daemon wake-only and routes maintenance ownership to the daemon class', () => {

--- a/test/playwright/unit/ai/scripts/orchestrator-daemon.spec.mjs
+++ b/test/playwright/unit/ai/scripts/orchestrator-daemon.spec.mjs
@@ -37,20 +37,30 @@ test.describe('ai/scripts/orchestrator-daemon.mjs (#11006/#11009)', () => {
     });
 
     test('starts mlx inference with the OpenAI-compatible Gemma 4 default', () => {
-        const scriptDir = path.resolve(process.cwd(), 'ai/scripts');
-        const tasks     = buildTaskDefinitions({scriptDir, nodeBin: '/test/node'});
+        const scriptDir     = path.resolve(process.cwd(), 'ai/scripts');
+        const originalModel = process.env.NEO_OPENAI_COMPATIBLE_MODEL;
 
-        expect(DEFAULT_MLX_MODEL).toBe('gemma-4-31b-it');
-        expect(DEFAULT_MLX_PORT).toBe('11435');
-        expect(tasks.mlx.args).toEqual([
-            '-m',
-            'mlx_lm.server',
-            '--model',
-            DEFAULT_MLX_MODEL,
-            '--port',
-            DEFAULT_MLX_PORT
-        ]);
-        expect(tasks.mlx.args).not.toContain('mlx-community/gemma-2-27b-it-4bit');
+        delete process.env.NEO_OPENAI_COMPATIBLE_MODEL;
+
+        try {
+            const tasks = buildTaskDefinitions({scriptDir, nodeBin: '/test/node'});
+
+            expect(DEFAULT_MLX_MODEL).toBe('gemma-4-31b-it');
+            expect(DEFAULT_MLX_PORT).toBe('11435');
+            expect(tasks.mlx.args).toEqual([
+                '-m',
+                'mlx_lm.server',
+                '--model',
+                DEFAULT_MLX_MODEL,
+                '--port',
+                DEFAULT_MLX_PORT
+            ]);
+            expect(tasks.mlx.args).not.toContain('mlx-community/gemma-2-27b-it-4bit');
+        } finally {
+            if (originalModel !== undefined) {
+                process.env.NEO_OPENAI_COMPATIBLE_MODEL = originalModel;
+            }
+        }
     });
 
     test('allows local mlx model overrides without changing task ownership', () => {


### PR DESCRIPTION
Authored by GPT-5.5 (Codex Desktop). Session 019e30ef-4702-73d1-a74f-b3321a13ba38.

FAIR-band: under-target [8/30] - Self-Selection Rule 1 fires (under-band -> bias toward author lane)

Resolves #11471

Aligns the orchestrator-owned MLX child-process command with the current OpenAI-compatible local inference contract. The daemon now defaults MLX to `gemma-4-31b-it`, honors `NEO_OPENAI_COMPATIBLE_MODEL`, and still exposes explicit `mlxModel` / `mlxPort` overrides for tests and local operation.

Evidence: L2 (task-factory unit tests + CI-env reproduction + static stale-literal grep) -> L4 required (operator daemon restart confirms host MLX fetch behavior). Residual: post-merge validation [#11471].

## Deltas from ticket
- Kept the fix in `ai/daemons/TaskDefinitions.mjs` instead of importing gitignored memory-core config.
- Preserved provider separation: this only touches the MLX/OpenAI-compatible command path, not Ollama naming.
- Added a fixup after CI exposed that the full unit workflow exports `NEO_OPENAI_COMPATIBLE_MODEL=gemma4`; the default-model test now isolates the no-env default before asserting it.

## Test Evidence
- `NEO_OPENAI_COMPATIBLE_MODEL=gemma4 npm run test-unit -- test/playwright/unit/ai/scripts/orchestrator-daemon.spec.mjs` - 5 passed.
- `npm run test-unit -- test/playwright/unit/ai/daemons/Orchestrator.spec.mjs` - 6 passed.
- `git diff --check` - passed.
- `rg -n "mlx-community/gemma-2-27b-it-4bit" ai test/playwright/unit/ai` - stale literal remains only as a negative regression assertion.

## Post-Merge Validation
- [ ] Restart `node ./ai/scripts/orchestrator-daemon.mjs` and confirm `mlx inference` no longer fetches `mlx-community/gemma-2-27b-it-4bit`.

## Commits
- `03200f399` - `fix(ai): align orchestrator mlx model (#11471)`
- `abf96949c` - `test(ai): isolate mlx model default assertion (#11471)`