### PR TITLE
fix(github-workflow/sync): defensive null-safety in IssueSyncer.formatTimelineEvent (#11474)

### DIFF
--- a/ai/services/github-workflow/sync/IssueSyncer.mjs
+++ b/ai/services/github-workflow/sync/IssueSyncer.mjs
@@ -191,18 +191,25 @@ class IssueSyncer extends Base {
 
         let details = '';
 
+        // Defensive null-safety per #11474: GitHub GraphQL returns null for referenced
+        // entities that have been deleted (users, labels, sub-issues, parent issues,
+        // blocking issues, commits, cross-referenced sources). Each deref site uses
+        // optional chaining + a fallback marker so a single null doesn't abort a sync
+        // run that's already processed thousands of issues. Fallback conventions:
+        // `'Ghost'` for users (matches existing actor/author convention at line 186);
+        // `'(deleted X)'` for named entities; `'?'` for numeric references.
         switch (event.__typename) {
             case 'LabeledEvent':
-                details = `added the \`${event.label.name}\` label`;
+                details = `added the \`${event.label?.name || '(deleted label)'}\` label`;
                 break;
             case 'UnlabeledEvent':
-                details = `removed the \`${event.label.name}\` label`;
+                details = `removed the \`${event.label?.name || '(deleted label)'}\` label`;
                 break;
             case 'AssignedEvent':
-                details = `assigned to @${event.assignee.login}`; // Assuming assignee is always a User
+                details = `assigned to @${event.assignee?.login || 'Ghost'}`;
                 break;
             case 'UnassignedEvent':
-                details = `unassigned from @${event.assignee.login}`; // Assuming assignee is always a User
+                details = `unassigned from @${event.assignee?.login || 'Ghost'}`;
                 break;
             case 'ClosedEvent':
                 details = `closed this issue`;
@@ -220,36 +227,41 @@ class IssueSyncer extends Base {
                 details = `removed this from the **${event.milestoneTitle}** milestone`;
                 break;
             case 'ReferencedEvent':
-                const commitMessage = event.commit.message.split('\\n')[0];
-                details = `referenced in commit \`${event.commit.oid.substring(0, 7)}\` - "${commitMessage}"`;
+                const commitMessage = event.commit?.message?.split('\\n')[0] || '(no message)';
+                const commitOid     = event.commit?.oid?.substring(0, 7) || '(deleted commit)';
+                details = `referenced in commit \`${commitOid}\` - "${commitMessage}"`;
                 break;
             case 'CrossReferencedEvent':
-                const sourceRef = event.source.__typename === 'Issue' ? `#${event.source.number}` : `PR #${event.source.number}`;
-                details = `cross-referenced by ${sourceRef}`;
+                if (event.source) {
+                    const sourceRef = event.source.__typename === 'Issue' ? `#${event.source.number}` : `PR #${event.source.number}`;
+                    details = `cross-referenced by ${sourceRef}`;
+                } else {
+                    details = `cross-referenced by (deleted)`;
+                }
                 break;
             case 'SubIssueAddedEvent':
-                details = `added sub-issue #${event.subIssue.number}`;
+                details = `added sub-issue #${event.subIssue?.number ?? '?'}`;
                 break;
             case 'SubIssueRemovedEvent':
-                details = `removed sub-issue #${event.subIssue.number}`;
+                details = `removed sub-issue #${event.subIssue?.number ?? '?'}`;
                 break;
             case 'ParentIssueAddedEvent':
-                details = `added parent issue #${event.parent.number}`;
+                details = `added parent issue #${event.parent?.number ?? '?'}`;
                 break;
             case 'ParentIssueRemovedEvent':
-                details = `removed parent issue #${event.parent.number}`;
+                details = `removed parent issue #${event.parent?.number ?? '?'}`;
                 break;
             case 'BlockedByAddedEvent':
-                details = `marked this issue as being blocked by #${event.blockingIssue.number}`;
+                details = `marked this issue as being blocked by #${event.blockingIssue?.number ?? '?'}`;
                 break;
             case 'BlockingAddedEvent':
-                details = `marked this issue as blocking #${event.blockedIssue.number}`;
+                details = `marked this issue as blocking #${event.blockedIssue?.number ?? '?'}`;
                 break;
             case 'BlockedByRemovedEvent':
-                details = `removed the block by #${event.blockingIssue.number}`;
+                details = `removed the block by #${event.blockingIssue?.number ?? '?'}`;
                 break;
             case 'BlockingRemovedEvent':
-                details = `removed the block on #${event.blockedIssue.number}`;
+                details = `removed the block on #${event.blockedIssue?.number ?? '?'}`;
                 break;
             default:
                 details = `performed a "${event.__typename}" event`;

--- a/test/playwright/unit/ai/services/github-workflow/IssueSyncer.spec.mjs
+++ b/test/playwright/unit/ai/services/github-workflow/IssueSyncer.spec.mjs
@@ -385,6 +385,76 @@ test.describe('Neo.ai.services.github-workflow.sync.IssueSyncer', () => {
         // Assert that dropped issue is nowhere in metadata
         expect(newMetadata.issues[mockIssueDropped.number]).toBeUndefined();
     });
+
+    test('formatTimelineEvent null-safety: null assignee / label / subIssue / source produce fallback markers, no crash (#11474)', async () => {
+        // Empirical anchor: post-#11470-merge sync_all crashed at IssueSyncer.mjs:202 on
+        // `event.assignee.login` when a GitHub user had been deleted. Same null-deref risk
+        // exists across the entire #formatTimelineEvent switch (label, subIssue, parent,
+        // blockingIssue, blockedIssue, commit, source). This test exercises four representative
+        // null entities and asserts (a) no crash, (b) fallback markers appear in rendered markdown.
+        const mockIssue = buildMockIssue({
+            number       : 42043,
+            title        : 'Mock issue — null-entity timeline regression #11474',
+            timelineFirst: [
+                {
+                    __typename: 'AssignedEvent',
+                    createdAt : '2026-05-16T10:00:00Z',
+                    actor     : {login: 'tobiu'},
+                    assignee  : null // deleted GitHub user
+                },
+                {
+                    __typename: 'LabeledEvent',
+                    createdAt : '2026-05-16T10:01:00Z',
+                    actor     : {login: 'tobiu'},
+                    label     : null // deleted label
+                },
+                {
+                    __typename: 'SubIssueAddedEvent',
+                    createdAt : '2026-05-16T10:02:00Z',
+                    actor     : {login: 'tobiu'},
+                    subIssue  : null // deleted sub-issue
+                },
+                {
+                    __typename: 'CrossReferencedEvent',
+                    createdAt : '2026-05-16T10:03:00Z',
+                    actor     : {login: 'tobiu'},
+                    source    : null // deleted source
+                }
+            ],
+            hasNextPage  : false,
+            endCursor    : null
+        });
+
+        GraphqlService.query = async (query) => {
+            if (query.includes('FetchSingleIssue')) {
+                return {repository: {issue: structuredClone(mockIssue)}};
+            }
+            throw new Error(`Unexpected GraphQL query in test: ${query.slice(0, 80)}`);
+        };
+
+        const metadata = {issues: {}};
+        const stats    = await IssueSyncer.refetchIssuesByNumber([mockIssue.number], metadata);
+
+        // No crash → refetch succeeds for all four null-entity events.
+        expect(stats.refetched.count).toBe(1);
+        expect(stats.errors).toHaveLength(0);
+
+        const chunkNumber = 1;
+        const writtenPath = path.join(issueSyncConfig.issuesDir, `chunk-${chunkNumber}`, `issue-${mockIssue.number}.md`);
+        const written     = await fs.readFile(writtenPath, 'utf-8');
+
+        // Fallback markers appear in rendered markdown.
+        expect(written).toContain('assigned to @Ghost');
+        expect(written).toContain('added the `(deleted label)` label');
+        expect(written).toContain('added sub-issue #?');
+        expect(written).toContain('cross-referenced by (deleted)');
+
+        // Verify no literal `undefined` / `null` artifacts leaked into the output —
+        // i.e., the optional-chaining + fallback approach landed everywhere instead
+        // of partial coverage that would yield raw `undefined` strings.
+        expect(written).not.toMatch(/assigned to @(undefined|null)/);
+        expect(written).not.toMatch(/added the `(undefined|null)` label/);
+    });
 });
 
 function buildComment(i) {


### PR DESCRIPTION
Authored by Claude Opus 4.7 (Claude Code). Session 0064efde-455e-4ecd-a26f-574381b3766a.

**FAIR-band stance**: in-band — post-merge-friction bug fix surfaced empirically by operator's first sync_all run from main checkout post-#11470 merge. Reactive scope, sub-100-LOC defensive fix.

**Evidence**: L2 (6/6 IssueSyncer unit specs pass including the new null-safety regression test that mocks 4 representative null entities) → L4 required (operator re-runs `npm run ai:sync-github-workflow` to verify the previously-crashing issue range processes past the null-assignee event). Residual: post-merge sync_all run by operator — annotated as third Required-Action checkbox.

## Summary

Defensive null-safety in `IssueSyncer.#formatTimelineEvent` switch cases. Eliminates a class of crashes where a single deleted entity (user / label / sub-issue / parent / blocking-issue / commit / cross-referenced-source) aborts the entire sync_all run.

## Empirical motivation

Operator ran `npm run ai:sync-github-workflow` from main checkout post-#11470 merge. Sync progressed through 8506 issues (created chunks up to `v8.1.0/chunk-40`), then crashed:

```
❌ Sync failed: TypeError: Cannot read properties of null (reading 'login')
    at #formatTimelineEvent (IssueSyncer.mjs:202:58)
```

Line 202: `event.assignee.login` with inline comment `// Assuming assignee is always a User`. That assumption fails for deleted GitHub users — `event.assignee` is `null`, `.login` throws.

The same null-deref pattern exists across the entire `#formatTimelineEvent` switch — see issue body #11474 for the full audit table. Single null anywhere aborts the whole sync run, wasting all prior GraphQL cost.

## What changed

| File | Type | Delta |
|------|------|-------|
| `ai/services/github-workflow/sync/IssueSyncer.mjs` | Modified | `#formatTimelineEvent` switch hardened with optional-chaining + fallback markers across 9 deref sites. Module-level comment added documenting the null-safety convention. |
| `test/playwright/unit/ai/services/github-workflow/IssueSyncer.spec.mjs` | Modified | New regression test exercising 4 representative null entities (AssignedEvent / LabeledEvent / SubIssueAddedEvent / CrossReferencedEvent). |

Total: 2 files, +98/-16 lines.

## Fallback marker conventions

| Entity | Fallback | Rationale |
|--------|----------|-----------|
| Users (`assignee.login`) | `'Ghost'` | Matches existing `event.actor?.login || event.author?.login || 'Ghost'` convention at line 186 |
| Labels (`label.name`) | `'(deleted label)'` | Preserves searchability + signals deletion |
| Numeric refs (`subIssue.number`, `parent.number`, `blockingIssue.number`, `blockedIssue.number`) | `'?'` | Compact + clear missing-data signal |
| Commit message | `'(no message)'` | Defensive: force-pushed-away commits |
| Commit OID | `'(deleted commit)'` | Same |
| CrossReferenced source | wrap-in-`if (event.source)` block, else `'cross-referenced by (deleted)'` | Most context-specific path; `__typename` check requires non-null source |

## Test plan

- [x] All 6 IssueSyncer unit specs pass (including the new null-safety regression test).
- [x] Branch-from-`origin/dev`-tip freshness check passed.
- [x] `git diff --check` passed.
- [ ] Cross-family review APPROVED.
- [ ] `@tobiu` merge.
- [ ] **L4 verification**: operator re-runs `npm run ai:sync-github-workflow` from main checkout; sync processes past the previously-crashing null-entity timeline event (currently somewhere in the v8.1.0 issue range based on the crash trace).

## Authority anchors

- **Parent context**: PR #11470 merged 2026-05-16 (ADR 0004 Phase 1 close-out CLI enabler); first operator-side full sync_all surfaced this bug
- **Authority artifact**: GitHub GraphQL API spec — `timelineItems` entities may have null fields when referenced entities are deleted
- **Empirical anchor**: operator log paste 2026-05-16 (chunk-40 of v8.1.0 archive write succeeded; crash on next issue's AssignedEvent)

## Avoided traps

- **Filtering null events at fetch time**: rejected — loses information in archived issue Timeline sections; deleted-user/deleted-label history is valuable archive context.
- **Returning early on null entity**: same information-loss concern.
- **Wrapping each case in try/catch**: rejected — obscures the systematic null-deref pattern; uniform optional-chaining is architecturally cleaner.
- **Only fixing AssignedEvent (the empirical crash)**: rejected — whack-a-mole; next sync hits a null `label` / `subIssue` etc. Defensive coverage across the whole switch is the right scope.

## Related

- **Parent context**: PR #11470 (`ai:sync-github-workflow` CLI enabler — merged)
- **Adjacent friction**: #11477 — log volume during sync (filed as follow-up enabler; reshaped per @neo-gpt V-B-A on logger.mjs missing level filtering)

Resolves #11474
