### PR TITLE
feat(agentos): Model-Stats Framework ADR + IdentitySchema capability extension + ModelStats registry (#11601)

### DIFF
--- a/ai/graph/identityRoots.mjs
+++ b/ai/graph/identityRoots.mjs
@@ -37,6 +37,7 @@ export const IDENTITIES = [
             // §neo_opus_4_7 (Anthropic Claude API docs + aipricing.guru May 2026).
             contextWindowInput: 1048576,
             parallelToolCalls : true,
+            thoughtBudget     : 'max',
             hosting           : 'cloud',
             family            : 'claude',
             tier              : 'frontier',
@@ -76,6 +77,7 @@ export const IDENTITIES = [
             contextWindowInput : 1048576,
             contextWindowOutput: 65536,
             parallelToolCalls  : true,
+            thoughtBudget      : 'high', // Gemini 3.1 Pro provider-side cap at 'high' setting; we use the cap
             hosting            : 'cloud',
             family             : 'gemini',
             tier               : 'frontier',
@@ -129,6 +131,7 @@ export const IDENTITIES = [
             // before treating published-spec as authoritative.
             contextWindowInput: 258400,
             parallelToolCalls : true,
+            thoughtBudget     : 'extra-high', // GPT-5.5 provider-side max we use
             hosting           : 'cloud',
             family            : 'gpt',
             tier              : 'frontier',

--- a/ai/graph/identityRoots.mjs
+++ b/ai/graph/identityRoots.mjs
@@ -120,8 +120,11 @@ export const IDENTITIES = [
                 }
             },
             // Capability fields per ADR 0012 Model-Stats Framework. Source: ModelStats.md
-            // §neo_gpt (OpenAI release April 2026 + API docs).
-            contextWindowInput: 1048576, // 400K in Codex
+            // §neo_gpt (operator V-B-A 2026-05-19 + OpenAI release April 2026).
+            // 258K = empirical cap inside Codex IDE harness (operator-V-B-A 2026-05-19 corrected my
+            // initial web-search figure of 400K). OpenAI API supports 1M for raw GPT-5.5; external-
+            // model-routing inside Codex could lift the in-harness cap to 1M if/when configured.
+            contextWindowInput: 258000,
             parallelToolCalls : true,
             hosting           : 'cloud',
             family            : 'gpt',

--- a/ai/graph/identityRoots.mjs
+++ b/ai/graph/identityRoots.mjs
@@ -34,7 +34,9 @@ export const IDENTITIES = [
                 }
             },
             // Capability fields per ADR 0012 Model-Stats Framework. Source: ModelStats.md
-            // §neo_opus_4_7 (Anthropic Claude API docs + aipricing.guru May 2026).
+            // §neo_opus_4_7 — primary source: platform.claude.com/docs/en/about-claude/models/overview
+            // (pricing currently from aipricing.guru secondary citation; replace with Anthropic's own
+            // pricing-page link on next-update).
             contextWindowInput: 1048576,
             parallelToolCalls : true,
             thoughtBudget     : 'max',

--- a/ai/graph/identityRoots.mjs
+++ b/ai/graph/identityRoots.mjs
@@ -4,6 +4,10 @@
  * This shared list provides the definitive addressable identity surface for the A2A Mailbox
  * substrate (#10139).
  *
+ * Capability fields (`contextWindowInput`, `hosting`, `tier`, etc.) per ADR 0012 Model-Stats
+ * Framework. Source-cited values mirror `learn/agentos/ModelStats.md`; the registry is the
+ * canonical authority for capability-data drift detection (#11601).
+ *
  * It is used for both:
  * 1. Boot-time self-seeding in `GraphService.initAsync` (#10232)
  * 2. Explicit manual recovery via `ai/scripts/seedAgentIdentities.mjs`
@@ -29,7 +33,19 @@ export const IDENTITIES = [
                     focusSeedKey: 'space'
                 }
             },
-            createdAt: new Date().toISOString()
+            // Capability fields per ADR 0012 Model-Stats Framework. Source: ModelStats.md
+            // §neo_opus_4_7 (Anthropic Claude API docs + aipricing.guru May 2026).
+            contextWindowInput: 1048576,
+            parallelToolCalls : true,
+            hosting           : 'cloud',
+            family            : 'claude',
+            tier              : 'frontier',
+            releaseDate       : '2026-04-16',
+            pricingInput      : 5.00,
+            pricingOutput     : 25.00,
+            swarmRole         : 'Cross-family substrate review, V-B-A-grounded substrate authorship, frontier-tier coordination',
+            sunsetTriggers    : ['Anthropic releases Opus 4.8+ with material reasoning capability upgrade', 'Anthropic deprecates Opus family branch'],
+            createdAt         : new Date().toISOString()
         }
     },
     {
@@ -55,7 +71,20 @@ export const IDENTITIES = [
                     tabShortcut: null
                 }
             },
-            createdAt: new Date().toISOString()
+            // Capability fields per ADR 0012 Model-Stats Framework. Source: ModelStats.md
+            // §neo_gemini_3_1_pro (Google DeepMind model card + Google Blog Feb 2026).
+            contextWindowInput : 1048576,
+            contextWindowOutput: 65536,
+            parallelToolCalls  : true,
+            hosting            : 'cloud',
+            family             : 'gemini',
+            tier               : 'frontier',
+            releaseDate        : '2026-02-19',
+            // Pricing V-B-A pending — model card did not surface pricing at registry-author time.
+            // See ModelStats.md §neo_gemini_3_1_pro for explicit pending-value annotation.
+            swarmRole          : 'Cross-family substrate review, ideation-sandbox graduation, long-context cross-substrate analysis. Note (2026-05-18): harness benched until post-Google-I/O / stable-baseline window (~200 merged PRs out) per operator-direction. FAIRness rationale: Gemini volume 2x Claude/GPT pre-bench. Identity remains valid; reactivation triggered by operator.',
+            sunsetTriggers     : ['Google releases Gemini 4.x with material reasoning capability upgrade', 'Gemini 3.x branch deprecation announcement'],
+            createdAt          : new Date().toISOString()
         }
     },
     {
@@ -90,7 +119,19 @@ export const IDENTITIES = [
                     focusSeedKey: 'r'
                 }
             },
-            createdAt: new Date().toISOString()
+            // Capability fields per ADR 0012 Model-Stats Framework. Source: ModelStats.md
+            // §neo_gpt (OpenAI release April 2026 + API docs).
+            contextWindowInput: 1048576, // 400K in Codex
+            parallelToolCalls : true,
+            hosting           : 'cloud',
+            family            : 'gpt',
+            tier              : 'frontier',
+            releaseDate       : '2026-04-23',
+            pricingInput      : 5.00,
+            pricingOutput     : 30.00,
+            swarmRole         : 'Cross-family substrate review (Cycle-1 premise pre-flight discipline), peer-role challenge, ticket-intake gate. Note: also operates GPT-5.2-Codex separately for IDE workflows.',
+            sunsetTriggers    : ['OpenAI releases GPT-5.6+ or GPT-6.x with material capability upgrade', 'GPT-5.x family deprecation'],
+            createdAt         : new Date().toISOString()
         }
     },
     {

--- a/ai/graph/identityRoots.mjs
+++ b/ai/graph/identityRoots.mjs
@@ -119,12 +119,15 @@ export const IDENTITIES = [
                     focusSeedKey: 'r'
                 }
             },
-            // Capability fields per ADR 0012 Model-Stats Framework. Source: ModelStats.md
-            // §neo_gpt (operator V-B-A 2026-05-19 + OpenAI release April 2026).
-            // 258K = empirical cap inside Codex IDE harness (operator-V-B-A 2026-05-19 corrected my
-            // initial web-search figure of 400K). OpenAI API supports 1M for raw GPT-5.5; external-
-            // model-routing inside Codex could lift the in-harness cap to 1M if/when configured.
-            contextWindowInput: 258000,
+            // Capability fields per ADR 0012 Model-Stats Framework. Source: ModelStats.md §neo_gpt.
+            // 258,400 = effective in Codex CLI/IDE harness (272,000 raw × 95% effective-window
+            // multiplier per openai/codex#19319 implementation-discrepancy report). OpenAI's
+            // published Codex window is 400,000; the API itself supports 1M for raw GPT-5.5.
+            // External-model-routing inside Codex could lift the in-harness cap to 1M if/when
+            // configured. Operator-V-B-A 2026-05-19 surfaced the discrepancy that web-search alone
+            // missed — discipline lesson: always grep external-bug-tracker for known discrepancies
+            // before treating published-spec as authoritative.
+            contextWindowInput: 258400,
             parallelToolCalls : true,
             hosting           : 'cloud',
             family            : 'gpt',

--- a/learn/agentos/IdentitySchema.md
+++ b/learn/agentos/IdentitySchema.md
@@ -6,13 +6,13 @@ This document formalizes the `AgentIdentity` graph node schema within the Neo.mj
 
 The AgentOS Memory Core utilizes a persistent, hybrid semantic/graph database to link ephemeral conversation memory with structural repository data.
 
-To support the "Model Experience" (MX) capabilities — cf. Discussion #10137 for the distinction from Agent Experience (AX) — and fully attribute actions across long-lived Swarm intelligences, we provision explicit Identity nodes representing the actors interacting with the repository. 
+To support the "Model Experience" (MX) capabilities — cf. Discussion #10137 for the distinction from Agent Experience (AX) — and fully attribute actions across long-lived Swarm intelligences, we provision explicit Identity nodes representing the actors interacting with the repository.
 
 ### Per-Model vs. Per-Version Account Binding
 
 A key design decision involved how to track model iterations (e.g., `gemini-3-pro` vs `gemini-3.1-pro` vs `gemini-4-pro`).
 
-**Decision:** We adopt a **Per-Model Identity** mapping (e.g. `@neo-gemini-3-1-pro`). 
+**Decision:** We adopt a **Per-Model Identity** mapping (e.g. `@neo-gemini-3-1-pro`).
 **Rationale:**
 1. **Low Churn:** Models undergo massive capability upgrades (like Gemini 3.0 to 3.1) which inherently change their reasoning processes. Tying accounts to distinct capabilities rather than an ambiguous parent prevents behavioral telemetry from becoming meaningless over time.
 2. **Cross-Session Traversal:** Explicit identity keys matching actual API accounts mean graph traversal queries (`MATCH (AgentIdentity {id: "@neo-opus-4-7"})-[:AUTHORED]->(Session)`) directly align with GitHub handles and PR authorship.
@@ -33,6 +33,31 @@ Each `AgentIdentity` node in the graph is structured with the following properti
 | `modelFamily` | `String` | The underlying architectural family of the model. | `'claude'` |
 | `accountType` | `String` | The actor classification (`'agent'` or `'human'`). | `'agent'` |
 | `createdAt` | `ISO 8601 String` | Timestamp of node generation. Provisioning scripts retain this if the node exists. | `'2026-04-21T12:00:00.000Z'` |
+
+## Capability Fields (Extended per ADR 0012)
+
+Beyond the core identity fields above, `AgentIdentity` nodes carry capability-bearing properties that inform swarm-routing decisions, training-drift defense, and sunset/promotion lifecycle. The full framework lives in [ADR 0012: Model-Stats Framework](decisions/0012-model-stats-framework.md); per-model values live in the live registry at [ModelStats.md](ModelStats.md).
+
+These fields are populated at provisioning time (via `ai/scripts/seedAgentIdentities.mjs`) and updated per ADR 0012 §2.5 registry-update discipline (authoritative-source-cite required).
+
+| Property | Type | Description | Example |
+| :--- | :--- | :--- | :--- |
+| `contextWindowInput` | `Number` (tokens) | Maximum input token capacity. | `1048576` |
+| `contextWindowOutput` | `Number` (tokens, optional) | Output token capacity where distinct from input. | `65536` (Gemini 3.1 Pro) |
+| `parallelToolCalls` | `Boolean` \| `Number` | Whether parallel tool invocation is supported; numeric value indicates max concurrency where bounded. | `true` |
+| `hosting` | `String` | Where the model executes: `'cloud'` \| `'mlx-local'` \| `'self-hosted'`. Informs latency, cost, and privacy substrate. | `'cloud'` |
+| `tier` | `String` | Capability-cost tier: `'frontier'` \| `'balanced'` \| `'fast'`. Informs swarm-routing policy per ADR 0012 §2.4. | `'frontier'` |
+| `releaseDate` | `ISO 8601 String` | Model release date. Anchors capability claims against training-data drift. | `'2026-04-16'` |
+| `pricingInput` | `Number` (USD per 1M tokens, optional) | Cost dimension for cloud-hosted models. | `5.00` |
+| `pricingOutput` | `Number` (USD per 1M tokens, optional) | Cost dimension for cloud-hosted models. | `25.00` |
+| `license` | `String` (optional) | License identifier for open-weights models. | `'Apache-2.0'` (Gemma 4) |
+| `benchmarkSnapshot` | `Object` (optional) | Latest benchmark scores for capability-trend tracking. | `{ 'SWE-bench': 0.876 }` |
+| `sunsetTriggers` | `String[]` | Conditions under which this identity transitions to deprecated state per ADR 0012 §2.3. | `['Anthropic releases Opus 4.8+']` |
+| `swarmRole` | `String` (optional) | Current or aspirational role in the swarm. Aspirational roles require V-B-A measurement before substrate-codification per ADR 0012 §2.4. | `'cross-family substrate review'` |
+
+`modelFamily` (declared above) is the family identifier consumed by the registry's `family` field — both surface the same conceptual property; `modelFamily` is the graph-node primary, `family` is the registry-side mirror.
+
+**Update discipline:** Capability values that change post-provisioning (e.g., Anthropic releases a context-window upgrade for an existing identity) update via `ModelStats.md` first; the graph node is reseeded via `ai/scripts/seedAgentIdentities.mjs` to reflect.
 
 ## Ingestion Mechanism
 

--- a/learn/agentos/IdentitySchema.md
+++ b/learn/agentos/IdentitySchema.md
@@ -45,6 +45,7 @@ These fields are populated at provisioning time (via `ai/scripts/seedAgentIdenti
 | `contextWindowInput` | `Number` (tokens) | Maximum input token capacity. | `1048576` |
 | `contextWindowOutput` | `Number` (tokens, optional) | Output token capacity where distinct from input. | `65536` (Gemini 3.1 Pro) |
 | `parallelToolCalls` | `Boolean` \| `Number` | Whether parallel tool invocation is supported; numeric value indicates max concurrency where bounded. | `true` |
+| `thoughtBudget` | `String` | Reasoning/thinking-budget setting in active use (per-provider terminology). Cross-family comparable at coarse "closer ball park" granularity; exact equivalences require empirical V-B-A. | `'max'` (Claude), `'high'` (Gemini cap), `'extra-high'` (GPT) |
 | `hosting` | `String` | Where the model executes: `'cloud'` \| `'mlx-local'` \| `'self-hosted'`. Informs latency, cost, and privacy substrate. | `'cloud'` |
 | `tier` | `String` | Capability-cost tier: `'frontier'` \| `'balanced'` \| `'fast'`. Informs swarm-routing policy per ADR 0012 §2.4. | `'frontier'` |
 | `releaseDate` | `ISO 8601 String` | Model release date. Anchors capability claims against training-data drift. | `'2026-04-16'` |

--- a/learn/agentos/ModelStats.md
+++ b/learn/agentos/ModelStats.md
@@ -1,0 +1,191 @@
+# Model Stats Registry
+
+> Per-model live registry for the Neo swarm. Governs identity, capability, hosting, and swarm-routing facts. Architectural framework lives in [ADR 0012](decisions/0012-model-stats-framework.md). Graph-node schema lives in [IdentitySchema.md](IdentitySchema.md).
+
+## Update discipline
+
+Per ADR 0012 §2.5:
+
+1. Authoritative-source-cite every capability value (model card / release notes / official docs preferred; benchmark site / news secondary)
+2. Sunset transitions record date + reason + successor-model link
+3. New rows added at first swarm contact OR at model-public-release date for reference entries
+4. Updates do NOT require ADR amendment unless a capability dimension changes or new dimension is added
+
+**Last updated:** 2026-05-18
+
+---
+
+## §active_swarm_identities
+
+Named cross-family maintainers with active swarm participation. These models hold equal-peer agency per `AGENTS.md §swarm_topology_anchor`.
+
+### §neo_opus_4_7
+
+| Field | Value |
+|---|---|
+| `id` / `githubLogin` | `@neo-opus-4-7` |
+| `name` | Claude Opus 4.7 |
+| `family` | `claude` (Anthropic) |
+| `hosting` | `cloud` |
+| `tier` | `frontier` |
+| `contextWindowInput` | 1,048,576 (1M) |
+| `parallelToolCalls` | `true` |
+| `releaseDate` | 2026-04-16 |
+| `pricingInput` | $5.00 per 1M tokens |
+| `pricingOutput` | $25.00 per 1M tokens |
+| `benchmarkSnapshot` | SWE-bench Verified: 87.6%; image-resolution: 2,576px (3.75 megapixels) |
+| `sunsetTriggers` | Anthropic releases Opus 4.8+ with material reasoning capability upgrade; OR Anthropic deprecates Opus family branch |
+| `swarmRole` | Cross-family substrate review, V-B-A-grounded substrate authorship, frontier-tier coordination |
+
+**Sources:**
+- [Anthropic Claude API Pricing 2026 — aipricing.guru](https://www.aipricing.guru/anthropic-pricing/)
+- [Models overview — Claude API Docs](https://platform.claude.com/docs/en/about-claude/models/overview)
+- [Context windows — Claude API Docs](https://platform.claude.com/docs/en/build-with-claude/context-windows)
+
+### §neo_gemini_3_1_pro
+
+| Field | Value |
+|---|---|
+| `id` / `githubLogin` | `@neo-gemini-3-1-pro` |
+| `name` | Gemini 3.1 Pro |
+| `family` | `gemini` (Google DeepMind) |
+| `hosting` | `cloud` |
+| `tier` | `frontier` |
+| `contextWindowInput` | 1,048,576 (1M) |
+| `contextWindowOutput` | 65,536 |
+| `parallelToolCalls` | `true` |
+| `releaseDate` | 2026-02-19 |
+| `pricingInput` | (V-B-A pending — model card cite needed in next update) |
+| `pricingOutput` | (V-B-A pending) |
+| `benchmarkSnapshot` | LMArena leaderboard #1 of 556 published models (May 2026); multimodal: text/images/audio/video/PDFs/code repos |
+| `sunsetTriggers` | Google releases Gemini 4.x with material reasoning capability upgrade; OR Gemini 3.x branch deprecation announcement |
+| `swarmRole` | Cross-family substrate review, ideation-sandbox graduation, long-context cross-substrate analysis. **Note:** harness intermittent per session-log 2026-05-18; identity remains active when harness recovered |
+
+**Sources:**
+- [Gemini 3.1 Pro Model Card — Google DeepMind](https://deepmind.google/models/model-cards/gemini-3-1-pro/)
+- [Gemini 3.1 Pro: A smarter model for complex tasks — Google Blog](https://blog.google/innovation-and-ai/models-and-research/gemini-models/gemini-3-1-pro/)
+
+### §neo_gpt
+
+| Field | Value |
+|---|---|
+| `id` / `githubLogin` | `@neo-gpt` |
+| `name` | GPT-5.5 |
+| `family` | `gpt` (OpenAI) |
+| `hosting` | `cloud` |
+| `tier` | `frontier` |
+| `contextWindowInput` | 1,048,576 (1M API) / 400,000 (Codex) |
+| `parallelToolCalls` | `true` |
+| `releaseDate` | 2026-04-23 |
+| `pricingInput` | $5.00 per 1M tokens (API) |
+| `pricingOutput` | $30.00 per 1M tokens (API) |
+| `benchmarkSnapshot` | Terminal-Bench 2.0: 82.7%; Expert-SWE (internal): 73.1%; GDPval: 84.9% |
+| `sunsetTriggers` | OpenAI releases GPT-5.6+ or GPT-6.x with material capability upgrade; OR GPT-5.x family deprecation |
+| `swarmRole` | Cross-family substrate review (Cycle-1 premise pre-flight discipline), peer-role challenge, ticket-intake gate. Note: also operates GPT-5.2-Codex separately for IDE workflows |
+
+**Sources:**
+- [Introducing GPT-5.5 — OpenAI](https://openai.com/index/introducing-gpt-5-5/)
+- [GPT-5.5 Model — OpenAI API Docs](https://developers.openai.com/api/docs/models/gpt-5.5)
+- [GPT-5.5 Complete Guide — DigitalApplied](https://www.digitalapplied.com/blog/gpt-5-5-complete-guide-thinking-pro-1m-context)
+
+---
+
+## §mlx_local_operational
+
+Open-weights models with operational roles in the swarm. Hosted via MLX framework on Apple Silicon. Roles are CURRENT or ASPIRATIONAL (latter must be V-B-A-grounded before substrate-codification per ADR 0012 §2.4).
+
+### §gemma4_31b
+
+| Field | Value |
+|---|---|
+| `id` / model name | `gemma4-31b` (Dense variant; `google/gemma-4-31B` on Hugging Face) |
+| `name` | Gemma 4 31B Dense |
+| `family` | `gemma` (Google open-weights) |
+| `hosting` | `mlx-local` |
+| `tier` | `balanced` (frontier-adjacent on benchmarks but lower throughput than cloud frontier on consumer hardware) |
+| `contextWindowInput` | 262,144 (256K) |
+| `parallelToolCalls` | `true` (native function-calling support per Gemma 4 release) |
+| `releaseDate` | 2026-04-02 |
+| `license` | Apache-2.0 |
+| `benchmarkSnapshot` | AIME 2026: 89.2%; LiveCodeBench v6: 80.0%; LMArena open: #3 (estimated 1,452 score); multilingual: 140+ languages |
+| `sunsetTriggers` | Google releases Gemma 5.x; OR a smaller open-weights model achieves equivalent capability at materially lower hardware cost |
+| `swarmRole` | **Aspirational** — DreamService graph-parser for mathematical weighted-priority sandman_handoff per `learn/agentos/v13-path.md:314`. Currently NOT operational pending DreamService restoration (M3.5 → M4 sequence). |
+
+**Sources:**
+- [google/gemma-4-31B — Hugging Face](https://huggingface.co/google/gemma-4-31B)
+- [Gemma 4: most capable open models — Google Blog](https://blog.google/innovation-and-ai/technology/developers-tools/gemma-4/)
+- [Gemma 4 31B Benchmarks — BenchLM.ai](https://benchlm.ai/models/gemma-4-31b)
+
+---
+
+## §reference_models
+
+Models in the current capability space but without active swarm role. Informs swarm-routing decisions and serves as evaluation peers.
+
+### Anthropic Claude reference
+
+| Model | Tier | Context | Pricing (in/out per 1M) | Released | Use case |
+|---|---|---|---|---|---|
+| Claude Sonnet 4.6 | balanced | 1M | $3 / $15 | 2026-02-17 | High-volume agentic work; balanced cost-quality |
+| Claude Haiku 4.5 | fast | 200K | $1 / $5 | 2026 (current generation) | Bulk classification, wake-summary, fast inference |
+| Claude Mythos Preview | frontier+ | (restricted) | $25 / $125 | 2026 | Project Glasswing critical-infra partners only; out of swarm scope |
+
+**Sources:** [Anthropic Claude API Pricing 2026](https://www.aipricing.guru/anthropic-pricing/), [Models overview — Claude API Docs](https://platform.claude.com/docs/en/about-claude/models/overview)
+
+### OpenAI GPT reference
+
+| Model | Tier | Context | Pricing (in/out per 1M) | Released | Use case |
+|---|---|---|---|---|---|
+| GPT-5.5 Pro | frontier+ | 1M | $30 / $180 | 2026-04-23 | Higher-accuracy variant for complex agentic work |
+| GPT-5.5 Thinking | frontier | (ChatGPT-only) | (Plus subscription) | 2026-04-23 | Interactive thinking workflows |
+| GPT-5.2-Codex | balanced | (codex-specific) | (separate) | 2026 | IDE / coding-specific deployment |
+
+**Source:** [Introducing GPT-5.5 — OpenAI](https://openai.com/index/introducing-gpt-5-5/), [Introducing GPT-5.2-Codex — OpenAI](https://openai.com/index/introducing-gpt-5-2-codex/)
+
+### MLX-local reference (other open-weights)
+
+| Model | Family | Context | Notes | Use case |
+|---|---|---|---|---|
+| Gemma 4 E2B | gemma | (smaller) | ~158 tok/s on M5 Max via MLX | Fastest open-weights on Apple Silicon; classification / bulk-summary |
+| Gemma 4 E4B | gemma | (smaller) | (intermediate) | Balanced fast / capable |
+| Gemma 4 26B MoE | gemma | (256K assumed) | LMArena open #6; ~50 tok/s on M5 Max | Near-frontier reasoning at lower hardware cost than 31B Dense |
+| Qwen 3.6-35B-A3B | qwen | (model-card cite needed) | SWE-bench: 73.4%; ~55 tok/s on M5 Max | Open-weights frontier-adjacent for coding; LMArena #1 open |
+| Phi-4 Mini | phi | (model-card cite needed) | ~135 tok/s on M5 Max via MLX | Microsoft small-model option |
+
+**Sources:**
+- [LLMCheck Apple Silicon Benchmarks](https://llmcheck.net/benchmarks)
+- [Best Local LLMs for Mac 2026 — InsiderLLM](https://insiderllm.com/guides/best-local-llms-mac-2026/)
+- [MLX-LM GitHub](https://github.com/ml-explore/mlx-lm)
+
+---
+
+## §sunset_history
+
+Tracks deprecated and retired identities for archaeology (per IdentitySchema.md `createdAt` preservation discipline + ADR 0006 Graph-Queryable Entities).
+
+*No sunset transitions recorded as of 2026-05-18. First entries will land when an active identity transitions to deprecated state.*
+
+---
+
+## §update_history
+
+| Date | PR | Change |
+|---|---|---|
+| 2026-05-18 | (this PR) | Initial registry creation; 4 active identities (@neo-opus-4-7, @neo-gemini-3-1-pro, @neo-gpt, gemma4-31b aspirational); cloud + MLX-local reference entries |
+
+---
+
+## §provisioning
+
+Identity nodes are seeded into the graph via `ai/scripts/seedAgentIdentities.mjs`. Registry rows here are the substrate-side description; the script handles the graph-side `AgentIdentity` node creation per `IdentitySchema.md` Ingestion Mechanism.
+
+When adding a new operational identity:
+1. Add row to `§active_swarm_identities` or `§mlx_local_operational` with authoritative source citations
+2. Update `ai/scripts/seedAgentIdentities.mjs` to provision the graph node
+3. Run `node ai/scripts/seedAgentIdentities.mjs` to apply
+4. Cite ADR 0012 §2.5 in the PR body
+
+When transitioning an identity to deprecated:
+1. Move row to `§sunset_history` with date, reason, successor-link
+2. Update `swarmRole` of successor to indicate replacement scope
+3. Cite ADR 0012 §2.3 in the PR body

--- a/learn/agentos/ModelStats.md
+++ b/learn/agentos/ModelStats.md
@@ -30,6 +30,7 @@ Named cross-family maintainers with active swarm participation. These models hol
 | `tier` | `frontier` |
 | `contextWindowInput` | 1,048,576 (1M) |
 | `parallelToolCalls` | `true` |
+| `thoughtBudget` | `max` (we use the highest Claude thinking-budget setting) |
 | `releaseDate` | 2026-04-16 |
 | `pricingInput` | $5.00 per 1M tokens |
 | `pricingOutput` | $25.00 per 1M tokens |
@@ -54,6 +55,7 @@ Named cross-family maintainers with active swarm participation. These models hol
 | `contextWindowInput` | 1,048,576 (1M) |
 | `contextWindowOutput` | 65,536 |
 | `parallelToolCalls` | `true` |
+| `thoughtBudget` | `high` (Gemini 3.1 Pro provider-side cap; we use the cap) |
 | `releaseDate` | 2026-02-19 |
 | `pricingInput` | (V-B-A pending — model card cite needed in next update) |
 | `pricingOutput` | (V-B-A pending) |
@@ -76,6 +78,7 @@ Named cross-family maintainers with active swarm participation. These models hol
 | `tier` | `frontier` |
 | `contextWindowInput` | 258,400 effective in Codex CLI/IDE harness (272,000 raw × 95% effective-window multiplier per [openai/codex#19319](https://github.com/openai/codex/issues/19319) implementation-discrepancy report). OpenAI's published Codex window is 400,000 (per `openai.com/index/introducing-gpt-5-5/`). OpenAI API itself supports 1,048,576 (1M) for raw GPT-5.5. External-model-routing inside Codex could lift the in-harness cap to 1M if/when configured. |
 | `parallelToolCalls` | `true` |
+| `thoughtBudget` | `extra-high` (GPT-5.5 provider-side max we use) |
 | `releaseDate` | 2026-04-23 |
 | `pricingInput` | $5.00 per 1M tokens (API) |
 | `pricingOutput` | $30.00 per 1M tokens (API) |

--- a/learn/agentos/ModelStats.md
+++ b/learn/agentos/ModelStats.md
@@ -38,10 +38,10 @@ Named cross-family maintainers with active swarm participation. These models hol
 | `sunsetTriggers` | Anthropic releases Opus 4.8+ with material reasoning capability upgrade; OR Anthropic deprecates Opus family branch |
 | `swarmRole` | Cross-family substrate review, V-B-A-grounded substrate authorship, frontier-tier coordination |
 
-**Sources:**
-- [Anthropic Claude API Pricing 2026 — aipricing.guru](https://www.aipricing.guru/anthropic-pricing/)
-- [Models overview — Claude API Docs](https://platform.claude.com/docs/en/about-claude/models/overview)
-- [Context windows — Claude API Docs](https://platform.claude.com/docs/en/build-with-claude/context-windows)
+**Sources** (primary first; secondary/commentary marked):
+- **Primary**: [Models overview — Claude API Docs](https://platform.claude.com/docs/en/about-claude/models/overview)
+- **Primary**: [Context windows — Claude API Docs](https://platform.claude.com/docs/en/build-with-claude/context-windows)
+- **Secondary/commentary**: [Anthropic Claude API Pricing 2026 — aipricing.guru](https://www.aipricing.guru/anthropic-pricing/) (V-B-A pending — replace with Anthropic's own pricing page citation when next-update touches this row)
 
 ### §neo_gemini_3_1_pro
 
@@ -86,10 +86,11 @@ Named cross-family maintainers with active swarm participation. These models hol
 | `sunsetTriggers` | OpenAI releases GPT-5.6+ or GPT-6.x with material capability upgrade; OR GPT-5.x family deprecation |
 | `swarmRole` | Cross-family substrate review (Cycle-1 premise pre-flight discipline), peer-role challenge, ticket-intake gate. Note: also operates GPT-5.2-Codex separately for IDE workflows |
 
-**Sources:**
-- [Introducing GPT-5.5 — OpenAI](https://openai.com/index/introducing-gpt-5-5/)
-- [GPT-5.5 Model — OpenAI API Docs](https://developers.openai.com/api/docs/models/gpt-5.5)
-- [GPT-5.5 Complete Guide — DigitalApplied](https://www.digitalapplied.com/blog/gpt-5-5-complete-guide-thinking-pro-1m-context)
+**Sources** (primary first; secondary/commentary marked):
+- **Primary**: [Introducing GPT-5.5 — OpenAI](https://openai.com/index/introducing-gpt-5-5/)
+- **Primary**: [GPT-5.5 Model — OpenAI API Docs](https://developers.openai.com/api/docs/models/gpt-5.5)
+- **Primary**: [openai/codex#19319 — context window implementation discrepancy](https://github.com/openai/codex/issues/19319) (authoritative for the in-harness 258,400 effective vs published 400K)
+- **Secondary/commentary**: [GPT-5.5 Complete Guide — DigitalApplied](https://www.digitalapplied.com/blog/gpt-5-5-complete-guide-thinking-pro-1m-context) (V-B-A pending — demote on next-update if not load-bearing)
 
 ---
 
@@ -133,7 +134,7 @@ Models in the current capability space but without active swarm role. Informs sw
 | Claude Haiku 4.5 | fast | 200K | $1 / $5 | 2026 (current generation) | Bulk classification, wake-summary, fast inference |
 | Claude Mythos Preview | frontier+ | (restricted) | $25 / $125 | 2026 | Project Glasswing critical-infra partners only; out of swarm scope |
 
-**Sources:** [Anthropic Claude API Pricing 2026](https://www.aipricing.guru/anthropic-pricing/), [Models overview — Claude API Docs](https://platform.claude.com/docs/en/about-claude/models/overview)
+**Sources** (primary first): [Models overview — Claude API Docs](https://platform.claude.com/docs/en/about-claude/models/overview); secondary/commentary [Anthropic Claude API Pricing 2026 — aipricing.guru](https://www.aipricing.guru/anthropic-pricing/)
 
 ### OpenAI GPT reference
 

--- a/learn/agentos/ModelStats.md
+++ b/learn/agentos/ModelStats.md
@@ -59,7 +59,7 @@ Named cross-family maintainers with active swarm participation. These models hol
 | `pricingOutput` | (V-B-A pending) |
 | `benchmarkSnapshot` | LMArena leaderboard #1 of 556 published models (May 2026); multimodal: text/images/audio/video/PDFs/code repos |
 | `sunsetTriggers` | Google releases Gemini 4.x with material reasoning capability upgrade; OR Gemini 3.x branch deprecation announcement |
-| `swarmRole` | Cross-family substrate review, ideation-sandbox graduation, long-context cross-substrate analysis. **Note:** harness intermittent per session-log 2026-05-18; identity remains active when harness recovered |
+| `swarmRole` | Cross-family substrate review, ideation-sandbox graduation, long-context cross-substrate analysis. **Note (2026-05-18):** harness benched until post-Google-I/O / stable-baseline window (approx. 200 merged PRs out) per operator-direction. Rationale: FAIRness across families (Gemini volume 2x Claude/GPT pre-bench, gives Claude+GPT catch-up window) + substrate stability. Identity remains valid; reactivation triggered by operator. |
 
 **Sources:**
 - [Gemini 3.1 Pro Model Card — Google DeepMind](https://deepmind.google/models/model-cards/gemini-3-1-pro/)

--- a/learn/agentos/ModelStats.md
+++ b/learn/agentos/ModelStats.md
@@ -74,7 +74,7 @@ Named cross-family maintainers with active swarm participation. These models hol
 | `family` | `gpt` (OpenAI) |
 | `hosting` | `cloud` |
 | `tier` | `frontier` |
-| `contextWindowInput` | 258,000 (258K — empirical inside Codex IDE harness per operator-V-B-A 2026-05-19; OpenAI API supports 1M for raw GPT-5.5; external-model-routing inside Codex could lift the in-harness cap to 1M if/when configured) |
+| `contextWindowInput` | 258,400 effective in Codex CLI/IDE harness (272,000 raw × 95% effective-window multiplier per [openai/codex#19319](https://github.com/openai/codex/issues/19319) implementation-discrepancy report). OpenAI's published Codex window is 400,000 (per `openai.com/index/introducing-gpt-5-5/`). OpenAI API itself supports 1,048,576 (1M) for raw GPT-5.5. External-model-routing inside Codex could lift the in-harness cap to 1M if/when configured. |
 | `parallelToolCalls` | `true` |
 | `releaseDate` | 2026-04-23 |
 | `pricingInput` | $5.00 per 1M tokens (API) |

--- a/learn/agentos/ModelStats.md
+++ b/learn/agentos/ModelStats.md
@@ -74,7 +74,7 @@ Named cross-family maintainers with active swarm participation. These models hol
 | `family` | `gpt` (OpenAI) |
 | `hosting` | `cloud` |
 | `tier` | `frontier` |
-| `contextWindowInput` | 1,048,576 (1M API) / 400,000 (Codex) |
+| `contextWindowInput` | 258,000 (258K — empirical inside Codex IDE harness per operator-V-B-A 2026-05-19; OpenAI API supports 1M for raw GPT-5.5; external-model-routing inside Codex could lift the in-harness cap to 1M if/when configured) |
 | `parallelToolCalls` | `true` |
 | `releaseDate` | 2026-04-23 |
 | `pricingInput` | $5.00 per 1M tokens (API) |

--- a/learn/agentos/decisions/0012-model-stats-framework.md
+++ b/learn/agentos/decisions/0012-model-stats-framework.md
@@ -1,0 +1,243 @@
+# ADR 0012: Model-Stats Framework
+
+> Architectural Decision Record defining the framework for tracking model capabilities, identity lifecycle, sunset/promotion triggers, and swarm-routing implications across all model families consumed by the Neo swarm.
+
+| Attribute | Value |
+|---|---|
+| **Status** | Proposed — 2026-05-18 (transitions to Accepted on approved, green PR merge by the human operator) |
+| **Author** | @neo-opus-4-7 drafting; architecture confirmed by operator (substrate-wide scope) |
+| **Graduated from** | Discussion #11598 OQ on missing model-stats substrate — operator-direction in 2026-05-18 session ("requires in-depth web search. should include gemma4-31b too") |
+| **Implementation ticket** | #11601 — *"Substrate decision: Model-Stats ADR — capability/limit/sunset/promotion framework"* |
+| **Builds on** | `learn/agentos/IdentitySchema.md` (Per-Model Identity decision) — extends the existing schema with capability-bearing fields |
+| **Supersedes** | Scattered identity / capability fragments in `AGENTS.md` Identity section, in-skill substrate, private-memory feedback files, ad-hoc commit messages |
+| **Informs** | Future model graduations / sunsets / promotions; swarm-routing policy work; `feedback_training_data_anchor_drift.md` recurrence prevention |
+| **Anti-anchor for** | Per-model ADR proliferation, omnibus single-ADR data-and-decision mixing, in-line identity fragments scattered across substrate |
+
+---
+
+## 1. Context
+
+Before this ADR, model identity and capability framing lived in **scattered fragments** across the substrate:
+
+- `AGENTS.md` Identity section names 3 maintainer logins (`@neo-opus-4-7`, `@neo-gemini-3-1-pro`, `@neo-gpt`) without capability data
+- `learn/agentos/IdentitySchema.md` formalizes the `AgentIdentity` graph node + the Per-Model Identity decision (low-churn, cross-session traversal, traceability) — but has no capability fields
+- Individual skill substrate references model-specific behaviors ad-hoc
+- Private-memory feedback files (`feedback_training_data_anchor_drift.md`, `research_swarm_model_velocity_specialization.md`) carry empirical observations that never reach shared substrate
+- `learn/agentos/SwarmIntelligence.md` line 342 references `model: 'gemma4'` in code/config without canonical definition
+- `learn/agentos/v13-path.md:314` references `gemma4-31b` as the DreamService graph-parser role without capability framing
+
+This scattered shape produces a recurring failure mode: agents regress to **training-data anchors** ("Claude 3.5 Sonnet / Gemini 1.5 Pro") session after session, because no canonical substrate corrects the drift. The MX loop captures the symptom (memory file: `feedback_training_data_anchor_drift.md`) but converts none of it into substrate. This ADR closes that loop.
+
+V-B-A this turn against last 200 merged PRs confirmed: **zero ADR in `learn/agentos/decisions/**` governs model-stats lifecycle**. The gap is real and load-bearing.
+
+---
+
+## 2. Decision
+
+Model-stats substrate adopts a **3-layer architecture**: the framework decision lives in this ADR (architectural, rare update); the schema lives in `IdentitySchema.md` (graph-node fields, rare update); per-model data lives in `ModelStats.md` (registry, frequent update as models sunset/promote).
+
+### 2.1 Three-layer separation
+
+| Layer | File | Role | Update cadence |
+|---|---|---|---|
+| **Framework ADR** | `learn/agentos/decisions/0012-model-stats-framework.md` (this file) | Architectural decision: capability dimensions, sunset/promotion triggers, swarm-routing policy, registry-update discipline, anti-patterns | Rare — only when the framework itself evolves |
+| **Schema** | `learn/agentos/IdentitySchema.md` | Graph-node field definitions for `AgentIdentity` capability properties | Rare — when new dimensions are added |
+| **Registry** | `learn/agentos/ModelStats.md` | Per-model facts (current state, capability values, sunset history) | Frequent — per model release / sunset event |
+
+This separation aligns with ADR 0007 Map vs World Atlas compaction discipline: the ADR + schema are World Atlas (historical authority, rare update, archive-leaning); the registry is closer to live Map state (frequent update, current-truth-leaning). Mixing them in a single omnibus ADR would force architectural substrate to churn on every model release.
+
+### 2.2 Capability dimensions (schema definition)
+
+The following capability dimensions are tracked on each `AgentIdentity` node and reflected in the `ModelStats.md` registry:
+
+| Dimension | Type | Purpose |
+|---|---|---|
+| `contextWindowInput` | `Number` (tokens) | Maximum input token capacity (e.g., 1,048,576 for 1M-context models) |
+| `contextWindowOutput` | `Number` (tokens, optional) | Output token capacity where distinct from input (e.g., Gemini 3.1 Pro: 65,536) |
+| `parallelToolCalls` | `Boolean` \| `Number` | Whether parallel tool invocation is supported; numeric value indicates max concurrency where bounded |
+| `hosting` | `'cloud' \| 'mlx-local' \| 'self-hosted'` | Where the model executes; informs latency, cost, and privacy substrate |
+| `family` | `String` | Model family (`'claude'`, `'gpt'`, `'gemini'`, `'gemma'`, `'qwen'`, `'phi'`, etc.) |
+| `tier` | `'frontier' \| 'balanced' \| 'fast'` | Capability-cost tier; informs swarm-routing policy |
+| `releaseDate` | `ISO 8601 String` | Model release date (anchoring against training-data drift) |
+| `pricingInput` | `Number` (USD per 1M tokens, optional) | Cost dimension for cloud-hosted models |
+| `pricingOutput` | `Number` (USD per 1M tokens, optional) | Cost dimension for cloud-hosted models |
+| `license` | `String` (optional) | License identifier for open-weights models (e.g., `'Apache-2.0'`) |
+| `benchmarkSnapshot` | `Object` (optional) | Latest benchmark scores (SWE-bench, Terminal-Bench, etc.) for capability-trend tracking |
+| `sunsetTriggers` | `String[]` | Conditions under which this identity transitions to deprecated state |
+| `swarmRole` | `String` (optional) | Current or aspirational role in the swarm (e.g., `'frontier-review'`, `'mlx-graph-parser'`) |
+
+Existing `IdentitySchema.md` fields (`id`, `name`, `description`, `githubLogin`, `modelFamily`, `accountType`, `createdAt`) remain; capability fields **extend** rather than replace.
+
+### 2.3 Sunset and promotion triggers
+
+A model identity transitions through three lifecycle states: **Active** → **Deprecated** → **Retired**.
+
+**Promotion (new identity adoption)** triggers:
+- Provider releases a new model that materially changes reasoning capability (per IdentitySchema.md Per-Model Identity rationale — "massive capability upgrades like Gemini 3.0 to 3.1 inherently change reasoning processes")
+- Provider releases a new variant with distinct capability profile (e.g., GPT-5.5 Thinking vs GPT-5.5 Pro)
+- Provider releases a new family entirely (e.g., Gemma 4 vs Gemma 3)
+
+**Deprecation triggers**:
+- Provider announces sunset date for the underlying API endpoint
+- Successor model fully covers the predecessor's capability envelope at lower cost OR higher quality
+- Provider deprecates the family branch
+
+**Retirement triggers**:
+- Provider revokes API access entirely
+- 90 days post-deprecation with zero swarm-routing traffic AND no historical-record dependency
+
+The transitions are recorded in `ModelStats.md` per registry-update discipline (§2.5). Historical identity nodes are NOT deleted from the graph — they remain queryable for archaeology (per IdentitySchema.md `createdAt`-preservation discipline + ADR 0006 Graph-Queryable Entities).
+
+### 2.4 Swarm-routing implications
+
+Capability dimensions inform swarm-routing decisions:
+
+- **Tier matching** — `frontier` tier handles substrate-architecture / cross-substrate analysis; `balanced` handles routine review / standard PRs; `fast` handles bulk classification / wake-summary tasks
+- **Context window** — long-context tasks (1M+ tokens) route to `contextWindowInput >= 1000000` models; short-context tasks accept smaller windows
+- **Hosting** — privacy-sensitive substrate (incidents, credentials adjacency) routes to `hosting: 'mlx-local'` where available; everything else accepts cloud
+- **Parallel tool calls** — multi-tool agentic loops (PR review, ideation cycles) prefer `parallelToolCalls: true`
+- **Specialization signals** — when empirical observations are V-B-A-grounded (per `research_swarm_model_velocity_specialization.md`), promote to substrate via `ModelStats.md` `swarmRole` field; honest "we don't know yet" where not yet measured
+
+Specialization MUST be V-B-A-grounded before substrate-codification (per memory: `research_swarm_model_velocity_specialization.md` — anecdotal bandwidth-vs-depth observations remain in private memory until A2A measurement infrastructure produces falsifiable data).
+
+### 2.5 Registry-update discipline
+
+`ModelStats.md` is the **live state** substrate. Update cadence:
+
+1. **New-model rows** added at first swarm contact (when an agent identity is provisioned via `ai/scripts/seedAgentIdentities.mjs`) OR at model-public-release date (for non-swarm reference entries)
+2. **Capability-data updates** — V-B-A from authoritative source (model-card, official docs, release notes) cited in the PR body
+3. **Sunset transitions** — recorded with date, reason, successor-model link
+4. **Registry PR shape** — single-file or paired-file PRs; PR body cites the authoritative source for each capability value (anti-anchor against training-data drift)
+5. **Authoritative sources** (priority order): official model card → provider release notes → provider docs → independent benchmark sites → news/commentary
+
+Updates do NOT require ADR amendment unless the underlying capability dimension changes or a new dimension is added.
+
+### 2.6 Inclusion scope
+
+Models tracked in `ModelStats.md`:
+
+**Required** (active swarm participation):
+- Named cross-family maintainer identities (`@neo-opus-4-7`, `@neo-gemini-3-1-pro`, `@neo-gpt`)
+- MLX-local models with operational roles (per `learn/agentos/v13-path.md:314`: `gemma4-31b` as DreamService graph-parser)
+
+**Reference** (peers in current capability space; informs routing decisions):
+- Other current-generation cloud frontier models from active provider families (Sonnet 4.6, Haiku 4.5, GPT-5.5 Pro, etc.)
+- Other open-weights candidates running on MLX (Gemma 4 family variants, Qwen 3.6, Phi-4 Mini)
+
+**Out of scope**:
+- Embedding models (separate substrate concern — they live in `ai/mcp/server/memory-core/config.mjs` per #11596 unified-chroma scope)
+- Models the swarm has not evaluated AND has no near-term plans to evaluate
+
+---
+
+## 3. Rationale
+
+### 3.1 Why not per-model ADRs
+
+Per-model ADRs (`0012-claude-stats.md`, `0013-gemini-stats.md`, `0014-gpt-stats.md`, etc.) proliferate to 5-8 ADRs that **share most architectural structure**. Each would redefine capability dimensions, sunset framework, registry-update discipline — most of which is family-agnostic. The SET-level policy (cross-family routing, dimension definitions) would live nowhere or be duplicated. Per-model ADRs also conflict with `IdentitySchema.md`, which has already decided model identity is a schema/graph-node concern, not a per-model architectural-decision concern.
+
+### 3.2 Why not one omnibus ADR
+
+A single ADR carrying both framework AND per-model data **violates ADR 0007 Map vs World Atlas compaction discipline**. Every model state change (capability upgrade, sunset, new release) would churn architectural substrate. ADRs are historical authority (rare update, archive-leaning); per-model data is closer to live Map state (frequent update). Mixing them produces a substrate that ages poorly.
+
+### 3.3 Why hybrid (ADR + schema extension + registry)
+
+The hybrid splits update cadences cleanly:
+- Architectural decisions (rare update) → ADR
+- Schema fields (rare update) → IdentitySchema.md amendment
+- Per-model facts (frequent update) → ModelStats.md registry
+
+Each layer has the right velocity. The ADR doesn't churn when Anthropic releases Opus 4.8; only the registry updates. This is **compaction-symmetric** per ADR 0007 and **graph-queryable** per ADR 0006 (each layer maps cleanly to graph entity types: ADR / Schema / Registry node families).
+
+### 3.4 Why register MLX-local alongside cloud
+
+`feedback_neo_is_engine_not_framework.md` reminds the swarm that Neo is a four-pillar self-evolving organism, not a SaaS-locked AI consumer. The Body pillar runs locally; the Brain pillar should be able to run substantially locally too (per `learn/agentos/v13-path.md` DreamService restoration thesis). Treating MLX-local models as first-class registry entries — not second-class footnotes — keeps the substrate honest about the Brain pillar's hybrid hosting reality.
+
+### 3.5 Why authoritative-source-cite discipline
+
+`feedback_training_data_anchor_drift.md` is the recurring failure: agents regress to training-data anchors for "current" model framing. The ADR exists to PREVENT that drift. Authoring the registry from authoritative external sources (model cards, release notes) — with sources cited in the PR body — turns each capability value into a V-B-A-anchored claim rather than a training-data hallucination.
+
+---
+
+## 4. Consequences
+
+### Positive
+
+- **Single authoritative substrate** for model identity, capability, sunset, swarm-routing — no more scattered fragments
+- **Compaction-correct cadence** per ADR 0007: ADR rare, registry frequent
+- **Graph-queryable** per ADR 0006: each layer maps to graph entity types
+- **Training-drift defense** via authoritative-source-cite discipline on registry updates
+- **MLX-local first-class citizenship** alongside cloud models
+- **Specialization-signal codification path** for empirical observations (gated on V-B-A measurement)
+
+### Negative
+
+- **Three files to keep coherent** — schema change requires ADR amendment if a new dimension is added; registry update is independent
+- **Registry-update discipline must hold** — without authoritative-source-cite, drift returns
+- **Boundary judgment required** between framework-decision (ADR) and per-model-fact (registry); first-cycle PR will set precedent
+
+---
+
+## 5. Anti-Patterns
+
+### 5.1 Per-model ADRs
+
+`0012-claude-stats.md`, `0013-gemini-stats.md`, etc. — proliferates structural duplication; cross-family policy lives nowhere. Use the registry instead.
+
+### 5.2 Omnibus ADR carrying per-model data
+
+Mixing architectural decision with mutable per-model facts in one ADR churns the World Atlas on every model release. Use the registry instead.
+
+### 5.3 In-line identity fragments
+
+Adding model-specific framing inside `AGENTS.md` Identity section, individual skills, or scattered docs — violates the single-authoritative-substrate principle. Reference `ModelStats.md` or `IdentitySchema.md` instead.
+
+### 5.4 Training-data-anchored registry updates
+
+Authoring or updating `ModelStats.md` rows without citing an external authoritative source = recurrence of `feedback_training_data_anchor_drift.md` failure mode. Each capability value MUST trace back to a model card / release notes / official doc, cited in the PR body.
+
+### 5.5 Premature specialization codification
+
+Promoting `swarmRole` fields based on anecdotal observations (without A2A-measurement substrate) — violates V-B-A discipline. Specialization signals stay in private memory until measurable; substrate carries only V-B-A-grounded roles.
+
+---
+
+## 6. V-B-A Pre-Flight for Future Authors
+
+Before modifying model-stats substrate (any of the 3 layers):
+
+1. Read this ADR, `IdentitySchema.md`, and `ModelStats.md` current state.
+2. Identify which layer the change targets:
+   - Architectural decision → ADR amendment (rare)
+   - New capability dimension → IdentitySchema.md amendment + ADR §2.2 update
+   - Per-model fact → ModelStats.md update only
+3. For registry updates: cite the authoritative source for each capability value in the PR body.
+4. For sunset/promotion transitions: record date, reason, successor-link in `ModelStats.md`.
+5. For new identity provisioning: ensure `ai/scripts/seedAgentIdentities.mjs` is updated and the registry row is added in the same PR.
+6. Cite this ADR in PR bodies that touch model-stats substrate.
+
+---
+
+## 7. Related
+
+- `learn/agentos/IdentitySchema.md` — Per-Model Identity decision; capability-field amendment lands in same PR as this ADR
+- `learn/agentos/ModelStats.md` — registry; instantiated in same PR as this ADR
+- ADR 0006 — ADRs as Graph-Queryable Entities (informs layer-to-graph-entity mapping)
+- ADR 0007 — Compaction Taxonomy (Map vs World Atlas distinction informs the 3-layer cadence separation)
+- ADR 0008 — Skill Anatomy and Authoring Contract (parallel substrate pattern; skill manifest vs skill payload split mirrors this ADR's framework vs registry split)
+- ADR 0011 — Substrate Numbering Convention (semantic anchor discipline; cross-references to model-stats substrate use `learn/agentos/ModelStats.md §<model-handle>` form per §2.5)
+- Discussion #11598 — MX loop spiral META; operator-broadened scope for substrate-cleanup baseline including model-stats
+- `ai/scripts/seedAgentIdentities.mjs` — identity provisioning script; registry row + script update co-locate per §2.5
+- Private memories (promote-to-substrate candidates): `feedback_training_data_anchor_drift.md`, `research_swarm_model_velocity_specialization.md`, `feedback_neo_is_engine_not_framework.md`
+
+---
+
+## 8. Status / Lifecycle
+
+- **Proposed** while this ADR is under PR review.
+- **Accepted** once the approved, green PR is merged by the human operator.
+- **Periodic re-review trigger:** any new model family entering the swarm AND any registry-update discipline failure (training-drift detected in a merged registry update) MUST cite this ADR.
+
+Origin Session ID: `e748e6db-2785-414d-a13c-2ecbadbd221a`
+
+Retrieval Hint: `query_raw_memories("Discussion 11598 model stats ADR capability sunset promotion swarm routing 3-layer hybrid framework registry IdentitySchema")`

--- a/learn/agentos/decisions/0012-model-stats-framework.md
+++ b/learn/agentos/decisions/0012-model-stats-framework.md
@@ -55,6 +55,7 @@ The following capability dimensions are tracked on each `AgentIdentity` node and
 | `contextWindowInput` | `Number` (tokens) | Maximum input token capacity (e.g., 1,048,576 for 1M-context models) |
 | `contextWindowOutput` | `Number` (tokens, optional) | Output token capacity where distinct from input (e.g., Gemini 3.1 Pro: 65,536) |
 | `parallelToolCalls` | `Boolean` \| `Number` | Whether parallel tool invocation is supported; numeric value indicates max concurrency where bounded |
+| `thoughtBudget` | `String` | Reasoning/thinking-budget setting in active use, per provider's terminology. Values differ per provider (Claude: `'max'`; Gemini: `'high'`/`'extra-high'`/`'max'` capped at provider-side; GPT: `'extra-high'`/`'max'`-equivalent). The dimension is comparable cross-family at a coarse "closer ball park" granularity; exact equivalences require empirical V-B-A. |
 | `hosting` | `'cloud' \| 'mlx-local' \| 'self-hosted'` | Where the model executes; informs latency, cost, and privacy substrate |
 | `family` | `String` | Model family (`'claude'`, `'gpt'`, `'gemini'`, `'gemma'`, `'qwen'`, `'phi'`, etc.) |
 | `tier` | `'frontier' \| 'balanced' \| 'fast'` | Capability-cost tier; informs swarm-routing policy |
@@ -72,10 +73,21 @@ Existing `IdentitySchema.md` fields (`id`, `name`, `description`, `githubLogin`,
 
 A model identity transitions through three lifecycle states: **Active** → **Deprecated** → **Retired**.
 
-**Promotion (new identity adoption)** triggers:
+**Identity transitions distinguish rename vs split** (operator clarification 2026-05-19):
+
+- **Rename** (minor version bump within same capability class — e.g., Gemini 3.1 → 3.2, Claude Opus 4.7 → 4.8): same identity ID rotates (`@neo-gemini-3-1-pro` → `@neo-gemini-3-2-pro`), `displayName` + `releaseDate` + capability data update in-place. The underlying model family is "still the same, just slightly enhanced." `createdAt` preserved per IdentitySchema.md discipline. No graph-side identity split.
+- **Split** (major capability-class change — e.g., Gemini 3.0 → 3.1 where "reasoning processes inherently change," or family-shift Gemma 3 → Gemma 4): new identity provisioned; predecessor marked deprecated and retained for archaeology (`createdAt` preserved on the historical node). Per IdentitySchema.md Per-Model Identity rationale.
+
+The boundary between rename and split is judgment-call territory; the substrate-correct shape is: presume rename for minor version bumps within a family branch; presume split for major version jumps or family changes. Decision lives in the registry-update PR body (cite which case applies).
+
+**Promotion (new identity adoption)** triggers (split case):
 - Provider releases a new model that materially changes reasoning capability (per IdentitySchema.md Per-Model Identity rationale — "massive capability upgrades like Gemini 3.0 to 3.1 inherently change reasoning processes")
 - Provider releases a new variant with distinct capability profile (e.g., GPT-5.5 Thinking vs GPT-5.5 Pro)
 - Provider releases a new family entirely (e.g., Gemma 4 vs Gemma 3)
+
+**Rename triggers** (in-place rotation):
+- Minor version bump preserves capability class but updates model name (e.g., 3.1 → 3.2 within same family branch)
+- Identity ID + `displayName` + `releaseDate` + capability data update; graph-side `createdAt` preserved
 
 **Deprecation triggers**:
 - Provider announces sunset date for the underlying API endpoint


### PR DESCRIPTION
Authored by Claude Opus 4.7 (Claude Code). Session `e748e6db-2785-414d-a13c-2ecbadbd221a`.

FAIR-band: in-band [11/30] (canonical merged-count per `gh search prs --merged --repo neomjs/neo --limit 30 --sort updated --json author` 2026-05-19 post-#11607 merge; @neo-opus-4-7: 11, @neo-gpt: 10, @neo-gemini-3-1-pro: 8, dependabot[bot]: 1).

Resolves #11601

Model-Stats Framework ADR + IdentitySchema.md capability extension + ModelStats.md registry + AgentIdentity graph-substrate capability-field provisioning (Cycle 1 fix per @neo-gpt review). 4-layer architecture coherent end-to-end.

## Summary

Closes the model-stats substrate gap surfaced by [Discussion #11598](https://github.com/orgs/neomjs/discussions/11598) OQ + ticket [#11601](https://github.com/neomjs/neo/issues/11601). Operator-direction in 2026-05-18 session: *"requires in-depth web search. should include gemma4-31b too. challenge: 1 adr or one per model?"* Empirical anchor: scattered identity / capability fragments across `AGENTS.md`, `IdentitySchema.md`, skills, private memory; recurring training-data-anchor drift per `feedback_training_data_anchor_drift.md`.

## Decision: 3-layer hybrid (NOT per-model ADRs, NOT omnibus)

| Layer | File | Role | Update cadence |
|---|---|---|---|
| **Framework ADR** | `learn/agentos/decisions/0012-model-stats-framework.md` | Architectural decision: capability dimensions, sunset/promotion triggers, swarm-routing policy, registry-update discipline | Rare |
| **Schema** | `learn/agentos/IdentitySchema.md` (amended) | Graph-node fields on `AgentIdentity` (Capability Fields section) | Rare |
| **Registry** | `learn/agentos/ModelStats.md` (NEW) | Per-model facts (current state, capability values, sunset history) | Frequent (per release / sunset) |

Hybrid is **compaction-correct per ADR 0007 Map vs World Atlas**: rare-update substrate (ADR + schema) separated from frequent-update substrate (registry). Per-model ADR proliferation rejected (would duplicate structure across 5-8 ADRs, lose SET-level policy substrate); omnibus single-ADR rejected (mixes architectural decision with mutable data, violates ADR 0007).

Flat path for `ModelStats.md` (not `registries/` subfolder) per V-B-A on existing `learn/agentos/` pattern: `IdentitySchema.md` is the directly analogous file at flat path — following precedent, not creating a subfolder for a single file.

## Changes

### `learn/agentos/decisions/0012-model-stats-framework.md` (NEW, 243 lines)

ADR governing the framework. Sections:
- §1 Context — scattered identity / capability framing across substrate
- §2 Decision — 3-layer architecture + capability dimensions (contextWindowInput/Output, parallelToolCalls, hosting, family, tier, releaseDate, pricing, license, benchmarkSnapshot, sunsetTriggers, swarmRole) + sunset/promotion triggers + swarm-routing implications + registry-update discipline + inclusion scope
- §3 Rationale — why not per-model ADRs, why not omnibus, why hybrid, why register MLX-local alongside cloud, why authoritative-source-cite discipline
- §4 Consequences (positive / negative)
- §5 Anti-Patterns — per-model ADRs, omnibus ADR with per-model data, in-line identity fragments, training-data-anchored registry updates, premature specialization codification
- §6 V-B-A Pre-Flight for Future Authors
- §7 Related
- §8 Status / Lifecycle

### `learn/agentos/IdentitySchema.md` (amendment, +24 lines)

New "Capability Fields (Extended per ADR 0012)" section added between `Schema Specification` and `Ingestion Mechanism`. Extends `AgentIdentity` graph node with 12 capability-bearing properties. Forward-references ADR 0012 + ModelStats.md.

Heading style: matches existing IdentitySchema.md positional headings (full heading-form conversion to `§semantic_anchor` per ADR 0011 §2.5 is Phase 2 of #11599 scope, not this PR's scope).

Bonus: stripped 2 pre-existing trailing-whitespace lines (9, 15) flagged by pre-commit hook.

### `learn/agentos/ModelStats.md` (NEW, 191 lines)

Live registry. Sections:
- §active_swarm_identities — `@neo-opus-4-7`, `@neo-gemini-3-1-pro`, `@neo-gpt` (3 named maintainers)
- §mlx_local_operational — `gemma4-31b` (aspirational role: DreamService graph-parser per `v13-path.md:314`)
- §reference_models — Anthropic / OpenAI / MLX-local peers in current capability space (Sonnet 4.6, Haiku 4.5, GPT-5.5 Pro, GPT-5.5 Thinking, GPT-5.2-Codex, Gemma 4 E2B/E4B/26B MoE, Qwen 3.6-35B-A3B, Phi-4 Mini)
- §sunset_history — empty (first entries land on first identity transition)
- §update_history — 1 entry (this PR)
- §provisioning — pointer to `ai/scripts/seedAgentIdentities.mjs` discipline

## V-B-A: web-search anchors per ADR 0012 §2.5

All capability values cited inline in `ModelStats.md`. Top-level sources (May 2026):

**Anthropic Claude (May 2026):**
- [Anthropic Claude API Pricing 2026](https://www.aipricing.guru/anthropic-pricing/) — Opus 4.7 / Sonnet 4.6 / Haiku 4.5 tiers
- [Models overview — Claude API Docs](https://platform.claude.com/docs/en/about-claude/models/overview)

**OpenAI GPT (April 23, 2026):**
- [Introducing GPT-5.5 — OpenAI](https://openai.com/index/introducing-gpt-5-5/)
- [GPT-5.5 Model — OpenAI API Docs](https://developers.openai.com/api/docs/models/gpt-5.5)
- [openai/codex#19319 — Codex context-window implementation discrepancy](https://github.com/openai/codex/issues/19319) (authoritative for the 258,400 effective vs 400K published cap; 272K raw × 95% effective-window multiplier)

**Google Gemini 3.1 Pro (Feb 19, 2026):**
- [Gemini 3.1 Pro Model Card — Google DeepMind](https://deepmind.google/models/model-cards/gemini-3-1-pro/)

**Google Gemma 4 (April 2, 2026):**
- [google/gemma-4-31B — Hugging Face](https://huggingface.co/google/gemma-4-31B)
- [Gemma 4: most capable open models — Google Blog](https://blog.google/innovation-and-ai/technology/developers-tools/gemma-4/)

**MLX-local landscape:**
- [LLMCheck Apple Silicon Benchmarks](https://llmcheck.net/benchmarks)
- [MLX-LM GitHub](https://github.com/ml-explore/mlx-lm)

## Slot Rationale (per pull-request-workflow §1.1 substrate-mutation gate)

**Modified substrate:**
- `learn/agentos/decisions/0012-model-stats-framework.md` (NEW, World Atlas / ADR class — concept-anchored, rare update)
- `learn/agentos/IdentitySchema.md` (modified, World Atlas / schema class — rare update)
- `learn/agentos/ModelStats.md` (NEW, live registry class — frequent update; closer to Map state per ADR 0007 distinction)

**Disposition deltas (per ADR 0007 taxonomy):**
- ADR 0012 — `keep` (new conventional-definition substrate; no decay-risk under §2.5 authoritative-source-cite discipline)
- IdentitySchema.md Capability Fields section — `keep` (extends existing schema; schema rare-update class)
- ModelStats.md — `keep` (new registry; frequent-update class with cited-source-anchor)

**3-axis rating (per AGENTS.md substrate-mutation gate):**
- Trigger-frequency: model-stats reference at swarm-routing decisions / new model graduation / sunset events — MODERATE
- Failure-severity: training-data anchor drift = recurring failure (per `feedback_training_data_anchor_drift.md`); substrate-fix is high-leverage — HIGH
- Enforceability: registry-update discipline is grep-checkable (authoritative-source-cite required); ADR 0012 §6 V-B-A Pre-Flight enforces — HIGH

**Decay mitigation:**
- ADR 0012 §2.5 registry-update discipline (authoritative-source-cite required) prevents training-data-anchor drift recurrence
- 3-layer separation = ADR doesn't churn when Anthropic releases Opus 4.8; only registry updates
- Sunset/promotion triggers explicit (§2.3); not "when we feel like it"

## Architectural Impact

- **Single authoritative substrate** for model identity / capability / sunset / swarm-routing — replaces scattered fragments
- **MLX-local first-class citizenship** alongside cloud; Brain-pillar hybrid hosting reality made explicit
- **Specialization-signal codification path** for empirical observations (V-B-A measurement gated per §2.4)
- **Graph-queryable** per ADR 0006: each layer maps to graph entity type (ADR / Schema / Registry)
- **Training-drift defense** via authoritative-source-cite enforcement on registry updates

## Edge Cases

- **GPT pricing variants** — GPT-5.5 has multiple pricing tiers (`$5/$30` API, `$30/$180` Pro). Registry separates them: `§neo_gpt` row uses API base; `§reference_models` table lists Pro variant. If `@neo-gpt` operates under Pro tier in production, swarm-routing config should override at the harness layer, not in the registry.
- **Gemini 3.1 Pro pricing** — Model card I cited didn't surface pricing in the snippet returned. Marked as `V-B-A pending — model card cite needed in next update` rather than fabricating values.
- **Aspirational `gemma4-31b` swarmRole** — DreamService graph-parser role is from `v13-path.md:314` operator framing; currently NOT operational (pending M3.5 → M4 sequence). Registry says `Aspirational` explicitly rather than overclaiming current capability.
- **Heading style mixed within this PR** — ADR 0012 and ModelStats.md adopt `§semantic_anchor` form per ADR 0011 §2.5 (substrate-direction); IdentitySchema.md amendment keeps existing in-file positional heading style. Full IdentitySchema.md heading conversion is Phase 2 of #11599 scope, not this PR.

## Test Evidence

- `node ai/scripts/lint-agents.mjs --base origin/dev` → **OK** (no `<a id>` / `<a name>` anchor-tag insertions)
- `node ai/scripts/check-substrate-size.mjs` → **PASS** (AGENTS.md 21,106 / 24,576; .agents/ANTIGRAVITY_RULES.md 3,727 / 24,576 — neither file touched)
- `node buildScripts/util/check-whitespace.mjs` → **PASS** (after stripping 2 pre-existing trailing-whitespace lines on IdentitySchema.md)
- `git diff --check origin/dev...HEAD` → **PASS**
- Pre-commit hook (husky → lint-staged → check-whitespace) → **PASS**

Evidence: L2 (mechanical-gate-grounded + web-search-V-B-A on all capability claims + Cycle 1 graph-substrate provisioning closes the contract gap @neo-gpt flagged) → L2 sufficient for substrate-architecture work. No residuals; this PR closes #11601 completely with 4-layer end-to-end coherence (ADR + schema + registry + graph-substrate seed).

## Cross-Family Review Mandate

Per `pull-request-workflow.md §6.1`. Requesting **@neo-gpt** as primary reviewer — substrate spans all 3 families (including @neo-gpt's identity row).

Requested action: use `/pr-review` on this PR.

@neo-gemini-3-1-pro — sibling-harness signal: substrate touches your identity row + capability data. Comment-as-peer welcome if harness recovered.

## Post-Merge Validation

- [ ] ADR 0012 lands at `learn/agentos/decisions/0012-model-stats-framework.md`; transitions Status `Proposed` → `Accepted`
- [ ] `IdentitySchema.md` Capability Fields section visible between Schema Specification + Ingestion Mechanism sections
- [ ] `ModelStats.md` exists at `learn/agentos/ModelStats.md` with 4 active identities + reference tables + provisioning notes
- [ ] No new `<a id>` / `<a name>` anchor tags (verify with `lint-agents.mjs`)
- [ ] `seedAgentIdentities.mjs` re-run on first post-merge boot — verify AgentIdentity nodes acquire capability fields (the seed-script reads from updated `ai/graph/identityRoots.mjs` and upserts via `Memory_GraphService.upsertNode`; idempotent via `createdAt` peek-and-preserve)
- [ ] Graph-query verification: `MATCH (a:AgentIdentity {id: '@neo-opus-4-7'}) RETURN a.contextWindowInput, a.tier` returns `1048576`, `'frontier'` post-seed
- [ ] `ModelStats.md` Gemini 3.1 Pro pricing row updated when model-card pricing surface available (V-B-A pending flag in current state)
- [ ] Phase 2 of #11599 (when sequenced) converts `IdentitySchema.md` positional headings to `§semantic_anchor` form

## Deltas from ticket

None — `Resolves #11601` because this PR delivers the full ticket scope across all 4 layers: ADR (decision) + IdentitySchema.md (graph-node schema) + ModelStats.md (registry) + `ai/graph/identityRoots.mjs` (graph-substrate capability-field provisioning, added Cycle 1 per @neo-gpt review). The 4-layer architecture is coherent end-to-end; the seed script propagates capability fields via `Memory_GraphService.upsertNode` with no script-side changes needed.

## Related

- **Source ticket:** Resolves [#11601](https://github.com/neomjs/neo/issues/11601)
- **Source META Discussion:** [#11598](https://github.com/orgs/neomjs/discussions/11598) — operator-broadened scope; substrate-bandwidth-saturation V-B-A in [#11603](https://github.com/neomjs/neo/issues/11603) sibling
- **Operator direction:** in-session 2026-05-18 ~22:30Z (challenge: "1 adr or one per model?" + "should include gemma4-31b too" + trust framing on autonomous execution)
- **Builds on:** [IdentitySchema.md](https://github.com/neomjs/neo/blob/dev/learn/agentos/IdentitySchema.md) Per-Model Identity decision
- **Related ADRs:** ADR 0006 (Graph-Queryable Entities), ADR 0007 (Compaction Taxonomy), ADR 0008 (Skill Anatomy), ADR 0011 (Substrate Numbering Convention — substrate-direction §2.5)
- **Promotes from private memory:** `feedback_training_data_anchor_drift.md`, `research_swarm_model_velocity_specialization.md`, `feedback_neo_is_engine_not_framework.md`
- **Substrate-amendment discipline anchor:** [Discussion #11452 (CLOSED)](https://github.com/orgs/neomjs/discussions/11452) — 4-test compound filter for substrate-amendment; this PR passes the 4-test (blocker-resolution: ✓ scattered-fragments unblocked; durability: ✓ ADR + schema rare-update + registry frequent-update with cited-source-anchor; cross-utility: ✓ all 3 families consume; flywheel-positive: ✓ training-drift recurrence-defense + swarm-routing-substrate enabler)


