### PR TITLE
feat(memory-core): graph RLS read-side return boundary (#10011)

### DIFF
--- a/ai/services/memory-core/GraphService.mjs
+++ b/ai/services/memory-core/GraphService.mjs
@@ -7,20 +7,23 @@ import SQLite       from '../../../ai/graph/storage/SQLite.mjs';
 import { IDENTITIES } from '../../../ai/graph/identityRoots.mjs';
 
 /**
- * Row-level-security visibility predicate for an in-memory graph node, mirroring the SQL
- * RLS clause used by `searchNodes` / `SQLite.loadNodeVicinitySync`. Applied at the public
- * read return boundary (#10011): the node Store is a process-wide cache, so a node warmed
- * by one requester's RLS-filtered lazy-load is otherwise readable by any other requester.
- * @param {Object|null} node A graph node (Record or plain object) from the in-memory Store.
+ * Row-level-security visibility predicate for an in-memory graph **node or edge**, mirroring
+ * the SQL RLS clause that `SQLite.loadNodeVicinitySync` / `searchNodes` apply to BOTH the
+ * `Nodes` and `Edges` tables. Applied at the public read return boundary (#10011): the
+ * node/edge Stores are a process-wide cache, so an entity warmed by one requester's
+ * RLS-filtered lazy-load is otherwise readable by any other requester straight from the
+ * cache. Edges carry their own `properties.userId` (server-stamped), so a private edge
+ * between two otherwise-visible nodes is a distinct leak surface from the nodes themselves.
+ * @param {Object|null} entity A graph node or edge (Record or plain object) from an in-memory Store.
  * @param {String|null} requesterUserId The acting agent-identity node id, or null.
- * @returns {Boolean} true when the node is visible to the requester.
+ * @returns {Boolean} true when the entity is visible to the requester.
  */
-function isNodeRlsVisible(node, requesterUserId) {
-    if (!node) {
+function isRlsVisible(entity, requesterUserId) {
+    if (!entity) {
         return false;
     }
 
-    const properties  = (node.isRecord ? node.get('properties') : node.properties) || {},
+    const properties  = (entity.isRecord ? entity.get('properties') : entity.properties) || {},
           ownerUserId = properties.userId;
 
     return ownerUserId == null              ||
@@ -572,7 +575,7 @@ class GraphService extends Base {
         // #10011 RLS: the node Store is a process-wide cache — re-check visibility at the
         // return boundary so a cross-requester cache-warmed node is not leaked.
         let rlsUserId = this.db.storage?.RequestContextService?.getAgentIdentityNodeId() ?? null;
-        if (!isNodeRlsVisible(node, rlsUserId)) {
+        if (!isRlsVisible(node, rlsUserId)) {
             return null;
         }
 
@@ -625,11 +628,11 @@ class GraphService extends Base {
         this.db.getAdjacentNodes(id, 'both');
 
         // #10011 RLS: resolve the requester once; do not expose the vicinity of a node the
-        // requester cannot see, and filter each neighbor by node visibility.
+        // requester cannot see, and filter each neighbor by node + edge visibility.
         let rlsUserId = this.db.storage?.RequestContextService?.getAgentIdentityNodeId() ?? null,
             rootNode  = this.db.nodes.get(id);
 
-        if (!rootNode || !isNodeRlsVisible(rootNode, rlsUserId)) {
+        if (!rootNode || !isRlsVisible(rootNode, rlsUserId)) {
             return {neighbors: []};
         }
 
@@ -640,7 +643,9 @@ class GraphService extends Base {
         [...inbound, ...outbound].forEach(e => {
             let adjacentId = e.source === id ? e.target : e.source;
             let node       = this.db.nodes.get(adjacentId);
-            if (node && isNodeRlsVisible(node, rlsUserId)) {
+            // A neighbor is exposed only when BOTH the adjacent node and the connecting
+            // edge are RLS-visible — a private edge between visible nodes still leaks.
+            if (node && isRlsVisible(node, rlsUserId) && isRlsVisible(e, rlsUserId)) {
                 results.push({
                     id          : node.id,
                     type        : node.label,
@@ -739,8 +744,8 @@ class GraphService extends Base {
                 let adjacentId = e.source === 'frontier' ? e.target : e.source;
                 let node       = this.db.nodes.get(adjacentId);
 
-                // Actively filter out CLOSED structural paths + #10011 RLS-invisible nodes
-                if (node && isNodeRlsVisible(node, rlsUserId) && node.properties?.state !== 'CLOSED') {
+                // Actively filter out CLOSED structural paths + #10011 RLS-invisible nodes/edges
+                if (node && isRlsVisible(node, rlsUserId) && isRlsVisible(e, rlsUserId) && node.properties?.state !== 'CLOSED') {
                     topology.strategicNeighbors.push({
                         id              : node.id,
                         type            : node.label,
@@ -778,7 +783,7 @@ class GraphService extends Base {
         // #10011 RLS: the node Store is a process-wide cache — re-check the cache-resident
         // root and every traversed node at the return boundary.
         let rlsUserId = this.db.storage?.RequestContextService?.getAgentIdentityNodeId() ?? null;
-        if (!isNodeRlsVisible(rootNode, rlsUserId)) {
+        if (!isRlsVisible(rootNode, rlsUserId)) {
             logger.info(`[GraphService] Node ${nodeId} not visible to the active requester.`);
             return null;
         }
@@ -814,9 +819,9 @@ class GraphService extends Base {
                     let adjacentId = e.source === id ? e.target : e.source;
                     let n          = this.db.nodes.get(adjacentId);
 
-                    // #10011 RLS: skip an edge whose far node is absent or not visible to
-                    // the requester — do not leak the node, the edge, or traverse through it.
-                    if (!n || !isNodeRlsVisible(n, rlsUserId)) {
+                    // #10011 RLS: skip an edge that is itself not visible, or whose far node
+                    // is absent or not visible — do not leak the node, edge, or traverse it.
+                    if (!n || !isRlsVisible(n, rlsUserId) || !isRlsVisible(e, rlsUserId)) {
                         return;
                     }
 

--- a/ai/services/memory-core/GraphService.mjs
+++ b/ai/services/memory-core/GraphService.mjs
@@ -7,6 +7,30 @@ import SQLite       from '../../../ai/graph/storage/SQLite.mjs';
 import { IDENTITIES } from '../../../ai/graph/identityRoots.mjs';
 
 /**
+ * Row-level-security visibility predicate for an in-memory graph node, mirroring the SQL
+ * RLS clause used by `searchNodes` / `SQLite.loadNodeVicinitySync`. Applied at the public
+ * read return boundary (#10011): the node Store is a process-wide cache, so a node warmed
+ * by one requester's RLS-filtered lazy-load is otherwise readable by any other requester.
+ * @param {Object|null} node A graph node (Record or plain object) from the in-memory Store.
+ * @param {String|null} requesterUserId The acting agent-identity node id, or null.
+ * @returns {Boolean} true when the node is visible to the requester.
+ */
+function isNodeRlsVisible(node, requesterUserId) {
+    if (!node) {
+        return false;
+    }
+
+    const properties  = (node.isRecord ? node.get('properties') : node.properties) || {},
+          ownerUserId = properties.userId;
+
+    return ownerUserId == null              ||
+           ownerUserId === requesterUserId  ||
+           properties.sharedEntity === 1    ||
+           properties.sharedEntity === true ||
+           properties.visibility === 'team';
+}
+
+/**
  * @summary Service that manages the SQLite Knowledge Graph (Nodes and Edges).
  *
  * It provides the topological layout of the Neo.mjs namespace, knowledge,
@@ -105,7 +129,7 @@ class GraphService extends Base {
                 for (const identity of IDENTITIES) {
                     // We use getAdjacentNodes as a trigger for lazy-loading into the cache
                     this.db.getAdjacentNodes(identity.id, 'both');
-                    
+
                     if (!this.db.nodes.has(identity.id)) {
                         this.upsertNode(identity);
                     } else {
@@ -156,13 +180,13 @@ class GraphService extends Base {
         this.db.getAdjacentNodes(id, 'both');
 
         let node = this.db.nodes.get(id);
-        
+
         let currentUserId = this.db.storage?.RequestContextService ? this.db.storage.RequestContextService.getAgentIdentityNodeId() : undefined;
 
         if (node) {
             const currentLabel = node.isRecord ? node.get('label') : node.label;
             const updatedLabel = type || currentLabel || 'NODE';
-            
+
             if (node.isRecord) {
                 node.set({ label: updatedLabel });
             } else {
@@ -186,11 +210,11 @@ class GraphService extends Base {
             if (updatedAt !== undefined) {
                 p.updatedAt = updatedAt;
             }
-            
+
             if (properties !== undefined && typeof properties === 'object') {
                 Object.assign(p, properties);
             }
-            
+
             if (currentUserId !== undefined && p.userId === undefined) {
                 p.userId = currentUserId;
             }
@@ -217,7 +241,7 @@ class GraphService extends Base {
                 updatedAt,
                 ...(properties || {})
             };
-            
+
             if (currentUserId !== undefined && p.userId === undefined) {
                 p.userId = currentUserId;
             }
@@ -233,19 +257,19 @@ class GraphService extends Base {
 
     /**
      * Links two nodes via a relationship tracking edge weight metadata.
-     * 
+     *
      * @summary Creates an edge between two nodes. This method executes as an atomic transaction
-     * (if not already inside one) to prevent race conditions during SQLite WAL flushes. It also 
+     * (if not already inside one) to prevent race conditions during SQLite WAL flushes. It also
      * features a cache-warm retry mechanism on FK verify miss to account for WAL-snapshot-lag
      * from other processes.
-     * 
+     *
      * @description
      * **Transaction Overhead:** Future callers should be aware that invoking `linkNodes` rapidly
      * in a hot path incurs SQLite transaction overhead.
      * **WAL Snapshot Lag:** If a peer process writes a node, the current connection's snapshot
      * might lack it temporarily. This method automatically attempts to warm the cache and retry
      * the FK verification before culling the edge.
-     * 
+     *
      * @param {String} source
      * @param {String} target
      * @param {String} relationship
@@ -261,18 +285,18 @@ class GraphService extends Base {
             // Enforce Foreign Key constraints preemptively to prevent SQLite crash from hallucinated paths
             const verifyStmt = this.db.storage.db.prepare('SELECT count(*) as count FROM Nodes WHERE id IN (?, ?)');
             let count = verifyStmt.get(source, target).count;
-            
+
             let expectedCount = source === target ? 1 : 2;
 
             if (count !== expectedCount) {
                 // #10347 Cache-Warm Retry: If the count check fails, the node might exist in the SQLite WAL
-                // from another agent but hasn't been synced to this connection's snapshot yet. 
+                // from another agent but hasn't been synced to this connection's snapshot yet.
                 // We force a cache warm (which invokes syncCache and WAL read) and re-verify.
                 if (this.db && typeof this.db.getAdjacentNodes === 'function') {
                     // Ensure we attempt to warm both endpoints in case either is the missing link
                     this.db.getAdjacentNodes(source, 'both');
                     this.db.getAdjacentNodes(target, 'both');
-                    
+
                     // Re-evaluate the count after forcing synchronization
                     count = verifyStmt.get(source, target).count;
                 }
@@ -314,7 +338,7 @@ class GraphService extends Base {
                 if (row && row.data) {
                     let parsed = JSON.parse(row.data);
                     parsed.properties = { ...(parsed.properties || {}), ...edgeProperties, weight: newWeight };
-                    
+
                     const updateStmt = this.db.storage.db.prepare(`UPDATE Edges SET data = ? WHERE id = ?`);
                     updateStmt.run(JSON.stringify(parsed), existing.id);
                 }
@@ -545,6 +569,13 @@ class GraphService extends Base {
             return null;
         }
 
+        // #10011 RLS: the node Store is a process-wide cache — re-check visibility at the
+        // return boundary so a cross-requester cache-warmed node is not leaked.
+        let rlsUserId = this.db.storage?.RequestContextService?.getAgentIdentityNodeId() ?? null;
+        if (!isNodeRlsVisible(node, rlsUserId)) {
+            return null;
+        }
+
         const
             nodeId     = node.isRecord ? node.get('id') : node.id,
             label      = node.isRecord ? node.get('label') : node.label,
@@ -562,7 +593,7 @@ class GraphService extends Base {
 
     /**
      * Dynamically computes the structural gravity (inbound/outbound edges) for a node natively via SQLite.
-     * @param {String} id 
+     * @param {String} id
      * @returns {Object} { in_degree, out_degree }
      */
     getNodeGravity(id) {
@@ -593,6 +624,15 @@ class GraphService extends Base {
         // Guarantee lazy-loading vicinity topology securely
         this.db.getAdjacentNodes(id, 'both');
 
+        // #10011 RLS: resolve the requester once; do not expose the vicinity of a node the
+        // requester cannot see, and filter each neighbor by node visibility.
+        let rlsUserId = this.db.storage?.RequestContextService?.getAgentIdentityNodeId() ?? null,
+            rootNode  = this.db.nodes.get(id);
+
+        if (!rootNode || !isNodeRlsVisible(rootNode, rlsUserId)) {
+            return {neighbors: []};
+        }
+
         let results  = [],
             inbound  = this.db.edges.getByIndex('target', id),
             outbound = this.db.edges.getByIndex('source', id);
@@ -600,7 +640,7 @@ class GraphService extends Base {
         [...inbound, ...outbound].forEach(e => {
             let adjacentId = e.source === id ? e.target : e.source;
             let node       = this.db.nodes.get(adjacentId);
-            if (node) {
+            if (node && isNodeRlsVisible(node, rlsUserId)) {
                 results.push({
                     id          : node.id,
                     type        : node.label,
@@ -629,15 +669,15 @@ class GraphService extends Base {
         }
 
         let q = `%${query.toLowerCase()}%`;
-        
+
         let userId = this.db.storage.RequestContextService ? this.db.storage.RequestContextService.getAgentIdentityNodeId() : null;
 
         let rlsClause = `AND (user_id = ? OR user_id IS NULL OR json_extract(data, '$.properties.sharedEntity') = 1 OR json_extract(data, '$.properties.visibility') = 'team')`;
 
         const stmt = this.db.storage.db.prepare(`
-            SELECT data FROM Nodes 
-            WHERE (lower(json_extract(data, '$.properties.name')) LIKE ? 
-               OR lower(json_extract(data, '$.properties.description')) LIKE ? 
+            SELECT data FROM Nodes
+            WHERE (lower(json_extract(data, '$.properties.name')) LIKE ?
+               OR lower(json_extract(data, '$.properties.description')) LIKE ?
                OR lower(id) LIKE ?)
               ${rlsClause}
             LIMIT 50
@@ -674,6 +714,10 @@ class GraphService extends Base {
             return null;
         }
 
+        // #10011 RLS: the frontier anchor is shared, but its strategic neighbors may be
+        // tenant-private — filter them at the return boundary.
+        let rlsUserId = this.db.storage?.RequestContextService?.getAgentIdentityNodeId() ?? null;
+
         const topology = {
             frontier          : {
                 id              : frontierNode.id,
@@ -695,8 +739,8 @@ class GraphService extends Base {
                 let adjacentId = e.source === 'frontier' ? e.target : e.source;
                 let node       = this.db.nodes.get(adjacentId);
 
-                // Actively filter out CLOSED structural paths
-                if (node && node.properties?.state !== 'CLOSED') {
+                // Actively filter out CLOSED structural paths + #10011 RLS-invisible nodes
+                if (node && isNodeRlsVisible(node, rlsUserId) && node.properties?.state !== 'CLOSED') {
                     topology.strategicNeighbors.push({
                         id              : node.id,
                         type            : node.label,
@@ -731,6 +775,14 @@ class GraphService extends Base {
             return null;
         }
 
+        // #10011 RLS: the node Store is a process-wide cache — re-check the cache-resident
+        // root and every traversed node at the return boundary.
+        let rlsUserId = this.db.storage?.RequestContextService?.getAgentIdentityNodeId() ?? null;
+        if (!isNodeRlsVisible(rootNode, rlsUserId)) {
+            logger.info(`[GraphService] Node ${nodeId} not visible to the active requester.`);
+            return null;
+        }
+
         const topology = {
             root : {
                 id              : rootNode.id,
@@ -759,6 +811,15 @@ class GraphService extends Base {
                 const outbound = this.db.edges.getByIndex('source', id);
 
                 [...inbound, ...outbound].forEach(e => {
+                    let adjacentId = e.source === id ? e.target : e.source;
+                    let n          = this.db.nodes.get(adjacentId);
+
+                    // #10011 RLS: skip an edge whose far node is absent or not visible to
+                    // the requester — do not leak the node, the edge, or traverse through it.
+                    if (!n || !isNodeRlsVisible(n, rlsUserId)) {
+                        return;
+                    }
+
                     if (!visitedEdges.has(e.id)) {
                         visitedEdges.add(e.id);
                         topology.edges.push({
@@ -769,20 +830,16 @@ class GraphService extends Base {
                         });
                     }
 
-                    let adjacentId = e.source === id ? e.target : e.source;
                     if (!visitedNodes.has(adjacentId)) {
                         visitedNodes.add(adjacentId);
                         nextLevel.add(adjacentId);
-                        let n = this.db.nodes.get(adjacentId);
-                        if (n) {
-                            topology.nodes.push({
-                                id              : n.id,
-                                type            : n.label,
-                                name            : n.properties?.name,
-                                description     : n.properties?.description,
-                                semanticVectorId: n.properties?.semanticVectorId
-                            });
-                        }
+                        topology.nodes.push({
+                            id              : n.id,
+                            type            : n.label,
+                            name            : n.properties?.name,
+                            description     : n.properties?.description,
+                            semanticVectorId: n.properties?.semanticVectorId
+                        });
                     }
                 });
             }
@@ -886,7 +943,7 @@ class GraphService extends Base {
      */
     getOrphanedNodes() {
         if (!this.db || !this.db.storage || !this.db.storage.db) return [];
-        
+
         const stmt = this.db.storage.db.prepare(`
             SELECT n.id, n.data
             FROM Nodes n
@@ -901,7 +958,7 @@ class GraphService extends Base {
                 // n.data maps to JSON payload storing the node label
                 data = JSON.parse(row.data);
             } catch(e) { continue; }
-            
+
             if (data.label !== 'SYSTEM_ANCHOR' && data.label !== 'System' && data.label !== 'ISSUE' && data.label !== 'DISCUSSION' && data.label !== 'PULL_REQUEST' && data.label !== 'SESSION' && data.label !== 'MEMORY' && data.label !== 'AgentIdentity' && data.label !== 'BroadcastSentinel' && data.label !== 'WAKE_SUBSCRIPTION') {
                 orphaned.push(row.id);
             }
@@ -916,7 +973,7 @@ class GraphService extends Base {
      */
     removeNodes(nodeIds) {
         if (!nodeIds || nodeIds.length === 0) return;
-        
+
         this.db.transaction(() => {
             nodeIds.forEach(id => this.db.removeNode(id));
         });

--- a/test/playwright/unit/ai/services/memory-core/GraphService.TenantIsolation.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/GraphService.TenantIsolation.spec.mjs
@@ -21,12 +21,12 @@ import * as core      from '../../../../../../src/core/_export.mjs';
  * #10011 — graph RLS read-side return boundary.
  *
  * `getNode` / `getNeighbors` / `queryNodeTopology` / `getContextFrontier` return graph nodes
- * read from `GraphService.db.nodes` — a process-wide in-memory Store. The SQL RLS clause in
- * `searchNodes` / `SQLite.loadNodeVicinitySync` filters only the lazy-load path; a node warmed
- * into the Store by one requester's load is otherwise readable by any other requester straight
- * from the cache. These specs stub `GraphService.db` with a pre-warmed fake Store (the
- * cache-warmed case) and assert the `isNodeRlsVisible` return-boundary predicate filters
- * cross-tenant nodes.
+ * AND edges read from `GraphService.db` — process-wide in-memory Stores. The SQL RLS clause in
+ * `searchNodes` / `SQLite.loadNodeVicinitySync` filters only the lazy-load path (and applies to
+ * BOTH the Nodes and Edges tables); a node or edge warmed into the Store by one requester's
+ * load is otherwise readable by any other requester straight from the cache. These specs stub
+ * `GraphService.db` with a pre-warmed fake Store (the cache-warmed case) and assert the
+ * `isRlsVisible` return-boundary predicate filters cross-tenant nodes and edges.
  *
  * RLS-visible to requester R iff: owner is null  OR  owner === R  OR  sharedEntity  OR
  * visibility === 'team' — mirroring the SQL clause.
@@ -39,8 +39,8 @@ function node(id, properties = {}) {
     return {id, label: properties.type || 'TestNode', properties};
 }
 
-function edge(id, source, target, weight = 1.0) {
-    return {id, source, target, type: 'REL', properties: {weight}};
+function edge(id, source, target, weight = 1.0, props = {}) {
+    return {id, source, target, type: 'REL', properties: {weight, ...props}};
 }
 
 /**
@@ -201,5 +201,49 @@ test.describe('GraphService — RLS read-side return boundary (#10011)', () => {
         expect(GraphService.getNode({id: 'n-private-a'})).toBeNull();
         expect(GraphService.getNode({id: 'n-team'})?.id).toBe('n-team');
         expect(GraphService.getNode({id: 'n-system'})?.id).toBe('n-system');
+    });
+
+    test('getNeighbors hides a neighbor reached only by a cross-tenant private edge', () => {
+        GraphService.db = makeFakeDb([
+            node('root-b', {userId: '@tenant-b'}),
+            node('n-team', {visibility: 'team'})
+        ], [
+            // n-team is team-visible, but the only edge to it is tenant A's private edge.
+            edge('e-private', 'root-b', 'n-team', 1.0, {userId: '@tenant-a'})
+        ]);
+
+        requester.value = '@tenant-b';
+
+        expect(GraphService.getNeighbors({id: 'root-b'}).neighbors).toEqual([]);
+    });
+
+    test('queryNodeTopology omits a cross-tenant private edge between visible nodes', () => {
+        GraphService.db = makeFakeDb([
+            node('root-b', {userId: '@tenant-b'}),
+            node('n-team', {visibility: 'team'})
+        ], [
+            edge('e-private', 'root-b', 'n-team', 1.0, {userId: '@tenant-a'})
+        ]);
+
+        requester.value = '@tenant-b';
+
+        const topology = GraphService.queryNodeTopology({nodeId: 'root-b', maxDepth: 2});
+
+        // The private edge is not surfaced, and n-team is not reached through it.
+        expect(topology.edges).toEqual([]);
+        expect(topology.nodes.map(n => n.id)).not.toContain('n-team');
+    });
+
+    test('getContextFrontier hides a strategic neighbor reached by a private edge', () => {
+        GraphService.db = makeFakeDb([
+            node('frontier'),
+            node('n-team', {visibility: 'team'})
+        ], [
+            edge('e-private', 'frontier', 'n-team', 1.0, {userId: '@tenant-a'})
+        ]);
+
+        requester.value = '@tenant-b';
+
+        expect(GraphService.getContextFrontier({depth: 2}).strategicNeighbors).toEqual([]);
     });
 });

--- a/test/playwright/unit/ai/services/memory-core/GraphService.TenantIsolation.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/GraphService.TenantIsolation.spec.mjs
@@ -1,0 +1,205 @@
+import { setup } from '../../../../setup.mjs';
+
+const appName = 'GraphServiceTenantIsolationTest';
+
+setup({
+    neoConfig: {
+        unitTestMode: true
+    },
+    appConfig: {
+        name             : appName,
+        isMounted        : () => true,
+        vnodeInitialising: false
+    }
+});
+
+import {test, expect} from '@playwright/test';
+import Neo            from '../../../../../../src/Neo.mjs';
+import * as core      from '../../../../../../src/core/_export.mjs';
+
+/**
+ * #10011 — graph RLS read-side return boundary.
+ *
+ * `getNode` / `getNeighbors` / `queryNodeTopology` / `getContextFrontier` return graph nodes
+ * read from `GraphService.db.nodes` — a process-wide in-memory Store. The SQL RLS clause in
+ * `searchNodes` / `SQLite.loadNodeVicinitySync` filters only the lazy-load path; a node warmed
+ * into the Store by one requester's load is otherwise readable by any other requester straight
+ * from the cache. These specs stub `GraphService.db` with a pre-warmed fake Store (the
+ * cache-warmed case) and assert the `isNodeRlsVisible` return-boundary predicate filters
+ * cross-tenant nodes.
+ *
+ * RLS-visible to requester R iff: owner is null  OR  owner === R  OR  sharedEntity  OR
+ * visibility === 'team' — mirroring the SQL clause.
+ */
+
+// Mutable holder so one fake db can switch the "active requester" between calls.
+const requester = {value: null};
+
+function node(id, properties = {}) {
+    return {id, label: properties.type || 'TestNode', properties};
+}
+
+function edge(id, source, target, weight = 1.0) {
+    return {id, source, target, type: 'REL', properties: {weight}};
+}
+
+/**
+ * Builds a fake `GraphService.db`: a pre-warmed in-memory node/edge Store plus a stubbed
+ * `storage.RequestContextService` whose `getAgentIdentityNodeId()` returns `requester.value`.
+ * `getAdjacentNodes` is a no-op — every node under test is pre-warmed, simulating the
+ * process-wide cache already holding a cross-tenant node.
+ */
+function makeFakeDb(nodes, edges = []) {
+    const nodeMap = new Map(nodes.map(n => [n.id, n]));
+    return {
+        getAdjacentNodes() {},
+        nodes: nodeMap,
+        edges: {
+            getByIndex(field, id) {
+                return edges.filter(e => e[field] === id);
+            }
+        },
+        storage: {
+            RequestContextService: {
+                getAgentIdentityNodeId: () => requester.value
+            }
+        }
+    };
+}
+
+test.describe('GraphService — RLS read-side return boundary (#10011)', () => {
+    let GraphService, originalDb;
+
+    test.beforeAll(async () => {
+        GraphService = (await import('../../../../../../ai/services/memory-core/GraphService.mjs')).default;
+    });
+
+    test.beforeEach(() => {
+        originalDb      = GraphService.db;
+        requester.value = null;
+    });
+
+    test.afterEach(() => {
+        GraphService.db = originalDb;
+        requester.value = null;
+    });
+
+    test('getNode hides a cache-warmed node owned by a different tenant', () => {
+        GraphService.db = makeFakeDb([
+            node('n-private-a', {userId: '@tenant-a', name: 'A private'}),
+            node('n-own-b',     {userId: '@tenant-b', name: 'B own'}),
+            node('n-team',      {visibility: 'team',  name: 'Team node'}),
+            node('n-shared',    {sharedEntity: 1,     name: 'Shared node'}),
+            node('n-system')  // no userId — null-owned, broadly visible
+        ]);
+
+        requester.value = '@tenant-b';
+
+        // The leak case: A's private node is warmed in the Store; B must not receive it.
+        expect(GraphService.getNode({id: 'n-private-a'})).toBeNull();
+
+        // RLS must NOT over-deny: B's own + team + shared + null-owned all resolve.
+        expect(GraphService.getNode({id: 'n-own-b'})?.id).toBe('n-own-b');
+        expect(GraphService.getNode({id: 'n-team'})?.id).toBe('n-team');
+        expect(GraphService.getNode({id: 'n-shared'})?.id).toBe('n-shared');
+        expect(GraphService.getNode({id: 'n-system'})?.id).toBe('n-system');
+    });
+
+    test('getNode returns the owner\'s own private node to the owner', () => {
+        GraphService.db = makeFakeDb([
+            node('n-private-a', {userId: '@tenant-a', name: 'A private'})
+        ]);
+        requester.value = '@tenant-a';
+
+        expect(GraphService.getNode({id: 'n-private-a'})?.id).toBe('n-private-a');
+    });
+
+    test('getNeighbors filters cross-tenant neighbor nodes', () => {
+        GraphService.db = makeFakeDb([
+            node('root-b',      {userId: '@tenant-b'}),
+            node('n-private-a', {userId: '@tenant-a', name: 'A private'}),
+            node('n-team',      {visibility: 'team',  name: 'Team node'})
+        ], [
+            edge('e1', 'root-b', 'n-private-a'),
+            edge('e2', 'root-b', 'n-team')
+        ]);
+
+        requester.value = '@tenant-b';
+
+        const ids = GraphService.getNeighbors({id: 'root-b'}).neighbors.map(n => n.id);
+
+        expect(ids).toContain('n-team');
+        expect(ids).not.toContain('n-private-a');
+    });
+
+    test('getNeighbors returns no neighbors when the root node is not visible', () => {
+        GraphService.db = makeFakeDb([
+            node('root-a', {userId: '@tenant-a'}),
+            node('n-team', {visibility: 'team'})
+        ], [
+            edge('e1', 'root-a', 'n-team')
+        ]);
+
+        requester.value = '@tenant-b';
+
+        // B cannot see root-a, so it must not receive root-a's vicinity at all.
+        expect(GraphService.getNeighbors({id: 'root-a'}).neighbors).toEqual([]);
+    });
+
+    test('queryNodeTopology rejects an invisible root and prunes invisible far nodes', () => {
+        GraphService.db = makeFakeDb([
+            node('root-b',      {userId: '@tenant-b'}),
+            node('n-private-a', {userId: '@tenant-a'}),
+            node('n-team',      {visibility: 'team'})
+        ], [
+            edge('e1', 'root-b', 'n-private-a'),
+            edge('e2', 'root-b', 'n-team')
+        ]);
+
+        requester.value = '@tenant-b';
+
+        const topology = GraphService.queryNodeTopology({nodeId: 'root-b', maxDepth: 2}),
+              ids      = topology.nodes.map(n => n.id);
+
+        expect(ids).toContain('root-b');
+        expect(ids).toContain('n-team');
+        expect(ids).not.toContain('n-private-a');
+        // The edge to the pruned node is dropped — every surfaced edge connects visible nodes.
+        expect(topology.edges.some(e => e.source === 'n-private-a' || e.target === 'n-private-a')).toBe(false);
+
+        // Invisible root → null; no topology is leaked.
+        expect(GraphService.queryNodeTopology({nodeId: 'n-private-a', maxDepth: 2})).toBeNull();
+    });
+
+    test('getContextFrontier filters cross-tenant strategic neighbors', () => {
+        GraphService.db = makeFakeDb([
+            node('frontier'),  // SYSTEM_ANCHOR — null-owned, visible to all
+            node('n-private-a', {userId: '@tenant-a'}),
+            node('n-team',      {visibility: 'team'})
+        ], [
+            edge('e1', 'frontier', 'n-private-a', 1.0),
+            edge('e2', 'frontier', 'n-team',      1.0)
+        ]);
+
+        requester.value = '@tenant-b';
+
+        const ids = GraphService.getContextFrontier({depth: 2}).strategicNeighbors.map(n => n.id);
+
+        expect(ids).toContain('n-team');
+        expect(ids).not.toContain('n-private-a');
+    });
+
+    test('a null requester sees only null-owned / shared / team nodes', () => {
+        GraphService.db = makeFakeDb([
+            node('n-private-a', {userId: '@tenant-a'}),
+            node('n-team',      {visibility: 'team'}),
+            node('n-system')
+        ]);
+
+        requester.value = null;  // no authenticated request context
+
+        expect(GraphService.getNode({id: 'n-private-a'})).toBeNull();
+        expect(GraphService.getNode({id: 'n-team'})?.id).toBe('n-team');
+        expect(GraphService.getNode({id: 'n-system'})?.id).toBe('n-system');
+    });
+});


### PR DESCRIPTION
Resolves #10011

Authored by Claude Opus 4.7 (Claude Code). Session 7360e917-1733-4cdd-a6f3-5ac51c34b838.

FAIR-band: in-band — operator nightshift directive 2026-05-20: continuous parallel-lane pickup on Epic #11624. #10011 is the read-side graph-RLS lane @neo-gpt and I converged on as the strongest pre-Phase-2 work — GPT posted the #10011 readiness overlay (issuecomment-4494253926); this PR implements the closeout slice. Parallel to GPT's #11669/#11670 — different files, no merge collision.

Completes #10011 (Native Edge Graph: Row-Level Security & Tenant Isolation) — the read-side return-boundary filter. Tasks 1-2 (the `user_id` column on `Nodes`/`Edges` + write-side `userId` stamping) were already shipped; this PR closes task 3 — RLS on the graph read primitives.

## The leak

`getNode`, `getNeighbors`, `queryNodeTopology`, and `getContextFrontier` return graph nodes — and the edges between them — read from `GraphService.db`, a **process-wide** in-memory Store. The SQL RLS clause in `searchNodes` / `SQLite.loadNodeVicinitySync` filters only the *lazy-load* path, and applies to BOTH the `Nodes` and `Edges` tables. A node or edge warmed into the Store by one requester's load is then readable by any other requester straight from the cache, bypassing RLS — the vicinity cache is keyed by entity id, not by requester identity (cross-family-verified against @neo-gpt's #10011 readiness overlay, and tightened to cover edges per the PR #11672 Cycle 1 review).

## The fix

A centralized `isRlsVisible(entity, requesterUserId)` predicate mirrors the SQL RLS clause `loadNodeVicinitySync` applies to BOTH tables (owner match / null owner / `sharedEntity` / `visibility: 'team'`), applied at each public read return boundary — to nodes AND edges, since edges carry their own server-stamped `properties.userId`:

- `getNode` — returns `null` for a node not visible to the requester.
- `getNeighbors` — returns no neighbors when the root is invisible; a neighbor is exposed only when BOTH the adjacent node and the connecting edge are RLS-visible.
- `getContextFrontier` — filters `strategicNeighbors` by node + edge visibility (the frontier anchor itself is shared / null-owned).
- `queryNodeTopology` — rejects an invisible root; skips an edge (no surface, no traversal) when the edge itself is invisible, or its far node is invisible/absent.

`getContextFrontier` extends #10011's literally-named primitives (`get_node` / `search_nodes` / `query_hybrid_graph`) — it has the identical process-wide-cache leak; a fix covering 3 of 4 equivalent read paths would not be a real closeout.

Evidence: L2 (10 unit tests — cache-warmed-leak coverage across all 4 read primitives, the node RLS-visibility matrix, the null-requester case, and 3 private-edge cases) → L2 sufficient (the RLS predicate + the return-boundary applications are mechanically verifiable in unit scope; live cross-tenant graph traffic arrives with the Phase 2 ingestion service). No residuals.

## Deltas from ticket

- `getContextFrontier` added to the named-3 — equivalent process-wide-cache leak; security-completeness (a 3-of-4 fix is not a closeout).
- Edge RLS — Cycle 1 review (@neo-gpt) caught that the first revision filtered cache-resident nodes only; edges carry their own `user_id` and the SQL lazy-load filters the `Edges` table too. Extended: the predicate generalized to `isRlsVisible` (node OR edge) and applied to edges in the relationship-surfacing methods.
- `searchNodes` left as-is — it already carries the SQL RLS clause; #10011's gap was strictly the in-memory-read methods. Further unification (a single shared source for the SQL clause + the JS predicate) is a possible follow-up, not required for this closeout.
- Incidental: stripped pre-existing trailing whitespace in `GraphService.mjs` — `check-whitespace.mjs` is a whole-file (not diff-aware) pre-commit hook, so touching the file forces full-file cleanup.

## Test Evidence

New spec: `test/playwright/unit/ai/services/memory-core/GraphService.TenantIsolation.spec.mjs` — **10 tests, 10 passed** (`npm run test-unit`). The spec stubs `GraphService.db` with a pre-warmed in-memory fake Store (the cache-warmed case) and a controllable requester identity; no real SQLite / Chroma is touched.

| # | Scenario |
|---|---|
| 1 | `getNode` hides a cache-warmed node owned by a different tenant; resolves own / team / shared / null-owned |
| 2 | `getNode` returns the owner's own private node to the owner |
| 3 | `getNeighbors` filters cross-tenant neighbor nodes |
| 4 | `getNeighbors` returns no neighbors when the root node is not visible |
| 5 | `queryNodeTopology` rejects an invisible root and prunes invisible far nodes |
| 6 | `getContextFrontier` filters cross-tenant strategic neighbors |
| 7 | a null requester sees only null-owned / shared / team nodes |
| 8 | `getNeighbors` hides a neighbor reached only by a cross-tenant private edge |
| 9 | `queryNodeTopology` omits a cross-tenant private edge between visible nodes |
| 10 | `getContextFrontier` hides a strategic neighbor reached by a private edge |

## Post-Merge Validation

- [ ] When Phase 2 multi-tenant ingestion lands, the read-side RLS is exercised end-to-end against live cross-tenant graph data
- [ ] Follow-up: decide whether the `searchNodes` SQL RLS clause and the `isRlsVisible` JS predicate should share a single source of truth (currently mirror-by-convention)

## Commits

- `3ff2b7b29` — feat(memory-core): graph RLS return-boundary filter for cache-resident reads (#10011)
- `9582367ba` — test(memory-core): cache-warmed-leak coverage for graph RLS read boundary (#10011)
- `5d80fafd1` — fix(memory-core): extend graph RLS return-boundary filter to edges (#10011)
