### PR TITLE
feat(ai): support remote MCP client transports (#10900)

### DIFF
--- a/ai/mcp/client/Client.mjs
+++ b/ai/mcp/client/Client.mjs
@@ -1,11 +1,13 @@
 import {Client as McpSdkClient} from '@modelcontextprotocol/sdk/client/index.js';
+import {SSEClientTransport}     from '@modelcontextprotocol/sdk/client/sse.js';
 import {StdioClientTransport}   from '@modelcontextprotocol/sdk/client/stdio.js';
+import {StreamableHTTPClientTransport} from '@modelcontextprotocol/sdk/client/streamableHttp.js';
 import Base                     from '../../../src/core/Base.mjs';
 import ClientConfig             from './config.mjs';
 import ToolService              from '../ToolService.mjs';
 
 /**
- * @summary A generic MCP Client that can connect to any local MCP server via Stdio.
+ * @summary A generic MCP Client that can connect to local or remote MCP servers.
  *
  * This class wraps the official MCP SDK Client in a Neo.mjs class structure.
  * It handles the connection lifecycle and tool discovery.
@@ -61,6 +63,21 @@ class Client extends Base {
          */
         requiredEnv: [],
         /**
+         * Additional SDK transport options for HTTP/SSE transports.
+         * @member {Object} transportOptions={}
+         */
+        transportOptions: {},
+        /**
+         * Transport type to use: 'stdio', 'sse', or 'streamable-http'.
+         * @member {String} transportType='stdio'
+         */
+        transportType: 'stdio',
+        /**
+         * Remote MCP endpoint URL for HTTP/SSE transports.
+         * @member {String|null} url=null
+         */
+        url: null,
+        /**
          * The logical name of the MCP server to connect to (e.g., 'github-workflow').
          * This name will be used to look up connection details from ClientConfig.
          * @member {String} serverName_='github-workflow'
@@ -108,6 +125,56 @@ class Client extends Base {
         if (value) {
             this.loadServerConfig(value);
         }
+    }
+
+    /**
+     * @summary Creates the SDK transport for the configured server connection.
+     * Creates the SDK transport for the configured server connection.
+     * @returns {StdioClientTransport|SSEClientTransport|StreamableHTTPClientTransport}
+     * @throws {Error} When the configured transport is unknown or incomplete.
+     */
+    createTransport() {
+        const me            = this,
+              transportType = me.normalizeTransportType(me.transportType);
+
+        switch (transportType) {
+        case 'stdio':
+            if (!me.command || !me.args) {
+                throw new Error('MCP Client: stdio transport requires server command and arguments. Ensure serverName is valid and config.mjs is properly configured.');
+            }
+
+            return new StdioClientTransport({
+                command: me.command,
+                args   : me.args,
+                env    : me.env
+            });
+
+        case 'sse':
+            return new SSEClientTransport(me.createTransportUrl(transportType), me.transportOptions);
+
+        case 'streamable-http':
+            return new StreamableHTTPClientTransport(me.createTransportUrl(transportType), me.transportOptions);
+
+        default:
+            throw new Error(`MCP Client: Unsupported transport type '${me.transportType}' for '${me.serverName}'. Expected 'stdio', 'sse', or 'streamable-http'.`);
+        }
+    }
+
+    /**
+     * @summary Creates a URL object for remote MCP SDK transports.
+     * Creates a URL object for remote MCP SDK transports.
+     * @param {String} transportType The normalized transport type.
+     * @returns {URL}
+     * @throws {Error} When no remote URL is configured.
+     */
+    createTransportUrl(transportType) {
+        const url = this.url;
+
+        if (!url) {
+            throw new Error(`MCP Client: ${transportType} transport requires a remote url in ai/mcp/client/config.mjs`);
+        }
+
+        return url instanceof URL ? url : new URL(url);
     }
 
     /**
@@ -183,15 +250,7 @@ class Client extends Base {
         });
 
         // 3. Connect the client and create tool proxies
-        if (!me.command || !me.args) {
-            throw new Error('MCP Client: Server command and arguments are not set. Ensure serverName is valid and config.mjs is properly configured.');
-        }
-
-        me.transport = new StdioClientTransport({
-            command: me.command,
-            args   : me.args,
-            env    : me.env
-        });
+        me.transport = me.createTransport();
 
         me.client = new McpSdkClient({
             name   : me.clientName,
@@ -250,12 +309,33 @@ class Client extends Base {
         if (!serverConfig) {
             throw new Error(`MCP Client: Server config not found for '${serverName}' in ai/mcp/client/config.mjs`);
         }
-        me.command         = serverConfig.command;
-        me.args            = serverConfig.args;
-        me.openApiFilePath = serverConfig.openApiFilePath || null;
-        me.requiredEnv     = serverConfig.requiredEnv     || [];
+        me.command          = serverConfig.command          || null;
+        me.args             = serverConfig.args             || null;
+        me.openApiFilePath  = serverConfig.openApiFilePath  || null;
+        me.requiredEnv      = serverConfig.requiredEnv      || [];
+        me.transportOptions = serverConfig.transportOptions || {};
+        me.transportType    = serverConfig.transportType || serverConfig.transport || 'stdio';
+        me.url              = serverConfig.url              || null;
         // Note: env from config.mjs is not explicitly merged here,
         // assuming agent will manage its own env (like GH_TOKEN) and pass it to client instance.
+    }
+
+    /**
+     * @summary Normalizes supported transport aliases to canonical config values.
+     * Normalizes supported transport aliases to canonical config values.
+     * @param {String} transportType The configured transport type or alias.
+     * @returns {String}
+     */
+    normalizeTransportType(transportType = 'stdio') {
+        switch (transportType) {
+        case 'http':
+        case 'streamableHttp':
+        case 'streamable-http':
+            return 'streamable-http';
+
+        default:
+            return transportType;
+        }
     }
 }
 

--- a/ai/mcp/client/Client.mjs
+++ b/ai/mcp/client/Client.mjs
@@ -129,7 +129,9 @@ class Client extends Base {
 
     /**
      * @summary Creates the SDK transport for the configured server connection.
-     * Creates the SDK transport for the configured server connection.
+     *
+     * Local servers use stdio process spawning, while remote endpoints use the SDK's URL-based
+     * SSE or Streamable HTTP transports with the configured transport options.
      * @returns {StdioClientTransport|SSEClientTransport|StreamableHTTPClientTransport}
      * @throws {Error} When the configured transport is unknown or incomplete.
      */
@@ -162,13 +164,16 @@ class Client extends Base {
 
     /**
      * @summary Creates a URL object for remote MCP SDK transports.
-     * Creates a URL object for remote MCP SDK transports.
+     *
+     * Accepts a configured string or pre-built URL instance and keeps the fail-fast error tied
+     * to the normalized transport type that requested it.
      * @param {String} transportType The normalized transport type.
      * @returns {URL}
      * @throws {Error} When no remote URL is configured.
      */
     createTransportUrl(transportType) {
-        const url = this.url;
+        const me  = this,
+              url = me.url;
 
         if (!url) {
             throw new Error(`MCP Client: ${transportType} transport requires a remote url in ai/mcp/client/config.mjs`);
@@ -322,7 +327,9 @@ class Client extends Base {
 
     /**
      * @summary Normalizes supported transport aliases to canonical config values.
-     * Normalizes supported transport aliases to canonical config values.
+     *
+     * Preserves unknown values so `createTransport()` can produce the single authoritative
+     * unsupported-transport error instead of silently coercing configuration typos.
      * @param {String} transportType The configured transport type or alias.
      * @returns {String}
      */

--- a/ai/mcp/client/config.mjs
+++ b/ai/mcp/client/config.mjs
@@ -10,35 +10,43 @@ const defaultConfig = {
     /**
      * A map of MCP server configurations.
      * The key is the logical name of the server (e.g., 'github-workflow').
-     * The value is an object with 'command' and 'args' properties.
+     * The value is an object with transport-specific connection properties:
+     * - `transportType: 'stdio'` uses `command` + `args`.
+     * - `transportType: 'sse'` or `'streamable-http'` uses `url` + optional `transportOptions`.
      */
     mcpServers: {
         "chrome-devtools": {
-            command: "npx",
-            args   : ["-y", "chrome-devtools-mcp@latest"]
+            transportType: "stdio",
+            command      : "npx",
+            args         : ["-y", "chrome-devtools-mcp@latest"]
         },
         "file-system": {
-            command: "npm",
-            args   : ["run", "ai:mcp-server-file-system"]
+            transportType: "stdio",
+            command      : "npm",
+            args         : ["run", "ai:mcp-server-file-system"]
         },
         "github-workflow": {
-            command    : "npm",
-            args       : ["run", "ai:mcp-server-github-workflow"],
-            requiredEnv: ["GH_TOKEN"]
+            transportType: "stdio",
+            command      : "npm",
+            args         : ["run", "ai:mcp-server-github-workflow"],
+            requiredEnv  : ["GH_TOKEN"]
         },
         "knowledge-base": {
-            command    : "npm",
-            args       : ["run", "ai:mcp-server-knowledge-base"],
-            requiredEnv: ["GEMINI_API_KEY"]
+            transportType: "stdio",
+            command      : "npm",
+            args         : ["run", "ai:mcp-server-knowledge-base"],
+            requiredEnv  : ["GEMINI_API_KEY"]
         },
         "memory-core": {
-            command    : "npm",
-            args       : ["run", "ai:mcp-server-memory-core"],
-            requiredEnv: ["GEMINI_API_KEY"]
+            transportType: "stdio",
+            command      : "npm",
+            args         : ["run", "ai:mcp-server-memory-core"],
+            requiredEnv  : ["GEMINI_API_KEY"]
         },
         "neural-link": {
-            command: "npm",
-            args   : ["run", "ai:mcp-server-neural-link"]
+            transportType: "stdio",
+            command      : "npm",
+            args         : ["run", "ai:mcp-server-neural-link"]
         }
     }
 };

--- a/test/playwright/unit/ai/mcp/client/McpClientTransportConfig.spec.mjs
+++ b/test/playwright/unit/ai/mcp/client/McpClientTransportConfig.spec.mjs
@@ -133,4 +133,18 @@ test.describe('Neo.ai.mcp.client.Client transport config', () => {
 
         client.destroy();
     });
+
+    test('fails fast when the configured transport type is unsupported', () => {
+        const serverName = addServerConfig({
+            transportType: 'websocket',
+            url          : 'http://127.0.0.1:13093/mcp'
+        });
+        const client = Neo.create(TransportConfigClient, {serverName});
+
+        client.loadServerConfig(serverName);
+
+        expect(() => client.createTransport()).toThrow(/Unsupported transport type 'websocket'/);
+
+        client.destroy();
+    });
 });

--- a/test/playwright/unit/ai/mcp/client/McpClientTransportConfig.spec.mjs
+++ b/test/playwright/unit/ai/mcp/client/McpClientTransportConfig.spec.mjs
@@ -1,0 +1,136 @@
+import {setup} from '../../../../setup.mjs';
+
+setup({
+    neoConfig: {
+        unitTestMode: true
+    },
+    appConfig: {
+        name             : 'McpClientTransportConfigTest',
+        isMounted        : () => true,
+        vnodeInitialising: false
+    }
+});
+
+import {test, expect} from '@playwright/test';
+import crypto         from 'crypto';
+
+import {SSEClientTransport}            from '@modelcontextprotocol/sdk/client/sse.js';
+import {StdioClientTransport}          from '@modelcontextprotocol/sdk/client/stdio.js';
+import {StreamableHTTPClientTransport} from '@modelcontextprotocol/sdk/client/streamableHttp.js';
+
+import Neo          from '../../../../../../src/Neo.mjs';
+import * as core    from '../../../../../../src/core/_export.mjs';
+import Client       from '../../../../../../ai/mcp/client/Client.mjs';
+import ClientConfig from '../../../../../../ai/mcp/client/config.mjs';
+
+const addedServerNames = new Set();
+
+class TransportConfigClient extends Client {
+    static config = {
+        className: 'Test.ai.mcp.client.TransportConfigClient'
+    }
+
+    async initAsync() {}
+}
+
+TransportConfigClient = Neo.setupClass(TransportConfigClient);
+
+function addServerConfig(config) {
+    const serverName = `transport-${crypto.randomUUID()}`;
+
+    ClientConfig.data.mcpServers[serverName] = config;
+    addedServerNames.add(serverName);
+
+    return serverName;
+}
+
+test.describe('Neo.ai.mcp.client.Client transport config', () => {
+    test.afterEach(() => {
+        for (const serverName of addedServerNames) {
+            delete ClientConfig.data.mcpServers[serverName];
+        }
+        addedServerNames.clear();
+    });
+
+    test('keeps stdio as the default transport for existing server configs', () => {
+        const client = Neo.create(TransportConfigClient, {
+            serverName: 'github-workflow'
+        });
+
+        client.loadServerConfig('github-workflow');
+
+        expect(client.transportType).toBe('stdio');
+        expect(client.command).toBe('npm');
+        expect(client.args).toEqual(['run', 'ai:mcp-server-github-workflow']);
+        expect(client.createTransport()).toBeInstanceOf(StdioClientTransport);
+
+        client.destroy();
+    });
+
+    test('creates streamable HTTP transports from remote endpoint config', () => {
+        const serverName = addServerConfig({
+            transportType   : 'streamable-http',
+            url             : 'http://127.0.0.1:13090/mcp',
+            transportOptions: {
+                requestInit: {
+                    headers: {
+                        'X-PREFERRED-USERNAME': '@neo-gpt'
+                    }
+                }
+            }
+        });
+        const client = Neo.create(TransportConfigClient, {serverName});
+
+        client.loadServerConfig(serverName);
+
+        expect(client.command).toBe(null);
+        expect(client.args).toBe(null);
+        expect(client.transportType).toBe('streamable-http');
+        expect(client.createTransport()).toBeInstanceOf(StreamableHTTPClientTransport);
+
+        client.destroy();
+    });
+
+    test('creates deprecated SSE transports for legacy remote servers', () => {
+        const serverName = addServerConfig({
+            transportType: 'sse',
+            url          : 'http://127.0.0.1:13091/sse'
+        });
+        const client = Neo.create(TransportConfigClient, {serverName});
+
+        client.loadServerConfig(serverName);
+
+        expect(client.transportType).toBe('sse');
+        expect(client.createTransport()).toBeInstanceOf(SSEClientTransport);
+
+        client.destroy();
+    });
+
+    test('accepts streamable HTTP transport aliases from config files', () => {
+        const serverName = addServerConfig({
+            transport: 'http',
+            url      : 'http://127.0.0.1:13092/mcp'
+        });
+        const client = Neo.create(TransportConfigClient, {serverName});
+
+        client.loadServerConfig(serverName);
+
+        expect(client.normalizeTransportType(client.transportType)).toBe('streamable-http');
+        expect(client.createTransport()).toBeInstanceOf(StreamableHTTPClientTransport);
+
+        client.destroy();
+    });
+
+    test('fails fast when a remote transport has no endpoint URL', () => {
+        const serverName = addServerConfig({
+            transportType: 'streamable-http'
+        });
+        const client = Neo.create(TransportConfigClient, {serverName});
+
+        client.loadServerConfig(serverName);
+
+        expect(() => client.createTransport()).toThrow(/requires a remote url/);
+
+        client.destroy();
+    });
+});


### PR DESCRIPTION
Authored by GPT-5 (Codex Desktop). Session 021172f9-cf8a-4762-917f-95bdf261ad23.

FAIR-band: under-target [11/30] — Self-Selection Rule 1 fires (under-band → bias toward author lane).

Resolves #10900

Adds configurable MCP SDK transport selection to `Neo.ai.mcp.client.Client` so existing stdio server configs keep working while remote/containerized MCP servers can be reached through `SSEClientTransport` or `StreamableHTTPClientTransport`. The built-in configs now declare `transportType: "stdio"` explicitly, and custom configs can opt into remote transports with `transportType` + `url` + optional SDK `transportOptions`.

Evidence: L2 (transport-factory unit coverage + stdio health regression) → L2 required (#10900 capability support; full L4 integration adoption is explicitly out of scope). No residuals.

## Deltas from ticket

- Uses `transportType` as the canonical config key to avoid colliding with the live SDK `transport` instance field.
- Accepts config aliases `transport: "http"`, `transportType: "streamableHttp"`, and `transportType: "streamable-http"` for Streamable HTTP.
- Keeps env-passing behavior unchanged; remote auth/header concerns stay in `transportOptions.requestInit`.
- There is no separate `ai/mcp/client/config.template.mjs` in the repo, so the schema documentation lives in `ai/mcp/client/config.mjs`.

## Contract Ledger

| Target Surface | Source of Authority | Implemented Behavior | Fallback | Docs | Evidence |
| :--- | :--- | :--- | :--- | :--- | :--- |
| `Neo.ai.mcp.client.Client` | MCP SDK client transports | Creates stdio, SSE, or Streamable HTTP SDK transports from config. | Defaults to stdio for existing server configs. | `config.mjs` documents `transportType`, `url`, and `transportOptions`. | Focused unit tests + existing stdio health regression. |

## Test Evidence

- `npm run test-unit -- test/playwright/unit/ai/mcp/client/McpClientTransportConfig.spec.mjs` → 6 passed.
- `npm run test-unit -- test/playwright/unit/ai/mcp/client/McpServersHealth.spec.mjs` → first sandbox run exposed environment failures (`EPERM 127.0.0.1:8081`, unhealthy dependency status); rerun outside sandbox → 5 passed.
- `git diff --check` → clean.
- `node -e "await import('./src/Neo.mjs'); await import('./src/core/_export.mjs'); await import('./ai/mcp/client/Client.mjs'); await import('./ai/mcp/client/config.mjs'); console.log('imports ok')"` → imports ok.

## Post-Merge Validation

- [ ] Optional follow-up integration specs can replace raw MCP SDK fixture clients with `Neo.ai.mcp.client.Client` using `transportType: "streamable-http"`.

## Close-Target Audit

- `#10900` is an open leaf enhancement ticket with `enhancement`, `ai`, and `architecture` labels; it is not epic-labeled.

## Commit

- `51485126c` — `feat(ai): support remote MCP client transports (#10900)`
- `fad0af302` — `fix(ai): address MCP transport review gaps (#10900)`
