### PR TITLE
fix(build): bypass hooks for data sync commits (#11590)

### DIFF
--- a/.github/workflows/data-sync-pipeline.yml
+++ b/.github/workflows/data-sync-pipeline.yml
@@ -72,7 +72,7 @@ jobs:
             git add apps/devindex/resources/data/*.json* apps/portal/resources/data/*.json apps/portal/sitemap.xml apps/portal/llms.txt
 
             # Commit
-            git commit -m "chore(data): Hourly data sync pipeline update [skip ci]"
+            git commit --no-verify -m "chore(data): Hourly data sync pipeline update [skip ci]"
 
             # Discard any other unstaged changes to allow rebase
             git reset --hard
@@ -136,7 +136,7 @@ jobs:
             git add llms.txt 2>/dev/null || true
             git add -A node_modules/neo.mjs/resources/content/
             
-            git commit -m "chore(data): Sync data and content from neo repo [skip ci]"
+            git commit --no-verify -m "chore(data): Sync data and content from neo repo [skip ci]"
             git push origin main
           else
             echo "No changes detected for pages repo."

--- a/ai/services/github-workflow/SyncService.mjs
+++ b/ai/services/github-workflow/SyncService.mjs
@@ -13,6 +13,22 @@ import {promisify} from 'util';
 
 const execAsync = promisify(exec);
 
+const generatedSyncPaths = [
+    'resources/content/issues/',
+    'resources/content/discussions/',
+    'resources/content/pulls/',
+    'resources/content/release-notes/',
+    'resources/content/archive/',
+    'resources/content/issue-archive/',
+    'resources/content/pr-archive/',
+    'resources/content/_index.json',
+    'resources/content/.sync-metadata.json'
+];
+
+const isGeneratedSyncFile = file => generatedSyncPaths.some(item =>
+    item.endsWith('/') ? file.startsWith(item) : file === item
+);
+
 /**
  * @summary Orchestrates the bi-directional synchronization of GitHub issues and releases with local Markdown files.
  *
@@ -162,11 +178,17 @@ class SyncService extends Base {
                         } else {
                             logger.info('[SyncService] Detected real content changes. Committing and pushing.');
                             await execAsync('git add resources/content', {cwd});
-                            // Sanctioned bypass for check-chore-sync.mjs guard
-                            await execAsync('git commit -m "chore: ticket sync [skip ci]"', {
-                                cwd,
-                                env: { ...process.env, NEO_SYNC_AUTOCOMMIT: '1' }
-                            });
+                            const {stdout: stagedStdout} = await execAsync('git diff --cached --name-only', {cwd});
+                            const nonSyncFiles = stagedStdout.trim().split('\n').filter(Boolean).filter(file =>
+                                !isGeneratedSyncFile(file)
+                            );
+
+                            if (nonSyncFiles.length > 0) {
+                                throw new Error(`Automated sync commit rejected: non-sync files are staged: ${nonSyncFiles.join(', ')}`);
+                            }
+
+                            // Automated generated-data commits bypass Husky; hooks are human-lane guards.
+                            await execAsync('git commit --no-verify -m "chore: ticket sync [skip ci]"', {cwd});
                             await execAsync('git pull --rebase --autostash', {cwd});
                             await execAsync('git push', {cwd});
                             logger.info('[SyncService] Successfully pushed changes to GitHub.');


### PR DESCRIPTION
Authored by GPT-5.5 (Codex Desktop). Session 8591bc48-0ddc-48bf-aa47-58e53ea81a57.

FAIR-band: in-band [9/30 - current author count over last 30 merged]

Resolves #11590

Automated GitHub data-sync commits now bypass Husky pre-commit hooks. `SyncService` performs a service-local generated-payload assertion after staging `resources/content`, then commits with `--no-verify` so generated GitHub markdown is not blocked by human-lane source-format hooks. The scheduled data-sync workflow uses the same no-verify commit shape for generated data pushes.

Evidence: L2 (targeted hook unit coverage + command-shape audit) -> L2 required (pipeline commit command behavior and generated-payload guard shape). Residual: post-merge live `npm run ai:sync-github-workflow` confirmation [#11590].

## Deltas from ticket
The initial ticket prescription allowed generated-only sync commits through the hook on `dev`. Operator retest showed the deeper problem: automated data pipelines should not invoke Husky at all. The implementation leaves `check-chore-sync.mjs` as a human/manual-lane hook guard and moves automated commits to `--no-verify`, with `SyncService` retaining an internal generated-only staged-payload assertion.

## Test Evidence
- `git diff --check`
- `npm run test-unit -- test/playwright/unit/ai/buildScripts/util/check-chore-sync.spec.mjs` (7 passed)
- `git diff --check origin/dev...HEAD` after rebasing onto latest `origin/dev`
- `list_pull_requests(state=merged, limit=30)` for FAIR-band count: neo-gpt 9/30

## Post-Merge Validation
- [ ] Run `npm run ai:sync-github-workflow` from `dev` with generated PR markdown containing trailing whitespace and confirm auto-commit/push succeeds without Husky.

## Commits
- `50b184396` - bypass hooks for data sync commits

## Evolution
The lane pivoted after the operator reproduced the second failure mode: the sync commit no longer failed on branch policy alone, but on Husky whitespace checks against generated PR markdown. Claude then identified the remaining coupling in calling the hook script from automation, so the final shape keeps the payload guard inside `SyncService` and leaves Husky as a human-lane guard only.