### PR TITLE
feat(kb): add Phase 2E tenant config storage (#11637)

### DIFF
--- a/ai/services/knowledge-base/KnowledgeBaseIngestionService.mjs
+++ b/ai/services/knowledge-base/KnowledgeBaseIngestionService.mjs
@@ -1,6 +1,7 @@
 import Ajv2020               from 'ajv/dist/2020.js';
 import Base                  from '../../../src/core/Base.mjs';
 import ChromaManager         from './ChromaManager.mjs';
+import GraphService          from '../memory-core/GraphService.mjs';
 import KBRecorderService     from './KBRecorderService.mjs';
 import RequestContextService,
        {normalizeUserId}    from '../../mcp/server/shared/services/RequestContextService.mjs';
@@ -54,6 +55,11 @@ class KnowledgeBaseIngestionService extends Base {
          * @summary Chroma collection manager. Injectable for deletion-signaling tests.
          */
         chromaManager: ChromaManager,
+        /**
+         * @member {Object} graphService=GraphService
+         * @summary Native Edge Graph service backing the #11637 `KnowledgeBaseTenantConfig` node. Injectable for tests.
+         */
+        graphService: GraphService,
         /**
          * @member {Object} recorderService=KBRecorderService
          * @summary Best-effort ingestion telemetry sink.
@@ -582,6 +588,98 @@ class KnowledgeBaseIngestionService extends Base {
                 ? file
                 : file?.parsedChunks?.[0] || file?.chunks?.[0];
             if (firstChunk?.repoSlug) return firstChunk.repoSlug;
+        }
+    }
+
+    /**
+     * @summary Resolves a tenant's Knowledge Base ingestion config (#11637 Phase 2E).
+     *
+     * Tiered resolution: the `KnowledgeBaseTenantConfig` graph node (`kb-config:<tenantId>`) →
+     * the default source/parser registry from `aiConfig`. The intermediate `kb-config.yaml`
+     * deployment-bootstrap tier lands in a subsequent commit; this resolves graph → default.
+     * @param {Object}  data
+     * @param {String} [data.tenantId] Tenant id; normalized, defaults to `aiConfig.defaultTenantId`.
+     * @returns {Promise<{tenantId: String, source: String, version: Number, useDefaultSources: Boolean, useDefaultParsers: Boolean, customSources: Array, customParsers: Array, sourcePaths: Object}>}
+     */
+    async getTenantConfig({tenantId} = {}) {
+        const resolvedTenant = normalizeUserId(tenantId) || aiConfig.defaultTenantId || 'neo-shared';
+
+        await this.graphService.initAsync();
+
+        const record = this.graphService.getNodeRecord({id: `kb-config:${resolvedTenant}`});
+
+        if (record?.properties) {
+            const p = record.properties;
+            return {
+                tenantId         : resolvedTenant,
+                source           : 'graph',
+                version          : p.version || 0,
+                useDefaultSources: p.useDefaultSources !== false,
+                useDefaultParsers: p.useDefaultParsers !== false,
+                customSources    : p.customSources || [],
+                customParsers    : p.customParsers || [],
+                sourcePaths      : p.sourcePaths    || {}
+            };
+        }
+
+        // Tier — default registry. The `kb-config.yaml` bootstrap tier follows in a subsequent commit.
+        return {
+            tenantId         : resolvedTenant,
+            source           : 'default',
+            version          : 0,
+            useDefaultSources: aiConfig.useDefaultSources !== false,
+            useDefaultParsers: aiConfig.useDefaultParsers !== false,
+            customSources    : aiConfig.customSources || [],
+            customParsers    : aiConfig.customParsers || [],
+            sourcePaths      : aiConfig.sourcePaths    || {}
+        };
+    }
+
+    /**
+     * @summary Persists a tenant's Knowledge Base ingestion config as a versioned graph node (#11637 Phase 2E).
+     *
+     * Writes the `KnowledgeBaseTenantConfig` node (`kb-config:<tenantId>`); `version` increments on
+     * each mutation. RLS: `resolveTenantContext` rejects a caller mutating another tenant's config
+     * (`KB_INGEST_TENANT_MISMATCH`). The explicit gate is required because `GraphService.upsertNode`
+     * auto-stamps the *caller's* identity onto `properties.userId` — an un-gated cross-tenant write
+     * would silently re-own the node rather than be rejected.
+     * @param {Object} data
+     * @param {String} data.tenantId Tenant id.
+     * @param {Object} [data.config={}] Config payload — `useDefaultSources` / `useDefaultParsers` /
+     *                                  `customSources` / `customParsers` / `sourcePaths`.
+     * @returns {Promise<{tenantId: String, version: Number}|{error: String, code: String, message: String}>}
+     */
+    async setTenantConfig({tenantId, config = {}} = {}) {
+        try {
+            const {tenantId: resolvedTenant} = this.resolveTenantContext({tenantId});
+
+            await this.graphService.initAsync();
+
+            const nodeId   = `kb-config:${resolvedTenant}`,
+                  existing = this.graphService.getNodeRecord({id: nodeId}),
+                  version  = (existing?.properties?.version || 0) + 1;
+
+            await this.graphService.upsertNode({
+                id        : nodeId,
+                type      : 'KnowledgeBaseTenantConfig',
+                properties: {
+                    tenantId         : resolvedTenant,
+                    useDefaultSources: config.useDefaultSources !== false,
+                    useDefaultParsers: config.useDefaultParsers !== false,
+                    customSources    : config.customSources || [],
+                    customParsers    : config.customParsers || [],
+                    sourcePaths      : config.sourcePaths    || {},
+                    version
+                }
+            });
+
+            return {tenantId: resolvedTenant, version};
+        } catch (error) {
+            return {
+                error  : 'Tenant config write failed',
+                code   : error.code || 'KB_TENANT_CONFIG_WRITE_FAILED',
+                message: error.message
+            };
         }
     }
 

--- a/ai/services/knowledge-base/KnowledgeBaseIngestionService.mjs
+++ b/ai/services/knowledge-base/KnowledgeBaseIngestionService.mjs
@@ -12,6 +12,7 @@ import crypto                from 'crypto';
 import fs                    from 'fs-extra';
 import os                    from 'os';
 import path                  from 'path';
+import yaml                  from 'js-yaml';
 import {fileURLToPath}       from 'url';
 
 const __filename = fileURLToPath(import.meta.url);
@@ -594,9 +595,8 @@ class KnowledgeBaseIngestionService extends Base {
     /**
      * @summary Resolves a tenant's Knowledge Base ingestion config (#11637 Phase 2E).
      *
-     * Tiered resolution: the `KnowledgeBaseTenantConfig` graph node (`kb-config:<tenantId>`) →
-     * the default source/parser registry from `aiConfig`. The intermediate `kb-config.yaml`
-     * deployment-bootstrap tier lands in a subsequent commit; this resolves graph → default.
+     * Three-tier resolution: the `KnowledgeBaseTenantConfig` graph node (`kb-config:<tenantId>`) →
+     * the `kb-config.yaml` deployment bootstrap → the default source/parser registry from `aiConfig`.
      * @param {Object}  data
      * @param {String} [data.tenantId] Tenant id; normalized, defaults to `aiConfig.defaultTenantId`.
      * @returns {Promise<{tenantId: String, source: String, version: Number, useDefaultSources: Boolean, useDefaultParsers: Boolean, customSources: Array, customParsers: Array, sourcePaths: Object}>}
@@ -622,7 +622,23 @@ class KnowledgeBaseIngestionService extends Base {
             };
         }
 
-        // Tier — default registry. The `kb-config.yaml` bootstrap tier follows in a subsequent commit.
+        // Tier 2 — kb-config.yaml deployment bootstrap (first-deploy convenience; the graph node is canonical).
+        const bootstrap = this.readKbConfigBootstrap()?.tenants?.[resolvedTenant];
+
+        if (bootstrap) {
+            return {
+                tenantId         : resolvedTenant,
+                source           : 'yaml',
+                version          : 0,
+                useDefaultSources: bootstrap.useDefaultSources !== false,
+                useDefaultParsers: bootstrap.useDefaultParsers !== false,
+                customSources    : bootstrap.customSources || [],
+                customParsers    : bootstrap.customParsers || [],
+                sourcePaths      : bootstrap.sourcePaths    || {}
+            };
+        }
+
+        // Tier 3 — default source/parser registry.
         return {
             tenantId         : resolvedTenant,
             source           : 'default',
@@ -633,6 +649,30 @@ class KnowledgeBaseIngestionService extends Base {
             customParsers    : aiConfig.customParsers || [],
             sourcePaths      : aiConfig.sourcePaths    || {}
         };
+    }
+
+    /**
+     * @summary Reads the optional `kb-config.yaml` deployment bootstrap, fail-soft (#11637 Phase 2E).
+     *
+     * The bootstrap is a deployment-root first-deploy convenience (`{tenants: {<tenantId>: {...}}}`);
+     * the `KnowledgeBaseTenantConfig` graph node remains the canonical store. A missing or malformed
+     * file resolves to `null` so `getTenantConfig` falls through to the default registry rather than
+     * throwing.
+     * @returns {Object|null} The parsed bootstrap document, or `null` when absent / unreadable.
+     * @protected
+     */
+    readKbConfigBootstrap() {
+        try {
+            const bootstrapPath = path.join(aiConfig.neoRootDir, 'kb-config.yaml');
+
+            if (!fs.existsSync(bootstrapPath)) {
+                return null;
+            }
+
+            return yaml.load(fs.readFileSync(bootstrapPath, 'utf8')) || null;
+        } catch {
+            return null;
+        }
     }
 
     /**

--- a/ai/services/knowledge-base/KnowledgeBaseIngestionService.mjs
+++ b/ai/services/knowledge-base/KnowledgeBaseIngestionService.mjs
@@ -120,6 +120,14 @@ class KnowledgeBaseIngestionService extends Base {
             const tenantContext = this.resolveTenantContext(payload);
             summary.tenantId    = tenantContext.tenantId;
 
+            // #11637 — resolve the active tenant-config version for chunk-metadata stamping.
+            // Fail-soft: a graph read must never break an ingest, so a resolution failure degrades to 0.
+            try {
+                tenantContext.configVersion = (await this.getTenantConfig({tenantId: tenantContext.tenantId})).version;
+            } catch {
+                tenantContext.configVersion = 0;
+            }
+
             if (!Array.isArray(payload.files)) {
                 summary.errors.push(this.createError({
                     code   : 'KB_INGEST_FILES_INVALID',

--- a/ai/services/knowledge-base/VectorService.mjs
+++ b/ai/services/knowledge-base/VectorService.mjs
@@ -10,7 +10,7 @@ import path                      from 'path';
 import readline                  from 'readline';
 import DestructiveOperationGuard from '../../mcp/server/shared/services/DestructiveOperationGuard.mjs';
 
-const TENANT_GUARDED_FIELDS = ['tenantId', 'repoSlug', 'visibility', 'originAgentIdentity'];
+const TENANT_GUARDED_FIELDS = ['tenantId', 'repoSlug', 'visibility', 'originAgentIdentity', 'tenantConfigVersion'];
 const STALE_STRATEGIES      = Object.freeze(new Set(['delete-upfront', 'shadow-swap']));
 const STALE_STRATEGY_SKIP   = 'skip';
 
@@ -122,14 +122,17 @@ class VectorService extends Base {
      * @param {String} [tenantContext.repoSlug] Repository slug within the tenant.
      * @param {String} [tenantContext.visibility] Visibility scope for read-side filtering.
      * @param {String} [tenantContext.originAgentIdentity] Authenticated agent identity.
-     * @returns {{tenantId: String, repoSlug: String, visibility: String, originAgentIdentity: String|undefined}}
+     * @param {Number} [tenantContext.configVersion] Active `KnowledgeBaseTenantConfig` version (#11637);
+     *                                               stamped onto chunk metadata as `tenantConfigVersion`.
+     * @returns {{tenantId: String, repoSlug: String, visibility: String, tenantConfigVersion: Number, originAgentIdentity: String|undefined}}
      */
     resolveTenantStamp(tenantContext = {}) {
         const config = this.getTenantIsolationConfig();
         const stamp = {
-            tenantId  : tenantContext.tenantId ?? config.defaultTenantId ?? 'neo-shared',
-            repoSlug  : tenantContext.repoSlug ?? config.defaultRepoSlug ?? 'neo',
-            visibility: tenantContext.visibility ?? config.defaultVisibility ?? 'team'
+            tenantId           : tenantContext.tenantId ?? config.defaultTenantId ?? 'neo-shared',
+            repoSlug           : tenantContext.repoSlug ?? config.defaultRepoSlug ?? 'neo',
+            visibility         : tenantContext.visibility ?? config.defaultVisibility ?? 'team',
+            tenantConfigVersion: tenantContext.configVersion ?? 0
         };
 
         if (tenantContext.originAgentIdentity) {

--- a/ai/services/memory-core/GraphService.mjs
+++ b/ai/services/memory-core/GraphService.mjs
@@ -609,6 +609,41 @@ class GraphService extends Base {
     }
 
     /**
+     * @summary Retrieves a node's full record — including the `properties` blob that {@link GraphService#getNode} strips.
+     *
+     * `getNode` projects only the hoisted fields (`id` / `type` / `name` / `description` / `semanticVectorId` /
+     * `state`); a consumer that stores a structured payload under `properties` (e.g. the #11637
+     * `KnowledgeBaseTenantConfig` node) needs the raw `properties` object. This getter applies the identical
+     * #10011 RLS visibility re-check as `getNode` — a cross-tenant node returns `null` — so it is a
+     * properties-returning read, not an RLS bypass.
+     * @param {Object} data
+     * @param {String} data.id Node id.
+     * @returns {Object|null} `{id, type, properties}`, or `null` when the node is absent or RLS-invisible.
+     */
+    getNodeRecord({id}) {
+        // Guarantee lazy-loading from SQLite triggers if not cached (mirrors getNode).
+        this.db.getAdjacentNodes(id, 'both');
+
+        const node = this.db.nodes.get(id);
+        if (!node) {
+            return null;
+        }
+
+        // #10011 RLS: the node Store is a process-wide cache — re-check visibility at the
+        // return boundary so a cross-requester cache-warmed node is not leaked.
+        const rlsUserId = this.db.storage?.RequestContextService?.getAgentIdentityNodeId() ?? null;
+        if (!isRlsVisible(node, rlsUserId)) {
+            return null;
+        }
+
+        return {
+            id        : node.isRecord ? node.get('id') : node.id,
+            type      : node.isRecord ? node.get('label') : node.label,
+            properties: (node.isRecord ? node.get('properties') : node.properties) || {}
+        };
+    }
+
+    /**
      * Dynamically computes the structural gravity (inbound/outbound edges) for a node natively via SQLite.
      * @param {String} id
      * @returns {Object} { in_degree, out_degree }

--- a/test/playwright/integration/KBBackupRestoreWipe.integration.spec.mjs
+++ b/test/playwright/integration/KBBackupRestoreWipe.integration.spec.mjs
@@ -578,6 +578,70 @@ function ingestTenantViaCli({collectionName, recordCount, repoSlug, tenantId}) {
     });
 }
 
+/**
+ * Drives the #11637 Phase 2E tenant-config-storage persistence path inside the deployed KB
+ * container. Writes a tenant's config as a `KnowledgeBaseTenantConfig` graph node via
+ * `setTenantConfig`, reads it back, then simulates a KB-server restart by dropping the
+ * in-memory Native Edge Graph cache — forcing the next `getTenantConfig` to reload the node
+ * from the on-disk `memory-core-graph.sqlite`. `KnowledgeBaseIngestionService` is imported
+ * directly (not via `ai/services.mjs`) so the makeSafe Zod wrapper does not strip the
+ * structured config payload; all calls run under the tenant's request context so the
+ * `setTenantConfig` RLS gate and the `getNodeRecord` RLS re-check resolve as the owner.
+ * @param {Object} options
+ * @param {String} options.tenantId Tenant id whose config node is written + reloaded.
+ * @returns {Object}
+ */
+function tenantConfigPersistsAcrossRestart({tenantId}) {
+    return execKnowledgeBaseJson(`
+        ${NEO_BOOTSTRAP}
+
+        const {KB_LifecycleService}            = await import('./ai/services.mjs');
+        const {default: KB_IngestionService}   = await import('./ai/services/knowledge-base/KnowledgeBaseIngestionService.mjs');
+        const {default: GraphService}          = await import('./ai/services/memory-core/GraphService.mjs');
+        const {default: RequestContextService} = await import('./ai/mcp/server/shared/services/RequestContextService.mjs');
+
+        await KB_LifecycleService.ready();
+        await GraphService.initAsync();
+
+        const tenantId = process.env.NEO_TEST_KB_TENANT;
+        const nodeId   = 'kb-config:' + tenantId;
+
+        function asTenant(callback) {
+            return RequestContextService.run({
+                userId             : tenantId,
+                username           : tenantId,
+                agentIdentityNodeId: '@' + tenantId,
+                source             : 'integration'
+            }, callback);
+        }
+
+        try {
+            await asTenant(() => KB_IngestionService.setTenantConfig({
+                tenantId,
+                config: {useDefaultSources: false, customParsers: [{parserId: 'restart-probe'}]}
+            }));
+
+            const beforeRestart = await asTenant(() => KB_IngestionService.getTenantConfig({tenantId}));
+
+            // Simulate a KB-server restart: drop the in-memory graph cache so the next read
+            // must reload the node from the on-disk memory-core-graph.sqlite.
+            GraphService.db.nodes.clearSilent();
+            GraphService.db.edges.clearSilent();
+            GraphService.db.vicinityLoadedNodes.clear();
+
+            const afterRestart = await asTenant(() => KB_IngestionService.getTenantConfig({tenantId}));
+
+            console.log(JSON.stringify({beforeRestart, afterRestart}));
+        } finally {
+            try {
+                await asTenant(() => GraphService.removeNodes([nodeId]));
+            } catch {}
+        }
+    `, {
+        NEO_TEST_KB_TENANT: tenantId
+    });
+}
+
 test.describe('Dockerized KB backup -> wipe -> restore integration (#11644)', () => {
     test('restores a seeded Knowledge Base vector after an isolated fixture wipe', async () => {
         const readiness = await getReadiness();
@@ -728,5 +792,33 @@ test.describe('Dockerized KB backup -> wipe -> restore integration (#11644)', ()
         // Chroma ground truth: every streamed chunk embedded into the isolated collection.
         expect(outcome.after.collectionName).toBe(collectionName);
         expect(outcome.after.count).toBe(recordCount);
+    });
+
+    test('tenant config persists across a simulated KB-server restart (#11637)', async () => {
+        const readiness = await getReadiness();
+
+        test.skip(readiness.dockerAvailable === false, `Docker unavailable: ${readiness.reason}`);
+        expect(readiness.servicesReady, readiness.reason).toBe(true);
+
+        const outcome = tenantConfigPersistsAcrossRestart({tenantId: `kb-cfg-restart-${Date.now()}`});
+
+        // Pre-restart: the config resolves from the KnowledgeBaseTenantConfig graph node
+        // setTenantConfig just wrote.
+        expect(outcome.beforeRestart).toMatchObject({
+            source           : 'graph',
+            version          : 1,
+            useDefaultSources: false,
+            customParsers    : [{parserId: 'restart-probe'}]
+        });
+
+        // Post-restart: the in-memory graph cache was cleared, so this read reloaded the
+        // node from memory-core-graph.sqlite — the config still resolves from the graph
+        // tier, proving on-disk persistence across a restart.
+        expect(outcome.afterRestart).toMatchObject({
+            source           : 'graph',
+            version          : 1,
+            useDefaultSources: false,
+            customParsers    : [{parserId: 'restart-probe'}]
+        });
     });
 });

--- a/test/playwright/unit/ai/services/knowledge-base/KnowledgeBaseIngestionService.spec.mjs
+++ b/test/playwright/unit/ai/services/knowledge-base/KnowledgeBaseIngestionService.spec.mjs
@@ -387,3 +387,96 @@ test.describe('KnowledgeBaseIngestionService.ingestSourceFiles', () => {
         expect(vectorCalls[0].options.viaMcp).toBe(true);
     });
 });
+
+test.describe('KnowledgeBaseIngestionService.tenantConfig (#11637)', () => {
+    let Service;
+    let originals;
+    let graphStub;
+
+    /**
+     * Minimal in-memory stub of the GraphService surface consumed by getTenantConfig / setTenantConfig.
+     * @returns {Object}
+     */
+    function createGraphStub() {
+        const store = new Map();
+
+        return {
+            store,
+            async initAsync() {},
+            getNodeRecord({id}) {
+                return store.has(id) ? {...store.get(id)} : null;
+            },
+            async upsertNode({id, type, properties}) {
+                store.set(id, {id, type, properties: {...properties}});
+            }
+        };
+    }
+
+    test.beforeAll(async () => {
+        Service = (await import('../../../../../../ai/services/knowledge-base/KnowledgeBaseIngestionService.mjs')).default;
+    });
+
+    test.beforeEach(() => {
+        graphStub = createGraphStub();
+        originals = {
+            graphService         : Service.graphService,
+            requestContextService: Service.requestContextService
+        };
+
+        Service.graphService          = graphStub;
+        Service.requestContextService = {
+            getAgentIdentityNodeId: () => '@tenant-a',
+            getUserId             : () => 'tenant-a'
+        };
+    });
+
+    test.afterEach(() => {
+        Object.assign(Service, originals);
+    });
+
+    test('setTenantConfig persists a versioned KnowledgeBaseTenantConfig node that getTenantConfig reads back', async () => {
+        const written = await Service.setTenantConfig({
+            tenantId: 'tenant-a',
+            config  : {useDefaultSources: false, customParsers: [{parserId: 'es5'}]}
+        });
+        expect(written).toEqual({tenantId: 'tenant-a', version: 1});
+
+        const node = graphStub.store.get('kb-config:tenant-a');
+        expect(node.type).toBe('KnowledgeBaseTenantConfig');
+
+        const resolved = await Service.getTenantConfig({tenantId: 'tenant-a'});
+        expect(resolved).toMatchObject({
+            tenantId         : 'tenant-a',
+            source           : 'graph',
+            version          : 1,
+            useDefaultSources: false,
+            customParsers    : [{parserId: 'es5'}]
+        });
+    });
+
+    test('setTenantConfig increments the config version on each mutation', async () => {
+        const first  = await Service.setTenantConfig({tenantId: 'tenant-a', config: {}});
+        const second = await Service.setTenantConfig({tenantId: 'tenant-a', config: {useDefaultParsers: false}});
+
+        expect(first.version).toBe(1);
+        expect(second.version).toBe(2);
+        expect((await Service.getTenantConfig({tenantId: 'tenant-a'})).version).toBe(2);
+    });
+
+    test('setTenantConfig rejects a cross-tenant write via the resolveTenantContext RLS gate', async () => {
+        // The authenticated context is tenant-a (beforeEach); a write targeting tenant-b must be refused.
+        const result = await Service.setTenantConfig({tenantId: 'tenant-b', config: {}});
+
+        expect(result.code).toBe('KB_INGEST_TENANT_MISMATCH');
+        expect(result.error).toBe('Tenant config write failed');
+        expect(graphStub.store.has('kb-config:tenant-b')).toBe(false);
+    });
+
+    test('getTenantConfig falls back to the default registry when no graph node exists', async () => {
+        const resolved = await Service.getTenantConfig({tenantId: 'tenant-without-config'});
+
+        expect(resolved.source).toBe('default');
+        expect(resolved.version).toBe(0);
+        expect(typeof resolved.useDefaultSources).toBe('boolean');
+    });
+});

--- a/test/playwright/unit/ai/services/knowledge-base/KnowledgeBaseIngestionService.spec.mjs
+++ b/test/playwright/unit/ai/services/knowledge-base/KnowledgeBaseIngestionService.spec.mjs
@@ -420,10 +420,12 @@ test.describe('KnowledgeBaseIngestionService.tenantConfig (#11637)', () => {
         graphStub = createGraphStub();
         originals = {
             graphService         : Service.graphService,
+            readKbConfigBootstrap: Service.readKbConfigBootstrap,
             requestContextService: Service.requestContextService
         };
 
         Service.graphService          = graphStub;
+        Service.readKbConfigBootstrap = () => null;
         Service.requestContextService = {
             getAgentIdentityNodeId: () => '@tenant-a',
             getUserId             : () => 'tenant-a'
@@ -478,5 +480,25 @@ test.describe('KnowledgeBaseIngestionService.tenantConfig (#11637)', () => {
         expect(resolved.source).toBe('default');
         expect(resolved.version).toBe(0);
         expect(typeof resolved.useDefaultSources).toBe('boolean');
+    });
+
+    test('getTenantConfig resolves the kb-config.yaml bootstrap tier when no graph node exists', async () => {
+        Service.readKbConfigBootstrap = () => ({
+            tenants: {
+                'tenant-a': {useDefaultSources: false, customSources: [{sourceName: 'BootstrapSource'}]}
+            }
+        });
+
+        const resolved = await Service.getTenantConfig({tenantId: 'tenant-a'});
+        expect(resolved).toMatchObject({
+            tenantId         : 'tenant-a',
+            source           : 'yaml',
+            version          : 0,
+            useDefaultSources: false,
+            customSources    : [{sourceName: 'BootstrapSource'}]
+        });
+
+        // A tenant absent from the bootstrap still falls through to the default tier.
+        expect((await Service.getTenantConfig({tenantId: 'tenant-z'})).source).toBe('default');
     });
 });

--- a/test/playwright/unit/ai/services/knowledge-base/KnowledgeBaseIngestionService.spec.mjs
+++ b/test/playwright/unit/ai/services/knowledge-base/KnowledgeBaseIngestionService.spec.mjs
@@ -88,6 +88,7 @@ test.describe('KnowledgeBaseIngestionService.ingestSourceFiles', () => {
 
         originals = {
             chromaManager        : Service.chromaManager,
+            getTenantConfig      : Service.getTenantConfig,
             recorderService      : Service.recorderService,
             requestContextService: Service.requestContextService,
             revisionResolver     : Service.revisionResolver,
@@ -98,6 +99,9 @@ test.describe('KnowledgeBaseIngestionService.ingestSourceFiles', () => {
         Service.chromaManager = {
             getKnowledgeBaseCollection: async () => collection
         };
+        // ingestSourceFiles resolves the tenant-config version for chunk stamping (#11637);
+        // stubbed here so this suite stays focused on ingestion orchestration.
+        Service.getTenantConfig = async () => ({version: 0});
         Service.recorderService = {
             recordIngestionMetric: entry => metrics.push(entry)
         };
@@ -385,6 +389,31 @@ test.describe('KnowledgeBaseIngestionService.ingestSourceFiles', () => {
         });
 
         expect(vectorCalls[0].options.viaMcp).toBe(true);
+    });
+
+    test('stamps the resolved tenant-config version onto the ingestion tenant context (#11637)', async () => {
+        Service.getTenantConfig = async () => ({version: 7});
+
+        const summary = await Service.ingestSourceFiles({
+            tenantId: 'tenant-a',
+            files   : [{parsedChunks: [validParsedChunk()]}]
+        });
+
+        expect(summary.ingested).toBe(1);
+        expect(vectorCalls[0].options.tenantContext.configVersion).toBe(7);
+    });
+
+    test('degrades tenantConfigVersion to 0 when tenant-config resolution fails — ingest still succeeds (#11637)', async () => {
+        Service.getTenantConfig = async () => { throw new Error('graph unavailable'); };
+
+        const summary = await Service.ingestSourceFiles({
+            tenantId: 'tenant-a',
+            files   : [{parsedChunks: [validParsedChunk()]}]
+        });
+
+        expect(summary.ingested).toBe(1);
+        expect(summary.errors).toEqual([]);
+        expect(vectorCalls[0].options.tenantContext.configVersion).toBe(0);
     });
 });
 

--- a/test/playwright/unit/ai/services/knowledge-base/VectorService.tenantStamping.spec.mjs
+++ b/test/playwright/unit/ai/services/knowledge-base/VectorService.tenantStamping.spec.mjs
@@ -187,7 +187,28 @@ test.describe('VectorService.embed — tenant stamping (#11631)', () => {
         expect(row.metadata.repoSlug).toBe('neo');
         expect(row.metadata.visibility).toBe('team');
         expect('originAgentIdentity' in row.metadata).toBe(false);
+        expect(row.metadata.tenantConfigVersion).toBe(0);
         expect(warnCalls).toHaveLength(0);
+    });
+
+    test('stamps the active tenant-config version onto chunk metadata (#11637)', async () => {
+        const spy = createSpyCollection();
+        KB_ChromaManager.getKnowledgeBaseCollection = async () => spy;
+
+        writeFixtureJsonl(fixturePath, [{
+            hash       : 'raw-hash-cfg',
+            type       : 'guide',
+            name       : 'TenantConfigVersionDoc',
+            className  : '',
+            description: 'tenant config version stamping',
+            content    : 'body'
+        }]);
+
+        await KB_VectorService.embed(fixturePath, {
+            tenantContext: {tenantId: 'tenant-a', repoSlug: 'repo-a', visibility: 'team', configVersion: 7}
+        });
+
+        expect(getOnlyRow(spy).metadata.tenantConfigVersion).toBe(7);
     });
 
     test('overwrites conflicting client-supplied tenant metadata and logs diagnostics', async () => {

--- a/test/playwright/unit/ai/services/memory-core/GraphService.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/GraphService.spec.mjs
@@ -31,7 +31,7 @@ test.describe('Neo.ai.services.memory-core.GraphService', () => {
 
     test.beforeAll(async () => {
         const aiConfig                = (await import('../../../../../../ai/mcp/server/memory-core/config.mjs')).default;
-        
+
         const tmpDir = path.resolve(process.cwd(), 'tmp');
         if (!fs.existsSync(tmpDir)) {
             fs.mkdirSync(tmpDir, { recursive: true });
@@ -137,6 +137,61 @@ test.describe('Neo.ai.services.memory-core.GraphService', () => {
         expect(() => GraphService.removeNodes(['ValidNode', undefined])).toThrow(/invalid node id/);
     });
 
+    test('getNodeRecord returns the properties blob that getNode strips (#11637)', async () => {
+        test.skip(!!process.env.NEO_TEST_SKIP_CI, 'CI-skip: SqliteError disk I/O - bucket G3 (#10924)');
+        await GraphService.upsertNode({
+            id        : 'kb-config:tenant-alpha',
+            type      : 'KnowledgeBaseTenantConfig',
+            properties: {useDefaultSources: true, customParsers: [{parserId: 'p1'}], version: 3}
+        });
+
+        const record = await GraphService.getNodeRecord({id: 'kb-config:tenant-alpha'});
+        expect(record.id).toBe('kb-config:tenant-alpha');
+        expect(record.type).toBe('KnowledgeBaseTenantConfig');
+        expect(record.properties.useDefaultSources).toBe(true);
+        expect(record.properties.customParsers).toEqual([{parserId: 'p1'}]);
+        expect(record.properties.version).toBe(3);
+
+        // getNode projects only hoisted fields — the structured payload is absent.
+        const projected = await GraphService.getNode({id: 'kb-config:tenant-alpha'});
+        expect(projected.properties).toBeUndefined();
+
+        // Absent id → null.
+        expect(await GraphService.getNodeRecord({id: 'kb-config:does-not-exist'})).toBe(null);
+    });
+
+    test('getNodeRecord applies the #10011 RLS visibility re-check (#11637)', async () => {
+        test.skip(!!process.env.NEO_TEST_SKIP_CI, 'CI-skip: SqliteError disk I/O - bucket G3 (#10924)');
+        const RequestContextService = (await import('../../../../../../ai/mcp/server/shared/services/RequestContextService.mjs')).default;
+
+        let mockIdentity    = '@tenant-alpha';
+        const originalGetId = RequestContextService.getAgentIdentityNodeId;
+        RequestContextService.getAgentIdentityNodeId = () => mockIdentity;
+
+        try {
+            // Written as tenant-alpha → upsertNode auto-stamps properties.userId.
+            await GraphService.upsertNode({
+                id        : 'kb-config:tenant-alpha',
+                type      : 'KnowledgeBaseTenantConfig',
+                properties: {useDefaultSources: false, version: 1}
+            });
+
+            // Force a disk reload so the RLS re-check runs against a cache-warmed node.
+            GraphService.db.nodes.clearSilent();
+
+            // Owner reads its own record.
+            mockIdentity = '@tenant-alpha';
+            const ownRecord = await GraphService.getNodeRecord({id: 'kb-config:tenant-alpha'});
+            expect(ownRecord?.properties.version).toBe(1);
+
+            // Cross-tenant read → null, not a leak.
+            mockIdentity = '@tenant-beta';
+            expect(await GraphService.getNodeRecord({id: 'kb-config:tenant-alpha'})).toBe(null);
+        } finally {
+            RequestContextService.getAgentIdentityNodeId = originalGetId;
+        }
+    });
+
     test('preBriefSession should hydrate episodic context through getNeighbors semanticVectorId', async () => {
         await GraphService.upsertNode({id: 'EpicA', name: 'Roadmap Planner'});
         await GraphService.upsertNode({id: 'MemoryA', name: 'Session Summary', semanticVectorId: 'summary-vector-1'});
@@ -181,7 +236,7 @@ test.describe('Neo.ai.services.memory-core.GraphService', () => {
 
         const gravityA = await GraphService.getNodeGravity('NodeA');
         const gravityB = await GraphService.getNodeGravity('NodeB');
-        
+
         // NodeA out:2 (NodeB, NodeC), in:1 (NodeD)
         expect(gravityA.out_degree).toBe(2);
         expect(gravityA.in_degree).toBe(1);
@@ -266,7 +321,7 @@ test.describe('Neo.ai.services.memory-core.GraphService', () => {
         const rows = GraphService.db.storage.db.prepare('SELECT data FROM Nodes WHERE id = ?').all('@test-identity');
         expect(rows.length).toBe(1);
         const data = JSON.parse(rows[0].data);
-        
+
         expect(data.label).toBe('AGENT'); // Type is updated
         expect(data.properties.name).toBe('Test Identity'); // Original properties preserved
         expect(data.properties.githubLogin).toBe('test-user');
@@ -469,7 +524,7 @@ test.describe('Neo.ai.services.memory-core.GraphService', () => {
         // but appears in SQLite exactly when the cache-warm mechanism is triggered.
 
         await GraphService.upsertNode({ id: 'AnchorNode', type: 'AGENT', name: 'Anchor', properties: {} });
-        
+
         expect(GraphService.db.nodes.has('GhostNode')).toBe(false);
 
         // Spy on getAdjacentNodes to simulate another process writing the node during the cache-warm retry
@@ -798,7 +853,7 @@ test.describe('Neo.ai.services.memory-core.GraphService', () => {
             await GraphService.db.getAdjacentNodes('shared-node-1', 1);
             let nodeLoadedB = GraphService.db.nodes.get('shared-node-1');
             expect(nodeLoadedB).toBeTruthy();
-            
+
             // Wait, edges might be private if not explicitly shared, but RLS clause applies to edges too.
             // Edge between shared and private might not be loaded if private is not accessible.
             // Since edge has `user_id = @identity-a`, Identity B won't see it unless the edge is shared.


### PR DESCRIPTION
Authored by Neo Opus 4.7 (Claude Code). Session 470c38e7-1ffc-4851-867d-d30c1b6fbdb2.

Resolves #11637
Refs #11626, #11624

Phase 2E of Epic #11624 (Cloud-Native KB Ingestion). Adds tenant ingestion-config storage: a per-tenant `KnowledgeBaseTenantConfig` node in the Native Edge Graph, resolved via a new `KnowledgeBaseIngestionService.getTenantConfig` (three-tier — graph node → `kb-config.yaml` deployment bootstrap → default registry) and mutated via `setTenantConfig` (versioned, RLS-gated). Every ingested chunk is stamped with the active `tenantConfigVersion`, so a future config change can drive retroactive invalidation.

FAIR-band: neo-opus-4-7 at 13/30 recent merged PRs (neo-gpt 17, Gemini absent → 2-author band, ~15 target). Under-target — FAIR-band-positive, no throttle.

Evidence: L2 (51 unit tests green — `getNodeRecord` RLS, `getTenantConfig` 3-tier, `setTenantConfig` version+RLS, the `tenantConfigVersion` stamp) → L3 (AC7 restart-persistence integration test — bucket-D Docker, CI `integration-unified`). No residuals.

## What shipped

- **`GraphService.getNodeRecord({id})`** (`ai/services/memory-core/`) — a properties-returning, RLS-checked node getter. `getNode` projects only the hoisted fields and strips the `properties` blob; the tenant config payload lives in `properties`, so the new getter applies the identical #10011 RLS re-check (a cross-tenant node returns `null`) and returns `{id, type, properties}`.
- **`KnowledgeBaseIngestionService.getTenantConfig({tenantId})`** — three-tier resolution: the `kb-config:<tenantId>` graph node → the `kb-config.yaml` deployment bootstrap (`{tenants: {<id>: {...}}}`, fail-soft via `js-yaml`) → the default source/parser registry.
- **`KnowledgeBaseIngestionService.setTenantConfig({tenantId, config})`** — writes the versioned `KnowledgeBaseTenantConfig` node; `version` increments per mutation. RLS-gated via `resolveTenantContext` (a cross-tenant write is rejected with `KB_INGEST_TENANT_MISMATCH`).
- **`tenantConfigVersion` chunk-metadata stamp** — `ingestSourceFiles` resolves the active version and threads it through `tenantContext`; `VectorService.resolveTenantStamp` adds it to the authoritative tenant stamp (and `TENANT_GUARDED_FIELDS` guards it server-side).

## Deltas from ticket

Substrate-grounded design decisions, documented on the #11637 Contract Ledger:

- **D1** — tenant config entries are a `properties` JSON payload, **not** `SourceRegistration`/`ParserRegistration` edge-nodes (the ticket Fix's literal wording). V-B-A found the #11658 Source Registry is class-`Map`-based — minting registration graph-nodes would be a substrate expansion past Q5's scope. The ticket *goal* (graph-stored, tenant-scoped, versioned config) is unchanged.
- **D2** — added `GraphService.getNodeRecord` because `getNode`/`searchNodes` strip the `properties` blob; a raw `db.nodes.get` would bypass the #10011 RLS re-check.
- **`setTenantConfig` RLS** — `GraphService.upsertNode` auto-stamps the *caller's* identity onto `properties.userId`, so an un-gated cross-tenant write would silently re-own the node rather than be rejected; `setTenantConfig` therefore gates explicitly on `resolveTenantContext`.
- **Ownership primitive — `properties.userId`, not an `OWNED_BY` edge.** The Contract Ledger's `KnowledgeBaseTenantConfig` matrix row listed one `OWNED_BY` edge → `AgentIdentity`; Phase 2E instead uses `properties.userId` (auto-stamped by `upsertNode`) as the sole ownership mechanism — #10011 `isRlsVisible` gates on `properties.userId`, so an `OWNED_BY` edge would be a redundant second representation (the same substrate-expansion logic as D1). The ledger row is corrected in #11637 comment `4503692675`; surfaced by @neo-gpt's Cycle-1 review.
- **Graph-as-ingestion-dependency** — routing `getTenantConfig` into `ingestSourceFiles` makes the Native Edge Graph a dependency of the ingestion path; the call is **fail-soft** (graph-unavailable → `tenantConfigVersion: 0`, the ingest still completes).
- **`kb-config.yaml` naming** — #11700's per-workspace fixture `kb-config.yaml` files are a distinct artifact (per-synthetic-workspace test descriptors) from this PR's deployment-root server-config; no path collision, the name overlap is benign for V1.

## Test Evidence

- `npm run test-unit -- GraphService.spec KnowledgeBaseIngestionService.spec VectorService.tenantStamping.spec` → **51 passed**. The 10 new #11637 cases: `getNodeRecord` returns `properties` + the RLS re-check (×2); `getTenantConfig` set/get round-trip, version increment, cross-tenant RLS rejection, default-tier fallback, yaml-bootstrap tier (×5); the `tenantConfigVersion` threading, fail-soft degrade-to-0, and the metadata stamp (×3).
- AC7 integration: `tenantConfigPersistsAcrossRestart` in `KBBackupRestoreWipe.integration.spec.mjs` — `setTenantConfig` writes a config node, the in-memory graph cache is cleared (restart simulation), and `getTenantConfig` re-resolves from the on-disk `memory-core-graph.sqlite`. bucket-D Docker; `node --check` syntax-valid; runs in CI's `integration-unified`.

## Post-Merge Validation

- [ ] CI `integration-unified` runs the #11637 restart-persistence scenario green against the deployed kb-server.

## Commits

- `c33a64e5d` — feat(memory-core): add `GraphService.getNodeRecord` RLS-checked properties getter
- `a8c5c9a4f` — feat(kb): add `getTenantConfig` / `setTenantConfig` tenant config storage
- `2ef790a6d` — feat(kb): add `kb-config.yaml` bootstrap tier to `getTenantConfig`
- `5a25eaa32` — feat(kb): stamp `tenantConfigVersion` onto ingested chunk metadata
- `c9a5dd3cd` — test(kb): add the restart-persistence integration test (AC7)

## Related

- Contract Ledger + the D1/D2 design decisions: #11637 comment `4503002767`
- Contract Ledger correction (the `OWNED_BY` ownership row): #11637 comment `4503692675`
- Implementation finding (the KB → Native Edge Graph integration): #11637 comment `4503195741`
- Discussion #11623 §4 Q5 — the Cloud-Native KB Ingestion design / Phase 2E source of authority
