### PR TITLE
test(memory-core): cover lms server start embeddings (#11402)

### DIFF
--- a/ai/services/memory-core/TextEmbeddingService.mjs
+++ b/ai/services/memory-core/TextEmbeddingService.mjs
@@ -63,7 +63,9 @@ class TextEmbeddingService extends Base {
     }
 
     /**
-     * Executes the /v1/embeddings POST request with retry semantics for unloaded models.
+     * Executes OpenAI-compatible /v1/embeddings POST requests with retry semantics for unloaded models.
+     * The same endpoint shape is used by LM Studio desktop, `lms server start`, MLX, llama.cpp,
+     * and other local OpenAI-format embedding servers.
      * @param {String|String[]} inputData The text or array of texts to embed.
      * @param {Number} retriesLeft Number of retries remaining.
      * @returns {Promise<Object>}
@@ -71,7 +73,7 @@ class TextEmbeddingService extends Base {
      */
     async #postOpenAiCompatible(inputData, retriesLeft) {
         const { host, embeddingModel, apiKey, unloadRetryCount = 3, unloadRetryDelayMs = 500 } = aiConfig.openAiCompatible;
-        
+
         try {
             const parsedUrl = new URL(`${host}/v1/embeddings`);
             const httpModule = parsedUrl.protocol === 'https:' ? await import('https') : await import('http');
@@ -182,7 +184,7 @@ class TextEmbeddingService extends Base {
             if (!this.embeddingModel) {
                  throw new Error('Google Generative AI Client not initialized properly.');
             }
-            
+
             const requests = texts.map(text => ({model: aiConfig.embeddingModel, content: {parts: [{text}]}}));
             const result = await this.embeddingModel.batchEmbedContents({ requests });
             return result.embeddings.map(e => e.values);

--- a/test/playwright/unit/ai/services/memory-core/TextEmbeddingService.retry.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/TextEmbeddingService.retry.spec.mjs
@@ -19,10 +19,11 @@ import * as core      from '../../../../../../src/core/_export.mjs';
 import http           from 'http';
 import aiConfig       from '../../../../../../ai/mcp/server/memory-core/config.mjs';
 
-test.describe.serial('TextEmbeddingService #11393 — openAiCompatible retry on model unload', () => {
+test.describe.serial('TextEmbeddingService #11393/#11402 — openAiCompatible retry and lms server start support', () => {
     let SDK, TextEmbeddingService, server;
     let requestCount = 0;
-    let serverBehavior = 'succeed'; // 'succeed', 'fail-then-succeed', 'fail-all', 'fail-shape-b-then-succeed', 'fail-all-shape-b'
+    let serverBehavior = 'succeed';
+    let lastRequest;
     let testPort;
     let originalHost, originalRetryCount, originalRetryDelay;
 
@@ -30,42 +31,65 @@ test.describe.serial('TextEmbeddingService #11393 — openAiCompatible retry on 
         SDK = await import('../../../../../../ai/services.mjs');
         TextEmbeddingService = SDK.Memory_TextEmbeddingService;
 
-        // Start a mock HTTP server
         server = http.createServer((req, res) => {
             requestCount++;
-            
-            if (serverBehavior === 'succeed') {
-                res.writeHead(200, { 'Content-Type': 'application/json' });
-                res.end(JSON.stringify({ data: [{ embedding: [0.1, 0.2, 0.3] }] }));
-            } else if (serverBehavior === 'fail-then-succeed') {
-                if (requestCount === 1) {
+
+            let body = '';
+
+            req.on('data', chunk => body += chunk);
+            req.on('end', () => {
+                lastRequest = {
+                    method: req.method,
+                    url   : req.url,
+                    body  : body ? JSON.parse(body) : null
+                };
+
+                if (serverBehavior === 'succeed') {
+                    res.writeHead(200, { 'Content-Type': 'application/json' });
+                    res.end(JSON.stringify({ data: [{ embedding: [0.1, 0.2, 0.3] }] }));
+                } else if (serverBehavior === 'lms-server-start-succeed') {
+                    res.writeHead(200, { 'Content-Type': 'application/json' });
+                    res.end(JSON.stringify({
+                        data: [{index: 0, embedding: [1.1, 1.2, 1.3]}]
+                    }));
+                } else if (serverBehavior === 'lms-server-start-batch-succeed') {
+                    res.writeHead(200, { 'Content-Type': 'application/json' });
+                    res.end(JSON.stringify({
+                        data: [
+                            {index: 1, embedding: [2.1, 2.2, 2.3]},
+                            {index: 0, embedding: [1.1, 1.2, 1.3]}
+                        ]
+                    }));
+                } else if (serverBehavior === 'fail-then-succeed') {
+                    if (requestCount === 1) {
+                        res.writeHead(400, { 'Content-Type': 'application/json' });
+                        res.end(JSON.stringify({ error: 'Model was unloaded while the request was still in queue..' }));
+                    } else {
+                        res.writeHead(200, { 'Content-Type': 'application/json' });
+                        res.end(JSON.stringify({ data: [{ embedding: [0.4, 0.5, 0.6] }] }));
+                    }
+                } else if (serverBehavior === 'fail-all') {
                     res.writeHead(400, { 'Content-Type': 'application/json' });
                     res.end(JSON.stringify({ error: 'Model was unloaded while the request was still in queue..' }));
-                } else {
-                    res.writeHead(200, { 'Content-Type': 'application/json' });
-                    res.end(JSON.stringify({ data: [{ embedding: [0.4, 0.5, 0.6] }] }));
-                }
-            } else if (serverBehavior === 'fail-all') {
-                res.writeHead(400, { 'Content-Type': 'application/json' });
-                res.end(JSON.stringify({ error: 'Model was unloaded while the request was still in queue..' }));
-            } else if (serverBehavior === 'fail-shape-b-then-succeed') {
-                if (requestCount === 1) {
+                } else if (serverBehavior === 'fail-shape-b-then-succeed') {
+                    if (requestCount === 1) {
+                        res.writeHead(400, { 'Content-Type': 'application/json' });
+                        res.end(JSON.stringify({ error: 'Failed to load model "text-embedding-qwen3-embedding-8b". Error: Operation canceled.' }));
+                    } else {
+                        res.writeHead(200, { 'Content-Type': 'application/json' });
+                        res.end(JSON.stringify({ data: [{ embedding: [0.7, 0.8, 0.9] }] }));
+                    }
+                } else if (serverBehavior === 'fail-all-shape-b') {
                     res.writeHead(400, { 'Content-Type': 'application/json' });
                     res.end(JSON.stringify({ error: 'Failed to load model "text-embedding-qwen3-embedding-8b". Error: Operation canceled.' }));
-                } else {
-                    res.writeHead(200, { 'Content-Type': 'application/json' });
-                    res.end(JSON.stringify({ data: [{ embedding: [0.7, 0.8, 0.9] }] }));
+                } else if (serverBehavior === 'fail-other') {
+                    res.writeHead(400, { 'Content-Type': 'application/json' });
+                    res.end(JSON.stringify({ error: 'Some other bad request error' }));
                 }
-            } else if (serverBehavior === 'fail-all-shape-b') {
-                res.writeHead(400, { 'Content-Type': 'application/json' });
-                res.end(JSON.stringify({ error: 'Failed to load model "text-embedding-qwen3-embedding-8b". Error: Operation canceled.' }));
-            } else if (serverBehavior === 'fail-other') {
-                res.writeHead(400, { 'Content-Type': 'application/json' });
-                res.end(JSON.stringify({ error: 'Some other bad request error' }));
-            }
+            });
         });
 
-        await new Promise(resolve => server.listen(0, resolve));
+        await new Promise(resolve => server.listen(0, '127.0.0.1', resolve));
         testPort = server.address().port;
     });
 
@@ -75,10 +99,11 @@ test.describe.serial('TextEmbeddingService #11393 — openAiCompatible retry on 
 
     test.beforeEach(() => {
         requestCount = 0;
+        lastRequest  = null;
         originalHost = aiConfig.openAiCompatible.host;
         originalRetryCount = aiConfig.openAiCompatible.unloadRetryCount;
         originalRetryDelay = aiConfig.openAiCompatible.unloadRetryDelayMs;
-        
+
         aiConfig.openAiCompatible.host = `http://127.0.0.1:${testPort}`;
         aiConfig.openAiCompatible.unloadRetryCount = 3;
         aiConfig.openAiCompatible.unloadRetryDelayMs = 10; // fast for tests
@@ -97,6 +122,43 @@ test.describe.serial('TextEmbeddingService #11393 — openAiCompatible retry on 
         expect(requestCount).toBe(1);
     });
 
+    test('lms server start-compatible single embedding uses the standard OpenAI-compatible endpoint', async () => {
+        serverBehavior = 'lms-server-start-succeed';
+
+        const result = await TextEmbeddingService.embedText('hello', 'openAiCompatible');
+
+        expect(result).toEqual([1.1, 1.2, 1.3]);
+        expect(requestCount).toBe(1);
+        expect(lastRequest).toMatchObject({
+            method: 'POST',
+            url   : '/v1/embeddings',
+            body  : {
+                model: aiConfig.openAiCompatible.embeddingModel,
+                input: 'hello'
+            }
+        });
+    });
+
+    test('lms server start-compatible batch embeddings preserve TextEmbeddingService ordering', async () => {
+        serverBehavior = 'lms-server-start-batch-succeed';
+
+        const result = await TextEmbeddingService.embedTexts(['first', 'second'], 'openAiCompatible');
+
+        expect(result).toEqual([
+            [1.1, 1.2, 1.3],
+            [2.1, 2.2, 2.3]
+        ]);
+        expect(requestCount).toBe(1);
+        expect(lastRequest).toMatchObject({
+            method: 'POST',
+            url   : '/v1/embeddings',
+            body  : {
+                model: aiConfig.openAiCompatible.embeddingModel,
+                input: ['first', 'second']
+            }
+        });
+    });
+
     test('first-call-fails-second-call-succeeds path with mock client', async () => {
         serverBehavior = 'fail-then-succeed';
         const result = await TextEmbeddingService.embedText('hello', 'openAiCompatible');
@@ -107,14 +169,14 @@ test.describe.serial('TextEmbeddingService #11393 — openAiCompatible retry on 
     test('exhausted-retry-final-failure path', async () => {
         serverBehavior = 'fail-all';
         aiConfig.openAiCompatible.unloadRetryCount = 2; // N=2
-        
+
         await expect(TextEmbeddingService.embedText('hello', 'openAiCompatible'))
             .rejects.toThrow(/Model was unloaded/);
-            
+
         // Initial request + 2 retries = 3 total requests
         expect(requestCount).toBe(3);
     });
-    
+
     test('first-call-fails-shape-b-second-call-succeeds path with mock client', async () => {
         serverBehavior = 'fail-shape-b-then-succeed';
         const result = await TextEmbeddingService.embedText('hello', 'openAiCompatible');
@@ -125,20 +187,20 @@ test.describe.serial('TextEmbeddingService #11393 — openAiCompatible retry on 
     test('exhausted-retry-final-failure path with shape b', async () => {
         serverBehavior = 'fail-all-shape-b';
         aiConfig.openAiCompatible.unloadRetryCount = 2; // N=2
-        
+
         await expect(TextEmbeddingService.embedText('hello', 'openAiCompatible'))
             .rejects.toThrow(/Failed to load model.*Operation canceled/);
-            
+
         // Initial request + 2 retries = 3 total requests
         expect(requestCount).toBe(3);
     });
-    
+
     test('propagates non-unload HTTP 400 errors immediately without retries', async () => {
         serverBehavior = 'fail-other';
-        
+
         await expect(TextEmbeddingService.embedText('hello', 'openAiCompatible'))
             .rejects.toThrow(/Some other bad request error/);
-            
+
         expect(requestCount).toBe(1); // No retries
     });
 });


### PR DESCRIPTION
Resolves #11402

Authored by GPT-5.5 (Codex Desktop). Session 019e3d6f-58a5-7100-b41d-639a026d9049.

FAIR-band: in-band [10/30 — current author count over last 30 merged]

Pins lightweight `lms server start` support in `TextEmbeddingService` by validating the service uses the standard OpenAI-compatible `/v1/embeddings` endpoint for both single and batch embedding calls. The investigation result is that no separate detection branch is needed: the existing host-configured OpenAI-compatible path is already the correct abstraction for LM Studio desktop, `lms server start`, MLX, llama.cpp, and similar local embedding servers.

Evidence: L2 (local mock OpenAI-compatible `/v1/embeddings` single + batch wire contract) -> L2 required (TextEmbeddingService connection semantics are host-configured HTTP contract semantics). Residual: none.

## Deltas from ticket
No runtime heuristic split was added. The ticket asked to identify whether `lms server start` needs separate connection or retry handling; the pinned behavior shows the same OpenAI-compatible path handles it, while existing Shape A/B retry coverage remains intact for desktop-style unload failures.

## Test Evidence
- `node --check ai/services/memory-core/TextEmbeddingService.mjs` passed.
- `node --check test/playwright/unit/ai/services/memory-core/TextEmbeddingService.retry.spec.mjs` passed.
- `git diff --check` passed.
- `node buildScripts/util/check-whitespace.mjs ai/services/memory-core/TextEmbeddingService.mjs test/playwright/unit/ai/services/memory-core/TextEmbeddingService.retry.spec.mjs` passed.
- `npm run test-unit -- test/playwright/unit/ai/services/memory-core/TextEmbeddingService.retry.spec.mjs` passed: 8 passed. The first sandboxed run failed with `listen EPERM` on local server bind; rerun with the same command outside the sandbox passed.

## Post-Merge Validation
- [ ] Optional manual smoke: point `NEO_OPENAI_COMPATIBLE_HOST` at an installed `lms server start` process and confirm embeddings are returned through the existing OpenAI-compatible provider path.

## Commit
- `bc781adea` — `test(memory-core): cover lms server start embeddings (#11402)`
