### PR TITLE
feat(deploy): reference deployment profile + ingress (#11724)

### DIFF
--- a/ai/deploy/Caddyfile
+++ b/ai/deploy/Caddyfile
@@ -1,0 +1,49 @@
+# ------------------------------------------------------------------------------
+# Neo.mjs Agent OS — reference ingress (Sub C #11724, Epic #11720).
+# ------------------------------------------------------------------------------
+# Caddy reverse proxy for the cloud Agent OS deployment: TLS termination, public
+# path routing to the Knowledge Base / Memory Core MCP servers, and identity-
+# header spoofing defense.
+#
+# Wired into ai/deploy/docker-compose.yml as the `ingress` profile service:
+#   docker compose --profile cloud --profile ingress up
+#
+# Copy-paste-runnable as-is: `tls internal` issues a self-signed certificate, so
+# the stack stands up with zero operator configuration. For production, replace
+# `:443` with your real hostname — Caddy then auto-provisions a publicly-trusted
+# certificate — or mount certs and swap `tls internal` for `tls /cert.pem /key.pem`.
+#
+# Security threat model: the MCP servers run with trustProxyIdentity, trusting the
+# X-PREFERRED-USERNAME header for authorization. Any client-supplied value for that
+# header MUST be stripped before a trusted auth layer injects its own — see
+# learn/agentos/SharedDeployment.md#authentication.
+# ------------------------------------------------------------------------------
+
+:443 {
+    tls internal
+
+    # 1. SECURITY — strip client-supplied identity headers before anything trusts them.
+    request_header -X-Preferred-Username
+    request_header -X-Auth-Request-Preferred-Username
+
+    # 2. OPTIONAL auth layer. Uncomment and provision an oauth2-proxy (operator-owned
+    #    OIDC) for enforced identity. Without it the stack still stands up, but identity
+    #    is unenforced — reference/demo posture only; never run multi-tenant unauthed.
+    # forward_auth oauth2-proxy:4180 {
+    #     uri /oauth2/auth
+    #     copy_headers X-Auth-Request-Preferred-Username
+    # }
+
+    # 3. Knowledge Base MCP server — compose service DNS, internal port 3000.
+    #    With the optional auth layer enabled, inject the trusted identity header
+    #    inside this block, e.g.:
+    #    `header_up X-Preferred-Username {http.request.header.X-Auth-Request-Preferred-Username}`
+    handle_path /kb/* {
+        reverse_proxy kb-server:3000
+    }
+
+    # 4. Memory Core MCP server — compose service DNS, internal port 3001.
+    handle_path /mc/* {
+        reverse_proxy mc-server:3001
+    }
+}

--- a/ai/deploy/Caddyfile
+++ b/ai/deploy/Caddyfile
@@ -17,33 +17,40 @@
 # X-PREFERRED-USERNAME header for authorization. Any client-supplied value for that
 # header MUST be stripped before a trusted auth layer injects its own — see
 # learn/agentos/SharedDeployment.md#authentication.
+#
+# The request-handling directives are wrapped in a `route` block so Caddy honors
+# their written order: header-stripping MUST run before the (optional) auth layer,
+# but Caddy's default directive order would otherwise sort `forward_auth` ahead of
+# `request_header`. `route` pins literal order — see ai/mcp/deploy/proxy/Caddyfile.
 # ------------------------------------------------------------------------------
 
 :443 {
     tls internal
 
-    # 1. SECURITY — strip client-supplied identity headers before anything trusts them.
-    request_header -X-Preferred-Username
-    request_header -X-Auth-Request-Preferred-Username
+    route {
+        # 1. SECURITY — strip client-supplied identity headers before anything trusts them.
+        request_header -X-Preferred-Username
+        request_header -X-Auth-Request-Preferred-Username
 
-    # 2. OPTIONAL auth layer. Uncomment and provision an oauth2-proxy (operator-owned
-    #    OIDC) for enforced identity. Without it the stack still stands up, but identity
-    #    is unenforced — reference/demo posture only; never run multi-tenant unauthed.
-    # forward_auth oauth2-proxy:4180 {
-    #     uri /oauth2/auth
-    #     copy_headers X-Auth-Request-Preferred-Username
-    # }
+        # 2. OPTIONAL auth layer. Uncomment and provision an oauth2-proxy (operator-owned
+        #    OIDC) for enforced identity. Without it the stack still stands up, but identity
+        #    is unenforced — reference/demo posture only; never run multi-tenant unauthed.
+        # forward_auth oauth2-proxy:4180 {
+        #     uri /oauth2/auth
+        #     copy_headers X-Auth-Request-Preferred-Username
+        # }
 
-    # 3. Knowledge Base MCP server — compose service DNS, internal port 3000.
-    #    With the optional auth layer enabled, inject the trusted identity header
-    #    inside this block, e.g.:
-    #    `header_up X-Preferred-Username {http.request.header.X-Auth-Request-Preferred-Username}`
-    handle_path /kb/* {
-        reverse_proxy kb-server:3000
-    }
+        # 3. Knowledge Base MCP server — compose service DNS, internal port 3000.
+        #    With the optional auth layer enabled, inject the trusted identity header
+        #    inside this block, e.g.:
+        #    `header_up X-Preferred-Username {http.request.header.X-Auth-Request-Preferred-Username}`
+        handle_path /kb/* {
+            reverse_proxy kb-server:3000
+        }
 
-    # 4. Memory Core MCP server — compose service DNS, internal port 3001.
-    handle_path /mc/* {
-        reverse_proxy mc-server:3001
+        # 4. Memory Core MCP server — compose service DNS, internal port 3001.
+        handle_path /mc/* {
+            reverse_proxy mc-server:3001
+        }
     }
 }

--- a/ai/deploy/docker-compose.yml
+++ b/ai/deploy/docker-compose.yml
@@ -6,8 +6,9 @@
 #   - default (no profile): the baseline MCP stack — chroma + kb-server + mc-server.
 #   - `cloud`:              adds the orchestrator — the full Agent OS deployment,
 #                           running ADR 0014's cloud-safe scheduler profile.
-# Reserved profile slots (services land in later subs):
-#   - `ingress`:     reverse proxy + TLS termination — Sub C #11724.
+#   - `ingress`:            adds the Caddy reverse proxy — TLS termination + public
+#                           `/kb` + `/mc` path routing for the MCP servers (Sub C #11724).
+# Reserved profile slot (service lands in a later variant):
 #   - `local-model`: an optional self-hosted model-provider container — ADR 0014
 #                    D1 variant (the MVP default is an external provider endpoint).
 #
@@ -117,6 +118,10 @@ services:
       - NEO_MEMORY_DB_PATH=/app/.neo-ai-data/sqlite/memory-core-graph.sqlite
     volumes:
       - shared-sqlite-data:/app/.neo-ai-data/sqlite
+      # Redeploy-safe backup persistence (Sub C #11724): the cloud-safe `backup`
+      # scheduler lane writes bundles here. A host bind-mount keeps them across
+      # container rebuilds and host-accessible for off-site copy / inspection.
+      - ./.neo-ai-data/backups:/app/.neo-ai-data/backups
     depends_on:
       chroma:
         condition: service_healthy
@@ -130,9 +135,35 @@ services:
           memory: 1g
           cpus: "1.0"
 
-# External exposure (reverse proxy + TLS) and redeploy-safe backup persistence
-# are layered on by Sub C #11724. Today kb-server / mc-server are internal-only
-# (`expose`) on `neo-mcp-network`.
+  # Reverse proxy + TLS termination — the public ingress for the cloud Agent OS
+  # deployment (Sub C #11724). `ingress` profile — `docker compose --profile
+  # ingress up` (combine with `--profile cloud` for the full stack). Caddy
+  # terminates TLS and path-routes `/kb/*` -> kb-server:3000, `/mc/*` -> mc-server:3001.
+  # Config: ai/deploy/Caddyfile.
+  ingress:
+    image: caddy:2-alpine
+    ports:
+      - "443:443"
+    volumes:
+      - ./Caddyfile:/etc/caddy/Caddyfile:ro
+      - caddy-data:/data
+      - caddy-config:/config
+    depends_on:
+      - kb-server
+      - mc-server
+    networks:
+      - neo-mcp-network
+    profiles:
+      - ingress
+    deploy:
+      resources:
+        limits:
+          memory: 256m
+          cpus: "0.5"
+
+# kb-server / mc-server stay internal-only (`expose`) on `neo-mcp-network`; the
+# `ingress` profile is the sole public surface. `caddy-data` persists Caddy's
+# internal CA + issued certs across container rebuilds (Sub C #11724).
 
 networks:
   neo-mcp-network:
@@ -141,3 +172,5 @@ networks:
 volumes:
   chroma-data:
   shared-sqlite-data:
+  caddy-data:
+  caddy-config:

--- a/ai/mcp/deploy/proxy/Caddyfile
+++ b/ai/mcp/deploy/proxy/Caddyfile
@@ -27,7 +27,7 @@ mcp.example.com {
 
         # 3. Pathname Routing: Knowledge Base Server
         handle_path /kb/* {
-            reverse_proxy 127.0.0.1:3001 {
+            reverse_proxy 127.0.0.1:3000 {
                 # Inject trusted header from the forward_auth step
                 header_up X-Preferred-Username {http.request.header.X-Auth-Request-Preferred-Username}
                 header_up -X-Auth-Request-Preferred-Username
@@ -37,7 +37,7 @@ mcp.example.com {
 
         # 4. Pathname Routing: Memory Core Server
         handle_path /mc/* {
-            reverse_proxy 127.0.0.1:3002 {
+            reverse_proxy 127.0.0.1:3001 {
                 # Inject trusted header from the forward_auth step
                 header_up X-Preferred-Username {http.request.header.X-Auth-Request-Preferred-Username}
                 header_up -X-Auth-Request-Preferred-Username

--- a/ai/mcp/deploy/proxy/nginx.conf
+++ b/ai/mcp/deploy/proxy/nginx.conf
@@ -16,11 +16,11 @@ upstream oauth2_proxy {
 
 # Example Neo MCP servers
 upstream neo_kb {
-    server 127.0.0.1:3001; # Port configured via MCP_HTTP_PORT
+    server 127.0.0.1:3000; # Port configured via MCP_HTTP_PORT
 }
 
 upstream neo_mc {
-    server 127.0.0.1:3002; # Port configured via MCP_HTTP_PORT
+    server 127.0.0.1:3001; # Port configured via MCP_HTTP_PORT
 }
 
 server {


### PR DESCRIPTION
Authored by Claude Opus 4.7 (Claude Code). Session `0b0a7cee-f2c4-4e1f-9eeb-cdc6bd0330fb`.

FAIR-band: in-band — @neo-opus-4-7 ~12-13 of the last 30 merged PRs; #11724 is my pre-claimed Sub C lane of the operator-prioritized #11720 epic.

Resolves #11724

Sub C of Epic #11720. Sub B (#11723) shipped the multi-container compose topology and explicitly left the public-ingress + redeploy-safe-persistence layer to this sub. This PR fills the reserved `ingress` profile slot and closes the persistence gap.

## What Changed

- **`ai/deploy/Caddyfile`** (new) — Caddy reverse proxy for the compose `ingress` profile: TLS termination (`tls internal` — copy-paste-runnable self-signed, with the documented swap for real certs), path routing `/kb/*` -> `kb-server:3000` and `/mc/*` -> `mc-server:3001` (compose service DNS), and client identity-header stripping (spoofing defense). The oauth2-proxy auth layer is an inline-documented, operator-provisioned extension point.
- **`docker-compose.yml`** — adds the `ingress` service (`caddy:2-alpine`, `profiles: [ingress]`, publishes 443, resource-limited) filling the slot Sub B reserved; adds a redeploy-safe backup bind-mount (`./.neo-ai-data/backups`) on the `orchestrator` (where the cloud-safe `backup` scheduler lane writes); adds `caddy-data` / `caddy-config` volumes so Caddy's internal CA + issued certs persist across rebuilds.
- **`ai/mcp/deploy/proxy/{Caddyfile,nginx.conf}`** — resolves the documented proxy-vs-compose port mismatch (KB 3001->3000, MC 3002->3001) so the manual-deploy reference configs match the compose `MCP_HTTP_PORT` values.

## Deltas from ticket

- **oauth2-proxy boundary** — the ticket says "wire the reverse proxy + TLS." oauth2-proxy needs an operator-owned OIDC provider, so it cannot be copy-paste-runnable; it is wired as a commented, documented `forward_auth` block in the Caddyfile rather than a live service. The `ingress` profile stands up TLS + routing + header-stripping with zero operator config; enforced identity is the operator's opt-in. This keeps AC4 honest.
- **Two Caddyfiles** — `ai/deploy/Caddyfile` is the compose-profile config (service DNS); `ai/mcp/deploy/proxy/Caddyfile` remains the manual/localhost reference (now port-corrected). They target different deployment models.

## Acceptance Criteria

- [x] AC1 — canonical production compose reference profile running the full D0 topology (chroma + kb-server + mc-server + orchestrator + ingress).
- [x] AC2 — reverse proxy + TLS termination wired; proxy-vs-compose port mismatch resolved.
- [x] AC3 — redeploy-safe persistence: live data on named volumes (survive rebuild) + backups on a host bind-mount.
- [x] AC4 — copy-paste-runnable by construction (`docker compose --profile cloud --profile ingress up`, zero operator config); runtime stand-up confirmation is Post-Merge / Sub D #11725.

## Test Evidence

Evidence: L1 (static — `check-whitespace` clean; `docker-compose.yml` parses as valid YAML, 5 services + 4 volumes confirmed; ports cross-checked KB 3000 / MC 3001) -> L2 required (AC4 runtime stand-up). Residual: AC4 [#11725]. Docker + caddy are unavailable in the agent sandbox — the L2+ runtime proof (`docker compose up` + the Milestone-0 SSE healthcheck demo) is Sub D #11725's scope per the epic structure.

## Post-Merge Validation

- [ ] `docker compose --profile cloud --profile ingress up` stands the stack up; Caddy serves HTTPS on :443.
- [ ] Sub D #11725's Milestone-0 SSE healthcheck demo runs against the `ingress` endpoint.
- [ ] A container rebuild preserves `.neo-ai-data/backups` bundles.

## Commit

- `5a0161e3e` — feat: ingress profile + backup bind-mount + port-mismatch fix