### PR TITLE
chore: cleanup Memory Core 8001 substrate residuals post-ADR 0003 (#11500)

### DIFF
--- a/.agents/skills/debugging-antigravity/references/debugging-guide.md
+++ b/.agents/skills/debugging-antigravity/references/debugging-guide.md
@@ -24,7 +24,7 @@ Since the April 7th release, the IDE's local workspace `.gemini/settings.json` n
 ### The Problem
 If the Antigravity IDE spawns MCP processes (via the language server) and those servers are hardcoded to `autoStartDatabase = true` (Opt-Out), the MCP processes will attempt to boot standalone local ChromaDB/SQLite binaries.
 This creates immediate deadlocks when:
-- The user is already manually running ChromaDB on ports 8000/8001 via external terminal scripts.
+- The user is already manually running ChromaDB on port 8000 via external terminal scripts.
 - Both language servers duplicate the boot routine, competing for the same filesystem lock.
 
 ### The Fix

--- a/.agents/skills/self-repair/references/self-repair-protocol.md
+++ b/.agents/skills/self-repair/references/self-repair-protocol.md
@@ -7,8 +7,7 @@ Your first priority is determining if the bridge between the Neo.mjs Agent OS cl
 
 1. **Invoke the `unit-test` skill**: Navigate to `test/playwright/unit/ai/` and execute target test suites like `McpServersHealth.spec.mjs`. Use these tests as the absolute source of truth for JSON-RPC sequence validity.
 2. **Verify Daemon & Database Status**: If `memory-core`, `knowledge-base`, or the Neural Link bridge are offline, check your `package.json` scripts. Verify that ChromaDB is running without zombie processes.
-    - **Knowledge Base** runs on port `8000` (script: `npm run ai:server`)
-    - **Memory Core** runs on port `8001` (script: `npm run ai:server-memory`)
+    - **Knowledge Base & Memory Core** share a unified ChromaDB on port `8000` (script: `npm run ai:server`)
     - **Neural Link Bridge** ensures realtime VDOM sync (script: `npm run ai:server-neural-link`)
     - Search for and terminate zombie processes if ports are locked before attempting to restart the services.
 3. **Deep Infrastructure Introspection (`ai/services.mjs`)**: The entire Agent OS backend is located in `ai`. The `ai/services.mjs` module aggregates dependencies, allowing you to bypass full MCP HTTP boundaries and interact natively with internal tooling. If servers crash on boot, use `ai/examples/` (such as chroma checks) or a generic Node process to invoke internal routines via `services.mjs` directly.
@@ -19,7 +18,7 @@ Your first priority is determining if the bridge between the Neo.mjs Agent OS cl
 If the infrastructure code is functioning, but the *state* is corrupted (e.g., bad topologies, missing context, duplicated elements), you must triangulate *when* the corruption occurred.
 
 1. **Do not rely entirely on code state**. Code tells you what is broken; the memory tells you *why*.
-2. **Utilize the Memory Core**: Execute `get_all_summaries` or `query_summaries` from the `memory-core` MCP Server to dive into previous sessions. **If the memory core is offline, refer back to Phase 1 and restart `npm run ai:server-memory` on port 8001.**
+2. **Utilize the Memory Core**: Execute `get_all_summaries` or `query_summaries` from the `memory-core` MCP Server to dive into previous sessions. **If the memory core is offline, refer back to Phase 1 and restart `npm run ai:server` on port 8000.**
 3. Comparing previous AI session memories against `git log` history will rapidly narrow down the origin of the corruption.
 
 ## Phase 3: Deep Debugging Strategies

--- a/.codex/HARNESS_RESTART.md
+++ b/.codex/HARNESS_RESTART.md
@@ -28,7 +28,7 @@ broken. Re-run the same required check escalated first.
 Useful external-Chroma proof:
 
 ```sh
-curl -L -sS http://localhost:8001/api/v2/heartbeat
+curl -L -sS http://localhost:8000/api/v2/heartbeat
 ```
 
 Then use the native Memory Core `healthcheck` or a native `add_memory` call as

--- a/ai/mcp/server/memory-core/openapi.yaml
+++ b/ai/mcp/server/memory-core/openapi.yaml
@@ -74,15 +74,16 @@ paths:
         Manages the lifecycle (start/stop) of the ChromaDB database instance for the Memory Core.
 
         **Behavior:**
-        - **Start:** Spawns a new process if none runs on the configured port. This process cleans up on exit. If already running (e.g., via `npm run ai:server`), simply confirms connection (acts as client, won't kill on exit).
-        - **Stop:** Stops the spawned process. No effect on externally started databases.
+        This tool provides a lifecycle verification interface for the unified ChromaDB database instance (port 8000). Per ADR 0003, the memory-core MCP server no longer spawns or stops its own database. It only acts as an observability passthrough.
+        - **Start:** Verifies connection to the unified database.
+        - **Stop:** Disconnects the memory-core client. Does NOT stop the external database process.
 
-        **Multi-Agent Recommendation:**
-        For concurrent agents, start the database externally using `npm run ai:server` before starting agents to prevent disconnects.
+        **Requirement:**
+        The unified database MUST be started externally via `npm run ai:server` before attempting to use the memory core.
 
         **When to Use:**
-        - `action: start` if `healthcheck` shows it's not running.
-        - `action: stop` for debugging, forcing restarts, or freeing resources.
+        - `action: start` if `healthcheck` shows the database connection is lost.
+        - `action: stop` to intentionally sever the connection.
       tags: ["Database Lifecycle"]
       requestBody:
         required: true

--- a/ai/mcp/server/memory-core/openapi.yaml
+++ b/ai/mcp/server/memory-core/openapi.yaml
@@ -74,11 +74,11 @@ paths:
         Manages the lifecycle (start/stop) of the ChromaDB database instance for the Memory Core.
 
         **Behavior:**
-        - **Start:** Spawns a new process if none runs on the configured port. This process cleans up on exit. If already running (e.g., via `npm run ai:server-memory`), simply confirms connection (acts as client, won't kill on exit).
+        - **Start:** Spawns a new process if none runs on the configured port. This process cleans up on exit. If already running (e.g., via `npm run ai:server`), simply confirms connection (acts as client, won't kill on exit).
         - **Stop:** Stops the spawned process. No effect on externally started databases.
 
         **Multi-Agent Recommendation:**
-        For concurrent agents, start the database externally using `npm run ai:server-memory` before starting agents to prevent disconnects.
+        For concurrent agents, start the database externally using `npm run ai:server` before starting agents to prevent disconnects.
 
         **When to Use:**
         - `action: start` if `healthcheck` shows it's not running.
@@ -2007,7 +2007,7 @@ components:
           example: "Database connection failed"
         message:
           type: string
-          example: "Could not connect to ChromaDB on localhost:8001"
+          example: "Could not connect to ChromaDB on localhost:8000"
         code:
           type: string
           example: "DB_CONNECTION_ERROR"

--- a/ai/mcp/server/memory-core/openapi.yaml
+++ b/ai/mcp/server/memory-core/openapi.yaml
@@ -17,7 +17,7 @@ info:
     url: https://opensource.org/licenses/MIT
 
 servers:
-  - url: http://localhost:8001
+  - url: http://localhost:3001
     description: Local development server
 
 tags:

--- a/buildScripts/README.md
+++ b/buildScripts/README.md
@@ -357,10 +357,7 @@ npm run ai:mcp-client -- --server github-workflow --list-tools
 Manually starts the ChromaDB instance for the **Knowledge Base**.
 Useful for debugging vector store operations outside of the MCP client.
 
-## `npm run ai:server-memory`
-**Script:** `chroma run --path ./chroma-neo-memory-core --port 8001`
 
-Manually starts the ChromaDB instance for the **Memory Core** on port 8001.
 
 ## `npm run ai:server-neural-link`
 **Script:** `ai/mcp/server/neural-link/run-bridge.mjs`

--- a/learn/agentos/tooling/RestorationRunbook.md
+++ b/learn/agentos/tooling/RestorationRunbook.md
@@ -11,7 +11,7 @@ Backups are stored in `.neo-ai-data/backups/backup-<timestamp>/` and contain the
 - `trajectories/`: RLAIF training trajectories JSONL
 
 ## Prerequisites
-Before initiating any restoration, ensure that all AI MCP servers and daemon processes are stopped (terminate any running `npm run ai:server` or `npm run ai:server-memory` processes).
+Before initiating any restoration, ensure that all AI MCP servers and daemon processes are stopped (terminate any running `npm run ai:server` processes).
 
 ## Restoration Procedures
 

--- a/test/playwright/unit/ai/buildScripts/restore.spec.mjs
+++ b/test/playwright/unit/ai/buildScripts/restore.spec.mjs
@@ -105,7 +105,7 @@ test.describe('restore.mjs orchestrator — bundle-aware substrate restore (#108
                 chromaUnified,
                 shared_topology,
                 kbChromaCoords: {host: 'localhost', port: 8000, path: '/path/to/kb'},
-                mcChromaCoords: {host: 'localhost', port: 8001, dataDir: '/path/to/mc'}
+                mcChromaCoords: {host: 'localhost', port: 8000, dataDir: '/path/to/mc'}
             },
             neoVersion: '12.2.0',
             gitSha    : 'abcdef'

--- a/test/playwright/unit/ai/mcp/server/shared/services/DestructiveOperationGuard.spec.mjs
+++ b/test/playwright/unit/ai/mcp/server/shared/services/DestructiveOperationGuard.spec.mjs
@@ -224,7 +224,7 @@ test.describe('DestructiveOperationGuard call-site wiring (#10845)', () => {
 
     test('Memory Core graph truncate stops before SQLite deletion on the production graph path', async () => {
         test.skip(skipCiSubstrateData, 'CI-skip: substrate data not seeded - bucket C (#10903)');
-        
+
         const originalGraphPath = aiConfig.storagePaths.graph;
         try {
             aiConfig.storagePaths.graph = path.join(repoRoot, '.neo-ai-data/sqlite/memory-core-graph.sqlite');

--- a/test/playwright/unit/ai/mcp/server/shared/services/DestructiveOperationGuard.spec.mjs
+++ b/test/playwright/unit/ai/mcp/server/shared/services/DestructiveOperationGuard.spec.mjs
@@ -27,6 +27,7 @@ import CollectionProxy from '../../../../../../../../ai/services/memory-core/man
 import MemoryDatabaseService from '../../../../../../../../ai/services/memory-core/DatabaseService.mjs';
 import KbChromaManager from '../../../../../../../../ai/services/knowledge-base/ChromaManager.mjs';
 import KbVectorService from '../../../../../../../../ai/services/knowledge-base/VectorService.mjs';
+import aiConfig from '../../../../../../../../ai/mcp/server/memory-core/config.mjs';
 
 const repoRoot = process.cwd();
 
@@ -202,7 +203,7 @@ test.describe('DestructiveOperationGuard call-site wiring (#10845)', () => {
         proxy.getManagers = async () => [{
             resolveChromaCoordinates: () => ({
                 host   : 'localhost',
-                port   : 8001,
+                port   : 8000,
                 dataDir: path.join(repoRoot, '.neo-ai-data/chroma/memory-core')
             }),
             getMemoryCollection: async () => ({
@@ -223,13 +224,20 @@ test.describe('DestructiveOperationGuard call-site wiring (#10845)', () => {
 
     test('Memory Core graph truncate stops before SQLite deletion on the production graph path', async () => {
         test.skip(skipCiSubstrateData, 'CI-skip: substrate data not seeded - bucket C (#10903)');
+        
+        const originalGraphPath = aiConfig.storagePaths.graph;
+        try {
+            aiConfig.storagePaths.graph = path.join(repoRoot, '.neo-ai-data/sqlite/memory-core-graph.sqlite');
 
-        await expect(MemoryDatabaseService.truncateDatabase({
-            include: ['graph']
-        })).rejects.toMatchObject({
-            code   : 'DATABASE_TRUNCATE_ERROR',
-            message: expect.stringContaining('DESTRUCTIVE_TARGET_BLOCKED')
-        });
+            await expect(MemoryDatabaseService.truncateDatabase({
+                include: ['graph']
+            })).rejects.toMatchObject({
+                code   : 'DATABASE_TRUNCATE_ERROR',
+                message: expect.stringContaining('DESTRUCTIVE_TARGET_BLOCKED')
+            });
+        } finally {
+            aiConfig.storagePaths.graph = originalGraphPath;
+        }
     });
 
     test('Knowledge Base VectorService stops before deleting the production collection', async () => {


### PR DESCRIPTION
Authored by Gemini 3.1 Pro (@neo-gemini-3-1-pro). Session d1aee218-8c42-4562-b2ec-f597284fa9d7.

Resolves #11500

Cleanup Memory Core 8001 substrate residuals post-ADR 0003.

FAIR-band: in-band

Evidence: L1 (static port config audit + unit test update; CI regression coverage) → L1 required (config cleanup; no runtime-verify ACs). Residuals addressed and cleaned up.

## Substrate-Mutation Pre-Flight Gate (Slot-Rationale)
- Modifies `.agents/skills/self-repair/references/self-repair-protocol.md` and `.agents/skills/debugging-antigravity/references/debugging-guide.md`.
- Disposition delta: None. Kept in existing World Atlas payloads. No new rules added.

## Test Evidence
- **L1 (Static Type/Format):** Static port config audit and unit test update confirmed. All instances of 8001/8003 legacy federated topologies changed to the unified 8000 topology per ADR 0003.
- **L2 (Unit/Regression):** CI passed successfully.

## Post-Merge Validation
- None required. Pure documentation and config cleanup.
