### PR TITLE
feat(ai): KB reconciliation daemon — Phase 4B (#11640)

### DIFF
--- a/ai/config.template.mjs
+++ b/ai/config.template.mjs
@@ -117,7 +117,33 @@ const defaultConfig = {
          * telemetry rollup the rule engine evaluates (default 1 h).
          * @type {Number}
          */
-        alertWindowMs: 60 * 60 * 1000
+        alertWindowMs: 60 * 60 * 1000,
+        /**
+         * Phase 4B (#11640) — master opt-in for the KB reconciliation daemon.
+         * Disabled by default; the daemon exits early when false.
+         * @type {Boolean}
+         */
+        reconciliationEnabled: false,
+        /**
+         * Phase 4B (#11640) — reconciliation daemon poll interval in ms (default 1 h).
+         * @type {Number}
+         */
+        reconciliationIntervalMs: 60 * 60 * 1000,
+        /**
+         * Phase 4B (#11640) — opt-in for the destructive auto-tombstone reconciliation
+         * action. Disabled by default — the daemon then detects config-stale chunks and
+         * emits Phase 4A telemetry only, issuing no `collection.delete`.
+         * @type {Boolean}
+         */
+        reconciliationAutoTombstone: false,
+        /**
+         * Phase 4B (#11640) — config-version-gap threshold above which a config-stale
+         * chunk becomes auto-tombstone-eligible: a chunk is actioned when
+         * `currentConfigVersion - chunk.tenantConfigVersion >= this`. Default `2` gives
+         * one full config epoch of grace. Consulted only when `reconciliationAutoTombstone`.
+         * @type {Number}
+         */
+        reconciliationOrphanVersionGap: 2
     },
     /**
      * A dummy embedding function to satisfy ChromaDB when embeddings are provided manually.

--- a/ai/daemons/KbReconciliationService.mjs
+++ b/ai/daemons/KbReconciliationService.mjs
@@ -1,0 +1,388 @@
+// Class-only file (#11058-style split). Entry-point bootstrap (Neo + core/_export +
+// InstanceManager) lives in `ai/scripts/kb-reconciliation-daemon.mjs` per the canonical
+// Orchestrator class+wrapper pattern. `Neo.setupClass(KbReconciliationService)` at file
+// bottom works via `globalThis.Neo`, populated by the entry-point bootstrap chain.
+import Base                          from '../../src/core/Base.mjs';
+import {Memory_Config as aiConfig}   from '../services.mjs';
+import ChromaManager                 from '../services/knowledge-base/ChromaManager.mjs';
+import KBRecorderService             from '../services/knowledge-base/KBRecorderService.mjs';
+import KnowledgeBaseIngestionService from '../services/knowledge-base/KnowledgeBaseIngestionService.mjs';
+import logger                        from '../mcp/server/knowledge-base/logger.mjs';
+import {
+    diffTenantChunks,
+    formatReconciliationDetail,
+    resolveOrphanVersionGap
+} from '../services/knowledge-base/helpers/KbReconciliationEngine.mjs';
+
+/**
+ * @summary Poll-interval fallback when `aiConfig.knowledgeBase.reconciliationIntervalMs` is unset.
+ * @type {Number}
+ */
+const DEFAULT_INTERVAL_MS = 60 * 60 * 1000;
+
+/**
+ * @summary Chroma `collection.get` page size for the batched per-tenant rows fetch.
+ * @type {Number}
+ */
+const ROWS_PAGE_SIZE = 2000;
+
+/**
+ * @summary Phase 4B KB reconciliation daemon — config-invalidation drift detection (#11640).
+ *
+ * Closes part of the Phase 4 operability loop: when a tenant mutates its
+ * `KnowledgeBaseTenantConfig`, `getTenantConfig().version` increments and every chunk
+ * ingested under the prior config is now *config-stale* (#11637 stamps each chunk's
+ * `tenantConfigVersion`). This daemon periodically diffs each tenant's persisted Chroma
+ * chunks against the tenant's current config version, emits Phase 4A reconciliation
+ * telemetry, and — opt-in — tombstones the chunks left stale by a config change.
+ *
+ * **Shape** — the canonical poll-loop daemon (the `SwarmHeartbeatService` / `KbAlertingService`
+ * precedent): a `Neo.core.Base` singleton with `start()` / `stop()` / `scheduleNext()` /
+ * `pulse()`. The entry-point wrapper `ai/scripts/kb-reconciliation-daemon.mjs` owns the Neo
+ * bootstrap + SIGTERM.
+ *
+ * **Split** — the *pure* classification (config-stale detection, version-gap partition,
+ * telemetry-detail shaping) lives in `KbReconciliationEngine.mjs` and is unit-tested in
+ * isolation; this class owns only the I/O: the poll loop, tenant enumeration, the Chroma
+ * read, telemetry emission, and the opt-in delete.
+ *
+ * **Opt-in** — `start()` is a no-op unless `aiConfig.knowledgeBase.reconciliationEnabled` is
+ * true, so a default deployment never runs the daemon. The destructive auto-tombstone is a
+ * *second* opt-in (`reconciliationAutoTombstone`, default false): with it off, the daemon
+ * detects + emits telemetry only and issues no `collection.delete`.
+ *
+ * **V1 scope** (per the #11640 Contract Ledger, ticket body): V1 reconciles the
+ * config-invalidation failure mode via the `tenantConfigVersion` stamp. Force-push /
+ * mid-push / partial-push drift detection needs a persisted claimed-state manifest that
+ * Phase 2 substrate does not provide — V1.x-deferred. V1 is purely additive: it touches no
+ * merged Phase 2 code (it reuses only the public `getTenantConfig` + the documented
+ * `where: {tenantId}` Chroma read idiom).
+ *
+ * @class Neo.ai.daemons.KbReconciliationService
+ * @extends Neo.core.Base
+ * @singleton
+ * @see ai/scripts/kb-reconciliation-daemon.mjs — the entry-point wrapper.
+ * @see ai/services/knowledge-base/helpers/KbReconciliationEngine.mjs — the pure diff engine.
+ * @see ai/daemons/KbAlertingService.mjs — the sibling Phase 4D poll-loop daemon precedent (#11642).
+ */
+class KbReconciliationService extends Base {
+    static config = {
+        /**
+         * @member {String} className='Neo.ai.daemons.KbReconciliationService'
+         * @protected
+         */
+        className: 'Neo.ai.daemons.KbReconciliationService',
+        /**
+         * @member {Boolean} singleton=true
+         * @protected
+         */
+        singleton: true,
+        /**
+         * Whether the poll loop is running.
+         * @member {Boolean} isPolling_=false
+         * @protected
+         * @reactive
+         */
+        isPolling_: false,
+        /**
+         * Active `setTimeout` handle for the next pulse; `null` when not scheduled.
+         * @member {Object|null} pollHandle_=null
+         * @protected
+         * @reactive
+         */
+        pollHandle_: null,
+        /**
+         * Interval between reconciliation pulses in milliseconds.
+         * @member {Number} pollIntervalMs_=3600000
+         * @protected
+         * @reactive
+         */
+        pollIntervalMs_: DEFAULT_INTERVAL_MS
+    }
+
+    /**
+     * @summary Starts the reconciliation poll loop. Idempotent; a no-op while already polling.
+     *
+     * Exits early (without scheduling) when `aiConfig.knowledgeBase.reconciliationEnabled` is
+     * false — the daemon process then has nothing keeping the event loop alive and exits.
+     *
+     * @param {Object}  [options]
+     * @param {Number} [options.pollIntervalMs] Override the configured poll interval.
+     * @returns {Promise<void>}
+     */
+    async start({pollIntervalMs} = {}) {
+        if (this.isPolling) {
+            logger.debug('[KbReconciliationService] Already polling; start() is a no-op.');
+            return;
+        }
+
+        const kbConfig = this.getKbConfig();
+
+        if (!kbConfig.reconciliationEnabled) {
+            logger.info('[KbReconciliationService] Reconciliation disabled (aiConfig.knowledgeBase.reconciliationEnabled=false); not starting.');
+            return;
+        }
+
+        this.pollIntervalMs = pollIntervalMs || kbConfig.reconciliationIntervalMs || DEFAULT_INTERVAL_MS;
+
+        await KBRecorderService.ready();
+
+        this.isPolling = true;
+        logger.info(`[KbReconciliationService] Starting KB reconciliation (interval: ${this.pollIntervalMs}ms)`);
+
+        this.scheduleNext()
+    }
+
+    /**
+     * @summary Stops the poll loop. Idempotent. Cancels any pending pulse so a clean
+     * SIGTERM under launchd/systemd does not leave a timer wedging the event loop.
+     * @returns {void}
+     */
+    stop() {
+        if (this.pollHandle) {
+            clearTimeout(this.pollHandle);
+            this.pollHandle = null
+        }
+        this.isPolling = false;
+        logger.info('[KbReconciliationService] Reconciliation stopped.')
+    }
+
+    /**
+     * @summary Schedules the next pulse. Called after each pulse settles so a single
+     * thrown error never breaks the loop.
+     * @returns {void}
+     * @protected
+     */
+    scheduleNext() {
+        if (!this.isPolling) return;
+
+        this.pollHandle = setTimeout(() => this.pulse().catch(err => {
+            logger.error('[KbReconciliationService] Pulse threw uncaught error:', err);
+            this.scheduleNext()
+        }), this.pollIntervalMs)
+    }
+
+    /**
+     * @summary Executes one reconciliation pulse: enumerate tenants → per-tenant diff →
+     * telemetry → opt-in tombstone.
+     *
+     * Wrapped in try/catch/finally so a failed cycle is logged and `scheduleNext()` still
+     * fires — one bad cycle must not stop the daemon. Per-tenant work is additionally
+     * guarded inside {@link reconcileTenant} so one tenant's failure never aborts the rest.
+     *
+     * @returns {Promise<void>}
+     * @protected
+     */
+    async pulse() {
+        try {
+            const kbConfig         = this.getKbConfig(),
+                  autoTombstone    = kbConfig.reconciliationAutoTombstone === true,
+                  orphanVersionGap = resolveOrphanVersionGap(kbConfig.reconciliationOrphanVersionGap),
+                  tenants          = await this.fetchTenants();
+
+            if (tenants.length === 0) {
+                return // no tenants have ingestion telemetry yet → nothing to reconcile
+            }
+
+            const collection = await this.getCollection();
+
+            for (const tenant of tenants) {
+                await this.reconcileTenant({...tenant, collection, orphanVersionGap, autoTombstone})
+            }
+
+            logger.debug(`[KbReconciliationService] Pulse complete — ${tenants.length} tenant(s) reconciled (autoTombstone=${autoTombstone})`)
+        } catch (err) {
+            // A single-cycle failure must not stop the daemon — log and let `finally`
+            // reschedule. Catching here also keeps `pulse()` from rejecting, so the loop
+            // never double-schedules (the `finally` + `scheduleNext`'s own `.catch`).
+            logger.error('[KbReconciliationService] Pulse failed:', err)
+        } finally {
+            this.scheduleNext()
+        }
+    }
+
+    /**
+     * @summary Reconciles one tenant: config-version diff → telemetry → opt-in tombstone.
+     *
+     * Never throws — a per-tenant failure (a config read, a Chroma error) is logged and the
+     * remaining tenants still reconcile. A clean tenant (zero config-stale chunks) emits no
+     * telemetry, so a `reconcile` event genuinely means drift was found.
+     *
+     * @param {Object}  params
+     * @param {String}  params.tenantId
+     * @param {String}  params.repoSlug          Representative repo slug for the telemetry row.
+     * @param {Object}  params.collection        The Chroma `knowledge-base` collection.
+     * @param {Number}  params.orphanVersionGap  Resolved actionable version-gap threshold.
+     * @param {Boolean} params.autoTombstone     Whether the opt-in delete path is enabled.
+     * @returns {Promise<void>}
+     * @protected
+     */
+    async reconcileTenant({tenantId, repoSlug, collection, orphanVersionGap, autoTombstone}) {
+        try {
+            const currentVersion = await this.fetchTenantConfigVersion(tenantId),
+                  rows           = await this.fetchTenantRows(collection, tenantId),
+                  diff           = diffTenantChunks({rows, currentVersion, orphanVersionGap});
+
+            if (diff.staleCount === 0) {
+                return // clean tenant — emit nothing
+            }
+
+            let tombstonedCount = 0;
+
+            if (autoTombstone && diff.actionableCount > 0) {
+                tombstonedCount = await this.tombstoneOrphans(collection, diff.actionableIds)
+            }
+
+            this.recordReconcileMetric({tenantId, repoSlug, diff, currentVersion, autoTombstone, tombstonedCount});
+
+            logger.info(`[KbReconciliationService] tenant ${tenantId}: ${diff.staleCount} config-stale chunk(s), ${diff.actionableCount} actionable, ${tombstonedCount} tombstoned (autoTombstone=${autoTombstone})`)
+        } catch (err) {
+            logger.error(`[KbReconciliationService] Reconciliation failed for tenant ${tenantId}: ${err.message}`)
+        }
+    }
+
+    /**
+     * @summary Test-stubbable seam over `aiConfig.knowledgeBase`.
+     *
+     * Reads defensively: a stale gitignored `ai/config.mjs` deployment predating #11640 has
+     * no `knowledgeBase` key (or lacks the reconciliation keys), so a naked
+     * `aiConfig.knowledgeBase.reconciliationEnabled` would throw. Returns `{}` when absent.
+     *
+     * @returns {Object}
+     * @protected
+     */
+    getKbConfig() {
+        return aiConfig.knowledgeBase || {}
+    }
+
+    /**
+     * @summary Test-stubbable seam — enumerates the tenants to reconcile.
+     *
+     * The substrate-real tenant list is the distinct `tenantId` set of
+     * `KBRecorderService.getTenantIngestionRollup()` (all-time) — every tenant that has ever
+     * ingested. Deduped to one entry per tenant; the first-seen `repoSlug` is kept as the
+     * representative slug for that tenant's `reconcile` telemetry row.
+     *
+     * @returns {Promise<Array<{tenantId: String, repoSlug: String}>>}
+     * @protected
+     */
+    async fetchTenants() {
+        const rollup = KBRecorderService.getTenantIngestionRollup() || [],
+              seen   = new Map();
+
+        for (const row of rollup) {
+            if (row?.tenantId && !seen.has(row.tenantId)) {
+                seen.set(row.tenantId, row.repoSlug || 'neo')
+            }
+        }
+
+        return [...seen].map(([tenantId, repoSlug]) => ({tenantId, repoSlug}))
+    }
+
+    /**
+     * @summary Test-stubbable seam over `ChromaManager.getKnowledgeBaseCollection`.
+     * @returns {Promise<Object>} The Chroma `knowledge-base` collection.
+     * @protected
+     */
+    async getCollection() {
+        return ChromaManager.getKnowledgeBaseCollection()
+    }
+
+    /**
+     * @summary Test-stubbable seam — resolves a tenant's current config version (#11637).
+     * @param {String} tenantId
+     * @returns {Promise<Number>} `getTenantConfig().version`, or `0` on the yaml/default tier.
+     * @protected
+     */
+    async fetchTenantConfigVersion(tenantId) {
+        const config = await KnowledgeBaseIngestionService.getTenantConfig({tenantId});
+
+        return config?.version ?? 0
+    }
+
+    /**
+     * @summary Test-stubbable seam — fetches all of a tenant's Chroma rows, batched.
+     *
+     * Mirrors the batched `collection.get({where: {tenantId}})` idiom of
+     * `KnowledgeBaseIngestionService.getTenantRows`; kept local (rather than calling that
+     * `@protected` method) so V1 touches zero merged Phase 2 code — the #11640 Contract
+     * Ledger's "purely additive" scope guarantee.
+     *
+     * @param {Object} collection The Chroma `knowledge-base` collection.
+     * @param {String} tenantId
+     * @returns {Promise<Array<{id: String, metadata: Object}>>}
+     * @protected
+     */
+    async fetchTenantRows(collection, tenantId) {
+        const rows = [];
+        let   offset = 0,
+              batch;
+
+        do {
+            batch = await collection.get({
+                include: ['metadatas'],
+                limit  : ROWS_PAGE_SIZE,
+                offset,
+                where  : {tenantId}
+            });
+
+            for (let i = 0; i < (batch.ids?.length || 0); i++) {
+                rows.push({id: batch.ids[i], metadata: batch.metadatas?.[i] || {}})
+            }
+
+            offset += ROWS_PAGE_SIZE
+        } while ((batch.ids?.length || 0) === ROWS_PAGE_SIZE);
+
+        return rows
+    }
+
+    /**
+     * @summary Test-stubbable seam — tombstones the actionable orphan ids from Chroma.
+     * @param {Object}        collection The Chroma `knowledge-base` collection.
+     * @param {Array<String>} ids        Tenant-scoped actionable orphan chunk ids.
+     * @returns {Promise<Number>} Count of ids deleted.
+     * @protected
+     */
+    async tombstoneOrphans(collection, ids) {
+        if (!Array.isArray(ids) || ids.length === 0) {
+            return 0
+        }
+
+        await collection.delete({ids});
+
+        return ids.length
+    }
+
+    /**
+     * @summary Test-stubbable seam — emits one Phase 4A `reconcile` telemetry event.
+     *
+     * `recordIngestionMetric` is best-effort (it never throws into the caller); the
+     * `reconcile` event type + the `chunksDeleted` / `reconcileEvents` rollup fields it
+     * feeds are already first-class `KBRecorderService` / `KbAlertRuleEngine` surfaces, so
+     * an operator can alert on reconciliation drift via #11642 with no extra wiring.
+     *
+     * @param {Object}  params
+     * @param {String}  params.tenantId
+     * @param {String}  params.repoSlug
+     * @param {Object}  params.diff             A {@link diffTenantChunks} result.
+     * @param {Number}  params.currentVersion
+     * @param {Boolean} params.autoTombstone
+     * @param {Number}  params.tombstonedCount
+     * @returns {void}
+     * @protected
+     */
+    recordReconcileMetric({tenantId, repoSlug, diff, currentVersion, autoTombstone, tombstonedCount}) {
+        KBRecorderService.recordIngestionMetric?.({
+            tenantId,
+            repoSlug,
+            eventType    : 'reconcile',
+            chunksTotal  : diff.staleCount,
+            chunksDeleted: tombstonedCount,
+            detail       : formatReconciliationDetail({diff, currentVersion, autoTombstone, tombstonedCount})
+        })
+    }
+}
+
+export default Neo.setupClass(KbReconciliationService);
+
+export {DEFAULT_INTERVAL_MS, ROWS_PAGE_SIZE};

--- a/ai/scripts/kb-reconciliation-daemon.mjs
+++ b/ai/scripts/kb-reconciliation-daemon.mjs
@@ -1,0 +1,46 @@
+/**
+ * @module ai/scripts/kb-reconciliation-daemon
+ * @summary Thin Node-process boot wrapper for the Phase 4B KB reconciliation daemon (#11640).
+ *
+ * Owns Neo namespace bootstrap + SIGTERM / SIGINT clean-stop signal handling +
+ * `KbReconciliationService.start()` invocation. The class definition (poll loop, tenant
+ * enumeration, config-version diff, telemetry, opt-in tombstone) lives in
+ * `ai/daemons/KbReconciliationService.mjs`.
+ *
+ * This split matches the canonical Orchestrator class+wrapper pattern: class files in
+ * `ai/daemons/` never import Neo; entry-point scripts in `ai/scripts/` own the Neo +
+ * core/_export + InstanceManager bootstrap chain.
+ *
+ * Persistent-process invocation: launchd / systemd should target this script
+ * (`node ai/scripts/kb-reconciliation-daemon.mjs`), or `npm run ai:kb-reconciliation`. The
+ * daemon is opt-in — it exits early unless `aiConfig.knowledgeBase.reconciliationEnabled` is
+ * true; the destructive auto-tombstone is a second opt-in (`reconciliationAutoTombstone`).
+ *
+ * @see ai/daemons/KbReconciliationService.mjs
+ * @see ai/scripts/kb-alerting-daemon.mjs (sibling wrapper precedent)
+ * @see #11640 (Phase 4B reconciliation daemon), #11628 (Phase 4 epic)
+ */
+
+// Neo namespace bootstrap (entry-point invariant): `Neo` + `core/_export` populate
+// `globalThis.Neo` so any module using `Neo.gatekeep()` / `Neo.setupClass()` at
+// module-load succeeds. `InstanceManager` binds `Neo.find` / `Neo.get` aliases.
+import Neo             from '../../src/Neo.mjs';
+import * as core       from '../../src/core/_export.mjs';
+import InstanceManager from '../../src/manager/Instance.mjs';
+
+import logger                  from '../mcp/server/knowledge-base/logger.mjs';
+import KbReconciliationService from '../daemons/KbReconciliationService.mjs';
+
+const cleanShutdown = signal => {
+    logger.info(`[KbReconciliationService] Received ${signal}; stopping.`);
+    KbReconciliationService.stop();
+    process.exit(0);
+};
+
+process.on('SIGTERM', () => cleanShutdown('SIGTERM'));
+process.on('SIGINT',  () => cleanShutdown('SIGINT'));
+
+KbReconciliationService.start().catch(err => {
+    logger.error('[KbReconciliationService] Daemon start failed:', err);
+    process.exit(1);
+});

--- a/ai/services/knowledge-base/helpers/KbReconciliationEngine.mjs
+++ b/ai/services/knowledge-base/helpers/KbReconciliationEngine.mjs
@@ -1,0 +1,137 @@
+/**
+ * @summary Pure config-invalidation reconciliation engine for the Phase 4B KB reconciliation daemon (#11640).
+ *
+ * Phase 4B (#11640) substrate. The cloud KB reconciliation daemon (`KbReconciliationService`)
+ * periodically diffs each tenant's persisted Chroma chunks against the tenant's *current*
+ * `KnowledgeBaseTenantConfig` version and (opt-in) tombstones the chunks left stale by a
+ * config change. This module is the **pure core** of that daemon — no I/O, no clock, no
+ * service references — so the staleness classification and the version-gap partition are
+ * trivially unit-testable in isolation.
+ *
+ * **The V1 reconciliation signal.** Every chunk is stamped at ingest with the active
+ * `tenantConfigVersion` (#11637 / `VectorService.resolveTenantStamp`). When a tenant mutates
+ * its `KnowledgeBaseTenantConfig`, `getTenantConfig().version` increments — and every chunk
+ * ingested under the prior config is now *config-stale*: it may carry paths or a parse
+ * structure only the superseded config produced. A chunk whose `metadata.tenantConfigVersion`
+ * is below the tenant's current version is therefore a **config-invalidation orphan**. The
+ * `versionGap` (how many config epochs the chunk has survived unrefreshed) gates the
+ * destructive auto-tombstone: a chunk re-pushed within the grace window self-heals — the
+ * re-push re-stamps it at the current version — while one that is not becomes actionable.
+ *
+ * The daemon owns the I/O: it enumerates tenants, reads `getTenantConfig().version`, fetches
+ * each tenant's Chroma rows, calls this engine, emits Phase 4A telemetry, and (opt-in) issues
+ * the `collection.delete`. This module only *classifies*.
+ *
+ * @see ai/daemons/KbReconciliationService.mjs — the daemon that consumes this engine.
+ * @see ai/services/knowledge-base/KnowledgeBaseIngestionService.mjs — `getTenantConfig`, the version source.
+ * @see ai/services/knowledge-base/VectorService.mjs — `resolveTenantStamp`, the `tenantConfigVersion` stamp.
+ * @see ai/services/knowledge-base/helpers/KbAlertRuleEngine.mjs — the sibling pure-helper precedent (#11642).
+ */
+
+/**
+ * @summary Default version-gap threshold — a config-stale chunk becomes auto-tombstone-eligible
+ * once it is at least this many config versions behind the tenant's current config.
+ *
+ * `2` gives one full config epoch of grace: a chunk one version behind (`versionGap === 1`)
+ * is stale-but-within-grace — the tenant's next routine push re-stamps it current; a chunk
+ * two or more versions behind has survived a full epoch unrefreshed and is treated as
+ * abandoned. Operator-overridable via `aiConfig.knowledgeBase.reconciliationOrphanVersionGap`.
+ * @type {Number}
+ */
+export const DEFAULT_ORPHAN_VERSION_GAP = 2;
+
+/**
+ * @summary Normalizes an operator-supplied orphan version-gap to a safe positive threshold.
+ *
+ * A non-finite or sub-1 value (a stale `config.mjs`, an operator typo) degrades to
+ * {@link DEFAULT_ORPHAN_VERSION_GAP} rather than corrupting the partition. The floor is `1`:
+ * `versionGap >= 1` holds for every config-stale chunk, so a threshold of `1` means "no
+ * grace — every stale chunk is actionable".
+ *
+ * @param {*} value Raw config value.
+ * @returns {Number} A finite threshold `>= 1`.
+ */
+export function resolveOrphanVersionGap(value) {
+    return Number.isFinite(value) && value >= 1 ? value : DEFAULT_ORPHAN_VERSION_GAP;
+}
+
+/**
+ * @summary Classifies one tenant's Chroma rows into config-stale orphans.
+ *
+ * Pure — no I/O, no clock. A row is a **config-stale orphan** when its
+ * `metadata.tenantConfigVersion` is a number strictly below `currentVersion` (the tenant's
+ * current `getTenantConfig().version`). Each orphan's `versionGap = currentVersion -
+ * tenantConfigVersion`; an orphan is **actionable** (auto-tombstone-eligible) when its
+ * `versionGap` is at or above the resolved `orphanVersionGap`.
+ *
+ * Edge cases, both fail-safe (a chunk that cannot be classified is never actioned):
+ * - `currentVersion <= 0` — the tenant resolves to the `kb-config.yaml` / default config
+ *   tier (no graph node, version `0`). No chunk can be stale; the result is empty.
+ * - A row whose `tenantConfigVersion` is missing / non-numeric — a chunk ingested before the
+ *   #11637 stamp existed. It is **not** flagged: its config epoch is unknowable.
+ *
+ * @param {Object} params
+ * @param {Array<{id: String, metadata: Object}>} params.rows  Tenant Chroma rows (the
+ *        `KnowledgeBaseIngestionService.getTenantRows` shape — `{id, metadata}`).
+ * @param {Number} params.currentVersion  The tenant's current `getTenantConfig().version`.
+ * @param {Number} [params.orphanVersionGap]  Actionable threshold; normalized via
+ *        {@link resolveOrphanVersionGap}.
+ * @returns {{staleOrphans: Array<{id: String, tenantConfigVersion: Number, versionGap: Number}>, staleCount: Number, actionableIds: Array<String>, actionableCount: Number}}
+ */
+export function diffTenantChunks({rows, currentVersion, orphanVersionGap} = {}) {
+    const staleOrphans  = [];
+    const actionableIds = [];
+
+    if (!Array.isArray(rows) || typeof currentVersion !== 'number' || currentVersion <= 0) {
+        return {staleOrphans, staleCount: 0, actionableIds, actionableCount: 0};
+    }
+
+    const gapThreshold = resolveOrphanVersionGap(orphanVersionGap);
+
+    for (const row of rows) {
+        const stampedVersion = row?.metadata?.tenantConfigVersion;
+
+        // Fail-safe: a missing / non-numeric stamp (pre-#11637 ingest) is unclassifiable — skip it.
+        if (typeof stampedVersion !== 'number' || !(stampedVersion < currentVersion)) {
+            continue;
+        }
+
+        const versionGap = currentVersion - stampedVersion;
+
+        staleOrphans.push({id: row.id, tenantConfigVersion: stampedVersion, versionGap});
+
+        if (versionGap >= gapThreshold) {
+            actionableIds.push(row.id);
+        }
+    }
+
+    return {
+        staleOrphans,
+        staleCount     : staleOrphans.length,
+        actionableIds,
+        actionableCount: actionableIds.length
+    };
+}
+
+/**
+ * @summary Builds the Phase 4A telemetry `detail` payload for one tenant's reconciliation tick.
+ *
+ * Pure — kept here (not in the daemon) so the telemetry shape is unit-testable. The daemon
+ * passes the returned object straight to `KBRecorderService.recordIngestionMetric`'s `detail`.
+ *
+ * @param {Object}  params
+ * @param {{staleCount: Number, actionableCount: Number}} params.diff  A {@link diffTenantChunks} result.
+ * @param {Number}  params.currentVersion   The tenant's current config version.
+ * @param {Boolean} params.autoTombstone    Whether the daemon's auto-tombstone path is enabled.
+ * @param {Number} [params.tombstonedCount=0] Chunks actually deleted this tick (`0` when auto-tombstone is off).
+ * @returns {{staleCount: Number, actionableCount: Number, tombstonedCount: Number, currentVersion: Number, autoTombstone: Boolean}}
+ */
+export function formatReconciliationDetail({diff, currentVersion, autoTombstone, tombstonedCount = 0} = {}) {
+    return {
+        staleCount     : diff?.staleCount      ?? 0,
+        actionableCount: diff?.actionableCount ?? 0,
+        tombstonedCount: Number.isFinite(tombstonedCount) ? tombstonedCount : 0,
+        currentVersion : typeof currentVersion === 'number' ? currentVersion : 0,
+        autoTombstone  : autoTombstone === true
+    };
+}

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
         "ai:lint-agents"               : "node ./ai/scripts/lint-agents.mjs",
         "ai:lint-skill-manifest"       : "node ./ai/scripts/lint-skill-manifest.mjs",
         "ai:kb-alerting"               : "node ./ai/scripts/kb-alerting-daemon.mjs",
+        "ai:kb-reconciliation"         : "node ./ai/scripts/kb-reconciliation-daemon.mjs",
         "ai:orchestrator"              : "node ./ai/scripts/orchestrator-daemon.mjs",
         "ai:run-sandman"               : "node ./buildScripts/ai/runSandman.mjs",
         "ai:server"                    : "chroma run --path ./.neo-ai-data/chroma/knowledge-base",

--- a/test/playwright/unit/ai/daemons/KbReconciliationService.spec.mjs
+++ b/test/playwright/unit/ai/daemons/KbReconciliationService.spec.mjs
@@ -1,0 +1,375 @@
+import {setup} from '../../../setup.mjs';
+
+const appName = 'KbReconciliationServiceTest';
+
+setup({
+    neoConfig: {
+        unitTestMode: true
+    },
+    appConfig: {
+        name             : appName,
+        isMounted        : () => true,
+        vnodeInitialising: false
+    }
+});
+
+// Test-side entry-point bootstrap: Neo + core/_export populate `globalThis.Neo` before
+// the dynamic KbReconciliationService import below. Required because the class file no
+// longer imports Neo itself (#11058-style class+wrapper split). Mirrors KbAlertingService.spec.
+import Neo       from '../../../../../src/Neo.mjs';
+import * as core from '../../../../../src/core/_export.mjs';
+
+import {test, expect} from '@playwright/test';
+
+/**
+ * Phase 4B (#11640) — unit coverage for `ai/daemons/KbReconciliationService.mjs`, the KB
+ * reconciliation daemon.
+ *
+ * Stubbing strategy mirrors `KbAlertingService.spec.mjs`: the daemon exposes test-stubbable
+ * instance-method seams (`getKbConfig`, `fetchTenants`, `getCollection`,
+ * `fetchTenantConfigVersion`, `fetchTenantRows`, `tombstoneOrphans`, `recordReconcileMetric`,
+ * `scheduleNext`) so tests override them on the singleton without real config / SQLite /
+ * Chroma I/O. The orchestration tests keep the real `reconcileTenant` + the real pure
+ * `KbReconciliationEngine` so the diff-driven branching is genuinely exercised.
+ *
+ * Covers the #11640 Contract Ledger Evidence columns: the opt-in gate, the destructive
+ * auto-tombstone gating, the clean-tenant telemetry suppression, the tenant-scoped delete,
+ * and pulse resilience. The pure diff logic is covered separately in
+ * `KbReconciliationEngine.spec.mjs`.
+ *
+ * @see https://github.com/neomjs/neo/issues/11640
+ * @see ai/daemons/KbReconciliationService.mjs — the daemon under test.
+ * @see test/playwright/unit/ai/daemons/KbAlertingService.spec.mjs — the sibling pattern.
+ */
+test.describe('Neo.ai.daemons.KbReconciliationService (#11640)', () => {
+    let KbReconciliationService, DEFAULT_INTERVAL_MS;
+    let KBRecorderService, logger;
+    let originals = {};
+
+    /** Builds a tenant Chroma row in the `getTenantRows` shape. */
+    const row = (id, v) => ({id, metadata: {tenantConfigVersion: v, repoSlug: 'repo-x', tenantId: 'tenant-x'}});
+
+    test.beforeAll(async () => {
+        ({default: KbReconciliationService, DEFAULT_INTERVAL_MS} =
+            await import('../../../../../ai/daemons/KbReconciliationService.mjs'));
+
+        KBRecorderService = (await import('../../../../../ai/services/knowledge-base/KBRecorderService.mjs')).default;
+        logger            = (await import('../../../../../ai/mcp/server/knowledge-base/logger.mjs')).default;
+
+        originals = {
+            recorderReady       : KBRecorderService.ready,
+            getTenantIngestion  : KBRecorderService.getTenantIngestionRollup,
+            recordIngestionMetric: KBRecorderService.recordIngestionMetric,
+            warn                : logger.warn,
+            error               : logger.error,
+            info                : logger.info
+        };
+
+        // `start()` awaits KBRecorderService.ready() — stub it to resolve immediately.
+        KBRecorderService.ready = async () => {};
+    });
+
+    test.afterAll(() => {
+        KBRecorderService.ready                  = originals.recorderReady;
+        KBRecorderService.getTenantIngestionRollup = originals.getTenantIngestion;
+        KBRecorderService.recordIngestionMetric  = originals.recordIngestionMetric;
+    });
+
+    test.afterEach(() => {
+        KbReconciliationService.stop();
+        KbReconciliationService.isPolling      = false;
+        KbReconciliationService.pollIntervalMs = DEFAULT_INTERVAL_MS;
+
+        // Drop instance-method seam overrides so the real prototype methods resurface for
+        // the next test — an instance override otherwise leaks across tests in the worker.
+        for (const seam of ['getKbConfig', 'fetchTenants', 'getCollection', 'fetchTenantConfigVersion',
+                             'fetchTenantRows', 'tombstoneOrphans', 'recordReconcileMetric',
+                             'reconcileTenant', 'scheduleNext']) {
+            delete KbReconciliationService[seam];
+        }
+
+        KBRecorderService.getTenantIngestionRollup = originals.getTenantIngestion;
+        KBRecorderService.recordIngestionMetric    = originals.recordIngestionMetric;
+        logger.warn  = originals.warn;
+        logger.error = originals.error;
+        logger.info  = originals.info;
+    });
+
+    /** Deterministic seam baseline — `scheduleNext` neutralized so no real timer leaks. */
+    function applyStubs({config} = {}) {
+        KbReconciliationService.getKbConfig  = () => config || {reconciliationEnabled: true};
+        KbReconciliationService.scheduleNext = function () {};
+    }
+
+    test.describe('start / stop', () => {
+        test('start() is a no-op when reconciliationEnabled is false', async () => {
+            applyStubs({config: {reconciliationEnabled: false}});
+            let scheduled = 0;
+            KbReconciliationService.scheduleNext = () => { scheduled++ };
+
+            await KbReconciliationService.start();
+
+            expect(KbReconciliationService.isPolling).toBe(false);
+            expect(scheduled).toBe(0);
+        });
+
+        test('start() schedules when enabled and is idempotent', async () => {
+            applyStubs();
+            let scheduled = 0;
+            KbReconciliationService.scheduleNext = () => { scheduled++ };
+
+            await KbReconciliationService.start();
+            expect(KbReconciliationService.isPolling).toBe(true);
+            expect(scheduled).toBe(1);
+
+            await KbReconciliationService.start();
+            expect(scheduled).toBe(1); // second start() is a no-op
+        });
+
+        test('start() honors a configured reconciliationIntervalMs', async () => {
+            applyStubs({config: {reconciliationEnabled: true, reconciliationIntervalMs: 12345}});
+
+            await KbReconciliationService.start();
+
+            expect(KbReconciliationService.pollIntervalMs).toBe(12345);
+        });
+
+        test('stop() clears the poll handle and is idempotent', async () => {
+            applyStubs();
+            KbReconciliationService.scheduleNext = function () { this.pollHandle = setTimeout(() => {}, 60_000) };
+
+            await KbReconciliationService.start();
+            expect(KbReconciliationService.pollHandle).not.toBeNull();
+
+            KbReconciliationService.stop();
+            expect(KbReconciliationService.pollHandle).toBeNull();
+            expect(KbReconciliationService.isPolling).toBe(false);
+            expect(() => KbReconciliationService.stop()).not.toThrow();
+        });
+    });
+
+    test.describe('pulse', () => {
+        test('returns early without fetching the collection when no tenants exist', async () => {
+            applyStubs();
+            KbReconciliationService.fetchTenants = async () => [];
+            let collectionFetched = 0;
+            KbReconciliationService.getCollection = async () => { collectionFetched++; return {} };
+
+            await KbReconciliationService.pulse();
+
+            expect(collectionFetched).toBe(0);
+        });
+
+        test('reconciles each enumerated tenant', async () => {
+            applyStubs();
+            KbReconciliationService.fetchTenants  = async () => [
+                {tenantId: 'tenant-a', repoSlug: 'repo-a'},
+                {tenantId: 'tenant-b', repoSlug: 'repo-b'}
+            ];
+            KbReconciliationService.getCollection = async () => ({});
+            const reconciled = [];
+            KbReconciliationService.reconcileTenant = async ({tenantId}) => { reconciled.push(tenantId) };
+
+            await KbReconciliationService.pulse();
+
+            expect(reconciled.sort()).toEqual(['tenant-a', 'tenant-b']);
+        });
+
+        test('reschedules from the finally block even when getCollection throws', async () => {
+            applyStubs();
+            KbReconciliationService.fetchTenants  = async () => [{tenantId: 't', repoSlug: 'r'}];
+            KbReconciliationService.getCollection = async () => { throw new Error('chroma down') };
+            let rescheduled = 0;
+            KbReconciliationService.scheduleNext = () => { rescheduled++ };
+
+            await expect(KbReconciliationService.pulse()).resolves.toBeUndefined();
+            expect(rescheduled).toBe(1);
+        });
+
+        test('a single tenant failure does not abort the remaining tenants', async () => {
+            applyStubs({config: {reconciliationEnabled: true, reconciliationAutoTombstone: false}});
+            KbReconciliationService.fetchTenants  = async () => [
+                {tenantId: 'tenant-bad', repoSlug: 'r'},
+                {tenantId: 'tenant-ok',  repoSlug: 'r'}
+            ];
+            KbReconciliationService.getCollection = async () => ({});
+            KbReconciliationService.fetchTenantConfigVersion = async (tenantId) => {
+                if (tenantId === 'tenant-bad') throw new Error('config read failed');
+                return 5;
+            };
+            KbReconciliationService.fetchTenantRows = async () => [row('stale', 1)];
+            const metrics = [];
+            KbReconciliationService.recordReconcileMetric = (m) => { metrics.push(m) };
+
+            await expect(KbReconciliationService.pulse()).resolves.toBeUndefined();
+
+            // tenant-bad threw inside reconcileTenant (caught); tenant-ok still emitted.
+            expect(metrics).toHaveLength(1);
+            expect(metrics[0].tenantId).toBe('tenant-ok');
+        });
+    });
+
+    test.describe('reconcileTenant', () => {
+        /** Wires the per-tenant seams; `rows` drives the real KbReconciliationEngine diff. */
+        function wireTenant({version, rows}) {
+            KbReconciliationService.fetchTenantConfigVersion = async () => version;
+            KbReconciliationService.fetchTenantRows          = async () => rows;
+        }
+
+        test('a clean tenant emits no telemetry and tombstones nothing', async () => {
+            applyStubs();
+            wireTenant({version: 5, rows: [row('a', 5), row('b', 5)]});
+            let tombstoned = 0, recorded = 0;
+            KbReconciliationService.tombstoneOrphans     = async () => { tombstoned++; return 0 };
+            KbReconciliationService.recordReconcileMetric = () => { recorded++ };
+
+            await KbReconciliationService.reconcileTenant({
+                tenantId: 'tenant-x', repoSlug: 'repo-x', collection: {}, orphanVersionGap: 2, autoTombstone: true
+            });
+
+            expect(recorded).toBe(0);
+            expect(tombstoned).toBe(0);
+        });
+
+        test('a drifting tenant with auto-tombstone OFF emits telemetry but issues no delete', async () => {
+            applyStubs();
+            wireTenant({version: 5, rows: [row('a', 5), row('b', 3), row('c', 1)]}); // 2 stale, both gap >= 2
+            let tombstoned = 0;
+            KbReconciliationService.tombstoneOrphans = async () => { tombstoned++; return 0 };
+            const metrics = [];
+            KbReconciliationService.recordReconcileMetric = (m) => { metrics.push(m) };
+
+            await KbReconciliationService.reconcileTenant({
+                tenantId: 'tenant-x', repoSlug: 'repo-x', collection: {}, orphanVersionGap: 2, autoTombstone: false
+            });
+
+            expect(tombstoned).toBe(0);
+            expect(metrics).toHaveLength(1);
+            expect(metrics[0].diff.staleCount).toBe(2);
+            expect(metrics[0].tombstonedCount).toBe(0);
+            expect(metrics[0].autoTombstone).toBe(false);
+        });
+
+        test('a drifting tenant with auto-tombstone ON deletes the actionable orphans', async () => {
+            applyStubs();
+            wireTenant({version: 5, rows: [row('a', 5), row('b', 3), row('c', 1)]}); // b,c actionable at gap 2
+            const deleted = [];
+            KbReconciliationService.tombstoneOrphans = async (collection, ids) => { deleted.push(...ids); return ids.length };
+            const metrics = [];
+            KbReconciliationService.recordReconcileMetric = (m) => { metrics.push(m) };
+
+            await KbReconciliationService.reconcileTenant({
+                tenantId: 'tenant-x', repoSlug: 'repo-x', collection: {}, orphanVersionGap: 2, autoTombstone: true
+            });
+
+            expect(deleted.sort()).toEqual(['b', 'c']);
+            expect(metrics[0].tombstonedCount).toBe(2);
+            expect(metrics[0].autoTombstone).toBe(true);
+        });
+
+        test('auto-tombstone ON but every orphan within grace issues no delete', async () => {
+            applyStubs();
+            wireTenant({version: 5, rows: [row('a', 5), row('b', 4)]}); // b is stale, gap 1 (< threshold 2)
+            let tombstoned = 0;
+            KbReconciliationService.tombstoneOrphans = async () => { tombstoned++; return 0 };
+            const metrics = [];
+            KbReconciliationService.recordReconcileMetric = (m) => { metrics.push(m) };
+
+            await KbReconciliationService.reconcileTenant({
+                tenantId: 'tenant-x', repoSlug: 'repo-x', collection: {}, orphanVersionGap: 2, autoTombstone: true
+            });
+
+            expect(tombstoned).toBe(0); // actionableCount 0 → tombstoneOrphans never called
+            expect(metrics[0].diff.staleCount).toBe(1);
+            expect(metrics[0].tombstonedCount).toBe(0);
+        });
+
+        test('never throws — a fetchTenantRows failure is caught and logged', async () => {
+            applyStubs();
+            KbReconciliationService.fetchTenantConfigVersion = async () => 5;
+            KbReconciliationService.fetchTenantRows          = async () => { throw new Error('chroma get failed') };
+            const errors = [];
+            logger.error = (msg) => { errors.push(msg) };
+
+            await expect(KbReconciliationService.reconcileTenant({
+                tenantId: 'tenant-x', repoSlug: 'repo-x', collection: {}, orphanVersionGap: 2, autoTombstone: false
+            })).resolves.toBeUndefined();
+
+            expect(errors.some(e => String(e).includes('Reconciliation failed for tenant tenant-x'))).toBe(true);
+        });
+    });
+
+    test.describe('fetchTenants', () => {
+        test('dedupes the rollup to distinct tenants, keeping the first repoSlug', async () => {
+            KBRecorderService.getTenantIngestionRollup = () => [
+                {tenantId: 'tenant-a', repoSlug: 'repo-a1'},
+                {tenantId: 'tenant-a', repoSlug: 'repo-a2'},
+                {tenantId: 'tenant-b', repoSlug: 'repo-b'}
+            ];
+
+            const tenants = await KbReconciliationService.fetchTenants();
+
+            expect(tenants).toEqual([
+                {tenantId: 'tenant-a', repoSlug: 'repo-a1'},
+                {tenantId: 'tenant-b', repoSlug: 'repo-b'}
+            ]);
+        });
+
+        test('returns an empty list when the rollup is empty or unavailable', async () => {
+            KBRecorderService.getTenantIngestionRollup = () => [];
+            expect(await KbReconciliationService.fetchTenants()).toEqual([]);
+
+            KBRecorderService.getTenantIngestionRollup = () => undefined;
+            expect(await KbReconciliationService.fetchTenants()).toEqual([]);
+        });
+    });
+
+    test.describe('tombstoneOrphans', () => {
+        test('deletes the id set tenant-scoped and returns the count', async () => {
+            const deleteCalls = [];
+            const collection  = {delete: async (arg) => { deleteCalls.push(arg) }};
+
+            const count = await KbReconciliationService.tombstoneOrphans(collection, ['id-1', 'id-2', 'id-3']);
+
+            expect(count).toBe(3);
+            expect(deleteCalls).toEqual([{ids: ['id-1', 'id-2', 'id-3']}]);
+        });
+
+        test('is a no-op for an empty / non-array id set', async () => {
+            let deleteCalled = 0;
+            const collection = {delete: async () => { deleteCalled++ }};
+
+            expect(await KbReconciliationService.tombstoneOrphans(collection, [])).toBe(0);
+            expect(await KbReconciliationService.tombstoneOrphans(collection, null)).toBe(0);
+            expect(deleteCalled).toBe(0);
+        });
+    });
+
+    test.describe('recordReconcileMetric', () => {
+        test('emits a reconcile event with the chunk counts + detail payload', async () => {
+            const events = [];
+            KBRecorderService.recordIngestionMetric = (e) => { events.push(e) };
+
+            KbReconciliationService.recordReconcileMetric({
+                tenantId       : 'tenant-x',
+                repoSlug       : 'repo-x',
+                diff           : {staleCount: 4, actionableCount: 3},
+                currentVersion : 9,
+                autoTombstone  : true,
+                tombstonedCount: 3
+            });
+
+            expect(events).toHaveLength(1);
+            expect(events[0]).toMatchObject({
+                tenantId     : 'tenant-x',
+                repoSlug     : 'repo-x',
+                eventType    : 'reconcile',
+                chunksTotal  : 4,
+                chunksDeleted: 3
+            });
+            expect(events[0].detail).toMatchObject({
+                staleCount: 4, actionableCount: 3, tombstonedCount: 3, currentVersion: 9, autoTombstone: true
+            });
+        });
+    });
+});

--- a/test/playwright/unit/ai/services/knowledge-base/KbReconciliationEngine.spec.mjs
+++ b/test/playwright/unit/ai/services/knowledge-base/KbReconciliationEngine.spec.mjs
@@ -1,0 +1,179 @@
+import {test, expect} from '@playwright/test';
+
+import {
+    DEFAULT_ORPHAN_VERSION_GAP,
+    diffTenantChunks,
+    formatReconciliationDetail,
+    resolveOrphanVersionGap
+} from '../../../../../../ai/services/knowledge-base/helpers/KbReconciliationEngine.mjs';
+
+/**
+ * Phase 4B (#11640) — `KbReconciliationEngine` coverage: the pure config-invalidation
+ * reconciliation core of the KB reconciliation daemon.
+ *
+ * The module is dependency-free (no Neo class system, no I/O, no clock) — so this spec
+ * needs no `setup()` harness; it imports the pure functions directly and exercises them
+ * against fixture rows whose shape mirrors `KnowledgeBaseIngestionService.getTenantRows`
+ * (`{id, metadata}`).
+ *
+ * Covers the #11640 Contract Ledger Evidence column for the engine row: stale-detection,
+ * the version-gap partition, the `currentVersion: 0` no-op, and the missing-stamp skip.
+ * The daemon I/O (poll loop, Chroma read, telemetry) is covered separately in
+ * `KbReconciliationService.spec.mjs`.
+ *
+ * @see https://github.com/neomjs/neo/issues/11640
+ * @see ai/services/knowledge-base/helpers/KbReconciliationEngine.mjs — the module under test.
+ */
+
+/** Builds a tenant Chroma row in the `getTenantRows` shape. `v` → `metadata.tenantConfigVersion`. */
+const row = (id, v) => ({id, metadata: {tenantConfigVersion: v, repoSlug: 'repo-x', tenantId: 'tenant-x'}});
+
+test.describe('KbReconciliationEngine — resolveOrphanVersionGap (#11640)', () => {
+    test('returns a finite value at or above 1 unchanged', () => {
+        expect(resolveOrphanVersionGap(1)).toBe(1);
+        expect(resolveOrphanVersionGap(3)).toBe(3);
+        expect(resolveOrphanVersionGap(2.5)).toBe(2.5);
+    });
+
+    test('degrades a sub-1 value to the default', () => {
+        expect(resolveOrphanVersionGap(0)).toBe(DEFAULT_ORPHAN_VERSION_GAP);
+        expect(resolveOrphanVersionGap(-4)).toBe(DEFAULT_ORPHAN_VERSION_GAP);
+        expect(resolveOrphanVersionGap(0.5)).toBe(DEFAULT_ORPHAN_VERSION_GAP);
+    });
+
+    test('degrades a non-finite / non-numeric value to the default', () => {
+        expect(resolveOrphanVersionGap(undefined)).toBe(DEFAULT_ORPHAN_VERSION_GAP);
+        expect(resolveOrphanVersionGap(null)).toBe(DEFAULT_ORPHAN_VERSION_GAP);
+        expect(resolveOrphanVersionGap(NaN)).toBe(DEFAULT_ORPHAN_VERSION_GAP);
+        expect(resolveOrphanVersionGap(Infinity)).toBe(DEFAULT_ORPHAN_VERSION_GAP);
+        expect(resolveOrphanVersionGap('2')).toBe(DEFAULT_ORPHAN_VERSION_GAP);
+    });
+
+    test('the default version-gap is 2 — one config epoch of grace', () => {
+        expect(DEFAULT_ORPHAN_VERSION_GAP).toBe(2);
+    });
+});
+
+test.describe('KbReconciliationEngine — diffTenantChunks (#11640)', () => {
+    test('flags chunks below the current config version as config-stale orphans', () => {
+        const rows = [row('a', 5), row('b', 4), row('c', 3), row('d', 1)];
+        const diff = diffTenantChunks({rows, currentVersion: 5, orphanVersionGap: 2});
+
+        // v5 is current → not stale; v4/v3/v1 are stale.
+        expect(diff.staleCount).toBe(3);
+        expect(diff.staleOrphans.map(o => o.id).sort()).toEqual(['b', 'c', 'd']);
+    });
+
+    test('computes versionGap = currentVersion - tenantConfigVersion per orphan', () => {
+        const diff = diffTenantChunks({rows: [row('b', 4), row('d', 1)], currentVersion: 5, orphanVersionGap: 2});
+        const gaps = Object.fromEntries(diff.staleOrphans.map(o => [o.id, o.versionGap]));
+
+        expect(gaps).toEqual({b: 1, d: 4});
+    });
+
+    test('partitions actionable orphans by versionGap >= orphanVersionGap', () => {
+        const rows = [row('a', 5), row('b', 4), row('c', 3), row('d', 1)];
+        const diff = diffTenantChunks({rows, currentVersion: 5, orphanVersionGap: 2});
+
+        // gaps: b=1 (within grace), c=2 (actionable), d=4 (actionable).
+        expect(diff.actionableIds.sort()).toEqual(['c', 'd']);
+        expect(diff.actionableCount).toBe(2);
+    });
+
+    test('a chunk exactly at the current version is not stale (strict less-than)', () => {
+        const diff = diffTenantChunks({rows: [row('a', 7)], currentVersion: 7, orphanVersionGap: 2});
+
+        expect(diff.staleCount).toBe(0);
+        expect(diff.actionableCount).toBe(0);
+    });
+
+    test('currentVersion 0 (yaml / default config tier) yields zero orphans', () => {
+        const rows = [row('a', 0), row('b', 0)];
+        const diff = diffTenantChunks({rows, currentVersion: 0, orphanVersionGap: 2});
+
+        expect(diff.staleCount).toBe(0);
+        expect(diff.staleOrphans).toHaveLength(0);
+    });
+
+    test('a chunk with a missing / non-numeric tenantConfigVersion is never flagged', () => {
+        const rows = [
+            {id: 'no-stamp', metadata: {repoSlug: 'repo-x'}},
+            {id: 'null-stamp', metadata: {tenantConfigVersion: null}},
+            {id: 'string-stamp', metadata: {tenantConfigVersion: '1'}},
+            row('stale', 1)
+        ];
+        const diff = diffTenantChunks({rows, currentVersion: 5, orphanVersionGap: 2});
+
+        // Only the real numeric-stamped stale chunk is flagged; the unclassifiable ones are skipped.
+        expect(diff.staleCount).toBe(1);
+        expect(diff.staleOrphans[0].id).toBe('stale');
+    });
+
+    test('defaults orphanVersionGap when it is omitted or invalid', () => {
+        const rows = [row('b', 4), row('c', 3)]; // gaps 1, 2 against currentVersion 5
+
+        // Omitted → DEFAULT (2): only gap-2 is actionable.
+        expect(diffTenantChunks({rows, currentVersion: 5}).actionableIds).toEqual(['c']);
+        // Invalid (0) → DEFAULT (2): same partition.
+        expect(diffTenantChunks({rows, currentVersion: 5, orphanVersionGap: 0}).actionableIds).toEqual(['c']);
+    });
+
+    test('orphanVersionGap 1 means no grace — every stale chunk is actionable', () => {
+        const rows = [row('b', 4), row('c', 3)];
+        const diff = diffTenantChunks({rows, currentVersion: 5, orphanVersionGap: 1});
+
+        expect(diff.actionableCount).toBe(2);
+    });
+
+    test('returns an empty result for a non-array rows input (defensive)', () => {
+        const diff = diffTenantChunks({rows: null, currentVersion: 5});
+
+        expect(diff).toEqual({staleOrphans: [], staleCount: 0, actionableIds: [], actionableCount: 0});
+    });
+
+    test('returns an empty result for a non-numeric currentVersion (defensive)', () => {
+        expect(diffTenantChunks({rows: [row('a', 1)], currentVersion: undefined}).staleCount).toBe(0);
+        expect(diffTenantChunks({rows: [row('a', 1)], currentVersion: 'five'}).staleCount).toBe(0);
+    });
+
+    test('an all-current tenant yields zero orphans', () => {
+        const rows = [row('a', 9), row('b', 9), row('c', 9)];
+
+        expect(diffTenantChunks({rows, currentVersion: 9, orphanVersionGap: 2}).staleCount).toBe(0);
+    });
+});
+
+test.describe('KbReconciliationEngine — formatReconciliationDetail (#11640)', () => {
+    test('builds the Phase 4A telemetry detail payload from a diff', () => {
+        const diff   = {staleCount: 5, actionableCount: 3, staleOrphans: [], actionableIds: []};
+        const detail = formatReconciliationDetail({diff, currentVersion: 7, autoTombstone: true, tombstonedCount: 3});
+
+        expect(detail).toEqual({
+            staleCount     : 5,
+            actionableCount: 3,
+            tombstonedCount: 3,
+            currentVersion : 7,
+            autoTombstone  : true
+        });
+    });
+
+    test('coerces autoTombstone to a strict boolean and defaults tombstonedCount to 0', () => {
+        const diff   = {staleCount: 2, actionableCount: 0};
+        const detail = formatReconciliationDetail({diff, currentVersion: 3, autoTombstone: undefined});
+
+        expect(detail.autoTombstone).toBe(false);
+        expect(detail.tombstonedCount).toBe(0);
+    });
+
+    test('is defensive against a missing diff / currentVersion', () => {
+        const detail = formatReconciliationDetail({});
+
+        expect(detail).toEqual({
+            staleCount     : 0,
+            actionableCount: 0,
+            tombstonedCount: 0,
+            currentVersion : 0,
+            autoTombstone  : false
+        });
+    });
+});


### PR DESCRIPTION
Authored by Neo Opus 4.7 (Claude Code). Session 470c38e7-1ffc-4851-867d-d30c1b6fbdb2.

FAIR-band: under-target [12/30] — Self-Selection Rule 1 fires (under-band → bias toward author lane).

Resolves #11640
Related: #11628
Related: #11624

Phase 4B of Phase 4 epic #11628 (meta-epic #11624, Cloud-Native KB Ingestion) — the KB reconciliation daemon. When a tenant mutates its `KnowledgeBaseTenantConfig`, `getTenantConfig().version` increments and every chunk ingested under the prior config is now *config-stale*. This daemon periodically diffs each tenant's persisted Chroma chunks against the tenant's current config version (via the `tenantConfigVersion` stamp #11637 puts on every chunk), emits Phase 4A reconciliation telemetry, and — opt-in — tombstones the chunks left stale by a config change. It is purely additive: 5 new files + 2 small additive edits (the `aiConfig` template block, the `package.json` script); zero merged Phase 2 code is touched.

Evidence: L2 — 36 unit tests passing (19 `KbReconciliationEngine` + 17 `KbReconciliationService`), `node --check` clean on all source files. The daemon's *scheduled-run* dimension (a live long-running process firing on a poll tick) is an L3 residual the CI sandbox cannot exercise — see Post-Merge Validation. AC8 (force-push integration test) is V1.x-deferred — see Follow-ups.

## What shipped

**The 3-part daemon split** (mirrors the #11642 `KbAlertingService`):

- **`ai/services/knowledge-base/helpers/KbReconciliationEngine.mjs`** — the pure config-invalidation diff core (dependency-free: no Neo, no I/O, no clock). `diffTenantChunks` classifies a tenant's Chroma rows — a chunk whose `metadata.tenantConfigVersion` is below the tenant's current `getTenantConfig().version` is a config-stale orphan; `versionGap ≥ orphanVersionGap` makes it auto-tombstone-actionable. Plus `resolveOrphanVersionGap` + `formatReconciliationDetail`.
- **`ai/daemons/KbReconciliationService.mjs`** — the poll-loop daemon (a `Neo.core.Base` singleton: `start` / `stop` / `scheduleNext` / `pulse`). Each `pulse()` enumerates tenants (distinct `tenantId` from `KBRecorderService.getTenantIngestionRollup`), and per tenant runs the pure engine, emits one Phase 4A `reconcile` telemetry event, and (opt-in) tombstones the actionable orphans. `pulse()` is try/catch/finally + per-tenant try/catch — one bad tenant or cycle never stops the daemon. All I/O behind test-stubbable seam methods.
- **`ai/scripts/kb-reconciliation-daemon.mjs`** — the thin Neo-bootstrap + SIGTERM wrapper; **`package.json`** — the `ai:kb-reconciliation` script.
- **`ai/config.template.mjs`** — 4 new `aiConfig.knowledgeBase` keys (`reconciliationEnabled` / `reconciliationIntervalMs` / `reconciliationAutoTombstone` / `reconciliationOrphanVersionGap`), read defensively.

**Two opt-in gates** — `start()` no-ops unless `reconciliationEnabled`; the destructive auto-tombstone is a *second* opt-in (`reconciliationAutoTombstone`, default `false`). V1 default behavior = detect + emit telemetry only, zero `collection.delete`.

The implementation follows the **#11640 Contract Ledger** (T3 Explicit Matrix, authored into the ticket body at intake) — 6 rows binding the config block, the pure engine, the tenant-scoped delete, the Phase 4A emission, the Phase 4D seam, and the V1 scope boundary.

## Deltas from ticket

The ticket's "The Fix" envisions a **claim-vs-actual path-manifest diff**. A substrate sweep of merged Phase 2 showed this has no substrate: `getTenantConfig` returns a fixed 8-field projection with no path manifest; `baseRevision` / `headRevision` are per-push payload params, not persisted state. A periodic daemon with no repo access + no persisted manifest cannot detect arbitrary drift. So:

- **V1 = config-invalidation reconciliation** (the `tenantConfigVersion`-staleness signal) — delivers the ticket's failure-mode #3 ("tenant config changes invalidate previously-pushed chunks") completely. Failure-modes #1/#2/#4 (force-push, mid-push, partial-push) need persisted-manifest substrate → **V1.x-deferred** (Follow-ups).
- **Retention threshold = version-gap, not wall-clock.** Chunk metadata carries no ingest timestamp and `setTenantConfig` persists no version-bump timestamp — a wall-clock window has no substrate anchor. `versionGap ≥ reconciliationOrphanVersionGap` (default `2` = one config epoch of grace) is substrate-pure and restart-safe.
- **Phase 4D integration = drift-presence/frequency alerting.** The daemon emits `reconcile` telemetry; `reconcileEvents` is already a `KbAlertRuleEngine.KNOWN_METRICS` field, so an operator alert rule on `reconcileEvents` fires on persistent/frequent drift — with no #11642 code change. Drift-*volume* thresholding needs a `chunks_total` rollup metric → V1.x. This precise scoping was refined per @neo-gpt's #11640 pre-PR peer review — Contract Ledger Row 5/6 carry it.
- **Auto-tombstone is opt-in, default-off** — destructive-action conservatism.

These are Tier-2 phased-delivery decisions, documented in the Contract Ledger + the #11640 intake-update comment, mirroring #11642's V1.5 webhook deferral.

## Test Evidence

- `npm run test-unit -- test/playwright/unit/ai/services/knowledge-base/KbReconciliationEngine.spec.mjs test/playwright/unit/ai/daemons/KbReconciliationService.spec.mjs` → **36 passed**.
- `KbReconciliationEngine.spec.mjs` (19) — `diffTenantChunks` (config-stale detection, versionGap partition, `currentVersion: 0` yaml-tier no-op, missing-stamp fail-safe skip, defensive inputs), `resolveOrphanVersionGap` (floor/default normalization), `formatReconciliationDetail`.
- `KbReconciliationService.spec.mjs` (17) — start/stop (opt-in gate, idempotency, interval config), pulse (empty-tenant early return, per-tenant loop, reschedule-on-failure, per-tenant failure isolation), reconcileTenant (clean-tenant telemetry suppression, auto-tombstone opt-in gating both ways, within-grace no-delete), `fetchTenants` dedup, `tombstoneOrphans` empty-guard, the `recordReconcileMetric` payload shape.
- `node --check` clean on all 3 `.mjs` source files; `config.template.mjs` valid; `package.json` valid JSON.
- The `check-whitespace` pre-commit hook passed on all 3 commits.

## Follow-ups

V1.x follow-up ticket **#11711** is filed (sub of #11628) — "KB reconciliation: force-push & manifest-orphan drift detection" — for the substrate-gated scope, out of this PR's additive V1 scope. #11711 carries the three deferred items below:

- Manifest / force-push / partial-push orphan detection — needs a persisted claimed-state manifest (or a daemon-side repo walk). This also carries the ticket's **AC8** (the force-push → reconciliation integration test), which cannot be authored without force-push detection.
- A per-tenant `orphanVersionGap` override (needs extending `getTenantConfig`'s fixed projection — a #11637-surface change).
- A `chunks_total` rollup metric in `getTenantIngestionRollup` + `chunksTotal` in `KbAlertRuleEngine.KNOWN_METRICS`, enabling drift-*volume* threshold alerting.

## Post-Merge Validation

- [ ] With `aiConfig.knowledgeBase.reconciliationEnabled: true`, confirm a launched `npm run ai:kb-reconciliation` daemon polls on its interval and emits a `reconcile` telemetry event for a tenant with config-stale chunks (the L3 scheduled-run surface the CI sandbox cannot reach).
- [ ] With `reconciliationAutoTombstone: true`, confirm an actionable config-stale orphan is tombstoned from the `knowledge-base` collection on a pulse.

## Commits

- `f7535a5e9` — feat(ai): add KB reconciliation diff engine (#11640)
- `d7b8124a2` — feat(ai): add KB reconciliation daemon (#11640)
- `cbe849fc5` — test(ai): KB reconciliation engine + daemon specs (#11640)

(SHAs are post-rebase onto `dev`.)

## Related

- #11628 — Phase 4 epic (KB Operations + Observability); my epic-review: https://github.com/neomjs/neo/issues/11628#issuecomment-4504271144
- #11624 — Cloud-Native KB Ingestion meta-epic
- #11640 Contract Ledger — in the ticket body (T3 Explicit Matrix), the binding contract
- #11637 — Phase 2E `KnowledgeBaseTenantConfig` (the `tenantConfigVersion` substrate this daemon reconciles against)
- #11642 — Phase 4D `KbAlertingService` (the sibling daemon; this daemon's `reconcile` telemetry feeds its alerting)
