### PR TITLE
feat(test): mock main route and local storage in setup (#11578)

### DIFF
--- a/learn/guides/testing/UnitTesting.md
+++ b/learn/guides/testing/UnitTesting.md
@@ -70,6 +70,19 @@ In a Unit Test:
 2.  We import **both** the App Worker classes and the VDom Worker classes into the same Node.js scope.
 3.  The `setup()` function mocks the messaging layer, allowing them to talk directly.
 
+### Runtime Facade Mocks
+
+`test/playwright/setup.mjs` also installs minimal runtime facades that production-shaped component trees expect during construction:
+
+```javascript
+setup({
+    mockMain        : true, // provides Neo.Main.setRoute()
+    mockLocalStorage: true  // provides Neo.main.addon.LocalStorage
+});
+```
+
+Both flags default to `true`. This lets downstream apps smoke-test a root `Neo.container.Viewport` with a real `Neo.controller.Component` controller, including `defaultHash` routing and persisted UI state reads, without wiring the browser main-thread runtime. Set either flag to `false` when a spec intentionally installs a richer route or storage mock before calling `setup()`.
+
 ### Understanding Imports (Critical)
 
 Because we are bypassing the standard build/worker loading process, you must manually import the dependencies your test needs.

--- a/test/playwright/setup.mjs
+++ b/test/playwright/setup.mjs
@@ -28,8 +28,22 @@ globalThis.DOMRect = class DOMRect {
 // This file sets up the Node.js global scope to run Neo.mjs
 // VDOM unit tests without a browser or jsdom.
 
+/**
+ * Configures the single-threaded Playwright unit-test runtime with the minimal
+ * Neo globals required by App Worker and VDom Worker classes.
+ * @param {Object} options={}
+ * @param {Object} options.appConfig={} App facade overrides.
+ * @param {Boolean} options.mockLocalStorage=true True installs minimal `Neo.main.addon.LocalStorage` methods.
+ * @param {Boolean} options.mockMain=true True installs a minimal `Neo.Main.setRoute()` method.
+ * @param {Object} options.neoConfig={} Neo.config overrides.
+ */
 export function setup(options = {}) {
-    const { neoConfig = {}, appConfig = {} } = options;
+    const {
+        appConfig        = {},
+        mockLocalStorage = true,
+        mockMain         = true,
+        neoConfig        = {}
+    } = options;
 
     const defaultNeoConfig = {
         environment : 'development',
@@ -54,6 +68,11 @@ export function setup(options = {}) {
 
     // Standardized Global Mocks to prevent cross-contamination in Playwright worker reuse
     Neo.applyDeltas ??= async () => {};
+
+    if (mockMain) {
+        Neo.Main ??= {};
+        Neo.Main.setRoute ??= () => {};
+    }
 
     Neo.main ??= {
         addon: {
@@ -81,6 +100,21 @@ export function setup(options = {}) {
             scrollTo      : async () => {}
         }
     };
+
+    if (mockLocalStorage) {
+        Neo.main.addon ??= {};
+        Neo.main.addon.LocalStorage ??= {};
+
+        Object.assign(Neo.main.addon.LocalStorage, {
+            createLocalStorageItem : Neo.main.addon.LocalStorage.createLocalStorageItem  ?? (async () => {}),
+            destroyLocalStorageItem: Neo.main.addon.LocalStorage.destroyLocalStorageItem ?? (async () => {}),
+            readLocalStorageItem   : Neo.main.addon.LocalStorage.readLocalStorageItem    ?? (async ({key} = {}) => ({
+                key,
+                value: Array.isArray(key) ? Object.fromEntries(key.map(item => [item, null])) : null
+            })),
+            updateLocalStorageItem : Neo.main.addon.LocalStorage.updateLocalStorageItem  ?? (async () => {})
+        });
+    }
 
     Neo.currentWorker ??= {
         getAddon: async () => ({

--- a/test/playwright/setup.mjs
+++ b/test/playwright/setup.mjs
@@ -70,8 +70,7 @@ export function setup(options = {}) {
     Neo.applyDeltas ??= async () => {};
 
     if (mockMain) {
-        Neo.Main ??= {};
-        Neo.Main.setRoute ??= () => {};
+        Neo.ns('Neo.Main', true).setRoute ??= () => {};
     }
 
     Neo.main ??= {
@@ -102,18 +101,15 @@ export function setup(options = {}) {
     };
 
     if (mockLocalStorage) {
-        Neo.main.addon ??= {};
-        Neo.main.addon.LocalStorage ??= {};
+        const localStorage = Neo.ns('Neo.main.addon.LocalStorage', true);
 
-        Object.assign(Neo.main.addon.LocalStorage, {
-            createLocalStorageItem : Neo.main.addon.LocalStorage.createLocalStorageItem  ?? (async () => {}),
-            destroyLocalStorageItem: Neo.main.addon.LocalStorage.destroyLocalStorageItem ?? (async () => {}),
-            readLocalStorageItem   : Neo.main.addon.LocalStorage.readLocalStorageItem    ?? (async ({key} = {}) => ({
-                key,
-                value: Array.isArray(key) ? Object.fromEntries(key.map(item => [item, null])) : null
-            })),
-            updateLocalStorageItem : Neo.main.addon.LocalStorage.updateLocalStorageItem  ?? (async () => {})
+        localStorage.createLocalStorageItem  ??= async () => {};
+        localStorage.destroyLocalStorageItem ??= async () => {};
+        localStorage.readLocalStorageItem    ??= async ({key} = {}) => ({
+            key,
+            value: Array.isArray(key) ? Object.fromEntries(key.map(item => [item, null])) : null
         });
+        localStorage.updateLocalStorageItem  ??= async () => {};
     }
 
     Neo.currentWorker ??= {

--- a/test/playwright/unit/container/ViewportSetupMocks.spec.mjs
+++ b/test/playwright/unit/container/ViewportSetupMocks.spec.mjs
@@ -1,0 +1,158 @@
+import {setup} from '../../setup.mjs';
+
+const appName = 'ContainerViewportSetupMocksTest';
+
+setup({
+    appConfig: {
+        name: appName
+    },
+    mockLocalStorage: false,
+    mockMain        : false
+});
+
+import {test, expect}       from '@playwright/test';
+import Neo                  from '../../../../src/Neo.mjs';
+import * as core            from '../../../../src/core/_export.mjs';
+import ComponentController  from '../../../../src/controller/Component.mjs';
+import Viewport             from '../../../../src/container/Viewport.mjs';
+
+/**
+ * @summary Test controller for exercising setup-level route and storage mocks.
+ *
+ * The controller combines default-hash routing with a construction-time LocalStorage
+ * read to mirror production-shaped root viewport controllers in downstream apps.
+ * @class Test.Unit.Container.ViewportSetupMocksController
+ * @extends Neo.controller.Component
+ */
+class TestController extends ComponentController {
+    static config = {
+        className  : 'Test.Unit.Container.ViewportSetupMocksController',
+        defaultHash: '/home'
+    }
+
+    onComponentConstructed() {
+        this.storagePromise = Neo.main.addon.LocalStorage.readLocalStorageItem({
+            key     : ['viewportSetupTheme', 'viewportSetupLayout'],
+            windowId: this.windowId
+        });
+    }
+}
+TestController = Neo.setupClass(TestController);
+
+/**
+ * @summary Test viewport for the setup runtime-facade smoke path.
+ *
+ * The viewport disables browser-only body mounting behavior so the unit test can
+ * focus on controller construction without requiring a real main-thread DOM.
+ * @class Test.Unit.Container.ViewportSetupMocksViewport
+ * @extends Neo.container.Viewport
+ */
+class TestViewport extends Viewport {
+    static config = {
+        applyBodyCls: false,
+        autoMount   : false,
+        className   : 'Test.Unit.Container.ViewportSetupMocksViewport',
+        controller  : TestController
+    }
+}
+TestViewport = Neo.setupClass(TestViewport);
+
+test.describe('test/playwright/setup.mjs viewport mocks', () => {
+    let previousMain, previousLocalStorage, viewport;
+
+    test.beforeEach(() => {
+        previousMain         = Neo.Main;
+        previousLocalStorage = Neo.main?.addon?.LocalStorage;
+        viewport             = null;
+
+        delete Neo.Main;
+
+        if (Neo.main?.addon) {
+            delete Neo.main.addon.LocalStorage;
+        }
+    });
+
+    test.afterEach(() => {
+        viewport?.destroy();
+
+        if (previousMain === undefined) {
+            delete Neo.Main;
+        } else {
+            Neo.Main = previousMain;
+        }
+
+        if (previousLocalStorage === undefined) {
+            delete Neo.main.addon.LocalStorage;
+        } else {
+            Neo.main.addon.LocalStorage = previousLocalStorage;
+        }
+    });
+
+    test('setup() provides default Neo.Main and LocalStorage mocks for viewport controller smoke tests', async () => {
+        setup({
+            appConfig: {
+                name: appName
+            }
+        });
+
+        expect(Neo.Main.setRoute).toBeInstanceOf(Function);
+        expect(Neo.main.addon.LocalStorage.readLocalStorageItem).toBeInstanceOf(Function);
+        expect(Neo.main.addon.LocalStorage.updateLocalStorageItem).toBeInstanceOf(Function);
+        expect(Neo.main.addon.LocalStorage.destroyLocalStorageItem).toBeInstanceOf(Function);
+
+        viewport = Neo.create(TestViewport, {appName});
+
+        await viewport.controller.ready();
+        await viewport.controller.storagePromise;
+
+        expect(viewport.controller.isReady).toBe(true);
+    });
+
+    test('setup() preserves pre-installed Neo.Main and LocalStorage mocks', async () => {
+        const routeCalls = [];
+        const storageReads = [];
+
+        Neo.Main = {
+            setRoute: data => routeCalls.push(data)
+        };
+
+        Neo.main.addon.LocalStorage = {
+            destroyLocalStorageItem: async () => {},
+            readLocalStorageItem: async data => {
+                storageReads.push(data);
+                return {key: data.key, value: Object.fromEntries(data.key.map(item => [item, null]))}
+            },
+            updateLocalStorageItem: async () => {}
+        };
+
+        setup({
+            appConfig: {
+                name: appName
+            }
+        });
+
+        viewport = Neo.create(TestViewport, {appName});
+
+        await viewport.controller.ready();
+        await viewport.controller.storagePromise;
+
+        expect(routeCalls).toEqual([{value: '/home', windowId: null}]);
+        expect(storageReads).toEqual([{
+            key     : ['viewportSetupTheme', 'viewportSetupLayout'],
+            windowId: null
+        }]);
+    });
+
+    test('setup() can opt out of Neo.Main and LocalStorage mocks', () => {
+        setup({
+            appConfig: {
+                name: appName
+            },
+            mockLocalStorage: false,
+            mockMain        : false
+        });
+
+        expect(Neo.Main).toBeUndefined();
+        expect(Neo.main.addon.LocalStorage).toBeUndefined();
+    });
+});


### PR DESCRIPTION
Authored by GPT-5.5 (Codex Desktop). Session 8591bc48-0ddc-48bf-aa47-58e53ea81a57.

FAIR-band: in-band [7/30]

Resolves #11578

Extends the shared unit-test setup helper with default `Neo.Main.setRoute()` and `Neo.main.addon.LocalStorage` facades, adds opt-out flags for specs that install richer mocks, and covers the downstream root viewport/controller smoke path with a regression spec.

Evidence: L2 (focused and compatibility unit-test coverage of setup defaults, preservation, and opt-outs) -> L2 required (unit-test setup-helper ACs). No residuals.

## Deltas from ticket
- The live LocalStorage API exposes `destroyLocalStorageItem`, so this PR mocks that method instead of the ticket body phrase `removeLocalStorageItem`.

## Test Evidence
- `git diff --check` passed.
- `git diff --cached --check` passed before commit.
- `npm run test-unit -- test/playwright/unit/container/ViewportSetupMocks.spec.mjs` -> 3 passed.
- `npm run test-unit -- test/playwright/unit/container/ViewportSetupMocks.spec.mjs test/playwright/unit/component/Progress.spec.mjs test/playwright/unit/core/Effect.spec.mjs` -> 7 passed.
- `npm run test-unit` was attempted: 1390 passed, 74 failed, 5 skipped, 19 did not run. The new `ViewportSetupMocks` tests passed in that run; observed failures were unrelated Chroma, GitHub network, SQLite readonly, MCP harness, and grid infrastructure failures.

## Post-Merge Validation
- [ ] Downstream app unit tests can construct a root `Neo.container.Viewport` with a real controller and no custom main-thread mocks.

## Commits
- `485504cf1` - `feat(test): mock main route and local storage in setup (#11578)`