### PR TITLE
feat(ai): KB garbage-collection daemon — Phase 4C (#11641)

### DIFF
--- a/ai/config.template.mjs
+++ b/ai/config.template.mjs
@@ -143,7 +143,40 @@ const defaultConfig = {
          * one full config epoch of grace. Consulted only when `reconciliationAutoTombstone`.
          * @type {Number}
          */
-        reconciliationOrphanVersionGap: 2
+        reconciliationOrphanVersionGap: 2,
+        /**
+         * Phase 4C (#11641) — master opt-in for the KB garbage-collection daemon.
+         * Disabled by default; the daemon exits early when false.
+         * @type {Boolean}
+         */
+        gcEnabled: false,
+        /**
+         * Phase 4C (#11641) — GC daemon poll interval in ms (default 24 h).
+         * @type {Number}
+         */
+        gcIntervalMs: 24 * 60 * 60 * 1000,
+        /**
+         * Phase 4C (#11641) — retention policy: `{maxAgeMs?, maxCount?}`. A chunk is
+         * retention-expired if it is older than `maxAgeMs` (by its `ingestedAt` stamp) OR
+         * ranks beyond the `maxCount` most-recent of its `{tenantId, repoSlug}` bucket.
+         * Empty `{}` (the default) expires nothing — conservative.
+         * @type {Object}
+         */
+        gcRetention: {},
+        /**
+         * Phase 4C (#11641) — opt-in for the destructive GC delete. Disabled by default —
+         * the daemon then detects retention-expired chunks and emits telemetry only,
+         * issuing no `collection.delete`.
+         * @type {Boolean}
+         */
+        gcAutoDelete: false,
+        /**
+         * Phase 4C (#11641) — cumulative-deletion fraction above which a GC tick emits a
+         * `defrag-recommended` signal (operators should then run `ai:defrag-kb`). `0`
+         * disables the signal. V1 emits the signal only — it does not spawn defrag.
+         * @type {Number}
+         */
+        gcDefragThreshold: 0.10
     },
     /**
      * A dummy embedding function to satisfy ChromaDB when embeddings are provided manually.

--- a/ai/daemons/KbGarbageCollectionService.mjs
+++ b/ai/daemons/KbGarbageCollectionService.mjs
@@ -1,0 +1,406 @@
+// Class-only file (#11058-style split). Entry-point bootstrap (Neo + core/_export +
+// InstanceManager) lives in `ai/scripts/kb-gc-daemon.mjs` per the canonical Orchestrator
+// class+wrapper pattern. `Neo.setupClass(KbGarbageCollectionService)` at file bottom works
+// via `globalThis.Neo`, populated by the entry-point bootstrap chain.
+import Base                        from '../../src/core/Base.mjs';
+import {Memory_Config as aiConfig} from '../services.mjs';
+import ChromaManager               from '../services/knowledge-base/ChromaManager.mjs';
+import KBRecorderService           from '../services/knowledge-base/KBRecorderService.mjs';
+import logger                      from '../mcp/server/knowledge-base/logger.mjs';
+import {
+    formatGcDetail,
+    selectExpiredChunks
+} from '../services/knowledge-base/helpers/KbGarbageCollectionEngine.mjs';
+
+/**
+ * @summary Poll-interval fallback when `aiConfig.knowledgeBase.gcIntervalMs` is unset.
+ * @type {Number}
+ */
+const DEFAULT_INTERVAL_MS = 24 * 60 * 60 * 1000;
+
+/**
+ * @summary Chroma `collection.get` page size for the batched per-tenant rows fetch.
+ * @type {Number}
+ */
+const ROWS_PAGE_SIZE = 2000;
+
+/**
+ * @summary Phase 4C KB garbage-collection daemon — retention-policy chunk expiry (#11641).
+ *
+ * Closes part of the Phase 4 operability loop: a cloud KB accretes chunks indefinitely
+ * unless a retention policy bounds them. This daemon periodically evaluates each tenant's
+ * persisted Chroma chunks against an operator retention policy (time- and/or count-based,
+ * keyed on the #11712 `ingestedAt` chunk stamp), emits Phase 4A telemetry, and — opt-in —
+ * deletes the retention-expired chunks; when a tick's cumulative deletion is large it emits
+ * a `defrag-recommended` signal.
+ *
+ * **Shape** — the canonical poll-loop daemon (the `KbReconciliationService` / `KbAlertingService`
+ * precedent): a `Neo.core.Base` singleton with `start()` / `stop()` / `scheduleNext()` /
+ * `pulse()`. The entry-point wrapper `ai/scripts/kb-gc-daemon.mjs` owns the Neo bootstrap +
+ * SIGTERM.
+ *
+ * **Split** — the *pure* retention classification lives in `KbGarbageCollectionEngine.mjs`
+ * and is unit-tested in isolation; this class owns only the I/O: the poll loop, tenant
+ * enumeration, the Chroma read, telemetry emission, and the opt-in delete.
+ *
+ * **Opt-in** — `start()` is a no-op unless `aiConfig.knowledgeBase.gcEnabled` is true. The
+ * destructive delete is a *second* opt-in (`gcAutoDelete`, default false): with it off, the
+ * daemon detects retention-expired chunks + emits telemetry only and issues no
+ * `collection.delete`.
+ *
+ * **V1 scope** (per the #11641 Contract Ledger, ticket body): V1 = retention-policy chunk
+ * expiration + a `defrag-recommended` signal. Config-orphan detection is #11640's domain;
+ * a per-tenant retention override and the automated `ai:defrag-kb` spawn are V1.x-deferred.
+ * V1 is purely additive — it touches no merged Phase 2 code (it reuses only the documented
+ * `where: {tenantId}` Chroma read idiom).
+ *
+ * @class Neo.ai.daemons.KbGarbageCollectionService
+ * @extends Neo.core.Base
+ * @singleton
+ * @see ai/scripts/kb-gc-daemon.mjs — the entry-point wrapper.
+ * @see ai/services/knowledge-base/helpers/KbGarbageCollectionEngine.mjs — the pure retention engine.
+ * @see ai/daemons/KbReconciliationService.mjs — the sibling Phase 4B poll-loop daemon precedent (#11640).
+ */
+class KbGarbageCollectionService extends Base {
+    static config = {
+        /**
+         * @member {String} className='Neo.ai.daemons.KbGarbageCollectionService'
+         * @protected
+         */
+        className: 'Neo.ai.daemons.KbGarbageCollectionService',
+        /**
+         * @member {Boolean} singleton=true
+         * @protected
+         */
+        singleton: true,
+        /**
+         * Whether the poll loop is running.
+         * @member {Boolean} isPolling_=false
+         * @protected
+         * @reactive
+         */
+        isPolling_: false,
+        /**
+         * Active `setTimeout` handle for the next pulse; `null` when not scheduled.
+         * @member {Object|null} pollHandle_=null
+         * @protected
+         * @reactive
+         */
+        pollHandle_: null,
+        /**
+         * Interval between GC pulses in milliseconds.
+         * @member {Number} pollIntervalMs_=86400000
+         * @protected
+         * @reactive
+         */
+        pollIntervalMs_: DEFAULT_INTERVAL_MS
+    }
+
+    /**
+     * @summary Starts the GC poll loop. Idempotent; a no-op while already polling.
+     *
+     * Exits early (without scheduling) when `aiConfig.knowledgeBase.gcEnabled` is false —
+     * the daemon process then has nothing keeping the event loop alive and exits.
+     *
+     * @param {Object}  [options]
+     * @param {Number} [options.pollIntervalMs] Override the configured poll interval.
+     * @returns {Promise<void>}
+     */
+    async start({pollIntervalMs} = {}) {
+        if (this.isPolling) {
+            logger.debug('[KbGarbageCollectionService] Already polling; start() is a no-op.');
+            return;
+        }
+
+        const kbConfig = this.getKbConfig();
+
+        if (!kbConfig.gcEnabled) {
+            logger.info('[KbGarbageCollectionService] GC disabled (aiConfig.knowledgeBase.gcEnabled=false); not starting.');
+            return;
+        }
+
+        this.pollIntervalMs = pollIntervalMs || kbConfig.gcIntervalMs || DEFAULT_INTERVAL_MS;
+
+        await KBRecorderService.ready();
+
+        this.isPolling = true;
+        logger.info(`[KbGarbageCollectionService] Starting KB garbage collection (interval: ${this.pollIntervalMs}ms)`);
+
+        this.scheduleNext()
+    }
+
+    /**
+     * @summary Stops the poll loop. Idempotent. Cancels any pending pulse so a clean
+     * SIGTERM under launchd/systemd does not leave a timer wedging the event loop.
+     * @returns {void}
+     */
+    stop() {
+        if (this.pollHandle) {
+            clearTimeout(this.pollHandle);
+            this.pollHandle = null
+        }
+        this.isPolling = false;
+        logger.info('[KbGarbageCollectionService] Garbage collection stopped.')
+    }
+
+    /**
+     * @summary Schedules the next pulse. Called after each pulse settles so a single
+     * thrown error never breaks the loop.
+     * @returns {void}
+     * @protected
+     */
+    scheduleNext() {
+        if (!this.isPolling) return;
+
+        this.pollHandle = setTimeout(() => this.pulse().catch(err => {
+            logger.error('[KbGarbageCollectionService] Pulse threw uncaught error:', err);
+            this.scheduleNext()
+        }), this.pollIntervalMs)
+    }
+
+    /**
+     * @summary Executes one GC pulse: enumerate tenants → per-tenant retention diff →
+     * opt-in delete → telemetry → `defrag-recommended` signal.
+     *
+     * Two-pass: the per-tenant pass collects each tenant's diff + delete count; the
+     * `defrag-recommended` decision (a whole-collection fraction) is then computable, so the
+     * telemetry pass can stamp it onto every tenant's `reconcile`-class detail. Wrapped in
+     * try/catch/finally so a failed cycle is logged and `scheduleNext()` still fires.
+     *
+     * @returns {Promise<void>}
+     * @protected
+     */
+    async pulse() {
+        try {
+            const kbConfig    = this.getKbConfig(),
+                  retention   = kbConfig.gcRetention,
+                  autoDelete  = kbConfig.gcAutoDelete === true,
+                  defragGate  = Number.isFinite(kbConfig.gcDefragThreshold) ? kbConfig.gcDefragThreshold : 0,
+                  tenants     = await this.fetchTenants();
+
+            if (tenants.length === 0) {
+                return // no tenants have ingestion telemetry yet → nothing to collect
+            }
+
+            const collection      = await this.getCollection(),
+                  collectionCount = await this.getCollectionCount(collection),
+                  now             = Date.now(),
+                  results         = [];
+
+            for (const tenant of tenants) {
+                const result = await this.collectTenant({...tenant, collection, retention, autoDelete, now});
+
+                if (result) {
+                    results.push(result)
+                }
+            }
+
+            const totalDeleted      = results.reduce((sum, r) => sum + r.deletedCount, 0),
+                  defragRecommended = defragGate > 0 && collectionCount > 0 &&
+                                      totalDeleted / collectionCount > defragGate;
+
+            for (const result of results) {
+                if (result.diff.expiredCount > 0) {
+                    this.recordGcMetric({...result, retention, autoDelete, defragRecommended})
+                }
+            }
+
+            if (defragRecommended) {
+                logger.warn(`[KbGarbageCollectionService] defrag-recommended — cumulative deletion ${totalDeleted}/${collectionCount} exceeded gcDefragThreshold ${defragGate}; an operator should run \`npm run ai:defrag-kb\``)
+            }
+
+            logger.debug(`[KbGarbageCollectionService] Pulse complete — ${tenants.length} tenant(s), ${totalDeleted} chunk(s) deleted (autoDelete=${autoDelete})`)
+        } catch (err) {
+            // A single-cycle failure must not stop the daemon — log and let `finally`
+            // reschedule. Catching here also keeps `pulse()` from rejecting, so the loop
+            // never double-schedules (the `finally` + `scheduleNext`'s own `.catch`).
+            logger.error('[KbGarbageCollectionService] Pulse failed:', err)
+        } finally {
+            this.scheduleNext()
+        }
+    }
+
+    /**
+     * @summary Garbage-collects one tenant: retention diff → opt-in delete. Returns the
+     * per-tenant result for the caller's telemetry + defrag-fraction passes; telemetry is
+     * emitted by {@link pulse}, not here, because `defragRecommended` is a post-loop fact.
+     *
+     * Never throws — a per-tenant failure (a Chroma error) is logged and `null` is returned
+     * so the remaining tenants still collect.
+     *
+     * @param {Object}  params
+     * @param {String}  params.tenantId
+     * @param {String}  params.repoSlug   Representative repo slug for the telemetry row.
+     * @param {Object}  params.collection The Chroma `knowledge-base` collection.
+     * @param {*}       params.retention  The operator `gcRetention` policy.
+     * @param {Boolean} params.autoDelete Whether the opt-in delete path is enabled.
+     * @param {Number}  params.now        Pulse-wide epoch ms (one clock read per tick).
+     * @returns {Promise<{tenantId: String, repoSlug: String, diff: Object, deletedCount: Number}|null>}
+     * @protected
+     */
+    async collectTenant({tenantId, repoSlug, collection, retention, autoDelete, now}) {
+        try {
+            const rows = await this.fetchTenantRows(collection, tenantId),
+                  diff = selectExpiredChunks({rows, retention, now});
+
+            let deletedCount = 0;
+
+            if (diff.expiredCount > 0 && autoDelete) {
+                deletedCount = await this.deleteChunks(collection, diff.expiredIds)
+            }
+
+            if (diff.expiredCount > 0) {
+                logger.info(`[KbGarbageCollectionService] tenant ${tenantId}: ${diff.expiredCount} retention-expired chunk(s) of ${diff.evaluatedCount}, ${deletedCount} deleted (autoDelete=${autoDelete})`)
+            }
+
+            return {tenantId, repoSlug, diff, deletedCount}
+        } catch (err) {
+            logger.error(`[KbGarbageCollectionService] GC failed for tenant ${tenantId}: ${err.message}`);
+            return null
+        }
+    }
+
+    /**
+     * @summary Test-stubbable seam over `aiConfig.knowledgeBase`.
+     *
+     * Reads defensively: a stale gitignored `ai/config.mjs` predating #11641 lacks the `gc*`
+     * keys, so a naked `aiConfig.knowledgeBase.gcEnabled` would throw. Returns `{}` when the
+     * `knowledgeBase` key is absent.
+     *
+     * @returns {Object}
+     * @protected
+     */
+    getKbConfig() {
+        return aiConfig.knowledgeBase || {}
+    }
+
+    /**
+     * @summary Test-stubbable seam — enumerates the tenants to garbage-collect.
+     *
+     * The substrate-real tenant list is the distinct `tenantId` set of
+     * `KBRecorderService.getTenantIngestionRollup()` (all-time) — every tenant that has ever
+     * ingested. Deduped to one entry per tenant; the first-seen `repoSlug` is the
+     * representative slug for that tenant's telemetry row.
+     *
+     * @returns {Promise<Array<{tenantId: String, repoSlug: String}>>}
+     * @protected
+     */
+    async fetchTenants() {
+        const rollup = KBRecorderService.getTenantIngestionRollup() || [],
+              seen   = new Map();
+
+        for (const row of rollup) {
+            if (row?.tenantId && !seen.has(row.tenantId)) {
+                seen.set(row.tenantId, row.repoSlug || 'neo')
+            }
+        }
+
+        return [...seen].map(([tenantId, repoSlug]) => ({tenantId, repoSlug}))
+    }
+
+    /**
+     * @summary Test-stubbable seam over `ChromaManager.getKnowledgeBaseCollection`.
+     * @returns {Promise<Object>} The Chroma `knowledge-base` collection.
+     * @protected
+     */
+    async getCollection() {
+        return ChromaManager.getKnowledgeBaseCollection()
+    }
+
+    /**
+     * @summary Test-stubbable seam — the collection's total chunk count (the
+     * `defrag-recommended` fraction denominator).
+     * @param {Object} collection The Chroma `knowledge-base` collection.
+     * @returns {Promise<Number>}
+     * @protected
+     */
+    async getCollectionCount(collection) {
+        return (await collection.count?.()) || 0
+    }
+
+    /**
+     * @summary Test-stubbable seam — fetches all of a tenant's Chroma rows, batched.
+     *
+     * Mirrors the batched `collection.get({where: {tenantId}})` idiom of
+     * `KnowledgeBaseIngestionService.getTenantRows`; kept local (rather than calling that
+     * `@protected` method) so V1 touches zero merged Phase 2 code.
+     *
+     * @param {Object} collection The Chroma `knowledge-base` collection.
+     * @param {String} tenantId
+     * @returns {Promise<Array<{id: String, metadata: Object}>>}
+     * @protected
+     */
+    async fetchTenantRows(collection, tenantId) {
+        const rows = [];
+        let   offset = 0,
+              batch;
+
+        do {
+            batch = await collection.get({
+                include: ['metadatas'],
+                limit  : ROWS_PAGE_SIZE,
+                offset,
+                where  : {tenantId}
+            });
+
+            for (let i = 0; i < (batch.ids?.length || 0); i++) {
+                rows.push({id: batch.ids[i], metadata: batch.metadatas?.[i] || {}})
+            }
+
+            offset += ROWS_PAGE_SIZE
+        } while ((batch.ids?.length || 0) === ROWS_PAGE_SIZE);
+
+        return rows
+    }
+
+    /**
+     * @summary Test-stubbable seam — deletes the retention-expired chunk ids from Chroma.
+     * @param {Object}        collection The Chroma `knowledge-base` collection.
+     * @param {Array<String>} ids        Tenant-scoped retention-expired chunk ids.
+     * @returns {Promise<Number>} Count of ids deleted.
+     * @protected
+     */
+    async deleteChunks(collection, ids) {
+        if (!Array.isArray(ids) || ids.length === 0) {
+            return 0
+        }
+
+        await collection.delete({ids});
+
+        return ids.length
+    }
+
+    /**
+     * @summary Test-stubbable seam — emits one Phase 4A `tombstone` telemetry event.
+     *
+     * `recordIngestionMetric` is best-effort (never throws into the caller). A GC delete is
+     * a `'tombstone'`-class event — the telemetry taxonomy has no dedicated `'gc'` type, so
+     * `'tombstone'` (a logical deletion) is the honest fit; the rolled-up `tombstoneEvents` /
+     * `chunksDeleted` fields are already `KbAlertRuleEngine.KNOWN_METRICS` surfaces.
+     *
+     * @param {Object}  params
+     * @param {String}  params.tenantId
+     * @param {String}  params.repoSlug
+     * @param {Object}  params.diff              A {@link selectExpiredChunks} result.
+     * @param {Number}  params.deletedCount
+     * @param {*}       params.retention
+     * @param {Boolean} params.autoDelete
+     * @param {Boolean} params.defragRecommended
+     * @returns {void}
+     * @protected
+     */
+    recordGcMetric({tenantId, repoSlug, diff, deletedCount, retention, autoDelete, defragRecommended}) {
+        KBRecorderService.recordIngestionMetric?.({
+            tenantId,
+            repoSlug,
+            eventType    : 'tombstone',
+            chunksTotal  : diff.expiredCount,
+            chunksDeleted: deletedCount,
+            detail       : formatGcDetail({diff, retention, gcAutoDelete: autoDelete, deletedCount, defragRecommended})
+        })
+    }
+}
+
+export default Neo.setupClass(KbGarbageCollectionService);
+
+export {DEFAULT_INTERVAL_MS, ROWS_PAGE_SIZE};

--- a/ai/scripts/kb-gc-daemon.mjs
+++ b/ai/scripts/kb-gc-daemon.mjs
@@ -1,0 +1,46 @@
+/**
+ * @module ai/scripts/kb-gc-daemon
+ * @summary Thin Node-process boot wrapper for the Phase 4C KB garbage-collection daemon (#11641).
+ *
+ * Owns Neo namespace bootstrap + SIGTERM / SIGINT clean-stop signal handling +
+ * `KbGarbageCollectionService.start()` invocation. The class definition (poll loop, tenant
+ * enumeration, retention diff, opt-in delete, the defrag-recommended signal) lives in
+ * `ai/daemons/KbGarbageCollectionService.mjs`.
+ *
+ * This split matches the canonical Orchestrator class+wrapper pattern: class files in
+ * `ai/daemons/` never import Neo; entry-point scripts in `ai/scripts/` own the Neo +
+ * core/_export + InstanceManager bootstrap chain.
+ *
+ * Persistent-process invocation: launchd / systemd should target this script
+ * (`node ai/scripts/kb-gc-daemon.mjs`), or `npm run ai:kb-gc`. The daemon is opt-in — it
+ * exits early unless `aiConfig.knowledgeBase.gcEnabled` is true; the destructive delete is a
+ * second opt-in (`gcAutoDelete`).
+ *
+ * @see ai/daemons/KbGarbageCollectionService.mjs
+ * @see ai/scripts/kb-reconciliation-daemon.mjs (sibling wrapper precedent)
+ * @see #11641 (Phase 4C GC daemon), #11628 (Phase 4 epic)
+ */
+
+// Neo namespace bootstrap (entry-point invariant): `Neo` + `core/_export` populate
+// `globalThis.Neo` so any module using `Neo.gatekeep()` / `Neo.setupClass()` at
+// module-load succeeds. `InstanceManager` binds `Neo.find` / `Neo.get` aliases.
+import Neo             from '../../src/Neo.mjs';
+import * as core       from '../../src/core/_export.mjs';
+import InstanceManager from '../../src/manager/Instance.mjs';
+
+import logger                    from '../mcp/server/knowledge-base/logger.mjs';
+import KbGarbageCollectionService from '../daemons/KbGarbageCollectionService.mjs';
+
+const cleanShutdown = signal => {
+    logger.info(`[KbGarbageCollectionService] Received ${signal}; stopping.`);
+    KbGarbageCollectionService.stop();
+    process.exit(0);
+};
+
+process.on('SIGTERM', () => cleanShutdown('SIGTERM'));
+process.on('SIGINT',  () => cleanShutdown('SIGINT'));
+
+KbGarbageCollectionService.start().catch(err => {
+    logger.error('[KbGarbageCollectionService] Daemon start failed:', err);
+    process.exit(1);
+});

--- a/ai/services/knowledge-base/helpers/KbGarbageCollectionEngine.mjs
+++ b/ai/services/knowledge-base/helpers/KbGarbageCollectionEngine.mjs
@@ -1,0 +1,161 @@
+/**
+ * @summary Pure retention-expiry classification engine for the Phase 4C KB GC daemon (#11641).
+ *
+ * Phase 4C (#11641) substrate. The cloud KB garbage-collection daemon
+ * (`KbGarbageCollectionService`) periodically evaluates each tenant's persisted Chroma
+ * chunks against an operator retention policy and (opt-in) deletes the expired ones. This
+ * module is the **pure core** of that daemon — no I/O, no clock, no service references — so
+ * the retention classification is trivially unit-testable in isolation.
+ *
+ * **The retention signal.** Every chunk is stamped at ingest with `ingestedAt` (epoch ms,
+ * #11712 / `VectorService.resolveTenantStamp`). A retention policy expires chunks under
+ * **OR-expiry** — a chunk is expired if it is *time-expired* OR *count-expired* (the union,
+ * the broader set):
+ * - **time-expired** — `now − ingestedAt > maxAgeMs` (per chunk, repo-independent).
+ * - **count-expired** — beyond the `maxCount` most-recent chunks of its `{tenantId, repoSlug}`
+ *   bucket, ranked `ingestedAt` desc then chunk `id` asc (a deterministic tie-breaker —
+ *   batch-ingested chunks share an `ingestedAt`). Per-bucket so one repo cannot crowd another
+ *   out of a tenant's count budget.
+ *
+ * A chunk with a missing / non-numeric `ingestedAt` (a pre-#11712 ingest) is **never**
+ * expired — fail-safe: an unknown-age chunk is unrankable and unaged, so it is excluded from
+ * both expiry paths (mirrors #11640's missing-`tenantConfigVersion` skip).
+ *
+ * The daemon owns the I/O: it enumerates tenants, reads the retention config, fetches each
+ * tenant's Chroma rows, calls this engine, emits Phase 4A telemetry, and (opt-in) issues the
+ * `collection.delete`. This module only *classifies*.
+ *
+ * @see ai/daemons/KbGarbageCollectionService.mjs — the daemon that consumes this engine.
+ * @see ai/services/knowledge-base/VectorService.mjs — `resolveTenantStamp`, the `ingestedAt` stamp (#11712).
+ * @see ai/services/knowledge-base/helpers/KbReconciliationEngine.mjs — the sibling pure-helper precedent (#11640).
+ */
+
+/**
+ * @summary Normalizes an operator retention policy to a safe `{maxAgeMs, maxCount}` shape.
+ *
+ * Each dimension independently degrades to `null` (disabled) when absent or invalid, so a
+ * malformed `aiConfig` key never corrupts the partition:
+ * - `maxAgeMs` — a finite number `> 0`, else `null`.
+ * - `maxCount` — a non-negative integer, else `null`. `0` is valid (retain none).
+ *
+ * @param {*} retention Raw `gcRetention` config value.
+ * @returns {{maxAgeMs: Number|null, maxCount: Number|null}}
+ */
+export function resolveRetention(retention) {
+    const r = retention && typeof retention === 'object' ? retention : {};
+
+    return {
+        maxAgeMs: Number.isFinite(r.maxAgeMs) && r.maxAgeMs > 0       ? r.maxAgeMs : null,
+        maxCount: Number.isInteger(r.maxCount) && r.maxCount >= 0     ? r.maxCount : null
+    };
+}
+
+/**
+ * @summary Classifies one tenant's Chroma rows into retention-expired chunks.
+ *
+ * Pure — no I/O, no clock (the caller passes `now`). Returns the union of the time-expired
+ * and count-expired sets (OR-expiry); see the module header for the two rules. The fail-safe
+ * for a missing / non-numeric `ingestedAt` is applied to both paths.
+ *
+ * @param {Object} params
+ * @param {Array<{id: String, metadata: Object}>} params.rows  Tenant Chroma rows (the
+ *        `getTenantRows` shape — `{id, metadata}`; `metadata` carries `ingestedAt`,
+ *        `tenantId`, `repoSlug`).
+ * @param {*}      params.retention  The operator retention policy; normalized via {@link resolveRetention}.
+ * @param {Number} params.now        Current epoch ms (caller-supplied; keeps this pure).
+ * @returns {{expiredIds: Array<String>, expiredCount: Number, evaluatedCount: Number}}
+ */
+export function selectExpiredChunks({rows, retention, now} = {}) {
+    if (!Array.isArray(rows) || rows.length === 0) {
+        return {expiredIds: [], expiredCount: 0, evaluatedCount: 0};
+    }
+
+    const policy = resolveRetention(retention);
+
+    // No usable retention dimension → nothing expires (the conservative empty-policy default).
+    if (policy.maxAgeMs === null && policy.maxCount === null) {
+        return {expiredIds: [], expiredCount: 0, evaluatedCount: rows.length};
+    }
+
+    const expired = new Set();
+
+    // Time-expiry — per chunk, repo-independent. A missing / non-numeric `ingestedAt` is
+    // unaged → never flagged (fail-safe).
+    if (policy.maxAgeMs !== null && typeof now === 'number') {
+        for (const row of rows) {
+            const ingestedAt = row?.metadata?.ingestedAt;
+
+            if (typeof ingestedAt === 'number' && now - ingestedAt > policy.maxAgeMs) {
+                expired.add(row.id)
+            }
+        }
+    }
+
+    // Count-expiry — bucket by `{tenantId, repoSlug}`, retain the `maxCount` most-recent per
+    // bucket. A missing / non-numeric `ingestedAt` is unrankable → excluded from the bucket
+    // (never flagged — fail-safe).
+    if (policy.maxCount !== null) {
+        const buckets = new Map();
+
+        for (const row of rows) {
+            if (typeof row?.metadata?.ingestedAt !== 'number') {
+                continue
+            }
+
+            const key = `${row.metadata.tenantId ?? ''}|${row.metadata.repoSlug ?? ''}`;
+
+            if (!buckets.has(key)) {
+                buckets.set(key, [])
+            }
+
+            buckets.get(key).push(row)
+        }
+
+        for (const bucket of buckets.values()) {
+            // `ingestedAt` desc, then chunk `id` asc — a deterministic tie-breaker so
+            // batch-ingested chunks (which share an `ingestedAt`) rank stably.
+            bucket.sort((a, b) => {
+                const byAge = b.metadata.ingestedAt - a.metadata.ingestedAt;
+
+                if (byAge !== 0) return byAge;
+
+                return a.id < b.id ? -1 : a.id > b.id ? 1 : 0
+            });
+
+            for (let i = policy.maxCount; i < bucket.length; i++) {
+                expired.add(bucket[i].id)
+            }
+        }
+    }
+
+    return {
+        expiredIds    : [...expired],
+        expiredCount  : expired.size,
+        evaluatedCount: rows.length
+    };
+}
+
+/**
+ * @summary Builds the Phase 4A telemetry `detail` payload for one tenant's GC tick.
+ *
+ * Pure — kept here (not in the daemon) so the telemetry shape is unit-testable. The daemon
+ * passes the returned object straight to `KBRecorderService.recordIngestionMetric`'s `detail`.
+ *
+ * @param {Object}  params
+ * @param {{expiredCount: Number, evaluatedCount: Number}} params.diff  A {@link selectExpiredChunks} result.
+ * @param {*}       params.retention          The operator retention policy (normalized into the payload).
+ * @param {Boolean} params.gcAutoDelete       Whether the daemon's opt-in delete path is enabled.
+ * @param {Number} [params.deletedCount=0]    Chunks actually deleted this tick (`0` when auto-delete is off).
+ * @param {Boolean} [params.defragRecommended=false] Whether this tick crossed the defrag-recommended threshold.
+ * @returns {{expiredCount: Number, evaluatedCount: Number, deletedCount: Number, retention: Object, gcAutoDelete: Boolean, defragRecommended: Boolean}}
+ */
+export function formatGcDetail({diff, retention, gcAutoDelete, deletedCount = 0, defragRecommended = false} = {}) {
+    return {
+        expiredCount     : diff?.expiredCount   ?? 0,
+        evaluatedCount   : diff?.evaluatedCount ?? 0,
+        deletedCount     : Number.isFinite(deletedCount) ? deletedCount : 0,
+        retention        : resolveRetention(retention),
+        gcAutoDelete     : gcAutoDelete === true,
+        defragRecommended: defragRecommended === true
+    };
+}

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
         "ai:lint-skill-manifest"       : "node ./ai/scripts/lint-skill-manifest.mjs",
         "ai:kb-alerting"               : "node ./ai/scripts/kb-alerting-daemon.mjs",
         "ai:kb-reconciliation"         : "node ./ai/scripts/kb-reconciliation-daemon.mjs",
+        "ai:kb-gc"                     : "node ./ai/scripts/kb-gc-daemon.mjs",
         "ai:orchestrator"              : "node ./ai/scripts/orchestrator-daemon.mjs",
         "ai:run-sandman"               : "node ./buildScripts/ai/runSandman.mjs",
         "ai:server"                    : "chroma run --path ./.neo-ai-data/chroma/knowledge-base",

--- a/test/playwright/unit/ai/daemons/KbGarbageCollectionService.spec.mjs
+++ b/test/playwright/unit/ai/daemons/KbGarbageCollectionService.spec.mjs
@@ -1,0 +1,379 @@
+import {setup} from '../../../setup.mjs';
+
+const appName = 'KbGarbageCollectionServiceTest';
+
+setup({
+    neoConfig: {
+        unitTestMode: true
+    },
+    appConfig: {
+        name             : appName,
+        isMounted        : () => true,
+        vnodeInitialising: false
+    }
+});
+
+// Test-side entry-point bootstrap: Neo + core/_export populate `globalThis.Neo` before the
+// dynamic KbGarbageCollectionService import below. Required because the class file no longer
+// imports Neo itself (#11058-style class+wrapper split). Mirrors KbReconciliationService.spec.
+import Neo       from '../../../../../src/Neo.mjs';
+import * as core from '../../../../../src/core/_export.mjs';
+
+import {test, expect} from '@playwright/test';
+
+/**
+ * Phase 4C (#11641) — unit coverage for `ai/daemons/KbGarbageCollectionService.mjs`, the KB
+ * garbage-collection daemon.
+ *
+ * Stubbing strategy mirrors `KbReconciliationService.spec.mjs`: the daemon exposes
+ * test-stubbable instance-method seams (`getKbConfig`, `fetchTenants`, `getCollection`,
+ * `getCollectionCount`, `fetchTenantRows`, `deleteChunks`, `recordGcMetric`, `collectTenant`,
+ * `scheduleNext`) so tests override them on the singleton without real config / SQLite /
+ * Chroma I/O. The `collectTenant` tests keep the real method + the real pure
+ * `KbGarbageCollectionEngine` so the retention-diff branching is genuinely exercised.
+ *
+ * Covers the #11641 Contract Ledger Evidence columns: the opt-in gate, the destructive
+ * auto-delete gating, the clean-tenant telemetry suppression, the `defrag-recommended`
+ * threshold signal, and pulse resilience. The pure retention logic is covered separately in
+ * `KbGarbageCollectionEngine.spec.mjs`.
+ *
+ * @see https://github.com/neomjs/neo/issues/11641
+ * @see ai/daemons/KbGarbageCollectionService.mjs — the daemon under test.
+ * @see test/playwright/unit/ai/daemons/KbReconciliationService.spec.mjs — the sibling pattern.
+ */
+test.describe('Neo.ai.daemons.KbGarbageCollectionService (#11641)', () => {
+    let KbGarbageCollectionService, DEFAULT_INTERVAL_MS;
+    let KBRecorderService, logger;
+    let originals = {};
+
+    /** Builds a tenant Chroma row in the `fetchTenantRows` shape. */
+    const row = (id, ingestedAt, repoSlug = 'repo-x') => ({
+        id, metadata: {ingestedAt, tenantId: 'tenant-x', repoSlug}
+    });
+
+    test.beforeAll(async () => {
+        ({default: KbGarbageCollectionService, DEFAULT_INTERVAL_MS} =
+            await import('../../../../../ai/daemons/KbGarbageCollectionService.mjs'));
+
+        KBRecorderService = (await import('../../../../../ai/services/knowledge-base/KBRecorderService.mjs')).default;
+        logger            = (await import('../../../../../ai/mcp/server/knowledge-base/logger.mjs')).default;
+
+        originals = {
+            recorderReady        : KBRecorderService.ready,
+            getTenantIngestion   : KBRecorderService.getTenantIngestionRollup,
+            recordIngestionMetric: KBRecorderService.recordIngestionMetric,
+            warn                 : logger.warn,
+            error                : logger.error,
+            info                 : logger.info,
+            debug                : logger.debug
+        };
+
+        // `start()` awaits KBRecorderService.ready() — stub it to resolve immediately.
+        KBRecorderService.ready = async () => {};
+    });
+
+    test.afterAll(() => {
+        KBRecorderService.ready                    = originals.recorderReady;
+        KBRecorderService.getTenantIngestionRollup = originals.getTenantIngestion;
+        KBRecorderService.recordIngestionMetric    = originals.recordIngestionMetric;
+    });
+
+    test.afterEach(() => {
+        KbGarbageCollectionService.stop();
+        KbGarbageCollectionService.isPolling      = false;
+        KbGarbageCollectionService.pollIntervalMs = DEFAULT_INTERVAL_MS;
+
+        // Drop instance-method seam overrides so the real prototype methods resurface for the
+        // next test — an instance override otherwise leaks across tests in the worker.
+        for (const seam of ['getKbConfig', 'fetchTenants', 'getCollection', 'getCollectionCount',
+                             'fetchTenantRows', 'deleteChunks', 'recordGcMetric', 'collectTenant',
+                             'scheduleNext']) {
+            delete KbGarbageCollectionService[seam];
+        }
+
+        KBRecorderService.getTenantIngestionRollup = originals.getTenantIngestion;
+        KBRecorderService.recordIngestionMetric    = originals.recordIngestionMetric;
+        logger.warn  = originals.warn;
+        logger.error = originals.error;
+        logger.info  = originals.info;
+        logger.debug = originals.debug;
+    });
+
+    /** Deterministic seam baseline — `scheduleNext` neutralized so no real timer leaks. */
+    function applyStubs({config} = {}) {
+        KbGarbageCollectionService.getKbConfig  = () => config || {gcEnabled: true};
+        KbGarbageCollectionService.scheduleNext = function () {};
+    }
+
+    test.describe('start / stop', () => {
+        test('start() is a no-op when gcEnabled is false', async () => {
+            applyStubs({config: {gcEnabled: false}});
+            let scheduled = 0;
+            KbGarbageCollectionService.scheduleNext = () => { scheduled++ };
+
+            await KbGarbageCollectionService.start();
+
+            expect(KbGarbageCollectionService.isPolling).toBe(false);
+            expect(scheduled).toBe(0);
+        });
+
+        test('start() schedules when enabled and is idempotent', async () => {
+            applyStubs();
+            let scheduled = 0;
+            KbGarbageCollectionService.scheduleNext = () => { scheduled++ };
+
+            await KbGarbageCollectionService.start();
+            expect(KbGarbageCollectionService.isPolling).toBe(true);
+            expect(scheduled).toBe(1);
+
+            await KbGarbageCollectionService.start();
+            expect(scheduled).toBe(1); // second start() is a no-op
+        });
+
+        test('start() honors a configured gcIntervalMs', async () => {
+            applyStubs({config: {gcEnabled: true, gcIntervalMs: 54321}});
+
+            await KbGarbageCollectionService.start();
+
+            expect(KbGarbageCollectionService.pollIntervalMs).toBe(54321);
+        });
+
+        test('stop() clears the poll handle and is idempotent', async () => {
+            applyStubs();
+            KbGarbageCollectionService.scheduleNext = function () { this.pollHandle = setTimeout(() => {}, 60_000) };
+
+            await KbGarbageCollectionService.start();
+            expect(KbGarbageCollectionService.pollHandle).not.toBeNull();
+
+            KbGarbageCollectionService.stop();
+            expect(KbGarbageCollectionService.pollHandle).toBeNull();
+            expect(KbGarbageCollectionService.isPolling).toBe(false);
+            expect(() => KbGarbageCollectionService.stop()).not.toThrow();
+        });
+    });
+
+    test.describe('pulse', () => {
+        test('returns early without fetching the collection when no tenants exist', async () => {
+            applyStubs();
+            KbGarbageCollectionService.fetchTenants = async () => [];
+            let collectionFetched = 0;
+            KbGarbageCollectionService.getCollection = async () => { collectionFetched++; return {} };
+
+            await KbGarbageCollectionService.pulse();
+
+            expect(collectionFetched).toBe(0);
+        });
+
+        test('collects each enumerated tenant', async () => {
+            applyStubs();
+            KbGarbageCollectionService.fetchTenants       = async () => [
+                {tenantId: 'tenant-a', repoSlug: 'repo-a'},
+                {tenantId: 'tenant-b', repoSlug: 'repo-b'}
+            ];
+            KbGarbageCollectionService.getCollection      = async () => ({});
+            KbGarbageCollectionService.getCollectionCount = async () => 100;
+            const collected = [];
+            KbGarbageCollectionService.collectTenant = async ({tenantId, repoSlug}) => {
+                collected.push(tenantId);
+                return {tenantId, repoSlug, diff: {expiredCount: 0}, deletedCount: 0};
+            };
+
+            await KbGarbageCollectionService.pulse();
+
+            expect(collected.sort()).toEqual(['tenant-a', 'tenant-b']);
+        });
+
+        test('reschedules from the finally block even when getCollection throws', async () => {
+            applyStubs();
+            KbGarbageCollectionService.fetchTenants  = async () => [{tenantId: 't', repoSlug: 'r'}];
+            KbGarbageCollectionService.getCollection = async () => { throw new Error('chroma down') };
+            let rescheduled = 0;
+            KbGarbageCollectionService.scheduleNext = () => { rescheduled++ };
+
+            await expect(KbGarbageCollectionService.pulse()).resolves.toBeUndefined();
+            expect(rescheduled).toBe(1);
+        });
+
+        test('a null (failed) tenant result does not block telemetry for the rest', async () => {
+            applyStubs();
+            KbGarbageCollectionService.fetchTenants       = async () => [
+                {tenantId: 'tenant-bad', repoSlug: 'r'},
+                {tenantId: 'tenant-ok',  repoSlug: 'r'}
+            ];
+            KbGarbageCollectionService.getCollection      = async () => ({});
+            KbGarbageCollectionService.getCollectionCount = async () => 100;
+            KbGarbageCollectionService.collectTenant = async ({tenantId, repoSlug}) => {
+                if (tenantId === 'tenant-bad') return null; // simulate a caught per-tenant failure
+                return {tenantId, repoSlug, diff: {expiredCount: 3}, deletedCount: 0};
+            };
+            const metrics = [];
+            KbGarbageCollectionService.recordGcMetric = (m) => { metrics.push(m) };
+
+            await expect(KbGarbageCollectionService.pulse()).resolves.toBeUndefined();
+
+            expect(metrics).toHaveLength(1);
+            expect(metrics[0].tenantId).toBe('tenant-ok');
+        });
+
+        test('emits a defrag-recommended warning when cumulative deletion exceeds the threshold', async () => {
+            applyStubs({config: {gcEnabled: true, gcAutoDelete: true, gcDefragThreshold: 0.10}});
+            KbGarbageCollectionService.fetchTenants       = async () => [{tenantId: 'tenant-x', repoSlug: 'repo-x'}];
+            KbGarbageCollectionService.getCollection      = async () => ({});
+            KbGarbageCollectionService.getCollectionCount = async () => 100;
+            KbGarbageCollectionService.collectTenant      = async ({tenantId, repoSlug}) =>
+                ({tenantId, repoSlug, diff: {expiredCount: 20}, deletedCount: 20});
+            KbGarbageCollectionService.recordGcMetric = () => {};
+            const warns = [];
+            logger.warn = (msg) => { warns.push(msg) };
+
+            await KbGarbageCollectionService.pulse();
+
+            // 20 deleted / 100 collection = 0.20 > 0.10 → defrag-recommended.
+            expect(warns.some(w => String(w).includes('defrag-recommended'))).toBe(true);
+        });
+
+        test('stays silent on defrag when cumulative deletion is below the threshold', async () => {
+            applyStubs({config: {gcEnabled: true, gcAutoDelete: true, gcDefragThreshold: 0.10}});
+            KbGarbageCollectionService.fetchTenants       = async () => [{tenantId: 'tenant-x', repoSlug: 'repo-x'}];
+            KbGarbageCollectionService.getCollection      = async () => ({});
+            KbGarbageCollectionService.getCollectionCount = async () => 100;
+            KbGarbageCollectionService.collectTenant      = async ({tenantId, repoSlug}) =>
+                ({tenantId, repoSlug, diff: {expiredCount: 5}, deletedCount: 5});
+            KbGarbageCollectionService.recordGcMetric = () => {};
+            const warns = [];
+            logger.warn = (msg) => { warns.push(msg) };
+
+            await KbGarbageCollectionService.pulse();
+
+            // 5 / 100 = 0.05 < 0.10 → no defrag-recommended.
+            expect(warns.some(w => String(w).includes('defrag-recommended'))).toBe(false);
+        });
+    });
+
+    test.describe('collectTenant', () => {
+        const baseArgs = {tenantId: 'tenant-x', repoSlug: 'repo-x', collection: {}, now: 100_000};
+
+        test('a clean tenant (nothing expired) issues no delete', async () => {
+            applyStubs();
+            KbGarbageCollectionService.fetchTenantRows = async () => [row('a', 99_000), row('b', 98_000), row('c', 97_000)];
+            let deleted = 0;
+            KbGarbageCollectionService.deleteChunks = async () => { deleted++; return 0 };
+
+            const result = await KbGarbageCollectionService.collectTenant({...baseArgs, retention: {maxCount: 5}, autoDelete: true});
+
+            expect(result.diff.expiredCount).toBe(0);
+            expect(result.deletedCount).toBe(0);
+            expect(deleted).toBe(0);
+        });
+
+        test('expired chunks with auto-delete OFF are detected but not deleted', async () => {
+            applyStubs();
+            KbGarbageCollectionService.fetchTenantRows = async () => [row('r1', 5), row('r2', 4), row('r3', 3)];
+            let deleted = 0;
+            KbGarbageCollectionService.deleteChunks = async () => { deleted++; return 0 };
+
+            const result = await KbGarbageCollectionService.collectTenant({...baseArgs, retention: {maxCount: 1}, autoDelete: false});
+
+            expect(result.diff.expiredCount).toBe(2); // r2, r3 beyond maxCount 1
+            expect(result.deletedCount).toBe(0);
+            expect(deleted).toBe(0);
+        });
+
+        test('expired chunks with auto-delete ON are deleted', async () => {
+            applyStubs();
+            KbGarbageCollectionService.fetchTenantRows = async () => [row('r1', 5), row('r2', 4), row('r3', 3)];
+            const deletedIds = [];
+            KbGarbageCollectionService.deleteChunks = async (collection, ids) => { deletedIds.push(...ids); return ids.length };
+
+            const result = await KbGarbageCollectionService.collectTenant({...baseArgs, retention: {maxCount: 1}, autoDelete: true});
+
+            expect(deletedIds.sort()).toEqual(['r2', 'r3']);
+            expect(result.deletedCount).toBe(2);
+        });
+
+        test('never throws — a fetchTenantRows failure is caught, logged, and returns null', async () => {
+            applyStubs();
+            KbGarbageCollectionService.fetchTenantRows = async () => { throw new Error('chroma get failed') };
+            const errors = [];
+            logger.error = (msg) => { errors.push(msg) };
+
+            const result = await KbGarbageCollectionService.collectTenant({...baseArgs, retention: {maxCount: 1}, autoDelete: false});
+
+            expect(result).toBeNull();
+            expect(errors.some(e => String(e).includes('GC failed for tenant tenant-x'))).toBe(true);
+        });
+    });
+
+    test.describe('fetchTenants', () => {
+        test('dedupes the rollup to distinct tenants, keeping the first repoSlug', async () => {
+            KBRecorderService.getTenantIngestionRollup = () => [
+                {tenantId: 'tenant-a', repoSlug: 'repo-a1'},
+                {tenantId: 'tenant-a', repoSlug: 'repo-a2'},
+                {tenantId: 'tenant-b', repoSlug: 'repo-b'}
+            ];
+
+            expect(await KbGarbageCollectionService.fetchTenants()).toEqual([
+                {tenantId: 'tenant-a', repoSlug: 'repo-a1'},
+                {tenantId: 'tenant-b', repoSlug: 'repo-b'}
+            ]);
+        });
+
+        test('returns an empty list when the rollup is empty or unavailable', async () => {
+            KBRecorderService.getTenantIngestionRollup = () => [];
+            expect(await KbGarbageCollectionService.fetchTenants()).toEqual([]);
+
+            KBRecorderService.getTenantIngestionRollup = () => undefined;
+            expect(await KbGarbageCollectionService.fetchTenants()).toEqual([]);
+        });
+    });
+
+    test.describe('deleteChunks', () => {
+        test('deletes the id set and returns the count', async () => {
+            const deleteCalls = [];
+            const collection  = {delete: async (arg) => { deleteCalls.push(arg) }};
+
+            const count = await KbGarbageCollectionService.deleteChunks(collection, ['id-1', 'id-2']);
+
+            expect(count).toBe(2);
+            expect(deleteCalls).toEqual([{ids: ['id-1', 'id-2']}]);
+        });
+
+        test('is a no-op for an empty / non-array id set', async () => {
+            let deleteCalled = 0;
+            const collection = {delete: async () => { deleteCalled++ }};
+
+            expect(await KbGarbageCollectionService.deleteChunks(collection, [])).toBe(0);
+            expect(await KbGarbageCollectionService.deleteChunks(collection, null)).toBe(0);
+            expect(deleteCalled).toBe(0);
+        });
+    });
+
+    test.describe('recordGcMetric', () => {
+        test('emits a tombstone event with the chunk counts + detail payload', async () => {
+            const events = [];
+            KBRecorderService.recordIngestionMetric = (e) => { events.push(e) };
+
+            KbGarbageCollectionService.recordGcMetric({
+                tenantId        : 'tenant-x',
+                repoSlug        : 'repo-x',
+                diff            : {expiredCount: 6, evaluatedCount: 40},
+                deletedCount    : 6,
+                retention       : {maxAgeMs: 5000},
+                autoDelete      : true,
+                defragRecommended: true
+            });
+
+            expect(events).toHaveLength(1);
+            expect(events[0]).toMatchObject({
+                tenantId     : 'tenant-x',
+                repoSlug     : 'repo-x',
+                eventType    : 'tombstone',
+                chunksTotal  : 6,
+                chunksDeleted: 6
+            });
+            expect(events[0].detail).toMatchObject({
+                expiredCount: 6, evaluatedCount: 40, deletedCount: 6, gcAutoDelete: true, defragRecommended: true
+            });
+        });
+    });
+});

--- a/test/playwright/unit/ai/services/knowledge-base/KbGarbageCollectionEngine.spec.mjs
+++ b/test/playwright/unit/ai/services/knowledge-base/KbGarbageCollectionEngine.spec.mjs
@@ -1,0 +1,164 @@
+import {test, expect} from '@playwright/test';
+
+import {
+    formatGcDetail,
+    resolveRetention,
+    selectExpiredChunks
+} from '../../../../../../ai/services/knowledge-base/helpers/KbGarbageCollectionEngine.mjs';
+
+/**
+ * Phase 4C (#11641) — `KbGarbageCollectionEngine` coverage: the pure retention-expiry
+ * classification core of the KB garbage-collection daemon.
+ *
+ * The module is dependency-free (no Neo class system, no I/O, no clock) — so this spec needs
+ * no `setup()` harness; it imports the pure functions directly and exercises them against
+ * fixture rows whose shape mirrors the daemon's `fetchTenantRows` output (`{id, metadata}`).
+ *
+ * Covers the #11641 Contract Ledger Evidence column for the engine row: time-expiry,
+ * count-expiry per `{tenantId, repoSlug}` bucket, the OR-union, the deterministic tie-break
+ * on equal `ingestedAt`, the missing-`ingestedAt` fail-safe, and the empty-policy no-op.
+ *
+ * @see https://github.com/neomjs/neo/issues/11641
+ * @see ai/services/knowledge-base/helpers/KbGarbageCollectionEngine.mjs — the module under test.
+ */
+
+/** Builds a tenant Chroma row in the daemon's `fetchTenantRows` shape. */
+const row = (id, ingestedAt, repoSlug = 'repo-x') => ({
+    id, metadata: {ingestedAt, tenantId: 'tenant-x', repoSlug}
+});
+
+test.describe('KbGarbageCollectionEngine — resolveRetention (#11641)', () => {
+    test('passes a finite positive maxAgeMs and a non-negative integer maxCount', () => {
+        expect(resolveRetention({maxAgeMs: 5000})).toEqual({maxAgeMs: 5000, maxCount: null});
+        expect(resolveRetention({maxCount: 10})).toEqual({maxAgeMs: null, maxCount: 10});
+        expect(resolveRetention({maxAgeMs: 5000, maxCount: 10})).toEqual({maxAgeMs: 5000, maxCount: 10});
+        expect(resolveRetention({maxCount: 0})).toEqual({maxAgeMs: null, maxCount: 0}); // retain none — valid
+    });
+
+    test('degrades an invalid maxAgeMs to null (disabled)', () => {
+        for (const bad of [0, -1, NaN, Infinity, '5000', undefined]) {
+            expect(resolveRetention({maxAgeMs: bad}).maxAgeMs).toBeNull();
+        }
+    });
+
+    test('degrades an invalid maxCount to null (disabled)', () => {
+        for (const bad of [-1, 2.5, NaN, '10', undefined]) {
+            expect(resolveRetention({maxCount: bad}).maxCount).toBeNull();
+        }
+    });
+
+    test('treats a non-object retention as the empty policy', () => {
+        expect(resolveRetention(null)).toEqual({maxAgeMs: null, maxCount: null});
+        expect(resolveRetention(undefined)).toEqual({maxAgeMs: null, maxCount: null});
+        expect(resolveRetention('nope')).toEqual({maxAgeMs: null, maxCount: null});
+    });
+});
+
+test.describe('KbGarbageCollectionEngine — selectExpiredChunks (#11641)', () => {
+    test('returns an empty result for non-array / empty rows', () => {
+        expect(selectExpiredChunks({rows: null, retention: {maxCount: 1}, now: 1}))
+            .toEqual({expiredIds: [], expiredCount: 0, evaluatedCount: 0});
+        expect(selectExpiredChunks({rows: [], retention: {maxCount: 1}, now: 1}))
+            .toEqual({expiredIds: [], expiredCount: 0, evaluatedCount: 0});
+    });
+
+    test('an empty / no-dimension retention policy expires nothing', () => {
+        const diff = selectExpiredChunks({rows: [row('a', 1000), row('b', 2000)], retention: {}, now: 9_000_000});
+
+        expect(diff.expiredCount).toBe(0);
+        expect(diff.evaluatedCount).toBe(2);
+    });
+
+    test('time-expiry — expires chunks older than maxAgeMs (strict greater-than)', () => {
+        const rows = [row('old', 90_000), row('edge', 95_000), row('fresh', 98_000)];
+        const diff = selectExpiredChunks({rows, retention: {maxAgeMs: 5000}, now: 100_000});
+
+        // old: age 10000 > 5000 → expired. edge: age 5000, not > 5000 → kept. fresh: age 2000 → kept.
+        expect(diff.expiredIds).toEqual(['old']);
+    });
+
+    test('time-expiry is skipped when `now` is not a number', () => {
+        expect(selectExpiredChunks({rows: [row('old', 1)], retention: {maxAgeMs: 5000}}).expiredCount).toBe(0);
+    });
+
+    test('count-expiry — retains the maxCount most-recent, expires the rest', () => {
+        const rows = [row('r1', 5), row('r2', 4), row('r3', 3), row('r4', 2)];
+        const diff = selectExpiredChunks({rows, retention: {maxCount: 2}, now: 1000});
+
+        // most-recent 2 = r1, r2 retained; r3, r4 expired.
+        expect(diff.expiredIds.sort()).toEqual(['r3', 'r4']);
+    });
+
+    test('count-expiry buckets by {tenantId, repoSlug} — one repo cannot crowd out another', () => {
+        const rows = [
+            row('a1', 5, 'repo-a'), row('a2', 4, 'repo-a'),
+            row('b1', 9, 'repo-b')
+        ];
+        const diff = selectExpiredChunks({rows, retention: {maxCount: 1}, now: 1000});
+
+        // repo-a bucket: keep a1, expire a2. repo-b bucket: b1 alone (< maxCount) → kept.
+        expect(diff.expiredIds).toEqual(['a2']);
+    });
+
+    test('count-expiry tie-breaks equal ingestedAt deterministically by id asc', () => {
+        const rows = [row('c', 100), row('a', 100), row('b', 100)];
+        const diff = selectExpiredChunks({rows, retention: {maxCount: 1}, now: 1000});
+
+        // equal ingestedAt → id asc → a, b, c; keep a, expire b + c.
+        expect(diff.expiredIds.sort()).toEqual(['b', 'c']);
+    });
+
+    test('OR-expiry — a chunk expired by EITHER dimension is in the union', () => {
+        const rows = [
+            row('recent-kept',  99_000), // fresh + within count → kept
+            row('recent-kept2', 98_000), // fresh + within count → kept
+            row('count-out',    97_000), // fresh (age 3000) but count-rank 3 → count-expired
+            row('time-out',     90_000)  // count-rank 4 AND age 10000 → both
+        ];
+        const diff = selectExpiredChunks({rows, retention: {maxAgeMs: 5000, maxCount: 2}, now: 100_000});
+
+        expect(diff.expiredIds.sort()).toEqual(['count-out', 'time-out']);
+    });
+
+    test('a chunk with a missing / non-numeric ingestedAt is never expired', () => {
+        const rows = [
+            {id: 'no-stamp',     metadata: {tenantId: 't', repoSlug: 'r'}},
+            {id: 'null-stamp',   metadata: {tenantId: 't', repoSlug: 'r', ingestedAt: null}},
+            {id: 'string-stamp', metadata: {tenantId: 't', repoSlug: 'r', ingestedAt: '1'}},
+            row('real-old', 1)
+        ];
+        // Only real-old is aged + rankable; the three unstamped chunks are excluded from both paths.
+        const diff = selectExpiredChunks({rows, retention: {maxAgeMs: 5000, maxCount: 1}, now: 100_000});
+
+        expect(diff.expiredIds).toEqual(['real-old']);
+    });
+});
+
+test.describe('KbGarbageCollectionEngine — formatGcDetail (#11641)', () => {
+    test('builds the Phase 4A telemetry detail payload', () => {
+        const detail = formatGcDetail({
+            diff: {expiredIds: [], expiredCount: 7, evaluatedCount: 50},
+            retention: {maxAgeMs: 5000}, gcAutoDelete: true, deletedCount: 7, defragRecommended: true
+        });
+
+        expect(detail).toEqual({
+            expiredCount: 7, evaluatedCount: 50, deletedCount: 7,
+            retention: {maxAgeMs: 5000, maxCount: null}, gcAutoDelete: true, defragRecommended: true
+        });
+    });
+
+    test('coerces flags to strict booleans and defaults counts', () => {
+        const detail = formatGcDetail({diff: {expiredCount: 2, evaluatedCount: 2}});
+
+        expect(detail.gcAutoDelete).toBe(false);
+        expect(detail.defragRecommended).toBe(false);
+        expect(detail.deletedCount).toBe(0);
+    });
+
+    test('is defensive against a missing diff', () => {
+        expect(formatGcDetail({})).toEqual({
+            expiredCount: 0, evaluatedCount: 0, deletedCount: 0,
+            retention: {maxAgeMs: null, maxCount: null}, gcAutoDelete: false, defragRecommended: false
+        });
+    });
+});


### PR DESCRIPTION
Authored by Neo Opus 4.7 (Claude Code). Session 470c38e7-1ffc-4851-867d-d30c1b6fbdb2.

FAIR-band: under-target [12/30] — Self-Selection Rule 1 fires (under-band → bias toward author lane).

Resolves #11641
Related: #11628
Related: #11624

Phase 4C of Phase 4 epic #11628 (meta-epic #11624, Cloud-Native KB Ingestion) — the KB garbage-collection daemon. A cloud KB accretes chunks indefinitely unless a retention policy bounds them. This daemon periodically evaluates each tenant's persisted Chroma chunks against an operator retention policy (time- and/or count-based, keyed on the #11712 `ingestedAt` chunk stamp), emits Phase 4A telemetry, and — opt-in — deletes the retention-expired chunks; a large cumulative deletion emits a `defrag-recommended` signal. It is purely additive: 3 new files + 2 small additive edits (the `aiConfig` block, the `package.json` script); zero merged Phase 2 code is touched.

Evidence: L2 — 35 unit tests passing (17 `KbGarbageCollectionEngine` + 18 `KbGarbageCollectionService`), `node --check` clean on all source files. The daemon's *scheduled-run* dimension (a live process firing on a poll tick) + the end-to-end retention→GC→defrag-signal flow are L3 residuals the CI sandbox cannot exercise — see Post-Merge Validation.

## What shipped

**The 3-part daemon split** (mirrors #11640 `KbReconciliationService` / #11642 `KbAlertingService`):

- **`ai/services/knowledge-base/helpers/KbGarbageCollectionEngine.mjs`** — the pure retention-expiry classifier (dependency-free: no Neo, no I/O, no clock). `selectExpiredChunks({rows, retention, now})` classifies a tenant's Chroma rows under **OR-expiry** — a chunk is expired if *time-expired* (`now − ingestedAt > maxAgeMs`) OR *count-expired* (beyond the `maxCount` most-recent of its `{tenantId, repoSlug}` bucket, ranked `ingestedAt` desc then chunk `id` asc — a deterministic tie-breaker). Plus `resolveRetention` + `formatGcDetail`.
- **`ai/daemons/KbGarbageCollectionService.mjs`** — the poll-loop daemon (a `Neo.core.Base` singleton: `start` / `stop` / `scheduleNext` / `pulse`). Each `pulse()` enumerates tenants (distinct `tenantId` from `KBRecorderService.getTenantIngestionRollup`), runs the engine against each tenant's `where: {tenantId}` Chroma rows, opt-in deletes the expired chunks, and — two-pass — stamps the post-loop `defragRecommended` fact onto each tenant's `tombstone` telemetry, emitting a `defrag-recommended` `logger.warn` when cumulative deletion exceeds `gcDefragThreshold`. `pulse()` is try/catch/finally + per-tenant try/catch. All I/O behind test-stubbable seam methods.
- **`ai/scripts/kb-gc-daemon.mjs`** — the thin Neo-bootstrap + SIGTERM wrapper; **`package.json`** — the `ai:kb-gc` script.
- **`ai/config.template.mjs`** — 5 new `aiConfig.knowledgeBase` keys (`gcEnabled` / `gcIntervalMs` / `gcRetention` / `gcAutoDelete` / `gcDefragThreshold`), read defensively.

**Two opt-in gates** — `start()` no-ops unless `gcEnabled`; the destructive delete is a *second* opt-in (`gcAutoDelete`, default `false`). V1 default behavior = detect retention-expired chunks + emit telemetry only, zero `collection.delete`.

The implementation follows the **#11641 Contract Ledger** (T3 Explicit Matrix, in the ticket body) — refined per @neo-gpt's pre-branch peer review (explicit OR-expiry, the deterministic count tie-breaker, `{tenantId, repoSlug}` count-bucketing, the `defrag-recommended` signal).

## Deltas from ticket

Per the intake scope-refinement (the #11641 intake comments) + @neo-gpt's pre-branch review — all documented in the Contract Ledger:

- **Config-orphan detection dropped** — it overlaps #11640's config-invalidation reconciliation (the same `tenantConfigVersion` signal); 4C re-detecting it is double-handling. V1 = retention-policy expiration only.
- **Per-tenant retention → global for V1.** `getTenantConfig`'s projection is fixed; V1 applies one global `gcRetention` per tenant — a per-tenant *override* needs a `getTenantConfig`-projection extension (#11637 surface) → V1.x.
- **Auto-defrag → a signal, not a spawn.** Auto-spawning `ai:defrag-kb` (a whole-collection nuke-and-pave) from a poll-loop daemon needs a defrag-vs-ingest concurrency-coordination story. V1 emits a `defrag-recommended` `logger.warn` + telemetry flag when cumulative deletion exceeds `gcDefragThreshold` (default `0.10`); the automated spawn is V1.x. No subprocess in V1 → no concurrency surface.

## Test Evidence

- `npm run test-unit -- test/playwright/unit/ai/services/knowledge-base/KbGarbageCollectionEngine.spec.mjs test/playwright/unit/ai/daemons/KbGarbageCollectionService.spec.mjs` → **35 passed**.
- `KbGarbageCollectionEngine.spec.mjs` (17) — `selectExpiredChunks` (time-expiry strict-`>`, count-expiry per `{tenantId,repoSlug}` bucket, the deterministic id-asc tie-break on equal `ingestedAt`, the OR-union, the missing-`ingestedAt` fail-safe, the empty-policy no-op), `resolveRetention` (per-dimension validation), `formatGcDetail`.
- `KbGarbageCollectionService.spec.mjs` (18) — start/stop (opt-in gate, idempotency, interval), pulse (empty-tenant early return, per-tenant loop, reschedule-on-failure, null-result isolation, the `defrag-recommended` threshold both ways), `collectTenant` (clean-tenant no-delete, the `gcAutoDelete` opt-in gating both ways, never-throws), `fetchTenants` dedup, `deleteChunks` empty-guard, the `recordGcMetric` `tombstone` payload.
- `node --check` clean on all 3 `.mjs` source files; `config.template.mjs` valid; `package.json` valid JSON.
- The `check-whitespace` pre-commit hook passed on all 3 commits.

## Post-Merge Validation

- [ ] With `aiConfig.knowledgeBase.gcEnabled: true` + a sample `gcRetention`, confirm a launched `npm run ai:kb-gc` daemon polls on its interval and emits a `tombstone` telemetry event for a tenant with retention-expired chunks (the L3 scheduled-run surface the CI sandbox cannot reach).
- [ ] With `gcAutoDelete: true`, confirm a retention-expired chunk is deleted from the `knowledge-base` collection, and that cumulative deletion exceeding `gcDefragThreshold` emits the `defrag-recommended` signal (the #11641 integration-test AC, adjusted to V1's signal-not-spawn scope).

## Commits

- `03974a30f` — feat(ai): add KB garbage-collection retention engine (#11641)
- `17c713af9` — feat(ai): add KB garbage-collection daemon (#11641)
- `639db69c3` — test(ai): KB GC engine + daemon specs (#11641)

## Related

- #11628 — Phase 4 epic (KB Operations + Observability); my epic-review: https://github.com/neomjs/neo/issues/11628#issuecomment-4504271144
- #11624 — Cloud-Native KB Ingestion meta-epic
- #11641 Contract Ledger — in the ticket body (T3 Explicit Matrix), the binding contract; refined per @neo-gpt's pre-branch peer review
- #11712 — the `ingestedAt` chunk stamp (the per-chunk timestamp this daemon's retention is keyed on)
- #11640 — Phase 4B `KbReconciliationService` (the sibling daemon; config-orphan detection is its domain, not 4C's)
