### PR TITLE
test(kb): add tenant isolation integration coverage (#11645)

### DIFF
--- a/ai/mcp/server/knowledge-base/Server.mjs
+++ b/ai/mcp/server/knowledge-base/Server.mjs
@@ -77,6 +77,26 @@ class Server extends BaseServer {
     }
 
     /**
+     * @summary SSE-only hook: builds the KB RequestContext from authenticated transport identity.
+     *
+     * Knowledge Base read and ingest services enforce tenant isolation from
+     * `RequestContextService.getUserId()`. Propagating the SSE auth context here keeps
+     * proxy/OIDC deployments tenant-aware while preserving single-tenant fallthrough when
+     * no identity is present.
+     * @param {Object|undefined} reqAuth
+     * @returns {Promise<Object>}
+     */
+    async buildRequestContext(reqAuth) {
+        if (!reqAuth?.userId) return {};
+
+        return {
+            userId  : reqAuth.userId,
+            username: reqAuth.username,
+            source  : reqAuth.source || 'oidc'
+        };
+    }
+
+    /**
      * @summary Records failed tool dispatch to KBRecorderService when the healthcheck gate rejects.
      * Preserves the existing telemetry shape (agent_id, session_id, sequence_id, timestamp,
      * tool, args, result, success, duration_ms) so KB-level analytics stay continuous post-migration.

--- a/ai/services/knowledge-base/SearchService.mjs
+++ b/ai/services/knowledge-base/SearchService.mjs
@@ -159,10 +159,6 @@ class SearchService extends Base {
      * @returns {Promise<Object>} The synthesized answer and references.
      */
     async ask({query, type = 'all', limit = 5}) {
-        if (!this.model) {
-            throw new Error('GEMINI_API_KEY is required for RAG features.');
-        }
-
         logger.info(`[SearchService] Processing RAG query: "${query}" (Type: ${type})`);
 
         // 1. Retrieve most relevant files using QueryService's scoring logic
@@ -173,6 +169,10 @@ class SearchService extends Base {
                 answer    : "No relevant documents found in the knowledge base.",
                 references: []
             };
+        }
+
+        if (!this.model) {
+            throw new Error('GEMINI_API_KEY is required for RAG features.');
         }
 
         const references = queryResult.results.map(r => ({

--- a/test/playwright/integration/KBAuthRejection.integration.spec.mjs
+++ b/test/playwright/integration/KBAuthRejection.integration.spec.mjs
@@ -47,4 +47,35 @@ test.describe('Dockerized KB proxy identity rejection integration (#11644)', () 
             await client.close();
         }
     });
+
+    test('KB rejects top-level tenant spoofing on ingest_source_files (#11645)', async () => {
+        const readiness = await getReadiness();
+
+        test.skip(readiness.dockerAvailable === false, `Docker unavailable: ${readiness.reason}`);
+
+        expect(readiness.servicesReady, readiness.reason).toBe(true);
+
+        const client = await createIdentityClient({
+            baseUrl   : KB_URL,
+            clientName: 'neo-integration-kb-tenant-spoof',
+            identity  : 'kb-auth-owner'
+        });
+
+        try {
+            const result = await callJsonTool(client, 'ingest_source_files', {
+                tenantId: 'kb-auth-attacker',
+                files   : [{
+                    content   : 'tenant spoof payload should not ingest',
+                    sourcePath: 'spoof/Attempt.md'
+                }]
+            });
+
+            expect(result.ingested).toBe(0);
+            expect(result.errors).toEqual(expect.arrayContaining([
+                expect.objectContaining({code: 'KB_INGEST_TENANT_MISMATCH'})
+            ]));
+        } finally {
+            await client.close();
+        }
+    });
 });

--- a/test/playwright/integration/KBCrossTenantIsolation.integration.spec.mjs
+++ b/test/playwright/integration/KBCrossTenantIsolation.integration.spec.mjs
@@ -1,0 +1,124 @@
+import {randomUUID}   from 'node:crypto';
+import {test, expect} from '@playwright/test';
+import {
+    callJsonTool,
+    createIdentityClient,
+    getReadiness
+} from './fixtures/mcpClient.mjs';
+import {
+    deleteKnowledgeBaseRecords,
+    seedKnowledgeBaseRecords
+} from './fixtures/kbTenantRecords.mjs';
+
+const KB_URL = process.env.NEO_INTEGRATION_KB_URL || 'http://127.0.0.1:13000';
+
+function resultSources(result) {
+    return (result.results || []).map(row => row.source);
+}
+
+function referenceSources(result) {
+    return (result.references || []).map(row => row.source);
+}
+
+function documentIds(result) {
+    return (result.documents || []).map(document => document.id);
+}
+
+function toolText(result) {
+    return result.content?.map(item => item.text).join('\n') || '';
+}
+
+function kbRecord({id, tenantId, source, name, content}) {
+    return {
+        id,
+        content,
+        metadata: {
+            content,
+            inheritanceChain: '[]',
+            name,
+            repoSlug: 'tenant-app',
+            source,
+            sourcePath: source,
+            tenantId,
+            type: 'guide',
+            visibility: 'private'
+        }
+    };
+}
+
+test.describe('Dockerized KB cross-tenant isolation integration (#11645)', () => {
+    test('public KB facades do not expose another tenant private chunk', async () => {
+        const readiness = await getReadiness();
+
+        test.skip(readiness.dockerAvailable === false, `Docker unavailable: ${readiness.reason}`);
+
+        expect(readiness.servicesReady, readiness.reason).toBe(true);
+
+        const runId       = `${Date.now()}-${randomUUID()}`;
+        const aliceTenant = `kb-isolation-alice-${runId}`;
+        const bobTenant   = `kb-isolation-bob-${runId}`;
+        const foreign     = kbRecord({
+            id      : `kb-isolation-foreign-${runId}`,
+            tenantId: bobTenant,
+            source  : `integration/${runId}/bob/Secret.md`,
+            name    : 'BobOnly',
+            content : `BOB_ONLY_PRIVATE_${runId}`
+        });
+        const alice       = await createIdentityClient({
+            baseUrl   : KB_URL,
+            clientName: 'neo-integration-kb-isolation-alice',
+            identity  : aliceTenant
+        });
+        const bob         = await createIdentityClient({
+            baseUrl   : KB_URL,
+            clientName: 'neo-integration-kb-isolation-bob',
+            identity  : bobTenant
+        });
+
+        seedKnowledgeBaseRecords([foreign]);
+
+        try {
+            const bobVisible = await callJsonTool(bob, 'get_document_by_id', {id: foreign.id});
+            expect(bobVisible.id).toBe(foreign.id);
+
+            const forgedQuery = await callJsonTool(alice, 'query_documents', {
+                query   : foreign.content,
+                limit   : 10,
+                tenantId: bobTenant
+            });
+            expect(resultSources(forgedQuery)).not.toContain(foreign.metadata.source);
+
+            const ask = await callJsonTool(alice, 'ask_knowledge_base', {
+                query   : foreign.content,
+                limit   : 5,
+                tenantId: bobTenant
+            });
+            expect(referenceSources(ask)).not.toContain(foreign.metadata.source);
+
+            const list = await callJsonTool(alice, 'list_documents', {limit: 1000});
+            expect(documentIds(list)).not.toContain(foreign.id);
+
+            const hiddenDocument = await alice.callTool({
+                name     : 'get_document_by_id',
+                arguments: {id: foreign.id}
+            });
+            expect(hiddenDocument.isError).toBe(true);
+            expect(hiddenDocument.content?.map(item => item.text).join('\n') || '')
+                .toContain(`Document with id '${foreign.id}' not found.`);
+
+            const hierarchyArgs = {root: 'Neo.component.Base'};
+            const [aliceHierarchy, bobHierarchy] = await Promise.all([
+                alice.callTool({name: 'get_class_hierarchy', arguments: hierarchyArgs}),
+                bob.callTool({name: 'get_class_hierarchy',   arguments: hierarchyArgs})
+            ]);
+            expect(aliceHierarchy.isError).toBe(bobHierarchy.isError);
+            expect(toolText(aliceHierarchy)).toBe(toolText(bobHierarchy));
+        } finally {
+            await Promise.allSettled([
+                alice.close(),
+                bob.close()
+            ]);
+            deleteKnowledgeBaseRecords([foreign.id]);
+        }
+    });
+});

--- a/test/playwright/integration/KBTeamPrivateRetrieval.integration.spec.mjs
+++ b/test/playwright/integration/KBTeamPrivateRetrieval.integration.spec.mjs
@@ -1,0 +1,120 @@
+import {randomUUID}   from 'node:crypto';
+import {test, expect} from '@playwright/test';
+import {
+    callJsonTool,
+    createIdentityClient,
+    getReadiness
+} from './fixtures/mcpClient.mjs';
+import {
+    deleteKnowledgeBaseRecords,
+    seedKnowledgeBaseRecords
+} from './fixtures/kbTenantRecords.mjs';
+
+const KB_URL = process.env.NEO_INTEGRATION_KB_URL || 'http://127.0.0.1:13000';
+
+function sourcesFromQuery(result) {
+    return (result.results || []).map(row => row.source);
+}
+
+function documentsById(result) {
+    return new Map((result.documents || []).map(document => [document.id, document]));
+}
+
+function kbRecord({id, tenantId, source, name, content}) {
+    return {
+        id,
+        content,
+        metadata: {
+            content,
+            inheritanceChain: '[]',
+            name,
+            repoSlug: tenantId === 'neo-shared' ? 'neo' : 'tenant-app',
+            source,
+            sourcePath: source,
+            tenantId,
+            type: 'guide',
+            visibility: tenantId === 'neo-shared' ? 'team' : 'private'
+        }
+    };
+}
+
+test.describe('Dockerized KB team/private retrieval integration (#11645)', () => {
+    test('tenant clients see own private chunks plus neo-shared chunks only', async () => {
+        const readiness = await getReadiness();
+
+        test.skip(readiness.dockerAvailable === false, `Docker unavailable: ${readiness.reason}`);
+
+        expect(readiness.servicesReady, readiness.reason).toBe(true);
+
+        const runId       = `${Date.now()}-${randomUUID()}`;
+        const aliceTenant = `kb-team-alice-${runId}`;
+        const bobTenant   = `kb-team-bob-${runId}`;
+        const own         = kbRecord({
+            id      : `kb-team-own-${runId}`,
+            tenantId: aliceTenant,
+            source  : `integration/${runId}/alice/Own.md`,
+            name    : 'AliceOwn',
+            content : `ALICE_PRIVATE_VISIBLE_${runId}`
+        });
+        const foreign     = kbRecord({
+            id      : `kb-team-foreign-${runId}`,
+            tenantId: bobTenant,
+            source  : `integration/${runId}/bob/Secret.md`,
+            name    : 'BobSecret',
+            content : `BOB_PRIVATE_HIDDEN_${runId}`
+        });
+        const shared      = kbRecord({
+            id      : `kb-team-shared-${runId}`,
+            tenantId: 'neo-shared',
+            source  : `integration/${runId}/shared/Curated.md`,
+            name    : 'SharedCurated',
+            content : `NEO_SHARED_VISIBLE_${runId}`
+        });
+        const records     = [own, foreign, shared];
+        const alice       = await createIdentityClient({
+            baseUrl   : KB_URL,
+            clientName: 'neo-integration-kb-team-alice',
+            identity  : aliceTenant
+        });
+        const bob         = await createIdentityClient({
+            baseUrl   : KB_URL,
+            clientName: 'neo-integration-kb-team-bob',
+            identity  : bobTenant
+        });
+
+        seedKnowledgeBaseRecords(records);
+
+        try {
+            const [aliceList, bobList] = await Promise.all([
+                callJsonTool(alice, 'list_documents', {limit: 1000}),
+                callJsonTool(bob,   'list_documents', {limit: 1000})
+            ]);
+            const aliceDocs = documentsById(aliceList);
+            const bobDocs   = documentsById(bobList);
+
+            expect(aliceDocs.has(own.id)).toBe(true);
+            expect(aliceDocs.has(shared.id)).toBe(true);
+            expect(aliceDocs.has(foreign.id)).toBe(false);
+            expect(bobDocs.has(foreign.id)).toBe(true);
+            expect(bobDocs.has(shared.id)).toBe(true);
+            expect(bobDocs.has(own.id)).toBe(false);
+
+            const [aliceOwnQuery, aliceSharedQuery, bobSharedQuery] = await Promise.all([
+                callJsonTool(alice, 'query_documents', {query: own.content, limit: 10}),
+                callJsonTool(alice, 'query_documents', {query: shared.content, limit: 10}),
+                callJsonTool(bob,   'query_documents', {query: shared.content, limit: 10})
+            ]);
+
+            expect(sourcesFromQuery(aliceOwnQuery)).toContain(own.metadata.source);
+            expect(sourcesFromQuery(aliceOwnQuery)).not.toContain(foreign.metadata.source);
+            expect(sourcesFromQuery(aliceSharedQuery)).toContain(shared.metadata.source);
+            expect(sourcesFromQuery(bobSharedQuery)).toContain(shared.metadata.source);
+        } finally {
+            await Promise.allSettled([
+                alice.close(),
+                bob.close()
+            ]);
+            deleteKnowledgeBaseRecords(records.map(record => record.id));
+        }
+    });
+});

--- a/test/playwright/integration/fixtures/kbTenantRecords.mjs
+++ b/test/playwright/integration/fixtures/kbTenantRecords.mjs
@@ -1,0 +1,126 @@
+import {spawnSync}     from 'node:child_process';
+import path            from 'node:path';
+import {fileURLToPath} from 'node:url';
+import {expect}        from '@playwright/test';
+
+const __filename  = fileURLToPath(import.meta.url);
+const __dirname   = path.dirname(__filename);
+const repoRoot    = path.resolve(__dirname, '../../..');
+const composeFile = path.join(repoRoot, 'ai/deploy/docker-compose.test.yml');
+const projectName = process.env.NEO_INTEGRATION_COMPOSE_PROJECT || 'neo-integration-test';
+
+const NEO_BOOTSTRAP = `
+    await import('./src/Neo.mjs');
+    await import('./src/core/_export.mjs');
+`;
+
+/**
+ * Runs Docker Compose against the integration fixture project.
+ * @param {String[]} args Docker Compose arguments after the compose file selector.
+ * @returns {import('node:child_process').SpawnSyncReturns<String>}
+ */
+function dockerCompose(args) {
+    return spawnSync('docker', ['compose', '-p', projectName, '-f', composeFile, ...args], {
+        cwd      : repoRoot,
+        encoding : 'utf8',
+        maxBuffer: 10 * 1024 * 1024
+    });
+}
+/**
+ * Runs an ES module snippet inside the deployed Knowledge Base container.
+ * @param {String} code The JavaScript source to execute.
+ * @param {Object} [env] Environment variables to pass into the process.
+ * @returns {Object}
+ */
+function execKnowledgeBaseJson(code, env = {}) {
+    const envArgs = Object.entries(env).flatMap(([key, value]) => ['-e', `${key}=${value}`]);
+    const result  = dockerCompose(['exec', '-T', ...envArgs, 'kb-server', 'node', '--input-type=module', '-e', code]);
+    const output  = [
+        result.stdout?.trim(),
+        result.stderr?.trim()
+    ].filter(Boolean).join('\n');
+
+    expect(result.status, output || result.error?.message || 'kb-server exec failed').toBe(0);
+
+    const jsonLine = result.stdout.trim().split('\n').filter(Boolean).reverse().find(line => {
+        try {
+            JSON.parse(line);
+            return true;
+        } catch {
+            return false;
+        }
+    });
+    expect(jsonLine, output).toBeTruthy();
+
+    return JSON.parse(jsonLine);
+}
+
+/**
+ * Seeds deterministic KB records directly into the deployed Chroma collection.
+ * @param {Array<{id: String, content: String, metadata: Object}>} records Records to seed.
+ * @returns {Object}
+ */
+export function seedKnowledgeBaseRecords(records) {
+    return execKnowledgeBaseJson(`
+        ${NEO_BOOTSTRAP}
+
+        const records = JSON.parse(process.env.NEO_TEST_KB_RECORDS);
+        const {KB_ChromaManager, KB_LifecycleService} = await import('./ai/services.mjs');
+        const TextEmbeddingService = (await import('./ai/services/memory-core/TextEmbeddingService.mjs')).default;
+        const mcConfig = (await import('./ai/mcp/server/memory-core/config.mjs')).default;
+
+        await KB_LifecycleService.ready();
+
+        const collection = await KB_ChromaManager.getKnowledgeBaseCollection();
+        const embeddings = [];
+
+        for (const record of records) {
+            embeddings.push(await TextEmbeddingService.embedText(record.content, mcConfig.embeddingProvider));
+        }
+
+        await collection.upsert({
+            ids       : records.map(record => record.id),
+            embeddings,
+            metadatas : records.map(record => record.metadata),
+            documents : records.map(record => record.content)
+        });
+
+        console.log(JSON.stringify({
+            count: await collection.count(),
+            ids  : records.map(record => record.id)
+        }));
+    `, {
+        NEO_TEST_KB_RECORDS: JSON.stringify(records)
+    });
+}
+
+/**
+ * Deletes deterministic KB records seeded by integration specs.
+ * @param {String[]} ids Chroma ids to delete.
+ * @returns {Object}
+ */
+export function deleteKnowledgeBaseRecords(ids) {
+    if (ids.length === 0) {
+        return {deleted: []};
+    }
+
+    return execKnowledgeBaseJson(`
+        ${NEO_BOOTSTRAP}
+
+        const ids = JSON.parse(process.env.NEO_TEST_KB_IDS);
+        const {KB_ChromaManager, KB_LifecycleService} = await import('./ai/services.mjs');
+
+        await KB_LifecycleService.ready();
+
+        const collection = await KB_ChromaManager.getKnowledgeBaseCollection();
+
+        await collection.delete({ids});
+
+        console.log(JSON.stringify({
+            count  : await collection.count(),
+            deleted: ids
+        }));
+    `, {
+        NEO_TEST_KB_IDS: JSON.stringify(ids)
+    });
+}

--- a/test/playwright/unit/ai/services/knowledge-base/SearchService.noModel.spec.mjs
+++ b/test/playwright/unit/ai/services/knowledge-base/SearchService.noModel.spec.mjs
@@ -18,20 +18,36 @@ import Neo            from '../../../../../../src/Neo.mjs';
 import * as core      from '../../../../../../src/core/_export.mjs';
 
 test.describe('Neo.ai.services.knowledge-base.SearchService model guard', () => {
-    let SearchService;
-    let originalModel;
+    let SearchService, QueryService;
+    let originalModel, originalQueryDocuments;
 
     test.beforeAll(async () => {
-        SearchService = (await import('../../../../../../ai/services/knowledge-base/SearchService.mjs')).default;
-        originalModel = SearchService.model;
+        SearchService          = (await import('../../../../../../ai/services/knowledge-base/SearchService.mjs')).default;
+        QueryService           = (await import('../../../../../../ai/services/knowledge-base/QueryService.mjs')).default;
+        originalModel          = SearchService.model;
+        originalQueryDocuments = QueryService.queryDocuments;
     });
 
     test.afterEach(() => {
-        SearchService.model = originalModel;
+        SearchService.model         = originalModel;
+        QueryService.queryDocuments = originalQueryDocuments;
     });
 
-    test('ask fails fast when no Gemini model is configured', async () => {
-        SearchService.model = null;
+    test('ask returns the no-documents response before requiring a Gemini model', async () => {
+        SearchService.model         = null;
+        QueryService.queryDocuments = async () => ({message: 'No results found for your query and type.'});
+
+        await expect(SearchService.ask({query: 'How does KB work?'})).resolves.toEqual({
+            answer    : 'No relevant documents found in the knowledge base.',
+            references: []
+        });
+    });
+
+    test('ask still requires a Gemini model when retrieval finds references', async () => {
+        SearchService.model         = null;
+        QueryService.queryDocuments = async () => ({
+            results: [{source: 'learn/agentos/KnowledgeBase.md', score: '100', metadata: {}}]
+        });
 
         await expect(SearchService.ask({query: 'How does KB work?'}))
             .rejects.toThrow('GEMINI_API_KEY is required for RAG features.');


### PR DESCRIPTION
Resolves #11645

Authored by GPT-5 Codex (Codex Desktop). Session d13c94dd-e721-4e28-ac9e-4d0b3c0f66de.

FAIR-band: over-target [17/30] - taking this lane despite over-target because the operator requested continued two-lane AFK progress, Claude owns #11637, #11645 was unassigned, and #11632 has landed so the KB tenant-isolation integration parity gap is now immediately actionable.

Adds dockerized Knowledge Base tenant-isolation integration coverage on top of the #11632 fail-closed unit suite. The new specs seed deterministic tenant-tagged KB Chroma records in the unified integration fixture, exercise KB MCP tools through proxy identities, and verify private tenant records stay hidden while `neo-shared` content remains visible across tenants.

Evidence: L2 local static/unit verification + L3 integration specs authored; GitHub `integration-unified` is the close-target because local Docker is unavailable in this sandbox. The first GitHub L3 run exposed that KB SSE transport was not propagating proxy/OIDC identity into `RequestContextService`; this PR now patches KB `Server.buildRequestContext()` so the existing #11632 tenant filters execute under SSE. Later CI passes exposed two test-shape assumptions: `SearchService.noModel.spec` expected model-guard fail-fast before retrieval, and the integration hierarchy assertion assumed `docs/output/class-hierarchy.json` exists in the Docker image. Both assertions are now aligned with the intended contracts.

## Deltas from ticket

- Implemented `KBTeamPrivateRetrieval.integration.spec.mjs` and `KBCrossTenantIsolation.integration.spec.mjs` as requested.
- Extended the existing `KBAuthRejection.integration.spec.mjs` instead of creating a separate `KBAuthRejection.tenant.integration.spec.mjs`, keeping the auth rejection surface colocated with its Phase 5A sibling.
- Added `fixtures/kbTenantRecords.mjs` to seed and clean deterministic KB records directly inside the deployed `kb-server` container, reusing the established compose fixture pattern rather than adding parallel infrastructure.
- Added KB SSE request-context propagation in `ai/mcp/server/knowledge-base/Server.mjs`; without this, authenticated proxy/OIDC requests fell through to the single-tenant path and the integration specs correctly failed.
- Tightened `SearchService.ask()` so an identity-scoped query with no visible references returns the empty-reference answer before requiring a synthesis model.
- `get_class_hierarchy` is validated as tenant-independent by comparing identity-scoped raw tool envelopes, since Docker CI may lack the generated hierarchy JSON but both tenants must still receive identical behavior.

## Test Evidence

- `node --check ai/mcp/server/knowledge-base/Server.mjs`
- `node --check test/playwright/integration/fixtures/kbTenantRecords.mjs`
- `node --check test/playwright/integration/KBTeamPrivateRetrieval.integration.spec.mjs`
- `node --check test/playwright/integration/KBCrossTenantIsolation.integration.spec.mjs`
- `node --check test/playwright/integration/KBAuthRejection.integration.spec.mjs`
- `npm run test-unit -- test/playwright/unit/ai/services/knowledge-base/SearchService.noModel.spec.mjs test/playwright/unit/ai/services/knowledge-base/KnowledgeBase.TenantIsolation.spec.mjs` - 16 passed
- `npm run test-integration-unified -- test/playwright/integration/KBTeamPrivateRetrieval.integration.spec.mjs test/playwright/integration/KBCrossTenantIsolation.integration.spec.mjs test/playwright/integration/KBAuthRejection.integration.spec.mjs` - sandboxed run hit `listen EPERM: operation not permitted 127.0.0.1:13090`; escalated rerun started the harness and skipped 4/4 because Docker is unavailable locally
- First GitHub `integration-unified` run on `e79e56684` failed 3/34, proving KB SSE identity context was not reaching tenant filters; amended head `b0bbade50` contains the request-context fix and is awaiting CI.
- Second GitHub `integration-unified` run on `b0bbade50` failed 1/34, proving `ask_knowledge_base` still required `GEMINI_API_KEY` before returning the no-visible-docs answer; amended head `46fe59d40` contains the `SearchService.ask()` retrieval-before-model fix and is awaiting CI.
- Third GitHub run on `46fe59d40` failed full `unit` on the stale `SearchService.noModel.spec` expectation and failed `integration-unified` on the generated hierarchy JSON being absent; amended head `eb5a4ab7` contains the assertion fixes and is awaiting CI.
- `git diff --cached --check`

## Post-Merge Validation

- [ ] Confirm GitHub CI `integration-unified` runs the three targeted KB integration specs in Docker and passes without local-sandbox skips.
- [ ] Confirm #11643 closeout matrix records #11645 as complete after merge.

## Commit

- `eb5a4ab7` - `test(kb): add tenant isolation integration coverage (#11645)`

## Related

- Parent: #11643
- Former blocker: #11632 (closed 2026-05-20T09:03:30Z)
