### PR TITLE
feat(worktree): add stale Claude worktree pruning (#11654)

### DIFF
--- a/ai/scripts/bootstrapWorktree.mjs
+++ b/ai/scripts/bootstrapWorktree.mjs
@@ -71,6 +71,12 @@
  * node ai/scripts/bootstrapWorktree.mjs --link-data --canonical-root /path/to/canonical
  *                                                    # independent-clone topology: explicit
  *                                                    # canonical-root override (per #10435)
+ * node ai/scripts/bootstrapWorktree.mjs --prune-stale
+ *                                                    # dry-run stale .claude/worktrees cleanup
+ * node ai/scripts/bootstrapWorktree.mjs --prune-stale --apply
+ *                                                    # remove prunable worktrees via git
+ * node ai/scripts/bootstrapWorktree.mjs --prune-stale --apply --force-dirty
+ *                                                    # also force-remove dirty-but-stale worktrees
  * ```
  *
  * Also supports the `NEO_AI_CANONICAL_ROOT` env var as a fallback for the `--canonical-root`
@@ -158,6 +164,13 @@ export const DATA_SUBDIRS_TO_LINK = [
 export const GITIGNORED_FILES_TO_LINK = [
     'resources/content/sandman_handoff.md'  // Sandman strategic-priming handoff (#10591)
 ];
+
+export const DEFAULT_CLAUDE_WORKTREES_ROOT = path.join('.claude', 'worktrees');
+
+export const PRUNABLE_WORKTREE_STATUSES = new Set([
+    'prunable-merged',
+    'prunable-deleted'
+]);
 
 /**
  * @summary Resolves the canonical "main checkout" path for a given project root.
@@ -531,6 +544,333 @@ export async function runBuildAll({projectRoot, log = console.log, exec = execFi
     return 'built';
 }
 
+/**
+ * @summary Parses `git worktree list --porcelain` into stable worktree records.
+ *
+ * @param {string} output Raw porcelain output from git.
+ * @returns {{path: string, head: string|null, branchRef: string|null, branch: string|null, detached: boolean}[]}
+ */
+export function parseWorktreePorcelain(output) {
+    const records = [];
+    let current   = null;
+
+    for (const line of output.split(/\r?\n/)) {
+        if (!line.trim()) {
+            if (current) {
+                records.push(current);
+                current = null;
+            }
+            continue;
+        }
+
+        const [key, ...rest] = line.split(' ');
+        const value          = rest.join(' ');
+
+        if (key === 'worktree') {
+            if (current) records.push(current);
+            current = {
+                path     : value,
+                head     : null,
+                branchRef: null,
+                branch   : null,
+                detached : false
+            };
+            continue;
+        }
+
+        if (!current) continue;
+
+        if (key === 'HEAD') {
+            current.head = value;
+        } else if (key === 'branch') {
+            current.branchRef = value;
+            current.branch    = value.startsWith('refs/heads/') ? value.slice('refs/heads/'.length) : value;
+        } else if (key === 'detached') {
+            current.detached = true;
+        }
+    }
+
+    if (current) records.push(current);
+
+    return records;
+}
+
+/**
+ * @summary Lists git worktrees below the Claude Code worktree root.
+ *
+ * The cleanup mode is scoped deliberately to `.claude/worktrees/`; shared-checkout
+ * harnesses such as Codex and Antigravity do not create this disk-growth pattern.
+ *
+ * @param {object}   options
+ * @param {string}   options.projectRoot Absolute primary checkout path.
+ * @param {string}   [options.worktreesRoot] Relative or absolute worktree parent.
+ * @param {Function} [options.exec] Dependency-injected execFile wrapper.
+ * @returns {Promise<object[]>}
+ */
+export async function listClaudeWorktrees({
+    projectRoot,
+    worktreesRoot = DEFAULT_CLAUDE_WORKTREES_ROOT,
+    exec          = execFileAsync
+}) {
+    const {stdout} = await exec('git', ['worktree', 'list', '--porcelain'], {cwd: projectRoot});
+    const rootPath = path.isAbsolute(worktreesRoot)
+        ? path.resolve(worktreesRoot)
+        : path.resolve(projectRoot, worktreesRoot);
+
+    return parseWorktreePorcelain(stdout).filter(record => isPathInside(rootPath, record.path));
+}
+
+/**
+ * @summary Classifies one Claude Code worktree for dry-run or removal.
+ *
+ * Safety is biased toward preservation: dirty worktrees, branches with open PRs,
+ * branches with unmerged commits, and branches whose PR status cannot be verified
+ * are classified as non-prunable.
+ *
+ * @param {object}   options
+ * @param {object}   options.worktree Parsed worktree record.
+ * @param {string}   options.projectRoot Primary checkout path used for repo-wide git queries.
+ * @param {string}   [options.baseRef='dev'] Base branch to compare against.
+ * @param {Function} [options.exec] Dependency-injected execFile wrapper.
+ * @param {Function} [options.getSize] Optional size resolver.
+ * @returns {Promise<object>}
+ */
+export async function classifyWorktree({
+    worktree,
+    projectRoot,
+    baseRef = 'dev',
+    exec    = execFileAsync,
+    getSize = getPathSizeBytes
+}) {
+    const sizeBytes = await getSize(worktree.path, {exec});
+    const dirty     = await isWorktreeDirty(worktree.path, exec);
+    const base      = {
+        ...worktree,
+        sizeBytes,
+        dirty,
+        prunable       : false,
+        forcePrunable  : false,
+        removeArgs     : ['worktree', 'remove', worktree.path],
+        status         : 'active',
+        reason         : ''
+    };
+
+    const branchExists = worktree.branch
+        ? await refExists(projectRoot, `refs/heads/${worktree.branch}`, exec)
+        : false;
+
+    const prState = worktree.branch ? await getPullRequestState(projectRoot, worktree.branch, exec) : null;
+    const merged = await isMergedToBase({projectRoot, worktree, baseRef, branchExists, exec});
+    const prStateBlocksRemoval = prState === 'OPEN' || prState === 'unknown';
+
+    if (dirty) {
+        return {
+            ...base,
+            status       : 'dirty',
+            reason       : merged || !branchExists ? 'dirty-but-otherwise-prunable' : 'dirty-active-or-unmerged',
+            forcePrunable: !prStateBlocksRemoval && (merged || !branchExists),
+            removeArgs   : ['worktree', 'remove', '--force', worktree.path]
+        };
+    }
+
+    if (prState === 'OPEN') {
+        return {
+            ...base,
+            status: 'active',
+            reason: `branch ${worktree.branch} has an open PR`
+        };
+    }
+
+    if (prState === 'unknown') {
+        return {
+            ...base,
+            status: 'active',
+            reason: `branch ${worktree.branch} PR status could not be verified`
+        };
+    }
+
+    if (worktree.branch && !branchExists) {
+        return {
+            ...base,
+            prunable: true,
+            status  : 'prunable-deleted',
+            reason  : `branch ${worktree.branch} no longer exists`
+        };
+    }
+
+    if (merged) {
+        return {
+            ...base,
+            prunable: true,
+            status  : 'prunable-merged',
+            reason  : worktree.branch
+                ? `branch ${worktree.branch} is merged or patch-equivalent to ${baseRef}`
+                : `detached HEAD ${worktree.head} is an ancestor of ${baseRef}`
+        };
+    }
+
+    return {
+        ...base,
+        status: 'active',
+        reason: worktree.branch
+            ? `branch ${worktree.branch} has commits not merged into ${baseRef}`
+            : `detached HEAD ${worktree.head || 'unknown'} is not known merged into ${baseRef}`
+    };
+}
+
+/**
+ * @summary Dry-runs or applies stale Claude Code worktree pruning.
+ *
+ * Default mode never mutates. `apply=true` removes only clean worktrees classified
+ * as prunable. Dirty worktrees remain preserved unless `forceDirty=true` is also
+ * provided and the dirty worktree is otherwise prunable.
+ *
+ * @param {object}   options
+ * @param {string}   options.projectRoot Primary checkout path.
+ * @param {boolean}  [options.apply=false] Whether to remove prunable worktrees.
+ * @param {boolean}  [options.forceDirty=false] Whether dirty-but-prunable worktrees may be force-removed.
+ * @param {string}   [options.baseRef='dev'] Base branch to compare against.
+ * @param {string}   [options.worktreesRoot] Worktree parent path.
+ * @param {Function} [options.exec] Dependency-injected execFile wrapper.
+ * @param {Function} [options.getSize] Optional size resolver.
+ * @param {Function} [options.log] Logger fn for action diagnostics.
+ * @returns {Promise<{worktrees: object[], removed: object[], skipped: object[], totalBytes: number, reclaimableBytes: number, reclaimedBytes: number}>}
+ */
+export async function pruneStaleWorktrees({
+    projectRoot,
+    apply         = false,
+    forceDirty    = false,
+    baseRef       = 'dev',
+    worktreesRoot = DEFAULT_CLAUDE_WORKTREES_ROOT,
+    exec          = execFileAsync,
+    getSize       = getPathSizeBytes,
+    log           = console.log
+}) {
+    const worktrees = await listClaudeWorktrees({projectRoot, worktreesRoot, exec});
+    const classified = [];
+
+    for (const worktree of worktrees) {
+        classified.push(await classifyWorktree({worktree, projectRoot, baseRef, exec, getSize}));
+    }
+
+    const removable = classified.filter(item => item.prunable || (forceDirty && item.forcePrunable));
+    const skipped   = classified.filter(item => !removable.includes(item));
+    const removed   = [];
+
+    const totalBytes       = classified.reduce((sum, item) => sum + item.sizeBytes, 0);
+    const reclaimableBytes = removable.reduce((sum, item) => sum + item.sizeBytes, 0);
+
+    log(`Claude worktree prune ${apply ? 'apply' : 'dry-run'} against ${baseRef}`);
+    log(`Found ${classified.length} worktree(s), ${formatBytes(totalBytes)} total, ${formatBytes(reclaimableBytes)} reclaimable.`);
+
+    for (const item of classified) {
+        const marker = removable.includes(item) ? (apply ? 'remove' : 'would-remove') : 'keep';
+        log(`${marker}: ${item.status} ${formatBytes(item.sizeBytes)} ${item.path}`);
+        log(`  ${item.reason}`);
+    }
+
+    if (apply) {
+        for (const item of removable) {
+            await exec('git', item.removeArgs, {cwd: projectRoot});
+            removed.push(item);
+        }
+        log(`Removed ${removed.length} worktree(s), reclaimed up to ${formatBytes(reclaimableBytes)}.`);
+    } else {
+        log(`Dry-run only. Re-run with --apply to remove prunable worktrees.`);
+    }
+
+    return {
+        worktrees      : classified,
+        removed,
+        skipped,
+        totalBytes,
+        reclaimableBytes,
+        reclaimedBytes: apply ? reclaimableBytes : 0
+    };
+}
+
+async function getPathSizeBytes(targetPath, {exec = execFileAsync} = {}) {
+    try {
+        const {stdout} = await exec('du', ['-sk', targetPath]);
+        const kb       = Number.parseInt(stdout.trim().split(/\s+/)[0], 10);
+        return Number.isFinite(kb) ? kb * 1024 : 0;
+    } catch {
+        return 0;
+    }
+}
+
+async function isWorktreeDirty(worktreePath, exec) {
+    const {stdout} = await exec('git', ['status', '--porcelain'], {cwd: worktreePath});
+    return stdout.trim().length > 0;
+}
+
+async function refExists(projectRoot, ref, exec) {
+    try {
+        await exec('git', ['show-ref', '--verify', '--quiet', ref], {cwd: projectRoot});
+        return true;
+    } catch {
+        return false;
+    }
+}
+
+async function isMergedToBase({projectRoot, worktree, baseRef, branchExists, exec}) {
+    if (worktree.head) {
+        try {
+            await exec('git', ['merge-base', '--is-ancestor', worktree.head, baseRef], {cwd: projectRoot});
+            return true;
+        } catch {}
+    }
+
+    if (!worktree.branch || !branchExists) {
+        return false;
+    }
+
+    const {stdout: mergedBranches} = await exec('git', ['branch', '--merged', baseRef, '--format=%(refname:short)'], {cwd: projectRoot});
+    if (mergedBranches.split(/\r?\n/).map(line => line.trim()).includes(worktree.branch)) {
+        return true;
+    }
+
+    try {
+        const {stdout: cherry} = await exec('git', ['cherry', baseRef, worktree.branch], {cwd: projectRoot});
+        const lines = cherry.split(/\r?\n/).map(line => line.trim()).filter(Boolean);
+        return lines.length > 0 && lines.every(line => line.startsWith('-'));
+    } catch {
+        return false;
+    }
+}
+
+async function getPullRequestState(projectRoot, branch, exec) {
+    try {
+        const {stdout} = await exec('gh', ['pr', 'view', branch, '--json', 'state', '--jq', '.state'], {cwd: projectRoot});
+        const state    = stdout.trim();
+        return state || null;
+    } catch (e) {
+        const stderr = String(e.stderr || e.message || '');
+        if (/no pull requests found|not found|could not resolve to a PullRequest/i.test(stderr)) {
+            return null;
+        }
+        return 'unknown';
+    }
+}
+
+function isPathInside(rootPath, candidatePath) {
+    const relative = path.relative(path.resolve(rootPath), path.resolve(candidatePath));
+    return relative === '' || (!!relative && !relative.startsWith('..') && !path.isAbsolute(relative));
+}
+
+function formatBytes(bytes) {
+    const units = ['B', 'KB', 'MB', 'GB', 'TB'];
+    let value   = bytes;
+    let unitIdx = 0;
+
+    while (value >= 1024 && unitIdx < units.length - 1) {
+        value /= 1024;
+        unitIdx++;
+    }
+
+    return `${value.toFixed(unitIdx === 0 ? 0 : 1)}${units[unitIdx]}`;
+}
+
 // -------------------------------------------------------------------------------------
 // CLI entry point. Runs only when invoked directly (node ai/scripts/bootstrapWorktree.mjs)
 // and not when imported by a test spec.
@@ -547,6 +887,10 @@ if (isMain) {
     const args     = new Set(argv);
     const linkData = args.has('--link-data');
     const force    = args.has('--force');
+    const pruneStale = args.has('--prune-stale') || argv.includes('--mode=prune-stale') ||
+        (argv.includes('--mode') && argv[argv.indexOf('--mode') + 1] === 'prune-stale');
+    const apply      = args.has('--apply');
+    const forceDirty = args.has('--force-dirty');
 
     // `--canonical-root <path>` flag wins; `NEO_AI_CANONICAL_ROOT` env var is the fallback.
     // Both are no-ops when running in an actual git worktree (the existing
@@ -565,6 +909,11 @@ if (isMain) {
             process.exit(1);
         }
         if (explicitRoot) console.log(`✓ Canonical checkout (explicit): ${mainCheckout}`);
+
+        if (pruneStale) {
+            await pruneStaleWorktrees({projectRoot: mainCheckout, apply, forceDirty});
+            process.exit(0);
+        }
 
         const result = await bootstrapWorktree({mainCheckout, projectRoot});
         const total  = result.copied.length + result.skipped.length + result.missing.length;

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
         "ai:mcp-server-knowledge-base" : "node ./ai/mcp/server/knowledge-base/mcp-server.mjs",
         "ai:mcp-server-memory-core"    : "node ./ai/mcp/server/memory-core/mcp-server.mjs",
         "ai:mcp-server-neural-link"    : "node ./ai/mcp/server/neural-link/mcp-server.mjs",
+        "ai:prune-worktrees"           : "node ./ai/scripts/bootstrapWorktree.mjs --prune-stale",
         "ai:lint-agents"               : "node ./ai/scripts/lint-agents.mjs",
         "ai:lint-skill-manifest"       : "node ./ai/scripts/lint-skill-manifest.mjs",
         "ai:orchestrator"              : "node ./ai/scripts/orchestrator-daemon.mjs",

--- a/test/playwright/unit/ai/scripts/bootstrapWorktree.spec.mjs
+++ b/test/playwright/unit/ai/scripts/bootstrapWorktree.spec.mjs
@@ -35,6 +35,8 @@ test.describe('ai/scripts/bootstrapWorktree', () => {
     let installDependencies;
     let runBuildAll;
     let resolveMainCheckout;
+    let parseWorktreePorcelain;
+    let pruneStaleWorktrees;
     let BOOTSTRAP_CONFIGS;
     let DATA_SUBDIRS_TO_LINK;
     let GITIGNORED_FILES_TO_LINK;
@@ -56,6 +58,8 @@ test.describe('ai/scripts/bootstrapWorktree', () => {
         installDependencies      = mod.installDependencies;
         runBuildAll              = mod.runBuildAll;
         resolveMainCheckout      = mod.resolveMainCheckout;
+        parseWorktreePorcelain   = mod.parseWorktreePorcelain;
+        pruneStaleWorktrees      = mod.pruneStaleWorktrees;
         BOOTSTRAP_CONFIGS        = mod.BOOTSTRAP_CONFIGS;
         DATA_SUBDIRS_TO_LINK     = mod.DATA_SUBDIRS_TO_LINK;
         GITIGNORED_FILES_TO_LINK = mod.GITIGNORED_FILES_TO_LINK;
@@ -704,6 +708,232 @@ test.describe('ai/scripts/bootstrapWorktree', () => {
             expect(calls).toHaveLength(2);
             expect(calls[0].args).toEqual(['run', 'bundle-parse5']);
             expect(calls[1].args).toEqual(['run', 'build-all']);
+        });
+    });
+
+    test.describe('#11654 pruneStaleWorktrees', () => {
+        function makePruneExec({removed, unknownBranches = []}) {
+            const worktreesRoot = path.join(fakeMainCheckout, '.claude', 'worktrees');
+            const paths = {
+                merged     : path.join(worktreesRoot, 'merged'),
+                deleted    : path.join(worktreesRoot, 'deleted'),
+                deletedOpen: path.join(worktreesRoot, 'deleted-open-pr'),
+                active     : path.join(worktreesRoot, 'active'),
+                dirty      : path.join(worktreesRoot, 'dirty')
+            };
+
+            const porcelain = [
+                `worktree ${fakeMainCheckout}`,
+                'HEAD main-head',
+                'branch refs/heads/dev',
+                '',
+                `worktree ${paths.merged}`,
+                'HEAD merged-head',
+                'branch refs/heads/agent/merged',
+                '',
+                `worktree ${paths.deleted}`,
+                'HEAD deleted-head',
+                'branch refs/heads/agent/deleted',
+                '',
+                `worktree ${paths.deletedOpen}`,
+                'HEAD deleted-open-head',
+                'branch refs/heads/agent/deleted-open',
+                '',
+                `worktree ${paths.active}`,
+                'HEAD active-head',
+                'branch refs/heads/agent/active',
+                '',
+                `worktree ${paths.dirty}`,
+                'HEAD dirty-head',
+                'branch refs/heads/agent/dirty',
+                ''
+            ].join('\n');
+
+            const exec = async (cmd, args, opts = {}) => {
+                if (cmd === 'git' && args.join(' ') === 'worktree list --porcelain') {
+                    return {stdout: porcelain, stderr: ''};
+                }
+
+                if (cmd === 'git' && args.join(' ') === 'status --porcelain') {
+                    return {stdout: opts.cwd === paths.dirty ? ' M local.txt\n' : '', stderr: ''};
+                }
+
+                if (cmd === 'git' && args[0] === 'show-ref') {
+                    const ref = args[3];
+                    if (
+                        ref === 'refs/heads/agent/deleted' ||
+                        ref === 'refs/heads/agent/deleted-open' ||
+                        ref === 'refs/heads/agent/dirty'
+                    ) {
+                        throw Object.assign(new Error('missing ref'), {stderr: ''});
+                    }
+                    return {stdout: '', stderr: ''};
+                }
+
+                if (cmd === 'git' && args[0] === 'merge-base') {
+                    throw Object.assign(new Error('not ancestor'), {stderr: ''});
+                }
+
+                if (cmd === 'git' && args[0] === 'branch') {
+                    return {stdout: 'dev\n', stderr: ''};
+                }
+
+                if (cmd === 'git' && args[0] === 'cherry') {
+                    const branch = args[2];
+                    if (branch === 'agent/merged') {
+                        return {stdout: '- merged-head\n', stderr: ''};
+                    }
+                    return {stdout: '+ unmerged-head\n', stderr: ''};
+                }
+
+                if (cmd === 'git' && args[0] === 'worktree' && args[1] === 'remove') {
+                    removed.push(args);
+                    return {stdout: '', stderr: ''};
+                }
+
+                if (cmd === 'gh' && args[0] === 'pr' && args[1] === 'view') {
+                    const branch = args[2];
+                    if (unknownBranches.includes(branch)) {
+                        throw Object.assign(new Error('api unavailable'), {stderr: 'api unavailable'});
+                    }
+                    return {stdout: ['agent/active', 'agent/deleted-open'].includes(branch) ? 'OPEN\n' : 'MERGED\n', stderr: ''};
+                }
+
+                throw new Error(`Unexpected command: ${cmd} ${args.join(' ')}`);
+            };
+
+            return {exec, paths};
+        }
+
+        test('parses git worktree porcelain output', () => {
+            const parsed = parseWorktreePorcelain([
+                'worktree /repo',
+                'HEAD abc123',
+                'branch refs/heads/dev',
+                '',
+                'worktree /repo/.claude/worktrees/detached',
+                'HEAD def456',
+                'detached',
+                ''
+            ].join('\n'));
+
+            expect(parsed).toEqual([
+                {
+                    path     : '/repo',
+                    head     : 'abc123',
+                    branchRef: 'refs/heads/dev',
+                    branch   : 'dev',
+                    detached : false
+                },
+                {
+                    path     : '/repo/.claude/worktrees/detached',
+                    head     : 'def456',
+                    branchRef: null,
+                    branch   : null,
+                    detached : true
+                }
+            ]);
+        });
+
+        test('classifies stale Claude worktrees and dry-runs by default', async () => {
+            const removed = [];
+            const {exec, paths} = makePruneExec({removed});
+
+            const result = await pruneStaleWorktrees({
+                projectRoot: fakeMainCheckout,
+                exec,
+                getSize: async p => ({
+                    [paths.merged]     : 1024,
+                    [paths.deleted]    : 2048,
+                    [paths.deletedOpen]: 3072,
+                    [paths.active]     : 4096,
+                    [paths.dirty]      : 8192
+                })[p] || 0,
+                log: () => {}
+            });
+
+            const byPath = Object.fromEntries(result.worktrees.map(item => [item.path, item]));
+
+            expect(byPath[paths.merged].status).toBe('prunable-merged');
+            expect(byPath[paths.merged].prunable).toBe(true);
+            expect(byPath[paths.deleted].status).toBe('prunable-deleted');
+            expect(byPath[paths.deleted].prunable).toBe(true);
+            expect(byPath[paths.deletedOpen].status).toBe('active');
+            expect(byPath[paths.deletedOpen].prunable).toBe(false);
+            expect(byPath[paths.deletedOpen].reason).toContain('open PR');
+            expect(byPath[paths.active].status).toBe('active');
+            expect(byPath[paths.active].prunable).toBe(false);
+            expect(byPath[paths.dirty].status).toBe('dirty');
+            expect(byPath[paths.dirty].prunable).toBe(false);
+
+            expect(result.reclaimableBytes).toBe(3072);
+            expect(result.reclaimedBytes).toBe(0);
+            expect(removed).toHaveLength(0);
+        });
+
+        test('preserves worktrees when PR state cannot be verified', async () => {
+            const removed = [];
+            const {exec, paths} = makePruneExec({removed, unknownBranches: ['agent/deleted']});
+
+            const result = await pruneStaleWorktrees({
+                projectRoot: fakeMainCheckout,
+                exec,
+                getSize: async p => ({
+                    [paths.merged] : 1024,
+                    [paths.deleted]: 2048
+                })[p] || 0,
+                log: () => {}
+            });
+
+            const byPath = Object.fromEntries(result.worktrees.map(item => [item.path, item]));
+
+            expect(byPath[paths.deleted].status).toBe('active');
+            expect(byPath[paths.deleted].prunable).toBe(false);
+            expect(byPath[paths.deleted].reason).toContain('PR status could not be verified');
+            expect(result.reclaimableBytes).toBe(1024);
+            expect(removed).toHaveLength(0);
+        });
+
+        test('apply removes only clean prunable worktrees unless forceDirty is set', async () => {
+            const removed = [];
+            const {exec, paths} = makePruneExec({removed});
+            const getSize = async p => ({
+                [paths.merged]     : 1024,
+                [paths.deleted]    : 2048,
+                [paths.deletedOpen]: 3072,
+                [paths.active]     : 4096,
+                [paths.dirty]      : 8192
+            })[p] || 0;
+
+            await pruneStaleWorktrees({
+                projectRoot: fakeMainCheckout,
+                apply      : true,
+                exec,
+                getSize,
+                log: () => {}
+            });
+
+            expect(removed).toEqual([
+                ['worktree', 'remove', paths.merged],
+                ['worktree', 'remove', paths.deleted]
+            ]);
+
+            removed.length = 0;
+
+            await pruneStaleWorktrees({
+                projectRoot: fakeMainCheckout,
+                apply      : true,
+                forceDirty : true,
+                exec,
+                getSize,
+                log: () => {}
+            });
+
+            expect(removed).toEqual([
+                ['worktree', 'remove', paths.merged],
+                ['worktree', 'remove', paths.deleted],
+                ['worktree', 'remove', '--force', paths.dirty]
+            ]);
         });
     });
 });


### PR DESCRIPTION
Authored by GPT-5 Codex (Codex Desktop). Session 021172f9-cf8a-4762-917f-95bdf261ad23.

FAIR-band: over-target [14/30] — taking this lane despite over-target because Claude explicitly split #11652/#11653 versus #11654, #11654 was the collision-free lane, and the operator disabled AGENT:* broadcasts during Gemini instability.

Resolves #11654

Adds a dry-run-first stale Claude worktree pruning mode to `ai/scripts/bootstrapWorktree.mjs`, plus an `npm run ai:prune-worktrees` entrypoint. The pruner is scoped to `.claude/worktrees`, preserves active, dirty, open-PR, unverified-PR, and unmerged worktrees by default, and only mutates through `git worktree remove` when `--apply` is explicitly passed.

Evidence: L3 (targeted unit coverage plus non-mutating dry-run against a real Claude worktree root: 58 worktrees, 20.7GB total, 6.0GB reclaimable) -> L4 required (post-merge apply-run actually removes stale worktrees on the shared host). Residual: post-merge apply remains an operator-controlled validation step [#11654].

## Deltas from ticket
- Adds `--prune-stale`, `--apply`, and `--force-dirty` modes to the existing bootstrap script instead of creating a parallel cleanup script.
- Uses Git worktree porcelain plus branch/PR/merge checks to classify stale worktrees, including patch-equivalent squash-merge detection via `git cherry`.
- Treats unverifiable PR state as active preservation, matching the observed sandbox ceiling where GitHub status can be unavailable.

## Test Evidence
- `node --check ai/scripts/bootstrapWorktree.mjs` passed.
- `git diff --cached --check` passed.
- `npm run test-unit -- test/playwright/unit/ai/scripts/bootstrapWorktree.spec.mjs` passed: 32 tests.
- `npm run ai:prune-worktrees` passed in this Codex checkout: 0 worktrees, 0B reclaimable.
- Non-mutating dry-run against a real Claude worktree root passed: 58 worktrees, 20.7GB total, 6.0GB reclaimable; no `--apply` run.

## Post-Merge Validation
- [ ] From a Claude canonical checkout, run `npm run ai:prune-worktrees` and review the dry-run list.
- [ ] If the dry-run is correct, run `node ai/scripts/bootstrapWorktree.mjs --prune-stale --apply --canonical-root <canonical-checkout>` to remove clean prunable worktrees.
- [ ] Re-run the dry-run and confirm reclaimed candidates are gone while dirty/active worktrees remain.

## Commits
- `5e341367a` — `feat(worktree): add stale Claude worktree pruning (#11654)`