### PR TITLE
fix(ai): separate mlx launch model from api label (#11524)

### DIFF
--- a/ai/config.template.mjs
+++ b/ai/config.template.mjs
@@ -72,10 +72,14 @@ const defaultConfig = {
          * MLX model artifact used to launch the orchestrator-owned inference server.
          * This is a Hugging Face repo id or local path for `mlx_lm.server --model`, not
          * the OpenAI-compatible API payload model label. Set this in gitignored
-         * `ai/config.mjs` or via `NEO_ORCHESTRATOR_MLX_MODEL`.
+         * `ai/config.mjs` or via `NEO_ORCHESTRATOR_MLX_MODEL`. Disabled by default
+         * because LM Studio / other OpenAI-compatible providers already own the normal
+         * inference endpoint; enable only when this orchestrator should supervise MLX
+         * by setting `enabled: true` or `NEO_ORCHESTRATOR_MLX_ENABLED=true`.
          * @type {Object}
          */
         mlx: {
+            enabled: false,
             model: null
         }
     },

--- a/ai/config.template.mjs
+++ b/ai/config.template.mjs
@@ -67,7 +67,17 @@ const defaultConfig = {
          * `ai/config.mjs` or via `NEO_ORCHESTRATOR_DEV_SYNC_ROOTS`.
          * @type {String[]}
          */
-        devSyncRoots: []
+        devSyncRoots: [],
+        /**
+         * MLX model artifact used to launch the orchestrator-owned inference server.
+         * This is a Hugging Face repo id or local path for `mlx_lm.server --model`, not
+         * the OpenAI-compatible API payload model label. Set this in gitignored
+         * `ai/config.mjs` or via `NEO_ORCHESTRATOR_MLX_MODEL`.
+         * @type {Object}
+         */
+        mlx: {
+            model: null
+        }
     },
     /**
      * A dummy embedding function to satisfy ChromaDB when embeddings are provided manually.

--- a/ai/daemons/Orchestrator.mjs
+++ b/ai/daemons/Orchestrator.mjs
@@ -359,8 +359,9 @@ export class Orchestrator extends Base {
         this.primaryDevSyncRootsConfig = options.primaryDevSyncRootsConfig ?? null;
         this.taskDefinitions        = options.taskDefinitions || buildTaskDefinitions({
             scriptDir,
-            nodeBin  : options.nodeBin || process.argv[0],
-            mlxModel : options.mlxModel || undefined
+            nodeBin   : options.nodeBin || process.argv[0],
+            mlxEnabled: options.mlxEnabled ?? undefined,
+            mlxModel  : options.mlxModel || undefined
         });
         this.healthService          = options.healthService          || HealthService;
         this.summarizationCoordinator = options.summarizationCoordinator || SummarizationCoordinatorService;

--- a/ai/daemons/Orchestrator.mjs
+++ b/ai/daemons/Orchestrator.mjs
@@ -359,7 +359,8 @@ export class Orchestrator extends Base {
         this.primaryDevSyncRootsConfig = options.primaryDevSyncRootsConfig ?? null;
         this.taskDefinitions        = options.taskDefinitions || buildTaskDefinitions({
             scriptDir,
-            nodeBin: options.nodeBin || process.argv[0]
+            nodeBin  : options.nodeBin || process.argv[0],
+            mlxModel : options.mlxModel || undefined
         });
         this.healthService          = options.healthService          || HealthService;
         this.summarizationCoordinator = options.summarizationCoordinator || SummarizationCoordinatorService;

--- a/ai/daemons/TaskDefinitions.mjs
+++ b/ai/daemons/TaskDefinitions.mjs
@@ -16,10 +16,28 @@ export const DEFAULT_GOLDEN_PATH_INTERVAL_MS      = 3600000;
 export const GOLDEN_PATH_TASK_NAME                = 'golden-path';
 export const DEFAULT_MLX_MODEL                    = 'mlx-community/gemma-4-31b-it-bf16';
 export const DEFAULT_MLX_PORT                     = '11435';
+export const DEFAULT_MLX_ENABLED                  = false;
 
 export const DEFAULT_DB_PATH    = process.env.NEO_AI_DB_PATH || '.neo-ai-data/sqlite/memory-core-graph.sqlite';
 export const DEFAULT_DATA_DIR   = process.env.NEO_AI_ORCHESTRATOR_DIR || '.neo-ai-data/orchestrator-daemon';
 export const DEFAULT_SCRIPT_DIR = path.resolve(__dirname, '../scripts');
+
+/**
+ * Resolves whether the orchestrator should own an mlx_lm.server child process.
+ * @param {String|Boolean|null|undefined} value Explicit value or env-var payload.
+ * @returns {Boolean}
+ */
+export function resolveMlxEnabled(value = process.env.NEO_ORCHESTRATOR_MLX_ENABLED) {
+    if (value === undefined || value === null || value === '') {
+        return DEFAULT_MLX_ENABLED;
+    }
+
+    if (typeof value === 'boolean') {
+        return value;
+    }
+
+    return String(value).toLowerCase() === 'true';
+}
 
 /**
  * @summary Builds child-process commands for orchestrator-owned maintenance tasks.
@@ -32,6 +50,7 @@ export const DEFAULT_SCRIPT_DIR = path.resolve(__dirname, '../scripts');
  * @param {Object} [options]
  * @param {String} [options.scriptDir] Script directory.
  * @param {String} [options.nodeBin] Node executable.
+ * @param {Boolean} [options.mlxEnabled] Whether to launch an orchestrator-owned mlx_lm.server.
  * @param {String} [options.mlxModel] MLX launch model: a Hugging Face repo id or local path.
  * @param {String|Number} [options.mlxPort] OpenAI-compatible local inference port.
  * @returns {Object}
@@ -39,10 +58,11 @@ export const DEFAULT_SCRIPT_DIR = path.resolve(__dirname, '../scripts');
 export function buildTaskDefinitions({
     scriptDir = DEFAULT_SCRIPT_DIR,
     nodeBin   = process.argv[0],
+    mlxEnabled = resolveMlxEnabled(),
     mlxModel  = process.env.NEO_ORCHESTRATOR_MLX_MODEL || DEFAULT_MLX_MODEL,
     mlxPort   = DEFAULT_MLX_PORT
 } = {}) {
-    return {
+    const tasks = {
         chroma: {
             label          : 'chroma daemon',
             command        : 'chroma',
@@ -56,13 +76,6 @@ export function buildTaskDefinitions({
             args           : [path.join(scriptDir, 'bridge-daemon.mjs')],
             pidFileName    : 'bridge-daemon.pid',
             expectedCommand: 'bridge-daemon.mjs'
-        },
-        mlx: {
-            label          : 'mlx inference',
-            command        : path.resolve(scriptDir, '../mcp/server/memory-core/.venv/bin/python'),
-            args           : ['-m', 'mlx_lm.server', '--model', mlxModel, '--port', String(mlxPort)],
-            pidFileName    : 'mlx.pid',
-            expectedCommand: 'mlx_lm.server'
         },
         summary: {
             label          : 'session summarization',
@@ -104,4 +117,16 @@ export function buildTaskDefinitions({
             serviceTask    : true
         }
     };
+
+    if (resolveMlxEnabled(mlxEnabled)) {
+        tasks.mlx = {
+            label          : 'mlx inference',
+            command        : path.resolve(scriptDir, '../mcp/server/memory-core/.venv/bin/python'),
+            args           : ['-m', 'mlx_lm.server', '--model', mlxModel, '--port', String(mlxPort)],
+            pidFileName    : 'mlx.pid',
+            expectedCommand: 'mlx_lm.server'
+        };
+    }
+
+    return tasks;
 }

--- a/ai/daemons/TaskDefinitions.mjs
+++ b/ai/daemons/TaskDefinitions.mjs
@@ -14,7 +14,7 @@ export const DEFAULT_DREAM_INTERVAL_MS            = 3600000;
 export const DREAM_TASK_NAME                      = 'dream';
 export const DEFAULT_GOLDEN_PATH_INTERVAL_MS      = 3600000;
 export const GOLDEN_PATH_TASK_NAME                = 'golden-path';
-export const DEFAULT_MLX_MODEL                    = 'gemma-4-31b-it';
+export const DEFAULT_MLX_MODEL                    = 'mlx-community/gemma-4-31b-it-bf16';
 export const DEFAULT_MLX_PORT                     = '11435';
 
 export const DEFAULT_DB_PATH    = process.env.NEO_AI_DB_PATH || '.neo-ai-data/sqlite/memory-core-graph.sqlite';
@@ -32,14 +32,14 @@ export const DEFAULT_SCRIPT_DIR = path.resolve(__dirname, '../scripts');
  * @param {Object} [options]
  * @param {String} [options.scriptDir] Script directory.
  * @param {String} [options.nodeBin] Node executable.
- * @param {String} [options.mlxModel] OpenAI-compatible local inference model.
+ * @param {String} [options.mlxModel] MLX launch model: a Hugging Face repo id or local path.
  * @param {String|Number} [options.mlxPort] OpenAI-compatible local inference port.
  * @returns {Object}
  */
 export function buildTaskDefinitions({
     scriptDir = DEFAULT_SCRIPT_DIR,
     nodeBin   = process.argv[0],
-    mlxModel  = process.env.NEO_OPENAI_COMPATIBLE_MODEL || DEFAULT_MLX_MODEL,
+    mlxModel  = process.env.NEO_ORCHESTRATOR_MLX_MODEL || DEFAULT_MLX_MODEL,
     mlxPort   = DEFAULT_MLX_PORT
 } = {}) {
     return {

--- a/ai/scripts/orchestrator-daemon.mjs
+++ b/ai/scripts/orchestrator-daemon.mjs
@@ -163,10 +163,15 @@ export async function startOrchestrator(options = {}) {
     setupCleanupHandlers();
     await loadLocalAiConfig();
     const orchestratorConfig = AiConfig.orchestrator || {};
+    const mlxConfig          = orchestratorConfig.mlx || {};
+    const mlxEnabled         = process.env.NEO_ORCHESTRATOR_MLX_ENABLED !== undefined
+        ? undefined
+        : mlxConfig.enabled;
     return Orchestrator.start({
         dataDir: DAEMON_DATA_DIR,
         primaryDevSyncRootsConfig: orchestratorConfig.devSyncRoots,
-        mlxModel: orchestratorConfig.mlx?.model || undefined,
+        mlxEnabled: mlxEnabled ?? undefined,
+        mlxModel  : mlxConfig.model || undefined,
         ...options
     });
 }

--- a/ai/scripts/orchestrator-daemon.mjs
+++ b/ai/scripts/orchestrator-daemon.mjs
@@ -162,9 +162,11 @@ export async function startOrchestrator(options = {}) {
     await enforceSingleton();
     setupCleanupHandlers();
     await loadLocalAiConfig();
+    const orchestratorConfig = AiConfig.orchestrator || {};
     return Orchestrator.start({
         dataDir: DAEMON_DATA_DIR,
-        primaryDevSyncRootsConfig: AiConfig.orchestrator?.devSyncRoots,
+        primaryDevSyncRootsConfig: orchestratorConfig.devSyncRoots,
+        mlxModel: orchestratorConfig.mlx?.model || undefined,
         ...options
     });
 }

--- a/test/playwright/unit/ai/daemons/Orchestrator.spec.mjs
+++ b/test/playwright/unit/ai/daemons/Orchestrator.spec.mjs
@@ -382,6 +382,30 @@ test.describe('Neo.ai.daemons.Orchestrator (#11009)', () => {
         expect(orchestrator.taskDefinitions.kbSync.args[0]).toBe(expectedKbSyncScript);
     });
 
+    test('passes local mlx launch model config into task definitions', () => {
+        const orchestrator = Neo.create(Orchestrator);
+
+        orchestrator.configure({
+            dataDir : '/tmp/orchestrator-test-mlx-model',
+            mlxModel: 'operator-configured-mlx-model'
+        });
+
+        expect(orchestrator.taskDefinitions.mlx.args).toContain('operator-configured-mlx-model');
+        expect(orchestrator.taskDefinitions.mlx.args).not.toContain('gemma-4-31b-it');
+    });
+
+    test('falls back to the dedicated mlx default when local config is null', () => {
+        const orchestrator = Neo.create(Orchestrator);
+
+        orchestrator.configure({
+            dataDir : '/tmp/orchestrator-test-mlx-null',
+            mlxModel: null
+        });
+
+        expect(orchestrator.taskDefinitions.mlx.args).toContain('mlx-community/gemma-4-31b-it-bf16');
+        expect(orchestrator.taskDefinitions.mlx.args).not.toContain(null);
+    });
+
     test('routes primary-dev-sync through its service coordinator', () => {
         const started = [];
         const orchestrator = createTestOrchestrator({

--- a/test/playwright/unit/ai/daemons/Orchestrator.spec.mjs
+++ b/test/playwright/unit/ai/daemons/Orchestrator.spec.mjs
@@ -78,7 +78,8 @@ test.describe('Neo.ai.daemons.Orchestrator (#11009)', () => {
             nodeBin  : '/node'
         }));
 
-        expect(Object.keys(state)).toEqual(['chroma', 'bridgeDaemon', 'mlx', 'summary', 'kbSync', 'backup', PRIMARY_DEV_SYNC_TASK_NAME, DREAM_TASK_NAME, GOLDEN_PATH_TASK_NAME]);
+        expect(Object.keys(state)).toEqual(['chroma', 'bridgeDaemon', 'summary', 'kbSync', 'backup', PRIMARY_DEV_SYNC_TASK_NAME, DREAM_TASK_NAME, GOLDEN_PATH_TASK_NAME]);
+        expect(state.mlx).toBeUndefined();
         expect(state.memoryCoreChroma).toBeUndefined();
         expect(state.summary).toMatchObject({
             running      : false,
@@ -380,14 +381,16 @@ test.describe('Neo.ai.daemons.Orchestrator (#11009)', () => {
         
         expect(orchestrator.taskDefinitions.summary.args[0]).toBe(expectedSummaryScript);
         expect(orchestrator.taskDefinitions.kbSync.args[0]).toBe(expectedKbSyncScript);
+        expect(orchestrator.taskDefinitions.mlx).toBeUndefined();
     });
 
     test('passes local mlx launch model config into task definitions', () => {
         const orchestrator = Neo.create(Orchestrator);
 
         orchestrator.configure({
-            dataDir : '/tmp/orchestrator-test-mlx-model',
-            mlxModel: 'operator-configured-mlx-model'
+            dataDir   : '/tmp/orchestrator-test-mlx-model',
+            mlxEnabled: true,
+            mlxModel  : 'operator-configured-mlx-model'
         });
 
         expect(orchestrator.taskDefinitions.mlx.args).toContain('operator-configured-mlx-model');
@@ -398,8 +401,9 @@ test.describe('Neo.ai.daemons.Orchestrator (#11009)', () => {
         const orchestrator = Neo.create(Orchestrator);
 
         orchestrator.configure({
-            dataDir : '/tmp/orchestrator-test-mlx-null',
-            mlxModel: null
+            dataDir   : '/tmp/orchestrator-test-mlx-null',
+            mlxEnabled: true,
+            mlxModel  : null
         });
 
         expect(orchestrator.taskDefinitions.mlx.args).toContain('mlx-community/gemma-4-31b-it-bf16');

--- a/test/playwright/unit/ai/scripts/orchestrator-daemon.spec.mjs
+++ b/test/playwright/unit/ai/scripts/orchestrator-daemon.spec.mjs
@@ -11,9 +11,11 @@ import {
     DEFAULT_SUMMARY_SWEEP_INTERVAL_MS
 } from '../../../../../ai/scripts/orchestrator-daemon.mjs';
 import {
+    DEFAULT_MLX_ENABLED,
     DEFAULT_MLX_MODEL,
     DEFAULT_MLX_PORT,
-    buildTaskDefinitions
+    buildTaskDefinitions,
+    resolveMlxEnabled
 } from '../../../../../ai/daemons/TaskDefinitions.mjs';
 
 test.describe('ai/scripts/orchestrator-daemon.mjs (#11006/#11009)', () => {
@@ -39,20 +41,27 @@ test.describe('ai/scripts/orchestrator-daemon.mjs (#11006/#11009)', () => {
         expect(tasks.backup.expectedCommand).toBe('backup.mjs');
     });
 
-    test('starts mlx inference with the dedicated Gemma 4 MLX launch default', () => {
+    test('keeps mlx inference opt-in with the dedicated Gemma 4 MLX launch default', () => {
         const scriptDir     = path.resolve(process.cwd(), 'ai/scripts');
         const originalApiModel = process.env.NEO_OPENAI_COMPATIBLE_MODEL;
         const originalMlxModel = process.env.NEO_ORCHESTRATOR_MLX_MODEL;
+        const originalMlxEnabled = process.env.NEO_ORCHESTRATOR_MLX_ENABLED;
 
         delete process.env.NEO_OPENAI_COMPATIBLE_MODEL;
         delete process.env.NEO_ORCHESTRATOR_MLX_MODEL;
+        delete process.env.NEO_ORCHESTRATOR_MLX_ENABLED;
 
         try {
             const tasks = buildTaskDefinitions({scriptDir, nodeBin: '/test/node'});
 
+            expect(DEFAULT_MLX_ENABLED).toBe(false);
             expect(DEFAULT_MLX_MODEL).toBe('mlx-community/gemma-4-31b-it-bf16');
             expect(DEFAULT_MLX_PORT).toBe('11435');
-            expect(tasks.mlx.args).toEqual([
+            expect(tasks.mlx).toBeUndefined();
+
+            const enabledTasks = buildTaskDefinitions({scriptDir, nodeBin: '/test/node', mlxEnabled: true});
+
+            expect(enabledTasks.mlx.args).toEqual([
                 '-m',
                 'mlx_lm.server',
                 '--model',
@@ -60,14 +69,19 @@ test.describe('ai/scripts/orchestrator-daemon.mjs (#11006/#11009)', () => {
                 '--port',
                 DEFAULT_MLX_PORT
             ]);
-            expect(tasks.mlx.args).not.toContain('mlx-community/gemma-2-27b-it-4bit');
-            expect(tasks.mlx.args).not.toContain('gemma-4-31b-it');
+            expect(enabledTasks.mlx.args).not.toContain('mlx-community/gemma-2-27b-it-4bit');
+            expect(enabledTasks.mlx.args).not.toContain('gemma-4-31b-it');
+            expect(resolveMlxEnabled('true')).toBe(true);
+            expect(resolveMlxEnabled('false')).toBe(false);
         } finally {
             if (originalApiModel !== undefined) {
                 process.env.NEO_OPENAI_COMPATIBLE_MODEL = originalApiModel;
             }
             if (originalMlxModel !== undefined) {
                 process.env.NEO_ORCHESTRATOR_MLX_MODEL = originalMlxModel;
+            }
+            if (originalMlxEnabled !== undefined) {
+                process.env.NEO_ORCHESTRATOR_MLX_ENABLED = originalMlxEnabled;
             }
         }
     });
@@ -76,14 +90,22 @@ test.describe('ai/scripts/orchestrator-daemon.mjs (#11006/#11009)', () => {
         const scriptDir     = path.resolve(process.cwd(), 'ai/scripts');
         const originalApiModel = process.env.NEO_OPENAI_COMPATIBLE_MODEL;
         const originalMlxModel = process.env.NEO_ORCHESTRATOR_MLX_MODEL;
+        const originalMlxEnabled = process.env.NEO_ORCHESTRATOR_MLX_ENABLED;
 
         process.env.NEO_OPENAI_COMPATIBLE_MODEL = 'api-label-only';
         delete process.env.NEO_ORCHESTRATOR_MLX_MODEL;
+        delete process.env.NEO_ORCHESTRATOR_MLX_ENABLED;
 
         try {
             const apiEnvTasks = buildTaskDefinitions({scriptDir, nodeBin: '/test/node'});
 
-            expect(apiEnvTasks.mlx.args).toEqual([
+            expect(apiEnvTasks.mlx).toBeUndefined();
+
+            process.env.NEO_ORCHESTRATOR_MLX_ENABLED = 'true';
+
+            const enabledDefaultTasks = buildTaskDefinitions({scriptDir, nodeBin: '/test/node'});
+
+            expect(enabledDefaultTasks.mlx.args).toEqual([
                 '-m',
                 'mlx_lm.server',
                 '--model',
@@ -115,13 +137,19 @@ test.describe('ai/scripts/orchestrator-daemon.mjs (#11006/#11009)', () => {
             } else {
                 process.env.NEO_ORCHESTRATOR_MLX_MODEL = originalMlxModel;
             }
+            if (originalMlxEnabled === undefined) {
+                delete process.env.NEO_ORCHESTRATOR_MLX_ENABLED;
+            } else {
+                process.env.NEO_ORCHESTRATOR_MLX_ENABLED = originalMlxEnabled;
+            }
         }
 
         const explicitTasks = buildTaskDefinitions({
             scriptDir,
-            nodeBin  : '/test/node',
-            mlxModel : 'explicit-model',
-            mlxPort  : 12345
+            nodeBin   : '/test/node',
+            mlxEnabled: true,
+            mlxModel  : 'explicit-model',
+            mlxPort   : 12345
         });
 
         expect(explicitTasks.mlx.args).toEqual([

--- a/test/playwright/unit/ai/scripts/orchestrator-daemon.spec.mjs
+++ b/test/playwright/unit/ai/scripts/orchestrator-daemon.spec.mjs
@@ -39,16 +39,18 @@ test.describe('ai/scripts/orchestrator-daemon.mjs (#11006/#11009)', () => {
         expect(tasks.backup.expectedCommand).toBe('backup.mjs');
     });
 
-    test('starts mlx inference with the OpenAI-compatible Gemma 4 default', () => {
+    test('starts mlx inference with the dedicated Gemma 4 MLX launch default', () => {
         const scriptDir     = path.resolve(process.cwd(), 'ai/scripts');
-        const originalModel = process.env.NEO_OPENAI_COMPATIBLE_MODEL;
+        const originalApiModel = process.env.NEO_OPENAI_COMPATIBLE_MODEL;
+        const originalMlxModel = process.env.NEO_ORCHESTRATOR_MLX_MODEL;
 
         delete process.env.NEO_OPENAI_COMPATIBLE_MODEL;
+        delete process.env.NEO_ORCHESTRATOR_MLX_MODEL;
 
         try {
             const tasks = buildTaskDefinitions({scriptDir, nodeBin: '/test/node'});
 
-            expect(DEFAULT_MLX_MODEL).toBe('gemma-4-31b-it');
+            expect(DEFAULT_MLX_MODEL).toBe('mlx-community/gemma-4-31b-it-bf16');
             expect(DEFAULT_MLX_PORT).toBe('11435');
             expect(tasks.mlx.args).toEqual([
                 '-m',
@@ -59,35 +61,59 @@ test.describe('ai/scripts/orchestrator-daemon.mjs (#11006/#11009)', () => {
                 DEFAULT_MLX_PORT
             ]);
             expect(tasks.mlx.args).not.toContain('mlx-community/gemma-2-27b-it-4bit');
+            expect(tasks.mlx.args).not.toContain('gemma-4-31b-it');
         } finally {
-            if (originalModel !== undefined) {
-                process.env.NEO_OPENAI_COMPATIBLE_MODEL = originalModel;
+            if (originalApiModel !== undefined) {
+                process.env.NEO_OPENAI_COMPATIBLE_MODEL = originalApiModel;
+            }
+            if (originalMlxModel !== undefined) {
+                process.env.NEO_ORCHESTRATOR_MLX_MODEL = originalMlxModel;
             }
         }
     });
 
-    test('allows local mlx model overrides without changing task ownership', () => {
+    test('separates OpenAI-compatible API labels from local mlx launch model overrides', () => {
         const scriptDir     = path.resolve(process.cwd(), 'ai/scripts');
-        const originalModel = process.env.NEO_OPENAI_COMPATIBLE_MODEL;
+        const originalApiModel = process.env.NEO_OPENAI_COMPATIBLE_MODEL;
+        const originalMlxModel = process.env.NEO_ORCHESTRATOR_MLX_MODEL;
 
-        process.env.NEO_OPENAI_COMPATIBLE_MODEL = 'local-openai-compatible-model';
+        process.env.NEO_OPENAI_COMPATIBLE_MODEL = 'api-label-only';
+        delete process.env.NEO_ORCHESTRATOR_MLX_MODEL;
 
         try {
-            const envTasks = buildTaskDefinitions({scriptDir, nodeBin: '/test/node'});
+            const apiEnvTasks = buildTaskDefinitions({scriptDir, nodeBin: '/test/node'});
 
-            expect(envTasks.mlx.args).toEqual([
+            expect(apiEnvTasks.mlx.args).toEqual([
                 '-m',
                 'mlx_lm.server',
                 '--model',
-                'local-openai-compatible-model',
+                DEFAULT_MLX_MODEL,
+                '--port',
+                DEFAULT_MLX_PORT
+            ]);
+
+            process.env.NEO_ORCHESTRATOR_MLX_MODEL = 'local-mlx-launch-model';
+
+            const mlxEnvTasks = buildTaskDefinitions({scriptDir, nodeBin: '/test/node'});
+
+            expect(mlxEnvTasks.mlx.args).toEqual([
+                '-m',
+                'mlx_lm.server',
+                '--model',
+                'local-mlx-launch-model',
                 '--port',
                 DEFAULT_MLX_PORT
             ]);
         } finally {
-            if (originalModel === undefined) {
+            if (originalApiModel === undefined) {
                 delete process.env.NEO_OPENAI_COMPATIBLE_MODEL;
             } else {
-                process.env.NEO_OPENAI_COMPATIBLE_MODEL = originalModel;
+                process.env.NEO_OPENAI_COMPATIBLE_MODEL = originalApiModel;
+            }
+            if (originalMlxModel === undefined) {
+                delete process.env.NEO_ORCHESTRATOR_MLX_MODEL;
+            } else {
+                process.env.NEO_ORCHESTRATOR_MLX_MODEL = originalMlxModel;
             }
         }
 


### PR DESCRIPTION
Authored by GPT-5.5 (Codex Desktop). Session 6e5b995a-c68e-4179-840c-a4cc48d449da.

FAIR-band: over-target [12/30] — taking this lane despite over-target because the operator surfaced an active orchestrator boot regression, the lane was already claimed before parallel work began, and @neo-opus-4-7 explicitly yielded #11524 for this PR rather than duplicating the fix.

Resolves #11524

Separates the MLX launch artifact from the OpenAI-compatible API payload model label and makes orchestrator-owned MLX supervision opt-in. The normal OpenAI-compatible provider path remains free to use LM Studio's `gemma-4-31b-it` payload label, while operators who want the orchestrator to launch `mlx_lm.server` can enable it with `orchestrator.mlx.enabled` / `NEO_ORCHESTRATOR_MLX_ENABLED=true` and a Gemma 4 MLX repo id such as `mlx-community/gemma-4-31b-it-bf16`.

Evidence: L2 (task-definition + orchestrator unit coverage, static diff check, live Hugging Face model-card verification) -> L4 required (operator restart confirms host orchestrator no longer starts the unused MLX lane by default; optional MLX path still launches when enabled). Residual: post-merge validation [#11524].

## Deltas from ticket
- Kept the default on Gemma 4 31B. No Gemma 2 fallback was introduced.
- Used Option C after peer/operator empirical context: LM Studio and `mlx_lm.server` are separate engines, and the active host stack uses LM Studio on `:1234`, not orchestrator-owned MLX on `:11435`.
- Kept the MLX-community BF16 repo id as the opt-in launch default because the current Hugging Face model card documents `mlx_lm.server --model "mlx-community/gemma-4-31b-it-bf16"` and the Google upstream model card confirms `google/gemma-4-31B-it`.
- Added local config hooks under `AiConfig.orchestrator.mlx.enabled` and `AiConfig.orchestrator.mlx.model`, distinct from the existing OpenAI-compatible provider label surface.
- Memory-mining note: queried prior Memory Core summaries for this exact LM Studio vs orchestrator-owned MLX architecture split; no prior mapped decision surfaced, so this PR follows current code reality plus the live operator/peer V-B-A relay.

## Test Evidence
- `npm run test-unit -- test/playwright/unit/ai/scripts/orchestrator-daemon.spec.mjs` - 5 passed.
- `npm run test-unit -- test/playwright/unit/ai/daemons/Orchestrator.spec.mjs` - 19 passed.
- `git diff --check origin/dev...HEAD` - passed.
- `gh search prs --merged --repo neomjs/neo --limit 30 --sort updated --json author --jq '.[].author.login'` - FAIR-band count verified as `neo-gpt=12`, `neo-opus-4-7=12`, `neo-gemini-3-1-pro=6`.
- Verified model-card sources:
  - https://huggingface.co/mlx-community/gemma-4-31b-it-bf16
  - https://huggingface.co/google/gemma-4-31B-it

## Post-Merge Validation
- [ ] Restart `npm run ai:orchestrator` in the primary host checkout with default config and confirm the supervisor no longer starts the `mlx inference` lane.
- [ ] With `NEO_ORCHESTRATOR_MLX_ENABLED=true`, confirm the optional MLX lane uses the Gemma 4 MLX repo id instead of bare `gemma-4-31b-it`.
- [ ] If the opt-in MLX path still returns 401, treat it as a real credential/license signal and validate with `HF_TOKEN`, not as repo-id drift.

## Evolution
PR #11473 merged with its post-merge restart checkbox still unchecked. That is the empirical MX signal for this regression: the previous PR removed the stale Gemma 2 launch artifact but collapsed the MLX launch repo id and API payload label into one string, so host restart validation was the only surface that would have caught the 401 against bare `gemma-4-31b-it`. The follow-up peer relay clarified a deeper issue: LM Studio's GGUF engine and `mlx_lm.server` are not interchangeable. Making MLX opt-in avoids turning a host boot path into a first-time large model download for an unused second inference server.

## Commits
- `5b9774712` - `fix(ai): separate mlx launch model from api label (#11524)`
- `53b5caa5d` - `fix(ai): make orchestrator mlx supervision opt-in (#11524)`
