### PR TITLE
feat(mcp): sync_all strict root validation and auto-commit bypass (#11580)

### DIFF
--- a/ai/mcp/server/github-workflow/toolService.mjs
+++ b/ai/mcp/server/github-workflow/toolService.mjs
@@ -27,6 +27,25 @@ const openApiFilePath = path.join(__dirname, 'openapi.yaml');
  * @returns {Promise<String>} current branch name, '' for detached HEAD.
  */
 async function defaultBranchDetector() {
+    let toplevel;
+    try {
+        const {stdout} = await execFileAsync('git', ['rev-parse', '--show-toplevel'], {cwd: config.projectRoot});
+        toplevel = stdout.trim();
+    } catch (e) {
+        throw new Error(`sync_all REJECTED: could not resolve git top-level (git error: ${e.message}).`);
+    }
+
+    const normalizedProjectRoot = path.resolve(config.projectRoot);
+    const normalizedToplevel = path.resolve(toplevel);
+
+    if (normalizedProjectRoot !== normalizedToplevel) {
+        throw new Error(
+            `sync_all REJECTED: Root mismatch. MCP server projectRoot '${normalizedProjectRoot}' ` +
+            `does not match git repository top-level '${normalizedToplevel}'. ` +
+            `This prevents cross-checkout branch diagnostics and context leakage.`
+        );
+    }
+
     const {stdout} = await execFileAsync('git', ['branch', '--show-current'], {cwd: config.projectRoot});
     return stdout.trim();
 }
@@ -54,6 +73,9 @@ function buildDevBranchGuard(delegate, getBranch = defaultBranchDetector) {
         try {
             branch = await getBranch();
         } catch (e) {
+            if (e.message && e.message.startsWith('sync_all REJECTED:')) {
+                throw e;
+            }
             throw new Error(`sync_all REJECTED: could not determine current branch (git error: ${e.message}). Refusing to sync without branch confirmation.`);
         }
         if (branch !== 'dev') {

--- a/ai/services/github-workflow/SyncService.mjs
+++ b/ai/services/github-workflow/SyncService.mjs
@@ -162,7 +162,11 @@ class SyncService extends Base {
                         } else {
                             logger.info('[SyncService] Detected real content changes. Committing and pushing.');
                             await execAsync('git add resources/content', {cwd});
-                            await execAsync('git commit -m "chore: ticket sync [skip ci]"', {cwd});
+                            // Sanctioned bypass for check-chore-sync.mjs guard
+                            await execAsync('git commit -m "chore: ticket sync [skip ci]"', {
+                                cwd,
+                                env: { ...process.env, NEO_SYNC_AUTOCOMMIT: '1' }
+                            });
                             await execAsync('git pull --rebase --autostash', {cwd});
                             await execAsync('git push', {cwd});
                             logger.info('[SyncService] Successfully pushed changes to GitHub.');

--- a/buildScripts/util/check-chore-sync.mjs
+++ b/buildScripts/util/check-chore-sync.mjs
@@ -1,10 +1,36 @@
 import { execSync } from 'node:child_process';
 import process from 'node:process';
+import path from 'node:path';
+
+// Allow explicit override via temporary environment flag NEO_SYNC_AUTOCOMMIT=1
+if (process.env.NEO_SYNC_AUTOCOMMIT === '1') {
+    process.exit(0);
+}
+
+// Get absolute git repository root to prevent cross-checkout branch diagnostics
+let gitRoot;
+try {
+    gitRoot = execSync('git rev-parse --show-toplevel', { encoding: 'utf-8' }).trim();
+} catch (e) {
+    console.error('\x1b[31mError: Could not determine git repository root.\x1b[0m');
+    process.exit(1);
+}
+
+// Verify that the current working directory matches the expected repository root
+const normalizedCwd = path.resolve(process.cwd());
+const normalizedGitRoot = path.resolve(gitRoot);
+
+if (normalizedCwd !== normalizedGitRoot) {
+    console.error(`\x1b[31mError: Repository root mismatch.\x1b[0m`);
+    console.error(`check-chore-sync.mjs is running in '${normalizedCwd}', but the git repository root is '${normalizedGitRoot}'.`);
+    console.error(`This prevents cross-checkout branch diagnostics and ensures context alignment.`);
+    process.exit(1);
+}
 
 // Get current branch
 let branch;
 try {
-    branch = execSync('git rev-parse --abbrev-ref HEAD', { encoding: 'utf-8' }).trim();
+    branch = execSync('git rev-parse --abbrev-ref HEAD', { cwd: gitRoot, encoding: 'utf-8' }).trim();
 } catch (e) {
     console.error('Error getting git branch');
     process.exit(1);
@@ -21,7 +47,7 @@ if (isDataBranch) {
 // Get staged files
 let stagedFiles = [];
 try {
-    const output = execSync('git diff --cached --name-only', { encoding: 'utf-8' }).trim();
+    const output = execSync('git diff --cached --name-only', { cwd: gitRoot, encoding: 'utf-8' }).trim();
     if (output) {
         stagedFiles = output.split('\n');
     }

--- a/buildScripts/util/check-chore-sync.mjs
+++ b/buildScripts/util/check-chore-sync.mjs
@@ -2,10 +2,7 @@ import { execSync } from 'node:child_process';
 import process from 'node:process';
 import path from 'node:path';
 
-// Allow explicit override via temporary environment flag NEO_SYNC_AUTOCOMMIT=1
-if (process.env.NEO_SYNC_AUTOCOMMIT === '1') {
-    process.exit(0);
-}
+
 
 // Get absolute git repository root to prevent cross-checkout branch diagnostics
 let gitRoot;
@@ -62,6 +59,19 @@ const dataDirs = [
     'resources/content/discussions/'
 ];
 
+// If NEO_SYNC_AUTOCOMMIT is set, we must strictly enforce that ONLY data files are staged.
+// This prevents auto-commits from leaking manually staged source code files into sync commits.
+if (process.env.NEO_SYNC_AUTOCOMMIT === '1') {
+    const nonSyncFiles = stagedFiles.filter(file => !dataDirs.some(dir => file.startsWith(dir)));
+    if (nonSyncFiles.length > 0) {
+        console.error(`\x1b[31mError: NEO_SYNC_AUTOCOMMIT bypass rejected.\x1b[0m`);
+        console.error(`Automated sync commits must ONLY contain data files. The following non-sync files are staged:`);
+        nonSyncFiles.forEach(f => console.error(`  - ${f}`));
+        process.exit(1);
+    }
+    process.exit(0);
+}
+
 const violatingFiles = stagedFiles.filter(file =>
     dataDirs.some(dir => file.startsWith(dir))
 );
@@ -71,7 +81,7 @@ const violatingFiles = stagedFiles.filter(file =>
 if (violatingFiles.length > 0) {
     const allowedList = ALLOWED_PREFIXES.map(p => `'${p}*'`).join(' or ');
     console.error(`\x1b[31mError: Sync-data leakage detected.\x1b[0m`);
-    console.error(`Branch '${branch}' is not a designated data-sync branch (e.g., ${allowedList}).`);
+    console.error(`Branch '${branch}' (in root '${normalizedGitRoot}') is not a designated data-sync branch (e.g., ${allowedList}).`);
     console.error(`The following data files are staged for commit:`);
     violatingFiles.forEach(f => console.error(`  - ${f}`));
     console.error(`\nIf you must commit these files, either:`);

--- a/test/playwright/unit/ai/buildScripts/util/check-chore-sync.spec.mjs
+++ b/test/playwright/unit/ai/buildScripts/util/check-chore-sync.spec.mjs
@@ -7,7 +7,7 @@ import { fileURLToPath } from 'node:url';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
-const scriptPath = path.resolve(__dirname, '../../../../../buildScripts/util/check-chore-sync.mjs');
+const scriptPath = path.resolve(__dirname, '../../../../../../buildScripts/util/check-chore-sync.mjs');
 
 test.describe('check-chore-sync.mjs', () => {
     let tempDir;

--- a/test/playwright/unit/ai/services/github-workflow/toolService.spec.mjs
+++ b/test/playwright/unit/ai/services/github-workflow/toolService.spec.mjs
@@ -84,6 +84,15 @@ test.describe('Neo.ai.services.github-workflow.toolService — sync_all dev-bran
         await expect(guarded()).rejects.toThrow(/sync_all REJECTED.*'\(detached\)'/);
     });
 
+    test('sync_all REJECTS immediately on root mismatch from branch detector', async () => {
+        const delegate = async () => { throw new Error('should not run'); };
+        const guarded = buildDevBranchGuard(delegate, async () => {
+            throw new Error('sync_all REJECTED: Root mismatch. MCP server projectRoot...');
+        });
+
+        await expect(guarded()).rejects.toThrow(/sync_all REJECTED: Root mismatch/);
+    });
+
     test('sync_all REJECTS with git-error message when branch detector throws', async () => {
         const delegate = async () => { throw new Error('should not run'); };
         const guarded = buildDevBranchGuard(delegate, async () => {

--- a/test/playwright/unit/buildScripts/util/check-chore-sync.spec.mjs
+++ b/test/playwright/unit/buildScripts/util/check-chore-sync.spec.mjs
@@ -1,0 +1,93 @@
+import { test, expect } from '@playwright/test';
+import { execSync } from 'node:child_process';
+import path from 'node:path';
+import fs from 'node:fs';
+import os from 'node:os';
+import { fileURLToPath } from 'node:url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const scriptPath = path.resolve(__dirname, '../../../../../buildScripts/util/check-chore-sync.mjs');
+
+test.describe('check-chore-sync.mjs', () => {
+    let tempDir;
+
+    test.beforeEach(() => {
+        tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'neo-sync-test-'));
+        execSync('git init', { cwd: tempDir, stdio: 'ignore' });
+        execSync('git config user.email "test@example.com"', { cwd: tempDir, stdio: 'ignore' });
+        execSync('git config user.name "Test User"', { cwd: tempDir, stdio: 'ignore' });
+        execSync('git commit --allow-empty -m "Init"', { cwd: tempDir, stdio: 'ignore' });
+
+        // Ensure we're on a non-data branch like 'dev'
+        execSync('git checkout -b dev', { cwd: tempDir, stdio: 'ignore' });
+    });
+
+    test.afterEach(() => {
+        fs.rmSync(tempDir, { recursive: true, force: true });
+    });
+
+    const runScript = (cwd, env = {}) => {
+        try {
+            const output = execSync(`node ${scriptPath}`, {
+                cwd,
+                env: { ...process.env, ...env },
+                encoding: 'utf-8',
+                stdio: 'pipe'
+            });
+            return { status: 0, output };
+        } catch (error) {
+            return { status: error.status, output: error.stderr || error.stdout };
+        }
+    };
+
+    const stageFile = (filePath) => {
+        const fullPath = path.join(tempDir, filePath);
+        fs.mkdirSync(path.dirname(fullPath), { recursive: true });
+        fs.writeFileSync(fullPath, 'test content');
+        execSync(`git add ${filePath}`, { cwd: tempDir, stdio: 'ignore' });
+    };
+
+    test('normal reject: staging a data file on dev branch fails', () => {
+        stageFile('resources/content/issues/1.md');
+        const result = runScript(tempDir);
+        expect(result.status).toBe(1);
+        expect(result.output).toContain('Error: Sync-data leakage detected');
+        expect(result.output).toContain("Branch 'dev' (in root");
+        expect(result.output).toContain('resources/content/issues/1.md');
+    });
+
+    test('sanctioned bypass: staging a data file on chore/sync- branch passes', () => {
+        execSync('git checkout -b chore/sync-123', { cwd: tempDir, stdio: 'ignore' });
+        stageFile('resources/content/issues/1.md');
+        const result = runScript(tempDir);
+        expect(result.status).toBe(0);
+    });
+
+    test('valid sync-only staging with NEO_SYNC_AUTOCOMMIT=1 passes', () => {
+        stageFile('resources/content/issues/1.md');
+        const result = runScript(tempDir, { NEO_SYNC_AUTOCOMMIT: '1' });
+        expect(result.status).toBe(0);
+    });
+
+    test('non-sync staged file rejection with env var: mixed files fails', () => {
+        stageFile('resources/content/issues/1.md');
+        stageFile('src/foo.js');
+        const result = runScript(tempDir, { NEO_SYNC_AUTOCOMMIT: '1' });
+        expect(result.status).toBe(1);
+        expect(result.output).toContain('Error: NEO_SYNC_AUTOCOMMIT bypass rejected.');
+        expect(result.output).toContain('Automated sync commits must ONLY contain data files.');
+        expect(result.output).toContain('src/foo.js');
+        // It shouldn't complain about the data file
+        expect(result.output).not.toContain('resources/content/issues/1.md');
+    });
+
+    test('root diagnostics: running the script in a subdirectory fails', () => {
+        const subDir = path.join(tempDir, 'subdir');
+        fs.mkdirSync(subDir);
+        const result = runScript(subDir);
+        expect(result.status).toBe(1);
+        expect(result.output).toContain('Error: Repository root mismatch');
+        expect(result.output).toContain('check-chore-sync.mjs is running in');
+    });
+});


### PR DESCRIPTION
Authored by neo-gemini-3-1-pro (Antigravity). Session d7e2d66c-d802-4156-ab43-bce28b07e089.
FAIR-band: in-band [11/30 — current author count over last 30 merged]

Resolves #11580

Implemented absolute git root verification in the `sync_all` tool to prevent cross-checkout branch diagnostic errors. Added an official bypass mechanism via `NEO_SYNC_AUTOCOMMIT=1` for automated chore syncs, enabling the buildScripts guard bypass.

Evidence: L1 (static logic and test audit) → L1 required (no runtime-verify ACs). No residuals.

## Deltas from ticket (if any)
None.

## Test Evidence
Added unit test case for root mismatch rejection in `toolService.spec.mjs` and hook-level tests for `check-chore-sync.mjs`. Verified locally via `npm run test-unit`.

## Post-Merge Validation
- [ ] Monitor CI runs to verify sync_all continues to function correctly during chore commits on dev without diagnostic errors.

## Commits
- 807d5efeb — fix(sync): implement data sync bypass and strict root validation (#11580)
- af3fb29de — test(sync): add hook-level tests and narrow bypass (#11580)
- adcb15bba — test(buildScripts): move check-chore-sync tests to ai subfolder (#11580)
