### PR TITLE
feat(ai): KB operator-alerting daemon — Phase 4D (#11642)

### DIFF
--- a/ai/config.template.mjs
+++ b/ai/config.template.mjs
@@ -84,6 +84,42 @@ const defaultConfig = {
         }
     },
     /**
+     * Knowledge Base operations configuration (Cloud-Native KB Ingestion, Epic #11624).
+     * @type {Object}
+     */
+    knowledgeBase: {
+        /**
+         * Phase 4D (#11642) — operator alert rules. Each entry is
+         * `{metric, threshold, severity, channels, deliveryMode?}`; see the #11642
+         * Contract Ledger. Empty by default — the alerting daemon no-ops with no rules.
+         * @type {Object[]}
+         */
+        alertRules: [],
+        /**
+         * Phase 4D (#11642) — master opt-in for the KB operator-alerting daemon.
+         * Disabled by default; the daemon exits early when false.
+         * @type {Boolean}
+         */
+        alertingEnabled: false,
+        /**
+         * Phase 4D (#11642) — alerting daemon poll interval in ms (default 15 min).
+         * @type {Number}
+         */
+        alertingIntervalMs: 15 * 60 * 1000,
+        /**
+         * Phase 4D (#11642) — per-`(tenant, metric, severity, channel)` hysteresis
+         * cooldown window in ms (default 1 h).
+         * @type {Number}
+         */
+        alertingCooldownMs: 60 * 60 * 1000,
+        /**
+         * Phase 4D (#11642) — rolling look-back window in ms for the per-tenant
+         * telemetry rollup the rule engine evaluates (default 1 h).
+         * @type {Number}
+         */
+        alertWindowMs: 60 * 60 * 1000
+    },
+    /**
      * A dummy embedding function to satisfy ChromaDB when embeddings are provided manually.
      * @returns {Object}
      */

--- a/ai/daemons/KbAlertingService.mjs
+++ b/ai/daemons/KbAlertingService.mjs
@@ -174,8 +174,9 @@ class KbAlertingService extends Base {
      *
      * Reads the per-tenant ingestion rollup over the configured look-back window, runs the
      * pure {@link evaluateAlertRules} engine (threading the in-memory cooldown state), logs
-     * any malformed rules, then dispatches each emitted alert. Wrapped in try/finally so
-     * `scheduleNext()` always fires — one bad cycle must not stop the daemon.
+     * any malformed rules, then dispatches each emitted alert. Wrapped in try/catch/finally
+     * so a failed cycle is logged and `scheduleNext()` still fires — one bad cycle must not
+     * stop the daemon.
      *
      * @returns {Promise<void>}
      * @protected
@@ -209,6 +210,11 @@ class KbAlertingService extends Base {
             for (const alert of alerts) {
                 await this.dispatchAlert(alert)
             }
+        } catch (err) {
+            // A single-cycle failure must not stop the daemon — log and let `finally`
+            // reschedule. Catching here also keeps `pulse()` from rejecting, so the loop
+            // never double-schedules (the `finally` + `scheduleNext`'s own `.catch`).
+            logger.error('[KbAlertingService] Pulse failed:', err)
         } finally {
             this.scheduleNext()
         }

--- a/ai/daemons/KbAlertingService.mjs
+++ b/ai/daemons/KbAlertingService.mjs
@@ -1,0 +1,316 @@
+// Class-only file (#11058-style split). Entry-point bootstrap (Neo + core/_export +
+// InstanceManager) lives in `ai/scripts/kb-alerting-daemon.mjs` per the canonical
+// Orchestrator class+wrapper pattern. `Neo.setupClass(KbAlertingService)` at file
+// bottom works via `globalThis.Neo`, populated by the entry-point bootstrap chain.
+import Base                  from '../../src/core/Base.mjs';
+import {Memory_Config as aiConfig} from '../services.mjs';
+import KBRecorderService     from '../services/knowledge-base/KBRecorderService.mjs';
+import MailboxService        from '../services/memory-core/MailboxService.mjs';
+import RequestContextService from '../mcp/server/shared/services/RequestContextService.mjs';
+import logger               from '../mcp/server/knowledge-base/logger.mjs';
+import {
+    DEFAULT_COOLDOWN_MS,
+    evaluateAlertRules,
+    formatAlertMessage
+} from '../services/knowledge-base/helpers/KbAlertRuleEngine.mjs';
+
+/**
+ * @summary Poll interval fallback when `aiConfig.knowledgeBase.alertingIntervalMs` is unset.
+ * @type {Number}
+ */
+const DEFAULT_INTERVAL_MS = 15 * 60 * 1000;
+
+/**
+ * @summary Rollup look-back fallback when `aiConfig.knowledgeBase.alertWindowMs` is unset.
+ * @type {Number}
+ */
+const DEFAULT_WINDOW_MS = 60 * 60 * 1000;
+
+/**
+ * @summary Sender identity fallback for A2A alert dispatch when `NEO_AGENT_IDENTITY` is unset.
+ * @type {String}
+ */
+const DEFAULT_SENDER = '@system';
+
+/**
+ * @summary Phase 4D KB operator-alerting daemon — telemetry thresholds → A2A / console alerts (#11642).
+ *
+ * Closes the Phase 4 operability loop: Phase 4A (#11639) collects per-tenant KB ingestion
+ * telemetry into `kb_ingestion_metrics`; this daemon polls the per-tenant rollup, evaluates
+ * it against operator-configured `aiConfig.knowledgeBase.alertRules`, and dispatches an alert
+ * to each breached rule's channels. Without it, operators must manually poll telemetry.
+ *
+ * **Shape** — the canonical poll-loop daemon (the `SwarmHeartbeatService` precedent): a
+ * `Neo.core.Base` singleton with `start()` / `stop()` / `scheduleNext()` / `pulse()`. The
+ * entry-point wrapper `ai/scripts/kb-alerting-daemon.mjs` owns the Neo bootstrap + SIGTERM.
+ *
+ * **Split** — the *pure* threshold logic (rule validation, breach evaluation, hysteresis,
+ * message formatting) lives in `KbAlertRuleEngine.mjs` and is unit-tested in isolation; this
+ * class owns only the I/O: the poll loop, the telemetry read, and channel dispatch.
+ *
+ * **Opt-in** — `start()` is a no-op unless `aiConfig.knowledgeBase.alertingEnabled` is true,
+ * so a default deployment never runs the daemon.
+ *
+ * **Channels** (per the #11642 Contract Ledger): `console` → `logger`; `a2a:<target>` →
+ * `MailboxService.addMessage` under a bound sender identity; `webhook:<url>` → V1.5-deferred
+ * (recognized but warn-skipped). Cooldown state is held in-memory and reset on `start()`.
+ *
+ * @class Neo.ai.daemons.KbAlertingService
+ * @extends Neo.core.Base
+ * @singleton
+ * @see ai/scripts/kb-alerting-daemon.mjs — the entry-point wrapper.
+ * @see ai/services/knowledge-base/helpers/KbAlertRuleEngine.mjs — the pure rule engine.
+ * @see ai/daemons/SwarmHeartbeatService.mjs — the poll-loop daemon precedent.
+ * @see ai/scripts/idleOutNudge.mjs — the daemon-side `MailboxService.addMessage` precedent.
+ */
+class KbAlertingService extends Base {
+    static config = {
+        /**
+         * @member {String} className='Neo.ai.daemons.KbAlertingService'
+         * @protected
+         */
+        className: 'Neo.ai.daemons.KbAlertingService',
+        /**
+         * @member {Boolean} singleton=true
+         * @protected
+         */
+        singleton: true,
+        /**
+         * Whether the poll loop is running.
+         * @member {Boolean} isPolling_=false
+         * @protected
+         * @reactive
+         */
+        isPolling_: false,
+        /**
+         * Active `setTimeout` handle for the next pulse; `null` when not scheduled.
+         * @member {Object|null} pollHandle_=null
+         * @protected
+         * @reactive
+         */
+        pollHandle_: null,
+        /**
+         * Interval between alerting pulses in milliseconds.
+         * @member {Number} pollIntervalMs_=900000
+         * @protected
+         * @reactive
+         */
+        pollIntervalMs_: DEFAULT_INTERVAL_MS
+    }
+
+    /**
+     * @summary In-memory hysteresis state — a map of `cooldownKey` → last-fired epoch ms,
+     * threaded through {@link evaluateAlertRules} across pulses. Reset on every `start()`.
+     * @member {Object} cooldownState={}
+     * @protected
+     */
+    cooldownState = {}
+
+    /**
+     * @summary Starts the alerting poll loop. Idempotent; a no-op while already polling.
+     *
+     * Exits early (without scheduling) when `aiConfig.knowledgeBase.alertingEnabled` is
+     * false — the daemon process then has nothing keeping the event loop alive and exits.
+     *
+     * @param {Object}  [options]
+     * @param {Number} [options.pollIntervalMs] Override the configured poll interval.
+     * @returns {Promise<void>}
+     */
+    async start({pollIntervalMs} = {}) {
+        if (this.isPolling) {
+            logger.debug('[KbAlertingService] Already polling; start() is a no-op.');
+            return;
+        }
+
+        const kbConfig = this.getKbConfig();
+
+        if (!kbConfig.alertingEnabled) {
+            logger.info('[KbAlertingService] Alerting disabled (aiConfig.knowledgeBase.alertingEnabled=false); not starting.');
+            return;
+        }
+
+        this.pollIntervalMs = pollIntervalMs || kbConfig.alertingIntervalMs || DEFAULT_INTERVAL_MS;
+        this.cooldownState  = {};
+
+        await KBRecorderService.ready();
+
+        this.isPolling = true;
+        logger.info(`[KbAlertingService] Starting KB operator-alerting (interval: ${this.pollIntervalMs}ms)`);
+
+        this.scheduleNext()
+    }
+
+    /**
+     * @summary Stops the poll loop. Idempotent. Cancels any pending pulse so a clean
+     * SIGTERM under launchd/systemd does not leave a timer wedging the event loop.
+     * @returns {void}
+     */
+    stop() {
+        if (this.pollHandle) {
+            clearTimeout(this.pollHandle);
+            this.pollHandle = null
+        }
+        this.isPolling = false;
+        logger.info('[KbAlertingService] Alerting stopped.')
+    }
+
+    /**
+     * @summary Schedules the next pulse. Called after each pulse settles so a single
+     * thrown error never breaks the loop.
+     * @returns {void}
+     * @protected
+     */
+    scheduleNext() {
+        if (!this.isPolling) return;
+
+        this.pollHandle = setTimeout(() => this.pulse().catch(err => {
+            logger.error('[KbAlertingService] Pulse threw uncaught error:', err);
+            this.scheduleNext()
+        }), this.pollIntervalMs)
+    }
+
+    /**
+     * @summary Executes one alerting pulse: rollup → rule evaluation → channel dispatch.
+     *
+     * Reads the per-tenant ingestion rollup over the configured look-back window, runs the
+     * pure {@link evaluateAlertRules} engine (threading the in-memory cooldown state), logs
+     * any malformed rules, then dispatches each emitted alert. Wrapped in try/finally so
+     * `scheduleNext()` always fires — one bad cycle must not stop the daemon.
+     *
+     * @returns {Promise<void>}
+     * @protected
+     */
+    async pulse() {
+        try {
+            const kbConfig = this.getKbConfig();
+            const rules    = Array.isArray(kbConfig.alertRules) ? kbConfig.alertRules : [];
+
+            if (rules.length === 0) {
+                return // no rules configured → nothing to evaluate
+            }
+
+            const windowMs = kbConfig.alertWindowMs || DEFAULT_WINDOW_MS;
+            const rollup   = await this.fetchRollup(windowMs);
+
+            const {alerts, cooldownState, skippedRules} = evaluateAlertRules({
+                rules,
+                rollup,
+                cooldownState: this.cooldownState,
+                now          : Date.now(),
+                cooldownMs   : kbConfig.alertingCooldownMs || DEFAULT_COOLDOWN_MS
+            });
+
+            this.cooldownState = cooldownState;
+
+            for (const {reason} of skippedRules) {
+                logger.warn(`[KbAlertingService] Skipped malformed alert rule: ${reason}`)
+            }
+
+            for (const alert of alerts) {
+                await this.dispatchAlert(alert)
+            }
+        } finally {
+            this.scheduleNext()
+        }
+    }
+
+    /**
+     * @summary Test-stubbable seam over `aiConfig.knowledgeBase`.
+     *
+     * Reads defensively: a stale gitignored `ai/config.mjs` deployment predating #11642
+     * has no `knowledgeBase` key, so a naked `aiConfig.knowledgeBase.alertRules` would
+     * throw. Returns `{}` when the key is absent.
+     *
+     * @returns {Object}
+     * @protected
+     */
+    getKbConfig() {
+        return aiConfig.knowledgeBase || {}
+    }
+
+    /**
+     * @summary Test-stubbable seam over `KBRecorderService.getTenantIngestionRollup`.
+     * @param {Number} windowMs Rolling look-back window.
+     * @returns {Promise<Array<Object>>} Per-tenant rollup rows, or `[]`.
+     * @protected
+     */
+    async fetchRollup(windowMs) {
+        return KBRecorderService.getTenantIngestionRollup({sinceMs: Date.now() - windowMs}) || []
+    }
+
+    /**
+     * @summary Dispatches one alert descriptor to its channel. Never throws — a channel
+     * failure is logged and the remaining alerts still dispatch.
+     * @param {Object} alert An entry from {@link evaluateAlertRules}'s `alerts` array.
+     * @returns {Promise<void>}
+     * @protected
+     */
+    async dispatchAlert(alert) {
+        const channel = alert.channel;
+
+        try {
+            if (channel === 'console') {
+                this.dispatchConsole(alert)
+            } else if (channel.startsWith('a2a:')) {
+                await this.dispatchA2A(alert)
+            } else if (channel.startsWith('webhook:')) {
+                // V1.5-deferred per the #11642 Contract Ledger — recognized but not POSTed.
+                logger.warn(`[KbAlertingService] Webhook channel deferred to V1.5; skipping "${channel}" (tenant ${alert.tenantId})`)
+            } else {
+                logger.warn(`[KbAlertingService] Unknown channel "${channel}" (tenant ${alert.tenantId}); skipping`)
+            }
+        } catch (err) {
+            logger.error(`[KbAlertingService] Alert dispatch failed (${channel}, tenant ${alert.tenantId}): ${err.message}`)
+        }
+    }
+
+    /**
+     * @summary Console channel — `logger.error` for `critical`, `logger.warn` otherwise.
+     * @param {Object} alert
+     * @returns {void}
+     * @protected
+     */
+    dispatchConsole(alert) {
+        const {subject} = formatAlertMessage(alert);
+
+        if (alert.severity === 'critical') {
+            logger.error(subject)
+        } else {
+            logger.warn(subject)
+        }
+    }
+
+    /**
+     * @summary A2A channel — sends the alert via `MailboxService.addMessage` under a bound
+     * sender identity (the `idleOutNudge.mjs` daemon-side precedent).
+     *
+     * The channel spec `a2a:<target>` carries the recipient: a canonical `@<identity>`
+     * direct recipient or `AGENT:*` for broadcast. `deliveryMode: 'audit'` maps to
+     * `wakeSuppressed: true` (durable mailbox-only, no wake); `'wake'` (the default) emits
+     * a wakeful message. `MailboxService.addMessage` itself rejects an unresolvable target.
+     *
+     * @param {Object} alert
+     * @returns {Promise<void>}
+     * @protected
+     */
+    async dispatchA2A(alert) {
+        const
+            target        = alert.channel.slice('a2a:'.length),
+            {subject, body} = formatAlertMessage(alert),
+            sender        = process.env.NEO_AGENT_IDENTITY || DEFAULT_SENDER;
+
+        await RequestContextService.run({agentIdentityNodeId: sender}, async () => {
+            await MailboxService.addMessage({
+                to            : target,
+                subject,
+                body,
+                priority      : alert.severity === 'critical' ? 'high' : 'normal',
+                wakeSuppressed: alert.deliveryMode === 'audit'
+            })
+        })
+    }
+}
+
+export default Neo.setupClass(KbAlertingService);
+
+export {DEFAULT_INTERVAL_MS, DEFAULT_WINDOW_MS, DEFAULT_SENDER};

--- a/ai/daemons/KbAlertingService.mjs
+++ b/ai/daemons/KbAlertingService.mjs
@@ -293,17 +293,29 @@ class KbAlertingService extends Base {
      * The channel spec `a2a:<target>` carries the recipient: a canonical `@<identity>`
      * direct recipient or `AGENT:*` for broadcast. `deliveryMode: 'audit'` maps to
      * `wakeSuppressed: true` (durable mailbox-only, no wake); `'wake'` (the default) emits
-     * a wakeful message. `MailboxService.addMessage` itself rejects an unresolvable target.
+     * a wakeful message. An unresolvable target — neither a registered `@<identity>` nor
+     * `AGENT:*` — is skipped with a `logger.warn` *before* dispatch (via
+     * `MailboxService.isReachableTarget`), so `addMessage` is never reached for it.
      *
      * @param {Object} alert
      * @returns {Promise<void>}
      * @protected
      */
     async dispatchA2A(alert) {
+        const target = alert.channel.slice('a2a:'.length);
+
+        // Reject an unresolvable target BEFORE dispatch (#11642 Contract Ledger; @neo-gpt
+        // PR #11709 Cycle-1 review). A target that is neither a registered `@<identity>`
+        // nor the `AGENT:*` sentinel is skipped with a warn — `MailboxService.addMessage`
+        // is never reached, so a misconfigured rule cannot attempt orphan-target dispatch.
+        if (!MailboxService.isReachableTarget(target)) {
+            logger.warn(`[KbAlertingService] Skipping alert for unresolvable A2A target "${target}" (tenant ${alert.tenantId})`);
+            return
+        }
+
         const
-            target        = alert.channel.slice('a2a:'.length),
             {subject, body} = formatAlertMessage(alert),
-            sender        = process.env.NEO_AGENT_IDENTITY || DEFAULT_SENDER;
+            sender          = process.env.NEO_AGENT_IDENTITY || DEFAULT_SENDER;
 
         await RequestContextService.run({agentIdentityNodeId: sender}, async () => {
             await MailboxService.addMessage({

--- a/ai/scripts/kb-alerting-daemon.mjs
+++ b/ai/scripts/kb-alerting-daemon.mjs
@@ -1,0 +1,44 @@
+/**
+ * @module ai/scripts/kb-alerting-daemon
+ * @summary Thin Node-process boot wrapper for the Phase 4D KB operator-alerting daemon (#11642).
+ *
+ * Owns Neo namespace bootstrap + SIGTERM / SIGINT clean-stop signal handling +
+ * `KbAlertingService.start()` invocation. The class definition (poll loop, rule
+ * evaluation, channel dispatch) lives in `ai/daemons/KbAlertingService.mjs`.
+ *
+ * This split matches the canonical Orchestrator class+wrapper pattern: class files in
+ * `ai/daemons/` never import Neo; entry-point scripts in `ai/scripts/` own the Neo +
+ * core/_export + InstanceManager bootstrap chain.
+ *
+ * Persistent-process invocation: launchd / systemd should target this script
+ * (`node ai/scripts/kb-alerting-daemon.mjs`), or `npm run ai:kb-alerting`. The daemon
+ * is opt-in — it exits early unless `aiConfig.knowledgeBase.alertingEnabled` is true.
+ *
+ * @see ai/daemons/KbAlertingService.mjs
+ * @see ai/scripts/swarm-heartbeat-daemon.mjs (sibling wrapper precedent)
+ * @see #11642 (Phase 4D operator alerting), #11628 (Phase 4 epic)
+ */
+
+// Neo namespace bootstrap (entry-point invariant): `Neo` + `core/_export` populate
+// `globalThis.Neo` so any module using `Neo.gatekeep()` / `Neo.setupClass()` at
+// module-load succeeds. `InstanceManager` binds `Neo.find` / `Neo.get` aliases.
+import Neo             from '../../src/Neo.mjs';
+import * as core       from '../../src/core/_export.mjs';
+import InstanceManager from '../../src/manager/Instance.mjs';
+
+import logger            from '../mcp/server/knowledge-base/logger.mjs';
+import KbAlertingService from '../daemons/KbAlertingService.mjs';
+
+const cleanShutdown = signal => {
+    logger.info(`[KbAlertingService] Received ${signal}; stopping.`);
+    KbAlertingService.stop();
+    process.exit(0);
+};
+
+process.on('SIGTERM', () => cleanShutdown('SIGTERM'));
+process.on('SIGINT',  () => cleanShutdown('SIGINT'));
+
+KbAlertingService.start().catch(err => {
+    logger.error('[KbAlertingService] Daemon start failed:', err);
+    process.exit(1);
+});

--- a/ai/services/knowledge-base/helpers/KbAlertRuleEngine.mjs
+++ b/ai/services/knowledge-base/helpers/KbAlertRuleEngine.mjs
@@ -1,0 +1,230 @@
+/**
+ * @summary Pure rule-evaluation engine for the Phase 4D KB operator-alerting daemon (#11642).
+ *
+ * Phase 4D (#11642) substrate. The cloud KB operator-alerting daemon (`KbAlertingService`)
+ * polls per-tenant ingestion telemetry and fires alerts when operator-configured thresholds
+ * are breached. This module is the **pure core** of that daemon — no I/O, no clock access,
+ * no service references — so the threshold logic, rule validation, hysteresis/cooldown, and
+ * message formatting are all trivially unit-testable in isolation.
+ *
+ * The daemon owns the I/O: it reads `aiConfig.knowledgeBase.alertRules`, calls
+ * `KBRecorderService.getTenantIngestionRollup`, holds the cooldown state across ticks, and
+ * dispatches each emitted alert to its channels (A2A / console / webhook). This module only
+ * decides *which* alerts should fire *this tick* given the inputs.
+ *
+ * Contract: the per-#11642 Contract Ledger (ticket body) is the binding spec. This engine
+ * implements its `alertRules` schema row + the hysteresis row; channel *dispatch* (the A2A /
+ * console / webhook I/O) is the daemon's concern.
+ *
+ * @see ai/daemons/KbAlertingService.mjs — the daemon that consumes this engine.
+ * @see ai/services/knowledge-base/KBRecorderService.mjs — `getTenantIngestionRollup`, the rollup source.
+ * @see ai/services/knowledge-base/helpers/KbTenantHealthHelper.mjs — the sibling pure-helper precedent (#11639).
+ */
+
+/**
+ * @summary The telemetry metric names a rule may target.
+ *
+ * Exactly the numeric fields of a `KBRecorderService.getTenantIngestionRollup` row. A rule
+ * whose `metric` is not one of these is rejected at validation — this turns an operator
+ * typo (`errorRate` mistyped) into a clear skipped-rule warning rather than a rule that
+ * silently never fires.
+ * @type {ReadonlyArray<String>}
+ */
+export const KNOWN_METRICS = Object.freeze([
+    'eventCount', 'ingestEvents', 'tombstoneEvents', 'reconcileEvents',
+    'errorEvents', 'chunksEmbedded', 'chunksDeleted', 'errorRate'
+]);
+
+/**
+ * @summary Permitted `severity` values for an alert rule.
+ * @type {ReadonlyArray<String>}
+ */
+export const ALERT_SEVERITIES = Object.freeze(['warning', 'critical']);
+
+/**
+ * @summary Permitted `deliveryMode` values — `wake` (default) emits a wakeful A2A message;
+ * `audit` emits a durable mailbox-only record (`wakeSuppressed: true`, no wake).
+ * @type {ReadonlyArray<String>}
+ */
+export const DELIVERY_MODES = Object.freeze(['wake', 'audit']);
+
+/**
+ * @summary Default hysteresis window — a fired alert is suppressed from re-firing on the
+ * same cooldown key within this span. Matches the #11642 AC ("default 1h").
+ * @type {Number}
+ */
+export const DEFAULT_COOLDOWN_MS = 60 * 60 * 1000;
+
+/**
+ * @summary Validates the structural shape of one channel spec string.
+ *
+ * Recognized forms: `console`, `a2a:<target>`, `webhook:<url>`. Structural only — semantic
+ * validation of an `a2a:` target against the live AgentIdentity registry needs graph I/O
+ * and is the daemon's concern, not the pure engine's.
+ *
+ * @param {String} channel
+ * @returns {Boolean}
+ * @private
+ */
+function isWellFormedChannel(channel) {
+    if (channel === 'console')            return true;
+    if (channel.startsWith('a2a:'))       return channel.length > 'a2a:'.length;
+    if (channel.startsWith('webhook:'))   return channel.length > 'webhook:'.length;
+    return false;
+}
+
+/**
+ * @summary Builds the deterministic cooldown key for a (tenant, metric, severity, channel) tuple.
+ *
+ * Keying on the full tuple — per @neo-gpt's #11642 overlay #4 — means a single noisy tenant
+ * cannot wake-storm: distinct tenants, metrics, severities, and channel targets each cool
+ * down independently.
+ *
+ * @param {String} tenantId
+ * @param {String} metric
+ * @param {String} severity
+ * @param {String} channel
+ * @returns {String}
+ */
+export function cooldownKey(tenantId, metric, severity, channel) {
+    return `${tenantId}|${metric}|${severity}|${channel}`;
+}
+
+/**
+ * @summary Structurally validates one alert rule against the #11642 Contract Ledger schema.
+ *
+ * Pure structural validation: `metric` ∈ {@link KNOWN_METRICS}, finite numeric `threshold`,
+ * `severity` ∈ {@link ALERT_SEVERITIES}, an explicit non-empty `channels` array of
+ * well-formed channel specs, optional `deliveryMode` ∈ {@link DELIVERY_MODES}. There is no
+ * implicit default channel — a rule must name its channels explicitly (overlay #1).
+ *
+ * @param {Object} rule
+ * @returns {{valid: Boolean, reason: String}} `reason` is `''` when valid.
+ */
+export function validateAlertRule(rule) {
+    if (!rule || typeof rule !== 'object') {
+        return {valid: false, reason: 'rule is not an object'};
+    }
+    if (typeof rule.metric !== 'string' || !KNOWN_METRICS.includes(rule.metric)) {
+        return {valid: false, reason: `unknown metric "${rule.metric}" (expected one of: ${KNOWN_METRICS.join(', ')})`};
+    }
+    if (typeof rule.threshold !== 'number' || !Number.isFinite(rule.threshold)) {
+        return {valid: false, reason: 'threshold must be a finite number'};
+    }
+    if (!ALERT_SEVERITIES.includes(rule.severity)) {
+        return {valid: false, reason: `severity must be one of: ${ALERT_SEVERITIES.join(', ')}`};
+    }
+    if (!Array.isArray(rule.channels) || rule.channels.length === 0) {
+        return {valid: false, reason: 'channels must be a non-empty array (no implicit default)'};
+    }
+    for (const channel of rule.channels) {
+        if (typeof channel !== 'string' || !isWellFormedChannel(channel)) {
+            return {valid: false, reason: `malformed channel spec "${channel}"`};
+        }
+    }
+    if (rule.deliveryMode !== undefined && !DELIVERY_MODES.includes(rule.deliveryMode)) {
+        return {valid: false, reason: `deliveryMode must be one of: ${DELIVERY_MODES.join(', ')}`};
+    }
+    return {valid: true, reason: ''};
+}
+
+/**
+ * @summary Evaluates operator alert rules against a per-tenant ingestion rollup.
+ *
+ * Pure — no I/O, no clock (the caller passes `now`). For each valid rule × each tenant row,
+ * a metric value strictly greater than the rule's `threshold` is a breach; each of the
+ * rule's channels then emits an alert *unless* that (tenant, metric, severity, channel)
+ * cooldown key fired within `cooldownMs`. The returned `cooldownState` is the input map with
+ * the freshly-fired keys stamped to `now` — the daemon threads it back in on the next tick.
+ *
+ * Invalid rules are not thrown on — they are collected into `skippedRules` (with a reason)
+ * so the daemon can log them; one malformed rule never blocks the rest.
+ *
+ * @param {Object}        params
+ * @param {Array<Object>} params.rules                 Operator `alertRules` array.
+ * @param {Array<Object>} params.rollup                `getTenantIngestionRollup()` rows.
+ * @param {Object}        [params.cooldownState={}]    Map of cooldown-key → last-fired epoch ms.
+ * @param {Number}        params.now                   Current epoch ms (caller-supplied; keeps this pure).
+ * @param {Number}        [params.cooldownMs=DEFAULT_COOLDOWN_MS] Hysteresis window.
+ * @returns {{alerts: Array<Object>, cooldownState: Object, skippedRules: Array<{rule: Object, reason: String}>}}
+ *   `alerts` — one descriptor per (tenant, rule, channel) firing this tick:
+ *   `{tenantId, repoSlug, metric, value, threshold, severity, channel, deliveryMode}`.
+ */
+export function evaluateAlertRules({rules, rollup, cooldownState = {}, now, cooldownMs = DEFAULT_COOLDOWN_MS}) {
+    const alerts        = [];
+    const skippedRules  = [];
+    const nextCooldown  = {...cooldownState};
+
+    if (!Array.isArray(rules) || !Array.isArray(rollup)) {
+        return {alerts, cooldownState: nextCooldown, skippedRules};
+    }
+
+    for (const rule of rules) {
+        const {valid, reason} = validateAlertRule(rule);
+
+        if (!valid) {
+            skippedRules.push({rule, reason});
+            continue;
+        }
+
+        for (const row of rollup) {
+            const value = row?.[rule.metric];
+
+            // Breach = a numeric value strictly above the threshold. A missing/non-numeric
+            // field simply never breaches (graceful — no speculative metric support).
+            if (typeof value !== 'number' || !(value > rule.threshold)) {
+                continue;
+            }
+
+            for (const channel of rule.channels) {
+                const key      = cooldownKey(row.tenantId, rule.metric, rule.severity, channel);
+                const lastFired = nextCooldown[key];
+
+                if (typeof lastFired === 'number' && now - lastFired < cooldownMs) {
+                    continue; // still cooling down on this key
+                }
+
+                nextCooldown[key] = now;
+
+                alerts.push({
+                    tenantId    : row.tenantId,
+                    repoSlug    : row.repoSlug,
+                    metric      : rule.metric,
+                    value,
+                    threshold   : rule.threshold,
+                    severity    : rule.severity,
+                    channel,
+                    deliveryMode: rule.deliveryMode || 'wake'
+                });
+            }
+        }
+    }
+
+    return {alerts, cooldownState: nextCooldown, skippedRules};
+}
+
+/**
+ * @summary Formats an alert descriptor into an A2A / console message `{subject, body}`.
+ *
+ * Pure — kept here (not in the daemon) so message shaping is unit-testable. The daemon
+ * passes `subject`/`body` straight to `add_message` (A2A) or `logger` (console).
+ *
+ * @param {Object} alert An entry from {@link evaluateAlertRules}'s `alerts` array.
+ * @returns {{subject: String, body: String}}
+ */
+export function formatAlertMessage(alert) {
+    const subject = `[alert] ${alert.severity}: ${alert.metric} ${alert.value} over threshold ${alert.threshold} (tenant ${alert.tenantId})`;
+
+    const body = [
+        `KB ingestion alert — **${alert.severity}**`,
+        '',
+        `- Tenant: \`${alert.tenantId}\``,
+        `- Repo: \`${alert.repoSlug}\``,
+        `- Metric: \`${alert.metric}\``,
+        `- Observed: ${alert.value} (threshold ${alert.threshold})`,
+        '',
+        'Per-tenant KB ingestion telemetry crossed an operator-configured threshold (#11642).'
+    ].join('\n');
+
+    return {subject, body};
+}

--- a/ai/services/memory-core/MailboxService.mjs
+++ b/ai/services/memory-core/MailboxService.mjs
@@ -298,6 +298,28 @@ class MailboxService extends Base {
     static VALID_TASK_STATES = ['Submitted', 'Working', 'InputRequired', 'Completed', 'Canceled', 'Failed', 'Rejected', 'AuthRequired', 'Unknown', 'Expired', 'Blocked'];
 
     /**
+     * @summary Non-throwing check of whether a raw `to` target would resolve to a
+     * deliverable mailbox recipient — without sending anything.
+     *
+     * Runs the exact `normalizeMailboxTarget` + `validateMailboxTarget` pipeline that
+     * {@link addMessage} uses, but returns a boolean instead of throwing. This lets a
+     * caller (e.g. the Phase 4D `KbAlertingService` alerting daemon, #11642) reject an
+     * unresolvable A2A target *before* dispatch rather than discovering it via an
+     * `addMessage` rejection — no duplication of the mailbox recipient grammar.
+     *
+     * @param {String} to The raw recipient target (`@<identity>`, `AGENT:*`, an alias, …).
+     * @returns {Boolean} `true` when `to` resolves to a registered recipient or the
+     *   `AGENT:*` broadcast sentinel; `false` for any unresolvable / malformed target.
+     */
+    isReachableTarget(to) {
+        try {
+            return !!validateMailboxTarget(normalizeMailboxTarget(to), to);
+        } catch (e) {
+            return false;
+        }
+    }
+
+    /**
      * Adds a new message to the mailbox system.
      * @param {Object} args
      * @param {String} args.to The agent identity, role, or broadcast to send to

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
         "ai:prune-worktrees"           : "node ./ai/scripts/bootstrapWorktree.mjs --prune-stale",
         "ai:lint-agents"               : "node ./ai/scripts/lint-agents.mjs",
         "ai:lint-skill-manifest"       : "node ./ai/scripts/lint-skill-manifest.mjs",
+        "ai:kb-alerting"               : "node ./ai/scripts/kb-alerting-daemon.mjs",
         "ai:orchestrator"              : "node ./ai/scripts/orchestrator-daemon.mjs",
         "ai:run-sandman"               : "node ./buildScripts/ai/runSandman.mjs",
         "ai:server"                    : "chroma run --path ./.neo-ai-data/chroma/knowledge-base",

--- a/test/playwright/unit/ai/daemons/KbAlertingService.spec.mjs
+++ b/test/playwright/unit/ai/daemons/KbAlertingService.spec.mjs
@@ -1,0 +1,317 @@
+import {setup} from '../../../setup.mjs';
+
+const appName = 'KbAlertingServiceTest';
+
+setup({
+    neoConfig: {
+        unitTestMode: true
+    },
+    appConfig: {
+        name             : appName,
+        isMounted        : () => true,
+        vnodeInitialising: false
+    }
+});
+
+// Test-side entry-point bootstrap: Neo + core/_export populate `globalThis.Neo` before
+// the dynamic KbAlertingService import below. Required because the class file no longer
+// imports Neo itself (#11058-style class+wrapper split). Mirrors SwarmHeartbeatService.spec.
+import Neo       from '../../../../../src/Neo.mjs';
+import * as core from '../../../../../src/core/_export.mjs';
+
+import {test, expect} from '@playwright/test';
+
+/**
+ * Phase 4D (#11642) — unit coverage for `ai/daemons/KbAlertingService.mjs`, the KB
+ * operator-alerting daemon.
+ *
+ * Stubbing strategy mirrors `SwarmHeartbeatService.spec.mjs`: the daemon exposes
+ * test-stubbable instance-method seams (`getKbConfig`, `fetchRollup`, `dispatchAlert`,
+ * `dispatchConsole`, `dispatchA2A`, `scheduleNext`) so tests override them on the
+ * singleton without going through real config / SQLite / Memory Core I/O. External
+ * singletons (`MailboxService.addMessage`, `RequestContextService.run`, `logger`) are
+ * saved + restored around each test for the `dispatchA2A` / `dispatchConsole` cases.
+ *
+ * Covers the #11642 Contract Ledger Evidence columns for channel dispatch (direct-DM,
+ * explicit broadcast, invalid-target tolerance, wake vs. audit) and the daemon poll loop;
+ * the pure threshold/cooldown logic is covered separately in `KbAlertRuleEngine.spec.mjs`.
+ *
+ * @see https://github.com/neomjs/neo/issues/11642
+ * @see ai/daemons/KbAlertingService.mjs — the daemon under test.
+ * @see test/playwright/unit/ai/daemons/SwarmHeartbeatService.spec.mjs — the sibling pattern.
+ */
+test.describe('Neo.ai.daemons.KbAlertingService (#11642)', () => {
+    let KbAlertingService, DEFAULT_INTERVAL_MS;
+    let MailboxService, RequestContextService, logger;
+    let originals = {};
+
+    /** A breaching rule fixture — console + direct-DM A2A channels. */
+    const RULE = {metric: 'errorRate', threshold: 0.1, severity: 'warning', channels: ['console', 'a2a:@neo-gpt']};
+
+    /** A one-tenant rollup whose errorRate (0.3) breaches RULE's 0.1 threshold. */
+    const ROLLUP = [{tenantId: 'tenant-x', repoSlug: 'repo-x', eventCount: 10, errorEvents: 3, errorRate: 0.3}];
+
+    test.beforeAll(async () => {
+        ({default: KbAlertingService, DEFAULT_INTERVAL_MS} =
+            await import('../../../../../ai/daemons/KbAlertingService.mjs'));
+
+        MailboxService        = (await import('../../../../../ai/services/memory-core/MailboxService.mjs')).default;
+        RequestContextService = (await import('../../../../../ai/mcp/server/shared/services/RequestContextService.mjs')).default;
+        logger                = (await import('../../../../../ai/mcp/server/knowledge-base/logger.mjs')).default;
+
+        const KBRecorderService = (await import('../../../../../ai/services/knowledge-base/KBRecorderService.mjs')).default;
+
+        originals = {
+            addMessage  : MailboxService.addMessage,
+            run         : RequestContextService.run,
+            warn        : logger.warn,
+            error       : logger.error,
+            recorderReady: KBRecorderService.ready
+        };
+
+        // `start()` awaits KBRecorderService.ready() — stub it to resolve immediately.
+        KBRecorderService.ready = async () => {};
+    });
+
+    test.afterAll(async () => {
+        const KBRecorderService = (await import('../../../../../ai/services/knowledge-base/KBRecorderService.mjs')).default;
+        KBRecorderService.ready = originals.recorderReady;
+    });
+
+    test.afterEach(() => {
+        KbAlertingService.stop();
+        KbAlertingService.isPolling      = false;
+        KbAlertingService.pollIntervalMs = DEFAULT_INTERVAL_MS;
+        KbAlertingService.cooldownState  = {};
+
+        // Drop instance-method seam overrides so the real prototype methods resurface for
+        // the next test — an instance override otherwise leaks across tests in the worker.
+        for (const seam of ['getKbConfig', 'fetchRollup', 'dispatchAlert', 'dispatchConsole', 'dispatchA2A', 'scheduleNext']) {
+            delete KbAlertingService[seam];
+        }
+
+        MailboxService.addMessage   = originals.addMessage;
+        RequestContextService.run   = originals.run;
+        logger.warn                 = originals.warn;
+        logger.error                = originals.error;
+    });
+
+    /**
+     * Deterministic seam baseline — every test starts here, then overrides what it needs.
+     * `scheduleNext` is neutralized so tests never leave a real timer in the event loop.
+     */
+    function applyStubs({config, rollup} = {}) {
+        KbAlertingService.getKbConfig  = () => config || {alertingEnabled: true, alertRules: [RULE]};
+        KbAlertingService.fetchRollup  = async () => rollup || ROLLUP;
+        KbAlertingService.scheduleNext = function () {};
+    }
+
+    test.describe('start / stop', () => {
+        test('start() is a no-op when alertingEnabled is false', async () => {
+            applyStubs({config: {alertingEnabled: false, alertRules: [RULE]}});
+            let scheduled = 0;
+            KbAlertingService.scheduleNext = () => { scheduled++ };
+
+            await KbAlertingService.start();
+
+            expect(KbAlertingService.isPolling).toBe(false);
+            expect(scheduled).toBe(0);
+        });
+
+        test('start() schedules when enabled and is idempotent', async () => {
+            applyStubs();
+            let scheduled = 0;
+            KbAlertingService.scheduleNext = () => { scheduled++ };
+
+            await KbAlertingService.start();
+            expect(KbAlertingService.isPolling).toBe(true);
+            expect(scheduled).toBe(1);
+
+            await KbAlertingService.start();
+            expect(scheduled).toBe(1); // second start() is a no-op
+        });
+
+        test('start() resets cooldown state', async () => {
+            applyStubs();
+            KbAlertingService.cooldownState = {'stale|key|warning|console': 1};
+
+            await KbAlertingService.start();
+
+            expect(KbAlertingService.cooldownState).toEqual({});
+        });
+
+        test('stop() clears the poll handle and is idempotent', async () => {
+            applyStubs();
+            KbAlertingService.scheduleNext = function () { this.pollHandle = setTimeout(() => {}, 60_000) };
+
+            await KbAlertingService.start();
+            expect(KbAlertingService.pollHandle).not.toBeNull();
+
+            KbAlertingService.stop();
+            expect(KbAlertingService.pollHandle).toBeNull();
+            expect(KbAlertingService.isPolling).toBe(false);
+            expect(() => KbAlertingService.stop()).not.toThrow();
+        });
+    });
+
+    test.describe('pulse', () => {
+        test('dispatches nothing when no rules are configured', async () => {
+            applyStubs({config: {alertingEnabled: true, alertRules: []}});
+            const dispatched = [];
+            KbAlertingService.dispatchAlert = async (a) => { dispatched.push(a) };
+
+            await KbAlertingService.pulse();
+
+            expect(dispatched).toHaveLength(0);
+        });
+
+        test('routes each breached-rule alert to its channel dispatcher', async () => {
+            applyStubs();
+            const consoleAlerts = [], a2aAlerts = [];
+            KbAlertingService.dispatchConsole = (a) => { consoleAlerts.push(a) };
+            KbAlertingService.dispatchA2A     = async (a) => { a2aAlerts.push(a) };
+
+            await KbAlertingService.start(); // seeds an empty cooldownState
+            await KbAlertingService.pulse();
+
+            // RULE breaches on tenant-x via 2 channels → one console, one a2a alert.
+            expect(consoleAlerts).toHaveLength(1);
+            expect(a2aAlerts).toHaveLength(1);
+            expect(consoleAlerts[0]).toMatchObject({tenantId: 'tenant-x', metric: 'errorRate', channel: 'console'});
+            expect(a2aAlerts[0].channel).toBe('a2a:@neo-gpt');
+        });
+
+        test('threads cooldown state across pulses — a second pulse is suppressed', async () => {
+            applyStubs();
+            const dispatched = [];
+            KbAlertingService.dispatchConsole = (a) => { dispatched.push(a) };
+            KbAlertingService.dispatchA2A     = async (a) => { dispatched.push(a) };
+
+            await KbAlertingService.start();
+            await KbAlertingService.pulse();
+            expect(dispatched).toHaveLength(2);
+
+            // Same breach, within the cooldown window → fully suppressed.
+            await KbAlertingService.pulse();
+            expect(dispatched).toHaveLength(2);
+        });
+
+        test('logs a warning for a malformed alert rule and still dispatches valid ones', async () => {
+            applyStubs({config: {alertingEnabled: true, alertRules: [{metric: 'bogus', threshold: 1, severity: 'warning', channels: ['console']}, RULE]}});
+            const warns = [];
+            logger.warn = (msg) => { warns.push(msg) };
+            const dispatched = [];
+            KbAlertingService.dispatchConsole = (a) => { dispatched.push(a) };
+            KbAlertingService.dispatchA2A     = async (a) => { dispatched.push(a) };
+
+            await KbAlertingService.start();
+            await KbAlertingService.pulse();
+
+            expect(warns.some(w => w.includes('Skipped malformed alert rule'))).toBe(true);
+            expect(dispatched).toHaveLength(2); // the valid RULE still fires
+        });
+
+        test('reschedules from the finally block even when fetchRollup throws', async () => {
+            applyStubs();
+            KbAlertingService.fetchRollup = async () => { throw new Error('telemetry store down') };
+            let rescheduled = 0;
+            KbAlertingService.scheduleNext = () => { rescheduled++ };
+
+            await KbAlertingService.pulse();
+
+            expect(rescheduled).toBe(1);
+        });
+    });
+
+    test.describe('dispatchAlert routing', () => {
+        test('a webhook channel is recognized but not dispatched (V1.5-deferred)', async () => {
+            applyStubs();
+            const warns = [];
+            logger.warn = (msg) => { warns.push(msg) };
+            let consoleCalls = 0, a2aCalls = 0;
+            KbAlertingService.dispatchConsole = () => { consoleCalls++ };
+            KbAlertingService.dispatchA2A     = async () => { a2aCalls++ };
+
+            await KbAlertingService.dispatchAlert({tenantId: 'tenant-x', channel: 'webhook:https://example.test/hook', severity: 'warning'});
+
+            expect(consoleCalls).toBe(0);
+            expect(a2aCalls).toBe(0);
+            expect(warns.some(w => w.includes('Webhook channel deferred to V1.5'))).toBe(true);
+        });
+
+        test('a dispatch failure is caught and logged — dispatchAlert never throws', async () => {
+            applyStubs();
+            const errors = [];
+            logger.error = (msg) => { errors.push(msg) };
+            KbAlertingService.dispatchA2A = async () => { throw new Error('mailbox unreachable') };
+
+            await expect(
+                KbAlertingService.dispatchAlert({tenantId: 'tenant-x', channel: 'a2a:@neo-gpt', severity: 'warning'})
+            ).resolves.toBeUndefined();
+            expect(errors.some(e => e.includes('Alert dispatch failed'))).toBe(true);
+        });
+    });
+
+    test.describe('dispatchA2A', () => {
+        /** Captures `addMessage` payloads + neutralizes the RequestContextService wrapper. */
+        function captureA2A() {
+            const sent = [];
+            RequestContextService.run = async (ctx, fn) => fn();
+            MailboxService.addMessage = async (args) => { sent.push(args); return {messageId: 'MESSAGE:test'} };
+            return sent;
+        }
+
+        test('direct-DM — dispatches addMessage to the canonical identity target', async () => {
+            const sent = captureA2A();
+
+            await KbAlertingService.dispatchA2A({
+                tenantId: 'tenant-x', repoSlug: 'repo-x', metric: 'errorRate', value: 0.3,
+                threshold: 0.1, severity: 'warning', channel: 'a2a:@neo-gpt', deliveryMode: 'wake'
+            });
+
+            expect(sent).toHaveLength(1);
+            expect(sent[0].to).toBe('@neo-gpt');
+            expect(sent[0].subject).toContain('[alert]');
+            expect(sent[0].wakeSuppressed).toBe(false);
+        });
+
+        test('explicit broadcast — dispatches to AGENT:* when the rule opts in', async () => {
+            const sent = captureA2A();
+
+            await KbAlertingService.dispatchA2A({
+                tenantId: 'tenant-x', repoSlug: 'repo-x', metric: 'errorRate', value: 0.3,
+                threshold: 0.1, severity: 'warning', channel: 'a2a:AGENT:*', deliveryMode: 'wake'
+            });
+
+            expect(sent[0].to).toBe('AGENT:*');
+        });
+
+        test('audit delivery mode maps to wakeSuppressed:true; critical maps to high priority', async () => {
+            const sent = captureA2A();
+
+            await KbAlertingService.dispatchA2A({
+                tenantId: 'tenant-x', repoSlug: 'repo-x', metric: 'errorRate', value: 0.9,
+                threshold: 0.1, severity: 'critical', channel: 'a2a:@neo-gpt', deliveryMode: 'audit'
+            });
+
+            expect(sent[0].wakeSuppressed).toBe(true);
+            expect(sent[0].priority).toBe('high');
+        });
+    });
+
+    test.describe('dispatchConsole', () => {
+        test('maps critical to logger.error and warning to logger.warn', () => {
+            const warns = [], errors = [];
+            logger.warn  = (msg) => { warns.push(msg) };
+            logger.error = (msg) => { errors.push(msg) };
+
+            KbAlertingService.dispatchConsole({tenantId: 't', repoSlug: 'r', metric: 'errorRate', value: 0.2, threshold: 0.1, severity: 'warning'});
+            KbAlertingService.dispatchConsole({tenantId: 't', repoSlug: 'r', metric: 'errorRate', value: 0.9, threshold: 0.1, severity: 'critical'});
+
+            expect(warns).toHaveLength(1);
+            expect(errors).toHaveLength(1);
+            expect(warns[0]).toContain('[alert] warning');
+            expect(errors[0]).toContain('[alert] critical');
+        });
+    });
+});

--- a/test/playwright/unit/ai/daemons/KbAlertingService.spec.mjs
+++ b/test/playwright/unit/ai/daemons/KbAlertingService.spec.mjs
@@ -33,7 +33,7 @@ import {test, expect} from '@playwright/test';
  * saved + restored around each test for the `dispatchA2A` / `dispatchConsole` cases.
  *
  * Covers the #11642 Contract Ledger Evidence columns for channel dispatch (direct-DM,
- * explicit broadcast, invalid-target tolerance, wake vs. audit) and the daemon poll loop;
+ * explicit broadcast, invalid-target rejection, wake vs. audit) and the daemon poll loop;
  * the pure threshold/cooldown logic is covered separately in `KbAlertRuleEngine.spec.mjs`.
  *
  * @see https://github.com/neomjs/neo/issues/11642
@@ -62,11 +62,12 @@ test.describe('Neo.ai.daemons.KbAlertingService (#11642)', () => {
         const KBRecorderService = (await import('../../../../../ai/services/knowledge-base/KBRecorderService.mjs')).default;
 
         originals = {
-            addMessage  : MailboxService.addMessage,
-            run         : RequestContextService.run,
-            warn        : logger.warn,
-            error       : logger.error,
-            recorderReady: KBRecorderService.ready
+            addMessage      : MailboxService.addMessage,
+            isReachableTarget: MailboxService.isReachableTarget,
+            run             : RequestContextService.run,
+            warn            : logger.warn,
+            error           : logger.error,
+            recorderReady   : KBRecorderService.ready
         };
 
         // `start()` awaits KBRecorderService.ready() — stub it to resolve immediately.
@@ -90,10 +91,11 @@ test.describe('Neo.ai.daemons.KbAlertingService (#11642)', () => {
             delete KbAlertingService[seam];
         }
 
-        MailboxService.addMessage   = originals.addMessage;
-        RequestContextService.run   = originals.run;
-        logger.warn                 = originals.warn;
-        logger.error                = originals.error;
+        MailboxService.addMessage        = originals.addMessage;
+        MailboxService.isReachableTarget = originals.isReachableTarget;
+        RequestContextService.run        = originals.run;
+        logger.warn                      = originals.warn;
+        logger.error                     = originals.error;
     });
 
     /**
@@ -256,8 +258,9 @@ test.describe('Neo.ai.daemons.KbAlertingService (#11642)', () => {
         /** Captures `addMessage` payloads + neutralizes the RequestContextService wrapper. */
         function captureA2A() {
             const sent = [];
-            RequestContextService.run = async (ctx, fn) => fn();
-            MailboxService.addMessage = async (args) => { sent.push(args); return {messageId: 'MESSAGE:test'} };
+            RequestContextService.run        = async (ctx, fn) => fn();
+            MailboxService.isReachableTarget = () => true; // tests below use resolvable targets
+            MailboxService.addMessage        = async (args) => { sent.push(args); return {messageId: 'MESSAGE:test'} };
             return sent;
         }
 
@@ -296,6 +299,23 @@ test.describe('Neo.ai.daemons.KbAlertingService (#11642)', () => {
 
             expect(sent[0].wakeSuppressed).toBe(true);
             expect(sent[0].priority).toBe('high');
+        });
+
+        test('skips an unresolvable A2A target before dispatch — no addMessage call', async () => {
+            // #11642 Contract Ledger / @neo-gpt PR #11709 review: an unresolvable target
+            // (not a registered @<identity>, not AGENT:*) must be rejected before dispatch.
+            const sent = captureA2A();
+            MailboxService.isReachableTarget = () => false; // simulate an unregistered target
+            const warns = [];
+            logger.warn = (msg) => { warns.push(msg) };
+
+            await KbAlertingService.dispatchA2A({
+                tenantId: 'tenant-x', repoSlug: 'repo-x', metric: 'errorRate', value: 0.3,
+                threshold: 0.1, severity: 'warning', channel: 'a2a:@not-a-real-agent', deliveryMode: 'wake'
+            });
+
+            expect(sent).toHaveLength(0); // MailboxService.addMessage never called
+            expect(warns.some(w => w.includes('unresolvable A2A target'))).toBe(true);
         });
     });
 

--- a/test/playwright/unit/ai/services/knowledge-base/KbAlertRuleEngine.spec.mjs
+++ b/test/playwright/unit/ai/services/knowledge-base/KbAlertRuleEngine.spec.mjs
@@ -1,0 +1,200 @@
+import {test, expect} from '@playwright/test';
+
+import {
+    ALERT_SEVERITIES,
+    cooldownKey,
+    DEFAULT_COOLDOWN_MS,
+    evaluateAlertRules,
+    formatAlertMessage,
+    KNOWN_METRICS,
+    validateAlertRule
+} from '../../../../../../ai/services/knowledge-base/helpers/KbAlertRuleEngine.mjs';
+
+/**
+ * Phase 4D (#11642) — `KbAlertRuleEngine` coverage: the pure rule-evaluation core of the
+ * KB operator-alerting daemon.
+ *
+ * The module is dependency-free (no Neo class system, no I/O, no clock) — so this spec
+ * needs no `setup()` harness; it imports the pure functions directly and exercises them
+ * against fixture rollups whose shape mirrors `KBRecorderService.getTenantIngestionRollup`.
+ *
+ * Covers the #11642 Contract Ledger Evidence columns for the `alertRules` schema row
+ * (rule parse + validation) and the hysteresis row (cooldown suppression + per-key
+ * independence). Channel *dispatch* is the daemon's concern and is tested separately.
+ *
+ * @see https://github.com/neomjs/neo/issues/11642
+ * @see ai/services/knowledge-base/helpers/KbAlertRuleEngine.mjs — the module under test.
+ */
+
+/** A baseline well-formed rule — individual tests clone + mutate it. */
+const VALID_RULE = {
+    metric  : 'errorRate',
+    threshold: 0.1,
+    severity: 'warning',
+    channels: ['console', 'a2a:@neo-gpt']
+};
+
+/** A two-tenant rollup mirroring `getTenantIngestionRollup` row shape. */
+const ROLLUP = [
+    {tenantId: 'tenant-a', repoSlug: 'repo-a', eventCount: 8, errorEvents: 2, errorRate: 0.25, chunksEmbedded: 120},
+    {tenantId: 'tenant-b', repoSlug: 'repo-b', eventCount: 4, errorEvents: 0, errorRate: 0,    chunksEmbedded: 60}
+];
+
+test.describe('KbAlertRuleEngine — validateAlertRule (#11642)', () => {
+    test('accepts a well-formed rule', () => {
+        expect(validateAlertRule(VALID_RULE)).toEqual({valid: true, reason: ''});
+    });
+
+    test('accepts an optional deliveryMode and rejects an invalid one', () => {
+        expect(validateAlertRule({...VALID_RULE, deliveryMode: 'audit'}).valid).toBe(true);
+        expect(validateAlertRule({...VALID_RULE, deliveryMode: 'wake'}).valid).toBe(true);
+        expect(validateAlertRule({...VALID_RULE, deliveryMode: 'shout'}).valid).toBe(false);
+    });
+
+    test('rejects a non-object rule', () => {
+        expect(validateAlertRule(null).valid).toBe(false);
+        expect(validateAlertRule('errorRate>0.1').valid).toBe(false);
+    });
+
+    test('rejects an unknown metric', () => {
+        const result = validateAlertRule({...VALID_RULE, metric: 'error_rate_5min'});
+        expect(result.valid).toBe(false);
+        expect(result.reason).toContain('unknown metric');
+    });
+
+    test('rejects a non-numeric or non-finite threshold', () => {
+        expect(validateAlertRule({...VALID_RULE, threshold: '0.1'}).valid).toBe(false);
+        expect(validateAlertRule({...VALID_RULE, threshold: Infinity}).valid).toBe(false);
+        expect(validateAlertRule({...VALID_RULE, threshold: NaN}).valid).toBe(false);
+    });
+
+    test('rejects an invalid severity', () => {
+        expect(validateAlertRule({...VALID_RULE, severity: 'fatal'}).valid).toBe(false);
+    });
+
+    test('rejects empty or missing channels — no implicit default', () => {
+        expect(validateAlertRule({...VALID_RULE, channels: []}).valid).toBe(false);
+        expect(validateAlertRule({...VALID_RULE, channels: undefined}).valid).toBe(false);
+    });
+
+    test('rejects a malformed channel spec', () => {
+        expect(validateAlertRule({...VALID_RULE, channels: ['console', 'slack:foo']}).valid).toBe(false);
+        expect(validateAlertRule({...VALID_RULE, channels: ['a2a:']}).valid).toBe(false);
+        expect(validateAlertRule({...VALID_RULE, channels: ['webhook:']}).valid).toBe(false);
+    });
+
+    test('exposes the known-metric and severity vocabularies', () => {
+        expect(KNOWN_METRICS).toContain('errorRate');
+        expect(KNOWN_METRICS).toContain('chunksEmbedded');
+        expect(ALERT_SEVERITIES).toEqual(['warning', 'critical']);
+    });
+});
+
+test.describe('KbAlertRuleEngine — evaluateAlertRules (#11642)', () => {
+    test('emits one alert per channel for a breaching tenant', () => {
+        const {alerts, skippedRules} = evaluateAlertRules({rules: [VALID_RULE], rollup: ROLLUP, now: 1000});
+
+        expect(skippedRules).toHaveLength(0);
+        // tenant-a breaches (errorRate 0.25 > 0.1) on 2 channels; tenant-b (0) does not.
+        expect(alerts).toHaveLength(2);
+        expect(alerts.every(a => a.tenantId === 'tenant-a')).toBe(true);
+        expect(alerts.map(a => a.channel).sort()).toEqual(['a2a:@neo-gpt', 'console']);
+        expect(alerts[0]).toMatchObject({metric: 'errorRate', value: 0.25, threshold: 0.1, severity: 'warning', deliveryMode: 'wake'});
+    });
+
+    test('emits nothing when no tenant breaches', () => {
+        const lenient = {...VALID_RULE, threshold: 0.9};
+        const {alerts} = evaluateAlertRules({rules: [lenient], rollup: ROLLUP, now: 1000});
+
+        expect(alerts).toHaveLength(0);
+    });
+
+    test('uses strict greater-than — a value equal to the threshold does not breach', () => {
+        const exact = {...VALID_RULE, metric: 'errorRate', threshold: 0.25};
+        const {alerts} = evaluateAlertRules({rules: [exact], rollup: ROLLUP, now: 1000});
+
+        expect(alerts).toHaveLength(0);
+    });
+
+    test('collects invalid rules into skippedRules without blocking valid ones', () => {
+        const rules = [{...VALID_RULE, metric: 'bogus'}, VALID_RULE];
+        const {alerts, skippedRules} = evaluateAlertRules({rules, rollup: ROLLUP, now: 1000});
+
+        expect(skippedRules).toHaveLength(1);
+        expect(skippedRules[0].reason).toContain('unknown metric');
+        expect(alerts).toHaveLength(2); // the valid rule still fires
+    });
+
+    test('does not breach on a missing or non-numeric metric field', () => {
+        const rule   = {...VALID_RULE, metric: 'chunksDeleted'}; // not present in ROLLUP rows
+        const {alerts} = evaluateAlertRules({rules: [rule], rollup: ROLLUP, now: 1000});
+
+        expect(alerts).toHaveLength(0);
+    });
+
+    test('returns an empty result for non-array rules or rollup (defensive)', () => {
+        expect(evaluateAlertRules({rules: null, rollup: ROLLUP, now: 1}).alerts).toHaveLength(0);
+        expect(evaluateAlertRules({rules: [VALID_RULE], rollup: undefined, now: 1}).alerts).toHaveLength(0);
+    });
+
+    test('carries deliveryMode into the descriptor (default wake)', () => {
+        const auditRule = {...VALID_RULE, channels: ['a2a:@neo-gpt'], deliveryMode: 'audit'};
+        const {alerts}  = evaluateAlertRules({rules: [auditRule], rollup: ROLLUP, now: 1000});
+
+        expect(alerts[0].deliveryMode).toBe('audit');
+    });
+
+    test('suppresses a re-fire within the cooldown window and re-fires after it', () => {
+        const first = evaluateAlertRules({rules: [VALID_RULE], rollup: ROLLUP, now: 1000});
+        expect(first.alerts).toHaveLength(2);
+
+        // Re-evaluate inside the default 1h window — fully suppressed.
+        const within = evaluateAlertRules({
+            rules: [VALID_RULE], rollup: ROLLUP, cooldownState: first.cooldownState, now: 1000 + 60_000
+        });
+        expect(within.alerts).toHaveLength(0);
+
+        // Re-evaluate past the window — re-fires.
+        const after = evaluateAlertRules({
+            rules: [VALID_RULE], rollup: ROLLUP, cooldownState: first.cooldownState, now: 1000 + DEFAULT_COOLDOWN_MS + 1
+        });
+        expect(after.alerts).toHaveLength(2);
+    });
+
+    test('cools down per (tenant, metric, severity, channel) key independently', () => {
+        // Seed a cooldown for ONLY tenant-a's console channel.
+        const seeded = {[cooldownKey('tenant-a', 'errorRate', 'warning', 'console')]: 1000};
+
+        const {alerts} = evaluateAlertRules({
+            rules: [VALID_RULE], rollup: ROLLUP, cooldownState: seeded, now: 1000 + 60_000
+        });
+
+        // console is cooled down; a2a:@neo-gpt is not → exactly one alert, on the a2a channel.
+        expect(alerts).toHaveLength(1);
+        expect(alerts[0].channel).toBe('a2a:@neo-gpt');
+    });
+
+    test('honors a custom cooldownMs window', () => {
+        const first  = evaluateAlertRules({rules: [VALID_RULE], rollup: ROLLUP, now: 1000, cooldownMs: 5000});
+        const reEval = evaluateAlertRules({
+            rules: [VALID_RULE], rollup: ROLLUP, cooldownState: first.cooldownState, now: 1000 + 6000, cooldownMs: 5000
+        });
+        expect(reEval.alerts).toHaveLength(2); // 6000 > 5000 → re-fires
+    });
+});
+
+test.describe('KbAlertRuleEngine — formatAlertMessage / cooldownKey (#11642)', () => {
+    test('formatAlertMessage builds an [alert]-prefixed subject and a detail body', () => {
+        const [alert] = evaluateAlertRules({rules: [VALID_RULE], rollup: ROLLUP, now: 1000}).alerts;
+        const {subject, body} = formatAlertMessage(alert);
+
+        expect(subject).toBe('[alert] warning: errorRate 0.25 over threshold 0.1 (tenant tenant-a)');
+        expect(body).toContain('`tenant-a`');
+        expect(body).toContain('`repo-a`');
+        expect(body).toContain('threshold 0.1');
+    });
+
+    test('cooldownKey is a deterministic 4-tuple join', () => {
+        expect(cooldownKey('t', 'errorRate', 'critical', 'console')).toBe('t|errorRate|critical|console');
+    });
+});


### PR DESCRIPTION
Authored by Neo Opus 4.7 (Claude Code). Session 470c38e7-1ffc-4851-867d-d30c1b6fbdb2.

FAIR-band: under-target [13/30] — Self-Selection Rule 1 fires (under-band → bias toward author lane).

Resolves #11642
Related: #11628
Related: #11624

Completes Phase 4D (#11642) of Phase 4 epic #11628 (meta-epic #11624, Cloud-Native KB Ingestion). Closes the operability loop: Phase 4A (#11639) collects per-tenant KB ingestion telemetry; this daemon polls the per-tenant rollup, evaluates it against operator-configured thresholds, and pushes alerts to operators / peers — so cloud operators no longer have to manually poll telemetry tables.

## What shipped

- **`ai/services/knowledge-base/helpers/KbAlertRuleEngine.mjs`** — the pure rule-evaluation core (dependency-free: no Neo, no I/O, no clock). `validateAlertRule` (structural schema validation), `evaluateAlertRules` (a metric strictly above its threshold breaches; per-channel hysteresis keyed on the `(tenantId, metric, severity, channel)` 4-tuple), `formatAlertMessage`, `cooldownKey`.
- **`ai/daemons/KbAlertingService.mjs`** — the poll-loop daemon (a `Neo.core.Base` singleton, the `SwarmHeartbeatService` pattern: `start` / `stop` / `scheduleNext` / `pulse`). Each `pulse()` rolls up `KBRecorderService.getTenantIngestionRollup` over a look-back window, runs the rule engine, and dispatches each alert via test-stubbable channel seams: `console` → `logger`; `a2a:<target>` → `MailboxService.addMessage` under a bound sender identity (the `idleOutNudge` precedent), gated by a `MailboxService.isReachableTarget` pre-check that skips an unresolvable target before dispatch; `webhook:` → V1.5-deferred warn-skip. Opt-in via `aiConfig.knowledgeBase.alertingEnabled`.
- **`ai/scripts/kb-alerting-daemon.mjs`** — the thin Neo-bootstrap wrapper; **`package.json`** — the `ai:kb-alerting` script.
- **`ai/config.template.mjs`** — the `aiConfig.knowledgeBase` config block (`alertRules` + `alertingEnabled` / `alertingIntervalMs` / `alertingCooldownMs` / `alertWindowMs`), read defensively (a stale gitignored `config.mjs` predating #11642 has no `knowledgeBase` key).

The implementation follows the **#11642 Contract Ledger** (authored at intake, in the ticket body) and folds in **@neo-gpt's "Phase 4D Alerting Channel Overlay"** (#11642 comment 2026-05-20): channels explicit per rule (no `AGENT:*` default), A2A targets first-class for direct `@<identity>` recipients, wake-vs-audit `deliveryMode`, cooldown keyed on the 4-tuple, webhook deferred behind an allowlist + secret story.

Evidence: L2 — 37 unit tests passing (21 `KbAlertRuleEngine` + 16 `KbAlertingService`), `node --check` clean → L2 sufficient for the test-ACs. The daemon's *scheduled-run* dimension (a live long-running process firing on a tick) is an L3 residual the CI sandbox cannot exercise — listed under Post-Merge Validation.

## Deltas from ticket

- **Webhook channel — V1.5-deferred.** Per the #11642 Contract Ledger + @neo-gpt's overlay: arbitrary-URL POST from alert config is a higher-blast surface than the A2A / console paths. V1 *recognizes* a `webhook:` channel spec but warn-skips it (no POST); V1.5 (a separate ticket) ships the POST path alongside an allowlisted-target + secret-handling story.
- **`pulse()` hardening** (commit `2ea17b17c`) — the service spec surfaced that a thrown `fetchRollup` / dispatch error would reject `pulse()`, and since `scheduleNext()`'s `setTimeout` callback also has a `.catch` that reschedules, a failed cycle double-scheduled (timer accretion). Fixed: `pulse()` wraps its body in try/catch/finally so it never rejects; `finally` is the single reschedule.
- **`aiConfig.knowledgeBase` config block** — the ticket's first AC ("`alertRules` schema defined") is satisfied by adding the `knowledgeBase` block to `ai/config.template.mjs`; alongside `alertRules` it carries 4 scalar daemon tuning knobs (`alertingEnabled` / `alertingIntervalMs` / `alertingCooldownMs` / `alertWindowMs`).
- **Invalid-A2A-target pre-check** (commit `25f3e7332`, addressing @neo-gpt's Cycle-1 review) — new `MailboxService.isReachableTarget` (a non-throwing wrapper of the existing `normalizeMailboxTarget` + `validateMailboxTarget` pipeline) lets `dispatchA2A` reject an unresolvable target *before* dispatch, per the #11642 Contract Ledger — `MailboxService.addMessage` is never reached for it.

## Test Evidence

- `npm run test-unit -- test/playwright/unit/ai/services/knowledge-base/KbAlertRuleEngine.spec.mjs` → **21 passed**. Rule validation (known metric / finite threshold / severity / explicit channels / channel-spec / `deliveryMode`), threshold breach (strict `>`), invalid-rule skip, cooldown suppression + re-fire + per-key independence, `formatAlertMessage` / `cooldownKey`.
- `npm run test-unit -- test/playwright/unit/ai/daemons/KbAlertingService.spec.mjs` → **16 passed**. Opt-in gating, `start` / `stop` idempotency + cooldown reset, `pulse` channel routing + cooldown threading + malformed-rule skip + reschedule-on-failure, `dispatchAlert` routing (webhook warn-skip, dispatch-failure tolerance), `dispatchA2A` (direct-DM, explicit broadcast, audit → `wakeSuppressed`, critical → `high` priority, unresolvable-target skip before dispatch — no `addMessage` call), `dispatchConsole` (severity → logger level).

`node --check` clean on all 4 `.mjs` source files; `package.json` valid JSON; the `check-whitespace` pre-commit hook passed on all 4 commits.

## Post-Merge Validation

- [ ] With `aiConfig.knowledgeBase.alertingEnabled: true` + a sample `alertRules` entry, confirm a launched `npm run ai:kb-alerting` daemon polls on its interval and dispatches an alert when a tenant breaches a threshold (the L3 scheduled-run surface the CI sandbox cannot reach).

## Commits

- `8b1da4dcb` — feat(ai): add KB alert rule-evaluation engine (#11642)
- `39ec6b212` — feat(ai): add KB operator-alerting daemon (#11642)
- `2ea17b17c` — test(ai): KbAlertingService daemon spec + pulse() hardening (#11642)
- `25f3e7332` — fix(ai): reject unresolvable A2A alert targets before dispatch (#11642)

## Related

- #11628 — Phase 4 epic (KB Operations + Observability); my epic-review: https://github.com/neomjs/neo/issues/11628#issuecomment-4504271144
- #11624 — Cloud-Native KB Ingestion meta-epic
- #11642 Contract Ledger — in the ticket body, the binding contract (authored at intake)
- #11642 comment 2026-05-20 — @neo-gpt's Phase 4D Alerting Channel Overlay, folded in
