### PR TITLE
fix(collection): guard isItem against null (#11705)

### DIFF
--- a/src/collection/Base.mjs
+++ b/src/collection/Base.mjs
@@ -1293,7 +1293,7 @@ class Collection extends Base {
      */
     isItem(value) {
         // We can not use Neo.isObject() || Neo.isRecord(), since collections can store neo instances too.
-        return typeof value === 'object'
+        return value !== null && typeof value === 'object'
     }
 
     /**

--- a/test/playwright/unit/collection/Base.spec.mjs
+++ b/test/playwright/unit/collection/Base.spec.mjs
@@ -284,6 +284,15 @@ test.describe.serial('Neo.collection.Base', () => {
         ]);
     });
 
+    test('isItem excludes null while preserving object-like items', () => {
+        let collection = Neo.create(Collection);
+
+        expect(collection.isItem(null)).toBe(false);
+        expect(collection.isItem('item-id')).toBe(false);
+        expect(collection.isItem({id: 'item-id'})).toBe(true);
+        expect(collection.isItem(collection)).toBe(true);
+    });
+
     test('Move collection items', () => {
         let moveCollection = Neo.create(Collection, {
             items: [


### PR DESCRIPTION
Authored by GPT-5 Codex (Codex Desktop). Session d13c94dd-e721-4e28-ac9e-4d0b3c0f66de.

FAIR-band: in-band [17/30 - current author count over last 30 merged].

Resolves #11705

Guards `Collection.isItem()` so `null` is not classified as an item, while preserving the existing object / Neo-instance acceptance path. Adds focused unit coverage proving `null` and primitive IDs remain non-items while plain objects and Neo instances remain item-like.

## Deltas from ticket
No scope deltas. The implementation follows the reported quick-win fix: `typeof value === 'object'` now additionally excludes `null`.

## Evidence
Evidence: L2 (focused Playwright unit coverage) -> L2 required (#11705 AC1-AC3). No residuals.

## Test Evidence
- `node --check src/collection/Base.mjs`
- `node --check test/playwright/unit/collection/Base.spec.mjs`
- `npm run test-unit -- test/playwright/unit/collection/Base.spec.mjs` -> 10 passed (586ms)
- `git diff --cached --check`

## Post-Merge Validation
- [ ] Optional operational rerun: `npm run ai:run-sandman` no longer trips the `Collection.isItem(null)` path during orphan cleanup.

## Commit
- `9759dd9a9` - `fix(collection): guard isItem against null (#11705)`
