### PR TITLE
feat(ai): KB Multi-Tenant Health section in Sandman handoff (#11639)

### DIFF
--- a/ai/daemons/services/GoldenPathSynthesizer.mjs
+++ b/ai/daemons/services/GoldenPathSynthesizer.mjs
@@ -443,6 +443,22 @@ DO NOT output markdown, \`\`\`json blocks, or any other explanations. Provide pu
             logger.warn(`[GoldenPathSynthesizer] ConsumerFriction section render failed: ${err.message}`);
         }
 
+        // --- #11639 Phase 4A — KB Multi-Tenant Ingestion Health (visibility) ---
+        // Per-tenant KB ingestion telemetry (the `kb_ingestion_metrics` rollup) surfaced as a
+        // handoff section. Composed here — not written by a standalone daemon — because
+        // sandman_handoff.md is regenerated idempotently in full (see the #11639 intake finding).
+        try {
+            const {renderKbMultiTenantHealthSection} = await import('../../services/knowledge-base/helpers/KbTenantHealthHelper.mjs');
+            const kbHealthSection = await renderKbMultiTenantHealthSection();
+
+            if (kbHealthSection) {
+                handoffContent += kbHealthSection + '\n';
+            }
+        } catch (err) {
+            // Defensive: a KB-telemetry failure must not break handoff rendering.
+            logger.warn(`[GoldenPathSynthesizer] KB Multi-Tenant Health section render failed: ${err.message}`);
+        }
+
         // --- Active PR Cycle State ---
         let prStateAppend = '';
         try {

--- a/ai/services/knowledge-base/helpers/KbTenantHealthHelper.mjs
+++ b/ai/services/knowledge-base/helpers/KbTenantHealthHelper.mjs
@@ -1,0 +1,91 @@
+import KBRecorderService from '../KBRecorderService.mjs';
+
+/**
+ * @summary Renders the per-tenant Knowledge Base ingestion health section for the Sandman handoff.
+ *
+ * Phase 4A (#11639) substrate. `KBRecorderService.recordIngestionMetric` captures per-event
+ * ingestion telemetry into `kb_ingestion_metrics`; `getTenantIngestionRollup` aggregates it
+ * per tenant. This helper formats that rollup as a `## KB Multi-Tenant Health` Markdown section
+ * that `GoldenPathSynthesizer.synthesizeGoldenPath` composes into `sandman_handoff.md`.
+ *
+ * It mirrors the `renderConsumerFrictionSection` pattern (`ConsumerFrictionHelper.mjs`): a
+ * section-renderer the centralized handoff generator imports and appends — deliberately NOT a
+ * standalone daemon. `sandman_handoff.md` is regenerated idempotently in full by
+ * `GoldenPathSynthesizer`, so a standalone writer's output would be overwritten; the
+ * render-helper is the substrate-correct integration shape (see #11639 intake finding).
+ *
+ * @see ai/services/knowledge-base/KBRecorderService.mjs — `getTenantIngestionRollup`, the rollup source.
+ * @see ai/daemons/services/GoldenPathSynthesizer.mjs — the handoff generator that composes this section.
+ * @see ai/services/memory-core/helpers/ConsumerFrictionHelper.mjs — the render-helper precedent.
+ */
+
+/**
+ * @summary Rolling-window default for the handoff health section — matches the handoff's 7-day TTL cadence.
+ * @type {Number}
+ */
+const SEVEN_DAYS_MS = 7 * 24 * 60 * 60 * 1000;
+
+/**
+ * @summary Formats a per-tenant ingestion rollup as the `## KB Multi-Tenant Health` Markdown section.
+ *
+ * Pure formatter — no I/O, no service access — so it is trivially unit-testable. Returns an
+ * empty string for an empty rollup, letting the caller omit the section entirely.
+ *
+ * @param {Array<Object>} rollup Per-tenant rows from `KBRecorderService.getTenantIngestionRollup`.
+ * @param {Object}  [options]
+ * @param {String} [options.windowLabel] Optional human label for the rollup window (e.g. `'last 7 days'`).
+ * @returns {String} The Markdown section, or `''` when the rollup is empty.
+ */
+export function formatKbTenantHealthSection(rollup, {windowLabel} = {}) {
+    if (!Array.isArray(rollup) || rollup.length === 0) {
+        return '';
+    }
+
+    const scope = windowLabel ? ` (${windowLabel})` : '';
+    const lines = [
+        '## KB Multi-Tenant Health',
+        '',
+        `Per-tenant Knowledge Base ingestion telemetry${scope}, rolled up from \`kb_ingestion_metrics\` (#11639).`,
+        '',
+        '| Tenant | Repo | Events | Ingest | Tombstone | Reconcile | Errors | Error rate | Embedded | Deleted |',
+        '|---|---|--:|--:|--:|--:|--:|--:|--:|--:|'
+    ];
+
+    for (const row of rollup) {
+        const errorRate = `${((row.errorRate ?? 0) * 100).toFixed(1)}%`;
+
+        lines.push(
+            `| \`${row.tenantId}\` | \`${row.repoSlug}\` | ${row.eventCount ?? 0} | ` +
+            `${row.ingestEvents ?? 0} | ${row.tombstoneEvents ?? 0} | ${row.reconcileEvents ?? 0} | ` +
+            `${row.errorEvents ?? 0} | ${errorRate} | ${row.chunksEmbedded ?? 0} | ${row.chunksDeleted ?? 0} |`
+        );
+    }
+
+    lines.push('');
+
+    return lines.join('\n');
+}
+
+/**
+ * @summary Resolves the per-tenant ingestion rollup and renders the handoff health section.
+ *
+ * The thin integration layer over {@link formatKbTenantHealthSection}: ensures the
+ * `KBRecorderService` SQLite connection is ready, fetches the per-tenant rollup, and delegates
+ * formatting. Defensive — any failure (telemetry store unavailable, locked, or absent) resolves
+ * to `''`, so a Sandman handoff regeneration is never broken by observability I/O.
+ *
+ * @param {Object}  [options]
+ * @param {Number} [options.sinceMs] Lower-bound timestamp for the rollup window. Defaults to 7 days ago.
+ * @returns {Promise<String>} The `## KB Multi-Tenant Health` section, or `''` when unavailable / empty.
+ */
+export async function renderKbMultiTenantHealthSection({sinceMs = Date.now() - SEVEN_DAYS_MS} = {}) {
+    try {
+        await KBRecorderService.ready();
+
+        const rollup = KBRecorderService.getTenantIngestionRollup({sinceMs});
+
+        return formatKbTenantHealthSection(rollup, {windowLabel: 'last 7 days'});
+    } catch (err) {
+        return '';
+    }
+}

--- a/test/playwright/unit/ai/services/knowledge-base/KbTenantHealthHelper.spec.mjs
+++ b/test/playwright/unit/ai/services/knowledge-base/KbTenantHealthHelper.spec.mjs
@@ -1,0 +1,247 @@
+import {setup} from '../../../../setup.mjs';
+
+const appName = 'KbTenantHealthHelperTest';
+
+setup({
+    neoConfig: {
+        unitTestMode: true
+    },
+    appConfig: {
+        name             : appName,
+        isMounted        : () => true,
+        vnodeInitialising: false
+    }
+});
+
+import {test, expect} from '@playwright/test';
+import Neo            from '../../../../../../src/Neo.mjs';
+import * as core      from '../../../../../../src/core/_export.mjs';
+import fs             from 'fs';
+import path           from 'path';
+
+/**
+ * Phase 4A (#11639) — `KbTenantHealthHelper` coverage: the `## KB Multi-Tenant Health`
+ * Sandman-handoff section renderer.
+ *
+ * Two surfaces:
+ *
+ * 1. `formatKbTenantHealthSection(rollup, {windowLabel})` — a pure formatter. No I/O, no
+ *    service access; the bulk of the tests exercise it directly with fixture rollups whose
+ *    shape mirrors `KBRecorderService.getTenantIngestionRollup`'s documented return contract.
+ * 2. `renderKbMultiTenantHealthSection({sinceMs})` — the thin integration layer over the
+ *    formatter. The integration block seeds the *real* `KBRecorderService` SQLite substrate
+ *    via `recordIngestionMetric`, then asserts the rendered section — covering the genuine
+ *    new seam #11639 introduces (telemetry store → rollup → Markdown section). The defensive
+ *    `''`-on-failure contract is verified by forcing the telemetry read to throw.
+ *
+ * `GoldenPathSynthesizer.synthesizeGoldenPath` composes the rendered section into
+ * `sandman_handoff.md` via the established `renderConsumerFrictionSection` precedent (a
+ * defensive try/catch append) — proven glue not re-tested here; the section's *content
+ * correctness* is what this spec guards.
+ *
+ * Serial mode: the integration block exercises the shared `KBRecorderService` SQLite singleton.
+ *
+ * @see https://github.com/neomjs/neo/issues/11639
+ * @see https://github.com/neomjs/neo/issues/11628 (Phase 4 parent epic)
+ * @see ai/services/knowledge-base/helpers/KbTenantHealthHelper.mjs — the renderer under test.
+ * @see test/playwright/unit/ai/services/knowledge-base/KBRecorderService.ingestionMetrics.spec.mjs — sibling pattern.
+ */
+test.describe.configure({mode: 'serial'});
+
+/**
+ * @summary A two-tenant rollup whose shape mirrors `KBRecorderService.getTenantIngestionRollup`.
+ * `errorRate` is supplied as the real read-API would compute it (`errorEvents / eventCount`).
+ * @type {Array<Object>}
+ */
+const TWO_TENANT_ROLLUP = [
+    {
+        tenantId       : 'tenant-acme',
+        repoSlug       : 'acme-web',
+        eventCount     : 12,
+        ingestEvents   : 9,
+        tombstoneEvents: 2,
+        reconcileEvents: 0,
+        errorEvents    : 1,
+        chunksEmbedded : 340,
+        chunksDeleted  : 18,
+        errorRate      : 1 / 12
+    },
+    {
+        tenantId       : 'neo-shared',
+        repoSlug       : 'neo',
+        eventCount     : 4,
+        ingestEvents   : 4,
+        tombstoneEvents: 0,
+        reconcileEvents: 0,
+        errorEvents    : 0,
+        chunksEmbedded : 88,
+        chunksDeleted  : 0,
+        errorRate      : 0
+    }
+];
+
+test.describe('KbTenantHealthHelper (#11639)', () => {
+    const testDbName = `kb-tenant-health-test-${process.pid}-${Date.now()}.sqlite`;
+    let testDbPath, KBRecorderService, formatKbTenantHealthSection, renderKbMultiTenantHealthSection;
+
+    test.beforeAll(async () => {
+        // Point KB telemetry at an isolated test DB *before* importing KBRecorderService — the
+        // singleton's import-time `initAsync` reads `config.memoryCoreDbPath`. The helper module
+        // is imported only after that, so its transitive `KBRecorderService` import never touches
+        // the production Memory Core database.
+        const config = (await import('../../../../../../ai/mcp/server/knowledge-base/config.mjs')).default;
+
+        const tmpDir = path.resolve(process.cwd(), 'tmp');
+        if (!fs.existsSync(tmpDir)) {
+            fs.mkdirSync(tmpDir, {recursive: true});
+        }
+
+        testDbPath = path.join(tmpDir, testDbName);
+        config.data.memoryCoreDbPath = testDbPath;
+
+        for (const suffix of ['', '-wal', '-shm']) {
+            try { fs.unlinkSync(`${testDbPath}${suffix}`); } catch (e) {}
+        }
+
+        KBRecorderService = (await import('../../../../../../ai/services/knowledge-base/KBRecorderService.mjs')).default;
+        await KBRecorderService.initAsync();
+
+        ({formatKbTenantHealthSection, renderKbMultiTenantHealthSection} =
+            await import('../../../../../../ai/services/knowledge-base/helpers/KbTenantHealthHelper.mjs'));
+    });
+
+    test.beforeEach(() => {
+        KBRecorderService.db.exec('DELETE FROM kb_ingestion_metrics;');
+    });
+
+    test.afterAll(() => {
+        if (KBRecorderService?.db) {
+            try { KBRecorderService.db.close(); } catch (e) {}
+            // Null the singleton db reference after close — `initAsync` short-circuits on
+            // `if (this.db) return`, so a sibling KBRecorderService spec running later in the
+            // same worker would otherwise inherit this closed connection. Mirrors the sibling
+            // KBRecorderService.ingestionMetrics.spec.mjs cleanup.
+            KBRecorderService.db = null;
+        }
+        for (const suffix of ['', '-wal', '-shm']) {
+            try { fs.unlinkSync(`${testDbPath}${suffix}`); } catch (e) {}
+        }
+    });
+
+    test.describe('formatKbTenantHealthSection — pure formatter', () => {
+        test('returns an empty string for an empty rollup', () => {
+            expect(formatKbTenantHealthSection([])).toBe('');
+        });
+
+        test('returns an empty string for a non-array rollup', () => {
+            expect(formatKbTenantHealthSection(null)).toBe('');
+            expect(formatKbTenantHealthSection(undefined)).toBe('');
+            expect(formatKbTenantHealthSection({})).toBe('');
+        });
+
+        test('renders the section heading, intro line, and Markdown table header', () => {
+            const section = formatKbTenantHealthSection(TWO_TENANT_ROLLUP);
+
+            expect(section).toContain('## KB Multi-Tenant Health');
+            expect(section).toContain('rolled up from `kb_ingestion_metrics` (#11639)');
+            expect(section).toContain(
+                '| Tenant | Repo | Events | Ingest | Tombstone | Reconcile | Errors | Error rate | Embedded | Deleted |'
+            );
+            expect(section).toContain('|---|---|--:|--:|--:|--:|--:|--:|--:|--:|');
+        });
+
+        test('renders exactly one Markdown table row per tenant rollup entry', () => {
+            const section  = formatKbTenantHealthSection(TWO_TENANT_ROLLUP);
+            const dataRows = section.split('\n').filter(line => line.startsWith('| `'));
+
+            expect(dataRows).toHaveLength(2);
+            expect(section).toContain('| `tenant-acme` | `acme-web` | 12 | 9 | 2 | 0 | 1 | 8.3% | 340 | 18 |');
+            expect(section).toContain('| `neo-shared` | `neo` | 4 | 4 | 0 | 0 | 0 | 0.0% | 88 | 0 |');
+        });
+
+        test('formats errorRate as a percentage with one decimal place', () => {
+            const rollup = [
+                {tenantId: 't-quarter', repoSlug: 'r', eventCount: 4, errorEvents: 1, errorRate: 0.25},
+                {tenantId: 't-all',     repoSlug: 'r', eventCount: 2, errorEvents: 2, errorRate: 1},
+                {tenantId: 't-none',    repoSlug: 'r', eventCount: 3, errorEvents: 0, errorRate: 0}
+            ];
+            const section = formatKbTenantHealthSection(rollup);
+
+            expect(section).toContain('| `t-quarter` | `r` | 4 | 0 | 0 | 0 | 1 | 25.0% | 0 | 0 |');
+            expect(section).toContain('| `t-all` | `r` | 2 | 0 | 0 | 0 | 2 | 100.0% | 0 | 0 |');
+            expect(section).toContain('| `t-none` | `r` | 3 | 0 | 0 | 0 | 0 | 0.0% | 0 | 0 |');
+        });
+
+        test('defaults missing numeric fields to 0 and a missing errorRate to 0.0%', () => {
+            const section = formatKbTenantHealthSection([{tenantId: 't-sparse', repoSlug: 'r-sparse'}]);
+
+            // Every count column renders 0, error rate 0.0% — never `undefined` or `NaN`.
+            expect(section).toContain('| `t-sparse` | `r-sparse` | 0 | 0 | 0 | 0 | 0 | 0.0% | 0 | 0 |');
+            expect(section).not.toContain('undefined');
+            expect(section).not.toContain('NaN');
+        });
+
+        test('includes the window label in the intro line when provided', () => {
+            const section = formatKbTenantHealthSection(TWO_TENANT_ROLLUP, {windowLabel: 'last 7 days'});
+
+            expect(section).toContain('ingestion telemetry (last 7 days), rolled up from');
+        });
+
+        test('omits the window-scope suffix when no window label is given', () => {
+            const section = formatKbTenantHealthSection(TWO_TENANT_ROLLUP);
+
+            expect(section).toContain('ingestion telemetry, rolled up from');
+            expect(section).not.toContain('(undefined)');
+        });
+    });
+
+    test.describe('renderKbMultiTenantHealthSection — KBRecorderService integration', () => {
+        test('renders a populated section from real seeded multi-tenant telemetry', async () => {
+            KBRecorderService.recordIngestionMetric({tenantId: 'tenant-blue',  repoSlug: 'blue-svc',  eventType: 'ingest',    chunksEmbedded: 50});
+            KBRecorderService.recordIngestionMetric({tenantId: 'tenant-blue',  repoSlug: 'blue-svc',  eventType: 'ingest',    chunksEmbedded: 30});
+            KBRecorderService.recordIngestionMetric({tenantId: 'tenant-blue',  repoSlug: 'blue-svc',  eventType: 'error',     errorCode: 'KB_INGEST_FAIL'});
+            KBRecorderService.recordIngestionMetric({tenantId: 'tenant-green', repoSlug: 'green-svc', eventType: 'tombstone', chunksDeleted: 7});
+
+            const section = await renderKbMultiTenantHealthSection();
+
+            expect(section).toContain('## KB Multi-Tenant Health');
+            // The renderer always passes a 'last 7 days' window label.
+            expect(section).toContain('ingestion telemetry (last 7 days), rolled up from');
+            // tenant-blue: 3 events, 2 ingest, 1 error -> 33.3% error rate, 50+30+0 embedded.
+            expect(section).toContain('| `tenant-blue` | `blue-svc` | 3 | 2 | 0 | 0 | 1 | 33.3% | 80 | 0 |');
+            // tenant-green: 1 tombstone, 7 chunks deleted.
+            expect(section).toContain('| `tenant-green` | `green-svc` | 1 | 0 | 1 | 0 | 0 | 0.0% | 0 | 7 |');
+        });
+
+        test('returns an empty string when no ingestion telemetry has been recorded', async () => {
+            // beforeEach already cleared kb_ingestion_metrics.
+            expect(await renderKbMultiTenantHealthSection()).toBe('');
+        });
+
+        test('excludes telemetry older than the default 7-day window', async () => {
+            const eightDaysMs = 8 * 24 * 60 * 60 * 1000;
+
+            KBRecorderService.recordIngestionMetric({tenantId: 'tenant-stale',  repoSlug: 'r-stale',  eventType: 'ingest', timestamp: Date.now() - eightDaysMs});
+            KBRecorderService.recordIngestionMetric({tenantId: 'tenant-recent', repoSlug: 'r-recent', eventType: 'ingest', timestamp: Date.now() - 60000});
+
+            const section = await renderKbMultiTenantHealthSection();
+
+            expect(section).toContain('| `tenant-recent` | `r-recent` |');
+            expect(section).not.toContain('tenant-stale');
+        });
+
+        test('resolves to an empty string defensively when the telemetry read throws', async () => {
+            const original = KBRecorderService.getTenantIngestionRollup;
+
+            KBRecorderService.getTenantIngestionRollup = () => {
+                throw new Error('simulated telemetry-store failure');
+            };
+
+            try {
+                expect(await renderKbMultiTenantHealthSection()).toBe('');
+            } finally {
+                KBRecorderService.getTenantIngestionRollup = original;
+            }
+        });
+    });
+});


### PR DESCRIPTION
Authored by Neo Opus 4.7 (Claude Code). Session 470c38e7-1ffc-4851-867d-d30c1b6fbdb2.

FAIR-band: under-target [13/30] — Self-Selection Rule 1 fires (under-band → bias toward author lane).

Resolves #11639
Related: #11628
Related: #11624

Completes Phase 4A (#11639) of Phase 4 epic #11628 (meta-epic #11624, Cloud-Native KB Ingestion). Surfaces per-tenant Knowledge Base ingestion health in `sandman_handoff.md` so cloud operators and the next REM cycle can see push frequency, error rates, and chunk volumes per tenant.

The telemetry-foundation slice of this ticket already merged: **PR #11667** (`Related: #11639`) shipped the `kb_ingestion_metrics` SQLite table, `KBRecorderService.recordIngestionMetric` (write API), and `getTenantIngestionRollup` (on-read per-tenant rollup); Phase 2A's `KnowledgeBaseIngestionService.recordMetric` already emits those events. This PR adds the remaining **handoff-visibility layer** and completes #11639:

- **`ai/services/knowledge-base/helpers/KbTenantHealthHelper.mjs`** (new) — a render helper:
  - `formatKbTenantHealthSection(rollup, {windowLabel})` — a pure formatter: a per-tenant rollup → a `## KB Multi-Tenant Health` Markdown table. Returns `''` for an empty rollup so the caller omits the section entirely.
  - `renderKbMultiTenantHealthSection({sinceMs})` — the thin integration layer: `KBRecorderService.ready()` → `getTenantIngestionRollup` over a 7-day window → `formatKbTenantHealthSection`. Defensive — any telemetry-read failure resolves to `''`, so a handoff regeneration is never broken by observability I/O.
- **`GoldenPathSynthesizer.synthesizeGoldenPath`** composes the section into `sandman_handoff.md`, in a defensive try/catch alongside the existing `renderConsumerFrictionSection` block.

Evidence: L2 (AC7+AC8 — 12/12 tests, the integration tests run the real `KBRecorderService` SQLite substrate end-to-end: `ready()` → real `getTenantIngestionRollup` → render) → L2 sufficient (test-ACs fully covered). AC6's `GoldenPathSynthesizer` composition is L1 (mirrors the already-merged `renderConsumerFrictionSection` precedent); live regenerated-handoff confirmation → Post-Merge Validation.

## Deltas from ticket

The #11639 intake surfaced that the ticket's prescribed mechanism is wrong-shape — correction posted as comment 4504088508 and acknowledged by @neo-gpt. Two ACs deviate:

- **AC5 (standalone `ai/scripts/kb-observability-daemon.mjs`) — not built.** `GoldenPathSynthesizer.synthesizeGoldenPath` regenerates `sandman_handoff.md` **idempotently in full** — a standalone daemon writing to that file would be overwritten on the next REM cycle. The substrate-correct shape is a render-helper composed by `GoldenPathSynthesizer` — the `renderConsumerFrictionSection` pattern the ticket's own "Related" hint already points at.
- **AC4 (materialized `kb_tenant_ingestion_health` projection table) — skipped for V1.** `getTenantIngestionRollup` is a single `GROUP BY` over `kb_ingestion_metrics`, read once per REM cycle — not a hot path. A materialized projection (the `kb_query_faqs` precedent materializes because FAQ-clustering is expensive) would be premature optimization here. The on-read rollup suffices for V1; a projection table can be added if read cost ever becomes measurable.

ACs 1–3 (telemetry table, write API, Phase 2A emission) shipped via PR #11667 / Phase 2A and are not re-shipped here. AC6 (handoff section), AC7 (unit tests), AC8 (integration test) are delivered by this PR.

## Test Evidence

`npm run test-unit -- test/playwright/unit/ai/services/knowledge-base/KbTenantHealthHelper.spec.mjs` → **12 passed (596ms)**.

- **8 pure-formatter tests** (`formatKbTenantHealthSection`): empty / non-array rollup → `''`; section heading + intro + Markdown table header; exactly one row per tenant; `errorRate` percentage formatting (25.0% / 100.0% / 0.0%); missing-field 0-defaults (never `undefined` / `NaN`); `windowLabel` scope suffix present / absent.
- **4 integration tests** (`renderKbMultiTenantHealthSection`, against a real `KBRecorderService` SQLite test DB): seeded multi-tenant telemetry → rendered section with the correct per-tenant rows; empty store → `''`; the default 7-day window excludes stale (8-day-old) events; the defensive `''` contract when the telemetry read throws.

`node --check` clean on `KbTenantHealthHelper.mjs` and the edited `GoldenPathSynthesizer.mjs`. The `check-whitespace` pre-commit hook passed on both commits.

## Post-Merge Validation

- [ ] After a REM cycle regenerates `sandman_handoff.md`, confirm the `## KB Multi-Tenant Health` section appears once per-tenant `kb_ingestion_metrics` telemetry exists in the 7-day window (empty telemetry → section omitted, by design).

## Commits

- `1633f1ccc` — feat(ai): add KB Multi-Tenant Health handoff section (#11639)
- `7862de23d` — test(ai): cover KB Multi-Tenant Health handoff renderer (#11639)

## Related

- #11628 — Phase 4 epic
- #11624 — Cloud-Native KB Ingestion meta-epic
- PR #11667 — the merged telemetry-foundation slice of #11639 (`kb_ingestion_metrics` + write/read APIs)
- #11639 comment 4504088508 — the intake-finding prescription correction
- #11665 — duplicate of #11639, closed `not_planned` (per PR #11667's reconciliation note)
