### PR TITLE
feat(kb): add ingest_source_files MCP facade with volume gate (#11634)

### DIFF
--- a/ai/mcp/server/knowledge-base/openapi.yaml
+++ b/ai/mcp/server/knowledge-base/openapi.yaml
@@ -2,8 +2,8 @@ openapi: 3.0.3
 info:
   title: Neo Knowledge Base MCP Server API
   description: |
-    This API provides structured access to the Neo.mjs project's knowledge base. 
-    It enables AI agents to build, query, and manage the vector database containing 
+    This API provides structured access to the Neo.mjs project's knowledge base.
+    It enables AI agents to build, query, and manage the vector database containing
     source code, documentation, and learning materials.
   version: 1.0.0
   contact:
@@ -152,6 +152,46 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
 
+  /db/data/ingest:
+    post:
+      summary: Ingest Source Files
+      operationId: ingest_source_files
+      x-pass-as-object: true
+      description: |
+        Agent-native Knowledge Base ingestion for small batches of source files.
+
+        Accepts raw `{path, content}` file payloads or client-side `parsed-chunk-v1`
+        records, applies tenant-scoped deletion signaling, and embeds the result.
+        Use this for small incremental pushes (e.g. post-commit hook batches).
+
+        **Volume gate:** when the batch volume exceeds `mcpSyncMaxChunks`
+        (default 50) this tool refuses up-front and returns a `KB_INGEST_VOLUME_EXCEEDED`
+        payload instead of embedding synchronously — split the batch into smaller
+        `ingest_source_files` calls. Batch volume = the summed `parsedChunks` length
+        across `files`, counting each raw (un-parsed) file as 1.
+      tags: [Database]
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/IngestSourceFilesRequest'
+      responses:
+        '200':
+          description: Ingestion completed, OR refused with a KB_INGEST_VOLUME_EXCEEDED payload.
+          content:
+            application/json:
+              schema:
+                oneOf:
+                  - $ref: '#/components/schemas/IngestSourceFilesResponse'
+                  - $ref: '#/components/schemas/KbIngestVolumeExceededResponse'
+        '500':
+          description: Ingestion failed.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
   /documents/query:
     post:
       summary: Query Documents
@@ -170,11 +210,11 @@ paths:
         synthesis step is overhead).
 
         ## How to Use This Tool
-        
+
         **Input:**
         - `query`: Natural language search query (1-10 words work best)
         - `type`: Optional filter by content type (all, blog, guide, src, example, ticket, release, test, skill, adr, concept)
-        
+
         **Output:**
         A ranked list of file paths with relevance scores. Example:
         ```
@@ -182,12 +222,12 @@ paths:
         - /path/to/relevant/file1.mjs (Score: 350)
         - /path/to/relevant/file2.md (Score: 210)
         - /path/to/relevant/file3.mjs (Score: 150)
-        
+
         Top result: /path/to/relevant/file1.mjs
         ```
-        
+
         ## How to Interpret Results
-        
+
         1. **Start with the top result**: Always read the highest-scoring file first.
         2. **Scan the next 5-10 results**: Check both file types and scores.
         3. **Balance source and guides**: Read top 1-2 source files (.mjs) AND top 1-2 guides (.md).
@@ -198,7 +238,7 @@ paths:
            - `blog`: Historical context (code examples may be outdated)
            - `example`: Concrete usage patterns
            - `ticket`: Can be historical context (**closed tickets**) or potential work items (**open tickets**). Distinguish between them carefully.
-        
+
         ## Query Strategies
 
         ### The Discovery Pattern: Broad to Narrow
@@ -235,7 +275,7 @@ paths:
         - Get explicit user approval to proceed
 
         ## Handling Failures
-        
+
         If this tool fails or throws an error:
         1. Run the `healthcheck` tool to diagnose the issue.
         2. If unhealthy, consult `.github/AI_QUICK_START.md` for setup guidance.
@@ -685,7 +725,7 @@ components:
             - Keep queries concise (1-10 words)
             - Use specific technical terms when known
             - Start broad, then narrow based on results
-            - Example good queries: "Button component", "state management patterns", 
+            - Example good queries: "Button component", "state management patterns",
               "afterSet hook implementation", "multi-window architecture"
           example: "How do I use the Tab Container component?"
         type:
@@ -818,3 +858,125 @@ components:
         code:
           type: string
           example: "DB_CONNECTION_ERROR"
+
+    IngestSourceFilesRequest:
+      type: object
+      description: |
+        Knowledge Base ingestion push envelope (Phase 2 agent-native facade). No field is
+        strictly required at this layer — the ingestion service validates and returns a
+        structured summary (accumulating per-file errors) rather than throwing.
+      properties:
+        tenantId:
+          type: string
+          description: |
+            Authenticated tenant id. The server stamps the authoritative value; offline
+            calls fall back to `neo-shared`.
+        files:
+          type: array
+          description: Raw file payloads or client-side parsed records to ingest.
+          items:
+            type: object
+            additionalProperties: true
+            properties:
+              path:
+                type: string
+                description: Source path relative to the repo root.
+              content:
+                type: string
+                description: Raw file content (omitted when parsedChunks is supplied).
+              parser:
+                type: string
+                description: Optional parser id hint for server-side raw-file parsing.
+              parsedChunks:
+                type: array
+                description: |
+                  Optional client-side parsed `parsed-chunk-v1` records. When present,
+                  these pass through to the ingestion service's Ajv `parsed-chunk-v1`
+                  validator — the deep per-chunk contract is enforced there, not
+                  duplicated in this tool schema.
+                items:
+                  type: object
+                  additionalProperties: true
+        deleted:
+          type: array
+          description: Explicit tombstones for files removed on the client.
+          items:
+            type: object
+            additionalProperties: true
+            properties:
+              sourcePath:
+                type: string
+              repoSlug:
+                type: string
+        manifestSnapshot:
+          type: object
+          additionalProperties: true
+          description: Post-push manifest used to derive orphaned-chunk deletions.
+          properties:
+            repoSlug:
+              type: string
+            pathsAfterPush:
+              type: array
+              items:
+                type: string
+        baseRevision:
+          type: string
+          description: Previous revision boundary (optional revision-range deletion signal).
+        headRevision:
+          type: string
+          description: Current revision boundary (optional revision-range deletion signal).
+
+    IngestSourceFilesResponse:
+      type: object
+      description: Structured ingestion summary returned by KnowledgeBaseIngestionService.
+      properties:
+        ingested:
+          type: integer
+          description: Count of chunks embedded/upserted.
+        deleted:
+          type: integer
+          description: Count of Chroma rows removed via deletion signaling.
+        embeddingsGenerated:
+          type: integer
+          description: Count of embeddings generated for this push.
+        errors:
+          type: array
+          description: Accumulated per-file caller errors; a non-empty array does not imply total failure.
+          items:
+            type: object
+            additionalProperties: true
+        tenantId:
+          type: string
+          description: The server-resolved authoritative tenant id.
+        durationMs:
+          type: integer
+          description: Wall-clock duration of the ingestion in milliseconds.
+
+    KbIngestVolumeExceededResponse:
+      type: object
+      description: |
+        Structured refusal returned (not thrown) when the batch volume exceeds the
+        MCP-callable threshold. The KB server's `'error' in result` contract converts
+        this to an MCP `isError: true` result.
+      properties:
+        error:
+          type: string
+          example: "KB ingest work volume exceeds MCP-callable threshold"
+        message:
+          type: string
+          description: Human-readable guidance, including the split-the-batch remedy.
+        code:
+          type: string
+          enum: [KB_INGEST_VOLUME_EXCEEDED]
+        bulkPath:
+          type: string
+          nullable: true
+          description: |
+            Runnable bulk-ingestion command. Currently `null` — the tenant-scoped bulk
+            ingestion facade is Phase 2C; until it ships, split the batch (see `message`).
+        batchSize:
+          type: integer
+          description: The computed batch volume that exceeded the threshold.
+        threshold:
+          type: integer
+          description: The `mcpSyncMaxChunks` threshold (default 50).

--- a/ai/mcp/server/knowledge-base/toolService.mjs
+++ b/ai/mcp/server/knowledge-base/toolService.mjs
@@ -1,18 +1,69 @@
-import path                     from 'path';
-import {fileURLToPath}          from 'url';
-import DatabaseService          from '../../../services/knowledge-base/DatabaseService.mjs';
-import DatabaseLifecycleService from '../../../services/knowledge-base/DatabaseLifecycleService.mjs';
-import DocumentService          from '../../../services/knowledge-base/DocumentService.mjs';
-import HealthService            from '../../../services/knowledge-base/HealthService.mjs';
-import KBRecorderService        from '../../../services/knowledge-base/KBRecorderService.mjs';
-import QueryService             from '../../../services/knowledge-base/QueryService.mjs';
-import SearchService            from '../../../services/knowledge-base/SearchService.mjs';
-import ToolService              from '../../ToolService.mjs';
+import path                          from 'path';
+import {fileURLToPath}               from 'url';
+import aiConfig                      from './config.mjs';
+import DatabaseService               from '../../../services/knowledge-base/DatabaseService.mjs';
+import DatabaseLifecycleService      from '../../../services/knowledge-base/DatabaseLifecycleService.mjs';
+import DocumentService               from '../../../services/knowledge-base/DocumentService.mjs';
+import HealthService                 from '../../../services/knowledge-base/HealthService.mjs';
+import KBRecorderService             from '../../../services/knowledge-base/KBRecorderService.mjs';
+import KnowledgeBaseIngestionService from '../../../services/knowledge-base/KnowledgeBaseIngestionService.mjs';
+import QueryService                  from '../../../services/knowledge-base/QueryService.mjs';
+import SearchService                 from '../../../services/knowledge-base/SearchService.mjs';
+import ToolService                   from '../../ToolService.mjs';
 
 const __filename      = fileURLToPath(import.meta.url);
 const __dirname       = path.dirname(__filename);
 /** @anchor test-isolation - ENV override to prevent parallel test mutations from corrupting the canonical file. Easily extensible to other servers via NEO_AI_MCP_<SERVER>_OPENAPI_PATH. */
 const openApiFilePath = process.env.NEO_AI_MCP_KB_OPENAPI_PATH || path.join(__dirname, 'openapi.yaml');
+
+/**
+ * @summary MCP facade for `KnowledgeBaseIngestionService.ingestSourceFiles` — applies the
+ * #10572 work-volume gate before dispatch.
+ *
+ * An agent-initiated `ingest_source_files` push embeds synchronously; an oversized batch
+ * would freeze the calling agent. This facade counts the batch volume up-front and, when
+ * it exceeds `aiConfig.mcpSyncMaxChunks` (default 50), refuses with a structured
+ * `KB_INGEST_VOLUME_EXCEEDED` payload instead of dispatching to the service.
+ *
+ * Batch volume = the summed `parsedChunks` length across `files`, counting each raw
+ * (un-parsed) file as 1. Raw files are chunked server-side, so a small batch of large
+ * raw files can still exceed the threshold post-parse — the gate is a coarse up-front
+ * guard, not an exact post-parse count.
+ *
+ * The gate lives at the MCP facade (not threaded into the service) because the batch
+ * volume is knowable from the input alone, and #11634 keeps service-layer ingestion
+ * logic (Phase 2A `KnowledgeBaseIngestionService`) untouched.
+ *
+ * @param {Object}    args            The `ingest_source_files` tool envelope.
+ * @param {String}   [args.tenantId]  Authenticated tenant id.
+ * @param {Object[]} [args.files]     Raw file payloads or client-side parsed records.
+ * @returns {Promise<Object>} The `KnowledgeBaseIngestionService.ingestSourceFiles` summary,
+ *     OR a `{error, message, code: 'KB_INGEST_VOLUME_EXCEEDED', bulkPath, batchSize, threshold}`
+ *     refusal when the work-volume gate fires.
+ * @see https://github.com/neomjs/neo/issues/11634
+ * @see https://github.com/neomjs/neo/issues/10572
+ */
+const ingestSourceFilesViaMcp = async args => {
+    const
+        files     = Array.isArray(args?.files) ? args.files : [],
+        batchSize = files.reduce((sum, file) => sum + (Array.isArray(file?.parsedChunks) ? file.parsedChunks.length : 1), 0),
+        threshold = aiConfig.mcpSyncMaxChunks ?? 50;
+
+    if (batchSize > threshold) {
+        return {
+            error    : 'KB ingest work volume exceeds MCP-callable threshold',
+            message  : `Batch volume ${batchSize} exceeds the MCP-synchronous threshold ${threshold}. ` +
+                       `Re-invoke ingest_source_files with at most ${threshold} files/chunks per call; ` +
+                       `a tenant-scoped bulk ingestion facade is planned (Phase 2C).`,
+            code     : 'KB_INGEST_VOLUME_EXCEEDED',
+            bulkPath : null,
+            batchSize,
+            threshold
+        };
+    }
+
+    return KnowledgeBaseIngestionService.ingestSourceFiles(args);
+};
 
 const serviceMapping = {
     ask_knowledge_base   : SearchService           .ask                .bind(SearchService),
@@ -26,6 +77,8 @@ const serviceMapping = {
     // work-volume gate. CLI invocations (via `npm run ai:sync-kb`) call DatabaseService.syncDatabase
     // directly without `viaMcp`, bypassing the gate — explicit opt-in to long-running work.
     manage_knowledge_base: args => DatabaseService.manageKnowledgeBase({...args, viaMcp: true}),
+    // #11634: facade applies the #10572 work-volume gate before dispatch — see ingestSourceFilesViaMcp.
+    ingest_source_files  : ingestSourceFilesViaMcp,
     query_documents      : QueryService            .queryDocuments     .bind(QueryService)
 };
 
@@ -69,4 +122,4 @@ const callTool = async (name, args) => {
 
 const listTools = toolService.listTools.bind(toolService);
 
-export {callTool, listTools};
+export {callTool, ingestSourceFilesViaMcp, listTools};

--- a/test/playwright/integration/KBBackupRestoreWipe.integration.spec.mjs
+++ b/test/playwright/integration/KBBackupRestoreWipe.integration.spec.mjs
@@ -350,6 +350,100 @@ function shadowSwapKnowledgeBase({collectionName, oldId, oldSentinel, fixturePat
     });
 }
 
+/**
+ * Drives the `ingest_source_files` MCP tool end-to-end inside the deployed KB container.
+ * Exercises both the #10572 work-volume gate (an oversized batch refused up-front) and the
+ * within-threshold dispatch path (parsed chunks embedded into an isolated temp collection).
+ * @param {Object} options
+ * @param {String} options.collectionName Temporary Chroma collection name.
+ * @param {String} options.repoSlug       Repo slug stamped onto the parsed-chunk fixtures.
+ * @param {String} options.tenantId       Mock tenant id for the ingestion push.
+ * @returns {Object}
+ */
+function ingestSourceFilesViaMcpTool({collectionName, repoSlug, tenantId}) {
+    return execKnowledgeBaseJson(`
+        ${NEO_BOOTSTRAP}
+
+        const {
+            KB_Config,
+            KB_ChromaManager,
+            KB_LifecycleService,
+            Memory_TextEmbeddingService
+        } = await import('./ai/services.mjs');
+        const {callTool} = await import('./ai/mcp/server/knowledge-base/toolService.mjs');
+
+        await KB_LifecycleService.ready();
+
+        const originalCollectionName   = KB_Config.data.collectionName;
+        const originalThreshold        = KB_Config.data.mcpSyncMaxChunks;
+        const originalEmbedTexts       = Memory_TextEmbeddingService.embedTexts.bind(Memory_TextEmbeddingService);
+        const vectorLength             = 4096;
+        const tenantId                 = process.env.NEO_TEST_KB_TENANT;
+        const repoSlug                 = process.env.NEO_TEST_KB_REPO;
+
+        KB_Config.data.collectionName   = process.env.NEO_TEST_KB_COLLECTION;
+        KB_Config.data.mcpSyncMaxChunks = 5;
+        KB_ChromaManager.invalidateKnowledgeBaseCollectionCache();
+
+        Memory_TextEmbeddingService.embedTexts = async texts => {
+            return texts.map((_, index) => {
+                return Array.from({length: vectorLength}, (__, dimension) => dimension === index ? 1 : 0);
+            });
+        };
+
+        let after, dispatch, gate;
+
+        try {
+            // Gate path: a 6-file batch exceeds the threshold (5) and is refused before dispatch.
+            const oversizedFiles = Array.from({length: 6}, (_, index) => ({
+                path   : 'ingest-gate-' + index + '.mjs',
+                content: 'ingest gate file ' + index
+            }));
+            gate = await callTool('ingest_source_files', {tenantId, files: oversizedFiles});
+
+            // Dispatch path: a 3-chunk batch is within the threshold and is embedded end-to-end.
+            const parsedChunks = Array.from({length: 3}, (_, index) => ({
+                schemaVersion: '1.0.0',
+                tenantId,
+                repoSlug,
+                rootKind     : 'bare-repo',
+                sourcePath   : 'ingest-dispatch-' + index + '.mjs',
+                content      : 'ingest dispatch chunk ' + index,
+                hashInputs   : ['sourcePath', 'content'],
+                parserId     : 'integration-fixture',
+                parserVersion: '1.0.0',
+                kind         : 'doc-section',
+                name         : 'ingestDispatchChunk' + index
+            }));
+            dispatch = await callTool('ingest_source_files', {
+                tenantId,
+                files: [{path: 'ingest-dispatch.mjs', parsedChunks}]
+            });
+
+            const collection = await KB_ChromaManager.getKnowledgeBaseCollection();
+            after = {
+                collectionName: collection.name,
+                count         : await collection.count()
+            };
+
+            console.log(JSON.stringify({after, dispatch, gate}));
+        } finally {
+            Memory_TextEmbeddingService.embedTexts = originalEmbedTexts;
+            KB_Config.data.collectionName          = originalCollectionName;
+            KB_Config.data.mcpSyncMaxChunks        = originalThreshold;
+            KB_ChromaManager.invalidateKnowledgeBaseCollectionCache();
+
+            try {
+                await KB_ChromaManager.client.deleteCollection({name: process.env.NEO_TEST_KB_COLLECTION});
+            } catch {}
+        }
+    `, {
+        NEO_TEST_KB_COLLECTION: collectionName,
+        NEO_TEST_KB_REPO      : repoSlug,
+        NEO_TEST_KB_TENANT    : tenantId
+    });
+}
+
 test.describe('Dockerized KB backup -> wipe -> restore integration (#11644)', () => {
     test('restores a seeded Knowledge Base vector after an isolated fixture wipe', async () => {
         const readiness = await getReadiness();
@@ -429,5 +523,38 @@ test.describe('Dockerized KB backup -> wipe -> restore integration (#11644)', ()
         expect(swap.after.collectionName).toBe(collectionName);
         expect(swap.after.count).toBe(3);
         expect(swap.after.oldFound).toBe(false);
+    });
+
+    test('ingest_source_files MCP tool gates oversized batches and ingests within-threshold pushes (#11634)', async () => {
+        const readiness = await getReadiness();
+
+        test.skip(readiness.dockerAvailable === false, `Docker unavailable: ${readiness.reason}`);
+        expect(readiness.servicesReady, readiness.reason).toBe(true);
+
+        const runId          = `${Date.now()}-${randomUUID()}`;
+        const collectionName = `kb-ingest-source-files-${runId}`;
+
+        const outcome = ingestSourceFilesViaMcpTool({
+            collectionName,
+            repoSlug: `kb-ingest-${runId}`,
+            tenantId: 'neo-shared'
+        });
+
+        // Gate path — a 6-file batch over the threshold (5) is refused before dispatch.
+        expect(outcome.gate.code).toBe('KB_INGEST_VOLUME_EXCEEDED');
+        expect(outcome.gate.batchSize).toBe(6);
+        expect(outcome.gate.threshold).toBe(5);
+        expect(outcome.gate.bulkPath).toBe(null);
+
+        // Dispatch path — a 3-chunk batch reaches the ingestion service end-to-end.
+        expect('error' in outcome.dispatch).toBe(false);
+        expect(outcome.dispatch.code).not.toBe('KB_INGEST_VOLUME_EXCEEDED');
+        expect(outcome.dispatch.ingested).toBe(3);
+        expect(outcome.dispatch.tenantId).toBe('neo-shared');
+        expect(Array.isArray(outcome.dispatch.errors)).toBe(true);
+
+        // The within-threshold push embedded into the isolated temp collection.
+        expect(outcome.after.collectionName).toBe(collectionName);
+        expect(outcome.after.count).toBe(3);
     });
 });

--- a/test/playwright/unit/ai/mcp/server/knowledge-base/IngestSourceFilesTool.spec.mjs
+++ b/test/playwright/unit/ai/mcp/server/knowledge-base/IngestSourceFilesTool.spec.mjs
@@ -1,0 +1,151 @@
+import {setup} from '../../../../../setup.mjs';
+
+const appName = 'KBIngestSourceFilesToolTest';
+
+setup({
+    neoConfig: {
+        allowVdomUpdatesInTests: false,
+        unitTestMode           : true,
+        useDomApiRenderer      : false
+    },
+    appConfig: {
+        name             : appName,
+        isMounted        : () => true,
+        vnodeInitialising: false
+    }
+});
+
+import {test, expect} from '@playwright/test';
+import Neo            from '../../../../../../../src/Neo.mjs';
+import * as core      from '../../../../../../../src/core/_export.mjs';
+
+/**
+ * Coverage for the `ingest_source_files` MCP facade (#11634, Phase 2B).
+ *
+ * `ingestSourceFilesViaMcp` wraps `KnowledgeBaseIngestionService.ingestSourceFiles`
+ * with the #10572 work-volume gate: an oversized agent-initiated push is refused
+ * up-front with a structured `KB_INGEST_VOLUME_EXCEEDED` payload instead of being
+ * dispatched (which would embed synchronously and freeze the calling agent).
+ *
+ * The facade is tested directly (exported from `toolService.mjs`) so the gate logic
+ * is isolated from the openapi -> Zod dispatch layer and the `callTool` telemetry
+ * wrapper; `listTools()` separately confirms the openapi operation registers.
+ *
+ * Serial mode: specs mutate the `aiConfig.mcpSyncMaxChunks` threshold and the
+ * `KnowledgeBaseIngestionService.ingestSourceFiles` singleton method.
+ */
+test.describe.configure({mode: 'serial'});
+
+test.describe('ingest_source_files MCP facade — work-volume gate (#11634)', () => {
+    let ingestSourceFilesViaMcp, listTools, KnowledgeBaseIngestionService, aiConfig;
+    let originalIngest, originalThreshold;
+
+    test.beforeAll(async () => {
+        const toolService = await import('../../../../../../../ai/mcp/server/knowledge-base/toolService.mjs');
+        ingestSourceFilesViaMcp = toolService.ingestSourceFilesViaMcp;
+        listTools               = toolService.listTools;
+
+        KnowledgeBaseIngestionService = (await import('../../../../../../../ai/services/knowledge-base/KnowledgeBaseIngestionService.mjs')).default;
+        aiConfig                      = (await import('../../../../../../../ai/mcp/server/knowledge-base/config.mjs')).default;
+
+        originalIngest    = KnowledgeBaseIngestionService.ingestSourceFiles;
+        originalThreshold = aiConfig.mcpSyncMaxChunks;
+    });
+
+    test.afterAll(() => {
+        if (KnowledgeBaseIngestionService) {
+            KnowledgeBaseIngestionService.ingestSourceFiles = originalIngest;
+        }
+        if (aiConfig) {
+            aiConfig.mcpSyncMaxChunks = originalThreshold;
+        }
+    });
+
+    test.beforeEach(() => {
+        // Tight, predictable threshold; restore the real service method before each spec.
+        aiConfig.mcpSyncMaxChunks                       = 5;
+        KnowledgeBaseIngestionService.ingestSourceFiles = originalIngest;
+    });
+
+    test('gate fires above threshold — returns KB_INGEST_VOLUME_EXCEEDED, service not dispatched', async () => {
+        let dispatched = false;
+        KnowledgeBaseIngestionService.ingestSourceFiles = async () => {
+            dispatched = true;
+            return {};
+        };
+
+        const files  = Array.from({length: 6}, (_, i) => ({path: `raw${i}.mjs`, content: `body ${i}`}));
+        const result = await ingestSourceFilesViaMcp({tenantId: 'neo-shared', files});
+
+        expect(result.code).toBe('KB_INGEST_VOLUME_EXCEEDED');
+        expect(result.batchSize).toBe(6);
+        expect(result.threshold).toBe(5);
+        expect(result.bulkPath).toBe(null);
+        expect('error' in result).toBe(true);
+        expect(result.message).toContain('exceeds');
+        expect(dispatched, 'service must not be dispatched when the gate fires').toBe(false);
+    });
+
+    test('gate does not fire at the threshold boundary — dispatches to the ingestion service', async () => {
+        let dispatchedArgs = null;
+        const summary      = {ingested: 5, deleted: 0, embeddingsGenerated: 5, errors: [], tenantId: 'neo-shared', durationMs: 1};
+
+        KnowledgeBaseIngestionService.ingestSourceFiles = async args => {
+            dispatchedArgs = args;
+            return summary;
+        };
+
+        const files  = Array.from({length: 5}, (_, i) => ({path: `raw${i}.mjs`, content: `body ${i}`}));
+        const result = await ingestSourceFilesViaMcp({tenantId: 'neo-shared', files});
+
+        expect(dispatchedArgs, 'service must be dispatched at-or-below the threshold').not.toBe(null);
+        expect(dispatchedArgs.files.length).toBe(5);
+        expect(result).toBe(summary);
+        expect('error' in result).toBe(false);
+    });
+
+    test('batch volume sums parsedChunks lengths and counts each raw file as 1', async () => {
+        let dispatched = false;
+        KnowledgeBaseIngestionService.ingestSourceFiles = async () => {
+            dispatched = true;
+            return {};
+        };
+
+        // 2 raw files (2) + 1 file carrying 4 parsed chunks (4) = batch volume 6 > 5.
+        const files = [
+            {path: 'raw-a.mjs', content: 'a'},
+            {path: 'raw-b.mjs', content: 'b'},
+            {path: 'parsed-c.mjs', parsedChunks: [{name: 'c0'}, {name: 'c1'}, {name: 'c2'}, {name: 'c3'}]}
+        ];
+        const result = await ingestSourceFilesViaMcp({files});
+
+        expect(result.code).toBe('KB_INGEST_VOLUME_EXCEEDED');
+        expect(result.batchSize).toBe(6);
+        expect(dispatched).toBe(false);
+    });
+
+    test('missing files field dispatches with a zero batch volume', async () => {
+        let dispatchedArgs = 'unset';
+        KnowledgeBaseIngestionService.ingestSourceFiles = async args => {
+            dispatchedArgs = args;
+            return {ingested: 0, deleted: 0, embeddingsGenerated: 0, errors: [], tenantId: 'neo-shared', durationMs: 0};
+        };
+
+        const result = await ingestSourceFilesViaMcp({tenantId: 'neo-shared'});
+
+        expect(dispatchedArgs, 'a no-files envelope must still reach the service for its structured error').not.toBe('unset');
+        expect('error' in result).toBe(false);
+    });
+
+    test('ingest_source_files is registered as an MCP tool via listTools()', () => {
+        const {tools} = listTools();
+        const tool    = tools.find(item => item.name === 'ingest_source_files');
+
+        expect(tool, 'ingest_source_files must be listed by the KB MCP server').toBeTruthy();
+        expect(tool.inputSchema, 'ingest_source_files must advertise an input schema').toBeTruthy();
+
+        // MCP description-budget guard (Anthropic/Gemini limits; pr-review guide §5.3).
+        expect(tool.name.length, 'tool name within the 64-char MCP limit').toBeLessThanOrEqual(64);
+        expect(tool.description.length, 'tool description within the 1024-char MCP budget').toBeLessThanOrEqual(1024);
+    });
+});


### PR DESCRIPTION
Resolves #11634

Authored by Claude Opus 4.7 (Claude Code). Session 85a5012f-a766-43c9-a480-707834c63587.

FAIR-band: in-band [15/30] — even split with @neo-gpt (15) across the last 30 merged PRs.

Adds the `ingest_source_files` MCP tool — the Phase 2B agent-native command-plane facade for small-batch Knowledge Base ingestion. The tool wraps `KnowledgeBaseIngestionService.ingestSourceFiles` (Phase 2A, #11633) and applies a facade-layer #10572 work-volume gate: an oversized agent-initiated batch is refused up-front with a structured `KB_INGEST_VOLUME_EXCEEDED` payload instead of being dispatched (which would embed synchronously and freeze the calling agent). The change is purely additive — the default KB sync path is unchanged.

Evidence: L2 (5 unit tests green — facade gate firing/passing, raw-vs-parsed batch counting, structured response, \`listTools\` registration + description-budget) -> L3 required (AC #7 dockerized end-to-end MCP invocation). Residual: AC #7 [#11634] — the integration test is syntax-valid and is validated by CI's \`integration-unified\` job (no Docker in the authoring sandbox).

## Deltas from ticket

- **Facade-layer volume gate** (not \`viaMcp\`-threaded into the service). \`KnowledgeBaseIngestionService.ingestSourceFiles\` has no \`viaMcp\` parameter, and modifying Phase 2A service-layer ingestion logic is Out-of-Scope. The batch volume is knowable from the input alone, so the gate is a pure facade pre-check (\`ingestSourceFilesViaMcp\` in \`toolService.mjs\`): it sums each file's \`parsedChunks\` length (a raw, un-parsed file counts as 1) and, above \`aiConfig.mcpSyncMaxChunks\` (default 50), returns the structured refusal before dispatch. Note: \`embedChunkGroups\` already passes \`viaMcp: true\` to \`VectorService.embed\` downstream — so the dispatch path has an inner per-\`repoSlug\`-group gate too. The facade gate is the *outer* gate: it gives the agent a clean up-front \`KB_INGEST_VOLUME_EXCEEDED\` rather than a deep per-group \`KB_SYNC_VOLUME_EXCEEDED\` buried in \`summary.errors\`.
- **\`bulkPath: null\`** in the \`KB_INGEST_VOLUME_EXCEEDED\` response. The ticket's example used \`npm run ai:ingest-tenant <tenantId>\` — verified non-existent (zero repo references; the tenant-scoped bulk facade is Phase 2C). Per truth-in-code the response does not hardcode a non-runnable command: \`bulkPath\` ships \`null\` and the \`message\` directs the agent to split the batch. Phase 2C populates \`bulkPath\` when the bulk facade lands.
- **AC #5 (\`makeSafe\` Zod schema)** is implemented as the openapi-derived input schema validating the *envelope* (\`tenantId\`, \`files\`, \`deleted\`, \`manifestSnapshot\`, revision boundaries). Deep per-chunk \`parsed-chunk-v1\` validation stays the ingestion service's existing Ajv \`parsedChunkValidator\` — single source of truth, no double-validation drift. \`files[]\` and \`parsedChunks[]\` items are declared \`additionalProperties: true\` so the strict input-Zod does not strip parsed-chunk fields.
- MCP tool name is **\`ingest_source_files\`** (snake_case, matching the \`ask_knowledge_base\` / \`manage_knowledge_base\` \`serviceMapping\` convention); the ticket's \`ingestSourceFiles\` is the service-method name.
- \`ingestSourceFilesViaMcp\` is exported from \`toolService.mjs\` for isolated unit-testability.
- The Contract Ledger Matrix was backfilled onto #11634 (Phase 2 Epic #11626 epic-review revision) before implementation.
- \`openapi.yaml\`: 10 lines of **pre-existing trailing whitespace** (in the \`info.description\`, \`query_documents\`, and \`QueryRequest\` blocks — unrelated to this change) were stripped — required by the \`check-whitespace\` pre-commit hook to stage the file.

## Test Evidence

- \`npm run test-unit -- test/playwright/unit/ai/mcp/server/knowledge-base/IngestSourceFilesTool.spec.mjs\` -> 5 passed (gate fires above threshold / passes at boundary / parsed-vs-raw counting / missing-files dispatch / \`listTools\` registration + <=1024-char description budget).
- \`node\` smoke check: the openapi parses, \`buildZodSchema\` / \`buildOutputZodSchema\` build for the new operation, a sample input parses with \`parsedChunks\` fields preserved.
- \`node --check\` on the integration spec — syntax valid.
- Integration test \`ingest_source_files MCP tool gates oversized batches and ingests within-threshold pushes (#11634)\` added to \`KBBackupRestoreWipe.integration.spec.mjs\` — Docker-dependent; exercises the gate path + the dispatch path (3 parsed chunks -> embedded into an isolated temp collection) end-to-end inside the deployed kb-server. Validated by CI's \`integration-unified\` job.

## Post-Merge Validation

- [ ] CI \`integration-unified\` runs the #11634 end-to-end MCP invocation against the deployed kb-server (gate + dispatch paths) green.