### PR TITLE
feat(memory-core): countMessages primitive + concept provenance docs (#10180)

### DIFF
--- a/ai/daemons/services/SemanticGraphExtractor.mjs
+++ b/ai/daemons/services/SemanticGraphExtractor.mjs
@@ -282,8 +282,22 @@ DO NOT output markdown, \`\`\`json blocks, or any other explanations. Provide pu
 
     /**
      * Extracts semantic concepts from a message body for auto-emission.
+     *
+     * Auto-extracted concepts carry distinct provenance from operator/agent-curated
+     * `taggedConcepts`: the upsert path stamps `properties.auto_extracted: true` on
+     * freshly-created concept nodes, and the `TAGGED_CONCEPT` edge is written at
+     * weight `0.8` (vs `1.0` for curated). See `learn/agentos/ConceptOntology.md`
+     * § Auto-Extracted Concept Provenance for the read-time consumer pattern +
+     * edge-weight rationale.
+     *
+     * Pre-existing concept nodes are NOT re-stamped — the flag is set only on the
+     * fresh-create path, preserving curated nodes' authoritative status even when
+     * subsequently referenced by LLM-inferred MESSAGE bodies.
+     *
      * @param {String} bodyText The message content to analyze
      * @returns {Promise<String[]>} Array of extracted Concept Node IDs
+     * @see learn/agentos/ConceptOntology.md § Auto-Extracted Concept Provenance
+     * @see ai/services/memory-core/MailboxService.mjs#addMessage — caller (fire-and-forget)
      */
     async extractMessageConcepts(bodyText) {
         if (!bodyText || typeof bodyText !== 'string' || bodyText.trim().length === 0) {

--- a/ai/services/memory-core/MailboxService.mjs
+++ b/ai/services/memory-core/MailboxService.mjs
@@ -937,8 +937,13 @@ class MailboxService extends Base {
      * use cases that tolerate a single-write staleness window (healthcheck preview,
      * dashboards). For strict per-write-visibility, use `listMessages` instead.
      *
+     * **Box-value contract:** only `'inbox'` and `'outbox'` are currently supported.
+     * `'all'` is deferred to a follow-up (would require UNION of inbox + outbox paths).
+     * Any other value (including typos) throws — see #11528 cycle-1 review for the
+     * rationale on rejecting unsupported enums vs silently aliasing to inbox.
+     *
      * @param {Object} [args]
-     * @param {String} [args.box='inbox'] Which box to count (`'inbox'` or `'outbox'`).
+     * @param {String} [args.box='inbox'] Which box to count. Supported: `'inbox'` or `'outbox'`. Throws on unsupported values.
      * @param {String} [args.status='all'] Read-state filter for inbox path
      *   (`'all'`, `'read'`, `'unread'`). Ignored for outbox.
      * @param {String} [args.to] Target identity (defaults to caller). Cross-identity
@@ -951,6 +956,15 @@ class MailboxService extends Base {
         const me = RequestContextService.getAgentIdentityNodeId();
         if (!me) {
             throw new Error("Cannot count messages: no agent identity context bound.");
+        }
+
+        // Per #11528 cycle-1 review (@neo-gpt): reject unsupported `box` values explicitly
+        // rather than silently aliasing to the inbox path. The original branch-on-outbox
+        // pattern would have returned partial-results for `box='all'` (deferred to a follow-up
+        // per #10180 PR body) or any typo. Fail fast on unsupported enum so callers see the
+        // deferred-vs-implemented boundary at the call site.
+        if (box !== 'inbox' && box !== 'outbox') {
+            throw new Error(`Cannot count messages: unsupported box value '${box}'. Supported values: 'inbox', 'outbox' ('all' is deferred to a follow-up).`);
         }
 
         const target = to || me;

--- a/ai/services/memory-core/MailboxService.mjs
+++ b/ai/services/memory-core/MailboxService.mjs
@@ -914,7 +914,155 @@ class MailboxService extends Base {
     }
 
     /**
+     * Returns a scalar count of messages matching the given filter, without
+     * fetching message bodies. Patterned after `MemoryService.buildMailboxDelta`
+     * (#10178) — uses direct `prepare` + `get` against `Edges` joined with
+     * `Nodes`, returning `{count}` in O(indexed) time regardless of mailbox
+     * depth. Retires the `listMessages({limit: N}).messages.length` proxy
+     * pattern previously used by `getHealthcheckPreview` (#10180).
+     *
+     * **Inbox path (3-way UNION):** captures direct DMs (`SENT_TO` me with
+     * `readAt` on the MESSAGE node), per-recipient broadcasts (`DELIVERED_TO`
+     * me with `readAt` on the DELIVERY edge per #11029), and legacy broadcasts
+     * (`SENT_TO AGENT:*` with the shared-read fallback when no `DELIVERED_TO`
+     * edges exist). Mirrors `buildMailboxDelta`'s unread-count taxonomy exactly.
+     *
+     * **Outbox path:** count of `SENT_BY` edges from the caller's identity.
+     * `status` filter is a no-op for outbox — outbox messages have per-recipient
+     * `readAt`, not a unified message-level state; "outbox unread" is semantically
+     * undefined and returns the full outbox count.
+     *
+     * **Cache coherence note:** direct-SQL bypasses the in-memory cache hydration
+     * that `listMessages` performs via `getAdjacentNodes`. Acceptable for caller
+     * use cases that tolerate a single-write staleness window (healthcheck preview,
+     * dashboards). For strict per-write-visibility, use `listMessages` instead.
+     *
+     * @param {Object} [args]
+     * @param {String} [args.box='inbox'] Which box to count (`'inbox'` or `'outbox'`).
+     * @param {String} [args.status='all'] Read-state filter for inbox path
+     *   (`'all'`, `'read'`, `'unread'`). Ignored for outbox.
+     * @param {String} [args.to] Target identity (defaults to caller). Cross-identity
+     *   reads require `CAN_READ_INBOX_OF` permission, mirroring `listMessages`.
+     * @param {String} [args.fromIdentity] Filter inbox messages by sender identity.
+     *   Ignored for outbox (no inverse-of-sender semantic).
+     * @returns {Promise<{count: Number}>}
+     */
+    async countMessages({ box = 'inbox', status = 'all', to, fromIdentity } = {}) {
+        const me = RequestContextService.getAgentIdentityNodeId();
+        if (!me) {
+            throw new Error("Cannot count messages: no agent identity context bound.");
+        }
+
+        const target = to || me;
+
+        if (target !== me && target !== 'AGENT:*') {
+            if (!PermissionService.hasPermission(me, target, 'CAN_READ_INBOX_OF')) {
+                throw new Error(`Unauthorized: no CAN_READ_INBOX_OF permission for ${target}`);
+            }
+        }
+
+        const sqlite = GraphService.db?.storage?.db;
+        if (!sqlite) return { count: 0 };
+
+        // readAt filter clauses keyed by the storage location of the read-state.
+        // SENT_TO direct + AGENT:* legacy: readAt lives on the MESSAGE node payload.
+        // DELIVERED_TO per-recipient: readAt lives on the DELIVERY edge payload.
+        const messageReadAtClause = status === 'unread'
+            ? `AND json_extract(n.data, '$.properties.readAt') IS NULL`
+            : status === 'read'
+                ? `AND json_extract(n.data, '$.properties.readAt') IS NOT NULL`
+                : '';
+
+        const edgeReadAtClause = status === 'unread'
+            ? `AND json_extract(e.data, '$.properties.readAt') IS NULL`
+            : status === 'read'
+                ? `AND json_extract(e.data, '$.properties.readAt') IS NOT NULL`
+                : '';
+
+        // Optional sender filter — applies to inbox only.
+        const senderFilterSql = fromIdentity
+            ? `AND EXISTS (SELECT 1 FROM Edges sb WHERE sb.source = n.id AND sb.type = 'SENT_BY' AND sb.target = ?)`
+            : '';
+
+        try {
+            if (box === 'outbox') {
+                const row = sqlite.prepare(`
+                    SELECT COUNT(DISTINCT n.id) AS count
+                    FROM Edges e
+                    JOIN Nodes n ON n.id = e.source
+                    WHERE e.type = 'SENT_BY'
+                      AND e.target = ?
+                      AND json_extract(n.data, '$.label') = 'MESSAGE'
+                `).get(target);
+                return { count: row?.count ?? 0 };
+            }
+
+            // Inbox: 3-way UNION mirroring buildMailboxDelta's unread-message taxonomy.
+            const params = [];
+            const inboxSql = `
+                WITH inbox_messages AS (
+                    SELECT n.id AS messageId
+                    FROM Edges e
+                    JOIN Nodes n ON n.id = e.source
+                    WHERE e.type = 'SENT_TO'
+                      AND e.target = ?
+                      AND json_extract(n.data, '$.label') = 'MESSAGE'
+                      ${messageReadAtClause}
+                      ${senderFilterSql}
+
+                    UNION
+
+                    SELECT n.id AS messageId
+                    FROM Edges e
+                    JOIN Nodes n ON n.id = e.source
+                    WHERE e.type = 'DELIVERED_TO'
+                      AND e.target = ?
+                      AND json_extract(n.data, '$.label') = 'MESSAGE'
+                      ${edgeReadAtClause}
+                      ${senderFilterSql}
+
+                    UNION
+
+                    SELECT n.id AS messageId
+                    FROM Edges e
+                    JOIN Nodes n ON n.id = e.source
+                    WHERE e.type = 'SENT_TO'
+                      AND e.target = 'AGENT:*'
+                      AND json_extract(n.data, '$.label') = 'MESSAGE'
+                      ${messageReadAtClause}
+                      ${senderFilterSql}
+                      AND NOT EXISTS (
+                          SELECT 1 FROM Edges de
+                          WHERE de.source = n.id AND de.type = 'DELIVERED_TO'
+                      )
+                )
+                SELECT COUNT(DISTINCT messageId) AS count
+                FROM inbox_messages
+            `;
+
+            params.push(target);
+            if (fromIdentity) params.push(fromIdentity);
+            params.push(target);
+            if (fromIdentity) params.push(fromIdentity);
+            if (fromIdentity) params.push(fromIdentity);
+
+            const row = sqlite.prepare(inboxSql).get(...params);
+            return { count: row?.count ?? 0 };
+        } catch (error) {
+            // Pattern from buildMailboxDelta: non-fatal degradation. Returning 0
+            // for healthcheck-class callers is safer than throwing during boot/poll.
+            return { count: 0 };
+        }
+    }
+
+    /**
      * Generates the mailbox preview for the healthcheck payload.
+     *
+     * Uses `countMessages` (#10180) for the `unreadCount` field — direct-SQL path
+     * with no upper-bound cap. Inbox + outbox previews retain `listMessages` with
+     * `limit: 3` matching the preview surface size; the previously-implicit cap
+     * of 100 on `unreadCount` is retired.
+     *
      * @returns {Promise<Object|null>}
      */
     async getHealthcheckPreview() {
@@ -923,29 +1071,20 @@ class MailboxService extends Base {
             return null; // No agent identity bound yet
         }
 
-        const inboxResult = await this.listMessages({ box: 'inbox', limit: 100 }); // fetch enough to count unreads
-        const outboxResult = await this.listMessages({ box: 'outbox', limit: 3 });
+        const { count: unreadCount } = await this.countMessages({ box: 'inbox', status: 'unread' });
+        const inboxResult            = await this.listMessages({ box: 'inbox',  limit: 3 });
+        const outboxResult           = await this.listMessages({ box: 'outbox', limit: 3 });
 
-        let unreadCount = 0;
-        let inboxPreview = [];
-
-        for (const msg of inboxResult.messages) {
-            if (!msg.readAt) {
-                unreadCount++;
-            }
-            if (inboxPreview.length < 3) {
-                inboxPreview.push({
-                    id: msg.messageId,
-                    // Legacy Data Remediation: Messages written during the #10184/#10181 incident
-                    // window may lack a SENT_BY edge if the sender was identity-unbound.
-                    // This fallback ensures schema compliance. New writes enforce bind-identity discipline.
-                    from: msg.from || 'unknown',
-                    subject: msg.subject ? msg.subject.substring(0, 60) + (msg.subject.length > 60 ? '...' : '') : '',
-                    createdAt: msg.sentAt,
-                    priority: msg.priority
-                });
-            }
-        }
+        const inboxPreview = inboxResult.messages.map(msg => ({
+            id: msg.messageId,
+            // Legacy Data Remediation: Messages written during the #10184/#10181 incident
+            // window may lack a SENT_BY edge if the sender was identity-unbound.
+            // This fallback ensures schema compliance. New writes enforce bind-identity discipline.
+            from: msg.from || 'unknown',
+            subject: msg.subject ? msg.subject.substring(0, 60) + (msg.subject.length > 60 ? '...' : '') : '',
+            createdAt: msg.sentAt,
+            priority: msg.priority
+        }));
 
         const outboxPreview = outboxResult.messages.map(msg => ({
             id: msg.messageId,

--- a/learn/agentos/ConceptOntology.md
+++ b/learn/agentos/ConceptOntology.md
@@ -117,6 +117,41 @@ Each line in `nodes.jsonl` is a JSON object:
 > Existing committed ontology nodes start with explicit `verifiedAt: null` so the first
 > source-grounding pass can be queried directly from the data file.
 
+## Auto-Extracted Concept Provenance
+
+Concepts in the Native Edge Graph arrive via two distinct paths, and consumers MUST be able to distinguish them when scoring, filtering, or ranking results.
+
+| Path | Trigger | Node property | Edge weight |
+|------|---------|---------------|-------------|
+| **Manual / curated** | Operator or agent calls `addMessage({taggedConcepts: [...]})` (or any other concept-tagging API) with explicit concept IDs | absent (concept node may pre-exist with no `auto_extracted` flag) | `1.0` |
+| **Auto-extracted** | `MailboxService.addMessage` runs `SemanticGraphExtractor.extractMessageConcepts(body)` as a fire-and-forget post-write; LLM-derived `CONCEPT:*` / `CLASS:*` IDs are upserted with `properties.auto_extracted: true` | `properties.auto_extracted = true` on the CONCEPT or CLASS node when the node is freshly created by this path | `0.8` on the `TAGGED_CONCEPT` edge |
+
+### Write Path
+
+1. `MailboxService.addMessage` persists the MESSAGE node + recipient edges.
+2. Synchronously links manual `taggedConcepts` with `TAGGED_CONCEPT` weight `1.0`.
+3. Asynchronously fires `SemanticGraphExtractor.extractMessageConcepts(bodyText)` — LLM call against the OpenAI-compatible chat provider. Returns 1-5 inferred concept IDs.
+4. For each extracted ID: upsert the concept node with `properties.auto_extracted: true` (only when freshly created — pre-existing nodes are NOT re-stamped), then link with `TAGGED_CONCEPT` weight `0.8`.
+
+The two paths emit the **same edge type** (`TAGGED_CONCEPT`); provenance lives in the edge weight + the node-side `auto_extracted` flag.
+
+### Read-Time Consumer Pattern
+
+Downstream consumers (DreamService topology synthesis, Librarian sub-agent traversal, future GraphRAG query layer) reading concept nodes from the graph SHOULD inspect both signals when ranking or filtering:
+
+- **For ranking** — weight curated concepts higher than auto-extracted (use the edge weight directly: 1.0 vs 0.8 is already calibrated for this).
+- **For filtering** — to exclude auto-extracted entirely, filter `node.properties.auto_extracted !== true`. To include only auto-extracted (e.g., to audit LLM output), filter `node.properties.auto_extracted === true`.
+- **For provenance audits** — `auto_extracted: true` is the durable signal that the concept entered the graph via LLM inference rather than human/agent curation. Useful for post-incident reasoning about graph noise.
+
+### Edge-Weight Convention Rationale
+
+The 0.8 / 1.0 split is deliberate: a TAGGED_CONCEPT edge from a curated source is **20% stronger** than an auto-extracted edge with the same source MESSAGE node. This calibration matches the operator-observed truthfulness gap between LLM concept inference (high recall, moderate precision) and human/agent curation (lower recall, near-perfect precision).
+
+Consumers SHOULD prefer reading the edge weight over the node-side flag when both are available, since edge weights propagate naturally through graph traversal scoring (vs the flag requiring an extra lookup at scoring time). Reserve the node-side flag for filtering and provenance audits.
+
+> [!IMPORTANT]
+> **Pre-existing concept nodes retain their original provenance.** When `extractMessageConcepts` returns a `CONCEPT:*` / `CLASS:*` ID that already exists in the graph (e.g., a high-tier concept seeded in `nodes.jsonl`), the upsert path does NOT overwrite `properties.auto_extracted`. The flag is set only when the node is freshly created by the auto-extraction path. This preserves curated concepts' status as authoritative even when they're subsequently mentioned by LLM-extracted MESSAGE bodies.
+
 ## Edge Schema
 
 Each line in `edges.jsonl` is a JSON object:

--- a/test/playwright/unit/ai/services/memory-core/MailboxService.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/MailboxService.spec.mjs
@@ -518,6 +518,93 @@ test.describe('Neo.ai.services.memory-core.MailboxService', () => {
         }
     });
 
+    test('#10180 AC4: countMessages matches listMessages.length for small inbox', async () => {
+        // Pin equivalence between the direct-SQL count and the in-memory listMessages
+        // length so future drift between the two paths surfaces as a test failure.
+        await RequestContextService.run({ agentIdentityNodeId: '@bob' }, async () => {
+            await PermissionService.grantPermission({ to: '@alice', scope: 'CAN_REPLY_TO' });
+        });
+
+        await RequestContextService.run({ agentIdentityNodeId: '@alice' }, async () => {
+            await MailboxService.addMessage({ to: '@bob', subject: 'count-1', body: '...' });
+            await MailboxService.addMessage({ to: '@bob', subject: 'count-2', body: '...' });
+            await MailboxService.addMessage({ to: '@bob', subject: 'count-3', body: '...' });
+        });
+
+        await RequestContextService.run({ agentIdentityNodeId: '@bob' }, async () => {
+            const list  = await MailboxService.listMessages({ box: 'inbox', status: 'unread' });
+            const count = await MailboxService.countMessages({ box: 'inbox', status: 'unread' });
+
+            expect(count.count).toBe(list.messages.length);
+            expect(count.count).toBe(3);
+
+            const allList  = await MailboxService.listMessages({ box: 'inbox', status: 'all' });
+            const allCount = await MailboxService.countMessages({ box: 'inbox', status: 'all' });
+            expect(allCount.count).toBe(allList.messages.length);
+        });
+    });
+
+    test('#10180 AC3: countMessages returns correct value for inbox depth > 100 (no silent cap)', async () => {
+        // Regression for the original 100-cap proxy pattern: getHealthcheckPreview
+        // previously fetched `listMessages({limit: 100})` and counted unreads. An inbox
+        // with > 100 unread messages would silently under-report. countMessages must
+        // return the true value via direct SQL.
+        const RECIPIENT = '@countmany-bob';
+        const SENDER    = '@countmany-alice';
+        const TARGET_DEPTH = 150;
+
+        // Seed agent identities matching the production convention.
+        GraphService.upsertNode({ id: RECIPIENT, type: 'AgentIdentity', name: 'CountManyBob',   properties: { accountType: 'agent' } });
+        GraphService.upsertNode({ id: SENDER,    type: 'AgentIdentity', name: 'CountManyAlice', properties: { accountType: 'agent' } });
+
+        await RequestContextService.run({ agentIdentityNodeId: RECIPIENT }, async () => {
+            await PermissionService.grantPermission({ to: SENDER, scope: 'CAN_REPLY_TO' });
+        });
+
+        await RequestContextService.run({ agentIdentityNodeId: SENDER }, async () => {
+            for (let i = 0; i < TARGET_DEPTH; i++) {
+                await MailboxService.addMessage({ to: RECIPIENT, subject: `bulk-${i}`, body: '...' });
+            }
+        });
+
+        await RequestContextService.run({ agentIdentityNodeId: RECIPIENT }, async () => {
+            const result = await MailboxService.countMessages({ box: 'inbox', status: 'unread' });
+            expect(result.count).toBe(TARGET_DEPTH);
+            expect(result.count).toBeGreaterThan(100); // explicit anti-regression assertion vs old proxy
+
+            // getHealthcheckPreview now uses countMessages — should also be uncapped.
+            const preview = await MailboxService.getHealthcheckPreview();
+            expect(preview.unreadCount).toBe(TARGET_DEPTH);
+            expect(preview.inbox.length).toBe(3); // preview-surface limit unchanged
+        });
+    });
+
+    test('#10180 AC1: countMessages outbox counts SENT_BY edges from caller', async () => {
+        await RequestContextService.run({ agentIdentityNodeId: '@bob' }, async () => {
+            await PermissionService.grantPermission({ to: '@alice', scope: 'CAN_REPLY_TO' });
+        });
+
+        await RequestContextService.run({ agentIdentityNodeId: '@alice' }, async () => {
+            await MailboxService.addMessage({ to: '@bob', subject: 'out-1', body: '...' });
+            await MailboxService.addMessage({ to: '@bob', subject: 'out-2', body: '...' });
+        });
+
+        await RequestContextService.run({ agentIdentityNodeId: '@alice' }, async () => {
+            const outbox = await MailboxService.countMessages({ box: 'outbox' });
+            expect(outbox.count).toBe(2);
+        });
+
+        await RequestContextService.run({ agentIdentityNodeId: '@bob' }, async () => {
+            const outbox = await MailboxService.countMessages({ box: 'outbox' });
+            expect(outbox.count).toBe(0); // Bob hasn't sent any
+        });
+    });
+
+    test('#10180 AC1: countMessages throws on unbound identity', async () => {
+        await expect(MailboxService.countMessages({ box: 'inbox', status: 'unread' }))
+            .rejects.toThrow(/no agent identity context bound/);
+    });
+
     test('getHealthcheckPreview returns formatted mailbox metrics', async () => {
         await RequestContextService.run({ agentIdentityNodeId: '@bob' }, async () => {
             await PermissionService.grantPermission({ to: '@alice', scope: 'CAN_REPLY_TO' });

--- a/test/playwright/unit/ai/services/memory-core/MailboxService.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/MailboxService.spec.mjs
@@ -605,6 +605,26 @@ test.describe('Neo.ai.services.memory-core.MailboxService', () => {
             .rejects.toThrow(/no agent identity context bound/);
     });
 
+    test('#10180 cycle-1 hardening: countMessages rejects unsupported box values explicitly', async () => {
+        // Per @neo-gpt review on PR #11528 cycle 1: previously, `if (box === 'outbox') ... else ...`
+        // silently aliased `box='all'` (deferred per PR body) AND any typo to the inbox query —
+        // returning a plausible but partial-result count. This regression pins fail-fast semantics
+        // on unsupported enums so callers see the deferred-vs-implemented boundary at call-time
+        // rather than receiving silent partial-results.
+        await RequestContextService.run({ agentIdentityNodeId: '@bob' }, async () => {
+            await expect(MailboxService.countMessages({ box: 'all' }))
+                .rejects.toThrow(/unsupported box value 'all'/);
+            await expect(MailboxService.countMessages({ box: 'unknown-typo' }))
+                .rejects.toThrow(/unsupported box value 'unknown-typo'/);
+            await expect(MailboxService.countMessages({ box: '' }))
+                .rejects.toThrow(/unsupported box value/);
+
+            // Sanity: supported values still work after the guard
+            await expect(MailboxService.countMessages({ box: 'inbox' })).resolves.toMatchObject({ count: expect.any(Number) });
+            await expect(MailboxService.countMessages({ box: 'outbox' })).resolves.toMatchObject({ count: expect.any(Number) });
+        });
+    });
+
     test('getHealthcheckPreview returns formatted mailbox metrics', async () => {
         await RequestContextService.run({ agentIdentityNodeId: '@bob' }, async () => {
             await PermissionService.grantPermission({ to: '@alice', scope: 'CAN_REPLY_TO' });


### PR DESCRIPTION
Authored by Claude Opus 4.7 (Claude Code). Session 39eee906-3fd4-424f-9348-828b46ece38c.

FAIR-band: in-band [12/30 — current author count over last 30 merged]. Lane pickup is post-handoff productivity during #11527 review wait window; ticket was unassigned + premise-validated via direct V-B-A on current code state.

Resolves #10180

Mailbox polish on two adjacent surfaces: a new `countMessages` direct-SQL primitive that retires the silent 100-cap on `getHealthcheckPreview.unreadCount`, plus the previously-undocumented `auto_extracted` concept-provenance contract codified in `learn/agentos/ConceptOntology.md`.

Evidence: L2 (unit coverage 51/51 — 47 baseline + 4 new — including AC3 anti-regression with explicit `>100` assertion, AC4 countMessages-vs-listMessages parity, AC1 outbox SENT_BY counting, AC1 unbound-identity error path). No L3/L4 residuals — the surfaces are fully covered by unit tests against an isolated SQLite tmp file; no runtime-host effect requires operator validation.

## Deltas from ticket

- **File paths in the original ticket body are stale.** Ticket cited `ai/mcp/server/memory-core/services/MailboxService.mjs`; the service moved to `ai/services/memory-core/MailboxService.mjs` via PR #11224 (memory-core flat SDK migration). Implementation here uses the current path; V-B-A confirmed the premise still holds (100-cap at line 920-927; ConceptOntology.md still silent on `auto_extracted`).
- **`countMessages` `box='all'` deferred.** Ticket signature implies `{box}` accepts inbox + outbox + all. This PR ships inbox + outbox only — both are the immediate consumers; `box='all'` adds UNION complexity for no current caller. Trivially additive in a follow-up if needed.

## What shipped

**`MailboxService.countMessages({box, status, to, fromIdentity?})` (new method):**

- Inbox path: 3-way UNION mirroring `MemoryService.buildMailboxDelta`'s unread-message taxonomy — SENT_TO me direct DMs + DELIVERED_TO me per-recipient broadcasts (#11029) + SENT_TO AGENT:* legacy fallback (only when no DELIVERED_TO edges exist).
- Outbox path: SENT_BY edges from caller's identity.
- `status='unread'|'read'|'all'` filter dynamically composes the `readAt` clause; outbox status is documented as a no-op (no unified message-level state for outbox).
- `fromIdentity` filters inbox by SENT_BY sender via correlated subquery; outbox ignores (no inverse-of-sender semantic).
- Permission checked via `CAN_READ_INBOX_OF` mirroring `listMessages`.
- Non-fatal degradation pattern from `buildMailboxDelta` — returns `{count: 0}` on SQL failure rather than throwing during healthcheck-class call sites.

**`getHealthcheckPreview` refactor:**

- `unreadCount` now sourced from `countMessages({box: 'inbox', status: 'unread'})` — direct-SQL, no cap.
- Inbox + outbox preview surfaces use `listMessages({limit: 3})` matching the preview-surface size (changed from `limit: 100` proxy → `limit: 3` true-purpose).
- The previously-implicit cap on `unreadCount` is retired.

**`learn/agentos/ConceptOntology.md` § Auto-Extracted Concept Provenance (new section):**

- Two-path table: manual/curated (weight 1.0, no flag) vs auto-extracted (weight 0.8, `properties.auto_extracted: true` on fresh-create)
- Write path: `MailboxService.addMessage` → `SemanticGraphExtractor.extractMessageConcepts` fire-and-forget LLM call → upsert + link
- Read-time consumer pattern: ranking (use edge weight), filtering (use node flag), provenance audits (use node flag)
- IMPORTANT callout: pre-existing concept nodes retain their curated authority — the flag is set only on fresh-create.

**`SemanticGraphExtractor.extractMessageConcepts` JSDoc:**

- Extended with `@see learn/agentos/ConceptOntology.md § Auto-Extracted Concept Provenance` + `@see ai/services/memory-core/MailboxService.mjs#addMessage` (the fire-and-forget caller) — completes the bi-directional anchor between code and substrate docs.

## Test Evidence

```
npm run test-unit -- test/playwright/unit/ai/services/memory-core/MailboxService.spec.mjs
# 51 passed (47 baseline + 4 new)
```

New test coverage:
- AC4 — `countMessages` matches `listMessages.length` for small inbox (3-msg parity test) including `status='unread'` and `status='all'`.
- AC3 — inbox depth = 150: `countMessages` returns 150 (not 100); `getHealthcheckPreview.unreadCount` also returns 150 (not capped); preview surface still limited to 3 items. Explicit `>100` anti-regression assertion.
- AC1 — outbox SENT_BY counting: `@alice` shows count=2; `@bob` (who received but never sent) shows count=0.
- AC1 — unbound identity: `countMessages` throws `no agent identity context bound` (matches `listMessages` error contract).

## Post-Merge Validation

None — fully covered by unit tests against isolated SQLite tmp file; no host-runtime effect requires operator validation.

## Commits

- `ac9901671` — `feat(memory-core): countMessages primitive + concept provenance docs (#10180)` (rebased post-push onto fresh `origin/dev` to absorb `3fc6e3f66` data-sync commit; rebase clean)

## Related

- Parent: #10139 Mailbox A2A primitive (not labeled `epic`, no epic-review pre-requisite per ticket-intake workflow §2)
- Builds on: #10178 (`buildMailboxDelta` direct-SQL pattern template)
- Surfaced by: #10175 review (auto_extracted `[KB_GAP]`) + #10177 review (100-cap observation)
- Adjacent: #10172 node-ID case canonicalization (CONCEPT:/CLASS: case coordination — ticket cross-references this one)
- Substrate-shift context: #11224 (memory-core flat SDK migration moved MailboxService path)