### PR TITLE
feat(agentos): codify resolves keyword convention (#10755)

### DIFF
--- a/.agents/skills/pull-request/references/pull-request-workflow.md
+++ b/.agents/skills/pull-request/references/pull-request-workflow.md
@@ -125,7 +125,7 @@ Decision rule: *"Does this enable a new capability that did not exist before?"* 
 
 ## 4. Pull Request Creation
 
-You MUST use the GitHub CLI to open a Pull Request targeting the `dev` branch. 
+You MUST use the GitHub CLI to open a Pull Request targeting the `dev` branch.
 
 If the PR changes `ai/mcp/server/<name>/config.template.mjs`, read `.agents/skills/pull-request/references/mcp-config-template-change-guide.md` before finalizing the PR body.
 
@@ -264,7 +264,7 @@ To prevent redundant parallel effort and reviewer collision, you MUST adhere to 
 
 6. **Cross-Reviewer Divergence Routing:** When a PR uses the Architectural-Pillar Exception and the two `independent-reviewer`s formally disagree (e.g., one issues `Approved`, the other issues `Request Changes`), the swarm has reached a deadlock. Because the core Triad Swarm consists of exactly three members (Author + 2 Reviewers), there is no remaining peer to act as a tie-breaker. Trigger fires when divergence PERSISTS after one calibration cycle. If either reviewer self-corrects within their next turn (per `feedback_pr_review_iteration_calibration.md` audit-letter discipline), escalation is not yet warranted. Escalate only when both reviewers have re-engaged after seeing each other's positions and still hold divergent verdicts.
    - **Escalation Mandate:** The Author MUST escalate the divergence to human review. The Author is strictly forbidden from breaking the tie themselves.
-   - **GitHub Layer:** 
+   - **GitHub Layer:**
      - The Author MUST post a comment on the PR containing the tag `[CROSS_REVIEWER_DIVERGENCE_ESCALATION]`, objectively summarizing the architectural tension between both reviewers' positions.
      - The Author MUST call `manage_pr_reviewers` (`action: 'add'`) to explicitly request review from the human repository owner (`@tobiu`).
    - **A2A Layer:** The Author MUST send an A2A ping to both independent reviewers notifying them of the escalation.
@@ -335,7 +335,7 @@ You are strictly FORBIDDEN from using magic close keywords (e.g., `Closes #N`, `
 - You may only use magic close keywords on leaf sub-issues that the PR fully implements.
 
 **The Syntax-Exact Keyword Mandate (Mandatory):**
-When your PR fully implements a ticket, you MUST use the exact GitHub-supported magic keyword syntax (e.g., `Resolves #N` or `Closes #N`) on its own line. 
+When your PR fully implements a ticket, you MUST use the exact GitHub-supported magic keyword syntax on its own line. Prefer `Resolves #N` for shipped work, or `Fixes #N` for bugs; avoid `Closes #N` unless the semantics are "closed but not necessarily delivered" such as not-planned, superseded, or dropped scope.
 You are strictly FORBIDDEN from embedding the closing keyword in a conversational sentence (e.g., "Closes Sub 3 of Epic #X (#Y)"). GitHub's parser requires strict syntax to establish the automatic close link. If you fail to use the exact syntax, the ticket will remain open after merge.
 **Multiple Tickets Loophole:** While we strive for a 1-Ticket-to-1-PR ratio, if your PR fully resolves multiple tickets, you MUST flag each one individually. Do NOT use comma-separated lists like `Resolves #X, #Y`. Instead, use a distinct line for each ticket:
 `Resolves #X`

--- a/learn/agentos/DreamPipeline.md
+++ b/learn/agentos/DreamPipeline.md
@@ -260,8 +260,11 @@ PR reviews are scanned for three structured tags:
 | `[RETROSPECTIVE]` | Architectural insight or lesson learned |
 
 These are extracted into dedicated graph nodes with Hebbian edges linking them
-back to their source PR. `Resolves #NNN` patterns also create `RESOLVES` edges,
-closing the feedback loop between PRs and the issues they address.
+back to their source PR. `Resolves #NNN` patterns are the canonical shipped-work
+form for creating `RESOLVES` edges, closing the feedback loop between PRs and the
+issues they address. The current ingestor is intentionally liberal and also
+accepts `Fixes` and `Closes`; narrowing `Closes` remains an open logic question
+because that keyword can also describe not-planned, superseded, or dropped scope.
 
 ## TTL Pruning (Stale Gap Removal)
 


### PR DESCRIPTION
Resolves #10755

Authored by GPT-5 (Codex Desktop). Session b61cfc87-e697-4395-a9d5-831f03fd8994.
FAIR-band: in-band [12/30 - current author count over last 30 merged]

Codifies the shipped-work keyword convention in the PR workflow and aligns DreamPipeline docs with the current ingestion reality: `Resolves` is canonical for shipped work, `Fixes` is bug-appropriate, and `Closes` should stay reserved for non-delivery semantics until the ingestor logic is narrowed.

Evidence: L1 (static docs/workflow substrate audit + lints) -> L1 required (documentation convention close-target). No residuals.

## Slot Rationale
- Modified `.agents/skills/pull-request/references/pull-request-workflow.md`: disposition remains `keep` within the PR-open reference payload; delta clarifies an existing mandatory PR-body syntax rule without adding new always-loaded trigger surface. Rating: high trigger-frequency x medium failure-severity x high enforceability.
- Modified `learn/agentos/DreamPipeline.md`: disposition remains `keep` in the Dream Pipeline guide; delta documents current permissive ingestor semantics so future readers do not infer a code constraint that does not exist yet. Rating: medium trigger-frequency x medium failure-severity x high enforceability.
- Net substrate effect: no new sections, no new skills, no turn-loaded expansion; 8 insertions / 5 deletions.

## Deltas from ticket
- Deferred `IssueIngestor.mjs` regex tightening. The current parser still accepts `Resolves|Closes|Fixes`; narrowing `Closes` is a logic-gap decision outside this documentation ticket.
- Cleaned two trailing whitespace lines in the touched pull-request workflow file.
- Empirical sample before PR open: latest 100 merged PR bodies contain 87 `Resolves`, 2 `Fixes`, and 1 `Closes` magic keyword line; the `Closes` example is PR #11407.

## Test Evidence
- `git diff --check`
- `node buildScripts/util/check-whitespace.mjs .agents/skills/pull-request/references/pull-request-workflow.md learn/agentos/DreamPipeline.md`
- `node ai/scripts/lint-agents.mjs --base origin/dev`
- `node ai/scripts/check-substrate-size.mjs`
- `node ai/scripts/lint-skill-manifest.mjs --base origin/dev`
- `git merge-base --is-ancestor origin/dev HEAD`
- `gh api -X GET search/issues -f q='repo:neomjs/neo is:pr is:merged' -f sort=updated -f order=desc -f per_page=100 --jq '{sampleSize:(.items|length), resolves:([.items[].body // "" | test("(?im)^Resolves #[0-9]+")]|map(select(.))|length), fixes:([.items[].body // "" | test("(?im)^Fixes #[0-9]+")]|map(select(.))|length), closes:([.items[].body // "" | test("(?im)^Closes #[0-9]+")]|map(select(.))|length), closesExamples:[.items[] | select((.body // "") | test("(?im)^Closes #[0-9]+")) | {number,title}]}'`

## Post-Merge Validation
- [ ] Issue #10755 auto-closes from the PR body's `Resolves #10755` line after human merge.
- [ ] A later logic-gap lane can decide whether `IssueIngestor.mjs` should distinguish shipped-work closure from `Closes` semantics.

## Commits
- `62aad4a20` - `feat(agentos): codify resolves keyword convention (#10755)`
