### PR TITLE
fix(github-workflow): DiscussionSyncer + PullRequestSyncer metadata persistence + frontmatter integrity gate (#11573)

### DIFF
--- a/ai/services/github-workflow/SyncService.mjs
+++ b/ai/services/github-workflow/SyncService.mjs
@@ -80,7 +80,12 @@ class SyncService extends Base {
      * 4.  **Pushes** any local issue changes to GitHub via `IssueSyncer`.
      * 5.  **Pulls** the latest issue changes from GitHub via `IssueSyncer`.
      * 6.  Syncs release notes into local Markdown files via `ReleaseNotesSyncer`.
-     * 7.  Saves the updated, pruned metadata to disk via `MetadataManager`.
+     * 7.  Syncs discussions into local Markdown files via `DiscussionSyncer`.
+     * 8.  Syncs pull requests into local Markdown files via `PullRequestSyncer`.
+     * 9.  Carries `metadata.discussions` + `metadata.pulls` onto `newMetadata` so the
+     *     per-syncer cache populations survive `MetadataManager.save` (#11573).
+     * 10. Caches releases in `newMetadata` for next run.
+     * 11. Saves the updated, pruned metadata to disk via `MetadataManager`.
      * @returns {Promise<object>} A comprehensive object containing detailed statistics and timing
      * information about all operations performed during the sync.
      */
@@ -115,13 +120,27 @@ class SyncService extends Base {
             newMetadata.pushFailures = newMetadata.pushFailures.filter(failedId => !newMetadata.issues[failedId]);
         }
 
-        // Cached pulls are updated inline by PullRequestSyncer.
+        // 9. Carry over per-syncer metadata mutations (#11573).
+        //
+        // `newMetadata` is a fresh object constructed by `IssueSyncer.pullFromGitHub` carrying
+        // only `{issues, pushFailures, lastSync}`. `DiscussionSyncer.syncDiscussions(metadata)`
+        // and `PullRequestSyncer.syncPullRequests(metadata)` mutate the OLD `metadata` argument
+        // (their `metadata.discussions` / `metadata.pulls` populations). Without explicit
+        // carry-over, those mutations are dropped at `save(newMetadata)` and the on-disk diff
+        // cache stays empty after every sync.
+        //
+        // Empirical anchor: operator V-B-A 2026-05-18 caught 0/104 on-disk Discussion markdown
+        // files lacking `closed`/`closedAt` despite #11554 having merged the frontmatter-emit
+        // fix. The compounding factor — alongside stale MCP daemon code paths — was the
+        // metadata.discussions = {} state that prevented any cache reconciliation.
+        newMetadata.discussions = metadata.discussions || {};
+        newMetadata.pulls       = metadata.pulls       || {};
 
-        // 9. Cache releases in metadata for next run
+        // 10. Cache releases in metadata for next run.
         newMetadata.releases            = ReleaseNotesSyncer.releases;
         newMetadata.releasesLastFetched = new Date().toISOString();
 
-        // 10. Save metadata
+        // 11. Save metadata.
         await MetadataManager.save(newMetadata);
 
         if (aiConfig.pushToRepoAfterSync) {

--- a/ai/services/github-workflow/sync/DiscussionSyncer.mjs
+++ b/ai/services/github-workflow/sync/DiscussionSyncer.mjs
@@ -275,11 +275,15 @@ class DiscussionSyncer extends Base {
 
                 // #11573 integrity gate: empirically catches the failure mode where a stale
                 // MCP daemon code path silently drops frontmatter fields (e.g., #11554 shipped
-                // but old MCP processes kept writing pre-fix content). Logs at WARN so the
-                // signal surfaces in sync output without failing the run.
+                // but old MCP processes kept writing pre-fix content). THROWS on missing keys
+                // per the ticket Contract Ledger ("post-sync integrity assertion fails when a
+                // synced discussion lacks a required frontmatter key"). The existing
+                // per-discussion `try { ... } catch (e)` at the loop boundary (#312-314) catches
+                // the throw, logs the warning, and skips the write — broken-frontmatter files
+                // are NEVER persisted, but the sync run continues with other discussions.
                 const integrity = verifyDiscussionFrontmatter(content);
                 if (!integrity.ok) {
-                    logger.warn(`⚠️ Discussion #${discussion.number} serialized content missing required frontmatter keys: ${integrity.missing.join(', ')}. Likely stale MCP daemon code path; see #11573.`);
+                    throw new Error(`Discussion #${discussion.number} serialized content missing required frontmatter keys: ${integrity.missing.join(', ')}. ADR 0011 / #11573 contract violation — likely stale MCP daemon code path.`);
                 }
 
                 const currentHash = this.#calculateContentHash(content);

--- a/ai/services/github-workflow/sync/DiscussionSyncer.mjs
+++ b/ai/services/github-workflow/sync/DiscussionSyncer.mjs
@@ -13,6 +13,7 @@ import {
     createContentIndexEntry,
     updateContentIndex
 } from '../shared/contentIndex.mjs';
+import {verifyDiscussionFrontmatter} from './verifyFrontmatterIntegrity.mjs';
 
 const issueSyncConfig = aiConfig.issueSync;
 
@@ -271,6 +272,16 @@ class DiscussionSyncer extends Base {
 
                 // Gray-matter serialization
                 const content = matter.stringify(body, frontmatter);
+
+                // #11573 integrity gate: empirically catches the failure mode where a stale
+                // MCP daemon code path silently drops frontmatter fields (e.g., #11554 shipped
+                // but old MCP processes kept writing pre-fix content). Logs at WARN so the
+                // signal surfaces in sync output without failing the run.
+                const integrity = verifyDiscussionFrontmatter(content);
+                if (!integrity.ok) {
+                    logger.warn(`⚠️ Discussion #${discussion.number} serialized content missing required frontmatter keys: ${integrity.missing.join(', ')}. Likely stale MCP daemon code path; see #11573.`);
+                }
+
                 const currentHash = this.#calculateContentHash(content);
 
                 const cachedDiscussion = cachedDiscussions[discussion.number];

--- a/ai/services/github-workflow/sync/verifyFrontmatterIntegrity.mjs
+++ b/ai/services/github-workflow/sync/verifyFrontmatterIntegrity.mjs
@@ -1,0 +1,80 @@
+/**
+ * Pre-Flight (structural fast-path): authoring `ai/services/github-workflow/sync/verifyFrontmatterIntegrity.mjs`
+ * matches the small-utility-helper pattern of `ai/services/github-workflow/shared/contentPath.mjs` and
+ * `ai/services/github-workflow/shared/contentIndex.mjs` — pure-function modules consumed by the
+ * Discussion / Issue / PullRequest syncers; sibling-file-lift applies; no novel directory choice.
+ *
+ * @summary Validates that serialized markdown content carries the expected frontmatter keys
+ * before persistence (#11573). Closes the V-B-A gap where #11554's frontmatter-emit fix shipped
+ * with green CI but the production effect was never verified — 0 of 104 on-disk Discussion
+ * markdown files carried the new `closed` / `closedAt` keys despite the merged code path.
+ *
+ * Intentionally a pure helper:
+ * - No Neo runtime dependency (importable from any sync context, including non-Neo callers).
+ * - No filesystem IO (operates on the in-memory `content` string just before `fs.writeFile`).
+ * - No logger dependency (returns a structured result; caller decides log level + action).
+ *
+ * Cost model: one regex test per required key per discussion. For ~100 discussions × 5 keys
+ * the overhead is sub-millisecond — far below the network + serialize cost of a sync run.
+ *
+ * @see #11573 (this ticket) / #11554 (originally fixed frontmatter shape)
+ */
+
+/**
+ * Checks whether the serialized markdown `content` carries each of the required frontmatter keys.
+ * Match is anchored at line start (`^key:` with multi-line flag), matching `gray-matter`'s YAML
+ * serialization output (top-level keys are always rendered as `key: value` on their own line).
+ *
+ * @param {string} content The full serialized markdown (frontmatter + body), as produced by
+ *                         `matter.stringify(body, frontmatter)`.
+ * @param {string[]} requiredKeys Top-level frontmatter keys that MUST appear.
+ * @returns {{ok: boolean, missing: string[]}} `ok=true` when every required key is present;
+ *                                              otherwise `ok=false` with `missing` listing the
+ *                                              keys that did not appear.
+ */
+function verifyFrontmatterIntegrity(content, requiredKeys) {
+    if (typeof content !== 'string') {
+        return {ok: false, missing: requiredKeys.slice()};
+    }
+    if (!Array.isArray(requiredKeys) || requiredKeys.length === 0) {
+        return {ok: true, missing: []};
+    }
+
+    const missing = requiredKeys.filter(key => {
+        // `key:` at the start of any line — covers both inline (`closed: false`) and
+        // block-scalar styles (`title: |`). Escapes regex metacharacters in the key just
+        // in case a caller passes a value containing them.
+        const escapedKey = key.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+        return !new RegExp(`^${escapedKey}:`, 'm').test(content);
+    });
+
+    return {
+        ok     : missing.length === 0,
+        missing
+    };
+}
+
+/**
+ * Convenience wrapper for the Discussion syncer's required key set. Centralizes the
+ * "what counts as a complete Discussion frontmatter" contract so future regression
+ * tickets can extend this single list instead of grepping all syncers.
+ *
+ * Currently mirrors `DiscussionSyncer.mjs:241-250` frontmatter object construction.
+ *
+ * @param {string} content
+ * @returns {{ok: boolean, missing: string[]}}
+ */
+function verifyDiscussionFrontmatter(content) {
+    return verifyFrontmatterIntegrity(content, [
+        'number',
+        'title',
+        'author',
+        'category',
+        'createdAt',
+        'updatedAt',
+        'closed',
+        'closedAt'
+    ]);
+}
+
+export {verifyDiscussionFrontmatter, verifyFrontmatterIntegrity};

--- a/ai/services/github-workflow/sync/verifyFrontmatterIntegrity.mjs
+++ b/ai/services/github-workflow/sync/verifyFrontmatterIntegrity.mjs
@@ -4,49 +4,60 @@
  * `ai/services/github-workflow/shared/contentIndex.mjs` — pure-function modules consumed by the
  * Discussion / Issue / PullRequest syncers; sibling-file-lift applies; no novel directory choice.
  *
- * @summary Validates that serialized markdown content carries the expected frontmatter keys
- * before persistence (#11573). Closes the V-B-A gap where #11554's frontmatter-emit fix shipped
- * with green CI but the production effect was never verified — 0 of 104 on-disk Discussion
- * markdown files carried the new `closed` / `closedAt` keys despite the merged code path.
+ * @summary Validates that the YAML frontmatter block of serialized markdown carries the expected
+ * top-level keys before persistence (#11573). Closes the V-B-A gap where #11554's frontmatter-emit
+ * fix shipped with green CI but the production effect was never verified — 0 of 104 on-disk
+ * Discussion markdown files carried the new `closed` / `closedAt` keys despite the merged code path.
  *
  * Intentionally a pure helper:
+ * - Uses `gray-matter` (the same parser the syncer uses) to isolate the frontmatter block from
+ *   the markdown body. This eliminates the body-line false-positive class GPT empirically caught
+ *   in PR #11574 cycle-1 V-B-A (where a body line starting with `closed:` falsely satisfied a
+ *   missing-key check against the actual frontmatter).
  * - No Neo runtime dependency (importable from any sync context, including non-Neo callers).
  * - No filesystem IO (operates on the in-memory `content` string just before `fs.writeFile`).
  * - No logger dependency (returns a structured result; caller decides log level + action).
  *
- * Cost model: one regex test per required key per discussion. For ~100 discussions × 5 keys
- * the overhead is sub-millisecond — far below the network + serialize cost of a sync run.
+ * Cost model: one `gray-matter` parse per discussion (~100/sync × ~1ms = sub-100ms — far below
+ * the network + serialize cost of a sync run).
  *
- * @see #11573 (this ticket) / #11554 (originally fixed frontmatter shape)
+ * @see #11573 (this ticket) / #11554 (originally fixed frontmatter shape) / PR #11574 cycle-1
+ *      (GPT V-B-A — the body-line false-positive that drove the gray-matter scope fix)
  */
+import matter from 'gray-matter';
 
 /**
- * Checks whether the serialized markdown `content` carries each of the required frontmatter keys.
- * Match is anchored at line start (`^key:` with multi-line flag), matching `gray-matter`'s YAML
- * serialization output (top-level keys are always rendered as `key: value` on their own line).
+ * Checks whether the YAML frontmatter block of `content` carries each of the required keys.
+ * Parses via `gray-matter` (same parser the syncer uses) so the check operates on the actual
+ * frontmatter substrate, NOT the full markdown document. This prevents the body-line
+ * false-positive class where a body line `closed:` would satisfy a frontmatter-`closed:` check.
  *
  * @param {string} content The full serialized markdown (frontmatter + body), as produced by
  *                         `matter.stringify(body, frontmatter)`.
  * @param {string[]} requiredKeys Top-level frontmatter keys that MUST appear.
- * @returns {{ok: boolean, missing: string[]}} `ok=true` when every required key is present;
- *                                              otherwise `ok=false` with `missing` listing the
- *                                              keys that did not appear.
+ * @returns {{ok: boolean, missing: string[]}} `ok=true` when every required key is present in
+ *                                              the parsed frontmatter object; otherwise
+ *                                              `ok=false` with `missing` listing the keys.
  */
 function verifyFrontmatterIntegrity(content, requiredKeys) {
     if (typeof content !== 'string') {
-        return {ok: false, missing: requiredKeys.slice()};
+        return {ok: false, missing: Array.isArray(requiredKeys) ? requiredKeys.slice() : []};
     }
     if (!Array.isArray(requiredKeys) || requiredKeys.length === 0) {
         return {ok: true, missing: []};
     }
 
-    const missing = requiredKeys.filter(key => {
-        // `key:` at the start of any line — covers both inline (`closed: false`) and
-        // block-scalar styles (`title: |`). Escapes regex metacharacters in the key just
-        // in case a caller passes a value containing them.
-        const escapedKey = key.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-        return !new RegExp(`^${escapedKey}:`, 'm').test(content);
-    });
+    let parsed;
+    try {
+        parsed = matter(content);
+    } catch (e) {
+        // Malformed YAML or other parse error — treat as missing all keys so caller can
+        // decide whether to fail the write or surface the parse failure.
+        return {ok: false, missing: requiredKeys.slice()};
+    }
+
+    const data = parsed.data || {};
+    const missing = requiredKeys.filter(key => !Object.prototype.hasOwnProperty.call(data, key));
 
     return {
         ok     : missing.length === 0,

--- a/test/playwright/unit/ai/services/github-workflow/SyncService.Stage2.spec.mjs
+++ b/test/playwright/unit/ai/services/github-workflow/SyncService.Stage2.spec.mjs
@@ -36,7 +36,7 @@ test.describe('SyncService — Stage 2 Ingestion', () => {
     let originalSyncDiscussions;
     let originalSyncPullRequests;
     let originalGetViewerPermission;
-    
+
     let originalIngestIssueStates;
     let originalIngestDiscussionStates;
     let originalIngestPullRequestFeedback;
@@ -118,10 +118,117 @@ test.describe('SyncService — Stage 2 Ingestion', () => {
 
     test('runFullSync executes Stage 2 ingestion by dynamically invoking IssueIngestor', async () => {
         const result = await SyncService.runFullSync();
-        
+
         expect(result.success).toBe(true);
         expect(stage2Calls.issueStates).toBe(1);
         expect(stage2Calls.discussionStates).toBe(1);
         expect(stage2Calls.pullRequestFeedback).toBe(1);
+    });
+
+    /**
+     * #11573 regression coverage — metadata persistence carry-over.
+     *
+     * Empirical bug: `IssueSyncer.pullFromGitHub` returns a FRESH `newMetadata` object
+     * carrying only `{issues, pushFailures, lastSync}`. Subsequent calls to
+     * `DiscussionSyncer.syncDiscussions(metadata)` and `PullRequestSyncer.syncPullRequests(metadata)`
+     * mutate the OLD `metadata` argument's `.discussions` and `.pulls` fields. Without explicit
+     * carry-over in `SyncService.runFullSync`, those mutations were dropped at `save(newMetadata)`,
+     * leaving `metadata.discussions = {}` and `metadata.pulls = {}` on disk after every sync.
+     *
+     * This test mocks the production behavior exactly:
+     * - `pullFromGitHub` returns a NEW object (not the same reference as input).
+     * - `syncDiscussions` mutates `metadata.discussions[id] = {...}` on its argument.
+     * - `syncPullRequests` mutates `metadata.pulls[id] = {...}` on its argument.
+     *
+     * Asserts that the metadata captured at `save()` retains both syncers' mutations.
+     */
+    test('runFullSync carries metadata.discussions + metadata.pulls from per-syncer mutations onto newMetadata before save (#11573)', async () => {
+        let savedMetadata = null;
+
+        // Mock pullFromGitHub returns a FRESH newMetadata, mirroring IssueSyncer.mjs:570-574.
+        IssueSyncer.pullFromGitHub = async () => ({
+            newMetadata: {
+                issues      : {42: {state: 'OPEN'}},
+                pushFailures: [],
+                lastSync    : '2026-05-18T04:42:00Z'
+            },
+            stats: {pulled: {count: 0, created: 0, updated: 0, moved: 0}, dropped: {count: 0}}
+        });
+
+        // DiscussionSyncer mutates the input `metadata` (matches DiscussionSyncer.mjs:317-340).
+        DiscussionSyncer.syncDiscussions = async (md) => {
+            md.discussions = md.discussions || {};
+            md.discussions[11089] = {
+                number     : 11089,
+                closed     : false,
+                closedAt   : null,
+                contentHash: 'hash-11089',
+                path       : 'resources/content/discussions/chunk-1/discussion-11089.md'
+            };
+            md.discussions[5408] = {
+                number     : 5408,
+                closed     : true,
+                closedAt   : '2024-08-03T00:00:00Z',
+                contentHash: 'hash-5408',
+                path       : 'resources/content/archive/discussions/v8.30.0/chunk-1/discussion-5408.md'
+            };
+            return {count: 2};
+        };
+
+        // PullRequestSyncer mutates the input `metadata` (matches PullRequestSyncer.mjs:333-339).
+        PullRequestSyncer.syncPullRequests = async (md) => {
+            md.pulls = md.pulls || {};
+            md.pulls[10001] = {state: 'OPEN', contentHash: 'hash-pr-10001'};
+            return {count: 1};
+        };
+
+        // Capture the metadata that lands in save().
+        MetadataManager.save = async (md) => {
+            savedMetadata = md;
+        };
+
+        await SyncService.runFullSync();
+
+        // Metadata persistence carry-over: both syncers' mutations survived.
+        expect(savedMetadata, 'MetadataManager.save received an argument').not.toBeNull();
+        expect(savedMetadata.discussions[11089]).toMatchObject({
+            number  : 11089,
+            closed  : false,
+            closedAt: null
+        });
+        expect(savedMetadata.discussions[5408]).toMatchObject({
+            number  : 5408,
+            closed  : true,
+            closedAt: '2024-08-03T00:00:00Z'
+        });
+        expect(savedMetadata.pulls[10001]).toMatchObject({state: 'OPEN'});
+    });
+
+    /**
+     * #11573 regression coverage — explicit empty-input safety.
+     *
+     * Verifies that when DiscussionSyncer / PullRequestSyncer leave metadata.discussions
+     * or metadata.pulls undefined (e.g., early-exit path), the carry-over still produces
+     * `{}` rather than `undefined` on `newMetadata`. MetadataManager.save then renders
+     * an empty object in the JSON file rather than a missing key.
+     */
+    test('runFullSync produces metadata.discussions = {} when syncers leave fields undefined (#11573)', async () => {
+        let savedMetadata = null;
+
+        IssueSyncer.pullFromGitHub = async () => ({
+            newMetadata: {issues: {}, pushFailures: [], lastSync: '2026-05-18T04:42:00Z'},
+            stats: {pulled: {count: 0, created: 0, updated: 0, moved: 0}, dropped: {count: 0}}
+        });
+
+        // Syncers don't mutate metadata at all (early-exit path).
+        DiscussionSyncer.syncDiscussions = async () => ({count: 0});
+        PullRequestSyncer.syncPullRequests = async () => ({count: 0});
+
+        MetadataManager.save = async (md) => { savedMetadata = md; };
+
+        await SyncService.runFullSync();
+
+        expect(savedMetadata.discussions).toEqual({});
+        expect(savedMetadata.pulls).toEqual({});
     });
 });

--- a/test/playwright/unit/ai/services/github-workflow/verifyFrontmatterIntegrity.spec.mjs
+++ b/test/playwright/unit/ai/services/github-workflow/verifyFrontmatterIntegrity.spec.mjs
@@ -61,8 +61,10 @@ test.describe('ai/services/github-workflow/sync/verifyFrontmatterIntegrity (#115
         expect(verifyFrontmatterIntegrity(undefined, ['closed'])).toEqual({ok: false, missing: ['closed']});
     });
 
-    test('verifyFrontmatterIntegrity: matches at line start, ignores inline mentions in body', () => {
-        // The string "closed:" appears inline in the body, but NOT at the start of any line.
+    test('verifyFrontmatterIntegrity: ignores body content (no false-positive on body-line `key:`)', () => {
+        // Body contains a quoted "closed:" line. The frontmatter LACKS `closed:`. Per the
+        // ticket contract + GPT cycle-1 V-B-A on PR #11574 (gray-matter parse, not regex on
+        // whole doc), this MUST report `closed` as missing.
         const content = [
             '---',
             'number: 11089',
@@ -76,10 +78,32 @@ test.describe('ai/services/github-workflow/sync/verifyFrontmatterIntegrity (#115
         expect(result.missing).toEqual(['closed']);
     });
 
-    test('verifyFrontmatterIntegrity: escapes regex metacharacters in key names', () => {
-        const content = "---\nweird.key: value\n---\nBody.";
+    test('verifyFrontmatterIntegrity: regression — body-line literal `closed:` does NOT satisfy missing frontmatter key (GPT V-B-A #11574 cycle-1)', () => {
+        // GPT's empirical false-positive reproduction from PR #11574 cycle-1 review:
+        //   content has `closed:` / `closedAt:` only AFTER the closing `---`, not inside
+        //   the frontmatter block. The pre-fix regex-on-whole-doc helper falsely reported
+        //   {ok:true, missing:[]}. The gray-matter parse correctly reports both keys missing.
+        const content = '---\nnumber: 1\n---\nclosed:\nclosedAt:\n';
 
-        const result = verifyFrontmatterIntegrity(content, ['weird.key']);
+        const result = verifyFrontmatterIntegrity(content, ['closed', 'closedAt']);
+
+        expect(result.ok).toBe(false);
+        expect(result.missing).toEqual(['closed', 'closedAt']);
+    });
+
+    test('verifyFrontmatterIntegrity: handles malformed frontmatter defensively', () => {
+        const content = 'No frontmatter at all, just body text.';
+
+        const result = verifyFrontmatterIntegrity(content, ['number', 'closed']);
+
+        expect(result.ok).toBe(false);
+        expect(result.missing).toEqual(['number', 'closed']);
+    });
+
+    test('verifyFrontmatterIntegrity: handles keys with special characters via hasOwnProperty (no regex needed)', () => {
+        const content = "---\nweird-key: value\n---\nBody.";
+
+        const result = verifyFrontmatterIntegrity(content, ['weird-key']);
 
         expect(result).toEqual({ok: true, missing: []});
     });

--- a/test/playwright/unit/ai/services/github-workflow/verifyFrontmatterIntegrity.spec.mjs
+++ b/test/playwright/unit/ai/services/github-workflow/verifyFrontmatterIntegrity.spec.mjs
@@ -1,0 +1,167 @@
+import {test, expect} from '@playwright/test';
+
+import {
+    verifyDiscussionFrontmatter,
+    verifyFrontmatterIntegrity
+} from '../../../../../../ai/services/github-workflow/sync/verifyFrontmatterIntegrity.mjs';
+
+/**
+ * @summary Coverage for `ai/services/github-workflow/sync/verifyFrontmatterIntegrity.mjs` —
+ * the post-serialization integrity gate authored under #11573.
+ *
+ * Test axes:
+ *
+ * 1. Empty / malformed input safety (null content, empty key set).
+ * 2. Happy path — full key set present.
+ * 3. AC3 failing fixture — synthesized markdown lacking `closed`/`closedAt` (the empirical
+ *    bug captured by operator V-B-A 2026-05-18: 0/104 on-disk Discussion files lacked
+ *    these keys despite #11554 having merged the frontmatter-emit fix).
+ * 4. AC2 allowed fixture — historical/archive-style discussions where `closed: true`
+ *    and `closedAt: '<date>'` are both present.
+ * 5. Convenience wrapper `verifyDiscussionFrontmatter` requires all 8 Discussion keys.
+ */
+test.describe('ai/services/github-workflow/sync/verifyFrontmatterIntegrity (#11573)', () => {
+    test('verifyFrontmatterIntegrity: returns ok=true when all required keys present', () => {
+        const content = [
+            '---',
+            'number: 11089',
+            'title: Test',
+            'closed: false',
+            'closedAt: null',
+            '---',
+            'Body.'
+        ].join('\n');
+
+        const result = verifyFrontmatterIntegrity(content, ['number', 'closed', 'closedAt']);
+
+        expect(result).toEqual({ok: true, missing: []});
+    });
+
+    test('verifyFrontmatterIntegrity: returns missing keys when fields absent', () => {
+        const content = [
+            '---',
+            'number: 11089',
+            'title: Test',
+            '---',
+            'Body.'
+        ].join('\n');
+
+        const result = verifyFrontmatterIntegrity(content, ['number', 'closed', 'closedAt']);
+
+        expect(result.ok).toBe(false);
+        expect(result.missing).toEqual(['closed', 'closedAt']);
+    });
+
+    test('verifyFrontmatterIntegrity: handles empty required-keys array as trivially ok', () => {
+        expect(verifyFrontmatterIntegrity('any content', [])).toEqual({ok: true, missing: []});
+    });
+
+    test('verifyFrontmatterIntegrity: handles non-string content defensively', () => {
+        expect(verifyFrontmatterIntegrity(null, ['number'])).toEqual({ok: false, missing: ['number']});
+        expect(verifyFrontmatterIntegrity(undefined, ['closed'])).toEqual({ok: false, missing: ['closed']});
+    });
+
+    test('verifyFrontmatterIntegrity: matches at line start, ignores inline mentions in body', () => {
+        // The string "closed:" appears inline in the body, but NOT at the start of any line.
+        const content = [
+            '---',
+            'number: 11089',
+            '---',
+            'See discussion-history for when closed: state changed.'
+        ].join('\n');
+
+        const result = verifyFrontmatterIntegrity(content, ['closed']);
+
+        expect(result.ok).toBe(false);
+        expect(result.missing).toEqual(['closed']);
+    });
+
+    test('verifyFrontmatterIntegrity: escapes regex metacharacters in key names', () => {
+        const content = "---\nweird.key: value\n---\nBody.";
+
+        const result = verifyFrontmatterIntegrity(content, ['weird.key']);
+
+        expect(result).toEqual({ok: true, missing: []});
+    });
+
+    test('verifyDiscussionFrontmatter: full key set passes (active Discussion)', () => {
+        const content = [
+            '---',
+            'number: 11089',
+            'title: Test',
+            'author: neo-test',
+            'category: Ideas',
+            'createdAt: \'2026-05-10T01:33:43Z\'',
+            'updatedAt: \'2026-05-10T22:54:27Z\'',
+            'closed: false',
+            'closedAt: null',
+            '---',
+            'Body.'
+        ].join('\n');
+
+        const result = verifyDiscussionFrontmatter(content);
+
+        expect(result).toEqual({ok: true, missing: []});
+    });
+
+    test('verifyDiscussionFrontmatter: full key set passes (archived Discussion)', () => {
+        const content = [
+            '---',
+            'number: 5408',
+            'title: Old discussion',
+            'author: tobiu',
+            'category: Ideas',
+            'createdAt: \'2024-06-03T13:44:19Z\'',
+            'updatedAt: \'2025-03-04T20:25:15Z\'',
+            'closed: true',
+            'closedAt: \'2024-08-03T00:00:00Z\'',
+            '---',
+            'Body.'
+        ].join('\n');
+
+        const result = verifyDiscussionFrontmatter(content);
+
+        expect(result).toEqual({ok: true, missing: []});
+    });
+
+    test('verifyDiscussionFrontmatter: catches the #11554 regression — missing closed + closedAt', () => {
+        // Empirical anchor: this is the exact frontmatter shape that all 104 on-disk
+        // Discussion markdown files had on 2026-05-18 (operator V-B-A) — pre-#11554 shape.
+        const content = [
+            '---',
+            'number: 11089',
+            'title: Calibrate AGENTS.md core values + define nightshift operating mode',
+            'author: neo-opus-4-7',
+            'category: Ideas',
+            'createdAt: \'2026-05-10T01:33:43Z\'',
+            'updatedAt: \'2026-05-10T22:54:27Z\'',
+            '---',
+            'Body.'
+        ].join('\n');
+
+        const result = verifyDiscussionFrontmatter(content);
+
+        expect(result.ok).toBe(false);
+        expect(result.missing).toEqual(['closed', 'closedAt']);
+    });
+
+    test('verifyDiscussionFrontmatter: catches single missing key', () => {
+        const content = [
+            '---',
+            'number: 11089',
+            'title: Test',
+            'author: neo-test',
+            'category: Ideas',
+            'createdAt: \'2026-05-10T01:33:43Z\'',
+            'updatedAt: \'2026-05-10T22:54:27Z\'',
+            'closed: false',
+            '---',
+            'Body.'
+        ].join('\n');
+
+        const result = verifyDiscussionFrontmatter(content);
+
+        expect(result.ok).toBe(false);
+        expect(result.missing).toEqual(['closedAt']);
+    });
+});


### PR DESCRIPTION
## Summary

Operator @tobiu V-B-A on 2026-05-18 ~04:30Z caught the empirical bug: **0 of 104 on-disk Discussion markdown files carry `closed` / `closedAt` in frontmatter despite #11554 having merged the frontmatter-emit fix ~1h before the most recent chore-sync ran**. Two compounding factors uncovered + fixed:

- **Factor A (operational, primary):** MCP daemons load `DiscussionSyncer.mjs` at startup and don't reload on code change. The MCP server that wrote `discussion-11557.md` at `709d9c44f` was running pre-#11554 code despite the merge.
- **Factor B (architectural, latent):** `IssueSyncer.pullFromGitHub` returns a fresh `newMetadata` carrying only `{issues, pushFailures, lastSync}`. `DiscussionSyncer.syncDiscussions(metadata)` and `PullRequestSyncer.syncPullRequests(metadata)` mutate the OLD `metadata` argument; without explicit carry-over those mutations were dropped at `save(newMetadata)`, leaving `metadata.discussions = {}` permanently empty on disk.

This PR closes Factor B (the substrate fix) and adds a runtime integrity gate that catches future Factor A regressions at sync time. Operational re-sync from a restarted MCP daemon will heal the existing 104 files.

**FAIR-band:** acceptable — REQUEST-REVIEW.

**Evidence:** 17 tests pass across the affected specs (`DiscussionSyncer` 2/2 + `SyncService.Stage2` 3/3 with 2 new + `verifyFrontmatterIntegrity` 12/12 with 4 new vs cycle-1). Empirical V-B-A trace below.

Resolves #11573.

Authored by @neo-opus-4-7 (origin session `0526ccc8-019a-4145-84c2-52b27ef09efd`).

## Empirical V-B-A trace

```
$ grep -l "^closed:" resources/content/discussions/chunk-*/*.md | wc -l
0
$ grep -l "^closedAt:" resources/content/discussions/chunk-*/*.md | wc -l
0
$ find resources/content -name "discussion-*.md" | wc -l
104

$ cat resources/content/.sync-metadata.json | jq '.discussions | length'
0
$ cat resources/content/.sync-metadata.json | jq '.pulls | length'
0
$ cat resources/content/.sync-metadata.json | jq '.issues | length'
8519   # ← issues populated; discussions + pulls empty (Factor B signature)
```

Confirms: code at `DiscussionSyncer.mjs:241-250` includes `closed: discussion.closed, closedAt: discussion.closedAt` and `matter.stringify` smoke produces those keys correctly under fixtures. But production-synced markdown lacks them across all 104 files including `discussion-11557.md` written AFTER the #11554 merge.

## Fix

### 1. `SyncService.mjs:120-126` — metadata carry-over

```javascript
// 9. Carry over per-syncer metadata mutations (#11573).
//
// `newMetadata` is a fresh object constructed by `IssueSyncer.pullFromGitHub` carrying
// only `{issues, pushFailures, lastSync}`. `DiscussionSyncer.syncDiscussions(metadata)`
// and `PullRequestSyncer.syncPullRequests(metadata)` mutate the OLD `metadata` argument
// ...
newMetadata.discussions = metadata.discussions || {};
newMetadata.pulls       = metadata.pulls       || {};
```

Defaults to `{}` when syncers leave the field undefined (early-exit path).

### 2. `ai/services/github-workflow/sync/verifyFrontmatterIntegrity.mjs` — YAML-scoped integrity helper

- **Parses via `gray-matter`** (the same parser the syncer uses for serialization) and inspects `parsed.data` via `hasOwnProperty`. The check operates on the actual frontmatter substrate, NOT the full markdown document.
- Eliminates the body-line false-positive class GPT empirically caught in cycle-1 V-B-A (where a body line `closed:` could falsely satisfy a frontmatter-`closed:` check). Now: `content = '---\nnumber: 1\n---\nclosed:\nclosedAt:\n'` correctly returns `{ok: false, missing: ['closed', 'closedAt']}`.
- Handles `null` / `undefined` content + malformed YAML defensively.
- Empty `requiredKeys` array trivially `{ok: true}`.
- Convenience wrapper `verifyDiscussionFrontmatter` encapsulates the 8-key Discussion contract (`number, title, author, category, createdAt, updatedAt, closed, closedAt`).

### 3. `DiscussionSyncer.mjs` — throw-on-missing per #11573 Contract Ledger

After `matter.stringify`:

```javascript
const integrity = verifyDiscussionFrontmatter(content);
if (!integrity.ok) {
    throw new Error(`Discussion #${discussion.number} serialized content missing required frontmatter keys: ${integrity.missing.join(', ')}. ADR 0011 / #11573 contract violation — likely stale MCP daemon code path.`);
}
```

**Throw, not warn-only** per ticket Contract Ledger AC3 ("post-sync integrity assertion fails when a synced discussion lacks a required frontmatter key"). The existing per-discussion `try { ... } catch (e)` at the loop boundary (`DiscussionSyncer.mjs:312-314`) catches the throw, logs the warning, and skips the `writeFile` — broken-frontmatter files are **never persisted**, but the sync run continues with other discussions. Net effect: per-discussion isolation preserved; broken content NEVER lands on disk.

## Test Evidence

```
$ UNIT_TEST_MODE=true ./node_modules/.bin/playwright test \
    -c test/playwright/playwright.config.unit.mjs \
    test/playwright/unit/ai/services/github-workflow/verifyFrontmatterIntegrity.spec.mjs \
    test/playwright/unit/ai/services/github-workflow/SyncService.Stage2.spec.mjs \
    test/playwright/unit/ai/services/github-workflow/DiscussionSyncer.spec.mjs
Running 17 tests using 9 workers
  17 passed (853ms)
```

Coverage breakdown (cycle-2):
- `verifyFrontmatterIntegrity` (12 tests, +2 vs cycle-1): happy path, missing-keys detection, empty-keys safety, non-string input safety, body-line false-positive regression (GPT V-B-A reproduction), malformed-frontmatter defensive, hasOwnProperty special-char keys, Discussion convenience wrapper (active + archived + single-missing + the #11554 regression fixture).
- `SyncService.Stage2` (3 tests, unchanged): metadata.discussions + metadata.pulls carry-over from per-syncer mutations onto `newMetadata` before `save()`; empty-input safety producing `{}` rather than `undefined`.
- `DiscussionSyncer` (2 tests, unchanged): both still pass post-import.

## Post-Merge Validation

- [ ] Operator (or any agent) restarts MCP daemon from worktree on post-merge `dev`, runs `sync_all`, confirms `grep -l "^closed:" resources/content/discussions/chunk-*/*.md | wc -l == 104`.
- [ ] `resources/content/.sync-metadata.json` `.discussions` field populates with 104 entries (one per Discussion).
- [ ] `resources/content/.sync-metadata.json` `.pulls` field populates with N entries (one per cached PR).
- [ ] Second consecutive sync run shows skip-on-unchanged-hash log lines for unchanged discussions (cache now working).
- [ ] No `⚠️ Could not sync discussion #N: ... frontmatter keys` warnings appear in sync output (all current 104 are valid; warnings would only fire on actual stale-MCP regressions going forward).

## Deltas

| Path | Type | Bytes |
|---|---|---|
| `ai/services/github-workflow/SyncService.mjs` | extend | +22 / -5 (JSDoc step list + carry-over block) |
| `ai/services/github-workflow/sync/DiscussionSyncer.mjs` | extend | +12 / -1 (import + throw-on-missing integrity gate per Contract Ledger) |
| `ai/services/github-workflow/sync/verifyFrontmatterIntegrity.mjs` | NEW | +85 (gray-matter parse + hasOwnProperty check) |
| `test/playwright/unit/ai/services/github-workflow/SyncService.Stage2.spec.mjs` | extend | +109 / -2 (2 new tests + whitespace polish on pre-existing blank line) |
| `test/playwright/unit/ai/services/github-workflow/verifyFrontmatterIntegrity.spec.mjs` | NEW | +180 (12 tests including GPT's body-line false-positive regression) |

Total: +408 / -8. No retired primitives. No canonical-file overwrites.

## Cycle-1 → Cycle-2 deltas

- `verifyFrontmatterIntegrity`: switched from regex-on-whole-doc (`^key:` with multi-line flag) to `gray-matter` parse + `hasOwnProperty` on `parsed.data`. Eliminates the body-line false-positive class GPT empirically caught.
- `DiscussionSyncer` integrity call: switched from `logger.warn` to `throw new Error(...)`, aligning with ticket Contract Ledger AC3 fail-on-missing semantics. Per-discussion catch boundary absorbs the throw to preserve sync-run continuity.
- Tests: added 2 new (body-line false-positive regression citing GPT cycle-1 V-B-A anchor + malformed-frontmatter defensive).

## Related

- Original (incomplete) fix: PR #11555 / commit `c70f2672a` / ticket #11554.
- Empirical anchor: operator V-B-A 2026-05-18 ~04:30Z.
- Cycle-1 V-B-A from @neo-gpt: https://github.com/neomjs/neo/pull/11574#pullrequestreview-4307330071 (body-line false-positive + Contract Ledger drift).
- Substrate discipline: `feedback_verify_effect_not_just_success` (post-merge verification) + `feedback_verify_before_assert` (multi-layer V-B-A) + `feedback_vba_completeness_layers` (V-B-A must check code + test + runtime + output layers; cycle-1 V-B-A on my output-fix surfaced a new code-layer gap — cross-family V-B-A propagates discipline recursively).
- Operational follow-up: this PR does NOT trigger the re-sync itself; operator (or any agent on fresh `dev`) runs `sync_all` after merge.

---

<sub>Authored by @neo-opus-4-7 (Claude Opus 4.7, Claude Code) — origin session `0526ccc8-019a-4145-84c2-52b27ef09efd`. Cycle-2 head: `d82d7abea`. Cross-family V-B-A chain: operator → me → GPT → me; substrate-discipline win shape.</sub>