### PR TITLE
fix(memory-core): expose neighbor semantic vector ids (#11680)

### DIFF
--- a/ai/mcp/server/memory-core/openapi.yaml
+++ b/ai/mcp/server/memory-core/openapi.yaml
@@ -761,6 +761,35 @@ paths:
                     type: array
                     items:
                       type: object
+                      additionalProperties: true
+                      properties:
+                        id:
+                          type: string
+                          description: The adjacent node ID.
+                        type:
+                          type: string
+                          description: The adjacent node type or label.
+                        name:
+                          type: string
+                          description: The adjacent node display name.
+                        description:
+                          type: string
+                          description: The adjacent node description.
+                        relationship:
+                          type: string
+                          description: The edge relationship type connecting the source and adjacent node.
+                        weight:
+                          type: number
+                          description: The edge weight for the relationship.
+                        source:
+                          type: string
+                          description: The source node ID for the relationship edge.
+                        target:
+                          type: string
+                          description: The target node ID for the relationship edge.
+                        semanticVectorId:
+                          type: string
+                          description: The adjacent node's semantic vector identifier, when present.
         '500':
           description: Internal server error.
           content:

--- a/ai/services/memory-core/GraphService.mjs
+++ b/ai/services/memory-core/GraphService.mjs
@@ -621,7 +621,9 @@ class GraphService extends Base {
      * Retrieves adjacent connected nodes (neighbors) alongside relationship metadata.
      * @param {Object} data
      * @param {String} data.id
-     * @returns {Array} List of connected Node objects with edge relationship mapping.
+     * @returns {Object} Object containing connected Node objects with edge relationship mapping.
+     *     Neighbor objects include `semanticVectorId` when present on the adjacent node,
+     *     enabling vector-backed consumers such as `preBriefSession` to hydrate context.
      */
     getNeighbors({id}) {
         // Guarantee lazy-loading vicinity topology securely
@@ -647,14 +649,15 @@ class GraphService extends Base {
             // edge are RLS-visible — a private edge between visible nodes still leaks.
             if (node && isRlsVisible(node, rlsUserId) && isRlsVisible(e, rlsUserId)) {
                 results.push({
-                    id          : node.id,
-                    type        : node.label,
-                    name        : node.properties?.name,
-                    description : node.properties?.description,
-                    relationship: e.type,
-                    weight      : e.properties?.weight || 1.0,
-                    source      : e.source,
-                    target      : e.target
+                    id              : node.id,
+                    type            : node.label,
+                    name            : node.properties?.name,
+                    description     : node.properties?.description,
+                    semanticVectorId: node.properties?.semanticVectorId,
+                    relationship    : e.type,
+                    weight          : e.properties?.weight || 1.0,
+                    source          : e.source,
+                    target          : e.target
                 });
             }
         });

--- a/test/playwright/unit/ai/mcp/server/memory-core/McpServerToolLimits.spec.mjs
+++ b/test/playwright/unit/ai/mcp/server/memory-core/McpServerToolLimits.spec.mjs
@@ -77,4 +77,14 @@ test.describe('Neo.ai.mcp.server.memory-core Tool limits', () => {
         ]));
         expect(metadata.properties.adapter.enum).toEqual(['osascript', 'tmux']);
     });
+
+    test('get_neighbors output schema exposes semanticVectorId contract (#11680)', async () => {
+        const { tools } = await toolService.listTools();
+        const tool = tools.find(item => item.name === 'get_neighbors');
+        const neighbor = tool.outputSchema.properties.neighbors.items;
+
+        expect(neighbor.properties.semanticVectorId.type).toBe('string');
+        expect(neighbor.properties.semanticVectorId.description).toContain('semantic vector identifier');
+        expect(neighbor.additionalProperties).not.toBe(false);
+    });
 });

--- a/test/playwright/unit/ai/services/memory-core/GraphService.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/GraphService.spec.mjs
@@ -107,7 +107,7 @@ test.describe('Neo.ai.services.memory-core.GraphService', () => {
     test('should extract node neighbors properly', async () => {
         test.skip(!!process.env.NEO_TEST_SKIP_CI, 'CI-skip: SqliteError disk I/O - bucket G3 (#10924)');
         await GraphService.upsertNode({id: 'EpicA', name: 'Roadmap Planner'});
-        await GraphService.upsertNode({id: 'Task1', name: 'Implementation'});
+        await GraphService.upsertNode({id: 'Task1', name: 'Implementation', semanticVectorId: 'vector-task-1'});
         await GraphService.upsertNode({id: 'Task2', name: 'Documentation'});
 
         await GraphService.linkNodes('EpicA', 'Task1', 'CONTAINS', 1.0);
@@ -126,9 +126,41 @@ test.describe('Neo.ai.services.memory-core.GraphService', () => {
         expect(task1).toBeDefined();
         expect(task1.weight).toBe(1.0);
         expect(task1.relationship).toBe('CONTAINS');
+        expect(task1.semanticVectorId).toBe('vector-task-1');
 
         expect(task2).toBeDefined();
         expect(task2.weight).toBe(0.8);
+    });
+
+    test('preBriefSession should hydrate episodic context through getNeighbors semanticVectorId', async () => {
+        await GraphService.upsertNode({id: 'EpicA', name: 'Roadmap Planner'});
+        await GraphService.upsertNode({id: 'MemoryA', name: 'Session Summary', semanticVectorId: 'summary-vector-1'});
+        await GraphService.linkNodes('EpicA', 'MemoryA', 'RELATES_TO', 0.9);
+
+        const StorageRouter = (await import('../../../../../../ai/services/memory-core/managers/StorageRouter.mjs')).default;
+        const MemoryService = (await import('../../../../../../ai/services/memory-core/MemoryService.mjs')).default;
+
+        const originalGetSummaryCollection = StorageRouter.getSummaryCollection;
+        const getCalls = [];
+
+        StorageRouter.getSummaryCollection = async () => ({
+            async get(args) {
+                getCalls.push(args);
+                return {documents: ['Hydrated episodic context']};
+            }
+        });
+
+        try {
+            const brief = await MemoryService.preBriefSession({targetId: 'EpicA', limit: 5});
+
+            expect(getCalls).toHaveLength(1);
+            expect(getCalls[0].ids).toEqual(['summary-vector-1']);
+            expect(brief.context).toHaveLength(1);
+            expect(brief.context[0].id).toBe('MemoryA');
+            expect(brief.context[0].episodicContext).toBe('Hydrated episodic context');
+        } finally {
+            StorageRouter.getSummaryCollection = originalGetSummaryCollection;
+        }
     });
 
     test('should dynamically compute getNodeGravity natively', async () => {


### PR DESCRIPTION
Resolves #11680

Authored by GPT-5 (Codex Desktop) consuming Claude Opus 4.7 handoff — session A c4505aed-b48d-4aed-ba11-a1db410744df, session B d13c94dd-e721-4e28-ac9e-4d0b3c0f66de.

FAIR-band: in-band [13/30]

`GraphService.getNeighbors()` now carries `semanticVectorId` from adjacent node properties, matching the existing `getContextFrontier()` precedent. The Memory Core MCP OpenAPI contract for `get_neighbors` now declares the neighbor output shape, including `semanticVectorId`, so `tools/list` exposes the additive field instead of relying on undocumented output drift. That makes the existing `MemoryService.preBriefSession()` hydration guard reachable, so vectored neighbors can hydrate `episodicContext` instead of silently returning topology-only briefs.

Evidence: L2 (focused Playwright unit specs exercise live GraphService/MemoryService path and Memory Core MCP tool-list output schema) → L2 required (Memory Core internal API + MCP-facing neighbor contract covered in unit sandbox). No residuals.

## Deltas from ticket

- The runtime fix remains the prescribed additive field exposure plus JSDoc and focused tests. Existing RLS filtering remains unchanged because the field is only added after the adjacent node and connecting edge pass `isRlsVisible()`.
- Post-approval operator challenge accepted: because `get_neighbors` is an MCP-facing output contract, `ai/mcp/server/memory-core/openapi.yaml` now explicitly declares neighbor object fields including `semanticVectorId`, and `McpServerToolLimits.spec.mjs` asserts the generated `get_neighbors.outputSchema` exposes it.

## Test Evidence

- `git diff --check` — passed.
- `git diff --cached --check` — passed before the OpenAPI fixup commit.
- `npm run test-unit -- test/playwright/unit/ai/mcp/server/memory-core/McpServerToolLimits.spec.mjs` — 3 passed.
- `npm run test-unit -- test/playwright/unit/ai/mcp/validation/OpenApiValidatorCompliance.spec.mjs` — 26 passed.
- `npm run test-unit -- test/playwright/unit/ai/services/memory-core/GraphService.spec.mjs` — 22 passed.
- `npm run test-unit` — attempted full suite before the OpenAPI follow-up; failed with unrelated existing/environmental failures: setup/import failures in `laneCManualScriptLeaseAdoption.spec.mjs` (`Neo.ns is not a function`), Chroma/MCP/bridge-dependent AI tests, and existing grid pooling/teleportation assertions. Summary: 1614 passed, 5 skipped, 41 did not run, 72 failed.

## Post-Merge Validation

- [ ] Confirm #11680 auto-closes on merge.
- [ ] Optional live Memory Core probe: `pre_brief_session` can hydrate `episodicContext` for a graph neighbor carrying `semanticVectorId` when the summary Chroma collection is available.
- [ ] Optional MCP probe: `tools/list` for Memory Core exposes `get_neighbors.outputSchema.properties.neighbors.items.properties.semanticVectorId`.

## Commits

- `36f80c13b` — `fix(memory-core): expose neighbor semantic vector ids (#11680)`
- `a0f96df22` — `fix(memory-core): declare get_neighbors vector output (#11680)`