### PR TITLE
feat(agentos): add review-intake lane gate (#11609)

### DIFF
--- a/.agents/skills/post-review-pickup/SKILL.md
+++ b/.agents/skills/post-review-pickup/SKILL.md
@@ -1,8 +1,11 @@
 ---
 name: post-review-pickup
-description: "Authoritative protocol for immediate next-phase pickup after PR review or author response handoff. Prevents silent idle after review cycles by requiring the next lane or an explicit halt-state. Triggers: Use immediately after posting a PR review, chaining a formal GitHub review state, or posting an author review-response handoff with a commentId."
+description: "Authoritative protocol for next-lane pickup after PR review / author response handoff AND for pre-review intake lane discovery from fresh boot or watchdog wake when no author lane is active. Prevents silent idle and reviewer-only cycles by requiring the next lane, a review-first rationale, or an explicit halt-state. Triggers: Use immediately after posting a PR review, chaining a formal GitHub review state, posting an author review-response handoff with a commentId, OR before accepting the first PR review/re-review request in a fresh session/wake when no current author or implementation lane is claimed."
 ---
 
 # Post-Review Pickup Skill
 
-If you just completed a PR review or review-response handoff, you MUST immediately use the `view_file` tool to read and strictly adhere to `.agents/skills/post-review-pickup/references/post-review-pickup-workflow.md` before ending the turn.
+If you just completed a PR review / review-response handoff, OR if you are
+about to accept the first review request in a fresh session or watchdog wake
+while no author lane is active, you MUST immediately use the `view_file` tool
+to read and strictly adhere to `.agents/skills/post-review-pickup/references/post-review-pickup-workflow.md` before proceeding or ending the turn.

--- a/.agents/skills/post-review-pickup/references/post-review-pickup-workflow.md
+++ b/.agents/skills/post-review-pickup/references/post-review-pickup-workflow.md
@@ -13,9 +13,22 @@ Use this skill immediately after one of these lifecycle handoffs:
   when required, and sends the A2A commentId handoff.
 - Author posts a review-response comment with fixup commits and sends the
   author-side A2A commentId handoff.
+- Fresh session, session recovery, or watchdog wake presents a PR review /
+  re-review request while the agent has no active author or implementation lane.
 
-The goal is to prevent silent idle after a handoff. The handled PR is now owned
-by the next actor in that cycle; unrelated ready lanes can proceed in parallel.
+The goal is to prevent silent idle after a handoff and to prevent pre-review
+reviewer-only cycles. The handled PR is now owned by the next actor in that
+cycle; unrelated ready lanes can proceed in parallel.
+
+## 1.5 Pre-Review Intake Gate
+
+<!-- trigger: fresh-session/watchdog review intake with no active author lane → read ./pre-review-intake-lane-gate.md before loading /pr-review -->
+
+Primary codification of the pre-review intake lane-discovery gate:
+[`./pre-review-intake-lane-gate.md`](./pre-review-intake-lane-gate.md).
+It defines when role payloads must be read before lane choice, how to survey
+positive-ROI author lanes, and when a review-first rationale is legitimate.
+This is a trigger-ordering guard, not a quota or blame mechanism.
 
 ## 2. Reviewer Pickup Matrix
 

--- a/.agents/skills/post-review-pickup/references/pre-review-intake-lane-gate.md
+++ b/.agents/skills/post-review-pickup/references/pre-review-intake-lane-gate.md
@@ -1,0 +1,69 @@
+# Pre-Review Intake Lane Gate
+
+This payload governs the moment before an agent accepts its first PR review /
+re-review request after fresh boot, session recovery, or watchdog wake while no
+author or implementation lane is active.
+
+The goal is lane-order correctness: pick a positive-ROI author lane first when
+that is the right move, then review peer PRs after the PR is opened or while CI
+is pending. This is not a quota, blame, or forced-assignment mechanism.
+
+## Trigger
+
+Use this gate when all are true:
+
+1. A PR review or re-review request is available.
+2. The current session has no active author lane, implementation branch, or
+   self-assigned ticket in progress.
+3. No human-directed urgent review instruction overrides lane discovery.
+
+If the agent already has an open PR waiting on CI, use
+`pull-request/references/ci-green-review-routing.md` instead: peer review during
+CI wait is healthy as long as the author re-checks the current PR head after.
+
+## Protocol
+
+1. **Mailbox + authority check:** read unread A2A, then verify the live PR /
+   issue state before asserting urgency or ownership.
+2. **Role-context check:** if `/lead-role` or `/peer-role` is active or
+   explicitly invoked, read that role payload before choosing the lane. Do not
+   synthesize role state when no real trigger exists.
+3. **Lane discovery:** inspect assigned-to-me, fresh operator focus, and open
+   unassigned positive-ROI tickets. Prefer an author lane when one is
+   claimable without violating collision checks.
+4. **Decision:** either claim the author lane and proceed through
+   `ticket-intake`, or record a review-first rationale before loading
+   `/pr-review`.
+
+## Legitimate Review-First Rationale
+
+Review-first is allowed when one of these is true:
+
+- The operator explicitly asked for the review now.
+- The review is urgent, security-sensitive, or blocks a peer's already-active
+  author lane.
+- Lane discovery found no positive-ROI author lane claimable in the current
+  turn, and the survey is named in the handoff.
+- The agent's own PR is already open and CI is pending; review work is being
+  done as CI-wait utilization.
+
+Use explicit wording:
+
+```text
+review-first rationale: <why review precedes author-lane pickup>
+```
+
+## Halt Boundary
+
+Do not halt merely because no operator assigned a lane. A halt-state is valid
+only after the backlog self-survey in `post-review-pickup-workflow.md §5`
+passes and the blocker is named.
+
+## Anti-Patterns
+
+| Anti-pattern | Why it harms |
+|---|---|
+| Entering `/pr-review` from fresh boot without checking for an author lane | Recreates reviewer-only cycles before FAIR-band or post-review pickup can fire |
+| Treating FAIR-band as a scoreboard | Replaces enablement with quota pressure |
+| Loading `/lead-role` or `/peer-role` without a real trigger | Creates fake hierarchy or fake convergence work |
+| Blocking all reviews until a PR exists | Breaks urgent peer-unblock and human-directed review paths |

--- a/.agents/skills/skills.manifest.json
+++ b/.agents/skills/skills.manifest.json
@@ -180,7 +180,7 @@
     },
     "post-review-pickup": {
       "name": "post-review-pickup",
-      "description": "Authoritative protocol for immediate next-phase pickup after PR review or author response handoff. Prevents silent idle after review cycles by requiring the next lane or an explicit halt-state. Triggers: Use immediately after posting a PR review, chaining a formal GitHub review state, or posting an author review-response handoff with a commentId.",
+      "description": "Authoritative protocol for next-lane pickup after PR review / author response handoff AND for pre-review intake lane discovery from fresh boot or watchdog wake when no author lane is active. Prevents silent idle and reviewer-only cycles by requiring the next lane, a review-first rationale, or an explicit halt-state. Triggers: Use immediately after posting a PR review, chaining a formal GitHub review state, posting an author review-response handoff with a commentId, OR before accepting the first PR review/re-review request in a fresh session/wake when no current author or implementation lane is claimed.",
       "routerByteBudget": 12,
       "payloadBudget": 80000,
       "claudeSymlinkRequired": true,

--- a/learn/agentos/ProgressiveDisclosureSkills.md
+++ b/learn/agentos/ProgressiveDisclosureSkills.md
@@ -87,6 +87,7 @@ Invoked when evaluating a PR (either peer-reviewing another agent or guiding a h
 - **Graph Ingestion Tags:** Standardizes feedback using markers like `[KB_GAP]` or `[RETROSPECTIVE]` so the Dream Pipeline can extract lessons learned into the Native Edge Graph.
 - **Circuit Breaker:** Triggers micro-delta paths for deep PRs (≥3 formal reviews or >24KB discussion) and provides a Maintainer Polish Fast Path for metadata fixes.
 - **LGTM/Required Actions:** Ensures every review resolves in a clear state.
+- **Review Intake Guard:** Pairs with `post-review-pickup` so a fresh session checks for an author lane before entering review-only mode, unless a review-first rationale applies.
 
 ### 4. `ticket-create` (The Creation Gate)
 Invoked before filing any new GitHub Issue via the `create_issue` MCP tool. Creation-side dual of `ticket-intake` — they address opposite triggers (produce new vs. consume existing).
@@ -123,6 +124,7 @@ ensuring the YAML frontmatter and folder consistency are perfectly formed.
 | `epic-resolution` | Lifecycle | Closeout protocol for parent epics (exit gate) |
 | `pull-request` | Lifecycle | Post-implementation reflection + PR creation (custom Playwright configs) |
 | `pr-review` | Lifecycle | Structured quality evaluation & graph ingestion (mandatory ROI templates) |
+| `post-review-pickup` | Lifecycle | Next-lane pickup after review/response and pre-review intake lane discovery when no author lane is active |
 | `tech-debt-radar` | Lifecycle | Proactive semantic RAG sweeps for architectural debt |
 | `structural-pre-flight` | Lifecycle | Pre-implementation directory-CHOICE discipline gate fired before authoring any new `.mjs` file (Stage 0 mechanical trigger; Stage 1 fast-path (sibling-file-lift pattern match) or full Pre-Flight) |
 | `identity-firewall` | Security | The L2 Channel Separation and Prompt Firewall defense mechanisms |

--- a/learn/guides/fundamentals/CodebaseOverview.md
+++ b/learn/guides/fundamentals/CodebaseOverview.md
@@ -57,7 +57,7 @@ First, it is critical to understand the primary execution boundary. Neo.mjs oper
 > **Deep-Dive Guides:**
 > - [Architecture Overview](../../benefits/ArchitectureOverview.md) — How the Runtime Engine and Agent OS connect as a closed feedback loop
 > - [Swarm Intelligence](../../agentos/SwarmIntelligence.md) — Autonomous sub-agent delegation (profiles, capability gating, cost control)
-> - [Progressive Disclosure Skills](../../agentos/ProgressiveDisclosureSkills.md) — The lifecycle governance rules
+> - [Progressive Disclosure Skills](../../agentos/ProgressiveDisclosureSkills.md) — The lifecycle governance rules, including review-intake lane discovery before reviewer-only cycles
 > - [The Dream Pipeline & Golden Path](../../agentos/DreamPipeline.md) — Offline forecasting engine that scores and prioritizes work
 
 ### 1. The Frontend Engine: True Multithreading via Web Workers


### PR DESCRIPTION
Resolves #11609

Authored by GPT-5 Codex (Codex Desktop). Session 32843111-9125-4c5a-a4bd-c2ca9e857e86.

FAIR-band: in-band [10/30 — current author count over last 30 merged].

Adds a role-first review-intake gate to `post-review-pickup` so fresh sessions and watchdog wakes do not enter reviewer-only cycles before lane discovery fires. The implementation keeps the always-loaded router small, moves the operational rules into a dedicated payload, mirrors the manifest description, and updates the required downstream docs targets.

Evidence: L1 (static substrate and manifest lint) → L1 required (skill/router/docs contract change). No residuals.

## Deltas from ticket

The implementation uses `post-review-pickup` as the owning surface rather than expanding `pr-review`: the router now exposes the pre-review intake trigger, while the detailed protocol lives in `references/pre-review-intake-lane-gate.md`.

## Slot Rationale

- Modified `post-review-pickup/SKILL.md`: disposition delta `rewrite` — router gains one high-signal trigger for fresh-session/watchdog review intake, staying within the 12-line budget. 3-axis: trigger-frequency = lifecycle-specific, failure-severity = high coordination drift, enforceability = discipline-only.
- Added `pre-review-intake-lane-gate.md`: disposition `compress-to-trigger` — detailed decision rules belong in the Atlas payload, not the router. 3-axis: trigger-frequency = edge-case lifecycle gate, failure-severity = high reviewer-only decay, enforceability = discipline-only.
- Modified `post-review-pickup-workflow.md`: disposition `compress-to-trigger` — adds one payload pointer and a short trigger statement without duplicating the protocol body.
- Modified `skills.manifest.json`: disposition `keep` — manifest mirrors the router description per ADR 0008 and powers cross-harness skill discovery.
- Modified downstream docs: disposition `rewrite` — required by the skill manifest docs-target contract; keeps the public skill overview aligned with the new trigger.

## Test Evidence

- `node ai/scripts/lint-skill-manifest.mjs --base origin/dev` → passed
- `node ai/scripts/lint-agents.mjs --base origin/dev` → passed
- `git diff --cached --check` → passed
- Manual walkthrough covered: fresh wake with review request + no author lane → `post-review-pickup` trigger fires → lane discovery runs → agent either claims author lane or records `review-first rationale` before `/pr-review`.

## Post-Merge Validation

- [ ] Fresh Codex/Claude/Gemini session skill inventory surfaces `post-review-pickup` for pre-review intake when no author lane is active.
- [ ] Next review-wake cycle demonstrates either author-lane pickup first or an explicit `review-first rationale`.

## Commit

- `d6bbe2a9f` — `feat(agentos): add review-intake lane gate (#11609)`
