### PR TITLE
feat(ai): add backup to heavy-maintenance set + tests (#11513)

### DIFF
--- a/ai/daemons/Orchestrator.mjs
+++ b/ai/daemons/Orchestrator.mjs
@@ -40,9 +40,32 @@ import {
     buildTaskDefinitions
 } from './TaskDefinitions.mjs';
 
+/**
+ * Canonical set of heavy-maintenance task names that participate in the orchestrator's
+ * cross-poll backpressure invariant: at any time, across orchestrator-owned tasks AND
+ * lease-aware manual scripts (see `HeavyMaintenanceLeaseService` + Lane C wrappers in
+ * `buildScripts/ai/*.mjs`), at most one substrate-heavy maintenance job may hold the
+ * heavy-maintenance lease.
+ *
+ * Membership rationale per #11503:
+ * - `summary` / `kbSync` / `dream` — Memory Core graph + Chroma write-heavy
+ * - `backup` — exports KB Chroma + Memory Core Chroma + SQLite graph state; substrate-heavy
+ *   even though it doesn't mutate, because concurrent IO with other heavy classes is the
+ *   contention surface (added by #11513 — Lane A of #11503)
+ * - `PRIMARY_DEV_SYNC_TASK_NAME` — git fetch + nested KB sync cascade
+ *
+ * Intentionally NOT in the heavy set:
+ * - `GOLDEN_PATH_TASK_NAME` — classified as light maintenance per #11511 / PR #11512
+ *   (synthesizer reads the graph; does not write the heavy substrates)
+ *
+ * Cross-poll deferral coverage lives in `test/playwright/unit/ai/daemons/Orchestrator.spec.mjs`.
+ *
+ * @type {ReadonlyArray<String>}
+ */
 export const DEFAULT_HEAVY_MAINTENANCE_TASK_NAMES = Object.freeze([
     'summary',
     'kbSync',
+    'backup',
     PRIMARY_DEV_SYNC_TASK_NAME,
     DREAM_TASK_NAME
 ]);
@@ -662,13 +685,20 @@ export class Orchestrator extends Base {
             return null;
         }, executeMaintenanceTask(executeTask), context);
 
+        // #11513 (Lane A of #11503): wrap backup execution with the heavy-maintenance
+        // executor so a due backup defers when ANY other heavy task is active. Adding
+        // `'backup'` to `DEFAULT_HEAVY_MAINTENANCE_TASK_NAMES` makes backup recognized
+        // as a heavy *blocker* (via `findActiveHeavyMaintenanceTask`), but the deferral
+        // check on the *candidate* side only runs through `createMaintenanceExecutor`.
+        // Sibling tasks (summary at line 675, kbSync at 686, primary-dev-sync at 718,
+        // dream at 742) all route through `executeMaintenanceTask`; backup must too.
         this.cadenceEngine.runIfDue('backup', () => {
             return this.backupCoordinator.getDueTask({
                 state           : this.taskStateService.getState(),
                 now,
                 backupIntervalMs: this.backupIntervalMs
             });
-        }, executeTask, context);
+        }, executeMaintenanceTask(executeTask), context);
 
         this.cadenceEngine.runIfDue(PRIMARY_DEV_SYNC_TASK_NAME, () => {
             return this.primaryRepoSyncService.getDueTask({

--- a/test/playwright/unit/ai/daemons/Orchestrator.spec.mjs
+++ b/test/playwright/unit/ai/daemons/Orchestrator.spec.mjs
@@ -3,6 +3,7 @@ import path from 'path';
 import Neo from '../../../../../src/Neo.mjs';
 import * as core from '../../../../../src/core/_export.mjs';
 import {
+    DEFAULT_HEAVY_MAINTENANCE_TASK_NAMES,
     Orchestrator,
     resolvePrimaryDevSyncRootsConfig,
     resolvePrimaryDevSyncRootsSource
@@ -473,6 +474,188 @@ test.describe('Neo.ai.daemons.Orchestrator (#11009)', () => {
                 process.env[DEV_SYNC_ROOTS_ENV_VAR] = originalEnvValue;
             }
         }
+    });
+
+    // ─────────────────────────────────────────────────────────────────────────────
+    // Lane A of #11503 — per #11513:
+    //   1. AC2: pin DEFAULT_HEAVY_MAINTENANCE_TASK_NAMES contents so future refactors
+    //      can't silently drop a heavy class.
+    //   2. AC3-AC6: cross-poll deferral coverage for backup / dream / primary-dev-sync
+    //      and proof that `backup` is now ALSO a valid blocker (previously: only
+    //      summary↔kbSync pair was pinned at line 184).
+    //
+    // Golden-path is intentionally NOT in this set (light-classified per #11511 / PR #11512).
+    // Its dream-dependency backpressure is covered separately at line ~242.
+    // ─────────────────────────────────────────────────────────────────────────────
+
+    test('DEFAULT_HEAVY_MAINTENANCE_TASK_NAMES pins the canonical heavy-classification set (#11513 AC2)', () => {
+        // Asserts EXACT membership (frozen array) so a future refactor that drops a
+        // class is caught at test-time. Order matters less than membership; using a
+        // sorted-set assertion to decouple from declaration order.
+        expect([...DEFAULT_HEAVY_MAINTENANCE_TASK_NAMES].sort()).toEqual([
+            'backup',
+            'kbSync',
+            PRIMARY_DEV_SYNC_TASK_NAME,
+            DREAM_TASK_NAME,
+            'summary'
+        ].sort());
+        expect(Object.isFrozen(DEFAULT_HEAVY_MAINTENANCE_TASK_NAMES)).toBe(true);
+        // Defensive: golden-path is intentionally OUT per #11511 / #11512 (light maintenance).
+        expect(DEFAULT_HEAVY_MAINTENANCE_TASK_NAMES).not.toContain(GOLDEN_PATH_TASK_NAME);
+    });
+
+    test('defers due backup when another heavy maintenance task is already running (#11513 AC3)', () => {
+        const logs     = [];
+        const outcomes = [];
+        const started  = [];
+
+        const orchestrator = createTestOrchestrator({
+            healthService: {
+                recordTaskOutcome(taskName, status, details) {
+                    outcomes.push({taskName, status, details});
+                }
+            },
+            backupCoordinator: {
+                getDueTask() {
+                    return {
+                        taskName: 'backup',
+                        reason  : 'periodic-backup:test'
+                    };
+                }
+            }
+        });
+
+        // summary is the blocker; backup must defer behind it.
+        TaskStateService.taskState.summary.running = true;
+        orchestrator.processSupervisorService = {
+            runTask(taskName, reason) {
+                started.push({taskName, reason});
+                return true;
+            }
+        };
+        orchestrator.writeLog = (level, message) => logs.push({level, message});
+
+        orchestrator.poll();
+
+        expect(started.filter(s => s.taskName === 'backup')).toEqual([]);
+        expect(outcomes).toContainEqual({
+            taskName: 'backup',
+            status  : 'skipped',
+            details : expect.objectContaining({
+                blockingTaskName: 'summary',
+                reasonCode      : 'heavy-maintenance-backpressure'
+            })
+        });
+    });
+
+    test('running backup defers due kbSync — proves backup is now a valid blocker (#11513 AC3 symmetric)', () => {
+        const outcomes = [];
+        const started  = [];
+
+        const orchestrator = createTestOrchestrator({
+            healthService: {
+                recordTaskOutcome(taskName, status, details) {
+                    outcomes.push({taskName, status, details});
+                }
+            }
+        });
+
+        // backup is now the blocker (only meaningful AFTER backup is in the heavy set —
+        // before #11513 this test would have observed kbSync running despite backup active).
+        TaskStateService.taskState.backup.running = true;
+        orchestrator.processSupervisorService = {
+            runTask(taskName, reason) {
+                started.push({taskName, reason});
+                return true;
+            }
+        };
+
+        orchestrator.poll();
+
+        expect(started).toEqual([]);
+        expect(outcomes).toContainEqual({
+            taskName: 'kbSync',
+            status  : 'skipped',
+            details : expect.objectContaining({
+                blockingTaskName: 'backup',
+                reasonCode      : 'heavy-maintenance-backpressure'
+            })
+        });
+    });
+
+    test('defers due dream when another heavy maintenance task is already running (#11513 AC4 — umbrella AC2 gap fill)', () => {
+        const dreamCalls = [];
+        const outcomes   = [];
+
+        const orchestrator = createTestOrchestrator({
+            dreamIntervalMs: 600000,
+            healthService  : {
+                recordTaskOutcome(taskName, status, details) {
+                    outcomes.push({taskName, status, details});
+                }
+            },
+            dreamService: {
+                processUndigestedSessions() {
+                    dreamCalls.push('dream');
+                    return Promise.resolve();
+                }
+            }
+        });
+
+        TaskStateService.taskState.summary.running = true;
+
+        orchestrator.poll();
+
+        expect(dreamCalls).toEqual([]);
+        expect(outcomes).toContainEqual({
+            taskName: DREAM_TASK_NAME,
+            status  : 'skipped',
+            details : expect.objectContaining({
+                blockingTaskName: 'summary',
+                reasonCode      : 'heavy-maintenance-backpressure'
+            })
+        });
+    });
+
+    test('defers due primary-dev-sync when another heavy maintenance task is already running (#11513 AC6 — umbrella AC2 gap fill)', () => {
+        const outcomes        = [];
+        const runTaskCalls    = [];
+        const getDueTaskCalls = [];
+
+        const orchestrator = createTestOrchestrator({
+            healthService: {
+                recordTaskOutcome(taskName, status, details) {
+                    outcomes.push({taskName, status, details});
+                }
+            },
+            primaryRepoSyncService: {
+                getDueTask() {
+                    getDueTaskCalls.push('called');
+                    return {
+                        taskName: PRIMARY_DEV_SYNC_TASK_NAME,
+                        reason  : 'periodic-primary-dev-sync:test'
+                    };
+                },
+                runTask(...args) {
+                    runTaskCalls.push(args);
+                }
+            }
+        });
+
+        TaskStateService.taskState.summary.running = true;
+
+        orchestrator.poll();
+
+        expect(getDueTaskCalls.length).toBeGreaterThan(0);
+        expect(runTaskCalls).toEqual([]);
+        expect(outcomes).toContainEqual({
+            taskName: PRIMARY_DEV_SYNC_TASK_NAME,
+            status  : 'skipped',
+            details : expect.objectContaining({
+                blockingTaskName: 'summary',
+                reasonCode      : 'heavy-maintenance-backpressure'
+            })
+        });
     });
 
 });


### PR DESCRIPTION
Resolves #11513
Related: #11503 (umbrella — do NOT auto-close; this is Lane A of 3+ remaining lanes)

Authored by Claude Opus 4.7 (Claude Code). Session f662d055-a35b-446a-83ff-5fc859604722.

FAIR-band: in-band [12/30] — prio-0 continuation of #11503 umbrella per operator elevation 2026-05-16T22:55Z; completes the heavy-maintenance mutex at the scheduler layer (Lane C closed the manual-CLI surface; Lane A closes the daemon-scheduler set + cross-poll proof).

Lane A closes the AC1 + AC2 gap of #11503: `backup` was defined in `TaskDefinitions.mjs` and tracked in `TaskStateService` but was NOT in `DEFAULT_HEAVY_MAINTENANCE_TASK_NAMES`, AND only summary↔kbSync had cross-poll deferral coverage. This PR closes both gaps and surfaced (and fixed) a hidden asymmetry in the orchestrator's backup scheduling — see §Substantive find.

Evidence: L2 (17/17 Orchestrator.spec.mjs tests pass in 986ms — 12 baseline unchanged + 5 new covering AC2 constant-pin, AC3 backup-deferred + backup-as-blocker, AC4 dream-deferred, AC6 primary-dev-sync-deferred). No L4 residuals — heavy-maintenance backpressure is fully observable through `recordTaskOutcome` + `writeLog`, both already verified by spec assertions on outcome shape + reasonCode. Underlying lease primitive verified by PR #11506's `HeavyMaintenanceLeaseService.spec.mjs` (8/8) is unchanged; this PR is orthogonal at the scheduler layer.

## Deltas from ticket

- **Substantive find during implementation:** the per-class deferral test for backup (AC3) initially failed despite `backup` being added to `DEFAULT_HEAVY_MAINTENANCE_TASK_NAMES`. Trace showed `Orchestrator.poll()` line 694 wired `backup`'s scheduling with raw `executeTask` instead of `executeMaintenanceTask(executeTask)` — meaning backup as a heavy-set member acted as a valid **blocker** (via `findActiveHeavyMaintenanceTask`) but did NOT actually defer as a **candidate** (the executor wrapper was missing). Sibling tasks all route through `executeMaintenanceTask`; backup was the outlier. Fixed with one more line + JSDoc-anchored rationale. This is exactly the regression-pin value the umbrella AC2 calls out — without per-class deferral tests, the asymmetry would have shipped silently.
- Tests cover 4 of the 5 heavy classes for cross-poll deferral (summary already covered at line 184 since #11487; new tests add backup × 2 (deferred + blocker), dream, primary-dev-sync). The umbrella's AC2 named dream + golden-path specifically — golden-path was reclassified as light per #11511 / PR #11512, so its omission here is intentional and asserted defensively in the constant-pin test.

## Test Evidence

- `npm run test-unit -- test/playwright/unit/ai/daemons/Orchestrator.spec.mjs` → **17/17 passed in 986ms**
  - 12 baseline tests unchanged
  - +1 AC2: `DEFAULT_HEAVY_MAINTENANCE_TASK_NAMES` constant-contents pin (exact membership + frozen invariant + defensive golden-path-OUT assertion)
  - +1 AC3: `backup` deferred by active `summary` (the test that surfaced the executor-wrapper asymmetry)
  - +1 AC3 symmetric: running `backup` defers due `kbSync` (proves backup is now a valid blocker)
  - +1 AC4: `dream` deferred by active `summary` (umbrella AC2 gap fill)
  - +1 AC6: `primary-dev-sync` deferred by active `summary` (umbrella AC2 gap fill)
- `git diff --check origin/dev...HEAD` → clean (no trailing whitespace)
- Branched from `origin/dev` at `a5c638069` (Lane C merge); single commit on this branch

## Post-Merge Validation

- [ ] **L4 operator verification:** trigger a long-running heavy task (e.g., orchestrator-owned `summary` or `dream`) and observe that the next-poll backup gets deferred with `recordTaskOutcome(taskName='backup', status='skipped', details.reasonCode='heavy-maintenance-backpressure')` AND a `Deferring backup` INFO log
- [ ] **Symmetric collision test:** trigger backup, then immediately schedule a `kbSync` — confirm kbSync defers behind backup (proves the heavy-blocker direction works at runtime, not just spec-level)

## Authority anchors

- **Parent umbrella:** #11503 (Enforce heavy-maintenance mutex across Agent OS tasks)
- **Sibling lane (closed):** #11505 / PR #11506 — Lane B lease primitive
- **Sibling lane (closed):** #11507 / PR #11509 — Lane C manual-CLI script adoption
- **Sibling offshoot (closed):** #11511 / PR #11512 — Golden Path light-maintenance classification (the rationale for golden-path's intentional OUT-of-set status, asserted defensively here)
- **Coordination anchor:** @neo-gpt A2A `MESSAGE:3c42e809-d1e9-43ca-a10c-9bdc9a08eb7d` (2026-05-17T01:14:56Z): *"No objection to you taking Lane A. It is localized enough and does not collide with my current #11475 review lane."*
- **Lane-claim broadcast:** `MESSAGE:19ef74ff-430c-4604-8de5-1ea91e0417b2` (2026-05-17T01:19:44Z) to `AGENT:*`
- **Empirical anchor:** 2026-05-16T19:27Z wedge cascade (orchestrator kbSync stuck under Chroma contention) — the failure class this umbrella's three remaining lanes (A, D, E) progressively close. Lane C closed the manual-CLI side; Lane A closes the daemon-scheduler side. Backup overlapping with summary/dream/kbSync would re-create the same contention pattern; this PR closes that re-entry path.

## Out of scope

- **Lane D** (`PrimaryRepoSyncService.runKbSync()` nested-cascade observability) — follows as separate small lane after V-B-A trace
- **Lane E** (observability / stale-lease health surfaces) — separate ticket
- **HeavyMaintenanceLeaseService consumer-side JSDoc** (cycle-1+cycle-2 friction→gold from PR #11509) — separate small follow-up ticket per @neo-gpt routing recommendation (`MESSAGE:3c42e809`)