### PR TITLE
fix(ai): harden Sandman REM failure handling (#11698)

### DIFF
--- a/ai/daemons/DreamService.mjs
+++ b/ai/daemons/DreamService.mjs
@@ -251,6 +251,7 @@ class DreamService extends Base {
             logger.info('[DreamService] REM pipeline completed.');
         } catch (error) {
             logger.error('[DreamService] Failed to process undigested sessions:', error);
+            throw error;
         } finally {
             this.isProcessing = false;
         }

--- a/ai/graph/Database.mjs
+++ b/ai/graph/Database.mjs
@@ -405,6 +405,10 @@ class Database extends Base {
      * @param {String} nodeId
      */
     removeNode(nodeId) {
+        if (typeof nodeId !== 'string' || nodeId.length === 0) {
+            throw new Error(`Graph Database removeNode requires a non-empty string node id. Received: ${String(nodeId)}`);
+        }
+
         let me            = this,
             outbound      = me.edges.getByIndex('source', nodeId),
             inbound       = me.edges.getByIndex('target', nodeId),

--- a/ai/graph/storage/SQLite.mjs
+++ b/ai/graph/storage/SQLite.mjs
@@ -167,6 +167,11 @@ class SQLite extends Base {
                     label: isRecord ? node.get('label') : node.label,
                     properties: isRecord ? node.get('properties') : node.properties
                 };
+
+                if (typeof nodeData.id !== 'string' || nodeData.id.length === 0) {
+                    throw new Error(`SQLite graph node writes require a non-empty string id. Received: ${String(nodeData.id)}`);
+                }
+
                 stmt.run(nodeData.id, nodeData.properties?.userId || null, JSON.stringify(nodeData));
             }
         });

--- a/ai/services/memory-core/GraphService.mjs
+++ b/ai/services/memory-core/GraphService.mjs
@@ -34,6 +34,16 @@ function isRlsVisible(entity, requesterUserId) {
 }
 
 /**
+ * Validates the Native Edge Graph node-id contract before writes/deletes reach
+ * the lower Store layer, where `null` otherwise looks object-like.
+ * @param {*} id Candidate graph node id.
+ * @returns {Boolean} true for non-empty string ids.
+ */
+function isValidGraphNodeId(id) {
+    return typeof id === 'string' && id.length > 0;
+}
+
+/**
  * @summary Service that manages the SQLite Knowledge Graph (Nodes and Edges).
  *
  * It provides the topological layout of the Neo.mjs namespace, knowledge,
@@ -177,6 +187,10 @@ class GraphService extends Base {
      * @param {Object} nodeData
      */
     upsertNode({id, type, name, description, semanticVectorId, state, updatedAt, properties}) {
+        if (!isValidGraphNodeId(id)) {
+            throw new Error(`[GraphService] Cannot upsert graph node without a non-empty string id. Received: ${String(id)}`);
+        }
+
         // Lazy-load from SQLite before in-memory check — prevents cold-cache stubs from
         // overwriting rich SQLite rows via addNodes' ON CONFLICT DO UPDATE semantics.
         // Mirrors the discipline in getNode:424. Resolves #10230.
@@ -981,6 +995,12 @@ class GraphService extends Base {
      */
     removeNodes(nodeIds) {
         if (!nodeIds || nodeIds.length === 0) return;
+
+        const invalidNodeIds = nodeIds.filter(id => !isValidGraphNodeId(id));
+
+        if (invalidNodeIds.length > 0) {
+            throw new Error(`[GraphService] removeNodes received invalid node id(s): ${invalidNodeIds.map(id => String(id)).join(', ')}`);
+        }
 
         this.db.transaction(() => {
             nodeIds.forEach(id => this.db.removeNode(id));

--- a/buildScripts/ai/runSandman.mjs
+++ b/buildScripts/ai/runSandman.mjs
@@ -215,11 +215,7 @@ export async function runSandman() {
 
                 console.log('✅ Services Ready. Entering REM Sleep...');
 
-                // Execute the REM pipeline (extract undigested graph entities + Golden Path synthesis)
-                await DreamService.processUndigestedSessions();
-                await GoldenPathSynthesizer.synthesizeGoldenPath();
-
-                console.log('✅ Sandman cycle complete.');
+                await runRemPipeline();
                 process.exitCode = 0;
                 return {providerReady: true};
             } catch (e) {
@@ -264,6 +260,27 @@ export async function runSandman() {
     // above for the release-timing invariant). Nothing further to do here besides honoring
     // the inner exitCode contract.
     process.exit(process.exitCode);
+}
+
+/**
+ * Runs the Sandman REM cycle body after provider and service readiness gates pass.
+ * Exposed for unit coverage so fatal DreamService failures cannot regress into
+ * a misleading success log or successful process exit.
+ * @param {Object} options
+ * @param {Object} [options.dreamService=DreamService]
+ * @param {Object} [options.goldenPathSynthesizer=GoldenPathSynthesizer]
+ * @param {Object} [options.output=console]
+ * @returns {Promise<void>}
+ */
+export async function runRemPipeline({
+    dreamService          = DreamService,
+    goldenPathSynthesizer = GoldenPathSynthesizer,
+    output                = console
+} = {}) {
+    await dreamService.processUndigestedSessions();
+    await goldenPathSynthesizer.synthesizeGoldenPath();
+
+    output.log('✅ Sandman cycle complete.');
 }
 
 if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {

--- a/test/playwright/unit/ai/buildScripts/runSandman.spec.mjs
+++ b/test/playwright/unit/ai/buildScripts/runSandman.spec.mjs
@@ -31,6 +31,8 @@ import * as core      from '../../../../../src/core/_export.mjs';
  * provider-unavailable state from missing DreamService / Golden Path output.
  */
 test.describe('runSandman.mjs provider readiness diagnostics (#10587)', () => {
+    test.describe.configure({mode: 'serial'});
+
     let aiConfig;
     let logger;
     let runSandmanModule;
@@ -119,5 +121,27 @@ test.describe('runSandman.mjs provider readiness diagnostics (#10587)', () => {
         expect(logLines).toContain('mlx-community/test-model');
         expect(logLines).toContain('Start the configured OpenAI-compatible / MLX provider');
         expect(logLines).not.toContain('must-not-be-logged');
+    });
+
+    test('runRemPipeline propagates REM failures without printing success (#11698)', async () => {
+        const logs = [];
+
+        await expect(runSandmanModule.runRemPipeline({
+            dreamService: {
+                processUndigestedSessions: async () => {
+                    throw new Error('simulated REM failure');
+                }
+            },
+            goldenPathSynthesizer: {
+                synthesizeGoldenPath: async () => {
+                    throw new Error('Golden Path must not run after REM failure');
+                }
+            },
+            output: {
+                log: message => logs.push(message)
+            }
+        })).rejects.toThrow('simulated REM failure');
+
+        expect(logs.some(message => message.includes('Sandman cycle complete'))).toBe(false);
     });
 });

--- a/test/playwright/unit/ai/daemons/DreamService.spec.mjs
+++ b/test/playwright/unit/ai/daemons/DreamService.spec.mjs
@@ -778,6 +778,42 @@ test.describe('Neo.ai.services.memory-core.DreamService', () => {
         }
     });
 
+    test('processUndigestedSessions rethrows garbage-collection failures (#11698)', async () => {
+        const aiConfig = (await import('../../../../../ai/mcp/server/memory-core/config.mjs')).default;
+
+        const orig = {
+            provider      : aiConfig.modelProvider,
+            findUndigested: DreamService.findUndigestedSessions,
+            runGarbageCol : DreamService.runGarbageCollection,
+            loggerError   : logger.error,
+            isProcessing  : DreamService.isProcessing
+        };
+
+        const errors = [];
+
+        try {
+            aiConfig.modelProvider    = 'mock-provider';
+            DreamService.isProcessing = false;
+
+            DreamService.findUndigestedSessions = async () => [];
+            DreamService.runGarbageCollection   = async () => {
+                throw new Error('simulated apoptosis failure');
+            };
+            logger.error = (...args) => { errors.push(args); };
+
+            await expect(DreamService.processUndigestedSessions()).rejects.toThrow('simulated apoptosis failure');
+
+            expect(DreamService.isProcessing).toBe(false);
+            expect(errors.some(args => args[0] === '[DreamService] Failed to process undigested sessions:')).toBe(true);
+        } finally {
+            aiConfig.modelProvider              = orig.provider;
+            DreamService.findUndigestedSessions = orig.findUndigested;
+            DreamService.runGarbageCollection   = orig.runGarbageCol;
+            logger.error                        = orig.loggerError;
+            DreamService.isProcessing           = orig.isProcessing;
+        }
+    });
+
     test('synthesizeGoldenPath should mathematically select and inject Golden Path while rejecting BLOCKS', async () => {
         // Mock StorageRouter to return deterministic ChromaDB metric formats
         const originalGetSummary = StorageRouter.getSummaryCollection;

--- a/test/playwright/unit/ai/graph/Database.spec.mjs
+++ b/test/playwright/unit/ai/graph/Database.spec.mjs
@@ -97,6 +97,12 @@ test.describe('Neo.ai.graph.Database', () => {
         expect(db.edges.getCount()).toBe(0); // Edge should be deleted because its source node is gone
     });
 
+    test('should reject invalid node ids before Store.remove sees null (#11698)', async () => {
+        expect(() => db.removeNode(null)).toThrow(/non-empty string node id/);
+        expect(() => db.removeNode(undefined)).toThrow(/non-empty string node id/);
+        expect(() => db.removeNode('')).toThrow(/non-empty string node id/);
+    });
+
     test('should persist nodes and edges properly using SQLite storage adapter', async () => {
         // Clean out previous runs
         if (fs.existsSync(dbPath)) fs.unlinkSync(dbPath);
@@ -142,6 +148,18 @@ test.describe('Neo.ai.graph.Database', () => {
         expect(reloadDb.edges.get('e1').type).toBe('KNOWS');
 
         reloadDb.destroy();
+    });
+
+    test('SQLite storage rejects invalid node ids before persistence (#11698)', async () => {
+        let storage = Neo.create(SQLite, { dbPath });
+        await storage.initAsync();
+
+        try {
+            expect(() => storage.addNodes([{ id: null, label: 'Broken', properties: {} }])).toThrow(/non-empty string id/);
+            expect(() => storage.addNodes([{ label: 'Broken', properties: {} }])).toThrow(/non-empty string id/);
+        } finally {
+            storage.destroy();
+        }
     });
 
     test('SQLite storage enables foreign_keys pragma — source-side Edges cascade-delete (#10856)', async () => {

--- a/test/playwright/unit/ai/services/memory-core/GraphService.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/GraphService.spec.mjs
@@ -132,6 +132,11 @@ test.describe('Neo.ai.services.memory-core.GraphService', () => {
         expect(task2.weight).toBe(0.8);
     });
 
+    test('removeNodes rejects invalid node ids before Database.removeNode null path (#11698)', async () => {
+        expect(() => GraphService.removeNodes([null])).toThrow(/invalid node id/);
+        expect(() => GraphService.removeNodes(['ValidNode', undefined])).toThrow(/invalid node id/);
+    });
+
     test('preBriefSession should hydrate episodic context through getNeighbors semanticVectorId', async () => {
         await GraphService.upsertNode({id: 'EpicA', name: 'Roadmap Planner'});
         await GraphService.upsertNode({id: 'MemoryA', name: 'Session Summary', semanticVectorId: 'summary-vector-1'});


### PR DESCRIPTION
Authored by GPT-5 (Codex Desktop). Session d13c94dd-e721-4e28-ac9e-4d0b3c0f66de.

FAIR-band: over-target [17/30] - taking this lane despite over-target because the operator surfaced a live Sandman false-success regression during the watchdog window; Gemini has 0 recent merged PRs but is not currently active in this lane, while Claude is concurrently handling #11697. This is a high-ROI Memory Core maintenance-trust bug.

Resolves #11698

## Summary

Hardens the Sandman REM failure path across two boundaries:

- Validates Native Edge Graph node ids before `GraphService`, `Database`, or `SQLite` routes invalid ids into `Store.remove()` / `Store.getKey()`.
- Re-throws `DreamService.processUndigestedSessions()` failures after logging so `runSandman` can fail non-zero instead of printing a false success.
- Extracts `runRemPipeline()` so the success-log contract is unit-testable, and serializes `runSandman.spec.mjs` because it mutates singleton logger config.

Evidence: L2 (focused unit regressions + combined touched-suite run) -> L3 required (operator CLI Sandman run against live graph state). Residual: post-merge live Sandman validation [#11698].

## Deltas from Ticket

- Added a lower-boundary `Database.removeNode()` guard in addition to the GraphService/SQLite guards so invalid ids fail before the collection layer sees `null`.
- Extracted `runRemPipeline()` from `runSandman()` to test the success-log/failure-propagation contract without booting provider infrastructure.
- Fixed a discovered singleton-test isolation issue in `runSandman.spec.mjs` with serial mode.

## Test Evidence

- `git diff --check` — pass.
- `git diff --check origin/dev...HEAD` — pass.
- `npm run test-unit -- test/playwright/unit/ai/graph/Database.spec.mjs` — 18 passed.
- `npm run test-unit -- test/playwright/unit/ai/buildScripts/runSandman.spec.mjs` — 3 passed.
- `npm run test-unit -- test/playwright/unit/ai/daemons/DreamService.spec.mjs` — 15 passed.
- `npm run test-unit -- test/playwright/unit/ai/services/memory-core/GraphService.spec.mjs` — 23 passed.
- `npm run test-unit -- test/playwright/unit/ai/graph/Database.spec.mjs test/playwright/unit/ai/services/memory-core/GraphService.spec.mjs test/playwright/unit/ai/daemons/DreamService.spec.mjs test/playwright/unit/ai/buildScripts/runSandman.spec.mjs` — 59 passed.

## Post-Merge Validation

- [ ] Rerun `npm run ai:run-sandman` on `dev`; the previous `Cannot read properties of null (reading 'id')` path should be gone.
- [ ] Confirm fatal REM failures exit non-zero and do not print `✅ Sandman cycle complete.` before failure.
