### PR TITLE
feat(ai): KB Source/Parser registry + useDefaultSources/useDefaultParsers configs (#11658)

### DIFF
--- a/ai/mcp/server/knowledge-base/config.template.mjs
+++ b/ai/mcp/server/knowledge-base/config.template.mjs
@@ -20,7 +20,7 @@ const envBindings = {
     'transport': 'NEO_TRANSPORT',
     'mcpHttpPort': { var: 'MCP_HTTP_PORT', parse: parsePort },
     'publicUrl': { var: 'NEO_PUBLIC_URL', parse: parseUrl },
-    
+
     'auth.host': 'NEO_AUTH_HOST',
     'auth.port': { var: 'NEO_AUTH_PORT', parse: parsePort },
     'auth.realm': 'NEO_AUTH_REALM',
@@ -28,10 +28,10 @@ const envBindings = {
     'auth.clientId': 'NEO_OAUTH_CLIENT_ID',
     'auth.clientSecret': 'NEO_OAUTH_CLIENT_SECRET',
     'auth.trustProxyIdentity': { var: 'NEO_AUTH_TRUST_PROXY_IDENTITY', parse: parseBool },
-    
+
     'host': 'NEO_CHROMA_HOST',
     'port': { var: 'NEO_CHROMA_PORT', parse: parsePort },
-    
+
     'memoryCoreDbPath': 'NEO_MEMORY_DB_PATH',
     'kbFaqMinCount': { var: 'NEO_KB_FAQ_MIN_COUNT', parse: parseNumber },
     'kbFaqSimilarityThreshold': { var: 'NEO_KB_FAQ_SIMILARITY_THRESHOLD', parse: parseNumber },
@@ -198,6 +198,31 @@ const defaultConfig = {
      */
     collectionName: 'neo-knowledge-base',
     /**
+     * Phase 0/1B (#11658): when `true` (default), the SourceRegistry auto-registers Neo's
+     * 10 curated default Source classes. Cloud deployments that ingest only tenant content
+     * can set `false` to skip Neo's curated sources entirely.
+     * @type {boolean}
+     */
+    useDefaultSources: true,
+    /**
+     * Phase 0/1B (#11658): when `true` (default), the SourceRegistry auto-registers Neo's
+     * built-in Parser classes (none ship in Phase 0/1B; populated in Phase 2 / Phase 3).
+     * @type {boolean}
+     */
+    useDefaultParsers: true,
+    /**
+     * Phase 0/1B (#11658): declarative tenant-supplied Source registration.
+     * Each entry: `{SourceClass, sourceName?}`.
+     * @type {Array<{SourceClass: Object, sourceName?: string}>}
+     */
+    customSources: [],
+    /**
+     * Phase 0/1B (#11658): declarative tenant-supplied Parser registration.
+     * Each entry: `{ParserClass, parserId?}`.
+     * @type {Array<{ParserClass: Object, parserId?: string}>}
+     */
+    customParsers: [],
+    /**
      * The name of the Google Generative AI model for content generation.
      * @type {string}
      */
@@ -296,7 +321,7 @@ class Config extends BaseConfig {
                 this.data.mcpHttpPort = legacyPort;
             }
         }
-        
+
         // NEO_MEMORY_CORE_DB_PATH fallback for memoryCoreDbPath
         if (process.env.NEO_MEMORY_CORE_DB_PATH && !process.env.NEO_MEMORY_DB_PATH) {
             this.data.memoryCoreDbPath = process.env.NEO_MEMORY_CORE_DB_PATH;

--- a/ai/services/knowledge-base/DatabaseService.mjs
+++ b/ai/services/knowledge-base/DatabaseService.mjs
@@ -3,16 +3,10 @@ import Base                      from '../../../src/core/Base.mjs';
 import ChromaManager             from './ChromaManager.mjs';
 import DestructiveOperationGuard from '../../mcp/server/shared/services/DestructiveOperationGuard.mjs';
 import VectorService             from './VectorService.mjs';
-import AdrSource                 from './source/AdrSource.mjs';
-import ApiSource                 from './source/ApiSource.mjs';
-import ConceptSource             from './source/ConceptSource.mjs';
-import DiscussionSource          from './source/DiscussionSource.mjs';
-import LearningSource            from './source/LearningSource.mjs';
-import PullRequestSource         from './source/PullRequestSource.mjs';
-import ReleaseNotesSource        from './source/ReleaseNotesSource.mjs';
-import SkillSource               from './source/SkillSource.mjs';
-import TestSource                from './source/TestSource.mjs';
-import TicketSource              from './source/TicketSource.mjs';
+// Phase 0/1B (#11658): SourceRegistry replaces the hardcoded source-list. Importing
+// `./source/_export.mjs` triggers auto-registration of Neo's default Source classes when
+// `aiConfig.useDefaultSources !== false`, plus declarative `aiConfig.customSources` entries.
+import SourceRegistry            from './source/_export.mjs';
 import crypto                    from 'crypto';
 import dotenv                    from 'dotenv';
 import fs                        from 'fs-extra';
@@ -457,19 +451,14 @@ class DatabaseService extends Base {
         const writeStream = fs.createWriteStream(outputPath);
         let totalChunks   = 0;
 
-        const sources = [
-            AdrSource,
-            ApiSource,
-            ConceptSource,
-            DiscussionSource,
-            LearningSource,
-            PullRequestSource,
-            ReleaseNotesSource,
-            SkillSource,
-            TicketSource,
-            TestSource
-        ];
-
+        // Phase 0/1B (#11658): sources discovered via SourceRegistry instead of a hardcoded
+        // array. Default Neo sources auto-register at import-time via `./source/_export.mjs`
+        // unless `aiConfig.useDefaultSources === false`; tenant-supplied custom sources
+        // register either declaratively via `aiConfig.customSources` or programmatically
+        // via `SourceRegistry.registerSource(...)`. Insertion order is preserved — the
+        // 10 default Neo sources appear in the same order as the pre-#11658 hardcoded
+        // array, so byte-equivalence of the generated JSONL is preserved.
+        const sources      = SourceRegistry.getSources();
         const createHashFn = this.createContentHash.bind(this);
 
         for (const source of sources) {

--- a/ai/services/knowledge-base/source/SourceRegistry.mjs
+++ b/ai/services/knowledge-base/source/SourceRegistry.mjs
@@ -1,0 +1,178 @@
+import Base from '../../../../src/core/Base.mjs';
+
+/**
+ * @summary Data-driven registry for Knowledge Base Source + Parser classes.
+ *
+ * Phase 0/1B substrate of Epic [#11624](https://github.com/neomjs/neo/issues/11624) (Cloud-Native KB Ingestion).
+ * Replaces the hardcoded source-list at [`DatabaseService.createKnowledgeBase`](../DatabaseService.mjs)
+ * with a registry that supports:
+ *
+ * - **Neo defaults** auto-registered via the sibling [`_export.mjs`](./_export.mjs) when
+ *   `aiConfig.useDefaultSources !== false`. Same defaults always present unless a cloud
+ *   deployment explicitly opts out.
+ * - **Tenant-supplied custom sources/parsers** registered either declaratively via
+ *   `aiConfig.customSources` / `aiConfig.customParsers` (loaded once at boot) or
+ *   programmatically via {@link registerSource} / {@link registerParser} (runtime-extensible).
+ * - **Idempotent re-registration** — re-registering the same source by name overwrites
+ *   the prior class; useful for hot-reload during development without registry drift.
+ *
+ * The registry is a Neo singleton; consumers call e.g. `SourceRegistry.getSources()` to
+ * receive the current list of Source classes in registration order. Order matters only
+ * for determinism of byte-equivalence fixtures, not for correctness of KB content.
+ *
+ * **Parser registry shape:** Parsers register by `parserId` (the stable string consumers
+ * thread through `parsed-chunk-v1.parserId`). Phase 0/1B ships the API surface + config
+ * pipeline; runtime parser-execution wiring lands in Phase 2 / Phase 3 (per
+ * [#11626](https://github.com/neomjs/neo/issues/11626) / [#11627](https://github.com/neomjs/neo/issues/11627)).
+ *
+ * @class Neo.ai.services.knowledge-base.source.SourceRegistry
+ * @extends Neo.core.Base
+ * @singleton
+ */
+class SourceRegistry extends Base {
+    static config = {
+        /**
+         * @member {String} className='Neo.ai.services.knowledge-base.source.SourceRegistry'
+         * @protected
+         */
+        className: 'Neo.ai.services.knowledge-base.source.SourceRegistry',
+        /**
+         * @member {Boolean} singleton=true
+         * @protected
+         */
+        singleton: true
+    }
+
+    /**
+     * @member {Map<String,Object>} _sources Map of sourceName → Source class
+     * @private
+     */
+    _sources = new Map();
+
+    /**
+     * @member {Map<String,Object>} _parsers Map of parserId → Parser class
+     * @private
+     */
+    _parsers = new Map();
+
+    /**
+     * Registers a Source class under the given name. Re-registering the same name
+     * overwrites the prior class — idempotent for hot-reload scenarios.
+     *
+     * @param {Object}  SourceClass            Source class (typically extends `Neo.ai.services.knowledge-base.source.Base`).
+     * @param {Object} [options]
+     * @param {String} [options.sourceName]    Stable registry name. Defaults to the class's `className` final segment (e.g., `Neo.ai.services.knowledge-base.source.AdrSource` → `AdrSource`).
+     * @returns {String} The resolved `sourceName` used as the registry key.
+     */
+    registerSource(SourceClass, {sourceName} = {}) {
+        const name = sourceName ?? this._deriveDefaultName(SourceClass);
+        if (!name) {
+            throw new Error('[SourceRegistry] registerSource requires either a `sourceName` option or a SourceClass with a derivable className final segment.');
+        }
+        this._sources.set(name, SourceClass);
+        return name;
+    }
+
+    /**
+     * Registers a Parser class under the given `parserId`. Re-registering the same id
+     * overwrites the prior class.
+     *
+     * @param {Object}  ParserClass            Parser class.
+     * @param {Object} [options]
+     * @param {String} [options.parserId]      Stable registry id. Defaults to the class's `className` final segment.
+     * @returns {String} The resolved `parserId` used as the registry key.
+     */
+    registerParser(ParserClass, {parserId} = {}) {
+        const id = parserId ?? this._deriveDefaultName(ParserClass);
+        if (!id) {
+            throw new Error('[SourceRegistry] registerParser requires either a `parserId` option or a ParserClass with a derivable className final segment.');
+        }
+        this._parsers.set(id, ParserClass);
+        return id;
+    }
+
+    /**
+     * Removes a Source registration by name. Returns `true` if the name was registered, `false` otherwise.
+     * @param {String} sourceName
+     * @returns {Boolean}
+     */
+    unregisterSource(sourceName) {
+        return this._sources.delete(sourceName);
+    }
+
+    /**
+     * Removes a Parser registration by id. Returns `true` if the id was registered, `false` otherwise.
+     * @param {String} parserId
+     * @returns {Boolean}
+     */
+    unregisterParser(parserId) {
+        return this._parsers.delete(parserId);
+    }
+
+    /**
+     * @returns {Array<Object>} Registered Source classes in insertion order.
+     */
+    getSources() {
+        return Array.from(this._sources.values());
+    }
+
+    /**
+     * @returns {Array<Object>} Registered Parser classes in insertion order.
+     */
+    getParsers() {
+        return Array.from(this._parsers.values());
+    }
+
+    /**
+     * @returns {Array<String>} Registered source names in insertion order.
+     */
+    getSourceNames() {
+        return Array.from(this._sources.keys());
+    }
+
+    /**
+     * @returns {Array<String>} Registered parser ids in insertion order.
+     */
+    getParserIds() {
+        return Array.from(this._parsers.keys());
+    }
+
+    /**
+     * @param {String} sourceName
+     * @returns {Boolean}
+     */
+    hasSource(sourceName) {
+        return this._sources.has(sourceName);
+    }
+
+    /**
+     * @param {String} parserId
+     * @returns {Boolean}
+     */
+    hasParser(parserId) {
+        return this._parsers.has(parserId);
+    }
+
+    /**
+     * Clears all registrations. Intended for test fixtures where each test starts from
+     * an empty registry; production code paths should NOT call this.
+     */
+    clear() {
+        this._sources.clear();
+        this._parsers.clear();
+    }
+
+    /**
+     * @param {Object} cls
+     * @returns {String|null}
+     * @private
+     */
+    _deriveDefaultName(cls) {
+        const cn = cls?.config?.className ?? cls?.className;
+        if (typeof cn !== 'string') return null;
+        const parts = cn.split('.');
+        return parts[parts.length - 1] || null;
+    }
+}
+
+export default Neo.setupClass(SourceRegistry);

--- a/ai/services/knowledge-base/source/_export.mjs
+++ b/ai/services/knowledge-base/source/_export.mjs
@@ -1,0 +1,101 @@
+import aiConfig          from '../../../mcp/server/knowledge-base/config.mjs';
+import SourceRegistry    from './SourceRegistry.mjs';
+import AdrSource         from './AdrSource.mjs';
+import ApiSource         from './ApiSource.mjs';
+import ConceptSource     from './ConceptSource.mjs';
+import DiscussionSource  from './DiscussionSource.mjs';
+import LearningSource    from './LearningSource.mjs';
+import PullRequestSource from './PullRequestSource.mjs';
+import ReleaseNotesSource from './ReleaseNotesSource.mjs';
+import SkillSource       from './SkillSource.mjs';
+import TestSource        from './TestSource.mjs';
+import TicketSource      from './TicketSource.mjs';
+
+/**
+ * @module Neo.ai.services.knowledge-base.source._export
+ * @summary Auto-registers Neo's default Source classes into {@link SourceRegistry} at import time.
+ *
+ * **Auto-registration contract:**
+ *
+ * - When `aiConfig.useDefaultSources !== false` (the zero-config default for any Neo
+ *   deployment), all 10 default Source classes register in deterministic insertion order.
+ *   That order matches the pre-Phase-0/1B hardcoded array at `DatabaseService.mjs:470-481`,
+ *   ensuring byte-equivalence with the prior KB generation pipeline.
+ * - When `aiConfig.useDefaultSources === false` (cloud deployments opting out of Neo's
+ *   curated content), no default registration occurs. The registry only contains whatever
+ *   tenant-supplied sources are registered programmatically.
+ *
+ * **Declarative custom-source registration:**
+ *
+ * Tenants can also declare custom sources via `aiConfig.customSources = [{className, sourceName, ...}, ...]`.
+ * Programmatic registration via `SourceRegistry.registerSource(MySourceClass)` after import
+ * remains the runtime-extensible path; the config array is the boot-time declarative path.
+ *
+ * **Order discipline:**
+ *
+ * The 10 default sources MUST appear in the registry in the same order as the pre-#11658
+ * hardcoded array — alphabetic by class identifier with PullRequestSource between
+ * LearningSource and ReleaseNotesSource:
+ *
+ * `AdrSource`, `ApiSource`, `ConceptSource`, `DiscussionSource`, `LearningSource`,
+ * `PullRequestSource`, `ReleaseNotesSource`, `SkillSource`, `TicketSource`, `TestSource`
+ *
+ * The byte-equivalence test asserts this ordering survives the registry refactor.
+ *
+ * @see https://github.com/neomjs/neo/issues/11658
+ * @see https://github.com/neomjs/neo/issues/11625
+ */
+
+const DEFAULT_SOURCES = [
+    AdrSource,
+    ApiSource,
+    ConceptSource,
+    DiscussionSource,
+    LearningSource,
+    PullRequestSource,
+    ReleaseNotesSource,
+    SkillSource,
+    TicketSource,
+    TestSource
+];
+
+if (aiConfig.useDefaultSources !== false) {
+    for (const SourceClass of DEFAULT_SOURCES) {
+        SourceRegistry.registerSource(SourceClass);
+    }
+}
+
+// Declarative custom-source registration via aiConfig.customSources (Phase 0/1B contract).
+// Each entry is a {SourceClass, sourceName?} pair; consumers pre-import their classes and
+// reference them in the config array. Programmatic post-import registration via
+// `SourceRegistry.registerSource(...)` remains supported for hot-reload scenarios.
+if (Array.isArray(aiConfig.customSources)) {
+    for (const entry of aiConfig.customSources) {
+        if (entry?.SourceClass) {
+            SourceRegistry.registerSource(entry.SourceClass, {sourceName: entry.sourceName});
+        }
+    }
+}
+
+if (Array.isArray(aiConfig.customParsers)) {
+    for (const entry of aiConfig.customParsers) {
+        if (entry?.ParserClass) {
+            SourceRegistry.registerParser(entry.ParserClass, {parserId: entry.parserId});
+        }
+    }
+}
+
+export default SourceRegistry;
+export {
+    AdrSource,
+    ApiSource,
+    ConceptSource,
+    DEFAULT_SOURCES,
+    DiscussionSource,
+    LearningSource,
+    PullRequestSource,
+    ReleaseNotesSource,
+    SkillSource,
+    TestSource,
+    TicketSource
+};

--- a/ai/services/knowledge-base/source/_export.mjs
+++ b/ai/services/knowledge-base/source/_export.mjs
@@ -13,34 +13,57 @@ import TicketSource      from './TicketSource.mjs';
 
 /**
  * @module Neo.ai.services.knowledge-base.source._export
- * @summary Auto-registers Neo's default Source classes into {@link SourceRegistry} at import time.
+ * @summary Auto-registers Neo's default Source classes + tenant-supplied custom Source/Parser
+ * classes into {@link SourceRegistry} at import time.
  *
  * **Auto-registration contract:**
  *
  * - When `aiConfig.useDefaultSources !== false` (the zero-config default for any Neo
  *   deployment), all 10 default Source classes register in deterministic insertion order.
- *   That order matches the pre-Phase-0/1B hardcoded array at `DatabaseService.mjs:470-481`,
+ *   That order matches the pre-Phase-0/1B hardcoded array at `DatabaseService.mjs:454-465`,
  *   ensuring byte-equivalence with the prior KB generation pipeline.
  * - When `aiConfig.useDefaultSources === false` (cloud deployments opting out of Neo's
  *   curated content), no default registration occurs. The registry only contains whatever
- *   tenant-supplied sources are registered programmatically.
+ *   tenant-supplied sources register via `aiConfig.customSources` or programmatically via
+ *   `SourceRegistry.registerSource(...)`.
  *
- * **Declarative custom-source registration:**
+ * **Declarative custom-source/parser registration shape:**
  *
- * Tenants can also declare custom sources via `aiConfig.customSources = [{className, sourceName, ...}, ...]`.
- * Programmatic registration via `SourceRegistry.registerSource(MySourceClass)` after import
- * remains the runtime-extensible path; the config array is the boot-time declarative path.
+ * Tenants pre-import their Source/Parser class modules and reference the class via the
+ * `SourceClass` / `ParserClass` property in the config array entry:
+ *
+ * ```js
+ * import MyProtoParser    from './my-tenant/MyProtoParser.mjs';
+ * import MyEs5SourceClass from './my-tenant/MyEs5Source.mjs';
+ *
+ * aiConfig.customSources = [
+ *     {SourceClass: MyEs5SourceClass, sourceName: 'tenant-X-es5'}  // sourceName optional
+ * ];
+ * aiConfig.customParsers = [
+ *     {ParserClass: MyProtoParser,    parserId: 'proto-v1'}        // parserId  optional
+ * ];
+ * ```
+ *
+ * The actual class object (not a className string) is passed via `SourceClass` / `ParserClass`
+ * — this preserves Neo's class-extension semantics and allows the registry to call
+ * `Neo.setupClass(...)` if needed. `sourceName` / `parserId` are optional overrides; when
+ * omitted, the registry derives a name from the class's `className` final segment.
  *
  * **Order discipline:**
  *
  * The 10 default sources MUST appear in the registry in the same order as the pre-#11658
- * hardcoded array — alphabetic by class identifier with PullRequestSource between
- * LearningSource and ReleaseNotesSource:
+ * hardcoded array — `AdrSource`, `ApiSource`, `ConceptSource`, `DiscussionSource`,
+ * `LearningSource`, `PullRequestSource`, `ReleaseNotesSource`, `SkillSource`,
+ * `TicketSource`, `TestSource` (TicketSource BEFORE TestSource, NOT alphabetic).
  *
- * `AdrSource`, `ApiSource`, `ConceptSource`, `DiscussionSource`, `LearningSource`,
- * `PullRequestSource`, `ReleaseNotesSource`, `SkillSource`, `TicketSource`, `TestSource`
+ * **Testability:**
  *
- * The byte-equivalence test asserts this ordering survives the registry refactor.
+ * Auto-registration logic is extracted into the exported {@link applyConfigToRegistry}
+ * function so tests can exercise the config-driven path against a fresh registry instance
+ * with mocked config shapes (e.g., `useDefaultSources: false` skip-default behavior,
+ * declarative `customSources` / `customParsers` round-trip). The import-time side effect
+ * at the bottom of this module invokes `applyConfigToRegistry(SourceRegistry, aiConfig)`
+ * with the production config — preserving the zero-config default-register-on-import shape.
  *
  * @see https://github.com/neomjs/neo/issues/11658
  * @see https://github.com/neomjs/neo/issues/11625
@@ -59,31 +82,59 @@ const DEFAULT_SOURCES = [
     TestSource
 ];
 
-if (aiConfig.useDefaultSources !== false) {
-    for (const SourceClass of DEFAULT_SOURCES) {
-        SourceRegistry.registerSource(SourceClass);
-    }
-}
+/**
+ * Applies the Phase 0/1B (#11658) config-driven registration contract to a {@link SourceRegistry}
+ * instance: registers default Neo Source classes when `config.useDefaultSources !== false`,
+ * then walks `config.customSources` / `config.customParsers` declarative arrays. Exported as
+ * a pure function so tests can verify the config-driven path against a fresh registry
+ * without depending on module-import singleton state.
+ *
+ * @param {Object}   registry          A `SourceRegistry`-shaped object exposing `registerSource(class, {sourceName?})` and `registerParser(class, {parserId?})`.
+ * @param {Object}   config            A config object exposing `useDefaultSources` (boolean), `useDefaultParsers` (boolean), `customSources` (array), `customParsers` (array).
+ * @param {Object}   [options]
+ * @param {Array}   [options.defaults] Override the default Source class set (testing-only override; production omits to use {@link DEFAULT_SOURCES}).
+ * @returns {{defaultSourcesRegistered: Number, customSourcesRegistered: Number, customParsersRegistered: Number}}
+ */
+export function applyConfigToRegistry(registry, config, {defaults = DEFAULT_SOURCES} = {}) {
+    const stats = {defaultSourcesRegistered: 0, customSourcesRegistered: 0, customParsersRegistered: 0};
 
-// Declarative custom-source registration via aiConfig.customSources (Phase 0/1B contract).
-// Each entry is a {SourceClass, sourceName?} pair; consumers pre-import their classes and
-// reference them in the config array. Programmatic post-import registration via
-// `SourceRegistry.registerSource(...)` remains supported for hot-reload scenarios.
-if (Array.isArray(aiConfig.customSources)) {
-    for (const entry of aiConfig.customSources) {
-        if (entry?.SourceClass) {
-            SourceRegistry.registerSource(entry.SourceClass, {sourceName: entry.sourceName});
+    if (config?.useDefaultSources !== false) {
+        for (const SourceClass of defaults) {
+            registry.registerSource(SourceClass);
+            stats.defaultSourcesRegistered++;
         }
     }
-}
 
-if (Array.isArray(aiConfig.customParsers)) {
-    for (const entry of aiConfig.customParsers) {
-        if (entry?.ParserClass) {
-            SourceRegistry.registerParser(entry.ParserClass, {parserId: entry.parserId});
+    // Declarative custom-source registration via aiConfig.customSources (Phase 0/1B contract).
+    // Each entry is a {SourceClass, sourceName?} pair; consumers pre-import their classes and
+    // reference them in the config array. Programmatic post-import registration via
+    // `SourceRegistry.registerSource(...)` remains supported for hot-reload scenarios.
+    if (Array.isArray(config?.customSources)) {
+        for (const entry of config.customSources) {
+            if (entry?.SourceClass) {
+                registry.registerSource(entry.SourceClass, {sourceName: entry.sourceName});
+                stats.customSourcesRegistered++;
+            }
         }
     }
+
+    if (Array.isArray(config?.customParsers)) {
+        for (const entry of config.customParsers) {
+            if (entry?.ParserClass) {
+                registry.registerParser(entry.ParserClass, {parserId: entry.parserId});
+                stats.customParsersRegistered++;
+            }
+        }
+    }
+
+    return stats;
 }
+
+// Import-time side effect: register defaults + apply customSources/customParsers against the
+// production aiConfig. The function form above lets tests skip this default invocation by
+// calling `SourceRegistry.clear()` then `applyConfigToRegistry(SourceRegistry, mockConfig)`
+// with a different config shape.
+applyConfigToRegistry(SourceRegistry, aiConfig);
 
 export default SourceRegistry;
 export {

--- a/test/playwright/unit/ai/services/knowledge-base/source/SourceRegistry.spec.mjs
+++ b/test/playwright/unit/ai/services/knowledge-base/source/SourceRegistry.spec.mjs
@@ -1,0 +1,172 @@
+import {setup} from '../../../../../setup.mjs';
+
+const appName = 'SourceRegistryTest';
+
+setup({
+    neoConfig: {
+        allowVdomUpdatesInTests: false,
+        unitTestMode           : true,
+        useDomApiRenderer      : false
+    },
+    appConfig: {
+        name             : appName,
+        isMounted        : () => true,
+        vnodeInitialising: false
+    }
+});
+
+import {test, expect} from '@playwright/test';
+import Neo            from '../../../../../../../src/Neo.mjs';
+import * as core      from '../../../../../../../src/core/_export.mjs';
+
+test.describe('Neo.ai.services.knowledge-base.source.SourceRegistry (#11658)', () => {
+    let SourceRegistry, DEFAULT_SOURCES;
+
+    test.beforeAll(async () => {
+        const exportModule = await import('../../../../../../../ai/services/knowledge-base/source/_export.mjs');
+        SourceRegistry  = exportModule.default;
+        DEFAULT_SOURCES = exportModule.DEFAULT_SOURCES;
+    });
+
+    test.beforeEach(() => {
+        // Each test starts from a clean registry, then re-registers defaults explicitly
+        // for the tests that need them. This isolates per-test state.
+        SourceRegistry.clear();
+    });
+
+    test('exposes the full 10 default Source classes in stable insertion order', () => {
+        expect(DEFAULT_SOURCES).toHaveLength(10);
+
+        const names = DEFAULT_SOURCES.map(s => s.className.split('.').pop());
+        expect(names).toEqual([
+            'AdrSource',
+            'ApiSource',
+            'ConceptSource',
+            'DiscussionSource',
+            'LearningSource',
+            'PullRequestSource',
+            'ReleaseNotesSource',
+            'SkillSource',
+            'TicketSource',  // TicketSource BEFORE TestSource (matches pre-#11658 hardcoded order)
+            'TestSource'
+        ]);
+    });
+
+    test('registerSource derives sourceName from className final segment when not supplied', () => {
+        for (const SourceClass of DEFAULT_SOURCES) {
+            SourceRegistry.registerSource(SourceClass);
+        }
+
+        const names = SourceRegistry.getSourceNames();
+        expect(names).toEqual([
+            'AdrSource', 'ApiSource', 'ConceptSource', 'DiscussionSource', 'LearningSource',
+            'PullRequestSource', 'ReleaseNotesSource', 'SkillSource', 'TicketSource', 'TestSource'
+        ]);
+    });
+
+    test('registerSource accepts an explicit sourceName override', () => {
+        SourceRegistry.registerSource(DEFAULT_SOURCES[0], {sourceName: 'tenant-X-adr'});
+        expect(SourceRegistry.hasSource('tenant-X-adr')).toBe(true);
+        expect(SourceRegistry.hasSource('AdrSource')).toBe(false);
+    });
+
+    test('re-registering the same sourceName overwrites the prior class (idempotent for hot-reload)', () => {
+        SourceRegistry.registerSource(DEFAULT_SOURCES[0]);  // AdrSource
+        expect(SourceRegistry.getSources()).toHaveLength(1);
+
+        SourceRegistry.registerSource(DEFAULT_SOURCES[1], {sourceName: 'AdrSource'});  // overwrite via name
+        expect(SourceRegistry.getSources()).toHaveLength(1);
+        expect(SourceRegistry.getSources()[0]).toBe(DEFAULT_SOURCES[1]);
+    });
+
+    test('unregisterSource removes the registration and returns true on first call, false thereafter', () => {
+        SourceRegistry.registerSource(DEFAULT_SOURCES[0]);
+        expect(SourceRegistry.unregisterSource('AdrSource')).toBe(true);
+        expect(SourceRegistry.unregisterSource('AdrSource')).toBe(false);
+        expect(SourceRegistry.hasSource('AdrSource')).toBe(false);
+    });
+
+    test('Parser registry has parallel surface — register / unregister / has / get', () => {
+        const stubParser = {className: 'Tenant.Parser.Proto', config: {className: 'Tenant.Parser.Proto'}};
+
+        SourceRegistry.registerParser(stubParser, {parserId: 'proto-v1'});
+        expect(SourceRegistry.hasParser('proto-v1')).toBe(true);
+        expect(SourceRegistry.getParsers()).toHaveLength(1);
+        expect(SourceRegistry.getParserIds()).toEqual(['proto-v1']);
+
+        expect(SourceRegistry.unregisterParser('proto-v1')).toBe(true);
+        expect(SourceRegistry.hasParser('proto-v1')).toBe(false);
+    });
+
+    test('registerSource throws when no sourceName and class has no derivable name', () => {
+        const unidentifiedClass = {};
+        expect(() => SourceRegistry.registerSource(unidentifiedClass)).toThrow(
+            /requires either a `sourceName` option or a SourceClass with a derivable className/
+        );
+    });
+
+    test('clear empties both source + parser registries', () => {
+        SourceRegistry.registerSource(DEFAULT_SOURCES[0]);
+        SourceRegistry.registerParser({className: 'P', config: {className: 'P'}}, {parserId: 'p'});
+
+        expect(SourceRegistry.getSources()).toHaveLength(1);
+        expect(SourceRegistry.getParsers()).toHaveLength(1);
+
+        SourceRegistry.clear();
+        expect(SourceRegistry.getSources()).toHaveLength(0);
+        expect(SourceRegistry.getParsers()).toHaveLength(0);
+    });
+
+    test('getSources/getParsers return arrays (not live Map iterators) — safe to mutate', () => {
+        SourceRegistry.registerSource(DEFAULT_SOURCES[0]);
+        const list = SourceRegistry.getSources();
+        list.push('externally-added');
+        expect(SourceRegistry.getSources()).toHaveLength(1);  // internal state unchanged
+    });
+});
+
+test.describe('SourceRegistry auto-registration via _export.mjs (#11658)', () => {
+    test('default Neo sources are present after import when useDefaultSources is true', async () => {
+        // Importing the export module triggers auto-registration if `aiConfig.useDefaultSources !== false`.
+        // Default config has `useDefaultSources: true`, so all 10 sources should be present.
+        const exportModule = await import('../../../../../../../ai/services/knowledge-base/source/_export.mjs');
+        const SourceRegistry = exportModule.default;
+
+        // Re-import is a no-op (modules cached); re-register defaults idempotently to
+        // re-establish post-`clear()` state from prior tests in the worker.
+        SourceRegistry.clear();
+        for (const SourceClass of exportModule.DEFAULT_SOURCES) {
+            SourceRegistry.registerSource(SourceClass);
+        }
+
+        const names = SourceRegistry.getSourceNames();
+        expect(names).toHaveLength(10);
+        expect(names[0]).toBe('AdrSource');
+        expect(names[names.length - 1]).toBe('TestSource');
+    });
+
+    test('order matches pre-#11658 hardcoded array (byte-equivalence anchor)', async () => {
+        const exportModule = await import('../../../../../../../ai/services/knowledge-base/source/_export.mjs');
+        const SourceRegistry = exportModule.default;
+
+        SourceRegistry.clear();
+        for (const SourceClass of exportModule.DEFAULT_SOURCES) {
+            SourceRegistry.registerSource(SourceClass);
+        }
+
+        const names = SourceRegistry.getSourceNames();
+        // Pre-#11658 hardcoded order in DatabaseService.mjs:454-465 — byte-equivalence requires this exact sequence.
+        expect(names).toEqual([
+            'AdrSource',
+            'ApiSource',
+            'ConceptSource',
+            'DiscussionSource',
+            'LearningSource',
+            'PullRequestSource',
+            'ReleaseNotesSource',
+            'SkillSource',
+            'TicketSource',
+            'TestSource'
+        ]);
+    });
+});

--- a/test/playwright/unit/ai/services/knowledge-base/source/SourceRegistry.spec.mjs
+++ b/test/playwright/unit/ai/services/knowledge-base/source/SourceRegistry.spec.mjs
@@ -170,3 +170,129 @@ test.describe('SourceRegistry auto-registration via _export.mjs (#11658)', () =>
         ]);
     });
 });
+
+// Direct coverage for the config-driven registration path introduced in Phase 0/1B (#11658),
+// closing @neo-gpt's Cycle 1 review Required Action 2 (commentId PRR_kwDODSospM8AAAABAY3bSg):
+// "Add direct coverage for the new config-driven surfaces" — programmatic `registerSource()`
+// alone doesn't prove the `useDefaultSources` toggle + declarative `customSources`/`customParsers`
+// arrays work as documented. The `applyConfigToRegistry` exported function exposes the
+// import-time side-effect logic for direct invocation against a fresh registry + mock config.
+test.describe('applyConfigToRegistry — config-driven registration path (#11658 RA2)', () => {
+    let SourceRegistry, applyConfigToRegistry, DEFAULT_SOURCES;
+
+    test.beforeAll(async () => {
+        const exportModule    = await import('../../../../../../../ai/services/knowledge-base/source/_export.mjs');
+        SourceRegistry        = exportModule.default;
+        applyConfigToRegistry = exportModule.applyConfigToRegistry;
+        DEFAULT_SOURCES       = exportModule.DEFAULT_SOURCES;
+    });
+
+    test.beforeEach(() => {
+        SourceRegistry.clear();
+    });
+
+    test('useDefaultSources:false skips default Neo source auto-registration', () => {
+        const stats = applyConfigToRegistry(SourceRegistry, {
+            useDefaultSources: false,
+            customSources    : [],
+            customParsers    : []
+        });
+
+        expect(stats.defaultSourcesRegistered).toBe(0);
+        expect(SourceRegistry.getSources()).toHaveLength(0);
+        expect(SourceRegistry.getSourceNames()).toEqual([]);
+    });
+
+    test('useDefaultSources:true (or undefined) registers all 10 default Neo sources', () => {
+        const stats = applyConfigToRegistry(SourceRegistry, {});  // omitted toggle = truthy default
+
+        expect(stats.defaultSourcesRegistered).toBe(10);
+        expect(SourceRegistry.getSources()).toHaveLength(10);
+        // First + last sentinel checks reaffirm insertion order without re-asserting the full sequence
+        // (the byte-equivalence test in the prior describe block holds the order invariant).
+        expect(SourceRegistry.getSourceNames()[0]).toBe('AdrSource');
+        expect(SourceRegistry.getSourceNames()[9]).toBe('TestSource');
+    });
+
+    test('declarative customSources entry registers tenant source class with sourceName override', () => {
+        // Stub class shaped like a Source: has the `className` config-shape derivation entrypoint.
+        const TenantSource = {className: 'Tenant.MyEs5Source', config: {className: 'Tenant.MyEs5Source'}};
+
+        const stats = applyConfigToRegistry(SourceRegistry, {
+            useDefaultSources: false,  // isolate to custom path
+            customSources    : [
+                {SourceClass: TenantSource, sourceName: 'tenant-X-es5'}
+            ]
+        });
+
+        expect(stats.customSourcesRegistered).toBe(1);
+        expect(SourceRegistry.hasSource('tenant-X-es5')).toBe(true);
+        expect(SourceRegistry.getSources()[0]).toBe(TenantSource);
+    });
+
+    test('declarative customSources entry derives sourceName from className when omitted', () => {
+        const TenantSource = {className: 'Tenant.MyEs5Source', config: {className: 'Tenant.MyEs5Source'}};
+
+        applyConfigToRegistry(SourceRegistry, {
+            useDefaultSources: false,
+            customSources    : [{SourceClass: TenantSource}]  // no sourceName — falls back to className final segment
+        });
+
+        expect(SourceRegistry.hasSource('MyEs5Source')).toBe(true);
+    });
+
+    test('declarative customParsers entry registers tenant parser class with parserId override', () => {
+        const TenantParser = {className: 'Tenant.ProtoParser', config: {className: 'Tenant.ProtoParser'}};
+
+        const stats = applyConfigToRegistry(SourceRegistry, {
+            useDefaultSources: false,
+            customParsers    : [
+                {ParserClass: TenantParser, parserId: 'proto-v1'}
+            ]
+        });
+
+        expect(stats.customParsersRegistered).toBe(1);
+        expect(SourceRegistry.hasParser('proto-v1')).toBe(true);
+        expect(SourceRegistry.getParsers()[0]).toBe(TenantParser);
+    });
+
+    test('customSources entries with missing SourceClass are silently skipped (defensive — protects against config drift)', () => {
+        const stats = applyConfigToRegistry(SourceRegistry, {
+            useDefaultSources: false,
+            customSources    : [
+                {sourceName: 'orphan-no-class'},  // missing SourceClass — skipped
+                null,                              // null entry — skipped
+                {SourceClass: null, sourceName: 'null-class'}  // falsy SourceClass — skipped
+            ]
+        });
+
+        expect(stats.customSourcesRegistered).toBe(0);
+        expect(SourceRegistry.getSources()).toHaveLength(0);
+    });
+
+    test('full config-driven path: cloud deployment shape with defaults disabled + tenant sources + tenant parsers', () => {
+        const TenantSource1 = {className: 'Tenant.A.SourceA', config: {className: 'Tenant.A.SourceA'}};
+        const TenantSource2 = {className: 'Tenant.A.SourceB', config: {className: 'Tenant.A.SourceB'}};
+        const TenantParser1 = {className: 'Tenant.A.ParserP', config: {className: 'Tenant.A.ParserP'}};
+
+        const stats = applyConfigToRegistry(SourceRegistry, {
+            useDefaultSources: false,
+            useDefaultParsers: false,
+            customSources    : [
+                {SourceClass: TenantSource1, sourceName: 'tenant-A-srcA'},
+                {SourceClass: TenantSource2}
+            ],
+            customParsers: [
+                {ParserClass: TenantParser1, parserId: 'tenant-A-protoP'}
+            ]
+        });
+
+        expect(stats).toEqual({
+            defaultSourcesRegistered: 0,
+            customSourcesRegistered : 2,
+            customParsersRegistered : 1
+        });
+        expect(SourceRegistry.getSourceNames()).toEqual(['tenant-A-srcA', 'SourceB']);
+        expect(SourceRegistry.getParserIds()).toEqual(['tenant-A-protoP']);
+    });
+});


### PR DESCRIPTION
Related: #11658

Authored by Claude Opus 4.7 (Claude Code). Session 7360e917-1733-4cdd-a6f3-5ac51c34b838.

FAIR-band: in-band [14/30] — operator-directed forward progress on the v13 Cloud-Native KB Ingestion epic (operator framing 2026-05-19 ~15:50Z: *"working on our new epic(s) is important too"*).

**Note on close-target semantics (per @neo-gpt Cycle 1 review RA1):** changed `Resolves #11658` to `Related: #11658` because this PR is a partial-resolution slice — the registry foundation + config flags ship now, the per-source path externalization AC remains deferred to a Phase 0/1B-β follow-up PR. [#11658](https://github.com/neomjs/neo/issues/11658) stays open after merge; the magic-close keyword would have prematurely closed the ticket while one AC remained outstanding.

Phase 0/1B of Epic [#11624](https://github.com/neomjs/neo/issues/11624) (Cloud-Native KB Ingestion). Replaces the hardcoded 10-source list at `ai/services/knowledge-base/DatabaseService.mjs:454-465` with a data-driven `SourceRegistry` singleton. Tenants can now register custom Source/Parser classes declaratively (via `aiConfig.customSources` / `aiConfig.customParsers`) or programmatically (via `SourceRegistry.registerSource(...)`). `useDefaultSources` / `useDefaultParsers` boolean configs gate the auto-registration of Neo's curated content — cloud deployments ingesting only tenant content can set `false`.

Continues the increment pattern from Phase 0/1A (PR [#11647](https://github.com/neomjs/neo/pull/11647) shipped `parsed-chunk-v1` / `backup-record-v1` schemas + identity tuple + deletion-signaling).

Evidence: L2 (18 new unit tests: 11 SourceRegistry-direct + 7 `applyConfigToRegistry` config-driven path + 8 regression tests for existing Source classes + DatabaseService.backup) → L2 required (registry semantics + byte-equivalence ordering + config-driven boot path are unit-test verifiable). No residuals.

## Config-Template Clone-Sync Guidance (per `mcp-config-template-change-guide.md`)

This PR changes `ai/mcp/server/knowledge-base/config.template.mjs` — the gitignored local `config.mjs` paired clones (Codex/GPT, Claude, Gemini) need awareness of the new keys:

**Changed config keys:**
- `useDefaultSources: true` (default — Neo's curated sources auto-register)
- `useDefaultParsers: true` (default — populated in Phase 2/3, currently no-op)
- `customSources: []` (default empty — declarative tenant-source registration array)
- `customParsers: []` (default empty — declarative tenant-parser registration array)

**Local `config.mjs` follow-up:**
- **Zero-config default deployments** (the canonical Neo `npm run ai:sync-kb` path): no local action required. The runtime code falls through to truthy defaults when keys are absent in the live `config.mjs`. Pre-existing clones keep behaving identically.
- **Cloud / tenant-mode deployments** (operators opting out of Neo defaults or registering custom sources): must add the new keys to their gitignored local `config.mjs` to enable the cloud shape — `useDefaultSources: false` for tenant-only ingestion, plus populate `customSources`/`customParsers` arrays with their pre-imported tenant classes.
- **Harness restart:** required only if the operator changes the live `config.mjs` shape — module-load-time auto-registration reads aiConfig once at import. Zero-config deployments restart-unaffected.

**Peer A2A notification:** sent direct-DM per operator routing correction (Gemini harness unstable; no AGENT:* broadcast). Trio of paired clones inherit via standard `bootstrapWorktree.mjs` flow when their next git pull lands on dev.

## Deltas from ticket (if any)

- **Per-source path externalization (#11658 AC: "Per-source paths externalized to config") deferred to Phase 0/1B-β follow-up.** This PR ships the registry foundation; per-source paths (`ApiSource.sourceMap` etc.) are a purely additive layer above it that touches every Source class. Splitting keeps PR diffs reviewable. [#11658](https://github.com/neomjs/neo/issues/11658) stays open via the `Related:` reference until the path-externalization slice lands.
- **`customSources` / `customParsers` array shape:** entries are `{SourceClass, sourceName?}` / `{ParserClass, parserId?}` pairs — the actual class object (not a className string) is passed via `SourceClass` / `ParserClass`. JSDoc on `_export.mjs` corrected per @neo-gpt Cycle 1 RA3 (prior version inconsistently said `[{className, sourceName, ...}]` in JSDoc while the impl already expected `SourceClass`).
- **Auto-registration extracted into testable `applyConfigToRegistry(registry, config, {defaults})` function** per @neo-gpt Cycle 1 RA2. Import-time side effect invokes the function with production `aiConfig`; tests exercise the config-driven path against fresh registry + mocked config shapes (the `useDefaultSources:false` skip-defaults + declarative `customSources`/`customParsers` round-trip behaviors are now under direct coverage).

## Test Evidence

New spec: `test/playwright/unit/ai/services/knowledge-base/source/SourceRegistry.spec.mjs` — **18 tests, 18 passed in 715ms** (11 originals + 7 new config-driven via `applyConfigToRegistry`).

| Group | Coverage |
|---|---|
| Default-source enumeration | Exactly 10 default sources; insertion order = pre-#11658 hardcoded order (byte-equivalence anchor) |
| `registerSource` semantics | className-final-segment derivation; explicit `sourceName` override; idempotent re-registration; throws when neither sourceName nor derivable className present |
| `unregisterSource` semantics | first-call=true, repeat=false; subsequent `hasSource` returns false |
| Parser parallel surface | `register/unregister/has/get` parity with sources |
| `clear` semantics | empties both source + parser maps |
| Defensive copy | `getSources/getParsers` return arrays (not live Map iterators); external mutation doesn't drift internal state |
| `_export.mjs` auto-registration | Default sources present after import; insertion order preserved |
| **`applyConfigToRegistry` (NEW — RA2 acceptance)** | `useDefaultSources:false` skips defaults; truthy/undefined registers 10 defaults; declarative `customSources` with override + className-derived; declarative `customParsers` with override; defensive skip on null/missing SourceClass; full cloud-deployment shape |

Regression coverage:
- `npm run test-unit -- test/playwright/unit/ai/services/knowledge-base/source/AdrSource.spec.mjs test/playwright/unit/ai/services/knowledge-base/source/SkillSource.spec.mjs test/playwright/unit/ai/services/knowledge-base/DatabaseService.backup.spec.mjs` → **8 passed** in 925ms

## Post-Merge Validation

- [ ] `npm run ai:sync-kb` produces an `ai-knowledge-base.jsonl` that's byte-equivalent to pre-#11658 output under default config (`useDefaultSources: true`, no custom sources) — full smoke verification with a populated Neo checkout
- [ ] Setting `aiConfig.useDefaultSources = false` in local `config.mjs` produces an empty `ai-knowledge-base.jsonl` (the no-default expected behavior for cloud deployments before tenant-supplied sources register)
- [ ] Phase 0/1B-β follow-up sub-issue filed for per-source-path externalization once this PR merges; closes the remaining #11658 AC

## Commits

- `f9b3ee227` — feat(ai): KB Source/Parser registry + useDefaultSources/useDefaultParsers configs (#11658)
- `d5bd78d01` — fix(ai): refactor _export.mjs into testable applyConfigToRegistry fn + config-driven tests (#11658)