### PR TITLE
fix(ai): KB importDatabase tolerates null document field (#11653)

### DIFF
--- a/ai/services/knowledge-base/DatabaseService.mjs
+++ b/ai/services/knowledge-base/DatabaseService.mjs
@@ -322,15 +322,25 @@ class DatabaseService extends Base {
                     continue;
                 }
 
+                // Per #11653: KB chunks store content in `metadata.content`, not in Chroma's
+                // primary `document` slot — so 100% of KB backup records carry `document: null`.
+                // Chroma's `collection.upsert` rejects null entries in the `documents` array
+                // with "Expected each document to be a string, but got object". Omit the
+                // `documents` field entirely when every record in the batch has a null doc;
+                // substitute empty strings for any remaining nulls in mixed batches so each
+                // array element satisfies Chroma's string-shape requirement uniformly.
                 const BATCH_SIZE = 500;
                 for (let i = 0; i < records.length; i += BATCH_SIZE) {
-                    const batch = records.slice(i, i + BATCH_SIZE);
-                    await collection.upsert({
+                    const batch      = records.slice(i, i + BATCH_SIZE);
+                    const upsertArgs = {
                         ids       : batch.map(r => r.id),
                         embeddings: batch.map(r => r.embedding),
-                        metadatas : batch.map(r => r.metadata),
-                        documents : batch.map(r => r.document)
-                    });
+                        metadatas : batch.map(r => r.metadata)
+                    };
+                    if (batch.some(r => r.document != null)) {
+                        upsertArgs.documents = batch.map(r => r.document ?? '');
+                    }
+                    await collection.upsert(upsertArgs);
                     imported += batch.length;
                 }
             }

--- a/test/playwright/unit/ai/services/knowledge-base/DatabaseService.importNullDoc.spec.mjs
+++ b/test/playwright/unit/ai/services/knowledge-base/DatabaseService.importNullDoc.spec.mjs
@@ -1,0 +1,193 @@
+import {setup} from '../../../../setup.mjs';
+
+const appName = 'KBImportNullDocTest';
+
+setup({
+    neoConfig: {
+        allowVdomUpdatesInTests: false,
+        unitTestMode           : true,
+        useDomApiRenderer      : false
+    },
+    appConfig: {
+        name             : appName,
+        isMounted        : () => true,
+        vnodeInitialising: false
+    }
+});
+
+import {test, expect}  from '@playwright/test';
+import Neo             from '../../../../../../src/Neo.mjs';
+import * as core       from '../../../../../../src/core/_export.mjs';
+import InstanceManager from '../../../../../../src/manager/Instance.mjs';
+import fs              from 'fs';
+import path            from 'path';
+
+// Serial: this spec mutates KB_ChromaManager.getKnowledgeBaseCollection singleton via beforeAll.
+test.describe.configure({mode: 'serial'});
+
+test.describe('KB_DatabaseService.importDatabase — null-document handling (#11653)', () => {
+    let SDK, KB_DatabaseService, KB_ChromaManager;
+    let originalGetCollection, tmpDir;
+    let capturedUpsertCalls;
+
+    test.beforeAll(async () => {
+        SDK                = await import('../../../../../../ai/services.mjs');
+        KB_DatabaseService = SDK.KB_DatabaseService;
+        KB_ChromaManager   = SDK.KB_ChromaManager;
+
+        tmpDir = path.resolve(process.cwd(), 'tmp', `kb-import-null-doc-${process.pid}-${Date.now()}`);
+        fs.mkdirSync(tmpDir, {recursive: true});
+
+        originalGetCollection = KB_ChromaManager.getKnowledgeBaseCollection.bind(KB_ChromaManager);
+    });
+
+    test.beforeEach(() => {
+        capturedUpsertCalls = [];
+
+        const mockCollection = {
+            upsert: async (args) => { capturedUpsertCalls.push(args); }
+        };
+
+        KB_ChromaManager.getKnowledgeBaseCollection = async () => mockCollection;
+    });
+
+    test.afterAll(async () => {
+        KB_ChromaManager.getKnowledgeBaseCollection = originalGetCollection;
+
+        if (tmpDir && fs.existsSync(tmpDir)) {
+            fs.rmSync(tmpDir, {recursive: true, force: true});
+        }
+    });
+
+    /**
+     * Writes a JSONL file in the per-test tmp dir from an array of records.
+     * Returns the absolute file path.
+     */
+    function writeBackupFile(name, records) {
+        const filePath = path.join(tmpDir, name);
+        fs.writeFileSync(filePath, records.map(r => JSON.stringify(r)).join('\n') + '\n');
+        return filePath;
+    }
+
+    test('omits documents field when every record in batch has document: null (KB steady-state shape)', async () => {
+        const filePath = writeBackupFile('kb-all-null.jsonl', [
+            {id: 'id-1', embedding: [0.1, 0.2], metadata: {kind: 'class', content: 'class A {}'}, document: null},
+            {id: 'id-2', embedding: [0.3, 0.4], metadata: {kind: 'method', content: 'method foo()'}, document: null},
+            {id: 'id-3', embedding: [0.5, 0.6], metadata: {kind: 'module', content: 'export default {}'}, document: null}
+        ]);
+
+        const result = await KB_DatabaseService.importDatabase({
+            action: 'import',
+            file  : filePath,
+            mode  : 'merge'
+        });
+
+        expect(result.imported).toBe(3);
+        expect(capturedUpsertCalls).toHaveLength(1);
+
+        const upsert = capturedUpsertCalls[0];
+        expect(upsert.ids).toEqual(['id-1', 'id-2', 'id-3']);
+        expect(upsert.embeddings).toHaveLength(3);
+        expect(upsert.metadatas).toHaveLength(3);
+        // The fix: `documents` field MUST be absent from the upsert payload when every
+        // record's document is null. Pre-#11653, this field was passed as [null,null,null]
+        // which Chroma rejects with "Expected each document to be a string, but got object".
+        expect('documents' in upsert).toBe(false);
+    });
+
+    test('includes documents field with strings when every record carries a non-null document (MC-style records)', async () => {
+        const filePath = writeBackupFile('kb-all-strings.jsonl', [
+            {id: 'id-1', embedding: [0.1, 0.2], metadata: {kind: 'memory'}, document: 'memory body 1'},
+            {id: 'id-2', embedding: [0.3, 0.4], metadata: {kind: 'memory'}, document: 'memory body 2'}
+        ]);
+
+        const result = await KB_DatabaseService.importDatabase({
+            action: 'import',
+            file  : filePath,
+            mode  : 'merge'
+        });
+
+        expect(result.imported).toBe(2);
+        const upsert = capturedUpsertCalls[0];
+        expect(upsert.documents).toEqual(['memory body 1', 'memory body 2']);
+    });
+
+    test('substitutes empty strings for null documents in mixed batch (defensive — preserves field for non-null entries)', async () => {
+        const filePath = writeBackupFile('kb-mixed.jsonl', [
+            {id: 'id-1', embedding: [0.1, 0.2], metadata: {kind: 'class'},   document: null},
+            {id: 'id-2', embedding: [0.3, 0.4], metadata: {kind: 'memory'},  document: 'memory body'},
+            {id: 'id-3', embedding: [0.5, 0.6], metadata: {kind: 'class'},   document: null}
+        ]);
+
+        const result = await KB_DatabaseService.importDatabase({
+            action: 'import',
+            file  : filePath,
+            mode  : 'merge'
+        });
+
+        expect(result.imported).toBe(3);
+        const upsert = capturedUpsertCalls[0];
+        // Every element must be a string for Chroma; nulls become empty strings.
+        expect(upsert.documents).toEqual(['', 'memory body', '']);
+    });
+
+    test('handles batch boundary correctly — 501 all-null records (BATCH_SIZE=500) still omits documents on both batches', async () => {
+        const records = [];
+        for (let i = 0; i < 501; i++) {
+            records.push({id: `id-${i}`, embedding: [i, i + 1], metadata: {n: i}, document: null});
+        }
+        const filePath = writeBackupFile('kb-501-null.jsonl', records);
+
+        const result = await KB_DatabaseService.importDatabase({
+            action: 'import',
+            file  : filePath,
+            mode  : 'merge'
+        });
+
+        expect(result.imported).toBe(501);
+        expect(capturedUpsertCalls).toHaveLength(2);
+        // Both batches must omit `documents` since every record is null.
+        for (const upsert of capturedUpsertCalls) {
+            expect('documents' in upsert).toBe(false);
+        }
+        // Verify batching boundary: first batch has 500 ids, second has 1.
+        expect(capturedUpsertCalls[0].ids).toHaveLength(500);
+        expect(capturedUpsertCalls[1].ids).toHaveLength(1);
+    });
+
+    test('reproducer for the 2026-05-19 restore failure: real KB backup shape (24,418 records all-null docs) succeeds', async () => {
+        // Synthetic minimal reproducer mirroring the actual `backup-2026-05-19T13-08-14.283Z`
+        // shape audit: 100% of records have `document: null`; metadata carries `content`,
+        // `source`, `name`, `hash`, `kind`, `className`, `type`, `id`.
+        const filePath = writeBackupFile('kb-shape-reproducer.jsonl', [
+            {
+                id: 'h-1',
+                embedding: [0.001, 0.002, 0.003],
+                metadata: {
+                    source    : 'src/canvas/_export.mjs',
+                    name      : 'src/canvas/_export.mjs - [Module Context]',
+                    line_start: 1,
+                    line_end  : 4,
+                    extends   : '',
+                    hash      : 'h-1',
+                    content   : "import Sparkline from './Sparkline.mjs';",
+                    className : '',
+                    kind      : 'module-context',
+                    type      : 'src'
+                },
+                document: null
+            }
+        ]);
+
+        const result = await KB_DatabaseService.importDatabase({
+            action: 'import',
+            file  : filePath,
+            mode  : 'merge'
+        });
+
+        // Pre-#11653: this throws `DATABASE_IMPORT_ERROR: Expected each document to be a string, but got object`.
+        // Post-#11653: imports cleanly because `documents` is omitted from the upsert.
+        expect(result.imported).toBe(1);
+        expect('documents' in capturedUpsertCalls[0]).toBe(false);
+    });
+});


### PR DESCRIPTION
Resolves #11653

Authored by Claude Opus 4.7 (Claude Code). Session 7360e917-1733-4cdd-a6f3-5ac51c34b838.

FAIR-band: in-band [14/30] — mechanical fix-it lane for the wipe-recovery cycle; sister PR to #11656 (substrate guard).

Unblocks `npm run ai:restore -- <bundle> --only-substrate=kb` on every KB backup ever taken. KB chunks store content in `metadata.content` (not Chroma's `document` slot, by design — symmetric with `parsed-chunk-v1` Phase 0/1A contract), so 100% of KB backup records carry `document: null`. Pre-#11653 the import path forwarded null straight into `collection.upsert({documents: [null, ...]})` which Chroma rejects with `Expected each document to be a string, but got object`. Patch omits the `documents` field from the upsert payload when every record in the batch has `document: null`, substitutes `''` for nulls in mixed batches.

Evidence: L2 (5 new unit tests covering all 3 batch shapes + batch boundary + real-backup-shape reproducer using synthetic 1-record file with exact metadata-key shape from `backup-2026-05-19T13-08-14.283Z` audit) → L3 required (live end-to-end restore against the actual `backup-2026-05-19T13-08-14.283Z` bundle's 24,418 chunks; round-trip parity export→restore on populated KB collection with byte-identical chunk count + identity-tuple membership). Residual: AC "end-to-end `npm run ai:restore -- <bundle> --only-substrate=kb` succeeds" [#11653] and AC "Round-trip parity: byte-identical chunk count + identity-tuple membership" [#11653] — sandbox ceiling: agent cannot drive real chromadb restore against live backups; post-merge operator handoff needed.

## Deltas from ticket (if any)

- Added an extra batch-boundary spec (501 records, BATCH_SIZE=500) to verify both batches handle null docs correctly — not in the original AC list but a low-cost addition that catches an off-by-one regression class.
- Added a "real-backup-shape reproducer" spec using the exact metadata keys observed in the live `backup-2026-05-19T13-08-14.283Z` audit (`source`, `name`, `line_start`, `line_end`, `extends`, `hash`, `content`, `className`, `kind`, `type`). Gives a concrete regression anchor without committing the full 24,418-record backup.
- **Evidence framing reshaped per @neo-gpt's Cycle 1 review (#11657 commentId PRR_kwDODSospM8AAAABAYzbzg, Required Action 1):** the prior PR body said "all ACs L2 unit-test-verifiable, no residuals" while listing post-merge ops as validation items — internally inconsistent. The end-to-end-restore + round-trip-parity ACs are L3-required runtime checks the agent sandbox cannot reach (no real chromadb instance + bundle wired up at PR-build time). Honest framing: ship L2-tested at sandbox ceiling, explicitly declare residuals, hand off live verification to the operator's post-merge validation pass.

## Test Evidence

New spec: `test/playwright/unit/ai/services/knowledge-base/DatabaseService.importNullDoc.spec.mjs` — 5 tests, **5 passed in 761ms**.

| # | Scenario | Verifies |
|---|---|---|
| 1 | All-null batch (KB steady-state) | `documents` field absent from upsert; Chroma never sees null |
| 2 | All-string batch (MC-shape hypothetical) | `documents` field present + forwards strings unchanged |
| 3 | Mixed null+string batch | nulls substituted with `''`; every array element a string |
| 4 | 501 records at BATCH_SIZE=500 | both batches handled correctly; off-by-one regression guard |
| 5 | Real-backup-shape reproducer | exact metadata-key shape from `backup-2026-05-19T...` succeeds |

Regression: `npm run test-unit -- test/playwright/unit/ai/services/knowledge-base/DatabaseService.backup.spec.mjs` → **3 passed** (export side unchanged, no regression).

## Post-Merge Validation (Explicit Residuals)

These items are L3-required runtime checks the agent sandbox cannot drive at PR-build time. They are deferred to operator post-merge validation per pr-review-guide §7.4 evidence-residual discipline:

- [ ] **Residual — L3-deferred — operator handoff needed:** `npm run ai:restore -- .neo-ai-data/backups/<any-existing-bundle> --mode merge --only-substrate=kb` succeeds end-to-end (restores the live KB collection from a real bundle's chunks via non-destructive merge mode). Empirical reproducer the unit spec models: `backup-2026-05-19T13-08-14.283Z` with 24,418 null-document records.
- [ ] **Residual — L3-deferred — operator handoff needed:** Subsequent `npm run ai:backup` + `ai:restore` round-trip preserves chunk count + identity-tuple membership (KB-as-cache invariant per #11628 framing).
- [ ] **Sandbox-checkable:** No regression to `npm run ai:sync-kb` (delta-update path uses `getKnowledgeBaseCollection().upsert` directly and pre-#11653 was already passing string documents from `metadata.content` — unaffected by this PR). Covered by existing `DatabaseService.backup.spec.mjs` regression run.

## Commits

- `e8f9dec37` — fix(ai): KB importDatabase tolerates null document field (#11653)