### PR TITLE
fix(devindex): reconcile rich-user tracker orphans (#11516)

### DIFF
--- a/apps/devindex/services/Cleanup.mjs
+++ b/apps/devindex/services/Cleanup.mjs
@@ -1,5 +1,6 @@
 import Base from '../../../src/core/Base.mjs';
 import config from './config.mjs';
+import GitHub from './GitHub.mjs';
 import Storage from './Storage.mjs';
 
 /**
@@ -126,6 +127,15 @@ class Cleanup extends Base {
             return true;
         });
 
+        const reconcileStats = await this.reconcileRichUsersWithTracker({
+            users,
+            tracker,
+            failed,
+            blocklist
+        });
+
+        users = reconcileStats.users;
+
         // Create a Set for O(1) lookups
         const userLogins = new Set(users.map(u => u.l.toLowerCase()));
 
@@ -187,6 +197,109 @@ class Cleanup extends Base {
         console.log(`[Cleanup] Complete.`);
         console.log(`  Users: ${initialUserCount} -> ${users.length} (-${initialUserCount - users.length})`);
         console.log(`  Tracker: ${initialTrackerCount} -> ${tracker.length} (-${initialTrackerCount - tracker.length})`);
+    }
+
+    /**
+     * Reconciles rich profile records that are missing from the tracker queue.
+     *
+     * @summary Restores refresh scheduling for rich users without blindly requeueing stale logins.
+     * The stored immutable GitHub database ID is resolved first; same-login users are restored to
+     * the tracker, renamed users are migrated to the current login, and unresolved IDs are pruned.
+     * Transient resolver failures intentionally bubble up so data-sync cannot silently corrupt
+     * identity-sensitive records.
+     * @param {Object} options
+     * @param {Object[]} options.users Rich user records from `users.jsonl`.
+     * @param {Object[]} options.tracker Tracker entries from `tracker.json`.
+     * @param {Map<String, String>} options.failed Failed-user penalty-box map.
+     * @param {Set<String>} options.blocklist Blocklisted login set.
+     * @returns {Promise<Object>} Reconciliation stats and the possibly updated `users` array.
+     */
+    async reconcileRichUsersWithTracker({users, tracker, failed, blocklist}) {
+        const trackerLogins = new Set(tracker.map(t => t.login.toLowerCase())),
+              usersByLogin  = new Map(users.map(u => [u.l.toLowerCase(), u])),
+              prunedLogins  = new Set(),
+              stats         = {
+                  users,
+                  richOrphans      : 0,
+                  restored         : 0,
+                  renamed          : 0,
+                  prunedMissingUser: 0,
+                  prunedConflicts  : 0
+              };
+
+        for (const user of users) {
+            const lowerLogin = user.l.toLowerCase();
+
+            if (trackerLogins.has(lowerLogin) || blocklist.has(lowerLogin) || prunedLogins.has(lowerLogin)) {
+                continue;
+            }
+
+            stats.richOrphans++;
+
+            const currentLogin = await GitHub.getLoginByDatabaseId(user.i);
+
+            if (!currentLogin) {
+                console.log(`[Cleanup] Pruning rich-user orphan with unresolved GitHub id: ${user.l} (${user.i})`);
+                prunedLogins.add(lowerLogin);
+                failed.delete(lowerLogin);
+                stats.prunedMissingUser++;
+                continue;
+            }
+
+            const currentLower = currentLogin.toLowerCase();
+
+            if (currentLower === lowerLogin) {
+                tracker.push({login: user.l, lastUpdate: user.lu || null});
+                trackerLogins.add(lowerLogin);
+                failed.delete(lowerLogin);
+                stats.restored++;
+                console.log(`[Cleanup] Restored rich-user orphan to tracker: ${user.l}`);
+                continue;
+            }
+
+            const existingCurrentUser = usersByLogin.get(currentLower);
+
+            if (existingCurrentUser && existingCurrentUser !== user) {
+                console.log(`[Cleanup] Pruning stale rich-user orphan after rename conflict: ${user.l} -> ${currentLogin}`);
+                prunedLogins.add(lowerLogin);
+                failed.delete(lowerLogin);
+                stats.prunedConflicts++;
+
+                if (!trackerLogins.has(currentLower)) {
+                    tracker.push({login: existingCurrentUser.l, lastUpdate: existingCurrentUser.lu || null});
+                    trackerLogins.add(currentLower);
+                }
+                continue;
+            }
+
+            console.log(`[Cleanup] Migrating rich-user orphan after rename: ${user.l} -> ${currentLogin}`);
+            usersByLogin.delete(lowerLogin);
+            user.l = currentLogin;
+            usersByLogin.set(currentLower, user);
+
+            if (!trackerLogins.has(currentLower)) {
+                tracker.push({login: currentLogin, lastUpdate: user.lu || null});
+                trackerLogins.add(currentLower);
+            }
+
+            failed.delete(lowerLogin);
+            failed.delete(currentLower);
+            stats.renamed++;
+        }
+
+        if (prunedLogins.size > 0) {
+            stats.users = users.filter(u => !prunedLogins.has(u.l.toLowerCase()));
+        }
+
+        if (stats.richOrphans > 0) {
+            console.log(
+                `[Cleanup] Rich-user tracker reconciliation: ` +
+                `${stats.richOrphans} orphan(s), ${stats.restored} restored, ` +
+                `${stats.renamed} renamed, ${stats.prunedMissingUser + stats.prunedConflicts} pruned.`
+            );
+        }
+
+        return stats;
     }
 }
 

--- a/learn/guides/devindex/data-factory/DataHygiene.md
+++ b/learn/guides/devindex/data-factory/DataHygiene.md
@@ -23,7 +23,10 @@ Conversely, the `allowlist.json` provides an absolute protective barrier. It ser
 *   **Protection:** If a user is on the allowlist, they are completely exempt from Threshold Pruning. They will remain in the index even if they have 0 contributions.
 *   **Resurrection:** Before pruning begins, the service cross-references the allowlist against the tracker queue. If an allowlisted VIP is somehow missing from the tracker, the Cleanup service will instantly "resurrect" them, injecting a new pending entry (`lastUpdate: null`) into the queue to ensure they are scheduled for the next Updater run.
 
-### 4. The 30-Day "Penalty Box" TTL
+### 4. Rich-User Tracker Reconciliation
+Cleanup also audits rich `users.jsonl` profiles that are missing from `tracker.json`. It resolves each stored immutable GitHub database ID before taking action: same-login records are restored to the tracker, renamed accounts are migrated to their current login, unresolved IDs are pruned, and transient resolver failures abort the run rather than blindly requeueing a stale login.
+
+### 5. The 30-Day "Penalty Box" TTL
 When the Updater encounters an error analyzing a user (e.g., a GraphQL timeout or a 404), that user is placed in `failed.json`—the "Penalty Box."
 
 Users in the Penalty Box are temporarily protected from being completely pruned from the tracker, giving them a chance to be successfully processed in a future run. However, the Cleanup service enforces a strict **30-Day Time-To-Live (TTL)**. 
@@ -45,7 +48,7 @@ If a user remains in a failed state for more than 30 days, their protection is r
 
 **Rationale & The "Right to be Forgotten":** With a 50,000 user cap and an hourly update limit of 800, the pipeline completes a full cycle of the entire index approximately every 3 days. A 30-day retention period means a user has persistently failed roughly 10 consecutive update attempts (each of which internally utilizes multiple API retries). After a month of continuous failures, it is safe to assume the profile has either been permanently banned by GitHub or the user has explicitly deleted their own account. Automatically purging these records aligns with data minimization principles and proactively respects a user's right to be forgotten if they have chosen to remove their presence from the platform.
 
-### 5. Canonical Sorting
+### 6. Canonical Sorting
 The final step of the Cleanup routine is purely for Developer Experience (DX) and Git repository health. 
 
 When JSON files are modified by asynchronous services, the order of keys or array elements is often unpredictable. If committed as-is, this creates massive, noisy Git diffs, making code review impossible.

--- a/test/playwright/unit/app/devindex/CleanupReconciliation.spec.mjs
+++ b/test/playwright/unit/app/devindex/CleanupReconciliation.spec.mjs
@@ -1,0 +1,148 @@
+import {setup} from '../../../setup.mjs';
+
+const appName = 'DevIndexCleanupReconciliationTest';
+
+setup({
+    appConfig: {
+        name: appName
+    }
+});
+
+import {test, expect} from '@playwright/test';
+import Neo            from '../../../../../src/Neo.mjs';
+import * as core      from '../../../../../src/core/_export.mjs';
+import Cleanup        from '../../../../../apps/devindex/services/Cleanup.mjs';
+import GitHub         from '../../../../../apps/devindex/services/GitHub.mjs';
+
+test.describe('DevIndex Cleanup rich-user tracker reconciliation', () => {
+    let originalGetLoginByDatabaseId;
+
+    test.beforeEach(() => {
+        originalGetLoginByDatabaseId = GitHub.getLoginByDatabaseId;
+    });
+
+    test.afterEach(() => {
+        GitHub.getLoginByDatabaseId = originalGetLoginByDatabaseId;
+    });
+
+    test('restores same-login rich-user orphans to the tracker', async () => {
+        const users = [{
+            l : 'SameLogin',
+            i : 12345,
+            lu: '2026-05-17T10:00:00.000Z',
+            tc: 5000
+        }];
+
+        const tracker = [];
+        const failed  = new Map([['samelogin', '2026-05-16T10:00:00.000Z']]);
+
+        GitHub.getLoginByDatabaseId = async () => 'SameLogin';
+
+        const stats = await Cleanup.reconcileRichUsersWithTracker({
+            users,
+            tracker,
+            failed,
+            blocklist: new Set()
+        });
+
+        expect(stats).toMatchObject({
+            richOrphans      : 1,
+            restored         : 1,
+            renamed          : 0,
+            prunedMissingUser: 0,
+            prunedConflicts  : 0
+        });
+        expect(stats.users).toEqual(users);
+        expect(tracker).toEqual([{login: 'SameLogin', lastUpdate: users[0].lu}]);
+        expect(failed.has('samelogin')).toBe(false);
+    });
+
+    test('migrates renamed rich-user orphans without requeueing stale logins', async () => {
+        const users = [{
+            l : '0xBigBoss',
+            i : 95193764,
+            lu: '2026-05-08T15:18:19.485Z',
+            tc: 17244
+        }];
+
+        const tracker = [];
+        const failed  = new Map();
+
+        GitHub.getLoginByDatabaseId = async () => 'alleneubank';
+
+        const stats = await Cleanup.reconcileRichUsersWithTracker({
+            users,
+            tracker,
+            failed,
+            blocklist: new Set()
+        });
+
+        expect(stats).toMatchObject({
+            richOrphans      : 1,
+            restored         : 0,
+            renamed          : 1,
+            prunedMissingUser: 0,
+            prunedConflicts  : 0
+        });
+        expect(stats.users).toHaveLength(1);
+        expect(stats.users[0]).toMatchObject({
+            l : 'alleneubank',
+            i : 95193764,
+            lu: '2026-05-08T15:18:19.485Z'
+        });
+        expect(tracker).toEqual([{login: 'alleneubank', lastUpdate: users[0].lu}]);
+        expect(tracker.some(entry => entry.login === '0xBigBoss')).toBe(false);
+    });
+
+    test('prunes rich-user orphans whose stored GitHub id no longer resolves', async () => {
+        const users = [{
+            l : 'DeletedUser',
+            i : 67890,
+            lu: '2026-05-01T10:00:00.000Z',
+            tc: 4000
+        }];
+
+        const tracker = [];
+        const failed  = new Map([['deleteduser', '2026-05-16T10:00:00.000Z']]);
+
+        GitHub.getLoginByDatabaseId = async () => null;
+
+        const stats = await Cleanup.reconcileRichUsersWithTracker({
+            users,
+            tracker,
+            failed,
+            blocklist: new Set()
+        });
+
+        expect(stats).toMatchObject({
+            richOrphans      : 1,
+            restored         : 0,
+            renamed          : 0,
+            prunedMissingUser: 1,
+            prunedConflicts  : 0
+        });
+        expect(stats.users).toEqual([]);
+        expect(tracker).toEqual([]);
+        expect(failed.has('deleteduser')).toBe(false);
+    });
+
+    test('rethrows transient resolver failures instead of blind requeueing', async () => {
+        const users = [{
+            l : 'TransientUser',
+            i : 24680,
+            lu: '2026-05-01T10:00:00.000Z',
+            tc: 4000
+        }];
+
+        GitHub.getLoginByDatabaseId = async () => {
+            throw new Error('REST Error: 502 Bad Gateway');
+        };
+
+        await expect(Cleanup.reconcileRichUsersWithTracker({
+            users,
+            tracker  : [],
+            failed   : new Map(),
+            blocklist: new Set()
+        })).rejects.toThrow('REST Error: 502 Bad Gateway');
+    });
+});


### PR DESCRIPTION
Resolves #11516

Authored by GPT-5 (Codex Desktop). Session 6e5b995a-c68e-4179-840c-a4cc48d449da.

FAIR-band: under-target [9/30] — Self-Selection Rule 1 fires (under-band -> bias toward author lane)

Evidence: L2 (focused unit tests + live REST spot checks + offline current-data audit) -> L3 required (post-merge data-sync cleanup against canonical data). Residual: post-merge cleanup/audit checklist below.

Adds an identity-aware Cleanup reconciliation pass for rich DevIndex profiles that are missing from `tracker.json`. The repair resolves the stored immutable GitHub database id before acting: same-login records are restored to the tracker, renamed accounts migrate to the current login, unresolved IDs are pruned, and transient resolver failures abort instead of blind-requeueing stale logins.

## Deltas from ticket
- #11517 and #11522 already landed the database-id resolver and rename-guard slices; this PR only implements the remaining reconciliation/repair path.
- No `apps/devindex/resources/data/*` files are changed in this PR. The canonical data repair should happen via the next post-merge data-sync cleanup run, or by manually running `npm run devindex:cleanup` on fresh `dev`.
- Current pre-repair audit on this branch: `users.jsonl=50000`, `tracker.json=49380`, `rich-user orphans=620`, `tracker-only=0`.
- Live spot check preserved from intake: `GET /user/95193764` resolves to `alleneubank`; `GET /users/0xBigBoss` resolves to a different account id `283503690`.

## Test Evidence
- `git diff --cached --check` passed before commit.
- `git diff --check` passed after commit.
- `npm run test-unit -- test/playwright/unit/app/devindex/CleanupReconciliation.spec.mjs test/playwright/unit/app/devindex/GitHubService.spec.mjs test/playwright/unit/app/devindex/UpdaterRenameRecovery.spec.mjs` -> 9 passed.
- Live V-B-A: #11516 is open, assigned to @neo-gpt, Project 12 status In Progress; no open PR existed before this one.

## Post-Merge Validation
- [ ] Let the scheduled DevIndex data-sync cleanup run on `dev`, or manually run `npm run devindex:cleanup` on fresh `dev`.
- [ ] Re-run the audit and record `users.jsonl`, `tracker.json`, rich-user orphan count, and tracker-only count.
- [ ] Confirm the `0xBigBoss` / `alleneubank` class is repaired without requeueing stale `0xBigBoss` under the wrong account identity.
- [ ] Comment on #10117 with the final audit and explicit close / keep-open recommendation.

## Commit
- `96210261f` — `fix(devindex): reconcile rich-user tracker orphans (#11516)`

## Related
- #10117
- #9137