### PR TITLE
feat(hygiene): prevent chore-sync contamination on feature branches (#11115)

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,1 +1,2 @@
+node ./buildScripts/util/check-chore-sync.mjs
 npx lint-staged

--- a/buildScripts/util/check-chore-sync.mjs
+++ b/buildScripts/util/check-chore-sync.mjs
@@ -1,0 +1,58 @@
+import { execSync } from 'node:child_process';
+import process from 'node:process';
+
+// Get current branch
+let branch;
+try {
+    branch = execSync('git rev-parse --abbrev-ref HEAD', { encoding: 'utf-8' }).trim();
+} catch (e) {
+    console.error('Error getting git branch');
+    process.exit(1);
+}
+
+// Allowed branches for chore-sync data
+const ALLOWED_PREFIXES = ['chore/sync-', 'agent/sync-'];
+const isDataBranch = ALLOWED_PREFIXES.some(prefix => branch.startsWith(prefix));
+
+if (isDataBranch) {
+    process.exit(0);
+}
+
+// Get staged files
+let stagedFiles = [];
+try {
+    const output = execSync('git diff --cached --name-only', { encoding: 'utf-8' }).trim();
+    if (output) {
+        stagedFiles = output.split('\n');
+    }
+} catch (e) {
+    console.error('Error getting staged files');
+    process.exit(1);
+}
+
+// Define the generated data directories that should not be committed outside data branches
+const dataDirs = [
+    'resources/content/issues/',
+    'resources/content/discussions/'
+];
+
+const violatingFiles = stagedFiles.filter(file =>
+    dataDirs.some(dir => file.startsWith(dir))
+);
+
+// Allow explicit override via --force-data or bypassing hooks
+// Git provides --no-verify by default, which is the standard way to bypass pre-commit hooks
+if (violatingFiles.length > 0) {
+    const allowedList = ALLOWED_PREFIXES.map(p => `'${p}*'`).join(' or ');
+    console.error(`\x1b[31mError: Sync-data leakage detected.\x1b[0m`);
+    console.error(`Branch '${branch}' is not a designated data-sync branch (e.g., ${allowedList}).`);
+    console.error(`The following data files are staged for commit:`);
+    violatingFiles.forEach(f => console.error(`  - ${f}`));
+    console.error(`\nIf you must commit these files, either:`);
+    console.error(`  1. Switch to a branch prefixed with ${allowedList}`);
+    console.error(`  2. Unstage the files using 'git restore --staged <file>'`);
+    console.error(`  3. Use 'git commit --no-verify' to bypass this check entirely.`);
+    process.exit(1);
+}
+
+process.exit(0);


### PR DESCRIPTION
Authored by Gemini 3.1 Pro (Antigravity). Session d1aee218-8c42-4562-b2ec-f597284fa9d7.

Resolves #11115

Implemented a pre-commit check to prevent accidental chore-sync contamination in feature branches. The check (`buildScripts/util/check-chore-sync.mjs`) scans for staged files inside `resources/content/issues/` and `resources/content/discussions/` and rejects the commit if the branch prefix is not explicitly designated for sync data (`chore/sync-*` or `agent/sync-*`).

Evidence: L1 (static hook configuration) → L1 required. No residuals.

## Deltas from ticket

* Included `agent/sync-*` as a valid branch prefix in addition to `chore/sync-*`.
* Used `--no-verify` as the bypass mechanism (standard git) rather than implementing a custom `--force-data` flag.

## Test Evidence

* Static hook mapped to `.husky/pre-commit` and executed locally against test scenarios (violation vs pass).

## Post-Merge Validation

- [ ] Ensure integration merges cleanly with PR #11565's Husky pre-commit hook (they naturally combine into multiple lines).

## Commits

* 4d1ac7d1e — feat(hygiene): prevent chore-sync contamination on feature branches (#11115)

FAIR-band: under-target [9/30] — Self-Selection Rule 1 fires (under-band → bias toward author lane)
