### PR TITLE
fix(github-workflow/sync): comprehensive null-safety sweep across IssueSyncer + ghost-issue regression (#11481)

### DIFF
--- a/ai/services/github-workflow/sync/IssueSyncer.mjs
+++ b/ai/services/github-workflow/sync/IssueSyncer.mjs
@@ -133,23 +133,37 @@ class IssueSyncer extends Base {
      * @private
      */
     #formatIssueMarkdown(issue) {
+        // Defensive null-safety per #11481 (follow-up to #11474 / PR #11476's whack-a-mole gap):
+        // GitHub GraphQL returns null for issue.author when the author has been deleted (Ghost
+        // user), and individual nodes within labels/assignees/subIssues/blockedBy/blocking can
+        // also be null when their referenced entities are deleted. Each deref site uses optional
+        // chaining + filter-out for list entries. Fallback conventions match #11476's: 'Ghost'
+        // for users (matches existing line-186 actor/author convention); '(no title)' for
+        // missing entity titles; filter-out for null list entries (preserves array integrity
+        // without injecting fallback objects into structured fields).
         const frontmatter = {
             id                : issue.number,
-            title             : issue.title.replace(lineBreaksRegex, ' '),
+            title             : issue.title?.replace(lineBreaksRegex, ' ') || '(no title)',
             state             : issue.state,
-            labels            : issue.labels.nodes.map(l => l.name),
-            assignees         : issue.assignees.nodes.map(a => a.login),
+            labels            : (issue.labels?.nodes || []).map(l => l?.name).filter(Boolean),
+            assignees         : (issue.assignees?.nodes || []).map(a => a?.login).filter(Boolean),
             createdAt         : issue.createdAt,
             updatedAt         : issue.updatedAt,
             githubUrl         : issue.url,
-            author            : issue.author.login,
+            author            : issue.author?.login || 'Ghost',
             commentsCount     : this.#countTimelineComments(issue), // Derived from the exhausted timeline — #10110
-            parentIssue       : issue.parent ? issue.parent.number : null,
-            subIssues         : issue.subIssues?.nodes.map(sub => `[${sub.state === 'CLOSED' ? 'x' : ' '}] ${sub.number} ${sub.title.replace(lineBreaksRegex, ' ')}`) || [],
+            parentIssue       : issue.parent?.number ?? null,
+            subIssues         : (issue.subIssues?.nodes || []).map(sub =>
+                sub ? `[${sub.state === 'CLOSED' ? 'x' : ' '}] ${sub.number} ${sub.title?.replace(lineBreaksRegex, ' ') || '(no title)'}` : null
+            ).filter(Boolean),
             subIssuesCompleted: issue.subIssuesSummary?.completed || 0,
             subIssuesTotal    : issue.subIssuesSummary?.total || 0,
-            blockedBy         : issue.blockedBy?.nodes.map(b => `[${b.state === 'CLOSED' ? 'x' : ' '}] ${b.number} ${b.title.replace(lineBreaksRegex, ' ')}`) || [],
-            blocking          : issue.blocking?.nodes.map(b => `[${b.state === 'CLOSED' ? 'x' : ' '}] ${b.number} ${b.title.replace(lineBreaksRegex, ' ')}`) || []
+            blockedBy         : (issue.blockedBy?.nodes || []).map(b =>
+                b ? `[${b.state === 'CLOSED' ? 'x' : ' '}] ${b.number} ${b.title?.replace(lineBreaksRegex, ' ') || '(no title)'}` : null
+            ).filter(Boolean),
+            blocking          : (issue.blocking?.nodes || []).map(b =>
+                b ? `[${b.state === 'CLOSED' ? 'x' : ' '}] ${b.number} ${b.title?.replace(lineBreaksRegex, ' ') || '(no title)'}` : null
+            ).filter(Boolean)
         };
 
         if (issue.closedAt) {
@@ -159,7 +173,7 @@ class IssueSyncer extends Base {
             frontmatter.milestone = issue.milestone.title;
         }
 
-        let body = `# ${issue.title}\n\n`;
+        let body = `# ${issue.title || '(no title)'}\n\n`;
 
         body += issue.body || '*(No description provided)*';
         body += '\n\n';
@@ -303,9 +317,12 @@ class IssueSyncer extends Base {
         }
 
         for (const issue of fetchedIssues) {
+            // Null-safety per #11481: GitHub may return null label nodes or null name fields
+            // when labels have been deleted. Filter-out null/empty so droppedLabels matching
+            // works on the valid subset.
             const labels = issue.labels?.nodes
-                ? issue.labels.nodes.map(l => l.name.toLowerCase())
-                : issue.labels?.map(l => l.name?.toLowerCase() || l.toLowerCase()) || [];
+                ? issue.labels.nodes.map(l => l?.name?.toLowerCase()).filter(Boolean)
+                : issue.labels?.map(l => l?.name?.toLowerCase() || (typeof l === 'string' ? l.toLowerCase() : null)).filter(Boolean) || [];
 
             const isDropped = issueSyncConfig.droppedLabels.some(label => labels.includes(label));
 
@@ -402,10 +419,11 @@ class IssueSyncer extends Base {
     #getIssuePath(issue, planBuckets = new Map()) {
         const filename = `${issueSyncConfig.issueFilenamePrefix}${issue.number}.md`;
 
-        // Handle both GraphQL (issue.labels.nodes) and potential direct array
+        // Handle both GraphQL (issue.labels.nodes) and potential direct array.
+        // Null-safety per #11481: filter-out null nodes / null name fields (deleted labels).
         const labels = issue.labels?.nodes
-            ? issue.labels.nodes.map(l => l.name.toLowerCase())
-            : issue.labels?.map(l => l.name?.toLowerCase() || l.toLowerCase()) || [];
+            ? issue.labels.nodes.map(l => l?.name?.toLowerCase()).filter(Boolean)
+            : issue.labels?.map(l => l?.name?.toLowerCase() || (typeof l === 'string' ? l.toLowerCase() : null)).filter(Boolean) || [];
 
         const isDropped = issueSyncConfig.droppedLabels.some(label => labels.includes(label));
         if (isDropped) {

--- a/test/playwright/unit/ai/services/github-workflow/IssueSyncer.spec.mjs
+++ b/test/playwright/unit/ai/services/github-workflow/IssueSyncer.spec.mjs
@@ -455,6 +455,82 @@ test.describe('Neo.ai.services.github-workflow.sync.IssueSyncer', () => {
         expect(written).not.toMatch(/assigned to @(undefined|null)/);
         expect(written).not.toMatch(/added the `(undefined|null)` label/);
     });
+
+    test('formatIssueMarkdown null-safety: ghost issue (null author + null label/assignee/subIssue nodes) renders without crash (#11481)', async () => {
+        // Empirical anchor: post-#11476-merge sync_all crashed at IssueSyncer.mjs:145 on
+        // `issue.author.login` when the GitHub author had been deleted (Ghost user). This is
+        // the whack-a-mole companion to the #11474 timeline-event fix — same null-deref class
+        // in the FRONTMATTER ASSEMBLY method (#formatIssueMarkdown) that PR #11476 didn't sweep.
+        // This test exercises EVERY nullable frontmatter site simultaneously ("ghost issue")
+        // to prevent future whack-a-mole regressions.
+        const ghostIssue = {
+            number   : 42044,
+            title    : null, // null title
+            body     : 'Mock body for ghost issue regression #11481.',
+            state    : 'CLOSED',
+            createdAt: '2026-05-16T17:00:00Z',
+            updatedAt: '2026-05-16T18:00:00Z',
+            closedAt : '2026-05-16T17:30:00Z',
+            url      : 'https://github.com/neomjs/neo/issues/42044',
+            author   : null, // deleted GitHub user (Ghost) — the empirical crash
+            labels   : {nodes: [null, {name: null}, {name: 'bug'}]}, // null entries + null-name + valid
+            assignees: {nodes: [null, {login: null}, {login: 'tobiu'}]}, // same shape: null entries + null-login + valid
+            milestone: null,
+            parent   : null,
+            subIssues       : {nodes: [null, {state: 'OPEN', number: 100, title: null}, {state: 'CLOSED', number: 101, title: 'valid sub'}]},
+            subIssuesSummary: {total: 2, completed: 1, percentCompleted: 50},
+            blockedBy       : {nodes: [null, {state: 'OPEN', number: 200, title: null}]},
+            blocking        : {nodes: [{state: 'CLOSED', number: 300, title: 'valid blocker'}]},
+            timelineItems   : {
+                pageInfo: {hasNextPage: false, endCursor: null},
+                nodes   : [] // empty timeline; the format-event path is covered by the prior test
+            }
+        };
+
+        GraphqlService.query = async (query) => {
+            if (query.includes('FetchSingleIssue')) {
+                return {repository: {issue: structuredClone(ghostIssue)}};
+            }
+            throw new Error(`Unexpected GraphQL query in test: ${query.slice(0, 80)}`);
+        };
+
+        const metadata = {issues: {}};
+        const stats    = await IssueSyncer.refetchIssuesByNumber([ghostIssue.number], metadata);
+
+        // No crash → refetch succeeds despite every nullable frontmatter field being null.
+        expect(stats.refetched.count).toBe(1);
+        expect(stats.errors).toHaveLength(0);
+
+        // ghost issue is CLOSED post-latest-release (no release applies; sortedReleases empty by default),
+        // so it lands in the active issues directory rather than archive — assert the file exists wherever it landed.
+        const writtenRelativePath = metadata.issues[ghostIssue.number].path;
+        const writtenAbsolutePath = path.resolve(aiConfig.projectRoot, writtenRelativePath);
+        const written             = await fs.readFile(writtenAbsolutePath, 'utf-8');
+
+        // Frontmatter fallback markers landed correctly. Use quote-agnostic regex because
+        // gray-matter's YAML serializer chooses single/double quoting based on content.
+        expect(written).toMatch(/author:\s*['"]?Ghost['"]?/); // null issue.author → 'Ghost' fallback
+        expect(written).toMatch(/title:\s*['"]?\(no title\)['"]?/); // null title → '(no title)' fallback
+        expect(written).toContain('# (no title)'); // body header uses same fallback
+
+        // List-mapped fields: nulls filtered out; valid entries preserved.
+        // labels: [null, {name: null}, {name: 'bug'}] → ['bug']
+        expect(written).toMatch(/labels:\s*\n\s*- bug\s*\n/);
+        // assignees: [null, {login: null}, {login: 'tobiu'}] → ['tobiu']
+        expect(written).toMatch(/assignees:\s*\n\s*- tobiu\s*\n/);
+
+        // subIssues: [null, {title: null}, {title: 'valid sub'}] → 2 entries (the null-title becomes '(no title)' marker; the null node is filtered out)
+        expect(written).toMatch(/100[^\n]*\(no title\)/);
+        expect(written).toContain('101 valid sub');
+
+        // blockedBy: [null, {title: null}] → 1 entry with '(no title)' marker
+        expect(written).toMatch(/200[^\n]*\(no title\)/);
+
+        // No literal undefined/null leaks anywhere in the frontmatter.
+        expect(written).not.toMatch(/author:\s*(undefined|null)\s*$/m);
+        expect(written).not.toMatch(/^\s*-\s+(undefined|null)\s*$/m);
+        expect(written).not.toContain('undefined');
+    });
 });
 
 function buildComment(i) {


### PR DESCRIPTION
Authored by Claude Opus 4.7 (Claude Code). Session 0064efde-455e-4ecd-a26f-574381b3766a.

FAIR-band: in-band [7/30] — direct follow-up to my own PR #11476 incompleteness; quick-win bug fix shape.

**Evidence**: L2 (7/7 IssueSyncer specs pass including the new comprehensive ghost-issue regression test that exercises ALL nullable frontmatter sites simultaneously + the sibling labels-deref in `#getIssuePath` / `#planBuckets`) → L4 required (operator re-runs `npm run ai:sync-github-workflow`; sync processes past v8.1.0/chunk-28 ghost-author crash AND any other ghost-issue in the corpus). Residual: operator post-merge sync_all verification — annotated on #11481's AC list as final checkbox.

## Summary

Comprehensive null-safety sweep across `IssueSyncer.mjs`. Breaks the whack-a-mole pattern that PR #11476 left open: that PR fixed `#formatTimelineEvent` (per-event timeline rendering) but did NOT sweep sibling methods in the same file with identical null-deref class.

## Empirical motivation

Operator ran `npm run ai:sync-github-workflow` post-#11476-merge. Sync processed through v8.1.0/chunk-28 then crashed at `IssueSyncer.mjs:145` (`issue.author.login` — Ghost user). Same root pattern as #11474; different surface.

Operator framing 2026-05-16: **"we need unit testing to ensure it works."** That's the load-bearing teaching for this PR. The prior test (PR #11476) verified one method; this test verifies the full failure surface end-to-end with a fully-null "ghost issue" mock.

## What changed

| File | Type | Delta |
|------|------|-------|
| `ai/services/github-workflow/sync/IssueSyncer.mjs` | Modified | `#formatIssueMarkdown` hardened across all nullable sites (title/labels/assignees/author/parent/subIssues/blockedBy/blocking); `#getIssuePath` + `#planBuckets` labels-mapping for droppedLabels now null-safe |
| `test/playwright/unit/ai/services/github-workflow/IssueSyncer.spec.mjs` | Modified | New comprehensive "ghost issue" regression test exercising every nullable frontmatter site simultaneously |

Total: 2 files, +108/-14 lines.

## Comprehensive sweep audit

| Method | Line | Before | After |
|--------|------|--------|-------|
| `#formatIssueMarkdown` | 138 | `issue.title.replace(...)` | `issue.title?.replace(...) \|\| '(no title)'` |
| `#formatIssueMarkdown` | 140 | `issue.labels.nodes.map(l => l.name)` | `(issue.labels?.nodes \|\| []).map(l => l?.name).filter(Boolean)` |
| `#formatIssueMarkdown` | 141 | `issue.assignees.nodes.map(a => a.login)` | `(issue.assignees?.nodes \|\| []).map(a => a?.login).filter(Boolean)` |
| **`#formatIssueMarkdown`** | **145** | **`issue.author.login`** | **`issue.author?.login \|\| 'Ghost'`** (the empirical crash) |
| `#formatIssueMarkdown` | 147 | `issue.parent ? issue.parent.number : null` | `issue.parent?.number ?? null` |
| `#formatIssueMarkdown` | 148 | `sub.title.replace(...)` | `sub.title?.replace(...) \|\| '(no title)'` + null-node filter |
| `#formatIssueMarkdown` | 151-152 | same pattern (b.title) | same fix |
| `#formatIssueMarkdown` | 162 | `# ${issue.title}` body header | `# ${issue.title \|\| '(no title)'}` |
| `#planBuckets` | 321 | `issue.labels.nodes.map(l => l.name.toLowerCase())` | `.map(l => l?.name?.toLowerCase()).filter(Boolean)` |
| `#getIssuePath` | 421 | same as above | same fix |

Fallback marker conventions: 'Ghost' for users (matches PR #11476 + line-186 existing convention); '(no title)' for missing entity titles; filter-out for null list entries (preserves array integrity without injecting fallback objects).

## V-B-A evidence

- **7/7 IssueSyncer specs pass** (`npm run test-unit -- --grep "IssueSyncer"` → 2.0s).
- New "ghost issue" regression test exercises EVERY nullable frontmatter site simultaneously:
  - `author: null` (deleted Ghost user — the empirical crash)
  - `labels.nodes: [null, {name: null}, {name: 'bug'}]` (null entries + null name + valid)
  - `assignees.nodes: [null, {login: null}, {login: 'tobiu'}]` (same pattern)
  - `subIssues.nodes: [null, {title: null}, {title: 'valid sub'}]` (same pattern)
  - `blockedBy.nodes: [null, {title: null}]` (null entries + null title)
  - `title: null` (null title)
- Assertions verify both fallback-marker correctness AND no literal `undefined`/`null` leaks.
- The test ALSO exercises `#getIssuePath`'s labels-deref via `refetchIssuesByNumber` (null label nodes would have crashed before this PR's `#getIssuePath` fix).

## Sibling syncer correctness (V-B-A — already correct, NOT touched)

- `PullRequestSyncer.mjs:250` — `author: pr.author?.login \|\| 'unknown'` ✓
- `DiscussionSyncer.mjs:244` — `author: discussion.author?.login \|\| 'unknown'` ✓
- `DiscussionSyncer.mjs:256` — `comment.author?.login \|\| 'unknown'` ✓

Only `IssueSyncer` was incomplete. This PR brings it to the same defensive standard.

## Test plan

- [x] 7/7 IssueSyncer specs pass locally.
- [x] New ghost-issue test exercises EVERY nullable frontmatter site simultaneously + sibling `#getIssuePath` labels-deref.
- [x] Branch-from-`origin/dev`-tip freshness check passed.
- [x] `git diff --check` passed.
- [ ] Cross-family review APPROVED (Gemini offline 90m per operator 17:46Z; routing to GPT).
- [ ] `@tobiu` merge.
- [ ] **L4 verification**: operator re-runs `npm run ai:sync-github-workflow`; sync processes past v8.1.0/chunk-28 ghost-author crash AND any other ghost-issue in the corpus.

## Avoided traps

- **Whack-a-mole pattern (the trap THIS PR exists to break)**: rejected — must sweep ALL null-deref sites in IssueSyncer.mjs, not just the empirical crash line. The "ghost issue" mock exercises the WHOLE file's failure surface via the existing test pipeline.
- **Only fixing `#formatIssueMarkdown`**: rejected — `#getIssuePath` + `#planBuckets` share the labels-mapping null-deref. Same-file sweep.
- **Filtering at GraphQL fetch time**: rejected (same as #11474 / #11476) — loses archive context for issues with deleted entities.
- **Adding Zod validation at SDK boundary**: rejected — runtime validation is too heavyweight for what's a render-time defensive concern; optional-chaining at the render site is the right scope.

## Related

- **Direct parent**: #11474 / PR #11476 (timeline-event null-safety only — this PR completes the IssueSyncer sweep)
- **Sibling correctness references**: PullRequestSyncer.mjs:250 + DiscussionSyncer.mjs:244+256 (already use the right pattern; NOT modified by this PR)
- **Empirical anchor**: operator's 2026-05-16 sync_all run from main checkout post-#11476-merge, crashed at IssueSyncer.mjs:145 (`issue.author.login`) after processing issues through v8.1.0/chunk-28
- **Operator framing**: "we need unit testing to ensure it works" (2026-05-16T18:00:00Z paste)

Resolves #11481
