### PR TITLE
feat(kb): gate ingest source tool by transport (#11744)

### DIFF
--- a/ai/mcp/server/knowledge-base/toolService.mjs
+++ b/ai/mcp/server/knowledge-base/toolService.mjs
@@ -15,6 +15,71 @@ const __filename      = fileURLToPath(import.meta.url);
 const __dirname       = path.dirname(__filename);
 /** @anchor test-isolation - ENV override to prevent parallel test mutations from corrupting the canonical file. Easily extensible to other servers via NEO_AI_MCP_<SERVER>_OPENAPI_PATH. */
 const openApiFilePath = process.env.NEO_AI_MCP_KB_OPENAPI_PATH || path.join(__dirname, 'openapi.yaml');
+const ingestToolName  = 'ingest_source_files';
+
+/**
+ * @summary Normalizes optional MCP server prefixes before transport-gating tool names.
+ * @param {String} toolName The requested MCP tool name.
+ * @returns {String} The effective OpenAPI operation id.
+ */
+const getEffectiveToolName = toolName => {
+    const lastDoubleUnderscoreIndex = toolName.lastIndexOf('__');
+
+    return lastDoubleUnderscoreIndex !== -1
+        ? toolName.substring(lastDoubleUnderscoreIndex + 2)
+        : toolName;
+};
+
+/**
+ * @summary Returns true when the KB MCP server is in its remote StreamableHTTP profile.
+ * @returns {Boolean} True when remote tenant push clients may call `ingest_source_files`.
+ */
+const isRemoteIngestTransport = () => aiConfig.transport === 'sse';
+
+/**
+ * @summary Fails closed when a local stdio client tries to invoke the remote push facade.
+ * @param {String} toolName The requested MCP tool name.
+ */
+const assertToolTransportAllowed = toolName => {
+    if (getEffectiveToolName(toolName) === ingestToolName && !isRemoteIngestTransport()) {
+        throw new Error(
+            '`ingest_source_files` is only exposed when the Knowledge Base MCP server runs ' +
+            'with `transport: "sse"` (StreamableHTTP). Use `npm run ai:ingest-tenant` or ' +
+            'direct service ingestion for local stdio workflows.'
+        );
+    }
+};
+
+/**
+ * @summary Applies the KB transport visibility policy before returning MCP tools/list.
+ * @param {Object} [options]
+ * @param {Number|String} [options.cursor=0]
+ * @param {Number} [options.limit]
+ * @returns {{tools: Object[], nextCursor: String|undefined}}
+ */
+const listTransportVisibleTools = ({cursor=0, limit} = {}) => {
+    const allTools = toolService.listTools().tools.filter(tool => (
+        tool.name !== ingestToolName || isRemoteIngestTransport()
+    ));
+
+    if (!limit) {
+        return {
+            tools     : allTools,
+            nextCursor: undefined
+        };
+    }
+
+    const
+        start      = Number(cursor) || 0,
+        end        = start + limit,
+        toolsSlice = allTools.slice(start, end),
+        nextCursor = end < allTools.length ? String(end) : undefined;
+
+    return {
+        tools: toolsSlice,
+        nextCursor
+    };
+};
 
 /**
  * @summary MCP facade for `KnowledgeBaseIngestionService.ingestSourceFiles` — applies the
@@ -99,6 +164,7 @@ const callTool = async (name, args) => {
     let result, success = 0;
 
     try {
+        assertToolTransportAllowed(name);
         result  = await _callTool(name, args);
         success = 1;
         return result;
@@ -120,6 +186,6 @@ const callTool = async (name, args) => {
     }
 };
 
-const listTools = toolService.listTools.bind(toolService);
+const listTools = listTransportVisibleTools;
 
 export {callTool, ingestSourceFilesViaMcp, listTools};

--- a/learn/agentos/cloud-deployment/HookWiring.md
+++ b/learn/agentos/cloud-deployment/HookWiring.md
@@ -10,14 +10,14 @@ For the operator-facing decision model — how to choose repo slugs, treat crede
 
 | Facade | Caller | Volume policy | Built for |
 |---|---|---|---|
-| `ingest_source_files` | An MCP client of the deployment — an agent in the tenant workspace, or a tenant push-client | Gated — refuses a batch over `mcpSyncMaxChunks` (default 50) | Incremental pushes: a commit's worth of changed files |
+| `ingest_source_files` | A remote MCP client of the `sse` / StreamableHTTP deployment — an agent in the tenant workspace, or a tenant push-client | Gated — refuses a batch over `mcpSyncMaxChunks` (default 50) | Incremental pushes: a commit's worth of changed files |
 | `npm run ai:ingest-tenant` | A shell process co-located with the KB server — the cloud operator, a CI job | Ungated (`viaMcp: false`) | Initial tenant onboarding (5k–50k chunks), large back-fills |
 
 The fork between them is the [#10572](https://github.com/neomjs/neo/issues/10572) **MCP work-volume gate**. An MCP tool call holds the calling agent's turn open; embedding tens of thousands of chunks synchronously inside one call is the wrong shape. The gate makes that structural — `ingest_source_files` *refuses* an over-volume batch (it returns a refusal payload, it does not block), and the bulk CLI is the sanctioned path for the volume the gate rejects. `viaMcp: false` — passed only by the CLI — is the single sanctioned gate bypass.
 
 ## Transport
 
-The KB MCP server runs dual-transport (`ai/mcp/server/knowledge-base/Server.mjs`): `stdio` for a local single-repo deployment, or `sse` (StreamableHTTP) for a cloud deployment serving remote tenants — selected by `aiConfig.transport` with `aiConfig.mcpHttpPort`. A cloud deployment runs `sse`; `ingest_source_files` is then reachable by any client that speaks MCP to the deployment's endpoint. The `ai:ingest-tenant` CLI is **not** a remote facade — it imports the KB services directly and runs on the deployment host.
+The KB MCP server runs dual-transport (`ai/mcp/server/knowledge-base/Server.mjs`): `stdio` for a local single-repo deployment, or `sse` (StreamableHTTP) for a cloud deployment serving remote tenants — selected by `aiConfig.transport` with `aiConfig.mcpHttpPort`. `ingest_source_files` is transport-gated: it is listed and callable only when the KB server runs with `transport === 'sse'`. Local `stdio` clients do not see it and direct calls fail closed with guidance to use the local CLI/service path instead. The `ai:ingest-tenant` CLI is **not** a remote facade — it imports the KB services directly and runs on the deployment host.
 
 ## The incremental facade — `ingest_source_files`
 
@@ -92,7 +92,7 @@ A `pre-push` hook is the recommended trigger: it fires once per `git push`, rece
 1. Read the pushed ref range (`<local-ref> <local-sha> <remote-ref> <remote-sha>`) from the hook's stdin.
 2. Enumerate changed files — `git diff --name-only --diff-filter=ACMR <remote-sha> <local-sha>` for adds/modifies, `--diff-filter=D` for deletes.
 3. Assemble the envelope — changed files into `files`, deleted paths into `deleted`, the SHA pair into `baseRevision` / `headRevision`.
-4. Submit it — a small push goes to `ingest_source_files`; an initial import of an existing repo goes to the bulk CLI. The submission step is the deployment-specific integration point: the hook hands the envelope to whatever MCP client the tenant environment wires to the deployment endpoint.
+4. Submit it — a small push goes to the `sse` / StreamableHTTP `ingest_source_files` endpoint; an initial import of an existing repo goes to the bulk CLI. The submission step is the deployment-specific integration point: the hook hands the envelope to the tenant push client wired to the deployment endpoint. In local `stdio` mode, use the CLI/service path instead; the MCP tool is intentionally hidden.
 5. Inspect the returned summary — a non-empty `errors` array fails the hook so the developer sees it.
 
 The example combines **tombstones + revision-boundary** — the precise-but-cheap pair for a hook that already runs `git diff`.

--- a/learn/agentos/cloud-deployment/TenantIngestionModel.md
+++ b/learn/agentos/cloud-deployment/TenantIngestionModel.md
@@ -20,10 +20,10 @@ Use the same underlying ingestion service through two facades:
 
 | Facade | Use when | Volume / lifecycle |
 |---|---|---|
-| `ingest_source_files` | A tenant agent or push client sends a bounded incremental change set to the cloud MCP endpoint. | MCP-callable and volume-gated by `mcpSyncMaxChunks`; split or use the CLI when the gate refuses. |
+| `ingest_source_files` | A tenant agent or push client sends a bounded incremental change set to the cloud MCP endpoint running with `transport === 'sse'`. | MCP-callable only in the remote StreamableHTTP profile and volume-gated by `mcpSyncMaxChunks`; split or use the CLI when the gate refuses. |
 | `npm run ai:ingest-tenant -- <tenantId> ...` | A deployment operator, CI job, or onboarding script performs an initial import, full backfill, or large re-push. | Runs on the deployment host, bypasses the MCP turn-volume gate via `viaMcp: false`, and holds the heavy-maintenance lease. |
 
-Both facades call `KnowledgeBaseIngestionService.ingestSourceFiles()`. Do not document a third ingestion path for the MVP unless the implementation adds one.
+Both facades call `KnowledgeBaseIngestionService.ingestSourceFiles()`. The MCP facade is hidden and fail-closed for local `stdio` server sessions because repo-push ingestion is an operator-facing remote deployment path, not an interactive local agent tool. Do not document a third ingestion path for the MVP unless the implementation adds one.
 
 ## Repository Identity
 

--- a/test/playwright/unit/ai/mcp/server/McpServerListToolsSmoke.spec.mjs
+++ b/test/playwright/unit/ai/mcp/server/McpServerListToolsSmoke.spec.mjs
@@ -88,6 +88,21 @@ function getOperationIds(server) {
 }
 
 /**
+ * @summary Resolves operation ids expected in default `tools/list` for a server.
+ * @param {Object} server The server fixture.
+ * @returns {String[]} Expected default-listed operation ids.
+ */
+function getDefaultListedOperationIds(server) {
+    const operationIds = getOperationIds(server);
+
+    if (server.name === 'knowledge-base') {
+        return operationIds.filter(name => name !== 'ingest_source_files');
+    }
+
+    return operationIds;
+}
+
+/**
  * @summary Parses the real per-server `serviceMapping` object without invoking handlers.
  * This catches OpenAPI/toolService drift while avoiding tool side effects.
  *
@@ -182,9 +197,10 @@ test.describe('Neo MCP servers — cross-server listTools smoke (#11687)', () =>
                 {tools}            = await listTools(server),
                 listedNames        = tools.map(tool => tool.name).sort(),
                 operationIds       = getOperationIds(server).sort(),
+                defaultListedIds   = getDefaultListedOperationIds(server).sort(),
                 serviceMappingKeys = getServiceMappingKeys(server).sort();
 
-            expect(listedNames, `${server.name} listTools output drifted from openapi.yaml operationIds`).toEqual(operationIds);
+            expect(listedNames, `${server.name} listTools output drifted from default-visible operationIds`).toEqual(defaultListedIds);
             expect(serviceMappingKeys, `${server.name} serviceMapping drifted from openapi.yaml operationIds`).toEqual(operationIds);
         });
     }

--- a/test/playwright/unit/ai/mcp/server/knowledge-base/IngestSourceFilesTool.spec.mjs
+++ b/test/playwright/unit/ai/mcp/server/knowledge-base/IngestSourceFilesTool.spec.mjs
@@ -37,11 +37,12 @@ import * as core      from '../../../../../../../src/core/_export.mjs';
 test.describe.configure({mode: 'serial'});
 
 test.describe('ingest_source_files MCP facade — work-volume gate (#11634)', () => {
-    let ingestSourceFilesViaMcp, listTools, KnowledgeBaseIngestionService, aiConfig;
-    let originalIngest, originalThreshold;
+    let callTool, ingestSourceFilesViaMcp, listTools, KnowledgeBaseIngestionService, aiConfig;
+    let originalIngest, originalThreshold, originalTransport;
 
     test.beforeAll(async () => {
         const toolService = await import('../../../../../../../ai/mcp/server/knowledge-base/toolService.mjs');
+        callTool               = toolService.callTool;
         ingestSourceFilesViaMcp = toolService.ingestSourceFilesViaMcp;
         listTools               = toolService.listTools;
 
@@ -50,6 +51,7 @@ test.describe('ingest_source_files MCP facade — work-volume gate (#11634)', ()
 
         originalIngest    = KnowledgeBaseIngestionService.ingestSourceFiles;
         originalThreshold = aiConfig.mcpSyncMaxChunks;
+        originalTransport = aiConfig.transport;
     });
 
     test.afterAll(() => {
@@ -58,12 +60,14 @@ test.describe('ingest_source_files MCP facade — work-volume gate (#11634)', ()
         }
         if (aiConfig) {
             aiConfig.mcpSyncMaxChunks = originalThreshold;
+            aiConfig.transport        = originalTransport;
         }
     });
 
     test.beforeEach(() => {
         // Tight, predictable threshold; restore the real service method before each spec.
         aiConfig.mcpSyncMaxChunks                       = 5;
+        aiConfig.transport                              = 'sse';
         KnowledgeBaseIngestionService.ingestSourceFiles = originalIngest;
     });
 
@@ -137,7 +141,9 @@ test.describe('ingest_source_files MCP facade — work-volume gate (#11634)', ()
         expect('error' in result).toBe(false);
     });
 
-    test('ingest_source_files is registered as an MCP tool via listTools()', () => {
+    test('ingest_source_files is listed for the remote SSE transport profile', () => {
+        aiConfig.transport = 'sse';
+
         const {tools} = listTools();
         const tool    = tools.find(item => item.name === 'ingest_source_files');
 
@@ -147,5 +153,14 @@ test.describe('ingest_source_files MCP facade — work-volume gate (#11634)', ()
         // MCP description-budget guard (Anthropic/Gemini limits; pr-review guide §5.3).
         expect(tool.name.length, 'tool name within the 64-char MCP limit').toBeLessThanOrEqual(64);
         expect(tool.description.length, 'tool description within the 1024-char MCP budget').toBeLessThanOrEqual(1024);
+    });
+
+    test('ingest_source_files is hidden and fail-closed for local stdio transport', async () => {
+        aiConfig.transport = 'stdio';
+
+        const {tools} = listTools();
+
+        expect(tools.find(item => item.name === 'ingest_source_files')).toBeUndefined();
+        await expect(callTool('ingest_source_files', {files: []})).rejects.toThrow(/transport: "sse"/);
     });
 });


### PR DESCRIPTION
Authored by GPT-5 Codex (Codex Desktop). Session 2741c4bd-92b2-428b-92d3-ab718d9a7c41.

FAIR-band: over-target [17/30] - taking this lane despite over-target because operator explicitly corrected watchdog idle behavior and #11744 is a GPT-owned blocker under #11743/#11728.

Resolves #11744
Related: #11743
Related: #11728
Related: #11720

Gate KB `ingest_source_files` so it behaves like a remote tenant-push facade instead of a local stdio tool: stdio no longer lists it and direct stdio calls fail closed with CLI/service guidance, while SSE/StreamableHTTP still exposes the tool for the repo-push client path.

Evidence: L2 (targeted unit coverage of list/call transport gate + cross-server listTools smoke + docs contract audit) -> L2 required (#11744 tool-surface ACs are local MCP facade behavior). No residuals.

## Deltas from ticket
- Implemented the narrow KB-local transport gate rather than a generic OpenAPI vendor-extension layer; this avoids broad shared ToolService changes for one acute tool-surface issue.
- Updated the cross-server listTools smoke test to distinguish OpenAPI/serviceMapping coverage from default transport-visible tools.
- This does not close #11743; it makes the #11743 MCP-over-StreamableHTTP candidate more honest by preventing stdio from advertising the remote-push facade.

## Slot Rationale
- Modified `learn/agentos/cloud-deployment/HookWiring.md`: disposition delta `rewrite`; rating medium trigger-frequency x medium failure-severity x high enforceability. Reason: align operator-facing hook docs with runtime transport gate.
- Modified `learn/agentos/cloud-deployment/TenantIngestionModel.md`: disposition delta `rewrite`; rating medium x medium x high. Reason: keep the model from teaching `ingest_source_files` as a local stdio primitive. No new always-loaded substrate was added.

## Test Evidence
- `npm run test-unit -- test/playwright/unit/ai/mcp/server/knowledge-base/IngestSourceFilesTool.spec.mjs` - 6 passed.
- `npm run test-unit -- test/playwright/unit/ai/mcp/server/McpServerListToolsSmoke.spec.mjs` - 11 passed.
- `git diff --check` - passed.
- `git diff --cached --check` - passed before commit.
- FAIR-band verifier: `gh search prs --merged --repo neomjs/neo --limit 30 --sort updated --json author` -> `neo-gpt` 17/30, `neo-opus-4-7` 13/30.

## Post-Merge Validation
- [ ] Confirm PR #11744 auto-closes and #11743 remains open for the operator-facing receiver/auth decision.
- [ ] When #11743 chooses the push client path, the day-0 tutorial points at an SSE/StreamableHTTP client, not local stdio.

## Commits
- `69cd9b36e` - `feat(kb): gate ingest source tool by transport (#11744)`

## Evolution
The watchdog correction is not part of this runtime patch, but it changed lane handling: no-progress heartbeat loops are now treated as material and the automation was updated before this PR was opened.