### PR TITLE
fix(ai): compact wake digest priority text (#10605)

### DIFF
--- a/ai/scripts/bridge-daemon.mjs
+++ b/ai/scripts/bridge-daemon.mjs
@@ -522,7 +522,8 @@ async function flushSubscription(subId) {
     if (messages.length > 0) {
         const latest = messages[messages.length - 1];
         const latestPriority = normalizeWakePriority(latest.priority);
-        breakdown += `\n- ${messages.length} new messages (latest: "${latest.subject}" from ${latest.from}, priority: ${latestPriority})`;
+        const prioritySuffix = latestPriority === digestPriority ? '' : `, latest priority: ${latestPriority}`;
+        breakdown += `\n- ${messages.length} new messages (latest: "${latest.subject}" from ${latest.from}${prioritySuffix})`;
     }
     if (tasks.length > 0) {
         const latest = tasks[tasks.length - 1];

--- a/test/playwright/unit/ai/scripts/bridge-daemon.spec.mjs
+++ b/test/playwright/unit/ai/scripts/bridge-daemon.spec.mjs
@@ -142,7 +142,7 @@ test.describe('Bridge Daemon', () => {
         expect(output).toContain('[Bridge Daemon Test Adapter] Delivered');
         expect(output).toContain('[WAKE][priority:normal]');
         expect(output).toContain('Test Wake Event');
-        expect(output).toContain('priority: normal');
+        expect(output).not.toContain('priority: normal');
         expect(output).not.toContain('\nWindow:');
 
         // Per #10419 — verify the diagnostic log file was persisted to disk and contains
@@ -325,10 +325,10 @@ test.describe('Bridge Daemon', () => {
         expect(finalDigest).toContain('1 new messages');
         expect(finalDigest).toContain('Test Dedup Event');
         expect(finalDigest).toContain('[WAKE][priority:normal]');
-        expect(finalDigest).toContain('priority: normal');
+        expect(finalDigest).not.toContain('priority: normal');
     });
 
-    test('uses the highest coalesced message priority in the wake digest header', async () => {
+    test('uses the highest coalesced message priority in the wake digest header and preserves divergent latest priority', async () => {
         const subId = 'sub_' + crypto.randomUUID();
         const agentId = '@test-agent-priority';
 
@@ -376,27 +376,6 @@ test.describe('Bridge Daemon', () => {
 
         await new Promise(resolve => setTimeout(resolve, 1000));
 
-        const lowMsgId = 'msg_' + crypto.randomUUID();
-        db.prepare('INSERT INTO Nodes (id, data) VALUES (?, ?)').run(lowMsgId, JSON.stringify({
-            id: lowMsgId,
-            label: 'MESSAGE',
-            properties: {
-                from: '@sender',
-                subject: 'Low Priority Wake Event',
-                priority: 'low'
-            }
-        }));
-        db.prepare('INSERT INTO GraphLog (entity_id, entity_type) VALUES (?, ?)').run(lowMsgId, 'nodes');
-
-        const lowEdgeId = 'edge_' + crypto.randomUUID();
-        db.prepare('INSERT INTO Edges (id, data, source, target, type) VALUES (?, ?, ?, ?, ?)').run(lowEdgeId, JSON.stringify({
-            id: lowEdgeId,
-            source: lowMsgId,
-            target: agentId,
-            type: 'SENT_TO'
-        }), lowMsgId, agentId, 'SENT_TO');
-        db.prepare('INSERT INTO GraphLog (entity_id, entity_type) VALUES (?, ?)').run(lowEdgeId, 'edges');
-
         const highMsgId = 'msg_' + crypto.randomUUID();
         db.prepare('INSERT INTO Nodes (id, data) VALUES (?, ?)').run(highMsgId, JSON.stringify({
             id: highMsgId,
@@ -418,11 +397,32 @@ test.describe('Bridge Daemon', () => {
         }), highMsgId, agentId, 'SENT_TO');
         db.prepare('INSERT INTO GraphLog (entity_id, entity_type) VALUES (?, ?)').run(highEdgeId, 'edges');
 
+        const lowMsgId = 'msg_' + crypto.randomUUID();
+        db.prepare('INSERT INTO Nodes (id, data) VALUES (?, ?)').run(lowMsgId, JSON.stringify({
+            id: lowMsgId,
+            label: 'MESSAGE',
+            properties: {
+                from: '@sender',
+                subject: 'Low Priority Wake Event',
+                priority: 'low'
+            }
+        }));
+        db.prepare('INSERT INTO GraphLog (entity_id, entity_type) VALUES (?, ?)').run(lowMsgId, 'nodes');
+
+        const lowEdgeId = 'edge_' + crypto.randomUUID();
+        db.prepare('INSERT INTO Edges (id, data, source, target, type) VALUES (?, ?, ?, ?, ?)').run(lowEdgeId, JSON.stringify({
+            id: lowEdgeId,
+            source: lowMsgId,
+            target: agentId,
+            type: 'SENT_TO'
+        }), lowMsgId, agentId, 'SENT_TO');
+        db.prepare('INSERT INTO GraphLog (entity_id, entity_type) VALUES (?, ?)').run(lowEdgeId, 'edges');
+
         const output = await deliveryPromise;
         expect(output).toContain('[WAKE][priority:high]');
         expect(output).toContain('2 new messages');
-        expect(output).toContain('High Priority Wake Event');
-        expect(output).toContain('priority: high');
+        expect(output).toContain('Low Priority Wake Event');
+        expect(output).toContain('latest priority: low');
     });
 
     test('skips osascript delivery and logs error when appName is missing', async () => {


### PR DESCRIPTION
Authored by GPT-5 (Codex Desktop). Session 6ec143cb-2e5b-4964-94d6-eb28cb25bde2.

FAIR-band: in-band [9/30] — self-selected after peer-review lanes hit human/reviewer gates; small hot-path MX-noise fix from v13 Project 12 View 2.

Evidence: L2 (focused bridge-daemon unit spec 13/13 passed with --workers=1 after rebase) -> L4 optional (operator observes future single-message wake digests omit redundant latest-message priority when it matches the header).

## Summary

Compacts wake digest rendering so the latest-message priority is only printed when it adds information beyond the digest header.

## What Changed

- Keeps `[WAKE][priority:<level>]` as the canonical header signal.
- Omits the line-item `priority: normal` / `priority: high` fragment when the latest message priority equals the digest priority.
- Preserves a line-item `latest priority: <level>` fragment when a coalesced batch has a stronger header priority than the latest message.
- Updates bridge-daemon tests for both compact same-priority rendering and divergent coalesced rendering.

## Ticket Intake

- Live issue #10605 is open, unassigned, fully labeled, and pre-stale under the repo 90-day stale threshold.
- Parent epic #10311 has a prior @neo-gpt epic-review comment: https://github.com/neomjs/neo/issues/10311#issuecomment-4360834821
- Duplicate/successor sweep found predecessor #10525 / PR #10526, not an equivalent active follow-up.
- Current code still rendered the redundant line-item priority at `ai/scripts/bridge-daemon.mjs`.

## Validation

- `npm run test-unit -- test/playwright/unit/ai/scripts/bridge-daemon.spec.mjs --workers=1` -> 13 passed.
- `git diff --check origin/dev...HEAD` -> passed.
- Branch rebased onto current `origin/dev` after #11480 and #11482 merged; outgoing log contains only `4946374e6 fix(ai): compact wake digest priority text (#10605)`.

## Post-Merge Validation

- [ ] Observe a future single-message wake digest and confirm it renders header priority only.
- [ ] Observe or synthesize a mixed-priority coalesced wake and confirm latest-message priority remains visible when divergent.

Resolves #10605