### PR TITLE
feat(agentos): add tenant ingestion model (#11726)

### DIFF
--- a/examples/cloud-deployment/README.md
+++ b/examples/cloud-deployment/README.md
@@ -10,4 +10,6 @@ guide tree (Epic #11624 — Cloud-Native KB Ingestion).
 
 These are *minimal* demonstrations of the ingestion contracts, not production
 deployments. Read [Overview](../../learn/agentos/cloud-deployment/Overview.md) first,
-then each artifact's own README / header comment.
+then [Tenant Ingestion Model](../../learn/agentos/cloud-deployment/TenantIngestionModel.md)
+for the operational repo-identity, credential-boundary, and source-family inventory rules before
+each artifact's own README / header comment.

--- a/learn/agentos/cloud-deployment/CustomParsers.md
+++ b/learn/agentos/cloud-deployment/CustomParsers.md
@@ -11,6 +11,8 @@ The KB ingestion substrate splits content acquisition into two roles (see [Overv
 
 Both register in the same `SourceRegistry` singleton. This guide covers parsers — the format layer a cloud tenant most often needs to extend, because a tenant's repos rarely contain only the formats Neo's built-in parsers (`SourceParser` for ES modules, `DocumentationParser` for Markdown, `TestParser`) understand.
 
+The tenant-level choice of which source families use server parsers, client-side `parsed-chunk-v1`, or an explicit unsupported status is defined in [Tenant Ingestion Model](./TenantIngestionModel.md).
+
 ## The `parsed-chunk-v1` contract
 
 Every chunk entering the KB through the push path conforms to [`parsed-chunk-v1`](../../../ai/services/knowledge-base/parser/parsed-chunk-v1.schema.json) — the ingest contract. A parser's job is to emit records of this shape. The required fields:
@@ -75,6 +77,7 @@ A runtime sandbox for in-process execution of tenant-supplied parser code (WASM 
 ## Related
 
 - [Overview](./Overview.md) — the Source/Parser registry split and the contract layering.
+- [Tenant Ingestion Model](./TenantIngestionModel.md) — source-family inventory and dispatch choices for external tenant repos.
 - [Hook Wiring](./HookWiring.md) — the `ingest_source_files` / `ai:ingest-tenant` push facades that invoke parsers.
 - [Custom Sources](./CustomSources.md) — the full-corpus `Source` counterpart.
 - [Configuration](./Configuration.md) — `useDefaultParsers`, `customParsers`, and the rest of the `aiConfig` surface.

--- a/learn/agentos/cloud-deployment/HookWiring.md
+++ b/learn/agentos/cloud-deployment/HookWiring.md
@@ -6,6 +6,8 @@
 
 A tenant's source content reaches the Knowledge Base through one of two facades. Both call the same `KnowledgeBaseIngestionService.ingestSourceFiles` orchestrator and write to the unified Chroma `knowledge-base` collection — they differ in **who calls them** and in **work-volume policy**.
 
+For the operator-facing decision model — how to choose repo slugs, treat credentials, inventory source families, and decide when to use each facade — read [Tenant Ingestion Model](./TenantIngestionModel.md) first.
+
 | Facade | Caller | Volume policy | Built for |
 |---|---|---|---|
 | `ingest_source_files` | An MCP client of the deployment — an agent in the tenant workspace, or a tenant push-client | Gated — refuses a batch over `mcpSyncMaxChunks` (default 50) | Incremental pushes: a commit's worth of changed files |
@@ -113,6 +115,7 @@ The example combines **tombstones + revision-boundary** — the precise-but-chea
 ## Related
 
 - [Overview](./Overview.md) — the contract split, topology anchor, default-source inheritance.
+- [Tenant Ingestion Model](./TenantIngestionModel.md) — tenant repo identity, credential boundary, source-family inventory, and push-vs-bulk operational flow.
 - [Configuration](./Configuration.md) — `mcpSyncMaxChunks`, `transport`, and the other `aiConfig` keys.
 - [Custom Parsers](./CustomParsers.md) — authoring a parser that turns a tenant file format into `parsed-chunk-v1` records.
 - [Security](./Security.md) — write-side stamping, spoof-rejection, and the parser-execution boundary.

--- a/learn/agentos/cloud-deployment/Overview.md
+++ b/learn/agentos/cloud-deployment/Overview.md
@@ -48,6 +48,7 @@ Neo's own guides, ADRs, skills, and API docs remain in the KB under `tenantId: '
 
 - **[Security](./Security.md)** — tenant-isolation invariants, write-side stamping + spoof-rejection, parser-execution boundary framing, and the KB-as-cache vs MC-as-store recovery model.
 - **[Migration Path](./MigrationPath.md)** — how an existing single-repo Neo deployment upgrades to the cloud-ingestion substrate with zero config changes.
+- **[Tenant Ingestion Model](./TenantIngestionModel.md)** — the operator-facing model for tenant repo identity, credential boundaries, parser dispatch, source-family inventory, and push-vs-bulk ingestion choices.
 - **[Configuration](./Configuration.md)** — the `aiConfig` keys and the `KnowledgeBaseTenantConfig` / `kb-config.yaml` tenant-config storage.
 - **[Custom Sources](./CustomSources.md)** / **[Custom Parsers](./CustomParsers.md)** — authoring a Source for the full-corpus build, or a Parser for the push path.
 - **[Hook Wiring](./HookWiring.md)** — the `ingest_source_files` / `ai:ingest-tenant` facades and git-hook patterns; runnable companions live under [`examples/cloud-deployment/`](../../../examples/cloud-deployment/).

--- a/learn/agentos/cloud-deployment/TenantIngestionModel.md
+++ b/learn/agentos/cloud-deployment/TenantIngestionModel.md
@@ -27,14 +27,18 @@ Both facades call `KnowledgeBaseIngestionService.ingestSourceFiles()`. Do not do
 
 ## Repository Identity
 
-Every pushed record belongs to a repository identity tuple:
+Every pushed `parsed-chunk-v1` record belongs to this path-identity tuple:
 
 | Field | Operational rule |
 |---|---|
 | `tenantId` | Server-derived from the authenticated caller. A payload may carry a tenant claim, but it is not authoritative. |
 | `repoSlug` | Tenant-owned repository identifier. It is namespaced by `tenantId`, must be deterministic, and must never contain credentials. |
-| `branch` | Operational label for the source branch or ref that produced the push. It is part of the deployment runbook and tutorial evidence, not part of the current `parsed-chunk-v1` required schema. |
+| `rootKind` | Required repository topology hint: `neo-workspace`, `bare-repo`, or `external-source`. It selects hydration assumptions for content under the same `repoSlug`. |
 | `sourcePath` | Forward-slash-normalized path relative to the `repoSlug` root. It is never resolved against the KB server's `neoRootDir`. |
+
+`branch` is still useful operational metadata for the source branch or ref that
+produced a push, but it is part of the deployment runbook and tutorial evidence,
+not part of the current `parsed-chunk-v1` required schema.
 
 Recommended `repoSlug` shape:
 
@@ -124,7 +128,7 @@ Incremental pushes should include deletion intent. Prefer this default shape:
 
 ## Operational Flow
 
-1. Pick a stable `tenantId` and one or more secret-free `repoSlug` values.
+1. Pick a stable `tenantId`, one or more secret-free `repoSlug` values, and the `rootKind` for each ingested source root.
 2. Build the source-family inventory.
 3. Choose dispatch for each family: raw server parse, registered server parser, client-side `parsed-chunk-v1`, unsupported, or excluded.
 4. Run initial import with `ai:ingest-tenant` when volume exceeds the MCP gate.

--- a/learn/agentos/cloud-deployment/TenantIngestionModel.md
+++ b/learn/agentos/cloud-deployment/TenantIngestionModel.md
@@ -1,0 +1,156 @@
+# Cloud-Native KB Ingestion — Tenant Ingestion Model
+
+> **Status — MVP operational model.** This guide documents Sub E of Epic [#11720](https://github.com/neomjs/neo/issues/11720): how an external tenant gets its repository content into a cloud-deployed Knowledge Base without tacit Neo maintainer knowledge. The substrate it names was delivered by Epic [#11624](https://github.com/neomjs/neo/issues/11624); this guide defines the operator-facing model on top.
+
+## Decision Summary
+
+For the MVP deployment path, tenant ingestion is **push-based**:
+
+1. The tenant workspace reads its own repository content.
+2. The tenant sends raw file deltas or `parsed-chunk-v1` records to the deployment.
+3. The KB server validates the payload, stamps the authoritative tenant tuple, embeds the chunk text server-side, and writes into the shared `knowledge-base` collection.
+
+The deployment does **not** need clone credentials for the MVP path. Server-side repo cloning is a later exploration owned by [#11731](https://github.com/neomjs/neo/issues/11731) and only starts if push-based ingestion proves insufficient.
+
+This model pairs with the D0 scheduler taxonomy in [#11721](https://github.com/neomjs/neo/issues/11721): local maintainer checkout sync stays local-only, while cloud tenant content arrives through the push-based path below.
+
+## Entry Points
+
+Use the same underlying ingestion service through two facades:
+
+| Facade | Use when | Volume / lifecycle |
+|---|---|---|
+| `ingest_source_files` | A tenant agent or push client sends a bounded incremental change set to the cloud MCP endpoint. | MCP-callable and volume-gated by `mcpSyncMaxChunks`; split or use the CLI when the gate refuses. |
+| `npm run ai:ingest-tenant -- <tenantId> ...` | A deployment operator, CI job, or onboarding script performs an initial import, full backfill, or large re-push. | Runs on the deployment host, bypasses the MCP turn-volume gate via `viaMcp: false`, and holds the heavy-maintenance lease. |
+
+Both facades call `KnowledgeBaseIngestionService.ingestSourceFiles()`. Do not document a third ingestion path for the MVP unless the implementation adds one.
+
+## Repository Identity
+
+Every pushed record belongs to a repository identity tuple:
+
+| Field | Operational rule |
+|---|---|
+| `tenantId` | Server-derived from the authenticated caller. A payload may carry a tenant claim, but it is not authoritative. |
+| `repoSlug` | Tenant-owned repository identifier. It is namespaced by `tenantId`, must be deterministic, and must never contain credentials. |
+| `branch` | Operational label for the source branch or ref that produced the push. It is part of the deployment runbook and tutorial evidence, not part of the current `parsed-chunk-v1` required schema. |
+| `sourcePath` | Forward-slash-normalized path relative to the `repoSlug` root. It is never resolved against the KB server's `neoRootDir`. |
+
+Recommended `repoSlug` shape:
+
+```text
+<provider-or-org>/<repo-name>
+```
+
+Examples:
+
+```text
+acme/app
+acme/docs
+internal/platform
+```
+
+If a tenant has multiple repos, each repo gets its own stable `repoSlug`. Manifests, tombstones, reconciliation, retention, alerting, telemetry, and source-family inventory remain scoped per `{tenantId, repoSlug}`. A bulk import that mixes repos must still let each record or batch resolve the correct `repoSlug`.
+
+Do not derive `repoSlug` from a credential-bearing remote URL. Normalize it from an explicit non-secret name chosen by the tenant or deployment operator.
+
+## Credential Boundary
+
+The push-based MVP path is credential-free from the KB server's perspective:
+
+- The tenant workspace already has access to its own repository.
+- The tenant push client reads local files and sends content or parsed chunks.
+- The KB server receives ingestion payloads, not Git credentials.
+
+Credential-bearing Git URLs are therefore rejected or treated as deferred clone-exploration input. They must not appear in:
+
+- `repoSlug`
+- logs
+- manifests
+- tutorial snippets
+- graph-visible configuration
+- source-family inventory output
+
+If a future server-side clone path becomes necessary, [#11731](https://github.com/neomjs/neo/issues/11731) owns the credential transport and storage contract before implementation begins.
+
+## Parser Dispatch
+
+The parser decision is per source family, not per tenant:
+
+| Source family | Default dispatch |
+|---|---|
+| Neo-supported text/source formats | Raw file delta to `ingest_source_files`; server-side parser or `raw-text` fallback. |
+| Custom but trusted operator-installed formats | Raw file delta with a registered `parserId`; server-side parser execution is operator-gated. |
+| Custom, untrusted, non-JS, or tenant-owned parser logic | Client-side parser emits `parsed-chunk-v1`; the KB server validates and embeds only the parsed records. |
+| Unknown format | Record as `unsupported` or `client-parser-required`; do not silently skip. |
+
+The KB server owns embeddings. `parsed-chunk-v1` records carrying an `embedding` field are rejected; pre-embedded records belong to restore-only backup paths, not ingestion.
+
+## Source-Family Inventory
+
+Before onboarding a tenant repository, produce a source-family inventory. The inventory is the handoff from Sub E into the day-0 tutorial work in [#11728](https://github.com/neomjs/neo/issues/11728).
+
+Use this checklist:
+
+| Source family | Questions to answer |
+|---|---|
+| Runtime source | Which languages and module systems are present? Which can use Neo-shipped parsers, and which require client-side parser output? |
+| Tests | Which unit, integration, e2e, fixture, and test-helper trees should be indexed? Which test artifacts should be excluded? |
+| Docs | Which Markdown, ADR, API, OpenAPI, generated-doc, and runbook files are authoritative? |
+| Config and deployment | Which package, Docker, CI, env-template, and infrastructure files should be indexed? Which carry secrets or local-only values and must be excluded or redacted? |
+| IDE/header/test-library equivalents | Which project-specific metadata files are needed for agents to understand conventions? |
+| Generated artifacts | Which files are generated and should be excluded unless they are the source of truth? |
+| Custom formats | Which formats need client-side parser output? Who owns parser versioning and deprecation? |
+
+Each inventory row should choose one dispatch outcome:
+
+```text
+server-raw
+server-parser:<parserId>
+client-parsed:<parserId>
+unsupported
+excluded
+```
+
+## Deletion and Manifest Policy
+
+Incremental pushes should include deletion intent. Prefer this default shape:
+
+- `deleted` tombstones for explicit deletes.
+- `baseRevision` + `headRevision` when the push client can provide a reliable SHA range.
+- `manifestSnapshot` when the push point is meant to advance the claimed live file set for a repo.
+
+`manifestSnapshot.repoSlug` must match the repo whose `pathsAfterPush` it describes. A missing manifest does not authorize deleting earlier rows; it only means that push did not advance the claimed-state baseline. A bulk initial import can skip manifest state, but the deployment should follow it with a manifest-carrying push or an explicit claimed-state resync before relying on reconciliation to delete orphans.
+
+## Operational Flow
+
+1. Pick a stable `tenantId` and one or more secret-free `repoSlug` values.
+2. Build the source-family inventory.
+3. Choose dispatch for each family: raw server parse, registered server parser, client-side `parsed-chunk-v1`, unsupported, or excluded.
+4. Run initial import with `ai:ingest-tenant` when volume exceeds the MCP gate.
+5. Wire incremental `pre-push` or CI pushes through `ingest_source_files`.
+6. Include tombstones and revision boundaries; include manifests at reconciliation points.
+7. Fail the hook or CI job on structured ingestion errors instead of silently dropping files.
+8. Verify retrieval against the tenant corpus plus `neo-shared` content before handing the deployment to agents.
+
+## Evidence Boundary
+
+This guide is an L1 operational contract. It does not require new runtime behavior by itself. Add tests only when implementation touches a real seam, for example:
+
+- repoSlug normalization or rejection logic;
+- credential-bearing URL redaction/rejection;
+- parser-dispatch branching;
+- manifest/tombstone handling;
+- tutorial fixture executability.
+
+The day-0 tutorial should reuse this model rather than redefine it.
+
+## Related
+
+- [Hook Wiring](./HookWiring.md) — the `ingest_source_files` and `ai:ingest-tenant` facades.
+- [Custom Parsers](./CustomParsers.md) — `parsed-chunk-v1` and parser execution boundaries.
+- [Custom Sources](./CustomSources.md) — full-corpus Source path, mostly not the push-based tenant default.
+- [Security](./Security.md) — tenant stamping, spoof rejection, parser trust, and KB-as-cache recovery.
+- [#11721](https://github.com/neomjs/neo/issues/11721) — D0 scheduler taxonomy that separates local-only maintainer sync from cloud tenant ingestion.
+- [`identity-tuple.md`](../../../ai/services/knowledge-base/parser/identity-tuple.md) — authoritative path identity tuple.
+- [`deletion-signaling-contract.md`](../../../ai/services/knowledge-base/parser/deletion-signaling-contract.md) — tombstone, manifest, and revision-boundary mechanics.

--- a/learn/tree.json
+++ b/learn/tree.json
@@ -40,6 +40,7 @@
         {"name": "Deployment Cookbook",                                "parentId": "AgentOS",                                             "id": "agentos/DeploymentCookbook"},
         {"name": "Cloud-Native KB Ingestion",                          "parentId": "AgentOS",                            "isLeaf": false, "id": "AgentOS/CloudDeployment", "collapsed": true},
             {"name": "Overview",                                       "parentId": "AgentOS/CloudDeployment",                             "id": "agentos/cloud-deployment/Overview"},
+            {"name": "Tenant Ingestion Model",                         "parentId": "AgentOS/CloudDeployment",                             "id": "agentos/cloud-deployment/TenantIngestionModel"},
             {"name": "Configuration",                                  "parentId": "AgentOS/CloudDeployment",                             "id": "agentos/cloud-deployment/Configuration"},
             {"name": "Custom Sources",                                 "parentId": "AgentOS/CloudDeployment",                             "id": "agentos/cloud-deployment/CustomSources"},
             {"name": "Custom Parsers",                                 "parentId": "AgentOS/CloudDeployment",                             "id": "agentos/cloud-deployment/CustomParsers"},


### PR DESCRIPTION
Resolves #11726

Authored by GPT-5 (Codex Desktop). Session 4526213f-539d-4200-ad90-95f44e333aa2.
FAIR-band: over-target [17/30] - taking this lane despite over-target because @tobiu explicitly assigned GPT /lead-role and #11726 was the unassigned #11720 parallel lane while Claude owns D0 #11721.

Adds the cloud deployment Tenant Ingestion Model: tenant repo identity, credential boundary, parser dispatch, source-family inventory, deletion/manifest policy, and the push-vs-bulk operational flow. The guide is linked from the cloud-deployment overview, hook wiring, custom parser docs, examples README, and `learn/tree.json` so the day-0 tutorial can consume one canonical model.

Evidence: L1 (static docs contract + tree parse + diff hygiene) -> L1 required (docs/operational-model close target; no runtime seam changed). No residuals.

## Slot Rationale
- Added `learn/agentos/cloud-deployment/TenantIngestionModel.md`: disposition `keep` as a conditionally loaded cloud-deployment guide; trigger-frequency medium, failure-severity high, enforceability medium. Keeps credential, repoSlug, parser-dispatch, and deletion semantics in operator docs rather than always-loaded substrate.
- Modified `learn/agentos/cloud-deployment/{Overview,HookWiring,CustomParsers}.md`, `examples/cloud-deployment/README.md`, and `learn/tree.json`: disposition delta `keep`; discoverability links/tree entry only, with no new always-loaded rule body.
- Retired sections: none.

## Deltas from ticket
- Backfilled the #11726 Contract Ledger before branch/code because intake found the public contract matrix missing.
- Implementation stayed docs-only: no runtime API, parser, credential, manifest, or test seam changed.
- Mirrored the #11721 D0 taxonomy boundary: local maintainer checkout sync stays local-only; tenant content uses push-based ingestion.

## Test Evidence
- `git diff --cached --check` - passed.
- `node -e "JSON.parse(require('fs').readFileSync('learn/tree.json','utf8')); console.log('learn/tree.json OK')"` - passed.
- `rg -n "#11721|local-only|push-based|TenantIngestionModel" learn/agentos/cloud-deployment examples/cloud-deployment/README.md learn/tree.json` - verified the guide links and D0 cross-reference.
- Pre-push freshness: `git fetch origin`; `merge-base HEAD origin/dev == origin/dev`; outgoing log only `64dd4da64 feat(agentos): add tenant ingestion model (#11726)`.

## Post-Merge Validation
- [ ] #11728 day-0 tutorial consumes Tenant Ingestion Model instead of redefining repo identity, credential boundary, parser dispatch, and deletion policy.

## Related
Related: #11720
Related: #11730 (post-MVP residual; not started by this PR)
Related: #11721

## Commits
- `64dd4da64` - `feat(agentos): add tenant ingestion model (#11726)`