### PR TITLE
fix(github-workflow): support PR labels (#10077)

### DIFF
--- a/ai/services/github-workflow/IssueService.mjs
+++ b/ai/services/github-workflow/IssueService.mjs
@@ -1068,7 +1068,7 @@ class IssueService extends Base {
     }
 
     /**
-     * Fetches the GraphQL node IDs for an issue and a set of labels.
+     * Fetches the GraphQL node IDs for an issue or pull request and a set of labels.
      * @param {number}   issueNumber The number of the issue or PR.
      * @param {string[]} labelNames  An array of label names.
      * @returns {Promise<{labelableId: string, labelIds: string[]}>} The node IDs.
@@ -1084,15 +1084,16 @@ class IssueService extends Base {
 
         const data = await GraphqlService.query(GET_ISSUE_AND_LABEL_IDS, variables);
 
-        const labelableId = data.repository.issue.id;
-        const repoLabels = data.repository.labels.nodes;
-        const labelIds = labelNames.map(name => {
-            const label = repoLabels.find(l => l.name === name);
-            return label ? label.id : null;
-        }).filter(Boolean);
+        const
+            labelableId = data.repository.issue?.id || data.repository.pullRequest?.id,
+            repoLabels   = data.repository.labels.nodes,
+            labelIds     = labelNames.map(name => {
+                const label = repoLabels.find(l => l.name === name);
+                return label ? label.id : null;
+            }).filter(Boolean);
 
         if (!labelableId || labelIds.length !== labelNames.length) {
-            throw new Error(`Could not find issue #${issueNumber} or one of the labels: ${labelNames.join(', ')}`);
+            throw new Error(`Could not find issue or pull request #${issueNumber} or one of the labels: ${labelNames.join(', ')}`);
         }
 
         return { labelableId, labelIds };

--- a/ai/services/github-workflow/queries/issueQueries.mjs
+++ b/ai/services/github-workflow/queries/issueQueries.mjs
@@ -786,7 +786,7 @@ export const GET_BLOCKED_BY = `
 `;
 
 /**
- * Fetches the GraphQL node ID for an issue and all labels in the repository.
+ * Fetches the GraphQL Labelable node ID for an issue or pull request and all labels in the repository.
  * This is a utility query used by mutations that add/remove labels.
  *
  * Variables required:
@@ -799,6 +799,9 @@ export const GET_ISSUE_AND_LABEL_IDS = `
     query GetIssueAndLabelIds($owner: String!, $repo: String!, $issueNumber: Int!, $maxLabels: Int!) {
         repository(owner: $owner, name: $repo) {
             issue(number: $issueNumber) {
+                id
+            }
+            pullRequest(number: $issueNumber) {
                 id
             }
             labels(first: $maxLabels) {

--- a/test/playwright/unit/ai/services/github-workflow/IssueService.spec.mjs
+++ b/test/playwright/unit/ai/services/github-workflow/IssueService.spec.mjs
@@ -269,6 +269,197 @@ test.describe('Neo.ai.services.github-workflow.IssueService — manageIssueComme
 });
 
 /**
+ * @summary Contract coverage for `IssueService.manageIssueLabels` issue-or-PR labelable lookup (#10077).
+ *
+ * `manage_issue_labels` advertises an `issue_number` path parameter that can target either a
+ * GitHub Issue or Pull Request. GitHub GraphQL models those as distinct fields, but both implement
+ * the `Labelable` interface consumed by `addLabelsToLabelable` / `removeLabelsFromLabelable`.
+ * These tests lock the dual lookup so PR labels do not regress to an Issue-only query path.
+ *
+ * @see Neo.ai.services.github-workflow.IssueService#manageIssueLabels
+ */
+test.describe('Neo.ai.services.github-workflow.IssueService — manageIssueLabels (#10077)', () => {
+    let IssueService;
+    let GraphqlService;
+    let originalQuery;
+
+    const repoLabels = [
+        {id: 'LA_bug', name: 'bug'},
+        {id: 'LA_ai',  name: 'ai'}
+    ];
+
+    test.beforeAll(async () => {
+        GraphqlService = (await import('../../../../../../ai/services/github-workflow/GraphqlService.mjs')).default;
+        IssueService   = (await import('../../../../../../ai/services/github-workflow/IssueService.mjs')).default;
+
+        originalQuery = GraphqlService.query.bind(GraphqlService);
+    });
+
+    test.afterAll(() => {
+        GraphqlService.query = originalQuery;
+    });
+
+    test('adds labels to an Issue using the issue Labelable id', async () => {
+        const ISSUE_NODE_ID = 'I_kwDOABcD_issue10077';
+        let callCount       = 0;
+
+        GraphqlService.query = async (query, variables) => {
+            callCount++;
+            if (callCount === 1) {
+                expect(variables.issueNumber).toBe(10077);
+                return {
+                    repository: {
+                        issue      : {id: ISSUE_NODE_ID},
+                        pullRequest: null,
+                        labels     : {nodes: repoLabels}
+                    }
+                };
+            }
+            if (callCount === 2) {
+                expect(variables).toEqual({
+                    labelableId: ISSUE_NODE_ID,
+                    labelIds   : ['LA_bug', 'LA_ai']
+                });
+                return {addLabelsToLabelable: {clientMutationId: null}};
+            }
+            throw new Error(`Unexpected additional GraphqlService.query call: ${callCount}`);
+        };
+
+        const result = await IssueService.manageIssueLabels({
+            issue_number: 10077,
+            action      : 'add',
+            labels      : ['bug', 'ai']
+        });
+
+        expect(result.message).toContain('Successfully added labels');
+        expect(callCount).toBe(2);
+    });
+
+    test('adds labels to a Pull Request using the pullRequest Labelable id', async () => {
+        const PR_NODE_ID = 'PR_kwDOABcD_pr11695';
+        let callCount    = 0;
+
+        GraphqlService.query = async (query, variables) => {
+            callCount++;
+            if (callCount === 1) {
+                expect(variables.issueNumber).toBe(11695);
+                return {
+                    repository: {
+                        issue      : null,
+                        pullRequest: {id: PR_NODE_ID},
+                        labels     : {nodes: repoLabels}
+                    }
+                };
+            }
+            if (callCount === 2) {
+                expect(variables).toEqual({
+                    labelableId: PR_NODE_ID,
+                    labelIds   : ['LA_ai']
+                });
+                return {addLabelsToLabelable: {clientMutationId: null}};
+            }
+            throw new Error(`Unexpected additional GraphqlService.query call: ${callCount}`);
+        };
+
+        const result = await IssueService.manageIssueLabels({
+            issue_number: 11695,
+            action      : 'add',
+            labels      : ['ai']
+        });
+
+        expect(result.message).toContain('Successfully added labels');
+        expect(callCount).toBe(2);
+    });
+
+    test('removes labels from a Pull Request using the pullRequest Labelable id', async () => {
+        const PR_NODE_ID = 'PR_kwDOABcD_pr11695';
+        let callCount    = 0;
+
+        GraphqlService.query = async (query, variables) => {
+            callCount++;
+            if (callCount === 1) {
+                return {
+                    repository: {
+                        issue      : null,
+                        pullRequest: {id: PR_NODE_ID},
+                        labels     : {nodes: repoLabels}
+                    }
+                };
+            }
+            if (callCount === 2) {
+                expect(variables).toEqual({
+                    labelableId: PR_NODE_ID,
+                    labelIds   : ['LA_bug']
+                });
+                return {removeLabelsFromLabelable: {clientMutationId: null}};
+            }
+            throw new Error(`Unexpected additional GraphqlService.query call: ${callCount}`);
+        };
+
+        const result = await IssueService.manageIssueLabels({
+            issue_number: 11695,
+            action      : 'remove',
+            labels      : ['bug']
+        });
+
+        expect(result.message).toContain('Successfully removed labels');
+        expect(callCount).toBe(2);
+    });
+
+    test('returns a structured GraphQL error when neither issue nor Pull Request exists', async () => {
+        let callCount = 0;
+
+        GraphqlService.query = async () => {
+            callCount++;
+            return {
+                repository: {
+                    issue      : null,
+                    pullRequest: null,
+                    labels     : {nodes: repoLabels}
+                }
+            };
+        };
+
+        const result = await IssueService.manageIssueLabels({
+            issue_number: 999999,
+            action      : 'add',
+            labels      : ['bug']
+        });
+
+        expect(result.error).toBe('GraphQL API request failed');
+        expect(result.code).toBe('GRAPHQL_API_ERROR');
+        expect(result.message).toContain('issue or pull request #999999');
+        expect(callCount).toBe(1);
+    });
+
+    test('returns a structured GraphQL error when a requested label is missing', async () => {
+        let callCount = 0;
+
+        GraphqlService.query = async () => {
+            callCount++;
+            return {
+                repository: {
+                    issue      : {id: 'I_kwDOABcD_issue10077'},
+                    pullRequest: null,
+                    labels     : {nodes: repoLabels}
+                }
+            };
+        };
+
+        const result = await IssueService.manageIssueLabels({
+            issue_number: 10077,
+            action      : 'add',
+            labels      : ['missing-label']
+        });
+
+        expect(result.error).toBe('GraphQL API request failed');
+        expect(result.code).toBe('GRAPHQL_API_ERROR');
+        expect(result.message).toContain('missing-label');
+        expect(callCount).toBe(1);
+    });
+});
+
+/**
  * @summary Contract coverage for `IssueService.manageIssueProjects` ProjectV2 membership surface (#11233 Phase 1).
  *
  * `manage_issue_projects` is the substrate-correct replacement for the deprecated `release:v*`


### PR DESCRIPTION
Authored by GPT-5 (Codex Desktop). Session d13c94dd-e721-4e28-ac9e-4d0b3c0f66de.

FAIR-band: over-target [17/30] - taking this lane despite over-target because @tobiu explicitly asked for two parallel lanes while Claude reviewed #11695, Gemini routing remains suppressed, and #10077 is a narrow unassigned MCP workflow bug that removes a fallback-to-gh friction path.

Resolves #10077

`manage_issue_labels` already advertised issue-or-pull-request support in `openapi.yaml`, but its ID lookup only queried `repository.issue(number)`. This PR keeps the existing Labelable mutation path and expands the lookup query to fetch `repository.pullRequest(number)` too, then selects whichever Labelable node exists before applying label add/remove mutations.

Evidence: L2 (focused Playwright unit contract tests for issue add, PR add, PR remove, missing target, and missing label) -> L2 required (GraphQL Labelable lookup contract). No residuals.

## Deltas from ticket
- No `openapi.yaml` change: the advertised tool shape already said issue or pull request; the runtime lookup now matches that contract.
- The fix uses one GraphQL lookup containing both `issue` and `pullRequest` fields rather than a second fallback round-trip.

## Test Evidence
- `git diff --check` - passed.
- `git diff --check origin/dev...HEAD` - passed.
- `npm run test-unit -- test/playwright/unit/ai/services/github-workflow/IssueService.spec.mjs` - 25 passed (758ms).

## Post-Merge Validation
- [ ] Optional live smoke: call `manage_issue_labels` against a fresh PR number to add/remove a harmless existing label, replacing the old `gh pr edit --add-label` fallback.

## Commit
- `4e7ff3a8c` - `fix(github-workflow): support PR labels (#10077)`