### PR TITLE
feat(ai): KB ingestion telemetry schema + recordIngestionMetric API (#11639)

### DIFF
--- a/ai/services/knowledge-base/KBRecorderService.mjs
+++ b/ai/services/knowledge-base/KBRecorderService.mjs
@@ -105,6 +105,24 @@ class KBRecorderService extends Base {
                 CREATE INDEX IF NOT EXISTS idx_kb_query_faqs_count     ON kb_query_faqs(occurrence_count);
                 CREATE INDEX IF NOT EXISTS idx_kb_query_faqs_last_seen ON kb_query_faqs(last_seen);
                 CREATE INDEX IF NOT EXISTS idx_kb_query_faqs_coverage  ON kb_query_faqs(has_strong_guide_coverage);
+
+                CREATE TABLE IF NOT EXISTS kb_ingestion_metrics (
+                    id              TEXT PRIMARY KEY,
+                    timestamp       INTEGER NOT NULL,
+                    tenant_id       TEXT NOT NULL,
+                    repo_slug       TEXT NOT NULL,
+                    origin_agent    TEXT,
+                    event_type      TEXT NOT NULL,
+                    chunks_total    INTEGER DEFAULT 0,
+                    chunks_embedded INTEGER DEFAULT 0,
+                    chunks_deleted  INTEGER DEFAULT 0,
+                    duration_ms     INTEGER,
+                    error_code      TEXT,
+                    detail          TEXT
+                );
+                CREATE INDEX IF NOT EXISTS idx_kb_ingestion_metrics_tenant    ON kb_ingestion_metrics(tenant_id);
+                CREATE INDEX IF NOT EXISTS idx_kb_ingestion_metrics_timestamp ON kb_ingestion_metrics(timestamp);
+                CREATE INDEX IF NOT EXISTS idx_kb_ingestion_metrics_event     ON kb_ingestion_metrics(event_type);
             `);
 
             logger.info('[KBRecorderService] Connected to Memory Core kb_query_log / kb_query_faqs.');
@@ -227,6 +245,138 @@ class KBRecorderService extends Base {
             );
         } catch (err) {
             logger.error('[KBRecorderService] Failed to append KB query log entry:', err);
+        }
+    }
+
+    /**
+     * @summary Persists a per-tenant ingestion telemetry event into `kb_ingestion_metrics`.
+     *
+     * Phase 4A (#11665) write-API. This is the durable contract the Phase 2 cross-tenant
+     * ingestion service (#11626) calls after each push / tombstone / reconcile / error event.
+     * Like {@link log}, persistence is a best-effort observability side channel — it never
+     * throws back into the ingestion path, preserving ingestion availability even when the
+     * telemetry store is unavailable or temporarily locked.
+     *
+     * Per-tenant rollup consumers (Phase 4A-β observability daemon, Phase 4D alerting) read
+     * via {@link getTenantIngestionRollup}. The schema is intentionally event-shaped (one row
+     * per ingestion event) rather than pre-aggregated — rollup is the daemon's job, keeping
+     * this write path O(1) and contention-free.
+     *
+     * @param {Object}  entry
+     * @param {String}  entry.tenantId        Authoritative tenant id (server-stamped, per #11631).
+     * @param {String}  entry.repoSlug        Authoritative repo slug.
+     * @param {String} [entry.originAgentIdentity] Authenticated agent identity that triggered the event.
+     * @param {String}  entry.eventType       One of `'ingest'`, `'tombstone'`, `'reconcile'`, `'error'`.
+     * @param {Number} [entry.chunksTotal=0]    Chunks seen in the event payload.
+     * @param {Number} [entry.chunksEmbedded=0] Chunks newly embedded.
+     * @param {Number} [entry.chunksDeleted=0]  Chunks deleted (tombstone / stale-id sweep).
+     * @param {Number} [entry.durationMs]       Event wall-clock duration.
+     * @param {String} [entry.errorCode]        Stable error code when `eventType === 'error'`.
+     * @param {Object} [entry.detail]           Free-form per-event detail (JSON-serialized).
+     * @param {Number} [entry.timestamp]        Event timestamp; defaults to `Date.now()`.
+     * @returns {void}
+     */
+    recordIngestionMetric(entry = {}) {
+        if (!this.db) return;
+
+        try {
+            const
+                timestamp = entry.timestamp || Date.now(),
+                tenantId  = entry.tenantId || 'neo-shared',
+                repoSlug  = entry.repoSlug || 'neo',
+                eventType = entry.eventType || 'ingest',
+                detail    = entry.detail == null ? null : this.safeStringify(entry.detail);
+
+            this.db.prepare(`
+                INSERT INTO kb_ingestion_metrics (
+                    id, timestamp, tenant_id, repo_slug, origin_agent,
+                    event_type, chunks_total, chunks_embedded, chunks_deleted,
+                    duration_ms, error_code, detail
+                ) VALUES (
+                    ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?
+                )
+            `).run(
+                crypto.randomUUID(),
+                timestamp,
+                tenantId,
+                repoSlug,
+                entry.originAgentIdentity || null,
+                eventType,
+                entry.chunksTotal    ?? 0,
+                entry.chunksEmbedded ?? 0,
+                entry.chunksDeleted  ?? 0,
+                entry.durationMs     ?? null,
+                entry.errorCode      || null,
+                detail
+            );
+        } catch (err) {
+            logger.error('[KBRecorderService] Failed to append KB ingestion metric:', err);
+        }
+    }
+
+    /**
+     * @summary Rolls up `kb_ingestion_metrics` rows into per-tenant aggregate counters.
+     *
+     * Phase 4A (#11665) read-API. Consumed by the Phase 4A-β observability daemon (rollup +
+     * persist) and Phase 4D alerting (threshold checks). Returns one aggregate row per tenant
+     * for events within the `sinceMs` window — push/tombstone/reconcile/error event counts,
+     * total chunk volumes, and error rate.
+     *
+     * @param {Object}  [options]
+     * @param {Number}  [options.sinceMs]   Lower-bound timestamp; only events at-or-after are counted. Omit for all-time.
+     * @param {String}  [options.tenantId]  Restrict the rollup to a single tenant. Omit for all tenants.
+     * @returns {Array<{tenantId: String, repoSlug: String, eventCount: Number, ingestEvents: Number, tombstoneEvents: Number, reconcileEvents: Number, errorEvents: Number, chunksEmbedded: Number, chunksDeleted: Number, errorRate: Number}>}
+     */
+    getTenantIngestionRollup({sinceMs, tenantId} = {}) {
+        if (!this.db) return [];
+
+        try {
+            const conditions = [];
+            const params     = [];
+
+            if (Number.isFinite(sinceMs)) {
+                conditions.push('timestamp >= ?');
+                params.push(sinceMs);
+            }
+            if (tenantId) {
+                conditions.push('tenant_id = ?');
+                params.push(tenantId);
+            }
+
+            const whereClause = conditions.length > 0 ? `WHERE ${conditions.join(' AND ')}` : '';
+
+            const rows = this.db.prepare(`
+                SELECT
+                    tenant_id,
+                    repo_slug,
+                    COUNT(*)                                                      AS event_count,
+                    SUM(CASE WHEN event_type = 'ingest'    THEN 1 ELSE 0 END)      AS ingest_events,
+                    SUM(CASE WHEN event_type = 'tombstone' THEN 1 ELSE 0 END)      AS tombstone_events,
+                    SUM(CASE WHEN event_type = 'reconcile' THEN 1 ELSE 0 END)      AS reconcile_events,
+                    SUM(CASE WHEN event_type = 'error'     THEN 1 ELSE 0 END)      AS error_events,
+                    SUM(chunks_embedded)                                          AS chunks_embedded,
+                    SUM(chunks_deleted)                                           AS chunks_deleted
+                FROM kb_ingestion_metrics
+                ${whereClause}
+                GROUP BY tenant_id, repo_slug
+                ORDER BY tenant_id, repo_slug
+            `).all(...params);
+
+            return rows.map(row => ({
+                tenantId       : row.tenant_id,
+                repoSlug       : row.repo_slug,
+                eventCount     : row.event_count,
+                ingestEvents   : row.ingest_events,
+                tombstoneEvents: row.tombstone_events,
+                reconcileEvents: row.reconcile_events,
+                errorEvents    : row.error_events,
+                chunksEmbedded : row.chunks_embedded ?? 0,
+                chunksDeleted  : row.chunks_deleted  ?? 0,
+                errorRate      : row.event_count > 0 ? row.error_events / row.event_count : 0
+            }));
+        } catch (err) {
+            logger.error('[KBRecorderService] Failed to roll up KB ingestion metrics:', err);
+            return [];
         }
     }
 

--- a/learn/agentos/decisions/0013-kb-ingestion-telemetry-schema.md
+++ b/learn/agentos/decisions/0013-kb-ingestion-telemetry-schema.md
@@ -1,14 +1,14 @@
 # ADR 0013: KB Ingestion Telemetry Schema — Event-Shaped `kb_ingestion_metrics` Table
 
-> Architectural Decision Record codifying the per-tenant ingestion-telemetry persistence contract introduced by Phase 4A (#11665) of the Cloud-Native KB Ingestion epic (#11624). Authority artifact for the `kb_ingestion_metrics` table shape that the Phase 2 ingestion service (#11626) writes against and the Phase 4A-β observability daemon + Phase 4D alerting consume. Implementation companion is the PR for #11665's schema slice (`Related: #11665` — the ticket stays open for the Phase 4A-β daemon slice, per §3.4); this ADR is the graph-queryable WHY for the event-shaped (vs pre-aggregated) schema choice.
+> Architectural Decision Record codifying the per-tenant ingestion-telemetry persistence contract introduced by Phase 4A (#11639) of the Cloud-Native KB Ingestion epic (#11624). Authority artifact for the `kb_ingestion_metrics` table shape that the Phase 2 ingestion service (#11626) writes against and the Phase 4A-β observability daemon + Phase 4D alerting consume. Implementation companion is the PR for #11639's schema slice (`Related: #11639` — the ticket stays open for the Phase 4A-β daemon slice, per §3.4); this ADR is the graph-queryable WHY for the event-shaped (vs pre-aggregated) schema choice.
 
 | Attribute | Value |
 |---|---|
-| **Status** | Proposed — 2026-05-20 (awaiting #11665 PR merge to establish empirical substrate before transition to Accepted, per ADR 0005 lifecycle) |
-| **Author** | @neo-opus-4-7 (Claude Opus 4.7) drafting; substrate-truth grounded in #11628 Phase 4 epic decomposition + #11665 implementer-hot-context shaping |
-| **Implementation ticket** | #11665 — *"KB Ingestion Phase 4A: Multi-tenant ingestion observability daemon scaffold + telemetry schema"* (schema slice; daemon shell deferred to Phase 4A-β) |
-| **Companion implementation PR** | PR for #11665's schema slice — references `Related: #11665` (not `Resolves:`); the ticket stays open for the Phase 4A-β daemon slice per §3.4. This ADR's §2 contract becomes live substrate only after that PR merges. |
-| **Anti-anchor for** | Pre-aggregated-counter schemas (rejected in §3); separate-telemetry-database (rejected in §3); daemon-rolls-up-empty-table dead-code-before-Phase-2 (the scope-correction that split #11665 into schema-now / daemon-later) |
+| **Status** | Proposed — 2026-05-20 (awaiting #11639 PR merge to establish empirical substrate before transition to Accepted, per ADR 0005 lifecycle) |
+| **Author** | @neo-opus-4-7 (Claude Opus 4.7) drafting; substrate-truth grounded in #11628 Phase 4 epic decomposition + #11639 implementer-hot-context shaping |
+| **Implementation ticket** | #11639 — *"Phase 4A — Per-Tenant Ingestion Observability Daemon (KBRecorderService Extension)"* (this ADR + PR cover the schema slice; daemon shell deferred to Phase 4A-β). The earlier-filed #11665 was a duplicate of #11639 — closed `not_planned` 2026-05-20; #11639 is the canonical Phase 4A sub-ticket per the #11628 → #11639/#11640/#11641/#11642 (4A/4B/4C/4D) decomposition. |
+| **Companion implementation PR** | PR for #11639's schema slice — references `Related: #11639` (not `Resolves:`); the ticket stays open for the Phase 4A-β daemon slice per §3.4. This ADR's §2 contract becomes live substrate only after that PR merges. |
+| **Anti-anchor for** | Pre-aggregated-counter schemas (rejected in §3); separate-telemetry-database (rejected in §3); daemon-rolls-up-empty-table dead-code-before-Phase-2 (the scope-correction that split #11639 into schema-now / daemon-later) |
 
 ---
 
@@ -22,7 +22,7 @@ Phase 4 (#11628) decomposes operational observability for cloud-native KB deploy
 
 The existing `KBRecorderService` (`ai/services/knowledge-base/KBRecorderService.mjs`) already persists KB MCP tool telemetry into the shared Memory Core SQLite database via `kb_query_log` + `kb_query_faqs`. Phase 4A extends that substrate rather than introducing a new one.
 
-**Pre-Phase-2 scope boundary.** A telemetry-ROLLUP daemon has nothing to roll up until the Phase 2 cross-tenant ingestion service (#11626) exists and calls `recordIngestionMetric`. The daemon shell would be dead code before Phase 2. The genuinely pre-Phase-2-actionable slice — and the scope of #11665's PR — is the **persistence schema + write-API + read-API**: the contract Phase 2 writes against. The daemon shell moves to Phase 4A-β (post-Phase-2).
+**Pre-Phase-2 scope boundary.** A telemetry-ROLLUP daemon has nothing to roll up until the Phase 2 cross-tenant ingestion service (#11626) exists and calls `recordIngestionMetric`. The daemon shell would be dead code before Phase 2. The genuinely pre-Phase-2-actionable slice — and the scope of #11639's PR — is the **persistence schema + write-API + read-API**: the contract Phase 2 writes against. The daemon shell moves to Phase 4A-β (post-Phase-2).
 
 ## 2. Decision
 
@@ -80,7 +80,7 @@ The event-shaped table keeps the write path O(1) + contention-free; rollup is th
 
 ### 3.4 Daemon shell shipped pre-Phase-2 (rejected — scope correction)
 
-#11665 originally scoped the observability DAEMON into the same PR as the schema. Reasoning during implementation: a daemon that rolls up `kb_ingestion_metrics` has nothing to roll up until Phase 2 ingestion calls `recordIngestionMetric` — it would be dead code activating later. The schema + write/read APIs have standalone pre-Phase-2 value (they're the contract Phase 2 writes against). #11665's PR ships the schema slice; the daemon shell moves to Phase 4A-β as an explicit post-Phase-2 follow-up. This is a friction-to-gold scope-correction: catching dead-code-before-dependency by reasoning about what's genuinely actionable now.
+#11639 originally scoped the observability DAEMON into the same PR as the schema. Reasoning during implementation: a daemon that rolls up `kb_ingestion_metrics` has nothing to roll up until Phase 2 ingestion calls `recordIngestionMetric` — it would be dead code activating later. The schema + write/read APIs have standalone pre-Phase-2 value (they're the contract Phase 2 writes against). #11639's PR ships the schema slice; the daemon shell moves to Phase 4A-β as an explicit post-Phase-2 follow-up. This is a friction-to-gold scope-correction: catching dead-code-before-dependency by reasoning about what's genuinely actionable now.
 
 ## 4. Consequences
 
@@ -93,7 +93,7 @@ The event-shaped table keeps the write path O(1) + contention-free; rollup is th
 
 - **Parent Phase Epic:** #11628 (Phase 4: Operations + Observability)
 - **Parent meta-Epic:** #11624 (Cloud-Native KB Ingestion)
-- **Implementation ticket:** #11665 (schema slice) + Phase 4A-β follow-up (daemon shell, post-Phase-2)
+- **Implementation ticket:** #11639 (schema slice) + Phase 4A-β follow-up (daemon shell, post-Phase-2)
 - **Write-side identity source:** #11631 (Phase 0/1C-α) — the `tenantId` / `repoSlug` / `originAgentIdentity` values stamped here are the authoritative server-derived values this telemetry records.
 - **Substrate-extension target:** `ai/services/knowledge-base/KBRecorderService.mjs`
 - **Sibling ADR:** ADR 0003 (Chroma Topology Unified Only) — the unified-Chroma topology this telemetry observes.

--- a/learn/agentos/decisions/0013-kb-ingestion-telemetry-schema.md
+++ b/learn/agentos/decisions/0013-kb-ingestion-telemetry-schema.md
@@ -1,0 +1,99 @@
+# ADR 0013: KB Ingestion Telemetry Schema — Event-Shaped `kb_ingestion_metrics` Table
+
+> Architectural Decision Record codifying the per-tenant ingestion-telemetry persistence contract introduced by Phase 4A (#11665) of the Cloud-Native KB Ingestion epic (#11624). Authority artifact for the `kb_ingestion_metrics` table shape that the Phase 2 ingestion service (#11626) writes against and the Phase 4A-β observability daemon + Phase 4D alerting consume. Implementation companion is the PR resolving #11665; this ADR is the graph-queryable WHY for the event-shaped (vs pre-aggregated) schema choice.
+
+| Attribute | Value |
+|---|---|
+| **Status** | Proposed — 2026-05-20 (awaiting #11665 PR merge to establish empirical substrate before transition to Accepted, per ADR 0005 lifecycle) |
+| **Author** | @neo-opus-4-7 (Claude Opus 4.7) drafting; substrate-truth grounded in #11628 Phase 4 epic decomposition + #11665 implementer-hot-context shaping |
+| **Implementation ticket** | #11665 — *"KB Ingestion Phase 4A: Multi-tenant ingestion observability daemon scaffold + telemetry schema"* (schema slice; daemon shell deferred to Phase 4A-β) |
+| **Companion implementation PR** | PR resolving #11665 (this ADR's §2 contract becomes live substrate only after that PR merges) |
+| **Anti-anchor for** | Pre-aggregated-counter schemas (rejected in §3); separate-telemetry-database (rejected in §3); daemon-rolls-up-empty-table dead-code-before-Phase-2 (the scope-correction that split #11665 into schema-now / daemon-later) |
+
+---
+
+## 1. Context
+
+Phase 4 (#11628) decomposes operational observability for cloud-native KB deployments into 4 sub-phases (4A observability, 4B reconciliation, 4C garbage collection, 4D alerting). Phase 4A needs a durable per-tenant ingestion-telemetry substrate so that:
+
+- Phase 4A-β observability daemon can roll up + persist per-tenant ingestion metrics.
+- Phase 4D alerting can threshold-check per-tenant error rates + push frequency.
+- Operators can reason about ingestion-fleet health (push frequency, error rates, chunk volumes, embedding-budget burn).
+
+The existing `KBRecorderService` (`ai/services/knowledge-base/KBRecorderService.mjs`) already persists KB MCP tool telemetry into the shared Memory Core SQLite database via `kb_query_log` + `kb_query_faqs`. Phase 4A extends that substrate rather than introducing a new one.
+
+**Pre-Phase-2 scope boundary.** A telemetry-ROLLUP daemon has nothing to roll up until the Phase 2 cross-tenant ingestion service (#11626) exists and calls `recordIngestionMetric`. The daemon shell would be dead code before Phase 2. The genuinely pre-Phase-2-actionable slice — and the scope of #11665's PR — is the **persistence schema + write-API + read-API**: the contract Phase 2 writes against. The daemon shell moves to Phase 4A-β (post-Phase-2).
+
+## 2. Decision
+
+### 2.1 `kb_ingestion_metrics` table — event-shaped
+
+A new SQLite table in the shared Memory Core database, created by `KBRecorderService.initAsync` beside `kb_query_log` / `kb_query_faqs`:
+
+```sql
+CREATE TABLE IF NOT EXISTS kb_ingestion_metrics (
+    id              TEXT PRIMARY KEY,   -- crypto.randomUUID()
+    timestamp       INTEGER NOT NULL,   -- event wall-clock (ms epoch)
+    tenant_id       TEXT NOT NULL,      -- authoritative tenant id (server-stamped per #11631)
+    repo_slug       TEXT NOT NULL,      -- authoritative repo slug
+    origin_agent    TEXT,               -- authenticated agent identity that triggered the event
+    event_type      TEXT NOT NULL,      -- 'ingest' | 'tombstone' | 'reconcile' | 'error'
+    chunks_total    INTEGER DEFAULT 0,  -- chunks seen in the event payload
+    chunks_embedded INTEGER DEFAULT 0,  -- chunks newly embedded
+    chunks_deleted  INTEGER DEFAULT 0,  -- chunks deleted (tombstone / stale-id sweep)
+    duration_ms     INTEGER,            -- event wall-clock duration
+    error_code      TEXT,               -- stable error code when event_type = 'error'
+    detail          TEXT                -- free-form per-event detail (JSON-serialized)
+);
+```
+
+Indexed on `tenant_id`, `timestamp`, `event_type` — the three dimensions every rollup / alerting query filters or groups on.
+
+### 2.2 Write-API — `KBRecorderService.recordIngestionMetric(entry)`
+
+One row per ingestion event. Best-effort observability side channel — never throws back into the ingestion path (mirrors the existing `log()` contract). The Phase 2 ingestion service calls this after each push / tombstone / reconcile / error event.
+
+### 2.3 Read-API — `KBRecorderService.getTenantIngestionRollup({sinceMs, tenantId})`
+
+Aggregates `kb_ingestion_metrics` rows into per-tenant counters: event counts per type, total chunk volumes, error rate. Consumed by the Phase 4A-β daemon + Phase 4D alerting. The rollup is computed on-read (SQL `GROUP BY`) — the table stores raw events, not pre-aggregated state.
+
+## 3. Decision Process — Rejected Alternatives
+
+### 3.1 Pre-aggregated per-tenant counter table (rejected)
+
+**Shape:** one row per tenant, columns incremented in place (`ingest_count`, `error_count`, etc.).
+
+**Rejected because:**
+- Loses time-windowing — Phase 4D alerting needs "error rate over the last N minutes", which a running counter cannot answer.
+- Write-contention — concurrent ingestion events for the same tenant would `UPDATE` the same row, serializing the write path. Event-shaped `INSERT`-only writes are contention-free.
+- Loses per-event detail (`duration_ms`, `error_code`, `detail`) needed for Phase 4B reconciliation forensics.
+
+The event-shaped table keeps the write path O(1) + contention-free; rollup is the daemon's read-time job.
+
+### 3.2 Separate telemetry database (rejected)
+
+`KBRecorderService` already uses the shared Memory Core SQLite database. A separate database would fork the operability story + add a second connection lifecycle to manage. Rejected per #11628 Avoided-Traps ("New telemetry database — KBRecorderService already uses Memory Core SQLite; reuse the substrate").
+
+### 3.3 Extend `kb_query_log` with tenant columns (rejected)
+
+`kb_query_log` is query-call-shaped (one row per MCP tool invocation). Ingestion metrics are ingestion-event-shaped (one row per push / tombstone / reconcile). Overloading one table with two distinct event grammars would force every consumer to filter on a discriminator column + complicate the existing FAQ-projection path. A sibling table is the cleaner separation.
+
+### 3.4 Daemon shell shipped pre-Phase-2 (rejected — scope correction)
+
+#11665 originally scoped the observability DAEMON into the same PR as the schema. Reasoning during implementation: a daemon that rolls up `kb_ingestion_metrics` has nothing to roll up until Phase 2 ingestion calls `recordIngestionMetric` — it would be dead code activating later. The schema + write/read APIs have standalone pre-Phase-2 value (they're the contract Phase 2 writes against). #11665's PR ships the schema slice; the daemon shell moves to Phase 4A-β as an explicit post-Phase-2 follow-up. This is a friction-to-gold scope-correction: catching dead-code-before-dependency by reasoning about what's genuinely actionable now.
+
+## 4. Consequences
+
+- **Phase 2 (#11626)** ingestion service gains a stable telemetry contract — call `recordIngestionMetric` after each event; no schema negotiation needed.
+- **Phase 4A-β** observability daemon consumes `getTenantIngestionRollup` — periodic rollup + persist to an operator-facing surface (portal app health section OR `sandman_handoff.md`).
+- **Phase 4D** alerting thresholds per-tenant `errorRate` / event frequency from the same read-API.
+- **Per-tenant telemetry retention** — distinct from the Phase 4 bundle retention (#11663). The `kb_ingestion_metrics` table will need its own retention sweep (delete rows older than N days) once volume justifies it; deferred to a Phase 4 follow-up — flagged here so future agents see the open thread.
+
+## 5. Related
+
+- **Parent Phase Epic:** #11628 (Phase 4: Operations + Observability)
+- **Parent meta-Epic:** #11624 (Cloud-Native KB Ingestion)
+- **Implementation ticket:** #11665 (schema slice) + Phase 4A-β follow-up (daemon shell, post-Phase-2)
+- **Write-side identity source:** #11631 (Phase 0/1C-α) — the `tenantId` / `repoSlug` / `originAgentIdentity` values stamped here are the authoritative server-derived values this telemetry records.
+- **Substrate-extension target:** `ai/services/knowledge-base/KBRecorderService.mjs`
+- **Sibling ADR:** ADR 0003 (Chroma Topology Unified Only) — the unified-Chroma topology this telemetry observes.

--- a/learn/agentos/decisions/0013-kb-ingestion-telemetry-schema.md
+++ b/learn/agentos/decisions/0013-kb-ingestion-telemetry-schema.md
@@ -1,13 +1,13 @@
 # ADR 0013: KB Ingestion Telemetry Schema — Event-Shaped `kb_ingestion_metrics` Table
 
-> Architectural Decision Record codifying the per-tenant ingestion-telemetry persistence contract introduced by Phase 4A (#11665) of the Cloud-Native KB Ingestion epic (#11624). Authority artifact for the `kb_ingestion_metrics` table shape that the Phase 2 ingestion service (#11626) writes against and the Phase 4A-β observability daemon + Phase 4D alerting consume. Implementation companion is the PR resolving #11665; this ADR is the graph-queryable WHY for the event-shaped (vs pre-aggregated) schema choice.
+> Architectural Decision Record codifying the per-tenant ingestion-telemetry persistence contract introduced by Phase 4A (#11665) of the Cloud-Native KB Ingestion epic (#11624). Authority artifact for the `kb_ingestion_metrics` table shape that the Phase 2 ingestion service (#11626) writes against and the Phase 4A-β observability daemon + Phase 4D alerting consume. Implementation companion is the PR for #11665's schema slice (`Related: #11665` — the ticket stays open for the Phase 4A-β daemon slice, per §3.4); this ADR is the graph-queryable WHY for the event-shaped (vs pre-aggregated) schema choice.
 
 | Attribute | Value |
 |---|---|
 | **Status** | Proposed — 2026-05-20 (awaiting #11665 PR merge to establish empirical substrate before transition to Accepted, per ADR 0005 lifecycle) |
 | **Author** | @neo-opus-4-7 (Claude Opus 4.7) drafting; substrate-truth grounded in #11628 Phase 4 epic decomposition + #11665 implementer-hot-context shaping |
 | **Implementation ticket** | #11665 — *"KB Ingestion Phase 4A: Multi-tenant ingestion observability daemon scaffold + telemetry schema"* (schema slice; daemon shell deferred to Phase 4A-β) |
-| **Companion implementation PR** | PR resolving #11665 (this ADR's §2 contract becomes live substrate only after that PR merges) |
+| **Companion implementation PR** | PR for #11665's schema slice — references `Related: #11665` (not `Resolves:`); the ticket stays open for the Phase 4A-β daemon slice per §3.4. This ADR's §2 contract becomes live substrate only after that PR merges. |
 | **Anti-anchor for** | Pre-aggregated-counter schemas (rejected in §3); separate-telemetry-database (rejected in §3); daemon-rolls-up-empty-table dead-code-before-Phase-2 (the scope-correction that split #11665 into schema-now / daemon-later) |
 
 ---

--- a/test/playwright/unit/ai/services/knowledge-base/KBRecorderService.ingestionMetrics.spec.mjs
+++ b/test/playwright/unit/ai/services/knowledge-base/KBRecorderService.ingestionMetrics.spec.mjs
@@ -1,0 +1,213 @@
+import {setup} from '../../../../setup.mjs';
+
+const appName = 'KBRecorderIngestionMetricsTest';
+
+setup({
+    neoConfig: {
+        unitTestMode: true
+    },
+    appConfig: {
+        name             : appName,
+        isMounted        : () => true,
+        vnodeInitialising: false
+    }
+});
+
+import {test, expect} from '@playwright/test';
+import Neo            from '../../../../../../src/Neo.mjs';
+import * as core      from '../../../../../../src/core/_export.mjs';
+import fs             from 'fs';
+import path           from 'path';
+
+/**
+ * Phase 4A (#11665) — `kb_ingestion_metrics` telemetry schema + `recordIngestionMetric`
+ * write-API + `getTenantIngestionRollup` read-API coverage.
+ *
+ * This is the pre-Phase-2 substrate slice: the persistence contract the Phase 2 cross-tenant
+ * ingestion service (#11626) writes against. The observability daemon that periodically rolls
+ * up + persists these metrics is deferred to Phase 4A-β (post-Phase-2) — a daemon has nothing
+ * to roll up until Phase 2 ingestion calls actually emit `recordIngestionMetric` events.
+ *
+ * Serial mode: the spec exercises a shared KBRecorderService SQLite singleton.
+ *
+ * @see https://github.com/neomjs/neo/issues/11665
+ * @see https://github.com/neomjs/neo/issues/11628 (Phase 4 parent epic)
+ */
+test.describe.configure({mode: 'serial'});
+
+test.describe('KBRecorderService — ingestion metrics (#11665)', () => {
+    const testDbName = `kb-recorder-ingestion-test-${process.pid}-${Date.now()}.sqlite`;
+    let testDbPath;
+    let KBRecorderService;
+
+    test.beforeAll(async () => {
+        const config = (await import('../../../../../../ai/mcp/server/knowledge-base/config.mjs')).default;
+
+        const tmpDir = path.resolve(process.cwd(), 'tmp');
+        if (!fs.existsSync(tmpDir)) {
+            fs.mkdirSync(tmpDir, {recursive: true});
+        }
+
+        testDbPath = path.join(tmpDir, testDbName);
+        config.data.memoryCoreDbPath = testDbPath;
+
+        for (const suffix of ['', '-wal', '-shm']) {
+            try { fs.unlinkSync(`${testDbPath}${suffix}`); } catch (e) {}
+        }
+
+        KBRecorderService = (await import('../../../../../../ai/services/knowledge-base/KBRecorderService.mjs')).default;
+        await KBRecorderService.initAsync();
+    });
+
+    test.beforeEach(() => {
+        KBRecorderService.db.exec('DELETE FROM kb_ingestion_metrics;');
+    });
+
+    test.afterAll(() => {
+        if (KBRecorderService?.db) {
+            try { KBRecorderService.db.close(); } catch (e) {}
+        }
+        for (const suffix of ['', '-wal', '-shm']) {
+            try { fs.unlinkSync(`${testDbPath}${suffix}`); } catch (e) {}
+        }
+    });
+
+    test('initAsync creates the kb_ingestion_metrics table with the expected columns', () => {
+        const columns = KBRecorderService.db
+            .prepare("PRAGMA table_info(kb_ingestion_metrics)")
+            .all()
+            .map(c => c.name);
+
+        expect(columns).toEqual(expect.arrayContaining([
+            'id', 'timestamp', 'tenant_id', 'repo_slug', 'origin_agent',
+            'event_type', 'chunks_total', 'chunks_embedded', 'chunks_deleted',
+            'duration_ms', 'error_code', 'detail'
+        ]));
+    });
+
+    test('recordIngestionMetric persists a single ingest event with all fields', () => {
+        KBRecorderService.recordIngestionMetric({
+            tenantId           : 'tenant-a',
+            repoSlug           : 'repo-x',
+            originAgentIdentity: '@neo-gpt',
+            eventType          : 'ingest',
+            chunksTotal        : 100,
+            chunksEmbedded     : 40,
+            chunksDeleted      : 5,
+            durationMs         : 1234,
+            detail             : {batch: 1, source: 'pre-push-hook'}
+        });
+
+        const row = KBRecorderService.db.prepare('SELECT * FROM kb_ingestion_metrics').get();
+
+        expect(row.tenant_id).toBe('tenant-a');
+        expect(row.repo_slug).toBe('repo-x');
+        expect(row.origin_agent).toBe('@neo-gpt');
+        expect(row.event_type).toBe('ingest');
+        expect(row.chunks_total).toBe(100);
+        expect(row.chunks_embedded).toBe(40);
+        expect(row.chunks_deleted).toBe(5);
+        expect(row.duration_ms).toBe(1234);
+        expect(JSON.parse(row.detail)).toEqual({batch: 1, source: 'pre-push-hook'});
+        expect(typeof row.id).toBe('string');
+        expect(row.id).toHaveLength(36); // crypto.randomUUID()
+    });
+
+    test('recordIngestionMetric applies neo-shared / neo / ingest defaults for omitted fields', () => {
+        KBRecorderService.recordIngestionMetric({eventType: 'ingest'});
+
+        const row = KBRecorderService.db.prepare('SELECT * FROM kb_ingestion_metrics').get();
+
+        expect(row.tenant_id).toBe('neo-shared');
+        expect(row.repo_slug).toBe('neo');
+        expect(row.event_type).toBe('ingest');
+        expect(row.chunks_total).toBe(0);
+        expect(row.chunks_embedded).toBe(0);
+        expect(row.chunks_deleted).toBe(0);
+        expect(row.origin_agent).toBeNull();
+        expect(row.detail).toBeNull();
+    });
+
+    test('recordIngestionMetric never throws — best-effort observability side channel', () => {
+        // A malformed detail object that can't serialize cleanly still must not throw.
+        const circular = {};
+        circular.self = circular;
+
+        // safeStringify handles the circular ref; the call must complete without throwing.
+        expect(() => KBRecorderService.recordIngestionMetric({
+            tenantId : 'tenant-b',
+            repoSlug : 'repo-y',
+            eventType: 'ingest',
+            detail   : circular
+        })).not.toThrow();
+
+        const row = KBRecorderService.db.prepare('SELECT * FROM kb_ingestion_metrics').get();
+        expect(row.tenant_id).toBe('tenant-b');
+    });
+
+    test('getTenantIngestionRollup aggregates events per tenant with per-event-type counts', () => {
+        const seed = [
+            {tenantId: 'tenant-a', repoSlug: 'r1', eventType: 'ingest',    chunksEmbedded: 10},
+            {tenantId: 'tenant-a', repoSlug: 'r1', eventType: 'ingest',    chunksEmbedded: 20},
+            {tenantId: 'tenant-a', repoSlug: 'r1', eventType: 'tombstone', chunksDeleted: 3},
+            {tenantId: 'tenant-a', repoSlug: 'r1', eventType: 'error',     errorCode: 'KB_INGEST_FAIL'},
+            {tenantId: 'tenant-b', repoSlug: 'r2', eventType: 'ingest',    chunksEmbedded: 50},
+            {tenantId: 'tenant-b', repoSlug: 'r2', eventType: 'reconcile'}
+        ];
+        seed.forEach(e => KBRecorderService.recordIngestionMetric(e));
+
+        const rollup = KBRecorderService.getTenantIngestionRollup();
+
+        expect(rollup).toHaveLength(2);
+
+        const a = rollup.find(r => r.tenantId === 'tenant-a');
+        expect(a.eventCount).toBe(4);
+        expect(a.ingestEvents).toBe(2);
+        expect(a.tombstoneEvents).toBe(1);
+        expect(a.errorEvents).toBe(1);
+        expect(a.chunksEmbedded).toBe(30);
+        expect(a.chunksDeleted).toBe(3);
+        expect(a.errorRate).toBeCloseTo(0.25);
+
+        const b = rollup.find(r => r.tenantId === 'tenant-b');
+        expect(b.eventCount).toBe(2);
+        expect(b.ingestEvents).toBe(1);
+        expect(b.reconcileEvents).toBe(1);
+        expect(b.chunksEmbedded).toBe(50);
+        expect(b.errorRate).toBe(0);
+    });
+
+    test('getTenantIngestionRollup honors the sinceMs window', () => {
+        const now = Date.now();
+        KBRecorderService.recordIngestionMetric({tenantId: 'tenant-a', repoSlug: 'r1', eventType: 'ingest', timestamp: now - 7200000}); // 2h ago
+        KBRecorderService.recordIngestionMetric({tenantId: 'tenant-a', repoSlug: 'r1', eventType: 'ingest', timestamp: now - 600000});  // 10m ago
+
+        const recentOnly = KBRecorderService.getTenantIngestionRollup({sinceMs: now - 1800000}); // last 30m
+        expect(recentOnly).toHaveLength(1);
+        expect(recentOnly[0].eventCount).toBe(1);
+
+        const allTime = KBRecorderService.getTenantIngestionRollup();
+        expect(allTime[0].eventCount).toBe(2);
+    });
+
+    test('getTenantIngestionRollup honors the tenantId filter', () => {
+        KBRecorderService.recordIngestionMetric({tenantId: 'tenant-a', repoSlug: 'r1', eventType: 'ingest'});
+        KBRecorderService.recordIngestionMetric({tenantId: 'tenant-b', repoSlug: 'r2', eventType: 'ingest'});
+
+        const onlyA = KBRecorderService.getTenantIngestionRollup({tenantId: 'tenant-a'});
+        expect(onlyA).toHaveLength(1);
+        expect(onlyA[0].tenantId).toBe('tenant-a');
+    });
+
+    test('getTenantIngestionRollup returns empty array when no metrics recorded', () => {
+        expect(KBRecorderService.getTenantIngestionRollup()).toEqual([]);
+    });
+
+    test('errorRate is 0 (not NaN) for a tenant whose only events are non-error', () => {
+        KBRecorderService.recordIngestionMetric({tenantId: 'tenant-c', repoSlug: 'r3', eventType: 'ingest'});
+
+        const rollup = KBRecorderService.getTenantIngestionRollup({tenantId: 'tenant-c'});
+        expect(rollup[0].errorRate).toBe(0);
+        expect(Number.isNaN(rollup[0].errorRate)).toBe(false);
+    });
+});

--- a/test/playwright/unit/ai/services/knowledge-base/KBRecorderService.ingestionMetrics.spec.mjs
+++ b/test/playwright/unit/ai/services/knowledge-base/KBRecorderService.ingestionMetrics.spec.mjs
@@ -66,6 +66,12 @@ test.describe('KBRecorderService — ingestion metrics (#11665)', () => {
     test.afterAll(() => {
         if (KBRecorderService?.db) {
             try { KBRecorderService.db.close(); } catch (e) {}
+            // Null the singleton db reference after close — `initAsync` short-circuits on
+            // `if (this.db) return`, so a sibling KBRecorderService spec running later in the
+            // same worker would otherwise inherit this closed connection and fail with
+            // "The database connection is not open". Mirrors KBRecorderService.spec.mjs cleanup.
+            // (@neo-gpt PR #11667 Cycle 1 review PRR_kwDODSospM8AAAABAcVsyg, Required Action 1.)
+            KBRecorderService.db = null;
         }
         for (const suffix of ['', '-wal', '-shm']) {
             try { fs.unlinkSync(`${testDbPath}${suffix}`); } catch (e) {}


### PR DESCRIPTION
Related: #11639

Authored by Claude Opus 4.7 (Claude Code). Session 7360e917-1733-4cdd-a6f3-5ac51c34b838.

> **Ticket reconciliation note (2026-05-20):** this PR was originally filed against #11665, which turned out to be a duplicate of the canonical Phase 4A sub-ticket #11639 (filed at Discussion #11623 graduation alongside #11640/#11641/#11642). #11665 was closed `not_planned`; this PR is re-homed to `Related: #11639`. The branch name `agent/11665-kb-observability-daemon` retains the original (now-closed) ticket number — harmless historical artifact; the PR title + body + ADR 0013 references all point at the canonical #11639. Caught via @neo-gpt's #11628 Phase 4 readiness audit.

FAIR-band: in-band [15/30] — operator nightshift-mode directive 2026-05-20 ~01:00Z: continuous parallel-lane pickup on Epic #11624. Parallel to @neo-gpt's #11646 (Phase 5C KB unit coverage) — different files, no merge collision risk.

Phase 4A **schema slice** of Phase 4 [#11628](https://github.com/neomjs/neo/issues/11628). Ships the pre-Phase-2-actionable substrate: the durable per-tenant ingestion-telemetry persistence contract that the Phase 2 ingestion service (#11626) writes against + the Phase 4A-β observability daemon + Phase 4D alerting consume.

Evidence: L2 (9 new unit tests covering schema creation + write-API full-fields/defaults/never-throws + rollup aggregation/window/filter/empty/NaN-safety; 3 pre-existing KBRecorderService tests pass as regression) → L2 required (schema + write/read API are mechanically verifiable in unit-test scope; the Phase 2 ingestion service that emits live metrics doesn't exist yet). No residuals.

## Scope correction — daemon shell deferred to Phase 4A-β

#11639's body scopes both the observability **daemon** AND the telemetry schema. During implementation I caught that a daemon rolling up `kb_ingestion_metrics` has **nothing to roll up** until the Phase 2 ingestion service (#11626) calls `recordIngestionMetric` — it would be dead code activating later. The schema + write/read APIs have standalone pre-Phase-2 value (they're the contract Phase 2 writes against). This PR ships the **schema slice only**; the daemon shell moves to a **Phase 4A-β follow-up** (post-Phase-2). PR uses `Related: #11639` (not `Resolves:`) — #11639 stays open for the daemon slice.

**Naming-alignment note:** #11639's body prescribes `kb_ingestion_events` / `recordIngestionEvent`; this PR shipped `kb_ingestion_metrics` / `recordIngestionMetric` / `getTenantIngestionRollup`. The shipped names are now substrate-truth (PR APPROVED Cycle 2). #11639's body should align to the shipped vocabulary — flagged in a comment on #11639 + consistent with @neo-gpt's #11628 Phase 4 audit recommendation.

This is a friction-to-gold scope-correction documented in ADR 0013 §3.4.

## Substrate-path note (`learn/agentos/**`)

This PR adds `learn/agentos/decisions/0013-kb-ingestion-telemetry-schema.md`. Per `pull-request-workflow.md §1.1`, substrate-path touches normally require a slot-rationale section. **ADRs are NOT always-loaded substrate** — they are conditionally-loaded graph-queryable reference docs per ADR 0006. ADR 0013 adds zero always-loaded bytes (the "Map"); it's World-Atlas reference fetched on demand when an agent audits the telemetry schema. Disposition: `keep` (ADRs persist as the authority artifact per ADR 0005 lifecycle). No always-loaded-substrate accretion.

## Deltas from ticket (if any)

- **Daemon shell deferred** (see Scope correction above) — the original #11639 AC list included `ai/scripts/kb-observability-daemon.mjs` + npm script. Those move to Phase 4A-β.
- **Sibling table, not `kb_query_log` extension** — #11639 left the choice to implementation. Chose a sibling `kb_ingestion_metrics` table: `kb_query_log` is query-call-shaped (one row per MCP tool invocation), ingestion metrics are ingestion-event-shaped. Overloading one table with two event grammars complicates every consumer. ADR 0013 §3.3 documents the rejection.
- **Event-shaped, not pre-aggregated** — ADR 0013 §3.1: pre-aggregated counters lose time-windowing (Phase 4D needs "error rate over last N min"), serialize the write path via UPDATE contention, and lose per-event forensic detail.

## Test Evidence

New spec: `test/playwright/unit/ai/services/knowledge-base/KBRecorderService.ingestionMetrics.spec.mjs` — **9 tests, 9 passed in 627ms**.

| # | Scenario |
|---|---|
| 1 | `initAsync` creates `kb_ingestion_metrics` with all 12 expected columns |
| 2 | `recordIngestionMetric` persists a full-fields ingest event (UUID id, all columns) |
| 3 | `recordIngestionMetric` applies `neo-shared`/`neo`/`ingest` defaults for omitted fields |
| 4 | `recordIngestionMetric` never throws — best-effort side channel (circular-ref detail) |
| 5 | `getTenantIngestionRollup` aggregates per-tenant with per-event-type counts + error rate |
| 6 | `getTenantIngestionRollup` honors the `sinceMs` window |
| 7 | `getTenantIngestionRollup` honors the `tenantId` filter |
| 8 | `getTenantIngestionRollup` returns `[]` when no metrics recorded |
| 9 | `errorRate` is `0` (not `NaN`) for a tenant with only non-error events |

Regression: `npm run test-unit -- test/playwright/unit/ai/services/knowledge-base/KBRecorderService.spec.mjs` → **3 passed** (existing `kb_query_log` / `kb_query_faqs` behavior unaffected).

## Post-Merge Validation

- [ ] Phase 4A-β follow-up sub-ticket filed for the observability daemon shell + npm script (post-Phase-2; the daemon consumes `getTenantIngestionRollup`)
- [ ] When Phase 2 #11626 ships, the ingestion service wires `recordIngestionMetric` calls after push/tombstone/reconcile/error events
- [ ] Per-tenant `kb_ingestion_metrics` retention sweep filed as a Phase 4 follow-up once metric volume justifies it (flagged in ADR 0013 §4)

## Commits

- `2e311b528` — feat(ai): KB ingestion telemetry schema + recordIngestionMetric write/read API (#11639)
