### PR TITLE
feat(ai): stamp ingestedAt on tenant KB chunks (#11712)

### DIFF
--- a/ai/services/knowledge-base/VectorService.mjs
+++ b/ai/services/knowledge-base/VectorService.mjs
@@ -124,13 +124,15 @@ class VectorService extends Base {
      * @param {String} [tenantContext.originAgentIdentity] Authenticated agent identity.
      * @param {Number} [tenantContext.configVersion] Active `KnowledgeBaseTenantConfig` version (#11637);
      *                                               stamped onto chunk metadata as `tenantConfigVersion`.
-     * `ingestedAt` (epoch ms, server-stamped at embed time via `Date.now()`) is added
-     * unconditionally — the #11712 retention / GC / reconciliation substrate. A re-push
-     * re-embeds the chunk and re-stamps `ingestedAt`, so the semantics are *last-ingested-at*.
+     * `ingestedAt` (epoch ms, server-stamped via `Date.now()`) is added unconditionally —
+     * the #11712 retention / GC / reconciliation substrate. It marks when the chunk row is
+     * **actually embedded / upserted**: `embed()`'s zero-change fast path skips an unchanged
+     * same-content re-push, so that chunk keeps its prior `ingestedAt` (a content change
+     * yields a *new* chunk row — new content-hash ID — with its own fresh `ingestedAt`).
      * It is purely server-derived (never client-authored), so it is also a
-     * `TENANT_GUARDED_FIELDS` member.
-     * Consumers MUST treat a missing `ingestedAt` (a chunk embedded before #11712) as
-     * unknown-age and fail-safe — never expire / action a chunk with no timestamp.
+     * `TENANT_GUARDED_FIELDS` member. Consumers MUST treat a missing `ingestedAt` (a chunk
+     * embedded before #11712) as unknown-age and fail-safe — never expire / action a chunk
+     * with no timestamp.
      * @returns {{tenantId: String, repoSlug: String, visibility: String, tenantConfigVersion: Number, ingestedAt: Number, originAgentIdentity: String|undefined}}
      */
     resolveTenantStamp(tenantContext = {}) {

--- a/ai/services/knowledge-base/VectorService.mjs
+++ b/ai/services/knowledge-base/VectorService.mjs
@@ -10,7 +10,7 @@ import path                      from 'path';
 import readline                  from 'readline';
 import DestructiveOperationGuard from '../../mcp/server/shared/services/DestructiveOperationGuard.mjs';
 
-const TENANT_GUARDED_FIELDS = ['tenantId', 'repoSlug', 'visibility', 'originAgentIdentity', 'tenantConfigVersion'];
+const TENANT_GUARDED_FIELDS = ['tenantId', 'repoSlug', 'visibility', 'originAgentIdentity', 'tenantConfigVersion', 'ingestedAt'];
 const STALE_STRATEGIES      = Object.freeze(new Set(['delete-upfront', 'shadow-swap']));
 const STALE_STRATEGY_SKIP   = 'skip';
 
@@ -124,7 +124,14 @@ class VectorService extends Base {
      * @param {String} [tenantContext.originAgentIdentity] Authenticated agent identity.
      * @param {Number} [tenantContext.configVersion] Active `KnowledgeBaseTenantConfig` version (#11637);
      *                                               stamped onto chunk metadata as `tenantConfigVersion`.
-     * @returns {{tenantId: String, repoSlug: String, visibility: String, tenantConfigVersion: Number, originAgentIdentity: String|undefined}}
+     * `ingestedAt` (epoch ms, server-stamped at embed time via `Date.now()`) is added
+     * unconditionally — the #11712 retention / GC / reconciliation substrate. A re-push
+     * re-embeds the chunk and re-stamps `ingestedAt`, so the semantics are *last-ingested-at*.
+     * It is purely server-derived (never client-authored), so it is also a
+     * `TENANT_GUARDED_FIELDS` member.
+     * Consumers MUST treat a missing `ingestedAt` (a chunk embedded before #11712) as
+     * unknown-age and fail-safe — never expire / action a chunk with no timestamp.
+     * @returns {{tenantId: String, repoSlug: String, visibility: String, tenantConfigVersion: Number, ingestedAt: Number, originAgentIdentity: String|undefined}}
      */
     resolveTenantStamp(tenantContext = {}) {
         const config = this.getTenantIsolationConfig();
@@ -132,7 +139,8 @@ class VectorService extends Base {
             tenantId           : tenantContext.tenantId ?? config.defaultTenantId ?? 'neo-shared',
             repoSlug           : tenantContext.repoSlug ?? config.defaultRepoSlug ?? 'neo',
             visibility         : tenantContext.visibility ?? config.defaultVisibility ?? 'team',
-            tenantConfigVersion: tenantContext.configVersion ?? 0
+            tenantConfigVersion: tenantContext.configVersion ?? 0,
+            ingestedAt         : Date.now()
         };
 
         if (tenantContext.originAgentIdentity) {

--- a/test/playwright/unit/ai/services/knowledge-base/VectorService.tenantStamping.spec.mjs
+++ b/test/playwright/unit/ai/services/knowledge-base/VectorService.tenantStamping.spec.mjs
@@ -364,4 +364,79 @@ test.describe('VectorService.embed — tenant stamping (#11631)', () => {
         expect(tenantAHash).not.toBe(tenantBHash);
         expect(defaultHash).toBe(explicitDefaultHash);
     });
+
+    test('stamps a server-derived ingestedAt timestamp onto chunk metadata (#11712)', async () => {
+        const spy = createSpyCollection();
+        KB_ChromaManager.getKnowledgeBaseCollection = async () => spy;
+
+        writeFixtureJsonl(fixturePath, [{
+            hash       : 'raw-hash-ingestedat',
+            type       : 'guide',
+            name       : 'IngestedAtDoc',
+            className  : '',
+            description: 'ingestedAt stamping',
+            content    : 'body'
+        }]);
+
+        const before = Date.now();
+        await KB_VectorService.embed(fixturePath);
+        const after  = Date.now();
+
+        const {ingestedAt} = getOnlyRow(spy).metadata;
+
+        expect(typeof ingestedAt).toBe('number');
+        expect(Number.isFinite(ingestedAt)).toBe(true);
+        expect(ingestedAt).toBeGreaterThanOrEqual(before);
+        expect(ingestedAt).toBeLessThanOrEqual(after);
+        expect(warnCalls).toHaveLength(0);
+    });
+
+    test('overwrites a client-supplied ingestedAt and logs diagnostics (#11712)', async () => {
+        const spy = createSpyCollection();
+        KB_ChromaManager.getKnowledgeBaseCollection = async () => spy;
+
+        writeFixtureJsonl(fixturePath, [{
+            hash       : 'raw-hash-ingestedat-spoof',
+            type       : 'guide',
+            name       : 'IngestedAtSpoofDoc',
+            className  : '',
+            description: 'client ingestedAt spoof',
+            content    : 'body',
+            ingestedAt : 111
+        }]);
+
+        const before = Date.now();
+        await KB_VectorService.embed(fixturePath);
+
+        const row = getOnlyRow(spy);
+
+        // The server stamp (Date.now()) wins over the client-supplied stale value.
+        expect(row.metadata.ingestedAt).not.toBe(111);
+        expect(row.metadata.ingestedAt).toBeGreaterThanOrEqual(before);
+        expect(warnCalls.map(([, details]) => details.field)).toContain('ingestedAt');
+    });
+
+    test('reject mode rejects a client-supplied ingestedAt before Chroma writes (#11712)', async () => {
+        const spy = createSpyCollection();
+        KB_ChromaManager.getKnowledgeBaseCollection = async () => spy;
+        KB_Config.data.spoofRejectionMode = 'reject';
+
+        writeFixtureJsonl(fixturePath, [{
+            hash       : 'raw-hash-ingestedat-reject',
+            type       : 'guide',
+            name       : 'IngestedAtRejectDoc',
+            className  : '',
+            description: 'client ingestedAt spoof, reject mode',
+            content    : 'body',
+            ingestedAt : 111
+        }]);
+
+        await expect(KB_VectorService.embed(fixturePath)).rejects.toMatchObject({
+            code: 'KB_TENANT_SPOOF_REJECTED'
+        });
+
+        expect(spy.calls.get).toBe(0);
+        expect(spy.calls.upsert).toBe(0);
+        expect(warnCalls).toHaveLength(0);
+    });
 });

--- a/test/playwright/unit/ai/services/knowledge-base/VectorService.tenantStamping.spec.mjs
+++ b/test/playwright/unit/ai/services/knowledge-base/VectorService.tenantStamping.spec.mjs
@@ -439,4 +439,35 @@ test.describe('VectorService.embed — tenant stamping (#11631)', () => {
         expect(spy.calls.upsert).toBe(0);
         expect(warnCalls).toHaveLength(0);
     });
+
+    test('a same-content re-push retains the prior ingestedAt — zero-change fast path (#11712)', async () => {
+        const spy = createSpyCollection();
+        KB_ChromaManager.getKnowledgeBaseCollection = async () => spy;
+
+        const chunk = {
+            hash       : 'raw-hash-repush',
+            type       : 'guide',
+            name       : 'RepushDoc',
+            className  : '',
+            description: 'stable content',
+            content    : 'unchanged body'
+        };
+
+        writeFixtureJsonl(fixturePath, [chunk]);
+        await KB_VectorService.embed(fixturePath);
+
+        const firstIngestedAt = getOnlyRow(spy).metadata.ingestedAt;
+
+        expect(typeof firstIngestedAt).toBe('number');
+        expect(spy.calls.upsert).toBe(1);
+
+        // Re-push byte-identical content: embed()'s zero-change fast path skips the
+        // already-known content-hash ID — no re-upsert, so ingestedAt is NOT refreshed.
+        // ingestedAt marks the actual embed/upsert, not the push attempt.
+        writeFixtureJsonl(fixturePath, [chunk]);
+        await KB_VectorService.embed(fixturePath);
+
+        expect(spy.calls.upsert).toBe(1); // still 1 — the re-push upserted nothing
+        expect(getOnlyRow(spy).metadata.ingestedAt).toBe(firstIngestedAt);
+    });
 });


### PR DESCRIPTION
Authored by Neo Opus 4.7 (Claude Code). Session 470c38e7-1ffc-4851-867d-d30c1b6fbdb2.

FAIR-band: under-target [12/30] — Self-Selection Rule 1 fires (under-band → bias toward author lane).

Resolves #11712
Related: #11628

Tenant Knowledge Base chunks now carry a server-stamped `ingestedAt` timestamp. The gap — chunks had no ingest timestamp anywhere in their metadata — blocked three cloud-KB features: #11641's time/count-based retention policies, #11640's wall-clock orphan-grace (it fell back to a `tenantConfigVersion` version-gap), and #11711's manifest-grace reasoning. This PR adds the one missing field at the write boundary.

Evidence: L2 — 11 `VectorService.tenantStamping` unit tests pass (4 new for `ingestedAt` + 7 preserved). All #11712 ACs are unit-coverable (stamp inclusion, metadata propagation, guarded-field spoof handling, same-content-re-push retention); no runtime-only AC → no L3 residual.

## What shipped

- **`ai/services/knowledge-base/VectorService.mjs`** — `resolveTenantStamp` stamps `ingestedAt` (epoch ms, `Date.now()`) onto the server-derived tenant stamp; it flows through `applyTenantStamp` (`{...chunk, ...stamp}`) onto every embedded chunk's Chroma metadata. `ingestedAt` joins `TENANT_GUARDED_FIELDS` — it is purely server-derived, so a client-supplied `ingestedAt` is overwritten (or, under `spoofRejectionMode: 'reject'`, rejected with `KB_TENANT_SPOOF_REJECTED`), consistent with `tenantConfigVersion`. `ingestedAt` marks the **actual embed / upsert** — an unchanged same-content re-push hits `embed()`'s zero-change fast path and keeps its prior value.
- **`VectorService.tenantStamping.spec.mjs`** — 4 new tests extending the #11631 tenant-stamping spec: (1) `embed` stamps a finite `ingestedAt` within the `[before, after]` window onto chunk metadata; (2) a client-supplied stale `ingestedAt` is overwritten by the server value + a per-field diagnostic warn; (3) `spoofRejectionMode: 'reject'` rejects a client `ingestedAt` before any Chroma write; (4) a byte-identical re-push (zero-change fast path) leaves `ingestedAt` unchanged.

The implementation follows the #11712 Contract Ledger (in the ticket body) — the `resolveTenantStamp` row + the `TENANT_GUARDED_FIELDS` row.

## Deltas / decisions

- **Re-push semantics — embed-time (corrected per @neo-gpt's Cycle-1 review).** `ingestedAt` marks when a chunk row is *actually embedded / upserted*. `embed()`'s zero-change fast path dedupes already-known content-hash IDs, so a same-content re-push does not re-upsert and the chunk keeps its prior `ingestedAt` (a content change yields a *new* content-hash chunk row with its own fresh stamp). The initial framing — "re-push re-stamps, last-ingested-at" (commit `659a92700`) — overstated this; corrected in commit `1810a344f` (JSDoc + a new spec test). Embed-time is the correct retention anchor anyway: re-pushing identical content must not reset its age.
- **Missing-`ingestedAt` is fail-safe, not backfilled.** A chunk embedded before this PR has no `ingestedAt`. Per the Contract Ledger, consumers (the #11641 GC daemon, etc.) MUST treat a missing `ingestedAt` as unknown-age and never expire / action it — mirroring #11640's missing-`tenantConfigVersion` skip. Backfilling historical chunks is explicitly out of scope.

## Test Evidence

- `npm run test-unit -- test/playwright/unit/ai/services/knowledge-base/VectorService.tenantStamping.spec.mjs` → **11 passed** (4 new `ingestedAt` tests + 7 preserved #11631 / #11637 tenant-stamping tests — the existing tests are unaffected: none of their fixtures supply `ingestedAt`).
- `node --check ai/services/knowledge-base/VectorService.mjs` — clean.
- The `check-whitespace` pre-commit hook passed on both commits.

## Post-Merge Validation

None — all #11712 ACs are unit-covered by the `VectorService.tenantStamping` spec (stamp inclusion, metadata propagation, guarded-field spoof handling, same-content-re-push retention). There is no runtime-only surface; the `Evidence:` line declares no L3 residual.

## Commits

- `659a92700` — feat(ai): stamp ingestedAt on tenant KB chunks (#11712)
- `1810a344f` — fix(ai): correct ingestedAt re-push semantics — embed-time, not last-push (#11712)

## Related

- #11712 Contract Ledger — in the ticket body, the binding contract.
- #11641 — Phase 4C GC daemon — **blocked-by this ticket** (time / count-based retention needs `ingestedAt`); unblocked on merge.
- #11640 / #11711 — reconciliation; both worked around the absent timestamp via a `tenantConfigVersion` version-gap.
- #11631 — write-side tenant stamping (`TENANT_GUARDED_FIELDS` + the `VectorService.tenantStamping` spec this PR extends).
- #11628 — Phase 4 epic (this is a Phase-2-substrate enabler for it).
