### PR TITLE
feat(ai): reconcile KB manifest orphans (#11711)

### DIFF
--- a/ai/daemons/KbReconciliationService.mjs
+++ b/ai/daemons/KbReconciliationService.mjs
@@ -10,6 +10,7 @@ import KnowledgeBaseIngestionService from '../services/knowledge-base/KnowledgeB
 import logger                        from '../mcp/server/knowledge-base/logger.mjs';
 import {
     diffTenantChunks,
+    diffTenantManifest,
     formatReconciliationDetail,
     resolveOrphanVersionGap
 } from '../services/knowledge-base/helpers/KbReconciliationEngine.mjs';
@@ -51,12 +52,11 @@ const ROWS_PAGE_SIZE = 2000;
  * *second* opt-in (`reconciliationAutoTombstone`, default false): with it off, the daemon
  * detects + emits telemetry only and issues no `collection.delete`.
  *
- * **V1 scope** (per the #11640 Contract Ledger, ticket body): V1 reconciles the
- * config-invalidation failure mode via the `tenantConfigVersion` stamp. Force-push /
- * mid-push / partial-push drift detection needs a persisted claimed-state manifest that
- * Phase 2 substrate does not provide — V1.x-deferred. V1 is purely additive: it touches no
- * merged Phase 2 code (it reuses only the public `getTenantConfig` + the documented
- * `where: {tenantId}` Chroma read idiom).
+ * **V1.x scope** (#11711): after V1 shipped the config-invalidation signal, ingestion now
+ * persists claimed path manifests in `kb-manifest:<tenantId>`. This daemon reads those
+ * manifests and runs a second pure diff pass so force-push / partial-push / hook-failure
+ * leftovers become manifest orphans. Config-stale and manifest-orphan actionable ids are
+ * unioned before the opt-in tombstone call.
  *
  * @class Neo.ai.daemons.KbReconciliationService
  * @extends Neo.core.Base
@@ -202,7 +202,7 @@ class KbReconciliationService extends Base {
     }
 
     /**
-     * @summary Reconciles one tenant: config-version diff → telemetry → opt-in tombstone.
+     * @summary Reconciles one tenant: config-version diff + manifest diff → telemetry → opt-in tombstone.
      *
      * Never throws — a per-tenant failure (a config read, a Chroma error) is logged and the
      * remaining tenants still reconcile. A clean tenant (zero config-stale chunks) emits no
@@ -219,11 +219,14 @@ class KbReconciliationService extends Base {
      */
     async reconcileTenant({tenantId, repoSlug, collection, orphanVersionGap, autoTombstone}) {
         try {
-            const currentVersion = await this.fetchTenantConfigVersion(tenantId),
-                  rows           = await this.fetchTenantRows(collection, tenantId),
-                  diff           = diffTenantChunks({rows, currentVersion, orphanVersionGap});
+            const currentVersion  = await this.fetchTenantConfigVersion(tenantId),
+                  rows            = await this.fetchTenantRows(collection, tenantId),
+                  manifestsByRepo = await this.fetchTenantManifests(tenantId),
+                  configDiff      = diffTenantChunks({rows, currentVersion, orphanVersionGap}),
+                  manifestDiff    = diffTenantManifest({rows, manifestsByRepo}),
+                  diff            = this.combineDiffs({configDiff, manifestDiff});
 
-            if (diff.staleCount === 0) {
+            if (diff.totalOrphanCount === 0) {
                 return // clean tenant — emit nothing
             }
 
@@ -235,7 +238,7 @@ class KbReconciliationService extends Base {
 
             this.recordReconcileMetric({tenantId, repoSlug, diff, currentVersion, autoTombstone, tombstonedCount});
 
-            logger.info(`[KbReconciliationService] tenant ${tenantId}: ${diff.staleCount} config-stale chunk(s), ${diff.actionableCount} actionable, ${tombstonedCount} tombstoned (autoTombstone=${autoTombstone})`)
+            logger.info(`[KbReconciliationService] tenant ${tenantId}: ${diff.staleCount} config-stale chunk(s), ${diff.manifestOrphanCount} manifest-orphan chunk(s), ${diff.actionableCount} actionable, ${tombstonedCount} tombstoned (autoTombstone=${autoTombstone})`)
         } catch (err) {
             logger.error(`[KbReconciliationService] Reconciliation failed for tenant ${tenantId}: ${err.message}`)
         }
@@ -298,6 +301,41 @@ class KbReconciliationService extends Base {
         const config = await KnowledgeBaseIngestionService.getTenantConfig({tenantId});
 
         return config?.version ?? 0
+    }
+
+    /**
+     * @summary Test-stubbable seam — reads the persisted claimed-state manifests for a tenant (#11711).
+     * @param {String} tenantId
+     * @returns {Promise<Object<String, {pathsAfterPush: Array<String>}>>}
+     * @protected
+     */
+    async fetchTenantManifests(tenantId) {
+        return KnowledgeBaseIngestionService.getTenantManifests({tenantId})
+    }
+
+    /**
+     * @summary Combines config-stale and manifest-orphan diff axes into one delete/telemetry contract (#11711).
+     * @param {Object} params
+     * @param {Object} params.configDiff Result from `diffTenantChunks`.
+     * @param {Object} params.manifestDiff Result from `diffTenantManifest`.
+     * @returns {{staleOrphans: Array, manifestOrphans: Array, staleCount: Number, manifestOrphanCount: Number, totalOrphanCount: Number, actionableIds: Array<String>, actionableCount: Number}}
+     * @protected
+     */
+    combineDiffs({configDiff, manifestDiff} = {}) {
+        const actionableIds = [...new Set([
+            ...(configDiff?.actionableIds || []),
+            ...(manifestDiff?.actionableIds || [])
+        ])];
+
+        return {
+            staleOrphans       : configDiff?.staleOrphans || [],
+            manifestOrphans    : manifestDiff?.manifestOrphans || [],
+            staleCount         : configDiff?.staleCount || 0,
+            manifestOrphanCount: manifestDiff?.orphanCount || 0,
+            totalOrphanCount   : (configDiff?.staleCount || 0) + (manifestDiff?.orphanCount || 0),
+            actionableIds,
+            actionableCount    : actionableIds.length
+        }
     }
 
     /**
@@ -364,7 +402,7 @@ class KbReconciliationService extends Base {
      * @param {Object}  params
      * @param {String}  params.tenantId
      * @param {String}  params.repoSlug
-     * @param {Object}  params.diff             A {@link diffTenantChunks} result.
+     * @param {Object}  params.diff             A combined config/manifest reconciliation diff.
      * @param {Number}  params.currentVersion
      * @param {Boolean} params.autoTombstone
      * @param {Number}  params.tombstonedCount
@@ -376,7 +414,7 @@ class KbReconciliationService extends Base {
             tenantId,
             repoSlug,
             eventType    : 'reconcile',
-            chunksTotal  : diff.staleCount,
+            chunksTotal  : diff.totalOrphanCount ?? diff.staleCount,
             chunksDeleted: tombstonedCount,
             detail       : formatReconciliationDetail({diff, currentVersion, autoTombstone, tombstonedCount})
         })

--- a/ai/daemons/KbReconciliationService.mjs
+++ b/ai/daemons/KbReconciliationService.mjs
@@ -306,7 +306,7 @@ class KbReconciliationService extends Base {
     /**
      * @summary Test-stubbable seam — reads the persisted claimed-state manifests for a tenant (#11711).
      * @param {String} tenantId
-     * @returns {Promise<Object<String, {pathsAfterPush: Array<String>}>>}
+     * @returns {Promise<Object<String, {pathsAfterPush: Array<String>, updatedAt: Number}>>}
      * @protected
      */
     async fetchTenantManifests(tenantId) {
@@ -326,13 +326,17 @@ class KbReconciliationService extends Base {
             ...(configDiff?.actionableIds || []),
             ...(manifestDiff?.actionableIds || [])
         ])];
+        const orphanIds = new Set([
+            ...(configDiff?.staleOrphans || []).map(orphan => orphan.id),
+            ...(manifestDiff?.manifestOrphans || []).map(orphan => orphan.id)
+        ].filter(id => typeof id === 'string' && id.length > 0));
 
         return {
             staleOrphans       : configDiff?.staleOrphans || [],
             manifestOrphans    : manifestDiff?.manifestOrphans || [],
             staleCount         : configDiff?.staleCount || 0,
             manifestOrphanCount: manifestDiff?.orphanCount || 0,
-            totalOrphanCount   : (configDiff?.staleCount || 0) + (manifestDiff?.orphanCount || 0),
+            totalOrphanCount   : orphanIds.size,
             actionableIds,
             actionableCount    : actionableIds.length
         }

--- a/ai/services/knowledge-base/KnowledgeBaseIngestionService.mjs
+++ b/ai/services/knowledge-base/KnowledgeBaseIngestionService.mjs
@@ -474,9 +474,12 @@ class KnowledgeBaseIngestionService extends Base {
     /**
      * @summary Persists one repo's post-push claimed-state manifest without bumping config version (#11711).
      *
-     * RLS: writes still pass through {@link resolveTenantContext}; the graph node is marked
-     * `visibility:'team'` because the offline reconciliation daemon has no request context but
-     * must read the manifest to produce tenant-scoped Chroma deletes.
+     * RLS: writes still pass through {@link resolveTenantContext}. `GraphService.upsertNode`
+     * stamps `properties.userId` when a request-scoped identity is active, while
+     * `GraphService.getNodeRecord` exposes ownerless, owned, shared, or `visibility:'team'`
+     * nodes. Manifest writes can originate from request-authored ingestion pushes and are later
+     * read by the offline reconciliation daemon with no request context, so `visibility:'team'`
+     * is the explicit shared-read marker for this sibling node.
      *
      * @param {Object} data
      * @param {String} data.tenantId Tenant id.

--- a/ai/services/knowledge-base/KnowledgeBaseIngestionService.mjs
+++ b/ai/services/knowledge-base/KnowledgeBaseIngestionService.mjs
@@ -154,6 +154,12 @@ class KnowledgeBaseIngestionService extends Base {
             summary.ingested   = chunks.length;
             summary.durationMs = Date.now() - startedAt;
 
+            await this.persistManifestSnapshot({
+                manifestSnapshot: payload.manifestSnapshot,
+                tenantContext,
+                summary
+            });
+
             this.recordMetric(summary, tenantContext);
             return summary;
         } catch (error) {
@@ -217,23 +223,15 @@ class KnowledgeBaseIngestionService extends Base {
             }
         }
 
-        if (manifestSnapshot) {
-            const pathsAfterPush = manifestSnapshot.pathsAfterPush;
+        const normalizedManifest = this.normalizeManifestSnapshot({manifestSnapshot, tenantContext, summary});
 
-            if (!Array.isArray(pathsAfterPush)) {
-                summary.errors.push(this.createError({
-                    code   : 'KB_MANIFEST_INVALID',
-                    message: '`manifestSnapshot.pathsAfterPush` must be an array.'
-                }));
-            } else {
-                const repoSlug = manifestSnapshot.repoSlug || tenantContext.repoSlug;
-                const livePaths = new Set(pathsAfterPush);
-                const rows = await this.getTenantRows(collection, tenantContext.tenantId);
+        if (normalizedManifest) {
+            const livePaths = new Set(normalizedManifest.pathsAfterPush);
+            const rows = await this.getTenantRows(collection, tenantContext.tenantId);
 
-                rows
-                    .filter(row => row.metadata.repoSlug === repoSlug && !livePaths.has(row.metadata.sourcePath))
-                    .forEach(row => ids.add(row.id));
-            }
+            rows
+                .filter(row => row.metadata.repoSlug === normalizedManifest.repoSlug && !livePaths.has(row.metadata.sourcePath))
+                .forEach(row => ids.add(row.id));
         }
 
         if (ids.size === 0) return 0;
@@ -418,6 +416,187 @@ class KnowledgeBaseIngestionService extends Base {
         } while ((batch.ids?.length || 0) === limit);
 
         return rows;
+    }
+
+    /**
+     * @summary Reads the persisted claimed-state manifests for one tenant (#11711).
+     *
+     * The sibling `kb-manifest:<tenantId>` graph node stores push-manifest state outside
+     * `KnowledgeBaseTenantConfig`: config `version` is the #11640 staleness signal and must
+     * not increment on routine pushes. Missing or RLS-hidden nodes resolve to an empty map so
+     * reconciliation never actions rows without a claimed baseline.
+     *
+     * @param {Object}  data
+     * @param {String} [data.tenantId] Tenant id.
+     * @returns {Promise<Object<String, {repoSlug: String, pathsAfterPush: Array<String>, updatedAt: Number}>>}
+     */
+    async getTenantManifests({tenantId} = {}) {
+        const {tenantId: resolvedTenant} = this.resolveTenantContext({tenantId});
+
+        await this.graphService.initAsync();
+
+        const record = this.graphService.getNodeRecord({id: `kb-manifest:${resolvedTenant}`}),
+              source = record?.properties?.manifests;
+
+        if (!source || typeof source !== 'object' || Array.isArray(source)) {
+            return {};
+        }
+
+        return Object.fromEntries(Object.entries(source)
+            .map(([repoSlug, manifest]) => {
+                const paths = this.normalizeManifestPaths(manifest?.pathsAfterPush);
+                return paths ? [repoSlug, {repoSlug, pathsAfterPush: paths, updatedAt: manifest.updatedAt || 0}] : null;
+            })
+            .filter(Boolean));
+    }
+
+    /**
+     * @summary Reads one persisted tenant/repo claimed-state manifest (#11711).
+     * @param {Object} data
+     * @param {String} data.tenantId Tenant id.
+     * @param {String} data.repoSlug Repo slug.
+     * @returns {Promise<{tenantId: String, repoSlug: String, source: String, pathsAfterPush: Array<String>, updatedAt: Number}>}
+     */
+    async getTenantManifest({tenantId, repoSlug} = {}) {
+        const {tenantId: resolvedTenant, repoSlug: resolvedRepo} = this.resolveTenantContext({tenantId, repoSlug});
+        const manifests = await this.getTenantManifests({tenantId: resolvedTenant});
+        const manifest  = manifests[resolvedRepo];
+
+        return {
+            tenantId      : resolvedTenant,
+            repoSlug      : resolvedRepo,
+            source        : manifest ? 'graph' : 'empty',
+            pathsAfterPush: manifest?.pathsAfterPush || [],
+            updatedAt     : manifest?.updatedAt || 0
+        };
+    }
+
+    /**
+     * @summary Persists one repo's post-push claimed-state manifest without bumping config version (#11711).
+     *
+     * RLS: writes still pass through {@link resolveTenantContext}; the graph node is marked
+     * `visibility:'team'` because the offline reconciliation daemon has no request context but
+     * must read the manifest to produce tenant-scoped Chroma deletes.
+     *
+     * @param {Object} data
+     * @param {String} data.tenantId Tenant id.
+     * @param {String} data.repoSlug Repo slug.
+     * @param {Array<String>} data.pathsAfterPush Post-push source-path set.
+     * @returns {Promise<{tenantId: String, repoSlug: String, pathsAfterPush: Array<String>, updatedAt: Number}|{error: String, code: String, message: String}>}
+     */
+    async setTenantManifest({tenantId, repoSlug, pathsAfterPush} = {}) {
+        try {
+            const tenantContext = this.resolveTenantContext({tenantId, repoSlug}),
+                  paths         = this.normalizeManifestPaths(pathsAfterPush);
+
+            if (!paths) {
+                return {
+                    error  : 'Tenant manifest write failed',
+                    code   : 'KB_TENANT_MANIFEST_INVALID',
+                    message: '`pathsAfterPush` must be an array.'
+                };
+            }
+
+            await this.graphService.initAsync();
+
+            const nodeId    = `kb-manifest:${tenantContext.tenantId}`,
+                  existing  = this.graphService.getNodeRecord({id: nodeId}),
+                  manifests = {...(existing?.properties?.manifests || {})},
+                  updatedAt = Date.now();
+
+            manifests[tenantContext.repoSlug] = {
+                repoSlug       : tenantContext.repoSlug,
+                pathsAfterPush : paths,
+                updatedAt
+            };
+
+            await this.graphService.upsertNode({
+                id        : nodeId,
+                type      : 'KnowledgeBaseTenantManifest',
+                properties: {
+                    tenantId  : tenantContext.tenantId,
+                    manifests,
+                    updatedAt,
+                    visibility: 'team'
+                }
+            });
+
+            return {tenantId: tenantContext.tenantId, repoSlug: tenantContext.repoSlug, pathsAfterPush: paths, updatedAt};
+        } catch (error) {
+            return {
+                error  : 'Tenant manifest write failed',
+                code   : error.code || 'KB_TENANT_MANIFEST_WRITE_FAILED',
+                message: error.message
+            };
+        }
+    }
+
+    /**
+     * @summary Best-effort persistence hook for the push manifest already consumed by deletion signaling (#11711).
+     * @param {Object} options
+     * @returns {Promise<void>}
+     * @protected
+     */
+    async persistManifestSnapshot({manifestSnapshot, tenantContext, summary}) {
+        const normalized = this.normalizeManifestSnapshot({manifestSnapshot, tenantContext});
+
+        if (!normalized) {
+            return;
+        }
+
+        const result = await this.setTenantManifest({
+            tenantId       : tenantContext.tenantId,
+            repoSlug       : normalized.repoSlug,
+            pathsAfterPush : normalized.pathsAfterPush
+        });
+
+        if (result?.error) {
+            summary.errors.push(this.createError({
+                code   : result.code,
+                message: result.message
+            }));
+        }
+    }
+
+    /**
+     * @summary Normalizes a caller-provided manifest snapshot into deterministic repo/path-set form.
+     * @param {Object} options
+     * @returns {{repoSlug: String, pathsAfterPush: Array<String>}|null}
+     * @protected
+     */
+    normalizeManifestSnapshot({manifestSnapshot, tenantContext, summary}) {
+        if (!manifestSnapshot) {
+            return null;
+        }
+
+        const pathsAfterPush = this.normalizeManifestPaths(manifestSnapshot.pathsAfterPush);
+
+        if (!pathsAfterPush) {
+            summary?.errors.push(this.createError({
+                code   : 'KB_MANIFEST_INVALID',
+                message: '`manifestSnapshot.pathsAfterPush` must be an array.'
+            }));
+            return null;
+        }
+
+        return {
+            repoSlug: manifestSnapshot.repoSlug || tenantContext.repoSlug,
+            pathsAfterPush
+        };
+    }
+
+    /**
+     * @summary Converts a manifest path array into a stable unique string set.
+     * @param {*} pathsAfterPush Raw manifest path list.
+     * @returns {Array<String>|null}
+     * @protected
+     */
+    normalizeManifestPaths(pathsAfterPush) {
+        if (!Array.isArray(pathsAfterPush)) {
+            return null;
+        }
+
+        return [...new Set(pathsAfterPush.filter(path => typeof path === 'string' && path.length > 0))].sort();
     }
 
     /**

--- a/ai/services/knowledge-base/helpers/KbReconciliationEngine.mjs
+++ b/ai/services/knowledge-base/helpers/KbReconciliationEngine.mjs
@@ -26,7 +26,9 @@
  * `kb-manifest:<tenantId>`. It is deliberately separate from `KnowledgeBaseTenantConfig`
  * because that config node's `version` is the config-staleness signal above; routine push
  * manifests must not bump it. `diffTenantManifest()` classifies rows whose `metadata.sourcePath`
- * no longer appears in the persisted manifest for their `metadata.repoSlug`.
+ * no longer appears in the persisted manifest for their `metadata.repoSlug`, but only when
+ * the row's `metadata.ingestedAt` is at or before the manifest's `updatedAt` snapshot time.
+ * Rows newer than the manifest are outside that manifest's authority and are skipped.
  *
  * @see ai/daemons/KbReconciliationService.mjs — the daemon that consumes this engine.
  * @see ai/services/knowledge-base/KnowledgeBaseIngestionService.mjs — `getTenantConfig`, the version source.
@@ -124,19 +126,21 @@ export function diffTenantChunks({rows, currentVersion, orphanVersionGap} = {}) 
  *
  * Pure — no I/O, no clock. A row is a **manifest orphan** when all of the following are true:
  * the row has a `metadata.repoSlug`, the tenant has a persisted manifest for that repo, the
- * row has a string `metadata.sourcePath`, and that path is absent from the persisted
- * `pathsAfterPush` set. Every manifest orphan is immediately actionable: unlike config
- * staleness, there is no version-gap grace once the tenant's claimed current path set no
- * longer includes the row.
+ * row has a finite numeric `metadata.ingestedAt`, the persisted manifest has a finite numeric
+ * `updatedAt`, the row was ingested at or before that manifest snapshot, the row has a string
+ * `metadata.sourcePath`, and that path is absent from the persisted `pathsAfterPush` set.
+ * Every manifest orphan inside the manifest's authority window is immediately actionable:
+ * unlike config staleness, there is no version-gap grace once the tenant's claimed current
+ * path set no longer includes the row.
  *
  * Edge cases are fail-safe: malformed manifest maps, repos with no persisted manifest, and
- * rows missing `repoSlug` / `sourcePath` are skipped so the daemon never tombstones without a
- * claimed baseline.
+ * rows missing `repoSlug` / `sourcePath` / `ingestedAt` are skipped so the daemon never
+ * tombstones without a claimed baseline and freshness boundary.
  *
  * @param {Object} params
  * @param {Array<{id: String, metadata: Object}>} params.rows Tenant Chroma rows.
- * @param {Object<String, {pathsAfterPush: Array<String>}|Array<String>>} params.manifestsByRepo Persisted repo manifests.
- * @returns {{manifestOrphans: Array<{id: String, repoSlug: String, sourcePath: String}>, orphanCount: Number, actionableIds: Array<String>, actionableCount: Number}}
+ * @param {Object<String, {pathsAfterPush: Array<String>, updatedAt: Number}>} params.manifestsByRepo Persisted repo manifests.
+ * @returns {{manifestOrphans: Array<{id: String, repoSlug: String, sourcePath: String, ingestedAt: Number, manifestUpdatedAt: Number}>, orphanCount: Number, actionableIds: Array<String>, actionableCount: Number}}
  */
 export function diffTenantManifest({rows, manifestsByRepo} = {}) {
     const manifestOrphans = [];
@@ -146,32 +150,38 @@ export function diffTenantManifest({rows, manifestsByRepo} = {}) {
         return {manifestOrphans, orphanCount: 0, actionableIds, actionableCount: 0};
     }
 
-    const pathSets = new Map();
+    const manifests = new Map();
 
     for (const [repoSlug, manifest] of Object.entries(manifestsByRepo)) {
-        const paths = Array.isArray(manifest) ? manifest : manifest?.pathsAfterPush;
+        const paths     = manifest?.pathsAfterPush,
+              updatedAt = manifest?.updatedAt;
 
-        if (typeof repoSlug !== 'string' || !repoSlug || !Array.isArray(paths)) {
+        if (typeof repoSlug !== 'string' || !repoSlug || !Array.isArray(paths) || !Number.isFinite(updatedAt)) {
             continue;
         }
 
-        pathSets.set(repoSlug, new Set(paths.filter(path => typeof path === 'string' && path.length > 0)));
+        manifests.set(repoSlug, {
+            pathSet: new Set(paths.filter(path => typeof path === 'string' && path.length > 0)),
+            updatedAt
+        });
     }
 
-    if (pathSets.size === 0) {
+    if (manifests.size === 0) {
         return {manifestOrphans, orphanCount: 0, actionableIds, actionableCount: 0};
     }
 
     for (const row of rows) {
         const repoSlug   = row?.metadata?.repoSlug,
               sourcePath = row?.metadata?.sourcePath,
-              pathSet    = pathSets.get(repoSlug);
+              ingestedAt = row?.metadata?.ingestedAt,
+              manifest   = manifests.get(repoSlug);
 
-        if (!pathSet || typeof sourcePath !== 'string' || !sourcePath || pathSet.has(sourcePath)) {
+        if (!manifest || typeof sourcePath !== 'string' || !sourcePath || !Number.isFinite(ingestedAt) ||
+            ingestedAt > manifest.updatedAt || manifest.pathSet.has(sourcePath)) {
             continue;
         }
 
-        manifestOrphans.push({id: row.id, repoSlug, sourcePath});
+        manifestOrphans.push({id: row.id, repoSlug, sourcePath, ingestedAt, manifestUpdatedAt: manifest.updatedAt});
         actionableIds.push(row.id);
     }
 

--- a/ai/services/knowledge-base/helpers/KbReconciliationEngine.mjs
+++ b/ai/services/knowledge-base/helpers/KbReconciliationEngine.mjs
@@ -22,6 +22,12 @@
  * each tenant's Chroma rows, calls this engine, emits Phase 4A telemetry, and (opt-in) issues
  * the `collection.delete`. This module only *classifies*.
  *
+ * **The V1.x manifest signal.** #11711 adds a sibling claimed-state manifest per tenant:
+ * `kb-manifest:<tenantId>`. It is deliberately separate from `KnowledgeBaseTenantConfig`
+ * because that config node's `version` is the config-staleness signal above; routine push
+ * manifests must not bump it. `diffTenantManifest()` classifies rows whose `metadata.sourcePath`
+ * no longer appears in the persisted manifest for their `metadata.repoSlug`.
+ *
  * @see ai/daemons/KbReconciliationService.mjs — the daemon that consumes this engine.
  * @see ai/services/knowledge-base/KnowledgeBaseIngestionService.mjs — `getTenantConfig`, the version source.
  * @see ai/services/knowledge-base/VectorService.mjs — `resolveTenantStamp`, the `tenantConfigVersion` stamp.
@@ -114,24 +120,90 @@ export function diffTenantChunks({rows, currentVersion, orphanVersionGap} = {}) 
 }
 
 /**
+ * @summary Classifies one tenant's Chroma rows into claimed-manifest orphans (#11711).
+ *
+ * Pure — no I/O, no clock. A row is a **manifest orphan** when all of the following are true:
+ * the row has a `metadata.repoSlug`, the tenant has a persisted manifest for that repo, the
+ * row has a string `metadata.sourcePath`, and that path is absent from the persisted
+ * `pathsAfterPush` set. Every manifest orphan is immediately actionable: unlike config
+ * staleness, there is no version-gap grace once the tenant's claimed current path set no
+ * longer includes the row.
+ *
+ * Edge cases are fail-safe: malformed manifest maps, repos with no persisted manifest, and
+ * rows missing `repoSlug` / `sourcePath` are skipped so the daemon never tombstones without a
+ * claimed baseline.
+ *
+ * @param {Object} params
+ * @param {Array<{id: String, metadata: Object}>} params.rows Tenant Chroma rows.
+ * @param {Object<String, {pathsAfterPush: Array<String>}|Array<String>>} params.manifestsByRepo Persisted repo manifests.
+ * @returns {{manifestOrphans: Array<{id: String, repoSlug: String, sourcePath: String}>, orphanCount: Number, actionableIds: Array<String>, actionableCount: Number}}
+ */
+export function diffTenantManifest({rows, manifestsByRepo} = {}) {
+    const manifestOrphans = [];
+    const actionableIds   = [];
+
+    if (!Array.isArray(rows) || !manifestsByRepo || typeof manifestsByRepo !== 'object' || Array.isArray(manifestsByRepo)) {
+        return {manifestOrphans, orphanCount: 0, actionableIds, actionableCount: 0};
+    }
+
+    const pathSets = new Map();
+
+    for (const [repoSlug, manifest] of Object.entries(manifestsByRepo)) {
+        const paths = Array.isArray(manifest) ? manifest : manifest?.pathsAfterPush;
+
+        if (typeof repoSlug !== 'string' || !repoSlug || !Array.isArray(paths)) {
+            continue;
+        }
+
+        pathSets.set(repoSlug, new Set(paths.filter(path => typeof path === 'string' && path.length > 0)));
+    }
+
+    if (pathSets.size === 0) {
+        return {manifestOrphans, orphanCount: 0, actionableIds, actionableCount: 0};
+    }
+
+    for (const row of rows) {
+        const repoSlug   = row?.metadata?.repoSlug,
+              sourcePath = row?.metadata?.sourcePath,
+              pathSet    = pathSets.get(repoSlug);
+
+        if (!pathSet || typeof sourcePath !== 'string' || !sourcePath || pathSet.has(sourcePath)) {
+            continue;
+        }
+
+        manifestOrphans.push({id: row.id, repoSlug, sourcePath});
+        actionableIds.push(row.id);
+    }
+
+    return {
+        manifestOrphans,
+        orphanCount    : manifestOrphans.length,
+        actionableIds,
+        actionableCount: actionableIds.length
+    };
+}
+
+/**
  * @summary Builds the Phase 4A telemetry `detail` payload for one tenant's reconciliation tick.
  *
  * Pure — kept here (not in the daemon) so the telemetry shape is unit-testable. The daemon
  * passes the returned object straight to `KBRecorderService.recordIngestionMetric`'s `detail`.
  *
  * @param {Object}  params
- * @param {{staleCount: Number, actionableCount: Number}} params.diff  A {@link diffTenantChunks} result.
+ * @param {{staleCount: Number, manifestOrphanCount: Number, actionableCount: Number, totalOrphanCount: Number}} params.diff  Combined reconciliation diff.
  * @param {Number}  params.currentVersion   The tenant's current config version.
  * @param {Boolean} params.autoTombstone    Whether the daemon's auto-tombstone path is enabled.
  * @param {Number} [params.tombstonedCount=0] Chunks actually deleted this tick (`0` when auto-tombstone is off).
- * @returns {{staleCount: Number, actionableCount: Number, tombstonedCount: Number, currentVersion: Number, autoTombstone: Boolean}}
+ * @returns {{staleCount: Number, manifestOrphanCount: Number, totalOrphanCount: Number, actionableCount: Number, tombstonedCount: Number, currentVersion: Number, autoTombstone: Boolean}}
  */
 export function formatReconciliationDetail({diff, currentVersion, autoTombstone, tombstonedCount = 0} = {}) {
     return {
-        staleCount     : diff?.staleCount      ?? 0,
-        actionableCount: diff?.actionableCount ?? 0,
-        tombstonedCount: Number.isFinite(tombstonedCount) ? tombstonedCount : 0,
-        currentVersion : typeof currentVersion === 'number' ? currentVersion : 0,
-        autoTombstone  : autoTombstone === true
+        staleCount         : diff?.staleCount          ?? 0,
+        manifestOrphanCount: diff?.manifestOrphanCount ?? 0,
+        totalOrphanCount   : diff?.totalOrphanCount    ?? diff?.staleCount ?? 0,
+        actionableCount    : diff?.actionableCount     ?? 0,
+        tombstonedCount    : Number.isFinite(tombstonedCount) ? tombstonedCount : 0,
+        currentVersion     : typeof currentVersion === 'number' ? currentVersion : 0,
+        autoTombstone      : autoTombstone === true
     };
 }

--- a/ai/services/knowledge-base/parser/deletion-signaling-contract.md
+++ b/ai/services/knowledge-base/parser/deletion-signaling-contract.md
@@ -44,7 +44,7 @@ Fast, light, single-record-granular. Requires the client (typically a git hook) 
 }
 ```
 
-Robust against missed-delete-signaling (e.g., a hook that skipped tracking deletes). Server reconciles: any Chroma chunk with `metadata.sourcePath` not in `pathsAfterPush` AND `metadata.repoSlug == manifest.repoSlug` is orphaned and queued for deletion (per Phase 4C garbage-collection daemon retention policy). Higher payload cost — O(N) per push where N = post-push file count.
+Robust against missed-delete-signaling (e.g., a hook that skipped tracking deletes). The ingest request applies the manifest to the current payload, and Phase 4B persists the latest claimed-state manifest on `kb-manifest:<tenantId>` for later daemon reconciliation. A daemon-classified manifest orphan must satisfy `metadata.repoSlug == manifest.repoSlug`, `metadata.sourcePath` absent from `pathsAfterPush`, and a freshness guard: finite `metadata.ingestedAt <= manifest.updatedAt`. Rows missing `ingestedAt`, or rows ingested after the manifest was written, are outside that manifest's deletion authority and are skipped. Higher payload cost — O(N) per push where N = post-push file count.
 
 ### 3. Revision boundary
 
@@ -66,8 +66,8 @@ Clients pick the mechanism that fits their workflow:
 | Workflow | Recommended primary | Fallback |
 |---|---|---|
 | Small repos (< 1k files), git-hook-triggered | Manifest snapshot (cheap to enumerate; robust) | Tombstones |
-| Large repos (1k+ files), git-hook-triggered | Tombstones + revision-boundary | Periodic manifest reconciliation (Phase 4B daemon-driven) |
-| Rapid hooks (post-commit fires on every commit) | Revision-boundary only | Periodic manifest reconciliation (Phase 4B daemon-driven) |
+| Large repos (1k+ files), git-hook-triggered | Tombstones + revision-boundary | Periodic manifest-carrying pushes advance the Phase 4B daemon baseline |
+| Rapid hooks (post-commit fires on every commit) | Revision-boundary only | Periodic manifest-carrying pushes advance the Phase 4B daemon baseline |
 
 Phase 3 ([`#11627`](https://github.com/neomjs/neo/issues/11627)) `HookWiring.md` guide documents reference patterns. Phase 3's pre-push hook example demonstrates tombstone + revision-boundary combined.
 

--- a/learn/agentos/cloud-deployment/HookWiring.md
+++ b/learn/agentos/cloud-deployment/HookWiring.md
@@ -65,7 +65,7 @@ npm run ai:ingest-tenant -- <tenantId> (--from-file <path.jsonl> | --from-stdin)
 
 The CLI prints a JSON summary — `{tenantId, ingested, embeddingsGenerated, deleted, batches, parseErrors, errors}` — and exits non-zero if any error was accumulated.
 
-> The CLI submits each batch as a plain `files` array — it does **not** carry `deleted` / `manifestSnapshot` / revision-boundary fields. Bulk imports are initial-load or full-resync; per-push deletion signaling is an `ingest_source_files` concern (see below).
+> The CLI submits each batch as a plain `files` array — it does **not** carry `deleted` / `manifestSnapshot` / revision-boundary fields. Bulk imports are initial-load or full-resync; per-push deletion signaling is an `ingest_source_files` concern (see below). Because every chunk carries `metadata.ingestedAt`, chunks imported by the CLI after the last persisted manifest are outside that manifest's deletion authority; run a later manifest-carrying push or full claimed-state resync when the operator wants to advance the manifest baseline.
 
 ## Deletion signaling
 
@@ -74,10 +74,14 @@ An incremental push carries only *changed* files, so the server cannot infer del
 | Mechanism | Envelope field | Shape | Trade-off |
 |---|---|---|---|
 | Tombstones | `deleted` | `[{sourcePath, repoSlug}]` | Cheap, single-record granular; the client tracks its own deletes |
-| Manifest snapshot | `manifestSnapshot` | `{repoSlug, pathsAfterPush: [...]}` | Robust against missed deletes; O(N) payload in post-push file count |
+| Manifest snapshot | `manifestSnapshot` | `{repoSlug, pathsAfterPush: [...]}` | Robust against missed deletes; O(N) payload in post-push file count; durable baseline for daemon reconciliation |
 | Revision boundary | `baseRevision` + `headRevision` | last-pushed + current SHA | Cheapest signal; the server derives the delete set from the tenant's tracked revision |
 
 When a payload carries more than one, the server applies them in precedence order — revision-boundary computes the expected change set, tombstones extend it, the manifest reconciles surplus chunks as orphans. **Revision-boundary deletion additionally requires Phase 2E tenant config storage** ([#11637](https://github.com/neomjs/neo/issues/11637)): the resolver that maps a SHA range to deleted paths is wired by that phase; until it lands, a revision-boundary-only payload returns `KB_REVISION_BOUNDARY_UNAVAILABLE`, and tombstones + manifest remain the available signals. The full contract is in [`deletion-signaling-contract.md`](../../../ai/services/knowledge-base/parser/deletion-signaling-contract.md).
+
+`manifestSnapshot` is also persisted on the sibling graph node `kb-manifest:<tenantId>` (#11711), keyed by `repoSlug` with its `updatedAt` timestamp. The Phase 4B reconciliation daemon can later classify persisted chunks that are absent from the latest manifest as manifest orphans, but only inside the manifest's freshness window: `metadata.ingestedAt` must be finite and `<= manifest.updatedAt`. Chunks missing `ingestedAt`, or chunks ingested after the manifest was written, are skipped because the manifest cannot speak for content added by a bulk import or a minimal hook after that snapshot.
+
+Enable `reconciliationAutoTombstone` only when the tenant hook topology sends full manifest snapshots at the reconciliation points that should authorize deletes. Tombstone/revision-boundary-only hooks remain safe and cheap; they just should not rely on an older manifest to delete content created after that older manifest until a later manifest-carrying push advances the baseline.
 
 ## Wiring a `pre-push` git hook
 
@@ -96,7 +100,7 @@ The example combines **tombstones + revision-boundary** — the precise-but-chea
 | Hook | Fires | Best mechanism | Notes |
 |---|---|---|---|
 | `pre-push` | once per `git push` | tombstones + revision-boundary | Recommended default — batches a push's commits, SHA range on stdin |
-| `post-commit` | every commit | revision-boundary only | High frequency; keep payloads minimal — let the Phase 4B reconciliation daemon catch drift rather than enumerating a manifest per commit |
+| `post-commit` | every commit | revision-boundary only | High frequency; keep payloads minimal. The Phase 4B reconciliation daemon can catch drift only within the last persisted manifest's freshness window; rows ingested after that manifest are skipped until a later manifest-carrying push advances the baseline. |
 
 ## Error handling — the structured summary
 

--- a/test/playwright/integration/ai/kb-ingestion/multi-tenant.spec.mjs
+++ b/test/playwright/integration/ai/kb-ingestion/multi-tenant.spec.mjs
@@ -111,6 +111,7 @@ function runMultiTenantMatrix(collectionName) {
             Memory_TextEmbeddingService
         } = await import('./ai/services.mjs');
         const {callTool} = await import('./ai/mcp/server/knowledge-base/toolService.mjs');
+        const {default: KbReconciliationService} = await import('./ai/daemons/KbReconciliationService.mjs');
         const {default: KnowledgeBaseIngestionService} = await import('./ai/services/knowledge-base/KnowledgeBaseIngestionService.mjs');
         const {default: QueryService} = await import('./ai/services/knowledge-base/QueryService.mjs');
         const {default: SearchService} = await import('./ai/services/knowledge-base/SearchService.mjs');
@@ -468,6 +469,31 @@ function runMultiTenantMatrix(collectionName) {
                 newPresent: forceRows.some(row => row.metadata.repoSlug === forcePushRepoSlug && row.metadata.sourcePath === 'src/new.js')
             };
 
+            await asTenant('tenant-alpha', () => KnowledgeBaseIngestionService.setTenantManifest({
+                tenantId      : 'tenant-alpha',
+                repoSlug      : forcePushRepoSlug,
+                pathsAfterPush: ['src/new.js']
+            }));
+            const manifestCollection = await KB_ChromaManager.getKnowledgeBaseCollection();
+            const manifestMetrics = [];
+            KbReconciliationService.recordReconcileMetric = metric => { manifestMetrics.push(metric) };
+            await KbReconciliationService.reconcileTenant({
+                tenantId        : 'tenant-alpha',
+                repoSlug        : forcePushRepoSlug,
+                collection      : manifestCollection,
+                orphanVersionGap: 2,
+                autoTombstone   : true
+            });
+            const manifestRows = await getRows({tenantId: 'tenant-alpha'});
+            result.manifestOrphanReconciliation = {
+                metricCount  : manifestMetrics.length,
+                orphanPresent: manifestRows.some(row => (
+                    row.metadata.repoSlug === forcePushRepoSlug && row.metadata.sourcePath === 'src/legacy-widget.js'
+                )),
+                deletedCount: manifestMetrics[0]?.tombstonedCount,
+                orphanCount : manifestMetrics[0]?.diff?.manifestOrphanCount
+            };
+
             const spoofPayload = await asTenant('tenant-alpha', () => callTool('ingest_source_files', {
                 tenantId  : 'tenant-alpha',
                 repoSlug  : 'spoof-repo',
@@ -492,6 +518,7 @@ function runMultiTenantMatrix(collectionName) {
             Memory_TextEmbeddingService.embedText  = originals.embedText;
             Memory_TextEmbeddingService.embedTexts = originals.embedTexts;
             KnowledgeBaseIngestionService.revisionResolver = originals.revisionResolver;
+            delete KbReconciliationService.recordReconcileMetric;
             KB_Config.data.collectionName      = originals.collectionName;
             KB_Config.data.defaultRepoSlug     = originals.defaultRepoSlug;
             KB_Config.data.defaultTenantId     = originals.defaultTenantId;
@@ -603,6 +630,12 @@ test.describe('KB ingestion external workspace fixtures (#11638)', () => {
             deleted      : 1,
             orphanPresent: false,
             newPresent   : true
+        });
+        expect(outcome.manifestOrphanReconciliation).toMatchObject({
+            metricCount  : 1,
+            orphanPresent: false,
+            deletedCount : 1,
+            orphanCount  : 1
         });
         expect(outcome.spoofRejection).toMatchObject({
             ingested    : 1,

--- a/test/playwright/unit/ai/daemons/KbReconciliationService.spec.mjs
+++ b/test/playwright/unit/ai/daemons/KbReconciliationService.spec.mjs
@@ -83,7 +83,7 @@ test.describe('Neo.ai.daemons.KbReconciliationService (#11640)', () => {
         // Drop instance-method seam overrides so the real prototype methods resurface for
         // the next test — an instance override otherwise leaks across tests in the worker.
         for (const seam of ['getKbConfig', 'fetchTenants', 'getCollection', 'fetchTenantConfigVersion',
-                             'fetchTenantRows', 'tombstoneOrphans', 'recordReconcileMetric',
+                             'fetchTenantRows', 'fetchTenantManifests', 'tombstoneOrphans', 'recordReconcileMetric',
                              'reconcileTenant', 'scheduleNext']) {
             delete KbReconciliationService[seam];
         }
@@ -97,8 +97,9 @@ test.describe('Neo.ai.daemons.KbReconciliationService (#11640)', () => {
 
     /** Deterministic seam baseline — `scheduleNext` neutralized so no real timer leaks. */
     function applyStubs({config} = {}) {
-        KbReconciliationService.getKbConfig  = () => config || {reconciliationEnabled: true};
-        KbReconciliationService.scheduleNext = function () {};
+        KbReconciliationService.getKbConfig         = () => config || {reconciliationEnabled: true};
+        KbReconciliationService.fetchTenantManifests = async () => ({});
+        KbReconciliationService.scheduleNext        = function () {};
     }
 
     test.describe('start / stop', () => {
@@ -211,9 +212,10 @@ test.describe('Neo.ai.daemons.KbReconciliationService (#11640)', () => {
 
     test.describe('reconcileTenant', () => {
         /** Wires the per-tenant seams; `rows` drives the real KbReconciliationEngine diff. */
-        function wireTenant({version, rows}) {
+        function wireTenant({version, rows, manifestsByRepo = {}}) {
             KbReconciliationService.fetchTenantConfigVersion = async () => version;
             KbReconciliationService.fetchTenantRows          = async () => rows;
+            KbReconciliationService.fetchTenantManifests     = async () => manifestsByRepo;
         }
 
         test('a clean tenant emits no telemetry and tombstones nothing', async () => {
@@ -250,6 +252,37 @@ test.describe('Neo.ai.daemons.KbReconciliationService (#11640)', () => {
             expect(metrics[0].autoTombstone).toBe(false);
         });
 
+        test('a manifest-orphan tenant with auto-tombstone OFF emits telemetry but issues no delete (#11711)', async () => {
+            applyStubs();
+            wireTenant({
+                version: 0,
+                rows: [
+                    row('live', 0),
+                    {id: 'manifest-orphan', metadata: {tenantConfigVersion: 0, tenantId: 'tenant-x', repoSlug: 'repo-x', sourcePath: 'src/orphan.js'}}
+                ],
+                manifestsByRepo: {
+                    'repo-x': {pathsAfterPush: ['src/live.js']}
+                }
+            });
+            let tombstoned = 0;
+            KbReconciliationService.tombstoneOrphans = async () => { tombstoned++; return 0 };
+            const metrics = [];
+            KbReconciliationService.recordReconcileMetric = (m) => { metrics.push(m) };
+
+            await KbReconciliationService.reconcileTenant({
+                tenantId: 'tenant-x', repoSlug: 'repo-x', collection: {}, orphanVersionGap: 2, autoTombstone: false
+            });
+
+            expect(tombstoned).toBe(0);
+            expect(metrics).toHaveLength(1);
+            expect(metrics[0].diff).toMatchObject({
+                staleCount         : 0,
+                manifestOrphanCount: 1,
+                totalOrphanCount   : 1,
+                actionableIds      : ['manifest-orphan']
+            });
+        });
+
         test('a drifting tenant with auto-tombstone ON deletes the actionable orphans', async () => {
             applyStubs();
             wireTenant({version: 5, rows: [row('a', 5), row('b', 3), row('c', 1)]}); // b,c actionable at gap 2
@@ -265,6 +298,38 @@ test.describe('Neo.ai.daemons.KbReconciliationService (#11640)', () => {
             expect(deleted.sort()).toEqual(['b', 'c']);
             expect(metrics[0].tombstonedCount).toBe(2);
             expect(metrics[0].autoTombstone).toBe(true);
+        });
+
+        test('auto-tombstone ON unions config-stale and manifest-orphan actionable ids once (#11711)', async () => {
+            applyStubs();
+            wireTenant({
+                version: 5,
+                rows: [
+                    {id: 'overlap', metadata: {tenantConfigVersion: 1, tenantId: 'tenant-x', repoSlug: 'repo-x', sourcePath: 'src/old.js'}},
+                    {id: 'manifest-only', metadata: {tenantConfigVersion: 5, tenantId: 'tenant-x', repoSlug: 'repo-x', sourcePath: 'src/removed.js'}},
+                    row('live', 5)
+                ],
+                manifestsByRepo: {
+                    'repo-x': {pathsAfterPush: ['src/live.js']}
+                }
+            });
+            const deleted = [];
+            KbReconciliationService.tombstoneOrphans = async (collection, ids) => { deleted.push(...ids); return ids.length };
+            const metrics = [];
+            KbReconciliationService.recordReconcileMetric = (m) => { metrics.push(m) };
+
+            await KbReconciliationService.reconcileTenant({
+                tenantId: 'tenant-x', repoSlug: 'repo-x', collection: {}, orphanVersionGap: 2, autoTombstone: true
+            });
+
+            expect(deleted.sort()).toEqual(['manifest-only', 'overlap']);
+            expect(metrics[0].diff).toMatchObject({
+                staleCount         : 1,
+                manifestOrphanCount: 2,
+                totalOrphanCount   : 3,
+                actionableCount    : 2
+            });
+            expect(metrics[0].tombstonedCount).toBe(2);
         });
 
         test('auto-tombstone ON but every orphan within grace issues no delete', async () => {

--- a/test/playwright/unit/ai/daemons/KbReconciliationService.spec.mjs
+++ b/test/playwright/unit/ai/daemons/KbReconciliationService.spec.mjs
@@ -47,7 +47,17 @@ test.describe('Neo.ai.daemons.KbReconciliationService (#11640)', () => {
     let originals = {};
 
     /** Builds a tenant Chroma row in the `getTenantRows` shape. */
-    const row = (id, v) => ({id, metadata: {tenantConfigVersion: v, repoSlug: 'repo-x', tenantId: 'tenant-x'}});
+    const row = (id, v, metadata = {}) => ({
+        id,
+        metadata: {
+            tenantConfigVersion: v,
+            ingestedAt          : 1000,
+            repoSlug           : 'repo-x',
+            sourcePath         : 'src/' + id + '.js',
+            tenantId           : 'tenant-x',
+            ...metadata
+        }
+    });
 
     test.beforeAll(async () => {
         ({default: KbReconciliationService, DEFAULT_INTERVAL_MS} =
@@ -97,9 +107,9 @@ test.describe('Neo.ai.daemons.KbReconciliationService (#11640)', () => {
 
     /** Deterministic seam baseline — `scheduleNext` neutralized so no real timer leaks. */
     function applyStubs({config} = {}) {
-        KbReconciliationService.getKbConfig         = () => config || {reconciliationEnabled: true};
+        KbReconciliationService.getKbConfig          = () => config || {reconciliationEnabled: true};
         KbReconciliationService.fetchTenantManifests = async () => ({});
-        KbReconciliationService.scheduleNext        = function () {};
+        KbReconciliationService.scheduleNext         = function () {};
     }
 
     test.describe('start / stop', () => {
@@ -258,10 +268,10 @@ test.describe('Neo.ai.daemons.KbReconciliationService (#11640)', () => {
                 version: 0,
                 rows: [
                     row('live', 0),
-                    {id: 'manifest-orphan', metadata: {tenantConfigVersion: 0, tenantId: 'tenant-x', repoSlug: 'repo-x', sourcePath: 'src/orphan.js'}}
+                    row('manifest-orphan', 0, {sourcePath: 'src/orphan.js'})
                 ],
                 manifestsByRepo: {
-                    'repo-x': {pathsAfterPush: ['src/live.js']}
+                    'repo-x': {pathsAfterPush: ['src/live.js'], updatedAt: 2000}
                 }
             });
             let tombstoned = 0;
@@ -305,12 +315,12 @@ test.describe('Neo.ai.daemons.KbReconciliationService (#11640)', () => {
             wireTenant({
                 version: 5,
                 rows: [
-                    {id: 'overlap', metadata: {tenantConfigVersion: 1, tenantId: 'tenant-x', repoSlug: 'repo-x', sourcePath: 'src/old.js'}},
-                    {id: 'manifest-only', metadata: {tenantConfigVersion: 5, tenantId: 'tenant-x', repoSlug: 'repo-x', sourcePath: 'src/removed.js'}},
+                    row('overlap', 1, {sourcePath: 'src/old.js'}),
+                    row('manifest-only', 5, {sourcePath: 'src/removed.js'}),
                     row('live', 5)
                 ],
                 manifestsByRepo: {
-                    'repo-x': {pathsAfterPush: ['src/live.js']}
+                    'repo-x': {pathsAfterPush: ['src/live.js'], updatedAt: 2000}
                 }
             });
             const deleted = [];
@@ -326,10 +336,40 @@ test.describe('Neo.ai.daemons.KbReconciliationService (#11640)', () => {
             expect(metrics[0].diff).toMatchObject({
                 staleCount         : 1,
                 manifestOrphanCount: 2,
-                totalOrphanCount   : 3,
+                totalOrphanCount   : 2,
                 actionableCount    : 2
             });
             expect(metrics[0].tombstonedCount).toBe(2);
+        });
+
+        test('auto-tombstone ON skips manifest-missing rows newer than the manifest snapshot (#11711)', async () => {
+            applyStubs();
+            wireTenant({
+                version: 0,
+                rows: [
+                    row('old-orphan', 0, {sourcePath: 'src/old.js', ingestedAt: 1000}),
+                    row('newer-row', 0, {sourcePath: 'src/new.js', ingestedAt: 3000}),
+                    row('live', 0)
+                ],
+                manifestsByRepo: {
+                    'repo-x': {pathsAfterPush: ['src/live.js'], updatedAt: 2000}
+                }
+            });
+            const deleted = [];
+            KbReconciliationService.tombstoneOrphans = async (collection, ids) => { deleted.push(...ids); return ids.length };
+            const metrics = [];
+            KbReconciliationService.recordReconcileMetric = (m) => { metrics.push(m) };
+
+            await KbReconciliationService.reconcileTenant({
+                tenantId: 'tenant-x', repoSlug: 'repo-x', collection: {}, orphanVersionGap: 2, autoTombstone: true
+            });
+
+            expect(deleted).toEqual(['old-orphan']);
+            expect(metrics[0].diff).toMatchObject({
+                manifestOrphanCount: 1,
+                totalOrphanCount   : 1,
+                actionableIds      : ['old-orphan']
+            });
         });
 
         test('auto-tombstone ON but every orphan within grace issues no delete', async () => {

--- a/test/playwright/unit/ai/services/knowledge-base/KbReconciliationEngine.spec.mjs
+++ b/test/playwright/unit/ai/services/knowledge-base/KbReconciliationEngine.spec.mjs
@@ -31,6 +31,7 @@ const row = (id, v, metadata = {}) => ({
     id,
     metadata: {
         tenantConfigVersion: v,
+        ingestedAt          : 1000,
         repoSlug           : 'repo-x',
         tenantId           : 'tenant-x',
         sourcePath         : 'src/' + id + '.js',
@@ -162,12 +163,18 @@ test.describe('KbReconciliationEngine — diffTenantManifest (#11711)', () => {
                 row('other-repo', 5, {repoSlug: 'repo-y', sourcePath: 'src/old.js'})
             ],
             manifestsByRepo: {
-                'repo-x': {pathsAfterPush: ['src/live.js']}
+                'repo-x': {pathsAfterPush: ['src/live.js'], updatedAt: 2000}
             }
         });
 
         expect(diff.orphanCount).toBe(1);
-        expect(diff.manifestOrphans).toEqual([{id: 'orphan', repoSlug: 'repo-x', sourcePath: 'src/old.js'}]);
+        expect(diff.manifestOrphans).toEqual([{
+            id               : 'orphan',
+            repoSlug         : 'repo-x',
+            sourcePath       : 'src/old.js',
+            ingestedAt       : 1000,
+            manifestUpdatedAt: 2000
+        }]);
         expect(diff.actionableIds).toEqual(['orphan']);
         expect(diff.actionableCount).toBe(1);
     });
@@ -179,17 +186,57 @@ test.describe('KbReconciliationEngine — diffTenantManifest (#11711)', () => {
                 row('missing-source', 5, {sourcePath: undefined})
             ],
             manifestsByRepo: {
-                'repo-x': {pathsAfterPush: ['src/live.js']}
+                'repo-x': {pathsAfterPush: ['src/live.js'], updatedAt: 2000}
             }
         });
 
         expect(diff).toEqual({manifestOrphans: [], orphanCount: 0, actionableIds: [], actionableCount: 0});
     });
 
+    test('skips rows that are newer than the persisted manifest snapshot', () => {
+        const diff = diffTenantManifest({
+            rows: [
+                row('old-orphan', 5, {sourcePath: 'src/old.js', ingestedAt: 1000}),
+                row('newer-row', 5, {sourcePath: 'src/new.js', ingestedAt: 3000})
+            ],
+            manifestsByRepo: {
+                'repo-x': {pathsAfterPush: ['src/live.js'], updatedAt: 2000}
+            }
+        });
+
+        expect(diff.orphanCount).toBe(1);
+        expect(diff.manifestOrphans[0]).toMatchObject({
+            id               : 'old-orphan',
+            ingestedAt       : 1000,
+            manifestUpdatedAt: 2000
+        });
+        expect(diff.actionableIds).toEqual(['old-orphan']);
+    });
+
+    test('skips rows without a finite ingestedAt stamp', () => {
+        const diff = diffTenantManifest({
+            rows: [
+                row('missing-ingested', 5, {sourcePath: 'src/missing.js', ingestedAt: undefined}),
+                row('string-ingested', 5, {sourcePath: 'src/string.js', ingestedAt: '1000'}),
+                row('real-orphan', 5, {sourcePath: 'src/old.js', ingestedAt: 1000})
+            ],
+            manifestsByRepo: {
+                'repo-x': {pathsAfterPush: ['src/live.js'], updatedAt: 2000}
+            }
+        });
+
+        expect(diff.orphanCount).toBe(1);
+        expect(diff.actionableIds).toEqual(['real-orphan']);
+    });
+
     test('returns an empty result when manifest input is absent or malformed', () => {
         expect(diffTenantManifest({rows: [row('a', 1)]}).orphanCount).toBe(0);
         expect(diffTenantManifest({rows: [row('a', 1)], manifestsByRepo: []}).orphanCount).toBe(0);
         expect(diffTenantManifest({rows: null, manifestsByRepo: {'repo-x': {pathsAfterPush: []}}}).orphanCount).toBe(0);
+        expect(diffTenantManifest({
+            rows           : [row('a', 1)],
+            manifestsByRepo: {'repo-x': {pathsAfterPush: [], updatedAt: undefined}}
+        }).orphanCount).toBe(0);
     });
 });
 

--- a/test/playwright/unit/ai/services/knowledge-base/KbReconciliationEngine.spec.mjs
+++ b/test/playwright/unit/ai/services/knowledge-base/KbReconciliationEngine.spec.mjs
@@ -3,6 +3,7 @@ import {test, expect} from '@playwright/test';
 import {
     DEFAULT_ORPHAN_VERSION_GAP,
     diffTenantChunks,
+    diffTenantManifest,
     formatReconciliationDetail,
     resolveOrphanVersionGap
 } from '../../../../../../ai/services/knowledge-base/helpers/KbReconciliationEngine.mjs';
@@ -26,7 +27,16 @@ import {
  */
 
 /** Builds a tenant Chroma row in the `getTenantRows` shape. `v` → `metadata.tenantConfigVersion`. */
-const row = (id, v) => ({id, metadata: {tenantConfigVersion: v, repoSlug: 'repo-x', tenantId: 'tenant-x'}});
+const row = (id, v, metadata = {}) => ({
+    id,
+    metadata: {
+        tenantConfigVersion: v,
+        repoSlug           : 'repo-x',
+        tenantId           : 'tenant-x',
+        sourcePath         : 'src/' + id + '.js',
+        ...metadata
+    }
+});
 
 test.describe('KbReconciliationEngine — resolveOrphanVersionGap (#11640)', () => {
     test('returns a finite value at or above 1 unchanged', () => {
@@ -143,17 +153,59 @@ test.describe('KbReconciliationEngine — diffTenantChunks (#11640)', () => {
     });
 });
 
+test.describe('KbReconciliationEngine — diffTenantManifest (#11711)', () => {
+    test('flags rows whose sourcePath is absent from the persisted repo manifest', () => {
+        const diff = diffTenantManifest({
+            rows: [
+                row('live', 5, {sourcePath: 'src/live.js'}),
+                row('orphan', 5, {sourcePath: 'src/old.js'}),
+                row('other-repo', 5, {repoSlug: 'repo-y', sourcePath: 'src/old.js'})
+            ],
+            manifestsByRepo: {
+                'repo-x': {pathsAfterPush: ['src/live.js']}
+            }
+        });
+
+        expect(diff.orphanCount).toBe(1);
+        expect(diff.manifestOrphans).toEqual([{id: 'orphan', repoSlug: 'repo-x', sourcePath: 'src/old.js'}]);
+        expect(diff.actionableIds).toEqual(['orphan']);
+        expect(diff.actionableCount).toBe(1);
+    });
+
+    test('skips repos without a persisted manifest and rows without sourcePath', () => {
+        const diff = diffTenantManifest({
+            rows: [
+                row('repo-without-manifest', 5, {repoSlug: 'repo-y', sourcePath: 'src/old.js'}),
+                row('missing-source', 5, {sourcePath: undefined})
+            ],
+            manifestsByRepo: {
+                'repo-x': {pathsAfterPush: ['src/live.js']}
+            }
+        });
+
+        expect(diff).toEqual({manifestOrphans: [], orphanCount: 0, actionableIds: [], actionableCount: 0});
+    });
+
+    test('returns an empty result when manifest input is absent or malformed', () => {
+        expect(diffTenantManifest({rows: [row('a', 1)]}).orphanCount).toBe(0);
+        expect(diffTenantManifest({rows: [row('a', 1)], manifestsByRepo: []}).orphanCount).toBe(0);
+        expect(diffTenantManifest({rows: null, manifestsByRepo: {'repo-x': {pathsAfterPush: []}}}).orphanCount).toBe(0);
+    });
+});
+
 test.describe('KbReconciliationEngine — formatReconciliationDetail (#11640)', () => {
     test('builds the Phase 4A telemetry detail payload from a diff', () => {
-        const diff   = {staleCount: 5, actionableCount: 3, staleOrphans: [], actionableIds: []};
+        const diff   = {staleCount: 5, manifestOrphanCount: 2, totalOrphanCount: 7, actionableCount: 3, staleOrphans: [], actionableIds: []};
         const detail = formatReconciliationDetail({diff, currentVersion: 7, autoTombstone: true, tombstonedCount: 3});
 
         expect(detail).toEqual({
-            staleCount     : 5,
-            actionableCount: 3,
-            tombstonedCount: 3,
-            currentVersion : 7,
-            autoTombstone  : true
+            staleCount         : 5,
+            manifestOrphanCount: 2,
+            totalOrphanCount   : 7,
+            actionableCount    : 3,
+            tombstonedCount    : 3,
+            currentVersion     : 7,
+            autoTombstone      : true
         });
     });
 
@@ -169,11 +221,13 @@ test.describe('KbReconciliationEngine — formatReconciliationDetail (#11640)', 
         const detail = formatReconciliationDetail({});
 
         expect(detail).toEqual({
-            staleCount     : 0,
-            actionableCount: 0,
-            tombstonedCount: 0,
-            currentVersion : 0,
-            autoTombstone  : false
+            staleCount         : 0,
+            manifestOrphanCount: 0,
+            totalOrphanCount   : 0,
+            actionableCount    : 0,
+            tombstonedCount    : 0,
+            currentVersion     : 0,
+            autoTombstone      : false
         });
     });
 });

--- a/test/playwright/unit/ai/services/knowledge-base/KnowledgeBaseIngestionService.spec.mjs
+++ b/test/playwright/unit/ai/services/knowledge-base/KnowledgeBaseIngestionService.spec.mjs
@@ -70,6 +70,25 @@ function createSpyCollection(rows = []) {
     };
 }
 
+/**
+ * Minimal in-memory stub of the GraphService surface consumed by tenant config / manifest APIs.
+ * @returns {Object}
+ */
+function createGraphStub() {
+    const store = new Map();
+
+    return {
+        store,
+        async initAsync() {},
+        getNodeRecord({id}) {
+            return store.has(id) ? {...store.get(id)} : null;
+        },
+        async upsertNode({id, type, properties}) {
+            store.set(id, {id, type, properties: {...properties}});
+        }
+    };
+}
+
 test.describe('KnowledgeBaseIngestionService.ingestSourceFiles', () => {
     let Service;
     let originals;
@@ -88,6 +107,7 @@ test.describe('KnowledgeBaseIngestionService.ingestSourceFiles', () => {
 
         originals = {
             chromaManager        : Service.chromaManager,
+            graphService         : Service.graphService,
             getTenantConfig      : Service.getTenantConfig,
             recorderService      : Service.recorderService,
             requestContextService: Service.requestContextService,
@@ -99,6 +119,7 @@ test.describe('KnowledgeBaseIngestionService.ingestSourceFiles', () => {
         Service.chromaManager = {
             getKnowledgeBaseCollection: async () => collection
         };
+        Service.graphService = createGraphStub();
         // ingestSourceFiles resolves the tenant-config version for chunk stamping (#11637);
         // stubbed here so this suite stays focused on ingestion orchestration.
         Service.getTenantConfig = async () => ({version: 0});
@@ -422,25 +443,6 @@ test.describe('KnowledgeBaseIngestionService.tenantConfig (#11637)', () => {
     let originals;
     let graphStub;
 
-    /**
-     * Minimal in-memory stub of the GraphService surface consumed by getTenantConfig / setTenantConfig.
-     * @returns {Object}
-     */
-    function createGraphStub() {
-        const store = new Map();
-
-        return {
-            store,
-            async initAsync() {},
-            getNodeRecord({id}) {
-                return store.has(id) ? {...store.get(id)} : null;
-            },
-            async upsertNode({id, type, properties}) {
-                store.set(id, {id, type, properties: {...properties}});
-            }
-        };
-    }
-
     test.beforeAll(async () => {
         Service = (await import('../../../../../../ai/services/knowledge-base/KnowledgeBaseIngestionService.mjs')).default;
     });
@@ -501,6 +503,51 @@ test.describe('KnowledgeBaseIngestionService.tenantConfig (#11637)', () => {
         expect(result.code).toBe('KB_INGEST_TENANT_MISMATCH');
         expect(result.error).toBe('Tenant config write failed');
         expect(graphStub.store.has('kb-config:tenant-b')).toBe(false);
+    });
+
+    test('setTenantManifest persists repo manifests without bumping KnowledgeBaseTenantConfig.version (#11711)', async () => {
+        await Service.setTenantConfig({tenantId: 'tenant-a', config: {customParsers: [{parserId: 'alpha'}]}});
+
+        const written = await Service.setTenantManifest({
+            tenantId      : 'tenant-a',
+            repoSlug      : 'repo-a',
+            pathsAfterPush: ['src/z.js', 'src/a.js', 'src/a.js']
+        });
+
+        expect(written).toMatchObject({
+            tenantId      : 'tenant-a',
+            repoSlug      : 'repo-a',
+            pathsAfterPush: ['src/a.js', 'src/z.js']
+        });
+
+        const node = graphStub.store.get('kb-manifest:tenant-a');
+        expect(node.type).toBe('KnowledgeBaseTenantManifest');
+        expect(node.properties.visibility).toBe('team');
+        expect(node.properties.manifests['repo-a'].pathsAfterPush).toEqual(['src/a.js', 'src/z.js']);
+
+        const manifest = await Service.getTenantManifest({tenantId: 'tenant-a', repoSlug: 'repo-a'});
+        expect(manifest).toMatchObject({
+            tenantId      : 'tenant-a',
+            repoSlug      : 'repo-a',
+            source        : 'graph',
+            pathsAfterPush: ['src/a.js', 'src/z.js']
+        });
+
+        expect((await Service.getTenantConfig({tenantId: 'tenant-a'})).version).toBe(1);
+    });
+
+    test('setTenantManifest rejects malformed path manifests without writing a graph node (#11711)', async () => {
+        const result = await Service.setTenantManifest({
+            tenantId      : 'tenant-a',
+            repoSlug      : 'repo-a',
+            pathsAfterPush: 'src/a.js'
+        });
+
+        expect(result).toMatchObject({
+            error: 'Tenant manifest write failed',
+            code : 'KB_TENANT_MANIFEST_INVALID'
+        });
+        expect(graphStub.store.has('kb-manifest:tenant-a')).toBe(false);
     });
 
     test('getTenantConfig falls back to the default registry when no graph node exists', async () => {


### PR DESCRIPTION
Resolves #11711

Authored by GPT-5 (Codex Desktop). Session d13c94dd-e721-4e28-ac9e-4d0b3c0f66de.

FAIR-band: over-target [18/30] - taking this lane despite over-target because #11711 is a narrow follow-up from my #11710 review findings, @neo-opus-4-7 is actively owning #11641, and the manifest-storage decision needed continuity from the intake Contract Ledger.

Adds durable KB claimed-state manifests and teaches the reconciliation daemon to classify manifest orphans alongside config-stale chunks. Push manifests are stored on a sibling `kb-manifest:<tenantId>` graph node keyed by `repoSlug`, not on `KnowledgeBaseTenantConfig`, so normal push activity does not bump the config `version` that #11640 uses as the config-staleness signal.

Cycle 2 adds the freshness boundary from review: persisted manifests only authorize deletion for chunks with finite `metadata.ingestedAt <= manifest.updatedAt`. Rows newer than the manifest, or rows missing `ingestedAt`, are skipped because the manifest cannot speak for content added by later bulk imports or minimal hooks.

Evidence: L2 (focused unit coverage for manifest persistence, manifest diffing, manifest freshness, daemon union/delete behavior, and static integration shape; Docker-backed scenario still skipped locally) -> L3 required for the Docker-backed force-push manifest integration. Residual: AC6 live Docker integration execution in CI/post-merge validation [#11711].

## Deltas From Ticket

- Finalized the provisional storage shape as `kb-manifest:<tenantId>` with `properties.manifests[repoSlug] = {repoSlug, pathsAfterPush, updatedAt}`.
- Kept manifest persistence separate from tenant config mutation to avoid false config-stale drift caused by routine push manifests.
- Added combined reconciliation telemetry fields while preserving the existing `staleCount` / `actionableCount` contract for #11640 consumers.
- Documented the durable manifest baseline and freshness window in the cloud hook guide and deletion-signaling contract.

## Test Evidence

- `node --check ai/services/knowledge-base/helpers/KbReconciliationEngine.mjs ai/daemons/KbReconciliationService.mjs ai/services/knowledge-base/KnowledgeBaseIngestionService.mjs test/playwright/unit/ai/services/knowledge-base/KbReconciliationEngine.spec.mjs test/playwright/unit/ai/daemons/KbReconciliationService.spec.mjs` - passed.
- `npm run test-unit -- test/playwright/unit/ai/services/knowledge-base/KbReconciliationEngine.spec.mjs test/playwright/unit/ai/services/knowledge-base/KnowledgeBaseIngestionService.spec.mjs test/playwright/unit/ai/daemons/KbReconciliationService.spec.mjs` - 65 passed.
- `npm run test-integration-unified -- test/playwright/integration/ai/kb-ingestion/multi-tenant.spec.mjs` - sandbox run failed to bind `127.0.0.1:13090` (`EPERM`); escalated rerun passed the fixture-shape test and skipped the Docker scenario because `docker` is unavailable on this host.
- `git diff --check` and `git diff --check HEAD~1..HEAD` - passed.
- Earlier full `npm run test-unit` attempt on this checkout: 1781 passed, 69 failed, 5 skipped, 41 did not run. Failures were outside the touched #11711 files (MCP/bridge/memory-core/grid areas already unhealthy in this checkout).

## Post-Merge Validation

- [ ] Confirm CI executes the Docker-backed `multi-tenant.spec.mjs` manifest-orphan scenario, or run it on a host with Docker available.

## Commits

- `cf6769017` - `feat(ai): reconcile KB manifest orphans (#11711)`
- `486d5154f` - `fix(ai): guard KB manifest freshness (#11711)`
