### PR TITLE
feat(ai): configurable bundle retention via aiConfig.backupRetention (#11663)

### DIFF
--- a/ai/mcp/server/memory-core/config.template.mjs
+++ b/ai/mcp/server/memory-core/config.template.mjs
@@ -306,6 +306,18 @@ const defaultConfig = {
      */
     backupPath: path.resolve(cwd, '.neo-ai-data/backups'),
     /**
+     * Phase 4 (#11663): bundle retention policy for `buildScripts/ai/backup.mjs`.
+     * Bundles older than `maxDays` are eligible for deletion, but the newest
+     * `keepMinimum` bundles are retained unconditionally regardless of age.
+     * Defaults match the pre-#11663 hardcoded behavior (`K=3, N_DAYS=30`) so
+     * existing deployments are unaffected without operator action.
+     * @type {{keepMinimum: number, maxDays: number}}
+     */
+    backupRetention: {
+        keepMinimum: 3,
+        maxDays    : 30
+    },
+    /**
      * Directory for the always-on Memory Core diagnostic log files (#10582). The MC
      * server's `logger.mjs` writes daily-rotated entries here regardless of `debug`,
      * so long-running operations (summarization, ingestion sweeps, ChromaDB

--- a/buildScripts/ai/backup.mjs
+++ b/buildScripts/ai/backup.mjs
@@ -175,7 +175,12 @@ export async function runBackup({
     subsystems.mailbox = await copyJsonlSource(sentToCullSourceFile, layout.mailbox, logger);
 
     logger.log('[7/7] Applying retention sweep...');
-    await cleanOldBackups(DEFAULT_BACKUP_ROOT, logger);
+    // Phase 4 (#11663): operator-configurable retention via `mcConfig.backupRetention`.
+    // Falls through to the legacy hardcoded defaults (`K=3, N_DAYS=30`) when the config
+    // key is absent — pre-#11663 deployments retain identical behavior without operator
+    // action. The atomic-bundle architecture is preserved (per-substrate retention
+    // asymmetry deferred to a follow-up post-Phase-2 per #11628 framing).
+    await cleanOldBackups(DEFAULT_BACKUP_ROOT, logger, mcConfig.backupRetention);
 
     logger.log('Verifying bundle integrity (row-count parity)...');
     const integrity = await verifyBundleIntegrity(layout, subsystems);
@@ -329,27 +334,40 @@ async function buildVersionDescriptor(projectRoot, logger) {
 
 /**
  * Applies retention policy to the backup root.
- * Keeps the newest K=3 bundles unconditionally.
- * Deletes older bundles if they are older than N=30 days.
+ *
+ * Two-axis policy (per Phase 4 #11663):
+ *   - `keepMinimum` — newest N bundles retained unconditionally regardless of age
+ *   - `maxDays`     — bundles older than this many days are eligible for deletion
+ *
+ * A bundle survives if EITHER axis protects it (i.e., it's in the keepMinimum-newest
+ * window OR younger than maxDays). Both defaults match the pre-#11663 hardcoded
+ * constants (`K=3, N_DAYS=30`) so omitting the `retention` argument preserves the
+ * legacy behavior exactly.
+ *
  * @param {String} backupRoot
  * @param {Object} logger
+ * @param {Object} [retention]
+ * @param {Number} [retention.keepMinimum=3] Newest N bundles to retain unconditionally.
+ * @param {Number} [retention.maxDays=30]    Bundles older than this in days are eligible for deletion.
  */
-async function cleanOldBackups(backupRoot, logger) {
+export async function cleanOldBackups(backupRoot, logger, retention = {}) {
     if (!await fs.pathExists(backupRoot)) return;
 
+    const {keepMinimum = 3, maxDays = 30} = retention;
+
     const entries = await fs.readdir(backupRoot, { withFileTypes: true });
-    
+
     const backups = [];
     for (const entry of entries) {
         if (!entry.isDirectory() || !entry.name.startsWith('backup-')) continue;
-        
+
         const tsMatch = entry.name.match(/^backup-(.+)$/);
         if (!tsMatch) continue;
-        
+
         const rawTs = tsMatch[1];
         const isoTime = rawTs.replace(/T(\d{2})-(\d{2})-(\d{2})/, 'T$1:$2:$3');
         const date = new Date(isoTime);
-        
+
         if (!isNaN(date.getTime())) {
             backups.push({
                 name: entry.name,
@@ -362,13 +380,13 @@ async function cleanOldBackups(backupRoot, logger) {
 
     backups.sort((a, b) => b.time - a.time);
 
-    const K = 3;
-    const N_DAYS = 30;
+    const K = keepMinimum;
+    const N_DAYS = maxDays;
     const now = Date.now();
     const thresholdMs = N_DAYS * 24 * 60 * 60 * 1000;
 
     let deletedCount = 0;
-    
+
     for (let i = K; i < backups.length; i++) {
         const backup = backups[i];
         const ageMs = now - backup.time;
@@ -386,7 +404,7 @@ async function cleanOldBackups(backupRoot, logger) {
             }
         }
     }
-    
+
     if (deletedCount > 0) {
         logger.log(`[Retention] Removed ${deletedCount} old backup(s).`);
     }

--- a/test/playwright/unit/ai/buildScripts/backup-retention.spec.mjs
+++ b/test/playwright/unit/ai/buildScripts/backup-retention.spec.mjs
@@ -1,0 +1,209 @@
+import {setup} from '../../../setup.mjs';
+
+const appName = 'BackupRetentionTest';
+
+setup({
+    neoConfig: {
+        allowVdomUpdatesInTests: false,
+        unitTestMode           : true,
+        useDomApiRenderer      : false
+    },
+    appConfig: {
+        name             : appName,
+        isMounted        : () => true,
+        vnodeInitialising: false
+    }
+});
+
+import {test, expect} from '@playwright/test';
+import Neo            from '../../../../../src/Neo.mjs';
+import * as core      from '../../../../../src/core/_export.mjs';
+import fs             from 'fs-extra';
+import path           from 'path';
+
+/**
+ * Verifies the Phase 4 (#11663) configurable bundle retention policy in
+ * `buildScripts/ai/backup.mjs#cleanOldBackups`. Two-axis policy:
+ *   - `keepMinimum` — newest N bundles retained unconditionally
+ *   - `maxDays`     — bundles older than N days are eligible for deletion
+ *
+ * Default values (`K=3, N_DAYS=30`) match the pre-#11663 hardcoded constants
+ * (byte-equivalence anchor — pre-#11663 deployments without `backupRetention`
+ * config behave identically).
+ *
+ * @see https://github.com/neomjs/neo/issues/11663
+ */
+// Serial mode: this spec exercises a shared `cleanOldBackups` import + tmp filesystem
+// state. Running serially within the file avoids cross-test parallel-worker contention
+// for the imported module symbol and produces deterministic backup-directory mtime
+// ordering. CI uses workers=1 in playwright.config.unit.mjs; this is a local-DX safeguard.
+test.describe.configure({mode: 'serial'});
+
+test.describe('cleanOldBackups — configurable retention (#11663)', () => {
+    let cleanOldBackups;
+    let tmpRoot;
+    let mtimeNudge = 0;
+
+    test.beforeAll(async () => {
+        const mod = await import('../../../../../buildScripts/ai/backup.mjs');
+        cleanOldBackups = mod.cleanOldBackups;
+    });
+
+    test.beforeEach(async () => {
+        // Per-test fresh tmp root + unique offset to avoid cross-test interference
+        // when Playwright runs the file in parallel workers.
+        tmpRoot = path.resolve(process.cwd(), 'tmp', `backup-retention-${process.pid}-${Date.now()}-${++mtimeNudge}`);
+        await fs.ensureDir(tmpRoot);
+    });
+
+    test.afterEach(async () => {
+        if (tmpRoot && await fs.pathExists(tmpRoot)) {
+            await fs.remove(tmpRoot);
+        }
+    });
+
+    /**
+     * Synthetic backup-* directory creator. Encodes the simulated age in the directory
+     * timestamp so `cleanOldBackups`'s production regex parser recognizes it. The actual
+     * timestamp values are millisecond-unique (ageInDays accepts fractional days), which
+     * keeps directory names distinct under rapid-fire seeding.
+     */
+    async function seedBackup(ageInDays) {
+        const ts      = new Date(Date.now() - ageInDays * 86400000);
+        const isoTs   = ts.toISOString().replace(/:/g, '-');
+        const dirName = `backup-${isoTs}`;
+        const dirPath = path.join(tmpRoot, dirName);
+        await fs.ensureDir(dirPath);
+        await fs.writeFile(path.join(dirPath, 'placeholder'), 'test-marker');
+        return dirName;
+    }
+
+    async function listBackups() {
+        const entries = await fs.readdir(tmpRoot);
+        return entries.filter(name => name.startsWith('backup-'));
+    }
+
+    test('default config (K=3, N=30 days) matches pre-#11663 hardcoded behavior — byte-equivalence anchor', async () => {
+        // Seed 5 bundles spanning the retention thresholds:
+        //   1d, 10d, 25d, 40d, 60d old
+        // Pre-#11663 expected outcome: newest 3 (1d, 10d, 25d) retained unconditionally;
+        // 40d + 60d eligible for deletion (both > 30 days AND outside newest-3 window).
+        await seedBackup(1);
+        await seedBackup(10);
+        await seedBackup(25);
+        await seedBackup(40);
+        await seedBackup(60);
+
+        await cleanOldBackups(tmpRoot, {log: () => {}});
+
+        const remaining = await listBackups();
+        expect(remaining).toHaveLength(3);
+        // Survivor set = newest 3
+        for (const name of remaining) {
+            const match = name.match(/^backup-(.+?)(-suffix.*)?$/);
+            const isoTime = match[1].replace(/T(\d{2})-(\d{2})-(\d{2})/, 'T$1:$2:$3');
+            const ageDays = (Date.now() - new Date(isoTime).getTime()) / 86400000;
+            expect(ageDays).toBeLessThan(30);
+        }
+    });
+
+    test('explicit default config object {keepMinimum: 3, maxDays: 30} matches no-argument behavior', async () => {
+        await seedBackup(1);
+        await seedBackup(10);
+        await seedBackup(40);
+
+        await cleanOldBackups(tmpRoot, {log: () => {}}, {keepMinimum: 3, maxDays: 30});
+
+        const remaining = await listBackups();
+        // 3 backups, newest-3 floor protects all of them (40d would normally be eligible
+        // but keepMinimum=3 holds it).
+        expect(remaining).toHaveLength(3);
+    });
+
+    test('tighter config (K=1, N=7) deletes more aggressively', async () => {
+        // 5 bundles: 1d, 3d, 10d, 30d, 60d
+        // K=1 → newest 1 retained unconditionally (1d survives)
+        // N=7 → bundles >7d eligible for deletion (10d, 30d, 60d eligible)
+        // Final survivor set: 1d + 3d (3d retained because <7d, even though outside newest-1)
+        await seedBackup(1);
+        await seedBackup(3);
+        await seedBackup(10);
+        await seedBackup(30);
+        await seedBackup(60);
+
+        await cleanOldBackups(tmpRoot, {log: () => {}}, {keepMinimum: 1, maxDays: 7});
+
+        const remaining = await listBackups();
+        expect(remaining).toHaveLength(2);
+        for (const name of remaining) {
+            const match = name.match(/^backup-(.+)$/);
+            const isoTime = match[1].replace(/T(\d{2})-(\d{2})-(\d{2})/, 'T$1:$2:$3');
+            const ageDays = (Date.now() - new Date(isoTime).getTime()) / 86400000;
+            expect(ageDays).toBeLessThan(7.1);  // 7 + tiny epsilon for rounding
+        }
+    });
+
+    test('higher-cadence config (K=24, N=2) preserves rolling 24-hour history regardless of age threshold', async () => {
+        // Seed 30 bundles with sub-day-unique offsets — each call gets a distinct timestamp.
+        // Ages span 0.5d to 15d (positions 0-29 at ages 0.5, 1.0, 1.5, ..., 15.0d).
+        // K=24 → newest 24 retained unconditionally (ages 0.5d-12.0d).
+        // N=2 → bundles >2d eligible for deletion, but K=24 wins for the newest 24.
+        // Of the remaining 6 (positions 24-29, ages 12.5-15d), all >2d, all deleted.
+        // Expected final survivor count = 24.
+        for (let i = 0; i < 30; i++) {
+            await seedBackup(0.5 + i * 0.5);
+        }
+
+        await cleanOldBackups(tmpRoot, {log: () => {}}, {keepMinimum: 24, maxDays: 2});
+
+        const remaining = await listBackups();
+        expect(remaining).toHaveLength(24);
+    });
+
+    test('missing retention config (undefined) falls through to defaults — preserves zero-config deployments', async () => {
+        await seedBackup(1);
+        await seedBackup(40);
+        await seedBackup(60);
+
+        await cleanOldBackups(tmpRoot, {log: () => {}}, undefined);
+
+        const remaining = await listBackups();
+        // K=3 default — all 3 backups retained unconditionally despite 40d + 60d being >30d
+        expect(remaining).toHaveLength(3);
+    });
+
+    test('empty retention config object ({}) falls through to defaults', async () => {
+        await seedBackup(1);
+        await seedBackup(40);
+        await seedBackup(60);
+        await seedBackup(90);
+
+        await cleanOldBackups(tmpRoot, {log: () => {}}, {});
+
+        const remaining = await listBackups();
+        // K=3 default — newest 3 retained (1d, 40d, 60d); 90d eligible for deletion (outside K=3, >N=30d)
+        expect(remaining).toHaveLength(3);
+    });
+
+    test('keepMinimum floor protects even ancient bundles when bundle count is low', async () => {
+        // Single ancient bundle — keepMinimum=3 should retain it unconditionally
+        await seedBackup(365);
+
+        await cleanOldBackups(tmpRoot, {log: () => {}}, {keepMinimum: 3, maxDays: 30});
+
+        const remaining = await listBackups();
+        expect(remaining).toHaveLength(1);
+    });
+
+    test('keepMinimum=0 + maxDays=0 deletes everything older than now', async () => {
+        await seedBackup(0.001);  // ~86s old
+        await seedBackup(1);
+        await seedBackup(7);
+
+        await cleanOldBackups(tmpRoot, {log: () => {}}, {keepMinimum: 0, maxDays: 0});
+
+        const remaining = await listBackups();
+        // K=0 → no unconditional retention; N=0 → anything older than 0 days (any age) eligible
+        expect(remaining).toHaveLength(0);
+    });
+});


### PR DESCRIPTION
Resolves #11663

Authored by Claude Opus 4.7 (Claude Code). Session 7360e917-1733-4cdd-a6f3-5ac51c34b838.

FAIR-band: in-band [15/30] — operator nightshift-mode directive 2026-05-20 ~01:00Z: *"if parallel tracks are not possible, you 2 can pick up items from the todo and in progress tickets ... anti-pattern: wake-up message -> ack, nothing to do."* Parallel lane to @neo-gpt's #11631 (write-side tenant stamping in VectorService). Different files — `buildScripts/ai/backup.mjs` + `ai/mcp/server/memory-core/config.template.mjs` — zero merge collision risk.

Phase 4 sub-ticket of [#11628](https://github.com/neomjs/neo/issues/11628). Replaces the hardcoded `K=3, N_DAYS=30` constants in `cleanOldBackups()` with operator-configurable two-axis policy. The 2026-05-17 MC wipe recovery anchor underlines why the defaults matter — `K=3 + N=30` retained the 5/16 bundle that became the recovery source. This PR preserves that protective floor as the default while allowing operator tuning for tighter disk budgets, higher cadence, or recovery-critical scenarios.

Evidence: L2 (8 new unit tests covering default byte-equivalence anchor + tighter / higher-cadence / missing-config / empty-config / extreme-zero scenarios; existing 7 backup.spec tests pass as regression) → L2 required (retention policy is mechanically verifiable in unit-test scope; no runtime-only surfaces). No residuals.

## Config-Template Clone-Sync Guidance (per `mcp-config-template-change-guide.md`)

This PR changes `ai/mcp/server/memory-core/config.template.mjs`.

**Changed config keys:**
- `backupRetention: {keepMinimum: 3, maxDays: 30}` — new key with defaults matching pre-#11663 hardcoded constants.

**Local `config.mjs` follow-up:**
- **Zero-config default deployments:** no local action required. `cleanOldBackups()` falls through to default `{keepMinimum: 3, maxDays: 30}` when `mcConfig.backupRetention` is undefined — pre-existing clones keep behaving identically.
- **Cloud / tighter-budget deployments:** add `backupRetention` block to local `config.mjs` with override values. Examples:
  - Tight budget: `{keepMinimum: 1, maxDays: 7}`
  - High cadence (hourly backups): `{keepMinimum: 24, maxDays: 2}`
  - Recovery-critical: `{keepMinimum: 7, maxDays: 90}`
- **Harness restart:** required only when changing live `config.mjs` retention values. The next `npm run ai:backup` invocation reads the updated config.

**Peer A2A notification:** sent direct-DM per operator routing correction (Gemini harness unstable; no AGENT:* broadcast).

## Deltas from ticket (if any)

- **KB config not modified.** The ticket's Fix section proposed adding `backupRetention` to BOTH KB + MC config templates for discoverability. Discovered during impl that KB config has no backup-related keys (backup path + orchestration lives entirely in MC config). Adding to only MC keeps the contract local to the substrate that owns it — better than scattering the same key across two configs with a fallback chain. The ticket plan called for `mcConfig.backupRetention ?? kbConfig.backupRetention ?? defaults`; actual impl is just `mcConfig.backupRetention` with function-default fallback. Simpler, single source of truth.
- **`cleanOldBackups` exported.** The pre-#11663 function was module-private. Exporting it (required for the new spec to import + test directly) is a minor public-surface change, but a defensible one — the function is the canonical retention primitive that any future Phase 4 retention work will build on.

## Test Evidence

New spec: `test/playwright/unit/ai/buildScripts/backup-retention.spec.mjs` — **8 tests, 8 passed in 667ms**.

| # | Scenario | Verifies |
|---|---|---|
| 1 | Default config (no argument) | `cleanOldBackups(root, logger)` matches pre-#11663 `K=3, N=30` behavior exactly — byte-equivalence anchor |
| 2 | Explicit `{keepMinimum: 3, maxDays: 30}` | Equivalent to no-argument case |
| 3 | Tighter `{K=1, N=7}` | Deletes more aggressively while still respecting both axes |
| 4 | Higher-cadence `{K=24, N=2}` | Preserves rolling 24h history despite N=2 being below the dataset age range |
| 5 | `undefined` retention argument | Falls through to function-default `{K=3, N=30}` |
| 6 | Empty object `{}` retention argument | Falls through to function-default per parameter-destructuring |
| 7 | `keepMinimum` floor protects ancient bundles | Single 365-day-old bundle retained because K=3 floor active |
| 8 | `{K=0, N=0}` | Edge case — no unconditional retention, no age threshold, all bundles eligible for deletion |

Regression: `npm run test-unit -- test/playwright/unit/ai/buildScripts/backup.spec.mjs` → **7 passed in 791ms** (pre-existing tests; refactor preserves behavior).

## Post-Merge Validation

- [ ] Local `npm run ai:backup` invocation produces no behavior change under default config (smoke-test the retention sweep doesn't delete bundles it shouldn't) — operator post-merge verification.
- [ ] Setting `mcConfig.backupRetention = {keepMinimum: 1, maxDays: 7}` in local config.mjs correctly deletes bundles >7d old beyond newest-1 (tighter-config cloud-deployment smoke).
- [ ] No regression to the existing `.neo-ai-data/backups/` history retention behavior (manual operator check that the recovery-source 5/16 bundle is still present in the live deployment).

## Commits

- `34fc62877` — feat(ai): configurable bundle retention via aiConfig.backupRetention (#11663)