### PR TITLE
fix(lint): invert lint-agents.mjs to block <a id> tags (#11584)

### DIFF
--- a/ai/scripts/lint-agents.mjs
+++ b/ai/scripts/lint-agents.mjs
@@ -1,63 +1,93 @@
 #!/usr/bin/env node
 /**
- * Pre-Flight (structural fast-path): authoring `ai/scripts/lint-agents.mjs` matches
- * sibling pattern of `ai/scripts/lint-skill-manifest.mjs` and `ai/scripts/check-retired-primitives.mjs`
- * in `ai/scripts/`; all three are mechanical-enforcement / CI scripts for agent substrate
- * validation; sibling-file-lift applies; no novel directory choice.
+ * @summary PR-diff-scoped lint that flags NEW `<a id="...">` / `<a name="...">` HTML
+ * anchor-tag insertions in turn-loaded Map substrate, `.agents/skills/**` skill substrate,
+ * and `learn/agentos/**` Agent OS substrate per Discussion #11577 graduation.
  *
- * @summary PR-diff-scoped lint that flags NEW live positional `§N` references in
- * `.agents/skills/**` markdown per ADR 0011 (Substrate Numbering Convention).
+ * **Graduation context:** Discussion #11577 graduated 2026-05-18 under operator-corrected
+ * substrate (DC_kwDODSospM4BAt-P). The graduated form is a substrate-discipline statement,
+ * NOT a migration plan: `§<ref>` text-only stable identifiers are correct; HTML `<a id>` /
+ * `<a name>` anchor-tag scaffolding is damage. Operator forward-rule: ANY new `<a>` anchor
+ * tags in substrate PRs are review blockers unless a narrow rendered-consumer exception is
+ * explicitly justified + operator-approved.
  *
- * Active references must target stable semantic anchors. Historical / archaeology
- * references remain permitted when the same line explicitly classifies them
- * (case-insensitive `historical`, `archaeology`, `errata`).
+ * **Inverts the original #11560 design.** The prior pattern (block positional `§\d+` refs in
+ * skill files) inverted the substrate-correct direction. PR #11571 demonstrated the damage
+ * empirically: +4,358 bytes / 36 `<a id>` tags / 46 markdown-link refs landed on `dev` across
+ * `AGENTS.md` (+1,543b / 13 tags), `AGENTS_STARTUP.md` (+409b / 0 tags), and
+ * `learn/agentos/AGENTS_ATLAS.md` (+2,406b / 23 tags) before substrate-correction caught it.
  *
- * Scope is intentionally diff-scoped: pre-existing positional references remain
- * (264+ across `.agents/skills/` at lint introduction time) and migrate under
- * sibling Epic #11558 sub-tickets #11561, #11562, #11564. This script is the
- * regression gate that prevents new positional refs from re-entering live
- * substrate after migration.
+ * **Diff-scoped + historical-marker discipline preserved.** Lint operates on NEW added lines
+ * only; same-line historical / archaeology / errata classification keeps existing
+ * substrate-archaeology references legitimate. Authors who genuinely need to insert an
+ * anchor tag for a narrow rendered-consumer reason can mark the line with `rendered-consumer`
+ * (operator-approved exception per Discussion #11577 forward-rule).
  *
- * @see learn/agentos/decisions/0011-substrate-numbering-convention.md §2.4
- * @see #11558 (epic) / #11560 (this ticket) / #11557 (graduating discussion)
+ * @see learn/agentos/decisions/0011-substrate-numbering-convention.md (amendment in progress)
+ * @see #11584 (this inversion) / #11577 (graduating discussion) / #11571 (damage PR)
+ * @see feedback_agents_md_24kib_hard_cap (review discipline anchor)
  */
-import {execFileSync} from 'node:child_process';
-import path           from 'node:path';
-import process        from 'node:process';
-import {fileURLToPath} from 'node:url';
+import {execFileSync}    from 'node:child_process';
+import path              from 'node:path';
+import process           from 'node:process';
+import {fileURLToPath}   from 'node:url';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname  = path.dirname(__filename);
 const ROOT_DIR   = path.resolve(__dirname, '../..');
 
 /**
- * Files matching this prefix are in scope. Lint operates on NEW lines added
- * inside `.agents/skills/` markdown only. Other substrate (AGENTS.md / ATLAS /
- * ADRs / general docs) migrates under separate Epic #11558 children and may
- * eventually carry its own guard.
+ * Top-level Map substrate files (turn-loaded; AGENTS.md is mechanically capped at
+ * 24,576 bytes by `check-substrate-size.mjs:PER_FILE_LIMIT_BYTES` with truncation).
+ * Anchor-tag scaffolding here directly compresses future instruction budget.
  */
-const SCOPE_PREFIX = '.agents/skills/';
+const TOP_LEVEL_MAP_FILES = new Set([
+    'AGENTS.md',
+    'AGENTS_STARTUP.md',
+    '.agents/ANTIGRAVITY_RULES.md'
+]);
+
+/**
+ * Skill substrate (skill-loaded; loaded at skill invocation, payloads can grow but
+ * carry per-invocation cost). Subject to the operator forward-rule.
+ */
+const SKILL_PREFIX = '.agents/skills/';
+
+/**
+ * Agent OS substrate (mixed turn-load + skill-load + reference-load). Includes
+ * `AGENTS_ATLAS.md` (World Atlas Map) and the ADR set under `decisions/`. Subject to
+ * the operator forward-rule per #11577 graduation.
+ */
+const AGENTOS_PREFIX = 'learn/agentos/';
+
+/**
+ * Only markdown files participate; manifests, JSON, and other non-prose substrate
+ * cannot meaningfully carry anchor-tag damage.
+ */
 const SCOPE_SUFFIX = '.md';
 
 /**
- * Regex for live positional references. Matches `§N` where N is one or more
- * digits with optional dotted sub-section (e.g. `§5.2.3`). Anchored on `§`
- * to avoid false matches against `#` heading anchors or `Section N` prose.
+ * Regex for `<a id="...">` / `<a name="...">` HTML anchor-tag insertions. Tolerates
+ * intervening attributes (e.g. `<a class="x" id="foo">`) and whitespace. Case-insensitive.
+ * Anchored on `<a\b` word-boundary to avoid false matches against `<abbr>`, `<area>`, etc.
+ * The `\s(?:id|name)\s*=` clause requires the attribute keyword to be a discrete token,
+ * so `<a href="...">` regular hyperlinks (no id/name attribute) are NOT flagged.
  */
-const POSITIONAL_REF_PATTERN = /§\d+(?:\.\d+)*\b/g;
+const ANCHOR_TAG_PATTERN = /<a\b[^>]*\s(?:id|name)\s*=/gi;
 
 /**
- * Same-line classification cues that explicitly mark a reference as historical /
- * archaeology per ADR 0011 §2.3. Case-insensitive substring match keeps the
- * heuristic simple and grep-auditable.
+ * Same-line classification cues that explicitly exempt a line per Discussion #11577
+ * forward-rule. `historical` / `archaeology` / `errata` preserve substrate-archaeology
+ * references; `rendered-consumer` covers the narrow operator-approved exception for
+ * specific rendered-consumer needs. Case-insensitive substring match.
  */
-const HISTORICAL_MARKERS = ['historical', 'archaeology', 'errata'];
+const EXEMPTION_MARKERS = ['historical', 'archaeology', 'errata', 'rendered-consumer'];
 
 /**
  * Parses simple `--base <branch>` / `--base=<branch>` CLI args. Default base is
  * `origin/dev` to match `lint-skill-manifest.mjs` and CI workflow conventions.
  * @param {string[]} argv
- * @returns {{base: string}}
+ * @returns {{base: string, help?: boolean}}
  */
 function parseArgs(argv = process.argv.slice(2)) {
     const options = {base: 'origin/dev'};
@@ -80,16 +110,24 @@ function parseArgs(argv = process.argv.slice(2)) {
 }
 
 /**
- * Runs `git diff --unified=0 <base>...HEAD -- <pathspec>` and returns the raw diff text.
+ * Runs `git diff --unified=0 <base>...HEAD` and returns the raw diff text.
+ * Pathspecs cover the union of all in-scope substrate roots so the lint catches
+ * insertions across Map + skill + Agent OS files in a single diff pass.
  * Empty string when no diff or when base ref doesn't exist locally.
  * @param {string} base Git ref to compare HEAD against.
  * @returns {string}
  */
 function gitDiff(base) {
+    const pathspecs = [
+        ...TOP_LEVEL_MAP_FILES,
+        SKILL_PREFIX,
+        AGENTOS_PREFIX
+    ];
+
     try {
         return execFileSync(
             'git',
-            ['diff', '--unified=0', `${base}...HEAD`, '--', SCOPE_PREFIX],
+            ['diff', '--unified=0', `${base}...HEAD`, '--', ...pathspecs],
             {cwd: ROOT_DIR, encoding: 'utf8'}
         );
     } catch (error) {
@@ -166,47 +204,53 @@ function parseAddedLines(diffText) {
 }
 
 /**
- * Returns true when the line text contains a same-line historical-classification
- * marker per ADR 0011 §2.3. Match is case-insensitive substring; intentionally
- * permissive so authors can mark refs without learning a strict syntax.
+ * Returns true when the line text contains a same-line exemption marker per
+ * Discussion #11577 forward-rule. Match is case-insensitive substring; intentionally
+ * permissive so authors can mark lines without learning a strict syntax.
  * @param {string} text
  * @returns {boolean}
  */
-function isHistoricalContext(text) {
+function isExempt(text) {
     const lower = text.toLowerCase();
-    return HISTORICAL_MARKERS.some(marker => lower.includes(marker));
+    return EXEMPTION_MARKERS.some(marker => lower.includes(marker));
 }
 
 /**
- * Returns true when the file path falls within the lint scope.
- * Excludes `.agents/skills/skills.manifest.json` and other non-markdown substrate.
+ * Returns true when the file path falls within the lint scope. Covers turn-loaded Map
+ * substrate (AGENTS.md / AGENTS_STARTUP.md / ANTIGRAVITY_RULES.md), skill substrate
+ * (.agents/skills/**\/*.md), and Agent OS substrate (learn/agentos/**\/*.md).
+ * Manifests, JSON, and other non-markdown substrate are out of scope.
  * @param {string} filePath
  * @returns {boolean}
  */
 function isInScope(filePath) {
-    return filePath.startsWith(SCOPE_PREFIX) && filePath.endsWith(SCOPE_SUFFIX);
+    if (TOP_LEVEL_MAP_FILES.has(filePath)) return true;
+    if (!filePath.endsWith(SCOPE_SUFFIX)) return false;
+    if (filePath.startsWith(SKILL_PREFIX))   return true;
+    if (filePath.startsWith(AGENTOS_PREFIX)) return true;
+    return false;
 }
 
 /**
- * Inspects a single added line for positional references that need migration to
- * a semantic anchor. Returns an array of violation records (empty when clean or
- * when the line is historically-classified).
+ * Inspects a single added line for `<a id>` / `<a name>` HTML anchor-tag insertions.
+ * Returns an array of violation records (empty when clean or when the line carries an
+ * exemption marker per `EXEMPTION_MARKERS`).
  * @param {{file: string, line: number, text: string}} record
- * @returns {Array<{file: string, line: number, ref: string, text: string}>}
+ * @returns {Array<{file: string, line: number, match: string, text: string}>}
  */
 function findViolationsInLine(record) {
     if (!isInScope(record.file)) return [];
-    if (isHistoricalContext(record.text)) return [];
+    if (isExempt(record.text))   return [];
 
     const violations = [];
-    const matches    = record.text.matchAll(POSITIONAL_REF_PATTERN);
+    const matches    = record.text.matchAll(ANCHOR_TAG_PATTERN);
 
     for (const match of matches) {
         violations.push({
-            file: record.file,
-            line: record.line,
-            ref : match[0],
-            text: record.text.trim()
+            file : record.file,
+            line : record.line,
+            match: match[0],
+            text : record.text.trim()
         });
     }
 
@@ -217,7 +261,7 @@ function findViolationsInLine(record) {
  * Pure-function lint entry: feed it diff text, get back violations. Exported for
  * unit testing without invoking `git` or the filesystem.
  * @param {string} diffText
- * @returns {Array<{file: string, line: number, ref: string, text: string}>}
+ * @returns {Array<{file: string, line: number, match: string, text: string}>}
  */
 function lintDiff(diffText) {
     const violations = [];
@@ -242,20 +286,23 @@ function runLint(options = {}) {
     const violations = lintDiff(diffText);
 
     if (violations.length === 0) {
-        console.log(`[lint-agents] OK — no new positional §N refs in ${SCOPE_PREFIX} diff against ${base}.`);
+        console.log(`[lint-agents] OK — no new <a id> / <a name> anchor-tag insertions in Map / skill / Agent OS substrate diff against ${base}.`);
         return {exitCode: 0, violations};
     }
 
-    console.error(`[lint-agents] FAILED — ${violations.length} new positional reference(s) detected in ${SCOPE_PREFIX} diff against ${base}:\n`);
+    console.error(`[lint-agents] FAILED — ${violations.length} new HTML anchor-tag insertion(s) detected against ${base}:\n`);
     for (const v of violations) {
-        console.error(`- ${v.file}:${v.line}: ${v.ref}`);
+        console.error(`- ${v.file}:${v.line}: ${v.match}`);
         console.error(`    > ${v.text}`);
     }
-    console.error(`\nLive substrate references MUST target stable semantic anchors per ADR 0011.`);
-    console.error(`  learn/agentos/decisions/0011-substrate-numbering-convention.md §2`);
-    console.error(`\nIf a reference is historical / archaeology / errata, mark it explicitly on the same line`);
-    console.error(`(e.g. "historical: §21" or "ADR 0007 recorded the old §21 disposition") so the classification`);
-    console.error(`is legible to readers and to this lint per ADR 0011 §2.3.`);
+    console.error(`\nHTML <a id> / <a name> anchor tags are review blockers in turn-loaded Map substrate,`);
+    console.error(`.agents/skills/ skill substrate, and learn/agentos/ Agent OS substrate per Discussion #11577 graduation:`);
+    console.error(`  https://github.com/neomjs/neo/discussions/11577#discussioncomment-16965519`);
+    console.error(`\nUse compact text-only §<ref> form (positional §3 or semantic §<kebab>, both acceptable).`);
+    console.error(`Auto-generated heading IDs cover rendered clickability where renderers support it.`);
+    console.error(`\nIf this insertion is genuinely required (narrow rendered-consumer need, substrate-archaeology, or`);
+    console.error(`errata), mark the line explicitly with "rendered-consumer", "historical", "archaeology", or "errata"`);
+    console.error(`so the classification is legible to readers and to this lint.`);
     return {exitCode: 1, violations};
 }
 
@@ -266,8 +313,13 @@ function main() {
         console.log('Usage: node ai/scripts/lint-agents.mjs [--base <ref>]');
         console.log('  --base <ref>   Git ref to diff HEAD against (default: origin/dev)');
         console.log('');
-        console.log('Flags NEW live positional §N references in .agents/skills/** per ADR 0011.');
-        console.log('Pre-existing references remain untouched; they migrate under #11561-#11564.');
+        console.log('Flags NEW <a id> / <a name> HTML anchor-tag insertions in:');
+        console.log('  - AGENTS.md / AGENTS_STARTUP.md / .agents/ANTIGRAVITY_RULES.md  (Map substrate)');
+        console.log('  - .agents/skills/**/*.md                                          (skill substrate)');
+        console.log('  - learn/agentos/**/*.md                                           (Agent OS substrate)');
+        console.log('');
+        console.log('Same-line markers exempt: historical, archaeology, errata, rendered-consumer.');
+        console.log('Per Discussion #11577 graduation: §<ref> text-only form is the substrate primitive.');
         process.exit(0);
     }
 
@@ -280,12 +332,14 @@ if (process.argv[1] && path.resolve(process.argv[1]) === __filename) {
 }
 
 export {
-    HISTORICAL_MARKERS,
-    POSITIONAL_REF_PATTERN,
-    SCOPE_PREFIX,
+    AGENTOS_PREFIX,
+    ANCHOR_TAG_PATTERN,
+    EXEMPTION_MARKERS,
     SCOPE_SUFFIX,
+    SKILL_PREFIX,
+    TOP_LEVEL_MAP_FILES,
     findViolationsInLine,
-    isHistoricalContext,
+    isExempt,
     isInScope,
     lintDiff,
     parseAddedLines,

--- a/test/playwright/unit/ai/scripts/lintAgents.spec.mjs
+++ b/test/playwright/unit/ai/scripts/lintAgents.spec.mjs
@@ -4,11 +4,13 @@ import {readFileSync}   from 'node:fs';
 import path             from 'node:path';
 
 import {
-    HISTORICAL_MARKERS,
-    POSITIONAL_REF_PATTERN,
-    SCOPE_PREFIX,
+    AGENTOS_PREFIX,
+    ANCHOR_TAG_PATTERN,
+    EXEMPTION_MARKERS,
+    SKILL_PREFIX,
+    TOP_LEVEL_MAP_FILES,
     findViolationsInLine,
-    isHistoricalContext,
+    isExempt,
     isInScope,
     lintDiff,
     parseAddedLines,
@@ -16,20 +18,22 @@ import {
 } from '../../../../../ai/scripts/lint-agents.mjs';
 
 /**
- * @summary Coverage for `ai/scripts/lint-agents.mjs` — the semantic-anchor lint guard
- * authored under #11560 (Epic #11558 / Discussion #11557 / ADR 0011).
+ * @summary Coverage for `ai/scripts/lint-agents.mjs` — the `<a id>` / `<a name>` HTML
+ * anchor-tag lint guard inverted under #11584 per Discussion #11577 graduation.
  *
- * Test axes mirror the ticket Acceptance Criteria:
+ * Test axes mirror #11584 AC3:
  *
- * - **AC1:** lint fails for new live `.agents/skills/**` refs that use raw positional `§N` anchors
- * - **AC2:** lint allows explicitly classified historical / archaeology references
- * - **AC3:** failing + allowed fixtures covered
- * - **AC5:** lint error text points authors to ADR 0011
+ * - Lint flags new `<a id>` / `<a name>` insertions in Map substrate (AGENTS.md / AGENTS_STARTUP.md / ANTIGRAVITY_RULES.md)
+ * - Lint flags new insertions in skill substrate (.agents/skills/**\/*.md)
+ * - Lint flags new insertions in Agent OS substrate (learn/agentos/**\/*.md)
+ * - Lint preserves positional `§\d+` and semantic `§<kebab>` refs (operator-corrected substrate permits both)
+ * - Lint allows explicitly exempt lines (historical / archaeology / errata / rendered-consumer)
+ * - Lint error text points authors to Discussion #11577 graduation
  *
  * Plus pure-function coverage for the exported helpers so reviewer-side V-B-A can be cheap
  * (no `git diff` shell-out required for happy-path verification).
  */
-test.describe('ai/scripts/lint-agents (#11560 — semantic-anchor lint per ADR 0011)', () => {
+test.describe('ai/scripts/lint-agents (#11584 — <a id> anchor-tag block per Discussion #11577)', () => {
     const scriptPath = path.resolve(process.cwd(), 'ai/scripts/lint-agents.mjs');
 
     test('CLI: --help exits 0 with usage text', () => {
@@ -41,6 +45,9 @@ test.describe('ai/scripts/lint-agents (#11560 — semantic-anchor lint per ADR 0
         expect(result.status).toBe(0);
         expect(result.stdout).toContain('Usage: node ai/scripts/lint-agents.mjs');
         expect(result.stdout).toContain('--base');
+        expect(result.stdout).toContain('Map substrate');
+        expect(result.stdout).toContain('skill substrate');
+        expect(result.stdout).toContain('Agent OS substrate');
     });
 
     test('CLI: clean substrate against HEAD passes (no diff = no violations)', () => {
@@ -73,75 +80,194 @@ test.describe('ai/scripts/lint-agents (#11560 — semantic-anchor lint per ADR 0
         expect(() => parseArgs(['--bogus'])).toThrow(/Unknown argument/);
     });
 
+    test('isInScope: accepts top-level Map substrate', () => {
+        expect(isInScope('AGENTS.md')).toBe(true);
+        expect(isInScope('AGENTS_STARTUP.md')).toBe(true);
+        expect(isInScope('.agents/ANTIGRAVITY_RULES.md')).toBe(true);
+    });
+
     test('isInScope: accepts .agents/skills/**/*.md', () => {
         expect(isInScope('.agents/skills/pull-request/SKILL.md')).toBe(true);
         expect(isInScope('.agents/skills/pull-request/references/foo.md')).toBe(true);
     });
 
+    test('isInScope: accepts learn/agentos/**/*.md', () => {
+        expect(isInScope('learn/agentos/AGENTS_ATLAS.md')).toBe(true);
+        expect(isInScope('learn/agentos/decisions/0011-substrate-numbering-convention.md')).toBe(true);
+        expect(isInScope('learn/agentos/MemoryCore.md')).toBe(true);
+    });
+
     test('isInScope: rejects non-markdown and out-of-scope paths', () => {
         expect(isInScope('.agents/skills/skills.manifest.json')).toBe(false);
-        expect(isInScope('AGENTS.md')).toBe(false);
-        expect(isInScope('learn/agentos/decisions/0007.md')).toBe(false);
         expect(isInScope('.agents/skills/pull-request/SKILL.txt')).toBe(false);
+        expect(isInScope('learn/guides/fundamentals/CodebaseOverview.md')).toBe(false);
+        expect(isInScope('src/Neo.mjs')).toBe(false);
+        expect(isInScope('README.md')).toBe(false);
     });
 
-    test('isHistoricalContext: matches case-insensitive markers', () => {
-        for (const marker of HISTORICAL_MARKERS) {
-            expect(isHistoricalContext(`See ${marker}: §5`)).toBe(true);
-            expect(isHistoricalContext(`See ${marker.toUpperCase()}: §5`)).toBe(true);
+    test('TOP_LEVEL_MAP_FILES export contains the 3 capped Map files', () => {
+        expect(TOP_LEVEL_MAP_FILES.has('AGENTS.md')).toBe(true);
+        expect(TOP_LEVEL_MAP_FILES.has('AGENTS_STARTUP.md')).toBe(true);
+        expect(TOP_LEVEL_MAP_FILES.has('.agents/ANTIGRAVITY_RULES.md')).toBe(true);
+        expect(TOP_LEVEL_MAP_FILES.size).toBe(3);
+    });
+
+    test('SKILL_PREFIX + AGENTOS_PREFIX exports are the canonical roots', () => {
+        expect(SKILL_PREFIX).toBe('.agents/skills/');
+        expect(AGENTOS_PREFIX).toBe('learn/agentos/');
+    });
+
+    test('isExempt: matches case-insensitive markers', () => {
+        for (const marker of EXEMPTION_MARKERS) {
+            expect(isExempt(`See ${marker}: <a id="x"></a>`)).toBe(true);
+            expect(isExempt(`See ${marker.toUpperCase()}: <a id="x"></a>`)).toBe(true);
         }
     });
 
-    test('isHistoricalContext: returns false for plain text', () => {
-        expect(isHistoricalContext('See §21 for mailbox protocol.')).toBe(false);
-        expect(isHistoricalContext('Plain live reference.')).toBe(false);
+    test('isExempt: rendered-consumer marker exempts narrow rendered-consumer cases', () => {
+        expect(isExempt('Example for renderer test (rendered-consumer): <a id="x"></a>')).toBe(true);
     });
 
-    test('POSITIONAL_REF_PATTERN: matches simple and dotted refs', () => {
-        const cases = ['§1', '§21', '§5.2', '§5.2.3', '§13.1'];
-        for (const c of cases) {
-            const re = new RegExp(POSITIONAL_REF_PATTERN.source);
-            expect(re.test(c)).toBe(true);
-        }
+    test('isExempt: returns false for plain text', () => {
+        expect(isExempt('Inserted <a id="foo"></a> anchor tag.')).toBe(false);
+        expect(isExempt('Plain live reference.')).toBe(false);
     });
 
-    test('POSITIONAL_REF_PATTERN: does not match plain # anchors or "Section N"', () => {
-        const re = new RegExp(POSITIONAL_REF_PATTERN.source);
+    test('ANCHOR_TAG_PATTERN: matches <a id="..."> forms', () => {
+        const re = new RegExp(ANCHOR_TAG_PATTERN.source, ANCHOR_TAG_PATTERN.flags);
+        expect(re.test('<a id="foo">')).toBe(true);
+        re.lastIndex = 0;
+        expect(re.test('<a id="anchor-id"></a>')).toBe(true);
+    });
+
+    test('ANCHOR_TAG_PATTERN: matches <a name="..."> forms (legacy HTML)', () => {
+        const re = new RegExp(ANCHOR_TAG_PATTERN.source, ANCHOR_TAG_PATTERN.flags);
+        expect(re.test('<a name="legacy">')).toBe(true);
+    });
+
+    test('ANCHOR_TAG_PATTERN: matches with intervening attributes', () => {
+        const re = new RegExp(ANCHOR_TAG_PATTERN.source, ANCHOR_TAG_PATTERN.flags);
+        expect(re.test('<a class="x" id="foo">')).toBe(true);
+        re.lastIndex = 0;
+        expect(re.test('<a href="#x" id="foo">')).toBe(true);
+    });
+
+    test('ANCHOR_TAG_PATTERN: matches case-insensitively', () => {
+        const re = new RegExp(ANCHOR_TAG_PATTERN.source, ANCHOR_TAG_PATTERN.flags);
+        expect(re.test('<A ID="foo">')).toBe(true);
+        re.lastIndex = 0;
+        expect(re.test('<a ID="foo">')).toBe(true);
+    });
+
+    test('ANCHOR_TAG_PATTERN: does NOT match <a href="..."> regular hyperlinks', () => {
+        const re = new RegExp(ANCHOR_TAG_PATTERN.source, ANCHOR_TAG_PATTERN.flags);
+        expect(re.test('<a href="https://example.com">link</a>')).toBe(false);
+    });
+
+    test('ANCHOR_TAG_PATTERN: does NOT match unrelated tags starting with <a', () => {
+        const re = new RegExp(ANCHOR_TAG_PATTERN.source, ANCHOR_TAG_PATTERN.flags);
+        expect(re.test('<abbr title="x">HTML</abbr>')).toBe(false);
+        re.lastIndex = 0;
+        expect(re.test('<article id="x">')).toBe(false);
+    });
+
+    test('ANCHOR_TAG_PATTERN: does NOT match positional §N or semantic §<kebab> refs', () => {
+        const re = new RegExp(ANCHOR_TAG_PATTERN.source, ANCHOR_TAG_PATTERN.flags);
+        expect(re.test('See §21 for mailbox protocol.')).toBe(false);
+        re.lastIndex = 0;
+        expect(re.test('See §mailbox-check-protocol for the protocol.')).toBe(false);
+        re.lastIndex = 0;
         expect(re.test('Section 5')).toBe(false);
-        expect(re.test('#mailbox-check-protocol')).toBe(false);
-        expect(re.test('Use anchor #foo')).toBe(false);
     });
 
-    test('findViolationsInLine: detects live §N in in-scope file', () => {
+    test('findViolationsInLine: detects <a id> insertion in AGENTS.md (Map substrate)', () => {
+        const result = findViolationsInLine({
+            file: 'AGENTS.md',
+            line: 100,
+            text: '## <a id="mailbox-check-protocol"></a> Mailbox Check Protocol'
+        });
+
+        expect(result).toHaveLength(1);
+        expect(result[0]).toMatchObject({
+            file : 'AGENTS.md',
+            line : 100
+        });
+        expect(result[0].match).toMatch(/<a\b[^>]*\sid\s*=/i);
+    });
+
+    test('findViolationsInLine: detects <a id> insertion in skill file', () => {
         const result = findViolationsInLine({
             file: '.agents/skills/pull-request/SKILL.md',
             line: 42,
-            text: 'See AGENTS.md §21 for mailbox protocol.'
+            text: 'Adding <a id="example"></a> tag here.'
         });
 
         expect(result).toHaveLength(1);
         expect(result[0]).toMatchObject({
             file: '.agents/skills/pull-request/SKILL.md',
-            line: 42,
-            ref : '§21'
+            line: 42
         });
     });
 
-    test('findViolationsInLine: detects multiple refs on one line', () => {
+    test('findViolationsInLine: detects <a id> insertion in learn/agentos file', () => {
         const result = findViolationsInLine({
-            file: '.agents/skills/pull-request/SKILL.md',
-            line: 42,
-            text: 'Combines §5.2 and §13.1 disciplines.'
+            file: 'learn/agentos/AGENTS_ATLAS.md',
+            line: 200,
+            text: '## <a id="memory-core"></a> Memory Core Section'
         });
 
-        expect(result.map(v => v.ref)).toEqual(['§5.2', '§13.1']);
+        expect(result).toHaveLength(1);
+        expect(result[0]).toMatchObject({
+            file: 'learn/agentos/AGENTS_ATLAS.md',
+            line: 200
+        });
     });
 
-    test('findViolationsInLine: skips line with historical marker (AC2)', () => {
+    test('findViolationsInLine: detects multiple anchor tags on one line', () => {
         const result = findViolationsInLine({
-            file: '.agents/skills/pull-request/SKILL.md',
+            file: 'AGENTS.md',
             line: 42,
-            text: 'ADR 0007 recorded the historical §21 disposition.'
+            text: '<a id="alpha"></a> <a id="beta"></a> two anchors.'
+        });
+
+        expect(result).toHaveLength(2);
+    });
+
+    test('findViolationsInLine: preserves positional §N references (operator-corrected substrate permits them)', () => {
+        const result = findViolationsInLine({
+            file: 'AGENTS.md',
+            line: 42,
+            text: 'See §21 for mailbox protocol.'
+        });
+
+        expect(result).toHaveLength(0);
+    });
+
+    test('findViolationsInLine: preserves semantic §<kebab> references', () => {
+        const result = findViolationsInLine({
+            file: 'AGENTS.md',
+            line: 42,
+            text: 'See §mailbox-check-protocol for the protocol.'
+        });
+
+        expect(result).toHaveLength(0);
+    });
+
+    test('findViolationsInLine: skips line with historical marker', () => {
+        const result = findViolationsInLine({
+            file: 'AGENTS.md',
+            line: 42,
+            text: 'historical: <a id="archived-section"></a> was the prior structure.'
+        });
+
+        expect(result).toHaveLength(0);
+    });
+
+    test('findViolationsInLine: skips line with rendered-consumer marker', () => {
+        const result = findViolationsInLine({
+            file: '.agents/skills/foo/SKILL.md',
+            line: 42,
+            text: '<a id="external-renderer-target"></a> rendered-consumer: justified per #NNNN.'
         });
 
         expect(result).toHaveLength(0);
@@ -151,7 +277,17 @@ test.describe('ai/scripts/lint-agents (#11560 — semantic-anchor lint per ADR 0
         const result = findViolationsInLine({
             file: '.agents/skills/skills.manifest.json',
             line: 1,
-            text: 'See §21'
+            text: '<a id="x">'
+        });
+
+        expect(result).toHaveLength(0);
+    });
+
+    test('findViolationsInLine: skips line outside scope (e.g. user-facing guide)', () => {
+        const result = findViolationsInLine({
+            file: 'learn/guides/devindex/frontend/Architecture.md',
+            line: 1,
+            text: '<a id="example-anchor-in-html-tutorial"></a>'
         });
 
         expect(result).toHaveLength(0);
@@ -159,29 +295,29 @@ test.describe('ai/scripts/lint-agents (#11560 — semantic-anchor lint per ADR 0
 
     test('parseAddedLines: extracts added lines with new-file line numbers', () => {
         const diff = [
-            'diff --git a/.agents/skills/foo/SKILL.md b/.agents/skills/foo/SKILL.md',
-            '--- a/.agents/skills/foo/SKILL.md',
-            '+++ b/.agents/skills/foo/SKILL.md',
+            'diff --git a/AGENTS.md b/AGENTS.md',
+            '--- a/AGENTS.md',
+            '+++ b/AGENTS.md',
             '@@ -10,0 +11,2 @@',
-            '+New line one referencing §5.',
+            '+New line with <a id="foo"></a> tag.',
             '+Second new line.'
         ].join('\n');
 
         const added = parseAddedLines(diff);
 
         expect(added).toEqual([
-            {file: '.agents/skills/foo/SKILL.md', line: 11, text: 'New line one referencing §5.'},
-            {file: '.agents/skills/foo/SKILL.md', line: 12, text: 'Second new line.'}
+            {file: 'AGENTS.md', line: 11, text: 'New line with <a id="foo"></a> tag.'},
+            {file: 'AGENTS.md', line: 12, text: 'Second new line.'}
         ]);
     });
 
     test('parseAddedLines: ignores removed lines and pre-image headers', () => {
         const diff = [
-            'diff --git a/.agents/skills/foo/SKILL.md b/.agents/skills/foo/SKILL.md',
-            '--- a/.agents/skills/foo/SKILL.md',
-            '+++ b/.agents/skills/foo/SKILL.md',
+            'diff --git a/AGENTS.md b/AGENTS.md',
+            '--- a/AGENTS.md',
+            '+++ b/AGENTS.md',
             '@@ -10,2 +10,1 @@',
-            '-Removed line referencing §99.',
+            '-Removed line with <a id="bar"></a>.',
             '-Second removed line.',
             '+Single new line.'
         ].join('\n');
@@ -195,9 +331,9 @@ test.describe('ai/scripts/lint-agents (#11560 — semantic-anchor lint per ADR 0
 
     test('parseAddedLines: handles multi-hunk diff', () => {
         const diff = [
-            'diff --git a/.agents/skills/foo/SKILL.md b/.agents/skills/foo/SKILL.md',
-            '--- a/.agents/skills/foo/SKILL.md',
-            '+++ b/.agents/skills/foo/SKILL.md',
+            'diff --git a/AGENTS.md b/AGENTS.md',
+            '--- a/AGENTS.md',
+            '+++ b/AGENTS.md',
             '@@ -5,0 +6,1 @@',
             '+Hunk one new line.',
             '@@ -20,0 +21,1 @@',
@@ -209,13 +345,31 @@ test.describe('ai/scripts/lint-agents (#11560 — semantic-anchor lint per ADR 0
         expect(added.map(a => a.line)).toEqual([6, 21]);
     });
 
-    test('lintDiff: surfaces violation on new live §N line (AC1)', () => {
+    test('lintDiff: surfaces violation on new <a id> insertion in AGENTS.md', () => {
+        const diff = [
+            'diff --git a/AGENTS.md b/AGENTS.md',
+            '--- a/AGENTS.md',
+            '+++ b/AGENTS.md',
+            '@@ -10,0 +11,1 @@',
+            '+## <a id="mailbox-check-protocol"></a> Mailbox Check Protocol'
+        ].join('\n');
+
+        const violations = lintDiff(diff);
+
+        expect(violations).toHaveLength(1);
+        expect(violations[0]).toMatchObject({
+            file: 'AGENTS.md',
+            line: 11
+        });
+    });
+
+    test('lintDiff: surfaces violation on new <a id> insertion in .agents/skills/**', () => {
         const diff = [
             'diff --git a/.agents/skills/foo/SKILL.md b/.agents/skills/foo/SKILL.md',
             '--- a/.agents/skills/foo/SKILL.md',
             '+++ b/.agents/skills/foo/SKILL.md',
             '@@ -10,0 +11,1 @@',
-            '+New live reference to AGENTS.md §21 here.'
+            '+Adding <a id="example"></a> to skill router.'
         ].join('\n');
 
         const violations = lintDiff(diff);
@@ -223,47 +377,50 @@ test.describe('ai/scripts/lint-agents (#11560 — semantic-anchor lint per ADR 0
         expect(violations).toHaveLength(1);
         expect(violations[0]).toMatchObject({
             file: '.agents/skills/foo/SKILL.md',
-            line: 11,
-            ref : '§21'
+            line: 11
         });
     });
 
-    test('lintDiff: passes when new line marked historical (AC2)', () => {
+    test('lintDiff: surfaces violation on new <a id> insertion in learn/agentos/**', () => {
         const diff = [
-            'diff --git a/.agents/skills/foo/SKILL.md b/.agents/skills/foo/SKILL.md',
-            '--- a/.agents/skills/foo/SKILL.md',
-            '+++ b/.agents/skills/foo/SKILL.md',
+            'diff --git a/learn/agentos/AGENTS_ATLAS.md b/learn/agentos/AGENTS_ATLAS.md',
+            '--- a/learn/agentos/AGENTS_ATLAS.md',
+            '+++ b/learn/agentos/AGENTS_ATLAS.md',
             '@@ -10,0 +11,1 @@',
-            '+Historical reference: §21 was the prior mailbox slot before ADR 0011.'
+            '+## <a id="atlas-section"></a> Atlas Section'
         ].join('\n');
 
         const violations = lintDiff(diff);
 
-        expect(violations).toHaveLength(0);
+        expect(violations).toHaveLength(1);
+        expect(violations[0]).toMatchObject({
+            file: 'learn/agentos/AGENTS_ATLAS.md',
+            line: 11
+        });
     });
 
-    test('lintDiff: ignores diff entries outside .agents/skills/', () => {
+    test('lintDiff: passes when new line marked with exemption marker', () => {
         const diff = [
             'diff --git a/AGENTS.md b/AGENTS.md',
             '--- a/AGENTS.md',
             '+++ b/AGENTS.md',
             '@@ -10,0 +11,1 @@',
-            '+See §21 for mailbox protocol (existing live ref).'
+            '+Historical: <a id="legacy-mailbox"></a> was the prior structure.'
         ].join('\n');
 
         const violations = lintDiff(diff);
 
-        // AGENTS.md is out of scope under #11560 — it migrates under #11561.
         expect(violations).toHaveLength(0);
     });
 
-    test('lintDiff: ignores removed lines containing §N', () => {
+    test('lintDiff: passes when new line uses §<ref> form (operator-corrected substrate)', () => {
         const diff = [
             'diff --git a/.agents/skills/foo/SKILL.md b/.agents/skills/foo/SKILL.md',
             '--- a/.agents/skills/foo/SKILL.md',
             '+++ b/.agents/skills/foo/SKILL.md',
-            '@@ -10,1 +10,0 @@',
-            '-Removed line still mentioning §21.'
+            '@@ -10,0 +11,2 @@',
+            '+See §21 for mailbox protocol.',
+            '+And §mailbox-check-protocol for semantic form.'
         ].join('\n');
 
         const violations = lintDiff(diff);
@@ -271,22 +428,69 @@ test.describe('ai/scripts/lint-agents (#11560 — semantic-anchor lint per ADR 0
         expect(violations).toHaveLength(0);
     });
 
-    test('runLint output: error text references ADR 0011 (AC5)', () => {
-        // Use spawnSync + a synthetic branch that has a new §N to capture stderr.
-        // Easier: assert against the script's `runLint` stderr indirectly by spawning
-        // against a base ref that diverges only on the synthetic fixture branch.
-        // The CLI smoke test above already covers the happy path; here we verify
-        // the message shape by reading the script's stderr template directly.
-        // Mock: feed lintDiff a violation, then check that the script source carries
-        // the ADR pointer (cheap and reliable).
-        const lintSource = readFileSync(scriptPath, 'utf8');
+    test('lintDiff: ignores diff entries outside scope (e.g. learn/guides/)', () => {
+        const diff = [
+            'diff --git a/learn/guides/foo.md b/learn/guides/foo.md',
+            '--- a/learn/guides/foo.md',
+            '+++ b/learn/guides/foo.md',
+            '@@ -10,0 +11,1 @@',
+            '+HTML tutorial: <a id="example"></a> shows anchor syntax.'
+        ].join('\n');
 
-        expect(lintSource).toContain('learn/agentos/decisions/0011-substrate-numbering-convention.md');
-        expect(lintSource).toContain('ADR 0011');
-        expect(lintSource).toContain('semantic anchor');
+        const violations = lintDiff(diff);
+
+        // learn/guides/ is user-facing documentation, NOT Agent OS substrate. Out of scope.
+        expect(violations).toHaveLength(0);
     });
 
-    test('SCOPE_PREFIX export is the canonical skills directory', () => {
-        expect(SCOPE_PREFIX).toBe('.agents/skills/');
+    test('lintDiff: ignores removed lines containing <a id>', () => {
+        const diff = [
+            'diff --git a/AGENTS.md b/AGENTS.md',
+            '--- a/AGENTS.md',
+            '+++ b/AGENTS.md',
+            '@@ -10,1 +10,0 @@',
+            '-Removed line still mentioning <a id="bar"></a>.'
+        ].join('\n');
+
+        const violations = lintDiff(diff);
+
+        expect(violations).toHaveLength(0);
+    });
+
+    test('lintDiff: handles multi-file diff across Map + skill + Agent OS substrate', () => {
+        const diff = [
+            'diff --git a/AGENTS.md b/AGENTS.md',
+            '--- a/AGENTS.md',
+            '+++ b/AGENTS.md',
+            '@@ -10,0 +11,1 @@',
+            '+<a id="map-anchor"></a> Map insertion',
+            'diff --git a/.agents/skills/foo/SKILL.md b/.agents/skills/foo/SKILL.md',
+            '--- a/.agents/skills/foo/SKILL.md',
+            '+++ b/.agents/skills/foo/SKILL.md',
+            '@@ -5,0 +6,1 @@',
+            '+<a id="skill-anchor"></a> Skill insertion',
+            'diff --git a/learn/agentos/MemoryCore.md b/learn/agentos/MemoryCore.md',
+            '--- a/learn/agentos/MemoryCore.md',
+            '+++ b/learn/agentos/MemoryCore.md',
+            '@@ -100,0 +101,1 @@',
+            '+<a id="agentos-anchor"></a> Agent OS insertion'
+        ].join('\n');
+
+        const violations = lintDiff(diff);
+
+        expect(violations).toHaveLength(3);
+        expect(violations.map(v => v.file).sort()).toEqual([
+            '.agents/skills/foo/SKILL.md',
+            'AGENTS.md',
+            'learn/agentos/MemoryCore.md'
+        ]);
+    });
+
+    test('runLint output: error text references Discussion #11577 graduation', () => {
+        const lintSource = readFileSync(scriptPath, 'utf8');
+
+        expect(lintSource).toContain('discussions/11577');
+        expect(lintSource).toContain('Discussion #11577');
+        expect(lintSource).toContain('§<ref>');
     });
 });


### PR DESCRIPTION
Authored by Claude Opus 4.7 (Claude Code). Session `1b7a3403-06f3-4862-be80-479e129656de`.

FAIR-band: in-band [10/30 — current author count over last 30 merged]

Refs #11584 (delivers AC3 / Lane C only; sibling lanes still pending). #11584 stays open until Lane A merges (PR #11588) and Lane B disposition lands per operator decision. Lane B (ADR 0011 amendment) was deferred per `MESSAGE:d2bdffaa`; cross-family lane split broadcast at `MESSAGE:e555e8fe`.

**Close-target discipline:** intentionally non-magic `Refs` keyword over the magic-resolver keyword family so squash-merge does not auto-finalize the parent ticket with residual Lane B still pending. Per @neo-gpt CHANGES_REQUESTED review `PRR_kwDODSospM8AAAABAQ3whQ` (Cycle 1) + `PRR_kwDODSospM8AAAABAQ6z0w` (Cycle 2 — `closingIssuesReferences` regex-match on negated prose).

## Summary

Inverts `ai/scripts/lint-agents.mjs` per Discussion #11577 graduation ([`DC_kwDODSospM4BAt-P`](https://github.com/neomjs/neo/discussions/11577#discussioncomment-16965519)). The original #11560 design blocked NEW positional `§\d+` refs in skill files; operator-corrected substrate permits `§<ref>` form (positional or semantic, both acceptable) and treats HTML `<a id>` / `<a name>` anchor-tag scaffolding as damage across Map / skill / Agent OS substrate.

This PR delivers Lane C of #11584 (the #11572 inversion). Lane A (revert #11571) and Lane B (ADR 0011 amendment) remain @neo-gpt natural authorship lanes per ticket-create §11.

## Changes

- **`ANCHOR_TAG_PATTERN`** (`/<a\b[^>]*\s(?:id|name)\s*=/gi`): matches `<a id="..."`/`<a name="..."` with attribute-boundary guard. Tolerates intervening attributes (`<a class="x" id="foo">`). Rejects `<a href>` regular hyperlinks and `<abbr>` / `<article>` / similar tags via word-boundary + `\s(id|name)\s*=` discrete-token requirement.
- **Scope expansion** — from `.agents/skills/**/*.md` only to:
  - Top-level Map substrate: `AGENTS.md`, `AGENTS_STARTUP.md`, `.agents/ANTIGRAVITY_RULES.md` (the 3 mechanically-capped Map files)
  - Skill substrate: `.agents/skills/**/*.md`
  - Agent OS substrate: `learn/agentos/**/*.md`
  - **Intentionally excluded**: `learn/guides/**` (user-facing documentation carries legitimate HTML anchor examples in tutorials about HTML).
- **`EXEMPTION_MARKERS`** — adds `rendered-consumer` for the narrow operator-approved exception case (per Discussion #11577 forward-rule); preserves `historical` / `archaeology` / `errata` markers for substrate-archaeology references.
- **Messaging** — CLI help, JSDoc, and error output rewritten to cite Discussion #11577 graduation + the `§<ref>` text-only primitive. Error trailer points authors at the exemption-marker mechanism for narrow rendered-consumer needs.
- **Playwright spec** — 45 tests covering: CLI smoke, scope expansion (Map / skill / Agent OS positive cases + `learn/guides/` negative), pattern coverage (`<a id>`, `<a name>`, intervening attrs, case-insensitivity), false-positive avoidance (`<a href>`, `<abbr>`, plain `§N` refs, semantic `§<kebab>` refs), exemption-marker handling, multi-file diff handling, removed-line ignoring.

## Architectural Impact

- **Cross-family forward-rule enforcement** — the lint now mechanically enforces what GPT (`MESSAGE:a9aee65c`) and I committed to mirror in PR reviews: "treat new `<a id>` anchor-tag additions in substrate PRs as a hard review blocker." Two-family review enforcement remains the primary discipline; the lint catches regressions before they reach a reviewer.
- **Map / Atlas compaction discipline (ADR 0007)** — preserves the multi-week compaction substrate. AGENTS.md (24,576-byte mechanical cap with truncation) gains future-substrate budget protection from anchor-tag scaffolding regressions.
- **Operator forward-rule realized at CI** — operator's stated rule (rejection of any new `<a>` anchor-tag insertion in substrate PRs) is now automated; PRs adding anchor tags fail CI rather than reaching the operator's manual review-time enforcement.

## Edge Cases

- **Author-intent exception**: rendered-consumer-justified `<a id>` insertions can be exempted via same-line marker `rendered-consumer`. Cross-family reviewer V-B-A on whether the exception is legitimate.
- **Legacy `<a name>` form**: caught by the pattern (operator framing covers any anchor-tag form). If an old substrate file naturally has `<a name>` from pre-#11571 archaeology, it survives because the lint is diff-scoped — only NEW additions trigger.
- **HTML examples in user-facing docs** (`learn/guides/**`) — explicitly out of scope. Code tutorials demonstrating HTML can legitimately include `<a>` tags without triggering the lint.
- **False-positive avoidance**: `<a href="...">` regular hyperlinks DO NOT trigger (no `id` / `name` attribute). Verified empirically in `ANCHOR_TAG_PATTERN: does NOT match <a href="..."> regular hyperlinks` test.

## Test Evidence

- `npm run test-unit -- test/playwright/unit/ai/scripts/lintAgents.spec.mjs` → **45 passed (731ms)**.
- `node ai/scripts/lint-agents.mjs --base HEAD` → OK (no false-positives on current branch state).
- `node buildScripts/util/check-whitespace.mjs` → passed (pre-commit hook).
- `git diff --check origin/dev...HEAD` → passed.

Evidence: L2 (Playwright unit harness covering diff parsing, pattern matching, scope predicates, and CLI smoke) → L2 required (lint is a pre-commit / CI behavioral surface). No residuals.

## Cross-Family Review Mandate

Per `pull-request-workflow.md §6.1` cross-family mandate + #11584 AC4. Requesting **@neo-gpt** as primary reviewer (Gemini harness degraded this session; A2A handoff follows immediately after PR-open per §6.2).

Requested action: use `/pr-review` on this PR.

## Related

- **Ticket:** Refs #11584 (delivers AC3 / Lane C only; non-finalizing — see close-target note above)
- **Graduating Discussion:** [#11577](https://github.com/neomjs/neo/discussions/11577) → graduation comment [`DC_kwDODSospM4BAt-P`](https://github.com/neomjs/neo/discussions/11577#discussioncomment-16965519)
- **Empirical damage anchor:** PR [#11571](https://github.com/neomjs/neo/pull/11571) (merge commit `3d4c01f7`) — 36 `<a id>` tags + 46 markdown-link refs + 4,358 bytes across AGENTS.md / AGENTS_STARTUP.md / AGENTS_ATLAS.md
- **Original lint substrate:** PR [#11572](https://github.com/neomjs/neo/pull/11572) (the inversion target — my own #11560 authorship)
- **Cross-family enforcement commit:** GPT `MESSAGE:a9aee65c` — committed to treat new `<a>` anchor-tag additions as hard review blockers
- **Map/Atlas discipline anchor:** [ADR 0007](https://github.com/neomjs/neo/blob/dev/learn/agentos/decisions/0007-agents-md-compaction-taxonomy.md) (compaction taxonomy that the operator-corrected substrate restores)

## Deltas from ticket (if any)

None. Implementation matches #11584 AC3 verbatim:
- Inverted enforcement: blocks new `<a id>` HTML tag insertions in `.agents/skills/**` ✓
- Permits positional `§\d+` and semantic `§<kebab>` refs ✓
- Header JSDoc + Playwright test spec updated ✓
- Scope expanded beyond AC3 minimum to also cover Map + Agent OS substrate (aligned with operator forward-rule).

## Post-Merge Validation

- [ ] Verify lint passes on next substrate-touching PR with no false positives on `§<ref>` refs (positional or semantic).
- [ ] Verify lint flags a hypothetical `<a id>` insertion in `AGENTS.md` / `.agents/skills/**` / `learn/agentos/**` at CI time.
- [ ] Verify `learn/guides/**` user-facing docs remain out of scope (no false positives on legitimate HTML anchor examples in tutorials).
- [ ] Coordinate with PR #11588 merge order — both PRs are file-disjoint (lint script vs. substrate revert); either order works without conflict.
- [ ] If #11584 Lane B (ADR 0011 amendment) lands later, verify `lint-agents.mjs` header `@see` reference to ADR 0011 reflects the amended worked-example form.
