### PR TITLE
feat(ai): annotate runKbSync cascade as kbSync lifecycle (#11520)

### DIFF
--- a/ai/daemons/services/PrimaryRepoSyncService.mjs
+++ b/ai/daemons/services/PrimaryRepoSyncService.mjs
@@ -201,7 +201,7 @@ class PrimaryRepoSyncService extends Base {
         taskStateService.markStarted(taskName, reason);
 
         try {
-            const result = this.syncPrimaryDev({cwd, execFileSyncFn, writeLog, devSyncRootsConfig, devSyncRootsSource});
+            const result = this.syncPrimaryDev({cwd, execFileSyncFn, writeLog, devSyncRootsConfig, devSyncRootsSource, taskStateService, healthService});
             const status = result.status === 'completed' ? 'completed' : result.status === 'failed' ? 'failed' : 'skipped';
 
             if (status === 'completed') {
@@ -239,7 +239,9 @@ class PrimaryRepoSyncService extends Base {
         execFileSyncFn,
         writeLog,
         devSyncRootsConfig = process.env[DEV_SYNC_ROOTS_ENV_VAR],
-        devSyncRootsSource = DEV_SYNC_ROOTS_ENV_VAR
+        devSyncRootsSource = DEV_SYNC_ROOTS_ENV_VAR,
+        taskStateService,
+        healthService
     }) {
         const rootsConfig = parseDevSyncRoots(devSyncRootsConfig, devSyncRootsSource);
 
@@ -258,11 +260,13 @@ class PrimaryRepoSyncService extends Base {
                 primaryRoot,
                 roots: rootsConfig.roots,
                 execFileSyncFn,
-                writeLog
+                writeLog,
+                taskStateService,
+                healthService
             });
         }
 
-        return this.syncDevRoot({root: primaryRoot, rootKey: 'primaryRoot', execFileSyncFn, writeLog});
+        return this.syncDevRoot({root: primaryRoot, rootKey: 'primaryRoot', execFileSyncFn, writeLog, taskStateService, healthService});
     }
 
     /**
@@ -307,7 +311,7 @@ class PrimaryRepoSyncService extends Base {
      * @param {Function} [options.writeLog] Optional logger.
      * @returns {Object}
      */
-    syncConfiguredDevRoots({primaryRoot, roots, execFileSyncFn, writeLog}) {
+    syncConfiguredDevRoots({primaryRoot, roots, execFileSyncFn, writeLog, taskStateService, healthService}) {
         const rootResults = roots.map(root => {
             const result = this.syncConfiguredDevRoot({root, execFileSyncFn, writeLog});
             return {status: result.status, ...result.details};
@@ -329,7 +333,7 @@ class PrimaryRepoSyncService extends Base {
         };
 
         if (completed > 0) {
-            this.runKbSync(primaryRoot, execFileSyncFn);
+            this.runKbSync(primaryRoot, execFileSyncFn, {taskStateService, healthService});
             details.kbSync = true;
         } else if (rootResults.length === 0) {
             details.reasonCode = 'no-configured-roots';
@@ -359,7 +363,7 @@ class PrimaryRepoSyncService extends Base {
      * @param {Boolean} [options.runKbSync=true] Whether this root owns the KB cascade.
      * @returns {Object}
      */
-    syncDevRoot({root, rootKey='primaryRoot', execFileSyncFn, writeLog, fetchBeforeBranch=false, runKbSync=true}) {
+    syncDevRoot({root, rootKey='primaryRoot', execFileSyncFn, writeLog, fetchBeforeBranch=false, runKbSync=true, taskStateService, healthService}) {
         const rootDetails = {[rootKey]: root};
 
         if (fetchBeforeBranch) {
@@ -389,7 +393,7 @@ class PrimaryRepoSyncService extends Base {
         const status = this.git(['status', '--porcelain'], root, execFileSyncFn);
         if (status.trim()) {
             if (this.isOnlyMetaSyncStatus(status)) {
-                return this.resolveMetaAndPull({root, rootKey, behind, execFileSyncFn, writeLog, runKbSync});
+                return this.resolveMetaAndPull({root, rootKey, behind, execFileSyncFn, writeLog, runKbSync, taskStateService, healthService});
             }
 
             return this.skip('local-divergence', {
@@ -402,7 +406,7 @@ class PrimaryRepoSyncService extends Base {
         try {
             this.git(['pull', '--ff-only', REMOTE_NAME, DEV_BRANCH], root, execFileSyncFn);
             if (runKbSync) {
-                this.runKbSync(root, execFileSyncFn);
+                this.runKbSync(root, execFileSyncFn, {taskStateService, healthService});
             }
             return {
                 status : 'completed',
@@ -411,7 +415,7 @@ class PrimaryRepoSyncService extends Base {
         } catch (e) {
             const postPullStatus = this.git(['status', '--porcelain'], root, execFileSyncFn);
             if (this.isOnlyMetaSyncStatus(postPullStatus)) {
-                return this.resolveMetaAndPull({root, rootKey, behind, execFileSyncFn, writeLog, runKbSync});
+                return this.resolveMetaAndPull({root, rootKey, behind, execFileSyncFn, writeLog, runKbSync, taskStateService, healthService});
             }
 
             return this.skip('non-FF-divergence', {
@@ -458,14 +462,14 @@ class PrimaryRepoSyncService extends Base {
      * @param {Boolean} [options.runKbSync=true] Whether this root owns the KB cascade.
      * @returns {Object}
      */
-    resolveMetaAndPull({primaryRoot, root=primaryRoot, rootKey='primaryRoot', behind, execFileSyncFn, writeLog, runKbSync=true}) {
+    resolveMetaAndPull({primaryRoot, root=primaryRoot, rootKey='primaryRoot', behind, execFileSyncFn, writeLog, runKbSync=true, taskStateService, healthService}) {
         const rootDetails = {[rootKey]: root};
 
         writeLog?.('INFO', `[PrimaryRepoSync] Resetting ${META_SYNC_PATH} before fast-forward pull.`);
         this.git(['checkout', '--', META_SYNC_PATH], root, execFileSyncFn);
         this.git(['pull', '--ff-only', REMOTE_NAME, DEV_BRANCH], root, execFileSyncFn);
         if (runKbSync) {
-            this.runKbSync(root, execFileSyncFn);
+            this.runKbSync(root, execFileSyncFn, {taskStateService, healthService});
         }
 
         return {
@@ -475,19 +479,72 @@ class PrimaryRepoSyncService extends Base {
     }
 
     /**
-     * Runs `npm run ai:sync-kb` from the primary checkout.
+     * Runs `npm run ai:sync-kb` from the primary checkout, annotating the
+     * cascade as a first-class `kbSync` task lifecycle event so the nested
+     * KB sync becomes observable in `TaskStateService` + `HealthService`
+     * surfaces (rather than being hidden inside `primary-dev-sync`).
+     *
+     * Lane D of #11503 (#11520): per umbrella AC8 the cascade was previously
+     * invisible — `TaskStateService.taskState.kbSync.running` stayed `false`
+     * during cascades, and `HealthService.recordTaskOutcome` recorded zero
+     * `kbSync` events for the cascade duration. Monitoring agents + post-
+     * incident forensics conflated cascade kbSync with the parent
+     * `primary-dev-sync` task. Annotation makes the cascade first-class.
+     *
+     * Both service injections are optional-chained for backward compatibility:
+     * callers (tests, ad-hoc tooling) that don't supply them get the prior
+     * behavior unchanged. The orchestrator-side wiring threads them through
+     * `runTask` → `syncPrimaryDev` → `syncConfiguredDevRoots` / `syncDevRoot`
+     * / `resolveMetaAndPull` → here.
+     *
+     * The annotation `reason` string carries the durable convention
+     * `cascaded-from-<parentTaskName>` so operator dashboards + Memory Core
+     * graph ingestion can filter cascade kbSync events from orchestrator-
+     * spawned kbSync events. The `details.parent` field on `recordTaskOutcome`
+     * carries the same provenance.
+     *
      * @param {String} primaryRoot Primary checkout path.
      * @param {Function} execFileSyncFn Command execution seam.
+     * @param {Object} [options]
+     * @param {Object} [options.taskStateService] Injected `TaskStateService` for state-lifecycle annotation; if absent the call is a pure shell-out with no state mutation.
+     * @param {Object} [options.healthService] Injected `HealthService` for outcome-telemetry annotation; if absent no outcomes are recorded.
+     * @param {String} [options.parentTaskName='primary-dev-sync'] Parent task name for cascade provenance.
      * @returns {void}
      */
-    runKbSync(primaryRoot, execFileSyncFn) {
+    runKbSync(primaryRoot, execFileSyncFn, {taskStateService, healthService, parentTaskName = 'primary-dev-sync'} = {}) {
         const npmBin = process.platform === 'win32' ? 'npm.cmd' : 'npm';
+        const reason = `cascaded-from-${parentTaskName}`;
 
-        execFileSyncFn(npmBin, ['run', 'ai:sync-kb'], {
-            cwd     : primaryRoot,
-            encoding: 'utf8',
-            stdio   : ['ignore', 'pipe', 'pipe']
+        taskStateService?.markStarted?.('kbSync', reason);
+        healthService?.recordTaskOutcome?.('kbSync', 'running', {
+            reason,
+            parent   : parentTaskName,
+            startedAt: new Date().toISOString()
         });
+
+        try {
+            execFileSyncFn(npmBin, ['run', 'ai:sync-kb'], {
+                cwd     : primaryRoot,
+                encoding: 'utf8',
+                stdio   : ['ignore', 'pipe', 'pipe']
+            });
+
+            taskStateService?.markCompleted?.('kbSync');
+            healthService?.recordTaskOutcome?.('kbSync', 'completed', {
+                reason,
+                parent     : parentTaskName,
+                completedAt: new Date().toISOString()
+            });
+        } catch (e) {
+            taskStateService?.markFailed?.('kbSync', e.status || 1);
+            healthService?.recordTaskOutcome?.('kbSync', 'failed', {
+                reason,
+                parent  : parentTaskName,
+                error   : e.message,
+                failedAt: new Date().toISOString()
+            });
+            throw e;
+        }
     }
 
     /**

--- a/ai/daemons/services/PrimaryRepoSyncService.mjs
+++ b/ai/daemons/services/PrimaryRepoSyncService.mjs
@@ -232,6 +232,8 @@ class PrimaryRepoSyncService extends Base {
      * @param {Function} [options.writeLog] Optional logger.
      * @param {String[]|String|undefined|null} [options.devSyncRootsConfig=process.env.NEO_ORCHESTRATOR_DEV_SYNC_ROOTS] Optional configured roots.
      * @param {String} [options.devSyncRootsSource=NEO_ORCHESTRATOR_DEV_SYNC_ROOTS] Config source label.
+     * @param {Object} [options.taskStateService] Optional `TaskStateService` forwarded to the eventual `runKbSync()` cascade so the nested KB sync is observable as a first-class `kbSync` task lifecycle event (Lane D narrow of #11503, #11520). Pass-through only; this method does not consume the service directly.
+     * @param {Object} [options.healthService] Optional `HealthService` forwarded to the eventual `runKbSync()` cascade for `recordTaskOutcome('kbSync', ..., {parent: 'primary-dev-sync', ...})` observability. Pass-through only; this method does not consume the service directly.
      * @returns {Object}
      */
     syncPrimaryDev({
@@ -309,6 +311,8 @@ class PrimaryRepoSyncService extends Base {
      * @param {String[]} options.roots Configured repo roots.
      * @param {Function} options.execFileSyncFn Command execution seam.
      * @param {Function} [options.writeLog] Optional logger.
+     * @param {Object} [options.taskStateService] Optional `TaskStateService` forwarded to the `runKbSync()` cascade for first-class `kbSync` lifecycle annotation (Lane D narrow of #11503, #11520). Direct consumer of the pass-through.
+     * @param {Object} [options.healthService] Optional `HealthService` forwarded to the `runKbSync()` cascade for `recordTaskOutcome('kbSync', ..., {parent: 'primary-dev-sync', ...})` observability. Direct consumer of the pass-through.
      * @returns {Object}
      */
     syncConfiguredDevRoots({primaryRoot, roots, execFileSyncFn, writeLog, taskStateService, healthService}) {
@@ -361,6 +365,8 @@ class PrimaryRepoSyncService extends Base {
      * @param {Function} [options.writeLog] Optional logger.
      * @param {Boolean} [options.fetchBeforeBranch=false] Fetch/verify origin/dev before branch checks.
      * @param {Boolean} [options.runKbSync=true] Whether this root owns the KB cascade.
+     * @param {Object} [options.taskStateService] Optional `TaskStateService` forwarded to `runKbSync()` for first-class `kbSync` lifecycle annotation when this root triggers the cascade (Lane D narrow of #11503, #11520). No-op when `runKbSync: false` (the singular configured-root path).
+     * @param {Object} [options.healthService] Optional `HealthService` forwarded to `runKbSync()` for cascade `recordTaskOutcome` events with `{parent: 'primary-dev-sync'}` annotation.
      * @returns {Object}
      */
     syncDevRoot({root, rootKey='primaryRoot', execFileSyncFn, writeLog, fetchBeforeBranch=false, runKbSync=true, taskStateService, healthService}) {
@@ -460,6 +466,8 @@ class PrimaryRepoSyncService extends Base {
      * @param {Function} options.execFileSyncFn Command execution seam.
      * @param {Function} [options.writeLog] Optional logger.
      * @param {Boolean} [options.runKbSync=true] Whether this root owns the KB cascade.
+     * @param {Object} [options.taskStateService] Optional `TaskStateService` forwarded to `runKbSync()` for first-class `kbSync` lifecycle annotation when this root triggers the cascade (Lane D narrow of #11503, #11520).
+     * @param {Object} [options.healthService] Optional `HealthService` forwarded to `runKbSync()` for cascade `recordTaskOutcome` events with `{parent: 'primary-dev-sync'}` annotation.
      * @returns {Object}
      */
     resolveMetaAndPull({primaryRoot, root=primaryRoot, rootKey='primaryRoot', behind, execFileSyncFn, writeLog, runKbSync=true, taskStateService, healthService}) {

--- a/test/playwright/unit/ai/daemons/services/PrimaryRepoSyncService.spec.mjs
+++ b/test/playwright/unit/ai/daemons/services/PrimaryRepoSyncService.spec.mjs
@@ -570,29 +570,70 @@ test.describe('PrimaryRepoSyncService (#11017)', () => {
     //   compatible for ad-hoc / test callers).
     // ─────────────────────────────────────────────────────────────────────────────
 
-    test('runKbSync annotates cascade as kbSync lifecycle via TaskStateService + HealthService on success (#11520 AC1+AC2+AC8)', () => {
-        const taskStateService = createTaskStateService();
-        const outcomes         = [];
-        const healthService    = {
-            recordTaskOutcome(taskName, status, details) {
-                outcomes.push({taskName, status, details});
+    test('runKbSync annotates cascade as kbSync lifecycle via TaskStateService + HealthService on success — STRICT TEMPORAL ORDERING (#11520 AC1+AC2+AC6+AC8)', () => {
+        // Per @neo-gpt PR #11521 cycle 1 review (PRR_kwDODSospM8AAAABAJRHVA): the end-state
+        // assertions on `events` and `outcomes` arrays prove WHAT happened but NOT WHEN.
+        // AC6 mandates temporal ordering: markStarted + running outcome MUST occur BEFORE
+        // execFileSyncFn begins; markCompleted + completed outcome MUST occur AFTER it
+        // returns. Without ordering assertions, a future refactor that accidentally moved
+        // the annotation calls inside/around execFileSyncFn could pass end-state tests
+        // while violating the lifecycle contract that observability tooling depends on.
+        //
+        // This test pins the contract via a call-sequence array: instrumented helpers
+        // push synchronous markers in execution order; the assertion is on the strict
+        // sequence, not just the end state.
+        const sequence = [];
+
+        const taskStateService = {
+            events: [],
+            getTaskState() { return {running: false}; },
+            markStarted(taskName, reason) {
+                this.events.push(['started', taskName, reason]);
+                sequence.push(`state-started:${taskName}:${reason}`);
+            },
+            markCompleted(taskName) {
+                this.events.push(['completed', taskName]);
+                sequence.push(`state-completed:${taskName}`);
+            },
+            markFailed(taskName, code) {
+                this.events.push(['failed', taskName, code]);
+                sequence.push(`state-failed:${taskName}:${code}`);
             }
         };
-        const execFileSyncFn = createExecStub([{
-            cmd : process.platform === 'win32' ? 'npm.cmd' : 'npm',
-            args: ['run', 'ai:sync-kb']
-        }]);
+        const outcomes = [];
+        const healthService = {
+            recordTaskOutcome(taskName, status, details) {
+                outcomes.push({taskName, status, details});
+                sequence.push(`health-${status}:${taskName}`);
+            }
+        };
+        const execFileSyncFn = (cmd, args, options) => {
+            sequence.push(`exec:${cmd}:${args.join(' ')}`);
+            return '';
+        };
 
         PrimaryRepoSyncService.runKbSync('/primary/neo', execFileSyncFn, {taskStateService, healthService});
 
-        // AC1: TaskStateService.markStarted('kbSync', 'cascaded-from-primary-dev-sync')
+        // AC6 — STRICT TEMPORAL ORDERING (the load-bearing assertion):
+        // markStarted + running outcome MUST be before exec; markCompleted + completed outcome MUST be after.
+        // Any future refactor that reorders these (e.g., moves recordTaskOutcome AFTER exec instead of before)
+        // breaks the observability lifecycle contract and fails this assertion.
+        expect(sequence).toEqual([
+            'state-started:kbSync:cascaded-from-primary-dev-sync',
+            `health-running:kbSync`,
+            `exec:${process.platform === 'win32' ? 'npm.cmd' : 'npm'}:run ai:sync-kb`,
+            'state-completed:kbSync',
+            'health-completed:kbSync'
+        ]);
+
+        // AC1: markStarted with cascaded-from-parent reason
         // AC3: markCompleted on success
         expect(taskStateService.events).toEqual([
             ['started', 'kbSync', 'cascaded-from-primary-dev-sync'],
             ['completed', 'kbSync']
         ]);
 
-        // AC2 + AC8: recordTaskOutcome with parent annotation on both running + completed
+        // AC2 + AC8: recordTaskOutcome shape with parent annotation
         expect(outcomes.length).toBe(2);
         expect(outcomes[0]).toMatchObject({
             taskName: 'kbSync',

--- a/test/playwright/unit/ai/daemons/services/PrimaryRepoSyncService.spec.mjs
+++ b/test/playwright/unit/ai/daemons/services/PrimaryRepoSyncService.spec.mjs
@@ -557,4 +557,144 @@ test.describe('PrimaryRepoSyncService (#11017)', () => {
         expect(outcomes[0].status).toBe('skipped');
         expect(outcomes[0].details.reasonCode).toBe('up-to-date');
     });
+
+    // ─────────────────────────────────────────────────────────────────────────────
+    // Lane D narrow observability of #11503 (#11520):
+    //   runKbSync cascade is annotated as a first-class `kbSync` task lifecycle
+    //   event via TaskStateService + HealthService so monitoring agents +
+    //   post-incident forensics can see cascade kbSync separately from the parent
+    //   `primary-dev-sync` task (umbrella AC8).
+    //
+    //   Optional-chained injection: when both services are absent, runKbSync is
+    //   a pure shell-out with no state mutation or outcome recording (backward-
+    //   compatible for ad-hoc / test callers).
+    // ─────────────────────────────────────────────────────────────────────────────
+
+    test('runKbSync annotates cascade as kbSync lifecycle via TaskStateService + HealthService on success (#11520 AC1+AC2+AC8)', () => {
+        const taskStateService = createTaskStateService();
+        const outcomes         = [];
+        const healthService    = {
+            recordTaskOutcome(taskName, status, details) {
+                outcomes.push({taskName, status, details});
+            }
+        };
+        const execFileSyncFn = createExecStub([{
+            cmd : process.platform === 'win32' ? 'npm.cmd' : 'npm',
+            args: ['run', 'ai:sync-kb']
+        }]);
+
+        PrimaryRepoSyncService.runKbSync('/primary/neo', execFileSyncFn, {taskStateService, healthService});
+
+        // AC1: TaskStateService.markStarted('kbSync', 'cascaded-from-primary-dev-sync')
+        // AC3: markCompleted on success
+        expect(taskStateService.events).toEqual([
+            ['started', 'kbSync', 'cascaded-from-primary-dev-sync'],
+            ['completed', 'kbSync']
+        ]);
+
+        // AC2 + AC8: recordTaskOutcome with parent annotation on both running + completed
+        expect(outcomes.length).toBe(2);
+        expect(outcomes[0]).toMatchObject({
+            taskName: 'kbSync',
+            status  : 'running',
+            details : expect.objectContaining({
+                reason: 'cascaded-from-primary-dev-sync',
+                parent: 'primary-dev-sync'
+            })
+        });
+        expect(outcomes[1]).toMatchObject({
+            taskName: 'kbSync',
+            status  : 'completed',
+            details : expect.objectContaining({
+                reason: 'cascaded-from-primary-dev-sync',
+                parent: 'primary-dev-sync'
+            })
+        });
+    });
+
+    test('runKbSync annotates cascade-failure path with markFailed + outcome + rethrow (#11520 AC3 failure)', () => {
+        const taskStateService = createTaskStateService();
+        const outcomes         = [];
+        const healthService    = {
+            recordTaskOutcome(taskName, status, details) {
+                outcomes.push({taskName, status, details});
+            }
+        };
+        const execFileSyncFn = (cmd, args, options) => {
+            const e   = new Error('npm ai:sync-kb failed: ENOENT');
+            e.status  = 127;
+            throw e;
+        };
+
+        expect(() => {
+            PrimaryRepoSyncService.runKbSync('/primary/neo', execFileSyncFn, {taskStateService, healthService});
+        }).toThrow('npm ai:sync-kb failed: ENOENT');
+
+        // AC3 failure: markStarted, then markFailed (with exit code from error.status)
+        expect(taskStateService.events).toEqual([
+            ['started', 'kbSync', 'cascaded-from-primary-dev-sync'],
+            ['failed', 'kbSync', 127]
+        ]);
+
+        // AC2 + AC8 failure: recordTaskOutcome('kbSync', 'failed', {parent, error, ...})
+        expect(outcomes.length).toBe(2);
+        expect(outcomes[0]).toMatchObject({
+            taskName: 'kbSync',
+            status  : 'running'
+        });
+        expect(outcomes[1]).toMatchObject({
+            taskName: 'kbSync',
+            status  : 'failed',
+            details : expect.objectContaining({
+                reason: 'cascaded-from-primary-dev-sync',
+                parent: 'primary-dev-sync',
+                error : 'npm ai:sync-kb failed: ENOENT'
+            })
+        });
+    });
+
+    test('runKbSync is no-op-annotated when no services injected (#11520 AC4 backward-compatibility)', () => {
+        // No taskStateService, no healthService → pure shell-out, no annotation.
+        const execFileSyncFn = createExecStub([{
+            cmd : process.platform === 'win32' ? 'npm.cmd' : 'npm',
+            args: ['run', 'ai:sync-kb']
+        }]);
+
+        // Should not throw despite the missing services (optional-chained).
+        expect(() => {
+            PrimaryRepoSyncService.runKbSync('/primary/neo', execFileSyncFn);
+        }).not.toThrow();
+
+        // Confirm shell-out actually happened (one execFileSync call recorded).
+        expect(execFileSyncFn.calls.length).toBe(1);
+        expect(execFileSyncFn.calls[0].cmd).toBe(process.platform === 'win32' ? 'npm.cmd' : 'npm');
+    });
+
+    test('runKbSync honors custom parentTaskName for cascade provenance (#11520 AC2 parent annotation contract)', () => {
+        // Defensive: if a future caller wraps runKbSync with a different parent context
+        // (e.g., hypothetical `summary` cascade), the annotation reason + parent field
+        // adapt to the parentTaskName option. Pins the convention without enumerating
+        // all future parents.
+        const taskStateService = createTaskStateService();
+        const outcomes         = [];
+        const healthService    = {
+            recordTaskOutcome(taskName, status, details) {
+                outcomes.push({taskName, status, details});
+            }
+        };
+        const execFileSyncFn = createExecStub([{
+            cmd : process.platform === 'win32' ? 'npm.cmd' : 'npm',
+            args: ['run', 'ai:sync-kb']
+        }]);
+
+        PrimaryRepoSyncService.runKbSync('/primary/neo', execFileSyncFn, {
+            taskStateService,
+            healthService,
+            parentTaskName: 'custom-parent-task'
+        });
+
+        expect(taskStateService.events[0]).toEqual(['started', 'kbSync', 'cascaded-from-custom-parent-task']);
+        expect(outcomes[0].details.parent).toBe('custom-parent-task');
+        expect(outcomes[0].details.reason).toBe('cascaded-from-custom-parent-task');
+    });
 });


### PR DESCRIPTION
Resolves #11520
Related: #11503 (umbrella context; this IS Lane D narrow, scope = AC8 observability gap)

Authored by Claude Opus 4.7 (Claude Code). Session f662d055-a35b-446a-83ff-5fc859604722.

FAIR-band: in-band [11/30] — Lane D narrow per @neo-gpt's lead-call MESSAGE:fb84293e (2026-05-17T01:39Z) explicitly routed observability-not-coverage scope. Cross-references #11519 cross-daemon coverage (self-claimed, queued post-merge); these tickets cross-reference each other but Lane D narrow does NOT depend on cross-daemon implementation landing.

Closes umbrella AC8: *"`PrimaryRepoSyncService.runKbSync()` no longer hides unguarded KB work inside the `primary-dev-sync` lane."* The cascade is now first-class in TaskStateService + HealthService surfaces with `parent: 'primary-dev-sync'` provenance annotation.

Evidence: L2 (16/16 PrimaryRepoSyncService.spec.mjs in 690ms — 12 baseline + 4 new covering AC1-AC4 + AC8 success/failure/backward-compat/custom-parent; 12/12 Orchestrator.spec.mjs unchanged) → L2 required. No L4 residuals — observability flows through TaskStateService + HealthService events; both verified at unit-test layer.

## What shipped

### Code: PrimaryRepoSyncService.runKbSync annotation
Brackets the cascade spawn with TaskStateService lifecycle + HealthService outcome events:
- `taskStateService.markStarted('kbSync', 'cascaded-from-primary-dev-sync')` before spawn
- `markCompleted` on cascade success / `markFailed(taskName, e.status||1)` on cascade failure
- `healthService.recordTaskOutcome('kbSync', 'running'|'completed'|'failed', {parent: 'primary-dev-sync', reason, ...})` at lifecycle points
- Cascade failure rethrows (preserves current caller semantics)
- Both injections optional-chained (backward-compatible for ad-hoc/test callers not supplying services)

### Plumbing: thread services through the call chain
Orchestrator already passes both services to `PrimaryRepoSyncService.runTask`. Added pass-through chain through `syncPrimaryDev` → `syncConfiguredDevRoots` / `syncDevRoot` / `resolveMetaAndPull` → `runKbSync`. The singular `syncConfiguredDevRoot` path is exempt (it passes `runKbSync: false` so the cascade never fires from that path; services threading would be dead-weight).

## Deltas from ticket

- **Threading scope**: ticket body implied a 1-method change but the actual surface required 4 chained method signatures (`syncPrimaryDev` → `syncConfiguredDevRoots`/`syncDevRoot`/`resolveMetaAndPull` → `runKbSync`). All threading is optional-chained for backward compat; no breaking changes to existing callers.
- **No taskState schema changes** as predicted: existing `recordTaskOutcome(taskName, status, details)` shape carries `{parent, reason, error?, startedAt|completedAt|failedAt}` without schema change.
- **The `parentTaskName` option** generalizes the annotation: defaults to `'primary-dev-sync'` (the realistic case) but accepts any string so future cascade contexts (e.g., a hypothetical `summary` cascade into kbSync) inherit the same annotation pattern without per-caller hardcoding.

## Test Evidence

- `npm run test-unit -- test/playwright/unit/ai/daemons/services/PrimaryRepoSyncService.spec.mjs` → **16/16 passed in 690ms**
  - 12 baseline tests unchanged
  - +1 AC1+AC2+AC8 (cascade success path: markStarted/markCompleted + 2 outcomes with parent annotation)
  - +1 AC3 failure (cascade error: markStarted/markFailed + 2 outcomes + rethrow)
  - +1 AC4 backward-compat (no services injected → pure shell-out, no annotation, no throw)
  - +1 AC2 custom-parent (annotation reason + details.parent adapt to parentTaskName option)
- `npm run test-unit -- test/playwright/unit/ai/daemons/Orchestrator.spec.mjs` → **12/12 passed in 1.2s** (will become 17/17 once PR #11514 Lane A merges; no regression in the runTask plumbing)
- `git diff --check origin/dev...HEAD` → clean

## Post-Merge Validation

- [ ] **L4 operator verification**: trigger `primary-dev-sync` cascade and confirm operator visibility — should see `kbSync` task lifecycle events in TaskStateService + `recordTaskOutcome('kbSync', ..., {parent: 'primary-dev-sync'})` in HealthService timeline (previously: cascade invisible as kbSync)
- [ ] **Cascade-failure dashboard test**: simulate `npm run ai:sync-kb` failure during cascade; confirm `kbSync` shows `failed` outcome with `parent: 'primary-dev-sync'` annotation (so post-incident forensics can distinguish cascade kbSync failure from orchestrator-spawned kbSync failure)
- [ ] **Cross-daemon prerequisite check**: when #11519 lands, verify cascade annotation interplays cleanly with the lease-inheritance env-var path (cascade child should still be observable AND inherit lease)

## Authority Anchors

- **Parent umbrella**: #11503 (AC8 explicit observability scope)
- **Sibling lane (closed)**: #11505 / PR #11506 (Lane B lease primitive)
- **Sibling lane (closed)**: #11507 / PR #11509 (Lane C manual CLI adoption — cascade COVERAGE transitively closed here)
- **Sibling lane (in flight)**: #11513 / PR #11514 (Lane A — Gemini APPROVED, awaiting @tobiu merge)
- **Sibling lane (queued)**: #11519 (cross-daemon coverage + env-var lease-inheritance; self-claimed; implementation post-merge of #11514/#11518)
- **Sibling consumer-guidance (in cycle 2)**: #11515 / PR #11518 (HeavyMaintenanceLeaseService release-timing JSDoc; cycle 1 addressed at commit `a46509a20`)
- **Lead-call authority**: @neo-gpt MESSAGE:fb84293e-325b-4f0f-bf76-473d9ad342ff — *"narrow D shape is `kbSync` TaskStateService + HealthService annotation with `{parent: 'primary-dev-sync'}` or equivalent"*
- **V-B-A trace**: #11503 comment `IC_kwDODSospM8AAAABClwhYQ` (cascade DOES route through Lane C-wrapped script; observability is the remaining gap)
- **Design dialogue**: #11503 comment `IC_kwDODSospM8AAAABCly8-w` (peer-role substrate-validation on cross-daemon ↔ Lane D split)
- **Lane-claim broadcast**: MESSAGE:31e7030b-c785-4649-b847-5eb51d2a7471 (broadcast-then-claim after 16-min open-pickup window with no peer claim)

## Out of Scope

- **Cross-daemon orchestrator-side lease adoption + env-var inheritance** — companion ticket #11519, self-claimed, queued post-merge
- **TaskStateService / HealthService schema changes** — none needed; existing `details`-object passes arbitrary `parent` field
- **Cascade-as-separate-task-class in `TaskDefinitions.mjs`** — rejected per #11520 avoided-traps (semantically IS the same kbSync class; provenance distinction is the annotation's job)
- **Synthetic `lastReason` mutation only** — rejected (observability mid-cascade requires `running: true` state for monitoring tools that poll TaskStateService)

## Avoided Traps

- **Mutating TaskStateService/HealthService schemas to add a top-level `parent` field**: rejected — existing `details`-object on `recordTaskOutcome` already carries arbitrary fields; no schema change needed
- **Spawning kbSync through orchestrator's full task pipeline instead of inline annotation**: rejected — would require routing through `ProcessSupervisorService.runTask` which would re-enter heavy-maintenance backpressure (cascade would self-defer behind its own parent `primary-dev-sync`). The cross-daemon ticket (#11519) handles that direction via env-var inheritance; THIS ticket is observability annotation only.
- **Threading services through the singular `syncConfiguredDevRoot` path**: rejected — that path passes `runKbSync: false` so the cascade never fires; threading there would be dead-weight
- **Hardcoding `parent: 'primary-dev-sync'` directly without a parameter**: rejected — the `parentTaskName` option generalizes to future cascade contexts without per-caller hardcoding