### PR TITLE
fix(github-workflow): sync closed + closedAt to Discussion frontmatter (#11554)

### DIFF
--- a/ai/services/github-workflow/sync/DiscussionSyncer.mjs
+++ b/ai/services/github-workflow/sync/DiscussionSyncer.mjs
@@ -244,7 +244,9 @@ class DiscussionSyncer extends Base {
                     author     : discussion.author?.login || 'unknown',
                     category   : discussion.category?.name || 'Uncategorized',
                     createdAt  : discussion.createdAt,
-                    updatedAt  : discussion.updatedAt
+                    updatedAt  : discussion.updatedAt,
+                    closed     : discussion.closed,
+                    closedAt   : discussion.closedAt
                 };
 
                 let body = discussion.body || '';

--- a/test/playwright/unit/ai/services/github-workflow/DiscussionSyncer.spec.mjs
+++ b/test/playwright/unit/ai/services/github-workflow/DiscussionSyncer.spec.mjs
@@ -95,6 +95,10 @@ test.describe('Neo.ai.services.github-workflow.sync.DiscussionSyncer', () => {
             chunkNumber: 1,
             path: path.join('discussions', 'chunk-1', 'discussion-24001.md')
         });
+
+        const content = await fs.readFile(targetPath, 'utf8');
+        expect(content).toMatch(/^closed: false$/m);
+        expect(content).toMatch(/^closedAt: null$/m);
     });
 
     test('writes archived discussions through contentPath and maintains _index.json', async () => {
@@ -127,6 +131,10 @@ test.describe('Neo.ai.services.github-workflow.sync.DiscussionSyncer', () => {
             chunkNumber: 1,
             path: path.join('archive', 'discussions', 'v13.0.0', 'chunk-1', 'discussion-24002.md')
         });
+
+        const content = await fs.readFile(targetPath, 'utf8');
+        expect(content).toMatch(/^closed: true$/m);
+        expect(content).toMatch(/^closedAt: '2026-05-01T00:00:00Z'$/m);
     });
 });
 


### PR DESCRIPTION
Authored by Claude Opus 4.7 (Claude Code). Session 39eee906-3fd4-424f-9348-828b46ece38c.

FAIR-band: in-band [~12/30]

Resolves #11554

Adds `closed` + `closedAt` to the frontmatter object emitted by `DiscussionSyncer` so synced Discussion markdown files can signal open/closed state without requiring a GraphQL re-query. The fields are already fetched by the existing GraphQL query — the fix is purely at the frontmatter-object construction step.

Evidence: L2 (unit tests pass for both active and archived discussion fixtures) → L2 required (synced-output observable assertion). No residuals.

## Test Evidence

- `npm run test-unit -- test/playwright/unit/ai/services/github-workflow/DiscussionSyncer.spec.mjs` → 2/2 pass (581ms)
- Both tests assert the new frontmatter fields via regex on the serialized markdown:
  - Active discussion (`closed: false`): asserts `closed: false` + `closedAt: null` in serialized output
  - Archived discussion (`closed: true`): asserts `closed: true` + `closedAt: '2026-05-01T00:00:00Z'`

## Post-Merge Validation

- [ ] Next hourly sync run regenerates `resources/content/discussions/**/discussion-*.md` files with the two new frontmatter fields populated.
- [ ] Sample close-target verification: `resources/content/discussions/chunk-1/discussion-10520.md` shows `closed: true` + `closedAt: '2026-04-30T19:51:34Z'` (the actual close time of Discussion #10520, used as the empirical anchor in the originating ticket).
- [ ] Future agent V-B-A on Discussion state can be answered via `view_file` / grep without GraphQL round-trip.

## Deltas from ticket

None. Implementation strictly matches the AC list:
- ✓ Frontmatter object includes `closed` + `closedAt` keys
- ✓ Unit test coverage in `DiscussionSyncer.spec.mjs` asserts the new fields
- ✓ Field naming aligns with GraphQL `closed` boolean (avoided unnecessary `state` enum that doesn't exist upstream — documented as Avoided Trap in ticket)
- Post-merge AC about sample-file verification is naturally observable after the next sync-pipeline run

## Avoided Traps

- **`state: open|closed`** — rejected. GraphQL's Discussion type has no `state` field; canonical shape is `closed` boolean.
- **GraphQL query modification** — not needed; both fields already fetched at `discussionQueries.mjs:82-83`.

@neo-gemini-3-1-pro requesting cross-family review — you have fresh context in the github-workflow substrate tonight (#11553 in flight).