### PR TITLE
feat(buildScripts): wrap manual heavy-maintenance scripts with shared lease — Lane C of #11503 (#11507)

### DIFF
--- a/buildScripts/ai/backup.mjs
+++ b/buildScripts/ai/backup.mjs
@@ -21,6 +21,8 @@ import {
     Memory_LifecycleService
 } from '../../ai/services.mjs';
 
+import {withHeavyMaintenanceLease} from '../../ai/daemons/services/HeavyMaintenanceLeaseService.mjs';
+
 const execFileAsync = promisify(execFile);
 
 /**
@@ -438,11 +440,24 @@ async function copyJsonlSource(source, destDir, logger=console) {
     return {copied: 1};
 }
 
-// Auto-run when invoked directly
+// Auto-run when invoked directly. Lane C of #11503 wraps the heavy-maintenance work in
+// the shared lease primitive (PR #11506 / #11505) so this CLI cannot collide with the
+// orchestrator's heavy tasks or with another manual heavy script. The exported `runBackup`
+// function is left lease-free so test harnesses and other module-level callers retain
+// full control of their own concurrency context.
 if (import.meta.url === `file://${process.argv[1]}`) {
-    runBackup()
-        .then(result => {
-            console.log(JSON.stringify(result, null, 2));
+    withHeavyMaintenanceLease(
+        () => runBackup(),
+        {owner: 'backup', reason: 'manual-cli', metadata: {script: 'buildScripts/ai/backup.mjs'}}
+    )
+        .then(outcome => {
+            if (outcome.status === 'held') {
+                const held = outcome.lease;
+                console.log(`⏸️  Deferred: heavy-maintenance lease held by '${held.owner}' (reason='${held.reason}', pid=${held.pid}, acquiredAt=${held.acquiredAt}).`);
+                console.log('   This script will not run while another heavy-maintenance task is active. Re-invoke once the active owner completes.');
+                process.exit(0);
+            }
+            console.log(JSON.stringify(outcome.result, null, 2));
             process.exit(0);
         })
         .catch(error => {

--- a/buildScripts/ai/runSandman.mjs
+++ b/buildScripts/ai/runSandman.mjs
@@ -221,19 +221,28 @@ export async function runSandman() {
             }
         }, {owner: 'sandman', reason: 'manual-cli', metadata: {script: 'buildScripts/ai/runSandman.mjs'}});
     } catch (e) {
-        // withHeavyMaintenanceLease itself failed (e.g., lease-write IO error).
+        // withHeavyMaintenanceLease itself failed (e.g., lease-write IO error). The whole
+        // point of the lease is to prevent concurrent graph mutation; if acquisition
+        // failed we MUST NOT proceed to graph-mutating decay. Fail-closed per GPT review
+        // PR #11509 cycle 1 (PRR_kwDODSospM8AAAABAJIdTg): GraphService.decayGlobalTopology
+        // touches SQLite graph edges + _SYSTEM_STATE; running it outside the lease defeats
+        // the substrate protection this PR is shipping.
         console.error('❌ REM cycle lease acquisition failed:', e);
-        process.exitCode = 1;
+        process.exit(1);
     }
 
     if (outcome?.status === 'held') {
         const held = outcome.lease;
         console.log(`⏸️  Deferred: heavy-maintenance lease held by '${held.owner}' (reason='${held.reason}', pid=${held.pid}, acquiredAt=${held.acquiredAt}).`);
         console.log('   This script will not run while another heavy-maintenance task is active. Re-invoke once the active owner completes.');
-        // Skip the decay step on held — no graph mutation occurred.
+        // Skip the decay step on held — no graph mutation occurred + we don't hold the lease.
         process.exit(0);
     }
 
+    // Reached here only when outcome.status === 'completed' — lease was acquired AND the
+    // inner work ran (success or graceful-fail) AND the lease is still held by us through
+    // this synchronous decay call. The decay-on-completion path is the only branch where
+    // graph mutation is safely lease-protected.
     console.log('🧹 Triggering global topology decay & pruning mechanism...');
     try {
         // Need to await? decayGlobalTopology is synchronous.

--- a/buildScripts/ai/runSandman.mjs
+++ b/buildScripts/ai/runSandman.mjs
@@ -176,9 +176,17 @@ export async function runSandman() {
     let outcome;
     try {
         outcome = await withHeavyMaintenanceLease(async () => {
-            // Inner try/catch preserves the script's prior graceful-fail semantics for
+            // Inner try/catch/finally preserves the script's prior graceful-fail semantics for
             // provider-readiness + DreamService failures (return-without-throw at the
-            // provider-fail branch; throw-and-catch for everything else).
+            // provider-fail branch; throw-and-catch for everything else) AND guarantees the
+            // graph-mutating decay runs INSIDE the lease window.
+            //
+            // Per GPT review PR #11509 cycle 2 (PRR_kwDODSospM8AAAABAJKF8w): `withHeavyMaintenanceLease`
+            // releases the lease in its own `finally` BEFORE returning, so any decay call placed
+            // after the await would mutate Memory Core graph state outside the lease — defeating
+            // the substrate protection this PR is shipping. Placing decay in THIS inner finally
+            // pins it inside the lease window: JS guarantees the inner finally completes before
+            // the awaited task settles, so the wrapper's release runs strictly after decay.
             try {
                 console.log('   Waiting for Lifecycle Service to auto-boot orchestrators...');
                 await LifecycleService.ready();
@@ -218,6 +226,18 @@ export async function runSandman() {
                 console.error('❌ REM cycle failed:', e);
                 process.exitCode = 1;
                 return {providerReady: false, error: e.message};
+            } finally {
+                // Inside-the-lease decay (see header comment). Wrapping in try/catch preserves
+                // prior graceful-fail semantics: a decay failure must not throw out of the
+                // lease-wrapped task, since that would mask the inner return value AND propagate
+                // to the outer catch — which is reserved for lease-acquisition failures (fail-closed).
+                console.log('🧹 Triggering global topology decay & pruning mechanism...');
+                try {
+                    // decayGlobalTopology is synchronous; no await needed.
+                    GraphService.decayGlobalTopology();
+                } catch (e) {
+                    console.error('❌ Failed to decay topology:', e);
+                }
             }
         }, {owner: 'sandman', reason: 'manual-cli', metadata: {script: 'buildScripts/ai/runSandman.mjs'}});
     } catch (e) {
@@ -240,16 +260,9 @@ export async function runSandman() {
     }
 
     // Reached here only when outcome.status === 'completed' — lease was acquired AND the
-    // inner work ran (success or graceful-fail) AND the lease is still held by us through
-    // this synchronous decay call. The decay-on-completion path is the only branch where
-    // graph mutation is safely lease-protected.
-    console.log('🧹 Triggering global topology decay & pruning mechanism...');
-    try {
-        // Need to await? decayGlobalTopology is synchronous.
-        GraphService.decayGlobalTopology();
-    } catch (e) {
-        console.error('❌ Failed to decay topology:', e);
-    }
+    // inner work + inner-finally decay both ran INSIDE the lease window (see inner finally
+    // above for the release-timing invariant). Nothing further to do here besides honoring
+    // the inner exitCode contract.
     process.exit(process.exitCode);
 }
 

--- a/buildScripts/ai/runSandman.mjs
+++ b/buildScripts/ai/runSandman.mjs
@@ -8,6 +8,7 @@ import GoldenPathSynthesizer from '../../ai/daemons/services/GoldenPathSynthesiz
 import LifecycleService from '../../ai/services/memory-core/lifecycle/SystemLifecycleService.mjs';
 import InferenceLifecycleService from '../../ai/services/memory-core/lifecycle/InferenceLifecycleService.mjs';
 import GraphService from '../../ai/services/memory-core/GraphService.mjs';
+import {withHeavyMaintenanceLease} from '../../ai/daemons/services/HeavyMaintenanceLeaseService.mjs';
 import logger from '../../ai/mcp/server/memory-core/logger.mjs';
 import http from 'http';
 import {pathToFileURL} from 'url';
@@ -166,53 +167,81 @@ export async function runSandman() {
 
     console.log('⏳ Initializing Sandman REM Extraction Pipeline...');
 
+    // Lane C of #11503 — wrap the REM cycle in the shared heavy-maintenance lease so this
+    // CLI cannot collide with the orchestrator's `dream` task or with other manual heavy
+    // scripts. The substrate-heavy work (DreamService + GoldenPathSynthesizer LLM passes
+    // + Memory Core graph writes) is the contention surface the lease primitive (PR #11506 /
+    // #11505) guards. On held-status, the script defers cleanly without running the decay
+    // step (since no graph mutation occurred).
+    let outcome;
     try {
-        console.log('   Waiting for Lifecycle Service to auto-boot orchestrators...');
-        await LifecycleService.ready();
-        console.log('   Lifecycle Service Ready. Database should be running.');
+        outcome = await withHeavyMaintenanceLease(async () => {
+            // Inner try/catch preserves the script's prior graceful-fail semantics for
+            // provider-readiness + DreamService failures (return-without-throw at the
+            // provider-fail branch; throw-and-catch for everything else).
+            try {
+                console.log('   Waiting for Lifecycle Service to auto-boot orchestrators...');
+                await LifecycleService.ready();
+                console.log('   Lifecycle Service Ready. Database should be running.');
 
-        console.log('   Waiting for MLX provider to warm up load weights into VRAM...');
-        const waitResult = await waitForProvider();
+                console.log('   Waiting for MLX provider to warm up load weights into VRAM...');
+                const waitResult = await waitForProvider();
 
-        if (!waitResult.running) {
-            const diagnostic = createProviderFailureDiagnostic({
-                waitResult,
-                lifecycleStatus: InferenceLifecycleService.getStatus()
-            });
+                if (!waitResult.running) {
+                    const diagnostic = createProviderFailureDiagnostic({
+                        waitResult,
+                        lifecycleStatus: InferenceLifecycleService.getStatus()
+                    });
 
-            await recordProviderReadinessFailure(diagnostic);
-            process.exitCode = 1;
-            return;
-        }
+                    await recordProviderReadinessFailure(diagnostic);
+                    process.exitCode = 1;
+                    return {providerReady: false};
+                }
 
-        console.log('\n   ✅ openAiCompatible server is running (auto-boot successful).');
+                console.log('\n   ✅ openAiCompatible server is running (auto-boot successful).');
 
-        console.log('   Waiting for DreamService Initialization...');
-        // We might need to ensure DreamService is fully inited, though it initAsync runs automatically upon Neo.setupClass
-        await DreamService.ready();
-        console.log('   DreamService Ready.');
+                console.log('   Waiting for DreamService Initialization...');
+                // We might need to ensure DreamService is fully inited, though it initAsync runs automatically upon Neo.setupClass
+                await DreamService.ready();
+                console.log('   DreamService Ready.');
 
-        console.log('✅ Services Ready. Entering REM Sleep...');
+                console.log('✅ Services Ready. Entering REM Sleep...');
 
-        // Execute the REM pipeline (extract undigested graph entities + Golden Path synthesis)
-        await DreamService.processUndigestedSessions();
-        await GoldenPathSynthesizer.synthesizeGoldenPath();
+                // Execute the REM pipeline (extract undigested graph entities + Golden Path synthesis)
+                await DreamService.processUndigestedSessions();
+                await GoldenPathSynthesizer.synthesizeGoldenPath();
 
-        console.log('✅ Sandman cycle complete.');
-        process.exitCode = 0;
+                console.log('✅ Sandman cycle complete.');
+                process.exitCode = 0;
+                return {providerReady: true};
+            } catch (e) {
+                console.error('❌ REM cycle failed:', e);
+                process.exitCode = 1;
+                return {providerReady: false, error: e.message};
+            }
+        }, {owner: 'sandman', reason: 'manual-cli', metadata: {script: 'buildScripts/ai/runSandman.mjs'}});
     } catch (e) {
-        console.error('❌ REM cycle failed:', e);
+        // withHeavyMaintenanceLease itself failed (e.g., lease-write IO error).
+        console.error('❌ REM cycle lease acquisition failed:', e);
         process.exitCode = 1;
-    } finally {
-        console.log('🧹 Triggering global topology decay & pruning mechanism...');
-        try {
-            // Need to await? decayGlobalTopology is synchronous.
-            GraphService.decayGlobalTopology();
-        } catch (e) {
-            console.error('❌ Failed to decay topology:', e);
-        }
-        process.exit(process.exitCode);
     }
+
+    if (outcome?.status === 'held') {
+        const held = outcome.lease;
+        console.log(`⏸️  Deferred: heavy-maintenance lease held by '${held.owner}' (reason='${held.reason}', pid=${held.pid}, acquiredAt=${held.acquiredAt}).`);
+        console.log('   This script will not run while another heavy-maintenance task is active. Re-invoke once the active owner completes.');
+        // Skip the decay step on held — no graph mutation occurred.
+        process.exit(0);
+    }
+
+    console.log('🧹 Triggering global topology decay & pruning mechanism...');
+    try {
+        // Need to await? decayGlobalTopology is synchronous.
+        GraphService.decayGlobalTopology();
+    } catch (e) {
+        console.error('❌ Failed to decay topology:', e);
+    }
+    process.exit(process.exitCode);
 }
 
 if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {

--- a/buildScripts/ai/syncGithubWorkflow.mjs
+++ b/buildScripts/ai/syncGithubWorkflow.mjs
@@ -1,4 +1,5 @@
-import {GH_Config, GH_SyncService} from '../../ai/services.mjs';
+import {GH_Config, GH_SyncService}     from '../../ai/services.mjs';
+import {withHeavyMaintenanceLease}     from '../../ai/daemons/services/HeavyMaintenanceLeaseService.mjs';
 
 /**
  * @module buildScripts/ai/syncGithubWorkflow
@@ -50,14 +51,31 @@ async function syncGithubWorkflow() {
 
     console.log('🔄 Starting full GitHub Workflow sync via GH_SyncService.runFullSync()...');
 
+    // Lane C of #11503 — wrap the heavy-maintenance work in the shared lease so this
+    // CLI cannot collide with the orchestrator's kbSync / summary / dream / golden-path
+    // tasks or with another manual heavy script (#11507 / #11505 lease primitive). Stage 2
+    // graph ingestion in particular is the substrate-heavy concern (per AC7 / #11503);
+    // whole-run guard is the v1 prescription pending future Stage 1 / Stage 2 split.
+    let outcome;
     try {
-        const result = await GH_SyncService.runFullSync();
-        console.log('✅ Sync complete:', result);
-        process.exit(0);
+        outcome = await withHeavyMaintenanceLease(
+            async () => GH_SyncService.runFullSync(),
+            {owner: 'syncGithubWorkflow', reason: 'manual-cli', metadata: {script: 'buildScripts/ai/syncGithubWorkflow.mjs', verbose}}
+        );
     } catch (e) {
         console.error('❌ Sync failed:', e);
         process.exit(1);
     }
+
+    if (outcome.status === 'held') {
+        const held = outcome.lease;
+        console.log(`⏸️  Deferred: heavy-maintenance lease held by '${held.owner}' (reason='${held.reason}', pid=${held.pid}, acquiredAt=${held.acquiredAt}).`);
+        console.log('   This script will not run while another heavy-maintenance task is active. Re-invoke once the active owner completes.');
+        process.exit(0);
+    }
+
+    console.log('✅ Sync complete:', outcome.result);
+    process.exit(0);
 }
 
 syncGithubWorkflow();

--- a/buildScripts/ai/syncKnowledgeBase.mjs
+++ b/buildScripts/ai/syncKnowledgeBase.mjs
@@ -1,13 +1,14 @@
 // Neo namespace bootstrap (entry-point invariant) — orchestrator spawn-child.
 // `InstanceManager` binds Neo.find/findFirst/get aliases + consumes pre-singleton
 // `Neo.idMap`; required for any consumer of the Neo singleton API.
-import Neo                  from '../../src/Neo.mjs';
-import * as core            from '../../src/core/_export.mjs';
-import InstanceManager      from '../../src/manager/Instance.mjs';
-import KB_Config            from '../../ai/mcp/server/knowledge-base/config.mjs';
-import KB_DatabaseService   from '../../ai/services/knowledge-base/DatabaseService.mjs';
-import KB_ChromaManager     from '../../ai/services/knowledge-base/ChromaManager.mjs';
-import KB_LifecycleService  from '../../ai/services/knowledge-base/DatabaseLifecycleService.mjs';
+import Neo                          from '../../src/Neo.mjs';
+import * as core                    from '../../src/core/_export.mjs';
+import InstanceManager              from '../../src/manager/Instance.mjs';
+import KB_Config                    from '../../ai/mcp/server/knowledge-base/config.mjs';
+import KB_DatabaseService           from '../../ai/services/knowledge-base/DatabaseService.mjs';
+import KB_ChromaManager             from '../../ai/services/knowledge-base/ChromaManager.mjs';
+import KB_LifecycleService          from '../../ai/services/knowledge-base/DatabaseLifecycleService.mjs';
+import {withHeavyMaintenanceLease}  from '../../ai/daemons/services/HeavyMaintenanceLeaseService.mjs';
 
 /**
  * @module buildScripts/ai/syncKnowledgeBase
@@ -18,31 +19,48 @@ async function syncKnowledgeBase() {
     KB_Config.data.debug = true;
 
     console.log('⏳ Initializing Knowledge Base Services...');
-    
-    try {
-        console.log('   Waiting for Lifecycle Service...');
-        await KB_LifecycleService.ready();
-        console.log('   Lifecycle Service Ready. Database should be running.');
 
-        console.log('   Waiting for Chroma Manager...');
-        await KB_ChromaManager.ready();
-        console.log('   Chroma Manager Ready.');
-        
-        console.log('   Waiting for Database Service...');
-        await KB_DatabaseService.ready();
-        console.log('   Database Service Ready.');
-        
-        console.log('✅ Services Ready. Starting Synchronization...');
-        
-        // Execute the full sync (create + embed)
-        const result = await KB_DatabaseService.syncDatabase();
-        
-        console.log('✅ Synchronization Complete:', result);
-        process.exit(0);
+    // Lane C of #11503 — wrap the heavy-maintenance work in the shared lease so this
+    // CLI cannot collide with the orchestrator's own kbSync task (which is the empirical
+    // collision class today's wedge at 19:27Z exhibited) or with other manual heavy
+    // scripts. The lease primitive lives in PR #11506 / #11505; Lane C is #11507.
+    let outcome;
+    try {
+        outcome = await withHeavyMaintenanceLease(
+            async () => {
+                console.log('   Waiting for Lifecycle Service...');
+                await KB_LifecycleService.ready();
+                console.log('   Lifecycle Service Ready. Database should be running.');
+
+                console.log('   Waiting for Chroma Manager...');
+                await KB_ChromaManager.ready();
+                console.log('   Chroma Manager Ready.');
+
+                console.log('   Waiting for Database Service...');
+                await KB_DatabaseService.ready();
+                console.log('   Database Service Ready.');
+
+                console.log('✅ Services Ready. Starting Synchronization...');
+
+                // Execute the full sync (create + embed)
+                return KB_DatabaseService.syncDatabase();
+            },
+            {owner: 'kbSync', reason: 'manual-cli', metadata: {script: 'buildScripts/ai/syncKnowledgeBase.mjs'}}
+        );
     } catch (e) {
         console.error('❌ Synchronization Failed:', e);
         process.exit(1);
     }
+
+    if (outcome.status === 'held') {
+        const held = outcome.lease;
+        console.log(`⏸️  Deferred: heavy-maintenance lease held by '${held.owner}' (reason='${held.reason}', pid=${held.pid}, acquiredAt=${held.acquiredAt}).`);
+        console.log('   This script will not run while another heavy-maintenance task is active. Re-invoke once the active owner completes.');
+        process.exit(0);
+    }
+
+    console.log('✅ Synchronization Complete:', outcome.result);
+    process.exit(0);
 }
 
 syncKnowledgeBase();

--- a/test/playwright/unit/ai/buildScripts/laneCManualScriptLeaseAdoption.spec.mjs
+++ b/test/playwright/unit/ai/buildScripts/laneCManualScriptLeaseAdoption.spec.mjs
@@ -82,6 +82,34 @@ test.describe('Lane C / #11507 — manual heavy-maintenance script lease adoptio
         });
     }
 
+    test('runSandman.mjs: fail-closed on lease-acquisition error — does NOT fall through to GraphService.decayGlobalTopology (per GPT review PRR_kwDODSospM8AAAABAJIdTg)', async () => {
+        // GPT's cycle-1 review (PR #11509 PRR_kwDODSospM8AAAABAJIdTg) caught: my prior code set
+        // process.exitCode=1 in the outer catch but FELL THROUGH to GraphService.decayGlobalTopology()
+        // which mutates SQLite graph edges + _SYSTEM_STATE. That defeats the substrate protection the
+        // PR is shipping — the one path where the lease was NOT acquired could still mutate the graph.
+        //
+        // Fix: process.exit(1) directly in the catch block to short-circuit before the decay call.
+        // This test pins the fail-closed contract via source inspection (subprocess test would require
+        // heavy Neo + LifecycleService bootstrap; content-grep matches this spec's existing pattern).
+        const source = await fs.readFile(path.join(scriptDir, 'runSandman.mjs'), 'utf-8');
+
+        // Find the catch block that handles withHeavyMaintenanceLease acquisition failure.
+        const acquisitionCatchMatch = source.match(/\}\s*catch\s*\([^)]+\)\s*\{[^}]*REM cycle lease acquisition failed[\s\S]*?\n\s{4}\}/);
+        expect(acquisitionCatchMatch).not.toBeNull();
+        const catchBlock = acquisitionCatchMatch[0];
+
+        // The catch block MUST call process.exit(1) to short-circuit (not just set exitCode then fall through).
+        expect(catchBlock).toMatch(/process\.exit\(1\)/);
+
+        // Defensive: ensure the catch block does NOT contain the prior buggy pattern
+        // (`process.exitCode = 1` without a subsequent `process.exit`).
+        const hasExitCodeAssignment = /process\.exitCode\s*=\s*1/.test(catchBlock);
+        const hasExitCall           = /process\.exit\(1\)/      .test(catchBlock);
+        if (hasExitCodeAssignment) {
+            expect(hasExitCall).toBe(true);
+        }
+    });
+
     test('all four scripts share the same lease-wrapper pattern (no per-script private locks)', async () => {
         // Empirical anchor: #11503 explicitly named "per-script private locks" as an avoided
         // trap. This test pins that none of the four scripts introduces an alternative

--- a/test/playwright/unit/ai/buildScripts/laneCManualScriptLeaseAdoption.spec.mjs
+++ b/test/playwright/unit/ai/buildScripts/laneCManualScriptLeaseAdoption.spec.mjs
@@ -110,6 +110,57 @@ test.describe('Lane C / #11507 — manual heavy-maintenance script lease adoptio
         }
     });
 
+    test('runSandman.mjs: decayGlobalTopology runs INSIDE the lease window (per GPT review PRR_kwDODSospM8AAAABAJKF8w)', async () => {
+        // GPT's cycle-2 review caught: `withHeavyMaintenanceLease` releases the lease in its
+        // own `finally` BEFORE returning, so calling `GraphService.decayGlobalTopology()` AFTER
+        // `await withHeavyMaintenanceLease(...)` settles would mutate Memory Core graph state
+        // OUTSIDE the lease — defeating the substrate protection this PR is shipping.
+        //
+        // Fix: decay is invoked inside an inner `finally` block within the async task passed
+        // to `withHeavyMaintenanceLease`. JS guarantees the inner finally runs before the
+        // task's returned promise settles, so the wrapper's own finally (release) runs strictly
+        // after decay.
+        //
+        // This test pins the release-timing invariant via source-offset comparison:
+        // the decay call MUST appear before the wrapper's owner-config trailer AND before any
+        // post-wrapper outcome handling — both of which mark the boundary where the lease has
+        // already been released by the wrapper.
+        const source = await fs.readFile(path.join(scriptDir, 'runSandman.mjs'), 'utf-8');
+
+        const decayMatch = source.match(/GraphService\.decayGlobalTopology\(\)/);
+        expect(decayMatch, 'decayGlobalTopology() call must exist in runSandman.mjs').not.toBeNull();
+
+        // The wrapper's options trailer `}, {owner: 'sandman', ...})` marks the end of the
+        // async-task argument. Decay must appear textually BEFORE this trailer to be inside
+        // the wrapped task.
+        const wrapperOptionsMatch = source.match(/\}\s*,\s*\{\s*owner\s*:\s*['"]sandman['"]/);
+        expect(wrapperOptionsMatch, "withHeavyMaintenanceLease wrapper's owner-config trailer must exist").not.toBeNull();
+        expect(
+            decayMatch.index,
+            'decay must run INSIDE the wrapped task (before the wrapper-options trailer) so it executes while the lease is still held'
+        ).toBeLessThan(wrapperOptionsMatch.index);
+
+        // Defensive: also assert decay appears BEFORE post-wrapper held-handling. Any decay
+        // call after the `if (outcome?.status === 'held')` branch would necessarily run after
+        // the wrapper's release.
+        const postWrapperMarkerMatch = source.match(/if\s*\(\s*outcome\?\.status\s*===\s*['"]held['"]\s*\)/);
+        expect(postWrapperMarkerMatch, 'post-wrapper held-handling branch must exist').not.toBeNull();
+        expect(
+            decayMatch.index,
+            'decay must NOT appear after the post-wrapper held-check — that position is outside the lease window'
+        ).toBeLessThan(postWrapperMarkerMatch.index);
+
+        // Defensive: the inner-task structure must contain a `finally {` block. This pins the
+        // structural mechanism (finally-block placement) rather than just the offset ordering,
+        // so a future refactor that accidentally moves decay into the wrapper's catch (which
+        // only fires on lease-acquisition failure → graph mutation outside the lease) is caught.
+        const innerFinallyMatch = source.match(/\}\s*finally\s*\{[\s\S]*?GraphService\.decayGlobalTopology\(\)/);
+        expect(
+            innerFinallyMatch,
+            'decayGlobalTopology must be invoked from inside a `finally {` block of the lease-wrapped task'
+        ).not.toBeNull();
+    });
+
     test('all four scripts share the same lease-wrapper pattern (no per-script private locks)', async () => {
         // Empirical anchor: #11503 explicitly named "per-script private locks" as an avoided
         // trap. This test pins that none of the four scripts introduces an alternative

--- a/test/playwright/unit/ai/buildScripts/laneCManualScriptLeaseAdoption.spec.mjs
+++ b/test/playwright/unit/ai/buildScripts/laneCManualScriptLeaseAdoption.spec.mjs
@@ -1,0 +1,97 @@
+import {setup} from '../../../setup.mjs';
+
+const appName = 'LaneCManualScriptLeaseAdoptionTest';
+
+setup({
+    neoConfig: {
+        unitTestMode: true
+    },
+    appConfig: {
+        name             : appName,
+        isMounted        : () => true,
+        vnodeInitialising: false
+    }
+});
+
+import {test, expect} from '@playwright/test';
+import fs             from 'fs/promises';
+import path           from 'path';
+
+/**
+ * @summary Lane C of #11503 — verifies that the four operator-runnable heavy-maintenance CLI
+ * scripts wrap their substrate-heavy work with the shared `withHeavyMaintenanceLease` primitive
+ * (PR #11506 / #11505) and handle the `held` outcome with a clean non-error exit.
+ *
+ * This spec uses content-verification (parse the script source for the expected import +
+ * wrapper call + held-status branch) rather than subprocess execution because:
+ * - Each script imports services.mjs / Neo / lifecycle services that initialize on module load,
+ *   making subprocess-per-test runs slow (multi-second) and flaky if any background daemon
+ *   is contending the same Chroma instance.
+ * - The underlying `withHeavyMaintenanceLease` is already tested by PR #11506's
+ *   `HeavyMaintenanceLeaseService.spec.mjs` (8/8 passing); Lane C just needs to verify the
+ *   WIRING is in place across all four scripts.
+ *
+ * Empirical anchor: today's wedge cascade at 2026-05-16T19:27Z showed the orchestrator's own
+ * kbSync subprocess in a collision class that would have allowed a manual `npm run ai:sync-kb`
+ * to compound the contention. Lane C closes that class at the script surface; this spec
+ * proves the wiring landed.
+ *
+ * @see #11503 (umbrella)
+ * @see #11505 (lease primitive ticket) / PR #11506 (lease primitive implementation)
+ * @see #11507 (this ticket)
+ */
+test.describe('Lane C / #11507 — manual heavy-maintenance script lease adoption', () => {
+    const scriptDir = path.resolve(process.cwd(), 'buildScripts/ai');
+
+    /**
+     * Maps each script to its expected lease `owner` string. Owner strings are stable
+     * identifiers used by both the wrapper-side defer message and the orchestrator-side
+     * task names — keep these in sync with `Orchestrator.mjs` DEFAULT_HEAVY_MAINTENANCE_TASK_NAMES.
+     */
+    const SCRIPTS = [
+        {file: 'runSandman.mjs',           owner: 'sandman'},
+        {file: 'syncKnowledgeBase.mjs',    owner: 'kbSync'},
+        {file: 'backup.mjs',               owner: 'backup'},
+        {file: 'syncGithubWorkflow.mjs',   owner: 'syncGithubWorkflow'}
+    ];
+
+    for (const {file, owner} of SCRIPTS) {
+        test(`${file}: imports withHeavyMaintenanceLease`, async () => {
+            const source = await fs.readFile(path.join(scriptDir, file), 'utf-8');
+            expect(source).toMatch(/import\s*\{[^}]*withHeavyMaintenanceLease[^}]*\}\s*from\s*['"]\.\.\/\.\.\/ai\/daemons\/services\/HeavyMaintenanceLeaseService\.mjs['"]/);
+        });
+
+        test(`${file}: wraps heavy work with withHeavyMaintenanceLease + correct owner '${owner}'`, async () => {
+            const source = await fs.readFile(path.join(scriptDir, file), 'utf-8');
+            // Assert the wrapper is INVOKED (not just imported)
+            expect(source).toContain('withHeavyMaintenanceLease(');
+            // Assert the correct owner string is passed
+            expect(source).toMatch(new RegExp(`owner\\s*:\\s*['"]${owner}['"]`));
+            // Assert the manual-cli reason tag is in place (distinguishes CLI invocations from orchestrator-spawned ones in lease telemetry)
+            expect(source).toMatch(/reason\s*:\s*['"]manual-cli['"]/);
+        });
+
+        test(`${file}: handles 'held' outcome with non-error exit + diagnostic message`, async () => {
+            const source = await fs.readFile(path.join(scriptDir, file), 'utf-8');
+            // Assert the held-status branch exists
+            expect(source).toMatch(/status\s*===\s*['"]held['"]/);
+            // Assert the deferred message names the active owner (so the user sees who holds the lease)
+            expect(source).toMatch(/Deferred:.*lease held by/i);
+            // Assert process.exit(0) is called on held — non-error semantics per AC2
+            expect(source).toMatch(/process\.exit\(0\)/);
+        });
+    }
+
+    test('all four scripts share the same lease-wrapper pattern (no per-script private locks)', async () => {
+        // Empirical anchor: #11503 explicitly named "per-script private locks" as an avoided
+        // trap. This test pins that none of the four scripts introduces an alternative
+        // lock-file or in-process mutex — they all consume the shared lease primitive.
+        for (const {file} of SCRIPTS) {
+            const source = await fs.readFile(path.join(scriptDir, file), 'utf-8');
+            expect(source).not.toMatch(/private.*lock|local.*mutex|script.*lock.*file/i);
+            // Each script must import from the same canonical lease module path; no alternate
+            // lease implementations.
+            expect(source).toContain('ai/daemons/services/HeavyMaintenanceLeaseService.mjs');
+        }
+    });
+});


### PR DESCRIPTION
Resolves #11507

FAIR-band: in-band [11/30] — prio-0 (operator elevation 2026-05-16T22:55Z); Lane C of #11503 umbrella; closes the gh-CLI bypass surface at the maintenance-script layer (parallel to PR #11502 closing the same Helpful-Assistant CLI-bypass pattern at the pr-review surface).

Evidence: L2 (15/15 content-verification spec tests pass in 2.5s — 13 baseline covering all 4 scripts × {import-presence + wrapper-invocation + correct-owner-string + held-outcome handling} + no-private-locks invariant, plus 2 regression tests on `runSandman.mjs` from GPT's cycle-1 + cycle-2 reviews: (1) acquisition-failure fail-closed catch must call `process.exit(1)` (not fall through to `decayGlobalTopology`); (2) release-timing invariant — `decayGlobalTopology` must run INSIDE the `withHeavyMaintenanceLease` wrapped task's `finally {}` block, not after the await where the lease is already released. Per-script subprocess integration testing deferred per scope-restraint). Underlying `withHeavyMaintenanceLease` primitive already covered by PR #11506's `HeavyMaintenanceLeaseService.spec.mjs` (8/8). L4 operator verification post-merge: run `npm run ai:sync-kb` while a long orchestrator-owned heavy task is active; confirm deferred-message exit.

## Deltas

- Scope locked per #11507 ACs + GPT's #11503 lead-sync (MESSAGE:20f48f73): four scripts (`runSandman`/`syncKnowledgeBase`/`backup`/`syncGithubWorkflow`); AC7 whole-run guard for `syncGithubWorkflow` (Stage 1/Stage 2 split deferred); per-script subprocess tests skipped in favor of content-verification (rationale in PR body avoided-traps).
- `backup.mjs` wraps only the auto-run-when-invoked-directly block (NOT the exported `runBackup` function itself) — test harnesses and module-level callers retain full control of their own concurrency context.
- `runSandman.mjs` preserves its existing graceful-fail semantics for provider-readiness (return-without-throw at provider-fail branch); decay-topology step runs INSIDE the wrapped task's inner `finally {}` so it always executes inside the lease window on the completed path. On held, no graph mutation occurs and decay is skipped entirely.
- **Cycle-1 fix (commit `375a1e90c`)**: per GPT review `PRR_kwDODSospM8AAAABAJIdTg` — lease-acquisition catch in `runSandman.mjs` short-circuits with `process.exit(1)` instead of falling through to `GraphService.decayGlobalTopology()` (which would mutate the graph outside the lease).
- **Cycle-2 fix (commit `3631fb361`)**: per GPT review `PRR_kwDODSospM8AAAABAJKF8w` — `decayGlobalTopology` moved into an inner `finally {}` block of the async task passed to `withHeavyMaintenanceLease`. JS guarantees inner-finally runs before the wrapper's outer-finally (which releases the lease), so decay is strictly inside the lease window. The inner try/catch around decay preserves graceful-fail semantics without throwing out of the wrapped task.

## Test Evidence

- `npm run test-unit -- test/playwright/unit/ai/buildScripts/laneCManualScriptLeaseAdoption.spec.mjs` → **15/15 passed in 2.5s**
  - 13 baseline: 4 scripts × {import-presence + wrapper-invocation/correct-owner + held-handling} + no-private-locks invariant
  - +1 cycle-1: `runSandman.mjs` lease-acquisition fail-closed catch (does NOT fall through to decay)
  - +1 cycle-2: `runSandman.mjs` release-timing invariant (3 independent assertions — decay offset < wrapper-options-trailer offset, decay offset < post-wrapper held-handler offset, structural `} finally { ... decayGlobalTopology` regex)
- `node --check` syntax-clean on all 4 modified scripts
- Branch-from-`origin/dev`-tip freshness verified (post-PR #11506 merge)
- Spec uses content-verification (parse script source for expected import + wrapper-call + held-status branch + release-timing); per-script subprocess integration tests deferred per scope-restraint

## Post-Merge Validation

- [ ] **L4 operator verification**: run `npm run ai:sync-kb` while orchestrator-owned `summary` or `kbSync` task is active; confirm deferred-message exit (non-error, names active lease owner)
- [ ] **L4 collision test**: trigger orchestrator to start a heavy task, then immediately `npm run ai:backup` — confirm second invocation defers cleanly
- [ ] **Sandman edge case**: confirm `runSandman` skips decay-topology step on held-outcome (since no graph mutation occurred) and runs decay on completed INSIDE the lease window
- [ ] **syncGithubWorkflow whole-run guard**: confirm lease held for entire Stage 1 + Stage 2 (no early release between phases); empirical anchor for future Stage-split refinement if hold-time becomes pain

## Authority anchors

- **Umbrella**: #11503 (Enforce heavy-maintenance mutex across Agent OS tasks)
- **Substrate dependency**: PR #11506 / #11505 (HeavyMaintenanceLeaseService primitive)
- **GPT lead-sync** (MESSAGE:20f48f73): lane ordering + AC7 whole-run guard + Lane D fold-in to Lane B API design
- **GPT cycle-1 review**: `PRR_kwDODSospM8AAAABAJIdTg` (fail-closed gap → commit 375a1e90c)
- **GPT cycle-2 review**: `PRR_kwDODSospM8AAAABAJKF8w` (release-timing gap → commit 3631fb361)
- **GPT cycle-3 review**: `PRR_kwDODSospM8AAAABAJLdYg` (APPROVED)
- **Operator prio-0 elevation** 2026-05-16T22:55Z: *"this should be our next prio 0 item to unblock us"*
- **Empirical anchor**: today's wedge cascade 2026-05-16T19:27Z — orchestrator kbSync wedged while manual `npm run ai:sync-kb` would have collided. The substrate gap is the failure class this PR closes.
- **Conceptual sibling**: PR #11502 / #11495 (CI lint for gh-pr-review CLI bypass) — same Helpful-Assistant CLI-bypass failure pattern, different substrate surface

## Avoided traps

- **Wrapping the exported `runBackup` function instead of the auto-run block**: rejected for `backup.mjs` — test harnesses and other module-level callers would inherit unwanted lease semantics. Wrap the CLI invocation surface only.
- **Splitting `syncGithubWorkflow` into Stage 1 (light) / Stage 2 (heavy) for finer lease scope**: rejected per GPT's lead-sync (whole-run guard for v1; refinement deferred until lease hold-time becomes empirical pain).
- **Per-script subprocess integration tests**: rejected for scope-restraint — each script's top-level imports trigger heavy Neo + service initialization that makes subprocess tests slow and flaky. Content-verification covers the wiring; underlying behavior is tested by PR #11506.
- **Wait-loop on held (block until lease released)**: rejected per `withHeavyMaintenanceLease` contract — held returns immediately. Scripts defer-and-exit; operator can re-invoke.
- **Per-script private locks**: rejected per #11503 avoided-trap. All 4 scripts consume the shared lease primitive; spec asserts no alternative lock-file or in-process mutex pattern.
- **Adding lease semantics to pure-static-validation scripts** (`check-substrate-size`, `lint-skill-manifest`, `check-retired-primitives`): rejected — those aren't in the heavy-maintenance set (no Chroma/SQLite/LLM writes).
- **Decay outside the lease window** (cycle-2 anti-pattern): rejected — `withHeavyMaintenanceLease` releases in its own `finally` before returning, so any decay after the await runs unprotected. Decay placed in the inner finally of the wrapped task to honor the release-timing invariant.
- **Decay-call throwing out of the wrapped task**: rejected — decay failure must not (a) suppress the inner return value used for held/completed discrimination or (b) propagate to the outer catch reserved for lease-acquisition fail-closed (cycle-1 contract). Wrapped in try/catch inside the finally.