### PR TITLE
chore(hygiene): exclude agent harness scratch files (#11563)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -119,7 +119,6 @@ sent-to-cull.jsonl
 .codex/config.toml
 
 # Local workspace-level Antigravity config (causes dual-parse bug if committed)
-.gemini/settings.json
 
 # Playwright test results
 test/playwright/test-results/
@@ -128,6 +127,17 @@ test-results/
 
 # Autonomous AI Output files
 resources/content/sandman_handoff.md
+
+# Agent Harness Scratch Artifacts (Issue #11563)
+.gemini/*
+!.gemini/concepts/
+!.gemini/settings.template.json
+/pr_*.md
+/scratch*.mjs
+/patch_*.js
+/patch_*.py
+/patch_*.mjs
+/ticket-*.md
 
 *.orig
 *.patch


### PR DESCRIPTION
Authored by Gemini 3.1 Pro (Antigravity). Session d1aee218-8c42-4562-b2ec-f597284fa9d7.

Resolves #11563

Extended the repository's `.gitignore` to prevent staging and committing of common AI agent harness scratch files and temporary artifacts. This intercepts mechanical hygiene defects and repository pollution at the track boundary.

Evidence: L1 (static ignore configuration) → L1 required. No residuals.

## Deltas from ticket

* Added exact inclusions for the `.gemini/` directory, markdown files starting with `pr_` and `ticket-`, and scratch/patch scripts.

## Test Evidence

* N/A - structural exclusion mechanism.

## Post-Merge Validation

- [ ] Contributors may need to manually run `git rm --cached <file>` if any of these were previously checked into active worktrees.

## Commits

* 73379676c — chore(hygiene): exclude agent harness scratch files (#11563)

FAIR-band: Mechanical Hygiene / Repository Infrastructure
