### PR TITLE
fix(github-workflow/sync): filter ARCHIVE ANOMALY false-positive WARN volume (#11486)

### DIFF
--- a/ai/services/github-workflow/sync/IssueSyncer.mjs
+++ b/ai/services/github-workflow/sync/IssueSyncer.mjs
@@ -5,6 +5,7 @@ import fs                                            from 'fs/promises';
 import logger                                        from '../../../mcp/server/github-workflow/logger.mjs';
 import matter                                        from 'gray-matter';
 import path                                          from 'path';
+import semver                                        from 'semver';
 import GraphqlService                                from '../GraphqlService.mjs';
 import ReleaseNotesSyncer                                 from './ReleaseNotesSyncer.mjs';
 import {FETCH_ISSUE_TIMELINE_PAGE, FETCH_ISSUES_FOR_SYNC, FETCH_SINGLE_ISSUE} from '../queries/issueQueries.mjs';
@@ -42,6 +43,16 @@ class IssueSyncer extends Base {
          */
         singleton: true
     }
+
+    /**
+     * Per-sync-cycle dedupe set tracking issue numbers already emitted as ARCHIVE ANOMALY WARN.
+     * `#planBuckets` is invoked from multiple sync entry points (pullFromGitHub, refetchIssuesByNumber,
+     * reconcileClosedIssueLocations) which would otherwise duplicate-warn for the same issue within
+     * a single sync. Cleared at the top of `pullFromGitHub` (the natural sync-cycle entrypoint).
+     * @member {Set<number>} #warnedAnomalies
+     * @private
+     */
+    #warnedAnomalies = new Set();
 
     /**
      * Calculates a SHA-256 hash of the given content for change detection.
@@ -374,7 +385,26 @@ class IssueSyncer extends Base {
             }
 
             if (issue.oldVersion && issue.oldVersion !== version) {
-                logger.warn(`🚨 [ARCHIVE ANOMALY] Issue #${issue.number} closedAt shift detected: moving from bucket '${issue.oldVersion}' to '${version}'. Dry-run review required.`);
+                // Filter false-positive WARN volume during ADR 0004 clean-cut migration window (#11486).
+                // `oldVersion` derives from the cached path's directory name (see lines ~310-317); during
+                // migration, that contains pre-cut title-derived strings (e.g. 'vneo.d.ts - Typescript
+                // definitions...') that fail semver validation. Sealed-chunk enforcement at the
+                // reconcile step (~L569/L575) already prevents these from causing actual moves, so
+                // emitting WARN is pure noise. Real release-boundary recalculations (e.g. v11.12.0 →
+                // v11.13.0) where both sides are valid semver remain at WARN.
+                const oldIsValidTag = semver.valid(semver.clean(issue.oldVersion)) !== null;
+                const newIsValidTag = semver.valid(semver.clean(version))            !== null;
+
+                if (oldIsValidTag && newIsValidTag) {
+                    // Dedupe across multiple `#planBuckets` call sites within one sync cycle (#11486).
+                    if (!this.#warnedAnomalies.has(issue.number)) {
+                        this.#warnedAnomalies.add(issue.number);
+                        logger.warn(`🚨 [ARCHIVE ANOMALY] Issue #${issue.number} closedAt shift detected: moving from bucket '${issue.oldVersion}' to '${version}'. Dry-run review required.`);
+                    }
+                } else {
+                    // Migration-state mismatch (one side is not a valid semver tag) — quiet observability only.
+                    logger.debug(`[ARCHIVE MIGRATION] Issue #${issue.number}: oldBucket='${issue.oldVersion}' → newBucket='${version}' (sealed-chunk enforcement preserves location)`);
+                }
             }
 
             if (!buckets.has(version)) buckets.set(version, []);
@@ -479,6 +509,12 @@ class IssueSyncer extends Base {
      */
     async pullFromGitHub(metadata) {
         logger.info('📥 Fetching issues from GitHub via GraphQL...');
+
+        // Reset per-sync-cycle dedupe set for ARCHIVE ANOMALY WARN emission (#11486).
+        // pullFromGitHub is the natural top-of-sync entrypoint; reconcileClosedIssueLocations and
+        // refetchIssuesByNumber called later in the cycle will reuse the same set, so the same
+        // issue is WARN'd at most once per full sync.
+        this.#warnedAnomalies.clear();
 
         let allIssues   = [];
         let hasNextPage = true;

--- a/test/playwright/unit/ai/services/github-workflow/IssueSyncer.spec.mjs
+++ b/test/playwright/unit/ai/services/github-workflow/IssueSyncer.spec.mjs
@@ -531,6 +531,138 @@ test.describe('Neo.ai.services.github-workflow.sync.IssueSyncer', () => {
         expect(written).not.toMatch(/^\s*-\s+(undefined|null)\s*$/m);
         expect(written).not.toContain('undefined');
     });
+
+    test('ARCHIVE ANOMALY WARN: only fires when both buckets parse as valid semver tags (#11486)', async () => {
+        // Empirical anchor: operator 2026-05-16T19:33Z paste — `npm run ai:sync-github-workflow`
+        // post-#11485-merge produced thousands of `[WARN] 🚨 [ARCHIVE ANOMALY]` lines, dominated by
+        // migration-shape false positives (oldVersion = title-derived garbage like
+        // 'vneo.d.ts - Typescript definitions for all neo framework classes') where sealed-chunk
+        // semantics already prevent any actual move. Only genuine vX.Y.Z → vX.Y.Z shifts (e.g.
+        // #7910 v11.12.0 → v11.13.0) are actionable anomalies and should retain WARN level.
+        //
+        // This test exercises two issues simultaneously:
+        // - Issue A: cached path bucket is title-derived garbage → semver.valid returns null →
+        //   DEBUG emitted, NO WARN
+        // - Issue B: cached path bucket is valid semver tag (v11.12.0) shifting to another valid
+        //   semver tag (v11.13.0) → WARN emitted exactly once
+        const issueAMigrationShape = buildMockIssue({
+            number       : 3285,
+            title        : 'Mock migration-shape issue (#11486 filter test)',
+            timelineFirst: [],
+            hasNextPage  : false,
+            endCursor    : null
+        });
+        issueAMigrationShape.state    = 'CLOSED';
+        issueAMigrationShape.closedAt = '2026-05-15T10:00:00Z';
+        issueAMigrationShape.milestone = {title: 'v8.1.0'}; // new resolution: valid semver
+
+        const issueBSemverShift = buildMockIssue({
+            number       : 7910,
+            title        : 'Mock valid-semver-shift issue (#11486 filter test)',
+            timelineFirst: [],
+            hasNextPage  : false,
+            endCursor    : null
+        });
+        issueBSemverShift.state    = 'CLOSED';
+        issueBSemverShift.closedAt = '2026-05-15T10:00:00Z';
+        issueBSemverShift.milestone = {title: 'v11.13.0'}; // new resolution: valid semver
+
+        GraphqlService.query = async (query) => {
+            if (query.includes('FetchIssuesForSync')) {
+                return {
+                    rateLimit : {cost: 1, remaining: 4999, resetAt: '2026-05-15T11:00:00Z'},
+                    repository: {
+                        issues: {
+                            pageInfo: {hasNextPage: false, endCursor: null},
+                            nodes   : [structuredClone(issueAMigrationShape), structuredClone(issueBSemverShift)]
+                        }
+                    }
+                };
+            }
+            if (query.includes('FetchSingleIssue')) {
+                // Refetch path may target either issue
+                const num = parseInt(query.match(/number:\s*(\d+)/)?.[1] || '0', 10);
+                const src = num === issueBSemverShift.number ? issueBSemverShift : issueAMigrationShape;
+                return {repository: {issue: structuredClone(src)}};
+            }
+            throw new Error(`Unexpected GraphQL query in test: ${query.slice(0, 80)}`);
+        };
+
+        // Cached paths: issue A under migration-shape bucket, issue B under valid v11.12.0
+        const issueAOldAbsolutePath = path.join(
+            issueSyncConfig.archiveRoot, 'issues',
+            'vneo.d.ts - typescript definitions for all neo framework classes',
+            'chunk-3000', `issue-${issueAMigrationShape.number}.md`
+        );
+        const issueBOldAbsolutePath = path.join(
+            issueSyncConfig.archiveRoot, 'issues',
+            'v11.12.0', 'chunk-7900', `issue-${issueBSemverShift.number}.md`
+        );
+        const issueAOldRelPath = path.relative(aiConfig.projectRoot, issueAOldAbsolutePath);
+        const issueBOldRelPath = path.relative(aiConfig.projectRoot, issueBOldAbsolutePath);
+
+        const metadata = {
+            issues: {
+                [issueAMigrationShape.number]: {
+                    state       : 'CLOSED',
+                    path        : issueAOldRelPath,
+                    updatedAt   : '2026-05-14T10:00:00Z',
+                    closedAt    : '2026-05-15T10:00:00Z',
+                    milestone   : null,
+                    title       : issueAMigrationShape.title,
+                    contentHash : 'hashA',
+                    commentsTotal: 0
+                },
+                [issueBSemverShift.number]: {
+                    state       : 'CLOSED',
+                    path        : issueBOldRelPath,
+                    updatedAt   : '2026-05-14T10:00:00Z',
+                    closedAt    : '2026-05-15T10:00:00Z',
+                    milestone   : null,
+                    title       : issueBSemverShift.title,
+                    contentHash : 'hashB',
+                    commentsTotal: 0
+                }
+            }
+        };
+
+        // Pre-create the two cached files so sealed-chunk path-resolution works.
+        await fs.ensureDir(path.dirname(issueAOldAbsolutePath));
+        await fs.ensureDir(path.dirname(issueBOldAbsolutePath));
+        await fs.writeFile(issueAOldAbsolutePath, 'mock content A', 'utf8');
+        await fs.writeFile(issueBOldAbsolutePath, 'mock content B', 'utf8');
+
+        // Spy on logger.warn and logger.debug.
+        const warnCalls  = [];
+        const debugCalls = [];
+        const originalWarn  = logger.warn;
+        const originalDebug = logger.debug;
+        logger.warn  = (...args) => { warnCalls.push(args[0]); };
+        logger.debug = (...args) => { debugCalls.push(args[0]); };
+
+        try {
+            await IssueSyncer.pullFromGitHub(metadata);
+        } finally {
+            logger.warn  = originalWarn;
+            logger.debug = originalDebug;
+            await fs.unlink(issueAOldAbsolutePath).catch(() => {});
+            await fs.unlink(issueBOldAbsolutePath).catch(() => {});
+        }
+
+        // Migration-shape issue A: NO WARN with [ARCHIVE ANOMALY], EXACTLY 1 DEBUG with [ARCHIVE MIGRATION]
+        const issueAWarns  = warnCalls.filter(s => typeof s === 'string' && s.includes('[ARCHIVE ANOMALY]') && s.includes(`#${issueAMigrationShape.number}`));
+        const issueADebugs = debugCalls.filter(s => typeof s === 'string' && s.includes('[ARCHIVE MIGRATION]') && s.includes(`#${issueAMigrationShape.number}`));
+        expect(issueAWarns).toHaveLength(0);
+        expect(issueADebugs.length).toBeGreaterThanOrEqual(1);
+
+        // Valid-semver-shift issue B: EXACTLY 1 WARN with [ARCHIVE ANOMALY], NO [ARCHIVE MIGRATION] DEBUG
+        const issueBWarns  = warnCalls.filter(s => typeof s === 'string' && s.includes('[ARCHIVE ANOMALY]') && s.includes(`#${issueBSemverShift.number}`));
+        const issueBDebugs = debugCalls.filter(s => typeof s === 'string' && s.includes('[ARCHIVE MIGRATION]') && s.includes(`#${issueBSemverShift.number}`));
+        expect(issueBWarns).toHaveLength(1);
+        expect(issueBWarns[0]).toContain("'v11.12.0'");
+        expect(issueBWarns[0]).toContain("'v11.13.0'");
+        expect(issueBDebugs).toHaveLength(0);
+    });
 });
 
 function buildComment(i) {


### PR DESCRIPTION
FAIR-band: in-band [1/30] — operator-empirical friction during post-#11485 verification; quick-win MX-friction reduction completing the post-#11480 substrate's full operator-visibility win across INFO + WARN tiers.

**Evidence**: L2 (8/8 IssueSyncer specs pass including new #11486 case; 1.0s runtime) → L4 required (operator re-runs `npm run ai:sync-github-workflow`; WARN volume bounded to genuine `vX.Y.Z → vX.Y.Z` shifts, single-emit per issue).

## Summary

Filter the line-377 `ARCHIVE ANOMALY` WARN to fire only when both `oldVersion` and `version` parse as valid semver tags via `semver.valid(semver.clean(s))`. Demote migration-state mismatches (one or both sides not valid semver) to a `[ARCHIVE MIGRATION]` DEBUG channel. Add a `#warnedAnomalies` instance Set (cleared at top of `pullFromGitHub`) to dedupe across the three `#planBuckets` call sites within a single sync cycle.

## Empirical motivation

Operator 2026-05-16T19:33Z `npm run ai:sync-github-workflow` paste (SIGINT after thousands of lines):

```
[WARN] 🚨 [ARCHIVE ANOMALY] Issue #3285 closedAt shift detected: moving from bucket 'vneo.d.ts - Typescript definitions for all neo framework classes' to 'v8.1.0'. Dry-run review required.
[WARN] 🚨 [ARCHIVE ANOMALY] Issue #3286 closedAt shift detected: moving from bucket 'vneo.d.ts - Typescript definitions for all neo framework classes' to 'v8.1.0'. Dry-run review required.
[WARN] 🚨 [ARCHIVE ANOMALY] Issue #3287 closedAt shift detected: moving from bucket 'vNeo-Material Component Library v0.1' to 'v8.1.0'. Dry-run review required.
[WARN] 🚨 [ARCHIVE ANOMALY] Issue #7910 closedAt shift detected: moving from bucket 'v11.12.0' to 'v11.13.0'. Dry-run review required.
... (each issue line appears TWICE; thousands of lines total)
```

Two compounding root causes:
1. **Migration-state false positives**: `oldVersion` is derived from the cached path's directory name (`IssueSyncer.mjs:310-317`). During ADR 0004's clean-cut, every historically-archived closed issue has an `oldVersion` from the pre-cut naming scheme (title-derived strings prefixed with `v`), while the new time-based resolution returns a `vX.Y.Z` release tag. Sealed-chunk enforcement at L569/L575 **already prevents** these from causing any actual move — pure noise.
2. **Double emission**: `#planBuckets` is called from lines 547 (main sync), 783 (re-fetch path), and 982 (reconcile step). Each call walks the merged-issue set; same issue WARN'd at every call site.

## What changed

| File | Change |
|------|--------|
| `ai/services/github-workflow/sync/IssueSyncer.mjs` | `import semver from 'semver';` + `#warnedAnomalies = new Set()` field + filtered+deduped WARN at line ~387 + `clear()` at top of `pullFromGitHub` |
| `test/playwright/unit/ai/services/github-workflow/IssueSyncer.spec.mjs` | New test: ARCHIVE ANOMALY WARN fires only when both buckets parse as valid semver tags (#11486) — exercises migration-shape vs valid-semver-shift scenarios in one fixture |

Total: 2 files, +169 / -1 lines.

## What's preserved

- **Real release-boundary WARN signal** remains intact at default CLI level. Genuine `vX.Y.Z → vX.Y.Z` shifts (e.g. #7910 v11.12.0 → v11.13.0) still emit WARN — operator visibility into actionable anomalies preserved.
- **`error` level untouched** — failures still print.
- **Sealed-chunk enforcement** (L569 + L575) — untouched; the WARN filter just stops emitting WARN for moves that sealed-chunk semantics already prevent.

## Test plan

- [x] 8/8 IssueSyncer specs pass (`npm run test-unit -- test/playwright/unit/ai/services/github-workflow/IssueSyncer.spec.mjs`, 1.0s).
- [x] New spec asserts both axes simultaneously: migration-shape issue (oldVersion=`vneo.d.ts - typescript definitions...`, milestone=`v8.1.0`) emits 0 WARN + ≥1 DEBUG; valid-semver-shift issue (oldVersion=`v11.12.0`, milestone=`v11.13.0`) emits exactly 1 WARN containing both version strings + 0 migration DEBUG.
- [x] Branch-from-`origin/dev`-tip freshness verified.
- [ ] Cross-family review APPROVED.
- [ ] `@tobiu` merge.
- [ ] **L4 verification**: operator re-runs `npm run ai:sync-github-workflow` post-merge; WARN volume bounded to genuine `vX.Y.Z → vX.Y.Z` shifts (operator's prior paste showed only 1 such case: #7910). `--verbose` exposes the `[ARCHIVE MIGRATION]` DEBUG events for diagnostic use.

## Authority anchors

- **Direct parent**: PR #11485 (per-item INFO→DEBUG, merged 2026-05-16T19:21Z) — this is the natural FAIR follow-up completing the post-#11480 substrate's full operator-visibility win
- **Substrate parent**: PR #11480 (logger filtering substrate, merged) — provides the level discipline this PR builds on
- **Substrate library**: `semver@^7.7.4` already in `package.json`; precedent at `ai/services/github-workflow/HealthService.mjs:416`
- **Operator hint**: 2026-05-16T19:43Z `"semver" : "^7.7.4"` package.json reference — challenged my original hand-rolled regex prescription; adopted in Avoided Traps section of #11486 ticket
- **Empirical anchor**: operator paste 2026-05-16T19:33Z showing thousands of WARN lines + SIGINT exit

## Avoided traps

- **Hand-rolled regex like `/^v\d+\.\d+\.\d+$/`**: rejected per operator hint — `semver` library handles pre-release tags (`v8.1.0-rc.1`) + build metadata (`v8.1.0+build.123`) + future tag-format evolution correctly; regex would miss these.
- **Removing the WARN entirely**: rejected — real `vX.Y.Z → vX.Y.Z` shifts ARE actionable; only false positives during migration are quieted.
- **Suppressing all `[ARCHIVE ANOMALY]` via a CLI flag**: rejected — operator visibility into genuine anomalies must remain default-on.
- **One-time migration script to rewrite cached `oldVersion` strings**: rejected per ADR 0004's "no migration scripts. clean cut" mandate — cached metadata refreshes naturally as the sync runs; noise self-resolves after one clean-cut cycle.
- **Demoting WARN to INFO**: rejected — WARN level is correct for the genuine-anomaly case; demoting loses signal entirely.
- **Suppressing across entire daemon lifetime**: rejected — dedupe set is reset per sync cycle so issue-shifts across separate sync runs still surface; we only suppress within a single sync.

## Related

- **Parent context**: PR #11485 (per-item INFO→DEBUG sweep, merged)
- **Substrate parent**: PR #11480 (logger filtering substrate, merged)
- **Adjacent**: GPT investigating orchestrator boot-time cadence (parallel substrate concern — `Orchestrator.start()` → `poll()` fires summary + KB sync simultaneously, root-cause of the 19:27Z wedge). Complementary lane to this WARN-tier fix.

Resolves #11486
