### PR TITLE
fix(ai): mark kb-config node visibility:team for offline daemon reads (#11716)

### DIFF
--- a/ai/services/knowledge-base/KnowledgeBaseIngestionService.mjs
+++ b/ai/services/knowledge-base/KnowledgeBaseIngestionService.mjs
@@ -869,10 +869,17 @@ class KnowledgeBaseIngestionService extends Base {
      * @summary Persists a tenant's Knowledge Base ingestion config as a versioned graph node (#11637 Phase 2E).
      *
      * Writes the `KnowledgeBaseTenantConfig` node (`kb-config:<tenantId>`); `version` increments on
-     * each mutation. RLS: `resolveTenantContext` rejects a caller mutating another tenant's config
-     * (`KB_INGEST_TENANT_MISMATCH`). The explicit gate is required because `GraphService.upsertNode`
-     * auto-stamps the *caller's* identity onto `properties.userId` — an un-gated cross-tenant write
-     * would silently re-own the node rather than be rejected.
+     * each mutation. RLS — two distinct layers:
+     * - **Write gate:** `resolveTenantContext` rejects a caller mutating another tenant's config
+     *   (`KB_INGEST_TENANT_MISMATCH`). The explicit gate is required because `GraphService.upsertNode`
+     *   auto-stamps the *caller's* identity onto `properties.userId` — an un-gated cross-tenant write
+     *   would silently re-own the node rather than be rejected.
+     * - **Read visibility (#11716):** the node is marked `visibility:'team'` so the offline KB
+     *   reconciliation daemon (#11640) — which reads `getTenantConfig` with no request context —
+     *   can resolve it. `GraphService.getNodeRecord` exposes only ownerless / owner-matched /
+     *   shared / `visibility:'team'` nodes; a request-authored (`userId`-stamped) config node
+     *   without this marker is invisible to the daemon, silently degrading config-staleness
+     *   detection to the default tier. Mirrors the `kb-manifest:<tenantId>` sibling node (#11711).
      * @param {Object} data
      * @param {String} data.tenantId Tenant id.
      * @param {Object} [data.config={}] Config payload — `useDefaultSources` / `useDefaultParsers` /
@@ -899,7 +906,8 @@ class KnowledgeBaseIngestionService extends Base {
                     customSources    : config.customSources || [],
                     customParsers    : config.customParsers || [],
                     sourcePaths      : config.sourcePaths    || {},
-                    version
+                    version,
+                    visibility       : 'team'
                 }
             });
 

--- a/test/playwright/unit/ai/services/knowledge-base/KnowledgeBaseIngestionService.spec.mjs
+++ b/test/playwright/unit/ai/services/knowledge-base/KnowledgeBaseIngestionService.spec.mjs
@@ -505,6 +505,24 @@ test.describe('KnowledgeBaseIngestionService.tenantConfig (#11637)', () => {
         expect(graphStub.store.has('kb-config:tenant-b')).toBe(false);
     });
 
+    test('setTenantConfig stamps visibility:team on the kb-config node for offline daemon reads (#11716)', async () => {
+        await Service.setTenantConfig({tenantId: 'tenant-a', config: {}});
+
+        // `GraphService.upsertNode` stamps the request identity onto `properties.userId`; without an
+        // explicit `visibility:'team'` marker the node is invisible to the offline #11640 reconciliation
+        // daemon (which reads `getTenantConfig` with no request context). The marker is the offline-read
+        // authorization, parallel to the `kb-manifest` sibling node (#11711).
+        const node = graphStub.store.get('kb-config:tenant-a');
+        expect(node.type).toBe('KnowledgeBaseTenantConfig');
+        expect(node.properties.visibility).toBe('team');
+
+        // The marker survives a version-bumping re-write.
+        await Service.setTenantConfig({tenantId: 'tenant-a', config: {useDefaultParsers: false}});
+        const bumped = graphStub.store.get('kb-config:tenant-a');
+        expect(bumped.properties.version).toBe(2);
+        expect(bumped.properties.visibility).toBe('team');
+    });
+
     test('setTenantManifest persists repo manifests without bumping KnowledgeBaseTenantConfig.version (#11711)', async () => {
         await Service.setTenantConfig({tenantId: 'tenant-a', config: {customParsers: [{parserId: 'alpha'}]}});
 


### PR DESCRIPTION
Resolves #11716

Authored by Neo Opus 4.7 (Claude Code). Session 470c38e7-1ffc-4851-867d-d30c1b6fbdb2.

FAIR-band: under-target [12/30] — Self-Selection Rule 1 fires (under-band → bias toward author lane).

`KnowledgeBaseIngestionService.setTenantConfig()` wrote the `kb-config:<tenantId>` graph node without a `visibility:'team'` marker. Per the verified `GraphService` RLS model, `upsertNode` stamps the caller's identity onto `properties.userId` for a request-authored write, and `getNodeRecord` exposes a `userId`-owned node only to that same owner (or to ownerless / shared / `visibility:'team'` nodes). The offline #11640 reconciliation daemon reads tenant config via `getTenantConfig` with **no request context** — so a request-authored `kb-config` node would be RLS-invisible to it, and `getTenantConfig` would silently fall through to the default/yaml tier, degrading the daemon's config-staleness detection. This PR adds `visibility:'team'` to the node — the offline-read marker — mirroring the `kb-manifest:<tenantId>` sibling node (#11711). The `resolveTenantContext` write-gate is unchanged.

Evidence: L2 (unit — `kb-config` node stamped `visibility:'team'`, marker survives version-bumping re-writes; `node --check` clean) → L2 required (all #11716 ACs are unit/static-coverable). No residuals — AC4's "focused unit coverage" of offline-read visibility is the marker assertion; the marker → RLS-visible link is `GraphService.isRlsVisible`'s own verified contract (#10011 family). The live cross-identity RLS read with the real `GraphService` is general post-merge integration confidence, not a #11716 AC gap.

## Deltas from ticket

#11716 AC1 mandated a V-B-A on whether `setTenantConfig()` *currently* creates daemon-invisible nodes. The finding refines the ticket's framing:

- **The bug is latent, not active.** `setTenantConfig()` has **no production caller** today — a repo-wide sweep found it referenced only by its own definition, the unit spec, and the `KBBackupRestoreWipe` integration spec. No MCP tool or CLI invokes it. So in production no `kb-config` graph node is written, and `getTenantConfig` always resolves the default/yaml tier — the RLS-invisibility is currently unreachable.
- **But the mechanism is real and demonstrated.** `KBBackupRestoreWipe.integration.spec.mjs` calls `setTenantConfig()` under `asTenant(...)` request context, and its own assertions confirm the written node resolves *as the owner* — i.e. when `setTenantConfig` runs under request context, the node IS `userId`-owned, and a null-identity offline reader could not see it.
- **Disposition — ship the prophylactic, not close-as-no-code.** #11716's Fix step 4 offered "close as no-code if `setTenantConfig` cannot run under request context." It *can* (the integration test proves it); it simply has no production caller *yet*. Because the offline-daemon consumer (`getTenantConfig` in the merged #11640) is real, and the fix is the established #11714 manifest-node pattern plus one property, the node is made correct-by-construction now — before the obvious future MCP-tool wiring of `setTenantConfig` makes the bug live.

No `getTenantConfig` / daemon-side change is needed — once the node carries `visibility:'team'`, the existing `getNodeRecord` read resolves it for the offline daemon.

## Test Evidence

- `npm run test-unit -- test/playwright/unit/ai/services/knowledge-base/KnowledgeBaseIngestionService.spec.mjs` → **22 passed** (21 prior + the new `#11716` test).
- New test — `setTenantConfig stamps visibility:team on the kb-config node for offline daemon reads (#11716)`: asserts the written `kb-config` node carries `visibility:'team'`, and that the marker survives a version-bumping re-write (the `upsertNode` update path).
- The existing `setTenantConfig` tests (persist + read-back, version increment, cross-tenant RLS rejection) still pass — the write-gate behavior is unchanged.
- `node --check` clean on `KnowledgeBaseIngestionService.mjs`.

## Post-Merge Validation

- [ ] **Integration confidence** (not a #11716 AC gap — AC4 is delivered by unit coverage): when `setTenantConfig()` gains a request-context caller (future MCP-tool wiring), confirm via the Docker-backed `KBBackupRestoreWipe.integration.spec.mjs` (or an extension) that a request-authored `kb-config` node is readable by the offline `KbReconciliationService` daemon path — the live cross-identity RLS read that unit coverage cannot exercise.

## Commits

- `cec1cb518` — fix(ai): mark kb-config node visibility:team for offline daemon reads (#11716)

## Related

- #11716 — the ticket (filed by @neo-gpt from my PR #11714 Cycle-2 RA-3 adjacent observation).
- #11711 / PR #11714 — the `kb-manifest:<tenantId>` sibling node whose `visibility:'team'` marker this fix mirrors; the `GraphService` RLS model was verified during that PR's Cycle-2 review.
- #11637 — Phase 2E `KnowledgeBaseTenantConfig` (the `setTenantConfig` / `kb-config` node this fix hardens).
- #11640 — Phase 4B `KbReconciliationService` (the offline `getTenantConfig` consumer the marker serves).
- #11628 — Phase 4 epic (parent).