### PR TITLE
feat(ai): classify Golden Path as light maintenance (#11511)

### DIFF
--- a/ai/daemons/Orchestrator.mjs
+++ b/ai/daemons/Orchestrator.mjs
@@ -44,8 +44,11 @@ export const DEFAULT_HEAVY_MAINTENANCE_TASK_NAMES = Object.freeze([
     'summary',
     'kbSync',
     PRIMARY_DEV_SYNC_TASK_NAME,
-    DREAM_TASK_NAME,
-    GOLDEN_PATH_TASK_NAME
+    DREAM_TASK_NAME
+]);
+
+export const DEFAULT_GOLDEN_PATH_DEPENDENCY_TASK_NAMES = Object.freeze([
+    DREAM_TASK_NAME
 ]);
 
 /**
@@ -273,6 +276,12 @@ export class Orchestrator extends Base {
          */
         heavyMaintenanceTaskNames_: DEFAULT_HEAVY_MAINTENANCE_TASK_NAMES,
         /**
+         * @member {String[]} goldenPathDependencyTaskNames_=DEFAULT_GOLDEN_PATH_DEPENDENCY_TASK_NAMES
+         * @protected
+         * @reactive
+         */
+        goldenPathDependencyTaskNames_: DEFAULT_GOLDEN_PATH_DEPENDENCY_TASK_NAMES,
+        /**
          * @member {Set|null} maintenanceDeferralLogKeys_=null
          * @protected
          * @reactive
@@ -334,6 +343,7 @@ export class Orchestrator extends Base {
         this.backupCoordinator      = options.backupCoordinator      || BackupCoordinatorService;
         this.primaryRepoSyncService = options.primaryRepoSyncService || PrimaryRepoSyncService;
         this.heavyMaintenanceTaskNames = [...(options.heavyMaintenanceTaskNames || DEFAULT_HEAVY_MAINTENANCE_TASK_NAMES)];
+        this.goldenPathDependencyTaskNames = [...(options.goldenPathDependencyTaskNames || DEFAULT_GOLDEN_PATH_DEPENDENCY_TASK_NAMES)];
         this.maintenanceDeferralLogKeys = new Set();
         this.spawnFn                = options.spawnFn                || spawn;
         this.processSupervisorService = options.processSupervisorService || ProcessSupervisorService;
@@ -422,6 +432,15 @@ export class Orchestrator extends Base {
     }
 
     /**
+     * Checks whether a running task should delay Golden Path frontier refresh.
+     * @param {String} taskName Stable orchestrator task name.
+     * @returns {Boolean}
+     */
+    isGoldenPathDependencyTask(taskName) {
+        return this.goldenPathDependencyTaskNames.includes(taskName);
+    }
+
+    /**
      * Finds the first running heavy maintenance task.
      * @param {Object} [options]
      * @param {String|null} [options.excludeTaskName=null] Task name to ignore.
@@ -433,6 +452,26 @@ export class Orchestrator extends Base {
                 continue;
             }
 
+            if (this.taskStateService.getTaskState(taskName)?.running) {
+                return taskName;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * Finds a running task that would make Golden Path read partial graph state.
+     * @param {Object} [options]
+     * @param {String|null} [options.activeTaskName=null] Newly started task in the current poll.
+     * @returns {String|null}
+     */
+    findActiveGoldenPathDependencyTask({activeTaskName = null} = {}) {
+        if (activeTaskName && this.isGoldenPathDependencyTask(activeTaskName)) {
+            return activeTaskName;
+        }
+
+        for (const taskName of this.goldenPathDependencyTaskNames) {
             if (this.taskStateService.getTaskState(taskName)?.running) {
                 return taskName;
             }
@@ -489,6 +528,33 @@ export class Orchestrator extends Base {
     }
 
     /**
+     * Records a sparse Golden Path deferral when graph-mutating dependencies are active.
+     * @param {String} blockingTaskName Active dependency task name.
+     * @param {String} reason Scheduling reason for the Golden Path task.
+     * @returns {void}
+     */
+    recordGoldenPathDependencyDeferral(blockingTaskName, reason) {
+        this.maintenanceDeferralLogKeys ??= new Set();
+
+        const key = `${GOLDEN_PATH_TASK_NAME}:${blockingTaskName}:${reason}`;
+
+        if (!this.maintenanceDeferralLogKeys.has(key)) {
+            const taskLabel     = this.taskDefinitions?.[GOLDEN_PATH_TASK_NAME]?.label || GOLDEN_PATH_TASK_NAME;
+            const blockingLabel = this.taskDefinitions?.[blockingTaskName]?.label || blockingTaskName;
+
+            this.writeLog('INFO', `[Orchestrator] Deferring ${taskLabel}; dependency task ${blockingLabel} is active (${reason}).`);
+            this.maintenanceDeferralLogKeys.add(key);
+        }
+
+        this.healthService?.recordTaskOutcome?.(GOLDEN_PATH_TASK_NAME, 'skipped', {
+            reason,
+            reasonCode     : 'golden-path-dependency-backpressure',
+            blockingTaskName,
+            deferredAt     : new Date().toISOString()
+        });
+    }
+
+    /**
      * Wraps a task executor with cross-task heavy-maintenance backpressure.
      * @param {Function} executeFn Task executor.
      * @param {Object} activeHeavyTask Mutable active-heavy tracker for the current poll.
@@ -518,6 +584,30 @@ export class Orchestrator extends Base {
             }
 
             return result;
+        };
+    }
+
+    /**
+     * Wraps Golden Path execution with dependency ordering without making it a heavyweight blocker.
+     * @param {Function} executeFn Task executor.
+     * @param {Object} activeHeavyTask Mutable active-heavy tracker for the current poll.
+     * @returns {Function}
+     */
+    createGoldenPathExecutor(executeFn, activeHeavyTask) {
+        return (taskName, reason) => {
+            const reasonText = reason || 'scheduled';
+            const blockingTaskName = this.findActiveGoldenPathDependencyTask({
+                activeTaskName: activeHeavyTask.name
+            });
+
+            if (blockingTaskName) {
+                this.recordGoldenPathDependencyDeferral(blockingTaskName, reasonText);
+                return false;
+            }
+
+            this.clearMaintenanceDeferralLogState(taskName);
+
+            return executeFn(taskName, reason);
         };
     }
 
@@ -637,7 +727,7 @@ export class Orchestrator extends Base {
                 return { reason: `periodic-golden-path:${this.goldenPathIntervalMs}` };
             }
             return null;
-        }, executeMaintenanceTask(async (taskName, reason) => {
+        }, this.createGoldenPathExecutor(async (taskName, reason) => {
             this.taskStateService.markStarted(taskName, reason.reason);
             this.healthService?.recordTaskOutcome?.(taskName, 'running', { reason, startedAt: new Date().toISOString() });
             try {
@@ -650,7 +740,7 @@ export class Orchestrator extends Base {
                 this.taskStateService.markFailed(taskName, 1);
                 this.healthService?.recordTaskOutcome?.(taskName, 'failed', { reason, error: e.message, failedAt: new Date().toISOString() });
             }
-        }), context);
+        }, activeHeavyTask), context);
 
         if (this.isPolling) {
             this.pollHandle = setTimeout(() => this.poll(), this.pollIntervalMs);

--- a/test/playwright/unit/ai/daemons/Orchestrator.spec.mjs
+++ b/test/playwright/unit/ai/daemons/Orchestrator.spec.mjs
@@ -218,6 +218,89 @@ test.describe('Neo.ai.daemons.Orchestrator (#11009)', () => {
         expect(logs.filter(entry => entry.message.includes('Deferring knowledge base sync'))).toHaveLength(1);
     });
 
+    test('does not let a running golden path refresh backpressure heavy maintenance', () => {
+        const started = [];
+
+        const orchestrator = createTestOrchestrator();
+
+        TaskStateService.taskState[GOLDEN_PATH_TASK_NAME].running = true;
+        orchestrator.processSupervisorService = {
+            runTask(taskName, reason) {
+                started.push({taskName, reason});
+                return true;
+            }
+        };
+
+        orchestrator.poll();
+
+        expect(started).toEqual([{
+            taskName: 'kbSync',
+            reason  : 'periodic-sync:600000'
+        }]);
+    });
+
+    test('defers golden path behind active dream graph mutation with explicit reason', () => {
+        const logs     = [];
+        const outcomes = [];
+        const calls    = [];
+
+        const orchestrator = createTestOrchestrator({
+            goldenPathIntervalMs: 600000,
+            healthService: {
+                recordTaskOutcome(taskName, status, details) {
+                    outcomes.push({taskName, status, details});
+                }
+            },
+            goldenPathSynthesizer: {
+                synthesizeGoldenPath() {
+                    calls.push('golden-path');
+                    return Promise.resolve();
+                }
+            }
+        });
+
+        TaskStateService.taskState[DREAM_TASK_NAME].running = true;
+        orchestrator.writeLog = (level, message) => logs.push({level, message});
+
+        orchestrator.poll();
+
+        expect(calls).toEqual([]);
+        expect(outcomes).toContainEqual({
+            taskName: GOLDEN_PATH_TASK_NAME,
+            status  : 'skipped',
+            details : expect.objectContaining({
+                blockingTaskName: DREAM_TASK_NAME,
+                reason          : 'periodic-golden-path:600000',
+                reasonCode      : 'golden-path-dependency-backpressure'
+            })
+        });
+        expect(logs).toContainEqual({
+            level  : 'INFO',
+            message: expect.stringContaining('Deferring golden path synthesis; dependency task REM sleep graph extraction is active')
+        });
+    });
+
+    test('allows golden path refresh while non-dream heavy maintenance is active', async () => {
+        const calls = [];
+
+        const orchestrator = createTestOrchestrator({
+            goldenPathIntervalMs: 600000,
+            goldenPathSynthesizer: {
+                synthesizeGoldenPath() {
+                    calls.push('golden-path');
+                    return Promise.resolve();
+                }
+            }
+        });
+
+        TaskStateService.taskState.summary.running = true;
+
+        orchestrator.poll();
+        await Promise.resolve();
+
+        expect(calls).toEqual(['golden-path']);
+    });
+
     test('keeps continuous daemon supervision outside heavy maintenance backpressure', () => {
         const started = [];
 


### PR DESCRIPTION
Resolves #11511

Authored by GPT-5.5 (Codex Desktop). Session unavailable; Memory Core `add_memory` intentionally skipped during the active Chroma / memory-pressure incident per operator instruction.

FAIR-band: in-band [10/30]

Evidence: L2 (focused Orchestrator unit policy tests) -> L2 required (scheduler conflict policy ACs). No residuals.

Golden Path is now classified as light frontier-refresh work instead of participating in the all-against-all heavyweight maintenance bucket. True heavyweight tasks still mutually exclude each other, while Golden Path keeps a narrower dependency guard against active DreamService graph mutation so it does not read a partially-mutated frontier.

## Deltas From Ticket

- Removed `GOLDEN_PATH_TASK_NAME` from `DEFAULT_HEAVY_MAINTENANCE_TASK_NAMES`.
- Added `DEFAULT_GOLDEN_PATH_DEPENDENCY_TASK_NAMES` so Golden Path can defer behind explicit graph-mutation dependencies without becoming a heavyweight blocker itself.
- Added a dedicated `golden-path-dependency-backpressure` health reason code and log text for DreamService ordering.
- Added focused Orchestrator unit coverage for running Golden Path not blocking heavy work, DreamService deferral, and non-Dream heavy work not blocking Golden Path.

## Test Evidence

- `node --check ai/daemons/Orchestrator.mjs`
- `node --check test/playwright/unit/ai/daemons/Orchestrator.spec.mjs`
- `npm run test-unit -- test/playwright/unit/ai/daemons/Orchestrator.spec.mjs` -> 12 passed
- `git diff --check origin/dev..HEAD`

## Post-Merge Validation

- [ ] Restart `npm run ai:orchestrator` and verify Golden Path no longer reports generic `heavy-maintenance-backpressure` merely because summary / KB sync is active.
- [ ] Verify Golden Path still defers behind active DreamService with `golden-path-dependency-backpressure`.

## Commit

- `f5f0edb4f` - `feat(ai): classify golden path as light maintenance (#11511)`

## Related

- Related: #11503
- Related: #11389
- Related: #11505
- Related: #11507
