### PR TITLE
feat(kb): add ingestion service (#11633)

### DIFF
--- a/ai/services.mjs
+++ b/ai/services.mjs
@@ -29,6 +29,7 @@ import _KB_DatabaseService from './services/knowledge-base/DatabaseService.mjs';
 import _KB_LifecycleService from './services/knowledge-base/DatabaseLifecycleService.mjs';
 import _KB_DocumentService from './services/knowledge-base/DocumentService.mjs';
 import _KB_HealthService from './services/knowledge-base/HealthService.mjs';
+import _KB_IngestionService from './services/knowledge-base/KnowledgeBaseIngestionService.mjs';
 import _KB_RecorderService from './services/knowledge-base/KBRecorderService.mjs';
 import _KB_QueryService from './services/knowledge-base/QueryService.mjs';
 import _KB_SearchService from './services/knowledge-base/SearchService.mjs';
@@ -208,6 +209,7 @@ const KB_DatabaseService = makeSafe(_KB_DatabaseService, kbSpec);
 const KB_LifecycleService = makeSafe(_KB_LifecycleService, kbSpec);
 const KB_DocumentService = makeSafe(_KB_DocumentService, kbSpec);
 const KB_HealthService = makeSafe(_KB_HealthService, kbSpec);
+const KB_IngestionService = makeSafe(_KB_IngestionService, kbSpec);
 const KB_RecorderService = makeSafe(_KB_RecorderService, kbSpec);
 const KB_QueryService = makeSafe(_KB_QueryService, kbSpec);
 const KB_SearchService = makeSafe(_KB_SearchService, kbSpec);
@@ -277,6 +279,7 @@ export {
     KB_LifecycleService,
     KB_DocumentService,
     KB_HealthService,
+    KB_IngestionService,
     KB_RecorderService,
     KB_QueryService,
     KB_SearchService,

--- a/ai/services/knowledge-base/KnowledgeBaseIngestionService.mjs
+++ b/ai/services/knowledge-base/KnowledgeBaseIngestionService.mjs
@@ -1,0 +1,712 @@
+import Ajv2020               from 'ajv/dist/2020.js';
+import Base                  from '../../../src/core/Base.mjs';
+import ChromaManager         from './ChromaManager.mjs';
+import KBRecorderService     from './KBRecorderService.mjs';
+import RequestContextService,
+       {normalizeUserId}    from '../../mcp/server/shared/services/RequestContextService.mjs';
+import SourceRegistry        from './source/_export.mjs';
+import VectorService         from './VectorService.mjs';
+import aiConfig              from '../../mcp/server/knowledge-base/config.mjs';
+import crypto                from 'crypto';
+import fs                    from 'fs-extra';
+import os                    from 'os';
+import path                  from 'path';
+import {fileURLToPath}       from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname  = path.dirname(__filename);
+
+const PARSED_CHUNK_SCHEMA_PATH = path.join(__dirname, 'parser/parsed-chunk-v1.schema.json');
+
+/**
+ * @summary Orchestrates Phase 2 Knowledge Base ingestion pushes.
+ *
+ * `KnowledgeBaseIngestionService` is the service-layer substrate consumed by the
+ * Phase 2 MCP and bulk facades. It validates the caller tenant boundary, accepts
+ * client-side parsed `parsed-chunk-v1` records or server-side raw file payloads,
+ * rejects restore-only embedding records, applies deletion signaling, and delegates
+ * embedding/upsert work to {@link Neo.ai.services.knowledge-base.VectorService}.
+ *
+ * The service returns a structured summary for both happy and error paths. Caller
+ * errors are accumulated into `errors[]` so one bad file does not discard the
+ * successful portion of a push, and fully failed pushes still return the contract
+ * summary instead of throwing out of the facade boundary.
+ *
+ * @class Neo.ai.services.knowledge-base.KnowledgeBaseIngestionService
+ * @extends Neo.core.Base
+ * @singleton
+ * @see https://github.com/neomjs/neo/issues/11633
+ */
+class KnowledgeBaseIngestionService extends Base {
+    static config = {
+        /**
+         * @member {String} className='Neo.ai.services.knowledge-base.KnowledgeBaseIngestionService'
+         * @protected
+         */
+        className: 'Neo.ai.services.knowledge-base.KnowledgeBaseIngestionService',
+        /**
+         * @member {Boolean} singleton=true
+         * @protected
+         */
+        singleton: true,
+        /**
+         * @member {Object} chromaManager=ChromaManager
+         * @summary Chroma collection manager. Injectable for deletion-signaling tests.
+         */
+        chromaManager: ChromaManager,
+        /**
+         * @member {Object} recorderService=KBRecorderService
+         * @summary Best-effort ingestion telemetry sink.
+         */
+        recorderService: KBRecorderService,
+        /**
+         * @member {Object|null} revisionResolver=null
+         * @summary Optional Phase 2E revision-boundary resolver used to derive deleted paths.
+         */
+        revisionResolver: null,
+        /**
+         * @member {Object} sourceRegistry=SourceRegistry
+         * @summary Source/parser registry used by raw-file server-side parsing.
+         */
+        sourceRegistry: SourceRegistry,
+        /**
+         * @member {Object} requestContextService=RequestContextService
+         * @summary Request-scoped identity source for tenant validation.
+         */
+        requestContextService: RequestContextService,
+        /**
+         * @member {Object} vectorService=VectorService
+         * @summary Downstream embedding/upsert service.
+         */
+        vectorService: VectorService
+    }
+
+    /**
+     * @member {Function|null} parsedChunkValidator=null
+     * @protected
+     */
+    parsedChunkValidator = null
+
+    /**
+     * @summary Ingests raw or client-parsed source files into the Knowledge Base.
+     *
+     * @param {Object}  payload
+     * @param {String} [payload.tenantId] Authenticated tenant id. Required when request
+     *                                    context is active; offline calls fall back to `neo-shared`.
+     * @param {Array}  [payload.files=[]] Raw file payloads or client-side parsed records.
+     * @param {Array}  [payload.deleted=[]] Explicit tombstones (`{sourcePath, repoSlug?}`).
+     * @param {Object} [payload.manifestSnapshot] Post-push manifest (`{repoSlug, pathsAfterPush}`).
+     * @param {String} [payload.baseRevision] Previous revision boundary.
+     * @param {String} [payload.headRevision] Current revision boundary.
+     * @returns {Promise<{ingested: Number, deleted: Number, embeddingsGenerated: Number, errors: Array, tenantId: String, durationMs: Number}>}
+     */
+    async ingestSourceFiles(payload = {}) {
+        const startedAt = Date.now();
+        const summary   = this.createSummary({startedAt});
+
+        try {
+            const tenantContext = this.resolveTenantContext(payload);
+            summary.tenantId    = tenantContext.tenantId;
+
+            if (!Array.isArray(payload.files)) {
+                summary.errors.push(this.createError({
+                    code   : 'KB_INGEST_FILES_INVALID',
+                    message: '`files` must be an array.'
+                }));
+            }
+
+            const files  = Array.isArray(payload.files) ? payload.files : [];
+            const chunks = await this.collectParsedChunks({files, tenantContext, summary});
+
+            summary.deleted = await this.applyDeletionSignals({
+                deleted         : payload.deleted,
+                manifestSnapshot: payload.manifestSnapshot,
+                baseRevision    : payload.baseRevision,
+                headRevision    : payload.headRevision,
+                tenantContext,
+                summary
+            });
+
+            if (chunks.length > 0) {
+                await this.embedChunkGroups({chunks, tenantContext, summary});
+            }
+
+            summary.ingested   = chunks.length;
+            summary.durationMs = Date.now() - startedAt;
+
+            this.recordMetric(summary, tenantContext);
+            return summary;
+        } catch (error) {
+            summary.errors.push(this.createError({code: error.code || 'KB_INGEST_FAILED', message: error.message}));
+            summary.durationMs = Date.now() - startedAt;
+            this.recordMetric(summary, {
+                tenantId: summary.tenantId || aiConfig.defaultTenantId || 'neo-shared',
+                repoSlug: aiConfig.defaultRepoSlug || 'neo'
+            });
+            return summary;
+        }
+    }
+
+    /**
+     * @summary Applies explicit tombstone, manifest, and revision-boundary delete signals.
+     * @param {Object} options
+     * @returns {Promise<Number>} Deleted Chroma row count.
+     * @protected
+     */
+    async applyDeletionSignals({deleted = [], manifestSnapshot, baseRevision, headRevision, tenantContext, summary}) {
+        const tombstones = [];
+
+        if (Array.isArray(deleted)) {
+            tombstones.push(...deleted);
+        } else if (deleted != null) {
+            summary.errors.push(this.createError({
+                code   : 'KB_DELETE_SIGNAL_INVALID',
+                message: '`deleted` must be an array when provided.'
+            }));
+        }
+
+        if (baseRevision || headRevision) {
+            tombstones.push(...await this.resolveRevisionTombstones({
+                baseRevision,
+                headRevision,
+                tenantContext,
+                summary
+            }));
+        }
+
+        const collection = await this.chromaManager.getKnowledgeBaseCollection();
+        const ids        = new Set();
+
+        if (tombstones.length > 0) {
+            const rows = await this.getTenantRows(collection, tenantContext.tenantId);
+
+            for (const tombstone of tombstones) {
+                if (!tombstone?.sourcePath) {
+                    summary.errors.push(this.createError({
+                        code   : 'KB_TOMBSTONE_INVALID',
+                        message: 'Tombstone entries require `sourcePath`.',
+                        details: {tombstone}
+                    }));
+                    continue;
+                }
+
+                const repoSlug = tombstone.repoSlug || tenantContext.repoSlug;
+                rows
+                    .filter(row => row.metadata.repoSlug === repoSlug && row.metadata.sourcePath === tombstone.sourcePath)
+                    .forEach(row => ids.add(row.id));
+            }
+        }
+
+        if (manifestSnapshot) {
+            const pathsAfterPush = manifestSnapshot.pathsAfterPush;
+
+            if (!Array.isArray(pathsAfterPush)) {
+                summary.errors.push(this.createError({
+                    code   : 'KB_MANIFEST_INVALID',
+                    message: '`manifestSnapshot.pathsAfterPush` must be an array.'
+                }));
+            } else {
+                const repoSlug = manifestSnapshot.repoSlug || tenantContext.repoSlug;
+                const livePaths = new Set(pathsAfterPush);
+                const rows = await this.getTenantRows(collection, tenantContext.tenantId);
+
+                rows
+                    .filter(row => row.metadata.repoSlug === repoSlug && !livePaths.has(row.metadata.sourcePath))
+                    .forEach(row => ids.add(row.id));
+            }
+        }
+
+        if (ids.size === 0) return 0;
+
+        await collection.delete({ids: Array.from(ids)});
+        return ids.size;
+    }
+
+    /**
+     * @summary Groups parsed chunks by repoSlug and routes each group to VectorService.embed().
+     * @param {Object} options
+     * @returns {Promise<void>}
+     * @protected
+     */
+    async embedChunkGroups({chunks, tenantContext, summary}) {
+        const groups = new Map();
+
+        for (const chunk of chunks) {
+            const repoSlug = chunk.repoSlug || tenantContext.repoSlug;
+            if (!groups.has(repoSlug)) {
+                groups.set(repoSlug, []);
+            }
+            groups.get(repoSlug).push(chunk);
+        }
+
+        for (const [repoSlug, group] of groups.entries()) {
+            const tempFile = await this.writeTempJsonl(group);
+
+            try {
+                const result = await this.vectorService.embed(tempFile, {
+                    deleteStale  : false,
+                    tenantContext: {...tenantContext, repoSlug},
+                    viaMcp       : true
+                });
+
+                if (result?.error) {
+                    summary.errors.push(this.createError({
+                        code   : result.code || 'KB_VECTOR_EMBED_FAILED',
+                        message: result.message || result.error,
+                        details: result
+                    }));
+                    continue;
+                }
+
+                summary.embeddingsGenerated += result?.embedded ?? group.length;
+            } catch (error) {
+                summary.errors.push(this.createError({
+                    code   : error.code || 'KB_VECTOR_EMBED_FAILED',
+                    message: error.message,
+                    details: {repoSlug}
+                }));
+            } finally {
+                await fs.remove(tempFile);
+            }
+        }
+    }
+
+    /**
+     * @summary Collects and validates parsed chunks from the file payload.
+     * @param {Object} options
+     * @returns {Promise<Array<Object>>}
+     * @protected
+     */
+    async collectParsedChunks({files, tenantContext, summary}) {
+        const chunks = [];
+
+        for (let fileIndex = 0; fileIndex < files.length; fileIndex++) {
+            const file = files[fileIndex];
+
+            try {
+                const parsed = await this.resolveFileChunks({file, fileIndex, tenantContext});
+
+                for (let chunkIndex = 0; chunkIndex < parsed.length; chunkIndex++) {
+                    const record = parsed[chunkIndex];
+                    const normalized = await this.validateAndNormalizeParsedChunk({
+                        record,
+                        fileIndex,
+                        chunkIndex,
+                        tenantContext,
+                        summary
+                    });
+
+                    if (normalized) {
+                        chunks.push(normalized);
+                    }
+                }
+            } catch (error) {
+                summary.errors.push(this.createError({
+                    code   : error.code || 'KB_FILE_PARSE_FAILED',
+                    message: error.message,
+                    details: {fileIndex, sourcePath: file?.sourcePath}
+                }));
+            }
+        }
+
+        return chunks;
+    }
+
+    /**
+     * @summary Builds a structured error entry for the ingestion summary.
+     * @param {Object} options
+     * @returns {Object}
+     * @protected
+     */
+    createError({code, message, details}) {
+        return {
+            code,
+            message,
+            ...(details === undefined ? {} : {details})
+        };
+    }
+
+    /**
+     * @summary Creates an empty ingestion summary.
+     * @param {Object} options
+     * @returns {Object}
+     * @protected
+     */
+    createSummary({startedAt}) {
+        return {
+            ingested           : 0,
+            deleted            : 0,
+            embeddingsGenerated: 0,
+            errors             : [],
+            tenantId           : aiConfig.defaultTenantId || 'neo-shared',
+            durationMs         : Date.now() - startedAt
+        };
+    }
+
+    /**
+     * @summary Creates the deterministic pre-vector content hash for a parsed chunk.
+     * @param {Object} record Parsed chunk.
+     * @param {Object} tenantContext Authoritative tenant context.
+     * @returns {String}
+     * @protected
+     */
+    createChunkHash(record, tenantContext) {
+        const values = {
+            tenantId: tenantContext.tenantId,
+            repoSlug: record.repoSlug || tenantContext.repoSlug
+        };
+
+        for (const field of record.hashInputs) {
+            values[field] = record[field];
+        }
+
+        return crypto.createHash('sha256').update(JSON.stringify(values)).digest('hex');
+    }
+
+    /**
+     * @summary Retrieves all Knowledge Base rows visible for a tenant from Chroma.
+     * @param {Object} collection Chroma collection.
+     * @param {String} tenantId Tenant id.
+     * @returns {Promise<Array<{id: String, metadata: Object}>>}
+     * @protected
+     */
+    async getTenantRows(collection, tenantId) {
+        const rows = [];
+        const limit = 2000;
+        let offset  = 0;
+        let batch;
+
+        do {
+            batch = await collection.get({
+                include: ['metadatas'],
+                limit,
+                offset,
+                where: {tenantId}
+            });
+
+            for (let i = 0; i < (batch.ids?.length || 0); i++) {
+                rows.push({
+                    id      : batch.ids[i],
+                    metadata: batch.metadatas?.[i] || {}
+                });
+            }
+
+            offset += limit;
+        } while ((batch.ids?.length || 0) === limit);
+
+        return rows;
+    }
+
+    /**
+     * @summary Lazily compiles the parsed-chunk-v1 JSON schema validator.
+     * @returns {Promise<Function>}
+     * @protected
+     */
+    async getParsedChunkValidator() {
+        if (!this.parsedChunkValidator) {
+            const schema = await fs.readJson(PARSED_CHUNK_SCHEMA_PATH);
+            const ajv    = new Ajv2020({allErrors: true, strict: false});
+
+            this.parsedChunkValidator = ajv.compile(schema);
+        }
+
+        return this.parsedChunkValidator;
+    }
+
+    /**
+     * @summary Records best-effort ingestion telemetry without affecting the caller path.
+     * @param {Object} summary Ingestion summary.
+     * @param {Object} tenantContext Tenant context.
+     * @returns {void}
+     * @protected
+     */
+    recordMetric(summary, tenantContext) {
+        this.recorderService.recordIngestionMetric?.({
+            tenantId           : tenantContext.tenantId,
+            repoSlug           : tenantContext.repoSlug,
+            originAgentIdentity: tenantContext.originAgentIdentity,
+            eventType          : this.resolveMetricEventType(summary),
+            chunksTotal        : summary.ingested,
+            chunksEmbedded     : summary.embeddingsGenerated,
+            chunksDeleted      : summary.deleted,
+            durationMs         : summary.durationMs,
+            errorCode          : summary.errors[0]?.code,
+            detail             : summary.errors.length > 0 ? {errors: summary.errors} : undefined
+        });
+    }
+
+    /**
+     * @summary Resolves raw file payloads into parsed-chunk-v1 records.
+     * @param {Object} options
+     * @returns {Promise<Array<Object>>}
+     * @protected
+     */
+    async resolveFileChunks({file, fileIndex, tenantContext}) {
+        if (file?.schemaVersion === '1.0.0') {
+            return [file];
+        }
+
+        if (Array.isArray(file?.parsedChunks)) {
+            return file.parsedChunks;
+        }
+
+        if (Array.isArray(file?.chunks)) {
+            return file.chunks;
+        }
+
+        if (typeof file?.content !== 'string') {
+            const error = new Error('File payload requires `parsedChunks`, `chunks`, a parsed-chunk-v1 record, or string `content`.');
+            error.code  = 'KB_FILE_PAYLOAD_INVALID';
+            throw error;
+        }
+
+        const parserId = file.parserId || 'raw-text';
+        const parser   = this.resolveParser(parserId);
+
+        if (file.parserId && !parser) {
+            const error = new Error(`Parser '${file.parserId}' is not registered.`);
+            error.code  = 'KB_PARSER_NOT_REGISTERED';
+            throw error;
+        }
+
+        if (parser?.parseIngestionFile) {
+            return await parser.parseIngestionFile(file, {tenantContext});
+        }
+
+        if (parser?.parse) {
+            const legacyChunks = await parser.parse(file.content, file.sourcePath, file.type || 'external-source', file.hierarchy || {});
+
+            return legacyChunks.map(chunk => this.legacyChunkToParsedRecord({
+                chunk,
+                file,
+                parserId,
+                tenantContext
+            }));
+        }
+
+        return [this.rawFileToParsedRecord({file, fileIndex, parserId, tenantContext})];
+    }
+
+    /**
+     * @summary Resolves a parser instance by parser id from SourceRegistry.
+     * @param {String} parserId Parser registry id.
+     * @returns {Object|null}
+     * @protected
+     */
+    resolveParser(parserId) {
+        const ids     = this.sourceRegistry.getParserIds?.() || [];
+        const parsers = this.sourceRegistry.getParsers?.() || [];
+        const index   = ids.indexOf(parserId);
+
+        return index === -1 ? null : parsers[index];
+    }
+
+    /**
+     * @summary Resolves revision-boundary tombstones via an injected Phase 2E resolver.
+     * @param {Object} options
+     * @returns {Promise<Array<Object>>}
+     * @protected
+     */
+    async resolveRevisionTombstones({baseRevision, headRevision, tenantContext, summary}) {
+        if (!baseRevision || !headRevision) {
+            summary.errors.push(this.createError({
+                code   : 'KB_REVISION_BOUNDARY_INVALID',
+                message: '`baseRevision` and `headRevision` must be provided together.'
+            }));
+            return [];
+        }
+
+        if (!this.revisionResolver?.resolveDeletedPaths) {
+            summary.errors.push(this.createError({
+                code   : 'KB_REVISION_BOUNDARY_UNAVAILABLE',
+                message: 'Revision-boundary deletion requires Phase 2E tenant config storage / resolver (#11637).'
+            }));
+            return [];
+        }
+
+        const resolved = await this.revisionResolver.resolveDeletedPaths({
+            baseRevision,
+            headRevision,
+            tenantContext
+        });
+
+        return Array.isArray(resolved) ? resolved : [];
+    }
+
+    /**
+     * @summary Resolves the authoritative tenant context for the ingest call.
+     * @param {Object} payload Ingestion payload.
+     * @returns {{tenantId: String, repoSlug: String, visibility: String, originAgentIdentity: String|undefined}}
+     * @protected
+     */
+    resolveTenantContext(payload = {}) {
+        const activeTenant = normalizeUserId(this.requestContextService.getUserId?.());
+        const requestedTenant = normalizeUserId(payload.tenantId);
+
+        if (activeTenant && requestedTenant && activeTenant !== requestedTenant) {
+            const error = new Error(`Tenant '${requestedTenant}' does not match authenticated tenant '${activeTenant}'.`);
+            error.code  = 'KB_INGEST_TENANT_MISMATCH';
+            throw error;
+        }
+
+        const tenantId = activeTenant || requestedTenant || aiConfig.defaultTenantId || 'neo-shared';
+
+        return {
+            tenantId,
+            repoSlug: payload.repoSlug || this.resolvePayloadRepoSlug(payload) || aiConfig.defaultRepoSlug || 'neo',
+            visibility: payload.visibility || aiConfig.defaultVisibility || 'team',
+            originAgentIdentity: this.requestContextService.getAgentIdentityNodeId?.() || payload.originAgentIdentity
+        };
+    }
+
+    /**
+     * @summary Finds a repoSlug in the payload when the caller omitted a top-level value.
+     * @param {Object} payload Ingestion payload.
+     * @returns {String|undefined}
+     * @protected
+     */
+    resolvePayloadRepoSlug(payload = {}) {
+        const files = Array.isArray(payload.files) ? payload.files : [];
+
+        for (const file of files) {
+            if (file?.repoSlug) return file.repoSlug;
+            const firstChunk = file?.schemaVersion === '1.0.0'
+                ? file
+                : file?.parsedChunks?.[0] || file?.chunks?.[0];
+            if (firstChunk?.repoSlug) return firstChunk.repoSlug;
+        }
+    }
+
+    /**
+     * @summary Maps the ingestion summary to the existing KB telemetry event taxonomy.
+     * @param {Object} summary Ingestion summary.
+     * @returns {'ingest'|'tombstone'|'reconcile'|'error'}
+     * @protected
+     */
+    resolveMetricEventType(summary) {
+        if (summary.errors.length > 0) {
+            return 'error';
+        }
+
+        if (summary.ingested > 0 && summary.deleted > 0) {
+            return 'reconcile';
+        }
+
+        return summary.deleted > 0 ? 'tombstone' : 'ingest';
+    }
+
+    /**
+     * @summary Converts legacy parser output into a parsed-chunk-v1 record.
+     * @param {Object} options
+     * @returns {Object}
+     * @protected
+     */
+    legacyChunkToParsedRecord({chunk, file, parserId, tenantContext}) {
+        const sourcePath = chunk.sourcePath || chunk.source || file.sourcePath;
+        const kind       = chunk.kind || chunk.type || 'doc-section';
+
+        return {
+            schemaVersion: '1.0.0',
+            tenantId     : tenantContext.tenantId,
+            repoSlug     : file.repoSlug || tenantContext.repoSlug,
+            rootKind     : file.rootKind || 'external-source',
+            sourcePath,
+            content      : chunk.content || chunk.description || '',
+            hashInputs   : ['kind', 'name', 'content', 'sourcePath', 'parserId', 'parserVersion'],
+            parserId,
+            parserVersion: file.parserVersion || '1.0.0',
+            kind,
+            name         : chunk.name || sourcePath,
+            ...(chunk.line_start ? {line_start: chunk.line_start} : {}),
+            ...(chunk.line_end ? {line_end: chunk.line_end} : {}),
+            ...(chunk.className ? {className: chunk.className} : {}),
+            ...(chunk.extends ? {extends: chunk.extends} : {})
+        };
+    }
+
+    /**
+     * @summary Creates a minimal parsed-chunk-v1 record for raw text payloads.
+     * @param {Object} options
+     * @returns {Object}
+     * @protected
+     */
+    rawFileToParsedRecord({file, fileIndex, parserId, tenantContext}) {
+        const sourcePath = file.sourcePath || `inline-${fileIndex}.txt`;
+
+        return {
+            schemaVersion: '1.0.0',
+            tenantId     : tenantContext.tenantId,
+            repoSlug     : file.repoSlug || tenantContext.repoSlug,
+            rootKind     : file.rootKind || 'external-source',
+            sourcePath,
+            content      : file.content,
+            hashInputs   : ['kind', 'name', 'content', 'sourcePath', 'parserId', 'parserVersion'],
+            parserId,
+            parserVersion: file.parserVersion || '1.0.0',
+            kind         : file.kind || 'doc-section',
+            name         : file.name || sourcePath,
+            ...(file.line_start ? {line_start: file.line_start} : {}),
+            ...(file.line_end ? {line_end: file.line_end} : {}),
+            ...(file.className ? {className: file.className} : {}),
+            ...(file.extends ? {extends: file.extends} : {}),
+            ...(file.customMeta ? {customMeta: file.customMeta} : {})
+        };
+    }
+
+    /**
+     * @summary Validates and normalizes one parsed-chunk-v1 record for VectorService.
+     * @param {Object} options
+     * @returns {Promise<Object|null>}
+     * @protected
+     */
+    async validateAndNormalizeParsedChunk({record, fileIndex, chunkIndex, tenantContext, summary}) {
+        if (Object.prototype.hasOwnProperty.call(record || {}, 'embedding')) {
+            summary.errors.push(this.createError({
+                code   : 'KB_PARSED_CHUNK_EMBEDDING_REJECTED',
+                message: 'parsed-chunk-v1 records must not carry `embedding`; use manageDatabaseBackup({action: \'import\'}) for restore payloads.',
+                details: {fileIndex, chunkIndex, restorePath: 'manageDatabaseBackup({action: \'import\'})'}
+            }));
+            return null;
+        }
+
+        const validate = await this.getParsedChunkValidator();
+
+        if (!validate(record)) {
+            summary.errors.push(this.createError({
+                code   : 'KB_PARSED_CHUNK_INVALID',
+                message: 'Record does not conform to parsed-chunk-v1.',
+                details: {fileIndex, chunkIndex, errors: validate.errors}
+            }));
+            return null;
+        }
+
+        const hash = this.createChunkHash(record, tenantContext);
+
+        return {
+            ...record,
+            hash,
+            id         : hash,
+            source     : record.sourcePath,
+            type       : record.kind,
+            description: record.content
+        };
+    }
+
+    /**
+     * @summary Writes an embedding batch to a temporary JSONL file for VectorService.
+     * @param {Array<Object>} chunks Parsed chunks.
+     * @returns {Promise<String>} Temporary file path.
+     * @protected
+     */
+    async writeTempJsonl(chunks) {
+        const dir  = path.join(os.tmpdir(), 'neo-kb-ingestion');
+        const file = path.join(dir, `ingest-${process.pid}-${Date.now()}-${crypto.randomUUID()}.jsonl`);
+
+        await fs.ensureDir(dir);
+        await fs.writeFile(file, chunks.map(chunk => JSON.stringify(chunk)).join('\n'), 'utf8');
+
+        return file;
+    }
+}
+
+export default Neo.setupClass(KnowledgeBaseIngestionService);

--- a/ai/services/knowledge-base/VectorService.mjs
+++ b/ai/services/knowledge-base/VectorService.mjs
@@ -245,11 +245,14 @@ class VectorService extends Base {
      * @param {Boolean} [opts.viaMcp=false]        True when called via MCP tool dispatch;
      *                                             enables the work-volume gate.
      * @param {Object}  [opts.tenantContext]       Server-derived tenant stamp context.
+     * @param {Boolean} [opts.deleteStale=true]    True applies full-corpus stale-id deletion.
+     *                                             Incremental Phase 2 pushes pass `false` and
+     *                                             use explicit deletion signaling instead.
      * @returns {Promise<object>} A promise that resolves to a success message, OR a
      *     `{error, code: 'KB_SYNC_VOLUME_EXCEEDED', ...}` shape when the MCP gate fires.
      * @see #10572
      */
-    async embed(knowledgeBasePath, {viaMcp = false, tenantContext = {}} = {}) {
+    async embed(knowledgeBasePath, {viaMcp = false, tenantContext = {}, deleteStale = true} = {}) {
         logger.log('Starting knowledge base embedding...');
 
         if (!await fs.pathExists(knowledgeBasePath)) {
@@ -343,7 +346,7 @@ class VectorService extends Base {
 
         // Convert existingIds Set to Array for filtering, as existingDocs object is no longer available
         const existingIdsArray = Array.from(existingIds);
-        const idsToDelete      = existingIdsArray.filter(id => !allIds.has(id));
+        const idsToDelete      = deleteStale ? existingIdsArray.filter(id => !allIds.has(id)) : [];
 
         logger.log(`${chunksToProcess.length} chunks to add or update.`);
         logger.log(`${idsToDelete.length} chunks to delete.`);
@@ -356,7 +359,7 @@ class VectorService extends Base {
 
             const message = 'No changes detected. Knowledge base is up to date.';
             logger.log(message);
-            return {message};
+            return {message, embedded: 0, deleted: idsToDelete.length};
         }
 
         // Work-volume gate (#10572): refuse synchronous embedding via MCP when the
@@ -442,7 +445,7 @@ class VectorService extends Base {
         const count   = await collection.count();
         const message = `Embedding complete. Collection now contains ${count} items.`;
         logger.log(message);
-        return {message};
+        return {message, embedded: chunksToProcess.length, deleted: idsToDelete.length};
     }
 
     /**

--- a/test/playwright/unit/ai/services/knowledge-base/KnowledgeBaseIngestionService.spec.mjs
+++ b/test/playwright/unit/ai/services/knowledge-base/KnowledgeBaseIngestionService.spec.mjs
@@ -1,0 +1,307 @@
+import {setup} from '../../../../setup.mjs';
+
+const appName = 'KBIngestionServiceTest';
+
+setup({
+    neoConfig: {
+        allowVdomUpdatesInTests: false,
+        unitTestMode           : true,
+        useDomApiRenderer      : false
+    },
+    appConfig: {
+        name             : appName,
+        isMounted        : () => true,
+        vnodeInitialising: false
+    }
+});
+
+import {test, expect} from '@playwright/test';
+import Neo            from '../../../../../../src/Neo.mjs';
+import * as core      from '../../../../../../src/core/_export.mjs';
+import fs             from 'fs-extra';
+
+/**
+ * Contract coverage for KnowledgeBaseIngestionService (#11633).
+ *
+ * The suite uses mock VectorService / Chroma / telemetry dependencies so it verifies the
+ * Phase 2A orchestration contract without touching the real ChromaDB collection or external
+ * embedding provider.
+ */
+test.describe.configure({mode: 'serial'});
+
+function validParsedChunk(overrides = {}) {
+    return {
+        schemaVersion: '1.0.0',
+        tenantId     : 'tenant-a',
+        repoSlug     : 'repo-a',
+        rootKind     : 'bare-repo',
+        sourcePath   : 'src/index.js',
+        content      : 'export const value = 1;',
+        hashInputs   : ['kind', 'name', 'content', 'sourcePath', 'parserId', 'parserVersion'],
+        parserId     : 'client-parser',
+        parserVersion: '1.0.0',
+        kind         : 'module-context',
+        name         : 'src/index.js - [Module]',
+        ...overrides
+    };
+}
+
+function createSpyCollection(rows = []) {
+    const state = new Map(rows.map(row => [row.id, row]));
+
+    return {
+        state,
+        name: 'spy-knowledge-base',
+
+        async get({where, limit = 2000, offset = 0, include = []} = {}) {
+            const all = Array.from(state.values())
+                .filter(row => !where?.tenantId || row.metadata.tenantId === where.tenantId);
+            const slice = all.slice(offset, offset + limit);
+
+            return {
+                ids      : slice.map(row => row.id),
+                metadatas: include.includes('metadatas') ? slice.map(row => row.metadata) : []
+            };
+        },
+
+        async delete({ids}) {
+            ids.forEach(id => state.delete(id));
+        }
+    };
+}
+
+test.describe('KnowledgeBaseIngestionService.ingestSourceFiles', () => {
+    let Service;
+    let originals;
+    let vectorCalls;
+    let metrics;
+    let collection;
+
+    test.beforeAll(async () => {
+        Service = (await import('../../../../../../ai/services/knowledge-base/KnowledgeBaseIngestionService.mjs')).default;
+    });
+
+    test.beforeEach(() => {
+        vectorCalls = [];
+        metrics     = [];
+        collection  = createSpyCollection();
+
+        originals = {
+            chromaManager        : Service.chromaManager,
+            recorderService      : Service.recorderService,
+            requestContextService: Service.requestContextService,
+            revisionResolver     : Service.revisionResolver,
+            sourceRegistry       : Service.sourceRegistry,
+            vectorService        : Service.vectorService
+        };
+
+        Service.chromaManager = {
+            getKnowledgeBaseCollection: async () => collection
+        };
+        Service.recorderService = {
+            recordIngestionMetric: entry => metrics.push(entry)
+        };
+        Service.requestContextService = {
+            getAgentIdentityNodeId: () => '@neo-gpt',
+            getUserId             : () => 'tenant-a'
+        };
+        Service.revisionResolver = null;
+        Service.sourceRegistry = {
+            getParserIds: () => [],
+            getParsers  : () => []
+        };
+        Service.vectorService = {
+            embed: async (filePath, options) => {
+                const lines = (await fs.readFile(filePath, 'utf8')).trim().split('\n').filter(Boolean);
+                vectorCalls.push({filePath, options, records: lines.map(line => JSON.parse(line))});
+                return {message: 'Embedding complete. Collection now contains 1 items.', embedded: lines.length, deleted: 0};
+            }
+        };
+    });
+
+    test.afterEach(() => {
+        Object.assign(Service, originals);
+    });
+
+    test('validates parsed-chunk-v1 records, routes them to VectorService, and records telemetry', async () => {
+        const summary = await Service.ingestSourceFiles({
+            tenantId: 'tenant-a',
+            files   : [{parsedChunks: [validParsedChunk()]}]
+        });
+
+        expect(summary.tenantId).toBe('tenant-a');
+        expect(summary.ingested).toBe(1);
+        expect(summary.embeddingsGenerated).toBe(1);
+        expect(summary.deleted).toBe(0);
+        expect(summary.errors).toEqual([]);
+        expect(vectorCalls).toHaveLength(1);
+        expect(vectorCalls[0].options.deleteStale).toBe(false);
+        expect(vectorCalls[0].options.tenantContext).toMatchObject({
+            tenantId           : 'tenant-a',
+            repoSlug           : 'repo-a',
+            visibility         : 'team',
+            originAgentIdentity: '@neo-gpt'
+        });
+        expect(vectorCalls[0].records[0]).toMatchObject({
+            source    : 'src/index.js',
+            sourcePath: 'src/index.js',
+            type      : 'module-context'
+        });
+        expect(vectorCalls[0].records[0].hash).toHaveLength(64);
+        expect(metrics[0]).toMatchObject({
+            tenantId      : 'tenant-a',
+            repoSlug      : 'repo-a',
+            eventType     : 'ingest',
+            chunksTotal   : 1,
+            chunksEmbedded: 1
+        });
+    });
+
+    test('rejects parsed-chunk-v1 records carrying embedding and routes caller to restore path', async () => {
+        const summary = await Service.ingestSourceFiles({
+            tenantId: 'tenant-a',
+            files   : [{parsedChunks: [{...validParsedChunk(), embedding: [0.1, 0.2]}]}]
+        });
+
+        expect(summary.ingested).toBe(0);
+        expect(summary.embeddingsGenerated).toBe(0);
+        expect(vectorCalls).toHaveLength(0);
+        expect(summary.errors[0]).toMatchObject({
+            code: 'KB_PARSED_CHUNK_EMBEDDING_REJECTED'
+        });
+        expect(summary.errors[0].message).toContain('manageDatabaseBackup');
+        expect(metrics[0].eventType).toBe('error');
+    });
+
+    test('returns a structured tenant-mismatch error instead of throwing', async () => {
+        const summary = await Service.ingestSourceFiles({
+            tenantId: 'tenant-b',
+            files   : [{parsedChunks: [validParsedChunk({tenantId: 'tenant-b'})]}]
+        });
+
+        expect(summary.ingested).toBe(0);
+        expect(summary.errors[0]).toMatchObject({
+            code: 'KB_INGEST_TENANT_MISMATCH'
+        });
+        expect(vectorCalls).toHaveLength(0);
+    });
+
+    test('applies tombstone, manifest, and mock revision-boundary deletion signaling', async () => {
+        collection = createSpyCollection([
+            {id: 'keep', metadata: {tenantId: 'tenant-a', repoSlug: 'repo-a', sourcePath: 'src/live.js'}},
+            {id: 'tombstone', metadata: {tenantId: 'tenant-a', repoSlug: 'repo-a', sourcePath: 'src/delete-me.js'}},
+            {id: 'manifest-orphan', metadata: {tenantId: 'tenant-a', repoSlug: 'repo-a', sourcePath: 'src/orphan.js'}},
+            {id: 'revision-delete', metadata: {tenantId: 'tenant-a', repoSlug: 'repo-a', sourcePath: 'src/revision.js'}},
+            {id: 'other-tenant', metadata: {tenantId: 'tenant-b', repoSlug: 'repo-a', sourcePath: 'src/delete-me.js'}}
+        ]);
+        Service.chromaManager = {
+            getKnowledgeBaseCollection: async () => collection
+        };
+        Service.revisionResolver = {
+            resolveDeletedPaths: async () => [{repoSlug: 'repo-a', sourcePath: 'src/revision.js'}]
+        };
+
+        const summary = await Service.ingestSourceFiles({
+            tenantId        : 'tenant-a',
+            repoSlug        : 'repo-a',
+            files           : [],
+            deleted         : [{sourcePath: 'src/delete-me.js'}],
+            manifestSnapshot: {repoSlug: 'repo-a', pathsAfterPush: ['src/live.js', 'src/revision.js']},
+            baseRevision    : 'base',
+            headRevision    : 'head'
+        });
+
+        expect(summary.deleted).toBe(3);
+        expect(Array.from(collection.state.keys()).sort()).toEqual(['keep', 'other-tenant']);
+        expect(metrics[0]).toMatchObject({
+            eventType    : 'tombstone',
+            chunksDeleted: 3
+        });
+    });
+
+    test('records reconcile telemetry when one push ingests and deletes chunks', async () => {
+        collection = createSpyCollection([
+            {id: 'deleted', metadata: {tenantId: 'tenant-a', repoSlug: 'repo-a', sourcePath: 'src/deleted.js'}}
+        ]);
+        Service.chromaManager = {
+            getKnowledgeBaseCollection: async () => collection
+        };
+
+        const summary = await Service.ingestSourceFiles({
+            tenantId: 'tenant-a',
+            repoSlug: 'repo-a',
+            files   : [{parsedChunks: [validParsedChunk({sourcePath: 'src/new.js'})]}],
+            deleted : [{sourcePath: 'src/deleted.js'}]
+        });
+
+        expect(summary.ingested).toBe(1);
+        expect(summary.deleted).toBe(1);
+        expect(metrics[0]).toMatchObject({
+            eventType      : 'reconcile',
+            chunksEmbedded : 1,
+            chunksDeleted  : 1
+        });
+    });
+
+    test('server-side raw parsing consumes registered parsers and normalizes legacy chunks', async () => {
+        const parser = {
+            parse: content => [{
+                content,
+                kind      : 'doc-section',
+                line_start: 1,
+                line_end  : 1,
+                name      : 'docs/readme.md - Intro',
+                source    : 'docs/readme.md'
+            }]
+        };
+
+        Service.sourceRegistry = {
+            getParserIds: () => ['mock-parser'],
+            getParsers  : () => [parser]
+        };
+
+        const summary = await Service.ingestSourceFiles({
+            tenantId: 'tenant-a',
+            repoSlug: 'repo-a',
+            files   : [{
+                content      : '# Intro',
+                parserId     : 'mock-parser',
+                parserVersion: '1.2.3',
+                rootKind     : 'external-source',
+                sourcePath   : 'docs/readme.md'
+            }]
+        });
+
+        expect(summary.ingested).toBe(1);
+        expect(summary.errors).toEqual([]);
+        expect(vectorCalls[0].records[0]).toMatchObject({
+            parserId     : 'mock-parser',
+            parserVersion: '1.2.3',
+            sourcePath   : 'docs/readme.md',
+            type         : 'doc-section'
+        });
+    });
+
+    test('captures VectorService refusal as a summary error without losing the summary', async () => {
+        Service.vectorService = {
+            embed: async () => ({
+                error  : 'KB sync work volume exceeds MCP-callable threshold',
+                code   : 'KB_SYNC_VOLUME_EXCEEDED',
+                message: 'too many chunks'
+            })
+        };
+
+        const summary = await Service.ingestSourceFiles({
+            tenantId: 'tenant-a',
+            files   : [{parsedChunks: [validParsedChunk()]}]
+        });
+
+        expect(summary.ingested).toBe(1);
+        expect(summary.embeddingsGenerated).toBe(0);
+        expect(summary.errors[0]).toMatchObject({
+            code   : 'KB_SYNC_VOLUME_EXCEEDED',
+            message: 'too many chunks'
+        });
+        expect(metrics[0].eventType).toBe('error');
+    });
+});

--- a/test/playwright/unit/ai/services/knowledge-base/KnowledgeBaseIngestionService.spec.mjs
+++ b/test/playwright/unit/ai/services/knowledge-base/KnowledgeBaseIngestionService.spec.mjs
@@ -186,6 +186,56 @@ test.describe('KnowledgeBaseIngestionService.ingestSourceFiles', () => {
         expect(vectorCalls).toHaveLength(0);
     });
 
+    test('returns structured caller errors for invalid file payloads and missing parsers', async () => {
+        const invalidFilesSummary = await Service.ingestSourceFiles({
+            tenantId: 'tenant-a',
+            files   : 'not-an-array'
+        });
+
+        expect(invalidFilesSummary.ingested).toBe(0);
+        expect(invalidFilesSummary.errors[0]).toMatchObject({
+            code: 'KB_INGEST_FILES_INVALID'
+        });
+        expect(metrics[0].eventType).toBe('error');
+
+        metrics = [];
+
+        const missingParserSummary = await Service.ingestSourceFiles({
+            tenantId: 'tenant-a',
+            files   : [{
+                content   : '# Missing parser',
+                parserId  : 'missing-parser',
+                sourcePath: 'docs/missing.md'
+            }]
+        });
+
+        expect(missingParserSummary.ingested).toBe(0);
+        expect(missingParserSummary.errors[0]).toMatchObject({
+            code: 'KB_PARSER_NOT_REGISTERED'
+        });
+        expect(vectorCalls).toHaveLength(0);
+        expect(metrics[0].eventType).toBe('error');
+    });
+
+    test('reports unavailable revision-boundary deletion resolver without throwing', async () => {
+        const summary = await Service.ingestSourceFiles({
+            tenantId    : 'tenant-a',
+            repoSlug    : 'repo-a',
+            files       : [],
+            baseRevision: 'base',
+            headRevision: 'head'
+        });
+
+        expect(summary.deleted).toBe(0);
+        expect(summary.errors[0]).toMatchObject({
+            code: 'KB_REVISION_BOUNDARY_UNAVAILABLE'
+        });
+        expect(metrics[0]).toMatchObject({
+            eventType    : 'error',
+            chunksDeleted: 0
+        });
+    });
+
     test('applies tombstone, manifest, and mock revision-boundary deletion signaling', async () => {
         collection = createSpyCollection([
             {id: 'keep', metadata: {tenantId: 'tenant-a', repoSlug: 'repo-a', sourcePath: 'src/live.js'}},


### PR DESCRIPTION
Authored by GPT-5 (Codex Desktop). Session d13c94dd-e721-4e28-ac9e-4d0b3c0f66de.

FAIR-band: over-target [12/30] — taking this lane despite over-target because #11633 was already claimed/assigned after Phase 0/1 closeout, it unblocks Phase 2B/2C ingestion facades, and AGENT:* author-yield is operator-suppressed during the active peer-harness instability window.

Resolves #11633

Adds the Phase 2A `KnowledgeBaseIngestionService` service boundary consumed by the upcoming MCP and bulk ingestion facades. The service validates request tenant context, accepts client-side `parsed-chunk-v1` payloads or server-side raw parser payloads, rejects restore-only embedding records, applies tombstone/manifest/revision deletion signals, routes embedding through `VectorService`, records ingestion telemetry, and returns the structured summary contract promised by the ticket.

Evidence: L2 (Playwright unit/service tests with mocked tenant context, parser registry, Chroma collection, VectorService, and telemetry sink) -> L2 required for this service-layer close target. Residual: real MCP/bulk facade wiring and deployed hook transport remain out of scope for #11633 and are owned by Phase 2B/2C.

## Signal Ledger (sourced from Discussion #11623)

- @neo-gemini-3-1-pro: `[GRADUATION_APPROVED]` @ `DC_kwDODSospM4BAwUa` — https://github.com/neomjs/neo/discussions/11623#discussioncomment-16975130
- @neo-gpt: `[GRADUATION_APPROVED by @neo-gpt @ body updatedAt 2026-05-19T11:25:13Z]` @ `DC_kwDODSospM4BAwUo` — https://github.com/neomjs/neo/discussions/11623#discussioncomment-16975144
- @neo-opus-4-7: `[GRADUATION_APPROVED by @neo-opus-4-7 @ body updatedAt 2026-05-19T11:25:13Z]` @ `DC_kwDODSospM4BAwVB` — https://github.com/neomjs/neo/discussions/11623#discussioncomment-16975169

## Unresolved Dissent

(empty)

## Unresolved Liveness

(empty)

## Contract Ledger Alignment

#11633 contains the required Contract Ledger matrix. This diff matches the ledger rows:

- `KnowledgeBaseIngestionService.ingestSourceFiles({tenantId, files, deleted?, manifestSnapshot?, baseRevision?, headRevision?})`
- summary return value `{ingested, deleted, embeddingsGenerated, errors, tenantId, durationMs}`
- `embedding`-field rejection with restore-path guidance

## Deltas from ticket

- Added `VectorService.embed(..., {deleteStale})`, defaulting to the old full-corpus stale-delete behavior. `KnowledgeBaseIngestionService` passes `deleteStale: false` because incremental Phase 2 pushes do not have a full-corpus view and must use explicit deletion signaling instead.
- Classified telemetry as `ingest`, `tombstone`, `reconcile`, or `error` to match the existing `KBRecorderService.recordIngestionMetric()` event taxonomy.

## Test Evidence

- `npm run test-unit -- test/playwright/unit/ai/services/knowledge-base/KnowledgeBaseIngestionService.spec.mjs test/playwright/unit/ai/services/knowledge-base/VectorService.tenantStamping.spec.mjs test/playwright/unit/ai/services/knowledge-base/VectorService.WorkVolumeBranching.spec.mjs test/playwright/unit/ai/services/knowledge-base/KBRecorderService.ingestionMetrics.spec.mjs test/playwright/unit/ai/services/knowledge-base/parser/Schemas.spec.mjs` — 49 passed.
- `git diff --cached --check` — passed before each commit.
- Full `npm run test-unit` attempted — 1621 passed, 70 failed, 5 skipped, 33 did not run. Failures were outside this lane, including pre-existing/environmental `Neo.ns is not a function` in `laneCManualScriptLeaseAdoption`, Chroma connection failures, localhost `EPERM` transport health failures, SQLite unable-to-open DB in bridge-daemon specs, and existing grid pooling/teleportation expectations. No failures were in the touched KB ingestion/stamping/schema slice.
- Branch freshness: `merge-base HEAD origin/dev == origin/dev` before PR creation.

## Post-Merge Validation

- [ ] Phase 2B MCP facade can import `KB_IngestionService` from `ai/services.mjs` and route small-batch requests to `ingestSourceFiles()`.
- [ ] Phase 2C bulk facade can reuse the same service while preserving `deleteStale: false` incremental-push semantics.

## Commits

- `da4e00327` — `feat(kb): add ingestion service (#11633)`
- `a6f37ca31` — `test(kb): cover ingestion error paths (#11633)`
