### PR TITLE
fix(ai): substrate guard refusing canonical Chroma collection deletes (#11652)

### DIFF
--- a/ai/mcp/server/shared/services/DestructiveOperationGuard.mjs
+++ b/ai/mcp/server/shared/services/DestructiveOperationGuard.mjs
@@ -6,6 +6,98 @@ export const DESTRUCTIVE_PRODUCTION_BYPASS_ENV  = 'NEO_ALLOW_PRODUCTION_DESTRUCT
 export const DESTRUCTIVE_PRODUCTION_CONFIRMATION = 'CONFIRM_PRODUCTION_DESTRUCTIVE_AI_SUBSTRATE';
 
 /**
+ * Canonical Chroma collection names that ChromaManager wrappers refuse to drop without
+ * either `UNIT_TEST_MODE=true` (tests opt in to test-prefixed isolation) or the explicit
+ * `DESTRUCTIVE_PRODUCTION_CONFIRMATION` token (operator-acknowledged production recovery).
+ *
+ * Shared between Memory Core's and Knowledge Base's `ChromaManager.deleteCollection`
+ * wrappers so the guard fires uniformly regardless of which subsystem's manager
+ * a caller imports. The set is the union of all production canonical names:
+ *
+ * - `neo-agent-memory`   — Memory Core memories collection (`aiConfig.collections.memory`).
+ * - `neo-agent-sessions` — Memory Core summaries collection (`aiConfig.collections.session`).
+ * - `neo-agent-graph`    — Memory Core graph collection (`aiConfig.collections.graph`).
+ * - `neo-knowledge-base` — Knowledge Base canonical collection (`aiConfig.collectionName`).
+ *
+ * Names are hardcoded (not derived from config) so a caller that loads a misconfigured
+ * `config.mjs` (e.g., running `npx playwright` without the unit-test config) still gets
+ * the canonical name blocked. The empirical anchor is the 2026-05-17 Memory Core wipe,
+ * where `aiConfig.collections.memory` returned canonical `'neo-agent-memory'` because
+ * `UNIT_TEST_MODE` was absent in the bare-playwright invocation environment.
+ *
+ * @see https://github.com/neomjs/neo/issues/11652
+ */
+export const GUARDED_CANONICAL_COLLECTION_NAMES = Object.freeze(new Set([
+    'neo-agent-memory',
+    'neo-agent-sessions',
+    'neo-agent-graph',
+    'neo-knowledge-base'
+]));
+
+/**
+ * @summary Error thrown when a ChromaManager wrapper refuses to drop a canonical collection.
+ *
+ * Distinct from {@link DestructiveOperationBlockedError} (path-target-driven, fired by
+ * `assertDestructiveTargetAllowed`). This error fires at the chroma-collection-name layer,
+ * one step closer to the chromadb-client boundary, and provides defense-in-depth against
+ * callers that bypass the path-target guard (e.g. tests that grab `ChromaManager.client`
+ * directly without going through `DatabaseService` or `CollectionProxy`).
+ *
+ * @class CanonicalCollectionGuardError
+ * @extends Error
+ */
+export class CanonicalCollectionGuardError extends Error {
+    constructor({name, subsystem}) {
+        super(
+            `CANONICAL_COLLECTION_GUARDED: refusing to delete canonical Chroma collection ` +
+            `"${name}" (subsystem: ${subsystem || 'unknown'}). Set UNIT_TEST_MODE=true for ` +
+            `tests, or pass confirmation '${DESTRUCTIVE_PRODUCTION_CONFIRMATION}' for ` +
+            `operator-acknowledged production recovery.`
+        );
+        this.name      = 'CanonicalCollectionGuardError';
+        this.code      = 'CANONICAL_COLLECTION_GUARDED';
+        this.collection = name;
+        this.subsystem  = subsystem;
+    }
+}
+
+/**
+ * Asserts a ChromaManager `deleteCollection({name})` call is allowed against a canonical
+ * production collection name. Returns silently for non-canonical names (test-prefixed
+ * collection names, ad-hoc names, etc.). Returns silently for canonical names under
+ * either bypass: `process.env.UNIT_TEST_MODE === 'true'` OR a `confirmation` argument
+ * equal to `DESTRUCTIVE_PRODUCTION_CONFIRMATION`. Throws {@link CanonicalCollectionGuardError}
+ * otherwise.
+ *
+ * **Why this guard is necessary alongside `assertDestructiveTargetAllowed`:**
+ *
+ * The path-target guard reasons over filesystem paths (`tmp/`, OS tempdir, `:memory:`).
+ * It does NOT see chroma-collection-name semantics, so a caller invoking
+ * `ChromaManager.client.deleteCollection({name: 'neo-agent-memory'})` from a process
+ * whose `aiConfig` resolved to canonical names (e.g., `npx playwright` without unit-test
+ * config) bypasses the path-target guard entirely. This collection-name-level guard
+ * closes that gap.
+ *
+ * @param {Object}  options
+ * @param {String}  options.name                  Chroma collection name about to be deleted.
+ * @param {String} [options.subsystem]            Owning subsystem identifier for diagnostics ('memory-core' or 'knowledge-base').
+ * @param {String} [options.confirmation]         Production-recovery confirmation token; must equal `DESTRUCTIVE_PRODUCTION_CONFIRMATION` to bypass.
+ * @throws {CanonicalCollectionGuardError} When `name` is canonical and neither bypass applies.
+ */
+export function assertCanonicalCollectionDeleteAllowed({name, subsystem, confirmation} = {}) {
+    if (!GUARDED_CANONICAL_COLLECTION_NAMES.has(name)) {
+        return;
+    }
+    if (process.env.UNIT_TEST_MODE === 'true') {
+        return;
+    }
+    if (confirmation === DESTRUCTIVE_PRODUCTION_CONFIRMATION) {
+        return;
+    }
+    throw new CanonicalCollectionGuardError({name, subsystem});
+}
+
+/**
  * @summary Error thrown when a destructive AI substrate operation targets a production path.
  *
  * Carries a stable `code` for callers and tests while preserving the rejected operation,

--- a/ai/mcp/server/shared/services/DestructiveOperationGuard.mjs
+++ b/ai/mcp/server/shared/services/DestructiveOperationGuard.mjs
@@ -48,46 +48,70 @@ export const GUARDED_CANONICAL_COLLECTION_NAMES = Object.freeze(new Set([
  */
 export class CanonicalCollectionGuardError extends Error {
     constructor({name, subsystem}) {
+        const isCanonical = GUARDED_CANONICAL_COLLECTION_NAMES.has(name);
+        const targetDesc  = isCanonical
+            ? `canonical Chroma collection "${name}"`
+            : `Chroma collection "${name}" (non-canonical; the uniform-gate fires for every destructive collection-delete regardless of name)`;
         super(
-            `CANONICAL_COLLECTION_GUARDED: refusing to delete canonical Chroma collection ` +
-            `"${name}" (subsystem: ${subsystem || 'unknown'}). Set UNIT_TEST_MODE=true for ` +
-            `tests, or pass confirmation '${DESTRUCTIVE_PRODUCTION_CONFIRMATION}' for ` +
+            `CANONICAL_COLLECTION_GUARDED: refusing to delete ${targetDesc} ` +
+            `(subsystem: ${subsystem || 'unknown'}). Set UNIT_TEST_MODE=true for tests, ` +
+            `or pass confirmation '${DESTRUCTIVE_PRODUCTION_CONFIRMATION}' for ` +
             `operator-acknowledged production recovery.`
         );
-        this.name      = 'CanonicalCollectionGuardError';
-        this.code      = 'CANONICAL_COLLECTION_GUARDED';
-        this.collection = name;
-        this.subsystem  = subsystem;
+        this.name        = 'CanonicalCollectionGuardError';
+        this.code        = 'CANONICAL_COLLECTION_GUARDED';
+        this.collection  = name;
+        this.isCanonical = isCanonical;
+        this.subsystem   = subsystem;
     }
 }
 
 /**
- * Asserts a ChromaManager `deleteCollection({name})` call is allowed against a canonical
- * production collection name. Returns silently for non-canonical names (test-prefixed
- * collection names, ad-hoc names, etc.). Returns silently for canonical names under
- * either bypass: `process.env.UNIT_TEST_MODE === 'true'` OR a `confirmation` argument
- * equal to `DESTRUCTIVE_PRODUCTION_CONFIRMATION`. Throws {@link CanonicalCollectionGuardError}
- * otherwise.
+ * Asserts a ChromaManager `deleteCollection({name})` call is allowed. The guard fires for
+ * **every** destructive collection-delete attempt regardless of whether `name` is in
+ * {@link GUARDED_CANONICAL_COLLECTION_NAMES} — destructive ops are not free for non-canonical
+ * names either (a buggy or malicious caller invoking `deleteCollection({name: 'arbitrary'})`
+ * without `UNIT_TEST_MODE` or a confirmation token is a fail-closed scenario, not a quiet
+ * pass-through).
+ *
+ * Bypass paths (either is sufficient):
+ *
+ * 1. `process.env.UNIT_TEST_MODE === 'true'` — the test harness is loaded; `aiConfig.collections.*`
+ *    resolves to process-isolated `test-*` prefixes per `config.mjs:228-229`, and the test
+ *    cleanup helpers are responsible for their own substrate.
+ * 2. `confirmation === DESTRUCTIVE_PRODUCTION_CONFIRMATION` — operator-acknowledged production
+ *    recovery (e.g., `restore.mjs --mode replace` already gates via `DestructiveOperationGuard`
+ *    and forwards the same token down through `DatabaseService.truncateDatabase` →
+ *    `ChromaManager.deleteCollection`).
+ *
+ * The canonical-collection-name set still surfaces in the `CanonicalCollectionGuardError`
+ * diagnostics so operators see which live target was protected, but membership is no longer
+ * the gate — the gate is the env-or-token check uniformly.
  *
  * **Why this guard is necessary alongside `assertDestructiveTargetAllowed`:**
  *
  * The path-target guard reasons over filesystem paths (`tmp/`, OS tempdir, `:memory:`).
  * It does NOT see chroma-collection-name semantics, so a caller invoking
- * `ChromaManager.client.deleteCollection({name: 'neo-agent-memory'})` from a process
- * whose `aiConfig` resolved to canonical names (e.g., `npx playwright` without unit-test
- * config) bypasses the path-target guard entirely. This collection-name-level guard
- * closes that gap.
+ * `ChromaManager.client.deleteCollection({name: 'neo-agent-memory'})` from a process whose
+ * `aiConfig` resolved to canonical names (e.g., `npx playwright` without unit-test config)
+ * bypasses the path-target guard entirely. This collection-name-level guard closes that gap.
+ *
+ * **Why the gate is uniform (not canonical-set-gated):**
+ *
+ * Per @neo-gpt's PR #11656 Cycle 1 review (commentId PRR_kwDODSospM8AAAABAYwPjg, Required
+ * Action 1) — a guard that returns early for non-canonical names leaves the "non-canonical
+ * name as bypass surface" open. A production caller could invoke
+ * `deleteCollection({name: 'arbitrary-collection'})` and bypass the substrate-level invariant
+ * entirely. The uniform-gate shape forces every destructive caller to thread either the test
+ * env or the explicit confirmation token, regardless of collection name.
  *
  * @param {Object}  options
  * @param {String}  options.name                  Chroma collection name about to be deleted.
  * @param {String} [options.subsystem]            Owning subsystem identifier for diagnostics ('memory-core' or 'knowledge-base').
  * @param {String} [options.confirmation]         Production-recovery confirmation token; must equal `DESTRUCTIVE_PRODUCTION_CONFIRMATION` to bypass.
- * @throws {CanonicalCollectionGuardError} When `name` is canonical and neither bypass applies.
+ * @throws {CanonicalCollectionGuardError} When neither bypass applies.
  */
 export function assertCanonicalCollectionDeleteAllowed({name, subsystem, confirmation} = {}) {
-    if (!GUARDED_CANONICAL_COLLECTION_NAMES.has(name)) {
-        return;
-    }
     if (process.env.UNIT_TEST_MODE === 'true') {
         return;
     }

--- a/ai/services/knowledge-base/ChromaManager.mjs
+++ b/ai/services/knowledge-base/ChromaManager.mjs
@@ -1,8 +1,9 @@
-import {ChromaClient}           from 'chromadb';
-import aiConfig                 from '../../mcp/server/knowledge-base/config.mjs';
-import logger                   from '../../mcp/server/knowledge-base/logger.mjs';
-import Base                     from '../../../src/core/Base.mjs';
-import DatabaseLifecycleService from './DatabaseLifecycleService.mjs';
+import {ChromaClient}                       from 'chromadb';
+import aiConfig                             from '../../mcp/server/knowledge-base/config.mjs';
+import logger                               from '../../mcp/server/knowledge-base/logger.mjs';
+import Base                                 from '../../../src/core/Base.mjs';
+import DatabaseLifecycleService             from './DatabaseLifecycleService.mjs';
+import {assertCanonicalCollectionDeleteAllowed} from '../../mcp/server/shared/services/DestructiveOperationGuard.mjs';
 
 /**
  * @summary Simple manager around the Chroma client that lazily caches the knowledge-base collection.
@@ -104,10 +105,10 @@ class ChromaManager extends Base {
         const nextLock = (async () => {
             // Await the completion of the previous silent execution
             await this.#chromaLock;
-            
+
             const originalWarn = console.warn;
             console.warn = () => {}; // Suppress unwanted warnings from ChromaDB client
-            
+
             try {
                 return await fn();
             } finally {
@@ -115,7 +116,7 @@ class ChromaManager extends Base {
                 console.warn = originalWarn;
             }
         })();
-        
+
         // Prevent chain crashing if an internal error occurs
         this.#chromaLock = nextLock.catch(() => {});
         return nextLock;
@@ -136,6 +137,29 @@ class ChromaManager extends Base {
 
         this.knowledgeBaseCollection = await this._knowledgeBaseCollectionPromise;
         return this.knowledgeBaseCollection;
+    }
+
+    /**
+     * Guarded delete-collection wrapper — peer of the Memory Core counterpart. Refuses
+     * canonical production collection names unless `UNIT_TEST_MODE=true` or a valid
+     * production `confirmation` token is supplied. See the Memory Core ChromaManager's
+     * `deleteCollection` JSDoc for the empirical anchor (2026-05-17 wipe) and rationale.
+     *
+     * All Knowledge Base callers (`DatabaseService.truncateDatabase`, `VectorService.deleteCollection`,
+     * future restore wrappers) MUST route through this method instead of bare
+     * `ChromaManager.client.deleteCollection` so the substrate-level invariant fires
+     * regardless of harness or config state.
+     *
+     * @param {Object}  options
+     * @param {String}  options.name              Collection name to delete.
+     * @param {String} [options.confirmation]     Production-recovery token; equals `CONFIRM_PRODUCTION_DESTRUCTIVE_AI_SUBSTRATE` for bypass.
+     * @returns {Promise<*>} Forwarded chromadb-client response.
+     * @throws {CanonicalCollectionGuardError} When `name` is canonical and neither bypass applies.
+     * @see https://github.com/neomjs/neo/issues/11652
+     */
+    async deleteCollection({name, confirmation} = {}) {
+        assertCanonicalCollectionDeleteAllowed({name, subsystem: 'knowledge-base', confirmation});
+        return await this.client.deleteCollection({name});
     }
 }
 

--- a/ai/services/knowledge-base/DatabaseService.mjs
+++ b/ai/services/knowledge-base/DatabaseService.mjs
@@ -390,7 +390,10 @@ class DatabaseService extends Base {
                 confirmation
             });
 
-            await ChromaManager.client.deleteCollection({name: collectionName});
+            // Route through ChromaManager.deleteCollection (#11652 substrate-level guard).
+            // The path-target guard above already passed `assertDestructiveTargetAllowed`;
+            // forward the operator confirmation so the canonical-name guard accepts it.
+            await ChromaManager.deleteCollection({name: collectionName, confirmation});
 
             ChromaManager._knowledgeBaseCollectionPromise = null;
             ChromaManager.knowledgeBaseCollection         = null;

--- a/ai/services/knowledge-base/VectorService.mjs
+++ b/ai/services/knowledge-base/VectorService.mjs
@@ -75,7 +75,9 @@ class VectorService extends Base {
                 confirmation
             });
 
-            await ChromaManager.client.deleteCollection({name: collectionName});
+            // Route through ChromaManager.deleteCollection (#11652 substrate-level guard).
+            // Forward the operator confirmation so the canonical-name guard accepts it.
+            await ChromaManager.deleteCollection({name: collectionName, confirmation});
             ChromaManager._knowledgeBaseCollectionPromise = null;
             ChromaManager.knowledgeBaseCollection = null;
             const message = `Knowledge base collection '${collectionName}' deleted successfully.`;
@@ -140,7 +142,7 @@ class VectorService extends Base {
             let currentClass = chunk.className; // Metadata is now on every chunk
             const inheritanceChain = [];
             const visited = new Set();
-            
+
             // If no className metadata (e.g. non-class files), skip
             if (!currentClass) return;
 

--- a/ai/services/memory-core/managers/ChromaManager.mjs
+++ b/ai/services/memory-core/managers/ChromaManager.mjs
@@ -1,8 +1,9 @@
-import {ChromaClient}           from 'chromadb';
-import aiConfig                 from '../../../mcp/server/memory-core/config.mjs';
-import logger                   from '../../../mcp/server/memory-core/logger.mjs';
-import AbstractVectorManager    from './AbstractVectorManager.mjs';
-import ChromaLifecycleService   from '../lifecycle/ChromaLifecycleService.mjs';
+import {ChromaClient}                       from 'chromadb';
+import aiConfig                             from '../../../mcp/server/memory-core/config.mjs';
+import logger                               from '../../../mcp/server/memory-core/logger.mjs';
+import AbstractVectorManager                from './AbstractVectorManager.mjs';
+import ChromaLifecycleService               from '../lifecycle/ChromaLifecycleService.mjs';
+import {assertCanonicalCollectionDeleteAllowed} from '../../../mcp/server/shared/services/DestructiveOperationGuard.mjs';
 
 /**
  * @summary Simple manager around the Chroma client that lazily caches frequently used collections.
@@ -218,6 +219,31 @@ class ChromaManager extends AbstractVectorManager {
 
         this.graphCollection = await this._graphCollectionPromise;
         return this.graphCollection;
+    }
+
+    /**
+     * Guarded delete-collection wrapper. Refuses canonical production collection names
+     * (`neo-agent-memory`, `neo-agent-sessions`, `neo-agent-graph`, `neo-knowledge-base`)
+     * unless `process.env.UNIT_TEST_MODE === 'true'` (test path) or a valid production
+     * `confirmation` token is supplied.
+     *
+     * All Memory Core callers (tests, `CollectionProxy`, future restore wrappers) MUST
+     * route through this method instead of `ChromaManager.client.deleteCollection` so the
+     * substrate-level invariant fires regardless of harness or config state. The empirical
+     * anchor is the 2026-05-17 wipe where `npx playwright` bypassed `playwright.config.unit.mjs`
+     * (`UNIT_TEST_MODE` absent) → `aiConfig.collections.*` returned canonical names →
+     * a destructive cleanup helper dropped the live collections.
+     *
+     * @param {Object}  options
+     * @param {String}  options.name              Collection name to delete.
+     * @param {String} [options.confirmation]     Production-recovery token; equals `CONFIRM_PRODUCTION_DESTRUCTIVE_AI_SUBSTRATE` for bypass.
+     * @returns {Promise<*>} Forwarded chromadb-client response.
+     * @throws {CanonicalCollectionGuardError} When `name` is canonical and neither bypass applies.
+     * @see https://github.com/neomjs/neo/issues/11652
+     */
+    async deleteCollection({name, confirmation} = {}) {
+        assertCanonicalCollectionDeleteAllowed({name, subsystem: 'memory-core', confirmation});
+        return await this.client.deleteCollection({name});
     }
 }
 

--- a/ai/services/memory-core/managers/CollectionProxy.mjs
+++ b/ai/services/memory-core/managers/CollectionProxy.mjs
@@ -117,14 +117,20 @@ class CollectionProxy extends Base {
                 confirmation
             });
 
-            // Prefer the guarded ChromaManager.deleteCollection (#11652 substrate guard).
-            // The path-target guard above already passed; forward the operator confirmation
-            // so the collection-name-level guard accepts it for canonical names.
-            if (manager.deleteCollection) {
-                await manager.deleteCollection({name: coll.name, confirmation});
-            } else if (manager.client?.deleteCollection) {
-                await manager.client.deleteCollection({name: coll.name});
+            // Route through the guarded `manager.deleteCollection({name, confirmation})`
+            // wrapper (#11652 substrate guard). The path-target guard above already passed;
+            // the operator confirmation token is threaded down so the uniform collection-name
+            // gate accepts the production-recovery bypass. Fail-closed if a manager lacks
+            // the wrapper — bare-client fallback would re-open the bypass surface this guard
+            // exists to close (#11656 review Required Action 2, commentId PRR_kwDODSospM8AAAABAYwPjg).
+            if (typeof manager.deleteCollection !== 'function') {
+                throw new Error(
+                    `[CollectionProxy] manager ${manager?.constructor?.config?.className || 'unknown'} ` +
+                    `lacks the guarded deleteCollection wrapper; refusing bare client.deleteCollection ` +
+                    `fallback per #11652 substrate-level invariant.`
+                );
             }
+            await manager.deleteCollection({name: coll.name, confirmation});
         }
     }
 }

--- a/ai/services/memory-core/managers/CollectionProxy.mjs
+++ b/ai/services/memory-core/managers/CollectionProxy.mjs
@@ -22,14 +22,14 @@ class CollectionProxy extends Base {
     async getManagers() {
         const architecture = aiConfig.engine || 'hybrid';
         const managers = [];
-        
+
         // In Hybrid RAG, vectors exclusively live in ChromaDB
         if (architecture === 'chroma' || architecture === 'hybrid') {
             const { default: ChromaManager } = await import('./ChromaManager.mjs');
             await ChromaManager.ready();
             managers.push(ChromaManager);
         }
-        
+
         return managers;
     }
 
@@ -63,7 +63,7 @@ class CollectionProxy extends Base {
         }
         return collections[0].get(args);
     }
-    
+
     async query(args) {
         const collections = await this.getCollections();
         if (!collections || collections.length === 0 || !collections[0]) {
@@ -71,7 +71,7 @@ class CollectionProxy extends Base {
         }
         return collections[0].query(args);
     }
-    
+
     async count() {
         const collections = await this.getCollections();
         if (!collections || collections.length === 0 || !collections[0]) {
@@ -79,7 +79,7 @@ class CollectionProxy extends Base {
         }
         return collections[0].count();
     }
-    
+
     async delete(args) {
         const collections = await this.getCollections();
         await Promise.all(collections.map(c => c.delete(args)));
@@ -92,8 +92,8 @@ class CollectionProxy extends Base {
             if (this.collectionType === 'graph') {
                 coll = await manager.getGraphCollection();
             } else {
-                coll = this.collectionType === 'memory' ? 
-                    await manager.getMemoryCollection() : 
+                coll = this.collectionType === 'memory' ?
+                    await manager.getMemoryCollection() :
                     await manager.getSummaryCollection();
             }
 
@@ -117,10 +117,13 @@ class CollectionProxy extends Base {
                 confirmation
             });
 
-            if (manager.client && manager.client.deleteCollection) {
-                await manager.client.deleteCollection({ name: coll.name });
-            } else if (manager.deleteCollection) {
-                await manager.deleteCollection(coll.name);
+            // Prefer the guarded ChromaManager.deleteCollection (#11652 substrate guard).
+            // The path-target guard above already passed; forward the operator confirmation
+            // so the collection-name-level guard accepts it for canonical names.
+            if (manager.deleteCollection) {
+                await manager.deleteCollection({name: coll.name, confirmation});
+            } else if (manager.client?.deleteCollection) {
+                await manager.client.deleteCollection({name: coll.name});
             }
         }
     }

--- a/test/playwright/unit/ai/services/memory-core/managers/ChromaManager.canonicalGuard.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/managers/ChromaManager.canonicalGuard.spec.mjs
@@ -32,10 +32,34 @@ test.describe('Neo.ai.mcp.server.shared.services.DestructiveOperationGuard — c
         expect(GUARDED_CANONICAL_COLLECTION_NAMES.has('neo-knowledge-base')).toBe(true);
     });
 
-    test('Allows non-canonical (test-prefixed) collection name regardless of env state', () => {
+    test('Refuses non-canonical (test-prefixed) name without UNIT_TEST_MODE — uniform-gate (#11656 RA1)', () => {
+        // Per #11656 Cycle 1 review (commentId PRR_kwDODSospM8AAAABAYwPjg, Required Action 1):
+        // the guard fires for EVERY destructive collection-delete regardless of name. Non-canonical
+        // names are not a free bypass — a production caller invoking
+        // `deleteCollection({name: 'arbitrary'})` without UNIT_TEST_MODE or a confirmation token
+        // is a fail-closed scenario, not a quiet pass-through. Test-prefixed names ARE the
+        // test-isolation surface — but their isolation is via UNIT_TEST_MODE-aware config, not
+        // by being implicitly trusted at the deleteCollection boundary.
         const previous = process.env.UNIT_TEST_MODE;
         try {
             delete process.env.UNIT_TEST_MODE;
+            expect(() => assertCanonicalCollectionDeleteAllowed({
+                name     : 'test-memory-12345',
+                subsystem: 'memory-core'
+            })).toThrow(CanonicalCollectionGuardError);
+        } finally {
+            if (previous === undefined) delete process.env.UNIT_TEST_MODE;
+            else process.env.UNIT_TEST_MODE = previous;
+        }
+    });
+
+    test('Allows non-canonical (test-prefixed) name when UNIT_TEST_MODE=true', () => {
+        // The bypass path for non-canonical names: UNIT_TEST_MODE=true is sufficient. The
+        // CanonicalCollectionGuardError diagnostic message distinguishes canonical vs non-
+        // canonical for operator clarity even though the gate is uniform.
+        const previous = process.env.UNIT_TEST_MODE;
+        try {
+            process.env.UNIT_TEST_MODE = 'true';
             expect(() => assertCanonicalCollectionDeleteAllowed({
                 name     : 'test-memory-12345',
                 subsystem: 'memory-core'
@@ -119,6 +143,28 @@ test.describe('Neo.ai.mcp.server.shared.services.DestructiveOperationGuard — c
                 expect(err.code).toBe('CANONICAL_COLLECTION_GUARDED');
                 expect(err.collection).toBe('neo-knowledge-base');
                 expect(err.subsystem).toBe('knowledge-base');
+                expect(err.isCanonical).toBe(true);
+            }
+        } finally {
+            if (previous === undefined) delete process.env.UNIT_TEST_MODE;
+            else process.env.UNIT_TEST_MODE = previous;
+        }
+    });
+
+    test('Error.isCanonical=false distinguishes non-canonical refusals in diagnostics', () => {
+        const previous = process.env.UNIT_TEST_MODE;
+        try {
+            delete process.env.UNIT_TEST_MODE;
+            try {
+                assertCanonicalCollectionDeleteAllowed({
+                    name     : 'arbitrary-collection',
+                    subsystem: 'memory-core'
+                });
+                throw new Error('expected throw, got nothing');
+            } catch (err) {
+                expect(err).toBeInstanceOf(CanonicalCollectionGuardError);
+                expect(err.isCanonical).toBe(false);
+                expect(err.message).toContain('non-canonical');
             }
         } finally {
             if (previous === undefined) delete process.env.UNIT_TEST_MODE;
@@ -194,6 +240,84 @@ test.describe('Neo.ai.services.memory-core.managers.ChromaManager#deleteCollecti
             expect(receivedArgs).toEqual({name: 'neo-agent-memory'});
         } finally {
             ChromaManager.client = originalClient;
+            if (previousEnv === undefined) delete process.env.UNIT_TEST_MODE;
+            else process.env.UNIT_TEST_MODE = previousEnv;
+        }
+    });
+});
+
+// Symmetric coverage on the Knowledge Base side per #11656 review Required Action 3
+// (commentId PRR_kwDODSospM8AAAABAYwPjg). The MC wrapper and KB wrapper are independent
+// classes that share the underlying `assertCanonicalCollectionDeleteAllowed` helper but
+// differ in subsystem label, canonical name targeted, and surrounding service surface.
+// Direct integration tests on the KB wrapper close the parity gap from Cycle 1.
+test.describe('Neo.ai.services.knowledge-base.ChromaManager#deleteCollection — guard integration (#11652)', () => {
+
+    test('KB ChromaManager.deleteCollection refuses canonical name without UNIT_TEST_MODE or confirmation', async () => {
+        const KBChromaManager = (await import('../../../../../../../ai/services/knowledge-base/ChromaManager.mjs')).default;
+
+        const originalClient = KBChromaManager.client;
+        let clientCalled     = false;
+        KBChromaManager.client = {
+            deleteCollection: async () => { clientCalled = true; }
+        };
+        const previousEnv = process.env.UNIT_TEST_MODE;
+
+        try {
+            delete process.env.UNIT_TEST_MODE;
+            await expect(KBChromaManager.deleteCollection({name: 'neo-knowledge-base'}))
+                .rejects.toThrow(CanonicalCollectionGuardError);
+            expect(clientCalled).toBe(false);
+        } finally {
+            KBChromaManager.client = originalClient;
+            if (previousEnv === undefined) delete process.env.UNIT_TEST_MODE;
+            else process.env.UNIT_TEST_MODE = previousEnv;
+        }
+    });
+
+    test('KB ChromaManager.deleteCollection forwards to client under UNIT_TEST_MODE=true', async () => {
+        const KBChromaManager = (await import('../../../../../../../ai/services/knowledge-base/ChromaManager.mjs')).default;
+
+        const originalClient = KBChromaManager.client;
+        let receivedArgs     = null;
+        KBChromaManager.client = {
+            deleteCollection: async (args) => { receivedArgs = args; return 'ok'; }
+        };
+        const previousEnv = process.env.UNIT_TEST_MODE;
+
+        try {
+            process.env.UNIT_TEST_MODE = 'true';
+            const result = await KBChromaManager.deleteCollection({name: 'neo-knowledge-base'});
+            expect(result).toBe('ok');
+            expect(receivedArgs).toEqual({name: 'neo-knowledge-base'});
+        } finally {
+            KBChromaManager.client = originalClient;
+            if (previousEnv === undefined) delete process.env.UNIT_TEST_MODE;
+            else process.env.UNIT_TEST_MODE = previousEnv;
+        }
+    });
+
+    test('KB ChromaManager.deleteCollection forwards under confirmation token bypass (production recovery)', async () => {
+        const KBChromaManager = (await import('../../../../../../../ai/services/knowledge-base/ChromaManager.mjs')).default;
+
+        const originalClient = KBChromaManager.client;
+        let receivedArgs     = null;
+        KBChromaManager.client = {
+            deleteCollection: async (args) => { receivedArgs = args; return 'ok'; }
+        };
+        const previousEnv = process.env.UNIT_TEST_MODE;
+
+        try {
+            delete process.env.UNIT_TEST_MODE;
+            const result = await KBChromaManager.deleteCollection({
+                name        : 'neo-knowledge-base',
+                confirmation: DESTRUCTIVE_PRODUCTION_CONFIRMATION
+            });
+            expect(result).toBe('ok');
+            // confirmation is consumed at the guard layer; not forwarded to chromadb-client.
+            expect(receivedArgs).toEqual({name: 'neo-knowledge-base'});
+        } finally {
+            KBChromaManager.client = originalClient;
             if (previousEnv === undefined) delete process.env.UNIT_TEST_MODE;
             else process.env.UNIT_TEST_MODE = previousEnv;
         }

--- a/test/playwright/unit/ai/services/memory-core/managers/ChromaManager.canonicalGuard.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/managers/ChromaManager.canonicalGuard.spec.mjs
@@ -1,0 +1,201 @@
+import {setup} from '../../../../../setup.mjs';
+
+const appName = 'ChromaManagerCanonicalGuardTest';
+
+setup({
+    neoConfig: {
+        unitTestMode: true
+    },
+    appConfig: {
+        name             : appName,
+        isMounted        : () => true,
+        vnodeInitialising: false
+    }
+});
+
+import {test, expect}      from '@playwright/test';
+import Neo                 from '../../../../../../../src/Neo.mjs';
+import * as core           from '../../../../../../../src/core/_export.mjs';
+import {
+    assertCanonicalCollectionDeleteAllowed,
+    CanonicalCollectionGuardError,
+    DESTRUCTIVE_PRODUCTION_CONFIRMATION,
+    GUARDED_CANONICAL_COLLECTION_NAMES
+} from '../../../../../../../ai/mcp/server/shared/services/DestructiveOperationGuard.mjs';
+
+test.describe('Neo.ai.mcp.server.shared.services.DestructiveOperationGuard — canonical-collection guard (#11652)', () => {
+
+    test('Set of canonical names covers MC + KB production collections', () => {
+        expect(GUARDED_CANONICAL_COLLECTION_NAMES.has('neo-agent-memory')).toBe(true);
+        expect(GUARDED_CANONICAL_COLLECTION_NAMES.has('neo-agent-sessions')).toBe(true);
+        expect(GUARDED_CANONICAL_COLLECTION_NAMES.has('neo-agent-graph')).toBe(true);
+        expect(GUARDED_CANONICAL_COLLECTION_NAMES.has('neo-knowledge-base')).toBe(true);
+    });
+
+    test('Allows non-canonical (test-prefixed) collection name regardless of env state', () => {
+        const previous = process.env.UNIT_TEST_MODE;
+        try {
+            delete process.env.UNIT_TEST_MODE;
+            expect(() => assertCanonicalCollectionDeleteAllowed({
+                name     : 'test-memory-12345',
+                subsystem: 'memory-core'
+            })).not.toThrow();
+        } finally {
+            if (previous === undefined) delete process.env.UNIT_TEST_MODE;
+            else process.env.UNIT_TEST_MODE = previous;
+        }
+    });
+
+    test('Allows canonical name when UNIT_TEST_MODE=true (test-isolation bypass)', () => {
+        const previous = process.env.UNIT_TEST_MODE;
+        try {
+            process.env.UNIT_TEST_MODE = 'true';
+            expect(() => assertCanonicalCollectionDeleteAllowed({
+                name     : 'neo-agent-memory',
+                subsystem: 'memory-core'
+            })).not.toThrow();
+        } finally {
+            if (previous === undefined) delete process.env.UNIT_TEST_MODE;
+            else process.env.UNIT_TEST_MODE = previous;
+        }
+    });
+
+    test('Allows canonical name with explicit production confirmation token (operator recovery bypass)', () => {
+        const previous = process.env.UNIT_TEST_MODE;
+        try {
+            delete process.env.UNIT_TEST_MODE;
+            expect(() => assertCanonicalCollectionDeleteAllowed({
+                name        : 'neo-knowledge-base',
+                subsystem   : 'knowledge-base',
+                confirmation: DESTRUCTIVE_PRODUCTION_CONFIRMATION
+            })).not.toThrow();
+        } finally {
+            if (previous === undefined) delete process.env.UNIT_TEST_MODE;
+            else process.env.UNIT_TEST_MODE = previous;
+        }
+    });
+
+    test('Refuses canonical name without UNIT_TEST_MODE and without confirmation (the npx playwright attack surface)', () => {
+        const previous = process.env.UNIT_TEST_MODE;
+        try {
+            delete process.env.UNIT_TEST_MODE;
+            expect(() => assertCanonicalCollectionDeleteAllowed({
+                name     : 'neo-agent-memory',
+                subsystem: 'memory-core'
+            })).toThrow(CanonicalCollectionGuardError);
+        } finally {
+            if (previous === undefined) delete process.env.UNIT_TEST_MODE;
+            else process.env.UNIT_TEST_MODE = previous;
+        }
+    });
+
+    test('Refuses canonical name with invalid confirmation token', () => {
+        const previous = process.env.UNIT_TEST_MODE;
+        try {
+            delete process.env.UNIT_TEST_MODE;
+            expect(() => assertCanonicalCollectionDeleteAllowed({
+                name        : 'neo-agent-sessions',
+                subsystem   : 'memory-core',
+                confirmation: 'wrong-token'
+            })).toThrow(CanonicalCollectionGuardError);
+        } finally {
+            if (previous === undefined) delete process.env.UNIT_TEST_MODE;
+            else process.env.UNIT_TEST_MODE = previous;
+        }
+    });
+
+    test('Error carries stable code CANONICAL_COLLECTION_GUARDED for caller pattern-matching', () => {
+        const previous = process.env.UNIT_TEST_MODE;
+        try {
+            delete process.env.UNIT_TEST_MODE;
+            try {
+                assertCanonicalCollectionDeleteAllowed({
+                    name     : 'neo-knowledge-base',
+                    subsystem: 'knowledge-base'
+                });
+                throw new Error('expected throw, got nothing');
+            } catch (err) {
+                expect(err).toBeInstanceOf(CanonicalCollectionGuardError);
+                expect(err.code).toBe('CANONICAL_COLLECTION_GUARDED');
+                expect(err.collection).toBe('neo-knowledge-base');
+                expect(err.subsystem).toBe('knowledge-base');
+            }
+        } finally {
+            if (previous === undefined) delete process.env.UNIT_TEST_MODE;
+            else process.env.UNIT_TEST_MODE = previous;
+        }
+    });
+});
+
+test.describe('Neo.ai.services.memory-core.managers.ChromaManager#deleteCollection — guard integration (#11652)', () => {
+
+    test('ChromaManager.deleteCollection invokes the canonical guard before chromadb client', async () => {
+        const ChromaManager = (await import('../../../../../../../ai/services/memory-core/managers/ChromaManager.mjs')).default;
+
+        const originalClient = ChromaManager.client;
+        let clientCalled     = false;
+        ChromaManager.client = {
+            deleteCollection: async () => { clientCalled = true; }
+        };
+        const previousEnv = process.env.UNIT_TEST_MODE;
+
+        try {
+            delete process.env.UNIT_TEST_MODE;
+            await expect(ChromaManager.deleteCollection({name: 'neo-agent-memory'}))
+                .rejects.toThrow(CanonicalCollectionGuardError);
+            expect(clientCalled).toBe(false);
+        } finally {
+            ChromaManager.client = originalClient;
+            if (previousEnv === undefined) delete process.env.UNIT_TEST_MODE;
+            else process.env.UNIT_TEST_MODE = previousEnv;
+        }
+    });
+
+    test('ChromaManager.deleteCollection forwards to client when guard passes (UNIT_TEST_MODE=true)', async () => {
+        const ChromaManager = (await import('../../../../../../../ai/services/memory-core/managers/ChromaManager.mjs')).default;
+
+        const originalClient = ChromaManager.client;
+        let receivedArgs     = null;
+        ChromaManager.client = {
+            deleteCollection: async (args) => { receivedArgs = args; return 'ok'; }
+        };
+        const previousEnv = process.env.UNIT_TEST_MODE;
+
+        try {
+            process.env.UNIT_TEST_MODE = 'true';
+            const result = await ChromaManager.deleteCollection({name: 'neo-agent-memory'});
+            expect(result).toBe('ok');
+            expect(receivedArgs).toEqual({name: 'neo-agent-memory'});
+        } finally {
+            ChromaManager.client = originalClient;
+            if (previousEnv === undefined) delete process.env.UNIT_TEST_MODE;
+            else process.env.UNIT_TEST_MODE = previousEnv;
+        }
+    });
+
+    test('ChromaManager.deleteCollection forwards to client when confirmation token bypasses canonical guard', async () => {
+        const ChromaManager = (await import('../../../../../../../ai/services/memory-core/managers/ChromaManager.mjs')).default;
+
+        const originalClient = ChromaManager.client;
+        let receivedArgs     = null;
+        ChromaManager.client = {
+            deleteCollection: async (args) => { receivedArgs = args; return 'ok'; }
+        };
+        const previousEnv = process.env.UNIT_TEST_MODE;
+
+        try {
+            delete process.env.UNIT_TEST_MODE;
+            const result = await ChromaManager.deleteCollection({
+                name        : 'neo-agent-memory',
+                confirmation: DESTRUCTIVE_PRODUCTION_CONFIRMATION
+            });
+            expect(result).toBe('ok');
+            // confirmation is consumed at the guard layer; not forwarded to the chromadb-client.
+            expect(receivedArgs).toEqual({name: 'neo-agent-memory'});
+        } finally {
+            ChromaManager.client = originalClient;
+            if (previousEnv === undefined) delete process.env.UNIT_TEST_MODE;
+            else process.env.UNIT_TEST_MODE = previousEnv;
+        }
+    });
+});

--- a/test/playwright/unit/ai/services/memory-core/util.mjs
+++ b/test/playwright/unit/ai/services/memory-core/util.mjs
@@ -13,12 +13,24 @@ export async function cleanupChromaManager(SDK) {
     }
 
     if (ChromaManager?.client && collectionsConfig) {
+        // Defense-in-depth (#11652): refuse cleanup when `UNIT_TEST_MODE !== 'true'` regardless of
+        // collection name. The pre-#11652 guard checked only the name; under `npx playwright`
+        // without the unit-test config, `aiConfig.collections.*` falls through to canonical
+        // names AND `UNIT_TEST_MODE` is unset — both invariants must hold for cleanup to proceed.
+        // The substrate-level guard in `ChromaManager.deleteCollection` is the hard backstop;
+        // this helper-level check fails fast with a clearer diagnostic before any chroma call.
+        if (process.env.UNIT_TEST_MODE !== 'true') {
+            throw new Error(`FATAL: cleanupChromaManager() invoked without UNIT_TEST_MODE=true. Refusing cleanup to protect live Chroma collections. Run via 'npm run test-unit' (loads playwright.config.unit.mjs) instead of bare 'npx playwright'.`);
+        }
         if (collectionsConfig.memory === 'neo-agent-memory' || collectionsConfig.session === 'neo-agent-sessions') {
             throw new Error(`FATAL: Attempted to delete production Chroma collections! Aborting cleanup. memory=${collectionsConfig.memory}, session=${collectionsConfig.session}`);
         }
         try {
-            try { await ChromaManager.client.deleteCollection({name: collectionsConfig.memory}); } catch(e) { if (!e.message.includes('not be found')) throw e; }
-            try { await ChromaManager.client.deleteCollection({name: collectionsConfig.session}); } catch(e) { if (!e.message.includes('not be found')) throw e; }
+            // Route through the guarded ChromaManager.deleteCollection (#11652) so the substrate-
+            // level invariant fires uniformly. Test-prefixed names skip the guard cleanly under
+            // UNIT_TEST_MODE; the bare `client.deleteCollection` access path is deprecated.
+            try { await ChromaManager.deleteCollection({name: collectionsConfig.memory}); } catch(e) { if (!e.message.includes('not be found')) throw e; }
+            try { await ChromaManager.deleteCollection({name: collectionsConfig.session}); } catch(e) { if (!e.message.includes('not be found')) throw e; }
         } catch (e) {
             if (!e.message.includes('not be found')) {
                 console.warn(`[Cleanup] Failed to delete test collections:`, e.message);


### PR DESCRIPTION
Resolves #11652

Authored by Claude Opus 4.7 (Claude Code). Session 7360e917-1733-4cdd-a6f3-5ac51c34b838.

FAIR-band: in-band [14/30] — operator-directed hardening lane for the wipe-recovery cycle (DM from operator 2026-05-19 15:30Z: *"tests must get hardened to still never delete live dbs"*).

Substrate-level invariant blocking the same wipe-attack surface that erased 11k+ Memory Core memories on 2026-05-17. Adds a shared `assertCanonicalCollectionDeleteAllowed` helper (uniform-gate shape after Cycle 1) + guarded `deleteCollection({name, confirmation})` wrappers on both Memory Core and Knowledge Base `ChromaManager` classes; refuses **every** destructive collection-delete unless `UNIT_TEST_MODE=true` OR the explicit production confirmation token is supplied — regardless of whether the name is in the canonical set. The canonical-collection-name set is retained as diagnostic context (the `CanonicalCollectionGuardError.isCanonical` field + error-message phrasing distinguish canonical vs non-canonical refusals), but membership is no longer the gate. All four bare-`client.deleteCollection` call sites rerouted through the guarded method. The CollectionProxy fallback to bare client was REMOVED in Cycle 1 — fail-closed throws if a manager lacks the wrapper. Test-helper `util.mjs` cleanup also gets a `UNIT_TEST_MODE !== 'true'` precondition for defense-in-depth ahead of the substrate guard.

Evidence: L2 (15 unit tests covering the guard at the helper layer, MC ChromaManager-wrapper layer, AND KB ChromaManager-wrapper layer with mocked chromadb-client) → L2 required (all #11652 ACs are mechanically verifiable in unit-test scope; no runtime-only surfaces). No residuals.

## Deltas from ticket (if any)

- **Uniform-gate semantic (Cycle 1 RA1):** The Cycle 0 implementation gated only on canonical-set membership — non-canonical names passed through without check. @neo-gpt's Cycle 1 review correctly identified this as the "non-canonical name as free bypass" attack surface. The current implementation requires `UNIT_TEST_MODE=true` OR a valid `confirmation` token for **every** destructive collection-delete attempt regardless of name. Production callers must thread either the test env or the explicit confirmation token through every destructive boundary — there is no "safe" name that bypasses the gate. The canonical-set is retained as diagnostic-only (`CanonicalCollectionGuardError.isCanonical` field + error message distinguishes canonical-target refusals from non-canonical-target refusals for operator clarity).
- **Drop bare-client fallback (Cycle 1 RA2):** The `else if (manager.client?.deleteCollection)` fallback in `CollectionProxy.drop` was the very bypass surface this PR exists to close. Replaced with fail-closed throw when a manager lacks the guarded `deleteCollection({name, confirmation})` wrapper. `rg -n "client\.deleteCollection" ai/ test/` now returns only the wrapper-internal calls (inside MC + KB `ChromaManager.deleteCollection`) — zero outside-manager bare callers.
- **Symmetric KB-side wrapper coverage (Cycle 1 RA3):** Added a new `Neo.ai.services.knowledge-base.ChromaManager#deleteCollection — guard integration (#11652)` describe block with 3 tests mirroring the MC-side wrapper integration coverage: refuse-without-bypass, UNIT_TEST_MODE forward, confirmation-token forward + non-leak verification. Both wrappers now have direct integration coverage.

## Test Evidence

New spec: `test/playwright/unit/ai/services/memory-core/managers/ChromaManager.canonicalGuard.spec.mjs` — **15 tests, 15 passed in 783ms** (+5 from Cycle 0's 10 — uniform-gate scenarios + non-canonical-refusal coverage + `isCanonical` diagnostic field + KB-side wrapper integration tests):

| # | Scenario | Verifies |
|---|---|---|
| 1 | Set membership for all 4 canonical names (MC memory/sessions/graph + KB) | The diagnostic set covers production-target names |
| 2 | Refuses non-canonical (test-prefixed) name without UNIT_TEST_MODE — uniform-gate (#11656 RA1) | Closed the "non-canonical name as free bypass" attack surface |
| 3 | Allows non-canonical (test-prefixed) name when UNIT_TEST_MODE=true | Bypass path symmetry |
| 4 | Allows canonical name when UNIT_TEST_MODE=true (test-isolation bypass) | Test path works |
| 5 | Allows canonical name with explicit production confirmation token | Operator recovery bypass works |
| 6 | Refuses canonical name without UNIT_TEST_MODE and without confirmation (the npx playwright attack surface) | Defense for the wipe scenario |
| 7 | Refuses canonical name with invalid confirmation token | No string-equality drift |
| 8 | Error carries stable code CANONICAL_COLLECTION_GUARDED for caller pattern-matching | Caller can pattern-match |
| 9 | Error.isCanonical=false distinguishes non-canonical refusals in diagnostics | Operator clarity preserved |
| 10-12 | MC ChromaManager.deleteCollection wrapper integration | Guard fires BEFORE client; forwards under bypass; confirmation not leaked |
| 13-15 | KB ChromaManager.deleteCollection wrapper integration (NEW — RA3) | Symmetric to MC: refuse-without-bypass, UNIT_TEST_MODE forward, confirmation-token forward + non-leak |

Regression coverage (all green):
- `npm run test-unit -- test/playwright/unit/ai/mcp/server/shared/services/DestructiveOperationGuard.spec.mjs` → **13 passed** (pre-existing tests; new exports don't break them)
- `npm run test-unit -- test/playwright/unit/ai/services/memory-core/managers/ChromaManager.spec.mjs` → **1 passed**
- `npm run test-unit -- test/playwright/unit/ai/services/knowledge-base/DatabaseService.backup.spec.mjs test/playwright/unit/ai/services/knowledge-base/VectorService.WorkVolumeBranching.spec.mjs` → **8 passed**

## Post-Merge Validation

- [ ] Live MC daemon startup unaffected (production reads canonical names via `aiConfig.collections.*` and uses `getOrCreateCollection`, never `deleteCollection` — verify by observing healthy `mcp__neo-mjs-memory-core__healthcheck` post-merge)
- [ ] `npm run ai:restore -- <bundle> --mode replace --only-substrate=mc` continues to work end-to-end (replace mode invokes `DatabaseService.truncateDatabase` which now routes through the guard with operator confirmation token — production recovery path)
- [ ] Live KB read paths (`ask_knowledge_base`, `query_documents`) continue to function — they bypass the guard entirely (read-only ops use `getOrCreateCollection`, not deleteCollection)
- [ ] No future caller can regress to bare `ChromaManager.client.deleteCollection` directly — `rg -n "client\.deleteCollection" ai/ test/` post-merge should remain bounded to the wrapper-internal calls. Future PR-review attention required if this expands.

## Commits

- `ea2d136dc` — fix(ai): substrate guard refusing canonical Chroma collection deletes (#11652)
- `257cb9469` — fix(ai): tighten canonical guard + drop bare-client fallback + KB wrapper coverage (#11652) [Cycle 1 response]