### PR TITLE
fix(devindex): protect rename recovery before replacement fetch (#11516)

### DIFF
--- a/apps/devindex/services/Updater.mjs
+++ b/apps/devindex/services/Updater.mjs
@@ -118,13 +118,12 @@ class Updater extends Base {
                          if (newLogin && newLogin.toLowerCase() !== lowerLogin) {
                              console.log(`[${login}] 🔄 RENAME DETECTED -> ${newLogin}`);
 
-                             // 1. Mark old login for removal
-                             indexUpdates.push({ login, delete: true }); // Tracker
-                             prunedLogins.push(login); // Rich Data
-
-                             // 2. Fetch data for new login immediately
+                             // Fetch the replacement before staging old-login deletion. If the
+                             // replacement fetch fails, the rich historical record must stay protected.
                              const newData = await this.fetchUserData(newLogin);
                              if (newData) {
+                                 indexUpdates.push({ login, delete: true }); // Tracker
+                                 prunedLogins.push(login); // Rich Data
                                  results.push(newData);
                                  indexUpdates.push({ login: newLogin, lastUpdate: newData.lu });
                                  // Success for new user implies we handled the 'slot' for the old user effectively

--- a/test/playwright/unit/app/devindex/UpdaterRenameRecovery.spec.mjs
+++ b/test/playwright/unit/app/devindex/UpdaterRenameRecovery.spec.mjs
@@ -1,0 +1,129 @@
+import {setup} from '../../../setup.mjs';
+
+setup({
+    appConfig: {
+        name: 'DevIndexUpdaterRenameRecoveryTest'
+    }
+});
+
+import {test, expect} from '@playwright/test';
+import Neo            from '../../../../../src/Neo.mjs';
+import * as core      from '../../../../../src/core/_export.mjs';
+import GitHub         from '../../../../../apps/devindex/services/GitHub.mjs';
+import Storage        from '../../../../../apps/devindex/services/Storage.mjs';
+import Updater        from '../../../../../apps/devindex/services/Updater.mjs';
+
+test.describe.serial('DevIndex Updater rename recovery (#11516)', () => {
+    let originalFetchUserData,
+        originalGetLoginByDatabaseId,
+        originalGetAllowlist,
+        originalGetLowestContributionThreshold,
+        originalGetUsers,
+        originalRateLimit,
+        originalUpdateFailed,
+        originalUpdateTracker,
+        originalUpdateUsers,
+        originalDeleteUsers,
+        calls;
+
+    test.beforeEach(() => {
+        originalFetchUserData                 = Updater.fetchUserData;
+        originalGetLoginByDatabaseId          = GitHub.getLoginByDatabaseId;
+        originalGetAllowlist                  = Storage.getAllowlist;
+        originalGetLowestContributionThreshold = Storage.getLowestContributionThreshold;
+        originalGetUsers                      = Storage.getUsers;
+        originalRateLimit                     = GitHub.rateLimit;
+        originalUpdateFailed                  = Storage.updateFailed;
+        originalUpdateTracker                 = Storage.updateTracker;
+        originalUpdateUsers                   = Storage.updateUsers;
+        originalDeleteUsers                   = Storage.deleteUsers;
+
+        calls = {
+            deleteUsers  : [],
+            failedUpdates: [],
+            tracker      : [],
+            users        : []
+        };
+
+        GitHub.rateLimit = {
+            core: {
+                limit    : 5000,
+                remaining: 5000
+            }
+        };
+
+        Storage.getAllowlist                  = async () => new Set();
+        Storage.getLowestContributionThreshold = async () => 0;
+        Storage.getUsers                      = async () => [{
+            l : '0xBigBoss',
+            i : 95193764,
+            lu: '2026-05-08T15:18:19.485Z',
+            tc: 17244
+        }];
+        Storage.updateFailed                  = async (logins, add) => calls.failedUpdates.push({logins, add});
+        Storage.updateTracker                 = async updates => calls.tracker.push(...updates);
+        Storage.updateUsers                   = async records => calls.users.push(...records);
+        Storage.deleteUsers                   = async logins => calls.deleteUsers.push(...logins);
+    });
+
+    test.afterEach(() => {
+        Updater.fetchUserData                 = originalFetchUserData;
+        GitHub.getLoginByDatabaseId          = originalGetLoginByDatabaseId;
+        GitHub.rateLimit                     = originalRateLimit;
+        Storage.getAllowlist                 = originalGetAllowlist;
+        Storage.getLowestContributionThreshold = originalGetLowestContributionThreshold;
+        Storage.getUsers                     = originalGetUsers;
+        Storage.updateFailed                 = originalUpdateFailed;
+        Storage.updateTracker                = originalUpdateTracker;
+        Storage.updateUsers                  = originalUpdateUsers;
+        Storage.deleteUsers                  = originalDeleteUsers;
+    });
+
+    test('keeps the old rich record protected when replacement login fetch returns no data', async () => {
+        GitHub.getLoginByDatabaseId = async () => 'alleneubank';
+
+        Updater.fetchUserData = async login => {
+            if (login === '0xBigBoss') {
+                throw new Error('NOT_FOUND');
+            }
+            return null;
+        };
+
+        await Updater.processBatch(['0xBigBoss']);
+
+        expect(calls.deleteUsers).toEqual([]);
+        expect(calls.users).toEqual([]);
+        expect(calls.tracker).toHaveLength(1);
+        expect(calls.tracker[0]).toMatchObject({login: '0xBigBoss'});
+        expect(calls.tracker[0].delete).toBe(undefined);
+        expect(calls.failedUpdates).toEqual([{logins: ['0xBigBoss'], add: true}]);
+    });
+
+    test('prunes old login only after the renamed replacement was fetched', async () => {
+        const replacement = {
+            l : 'alleneubank',
+            i : 95193764,
+            lu: '2026-05-17T02:00:00.000Z',
+            tc: 18000
+        };
+
+        GitHub.getLoginByDatabaseId = async () => 'alleneubank';
+
+        Updater.fetchUserData = async login => {
+            if (login === '0xBigBoss') {
+                throw new Error('NOT_FOUND');
+            }
+            return replacement;
+        };
+
+        await Updater.processBatch(['0xBigBoss']);
+
+        expect(calls.users).toEqual([replacement]);
+        expect(calls.deleteUsers).toEqual(['0xBigBoss']);
+        expect(calls.tracker).toEqual([
+            {login: '0xBigBoss', delete: true},
+            {login: 'alleneubank', lastUpdate: replacement.lu}
+        ]);
+        expect(calls.failedUpdates).toEqual([]);
+    });
+});


### PR DESCRIPTION
Refs #11516

Authored by GPT-5 (Codex Desktop). Session c934160e-e886-455a-b41e-4bb2dd1f2732.

FAIR-band: in-band [11/30 - current author count over last 30 merged]

This is a narrow #11516 slice. It does not duplicate PR #11517's `GitHub.getLoginByDatabaseId()` resolver repair; instead it fixes the independent Updater safety bug where rename recovery staged old-login tracker deletion and rich-record pruning before the replacement login fetch had succeeded.

The new behavior keeps the stored rich record protected when replacement fetch returns no data, and only prunes the old login after the renamed replacement profile exists. This directly covers the `0xBigBoss` / `alleneubank` class from #11516 without broad data repair or blind tracker resurrection.

Evidence: L2 (focused Playwright unit coverage + DevIndex unit cluster) -> L2 required for this rename-recovery safety slice. Residual: #11516 remains open for #11517 merge, full reconciliation/repair path, offline count audit, and parent #10117 closeout.

## Deltas from ticket
- Partial-resolution PR: uses `Refs #11516`, not `Resolves`, because the broader ticket still has remaining ACs.
- Fix is intentionally limited to `Updater.processBatch()` rename recovery staging order.
- Adds focused unit coverage instead of touching committed DevIndex data files.

## Test Evidence
- `node --check apps/devindex/services/Updater.mjs`
- `node --check test/playwright/unit/app/devindex/UpdaterRenameRecovery.spec.mjs`
- `git diff --check`
- `git diff --cached --check`
- `git diff --check origin/dev...HEAD`
- `npm run test-unit -- test/playwright/unit/app/devindex/UpdaterRenameRecovery.spec.mjs` -> 2 passed
- `npm run test-unit -- test/playwright/unit/app/devindex/UpdaterRenameRecovery.spec.mjs test/playwright/unit/app/devindex/StoreRankCalculation.spec.mjs test/playwright/unit/app/devindex/StoreFilterProfile.spec.mjs test/playwright/unit/app/devindex/GridScrollProfile.spec.mjs` -> 5 passed

## Post-Merge Validation
- [ ] Continue #11516 after PR #11517 merges: resolver fixed first, then full reconciliation/repair and data-count audit.

## Commit
- `87a56ae02` - `fix(devindex): protect rename recovery before replacement fetch (#11516)`
