### PR TITLE
fix(ai): remove memory core chroma daemon task (#11496)

### DIFF
--- a/ai/daemons/Orchestrator.mjs
+++ b/ai/daemons/Orchestrator.mjs
@@ -405,7 +405,7 @@ export class Orchestrator extends Base {
             healthService: this.healthService
         };
 
-        const continuousTasks = ['chroma', 'memoryCoreChroma', 'bridgeDaemon', 'mlx'];
+        const continuousTasks = ['chroma', 'bridgeDaemon', 'mlx'];
         const RESTART_COOLDOWN_MS = 15000;
         for (const taskName of continuousTasks) {
             const state = this.taskStateService.getTaskState(taskName);

--- a/ai/daemons/TaskDefinitions.mjs
+++ b/ai/daemons/TaskDefinitions.mjs
@@ -50,13 +50,6 @@ export function buildTaskDefinitions({
             pidFileName    : 'chroma.pid',
             expectedCommand: 'chroma'
         },
-        memoryCoreChroma: {
-            label          : 'memory core chroma',
-            command        : 'chroma',
-            args           : ['run', '--path', '.neo-ai-data/chroma/memory-core', '--port', '8001'],
-            pidFileName    : 'mc-chroma.pid',
-            expectedCommand: 'chroma'
-        },
         bridgeDaemon: {
             label          : 'bridge daemon',
             command        : nodeBin,

--- a/test/playwright/unit/ai/daemons/Orchestrator.spec.mjs
+++ b/test/playwright/unit/ai/daemons/Orchestrator.spec.mjs
@@ -35,7 +35,7 @@ function createTestOrchestrator(config = {}) {
         writeLogFn     : () => {}
     });
     TaskStateService.taskState = createInitialTaskState(taskDefinitions);
-    ['chroma', 'memoryCoreChroma', 'bridgeDaemon', 'mlx'].forEach(name => {
+    ['chroma', 'bridgeDaemon', 'mlx'].forEach(name => {
         if (TaskStateService.taskState[name]) {
             TaskStateService.taskState[name].running = true;
         }
@@ -77,7 +77,8 @@ test.describe('Neo.ai.daemons.Orchestrator (#11009)', () => {
             nodeBin  : '/node'
         }));
 
-        expect(Object.keys(state)).toEqual(['chroma', 'memoryCoreChroma', 'bridgeDaemon', 'mlx', 'summary', 'kbSync', 'backup', PRIMARY_DEV_SYNC_TASK_NAME, DREAM_TASK_NAME, GOLDEN_PATH_TASK_NAME]);
+        expect(Object.keys(state)).toEqual(['chroma', 'bridgeDaemon', 'mlx', 'summary', 'kbSync', 'backup', PRIMARY_DEV_SYNC_TASK_NAME, DREAM_TASK_NAME, GOLDEN_PATH_TASK_NAME]);
+        expect(state.memoryCoreChroma).toBeUndefined();
         expect(state.summary).toMatchObject({
             running      : false,
             pid          : null,

--- a/test/playwright/unit/ai/scripts/orchestrator-daemon.spec.mjs
+++ b/test/playwright/unit/ai/scripts/orchestrator-daemon.spec.mjs
@@ -23,6 +23,9 @@ test.describe('ai/scripts/orchestrator-daemon.mjs (#11006/#11009)', () => {
         const scriptDir = path.resolve(process.cwd(), 'ai/scripts');
         const tasks     = buildTaskDefinitions({scriptDir, nodeBin: '/test/node'});
 
+        expect(tasks.memoryCoreChroma).toBeUndefined();
+        expect(Object.values(tasks).flatMap(task => task.args || [])).not.toContain('8001');
+
         expect(tasks.summary.command).toBe('/test/node');
         expect(tasks.summary.args).toEqual([path.join(scriptDir, 'summarize-sessions.mjs')]);
         expect(tasks.summary.expectedCommand).toBe('summarize-sessions.mjs');


### PR DESCRIPTION
Authored by GPT-5.5 (Codex Desktop). Session 019e30ef-4702-73d1-a74f-b3321a13ba38.
FAIR-band: in-band [10/30]

Resolves #11496

Removes the post-ADR 0003 `memoryCoreChroma` daemon task from the orchestrator. The orchestrator now supervises only the shared Chroma daemon on port 8000, plus bridge and MLX, matching the unified-only Chroma contract from #11011 / ADR 0003.

## Evidence

- Live investigation comment: https://github.com/neomjs/neo/issues/11496#issuecomment-4468112432
- `git blame` traced `memoryCoreChroma` to commit `94cd337c0d` from PR #11382, merged after the unified-only clean cut in PR #11014.
- `buildTaskDefinitions()` no longer returns `memoryCoreChroma`.
- `Orchestrator.poll()` no longer includes `memoryCoreChroma` in continuous supervision.
- Focused tests assert no `memoryCoreChroma` state envelope and no daemon task args containing `8001`.

## Test Evidence

- `npm run test-unit -- test/playwright/unit/ai/daemons/Orchestrator.spec.mjs test/playwright/unit/ai/scripts/orchestrator-daemon.spec.mjs`
- `git diff --check`
- `git diff --cached --check`

## Residuals / Follow-Up

- This PR intentionally does not kill live processes. After merge, operator cleanup should stop stale port-8001 Chroma and restart the orchestrator from merged source.
- The operator correctly flagged that MCP servers do not have normal runtime ports. Stale `8001` guidance remains in Memory Core OpenAPI/tool-description substrate and self-repair/Antigravity skill text. I did not bundle that into this daemon PR because it crosses tool-description and skill-substrate surfaces; it should be handled as an explicit follow-up or broadened scope.
- Gitignored local `config.mjs` drift remains a separate operational risk: the canonical checkout still has `chromaUnified:false` plus `engines.chroma.port:8001`, and `initServerConfigs` does not detect value-level drift.

## Review Routing

CI must go green before requesting a primary reviewer, per the pull-request skill's CI-green routing gate.
