### PR TITLE
fix(ai): preserve discussion lifecycle state (#11693)

### DIFF
--- a/ai/daemons/services/IssueIngestor.mjs
+++ b/ai/daemons/services/IssueIngestor.mjs
@@ -305,20 +305,36 @@ class IssueIngestor extends Base {
                         }
                         const discussionId = `discussion-${id}`;
 
+                        // DiscussionSyncer emits lifecycle metadata; Golden Path OPEN filtering relies on graph state.
+                        const
+                            closed          = meta.closed === true,
+                            discussionState = closed ? 'CLOSED' : 'OPEN',
+                            closedAt        = closed ? (meta.closedAt || null) : null,
+                            category        = meta.category || 'Ideas';
+
                         GraphService.upsertNode({
                             id: discussionId,
                             type: 'DISCUSSION',
                             name: meta.title || discussionId,
-                            state: 'OPEN', // Discussions are treated as perpetually open for semantic traversal
+                            state: discussionState,
                             updatedAt: meta.updatedAt || meta.createdAt,
-                            category: meta.category || 'Ideas'
+                            properties: {
+                                state: discussionState,
+                                closed,
+                                closedAt,
+                                category
+                            }
                         });
 
                         const body = content.replace(/^---\n[\s\S]*?\n---\n/, '').trim();
                         const titleAndBody = `[DISCUSSION] ${meta.title}\n\n${body}`;
 
                         if (nodesCollection) {
-                            const contentHash = crypto.createHash('md5').update(titleAndBody).digest('hex');
+                            const
+                                lifecycleFingerprint = JSON.stringify({closed, closedAt, discussionState}),
+                                contentHash = crypto.createHash('md5')
+                                    .update(`${titleAndBody}\n${lifecycleFingerprint}`)
+                                    .digest('hex');
                             let needsEmbedding = true;
 
                             try {
@@ -336,7 +352,15 @@ class IssueIngestor extends Base {
                                 await nodesCollection.upsert({
                                     ids: [discussionId],
                                     documents: [titleAndBody],
-                                    metadatas: [{ hash: contentHash, title: meta.title, type: 'DISCUSSION' }]
+                                    metadatas: [{
+                                        hash: contentHash,
+                                        title: meta.title,
+                                        type: 'DISCUSSION',
+                                        state: discussionState,
+                                        closed,
+                                        closedAt,
+                                        category
+                                    }]
                                 });
                             }
                         }

--- a/test/playwright/unit/ai/daemons/services/GoldenPathSynthesizer.spec.mjs
+++ b/test/playwright/unit/ai/daemons/services/GoldenPathSynthesizer.spec.mjs
@@ -178,4 +178,58 @@ test.describe('Neo.ai.daemons.services.GoldenPathSynthesizer', () => {
             TextEmbeddingService.embedText     = originalEmbedText;
         }
     });
+
+    test('synthesizeGoldenPath excludes CLOSED discussion nodes from computed recommendations', async () => {
+        const originalGetGraphCollection   = StorageRouter.getGraphCollection;
+        const originalGetSummaryCollection = StorageRouter.getSummaryCollection;
+        const originalEmbedText            = TextEmbeddingService.embedText;
+        const originalFetchOpenPRs         = GoldenPathSynthesizer.fetchOpenPRs;
+        const OpenAiCompatible             = (await import('../../../../../../ai/provider/OpenAiCompatible.mjs')).default;
+        const originalGenerate             = OpenAiCompatible.prototype.generate;
+
+        aiConfig.vectorDimension = 2;
+
+        const openId   = `discussion-open-${Date.now()}`;
+        const closedId = `discussion-closed-${Date.now()}`;
+
+        GraphService.upsertNode({
+            id: openId,
+            type: 'DISCUSSION',
+            name: 'Open Discussion Fixture',
+            state: 'OPEN',
+            properties: {state: 'OPEN', title: 'Open Discussion Fixture'}
+        });
+        GraphService.upsertNode({
+            id: closedId,
+            type: 'DISCUSSION',
+            name: 'Closed Discussion Fixture',
+            state: 'CLOSED',
+            properties: {state: 'CLOSED', title: 'Closed Discussion Fixture', closed: true}
+        });
+
+        StorageRouter.getGraphCollection = async () => ({
+            query: async () => ({ ids: [[openId, closedId]], distances: [[0.1, 0.01]] })
+        });
+        StorageRouter.getSummaryCollection = async () => ({
+            get: async () => ({documents: ['mock document']})
+        });
+        TextEmbeddingService.embedText      = async () => [0.1, 0.2];
+        GoldenPathSynthesizer.fetchOpenPRs  = async () => [];
+        OpenAiCompatible.prototype.generate = async () => ({content: '{"strategic_brief":"stub"}'});
+
+        try {
+            await GoldenPathSynthesizer.synthesizeGoldenPath();
+        } finally {
+            StorageRouter.getGraphCollection   = originalGetGraphCollection;
+            StorageRouter.getSummaryCollection = originalGetSummaryCollection;
+            TextEmbeddingService.embedText     = originalEmbedText;
+            GoldenPathSynthesizer.fetchOpenPRs = originalFetchOpenPRs;
+            OpenAiCompatible.prototype.generate  = originalGenerate;
+        }
+
+        const handoffContent = fs.readFileSync(tmpHandoffFile, 'utf-8');
+
+        expect(handoffContent).toContain(openId);
+        expect(handoffContent).not.toContain(closedId);
+    });
 });

--- a/test/playwright/unit/ai/daemons/services/IssueIngestor.spec.mjs
+++ b/test/playwright/unit/ai/daemons/services/IssueIngestor.spec.mjs
@@ -20,34 +20,65 @@ const repoRoot   = path.resolve(__dirname, '../../../../../../..');
 
 test.describe('Neo.ai.daemons.services.IssueIngestor', () => {
     let IssueIngestor;
+    let StorageRouter;
     let _originalExistsSync;
     let _originalReaddir;
     let _originalReadFile;
+    let _originalGetGraphCollection;
     let GraphService;
     let _originalGraphDb;
+    let graphNodes;
 
     // We will use a mock index.json and mock markdown files
     const mockIndexMap = [
         { type: 'issues', id: 2001, path: 'issues/issue-2001.md' },
-        { type: 'issues', id: 2002, path: 'archive/issues/v1.0.0/issue-2002.md' }
+        { type: 'issues', id: 2002, path: 'archive/issues/v1.0.0/issue-2002.md' },
+        { type: 'discussions', id: 3001, path: 'discussions/discussion-3001.md' },
+        { type: 'discussions', id: 3002, path: 'discussions/discussion-3002.md' }
     ];
 
     const mockFiles = {
         'resources/content/issues/issue-2001.md': '---\nstate: OPEN\n---\n# Active Issue',
         'resources/content/archive/issues/v1.0.0/issue-2002.md': '---\nstate: CLOSED\n---\n# Archive Issue',
+        'resources/content/discussions/discussion-3001.md': [
+            '---',
+            'number: 3001',
+            'title: Open Discussion',
+            'category: Ideas',
+            "createdAt: '2026-05-20T10:00:00Z'",
+            "updatedAt: '2026-05-20T11:00:00Z'",
+            'closed: false',
+            '---',
+            '# Open Discussion Body'
+        ].join('\n'),
+        'resources/content/discussions/discussion-3002.md': [
+            '---',
+            'number: 3002',
+            'title: Closed Discussion',
+            'category: Q&A',
+            "createdAt: '2026-05-19T10:00:00Z'",
+            "updatedAt: '2026-05-20T11:00:00Z'",
+            'closed: true',
+            "closedAt: '2026-05-20T12:00:00Z'",
+            '---',
+            '# Closed Discussion Body'
+        ].join('\n'),
         'resources/content/_index.json': JSON.stringify(mockIndexMap)
     };
 
     test.beforeAll(async () => {
         IssueIngestor = (await import('../../../../../../ai/daemons/services/IssueIngestor.mjs')).default;
-        GraphService = (await import('../../../../../../ai/services.mjs')).Memory_GraphService;
+        const services = await import('../../../../../../ai/services.mjs');
+        GraphService   = services.Memory_GraphService;
+        StorageRouter  = services.Memory_StorageRouter;
 
         _originalGraphDb = GraphService.db;
+        _originalGetGraphCollection = StorageRouter.getGraphCollection;
         GraphService.db = {
             nodes: { get: () => null },
             edges: { items: [] },
             getAdjacentNodes: () => {},
-            addNode: () => {},
+            addNode: node => graphNodes.push(node),
             updateNode: () => {}
         };
 
@@ -72,6 +103,12 @@ test.describe('Neo.ai.daemons.services.IssueIngestor', () => {
             if (typeof dirPath === 'string' && dirPath.includes('resources/content/archive/issues')) {
                 return ['v1.0.0/issue-2002.md'];
             }
+            if (typeof dirPath === 'string' && dirPath.includes('resources/content/archive/discussions')) {
+                return [];
+            }
+            if (typeof dirPath === 'string' && dirPath.includes('resources/content/discussions')) {
+                return ['discussion-3001.md', 'discussion-3002.md'];
+            }
             if (typeof dirPath === 'string' && dirPath.includes('resources/content/issues')) {
                 return ['issue-2001.md'];
             }
@@ -95,18 +132,23 @@ test.describe('Neo.ai.daemons.services.IssueIngestor', () => {
         };
     });
 
+    test.beforeEach(() => {
+        graphNodes = [];
+    });
+
     test.afterAll(() => {
         fs.existsSync = _originalExistsSync;
         fs.promises.readdir = _originalReaddir;
         fs.promises.readFile = _originalReadFile;
+        if (StorageRouter) {
+            StorageRouter.getGraphCollection = _originalGetGraphCollection;
+        }
         if (GraphService) {
             GraphService.db = _originalGraphDb;
         }
     });
 
     test('ingestIssueStates() maps issues correctly through _index.json', async () => {
-        const { Memory_StorageRouter: StorageRouter } = await import('../../../../../../ai/services.mjs');
-        const _originalGetGraphCollection = StorageRouter.getGraphCollection;
         StorageRouter.getGraphCollection = async () => ({
             upsert: async () => {},
             get: async () => ({ ids: [], metadatas: [], documents: [] }),
@@ -124,5 +166,45 @@ test.describe('Neo.ai.daemons.services.IssueIngestor', () => {
         } finally {
             StorageRouter.getGraphCollection = _originalGetGraphCollection;
         }
+    });
+
+    test('ingestDiscussionStates() maps closed frontmatter into graph and vector lifecycle metadata', async () => {
+        const upserts = [];
+
+        StorageRouter.getGraphCollection = async () => ({
+            upsert: async payload => upserts.push(payload),
+            get: async () => ({ ids: [], metadatas: [], documents: [] })
+        });
+
+        try {
+            await IssueIngestor.ingestDiscussionStates();
+        } finally {
+            StorageRouter.getGraphCollection = _originalGetGraphCollection;
+        }
+
+        const openNode   = graphNodes.find(node => node.id === 'discussion-3001');
+        const closedNode = graphNodes.find(node => node.id === 'discussion-3002');
+
+        expect(openNode.properties).toMatchObject({
+            state   : 'OPEN',
+            closed  : false,
+            closedAt: null,
+            category: 'Ideas'
+        });
+        expect(closedNode.properties).toMatchObject({
+            state   : 'CLOSED',
+            closed  : true,
+            closedAt: '2026-05-20T12:00:00Z',
+            category: 'Q&A'
+        });
+
+        const closedUpsert = upserts.find(payload => payload.ids[0] === 'discussion-3002');
+        expect(closedUpsert.metadatas[0]).toMatchObject({
+            type    : 'DISCUSSION',
+            state   : 'CLOSED',
+            closed  : true,
+            closedAt: '2026-05-20T12:00:00Z',
+            category: 'Q&A'
+        });
     });
 });


### PR DESCRIPTION
Authored by GPT-5 (Codex Desktop). Session d13c94dd-e721-4e28-ac9e-4d0b3c0f66de.

FAIR-band: over-target [17/30] - taking this lane despite over-target because @tobiu called #11693 high ROI for Golden Path correctness, @neo-opus-4-7 already owns #11635, @neo-gemini-3-1-pro routing is suppressed, and the change is narrow bug containment.

Resolves #11693

Maps synced Discussion `closed`/`closedAt` frontmatter into the graph projection instead of forcing every Discussion OPEN, carries lifecycle metadata into the graph vector collection, and adds focused coverage that CLOSED Discussion candidates are filtered out of Golden Path recommendations while OPEN Discussions still survive.

Evidence: L2 (focused daemon unit tests verify IssueIngestor graph/vector lifecycle metadata and GoldenPathSynthesizer exclusion of CLOSED Discussion nodes) -> L3 required (AC5 existing graph nodes corrected after next graph ingestion / Sandman run). Residual: AC5 [#11693].

## Deltas from ticket
- No GoldenPathSynthesizer production logic change was needed; the existing OPEN-state SQL filter was correct once IssueIngestor stops forcing Discussion state to OPEN.
- Lifecycle fields are included in the vector content hash so closed/open transitions refresh metadata even when Discussion body text is unchanged.

## Test Evidence
- `git diff --check` - passed before rebase.
- `git diff --check origin/dev...HEAD` - passed after rebase.
- `npm run test-unit -- test/playwright/unit/ai/daemons/services/IssueIngestor.spec.mjs test/playwright/unit/ai/daemons/services/GoldenPathSynthesizer.spec.mjs` - 5 passed (796ms) before rebase; 5 passed (839ms) after rebase.

## Post-Merge Validation
- [ ] Run the next graph ingestion / Sandman cycle and verify `discussion-11168` and `discussion-10520` no longer appear as OPEN actionable Golden Path candidates.

## Commit
- `12928fd19` - `fix(ai): preserve discussion lifecycle state (#11693)`