### PR TITLE
feat(agentos): realign deployment cookbook authority (#11727)

### DIFF
--- a/learn/agentos/DeploymentCookbook.md
+++ b/learn/agentos/DeploymentCookbook.md
@@ -1,117 +1,168 @@
-# Deployment Cookbook: Shared Topology Walkthrough
+# Deployment Cookbook: Agent OS Cloud Deployment Authority
 
-This cookbook is a concrete, ordered, end-to-end deployment guide for standing up the Neo.mjs Knowledge Base (KB) and Memory Core (MC) servers against a shared cloud-hosted Chroma instance, protected by an identity-aware reverse proxy.
+This cookbook is the F1 deployment authority for Epic #11720. It describes the
+current Agent OS deployment baseline, the D0-decided target topology, and the
+handoffs that are still owned by the active #11720 implementation subs.
 
-For theoretical background, threat models, and architectural reference, see [Shared Deployment MVP](SharedDeployment.md).
+This is not the day-0 tutorial. The tutorial is tracked separately by #11728.
+For the older shared-KB/MC background and threat model, see
+[Shared Deployment MVP](SharedDeployment.md). For the cloud topology decision
+record, see [ADR 0014](decisions/0014-cloud-deployment-topology-and-scheduler-task-taxonomy.md).
 
-## Section 1: Prerequisites & Architecture Picture
+## Section 1: Current Baseline vs Target Topology
 
-Before deploying, ensure you understand the target topology.
+The current reference compose file in [`ai/deploy/`](../../ai/deploy/) is a
+profile-structured Agent OS stack. The default profile starts the MCP baseline:
+`chroma`, `kb-server`, and `mc-server`. The `cloud` profile adds the
+cloud-safe `orchestrator`. The compose header also reserves the `ingress` and
+`local-model` profile slots for later deployment variants.
 
-### Architecture Topology
-1. **Agent Harnesses (Clients):** Local agent runners (e.g., Anthropic Claude Desktop, Gemini) sending MCP JSON-RPC over Server-Sent Events (SSE) or HTTP.
-2. **Reverse Proxy:** The public gateway that terminates TLS, enforces OAuth/OIDC authentication, and injects trusted identity headers.
-3. **MCP Servers:** The Node.js processes running `knowledge-base` and `memory-core`. These must be configured with a canonical `publicUrl` to support correct SSE advertisement and OAuth callbacks behind the proxy.
-4. **Data Layer:** A shared Chroma vector database and isolated SQLite graph databases for each server.
+| Service / profile | Current baseline | D0 target |
+|---|---|---|
+| default profile | `chroma`, `kb-server`, and `mc-server`; all three declare per-service `deploy.resources.limits`. `chroma` owns the only Docker healthcheck currently in the stack. | Keep as the baseline MCP stack: Chroma as the unified vector-store primitive, KB/MC as separate request-serving MCP containers, and Sub D-owned MCP readiness proof for the server containers. |
+| `cloud` profile | Adds the `orchestrator` service with `NEO_AI_DEPLOYMENT_MODE=cloud`, shared SQLite volume access, and its own resource envelope. | Keep as the Agent OS maintenance control-plane container, running only the cloud-safe scheduler lanes from ADR 0014. |
+| `ingress` profile slot | Reserved in the compose header; no service is wired yet. KB and MC are internal-only via `expose`. | Sub C (#11724) adds reverse proxy / TLS termination and public MCP URL wiring. |
+| `local-model` profile slot | Reserved in the compose header; no service is wired yet. | Optional self-hosted provider variant. External provider endpoints remain the MVP default. |
 
-### Identity Flow
-External Identity Provider (IdP) → Reverse Proxy (OIDC verify) → Reverse Proxy injects `X-PREFERRED-USERNAME` → MCP Server (Proxy-header-trusted auth).
+The service boundary is intentional: KB and MC serve MCP requests, Chroma stores
+vectors, and the orchestrator owns background Agent OS maintenance. Do not
+collapse them into a mono-container unless a later ADR explicitly changes the
+resource-isolation model.
 
-### Provisioning Obligations
-The Neo.mjs repository provides the MCP server applications. The external operator is responsible for provisioning:
-- The container runtime (e.g., Docker, Kubernetes).
-- The OAuth 2.1 / OIDC provider.
-- The reverse proxy.
-- The ChromaDB instance.
+## Section 2: Scheduler Taxonomy and Cloud Profile
 
-### Operator Config Bootstrap
+ADR 0014 classifies every orchestrator scheduler lane before the orchestrator is
+placed into a cloud container:
 
-The MCP servers boot from per-server `config.mjs` files (gitignored). On first clone, `npm prepare` clones each server's `config.template.mjs` into the matching `config.mjs`. After `git pull` runs that introduce **structural template evolution** — new top-level `import ... from '...'` lines, new named specifiers within existing import blocks, or new `export { ... }` blocks — re-run `npm run prepare` to surface stale-config warnings. The detector covers the import + named-export surface only; value-level changes inside `defaultConfig` (e.g., new env-binding entries, default-value adjustments) are not yet inspected and require operator awareness from release notes / PR descriptions. To refresh a stale gitignored `config.mjs` from the canonical template, run `npm run prepare -- --migrate-config` — idempotent, safe on already-current files. (See [#10815](https://github.com/neomjs/neo/issues/10815) for the drift-detection substrate.)
+| Lane set | Cloud profile behavior |
+|---|---|
+| `summary`, `backup`, `dream`, `golden-path` | Cloud-deployable maintenance lanes. They need reachable model/provider and storage substrates, but no local maintainer checkout. |
+| `bridgeDaemon`, `mlx`, `kbSync`, `primary-dev-sync` | Local-only lanes. They must be disabled in a tenant cloud deployment. |
+| `chroma` | Shared primitive. Compose or the platform owns the Chroma process in cloud; the orchestrator does not supervise it. |
 
-## Section 2: Container Packaging
+Sub A (#11722) delivered the config-level deployment-mode surface. A cloud
+orchestrator profile sets `NEO_AI_DEPLOYMENT_MODE=cloud`; the config resolver
+then disables local-only lanes unless an operator explicitly opts a narrower
+lane back in. The explicit env overrides are:
 
-When containerizing the MCP servers, you must choose between packaging both servers in one image or building two separate images. 
+| Env var | Cloud default intent |
+|---|---|
+| `NEO_ORCHESTRATOR_PRIMARY_DEV_SYNC_ENABLED=false` | Prevents `git fetch` / `git pull`, worktree discovery, `.sync-metadata.json` resets, and local KB-sync cascades. |
+| `NEO_ORCHESTRATOR_KB_SYNC_ENABLED=false` | Prevents the local Neo checkout full-corpus `ai:sync-kb` loop. Tenant KB content arrives through push/bulk ingestion instead. |
+| `NEO_ORCHESTRATOR_BRIDGE_DAEMON_ENABLED=false` | Prevents desktop wake delivery through `osascript` / `tmux`. A2A message storage remains Memory Core behavior. |
+| `NEO_ORCHESTRATOR_GOLDEN_PATH_REPO_ENRICHMENT_ENABLED=false` | Keeps tenant deployments from emitting Neo-maintainer repo backlog/PR enrichment sections. |
+| `NEO_ORCHESTRATOR_MLX_ENABLED=false` | Keeps Apple-Silicon local inference out of the cloud profile unless a local-model variant explicitly opts in. |
 
-### Recommended Pattern: Two Images (Sidecar Pattern)
-We recommend building two distinct images (or running the same image with different entrypoints).
-- **Isolation:** Process crashes in the Knowledge Base do not take down the Memory Core.
-- **Resource Limits:** KB is read-heavy; MC is write-heavy. They can be scaled or constrained independently.
-- **Shared Chroma:** Both containers connect to a single unified Chroma instance via internal container networking.
+Sub D (#11725) owns the CI-safe negative proof that the cloud profile cannot run
+the forbidden local-only behavior. This cookbook records the contract; it does
+not claim that proof has already landed.
 
-*(Note: Reference `Dockerfile` and `docker-compose.yml` artifacts are provided in the [`ai/deploy/`](../../ai/deploy/) directory, shipped under [#10801](https://github.com/neomjs/neo/issues/10801)).*
+## Section 3: Container Packaging
 
-## Section 3: Reverse Proxy Configuration
+Use per-service containers. Sub B (#11723) delivered the current
+profile-structured compose baseline: default MCP stack, `cloud` orchestrator
+profile, reserved `ingress` / `local-model` slots, and per-service resource
+limits. Sub C (#11724) and Sub D (#11725) still own the remaining
+production-profile hardening, so the compose file is closer to the target but
+not yet a complete production profile.
 
-The reverse proxy is the security boundary for the shared deployment.
+Required production-profile properties:
 
-### Routing Strategy
-You must map a single public hostname to two distinct upstream services. We recommend **pathname-based routing** to avoid managing multiple TLS certificates:
-- `/kb/*` routes to the Knowledge Base MCP server container (e.g., port 3001).
-- `/mc/*` routes to the Memory Core MCP server container (e.g., port 3002).
+Delivered by Sub B:
 
-### Header Stripping (Security)
-To prevent spoofing attacks, the reverse proxy **MUST** strip any incoming `X-PREFERRED-USERNAME` headers provided by the client before injecting its own trusted value.
+- Dedicated containers for `chroma`, `kb-server`, `mc-server`, and cloud-safe
+  `orchestrator`.
+- Resource envelopes for each declared service.
+- Default and `cloud` compose profiles, with reserved `ingress` and
+  `local-model` slots.
 
-See the [Reference Nginx and Caddy Configurations](../../ai/mcp/deploy/proxy/) for concrete examples of how to implement this header stripping securely.
+Still owned by Sub C / Sub D:
 
-## Section 4: Identity Provider Setup
+- Reverse proxy / TLS ingress and public MCP URL wiring.
+- Volumes for backup bundles that survive container rebuilds.
+- Healthcheck/readiness semantics for KB, MC, and orchestrator.
+- Optional platform variants for Kubernetes, managed Chroma, managed SQL, and
+  external model providers without changing the logical service model.
 
-You must register an OAuth application with your Identity Provider (e.g., Google, Okta, Auth0).
+## Section 4: Reverse Proxy and Auth Boundary
 
-### Client Registration
-1. Create a new Web Application client.
-2. Store the `clientId` and `clientSecret` securely.
-3. Configure the Redirect URIs. If your proxy does not handle the OAuth flow and terminates it at the MCP server, you MUST configure the `NEO_PUBLIC_URL` environment variable so the MCP server can construct correct canonical callbacks.
+The reverse proxy is the public security boundary. It terminates TLS, enforces
+OAuth/OIDC or equivalent identity, strips spoofable client identity headers, and
+injects the trusted identity headers consumed by the MCP servers.
 
-### Authentication Modes
-You must configure the MCP servers to trust the proxy:
-- Set `NEO_AUTH_TRUST_PROXY_IDENTITY=true` on both servers.
-- The proxy handles the OIDC flow, sets a session cookie, and injects the verified email or username into the `X-PREFERRED-USERNAME` header on all proxied requests.
-- See the [Authentication Threat Model](SharedDeployment.md#authentication) for details.
+The current internal compose ports are:
 
-## Section 5: Shared Chroma Topology
+| Service | Internal port |
+|---|---|
+| `kb-server` | `3000` |
+| `mc-server` | `3001` |
 
-Both MCP servers must share a single Chroma instance to enable cross-domain semantic awareness.
+Sub C (#11724) owns the production ingress wiring. A path-routed deployment can
+publish `/kb/*` and `/mc/*` on one hostname, or the operator can use separate
+hostnames. In either shape, set each server's `NEO_PUBLIC_URL` to the canonical
+public MCP URL that agents will use.
 
-1. Ensure the Chroma container/service is accessible to both MCP containers.
-2. Configure the Chroma host and port:
-   - `NEO_CHROMA_HOST=http://chroma` (or your internal DNS name).
-   - `NEO_CHROMA_PORT=8000`.
+Header rule: the proxy must remove any incoming `X-PREFERRED-USERNAME` or
+`X-AUTH-REQUEST-PREFERRED-USERNAME` header before injecting its own verified
+value. With proxy-auth mode enabled, set `NEO_AUTH_TRUST_PROXY_IDENTITY=true`.
+For direct OIDC mode, configure the issuer/client values instead of trusting the
+proxy header path.
+
+## Section 5: Persistence, Backups, and Provider Profile
+
+The deployment substrates have different recovery properties:
+
+- Chroma data is shared by KB and MC but collection-scoped by substrate.
+- KB content is a cache/index over Neo's curated corpus plus tenant-pushed repo
+  content. A KB wipe is recoverable by re-sync/re-push, but the operational cost
+  scales with tenant count.
+- Memory Core graph/session data is a primary store. A wipe between backups is
+  data loss.
+- Backup bundles need their own durable volume or managed-object-storage target;
+  the baseline compose file does not yet provide this.
+
+The orchestrator consumes model-provider endpoints for `summary`, `dream`, and
+similar lanes. External provider endpoints are the MVP default. A self-hosted
+provider container is a profile variant and should not be coupled to the
+orchestrator container.
 
 ## Section 6: Environment Variable Inventory
 
-When provisioning your containers, supply the following minimal environment variables:
+Supply these values per service/profile as needed:
 
 | Variable | Target | Purpose |
 |---|---|---|
-| `MCP_HTTP_PORT` | Both | The port the HTTP/SSE server listens on (e.g., `3001` for KB, `3002` for MC). |
-| `NEO_CHROMA_HOST` | Both | Internal URL of the Chroma instance. |
-| `NEO_CHROMA_PORT` | Both | Port of the Chroma instance. |
-| `NEO_PUBLIC_URL` | Both | The canonical public URL for this MCP server (e.g., `https://api.example.com/mc`). Required for SSE advertisement and OAuth `redirect_uri` generation behind reverse proxies. |
-| `NEO_AUTH_TRUST_PROXY_IDENTITY` | Both | Set to `true` if your reverse proxy handles authentication. |
-| `GEMINI_API_KEY` | Both | Required for Gemini integration. |
-| `NEO_TRANSPORT` | Both | Steady runtime binding for HTTP/SSE deployments (e.g., set to `sse`). |
-| `NEO_AUTO_SYNC` | KB | Deployment safety toggle. Operator one-shot KB sync toggle (safe deploy default: `false`). |
-| `NEO_KB_AUTO_START_DATABASE` | KB | Deployment safety toggle. Operator one-shot lifecycle toggle for local Chroma startup (safe deploy default: `false`). |
-| `NEO_MEM_AUTO_START_DATABASE` | MC | Safe deploy control. Operator one-shot lifecycle toggle for local Chroma startup (disabled by default: `false`). |
-| `NEO_MEM_AUTO_START_INFERENCE` | MC | Safe deploy control. Operator one-shot lifecycle toggle for local inference startup (disabled by default: `false`). |
-| `NEO_AUTO_DREAM` | MC | Safe deploy control. Operator one-shot/daemon toggle (disabled by default: `false`). |
-| `NEO_AUTO_GOLDEN_PATH` | MC | Safe deploy control. Operator one-shot/daemon toggle for Golden Path synthesis (disabled by default: `false`). |
-| `NEO_REAL_TIME_MEMORY_PARSING` | MC | Safe deploy control. Operator one-shot/daemon toggle (disabled by default: `false`). |
-| `NEO_AUTO_INGEST_FS` | MC | Safe deploy control. Operator one-shot ingestion toggle (disabled by default: `false`). |
-| `NEO_AUTO_SUMMARIZE` | MC | Set to `true` to enable startup + disconnect-driven session summarization. The lifecycle is now handled by the `bridge-daemon`, which acts as a host-level singleton via a `PID_FILE` lock. The daemon uses an in-process mutex to guarantee single-writer semantics across multiple local harness instances on that host. |
-| `NEO_MC_PRIMARY` | MC | *(Deprecated)* Previously used for single-writer enforcement. Replaced by daemon-enforced singleton locks for local multi-harness clusters. Remote multi-user Memory Core deployments instead rely on request-scoped identity context to partition write visibility. |
-| `NEO_SUMMARIZATION_SWEEP_INTERVAL_MS` | MC | The interval in milliseconds for the bridge-daemon to poll SQLite for un-summarized sessions (default: `600000` = 10 mins). Set to `0` to disable periodic sweeping. |
-| `NEO_ORCHESTRATOR_PRIMARY_DEV_SYNC_INTERVAL_MS` | Orchestrator | Primary-checkout `dev` auto-sync cadence (default: `600000` = 10 mins). Set to `0` to disable the periodic trigger. |
-| `NEO_ORCHESTRATOR_PRIMARY_DEV_SYNC_ENABLED` | Orchestrator | Set to `false`/`0`/`no`/`off` to disable the primary-checkout auto-sync lane without changing the daemon process. |
-| `NEO_ORCHESTRATOR_DEV_SYNC_ROOTS` | Orchestrator | Optional JSON array of absolute Neo repo roots to include in the primary-dev-sync lane. This env var has precedence over local config. Unset preserves the single owning-checkout behavior unless `ai/config.mjs` sets `orchestrator.devSyncRoots`. Configured roots are never auto-discovered or branch-switched; non-`dev` roots are fetch-only. KB sync still cascades once from the owning checkout after at least one successful `dev` update. |
-| `NEO_MCP_GITHUB_ARCHIVE_ROOT` | GitHub Workflow | The root directory for version-based archives across all entities. |
+| `NEO_TRANSPORT=sse` | KB, MC | HTTP/SSE transport for deployed MCP servers. |
+| `MCP_HTTP_PORT` | KB, MC | Internal listener port. Current baseline: KB `3000`, MC `3001`. |
+| `NEO_PUBLIC_URL` | KB, MC | Canonical public MCP URL used for advertised endpoints and auth callbacks. |
+| `NEO_CHROMA_HOST` | KB, MC, Orchestrator | Internal Chroma host, for example `chroma`. |
+| `NEO_CHROMA_PORT` | KB, MC, Orchestrator | Chroma port, normally `8000`. |
+| `NEO_MEMORY_DB_PATH` | KB, MC, Orchestrator | Shared SQLite graph path or mounted graph-store path. |
+| `NEO_AUTH_TRUST_PROXY_IDENTITY=true` | KB, MC | Enables the trusted reverse-proxy identity-header path. |
+| `NEO_AUTH_ISSUER_URL`, `NEO_OAUTH_CLIENT_ID`, `NEO_OAUTH_CLIENT_SECRET` | KB, MC | Direct OIDC/OAuth mode inputs when the MCP server handles auth instead of a trusted proxy. |
+| `NEO_AI_DEPLOYMENT_MODE=cloud` | Orchestrator | Selects the cloud maintenance profile. |
+| `NEO_ORCHESTRATOR_PRIMARY_DEV_SYNC_ENABLED=false` | Orchestrator | Disables local maintainer checkout sync. |
+| `NEO_ORCHESTRATOR_KB_SYNC_ENABLED=false` | Orchestrator | Disables local full-corpus KB sync. |
+| `NEO_ORCHESTRATOR_BRIDGE_DAEMON_ENABLED=false` | Orchestrator | Disables desktop wake delivery. |
+| `NEO_ORCHESTRATOR_GOLDEN_PATH_REPO_ENRICHMENT_ENABLED=false` | Orchestrator | Disables Neo-maintainer repo enrichment sections. |
+| `NEO_ORCHESTRATOR_MLX_ENABLED=false` | Orchestrator | Keeps local MLX supervision disabled. |
+| `NEO_AUTO_SYNC=false` | KB | Prevents one-shot local KB sync during server startup. |
+| `NEO_KB_AUTO_START_DATABASE=false` | KB | Prevents the KB server from starting a local Chroma process. |
+| `NEO_MEM_AUTO_START_DATABASE=false` | MC | Prevents the MC server from starting a local Chroma process. |
+| `NEO_MEM_AUTO_START_INFERENCE=false` | MC | Prevents the MC server from starting local inference. |
+| `NEO_AUTO_SUMMARIZE`, `NEO_AUTO_DREAM`, `NEO_AUTO_GOLDEN_PATH`, `NEO_REAL_TIME_MEMORY_PARSING`, `NEO_AUTO_INGEST_FS` | MC | Local/server startup toggles; leave disabled unless the deployment owns those daemon behaviors explicitly. |
 
-*(Notes: Public URL advertising is tracked under [#10802](https://github.com/neomjs/neo/issues/10802). Provider consolidation shipped in [PR #10810](https://github.com/neomjs/neo/pull/10810) — `embeddingProvider` is now the canonical selector. Env-var ergonomics shipped in [#10808](https://github.com/neomjs/neo/issues/10808): `MCP_HTTP_PORT` is the canonical operator-facing env var (`SSE_PORT` remains readable during the deprecation window with a warning); `NEO_CHROMA_HOST` / `NEO_CHROMA_PORT` are now env-overridable on both KB + MC. Session-summary single-writer flag `NEO_MC_PRIMARY` has been deprecated in favor of daemon-owned locks per Piece B/C migration [#10956](https://github.com/neomjs/neo/issues/10956).)*
+The top-level AI config template is [`ai/config.template.mjs`](../../ai/config.template.mjs).
+The cloud-ingestion tenant config guide is
+[Configuration](cloud-deployment/Configuration.md).
 
-### Local Orchestrator Dev-Sync Roots
+## Section 7: Local-Only Orchestrator Appendix
 
-The orchestrator can sync multiple local Neo checkouts through the primary-dev-sync lane without committing machine-specific paths. Precedence is:
+This section is for Neo maintainer machines only. It is not part of a tenant
+cloud deployment.
+
+The local orchestrator can sync multiple local Neo checkouts through the
+`primary-dev-sync` lane without committing machine-specific paths. Precedence is:
 
 1. `NEO_ORCHESTRATOR_DEV_SYNC_ROOTS`
 2. `ai/config.mjs` `orchestrator.devSyncRoots`
@@ -131,7 +182,7 @@ export default {
 };
 ```
 
-Then start the existing orchestrator command:
+Then start the existing local orchestrator command:
 
 ```sh
 npm run ai:orchestrator
@@ -143,87 +194,76 @@ For one-off process-manager overrides, keep using the env var:
 NEO_ORCHESTRATOR_DEV_SYNC_ROOTS='["/absolute/path/to/neo-gpt/neo","/absolute/path/to/neo-gemini/neo","/absolute/path/to/neo-opus/neo"]' npm run ai:orchestrator
 ```
 
-Do not add real local clone paths to `package.json` or `ai/config.template.mjs`; the template default remains `orchestrator.devSyncRoots: []`.
+Do not add real local clone paths to `package.json` or
+`ai/config.template.mjs`; the template default remains
+`orchestrator.devSyncRoots: []`.
 
-## Section 7: Healthcheck Verification
+## Section 8: Healthcheck and Journey Proof
 
-Once deployed, verify the stack by invoking each server's MCP `healthcheck` tool over its `/mcp` endpoint. The MCP servers do not expose a direct `/healthcheck` HTTP route; use JSON-RPC `tools/call` with `name: "healthcheck"` against the KB and MC MCP URLs.
+Deployed proof uses MCP tool calls, not a direct HTTP `/healthcheck` route. Call
+each server's `healthcheck` tool over its `/mcp` endpoint through the same public
+URL and auth path used by real agents.
 
-Expected JSON block (excerpt):
-```json
-{
-  "status": "healthy",
-  "identity": {
-    "source": "proxy-header",
-    "bound": true,
-    "nodeId": "@your-username"
-  },
-  "database": {
-    "topology": {
-      "mode": "unified",
-      "coordinates": { "host": "http://chroma", "port": 8000 },
-      "resolvedVia": "engines.chroma"
-    }
-  },
-  "providers": {
-    "embedding": {
-      "active": "openAiCompatible",
-      "host": "http://127.0.0.1:8000",
-      "model": "text-embedding-qwen3-embedding-1.5b",
-      "dimensions": 4096
-    },
-    "summary": {
-      "active": "openAiCompatible",
-      "host": "http://127.0.0.1:11434",
-      "model": "qwen3-8b",
-      "endpoint": "http://127.0.0.1:11434/v1/chat/completions",
-      "local": true,
-      "credential": {
-        "env": "NEO_OPENAI_COMPATIBLE_API_KEY",
-        "configured": false,
-        "required": false
-      }
-    },
-    "auth": {
-      "configured": "proxy-header",
-      "oidc": {
-        "host": null,
-        "issuerUrl": null,
-        "realm": null,
-        "configured": false
-      },
-      "proxyHeader": {
-        "trusted": true,
-        "headersChecked": ["x-preferred-username", "x-auth-request-preferred-username"]
-      }
-    }
-  }
-}
-```
 Operator verification anchors:
-- `identity.source === "proxy-header"` confirms the reverse proxy is injecting the `X-PREFERRED-USERNAME` header and the MC server is reading it.
-- `database.topology.mode === "unified"` confirms shared Chroma topology is active.
-- `providers.embedding.active` reflects the configured embedding provider per [#10804](https://github.com/neomjs/neo/issues/10804) consolidation — `'gemini'` (cloud), `'openAiCompatible'` (local Qwen3 / MLX), or `'ollama'`.
-- `providers.summary.active` mirrors the same shape for the session-summary provider.
-- `providers.auth.configured === "proxy-header"` confirms the deployment is using the trust-proxy-identity path; for OIDC mode it would be `'oidc'` (with the `oidc.{host, issuerUrl, realm, configured: true}` block populated). `providers.auth.proxyHeader.headersChecked` is the canonical + `oauth2-proxy`-variant header pair the server reads.
 
-See [Memory Core Healthcheck](MemoryCore.md) for the full schema contract (including the `clientSecret`-non-leak invariant per [#10770](https://github.com/neomjs/neo/issues/10770)).
+- `identity.source === "proxy-header"` confirms the reverse proxy is injecting
+  trusted identity headers and the server is reading them.
+- `database.topology.mode === "unified"` confirms the shared Chroma topology.
+- Provider fields confirm the selected embedding/summary provider profile.
+- The Memory Core healthcheck remains the schema authority for MC provider/auth
+  details; see [Memory Core](MemoryCore.md).
 
-## Section 8: First-Connection Smoke Test
+For the local Dockerized fixture, run `npm run test-integration-unified`. The
+integration harness builds `ai/deploy/docker-compose.test.yml`, waits for
+Chroma, KB, and MC readiness, then calls the KB and MC `healthcheck` tools over
+`/mcp`.
+Sub D (#11725) extends the proof to the cloud-safe orchestrator profile and
+negative local-only behavior assertions.
 
-For the local Dockerized fixture, run `npm run test-integration-unified`. The Playwright integration harness builds `ai/deploy/docker-compose.test.yml`, waits for Chroma + KB + MC readiness, then calls the KB and MC `healthcheck` tools over `/mcp`. The same harness also drives the proxy-identity path with `test/playwright/integration/fixtures/mcpClient.mjs`, including the `401 Unauthorized` rejection check in `AuthRejection.integration.spec.mjs` and the cross-tenant memory-read isolation check in `CrossTenantIsolation.integration.spec.mjs`.
+## Section 9: Tenant Repo Ingestion Boundary
 
-1. Configure your local agent harness (e.g., `claude_desktop_config.json`) to point the `sse` transport URL to your public proxy endpoint.
-2. Ensure you have authenticated with the proxy (e.g., logging in via browser to obtain the session cookie, or injecting a proxy-issued bearer token).
-3. Ask the agent: *"Call the `healthcheck` tool on the remote Memory Core server."*
-4. Verify the agent successfully completes the turn and receives the healthy response.
+Tenant KB content enters through the cloud-native ingestion facades, not through
+the local `kbSync` scheduler lane. Use the
+[Cloud-Native KB Ingestion](cloud-deployment/Overview.md) guide tree for:
 
-## Section 9: Known Gaps & Follow-Up Tickets
+- per-tenant identity and visibility rules;
+- `ingest_source_files` and bulk CLI hook wiring;
+- custom parser/source registration;
+- tenant config persistence.
 
-This cookbook surfaces the following architectural gaps between "substrate complete" and "operator ready," which are actively tracked for remediation:
+Runnable ingestion examples live in
+[`examples/cloud-deployment/`](../../examples/cloud-deployment/). They are
+ingestion-contract demonstrations, not production deployment profiles.
 
-- **[#10801](https://github.com/neomjs/neo/issues/10801):** (Shipped) Create reference Docker and docker-compose artifacts for shared KB/MC deployment.
-- **[#10802](https://github.com/neomjs/neo/issues/10802):** Expose public canonical URL configuration to MCP servers for SSE and OAuth callbacks.
-- **[#10804](https://github.com/neomjs/neo/issues/10804):** Consolidate `neoEmbeddingProvider` and `chromaEmbeddingProvider` configurations.
-- **[#10805](https://github.com/neomjs/neo/issues/10805):** Build staged-stack integration test harness for shared cloud deployment.
-- **[#10808](https://github.com/neomjs/neo/issues/10808):** Operator-facing env var ergonomics — descriptive names (`MCP_HTTP_PORT`, `NEO_PUBLIC_URL`, etc.) + `NEO_CHROMA_HOST` / `NEO_CHROMA_PORT` overridability. Cross-cuts Section 6 (env var inventory) where the forward-looking names are documented ahead of substrate-side wiring.
+## Section 10: Known Gaps and Owner Map
+
+Active #11720 deployment-readiness gaps:
+
+- [#11723](https://github.com/neomjs/neo/issues/11723) - Sub B production
+  container topology.
+- [#11724](https://github.com/neomjs/neo/issues/11724) - Sub C reference
+  compose/profile, ingress, persistence, and provider wiring.
+- [#11725](https://github.com/neomjs/neo/issues/11725) - Sub D healthcheck,
+  journey proof, and negative cloud-profile assertions.
+- [#11728](https://github.com/neomjs/neo/issues/11728) - Sub F2 day-0 tutorial.
+- [#11730](https://github.com/neomjs/neo/issues/11730) - Post-MVP residual
+  architecture once #11720 closes.
+- [#11736](https://github.com/neomjs/neo/issues/11736) - Broader deployment
+  guide/security hardening outside the F1 MVP cleanup.
+
+Related boundary item closed separately:
+
+- [#11719](https://github.com/neomjs/neo/issues/11719) / PR
+  [#11748](https://github.com/neomjs/neo/pull/11748) - Separate narrow
+  Markdown table rendering fix for the old Section 6. This rewrite removes the
+  old table from the cookbook and intentionally does not use #11719 as a close
+  target.
+
+Completed baseline inputs for this cookbook:
+
+- [#11721](https://github.com/neomjs/neo/issues/11721) / PR #11738 - D0 ADR
+  0014 topology and scheduler taxonomy.
+- [#11722](https://github.com/neomjs/neo/issues/11722) / PR #11739 - top-level
+  AI deployment/maintenance config.
+- [#11726](https://github.com/neomjs/neo/issues/11726) / PR #11737 - tenant repo
+  ingestion operational model.

--- a/learn/agentos/MemoryCore.md
+++ b/learn/agentos/MemoryCore.md
@@ -327,7 +327,7 @@ You can provide a JSON file or an ES Module (`.mjs`) that exports a configuratio
 ```
 
 This flexibility is crucial for:
-*   **Cloud Deployments:** Switching `transport` to `"sse"` allows the server to run as a microservice in Docker, accepting connections on `mcpHttpPort` (default 3001; env var `MCP_HTTP_PORT` per #10808; `SSE_PORT` legacy alias remains readable during deprecation window). See the [Deployment Cookbook](DeploymentCookbook.md) for a full shared deployment walkthrough.
+*   **Cloud Deployments:** Switching `transport` to `"sse"` allows the server to run as a microservice in Docker, accepting connections on `mcpHttpPort` (default 3001; env var `MCP_HTTP_PORT` per #10808; `SSE_PORT` legacy alias remains readable during deprecation window). See the [Deployment Cookbook](DeploymentCookbook.md) for the current Agent OS deployment authority.
 *   **Custom Models:** Switching to a different Gemini model version.
 *   **Port Conflicts:** Running multiple instances or avoiding conflicts with other services.
 *   **Environment Specifics:** Adjusting paths for different deployment environments.

--- a/learn/agentos/SharedDeployment.md
+++ b/learn/agentos/SharedDeployment.md
@@ -10,7 +10,7 @@ Shared deployment removes that staleness by giving the team **one Chroma process
 
 This document is the single source of truth for the shared-deployment MVP profile. It deliberately does not cover full multi-tenant data privacy isolation — that work continues under [#10011](https://github.com/neomjs/neo/issues/10011) and is out of MVP scope.
 
-For a step-by-step deployment guide and reference Docker configurations, see the [Deployment Cookbook](DeploymentCookbook.md) walkthrough and the [`ai/deploy/`](../../ai/deploy/) directory.
+For the current Agent OS cloud deployment authority and reference topology handoffs, see the [Deployment Cookbook](DeploymentCookbook.md) and the [`ai/deploy/`](../../ai/deploy/) directory.
 
 ## Architecture: One Process, Many Collections, Two Servers
 

--- a/learn/agentos/cloud-deployment/MigrationPath.md
+++ b/learn/agentos/cloud-deployment/MigrationPath.md
@@ -15,7 +15,7 @@ This is the load-bearing migration property: the substrate is **additive**, not 
 | Source discovery | Hardcoded 10-source array | `SourceRegistry` auto-registers the same 10 sources (`useDefaultSources` defaults `true`) — same set, same order |
 | Source input paths | Hardcoded in each Source class | `aiConfig.sourcePaths` carries Neo's default layout; each Source falls through to its hardcoded fallback if the config key is absent |
 | Chunk identity | `neoRootDir`-relative `source` string | Path-identity tuple with `tenantId: 'neo-shared'`, `repoSlug: 'neo'` — the default tenant for a single-repo deployment |
-| `npm run ai:sync-kb` output | — | Byte-equivalent under default config (the byte-equivalence test in #11660/#11661 — approved, pending merge — is the regression guard) |
+| `npm run ai:sync-kb` output | — | Byte-equivalent under default config (the byte-equivalence test in #11660/#11661 is the regression guard) |
 
 A single-repo deployment *is* a one-tenant deployment where the tenant is `neo-shared`. The cloud substrate doesn't add a code path the single-repo case has to navigate — it generalizes the existing path, with the existing behavior as the `N=1` default.
 
@@ -32,7 +32,7 @@ Each of these is a local config edit; none requires a code fork.
 
 ## Config-template clone-sync
 
-The new config keys (`useDefaultSources`, `useDefaultParsers`, `customSources`, `customParsers`, `sourcePaths`, `defaultTenantId`, `defaultRepoSlug`, `defaultVisibility`, `spoofRejectionMode`) live in `ai/mcp/server/knowledge-base/config.template.mjs` — the `SourceRegistry` keys via merged PR #11659, the `sourcePaths` + tenant-stamping keys via PRs #11661 / #11662 (approved, pending the operator merge gate). Each clone's local `config.mjs` is gitignored and copied from the template.
+The new config keys (`useDefaultSources`, `useDefaultParsers`, `customSources`, `customParsers`, `sourcePaths`, `defaultTenantId`, `defaultRepoSlug`, `defaultVisibility`, `spoofRejectionMode`) live in `ai/mcp/server/knowledge-base/config.template.mjs` — the `SourceRegistry` keys via PR #11659, the `sourcePaths` keys via PR #11661, and the tenant-stamping keys via PR #11662. Each clone's local `config.mjs` is gitignored and copied from the template.
 
 - **Zero-config deployments** need no local `config.mjs` edit — the runtime falls through to defaults when a key is absent.
 - **Cloud / tenant-mode deployments** add the keys they need to their local `config.mjs`. A harness restart picks up the change (config modules load once per MCP process).

--- a/learn/agentos/cloud-deployment/Overview.md
+++ b/learn/agentos/cloud-deployment/Overview.md
@@ -1,6 +1,6 @@
 # Cloud-Native KB Ingestion — Overview
 
-> **Status — Phase 3A invariant scaffold.** This guide describes the *invariant* substrate of cloud-native Knowledge Base ingestion (Epic #11624). Endpoint-exact details — the `ingestSourceFiles` MCP tool, the bulk-ingest CLI facade, hook-wiring examples — land with Phase 2 (#11626) and are intentionally **not** specified here. Sections that depend on un-merged work are marked `[Phase 2 — pending]`.
+> **Status — Phase 3B operational substrate.** This guide describes the cloud-native Knowledge Base ingestion substrate (Epic #11624): tenant identity, ingestion contracts, server-side stamping, read-side filtering, and the Phase 2 push/bulk facades.
 
 ## What "cloud-native KB ingestion" means
 
@@ -12,7 +12,7 @@ The substrate that makes this possible is the **per-tenant ingestion contract**:
 
 ## The contract split (Phase 0/1)
 
-Phase 0/1 defines the data contracts cloud ingestion is built on. PRs #11647 and #11659 are **merged**; PRs #11661 and #11662 are **approved and pending the operator merge gate**:
+Phase 0/1 defines the data contracts cloud ingestion is built on. PRs #11647, #11659, #11661, and #11662 are merged:
 
 | Contract | Ticket / PR | What it provides |
 |---|---|---|
@@ -23,7 +23,7 @@ Phase 0/1 defines the data contracts cloud ingestion is built on. PRs #11647 and
 | Per-source path externalization | #11660 / PR #11661 | `aiConfig.sourcePaths` — each default Source class reads its input path from config, so a tenant whose layout differs from Neo's can reuse the curated Source classes. |
 | Write-side tenant stamping | #11631 / PR #11662 | `VectorService.embed` server-stamps `{tenantId, repoSlug, visibility, originAgentIdentity}` from the authenticated ingestion context; client-supplied identity fields are overwritten or rejected. Tenant-aware Chroma IDs prevent byte-identical chunks from different tenants colliding. |
 
-The split is deliberate: **contracts before transport**. The schemas and registry stabilize first; the ingestion endpoints that consume them (Phase 2) are built against a frozen contract surface.
+The split was deliberate: **contracts before transport**. The schemas and registry stabilized first; the Phase 2 ingestion endpoints were built against that frozen contract surface.
 
 ## Topology anchor — unified Chroma
 
@@ -38,11 +38,11 @@ A zero-config Neo deployment behaves identically with or without the cloud-inges
 - A **Source** locates and reads content from a territory (a directory tree, an external workspace) and emits knowledge chunks into the full-corpus build.
 - A **Parser** transforms a specific file format into chunk content (e.g. a `.proto` parser, an ES5-aware parser).
 
-`SourceRegistry` holds both. Neo's curated Sources auto-register; tenant Sources/Parsers register declaratively via `aiConfig.customSources` / `aiConfig.customParsers` or programmatically via `SourceRegistry.registerSource(...)`. `[Phase 2 — pending]` the runtime wiring that invokes a registered Parser during an ingestion call is built in Phase 2; Phase 0/1B covers the registration API + config pipeline only.
+`SourceRegistry` holds both. Neo's curated Sources auto-register; tenant Sources/Parsers register declaratively via `aiConfig.customSources` / `aiConfig.customParsers` or programmatically via `SourceRegistry.registerSource(...)`. The Phase 2 ingestion facades can invoke a registered Parser during an ingestion call; with no parser match, the raw-text fallback ingests the whole file as one chunk.
 
 ## Relationship to Neo's curated content
 
-Neo's own guides, ADRs, skills, and API docs remain in the KB under `tenantId: 'neo-shared'`, `visibility: 'team'` — readable by every tenant. A cloud tenant's content is stamped with the tenant's own `tenantId` and a `visibility` of `team` (tenant-internal) or `private`. Read-side filtering (`[Phase 2/0-1D — pending]`, #11632) resolves each query against the requester's authenticated identity: a tenant sees its own content plus `neo-shared`, never another tenant's `private` chunks.
+Neo's own guides, ADRs, skills, and API docs remain in the KB under `tenantId: 'neo-shared'`, `visibility: 'team'` — readable by every tenant. A cloud tenant's content is stamped with the tenant's own `tenantId` and a `visibility` of `team` (tenant-internal) or `private`. Read-side filtering (#11632) resolves each query against the requester's authenticated identity: a tenant sees its own content plus `neo-shared`, never another tenant's `private` chunks.
 
 ## Where to go next
 

--- a/learn/agentos/cloud-deployment/Security.md
+++ b/learn/agentos/cloud-deployment/Security.md
@@ -1,6 +1,6 @@
 # Cloud-Native KB Ingestion — Security
 
-> **Status — Phase 3A invariant scaffold.** This guide describes the *invariant* security model of cloud-native KB ingestion (Epic #11624). Parser-execution sandboxing details depend on Phase 2/3 runtime wiring and are framed conceptually only — marked `[Phase 2/3 — pending]`.
+> **Status — Phase 3B operational security model.** This guide describes the security model of cloud-native KB ingestion (Epic #11624): server-derived tenant identity, tenant-aware chunk IDs, read-side filtering, and the parser-execution boundary.
 
 ## The threat the substrate defends against
 
@@ -11,9 +11,9 @@ A cloud-native KB deployment indexes content from mutually-untrusting tenants in
 3. **No chunk-ID collision** — byte-identical content ingested by two tenants must not overwrite each other in the index.
 4. **No untrusted-code execution escape** — a tenant-supplied Parser must not be able to read or mutate another tenant's substrate.
 
-Invariants 2 and 3 are **defined** by PR #11662 (Phase 0/1C-α — approved, pending the operator merge gate). Invariant 1's read-side enforcement is `[Phase 0/1D — pending]` (#11632). Invariant 4's runtime sandbox is `[Phase 2/3 — pending]`; its boundary *policy* is stable and documented below.
+Invariants 1, 2, and 3 are implemented by the Phase 0/1 read/write isolation work (#11632 and PR #11662). Invariant 4's boundary policy is stable and documented below; a runtime sandbox for future in-process untrusted parsers remains separate future work if that feature is introduced.
 
-## Write-side tenant stamping (PR #11662 — approved, pending merge)
+## Write-side tenant stamping
 
 Every chunk entering the index is stamped with a **server-derived** identity tuple before it reaches Chroma. The authoritative tuple is `{tenantId, repoSlug, visibility, originAgentIdentity}`, resolved from the authenticated ingestion context — never from client-supplied chunk metadata.
 
@@ -22,17 +22,17 @@ Every chunk entering the index is stamped with a **server-derived** identity tup
 - `'overwrite'` (default) — a client-supplied `tenantId` / `repoSlug` / `visibility` / `originAgentIdentity` that conflicts with the server-derived value is replaced, and a structured warning is logged.
 - `'reject'` — a conflict fails the embedding call with `KB_TENANT_SPOOF_REJECTED` *before* any Chroma read or write.
 
-A cloud-deployment operator running mutually-untrusting tenants should consider `'reject'` — it fails closed and surfaces spoof attempts as hard errors rather than silently-corrected warnings. The ingestion service (`[Phase 2 — pending]`, #11626) should additionally pass the authoritative tenant context *explicitly* rather than relying on the spoof-guard as the primary path; the guard is defense-in-depth, not the front door.
+A cloud-deployment operator running mutually-untrusting tenants should consider `'reject'` — it fails closed and surfaces spoof attempts as hard errors rather than silently-corrected warnings. The ingestion service (#11626) passes the authoritative tenant context explicitly; the spoof guard remains defense-in-depth, not the front door.
 
-## Tenant-aware chunk IDs (PR #11662 — approved, pending merge)
+## Tenant-aware chunk IDs
 
 `chunk.hash` remains the content fingerprint. The **Chroma storage ID** is derived from `{tenantId, repoSlug, hash, type, name, source}` — the content fingerprint *bound to* the authoritative tenant tuple. Consequence: two tenants ingesting a byte-identical file produce **distinct** 64-character Chroma IDs and cannot collide. The content-hash itself (`DatabaseService.createContentHash`) also folds `tenantId` + `repoSlug` into its input, so change-detection deltas are tenant-scoped.
 
-## Read-side tenant filter `[Phase 0/1D — pending]`
+## Read-side tenant filter
 
-Write-side stamping puts the `tenantId` / `visibility` fields *into* the index. Read-side enforcement — injecting a `where: {tenantId: {$in: [<requester>, 'neo-shared']}}` clause into every `collection.query()` from the authenticated requester identity — is tracked in #11632 and is **not yet shipped**. Until #11632 lands, the index is *stampable* but not *filtered*: do not run a multi-tenant cloud deployment as security-complete before #11632 merges. The fail-closed test suite that validates "tenant A cannot see tenant B's `private` content" is part of that ticket.
+Write-side stamping puts the `tenantId` / `visibility` fields *into* the index. Read-side enforcement injects tenant-aware Chroma `where` clauses into query paths from the authenticated requester identity. A tenant can see its own content plus `neo-shared`; another tenant's `private` content is filtered out. The fail-closed test suite for "tenant A cannot see tenant B's private content" is part of #11632.
 
-## Parser-execution boundary `[Phase 2/3 — pending]`
+## Parser-execution boundary
 
 A tenant-supplied Parser is untrusted code. The stable *policy* (the boundary will not change even though the runtime is pending):
 
@@ -50,9 +50,9 @@ A security guide must be honest about data-loss blast radius. The two AI substra
 
 This asymmetry drives retention policy (see Phase 4 #11628): KB backup is cost-optimization for re-sync orchestration; MC backup is genuine data-loss prevention. A security incident response treats a KB-wipe alert as "orchestrate re-syncs" and an MC-wipe alert as "amnesia event — recover from last backup." Per-substrate alert severity follows from this distinction.
 
-## Auth flow `[Phase 2 — pending]`
+## Auth flow and tenant context
 
-The authenticated-ingestion-context resolution — how a tenant's push is authenticated and mapped to its `tenantId` / `originAgentIdentity` — depends on the Phase 2 ingestion service + the v12.1 OIDC substrate. The invariant that holds regardless of the transport: **the tenant tuple is server-derived from the authenticated identity, never trusted from the payload.** The endpoint-exact auth handshake is documented when Phase 2 lands.
+The authenticated-ingestion-context resolution maps a tenant's push to its `tenantId` / `originAgentIdentity` before the ingestion service reaches Chroma. The invariant that holds regardless of the transport: **the tenant tuple is server-derived from the authenticated identity, never trusted from the payload.** Endpoint-exact auth wiring depends on the deployment's proxy/OIDC mode; see [Deployment Cookbook](../DeploymentCookbook.md) for the MCP deployment boundary and [Hook Wiring](./HookWiring.md) for ingestion facades.
 
 ## Related
 

--- a/learn/agentos/decisions/0014-cloud-deployment-topology-and-scheduler-task-taxonomy.md
+++ b/learn/agentos/decisions/0014-cloud-deployment-topology-and-scheduler-task-taxonomy.md
@@ -1,14 +1,14 @@
 # ADR 0014: Cloud Deployment Topology + Scheduler Task Taxonomy
 
-> Architectural Decision Record for the **D0** critical-path workstream of Epic #11720 (*Cloud Agent OS Deployment Readiness*, graduated from Discussion #11718). Classifies every `Orchestrator` scheduler lane as `cloud-deployable` / `local-only` / `shared primitive`, and records the target production deployment topology. This ADR is the decision input that unblocks Sub B (#11723), Sub C (#11724), Sub D (#11725), Sub F1 (#11727), and Sub G (#11729).
+> Architectural Decision Record for the **D0** critical-path workstream of Epic #11720 (*Cloud Agent OS Deployment Readiness*, graduated from Discussion #11718). Classifies every `Orchestrator` scheduler lane as `cloud-deployable` / `local-only` / `shared primitive`, and records the target production deployment topology. This ADR is the decision input that unblocks Sub B (#11723), Sub C (#11724), Sub D (#11725), and Sub F1 (#11727).
 
 | Attribute | Value |
 |---|---|
-| **Status** | Proposed — 2026-05-21 (D0 decision record; transitions to Accepted on the #11721 PR merge + cross-family review, per ADR 0005 lifecycle) |
+| **Status** | Accepted — 2026-05-21 (D0 decision record merged via PR #11738 with cross-family review, per ADR 0005 lifecycle) |
 | **Author** | @neo-opus-4-7 (Claude Opus 4.7) drafting; substrate-truth grounded in the live `ai/daemons/` source audited at `dev` |
 | **Resolves** | #11721 — *"Cloud deployment topology + scheduler-task-taxonomy ADR"* (D0 of Epic #11720) |
 | **Graduated from** | Discussion #11718 (*Cloud Agent OS Deployment Readiness*) → Epic #11720 |
-| **Unblocks** | #11723 (Sub B — container topology), #11724 (Sub C — reference compose), #11725 (Sub D — healthcheck / journey proof), #11727 (Sub F1 — cookbook), #11729 (Sub G — ADR set) |
+| **Unblocks** | #11723 (Sub B — container topology), #11724 (Sub C — reference compose), #11725 (Sub D — healthcheck / journey proof), #11727 (Sub F1 — cookbook) |
 | **Informs** | #11722 (Sub A — deployment-mode feature toggles), #11726 (Sub E — tenant-repo ingestion model) |
 | **Anti-anchor for** | Containerizing the mixed-responsibility `Orchestrator` as-is; mono-container deployment; ADR-as-options-workspace |
 
@@ -87,7 +87,7 @@ Per the Epic, D0 sweeps the two existing daemon-relevant ADRs:
 - **ADR 0003 (Chroma Topology — Unified Only)** — **not stale.** It already anticipates an "independently hosted ChromaDB instance"; the cloud `chroma` container *is* that unified instance. Cross-referenced here as the authority for the `chroma` = shared-primitive classification. No amendment.
 - **ADR 0009 (Cross-Daemon Heavy-Maintenance Lease Inheritance)** — **not stale.** The file-lease serializes the heavy lanes (`summary` / `kbSync` / `backup` / `primary-dev-sync` / `dream`) across processes; in a single-`orchestrator`-container cloud deployment it is a degenerate-but-correct safety net. No amendment.
 
-Broader deployment-doc / ADR reconciliation beyond 0003 / 0009 is **Sub G #11729** scope.
+Broader deployment-doc / ADR reconciliation beyond 0003 / 0009 is tracked by the #11720 owner map and its follow-up tickets; #11729 was closed after D0 owner-map narrowing.
 
 ## 3. Decision Process — Rejected Alternatives
 
@@ -103,7 +103,7 @@ Broader deployment-doc / ADR reconciliation beyond 0003 / 0009 is **Sub G #11729
 
 ### Positive
 - **The `Orchestrator` becomes containerizable** — excluding the four local-only lanes by config removes every local-checkout / git / desktop-harness dependency. The taxonomy *is* the unblock.
-- **Sub B / C / D / F1 / G are unblocked** with a decided topology and a classified lane set, instead of guessing.
+- **Sub B / C / D / F1 are unblocked** with a decided topology and a classified lane set, instead of guessing.
 - **The cloud profile is contract-bound** — the negative-behavior contract (§2.4) gives Sub D a precise, falsifiable assertion target.
 - **Profile-derived service count** — the container count follows the topology (§2.2), not a target number.
 
@@ -139,14 +139,14 @@ Service boundaries derive from the lane taxonomy + resource-isolation needs. Pic
 - **Epic:** #11720 (Cloud Agent OS Deployment Readiness)
 - **Resolves:** #11721 (D0)
 - **Origin Discussion:** #11718 — §5/D0; orchestrator-role-split anchor `DC_kwDODSospM4BA4F9`
-- **Unblocks:** #11723, #11724, #11725, #11727, #11729
+- **Unblocks:** #11723, #11724, #11725, #11727
 - **Informs:** #11722 (Sub A — the toggle + `golden-path`-gating handoff), #11726 (Sub E — the local `kbSync` exclusion is *why* push-based ingestion is the cloud KB path)
 - **ADRs:** 0003 (unified Chroma — swept, not stale), 0009 (cross-daemon lease — swept, not stale), 0005 (ADR-at-graduation), 0006 (ADRs as graph-queryable entities)
 - **Substrate:** `ai/daemons/TaskDefinitions.mjs`, `ai/daemons/Orchestrator.mjs`, `ai/daemons/services/PrimaryRepoSyncService.mjs`, `ai/scripts/bridge-daemon.mjs`, `buildScripts/ai/syncKnowledgeBase.mjs`, `ai/daemons/services/GoldenPathSynthesizer.mjs`, `buildScripts/ai/backup.mjs`, `ai/deploy/docker-compose.yml`
 
 ## 8. Status / Lifecycle
 
-- **Proposed** at filing. Transition to **Accepted** is gated on: (1) the #11721 PR merges to `dev`; (2) cross-family review — at least one peer `APPROVED` (GPT or Gemini); (3) no Sub B / C / D reshaping that invalidates the taxonomy.
+- **Accepted** after PR #11738 merged to `dev` with cross-family review. Re-open the decision only if Sub B / C / D discovers evidence that invalidates the taxonomy.
 - **Periodic re-review trigger:** any PR that enables a `local-only` lane in a cloud profile, or adds a new `Orchestrator` scheduler lane, MUST cite this ADR and classify the lane.
 
 Origin Session ID: `8e1dc8ca-b5a5-4479-b3cf-31918eb4a5b2` (Epic #11720 / D0 #11721 graduation lineage; this ADR authored in the continuing #11720 implementation sprint)


### PR DESCRIPTION
Authored by GPT-5.5 (Codex Desktop). Session `019e4c2e-c7aa-72a2-b0bc-58c0996c63f3`.

FAIR-band: over-target [18/30 - last 30 merged PRs: @neo-gpt 18, @neo-opus-4-7 12, @neo-gemini-3-1-pro 0 (unavailable)] — taking this lane despite over-target because #11727 is an operator-requested #11720 MVP closeout lane, already self-assigned/lane-claimed before PR open, and @neo-opus-4-7 self-selected the parallel #11723 container-topology lane rather than this deployment-authority docs lane.

Resolves #11727
Related: #11720, #11721, #11722, #11723, #11724, #11725, #11728, #11730, Discussion #11718

Evidence: L1 (live issue/PR-state verification, docs authority rewrite, `git diff --check`, stale-term grep sweep, relative-link existence check, and post-#11748 rebase conflict resolution) -> L1 required (#11727 docs-authority ACs). No residuals for #11727; runtime deployment proof remains Sub D #11725.

This PR realigns `DeploymentCookbook.md` from the old KB/MC sidecar walkthrough into the current #11720 Agent OS cloud deployment authority. It separates current baseline from D0 target topology, records the cloud-safe scheduler taxonomy and Sub A deployment-mode toggles, isolates local-only orchestrator material into an appendix, refreshes known gaps to the #11720/#11730 owner map, and removes stale surrounding guide-tree contradictions.

## What Changed

- Rewrote `learn/agentos/DeploymentCookbook.md` around the D0 topology: current 3-service baseline vs target `chroma` / `kb-server` / `mc-server` / cloud-safe `orchestrator` topology.
- Documented the cloud scheduler profile from ADR 0014 and the Sub A #11722 deployment-mode/local-only toggles.
- Moved local maintainer dev-sync roots into a clearly local-only appendix instead of leaving them in the cloud deployment spine.
- Refreshed environment variables, health/proof boundaries, tenant-ingestion boundaries, and the #11720/#11730 known-gap owner map.
- Updated ADR 0014 lifecycle metadata from Proposed to Accepted after PR #11738 merged, and removed stale #11729 unblock framing.
- Updated adjacent cloud-deployment guide status text for #11661/#11662/#11632/#11626 merged state, plus two cookbook backlinks that still described the old walkthrough shape.

## Deltas From Ticket

- Added a narrow ADR 0014 status cleanup because the cookbook now cites it as accepted D0 authority.
- Updated `SharedDeployment.md` and `MemoryCore.md` backlink text so they no longer call the cookbook a full step-by-step shared deployment walkthrough.
- Did not change the runnable ingestion examples: the stale sweep found them consistent with the tenant-ingestion boundary, and they remain examples rather than production deployment profiles.
- Did not use #11719 as a close target. #11748 merged first and closed #11719; this cookbook rewrite now records #11719 / #11748 as a separately closed boundary item for the old Section 6 table.

## Slot Rationale

This PR mutates `learn/agentos/**` documentation substrate, so the slot rationale is explicit:

- Modified `DeploymentCookbook.md`: disposition delta `rewrite -> keep`. Trigger-frequency medium (agents/operators entering #11720 deployment work), failure-severity high (wrong deployment authority can mis-shape Sub B/C/D/F work), enforceability high (reviewable against ADR 0014, owner-map issues, stale-term sweeps, and link checks). Future-decay mitigation: active handoff references are isolated in the known-gap owner map so they can be retired as #11723/#11724/#11725/#11728 land.
- Modified ADR 0014 metadata: disposition delta `metadata refresh -> keep`. Trigger-frequency medium, failure-severity medium-high (Proposed vs Accepted changes downstream authority), enforceability high (PR #11738 merge state is mechanically checkable). Future-decay mitigation: status text now names the re-open condition instead of staying in a stale proposed lifecycle.
- Modified cloud-deployment Overview/Security/MigrationPath: disposition delta `stale pending claims -> keep current operational guide text`. Trigger-frequency medium, failure-severity high for tenant-ingestion/security claims, enforceability high via live issue/PR state and grep for pending markers.
- Modified `SharedDeployment.md` and `MemoryCore.md` backlink text: disposition delta `rewrite pointer -> keep`. Trigger-frequency low-medium, failure-severity medium (misroutes readers to the wrong cookbook shape), enforceability high through direct text search.
- Retired obsolete cookbook assertions: old KB/MC-only sidecar framing, stale port `3002`, old #108xx known-gap authority, and cloud-spine local-dev-sync instructions. Rationale: ADR 0014 + #11720 owner map supersede them for current cloud deployment readiness.

## Signal Ledger (sourced from Discussion #11718)

- @neo-gpt: APPROVED / author lane — #11720 epic-review greenlight plus F1 #11727 lane-claim after D0 delivery.
- @neo-opus-4-7: APPROVED / peer lane — authored D0 ADR PR #11738, claimed Sub B #11723, and acknowledged this F1 lane split.

## Unresolved Dissent

(none)

## Unresolved Liveness

- @neo-gemini-3-1-pro: no signal — unavailable in the current swarm window; operator-approved liveness disposition from #11718 still applies.

## Test Evidence

- `git diff --check`
- `git diff --check origin/dev...HEAD`
- Rebased after #11748 merged first; resolved the expected `learn/agentos/DeploymentCookbook.md` conflict by keeping the cookbook rewrite and updating the #11719 boundary note to point at closed PR #11748.
- Stale-term sweep: `rg -n "approved, pending|pending the operator|not yet shipped|Phase 2 — pending|Phase 2/0-1D|Sub G|Two Images|Sidecar Pattern|port 3002|Shared Topology Walkthrough|full shared deployment walkthrough|step-by-step deployment guide" ...` -> no matches
- Relative-link existence check over the 7 touched markdown files -> `relative links ok`
- Live GitHub verification: #11727 open/assigned to @neo-gpt; #11721/#11722/#11726 delivered; #11661/#11662 merged; #11632/#11626 closed; #11729 closed after owner-map narrowing; #11748 merged before this rebase and closed #11719.

## Post-Merge Validation

- [ ] #11723/#11724 compare their container/profile changes against the updated cookbook authority.
- [ ] #11725 negative-behavior proof confirms the cookbook's cloud-profile assertions.
- [ ] #11728 uses the cookbook as authority while producing the separate day-0 tutorial.
- [ ] Confirm #11742 remains mergeable after #11748-first sequencing and current-head CI refresh.

## Commit

- `1a36f9e6b` - `feat(agentos): realign deployment cookbook authority (#11727)`

lane-state: rebase-pushed (PR #11742 rebased after #11748; CI refreshing on current head `1a36f9e6b`).
