### PR TITLE
feat(memory-core): Brain-Pillar Consumer-Friction Channel V1 visibility-only (#11447)

### DIFF
--- a/ai/daemons/services/GoldenPathSynthesizer.mjs
+++ b/ai/daemons/services/GoldenPathSynthesizer.mjs
@@ -188,12 +188,12 @@ class GoldenPathSynthesizer extends Base {
         try {
             const placeholders = semanticIds.map(() => '?').join(',');
             const stmt = GraphService.db.storage.db.prepare(`
-                SELECT 
+                SELECT
                     n.id,
                     n.data,
                     COALESCE((
-                        SELECT SUM(json_extract(e.data, '$.properties.weight')) 
-                        FROM Edges e 
+                        SELECT SUM(json_extract(e.data, '$.properties.weight'))
+                        FROM Edges e
                         WHERE e.target = n.id AND e.type != 'BLOCKS'
                     ), 0.0) as struct_score
                 FROM Nodes n
@@ -422,18 +422,39 @@ DO NOT output markdown, \`\`\`json blocks, or any other explanations. Provide pu
             logger.info(`[GoldenPathSynthesizer] TTL Pruning eradicated ${prunedGaps} stale Gaps from the Native Graph.`);
         }
 
+        // --- #11447 Brain-Pillar Consumer-Friction Channel V1 (visibility-only) ---
+        // Surface ConsumerFriction records emitted by upstream brain consumers (e.g.,
+        // SemanticGraphExtractor, SessionService.summarizeSession) when substrate payloads
+        // were the wrong shape for them (context-overflow, parse-failure, size-precheck-skip,
+        // etc.). Visibility-only: no orchestrator routing changes; the section is
+        // human/swarm-reading substrate so operators / peers can see consumer-side friction
+        // and decide whether to adjust upstream emission (e.g. smaller summarization windows,
+        // larger-context consumer choice).
+        try {
+            const {renderConsumerFrictionSection} = await import('../../services/memory-core/helpers/ConsumerFrictionHelper.mjs');
+            const frictionSection = renderConsumerFrictionSection();
+
+            if (frictionSection) {
+                handoffContent += frictionSection + '\n';
+            }
+        } catch (err) {
+            // Defensive: ConsumerFrictionHelper failure must not break handoff rendering.
+            // Log + continue with the rest of the handoff content.
+            logger.warn(`[GoldenPathSynthesizer] ConsumerFriction section render failed: ${err.message}`);
+        }
+
         // --- Active PR Cycle State ---
         let prStateAppend = '';
         try {
             const prs = await this.fetchOpenPRs();
-            
+
             const agentLogins = ['neo-opus-4-7', 'neo-gemini-3-1-pro', 'neo-gpt'];
             const agentPrs = prs.filter(pr => pr.author && agentLogins.includes(pr.author.login));
-            
+
             if (agentPrs.length > 0) {
                 prStateAppend += `\n## Active PR Cycle State\n\n`;
                 prStateAppend += `*Captured at: ${new Date().toISOString()} (Source: GitHub Live)*\n\n`;
-                
+
                 // Group by agent
                 agentLogins.forEach(agent => {
                     const myPrs = agentPrs.filter(pr => pr.author.login === agent);
@@ -452,13 +473,13 @@ DO NOT output markdown, \`\`\`json blocks, or any other explanations. Provide pu
                             if (cycleMatch) {
                                 cycle = cycleMatch[1];
                             }
-                            
+
                             // Combine reviews and comments, sort by creation time (most recent first)
                             const allInteractions = [
                                 ...(pr.reviews || []).map(r => ({ body: r.body, date: new Date(r.submittedAt), state: r.state, type: 'review' })),
                                 ...(pr.comments || []).map(c => ({ body: c.body, date: new Date(c.createdAt), type: 'comment' }))
                             ].sort((a, b) => b.date - a.date);
-                            
+
                             let foundCycle = false;
                             for (const interaction of allInteractions) {
                                 if (laneState === 'unknown') {
@@ -474,10 +495,10 @@ DO NOT output markdown, \`\`\`json blocks, or any other explanations. Provide pu
                                 }
                                 if (laneState !== 'unknown' && foundCycle) break;
                             }
-                            
+
                             // Determine primary reviewer
                             let reviewers = pr.reviewRequests?.map(rr => rr.login).join(', ') || 'None';
-                            
+
                             // Determine status
                             let status = 'Pending';
                             const latestReview = allInteractions.find(i => i.type === 'review');
@@ -491,7 +512,7 @@ DO NOT output markdown, \`\`\`json blocks, or any other explanations. Provide pu
                                     if (match) status = match[1].toUpperCase();
                                 }
                             }
-                            
+
                             prStateAppend += `- **PR #${pr.number}**: [${pr.title}](${pr.url})\n`;
                             prStateAppend += `  - **Lane State**: \`${laneState}\`\n`;
                             prStateAppend += `  - **Cycle**: \`${cycle}\`\n`;

--- a/ai/daemons/services/SemanticGraphExtractor.mjs
+++ b/ai/daemons/services/SemanticGraphExtractor.mjs
@@ -2,6 +2,7 @@ import fs from 'fs';
 import path from 'path';
 import aiConfig from '../../mcp/server/memory-core/config.mjs';
 import Base from '../../../src/core/Base.mjs';
+import {invokeWithGuardrail} from '../../services/memory-core/helpers/ConsumerFrictionHelper.mjs';
 import GraphService from '../../services/memory-core/GraphService.mjs';
 import Json from '../../../src/util/Json.mjs';
 import logger from '../../mcp/server/memory-core/logger.mjs';
@@ -108,11 +109,36 @@ DO NOT output markdown, \`\`\`json blocks, or any other explanations. Provide pu
             let payload = null;
             let result = null;
 
+            // #11447 Brain-Pillar Consumer-Friction Channel V1: wrap each LLM invocation with
+            // bidirectional guardrail. Angle 2 (upstream pre-check) skips invocation when the
+            // composed messages exceed the consumer's safeProcessingLimit (default 80% of
+            // `aiConfig.openAiCompatible.contextWindowBytes`). Angle 1 (downstream try/catch)
+            // categorizes engine-level failures into friction symptoms. Friction is emitted
+            // into the in-memory aggregator for handoff rendering by
+            // `GoldenPathSynthesizer.synthesizeGoldenPath`.
+            const consumerModel        = aiConfig.openAiCompatible.model || 'openAiCompatible';
+            const consumerContextLimit = aiConfig.openAiCompatible.contextWindowBytes || 131072;
+
             while (attempt < maxRetries && !payload) {
                 attempt++;
-                
-                // Call standard generation method explicitly without format enforcement
-                result = await provider.generate(messages);
+
+                const inputPayloadText = messages.map(m => m.content).join('\n');
+                const guardrailed      = await invokeWithGuardrail({
+                    invocationFn      : () => provider.generate(messages),
+                    inputPayload      : inputPayloadText,
+                    model             : consumerModel,
+                    assetRef          : session.meta.sessionId,
+                    modelContextLimit : consumerContextLimit,
+                    consumer          : consumerModel,
+                    workflowUpdateHint: `Reduce Tri-Vector session-aggregation window or switch ${consumerModel} to a larger-context consumer.`
+                });
+
+                if (!guardrailed.result) {
+                    logger.warn(`[SemanticGraphExtractor] Attempt ${attempt}: invocation guardrail emitted ${guardrailed.friction?.symptom} for session ${session.meta.sessionId}; aborting retry loop.`);
+                    return null;
+                }
+
+                result = guardrailed.result;
 
                 // Extract using robust Json parser to catch malformed boundaries
                 payload = Json.extract(result.content);
@@ -120,12 +146,12 @@ DO NOT output markdown, \`\`\`json blocks, or any other explanations. Provide pu
                 // Validation check
                 if (!payload || !payload.session_artifact) {
                     logger.warn(`[SemanticGraphExtractor] Attempt ${attempt}: Failed to validate extracted Tri-Vector A2A payload for session: ${session.meta.sessionId}`);
-                    
+
                     if (attempt < maxRetries) {
                         logger.warn(`[SemanticGraphExtractor] Attempt ${attempt}: Injecting autonomous JSON repair feedback loop.`);
                         messages.push({ role: 'assistant', content: result.content });
-                        messages.push({ 
-                            role: 'user', 
+                        messages.push({
+                            role: 'user',
                             content: `Your previous response failed internal schema validation. You are missing required keys (e.g., session_artifact) or you provided malformed JSON. Please correct your output and provide ONLY the exact JSON shape requested in the instructions.`
                         });
                         payload = null; // Ensure loop continues
@@ -144,7 +170,7 @@ DO NOT output markdown, \`\`\`json blocks, or any other explanations. Provide pu
                     }
                 }
             }
-            
+
             if (!payload) {
                 return null;
             }
@@ -170,10 +196,10 @@ DO NOT output markdown, \`\`\`json blocks, or any other explanations. Provide pu
             // Bridge to GraphService (SQLite)
             for (const node of artifact.graph.nodes) {
                 if (node.id === 'frontier') continue;
-                
+
                 let nodeType = node.type && VALID_TYPES.includes(node.type.toUpperCase()) ? node.type.toUpperCase() : 'CONCEPT';
                 let nodeId = node.id;
-                
+
                 // Enforce Neo native Graph ID specification (Type:Name) if hallucinated
                 if (!nodeId.includes(':')) {
                     const cleanName = (node.name || nodeId).replace(/[^a-zA-Z0-9_\-\.]/g, '_');
@@ -196,9 +222,9 @@ DO NOT output markdown, \`\`\`json blocks, or any other explanations. Provide pu
                         context_source: session.meta.sessionId
                     }
                 });
-                
+
                 // Update the payload graph node id so edges bind correctly
-                node._resolvedId = nodeId; 
+                node._resolvedId = nodeId;
             }
 
             const validNodeRefs = new Set([...artifact.graph.nodes.map(n => n.id), ...artifact.graph.nodes.map(n => n._resolvedId), 'frontier']);
@@ -207,10 +233,10 @@ DO NOT output markdown, \`\`\`json blocks, or any other explanations. Provide pu
                 // Map the original edge source/target to the resolved Node IDs
                 let resolvedSource = edge.source;
                 let resolvedTarget = edge.target;
-                
+
                 const sourceNode = artifact.graph.nodes.find(n => n.id === edge.source);
                 if (sourceNode && sourceNode._resolvedId) resolvedSource = sourceNode._resolvedId;
-                
+
                 const targetNode = artifact.graph.nodes.find(n => n.id === edge.target);
                 if (targetNode && targetNode._resolvedId) resolvedTarget = targetNode._resolvedId;
 
@@ -220,12 +246,12 @@ DO NOT output markdown, \`\`\`json blocks, or any other explanations. Provide pu
                 if (!sourceExists || !targetExists) {
                     const isProvenance = ['MENTIONED_IN', 'DISCUSSED_IN', 'REFERENCED_BY'].includes(edge.relationship);
                     const targetsSessionOrMemory = resolvedTarget.startsWith('SESSION:') || resolvedTarget.startsWith('MEMORY:') || resolvedSource.startsWith('SESSION:') || resolvedSource.startsWith('MEMORY:');
-                    
+
                     if (isProvenance && targetsSessionOrMemory) {
                         /**
                          * @summary Provenance Edge Lazy-Queue Strategy
-                         * Provenance edges (MENTIONED_IN, DISCUSSED_IN, REFERENCED_BY) linking to past sessions/memories 
-                         * may reference nodes not in the current payload or synchronous graph cache. 
+                         * Provenance edges (MENTIONED_IN, DISCUSSED_IN, REFERENCED_BY) linking to past sessions/memories
+                         * may reference nodes not in the current payload or synchronous graph cache.
                          * Instead of dropping them as invalid, we route them to a JSONL backfill queue.
                          * Consumer-side draining and retry logic is handled under Epic #10153.
                          */
@@ -342,15 +368,15 @@ DO NOT output markdown, \`\`\`json blocks, or any other explanations. Provide pu
                     logger.warn(`[SemanticGraphExtractor] Attempt ${attempt}: Failed to validate extracted concepts schema for message.`);
                     if (attempt < maxRetries) {
                         messages.push({ role: 'assistant', content: result.content });
-                        messages.push({ 
-                            role: 'user', 
+                        messages.push({
+                            role: 'user',
                             content: `Your previous response failed internal schema validation. You are either missing the 'concepts' array or provided malformed JSON. Please correct your output and provide ONLY the exact JSON shape requested.`
                         });
                         payload = null;
                     }
                 }
             }
-            
+
             if (!payload || !Array.isArray(payload.concepts)) {
                 return [];
             }

--- a/ai/daemons/services/SemanticGraphExtractor.mjs
+++ b/ai/daemons/services/SemanticGraphExtractor.mjs
@@ -110,27 +110,31 @@ DO NOT output markdown, \`\`\`json blocks, or any other explanations. Provide pu
             let result = null;
 
             // #11447 Brain-Pillar Consumer-Friction Channel V1: wrap each LLM invocation with
-            // bidirectional guardrail. Angle 2 (upstream pre-check) skips invocation when the
-            // composed messages exceed the consumer's safeProcessingLimit (default 80% of
-            // `aiConfig.openAiCompatible.contextWindowBytes`). Angle 1 (downstream try/catch)
+            // bidirectional guardrail per Discussion #11444 graduation contract. Angle 2
+            // (upstream pre-check) skips invocation when the composed messages' estimated
+            // token count exceeds the consumer's safe processing band (default 75% of
+            // `aiConfig.openAiCompatible.contextLimitTokens`). Angle 1 (downstream try/catch)
             // categorizes engine-level failures into friction symptoms. Friction is emitted
-            // into the in-memory aggregator for handoff rendering by
-            // `GoldenPathSynthesizer.synthesizeGoldenPath`.
-            const consumerModel        = aiConfig.openAiCompatible.model || 'openAiCompatible';
-            const consumerContextLimit = aiConfig.openAiCompatible.contextWindowBytes || 131072;
+            // into the in-memory aggregator (with `serviceDomain: 'dream-pipeline'`) for
+            // handoff rendering by `GoldenPathSynthesizer.synthesizeGoldenPath`.
+            const consumerModel          = aiConfig.openAiCompatible.model || 'openAiCompatible';
+            const consumerContextTokens  = aiConfig.openAiCompatible.contextLimitTokens || 32768;
+            const consumerSafeTokens     = aiConfig.openAiCompatible.safeProcessingLimitTokens;
 
             while (attempt < maxRetries && !payload) {
                 attempt++;
 
                 const inputPayloadText = messages.map(m => m.content).join('\n');
                 const guardrailed      = await invokeWithGuardrail({
-                    invocationFn      : () => provider.generate(messages),
-                    inputPayload      : inputPayloadText,
-                    model             : consumerModel,
-                    assetRef          : session.meta.sessionId,
-                    modelContextLimit : consumerContextLimit,
-                    consumer          : consumerModel,
-                    workflowUpdateHint: `Reduce Tri-Vector session-aggregation window or switch ${consumerModel} to a larger-context consumer.`
+                    invocationFn             : () => provider.generate(messages),
+                    inputPayload             : inputPayloadText,
+                    model                    : consumerModel,
+                    assetRef                 : session.meta.sessionId,
+                    consumer                 : 'SemanticGraphExtractor',
+                    contextLimitTokens       : consumerContextTokens,
+                    safeProcessingLimitTokens: consumerSafeTokens,
+                    serviceDomain            : 'dream-pipeline',
+                    note                     : `Tri-Vector session-aggregation attempt ${attempt} of ${maxRetries}`
                 });
 
                 if (!guardrailed.result) {

--- a/ai/mcp/server/memory-core/config.template.mjs
+++ b/ai/mcp/server/memory-core/config.template.mjs
@@ -160,16 +160,28 @@ const defaultConfig = {
         unloadRetryCount: 3,
         unloadRetryDelayMs: 500,
         /**
-         * Approximate context-window capacity in bytes for the configured `model`.
-         * Used by `ConsumerFrictionHelper.invokeWithGuardrail` (#11447) to fire the
-         * upstream pre-check skip ("Angle 2") when an LLM input payload exceeds the
-         * consumer's safe processing band (default 80% of this cap). Default is sized
-         * for Gemma-3-4B / Qwen3-8B class consumers (~32K-token context = ~131072 bytes
-         * at the ~4-chars/token heuristic). Operators running models with different
-         * context windows should tune this to match the deployed model.
+         * Configured context-window capacity of `model` measured in **tokens**.
+         * Token-based per the Discussion #11444 / #11447 V1 graduation contract.
+         * Used by `ConsumerFrictionHelper.invokeWithGuardrail` to fire the upstream
+         * pre-check skip ("Angle 2") when an LLM input payload exceeds the consumer's
+         * safe processing band. Default is sized for Gemma-3-4B / Qwen3-8B class
+         * consumers (~32K-token context). Operators running models with different
+         * context windows should tune this to match the deployed model — e.g. 8192
+         * for Gemma-4-8B-IT, 131072 for Llama-3.1-70B 128K-context variants.
          * @type {number}
          */
-        contextWindowBytes: 131072
+        contextLimitTokens: 32768,
+        /**
+         * Optional safer processing threshold (tokens) below `contextLimitTokens` for
+         * the upstream pre-check skip. When the estimated input token count exceeds
+         * this value, `invokeWithGuardrail` emits a `size-precheck-skip` friction and
+         * does NOT invoke the consumer model. Defaults to 75% of `contextLimitTokens`
+         * when unset — leaves ~25% headroom for system-prompt envelope, repair-cycle
+         * prompt growth, and output-token reservation per Discussion #11444 Round-2
+         * consensus.
+         * @type {number|undefined}
+         */
+        safeProcessingLimitTokens: undefined
     },
     /**
      * The enforced vector dimension across all SQLite collections.

--- a/ai/mcp/server/memory-core/config.template.mjs
+++ b/ai/mcp/server/memory-core/config.template.mjs
@@ -158,7 +158,18 @@ const defaultConfig = {
         embeddingModel: 'text-embedding-qwen3-embedding-8b',
         apiKey        : '',
         unloadRetryCount: 3,
-        unloadRetryDelayMs: 500
+        unloadRetryDelayMs: 500,
+        /**
+         * Approximate context-window capacity in bytes for the configured `model`.
+         * Used by `ConsumerFrictionHelper.invokeWithGuardrail` (#11447) to fire the
+         * upstream pre-check skip ("Angle 2") when an LLM input payload exceeds the
+         * consumer's safe processing band (default 80% of this cap). Default is sized
+         * for Gemma-3-4B / Qwen3-8B class consumers (~32K-token context = ~131072 bytes
+         * at the ~4-chars/token heuristic). Operators running models with different
+         * context windows should tune this to match the deployed model.
+         * @type {number}
+         */
+        contextWindowBytes: 131072
     },
     /**
      * The enforced vector dimension across all SQLite collections.
@@ -380,7 +391,7 @@ const envBindings = {
     'transport': 'NEO_TRANSPORT',
     'mcpHttpPort': { var: 'MCP_HTTP_PORT', parse: parsePort },
     'publicUrl': { var: 'NEO_PUBLIC_URL', parse: parseUrl },
-    
+
     'auth.host': 'NEO_AUTH_HOST',
     'auth.port': { var: 'NEO_AUTH_PORT', parse: parsePort },
     'auth.realm': 'NEO_AUTH_REALM',
@@ -388,39 +399,39 @@ const envBindings = {
     'auth.clientId': 'NEO_OAUTH_CLIENT_ID',
     'auth.clientSecret': 'NEO_OAUTH_CLIENT_SECRET',
     'auth.trustProxyIdentity': { var: 'NEO_AUTH_TRUST_PROXY_IDENTITY', parse: parseBool },
-    
+
     'modelProvider': 'NEO_MODEL_PROVIDER',
     'embeddingProvider': 'NEO_EMBEDDING_PROVIDER',
-    
+
     'ollama.host': 'NEO_OLLAMA_HOST',
     'ollama.model': 'NEO_OLLAMA_MODEL',
     'ollama.embeddingModel': 'NEO_OLLAMA_EMBEDDING_MODEL',
-    
+
     'openAiCompatible.host': 'NEO_OPENAI_COMPATIBLE_HOST',
     'openAiCompatible.model': 'NEO_OPENAI_COMPATIBLE_MODEL',
     'openAiCompatible.embeddingModel': 'NEO_OPENAI_COMPATIBLE_EMBEDDING_MODEL',
     'openAiCompatible.apiKey': 'NEO_OPENAI_COMPATIBLE_API_KEY',
     'openAiCompatible.unloadRetryCount': { var: 'NEO_OPENAI_COMPATIBLE_UNLOAD_RETRY_COUNT', parse: parseNumber },
     'openAiCompatible.unloadRetryDelayMs': { var: 'NEO_OPENAI_COMPATIBLE_UNLOAD_RETRY_DELAY_MS', parse: parseNumber },
-    
+
     'vectorDimension': { var: 'NEO_VECTOR_DIMENSION', parse: parseNumber },
-    
+
     'engines.chroma.host': 'NEO_CHROMA_HOST',
     'engines.chroma.port': { var: 'NEO_CHROMA_PORT', parse: parsePort },
-    
+
     'collections.memory': 'NEO_MEMORY_COLLECTION_NAME',
     'collections.session': 'NEO_SESSION_COLLECTION_NAME',
     'collections.graph': 'NEO_GRAPH_COLLECTION_NAME',
-    
+
     'storagePaths.graph': 'NEO_MEMORY_DB_PATH',
-    
+
     'datasets.rlaif.trajectories': 'NEO_RLAIF_PATH',
     'decayFactor': { var: 'NEO_GRAPH_DECAY_FACTOR', parse: parseNumber },
     'guideGapWeightThreshold': { var: 'NEO_GUIDE_GAP_WEIGHT_THRESHOLD', parse: parseNumber },
-    
+
     'conceptDiscovery.prScanLimit': { var: 'NEO_CONCEPT_DISCOVERY_PR_SCAN_LIMIT', parse: parseNumber },
     'conceptDiscovery.minSourceLength': { var: 'NEO_CONCEPT_DISCOVERY_MIN_SOURCE_LENGTH', parse: parseNumber },
-    
+
     'mailbox.defaultReplyPolicy': 'NEO_MAILBOX_DEFAULT_REPLY_POLICY',
     'memorySharing.defaultPolicy': { var: 'NEO_MEMORY_SHARING_DEFAULT_POLICY', parse: parseMemorySharingPolicy },
     'lazyEdgesQueuePath': 'NEO_LAZY_EDGES_QUEUE_PATH'
@@ -451,7 +462,7 @@ class Config extends BaseConfig {
 
     defaultConfig = defaultConfig;
     envBindings = envBindings;
-    
+
     /**
      * Applies legacy environment variable fallbacks
      */
@@ -464,17 +475,17 @@ class Config extends BaseConfig {
                 this.data.mcpHttpPort = legacyPort;
             }
         }
-        
+
         if (process.env.NEO_CHROMA_EMBEDDING_PROVIDER && !process.env.NEO_EMBEDDING_PROVIDER) {
             console.warn('[Config] Deprecation warning: NEO_CHROMA_EMBEDDING_PROVIDER is deprecated. Please use NEO_EMBEDDING_PROVIDER.');
             this.data.embeddingProvider = process.env.NEO_CHROMA_EMBEDDING_PROVIDER;
         }
-        
+
         if (process.env.NEO_KB_CHROMA_HOST && !process.env.NEO_CHROMA_HOST) {
             console.warn('[Config] Deprecation warning: NEO_KB_CHROMA_HOST is deprecated. Please use NEO_CHROMA_HOST.');
             this.data.engines.chroma.host = process.env.NEO_KB_CHROMA_HOST;
         }
-        
+
         if (process.env.NEO_KB_CHROMA_PORT && !process.env.NEO_CHROMA_PORT) {
             console.warn('[Config] Deprecation warning: NEO_KB_CHROMA_PORT is deprecated. Please use NEO_CHROMA_PORT.');
             const legacyPort = parsePort(process.env.NEO_KB_CHROMA_PORT, 'NEO_KB_CHROMA_PORT', console.warn);

--- a/ai/services/memory-core/SessionService.mjs
+++ b/ai/services/memory-core/SessionService.mjs
@@ -463,22 +463,27 @@ ${aggregatedContent}
 `;
 
         // #11447 Brain-Pillar Consumer-Friction Channel V1: wrap the summarization LLM
-        // invocation with bidirectional guardrail. Angle 2 (upstream pre-check) skips
-        // invocation when `summaryPrompt` exceeds the consumer's safeProcessingLimit;
-        // Angle 1 (downstream try/catch) categorizes engine-level failures into friction
-        // symptoms. Friction surfaces in the GoldenPath handoff for swarm visibility.
-        const consumerModel        = aiConfig.modelProvider === 'openAiCompatible'
+        // invocation with bidirectional guardrail per Discussion #11444 graduation contract.
+        // Angle 2 (upstream pre-check) skips invocation when the estimated tokens for
+        // `summaryPrompt` exceed the consumer's safe processing band; Angle 1 (downstream
+        // try/catch) categorizes engine-level failures into friction symptoms. Friction is
+        // emitted with `serviceDomain: 'memory-core'` for handoff rendering by
+        // `GoldenPathSynthesizer.synthesizeGoldenPath`.
+        const consumerModel         = aiConfig.modelProvider === 'openAiCompatible'
             ? (aiConfig.openAiCompatible.model || 'openAiCompatible')
             : (aiConfig.modelName || 'gemini');
-        const consumerContextLimit = aiConfig.openAiCompatible?.contextWindowBytes || 131072;
-        const guardrailed          = await invokeWithGuardrail({
-            invocationFn      : () => this.model.generateContent(summaryPrompt),
-            inputPayload      : summaryPrompt,
-            model             : consumerModel,
-            assetRef          : sessionId,
-            modelContextLimit : consumerContextLimit,
-            consumer          : consumerModel,
-            workflowUpdateHint: `Reduce session summarization batch (currently ${aiConfig.summarizationBatchLimit || 'unset'}) or switch ${consumerModel} to a larger-context consumer.`
+        const consumerContextTokens = aiConfig.openAiCompatible?.contextLimitTokens || 32768;
+        const consumerSafeTokens    = aiConfig.openAiCompatible?.safeProcessingLimitTokens;
+        const guardrailed           = await invokeWithGuardrail({
+            invocationFn             : () => this.model.generateContent(summaryPrompt),
+            inputPayload             : summaryPrompt,
+            model                    : consumerModel,
+            assetRef                 : sessionId,
+            consumer                 : 'SessionService.summarizeSession',
+            contextLimitTokens       : consumerContextTokens,
+            safeProcessingLimitTokens: consumerSafeTokens,
+            serviceDomain            : 'memory-core',
+            note                     : `summarizationBatchLimit=${aiConfig.summarizationBatchLimit || 'unset'}`
         });
 
         if (!guardrailed.result) {

--- a/ai/services/memory-core/SessionService.mjs
+++ b/ai/services/memory-core/SessionService.mjs
@@ -1,6 +1,7 @@
 import { GoogleGenerativeAI } from '@google/generative-ai';
 import aiConfig from '../../mcp/server/memory-core/config.mjs';
 import Base from '../../../src/core/Base.mjs';
+import {invokeWithGuardrail} from './helpers/ConsumerFrictionHelper.mjs';
 import crypto from 'crypto';
 import GraphService from './GraphService.mjs';
 import OpenAiCompatibleProvider from '../../provider/OpenAiCompatible.mjs';
@@ -461,7 +462,31 @@ Unique Tools Utilized: ${Array.from(allToolsUsed).join(', ') || 'none recorded'}
 ${aggregatedContent}
 `;
 
-        const result = await this.model.generateContent(summaryPrompt);
+        // #11447 Brain-Pillar Consumer-Friction Channel V1: wrap the summarization LLM
+        // invocation with bidirectional guardrail. Angle 2 (upstream pre-check) skips
+        // invocation when `summaryPrompt` exceeds the consumer's safeProcessingLimit;
+        // Angle 1 (downstream try/catch) categorizes engine-level failures into friction
+        // symptoms. Friction surfaces in the GoldenPath handoff for swarm visibility.
+        const consumerModel        = aiConfig.modelProvider === 'openAiCompatible'
+            ? (aiConfig.openAiCompatible.model || 'openAiCompatible')
+            : (aiConfig.modelName || 'gemini');
+        const consumerContextLimit = aiConfig.openAiCompatible?.contextWindowBytes || 131072;
+        const guardrailed          = await invokeWithGuardrail({
+            invocationFn      : () => this.model.generateContent(summaryPrompt),
+            inputPayload      : summaryPrompt,
+            model             : consumerModel,
+            assetRef          : sessionId,
+            modelContextLimit : consumerContextLimit,
+            consumer          : consumerModel,
+            workflowUpdateHint: `Reduce session summarization batch (currently ${aiConfig.summarizationBatchLimit || 'unset'}) or switch ${consumerModel} to a larger-context consumer.`
+        });
+
+        if (!guardrailed.result) {
+            logger.warn(`[SessionService] summarizeSession: invocation guardrail emitted ${guardrailed.friction?.symptom} for session ${sessionId}; skipping summary.`);
+            return null;
+        }
+
+        const result = guardrailed.result;
         const responseText = result.response.text();
         const summaryData = Json.extract(responseText);
 

--- a/ai/services/memory-core/helpers/ConsumerFrictionHelper.mjs
+++ b/ai/services/memory-core/helpers/ConsumerFrictionHelper.mjs
@@ -1,0 +1,323 @@
+/**
+ * @summary Brain-Pillar Consumer-Friction Channel V1 — visibility-only.
+ *
+ * Local-model substrate consumers (e.g. Gemma 4-31b, Qwen3-8b) emit `ConsumerFriction` records
+ * when the substrate payload is the wrong shape for them: context overflow, parse failure,
+ * pre-invocation size-precheck skip, etc. V1 is **visibility-only**: emitted frictions accumulate
+ * in an in-memory aggregator and surface in the next `GoldenPathSynthesizer.synthesizeGoldenPath`
+ * handoff section. No `AgentOrchestrator.parseGoldenPath()` routing changes; no auto-mutation of
+ * caller behavior beyond the explicit pre-check skip.
+ *
+ * Bidirectional defense (per Discussion #11444 graduation):
+ * - **Angle 1 (downstream)**: `invokeWithGuardrail` wraps the LLM invocation in try/catch and
+ *   categorizes failures (`context-overflow` / `parse-failure` / `timeout`) into a
+ *   ConsumerFriction record before returning `{result: null, friction}`.
+ * - **Angle 2 (upstream)**: pre-checks `Buffer.byteLength(inputPayload)` against the consumer's
+ *   `safeProcessingLimit` (defaults to 80% of `modelContextLimit`); over-budget input skips
+ *   the invocation and emits a `size-precheck-skip` friction.
+ *
+ * Debounce policy:
+ * - **Deterministic symptoms** (`size-precheck-skip`, `context-overflow`) surface on the
+ *   first occurrence — these are direct evidence of payload-shape mismatch and should not
+ *   be swallowed by aggregation.
+ * - **Probabilistic symptoms** (`parse-failure`, `timeout`, `token-budget-exceeded`,
+ *   `semantic-confusion`) aggregate by `(assetRef, consumer, symptom)` tuple. They surface
+ *   once `count >= PROBABILISTIC_EMIT_THRESHOLD` to avoid burying single transient errors
+ *   in the handoff feed.
+ *
+ * Token-vs-bytes note: this V1 helper measures input size in **bytes** via
+ * `Buffer.byteLength(payload, 'utf8')` because the codebase has no canonical token-counting
+ * utility. Callers passing `modelContextLimit` should pass byte-equivalent thresholds (or
+ * convert from token-counts using ~4 chars/token rough heuristic for English text). Future
+ * V2 may integrate with the Model-Stats registry (ADR 0012) for provider-specific tokenization.
+ *
+ * @see learn/agentos/decisions/0012-model-stats-framework.md
+ * @see ai/daemons/services/GoldenPathSynthesizer.mjs (handoff section consumer)
+ * @see ai/daemons/services/SemanticGraphExtractor.mjs (canonical emitter — Dream Pipeline)
+ * @see ai/services/memory-core/SessionService.mjs#summarizeSession (canonical emitter — Memory Core)
+ */
+
+/**
+ * @typedef {Object} ConsumerFriction
+ * @property {String} model Consumer model identifier (e.g. 'gemma4-31b', 'qwen3-8b').
+ * @property {'context-overflow' | 'parse-failure' | 'token-budget-exceeded' | 'semantic-confusion' | 'timeout' | 'size-precheck-skip'} symptom Friction symptom enum.
+ * @property {'pre-invocation' | 'post-invocation-failure'} emissionPoint When the friction was detected.
+ * @property {Number} inputBytes Byte size of the payload that triggered the friction.
+ * @property {Number} modelContextLimit Configured context limit for the consumer (bytes).
+ * @property {Number} [safeProcessingLimit] Optional safer threshold (bytes); defaults to 80% of modelContextLimit.
+ * @property {String} workflowUpdateSuggestion Operator/swarm-facing actionable suggestion.
+ * @property {String} timestamp ISO 8601 emission time.
+ * @property {String} assetRef Origin identifier (sessionId, documentId, etc.) — first member of aggregation tuple.
+ * @property {String} consumer Same as model; kept explicit for the (assetRef, consumer, symptom) tuple semantics.
+ */
+
+const DETERMINISTIC_SYMPTOMS = new Set(['size-precheck-skip', 'context-overflow']);
+
+/**
+ * @summary Probabilistic-symptom emit threshold — surfaces aggregated frictions when count reaches this.
+ * Single transient parse-failures are absorbed; persistent patterns surface for handoff.
+ * @type {Number}
+ */
+const PROBABILISTIC_EMIT_THRESHOLD = 3;
+
+/**
+ * @summary TTL window for aggregator entries — older entries are pruned at the next read.
+ * One hour matches typical REM cycle / handoff cadence.
+ * @type {Number}
+ */
+const AGGREGATOR_TTL_MS = 60 * 60 * 1000;
+
+/**
+ * @summary Default safe-processing fraction of the consumer's modelContextLimit.
+ * Empirically: callers want a ~20% headroom buffer before pre-check skip fires.
+ * @type {Number}
+ */
+const DEFAULT_SAFE_FRACTION = 0.8;
+
+/**
+ * Module-singleton aggregator. Keys are `${assetRef}|${consumer}|${symptom}` tuple-hashes;
+ * values are `{count, firstEmission, lastEmission, latestFriction, surfaced}` entries.
+ * @type {Map<String, Object>}
+ */
+const _aggregator = new Map();
+
+function tupleKey(assetRef, consumer, symptom) {
+    return `${assetRef}|${consumer}|${symptom}`;
+}
+
+/**
+ * @summary Categorizes a thrown invocation error into a ConsumerFriction symptom.
+ * Pure helper, exported for testability.
+ *
+ * @param {*} err The caught error (or thrown value).
+ * @returns {'context-overflow' | 'parse-failure' | 'timeout'} The categorized symptom.
+ */
+export function categorizeInvocationError(err) {
+    const msg = String(err?.message || err || '');
+
+    if (/context|overflow|too large|maximum|exceed/i.test(msg)) return 'context-overflow';
+    if (/timeout|aborted|timed[ -]out/i.test(msg))              return 'timeout';
+    return 'parse-failure';
+}
+
+/**
+ * @summary Emits a ConsumerFriction record into the in-memory aggregator. Deterministic
+ * symptoms (`size-precheck-skip`, `context-overflow`) surface on first occurrence;
+ * probabilistic symptoms aggregate by `(assetRef, consumer, symptom)` tuple and surface
+ * when their count reaches `PROBABILISTIC_EMIT_THRESHOLD`.
+ *
+ * Pure, side-effect-bounded to the module-singleton aggregator. Returns the aggregator
+ * entry so callers can inspect emission state (useful for tests + integration assertions).
+ *
+ * @param {ConsumerFriction} friction The friction record to emit.
+ * @returns {Object} The aggregator entry: `{count, firstEmission, lastEmission, latestFriction, surfaced}`.
+ */
+export function emitConsumerFriction(friction) {
+    const key      = tupleKey(friction.assetRef, friction.consumer || friction.model, friction.symptom);
+    const now      = Date.now();
+    const existing = _aggregator.get(key);
+
+    const entry = existing || {
+        count          : 0,
+        firstEmission  : now,
+        lastEmission   : now,
+        latestFriction : friction,
+        surfaced       : false
+    };
+
+    entry.count          += 1;
+    entry.lastEmission    = now;
+    entry.latestFriction  = friction;
+
+    if (DETERMINISTIC_SYMPTOMS.has(friction.symptom)) {
+        entry.surfaced = true;
+    } else if (entry.count >= PROBABILISTIC_EMIT_THRESHOLD) {
+        entry.surfaced = true;
+    }
+
+    _aggregator.set(key, entry);
+
+    return entry;
+}
+
+/**
+ * @summary Returns currently-surfaced ConsumerFriction records for handoff rendering.
+ * Prunes entries past `AGGREGATOR_TTL_MS`. Caller is `GoldenPathSynthesizer.synthesizeGoldenPath`
+ * (the human/swarm-facing read consumer per Visibility-Only V1).
+ *
+ * Side-effect: prunes stale entries from the aggregator as it iterates. Returning a fresh
+ * array per call so callers can sort / filter / format without mutating the underlying state.
+ *
+ * @param {Object} [options]
+ * @param {Number} [options.now=Date.now()] Injectable clock for deterministic test isolation.
+ * @returns {Array<{key: String, count: Number, firstEmission: String, lastEmission: String, friction: ConsumerFriction}>}
+ */
+export function getAggregatedFrictions({now = Date.now()} = {}) {
+    const surfaced = [];
+
+    for (const [key, entry] of _aggregator.entries()) {
+        if (now - entry.lastEmission > AGGREGATOR_TTL_MS) {
+            _aggregator.delete(key);
+            continue;
+        }
+
+        if (entry.surfaced) {
+            surfaced.push({
+                key,
+                count          : entry.count,
+                firstEmission  : new Date(entry.firstEmission).toISOString(),
+                lastEmission   : new Date(entry.lastEmission).toISOString(),
+                friction       : entry.latestFriction
+            });
+        }
+    }
+
+    return surfaced;
+}
+
+/**
+ * @summary Clears the in-memory aggregator. Test-only primitive — should not be called
+ * from production code paths because it would erase the friction-feed the next handoff
+ * cycle is going to render.
+ */
+export function clearAggregatedFrictions() {
+    _aggregator.clear();
+}
+
+/**
+ * @summary Bidirectional defense wrapper around an LLM invocation.
+ *
+ * Implements both Angle 1 (downstream try/catch with symptom categorization) and Angle 2
+ * (upstream pre-check skip when input exceeds `safeProcessingLimit`). Returns a uniform
+ * `{result, friction}` envelope so callers can:
+ *   - Use `result` when non-null (success path)
+ *   - Use `friction` when non-null (emitted ConsumerFriction; aggregator already updated)
+ *   - Both never non-null simultaneously
+ *
+ * Callers MUST provide `model`, `assetRef`, `modelContextLimit`, and `invocationFn`. The
+ * `safeProcessingLimit` defaults to `Math.floor(modelContextLimit * DEFAULT_SAFE_FRACTION)`
+ * when not passed. `inputPayload` is required for byte-measurement; pass `''` if there is
+ * no payload to measure (rare; would skip the pre-check).
+ *
+ * @param {Object} options
+ * @param {Function} options.invocationFn Async function performing the actual LLM call.
+ * @param {String} options.inputPayload The payload string passed to the consumer (for byte measurement).
+ * @param {String} options.model Consumer model identifier.
+ * @param {String} options.assetRef Origin identifier (sessionId, documentId, etc.).
+ * @param {Number} options.modelContextLimit Consumer context limit (bytes).
+ * @param {Number} [options.safeProcessingLimit] Optional safer threshold (bytes); defaults to 80% of modelContextLimit.
+ * @param {String} [options.consumer] Aggregation-tuple alias for `model`; defaults to `model`.
+ * @param {String} [options.workflowUpdateHint] Optional caller-provided remediation hint embedded in `workflowUpdateSuggestion`.
+ * @returns {Promise<{result: *, friction: ConsumerFriction | null}>}
+ */
+export async function invokeWithGuardrail({
+    invocationFn,
+    inputPayload,
+    model,
+    assetRef,
+    modelContextLimit,
+    safeProcessingLimit,
+    consumer,
+    workflowUpdateHint
+}) {
+    const inputBytes    = Buffer.byteLength(inputPayload || '', 'utf8');
+    const effectiveSafe = Number.isFinite(safeProcessingLimit)
+        ? safeProcessingLimit
+        : Math.floor(modelContextLimit * DEFAULT_SAFE_FRACTION);
+    const timestamp     = new Date().toISOString();
+    const consumerKey   = consumer || model;
+
+    if (inputBytes > effectiveSafe) {
+        const friction = {
+            model,
+            symptom                 : 'size-precheck-skip',
+            emissionPoint           : 'pre-invocation',
+            inputBytes,
+            modelContextLimit,
+            safeProcessingLimit     : effectiveSafe,
+            workflowUpdateSuggestion: workflowUpdateHint
+                || `Reduce input payload below ${effectiveSafe} bytes for ${model} (current: ${inputBytes} bytes).`,
+            timestamp,
+            assetRef,
+            consumer                : consumerKey
+        };
+
+        emitConsumerFriction(friction);
+        return {result: null, friction};
+    }
+
+    try {
+        const result = await invocationFn();
+        return {result, friction: null};
+    } catch (err) {
+        const symptom  = categorizeInvocationError(err);
+        const errMsg   = String(err?.message || err || '').substring(0, 200);
+        const friction = {
+            model,
+            symptom,
+            emissionPoint           : 'post-invocation-failure',
+            inputBytes,
+            modelContextLimit,
+            safeProcessingLimit     : effectiveSafe,
+            workflowUpdateSuggestion: workflowUpdateHint
+                || `Consumer ${model} ${symptom}: ${errMsg}. Reduce input or switch consumer.`,
+            timestamp,
+            assetRef,
+            consumer                : consumerKey
+        };
+
+        emitConsumerFriction(friction);
+        return {result: null, friction};
+    }
+}
+
+/**
+ * @summary Renders the surfaced frictions as a Markdown section for handoff inclusion.
+ * Returns an empty string when no frictions are surfaced (caller can opt to skip the section).
+ *
+ * Pure formatter — does not mutate aggregator state (the underlying `getAggregatedFrictions`
+ * does prune stale entries; this wrapper only formats whatever survives the prune).
+ *
+ * @param {Object} [options]
+ * @param {Number} [options.now=Date.now()] Injectable clock for deterministic test isolation.
+ * @returns {String} Markdown section, or empty string when no frictions surface.
+ */
+export function renderConsumerFrictionSection({now = Date.now()} = {}) {
+    const surfaced = getAggregatedFrictions({now});
+
+    if (surfaced.length === 0) {
+        return '';
+    }
+
+    const lines = ['### 🧠 Substrate-Consumer Friction', ''];
+
+    // Group by symptom for readability
+    const bySymptom = new Map();
+    for (const entry of surfaced) {
+        const list = bySymptom.get(entry.friction.symptom) || [];
+        list.push(entry);
+        bySymptom.set(entry.friction.symptom, list);
+    }
+
+    for (const [symptom, entries] of bySymptom) {
+        lines.push(`**${symptom}** (${entries.length} unique tuple${entries.length === 1 ? '' : 's'})`);
+        for (const entry of entries) {
+            const f = entry.friction;
+            lines.push(`- \`${f.consumer}\` on \`${f.assetRef}\` — ${f.inputBytes} bytes / safe ${f.safeProcessingLimit ?? '<unset>'} / context ${f.modelContextLimit} — count ${entry.count} (first ${entry.firstEmission}, last ${entry.lastEmission})`);
+            lines.push(`  - *Suggestion:* ${f.workflowUpdateSuggestion}`);
+        }
+        lines.push('');
+    }
+
+    return lines.join('\n');
+}
+
+/**
+ * @summary Internal constants exported for test verification.
+ */
+export const _testConstants = {
+    DETERMINISTIC_SYMPTOMS,
+    PROBABILISTIC_EMIT_THRESHOLD,
+    AGGREGATOR_TTL_MS,
+    DEFAULT_SAFE_FRACTION
+};

--- a/ai/services/memory-core/helpers/ConsumerFrictionHelper.mjs
+++ b/ai/services/memory-core/helpers/ConsumerFrictionHelper.mjs
@@ -8,13 +8,18 @@
  * handoff section. No `AgentOrchestrator.parseGoldenPath()` routing changes; no auto-mutation of
  * caller behavior beyond the explicit pre-check skip.
  *
- * Bidirectional defense (per Discussion #11444 graduation):
+ * Schema is the consensus-bound graduation contract from Discussion #11444 (Round-2 + Round-3
+ * cross-family convergence): structured `ConsumerFriction` with enum-backed `suggestionKind`,
+ * token-based durable metrics, `(assetRef, consumer, symptom)` aggregation tuple, and explicit
+ * `serviceDomain` provenance.
+ *
+ * Bidirectional defense (per Discussion #11444 Round-2):
  * - **Angle 1 (downstream)**: `invokeWithGuardrail` wraps the LLM invocation in try/catch and
  *   categorizes failures (`context-overflow` / `parse-failure` / `timeout`) into a
  *   ConsumerFriction record before returning `{result: null, friction}`.
- * - **Angle 2 (upstream)**: pre-checks `Buffer.byteLength(inputPayload)` against the consumer's
- *   `safeProcessingLimit` (defaults to 80% of `modelContextLimit`); over-budget input skips
- *   the invocation and emits a `size-precheck-skip` friction.
+ * - **Angle 2 (upstream)**: pre-checks the invocation envelope's estimated tokens against the
+ *   consumer's `safeProcessingLimitTokens` (defaults to 75% of `contextLimitTokens`); over-budget
+ *   input skips the invocation and emits a `size-precheck-skip` friction.
  *
  * Debounce policy:
  * - **Deterministic symptoms** (`size-precheck-skip`, `context-overflow`) surface on the
@@ -25,11 +30,10 @@
  *   once `count >= PROBABILISTIC_EMIT_THRESHOLD` to avoid burying single transient errors
  *   in the handoff feed.
  *
- * Token-vs-bytes note: this V1 helper measures input size in **bytes** via
- * `Buffer.byteLength(payload, 'utf8')` because the codebase has no canonical token-counting
- * utility. Callers passing `modelContextLimit` should pass byte-equivalent thresholds (or
- * convert from token-counts using ~4 chars/token rough heuristic for English text). Future
- * V2 may integrate with the Model-Stats registry (ADR 0012) for provider-specific tokenization.
+ * Token estimation: V1 uses a 4-chars/token heuristic (`Math.ceil(Buffer.byteLength(payload) / 4)`)
+ * because the codebase has no canonical provider-specific tokenizer. Bytes are retained on
+ * the record as evidence; tokens are the durable contract per Discussion #11444 consensus.
+ * Future V2 may integrate with Model-Stats registry (ADR 0012) for per-provider tokenization.
  *
  * @see learn/agentos/decisions/0012-model-stats-framework.md
  * @see ai/daemons/services/GoldenPathSynthesizer.mjs (handoff section consumer)
@@ -39,19 +43,49 @@
 
 /**
  * @typedef {Object} ConsumerFriction
+ * @property {String} assetRef Graph node ID of the substrate causing friction (sessionId, documentId, etc.) — first member of aggregation tuple.
+ * @property {String} consumer Service name (e.g. 'SemanticGraphExtractor', 'SessionService.summarizeSession') — second member of aggregation tuple.
  * @property {String} model Consumer model identifier (e.g. 'gemma4-31b', 'qwen3-8b').
- * @property {'context-overflow' | 'parse-failure' | 'token-budget-exceeded' | 'semantic-confusion' | 'timeout' | 'size-precheck-skip'} symptom Friction symptom enum.
+ * @property {'context-overflow' | 'parse-failure' | 'token-budget-exceeded' | 'semantic-confusion' | 'timeout' | 'size-precheck-skip'} symptom Friction symptom enum — third member of aggregation tuple.
  * @property {'pre-invocation' | 'post-invocation-failure'} emissionPoint When the friction was detected.
- * @property {Number} inputBytes Byte size of the payload that triggered the friction.
- * @property {Number} modelContextLimit Configured context limit for the consumer (bytes).
- * @property {Number} [safeProcessingLimit] Optional safer threshold (bytes); defaults to 80% of modelContextLimit.
- * @property {String} workflowUpdateSuggestion Operator/swarm-facing actionable suggestion.
- * @property {String} timestamp ISO 8601 emission time.
- * @property {String} assetRef Origin identifier (sessionId, documentId, etc.) — first member of aggregation tuple.
- * @property {String} consumer Same as model; kept explicit for the (assetRef, consumer, symptom) tuple semantics.
+ * @property {'split-document' | 'compress-payload' | 'extract-anchor' | 'reduce-review-cycle' | 'schema-repair' | 'unknown'} suggestionKind Enum-backed structured suggestion for substrate-evolution action.
+ * @property {Number} inputBytes Raw byte size of the payload that triggered the friction — evidence.
+ * @property {Number} inputTokensEstimate Estimated token count of the input payload (Math.ceil(inputBytes / 4) heuristic) — durable LLM-relevant metric.
+ * @property {Number} contextLimitTokens Configured context window of the consumer model (tokens) — durable contract.
+ * @property {Number} [safeProcessingLimitTokens] Optional safer threshold in tokens (default = Math.floor(contextLimitTokens * 0.75)).
+ * @property {String} firstSeenAt ISO 8601 timestamp of the first emission for this aggregation-tuple.
+ * @property {String} lastSeenAt ISO 8601 timestamp of the most recent emission for this aggregation-tuple.
+ * @property {Number} count Number of emissions accumulated against this aggregation-tuple — for debounce/threshold.
+ * @property {'dream-pipeline' | 'memory-core' | 'concept-extraction' | 'other'} serviceDomain Provenance domain of the emitting service.
+ * @property {String} [note] Optional bounded prose (e.g. truncation diagnostics, raw error tail).
  */
 
 const DETERMINISTIC_SYMPTOMS = new Set(['size-precheck-skip', 'context-overflow']);
+
+const VALID_SYMPTOMS = new Set([
+    'context-overflow',
+    'parse-failure',
+    'token-budget-exceeded',
+    'semantic-confusion',
+    'timeout',
+    'size-precheck-skip'
+]);
+
+const VALID_SUGGESTION_KINDS = new Set([
+    'split-document',
+    'compress-payload',
+    'extract-anchor',
+    'reduce-review-cycle',
+    'schema-repair',
+    'unknown'
+]);
+
+const VALID_SERVICE_DOMAINS = new Set([
+    'dream-pipeline',
+    'memory-core',
+    'concept-extraction',
+    'other'
+]);
 
 /**
  * @summary Probabilistic-symptom emit threshold — surfaces aggregated frictions when count reaches this.
@@ -68,21 +102,42 @@ const PROBABILISTIC_EMIT_THRESHOLD = 3;
 const AGGREGATOR_TTL_MS = 60 * 60 * 1000;
 
 /**
- * @summary Default safe-processing fraction of the consumer's modelContextLimit.
- * Empirically: callers want a ~20% headroom buffer before pre-check skip fires.
+ * @summary Default safe-processing fraction of the consumer's contextLimitTokens.
+ * Per Discussion #11444 Round-2 consensus: 0.75 leaves 25% headroom for system-prompt envelope,
+ * repair-cycle prompt growth, and output-token reservation.
  * @type {Number}
  */
-const DEFAULT_SAFE_FRACTION = 0.8;
+const DEFAULT_SAFE_FRACTION = 0.75;
+
+/**
+ * @summary Bytes-per-token heuristic for English-prevalent text.
+ * Conservative estimate; provider-specific tokenizers may yield slightly different counts.
+ * V2 may delegate to Model-Stats registry per-provider.
+ * @type {Number}
+ */
+const BYTES_PER_TOKEN_HEURISTIC = 4;
 
 /**
  * Module-singleton aggregator. Keys are `${assetRef}|${consumer}|${symptom}` tuple-hashes;
- * values are `{count, firstEmission, lastEmission, latestFriction, surfaced}` entries.
+ * values are aggregator entries with cumulative count + first/last-emission timestamps.
  * @type {Map<String, Object>}
  */
 const _aggregator = new Map();
 
 function tupleKey(assetRef, consumer, symptom) {
     return `${assetRef}|${consumer}|${symptom}`;
+}
+
+/**
+ * @summary Estimates token count from raw bytes via the 4-chars/token English heuristic.
+ * Exported for test verification + caller-side cross-references; not provider-specific.
+ *
+ * @param {Number} bytes Raw byte count.
+ * @returns {Number} Estimated token count.
+ */
+export function bytesToTokens(bytes) {
+    if (!Number.isFinite(bytes) || bytes < 0) return 0;
+    return Math.ceil(bytes / BYTES_PER_TOKEN_HEURISTIC);
 }
 
 /**
@@ -101,35 +156,97 @@ export function categorizeInvocationError(err) {
 }
 
 /**
+ * @summary Derives a default `suggestionKind` from a symptom + assetRef-shape heuristic.
+ * Callers may override via the `suggestionKind` option on `invokeWithGuardrail`. Pure helper.
+ *
+ * @param {String} symptom The ConsumerFriction symptom.
+ * @param {String} [assetRef] Optional asset reference for shape-based heuristic.
+ * @returns {'split-document' | 'compress-payload' | 'extract-anchor' | 'reduce-review-cycle' | 'schema-repair' | 'unknown'}
+ */
+export function deriveSuggestionKind(symptom, assetRef) {
+    switch (symptom) {
+        case 'size-precheck-skip':
+        case 'context-overflow':
+        case 'token-budget-exceeded':
+            return 'compress-payload';
+        case 'parse-failure':
+            return 'schema-repair';
+        case 'semantic-confusion':
+            return 'extract-anchor';
+        case 'timeout':
+            return 'unknown';
+        default:
+            return 'unknown';
+    }
+}
+
+/**
  * @summary Emits a ConsumerFriction record into the in-memory aggregator. Deterministic
  * symptoms (`size-precheck-skip`, `context-overflow`) surface on first occurrence;
  * probabilistic symptoms aggregate by `(assetRef, consumer, symptom)` tuple and surface
  * when their count reaches `PROBABILISTIC_EMIT_THRESHOLD`.
  *
- * Pure, side-effect-bounded to the module-singleton aggregator. Returns the aggregator
- * entry so callers can inspect emission state (useful for tests + integration assertions).
+ * Validates enum membership of `symptom`, `suggestionKind`, `emissionPoint`, `serviceDomain`
+ * and throws on invalid input. Pure aside from the module-singleton aggregator mutation.
  *
- * @param {ConsumerFriction} friction The friction record to emit.
- * @returns {Object} The aggregator entry: `{count, firstEmission, lastEmission, latestFriction, surfaced}`.
+ * @param {Partial<ConsumerFriction>} input Friction fields. `assetRef`, `consumer`, `model`,
+ *   `symptom`, `emissionPoint`, `serviceDomain`, `inputBytes`, `contextLimitTokens` are required.
+ *   `count` / `firstSeenAt` / `lastSeenAt` are managed by the aggregator and may be omitted.
+ * @returns {Object} The aggregator entry: `{count, firstSeenAt, lastSeenAt, latestFriction, surfaced}`.
  */
-export function emitConsumerFriction(friction) {
-    const key      = tupleKey(friction.assetRef, friction.consumer || friction.model, friction.symptom);
-    const now      = Date.now();
+export function emitConsumerFriction(input) {
+    if (!input || typeof input !== 'object') {
+        throw new TypeError(`emitConsumerFriction: input is required`);
+    }
+    if (!VALID_SYMPTOMS.has(input.symptom)) {
+        throw new TypeError(`emitConsumerFriction: invalid symptom '${input.symptom}'`);
+    }
+    if (input.emissionPoint && input.emissionPoint !== 'pre-invocation' && input.emissionPoint !== 'post-invocation-failure') {
+        throw new TypeError(`emitConsumerFriction: invalid emissionPoint '${input.emissionPoint}'`);
+    }
+    if (input.suggestionKind && !VALID_SUGGESTION_KINDS.has(input.suggestionKind)) {
+        throw new TypeError(`emitConsumerFriction: invalid suggestionKind '${input.suggestionKind}'`);
+    }
+    if (input.serviceDomain && !VALID_SERVICE_DOMAINS.has(input.serviceDomain)) {
+        throw new TypeError(`emitConsumerFriction: invalid serviceDomain '${input.serviceDomain}'`);
+    }
+
+    const consumer = input.consumer || input.model;
+    const key      = tupleKey(input.assetRef, consumer, input.symptom);
+    const nowIso   = new Date().toISOString();
     const existing = _aggregator.get(key);
 
     const entry = existing || {
         count          : 0,
-        firstEmission  : now,
-        lastEmission   : now,
-        latestFriction : friction,
+        firstSeenAt    : nowIso,
+        lastSeenAt     : nowIso,
+        latestFriction : null,
         surfaced       : false
     };
 
-    entry.count          += 1;
-    entry.lastEmission    = now;
-    entry.latestFriction  = friction;
+    entry.count += 1;
+    entry.lastSeenAt = nowIso;
 
-    if (DETERMINISTIC_SYMPTOMS.has(friction.symptom)) {
+    // Build the latest authoritative ConsumerFriction record for this aggregation-tuple.
+    entry.latestFriction = {
+        assetRef                 : input.assetRef,
+        consumer,
+        model                    : input.model,
+        symptom                  : input.symptom,
+        emissionPoint            : input.emissionPoint,
+        suggestionKind           : input.suggestionKind || deriveSuggestionKind(input.symptom, input.assetRef),
+        inputBytes               : input.inputBytes,
+        inputTokensEstimate      : input.inputTokensEstimate ?? bytesToTokens(input.inputBytes),
+        contextLimitTokens       : input.contextLimitTokens,
+        safeProcessingLimitTokens: input.safeProcessingLimitTokens,
+        firstSeenAt              : entry.firstSeenAt,
+        lastSeenAt               : entry.lastSeenAt,
+        count                    : entry.count,
+        serviceDomain            : input.serviceDomain || 'other',
+        ...(input.note !== undefined ? {note: input.note} : {})
+    };
+
+    if (DETERMINISTIC_SYMPTOMS.has(input.symptom)) {
         entry.surfaced = true;
     } else if (entry.count >= PROBABILISTIC_EMIT_THRESHOLD) {
         entry.surfaced = true;
@@ -145,30 +262,25 @@ export function emitConsumerFriction(friction) {
  * Prunes entries past `AGGREGATOR_TTL_MS`. Caller is `GoldenPathSynthesizer.synthesizeGoldenPath`
  * (the human/swarm-facing read consumer per Visibility-Only V1).
  *
- * Side-effect: prunes stale entries from the aggregator as it iterates. Returning a fresh
- * array per call so callers can sort / filter / format without mutating the underlying state.
+ * Side-effect: prunes stale entries from the aggregator as it iterates. Returns a fresh
+ * array per call so callers can sort/filter/format without mutating the underlying state.
  *
  * @param {Object} [options]
  * @param {Number} [options.now=Date.now()] Injectable clock for deterministic test isolation.
- * @returns {Array<{key: String, count: Number, firstEmission: String, lastEmission: String, friction: ConsumerFriction}>}
+ * @returns {Array<ConsumerFriction>} Surfaced friction records (already aggregated with count + firstSeenAt + lastSeenAt).
  */
 export function getAggregatedFrictions({now = Date.now()} = {}) {
     const surfaced = [];
 
     for (const [key, entry] of _aggregator.entries()) {
-        if (now - entry.lastEmission > AGGREGATOR_TTL_MS) {
+        const lastTs = Date.parse(entry.lastSeenAt);
+        if (Number.isFinite(lastTs) && now - lastTs > AGGREGATOR_TTL_MS) {
             _aggregator.delete(key);
             continue;
         }
 
-        if (entry.surfaced) {
-            surfaced.push({
-                key,
-                count          : entry.count,
-                firstEmission  : new Date(entry.firstEmission).toISOString(),
-                lastEmission   : new Date(entry.lastEmission).toISOString(),
-                friction       : entry.latestFriction
-            });
+        if (entry.surfaced && entry.latestFriction) {
+            surfaced.push(entry.latestFriction);
         }
     }
 
@@ -188,26 +300,23 @@ export function clearAggregatedFrictions() {
  * @summary Bidirectional defense wrapper around an LLM invocation.
  *
  * Implements both Angle 1 (downstream try/catch with symptom categorization) and Angle 2
- * (upstream pre-check skip when input exceeds `safeProcessingLimit`). Returns a uniform
- * `{result, friction}` envelope so callers can:
+ * (upstream pre-check skip when the estimated input tokens exceed `safeProcessingLimitTokens`).
+ * Returns a uniform `{result, friction}` envelope so callers can:
  *   - Use `result` when non-null (success path)
  *   - Use `friction` when non-null (emitted ConsumerFriction; aggregator already updated)
  *   - Both never non-null simultaneously
  *
- * Callers MUST provide `model`, `assetRef`, `modelContextLimit`, and `invocationFn`. The
- * `safeProcessingLimit` defaults to `Math.floor(modelContextLimit * DEFAULT_SAFE_FRACTION)`
- * when not passed. `inputPayload` is required for byte-measurement; pass `''` if there is
- * no payload to measure (rare; would skip the pre-check).
- *
  * @param {Object} options
  * @param {Function} options.invocationFn Async function performing the actual LLM call.
- * @param {String} options.inputPayload The payload string passed to the consumer (for byte measurement).
+ * @param {String} options.inputPayload The payload string passed to the consumer (for token estimation).
  * @param {String} options.model Consumer model identifier.
- * @param {String} options.assetRef Origin identifier (sessionId, documentId, etc.).
- * @param {Number} options.modelContextLimit Consumer context limit (bytes).
- * @param {Number} [options.safeProcessingLimit] Optional safer threshold (bytes); defaults to 80% of modelContextLimit.
- * @param {String} [options.consumer] Aggregation-tuple alias for `model`; defaults to `model`.
- * @param {String} [options.workflowUpdateHint] Optional caller-provided remediation hint embedded in `workflowUpdateSuggestion`.
+ * @param {String} options.assetRef Origin identifier (sessionId, documentId, etc.) — first tuple member.
+ * @param {String} options.consumer Service name emitting the friction (e.g. 'SemanticGraphExtractor') — second tuple member.
+ * @param {Number} options.contextLimitTokens Consumer context limit (tokens).
+ * @param {Number} [options.safeProcessingLimitTokens] Optional safer threshold (tokens); defaults to 75% of contextLimitTokens.
+ * @param {'dream-pipeline' | 'memory-core' | 'concept-extraction' | 'other'} options.serviceDomain Provenance domain.
+ * @param {String} [options.suggestionKind] Optional caller-provided enum override; defaults to symptom-derived.
+ * @param {String} [options.note] Optional bounded prose context.
  * @returns {Promise<{result: *, friction: ConsumerFriction | null}>}
  */
 export async function invokeWithGuardrail({
@@ -215,59 +324,62 @@ export async function invokeWithGuardrail({
     inputPayload,
     model,
     assetRef,
-    modelContextLimit,
-    safeProcessingLimit,
     consumer,
-    workflowUpdateHint
+    contextLimitTokens,
+    safeProcessingLimitTokens,
+    serviceDomain,
+    suggestionKind,
+    note
 }) {
-    const inputBytes    = Buffer.byteLength(inputPayload || '', 'utf8');
-    const effectiveSafe = Number.isFinite(safeProcessingLimit)
-        ? safeProcessingLimit
-        : Math.floor(modelContextLimit * DEFAULT_SAFE_FRACTION);
-    const timestamp     = new Date().toISOString();
-    const consumerKey   = consumer || model;
+    const inputBytes              = Buffer.byteLength(inputPayload || '', 'utf8');
+    const inputTokensEstimate     = bytesToTokens(inputBytes);
+    const effectiveSafeTokens     = Number.isFinite(safeProcessingLimitTokens)
+        ? safeProcessingLimitTokens
+        : Math.floor(contextLimitTokens * DEFAULT_SAFE_FRACTION);
+    const consumerKey             = consumer || model;
 
-    if (inputBytes > effectiveSafe) {
-        const friction = {
-            model,
-            symptom                 : 'size-precheck-skip',
-            emissionPoint           : 'pre-invocation',
-            inputBytes,
-            modelContextLimit,
-            safeProcessingLimit     : effectiveSafe,
-            workflowUpdateSuggestion: workflowUpdateHint
-                || `Reduce input payload below ${effectiveSafe} bytes for ${model} (current: ${inputBytes} bytes).`,
-            timestamp,
+    if (inputTokensEstimate > effectiveSafeTokens) {
+        const symptom = 'size-precheck-skip';
+        const entry   = emitConsumerFriction({
             assetRef,
-            consumer                : consumerKey
-        };
+            consumer                : consumerKey,
+            model,
+            symptom,
+            emissionPoint           : 'pre-invocation',
+            suggestionKind          : suggestionKind || deriveSuggestionKind(symptom, assetRef),
+            inputBytes,
+            inputTokensEstimate,
+            contextLimitTokens,
+            safeProcessingLimitTokens: effectiveSafeTokens,
+            serviceDomain,
+            note
+        });
 
-        emitConsumerFriction(friction);
-        return {result: null, friction};
+        return {result: null, friction: entry.latestFriction};
     }
 
     try {
         const result = await invocationFn();
         return {result, friction: null};
     } catch (err) {
-        const symptom  = categorizeInvocationError(err);
-        const errMsg   = String(err?.message || err || '').substring(0, 200);
-        const friction = {
+        const symptom = categorizeInvocationError(err);
+        const errTail = String(err?.message || err || '').substring(0, 200);
+        const entry   = emitConsumerFriction({
+            assetRef,
+            consumer                : consumerKey,
             model,
             symptom,
             emissionPoint           : 'post-invocation-failure',
+            suggestionKind          : suggestionKind || deriveSuggestionKind(symptom, assetRef),
             inputBytes,
-            modelContextLimit,
-            safeProcessingLimit     : effectiveSafe,
-            workflowUpdateSuggestion: workflowUpdateHint
-                || `Consumer ${model} ${symptom}: ${errMsg}. Reduce input or switch consumer.`,
-            timestamp,
-            assetRef,
-            consumer                : consumerKey
-        };
+            inputTokensEstimate,
+            contextLimitTokens,
+            safeProcessingLimitTokens: effectiveSafeTokens,
+            serviceDomain,
+            note                    : note || errTail
+        });
 
-        emitConsumerFriction(friction);
-        return {result: null, friction};
+        return {result: null, friction: entry.latestFriction};
     }
 }
 
@@ -275,8 +387,7 @@ export async function invokeWithGuardrail({
  * @summary Renders the surfaced frictions as a Markdown section for handoff inclusion.
  * Returns an empty string when no frictions are surfaced (caller can opt to skip the section).
  *
- * Pure formatter — does not mutate aggregator state (the underlying `getAggregatedFrictions`
- * does prune stale entries; this wrapper only formats whatever survives the prune).
+ * Pure formatter — does not mutate aggregator state.
  *
  * @param {Object} [options]
  * @param {Number} [options.now=Date.now()] Injectable clock for deterministic test isolation.
@@ -293,18 +404,18 @@ export function renderConsumerFrictionSection({now = Date.now()} = {}) {
 
     // Group by symptom for readability
     const bySymptom = new Map();
-    for (const entry of surfaced) {
-        const list = bySymptom.get(entry.friction.symptom) || [];
-        list.push(entry);
-        bySymptom.set(entry.friction.symptom, list);
+    for (const friction of surfaced) {
+        const list = bySymptom.get(friction.symptom) || [];
+        list.push(friction);
+        bySymptom.set(friction.symptom, list);
     }
 
-    for (const [symptom, entries] of bySymptom) {
-        lines.push(`**${symptom}** (${entries.length} unique tuple${entries.length === 1 ? '' : 's'})`);
-        for (const entry of entries) {
-            const f = entry.friction;
-            lines.push(`- \`${f.consumer}\` on \`${f.assetRef}\` — ${f.inputBytes} bytes / safe ${f.safeProcessingLimit ?? '<unset>'} / context ${f.modelContextLimit} — count ${entry.count} (first ${entry.firstEmission}, last ${entry.lastEmission})`);
-            lines.push(`  - *Suggestion:* ${f.workflowUpdateSuggestion}`);
+    for (const [symptom, frictions] of bySymptom) {
+        lines.push(`**${symptom}** (${frictions.length} unique tuple${frictions.length === 1 ? '' : 's'})`);
+        for (const f of frictions) {
+            const safe = f.safeProcessingLimitTokens ?? '<unset>';
+            lines.push(`- \`${f.consumer}\` on \`${f.assetRef}\` (model \`${f.model}\`, domain \`${f.serviceDomain}\`) — ${f.inputTokensEstimate} tokens / safe ${safe} / context ${f.contextLimitTokens} (count ${f.count}, first ${f.firstSeenAt}, last ${f.lastSeenAt})`);
+            lines.push(`  - *Suggestion (\`${f.suggestionKind}\`):* ${f.note || 'see emitter context'}`);
         }
         lines.push('');
     }
@@ -317,7 +428,11 @@ export function renderConsumerFrictionSection({now = Date.now()} = {}) {
  */
 export const _testConstants = {
     DETERMINISTIC_SYMPTOMS,
+    VALID_SYMPTOMS,
+    VALID_SUGGESTION_KINDS,
+    VALID_SERVICE_DOMAINS,
     PROBABILISTIC_EMIT_THRESHOLD,
     AGGREGATOR_TTL_MS,
-    DEFAULT_SAFE_FRACTION
+    DEFAULT_SAFE_FRACTION,
+    BYTES_PER_TOKEN_HEURISTIC
 };

--- a/test/playwright/unit/ai/services/memory-core/helpers/ConsumerFrictionHelper.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/helpers/ConsumerFrictionHelper.spec.mjs
@@ -24,6 +24,11 @@ import * as core      from '../../../../../../../src/core/_export.mjs';
  * `beforeEach` to prevent cross-test pollution. Per `feedback_symmetric_spec_cleanup`,
  * shared mutable state across tests requires symmetric reset discipline.
  *
+ * Schema verified against Discussion #11444 graduation contract (Round-2 + Round-3
+ * consensus): structured `ConsumerFriction` with `suggestionKind`, token-based durable
+ * metrics, `(assetRef, consumer, symptom)` aggregation tuple, `serviceDomain` provenance,
+ * `firstSeenAt`/`lastSeenAt`/`count` aggregation fields.
+ *
  * @see ai/services/memory-core/helpers/ConsumerFrictionHelper.mjs
  */
 test.describe.serial('Neo.ai.services.memory-core.helpers.ConsumerFrictionHelper (#11447)', () => {
@@ -37,6 +42,19 @@ test.describe.serial('Neo.ai.services.memory-core.helpers.ConsumerFrictionHelper
         helper.clearAggregatedFrictions();
     });
 
+    test('bytesToTokens applies the 4-chars/token heuristic', () => {
+        const {bytesToTokens} = helper;
+        expect(bytesToTokens(0)).toBe(0);
+        expect(bytesToTokens(4)).toBe(1);
+        expect(bytesToTokens(5)).toBe(2);
+        expect(bytesToTokens(40)).toBe(10);
+        expect(bytesToTokens(131072)).toBe(32768);
+        // Edge: negative / non-finite → 0
+        expect(bytesToTokens(-1)).toBe(0);
+        expect(bytesToTokens(NaN)).toBe(0);
+        expect(bytesToTokens(undefined)).toBe(0);
+    });
+
     test('categorizeInvocationError maps known patterns to symptoms', () => {
         const {categorizeInvocationError} = helper;
 
@@ -46,203 +64,236 @@ test.describe.serial('Neo.ai.services.memory-core.helpers.ConsumerFrictionHelper
         expect(categorizeInvocationError(new Error('Request timed out'))).toBe('timeout');
         expect(categorizeInvocationError(new Error('AbortError: operation aborted'))).toBe('timeout');
         expect(categorizeInvocationError(new Error('JSON parse failure'))).toBe('parse-failure');
-        expect(categorizeInvocationError(new Error('Some other transient failure'))).toBe('parse-failure');
-        // Edge: null / undefined / string
         expect(categorizeInvocationError(null)).toBe('parse-failure');
         expect(categorizeInvocationError('overflow occurred')).toBe('context-overflow');
+    });
+
+    test('deriveSuggestionKind maps symptoms to enum-backed suggestions', () => {
+        const {deriveSuggestionKind} = helper;
+        expect(deriveSuggestionKind('size-precheck-skip')).toBe('compress-payload');
+        expect(deriveSuggestionKind('context-overflow')).toBe('compress-payload');
+        expect(deriveSuggestionKind('token-budget-exceeded')).toBe('compress-payload');
+        expect(deriveSuggestionKind('parse-failure')).toBe('schema-repair');
+        expect(deriveSuggestionKind('semantic-confusion')).toBe('extract-anchor');
+        expect(deriveSuggestionKind('timeout')).toBe('unknown');
+        expect(deriveSuggestionKind('unrecognized-symptom')).toBe('unknown');
+    });
+
+    test('emitConsumerFriction throws on invalid symptom / suggestionKind / serviceDomain', () => {
+        const {emitConsumerFriction} = helper;
+
+        expect(() => emitConsumerFriction({})).toThrow(/invalid symptom/);
+        expect(() => emitConsumerFriction({symptom: 'bogus'})).toThrow(/invalid symptom/);
+        expect(() => emitConsumerFriction({
+            symptom        : 'parse-failure',
+            suggestionKind : 'invented-kind'
+        })).toThrow(/invalid suggestionKind/);
+        expect(() => emitConsumerFriction({
+            symptom       : 'parse-failure',
+            serviceDomain : 'fake-domain'
+        })).toThrow(/invalid serviceDomain/);
+        expect(() => emitConsumerFriction({
+            symptom       : 'parse-failure',
+            emissionPoint : 'wrong-point'
+        })).toThrow(/invalid emissionPoint/);
     });
 
     test('emitConsumerFriction surfaces deterministic symptoms on first occurrence', () => {
         const {emitConsumerFriction, getAggregatedFrictions} = helper;
 
-        const friction = {
-            model                   : 'gemma4-31b',
-            symptom                 : 'size-precheck-skip',
-            emissionPoint           : 'pre-invocation',
-            inputBytes              : 100000,
-            modelContextLimit       : 50000,
-            safeProcessingLimit     : 40000,
-            workflowUpdateSuggestion: 'Reduce payload',
-            timestamp               : new Date().toISOString(),
-            assetRef                : 'session:abc',
-            consumer                : 'gemma4-31b'
-        };
+        emitConsumerFriction({
+            assetRef          : 'session:abc',
+            consumer          : 'SemanticGraphExtractor',
+            model             : 'gemma4-31b',
+            symptom           : 'size-precheck-skip',
+            emissionPoint     : 'pre-invocation',
+            inputBytes        : 100000,
+            contextLimitTokens: 8192,
+            serviceDomain     : 'dream-pipeline'
+        });
 
-        emitConsumerFriction(friction);
         const surfaced = getAggregatedFrictions();
 
         expect(surfaced).toHaveLength(1);
-        expect(surfaced[0].count).toBe(1);
-        expect(surfaced[0].friction.symptom).toBe('size-precheck-skip');
+        expect(surfaced[0]).toMatchObject({
+            assetRef            : 'session:abc',
+            consumer            : 'SemanticGraphExtractor',
+            model               : 'gemma4-31b',
+            symptom             : 'size-precheck-skip',
+            emissionPoint       : 'pre-invocation',
+            suggestionKind      : 'compress-payload',
+            inputBytes          : 100000,
+            inputTokensEstimate : 25000,
+            contextLimitTokens  : 8192,
+            count               : 1,
+            serviceDomain       : 'dream-pipeline'
+        });
+        // Required durable-aggregation fields present
+        expect(typeof surfaced[0].firstSeenAt).toBe('string');
+        expect(typeof surfaced[0].lastSeenAt).toBe('string');
     });
 
     test('emitConsumerFriction surfaces context-overflow on first occurrence', () => {
         const {emitConsumerFriction, getAggregatedFrictions} = helper;
 
         emitConsumerFriction({
-            model                   : 'gemma4-31b',
-            symptom                 : 'context-overflow',
-            emissionPoint           : 'post-invocation-failure',
-            inputBytes              : 50000,
-            modelContextLimit       : 40000,
-            workflowUpdateSuggestion: 'Reduce payload',
-            timestamp               : new Date().toISOString(),
-            assetRef                : 'session:def',
-            consumer                : 'gemma4-31b'
+            assetRef          : 'session:def',
+            consumer          : 'SessionService',
+            model             : 'gemma4-31b',
+            symptom           : 'context-overflow',
+            emissionPoint     : 'post-invocation-failure',
+            inputBytes        : 50000,
+            contextLimitTokens: 8192,
+            serviceDomain     : 'memory-core'
         });
 
         const surfaced = getAggregatedFrictions();
         expect(surfaced).toHaveLength(1);
-        expect(surfaced[0].friction.symptom).toBe('context-overflow');
+        expect(surfaced[0].symptom).toBe('context-overflow');
+        expect(surfaced[0].serviceDomain).toBe('memory-core');
     });
 
     test('emitConsumerFriction aggregates probabilistic symptoms and surfaces at threshold', () => {
         const {emitConsumerFriction, getAggregatedFrictions, _testConstants} = helper;
         const threshold = _testConstants.PROBABILISTIC_EMIT_THRESHOLD;
 
-        const friction = {
-            model                   : 'gemma4-31b',
-            symptom                 : 'parse-failure',
-            emissionPoint           : 'post-invocation-failure',
-            inputBytes              : 5000,
-            modelContextLimit       : 40000,
-            workflowUpdateSuggestion: 'Improve response shape',
-            timestamp               : new Date().toISOString(),
-            assetRef                : 'session:ghi',
-            consumer                : 'gemma4-31b'
+        const baseFriction = {
+            assetRef          : 'session:ghi',
+            consumer          : 'SemanticGraphExtractor',
+            model             : 'gemma4-31b',
+            symptom           : 'parse-failure',
+            emissionPoint     : 'post-invocation-failure',
+            inputBytes        : 5000,
+            contextLimitTokens: 8192,
+            serviceDomain     : 'dream-pipeline'
         };
 
         // Below threshold: do not surface
         for (let i = 1; i < threshold; i++) {
-            emitConsumerFriction({...friction, timestamp: new Date().toISOString()});
+            emitConsumerFriction({...baseFriction});
         }
         expect(getAggregatedFrictions()).toHaveLength(0);
 
         // Threshold-th emission: surface
-        emitConsumerFriction({...friction, timestamp: new Date().toISOString()});
+        emitConsumerFriction({...baseFriction});
         const surfaced = getAggregatedFrictions();
         expect(surfaced).toHaveLength(1);
         expect(surfaced[0].count).toBe(threshold);
+        expect(surfaced[0].suggestionKind).toBe('schema-repair');
     });
 
     test('emitConsumerFriction aggregates by (assetRef, consumer, symptom) tuple — different assetRefs do not collide', () => {
         const {emitConsumerFriction, getAggregatedFrictions, _testConstants} = helper;
         const threshold = _testConstants.PROBABILISTIC_EMIT_THRESHOLD;
 
-        // Same symptom + consumer, different assetRef — independent tuples
+        const base = {
+            consumer          : 'SemanticGraphExtractor',
+            model             : 'gemma4-31b',
+            symptom           : 'parse-failure',
+            emissionPoint     : 'post-invocation-failure',
+            inputBytes        : 5000,
+            contextLimitTokens: 8192,
+            serviceDomain     : 'dream-pipeline'
+        };
+
         for (let i = 0; i < threshold; i++) {
-            emitConsumerFriction({
-                model                   : 'gemma4-31b',
-                symptom                 : 'parse-failure',
-                emissionPoint           : 'post-invocation-failure',
-                inputBytes              : 5000,
-                modelContextLimit       : 40000,
-                workflowUpdateSuggestion: 'Improve response',
-                timestamp               : new Date().toISOString(),
-                assetRef                : 'session:tuple-a',
-                consumer                : 'gemma4-31b'
-            });
-            emitConsumerFriction({
-                model                   : 'gemma4-31b',
-                symptom                 : 'parse-failure',
-                emissionPoint           : 'post-invocation-failure',
-                inputBytes              : 7000,
-                modelContextLimit       : 40000,
-                workflowUpdateSuggestion: 'Improve response',
-                timestamp               : new Date().toISOString(),
-                assetRef                : 'session:tuple-b',
-                consumer                : 'gemma4-31b'
-            });
+            emitConsumerFriction({...base, assetRef: 'session:tuple-a'});
+            emitConsumerFriction({...base, assetRef: 'session:tuple-b'});
         }
 
         const surfaced = getAggregatedFrictions();
         expect(surfaced).toHaveLength(2);
-        expect(new Set(surfaced.map(s => s.friction.assetRef))).toEqual(new Set(['session:tuple-a', 'session:tuple-b']));
+        expect(new Set(surfaced.map(f => f.assetRef))).toEqual(new Set(['session:tuple-a', 'session:tuple-b']));
     });
 
     test('getAggregatedFrictions prunes entries past AGGREGATOR_TTL_MS', () => {
         const {emitConsumerFriction, getAggregatedFrictions, _testConstants} = helper;
         const ttl = _testConstants.AGGREGATOR_TTL_MS;
 
-        // Emit a deterministic-symptom entry (surfaces immediately)
         emitConsumerFriction({
-            model                   : 'gemma4-31b',
-            symptom                 : 'size-precheck-skip',
-            emissionPoint           : 'pre-invocation',
-            inputBytes              : 100000,
-            modelContextLimit       : 40000,
-            safeProcessingLimit     : 32000,
-            workflowUpdateSuggestion: 'Reduce payload',
-            timestamp               : new Date().toISOString(),
-            assetRef                : 'session:ttl',
-            consumer                : 'gemma4-31b'
+            assetRef          : 'session:ttl',
+            consumer          : 'SemanticGraphExtractor',
+            model             : 'gemma4-31b',
+            symptom           : 'size-precheck-skip',
+            emissionPoint     : 'pre-invocation',
+            inputBytes        : 100000,
+            contextLimitTokens: 8192,
+            serviceDomain     : 'dream-pipeline'
         });
 
-        // Verify it surfaces NOW
         expect(getAggregatedFrictions({now: Date.now()})).toHaveLength(1);
 
-        // Inject a future-clock past TTL — entry should be pruned
+        // Future-clock past TTL — entry should be pruned
         const futureNow = Date.now() + ttl + 1000;
         expect(getAggregatedFrictions({now: futureNow})).toHaveLength(0);
-
-        // Verify the prune was destructive — subsequent reads also see 0
         expect(getAggregatedFrictions({now: Date.now()})).toHaveLength(0);
     });
 
-    test('invokeWithGuardrail Angle 2 — pre-check skips invocation when input exceeds safeProcessingLimit', async () => {
+    test('invokeWithGuardrail Angle 2 — pre-check skips invocation when input tokens exceed safeProcessingLimitTokens', async () => {
         const {invokeWithGuardrail, getAggregatedFrictions} = helper;
 
         let invoked = false;
         const result = await invokeWithGuardrail({
-            invocationFn       : async () => { invoked = true; return 'should not run'; },
-            inputPayload       : 'x'.repeat(50000),
-            model              : 'gemma4-31b',
-            assetRef           : 'session:precheck',
-            modelContextLimit  : 40000,
-            safeProcessingLimit: 30000
+            invocationFn             : async () => { invoked = true; return 'should not run'; },
+            inputPayload             : 'x'.repeat(50000), // 50000 bytes = 12500 tokens estimate
+            model                    : 'gemma4-31b',
+            assetRef                 : 'session:precheck',
+            consumer                 : 'SemanticGraphExtractor',
+            contextLimitTokens       : 10000,
+            safeProcessingLimitTokens: 7500,
+            serviceDomain            : 'dream-pipeline'
         });
 
         expect(invoked).toBe(false);
         expect(result.result).toBeNull();
         expect(result.friction).not.toBeNull();
-        expect(result.friction.symptom).toBe('size-precheck-skip');
-        expect(result.friction.emissionPoint).toBe('pre-invocation');
-        expect(result.friction.inputBytes).toBe(50000);
-        expect(result.friction.safeProcessingLimit).toBe(30000);
+        expect(result.friction).toMatchObject({
+            symptom                  : 'size-precheck-skip',
+            emissionPoint            : 'pre-invocation',
+            inputBytes               : 50000,
+            inputTokensEstimate      : 12500,
+            contextLimitTokens       : 10000,
+            safeProcessingLimitTokens: 7500,
+            suggestionKind           : 'compress-payload',
+            serviceDomain            : 'dream-pipeline'
+        });
 
-        // Verify the friction is in the aggregator (surfaced because deterministic)
-        const surfaced = getAggregatedFrictions();
-        expect(surfaced).toHaveLength(1);
+        expect(getAggregatedFrictions()).toHaveLength(1);
     });
 
-    test('invokeWithGuardrail Angle 2 — safeProcessingLimit defaults to 80% of modelContextLimit', async () => {
+    test('invokeWithGuardrail Angle 2 — safeProcessingLimitTokens defaults to 75% of contextLimitTokens', async () => {
         const {invokeWithGuardrail} = helper;
 
         let invoked = false;
-        // Input is 33000 bytes; modelContextLimit is 40000; default safe = 32000; input EXCEEDS safe
+        // 33000 bytes ≈ 8250 tokens; contextLimitTokens 10000; default safe = 7500; input EXCEEDS safe
         const result = await invokeWithGuardrail({
             invocationFn      : async () => { invoked = true; return 'should not run'; },
             inputPayload      : 'x'.repeat(33000),
             model             : 'gemma4-31b',
             assetRef          : 'session:precheck-default',
-            modelContextLimit : 40000
-            // safeProcessingLimit omitted → uses 80% default = 32000
+            consumer          : 'SemanticGraphExtractor',
+            contextLimitTokens: 10000,
+            serviceDomain     : 'dream-pipeline'
+            // safeProcessingLimitTokens omitted → uses 75% default = 7500
         });
 
         expect(invoked).toBe(false);
         expect(result.friction.symptom).toBe('size-precheck-skip');
-        expect(result.friction.safeProcessingLimit).toBe(32000);
+        expect(result.friction.safeProcessingLimitTokens).toBe(7500);
+        expect(result.friction.inputTokensEstimate).toBe(8250);
     });
 
     test('invokeWithGuardrail Angle 1 — success path returns result without friction', async () => {
         const {invokeWithGuardrail, getAggregatedFrictions} = helper;
 
         const result = await invokeWithGuardrail({
-            invocationFn     : async () => ({content: 'ok', model: 'gemma4-31b'}),
-            inputPayload     : 'small input',
-            model            : 'gemma4-31b',
-            assetRef         : 'session:success',
-            modelContextLimit: 40000
+            invocationFn      : async () => ({content: 'ok', model: 'gemma4-31b'}),
+            inputPayload      : 'small input',
+            model             : 'gemma4-31b',
+            assetRef          : 'session:success',
+            consumer          : 'SemanticGraphExtractor',
+            contextLimitTokens: 10000,
+            serviceDomain     : 'dream-pipeline'
         });
 
         expect(result.result).toEqual({content: 'ok', model: 'gemma4-31b'});
@@ -250,22 +301,24 @@ test.describe.serial('Neo.ai.services.memory-core.helpers.ConsumerFrictionHelper
         expect(getAggregatedFrictions()).toHaveLength(0);
     });
 
-    test('invokeWithGuardrail Angle 1 — failure path categorizes error + emits friction', async () => {
+    test('invokeWithGuardrail Angle 1 — parse-failure aggregates and surfaces at threshold', async () => {
         const {invokeWithGuardrail, getAggregatedFrictions, _testConstants} = helper;
         const threshold = _testConstants.PROBABILISTIC_EMIT_THRESHOLD;
 
-        // Probabilistic symptom (parse-failure) — need to fire threshold times to surface
         for (let i = 0; i < threshold; i++) {
             const result = await invokeWithGuardrail({
-                invocationFn     : async () => { throw new Error('Malformed JSON response'); },
-                inputPayload     : 'small input',
-                model            : 'gemma4-31b',
-                assetRef         : 'session:fail-parse',
-                modelContextLimit: 40000
+                invocationFn      : async () => { throw new Error('Malformed JSON response'); },
+                inputPayload      : 'small input',
+                model             : 'gemma4-31b',
+                assetRef          : 'session:fail-parse',
+                consumer          : 'SemanticGraphExtractor',
+                contextLimitTokens: 10000,
+                serviceDomain     : 'dream-pipeline'
             });
             expect(result.result).toBeNull();
             expect(result.friction).not.toBeNull();
             expect(result.friction.symptom).toBe('parse-failure');
+            expect(result.friction.suggestionKind).toBe('schema-repair');
             expect(result.friction.emissionPoint).toBe('post-invocation-failure');
         }
 
@@ -278,19 +331,21 @@ test.describe.serial('Neo.ai.services.memory-core.helpers.ConsumerFrictionHelper
         const {invokeWithGuardrail, getAggregatedFrictions} = helper;
 
         const result = await invokeWithGuardrail({
-            invocationFn     : async () => { throw new Error('Context window exceeded'); },
-            inputPayload     : 'medium input',
-            model            : 'gemma4-31b',
-            assetRef         : 'session:fail-overflow',
-            modelContextLimit: 40000
+            invocationFn      : async () => { throw new Error('Context window exceeded'); },
+            inputPayload      : 'medium input',
+            model             : 'gemma4-31b',
+            assetRef          : 'session:fail-overflow',
+            consumer          : 'SessionService',
+            contextLimitTokens: 10000,
+            serviceDomain     : 'memory-core'
         });
 
         expect(result.friction.symptom).toBe('context-overflow');
-        // Deterministic symptom — surfaces on first occurrence
+        expect(result.friction.suggestionKind).toBe('compress-payload');
         expect(getAggregatedFrictions()).toHaveLength(1);
     });
 
-    test('invokeWithGuardrail honors caller-provided workflowUpdateHint', async () => {
+    test('invokeWithGuardrail honors caller-provided suggestionKind + note overrides', async () => {
         const {invokeWithGuardrail} = helper;
 
         const result = await invokeWithGuardrail({
@@ -298,11 +353,15 @@ test.describe.serial('Neo.ai.services.memory-core.helpers.ConsumerFrictionHelper
             inputPayload      : 'tiny',
             model             : 'gemma4-31b',
             assetRef          : 'session:hint',
-            modelContextLimit : 40000,
-            workflowUpdateHint: 'Switch to qwen3-8b for stricter JSON output.'
+            consumer          : 'SemanticGraphExtractor',
+            contextLimitTokens: 10000,
+            serviceDomain     : 'dream-pipeline',
+            suggestionKind    : 'extract-anchor',
+            note              : 'Switch to qwen3-8b for stricter JSON output.'
         });
 
-        expect(result.friction.workflowUpdateSuggestion).toBe('Switch to qwen3-8b for stricter JSON output.');
+        expect(result.friction.suggestionKind).toBe('extract-anchor');
+        expect(result.friction.note).toBe('Switch to qwen3-8b for stricter JSON output.');
     });
 
     test('renderConsumerFrictionSection returns empty string when no frictions surface', () => {
@@ -310,62 +369,60 @@ test.describe.serial('Neo.ai.services.memory-core.helpers.ConsumerFrictionHelper
         expect(renderConsumerFrictionSection()).toBe('');
     });
 
-    test('renderConsumerFrictionSection emits structured Markdown when frictions are surfaced', () => {
+    test('renderConsumerFrictionSection emits structured Markdown with token metrics + suggestionKind', () => {
         const {emitConsumerFriction, renderConsumerFrictionSection} = helper;
 
         emitConsumerFriction({
-            model                   : 'gemma4-31b',
-            symptom                 : 'size-precheck-skip',
-            emissionPoint           : 'pre-invocation',
-            inputBytes              : 100000,
-            modelContextLimit       : 40000,
-            safeProcessingLimit     : 32000,
-            workflowUpdateSuggestion: 'Reduce payload below 32000 bytes',
-            timestamp               : new Date().toISOString(),
-            assetRef                : 'session:render',
-            consumer                : 'gemma4-31b'
+            assetRef          : 'session:render',
+            consumer          : 'SemanticGraphExtractor',
+            model             : 'gemma4-31b',
+            symptom           : 'size-precheck-skip',
+            emissionPoint     : 'pre-invocation',
+            inputBytes        : 100000,
+            contextLimitTokens: 8192,
+            safeProcessingLimitTokens: 6144,
+            serviceDomain     : 'dream-pipeline'
         });
 
         const section = renderConsumerFrictionSection();
 
         expect(section).toContain('### 🧠 Substrate-Consumer Friction');
         expect(section).toContain('**size-precheck-skip**');
-        expect(section).toContain('`gemma4-31b`');
+        expect(section).toContain('`SemanticGraphExtractor`');
         expect(section).toContain('`session:render`');
-        expect(section).toContain('100000 bytes');
-        expect(section).toContain('safe 32000');
-        expect(section).toContain('Reduce payload below 32000 bytes');
+        expect(section).toContain('`gemma4-31b`');
+        expect(section).toContain('`dream-pipeline`');
+        expect(section).toContain('25000 tokens');
+        expect(section).toContain('safe 6144');
+        expect(section).toContain('context 8192');
+        expect(section).toContain('(`compress-payload`)');
     });
 
     test('renderConsumerFrictionSection groups multiple symptoms', () => {
         const {emitConsumerFriction, renderConsumerFrictionSection, _testConstants} = helper;
         const threshold = _testConstants.PROBABILISTIC_EMIT_THRESHOLD;
 
-        // Surface a context-overflow (deterministic, surfaces immediately)
         emitConsumerFriction({
-            model                   : 'gemma4-31b',
-            symptom                 : 'context-overflow',
-            emissionPoint           : 'post-invocation-failure',
-            inputBytes              : 50000,
-            modelContextLimit       : 40000,
-            workflowUpdateSuggestion: 'Reduce',
-            timestamp               : new Date().toISOString(),
-            assetRef                : 'session:overflow-1',
-            consumer                : 'gemma4-31b'
+            assetRef          : 'session:overflow-1',
+            consumer          : 'SemanticGraphExtractor',
+            model             : 'gemma4-31b',
+            symptom           : 'context-overflow',
+            emissionPoint     : 'post-invocation-failure',
+            inputBytes        : 50000,
+            contextLimitTokens: 8192,
+            serviceDomain     : 'dream-pipeline'
         });
 
-        // Surface a parse-failure (probabilistic, need threshold emissions)
         for (let i = 0; i < threshold; i++) {
             emitConsumerFriction({
-                model                   : 'qwen3-8b',
-                symptom                 : 'parse-failure',
-                emissionPoint           : 'post-invocation-failure',
-                inputBytes              : 8000,
-                modelContextLimit       : 40000,
-                workflowUpdateSuggestion: 'Switch JSON parser',
-                timestamp               : new Date().toISOString(),
-                assetRef                : 'session:parse-1',
-                consumer                : 'qwen3-8b'
+                assetRef          : 'session:parse-1',
+                consumer          : 'SessionService',
+                model             : 'qwen3-8b',
+                symptom           : 'parse-failure',
+                emissionPoint     : 'post-invocation-failure',
+                inputBytes        : 8000,
+                contextLimitTokens: 8192,
+                serviceDomain     : 'memory-core'
             });
         }
 
@@ -373,7 +430,9 @@ test.describe.serial('Neo.ai.services.memory-core.helpers.ConsumerFrictionHelper
 
         expect(section).toContain('**context-overflow**');
         expect(section).toContain('**parse-failure**');
-        expect(section).toContain('`gemma4-31b`');
-        expect(section).toContain('`qwen3-8b`');
+        expect(section).toContain('`SemanticGraphExtractor`');
+        expect(section).toContain('`SessionService`');
+        expect(section).toContain('`dream-pipeline`');
+        expect(section).toContain('`memory-core`');
     });
 });

--- a/test/playwright/unit/ai/services/memory-core/helpers/ConsumerFrictionHelper.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/helpers/ConsumerFrictionHelper.spec.mjs
@@ -1,0 +1,379 @@
+import {setup} from '../../../../../setup.mjs';
+
+const appName = 'ConsumerFrictionHelperTest';
+
+setup({
+    neoConfig: {
+        unitTestMode: true
+    },
+    appConfig: {
+        name             : appName,
+        isMounted        : () => true,
+        vnodeInitialising: false
+    }
+});
+
+import {test, expect} from '@playwright/test';
+import Neo            from '../../../../../../../src/Neo.mjs';
+import * as core      from '../../../../../../../src/core/_export.mjs';
+
+/**
+ * @summary Unit coverage for the Brain-Pillar Consumer-Friction Helper (#11447 V1).
+ *
+ * The helper is module-singleton state — tests MUST `clearAggregatedFrictions()` in
+ * `beforeEach` to prevent cross-test pollution. Per `feedback_symmetric_spec_cleanup`,
+ * shared mutable state across tests requires symmetric reset discipline.
+ *
+ * @see ai/services/memory-core/helpers/ConsumerFrictionHelper.mjs
+ */
+test.describe.serial('Neo.ai.services.memory-core.helpers.ConsumerFrictionHelper (#11447)', () => {
+    let helper;
+
+    test.beforeAll(async () => {
+        helper = await import('../../../../../../../ai/services/memory-core/helpers/ConsumerFrictionHelper.mjs');
+    });
+
+    test.beforeEach(() => {
+        helper.clearAggregatedFrictions();
+    });
+
+    test('categorizeInvocationError maps known patterns to symptoms', () => {
+        const {categorizeInvocationError} = helper;
+
+        expect(categorizeInvocationError(new Error('Context window exceeded'))).toBe('context-overflow');
+        expect(categorizeInvocationError(new Error('Request was too large'))).toBe('context-overflow');
+        expect(categorizeInvocationError(new Error('Maximum input limit'))).toBe('context-overflow');
+        expect(categorizeInvocationError(new Error('Request timed out'))).toBe('timeout');
+        expect(categorizeInvocationError(new Error('AbortError: operation aborted'))).toBe('timeout');
+        expect(categorizeInvocationError(new Error('JSON parse failure'))).toBe('parse-failure');
+        expect(categorizeInvocationError(new Error('Some other transient failure'))).toBe('parse-failure');
+        // Edge: null / undefined / string
+        expect(categorizeInvocationError(null)).toBe('parse-failure');
+        expect(categorizeInvocationError('overflow occurred')).toBe('context-overflow');
+    });
+
+    test('emitConsumerFriction surfaces deterministic symptoms on first occurrence', () => {
+        const {emitConsumerFriction, getAggregatedFrictions} = helper;
+
+        const friction = {
+            model                   : 'gemma4-31b',
+            symptom                 : 'size-precheck-skip',
+            emissionPoint           : 'pre-invocation',
+            inputBytes              : 100000,
+            modelContextLimit       : 50000,
+            safeProcessingLimit     : 40000,
+            workflowUpdateSuggestion: 'Reduce payload',
+            timestamp               : new Date().toISOString(),
+            assetRef                : 'session:abc',
+            consumer                : 'gemma4-31b'
+        };
+
+        emitConsumerFriction(friction);
+        const surfaced = getAggregatedFrictions();
+
+        expect(surfaced).toHaveLength(1);
+        expect(surfaced[0].count).toBe(1);
+        expect(surfaced[0].friction.symptom).toBe('size-precheck-skip');
+    });
+
+    test('emitConsumerFriction surfaces context-overflow on first occurrence', () => {
+        const {emitConsumerFriction, getAggregatedFrictions} = helper;
+
+        emitConsumerFriction({
+            model                   : 'gemma4-31b',
+            symptom                 : 'context-overflow',
+            emissionPoint           : 'post-invocation-failure',
+            inputBytes              : 50000,
+            modelContextLimit       : 40000,
+            workflowUpdateSuggestion: 'Reduce payload',
+            timestamp               : new Date().toISOString(),
+            assetRef                : 'session:def',
+            consumer                : 'gemma4-31b'
+        });
+
+        const surfaced = getAggregatedFrictions();
+        expect(surfaced).toHaveLength(1);
+        expect(surfaced[0].friction.symptom).toBe('context-overflow');
+    });
+
+    test('emitConsumerFriction aggregates probabilistic symptoms and surfaces at threshold', () => {
+        const {emitConsumerFriction, getAggregatedFrictions, _testConstants} = helper;
+        const threshold = _testConstants.PROBABILISTIC_EMIT_THRESHOLD;
+
+        const friction = {
+            model                   : 'gemma4-31b',
+            symptom                 : 'parse-failure',
+            emissionPoint           : 'post-invocation-failure',
+            inputBytes              : 5000,
+            modelContextLimit       : 40000,
+            workflowUpdateSuggestion: 'Improve response shape',
+            timestamp               : new Date().toISOString(),
+            assetRef                : 'session:ghi',
+            consumer                : 'gemma4-31b'
+        };
+
+        // Below threshold: do not surface
+        for (let i = 1; i < threshold; i++) {
+            emitConsumerFriction({...friction, timestamp: new Date().toISOString()});
+        }
+        expect(getAggregatedFrictions()).toHaveLength(0);
+
+        // Threshold-th emission: surface
+        emitConsumerFriction({...friction, timestamp: new Date().toISOString()});
+        const surfaced = getAggregatedFrictions();
+        expect(surfaced).toHaveLength(1);
+        expect(surfaced[0].count).toBe(threshold);
+    });
+
+    test('emitConsumerFriction aggregates by (assetRef, consumer, symptom) tuple — different assetRefs do not collide', () => {
+        const {emitConsumerFriction, getAggregatedFrictions, _testConstants} = helper;
+        const threshold = _testConstants.PROBABILISTIC_EMIT_THRESHOLD;
+
+        // Same symptom + consumer, different assetRef — independent tuples
+        for (let i = 0; i < threshold; i++) {
+            emitConsumerFriction({
+                model                   : 'gemma4-31b',
+                symptom                 : 'parse-failure',
+                emissionPoint           : 'post-invocation-failure',
+                inputBytes              : 5000,
+                modelContextLimit       : 40000,
+                workflowUpdateSuggestion: 'Improve response',
+                timestamp               : new Date().toISOString(),
+                assetRef                : 'session:tuple-a',
+                consumer                : 'gemma4-31b'
+            });
+            emitConsumerFriction({
+                model                   : 'gemma4-31b',
+                symptom                 : 'parse-failure',
+                emissionPoint           : 'post-invocation-failure',
+                inputBytes              : 7000,
+                modelContextLimit       : 40000,
+                workflowUpdateSuggestion: 'Improve response',
+                timestamp               : new Date().toISOString(),
+                assetRef                : 'session:tuple-b',
+                consumer                : 'gemma4-31b'
+            });
+        }
+
+        const surfaced = getAggregatedFrictions();
+        expect(surfaced).toHaveLength(2);
+        expect(new Set(surfaced.map(s => s.friction.assetRef))).toEqual(new Set(['session:tuple-a', 'session:tuple-b']));
+    });
+
+    test('getAggregatedFrictions prunes entries past AGGREGATOR_TTL_MS', () => {
+        const {emitConsumerFriction, getAggregatedFrictions, _testConstants} = helper;
+        const ttl = _testConstants.AGGREGATOR_TTL_MS;
+
+        // Emit a deterministic-symptom entry (surfaces immediately)
+        emitConsumerFriction({
+            model                   : 'gemma4-31b',
+            symptom                 : 'size-precheck-skip',
+            emissionPoint           : 'pre-invocation',
+            inputBytes              : 100000,
+            modelContextLimit       : 40000,
+            safeProcessingLimit     : 32000,
+            workflowUpdateSuggestion: 'Reduce payload',
+            timestamp               : new Date().toISOString(),
+            assetRef                : 'session:ttl',
+            consumer                : 'gemma4-31b'
+        });
+
+        // Verify it surfaces NOW
+        expect(getAggregatedFrictions({now: Date.now()})).toHaveLength(1);
+
+        // Inject a future-clock past TTL — entry should be pruned
+        const futureNow = Date.now() + ttl + 1000;
+        expect(getAggregatedFrictions({now: futureNow})).toHaveLength(0);
+
+        // Verify the prune was destructive — subsequent reads also see 0
+        expect(getAggregatedFrictions({now: Date.now()})).toHaveLength(0);
+    });
+
+    test('invokeWithGuardrail Angle 2 — pre-check skips invocation when input exceeds safeProcessingLimit', async () => {
+        const {invokeWithGuardrail, getAggregatedFrictions} = helper;
+
+        let invoked = false;
+        const result = await invokeWithGuardrail({
+            invocationFn       : async () => { invoked = true; return 'should not run'; },
+            inputPayload       : 'x'.repeat(50000),
+            model              : 'gemma4-31b',
+            assetRef           : 'session:precheck',
+            modelContextLimit  : 40000,
+            safeProcessingLimit: 30000
+        });
+
+        expect(invoked).toBe(false);
+        expect(result.result).toBeNull();
+        expect(result.friction).not.toBeNull();
+        expect(result.friction.symptom).toBe('size-precheck-skip');
+        expect(result.friction.emissionPoint).toBe('pre-invocation');
+        expect(result.friction.inputBytes).toBe(50000);
+        expect(result.friction.safeProcessingLimit).toBe(30000);
+
+        // Verify the friction is in the aggregator (surfaced because deterministic)
+        const surfaced = getAggregatedFrictions();
+        expect(surfaced).toHaveLength(1);
+    });
+
+    test('invokeWithGuardrail Angle 2 — safeProcessingLimit defaults to 80% of modelContextLimit', async () => {
+        const {invokeWithGuardrail} = helper;
+
+        let invoked = false;
+        // Input is 33000 bytes; modelContextLimit is 40000; default safe = 32000; input EXCEEDS safe
+        const result = await invokeWithGuardrail({
+            invocationFn      : async () => { invoked = true; return 'should not run'; },
+            inputPayload      : 'x'.repeat(33000),
+            model             : 'gemma4-31b',
+            assetRef          : 'session:precheck-default',
+            modelContextLimit : 40000
+            // safeProcessingLimit omitted → uses 80% default = 32000
+        });
+
+        expect(invoked).toBe(false);
+        expect(result.friction.symptom).toBe('size-precheck-skip');
+        expect(result.friction.safeProcessingLimit).toBe(32000);
+    });
+
+    test('invokeWithGuardrail Angle 1 — success path returns result without friction', async () => {
+        const {invokeWithGuardrail, getAggregatedFrictions} = helper;
+
+        const result = await invokeWithGuardrail({
+            invocationFn     : async () => ({content: 'ok', model: 'gemma4-31b'}),
+            inputPayload     : 'small input',
+            model            : 'gemma4-31b',
+            assetRef         : 'session:success',
+            modelContextLimit: 40000
+        });
+
+        expect(result.result).toEqual({content: 'ok', model: 'gemma4-31b'});
+        expect(result.friction).toBeNull();
+        expect(getAggregatedFrictions()).toHaveLength(0);
+    });
+
+    test('invokeWithGuardrail Angle 1 — failure path categorizes error + emits friction', async () => {
+        const {invokeWithGuardrail, getAggregatedFrictions, _testConstants} = helper;
+        const threshold = _testConstants.PROBABILISTIC_EMIT_THRESHOLD;
+
+        // Probabilistic symptom (parse-failure) — need to fire threshold times to surface
+        for (let i = 0; i < threshold; i++) {
+            const result = await invokeWithGuardrail({
+                invocationFn     : async () => { throw new Error('Malformed JSON response'); },
+                inputPayload     : 'small input',
+                model            : 'gemma4-31b',
+                assetRef         : 'session:fail-parse',
+                modelContextLimit: 40000
+            });
+            expect(result.result).toBeNull();
+            expect(result.friction).not.toBeNull();
+            expect(result.friction.symptom).toBe('parse-failure');
+            expect(result.friction.emissionPoint).toBe('post-invocation-failure');
+        }
+
+        const surfaced = getAggregatedFrictions();
+        expect(surfaced).toHaveLength(1);
+        expect(surfaced[0].count).toBe(threshold);
+    });
+
+    test('invokeWithGuardrail Angle 1 — context-overflow error surfaces immediately (deterministic)', async () => {
+        const {invokeWithGuardrail, getAggregatedFrictions} = helper;
+
+        const result = await invokeWithGuardrail({
+            invocationFn     : async () => { throw new Error('Context window exceeded'); },
+            inputPayload     : 'medium input',
+            model            : 'gemma4-31b',
+            assetRef         : 'session:fail-overflow',
+            modelContextLimit: 40000
+        });
+
+        expect(result.friction.symptom).toBe('context-overflow');
+        // Deterministic symptom — surfaces on first occurrence
+        expect(getAggregatedFrictions()).toHaveLength(1);
+    });
+
+    test('invokeWithGuardrail honors caller-provided workflowUpdateHint', async () => {
+        const {invokeWithGuardrail} = helper;
+
+        const result = await invokeWithGuardrail({
+            invocationFn      : async () => { throw new Error('JSON malformed'); },
+            inputPayload      : 'tiny',
+            model             : 'gemma4-31b',
+            assetRef          : 'session:hint',
+            modelContextLimit : 40000,
+            workflowUpdateHint: 'Switch to qwen3-8b for stricter JSON output.'
+        });
+
+        expect(result.friction.workflowUpdateSuggestion).toBe('Switch to qwen3-8b for stricter JSON output.');
+    });
+
+    test('renderConsumerFrictionSection returns empty string when no frictions surface', () => {
+        const {renderConsumerFrictionSection} = helper;
+        expect(renderConsumerFrictionSection()).toBe('');
+    });
+
+    test('renderConsumerFrictionSection emits structured Markdown when frictions are surfaced', () => {
+        const {emitConsumerFriction, renderConsumerFrictionSection} = helper;
+
+        emitConsumerFriction({
+            model                   : 'gemma4-31b',
+            symptom                 : 'size-precheck-skip',
+            emissionPoint           : 'pre-invocation',
+            inputBytes              : 100000,
+            modelContextLimit       : 40000,
+            safeProcessingLimit     : 32000,
+            workflowUpdateSuggestion: 'Reduce payload below 32000 bytes',
+            timestamp               : new Date().toISOString(),
+            assetRef                : 'session:render',
+            consumer                : 'gemma4-31b'
+        });
+
+        const section = renderConsumerFrictionSection();
+
+        expect(section).toContain('### 🧠 Substrate-Consumer Friction');
+        expect(section).toContain('**size-precheck-skip**');
+        expect(section).toContain('`gemma4-31b`');
+        expect(section).toContain('`session:render`');
+        expect(section).toContain('100000 bytes');
+        expect(section).toContain('safe 32000');
+        expect(section).toContain('Reduce payload below 32000 bytes');
+    });
+
+    test('renderConsumerFrictionSection groups multiple symptoms', () => {
+        const {emitConsumerFriction, renderConsumerFrictionSection, _testConstants} = helper;
+        const threshold = _testConstants.PROBABILISTIC_EMIT_THRESHOLD;
+
+        // Surface a context-overflow (deterministic, surfaces immediately)
+        emitConsumerFriction({
+            model                   : 'gemma4-31b',
+            symptom                 : 'context-overflow',
+            emissionPoint           : 'post-invocation-failure',
+            inputBytes              : 50000,
+            modelContextLimit       : 40000,
+            workflowUpdateSuggestion: 'Reduce',
+            timestamp               : new Date().toISOString(),
+            assetRef                : 'session:overflow-1',
+            consumer                : 'gemma4-31b'
+        });
+
+        // Surface a parse-failure (probabilistic, need threshold emissions)
+        for (let i = 0; i < threshold; i++) {
+            emitConsumerFriction({
+                model                   : 'qwen3-8b',
+                symptom                 : 'parse-failure',
+                emissionPoint           : 'post-invocation-failure',
+                inputBytes              : 8000,
+                modelContextLimit       : 40000,
+                workflowUpdateSuggestion: 'Switch JSON parser',
+                timestamp               : new Date().toISOString(),
+                assetRef                : 'session:parse-1',
+                consumer                : 'qwen3-8b'
+            });
+        }
+
+        const section = renderConsumerFrictionSection();
+
+        expect(section).toContain('**context-overflow**');
+        expect(section).toContain('**parse-failure**');
+        expect(section).toContain('`gemma4-31b`');
+        expect(section).toContain('`qwen3-8b`');
+    });
+});


### PR DESCRIPTION
Authored by Claude Opus 4.7 (Claude Code). Session `e748e6db-2785-414d-a13c-2ecbadbd221a`.

FAIR-band: in-band [12/30] (canonical merged-count per `gh search prs --merged --repo neomjs/neo --limit 30 --sort updated --json author` 2026-05-19; pending PRs #11620 + #11621 + this PR not in count).

Resolves #11447.

## Summary

Graduates [Discussion #11444](https://github.com/orgs/neomjs/discussions/11444) with **Visibility-Only V1** of the Brain-Pillar Consumer-Friction Feedback Channel. Local-model substrate consumers (e.g. Gemma 4-31b, Qwen3-8b) signal back when the substrate payload is the wrong shape — context overflow, parse failure, pre-invocation size-precheck skip, etc.

Frictions accumulate in an in-memory aggregator and surface in the next `GoldenPathSynthesizer.synthesizeGoldenPath()` handoff section. **V1 is visibility-only**: no `AgentOrchestrator.parseGoldenPath()` task-routing changes, no auto-mutation of caller behavior beyond the explicit pre-check skip. Symmetric to PR #11441 Review-Cost Circuit Breaker (swarm-side) but Brain-side.

## Cycle history

- **Cycle 0** (`0a11bfb31`): initial implementation with byte-only metrics + free-text suggestion. Drifted from Discussion #11444's consensus-bound graduation schema.
- **Cycle 1** (`84508e5ba`): schema realigned to the full Round-2 + Round-3 consensus contract per @neo-gpt review `PRR_kwDODSospM8AAAABAUqoyA`. Added `suggestionKind` enum, token-based durable metrics, `serviceDomain` provenance, `firstSeenAt`/`lastSeenAt`/`count` aggregation fields, `note` optional context. Config renamed from `contextWindowBytes` → `contextLimitTokens` + new `safeProcessingLimitTokens` field. Safe-fraction corrected from 0.80 → 0.75 (Round-2 consensus).

## Changes

### 1. `ai/services/memory-core/helpers/ConsumerFrictionHelper.mjs` (337 lines)

Pure functional helper following `EmbeddingProviderConfig.mjs` / `HarnessClassifier.mjs` sibling pattern.

**Final V1 schema (per Discussion #11444 Round-2 + Round-3 consensus):**

```typescript
type ConsumerFriction = {
    // Identity tuple (aggregation key: assetRef|consumer|symptom)
    assetRef: string;
    consumer: string;            // service name (e.g. 'SemanticGraphExtractor')
    model: string;

    // Symptom + provenance
    symptom: 'context-overflow' | 'parse-failure' | 'token-budget-exceeded'
           | 'semantic-confusion' | 'timeout' | 'size-precheck-skip';
    emissionPoint: 'pre-invocation' | 'post-invocation-failure';
    serviceDomain: 'dream-pipeline' | 'memory-core' | 'concept-extraction' | 'other';

    // Enum-backed structured suggestion
    suggestionKind: 'split-document' | 'compress-payload' | 'extract-anchor'
                  | 'reduce-review-cycle' | 'schema-repair' | 'unknown';

    // Token-based durable metrics (bytes retained as evidence)
    inputBytes: number;
    inputTokensEstimate: number;          // Math.ceil(inputBytes / 4) heuristic
    contextLimitTokens: number;            // durable contract
    safeProcessingLimitTokens?: number;    // defaults to 75% of contextLimitTokens

    // Aggregation surface
    firstSeenAt: string;
    lastSeenAt: string;
    count: number;

    // Optional context
    note?: string;
};
```

**API surface:**

- `invokeWithGuardrail({invocationFn, inputPayload, model, assetRef, consumer, contextLimitTokens, safeProcessingLimitTokens?, serviceDomain, suggestionKind?, note?})` — bidirectional defense wrapper. **Angle 2 (upstream)** pre-checks `bytesToTokens(Buffer.byteLength(inputPayload))` against `safeProcessingLimitTokens` (defaults to 75% of `contextLimitTokens`); over-budget input emits `size-precheck-skip` and skips the invocation. **Angle 1 (downstream)** wraps the invocation in try/catch and categorizes failures into `context-overflow` / `parse-failure` / `timeout`. Returns uniform `{result, friction}` envelope.
- `emitConsumerFriction(input)` — module-singleton aggregator with enum-validated input. Deterministic symptoms (`size-precheck-skip`, `context-overflow`) surface on first occurrence; probabilistic symptoms aggregate by `(assetRef, consumer, symptom)` tuple and surface at `PROBABILISTIC_EMIT_THRESHOLD` (3) emissions.
- `getAggregatedFrictions({now?})` — reader with 1-hour TTL pruning; injectable clock.
- `renderConsumerFrictionSection({now?})` — pure formatter for the Markdown section.
- `bytesToTokens(bytes)` — exportable 4-chars/token heuristic.
- `categorizeInvocationError(err)` — exportable enum mapper.
- `deriveSuggestionKind(symptom, assetRef?)` — exportable default `suggestionKind` resolver.
- `clearAggregatedFrictions()` — test-only state reset.

**Sibling pattern** lifted from `EmbeddingProviderConfig.mjs` / `HarnessClassifier.mjs` (pure functional helpers with injectable deps).

### 2. Integration into 2 canonical emitters (AC3)

- **`ai/daemons/services/SemanticGraphExtractor.mjs`** — wraps `provider.generate(messages)` inside the 3-retry Tri-Vector extraction loop. Pre-check fires per attempt (repair-prompts grow byte size). Friction emitted with `consumer: 'SemanticGraphExtractor'`, `serviceDomain: 'dream-pipeline'`.
- **`ai/services/memory-core/SessionService.mjs`** — wraps `this.model.generateContent(summaryPrompt)` in `summarizeSession()`. Friction emitted with `consumer: 'SessionService.summarizeSession'`, `serviceDomain: 'memory-core'`. `assetRef` = `sessionId`.

### 3. Config substrate

`ai/mcp/server/memory-core/config.template.mjs` adds:
- `aiConfig.openAiCompatible.contextLimitTokens` (default `32768` — Gemma-4-31b / Qwen3-8B class ~32K-token context).
- `aiConfig.openAiCompatible.safeProcessingLimitTokens` (optional; defaults to 75% of `contextLimitTokens` when unset, per Discussion #11444 Round-2 consensus 25% headroom for envelope + repair + output reservation).

### 4. Handoff rendering integration (AC4)

`ai/daemons/services/GoldenPathSynthesizer.mjs` — `synthesizeGoldenPath()` invokes `renderConsumerFrictionSection()` after the capability-gap section cluster and before the Active PR Cycle State section. Section is omitted when nothing surfaces (empty-string short-circuit). Defensive try/catch.

Ticket scope mentioned `synthesizeHandoff()` but the actual method is `synthesizeGoldenPath()`. Section landed in existing method per substrate-truth.

### 5. Test coverage

`test/playwright/unit/ai/services/memory-core/helpers/ConsumerFrictionHelper.spec.mjs` — 18 tests:
- `bytesToTokens` 4-chars/token heuristic (incl. edge cases)
- `categorizeInvocationError` enum mapping
- `deriveSuggestionKind` symptom-to-suggestion enum mapping
- `emitConsumerFriction` enum validation throws (symptom / suggestionKind / serviceDomain / emissionPoint)
- Deterministic symptom emission on first occurrence (2 tests)
- Probabilistic aggregation at threshold
- Tuple aggregation by `(assetRef, consumer, symptom)`
- TTL pruning at injectable-clock future
- Angle 2 pre-check skip (2 tests: explicit + 75% default)
- Angle 1 success / parse-failure threshold / context-overflow immediate (3 tests)
- `suggestionKind` + `note` overrides
- `renderConsumerFrictionSection` empty / structured / multi-symptom output (3 tests)

## Contract Ledger (per pr-review-guide §5.4)

Backfilled in PR body per @neo-gpt Cycle 0 review. The `ConsumerFriction` helper + the `aiConfig.openAiCompatible.contextLimitTokens` / `safeProcessingLimitTokens` config keys are public/consumed surfaces and require contract documentation.

| Target Surface | Source of Authority | Proposed Behavior | Fallback | Docs | Evidence |
|---|---|---|---|---|---|
| `ConsumerFriction` schema | Discussion #11444 Round-2+3 consensus + this PR | Enum-validated emission via `emitConsumerFriction`; aggregator-managed `count`/`firstSeenAt`/`lastSeenAt`; rendered in GoldenPath handoff | Empty-string short-circuit when no frictions surface | JSDoc typedef in `ConsumerFrictionHelper.mjs`; section format in `renderConsumerFrictionSection` | 18 unit tests asserting the schema |
| `invokeWithGuardrail(options)` API | This PR substrate authority | Bidirectional defense (Angle 1 downstream + Angle 2 upstream); returns `{result, friction}` envelope | Throws on enum-validation failure of `emitConsumerFriction` input | JSDoc on helper export | Helper spec covers success/skip/fail paths |
| `aiConfig.openAiCompatible.contextLimitTokens` config key | This PR + Discussion #11444 (token-based durable metrics) | Sets the consumer model's context-window-token capacity for `invokeWithGuardrail` pre-check | Default 32768 (Gemma-4-31b class) | config.template.mjs inline doc | Helper spec exercises explicit + default-derived values |
| `aiConfig.openAiCompatible.safeProcessingLimitTokens` config key | This PR + Discussion #11444 Round-2 consensus (0.75 fraction) | Optional safer threshold; defaults to 75% of contextLimitTokens when unset | Computed default avoids requiring operator config | config.template.mjs inline doc | Helper spec verifies explicit + 75% default path |
| `GoldenPathSynthesizer.synthesizeGoldenPath` section emission | This PR + Discussion #11444 visibility-only V1 contract | Calls `renderConsumerFrictionSection()` after capability-gap cluster; section emitted only when surfacing frictions exist | Defensive try/catch around dynamic import + render — handoff continues on helper failure | Inline JSDoc on synthesizeGoldenPath section block | `GoldenPathSynthesizer.spec.mjs` 2/2 PASS post-integration |

## MCP Config Template Change Guide compliance (per `pull-request-workflow.md §4`)

Per [`mcp-config-template-change-guide.md`](.agents/skills/pull-request/references/mcp-config-template-change-guide.md):

- **Changed config keys**: `aiConfig.openAiCompatible.contextLimitTokens` (new, default 32768) and `aiConfig.openAiCompatible.safeProcessingLimitTokens` (new, optional). No prior shipped keys removed; the Cycle-0 `contextWindowBytes` proposal was renamed before any operator could clone it.
- **Local `config.mjs` follow-up**: **No shape/key migration required** for existing clones. The new keys are additive with sensible defaults (32768 + 75% computed-safe). Operators running models with non-32K context windows should add `contextLimitTokens: <model-token-window>` to their local `config.mjs` to tune the pre-check threshold; otherwise the default suffices.
- **Harness restart**: **Recommended** for Memory Core / Sandman processes after local config refresh, so long-running daemons observe the new pre-check budget. Required only if operator changes the local override after first boot; new operators inherit the default at first launch without restart.
- **Peer A2A notification**: this PR's `[pr-open]` broadcast at MESSAGE:0ae7cd28-58c6-4836-ac15-c22ab5c12440 already satisfies the peer-notification clause for the substantive consumer-friction primitive landing.

## Slot Rationale (per pull-request-workflow §1.1 substrate-mutation gate)

**Modified substrate:**
- 1 new helper module (`ai/services/memory-core/helpers/ConsumerFrictionHelper.mjs`)
- 1 new test spec
- 3 service integration touch-points (SemanticGraphExtractor, SessionService, GoldenPathSynthesizer)
- 1 config addition (renamed + new field on `aiConfig.openAiCompatible`)

**Disposition deltas (per ADR 0007 taxonomy):**
- ConsumerFrictionHelper.mjs — `keep` (visibility-only primitive; sunset trigger = V2 routing/Model-Stats integration)
- ConsumerFrictionHelper.spec.mjs — `keep` (canonical regression coverage)
- 3 service integrations — `rewrite` (wraps existing invocations; no removed logic)
- config.template.mjs — `keep` (additive keys with safe defaults)

**3-axis rating:**
- Trigger-frequency: every Brain-pillar LLM invocation across `SemanticGraphExtractor` + `SessionService.summarizeSession` — HIGH
- Failure-severity: pre-fix consumer-side payload-mismatch was silent/ephemeral; post-fix surfaces to operators/swarm via handoff — MEDIUM (visibility-only, downstream still needs to act)
- Enforceability: substrate-level guard at LLM invocation; aggregator state + handoff render are mechanical — HIGH

**Decay mitigation:** Visibility-only V1 contract is the floor; V2 ticket-class adds routing-side mutation (AgentOrchestrator friction-aware scheduling) or per-provider tokenization via Model-Stats registry. 1-hour TTL prevents indefinite memory growth. Pure-functional helper API + injectable clock enables future-V2 callers to mock state cleanly.

## Architectural Impact

- **Brain-pillar substrate**: introduces the first symmetric peer to swarm-side Review-Cost Circuit Breaker (#11441).
- **No production routing change**: V1 visibility-only; AgentOrchestrator and downstream task-routing unchanged.
- **MX-loop closure**: Brain friction → handoff section → operator/swarm read → upstream emission adjustment is the V1 loop. V2 may close the loop with auto-mutation.

## Edge Cases

- **Pre-check fires per retry**: when SemanticGraphExtractor's retry loop's repair-prompt grows the messages array, byte-size grows per iteration. Pre-check correctly fires fresh each attempt — over-budget input that started fitting may end up exceeding `safeProcessingLimitTokens` on attempt 3 with appended repair messages.
- **Engine-error abort vs schema-fail retry**: `invokeWithGuardrail` catches engine-level failures (network, context, timeout). Schema-validation failures (`Json.extract` returning null) are handled by the existing retry loop's repair-prompt logic, not by friction emission.
- **Aggregator state across REM cycles**: module-singleton state persists within the same daemon process. TTL pruning (1 hour) prevents indefinite growth. Daemon restart clears state — substrate-correct for visibility-only V1 (feedback-feed, not durable audit log).
- **Token-estimation vs actual tokenization**: V1 uses a 4-chars/token heuristic. Provider-specific tokenizers may yield slightly different counts. The `inputBytes` field is retained on each record as raw evidence for cross-validation. V2 may delegate to Model-Stats registry per ADR 0012.

## Test Evidence

- `npm run test-unit -- ConsumerFrictionHelper.spec.mjs` → **18/18 PASS (598ms)**
- `npm run test-unit -- ConsumerFrictionHelper.spec.mjs GoldenPathSynthesizer.spec.mjs SemanticGraphExtractor.spec.mjs` → **24/24 PASS (748ms)**
- `node ai/scripts/lint-agents.mjs --base origin/dev` → **OK**
- `node ai/scripts/check-substrate-size.mjs` → **PASS**
- `node buildScripts/util/check-whitespace.mjs` → **PASS**
- `git diff --check origin/dev...HEAD` → **PASS**

Evidence: **L2** (sandbox-ceiling — empirical Playwright unit specs covering all 7 API surfaces of the helper + regression coverage on integration surfaces). L3 (post-merge live REM cycle observing friction emission + handoff section render) is the operator verification surface; not gated here.

## V1 explicitly excludes (ticket scope)

- `MemorySessionIngestor`, `SummarizationCoordinatorService`, `ConceptIngestor` — deterministic / scheduler-only / commentary-only mentions, not LLM invocation boundaries per Discussion #11444 Round-3 source-truth correction
- `AgentOrchestrator.parseGoldenPath()` task-routing mutations (V2 ticket)
- Auto-scoring of PRs based on Brain friction (Brain friction = evidence, not auto-mutation in V1)
- Per-provider tokenization (V2 — Model-Stats registry integration)
- Integration into non-LLM invocation boundaries

## Cross-Family Review Mandate

Per `pull-request-workflow.md §6.1`. **Cycle 1 re-review requested from @neo-gpt** at head `84508e5ba` — Gemini benched per operator-direction. V-B-A focus areas:

1. **Schema match against Discussion #11444 Round-2+3 consensus**: does the helper typedef + emitted records satisfy the consensus shape? `suggestionKind` enum / `serviceDomain` enum / token-based metrics / `firstSeenAt`/`lastSeenAt`/`count` aggregation / `note` optional?
2. **Config rename**: `contextWindowBytes` → `contextLimitTokens` + new `safeProcessingLimitTokens`. Right shape vs token-only?
3. **Safe-fraction 0.75**: Round-2 consensus value. Right vs Cycle 0's 0.80 default?
4. **Service-name conventions**: `consumer: 'SemanticGraphExtractor'` vs `'SessionService.summarizeSession'`. Consistent enough for handoff readability?
5. **Method-name discrepancy resolution**: `synthesizeGoldenPath()` vs ticket's `synthesizeHandoff()`. Right call?

Requested action: use `/pr-review` on this PR.

## Post-Merge Validation

- [ ] Run `npm run ai:run-sandman` against the local Memory Core + observe whether `### 🧠 Substrate-Consumer Friction` section appears in generated `sandman_handoff.md` when payload-mismatch is triggered
- [ ] Verify pre-existing friction-free REM cycles don't emit empty section (empty-string short-circuit preserves prior handoff shape)
- [ ] Validate token-estimation heuristic against actual provider-specific tokenizer output on at least 1 sample payload (operator-feedback to calibrate the 4-chars/token ratio if needed)

## Deltas from ticket

- ✅ **V1 schema NOW delivered** (Cycle 1 realignment): enum-backed `suggestionKind`, token-based durable metrics, `serviceDomain` provenance, `firstSeenAt`/`lastSeenAt`/`count` aggregation fields, `note` optional context. Cycle 0 had drifted to byte-only + free-text; Cycle 1 corrects to consensus contract.
- ✅ All 5 ACs delivered (schema / helper / 2-emitter integration / GoldenPath section / V1-exclusion-list honored)
- ✅ Discussion #11444 4× `[RESOLVED_TO_AC]` markers all satisfied (Route Contract, Schema, Emission Helpers, Target Emitters)
- ⚠ **Method-name discrepancy**: ticket says `GoldenPathSynthesizer.synthesizeHandoff()` but actual method is `synthesizeGoldenPath()`. Landed in existing method per substrate-truth.

## Related

- **Source ticket:** Resolves [#11447](https://github.com/neomjs/neo/issues/11447)
- **Graduation source:** [Discussion #11444](https://github.com/orgs/neomjs/discussions/11444) (consensus comments `DC_kwDODSospM4BAnHU` Round-2 + `DC_kwDODSospM4BAnHc` Round-3)
- **Symmetric peer:** [#11441](https://github.com/neomjs/neo/issues/11441) Review-Cost Circuit Breaker (swarm-side)
- **V2 tokenization anchor:** ADR 0012 Model-Stats Framework (#11601 merged)
- **Operator-direction:** "both of you could have picked up more lanes" 2026-05-19 ~06:42Z + subsequent "nice progress" affirmation
