### PR TITLE
fix(kb): harden shadow-swap promotion (#11685)

### DIFF
--- a/ai/services/knowledge-base/ChromaManager.mjs
+++ b/ai/services/knowledge-base/ChromaManager.mjs
@@ -5,6 +5,10 @@ import Base                                 from '../../../src/core/Base.mjs';
 import DatabaseLifecycleService             from './DatabaseLifecycleService.mjs';
 import {assertCanonicalCollectionDeleteAllowed} from '../../mcp/server/shared/services/DestructiveOperationGuard.mjs';
 
+const COLLECTION_ALREADY_EXISTS_RE = /already exists|already contains|conflict/i;
+const COLLECTION_NOT_FOUND_RE      = /does not exist|not found|404/i;
+const SWAP_ACTIVE_PHASES           = ['parking', 'shadow'];
+
 /**
  * @summary Simple manager around the Chroma client that lazily caches the knowledge-base collection.
  *
@@ -128,15 +132,134 @@ class ChromaManager extends Base {
     async getKnowledgeBaseCollection() {
         if (!this._knowledgeBaseCollectionPromise) {
             this._knowledgeBaseCollectionPromise = this.#executeSilently(async () => {
-                return await this.client.getOrCreateCollection({
-                    name             : aiConfig.collectionName,
-                    embeddingFunction: aiConfig.dummyEmbeddingFunction
-                });
+                return await this.#resolveKnowledgeBaseCollection();
             });
         }
 
-        this.knowledgeBaseCollection = await this._knowledgeBaseCollectionPromise;
-        return this.knowledgeBaseCollection;
+        try {
+            this.knowledgeBaseCollection = await this._knowledgeBaseCollectionPromise;
+            return this.knowledgeBaseCollection;
+        } catch (error) {
+            this.invalidateKnowledgeBaseCollectionCache();
+            throw error;
+        }
+    }
+
+    /**
+     * @summary Resolves the canonical KB collection without creating it during a shadow-swap promote window.
+     *
+     * Shadow-swap promotion briefly renames the canonical collection to a parking
+     * name before the shadow collection takes the canonical name. During that
+     * interval, plain `getOrCreateCollection()` can create an empty canonical
+     * collection and cause the promote rename to collide. This resolver first
+     * attempts `getCollection()`, then checks for active swap artifacts before
+     * creating the canonical collection for true first-run bootstrap only.
+     *
+     * @returns {Promise<Object>}
+     * @throws {Error} `KB_COLLECTION_SWAP_IN_PROGRESS` when active swap artifacts exist.
+     * @see https://github.com/neomjs/neo/issues/11685
+     */
+    async #resolveKnowledgeBaseCollection() {
+        const options = this.#getKnowledgeBaseCollectionOptions();
+
+        try {
+            return await this.client.getCollection(options);
+        } catch (error) {
+            if (!this.#isCollectionNotFoundError(error)) {
+                throw error;
+            }
+        }
+
+        const activeSwapCollections = await this.#getActiveKnowledgeBaseSwapCollections();
+        if (activeSwapCollections.length > 0) {
+            throw this.#createSwapInProgressError(activeSwapCollections);
+        }
+
+        try {
+            return await this.client.createCollection(options);
+        } catch (error) {
+            if (!this.#isCollectionAlreadyExistsError(error)) {
+                throw error;
+            }
+
+            const activeSwapCollections = await this.#getActiveKnowledgeBaseSwapCollections();
+            if (activeSwapCollections.length > 0) {
+                throw this.#createSwapInProgressError(activeSwapCollections);
+            }
+
+            return await this.client.getCollection(options);
+        }
+    }
+
+    /**
+     * @returns {{name: String, embeddingFunction: Object}}
+     */
+    #getKnowledgeBaseCollectionOptions() {
+        return {
+            name             : aiConfig.collectionName,
+            embeddingFunction: aiConfig.dummyEmbeddingFunction
+        };
+    }
+
+    /**
+     * @param {Error} error
+     * @returns {Boolean}
+     */
+    #isCollectionNotFoundError(error) {
+        return COLLECTION_NOT_FOUND_RE.test(error?.message || '');
+    }
+
+    /**
+     * @param {Error} error
+     * @returns {Boolean}
+     */
+    #isCollectionAlreadyExistsError(error) {
+        return COLLECTION_ALREADY_EXISTS_RE.test(error?.message || '');
+    }
+
+    /**
+     * @returns {Promise<String[]>}
+     */
+    async #getActiveKnowledgeBaseSwapCollections() {
+        const names = [];
+        const limit = 1000;
+        let offset  = 0;
+
+        do {
+            const collections = await this.client.listCollections({limit, offset});
+            names.push(...collections.map(collection => collection.name));
+
+            if (collections.length < limit) {
+                break;
+            }
+
+            offset += limit;
+        } while (true);
+
+        return names.filter(name => this.#isActiveKnowledgeBaseSwapName(name)).sort();
+    }
+
+    /**
+     * @param {String} name
+     * @returns {Boolean}
+     */
+    #isActiveKnowledgeBaseSwapName(name) {
+        return SWAP_ACTIVE_PHASES.some(phase => name.startsWith(`${aiConfig.collectionName}-${phase}-`));
+    }
+
+    /**
+     * @param {String[]} activeSwapCollections
+     * @returns {Error}
+     */
+    #createSwapInProgressError(activeSwapCollections) {
+        const error = new Error(
+            `Knowledge base collection '${aiConfig.collectionName}' is temporarily unavailable during shadow-swap promotion. ` +
+            `Active swap collections: ${activeSwapCollections.join(', ')}. Retry after promotion completes.`
+        );
+        error.code                  = 'KB_COLLECTION_SWAP_IN_PROGRESS';
+        error.collection            = aiConfig.collectionName;
+        error.activeSwapCollections = activeSwapCollections;
+        return error;
     }
 
     /**

--- a/ai/services/knowledge-base/ChromaManager.mjs
+++ b/ai/services/knowledge-base/ChromaManager.mjs
@@ -6,7 +6,7 @@ import DatabaseLifecycleService             from './DatabaseLifecycleService.mjs
 import {assertCanonicalCollectionDeleteAllowed} from '../../mcp/server/shared/services/DestructiveOperationGuard.mjs';
 
 const COLLECTION_ALREADY_EXISTS_RE = /already exists|already contains|conflict/i;
-const COLLECTION_NOT_FOUND_RE      = /does not exist|not found|404/i;
+const COLLECTION_NOT_FOUND_RE      = /does not exist|not found|not be found|could not be found|404/i;
 const SWAP_ACTIVE_PHASES           = ['parking', 'shadow'];
 
 /**
@@ -206,7 +206,7 @@ class ChromaManager extends Base {
      * @returns {Boolean}
      */
     #isCollectionNotFoundError(error) {
-        return COLLECTION_NOT_FOUND_RE.test(error?.message || '');
+        return error?.name === 'ChromaNotFoundError' || COLLECTION_NOT_FOUND_RE.test(error?.message || '');
     }
 
     /**

--- a/ai/services/knowledge-base/DatabaseService.mjs
+++ b/ai/services/knowledge-base/DatabaseService.mjs
@@ -427,17 +427,18 @@ class DatabaseService extends Base {
      *                                            wrapper; threaded through to `embed()` to enable
      *                                            the work-volume gate (#10572). CLI callers
      *                                            omit this and bypass the gate.
+     * @param {String}       [params.staleStrategy] Optional VectorService stale strategy.
      * @param {String|Object} [params.confirmation] Explicit production confirmation token for delete.
      * @returns {Promise<Object>}
      */
-    async manageKnowledgeBase({action, viaMcp = false, confirmation}) {
+    async manageKnowledgeBase({action, viaMcp = false, staleStrategy, confirmation}) {
         switch (action) {
             case 'sync':
-                return this.syncDatabase({viaMcp});
+                return this.syncDatabase({viaMcp, staleStrategy});
             case 'create':
                 return this.createKnowledgeBase();
             case 'embed':
-                return this.embedKnowledgeBase({viaMcp});
+                return this.embedKnowledgeBase({viaMcp, staleStrategy});
             case 'delete':
                 return this.deleteDatabase({confirmation});
             default:
@@ -513,11 +514,12 @@ class DatabaseService extends Base {
      * @param {Boolean} [opts.viaMcp=false] True when invoked via MCP tool dispatch;
      *                                      threaded to VectorService.embed for #10572's
      *                                      work-volume gate.
+     * @param {String}  [opts.staleStrategy] Explicit stale-data handling strategy.
      * @returns {Promise<object>} A promise that resolves to a success message, OR a
      *     `{error, code: 'KB_SYNC_VOLUME_EXCEEDED', ...}` shape when the MCP gate fires.
      */
-    async embedKnowledgeBase({viaMcp = false} = {}) {
-        return await VectorService.embed(aiConfig.dataPath, {viaMcp});
+    async embedKnowledgeBase({viaMcp = false, staleStrategy} = {}) {
+        return await VectorService.embed(aiConfig.dataPath, {viaMcp, staleStrategy});
     }
 
     /**
@@ -564,12 +566,13 @@ class DatabaseService extends Base {
      * @param {Object}  [opts]
      * @param {Boolean} [opts.viaMcp=false] True when invoked via MCP tool dispatch;
      *                                      threaded to embed() for #10572's work-volume gate.
+     * @param {String}  [opts.staleStrategy] Explicit stale-data handling strategy.
      * @returns {Promise<object>} A promise that resolves to the final success message from the embedding step.
      */
-    async syncDatabase({viaMcp = false} = {}) {
+    async syncDatabase({viaMcp = false, staleStrategy} = {}) {
         logger.log('Starting full database synchronization...');
         await this.createKnowledgeBase();
-        return await this.embedKnowledgeBase({viaMcp});
+        return await this.embedKnowledgeBase({viaMcp, staleStrategy});
     }
 }
 

--- a/ai/services/knowledge-base/VectorService.mjs
+++ b/ai/services/knowledge-base/VectorService.mjs
@@ -351,7 +351,8 @@ class VectorService extends Base {
             embeddingFunction: aiConfig.dummyEmbeddingFunction
         });
 
-        let liveParked = false;
+        let liveParked     = false;
+        let shadowPromoted = false;
 
         try {
             await this.embedChunks({collection: shadowCollection, chunksToProcess: knowledgeBase});
@@ -360,6 +361,7 @@ class VectorService extends Base {
             await liveCollection.modify({name: parkingName});
             liveParked = true;
             await shadowCollection.modify({name: aiConfig.collectionName});
+            shadowPromoted = true;
 
             ChromaManager.invalidateKnowledgeBaseCollectionCache();
 
@@ -380,7 +382,7 @@ class VectorService extends Base {
         } catch (error) {
             ChromaManager.invalidateKnowledgeBaseCollectionCache();
 
-            if (liveParked) {
+            if (liveParked && !shadowPromoted) {
                 try {
                     await liveCollection.modify({name: aiConfig.collectionName});
                     ChromaManager.invalidateKnowledgeBaseCollectionCache();
@@ -388,7 +390,37 @@ class VectorService extends Base {
                     logger.error('[VectorService] Failed to roll back parked live collection after shadow-swap failure:', rollbackError.message);
                 }
             }
+
+            if (!shadowPromoted) {
+                await this.parkFailedShadowCollection({shadowCollection, shadowName});
+            }
             throw error;
+        }
+    }
+
+    /**
+     * @summary Renames an incomplete shadow collection so future canonical resolves do not treat it as an active promote.
+     *
+     * The collection-name delete guard intentionally blocks unconfirmed production
+     * deletes, including non-canonical names. A failed pre-promote shadow therefore
+     * gets moved to a non-active recovery name instead of being dropped silently.
+     *
+     * @param {Object} options
+     * @param {Object} options.shadowCollection Shadow collection handle to park.
+     * @param {String} options.shadowName       Original active shadow collection name.
+     * @returns {Promise<String|null>} Parked name, or `null` if parking failed.
+     * @see https://github.com/neomjs/neo/issues/11685
+     */
+    async parkFailedShadowCollection({shadowCollection, shadowName}) {
+        const failedShadowName = this.createSwapCollectionName('failed-shadow');
+
+        try {
+            await shadowCollection.modify({name: failedShadowName});
+            logger.warn(`[VectorService] Parked failed shadow collection '${shadowName}' as '${failedShadowName}'.`);
+            return failedShadowName;
+        } catch (error) {
+            logger.error(`[VectorService] Failed to park shadow collection '${shadowName}' after shadow-swap failure:`, error.message);
+            return null;
         }
     }
 

--- a/buildScripts/ai/syncKnowledgeBase.mjs
+++ b/buildScripts/ai/syncKnowledgeBase.mjs
@@ -17,8 +17,12 @@ import {withHeavyMaintenanceLease}  from '../../ai/daemons/services/HeavyMainten
 async function syncKnowledgeBase() {
     // Enable debug logging to see progress
     KB_Config.data.debug = true;
+    const staleStrategy   = process.env.NEO_KB_STALE_STRATEGY || undefined;
 
     console.log('⏳ Initializing Knowledge Base Services...');
+    if (staleStrategy) {
+        console.log(`   Using explicit stale strategy: ${staleStrategy}`);
+    }
 
     // Lane C of #11503 — wrap the heavy-maintenance work in the shared lease so this
     // CLI cannot collide with the orchestrator's own kbSync task (which is the empirical
@@ -42,8 +46,9 @@ async function syncKnowledgeBase() {
 
                 console.log('✅ Services Ready. Starting Synchronization...');
 
-                // Execute the full sync (create + embed)
-                return KB_DatabaseService.syncDatabase();
+                // Execute the full sync (create + embed). `NEO_KB_STALE_STRATEGY=shadow-swap`
+                // is the explicit activation path for #11685; default CLI sync remains unchanged.
+                return KB_DatabaseService.syncDatabase({staleStrategy});
             },
             {owner: 'kbSync', reason: 'manual-cli', metadata: {script: 'buildScripts/ai/syncKnowledgeBase.mjs'}}
         );

--- a/test/playwright/integration/KBBackupRestoreWipe.integration.spec.mjs
+++ b/test/playwright/integration/KBBackupRestoreWipe.integration.spec.mjs
@@ -252,11 +252,11 @@ function shadowSwapKnowledgeBase({collectionName, oldId, oldSentinel, fixturePat
         const originalCollectionName = KB_Config.data.collectionName;
         const originalEmbedTexts     = Memory_TextEmbeddingService.embedTexts.bind(Memory_TextEmbeddingService);
         const originalEmbedChunks    = KB_VectorService.embedChunks.bind(KB_VectorService);
-	        const cleanupNames           = new Set([process.env.NEO_TEST_KB_COLLECTION]);
-	        const vectorLength           = 4096;
-	        let result;
-	        let beforePromotion;
-	        let promoteWindowProbe;
+        const cleanupNames           = new Set([process.env.NEO_TEST_KB_COLLECTION]);
+        const vectorLength           = 4096;
+        let result;
+        let beforePromotion;
+        let promoteWindowProbe;
 
         KB_Config.data.collectionName = process.env.NEO_TEST_KB_COLLECTION;
         KB_ChromaManager.invalidateKnowledgeBaseCollectionCache();
@@ -268,26 +268,26 @@ function shadowSwapKnowledgeBase({collectionName, oldId, oldSentinel, fixturePat
         };
 
         try {
-	            const collection = await KB_ChromaManager.getKnowledgeBaseCollection();
-	            const originalModify = collection.modify.bind(collection);
-	            collection.modify = async options => {
-	                const value = await originalModify(options);
-	                if (options.name.includes(\`\${process.env.NEO_TEST_KB_COLLECTION}-parking-\`)) {
-	                    KB_ChromaManager.invalidateKnowledgeBaseCollectionCache();
-	                    try {
-	                        await KB_ChromaManager.getKnowledgeBaseCollection();
-	                    } catch (error) {
-	                        promoteWindowProbe = {
-	                            activeSwapCollections: error.activeSwapCollections || [],
-	                            code                 : error.code || null,
-	                            message              : error.message
-	                        };
-	                    }
-	                }
-	                return value;
-	            };
+            const collection = await KB_ChromaManager.getKnowledgeBaseCollection();
+            const originalModify = collection.modify.bind(collection);
+            collection.modify = async options => {
+                const value = await originalModify(options);
+                if (options.name.includes(\`\${process.env.NEO_TEST_KB_COLLECTION}-parking-\`)) {
+                    KB_ChromaManager.invalidateKnowledgeBaseCollectionCache();
+                    try {
+                        await KB_ChromaManager.getKnowledgeBaseCollection();
+                    } catch (error) {
+                        promoteWindowProbe = {
+                            activeSwapCollections: error.activeSwapCollections || [],
+                            code                 : error.code || null,
+                            message              : error.message
+                        };
+                    }
+                }
+                return value;
+            };
 
-	            await collection.upsert({
+            await collection.upsert({
                 ids       : [process.env.NEO_TEST_KB_OLD_ID],
                 embeddings: [Array.from({length: vectorLength}, (_, dimension) => dimension === 0 ? 1 : 0)],
                 metadatas : [{kind: 'integration', source: 'kb-shadow-swap', sentinel: process.env.NEO_TEST_KB_OLD_SENTINEL}],
@@ -338,16 +338,16 @@ function shadowSwapKnowledgeBase({collectionName, oldId, oldSentinel, fixturePat
                 include: ['documents']
             });
 
-	            console.log(JSON.stringify({
-	                after: {
-	                    collectionName: afterCollection.name,
-	                    count         : await afterCollection.count(),
-	                    oldFound      : oldProbe.ids?.includes(process.env.NEO_TEST_KB_OLD_ID) || false
-	                },
-	                beforePromotion,
-	                promoteWindowProbe,
-	                result
-	            }));
+            console.log(JSON.stringify({
+                after: {
+                    collectionName: afterCollection.name,
+                    count         : await afterCollection.count(),
+                    oldFound      : oldProbe.ids?.includes(process.env.NEO_TEST_KB_OLD_ID) || false
+                },
+                beforePromotion,
+                promoteWindowProbe,
+                result
+            }));
         } finally {
             KB_VectorService.embedChunks             = originalEmbedChunks;
             Memory_TextEmbeddingService.embedTexts   = originalEmbedTexts;
@@ -442,16 +442,16 @@ test.describe('Dockerized KB backup -> wipe -> restore integration (#11644)', ()
         expect(swap.result.deleted).toBe(1);
 
         expect(swap.beforePromotion.found).toBe(true);
-	        expect(swap.beforePromotion.document).toBe(oldSentinel);
-	        expect(swap.beforePromotion.queriedCollection).toBe(collectionName);
-	        expect(swap.beforePromotion.shadowCollection).not.toBe(collectionName);
-	        expect(swap.promoteWindowProbe.code).toBe('KB_COLLECTION_SWAP_IN_PROGRESS');
-	        expect(swap.promoteWindowProbe.activeSwapCollections).toEqual(expect.arrayContaining([
-	            swap.result.parkedCollection,
-	            swap.result.shadowCollection
-	        ]));
+        expect(swap.beforePromotion.document).toBe(oldSentinel);
+        expect(swap.beforePromotion.queriedCollection).toBe(collectionName);
+        expect(swap.beforePromotion.shadowCollection).not.toBe(collectionName);
+        expect(swap.promoteWindowProbe.code).toBe('KB_COLLECTION_SWAP_IN_PROGRESS');
+        expect(swap.promoteWindowProbe.activeSwapCollections).toEqual(expect.arrayContaining([
+            swap.result.parkedCollection,
+            swap.result.shadowCollection
+        ]));
 
-	        expect(swap.after.collectionName).toBe(collectionName);
+        expect(swap.after.collectionName).toBe(collectionName);
         expect(swap.after.count).toBe(3);
         expect(swap.after.oldFound).toBe(false);
     });

--- a/test/playwright/integration/KBBackupRestoreWipe.integration.spec.mjs
+++ b/test/playwright/integration/KBBackupRestoreWipe.integration.spec.mjs
@@ -252,10 +252,11 @@ function shadowSwapKnowledgeBase({collectionName, oldId, oldSentinel, fixturePat
         const originalCollectionName = KB_Config.data.collectionName;
         const originalEmbedTexts     = Memory_TextEmbeddingService.embedTexts.bind(Memory_TextEmbeddingService);
         const originalEmbedChunks    = KB_VectorService.embedChunks.bind(KB_VectorService);
-        const cleanupNames           = new Set([process.env.NEO_TEST_KB_COLLECTION]);
-        const vectorLength           = 4096;
-        let result;
-        let beforePromotion;
+	        const cleanupNames           = new Set([process.env.NEO_TEST_KB_COLLECTION]);
+	        const vectorLength           = 4096;
+	        let result;
+	        let beforePromotion;
+	        let promoteWindowProbe;
 
         KB_Config.data.collectionName = process.env.NEO_TEST_KB_COLLECTION;
         KB_ChromaManager.invalidateKnowledgeBaseCollectionCache();
@@ -267,8 +268,26 @@ function shadowSwapKnowledgeBase({collectionName, oldId, oldSentinel, fixturePat
         };
 
         try {
-            const collection = await KB_ChromaManager.getKnowledgeBaseCollection();
-            await collection.upsert({
+	            const collection = await KB_ChromaManager.getKnowledgeBaseCollection();
+	            const originalModify = collection.modify.bind(collection);
+	            collection.modify = async options => {
+	                const value = await originalModify(options);
+	                if (options.name.includes(\`\${process.env.NEO_TEST_KB_COLLECTION}-parking-\`)) {
+	                    KB_ChromaManager.invalidateKnowledgeBaseCollectionCache();
+	                    try {
+	                        await KB_ChromaManager.getKnowledgeBaseCollection();
+	                    } catch (error) {
+	                        promoteWindowProbe = {
+	                            activeSwapCollections: error.activeSwapCollections || [],
+	                            code                 : error.code || null,
+	                            message              : error.message
+	                        };
+	                    }
+	                }
+	                return value;
+	            };
+
+	            await collection.upsert({
                 ids       : [process.env.NEO_TEST_KB_OLD_ID],
                 embeddings: [Array.from({length: vectorLength}, (_, dimension) => dimension === 0 ? 1 : 0)],
                 metadatas : [{kind: 'integration', source: 'kb-shadow-swap', sentinel: process.env.NEO_TEST_KB_OLD_SENTINEL}],
@@ -319,15 +338,16 @@ function shadowSwapKnowledgeBase({collectionName, oldId, oldSentinel, fixturePat
                 include: ['documents']
             });
 
-            console.log(JSON.stringify({
-                after: {
-                    collectionName: afterCollection.name,
-                    count         : await afterCollection.count(),
-                    oldFound      : oldProbe.ids?.includes(process.env.NEO_TEST_KB_OLD_ID) || false
-                },
-                beforePromotion,
-                result
-            }));
+	            console.log(JSON.stringify({
+	                after: {
+	                    collectionName: afterCollection.name,
+	                    count         : await afterCollection.count(),
+	                    oldFound      : oldProbe.ids?.includes(process.env.NEO_TEST_KB_OLD_ID) || false
+	                },
+	                beforePromotion,
+	                promoteWindowProbe,
+	                result
+	            }));
         } finally {
             KB_VectorService.embedChunks             = originalEmbedChunks;
             Memory_TextEmbeddingService.embedTexts   = originalEmbedTexts;
@@ -422,11 +442,16 @@ test.describe('Dockerized KB backup -> wipe -> restore integration (#11644)', ()
         expect(swap.result.deleted).toBe(1);
 
         expect(swap.beforePromotion.found).toBe(true);
-        expect(swap.beforePromotion.document).toBe(oldSentinel);
-        expect(swap.beforePromotion.queriedCollection).toBe(collectionName);
-        expect(swap.beforePromotion.shadowCollection).not.toBe(collectionName);
+	        expect(swap.beforePromotion.document).toBe(oldSentinel);
+	        expect(swap.beforePromotion.queriedCollection).toBe(collectionName);
+	        expect(swap.beforePromotion.shadowCollection).not.toBe(collectionName);
+	        expect(swap.promoteWindowProbe.code).toBe('KB_COLLECTION_SWAP_IN_PROGRESS');
+	        expect(swap.promoteWindowProbe.activeSwapCollections).toEqual(expect.arrayContaining([
+	            swap.result.parkedCollection,
+	            swap.result.shadowCollection
+	        ]));
 
-        expect(swap.after.collectionName).toBe(collectionName);
+	        expect(swap.after.collectionName).toBe(collectionName);
         expect(swap.after.count).toBe(3);
         expect(swap.after.oldFound).toBe(false);
     });

--- a/test/playwright/unit/ai/services/knowledge-base/ChromaManager.spec.mjs
+++ b/test/playwright/unit/ai/services/knowledge-base/ChromaManager.spec.mjs
@@ -100,6 +100,34 @@ test.describe('Neo.ai.services.knowledge-base.ChromaManager', () => {
         });
     });
 
+    test('getKnowledgeBaseCollection treats ChromaNotFoundError as missing canonical collection', async () => {
+        let createCount = 0;
+        let capturedOptions;
+
+        ChromaManager.client = {
+            getCollection: async () => {
+                const error = new Error('The requested resource could not be found');
+                error.name  = 'ChromaNotFoundError';
+                throw error;
+            },
+            listCollections: async () => [],
+            createCollection: async options => {
+                createCount++;
+                capturedOptions = options;
+                return {name: options.name};
+            }
+        };
+
+        const collection = await ChromaManager.getKnowledgeBaseCollection();
+
+        expect(collection.name).toBe(aiConfig.collectionName);
+        expect(createCount).toBe(1);
+        expect(capturedOptions).toEqual({
+            name             : aiConfig.collectionName,
+            embeddingFunction: aiConfig.dummyEmbeddingFunction
+        });
+    });
+
     test('getKnowledgeBaseCollection refuses to create canonical during active shadow-swap promotion', async () => {
         let createCount = 0;
 

--- a/test/playwright/unit/ai/services/knowledge-base/ChromaManager.spec.mjs
+++ b/test/playwright/unit/ai/services/knowledge-base/ChromaManager.spec.mjs
@@ -65,13 +65,24 @@ test.describe('Neo.ai.services.knowledge-base.ChromaManager', () => {
         expect(ChromaManager.connected).toBe(false);
     });
 
-    test('getKnowledgeBaseCollection creates and caches the configured collection', async () => {
-        let callCount = 0;
+    test('getKnowledgeBaseCollection creates and caches the configured collection after missing get', async () => {
+        let createCount = 0;
+        let getCount = 0;
+        let created = false;
         let capturedOptions;
 
         ChromaManager.client = {
-            getOrCreateCollection: async options => {
-                callCount++;
+            getCollection: async options => {
+                getCount++;
+                if (!created) {
+                    throw new Error(`Collection ${options.name} does not exist.`);
+                }
+                return {name: options.name};
+            },
+            listCollections: async () => [],
+            createCollection: async options => {
+                createCount++;
+                created = true;
                 capturedOptions = options;
                 return {name: options.name};
             }
@@ -80,12 +91,45 @@ test.describe('Neo.ai.services.knowledge-base.ChromaManager', () => {
         const first  = await ChromaManager.getKnowledgeBaseCollection();
         const second = await ChromaManager.getKnowledgeBaseCollection();
 
-        expect(callCount).toBe(1);
+        expect(getCount).toBe(1);
+        expect(createCount).toBe(1);
         expect(first).toBe(second);
         expect(capturedOptions).toEqual({
             name             : aiConfig.collectionName,
             embeddingFunction: aiConfig.dummyEmbeddingFunction
         });
+    });
+
+    test('getKnowledgeBaseCollection refuses to create canonical during active shadow-swap promotion', async () => {
+        let createCount = 0;
+
+        ChromaManager.client = {
+            getCollection: async options => {
+                throw new Error(`Collection ${options.name} does not exist.`);
+            },
+            listCollections: async () => [
+                {name: `${aiConfig.collectionName}-parking-123`},
+                {name: `${aiConfig.collectionName}-shadow-123`},
+                {name: `${aiConfig.collectionName}-failed-shadow-older`}
+            ],
+            createCollection: async () => {
+                createCount++;
+                return {name: aiConfig.collectionName};
+            }
+        };
+
+        await expect(ChromaManager.getKnowledgeBaseCollection())
+            .rejects.toMatchObject({
+                code                  : 'KB_COLLECTION_SWAP_IN_PROGRESS',
+                activeSwapCollections : [
+                    `${aiConfig.collectionName}-parking-123`,
+                    `${aiConfig.collectionName}-shadow-123`
+                ]
+            });
+
+        expect(createCount).toBe(0);
+        expect(ChromaManager._knowledgeBaseCollectionPromise).toBe(null);
+        expect(ChromaManager.knowledgeBaseCollection).toBe(null);
     });
 
     test('invalidateKnowledgeBaseCollectionCache clears cached canonical collection handles', async () => {
@@ -103,7 +147,7 @@ test.describe('Neo.ai.services.knowledge-base.ChromaManager', () => {
     test('checkConnectivity returns heartbeat and cached collection name', async () => {
         ChromaManager.client = {
             heartbeat: async () => 456,
-            getOrCreateCollection: async () => ({name: 'knowledge-base-test'})
+            getCollection: async () => ({name: 'knowledge-base-test'})
         };
 
         await expect(ChromaManager.checkConnectivity()).resolves.toEqual({

--- a/test/playwright/unit/ai/services/knowledge-base/DatabaseService.sync.spec.mjs
+++ b/test/playwright/unit/ai/services/knowledge-base/DatabaseService.sync.spec.mjs
@@ -10,10 +10,12 @@ import path from 'path';
 test.describe('Neo.ai.services.knowledge-base.DatabaseService sync', () => {
     let DatabaseService;
     let aiConfig;
+    let VectorService;
 
     test.beforeAll(async () => {
         aiConfig = (await import('../../../../../../ai/mcp/server/knowledge-base/config.mjs')).default;
         DatabaseService = (await import('../../../../../../ai/services.mjs')).KB_DatabaseService;
+        VectorService = (await import('../../../../../../ai/services/knowledge-base/VectorService.mjs')).default;
     });
 
     test('createKnowledgeBase() emits type: adr chunks', async () => {
@@ -46,5 +48,37 @@ test.describe('Neo.ai.services.knowledge-base.DatabaseService sync', () => {
                 await fs.unlink(testDataPath);
             }
         }
+    });
+
+    test('embedKnowledgeBase forwards explicit staleStrategy while default remains unchanged', async () => {
+        const originalEmbed = VectorService.embed.bind(VectorService);
+        const calls = [];
+
+        VectorService.embed = async (knowledgeBasePath, options) => {
+            calls.push({knowledgeBasePath, options});
+            return {message: 'stubbed embed'};
+        };
+
+        try {
+            await DatabaseService.embedKnowledgeBase({viaMcp: true});
+            await DatabaseService.embedKnowledgeBase({staleStrategy: 'shadow-swap'});
+        } finally {
+            VectorService.embed = originalEmbed;
+        }
+
+        expect(calls[0]).toEqual({
+            knowledgeBasePath: aiConfig.dataPath,
+            options          : {
+                viaMcp       : true,
+                staleStrategy: undefined
+            }
+        });
+        expect(calls[1]).toEqual({
+            knowledgeBasePath: aiConfig.dataPath,
+            options          : {
+                viaMcp       : false,
+                staleStrategy: 'shadow-swap'
+            }
+        });
     });
 });

--- a/test/playwright/unit/ai/services/knowledge-base/VectorService.WorkVolumeBranching.spec.mjs
+++ b/test/playwright/unit/ai/services/knowledge-base/VectorService.WorkVolumeBranching.spec.mjs
@@ -97,6 +97,57 @@ function createSpyCollection({existingIds = [], name = 'spy-knowledge-base'} = {
     return collection;
 }
 
+function createRegistryBackedCollection({existingIds = [], name, registry, onModify} = {}) {
+    const collection = createSpyCollection({existingIds, name});
+
+    collection.modify = async ({name: nextName}) => {
+        collection.calls.modify.push({name: nextName});
+        if (registry.has(nextName)) {
+            throw new Error(`Collection ${nextName} already exists.`);
+        }
+        registry.delete(collection.name);
+        collection.name = nextName;
+        registry.set(nextName, collection);
+        if (onModify) {
+            await onModify({collection, name: nextName});
+        }
+    };
+
+    return collection;
+}
+
+function createRegistryBackedClient(registry) {
+    const calls = {createCollection: [], getCollection: [], listCollections: 0};
+
+    return {
+        calls,
+
+        async getCollection({name}) {
+            calls.getCollection.push(name);
+            const collection = registry.get(name);
+            if (!collection) {
+                throw new Error(`Collection ${name} does not exist.`);
+            }
+            return collection;
+        },
+
+        async listCollections() {
+            calls.listCollections++;
+            return Array.from(registry.values());
+        },
+
+        async createCollection({name}) {
+            calls.createCollection.push(name);
+            if (registry.has(name)) {
+                throw new Error(`Collection ${name} already exists.`);
+            }
+            const collection = createRegistryBackedCollection({name, registry});
+            registry.set(name, collection);
+            return collection;
+        }
+    };
+}
+
 /**
  * Writes a JSONL file with N synthetic chunks. Each chunk is `kind: 'method-context'` (skips
  * the `module-context` className-map enrichment loop in embed()) with a unique `hash`.
@@ -163,6 +214,7 @@ test.describe('VectorService.embed — work-volume branching (#10572)', () => {
     test.beforeEach(() => {
         KB_Config.data.mcpSyncMaxChunks = 5; // tight threshold for predictable branching
         KB_ChromaManager.client         = originalClient;
+        KB_ChromaManager.getKnowledgeBaseCollection = originalGetCollection;
         KB_ChromaManager.invalidateKnowledgeBaseCollectionCache();
     });
 
@@ -278,6 +330,86 @@ test.describe('VectorService.embed — work-volume branching (#10572)', () => {
 
         expect(KB_ChromaManager._knowledgeBaseCollectionPromise).toBe(null);
         expect(KB_ChromaManager.knowledgeBaseCollection).toBe(null);
+    });
+
+    test('shadow-swap blocks cold-cache canonical recreation during the promote window', async () => {
+        const registry = new Map();
+        let coldCacheError;
+
+        const live = createRegistryBackedCollection({
+            existingIds: [],
+            name       : KB_Config.data.collectionName,
+            registry,
+            onModify   : async ({name}) => {
+                if (name.includes(`${KB_Config.data.collectionName}-parking-`)) {
+                    KB_ChromaManager.invalidateKnowledgeBaseCollectionCache();
+                    try {
+                        await KB_ChromaManager.getKnowledgeBaseCollection();
+                    } catch (error) {
+                        coldCacheError = error;
+                    }
+                }
+            }
+        });
+        registry.set(live.name, live);
+
+        const client = createRegistryBackedClient(registry);
+        KB_ChromaManager.client = client;
+
+        const result = await KB_VectorService.embedViaShadowSwap({
+            liveCollection: live,
+            knowledgeBase: [{
+                id         : 'chunk-0',
+                hash       : 'chunk-0',
+                type       : 'method',
+                name       : 'method0',
+                className  : '',
+                description: 'body 0'
+            }],
+            idsToDeleteCount: 0
+        });
+
+        expect(result.staleStrategy).toBe('shadow-swap');
+        expect(coldCacheError).toMatchObject({
+            code: 'KB_COLLECTION_SWAP_IN_PROGRESS'
+        });
+        expect(coldCacheError.activeSwapCollections).toEqual(expect.arrayContaining([
+            result.parkedCollection,
+            result.shadowCollection
+        ]));
+        expect(client.calls.createCollection).not.toContain(KB_Config.data.collectionName);
+        expect(registry.get(KB_Config.data.collectionName).rows.size).toBe(1);
+    });
+
+    test('shadow-swap parks failed pre-promote shadow collections under a non-active name', async () => {
+        const live = createSpyCollection({existingIds: [], name: KB_Config.data.collectionName});
+        const originalEmbedChunks = KB_VectorService.embedChunks.bind(KB_VectorService);
+        let shadow;
+
+        KB_ChromaManager.client = {
+            createCollection: async ({name}) => {
+                shadow = createSpyCollection({name});
+                return shadow;
+            }
+        };
+        KB_VectorService.embedChunks = async () => {
+            throw new Error('forced embed failure');
+        };
+
+        try {
+            await expect(KB_VectorService.embedViaShadowSwap({
+                liveCollection   : live,
+                knowledgeBase    : [{id: 'chunk-0', type: 'method', name: 'method0'}],
+                idsToDeleteCount : 0
+            })).rejects.toThrow('forced embed failure');
+
+            expect(live.calls.modify).toEqual([]);
+            expect(shadow.calls.modify).toHaveLength(1);
+            expect(shadow.calls.modify[0].name).toContain(`${KB_Config.data.collectionName}-failed-shadow-`);
+            expect(shadow.calls.modify[0].name).not.toContain(`${KB_Config.data.collectionName}-shadow-`);
+        } finally {
+            KB_VectorService.embedChunks = originalEmbedChunks;
+        }
     });
 
     test('shadow-swap MCP gate measures full-corpus rebuild volume before creating shadow collection', async () => {


### PR DESCRIPTION
Resolves #11685

Authored by GPT-5.5 (Codex Desktop). Session 019e44ba-d309-7e91-a819-36911fbf4e10.

FAIR-band: in-band [15/30]

Evidence: L2 (unit-simulated Chroma promote-window collision + full KB unit slice) -> L3 CI validation. Current-head CI executed the dockerized `integration-unified` suite successfully after the follow-up `ChromaNotFoundError` repair; local docker fixture command completed with both tests skipped after escalation.

Hardens the Knowledge Base shadow-swap path before activation. The canonical KB resolver now fails closed during an active live->parking / shadow->canonical promote window instead of using `getOrCreateCollection()` and risking an empty canonical collection. Failed pre-promote shadows are parked under a non-active recovery name. The default sync path remains unchanged; `NEO_KB_STALE_STRATEGY=shadow-swap npm run ai:sync-kb` is the explicit activation path.

## Deltas from ticket

- Implemented the no-canonical-window guard in `ChromaManager.getKnowledgeBaseCollection()` by resolving with `getCollection()`, detecting active swap artifacts, and only creating the canonical collection when no swap is in progress.
- Parked failed pre-promote shadow collections as `*-failed-shadow-*` instead of leaving active `*-shadow-*` names behind.
- Threaded `staleStrategy` through `DatabaseService` and added the explicit CLI env activation hook without changing the MCP `manage_knowledge_base` tool schema.
- Extended existing unit and dockerized integration coverage around the promote-window probe, plus the Chroma bootstrap `ChromaNotFoundError` fallback.
- Normalized tab indentation in the shadow-swap integration test after the approved review's non-blocking polish note.

## Test Evidence

- `npm run test-unit -- test/playwright/unit/ai/services/knowledge-base/ChromaManager.spec.mjs test/playwright/unit/ai/services/knowledge-base/VectorService.WorkVolumeBranching.spec.mjs test/playwright/unit/ai/services/knowledge-base/DatabaseService.sync.spec.mjs` -> 19 passed.
- `npm run test-unit -- test/playwright/unit/ai/services/knowledge-base/ChromaManager.spec.mjs` -> 7 passed.
- `npm run test-unit -- test/playwright/unit/ai/services/knowledge-base` -> 174 passed.
- `npm run test-integration-unified -- test/playwright/integration/KBBackupRestoreWipe.integration.spec.mjs` -> sandbox failed with `listen EPERM: operation not permitted 127.0.0.1:13090`; escalated rerun completed with 2 skipped.
- CI `integration-unified` first run at `d5b8337f5` failed with `ChromaNotFoundError: The requested resource could not be found`; fixed in `c51a3d01a`.
- CI on `c51a3d01a6a7f82619aed84b3532368cc21bea94` -> `lint-pr-body`, `check`, `unit`, `integration-unified`, `Analyze (javascript)`, and `CodeQL` passed. `integration-unified` passed in 6m33s.
- Review polish commit `73587ce9f` is whitespace-only in `KBBackupRestoreWipe.integration.spec.mjs`; `rg -nP '^\\t' test/playwright/integration/KBBackupRestoreWipe.integration.spec.mjs` found no remaining leading tabs.
- CI on `73587ce9ff4cd9f8a7a445df8e28d73a3f2411b3` -> `lint-pr-body`, `check`, `unit`, `integration-unified`, `Analyze (javascript)`, and `CodeQL` passed. `integration-unified` passed in 6m31s.
- `git diff --check` -> passed.

## Post-Merge Validation

- [ ] Run an operator-controlled `NEO_KB_STALE_STRATEGY=shadow-swap npm run ai:sync-kb` only after this PR is merged and CI-green.

## Commit

- `d5b8337f5` - `fix(kb): harden shadow-swap promotion (#11685)`
- `c51a3d01a` - `fix(kb): handle chroma missing collection errors (#11685)`
- `73587ce9f` - `chore(kb): normalize shadow swap test indentation (#11685)`
