### PR TITLE
fix(test): stabilize ai scripts focused specs (#11617)

### DIFF
--- a/test/playwright/unit/ai/scripts/checkRetiredPrimitives.spec.mjs
+++ b/test/playwright/unit/ai/scripts/checkRetiredPrimitives.spec.mjs
@@ -17,6 +17,8 @@ import {test, expect} from '@playwright/test';
 import {execFileSync} from 'child_process';
 import path           from 'path';
 import fs             from 'fs/promises';
+import Neo            from '../../../../../src/Neo.mjs';
+import * as core      from '../../../../../src/core/_export.mjs';
 
 /**
  * @summary Coverage for `ai/scripts/check-retired-primitives.mjs` — the mechanical-enforcement

--- a/test/playwright/unit/ai/scripts/harnessLifecycle.spec.mjs
+++ b/test/playwright/unit/ai/scripts/harnessLifecycle.spec.mjs
@@ -19,6 +19,8 @@ import fs             from 'fs/promises';
 import {existsSync}   from 'fs';
 import path           from 'path';
 import os             from 'os';
+import Neo            from '../../../../../src/Neo.mjs';
+import * as core      from '../../../../../src/core/_export.mjs';
 
 test.describe('ai/scripts/harnessLifecycle', () => {
     // Shared harness-state identity writes one state file; keep this spec serial under default-worker runs.

--- a/test/playwright/unit/ai/scripts/heartbeatLock.spec.mjs
+++ b/test/playwright/unit/ai/scripts/heartbeatLock.spec.mjs
@@ -16,6 +16,8 @@ setup({
 import {test, expect} from '@playwright/test';
 import fs             from 'fs-extra';
 import path           from 'path';
+import Neo            from '../../../../../src/Neo.mjs';
+import * as core      from '../../../../../src/core/_export.mjs';
 
 /**
  * @summary Unit coverage for the heartbeat concurrency mutex helper (#10319).

--- a/test/playwright/unit/ai/scripts/idleOutNudge.spec.mjs
+++ b/test/playwright/unit/ai/scripts/idleOutNudge.spec.mjs
@@ -20,6 +20,8 @@ import os                        from 'os';
 import path                      from 'path';
 import fs                        from 'fs';
 import fsp                       from 'fs/promises';
+import Neo                       from '../../../../../src/Neo.mjs';
+import * as core                 from '../../../../../src/core/_export.mjs';
 
 import {getLockPath, writeInflightLock} from '../../../../../ai/scripts/inflightLock.mjs';
 
@@ -38,6 +40,9 @@ import {getLockPath, writeInflightLock} from '../../../../../ai/scripts/inflight
  * test path here. Tests can run with default env safely.
  */
 test.describe('ai/scripts/idleOutNudge', () => {
+    // Shared identity-derived lock path; focused runs must not race the file state.
+    test.describe.configure({mode: 'serial'});
+
     const scriptPath  = path.resolve(process.cwd(), 'ai/scripts/idleOutNudge.mjs');
     const testIdentity = '@neo-idle-out-test';
     const lockPath    = getLockPath('idle_out_nudge', testIdentity);

--- a/test/playwright/unit/ai/scripts/inflightLock.spec.mjs
+++ b/test/playwright/unit/ai/scripts/inflightLock.spec.mjs
@@ -19,8 +19,13 @@ import {existsSync}              from 'fs';
 import path                      from 'path';
 import {randomUUID}              from 'crypto';
 import os                        from 'os';
+import Neo                       from '../../../../../src/Neo.mjs';
+import * as core                 from '../../../../../src/core/_export.mjs';
 
 test.describe('ai/scripts/inflightLock', () => {
+    // Shared identity-derived lock and gate paths; focused runs must not race the file state.
+    test.describe.configure({mode: 'serial'});
+
     let inflightLock;
     let wakeSafetyGate;
     let getLockPath;

--- a/test/playwright/unit/ai/scripts/resumeHarness.spec.mjs
+++ b/test/playwright/unit/ai/scripts/resumeHarness.spec.mjs
@@ -20,6 +20,8 @@ import {randomUUID}              from 'crypto';
 import os                        from 'os';
 import path                      from 'path';
 import fs                        from 'fs';
+import Neo                       from '../../../../../src/Neo.mjs';
+import * as core                 from '../../../../../src/core/_export.mjs';
 
 test.describe('ai/scripts/resumeHarness', () => {
     test.describe.configure({mode: 'serial'});

--- a/test/playwright/unit/ai/scripts/swarm-heartbeat.spec.mjs
+++ b/test/playwright/unit/ai/scripts/swarm-heartbeat.spec.mjs
@@ -17,6 +17,8 @@ import {test, expect}     from '@playwright/test';
 import {execFileSync}     from 'child_process';
 import fs                 from 'fs/promises';
 import path               from 'path';
+import Neo                from '../../../../../src/Neo.mjs';
+import * as core          from '../../../../../src/core/_export.mjs';
 
 /**
  * @summary Drift guards + fixture-backed regression coverage on `ai/scripts/swarm-heartbeat.sh` (#10622).

--- a/test/playwright/unit/ai/scripts/trioWakeCooldown.spec.mjs
+++ b/test/playwright/unit/ai/scripts/trioWakeCooldown.spec.mjs
@@ -18,10 +18,15 @@ import {execFileSync, exec} from 'child_process';
 import path           from 'path';
 import fs             from 'fs-extra';
 import util           from 'util';
+import Neo            from '../../../../../src/Neo.mjs';
+import * as core      from '../../../../../src/core/_export.mjs';
 
 const execAsync = util.promisify(exec);
 
 test.describe('ai/scripts/trioWakeCooldown', () => {
+    // Shared cooldown state path; focused runs must not race the file state.
+    test.describe.configure({mode: 'serial'});
+
     const STATE_PATH = '.neo-ai-data/wake-daemon/trio-wake-cooldown.json';
     const scriptPath = path.resolve(process.cwd(), 'ai/scripts/trioWakeCooldown.mjs');
 

--- a/test/playwright/unit/ai/scripts/wakeSafetyGate.spec.mjs
+++ b/test/playwright/unit/ai/scripts/wakeSafetyGate.spec.mjs
@@ -19,6 +19,8 @@ import {randomUUID}      from 'crypto';
 import fs                from 'fs';
 import os                from 'os';
 import path              from 'path';
+import Neo               from '../../../../../src/Neo.mjs';
+import * as core         from '../../../../../src/core/_export.mjs';
 
 /**
  * @summary Validation for the Wake Safety Gate primitive (#10648, child of #10647).


### PR DESCRIPTION
Resolves #11617

Authored by GPT-5.5 (Codex Desktop). Session 019e3d6f-58a5-7100-b41d-639a026d9049.

FAIR-band: in-band [10/30 — current author count over last 30 merged]

Restores standalone execution for the `test/playwright/unit/ai/scripts/*.spec.mjs` specs that call the shared Playwright `setup()` helper by importing the Neo core augmentation pair those specs were missing. The focused failure was `TypeError: Neo.ns is not a function` from `test/playwright/setup.mjs:73`, which comes from loading setup without `src/core/_export.mjs` side effects.

The fix also serializes three focused script specs whose tests share identity-derived lock or state files. That keeps the focused commands deterministic after the `Neo.ns` bootstrap issue is removed.

Evidence: L2 (focused Playwright unit execution for setup-consuming ai/scripts specs) -> L2 required (unit-test substrate stability for script specs). Residual: none.

## Deltas from ticket
The ticket targeted the missing core augmentation import. During verification, the same focused surface exposed same-file races in `idleOutNudge`, `inflightLock`, and `trioWakeCooldown`; those specs are now marked serial because their tests intentionally share lock or cooldown state paths.

## Test Evidence
- `node --check` passed for all 9 modified `test/playwright/unit/ai/scripts/*.spec.mjs` files.
- `git diff --check` passed.
- `node buildScripts/util/check-whitespace.mjs` passed.
- `npm run test-unit -- test/playwright/unit/ai/scripts/trioWakeCooldown.spec.mjs` passed: 3 passed.
- `npm run test-unit -- test/playwright/unit/ai/scripts/wakeSafetyGate.spec.mjs` passed: 11 passed.
- Sequential focused verification across the 9 modified specs passed: 64 passed, 2 skipped. The commands were run per-file because a single cross-file run still shares external script-state paths that are not isolated by this ticket.

## Post-Merge Validation
- [ ] Confirm GitHub `unit` remains green on the PR head.

## Commit
- `c08229620` — `fix(test): stabilize ai scripts focused specs (#11617)`