### PR TITLE
fix(github-workflow): retry transient GraphQL sync failures (#11585)

### DIFF
--- a/ai/services/github-workflow/GraphqlService.mjs
+++ b/ai/services/github-workflow/GraphqlService.mjs
@@ -34,7 +34,44 @@ class GraphqlService extends Base {
          * @member {String} apiUrl='https://api.github.com/graphql'
          * @protected
          */
-        apiUrl: 'https://api.github.com/graphql'
+        apiUrl: 'https://api.github.com/graphql',
+        /**
+         * Optional explicit token override for tests or controlled embedded callers.
+         * Normal runtime auth continues to use `gh auth token`.
+         * @member {String|null} authTokenOverride=null
+         * @protected
+         */
+        authTokenOverride: null,
+        /**
+         * Maximum retry attempts for transient GitHub transport/gateway failures.
+         * @member {Number} maxRetryAttempts=3
+         * @protected
+         */
+        maxRetryAttempts: 3,
+        /**
+         * Initial retry delay in milliseconds.
+         * @member {Number} retryBaseDelayMs=1000
+         * @protected
+         */
+        retryBaseDelayMs: 1000,
+        /**
+         * Maximum retry delay in milliseconds.
+         * @member {Number} retryMaxDelayMs=10000
+         * @protected
+         */
+        retryMaxDelayMs: 10000,
+        /**
+         * Jitter ratio applied to exponential retry delays.
+         * @member {Number} retryJitterRatio=0.2
+         * @protected
+         */
+        retryJitterRatio: 0.2,
+        /**
+         * HTTP statuses that represent transient GitHub/proxy failures.
+         * @member {Number[]} retryableHttpStatuses=[429,502,503,504]
+         * @protected
+         */
+        retryableHttpStatuses: [429, 502, 503, 504]
     }
 
     /**
@@ -52,6 +89,10 @@ class GraphqlService extends Base {
      * @private
      */
     async #getAuthToken() {
+        if (this.authTokenOverride) {
+            return String(this.authTokenOverride).trim();
+        }
+
         if (this.#authToken) {
             return this.#authToken;
         }
@@ -64,6 +105,102 @@ class GraphqlService extends Base {
             logger.error('Failed to get GitHub auth token from `gh` CLI.', e);
             throw new Error('Could not authenticate with GitHub. Please ensure you have run `gh auth login`.');
         }
+    }
+
+    /**
+     * Calculates the retry delay for a transient GitHub failure.
+     * @param {Number} attempt The 1-based retry attempt.
+     * @param {Response|null} response The failed response, if one exists.
+     * @returns {Number} Delay in milliseconds.
+     * @private
+     */
+    #getRetryDelay(attempt, response=null) {
+        const retryAfter = response?.headers?.get?.('retry-after');
+
+        if (retryAfter) {
+            const seconds = Number(retryAfter);
+
+            if (Number.isFinite(seconds)) {
+                return Math.max(0, seconds * 1000);
+            }
+
+            const retryAt = Date.parse(retryAfter);
+
+            if (Number.isFinite(retryAt)) {
+                return Math.max(0, retryAt - Date.now());
+            }
+        }
+
+        const baseDelay = Math.min(this.retryMaxDelayMs, this.retryBaseDelayMs * 2 ** (attempt - 1));
+        const jitter    = baseDelay * this.retryJitterRatio * Math.random();
+
+        return Math.round(baseDelay + jitter);
+    }
+
+    /**
+     * Determines whether a transport error is likely transient.
+     * @param {Error|*} error The thrown fetch error.
+     * @returns {Boolean}
+     * @private
+     */
+    #isRetryableNetworkError(error) {
+        const message = [
+            error?.message,
+            error?.cause?.message,
+            error?.cause?.code,
+            error?.code,
+            String(error)
+        ].filter(Boolean).join(' ').toLowerCase();
+
+        return [
+            'fetch failed',
+            'network',
+            'terminated',
+            'timeout',
+            'econnreset',
+            'etimedout',
+            'enotfound',
+            'eai_again',
+            'socket hang up'
+        ].some(pattern => message.includes(pattern));
+    }
+
+    /**
+     * @param {Number} status The HTTP response status.
+     * @returns {Boolean}
+     * @private
+     */
+    #isRetryableHttpStatus(status) {
+        return this.retryableHttpStatuses.includes(status);
+    }
+
+    /**
+     * Waits before a retry attempt.
+     * @param {Number} delay Delay in milliseconds.
+     * @returns {Promise<void>}
+     * @private
+     */
+    async #sleep(delay) {
+        if (delay <= 0) {
+            return;
+        }
+
+        await new Promise(resolve => setTimeout(resolve, delay));
+    }
+
+    /**
+     * Logs and waits for a transient retry.
+     * @param {String} reason Safe retry reason for logs.
+     * @param {Number} attempt The 1-based retry attempt.
+     * @param {Response|null} response The failed response, if one exists.
+     * @returns {Promise<void>}
+     * @private
+     */
+    async #waitForRetry(reason, attempt, response=null) {
+        const delay = this.#getRetryDelay(attempt, response);
+
+        logger.warn(`[GraphqlService] ${reason}; retrying in ${delay}ms (attempt ${attempt}/${this.maxRetryAttempts})`);
+        await this.#sleep(delay);
     }
 
     /**
@@ -87,14 +224,36 @@ class GraphqlService extends Base {
             headers['GraphQL-Features'] = 'sub_issues';
         }
 
-        const response = await fetch(this.apiUrl, {
-            method: 'POST',
-            headers,
-            body  : JSON.stringify({query, variables})
-        });
+        let response;
 
-        if (!response.ok) {
-            throw new Error(`GitHub API request failed: ${response.status} ${response.statusText}`);
+        for (let attempt = 0; attempt <= this.maxRetryAttempts; attempt++) {
+            try {
+                response = await fetch(this.apiUrl, {
+                    method: 'POST',
+                    headers,
+                    body  : JSON.stringify({query, variables})
+                });
+            } catch (e) {
+                if (attempt < this.maxRetryAttempts && this.#isRetryableNetworkError(e)) {
+                    await this.#waitForRetry(`Transient GitHub GraphQL transport failure (${e.message})`, attempt + 1);
+                    continue;
+                }
+
+                throw e;
+            }
+
+            if (response.ok) {
+                break;
+            }
+
+            const errorMessage = `GitHub API request failed: ${response.status} ${response.statusText}`;
+
+            if (attempt < this.maxRetryAttempts && this.#isRetryableHttpStatus(response.status)) {
+                await this.#waitForRetry(errorMessage, attempt + 1, response);
+                continue;
+            }
+
+            throw new Error(errorMessage);
         }
 
         const json = await response.json();

--- a/test/playwright/unit/ai/services/github-workflow/GraphqlService.spec.mjs
+++ b/test/playwright/unit/ai/services/github-workflow/GraphqlService.spec.mjs
@@ -1,0 +1,151 @@
+import {setup} from '../../../../setup.mjs';
+
+const appName = 'GraphqlServiceTest';
+
+setup({
+    neoConfig: {
+        unitTestMode: true
+    },
+    appConfig: {
+        name             : appName,
+        isMounted        : () => true,
+        vnodeInitialising: false
+    }
+});
+
+import {test, expect} from '@playwright/test';
+import Neo            from '../../../../../../src/Neo.mjs';
+import * as core      from '../../../../../../src/core/_export.mjs';
+
+/**
+ * @summary Contract coverage for `GraphqlService.query` transient GitHub retry behavior (#11585).
+ *
+ * GitHub's GraphQL edge can return transient `502`/`503`/`504` gateway failures or
+ * terminate a fetch mid-flight. The GitHub Workflow sync pipeline is long-running,
+ * so a single transient response must not abort the entire run without a bounded retry.
+ */
+test.describe('Neo.ai.services.github-workflow.GraphqlService — transient retry (#11585)', () => {
+    let GraphqlService;
+    let originalFetch;
+    let originalAuthTokenOverride;
+    let originalMaxRetryAttempts;
+    let originalRetryBaseDelayMs;
+    let originalRetryMaxDelayMs;
+    let originalRetryJitterRatio;
+
+    const QUERY = 'query TestQuery { viewer { login } }';
+
+    test.beforeAll(async () => {
+        GraphqlService = (await import('../../../../../../ai/services/github-workflow/GraphqlService.mjs')).default;
+    });
+
+    test.beforeEach(() => {
+        originalFetch              = globalThis.fetch;
+        originalAuthTokenOverride  = GraphqlService.authTokenOverride;
+        originalMaxRetryAttempts   = GraphqlService.maxRetryAttempts;
+        originalRetryBaseDelayMs   = GraphqlService.retryBaseDelayMs;
+        originalRetryMaxDelayMs    = GraphqlService.retryMaxDelayMs;
+        originalRetryJitterRatio   = GraphqlService.retryJitterRatio;
+
+        GraphqlService.authTokenOverride  = 'unit-test-token';
+        GraphqlService.maxRetryAttempts = 2;
+        GraphqlService.retryBaseDelayMs = 0;
+        GraphqlService.retryMaxDelayMs  = 0;
+        GraphqlService.retryJitterRatio = 0;
+    });
+
+    test.afterEach(() => {
+        globalThis.fetch = originalFetch;
+
+        GraphqlService.authTokenOverride  = originalAuthTokenOverride;
+        GraphqlService.maxRetryAttempts = originalMaxRetryAttempts;
+        GraphqlService.retryBaseDelayMs = originalRetryBaseDelayMs;
+        GraphqlService.retryMaxDelayMs  = originalRetryMaxDelayMs;
+        GraphqlService.retryJitterRatio = originalRetryJitterRatio;
+    });
+
+    test('retries a transient 504 response and returns the eventual data', async () => {
+        let callCount = 0;
+
+        globalThis.fetch = async () => {
+            callCount++;
+
+            if (callCount === 1) {
+                return new Response('', {status: 504, statusText: 'Gateway Timeout'});
+            }
+
+            return new Response(JSON.stringify({data: {viewer: {login: 'neo-gpt'}}}), {
+                status : 200,
+                headers: {'content-type': 'application/json'}
+            });
+        };
+
+        const result = await GraphqlService.query(QUERY);
+
+        expect(result).toEqual({viewer: {login: 'neo-gpt'}});
+        expect(callCount).toBe(2);
+    });
+
+    test('retries a transient fetch failure and returns the eventual data', async () => {
+        let callCount = 0;
+
+        globalThis.fetch = async () => {
+            callCount++;
+
+            if (callCount === 1) {
+                const error = new TypeError('fetch failed');
+                error.cause = {message: 'terminated'};
+                throw error;
+            }
+
+            return new Response(JSON.stringify({data: {ok: true}}), {
+                status : 200,
+                headers: {'content-type': 'application/json'}
+            });
+        };
+
+        const result = await GraphqlService.query(QUERY);
+
+        expect(result).toEqual({ok: true});
+        expect(callCount).toBe(2);
+    });
+
+    test('fails after the retry budget is exhausted', async () => {
+        let callCount = 0;
+
+        globalThis.fetch = async () => {
+            callCount++;
+            return new Response('', {status: 504, statusText: 'Gateway Timeout'});
+        };
+
+        await expect(GraphqlService.query(QUERY)).rejects.toThrow('GitHub API request failed: 504 Gateway Timeout');
+        expect(callCount).toBe(3);
+    });
+
+    test('does not retry non-transient 400 responses', async () => {
+        let callCount = 0;
+
+        globalThis.fetch = async () => {
+            callCount++;
+            return new Response('', {status: 400, statusText: 'Bad Request'});
+        };
+
+        await expect(GraphqlService.query(QUERY)).rejects.toThrow('GitHub API request failed: 400 Bad Request');
+        expect(callCount).toBe(1);
+    });
+
+    test('does not retry semantic GraphQL errors in a 200 response', async () => {
+        let callCount = 0;
+
+        globalThis.fetch = async () => {
+            callCount++;
+            return new Response(JSON.stringify({errors: [{message: 'Field does not exist'}]}), {
+                status : 200,
+                headers: {'content-type': 'application/json'}
+            });
+        };
+
+        await expect(GraphqlService.query(QUERY)).rejects.toThrow('GitHub API error: Field does not exist');
+        expect(callCount).toBe(1);
+    });
+});


### PR DESCRIPTION
Resolves #11585

Authored by GPT-5.5 (Codex Desktop). Session 8591bc48-0ddc-48bf-aa47-58e53ea81a57.
FAIR-band: under-target [9/30] — Self-Selection Rule 1 fires (under-band -> bias toward author lane)

Restores GitHub workflow sync resilience for transient GraphQL edge failures. `GraphqlService.query()` now retries bounded transient HTTP 429/502/503/504 responses and likely transient fetch transport failures with exponential backoff, jitter, and Retry-After support, while preserving fail-fast behavior for non-transient 4xx and semantic GraphQL errors.

Evidence: L3 (same-shape live GitHub GraphQL pagination probe completed 96 pages / 2,879 PRs after an operator-observed 504; focused unit contracts cover retry/fail-fast behavior) -> L3 required. No residuals.

## Deltas from ticket
- Added retry policy configs to `GraphqlService` with default max 3 retry attempts, bounded exponential delay, jitter, Retry-After support, and retryable status list.
- Added transient network/fetch detection for edge cases such as `fetch failed`, `terminated`, timeout, reset, DNS retry, and socket hang-up failures.
- Added `authTokenOverride` for unit tests and controlled embedded callers; normal runtime auth still uses `gh auth token`.
- Added focused unit coverage for 504 retry success, fetch failure retry success, exhausted retry budget, non-transient 400 fail-fast, and semantic GraphQL error fail-fast.

## Test Evidence
- `npm run test-unit -- test/playwright/unit/ai/services/github-workflow/GraphqlService.spec.mjs test/playwright/unit/ai/services/github-workflow/LabelService.spec.mjs test/playwright/unit/ai/services/github-workflow/PullRequestSyncer.spec.mjs` — 9 passed.
- `npm run test-unit -- test/playwright/unit/ai/services/github-workflow` — 171 passed, 3 failed in existing `PullRequestService.spec.mjs` cases because sandboxed `gh pr view/diff` could not connect to `api.github.com`; failures were outside the new `GraphqlService` spec and the focused slice.
- `git diff --cached --check` — passed.
- Live same-shape GraphQL PR pagination probe against GitHub completed 96 pages / 2,879 PRs without 504, confirming the operator failure mode is transient and belongs at the bounded retry boundary.

## Post-Merge Validation
- [ ] Run `npm run ai:sync-github-workflow` from the direct-dev sync environment and confirm a transient GitHub 502/503/504 no longer aborts the full sync without bounded retries.
- [ ] Watch the next scheduled data-sync pipeline run for successful PR sync completion.

## Commit
- `a373103d4` — `fix(github-workflow): retry transient GraphQL sync failures (#11585)`