### PR TITLE
feat(kb): scaffold Phase 0/1A ingestion contracts (#11629)

### DIFF
--- a/ai/services/knowledge-base/parser/backup-record-v1.schema.json
+++ b/ai/services/knowledge-base/parser/backup-record-v1.schema.json
@@ -1,0 +1,34 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$id": "https://neomjs.com/schemas/backup-record-v1.schema.json",
+    "title": "backup-record-v1",
+    "description": "Restore-only record shape produced by DatabaseService.manageDatabaseBackup({action: 'export'}) and consumed by manageDatabaseBackup({action: 'import'}). Embeddings are preserved verbatim — NO re-embedding is triggered on import. Distinct from parsed-chunk-v1 (ingest-time, server-embeds). Restore is sound only when the embedding model + Chroma collection schema match the export environment (#10129 atomic-bundle context). See: DatabaseService.mjs:250-349 (import path), DatabaseService.mjs:99-211 (export path), Discussion #11623 §3 audit table + §11 Avoided Trap 'Conflating backup-record-v1 (restore) with ingest contract'.",
+    "type": "object",
+    "additionalProperties": false,
+    "required": [
+        "id",
+        "metadata",
+        "document"
+    ],
+    "properties": {
+        "id": {
+            "type": "string",
+            "minLength": 1,
+            "description": "Chroma vector id. For records originally produced by the Neo KB ingest pipeline this is the chunk content-hash (sha256 of the canonical chunk shape; see DatabaseService.createContentHash). Backup-record-v1 transports this id verbatim — collections must be empty or merge-compatible at restore time, or 'mode: replace' is required to wipe the target first."
+        },
+        "embedding": {
+            "type": "array",
+            "items": { "type": "number" },
+            "description": "The pre-computed embedding vector. OPTIONAL because Chroma can re-embed at upsert time when this field is absent and an embedding function is bound to the collection. In practice, Neo's backup format always carries the embedding for fast bounded-cost restore (key #10129 design goal). Vector dimensionality MUST match the destination Chroma collection's embedding-function dimensionality; mismatch is a hard restore failure."
+        },
+        "metadata": {
+            "type": "object",
+            "description": "Free-form chunk metadata. Carries everything that was on the chunk at upsert time — including tenant fields once Phase 0/1C ships server-stamped {tenantId, visibility, originAgentIdentity?} into chunk metadata. Restore copies this verbatim; no re-stamping happens during import."
+        },
+        "document": {
+            "type": "string",
+            "description": "The chunk text payload that Chroma stores alongside the embedding for retrieval-time hydration. Matches the parsed-chunk-v1.content field for records originally produced by the Neo ingest pipeline."
+        }
+    },
+    "$comment": "This schema formalizes the EXISTING shape produced by DatabaseService.exportDatabase and consumed by DatabaseService.importDatabase. It is not introducing new behavior; it documents the contract so downstream tooling (Phase 2 ingestion service, Phase 4 reconciliation/GC daemons, future cross-collection migration scripts) can validate restore payloads at service boundaries. Records with this shape MUST NOT enter the parsed-chunk-v1 ingest path — the Phase 2 KnowledgeBaseIngestionService routes restore-only records through DatabaseService.importDatabase exclusively, NOT through VectorService.embed (which re-embeds and would corrupt vector-id semantics)."
+}

--- a/ai/services/knowledge-base/parser/backup-record-v1.schema.json
+++ b/ai/services/knowledge-base/parser/backup-record-v1.schema.json
@@ -7,6 +7,7 @@
     "additionalProperties": false,
     "required": [
         "id",
+        "embedding",
         "metadata",
         "document"
     ],
@@ -19,7 +20,8 @@
         "embedding": {
             "type": "array",
             "items": { "type": "number" },
-            "description": "The pre-computed embedding vector. OPTIONAL because Chroma can re-embed at upsert time when this field is absent and an embedding function is bound to the collection. In practice, Neo's backup format always carries the embedding for fast bounded-cost restore (key #10129 design goal). Vector dimensionality MUST match the destination Chroma collection's embedding-function dimensionality; mismatch is a hard restore failure."
+            "minItems": 1,
+            "description": "The pre-computed embedding vector. REQUIRED to match the current DatabaseService.importDatabase() restore path which calls `collection.upsert({ ids, embeddings: batch.map(r => r.embedding), metadatas, documents })`. A missing embedding field would land in the upsert as an `undefined` slot in the embeddings array — Chroma only re-embeds when the ENTIRE recordSet.embeddings property is absent, not when individual slots are undefined. Honoring no-embedding restore would require runtime changes to importDatabase to omit the embeddings field when appropriate (out of scope for #11629 Phase 0/1A). Vector dimensionality MUST match the destination Chroma collection's embedding-function dimensionality; mismatch is a hard restore failure."
         },
         "metadata": {
             "type": "object",

--- a/ai/services/knowledge-base/parser/deletion-signaling-contract.md
+++ b/ai/services/knowledge-base/parser/deletion-signaling-contract.md
@@ -1,0 +1,100 @@
+# Deletion-Signaling Contract
+
+The deletion-signaling contract is the incremental-push deletion-detection contract introduced by Phase 0/1A of Epic [#11624](https://github.com/neomjs/neo/issues/11624). It complements (does NOT replace) the existing content-hash full-corpus delete logic in [`VectorService.mjs:198-207`](../VectorService.mjs).
+
+## The gap this closes
+
+Today's KB delete logic ([`VectorService.mjs:198-207`](../VectorService.mjs)) computes `allIds = Set(every chunk hash in the FULL corpus)` and deletes existing Chroma ids not in that set. This works under FULL-corpus sync only — when the entire knowledge base is regenerated on disk and embedded fresh.
+
+For Phase 2 incremental cloud push (where a client tenant sends only changed files via `ingestSourceFiles`), the server has NO global view of the tenant's claimed state. Without explicit deletion-signaling, deleted-on-client files would persist as orphaned chunks in Chroma forever.
+
+## Three mutually-supporting mechanisms
+
+A push payload (Phase 2A [`KnowledgeBaseIngestionService.ingestSourceFiles`](../../../../ai/services/knowledge-base/) once shipped) MAY include any combination of:
+
+### 1. Explicit tombstones
+
+```jsonc
+{
+  "tenantId": "...",
+  "files": [/* changed files */],
+  "deleted": [
+    { "sourcePath": "src/old-module.mjs", "repoSlug": "main-app" },
+    { "sourcePath": "src/another-removed.mjs", "repoSlug": "main-app" }
+  ]
+}
+```
+
+Fast, light, single-record-granular. Requires the client (typically a git hook) to track deletes — usable when the client wraps `git diff --diff-filter=D` or equivalent.
+
+### 2. Manifest snapshot
+
+```jsonc
+{
+  "tenantId": "...",
+  "files": [/* changed files */],
+  "manifestSnapshot": {
+    "repoSlug": "main-app",
+    "pathsAfterPush": [
+      "src/index.mjs",
+      "src/foo.mjs",
+      "docs/README.md"
+    ]
+  }
+}
+```
+
+Robust against missed-delete-signaling (e.g., a hook that skipped tracking deletes). Server reconciles: any Chroma chunk with `metadata.sourcePath` not in `pathsAfterPush` AND `metadata.repoSlug == manifest.repoSlug` is orphaned and queued for deletion (per Phase 4C garbage-collection daemon retention policy). Higher payload cost — O(N) per push where N = post-push file count.
+
+### 3. Revision boundary
+
+```jsonc
+{
+  "tenantId": "...",
+  "files": [/* changed files */],
+  "baseRevision": "<last-pushed-SHA>",
+  "headRevision": "<current-SHA>"
+}
+```
+
+Server compares against tenant's last-known revision (tracked in `KnowledgeBaseTenantConfig` Phase 2E [`#11637`](https://github.com/neomjs/neo/issues/11637)) to derive the deletion set without explicit client signaling. Best for repos with linear history; force-push history rewrites need Phase 4B reconciliation daemon ([`#11640`](https://github.com/neomjs/neo/issues/11640)) to detect the rewrite and trigger full reconciliation.
+
+## Client-side hook patterns
+
+Clients pick the mechanism that fits their workflow:
+
+| Workflow | Recommended primary | Fallback |
+|---|---|---|
+| Small repos (< 1k files), git-hook-triggered | Manifest snapshot (cheap to enumerate; robust) | Tombstones |
+| Large repos (1k+ files), git-hook-triggered | Tombstones + revision-boundary | Periodic manifest reconciliation (Phase 4B daemon-driven) |
+| Rapid hooks (post-commit fires on every commit) | Revision-boundary only | Periodic manifest reconciliation (Phase 4B daemon-driven) |
+
+Phase 3 ([`#11627`](https://github.com/neomjs/neo/issues/11627)) `HookWiring.md` guide documents reference patterns. Phase 3's pre-push hook example demonstrates tombstone + revision-boundary combined.
+
+## Multi-mechanism precedence
+
+When a single push payload includes multiple mechanisms, the server applies them in order:
+
+1. **Revision-boundary** computes the expected change set
+2. **Tombstones** add explicit deletes (extends the expected set)
+3. **Manifest snapshot** reconciles against the resulting set; surplus chunks → orphans
+
+This precedence means richer payloads override sparser ones — clients that send all three get the most precise deletion handling. Clients that send fewer fields trade precision for payload size.
+
+## Out of scope
+
+- Bulk import deletion-signaling (CLI `npm run ai:ingest-tenant`) — bulk imports are typically initial-load OR full-resync; deletion signaling on bulk-paths is operator-config-driven, not per-push.
+- Tombstone TTL / grace period — Phase 4C ([`#11641`](https://github.com/neomjs/neo/issues/11641)) garbage-collection daemon owns retention semantics.
+- Restore-from-backup semantics — `backup-record-v1` restore preserves chunk ids verbatim including ids of since-deleted chunks; Phase 4B reconciliation daemon can detect this drift on a configurable schedule.
+
+## Related
+
+- Parent ticket: [#11629 Phase 0/1A](https://github.com/neomjs/neo/issues/11629)
+- Companion contract: [`identity-tuple.md`](identity-tuple.md)
+- Schema: [`parsed-chunk-v1.schema.json`](parsed-chunk-v1.schema.json)
+- VectorService full-corpus delete logic: [`VectorService.mjs:198-207`](../VectorService.mjs)
+- Phase 2A KnowledgeBaseIngestionService: [`#11633`](https://github.com/neomjs/neo/issues/11633)
+- Phase 2E tenant config storage (revision tracking): [`#11637`](https://github.com/neomjs/neo/issues/11637)
+- Phase 4B reconciliation daemon: [`#11640`](https://github.com/neomjs/neo/issues/11640)
+- Phase 4C garbage-collection daemon: [`#11641`](https://github.com/neomjs/neo/issues/11641)
+- Discussion [#11623](https://github.com/neomjs/neo/discussions/11623) §4 Q11 + §6 sweep point 4 + §11 Avoided Trap "Content-hash delta as sole deletion mechanism"

--- a/ai/services/knowledge-base/parser/identity-tuple.md
+++ b/ai/services/knowledge-base/parser/identity-tuple.md
@@ -1,0 +1,50 @@
+# Path-Identity Tuple
+
+The path-identity tuple `{tenantId, repoSlug, rootKind, sourcePath}` is the cross-tenant chunk-identity contract introduced by Phase 0/1A of Epic [#11624](https://github.com/neomjs/neo/issues/11624) (Cloud-Native KB Ingestion for External Workspaces). It replaces the implicit single-`neoRootDir` source-path assumption baked into Neo's pre-v13 KB substrate (see [`ApiSource.mjs:101-105`](../source/ApiSource.mjs), [`SearchService.mjs:118-120`](../SearchService.mjs)).
+
+## Topology anchor
+
+Per [ADR 0003 — Chroma Topology Unified Only](../../../../learn/agentos/decisions/0003-chroma-topology-unified-only.md): one ChromaDB daemon, two MCP servers (KB + Memory Core), three collections (`knowledge-base`, `neo-agent-memory`, `neo-agent-sessions`). The path-identity tuple lives in `chunk.metadata` for records in the `knowledge-base` collection ONLY. Memory Core's `neo-agent-memory` + `neo-agent-sessions` collections use the existing `userId`/`memorySharing` provenance shape; this tuple does NOT extend cross-collection.
+
+## Tuple semantics
+
+| Field | Type | Meaning |
+|---|---|---|
+| `tenantId` | string (lowercase kebab; `^[a-z0-9][a-z0-9-]{0,62}[a-z0-9]$` or single char) | Authoritative tenant identifier. Server-stamped per Phase 0/1C ([#11631](https://github.com/neomjs/neo/issues/11631)) from authenticated AgentIdentity context; client-supplied values are OVERWRITTEN or REJECTED per `aiConfig.knowledgeBase.spoofRejectionMode`. The reserved team-namespace value `'neo-shared'` tags Neo's curated content (visible across tenants via `memorySharing: 'team'` semantics). |
+| `repoSlug` | string (non-empty) | Tenant-owned repo identifier within their workspace. Examples: `'client-org/main-app'`, `'internal/docs'`, `'core'` (for a tenant with a single primary repo). Disambiguates same `sourcePath` under different repos for the same tenant. |
+| `rootKind` | enum: `neo-workspace`, `bare-repo`, `external-source` | Repository topology hint. `neo-workspace` = `npx neo app`-created workspace where `neo` is a `node_module` dependency. `bare-repo` = plain git repo (any language, may be non-JS). `external-source` = non-VCS source (e.g., live API mirror, generated docs). Hint for hydration mode selection (Phase 2D Q12). |
+| `sourcePath` | string (forward-slash normalized, no leading slash) | Path relative to the `repoSlug` root. NOT resolved against KB server's `neoRootDir`. |
+
+## Tenant-aware chunkId derivation
+
+The server-side `chunkId` hash (`chunk.hash` per [`VectorService.mjs:188-194`](../VectorService.mjs)) is derived from the `hashInputs` field-list (parser-controlled) PLUS an implicit prepend of `tenantId` + `repoSlug` (server-controlled). The implicit prepend is what makes "same source content under two tenants" produce distinct ids — no cross-tenant chunk shadow attack.
+
+This is implemented in Phase 0/1B ([#11630](https://github.com/neomjs/neo/issues/11630)) registry extraction work and Phase 0/1C ([#11631](https://github.com/neomjs/neo/issues/11631)) write-side stamping work. Phase 0/1A (this sub) defines the contract; Phase 0/1B + 0/1C implement it.
+
+## Backward-compat for Neo's own content
+
+Neo's curated content (10 default sources: `AdrSource`, `ApiSource`, `ConceptSource`, etc.) is reformulated with:
+- `tenantId: 'neo-shared'`
+- `repoSlug: 'neo'`
+- `rootKind: 'neo-workspace'`
+- `sourcePath`: existing `neoRootDir`-relative path
+
+The Phase 0/1B byte-equivalence fixture validates that adding `tenantId` + `repoSlug` + `rootKind` to chunk metadata does NOT perturb the chunk-hash semantics for existing content (the hash-derivation function is backward-compatible for the `'neo-shared'` + `'neo'` constants).
+
+## Hydration
+
+`SearchService` hydration (current single-`neoRootDir` resolution at [`SearchService.mjs:118-120`](../SearchService.mjs)) is tenant-aware after Phase 2D ([#11636](https://github.com/neomjs/neo/issues/11636)) resolves Q12 (chunk-metadata-embedded vs server-mirror vs hybrid). Phase 0/1A defines the tuple shape; Phase 2D picks the hydration mode.
+
+## Out of scope
+
+- `tenantId` enforcement at storage layer (Chroma-layer RLS) — Phase 0/1D ([#11632](https://github.com/neomjs/neo/issues/11632)) ships application-layer enforcement (Q13b Option A); Chroma-layer is V2 if leak class manifests.
+- Cross-collection cross-tenant queries (joins between `knowledge-base` and `neo-agent-memory`) — out of scope for v13.
+- Per-tenant `repoSlug` namespace conflict resolution (two tenants both claiming `'client-org/main-app'`) — not a real conflict since `tenantId` namespaces `repoSlug`.
+
+## Related
+
+- Parent ticket: [#11629 Phase 0/1A](https://github.com/neomjs/neo/issues/11629)
+- Schema: [`parsed-chunk-v1.schema.json`](parsed-chunk-v1.schema.json)
+- Companion contract: [`deletion-signaling-contract.md`](deletion-signaling-contract.md)
+- ADR 0003 Chroma Topology Unified Only
+- Discussion [#11623](https://github.com/neomjs/neo/discussions/11623) §4 Q12 + §6 sweep point 3 + Cycle 2.5/2.6 absorption

--- a/ai/services/knowledge-base/parser/parsed-chunk-v1.schema.json
+++ b/ai/services/knowledge-base/parser/parsed-chunk-v1.schema.json
@@ -1,0 +1,106 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$id": "https://neomjs.com/schemas/parsed-chunk-v1.schema.json",
+    "title": "parsed-chunk-v1",
+    "description": "Client-side parsed knowledge chunk emitted by a tenant parser-runner and consumed by KnowledgeBaseIngestionService. Distinct from backup-record-v1 (restore-only, embedding-preserving). Records of this shape ALWAYS trigger server-side embedding via TextEmbeddingService.embedTexts(); records carrying an embedding field are routed away from this contract toward backup-record-v1 (restore-only) or rejected per spoof-rejection policy. See: ../source/Base.mjs (extract contract), ../../knowledge-base/VectorService.mjs (embedding pipeline at lines 243-274), Discussion #11623 §4 Q4 + §1 #3 + §7 Phase 0/1 + ADR 0003 Chroma Topology Unified Only.",
+    "type": "object",
+    "additionalProperties": false,
+    "required": [
+        "schemaVersion",
+        "tenantId",
+        "repoSlug",
+        "rootKind",
+        "sourcePath",
+        "content",
+        "hashInputs",
+        "parserId",
+        "parserVersion",
+        "kind",
+        "name"
+    ],
+    "properties": {
+        "schemaVersion": {
+            "type": "string",
+            "const": "1.0.0",
+            "description": "Schema version this record conforms to. Server validates exact match; deprecation warning emitted on version drift (Phase 2 ingestion service behavior)."
+        },
+        "tenantId": {
+            "type": "string",
+            "minLength": 1,
+            "pattern": "^[a-z0-9][a-z0-9-]{0,62}[a-z0-9]$|^[a-z0-9]$",
+            "description": "Authoritative tenant identifier. Server-OVERWRITES or REJECTS client-supplied values during ingestion per Phase 0/1C spoof-rejection invariant; the wire-format MUST still carry this field as the client's claim, but the server-stamped value is authoritative. The shared-Neo-content team-namespace constant is 'neo-shared' (reserved). Lowercase kebab-case constraint matches AgentIdentity slug convention."
+        },
+        "repoSlug": {
+            "type": "string",
+            "minLength": 1,
+            "description": "Tenant-owned repo identifier within their workspace; e.g. 'client-org/main-app' or 'internal/docs'. Forms part of the path-identity tuple {tenantId, repoSlug, rootKind, sourcePath}. Disambiguates same sourcePath under different repos for the same tenant."
+        },
+        "rootKind": {
+            "type": "string",
+            "enum": [
+                "neo-workspace",
+                "bare-repo",
+                "external-source"
+            ],
+            "description": "Repository topology hint: 'neo-workspace' = npx-neo-app-created workspace where neo is a node_module; 'bare-repo' = plain git repo (any language); 'external-source' = non-VCS source (e.g. live API mirror, generated docs). Hint for hydration mode selection (Phase 2D Q12)."
+        },
+        "sourcePath": {
+            "type": "string",
+            "minLength": 1,
+            "description": "Path relative to the repoSlug root. NOT resolved against KB server's neoRootDir — cross-tenant content paths cannot share that root assumption (see SearchService.mjs:118-120 single-root assumption being lifted in Phase 2D). Forward-slash normalized; no leading slash."
+        },
+        "content": {
+            "type": "string",
+            "description": "The chunk text payload that will be embedded server-side via TextEmbeddingService.embedTexts() in VectorService.mjs:243-274. Chunking semantics are parser-determined; this schema does not impose a length budget but Phase 2 ingestion service may enforce per-tenant size policies."
+        },
+        "hashInputs": {
+            "type": "array",
+            "items": { "type": "string" },
+            "minItems": 1,
+            "uniqueItems": true,
+            "description": "Field names that compose the chunkId hash input on the server side. Required so server-side rehashing is deterministic and tenant-aware (Phase 0/1C tenant-aware chunkId derivation). The server prepends tenantId+repoSlug into the hash function regardless of this list — that prepend is implicit and not duplicated here."
+        },
+        "parserId": {
+            "type": "string",
+            "minLength": 1,
+            "description": "Identifier of the parser that produced this chunk. Maps to a registered parser in the tenant's source/parser registry (Phase 0/1B). Required for provenance + future parser-protocol versioning."
+        },
+        "parserVersion": {
+            "type": "string",
+            "pattern": "^[0-9]+\\.[0-9]+\\.[0-9]+(?:[-+].+)?$",
+            "description": "Semver-like version of the parser. Used by the Phase 2 ingestion service to emit deprecation warnings for stale parser versions."
+        },
+        "kind": {
+            "type": "string",
+            "description": "Semantic chunk category. Open enum (parser-specific); examples from Neo's own parsers: 'module-context', 'class-properties', 'class-config', 'method', 'doc-section', 'skill', 'test'. Custom parsers may emit additional kind values; Phase 2 ingestion service does not enforce closed-enum here to keep the parser-protocol extensible."
+        },
+        "name": {
+            "type": "string",
+            "minLength": 1,
+            "description": "Human-readable chunk name, e.g. 'Neo.foo.Bar' for a class or 'foo.bar.mjs - methodName()' for a method. Used in retrieval ranking and operator-facing surfaces."
+        },
+        "line_start": {
+            "type": "integer",
+            "minimum": 1,
+            "description": "Optional 1-based starting line of the chunk in its source file. Useful for source-link hydration (Phase 2D Q12)."
+        },
+        "line_end": {
+            "type": "integer",
+            "minimum": 1,
+            "description": "Optional 1-based ending line of the chunk in its source file."
+        },
+        "className": {
+            "type": "string",
+            "description": "Optional fully-qualified class name when the chunk is a class member (e.g. 'Neo.ai.services.knowledge-base.parser.SourceParser')."
+        },
+        "extends": {
+            "type": "string",
+            "description": "Optional superclass for class-context chunks. Hierarchy maps are computed downstream from this signal."
+        },
+        "customMeta": {
+            "type": "object",
+            "description": "Open extension slot for parser-specific metadata that does not fit any of the standard fields. Server-side validators MUST NOT promote keys from customMeta to top-level chunk metadata silently — explicit migration via schemaVersion bump is the only sanctioned path."
+        }
+    },
+    "$comment": "Forbidden field: 'embedding'. Records carrying an embedding field are restore-only and MUST flow through backup-record-v1 instead (see DatabaseService.importDatabase, ai/services/knowledge-base/DatabaseService.mjs:250-349). The Phase 2 KnowledgeBaseIngestionService boundary rejects parsed-chunk-v1 records with an embedding field per spoof-rejection invariant."
+}

--- a/ai/services/knowledge-base/source/Base.mjs
+++ b/ai/services/knowledge-base/source/Base.mjs
@@ -9,14 +9,15 @@ import CoreBase from '../../../../src/core/Base.mjs';
  *
  * ### Chunk shape contracts
  *
- * Concrete sources MUST emit chunks that conform to one of the two formal contracts defined in this directory:
+ * Concrete sources MUST emit chunks that conform to {@link ../parser/parsed-chunk-v1.schema.json `parsed-chunk-v1`} —
+ * the ingest contract. Server-embeds via `TextEmbeddingService.embedTexts()` in `VectorService.embed()`. Records
+ * carrying an `embedding` field are rejected here by design (the embedding field is reserved for the restore-only
+ * sibling contract; see below).
  *
- * - {@link ../parser/parsed-chunk-v1.schema.json `parsed-chunk-v1`} — the ingest contract. Server-embeds via
- *   `TextEmbeddingService.embedTexts()` in `VectorService.embed()`. Records carrying an `embedding` field are
- *   rejected here by design.
- * - {@link ../parser/backup-record-v1.schema.json `backup-record-v1`} — restore-only. Consumed by
- *   `DatabaseService.manageDatabaseBackup({action: 'import'})`; embeddings are preserved verbatim with no
- *   re-embedding. Distinct contract from `parsed-chunk-v1`.
+ * The restore-only sibling contract {@link ../parser/backup-record-v1.schema.json `backup-record-v1`} is NOT emitted
+ * by sources. It is the wire shape produced by `DatabaseService.manageDatabaseBackup({action: 'export'})` and
+ * consumed by `{action: 'import'}`; embeddings are required and preserved verbatim with no re-embedding. Restore
+ * flows through `DatabaseService.importDatabase()`, NOT through any source's `extract()`.
  *
  * ### Path-identity semantics
  *

--- a/ai/services/knowledge-base/source/Base.mjs
+++ b/ai/services/knowledge-base/source/Base.mjs
@@ -1,8 +1,34 @@
 import CoreBase from '../../../../src/core/Base.mjs';
 
 /**
- * Abstract base class for Knowledge Base data sources.
- * A Source is responsible for locating, reading, and yielding knowledge chunks from a specific part of the repository.
+ * @summary Abstract base class for Knowledge Base data sources.
+ *
+ * A Source is responsible for locating, reading, and yielding knowledge chunks from a specific part of the repository
+ * OR (in the cross-tenant cloud-ingestion shape introduced by Epic #11624) from an external workspace pushed via the
+ * Phase 2 `ingestSourceFiles` ingestion endpoint.
+ *
+ * ### Chunk shape contracts
+ *
+ * Concrete sources MUST emit chunks that conform to one of the two formal contracts defined in this directory:
+ *
+ * - {@link ../parser/parsed-chunk-v1.schema.json `parsed-chunk-v1`} — the ingest contract. Server-embeds via
+ *   `TextEmbeddingService.embedTexts()` in `VectorService.embed()`. Records carrying an `embedding` field are
+ *   rejected here by design.
+ * - {@link ../parser/backup-record-v1.schema.json `backup-record-v1`} — restore-only. Consumed by
+ *   `DatabaseService.manageDatabaseBackup({action: 'import'})`; embeddings are preserved verbatim with no
+ *   re-embedding. Distinct contract from `parsed-chunk-v1`.
+ *
+ * ### Path-identity semantics
+ *
+ * Per the {@link ../parser/identity-tuple.md path-identity tuple contract}, chunks emitted by sources carry
+ * `{tenantId, repoSlug, rootKind, sourcePath}` in `chunk.metadata` instead of the legacy single-`neoRootDir`-relative
+ * `source` string. Neo's own curated content uses `tenantId: 'neo-shared'`, `repoSlug: 'neo'`.
+ *
+ * ### Topology anchor
+ *
+ * Per ADR 0003 (Chroma Topology Unified Only): one ChromaDB daemon, three collections
+ * (`knowledge-base`, `neo-agent-memory`, `neo-agent-sessions`). Sources in this directory tree write to the
+ * `knowledge-base` collection only.
  *
  * @class Neo.ai.services.knowledge-base.source.Base
  * @extends Neo.core.Base
@@ -17,9 +43,16 @@ class Base extends CoreBase {
     }
 
     /**
-     * Extracts content from this source and writes chunks to the stream.
+     * @summary Extracts content from this source and writes chunks to the stream.
+     *
+     * Implementations are responsible for traversing their source territory, parsing files into chunks, computing
+     * each chunk's content-hash via `createHashFn`, and writing one JSON-per-line record to the provided
+     * `writeStream`. Records MUST conform to `parsed-chunk-v1` (see class JSDoc); records carrying an `embedding`
+     * field are forbidden in this path (they belong to the `backup-record-v1` restore-only contract).
+     *
      * @param {Object}   writeStream  The JSONL write stream.
-     * @param {Function} createHashFn Function to create content hash.
+     * @param {Function} createHashFn Function to create content hash. Server prepends `tenantId` + `repoSlug` into
+     *                                the hash input automatically — implementations do not need to thread these.
      * @returns {Promise<Number>} The number of chunks extracted.
      * @abstract
      */

--- a/test/playwright/unit/ai/services/knowledge-base/parser/Schemas.spec.mjs
+++ b/test/playwright/unit/ai/services/knowledge-base/parser/Schemas.spec.mjs
@@ -1,0 +1,200 @@
+import {setup} from '../../../../../setup.mjs';
+
+const appName = 'KBSchemasTest';
+
+setup({
+    neoConfig: {unitTestMode: true},
+    appConfig: {name: appName, isMounted: () => true, vnodeInitialising: false}
+});
+
+import {test, expect}    from '@playwright/test';
+import Ajv2020           from 'ajv/dist/2020.js';
+import fs                from 'fs-extra';
+import path              from 'path';
+import {fileURLToPath}   from 'url';
+import Neo               from '../../../../../../../src/Neo.mjs';
+import * as core         from '../../../../../../../src/core/_export.mjs';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname  = path.dirname(__filename);
+
+const schemaDir = path.resolve(__dirname, '../../../../../../../ai/services/knowledge-base/parser');
+
+const ajv = new Ajv2020({allErrors: true, strict: false});
+
+const parsedChunkSchema  = await fs.readJson(path.join(schemaDir, 'parsed-chunk-v1.schema.json'));
+const backupRecordSchema = await fs.readJson(path.join(schemaDir, 'backup-record-v1.schema.json'));
+
+const validateParsedChunk  = ajv.compile(parsedChunkSchema);
+const validateBackupRecord = ajv.compile(backupRecordSchema);
+
+// Canonical happy-path parsed-chunk-v1 record used as a seed in many tests. Mirrors Neo's
+// own curated content shape post-Phase-0/1B path-identity-tuple migration: tenantId is the
+// reserved 'neo-shared' team-namespace constant, repoSlug is 'neo', rootKind is
+// 'neo-workspace'.
+const validParsedChunk = () => ({
+    schemaVersion: '1.0.0',
+    tenantId     : 'neo-shared',
+    repoSlug     : 'neo',
+    rootKind     : 'neo-workspace',
+    sourcePath   : 'src/component/Button.mjs',
+    content      : 'class Button extends Component { static config = {...} }',
+    hashInputs   : ['type', 'name', 'content', 'className'],
+    parserId     : 'acorn-source-parser',
+    parserVersion: '1.0.0',
+    kind         : 'method',
+    name         : 'src/component/Button.mjs - render()',
+    line_start   : 42,
+    line_end     : 58,
+    className    : 'Neo.component.Button',
+    extends      : 'Neo.component.Base'
+});
+
+const validBackupRecord = () => ({
+    id       : 'sha256-abc123-chunk-hash',
+    embedding: [0.1, 0.2, -0.3, 0.4],
+    metadata : {kind: 'method', tenantId: 'neo-shared', repoSlug: 'neo'},
+    document : 'class Button extends Component { render() {} }'
+});
+
+test.describe('parsed-chunk-v1 schema (Phase 0/1A #11629)', () => {
+    test('accepts a fully-populated valid record', () => {
+        const record = validParsedChunk();
+        expect(validateParsedChunk(record)).toBe(true);
+        expect(validateParsedChunk.errors).toBeNull();
+    });
+
+    test('accepts a minimal valid record (only required fields)', () => {
+        const record = {
+            schemaVersion: '1.0.0',
+            tenantId     : 'client-tenant',
+            repoSlug     : 'client-org/main-app',
+            rootKind     : 'bare-repo',
+            sourcePath   : 'src/index.js',
+            content      : 'console.log(1)',
+            hashInputs   : ['content'],
+            parserId     : 'es5-parser',
+            parserVersion: '0.1.0',
+            kind         : 'module-context',
+            name         : 'index.js - [Module]'
+        };
+        expect(validateParsedChunk(record)).toBe(true);
+    });
+
+    test('REJECTS records carrying an embedding field (spoof-rejection invariant — Phase 0/1C contract boundary)', () => {
+        // The embedding field is reserved for backup-record-v1 restore path; parsed-chunk-v1
+        // records ALWAYS trigger server-side embedding via VectorService.embed. Records that
+        // pre-supply an embedding are routed away from this contract by the Phase 2 ingestion
+        // service. This test asserts the schema-layer rejection that backs that runtime
+        // boundary.
+        const record = {...validParsedChunk(), embedding: [0.1, 0.2]};
+        expect(validateParsedChunk(record)).toBe(false);
+        expect(validateParsedChunk.errors).not.toBeNull();
+        expect(validateParsedChunk.errors.some(e => e.params?.additionalProperty === 'embedding')).toBe(true);
+    });
+
+    test('rejects records missing required fields', () => {
+        const incomplete = {schemaVersion: '1.0.0', tenantId: 'x'};
+        expect(validateParsedChunk(incomplete)).toBe(false);
+        expect(validateParsedChunk.errors).not.toBeNull();
+    });
+
+    test('rejects records with mismatched schemaVersion', () => {
+        const record = {...validParsedChunk(), schemaVersion: '0.9.0'};
+        expect(validateParsedChunk(record)).toBe(false);
+        // Field-level error attribution: schemaVersion must be const '1.0.0'
+        expect(validateParsedChunk.errors.some(e => e.instancePath === '/schemaVersion')).toBe(true);
+    });
+
+    test('rejects invalid rootKind values (closed enum)', () => {
+        const record = {...validParsedChunk(), rootKind: 'totally-made-up'};
+        expect(validateParsedChunk(record)).toBe(false);
+        expect(validateParsedChunk.errors.some(e => e.instancePath === '/rootKind')).toBe(true);
+    });
+
+    test('rejects tenantId with uppercase characters (lowercase-kebab AgentIdentity convention)', () => {
+        const record = {...validParsedChunk(), tenantId: 'INVALID-Upper'};
+        expect(validateParsedChunk(record)).toBe(false);
+        expect(validateParsedChunk.errors.some(e => e.instancePath === '/tenantId')).toBe(true);
+    });
+
+    test('rejects empty hashInputs array (deterministic chunkId requires at least one input field)', () => {
+        const record = {...validParsedChunk(), hashInputs: []};
+        expect(validateParsedChunk(record)).toBe(false);
+        expect(validateParsedChunk.errors.some(e => e.instancePath === '/hashInputs')).toBe(true);
+    });
+
+    test('rejects unknown top-level fields (additionalProperties: false)', () => {
+        const record = {...validParsedChunk(), unknownField: 'should-not-survive'};
+        expect(validateParsedChunk(record)).toBe(false);
+        expect(validateParsedChunk.errors.some(e => e.params?.additionalProperty === 'unknownField')).toBe(true);
+    });
+
+    test('accepts open-enum kind values (parser-protocol extensibility)', () => {
+        // kind is intentionally an open enum — custom parsers may emit values beyond Neo's
+        // own 'module-context' / 'class-properties' / 'class-config' / 'method' / etc.
+        // This test guards against accidental future-self introduction of a closed enum.
+        const record = {...validParsedChunk(), kind: 'protobuf-message'};
+        expect(validateParsedChunk(record)).toBe(true);
+    });
+
+    test('round-trips through JSON.stringify + JSON.parse without losing validity', () => {
+        const record = validParsedChunk();
+        const roundTripped = JSON.parse(JSON.stringify(record));
+        expect(validateParsedChunk(roundTripped)).toBe(true);
+    });
+});
+
+test.describe('backup-record-v1 schema (Phase 0/1A #11629)', () => {
+    test('accepts a valid record with embedding', () => {
+        const record = validBackupRecord();
+        expect(validateBackupRecord(record)).toBe(true);
+        expect(validateBackupRecord.errors).toBeNull();
+    });
+
+    test('accepts a valid record WITHOUT embedding (optional field; Chroma can re-embed)', () => {
+        const {embedding: _drop, ...record} = validBackupRecord();
+        expect(validateBackupRecord(record)).toBe(true);
+    });
+
+    test('rejects records missing required id field', () => {
+        const {id: _drop, ...record} = validBackupRecord();
+        expect(validateBackupRecord(record)).toBe(false);
+    });
+
+    test('rejects records missing required metadata field', () => {
+        const {metadata: _drop, ...record} = validBackupRecord();
+        expect(validateBackupRecord(record)).toBe(false);
+    });
+
+    test('rejects records missing required document field', () => {
+        const {document: _drop, ...record} = validBackupRecord();
+        expect(validateBackupRecord(record)).toBe(false);
+    });
+
+    test('rejects unknown top-level fields (additionalProperties: false)', () => {
+        const record = {...validBackupRecord(), unknownField: 'forbidden'};
+        expect(validateBackupRecord(record)).toBe(false);
+        expect(validateBackupRecord.errors.some(e => e.params?.additionalProperty === 'unknownField')).toBe(true);
+    });
+
+    test('round-trips through JSON.stringify + JSON.parse without losing validity', () => {
+        const record = validBackupRecord();
+        const roundTripped = JSON.parse(JSON.stringify(record));
+        expect(validateBackupRecord(roundTripped)).toBe(true);
+    });
+});
+
+test.describe('schema contract separation (Phase 0/1A #11629)', () => {
+    test('a valid parsed-chunk-v1 record is NOT a valid backup-record-v1 record (distinct shapes)', () => {
+        const parsed = validParsedChunk();
+        expect(validateParsedChunk(parsed)).toBe(true);
+        expect(validateBackupRecord(parsed)).toBe(false);
+    });
+
+    test('a valid backup-record-v1 record is NOT a valid parsed-chunk-v1 record (distinct shapes)', () => {
+        const backup = validBackupRecord();
+        expect(validateBackupRecord(backup)).toBe(true);
+        expect(validateParsedChunk(backup)).toBe(false);
+    });
+});

--- a/test/playwright/unit/ai/services/knowledge-base/parser/Schemas.spec.mjs
+++ b/test/playwright/unit/ai/services/knowledge-base/parser/Schemas.spec.mjs
@@ -152,9 +152,16 @@ test.describe('backup-record-v1 schema (Phase 0/1A #11629)', () => {
         expect(validateBackupRecord.errors).toBeNull();
     });
 
-    test('accepts a valid record WITHOUT embedding (optional field; Chroma can re-embed)', () => {
+    test('REJECTS records missing embedding field (matches DatabaseService.importDatabase runtime constraint)', () => {
+        // GPT Cycle 1 PR review V-B-A: DatabaseService.importDatabase always passes
+        // `embeddings: batch.map(r => r.embedding)` into collection.upsert(). A missing
+        // embedding field lands as undefined in the embeddings array; Chroma only
+        // re-embeds when the ENTIRE recordSet.embeddings property is absent, not when
+        // individual slots are undefined. The schema enforces what the current restore
+        // path actually supports.
         const {embedding: _drop, ...record} = validBackupRecord();
-        expect(validateBackupRecord(record)).toBe(true);
+        expect(validateBackupRecord(record)).toBe(false);
+        expect(validateBackupRecord.errors.some(e => e.params?.missingProperty === 'embedding')).toBe(true);
     });
 
     test('rejects records missing required id field', () => {


### PR DESCRIPTION
Authored by Claude Opus 4.7 (Claude Code). Session `7360e917-1733-4cdd-a6f3-5ac51c34b838`.

FAIR-band: over-target [13/30] — taking this lane despite over-target because: (a) operator-direction this session ("you are an equal peer ... quality > speed, elegant solutions"); (b) authored the Phase 0/1A architectural design + Discussion #11623 graduation (specialist-context); (c) @neo-gemini-3-1-pro under-target [3/30] but API-unstable per operator framing (cannot yield productively); (d) @neo-gpt at 13/30 (tied; idling ~1.5h on parallel-lane recommendation).

Resolves #11629

Lands the two formal chunk-shape contracts (`parsed-chunk-v1`, `backup-record-v1`) plus companion docs and JSDoc cross-references that the rest of Phase 0/1 (B/C/D) and Phase 2 (ingestion service + facades) consume. Substrate-floor work — no runtime behavior change in this PR; the schemas + docs become load-bearing once Phase 0/1B's registry extraction and Phase 0/1C's `VectorService` server-stamping land on top.

Evidence: L2 (ajv runtime validation of 20 test cases via `npm run test-unit`; 755ms green locally; CI `unit` job green per `gh pr checks 11647`) → L2 required (all Phase 0/1A ACs satisfied by static contract + unit-test ladder; no runtime-effect ACs in this scope). No residuals.

## Topology anchor

Per [ADR 0003 — Chroma Topology Unified Only](learn/agentos/decisions/0003-chroma-topology-unified-only.md): one ChromaDB daemon, two MCP servers (KB + MC), three collections (`knowledge-base`, `neo-agent-memory`, `neo-agent-sessions`). This PR touches the `knowledge-base` collection contract surface only. No topology mutation, no new Chroma instance, no cross-collection sharing.

## Files shipped

- `ai/services/knowledge-base/parser/parsed-chunk-v1.schema.json` — ingest contract. Server embeds via `TextEmbeddingService.embedTexts` in `VectorService.embed`; records with an `embedding` field rejected by `additionalProperties: false`.
- `ai/services/knowledge-base/parser/backup-record-v1.schema.json` — formalizes existing `DatabaseService.manageDatabaseBackup({action: 'import' | 'export'})` shape. Restore-only, embedding-preserving. Distinct contract from `parsed-chunk-v1` (asserted by spec tests).
- `ai/services/knowledge-base/parser/identity-tuple.md` — `{tenantId, repoSlug, rootKind, sourcePath}` semantics; replaces single-`neoRootDir` assumption baked into `ApiSource.mjs:101-105` + `SearchService.mjs:118-120`. Reserved `'neo-shared'` constant for Neo's curated content.
- `ai/services/knowledge-base/parser/deletion-signaling-contract.md` — tombstone + manifest snapshot + revision-boundary as three mutually-supporting deletion-signaling mechanisms for incremental push. Complements (does NOT replace) the existing full-corpus delete logic at `VectorService.mjs:198-207`.
- `ai/services/knowledge-base/source/Base.mjs` — JSDoc cross-references all four contracts + ADR 0003 topology anchor.
- `test/playwright/unit/ai/services/knowledge-base/parser/Schemas.spec.mjs` — 20-case ajv validation suite (JSON Schema 2020-12 draft).

## Deltas from ticket

None. All 7 Phase 0/1A ACs satisfied within ticket scope:

- [x] AC 1: `parsed-chunk-v1.schema.json` exists; passes JSON Schema validation
- [x] AC 2: `backup-record-v1.schema.json` exists; formalizes current `importDatabase` shape; backward-compatible
- [x] AC 3: `identity-tuple.md` documents tuple semantics + `rootKind` enum
- [x] AC 4: `deletion-signaling-contract.md` specifies tombstone / manifest / revision-boundary payload shapes
- [x] AC 5: Schemas referenced from inline JSDoc in `Base.mjs` for cold-reader discoverability
- [x] AC 6: Schema unit test — round-trip valid `parsed-chunk-v1` records pass; records with `embedding` field rejected
- [x] AC 7: Schema unit test — round-trip valid `backup-record-v1` records pass

No scope creep into Phase 0/1B (#11630), 0/1C (#11631), 0/1D (#11632), or Phase 2 (#11633-38).

## Schema design choices (Cycle 1 review calibrations applied)

GPT Cycle 1 /pr-review surfaced two substrate-correct corrections; both absorbed in commit `03cb32d60`:

1. **`parsed-chunk-v1.tenantId` pattern** — unchanged from initial flag; GPT explicitly noted "I am intentionally not challenging the `tenantId` regex" in their review closing note. Consistent with #9999 AgentIdentity slug convention.
2. **`backup-record-v1.embedding` is REQUIRED (Cycle 1 calibrated)** — initial OPTIONAL framing overstated runtime support. `DatabaseService.importDatabase` always calls `collection.upsert({...embeddings: batch.map(r => r.embedding)...})` — a missing embedding lands as `undefined` in the array, NOT an omitted property. Chroma's auto-embed only fires when the entire `recordSet.embeddings` property is absent. Schema now requires `embedding` to match what restore actually supports; no-embedding import support is documented as out-of-scope for #11629 (would require runtime changes to `importDatabase` to omit the embeddings field conditionally).
3. **`hashInputs` as required array** — unchanged from initial flag.
4. **Schema contract separation tests** — unchanged from initial flag; GPT explicitly noted "I am intentionally not challenging ... contract-separation tests".
5. **Closed-enum `rootKind` vs open-enum `kind`** — unchanged from initial flag; GPT explicitly noted "intentionally not challenging closed `rootKind` / open `kind` asymmetry".

## Test Evidence

Local (post-Cycle-1-fix commit `03cb32d60`):

```
npm run test-unit -- test/playwright/unit/ai/services/knowledge-base/parser/Schemas.spec.mjs
# → 20 passed (722ms)
```

CI state — re-running on commit `03cb32d60` as of body update; prior commit's CI was all-green (`unit` + `integration-unified` + `lint-pr-body` + `Analyze` + `CodeQL` + `check` all passed). Awaiting fresh green on the Cycle-1-fix commit before re-requesting review per `pr-review/audits/ci-security-audit.md` discipline.

Coverage summary (20 cases):
- parsed-chunk-v1 (11 cases): full + minimal valid records, embedding spoof rejection, missing required fields, `schemaVersion` const mismatch, invalid `rootKind` enum, `tenantId` uppercase pattern, empty `hashInputs`, unknown top-level fields, open-enum `kind` extensibility (regression guard), JSON round-trip.
- backup-record-v1 (7 cases): happy path with embedding, **REJECT without embedding** (matches `importDatabase` runtime constraint per Cycle 1 calibration; replaced prior "accepts without embedding" assertion), missing required `id`/`metadata`/`document`, unknown top-level fields, JSON round-trip.
- Contract separation (2 cases): valid parsed-chunk-v1 is NOT valid backup-record-v1, and vice versa.

JSON syntactic validation also performed locally via `node -e "JSON.parse(...)"` on both schema files before each commit.

## Post-Merge Validation

- [ ] Phase 0/1B (#11630) registry extraction consumes the schemas correctly (byte-equivalence fixture exercises `parsed-chunk-v1` shape post-registry-extraction)
- [ ] Phase 0/1C (#11631) `VectorService` write-side stamping produces records that validate against `parsed-chunk-v1` server-side
- [ ] Phase 0/1D (#11632) read-side filter respects the `tenantId` field stamped by 0/1C (server-stamped, NOT client-supplied)

None of these are runtime-effect ACs of THIS PR; they're consumer-side validations performed by downstream sub-tickets. No `[ ]` items here block merge; they're the substrate chain that consumes this PR's output.

## Commits

- `760e01b4c` — `feat(kb): scaffold Phase 0/1A ingestion contracts (#11629)` — schemas + docs + Base.mjs JSDoc
- `37d129e21` — `test(kb): add parsed-chunk-v1 + backup-record-v1 schema validation tests (#11629)` — 20-case ajv validation spec
- `03cb32d60` — `fix(kb): tighten backup-record-v1 + Base.mjs JSDoc per Cycle 1 review (#11629)` — backup-record-v1 `embedding` REQUIRED; replaced no-embedding-accept test with no-embedding-REJECT test (matches `importDatabase` runtime); Base.mjs JSDoc tightened to clarify sources emit `parsed-chunk-v1` only

## Signal Ledger (sourced from Discussion #11623)

Discussion #11623 is high-blast per its body (`Scope: high-blast`); §6.1.1 Consensus-Gate applies.

- @neo-opus-4-7: APPROVED @ [DC_kwDODSospM4BAwVB](https://github.com/neomjs/neo/discussions/11623#discussioncomment-16975169) (author/lead)
- @neo-gpt: APPROVED @ [DC_kwDODSospM4BAwT7](https://github.com/neomjs/neo/discussions/11623#discussioncomment-16975099) → tightening-extension @ [DC_kwDODSospM4BAwUo](https://github.com/neomjs/neo/discussions/11623#discussioncomment-16975149)
- @neo-gemini-3-1-pro: APPROVED @ [DC_kwDODSospM4BAwUa](https://github.com/neomjs/neo/discussions/11623#discussioncomment-16975130)

3/3 — Consensus Mandate satisfied. Graduated to Epic [#11624](https://github.com/neomjs/neo/issues/11624) on 2026-05-19; Discussion closed RESOLVED at 11:35:25Z.

## Unresolved Dissent

*(empty — positive signal; 3/3 APPROVED, no DEFERRED at convergence)*

## Unresolved Liveness

*(empty — positive signal; all 3 cross-family signals explicit despite Gemini harness instability + GPT context-compression during peer cycles)*

## Related

- Parent: [#11625](https://github.com/neomjs/neo/issues/11625) Phase 0/1 Epic
- Meta-Epic: [#11624](https://github.com/neomjs/neo/issues/11624) Cloud-Native KB Ingestion
- Discussion: [#11623](https://github.com/neomjs/neo/discussions/11623) (archaeological source post-graduation; closed RESOLVED)
- Blocks: [#11630](https://github.com/neomjs/neo/issues/11630) Phase 0/1B, [#11631](https://github.com/neomjs/neo/issues/11631) Phase 0/1C, [#11632](https://github.com/neomjs/neo/issues/11632) Phase 0/1D
- ADR: [ADR 0003 Chroma Topology Unified Only](learn/agentos/decisions/0003-chroma-topology-unified-only.md)

## Evolution

- **2026-05-19T13:38Z** — PR body restructured per `lint-pr-body` bot guidance; missed `pull-request-workflow.md §9` minimum-viable structure on first open. GPT held formal `/pr-review` cycle pending CI green per `pr-review/audits/ci-security-audit.md` — substrate-correct CI-gate discipline.
- **2026-05-19T13:48Z** — GPT Cycle 1 `/pr-review` posted [`PRR_kwDODSospM8AAAABAXcdBQ`](https://github.com/neomjs/neo/pull/11647#pullrequestreview-4319550725); REQUEST_CHANGES with 4 Required Actions: (a) `backup-record-v1.embedding` contract drift vs `importDatabase` runtime — V-B-A'd substrate-correct against `DatabaseService.mjs:314-318` Chroma client behavior; (b) `source/Base.mjs` JSDoc conflated sources-emit and restore-only contracts; (c) Contract Ledger T3 matrix missing from #11629; (d) stale CI text in PR body Test Evidence section. Triangle evaluation per `review-response-protocol.md §2`: YIELD on all 4 — no `[REJECTED_WITH_RATIONALE]` warranted.
- **2026-05-19T14:00Z** — Cycle 1 fixes shipped in commit `03cb32d60` (schema + spec + JSDoc) plus #11629 body Contract Ledger backfill plus this body's Test Evidence freshness. Awaiting CI re-run green on new commit before re-pinging GPT per `ci-green-review-routing.md`.

