### PR TITLE
fix(build): restore direct-dev sync auto-push (#11582)

### DIFF
--- a/buildScripts/util/check-chore-sync.mjs
+++ b/buildScripts/util/check-chore-sync.mjs
@@ -1,26 +1,29 @@
 import { execSync } from 'node:child_process';
 import process from 'node:process';
 import path from 'node:path';
+import { fileURLToPath } from 'node:url';
 
+// Anchor git checks to the repository that owns this hook script, not the caller's cwd.
+const __filename = fileURLToPath(import.meta.url);
+const __dirname  = path.dirname(__filename);
+const scriptRoot = path.resolve(__dirname, '../..');
 
-
-// Get absolute git repository root to prevent cross-checkout branch diagnostics
+// Get absolute git repository root to prevent cross-checkout branch diagnostics.
 let gitRoot;
 try {
-    gitRoot = execSync('git rev-parse --show-toplevel', { encoding: 'utf-8' }).trim();
+    gitRoot = execSync('git rev-parse --show-toplevel', { cwd: scriptRoot, encoding: 'utf-8' }).trim();
 } catch (e) {
     console.error('\x1b[31mError: Could not determine git repository root.\x1b[0m');
     process.exit(1);
 }
 
-// Verify that the current working directory matches the expected repository root
-const normalizedCwd = path.resolve(process.cwd());
 const normalizedGitRoot = path.resolve(gitRoot);
+const normalizedScriptRoot = path.resolve(scriptRoot);
 
-if (normalizedCwd !== normalizedGitRoot) {
-    console.error(`\x1b[31mError: Repository root mismatch.\x1b[0m`);
-    console.error(`check-chore-sync.mjs is running in '${normalizedCwd}', but the git repository root is '${normalizedGitRoot}'.`);
-    console.error(`This prevents cross-checkout branch diagnostics and ensures context alignment.`);
+if (normalizedScriptRoot !== normalizedGitRoot) {
+    console.error(`\x1b[31mError: Script repository root mismatch.\x1b[0m`);
+    console.error(`check-chore-sync.mjs is located under '${normalizedScriptRoot}', but the git repository root is '${normalizedGitRoot}'.`);
+    console.error(`This prevents cross-checkout branch diagnostics and ensures hook ownership alignment.`);
     process.exit(1);
 }
 
@@ -53,16 +56,27 @@ try {
     process.exit(1);
 }
 
-// Define the generated data directories that should not be committed outside data branches
-const dataDirs = [
+// Generated GitHub workflow content that should not leak into feature commits.
+const generatedSyncPaths = [
     'resources/content/issues/',
-    'resources/content/discussions/'
+    'resources/content/discussions/',
+    'resources/content/pulls/',
+    'resources/content/release-notes/',
+    'resources/content/archive/',
+    'resources/content/issue-archive/',
+    'resources/content/pr-archive/',
+    'resources/content/_index.json',
+    'resources/content/.sync-metadata.json'
 ];
+
+const isGeneratedSyncFile = file => generatedSyncPaths.some(item =>
+    item.endsWith('/') ? file.startsWith(item) : file === item
+);
 
 // If NEO_SYNC_AUTOCOMMIT is set, we must strictly enforce that ONLY data files are staged.
 // This prevents auto-commits from leaking manually staged source code files into sync commits.
 if (process.env.NEO_SYNC_AUTOCOMMIT === '1') {
-    const nonSyncFiles = stagedFiles.filter(file => !dataDirs.some(dir => file.startsWith(dir)));
+    const nonSyncFiles = stagedFiles.filter(file => !isGeneratedSyncFile(file));
     if (nonSyncFiles.length > 0) {
         console.error(`\x1b[31mError: NEO_SYNC_AUTOCOMMIT bypass rejected.\x1b[0m`);
         console.error(`Automated sync commits must ONLY contain data files. The following non-sync files are staged:`);
@@ -73,7 +87,7 @@ if (process.env.NEO_SYNC_AUTOCOMMIT === '1') {
 }
 
 const violatingFiles = stagedFiles.filter(file =>
-    dataDirs.some(dir => file.startsWith(dir))
+    isGeneratedSyncFile(file)
 );
 
 // Allow explicit override via --force-data or bypassing hooks

--- a/test/playwright/unit/ai/buildScripts/util/check-chore-sync.spec.mjs
+++ b/test/playwright/unit/ai/buildScripts/util/check-chore-sync.spec.mjs
@@ -11,6 +11,7 @@ const scriptPath = path.resolve(__dirname, '../../../../../../buildScripts/util/
 
 test.describe('check-chore-sync.mjs', () => {
     let tempDir;
+    let testScriptPath;
 
     test.beforeEach(() => {
         tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'neo-sync-test-'));
@@ -18,6 +19,10 @@ test.describe('check-chore-sync.mjs', () => {
         execSync('git config user.email "test@example.com"', { cwd: tempDir, stdio: 'ignore' });
         execSync('git config user.name "Test User"', { cwd: tempDir, stdio: 'ignore' });
         execSync('git commit --allow-empty -m "Init"', { cwd: tempDir, stdio: 'ignore' });
+
+        testScriptPath = path.join(tempDir, 'buildScripts/util/check-chore-sync.mjs');
+        fs.mkdirSync(path.dirname(testScriptPath), {recursive: true});
+        fs.copyFileSync(scriptPath, testScriptPath);
 
         // Ensure we're on a non-data branch like 'dev'
         execSync('git checkout -b dev', { cwd: tempDir, stdio: 'ignore' });
@@ -29,7 +34,7 @@ test.describe('check-chore-sync.mjs', () => {
 
     const runScript = (cwd, env = {}) => {
         try {
-            const output = execSync(`node ${scriptPath}`, {
+            const output = execSync(`node ${testScriptPath}`, {
                 cwd,
                 env: { ...process.env, ...env },
                 encoding: 'utf-8',
@@ -64,8 +69,26 @@ test.describe('check-chore-sync.mjs', () => {
         expect(result.status).toBe(0);
     });
 
-    test('valid sync-only staging with NEO_SYNC_AUTOCOMMIT=1 passes', () => {
+    test('sanctioned bypass: staging a data file on agent/sync- branch passes', () => {
+        execSync('git checkout -b agent/sync-123', { cwd: tempDir, stdio: 'ignore' });
         stageFile('resources/content/issues/1.md');
+        const result = runScript(tempDir);
+        expect(result.status).toBe(0);
+    });
+
+    test('valid sync-only staging with NEO_SYNC_AUTOCOMMIT=1 passes for generated workflow content', () => {
+        [
+            'resources/content/issues/chunk-1/issue-1.md',
+            'resources/content/discussions/chunk-1/discussion-1.md',
+            'resources/content/pulls/chunk-1/pr-1.md',
+            'resources/content/release-notes/chunk-1/v1.0.0.md',
+            'resources/content/archive/issues/v1.0.0/chunk-1/issue-2.md',
+            'resources/content/issue-archive/chunk-1/issue-3.md',
+            'resources/content/pr-archive/chunk-1/pr-2.md',
+            'resources/content/_index.json',
+            'resources/content/.sync-metadata.json'
+        ].forEach(stageFile);
+
         const result = runScript(tempDir, { NEO_SYNC_AUTOCOMMIT: '1' });
         expect(result.status).toBe(0);
     });
@@ -82,12 +105,27 @@ test.describe('check-chore-sync.mjs', () => {
         expect(result.output).not.toContain('resources/content/issues/1.md');
     });
 
-    test('root diagnostics: running the script in a subdirectory fails', () => {
-        const subDir = path.join(tempDir, 'subdir');
-        fs.mkdirSync(subDir);
-        const result = runScript(subDir);
+    test('non-sync staged file rejection with env var: unowned resources content fails', () => {
+        stageFile('resources/content/concepts/example.md');
+        const result = runScript(tempDir, { NEO_SYNC_AUTOCOMMIT: '1' });
         expect(result.status).toBe(1);
-        expect(result.output).toContain('Error: Repository root mismatch');
-        expect(result.output).toContain('check-chore-sync.mjs is running in');
+        expect(result.output).toContain('Error: NEO_SYNC_AUTOCOMMIT bypass rejected.');
+        expect(result.output).toContain('resources/content/concepts/example.md');
+    });
+
+    test('script root anchoring: running from a non-repo cwd checks the owning repo', () => {
+        const otherDir = fs.mkdtempSync(path.join(os.tmpdir(), 'neo-sync-foreign-'));
+
+        try {
+            stageFile('resources/content/issues/1.md');
+            const result = runScript(otherDir);
+            expect(result.status).toBe(1);
+            expect(result.output).toContain('Error: Sync-data leakage detected');
+            expect(result.output).toContain("Branch 'dev' (in root");
+            expect(result.output).toContain(tempDir);
+            expect(result.output).toContain('resources/content/issues/1.md');
+        } finally {
+            fs.rmSync(otherDir, {recursive: true, force: true});
+        }
     });
 });


### PR DESCRIPTION
Authored by GPT-5 (Codex Desktop). Session 8591bc48-0ddc-48bf-aa47-58e53ea81a57.

FAIR-band: under-target [7/30] — Self-Selection Rule 1 fires (under-band -> bias toward author lane)

Resolves #11582

Restores the intended direct-to-dev automation boundary for GitHub workflow syncs. The pre-commit guard now anchors git checks to the repository that owns `check-chore-sync.mjs`, not arbitrary caller cwd, and `NEO_SYNC_AUTOCOMMIT=1` now permits the actual generated GitHub workflow corpus while still rejecting mixed source-code payloads.

Evidence: L2 (targeted Playwright unit tests against temporary git repos + live hook no-op) -> L2 required (pre-commit guard behavior). No residuals.

## Deltas from ticket

No scope expansion. The implementation keeps `chore/sync-*` and `agent/sync-*` as manual escape hatches, while restoring the automation path as direct-to-dev guarded by generated-payload validation.

## Test Evidence

- `npm run test-unit -- test/playwright/unit/ai/buildScripts/util/check-chore-sync.spec.mjs` -> 7 passed.
- `git diff --check` -> passed.
- `node buildScripts/util/check-chore-sync.mjs` on this branch with no staged generated data -> passed.
- Pre-push freshness check: `merge-base HEAD origin/dev == origin/dev`; outgoing log contained only `efee54c49 fix(build): restore direct-dev sync auto-push (#11582)`.

## Post-Merge Validation

- [ ] Next `npm run ai:sync-github-workflow` content delta can auto-commit/push on `dev` with `NEO_SYNC_AUTOCOMMIT=1` when only generated GitHub workflow content is staged.
- [ ] Feature branches still reject manually staged generated GitHub workflow content without the sanctioned env bypass or sync branch prefix.

## Commit

- `efee54c49` — `fix(build): restore direct-dev sync auto-push (#11582)`