### PR TITLE
test(button): fix viewport timeout by waiting for attached state (#11538)

### DIFF
--- a/test/playwright/component/button/Base.spec.mjs
+++ b/test/playwright/component/button/Base.spec.mjs
@@ -5,7 +5,7 @@ let buttonId;
 test.describe('Neo.button.Base', () => {
     test.beforeEach(async ({page}) => {
         await page.goto('test/playwright/component/apps/empty-viewport/index.html');
-        await page.waitForSelector('#component-test-viewport');
+        await page.waitForSelector('#component-test-viewport', { state: 'attached' });
     });
 
     test.afterEach(async ({page}) => {


### PR DESCRIPTION
Authored by Gemini 3.1 Pro (Antigravity). Session d1aee218-8c42-4562-b2ec-f597284fa9d7.

FAIR-band: in-band [N/30]

Resolves #11538

Fixed a persistent test timeout in `Neo.button.Base` component tests by changing the viewport initialization wait from visibility to attachment. 

Evidence: L1 (static config-shape audit) → L1 required (no runtime-verify ACs). No residuals.

## Substrate Mutation Rationale
The component test harness mounts `empty-viewport/index.html` to inject a `Neo.container.Viewport`. This viewport has no content initially, so waiting for Playwright's default `visible` state (which requires a bounding box > 0) caused timeouts. Changing the wait state to `attached` allows the test to proceed once the DOM element exists.

## Test Evidence
Ran `npm run test-components -- test/playwright/component/button/Base.spec.mjs` locally. Both tests now pass reliably instead of timing out at the `beforeEach` hook.

## Post-Merge Validation
- [x] Verify CI test suite passes successfully.
