### PR TITLE
fix(devindex): repair database-id login resolver (#11516)

### DIFF
--- a/apps/devindex/services/GitHub.mjs
+++ b/apps/devindex/services/GitHub.mjs
@@ -328,26 +328,21 @@ class GitHub extends Base {
      *
      * This method is critical for handling username changes (renames). When a stored login returns 404,
      * this method allows us to look up the new login associated with the immutable Database ID, preventing data loss.
+     * Uses GitHub's REST account lookup (`/user/{account_id}`), since GraphQL's `user` field only accepts `login`.
      *
      * @param {Number} dbId The integer user ID.
      * @returns {Promise<String|null>} The current login, or null if the ID is invalid/deleted.
      */
     async getLoginByDatabaseId(dbId) {
-        const query = `
-            query { 
-                user(databaseId: ${dbId}) {
-                    login
-                } 
-            }`;
-
         try {
-            const data = await this.query(query, {}, 1, `DB_ID:${dbId}`);
-            if (data?.user?.login) {
-                return data.user.login;
-            }
-            return null;
+            const data = await this.rest(`user/${dbId}`, `DB_ID:${dbId}`);
+            return data?.login || null;
         } catch (error) {
-            if (error.message.includes('NOT_FOUND') || error.message.includes('Could not resolve')) {
+            if (
+                error.message.includes('404') ||
+                error.message.includes('NOT_FOUND') ||
+                error.message.includes('Could not resolve')
+            ) {
                 return null;
             }
             throw error;

--- a/test/playwright/unit/app/devindex/GitHubService.spec.mjs
+++ b/test/playwright/unit/app/devindex/GitHubService.spec.mjs
@@ -1,0 +1,64 @@
+import {setup} from '../../../setup.mjs';
+
+const appName = 'DevIndexGitHubServiceTest';
+
+setup({
+    appConfig: {
+        name: appName
+    }
+});
+
+import {test, expect} from '@playwright/test';
+import Neo            from '../../../../../src/Neo.mjs';
+import * as core      from '../../../../../src/core/_export.mjs';
+import GitHub         from '../../../../../apps/devindex/services/GitHub.mjs';
+
+test.describe('DevIndex GitHub service', () => {
+    let originalRest;
+
+    test.beforeEach(() => {
+        originalRest = GitHub.rest;
+    });
+
+    test.afterEach(() => {
+        GitHub.rest = originalRest;
+    });
+
+    test('getLoginByDatabaseId resolves the current login via REST account id lookup', async () => {
+        let requestedEndpoint;
+        let requestedContext;
+
+        GitHub.rest = async (endpoint, logContext) => {
+            requestedEndpoint = endpoint;
+            requestedContext  = logContext;
+
+            return {
+                id   : 95193764,
+                login: 'alleneubank',
+                type : 'User'
+            };
+        };
+
+        const login = await GitHub.getLoginByDatabaseId(95193764);
+
+        expect(login).toBe('alleneubank');
+        expect(requestedEndpoint).toBe('user/95193764');
+        expect(requestedContext).toBe('DB_ID:95193764');
+    });
+
+    test('getLoginByDatabaseId returns null when GitHub cannot resolve the account id', async () => {
+        GitHub.rest = async () => {
+            throw new Error('REST Error: 404 Not Found');
+        };
+
+        await expect(GitHub.getLoginByDatabaseId(123)).resolves.toBeNull();
+    });
+
+    test('getLoginByDatabaseId rethrows transient REST failures', async () => {
+        GitHub.rest = async () => {
+            throw new Error('REST Error: 502 Bad Gateway');
+        };
+
+        await expect(GitHub.getLoginByDatabaseId(123)).rejects.toThrow('REST Error: 502 Bad Gateway');
+    });
+});


### PR DESCRIPTION
Refs #11516

Authored by GPT-5 (Codex Desktop). Session c934160e-e886-455a-b41e-4bb2dd1f2732.

FAIR-band: in-band [11/30 — current author count over last 30 merged]

Repairs the DevIndex database-id resolver so username rename recovery uses GitHub REST `GET /user/{account_id}` instead of the invalid GraphQL `user(databaseId: ...)` query. This is the first #11516 repair slice: it fixes the resolver contract and pins 404/transient-error behavior; the broader users/tracker reconciliation and data repair work remains in #11516.

Evidence: L2 (focused Playwright unit coverage for resolver success, missing account, and transient REST failure; neighboring DevIndex unit slice passes) -> L2 required for this resolver slice. Residual: full users/tracker reconciliation and data repair remain in #11516.

## Deltas from ticket
- Implements only the resolver prerequisite slice from #11516; PR intentionally uses `Refs #11516` and does not close the ticket.
- Adds focused unit coverage under `test/playwright/unit/app/devindex/GitHubService.spec.mjs`.

## Test Evidence
- `node --check apps/devindex/services/GitHub.mjs`
- `node --check test/playwright/unit/app/devindex/GitHubService.spec.mjs`
- `git diff --check`
- `git diff --cached --check`
- `npm run test-unit -- test/playwright/unit/app/devindex/GitHubService.spec.mjs` -> 3 passed
- `npm run test-unit -- test/playwright/unit/app/devindex/GitHubService.spec.mjs test/playwright/unit/app/devindex/StoreRankCalculation.spec.mjs test/playwright/unit/app/devindex/StoreFilterProfile.spec.mjs test/playwright/unit/app/devindex/GridScrollProfile.spec.mjs` -> 6 passed
- `git log origin/dev..HEAD --format=%h%x09%s%n%b` confirmed no stale close keyword in branch history for partial #11516 scope.

## Post-Merge Validation
- [ ] Run the next #11516 reconciliation slice against current DevIndex data and verify renamed accounts are matched by immutable account id before changing tracker entries.

## Commits
- `ca882739a` - `fix(devindex): repair database-id login resolver (#11516)`
