### PR TITLE
feat(deploy): multi-container topology + per-service resource limits (#11723)

### DIFF
--- a/ai/deploy/Dockerfile
+++ b/ai/deploy/Dockerfile
@@ -28,8 +28,13 @@ COPY --from=builder /app ./
 ENV NODE_ENV=production
 ENV NEO_TRANSPORT=sse
 
-# Accept target server as a build argument: 'knowledge-base' or 'memory-core'
+# Accept the target service as build arguments.
+# `TARGET_SERVER` selects an MCP server image ('knowledge-base' or 'memory-core').
+# `SERVICE_ENTRYPOINT` generalizes the entrypoint so non-MCP-server services — e.g.
+# the Agent OS orchestrator (ADR 0014 cloud topology, Sub B #11723) — build from the
+# same image: pass `SERVICE_ENTRYPOINT=ai/scripts/orchestrator-daemon.mjs`.
 ARG TARGET_SERVER
-ENV SERVER_ENTRYPOINT=ai/mcp/server/${TARGET_SERVER}/mcp-server.mjs
+ARG SERVICE_ENTRYPOINT=ai/mcp/server/${TARGET_SERVER}/mcp-server.mjs
+ENV SERVER_ENTRYPOINT=${SERVICE_ENTRYPOINT}
 
 CMD ["sh", "-c", "node ${SERVER_ENTRYPOINT}"]

--- a/ai/deploy/docker-compose.yml
+++ b/ai/deploy/docker-compose.yml
@@ -1,3 +1,20 @@
+# Production container topology for the cloud Agent OS deployment (Sub B of
+# Epic #11720). Implements the multi-container topology decided in ADR 0014
+# (Cloud Deployment Topology + Scheduler Task Taxonomy).
+#
+# Profile variants — `docker compose [--profile <name>] up`:
+#   - default (no profile): the baseline MCP stack — chroma + kb-server + mc-server.
+#   - `cloud`:              adds the orchestrator — the full Agent OS deployment,
+#                           running ADR 0014's cloud-safe scheduler profile.
+# Reserved profile slots (services land in later subs):
+#   - `ingress`:     reverse proxy + TLS termination — Sub C #11724.
+#   - `local-model`: an optional self-hosted model-provider container — ADR 0014
+#                    D1 variant (the MVP default is an external provider endpoint).
+#
+# Per-container resource limits (`deploy.resources.limits`) are declared on every
+# service so devops can govern RAM / CPU per service. The values are conservative
+# starting points — tune per deployment host.
+
 services:
   chroma:
     image: chromadb/chroma:1.5.9
@@ -11,6 +28,11 @@ services:
       start_period: 60s
     networks:
       - neo-mcp-network
+    deploy:
+      resources:
+        limits:
+          memory: 2g
+          cpus: "2.0"
 
   kb-server:
     build:
@@ -35,6 +57,11 @@ services:
       - neo-mcp-network
     expose:
       - "3000"
+    deploy:
+      resources:
+        limits:
+          memory: 1g
+          cpus: "1.0"
 
   mc-server:
     build:
@@ -65,10 +92,47 @@ services:
       - neo-mcp-network
     expose:
       - "3001"
+    deploy:
+      resources:
+        limits:
+          memory: 1g
+          cpus: "1.0"
 
-    # To expose these services externally, configure a reverse proxy (e.g., Nginx, Caddy)
-    # on the `neo-mcp-network` to route traffic to `kb-server:3000` and `mc-server:3001`.
-    # See tracking issue #10803 for reverse proxy patterns.
+  # The Agent OS maintenance orchestrator (ADR 0014 §2.3). Built from the shared
+  # image via the generalized `SERVICE_ENTRYPOINT` arg. `NEO_AI_DEPLOYMENT_MODE=cloud`
+  # activates the cloud-safe scheduler profile — only the cloud-deployable lanes
+  # (summary, backup, dream, golden-path) run; the local-only lanes (primary-dev-sync,
+  # kbSync, bridgeDaemon) are disabled via the Sub A #11722 deployment-mode toggles.
+  # `cloud` profile — started by `docker compose --profile cloud up`.
+  orchestrator:
+    build:
+      context: ../..
+      dockerfile: ai/deploy/Dockerfile
+      args:
+        SERVICE_ENTRYPOINT: ai/scripts/orchestrator-daemon.mjs
+    environment:
+      - NEO_AI_DEPLOYMENT_MODE=cloud
+      - NEO_CHROMA_HOST=chroma
+      - NEO_CHROMA_PORT=8000
+      - NEO_MEMORY_DB_PATH=/app/.neo-ai-data/sqlite/memory-core-graph.sqlite
+    volumes:
+      - shared-sqlite-data:/app/.neo-ai-data/sqlite
+    depends_on:
+      chroma:
+        condition: service_healthy
+    networks:
+      - neo-mcp-network
+    profiles:
+      - cloud
+    deploy:
+      resources:
+        limits:
+          memory: 1g
+          cpus: "1.0"
+
+# External exposure (reverse proxy + TLS) and redeploy-safe backup persistence
+# are layered on by Sub C #11724. Today kb-server / mc-server are internal-only
+# (`expose`) on `neo-mcp-network`.
 
 networks:
   neo-mcp-network:


### PR DESCRIPTION
Authored by Claude Opus 4.7 (Claude Code). Session `905a1458-4c28-477c-b267-e9f25d70916a`.

FAIR-band: under-target [12/30 — last 30 merged PRs: @neo-gpt 18, @neo-opus-4-7 12, @neo-gemini-3-1-pro 0 (unavailable)] — Self-Selection Rule 1: under-band → bias toward author lane (Sub B #11723).

Resolves #11723
Related: #11720
Related: #11721

Evidence: L1 (static — `ai/deploy/docker-compose.yml` + `Dockerfile` structure validated by inspection + a `js-yaml` parse; **Docker is unavailable in the agent sandbox**, so no `docker build` / `docker compose config`). Structural ACs 1-3 are L1-covered; AC4's runtime negative-behavior proof is Sub D #11725's scope. Residual: AC4 deployed proof [#11725].

Sub B of Epic #11720 — implements the multi-container topology decided in **ADR 0014** (D0). The cloud `docker-compose.yml` was a stale 3-service KB/MC/Chroma baseline with no orchestrator and no resource limits; this PR brings it to the ADR-0014 topology.

## What Changed

- **`ai/deploy/Dockerfile`** — generalized the entrypoint: a new `SERVICE_ENTRYPOINT` build arg (defaulting to the existing `ai/mcp/server/${TARGET_SERVER}/mcp-server.mjs` path — fully backward-compatible) lets non-MCP-server services build from the shared image. The orchestrator passes `SERVICE_ENTRYPOINT=ai/scripts/orchestrator-daemon.mjs`.
- **`ai/deploy/docker-compose.yml`**:
  - Added the **`orchestrator` service** — built from the shared image, running the cloud-safe scheduler profile via `NEO_AI_DEPLOYMENT_MODE=cloud` (the Sub A #11722 toggle). Behind the `cloud` compose profile.
  - **Per-container resource limits** (`deploy.resources.limits` — `memory` + `cpus`) on all four services, so devops can govern RAM/CPU per service. Values are conservative, commented as tunable.
  - **Compose profiles** — default = the baseline MCP stack (chroma + kb + mc); `cloud` = + orchestrator (the full Agent OS). Reserved `ingress` / `local-model` profile slots documented for Sub C / D1.

## Topology — per ADR 0014 §2.2

Four logical services: `chroma` (shared vector store), `kb-server`, `mc-server`, `orchestrator` (NEW — the D0-unblocked gap). The orchestrator runs only the cloud-deployable scheduler lanes; `NEO_AI_DEPLOYMENT_MODE=cloud` disables `primary-dev-sync` / `kbSync` / `bridgeDaemon` per ADR 0014 §2.3 — verified against the Sub A `resolveOrchestratorStartOptions` path (`deploymentMode === 'cloud'` → `assignLocalOnlyToggle` sets each lane `false`).

## Deltas from ticket

- **B/C boundary clarification (Tier-2 decision):** #11723 (Sub B) and #11724 (Sub C) overlap on the `ai/deploy/` compose surface. To avoid two agents editing the same files, I claimed the **B → C lane as one owner** (GPT confirmed, took F1). Sub B's scope here = the topology + resource limits + profile *mechanism* in `docker-compose.yml`; Sub C layers reverse-proxy + TLS + redeploy-safe persistence. The `orchestrator` PID/log/state dir is on the container's ephemeral layer for now — redeploy-safe persistence (the backup volume) is explicitly Sub C #11724's AC.
- **Profile variants:** the ticket named five variants; the model-provider container (`local-model`) and reverse proxy (`ingress`) do not exist yet (D1 / Sub C). Sub B ships the profile *mechanism* + the working baseline/cloud split + documented extension slots — rather than empty profiles for unbuilt services (truth-in-code).

## Test Evidence

- `js-yaml` parse of `docker-compose.yml` — valid; 4 services (chroma, kb-server, mc-server, orchestrator).
- `orchestrator-daemon.mjs` verified to run as a foreground long-lived process (poll loop via `setTimeout` recursion; SIGTERM → graceful `Orchestrator.stop()`) — correct as a container main process.
- Dockerfile change is backward-compatible: existing `TARGET_SERVER`-only builds (kb/mc, the `integration-unified` CI compose) resolve `SERVICE_ENTRYPOINT` to the unchanged default.
- No `docker build` / `docker compose config` — Docker unavailable in the agent sandbox (see Evidence).

## Post-Merge Validation

- [ ] Sub D #11725 proves the deployed profile: `docker compose --profile cloud up`, the orchestrator negative-behavior assertion (no local dev-sync), the SSE healthcheck demo.
- [ ] Sub C #11724 layers reverse-proxy + TLS + redeploy-safe persistence onto this topology.

## Signal Ledger (sourced from Discussion #11718)

- @neo-gpt: APPROVED — `[SCOPING_APPROVED]` on Discussion #11718 + #11720 epic-review greenlight.
- @neo-opus-4-7: author (Sub B #11723); D0 ADR 0014 author.

## Unresolved Dissent

(none — Discussion #11718 graduated cleanly to Epic #11720.)

## Unresolved Liveness

- @neo-gemini-3-1-pro: no signal — unavailable ~1 month. Operator §6.5 liveness disposition (`DC_kwDODSospM4BA4Qb`) authorizes the sprint on Claude + GPT + operator convergence.

## Related

- Epic #11720 (Cloud Agent OS Deployment Readiness); D0 #11721 / ADR 0014 (the topology this implements); Sub C #11724 (the continuing lane — reference compose); Sub D #11725 (deployed proof).