### PR TITLE
fix(docs): repair deployment cookbook env table (#11719)

### DIFF
--- a/learn/agentos/DeploymentCookbook.md
+++ b/learn/agentos/DeploymentCookbook.md
@@ -85,7 +85,6 @@ When provisioning your containers, supply the following minimal environment vari
 | Variable | Target | Purpose |
 |---|---|---|
 | `MCP_HTTP_PORT` | Both | The port the HTTP/SSE server listens on (e.g., `3001` for KB, `3002` for MC). |
-
 | `NEO_CHROMA_HOST` | Both | Internal URL of the Chroma instance. |
 | `NEO_CHROMA_PORT` | Both | Port of the Chroma instance. |
 | `NEO_PUBLIC_URL` | Both | The canonical public URL for this MCP server (e.g., `https://api.example.com/mc`). Required for SSE advertisement and OAuth `redirect_uri` generation behind reverse proxies. |


### PR DESCRIPTION
Authored by GPT-5 Codex (Codex Desktop). Session 2741c4bd-92b2-428b-92d3-ab718d9a7c41.

FAIR-band: over-target [17/30] - taking this lane despite over-target because the operator explicitly corrected no-idle behavior, #11719 is an unassigned one-line docs bug, and PR #11747 was still CI-pending at pickup time.

Resolves #11719
Related: #11718
Related: #10969

Fixes the broken Section 6 environment-variable table in `learn/agentos/DeploymentCookbook.md` by removing the blank line that split the table after the `MCP_HTTP_PORT` row. No env-var content or deployment topology semantics changed.

Evidence: L1 (static line-level diff and whitespace checks) -> L1 required (#11719 is a Markdown rendering bug with no runtime surface). No residuals.

## Deltas from ticket
- None. The change is exactly the requested blank-line removal.

## Slot Rationale
- Modified `learn/agentos/DeploymentCookbook.md`: disposition delta `rewrite`; rating low trigger-frequency x low failure-severity x high enforceability. Reason: remove a rendering defect in an existing docs table without adding new substrate, rules, or conceptual load.

## Test Evidence
- `sed -n '74,120p' learn/agentos/DeploymentCookbook.md` - verified Section 6 table is continuous from header through `NEO_MCP_GITHUB_ARCHIVE_ROOT`.
- `git diff --check` - passed.
- `git diff --cached --check` - passed before commit.
- Pre-push freshness check: `merge-base HEAD origin/dev == origin/dev`; outgoing log contained only `13395a001 fix(docs): repair deployment cookbook env table (#11719)`.

## Post-Merge Validation
- [ ] Confirm #11719 auto-closes and Section 6 renders as one Markdown table in GitHub.

## Commit
- `13395a001` - `fix(docs): repair deployment cookbook env table (#11719)`