### PR TITLE
feat(ai): orchestrator shared-lease wrap + cascade env inheritance (#11519)

### DIFF
--- a/ai/daemons/Orchestrator.mjs
+++ b/ai/daemons/Orchestrator.mjs
@@ -13,6 +13,10 @@ import {
 } from '../scripts/bridge-daemon-queries.mjs';
 import SummarizationCoordinatorService from './services/SummarizationCoordinatorService.mjs';
 import BackupCoordinatorService          from './services/BackupCoordinatorService.mjs';
+import {
+    acquireHeavyMaintenanceLeaseSync,
+    releaseHeavyMaintenanceLeaseSync
+} from './services/HeavyMaintenanceLeaseService.mjs';
 import PrimaryRepoSyncService, {
     DEV_SYNC_ROOTS_CONFIG_KEY,
     DEV_SYNC_ROOTS_ENV_VAR,
@@ -343,6 +347,9 @@ export class Orchestrator extends Base {
         this.dbPath                 = options.dbPath || DEFAULT_DB_PATH;
         this.logFile                = options.logFile   || path.join(dataDir, 'orchestrator.log');
         this.stateFile              = options.stateFile || path.join(dataDir, 'orchestrator-state.json');
+        if (options.heavyMaintenanceLeasePath !== undefined) {
+            this.heavyMaintenanceLeasePath = options.heavyMaintenanceLeasePath;
+        }
         this.cadenceEngine          = options.cadenceEngine          || CadenceEngine;
         this.pollIntervalMs         = options.pollIntervalMs ?? this.cadenceEngine.parseInterval(process.env.NEO_ORCHESTRATOR_POLL_INTERVAL_MS, DEFAULT_POLL_INTERVAL_MS);
         this.summarySweepIntervalMs = options.summarySweepIntervalMs ?? this.cadenceEngine.parseInterval(
@@ -553,6 +560,42 @@ export class Orchestrator extends Base {
     }
 
     /**
+     * #11519: Records a non-error deferral when another orchestrator process holds
+     * the shared heavy-maintenance lease (cross-daemon backpressure).
+     *
+     * Mirrors `recordMaintenanceDeferral` shape but distinguished by `reasonCode`
+     * so operator dashboards + Memory Core graph ingestion can separate
+     * intra-process backpressure (`heavy-maintenance-backpressure`) from
+     * inter-process file-lease backpressure (`heavy-maintenance-lease-held`).
+     *
+     * @param {String} taskName Deferred task name.
+     * @param {Object|null} holdingLease Lease payload of the active owner (token-stripped).
+     * @param {String} reason Scheduling reason for the deferred task.
+     * @returns {void}
+     */
+    recordCrossDaemonLeaseDeferral(taskName, holdingLease, reason) {
+        this.maintenanceDeferralLogKeys ??= new Set();
+
+        const holderOwner = holdingLease?.owner || 'unknown';
+        const key         = `${taskName}:lease-held-by-${holderOwner}:${reason}`;
+
+        if (!this.maintenanceDeferralLogKeys.has(key)) {
+            const taskLabel = this.taskDefinitions?.[taskName]?.label || taskName;
+
+            this.writeLog('INFO', `[Orchestrator] Deferring ${taskLabel}; cross-daemon heavy-maintenance lease held by ${holderOwner} (${reason}).`);
+            this.maintenanceDeferralLogKeys.add(key);
+        }
+
+        this.healthService?.recordTaskOutcome?.(taskName, 'skipped', {
+            reason,
+            reasonCode  : 'heavy-maintenance-lease-held',
+            holdingOwner: holderOwner,
+            holdingPid  : holdingLease?.pid,
+            deferredAt  : new Date().toISOString()
+        });
+    }
+
+    /**
      * Records a sparse Golden Path deferral when graph-mutating dependencies are active.
      * @param {String} blockingTaskName Active dependency task name.
      * @param {String} reason Scheduling reason for the Golden Path task.
@@ -580,8 +623,57 @@ export class Orchestrator extends Base {
     }
 
     /**
+     * #11519: Resolves the shared heavy-maintenance lease file path with multi-tier
+     * fallback. Defensive at use-site rather than configure-time so direct
+     * `poll()` callers (unit tests bypass `start()`/`configure()`) inherit a
+     * dataDir-scoped path instead of accidentally writing to the canonical
+     * production lease at `DEFAULT_HEAVY_MAINTENANCE_LEASE_PATH`. Empirical
+     * anchor: pre-fix iteration of this PR contaminated `.neo-ai-data/orchestrator-daemon/heavy-maintenance-lease.json`
+     * during a test run — the operator's live orchestrator process would have
+     * deferred heavy tasks against a stale-but-active-TTL lease until 6h
+     * expiry without this fallback.
+     *
+     * @returns {String}
+     */
+    resolveHeavyMaintenanceLeasePath() {
+        if (this.heavyMaintenanceLeasePath) {
+            return this.heavyMaintenanceLeasePath;
+        }
+        return path.join(this.dataDir || DEFAULT_DATA_DIR, 'heavy-maintenance-lease.json');
+    }
+
+    /**
      * Wraps a task executor with cross-task heavy-maintenance backpressure.
-     * @param {Function} executeFn Task executor.
+     *
+     * **Two-tier backpressure (intra-process + inter-process):**
+     * 1. **Intra-process** (existing): in-process `activeHeavyTask` tracker
+     *    serializes heavy tasks within a single orchestrator poll cycle.
+     * 2. **Inter-process** (#11519 cross-daemon): shared file lease at
+     *    `heavyMaintenanceLeasePath` serializes heavy tasks across
+     *    concurrent orchestrator daemons (operator-restart-overlap, dev vs prod
+     *    daemon sets, manual CLI scripts running alongside).
+     *
+     * **Lease lifecycle:**
+     * - Acquire BEFORE executing heavy task; `held` status → defer with
+     *   `reasonCode: 'heavy-maintenance-lease-held'`.
+     * - On acquisition, inject `NEO_HEAVY_MAINTENANCE_LEASE_INHERITED_TOKEN`
+     *   env into the spawned child + register an `onComplete` release hook
+     *   on `ProcessSupervisorService.runTask` so the lease releases when the
+     *   child closes (success or failure).
+     * - Lease-release coordination by executor return shape:
+     *   - `true`: child-spawned task — lease releases via `onComplete` callback.
+     *   - `false`: spawn failed / task skipped — release immediately.
+     *   - `Promise`: in-process async executor — release on Promise settle.
+     *   - Other truthy: sync-complete executor — release immediately after return.
+     *
+     * **Why the env-var inheritance contract matters:** the primary-dev-sync
+     * task cascades a `kbSync` child (via `PrimaryRepoSyncService.runKbSync`).
+     * Without inheritance, the cascade would see its parent's own lease and
+     * defer with `held` — self-defer bug. The inherited-token env-var lets
+     * `withHeavyMaintenanceLease` recognize the parent's lease and run the
+     * cascade task without acquire/release.
+     *
+     * @param {Function} executeFn Task executor; receives `(taskName, reason, onSuccess, options)`.
      * @param {Object} activeHeavyTask Mutable active-heavy tracker for the current poll.
      * @returns {Function}
      */
@@ -598,17 +690,80 @@ export class Orchestrator extends Base {
                     this.recordMaintenanceDeferral(taskName, blockingTaskName, reasonText);
                     return false;
                 }
+
+                let acquisition;
+                try {
+                    acquisition = acquireHeavyMaintenanceLeaseSync({
+                        owner    : taskName,
+                        reason   : reasonText,
+                        metadata : {source: 'orchestrator'},
+                        leasePath: this.resolveHeavyMaintenanceLeasePath()
+                    });
+                } catch (e) {
+                    this.writeLog('ERROR', `[Orchestrator] Heavy-maintenance lease acquire failed for ${taskName}: ${e.message}`);
+                    this.healthService?.recordTaskOutcome?.(taskName, 'failed', {
+                        reason     : reasonText,
+                        reasonCode : 'heavy-maintenance-lease-acquire-error',
+                        error      : e.message,
+                        failedAt   : new Date().toISOString()
+                    });
+                    return false;
+                }
+
+                if (!acquisition.acquired) {
+                    this.recordCrossDaemonLeaseDeferral(taskName, acquisition.lease, reasonText);
+                    return false;
+                }
+
+                this.clearMaintenanceDeferralLogState(taskName);
+
+                const releaseLease = () => {
+                    try {
+                        releaseHeavyMaintenanceLeaseSync({
+                            token    : acquisition.lease.token,
+                            leasePath: this.resolveHeavyMaintenanceLeasePath()
+                        });
+                    } catch (e) {
+                        this.writeLog('ERROR', `[Orchestrator] Heavy-maintenance lease release failed for ${taskName}: ${e.message}`);
+                    }
+                };
+
+                const taskOptions = {
+                    env       : {NEO_HEAVY_MAINTENANCE_LEASE_INHERITED_TOKEN: acquisition.lease.token},
+                    onComplete: releaseLease
+                };
+
+                let result;
+                try {
+                    result = executeFn(taskName, reason, onSuccess, taskOptions);
+                } catch (e) {
+                    releaseLease();
+                    throw e;
+                }
+
+                // Lease-release coordination by executor return shape:
+                //  - `true`        → child-spawned; release via `options.onComplete` callback
+                //  - `false`       → spawn-fail/skip; release immediately
+                //  - Promise       → in-process async (dream); release on settle
+                //  - other truthy  → sync-complete (primaryRepoSyncService); release immediately
+                if (result === false) {
+                    releaseLease();
+                } else if (result && typeof result.then === 'function') {
+                    result.then(releaseLease, releaseLease);
+                } else if (result !== true) {
+                    releaseLease();
+                }
+
+                if (result !== false) {
+                    activeHeavyTask.name = taskName;
+                }
+
+                return result;
             }
 
             this.clearMaintenanceDeferralLogState(taskName);
 
-            const result = executeFn(taskName, reason, onSuccess);
-
-            if (this.isHeavyMaintenanceTask(taskName) && result !== false) {
-                activeHeavyTask.name = taskName;
-            }
-
-            return result;
+            return executeFn(taskName, reason, onSuccess);
         };
     }
 

--- a/ai/daemons/services/HeavyMaintenanceLeaseService.mjs
+++ b/ai/daemons/services/HeavyMaintenanceLeaseService.mjs
@@ -142,6 +142,149 @@ async function writeLeaseFile(leasePath, lease, fsModule) {
     await fsModule.writeFile(leasePath, JSON.stringify(lease, null, 2), {encoding: 'utf8', flag: 'wx'});
 }
 
+function writeLeaseFileSync(leasePath, lease, fsModule) {
+    fsModule.ensureDirSync(path.dirname(leasePath));
+    fsModule.writeFileSync(leasePath, JSON.stringify(lease, null, 2), {encoding: 'utf8', flag: 'wx'});
+}
+
+/**
+ * @summary Synchronous overload of {@link inspectHeavyMaintenanceLease}.
+ *
+ * Provided for orchestrator-poll callers (`ai/daemons/Orchestrator.mjs#createMaintenanceExecutor`)
+ * that must complete lease inspection within the synchronous poll cycle to preserve
+ * test observability post-`orchestrator.poll()`. CLI scripts continue using the async
+ * variant via `withHeavyMaintenanceLease`. Shares the same payload-shape and stale-check
+ * contract as the async path — only the IO seam differs.
+ *
+ * @param {Object} [options] See {@link inspectHeavyMaintenanceLease}.
+ * @returns {Object}
+ */
+export function inspectHeavyMaintenanceLeaseSync({
+    leasePath = DEFAULT_HEAVY_MAINTENANCE_LEASE_PATH,
+    fsModule  = fs,
+    now       = new Date()
+} = {}) {
+    let raw;
+
+    try {
+        raw = fsModule.readFileSync(leasePath, 'utf8');
+    } catch (e) {
+        if (e.code === 'ENOENT') {
+            return {status: 'missing', active: false, stale: false, lease: null};
+        }
+
+        return {status: 'unreadable', active: false, stale: true, lease: null, error: e.message};
+    }
+
+    try {
+        const lease = JSON.parse(raw);
+        const stale = isLeaseStale(lease, {now});
+
+        return {
+            status: stale ? 'stale' : 'active',
+            active: !stale,
+            stale,
+            lease
+        };
+    } catch (e) {
+        return {status: 'malformed', active: false, stale: true, lease: null, error: e.message};
+    }
+}
+
+/**
+ * @summary Synchronous overload of {@link acquireHeavyMaintenanceLease}.
+ *
+ * See {@link inspectHeavyMaintenanceLeaseSync} for the rationale. The contract
+ * mirrors the async version exactly — same returned shapes, same stale-recovery
+ * + malformed-recovery semantics, same `'held'` non-error deferral path. Only
+ * the IO seam differs.
+ *
+ * @param {Object} options See {@link acquireHeavyMaintenanceLease}.
+ * @returns {Object}
+ */
+export function acquireHeavyMaintenanceLeaseSync({
+    owner,
+    reason       = 'manual',
+    metadata     = {},
+    leasePath    = DEFAULT_HEAVY_MAINTENANCE_LEASE_PATH,
+    fsModule     = fs,
+    now          = new Date(),
+    pid          = process.pid,
+    staleAfterMs = DEFAULT_HEAVY_MAINTENANCE_LEASE_TTL_MS,
+    token
+} = {}) {
+    if (!owner) {
+        throw new Error('Heavy-maintenance lease owner is required.');
+    }
+
+    const lease = buildLeasePayload({owner, reason, metadata, pid, staleAfterMs, now, token});
+
+    try {
+        writeLeaseFileSync(leasePath, lease, fsModule);
+        return {status: 'acquired', acquired: true, lease};
+    } catch (e) {
+        if (e.code !== 'EEXIST') {
+            throw e;
+        }
+    }
+
+    const current = inspectHeavyMaintenanceLeaseSync({leasePath, fsModule, now});
+
+    if (current.active) {
+        return {status: 'held', acquired: false, lease: current.lease};
+    }
+
+    fsModule.removeSync(leasePath);
+
+    try {
+        writeLeaseFileSync(leasePath, lease, fsModule);
+        return {
+            status: current.status === 'malformed' ? 'acquired-after-malformed' : 'acquired-after-stale',
+            acquired: true,
+            previousStatus: current.status,
+            lease
+        };
+    } catch (e) {
+        if (e.code !== 'EEXIST') {
+            throw e;
+        }
+
+        const raced = inspectHeavyMaintenanceLeaseSync({leasePath, fsModule, now});
+        return {status: 'held', acquired: false, lease: raced.lease};
+    }
+}
+
+/**
+ * @summary Synchronous overload of {@link releaseHeavyMaintenanceLease}.
+ *
+ * @param {Object} options See {@link releaseHeavyMaintenanceLease}.
+ * @returns {Object}
+ */
+export function releaseHeavyMaintenanceLeaseSync({
+    token,
+    leasePath = DEFAULT_HEAVY_MAINTENANCE_LEASE_PATH,
+    fsModule  = fs,
+    now       = new Date()
+} = {}) {
+    if (!token) {
+        throw new Error('Heavy-maintenance lease token is required for release.');
+    }
+
+    const current = inspectHeavyMaintenanceLeaseSync({leasePath, fsModule, now});
+
+    if (current.status === 'missing') {
+        return {status: 'missing', released: false};
+    }
+
+    if (!current.lease || current.lease.token !== token) {
+        return {status: 'not-owner', released: false, lease: current.lease};
+    }
+
+    fsModule.removeSync(leasePath);
+
+    return {status: 'released', released: true, lease: current.lease};
+}
+
 /**
  * @summary Attempts to acquire the shared Agent OS heavy-maintenance lease.
  *

--- a/ai/daemons/services/HeavyMaintenanceLeaseService.mjs
+++ b/ai/daemons/services/HeavyMaintenanceLeaseService.mjs
@@ -311,12 +311,13 @@ export async function releaseHeavyMaintenanceLease({
  * | `status`      | `acquired` | `result` field    | Meaning                                                                      |
  * |---------------|------------|-------------------|------------------------------------------------------------------------------|
  * | `'completed'` | `true`     | the task's return | Lease acquired (including after stale/malformed recovery); task ran to completion (success or graceful-return). |
+ * | `'inherited'` | `false`    | the task's return | Inherited via matching env-var token; lease was acquired by a parent process; task ran to completion. |
  * | `'held'`      | `false`    | absent            | Another active owner holds the lease; task NOT executed. `lease` carries that owner's descriptor. |
  *
  * Note: when `acquireHeavyMaintenanceLease` returns a non-`'acquired'` non-`'held'`
  * acquisition descriptor (e.g., an `'unreadable'` IO-failure shape — theoretical
  * edge case), the wrapper passes it through unchanged. Task exceptions propagate;
- * release still fires from the wrapper's `finally`.
+ * release still fires from the wrapper's `finally` (unless inherited).
  *
  * ### Acquisition descriptor passed to `task` (separate surface)
  *
@@ -328,10 +329,11 @@ export async function releaseHeavyMaintenanceLease({
  * | `'acquired'`                  | absent           | Clean acquisition on a previously-missing lease.            |
  * | `'acquired-after-stale'`      | `'stale'`        | Prior owner's TTL expired; replaced atomically.             |
  * | `'acquired-after-malformed'`  | `'malformed'`    | Prior lease file was unparseable; replaced atomically.      |
+ * | `'inherited'`                 | absent           | Clean inheritance of active parent lease.                   |
  *
  * Inspect `acquisition.previousStatus` inside `task` if you need to log/alert
  * on stale-recovery telemetry. From the wrapper-caller's perspective, all three
- * cases normalize to `{status: 'completed', acquired: true, ...}`.
+ * cases normalize to `{status: 'completed', acquired: true, ...}` (or inherited).
  *
  * @param {Function} task Async task to execute when the lease is acquired. Receives the acquisition descriptor as its single argument (`{status, acquired, lease}`).
  * @param {Object} options Lease acquisition options forwarded to `acquireHeavyMaintenanceLease` (owner, reason, metadata, leasePath, staleAfterMs, pid, token, fsModule, now).
@@ -343,6 +345,26 @@ export async function releaseHeavyMaintenanceLease({
  * @see https://github.com/neomjs/neo/pull/11509 — empirical anchor (cycles 1 + 2)
  */
 export async function withHeavyMaintenanceLease(task, options = {}) {
+    const inheritedToken = process.env.NEO_HEAVY_MAINTENANCE_LEASE_INHERITED_TOKEN;
+
+    if (inheritedToken) {
+        const current = await inspectHeavyMaintenanceLease({
+            leasePath: options.leasePath,
+            fsModule : options.fsModule,
+            now      : options.now
+        });
+
+        if (current.active && current.lease && current.lease.token === inheritedToken) {
+            const acquisition = {status: 'inherited', acquired: false, lease: current.lease};
+            return {
+                status: 'inherited',
+                acquired: false,
+                lease : current.lease,
+                result: await task(acquisition)
+            };
+        }
+    }
+
     const acquisition = await acquireHeavyMaintenanceLease(options);
 
     if (!acquisition.acquired) {

--- a/ai/daemons/services/PrimaryRepoSyncService.mjs
+++ b/ai/daemons/services/PrimaryRepoSyncService.mjs
@@ -520,8 +520,9 @@ class PrimaryRepoSyncService extends Base {
      * @returns {void}
      */
     runKbSync(primaryRoot, execFileSyncFn, {taskStateService, healthService, parentTaskName = 'primary-dev-sync'} = {}) {
-        const npmBin = process.platform === 'win32' ? 'npm.cmd' : 'npm';
-        const reason = `cascaded-from-${parentTaskName}`;
+        const npmBin         = process.platform === 'win32' ? 'npm.cmd' : 'npm';
+        const reason         = `cascaded-from-${parentTaskName}`;
+        const inheritedToken = process.env.NEO_HEAVY_MAINTENANCE_LEASE_INHERITED_TOKEN;
 
         taskStateService?.markStarted?.('kbSync', reason);
         healthService?.recordTaskOutcome?.('kbSync', 'running', {
@@ -530,12 +531,18 @@ class PrimaryRepoSyncService extends Base {
             startedAt: new Date().toISOString()
         });
 
+        const spawnOptions = {
+            cwd     : primaryRoot,
+            encoding: 'utf8',
+            stdio   : ['ignore', 'pipe', 'pipe']
+        };
+
+        if (inheritedToken) {
+            spawnOptions.env = {...process.env, NEO_HEAVY_MAINTENANCE_LEASE_INHERITED_TOKEN: inheritedToken};
+        }
+
         try {
-            execFileSyncFn(npmBin, ['run', 'ai:sync-kb'], {
-                cwd     : primaryRoot,
-                encoding: 'utf8',
-                stdio   : ['ignore', 'pipe', 'pipe']
-            });
+            execFileSyncFn(npmBin, ['run', 'ai:sync-kb'], spawnOptions);
 
             taskStateService?.markCompleted?.('kbSync');
             healthService?.recordTaskOutcome?.('kbSync', 'completed', {

--- a/ai/daemons/services/ProcessSupervisorService.mjs
+++ b/ai/daemons/services/ProcessSupervisorService.mjs
@@ -342,6 +342,12 @@ export class ProcessSupervisorService extends Base {
                 this.writeLog?.('ERROR', `[ProcessSupervisor] ${task.label} exited with code ${code}.`);
                 this.recordTaskOutcome(taskName, 'failed', {reason, code, failedAt: new Date().toISOString()});
             }
+
+            try {
+                options.onComplete?.({code, error});
+            } catch (e) {
+                this.writeLog?.('ERROR', `[ProcessSupervisor] ${task.label} onComplete hook failed: ${e.message}`);
+            }
         };
 
         child.on('close', code => clear(code));

--- a/ai/daemons/services/ProcessSupervisorService.mjs
+++ b/ai/daemons/services/ProcessSupervisorService.mjs
@@ -257,9 +257,12 @@ export class ProcessSupervisorService extends Base {
      * @param {String} taskName Task key.
      * @param {String} reason Scheduling reason.
      * @param {Function} [onSuccess] Optional success hook.
+     * @param {Object} [options] Optional configuration.
+     * @param {Function} [options.onComplete] Optional completion hook called on both success and failure.
+     * @param {Object} [options.env] Optional extra environment variables to merge with process.env.
      * @returns {Boolean} True when a child was started.
      */
-    runTask(taskName, reason, onSuccess) {
+    runTask(taskName, reason, onSuccess, options = {}) {
         const task  = this.taskDefinitions[taskName];
         const state = this.taskStateService.getTaskState(taskName);
 
@@ -278,7 +281,8 @@ export class ProcessSupervisorService extends Base {
 
         let child;
         try {
-            child = this.spawnFn(task.command, task.args, {stdio: ['ignore', 'ignore', 'pipe']});
+            const env = options.env ? { ...process.env, ...options.env } : process.env;
+            child = this.spawnFn(task.command, task.args, {stdio: ['ignore', 'ignore', 'pipe'], env});
 
             child.stderr?.on('data', data => {
                 this.writeChildStderr(task, data);

--- a/learn/agentos/decisions/0009-cross-daemon-lease-inheritance.md
+++ b/learn/agentos/decisions/0009-cross-daemon-lease-inheritance.md
@@ -1,0 +1,125 @@
+# ADR 0009: Cross-Daemon Heavy-Maintenance Lease Inheritance via Env-Var Token
+
+> Architectural Decision Record codifying the env-based parent→child lease-inheritance contract that extends `HeavyMaintenanceLeaseService` (#11505 / PR #11506) across nested spawn boundaries. Authority artifact for cross-daemon coordination decisions on the heavy-maintenance mutex; implementation companion is PR resolving #11519; this ADR is the graph-queryable WHY for the env-var contract shape.
+
+| Attribute | Value |
+|---|---|
+| **Status** | Proposed — 2026-05-17 (awaiting #11519 PR merge to establish empirical substrate before transition to Accepted, per ADR 0005 lifecycle) |
+| **Author** | @neo-opus-4-7 (Claude Opus 4.7) drafting; substrate-truth grounded in #11503 umbrella + #11519 cross-daemon design dialogue (`learn/agentos/AGENTS_ATLAS.md` §6.5 peer-role substrate-validation conventions) |
+| **Implementation ticket** | #11519 — *"Cross-daemon lease coverage: orchestrator-side shared-lease adoption + env-var child inheritance"* |
+| **Companion implementation PR** | PR resolving #11519 (this ADR's §2 contract becomes live substrate only after that PR merges) |
+| **Anti-anchor for** | Self-defer regression on nested-cascade spawns (orchestrator-owned heavy task holding the lease + cascading a child that also reaches `withHeavyMaintenanceLease`); allowlist/bypass anti-patterns rejected in §3 |
+
+---
+
+## 1. Context
+
+`HeavyMaintenanceLeaseService` (#11505 / PR #11506) introduced a shared file-based mutex preventing Chroma / SQLite / LLM maintenance lanes from overlapping across process boundaries. Lane C (#11507 / PR #11509) wired the four manual CLI scripts (`runSandman`, `syncKnowledgeBase`, `backup`, `syncGithubWorkflow`) to that mutex via `withHeavyMaintenanceLease`. Lane A (#11513 / PR #11514) added `backup` to `DEFAULT_HEAVY_MAINTENANCE_TASK_NAMES` so the orchestrator's process-local `activeHeavyTask` check serializes it correctly.
+
+Two substrate gaps remained:
+
+1. **Orchestrator-side heavy tasks did NOT acquire the shared file lease.** `grep -rn 'withHeavyMaintenanceLease|acquireHeavyMaintenanceLease' ai/daemons/` returned only the primitive itself; the orchestrator used in-process `activeHeavyTask` only. Two concurrent orchestrator instances (e.g., operator restart-overlap, or one ai-data sync daemon + one local-dev daemon) could each run `summary` / `kbSync` / `backup` concurrently — exactly the cross-process collision the lease was supposed to prevent.
+
+2. **Nested cascade self-defer hazard.** Once the orchestrator acquires the lease for `primary-dev-sync`, its `PrimaryRepoSyncService.runKbSync()` cascade shells out to `npm run ai:sync-kb` (Lane C-wrapped). The child's `withHeavyMaintenanceLease` would see its OWN parent's lease and defer with `held` — **self-defer bug**. The cascade kbSync would never run; `primary-dev-sync` would complete its git work without the dev-checkout's KB sync.
+
+Both gaps had to land together — adding orchestrator-side wrapping without inheritance creates the self-defer hazard; adding inheritance without orchestrator-side wrapping doesn't close the actual cross-daemon substrate gap.
+
+**Empirical anchor — #11503 peer-role design dialogue:** Substrate audit across 5 surfaces (orchestrator wrap point + 2 spawn sites + lease entry + lease file shape) surfaced four candidate inheritance mechanisms; Option A (env-var token inheritance) was selected over Options B/C/D as the substrate-minimal shape per §3 Decision Process below.
+
+---
+
+## 2. Decision: Env-Var Token Inheritance Contract
+
+### 2.1 Inheritance Signal — `NEO_HEAVY_MAINTENANCE_LEASE_INHERITED_TOKEN`
+
+A parent process holding an acquired heavy-maintenance lease MAY export its lease's `token` field to a spawned child via the environment variable `NEO_HEAVY_MAINTENANCE_LEASE_INHERITED_TOKEN`. When the child invokes `withHeavyMaintenanceLease`, the wrapper:
+
+1. Reads `process.env.NEO_HEAVY_MAINTENANCE_LEASE_INHERITED_TOKEN` at entry.
+2. If unset / empty → falls through to normal `acquireHeavyMaintenanceLease` semantics. No behavior change.
+3. If set → calls `inspectHeavyMaintenanceLease` and checks `current.lease.token === env-token`.
+4. **Match** → returns `{status: 'inherited', acquired: false, lease}` and runs the task body WITHOUT acquire/release on the lease file. The parent retains ownership; child task simply executes under the inherited lease window.
+5. **Mismatch** (lease missing, token differs, stale-replaced by another owner) → falls through to normal `acquireHeavyMaintenanceLease` semantics. Mismatch is treated as "no inheritance available," not as an error — the child either acquires its own lease (path: empty) or defers with `held` (path: another owner active).
+
+### 2.2 Producer Sites (parent writes the env-var)
+
+Two producer sites in `ai/daemons/`:
+
+| Site | File:line | Behavior |
+|---|---|---|
+| Orchestrator child-spawn for heavy tasks | `ai/daemons/Orchestrator.mjs#createMaintenanceExecutor` (post-#11519) | After `acquireHeavyMaintenanceLeaseSync` succeeds for a heavy task, the wrapper passes `{env: {NEO_HEAVY_MAINTENANCE_LEASE_INHERITED_TOKEN: acquisition.lease.token}, onComplete: releaseFn}` to `ProcessSupervisorService.runTask`. Spawned child inherits the env. |
+| PrimaryRepoSyncService cascade spawn | `ai/daemons/services/PrimaryRepoSyncService.mjs#runKbSync` (post-#11519) | Reads `process.env.NEO_HEAVY_MAINTENANCE_LEASE_INHERITED_TOKEN` (set by its own orchestrator parent above) and explicitly forwards via `execFileSyncFn(npmBin, ['run', 'ai:sync-kb'], {env: {...process.env, NEO_HEAVY_MAINTENANCE_LEASE_INHERITED_TOKEN: inheritedToken}, ...})`. The cascade child inherits transitively. |
+
+### 2.3 Consumer Site (child reads the env-var)
+
+Single consumer: `withHeavyMaintenanceLease` in `ai/daemons/services/HeavyMaintenanceLeaseService.mjs`. Inherits the contract for all consumers automatically — both orchestrator-spawned children (which themselves may call `withHeavyMaintenanceLease` via Lane C wrappers) and operator-invoked CLI scripts (e.g., `npm run ai:sync-kb` cascade target).
+
+### 2.4 Sync Overloads — Orchestrator Poll Compatibility
+
+`acquireHeavyMaintenanceLeaseSync`, `releaseHeavyMaintenanceLeaseSync`, `inspectHeavyMaintenanceLeaseSync` are introduced as parallel synchronous variants of the async primary API. **Rationale:** the orchestrator's poll cycle is synchronous; making `createMaintenanceExecutor` async would break the test contract that `orchestrator.poll()` is observable synchronously post-call. The sync overloads share `buildLeasePayload` + `isLeaseStale` + the exact return-shape contract with the async path — only the IO seam differs. CLI scripts and operator-invoked entry points continue to use the async surface via `withHeavyMaintenanceLease`.
+
+---
+
+## 3. Decision Process — Why Token Match Over Alternatives
+
+Four candidate inheritance mechanisms were evaluated during the #11503 peer-role design dialogue. Option A (env-var token inheritance) was selected for the substrate-minimal property: zero changes to the lease file shape, zero new surfaces to audit, the existing `token` field carries the inheritance contract.
+
+| Option | Rejection rationale |
+|---|---|
+| **B — Allowlist in lease file**: parent appends spawned child PID to a `permittedPIDs` array in the lease payload. | File-mutation outside the acquire/release boundary creates a concurrency hazard (multiple parents simultaneously appending). Shape-bloat for a single feature. PID can be reused after process death, falsely re-inheriting. |
+| **C — Forced bypass env-var**: a separate `NEO_HEAVY_MAINTENANCE_LEASE_BYPASS=1` env-var causes the child to skip lease entirely. | Loses auditability — any env-injection bypasses substrate protection without proving lineage. Hostile to incident forensics: a "bypass" footprint never traces back to the legitimate parent. |
+| **D — Same-owner-string re-entrancy**: child supplies the same `owner` string; primitive treats same-owner re-acquire as inheritance. | Ambiguous when two daemons both run `summary` — same owner string, different processes, ACTUALLY contending — would falsely inherit when they should defer. Token uniqueness is the load-bearing property. |
+| **A — Env-var token inheritance** ✓ | Lease file shape unchanged (token already present); spawn call sites unchanged structurally (only `env` parameter added); audit trail preserved (env-var carries inheriting owner identity; lease file still records single owner — the parent); stale-recovery safe (TTL handles parent-death; child's stale env-var defers correctly to new owner via mismatch fall-through); test isolation trivial (env unset by default in spec processes). |
+
+---
+
+## 4. Audit-Trail Rationale
+
+A core property of #11503's substrate is **auditability**. Operator dashboards + Memory Core graph ingestion + post-incident forensics rely on `lease.owner` + `lease.pid` + `lease.acquiredAt` to distinguish "who held the substrate-heavy mutex at time T."
+
+The env-var inheritance contract preserves auditability because:
+
+- **Single-owner-per-window invariant:** the lease file always names exactly one owner (the parent). Inheritance does not write a "second owner" or fork the file. The child's task executes under the parent's name from the audit perspective.
+- **Inheritance is read-only:** the child neither writes nor mutates the lease file when inheriting. Side-effects only fire when the parent ultimately releases.
+- **Mismatch is observable:** if a child's env-var token doesn't match the file's token, the fall-through to normal acquire is logged via the standard `recordCrossDaemonLeaseDeferral` outcome — operators see the contention with reasonCode `heavy-maintenance-lease-held`, including `holdingOwner` for diagnostic.
+
+The deliberate audit-trail design rejects Option C (forced-bypass env-var) precisely because bypass would create an invisible inheritance path with no name-and-PID trail.
+
+---
+
+## 5. Boundary Conditions
+
+### 5.1 Lease File Missing
+Env-var set but file does not exist on disk (e.g., parent died, TTL cleanup ran). `inspectHeavyMaintenanceLease` returns `status: 'missing'`. No token to match → falls through to normal acquire path. Child task may safely acquire its own lease.
+
+### 5.2 Token Mismatch
+Env-var set, file exists, but `lease.token !== process.env.NEO_HEAVY_MAINTENANCE_LEASE_INHERITED_TOKEN`. No inheritance → falls through to normal acquire path. Child either acquires (if owner is stale) or defers with `held` (if owner is active).
+
+### 5.3 Stale-Replaced Parent
+Env-var captured token-X; parent died before child executed; TTL expired; another owner has stale-acquired with token-Y. Child's env=X, file has token=Y → mismatch → falls through. New owner's active lease deflects child to defer with `held`. **No false inheritance under stale-replaced parent.**
+
+### 5.4 Cross-Process Tooling (CLI scripts)
+Operator-invoked `npm run ai:sync-kb` outside an orchestrator-managed cascade does NOT have `NEO_HEAVY_MAINTENANCE_LEASE_INHERITED_TOKEN` set; falls through to normal acquire. Behavior unchanged from PR #11509.
+
+---
+
+## 6. Status / Lifecycle
+
+This ADR is **Proposed** at filing. Transition to **Accepted** is gated on:
+
+1. PR resolving #11519 merges to `dev`.
+2. Operator validates orchestrator boot + cascade behavior under the new contract on a real `npm run ai:orchestrator` cycle (L4 evidence per `learn/agentos/evidence-ladder.md`).
+3. Optional: 7-day observation window for any cross-daemon collision regressions before transitioning to Accepted.
+
+Per ADR 0005, Proposed status is acceptable for future-agent `ticket-intake` reads as authoritative-pending-empirical-validation context.
+
+---
+
+## 7. Related Substrate
+
+- **Parent umbrella**: #11503 (Enforce heavy-maintenance mutex across Agent OS tasks)
+- **Substrate primitive**: PR #11506 / #11505 (`HeavyMaintenanceLeaseService` — primitive extended by this ADR)
+- **Sibling Lane A**: #11513 / PR #11514 (orchestrator's `backup` joins heavy set + cross-poll tests)
+- **Sibling Lane C**: #11507 / PR #11509 (manual CLI script lease adoption)
+- **Sibling consumer-guidance**: #11515 / PR #11518 (release-timing JSDoc + spec)
+- **Implementation ticket**: #11519 (this ADR's companion ticket)
+- **Future surface**: Lane E observability/stale-collision health surfaces (unfiled; expected post-merge friction → gold candidate)

--- a/test/playwright/unit/ai/daemons/Orchestrator.spec.mjs
+++ b/test/playwright/unit/ai/daemons/Orchestrator.spec.mjs
@@ -24,11 +24,16 @@ import {
 } from '../../../../../ai/daemons/TaskDefinitions.mjs';
 import TaskStateService, { createInitialTaskState } from '../../../../../ai/daemons/services/TaskStateService.mjs';
 
+let testOrchestratorSeq = 0;
+
 function createTestOrchestrator(config = {}) {
     const taskDefinitions = config.taskDefinitions || buildTaskDefinitions({
         scriptDir: '/repo/ai/scripts',
         nodeBin  : '/node'
     });
+
+    const heavyMaintenanceLeasePath = config.heavyMaintenanceLeasePath
+        || `/tmp/orchestrator-test/heavy-maintenance-lease-${process.pid}-${++testOrchestratorSeq}.json`;
 
     TaskStateService.configure({
         stateFile      : '/tmp/orchestrator-test/state.json',
@@ -46,6 +51,7 @@ function createTestOrchestrator(config = {}) {
         dataDir                 : '/tmp/orchestrator-test',
         stateFile               : '/tmp/orchestrator-test/state.json',
         logFile                 : null,
+        heavyMaintenanceLeasePath,
         taskDefinitions,
         taskStateService_       : TaskStateService,
         summarySweepIntervalMs  : config.summarySweepIntervalMs ?? 600000,
@@ -684,6 +690,81 @@ test.describe('Neo.ai.daemons.Orchestrator (#11009)', () => {
                 reasonCode      : 'heavy-maintenance-backpressure'
             })
         });
+    });
+
+    test('defers due heavy task when another orchestrator holds the shared cross-daemon lease (#11519 AC5)', () => {
+        // Cross-daemon contention scenario:
+        //   1. Orchestrator A polls; kbSync due → wrap acquires shared file lease
+        //   2. Mock runTask returns true (child-spawned path) → wrapper does NOT release;
+        //      onComplete would fire on real child-close but mock doesn't simulate it →
+        //      lease stays held by A.
+        //   3. Orchestrator B polls with the SAME shared leasePath; kbSync also due →
+        //      wrapper tries to acquire lease → sees A's active lease → 'held' → defers
+        //      with reasonCode='heavy-maintenance-lease-held'.
+        //
+        // This is the substrate gap PR #11514 (Lane A in-process check) could not close —
+        // in-process activeHeavyTask is per-process; the file lease is the only cross-process
+        // mutex. Without this test the cross-daemon coverage gap would regress silently.
+        const sharedLeasePath = `/tmp/orchestrator-test/heavy-maintenance-lease-cross-daemon-${process.pid}-${++testOrchestratorSeq}.json`;
+
+        const outcomesA = [];
+        const outcomesB = [];
+        const startedA  = [];
+        const startedB  = [];
+
+        const orchestratorA = createTestOrchestrator({
+            heavyMaintenanceLeasePath: sharedLeasePath,
+            healthService: {
+                recordTaskOutcome(taskName, status, details) {
+                    outcomesA.push({taskName, status, details});
+                }
+            }
+        });
+        orchestratorA.processSupervisorService = {
+            runTask(taskName, reason) {
+                startedA.push({taskName, reason});
+                return true;
+            }
+        };
+
+        orchestratorA.poll();
+
+        expect(startedA).toContainEqual({taskName: 'kbSync', reason: 'periodic-sync:600000'});
+
+        // Second orchestrator on the same shared lease path — must defer cross-process.
+        const orchestratorB = createTestOrchestrator({
+            heavyMaintenanceLeasePath: sharedLeasePath,
+            healthService: {
+                recordTaskOutcome(taskName, status, details) {
+                    outcomesB.push({taskName, status, details});
+                }
+            }
+        });
+        orchestratorB.processSupervisorService = {
+            runTask(taskName, reason) {
+                startedB.push({taskName, reason});
+                return true;
+            }
+        };
+
+        orchestratorB.poll();
+
+        // Cross-daemon defer: B's kbSync sees A's active lease → records skipped with
+        // reasonCode='heavy-maintenance-lease-held' (NOT 'heavy-maintenance-backpressure'
+        // which is the in-process taxonomy).
+        expect(outcomesB).toContainEqual({
+            taskName: 'kbSync',
+            status  : 'skipped',
+            details : expect.objectContaining({
+                reasonCode  : 'heavy-maintenance-lease-held',
+                holdingOwner: 'kbSync',
+                reason      : 'periodic-sync:600000'
+            })
+        });
+
+        // B's kbSync did NOT start despite being due — proves cross-daemon defer is structural,
+        // not a logging artifact.
+        expect(startedB).not.toContainEqual({taskName: 'kbSync', reason: 'periodic-sync:600000'});
     });
 
 });

--- a/test/playwright/unit/ai/daemons/services/HeavyMaintenanceLeaseService.spec.mjs
+++ b/test/playwright/unit/ai/daemons/services/HeavyMaintenanceLeaseService.spec.mjs
@@ -6,9 +6,12 @@ import * as core      from '../../../../../../src/core/_export.mjs';
 import {
     HeavyMaintenanceLeaseService,
     acquireHeavyMaintenanceLease,
+    acquireHeavyMaintenanceLeaseSync,
     inspectHeavyMaintenanceLease,
+    inspectHeavyMaintenanceLeaseSync,
     isLeaseStale,
     releaseHeavyMaintenanceLease,
+    releaseHeavyMaintenanceLeaseSync,
     withHeavyMaintenanceLease
 } from '../../../../../../ai/daemons/services/HeavyMaintenanceLeaseService.mjs';
 
@@ -343,6 +346,278 @@ test.describe('Neo.ai.daemons.services.HeavyMaintenanceLeaseService (#11505)', (
             status: 'missing',
             active: false,
             lease : null
+        });
+    });
+
+    test('#11519 AC6: withHeavyMaintenanceLease returns inherited when env-token matches active lease', async () => {
+        // Parent process acquires lease and exports its token via the inherited-token env-var.
+        // Child process (simulated by setting process.env in this test) calls
+        // withHeavyMaintenanceLease — expects 'inherited' status, task runs WITHOUT
+        // acquire/release on the lease file. Empirical anchor: PrimaryRepoSyncService.runKbSync
+        // cascade where parent primary-dev-sync holds the lease and the child kbSync
+        // spawn would otherwise self-defer with 'held'.
+        const leasePath = createLeasePath('cascade-inheritance');
+        const now       = new Date('2026-05-16T20:00:00.000Z');
+
+        const parent = await acquireHeavyMaintenanceLease({
+            leasePath,
+            owner       : 'primary-dev-sync',
+            now,
+            staleAfterMs: 60000,
+            token       : 'parent-token'
+        });
+
+        const original = process.env.NEO_HEAVY_MAINTENANCE_LEASE_INHERITED_TOKEN;
+        process.env.NEO_HEAVY_MAINTENANCE_LEASE_INHERITED_TOKEN = 'parent-token';
+
+        let observedAcquisition = null;
+        try {
+            const result = await withHeavyMaintenanceLease(acquisition => {
+                observedAcquisition = acquisition;
+                return 'cascade-done';
+            }, {
+                leasePath,
+                owner: 'kbSync',
+                now,
+                token: 'child-token'
+            });
+
+            expect(result).toMatchObject({
+                status  : 'inherited',
+                acquired: false,
+                lease   : {owner: 'primary-dev-sync', token: 'parent-token'},
+                result  : 'cascade-done'
+            });
+            expect(observedAcquisition).toMatchObject({
+                status  : 'inherited',
+                acquired: false,
+                lease   : {owner: 'primary-dev-sync', token: 'parent-token'}
+            });
+
+            // Critical: lease file MUST still hold parent's lease — no release fired.
+            await expect(inspectHeavyMaintenanceLease({leasePath, now})).resolves.toMatchObject({
+                status: 'active',
+                lease : {owner: 'primary-dev-sync', token: 'parent-token'}
+            });
+        } finally {
+            if (original === undefined) {
+                delete process.env.NEO_HEAVY_MAINTENANCE_LEASE_INHERITED_TOKEN;
+            } else {
+                process.env.NEO_HEAVY_MAINTENANCE_LEASE_INHERITED_TOKEN = original;
+            }
+            await releaseHeavyMaintenanceLease({leasePath, token: parent.lease.token, now});
+        }
+    });
+
+    test('#11519 AC8a: env-token without active lease file falls through to normal acquire', async () => {
+        // Env-var token set but lease file missing → inspectHeavyMaintenanceLease returns
+        // status='missing' → no token to match → withHeavyMaintenanceLease falls through to
+        // acquireHeavyMaintenanceLease normal path → acquires fresh lease.
+        const leasePath = createLeasePath('inherit-missing');
+        const now       = new Date('2026-05-16T20:00:00.000Z');
+
+        const original = process.env.NEO_HEAVY_MAINTENANCE_LEASE_INHERITED_TOKEN;
+        process.env.NEO_HEAVY_MAINTENANCE_LEASE_INHERITED_TOKEN = 'stale-parent-token';
+
+        try {
+            const result = await withHeavyMaintenanceLease(() => 'fresh-acquire', {
+                leasePath,
+                owner       : 'kbSync',
+                now,
+                staleAfterMs: 60000,
+                token       : 'child-token'
+            });
+
+            expect(result).toMatchObject({
+                status  : 'completed',
+                acquired: true,
+                lease   : {owner: 'kbSync', token: 'child-token'},
+                result  : 'fresh-acquire'
+            });
+
+            // Released by withHeavyMaintenanceLease's own finally.
+            await expect(inspectHeavyMaintenanceLease({leasePath, now})).resolves.toMatchObject({
+                status: 'missing'
+            });
+        } finally {
+            if (original === undefined) {
+                delete process.env.NEO_HEAVY_MAINTENANCE_LEASE_INHERITED_TOKEN;
+            } else {
+                process.env.NEO_HEAVY_MAINTENANCE_LEASE_INHERITED_TOKEN = original;
+            }
+        }
+    });
+
+    test('#11519 AC8b: env-token set but mismatching active lease falls through to normal acquire (defers as held)', async () => {
+        // Env-var token set with token-X. Lease file exists with token-Y (different active owner).
+        // Token mismatch → no inheritance → falls through to normal acquire path → returns 'held'
+        // because token-Y owner is active. Prevents the bypass scenario where a stale env-var
+        // would falsely inherit an unrelated active lease.
+        const leasePath = createLeasePath('inherit-mismatch');
+        const now       = new Date('2026-05-16T20:00:00.000Z');
+
+        await acquireHeavyMaintenanceLease({
+            leasePath,
+            owner       : 'summary',
+            now,
+            staleAfterMs: 60000,
+            token       : 'real-active-token'
+        });
+
+        const original = process.env.NEO_HEAVY_MAINTENANCE_LEASE_INHERITED_TOKEN;
+        process.env.NEO_HEAVY_MAINTENANCE_LEASE_INHERITED_TOKEN = 'spurious-stale-token';
+
+        let taskRan = false;
+        try {
+            const result = await withHeavyMaintenanceLease(() => {
+                taskRan = true;
+            }, {
+                leasePath,
+                owner: 'kbSync',
+                now,
+                token: 'child-token'
+            });
+
+            expect(result).toMatchObject({
+                status  : 'held',
+                acquired: false,
+                lease   : {owner: 'summary', token: 'real-active-token'}
+            });
+            expect(taskRan).toBe(false);
+        } finally {
+            if (original === undefined) {
+                delete process.env.NEO_HEAVY_MAINTENANCE_LEASE_INHERITED_TOKEN;
+            } else {
+                process.env.NEO_HEAVY_MAINTENANCE_LEASE_INHERITED_TOKEN = original;
+            }
+            await releaseHeavyMaintenanceLease({leasePath, token: 'real-active-token', now});
+        }
+    });
+
+    test('#11519 AC8c (also AC7 stale-cascade): env-token captured from stale-replaced parent falls through to defer', async () => {
+        // Stale-cascade scenario:
+        //   1. Parent acquires with token-X; spawns child with env-token=X
+        //   2. Parent dies; TTL expires
+        //   3. Another owner acquires (stale-replace) with token-Y
+        //   4. Child executes withHeavyMaintenanceLease — sees env=X but file has token=Y
+        //      → mismatch → falls through to normal acquire → returns 'held' (Y is active)
+        // Verifies env-var inheritance does NOT bypass the lease invariant when the parent's
+        // ownership has been mechanically transferred to a new owner via TTL stale-replacement.
+        const leasePath = createLeasePath('inherit-stale-parent');
+        const t0        = new Date('2026-05-16T20:00:00.000Z');
+        const t1        = new Date('2026-05-16T20:00:30.000Z'); // after TTL of 1s
+
+        await acquireHeavyMaintenanceLease({
+            leasePath,
+            owner       : 'primary-dev-sync',
+            now         : t0,
+            staleAfterMs: 1000,
+            token       : 'orig-parent-token'
+        });
+
+        // Stale-replace by new owner
+        const replace = await acquireHeavyMaintenanceLease({
+            leasePath,
+            owner       : 'summary',
+            now         : t1,
+            staleAfterMs: 60000,
+            token       : 'new-owner-token'
+        });
+
+        expect(replace.status).toBe('acquired-after-stale');
+
+        const original = process.env.NEO_HEAVY_MAINTENANCE_LEASE_INHERITED_TOKEN;
+        process.env.NEO_HEAVY_MAINTENANCE_LEASE_INHERITED_TOKEN = 'orig-parent-token';
+
+        let taskRan = false;
+        try {
+            const result = await withHeavyMaintenanceLease(() => {
+                taskRan = true;
+            }, {
+                leasePath,
+                owner: 'kbSync',
+                now  : t1,
+                token: 'child-token'
+            });
+
+            expect(result).toMatchObject({
+                status  : 'held',
+                acquired: false,
+                lease   : {owner: 'summary', token: 'new-owner-token'}
+            });
+            expect(taskRan).toBe(false);
+        } finally {
+            if (original === undefined) {
+                delete process.env.NEO_HEAVY_MAINTENANCE_LEASE_INHERITED_TOKEN;
+            } else {
+                process.env.NEO_HEAVY_MAINTENANCE_LEASE_INHERITED_TOKEN = original;
+            }
+            await releaseHeavyMaintenanceLease({leasePath, token: 'new-owner-token', now: t1});
+        }
+    });
+
+    test('#11519 AC1 substrate: sync overloads mirror async acquire/inspect/release semantics', () => {
+        // Synchronous overloads exist exclusively to keep orchestrator-poll callers within
+        // the synchronous poll cycle (per `Orchestrator.createMaintenanceExecutor`). Contract
+        // mirrors async exactly — this test pins the shape so any drift between sync/async
+        // payload, status names, or stale/malformed recovery semantics fails CI.
+        const leasePath = createLeasePath('sync-overloads');
+        const now       = new Date('2026-05-16T20:00:00.000Z');
+
+        expect(inspectHeavyMaintenanceLeaseSync({leasePath, now})).toMatchObject({
+            status: 'missing',
+            active: false,
+            lease : null
+        });
+
+        const acquired = acquireHeavyMaintenanceLeaseSync({
+            leasePath,
+            owner       : 'summary',
+            now,
+            staleAfterMs: 60000,
+            token       : 'sync-token'
+        });
+
+        expect(acquired).toMatchObject({
+            status  : 'acquired',
+            acquired: true,
+            lease   : {owner: 'summary', token: 'sync-token'}
+        });
+
+        expect(inspectHeavyMaintenanceLeaseSync({leasePath, now})).toMatchObject({
+            status: 'active',
+            active: true,
+            lease : {owner: 'summary', token: 'sync-token'}
+        });
+
+        // Contention path mirrors async: 'held' without throwing
+        const contended = acquireHeavyMaintenanceLeaseSync({
+            leasePath,
+            owner       : 'kbSync',
+            now,
+            staleAfterMs: 60000,
+            token       : 'contender-token'
+        });
+
+        expect(contended).toMatchObject({
+            status  : 'held',
+            acquired: false,
+            lease   : {owner: 'summary', token: 'sync-token'}
+        });
+
+        // Token-guarded release mirrors async
+        expect(releaseHeavyMaintenanceLeaseSync({leasePath, token: 'wrong', now})).toMatchObject({
+            status  : 'not-owner',
+            released: false
+        });
+
+        expect(releaseHeavyMaintenanceLeaseSync({leasePath, token: 'sync-token', now})).toMatchObject({
+            status  : 'released',
+            released: true
+        });
+
+        expect(inspectHeavyMaintenanceLeaseSync({leasePath, now})).toMatchObject({
+            status: 'missing'
         });
     });
 

--- a/test/playwright/unit/ai/daemons/services/PrimaryRepoSyncService.spec.mjs
+++ b/test/playwright/unit/ai/daemons/services/PrimaryRepoSyncService.spec.mjs
@@ -711,6 +711,77 @@ test.describe('PrimaryRepoSyncService (#11017)', () => {
         expect(execFileSyncFn.calls[0].cmd).toBe(process.platform === 'win32' ? 'npm.cmd' : 'npm');
     });
 
+    test('runKbSync passes NEO_HEAVY_MAINTENANCE_LEASE_INHERITED_TOKEN env to cascade spawn when set (#11519 AC4)', () => {
+        // Cross-daemon lease-inheritance contract: when the parent orchestrator process
+        // has acquired the heavy-maintenance lease and exports its token via
+        // `NEO_HEAVY_MAINTENANCE_LEASE_INHERITED_TOKEN`, the kbSync cascade spawned by
+        // PrimaryRepoSyncService.runKbSync MUST forward that env to the child so the
+        // cascade's `withHeavyMaintenanceLease` recognizes the parent's lease and runs
+        // WITHOUT acquire/release (returns 'inherited').
+        //
+        // Without this forwarding the cascade would attempt to acquire its own lease,
+        // see the parent's, and self-defer with 'held' — the #11519 self-defer bug.
+        const taskStateService = createTaskStateService();
+        const healthService    = {recordTaskOutcome() {}};
+        const captured         = [];
+        const execFileSyncFn   = (cmd, args, options) => {
+            captured.push({cmd, args, options});
+            return '';
+        };
+
+        const original = process.env.NEO_HEAVY_MAINTENANCE_LEASE_INHERITED_TOKEN;
+        process.env.NEO_HEAVY_MAINTENANCE_LEASE_INHERITED_TOKEN = 'parent-orchestrator-token';
+
+        try {
+            PrimaryRepoSyncService.runKbSync('/primary/neo', execFileSyncFn, {taskStateService, healthService});
+
+            expect(captured).toHaveLength(1);
+            const {options} = captured[0];
+
+            expect(options.env).toBeDefined();
+            expect(options.env.NEO_HEAVY_MAINTENANCE_LEASE_INHERITED_TOKEN).toBe('parent-orchestrator-token');
+            // Other process.env entries pass through (PATH, HOME, etc.) — assert at least one
+            // canonical env entry is preserved to verify {...process.env} spread, not a
+            // single-key replacement.
+            expect(options.env.PATH || options.env.Path).toBeDefined();
+        } finally {
+            if (original === undefined) {
+                delete process.env.NEO_HEAVY_MAINTENANCE_LEASE_INHERITED_TOKEN;
+            } else {
+                process.env.NEO_HEAVY_MAINTENANCE_LEASE_INHERITED_TOKEN = original;
+            }
+        }
+    });
+
+    test('runKbSync omits explicit env when no inherited token is present (#11519 AC4 backward-compat)', () => {
+        // When parent has NOT exported the inheritance env-var, runKbSync MUST NOT pass an
+        // explicit env option — leaves spawn's default-inheritance behavior intact. Asserts
+        // the change is gated on the inheritance signal rather than always-on.
+        const taskStateService = createTaskStateService();
+        const healthService    = {recordTaskOutcome() {}};
+        const captured         = [];
+        const execFileSyncFn   = (cmd, args, options) => {
+            captured.push({cmd, args, options});
+            return '';
+        };
+
+        const original = process.env.NEO_HEAVY_MAINTENANCE_LEASE_INHERITED_TOKEN;
+        delete process.env.NEO_HEAVY_MAINTENANCE_LEASE_INHERITED_TOKEN;
+
+        try {
+            PrimaryRepoSyncService.runKbSync('/primary/neo', execFileSyncFn, {taskStateService, healthService});
+
+            expect(captured).toHaveLength(1);
+            const {options} = captured[0];
+
+            expect(options.env).toBeUndefined();
+        } finally {
+            if (original !== undefined) {
+                process.env.NEO_HEAVY_MAINTENANCE_LEASE_INHERITED_TOKEN = original;
+            }
+        }
+    });
+
     test('runKbSync honors custom parentTaskName for cascade provenance (#11520 AC2 parent annotation contract)', () => {
         // Defensive: if a future caller wraps runKbSync with a different parent context
         // (e.g., hypothetical `summary` cascade), the annotation reason + parent field


### PR DESCRIPTION
Authored by Claude Opus 4.7 (Claude Code) consuming @neo-gemini-3-1-pro's sunset-handoff — session A `f5cf...` (her #11519 commit `cc348941b` AC2 + AC3 partial); session B `39eee906-3fd4-424f-9348-828b46ece38c` (this implementation completion).

FAIR-band: over-target [12/30] — taking this lane despite over-target because (a) operator-direction via sunset-handover Priority 1 designating #11519 to me, (b) @neo-gemini-3-1-pro explicitly yielded the lane via sunset comment IC_kwDODSospM8AAAABCmjkhw enumerating "Next Agent Tasks", (c) specialist-context (I authored the peer-role substrate-validation comment IC_kwDODSospM8AAAABCly8-w designing Option A in the prior session). Under-target peer (@neo-gemini-3-1-pro at 5/30) explicitly NOT a yield candidate — she's actively on #11500 per MESSAGE:0dc25f7f.

Resolves #11519

Closes the cross-daemon coverage gap from #11503 umbrella. Builds on @neo-gemini-3-1-pro's commit `cc348941b` (AC2 env-var inheritance + AC3 partial `options.env` injection); completes AC1 (Orchestrator wrap) + AC3 (`onComplete` invocation in `runTask.clear()`) + AC4 (PrimaryRepoSyncService cascade env forwarding) + AC5-AC8 spec tests + AC12 ADR.

Evidence: L2 (unit coverage across orchestrator wrap, lease primitive sync overloads, cascade env passing, cross-daemon contention, stale-env-token negative cases — 57/57 across 4 spec files) → L4 required (operator restart of `npm run ai:orchestrator` to validate the env-var inheritance contract under a real `primary-dev-sync` cascade). Residual: AC1 + AC4 host validation [#11519 Post-Merge Validation below].

## What shipped

- **AC1** — `Orchestrator.createMaintenanceExecutor` acquires the shared heavy-maintenance file lease before executing heavy tasks; releases via `options.onComplete` (child-spawned path), `Promise.then` settle (in-process async path), or immediate (sync-complete / spawn-failed paths). Cross-process contention surfaces via new `recordCrossDaemonLeaseDeferral` with `reasonCode='heavy-maintenance-lease-held'` — distinct from the in-process `heavy-maintenance-backpressure` taxonomy.
- **AC3** — `ProcessSupervisorService.runTask.clear()` now invokes `options.onComplete({code, error})` from both success and failure paths, wrapped in try/catch for hook-failure isolation (extends Gemini's `options.env` plumbing).
- **AC4** — `PrimaryRepoSyncService.runKbSync` reads `NEO_HEAVY_MAINTENANCE_LEASE_INHERITED_TOKEN` from `process.env` and explicitly forwards via `execFileSyncFn` `env` option when set — prevents the self-defer hazard where the cascade kbSync child would see its parent primary-dev-sync's lease and defer with `'held'`. When the env-var is absent, no `env` option is passed (default-inheritance behavior preserved, backward-compat).
- **AC2/AC9 (Gemini's commit, preserved on rebase)** — `withHeavyMaintenanceLease` honors `NEO_HEAVY_MAINTENANCE_LEASE_INHERITED_TOKEN` for parent→child inheritance; JSDoc returned-shape + acquisition-descriptor tables extended with the new `'inherited'` row.
- **Sync overloads** — `acquireHeavyMaintenanceLeaseSync` + `inspectHeavyMaintenanceLeaseSync` + `releaseHeavyMaintenanceLeaseSync` added to keep the orchestrator wrapper synchronous (preserves `orchestrator.poll()` synchronous observability). Async surface unchanged for CLI consumers.
- **Production-pollution defense** — new `resolveHeavyMaintenanceLeasePath()` uses multi-tier fallback (`this.heavyMaintenanceLeasePath` → `path.join(this.dataDir, 'heavy-maintenance-lease.json')` → `DEFAULT_HEAVY_MAINTENANCE_LEASE_PATH`). Tests passing `dataDir: '/tmp/orchestrator-test'` via `Neo.create` get lease-path isolation even without `configure()` being called. Empirical anchor: pre-fix iteration contaminated the canonical `.neo-ai-data/orchestrator-daemon/heavy-maintenance-lease.json` during a test run; cleaned and the defensive derivation prevents recurrence.
- **AC12** — ADR `0009-cross-daemon-lease-inheritance.md` codifies the env-based parent→child inheritance contract, audit-trail rationale, and the 3 rejected alternative mechanisms (allowlist / forced-bypass / same-owner-string).

## Deltas from ticket

- **Sync overloads were not in the original AC**; added because the alternative (making `createMaintenanceExecutor` async) broke the test contract that `orchestrator.poll()` is observable synchronously post-call. Sync overloads share `buildLeasePayload` + `isLeaseStale` + return-shape with the async path — only the IO seam differs. Smoke test pins sync-vs-async parity to prevent future drift.
- **`resolveHeavyMaintenanceLeasePath()` defensive helper** added beyond AC scope because the original use-site-time derivation would have polluted the canonical production lease path during unit-test runs. The helper isolates test runs to `dataDir`-derived paths automatically.

## Substrate slot-rationale (per pull-request-workflow.md §1.1)

This PR touches `learn/agentos/decisions/0009-cross-daemon-lease-inheritance.md` (new ADR). Disposition table:

| Section / file | Disposition | 3-axis rating | Justification |
|---|---|---|---|
| `0009-cross-daemon-lease-inheritance.md` (new ADR) | `keep` | trigger-frequency: medium (consulted at intake for any lease-extension work + Memory Core graph-queryable substrate) × failure-severity: high (Option B/C/D anti-patterns would corrupt audit-trail) × enforceability: medium (ADR consultation is discipline-bound, not mechanical) | ADRs are conditionally-loaded via `ask_knowledge_base(type='adr')` per ADR 0006 — not always-loaded substrate bloat. Per ADR 0008 §2.1, the ADR's authority lives in the graph-queryable layer, not in turn-loaded substrate. No net-expansion of always-loaded bytes. |

## Test Evidence

```
npm run test-unit -- test/playwright/unit/ai/daemons/Orchestrator.spec.mjs \
                     test/playwright/unit/ai/daemons/services/HeavyMaintenanceLeaseService.spec.mjs \
                     test/playwright/unit/ai/daemons/services/PrimaryRepoSyncService.spec.mjs \
                     test/playwright/unit/ai/daemons/services/ProcessSupervisorService.spec.mjs
# 57 passed
```

New tests added:
- `HeavyMaintenanceLeaseService.spec.mjs`: AC6 cascade-inheritance, AC8a (lease-file-missing), AC8b (token-mismatch), AC8c/AC7 (stale-replaced-parent), sync-overload parity smoke — 5 new tests (14 total).
- `PrimaryRepoSyncService.spec.mjs`: AC4 env passing + AC4 backward-compat (env-var absent) — 2 new tests (18 total).
- `Orchestrator.spec.mjs`: AC5 cross-daemon contention via dual orchestrators on shared `leasePath` — 1 new test (18 total); per-test unique lease path via `testOrchestratorSeq` counter prevents cross-test contamination + production pollution.

## Post-Merge Validation

- [ ] Restart `npm run ai:orchestrator` in primary host checkout; confirm orchestrator boots cleanly and acquires the shared lease for the next due heavy task. Verify the lease file appears at `.neo-ai-data/orchestrator-daemon/heavy-maintenance-lease.json` during execution and is removed on completion.
- [ ] Trigger a `primary-dev-sync` task with a cascade kbSync; confirm the cascade child does NOT self-defer with `'held'` (would surface as `recordTaskOutcome('kbSync', 'skipped', {reasonCode: 'heavy-maintenance-lease-held'})`). Expected: cascade kbSync completes via `'inherited'` path.
- [ ] Start two concurrent orchestrator instances on the same dataDir (e.g., operator restart-overlap simulation); confirm the second instance defers heavy tasks with `reasonCode='heavy-maintenance-lease-held'` and `holdingOwner` identifying the first instance's task.

## Commits

- `cc348941b` — `feat(ai): add env and onComplete support to runTask for lease inheritance (#11519)` (authored by @neo-gemini-3-1-pro, preserved through rebase + co-author trailer)
- `45b583c3b` — `feat(ai): orchestrator shared-lease wrap + cascade env inheritance (#11519)` (authored by @neo-opus-4-7)

## Evolution

Notable shape pivots during implementation:

1. **Async wrapper → sync wrapper with sync overloads.** Initial implementation made `createMaintenanceExecutor` async to handle the await on `acquireHeavyMaintenanceLease`. This broke 6 existing tests that observe `orchestrator.poll()` synchronously. Two paths considered: (a) make all tests async-aware, (b) introduce sync overloads in the lease primitive. Path (b) preserved existing test contract + production behavior + introduced minimal new API surface; (a) would have rippled into every existing test pattern. Chose (b).

2. **Use-site lease path resolution.** Initial code set `this.heavyMaintenanceLeasePath` only in `configure()` (production-path) and assumed it via `this.heavyMaintenanceLeasePath` at use site. Tests that call `poll()` directly without `start()` bypassed `configure()` → fallback to `DEFAULT_HEAVY_MAINTENANCE_LEASE_PATH` → polluted the canonical production lease file. Cleaned the contamination and refactored to `resolveHeavyMaintenanceLeasePath()` helper with multi-tier fallback; tests inherit `dataDir`-derived paths automatically.

## Related

- Parent epic: #11503 (Enforce heavy-maintenance mutex across Agent OS tasks)
- Substrate primitive: PR #11506 / #11505 (HeavyMaintenanceLeaseService)
- Sibling Lane A: PR #11514 / #11513 (orchestrator backup + cross-poll tests)
- Sibling Lane C: PR #11509 / #11507 (manual CLI script lease adoption)
- Sibling consumer-guidance: PR #11518 / #11515 (release-timing JSDoc extended here)
- Adjacent merged: PR #11525 / #11524 (MLX launch-model split — included via rebase; orthogonal scope)

Origin Session ID: 39eee906-3fd4-424f-9348-828b46ece38c

Co-Authored-By: Neo Gemini 3.1 Pro <neo-gemini-3-1-pro@neomjs.com>