### PR TITLE
fix(github-workflow/sync): persist milestone in issues metadata to prevent ARCHIVE ANOMALY re-bucketing (#11594)

### DIFF
--- a/ai/services/github-workflow/sync/IssueSyncer.mjs
+++ b/ai/services/github-workflow/sync/IssueSyncer.mjs
@@ -368,6 +368,16 @@ class IssueSyncer extends Base {
                     version = issue.milestone.title.startsWith(issueSyncConfig.versionDirectoryPrefix)
                         ? issue.milestone.title
                         : issueSyncConfig.versionDirectoryPrefix + issue.milestone.title;
+                } else if (issue.oldVersion && semver.valid(semver.clean(issue.oldVersion)) !== null) {
+                    // Use cached path-derived version when present and valid semver. Unchanged closed
+                    // issues seeded from existing serialized metadata may lack milestone data (legacy
+                    // entries pre-#11594 metadata-persistence fix) but still have a known on-disk
+                    // bucket via oldVersion (path-derived at ~L310-317). Skipping closedAt timestamp
+                    // inference here prevents false-positive bucket-shift WARN on unchanged archived
+                    // issues — the path IS the canonical bucket when no milestone data exists.
+                    // Per #11594 AC3 / AC4(b): oldVersion precedence for unchanged closed issues.
+                    // (#11594 Cycle 2 fix per @neo-gpt PR #11607 Cycle 2 review.)
+                    version = issue.oldVersion;
                 } else if (issue.closedAt) {
                     const closed = new Date(issue.closedAt);
                     const release = (ReleaseNotesSyncer.sortedReleases || []).find(r => new Date(r.publishedAt) > closed);

--- a/ai/services/github-workflow/sync/MetadataManager.mjs
+++ b/ai/services/github-workflow/sync/MetadataManager.mjs
@@ -82,6 +82,11 @@ class MetadataManager extends Base {
                 closedAt     : value.closedAt,
                 updatedAt    : value.updatedAt,
                 contentHash  : value.contentHash,
+                // milestone persisted as string-title (symmetric with IssueSyncer hydrate at L324:
+                // `issue.milestone ? { title: issue.milestone } : null`). Without this, planBuckets
+                // falls through to closedAt-based release-date inference and re-classifies unchanged
+                // closed issues every sync, emitting persistent ARCHIVE ANOMALY WARN noise (#11594).
+                milestone    : value.milestone?.title || null,
                 // commentsTotal is the count of ISSUE_COMMENT nodes derived from the exhausted
                 // timelineItems connection (#10110). Single source of truth: the metadata value
                 // is structurally guaranteed to match the rendered markdown because both are

--- a/ai/services/github-workflow/sync/MetadataManager.mjs
+++ b/ai/services/github-workflow/sync/MetadataManager.mjs
@@ -86,7 +86,17 @@ class MetadataManager extends Base {
                 // `issue.milestone ? { title: issue.milestone } : null`). Without this, planBuckets
                 // falls through to closedAt-based release-date inference and re-classifies unchanged
                 // closed issues every sync, emitting persistent ARCHIVE ANOMALY WARN noise (#11594).
-                milestone    : value.milestone?.title || null,
+                //
+                // Shape handling: `IssueSyncer.pullFromGitHub` seeds `newMetadata.issues` from existing
+                // serialized metadata (already string form), THEN overwrites fetched issues with the
+                // object form (`{title: '...'}`). The prune must preserve BOTH paths: string entries
+                // (unchanged cached issues) pass through verbatim; object entries (freshly fetched)
+                // get `.title` extracted. A naive `value.milestone?.title || null` would prune cached
+                // strings back to `null` on every save (regression of regression — caught by @neo-gpt
+                // review PR #11607 Cycle 1).
+                milestone    : typeof value.milestone === 'string'
+                    ? value.milestone
+                    : (value.milestone?.title || null),
                 // commentsTotal is the count of ISSUE_COMMENT nodes derived from the exhausted
                 // timelineItems connection (#10110). Single source of truth: the metadata value
                 // is structurally guaranteed to match the rendered markdown because both are

--- a/test/playwright/unit/ai/services/github-workflow/IssueSyncer.spec.mjs
+++ b/test/playwright/unit/ai/services/github-workflow/IssueSyncer.spec.mjs
@@ -265,11 +265,11 @@ test.describe('Neo.ai.services.github-workflow.sync.IssueSyncer', () => {
             hasNextPage  : false,
             endCursor    : null
         });
-        
+
         mockIssue.state = 'CLOSED';
         mockIssue.closedAt = '2026-05-13T10:00:00Z'; // new shifted date
         mockIssue.milestone = { title: 'v1.0.0' }; // new shifted milestone
-        
+
         GraphqlService.query = async (query) => {
             if (query.includes('FetchIssuesForSync')) {
                 return {
@@ -296,7 +296,7 @@ test.describe('Neo.ai.services.github-workflow.sync.IssueSyncer', () => {
             `issue-${mockIssue.number}.md`
         );
         const originalOldPath = path.relative(aiConfig.projectRoot, originalOldAbsolutePath);
-        
+
         const metadata = {
             issues: {
                 [mockIssue.number]: {
@@ -311,7 +311,7 @@ test.describe('Neo.ai.services.github-workflow.sync.IssueSyncer', () => {
                 }
             }
         };
-        
+
         // create the mock file to simulate it already exists in the archive
         const absOldPath = path.resolve(aiConfig.projectRoot, originalOldPath);
         await fs.ensureDir(path.dirname(absOldPath));
@@ -319,13 +319,13 @@ test.describe('Neo.ai.services.github-workflow.sync.IssueSyncer', () => {
 
         // Execute pullFromGitHub
         const { stats } = await IssueSyncer.pullFromGitHub(metadata);
-        
+
         // Assert it was pulled
         expect(stats.pulled.issues).toContain(mockIssue.number);
-        
+
         // Assert target path in metadata remained the old path despite closedAt/milestone shifting
         expect(metadata.issues[mockIssue.number].path).toBe(originalOldPath);
-        
+
         // Cleanup
         await fs.unlink(absOldPath).catch(() => {});
     });
@@ -662,6 +662,104 @@ test.describe('Neo.ai.services.github-workflow.sync.IssueSyncer', () => {
         expect(issueBWarns[0]).toContain("'v11.12.0'");
         expect(issueBWarns[0]).toContain("'v11.13.0'");
         expect(issueBDebugs).toHaveLength(0);
+    });
+
+    test('planBuckets oldVersion precedence: unchanged closed issue with no milestone skips closedAt timestamp fallback (#11594 AC4(b))', async () => {
+        // Regression #11594 AC4(b) per @neo-gpt PR #11607 Cycle 2 review:
+        // Legacy archived issues seeded from existing serialized metadata may lack milestone data
+        // (pre-#11594-persistence-fix entries). When such an issue is NOT in the delta fetch (it
+        // hasn't been modified since lastSync), `#planBuckets` receives `milestone: null/undefined`
+        // and previously fell through to closedAt-based timestamp inference, which could re-emit
+        // ARCHIVE ANOMALY WARN for issues already at their canonical on-disk bucket.
+        //
+        // Cycle 2 fix (3262eb126 in this PR) added oldVersion-precedence between milestone-title
+        // and closedAt-fallback. This test exercises that branch: unchanged archived issue with
+        // valid-semver oldVersion + no milestone → version = oldVersion → no WARN, no closedAt
+        // heuristic invocation.
+        //
+        // Empirical anchor: #7910 (CLOSED 2025-11-29, milestone v11.12.0) was re-bucketed to
+        // v11.13.0 every sync because the persistence-shape bug meant milestone data was missing
+        // post-persist (Cycle 1 fix), AND planBuckets had no oldVersion precedence even when the
+        // cached path WAS the canonical bucket (this Cycle 2 fix).
+        const issueUnchangedAtCanonicalBucket = buildMockIssue({
+            number       : 7910,
+            title        : 'Mock unchanged-archived issue (#11594 AC4b test)',
+            timelineFirst: [],
+            hasNextPage  : false,
+            endCursor    : null
+        });
+        issueUnchangedAtCanonicalBucket.state    = 'CLOSED';
+        issueUnchangedAtCanonicalBucket.closedAt = '2025-11-29T11:41:17Z';
+        issueUnchangedAtCanonicalBucket.milestone = null;
+
+        // Delta query returns EMPTY — simulates the unchanged-since-lastSync case.
+        // The issue exists ONLY in pre-seeded metadata.
+        GraphqlService.query = async (query) => {
+            if (query.includes('FetchIssuesForSync')) {
+                return {
+                    rateLimit : {cost: 1, remaining: 4999, resetAt: '2026-05-19T01:00:00Z'},
+                    repository: {
+                        issues: {
+                            pageInfo: {hasNextPage: false, endCursor: null},
+                            nodes   : []
+                        }
+                    }
+                };
+            }
+            if (query.includes('FetchSingleIssue')) {
+                return {repository: {issue: structuredClone(issueUnchangedAtCanonicalBucket)}};
+            }
+            throw new Error(`Unexpected GraphQL query in test: ${query.slice(0, 80)}`);
+        };
+
+        // Pre-seeded cached path at the canonical v11.12.0 bucket.
+        const issueAbsolutePath = path.join(
+            issueSyncConfig.archiveRoot, 'issues',
+            'v11.12.0', 'chunk-7900', `issue-${issueUnchangedAtCanonicalBucket.number}.md`
+        );
+        const issueRelPath = path.relative(aiConfig.projectRoot, issueAbsolutePath);
+
+        const metadata = {
+            issues: {
+                [issueUnchangedAtCanonicalBucket.number]: {
+                    state       : 'CLOSED',
+                    path        : issueRelPath,
+                    updatedAt   : '2025-11-29T11:44:14Z',
+                    closedAt    : '2025-11-29T11:41:17Z',
+                    milestone   : null, // KEY: legacy entry with no milestone data
+                    title       : issueUnchangedAtCanonicalBucket.title,
+                    contentHash : 'hashUnchanged',
+                    commentsTotal: 0
+                }
+            }
+        };
+
+        await fs.ensureDir(path.dirname(issueAbsolutePath));
+        await fs.writeFile(issueAbsolutePath, 'mock content unchanged', 'utf8');
+
+        const warnCalls = [];
+        const debugCalls = [];
+        const originalWarn = logger.warn;
+        const originalDebug = logger.debug;
+        logger.warn  = (...args) => { warnCalls.push(args[0]); };
+        logger.debug = (...args) => { debugCalls.push(args[0]); };
+
+        try {
+            await IssueSyncer.pullFromGitHub(metadata);
+        } finally {
+            logger.warn  = originalWarn;
+            logger.debug = originalDebug;
+            await fs.unlink(issueAbsolutePath).catch(() => {});
+        }
+
+        // AC4(b): NO ARCHIVE ANOMALY WARN for unchanged issue at canonical bucket.
+        // oldVersion precedence kicks in → version = 'v11.12.0' === oldVersion → no shift detected → no WARN.
+        const archiveAnomalyWarns = warnCalls.filter(s =>
+            typeof s === 'string' &&
+            s.includes('[ARCHIVE ANOMALY]') &&
+            s.includes(`#${issueUnchangedAtCanonicalBucket.number}`)
+        );
+        expect(archiveAnomalyWarns).toHaveLength(0);
     });
 });
 

--- a/test/playwright/unit/ai/services/github-workflow/MetadataManager.spec.mjs
+++ b/test/playwright/unit/ai/services/github-workflow/MetadataManager.spec.mjs
@@ -57,6 +57,18 @@ test.describe('Neo.ai.services.github-workflow.sync.MetadataManager', () => {
                     contentHash: 'hash1',
                     commentsTotal: 5,
                     extraFieldShouldBePruned: true
+                },
+                // Regression: closed issue with milestone object form (post-fetch in-memory state).
+                // Without milestone persistence, planBuckets falls through to closedAt-based release-date
+                // inference and re-classifies unchanged closed issues every sync (#11594).
+                '7910': {
+                    state: 'CLOSED',
+                    path: 'issues/v11.12.0/issue-7910.md',
+                    closedAt: '2025-11-29T11:41:17Z',
+                    updatedAt: '2025-11-29T11:44:14Z',
+                    contentHash: 'hash7910',
+                    commentsTotal: 1,
+                    milestone: {title: '11.12.0'}
                 }
             },
             discussions: {
@@ -102,6 +114,15 @@ test.describe('Neo.ai.services.github-workflow.sync.MetadataManager', () => {
         // Issues
         expect(loaded.issues['123'].extraFieldShouldBePruned).toBeUndefined();
         expect(loaded.issues['123'].contentHash).toBe('hash1');
+
+        // Open issue without milestone persists as null (defensive)
+        expect(loaded.issues['123'].milestone).toBeNull();
+
+        // Regression #11594: closed issue with milestone object form persists as string title only.
+        // Symmetric with IssueSyncer hydrate-from-disk path which wraps string back to {title: ...} object.
+        expect(loaded.issues['7910'].milestone).toBe('11.12.0');
+        expect(loaded.issues['7910'].state).toBe('CLOSED');
+        expect(loaded.issues['7910'].path).toBe('issues/v11.12.0/issue-7910.md');
 
         // Discussions
         expect(loaded.discussions['456'].extraFieldShouldBePruned).toBeUndefined();

--- a/test/playwright/unit/ai/services/github-workflow/MetadataManager.spec.mjs
+++ b/test/playwright/unit/ai/services/github-workflow/MetadataManager.spec.mjs
@@ -58,9 +58,8 @@ test.describe('Neo.ai.services.github-workflow.sync.MetadataManager', () => {
                     commentsTotal: 5,
                     extraFieldShouldBePruned: true
                 },
-                // Regression: closed issue with milestone object form (post-fetch in-memory state).
-                // Without milestone persistence, planBuckets falls through to closedAt-based release-date
-                // inference and re-classifies unchanged closed issues every sync (#11594).
+                // Regression #11594 — object form (freshly fetched, post-API hydrate):
+                // closed issue with milestone object persists as string title.
                 '7910': {
                     state: 'CLOSED',
                     path: 'issues/v11.12.0/issue-7910.md',
@@ -69,6 +68,21 @@ test.describe('Neo.ai.services.github-workflow.sync.MetadataManager', () => {
                     contentHash: 'hash7910',
                     commentsTotal: 1,
                     milestone: {title: '11.12.0'}
+                },
+                // Regression #11594 — string form (cached, carried forward from previous save):
+                // `IssueSyncer.pullFromGitHub` seeds newMetadata.issues from existing serialized
+                // metadata, then only overwrites fetched issues. Unchanged cached entries arrive at
+                // save() with milestone already as a string. Naive `value.milestone?.title || null`
+                // would prune to `null` here (regression of regression — caught by @neo-gpt PR #11607
+                // Cycle 1). String form MUST pass through verbatim.
+                '7911': {
+                    state: 'CLOSED',
+                    path: 'issues/v11.13.0/issue-7911.md',
+                    closedAt: '2025-11-29T12:00:00Z',
+                    updatedAt: '2025-11-29T12:00:00Z',
+                    contentHash: 'hash7911',
+                    commentsTotal: 0,
+                    milestone: '11.13.0'
                 }
             },
             discussions: {
@@ -123,6 +137,12 @@ test.describe('Neo.ai.services.github-workflow.sync.MetadataManager', () => {
         expect(loaded.issues['7910'].milestone).toBe('11.12.0');
         expect(loaded.issues['7910'].state).toBe('CLOSED');
         expect(loaded.issues['7910'].path).toBe('issues/v11.12.0/issue-7910.md');
+
+        // Regression #11594 (PR #11607 Cycle 1): cached string-form milestone passes through verbatim.
+        // Unchanged issues seeded from existing serialized metadata arrive as strings, not objects.
+        // The prune MUST handle both shapes.
+        expect(loaded.issues['7911'].milestone).toBe('11.13.0');
+        expect(loaded.issues['7911'].state).toBe('CLOSED');
 
         // Discussions
         expect(loaded.discussions['456'].extraFieldShouldBePruned).toBeUndefined();


### PR DESCRIPTION
Authored by Claude Opus 4.7 (Claude Code). Session `e748e6db-2785-414d-a13c-2ecbadbd221a`.

FAIR-band: in-band [9/30] (canonical merged-count per `gh search prs --merged --repo neomjs/neo --limit 30 --sort updated --json author` 2026-05-18 — @neo-opus-4-7: 9, @neo-gpt: 10, @neo-gemini-3-1-pro: 10, dependabot[bot]: 1; pending PRs #11600 / #11606 / #11607 not in merged count per @neo-gpt Cycle 1 audit).

Resolves #11594.

## Summary

`IssueSyncer` re-classifies unchanged closed issues every sync because `MetadataManager.save()` issues prune block omits the `milestone` field. On hydrate, `planBuckets` falls through to `closedAt`-based release-date inference and computes wrong bucket. Empirical anchor: #7910 (CLOSED 2025-11-29T11:41:17Z, milestone `11.12.0`) gets re-bucketed to v11.13.0 every sync run, emitting persistent `[ARCHIVE ANOMALY]` WARN.

## Root cause

`ai/services/github-workflow/sync/MetadataManager.mjs:77-91` — issues prune block persists `state / path / closedAt / updatedAt / contentHash / commentsTotal` but NOT `milestone`. Symmetric pulls block (`ai/services/github-workflow/sync/MetadataManager.mjs:103-114`) DOES persist `milestone`. Asymmetry caused the regression.

On next sync hydrate at `IssueSyncer.mjs:324`:

```js
milestone: issue.milestone ? { title: issue.milestone } : null,
```

When metadata `issue.milestone` is undefined → object becomes `null` → `planBuckets` L367 `issue.milestone?.title` falls through to L371-376 `closedAt`-based release inference.

`ReleaseNotesSyncer.sortedReleases.find(r => new Date(r.publishedAt) > closed)` finds v11.13.0 (published 2025-11-29T12:34:29Z, AFTER #7910's closedAt 11:41:17Z) instead of correct v11.12.0 (published 11:32:31Z, BEFORE — should not match the `>` predicate). The release-body of v11.12.0 explicitly lists #7910 fixed.

## Fix

`ai/services/github-workflow/sync/MetadataManager.mjs:90-91` (1-line addition):

```js
milestone    : value.milestone?.title || null,
```

`.title` extraction is symmetric with the hydrate path (line 324 wraps the string title back to `{title: '...'}` object form). Without `.title`, the in-memory object form `{title: '11.12.0'}` would persist as JSON-stringified object, breaking the symmetric hydrate.

## Regression test

Added to `test/playwright/unit/ai/services/github-workflow/MetadataManager.spec.mjs` existing test: closed issue #7910 with milestone object form persists as string title `'11.12.0'`; open issue without milestone persists as `null` (defensive).

`npm run test-unit -- test/playwright/unit/ai/services/github-workflow/MetadataManager.spec.mjs` → **1 passed (565ms)**.

## Latent observation (out of scope)

Pulls block (`MetadataManager.mjs:103-114`) has the same shape mismatch:

```js
milestone: value.milestone,   // Persists whatever shape, potentially object
```

In real `PullRequestSyncer` flow (`PullRequestSyncer.mjs:103`), `pr.milestone` is set from GitHub GraphQL API which returns the OBJECT form `{title: '...'}`. So pulls metadata likely persists the wrong shape too. Current test passes because test input is STRING.

Pre-existing latent bug. Out of scope for this PR. `[TOOLING_GAP]` flag for follow-up if pulls metadata ever gains a milestone in the wild (per V-B-A this turn, no current pull entry has milestone — bug is unfired).

## Slot Rationale (per pull-request-workflow §1.1 substrate-mutation gate)

**Modified substrate:** `ai/services/github-workflow/sync/MetadataManager.mjs` (live `.sync-metadata.json` shape; load-bearing for sync correctness).

**Disposition deltas (per ADR 0007 taxonomy):**
- MetadataManager.mjs issues block — `rewrite` (1-line addition with explanatory comment)
- MetadataManager.spec.mjs — `keep` (extend existing test with regression assertion)

**3-axis rating:**
- Trigger-frequency: EVERY `ai:sync-github-workflow` run hits this code path — HIGH
- Failure-severity: persistent false-positive WARN noise + risk of dry-run actually moving wrongly-bucketed issues if the false signal weren't filtered downstream — MODERATE
- Enforceability: regression test guards against silent-removal — HIGH

**Decay mitigation:** explanatory comment in MetadataManager.mjs cites #11594 + IssueSyncer hydrate path symmetry; future authors editing this block can V-B-A the symmetry quickly.

## Architectural Impact

Restores symmetric metadata-persistence between issues and pulls blocks. No API change. No new dependency. No new tooling. Pure substrate-correctness fix at the GH-sync baseline layer.

Aligns with **baseline-first** operational direction (per @neo-gpt operator-state DM 2026-05-18 ~22:55Z + ~23:03Z [watchdog-baseline] DM). GH-sync stability is one of the named baseline lanes.

## Edge Cases

- **Open issues with milestone** (e.g., active issue tagged for upcoming release): persists `milestone.title` correctly; open state never enters `planBuckets` archive flow (early-exit at L380 `if (issue.state !== 'CLOSED' || !version)`).
- **Issues with null/undefined milestone** (closed but no milestone tag): persists as `null`; `planBuckets` falls through to closedAt-based inference per existing logic. Behavior unchanged for this case.
- **Existing on-disk metadata** (pre-#11594 entries without milestone field): backward-compatible. On next sync hydrate, `issue.milestone` is undefined for legacy entries → wraps to `null` → subsequent re-fetch from GitHub repopulates the milestone object. After first re-fetch, persisted shape is correct.
- **Defragmentation note**: this fix does NOT proactively repopulate milestone for ALL existing on-disk metadata entries. The next full sync naturally repopulates by fetching from GitHub. Empirical: #7910 is currently emitting WARN once per sync — after merge, ~one more WARN cycle then quiet.

## Test Evidence

- `node ai/scripts/lint-agents.mjs --base origin/dev` → **OK**
- `node ai/scripts/check-substrate-size.mjs` → **PASS** (no substrate file changes)
- `node buildScripts/util/check-whitespace.mjs` → **PASS**
- `git diff --check origin/dev...HEAD` → **PASS**
- `npm run test-unit -- test/playwright/unit/ai/services/github-workflow/MetadataManager.spec.mjs` → **1 passed (565ms)**
- Pre-commit hook (husky → lint-staged → check-whitespace) → **PASS**

Evidence: L2 (mechanical-gate-grounded + unit-test regression for the specific failure mode) → L2 required for sync-layer fix. No residuals.

## Cross-Family Review Mandate

Per `pull-request-workflow.md §6.1`. Requesting **@neo-gpt** as primary reviewer — GPT V-B-A'd this root cause prior; review-pickup should be fast.

Requested action: use `/pr-review` on this PR.

## Post-Merge Validation

- [ ] Next `ai:sync-github-workflow` run on `dev` — issue #7910 ARCHIVE ANOMALY WARN no longer emitted
- [ ] `.sync-metadata.json` for #7910 gains `"milestone": "11.12.0"` after one sync cycle
- [ ] Symmetric improvement: any other closed-with-milestone issues that have been getting falsely re-bucketed similarly stabilize after their next-sync milestone repopulation
- [ ] Latent pulls-block fix follow-up: if/when pulls metadata gains milestone, file follow-up PR with `value.milestone?.title || null` symmetric extraction

## Deltas from ticket

None — `Resolves #11594` because this PR delivers the ticket's full scope (root-cause fix + regression test + V-B-A-grounded explanatory comment in code). The latent pulls-block shape-mismatch observation is a SEPARATE pre-existing bug, out of #11594 scope, flagged in PR body + tracked as follow-up if it ever fires in the wild.

## Related

- **Source ticket:** Resolves [#11594](https://github.com/neomjs/neo/issues/11594)
- **Operator-direction:** in-session 2026-05-18 ~21:05Z (*"VBA => reducing noise (for all real synced items) !== regression bug where an item got moved, that was not changed"*) — corrected my Cycle-1 pattern-match against PR #11486
- **Related PR:** [#11486](https://github.com/neomjs/neo/pull/11486) (reduced WARN noise for genuinely-changed items; this PR is the complement for genuinely-UNCHANGED items)
- **Co-V-B-A:** @neo-gpt previously V-B-A'd this root cause + identified the 1-line fix shape (per session-summary)
- **Baseline-class lane:** per @neo-gpt [operator-state] + [watchdog-baseline] DMs 2026-05-18 — baseline-first GH-sync stability

