### PR TITLE
fix(memory-core): guard Golden Path embedding dimensions (#11596)

### DIFF
--- a/ai/daemons/services/GoldenPathSynthesizer.mjs
+++ b/ai/daemons/services/GoldenPathSynthesizer.mjs
@@ -14,6 +14,61 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname  = path.dirname(__filename);
 
 /**
+ * @summary Returns the vector length emitted by an embedding provider.
+ *
+ * Kept as a pure helper so the Golden Path query boundary can validate the provider output
+ * before ChromaDB rejects a mismatched query shape.
+ *
+ * @param {*} embedding Provider-produced embedding payload.
+ * @returns {Number|null} The embedding vector length, or null for invalid/non-vector payloads.
+ */
+export function getEmbeddingVectorLength(embedding) {
+    return Number.isInteger(embedding?.length) ? embedding.length : null;
+}
+
+/**
+ * @summary Resolves the configured embedding model name for the active provider.
+ *
+ * @param {Object} config Memory Core config object.
+ * @param {String} provider Active embedding provider key.
+ * @returns {String|null}
+ */
+export function getEmbeddingModelName(config, provider) {
+    switch (provider) {
+        case 'openAiCompatible':
+            return config.openAiCompatible?.embeddingModel || null;
+        case 'ollama':
+            return config.ollama?.embeddingModel || null;
+        case 'gemini':
+            return config.embeddingModel || null;
+        default:
+            return null;
+    }
+}
+
+/**
+ * @summary Builds the operator-facing Golden Path dimension mismatch warning.
+ *
+ * The message intentionally names both config and observed dimensions because this is the
+ * runtime evidence operators need to align `NEO_EMBEDDING_PROVIDER`, `NEO_VECTOR_DIMENSION`,
+ * and the existing Chroma collection dimension without destructive collection rebuilds.
+ *
+ * @param {Object} options
+ * @param {String} options.provider Active embedding provider key.
+ * @param {String|null} options.model Active embedding model name.
+ * @param {Number} options.configuredDimension Configured vector dimension.
+ * @param {Number|null} options.actualDimension Provider-produced vector length.
+ * @returns {String}
+ */
+export function buildEmbeddingDimensionMismatchMessage({provider, model, configuredDimension, actualDimension}) {
+    return `[GoldenPathSynthesizer] Embedding dimension mismatch before Chroma query: ` +
+        `provider=${provider || '<unset>'}, model=${model || '<unknown>'}, ` +
+        `configuredVectorDimension=${configuredDimension}, actualEmbeddingDimension=${actualDimension}. ` +
+        `Skipping semantic route. Align NEO_EMBEDDING_PROVIDER / NEO_VECTOR_DIMENSION with ` +
+        `the Chroma collection dimension, or rebuild the collection intentionally after backup.`;
+}
+
+/**
  * @class Neo.ai.daemons.services.GoldenPathSynthesizer
  * @extends Neo.core.Base
  * @singleton
@@ -81,6 +136,25 @@ class GoldenPathSynthesizer extends Base {
             frontierEmbedding = await TextEmbeddingService.embedText(frontierText, aiConfig.embeddingProvider);
         } catch (e) {
             logger.warn('[GoldenPathSynthesizer] Failed to generate Frontier Baseline Vector. Aborting Hybrid route.', e);
+            return;
+        }
+
+        const actualDimension     = getEmbeddingVectorLength(frontierEmbedding);
+        const configuredDimension = Number(aiConfig.vectorDimension);
+
+        if (!Number.isInteger(actualDimension) ||
+            !Number.isInteger(configuredDimension) ||
+            configuredDimension <= 0 ||
+            actualDimension !== configuredDimension) {
+            const provider = aiConfig.embeddingProvider;
+            const model    = getEmbeddingModelName(aiConfig, provider);
+
+            logger.warn(buildEmbeddingDimensionMismatchMessage({
+                provider,
+                model,
+                configuredDimension,
+                actualDimension
+            }));
             return;
         }
 

--- a/ai/mcp/server/memory-core/config.template.mjs
+++ b/ai/mcp/server/memory-core/config.template.mjs
@@ -131,12 +131,15 @@ const defaultConfig = {
     /**
      * Canonical embedding provider for Memory Core and Knowledge Base embedding callsites.
      * Supported values: 'gemini', 'ollama', 'openAiCompatible'
+     * Defaults to the local OpenAI-compatible Qwen3 route so the source tuple matches the
+     * unified 4096-dimension Chroma collection invariant. Gemini remains available as an
+     * explicit operator override and must be paired with `vectorDimension: 3072`.
      *
      * `NEO_CHROMA_EMBEDDING_PROVIDER` remains readable for one deprecation window but emits
      * a warning and feeds this unified selector.
      * @type {String}
      */
-    embeddingProvider: 'gemini',
+    embeddingProvider: 'openAiCompatible',
     /**
      * Settings for the Ollama integration
      */

--- a/ai/services/memory-core/HealthService.mjs
+++ b/ai/services/memory-core/HealthService.mjs
@@ -172,7 +172,7 @@ export function buildTopologyBlock(cfg) {
  * @see learn/agentos/SharedDeployment.md
  */
 export function buildEmbeddingProviderBlock(cfg) {
-    return buildSingleEmbeddingProviderBlock(cfg, cfg.embeddingProvider || 'gemini', 'embeddingProvider');
+    return buildSingleEmbeddingProviderBlock(cfg, cfg.embeddingProvider || 'openAiCompatible', 'embeddingProvider');
 }
 
 /**

--- a/ai/services/memory-core/helpers/EmbeddingProviderConfig.mjs
+++ b/ai/services/memory-core/helpers/EmbeddingProviderConfig.mjs
@@ -9,7 +9,7 @@
 export function resolveEmbeddingProvider({config = {}, env = process.env} = {}) {
     const unified = !Neo.isEmpty(config.embeddingProvider) ? config.embeddingProvider : env.NEO_EMBEDDING_PROVIDER;
 
-    return unified || 'gemini';
+    return unified || 'openAiCompatible';
 }
 
 /**

--- a/learn/agentos/ConfigSubstrateEnvVarAudit.md
+++ b/learn/agentos/ConfigSubstrateEnvVarAudit.md
@@ -58,7 +58,7 @@ Target-tier shorthand:
 | `NEO_CHROMA_EMBEDDING_PROVIDER` | `memory-core/helpers/EmbeddingProviderConfig.mjs:15` | Delete | Legacy dev-branch-only alias targeted by #10823. |
 | `NEO_CONCEPT_DISCOVERY_MIN_SOURCE_LENGTH` | `memory-core/config.template.mjs:313` | Tier 2 | Memory Core daemon tuning. Move to per-server config unless one-shot operator override is still desired. |
 | `NEO_CONCEPT_DISCOVERY_PR_SCAN_LIMIT` | `memory-core/config.template.mjs:312` | Tier 2 | Memory Core daemon tuning. Move to per-server config. |
-| `NEO_EMBEDDING_PROVIDER` | `memory-core/helpers/EmbeddingProviderConfig.mjs:14`; `memory-core/config.template.mjs:147` | Tier 1 | Shared provider selector. Tier 1 default plus optional env override for tests/deployments. |
+| `NEO_EMBEDDING_PROVIDER` | `memory-core/helpers/EmbeddingProviderConfig.mjs:14`; `memory-core/config.template.mjs:147` | Tier 1 | Shared provider selector. Tier 1 default is the 4096-dim `openAiCompatible` route; env override remains available for tests/deployments. |
 | `NEO_GUIDE_GAP_WEIGHT_THRESHOLD` | `memory-core/config.template.mjs:296` | Tier 2 | Concept-gap tuning. Prefer Memory Core config. |
 | `NEO_KB_AUTO_START_DATABASE` | `knowledge-base/config.template.mjs:30` | Tier 3 | Operator one-shot lifecycle toggle for local Chroma startup. |
 | `NEO_KB_CHROMA_HOST` | `memory-core/config.template.mjs:243`; `shared/helpers/DeploymentConfig.mjs:71` | Delete | Legacy server-prefixed alias targeted by #10823. |

--- a/learn/agentos/MemoryCore.md
+++ b/learn/agentos/MemoryCore.md
@@ -182,7 +182,7 @@ Introduced for Chroma-side local embedding-provider validation (#10723), then co
 | `active` | `'gemini' \| 'openAiCompatible' \| 'ollama' \| string` | Provider selected for every embedding consumer. Controlled by `embeddingProvider` / `NEO_EMBEDDING_PROVIDER`. |
 | `host` | `string \| null` | Embedding provider host for local providers; `null` for Gemini. |
 | `model` | `string \| null` | Configured embedding model name. |
-| `dimensions` | `number` | Configured `vectorDimension`; must match the embedding model's actual output dimension. |
+| `dimensions` | `number` | Configured `vectorDimension`; must match the embedding model's actual output dimension. Live output length is provider-call evidence rather than a cheap config projection; Golden Path logs `actualEmbeddingDimension` when it already generated a frontier embedding and detects a mismatch before Chroma query. |
 | `error` | `string` (optional) | Present only when the provider key is unrecognized; healthcheck surfaces the misconfig instead of throwing. |
 
 `NEO_CHROMA_EMBEDDING_PROVIDER` remains readable during the #10804 deprecation window and feeds the unified selector with a warning. Operators should use `NEO_EMBEDDING_PROVIDER` for new deployments.

--- a/learn/agentos/SharedDeployment.md
+++ b/learn/agentos/SharedDeployment.md
@@ -37,21 +37,21 @@ The system uses a **permanently unified** topology. The Memory Core and Knowledg
 
 ### Embedding provider
 
-Embedding generation is provider-pluggable. The active provider is controlled by `NEO_EMBEDDING_PROVIDER`; supported values are `'gemini'` (default, cloud), `'ollama'` (local), and `'openAiCompatible'` (local OpenAI-format servers including MLX-served Qwen3 models, llama.cpp, LM Studio, etc.). The selector drives ChromaDB retrieval operations.
+Embedding generation is provider-pluggable. The active provider is controlled by `NEO_EMBEDDING_PROVIDER`; supported values are `'openAiCompatible'` (default local OpenAI-format route, including MLX-served Qwen3 models, llama.cpp, LM Studio, etc.), `'gemini'` (cloud), and `'ollama'` (local). The selector drives ChromaDB retrieval operations.
 
 ```bash
-# Default: Google Gemini cloud embedding (gemini-embedding-001):
+# Default: local OpenAI-compatible Qwen3 embedding, matching the 4096-dim collection invariant:
 unset NEO_EMBEDDING_PROVIDER
-# or
-export NEO_EMBEDDING_PROVIDER=gemini
-
-# Local OpenAI-compatible embedding (e.g. Qwen3 family via MLX):
 export NEO_EMBEDDING_PROVIDER=openAiCompatible
 export NEO_OPENAI_COMPATIBLE_HOST=http://127.0.0.1:8000              # MLX server endpoint
-export NEO_OPENAI_COMPATIBLE_EMBEDDING_MODEL=text-embedding-qwen3-embedding-1.5b  # Qwen3-1.5B variant
-# OR for the 8B variant:
-# export NEO_OPENAI_COMPATIBLE_EMBEDDING_MODEL=text-embedding-qwen3-embedding-8b
+export NEO_OPENAI_COMPATIBLE_EMBEDDING_MODEL=text-embedding-qwen3-embedding-8b  # Qwen3-8B default
+# OR for the smaller 1.5B variant:
+# export NEO_OPENAI_COMPATIBLE_EMBEDDING_MODEL=text-embedding-qwen3-embedding-1.5b
 export NEO_OPENAI_COMPATIBLE_API_KEY=                                # leave empty for local servers
+
+# Optional Google Gemini cloud embedding (gemini-embedding-001, 3072 dims):
+export NEO_EMBEDDING_PROVIDER=gemini
+export NEO_VECTOR_DIMENSION=3072
 
 # Local Ollama embedding:
 export NEO_EMBEDDING_PROVIDER=ollama
@@ -228,7 +228,7 @@ Embedding diagnostic fields:
 - `active`: the provider key selected for embedding generation (`'gemini'` | `'openAiCompatible'` | `'ollama'`). Mismatch between operator intent (e.g. expected local Qwen3) and observed value (e.g. silent fallback to `'gemini'` because `NEO_EMBEDDING_PROVIDER` was unset) is the load-bearing diagnostic.
 - `host`: provider endpoint URL when applicable (`null` for cloud `gemini`).
 - `model`: resolved embedding model name. Operators verify this matches the model running on the local server.
-- `dimensions`: configured `vectorDimension`. Must match the embedding model's actual output dimension; mismatch is silent in collection writes but breaks retrieval.
+- `dimensions`: configured `vectorDimension`. Must match the embedding model's actual output dimension; mismatch is silent in collection writes but breaks retrieval. This is intentionally config-only: a live `actualDimensions` smoke requires calling the provider, which may load local models or need cloud credentials. Golden Path now logs the observed `actualEmbeddingDimension` when it already has a generated frontier embedding and refuses the Chroma query before a raw shape error.
 
 If the embedding provider key resolves to an unrecognized value, the block additionally surfaces an `error` field naming the misconfig directly without making healthcheck throw.
 

--- a/test/playwright/unit/ai/daemons/services/GoldenPathSynthesizer.spec.mjs
+++ b/test/playwright/unit/ai/daemons/services/GoldenPathSynthesizer.spec.mjs
@@ -33,6 +33,10 @@ test.describe('Neo.ai.daemons.services.GoldenPathSynthesizer', () => {
     let TextEmbeddingService;
     let tmpHandoffFile;
     let originalExecSync;
+    let originalEmbeddingModel;
+    let originalEmbeddingProvider;
+    let originalVectorDimension;
+    let originalWarn;
     
     test.beforeAll(async () => {
         aiConfig = (await import('../../../../../../ai/mcp/server/memory-core/config.mjs')).default;
@@ -60,11 +64,20 @@ test.describe('Neo.ai.daemons.services.GoldenPathSynthesizer', () => {
     });
 
     test.beforeEach(() => {
-        originalExecSync = child_process.execSync;
+        originalEmbeddingModel    = aiConfig.embeddingModel;
+        originalEmbeddingProvider = aiConfig.embeddingProvider;
+        originalExecSync          = child_process.execSync;
+        originalVectorDimension   = aiConfig.vectorDimension;
+        originalWarn              = logger.warn;
     });
 
     test.afterEach(() => {
-        child_process.execSync = originalExecSync;
+        aiConfig.embeddingModel    = originalEmbeddingModel;
+        aiConfig.embeddingProvider = originalEmbeddingProvider;
+        aiConfig.vectorDimension   = originalVectorDimension;
+        child_process.execSync     = originalExecSync;
+        logger.warn                = originalWarn;
+
         if (fs.existsSync(tmpHandoffFile)) {
             try { fs.unlinkSync(tmpHandoffFile); } catch(e) {}
         }
@@ -79,6 +92,7 @@ test.describe('Neo.ai.daemons.services.GoldenPathSynthesizer', () => {
         const originalGetGraphCollection = StorageRouter.getGraphCollection;
         const originalGetSummaryCollection = StorageRouter.getSummaryCollection;
         const originalEmbedText = TextEmbeddingService.embedText;
+        aiConfig.vectorDimension = 2;
         
         StorageRouter.getGraphCollection = async () => ({ query: async () => ({ ids: [['mock-id']], distances: [[0.1]] }) });
         StorageRouter.getSummaryCollection = async () => ({ get: async () => ({ documents: ['mock document'] }) });
@@ -104,12 +118,14 @@ test.describe('Neo.ai.daemons.services.GoldenPathSynthesizer', () => {
         const originalFetchOpenPRs = GoldenPathSynthesizer.fetchOpenPRs;
         GoldenPathSynthesizer.fetchOpenPRs = async () => mockPrData;
 
-        await GoldenPathSynthesizer.synthesizeGoldenPath();
-        
-        GoldenPathSynthesizer.fetchOpenPRs = originalFetchOpenPRs;
-        StorageRouter.getGraphCollection = originalGetGraphCollection;
-        StorageRouter.getSummaryCollection = originalGetSummaryCollection;
-        TextEmbeddingService.embedText = originalEmbedText;
+        try {
+            await GoldenPathSynthesizer.synthesizeGoldenPath();
+        } finally {
+            GoldenPathSynthesizer.fetchOpenPRs = originalFetchOpenPRs;
+            StorageRouter.getGraphCollection   = originalGetGraphCollection;
+            StorageRouter.getSummaryCollection = originalGetSummaryCollection;
+            TextEmbeddingService.embedText     = originalEmbedText;
+        }
 
         const handoffContent = fs.readFileSync(tmpHandoffFile, 'utf-8');
         
@@ -121,5 +137,45 @@ test.describe('Neo.ai.daemons.services.GoldenPathSynthesizer', () => {
         expect(handoffContent).toContain('- **Reviewers**: neo-opus-4-7');
         expect(handoffContent).toContain('- **Status**: `CHANGES_REQUESTED`');
         expect(handoffContent).toContain('- **Head SHA**: `abcdef1234567890`');
+    });
+
+    test('synthesizeGoldenPath skips Chroma query when embedding dimension mismatches vectorDimension', async () => {
+        const originalGetGraphCollection   = StorageRouter.getGraphCollection;
+        const originalGetSummaryCollection = StorageRouter.getSummaryCollection;
+        const originalEmbedText            = TextEmbeddingService.embedText;
+        const warnings                     = [];
+        let queryCalls                     = 0;
+
+        aiConfig.embeddingProvider = 'gemini';
+        aiConfig.embeddingModel    = 'gemini-embedding-001';
+        aiConfig.vectorDimension   = 4096;
+
+        StorageRouter.getGraphCollection = async () => ({
+            query: async () => {
+                queryCalls++;
+                return {ids: [['mock-id']], distances: [[0.1]]};
+            }
+        });
+        StorageRouter.getSummaryCollection = async () => ({ get: async () => ({ documents: ['mock document'] }) });
+        TextEmbeddingService.embedText = async () => new Array(3072).fill(0.1);
+        logger.warn = (...args) => warnings.push(args.join(' '));
+
+        try {
+            await GoldenPathSynthesizer.synthesizeGoldenPath();
+
+            expect(queryCalls).toBe(0);
+
+            const warningText = warnings.join('\n');
+            expect(warningText).toContain('Embedding dimension mismatch before Chroma query');
+            expect(warningText).toContain('provider=gemini');
+            expect(warningText).toContain('model=gemini-embedding-001');
+            expect(warningText).toContain('configuredVectorDimension=4096');
+            expect(warningText).toContain('actualEmbeddingDimension=3072');
+            expect(warningText).toContain('NEO_EMBEDDING_PROVIDER / NEO_VECTOR_DIMENSION');
+        } finally {
+            StorageRouter.getGraphCollection   = originalGetGraphCollection;
+            StorageRouter.getSummaryCollection = originalGetSummaryCollection;
+            TextEmbeddingService.embedText     = originalEmbedText;
+        }
     });
 });

--- a/test/playwright/unit/ai/services/memory-core/HealthService.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/HealthService.spec.mjs
@@ -337,16 +337,19 @@ test.describe('HealthService #10723/#10773/#10804 — buildEmbeddingProviderBloc
         });
     });
 
-    test('unset embeddingProvider defaults provider to gemini', () => {
+    test('unset embeddingProvider defaults provider to openAiCompatible', () => {
         const cfg = {
-            vectorDimension: 3072,
-            embeddingModel : 'gemini-embedding-001'
+            vectorDimension : 4096,
+            openAiCompatible: {
+                host          : 'http://127.0.0.1:11434',
+                embeddingModel: 'text-embedding-qwen3-embedding-8b'
+            }
         };
         expect(buildEmbeddingProviderBlock(cfg)).toEqual({
-            active    : 'gemini',
-            host      : null,
-            model     : 'gemini-embedding-001',
-            dimensions: 3072
+            active    : 'openAiCompatible',
+            host      : 'http://127.0.0.1:11434',
+            model     : 'text-embedding-qwen3-embedding-8b',
+            dimensions: 4096
         });
     });
 
@@ -383,6 +386,27 @@ test.describe('HealthService #10723/#10773/#10804 — buildEmbeddingProviderBloc
             const result = buildEmbeddingProviderBlock(cfg);
             expect(result.dimensions).toBe(768);
         }
+    });
+});
+
+/**
+ * @summary Coverage for the source-default embedding provider resolver (#11596).
+ *
+ * The default must be coherent with the unified 4096-dimension Chroma substrate even when
+ * standalone scripts run without `NEO_EMBEDDING_PROVIDER`.
+ *
+ * @see Neo.ai.services.memory-core.helpers.EmbeddingProviderConfig#resolveEmbeddingProvider
+ */
+test.describe('EmbeddingProviderConfig #11596 — resolveEmbeddingProvider', () => {
+    let resolveEmbeddingProvider;
+
+    test.beforeAll(async () => {
+        const mod = await import('../../../../../../ai/services/memory-core/helpers/EmbeddingProviderConfig.mjs');
+        resolveEmbeddingProvider = mod.resolveEmbeddingProvider;
+    });
+
+    test('defaults to openAiCompatible when config and env are unset', () => {
+        expect(resolveEmbeddingProvider({config: {}, env: {}})).toBe('openAiCompatible');
     });
 });
 


### PR DESCRIPTION
Resolves #11596

Authored by GPT-5 (Codex Desktop). Session b61cfc87-e697-4395-a9d5-831f03fd8994.

FAIR-band: in-band [11/30 — current author count over last 30 merged]

lane-state: ci-pending (primary reviewer assignment waits for current-head CI)

Golden Path now validates the generated frontier embedding length before it queries Chroma. If a caller produces a 3072-dim vector for a 4096-dim graph collection, the semantic route is skipped with an actionable warning naming provider, model, configured dimension, actual dimension, and remediation instead of surfacing the raw Chroma shape error.

Evidence: L2 (focused Playwright unit specs plus syntax/diff hygiene checks) → L3 required (post-merge Sandman smoke against the live provider + Chroma collection). Residual: post-merge Sandman run [#11596].

## Deltas from ticket
- Added the Golden Path preflight at the embedding/query boundary and covered the 3072-vs-4096 mismatch with a unit test proving `graphColl.query()` is not called.
- Changed the tracked Memory Core config template and provider fallback projections to default to `openAiCompatible` / Qwen3 / 4096 rather than Gemini / 3072.
- Documented why healthcheck `providers.embedding.dimensions` remains config-only: a live actual-dimension smoke requires calling the provider, while Golden Path logs `actualEmbeddingDimension` when it already has a frontier embedding.

## MCP Config Template Change
- Changed key: `embeddingProvider` in `ai/mcp/server/memory-core/config.template.mjs`, defaulting from `gemini` to `openAiCompatible`.
- Local `config.mjs` follow-up: no shape/key migration is required. Existing clones whose gitignored local config explicitly sets `embeddingProvider: 'gemini'` should either switch to `openAiCompatible` or pair Gemini with `vectorDimension: 3072`; the runtime guard prevents raw Chroma query failure before local config is refreshed.
- Harness restart: recommended for Memory Core / Sandman processes after local config refresh so long-running processes observe the coherent provider tuple.

## Slot Rationale
This PR modifies `learn/agentos/**` documentation only; no always-loaded agent instruction substrate grows.

- Modified `learn/agentos/SharedDeployment.md`: disposition `keep`; delta updates the operator runbook to the current 4096-dim default and documents live-dimension smoke. Rating: high trigger-frequency x high failure-severity x medium enforceability.
- Modified `learn/agentos/MemoryCore.md`: disposition `keep`; delta clarifies healthcheck `dimensions` is config-only while Golden Path logs actual output length on mismatch. Rating: medium trigger-frequency x high failure-severity x medium enforceability.
- Modified `learn/agentos/ConfigSubstrateEnvVarAudit.md`: disposition `keep`; delta aligns the env-var audit with the new default. Rating: low trigger-frequency x medium failure-severity x high enforceability.
- Retired sections: none.

## Test Evidence
- `npm run test-unit -- test/playwright/unit/ai/daemons/services/GoldenPathSynthesizer.spec.mjs` — 2 passed
- `npm run test-unit -- test/playwright/unit/ai/services/memory-core/HealthService.spec.mjs` — 45 passed
- `node --check ai/daemons/services/GoldenPathSynthesizer.mjs`
- `node --check ai/mcp/server/memory-core/config.template.mjs`
- `node --check ai/services/memory-core/helpers/EmbeddingProviderConfig.mjs`
- `node --check ai/services/memory-core/HealthService.mjs`
- `git diff --check`
- `git diff --cached --check`
- `node buildScripts/util/check-whitespace.mjs`

## Post-Merge Validation
- [ ] Refresh/restart any local Memory Core config that still pins Gemini unintentionally, then run `npm run ai:run-sandman` and confirm no raw `Collection expecting embedding with dimension of 4096, got 3072` Chroma query error appears. A remaining mismatch should log the new Golden Path preflight warning instead.

## Related
- #10003 — prior unified embedding boundary work for KB / Memory Core sync flows.
- #10723 — local embedding provider validation and `NEO_VECTOR_DIMENSION` contract.
- Origin Session ID: 8591bc48-0ddc-48bf-aa47-58e53ea81a57.

## Commits
- `c026a8ab4` — `fix(memory-core): guard Golden Path embedding dimensions (#11596)`
