### PR TITLE
feat(kb): read-side tenant isolation + fail-closed tests (#11632)

### DIFF
--- a/ai/mcp/server/knowledge-base/config.template.mjs
+++ b/ai/mcp/server/knowledge-base/config.template.mjs
@@ -255,11 +255,14 @@ const defaultConfig = {
         }
     },
     /**
-     * @summary Default tenant identity for Neo's curated Knowledge Base corpus.
+     * @summary Default tenant identity for Neo's curated Knowledge Base corpus — the team
+     * namespace visible across every tenant.
      *
-     * Used by `VectorService.embed()` when no authenticated ingestion context is supplied.
-     * Cloud ingestion paths override this with server-derived tenant context; client-supplied
-     * chunk metadata is never authoritative.
+     * Write side: `VectorService.embed()` stamps this when no authenticated ingestion context
+     * is supplied. Read side (#11632): `QueryService.queryDocuments` and `DocumentService`
+     * include it in the `where: {tenantId: {$in: [<requester>, <this>]}}` filter so every tenant
+     * additionally retrieves the curated corpus. Cloud ingestion paths override the write-side
+     * value with server-derived tenant context; client-supplied chunk metadata is never authoritative.
      * @type {string}
      */
     defaultTenantId: 'neo-shared',

--- a/ai/services/knowledge-base/DocumentService.mjs
+++ b/ai/services/knowledge-base/DocumentService.mjs
@@ -1,5 +1,7 @@
+import aiConfig      from '../../mcp/server/knowledge-base/config.mjs';
 import Base          from '../../../src/core/Base.mjs';
 import ChromaManager from './ChromaManager.mjs';
+import RequestContextService, {normalizeUserId} from '../../mcp/server/shared/services/RequestContextService.mjs';
 
 /**
  * @summary Retrieves documents from the knowledge base.
@@ -26,7 +28,11 @@ class DocumentService extends Base {
     }
 
     /**
-     * Retrieves a paginated list of all documents from the knowledge base collection.
+     * Retrieves a paginated, tenant-scoped list of documents from the knowledge base collection.
+     *
+     * When a request context is active, results are filtered to the requester's own tenant plus
+     * Neo's curated `neo-shared` corpus (#11632). Without a context (stdio single-tenant / offline
+     * daemon) every document is returned, byte-equivalent with pre-#11632 behavior.
      * @param {Object} params             The parameters for listing documents.
      * @param {Number} [params.limit=100] The maximum number of documents to return.
      * @param {Number} [params.offset=0]  The number of documents to skip for pagination.
@@ -35,11 +41,23 @@ class DocumentService extends Base {
     async listDocuments({limit=100, offset=0} = {}) {
         const collection = await ChromaManager.getKnowledgeBaseCollection();
 
-        const results = await collection.get({
+        const getOptions = {
             limit,
             offset,
             include: ["metadatas", "documents"]
-        });
+        };
+
+        // #11632 read-side tenant filter: a requester lists its own tenant's documents plus
+        // Neo's curated `neo-shared` corpus. The requester is derived server-side from the
+        // request context — never a client parameter. No context (stdio single-tenant /
+        // offline daemon) → no filter, byte-equivalent with pre-#11632 behavior. Mirrors the
+        // QueryService.queryDocuments clause (inline per the memory-core MemoryService pattern).
+        const requesterTenantId = normalizeUserId(RequestContextService.getUserId());
+        if (requesterTenantId) {
+            getOptions.where = {tenantId: {$in: [requesterTenantId, aiConfig.defaultTenantId ?? 'neo-shared']}};
+        }
+
+        const results = await collection.get(getOptions);
 
         const documents = results.ids.map((id, index) => ({
             id,
@@ -55,16 +73,31 @@ class DocumentService extends Base {
 
     /**
      * Retrieves a single document from the collection by its unique ID.
+     *
+     * When a request context is active, the lookup is tenant-scoped (#11632): an ID owned by
+     * another tenant resolves to a "not found" error, indistinguishable from a genuinely absent
+     * ID so no cross-tenant existence signal leaks.
      * @param {String} id The unique ID of the document to retrieve.
      * @returns {Promise<Object>} A promise that resolves to the requested document.
+     * @throws {Error} When no document with the given ID is visible to the requester.
      */
     async getDocumentById({id}) {
         const collection = await ChromaManager.getKnowledgeBaseCollection();
 
-        const result = await collection.get({
+        const getOptions = {
             ids    : [id],
             include: ["metadatas", "documents"]
-        });
+        };
+
+        // #11632 read-side tenant filter: a document owned by another tenant resolves to
+        // "not found" — fail-closed, indistinguishable from a genuinely absent id, so the
+        // error leaks no cross-tenant existence signal. Mirrors QueryService.queryDocuments.
+        const requesterTenantId = normalizeUserId(RequestContextService.getUserId());
+        if (requesterTenantId) {
+            getOptions.where = {tenantId: {$in: [requesterTenantId, aiConfig.defaultTenantId ?? 'neo-shared']}};
+        }
+
+        const result = await collection.get(getOptions);
 
         if (result.ids.length === 0) {
             throw new Error(`Document with id '${id}' not found.`);

--- a/ai/services/knowledge-base/QueryService.mjs
+++ b/ai/services/knowledge-base/QueryService.mjs
@@ -4,6 +4,7 @@ import mcConfig             from '../../mcp/server/memory-core/config.mjs';
 import aiConfig             from '../../mcp/server/knowledge-base/config.mjs';
 import Base                 from '../../../src/core/Base.mjs';
 import ChromaManager        from './ChromaManager.mjs';
+import RequestContextService, {normalizeUserId} from '../../mcp/server/shared/services/RequestContextService.mjs';
 import dotenv               from 'dotenv';
 import path                 from 'path';
 
@@ -80,7 +81,7 @@ class QueryService extends Base {
 
         while (queue.length > 0) {
             const currentParent = queue.shift();
-            
+
             Object.entries(hierarchy).forEach(([className, parentName]) => {
                 if (parentName === currentParent) {
                     subtree[className] = parentName;
@@ -114,6 +115,16 @@ class QueryService extends Base {
         const queryLower     = query.toLowerCase();
 
         const whereClause = (type && type !== 'all') ? { type } : {};
+
+        // #11632 read-side tenant filter: a requester retrieves its own tenant's chunks plus
+        // Neo's curated `neo-shared` corpus. The requester is derived server-side from the
+        // authenticated request context — never from a client-supplied parameter (a forged
+        // `tenantId` query arg is therefore ignored). No request context (stdio single-tenant
+        // / offline daemon) → no tenant filter, byte-equivalent with pre-#11632 behavior.
+        const requesterTenantId = normalizeUserId(RequestContextService.getUserId());
+        if (requesterTenantId) {
+            whereClause.tenantId = {$in: [requesterTenantId, aiConfig.defaultTenantId ?? 'neo-shared']};
+        }
 
         const queryOptions = {
             queryEmbeddings: [queryEmbeddingValues],
@@ -150,7 +161,7 @@ class QueryService extends Base {
                 if (keywordSingular.length > 2) {
                     if (sourcePathLower.includes(`/${keywordSingular}/`)) score += queryScoreWeights.sourcePathMatch;
                     if (fileName.includes(keywordSingular)) score += queryScoreWeights.fileNameMatch;
-                    
+
                     // Old JSDoc based check: metadata.type === 'class'
                     // New SourceParser check: metadata.className exists
                     if (metadata.className && metadata.className.toLowerCase().includes(keywordSingular)) {

--- a/test/playwright/unit/ai/services/knowledge-base/KnowledgeBase.TenantIsolation.spec.mjs
+++ b/test/playwright/unit/ai/services/knowledge-base/KnowledgeBase.TenantIsolation.spec.mjs
@@ -1,0 +1,345 @@
+import {setup} from '../../../../setup.mjs';
+
+const appName = 'KBTenantIsolationTest';
+
+setup({
+    neoConfig: {
+        unitTestMode: true
+    },
+    appConfig: {
+        name             : appName,
+        isMounted        : () => true,
+        vnodeInitialising: false
+    }
+});
+
+import {test, expect}        from '@playwright/test';
+import Neo                   from '../../../../../../src/Neo.mjs';
+import * as core             from '../../../../../../src/core/_export.mjs';
+import fs                    from 'fs-extra';
+import os                    from 'os';
+import path                  from 'path';
+import RequestContextService from '../../../../../../ai/mcp/server/shared/services/RequestContextService.mjs';
+
+/**
+ * @summary Fail-closed tenant-isolation suite for the Knowledge Base read side (#11632).
+ *
+ * Covers the 8 fail-closed cases graduated from Discussion #11623 §8, parameterized over the
+ * 5 public KB MCP facades. ChromaDB is replaced with an in-memory spy collection that locally
+ * simulates the `where: {tenantId: {$in: [...]}}` filter, and `RequestContextService.run`
+ * controls the server-side requester identity — no real SQLite / Chroma is touched.
+ *
+ * Cases 3 and 4 are write-side concerns (tenant-aware chunk-id derivation and write-side spoof
+ * rejection). They are exhaustively covered by `VectorService.tenantStamping.spec.mjs` (#11631);
+ * this suite re-anchors their security property against the `VectorService` primitives so all
+ * 8 cases stay visible in one load-bearing place, without re-driving the `embed` pipeline.
+ *
+ * The 5 facades map 1:1 to service methods via `ai/mcp/server/knowledge-base/toolService.mjs`
+ * `serviceMapping`; the case-8 block exercises each facade's implementation directly.
+ *
+ * Serial mode: the suite mutates singleton services and `aiConfig`.
+ */
+test.describe.configure({mode: 'serial'});
+
+/**
+ * Builds an in-memory ChromaDB stand-in. `query` / `get` apply the same `where` predicate
+ * ChromaDB would, including the `$in` operator the tenant filter relies on.
+ * @returns {Object}
+ */
+function createSpyCollection() {
+    const rows  = new Map();
+    const calls = {query: [], get: []};
+
+    const matchesWhere = (metadata, where) => {
+        if (!where) return true;
+        return Object.entries(where).every(([key, cond]) => {
+            if (cond && typeof cond === 'object' && Array.isArray(cond.$in)) {
+                return cond.$in.includes(metadata?.[key]);
+            }
+            return metadata?.[key] === cond;
+        });
+    };
+
+    return {
+        rows,
+        calls,
+        name: 'spy-knowledge-base',
+
+        /** Seeds a cache-resident chunk. */
+        seed(id, metadata, document = '') {
+            rows.set(id, {id, metadata, document});
+            return this;
+        },
+
+        async query({queryEmbeddings, nResults, where} = {}) {
+            calls.query.push({queryEmbeddings, nResults, where});
+
+            const matched = Array.from(rows.values())
+                .filter(row => matchesWhere(row.metadata, where))
+                .slice(0, nResults);
+
+            return {
+                ids      : [matched.map(row => row.id)],
+                distances: [matched.map(() => 0)],
+                metadatas: [matched.map(row => row.metadata)],
+                documents: [matched.map(row => row.document)]
+            };
+        },
+
+        async get({ids, where, limit = 100, offset = 0} = {}) {
+            calls.get.push({ids, where, limit, offset});
+
+            let entries = ids
+                ? ids.map(id => rows.get(id)).filter(Boolean)
+                : Array.from(rows.values());
+
+            entries = entries.filter(row => matchesWhere(row.metadata, where));
+
+            if (!ids) {
+                entries = entries.slice(offset, offset + limit);
+            }
+
+            return {
+                ids      : entries.map(row => row.id),
+                metadatas: entries.map(row => row.metadata),
+                documents: entries.map(row => row.document)
+            };
+        }
+    };
+}
+
+/**
+ * Builds a knowledge-base chunk record. `inheritanceChain` is the JSON-string shape
+ * `QueryService.queryDocuments` expects (it `JSON.parse`s the field).
+ * @returns {{id: String, metadata: Object}}
+ */
+function chunk({id, tenantId, source, name, type = 'guide'}) {
+    return {
+        id,
+        metadata: {tenantId, source, name, type, inheritanceChain: '[]'}
+    };
+}
+
+test.describe('KnowledgeBase — fail-closed tenant isolation (#11632)', () => {
+    let ChromaManager, DocumentService, QueryService, SearchService, VectorService;
+    let TextEmbeddingService, aiConfig;
+    let originalGetCollection, originalEmbedText, originalModel, originalDefaultTenantId;
+    let spy;
+
+    // Canonical fixtures: a chunk owned by tenant-a, a private chunk owned by tenant-b, and a
+    // curated chunk in the cross-tenant `neo-shared` namespace.
+    const OWN     = chunk({id: 'c-own',     tenantId: 'tenant-a',   source: 'kb/tenant-a/Own.md',       name: 'Own'});
+    const FOREIGN = chunk({id: 'c-foreign', tenantId: 'tenant-b',   source: 'kb/tenant-b/Secret.md',    name: 'Secret'});
+    const SHARED  = chunk({id: 'c-shared',  tenantId: 'neo-shared', source: 'kb/neo-shared/Curated.md', name: 'Curated'});
+
+    test.beforeAll(async () => {
+        ChromaManager        = (await import('../../../../../../ai/services/knowledge-base/ChromaManager.mjs')).default;
+        DocumentService      = (await import('../../../../../../ai/services/knowledge-base/DocumentService.mjs')).default;
+        QueryService         = (await import('../../../../../../ai/services/knowledge-base/QueryService.mjs')).default;
+        SearchService        = (await import('../../../../../../ai/services/knowledge-base/SearchService.mjs')).default;
+        VectorService        = (await import('../../../../../../ai/services/knowledge-base/VectorService.mjs')).default;
+        TextEmbeddingService = (await import('../../../../../../ai/services/memory-core/TextEmbeddingService.mjs')).default;
+        aiConfig             = (await import('../../../../../../ai/mcp/server/knowledge-base/config.mjs')).default;
+
+        originalGetCollection   = ChromaManager.getKnowledgeBaseCollection;
+        originalEmbedText       = TextEmbeddingService.embedText;
+        originalModel           = SearchService.model;
+        originalDefaultTenantId = aiConfig.defaultTenantId;
+    });
+
+    test.beforeEach(() => {
+        spy = createSpyCollection();
+        [OWN, FOREIGN, SHARED].forEach(c => spy.seed(c.id, c.metadata));
+
+        ChromaManager.getKnowledgeBaseCollection = async () => spy;
+        TextEmbeddingService.embedText           = async () => [0.1, 0.2, 0.3];
+        SearchService.model                      = {
+            generateContent: async () => ({response: {text: () => 'stub-synthesis'}})
+        };
+        // The worktree's gitignored config.mjs predates the tenant keys — pin the value so the
+        // suite is deterministic regardless of local config staleness.
+        aiConfig.defaultTenantId = 'neo-shared';
+    });
+
+    test.afterEach(() => {
+        ChromaManager.getKnowledgeBaseCollection = originalGetCollection;
+        TextEmbeddingService.embedText           = originalEmbedText;
+        SearchService.model                      = originalModel;
+        aiConfig.defaultTenantId                 = originalDefaultTenantId;
+    });
+
+    test('no request context → no tenant filter (single-tenant fallthrough, pre-#11632 behavior)', async () => {
+        const result = await QueryService.queryDocuments({query: 'anything', type: 'all'});
+
+        // Every seeded chunk is returned and the query carries no tenantId predicate.
+        const sources = result.results.map(r => r.source);
+        expect(sources).toEqual(expect.arrayContaining([
+            OWN.metadata.source, FOREIGN.metadata.source, SHARED.metadata.source
+        ]));
+        expect(spy.calls.query.at(-1).where).toBeUndefined();
+    });
+
+    test('case 1 — tenant isolation: query_documents hides another tenant\'s private chunks', async () => {
+        const result = await RequestContextService.run({userId: 'tenant-a'}, () =>
+            QueryService.queryDocuments({query: 'anything', type: 'all'})
+        );
+
+        const sources = result.results.map(r => r.source);
+        expect(sources).toContain(OWN.metadata.source);
+        expect(sources).not.toContain(FOREIGN.metadata.source);
+
+        // The filter is server-derived and carries exactly the requester plus the team namespace.
+        expect(spy.calls.query.at(-1).where).toEqual({tenantId: {$in: ['tenant-a', 'neo-shared']}});
+    });
+
+    test('case 2 — team visibility: neo-shared chunks stay visible across every tenant', async () => {
+        const asTenantA = await RequestContextService.run({userId: 'tenant-a'}, () =>
+            QueryService.queryDocuments({query: 'anything', type: 'all'})
+        );
+        const asTenantB = await RequestContextService.run({userId: 'tenant-b'}, () =>
+            QueryService.queryDocuments({query: 'anything', type: 'all'})
+        );
+
+        expect(asTenantA.results.map(r => r.source)).toContain(SHARED.metadata.source);
+        expect(asTenantB.results.map(r => r.source)).toContain(SHARED.metadata.source);
+    });
+
+    test('case 3 — chunk-shadow: identical content under two tenants yields distinct chunk ids', () => {
+        // Write-side anchor — full coverage in VectorService.tenantStamping.spec.mjs (#11631).
+        const content = {hash: 'identical-content-hash', type: 'guide', name: 'Doc', source: 'shared/Doc.md'};
+
+        const idA = VectorService.createTenantAwareChunkId(content, {tenantId: 'tenant-a', repoSlug: 'repo'});
+        const idB = VectorService.createTenantAwareChunkId(content, {tenantId: 'tenant-b', repoSlug: 'repo'});
+
+        expect(idA).toHaveLength(64);
+        expect(idA).not.toBe(idB);
+    });
+
+    test('case 4 — write-side spoof: a forged client tenantId is rejected in reject mode', () => {
+        // Write-side anchor — full coverage in VectorService.tenantStamping.spec.mjs (#11631).
+        const originalMode = aiConfig.spoofRejectionMode;
+        aiConfig.spoofRejectionMode = 'reject';
+
+        try {
+            const forged      = {hash: 'h', type: 'guide', name: 'Doc', source: 's', tenantId: 'tenant-victim'};
+            const serverStamp = {tenantId: 'tenant-attacker', repoSlug: 'repo', visibility: 'team'};
+
+            expect(() => VectorService.validateTenantStamp(forged, serverStamp, 'chunk-id'))
+                .toThrow(/KB_TENANT_SPOOF_REJECTED/);
+        } finally {
+            aiConfig.spoofRejectionMode = originalMode;
+        }
+    });
+
+    test('case 5 — read-side spoof: a forged client tenantId query argument is ignored', async () => {
+        // tenant-a passes a forged `tenantId: 'tenant-b'` query argument, attempting to pivot the
+        // read filter onto tenant-b's corpus. The argument is inert — the filter is derived from
+        // the server-side request context only (DocumentService behaves identically).
+        const result = await RequestContextService.run({userId: 'tenant-a'}, () =>
+            QueryService.queryDocuments({query: 'anything', type: 'all', tenantId: 'tenant-b'})
+        );
+
+        expect(spy.calls.query.at(-1).where).toEqual({tenantId: {$in: ['tenant-a', 'neo-shared']}});
+        expect(result.results.map(r => r.source)).not.toContain(FOREIGN.metadata.source);
+    });
+
+    test('case 6 — backup-record path isolation: a restored foreign chunk still obeys the read filter', async () => {
+        // manageDatabaseBackup({action: 'import'}) restores records verbatim — it bypasses
+        // ingestion validation by design (to preserve embeddings) but does NOT bypass tenant
+        // metadata. The read filter is metadata-driven, so a restored foreign-tenant chunk is
+        // still fail-closed. Modelled here as a cache-resident chunk carrying a foreign tenantId.
+        spy.seed('c-restored', {
+            tenantId: 'tenant-b', source: 'kb/tenant-b/Restored.md', name: 'Restored',
+            type    : 'guide',    inheritanceChain: '[]'
+        });
+
+        const result = await RequestContextService.run({userId: 'tenant-a'}, () =>
+            QueryService.queryDocuments({query: 'anything', type: 'all'})
+        );
+
+        expect(result.results.map(r => r.source)).not.toContain('kb/tenant-b/Restored.md');
+    });
+
+    test('case 7 — search hydration is tenant-aware: ask never surfaces a foreign tenant\'s source', async () => {
+        const result = await RequestContextService.run({userId: 'tenant-a'}, () =>
+            SearchService.ask({query: 'anything', type: 'all'})
+        );
+
+        // References derive from the tenant-filtered retrieval, so a foreign chunk is dropped
+        // before SearchService would ever resolve/hydrate its source path.
+        const refSources = result.references.map(r => r.source);
+        expect(refSources).toContain(SHARED.metadata.source);
+        expect(refSources).not.toContain(FOREIGN.metadata.source);
+    });
+
+    test.describe('case 8 — every public KB facade respects the tenant boundary', () => {
+        test('query_documents (QueryService.queryDocuments)', async () => {
+            const result = await RequestContextService.run({userId: 'tenant-a'}, () =>
+                QueryService.queryDocuments({query: 'anything', type: 'all'})
+            );
+            expect(result.results.map(r => r.source)).not.toContain(FOREIGN.metadata.source);
+        });
+
+        test('ask_knowledge_base (SearchService.ask)', async () => {
+            const result = await RequestContextService.run({userId: 'tenant-a'}, () =>
+                SearchService.ask({query: 'anything', type: 'all'})
+            );
+            expect(result.references.map(r => r.source)).not.toContain(FOREIGN.metadata.source);
+        });
+
+        test('list_documents (DocumentService.listDocuments)', async () => {
+            const result = await RequestContextService.run({userId: 'tenant-a'}, () =>
+                DocumentService.listDocuments({limit: 100})
+            );
+
+            const ids = result.documents.map(d => d.id);
+            expect(ids).toContain(OWN.id);
+            expect(ids).toContain(SHARED.id);
+            expect(ids).not.toContain(FOREIGN.id);
+            expect(spy.calls.get.at(-1).where).toEqual({tenantId: {$in: ['tenant-a', 'neo-shared']}});
+        });
+
+        test('get_document_by_id (DocumentService.getDocumentById) — a foreign id is not found', async () => {
+            const own = await RequestContextService.run({userId: 'tenant-a'}, () =>
+                DocumentService.getDocumentById({id: OWN.id})
+            );
+            expect(own.id).toBe(OWN.id);
+
+            // A cross-tenant id fails closed — the error is indistinguishable from a genuinely
+            // absent id, so no existence signal leaks.
+            await expect(RequestContextService.run({userId: 'tenant-a'}, () =>
+                DocumentService.getDocumentById({id: FOREIGN.id})
+            )).rejects.toThrow(`Document with id '${FOREIGN.id}' not found.`);
+        });
+
+        test('get_class_hierarchy (QueryService.getClassHierarchy) — static, never queries the tenant collection', async () => {
+            const tmpHierarchy = path.join(os.tmpdir(), `kb-tenant-hierarchy-${process.pid}-${Date.now()}.json`);
+            await fs.writeJson(tmpHierarchy, {
+                'Neo.component.Base': 'Neo.core.Base',
+                'Neo.button.Base'   : 'Neo.component.Base'
+            });
+            const originalHierarchyPath = aiConfig.hierarchyPath;
+            aiConfig.hierarchyPath = tmpHierarchy;
+
+            try {
+                const asTenantA = await RequestContextService.run({userId: 'tenant-a'}, () =>
+                    QueryService.getClassHierarchy({root: 'Neo.component.Base'})
+                );
+                const asTenantB = await RequestContextService.run({userId: 'tenant-b'}, () =>
+                    QueryService.getClassHierarchy({root: 'Neo.component.Base'})
+                );
+
+                // The class graph is Neo's own framework structure — shared-by-design and
+                // tenant-independent — and the facade never consults the Chroma collection,
+                // so it structurally cannot leak tenant-scoped chunks.
+                expect(asTenantA).toEqual(asTenantB);
+                expect(asTenantA['Neo.button.Base']).toBe('Neo.component.Base');
+                expect(spy.calls.query).toHaveLength(0);
+                expect(spy.calls.get).toHaveLength(0);
+            } finally {
+                aiConfig.hierarchyPath = originalHierarchyPath;
+                await fs.remove(tmpHierarchy).catch(() => {});
+            }
+        });
+    });
+});


### PR DESCRIPTION
Resolves #11632

Authored by Claude Opus 4.7 (Claude Code). Session 470c38e7-1ffc-4851-867d-d30c1b6fbdb2.

FAIR-band: over-target [18/30] — taking this lane despite over-target because of the operator nightshift directive (2026-05-20: continuous parallel-lane pickup on Epic #11624; "i am afk for an hour, it would be nice if you two could continue"). The implementation is complete and verified (29/29 unit tests green) — yielding finished, tested work would be negative-ROI. #11632 is the read-side twin of the already-shipped #11631 write-side stamping.

Closes the Phase 0/1 KB security boundary: the read-side tenant filter that makes write-side stamping (#11631) actually enforced. Every authenticated requester now retrieves only its own tenant's chunks plus Neo's curated `neo-shared` corpus — across all five public KB MCP facades. Ships with the load-bearing fail-closed test suite graduated from Discussion #11623 §8.

## The leak

`QueryService.queryDocuments` built the Chroma `where` clause from the `type` predicate only — no tenant filter. `DocumentService.listDocuments` and `getDocumentById` called `collection.get()` with no `where` clause at all. With write-side server-stamping shipped (#11631) but no read-side enforcement, every tenant retrieved every other tenant's content through `query_documents`, `ask_knowledge_base`, `get_document_by_id`, and `list_documents`.

## The fix

A server-derived filter `where: {tenantId: {$in: [<requester>, 'neo-shared']}}` applied at each KB read boundary. The requester is resolved from the authenticated `RequestContextService` context — never from a client-supplied parameter, so a forged `tenantId` query argument is inert. No request context (stdio single-tenant / offline daemon) → no filter, byte-equivalent with pre-#11632 behavior.

- `QueryService.queryDocuments` — merges the tenant predicate into the existing `type` where-clause; `ask_knowledge_base` inherits it via `SearchService.ask` → `queryDocuments`.
- `DocumentService.listDocuments` — tenant-scoped `collection.get`.
- `DocumentService.getDocumentById` — tenant-scoped lookup; a cross-tenant id resolves to a "not found" error, fail-closed and indistinguishable from a genuinely absent id (no existence-signal leak).

Per Discussion #11623 §4 Q13b, V1 ships the application-layer filter (Option A); Chroma-layer hardening (Option B) is deferred to Phase 2-or-later.

Evidence: L2 (13-case fail-closed unit suite — tenant isolation across all 5 KB facades, the no-context fallthrough, and write-side anchors) → L2 sufficient (the application-layer filter and its return-boundary applications are mechanically verifiable in unit scope; live cross-tenant KB traffic arrives with the Phase 2 ingestion service per the ticket's Out of Scope). No residuals.

## Config template change

`ai/mcp/server/knowledge-base/config.template.mjs` — **JSDoc-only**. The `defaultTenantId` JSDoc is extended to document its read-side role (the cross-tenant team namespace in the `$in` filter). No config key is added, removed, or renamed. No local `config.mjs` follow-up is needed and no harness restart is required. In stdio single-tenant mode (how the swarm runs the KB server) there is no request context, so the filter is inert and KB query behavior is byte-equivalent — no peer clone is affected at runtime by this PR.

## Deltas from ticket

- **`DocumentService` extended beyond the ticket's "The Fix" section.** That section names only `QueryService` / `SearchService`, but AC item "no facade can bypass" + §8 case 8 enumerate `get_document_by_id` / `list_documents` — both route through `DocumentService`, which queried Chroma with no `where`. The AC + the fail-closed cases are the binding contract; the prose under-enumerated. Filter extended to both `DocumentService` methods.
- **Cases 3 & 4 anchored, not duplicated.** The ticket's 8 fail-closed cases include two write-side concerns — chunk-id distinctness (3) and write-side spoof rejection (4) — already exhaustively covered by `VectorService.tenantStamping.spec.mjs` (#11631). The new suite re-anchors their security property against the `VectorService` primitives (one assertion each) so all 8 cases stay visible in one place, without re-driving the `embed` pipeline.
- **`?? 'neo-shared'` parity fallback.** The filter resolves the team namespace as `aiConfig.defaultTenantId ?? 'neo-shared'`, matching the write-side idiom in `VectorService.resolveTenantStamp` / `DatabaseService`. A clone's gitignored `config.mjs` can predate the tenant keys; the fallback keeps the filter correct against stale local config.
- **`get_class_hierarchy` is structurally not a Chroma facade.** It reads a static JSON file (Neo's own class graph — shared-by-design, tenant-independent). The facade-coverage test asserts it never consults the tenant collection, rather than applying a filter that would be meaningless.
- **No-context fallthrough test added.** Not one of the 8 numbered cases, but it locks the "byte-equivalent with pre-#11632 behavior" guarantee for single-tenant / offline-daemon contexts.
- **Incidental:** stripped 2 pre-existing trailing-whitespace lines in `QueryService.mjs` — `check-whitespace.mjs` is a whole-file (not diff-aware) pre-commit hook, so touching the file forces full-file cleanup.

## Test Evidence

New spec: `test/playwright/unit/ai/services/knowledge-base/KnowledgeBase.TenantIsolation.spec.mjs` — **13 tests, 13 passed** (`npm run test-unit`). ChromaDB is replaced with an in-memory spy collection that locally simulates the `where: {tenantId: {$in: [...]}}` filter; `RequestContextService.run` controls the server-side requester identity. No real SQLite / Chroma is touched.

| # | Fail-closed case | Coverage |
|---|---|---|
| — | no request context → no filter | single-tenant / offline fallthrough, byte-equivalent with pre-#11632 |
| 1 | tenant isolation | `query_documents` hides another tenant's private chunks |
| 2 | team visibility | `neo-shared` chunks stay visible across every tenant |
| 3 | cross-tenant chunk shadow | identical content under two tenants → distinct chunk ids (write-side anchor) |
| 4 | write-side spoof rejection | a forged client `tenantId` is rejected in `reject` mode (write-side anchor) |
| 5 | read-side spoof rejection | a forged client `tenantId` query argument is ignored |
| 6 | backup-record path isolation | a restored foreign chunk still obeys the read filter |
| 7 | search hydration tenant-aware | `ask` never surfaces a foreign tenant's source |
| 8 | every public KB facade | `query_documents`, `ask_knowledge_base`, `list_documents`, `get_document_by_id`, `get_class_hierarchy` each respect the boundary |

Regression: the 16 existing KB specs that exercise the modified files (`QueryService.queryDocuments`, `QueryService.classHierarchy`, `DocumentService`, `SearchService`) — **16 passed**. The source edits introduce no regression (the filter is inert without a request context, which is how every existing spec runs).

## Post-Merge Validation

- [ ] When Phase 2 multi-tenant ingestion lands, the read-side RLS is exercised end-to-end against live cross-tenant KB data.
- [ ] Q13b follow-up: if the application-layer filter (Option A) leak class manifests in production, reconsider Chroma-layer hardening (Option B) per Discussion #11623 §4.

## Related

- **Parent:** #11625 (Phase 0/1 Epic); meta-Epic #11624
- **Discussion source:** #11623 §4 Q13b + §8 fail-closed test cases
- **Sibling:** #11631 (Phase 0/1C write-side tenant stamping, shipped) — this PR is the read-side twin
- **Blocks:** Phase 0/1 Epic closeout
