### PR TITLE
fix(github-workflow): add log-level filtering (#11477)

### DIFF
--- a/ai/mcp/server/github-workflow/config.template.mjs
+++ b/ai/mcp/server/github-workflow/config.template.mjs
@@ -7,6 +7,18 @@ const __dirname   = path.dirname(__filename);
 
 const packageRoot = path.resolve(__dirname, '../../../../');
 const projectRoot = process.cwd() === '/' ? packageRoot : process.cwd();
+const validLogLevels = ['error', 'warn', 'info', 'log', 'debug'];
+
+function parseLogLevel(rawValue, envVarName, warn = console.warn) {
+    const value = String(rawValue).trim().toLowerCase();
+
+    if (validLogLevels.includes(value)) {
+        return value;
+    }
+
+    warn(`[Config] Invalid ${envVarName} value: "${rawValue}" (must be one of: ${validLogLevels.join(', ')}); falling back.`);
+    return undefined;
+}
 
 /**
  * Default configuration object.
@@ -23,6 +35,11 @@ const defaultConfig = {
      * @type {boolean}
      */
     debug: false,
+    /**
+     * Minimum stderr log level for the GitHub workflow logger.
+     * @type {string}
+     */
+    logLevel: 'warn',
     /**
      * A dummy embedding function to satisfy the ChromaDB API when embeddings are provided manually.
      * @returns {null}
@@ -231,7 +248,8 @@ const defaultConfig = {
 };
 
 const envBindings = {
-    'issueSync.archiveRoot': 'NEO_MCP_GITHUB_ARCHIVE_ROOT'
+    'issueSync.archiveRoot': 'NEO_MCP_GITHUB_ARCHIVE_ROOT',
+    'logLevel': { var: 'NEO_LOG_LEVEL', parse: parseLogLevel }
 };
 
 /**

--- a/ai/mcp/server/github-workflow/logger.mjs
+++ b/ai/mcp/server/github-workflow/logger.mjs
@@ -1,14 +1,45 @@
 import aiConfig from './config.mjs';
 
 /**
- * A simple logger that writes to stderr only when the global debug flag is enabled.
- * This prevents corrupting the MCP stdio transport and keeps production output clean.
+ * A simple stderr logger with priority-based filtering.
+ * Keeps MCP server noise low by default while preserving fail-loud error output.
  */
 const logger = {};
 
+const LEVEL_PRIORITY = {
+    error: 0,
+    warn : 1,
+    info : 2,
+    log  : 2,
+    debug: 3
+};
+
+const DEFAULT_LOG_LEVEL = 'warn';
+
+const getConfiguredLogLevel = () => {
+    const configuredLevel = aiConfig.logLevel;
+
+    if (aiConfig.debug && (!configuredLevel || configuredLevel === DEFAULT_LOG_LEVEL)) {
+        return 'debug';
+    }
+
+    if (configuredLevel && LEVEL_PRIORITY[configuredLevel] !== undefined) {
+        return configuredLevel;
+    }
+
+    return aiConfig.debug ? 'debug' : DEFAULT_LOG_LEVEL;
+};
+
 const createLogMethod = (level) => {
     return (...args) => {
-        if (aiConfig.debug) {
+        if (level === 'error') {
+            console.error(`[${level.toUpperCase()}]`, ...args);
+            return;
+        }
+
+        const configuredLevel = getConfiguredLogLevel();
+
+        if (LEVEL_PRIORITY[level] <= LEVEL_PRIORITY[configuredLevel]) {
             console.error(`[${level.toUpperCase()}]`, ...args);
         }
     };

--- a/buildScripts/ai/syncGithubWorkflow.mjs
+++ b/buildScripts/ai/syncGithubWorkflow.mjs
@@ -38,13 +38,15 @@ import {GH_Config, GH_SyncService} from '../../ai/services.mjs';
  *
  * @example
  *   npm run ai:sync-github-workflow
+ *   npm run ai:sync-github-workflow -- --verbose
  *
  *   # Full output streamed to stdout/stderr (no MCP timeout ceiling).
  *   # Exit code 0 on success / 1 on failure.
  */
 
 async function syncGithubWorkflow() {
-    GH_Config.data.debug = true;
+    const verbose = process.argv.includes('--verbose');
+    GH_Config.data.logLevel = verbose ? 'debug' : 'info';
 
     console.log('🔄 Starting full GitHub Workflow sync via GH_SyncService.runFullSync()...');
 

--- a/test/playwright/unit/ai/mcp/server/github-workflow/ConfigCompleteness.spec.mjs
+++ b/test/playwright/unit/ai/mcp/server/github-workflow/ConfigCompleteness.spec.mjs
@@ -19,6 +19,7 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname  = path.dirname(__filename);
 const templatePath = path.resolve(__dirname, '../../../../../../../ai/mcp/server/github-workflow/config.template.mjs');
 const templateClassName = 'Neo.ai.mcp.server.github-workflow.Config';
+const cliScriptPath = path.resolve(__dirname, '../../../../../../../buildScripts/ai/syncGithubWorkflow.mjs');
 
 /**
  * @summary Imports the copyable GitHub workflow config template under a unit-test-only namespace.
@@ -109,5 +110,104 @@ test.describe('GitHub Workflow MCP Server Config Completeness', () => {
             // Reset to defaults so other tests aren't affected
             config.data.issueSync.archiveRoot = config.defaultConfig.issueSync.archiveRoot;
         }
+    });
+
+    test('NEO_LOG_LEVEL overrides config.logLevel with validation', async () => {
+        const configModule = await importTemplateConfig();
+        const config = configModule.default;
+
+        const originalEnv = process.env.NEO_LOG_LEVEL;
+        const originalWarn = console.warn;
+        const warnings = [];
+
+        console.warn = (...args) => warnings.push(args.join(' '));
+
+        try {
+            process.env.NEO_LOG_LEVEL = 'DEBUG';
+            config.applyEnv();
+            expect(config.logLevel).toBe('debug');
+
+            process.env.NEO_LOG_LEVEL = 'noisy';
+            config.data.logLevel = config.defaultConfig.logLevel;
+            config.applyEnv();
+            expect(config.logLevel).toBe(config.defaultConfig.logLevel);
+            expect(warnings.join('\n')).toContain('Invalid NEO_LOG_LEVEL value: "noisy"');
+        } finally {
+            console.warn = originalWarn;
+            if (originalEnv !== undefined) {
+                process.env.NEO_LOG_LEVEL = originalEnv;
+            } else {
+                delete process.env.NEO_LOG_LEVEL;
+            }
+            config.data.logLevel = config.defaultConfig.logLevel;
+        }
+    });
+
+    test('logger filters stderr by priority and always emits errors', async () => {
+        const aiConfig = (await import('../../../../../../../ai/mcp/server/github-workflow/config.mjs')).default;
+        const logger = (await import('../../../../../../../ai/mcp/server/github-workflow/logger.mjs')).default;
+
+        const originalDebug = aiConfig.data.debug;
+        const originalLogLevel = aiConfig.data.logLevel;
+        const originalError = console.error;
+        const calls = [];
+
+        console.error = (...args) => calls.push(args.join(' '));
+
+        try {
+            aiConfig.data.debug = false;
+            aiConfig.data.logLevel = 'warn';
+            logger.debug('debug-hidden');
+            logger.info('info-hidden');
+            logger.log('log-hidden');
+            logger.warn('warn-visible');
+            logger.error('error-visible');
+
+            expect(calls).toEqual([
+                '[WARN] warn-visible',
+                '[ERROR] error-visible'
+            ]);
+
+            calls.length = 0;
+            aiConfig.data.logLevel = 'info';
+            logger.debug('debug-hidden');
+            logger.info('info-visible');
+            logger.log('log-visible');
+            logger.warn('warn-visible');
+            logger.error('error-visible');
+
+            expect(calls).toEqual([
+                '[INFO] info-visible',
+                '[LOG] log-visible',
+                '[WARN] warn-visible',
+                '[ERROR] error-visible'
+            ]);
+
+            calls.length = 0;
+            aiConfig.data.logLevel = 'error';
+            logger.warn('warn-hidden');
+            logger.error('error-still-visible');
+
+            expect(calls).toEqual(['[ERROR] error-still-visible']);
+
+            calls.length = 0;
+            aiConfig.data.logLevel = 'warn';
+            aiConfig.data.debug = true;
+            logger.debug('legacy-debug-visible');
+
+            expect(calls).toEqual(['[DEBUG] legacy-debug-visible']);
+        } finally {
+            console.error = originalError;
+            aiConfig.data.debug = originalDebug;
+            aiConfig.data.logLevel = originalLogLevel;
+        }
+    });
+
+    test('syncGithubWorkflow CLI selects info by default and debug for --verbose', async () => {
+        const content = await fs.promises.readFile(cliScriptPath, 'utf8');
+
+        expect(content).not.toContain('GH_Config.data.debug = true');
+        expect(content).toContain("GH_Config.data.logLevel = verbose ? 'debug' : 'info'");
+        expect(content).toContain("process.argv.includes('--verbose')");
     });
 });


### PR DESCRIPTION
Authored by GPT-5 (Codex Desktop). Session 6ec143cb-2e5b-4964-94d6-eb28cb25bde2.

FAIR-band: under-target [8/30] — Self-Selection Rule 1 fires (under-band -> bias toward author lane)

Resolves #11477

Adds real priority filtering to the GitHub Workflow logger so `error` always prints, `warn` remains visible by default, and `info` / `debug` only print when the configured level permits them. The operator CLI now sets `logLevel = "info"` instead of forcing `debug = true`; `npm run ai:sync-github-workflow -- --verbose` opts into debug-level output.

Evidence: L2 (unit/runtime logger filtering, env-binding validation, CLI static contract, and GitHub-workflow syncer slice) -> L4 required (operator-side full clean-slate sync observation). Residual: post-merge operator CLI validation.

## Deltas from Ticket
The original title still describes the rejected `info -> debug` prescription. This PR follows the revised ticket body after the V-B-A correction: keep per-item events at `info`, add logger level filtering, and make the CLI choose the intended level explicitly.

## Config Template Follow-Up
Changed config keys: `logLevel` on `ai/mcp/server/github-workflow/config.template.mjs`.

Local `config.mjs` follow-up is not required for the CLI path or default MCP quiet behavior: the logger falls back to `warn` when `logLevel` is absent, and the CLI sets `GH_Config.data.logLevel` at runtime. Clones that want `NEO_LOG_LEVEL` env override support should refresh or manually add the new `logLevel` key and binding to their gitignored local GitHub Workflow config. Restarting the GitHub Workflow MCP server is recommended after merge so long-running server processes load the new logger code.

## Test Evidence
- `npm run test-unit -- test/playwright/unit/ai/mcp/server/github-workflow/ConfigCompleteness.spec.mjs` -> 5 passed.
- `npm run test-unit -- test/playwright/unit/ai/mcp/server/github-workflow/ConfigCompleteness.spec.mjs --workers=1` -> 5 passed.
- `npm run test-unit -- test/playwright/unit/ai/mcp/server/github-workflow/ConfigCompleteness.spec.mjs test/playwright/unit/ai/mcp/server/github-workflow/ToolRegistration.spec.mjs test/playwright/unit/ai/services/github-workflow/ContentPath.spec.mjs test/playwright/unit/ai/services/github-workflow/LocalFileService.spec.mjs test/playwright/unit/ai/services/github-workflow/MetadataManager.spec.mjs test/playwright/unit/ai/services/github-workflow/IssueSyncer.spec.mjs test/playwright/unit/ai/services/github-workflow/PullRequestSyncer.spec.mjs test/playwright/unit/ai/services/github-workflow/DiscussionSyncer.spec.mjs test/playwright/unit/ai/services/github-workflow/ReleaseNotesSyncer.spec.mjs` -> 87 passed after rebase.
- `git diff --check origin/dev...HEAD` -> passed.

## Post-Merge Validation
- [ ] Restart any long-running GitHub Workflow MCP server process that should use the new logger code.
- [ ] Optional: run `npm run ai:sync-github-workflow` and confirm normal CLI progress is info-level only; use `npm run ai:sync-github-workflow -- --verbose` for debug diagnostics.
- [ ] Optional: refresh gitignored local `ai/mcp/server/github-workflow/config.mjs` in clones that need `NEO_LOG_LEVEL` support.

## Commits
- `1383d21ca` — `fix(github-workflow): add log-level filtering (#11477)`

## Evolution
The implementation is the direct result of the operator challenge plus V-B-A: moving calls from `info` to `debug` was a no-op because the logger previously ignored level priority. The durable fix is to make the level API mean something, then configure the CLI and MCP surfaces explicitly.