### PR TITLE
fix(collection): exclude null from item classification (#11701)

### DIFF
--- a/src/collection/Base.mjs
+++ b/src/collection/Base.mjs
@@ -1293,7 +1293,7 @@ class Collection extends Base {
      */
     isItem(value) {
         // We can not use Neo.isObject() || Neo.isRecord(), since collections can store neo instances too.
-        return typeof value === 'object'
+        return value !== null && typeof value === 'object'
     }
 
     /**

--- a/test/playwright/unit/collection/Base.spec.mjs
+++ b/test/playwright/unit/collection/Base.spec.mjs
@@ -12,6 +12,8 @@ import {test, expect}  from '@playwright/test';
 import Neo             from '../../../../src/Neo.mjs';
 import * as core       from '../../../../src/core/_export.mjs';
 import Collection      from '../../../../src/collection/Base.mjs';
+import Model           from '../../../../src/data/Model.mjs';
+import RecordFactory   from '../../../../src/data/RecordFactory.mjs';
 import InstanceManager from '../../../../src/manager/Instance.mjs';
 
 /**
@@ -76,6 +78,26 @@ test.describe.serial('Neo.collection.Base', () => {
         ]);
 
         expect(collection.indexOf('elmasse')).toBe(4);
+    });
+
+    test('Classify null as non-item while preserving object-like items', () => {
+        const nullCollection = Neo.create(Collection, {
+            items: [{id: 'keep'}]
+        });
+        const model = Neo.create(Model, {
+            fields: [{name: 'id'}]
+        });
+        const record      = RecordFactory.createRecord(model, {id: 'record'});
+        const neoInstance = Neo.create(Collection, {items: []});
+
+        expect(nullCollection.isItem(null)).toBe(false);
+        expect(nullCollection.isItem({id: 'plain'})).toBe(true);
+        expect(nullCollection.isItem(record)).toBe(true);
+        expect(nullCollection.isItem(neoInstance)).toBe(true);
+
+        expect(() => nullCollection.remove(null)).not.toThrow();
+        expect(nullCollection.count).toBe(1);
+        expect(nullCollection.getRange()).toEqual([{id: 'keep'}]);
     });
 
     test('Sort collection items', () => {


### PR DESCRIPTION
Resolves #11701

Authored by GPT-5 (Codex Desktop). Session d13c94dd-e721-4e28-ac9e-4d0b3c0f66de.
FAIR-band: over-target [17/30] — taking this lane despite over-target because it is an operator-surfaced, same-session quick win tied to the Sandman/null-removal failure mode, and Claude is actively on the parallel #11637 lane.
Evidence: L2 — focused collection unit coverage plus syntax and diff checks.

## Deltas from ticket
- Updates `Neo.collection.Base#isItem()` so `null` is treated as a non-item key/value instead of object-like item data.
- Adds focused collection unit coverage proving null exclusion while preserving plain object, Record, and Neo-instance item classification.
- Covers the removal path with `remove(null)` to ensure it does not route into `getKey(null)` or mutate the collection.

## Scope Notes
- Preserves the broad object-like behavior introduced for #5954; this is not a reversion to `Neo.isObject()` / `Neo.isRecord()`.
- No sorter, hydration, or collection key-semantics refactor.

## Test Evidence
- `node --check src/collection/Base.mjs`
- `node --check test/playwright/unit/collection/Base.spec.mjs`
- `git diff --check`
- `npm run test-unit -- test/playwright/unit/collection/Base.spec.mjs` — 10 passed.

## Post-Merge Validation
- [ ] Confirm the next Sandman / graph-cleanup cycle no longer hits `Store.getKey(null)` from null removal input.

## Commits
- `521a3da10` — `fix(collection): exclude null from item classification (#11701)`
