### PR TITLE
feat(kb): add shadow-swap re-embed strategy (#11683)

### DIFF
--- a/ai/services/knowledge-base/ChromaManager.mjs
+++ b/ai/services/knowledge-base/ChromaManager.mjs
@@ -140,6 +140,22 @@ class ChromaManager extends Base {
     }
 
     /**
+     * @summary Invalidates the memoized canonical knowledge-base collection handle.
+     *
+     * Shadow-swap re-embeds rename the canonical Chroma collection behind the stable
+     * `aiConfig.collectionName`. Any cached collection object can point at the parked
+     * pre-swap collection after that rename, so callers must force the next read to
+     * lazily resolve the canonical name again.
+     *
+     * @returns {void}
+     * @see https://github.com/neomjs/neo/issues/11683
+     */
+    invalidateKnowledgeBaseCollectionCache() {
+        this._knowledgeBaseCollectionPromise = null;
+        this.knowledgeBaseCollection         = null;
+    }
+
+    /**
      * Guarded delete-collection wrapper — peer of the Memory Core counterpart. Refuses
      * canonical production collection names unless `UNIT_TEST_MODE=true` or a valid
      * production `confirmation` token is supplied. See the Memory Core ChromaManager's

--- a/ai/services/knowledge-base/DatabaseService.mjs
+++ b/ai/services/knowledge-base/DatabaseService.mjs
@@ -404,8 +404,7 @@ class DatabaseService extends Base {
             // forward the operator confirmation so the canonical-name guard accepts it.
             await ChromaManager.deleteCollection({name: collectionName, confirmation});
 
-            ChromaManager._knowledgeBaseCollectionPromise = null;
-            ChromaManager.knowledgeBaseCollection         = null;
+            ChromaManager.invalidateKnowledgeBaseCollectionCache();
 
             const message = `Knowledge base collection '${collectionName}' truncated successfully.`;
             logger.log(message);

--- a/ai/services/knowledge-base/VectorService.mjs
+++ b/ai/services/knowledge-base/VectorService.mjs
@@ -11,6 +11,8 @@ import readline                  from 'readline';
 import DestructiveOperationGuard from '../../mcp/server/shared/services/DestructiveOperationGuard.mjs';
 
 const TENANT_GUARDED_FIELDS = ['tenantId', 'repoSlug', 'visibility', 'originAgentIdentity'];
+const STALE_STRATEGIES      = Object.freeze(new Set(['delete-upfront', 'shadow-swap']));
+const STALE_STRATEGY_SKIP   = 'skip';
 
 /**
  * @summary Manages vector database operations including embedding generation and storage.
@@ -81,8 +83,7 @@ class VectorService extends Base {
             // Route through ChromaManager.deleteCollection (#11652 substrate-level guard).
             // Forward the operator confirmation so the canonical-name guard accepts it.
             await ChromaManager.deleteCollection({name: collectionName, confirmation});
-            ChromaManager._knowledgeBaseCollectionPromise = null;
-            ChromaManager.knowledgeBaseCollection = null;
+            ChromaManager.invalidateKnowledgeBaseCollectionCache();
             const message = `Knowledge base collection '${collectionName}' deleted successfully.`;
             logger.log(message);
             return {message};
@@ -231,6 +232,167 @@ class VectorService extends Base {
     }
 
     /**
+     * Resolves the stale-data handling strategy while preserving the legacy
+     * `deleteStale: false` incremental-ingestion contract.
+     *
+     * @param {Object}  options
+     * @param {String} [options.staleStrategy] Explicit stale strategy.
+     * @param {Boolean} [options.deleteStale]  Legacy boolean stale-deletion flag.
+     * @returns {String} Resolved strategy: `delete-upfront`, `shadow-swap`, or internal `skip`.
+     * @throws {Error} When the explicit stale strategy is unsupported.
+     */
+    resolveStaleStrategy({staleStrategy, deleteStale = true} = {}) {
+        if (staleStrategy) {
+            if (!STALE_STRATEGIES.has(staleStrategy)) {
+                throw new Error(`Unsupported staleStrategy '${staleStrategy}'. Expected one of: ${Array.from(STALE_STRATEGIES).join(', ')}.`);
+            }
+            return staleStrategy;
+        }
+
+        return deleteStale ? 'delete-upfront' : STALE_STRATEGY_SKIP;
+    }
+
+    /**
+     * Embeds a set of chunks into the provided Chroma collection.
+     *
+     * @param {Object}   options
+     * @param {Object}   options.collection      Chroma collection target.
+     * @param {Object[]} options.chunksToProcess Tenant-stamped chunks to embed.
+     * @returns {Promise<void>}
+     */
+    async embedChunks({collection, chunksToProcess}) {
+        if (chunksToProcess.length === 0) {
+            return;
+        }
+
+        logger.log(`Using TextEmbeddingService with provider: ${mcConfig.embeddingProvider}.`);
+        logger.log('Embedding chunks...');
+
+        const {batchSize, batchDelay, maxRetries} = aiConfig;
+
+        for (let i = 0; i < chunksToProcess.length; i += batchSize) {
+            if (i > 0 && batchDelay) {
+                await this.timeout(batchDelay);
+            }
+
+            const batch = chunksToProcess.slice(i, i + batchSize);
+            const textsToEmbed = batch.map(chunk => `${chunk.type}: ${chunk.name} in ${chunk.className || ''}\n${chunk.description || chunk.content || ''}`);
+
+            let retries = 0;
+            let success = false;
+
+            while (retries < maxRetries && !success) {
+                try {
+                    const embeddings = await TextEmbeddingService.embedTexts(textsToEmbed, mcConfig.embeddingProvider);
+
+                    const metadatas = batch.map(chunk => {
+                        const metadata = {};
+                        for (const [key, value] of Object.entries(chunk)) {
+                            metadata[key] = (value === null) ? 'null' : (typeof value === 'object') ? JSON.stringify(value) : value;
+                        }
+                        return metadata;
+                    });
+
+                    await collection.upsert({
+                        ids: batch.map(chunk => chunk.id),
+                        embeddings,
+                        metadatas
+                    });
+
+                    logger.log(`Processed and embedded batch ${i / batchSize + 1} of ${Math.ceil(chunksToProcess.length / batchSize)}`);
+                    success = true;
+                } catch (err) {
+                    retries++;
+                    console.error(`An error occurred during embedding batch ${i / batchSize + 1}. Retrying (${retries}/${maxRetries})...`, err.message);
+                    if (retries < maxRetries) {
+                        await new Promise(res => setTimeout(res, 2 ** retries * 1000)); // Exponential backoff
+                    } else {
+                        throw new Error(`Failed to process batch ${i / batchSize + 1} after ${maxRetries} retries. Aborting.`);
+                    }
+                }
+            }
+        }
+    }
+
+    /**
+     * Creates a process-unique temporary collection name for a shadow-swap phase.
+     *
+     * @param {String} phase Name suffix identifying the phase.
+     * @returns {String} Temporary Chroma collection name.
+     */
+    createSwapCollectionName(phase) {
+        return `${aiConfig.collectionName}-${phase}-${Date.now()}-${crypto.randomUUID()}`;
+    }
+
+    /**
+     * Rebuilds the full corpus into a shadow collection, then promotes it to the
+     * canonical name without ever gutting the live collection in-place.
+     *
+     * ChromaDB has no single atomic exchange primitive, so the promote step is a
+     * bounded two-rename transaction: live -> parking, shadow -> canonical. The old
+     * collection remains parked as a rollback artifact because destructive collection
+     * deletion is operator-gated outside unit tests.
+     *
+     * @param {Object}   options
+     * @param {Object}   options.liveCollection Existing canonical collection handle.
+     * @param {Object[]} options.knowledgeBase   Full tenant-stamped corpus.
+     * @param {Number}   options.idsToDeleteCount Logical stale-id count removed from the canonical view.
+     * @returns {Promise<Object>} Embedding result.
+     * @see https://github.com/neomjs/neo/issues/11683
+     */
+    async embedViaShadowSwap({liveCollection, knowledgeBase, idsToDeleteCount}) {
+        const shadowName  = this.createSwapCollectionName('shadow');
+        const parkingName = this.createSwapCollectionName('parking');
+
+        logger.log(`Building shadow knowledge-base collection '${shadowName}'.`);
+
+        const shadowCollection = await ChromaManager.client.createCollection({
+            name             : shadowName,
+            embeddingFunction: aiConfig.dummyEmbeddingFunction
+        });
+
+        let liveParked = false;
+
+        try {
+            await this.embedChunks({collection: shadowCollection, chunksToProcess: knowledgeBase});
+
+            logger.log(`Promoting shadow collection '${shadowName}' to '${aiConfig.collectionName}'.`);
+            await liveCollection.modify({name: parkingName});
+            liveParked = true;
+            await shadowCollection.modify({name: aiConfig.collectionName});
+
+            ChromaManager.invalidateKnowledgeBaseCollectionCache();
+
+            const collection = await ChromaManager.getKnowledgeBaseCollection();
+            const count      = await collection.count();
+            const message    = `Embedding complete via shadow-swap. Collection now contains ${count} items. Previous collection parked as '${parkingName}'.`;
+            logger.log(message);
+
+            return {
+                message,
+                embedded           : knowledgeBase.length,
+                deleted            : idsToDeleteCount,
+                staleStrategy      : 'shadow-swap',
+                shadowCollection   : shadowName,
+                parkedCollection   : parkingName,
+                canonicalCollection: aiConfig.collectionName
+            };
+        } catch (error) {
+            ChromaManager.invalidateKnowledgeBaseCollectionCache();
+
+            if (liveParked) {
+                try {
+                    await liveCollection.modify({name: aiConfig.collectionName});
+                    ChromaManager.invalidateKnowledgeBaseCollectionCache();
+                } catch (rollbackError) {
+                    logger.error('[VectorService] Failed to roll back parked live collection after shadow-swap failure:', rollbackError.message);
+                }
+            }
+            throw error;
+        }
+    }
+
+    /**
      * Reads a JSONL file, enriches data, generates embeddings, and updates ChromaDB.
      *
      * **Work-volume gate (#10572):** when invoked via MCP (`viaMcp: true`), refuses
@@ -248,12 +410,17 @@ class VectorService extends Base {
      * @param {Boolean} [opts.deleteStale=true]    True applies full-corpus stale-id deletion.
      *                                             Incremental Phase 2 pushes pass `false` and
      *                                             use explicit deletion signaling instead.
+     * @param {String}  [opts.staleStrategy]       Stale handling strategy. `delete-upfront`
+     *                                             preserves the historical behavior;
+     *                                             `shadow-swap` rebuilds into a fresh collection
+     *                                             before promoting it to the canonical name.
      * @returns {Promise<object>} A promise that resolves to a success message, OR a
      *     `{error, code: 'KB_SYNC_VOLUME_EXCEEDED', ...}` shape when the MCP gate fires.
      * @see #10572
      */
-    async embed(knowledgeBasePath, {viaMcp = false, tenantContext = {}, deleteStale = true} = {}) {
+    async embed(knowledgeBasePath, {viaMcp = false, tenantContext = {}, deleteStale = true, staleStrategy} = {}) {
         logger.log('Starting knowledge base embedding...');
+        const resolvedStaleStrategy = this.resolveStaleStrategy({staleStrategy, deleteStale});
 
         if (!await fs.pathExists(knowledgeBasePath)) {
             throw new Error(`Knowledge base file not found at ${knowledgeBasePath}.`);
@@ -346,12 +513,14 @@ class VectorService extends Base {
 
         // Convert existingIds Set to Array for filtering, as existingDocs object is no longer available
         const existingIdsArray = Array.from(existingIds);
-        const idsToDelete      = deleteStale ? existingIdsArray.filter(id => !allIds.has(id)) : [];
+        const idsToDelete      = resolvedStaleStrategy === STALE_STRATEGY_SKIP ? [] : existingIdsArray.filter(id => !allIds.has(id));
+        const shouldShadowSwap = resolvedStaleStrategy === 'shadow-swap' && (chunksToProcess.length > 0 || idsToDelete.length > 0);
+        const workVolume       = shouldShadowSwap ? knowledgeBase.length : chunksToProcess.length;
 
-        logger.log(`${chunksToProcess.length} chunks to add or update.`);
+        logger.log(`${workVolume} chunks to add or update.`);
         logger.log(`${idsToDelete.length} chunks to delete.`);
 
-        if (chunksToProcess.length === 0) {
+        if (!shouldShadowSwap && chunksToProcess.length === 0) {
             if (idsToDelete.length > 0) {
                 await collection.delete({ ids: idsToDelete });
                 logger.log(`Deleted ${idsToDelete.length} stale chunks.`);
@@ -369,7 +538,7 @@ class VectorService extends Base {
         // the threshold is empirically tunable rather than timing-derived.
         // CLI invocations pass viaMcp: false and bypass.
         const mcpThreshold = aiConfig.mcpSyncMaxChunks ?? 50;
-        if (viaMcp && chunksToProcess.length > mcpThreshold) {
+        if (viaMcp && workVolume > mcpThreshold) {
             // Defensive log-path resolution mirrors logger.mjs's lazy resolution — keeps
             // the refusal message coherent even on existing gitignored config.mjs deployments
             // that pre-date the `logPath` template key. Without the fallback, the rendered
@@ -377,16 +546,24 @@ class VectorService extends Base {
             const logDir = aiConfig.logPath || `${aiConfig.neoRootDir}/.neo-ai-data/logs`;
             const errorPayload = {
                 error  : `KB sync work volume exceeds MCP-callable threshold`,
-                message: `${chunksToProcess.length} chunks need re-embedding (threshold: ${mcpThreshold}). ` +
+                message: `${workVolume} chunks need re-embedding (threshold: ${mcpThreshold}). ` +
                          `Synchronous embedding at this volume risks agent freeze. ` +
                          `Run via CLI: \`npm run ai:sync-kb\`. ` +
                          `Tail progress: \`tail -f ${logDir}/kb-server-$(date +%Y-%m-%d).log\`.`,
                 code           : 'KB_SYNC_VOLUME_EXCEEDED',
-                chunksToProcess: chunksToProcess.length,
+                chunksToProcess: workVolume,
                 threshold      : mcpThreshold
             };
             logger.warn(`[VectorService] ${errorPayload.error}: ${errorPayload.message}`);
             return errorPayload;
+        }
+
+        if (shouldShadowSwap) {
+            return await this.embedViaShadowSwap({
+                liveCollection: collection,
+                knowledgeBase,
+                idsToDeleteCount: idsToDelete.length
+            });
         }
 
         if (idsToDelete.length > 0) {
@@ -394,53 +571,7 @@ class VectorService extends Base {
             logger.log(`Deleted ${idsToDelete.length} stale chunks.`);
         }
 
-        logger.log(`Using TextEmbeddingService with provider: ${mcConfig.embeddingProvider}.`);
-
-        logger.log('Embedding chunks...');
-        const {batchSize, batchDelay, maxRetries} = aiConfig;
-
-        for (let i = 0; i < chunksToProcess.length; i += batchSize) {
-            if (i > 0 && batchDelay) {
-                await this.timeout(batchDelay);
-            }
-
-            const batch = chunksToProcess.slice(i, i + batchSize);
-            const textsToEmbed = batch.map(chunk => `${chunk.type}: ${chunk.name} in ${chunk.className || ''}\n${chunk.description || chunk.content || ''}`);
-
-            let retries = 0;
-            let success = false;
-
-            while (retries < maxRetries && !success) {
-                try {
-                    const embeddings = await TextEmbeddingService.embedTexts(textsToEmbed, mcConfig.embeddingProvider);
-
-                    const metadatas = batch.map(chunk => {
-                        const metadata = {};
-                        for (const [key, value] of Object.entries(chunk)) {
-                            metadata[key] = (value === null) ? 'null' : (typeof value === 'object') ? JSON.stringify(value) : value;
-                        }
-                        return metadata;
-                    });
-
-                    await collection.upsert({
-                        ids: batch.map(chunk => chunk.id),
-                        embeddings,
-                        metadatas
-                    });
-
-                    logger.log(`Processed and embedded batch ${i / batchSize + 1} of ${Math.ceil(chunksToProcess.length / batchSize)}`);
-                    success = true;
-                } catch (err) {
-                    retries++;
-                    console.error(`An error occurred during embedding batch ${i / batchSize + 1}. Retrying (${retries}/${maxRetries})...`, err.message);
-                    if (retries < maxRetries) {
-                        await new Promise(res => setTimeout(res, 2 ** retries * 1000)); // Exponential backoff
-                    } else {
-                        throw new Error(`Failed to process batch ${i / batchSize + 1} after ${maxRetries} retries. Aborting.`);
-                    }
-                }
-            }
-        }
+        await this.embedChunks({collection, chunksToProcess});
 
         const count   = await collection.count();
         const message = `Embedding complete. Collection now contains ${count} items.`;

--- a/test/playwright/integration/KBBackupRestoreWipe.integration.spec.mjs
+++ b/test/playwright/integration/KBBackupRestoreWipe.integration.spec.mjs
@@ -225,6 +225,131 @@ function cleanupBackupPath(backupPath) {
     });
 }
 
+/**
+ * Runs a shadow-swap re-embed against a temporary deployed KB collection name.
+ * @param {Object} options
+ * @param {String} options.collectionName Temporary Chroma collection name.
+ * @param {String} options.oldId          Sentinel id seeded into the pre-swap collection.
+ * @param {String} options.oldSentinel    Sentinel document text seeded into the pre-swap collection.
+ * @param {String} options.fixturePath    JSONL fixture path inside the container.
+ * @returns {Object}
+ */
+function shadowSwapKnowledgeBase({collectionName, oldId, oldSentinel, fixturePath}) {
+    return execKnowledgeBaseJson(`
+        ${NEO_BOOTSTRAP}
+
+        const fs = await import('node:fs/promises');
+        const {
+            KB_Config,
+            KB_ChromaManager,
+            KB_LifecycleService,
+            Memory_TextEmbeddingService
+        } = await import('./ai/services.mjs');
+        const {default: KB_VectorService} = await import('./ai/services/knowledge-base/VectorService.mjs');
+
+        await KB_LifecycleService.ready();
+
+        const originalCollectionName = KB_Config.data.collectionName;
+        const originalEmbedTexts     = Memory_TextEmbeddingService.embedTexts.bind(Memory_TextEmbeddingService);
+        const originalEmbedChunks    = KB_VectorService.embedChunks.bind(KB_VectorService);
+        const cleanupNames           = new Set([process.env.NEO_TEST_KB_COLLECTION]);
+        const vectorLength           = 4096;
+        let result;
+        let beforePromotion;
+
+        KB_Config.data.collectionName = process.env.NEO_TEST_KB_COLLECTION;
+        KB_ChromaManager.invalidateKnowledgeBaseCollectionCache();
+
+        Memory_TextEmbeddingService.embedTexts = async texts => {
+            return texts.map((_, index) => {
+                return Array.from({length: vectorLength}, (__, dimension) => dimension === index ? 1 : 0);
+            });
+        };
+
+        try {
+            const collection = await KB_ChromaManager.getKnowledgeBaseCollection();
+            await collection.upsert({
+                ids       : [process.env.NEO_TEST_KB_OLD_ID],
+                embeddings: [Array.from({length: vectorLength}, (_, dimension) => dimension === 0 ? 1 : 0)],
+                metadatas : [{kind: 'integration', source: 'kb-shadow-swap', sentinel: process.env.NEO_TEST_KB_OLD_SENTINEL}],
+                documents : [process.env.NEO_TEST_KB_OLD_SENTINEL]
+            });
+
+            const fixtureRows = [0, 1, 2].map(index => ({
+                hash       : \`shadow-swap-new-\${index}\`,
+                type       : 'method',
+                name       : \`shadowSwapMethod\${index}\`,
+                className  : '',
+                description: \`shadow swap new chunk \${index}\`,
+                content    : \`shadow swap body \${index}\`
+            }));
+            await fs.writeFile(
+                process.env.NEO_TEST_KB_FIXTURE_PATH,
+                fixtureRows.map(row => JSON.stringify(row)).join('\\n'),
+                'utf8'
+            );
+
+            KB_VectorService.embedChunks = async options => {
+                const value = await originalEmbedChunks(options);
+                const liveCollection = await KB_ChromaManager.getKnowledgeBaseCollection();
+                const probe = await liveCollection.get({
+                    ids    : [process.env.NEO_TEST_KB_OLD_ID],
+                    include: ['documents', 'metadatas']
+                });
+
+                beforePromotion = {
+                    count            : await liveCollection.count(),
+                    document         : probe.documents?.[0] || null,
+                    found            : probe.ids?.includes(process.env.NEO_TEST_KB_OLD_ID) || false,
+                    queriedCollection: liveCollection.name,
+                    shadowCollection : options.collection.name
+                };
+
+                return value;
+            };
+
+            result = await KB_VectorService.embed(process.env.NEO_TEST_KB_FIXTURE_PATH, {
+                staleStrategy: 'shadow-swap'
+            });
+            cleanupNames.add(result.parkedCollection);
+
+            const afterCollection = await KB_ChromaManager.getKnowledgeBaseCollection();
+            const oldProbe = await afterCollection.get({
+                ids    : [process.env.NEO_TEST_KB_OLD_ID],
+                include: ['documents']
+            });
+
+            console.log(JSON.stringify({
+                after: {
+                    collectionName: afterCollection.name,
+                    count         : await afterCollection.count(),
+                    oldFound      : oldProbe.ids?.includes(process.env.NEO_TEST_KB_OLD_ID) || false
+                },
+                beforePromotion,
+                result
+            }));
+        } finally {
+            KB_VectorService.embedChunks             = originalEmbedChunks;
+            Memory_TextEmbeddingService.embedTexts   = originalEmbedTexts;
+            KB_Config.data.collectionName            = originalCollectionName;
+            KB_ChromaManager.invalidateKnowledgeBaseCollectionCache();
+
+            for (const name of cleanupNames) {
+                try {
+                    await KB_ChromaManager.client.deleteCollection({name});
+                } catch {}
+            }
+
+            await fs.rm(process.env.NEO_TEST_KB_FIXTURE_PATH, {force: true});
+        }
+    `, {
+        NEO_TEST_KB_COLLECTION  : collectionName,
+        NEO_TEST_KB_FIXTURE_PATH: fixturePath,
+        NEO_TEST_KB_OLD_ID      : oldId,
+        NEO_TEST_KB_OLD_SENTINEL: oldSentinel
+    });
+}
+
 test.describe('Dockerized KB backup -> wipe -> restore integration (#11644)', () => {
     test('restores a seeded Knowledge Base vector after an isolated fixture wipe', async () => {
         const readiness = await getReadiness();
@@ -271,5 +396,38 @@ test.describe('Dockerized KB backup -> wipe -> restore integration (#11644)', ()
                 Promise.resolve().then(() => cleanupBackupPath(backupPath))
             ]);
         }
+    });
+
+    test('shadow-swap re-embed keeps the old canonical corpus queryable until promotion (#11683)', async () => {
+        const readiness = await getReadiness();
+
+        test.skip(readiness.dockerAvailable === false, `Docker unavailable: ${readiness.reason}`);
+        expect(readiness.servicesReady, readiness.reason).toBe(true);
+
+        const runId          = `${Date.now()}-${randomUUID()}`;
+        const collectionName = `kb-shadow-swap-${runId}`;
+        const oldId          = `kb-shadow-swap-old-${runId}`;
+        const oldSentinel    = `kb-shadow-swap-sentinel-${runId}`;
+        const fixturePath    = `/tmp/neo-integration/kb-shadow-swap-${runId}.jsonl`;
+
+        const swap = shadowSwapKnowledgeBase({
+            collectionName,
+            fixturePath,
+            oldId,
+            oldSentinel
+        });
+
+        expect(swap.result.staleStrategy).toBe('shadow-swap');
+        expect(swap.result.embedded).toBe(3);
+        expect(swap.result.deleted).toBe(1);
+
+        expect(swap.beforePromotion.found).toBe(true);
+        expect(swap.beforePromotion.document).toBe(oldSentinel);
+        expect(swap.beforePromotion.queriedCollection).toBe(collectionName);
+        expect(swap.beforePromotion.shadowCollection).not.toBe(collectionName);
+
+        expect(swap.after.collectionName).toBe(collectionName);
+        expect(swap.after.count).toBe(3);
+        expect(swap.after.oldFound).toBe(false);
     });
 });

--- a/test/playwright/unit/ai/services/knowledge-base/ChromaManager.spec.mjs
+++ b/test/playwright/unit/ai/services/knowledge-base/ChromaManager.spec.mjs
@@ -88,6 +88,18 @@ test.describe('Neo.ai.services.knowledge-base.ChromaManager', () => {
         });
     });
 
+    test('invalidateKnowledgeBaseCollectionCache clears cached canonical collection handles', async () => {
+        const cachedCollection = {name: 'cached-knowledge-base'};
+
+        ChromaManager._knowledgeBaseCollectionPromise = Promise.resolve(cachedCollection);
+        ChromaManager.knowledgeBaseCollection         = cachedCollection;
+
+        ChromaManager.invalidateKnowledgeBaseCollectionCache();
+
+        expect(ChromaManager._knowledgeBaseCollectionPromise).toBe(null);
+        expect(ChromaManager.knowledgeBaseCollection).toBe(null);
+    });
+
     test('checkConnectivity returns heartbeat and cached collection name', async () => {
         ChromaManager.client = {
             heartbeat: async () => 456,

--- a/test/playwright/unit/ai/services/knowledge-base/VectorService.WorkVolumeBranching.spec.mjs
+++ b/test/playwright/unit/ai/services/knowledge-base/VectorService.WorkVolumeBranching.spec.mjs
@@ -31,8 +31,8 @@ const __dirname  = path.dirname(__filename);
  *
  * Verifies the post-delta-pre-embed gate at the four meaningful states:
  *
- * 1. Zero-changes fast-path is unchanged — the existing `if (chunksToProcess.length === 0)`
- *    early-return at line 177 of VectorService.mjs is preserved by the gate.
+ * 1. Zero-changes fast-path is unchanged — the existing no-work early return in
+ *    VectorService.embed is preserved by the gate.
  * 2. Below-threshold MCP invocation succeeds — agent-callable steady-state.
  * 3. Above-threshold MCP invocation refuses with `KB_SYNC_VOLUME_EXCEEDED` payload that
  *    the KB Server's `'error' in result` contract converts to `isError: true`.
@@ -47,16 +47,16 @@ const __dirname  = path.dirname(__filename);
  */
 test.describe.configure({mode: 'serial'});
 
-function createSpyCollection({existingIds = []} = {}) {
+function createSpyCollection({existingIds = [], name = 'spy-knowledge-base'} = {}) {
     const rows = new Map();
     existingIds.forEach(id => rows.set(id, {id, metadata: {}, document: ''}));
 
-    const calls = {get: 0, upsert: 0, delete: 0, count: 0};
+    const calls = {get: 0, upsert: 0, delete: 0, count: 0, modify: []};
 
-    return {
+    const collection = {
         rows,
         calls,
-        name: 'spy-knowledge-base',
+        name,
 
         async get({ids, where, limit = 2000, offset = 0, include = []} = {}) {
             calls.get++;
@@ -83,11 +83,18 @@ function createSpyCollection({existingIds = []} = {}) {
             ids.forEach(id => rows.delete(id));
         },
 
+        async modify({name}) {
+            calls.modify.push({name});
+            collection.name = name;
+        },
+
         async count() {
             calls.count++;
             return rows.size;
         }
     };
+
+    return collection;
 }
 
 /**
@@ -113,6 +120,7 @@ test.describe('VectorService.embed — work-volume branching (#10572)', () => {
     let SDK, KB_VectorService, KB_ChromaManager, KB_Config;
     let TextEmbeddingService_orig;
     let originalGetCollection;
+    let originalClient;
     let originalThreshold;
     let tmpDir, fixturePath;
 
@@ -134,6 +142,7 @@ test.describe('VectorService.embed — work-volume branching (#10572)', () => {
         TextEmbeddingService.embedTexts = async texts => texts.map(() => new Array(384).fill(0));
 
         originalGetCollection = KB_ChromaManager.getKnowledgeBaseCollection.bind(KB_ChromaManager);
+        originalClient        = KB_ChromaManager.client;
         originalThreshold     = KB_Config.data.mcpSyncMaxChunks;
 
         tmpDir      = path.resolve(os.tmpdir(), `kb-work-volume-test-${process.pid}-${Date.now()}`);
@@ -143,6 +152,7 @@ test.describe('VectorService.embed — work-volume branching (#10572)', () => {
 
     test.afterAll(async () => {
         KB_ChromaManager.getKnowledgeBaseCollection = originalGetCollection;
+        KB_ChromaManager.client                     = originalClient;
         KB_Config.data.mcpSyncMaxChunks             = originalThreshold;
         TextEmbeddingService.embedTexts             = TextEmbeddingService_orig;
         if (tmpDir && fs.existsSync(tmpDir)) {
@@ -152,6 +162,8 @@ test.describe('VectorService.embed — work-volume branching (#10572)', () => {
 
     test.beforeEach(() => {
         KB_Config.data.mcpSyncMaxChunks = 5; // tight threshold for predictable branching
+        KB_ChromaManager.client         = originalClient;
+        KB_ChromaManager.invalidateKnowledgeBaseCollectionCache();
     });
 
     test('zero-changes fast-path is unchanged (existing chunks dedup to empty queue)', async () => {
@@ -190,6 +202,104 @@ test.describe('VectorService.embed — work-volume branching (#10572)', () => {
         expect('error' in result).toBe(false);
         expect(result.message).toContain('Embedding complete');
         expect(spy.calls.upsert).toBeGreaterThan(0); // embedding actually happened
+    });
+
+    test('deleteStale:false preserves incremental-push callers by skipping stale deletion', async () => {
+        const spy = createSpyCollection({existingIds: ['stale-id']});
+        KB_ChromaManager.getKnowledgeBaseCollection = async () => spy;
+
+        writeFixtureJsonl(fixturePath, 1);
+
+        const result = await KB_VectorService.embed(fixturePath, {deleteStale: false});
+
+        expect('error' in result).toBe(false);
+        expect(result.message).toContain('Embedding complete');
+        expect(spy.calls.delete).toBe(0);
+        expect(spy.rows.has('stale-id')).toBe(true);
+        expect(spy.calls.upsert).toBeGreaterThan(0);
+    });
+
+    test('shadow-swap embeds full corpus into a shadow collection before canonical promotion', async () => {
+        const live = createSpyCollection({existingIds: ['stale-id'], name: KB_Config.data.collectionName});
+        let shadow;
+
+        KB_ChromaManager.client = {
+            createCollection: async ({name}) => {
+                shadow = createSpyCollection({name});
+                return shadow;
+            }
+        };
+        KB_ChromaManager.getKnowledgeBaseCollection = async () => {
+            return shadow?.name === KB_Config.data.collectionName ? shadow : live;
+        };
+
+        writeFixtureJsonl(fixturePath, 3);
+
+        const result = await KB_VectorService.embed(fixturePath, {staleStrategy: 'shadow-swap'});
+
+        expect('error' in result).toBe(false);
+        expect(result.staleStrategy).toBe('shadow-swap');
+        expect(result.embedded).toBe(3);
+        expect(result.deleted).toBe(1);
+        expect(result.shadowCollection).toContain(`${KB_Config.data.collectionName}-shadow-`);
+        expect(result.parkedCollection).toContain(`${KB_Config.data.collectionName}-parking-`);
+        expect(result.canonicalCollection).toBe(KB_Config.data.collectionName);
+
+        expect(live.calls.delete).toBe(0);
+        expect(live.calls.upsert).toBe(0);
+        expect(live.calls.modify[0]).toEqual({name: result.parkedCollection});
+        expect(shadow.calls.upsert).toBeGreaterThan(0);
+        expect(shadow.calls.modify[0]).toEqual({name: KB_Config.data.collectionName});
+        expect(shadow.rows.size).toBe(3);
+    });
+
+    test('shadow-swap failure invalidates cached canonical handles after local rename mutation', async () => {
+        const live = createSpyCollection({existingIds: [], name: KB_Config.data.collectionName});
+        const cachedCollectionPromise = Promise.resolve(live);
+
+        live.modify = async ({name}) => {
+            live.calls.modify.push({name});
+            live.name = name;
+            throw new Error('live rename failed');
+        };
+
+        KB_ChromaManager._knowledgeBaseCollectionPromise = cachedCollectionPromise;
+        KB_ChromaManager.knowledgeBaseCollection         = live;
+        KB_ChromaManager.client = {
+            createCollection: async ({name}) => createSpyCollection({name})
+        };
+        KB_ChromaManager.getKnowledgeBaseCollection = async () => live;
+
+        writeFixtureJsonl(fixturePath, 3);
+
+        await expect(
+            KB_VectorService.embed(fixturePath, {staleStrategy: 'shadow-swap'})
+        ).rejects.toThrow('live rename failed');
+
+        expect(KB_ChromaManager._knowledgeBaseCollectionPromise).toBe(null);
+        expect(KB_ChromaManager.knowledgeBaseCollection).toBe(null);
+    });
+
+    test('shadow-swap MCP gate measures full-corpus rebuild volume before creating shadow collection', async () => {
+        const live = createSpyCollection({existingIds: [], name: KB_Config.data.collectionName});
+        let createCollectionCalls = 0;
+
+        KB_ChromaManager.client = {
+            createCollection: async ({name}) => {
+                createCollectionCalls++;
+                return createSpyCollection({name});
+            }
+        };
+        KB_ChromaManager.getKnowledgeBaseCollection = async () => live;
+
+        writeFixtureJsonl(fixturePath, 10);
+
+        const result = await KB_VectorService.embed(fixturePath, {viaMcp: true, staleStrategy: 'shadow-swap'});
+
+        expect(result.code).toBe('KB_SYNC_VOLUME_EXCEEDED');
+        expect(result.chunksToProcess).toBe(10);
+        expect(createCollectionCalls).toBe(0);
+        expect(live.calls.upsert).toBe(0);
     });
 
     test('above-threshold MCP invocation returns KB_SYNC_VOLUME_EXCEEDED — adapter converts to isError', async () => {


### PR DESCRIPTION
Authored by GPT-5.5 (Codex Desktop). Session 019e44ba-d309-7e91-a819-36911fbf4e10.

FAIR-band: over-target [14/30] — taking this lane despite over-target because #11683 was already claimed from the #11677 graduation wake, has no competing owner, and removes an active Knowledge Base re-embed completeness failure while Claude owns the parallel #11634/#11676 lanes.

Resolves #11683

Adds a backward-compatible stale-data strategy layer to `VectorService.embed`: the existing `delete-upfront` behavior remains the default, `deleteStale: false` still preserves incremental-push callers, and the new `shadow-swap` strategy rebuilds the full corpus into a fresh Chroma collection before promoting it to the canonical KB name. The patch also centralizes KB collection-handle invalidation in `ChromaManager` so rename promotion does not leave callers pinned to parked collection handles.

Evidence: L2 (169 KB unit tests passed + dockerized integration spec syntax-loaded on this host) -> L3 required (dockerized Chroma rename integration execution). Residual: Docker-ready CI/host execution of the #11683 shadow-swap integration test.

## Deltas From Ticket

- Kept `staleStrategy: 'delete-upfront' | 'shadow-swap'` truth-in-code narrow; no speculative `incremental` enum was added.
- Preserved PR #11678's incremental path by resolving `deleteStale: false` to the internal skip strategy.
- The prior live collection is parked and reported in the result instead of being deleted, matching the destructive-operation guard posture and giving operators a rollback artifact.
- The two-step no-canonical-name window is bounded to `live.modify({name: parking})` then `shadow.modify({name: canonical})`; no cross-process pause/bus was added because that would expand beyond #11683's low-blast scope.

## Test Evidence

- `git diff --check`
- `npm run test-unit -- test/playwright/unit/ai/services/knowledge-base/ChromaManager.spec.mjs test/playwright/unit/ai/services/knowledge-base/VectorService.WorkVolumeBranching.spec.mjs` — 14 passed.
- `npm run test-unit -- test/playwright/unit/ai/services/knowledge-base` — 169 passed.
- `npm run test-integration-unified -- test/playwright/integration/KBBackupRestoreWipe.integration.spec.mjs` — sandbox run hit `listen EPERM 127.0.0.1:13090`; escalated run loaded the spec and reported 2 skipped because Docker readiness was unavailable on this host.

## Post-Merge Validation

- [ ] Docker-ready CI/host runs `npm run test-integration-unified -- test/playwright/integration/KBBackupRestoreWipe.integration.spec.mjs` without skip and confirms the #11683 shadow-swap integration assertion.
- [ ] First real `staleStrategy: 'shadow-swap'` KB re-embed confirms old KB query results remain complete until promotion and records the parked collection name for rollback/cleanup.

## Commits

- `a52f36c59` — `feat(kb): add shadow-swap re-embed strategy (#11683)`
