### PR TITLE
feat(kb): add write-side tenant stamping (#11631)

### DIFF
--- a/ai/mcp/server/knowledge-base/config.template.mjs
+++ b/ai/mcp/server/knowledge-base/config.template.mjs
@@ -35,7 +35,11 @@ const envBindings = {
     'memoryCoreDbPath': 'NEO_MEMORY_DB_PATH',
     'kbFaqMinCount': { var: 'NEO_KB_FAQ_MIN_COUNT', parse: parseNumber },
     'kbFaqSimilarityThreshold': { var: 'NEO_KB_FAQ_SIMILARITY_THRESHOLD', parse: parseNumber },
-    'kbFaqConceptLimit': { var: 'NEO_KB_FAQ_CONCEPT_LIMIT', parse: parseNumber }
+    'kbFaqConceptLimit': { var: 'NEO_KB_FAQ_CONCEPT_LIMIT', parse: parseNumber },
+    'defaultTenantId': 'NEO_KB_DEFAULT_TENANT_ID',
+    'defaultRepoSlug': 'NEO_KB_DEFAULT_REPO_SLUG',
+    'defaultVisibility': 'NEO_KB_DEFAULT_VISIBILITY',
+    'spoofRejectionMode': 'NEO_KB_SPOOF_REJECTION_MODE'
 };
 
 const defaultConfig = {
@@ -222,6 +226,40 @@ const defaultConfig = {
      * @type {Array<{ParserClass: Object, parserId?: string}>}
      */
     customParsers: [],
+    /**
+     * @summary Default tenant identity for Neo's curated Knowledge Base corpus.
+     *
+     * Used by `VectorService.embed()` when no authenticated ingestion context is supplied.
+     * Cloud ingestion paths override this with server-derived tenant context; client-supplied
+     * chunk metadata is never authoritative.
+     * @type {string}
+     */
+    defaultTenantId: 'neo-shared',
+    /**
+     * @summary Default repository slug for Neo's curated Knowledge Base corpus.
+     *
+     * Included in content hashing and Chroma IDs so byte-identical chunks from different
+     * tenant repositories cannot collide.
+     * @type {string}
+     */
+    defaultRepoSlug: 'neo',
+    /**
+     * @summary Default read visibility for embedded Knowledge Base chunks.
+     *
+     * Phase 0/1C writes the authoritative value; Phase 2/3 read paths consume it for
+     * tenant-aware filtering.
+     * @type {string}
+     */
+    defaultVisibility: 'team',
+    /**
+     * @summary Policy for conflicting client-supplied tenant metadata.
+     *
+     * `'overwrite'` logs and replaces conflicting `{tenantId, repoSlug, visibility,
+     * originAgentIdentity}` fields with server-derived values. `'reject'` fails the
+     * embedding call with `KB_TENANT_SPOOF_REJECTED`.
+     * @type {'overwrite'|'reject'}
+     */
+    spoofRejectionMode: 'overwrite',
     /**
      * The name of the Google Generative AI model for content generation.
      * @type {string}

--- a/ai/services/knowledge-base/DatabaseService.mjs
+++ b/ai/services/knowledge-base/DatabaseService.mjs
@@ -69,14 +69,19 @@ class DatabaseService extends Base {
     }
 
     /**
-     * Creates a SHA-256 hash from a stable JSON string representation of a chunk's content.
-     * This hash is used to detect changes in content without having to compare the full text.
+     * Creates a SHA-256 hash from a stable JSON string representation of a chunk's content
+     * and source identity tuple. This hash is used to detect changes in content without
+     * having to compare the full text, while keeping byte-identical chunks from different
+     * tenants or repositories collision-safe.
      * @param {Object} chunk The chunk object.
      * @returns {String} The hexadecimal hash string.
      * @private
      */
     createContentHash(chunk) {
+        const kbConfig = aiConfig.knowledgeBase ?? aiConfig;
         const contentString = JSON.stringify({
+            tenantId   : chunk.tenantId ?? kbConfig.defaultTenantId ?? 'neo-shared',
+            repoSlug   : chunk.repoSlug ?? kbConfig.defaultRepoSlug ?? 'neo',
             type       : chunk.type,
             name       : chunk.name,
             description: chunk.description,

--- a/ai/services/knowledge-base/VectorService.mjs
+++ b/ai/services/knowledge-base/VectorService.mjs
@@ -3,11 +3,14 @@ import TextEmbeddingService      from '../memory-core/TextEmbeddingService.mjs';
 import mcConfig                  from '../../mcp/server/memory-core/config.mjs';
 import Base                      from '../../../src/core/Base.mjs';
 import ChromaManager             from './ChromaManager.mjs';
+import crypto                    from 'crypto';
 import fs                        from 'fs-extra';
 import logger                    from '../../mcp/server/knowledge-base/logger.mjs';
 import path                      from 'path';
 import readline                  from 'readline';
 import DestructiveOperationGuard from '../../mcp/server/shared/services/DestructiveOperationGuard.mjs';
+
+const TENANT_GUARDED_FIELDS = ['tenantId', 'repoSlug', 'visibility', 'originAgentIdentity'];
 
 /**
  * @summary Manages vector database operations including embedding generation and storage.
@@ -94,6 +97,140 @@ class VectorService extends Base {
     }
 
     /**
+     * Returns the tenant-isolation config surface.
+     *
+     * Phase 0/1C runs inside the Knowledge Base server config directly, while the
+     * graduated contract documents the portable `aiConfig.knowledgeBase.*` shape for
+     * future shared AI config surfaces. Supporting both keeps this write boundary stable
+     * across the Phase 2/3 ingestion API work.
+     *
+     * @returns {Object} Tenant-isolation configuration object.
+     */
+    getTenantIsolationConfig() {
+        return aiConfig.knowledgeBase ?? aiConfig;
+    }
+
+    /**
+     * Resolves the authoritative tenant tuple used for KB write-side stamping.
+     *
+     * The tuple is server-derived: external ingestion callers pass already-authenticated
+     * context here, while Neo's default local sync falls back to the shared curated corpus.
+     *
+     * @param {Object} [tenantContext] Server-derived tenant context.
+     * @param {String} [tenantContext.tenantId] Tenant identifier.
+     * @param {String} [tenantContext.repoSlug] Repository slug within the tenant.
+     * @param {String} [tenantContext.visibility] Visibility scope for read-side filtering.
+     * @param {String} [tenantContext.originAgentIdentity] Authenticated agent identity.
+     * @returns {{tenantId: String, repoSlug: String, visibility: String, originAgentIdentity: String|undefined}}
+     */
+    resolveTenantStamp(tenantContext = {}) {
+        const config = this.getTenantIsolationConfig();
+        const stamp = {
+            tenantId  : tenantContext.tenantId ?? config.defaultTenantId ?? 'neo-shared',
+            repoSlug  : tenantContext.repoSlug ?? config.defaultRepoSlug ?? 'neo',
+            visibility: tenantContext.visibility ?? config.defaultVisibility ?? 'team'
+        };
+
+        if (tenantContext.originAgentIdentity) {
+            stamp.originAgentIdentity = tenantContext.originAgentIdentity;
+        }
+
+        return stamp;
+    }
+
+    /**
+     * Creates the tenant-aware storage ID for a parsed chunk.
+     *
+     * `chunk.hash` remains the content fingerprint, while the Chroma ID binds that
+     * fingerprint to the authoritative `{tenantId, repoSlug}` tuple so two tenants can
+     * ingest byte-identical files without colliding.
+     *
+     * @param {Object} chunk Parsed knowledge chunk.
+     * @param {Object} stamp Authoritative tenant stamp.
+     * @returns {String} SHA-256 tenant-aware chunk ID.
+     */
+    createTenantAwareChunkId(chunk, stamp) {
+        const identityString = JSON.stringify({
+            tenantId: stamp.tenantId,
+            repoSlug: stamp.repoSlug,
+            hash    : chunk.hash,
+            type    : chunk.type,
+            name    : chunk.name,
+            source  : chunk.source
+        });
+
+        return crypto.createHash('sha256').update(identityString).digest('hex');
+    }
+
+    /**
+     * Rejects or logs client-supplied identity fields that conflict with server context.
+     *
+     * @param {Object} chunk Parsed knowledge chunk.
+     * @param {Object} stamp Authoritative tenant stamp.
+     * @param {String} chunkId Tenant-aware chunk ID for diagnostics.
+     * @returns {void}
+     */
+    validateTenantStamp(chunk, stamp, chunkId) {
+        const config = this.getTenantIsolationConfig();
+        const mode   = config.spoofRejectionMode ?? 'overwrite';
+
+        for (const field of TENANT_GUARDED_FIELDS) {
+            const hasClientValue = Object.prototype.hasOwnProperty.call(chunk, field);
+            const serverValue    = stamp[field];
+            const clientValue    = chunk[field];
+
+            if (!hasClientValue || clientValue === serverValue) {
+                continue;
+            }
+
+            const warning = {
+                field,
+                chunkId,
+                clientValue,
+                serverValue: serverValue ?? null,
+                tenantId: stamp.tenantId,
+                repoSlug: stamp.repoSlug,
+                originAgentIdentity: stamp.originAgentIdentity ?? null
+            };
+
+            if (mode === 'reject') {
+                const error = new Error(`KB_TENANT_SPOOF_REJECTED: client-supplied ${field} does not match the server-derived value.`);
+                error.code  = 'KB_TENANT_SPOOF_REJECTED';
+                error.details = warning;
+                throw error;
+            }
+
+            logger.warn('[VectorService] Overwriting client-supplied tenant metadata field.', warning);
+        }
+    }
+
+    /**
+     * Applies authoritative tenant metadata before diffing or upserting.
+     *
+     * @param {Object} chunk Parsed knowledge chunk.
+     * @param {Object} stamp Authoritative tenant stamp.
+     * @returns {Object} Stamped chunk with tenant-aware `id` and `hash`.
+     */
+    applyTenantStamp(chunk, stamp) {
+        const chunkId = this.createTenantAwareChunkId(chunk, stamp);
+
+        this.validateTenantStamp(chunk, stamp, chunkId);
+
+        const stampedChunk = {
+            ...chunk,
+            ...stamp,
+            hash: chunkId,
+            id  : chunkId
+        };
+
+        if (!stamp.originAgentIdentity) {
+            delete stampedChunk.originAgentIdentity;
+        }
+
+        return stampedChunk;
+    }
+
+    /**
      * Reads a JSONL file, enriches data, generates embeddings, and updates ChromaDB.
      *
      * **Work-volume gate (#10572):** when invoked via MCP (`viaMcp: true`), refuses
@@ -107,11 +244,12 @@ class VectorService extends Base {
      * @param {Object}  [opts]                     Optional invocation context.
      * @param {Boolean} [opts.viaMcp=false]        True when called via MCP tool dispatch;
      *                                             enables the work-volume gate.
+     * @param {Object}  [opts.tenantContext]       Server-derived tenant stamp context.
      * @returns {Promise<object>} A promise that resolves to a success message, OR a
      *     `{error, code: 'KB_SYNC_VOLUME_EXCEEDED', ...}` shape when the MCP gate fires.
      * @see #10572
      */
-    async embed(knowledgeBasePath, {viaMcp = false} = {}) {
+    async embed(knowledgeBasePath, {viaMcp = false, tenantContext = {}} = {}) {
         logger.log('Starting knowledge base embedding...');
 
         if (!await fs.pathExists(knowledgeBasePath)) {
@@ -126,6 +264,12 @@ class VectorService extends Base {
             knowledgeBase.push(JSON.parse(line));
         }
         logger.log(`Loaded ${knowledgeBase.length} knowledge chunks from file.`);
+
+        const tenantStamp = this.resolveTenantStamp(tenantContext);
+
+        for (let i = 0; i < knowledgeBase.length; i++) {
+            knowledgeBase[i] = this.applyTenantStamp(knowledgeBase[i], tenantStamp);
+        }
 
         // Enrich with inheritance chains
         const classNameToDataMap = {};
@@ -188,11 +332,11 @@ class VectorService extends Base {
         const processedIds    = new Set();
 
         knowledgeBase.forEach(chunk => {
-            const chunkId = chunk.hash;
+            const chunkId = chunk.id;
             allIds.add(chunkId);
 
             if (!existingIds.has(chunkId) && !processedIds.has(chunkId)) {
-                chunksToProcess.push({ ...chunk, id: chunkId });
+                chunksToProcess.push(chunk);
                 processedIds.add(chunkId);
             }
         });
@@ -204,12 +348,12 @@ class VectorService extends Base {
         logger.log(`${chunksToProcess.length} chunks to add or update.`);
         logger.log(`${idsToDelete.length} chunks to delete.`);
 
-        if (idsToDelete.length > 0) {
-            await collection.delete({ ids: idsToDelete });
-            logger.log(`Deleted ${idsToDelete.length} stale chunks.`);
-        }
-
         if (chunksToProcess.length === 0) {
+            if (idsToDelete.length > 0) {
+                await collection.delete({ ids: idsToDelete });
+                logger.log(`Deleted ${idsToDelete.length} stale chunks.`);
+            }
+
             const message = 'No changes detected. Knowledge base is up to date.';
             logger.log(message);
             return {message};
@@ -240,6 +384,11 @@ class VectorService extends Base {
             };
             logger.warn(`[VectorService] ${errorPayload.error}: ${errorPayload.message}`);
             return errorPayload;
+        }
+
+        if (idsToDelete.length > 0) {
+            await collection.delete({ ids: idsToDelete });
+            logger.log(`Deleted ${idsToDelete.length} stale chunks.`);
         }
 
         logger.log(`Using TextEmbeddingService with provider: ${mcConfig.embeddingProvider}.`);

--- a/test/playwright/unit/ai/services/knowledge-base/VectorService.WorkVolumeBranching.spec.mjs
+++ b/test/playwright/unit/ai/services/knowledge-base/VectorService.WorkVolumeBranching.spec.mjs
@@ -155,8 +155,17 @@ test.describe('VectorService.embed — work-volume branching (#10572)', () => {
     });
 
     test('zero-changes fast-path is unchanged (existing chunks dedup to empty queue)', async () => {
-        // Seed existing IDs that match the fixture exactly — chunksToProcess becomes empty.
-        const ids = ['chunk-0', 'chunk-1', 'chunk-2'];
+        // Seed tenant-aware existing IDs that match the fixture exactly — chunksToProcess
+        // becomes empty under the Phase 0/1C write-side stamping contract (#11631).
+        const stamp = KB_VectorService.resolveTenantStamp();
+        const ids   = ['chunk-0', 'chunk-1', 'chunk-2'].map((hash, i) => {
+            return KB_VectorService.createTenantAwareChunkId({
+                hash,
+                type  : 'method',
+                name  : `method${i}`,
+                source: undefined
+            }, stamp);
+        });
         const spy = createSpyCollection({existingIds: ids});
         KB_ChromaManager.getKnowledgeBaseCollection = async () => spy;
 

--- a/test/playwright/unit/ai/services/knowledge-base/VectorService.tenantStamping.spec.mjs
+++ b/test/playwright/unit/ai/services/knowledge-base/VectorService.tenantStamping.spec.mjs
@@ -1,0 +1,346 @@
+import {setup} from '../../../../setup.mjs';
+
+const appName = 'KBTenantStampingTest';
+
+setup({
+    neoConfig: {
+        allowVdomUpdatesInTests: false,
+        unitTestMode           : true,
+        useDomApiRenderer      : false
+    },
+    appConfig: {
+        name             : appName,
+        isMounted        : () => true,
+        vnodeInitialising: false
+    }
+});
+
+import {test, expect} from '@playwright/test';
+import Neo            from '../../../../../../src/Neo.mjs';
+import * as core      from '../../../../../../src/core/_export.mjs';
+import fs             from 'fs';
+import path           from 'path';
+import os             from 'os';
+import {fileURLToPath} from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname  = path.dirname(__filename);
+
+/**
+ * Write-side tenant isolation coverage for `VectorService.embed` (#11631).
+ *
+ * The tests replace ChromaDB with an in-memory spy collection and stub the embedding
+ * provider, so they verify only the write-boundary contract: authoritative tenant
+ * stamping, spoof handling, and tenant-aware IDs.
+ *
+ * Serial mode: specs mutate singleton services and KB config.
+ */
+test.describe.configure({mode: 'serial'});
+
+function createSpyCollection({existingIds = []} = {}) {
+    const rows = new Map();
+    existingIds.forEach(id => rows.set(id, {id, metadata: {}, document: ''}));
+
+    const calls = {get: 0, upsert: 0, delete: 0, count: 0};
+
+    return {
+        rows,
+        calls,
+        name: 'spy-knowledge-base',
+
+        async get({limit = 2000, offset = 0, include = []} = {}) {
+            calls.get++;
+            const all   = Array.from(rows.keys());
+            const slice = all.slice(offset, offset + limit);
+
+            return {
+                ids      : slice,
+                metadatas: include.includes('metadatas') ? slice.map(() => ({})) : [],
+                documents: include.includes('documents') ? slice.map(() => '') : []
+            };
+        },
+
+        async upsert({ids, embeddings, metadatas}) {
+            calls.upsert++;
+            ids.forEach((id, i) => rows.set(id, {
+                id,
+                metadata : metadatas?.[i] ?? {},
+                embedding: embeddings?.[i] ?? null
+            }));
+        },
+
+        async delete({ids}) {
+            calls.delete++;
+            ids.forEach(id => rows.delete(id));
+        },
+
+        async count() {
+            calls.count++;
+            return rows.size;
+        }
+    };
+}
+
+function writeFixtureJsonl(filePath, chunks) {
+    fs.writeFileSync(filePath, chunks.map(chunk => JSON.stringify(chunk)).join('\n'), 'utf8');
+}
+
+function getOnlyRow(spy) {
+    return Array.from(spy.rows.values())[0];
+}
+
+test.describe('VectorService.embed — tenant stamping (#11631)', () => {
+    let SDK, KB_VectorService, KB_DatabaseService, KB_ChromaManager, KB_Config, Logger;
+    let TextEmbeddingService;
+    let originalGetCollection;
+    let originalEmbedTexts;
+    let originalWarn;
+    let originalConfig;
+    let tmpDir, fixturePath;
+    let warnCalls;
+
+    test.beforeAll(async () => {
+        SDK              = await import('../../../../../../ai/services.mjs');
+        KB_ChromaManager = SDK.KB_ChromaManager;
+        KB_Config        = SDK.KB_Config;
+        TextEmbeddingService = SDK.Memory_TextEmbeddingService;
+
+        const VectorServiceModule   = await import('../../../../../../ai/services/knowledge-base/VectorService.mjs');
+        const DatabaseServiceModule = await import('../../../../../../ai/services/knowledge-base/DatabaseService.mjs');
+        const LoggerModule          = await import('../../../../../../ai/mcp/server/knowledge-base/logger.mjs');
+
+        KB_VectorService   = VectorServiceModule.default;
+        KB_DatabaseService = DatabaseServiceModule.default;
+        Logger             = LoggerModule.default;
+
+        originalGetCollection = KB_ChromaManager.getKnowledgeBaseCollection.bind(KB_ChromaManager);
+        originalEmbedTexts    = TextEmbeddingService.embedTexts.bind(TextEmbeddingService);
+        originalWarn          = Logger.warn.bind(Logger);
+        originalConfig        = {
+            batchSize              : KB_Config.data.batchSize,
+            batchDelay             : KB_Config.data.batchDelay,
+            maxRetries             : KB_Config.data.maxRetries,
+            defaultTenantId        : KB_Config.data.defaultTenantId,
+            defaultRepoSlug        : KB_Config.data.defaultRepoSlug,
+            defaultVisibility      : KB_Config.data.defaultVisibility,
+            spoofRejectionMode     : KB_Config.data.spoofRejectionMode,
+            knowledgeBase          : KB_Config.data.knowledgeBase,
+            mcpSyncMaxChunks       : KB_Config.data.mcpSyncMaxChunks
+        };
+
+        TextEmbeddingService.embedTexts = async texts => texts.map(() => new Array(384).fill(0));
+
+        tmpDir      = path.resolve(os.tmpdir(), `kb-tenant-stamping-test-${process.pid}-${Date.now()}`);
+        fs.mkdirSync(tmpDir, {recursive: true});
+        fixturePath = path.join(tmpDir, 'fixture.jsonl');
+    });
+
+    test.afterAll(async () => {
+        KB_ChromaManager.getKnowledgeBaseCollection = originalGetCollection;
+        TextEmbeddingService.embedTexts             = originalEmbedTexts;
+        Logger.warn                                 = originalWarn;
+        Object.assign(KB_Config.data, originalConfig);
+
+        if (tmpDir && fs.existsSync(tmpDir)) {
+            fs.rmSync(tmpDir, {recursive: true, force: true});
+        }
+    });
+
+    test.beforeEach(() => {
+        Object.assign(KB_Config.data, {
+            batchSize         : 50,
+            batchDelay        : 0,
+            maxRetries        : 1,
+            defaultTenantId   : 'neo-shared',
+            defaultRepoSlug   : 'neo',
+            defaultVisibility : 'team',
+            spoofRejectionMode: 'overwrite',
+            knowledgeBase     : undefined,
+            mcpSyncMaxChunks  : 50
+        });
+
+        warnCalls   = [];
+        Logger.warn = (...args) => warnCalls.push(args);
+    });
+
+    test('stamps Neo default tenant metadata before upsert', async () => {
+        const spy = createSpyCollection();
+        KB_ChromaManager.getKnowledgeBaseCollection = async () => spy;
+
+        writeFixtureJsonl(fixturePath, [{
+            hash       : 'raw-hash-1',
+            type       : 'guide',
+            name       : 'DefaultTenantDoc',
+            className  : '',
+            description: 'default tenant stamping',
+            content    : 'body'
+        }]);
+
+        const result = await KB_VectorService.embed(fixturePath);
+        const row    = getOnlyRow(spy);
+
+        expect(result.message).toContain('Embedding complete');
+        expect(row.id).toHaveLength(64);
+        expect(row.metadata.id).toBe(row.id);
+        expect(row.metadata.hash).toBe(row.id);
+        expect(row.metadata.tenantId).toBe('neo-shared');
+        expect(row.metadata.repoSlug).toBe('neo');
+        expect(row.metadata.visibility).toBe('team');
+        expect('originAgentIdentity' in row.metadata).toBe(false);
+        expect(warnCalls).toHaveLength(0);
+    });
+
+    test('overwrites conflicting client-supplied tenant metadata and logs diagnostics', async () => {
+        const spy = createSpyCollection();
+        KB_ChromaManager.getKnowledgeBaseCollection = async () => spy;
+
+        writeFixtureJsonl(fixturePath, [{
+            hash               : 'raw-hash-2',
+            type               : 'guide',
+            name               : 'ExternalTenantDoc',
+            className          : '',
+            description        : 'external tenant stamping',
+            content            : 'body',
+            tenantId           : 'client-tenant',
+            repoSlug           : 'client-repo',
+            visibility         : 'public',
+            originAgentIdentity: '@client-claim'
+        }]);
+
+        await KB_VectorService.embed(fixturePath, {
+            tenantContext: {
+                tenantId           : 'server-tenant',
+                repoSlug           : 'server-repo',
+                visibility         : 'private',
+                originAgentIdentity: '@neo-gpt'
+            }
+        });
+
+        const row = getOnlyRow(spy);
+        const warnedFields = warnCalls.map(([, details]) => details.field).sort();
+
+        expect(row.metadata.tenantId).toBe('server-tenant');
+        expect(row.metadata.repoSlug).toBe('server-repo');
+        expect(row.metadata.visibility).toBe('private');
+        expect(row.metadata.originAgentIdentity).toBe('@neo-gpt');
+        expect(warnedFields).toEqual(['originAgentIdentity', 'repoSlug', 'tenantId', 'visibility']);
+        expect(warnCalls[0][0]).toContain('Overwriting client-supplied tenant metadata field');
+        expect(warnCalls[0][1].originAgentIdentity).toBe('@neo-gpt');
+    });
+
+    test('derives distinct Chroma IDs for identical chunks in different tenants', async () => {
+        const chunk = {
+            hash       : 'same-content-hash',
+            type       : 'guide',
+            name       : 'SameDoc',
+            className  : '',
+            description: 'same bytes',
+            content    : 'same body'
+        };
+
+        const spyA = createSpyCollection();
+        KB_ChromaManager.getKnowledgeBaseCollection = async () => spyA;
+        writeFixtureJsonl(fixturePath, [chunk]);
+        await KB_VectorService.embed(fixturePath, {
+            tenantContext: {tenantId: 'tenant-a', repoSlug: 'repo-a', visibility: 'team'}
+        });
+
+        const idA = getOnlyRow(spyA).id;
+
+        const spyB = createSpyCollection();
+        KB_ChromaManager.getKnowledgeBaseCollection = async () => spyB;
+        writeFixtureJsonl(fixturePath, [chunk]);
+        await KB_VectorService.embed(fixturePath, {
+            tenantContext: {tenantId: 'tenant-b', repoSlug: 'repo-a', visibility: 'team'}
+        });
+
+        const idB = getOnlyRow(spyB).id;
+
+        expect(idA).toHaveLength(64);
+        expect(idB).toHaveLength(64);
+        expect(idA).not.toBe(idB);
+    });
+
+    test('reject mode fails before Chroma writes when client metadata conflicts', async () => {
+        const spy = createSpyCollection();
+        KB_ChromaManager.getKnowledgeBaseCollection = async () => spy;
+        KB_Config.data.spoofRejectionMode = 'reject';
+
+        writeFixtureJsonl(fixturePath, [{
+            hash       : 'raw-hash-3',
+            type       : 'guide',
+            name       : 'RejectedTenantDoc',
+            className  : '',
+            description: 'tenant spoof',
+            content    : 'body',
+            tenantId   : 'client-tenant'
+        }]);
+
+        await expect(KB_VectorService.embed(fixturePath, {
+            tenantContext: {tenantId: 'server-tenant', repoSlug: 'server-repo', visibility: 'team'}
+        })).rejects.toMatchObject({
+            code: 'KB_TENANT_SPOOF_REJECTED'
+        });
+
+        expect(spy.calls.get).toBe(0);
+        expect(spy.calls.upsert).toBe(0);
+        expect(warnCalls).toHaveLength(0);
+    });
+
+    test('honors nested knowledgeBase isolation config shape', async () => {
+        const spy = createSpyCollection();
+        KB_ChromaManager.getKnowledgeBaseCollection = async () => spy;
+        KB_Config.data.knowledgeBase = {
+            defaultTenantId   : 'nested-tenant',
+            defaultRepoSlug   : 'nested-repo',
+            defaultVisibility : 'private',
+            spoofRejectionMode: 'overwrite'
+        };
+
+        writeFixtureJsonl(fixturePath, [{
+            hash       : 'raw-hash-4',
+            type       : 'guide',
+            name       : 'NestedConfigDoc',
+            className  : '',
+            description: 'nested config',
+            content    : 'body'
+        }]);
+
+        await KB_VectorService.embed(fixturePath);
+
+        const row = getOnlyRow(spy);
+
+        expect(row.metadata.tenantId).toBe('nested-tenant');
+        expect(row.metadata.repoSlug).toBe('nested-repo');
+        expect(row.metadata.visibility).toBe('private');
+    });
+
+    test('content hashes include tenant and repository identity', () => {
+        const baseChunk = {
+            type       : 'guide',
+            name       : 'HashDoc',
+            description: 'same',
+            content    : 'same'
+        };
+
+        const tenantAHash = KB_DatabaseService.createContentHash({
+            ...baseChunk,
+            tenantId: 'tenant-a',
+            repoSlug: 'repo'
+        });
+        const tenantBHash = KB_DatabaseService.createContentHash({
+            ...baseChunk,
+            tenantId: 'tenant-b',
+            repoSlug: 'repo'
+        });
+        const defaultHash = KB_DatabaseService.createContentHash(baseChunk);
+        const explicitDefaultHash = KB_DatabaseService.createContentHash({
+            ...baseChunk,
+            tenantId: 'neo-shared',
+            repoSlug: 'neo'
+        });
+
+        expect(tenantAHash).not.toBe(tenantBHash);
+        expect(defaultHash).toBe(explicitDefaultHash);
+    });
+});


### PR DESCRIPTION
Authored by GPT-5.5 (Codex Desktop). Session `021172f9-cf8a-4762-917f-95bdf261ad23`.

FAIR-band: in-band [13/30].

Resolves #11631

Implements Phase 0/1C write-side tenant isolation for the Knowledge Base embedding path. `VectorService.embed()` now stamps authoritative tenant metadata before diffing/upsert, guards client-supplied identity fields with overwrite-or-reject policy, and derives tenant-aware Chroma IDs so byte-identical chunks from different tenants cannot collide. `DatabaseService.createContentHash()` now includes tenant/repo identity inputs, and the KB config template exposes the default tenant/repo/visibility and spoof policy knobs.

Evidence: L2 (unit tests with in-memory Chroma spy + embedding stub; config/hash direct coverage) -> L2 required (all #11631 ACs are write-boundary contract/unit-test verifiable; no live cloud tenant endpoint exists until Phase 2). No residuals.

## Topology anchor

Per [ADR 0003 — Chroma Topology Unified Only](learn/agentos/decisions/0003-chroma-topology-unified-only.md): this PR writes tenant-scoping metadata to the `knowledge-base` collection in the unified Chroma daemon. It does not introduce a new Chroma instance and does not touch Memory Core collections (`neo-agent-memory`, `neo-agent-sessions`).

## Config-Template Clone-Sync Guidance

This PR changes `ai/mcp/server/knowledge-base/config.template.mjs`.

Changed config keys:
- `defaultTenantId: 'neo-shared'`
- `defaultRepoSlug: 'neo'`
- `defaultVisibility: 'team'`
- `spoofRejectionMode: 'overwrite'`

Changed env bindings:
- `NEO_KB_DEFAULT_TENANT_ID`
- `NEO_KB_DEFAULT_REPO_SLUG`
- `NEO_KB_DEFAULT_VISIBILITY`
- `NEO_KB_SPOOF_REJECTION_MODE`

Local `config.mjs` follow-up:
- Zero-config/default Neo deployments need no local change. Runtime fallbacks preserve `neo-shared` / `neo` / `team` / `overwrite` even when gitignored local configs lack these keys.
- Cloud or tenant-mode deployments that need non-default stamping should add either the flat KB-server keys above or the documented nested `knowledgeBase` shape; `VectorService` and `DatabaseService` support both.
- Harness restart is required only after a local gitignored `config.mjs` edit, because config modules are loaded once per MCP process.

Peer notification: direct-DM only per operator constraint while Gemini's harness is unstable; no `AGENT:*` broadcast.

## Deltas from ticket

- Added compatibility for both the current flat KB server config (`aiConfig.defaultTenantId`) and the documented future shared shape (`aiConfig.knowledgeBase.defaultTenantId`). This keeps #11631 aligned with Phase 0/1A docs while avoiding a broad config-shape migration inside this PR.
- Moved stale-ID deletion after the MCP work-volume gate when there are chunks to process. Tenant-aware IDs intentionally invalidate old raw-hash IDs; the gate must not delete old IDs and then refuse a large re-embed.
- Guarded `repoSlug` and `originAgentIdentity` alongside `tenantId` and `visibility`; they are part of the same write-side identity boundary.

## Test Evidence

Local:

```bash
npm run test-unit -- test/playwright/unit/ai/services/knowledge-base/VectorService.tenantStamping.spec.mjs test/playwright/unit/ai/services/knowledge-base/VectorService.WorkVolumeBranching.spec.mjs
# -> 11 passed (719ms)
```

Hygiene:

```bash
git diff --check
git diff --cached --check
# -> passed
```

Coverage summary:
- Default Neo chunks stamp `tenantId: 'neo-shared'`, `repoSlug: 'neo'`, `visibility: 'team'`.
- Server-derived tenant context overwrites client-supplied tenant/repo/visibility/origin fields and emits structured warnings.
- Reject mode fails before Chroma reads/writes with `KB_TENANT_SPOOF_REJECTED`.
- Same content under different tenants yields distinct 64-char Chroma IDs.
- `createContentHash()` includes tenant/repo identity.
- Existing work-volume branch coverage remains green after tenant-aware IDs.

## Post-Merge Validation

- [ ] Default `npm run ai:sync-kb` re-embeds Neo curated content under `tenantId: 'neo-shared'` and preserves effective query results.
- [ ] Tenant-mode operators that edit local `config.mjs` restart the KB MCP server after adding non-default tenant/repo/visibility/spoof policy keys.
- [ ] Phase 0/1D read-side filter (#11632) consumes the stamped `tenantId` / `visibility` fields and fails closed.

## Commits

- `28d3c187c` — `feat(kb): add write-side tenant stamping (#11631)`

## Signal Ledger (sourced from Discussion #11623)

Discussion #11623 is high-blast per its body (`Scope: high-blast`); `pull-request-workflow.md §6.1.1` Consensus-Gate applies.

- @neo-opus-4-7: APPROVED @ [DC_kwDODSospM4BAwVB](https://github.com/neomjs/neo/discussions/11623#discussioncomment-16975169) (author/lead)
- @neo-gpt: APPROVED @ [DC_kwDODSospM4BAwT7](https://github.com/neomjs/neo/discussions/11623#discussioncomment-16975099) -> tightening-extension @ [DC_kwDODSospM4BAwUo](https://github.com/neomjs/neo/discussions/11623#discussioncomment-16975149)
- @neo-gemini-3-1-pro: APPROVED @ [DC_kwDODSospM4BAwUa](https://github.com/neomjs/neo/discussions/11623#discussioncomment-16975130)

3/3 — Consensus Mandate satisfied. Graduated to Epic [#11624](https://github.com/neomjs/neo/issues/11624) on 2026-05-19; Discussion closed RESOLVED at 11:35:25Z.

## Unresolved Dissent

*(empty — positive signal; 3/3 APPROVED, no DEFERRED at convergence)*

## Unresolved Liveness

*(empty — positive signal; all 3 cross-family signals explicit despite Gemini harness instability)*

## Related

- Parent: [#11625](https://github.com/neomjs/neo/issues/11625) Phase 0/1 Epic
- Meta-Epic: [#11624](https://github.com/neomjs/neo/issues/11624) Cloud-Native KB Ingestion
- Source Discussion: [#11623](https://github.com/neomjs/neo/discussions/11623)
- Downstream: [#11632](https://github.com/neomjs/neo/issues/11632) Phase 0/1D read-side fail-closed filters
