### PR TITLE
test(kb): add KB integration parity coverage (#11644)

### DIFF
--- a/ai/deploy/docker-compose.test.yml
+++ b/ai/deploy/docker-compose.test.yml
@@ -74,6 +74,43 @@ services:
     ports:
       - "13000:3000"
 
+  kb-server-oidc:
+    build:
+      context: ../..
+      dockerfile: ai/deploy/Dockerfile
+      args:
+        TARGET_SERVER: knowledge-base
+    environment:
+      - NEO_TRANSPORT=sse
+      - NEO_AUTO_SYNC=false
+      - NEO_KB_AUTO_START_DATABASE=false
+      - NEO_CHROMA_HOST=chroma
+      - NEO_CHROMA_PORT=8000
+      - NEO_AUTH_TRUST_PROXY_IDENTITY=false
+      - NEO_AUTH_ISSUER_URL=http://oidc-server:4000
+      - MCP_DANGEROUSLY_ALLOW_INSECURE_ISSUER_URL=1
+      - NEO_PUBLIC_URL=http://127.0.0.1:13003
+      - MCP_HTTP_PORT=3003
+      - NEO_MEMORY_DB_PATH=/tmp/neo-integration/kb-recorder-oidc.sqlite
+      - NEO_MODEL_PROVIDER=openAiCompatible
+      - NEO_EMBEDDING_PROVIDER=openAiCompatible
+      - NEO_OPENAI_COMPATIBLE_HOST=http://embedding-server:11434
+      - NEO_OPENAI_COMPATIBLE_EMBEDDING_MODEL=text-embedding-qwen3-embedding-8b
+      - NEO_OPENAI_COMPATIBLE_API_KEY=test-integration-key
+    tmpfs:
+      - /tmp/neo-integration
+    depends_on:
+      chroma:
+        condition: service_healthy
+      embedding-server:
+        condition: service_healthy
+      oidc-server:
+        condition: service_healthy
+    networks:
+      - neo-mcp-test-network
+    ports:
+      - "13003:3003"
+
   mc-server:
     build:
       context: ../..

--- a/ai/deploy/mock-oidc-server.mjs
+++ b/ai/deploy/mock-oidc-server.mjs
@@ -2,6 +2,11 @@ import http from 'node:http';
 
 const host = process.env.NEO_TEST_OIDC_HOST || '0.0.0.0';
 const port = Number(process.env.NEO_TEST_OIDC_PORT || 4000);
+const validAudiences = [
+    'http://127.0.0.1:13002',
+    'http://127.0.0.1:13003',
+    'http://127.0.0.1:13090'
+];
 
 /**
  * @summary Reads a form-urlencoded request body.
@@ -61,7 +66,7 @@ const server = http.createServer(async (request, response) => {
             if (token === 'valid-test-token') {
                 sendJson(response, 200, {
                     active            : true,
-                    aud               : ['http://127.0.0.1:13002', 'http://127.0.0.1:13090'],
+                    aud               : validAudiences,
                     exp               : Math.floor(Date.now() / 1000) + 3600,
                     preferred_username: 'neo-test-oidc-user',
                     client_id         : params.get('client_id')
@@ -72,7 +77,7 @@ const server = http.createServer(async (request, response) => {
             if (token === 'valid-test-token-bob') {
                 sendJson(response, 200, {
                     active            : true,
-                    aud               : ['http://127.0.0.1:13002', 'http://127.0.0.1:13090'],
+                    aud               : validAudiences,
                     exp               : Math.floor(Date.now() / 1000) + 3600,
                     preferred_username: 'neo-test-oidc-bob',
                     client_id         : params.get('client_id')
@@ -83,7 +88,7 @@ const server = http.createServer(async (request, response) => {
             if (token === 'valid-test-token-no-username') {
                 sendJson(response, 200, {
                     active   : true,
-                    aud      : ['http://127.0.0.1:13002', 'http://127.0.0.1:13090'],
+                    aud      : validAudiences,
                     exp      : Math.floor(Date.now() / 1000) + 3600,
                     sub      : 'neo-test-oidc-sub',
                     client_id: params.get('client_id')

--- a/test/playwright/integration/KBAuthRejection.integration.spec.mjs
+++ b/test/playwright/integration/KBAuthRejection.integration.spec.mjs
@@ -1,0 +1,50 @@
+import {test, expect} from '@playwright/test';
+import {
+    callJsonTool,
+    createIdentityClient,
+    getReadiness
+} from './fixtures/mcpClient.mjs';
+
+const KB_URL = process.env.NEO_INTEGRATION_KB_URL || 'http://127.0.0.1:13000';
+
+test.describe('Dockerized KB proxy identity rejection integration (#11644)', () => {
+    test('KB rejects missing proxy identity and accepts an identity-bearing client', async () => {
+        const readiness = await getReadiness();
+
+        test.skip(readiness.dockerAvailable === false, `Docker unavailable: ${readiness.reason}`);
+
+        expect(readiness.servicesReady, readiness.reason).toBe(true);
+
+        let rejectionError;
+        let unexpectedClient;
+
+        try {
+            unexpectedClient = await createIdentityClient({
+                baseUrl   : KB_URL,
+                clientName: 'neo-integration-kb-auth-rejection'
+            });
+        } catch (error) {
+            rejectionError = error;
+        } finally {
+            await unexpectedClient?.close();
+        }
+
+        expect(rejectionError).toBeTruthy();
+        expect(String(rejectionError?.message || rejectionError)).toMatch(/401|Unauthorized/i);
+
+        const client = await createIdentityClient({
+            baseUrl   : KB_URL,
+            clientName: 'neo-integration-kb-auth-positive',
+            identity  : 'kb-auth-positive'
+        });
+
+        try {
+            const health = await callJsonTool(client, 'healthcheck');
+
+            expect(health.status).toBe('healthy');
+            expect(health.database.connection.connected).toBe(true);
+        } finally {
+            await client.close();
+        }
+    });
+});

--- a/test/playwright/integration/KBBackupRestoreWipe.integration.spec.mjs
+++ b/test/playwright/integration/KBBackupRestoreWipe.integration.spec.mjs
@@ -206,6 +206,34 @@ function truncateKnowledgeBase() {
 }
 
 /**
+ * Deletes the deterministic record seeded by this spec without dropping the shared fixture collection.
+ * @param {String} id Chroma vector id.
+ * @returns {Object}
+ */
+function deleteKnowledgeBaseRecord(id) {
+    return execKnowledgeBaseJson(`
+        ${NEO_BOOTSTRAP}
+
+        const {KB_ChromaManager, KB_LifecycleService} = await import('./ai/services.mjs');
+
+        await KB_LifecycleService.ready();
+
+        const collection = await KB_ChromaManager.getKnowledgeBaseCollection();
+
+        await collection.delete({
+            ids: [process.env.NEO_TEST_KB_ID]
+        });
+
+        console.log(JSON.stringify({
+            count  : await collection.count(),
+            deleted: process.env.NEO_TEST_KB_ID
+        }));
+    `, {
+        NEO_TEST_KB_ID: id
+    });
+}
+
+/**
  * Deletes a backup directory from the deployed Knowledge Base container tmpfs.
  * @param {String} backupPath Absolute backup path inside the container.
  * @returns {Object}
@@ -264,7 +292,7 @@ test.describe('Dockerized KB backup -> wipe -> restore integration (#11644)', ()
             expect(restoredRecord.metadata.sentinel).toBe(sentinel);
         } finally {
             await Promise.allSettled([
-                Promise.resolve().then(() => truncateKnowledgeBase()),
+                Promise.resolve().then(() => deleteKnowledgeBaseRecord(recordId)),
                 Promise.resolve().then(() => cleanupBackupPath(backupPath))
             ]);
         }

--- a/test/playwright/integration/KBBackupRestoreWipe.integration.spec.mjs
+++ b/test/playwright/integration/KBBackupRestoreWipe.integration.spec.mjs
@@ -15,7 +15,6 @@ const composeFile = path.join(repoRoot, 'ai/deploy/docker-compose.test.yml');
 const projectName = process.env.NEO_INTEGRATION_COMPOSE_PROJECT || 'neo-integration-test';
 const KB_URL      = process.env.NEO_INTEGRATION_KB_URL || 'http://127.0.0.1:13000';
 
-const CONFIRMATION  = 'CONFIRM_PRODUCTION_DESTRUCTIVE_AI_SUBSTRATE';
 const NEO_BOOTSTRAP = `
     await import('./src/Neo.mjs');
     await import('./src/core/_export.mjs');
@@ -182,30 +181,6 @@ function importKnowledgeBase(backupPath) {
 }
 
 /**
- * Truncates the deployed KB collection.
- * @returns {Object}
- */
-function truncateKnowledgeBase() {
-    return execKnowledgeBaseJson(`
-        ${NEO_BOOTSTRAP}
-
-        const {KB_DatabaseService, KB_LifecycleService} = await import('./ai/services.mjs');
-
-        await KB_LifecycleService.ready();
-
-        const result = await KB_DatabaseService.manageDatabaseBackup({
-            action      : 'truncate',
-            confirmation: process.env.NEO_DESTRUCTIVE_CONFIRMATION
-        });
-
-        console.log(JSON.stringify(result));
-    `, {
-        NEO_ALLOW_PRODUCTION_DESTRUCTIVE_AI_SUBSTRATE: 'true',
-        NEO_DESTRUCTIVE_CONFIRMATION                : CONFIRMATION
-    });
-}
-
-/**
  * Deletes the deterministic record seeded by this spec without dropping the shared fixture collection.
  * @param {String} id Chroma vector id.
  * @returns {Object}
@@ -269,8 +244,8 @@ test.describe('Dockerized KB backup -> wipe -> restore integration (#11644)', ()
             const backup = exportKnowledgeBase(backupPath);
             expect(backup.message).toContain('Exported');
 
-            const truncated = truncateKnowledgeBase();
-            expect(truncated.message).toContain('truncated successfully');
+            const deleted = deleteKnowledgeBaseRecord(recordId);
+            expect(deleted.deleted).toBe(recordId);
 
             const wipedHealth = await callHealthcheck(KB_URL, {
                 clientName: 'neo-integration-kb-backup-restore-health',

--- a/test/playwright/integration/KBBackupRestoreWipe.integration.spec.mjs
+++ b/test/playwright/integration/KBBackupRestoreWipe.integration.spec.mjs
@@ -1,0 +1,272 @@
+import {randomUUID}    from 'node:crypto';
+import {spawnSync}     from 'node:child_process';
+import path            from 'node:path';
+import {fileURLToPath} from 'node:url';
+import {test, expect}  from '@playwright/test';
+import {
+    callHealthcheck,
+    getReadiness
+} from './fixtures/mcpClient.mjs';
+
+const __filename  = fileURLToPath(import.meta.url);
+const __dirname   = path.dirname(__filename);
+const repoRoot    = path.resolve(__dirname, '../../..');
+const composeFile = path.join(repoRoot, 'ai/deploy/docker-compose.test.yml');
+const projectName = process.env.NEO_INTEGRATION_COMPOSE_PROJECT || 'neo-integration-test';
+const KB_URL      = process.env.NEO_INTEGRATION_KB_URL || 'http://127.0.0.1:13000';
+
+const CONFIRMATION  = 'CONFIRM_PRODUCTION_DESTRUCTIVE_AI_SUBSTRATE';
+const NEO_BOOTSTRAP = `
+    await import('./src/Neo.mjs');
+    await import('./src/core/_export.mjs');
+`;
+
+/**
+ * Runs Docker Compose against the integration fixture project.
+ * @param {String[]} args Docker Compose arguments after the compose file selector.
+ * @returns {import('node:child_process').SpawnSyncReturns<String>}
+ */
+function dockerCompose(args) {
+    return spawnSync('docker', ['compose', '-p', projectName, '-f', composeFile, ...args], {
+        cwd      : repoRoot,
+        encoding : 'utf8',
+        maxBuffer: 10 * 1024 * 1024
+    });
+}
+
+/**
+ * Runs an ES module snippet inside the deployed Knowledge Base container.
+ * @param {String} code The JavaScript source to execute.
+ * @param {Object} [env] Environment variables to pass into the process.
+ * @returns {Object}
+ */
+function execKnowledgeBaseJson(code, env = {}) {
+    const envArgs = Object.entries(env).flatMap(([key, value]) => ['-e', `${key}=${value}`]);
+    const result  = dockerCompose(['exec', '-T', ...envArgs, 'kb-server', 'node', '--input-type=module', '-e', code]);
+    const output  = [
+        result.stdout?.trim(),
+        result.stderr?.trim()
+    ].filter(Boolean).join('\n');
+
+    expect(result.status, output || result.error?.message || 'kb-server exec failed').toBe(0);
+
+    const jsonLine = result.stdout.trim().split('\n').filter(Boolean).reverse().find(line => {
+        try {
+            JSON.parse(line);
+            return true;
+        } catch {
+            return false;
+        }
+    });
+    expect(jsonLine, output).toBeTruthy();
+
+    return JSON.parse(jsonLine);
+}
+
+/**
+ * Seeds a deterministic record directly into the deployed KB Chroma collection.
+ * @param {String} id       Chroma vector id.
+ * @param {String} sentinel Unique document text.
+ * @returns {Object}
+ */
+function seedKnowledgeBaseRecord(id, sentinel) {
+    return execKnowledgeBaseJson(`
+        ${NEO_BOOTSTRAP}
+
+        const {KB_ChromaManager, KB_LifecycleService} = await import('./ai/services.mjs');
+
+        await KB_LifecycleService.ready();
+
+        const collection = await KB_ChromaManager.getKnowledgeBaseCollection();
+        const embedding = Array.from({length: 4096}, (_, index) => index === 0 ? 1 : 0);
+
+        await collection.upsert({
+            ids       : [process.env.NEO_TEST_KB_ID],
+            embeddings: [embedding],
+            metadatas : [{kind: 'integration', source: 'kb-backup-restore', sentinel: process.env.NEO_TEST_KB_SENTINEL}],
+            documents : [process.env.NEO_TEST_KB_SENTINEL]
+        });
+
+        const result = await collection.get({
+            ids    : [process.env.NEO_TEST_KB_ID],
+            include: ['documents', 'metadatas']
+        });
+
+        console.log(JSON.stringify({
+            count: await collection.count(),
+            found: result.ids?.includes(process.env.NEO_TEST_KB_ID)
+        }));
+    `, {
+        NEO_TEST_KB_ID      : id,
+        NEO_TEST_KB_SENTINEL: sentinel
+    });
+}
+
+/**
+ * Reads a deterministic record from the deployed KB Chroma collection.
+ * @param {String} id Chroma vector id.
+ * @returns {Object}
+ */
+function readKnowledgeBaseRecord(id) {
+    return execKnowledgeBaseJson(`
+        ${NEO_BOOTSTRAP}
+
+        const {KB_ChromaManager, KB_LifecycleService} = await import('./ai/services.mjs');
+
+        await KB_LifecycleService.ready();
+
+        const collection = await KB_ChromaManager.getKnowledgeBaseCollection();
+        const result = await collection.get({
+            ids    : [process.env.NEO_TEST_KB_ID],
+            include: ['documents', 'metadatas']
+        });
+
+        console.log(JSON.stringify({
+            count   : await collection.count(),
+            document: result.documents?.[0] || null,
+            found   : result.ids?.includes(process.env.NEO_TEST_KB_ID) || false,
+            metadata: result.metadatas?.[0] || null
+        }));
+    `, {
+        NEO_TEST_KB_ID: id
+    });
+}
+
+/**
+ * Exports the deployed KB collection into a JSONL backup directory.
+ * @param {String} backupPath Absolute backup path inside the container.
+ * @returns {Object}
+ */
+function exportKnowledgeBase(backupPath) {
+    return execKnowledgeBaseJson(`
+        ${NEO_BOOTSTRAP}
+
+        const {KB_DatabaseService, KB_LifecycleService} = await import('./ai/services.mjs');
+
+        await KB_LifecycleService.ready();
+
+        const result = await KB_DatabaseService.manageDatabaseBackup({
+            action    : 'export',
+            backupPath: process.env.NEO_TEST_KB_BACKUP_PATH
+        });
+
+        console.log(JSON.stringify(result));
+    `, {
+        NEO_TEST_KB_BACKUP_PATH: backupPath
+    });
+}
+
+/**
+ * Imports a deployed KB JSONL backup directory.
+ * @param {String} backupPath Absolute backup path inside the container.
+ * @returns {Object}
+ */
+function importKnowledgeBase(backupPath) {
+    return execKnowledgeBaseJson(`
+        ${NEO_BOOTSTRAP}
+
+        const {KB_DatabaseService, KB_LifecycleService} = await import('./ai/services.mjs');
+
+        await KB_LifecycleService.ready();
+
+        const result = await KB_DatabaseService.manageDatabaseBackup({
+            action: 'import',
+            file  : process.env.NEO_TEST_KB_BACKUP_PATH,
+            mode  : 'merge'
+        });
+
+        console.log(JSON.stringify(result));
+    `, {
+        NEO_TEST_KB_BACKUP_PATH: backupPath
+    });
+}
+
+/**
+ * Truncates the deployed KB collection.
+ * @returns {Object}
+ */
+function truncateKnowledgeBase() {
+    return execKnowledgeBaseJson(`
+        ${NEO_BOOTSTRAP}
+
+        const {KB_DatabaseService, KB_LifecycleService} = await import('./ai/services.mjs');
+
+        await KB_LifecycleService.ready();
+
+        const result = await KB_DatabaseService.manageDatabaseBackup({
+            action      : 'truncate',
+            confirmation: process.env.NEO_DESTRUCTIVE_CONFIRMATION
+        });
+
+        console.log(JSON.stringify(result));
+    `, {
+        NEO_ALLOW_PRODUCTION_DESTRUCTIVE_AI_SUBSTRATE: 'true',
+        NEO_DESTRUCTIVE_CONFIRMATION                : CONFIRMATION
+    });
+}
+
+/**
+ * Deletes a backup directory from the deployed Knowledge Base container tmpfs.
+ * @param {String} backupPath Absolute backup path inside the container.
+ * @returns {Object}
+ */
+function cleanupBackupPath(backupPath) {
+    return execKnowledgeBaseJson(`
+        const fs = await import('node:fs/promises');
+
+        await fs.rm(process.env.NEO_TEST_KB_BACKUP_PATH, {recursive: true, force: true});
+
+        console.log(JSON.stringify({removed: process.env.NEO_TEST_KB_BACKUP_PATH}));
+    `, {
+        NEO_TEST_KB_BACKUP_PATH: backupPath
+    });
+}
+
+test.describe('Dockerized KB backup -> wipe -> restore integration (#11644)', () => {
+    test('restores a seeded Knowledge Base vector after an isolated fixture wipe', async () => {
+        const readiness = await getReadiness();
+
+        test.skip(readiness.dockerAvailable === false, `Docker unavailable: ${readiness.reason}`);
+        expect(readiness.servicesReady, readiness.reason).toBe(true);
+
+        const runId      = `${Date.now()}-${randomUUID()}`;
+        const recordId   = `kb-backup-restore-${runId}`;
+        const sentinel   = `kb-backup-restore-sentinel-${runId}`;
+        const backupPath = `/tmp/neo-integration/kb-backup-restore-${runId}`;
+
+        try {
+            const seeded = seedKnowledgeBaseRecord(recordId, sentinel);
+            expect(seeded.found).toBe(true);
+
+            const backup = exportKnowledgeBase(backupPath);
+            expect(backup.message).toContain('Exported');
+
+            const truncated = truncateKnowledgeBase();
+            expect(truncated.message).toContain('truncated successfully');
+
+            const wipedHealth = await callHealthcheck(KB_URL, {
+                clientName: 'neo-integration-kb-backup-restore-health',
+                identity  : 'kb-backup-restore'
+            });
+            expect(wipedHealth.status).toBe('healthy');
+            expect(wipedHealth.database.connection.connected).toBe(true);
+
+            const wiped = readKnowledgeBaseRecord(recordId);
+            expect(wiped.found).toBe(false);
+
+            const restored = importKnowledgeBase(backupPath);
+            expect(restored.imported).toBeGreaterThan(0);
+            expect(restored.mode).toBe('merge');
+
+            const restoredRecord = readKnowledgeBaseRecord(recordId);
+            expect(restoredRecord.found).toBe(true);
+            expect(restoredRecord.document).toBe(sentinel);
+            expect(restoredRecord.metadata.sentinel).toBe(sentinel);
+        } finally {
+            await Promise.allSettled([
+                Promise.resolve().then(() => truncateKnowledgeBase()),
+                Promise.resolve().then(() => cleanupBackupPath(backupPath))
+            ]);
+        }
+    });
+});

--- a/test/playwright/integration/KBHeartbeatPropagation.integration.spec.mjs
+++ b/test/playwright/integration/KBHeartbeatPropagation.integration.spec.mjs
@@ -1,0 +1,30 @@
+import {test, expect} from '@playwright/test';
+import {assertSustainedHealth} from './util/assertSustainedHealth.mjs';
+import {callHealthcheck, getReadiness} from './fixtures/mcpClient.mjs';
+
+const KB_URL = process.env.NEO_INTEGRATION_KB_URL || 'http://127.0.0.1:13000';
+
+test.describe('KB Heartbeat Propagation Integration (#11644)', () => {
+    test.setTimeout(120000);
+
+    test('sustains KB healthcheck collection-state assertions', async () => {
+        const readiness = await getReadiness();
+        test.skip(readiness.dockerAvailable === false, `Docker unavailable: ${readiness.reason}`);
+        expect(readiness.servicesReady, readiness.reason).toBe(true);
+
+        await assertSustainedHealth({
+            probe: () => callHealthcheck(KB_URL),
+            onSample(sample, previousSamples) {
+                expect(sample.status).toBe('healthy');
+                expect(typeof sample.uptime).toBe('number');
+                expect(sample.database.connection.connected).toBe(true);
+                expect(sample.database.connection.collections.knowledgeBase.exists).toBe(true);
+
+                if (previousSamples.length > 1) {
+                    const prev = previousSamples[previousSamples.length - 2];
+                    expect(sample.uptime).toBeGreaterThanOrEqual(prev.uptime);
+                }
+            }
+        });
+    });
+});

--- a/test/playwright/integration/KBOidcAuth.integration.spec.mjs
+++ b/test/playwright/integration/KBOidcAuth.integration.spec.mjs
@@ -1,0 +1,85 @@
+import {test, expect} from '@playwright/test';
+import {callJsonTool, createIdentityClient, getReadiness} from './fixtures/mcpClient.mjs';
+
+const KB_OIDC_URL = process.env.NEO_INTEGRATION_KB_OIDC_URL || 'http://127.0.0.1:13003';
+
+test.describe('KB OIDC Authentication Fixture (#11644)', () => {
+    test.beforeEach(async () => {
+        const readiness = await getReadiness();
+        test.skip(readiness.dockerAvailable === false, `Docker unavailable: ${readiness.reason}`);
+    });
+
+    test('rejects connection without token when OIDC is configured', async () => {
+        const error = await createIdentityClient({
+            baseUrl    : KB_OIDC_URL,
+            identity   : null,
+            bearerToken: null
+        }).catch(e => e);
+
+        expect(error).toBeInstanceOf(Error);
+        expect(error.message).toMatch(/401|Unauthorized|Missing Authorization header/i);
+    });
+
+    test('rejects connection with spoofed proxy header when OIDC is configured', async () => {
+        const error = await createIdentityClient({
+            baseUrl    : KB_OIDC_URL,
+            identity   : 'spoofed-user',
+            bearerToken: null
+        }).catch(e => e);
+
+        expect(error).toBeInstanceOf(Error);
+        expect(error.message).toMatch(/401|Unauthorized|Missing Authorization header/i);
+    });
+
+    test('rejects connection with invalid bearer token', async () => {
+        const error = await createIdentityClient({
+            baseUrl    : KB_OIDC_URL,
+            bearerToken: 'invalid-token'
+        }).catch(e => e);
+
+        expect(error).toBeInstanceOf(Error);
+        expect(error.message).toMatch(/401|Unauthorized|invalid_token/i);
+    });
+
+    test('rejects connection with wrong audience token', async () => {
+        const error = await createIdentityClient({
+            baseUrl    : KB_OIDC_URL,
+            bearerToken: 'wrong-audience-token'
+        }).catch(e => e);
+
+        expect(error).toBeInstanceOf(Error);
+        expect(error.message).toMatch(/401|Unauthorized|invalid_token/i);
+    });
+
+    test('accepts connection with valid token', async () => {
+        const client = await createIdentityClient({
+            baseUrl    : KB_OIDC_URL,
+            bearerToken: 'valid-test-token'
+        });
+
+        try {
+            const health = await callJsonTool(client, 'healthcheck');
+
+            expect(health.status).toBe('healthy');
+            expect(health.database.connection.connected).toBe(true);
+        } finally {
+            await client.close();
+        }
+    });
+
+    test('accepts connection with valid token when preferred_username is missing', async () => {
+        const client = await createIdentityClient({
+            baseUrl    : KB_OIDC_URL,
+            bearerToken: 'valid-test-token-no-username'
+        });
+
+        try {
+            const health = await callJsonTool(client, 'healthcheck');
+
+            expect(health.status).toBe('healthy');
+            expect(health.database.connection.connected).toBe(true);
+        } finally {
+            await client.close();
+        }
+    });
+});

--- a/test/playwright/integration/KBRemoteMcpTransport.integration.spec.mjs
+++ b/test/playwright/integration/KBRemoteMcpTransport.integration.spec.mjs
@@ -1,0 +1,44 @@
+import {test, expect} from '@playwright/test';
+import {callJsonTool, createIdentityClient, getReadiness} from './fixtures/mcpClient.mjs';
+
+const KB_URL = process.env.NEO_INTEGRATION_KB_URL || 'http://127.0.0.1:13000';
+
+test.describe('KB Remote MCP Transport (#11644)', () => {
+    test.beforeEach(async () => {
+        const readiness = await getReadiness();
+        test.skip(readiness.dockerAvailable === false, `Docker unavailable: ${readiness.reason}`);
+        expect(readiness.servicesReady, readiness.reason).toBe(true);
+    });
+
+    test('validates KB remote transport with session persistence across multiple tools', async () => {
+        const client = await createIdentityClient({
+            baseUrl   : KB_URL,
+            clientName: 'neo-integration-kb-remote',
+            identity  : 'kb-remote-user'
+        });
+
+        try {
+            const health = await callJsonTool(client, 'healthcheck');
+            expect(health.status).toBe('healthy');
+
+            const documents = await callJsonTool(client, 'list_documents', {
+                limit : 1,
+                offset: 0
+            });
+            expect(documents).toBeDefined();
+
+            const query = await callJsonTool(client, 'query_documents', {
+                query: 'What is Neo.mjs?',
+                limit: 2
+            });
+            expect(query).toBeDefined();
+            if (query.message) {
+                expect(typeof query.message).toBe('string');
+            } else {
+                expect(Array.isArray(query.results)).toBe(true);
+            }
+        } finally {
+            await client.close();
+        }
+    });
+});

--- a/test/playwright/integration/KBRemoteMcpTransport.integration.spec.mjs
+++ b/test/playwright/integration/KBRemoteMcpTransport.integration.spec.mjs
@@ -1,16 +1,22 @@
-import {test, expect} from '@playwright/test';
+import {test, expect}         from '@playwright/test';
+import {Client}               from '@modelcontextprotocol/sdk/client/index.js';
+import {StdioClientTransport} from '@modelcontextprotocol/sdk/client/stdio.js';
+import path                   from 'node:path';
+import {fileURLToPath}        from 'node:url';
 import {callJsonTool, createIdentityClient, getReadiness} from './fixtures/mcpClient.mjs';
 
-const KB_URL = process.env.NEO_INTEGRATION_KB_URL || 'http://127.0.0.1:13000';
+const __filename  = fileURLToPath(import.meta.url);
+const __dirname   = path.dirname(__filename);
+const repoRoot    = path.resolve(__dirname, '../../..');
+const SERVER_PATH = path.join(repoRoot, 'ai/mcp/server/knowledge-base/mcp-server.mjs');
+const KB_URL      = process.env.NEO_INTEGRATION_KB_URL || 'http://127.0.0.1:13000';
 
 test.describe('KB Remote MCP Transport (#11644)', () => {
-    test.beforeEach(async () => {
+    test('validates KB remote transport with session persistence across multiple tools', async () => {
         const readiness = await getReadiness();
         test.skip(readiness.dockerAvailable === false, `Docker unavailable: ${readiness.reason}`);
         expect(readiness.servicesReady, readiness.reason).toBe(true);
-    });
 
-    test('validates KB remote transport with session persistence across multiple tools', async () => {
         const client = await createIdentityClient({
             baseUrl   : KB_URL,
             clientName: 'neo-integration-kb-remote',
@@ -39,6 +45,39 @@ test.describe('KB Remote MCP Transport (#11644)', () => {
             }
         } finally {
             await client.close();
+        }
+    });
+
+    test('validates KB stdio transport tool surface', async () => {
+        const transport = new StdioClientTransport({
+            command: 'node',
+            args   : [SERVER_PATH],
+            env    : {
+                ...process.env,
+                NEO_AUTO_SYNC             : 'false',
+                NEO_KB_AUTO_START_DATABASE: 'false',
+                NEO_TRANSPORT             : 'stdio'
+            }
+        });
+
+        const client = new Client({
+            name   : 'neo-integration-kb-stdio',
+            version: '1.0.0'
+        }, {
+            capabilities: {}
+        });
+
+        try {
+            await client.connect(transport);
+
+            const {tools} = await client.listTools();
+            const names   = tools.map(tool => tool.name);
+
+            expect(names).toContain('healthcheck');
+            expect(names).toContain('query_documents');
+            expect(names).toContain('list_documents');
+        } finally {
+            await transport.close();
         }
     });
 });

--- a/test/playwright/integration/fixtures/composeWebServer.mjs
+++ b/test/playwright/integration/fixtures/composeWebServer.mjs
@@ -98,20 +98,21 @@ async function waitForServices() {
 
     while (!shuttingDown && Date.now() < deadline) {
         try {
-            const [chroma, kbPort, mcPort, mcOidcPort] = await Promise.all([
+            const [chroma, kbPort, mcPort, mcOidcPort, kbOidcPort] = await Promise.all([
                 fetch('http://127.0.0.1:18080/api/v2/heartbeat').then(r => r.ok).catch(() => false),
                 portOpen(13000),
                 portOpen(13001),
-                portOpen(13002)
+                portOpen(13002),
+                portOpen(13003)
             ]);
 
-            if (chroma && kbPort && mcPort && mcOidcPort) {
+            if (chroma && kbPort && mcPort && mcOidcPort && kbOidcPort) {
                 state.servicesReady = true;
                 state.reason        = 'Dockerized MCP integration stack is ready.';
                 return;
             }
 
-            state.reason = `Waiting for stack readiness: chroma=${chroma}, kb=${kbPort}, mc=${mcPort}`;
+            state.reason = `Waiting for stack readiness: chroma=${chroma}, kb=${kbPort}, mc=${mcPort}, mcOidc=${mcOidcPort}, kbOidc=${kbOidcPort}`;
         } catch (error) {
             state.reason = error.message;
         }


### PR DESCRIPTION
Authored by GPT-5.5 (Codex Desktop). Session 019e3f6c-1692-74c1-8799-4d2244a15444.

FAIR-band: in-band [13/30 — current author count over last 30 merged]

Resolves #11644

Adds the Phase 5A KB MCP integration parity surface as dedicated KB-prefixed specs, plus the missing KB OIDC fixture in the Dockerized integration stack. The PR keeps Memory Core specs untouched and mirrors their coverage shape for KB remote transport, proxy-auth rejection, OIDC auth, backup/wipe/restore, and sustained health propagation.

Evidence: L3 (local KB stdio MCP transport probe executed via `npm run test-integration-unified`; Docker-gated specs verified as cleanly skip-gated because this Codex host has no `docker` binary; PR CI `integration-unified` failures were root-caused and patched in `1af8bb18e` + `50fabc6e0`) → L3 required (Dockerized KB integration behavior under `integration-unified` CI). Residual: PR CI `integration-unified` must rerun the Docker-gated specs on GitHub Actions before merge [#11644].

## Files shipped

- `test/playwright/integration/KBRemoteMcpTransport.integration.spec.mjs` — KB SSE remote transport plus an executable stdio list-tools probe.
- `test/playwright/integration/KBAuthRejection.integration.spec.mjs` — KB proxy-identity rejection and positive identity-bearing healthcheck path.
- `test/playwright/integration/KBOidcAuth.integration.spec.mjs` — KB OIDC rejection matrix and valid-token healthcheck access.
- `test/playwright/integration/KBBackupRestoreWipe.integration.spec.mjs` — SDK-level KB `manageDatabaseBackup` export/import plus record-scoped fixture wipe against the deployed KB container, preserving the deliberate no-MCP-backup-tool boundary without dropping the shared Chroma collection.
- `test/playwright/integration/KBHeartbeatPropagation.integration.spec.mjs` — sustained KB healthcheck and collection-state assertions.
- `ai/deploy/docker-compose.test.yml` + `composeWebServer.mjs` — add `kb-server-oidc` on port `13003` and include it in readiness.

## Deltas from ticket

- I kept the backup/restore coverage through the KB SDK inside the deployed container instead of exposing a new MCP backup tool. This matches the existing `DatabaseService.mjs` JSDoc boundary: backup is intentionally reachable through `ai/services.mjs` / scripts, not added to the MCP tool surface.
- `KBOidcAuth.integration.spec.mjs` proves OIDC-gated KB tool access via `healthcheck`; it does not assert a returned identity field because KB `HealthService` does not expose the Memory Core identity observability block.
- `KBRemoteMcpTransport.integration.spec.mjs` keeps the Docker skip local to the SSE test, so the stdio transport probe remains executable even on hosts without Docker.

## Test Evidence

Local static and executable checks:

```bash
node --check test/playwright/integration/KBAuthRejection.integration.spec.mjs
node --check test/playwright/integration/KBBackupRestoreWipe.integration.spec.mjs
node --check test/playwright/integration/KBHeartbeatPropagation.integration.spec.mjs
node --check test/playwright/integration/KBOidcAuth.integration.spec.mjs
node --check test/playwright/integration/KBRemoteMcpTransport.integration.spec.mjs
node -e "const fs=require('fs'); const yaml=require('js-yaml'); const doc=yaml.load(fs.readFileSync('ai/deploy/docker-compose.test.yml','utf8')); console.log(Object.keys(doc.services).join('\\n'))"
git diff --check
git diff --cached --check
```

Results: all passed. YAML parse confirmed the expected services including `kb-server-oidc`.

Focused integration command:

```bash
npm run test-integration-unified -- test/playwright/integration/KBRemoteMcpTransport.integration.spec.mjs
# -> 1 passed, 1 skipped
```

The passing test was the KB stdio transport list-tools probe. The skipped test was the Docker-gated KB SSE remote transport path, because this Codex environment has no Docker binary.

Docker-gated suite command:

```bash
npm run test-integration-unified -- \
  test/playwright/integration/KBRemoteMcpTransport.integration.spec.mjs \
  test/playwright/integration/KBAuthRejection.integration.spec.mjs \
  test/playwright/integration/KBOidcAuth.integration.spec.mjs \
  test/playwright/integration/KBBackupRestoreWipe.integration.spec.mjs \
  test/playwright/integration/KBHeartbeatPropagation.integration.spec.mjs
# -> 10 skipped locally
```

Environment classification:

```bash
docker compose version
# -> zsh:1: command not found: docker

docker info
# -> zsh:1: command not found: docker
```

## Post-Merge Validation

- [ ] Verify rerun PR CI `integration-unified` passes the Docker-gated KB specs on GitHub Actions after commit `50fabc6e0`.
- [ ] Phase 0/1 PRs keep these KB parity specs green as the KB ingestion contracts and tenant-isolation implementation land.

## Commits

- `133c3914e` — `feat(kb): add KB integration parity specs (#11644)` — KB OIDC fixture, readiness, and five KB-prefixed integration specs.
- `b1eac44bc` — `test(kb): cover KB stdio transport probe (#11644)` — executable stdio list-tools probe and SSE-only Docker skip.
- `1af8bb18e` — `fix(kb): stabilize KB integration CI fixtures (#11644)` — valid KB OIDC token audience and initial cleanup narrowing.
- `50fabc6e0` — `fix(kb): keep backup restore fixture collection stable (#11644)` — removes collection-level truncate from the shared-stack backup/restore spec and keeps cleanup record-scoped.

## Signal Ledger (sourced from Discussion #11623)

Discussion #11623 is high-blast per its body (`Scope: high-blast`); §6.1.1 Consensus-Gate applies.

- @neo-opus-4-7: APPROVED @ [DC_kwDODSospM4BAwVB](https://github.com/neomjs/neo/discussions/11623#discussioncomment-16975169)
- @neo-gpt: APPROVED @ [DC_kwDODSospM4BAwT7](https://github.com/neomjs/neo/discussions/11623#discussioncomment-16975099) → tightening-extension @ [DC_kwDODSospM4BAwUo](https://github.com/neomjs/neo/discussions/11623#discussioncomment-16975149)
- @neo-gemini-3-1-pro: APPROVED @ [DC_kwDODSospM4BAwUa](https://github.com/neomjs/neo/discussions/11623#discussioncomment-16975130)

3/3 — Consensus Mandate satisfied. Graduated to Epic #11624 on 2026-05-19; Discussion closed RESOLVED at 11:35:25Z.

## Unresolved Dissent

*(empty — positive signal; 3/3 APPROVED, no DEFERRED at convergence)*

## Unresolved Liveness

*(empty — positive signal; all 3 cross-family signals explicit despite Gemini harness instability during peer cycles)*

## Related

- Parent: #11643 Phase 5 Epic
- Meta-Epic: #11624 Cloud-Native KB Ingestion
- Origin Discussion: #11623
- Reference precedent: #10805 Lane A and existing MC integration specs

## Evolution

Pre-commit reflection caught that extending the existing MC auth specs would not satisfy #11644's dedicated KB-spec AC shape. I restored the MC specs to zero diff and moved the work into KB-prefixed files before committing. The backup/restore spec intentionally uses the deployed-container SDK surface rather than adding an MCP backup tool, preserving the existing tool-budget boundary. The fixture wipe is record-scoped so it does not invalidate the shared KB MCP server collection cache used by later integration files.