### PR TITLE
fix(agentos): clarify broadcast fallback pickup (#11669)

### DIFF
--- a/.agents/skills/peer-role/references/peer-role-mode.md
+++ b/.agents/skills/peer-role/references/peer-role-mode.md
@@ -65,7 +65,7 @@ The substrate operates **two distinct primitives** for pre-write coordination:
 **Required A2A shape**:
 - Subject: `[lane-claim] taking #N` (or `taking <substrate-description>` for unticketed work)
 - Body: scope-boundary statement (which files / surfaces / write-operations), expected timeline, source-of-authority collision-check findings (see §6.6)
-- Recipient: `AGENT:*` broadcast (let all peers V-B-A against parallel-claim risk)
+- Recipient: `AGENT:*` broadcast (let all peers V-B-A against parallel-claim risk). If the operator has explicitly suppressed broadcasts to protect an unstable peer harness, use the operator-authorized reachable peer DM instead and state that fallback in the body; broadcast suppression is not a work-stop.
 
 **Tool-side enforcement (per #11537 AC3/AC4):** issue assignment is mechanically gated via `manage_issue_assignees` MCP tool. The tool fetches current assignees, rejects blind-add with `ASSIGNEE_CONFLICT` (409) unless `acknowledgedReassign: '<reason>'` is provided (strict-replacement with audit-trail comment persistence). Direct `gh issue edit --add-assignee` / `--remove-assignee` invocations bypass this gate and are **forbidden for agents** (narrow scope: assignee mutation only; PR review, checks, API reads still use `gh`). This is the mechanical safeguard complementing the discipline above — empirical anchor §7 "Lane-claim without authority check" (PR #11245).
 
@@ -98,6 +98,24 @@ add_message({
 ```
 
 Pre-#11417 confabulation patterns like `to: "AGENT:openai/gpt"` silently stored as `to: null` (orphan messages invisible to the recipient). Post-#11417 the MailboxService rejects unrecognized formats with a clear error and attempts `AGENT:<family>/<model>` alias resolution against `AgentIdentity.modelFamily` only when exactly one match exists.
+
+**Worked example — operator-suppressed broadcast fallback (scoped exception, #11669):**
+
+```js
+// Direct-DM lane claim because the operator suppressed AGENT:* for a named peer
+// harness incident. Keep AGENT:* as canonical outside that explicit constraint.
+add_message({
+    to     : '@<reachable-peer>',
+    subject: '[lane-claim] taking #N <substrate-description>',
+    body   : 'Direct-DM lane claim under operator broadcast-suppression. ' +
+             'Suppressed channel/peer: <operator-named constraint>. ' +
+             'Lane scope: <files/surfaces touched>. ETA: <timeline>. ' +
+             'Source-of-authority check: <findings per §6.6>. ' +
+             'V-B-A validated: <evidence>.',
+    relatedTickets : ['#N'],
+    taggedConcepts : ['lane-claim', '<work-class>']
+});
+```
 
 ### 6.5.1 Lane-Override Protocol (`[lane-override]`)
 

--- a/.agents/skills/post-review-pickup/references/post-review-pickup-workflow.md
+++ b/.agents/skills/post-review-pickup/references/post-review-pickup-workflow.md
@@ -44,6 +44,11 @@ pre-review reviewer-only cycles. The handled artifact is now owned by the next
 actor in that cycle (or the team board for ticket creation); unrelated ready
 lanes can proceed in parallel.
 
+If a watchdog or night-shift wake is paired with an operator-suppressed
+`AGENT:*` broadcast channel, treat that as a coordination-shape constraint, not
+as lack of work. Use the operator-authorized reachable peer DM as the lane
+coordination substitute and continue the lane-discovery protocol below.
+
 **`blocked-task-state` scope preservation**: this skill covers the EXIT from a
 blocked state (forward-motion resumption). Entry INTO a blocked state — when
 the agent's current lane hits a blocker — remains the `blocked-task-state`
@@ -130,9 +135,13 @@ Primary codification of the FAIR-band author-lane pickup discipline: [`./fair-ba
 
 ## 5. Legitimate Halt States
 
+Lineage: #10970 established lifecycle pickup; #11165 tightened halt-state
+backlog self-survey; #11221 closed stated-intent-without-execution; #11669
+adds the broadcast-suppressed fallback below.
+
 Halt is allowed only when it is explicit and true:
 
-1. **Backlog self-survey completed** — agent has actively surveyed available open lanes (v13 board / assigned-to-me / authored-by-me / lane-pickable-from-cross-author-substrate) AND found no positive-ROI lane self-selectable, OR all candidate lanes hit conditions 2-5 below. The survey + finding MUST be named in the halt declaration.
+1. **Backlog self-survey completed** — agent has actively surveyed available open lanes (v13 board / assigned-to-me / authored-by-me / lane-pickable-from-cross-author-substrate / broader non-conflicting backlog such as body, grid, docs, testing, or general Project work) AND found no positive-ROI lane self-selectable, OR all candidate lanes hit conditions 2-5 below. The survey + finding MUST be named in the halt declaration.
 2. Every candidate lane is blocked on human-only action.
 3. A safety gate forbids continuing.
 4. The operator explicitly requested a pause.
@@ -141,7 +150,24 @@ Halt is allowed only when it is explicit and true:
    - NOT criterion #5 triggers (these are deference-slip cover dressed as prudence): "context preservation for next-session", "sustained decision-quality budget exhausted" (subjective feel), "long session, time to halt" (time-based heuristic without concrete error-rate signal).
    - **Reflex test:** if no concrete trigger has fired AND no observable error-rate degradation, criterion #5 does NOT apply. Continue self-select + execute per the substrate-evolution-flywheel reality below.
 
-Lead-role and peer-role agents are explicitly expected to **self-select from the backlog and announce the lane pickup** rather than treating absence-of-operator-direction as legitimate halt. Per AGENTS.md §15.6: *"Proactively select high-value tickets from the backlog or state your intended next lane instead of waiting for passive instruction."*
+### Broadcast-Suppressed Coordination Fallback
+
+`AGENT:*` broadcast is the canonical lane-visibility path, but temporary
+operator suppression of broadcast is not by itself a halt-state. If the operator
+suppresses broadcast to protect an unstable peer harness, the agent MUST:
+
+1. Avoid the suppressed peer / channel exactly as instructed.
+2. Use the operator-authorized reachable peer DM as the lane-claim /
+   lane-coordination substitute.
+3. Name the fallback in the A2A body so future readers understand why the
+   canonical broadcast path was not used.
+4. Continue the broad backlog self-survey before considering halt-state.
+
+Only if no safe coordination channel exists AND all candidate lanes are blocked
+by the halt criteria above may the agent declare halt or enter
+`blocked-task-state`.
+
+Lead-role and peer-role agents are explicitly expected to **self-select from the backlog and announce the lane pickup** rather than treating absence-of-operator-direction or absence-of-broadcast as legitimate halt. Per AGENTS.md §15.6: *"Proactively select high-value tickets from the backlog AND begin the lane in the same turn."*
 
 ### Substrate-evolution-flywheel reality
 
@@ -177,6 +203,8 @@ for the next prompt. Ticket #10970 is the instance-codification.
 | Anti-pattern | Why it harms |
 |---|---|
 | Declaring halt-state per §5 criterion #1 without first surveying backlog | Condones deference-slip; reverses AGENTS.md §15.6 self-select discipline |
+| Treating operator-suppressed `AGENT:*` broadcast as work-stop | Confuses coordination visibility with implementation authority; use the authorized direct-DM fallback or declare a real blocker. |
+| Watchdog wake -> ack -> nothing to do without broad lane search | Burns wake cycles while positive-ROI backlog lanes exist; repeat wakes must re-check A2A + live repo state + broad backlog before any no-delta response. |
 | Ending the turn after `Approved` without checking the next lane | Leaves the swarm idle at the human merge gate even when unrelated work is ready. |
 | Waiting for author response after `Request Changes` | Serializes work that can proceed in parallel. |
 | Broadcasting generic idle/capacity status | Creates coordination noise without assigning ownership or naming the blocker. |


### PR DESCRIPTION
Resolves #11669

Authored by GPT-5 (Codex Desktop). Session 021172f9-cf8a-4762-917f-95bdf261ad23.

FAIR-band: in-band [11/30 - current author count over last 30 merged]

This PR clarifies the workflow gap surfaced during night-shift: an operator-suppressed `AGENT:*` broadcast channel is a coordination-shape constraint, not a halt-state. Agents must use the operator-authorized direct-DM fallback when available, keep the suppressed peer/channel quiet, and widen lane discovery to non-conflicting backlog work before declaring halt.

Evidence: L1 (static skill-substrate patch + lint) -> L1 required (workflow contract clarification; no runtime ACs). No residuals.

## Slot Rationale

- `.agents/skills/post-review-pickup/references/post-review-pickup-workflow.md`
  - Disposition delta: `rewrite` / `keep in Atlas payload`.
  - 3-axis rating: trigger-frequency = lifecycle/watchdog lane-discovery only, failure-severity = high when missed (multi-hour idle / lost swarm work), enforceability = discipline-only with A2A evidence.
  - Rationale: the rule belongs in the post-review-pickup Atlas because it governs lane discovery and halt-state evaluation, not every turn. Keeping it out of `AGENTS.md` avoids turn-loaded bloat while still firing at the relevant lifecycle boundary.
- `.agents/skills/peer-role/references/peer-role-mode.md`
  - Disposition delta: `rewrite` / `keep in Atlas payload`.
  - 3-axis rating: trigger-frequency = lane-claim coordination only, failure-severity = high when broadcast suppression is misread, enforceability = discipline-only plus `add_message` recipient evidence.
  - Rationale: the existing lane-claim recipient contract was the ambiguous surface. A scoped example preserves `AGENT:*` as canonical while documenting the operator-authorized direct-DM exception.

## Deltas from Ticket

- Also corrected stale `post-review-pickup` wording that still quoted the pre-#11221 "or state your intended next lane" loophole. The workflow now quotes the current AND-discipline from `AGENTS.md §15.6`.

## Test Evidence

- `git diff --check origin/dev...HEAD`
- `npm run ai:lint-skill-manifest -- --base origin/dev`
- `node ai/scripts/lint-agents.mjs --base origin/dev`
- Live duplicate sweep before filing #11669:
  - `ask_knowledge_base(type:'ticket', query:'duplicate tickets broadcast suppression direct DM fallback halt-state watchdog post-review-pickup lane selection')`
  - `gh issue list --state open --search "halt-state backlog self-survey broadcast direct DM idling" --json number,title,state,labels,assignees,updatedAt --limit 20`
  - `gh issue list --state open --search "nightshift watchdog idle halt post-review-pickup" --json number,title,state,labels,assignees,updatedAt --limit 20`
  - `gh issue list --state open --search "broadcast suppression fallback direct DM coordination" --json number,title,state,labels,assignees,updatedAt --limit 20`
  - `gh issue list --state open --search "Gemini harness crash broadcast direct DM" --json number,title,state,labels,assignees,updatedAt --limit 20`

## Post-Merge Validation

- [ ] Future watchdog / night-shift wake with broadcast suppression uses direct-DM fallback or broad backlog lane discovery before any no-delta response.

## Commit

- `c9934efbc` - `fix(agentos): clarify broadcast fallback pickup (#11669)`
