### PR TITLE
fix(memory-core): add .claude and .codex to FileSystemIngestor ignorePatterns (#11650)

### DIFF
--- a/ai/services/memory-core/FileSystemIngestor.mjs
+++ b/ai/services/memory-core/FileSystemIngestor.mjs
@@ -28,7 +28,7 @@ class FileSystemIngestor extends Base {
         /**
          * Standard high-noise directories and files to completely ignore.
          */
-        ignorePatterns_: ['node_modules', 'dist', '.git', '.DS_Store', 'build', '.env', '.neo-ai-data', 'docs/output', 'tmp', '.idea', '.gemini', '.agents', 'resources/images', 'resources/fonts'],
+        ignorePatterns_: ['node_modules', 'dist', '.git', '.DS_Store', 'build', '.env', '.neo-ai-data', 'docs/output', 'tmp', '.idea', '.gemini', '.codex', '.claude', '.agents', 'resources/images', 'resources/fonts'],
         /**
          * Extensions to explicitly ignore (images, fonts, raw binaries)
          */
@@ -77,7 +77,7 @@ class FileSystemIngestor extends Base {
 
         const stats = { nodes: 0, edges: 0 };
         await this.walkDirectory(neoRootDir, neoRootDir, rootNodeId, stats, mtimeMap, hashMap);
-        
+
         logger.info(`[FileSystemIngestor] Workspace Sync Complete. Upserted/Verified ${stats.nodes} Nodes and ${stats.edges} tracked CONTAINS Edges.`);
     }
 
@@ -100,12 +100,12 @@ class FileSystemIngestor extends Base {
             const fullPath = path.join(dir, file);
             let isDir = false;
             let stat;
-            
+
             try {
                 stat = await fs.promises.stat(fullPath);
                 isDir = stat.isDirectory();
             } catch(e) { continue; } // symlink drops
-            
+
             const relativePath = path.relative(rootDir, fullPath).replace(/\\/g, '/');
 
             // 1. Structural check for explicit matches or directory hierarchies (e.g., docs/output/*)

--- a/test/playwright/unit/ai/services/memory-core/FileSystemIngestor.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/FileSystemIngestor.spec.mjs
@@ -33,7 +33,7 @@ test.describe('Neo.ai.services.memory-core.FileSystemIngestor', () => {
     test.beforeAll(async () => {
         const aiConfig                = (await import('../../../../../../ai/mcp/server/memory-core/config.mjs')).default;
         originalDbPath = aiConfig.storagePaths.graph;
-        
+
         const tmpDir = path.resolve(process.cwd(), 'tmp');
         if (!fs.existsSync(tmpDir)) {
             fs.mkdirSync(tmpDir, { recursive: true });
@@ -49,7 +49,7 @@ test.describe('Neo.ai.services.memory-core.FileSystemIngestor', () => {
         GraphService       = (await import('../../../../../../ai/services/memory-core/GraphService.mjs')).default;
         FileSystemIngestor = (await import('../../../../../../ai/services/memory-core/FileSystemIngestor.mjs')).default;
         SystemLifecycleService = (await import('../../../../../../ai/services/memory-core/lifecycle/SystemLifecycleService.mjs')).default;
-        
+
         const { TestLifecycleHelper } = await import('./util.mjs');
         await TestLifecycleHelper.cleanupGraphService(GraphService, SystemLifecycleService, testDbPath, fs, 'clear');
 
@@ -62,6 +62,12 @@ test.describe('Neo.ai.services.memory-core.FileSystemIngestor', () => {
         fs.ensureDirSync(path.join(mockFsRoot, 'resources', 'scss'));
         fs.ensureDirSync(path.join(mockFsRoot, 'resources', 'images'));
         fs.ensureDirSync(path.join(mockFsRoot, 'node_modules', 'dep'));
+        // Agent harness directories — neither should be indexed (#11650).
+        // .claude/worktrees/<NAME>/ carries each Claude Code session's own multi-GB
+        // node_modules + its own .neo-ai-data (recursive substrate amplification).
+        // .codex/ carries Codex agent state similarly.
+        fs.ensureDirSync(path.join(mockFsRoot, '.claude', 'worktrees', 'test-worktree', 'node_modules', 'transitive-dep'));
+        fs.ensureDirSync(path.join(mockFsRoot, '.codex', 'sessions'));
 
         fs.writeFileSync(path.join(mockFsRoot, 'src', 'App.mjs'), 'export default {}');
         fs.writeFileSync(path.join(mockFsRoot, 'docs', 'output', 'index.html'), '<html></html>');
@@ -72,6 +78,12 @@ test.describe('Neo.ai.services.memory-core.FileSystemIngestor', () => {
         fs.writeFileSync(path.join(mockFsRoot, 'node_modules', 'dep', 'index.js'), 'foo');
         fs.writeFileSync(path.join(mockFsRoot, '.env'), 'SECRET=123');
         fs.writeFileSync(path.join(mockFsRoot, 'package.json'), '{}');
+        // Files inside the agent harness directories — would have leaked under the
+        // pre-#11650 path-prefix matcher because relativePath starts with `.claude/`
+        // or `.codex/`, not with `node_modules/`. Adding `.claude` + `.codex` to the
+        // top-level ignorePatterns is the surgical fix.
+        fs.writeFileSync(path.join(mockFsRoot, '.claude', 'worktrees', 'test-worktree', 'node_modules', 'transitive-dep', 'index.js'), 'agent-harness-leak');
+        fs.writeFileSync(path.join(mockFsRoot, '.codex', 'sessions', 'session.json'), '{"data":"codex-state"}');
     });
 
     test.beforeEach(async () => {
@@ -91,7 +103,7 @@ test.describe('Neo.ai.services.memory-core.FileSystemIngestor', () => {
     test.afterAll(async () => {
         const { cleanupChromaManager, TestLifecycleHelper } = await import('./util.mjs');
         await cleanupChromaManager();
-        
+
         const aiConfig = (await import('../../../../../../ai/mcp/server/memory-core/config.mjs')).default;
         aiConfig.storagePaths.graph = originalDbPath;
 
@@ -109,29 +121,35 @@ test.describe('Neo.ai.services.memory-core.FileSystemIngestor', () => {
         // Nodes: src, src/App.mjs, docs, resources, resources/scss, resources/scss/theme.scss, resources/images, package.json
         // NOTE: Relative paths here depend on CWD. In `walkDirectory`, it compares against `neoRootDir`,
         // meaning `path.relative(neoRootDir, fullPath)` will be evaluated.
-        
+
         // Let's assert based on DB injection output to ensure structural Graph integrity exists natively
         const allNodes = GraphService.db.nodes.items.map(n => n.properties?.path).filter(Boolean);
-        
+
         // SHOULD NOT BE PRESENT:
         expect(allNodes.some(p => p.includes('docs/output'))).toBe(false);
         expect(allNodes.some(p => p.includes('node_modules'))).toBe(false);
         expect(allNodes.some(p => p.includes('.env'))).toBe(false);
         expect(allNodes.some(p => p.includes('.png'))).toBe(false);
         expect(allNodes.some(p => p.includes('.svg'))).toBe(false);
+        // Agent harness directories must be excluded (#11650). Pre-#11650 the
+        // path-prefix matcher caught only root-level node_modules; nested
+        // .claude/worktrees/<X>/node_modules slipped through because the path
+        // doesn't start with `node_modules/` — it starts with `.claude/`.
+        expect(allNodes.some(p => p.includes('.claude'))).toBe(false);
+        expect(allNodes.some(p => p.includes('.codex'))).toBe(false);
 
         // SHOULD BE PRESENT:
         expect(allNodes.some(p => p.endsWith('src/App.mjs'))).toBe(true);
         expect(allNodes.some(p => p.endsWith('package.json'))).toBe(true);
         expect(allNodes.some(p => p.endsWith('resources/scss/theme.scss'))).toBe(true);
-        
+
         // We verify that the edge connection `CONTAINS` works hierarchically:
         const srcNode = GraphService.db.nodes.items.find(n => n.label === 'DIRECTORY' && n.properties.path.endsWith('src'));
         const fileNode = GraphService.db.nodes.items.find(n => n.label === 'FILE' && n.properties.path.endsWith('src/App.mjs'));
-        
+
         expect(srcNode).toBeDefined();
         expect(fileNode).toBeDefined();
-        
+
         const link = GraphService.db.edges.items.find(e => e.source === srcNode.id && e.target === fileNode.id);
         expect(link).toBeDefined();
         expect(link.type).toBe('CONTAINS');


### PR DESCRIPTION
Authored by Claude Opus 4.7 (Claude Code). Session \`7360e917-1733-4cdd-a6f3-5ac51c34b838\`.

FAIR-band: under-target [13/30] — Self-Selection Rule 1 fires (under-band → bias toward author lane); operator-V-B-A surfaced the bug this session and approved the fix shape.

Resolves #11650

Surgical fix to FileSystemIngestor ignorePatterns adding the two missing harness-substrate directories (\`.claude\` for Claude Code worktrees, \`.codex\` for Codex agent state) that were leaking ~3.1M FILE/DIRECTORY/CONTAINS graph elements (~98% of the corpus) into the Memory Core graph database. No code-flow change; no destructive operation; future syncs stop adding stale records under these paths.

Evidence: L2 (focused unit-test re-run via \`npm run test-unit\` confirms the new fixture exclusions; extended regression-guard for \`.claude/worktrees/<NAME>/node_modules\` + \`.codex/sessions\` paths) → L2 required (Phase 0/1A-class static fix; no runtime daemon-restart needed). No residuals on the fix-shape AC; cleanup-of-existing-stale-records is OUT OF SCOPE per ticket framing.

## Diagnostic anchor

Operator V-B-A on the 3.17M graph-element count led to in-depth analysis of \`graph-backup-2026-05-19T13-08-22.938Z.jsonl\` via every-1000th + every-2000th statistical sampling. Findings:

| Element class | Sample % | Extrapolated count |
|---|---|---|
| FILE nodes | 81.7% | ~1,298,000 |
| DIRECTORY nodes | 16.0% | ~254,000 |
| CONTAINS edges | 98.4% of edges | ~1,554,000 |
| Legitimate semantic graph | ~2% | ~67,000 (matches operator's 10-day-ago baseline) |

FILE-node path-prefix distribution: ~25 distinct \`.claude/worktrees/<NAME>/\` paths visible in the sample, each contributing 11-14 sampled records (× 2000 = ~22-28k actual records per worktree).

## Files shipped

- \`ai/services/memory-core/FileSystemIngestor.mjs\` — added \`.claude\` and \`.codex\` to \`ignorePatterns_\` at line 31. Plus stripped pre-existing trailing whitespace on lines 103+108 (pre-commit hook strictness; mechanical cleanup, not scope creep).
- \`test/playwright/unit/ai/services/memory-core/FileSystemIngestor.spec.mjs\` — extended mock filesystem with \`.claude/worktrees/test-worktree/node_modules/transitive-dep/\` AND \`.codex/sessions/\` entries; added regression-guard assertions \`expect(allNodes.some(p => p.includes('.claude'))).toBe(false)\` and same for \`.codex\`. Pre-fix would have leaked these paths as FILE nodes because path-prefix matcher doesn't catch nested \`node_modules\` under \`.claude/\`.

## Deltas from ticket

None. Surgical scope per ticket Out of Scope section.

## Test Evidence

\`\`\`
npm run test-unit -- test/playwright/unit/ai/services/memory-core/FileSystemIngestor.spec.mjs
# → 1 passed (922ms)
\`\`\`

Regression-guard verified: pre-fix test would have FAILED on \`.claude\` + \`.codex\` exclusion assertions (mock fixtures placed entries under these paths). Post-fix test passes cleanly.

## Post-Merge Validation

- [ ] Operator decides cleanup approach for existing 3.1M stale FILE/DIRECTORY/CONTAINS records — separate destructive operation (backup-first; mass-delete via SQLite WHERE id LIKE 'file-.claude/%' OR similar; OR full nuke-and-rebuild of FILE/DIRECTORY graph slice via post-merge \`FileSystemIngestor.syncWorkspaceToGraph()\` if it can detect orphans). Not blocking this PR's merge.
- [ ] Phase 4B (#11640) reconciliation daemon scope confirmed to include orphan auto-prune of FILE/DIRECTORY records whose paths no longer match a walkable directory — future-proofs the prevention layer this PR delivers.

## Commits

- \`389fd7ddd\` — \`fix(memory-core): add .claude and .codex to FileSystemIngestor ignorePatterns (#11650)\`

## Substrate-evolution observation worth preserving

The leak was caused by **substrate-recursion footprint**: each Claude Code agent worktree at \`.claude/worktrees/<NAME>/\` carries the SAME harness substrate (\`node_modules\`, \`.neo-ai-data\`) that the indexer was already configured to skip at root. Path-prefix matching only catches root-level patterns, so nested-substrate-recursion slips through. Adding \`.claude\` and \`.codex\` as top-level prefixes is the surgical fix because ALL observed leak paths start with one of these two prefixes.

Path-component (gitignore-style) refactor would be the general-robustness follow-up if other nested-pattern leaks emerge (e.g., \`apps/*/node_modules\` in a monorepo-style workspace). Tracking as out-of-scope per surgical-fix framing.

## Related

- **Resolves**: #11650
- **Diagnostic context**: 2026-05-19 graph-backup analysis (\`.neo-ai-data/backups/backup-2026-05-19T13-08-14.283Z/graph/\`)
- **Phase 4B (#11640)** reconciliation daemon — long-term home for orphan auto-prune
- **Phase 4 Epic (#11628)** — KB-as-Cache vs MC-as-Store framing context
- **Memory anchor**: \`feedback_substrate_audit_consumer_sweep.md\` Category 4 — substrate-recursion footprint is the same audit-completeness pattern at the directory-traversal layer