### PR TITLE
fix(github-workflow/sync): downgrade per-item Created/Moved/Updated logs to DEBUG (#11484)

### DIFF
--- a/ai/services/github-workflow/sync/DiscussionSyncer.mjs
+++ b/ai/services/github-workflow/sync/DiscussionSyncer.mjs
@@ -294,7 +294,7 @@ class DiscussionSyncer extends Base {
                 if (oldAbsolutePath && oldAbsolutePath !== targetPath) {
                     try {
                         await fs.unlink(oldAbsolutePath);
-                        logger.info(`📦 Moved Discussion #${discussion.number}: ${oldAbsolutePath} → ${targetPath}`);
+                        logger.debug(`📦 Moved Discussion #${discussion.number}: ${oldAbsolutePath} → ${targetPath}`);
                     } catch (e) {
                         // File might not exist
                     }

--- a/ai/services/github-workflow/sync/IssueSyncer.mjs
+++ b/ai/services/github-workflow/sync/IssueSyncer.mjs
@@ -95,7 +95,7 @@ class IssueSyncer extends Base {
 
             const page = data.repository.issue.timelineItems;
             allNodes.push(...page.nodes);
-            logger.info(`  📄 Fetched timeline page for #${issue.number}: +${page.nodes.length} events (cumulative: ${allNodes.length})`);
+            logger.debug(`  📄 Fetched timeline page for #${issue.number}: +${page.nodes.length} events (cumulative: ${allNodes.length})`);
 
             cursor = page.pageInfo.hasNextPage ? page.pageInfo.endCursor : null;
         }
@@ -797,7 +797,7 @@ class IssueSyncer extends Base {
 
                 stats.refetched.count++;
                 stats.refetched.issues.push(issueNumber);
-                logger.info(`✅ Refetched issue #${issueNumber}`);
+                logger.debug(`✅ Refetched issue #${issueNumber}`);
 
                 metadata.issues[issueNumber] = {
                     state        : issue.state,
@@ -885,7 +885,7 @@ class IssueSyncer extends Base {
                     continue;
                 }
 
-                logger.info(`📝 Content changed for #${issueNumber}`);
+                logger.debug(`📝 Content changed for #${issueNumber}`);
 
                 // Step 1: Get the issue's GraphQL ID
                 const idData = await GraphqlService.query(GET_ISSUE_ID, {
@@ -1002,7 +1002,7 @@ class IssueSyncer extends Base {
                     continue;
                 }
 
-                logger.info(`📦 Archiving closed issue #${issueNumber}: ${currentAbsolutePath} → ${correctPath}`);
+                logger.debug(`📦 Archiving closed issue #${issueNumber}: ${currentAbsolutePath} → ${correctPath}`);
 
                 try {
                     // Ensure target directory exists
@@ -1017,7 +1017,7 @@ class IssueSyncer extends Base {
                     stats.count++;
                     stats.issues.push(parseInt(issueNumber));
 
-                    logger.info(`✅ Archived #${issueNumber} to ${path.relative(process.cwd(), correctPath)}`);
+                    logger.debug(`✅ Archived #${issueNumber} to ${path.relative(process.cwd(), correctPath)}`);
                 } catch (e) {
                     logger.error(`❌ Failed to archive #${issueNumber}: ${e.message}`);
                 }

--- a/ai/services/github-workflow/sync/IssueSyncer.mjs
+++ b/ai/services/github-workflow/sync/IssueSyncer.mjs
@@ -585,7 +585,7 @@ class IssueSyncer extends Base {
                     try {
                         const oldPath = this.#resolvePath(oldPathRelative);
                         await fs.unlink(oldPath);
-                        logger.info(`🗑️ Removed dropped issue #${issueNumber}: ${oldPath}`);
+                        logger.debug(`🗑️ Removed dropped issue #${issueNumber}: ${oldPath}`);
                     } catch (e) { /* File might not exist */ }
                 }
                 // Remove from metadata
@@ -617,19 +617,19 @@ class IssueSyncer extends Base {
 
                 if (!oldIssue) {
                     stats.pulled.created++;
-                    logger.info(`✨ Created #${issueNumber}: ${targetPath}`);
+                    logger.debug(`✨ Created #${issueNumber}: ${targetPath}`);
                 } else if (oldAbsolutePath && oldAbsolutePath !== targetPath) {
                     stats.pulled.moved++;
                     try {
                         await fs.rename(oldAbsolutePath, targetPath);
-                        logger.info(`📦 Moved #${issueNumber}: ${oldAbsolutePath} → ${targetPath}`);
+                        logger.debug(`📦 Moved #${issueNumber}: ${oldAbsolutePath} → ${targetPath}`);
                     } catch (e) {
                         logger.warn(`Could not rename #${issueNumber}, falling back to write. Error: ${e.message}`);
                         await fs.unlink(oldAbsolutePath).catch(() => {});
                     }
                 } else {
                     stats.pulled.updated++;
-                    logger.info(`✅ Updated #${issueNumber}: ${targetPath}`);
+                    logger.debug(`✅ Updated #${issueNumber}: ${targetPath}`);
                 }
             }
 
@@ -917,7 +917,7 @@ class IssueSyncer extends Base {
                     body: cleanBody
                 });
 
-                logger.info(`✅ Updated GitHub issue #${issueNumber} via GraphQL`);
+                logger.debug(`✅ Updated GitHub issue #${issueNumber} via GraphQL`);
                 stats.count++;
                 stats.issues.push(issueNumber);
             } catch (e) {

--- a/ai/services/github-workflow/sync/PullRequestSyncer.mjs
+++ b/ai/services/github-workflow/sync/PullRequestSyncer.mjs
@@ -311,7 +311,7 @@ class PullRequestSyncer extends Base {
                 if (oldAbsolutePath && oldAbsolutePath !== targetPath) {
                     try {
                         await fs.unlink(oldAbsolutePath);
-                        logger.info(`📦 Moved PR #${pr.number}: ${oldAbsolutePath} → ${targetPath}`);
+                        logger.debug(`📦 Moved PR #${pr.number}: ${oldAbsolutePath} → ${targetPath}`);
                     } catch (e) {
                         // File might not exist
                     }

--- a/ai/services/github-workflow/sync/ReleaseNotesSyncer.mjs
+++ b/ai/services/github-workflow/sync/ReleaseNotesSyncer.mjs
@@ -253,7 +253,7 @@ class ReleaseNotesSyncer extends Base {
 
                 await fs.mkdir(path.dirname(filePath), { recursive: true });
                 await fs.writeFile(filePath, content, 'utf-8');
-                logger.info(`✅ Synced release notes for ${release.tagName}`);
+                logger.debug(`✅ Synced release notes for ${release.tagName}`);
                 stats.count++;
                 stats.synced.push(release.tagName);
             } catch (e) {


### PR DESCRIPTION
Authored by Claude Opus 4.7 (Claude Code). Session 0064efde-455e-4ecd-a26f-574381b3766a.

FAIR-band: in-band [8/30] — completes the second half of #11477's original prescription; quick-win MX-friction reduction.

**Evidence**: L2 (12/12 syncer unit specs pass; no spec asserts on log level, downgrade is invisible to tests) → L4 required (operator re-runs `npm run ai:sync-github-workflow`; CLI output is bounded to phase headers + final summaries instead of ~35k per-item INFO lines). Residual: post-merge operator verification.

## Summary

Downgrade per-item `Created` / `Moved` / `Updated` / `Removed dropped` event logs from `logger.info` to `logger.debug` across the 4 syncers. Default-CLI runs (`logLevel: 'info'`) now show only phase headers + final summaries; operators wanting per-item detail opt-in via `npm run ai:sync-github-workflow -- --verbose` (already wired by PR #11480).

## Empirical motivation

Operator 2026-05-16T18:35Z paste post-#11480-merge:

```
[INFO] ✨ Created #160: /Users/.../archive/issues/v8.1.0/chunk-2/issue-160.md
[INFO] ✨ Created #304: /Users/.../archive/issues/v8.1.0/chunk-3/issue-304.md
[INFO] ✨ Created #300: /Users/.../archive/issues/v8.1.0/chunk-3/issue-300.md
... (continues for thousands of lines)
```

Per-item `logger.info` calls bypass PR #11480's `logLevel: 'info'` filter because their level matches the CLI default. The original #11477 prescription (info → debug) was correct intent but couldn't land before #11480 added the logger filtering substrate. With filtering now in place, this completes the prescription's second half.

## What changed

| File | Site count | Sites |
|------|-----------|-------|
| `IssueSyncer.mjs` | 10 | `📄 Fetched timeline page` / `🗑️ Removed dropped issue` / `✨ Created` / `📦 Moved` / `✅ Updated` / `✅ Refetched issue` / `📝 Content changed` / `✅ Updated GitHub issue via GraphQL` / `📦 Archiving closed issue` / `✅ Archived` |
| `PullRequestSyncer.mjs` | 1 | `📦 Moved PR` |
| `DiscussionSyncer.mjs` | 1 | `📦 Moved Discussion` |
| `ReleaseNotesSyncer.mjs` | 1 | `✅ Synced release notes for ${tagName}` |

Total: 4 files, +13/-13 lines (mechanical level reassignment).

## What's preserved at INFO

Operator visibility narrative remains intact at the default CLI level:
- **Phase headers**: `📥 Fetching issues from GitHub via GraphQL...`, `🔄 Reconciling closed issue locations...`, `📄 Syncing release notes...`, etc.
- **Final per-syncer summaries**: `✨ Synced N modified pull requests to disk.`, `📦 Archived N closed issue(s)`, `✅ Synced 0 discussions (all up to date).`, etc.
- **`_index.json` write confirmation**: `✅ Synced _index.json for release-notes`

Plus: `warn`/`error` levels untouched — anomalies + failures still print.

## Test plan

- [x] 12/12 syncer unit specs pass (`IssueSyncer + PullRequestSyncer + DiscussionSyncer + ReleaseNotesSyncer`).
- [x] No spec asserts on log level today; downgrade is invisible to existing tests.
- [x] Branch-from-`origin/dev`-tip freshness check passed.
- [ ] Cross-family review APPROVED.
- [ ] `@tobiu` merge.
- [ ] **L4 verification**: operator re-runs `npm run ai:sync-github-workflow` post-merge; CLI output is bounded to phase headers + final summaries (~30 lines per syncer phase instead of ~thousands). `--verbose` flag still produces per-item debug output for diagnostic use.

## Authority anchors

- **Direct parent**: #11477 / PR #11480 (logger filtering substrate)
- **Original prescription**: my #11477 ticket prescription before V-B-A reshape — was correct in intent (info → debug for per-item events) but couldn't land before #11480 added logger filtering. This PR delivers the second half cleanly.
- **Empirical anchor**: operator log paste 2026-05-16T18:35Z showing the post-#11480-merge per-item flood

## Avoided traps

- **Adding `--quiet` flag**: rejected per #11477 Out of Scope — `NEO_LOG_LEVEL=warn npm run ai:sync-github-workflow` already achieves quiet via the env binding PR #11480 added.
- **Removing per-item logs entirely**: rejected — operators need per-item visibility for debugging stuck syncs; preserved via `--verbose` opt-in.
- **Adding batch-summary INFO checkpoints (every N items)**: deferred — separate ticket if INFO-level progress signal feels too sparse post-this-fix. Phase headers + final summaries already provide bounded INFO narrative.

## Related

- **Parent context**: PR #11480 (logger filtering substrate — merged)
- **Original prescription source**: #11477 (closed via #11480; this PR delivers the prescription's second half per the reshape)
- **Adjacent**: PR #11476 + #11482 (IssueSyncer null-safety — solved the crashes that revealed this log-volume friction)

Resolves #11484
