### PR TITLE
test(kb): expand service unit coverage (#11646)

### DIFF
--- a/test/playwright/unit/ai/services/knowledge-base/COVERAGE_AUDIT.md
+++ b/test/playwright/unit/ai/services/knowledge-base/COVERAGE_AUDIT.md
@@ -1,0 +1,28 @@
+# Knowledge Base Unit Coverage Audit (#11646)
+
+## Baseline
+
+Current branch baseline (`origin/dev` at branch creation):
+
+| Scope | Spec count |
+|---|---:|
+| `test/playwright/unit/ai/services/memory-core/**/*.spec.mjs` | 27 |
+| `test/playwright/unit/ai/services/knowledge-base/**/*.spec.mjs` | 14 |
+
+This branch adds 6 Knowledge Base service specs, moving the path-scoped count to 20.
+
+## Prioritization
+
+| Service | Existing coverage | Gap | Action |
+|---|---|---|---|
+| `DocumentService` | none | MCP-facing document list/get helpers lacked unit coverage | Added `DocumentService.spec.mjs` |
+| `ChromaManager` | canonical delete guard covered from MC manager suite | KB connection, cached collection, and connectivity projection lacked local KB coverage | Added `ChromaManager.spec.mjs` |
+| `DatabaseLifecycleService` | none | Unified-topology lifecycle facade lacked status/action coverage | Added `DatabaseLifecycleService.spec.mjs` |
+| `QueryService` | no direct KB query unit spec on `origin/dev` | Class hierarchy file behavior and query option construction are Phase 0/1D-sensitive surfaces | Added `QueryService.classHierarchy.spec.mjs` and `QueryService.queryDocuments.spec.mjs` |
+| `SearchService` | relative/absolute context hydration covered | API-key/model guard branch lacked explicit coverage | Added `SearchService.noModel.spec.mjs` |
+
+## Deferred
+
+- `VectorService` is actively covered by PR #11662 and avoided here to prevent branch coupling.
+- `source/*` path-config coverage is actively covered by PR #11661 and avoided here to prevent duplicate work.
+- Tenant read-side filter coverage belongs to #11632 / #11645 and should land with that implementation.

--- a/test/playwright/unit/ai/services/knowledge-base/ChromaManager.spec.mjs
+++ b/test/playwright/unit/ai/services/knowledge-base/ChromaManager.spec.mjs
@@ -1,0 +1,102 @@
+import {setup} from '../../../../setup.mjs';
+
+const appName = 'KBChromaManagerTest';
+
+setup({
+    neoConfig: {
+        unitTestMode: true
+    },
+    appConfig: {
+        name             : appName,
+        isMounted        : () => true,
+        vnodeInitialising: false
+    }
+});
+
+import {test, expect} from '@playwright/test';
+import Neo            from '../../../../../../src/Neo.mjs';
+import * as core      from '../../../../../../src/core/_export.mjs';
+
+test.describe('Neo.ai.services.knowledge-base.ChromaManager', () => {
+    let aiConfig;
+    let ChromaManager;
+    let originalClient;
+    let originalCollectionPromise;
+    let originalKnowledgeBaseCollection;
+
+    test.beforeAll(async () => {
+        aiConfig      = (await import('../../../../../../ai/mcp/server/knowledge-base/config.mjs')).default;
+        ChromaManager = (await import('../../../../../../ai/services/knowledge-base/ChromaManager.mjs')).default;
+
+        originalClient                  = ChromaManager.client;
+        originalCollectionPromise       = ChromaManager._knowledgeBaseCollectionPromise;
+        originalKnowledgeBaseCollection = ChromaManager.knowledgeBaseCollection;
+    });
+
+    test.beforeEach(() => {
+        ChromaManager._knowledgeBaseCollectionPromise = null;
+        ChromaManager.knowledgeBaseCollection         = null;
+    });
+
+    test.afterEach(() => {
+        ChromaManager.client                         = originalClient;
+        ChromaManager.connected                      = false;
+        ChromaManager._knowledgeBaseCollectionPromise = originalCollectionPromise;
+        ChromaManager.knowledgeBaseCollection        = originalKnowledgeBaseCollection;
+    });
+
+    test('connect marks the manager connected when heartbeat succeeds', async () => {
+        ChromaManager.client = {
+            heartbeat: async () => 123
+        };
+
+        await expect(ChromaManager.connect()).resolves.toBe(true);
+        expect(ChromaManager.connected).toBe(true);
+    });
+
+    test('connect marks the manager disconnected when heartbeat fails', async () => {
+        ChromaManager.client = {
+            heartbeat: async () => {
+                throw new Error('offline');
+            }
+        };
+
+        await expect(ChromaManager.connect()).resolves.toBe(false);
+        expect(ChromaManager.connected).toBe(false);
+    });
+
+    test('getKnowledgeBaseCollection creates and caches the configured collection', async () => {
+        let callCount = 0;
+        let capturedOptions;
+
+        ChromaManager.client = {
+            getOrCreateCollection: async options => {
+                callCount++;
+                capturedOptions = options;
+                return {name: options.name};
+            }
+        };
+
+        const first  = await ChromaManager.getKnowledgeBaseCollection();
+        const second = await ChromaManager.getKnowledgeBaseCollection();
+
+        expect(callCount).toBe(1);
+        expect(first).toBe(second);
+        expect(capturedOptions).toEqual({
+            name             : aiConfig.collectionName,
+            embeddingFunction: aiConfig.dummyEmbeddingFunction
+        });
+    });
+
+    test('checkConnectivity returns heartbeat and cached collection name', async () => {
+        ChromaManager.client = {
+            heartbeat: async () => 456,
+            getOrCreateCollection: async () => ({name: 'knowledge-base-test'})
+        };
+
+        await expect(ChromaManager.checkConnectivity()).resolves.toEqual({
+            heartbeat              : 456,
+            knowledgeBaseCollection: 'knowledge-base-test'
+        });
+    });
+});

--- a/test/playwright/unit/ai/services/knowledge-base/DatabaseLifecycleService.spec.mjs
+++ b/test/playwright/unit/ai/services/knowledge-base/DatabaseLifecycleService.spec.mjs
@@ -1,0 +1,119 @@
+import {setup} from '../../../../setup.mjs';
+
+const appName = 'KBDatabaseLifecycleServiceTest';
+
+setup({
+    neoConfig: {
+        unitTestMode: true
+    },
+    appConfig: {
+        name             : appName,
+        isMounted        : () => true,
+        vnodeInitialising: false
+    }
+});
+
+import {test, expect} from '@playwright/test';
+import Neo            from '../../../../../../src/Neo.mjs';
+import * as core      from '../../../../../../src/core/_export.mjs';
+
+test.describe('Neo.ai.services.knowledge-base.DatabaseLifecycleService', () => {
+    let DatabaseLifecycleService;
+    let originalFire;
+    let originalIsDbRunning;
+    let originalWaitForHeartbeat;
+
+    test.beforeAll(async () => {
+        DatabaseLifecycleService = (await import('../../../../../../ai/services/knowledge-base/DatabaseLifecycleService.mjs')).default;
+
+        originalFire             = DatabaseLifecycleService.fire;
+        originalIsDbRunning      = DatabaseLifecycleService.isDbRunning;
+        originalWaitForHeartbeat = DatabaseLifecycleService.waitForHeartbeat;
+    });
+
+    test.afterEach(() => {
+        DatabaseLifecycleService.fire             = originalFire;
+        DatabaseLifecycleService.isDbRunning      = originalIsDbRunning;
+        DatabaseLifecycleService.waitForHeartbeat = originalWaitForHeartbeat;
+    });
+
+    test('manageDatabase dispatches start and stop actions', async () => {
+        DatabaseLifecycleService.isDbRunning = async () => true;
+
+        await expect(DatabaseLifecycleService.manageDatabase({action: 'start'}))
+            .resolves.toEqual({
+                status: 'already_running',
+                pid   : null,
+                detail: 'Server is managed by AgentOrchestrator.'
+            });
+
+        await expect(DatabaseLifecycleService.manageDatabase({action: 'stop'}))
+            .resolves.toEqual({
+                status: 'not_running',
+                detail: 'Knowledge Base does not manage the ChromaDB daemon.'
+            });
+    });
+
+    test('manageDatabase rejects unsupported actions', async () => {
+        await expect(DatabaseLifecycleService.manageDatabase({action: 'restart'}))
+            .rejects.toThrow("Invalid action: restart. Must be 'start' or 'stop'.");
+    });
+
+    test('startDatabase reports already_running when Chroma heartbeat is reachable', async () => {
+        const events = [];
+
+        DatabaseLifecycleService.fire        = (name, payload) => events.push({name, payload});
+        DatabaseLifecycleService.isDbRunning = async () => true;
+
+        const result = await DatabaseLifecycleService.startDatabase();
+
+        expect(result).toEqual({
+            status: 'already_running',
+            pid   : null,
+            detail: 'Server is managed by AgentOrchestrator.'
+        });
+        expect(events).toEqual([{
+            name   : 'processActive',
+            payload: {
+                pid             : null,
+                managedByService: false,
+                detail          : 'Server is managed by AgentOrchestrator.'
+            }
+        }]);
+    });
+
+    test('startDatabase waits for the externally managed daemon when heartbeat is initially absent', async () => {
+        const events = [];
+        let waited = false;
+
+        DatabaseLifecycleService.fire             = (name, payload) => events.push({name, payload});
+        DatabaseLifecycleService.isDbRunning      = async () => false;
+        DatabaseLifecycleService.waitForHeartbeat = async () => {
+            waited = true;
+        };
+
+        const result = await DatabaseLifecycleService.startDatabase();
+
+        expect(waited).toBe(true);
+        expect(result).toEqual({
+            status: 'started_externally',
+            pid   : null
+        });
+        expect(events).toEqual([{
+            name   : 'processActive',
+            payload: {
+                pid             : null,
+                managedByService: false,
+                detail          : 'started externally'
+            }
+        }]);
+    });
+
+    test('getDatabaseStatus exposes observability-only unified topology state', () => {
+        expect(DatabaseLifecycleService.getDatabaseStatus()).toEqual({
+            running: false,
+            pid    : null,
+            managed: false
+        });
+    });
+});

--- a/test/playwright/unit/ai/services/knowledge-base/DocumentService.spec.mjs
+++ b/test/playwright/unit/ai/services/knowledge-base/DocumentService.spec.mjs
@@ -1,0 +1,107 @@
+import {setup} from '../../../../setup.mjs';
+
+const appName = 'KBDocumentServiceTest';
+
+setup({
+    neoConfig: {
+        unitTestMode: true
+    },
+    appConfig: {
+        name             : appName,
+        isMounted        : () => true,
+        vnodeInitialising: false
+    }
+});
+
+import {test, expect} from '@playwright/test';
+import Neo            from '../../../../../../src/Neo.mjs';
+import * as core      from '../../../../../../src/core/_export.mjs';
+
+test.describe('Neo.ai.services.knowledge-base.DocumentService', () => {
+    let ChromaManager;
+    let DocumentService;
+    let originalGetKnowledgeBaseCollection;
+
+    test.beforeAll(async () => {
+        ChromaManager   = (await import('../../../../../../ai/services/knowledge-base/ChromaManager.mjs')).default;
+        DocumentService = (await import('../../../../../../ai/services/knowledge-base/DocumentService.mjs')).default;
+
+        originalGetKnowledgeBaseCollection = ChromaManager.getKnowledgeBaseCollection;
+    });
+
+    test.afterEach(() => {
+        ChromaManager.getKnowledgeBaseCollection = originalGetKnowledgeBaseCollection;
+    });
+
+    test('listDocuments maps Chroma ids, metadatas, and documents into MCP payload rows', async () => {
+        let capturedOptions;
+
+        ChromaManager.getKnowledgeBaseCollection = async () => ({
+            get: async options => {
+                capturedOptions = options;
+
+                return {
+                    ids      : ['doc-1', 'doc-2'],
+                    metadatas: [{type: 'guide'}, {type: 'src'}],
+                    documents: ['Guide body', 'Source body']
+                };
+            }
+        });
+
+        const result = await DocumentService.listDocuments({limit: 2, offset: 5});
+
+        expect(capturedOptions).toEqual({
+            limit  : 2,
+            offset : 5,
+            include: ['metadatas', 'documents']
+        });
+        expect(result).toEqual({
+            count    : 2,
+            documents: [
+                {id: 'doc-1', metadata: {type: 'guide'}, content: 'Guide body'},
+                {id: 'doc-2', metadata: {type: 'src'}, content: 'Source body'}
+            ]
+        });
+    });
+
+    test('getDocumentById returns the first matching Chroma record', async () => {
+        let capturedOptions;
+
+        ChromaManager.getKnowledgeBaseCollection = async () => ({
+            get: async options => {
+                capturedOptions = options;
+
+                return {
+                    ids      : ['doc-42'],
+                    metadatas: [{source: 'learn/agentos/KnowledgeBase.md'}],
+                    documents: ['Knowledge Base guide']
+                };
+            }
+        });
+
+        const result = await DocumentService.getDocumentById({id: 'doc-42'});
+
+        expect(capturedOptions).toEqual({
+            ids    : ['doc-42'],
+            include: ['metadatas', 'documents']
+        });
+        expect(result).toEqual({
+            id      : 'doc-42',
+            metadata: {source: 'learn/agentos/KnowledgeBase.md'},
+            content : 'Knowledge Base guide'
+        });
+    });
+
+    test('getDocumentById throws a precise not-found error for empty Chroma results', async () => {
+        ChromaManager.getKnowledgeBaseCollection = async () => ({
+            get: async () => ({
+                ids      : [],
+                metadatas: [],
+                documents: []
+            })
+        });
+
+        await expect(DocumentService.getDocumentById({id: 'missing-doc'}))
+            .rejects.toThrow("Document with id 'missing-doc' not found.");
+    });
+});

--- a/test/playwright/unit/ai/services/knowledge-base/QueryService.classHierarchy.spec.mjs
+++ b/test/playwright/unit/ai/services/knowledge-base/QueryService.classHierarchy.spec.mjs
@@ -1,0 +1,98 @@
+import {setup} from '../../../../setup.mjs';
+
+const appName = 'KBQueryServiceClassHierarchyTest';
+
+setup({
+    neoConfig: {
+        unitTestMode: true
+    },
+    appConfig: {
+        name             : appName,
+        isMounted        : () => true,
+        vnodeInitialising: false
+    }
+});
+
+import {test, expect} from '@playwright/test';
+import Neo            from '../../../../../../src/Neo.mjs';
+import * as core      from '../../../../../../src/core/_export.mjs';
+import fs             from 'fs-extra';
+import path           from 'path';
+
+test.describe('Neo.ai.services.knowledge-base.QueryService#getClassHierarchy', () => {
+    let aiConfig;
+    let QueryService;
+    let originalHierarchyPath;
+    let tmpHierarchyPath;
+
+    test.beforeAll(async () => {
+        aiConfig      = (await import('../../../../../../ai/mcp/server/knowledge-base/config.mjs')).default;
+        QueryService  = (await import('../../../../../../ai/services/knowledge-base/QueryService.mjs')).default;
+
+        originalHierarchyPath = aiConfig.hierarchyPath;
+        tmpHierarchyPath      = path.resolve(process.cwd(), 'tmp', `kb-hierarchy-${process.pid}-${Date.now()}.json`);
+        await fs.ensureDir(path.dirname(tmpHierarchyPath));
+    });
+
+    test.afterEach(async () => {
+        aiConfig.hierarchyPath = originalHierarchyPath;
+        await fs.remove(tmpHierarchyPath).catch(() => {});
+    });
+
+    test('requires a root to protect callers from excessive hierarchy payloads', async () => {
+        await expect(QueryService.getClassHierarchy())
+            .rejects.toThrow('The "root" parameter is required to prevent excessive context payload.');
+    });
+
+    test('throws a sync guidance error when the hierarchy file is absent', async () => {
+        aiConfig.hierarchyPath = tmpHierarchyPath;
+
+        await expect(QueryService.getClassHierarchy({root: 'Neo.component.Base'}))
+            .rejects.toThrow('Class hierarchy file not found. Please sync the knowledge base first.');
+    });
+
+    test('returns the requested root and all recursive descendants', async () => {
+        aiConfig.hierarchyPath = tmpHierarchyPath;
+        await fs.writeJson(tmpHierarchyPath, {
+            'Neo.component.Base'  : 'Neo.core.Base',
+            'Neo.button.Base'     : 'Neo.component.Base',
+            'Neo.form.field.Text' : 'Neo.component.Base',
+            'Neo.form.field.Email': 'Neo.form.field.Text',
+            'Neo.grid.Base'       : 'Neo.component.Base',
+            'Neo.data.Store'      : 'Neo.core.Base'
+        });
+
+        await expect(QueryService.getClassHierarchy({root: 'Neo.component.Base'}))
+            .resolves.toEqual({
+                'Neo.component.Base'  : 'Neo.core.Base',
+                'Neo.button.Base'     : 'Neo.component.Base',
+                'Neo.form.field.Text' : 'Neo.component.Base',
+                'Neo.grid.Base'       : 'Neo.component.Base',
+                'Neo.form.field.Email': 'Neo.form.field.Text'
+            });
+    });
+
+    test('reports a known leaf root with no subclasses without expanding payload', async () => {
+        aiConfig.hierarchyPath = tmpHierarchyPath;
+        await fs.writeJson(tmpHierarchyPath, {
+            'Neo.core.Base': null
+        });
+
+        await expect(QueryService.getClassHierarchy({root: 'Neo.core.Base'}))
+            .resolves.toEqual({
+                'Neo.core.Base': null
+            });
+    });
+
+    test('reports an unknown root without leaking the whole hierarchy', async () => {
+        aiConfig.hierarchyPath = tmpHierarchyPath;
+        await fs.writeJson(tmpHierarchyPath, {
+            'Neo.component.Base': 'Neo.core.Base'
+        });
+
+        await expect(QueryService.getClassHierarchy({root: 'Neo.unknown.Missing'}))
+            .resolves.toEqual({
+                message: "Class 'Neo.unknown.Missing' found in hierarchy, but it has no subclasses or entry."
+            });
+    });
+});

--- a/test/playwright/unit/ai/services/knowledge-base/QueryService.queryDocuments.spec.mjs
+++ b/test/playwright/unit/ai/services/knowledge-base/QueryService.queryDocuments.spec.mjs
@@ -1,0 +1,127 @@
+import {setup} from '../../../../setup.mjs';
+
+const appName = 'KBQueryServiceDocumentsTest';
+
+setup({
+    neoConfig: {
+        unitTestMode: true
+    },
+    appConfig: {
+        name             : appName,
+        isMounted        : () => true,
+        vnodeInitialising: false
+    }
+});
+
+import {test, expect} from '@playwright/test';
+import Neo            from '../../../../../../src/Neo.mjs';
+import * as core      from '../../../../../../src/core/_export.mjs';
+
+test.describe('Neo.ai.services.knowledge-base.QueryService#queryDocuments', () => {
+    let ChromaManager;
+    let QueryService;
+    let TextEmbeddingService;
+    let originalEmbedText;
+    let originalGetKnowledgeBaseCollection;
+
+    test.beforeAll(async () => {
+        ChromaManager        = (await import('../../../../../../ai/services/knowledge-base/ChromaManager.mjs')).default;
+        QueryService         = (await import('../../../../../../ai/services/knowledge-base/QueryService.mjs')).default;
+        TextEmbeddingService = (await import('../../../../../../ai/services/memory-core/TextEmbeddingService.mjs')).default;
+
+        originalEmbedText                  = TextEmbeddingService.embedText;
+        originalGetKnowledgeBaseCollection = ChromaManager.getKnowledgeBaseCollection;
+    });
+
+    test.afterEach(() => {
+        TextEmbeddingService.embedText        = originalEmbedText;
+        ChromaManager.getKnowledgeBaseCollection = originalGetKnowledgeBaseCollection;
+    });
+
+    function installQueryStub(metadatas, capture) {
+        TextEmbeddingService.embedText = async () => [0.1, 0.2, 0.3];
+
+        ChromaManager.getKnowledgeBaseCollection = async () => ({
+            query: async options => {
+                capture.options = options;
+
+                return {
+                    metadatas: [metadatas]
+                };
+            }
+        });
+    }
+
+    test('requires a query string before calling embedding or Chroma services', async () => {
+        await expect(QueryService.queryDocuments({query: ''}))
+            .rejects.toThrow('A query string must be provided.');
+    });
+
+    test('passes a type where-clause to Chroma for typed searches', async () => {
+        const capture = {};
+        installQueryStub([{
+            source          : 'learn/guides/testing/UnitTesting.md',
+            type            : 'guide',
+            name            : 'UnitTesting',
+            inheritanceChain: '[]'
+        }], capture);
+
+        const result = await QueryService.queryDocuments({
+            query: 'unit testing',
+            type : 'guide',
+            limit: 5
+        });
+
+        expect(capture.options.queryEmbeddings).toEqual([[0.1, 0.2, 0.3]]);
+        expect(capture.options.where).toEqual({type: 'guide'});
+        expect(result.topResult).toBe('learn/guides/testing/UnitTesting.md');
+        expect(result.results).toHaveLength(1);
+    });
+
+    test('omits where when type is all', async () => {
+        const capture = {};
+        installQueryStub([{
+            source          : 'src/component/Base.mjs',
+            type            : 'src',
+            name            : 'Neo.component.Base',
+            className       : 'Neo.component.Base',
+            inheritanceChain: '[]'
+        }], capture);
+
+        await QueryService.queryDocuments({
+            query: 'component base',
+            type : 'all',
+            limit: 5
+        });
+
+        expect(Object.hasOwn(capture.options, 'where')).toBe(false);
+    });
+
+    test('returns the no-results message when Chroma returns an empty metadata payload', async () => {
+        const capture = {};
+        installQueryStub([], capture);
+
+        await expect(QueryService.queryDocuments({query: 'missing', type: 'all'}))
+            .resolves.toEqual({message: 'No results found for your query and type.'});
+    });
+
+    test('boosts inheritance parent sources into the ranked result set', async () => {
+        const capture = {};
+        installQueryStub([{
+            source          : 'src/button/Base.mjs',
+            type            : 'src',
+            name            : 'Neo.button.Base',
+            className       : 'Neo.button.Base',
+            inheritanceChain: JSON.stringify([{source: 'src/component/Base.mjs'}])
+        }], capture);
+
+        const result = await QueryService.queryDocuments({
+            query: 'button component',
+            type : 'src',
+            limit: 5
+        });
+
+        expect(result.results.map(item => item.source)).toContain('src/button/Base.mjs');
+        expect(result.results.map(item => item.source)).toContain('src/component/Base.mjs');
+    });
+});

--- a/test/playwright/unit/ai/services/knowledge-base/SearchService.noModel.spec.mjs
+++ b/test/playwright/unit/ai/services/knowledge-base/SearchService.noModel.spec.mjs
@@ -1,0 +1,39 @@
+import {setup} from '../../../../setup.mjs';
+
+const appName = 'KBSearchServiceNoModelTest';
+
+setup({
+    neoConfig: {
+        unitTestMode: true
+    },
+    appConfig: {
+        name             : appName,
+        isMounted        : () => true,
+        vnodeInitialising: false
+    }
+});
+
+import {test, expect} from '@playwright/test';
+import Neo            from '../../../../../../src/Neo.mjs';
+import * as core      from '../../../../../../src/core/_export.mjs';
+
+test.describe('Neo.ai.services.knowledge-base.SearchService model guard', () => {
+    let SearchService;
+    let originalModel;
+
+    test.beforeAll(async () => {
+        SearchService = (await import('../../../../../../ai/services/knowledge-base/SearchService.mjs')).default;
+        originalModel = SearchService.model;
+    });
+
+    test.afterEach(() => {
+        SearchService.model = originalModel;
+    });
+
+    test('ask fails fast when no Gemini model is configured', async () => {
+        SearchService.model = null;
+
+        await expect(SearchService.ask({query: 'How does KB work?'}))
+            .rejects.toThrow('GEMINI_API_KEY is required for RAG features.');
+    });
+});


### PR DESCRIPTION
Resolves #11646

Related: #11643
Related: #11624

Authored by GPT-5.5 (Codex Desktop). Session 021172f9-cf8a-4762-917f-95bdf261ad23.

FAIR-band: in-band [13/30 - current author count over last 30 merged]

Phase 5C of Epic #11624 expands Knowledge Base unit-test coverage toward Memory Core parity. The change adds focused service-level coverage for DocumentService, ChromaManager, DatabaseLifecycleService, QueryService class-hierarchy/query paths, and the SearchService missing-model guard, plus a coverage audit that records the current KB-vs-MC parity delta.

Evidence: L2 (91-test KB service unit slice, including 23 newly added assertions) -> L2 required (unit-test coverage expansion). No residuals.

## Deltas from Ticket

- Current `origin/dev` baseline observed during intake: Memory Core path-scoped service specs = 27; Knowledge Base path-scoped service specs = 14. This differed from the ticket's earlier parity snapshot, so the audit records the live baseline instead of copying stale counts.
- This branch adds 6 KB service spec files plus one coverage audit, moving the path-scoped KB service spec count from 14 to 20.
- The lane intentionally avoids colliding with parallel Phase 0/1 work:
  - VectorService tenant/write-side surfaces are covered by #11662.
  - Source path config/registry surfaces are covered by #11661.
  - Tenant read-side filter work is owned by #11632/#11645.

## Coverage Added

- `DocumentService.spec.mjs`: list-document row mapping, single-record lookup, and precise not-found behavior.
- `ChromaManager.spec.mjs`: heartbeat success/failure, cached collection creation, and connectivity reporting.
- `DatabaseLifecycleService.spec.mjs`: managed start/stop dispatch, invalid action rejection, already-running Chroma path, external-daemon wait path, and status observability.
- `QueryService.classHierarchy.spec.mjs`: root guard, missing hierarchy-file guidance, recursive subtree expansion, known leaf, and unknown-root behavior.
- `QueryService.queryDocuments.spec.mjs`: query validation, typed `where` filters, `all` behavior, empty-result messaging, and inheritance-parent source boosting.
- `SearchService.noModel.spec.mjs`: explicit failure when no Gemini model / API key is configured.

## Test Evidence

- `git diff --cached --check` -> passed before commit.
- `npm run test-unit -- test/playwright/unit/ai/services/knowledge-base/DocumentService.spec.mjs test/playwright/unit/ai/services/knowledge-base/ChromaManager.spec.mjs test/playwright/unit/ai/services/knowledge-base/DatabaseLifecycleService.spec.mjs test/playwright/unit/ai/services/knowledge-base/QueryService.classHierarchy.spec.mjs test/playwright/unit/ai/services/knowledge-base/QueryService.queryDocuments.spec.mjs test/playwright/unit/ai/services/knowledge-base/SearchService.noModel.spec.mjs` -> 23 passed.
- `npm run test-unit -- test/playwright/unit/ai/services/knowledge-base` -> 91 passed.

## Post-Merge Validation

- [ ] Re-run `npm run test-unit -- test/playwright/unit/ai/services/knowledge-base` after the sibling Phase 0/1B/1C PRs land, to confirm the expanded coverage slice remains green on the merged substrate.
- [ ] Use this audit as the next Phase 5 count baseline before adding higher-level integration parity coverage.

## Commit

- `8d216dc2f` - `test(kb): expand service unit coverage (#11646)`
