### PR TITLE
chore(ci): upgrade github-script to v9 and remove Node 24 overrides (#11508)

### DIFF
--- a/.github/workflows/agent-pr-body-lint.yml
+++ b/.github/workflows/agent-pr-body-lint.yml
@@ -3,15 +3,13 @@ on:
   pull_request:
     types: [opened, edited, synchronize]
 
-env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
 jobs:
   lint-pr-body:
     runs-on: ubuntu-latest
     steps:
       - name: Validate PR Body
-        uses: actions/github-script@v8
+        uses: actions/github-script@v9
         with:
           script: |
             const pr = context.payload.pull_request;

--- a/.github/workflows/agent-pr-review-body-lint.yml
+++ b/.github/workflows/agent-pr-review-body-lint.yml
@@ -11,15 +11,13 @@ on:
   pull_request_review:
     types: [submitted, edited]
 
-env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
 jobs:
   lint-pr-review-body:
     runs-on: ubuntu-latest
     steps:
       - name: Validate PR Review Body
-        uses: actions/github-script@v8
+        uses: actions/github-script@v9
         with:
           script: |
             const review   = context.payload.review;

--- a/.github/workflows/close-inactive-issues.yml
+++ b/.github/workflows/close-inactive-issues.yml
@@ -3,8 +3,6 @@ on:
   schedule:
     - cron: '30 1 * * *'
 
-env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
 jobs:
   close-issues:

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -20,8 +20,6 @@ on:
   schedule:
     - cron: '24 9 * * 3'
 
-env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
 jobs:
   analyze:

--- a/.github/workflows/data-sync-pipeline.yml
+++ b/.github/workflows/data-sync-pipeline.yml
@@ -9,8 +9,6 @@ concurrency:
   group: data-sync-pipeline
   cancel-in-progress: false
 
-env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
 jobs:
   run-pipeline:

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -2,8 +2,6 @@ name: Publish Package to npmjs
 on:
   release:
     types: [ published ]
-env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
 jobs:
   build:

--- a/.github/workflows/pr-base-guard.yml
+++ b/.github/workflows/pr-base-guard.yml
@@ -5,8 +5,6 @@ on:
     branches:
       - main
 
-env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
 jobs:
   enforce-dev-base:
@@ -16,7 +14,7 @@ jobs:
       issues: write
     steps:
       - name: Enforce dev base for agents
-        uses: actions/github-script@v8
+        uses: actions/github-script@v9
         with:
           script: |
             const pr = context.payload.pull_request;

--- a/.github/workflows/prevent-reopen.yml
+++ b/.github/workflows/prevent-reopen.yml
@@ -3,15 +3,13 @@ on:
   issues:
     types: [reopened]
 
-env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
 jobs:
   prevent-reopen:
     runs-on: ubuntu-latest
     steps:
       - name: Close and create new ticket
-        uses: actions/github-script@v8
+        uses: actions/github-script@v9
         with:
           script: |
             const issue = context.payload.issue;

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,8 +10,6 @@ concurrency:
   group: tests-${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
-env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
 jobs:
   test:


### PR DESCRIPTION
Authored by Gemini 3.1 Pro (Antigravity). Session fc8abc96-ce88-407e-9d92-7fcc494f8236.

FAIR-band: under-target [8/30] — Self-Selection Rule 1 fires (under-band → bias toward author lane)

Resolves #11508

This PR modernizes the CI/CD pipeline by removing the obsolete `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24` environment variable across all relevant workflow files and upgrading the `actions/github-script` dependency from `v8` to `v9`. Version 9 natively uses Node 24 as an ESM-only environment, aligning with the architectural requirement.

Evidence: L1 (static config-shape audit) → L1 required (no runtime-verify ACs). No residuals.

## Deltas from ticket (if any)
None.

## Test Evidence
Verified that the removed environment variables and upgraded action versions pass standard YAML validation. The CI checks will execute automatically upon opening this PR to verify ESM compatibility.

## Post-Merge Validation
- [ ] Verify that CI pipelines complete successfully without Node 24 deprecation warnings.
