### PR TITLE
docs(agent): remove sandbox human liveness gate (#11691)

### DIFF
--- a/.agents/skills/ideation-sandbox/references/ideation-sandbox-workflow.md
+++ b/.agents/skills/ideation-sandbox/references/ideation-sandbox-workflow.md
@@ -132,12 +132,12 @@ Three explicit signal patterns are recognized; VETO is a substantive divergence 
 | Signal | Effect on graduation | Definition |
 |--------|----------------------|------------|
 | `[GRADUATION_APPROVED by @<peer> @ <anchor>]` | Satisfies this peer's consensus contribution | Peer endorses substrate at specific version anchor |
-| `[GRADUATION_DEFERRED by @<peer> @ <anchor> — <reason>]` | **BLOCKS** until withdrawn-post-reconciliation OR operator-override | Peer holds substantive concern; reconciliation cycle needed |
+| `[GRADUATION_DEFERRED by @<peer> @ <anchor> — <reason>]` | **BLOCKS** until withdrawn-post-reconciliation OR peer-owned resolution path is explicitly documented | Peer holds substantive concern; reconciliation cycle needed |
 | `[GRADUATION_ABSTAIN by @<peer> @ <anchor>]` | **NOT approval**; if all 3 peers ABSTAIN, no graduation (no peer endorsed) | Peer explicitly passes on this Discussion |
 
 **VETO collapse rule**: A VETO requires either (a) an alternative-implementation proposal OR (b) a V-B-A-falsifier of the proposing peer's claims. Pure "I disagree" without one of these collapses to DEFERRED. Aligns with `pr-review §9.1 Reviewer-Yield Protocol`.
 
-**No-signal handling**: A peer who has not posted any of the three explicit signals does NOT count as ABSTAIN or as consent. **No-signal is liveness-failure, never consent.** Graduation requires 3 explicit signals; if a peer is unreachable, the path forward is operator-override per §6.4, not timeout-as-implicit-consent.
+**No-signal handling**: A peer who has not posted any of the three explicit signals does NOT count as ABSTAIN or as consent. **No-signal is liveness-failure, never consent.** Graduation normally requires 3 explicit named-maintainer signals. If a peer is unreachable, the path forward is peer-owned liveness handling — recover/re-poll the peer, receive an explicit ABSTAIN when the peer is reachable, or cite a separately codified active-peer quorum rule. It is NOT a human/operator graduation approval gate.
 
 ### 6.3 Version-Binding (mandatory per signal)
 
@@ -158,15 +158,15 @@ When a peer signals DEFERRED, the **burden of convergence falls on the APPROVED-
 
 The DEFERRED peer is NOT obligated to either prove their case or update their signal unilaterally — they hold the substantive divergence position. The inversion ("what would change your signal?" framing) is an anti-pattern that re-introduces author-pressure on dissenters.
 
-**Reconciliation cycles**: typically resolve in 1-3 substantive cycles. If reconciliation stalls after ~20 comments, escalate to operator per AGENTS.md §0 Invariant for resolution authority.
+**Reconciliation cycles**: typically resolve in 1-3 substantive cycles. If reconciliation stalls after ~20 comments, route the design back through peer-owned convergence substrate (fresh Step-Back, lead-role facilitation, or a narrower follow-up Discussion). Ask the operator only for Tier-4 human-owned intent clarification per AGENTS.md §15.6; do not convert a stalled sandbox into a human graduation approval gate.
 
-### 6.5 Operator-Override (preserves residual risk)
+### 6.5 Peer-Owned Dissent / Liveness Disposition (preserves residual risk)
 
-Per AGENTS.md §0 Invariant + §15.6 Flat Peer-Team, operator (`@tobiu`) retains override authority for graduation despite unresolved DEFERRED. **But the override does NOT erase residual risk.**
+Ideation Sandbox graduation is a peer-owned substrate transition. The operator can surface friction, clarify intent, or exercise separate human-owned authority (for example PR merge execution), but operator approval is not a substitute for named-maintainer graduation signals.
 
-The graduated Issue / Epic / PR body MUST archive the dissent signal in a `## Unresolved Dissent` section with the DEFERRED commentId + reason + override-rationale. Future Discussions can re-open the dissent if the residual risk materializes.
+The graduated Issue / Epic / PR body MUST archive any non-empty dissent or liveness gap in `## Unresolved Dissent` / `## Unresolved Liveness` with commentId/state anchors and the peer-owned disposition. Future Discussions can re-open the risk if it materializes.
 
-Override syntax: any user-facing directive from `@tobiu` referencing the Discussion. Specific syntax not codified — operator authority is delegated by the Invariant, not by graduation-protocol substrate.
+If a future active-peer quorum rule is adopted, it MUST be codified explicitly and cited by the graduating artifact. Until then, unresolved no-signal remains a liveness gap to hold or re-poll; it never becomes implicit approval and never asks the operator to approve sandbox graduation.
 
 ### 6.6 Graduated-Artifact Required Sections (AC11)
 
@@ -181,11 +181,11 @@ The graduated Issue / Epic / PR body MUST include these explicit sections, even 
 
 ## Unresolved Dissent
 (empty if 100% APPROVED — positive signal)
-(otherwise: each DEFERRED/VETO with reason + STATUS: operator-override on <date> OR pending-reconciliation)
+(otherwise: each DEFERRED/VETO with reason + STATUS: resolved-by-peer-reconciliation <anchor> OR pending-reconciliation)
 
 ## Unresolved Liveness
 (empty if all 3 signals collected — positive signal)
-(otherwise: each peer with no-signal + STATUS: operator-override-rationale)
+(otherwise: each peer with no-signal + STATUS: pending-peer-repoll OR peer-owned liveness disposition <anchor>)
 
 ## Discussion Criteria Mapping
 (required for Epics graduating from a Discussion to satisfy `epic-resolution` Closeout Gates)
@@ -197,7 +197,7 @@ This pattern makes substrate-state legible in the graduated artifact, archives t
 
 ### 6.7 Author Actions Post-Consensus
 
-When the Signal Ledger reaches 3× APPROVED (or operator-override resolves remaining gaps):
+When the Signal Ledger reaches 3× APPROVED (or a codified peer-owned liveness disposition resolves remaining gaps without treating no-signal as consent):
 
 1. Add `[GRADUATED_TO_TICKET: #N]` marker near top of body (per §4 OQ-resolution-tag pattern)
 2. Update body with `## Signal Ledger` + `## Unresolved Dissent` + `## Unresolved Liveness` + `## Discussion Criteria Mapping` sections

--- a/.agents/skills/pull-request/references/pull-request-workflow.md
+++ b/.agents/skills/pull-request/references/pull-request-workflow.md
@@ -202,7 +202,7 @@ You MUST follow this exact handoff protocol:
 (empty if 100% APPROVED; otherwise: DEFERRED/VETO entries with status)
 
 ## Unresolved Liveness
-(empty if all 3 signals collected; otherwise: no-signal entries with operator-override-rationale)
+(empty if all 3 signals collected; otherwise: no-signal entries with peer-owned liveness disposition)
 ```
 
 These three sections are mandatory in the PR body for substrate-mutating PRs from high-blast Discussions. Empty sections are positive signals.
@@ -212,9 +212,9 @@ These three sections are mandatory in the PR body for substrate-mutating PRs fro
 1. Read the cited Discussion via GitHub GraphQL (`gh api graphql -f query='{ repository(owner, name) { discussion(number: N) { body comments { ... } } } }'`), public comment URLs, or the locally synced discussion artifact when available. Note: the github-workflow MCP `get_conversation` tool is PR-specific; it does NOT retrieve Discussion content.
 2. Confirm each peer's APPROVED signal exists at the cited commentId
 3. Confirm version-binding: signals are bound to the substrate state being implemented (not stale relative to body edits)
-4. Confirm any DEFERRED/VETO carries explicit operator-override + residual-risk documentation
+4. Confirm any DEFERRED/VETO carries explicit peer-reconciliation / peer-owned disposition + residual-risk documentation
 
-**Rejection path**: if the Signal Ledger is incomplete OR contains unresolved DEFERRED/VETO without operator-override, the reviewer posts `Request Changes` citing this §6.1.1 — NOT iterative Cycle-N review-comments on the code itself. The PR is **premature** and must close OR wait for Discussion-graduation to complete.
+**Rejection path**: if the Signal Ledger is incomplete OR contains unresolved DEFERRED/VETO/liveness gaps without a codified peer-owned disposition, the reviewer posts `Request Changes` citing this §6.1.1 — NOT iterative Cycle-N review-comments on the code itself. The PR is **premature** and must close OR wait for Discussion-graduation to complete.
 
 **Operator merge-gate**: PRs that bypass the consensus-gate get rejected at the merge boundary by `@tobiu` regardless of CI green or cross-family approval. This is the structural enforcement of §0 Invariant 1 extended to consensus-gated substrate.
 


### PR DESCRIPTION
Authored by GPT-5.5 (Codex Desktop). Session d13c94dd-e721-4e28-ac9e-4d0b3c0f66de.

FAIR-band: over-target [15/30] - taking this lane despite over-target because an operator-corrected substrate bug currently routes Ideation Sandbox liveness gaps to human approval, and active Discussion #11690 already hit that wrong path.

Resolves #11691

Rewrites the Ideation Sandbox graduation liveness contract and the PR reviewer mirror so missing peer signals are handled as peer-owned liveness state, not as a human/operator graduation approval gate. Human-only PR merge authority remains unchanged.

Evidence: L1 (static skill-substrate audit plus skill manifest lint) -> L1 required (instruction-substrate correction; no runtime surface). No residuals.

Consensus-gate: N/A - this is a direct correction ticket for the sandbox workflow substrate, not an implementation of the still-proposed MCP tool-surface governance Discussion #11690.

## Slot Rationale

- `.agents/skills/ideation-sandbox/references/ideation-sandbox-workflow.md` Section 6: rewrite. Trigger frequency is edge-case high-blast graduation; failure severity is high because the old text created a hidden human approval gate; enforceability is discipline-only until a future active-peer quorum rule exists. The change is net-neutral and removes wrong operator-override wording instead of adding a new rule surface.
- `.agents/skills/pull-request/references/pull-request-workflow.md` Section 6.1.1: rewrite. Trigger frequency is PR review for high-blast Discussion-origin substrate; failure severity is high because reviewers would otherwise enforce the stale operator-override template; enforceability is discipline plus review-body verification.

## Deltas from Ticket

- Included the coupled `pull-request` workflow mirror after V-B-A found the same stale `operator-override-rationale` wording in the Signal Ledger reviewer gate.
- Did not define a new active-peer quorum rule; the patch preserves conservative hold/re-poll semantics unless a future rule is explicitly codified.

## Test Evidence

- `git diff --check origin/dev..HEAD`
- `node ai/scripts/lint-skill-manifest.mjs --base origin/dev`
- `rg` sweep for stale operator-override liveness phrases across `ideation-sandbox`, `pull-request` workflow, and `AGENTS.md` returned no stale matches.
- Pre-push freshness check passed: `merge-base HEAD origin/dev == origin/dev` at `0fc414d10086eda196d2bcc60a9ceb90f8e5d561`.

## Post-Merge Validation

- [ ] Next high-blast sandbox graduation with a missing peer signal records peer-owned liveness state rather than asking @tobiu for approval.

## Commit

- `daef1086a` - `docs(agent): remove sandbox human liveness gate (#11691)`

## Related

- Discussion #11690 correction comment: `DC_kwDODSospM4BA1Ea`
- Prior consensus mandate source: #11217 / Discussion #11216