### PR TITLE
feat(memory-core): classify sibling harnesses at boot (#10206)

### DIFF
--- a/ai/mcp/server/memory-core/Server.mjs
+++ b/ai/mcp/server/memory-core/Server.mjs
@@ -5,6 +5,10 @@ import {listTools, callTool}       from './toolService.mjs';
 import AuthMiddleware              from '../shared/services/AuthMiddleware.mjs';
 import RequestContextService       from '../shared/services/RequestContextService.mjs';
 import StdioIdentityResolver       from '../shared/services/StdioIdentityResolver.mjs';
+import {
+    formatHarnessGroups,
+    groupProcessesByHarness
+} from '../../../services/memory-core/helpers/HarnessClassifier.mjs';
 
 import {
     Memory_Config                  as aiConfig,
@@ -406,7 +410,15 @@ class Server extends BaseServer {
             });
 
             if (siblings.length > 0) {
-                logger.info(`ℹ️  [Startup] Sibling concurrency: ${siblings.length} peer process(es) holding SQLite files. PIDs: ${siblings.map(s => s.pid).join(', ')}`);
+                const groups  = groupProcessesByHarness(siblings);
+                const summary = formatHarnessGroups(groups);
+                const message = `ℹ️  [Startup] Sibling concurrency: ${siblings.length} peer process(es) holding SQLite files. Harnesses: ${summary}`;
+
+                if (groups.some(group => group.harness === 'unknown')) {
+                    logger.warn(message);
+                } else {
+                    logger.info(message);
+                }
             }
         } catch (error) {
             // Ignore ENOENT (lsof missing on Windows) or status 1 (no matching processes)

--- a/ai/scripts/diagnoseMcpConcurrency.mjs
+++ b/ai/scripts/diagnoseMcpConcurrency.mjs
@@ -41,6 +41,7 @@ import {execSync}      from 'child_process';
 import fs              from 'fs';
 import path            from 'path';
 import {fileURLToPath} from 'url';
+import {classifyHarness} from '../services/memory-core/helpers/HarnessClassifier.mjs';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname  = path.dirname(__filename);
@@ -170,66 +171,6 @@ function parseLsofOutput(raw) {
 function listHoldingProcesses() {
     const raw = runLsof([SQLITE_MAIN, SQLITE_WAL, SQLITE_SHM]);
     return parseLsofOutput(raw);
-}
-
-/**
- * @summary Walk the `ppid` chain for a PID and classify the owning harness.
- *
- * The Structural Layer (lsof output) gives us each process in isolation; the
- * Projection Layer for swarm-concurrency reasoning needs the *harness* (Claude
- * Desktop / Claude Code / Antigravity / IDE host) that spawned each MCP server.
- * That requires traversing up to the recognizable ancestor in the `ppid` chain.
- *
- * Bounded to 8 levels to protect against runaway loops on an unexpected process
- * graph. Classification is heuristic — matches against command substrings in
- * case-insensitive mode. Unknown ancestors fall through to `'unknown'`, which is
- * itself useful signal (uncategorized harness = worth investigating).
- *
- * @param {number} pid Starting PID to walk from.
- * @returns {{harness: string, chain: Array<{pid: number, command: string}>}}
- */
-function classifyHarness(pid) {
-    const chain = [];
-    let cursor  = pid;
-
-    for (let depth = 0; depth < 8; depth++) {
-        let raw;
-        try {
-            raw = execSync(`ps -o ppid=,comm= -p ${cursor}`, {
-                encoding: 'utf8',
-                stdio   : ['ignore', 'pipe', 'pipe']
-            }).trim();
-        } catch {
-            break;
-        }
-        if (!raw) break;
-
-        // `ps` output: "  <ppid> <comm>" — split on first whitespace gap
-        const match = raw.match(/^\s*(\d+)\s+(.*)$/);
-        if (!match) break;
-
-        const ppid    = parseInt(match[1], 10);
-        const command = match[2];
-        chain.push({pid: cursor, command});
-
-        if (!ppid || ppid === 1 || ppid === cursor) break;
-        cursor = ppid;
-    }
-
-    // Bottom-up classification: closest recognizable ancestor wins. Order matters —
-    // `claude-code` checks precede the generic `claude` match to avoid misclassifying
-    // Claude Code's CLI as Claude Desktop.
-    for (const entry of chain) {
-        const cmd = entry.command.toLowerCase();
-        if (cmd.includes('claude') && cmd.includes('code')) return {harness: 'claude-code', chain};
-        if (cmd === 'claude' || cmd.endsWith('/claude'))    return {harness: 'claude-code', chain};
-        if (cmd.includes('claude'))                          return {harness: 'claude-desktop', chain};
-        if (cmd.includes('antigravity'))                     return {harness: 'antigravity', chain};
-        if (cmd.includes('cursor'))                          return {harness: 'cursor', chain};
-        if (cmd.includes('code helper') || cmd.includes('vscode')) return {harness: 'vscode', chain};
-    }
-
-    return {harness: 'unknown', chain};
 }
 
 /**

--- a/ai/services/memory-core/helpers/HarnessClassifier.mjs
+++ b/ai/services/memory-core/helpers/HarnessClassifier.mjs
@@ -1,0 +1,110 @@
+import {execSync as defaultExecSync} from 'node:child_process';
+
+const harnessLabels = {
+    'claude-code'   : 'Claude Code',
+    'claude-desktop': 'Claude Desktop',
+    antigravity    : 'Antigravity',
+    cursor         : 'Cursor',
+    unknown        : 'unknown',
+    vscode         : 'VS Code'
+};
+
+/**
+ * @summary Classifies the harness that owns a local MCP process by walking its parent process chain.
+ *
+ * The diagnostic is intentionally heuristic and read-only. It mirrors the process-chain
+ * classifier pioneered by `ai/scripts/diagnoseMcpConcurrency.mjs` for #10187, but lives at
+ * the Memory Core SDK boundary so both operator scripts and boot-time server logging can
+ * share one contract.
+ *
+ * @param {Number}   pid                    Starting PID to inspect.
+ * @param {Object}   [options]
+ * @param {Function} [options.execSync]     Injectable command runner for tests.
+ * @param {Number}   [options.maxDepth=8]   Parent-chain traversal cap.
+ * @returns {{harness: String, chain: Array<{pid: Number, command: String}>}}
+ */
+export function classifyHarness(pid, {execSync = defaultExecSync, maxDepth = 8} = {}) {
+    const chain = [];
+    let cursor  = pid;
+
+    for (let depth = 0; depth < maxDepth; depth++) {
+        let raw;
+        try {
+            raw = execSync(`ps -o ppid=,comm= -p ${cursor}`, {
+                encoding: 'utf8',
+                stdio   : ['ignore', 'pipe', 'pipe']
+            }).trim();
+        } catch {
+            break;
+        }
+        if (!raw) break;
+
+        const match = raw.match(/^\s*(\d+)\s+(.*)$/);
+        if (!match) break;
+
+        const ppid    = parseInt(match[1], 10);
+        const command = match[2];
+        chain.push({pid: cursor, command});
+
+        if (!ppid || ppid === 1 || ppid === cursor) break;
+        cursor = ppid;
+    }
+
+    for (const entry of chain) {
+        const cmd = entry.command.toLowerCase();
+        if (cmd.includes('claude') && cmd.includes('code')) return {harness: 'claude-code', chain};
+        if (cmd === 'claude' || cmd.endsWith('/claude'))    return {harness: 'claude-code', chain};
+        if (cmd.includes('claude'))                         return {harness: 'claude-desktop', chain};
+        if (cmd.includes('antigravity'))                    return {harness: 'antigravity', chain};
+        if (cmd.includes('cursor'))                         return {harness: 'cursor', chain};
+        if (cmd.includes('code helper') || cmd.includes('vscode')) return {harness: 'vscode', chain};
+    }
+
+    return {harness: 'unknown', chain};
+}
+
+/**
+ * @summary Groups process records by owning harness while preserving PID and chain detail.
+ *
+ * @param {Array<{pid: Number, command?: String}>} processes Process records to classify.
+ * @param {Object} [options]
+ * @param {Function} [options.classifier=classifyHarness] Injectable classifier for tests.
+ * @returns {Array<{harness: String, label: String, processes: Array<Object>}>}
+ */
+export function groupProcessesByHarness(processes, {classifier = classifyHarness} = {}) {
+    const groups = new Map();
+
+    for (const processRecord of processes) {
+        const {harness, chain} = classifier(processRecord.pid);
+        if (!groups.has(harness)) {
+            groups.set(harness, {
+                harness,
+                label    : harnessLabels[harness] || harness,
+                processes: []
+            });
+        }
+
+        groups.get(harness).processes.push({
+            ...processRecord,
+            harness,
+            chain
+        });
+    }
+
+    return Array.from(groups.values());
+}
+
+/**
+ * @summary Renders grouped harness counts with PID visibility for startup diagnostics.
+ *
+ * @param {Array<{label: String, processes: Array<{pid: Number}>}>} groups Harness groups.
+ * @returns {String}
+ */
+export function formatHarnessGroups(groups) {
+    return groups.map(group => {
+        const pids     = group.processes.map(processRecord => processRecord.pid).join(', ');
+        const pidLabel = group.processes.length === 1 ? 'PID' : 'PIDs';
+
+        return `${group.processes.length} ${group.label} (${pidLabel}: ${pids})`;
+    }).join(' + ');
+}

--- a/test/playwright/unit/ai/services/memory-core/HarnessClassifier.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/HarnessClassifier.spec.mjs
@@ -1,0 +1,103 @@
+import {setup} from '../../../../setup.mjs';
+
+const appName = 'HarnessClassifierTest';
+
+setup({
+    neoConfig: {
+        unitTestMode: true
+    },
+    appConfig: {
+        name             : appName,
+        isMounted        : () => true,
+        vnodeInitialising: false
+    }
+});
+
+import {test, expect} from '@playwright/test';
+import Neo            from '../../../../../../src/Neo.mjs';
+import * as core      from '../../../../../../src/core/_export.mjs';
+
+/**
+ * @summary Coverage for #10206 Memory Core harness-classified sibling diagnostics.
+ *
+ * Pins the extracted classifier used by both `diagnoseMcpConcurrency.mjs` and
+ * `MemoryCoreServer.logSiblingConcurrency()`. The helper remains read-only and testable
+ * through injected process-chain output rather than live host process state.
+ *
+ * @see ai.services.memory-core.helpers.HarnessClassifier#classifyHarness
+ */
+test.describe('Memory Core HarnessClassifier #10206', () => {
+    let classifyHarness, groupProcessesByHarness, formatHarnessGroups;
+
+    test.beforeAll(async () => {
+        const mod = await import('../../../../../../ai/services/memory-core/helpers/HarnessClassifier.mjs');
+        classifyHarness        = mod.classifyHarness;
+        groupProcessesByHarness = mod.groupProcessesByHarness;
+        formatHarnessGroups     = mod.formatHarnessGroups;
+    });
+
+    function makeExecSync(responses) {
+        return command => {
+            const pid = Number(command.match(/-p\s+(\d+)/)?.[1]);
+            if (!responses.has(pid)) throw new Error(`unexpected pid ${pid}`);
+            return responses.get(pid);
+        };
+    }
+
+    test('walks parent process chain and classifies Antigravity harness', () => {
+        const execSync = makeExecSync(new Map([
+            [101, '  202 node'],
+            [202, '    1 /Applications/Antigravity.app/Contents/MacOS/Antigravity']
+        ]));
+
+        const result = classifyHarness(101, {execSync});
+
+        expect(result.harness).toBe('antigravity');
+        expect(result.chain).toEqual([
+            {pid: 101, command: 'node'},
+            {pid: 202, command: '/Applications/Antigravity.app/Contents/MacOS/Antigravity'}
+        ]);
+    });
+
+    test('prefers Claude Code over generic Claude Desktop classification', () => {
+        const execSync = makeExecSync(new Map([
+            [301, '  302 node'],
+            [302, '    1 /usr/local/bin/claude-code']
+        ]));
+
+        expect(classifyHarness(301, {execSync}).harness).toBe('claude-code');
+    });
+
+    test('falls back to unknown when no recognizable harness exists', () => {
+        const execSync = makeExecSync(new Map([
+            [401, '  402 node'],
+            [402, '    1 /usr/bin/loginwindow']
+        ]));
+
+        const result = classifyHarness(401, {execSync});
+
+        expect(result.harness).toBe('unknown');
+        expect(result.chain).toHaveLength(2);
+    });
+
+    test('groups process records and preserves PID visibility in formatted output', () => {
+        const groups = groupProcessesByHarness([
+            {pid: 101, command: 'node'},
+            {pid: 102, command: 'node'},
+            {pid: 201, command: 'node'}
+        ], {
+            classifier(pid) {
+                return {
+                    harness: pid < 200 ? 'antigravity' : 'unknown',
+                    chain  : [{pid, command: 'node'}]
+                };
+            }
+        });
+
+        expect(Object.fromEntries(groups.map(group => [group.harness, group.processes.length]))).toEqual({
+            antigravity: 2,
+            unknown    : 1
+        });
+        expect(formatHarnessGroups(groups)).toBe('2 Antigravity (PIDs: 101, 102) + 1 unknown (PID: 201)');
+    });
+});


### PR DESCRIPTION
Resolves #10206
Related: #10186

Authored by GPT-5.5 (Codex Desktop). Session current Codex Desktop request-scoped session.

FAIR-band: under-target [7/30] — Self-Selection Rule 1 fires (under-band -> bias toward author lane)

Memory Core now shares the process-chain harness classifier between the existing concurrency diagnostic script and boot-time sibling SQLite logging. Startup diagnostics group peer holders by harness with PID visibility and escalate to warn when any sibling remains unknown.

Evidence: L2 (unit/stub verification of process-chain classification, grouping, unknown fallback, and Memory Core server import smoke) -> L2 required (#10206 consumed boot-log diagnostic behavior). No residuals.

## Deltas from ticket

- Used the post-M6 SDK helper location `ai/services/memory-core/helpers/` instead of the older ticket suggestion under `ai/mcp/server/`, matching current ArchitectureOverview and code reality.
- Preserved `diagnoseMcpConcurrency.mjs` read-only output shape while removing its local duplicate classifier.
- Implemented the optional unknown-harness severity escalation in the narrow boot-log path only.

## Test Evidence

- `npm run test-unit -- test/playwright/unit/ai/services/memory-core/HarnessClassifier.spec.mjs` — 4 passed.
- `npm run test-unit -- test/playwright/unit/ai/mcp/server/memory-core/Server.spec.mjs` — 4 passed.
- `node --check ai/services/memory-core/helpers/HarnessClassifier.mjs` — passed.
- `node --check ai/mcp/server/memory-core/Server.mjs` — passed.
- `node --check ai/scripts/diagnoseMcpConcurrency.mjs` — passed.
- `git diff --check` and `git diff --cached --check` — passed.

## Post-Merge Validation

- [ ] On a real multi-harness host, start Memory Core and confirm the startup sibling-concurrency line reports grouped harness counts with PIDs.

## Commits

- `63b0163d1` — `feat(memory-core): classify sibling harnesses at boot (#10206)`