### PR TITLE
feat(kb): add ai:ingest-tenant bulk-facade CLI (#11635)

### DIFF
--- a/ai/services/knowledge-base/KnowledgeBaseIngestionService.mjs
+++ b/ai/services/knowledge-base/KnowledgeBaseIngestionService.mjs
@@ -98,6 +98,11 @@ class KnowledgeBaseIngestionService extends Base {
      * @param {Object} [payload.manifestSnapshot] Post-push manifest (`{repoSlug, pathsAfterPush}`).
      * @param {String} [payload.baseRevision] Previous revision boundary.
      * @param {String} [payload.headRevision] Current revision boundary.
+     * @param {Boolean} [payload.viaMcp=true] Caller-selected work-volume-gate mode (#11635 Phase 2C).
+     *                                        Omitted / truthy → MCP-safe: the #10572 gate in
+     *                                        `VectorService.embed` applies. Explicit `false` (the
+     *                                        `ai:ingest-tenant` bulk CLI path) bypasses the gate —
+     *                                        opt-in to long-running bulk work.
      * @returns {Promise<{ingested: Number, deleted: Number, embeddingsGenerated: Number, errors: Array, tenantId: String, durationMs: Number}>}
      */
     async ingestSourceFiles(payload = {}) {
@@ -128,7 +133,7 @@ class KnowledgeBaseIngestionService extends Base {
             });
 
             if (chunks.length > 0) {
-                await this.embedChunkGroups({chunks, tenantContext, summary});
+                await this.embedChunkGroups({chunks, tenantContext, summary, viaMcp: payload.viaMcp !== false});
             }
 
             summary.ingested   = chunks.length;
@@ -223,12 +228,15 @@ class KnowledgeBaseIngestionService extends Base {
     }
 
     /**
-     * @summary Groups parsed chunks by repoSlug and routes each group to VectorService.embed().
-     * @param {Object} options
+     * @summary Groups parsed chunks by repoSlug and routes each group to VectorService.embed(),
+     * threading the caller-selected `viaMcp` work-volume-gate mode (#11635 Phase 2C).
+     * @param {Object}  options
+     * @param {Boolean} [options.viaMcp=true] Forwarded to `VectorService.embed`; `true` keeps the
+     *                                        #10572 work-volume gate, `false` (bulk CLI) bypasses it.
      * @returns {Promise<void>}
      * @protected
      */
-    async embedChunkGroups({chunks, tenantContext, summary}) {
+    async embedChunkGroups({chunks, tenantContext, summary, viaMcp = true}) {
         const groups = new Map();
 
         for (const chunk of chunks) {
@@ -246,7 +254,7 @@ class KnowledgeBaseIngestionService extends Base {
                 const result = await this.vectorService.embed(tempFile, {
                     deleteStale  : false,
                     tenantContext: {...tenantContext, repoSlug},
-                    viaMcp       : true
+                    viaMcp
                 });
 
                 if (result?.error) {

--- a/buildScripts/ai/ingestTenant.mjs
+++ b/buildScripts/ai/ingestTenant.mjs
@@ -34,7 +34,7 @@ import {withHeavyMaintenanceLease}  from '../../ai/daemons/services/HeavyMainten
  * units; the CLI auto-runs only when invoked directly (the `import.meta` main guard), so the
  * module can be imported substrate-free by unit tests.
  *
- * Usage: `npm run ai:ingest-tenant <tenantId> (--from-file <path.jsonl> | --from-stdin) [--batch-size <n>]`
+ * Usage: `npm run ai:ingest-tenant -- <tenantId> (--from-file <path.jsonl> | --from-stdin) [--batch-size <n>]`
  *
  * @see https://github.com/neomjs/neo/issues/11635
  * @see https://github.com/neomjs/neo/issues/11624
@@ -74,7 +74,7 @@ function parseArgs(argv) {
  * @returns {void}
  */
 function printUsage() {
-    console.error('Usage: npm run ai:ingest-tenant <tenantId> (--from-file <path.jsonl> | --from-stdin) [--batch-size <n>]');
+    console.error('Usage: npm run ai:ingest-tenant -- <tenantId> (--from-file <path.jsonl> | --from-stdin) [--batch-size <n>]');
 }
 
 /**

--- a/buildScripts/ai/ingestTenant.mjs
+++ b/buildScripts/ai/ingestTenant.mjs
@@ -1,0 +1,204 @@
+// Neo namespace bootstrap (entry-point invariant) — KB data-plane CLI.
+// `InstanceManager` binds Neo.find/findFirst/get aliases + consumes pre-singleton
+// `Neo.idMap`; required for any consumer of the Neo singleton API.
+import Neo                          from '../../src/Neo.mjs';
+import * as core                    from '../../src/core/_export.mjs';
+import InstanceManager              from '../../src/manager/Instance.mjs';
+import fs                           from 'fs';
+import readline                     from 'readline';
+import KB_Config                    from '../../ai/mcp/server/knowledge-base/config.mjs';
+import KB_ChromaManager             from '../../ai/services/knowledge-base/ChromaManager.mjs';
+import KB_IngestionService          from '../../ai/services/knowledge-base/KnowledgeBaseIngestionService.mjs';
+import KB_LifecycleService          from '../../ai/services/knowledge-base/DatabaseLifecycleService.mjs';
+import {withHeavyMaintenanceLease}  from '../../ai/daemons/services/HeavyMaintenanceLeaseService.mjs';
+
+/**
+ * @module buildScripts/ai/ingestTenant
+ *
+ * @summary Phase 2C bulk-facade CLI (`npm run ai:ingest-tenant`) for Cloud-Native KB Ingestion.
+ *
+ * Streams `parsed-chunk-v1` JSONL records (one record per line) from a file or stdin into the
+ * Knowledge Base via {@link Neo.ai.services.knowledge-base.KnowledgeBaseIngestionService}. This is
+ * the bulk data-plane counterpart to the `ingest_source_files` MCP small-batch facade (#11634):
+ * initial tenant onboarding (5k–50k chunks) and large `git push` hook bursts exceed the #10572
+ * MCP work-volume gate (`aiConfig.mcpSyncMaxChunks`), so the CLI calls `ingestSourceFiles` with
+ * `viaMcp: false` — an explicit opt-in to long-running bulk work that bypasses that gate.
+ *
+ * Records are flushed in batches (`--batch-size`, default 500) so a multi-thousand-record push
+ * streams incrementally rather than materializing the whole corpus in memory. The heavy work is
+ * wrapped in the shared heavy-maintenance lease so a bulk ingest cannot collide with `ai:sync-kb`
+ * or the orchestrator's `kbSync` task on the unified Chroma `knowledge-base` collection.
+ *
+ * Usage: `npm run ai:ingest-tenant <tenantId> (--from-file <path.jsonl> | --from-stdin) [--batch-size <n>]`
+ *
+ * @see https://github.com/neomjs/neo/issues/11635
+ * @see https://github.com/neomjs/neo/issues/11624
+ */
+
+const DEFAULT_BATCH_SIZE = 500;
+
+/**
+ * @summary Parses the CLI argv into a structured options object.
+ * @param {String[]} argv `process.argv.slice(2)`.
+ * @returns {{tenantId: String|null, fromFile: String|null, fromStdin: Boolean, batchSize: Number}}
+ */
+function parseArgs(argv) {
+    const args       = {tenantId: null, fromFile: null, fromStdin: false, batchSize: DEFAULT_BATCH_SIZE};
+    const positional = [];
+
+    for (let i = 0; i < argv.length; i++) {
+        const arg = argv[i];
+
+        if (arg === '--from-file') {
+            args.fromFile = argv[++i];
+        } else if (arg === '--from-stdin') {
+            args.fromStdin = true;
+        } else if (arg === '--batch-size') {
+            args.batchSize = Number(argv[++i]);
+        } else if (!arg.startsWith('--')) {
+            positional.push(arg);
+        }
+    }
+
+    args.tenantId = positional[0] || null;
+    return args;
+}
+
+/**
+ * @summary Prints CLI usage to stderr.
+ * @returns {void}
+ */
+function printUsage() {
+    console.error('Usage: npm run ai:ingest-tenant <tenantId> (--from-file <path.jsonl> | --from-stdin) [--batch-size <n>]');
+}
+
+/**
+ * @summary Async-generates `parsed-chunk-v1` records from a JSONL file or stdin, line by line.
+ * @param {Object} args Parsed CLI options.
+ * @yields {{record: Object, lineNo: Number}|{parseError: String, lineNo: Number}}
+ */
+async function* readJsonlRecords(args) {
+    const input = args.fromStdin ? process.stdin : fs.createReadStream(args.fromFile, 'utf8');
+    const rl    = readline.createInterface({input, crlfDelay: Infinity});
+    let lineNo  = 0;
+
+    for await (const line of rl) {
+        lineNo++;
+        const trimmed = line.trim();
+        if (!trimmed) continue;
+
+        try {
+            yield {record: JSON.parse(trimmed), lineNo};
+        } catch (error) {
+            yield {parseError: error.message, lineNo};
+        }
+    }
+}
+
+/**
+ * @summary CLI entry point — streams a tenant's parsed-chunk-v1 JSONL into the Knowledge Base.
+ * @returns {Promise<void>}
+ */
+async function ingestTenant() {
+    const args = parseArgs(process.argv.slice(2));
+
+    if (!args.tenantId || (!args.fromFile && !args.fromStdin) || (args.fromFile && args.fromStdin)) {
+        printUsage();
+        process.exit(1);
+    }
+
+    if (!Number.isInteger(args.batchSize) || args.batchSize < 1) {
+        console.error(`❌ Invalid --batch-size '${args.batchSize}'; must be a positive integer.`);
+        process.exit(1);
+    }
+
+    if (args.fromFile && !fs.existsSync(args.fromFile)) {
+        console.error(`❌ --from-file path does not exist: ${args.fromFile}`);
+        process.exit(1);
+    }
+
+    KB_Config.data.debug = true;
+    console.log(`⏳ ai:ingest-tenant — tenant='${args.tenantId}', source=${args.fromStdin ? 'stdin' : args.fromFile}, batchSize=${args.batchSize}`);
+
+    let outcome;
+
+    try {
+        outcome = await withHeavyMaintenanceLease(
+            async () => {
+                await KB_LifecycleService.ready();
+                await KB_ChromaManager.ready();
+                await KB_IngestionService.ready();
+                console.log('✅ KB services ready. Streaming parsed-chunk-v1 records...');
+
+                const totals = {ingested: 0, embeddingsGenerated: 0, deleted: 0, batches: 0, parseErrors: 0, errors: []};
+                let batch    = [];
+
+                const flushBatch = async () => {
+                    if (batch.length === 0) return;
+
+                    totals.batches++;
+                    const pending = batch;
+                    batch = [];
+
+                    // Bulk path: viaMcp:false bypasses the #10572 work-volume gate (#11635 Phase 2C).
+                    const summary = await KB_IngestionService.ingestSourceFiles({
+                        tenantId: args.tenantId,
+                        files   : pending,
+                        viaMcp  : false
+                    });
+
+                    totals.ingested            += summary.ingested;
+                    totals.embeddingsGenerated += summary.embeddingsGenerated;
+                    totals.deleted             += summary.deleted;
+
+                    if (summary.errors?.length) {
+                        totals.errors.push(...summary.errors);
+                    }
+
+                    console.log(`   batch ${totals.batches}: ${summary.ingested} ingested, ${summary.embeddingsGenerated} embedded` +
+                        (summary.errors?.length ? `, ${summary.errors.length} error(s)` : ''));
+                };
+
+                for await (const {record, parseError, lineNo} of readJsonlRecords(args)) {
+                    if (parseError) {
+                        totals.parseErrors++;
+                        totals.errors.push({
+                            code   : 'KB_INGEST_CLI_JSONL_PARSE_FAILED',
+                            message: `Line ${lineNo}: ${parseError}`
+                        });
+                        continue;
+                    }
+
+                    batch.push(record);
+
+                    if (batch.length >= args.batchSize) {
+                        await flushBatch();
+                    }
+                }
+
+                await flushBatch();
+                return totals;
+            },
+            {owner: 'kbIngest', reason: 'manual-cli', metadata: {script: 'buildScripts/ai/ingestTenant.mjs', tenantId: args.tenantId}}
+        );
+    } catch (error) {
+        console.error('❌ ai:ingest-tenant failed:', error);
+        process.exit(1);
+    }
+
+    if (outcome.status === 'held') {
+        const held = outcome.lease;
+        console.log(`⏸️  Deferred: heavy-maintenance lease held by '${held.owner}' (reason='${held.reason}', pid=${held.pid}). Re-invoke once it completes.`);
+        process.exit(0);
+    }
+
+    const totals = outcome.result;
+    console.log(`✅ ai:ingest-tenant complete — tenant='${args.tenantId}': ${totals.ingested} ingested, ` +
+        `${totals.embeddingsGenerated} embedded, ${totals.deleted} deleted across ${totals.batches} batch(es); ` +
+        `${totals.parseErrors} JSONL parse error(s), ${totals.errors.length} total error(s).`);
+    console.log(JSON.stringify({tenantId: args.tenantId, ...totals}, null, 2));
+
+    process.exit(totals.errors.length > 0 ? 1 : 0);
+}
+
+ingestTenant();

--- a/buildScripts/ai/ingestTenant.mjs
+++ b/buildScripts/ai/ingestTenant.mjs
@@ -6,6 +6,7 @@ import * as core                    from '../../src/core/_export.mjs';
 import InstanceManager              from '../../src/manager/Instance.mjs';
 import fs                           from 'fs';
 import readline                     from 'readline';
+import {pathToFileURL}              from 'url';
 import KB_Config                    from '../../ai/mcp/server/knowledge-base/config.mjs';
 import KB_ChromaManager             from '../../ai/services/knowledge-base/ChromaManager.mjs';
 import KB_IngestionService          from '../../ai/services/knowledge-base/KnowledgeBaseIngestionService.mjs';
@@ -28,6 +29,10 @@ import {withHeavyMaintenanceLease}  from '../../ai/daemons/services/HeavyMainten
  * streams incrementally rather than materializing the whole corpus in memory. The heavy work is
  * wrapped in the shared heavy-maintenance lease so a bulk ingest cannot collide with `ai:sync-kb`
  * or the orchestrator's `kbSync` task on the unified Chroma `knowledge-base` collection.
+ *
+ * `parseArgs`, `readJsonlRecords`, and `runIngest` are exported as pure, dependency-injectable
+ * units; the CLI auto-runs only when invoked directly (the `import.meta` main guard), so the
+ * module can be imported substrate-free by unit tests.
  *
  * Usage: `npm run ai:ingest-tenant <tenantId> (--from-file <path.jsonl> | --from-stdin) [--batch-size <n>]`
  *
@@ -73,14 +78,18 @@ function printUsage() {
 }
 
 /**
- * @summary Async-generates `parsed-chunk-v1` records from a JSONL file or stdin, line by line.
- * @param {Object} args Parsed CLI options.
+ * @summary Async-generates `parsed-chunk-v1` records from a JSONL stream, one record per line.
+ *
+ * Takes the readable stream directly (not a file path) so unit tests can drive it with an
+ * in-memory `Readable`. Blank lines are skipped; a line that fails `JSON.parse` yields a
+ * `parseError` entry instead of throwing, so one malformed line never aborts the stream.
+ *
+ * @param {ReadableStream} input A readable stream of UTF-8 JSONL text (a file stream or stdin).
  * @yields {{record: Object, lineNo: Number}|{parseError: String, lineNo: Number}}
  */
-async function* readJsonlRecords(args) {
-    const input = args.fromStdin ? process.stdin : fs.createReadStream(args.fromFile, 'utf8');
-    const rl    = readline.createInterface({input, crlfDelay: Infinity});
-    let lineNo  = 0;
+async function* readJsonlRecords(input) {
+    const rl   = readline.createInterface({input, crlfDelay: Infinity});
+    let lineNo = 0;
 
     for await (const line of rl) {
         lineNo++;
@@ -93,6 +102,65 @@ async function* readJsonlRecords(args) {
             yield {parseError: error.message, lineNo};
         }
     }
+}
+
+/**
+ * @summary Batches an async stream of parsed records and ingests each batch, aggregating a summary.
+ *
+ * Pure orchestration: `ingestFn` is injected so unit tests can verify batching, error handling,
+ * and summary aggregation without the Knowledge Base substrate. JSONL `parseError` entries are
+ * counted and recorded as structured errors; valid records are flushed in `batchSize` groups.
+ *
+ * @param {Object}        options
+ * @param {AsyncIterable} options.records  Async iterable of `readJsonlRecords` entries.
+ * @param {Number}        options.batchSize Records per `ingestFn` call.
+ * @param {Function}      options.ingestFn `async (files) => summary` — ingests one batch.
+ * @param {Function}     [options.onBatch] `(batchNumber, summary) => void` progress callback.
+ * @returns {Promise<{ingested: Number, embeddingsGenerated: Number, deleted: Number, batches: Number, parseErrors: Number, errors: Array}>}
+ */
+async function runIngest({records, batchSize, ingestFn, onBatch}) {
+    const totals = {ingested: 0, embeddingsGenerated: 0, deleted: 0, batches: 0, parseErrors: 0, errors: []};
+    let batch    = [];
+
+    const flushBatch = async () => {
+        if (batch.length === 0) return;
+
+        totals.batches++;
+        const pending = batch;
+        batch = [];
+
+        const summary = await ingestFn(pending);
+
+        totals.ingested            += summary.ingested            || 0;
+        totals.embeddingsGenerated += summary.embeddingsGenerated || 0;
+        totals.deleted             += summary.deleted             || 0;
+
+        if (summary.errors?.length) {
+            totals.errors.push(...summary.errors);
+        }
+
+        onBatch?.(totals.batches, summary);
+    };
+
+    for await (const {record, parseError, lineNo} of records) {
+        if (parseError) {
+            totals.parseErrors++;
+            totals.errors.push({
+                code   : 'KB_INGEST_CLI_JSONL_PARSE_FAILED',
+                message: `Line ${lineNo}: ${parseError}`
+            });
+            continue;
+        }
+
+        batch.push(record);
+
+        if (batch.length >= batchSize) {
+            await flushBatch();
+        }
+    }
+
+    await flushBatch();
+    return totals;
 }
 
 /**
@@ -130,54 +198,18 @@ async function ingestTenant() {
                 await KB_IngestionService.ready();
                 console.log('✅ KB services ready. Streaming parsed-chunk-v1 records...');
 
-                const totals = {ingested: 0, embeddingsGenerated: 0, deleted: 0, batches: 0, parseErrors: 0, errors: []};
-                let batch    = [];
+                const input = args.fromStdin ? process.stdin : fs.createReadStream(args.fromFile, 'utf8');
 
-                const flushBatch = async () => {
-                    if (batch.length === 0) return;
-
-                    totals.batches++;
-                    const pending = batch;
-                    batch = [];
-
+                return runIngest({
+                    records  : readJsonlRecords(input),
+                    batchSize: args.batchSize,
                     // Bulk path: viaMcp:false bypasses the #10572 work-volume gate (#11635 Phase 2C).
-                    const summary = await KB_IngestionService.ingestSourceFiles({
-                        tenantId: args.tenantId,
-                        files   : pending,
-                        viaMcp  : false
-                    });
-
-                    totals.ingested            += summary.ingested;
-                    totals.embeddingsGenerated += summary.embeddingsGenerated;
-                    totals.deleted             += summary.deleted;
-
-                    if (summary.errors?.length) {
-                        totals.errors.push(...summary.errors);
-                    }
-
-                    console.log(`   batch ${totals.batches}: ${summary.ingested} ingested, ${summary.embeddingsGenerated} embedded` +
-                        (summary.errors?.length ? `, ${summary.errors.length} error(s)` : ''));
-                };
-
-                for await (const {record, parseError, lineNo} of readJsonlRecords(args)) {
-                    if (parseError) {
-                        totals.parseErrors++;
-                        totals.errors.push({
-                            code   : 'KB_INGEST_CLI_JSONL_PARSE_FAILED',
-                            message: `Line ${lineNo}: ${parseError}`
-                        });
-                        continue;
-                    }
-
-                    batch.push(record);
-
-                    if (batch.length >= args.batchSize) {
-                        await flushBatch();
-                    }
-                }
-
-                await flushBatch();
-                return totals;
+                    ingestFn : files => KB_IngestionService.ingestSourceFiles({tenantId: args.tenantId, files, viaMcp: false}),
+                    onBatch  : (batchNumber, summary) => console.log(
+                        `   batch ${batchNumber}: ${summary.ingested} ingested, ${summary.embeddingsGenerated} embedded` +
+                        (summary.errors?.length ? `, ${summary.errors.length} error(s)` : '')
+                    )
+                });
             },
             {owner: 'kbIngest', reason: 'manual-cli', metadata: {script: 'buildScripts/ai/ingestTenant.mjs', tenantId: args.tenantId}}
         );
@@ -201,4 +233,9 @@ async function ingestTenant() {
     process.exit(totals.errors.length > 0 ? 1 : 0);
 }
 
-ingestTenant();
+// Auto-run only when invoked directly as the CLI — not when imported by unit tests.
+if (import.meta.url === pathToFileURL(process.argv[1] || '').href) {
+    ingestTenant();
+}
+
+export {parseArgs, readJsonlRecords, runIngest};

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
         "ai:defrag-memory"             : "node ./buildScripts/ai/defragChromaDB.mjs --target memory-core",
         "ai:defrag-sqlite"             : "node ./buildScripts/ai/defragSQLiteDB.mjs",
         "ai:download-kb"               : "node ./buildScripts/ai/downloadKnowledgeBase.mjs",
+        "ai:ingest-tenant"             : "node ./buildScripts/ai/ingestTenant.mjs",
         "ai:mcp-client"                : "node ./ai/mcp/client/mcp-cli.mjs",
         "ai:mcp-server-file-system"    : "node ./ai/mcp/server/file-system/mcp-server.mjs",
         "ai:mcp-server-github-workflow": "node ./ai/mcp/server/github-workflow/mcp-server.mjs",

--- a/test/playwright/integration/KBBackupRestoreWipe.integration.spec.mjs
+++ b/test/playwright/integration/KBBackupRestoreWipe.integration.spec.mjs
@@ -464,6 +464,120 @@ function ingestSourceFilesViaMcpTool({collectionName, repoSlug, tenantId}) {
     });
 }
 
+/**
+ * Drives the `ai:ingest-tenant` Phase 2C bulk-facade CLI end-to-end inside the deployed KB
+ * container. Streams a 1k+-record `parsed-chunk-v1` JSONL fixture through the CLI's exported
+ * orchestration units (`readJsonlRecords` -> `runIngest`) wired to the real ingestion `ingestFn`
+ * (`KnowledgeBaseIngestionService.ingestSourceFiles` with `viaMcp:false` — the bulk gate-bypass),
+ * then verifies the isolated temp collection holds every embedded chunk. The ingestion service
+ * is imported directly (not via `ai/services.mjs`) so the closure-injected `viaMcp:false` flag
+ * survives the makeSafe Zod wrapper and reaches `VectorService.embed` as the explicit #10572
+ * work-volume-gate bypass: a 1k+-chunk corpus far exceeds `mcpSyncMaxChunks`, so a clean
+ * full-count ingest is itself proof the gate was bypassed.
+ * @param {Object} options
+ * @param {String} options.collectionName Temporary Chroma collection name.
+ * @param {Number} options.recordCount    parsed-chunk-v1 records streamed through the CLI.
+ * @param {String} options.repoSlug       Repo slug stamped onto the parsed-chunk fixtures.
+ * @param {String} options.tenantId       Tenant id for the bulk ingest.
+ * @returns {Object}
+ */
+function ingestTenantViaCli({collectionName, recordCount, repoSlug, tenantId}) {
+    return execKnowledgeBaseJson(`
+        ${NEO_BOOTSTRAP}
+
+        const fs                 = await import('node:fs/promises');
+        const {createReadStream} = await import('node:fs');
+        const {
+            KB_Config,
+            KB_ChromaManager,
+            KB_LifecycleService,
+            Memory_TextEmbeddingService
+        } = await import('./ai/services.mjs');
+        // Direct import (not ai/services.mjs): the makeSafe Zod wrapper strips the
+        // closure-injected viaMcp flag, and the bulk CLI relies on viaMcp:false reaching
+        // VectorService.embed as the explicit #10572 work-volume-gate bypass.
+        const {default: KB_IngestionService} = await import('./ai/services/knowledge-base/KnowledgeBaseIngestionService.mjs');
+        const {readJsonlRecords, runIngest}  = await import('./buildScripts/ai/ingestTenant.mjs');
+
+        await KB_LifecycleService.ready();
+
+        const originalCollectionName = KB_Config.data.collectionName;
+        const originalBatchDelay     = KB_Config.data.batchDelay;
+        const originalEmbedTexts     = Memory_TextEmbeddingService.embedTexts.bind(Memory_TextEmbeddingService);
+        const recordCount            = Number(process.env.NEO_TEST_KB_RECORD_COUNT);
+        const tenantId               = process.env.NEO_TEST_KB_TENANT;
+        const repoSlug               = process.env.NEO_TEST_KB_REPO;
+        const fixturePath            = process.env.NEO_TEST_KB_FIXTURE_PATH;
+        const vectorLength           = 8;
+
+        KB_Config.data.collectionName = process.env.NEO_TEST_KB_COLLECTION;
+        // Zero the inter-batch rate-limit sleep so the 1k+-chunk bulk ingest finishes
+        // inside the 120s integration-test timeout.
+        KB_Config.data.batchDelay     = 0;
+        KB_ChromaManager.invalidateKnowledgeBaseCollectionCache();
+
+        Memory_TextEmbeddingService.embedTexts = async texts => {
+            return texts.map(() => Array.from({length: vectorLength}, (_, dimension) => dimension === 0 ? 1 : 0));
+        };
+
+        let after, totals;
+
+        try {
+            // One schema-valid parsed-chunk-v1 record per line; unique sourcePath + content
+            // keep every server-side chunkId hash distinct so no upsert collapses a row.
+            const lines = Array.from({length: recordCount}, (_, index) => JSON.stringify({
+                schemaVersion: '1.0.0',
+                tenantId,
+                repoSlug,
+                rootKind     : 'bare-repo',
+                sourcePath   : 'ingest-tenant-cli-' + index + '.mjs',
+                content      : 'ingest tenant cli chunk ' + index,
+                hashInputs   : ['sourcePath', 'content'],
+                parserId     : 'integration-fixture',
+                parserVersion: '1.0.0',
+                kind         : 'doc-section',
+                name         : 'ingestTenantCliChunk' + index
+            }));
+
+            await fs.mkdir('/tmp/neo-integration', {recursive: true});
+            await fs.writeFile(fixturePath, lines.join('\\n') + '\\n', 'utf8');
+
+            // Exercise the CLI's exported orchestration: stream-parse the JSONL, batch at
+            // the CLI default (500), and ingest each batch through the bulk gate-bypass path.
+            totals = await runIngest({
+                records  : readJsonlRecords(createReadStream(fixturePath, 'utf8')),
+                batchSize: 500,
+                ingestFn : files => KB_IngestionService.ingestSourceFiles({tenantId, files, viaMcp: false})
+            });
+
+            const collection = await KB_ChromaManager.getKnowledgeBaseCollection();
+            after = {
+                collectionName: collection.name,
+                count         : await collection.count()
+            };
+
+            console.log(JSON.stringify({after, totals}));
+        } finally {
+            Memory_TextEmbeddingService.embedTexts = originalEmbedTexts;
+            KB_Config.data.collectionName          = originalCollectionName;
+            KB_Config.data.batchDelay              = originalBatchDelay;
+            KB_ChromaManager.invalidateKnowledgeBaseCollectionCache();
+
+            try {
+                await KB_ChromaManager.client.deleteCollection({name: process.env.NEO_TEST_KB_COLLECTION});
+            } catch {}
+
+            await fs.rm(fixturePath, {force: true});
+        }
+    `, {
+        NEO_TEST_KB_COLLECTION  : collectionName,
+        NEO_TEST_KB_FIXTURE_PATH: '/tmp/neo-integration/' + collectionName + '.jsonl',
+        NEO_TEST_KB_RECORD_COUNT: String(recordCount),
+        NEO_TEST_KB_REPO        : repoSlug,
+        NEO_TEST_KB_TENANT      : tenantId
+    });
+}
+
 test.describe('Dockerized KB backup -> wipe -> restore integration (#11644)', () => {
     test('restores a seeded Knowledge Base vector after an isolated fixture wipe', async () => {
         const readiness = await getReadiness();
@@ -581,5 +695,38 @@ test.describe('Dockerized KB backup -> wipe -> restore integration (#11644)', ()
         // The within-threshold push embedded into the isolated temp collection.
         expect(outcome.after.collectionName).toBe(collectionName);
         expect(outcome.after.count).toBe(3);
+    });
+
+    test('ai:ingest-tenant CLI bulk-streams a 1k+-chunk parsed-chunk-v1 corpus past the MCP volume gate (#11635)', async () => {
+        const readiness = await getReadiness();
+
+        test.skip(readiness.dockerAvailable === false, `Docker unavailable: ${readiness.reason}`);
+        expect(readiness.servicesReady, readiness.reason).toBe(true);
+
+        const runId          = `${Date.now()}-${randomUUID()}`;
+        const collectionName = `kb-ingest-tenant-cli-${runId}`;
+        const recordCount    = 1024;
+
+        const outcome = ingestTenantViaCli({
+            collectionName,
+            recordCount,
+            repoSlug: `kb-ingest-tenant-${runId}`,
+            tenantId: 'neo-shared'
+        });
+
+        // The CLI stream-batched the corpus at the default batchSize (500): ceil(1024 / 500) = 3.
+        expect(outcome.totals.batches).toBe(3);
+        expect(outcome.totals.parseErrors).toBe(0);
+        expect(outcome.totals.errors).toEqual([]);
+
+        // viaMcp:false bypassed the #10572 work-volume gate — a 1024-chunk corpus far exceeds
+        // mcpSyncMaxChunks, so a clean full-count ingest is itself proof of the bulk bypass.
+        expect(outcome.totals.ingested).toBe(recordCount);
+        expect(outcome.totals.embeddingsGenerated).toBe(recordCount);
+        expect(outcome.totals.deleted).toBe(0);
+
+        // Chroma ground truth: every streamed chunk embedded into the isolated collection.
+        expect(outcome.after.collectionName).toBe(collectionName);
+        expect(outcome.after.count).toBe(recordCount);
     });
 });

--- a/test/playwright/unit/ai/buildScripts/ingestTenant.spec.mjs
+++ b/test/playwright/unit/ai/buildScripts/ingestTenant.spec.mjs
@@ -1,0 +1,197 @@
+import {setup} from '../../../setup.mjs';
+
+const appName = 'IngestTenantCliTest';
+
+setup({
+    neoConfig: {
+        unitTestMode: true
+    },
+    appConfig: {
+        name             : appName,
+        isMounted        : () => true,
+        vnodeInitialising: false
+    }
+});
+
+import {test, expect} from '@playwright/test';
+import Neo            from '../../../../../src/Neo.mjs';
+import * as core      from '../../../../../src/core/_export.mjs';
+import {Readable}     from 'stream';
+
+/**
+ * Unit coverage for the `ai:ingest-tenant` Phase 2C bulk-facade CLI (#11635).
+ *
+ * Tests the three exported pure units — `parseArgs`, `readJsonlRecords`, `runIngest` —
+ * substrate-free: `runIngest` takes an injected `ingestFn`, so batching / error-handling /
+ * summary-aggregation are verified without the Knowledge Base. The module is dynamically
+ * imported in `beforeAll` (after `setup()`), and its `import.meta` main guard keeps the CLI
+ * from auto-running when imported here. End-to-end CLI + Chroma behaviour is the separate
+ * integration test.
+ */
+
+/**
+ * Wraps an array as an async iterable for `runIngest`'s `records` parameter.
+ * @param {Array} entries
+ * @returns {AsyncIterable}
+ */
+async function* asAsyncIterable(entries) {
+    for (const entry of entries) {
+        yield entry;
+    }
+}
+
+test.describe('buildScripts/ai/ingestTenant — Phase 2C CLI (#11635)', () => {
+    let parseArgs, readJsonlRecords, runIngest;
+
+    test.beforeAll(async () => {
+        ({parseArgs, readJsonlRecords, runIngest} = await import('../../../../../buildScripts/ai/ingestTenant.mjs'));
+    });
+
+    test.describe('parseArgs', () => {
+        test('parses the tenantId positional and --from-file', () => {
+            expect(parseArgs(['neo-shared', '--from-file', 'chunks.jsonl'])).toEqual({
+                tenantId : 'neo-shared',
+                fromFile : 'chunks.jsonl',
+                fromStdin: false,
+                batchSize: 500
+            });
+        });
+
+        test('parses --from-stdin and a custom --batch-size', () => {
+            expect(parseArgs(['tenant-a', '--from-stdin', '--batch-size', '100'])).toEqual({
+                tenantId : 'tenant-a',
+                fromFile : null,
+                fromStdin: true,
+                batchSize: 100
+            });
+        });
+
+        test('defaults batchSize to 500 and tenantId to null when absent', () => {
+            expect(parseArgs([])).toEqual({
+                tenantId : null,
+                fromFile : null,
+                fromStdin: false,
+                batchSize: 500
+            });
+        });
+    });
+
+    test.describe('readJsonlRecords', () => {
+        test('yields one record per JSONL line and skips blank lines', async () => {
+            const entries = [];
+
+            for await (const entry of readJsonlRecords(Readable.from('{"a":1}\n\n  \n{"a":2}\n'))) {
+                entries.push(entry);
+            }
+
+            expect(entries).toEqual([
+                {record: {a: 1}, lineNo: 1},
+                {record: {a: 2}, lineNo: 4}
+            ]);
+        });
+
+        test('yields a parseError for a malformed line without aborting the stream', async () => {
+            const entries = [];
+
+            for await (const entry of readJsonlRecords(Readable.from('{"a":1}\nNOT JSON\n{"a":3}\n'))) {
+                entries.push(entry);
+            }
+
+            expect(entries[0]).toEqual({record: {a: 1}, lineNo: 1});
+            expect(entries[1].lineNo).toBe(2);
+            expect(typeof entries[1].parseError).toBe('string');
+            expect(entries[1].record).toBeUndefined();
+            expect(entries[2]).toEqual({record: {a: 3}, lineNo: 3});
+        });
+    });
+
+    test.describe('runIngest', () => {
+        test('batches records into batchSize groups', async () => {
+            const batchSizes = [];
+            const records    = asAsyncIterable(
+                [1, 2, 3, 4, 5].map(n => ({record: {n}, lineNo: n}))
+            );
+
+            const totals = await runIngest({
+                records,
+                batchSize: 2,
+                ingestFn : files => {
+                    batchSizes.push(files.length);
+                    return {ingested: files.length, embeddingsGenerated: files.length, deleted: 0, errors: []};
+                }
+            });
+
+            expect(batchSizes).toEqual([2, 2, 1]);
+            expect(totals.batches).toBe(3);
+            expect(totals.ingested).toBe(5);
+            expect(totals.embeddingsGenerated).toBe(5);
+        });
+
+        test('counts JSONL parseError entries and records structured errors', async () => {
+            const ingested = [];
+            const records  = asAsyncIterable([
+                {record: {n: 1}, lineNo: 1},
+                {parseError: 'Unexpected token', lineNo: 2},
+                {record: {n: 3}, lineNo: 3},
+                {parseError: 'Unexpected end of JSON input', lineNo: 4}
+            ]);
+
+            const totals = await runIngest({
+                records,
+                batchSize: 10,
+                ingestFn : files => {
+                    ingested.push(...files);
+                    return {ingested: files.length, embeddingsGenerated: files.length, deleted: 0, errors: []};
+                }
+            });
+
+            expect(totals.parseErrors).toBe(2);
+            expect(totals.errors).toHaveLength(2);
+            expect(totals.errors[0].code).toBe('KB_INGEST_CLI_JSONL_PARSE_FAILED');
+            expect(totals.errors[0].message).toContain('Line 2');
+            // ingestFn receives only the valid records
+            expect(ingested).toEqual([{n: 1}, {n: 3}]);
+            expect(totals.ingested).toBe(2);
+        });
+
+        test('propagates per-batch summary errors into totals.errors', async () => {
+            const totals = await runIngest({
+                records  : asAsyncIterable([{record: {n: 1}, lineNo: 1}]),
+                batchSize: 10,
+                ingestFn : () => ({
+                    ingested           : 1,
+                    embeddingsGenerated: 0,
+                    deleted            : 0,
+                    errors             : [{code: 'KB_VECTOR_EMBED_FAILED', message: 'embed failed'}]
+                })
+            });
+
+            expect(totals.ingested).toBe(1);
+            expect(totals.errors).toHaveLength(1);
+            expect(totals.errors[0].code).toBe('KB_VECTOR_EMBED_FAILED');
+        });
+
+        test('returns the zero-summary shape for an empty stream and never calls ingestFn', async () => {
+            let called = false;
+
+            const totals = await runIngest({
+                records  : asAsyncIterable([]),
+                batchSize: 10,
+                ingestFn : () => {
+                    called = true;
+                    return {ingested: 0, embeddingsGenerated: 0, deleted: 0, errors: []};
+                }
+            });
+
+            expect(called).toBe(false);
+            expect(totals).toEqual({
+                ingested           : 0,
+                embeddingsGenerated: 0,
+                deleted            : 0,
+                batches            : 0,
+                parseErrors        : 0,
+                errors             : []
+            });
+        });
+    });
+});

--- a/test/playwright/unit/ai/services/knowledge-base/KnowledgeBaseIngestionService.spec.mjs
+++ b/test/playwright/unit/ai/services/knowledge-base/KnowledgeBaseIngestionService.spec.mjs
@@ -354,4 +354,36 @@ test.describe('KnowledgeBaseIngestionService.ingestSourceFiles', () => {
         });
         expect(metrics[0].eventType).toBe('error');
     });
+
+    test('threads viaMcp:false to VectorService.embed for the bulk CLI path (#11635)', async () => {
+        const summary = await Service.ingestSourceFiles({
+            tenantId: 'tenant-a',
+            files   : [{parsedChunks: [validParsedChunk()]}],
+            viaMcp  : false
+        });
+
+        expect(summary.ingested).toBe(1);
+        expect(vectorCalls).toHaveLength(1);
+        expect(vectorCalls[0].options.viaMcp).toBe(false);
+    });
+
+    test('defaults to the MCP-safe viaMcp:true when the caller omits viaMcp (#11635)', async () => {
+        const summary = await Service.ingestSourceFiles({
+            tenantId: 'tenant-a',
+            files   : [{parsedChunks: [validParsedChunk()]}]
+        });
+
+        expect(summary.ingested).toBe(1);
+        expect(vectorCalls[0].options.viaMcp).toBe(true);
+    });
+
+    test('preserves an explicit viaMcp:true for the MCP facade path (#11635)', async () => {
+        await Service.ingestSourceFiles({
+            tenantId: 'tenant-a',
+            files   : [{parsedChunks: [validParsedChunk()]}],
+            viaMcp  : true
+        });
+
+        expect(vectorCalls[0].options.viaMcp).toBe(true);
+    });
 });


### PR DESCRIPTION
Authored by Neo Opus 4.7 (Claude Code). Session 470c38e7-1ffc-4851-867d-d30c1b6fbdb2.

Resolves #11635
Refs #11624, #11626

## Summary

Phase 2C of Epic #11624 (Cloud-Native KB Ingestion). Adds `npm run ai:ingest-tenant` — the bulk data-plane facade for initial tenant onboarding (5k–50k chunks) and large `git push` hook bursts that exceed the #10572 MCP work-volume gate. The CLI streams `parsed-chunk-v1` JSONL (file or stdin), batches it (default 500/batch, configurable), and calls `KnowledgeBaseIngestionService.ingestSourceFiles` with `viaMcp:false` — the explicit bulk opt-in that bypasses the work-volume gate — all wrapped in the shared heavy-maintenance lease so a bulk ingest cannot collide with `ai:sync-kb` or the orchestrator's `kbSync` task on the unified Chroma `knowledge-base` collection.

Evidence: L2 (21 unit tests green — 12 new for #11635: viaMcp seam ×3 + CLI orchestration units ×9; plus the 9 pre-existing #11633 contract cases re-run green) → L3 (AC8 1k+-chunk integration test written, `node --check` syntax-valid, validated by CI's `integration-unified` job — no Docker in the authoring sandbox, mirroring the #11634/#11688 precedent).

FAIR-band: neo-opus-4-7 at 13/30 recent merged PRs (neo-gpt 17, Gemini absent → 2-author band, ~15 target). This PR is under-target — FAIR-band-positive, no throttle.

## What changed

- **`buildScripts/ai/ingestTenant.mjs`** (new) — the `ai:ingest-tenant` CLI. Streams `parsed-chunk-v1` JSONL from `--from-file <path>` or `--from-stdin`, batches (`--batch-size`, default 500), emits per-batch progress + a final JSON summary to stdout, and calls `ingestSourceFiles({viaMcp:false})` inside `withHeavyMaintenanceLease`. structural-pre-flight: placed in `buildScripts/ai/` alongside the KB data-plane scripts (`syncKnowledgeBase` / `backup` / `restore`), camelCase per the sibling convention — not `ai/scripts/` (agent-OS daemons). `parseArgs` / `readJsonlRecords` / `runIngest` are exported as pure, dependency-injectable units; an `import.meta` main guard keeps the CLI from auto-running on import.
- **`KnowledgeBaseIngestionService`** — threads a caller-selected `viaMcp` seam through `ingestSourceFiles` → `embedChunkGroups` → `VectorService.embed` instead of hardcoding `viaMcp:true` (the #11679-fold). Omitted/truthy = MCP-safe default (the #10572 gate applies); explicit `false` = bulk CLI bypass.
- **`package.json`** — `ai:ingest-tenant` script entry.

## Deltas from ticket

None. All 8 acceptance criteria are met:

1. ✓ `npm run ai:ingest-tenant` defined in `package.json`
2. ✓ reads `parsed-chunk-v1` from `--from-file` OR `--from-stdin`
3. ✓ batches (default 500/batch, `--batch-size` configurable)
4. ✓ streams per-batch progress + final JSON summary to stdout
5. ✓ bypasses the MCP volume gate (`viaMcp:false`)
6. ✓ structural-pre-flight consulted — `buildScripts/ai/` (KB data-plane), not `ai/scripts/` (agent-OS daemons)
7. ✓ unit tests — stream parsing, batching, error handling, summary shape
8. ✓ integration test — 1k+-chunk CLI ingest with Chroma state verification

## Test Evidence

- **Unit (L2, locally green):** `npm run test-unit -- buildScripts/ingestTenant.spec services/knowledge-base/KnowledgeBaseIngestionService.spec` → **21 passed (793ms)**.
  - `test/playwright/unit/ai/buildScripts/ingestTenant.spec.mjs` (9 new cases) — `parseArgs` ×3, `readJsonlRecords` ×2 (incl. malformed-line `parseError` without aborting the stream), `runIngest` ×4 (batchSize grouping, parse-error counting, per-batch summary-error propagation, empty-stream zero-summary shape). Drives the exported units substrate-free via an injected `ingestFn`.
  - `test/playwright/unit/ai/services/knowledge-base/KnowledgeBaseIngestionService.spec.mjs` (+3 new viaMcp-seam cases, 12 total) — explicit `viaMcp:false` threads to `VectorService.embed`; omitted defaults to MCP-safe `true`; explicit `true` preserved.
- **Integration (L3, CI-validated):** `test/playwright/integration/KBBackupRestoreWipe.integration.spec.mjs` — new `ingestTenantViaCli` helper + test case streams a 1024-record `parsed-chunk-v1` JSONL fixture through the CLI's exported orchestration (`readJsonlRecords` → `runIngest`, batchSize 500) into an isolated temp Chroma collection, asserting batch count (`ceil(1024/500)=3`), full-count ingest + `embeddingsGenerated`, and the Chroma ground-truth `count`. The 1024-chunk corpus far exceeds `mcpSyncMaxChunks`, so a clean ingest is itself proof of the `viaMcp:false` bulk bypass. bucket-D Docker test — `node --check` syntax-valid; exercised by CI's `integration-unified` job.

## Post-Merge Validation

- [ ] CI `integration-unified` runs the #11635 1k+-chunk CLI ingest end-to-end against the deployed kb-server (bulk gate-bypass + Chroma count) green.

## Commits

- `8a293531a` feat(kb): add ai:ingest-tenant bulk-facade CLI (#11635)
- `a4e7e408f` test(kb): cover the ai:ingest-tenant viaMcp seam (#11635)
- `97b1d09af` test(kb): cover the ai:ingest-tenant CLI units (#11635)
- `727857f09` test(kb): cover the ai:ingest-tenant CLI integration path (#11635)

Related: Discussion #11623 (Cloud-Native KB Ingestion design).
