### PR TITLE
feat(ai): document withHeavyMaintenanceLease release-timing + reference-impl + spec (#11515)

### DIFF
--- a/ai/daemons/services/HeavyMaintenanceLeaseService.mjs
+++ b/ai/daemons/services/HeavyMaintenanceLeaseService.mjs
@@ -258,7 +258,8 @@ export async function releaseHeavyMaintenanceLease({
  *
  * ## ⚠️  Release-timing semantics (consumer-side correctness invariant)
  *
- * The lease is released in **this helper's `finally` block** at line ~272.
+ * The lease is released in **this helper's own `finally` block** (the one that
+ * wraps the `task` invocation below and calls `releaseHeavyMaintenanceLease`).
  * JavaScript await semantics guarantee the following ordering for the
  * `await withHeavyMaintenanceLease(...)` call site:
  *
@@ -303,15 +304,34 @@ export async function releaseHeavyMaintenanceLease({
  * Canonical consumer reference: `buildScripts/ai/runSandman.mjs` post-PR #11509
  * cycles 1 + 2 (decay inside inner `finally`).
  *
- * ## Returned shape
+ * ## Returned shape (what callers of `await withHeavyMaintenanceLease(...)` see)
  *
- * | `status`     | `acquired` | `result` field        | Meaning                                                                |
- * |--------------|------------|-----------------------|------------------------------------------------------------------------|
- * | `'completed'`| `true`     | the task's return     | Lease acquired, task ran to completion (success or graceful-return).   |
- * | `'held'`     | `false`    | absent                | Another owner holds the lease; task NOT executed.                      |
- * | `'stale'`    | (varies)   | (varies)              | See `acquireHeavyMaintenanceLease` for stale-handling semantics.       |
+ * The wrapper normalizes acquisition outcomes into ONE of these two shapes:
  *
- * Task exceptions propagate; release still fires from the `finally`.
+ * | `status`      | `acquired` | `result` field    | Meaning                                                                      |
+ * |---------------|------------|-------------------|------------------------------------------------------------------------------|
+ * | `'completed'` | `true`     | the task's return | Lease acquired (including after stale/malformed recovery); task ran to completion (success or graceful-return). |
+ * | `'held'`      | `false`    | absent            | Another active owner holds the lease; task NOT executed. `lease` carries that owner's descriptor. |
+ *
+ * Note: when `acquireHeavyMaintenanceLease` returns a non-`'acquired'` non-`'held'`
+ * acquisition descriptor (e.g., an `'unreadable'` IO-failure shape — theoretical
+ * edge case), the wrapper passes it through unchanged. Task exceptions propagate;
+ * release still fires from the wrapper's `finally`.
+ *
+ * ### Acquisition descriptor passed to `task` (separate surface)
+ *
+ * The acquisition descriptor passed into `task(acquisition)` exposes internal
+ * recovery telemetry NOT visible in the wrapper's return:
+ *
+ * | `acquisition.status`          | `previousStatus` | When it fires                                                |
+ * |-------------------------------|------------------|--------------------------------------------------------------|
+ * | `'acquired'`                  | absent           | Clean acquisition on a previously-missing lease.            |
+ * | `'acquired-after-stale'`      | `'stale'`        | Prior owner's TTL expired; replaced atomically.             |
+ * | `'acquired-after-malformed'`  | `'malformed'`    | Prior lease file was unparseable; replaced atomically.      |
+ *
+ * Inspect `acquisition.previousStatus` inside `task` if you need to log/alert
+ * on stale-recovery telemetry. From the wrapper-caller's perspective, all three
+ * cases normalize to `{status: 'completed', acquired: true, ...}`.
  *
  * @param {Function} task Async task to execute when the lease is acquired. Receives the acquisition descriptor as its single argument (`{status, acquired, lease}`).
  * @param {Object} options Lease acquisition options forwarded to `acquireHeavyMaintenanceLease` (owner, reason, metadata, leasePath, staleAfterMs, pid, token, fsModule, now).

--- a/ai/daemons/services/HeavyMaintenanceLeaseService.mjs
+++ b/ai/daemons/services/HeavyMaintenanceLeaseService.mjs
@@ -250,9 +250,77 @@ export async function releaseHeavyMaintenanceLease({
 /**
  * @summary Runs a task while holding the heavy-maintenance lease.
  *
- * @param {Function} task Async task to execute.
- * @param {Object} options Lease acquisition options.
- * @returns {Promise<Object>}
+ * Acquires the lease, runs `task` with the acquisition descriptor, then releases
+ * the lease in a `finally` block — guaranteeing release even on task failure.
+ * On `held` (lease already owned by another maintenance lane), returns the
+ * acquisition descriptor without running the task — caller decides whether to
+ * defer-exit or retry.
+ *
+ * ## ⚠️  Release-timing semantics (consumer-side correctness invariant)
+ *
+ * The lease is released in **this helper's `finally` block** at line ~272.
+ * JavaScript await semantics guarantee the following ordering for the
+ * `await withHeavyMaintenanceLease(...)` call site:
+ *
+ *   1. `task` body runs to completion (return OR throw)
+ *   2. `task`'s own `finally` blocks run (if any)
+ *   3. THIS helper's `finally` runs → `releaseHeavyMaintenanceLease` removes the lease file
+ *   4. THIS helper's returned promise settles
+ *   5. Caller's code AFTER `await withHeavyMaintenanceLease(...)` executes
+ *
+ * **Consequence:** any side effect placed in step 5 runs **OUTSIDE the lease window**.
+ * If the side effect must be substrate-protected (Chroma write, SQLite mutation,
+ * Memory Core graph edit, file lock, etc.), it MUST be inside the task — typically
+ * inside the task's own `finally` so it runs regardless of task success/failure.
+ *
+ * This release-timing trap was the empirical root cause of two cycles of changes
+ * requested on PR #11509 — see #11515 for the friction-to-gold lineage.
+ *
+ * ### ✅ Right shape — substrate mutation INSIDE the lease window
+ *
+ * ```js
+ * await withHeavyMaintenanceLease(async () => {
+ *     try {
+ *         await runHeavyWork(); // primary task
+ *     } finally {
+ *         // Runs in step 2 above — lease still held.
+ *         GraphService.decayGlobalTopology();
+ *     }
+ * }, {owner: 'sandman', reason: 'manual-cli'});
+ * ```
+ *
+ * ### ❌ Wrong shape — substrate mutation AFTER the await runs OUTSIDE the lease
+ *
+ * ```js
+ * await withHeavyMaintenanceLease(async () => {
+ *     await runHeavyWork();
+ * }, {owner: 'sandman', reason: 'manual-cli'});
+ *
+ * // BUG: lease was released in step 3 above; this graph mutation runs unprotected.
+ * GraphService.decayGlobalTopology();
+ * ```
+ *
+ * Canonical consumer reference: `buildScripts/ai/runSandman.mjs` post-PR #11509
+ * cycles 1 + 2 (decay inside inner `finally`).
+ *
+ * ## Returned shape
+ *
+ * | `status`     | `acquired` | `result` field        | Meaning                                                                |
+ * |--------------|------------|-----------------------|------------------------------------------------------------------------|
+ * | `'completed'`| `true`     | the task's return     | Lease acquired, task ran to completion (success or graceful-return).   |
+ * | `'held'`     | `false`    | absent                | Another owner holds the lease; task NOT executed.                      |
+ * | `'stale'`    | (varies)   | (varies)              | See `acquireHeavyMaintenanceLease` for stale-handling semantics.       |
+ *
+ * Task exceptions propagate; release still fires from the `finally`.
+ *
+ * @param {Function} task Async task to execute when the lease is acquired. Receives the acquisition descriptor as its single argument (`{status, acquired, lease}`).
+ * @param {Object} options Lease acquisition options forwarded to `acquireHeavyMaintenanceLease` (owner, reason, metadata, leasePath, staleAfterMs, pid, token, fsModule, now).
+ * @returns {Promise<Object>} `{status, acquired, lease, result}` on completion; `{status: 'held', acquired: false, lease}` on contention.
+ * @see acquireHeavyMaintenanceLease
+ * @see releaseHeavyMaintenanceLease
+ * @see buildScripts/ai/runSandman.mjs — canonical consumer pattern
+ * @see https://github.com/neomjs/neo/issues/11515 — release-timing JSDoc friction-to-gold
+ * @see https://github.com/neomjs/neo/pull/11509 — empirical anchor (cycles 1 + 2)
  */
 export async function withHeavyMaintenanceLease(task, options = {}) {
     const acquisition = await acquireHeavyMaintenanceLease(options);

--- a/test/playwright/unit/ai/daemons/services/HeavyMaintenanceLeaseService.spec.mjs
+++ b/test/playwright/unit/ai/daemons/services/HeavyMaintenanceLeaseService.spec.mjs
@@ -267,6 +267,85 @@ test.describe('Neo.ai.daemons.services.HeavyMaintenanceLeaseService (#11505)', (
         expect(ran).toBe(false);
     });
 
+    test('withLease release-timing invariant: task inner finally runs INSIDE the lease window (#11515)', async () => {
+        // Empirical anchor: PR #11509 cycles 1 + 2 surfaced the same root failure-mode at two
+        // different surfaces — substrate mutation placed AFTER `await withHeavyMaintenanceLease(...)`
+        // runs OUTSIDE the lease window because the helper's own `finally` (release) fires before
+        // the awaited promise settles.
+        //
+        // This test pins the structural ordering by capturing the lease-file presence at three
+        // probe points:
+        //   1. Inside the task body          (lease MUST exist)
+        //   2. Inside the task's inner finally (lease MUST still exist — release hasn't fired yet)
+        //   3. After `await withHeavyMaintenanceLease(...)` resolves (lease MUST be released)
+        //
+        // A future refactor that releases the lease before the task's inner finally runs would
+        // fail probe 2 — exactly the consumer-side correctness invariant the JSDoc documents.
+        const leasePath = createLeasePath('release-timing');
+        const now       = new Date('2026-05-16T20:00:00.000Z');
+        const order     = [];
+        let leaseDuringBody    = null;
+        let leaseDuringFinally = null;
+        let leaseAfterAwait    = null;
+
+        const completed = await withHeavyMaintenanceLease(async () => {
+            order.push('task-body');
+            leaseDuringBody = await inspectHeavyMaintenanceLease({leasePath, now});
+            try {
+                // Primary "heavy work" stand-in
+                await Promise.resolve();
+            } finally {
+                // Substrate-protected side effect (canonical inner-finally pattern from
+                // buildScripts/ai/runSandman.mjs post-PR #11509).
+                order.push('task-finally');
+                leaseDuringFinally = await inspectHeavyMaintenanceLease({leasePath, now});
+            }
+            return 'ok';
+        }, {
+            leasePath,
+            owner: 'sandman',
+            now,
+            token: 'release-timing-token'
+        });
+
+        order.push('after-await');
+        leaseAfterAwait = await inspectHeavyMaintenanceLease({leasePath, now});
+
+        // Wrapper completed correctly.
+        expect(completed).toMatchObject({
+            status  : 'completed',
+            acquired: true,
+            result  : 'ok'
+        });
+
+        // Strict execution order: body → inner finally → post-await caller code.
+        expect(order).toEqual(['task-body', 'task-finally', 'after-await']);
+
+        // Probe 1: lease present during task body.
+        expect(leaseDuringBody).toMatchObject({
+            status: 'active',
+            active: true,
+            lease : {owner: 'sandman', token: 'release-timing-token'}
+        });
+
+        // Probe 2 — THE LOAD-BEARING ASSERTION:
+        // Lease is STILL present during the task's inner finally. This is the contract the
+        // canonical inner-finally pattern relies on for substrate-protected side effects.
+        expect(leaseDuringFinally).toMatchObject({
+            status: 'active',
+            active: true,
+            lease : {owner: 'sandman', token: 'release-timing-token'}
+        });
+
+        // Probe 3: lease released by the wrapper's own finally BEFORE the await settles.
+        // Caller code post-await sees an empty lease file.
+        expect(leaseAfterAwait).toMatchObject({
+            status: 'missing',
+            active: false,
+            lease : null
+        });
+    });
+
     test('default singleton delegates to the reusable helpers', async () => {
         const leasePath = createLeasePath('service');
         const service   = Neo.create(HeavyMaintenanceLeaseService, {


### PR DESCRIPTION
Resolves #11515
Related: #11503 (umbrella context; not a Lane), #11509 (empirical anchor — cycles 1+2)

Authored by Claude Opus 4.7 (Claude Code). Session f662d055-a35b-446a-83ff-5fc859604722.

FAIR-band: in-band [11/30] — corrected per @neo-gpt cycle 1 review (`PRR_kwDODSospM8AAAABAJO13Q` flagged the initial `[3/30]` declaration was wrong; live verifier query returned `neo-opus-4-7: 11/30`). Small documentation + spec PR. Friction-to-gold follow-up from PR #11509 cycles 1 + 2 per @neo-gpt routing recommendation (MESSAGE:3c42e809: *"file a tiny follow-up after A so the backup PR does not grow a sidecar surface"*).

Evidence: L2 (9/9 HeavyMaintenanceLeaseService.spec.mjs passing in 635ms — 8 baseline + new release-timing test; verified unchanged after cycle-1 JSDoc fixes) → L2 required. No L4 residuals — the JSDoc + spec change is fully verifiable at unit-test layer. AC5 (KB re-index verification via `ask_knowledge_base`) is post-merge cosmetic.

## Cycle 1 fixes (commit `a46509a20`, per @neo-gpt review `PRR_kwDODSospM8AAAABAJO13Q`)

Three contract-text corrections, NO runtime redesign:
1. **Returned-shape table restructured** to accurately reflect wrapper-vs-acquisition surfaces. Previous version listed `'stale'` as a wrapper-return status — but the wrapper normalizes ALL acquired outcomes (acquired / acquired-after-stale / acquired-after-malformed) into `{status: 'completed', acquired: true, ...}`. New JSDoc has TWO tables: (a) wrapper return shape with 2 rows (`completed`, `held`) + pass-through note for theoretical edge cases; (b) acquisition descriptor passed to `task` with 3 rows enumerating internal recovery telemetry (`acquired` / `acquired-after-stale` / `acquired-after-malformed`) with `previousStatus` field semantics.
2. **Removed fragile `line ~272` self-reference** from JSDoc — replaced with stable relative pointer ("this helper's own `finally` block — the one that wraps the `task` invocation below and calls `releaseHeavyMaintenanceLease`").
3. **FAIR-band declaration corrected** from `[3/30]` to `[11/30]` per live verifier query.

## What shipped

This PR closes the consumer-guidance gap that bit PR #11509 across two review cycles — both fixed the SAME root mental-model mistake (substrate mutation runs after the await, which is OUTSIDE the lease window because the helper's own `finally` released the lease BEFORE the awaited promise settled).

### Edit 1: `HeavyMaintenanceLeaseService.mjs` JSDoc augmentation

Replaced the 6-line JSDoc above `withHeavyMaintenanceLease` (line 257) with substantive consumer guidance:

- **Release-timing semantics callout** explicitly tracing the 5-step await ordering (task body → task's inner finally → wrapper's release → returned promise settles → caller's post-await code)
- **✅ Right shape** runnable code example showing the inner-finally pattern (matches canonical `buildScripts/ai/runSandman.mjs` post-PR #11509 cycles 1+2)
- **❌ Wrong shape** runnable code example showing the post-await mutation that caused the cycle-2 bug
- **Returned shape table** documenting `completed` / `held` / `stale` statuses + the `result` field semantics
- Cross-references to `runSandman.mjs` (canonical consumer), PR #11509 (empirical anchor), this ticket #11515

No code-semantics changes. JSDoc rewrite is additive substrate-quality work.

### Edit 2: `HeavyMaintenanceLeaseService.spec.mjs` release-timing test

New test `withLease release-timing invariant: task inner finally runs INSIDE the lease window (#11515)`. Captures lease-file presence via `inspectHeavyMaintenanceLease` at three probe points:

| Probe | Where | Expected | Why |
|---|---|---|---|
| 1 | Inside task body | `status: 'active'` | Lease was acquired |
| 2 | **Inside task's inner finally** | `status: 'active'` | **Load-bearing assertion** — release hasn't fired yet, canonical inner-finally pattern depends on this |
| 3 | After `await withHeavyMaintenanceLease(...)` returns | `status: 'missing'` | Wrapper's own finally released the lease before returning |

Plus a strict-order assertion via call-order array (`['task-body', 'task-finally', 'after-await']`) that proves the temporal sequence.

A future refactor that releases the lease BEFORE the task's inner finally runs would fail probe 2 — exactly the structural contract the JSDoc now documents.

## Test Evidence

```
npm run test-unit -- test/playwright/unit/ai/daemons/services/HeavyMaintenanceLeaseService.spec.mjs
9 passed (627ms)
```

8 baseline tests unchanged + 1 new release-timing test = 9/9.

`git diff --check origin/dev...HEAD` → clean.

## Post-Merge Validation

- [ ] **AC5**: `ask_knowledge_base(query='how do I correctly use withHeavyMaintenanceLease for graph mutation')` returns a synthesized answer that includes the inner-finally pattern (verifies the JSDoc augmentation flowed into KB synthesis; needs KB re-index post-merge)

## Authority Anchors

- **Source friction**: PR #11509 cycles 1 + 2 — review IDs `PRR_kwDODSospM8AAAABAJIdTg` (cycle 1: fail-closed fall-through) + `PRR_kwDODSospM8AAAABAJKF8w` (cycle 2: post-await release-timing). Both shipped initially; both required follow-up commits. Two cycles of swarm attention on the SAME root cause = friction → gold candidate per AGENTS.md §13.2.
- **Routing authority**: @neo-gpt MESSAGE:3c42e809-d1e9-43ca-a10c-9bdc9a08eb7d (2026-05-17T01:14:56Z) — *"file a tiny follow-up after A so the backup PR does not grow a sidecar surface"*
- **Lane-claim**: MESSAGE:a1adf7d9-051e-42bc-9963-b8d08517f693 (2026-05-17T01:39:59Z) to AGENT:* — non-colliding with Claude PR #11514 Lane A / GPT #10117/#11516 DevIndex / Gemini #11475 memory-core lanes
- **Canonical consumer reference**: `buildScripts/ai/runSandman.mjs` lines 176-258 (post-PR #11509 cycles 1+2)
- **Substrate primitive**: PR #11506 / #11505 (HeavyMaintenanceLeaseService primitive itself; unchanged by this PR)

## Out of Scope

- **Re-entrancy / owner-inheritance semantics** (child process of an owner-X task inheriting the parent's lease) — deeper architectural change with own tradeoffs; not addressed here
- **Static analysis / lint for the wrong-shape pattern** — speculative for v1; JSDoc + reference-impl + spec is sufficient signal
- **Cross-daemon-coverage gap** (orchestrator-spawned heavy tasks don't acquire shared lease) — flagged in my #11503 comment `IC_kwDODSospM8AAAABClwhYQ`; routing TBD by @neo-gpt as lead

## Avoided Traps

- **JSDoc only without spec assertion**: rejected — JSDoc rots silently when behavior changes; spec is the load-bearing contract verifier
- **Documentation in `learn/` instead of JSDoc**: rejected — consumers reading `HeavyMaintenanceLeaseService.mjs` won't see it. The JSDoc lives at the consumption point.
- **Adding to AGENTS.md / atlas**: rejected per substrate-accretion defense — consumer-side guidance for a specific primitive belongs at the primitive's surface, not always-loaded substrate
- **Refactoring `withHeavyMaintenanceLease` to return-before-release**: rejected — would break the release-on-task-completion guarantee; not the right substrate change. Documentation IS the right fix because the release-in-finally contract is correct; consumer mental model is what needs the calibration aid.
