### PR TITLE
feat(ai): add heavy-maintenance lease service (#11505)

### DIFF
--- a/ai/daemons/services/HeavyMaintenanceLeaseService.mjs
+++ b/ai/daemons/services/HeavyMaintenanceLeaseService.mjs
@@ -1,0 +1,383 @@
+import crypto from 'crypto';
+import fs     from 'fs-extra';
+import path   from 'path';
+import Neo    from '../../../src/Neo.mjs';
+import Base   from '../../../src/core/Base.mjs';
+
+export const DEFAULT_HEAVY_MAINTENANCE_LEASE_PATH = '.neo-ai-data/orchestrator-daemon/heavy-maintenance-lease.json';
+export const DEFAULT_HEAVY_MAINTENANCE_LEASE_TTL_MS = 6 * 60 * 60 * 1000;
+
+/**
+ * @summary Converts supported time inputs into epoch milliseconds.
+ *
+ * @param {Date|Number|String} value Time input.
+ * @returns {Number}
+ */
+export function toTimestamp(value) {
+    if (value instanceof Date) {
+        return value.getTime();
+    }
+
+    if (typeof value === 'number') {
+        return value;
+    }
+
+    return new Date(value).getTime();
+}
+
+/**
+ * @summary Determines whether a persisted heavy-maintenance lease has expired.
+ *
+ * The stale check is intentionally payload-based instead of file-mtime-based so
+ * copied or restored state keeps the owning task's declared deadline. This is the
+ * shared #11503 recovery contract for daemon-owned and CLI-owned maintenance work.
+ *
+ * @param {Object|null} lease Persisted lease payload.
+ * @param {Object} [options]
+ * @param {Date|Number|String} [options.now=new Date()] Current time.
+ * @returns {Boolean}
+ */
+export function isLeaseStale(lease, {now = new Date()} = {}) {
+    if (!lease || !lease.acquiredAt) {
+        return true;
+    }
+
+    const nowMs = toTimestamp(now);
+
+    if (!Number.isFinite(nowMs)) {
+        return false;
+    }
+
+    const expiresAtMs = lease.expiresAt ? toTimestamp(lease.expiresAt) : NaN;
+    if (Number.isFinite(expiresAtMs)) {
+        return nowMs >= expiresAtMs;
+    }
+
+    const acquiredAtMs = toTimestamp(lease.acquiredAt);
+    const staleAfterMs = Number(lease.staleAfterMs);
+
+    return !Number.isFinite(acquiredAtMs) || !Number.isFinite(staleAfterMs) || nowMs - acquiredAtMs >= staleAfterMs;
+}
+
+/**
+ * @summary Builds the durable diagnostic payload for a heavy-maintenance lease.
+ *
+ * @param {Object} options
+ * @param {String} options.owner Stable owner label.
+ * @param {String} [options.reason='manual'] Acquisition reason.
+ * @param {Object} [options.metadata={}] Diagnostic metadata.
+ * @param {Number} [options.pid=process.pid] Owning process ID.
+ * @param {Number} [options.staleAfterMs=DEFAULT_HEAVY_MAINTENANCE_LEASE_TTL_MS] Stale TTL.
+ * @param {Date|Number|String} [options.now=new Date()] Current time.
+ * @param {String} [options.token] Owner release token.
+ * @returns {Object}
+ */
+export function buildLeasePayload({
+    owner,
+    reason       = 'manual',
+    metadata     = {},
+    pid          = process.pid,
+    staleAfterMs = DEFAULT_HEAVY_MAINTENANCE_LEASE_TTL_MS,
+    now          = new Date(),
+    token        = crypto.randomUUID()
+}) {
+    const acquiredAt = new Date(toTimestamp(now));
+    const expiresAt  = new Date(acquiredAt.getTime() + staleAfterMs);
+
+    return {
+        owner,
+        reason,
+        pid,
+        token,
+        acquiredAt: acquiredAt.toISOString(),
+        staleAfterMs,
+        expiresAt : expiresAt.toISOString(),
+        metadata
+    };
+}
+
+/**
+ * @summary Reads and classifies the current heavy-maintenance lease file.
+ *
+ * @param {Object} [options]
+ * @param {String} [options.leasePath=DEFAULT_HEAVY_MAINTENANCE_LEASE_PATH] Lease file path.
+ * @param {Object} [options.fsModule=fs] File-system implementation seam.
+ * @param {Date|Number|String} [options.now=new Date()] Current time.
+ * @returns {Promise<Object>}
+ */
+export async function inspectHeavyMaintenanceLease({
+    leasePath = DEFAULT_HEAVY_MAINTENANCE_LEASE_PATH,
+    fsModule  = fs,
+    now       = new Date()
+} = {}) {
+    let raw;
+
+    try {
+        raw = await fsModule.readFile(leasePath, 'utf8');
+    } catch (e) {
+        if (e.code === 'ENOENT') {
+            return {status: 'missing', active: false, stale: false, lease: null};
+        }
+
+        return {status: 'unreadable', active: false, stale: true, lease: null, error: e.message};
+    }
+
+    try {
+        const lease = JSON.parse(raw);
+        const stale = isLeaseStale(lease, {now});
+
+        return {
+            status: stale ? 'stale' : 'active',
+            active: !stale,
+            stale,
+            lease
+        };
+    } catch (e) {
+        return {status: 'malformed', active: false, stale: true, lease: null, error: e.message};
+    }
+}
+
+async function writeLeaseFile(leasePath, lease, fsModule) {
+    await fsModule.ensureDir(path.dirname(leasePath));
+    await fsModule.writeFile(leasePath, JSON.stringify(lease, null, 2), {encoding: 'utf8', flag: 'wx'});
+}
+
+/**
+ * @summary Attempts to acquire the shared Agent OS heavy-maintenance lease.
+ *
+ * Normal contention returns a held status with active-owner metadata. It does
+ * not throw because #11503 treats overlap prevention as a non-error deferral.
+ *
+ * @param {Object} options
+ * @param {String} options.owner Stable owner label.
+ * @param {String} [options.reason='manual'] Acquisition reason.
+ * @param {Object} [options.metadata={}] Diagnostic metadata.
+ * @param {String} [options.leasePath=DEFAULT_HEAVY_MAINTENANCE_LEASE_PATH] Lease file path.
+ * @param {Object} [options.fsModule=fs] File-system implementation seam.
+ * @param {Date|Number|String} [options.now=new Date()] Current time.
+ * @param {Number} [options.pid=process.pid] Owning process ID.
+ * @param {Number} [options.staleAfterMs=DEFAULT_HEAVY_MAINTENANCE_LEASE_TTL_MS] Stale TTL.
+ * @param {String} [options.token] Owner release token.
+ * @returns {Promise<Object>}
+ */
+export async function acquireHeavyMaintenanceLease({
+    owner,
+    reason       = 'manual',
+    metadata     = {},
+    leasePath    = DEFAULT_HEAVY_MAINTENANCE_LEASE_PATH,
+    fsModule     = fs,
+    now          = new Date(),
+    pid          = process.pid,
+    staleAfterMs = DEFAULT_HEAVY_MAINTENANCE_LEASE_TTL_MS,
+    token
+} = {}) {
+    if (!owner) {
+        throw new Error('Heavy-maintenance lease owner is required.');
+    }
+
+    const lease = buildLeasePayload({owner, reason, metadata, pid, staleAfterMs, now, token});
+
+    try {
+        await writeLeaseFile(leasePath, lease, fsModule);
+        return {status: 'acquired', acquired: true, lease};
+    } catch (e) {
+        if (e.code !== 'EEXIST') {
+            throw e;
+        }
+    }
+
+    const current = await inspectHeavyMaintenanceLease({leasePath, fsModule, now});
+
+    if (current.active) {
+        return {status: 'held', acquired: false, lease: current.lease};
+    }
+
+    await fsModule.remove(leasePath);
+
+    try {
+        await writeLeaseFile(leasePath, lease, fsModule);
+        return {
+            status: current.status === 'malformed' ? 'acquired-after-malformed' : 'acquired-after-stale',
+            acquired: true,
+            previousStatus: current.status,
+            lease
+        };
+    } catch (e) {
+        if (e.code !== 'EEXIST') {
+            throw e;
+        }
+
+        const raced = await inspectHeavyMaintenanceLease({leasePath, fsModule, now});
+        return {status: 'held', acquired: false, lease: raced.lease};
+    }
+}
+
+/**
+ * @summary Releases the shared heavy-maintenance lease when the token matches.
+ *
+ * @param {Object} options
+ * @param {String} options.token Owner token returned by acquire.
+ * @param {String} [options.leasePath=DEFAULT_HEAVY_MAINTENANCE_LEASE_PATH] Lease file path.
+ * @param {Object} [options.fsModule=fs] File-system implementation seam.
+ * @param {Date|Number|String} [options.now=new Date()] Current time.
+ * @returns {Promise<Object>}
+ */
+export async function releaseHeavyMaintenanceLease({
+    token,
+    leasePath = DEFAULT_HEAVY_MAINTENANCE_LEASE_PATH,
+    fsModule  = fs,
+    now       = new Date()
+} = {}) {
+    if (!token) {
+        throw new Error('Heavy-maintenance lease token is required for release.');
+    }
+
+    const current = await inspectHeavyMaintenanceLease({leasePath, fsModule, now});
+
+    if (current.status === 'missing') {
+        return {status: 'missing', released: false};
+    }
+
+    if (!current.lease || current.lease.token !== token) {
+        return {status: 'not-owner', released: false, lease: current.lease};
+    }
+
+    await fsModule.remove(leasePath);
+
+    return {status: 'released', released: true, lease: current.lease};
+}
+
+/**
+ * @summary Runs a task while holding the heavy-maintenance lease.
+ *
+ * @param {Function} task Async task to execute.
+ * @param {Object} options Lease acquisition options.
+ * @returns {Promise<Object>}
+ */
+export async function withHeavyMaintenanceLease(task, options = {}) {
+    const acquisition = await acquireHeavyMaintenanceLease(options);
+
+    if (!acquisition.acquired) {
+        return acquisition;
+    }
+
+    try {
+        return {
+            status: 'completed',
+            acquired: true,
+            lease : acquisition.lease,
+            result: await task(acquisition)
+        };
+    } finally {
+        await releaseHeavyMaintenanceLease({
+            token    : acquisition.lease.token,
+            leasePath: options.leasePath,
+            fsModule : options.fsModule,
+            now      : options.now
+        });
+    }
+}
+
+/**
+ * @summary Shared lease service for Agent OS substrate-heavy maintenance work (#11505).
+ *
+ * The service is the reusable #11503 mutex contract between orchestrator-owned
+ * tasks and operator-runnable CLI scripts. It prevents Chroma / SQLite / LLM
+ * maintenance lanes from overlapping across process boundaries while preserving
+ * non-error deferral semantics for expected contention.
+ *
+ * @class Neo.ai.daemons.services.HeavyMaintenanceLeaseService
+ * @extends Neo.core.Base
+ * @singleton
+ * @see https://github.com/neomjs/neo/issues/11503
+ * @see https://github.com/neomjs/neo/issues/11505
+ */
+export class HeavyMaintenanceLeaseService extends Base {
+    static config = {
+        /**
+         * @member {String} className='Neo.ai.daemons.services.HeavyMaintenanceLeaseService'
+         * @protected
+         */
+        className: 'Neo.ai.daemons.services.HeavyMaintenanceLeaseService',
+        /**
+         * @member {Boolean} singleton=true
+         * @protected
+         */
+        singleton: true,
+        /**
+         * @member {String} leasePath_='.neo-ai-data/orchestrator-daemon/heavy-maintenance-lease.json'
+         * @protected
+         * @reactive
+         */
+        leasePath_: DEFAULT_HEAVY_MAINTENANCE_LEASE_PATH,
+        /**
+         * @member {Number} staleAfterMs_=21600000
+         * @protected
+         * @reactive
+         */
+        staleAfterMs_: DEFAULT_HEAVY_MAINTENANCE_LEASE_TTL_MS,
+        /**
+         * @member {Object} fsModule_=fs
+         * @protected
+         * @reactive
+         */
+        fsModule_: fs
+    }
+
+    /**
+     * Inspects the current lease file.
+     * @param {Object} [options] Inspect overrides.
+     * @returns {Promise<Object>}
+     */
+    inspect(options = {}) {
+        return inspectHeavyMaintenanceLease({
+            leasePath: options.leasePath ?? this.leasePath,
+            fsModule : options.fsModule  ?? this.fsModule,
+            now      : options.now       ?? new Date()
+        });
+    }
+
+    /**
+     * Acquires the current lease when no active owner exists.
+     * @param {Object} options Acquisition options.
+     * @returns {Promise<Object>}
+     */
+    acquire(options = {}) {
+        return acquireHeavyMaintenanceLease({
+            ...options,
+            leasePath   : options.leasePath    ?? this.leasePath,
+            fsModule    : options.fsModule     ?? this.fsModule,
+            staleAfterMs: options.staleAfterMs ?? this.staleAfterMs
+        });
+    }
+
+    /**
+     * Releases the current lease if the token matches.
+     * @param {Object} options Release options.
+     * @returns {Promise<Object>}
+     */
+    release(options = {}) {
+        return releaseHeavyMaintenanceLease({
+            ...options,
+            leasePath: options.leasePath ?? this.leasePath,
+            fsModule : options.fsModule  ?? this.fsModule
+        });
+    }
+
+    /**
+     * Runs an async task while holding the heavy-maintenance lease.
+     * @param {Function} task Async task to execute.
+     * @param {Object} options Lease options.
+     * @returns {Promise<Object>}
+     */
+    withLease(task, options = {}) {
+        return withHeavyMaintenanceLease(task, {
+            ...options,
+            leasePath   : options.leasePath    ?? this.leasePath,
+            fsModule    : options.fsModule     ?? this.fsModule,
+            staleAfterMs: options.staleAfterMs ?? this.staleAfterMs
+        });
+    }
+}
+
+export default Neo.setupClass(HeavyMaintenanceLeaseService);

--- a/ai/services.mjs
+++ b/ai/services.mjs
@@ -77,6 +77,7 @@ NeuralLink_Config.data.autoConnect = false;
 
 // --- Daemons ---
 import DreamService from './daemons/DreamService.mjs';
+import HeavyMaintenanceLeaseService from './daemons/services/HeavyMaintenanceLeaseService.mjs';
 import SemanticGraphExtractor from './daemons/services/SemanticGraphExtractor.mjs';
 import TopologyInferenceEngine from './daemons/services/TopologyInferenceEngine.mjs';
 
@@ -312,6 +313,7 @@ export {
 
     // Daemons
     DreamService,
+    HeavyMaintenanceLeaseService,
     SemanticGraphExtractor,
     TopologyInferenceEngine,
 

--- a/test/playwright/unit/ai/daemons/services/HeavyMaintenanceLeaseService.spec.mjs
+++ b/test/playwright/unit/ai/daemons/services/HeavyMaintenanceLeaseService.spec.mjs
@@ -1,0 +1,293 @@
+import {test, expect} from '@playwright/test';
+import fs             from 'fs-extra';
+import path           from 'path';
+import Neo            from '../../../../../../src/Neo.mjs';
+import * as core      from '../../../../../../src/core/_export.mjs';
+import {
+    HeavyMaintenanceLeaseService,
+    acquireHeavyMaintenanceLease,
+    inspectHeavyMaintenanceLease,
+    isLeaseStale,
+    releaseHeavyMaintenanceLease,
+    withHeavyMaintenanceLease
+} from '../../../../../../ai/daemons/services/HeavyMaintenanceLeaseService.mjs';
+
+function createLeasePath(name) {
+    const dir = path.join(process.cwd(), 'tmp', `heavy-maintenance-lease-${process.pid}-${Date.now()}-${Math.random()}`);
+    fs.ensureDirSync(dir);
+    return path.join(dir, `${name}.json`);
+}
+
+test.describe('Neo.ai.daemons.services.HeavyMaintenanceLeaseService (#11505)', () => {
+    test('acquires and inspects a missing lease', async () => {
+        const leasePath = createLeasePath('missing');
+        const now       = new Date('2026-05-16T20:00:00.000Z');
+
+        await expect(inspectHeavyMaintenanceLease({leasePath, now})).resolves.toMatchObject({
+            status: 'missing',
+            active: false,
+            stale : false,
+            lease : null
+        });
+
+        const result = await acquireHeavyMaintenanceLease({
+            leasePath,
+            owner       : 'kbSync',
+            reason      : 'periodic-sync:1800000',
+            metadata    : {taskName: 'kbSync'},
+            pid         : 1234,
+            staleAfterMs: 60000,
+            now,
+            token       : 'owner-token'
+        });
+
+        expect(result).toMatchObject({
+            status  : 'acquired',
+            acquired: true,
+            lease   : {
+                owner       : 'kbSync',
+                reason      : 'periodic-sync:1800000',
+                pid         : 1234,
+                token       : 'owner-token',
+                staleAfterMs: 60000,
+                metadata    : {taskName: 'kbSync'}
+            }
+        });
+        expect(result.lease.acquiredAt).toBe('2026-05-16T20:00:00.000Z');
+        expect(result.lease.expiresAt).toBe('2026-05-16T20:01:00.000Z');
+
+        await expect(inspectHeavyMaintenanceLease({leasePath, now})).resolves.toMatchObject({
+            status: 'active',
+            active: true,
+            stale : false,
+            lease : {
+                owner: 'kbSync',
+                token: 'owner-token'
+            }
+        });
+    });
+
+    test('returns held status for active contention without throwing', async () => {
+        const leasePath = createLeasePath('held');
+        const now       = new Date('2026-05-16T20:00:00.000Z');
+
+        await acquireHeavyMaintenanceLease({
+            leasePath,
+            owner       : 'summary',
+            reason      : 'periodic-sweep:600000',
+            now,
+            staleAfterMs: 60000,
+            token       : 'summary-token'
+        });
+
+        const result = await acquireHeavyMaintenanceLease({
+            leasePath,
+            owner       : 'kbSync',
+            reason      : 'periodic-sync:1800000',
+            now,
+            staleAfterMs: 60000,
+            token       : 'kb-token'
+        });
+
+        expect(result).toMatchObject({
+            status  : 'held',
+            acquired: false,
+            lease   : {
+                owner: 'summary',
+                token: 'summary-token'
+            }
+        });
+    });
+
+    test('concurrent acquisition converges to one owner', async () => {
+        const leasePath = createLeasePath('concurrent');
+        const now       = new Date('2026-05-16T20:00:00.000Z');
+
+        const results = await Promise.all([
+            acquireHeavyMaintenanceLease({leasePath, owner: 'summary', now, token: 'summary-token'}),
+            acquireHeavyMaintenanceLease({leasePath, owner: 'kbSync', now, token: 'kb-token'})
+        ]);
+
+        expect(results.filter(result => result.acquired)).toHaveLength(1);
+        expect(results.filter(result => result.status === 'held')).toHaveLength(1);
+
+        const active = await inspectHeavyMaintenanceLease({leasePath, now});
+        expect(['summary', 'kbSync']).toContain(active.lease.owner);
+    });
+
+    test('release is token guarded and idempotent for missing leases', async () => {
+        const leasePath = createLeasePath('release');
+        const now       = new Date('2026-05-16T20:00:00.000Z');
+
+        await acquireHeavyMaintenanceLease({
+            leasePath,
+            owner: 'backup',
+            now,
+            token: 'backup-token'
+        });
+
+        await expect(releaseHeavyMaintenanceLease({
+            leasePath,
+            token: 'wrong-token',
+            now
+        })).resolves.toMatchObject({
+            status  : 'not-owner',
+            released: false,
+            lease   : {owner: 'backup'}
+        });
+
+        await expect(inspectHeavyMaintenanceLease({leasePath, now})).resolves.toMatchObject({
+            status: 'active',
+            lease : {owner: 'backup'}
+        });
+
+        await expect(releaseHeavyMaintenanceLease({
+            leasePath,
+            token: 'backup-token',
+            now
+        })).resolves.toMatchObject({
+            status  : 'released',
+            released: true
+        });
+
+        await expect(releaseHeavyMaintenanceLease({
+            leasePath,
+            token: 'backup-token',
+            now
+        })).resolves.toMatchObject({
+            status  : 'missing',
+            released: false
+        });
+    });
+
+    test('stale leases can be replaced deterministically', async () => {
+        const leasePath = createLeasePath('stale');
+
+        await acquireHeavyMaintenanceLease({
+            leasePath,
+            owner       : 'dream',
+            now         : new Date('2026-05-16T20:00:00.000Z'),
+            staleAfterMs: 1000,
+            token       : 'dream-token'
+        });
+
+        expect(isLeaseStale(JSON.parse(await fs.readFile(leasePath, 'utf8')), {
+            now: new Date('2026-05-16T20:00:01.000Z')
+        })).toBe(true);
+
+        const result = await acquireHeavyMaintenanceLease({
+            leasePath,
+            owner       : 'golden-path',
+            now         : new Date('2026-05-16T20:00:01.000Z'),
+            staleAfterMs: 1000,
+            token       : 'golden-token'
+        });
+
+        expect(result).toMatchObject({
+            status        : 'acquired-after-stale',
+            acquired      : true,
+            previousStatus: 'stale',
+            lease         : {
+                owner: 'golden-path',
+                token: 'golden-token'
+            }
+        });
+    });
+
+    test('malformed leases recover at acquisition time', async () => {
+        const leasePath = createLeasePath('malformed');
+        await fs.writeFile(leasePath, '{not-json', 'utf8');
+
+        await expect(inspectHeavyMaintenanceLease({leasePath})).resolves.toMatchObject({
+            status: 'malformed',
+            active: false,
+            stale : true
+        });
+
+        await expect(acquireHeavyMaintenanceLease({
+            leasePath,
+            owner: 'summary',
+            token: 'summary-token'
+        })).resolves.toMatchObject({
+            status        : 'acquired-after-malformed',
+            acquired      : true,
+            previousStatus: 'malformed',
+            lease         : {
+                owner: 'summary',
+                token: 'summary-token'
+            }
+        });
+    });
+
+    test('withLease releases after task completion and skips held tasks', async () => {
+        const leasePath = createLeasePath('with-lease');
+        const now       = new Date('2026-05-16T20:00:00.000Z');
+        let ran = false;
+
+        const completed = await withHeavyMaintenanceLease(() => {
+            ran = true;
+            return 'done';
+        }, {
+            leasePath,
+            owner: 'summary',
+            now,
+            token: 'summary-token'
+        });
+
+        expect(completed).toMatchObject({
+            status  : 'completed',
+            acquired: true,
+            result  : 'done'
+        });
+        expect(ran).toBe(true);
+        await expect(inspectHeavyMaintenanceLease({leasePath, now})).resolves.toMatchObject({status: 'missing'});
+
+        await acquireHeavyMaintenanceLease({
+            leasePath,
+            owner: 'kbSync',
+            now,
+            token: 'kb-token'
+        });
+
+        ran = false;
+        const held = await withHeavyMaintenanceLease(() => {
+            ran = true;
+        }, {
+            leasePath,
+            owner: 'backup',
+            now,
+            token: 'backup-token'
+        });
+
+        expect(held).toMatchObject({
+            status  : 'held',
+            acquired: false,
+            lease   : {owner: 'kbSync'}
+        });
+        expect(ran).toBe(false);
+    });
+
+    test('default singleton delegates to the reusable helpers', async () => {
+        const leasePath = createLeasePath('service');
+        const service   = Neo.create(HeavyMaintenanceLeaseService, {
+            leasePath_: leasePath,
+            staleAfterMs_: 60000
+        });
+
+        const acquired = await service.acquire({
+            owner: 'summary',
+            token: 'service-token',
+            now  : new Date('2026-05-16T20:00:00.000Z')
+        });
+
+        expect(acquired).toMatchObject({
+            status: 'acquired',
+            lease : {owner: 'summary', token: 'service-token'}
+        });
+
+        await expect(service.release({
+            token: 'service-token',
+            now  : new Date('2026-05-16T20:00:00.000Z')
+        })).resolves.toMatchObject({status: 'released'});
+    });
+});


### PR DESCRIPTION
Resolves #11505

Related: #11503

Authored by GPT-5.5 (Codex Desktop). Session unavailable — Memory Core add_memory disabled per operator during Chroma pressure incident.

FAIR-band: in-band [9/30]

Adds the shared Agent OS heavy-maintenance lease primitive for #11503 Lane B. The new service provides atomic acquire, held/deferred status, stale replacement, malformed-lock recovery, token-guarded release, and with-lease helper semantics over `.neo-ai-data/orchestrator-daemon/heavy-maintenance-lease.json`. It also exports the service through `ai/services.mjs` so follow-up script adoption can consume a stable SDK-facing surface.

Evidence: L2 (focused Playwright unit coverage + syntax checks) → L2 required (#11505 ACs). Residual: #11503 AC4-AC10 remain for later lanes.

## Deltas from ticket

- Added `HeavyMaintenanceLeaseService` to `ai/services.mjs` as a stable consumer surface for Lane C script adoption.
- Kept manual script wrapping, primary-dev-sync wiring, live Chroma/KB/Sandman/backup execution, and orchestrator scheduler completion out of this PR.

## Test Evidence

- `node --check ai/daemons/services/HeavyMaintenanceLeaseService.mjs`
- `node --check ai/services.mjs`
- `npm run test-unit -- test/playwright/unit/ai/daemons/services/HeavyMaintenanceLeaseService.spec.mjs` — 8 passed
- `git diff --check origin/dev..HEAD`

## Post-Merge Validation

- [ ] Lane C can wrap manual heavy scripts using this lease API without introducing a second lock primitive.

## Commit

- `2642c11d3` — `feat(ai): add heavy-maintenance lease service (#11505)`