### PR TITLE
fix(kb): hydrate tenant search results from metadata (#11636)

### DIFF
--- a/ai/services/knowledge-base/QueryService.mjs
+++ b/ai/services/knowledge-base/QueryService.mjs
@@ -100,12 +100,13 @@ class QueryService extends Base {
     /**
      * Performs a semantic search on the knowledge base using a natural language query.
      * Returns a scored and ranked list of the most relevant source files.
-     * @param {String} query        The natural language search query.
-     * @param {String} [type='all'] The content type to filter by. Valid values: 'all', 'blog', 'guide', 'src', 'example', 'ticket', 'release'.
-     * @param {Number} [limit=25]   The maximum number of results to return.
+     * @param {String}  query                         The natural language search query.
+     * @param {String}  [type='all']                  The content type to filter by. Valid values: 'all', 'blog', 'guide', 'src', 'example', 'ticket', 'release'.
+     * @param {Number}  [limit=25]                    The maximum number of results to return.
+     * @param {Boolean} [includeMetadata=false]       Internal hydration flag for RAG synthesis callers.
      * @returns {Promise<Object>} A promise that resolves to the query results object.
      */
-    async queryDocuments({query, type='all', limit=25}) {
+    async queryDocuments({query, type='all', limit=25, includeMetadata=false}) {
         if (!query) {
             throw new Error('A query string must be provided.');
         }
@@ -142,8 +143,9 @@ class QueryService extends Base {
             return {message: 'No results found for your query and type.'};
         }
 
-        const sourceScores = {};
-        const queryWords   = queryLower.replace(/[^a-zA-Z ]/g, '').split(' ').filter(w => w.length > 2);
+        const sourceScores   = {};
+        const sourceMetadata = {};
+        const queryWords     = queryLower.replace(/[^a-zA-Z ]/g, '').split(' ').filter(w => w.length > 2);
 
         results.metadatas[0].forEach((metadata, index) => {
             if (!metadata.source || metadata.source === 'unknown') return;
@@ -153,6 +155,13 @@ class QueryService extends Base {
             const sourcePathLower = sourcePath.toLowerCase();
             const fileName        = sourcePath.split('/').pop().toLowerCase();
             const nameLower       = (metadata.name || '').toLowerCase();
+
+            // Chroma returns chunk metadata in relevance order. Keep the highest-ranked
+            // source metadata available for SearchService hydration without changing the
+            // public queryDocuments result shape unless explicitly requested.
+            if (!sourceMetadata[sourcePath]) {
+                sourceMetadata[sourcePath] = metadata;
+            }
 
             queryWords.forEach(queryWord => {
                 const keyword = queryWord;
@@ -217,7 +226,15 @@ class QueryService extends Base {
         const finalSorted = Object.entries(finalScores)
             .sort(([, a], [, b]) => b - a)
             .slice(0, limit)
-            .map(([source, score]) => ({ source, score: score.toFixed(0) }));
+            .map(([source, score]) => {
+                const result = {source, score: score.toFixed(0)};
+
+                if (includeMetadata) {
+                    result.metadata = sourceMetadata[source] || {};
+                }
+
+                return result;
+            });
 
         if (finalSorted.length > 0) {
             return {

--- a/ai/services/knowledge-base/SearchService.mjs
+++ b/ai/services/knowledge-base/SearchService.mjs
@@ -68,6 +68,88 @@ class SearchService extends Base {
     }
 
     /**
+     * Returns embedded chunk content when a ranked result carries full source metadata.
+     * @param {Object} [metadata] Result metadata from QueryService.
+     * @returns {String} The embedded content or an empty string.
+     */
+    getEmbeddedReferenceContent(metadata = {}) {
+        return typeof metadata.content === 'string' && metadata.content.trim()
+            ? metadata.content
+            : '';
+    }
+
+    /**
+     * Determines whether a ranked result belongs to a tenant/repo that must not be hydrated
+     * from the local neoRootDir filesystem.
+     * @param {Object} [metadata] Result metadata from QueryService.
+     * @returns {Boolean} True when local filesystem hydration is unsafe for this reference.
+     */
+    isNonLocalTenantReference(metadata = {}) {
+        const defaultTenantId = aiConfig.defaultTenantId ?? 'neo-shared';
+        const defaultRepoSlug = aiConfig.defaultRepoSlug ?? 'neo';
+
+        if (metadata.repoSlug && metadata.repoSlug !== defaultRepoSlug) {
+            return true;
+        }
+
+        if (!metadata.tenantId) {
+            return false;
+        }
+
+        return metadata.tenantId !== defaultTenantId;
+    }
+
+    /**
+     * Resolves the best available source content for RAG synthesis.
+     *
+     * Local Neo references keep using neoRootDir filesystem hydration so agents see the
+     * current checkout. Tenant-ingested references use Chroma metadata content instead,
+     * preventing same-relative-path collisions from reading files out of the host repo.
+     *
+     * @param {Object} ref Query reference.
+     * @returns {Promise<String>} Hydrated content or the standard placeholder.
+     */
+    async hydrateReferenceContent(ref) {
+        const metadata        = ref.metadata || {};
+        const embeddedContent = this.getEmbeddedReferenceContent(metadata);
+        let   content         = '';
+        let   absoluteSource  = '';
+
+        if (this.isNonLocalTenantReference(metadata)) {
+            if (embeddedContent) {
+                return embeddedContent;
+            }
+
+            logger.warn(`[SearchService] Missing metadata.content for non-local tenant ref.source="${ref.source}" (tenantId="${metadata.tenantId}", repoSlug="${metadata.repoSlug || ''}") — refusing neoRootDir fallback.`);
+
+            return 'No Content (File missing or empty)';
+        }
+
+        absoluteSource = ref.source && path.isAbsolute(ref.source)
+            ? ref.source
+            : path.resolve(aiConfig.neoRootDir, ref.source || '');
+
+        if (absoluteSource && await fs.pathExists(absoluteSource)) {
+            try {
+                content = await fs.readFile(absoluteSource, 'utf8');
+            } catch (err) {
+                logger.warn(`[SearchService] Failed to read file ${absoluteSource}:`, err.message);
+            }
+        }
+
+        if (!content && embeddedContent) {
+            return embeddedContent;
+        }
+
+        if (!content) {
+            content = 'No Content (File missing or empty)';
+            logger.warn(`[SearchService] Empty context for ref.source="${ref.source}" (resolved to "${absoluteSource}") — chunk content will not reach the synthesis LLM.`);
+        }
+
+        return content;
+    }
+
+    /**
      * Performs a semantic search via QueryService and synthesizes an answer using the LLM.
      *
      * @param {Object} params
@@ -84,7 +166,7 @@ class SearchService extends Base {
         logger.info(`[SearchService] Processing RAG query: "${query}" (Type: ${type})`);
 
         // 1. Retrieve most relevant files using QueryService's scoring logic
-        const queryResult = await QueryService.queryDocuments({query, type, limit});
+        const queryResult = await QueryService.queryDocuments({query, type, limit, includeMetadata: true});
 
         if (queryResult.message || !queryResult.results || queryResult.results.length === 0) {
             return {
@@ -98,8 +180,12 @@ class SearchService extends Base {
             source: r.source,
             score : Number(r.score)
         }));
+        const contextReferences = queryResult.results.map((r, index) => ({
+            ...references[index],
+            metadata: r.metadata || {}
+        }));
 
-        // 2. Read file contents for context.
+        // 2. Read source contents for context.
         //
         // All source loaders store `metadata.source` as a path relative to `neoRootDir`
         // so the Chroma collection shipped with each neo release remains portable across
@@ -112,25 +198,14 @@ class SearchService extends Base {
         // answers for every `type='src'` / `type='ai-infrastructure'` query. The
         // `path.isAbsolute` short-circuit keeps legacy absolute-path chunks working
         // during the grace period when a consumer has not yet re-synced.
-        const contextPromises = references.map(async (ref, index) => {
-            let content = '';
-
-            const absoluteSource = ref.source && path.isAbsolute(ref.source)
-                ? ref.source
-                : path.resolve(aiConfig.neoRootDir, ref.source || '');
-
-            if (absoluteSource && await fs.pathExists(absoluteSource)) {
-                try {
-                    content = await fs.readFile(absoluteSource, 'utf8');
-                } catch (err) {
-                    logger.warn(`[SearchService] Failed to read file ${absoluteSource}:`, err.message);
-                }
-            }
-
-            if (!content) {
-                content = 'No Content (File missing or empty)';
-                logger.warn(`[SearchService] Empty context for ref.source="${ref.source}" (resolved to "${absoluteSource}") — chunk content will not reach the synthesis LLM.`);
-            }
+        //
+        // #11636 chooses Q12 Option A (metadata-embedded hydration) for tenant content.
+        // The measured chunk distribution keeps the V1 storage cost acceptable, while
+        // avoiding server-mirror infrastructure. Non-local tenants may use the same
+        // relative `source` strings as Neo itself, so those references hydrate from
+        // metadata.content and never fall through to the host checkout.
+        const contextPromises = contextReferences.map(async (ref, index) => {
+            const content = await this.hydrateReferenceContent(ref);
 
             return `--- DOCUMENT ${index + 1} (${ref.name} from ${ref.source}) ---\n${content}`;
         });

--- a/test/playwright/unit/ai/services/knowledge-base/KnowledgeBase.TenantIsolation.spec.mjs
+++ b/test/playwright/unit/ai/services/knowledge-base/KnowledgeBase.TenantIsolation.spec.mjs
@@ -113,10 +113,20 @@ function createSpyCollection() {
  * `QueryService.queryDocuments` expects (it `JSON.parse`s the field).
  * @returns {{id: String, metadata: Object}}
  */
-function chunk({id, tenantId, source, name, type = 'guide'}) {
+function chunk({id, tenantId, source, name, type = 'guide', content, repoSlug}) {
+    const metadata = {tenantId, source, name, type, inheritanceChain: '[]'};
+
+    if (content) {
+        metadata.content = content;
+    }
+
+    if (repoSlug) {
+        metadata.repoSlug = repoSlug;
+    }
+
     return {
         id,
-        metadata: {tenantId, source, name, type, inheritanceChain: '[]'}
+        metadata
     };
 }
 
@@ -128,9 +138,29 @@ test.describe('KnowledgeBase — fail-closed tenant isolation (#11632)', () => {
 
     // Canonical fixtures: a chunk owned by tenant-a, a private chunk owned by tenant-b, and a
     // curated chunk in the cross-tenant `neo-shared` namespace.
-    const OWN     = chunk({id: 'c-own',     tenantId: 'tenant-a',   source: 'kb/tenant-a/Own.md',       name: 'Own'});
-    const FOREIGN = chunk({id: 'c-foreign', tenantId: 'tenant-b',   source: 'kb/tenant-b/Secret.md',    name: 'Secret'});
-    const SHARED  = chunk({id: 'c-shared',  tenantId: 'neo-shared', source: 'kb/neo-shared/Curated.md', name: 'Curated'});
+    const OWN = chunk({
+        id      : 'c-own',
+        tenantId: 'tenant-a',
+        repoSlug: 'tenant-app',
+        source  : 'kb/tenant-a/Own.md',
+        name    : 'Own',
+        content : 'TENANT_A_VISIBLE_CONTENT'
+    });
+    const FOREIGN = chunk({
+        id      : 'c-foreign',
+        tenantId: 'tenant-b',
+        repoSlug: 'tenant-app',
+        source  : 'kb/tenant-b/Secret.md',
+        name    : 'Secret',
+        content : 'TENANT_B_SECRET_CONTENT'
+    });
+    const SHARED = chunk({
+        id      : 'c-shared',
+        tenantId: 'neo-shared',
+        repoSlug: 'neo',
+        source  : 'kb/neo-shared/Curated.md',
+        name    : 'Curated'
+    });
 
     test.beforeAll(async () => {
         ChromaManager        = (await import('../../../../../../ai/services/knowledge-base/ChromaManager.mjs')).default;
@@ -270,6 +300,25 @@ test.describe('KnowledgeBase — fail-closed tenant isolation (#11632)', () => {
         const refSources = result.references.map(r => r.source);
         expect(refSources).toContain(SHARED.metadata.source);
         expect(refSources).not.toContain(FOREIGN.metadata.source);
+    });
+
+    test('case 7b — search hydration feeds tenant-owned metadata content to synthesis', async () => {
+        let capturedPrompt = null;
+
+        SearchService.model = {
+            generateContent: async (prompt) => {
+                capturedPrompt = prompt;
+                return {response: {text: () => 'stub-synthesis'}};
+            }
+        };
+
+        const result = await RequestContextService.run({userId: 'tenant-a'}, () =>
+            SearchService.ask({query: 'anything', type: 'all'})
+        );
+
+        expect(result.references.map(r => r.source)).toContain(OWN.metadata.source);
+        expect(capturedPrompt).toContain('TENANT_A_VISIBLE_CONTENT');
+        expect(capturedPrompt).not.toContain('TENANT_B_SECRET_CONTENT');
     });
 
     test.describe('case 8 — every public KB facade respects the tenant boundary', () => {

--- a/test/playwright/unit/ai/services/knowledge-base/QueryService.queryDocuments.spec.mjs
+++ b/test/playwright/unit/ai/services/knowledge-base/QueryService.queryDocuments.spec.mjs
@@ -124,4 +124,39 @@ test.describe('Neo.ai.services.knowledge-base.QueryService#queryDocuments', () =
         expect(result.results.map(item => item.source)).toContain('src/button/Base.mjs');
         expect(result.results.map(item => item.source)).toContain('src/component/Base.mjs');
     });
+
+    test('returns ranked metadata only when internal hydration callers request it', async () => {
+        const capture = {};
+        installQueryStub([{
+            source          : 'tenant-app/src/Foo.mjs',
+            type            : 'src',
+            name            : 'Foo',
+            className       : 'Foo',
+            content         : 'TENANT_METADATA_CONTENT',
+            repoSlug        : 'tenant-app',
+            tenantId        : 'tenant-a',
+            inheritanceChain: '[]'
+        }], capture);
+
+        const publicResult = await QueryService.queryDocuments({
+            query: 'foo',
+            type : 'src',
+            limit: 5
+        });
+
+        expect(publicResult.results[0]).not.toHaveProperty('metadata');
+
+        const internalResult = await QueryService.queryDocuments({
+            query          : 'foo',
+            type           : 'src',
+            limit          : 5,
+            includeMetadata: true
+        });
+
+        expect(internalResult.results[0].metadata).toMatchObject({
+            content : 'TENANT_METADATA_CONTENT',
+            repoSlug: 'tenant-app',
+            tenantId: 'tenant-a'
+        });
+    });
 });

--- a/test/playwright/unit/ai/services/knowledge-base/SearchService.spec.mjs
+++ b/test/playwright/unit/ai/services/knowledge-base/SearchService.spec.mjs
@@ -115,6 +115,96 @@ test.describe('Neo.ai.services.knowledge-base.SearchService', () => {
         expect(capturedPrompt).not.toContain('No Content (File missing or empty)');
     });
 
+    test('ask hydrates non-local tenant references from embedded metadata content', async () => {
+        let capturedPrompt = null;
+
+        QueryService.queryDocuments = async () => ({
+            topResult: tmpFileRelativeToRoot,
+            results  : [{
+                source  : tmpFileRelativeToRoot,
+                score   : '777',
+                metadata: {
+                    content : 'TENANT_EMBEDDED_CONTENT_from_metadata',
+                    repoSlug: 'tenant-app',
+                    tenantId: 'tenant-a'
+                }
+            }]
+        });
+
+        SearchService.model = {
+            generateContent: async (prompt) => {
+                capturedPrompt = prompt;
+                return {response: {text: () => 'mocked-answer'}};
+            }
+        };
+
+        const result = await SearchService.ask({query: 'tenant fixture query', type: 'src'});
+
+        expect(result.answer).toBe('mocked-answer');
+        expect(result.references[0]).not.toHaveProperty('metadata');
+        expect(capturedPrompt).toContain('TENANT_EMBEDDED_CONTENT_from_metadata');
+        expect(capturedPrompt).not.toContain(tmpFileContents);
+    });
+
+    test('ask keeps default Neo references hydrated from the local checkout', async () => {
+        let capturedPrompt = null;
+
+        QueryService.queryDocuments = async () => ({
+            topResult: tmpFileRelativeToRoot,
+            results  : [{
+                source  : tmpFileRelativeToRoot,
+                score   : '777',
+                metadata: {
+                    content : 'STALE_METADATA_CONTENT_should_not_win_for_default_neo',
+                    repoSlug: 'neo',
+                    tenantId: 'neo-shared'
+                }
+            }]
+        });
+
+        SearchService.model = {
+            generateContent: async (prompt) => {
+                capturedPrompt = prompt;
+                return {response: {text: () => 'mocked-answer'}};
+            }
+        };
+
+        const result = await SearchService.ask({query: 'default fixture query', type: 'src'});
+
+        expect(result.answer).toBe('mocked-answer');
+        expect(capturedPrompt).toContain(tmpFileContents);
+        expect(capturedPrompt).not.toContain('STALE_METADATA_CONTENT_should_not_win_for_default_neo');
+    });
+
+    test('ask refuses neoRootDir fallback for non-local tenant references without embedded content', async () => {
+        let capturedPrompt = null;
+
+        QueryService.queryDocuments = async () => ({
+            topResult: tmpFileRelativeToRoot,
+            results  : [{
+                source  : tmpFileRelativeToRoot,
+                score   : '777',
+                metadata: {
+                    repoSlug: 'tenant-app',
+                    tenantId: 'tenant-a'
+                }
+            }]
+        });
+
+        SearchService.model = {
+            generateContent: async (prompt) => {
+                capturedPrompt = prompt;
+                return {response: {text: () => 'mocked-answer'}};
+            }
+        };
+
+        const result = await SearchService.ask({query: 'tenant missing content query', type: 'src'});
+
+        expect(result.answer).toBe('mocked-answer');
+        expect(capturedPrompt).toContain('No Content (File missing or empty)');
+        expect(capturedPrompt).not.toContain(tmpFileContents);
+    });
+
     test('ask logs a warning and falls back to placeholder when the resolved path does not exist', async () => {
         let capturedPrompt = null;
 


### PR DESCRIPTION
Resolves #11636

Authored by GPT-5.5 (Codex Desktop). Session 019e44ba-d309-7e91-a819-36911fbf4e10.

FAIR-band: over-target [17/30] — taking this lane despite over-target because the operator reopened lane pickup, @neo-opus-4-7 is already on #11635, and #11636 blocks Phase 2 retrieval hydration.

Implements Q12 Option A for `SearchService`: tenant-owned search results hydrate from `metadata.content`, while local Neo / `neo-shared` results keep the existing `neoRootDir` filesystem path so agents see the current checkout.

Evidence: L2 (mocked Chroma collection + RequestContextService + QueryService/SearchService synthesis-prompt integration tests) → L2 required (service-level tenant retrieval and hydration ACs). No residuals.

## Deltas from ticket

- Chose Q12 Option A based on the measured chunk-size overlay already posted on #11636: median 481 bytes, p95 8,168 bytes, p99 22,442 bytes, max 87,398 bytes.
- Kept `QueryService.queryDocuments()` metadata opt-in via `includeMetadata`, preserving the public `query_documents` shape unless an internal hydration caller asks for metadata.
- Kept public `SearchService.ask()` references metadata-free; metadata content is used only for synthesis context hydration.
- Added a fail-closed guard: non-local tenant/repo results without embedded content do not fall through to the host checkout.

## Test Evidence

- `npm run test-unit -- test/playwright/unit/ai/services/knowledge-base/SearchService.spec.mjs test/playwright/unit/ai/services/knowledge-base/QueryService.queryDocuments.spec.mjs`
- `npm run test-unit -- test/playwright/unit/ai/services/knowledge-base/KnowledgeBase.TenantIsolation.spec.mjs`
- `npm run test-unit -- test/playwright/unit/ai/services/knowledge-base/SearchService.spec.mjs test/playwright/unit/ai/services/knowledge-base/QueryService.queryDocuments.spec.mjs test/playwright/unit/ai/services/knowledge-base/KnowledgeBase.TenantIsolation.spec.mjs` — 26 passed
- `git diff --check`
- `git diff --cached --check`
- FAIR verifier: `gh search prs --merged --repo neomjs/neo --limit 30 --sort updated --json author --jq '.[].author.login'` → GPT 17/30, Opus 13/30

## Post-Merge Validation

- [ ] Once Phase 2C tenant ingest surfaces a real tenant corpus, run live `ask_knowledge_base` against tenant content to confirm the metadata-hydration path outside the spy collection.

## Commits

- `8c6bd9c39` — `fix(kb): hydrate tenant search results from metadata (#11636)`

## Evolution

During implementation, the sandman_handoff / Golden Path closed-Discussion suspicion was verified as a separate downstream graph-state bug and filed as #11693. That is intentionally out of scope for this PR.
