### PR TITLE
feat(github-workflow): extend get_conversation to issues (#10702)

### DIFF
--- a/ai/mcp/server/github-workflow/openapi.yaml
+++ b/ai/mcp/server/github-workflow/openapi.yaml
@@ -2,8 +2,8 @@ openapi: 3.0.3
 info:
   title: Neo.mjs GitHub Workflow MCP Server API
   description: |
-    This API provides structured access to the Neo.mjs GitHub repository, enabling the automation of contribution workflows. 
-    It uses a hybrid approach, leveraging both the GitHub CLI (`gh`) for simple, direct commands (e.g., checking out a PR) 
+    This API provides structured access to the Neo.mjs GitHub repository, enabling the automation of contribution workflows.
+    It uses a hybrid approach, leveraging both the GitHub CLI (`gh`) for simple, direct commands (e.g., checking out a PR)
     and the GitHub GraphQL API for complex data fetching and mutations (e.g., listing PRs, creating comments, syncing issues).
     This allows AI agents to programmatically interact with pull requests and issues in a safe and efficient manner.
   version: 1.0.0
@@ -291,16 +291,17 @@ paths:
 
   /pull-requests/{pr_number}/conversation:
     get:
-      summary: Get PR Conversation
+      summary: Get Conversation (Issue or PR)
       operationId: get_conversation
       x-pass-as-object: true
       x-annotations:
         readOnlyHint: true
       description: |
-        Retrieves the conversation for a pull request, including the title, body, and comments.
+        Retrieves the conversation (title, body, comments) for a pull request OR an issue.
+        Supply exactly one of `pr_number` or `issue_number`.
 
         **When to Use:**
-        Use this tool to get the context of a pull request — the initial proposal and the discussion history.
+        Use this tool to get the context of a pull request or issue — the initial proposal/body and the discussion history.
 
         **Comment selectors (optional, first-match precedence):**
         - `comment_id`: fetch ONLY the comment whose GitHub node ID matches. Used for A2A
@@ -319,13 +320,15 @@ paths:
           application/json:
             schema:
               type: object
-              required:
-                - pr_number
               properties:
                 pr_number:
                   type: integer
-                  description: The number of the pull request.
+                  description: The pull request number. Supply either `pr_number` or `issue_number`, not both.
                   example: 10272
+                issue_number:
+                  type: integer
+                  description: The issue number. Supply either `pr_number` or `issue_number`, not both.
+                  example: 10702
                 comment_id:
                   type: string
                   description: Return only the comment whose GitHub global node ID matches. Elides all other comments; PR title/body are still returned.
@@ -345,7 +348,7 @@ paths:
             application/json:
               schema:
                 type: object
-                description: Pull request conversation shape — title/body/author plus a (possibly filtered) comments collection.
+                description: Conversation shape (issue or pull request) — title/body/author plus a (possibly filtered) comments collection.
                 properties:
                   title:
                     type: string
@@ -378,7 +381,7 @@ paths:
                               type: string
                               format: date-time
         '400':
-          description: Bad Request (missing `pr_number`).
+          description: Bad Request (neither or both of `pr_number` / `issue_number` supplied).
           content:
             application/json:
               schema:
@@ -1358,7 +1361,7 @@ paths:
         readOnlyHint: false
       description: |
         Provides a native state-trap for Headless Orchestration to gracefully capture execution states or signal logic failures.
-        
+
         Support `state: 'PR_OPENED'` to trigger autonomous turn-completion and shutdown sequences.
         Support `state: 'BLOCKED'` and `state: 'HANDOFF'` for derailed agents, enabling them to pass a localized artifact mapping the problem back to the Orchestrator, which natively applies the `agent-task:blocked` label on GitHub.
       tags: [Issues]

--- a/ai/mcp/server/github-workflow/toolService.mjs
+++ b/ai/mcp/server/github-workflow/toolService.mjs
@@ -91,11 +91,55 @@ function buildDevBranchGuard(delegate, getBranch = defaultBranchDetector) {
 
 const syncAllOnDevOnly = buildDevBranchGuard(SyncService.runFullSync.bind(SyncService));
 
+/**
+ * #10702 — `get_conversation` dispatch router. The tool serves BOTH pull requests and
+ * issues; it routes to the matching service by which identifier the caller supplied.
+ * Rejects ambiguous (both ids) and empty (neither id) argument shapes with structured
+ * errors so the failure is legible rather than a downstream null-deref.
+ *
+ * Exported for unit-test access (#10702), mirroring the `buildDevBranchGuard` /
+ * `syncAllOnDevOnly` test-surface precedent below.
+ *
+ * @param {Object|Number} options `pr_number` XOR `issue_number`, plus optional selectors.
+ *                                A bare number is the legacy positional PR form (pre-#10702).
+ * @returns {Promise<Object>} Conversation data or a structured error.
+ */
+async function getConversationRouter(options) {
+    // Legacy positional number form predates #10702 and is always a pull request.
+    if (typeof options === 'number') {
+        return PullRequestService.getConversation(options);
+    }
+
+    const {pr_number, issue_number} = options || {};
+
+    if (pr_number && issue_number) {
+        return {
+            error  : 'Bad Request',
+            message: "Provide exactly one of 'pr_number' or 'issue_number', not both.",
+            code   : 'AMBIGUOUS_ARGUMENTS'
+        };
+    }
+
+    if (issue_number) {
+        return IssueService.getConversation(options);
+    }
+
+    if (pr_number) {
+        return PullRequestService.getConversation(options);
+    }
+
+    return {
+        error  : 'Bad Request',
+        message: "Missing required argument: provide 'pr_number' or 'issue_number'.",
+        code   : 'MISSING_ARGUMENTS'
+    };
+}
+
 const serviceMapping = {
     checkout_pull_request    : PullRequestService.checkoutPullRequest    .bind(PullRequestService),
     create_discussion        : DiscussionService .createDiscussion       .bind(DiscussionService),
     create_issue             : IssueService      .createIssue            .bind(IssueService),
-    get_conversation         : PullRequestService.getConversation        .bind(PullRequestService),
+    get_conversation         : getConversationRouter,
     get_local_issue_by_id    : LocalFileService  .getIssueById           .bind(LocalFileService),
     get_pull_request_diff    : PullRequestService.getPullRequestDiff     .bind(PullRequestService),
     get_viewer_permission    : RepositoryService .getViewerPermission    .bind(RepositoryService),
@@ -117,7 +161,7 @@ const serviceMapping = {
 
 // Exported for unit-test access (#11145). `buildDevBranchGuard` accepts injected
 // `delegate` + `getBranch` for fixture-driven testing without spawning real `git`.
-export {buildDevBranchGuard, syncAllOnDevOnly};
+export {buildDevBranchGuard, getConversationRouter, syncAllOnDevOnly};
 
 const toolService = Neo.create(ToolService, {
     openApiFilePath,

--- a/ai/services/github-workflow/IssueService.mjs
+++ b/ai/services/github-workflow/IssueService.mjs
@@ -6,7 +6,7 @@ import logger            from '../../mcp/server/github-workflow/logger.mjs';
 import {exec}            from 'child_process';
 import {promisify}       from 'util';
 import {spawn}           from 'child_process';
-import {GET_ISSUE_AND_LABEL_IDS, GET_ISSUE_PARENT, GET_BLOCKED_BY, GET_ISSUE_ASSIGNEES, FETCH_ISSUES_FOR_SYNC, FETCH_ISSUES_LIST} from './queries/issueQueries.mjs';
+import {GET_ISSUE_AND_LABEL_IDS, GET_ISSUE_PARENT, GET_BLOCKED_BY, GET_ISSUE_ASSIGNEES, GET_ISSUE_CONVERSATION, FETCH_ISSUES_FOR_SYNC, FETCH_ISSUES_LIST} from './queries/issueQueries.mjs';
 import {GET_PULL_REQUEST_ID} from './queries/pullRequestQueries.mjs';
 import {
     ADD_LABELS,
@@ -66,6 +66,80 @@ class IssueService extends Base {
          * @protected
          */
         writePermissions: ['ADMIN', 'MAINTAIN', 'WRITE']
+    }
+
+    /**
+     * Fetches the conversation (title, body, author, comments) for an issue.
+     *
+     * Issue-side twin of `PullRequestService.getConversation` (#10702). `get_conversation`
+     * is a single dual-purpose tool; `toolService` routes here when the caller supplies
+     * `issue_number`. The selector contract (`comment_id` > `since_comment_id` > `last_n` >
+     * full) is identical to the PR path; only the GraphQL resource type differs.
+     *
+     * @param {Object} options
+     * @param {Number} options.issue_number       The issue number (required).
+     * @param {String} [options.comment_id]       Return only the matching comment; others elided. Issue title/body still returned.
+     * @param {String} [options.since_comment_id] Return comments strictly after the matching comment (by createdAt order). Unknown id → empty comments.
+     * @param {Number} [options.last_n]           Return only the last N comments (by createdAt order).
+     * @returns {Promise<Object>} Conversation data (optionally filtered) or a structured error.
+     */
+    async getConversation(options) {
+        const {issue_number, comment_id, since_comment_id, last_n} = options || {};
+
+        if (!issue_number) {
+            return {
+                error  : 'Bad Request',
+                message: "Missing required argument: 'issue_number' is required.",
+                code   : 'MISSING_ARGUMENTS'
+            };
+        }
+
+        const variables = {
+            owner      : aiConfig.owner,
+            repo       : aiConfig.repo,
+            issueNumber: issue_number,
+            // get_conversation is one dual-purpose tool; the issue path shares the PR
+            // conversation comment cap rather than adding a separate config key (#10702).
+            maxComments: aiConfig.pullRequest.maxCommentsPerPullRequest
+        };
+
+        try {
+            const data        = await GraphqlService.query(GET_ISSUE_CONVERSATION, variables);
+            const issue       = data.repository.issue;
+            const allComments = issue.comments?.nodes || [];
+
+            // Selector precedence: comment_id > since_comment_id > last_n > full.
+            let filtered;
+
+            if (comment_id) {
+                filtered = allComments.filter(c => c.id === comment_id);
+            } else if (since_comment_id) {
+                const anchorIdx = allComments.findIndex(c => c.id === since_comment_id);
+                // Anchor not found → empty result set (mirrors the PR path).
+                filtered = anchorIdx === -1 ? [] : allComments.slice(anchorIdx + 1);
+            } else if (typeof last_n === 'number' && last_n > 0) {
+                filtered = allComments.slice(-last_n);
+            } else {
+                // No selector — return the full conversation shape unchanged.
+                return issue;
+            }
+
+            // Filtered paths preserve issue title/body/author; only comments are narrowed.
+            return {
+                ...issue,
+                comments: {
+                    ...issue.comments,
+                    nodes: filtered
+                }
+            };
+        } catch (error) {
+            logger.error(`Error getting conversation for issue #${issue_number} via GraphQL:`, error);
+            return {
+                error  : 'GraphQL API request failed',
+                message: error.message,
+                code   : 'GRAPHQL_API_ERROR'
+            };
+        }
     }
 
     /**

--- a/ai/services/github-workflow/queries/issueQueries.mjs
+++ b/ai/services/github-workflow/queries/issueQueries.mjs
@@ -66,33 +66,33 @@ export const FETCH_ISSUES_FOR_SYNC = `
           updatedAt
           closedAt
           url
-          
+
           author {
             login
           }
-          
+
           labels(first: $maxLabels) {
             nodes {
               name
             }
           }
-          
+
           assignees(first: $maxAssignees) {
             nodes {
               login
             }
           }
-          
+
           milestone {
             title
           }
-          
+
           # Parent/child relationships
           parent {
             number
             title
           }
-          
+
           subIssues(first: $maxSubIssues) {
             nodes {
               number
@@ -100,13 +100,13 @@ export const FETCH_ISSUES_FOR_SYNC = `
               state
             }
           }
-          
+
           subIssuesSummary {
             total
             completed
             percentCompleted
           }
-          
+
           # Blocked-by relationships
           blockedBy(first: $maxSubIssues) {
             nodes {
@@ -115,7 +115,7 @@ export const FETCH_ISSUES_FOR_SYNC = `
               state
             }
           }
-          
+
           blocking(first: $maxSubIssues) {
             nodes {
               number
@@ -123,7 +123,7 @@ export const FETCH_ISSUES_FOR_SYNC = `
               state
             }
           }
-          
+
           timelineItems(
             first: $maxTimelineItems,
             # We explicitly list event types to:
@@ -337,17 +337,17 @@ export const FETCH_ISSUES_LIST = `
           state
           createdAt
           url
-          
+
           author {
             login
           }
-          
+
           labels(first: $maxLabels) {
             nodes {
               name
             }
           }
-          
+
           assignees(first: $maxAssignees) {
             nodes {
               login
@@ -456,7 +456,7 @@ export const FETCH_SINGLE_ISSUE = `
               RENAMED_TITLE_EVENT,    # Title updates
               MILESTONED_EVENT,       # Added to milestone
               DEMILESTONED_EVENT,     # Removed from milestone
-              
+
               # Relationship Events
               # Critical for sync: Adding/removing sub-issues does not always bump the parent's updatedAt.
               SUB_ISSUE_ADDED_EVENT,
@@ -860,4 +860,41 @@ export const GET_ISSUE_ASSIGNEES = `
             }
         }
     }
+`;
+
+/**
+ * Query to fetch the full conversation for an issue.
+ *
+ * Issue-side twin of `pullRequestQueries.GET_CONVERSATION` — identical shape, querying the
+ * `issue` field instead of `pullRequest`. Powers the `get_conversation` tool when the
+ * caller supplies an `issue_number` (#10702).
+ *
+ * Variables required:
+ * - $owner: String! - Repository owner
+ * - $repo: String! - Repository name
+ * - $issueNumber: Int! - The issue number
+ * - $maxComments: Int! - Max comments to fetch
+ */
+export const GET_ISSUE_CONVERSATION = `
+  query GetIssueConversation($owner: String!, $repo: String!, $issueNumber: Int!, $maxComments: Int!) {
+    repository(owner: $owner, name: $repo) {
+      issue(number: $issueNumber) {
+        title
+        body
+        author {
+          login
+        }
+        comments(first: $maxComments) {
+          nodes {
+            id
+            author {
+              login
+            }
+            body
+            createdAt
+          }
+        }
+      }
+    }
+  }
 `;

--- a/learn/agentos/GitHubWorkflow.md
+++ b/learn/agentos/GitHubWorkflow.md
@@ -105,7 +105,7 @@ The server exposes a comprehensive suite of tools via the Model Context Protocol
 *   **`list_pull_requests`**: Lists PRs with status filtering.
 *   **`checkout_pull_request`**: Checks out a PR branch locally using `gh pr checkout`.
 *   **`get_pull_request_diff`**: Fetches the code difference via `gh pr diff`.
-*   **`get_conversation`**: Retrieves the full PR discussion history using the `GET_CONVERSATION` GraphQL query.
+*   **`get_conversation`**: Retrieves the full conversation (title, body, comments) for a **pull request _or_ an issue** — supply exactly one of `pr_number` / `issue_number`. The same comment selectors (`comment_id` / `since_comment_id` / `last_n`) narrow the result on both.
 *   **`create_comment`**: Posts a new comment to a PR or Issue. Supports "Agent Headers" to identify which AI identity is speaking.
 *   **`update_comment`**: Edits an existing comment.
 

--- a/test/playwright/unit/ai/services/github-workflow/IssueService.spec.mjs
+++ b/test/playwright/unit/ai/services/github-workflow/IssueService.spec.mjs
@@ -890,3 +890,165 @@ test.describe('Neo.ai.services.github-workflow.IssueService — assignIssue prec
         });
     });
 });
+
+/**
+ * @summary Contract coverage for `IssueService.getConversation` (#10702).
+ *
+ * Issue-side twin of `PullRequestService.getConversation` — `get_conversation` is now a
+ * single dual-purpose tool routing by `pr_number` xor `issue_number`. This block pins the
+ * issue path's selector contract (identical to the PR path: `comment_id` > `since_comment_id`
+ * > `last_n` > full), the missing-`issue_number` guard, and GraphQL-error propagation.
+ *
+ * Each test mocks `GraphqlService.query` to return a controlled four-comment issue fixture.
+ *
+ * @see Neo.ai.services.github-workflow.IssueService#getConversation
+ */
+test.describe('Neo.ai.services.github-workflow.IssueService — getConversation (#10702)', () => {
+    let IssueService;
+    let GraphqlService;
+    let originalQuery;
+
+    const COMMENT_A = {id: 'IC_a1111', author: {login: 'alice'}, body: 'First comment',  createdAt: '2026-05-22T01:00:00Z'};
+    const COMMENT_B = {id: 'IC_b2222', author: {login: 'bob'},   body: 'Second comment', createdAt: '2026-05-22T01:10:00Z'};
+    const COMMENT_C = {id: 'IC_c3333', author: {login: 'alice'}, body: 'Third comment',  createdAt: '2026-05-22T01:20:00Z'};
+    const COMMENT_D = {id: 'IC_d4444', author: {login: 'bob'},   body: 'Fourth comment', createdAt: '2026-05-22T01:30:00Z'};
+
+    const ISSUE_FIXTURE = {
+        title   : 'Test Issue',
+        body    : 'Issue body text',
+        author  : {login: 'alice'},
+        comments: {
+            nodes: [COMMENT_A, COMMENT_B, COMMENT_C, COMMENT_D]
+        }
+    };
+
+    test.beforeAll(async () => {
+        GraphqlService = (await import('../../../../../../ai/services/github-workflow/GraphqlService.mjs')).default;
+        IssueService   = (await import('../../../../../../ai/services/github-workflow/IssueService.mjs')).default;
+
+        originalQuery = GraphqlService.query.bind(GraphqlService);
+    });
+
+    test.afterAll(() => {
+        GraphqlService.query = originalQuery;
+    });
+
+    test.beforeEach(() => {
+        GraphqlService.query = async () => ({repository: {issue: ISSUE_FIXTURE}});
+    });
+
+    test('returns full conversation when no selector is passed (backward-compat default)', async () => {
+        const result = await IssueService.getConversation({issue_number: 10702});
+
+        expect(result.title).toBe('Test Issue');
+        expect(result.comments.nodes).toHaveLength(4);
+        expect(result.comments.nodes[0].id).toBe('IC_a1111');
+        expect(result.comments.nodes[3].id).toBe('IC_d4444');
+    });
+
+    test('comment_id selector returns only the matching comment', async () => {
+        const result = await IssueService.getConversation({
+            issue_number: 10702,
+            comment_id  : 'IC_c3333'
+        });
+
+        expect(result.title).toBe('Test Issue');
+        expect(result.comments.nodes).toHaveLength(1);
+        expect(result.comments.nodes[0].id).toBe('IC_c3333');
+        expect(result.comments.nodes[0].body).toBe('Third comment');
+    });
+
+    test('comment_id selector returns empty when id not found (no match is not a fallback to full)', async () => {
+        const result = await IssueService.getConversation({
+            issue_number: 10702,
+            comment_id  : 'IC_nonexistent'
+        });
+
+        expect(result.title).toBe('Test Issue');
+        expect(result.comments.nodes).toHaveLength(0);
+    });
+
+    test('since_comment_id selector returns comments strictly AFTER the anchor', async () => {
+        const result = await IssueService.getConversation({
+            issue_number    : 10702,
+            since_comment_id: 'IC_b2222'
+        });
+
+        expect(result.comments.nodes).toHaveLength(2);
+        expect(result.comments.nodes[0].id).toBe('IC_c3333');
+        expect(result.comments.nodes[1].id).toBe('IC_d4444');
+    });
+
+    test('since_comment_id at the last comment returns empty (nothing after)', async () => {
+        const result = await IssueService.getConversation({
+            issue_number    : 10702,
+            since_comment_id: 'IC_d4444'
+        });
+
+        expect(result.comments.nodes).toHaveLength(0);
+    });
+
+    test('since_comment_id with invalid id returns empty (same shape as "nothing after")', async () => {
+        const result = await IssueService.getConversation({
+            issue_number    : 10702,
+            since_comment_id: 'IC_nonexistent'
+        });
+
+        expect(result.comments.nodes).toHaveLength(0);
+    });
+
+    test('last_n selector returns last N comments in order', async () => {
+        const result = await IssueService.getConversation({
+            issue_number: 10702,
+            last_n      : 2
+        });
+
+        expect(result.comments.nodes).toHaveLength(2);
+        expect(result.comments.nodes[0].id).toBe('IC_c3333');
+        expect(result.comments.nodes[1].id).toBe('IC_d4444');
+    });
+
+    test('last_n larger than available returns all comments', async () => {
+        const result = await IssueService.getConversation({
+            issue_number: 10702,
+            last_n      : 100
+        });
+
+        expect(result.comments.nodes).toHaveLength(4);
+    });
+
+    test('selector precedence: comment_id wins over since_comment_id and last_n', async () => {
+        const result = await IssueService.getConversation({
+            issue_number    : 10702,
+            comment_id      : 'IC_a1111',
+            since_comment_id: 'IC_b2222',
+            last_n          : 2
+        });
+
+        expect(result.comments.nodes).toHaveLength(1);
+        expect(result.comments.nodes[0].id).toBe('IC_a1111');
+    });
+
+    test('rejects missing issue_number with structured error', async () => {
+        let callCount = 0;
+        GraphqlService.query = async () => { callCount++; return null; };
+
+        const result = await IssueService.getConversation({comment_id: 'IC_a1111'});
+
+        expect(result.error).toBe('Bad Request');
+        expect(result.code).toBe('MISSING_ARGUMENTS');
+        expect(callCount).toBe(0);
+    });
+
+    test('propagates GraphQL error shape on API failure', async () => {
+        GraphqlService.query = async () => {
+            throw new Error('GitHub API authentication failed');
+        };
+
+        const result = await IssueService.getConversation({issue_number: 10702});
+
+        expect(result.error).toBe('GraphQL API request failed');
+        expect(result.code).toBe('GRAPHQL_API_ERROR');
+        expect(result.message).toContain('authentication');
+    });
+});

--- a/test/playwright/unit/ai/services/github-workflow/toolService.spec.mjs
+++ b/test/playwright/unit/ai/services/github-workflow/toolService.spec.mjs
@@ -108,3 +108,97 @@ test.describe('Neo.ai.services.github-workflow.toolService — sync_all dev-bran
         await expect(guarded()).rejects.toThrow(/PrimaryRepoSyncService/);
     });
 });
+
+/**
+ * #10702 — `get_conversation` dispatch router. The tool now serves BOTH pull requests and
+ * issues; `getConversationRouter` picks the service by which identifier the caller supplied
+ * (`pr_number` xor `issue_number`) and rejects ambiguous/empty argument shapes.
+ *
+ * These tests spy on `IssueService.getConversation` / `PullRequestService.getConversation`
+ * to assert routing without GitHub API round-trips — the router itself owns no GraphQL.
+ */
+test.describe('Neo.ai.services.github-workflow.toolService — getConversationRouter (#10702)', () => {
+    let getConversationRouter;
+    let IssueService;
+    let PullRequestService;
+    let originalIssueGetConversation;
+    let originalPrGetConversation;
+
+    test.beforeAll(async () => {
+        const mod             = await import('../../../../../../ai/mcp/server/github-workflow/toolService.mjs');
+        getConversationRouter = mod.getConversationRouter;
+        IssueService          = (await import('../../../../../../ai/services/github-workflow/IssueService.mjs')).default;
+        PullRequestService    = (await import('../../../../../../ai/services/github-workflow/PullRequestService.mjs')).default;
+
+        originalIssueGetConversation = IssueService.getConversation.bind(IssueService);
+        originalPrGetConversation    = PullRequestService.getConversation.bind(PullRequestService);
+    });
+
+    test.afterAll(() => {
+        IssueService.getConversation       = originalIssueGetConversation;
+        PullRequestService.getConversation = originalPrGetConversation;
+    });
+
+    test('issue_number routes to IssueService.getConversation (PR service untouched)', async () => {
+        let issueCalls = 0, prCalls = 0, capturedOptions;
+        IssueService.getConversation       = async (opts) => { issueCalls++; capturedOptions = opts; return {routed: 'issue'}; };
+        PullRequestService.getConversation = async () => { prCalls++; return {routed: 'pr'}; };
+
+        const result = await getConversationRouter({issue_number: 10702, last_n: 3});
+
+        expect(result).toEqual({routed: 'issue'});
+        expect(issueCalls).toBe(1);
+        expect(prCalls).toBe(0);
+        expect(capturedOptions).toEqual({issue_number: 10702, last_n: 3});
+    });
+
+    test('pr_number routes to PullRequestService.getConversation (issue service untouched)', async () => {
+        let issueCalls = 0, prCalls = 0;
+        IssueService.getConversation       = async () => { issueCalls++; return {routed: 'issue'}; };
+        PullRequestService.getConversation = async () => { prCalls++; return {routed: 'pr'}; };
+
+        const result = await getConversationRouter({pr_number: 10272});
+
+        expect(result).toEqual({routed: 'pr'});
+        expect(prCalls).toBe(1);
+        expect(issueCalls).toBe(0);
+    });
+
+    test('legacy positional number routes to PullRequestService (backward-compat, pre-#10702)', async () => {
+        let issueCalls = 0, prCalls = 0;
+        IssueService.getConversation       = async () => { issueCalls++; return {routed: 'issue'}; };
+        PullRequestService.getConversation = async () => { prCalls++; return {routed: 'pr'}; };
+
+        const result = await getConversationRouter(10272);
+
+        expect(result).toEqual({routed: 'pr'});
+        expect(prCalls).toBe(1);
+        expect(issueCalls).toBe(0);
+    });
+
+    test('both pr_number and issue_number rejected with AMBIGUOUS_ARGUMENTS (neither service called)', async () => {
+        let issueCalls = 0, prCalls = 0;
+        IssueService.getConversation       = async () => { issueCalls++; return {routed: 'issue'}; };
+        PullRequestService.getConversation = async () => { prCalls++; return {routed: 'pr'}; };
+
+        const result = await getConversationRouter({pr_number: 10272, issue_number: 10702});
+
+        expect(result.error).toBe('Bad Request');
+        expect(result.code).toBe('AMBIGUOUS_ARGUMENTS');
+        expect(issueCalls).toBe(0);
+        expect(prCalls).toBe(0);
+    });
+
+    test('neither pr_number nor issue_number rejected with MISSING_ARGUMENTS (neither service called)', async () => {
+        let issueCalls = 0, prCalls = 0;
+        IssueService.getConversation       = async () => { issueCalls++; return {routed: 'issue'}; };
+        PullRequestService.getConversation = async () => { prCalls++; return {routed: 'pr'}; };
+
+        const result = await getConversationRouter({comment_id: 'IC_a1111'});
+
+        expect(result.error).toBe('Bad Request');
+        expect(result.code).toBe('MISSING_ARGUMENTS');
+        expect(issueCalls).toBe(0);
+        expect(prCalls).toBe(0);
+    });
+});


### PR DESCRIPTION
Authored by Claude Opus 4.7 (Claude Code). Session `0b0a7cee-f2c4-4e1f-9eeb-cdc6bd0330fb`.

FAIR-band: in-band — @neo-opus-4-7 at ~12 of the last 30 merged PRs (per the #11742 ledger snapshot); additionally an operator-directed lane — @tobiu greenlit #10702 as a nightshift friction-fix.

Resolves #10702

`get_conversation` was dispatched to `PullRequestService.getConversation` only — calling it with an issue number failed with `Could not resolve to a PullRequest`. That broke a hard `MUST` in `ticket-intake-workflow.md §1.1` ("use `get_conversation` to fetch the live issue body"). This PR extends the tool to serve issues and pull requests through one dispatch.

## What Changed

- **`IssueService.getConversation`** — issue-side twin of `PullRequestService.getConversation`; identical selector contract (`comment_id` > `since_comment_id` > `last_n` > full), structured `MISSING_ARGUMENTS` / `GRAPHQL_API_ERROR`.
- **`GET_ISSUE_CONVERSATION`** GraphQL query (`issueQueries.mjs`) — mirrors `GET_CONVERSATION` against the `issue` field.
- **`getConversationRouter`** (`toolService.mjs`) — `get_conversation` dispatch now routes by `pr_number` xor `issue_number`; rejects ambiguous (both) and empty (neither) shapes with structured errors. The legacy positional-number form stays PR (backward-compat).
- **`openapi.yaml`** — `get_conversation` schema is now dual-input (`pr_number` xor `issue_number`), following the in-file `manage_issue_comment` XOR precedent.
- 16 unit tests across `IssueService.spec.mjs` + `toolService.spec.mjs`.

## Deltas from ticket

- **Stale file paths.** #10702's body (filed 2026-05-04) referenced a `services/`-nested layout (`ai/mcp/server/github-workflow/services/...`) that no longer exists — the github-workflow MCP server was refactored; services now live in `ai/services/github-workflow/`. The fix was re-derived against the current structure.
- **Comment cap.** Rather than add a new `maxCommentsPerIssue` config key (config-migration debt + stale-`config.mjs` hazard), `IssueService.getConversation` reuses `pullRequest.maxCommentsPerPullRequest` — `get_conversation` is one dual-purpose tool, one cap.
- **Incidental whitespace.** The whole-file `check-whitespace` pre-commit hook flagged pre-existing trailing whitespace in the two touched files (`issueQueries.mjs`, `openapi.yaml`); cleaned in the feat commit (no functional change — blank lines / YAML description text).

## Test Evidence

`NEO_TEST_SKIP_CI=1 npm run test-unit -- IssueService.spec.mjs toolService.spec.mjs` -> **40 passed, 8 skipped** (the 8 skipped are pre-existing CI-fragile IssueService tests). 16 of the 40 are new:
- `IssueService.getConversation` (11): full / comment_id / comment_id-miss / since_comment_id x3 / last_n x2 / precedence / missing-issue_number / GraphQL-error.
- `getConversationRouter` (5): issue routing / pr routing / legacy-positional / AMBIGUOUS / MISSING.

Evidence: L1 (unit tests, all green) -> L1 required (#10702 ACs are fully unit-testable). No residuals.

## Post-Merge Validation

- [ ] After the github-workflow MCP server restarts, `get_conversation({issue_number: N})` returns issue conversation data live.

## Commits

- `b85f78dbc` — feat: production code (router + `IssueService.getConversation` + query + openapi)
- `38ddc2b14` — test: 16 unit cases