### PR TITLE
feat(ai): add deployment maintenance config (#11722)

### DIFF
--- a/ai/config.template.mjs
+++ b/ai/config.template.mjs
@@ -97,6 +97,8 @@ const defaultConfig = {
             kbSyncEnabled        : null,
             bridgeDaemonEnabled  : null,
             goldenPathRepoEnrichmentEnabled: null,
+            // Reserved policy placeholder: no runtime consumer yet.
+            // `bridgeDaemonEnabled` is the active scheduler gate for desktop wake delivery.
             wakeDispatchEnabled  : null
         },
         /**

--- a/ai/config.template.mjs
+++ b/ai/config.template.mjs
@@ -10,6 +10,9 @@ const neoRootDir = path.resolve(__dirname, '../');
 // Fallback to neoRootDir if cwd is root (e.g., container/daemon edge cases)
 const projectRoot = process.cwd() === '/' ? neoRootDir : process.cwd();
 
+const HOUR_MS = 60 * 60 * 1000;
+const DAY_MS  = 24 * HOUR_MS;
+
 /**
  * Top-level configuration object (Tier 1).
  * Defines the core immutable plain-data structures applied universally across all AI/MCP infrastructure.
@@ -62,6 +65,41 @@ const defaultConfig = {
      */
     orchestrator: {
         /**
+         * Deployment profile for Agent OS maintenance ownership.
+         * `local` preserves maintainer-checkout behavior; `cloud` disables local-only
+         * maintenance lanes unless a narrower localOnly override opts them back in.
+         * @type {'local'|'cloud'}
+         */
+        deploymentMode: process.env.NEO_AI_DEPLOYMENT_MODE || 'local',
+        /**
+         * Maintenance-loop intervals consumed by the orchestrator daemon.
+         * Env vars at the daemon boundary retain precedence over these defaults.
+         * @type {Object}
+         */
+        intervals: {
+            pollMs          : 3000,
+            summarySweepMs  : 10 * 60 * 1000,
+            kbSyncMs        : 30 * 60 * 1000,
+            backupMs        : DAY_MS,
+            primaryDevSyncMs: 10 * 60 * 1000,
+            dreamMs         : HOUR_MS,
+            goldenPathMs    : HOUR_MS
+        },
+        /**
+         * Local-only maintenance lane switches. Cloud deployments can disable these
+         * without changing remote graph-backed A2A / Memory Core behavior.
+         * `null` means "use the deployment profile default" (`local` enables,
+         * `cloud` disables); set `true` only when explicitly opting a lane back in.
+         * @type {Object}
+         */
+        localOnly: {
+            primaryDevSyncEnabled: null,
+            kbSyncEnabled        : null,
+            bridgeDaemonEnabled  : null,
+            goldenPathRepoEnrichmentEnabled: null,
+            wakeDispatchEnabled  : null
+        },
+        /**
          * Optional local Neo repo roots for the primary-dev-sync lane.
          * Keep the template machine-neutral; set real absolute paths in gitignored
          * `ai/config.mjs` or via `NEO_ORCHESTRATOR_DEV_SYNC_ROOTS`.
@@ -81,6 +119,36 @@ const defaultConfig = {
         mlx: {
             enabled: false,
             model: null
+        }
+    },
+    /**
+     * Agent OS maintenance policy shared by operator scripts and daemons.
+     * @type {Object}
+     */
+    maintenance: {
+        /**
+         * Canonical atomic-bundle backup policy. Bundles remain atomic; per-substrate
+         * retention is intentionally not represented here.
+         * @type {Object}
+         */
+        backup: {
+            intervalMs: DAY_MS,
+            retention: {
+                keepMinimum: 3,
+                maxDays    : 30
+            }
+        },
+        /**
+         * Chroma defrag policy. V1 exposes cadence as operator policy only; no daemon
+         * auto-spawns defrag from this value.
+         * @type {Object}
+         */
+        defrag: {
+            intervalMs: 7 * DAY_MS,
+            snapshotRetention: {
+                keepMinimum: 3,
+                maxDays    : 7
+            }
         }
     },
     /**

--- a/ai/daemons/Orchestrator.mjs
+++ b/ai/daemons/Orchestrator.mjs
@@ -219,6 +219,12 @@ export class Orchestrator extends Base {
          */
         kbSyncIntervalMs_: DEFAULT_KB_SYNC_INTERVAL_MS,
         /**
+         * @member {Boolean} kbSyncEnabled_=true
+         * @protected
+         * @reactive
+         */
+        kbSyncEnabled_: true,
+        /**
          * @member {Number} backupIntervalMs_=86400000
          * @protected
          * @reactive
@@ -237,6 +243,12 @@ export class Orchestrator extends Base {
          */
         primaryDevSyncEnabled_: true,
         /**
+         * @member {Boolean} bridgeDaemonEnabled_=true
+         * @protected
+         * @reactive
+         */
+        bridgeDaemonEnabled_: true,
+        /**
          * @member {String[]|String|null} primaryDevSyncRootsConfig_=null
          * @protected
          * @reactive
@@ -254,6 +266,12 @@ export class Orchestrator extends Base {
          * @reactive
          */
         goldenPathIntervalMs_: DEFAULT_GOLDEN_PATH_INTERVAL_MS,
+        /**
+         * @member {Boolean} goldenPathRepoEnrichmentEnabled_=true
+         * @protected
+         * @reactive
+         */
+        goldenPathRepoEnrichmentEnabled_: true,
         /**
          * @member {Object} healthService_=HealthService
          * @protected
@@ -357,10 +375,22 @@ export class Orchestrator extends Base {
             DEFAULT_SUMMARY_SWEEP_INTERVAL_MS
         );
         this.kbSyncIntervalMs       = options.kbSyncIntervalMs ?? this.cadenceEngine.parseInterval(process.env.NEO_ORCHESTRATOR_KB_SYNC_INTERVAL_MS, DEFAULT_KB_SYNC_INTERVAL_MS);
+        this.kbSyncEnabled          = options.kbSyncEnabled ?? parseEnabledFlag(
+            process.env.NEO_ORCHESTRATOR_KB_SYNC_ENABLED,
+            true
+        );
         this.backupIntervalMs       = options.backupIntervalMs ?? this.cadenceEngine.parseInterval(process.env.NEO_ORCHESTRATOR_BACKUP_INTERVAL_MS, DEFAULT_BACKUP_INTERVAL_MS);
         this.primaryDevSyncIntervalMs = options.primaryDevSyncIntervalMs ?? this.cadenceEngine.parseInterval(process.env.NEO_ORCHESTRATOR_PRIMARY_DEV_SYNC_INTERVAL_MS, DEFAULT_PRIMARY_DEV_SYNC_INTERVAL_MS);
         this.primaryDevSyncEnabled  = options.primaryDevSyncEnabled ?? parseEnabledFlag(
             process.env.NEO_ORCHESTRATOR_PRIMARY_DEV_SYNC_ENABLED,
+            true
+        );
+        this.bridgeDaemonEnabled    = options.bridgeDaemonEnabled ?? parseEnabledFlag(
+            process.env.NEO_ORCHESTRATOR_BRIDGE_DAEMON_ENABLED,
+            true
+        );
+        this.goldenPathRepoEnrichmentEnabled = options.goldenPathRepoEnrichmentEnabled ?? parseEnabledFlag(
+            process.env.NEO_ORCHESTRATOR_GOLDEN_PATH_REPO_ENRICHMENT_ENABLED,
             true
         );
         this.primaryDevSyncRootsConfig = options.primaryDevSyncRootsConfig ?? null;
@@ -806,7 +836,11 @@ export class Orchestrator extends Base {
             healthService: this.healthService
         };
 
-        const continuousTasks = ['chroma', 'bridgeDaemon', 'mlx'];
+        const continuousTasks = [
+            'chroma',
+            ...(this.bridgeDaemonEnabled ? ['bridgeDaemon'] : []),
+            'mlx'
+        ];
         const RESTART_COOLDOWN_MS = 15000;
         for (const taskName of continuousTasks) {
             const state = this.taskStateService.getTaskState(taskName);
@@ -832,6 +866,10 @@ export class Orchestrator extends Base {
         }, executeMaintenanceTask(executeTask), context);
 
         this.cadenceEngine.runIfDue('kbSync', () => {
+            if (!this.kbSyncEnabled) {
+                return null;
+            }
+
             if (this.cadenceEngine.shouldRunIntervalTask({
                 now,
                 lastRunAt : this.taskStateService.getTaskState('kbSync').lastRunAt,
@@ -918,7 +956,9 @@ export class Orchestrator extends Base {
             this.taskStateService.markStarted(taskName, reason.reason);
             this.healthService?.recordTaskOutcome?.(taskName, 'running', { reason, startedAt: new Date().toISOString() });
             try {
-                await this.goldenPathSynthesizer.synthesizeGoldenPath();
+                await this.goldenPathSynthesizer.synthesizeGoldenPath({
+                    repoEnrichmentEnabled: this.goldenPathRepoEnrichmentEnabled
+                });
                 this.taskStateService.markCompleted(taskName);
                 this.healthService?.recordTaskOutcome?.(taskName, 'completed', { reason, completedAt: new Date().toISOString() });
             } catch (e) {

--- a/ai/daemons/services/GoldenPathSynthesizer.mjs
+++ b/ai/daemons/services/GoldenPathSynthesizer.mjs
@@ -102,7 +102,9 @@ class GoldenPathSynthesizer extends Base {
         return JSON.parse(rawPrData);
     }
 
-    async synthesizeGoldenPath() {
+    async synthesizeGoldenPath({
+        repoEnrichmentEnabled = true
+    } = {}) {
         logger.info('[GoldenPathSynthesizer] Initializing Hybrid GraphRAG Strategic Traversal...');
 
         let graphColl = null;
@@ -461,125 +463,129 @@ DO NOT output markdown, \`\`\`json blocks, or any other explanations. Provide pu
 
         // --- Active PR Cycle State ---
         let prStateAppend = '';
-        try {
-            const prs = await this.fetchOpenPRs();
+        if (repoEnrichmentEnabled) {
+            try {
+                const prs = await this.fetchOpenPRs();
 
-            const agentLogins = ['neo-opus-4-7', 'neo-gemini-3-1-pro', 'neo-gpt'];
-            const agentPrs = prs.filter(pr => pr.author && agentLogins.includes(pr.author.login));
+                const agentLogins = ['neo-opus-4-7', 'neo-gemini-3-1-pro', 'neo-gpt'];
+                const agentPrs = prs.filter(pr => pr.author && agentLogins.includes(pr.author.login));
 
-            if (agentPrs.length > 0) {
-                prStateAppend += `\n## Active PR Cycle State\n\n`;
-                prStateAppend += `*Captured at: ${new Date().toISOString()} (Source: GitHub Live)*\n\n`;
+                if (agentPrs.length > 0) {
+                    prStateAppend += `\n## Active PR Cycle State\n\n`;
+                    prStateAppend += `*Captured at: ${new Date().toISOString()} (Source: GitHub Live)*\n\n`;
 
-                // Group by agent
-                agentLogins.forEach(agent => {
-                    const myPrs = agentPrs.filter(pr => pr.author.login === agent);
-                    if (myPrs.length > 0) {
-                        prStateAppend += `### @${agent}\n`;
-                        myPrs.forEach(pr => {
-                            // Extract lane-state
-                            let laneState = 'unknown';
-                            const laneMatch = pr.body.match(/lane-state:\s*([^\s]+)/);
-                            if (laneMatch) {
-                                laneState = laneMatch[1];
-                            }
-                            // Attempt to find cycle #. For example, "Cycle 3" in body or title.
-                            let cycle = '1';
-                            const cycleMatch = pr.body.match(/Cycle\s*(\d+)/i) || pr.title.match(/Cycle\s*(\d+)/i);
-                            if (cycleMatch) {
-                                cycle = cycleMatch[1];
-                            }
-
-                            // Combine reviews and comments, sort by creation time (most recent first)
-                            const allInteractions = [
-                                ...(pr.reviews || []).map(r => ({ body: r.body, date: new Date(r.submittedAt), state: r.state, type: 'review' })),
-                                ...(pr.comments || []).map(c => ({ body: c.body, date: new Date(c.createdAt), type: 'comment' }))
-                            ].sort((a, b) => b.date - a.date);
-
-                            let foundCycle = false;
-                            for (const interaction of allInteractions) {
-                                if (laneState === 'unknown') {
-                                    const rLaneMatch = interaction.body.match(/lane-state:\s*([^\s]+)/);
-                                    if (rLaneMatch) laneState = rLaneMatch[1];
+                    // Group by agent
+                    agentLogins.forEach(agent => {
+                        const myPrs = agentPrs.filter(pr => pr.author.login === agent);
+                        if (myPrs.length > 0) {
+                            prStateAppend += `### @${agent}\n`;
+                            myPrs.forEach(pr => {
+                                // Extract lane-state
+                                let laneState = 'unknown';
+                                const laneMatch = pr.body.match(/lane-state:\s*([^\s]+)/);
+                                if (laneMatch) {
+                                    laneState = laneMatch[1];
                                 }
-                                if (!foundCycle) {
-                                    const rCycleMatch = interaction.body.match(/Cycle\s*(\d+)/i);
-                                    if (rCycleMatch) {
-                                        cycle = rCycleMatch[1];
-                                        foundCycle = true;
+                                // Attempt to find cycle #. For example, "Cycle 3" in body or title.
+                                let cycle = '1';
+                                const cycleMatch = pr.body.match(/Cycle\s*(\d+)/i) || pr.title.match(/Cycle\s*(\d+)/i);
+                                if (cycleMatch) {
+                                    cycle = cycleMatch[1];
+                                }
+
+                                // Combine reviews and comments, sort by creation time (most recent first)
+                                const allInteractions = [
+                                    ...(pr.reviews || []).map(r => ({ body: r.body, date: new Date(r.submittedAt), state: r.state, type: 'review' })),
+                                    ...(pr.comments || []).map(c => ({ body: c.body, date: new Date(c.createdAt), type: 'comment' }))
+                                ].sort((a, b) => b.date - a.date);
+
+                                let foundCycle = false;
+                                for (const interaction of allInteractions) {
+                                    if (laneState === 'unknown') {
+                                        const rLaneMatch = interaction.body.match(/lane-state:\s*([^\s]+)/);
+                                        if (rLaneMatch) laneState = rLaneMatch[1];
+                                    }
+                                    if (!foundCycle) {
+                                        const rCycleMatch = interaction.body.match(/Cycle\s*(\d+)/i);
+                                        if (rCycleMatch) {
+                                            cycle = rCycleMatch[1];
+                                            foundCycle = true;
+                                        }
+                                    }
+                                    if (laneState !== 'unknown' && foundCycle) break;
+                                }
+
+                                // Determine primary reviewer
+                                let reviewers = pr.reviewRequests?.map(rr => rr.login).join(', ') || 'None';
+
+                                // Determine status
+                                let status = 'Pending';
+                                const latestReview = allInteractions.find(i => i.type === 'review');
+                                if (latestReview) {
+                                    status = latestReview.state;
+                                } else {
+                                    // Check if there's an approval or change request in comments (e.g. from a non-review PR comment)
+                                    const latestCommentStatus = allInteractions.find(i => i.body.match(/\*\*Status:\*\*\s*(Approved|Changes Requested|Pending)/i));
+                                    if (latestCommentStatus) {
+                                        const match = latestCommentStatus.body.match(/\*\*Status:\*\*\s*(Approved|Changes Requested|Pending)/i);
+                                        if (match) status = match[1].toUpperCase();
                                     }
                                 }
-                                if (laneState !== 'unknown' && foundCycle) break;
-                            }
 
-                            // Determine primary reviewer
-                            let reviewers = pr.reviewRequests?.map(rr => rr.login).join(', ') || 'None';
-
-                            // Determine status
-                            let status = 'Pending';
-                            const latestReview = allInteractions.find(i => i.type === 'review');
-                            if (latestReview) {
-                                status = latestReview.state;
-                            } else {
-                                // Check if there's an approval or change request in comments (e.g. from a non-review PR comment)
-                                const latestCommentStatus = allInteractions.find(i => i.body.match(/\*\*Status:\*\*\s*(Approved|Changes Requested|Pending)/i));
-                                if (latestCommentStatus) {
-                                    const match = latestCommentStatus.body.match(/\*\*Status:\*\*\s*(Approved|Changes Requested|Pending)/i);
-                                    if (match) status = match[1].toUpperCase();
-                                }
-                            }
-
-                            prStateAppend += `- **PR #${pr.number}**: [${pr.title}](${pr.url})\n`;
-                            prStateAppend += `  - **Lane State**: \`${laneState}\`\n`;
-                            prStateAppend += `  - **Cycle**: \`${cycle}\`\n`;
-                            prStateAppend += `  - **Reviewers**: ${reviewers}\n`;
-                            prStateAppend += `  - **Status**: \`${status}\`\n`;
-                            prStateAppend += `  - **Head SHA**: \`${pr.headRefOid}\`\n`;
-                        });
-                        prStateAppend += `\n`;
-                    }
-                });
+                                prStateAppend += `- **PR #${pr.number}**: [${pr.title}](${pr.url})\n`;
+                                prStateAppend += `  - **Lane State**: \`${laneState}\`\n`;
+                                prStateAppend += `  - **Cycle**: \`${cycle}\`\n`;
+                                prStateAppend += `  - **Reviewers**: ${reviewers}\n`;
+                                prStateAppend += `  - **Status**: \`${status}\`\n`;
+                                prStateAppend += `  - **Head SHA**: \`${pr.headRefOid}\`\n`;
+                            });
+                            prStateAppend += `\n`;
+                        }
+                    });
+                }
+            } catch (e) {
+                logger.warn('[GoldenPathSynthesizer] Failed to generate Active PR Cycle State', e);
             }
-        } catch (e) {
-            logger.warn('[GoldenPathSynthesizer] Failed to generate Active PR Cycle State', e);
         }
 
         // --- Executive Priority Backlog ---
         const goldenIds = new Set(topNodes.map(item => item.node.id));
         let backlogAppend = '';
-        try {
-            const rawIssuesDir = path.resolve(__dirname, '../../../resources/content/issues');
-            const filesRaw = fs.readdirSync(rawIssuesDir);
-            const mdFiles = filesRaw.filter(f => f.endsWith('.md'));
-            const openIssuesData = [];
-            for (const file of mdFiles) {
-                const issueId = file.replace(/\\.md$/, '');
-                if (goldenIds.has(issueId)) continue; // Skip if already in Golden Path
+        if (repoEnrichmentEnabled) {
+            try {
+                const rawIssuesDir = path.resolve(__dirname, '../../../resources/content/issues');
+                const filesRaw = fs.readdirSync(rawIssuesDir);
+                const mdFiles = filesRaw.filter(f => f.endsWith('.md'));
+                const openIssuesData = [];
+                for (const file of mdFiles) {
+                    const issueId = file.replace(/\\.md$/, '');
+                    if (goldenIds.has(issueId)) continue; // Skip if already in Golden Path
 
-                // Query SQLite GraphService natively instead of reading the filesystem content again
-                const dbNode = GraphService.db.nodes.get(issueId);
-                if (dbNode && (dbNode.state === 'OPEN' || dbNode.properties?.state === 'OPEN')) {
-                    if (!dbNode.properties?.labels?.includes('needs-re-triage')) {
-                        const numericId = parseInt(issueId.replace('issue-', ''), 10) || 0;
-                        openIssuesData.push({ id: issueId, numericId, node: dbNode });
+                    // Query SQLite GraphService natively instead of reading the filesystem content again
+                    const dbNode = GraphService.db.nodes.get(issueId);
+                    if (dbNode && (dbNode.state === 'OPEN' || dbNode.properties?.state === 'OPEN')) {
+                        if (!dbNode.properties?.labels?.includes('needs-re-triage')) {
+                            const numericId = parseInt(issueId.replace('issue-', ''), 10) || 0;
+                            openIssuesData.push({ id: issueId, numericId, node: dbNode });
+                        }
                     }
                 }
-            }
 
-            openIssuesData.sort((a, b) => b.numericId - a.numericId);
-            const latest5 = openIssuesData.slice(0, 5);
+                openIssuesData.sort((a, b) => b.numericId - a.numericId);
+                const latest5 = openIssuesData.slice(0, 5);
 
-            if (latest5.length > 0) {
-                backlogAppend += `\n## 📋 Latest Priority Backlog\n\nThe following open tickets represent the most recently created structural objectives.\n\n`;
-                latest5.forEach((item, idx) => {
-                   const title = item.node.properties?.title || item.node.properties?.name || item.node.name || 'Unknown Title';
-                   const labels = item.node.properties?.labels || [];
-                   const labelTags = labels.length > 0 ? ' [\\`' + labels.join('\\`, \\`') + '\\`]' : '';
-                   backlogAppend += `${idx + 1}. **${item.id}**${labelTags}\n   - *${title}*\n`;
-                });
+                if (latest5.length > 0) {
+                    backlogAppend += `\n## 📋 Latest Priority Backlog\n\nThe following open tickets represent the most recently created structural objectives.\n\n`;
+                    latest5.forEach((item, idx) => {
+                       const title = item.node.properties?.title || item.node.properties?.name || item.node.name || 'Unknown Title';
+                       const labels = item.node.properties?.labels || [];
+                       const labelTags = labels.length > 0 ? ' [\\`' + labels.join('\\`, \\`') + '\\`]' : '';
+                       backlogAppend += `${idx + 1}. **${item.id}**${labelTags}\n   - *${title}*\n`;
+                    });
+                }
+            } catch (e) {
+                logger.warn('[GoldenPathSynthesizer] Failed to generate Latest Priority Backlog', e);
             }
-        } catch (e) {
-            logger.warn('[GoldenPathSynthesizer] Failed to generate Latest Priority Backlog', e);
         }
 
         handoffContent += `${prStateAppend}${backlogAppend}${markdownAppend}`;

--- a/ai/scripts/orchestrator-daemon.mjs
+++ b/ai/scripts/orchestrator-daemon.mjs
@@ -38,6 +38,24 @@ const PID_FILE        = path.join(DAEMON_DATA_DIR, 'orchestrator-daemon.pid');
 const LOG_FILE        = path.join(DAEMON_DATA_DIR, 'orchestrator.log');
 export const LOCAL_AI_CONFIG_FILE = fileURLToPath(new URL('../config.mjs', import.meta.url));
 
+const hasEnvValue = (env, key) => env[key] !== undefined && env[key] !== null && env[key] !== '';
+
+function assignConfigInterval(options, key, value, envNames, env) {
+    if (envNames.some(name => hasEnvValue(env, name))) return;
+    if (Number.isFinite(value) && value > 0) {
+        options[key] = value;
+    }
+}
+
+function assignLocalOnlyToggle(options, key, value, envName, deploymentMode, env) {
+    if (hasEnvValue(env, envName)) return;
+    if (typeof value === 'boolean') {
+        options[key] = value;
+    } else if (deploymentMode === 'cloud') {
+        options[key] = false;
+    }
+}
+
 function writeLog(level, message) {
     const timestamp = new Date().toISOString();
     const line      = `[${timestamp}] [PID:${process.pid}] [${level}] ${message}`;
@@ -153,6 +171,87 @@ export async function loadLocalAiConfig({
 }
 
 /**
+ * Resolves daemon start options from the Tier-1 AI config while preserving env precedence.
+ * @param {Object} [options]
+ * @param {Object} [options.orchestratorConfig={}] Top-level `orchestrator` config block.
+ * @param {Object} [options.maintenanceConfig={}] Top-level `maintenance` config block.
+ * @param {Object} [options.env=process.env] Environment source.
+ * @returns {Object}
+ */
+export function resolveOrchestratorStartOptions({
+    orchestratorConfig = {},
+    maintenanceConfig  = {},
+    env                = process.env
+} = {}) {
+    const options   = {};
+    const intervals = orchestratorConfig.intervals || {};
+
+    assignConfigInterval(options, 'pollIntervalMs', intervals.pollMs, ['NEO_ORCHESTRATOR_POLL_INTERVAL_MS'], env);
+    assignConfigInterval(
+        options,
+        'summarySweepIntervalMs',
+        intervals.summarySweepMs,
+        ['NEO_ORCHESTRATOR_SUMMARY_SWEEP_INTERVAL_MS', 'NEO_SUMMARIZATION_SWEEP_INTERVAL_MS'],
+        env
+    );
+    assignConfigInterval(options, 'kbSyncIntervalMs', intervals.kbSyncMs, ['NEO_ORCHESTRATOR_KB_SYNC_INTERVAL_MS'], env);
+    assignConfigInterval(
+        options,
+        'backupIntervalMs',
+        intervals.backupMs ?? maintenanceConfig.backup?.intervalMs,
+        ['NEO_ORCHESTRATOR_BACKUP_INTERVAL_MS'],
+        env
+    );
+    assignConfigInterval(
+        options,
+        'primaryDevSyncIntervalMs',
+        intervals.primaryDevSyncMs,
+        ['NEO_ORCHESTRATOR_PRIMARY_DEV_SYNC_INTERVAL_MS'],
+        env
+    );
+    assignConfigInterval(options, 'dreamIntervalMs', intervals.dreamMs, [], env);
+    assignConfigInterval(options, 'goldenPathIntervalMs', intervals.goldenPathMs, [], env);
+
+    const deploymentMode = orchestratorConfig.deploymentMode || 'local';
+    const localOnly      = orchestratorConfig.localOnly || {};
+
+    assignLocalOnlyToggle(
+        options,
+        'primaryDevSyncEnabled',
+        localOnly.primaryDevSyncEnabled,
+        'NEO_ORCHESTRATOR_PRIMARY_DEV_SYNC_ENABLED',
+        deploymentMode,
+        env
+    );
+    assignLocalOnlyToggle(
+        options,
+        'kbSyncEnabled',
+        localOnly.kbSyncEnabled,
+        'NEO_ORCHESTRATOR_KB_SYNC_ENABLED',
+        deploymentMode,
+        env
+    );
+    assignLocalOnlyToggle(
+        options,
+        'bridgeDaemonEnabled',
+        localOnly.bridgeDaemonEnabled,
+        'NEO_ORCHESTRATOR_BRIDGE_DAEMON_ENABLED',
+        deploymentMode,
+        env
+    );
+    assignLocalOnlyToggle(
+        options,
+        'goldenPathRepoEnrichmentEnabled',
+        localOnly.goldenPathRepoEnrichmentEnabled,
+        'NEO_ORCHESTRATOR_GOLDEN_PATH_REPO_ENRICHMENT_ENABLED',
+        deploymentMode,
+        env
+    );
+
+    return options;
+}
+
+/**
  * Starts the singleton orchestrator daemon.
  * @param {Object} [options] Runtime overrides for tests or process managers.
  * @returns {Promise<void>}
@@ -163,6 +262,7 @@ export async function startOrchestrator(options = {}) {
     setupCleanupHandlers();
     await loadLocalAiConfig();
     const orchestratorConfig = AiConfig.orchestrator || {};
+    const maintenanceConfig  = AiConfig.maintenance || {};
     const mlxConfig          = orchestratorConfig.mlx || {};
     const mlxEnabled         = process.env.NEO_ORCHESTRATOR_MLX_ENABLED !== undefined
         ? undefined
@@ -172,6 +272,7 @@ export async function startOrchestrator(options = {}) {
         primaryDevSyncRootsConfig: orchestratorConfig.devSyncRoots,
         mlxEnabled: mlxEnabled ?? undefined,
         mlxModel  : mlxConfig.model || undefined,
+        ...resolveOrchestratorStartOptions({orchestratorConfig, maintenanceConfig}),
         ...options
     });
 }

--- a/buildScripts/ai/backup.mjs
+++ b/buildScripts/ai/backup.mjs
@@ -11,6 +11,7 @@ import {fileURLToPath}  from 'url';
 import Neo              from '../../src/Neo.mjs';
 import * as core        from '../../src/core/_export.mjs';
 import InstanceManager  from '../../src/manager/Instance.mjs';
+import AiConfig         from '../../ai/config.template.mjs';
 import kbConfig         from '../../ai/mcp/server/knowledge-base/config.mjs';
 import mcConfig         from '../../ai/mcp/server/memory-core/config.mjs';
 
@@ -106,6 +107,43 @@ const DEFAULT_CONCEPTS_DIR      = path.join(PROJECT_ROOT, '.neo-ai-data', 'conce
 const DEFAULT_TRAJECTORIES_FILE = path.join(PROJECT_ROOT, '.neo-ai-data', 'datasets', 'rlaif', 'trajectories.jsonl');
 const DEFAULT_SENT_TO_CULL_FILE = path.join(path.dirname(mcConfig.storagePaths.graph), 'sent-to-cull.jsonl');
 const DEFAULT_BACKUP_ROOT       = path.join(PROJECT_ROOT, '.neo-ai-data', 'backups');
+export const LOCAL_AI_CONFIG_FILE = path.join(PROJECT_ROOT, 'ai', 'config.mjs');
+
+/**
+ * Loads the gitignored Tier-1 AI config for operator-run scripts when present.
+ * @param {Object} [options]
+ * @param {String} [options.configPath=LOCAL_AI_CONFIG_FILE] Config path.
+ * @param {Object} [options.aiConfig=AiConfig] Config singleton.
+ * @param {Object} [options.fsModule=fs] Filesystem seam.
+ * @returns {Promise<Object>}
+ */
+export async function loadTopLevelAiConfig({
+    configPath = LOCAL_AI_CONFIG_FILE,
+    aiConfig   = AiConfig,
+    fsModule   = fs
+} = {}) {
+    if (!await fsModule.pathExists(configPath)) {
+        return {loaded: false, configPath};
+    }
+
+    await aiConfig.load(configPath);
+
+    return {loaded: true, configPath};
+}
+
+/**
+ * Resolves atomic-bundle retention from Tier-1 AI config with legacy fallback.
+ * @param {Object} [options]
+ * @param {Object} [options.aiConfig=AiConfig] Tier-1 AI config.
+ * @param {Object} [options.memoryCoreConfig=mcConfig] Memory Core config fallback.
+ * @returns {Object}
+ */
+export function resolveBackupRetention({
+    aiConfig = AiConfig,
+    memoryCoreConfig = mcConfig
+} = {}) {
+    return aiConfig.maintenance?.backup?.retention || memoryCoreConfig.backupRetention || {};
+}
 
 /**
  * Executes a full-substrate backup.
@@ -175,12 +213,10 @@ export async function runBackup({
     subsystems.mailbox = await copyJsonlSource(sentToCullSourceFile, layout.mailbox, logger);
 
     logger.log('[7/7] Applying retention sweep...');
-    // Phase 4 (#11663): operator-configurable retention via `mcConfig.backupRetention`.
-    // Falls through to the legacy hardcoded defaults (`K=3, N_DAYS=30`) when the config
-    // key is absent — pre-#11663 deployments retain identical behavior without operator
-    // action. The atomic-bundle architecture is preserved (per-substrate retention
-    // asymmetry deferred to a follow-up post-Phase-2 per #11628 framing).
-    await cleanOldBackups(DEFAULT_BACKUP_ROOT, logger, mcConfig.backupRetention);
+    await loadTopLevelAiConfig();
+    // Operator-configurable retention comes from Tier-1 AI maintenance policy when
+    // available. Missing keys fall through to legacy Memory Core config/defaults.
+    await cleanOldBackups(DEFAULT_BACKUP_ROOT, logger, resolveBackupRetention());
 
     logger.log('Verifying bundle integrity (row-count parity)...');
     const integrity = await verifyBundleIntegrity(layout, subsystems);

--- a/buildScripts/ai/defragChromaDB.mjs
+++ b/buildScripts/ai/defragChromaDB.mjs
@@ -3,8 +3,9 @@ import {ChromaClient}  from 'chromadb';
 import {execSync}      from 'child_process';
 import fs              from 'fs-extra';
 import path            from 'path';
-import {fileURLToPath} from 'url';
+import {fileURLToPath, pathToFileURL} from 'url';
 import Neo             from '../../src/Neo.mjs';
+import AiConfig        from '../../ai/config.template.mjs';
 
 /**
  * @summary A generic CLI tool to defragment ChromaDB instances (Knowledge Base & Memory Core).
@@ -56,6 +57,7 @@ import Neo             from '../../src/Neo.mjs';
 const __filename   = fileURLToPath(import.meta.url);
 const __dirname    = path.dirname(__filename);
 const PROJECT_ROOT = path.resolve(__dirname, '../..');
+export const LOCAL_AI_CONFIG_FILE = path.join(PROJECT_ROOT, 'ai', 'config.mjs');
 
 // Configuration Mapping
 // Maps CLI target names to their respective config files and adapts the config structure
@@ -106,14 +108,54 @@ async function loadConfig(targetName) {
 }
 
 /**
+ * Loads the gitignored Tier-1 AI config for operator-run scripts when present.
+ * @param {Object} [options]
+ * @param {String} [options.configPath=LOCAL_AI_CONFIG_FILE] Config path.
+ * @param {Object} [options.aiConfig=AiConfig] Config singleton.
+ * @param {Object} [options.fsModule=fs] Filesystem seam.
+ * @returns {Promise<Object>}
+ */
+export async function loadTopLevelAiConfig({
+    configPath = LOCAL_AI_CONFIG_FILE,
+    aiConfig   = AiConfig,
+    fsModule   = fs
+} = {}) {
+    if (!await fsModule.pathExists(configPath)) {
+        return {loaded: false, configPath};
+    }
+
+    await aiConfig.load(configPath);
+
+    return {loaded: true, configPath};
+}
+
+/**
+ * Resolves defrag snapshot retention from Tier-1 AI maintenance config.
+ * @param {Object} [options]
+ * @param {Object} [options.aiConfig=AiConfig] Tier-1 AI config.
+ * @returns {Object}
+ */
+export function resolveDefragSnapshotRetention({
+    aiConfig = AiConfig
+} = {}) {
+    return aiConfig.maintenance?.defrag?.snapshotRetention || {};
+}
+
+/**
  * Manages backup retention.
- * Policy: Keep last 3 backups, delete others if older than 7 days.
+ * Policy: Keep the newest `keepMinimum` snapshots, delete older extras after `maxDays`.
  *
  * @param {String} backupDir - The directory containing backups.
+ * @param {Object} [retention] Retention policy.
+ * @param {Number} [retention.keepMinimum=3] Newest snapshots retained unconditionally.
+ * @param {Number} [retention.maxDays=7] Extra snapshots older than this are removed.
  */
-async function cleanOldBackups(backupDir) {
+export async function cleanOldBackups(backupDir, retention = resolveDefragSnapshotRetention()) {
     try {
         if (!await fs.pathExists(backupDir)) return;
+
+        const keepMinimum = Number.isInteger(retention?.keepMinimum) ? retention.keepMinimum : 3;
+        const maxDays     = Number.isFinite(retention?.maxDays) ? retention.maxDays : 7;
 
         const entries = await fs.readdir(backupDir, {withFileTypes: true});
         const backups = entries
@@ -132,12 +174,11 @@ async function cleanOldBackups(backupDir) {
             .filter(b => !isNaN(b.time))
             .sort((a, b) => b.time - a.time); // Newest first
 
-        // Always keep the newest 3
-        const toCheck = backups.slice(3);
-        const weekAgo = Date.now() - (7 * 24 * 60 * 60 * 1000);
+        const toCheck = backups.slice(keepMinimum);
+        const cutoff  = Date.now() - (maxDays * 24 * 60 * 60 * 1000);
 
         for (const backup of toCheck) {
-            if (backup.time < weekAgo) {
+            if (backup.time < cutoff) {
                 console.log(`   🗑️  Removing old backup: ${backup.name}`);
                 await fs.remove(backup.path);
             }
@@ -218,6 +259,8 @@ async function defragChromaDB() {
     console.log(`🧹 Starting Defragmentation for target: ${targetName}`);
 
     try {
+        await loadTopLevelAiConfig();
+
         const config  = await loadConfig(targetName);
         const DB_PATH = config.path;
 
@@ -254,7 +297,7 @@ async function defragChromaDB() {
         console.log(`   ✅ Pre-nuke snapshot created (defrag-exclusive, not the canonical backup).`);
 
         // 1.1 Cleanup Old Backups
-        await cleanOldBackups(backupRoot);
+        await cleanOldBackups(backupRoot, resolveDefragSnapshotRetention());
 
         // 2. Connect
         console.log(`\n2️⃣  Connecting to ChromaDB...`);
@@ -470,6 +513,8 @@ async function defragChromaDB() {
     }
 }
 
-defragChromaDB().then(() => {
-    process.exit(0);
-});
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+    defragChromaDB().then(() => {
+        process.exit(0);
+    });
+}

--- a/test/playwright/unit/ai/buildScripts/backup-retention.spec.mjs
+++ b/test/playwright/unit/ai/buildScripts/backup-retention.spec.mjs
@@ -41,12 +41,16 @@ test.describe.configure({mode: 'serial'});
 
 test.describe('cleanOldBackups — configurable retention (#11663)', () => {
     let cleanOldBackups;
+    let loadTopLevelAiConfig;
+    let resolveBackupRetention;
     let tmpRoot;
     let mtimeNudge = 0;
 
     test.beforeAll(async () => {
         const mod = await import('../../../../../buildScripts/ai/backup.mjs');
-        cleanOldBackups = mod.cleanOldBackups;
+        cleanOldBackups        = mod.cleanOldBackups;
+        loadTopLevelAiConfig   = mod.loadTopLevelAiConfig;
+        resolveBackupRetention = mod.resolveBackupRetention;
     });
 
     test.beforeEach(async () => {
@@ -205,5 +209,161 @@ test.describe('cleanOldBackups — configurable retention (#11663)', () => {
         const remaining = await listBackups();
         // K=0 → no unconditional retention; N=0 → anything older than 0 days (any age) eligible
         expect(remaining).toHaveLength(0);
+    });
+
+    test('resolves backup retention from top-level maintenance config before legacy Memory Core fallback', () => {
+        expect(resolveBackupRetention({
+            aiConfig: {
+                maintenance: {
+                    backup: {
+                        retention: {
+                            keepMinimum: 7,
+                            maxDays    : 14
+                        }
+                    }
+                }
+            },
+            memoryCoreConfig: {
+                backupRetention: {
+                    keepMinimum: 3,
+                    maxDays    : 30
+                }
+            }
+        })).toEqual({
+            keepMinimum: 7,
+            maxDays    : 14
+        });
+    });
+
+    test('falls back to legacy Memory Core backupRetention when top-level maintenance is absent', () => {
+        expect(resolveBackupRetention({
+            aiConfig: {},
+            memoryCoreConfig: {
+                backupRetention: {
+                    keepMinimum: 5,
+                    maxDays    : 20
+                }
+            }
+        })).toEqual({
+            keepMinimum: 5,
+            maxDays    : 20
+        });
+    });
+
+    test('loads gitignored top-level AI config only when present', async () => {
+        const loadedPaths = [];
+        const aiConfig = {
+            async load(configPath) {
+                loadedPaths.push(configPath);
+            }
+        };
+        const fsModule = {
+            async pathExists(configPath) {
+                return configPath.endsWith('/present-config.mjs');
+            }
+        };
+
+        await expect(loadTopLevelAiConfig({
+            configPath: '/tmp/missing-config.mjs',
+            aiConfig,
+            fsModule
+        })).resolves.toEqual({
+            loaded    : false,
+            configPath: '/tmp/missing-config.mjs'
+        });
+
+        await expect(loadTopLevelAiConfig({
+            configPath: '/tmp/present-config.mjs',
+            aiConfig,
+            fsModule
+        })).resolves.toEqual({
+            loaded    : true,
+            configPath: '/tmp/present-config.mjs'
+        });
+
+        expect(loadedPaths).toEqual(['/tmp/present-config.mjs']);
+    });
+});
+
+test.describe('defragChromaDB cleanOldBackups — configurable snapshot retention (#11722)', () => {
+    let cleanOldDefragBackups;
+    let resolveDefragSnapshotRetention;
+    let tmpRoot;
+    let timestampNudge = 0;
+
+    test.beforeAll(async () => {
+        const mod = await import('../../../../../buildScripts/ai/defragChromaDB.mjs');
+        cleanOldDefragBackups        = mod.cleanOldBackups;
+        resolveDefragSnapshotRetention = mod.resolveDefragSnapshotRetention;
+    });
+
+    test.beforeEach(async () => {
+        tmpRoot = path.resolve(process.cwd(), 'tmp', `defrag-retention-${process.pid}-${Date.now()}-${++timestampNudge}`);
+        await fs.ensureDir(tmpRoot);
+    });
+
+    test.afterEach(async () => {
+        if (tmpRoot && await fs.pathExists(tmpRoot)) {
+            await fs.remove(tmpRoot);
+        }
+    });
+
+    async function seedDefragBackup(ageInDays) {
+        const timestamp = Math.floor(Date.now() - ageInDays * 86400000 - ++timestampNudge);
+        const dirName   = `backup-${timestamp}`;
+        const dirPath   = path.join(tmpRoot, dirName);
+
+        await fs.ensureDir(dirPath);
+        await fs.writeFile(path.join(dirPath, 'placeholder'), 'test-marker');
+
+        return dirName;
+    }
+
+    async function listDefragBackups() {
+        const entries = await fs.readdir(tmpRoot);
+        return entries.filter(name => name.startsWith('backup-'));
+    }
+
+    test('default snapshot config (K=3, N=7 days) matches pre-#11722 hardcoded behavior', async () => {
+        await seedDefragBackup(1);
+        await seedDefragBackup(3);
+        await seedDefragBackup(5);
+        await seedDefragBackup(10);
+        await seedDefragBackup(20);
+
+        await cleanOldDefragBackups(tmpRoot, undefined);
+
+        const remaining = await listDefragBackups();
+        expect(remaining).toHaveLength(3);
+    });
+
+    test('tighter snapshot config deletes old extras outside the keepMinimum floor', async () => {
+        await seedDefragBackup(1);
+        await seedDefragBackup(3);
+        await seedDefragBackup(10);
+        await seedDefragBackup(20);
+
+        await cleanOldDefragBackups(tmpRoot, {keepMinimum: 1, maxDays: 7});
+
+        const remaining = await listDefragBackups();
+        expect(remaining).toHaveLength(2);
+    });
+
+    test('resolves defrag snapshot retention from top-level maintenance config', () => {
+        expect(resolveDefragSnapshotRetention({
+            aiConfig: {
+                maintenance: {
+                    defrag: {
+                        snapshotRetention: {
+                            keepMinimum: 2,
+                            maxDays    : 5
+                        }
+                    }
+                }
+            }
+        })).toEqual({
+            keepMinimum: 2,
+            maxDays    : 5
+        });
     });
 });

--- a/test/playwright/unit/ai/config.template.spec.mjs
+++ b/test/playwright/unit/ai/config.template.spec.mjs
@@ -1,5 +1,6 @@
 import { test, expect } from '@playwright/test';
 import '../../../../src/Neo.mjs';
+import '../../../../src/core/_export.mjs';
 import Config from '../../../../ai/config.template.mjs';
 
 test.describe('Tier 1 Config Immutability', () => {
@@ -20,5 +21,40 @@ test.describe('Tier 1 Config Immutability', () => {
 
     test('ships a machine-neutral orchestrator dev-sync root default', async () => {
         expect(Config.orchestrator.devSyncRoots).toEqual([]);
+    });
+
+    test('ships top-level deployment and maintenance policy defaults', async () => {
+        expect(Config.orchestrator.deploymentMode).toBe('local');
+        expect(Config.orchestrator.intervals).toMatchObject({
+            pollMs          : 3000,
+            summarySweepMs  : 10 * 60 * 1000,
+            kbSyncMs        : 30 * 60 * 1000,
+            backupMs        : 24 * 60 * 60 * 1000,
+            primaryDevSyncMs: 10 * 60 * 1000,
+            dreamMs         : 60 * 60 * 1000,
+            goldenPathMs    : 60 * 60 * 1000
+        });
+        expect(Config.orchestrator.localOnly).toEqual({
+            primaryDevSyncEnabled: null,
+            kbSyncEnabled        : null,
+            bridgeDaemonEnabled  : null,
+            goldenPathRepoEnrichmentEnabled: null,
+            wakeDispatchEnabled  : null
+        });
+
+        expect(Config.maintenance.backup).toEqual({
+            intervalMs: 24 * 60 * 60 * 1000,
+            retention: {
+                keepMinimum: 3,
+                maxDays    : 30
+            }
+        });
+        expect(Config.maintenance.defrag).toEqual({
+            intervalMs: 7 * 24 * 60 * 60 * 1000,
+            snapshotRetention: {
+                keepMinimum: 3,
+                maxDays    : 7
+            }
+        });
     });
 });

--- a/test/playwright/unit/ai/daemons/Orchestrator.spec.mjs
+++ b/test/playwright/unit/ai/daemons/Orchestrator.spec.mjs
@@ -56,12 +56,15 @@ function createTestOrchestrator(config = {}) {
         taskStateService_       : TaskStateService,
         summarySweepIntervalMs  : config.summarySweepIntervalMs ?? 600000,
         kbSyncIntervalMs        : config.kbSyncIntervalMs ?? 600000,
+        kbSyncEnabled           : config.kbSyncEnabled ?? true,
         backupIntervalMs        : config.backupIntervalMs ?? 86400000,
         primaryDevSyncIntervalMs: config.primaryDevSyncIntervalMs ?? 600000,
         primaryDevSyncEnabled   : config.primaryDevSyncEnabled ?? false,
+        bridgeDaemonEnabled     : config.bridgeDaemonEnabled ?? true,
         primaryDevSyncRootsConfig: config.primaryDevSyncRootsConfig ?? null,
         dreamIntervalMs         : config.dreamIntervalMs ?? Number.MAX_SAFE_INTEGER,
         goldenPathIntervalMs    : config.goldenPathIntervalMs ?? Number.MAX_SAFE_INTEGER,
+        goldenPathRepoEnrichmentEnabled: config.goldenPathRepoEnrichmentEnabled ?? true,
         healthService           : config.healthService || {recordTaskOutcome() {}},
         summarizationCoordinator: config.summarizationCoordinator || {getDueTask: () => null},
         backupCoordinator       : config.backupCoordinator || {getDueTask: () => null},
@@ -247,6 +250,48 @@ test.describe('Neo.ai.daemons.Orchestrator (#11009)', () => {
         }]);
     });
 
+    test('does not schedule kbSync when deployment config disables the local-checkout sync lane', () => {
+        const started = [];
+
+        const orchestrator = createTestOrchestrator({
+            kbSyncEnabled: false
+        });
+
+        orchestrator.processSupervisorService = {
+            runTask(taskName, reason) {
+                started.push({taskName, reason});
+                return true;
+            }
+        };
+
+        orchestrator.poll();
+
+        expect(started).toEqual([]);
+    });
+
+    test('does not restart bridge-daemon when deployment config disables local wake delivery', () => {
+        const started = [];
+
+        const orchestrator = createTestOrchestrator({
+            bridgeDaemonEnabled: false,
+            kbSyncEnabled     : false
+        });
+
+        TaskStateService.taskState.bridgeDaemon.running   = false;
+        TaskStateService.taskState.bridgeDaemon.lastRunAt = 0;
+
+        orchestrator.processSupervisorService = {
+            runTask(taskName, reason) {
+                started.push({taskName, reason});
+                return true;
+            }
+        };
+
+        orchestrator.poll();
+
+        expect(started).toEqual([]);
+    });
+
     test('defers golden path behind active dream graph mutation with explicit reason', () => {
         const logs     = [];
         const outcomes = [];
@@ -307,6 +352,27 @@ test.describe('Neo.ai.daemons.Orchestrator (#11009)', () => {
         await Promise.resolve();
 
         expect(calls).toEqual(['golden-path']);
+    });
+
+    test('passes deployment-mode repo enrichment toggle into golden path synthesis', async () => {
+        const calls = [];
+
+        const orchestrator = createTestOrchestrator({
+            kbSyncEnabled: false,
+            goldenPathIntervalMs: 600000,
+            goldenPathRepoEnrichmentEnabled: false,
+            goldenPathSynthesizer: {
+                synthesizeGoldenPath(options) {
+                    calls.push(options);
+                    return Promise.resolve();
+                }
+            }
+        });
+
+        orchestrator.poll();
+        await Promise.resolve();
+
+        expect(calls).toEqual([{repoEnrichmentEnabled: false}]);
     });
 
     test('keeps continuous daemon supervision outside heavy maintenance backpressure', () => {

--- a/test/playwright/unit/ai/daemons/services/GoldenPathSynthesizer.spec.mjs
+++ b/test/playwright/unit/ai/daemons/services/GoldenPathSynthesizer.spec.mjs
@@ -139,6 +139,35 @@ test.describe('Neo.ai.daemons.services.GoldenPathSynthesizer', () => {
         expect(handoffContent).toContain('- **Head SHA**: `abcdef1234567890`');
     });
 
+    test('synthesizeGoldenPath skips Neo repo enrichment sections when deployment config disables them', async () => {
+        const originalGetGraphCollection = StorageRouter.getGraphCollection;
+        const originalGetSummaryCollection = StorageRouter.getSummaryCollection;
+        const originalEmbedText = TextEmbeddingService.embedText;
+        const originalFetchOpenPRs = GoldenPathSynthesizer.fetchOpenPRs;
+        aiConfig.vectorDimension = 2;
+
+        StorageRouter.getGraphCollection = async () => ({ query: async () => ({ ids: [['mock-id']], distances: [[0.1]] }) });
+        StorageRouter.getSummaryCollection = async () => ({ get: async () => ({ documents: ['mock document'] }) });
+        TextEmbeddingService.embedText = async () => [0.1, 0.2];
+        GoldenPathSynthesizer.fetchOpenPRs = async () => {
+            throw new Error('fetchOpenPRs should not run when repo enrichment is disabled');
+        };
+
+        try {
+            await GoldenPathSynthesizer.synthesizeGoldenPath({repoEnrichmentEnabled: false});
+        } finally {
+            GoldenPathSynthesizer.fetchOpenPRs = originalFetchOpenPRs;
+            StorageRouter.getGraphCollection   = originalGetGraphCollection;
+            StorageRouter.getSummaryCollection = originalGetSummaryCollection;
+            TextEmbeddingService.embedText     = originalEmbedText;
+        }
+
+        const handoffContent = fs.readFileSync(tmpHandoffFile, 'utf-8');
+
+        expect(handoffContent).not.toContain('## Active PR Cycle State');
+        expect(handoffContent).not.toContain('## 📋 Latest Priority Backlog');
+    });
+
     test('synthesizeGoldenPath skips Chroma query when embedding dimension mismatches vectorDimension', async () => {
         const originalGetGraphCollection   = StorageRouter.getGraphCollection;
         const originalGetSummaryCollection = StorageRouter.getSummaryCollection;

--- a/test/playwright/unit/ai/scripts/orchestrator-daemon.spec.mjs
+++ b/test/playwright/unit/ai/scripts/orchestrator-daemon.spec.mjs
@@ -8,7 +8,8 @@ import {
     LOCAL_AI_CONFIG_FILE,
     loadLocalAiConfig,
     DEFAULT_POLL_INTERVAL_MS,
-    DEFAULT_SUMMARY_SWEEP_INTERVAL_MS
+    DEFAULT_SUMMARY_SWEEP_INTERVAL_MS,
+    resolveOrchestratorStartOptions
 } from '../../../../../ai/scripts/orchestrator-daemon.mjs';
 import {
     DEFAULT_MLX_ENABLED,
@@ -220,5 +221,129 @@ test.describe('ai/scripts/orchestrator-daemon.mjs (#11006/#11009)', () => {
 
         expect(loadedPaths).toEqual(['/tmp/local-ai-config.mjs']);
         expect(LOCAL_AI_CONFIG_FILE).toBe(path.resolve(process.cwd(), 'ai/config.mjs'));
+    });
+
+    test('resolves orchestrator intervals from top-level config when env overrides are absent', () => {
+        expect(resolveOrchestratorStartOptions({
+            orchestratorConfig: {
+                deploymentMode: 'local',
+                intervals: {
+                    pollMs          : 11,
+                    summarySweepMs  : 22,
+                    kbSyncMs        : 33,
+                    backupMs        : 44,
+                    primaryDevSyncMs: 55,
+                    dreamMs         : 66,
+                    goldenPathMs    : 77
+                },
+                localOnly: {
+                    primaryDevSyncEnabled: true,
+                    kbSyncEnabled        : true,
+                    bridgeDaemonEnabled  : true,
+                    goldenPathRepoEnrichmentEnabled: true
+                }
+            },
+            env: {}
+        })).toEqual({
+            pollIntervalMs          : 11,
+            summarySweepIntervalMs  : 22,
+            kbSyncIntervalMs        : 33,
+            backupIntervalMs        : 44,
+            primaryDevSyncIntervalMs: 55,
+            dreamIntervalMs         : 66,
+            goldenPathIntervalMs    : 77,
+            primaryDevSyncEnabled   : true,
+            kbSyncEnabled           : true,
+            bridgeDaemonEnabled     : true,
+            goldenPathRepoEnrichmentEnabled: true
+        });
+    });
+
+    test('falls back to maintenance backup cadence when orchestrator cadence omits backupMs', () => {
+        expect(resolveOrchestratorStartOptions({
+            orchestratorConfig: {
+                intervals: {
+                    pollMs: 11
+                }
+            },
+            maintenanceConfig: {
+                backup: {
+                    intervalMs: 88
+                }
+            },
+            env: {}
+        })).toMatchObject({
+            pollIntervalMs  : 11,
+            backupIntervalMs: 88
+        });
+    });
+
+    test('preserves env precedence over config-derived orchestrator options', () => {
+        const options = resolveOrchestratorStartOptions({
+            orchestratorConfig: {
+                deploymentMode: 'cloud',
+                intervals: {
+                    pollMs          : 11,
+                    summarySweepMs  : 22,
+                    kbSyncMs        : 33,
+                    backupMs        : 44,
+                    primaryDevSyncMs: 55
+                }
+            },
+            env: {
+                NEO_ORCHESTRATOR_POLL_INTERVAL_MS            : '100',
+                NEO_SUMMARIZATION_SWEEP_INTERVAL_MS          : '200',
+                NEO_ORCHESTRATOR_KB_SYNC_INTERVAL_MS         : '300',
+                NEO_ORCHESTRATOR_BACKUP_INTERVAL_MS          : '400',
+                NEO_ORCHESTRATOR_PRIMARY_DEV_SYNC_INTERVAL_MS: '500',
+                NEO_ORCHESTRATOR_PRIMARY_DEV_SYNC_ENABLED    : 'false',
+                NEO_ORCHESTRATOR_KB_SYNC_ENABLED             : 'false',
+                NEO_ORCHESTRATOR_BRIDGE_DAEMON_ENABLED       : 'false',
+                NEO_ORCHESTRATOR_GOLDEN_PATH_REPO_ENRICHMENT_ENABLED: 'false'
+            }
+        });
+
+        expect(options).not.toHaveProperty('pollIntervalMs');
+        expect(options).not.toHaveProperty('summarySweepIntervalMs');
+        expect(options).not.toHaveProperty('kbSyncIntervalMs');
+        expect(options).not.toHaveProperty('backupIntervalMs');
+        expect(options).not.toHaveProperty('primaryDevSyncIntervalMs');
+        expect(options).not.toHaveProperty('primaryDevSyncEnabled');
+        expect(options).not.toHaveProperty('kbSyncEnabled');
+        expect(options).not.toHaveProperty('bridgeDaemonEnabled');
+        expect(options).not.toHaveProperty('goldenPathRepoEnrichmentEnabled');
+    });
+
+    test('disables local-only scheduler lanes for cloud deployments unless explicitly enabled', () => {
+        expect(resolveOrchestratorStartOptions({
+            orchestratorConfig: {
+                deploymentMode: 'cloud',
+                localOnly     : {}
+            },
+            env: {}
+        })).toMatchObject({
+            primaryDevSyncEnabled: false,
+            kbSyncEnabled        : false,
+            bridgeDaemonEnabled  : false,
+            goldenPathRepoEnrichmentEnabled: false
+        });
+
+        expect(resolveOrchestratorStartOptions({
+            orchestratorConfig: {
+                deploymentMode: 'cloud',
+                localOnly: {
+                    primaryDevSyncEnabled: true,
+                    kbSyncEnabled        : true,
+                    bridgeDaemonEnabled  : true,
+                    goldenPathRepoEnrichmentEnabled: true
+                }
+            },
+            env: {}
+        })).toMatchObject({
+            primaryDevSyncEnabled: true,
+            kbSyncEnabled        : true,
+            bridgeDaemonEnabled  : true,
+            goldenPathRepoEnrichmentEnabled: true
+        });
     });
 });


### PR DESCRIPTION
Authored by GPT-5 (Codex Desktop). Session `4435cdc7-4380-4643-9721-ecef2c705a11`.

FAIR-band: in-band [17/30 - last 30 merged PRs: @neo-gpt 17, @neo-opus-4-7 13, @neo-gemini-3-1-pro 0 (unavailable)].

Resolves #11722
Related: #11720, #11721, #11726, Discussion #11718

Evidence: L2 (focused unit coverage for config defaults, env precedence, local-only scheduler disables, Golden Path repo-enrichment gating, backup/defrag retention fallback, plus syntax and whitespace checks) -> L2 required (#11722 config-read + backward-compat ACs). No residuals.

This PR ships Sub A for #11720: a top-level `ai` deployment/maintenance config surface plus the first runtime consumers that make the cloud profile actionable. The new config centralizes orchestrator cadence, backup/defrag cadence and retention, deployment mode, and local-only lane toggles while preserving zero-config local behavior.

## What Changed

- Added `AiConfig.orchestrator.deploymentMode`, `orchestrator.intervals`, `orchestrator.localOnly`, and `maintenance` backup/defrag policy defaults in `ai/config.template.mjs`.
- Wired `ai/scripts/orchestrator-daemon.mjs` to resolve config-derived start options while preserving existing env-var precedence.
- Added scheduler-level local-only gates for `primary-dev-sync`, `kbSync`, `bridgeDaemon`, and `golden-path` Neo-repo enrichment.
- Routed `backup.mjs` retention through the top-level maintenance policy with the legacy Memory Core config as fallback.
- Routed `defragChromaDB.cleanOldBackups` through top-level defrag snapshot retention and made the module import-safe for tests.

## Deltas From Ticket

- Folded in the D0 ADR #11721 handoff after PR #11738: `kbSync` and `bridgeDaemon` are now cloud-disableable, and Golden Path can skip Neo-maintainer-repo enrichment sections instead of merely relying on graceful degradation.
- Preserved `wakeDispatchEnabled` as top-level policy surface only; the concrete wake dispatch consumer is intentionally not broadened in this PR because `bridgeDaemonEnabled` is the scheduler seam #11722 can safely own.
- Kept per-substrate backup retention out of scope; atomic bundle retention remains the policy shape per #10129 / #11649 findings.

## Signal Ledger (sourced from Discussion #11718)

- @neo-gpt: APPROVED - `[SCOPING_APPROVED]` on Discussion #11718 and #11720 epic-review greenlight.
- @neo-opus-4-7: APPROVED/authoring peer for D0 PR #11738; yielded #11722 collision after live authority check and is reviewing PR #11737.

## Unresolved Dissent

(none)

## Unresolved Liveness

- @neo-gemini-3-1-pro: no signal - unavailable in the current swarm window; operator-approved liveness disposition from #11718 still applies.

## Test Evidence

- `node --check ai/config.template.mjs`
- `node --check ai/scripts/orchestrator-daemon.mjs`
- `node --check ai/daemons/Orchestrator.mjs`
- `node --check ai/daemons/services/GoldenPathSynthesizer.mjs`
- `node --check buildScripts/ai/backup.mjs`
- `node --check buildScripts/ai/defragChromaDB.mjs`
- `node --check test/playwright/unit/ai/buildScripts/backup-retention.spec.mjs`
- `node --check test/playwright/unit/ai/scripts/orchestrator-daemon.spec.mjs`
- `node --check test/playwright/unit/ai/daemons/Orchestrator.spec.mjs`
- `node --check test/playwright/unit/ai/daemons/services/GoldenPathSynthesizer.spec.mjs`
- `npm run test-unit -- test/playwright/unit/ai/config.template.spec.mjs test/playwright/unit/ai/scripts/orchestrator-daemon.spec.mjs test/playwright/unit/ai/daemons/Orchestrator.spec.mjs test/playwright/unit/ai/daemons/services/GoldenPathSynthesizer.spec.mjs test/playwright/unit/ai/buildScripts/backup-retention.spec.mjs` -> 53 passed
- `git diff --check`
- `git diff --cached --check`

## Post-Merge Validation

- [ ] #11723/#11724 consume the cloud-mode toggles in the container/profile shape.
- [ ] #11725 negative-behavior proof asserts the cloud profile cannot run local checkout sync, local KB sync, or desktop wake delivery.
- [ ] #11738 ADR 0014 and this PR stay aligned if the D0 ADR receives follow-up review edits.

## Commit

- `e9248388e` - `feat(ai): add deployment maintenance config (#11722)`

lane-state: human-gate (PR opened for #11722; awaiting CI and cross-family review routing).