### PR TITLE
docs(test): document Neo setup import pair (#11619)

### DIFF
--- a/.agents/skills/unit-test/references/unit-test.md
+++ b/.agents/skills/unit-test/references/unit-test.md
@@ -50,8 +50,8 @@ To understand the "Neo.mjs Way", you **MUST** read these examples:
 - **Environment:** Global `Neo` namespace persists across tests in the same file.
 
 ### Critical Rules (Zero Tolerance)
-1.  **Import Core Augmentation:** You **MUST** import `src/core/_export.mjs` in every test file.
-    - *Why:* `Neo.mjs` does not include utilities like `Neo.isString` or `Neo.isEqual`. Without this, tests will fail mysteriously.
+1.  **Import Neo + Core Augmentation:** You **MUST** import `src/Neo.mjs` and `src/core/_export.mjs` in every test file that depends on Neo globals or the shared `test/playwright/setup.mjs` helper.
+    - *Why:* `src/Neo.mjs` initializes the global Neo namespace and defines helpers like `Neo.ns`; `src/core/_export.mjs` augments that namespace with utilities like `Neo.isString` or `Neo.isEqual`. Missing `src/Neo.mjs` surfaces as setup-driven errors like `TypeError: Neo.ns is not a function`; missing `src/core/_export.mjs` surfaces later as absent core utilities.
 2.  **Unique Neo ClassNames:** The `className` config property defines the namespace and **MUST** be unique across the entire test suite.
     - The JavaScript class symbol (e.g., `class MyButton`) does not affect the namespace and can be anything.
     - **Requirement:** Use a verbose, specific namespace for the `className` config.


### PR DESCRIPTION
Resolves #11619

Authored by GPT-5.5 (Codex Desktop). Session b61cfc87-e697-4395-a9d5-831f03fd8994.

FAIR-band: in-band [10/30 — current author count over last 30 merged]

Updates the `unit-test` skill payload so setup-consuming unit specs carry the full Neo bootstrap import-pair contract: `src/Neo.mjs` initializes the global Neo namespace, and `src/core/_export.mjs` augments it with utilities. This captures the #11617/#11618 focused-run failure mode without expanding the lightweight skill router or always-loaded AGENTS substrate.

Evidence: L1 (static payload diff + skill/substrate lint) → L1 required (skill-doc contract update). Residual: none.

## Deltas from ticket
No scope additions. The implementation stays payload-scoped in `.agents/skills/unit-test/references/unit-test.md`; it does not touch `.agents/skills/unit-test/SKILL.md`, `AGENTS.md`, or test files.

## Slot Rationale

**Modified substrate:** `.agents/skills/unit-test/references/unit-test.md` — skill-loaded payload.

**Disposition delta:** `rewrite` — existing Critical Rule 1 already required `src/core/_export.mjs`; this PR rewrites that line to name the full `src/Neo.mjs` + `src/core/_export.mjs` pair and the concrete focused-run failure symptom.

**3-axis rating:**
- Trigger-frequency: medium — fires only during unit-test skill usage, not every turn.
- Failure-severity: medium — missing the rule causes focused test failures and MX review churn, but not production runtime breakage.
- Enforceability: discipline-first with partial CI feedback — focused test runs catch existing files, but future authoring needs the skill guidance.

**Decay mitigation:** the rule remains in the conditionally loaded unit-test payload, not in always-loaded AGENTS substrate. If a future mechanical linter enforces setup-consuming spec imports, this prose can compress to a pointer or retire.

## Test Evidence
- `node ai/scripts/lint-agents.mjs --base origin/dev` passed.
- `node ai/scripts/check-substrate-size.mjs` passed.
- `node ai/scripts/lint-skill-manifest.mjs --base origin/dev` passed.
- `git diff --check` passed.
- `node buildScripts/util/check-whitespace.mjs .agents/skills/unit-test/references/unit-test.md` passed.

## Post-Merge Validation
- [ ] Next setup-consuming unit-test authoring pass sees the explicit `Neo.mjs` + `core/_export.mjs` import-pair rule in `/unit-test`.

## Commit
- `604b0ad4b` — `docs(test): document Neo setup import pair (#11619)`