### PR TITLE
feat(kb): add repo-push MCP client (#11743)

### DIFF
--- a/buildScripts/ai/kbPushClient.mjs
+++ b/buildScripts/ai/kbPushClient.mjs
@@ -1,6 +1,8 @@
 // Neo namespace bootstrap (entry-point invariant) - tenant-side KB push client.
 // Mirrors buildScripts/ai/ingestTenant.mjs so this CLI can use Neo's MCP client
 // wrapper from a tenant checkout or CI job.
+import 'dotenv/config';
+import {Command}       from 'commander';
 import Neo            from '../../src/Neo.mjs';
 import * as core      from '../../src/core/_export.mjs';
 import InstanceManager from '../../src/manager/Instance.mjs';
@@ -36,64 +38,70 @@ import ClientConfig   from '../../ai/mcp/client/config.mjs';
 const DEFAULT_TOKEN_ENV = 'NEO_KB_INGEST_TOKEN';
 
 /**
+ * @summary Creates an isolated Commander parser for one invocation.
+ * @returns {Command}
+ */
+function createArgParser() {
+    const program = new Command();
+
+    program
+        .name('kb-push-client')
+        .description('Tenant-side repo-push client for the KB ingest_source_files MCP facade')
+        .exitOverride()
+        .configureOutput({
+            writeErr: () => {},
+            writeOut: () => {}
+        })
+        .allowExcessArguments(false)
+        .option('--allow-unauthenticated', 'Allow missing bearer token for local demo deployments only')
+        .option('--client-name <name>', 'MCP client name')
+        .option('--from-file <path>', 'Read one JSON ingestion envelope from a file')
+        .option('--from-stdin', 'Read one JSON ingestion envelope from stdin')
+        .option('--repo-slug <slug>', 'Default repoSlug for the envelope')
+        .option('--tenant-id <tenantId>', 'Default tenantId for the envelope')
+        .option('--token <token>', 'Bearer token value')
+        .option('--token-env <name>', 'Environment variable containing the bearer token')
+        .option('--transport <type>', 'Remote MCP transport: streamable-http or sse')
+        .option('--url <url>', 'Remote KB MCP endpoint URL');
+
+    return program;
+}
+
+/**
  * @summary Parses the tenant push-client CLI argv.
  * @param {String[]} argv `process.argv.slice(2)`.
  * @param {Object} env Environment defaults; injected by tests.
  * @returns {Object}
  */
 function parseArgs(argv, env = process.env) {
-    const args = {
-        allowUnauthenticated: false,
-        clientName          : 'neo-kb-push-client',
-        fromFile            : null,
-        fromStdin           : false,
-        repoSlug            : env.NEO_KB_REPO_SLUG || null,
-        tenantId            : env.NEO_KB_TENANT_ID || null,
-        token               : null,
-        tokenEnv            : env.NEO_KB_TOKEN_ENV || DEFAULT_TOKEN_ENV,
-        transport           : env.NEO_KB_MCP_TRANSPORT || 'streamable-http',
-        url                 : env.NEO_KB_MCP_URL || null
-    };
+    const program = createArgParser();
+    let parseError = null;
 
-    for (let i = 0; i < argv.length; i++) {
-        const arg = argv[i];
-
-        switch (arg) {
-        case '--allow-unauthenticated':
-            args.allowUnauthenticated = true;
-            break;
-        case '--client-name':
-            args.clientName = argv[++i];
-            break;
-        case '--from-file':
-            args.fromFile = argv[++i];
-            break;
-        case '--from-stdin':
-            args.fromStdin = true;
-            break;
-        case '--repo-slug':
-            args.repoSlug = argv[++i];
-            break;
-        case '--tenant-id':
-            args.tenantId = argv[++i];
-            break;
-        case '--token':
-            args.token = argv[++i];
-            break;
-        case '--token-env':
-            args.tokenEnv = argv[++i];
-            break;
-        case '--transport':
-            args.transport = argv[++i];
-            break;
-        case '--url':
-            args.url = argv[++i];
-            break;
-        }
+    try {
+        program.parse(argv, {from: 'user'});
+    } catch (error) {
+        parseError = error.message;
     }
 
-    if (!args.token && args.tokenEnv) {
-        args.token = env[args.tokenEnv] || null;
+    const options  = program.opts(),
+          tokenEnv = options.tokenEnv || env.NEO_KB_TOKEN_ENV || DEFAULT_TOKEN_ENV,
+          token    = options.token || (tokenEnv ? env[tokenEnv] : null) || null;
+
+    const args = {
+        allowUnauthenticated: Boolean(options.allowUnauthenticated),
+        clientName          : options.clientName || 'neo-kb-push-client',
+        fromFile            : options.fromFile || null,
+        fromStdin           : Boolean(options.fromStdin),
+        repoSlug            : options.repoSlug || env.NEO_KB_REPO_SLUG || null,
+        tenantId            : options.tenantId || env.NEO_KB_TENANT_ID || null,
+        token,
+        tokenEnv,
+        transport           : options.transport || env.NEO_KB_MCP_TRANSPORT || 'streamable-http',
+        url                 : options.url || env.NEO_KB_MCP_URL || null
+    };
+
+    if (parseError) {
+        args.parseError = parseError;
     }
 
     return args;
@@ -243,6 +251,10 @@ async function runPush({args, input, clientFactory, clientConfig = ClientConfig}
  */
 function validateArgs(args) {
     const errors = [];
+
+    if (args.parseError) {
+        return [args.parseError];
+    }
 
     if (!args.url) {
         errors.push('Missing --url or NEO_KB_MCP_URL.');

--- a/buildScripts/ai/kbPushClient.mjs
+++ b/buildScripts/ai/kbPushClient.mjs
@@ -1,0 +1,314 @@
+// Neo namespace bootstrap (entry-point invariant) - tenant-side KB push client.
+// Mirrors buildScripts/ai/ingestTenant.mjs so this CLI can use Neo's MCP client
+// wrapper from a tenant checkout or CI job.
+import Neo            from '../../src/Neo.mjs';
+import * as core      from '../../src/core/_export.mjs';
+import InstanceManager from '../../src/manager/Instance.mjs';
+import fs             from 'fs';
+import {pathToFileURL} from 'url';
+import Client         from '../../ai/mcp/client/Client.mjs';
+import ClientConfig   from '../../ai/mcp/client/config.mjs';
+
+/**
+ * @module buildScripts/ai/kbPushClient
+ *
+ * @summary Tenant-side repo-push client for the KB `ingest_source_files` MCP facade.
+ *
+ * This is the operator-facing invocation primitive for #11743's MCP-over-StreamableHTTP
+ * path. Tenant hooks or CI jobs build a content-bearing ingestion envelope, then this
+ * client connects to the cloud KB MCP `/mcp` endpoint with an automation identity token
+ * and calls `ingest_source_files`. Large backfills remain the co-located
+ * `ai:ingest-tenant` bulk CLI; this client intentionally preserves the MCP work-volume
+ * gate and fails visibly when the server returns `KB_INGEST_VOLUME_EXCEEDED`.
+ *
+ * Usage:
+ * `npm run ai:kb-push-client -- --url https://kb.example.com/mcp --from-file envelope.json`
+ *
+ * Environment defaults:
+ * - `NEO_KB_MCP_URL` - remote KB MCP endpoint URL.
+ * - `NEO_KB_MCP_TRANSPORT` - `streamable-http` (default) or `sse`.
+ * - `NEO_KB_INGEST_TOKEN` - bearer token for the repo-push automation identity.
+ * - `NEO_KB_TENANT_ID` / `NEO_KB_REPO_SLUG` - optional envelope defaults.
+ *
+ * @see https://github.com/neomjs/neo/issues/11743
+ */
+
+const DEFAULT_TOKEN_ENV = 'NEO_KB_INGEST_TOKEN';
+
+/**
+ * @summary Parses the tenant push-client CLI argv.
+ * @param {String[]} argv `process.argv.slice(2)`.
+ * @param {Object} env Environment defaults; injected by tests.
+ * @returns {Object}
+ */
+function parseArgs(argv, env = process.env) {
+    const args = {
+        allowUnauthenticated: false,
+        clientName          : 'neo-kb-push-client',
+        fromFile            : null,
+        fromStdin           : false,
+        repoSlug            : env.NEO_KB_REPO_SLUG || null,
+        tenantId            : env.NEO_KB_TENANT_ID || null,
+        token               : null,
+        tokenEnv            : env.NEO_KB_TOKEN_ENV || DEFAULT_TOKEN_ENV,
+        transport           : env.NEO_KB_MCP_TRANSPORT || 'streamable-http',
+        url                 : env.NEO_KB_MCP_URL || null
+    };
+
+    for (let i = 0; i < argv.length; i++) {
+        const arg = argv[i];
+
+        switch (arg) {
+        case '--allow-unauthenticated':
+            args.allowUnauthenticated = true;
+            break;
+        case '--client-name':
+            args.clientName = argv[++i];
+            break;
+        case '--from-file':
+            args.fromFile = argv[++i];
+            break;
+        case '--from-stdin':
+            args.fromStdin = true;
+            break;
+        case '--repo-slug':
+            args.repoSlug = argv[++i];
+            break;
+        case '--tenant-id':
+            args.tenantId = argv[++i];
+            break;
+        case '--token':
+            args.token = argv[++i];
+            break;
+        case '--token-env':
+            args.tokenEnv = argv[++i];
+            break;
+        case '--transport':
+            args.transport = argv[++i];
+            break;
+        case '--url':
+            args.url = argv[++i];
+            break;
+        }
+    }
+
+    if (!args.token && args.tokenEnv) {
+        args.token = env[args.tokenEnv] || null;
+    }
+
+    return args;
+}
+
+/**
+ * @summary Prints CLI usage to stderr.
+ * @returns {void}
+ */
+function printUsage() {
+    console.error('Usage: npm run ai:kb-push-client -- --url <https://kb.example.com/mcp> (--from-file envelope.json | --from-stdin) [--token-env NEO_KB_INGEST_TOKEN]');
+}
+
+/**
+ * @summary Reads one JSON ingestion envelope from a stream.
+ * @param {ReadableStream} input Stream containing one JSON object.
+ * @returns {Promise<Object>}
+ */
+async function readJsonPayload(input) {
+    let text = '';
+
+    for await (const chunk of input) {
+        text += chunk;
+    }
+
+    const trimmed = text.trim();
+
+    if (!trimmed) {
+        throw new Error('No JSON payload provided.');
+    }
+
+    return JSON.parse(trimmed);
+}
+
+/**
+ * @summary Applies CLI/env defaults to an ingestion envelope without overriding explicit payload fields.
+ * @param {Object} envelope Source envelope from hook/CI.
+ * @param {Object} args Parsed CLI args.
+ * @returns {Object}
+ */
+function applyEnvelopeDefaults(envelope, args) {
+    const normalized = {...envelope};
+
+    if (args.tenantId && normalized.tenantId === undefined) {
+        normalized.tenantId = args.tenantId;
+    }
+
+    if (args.repoSlug && normalized.repoSlug === undefined) {
+        normalized.repoSlug = args.repoSlug;
+    }
+
+    if (args.repoSlug && normalized.manifestSnapshot && normalized.manifestSnapshot.repoSlug === undefined) {
+        normalized.manifestSnapshot = {
+            ...normalized.manifestSnapshot,
+            repoSlug: args.repoSlug
+        };
+    }
+
+    return normalized;
+}
+
+/**
+ * @summary Builds the transient MCP client config for the remote KB endpoint.
+ * @param {Object} args Parsed CLI args.
+ * @returns {Object}
+ */
+function buildServerConfig(args) {
+    const headers = {};
+
+    if (args.token) {
+        headers.Authorization = `Bearer ${args.token}`;
+    }
+
+    return {
+        transportType   : args.transport,
+        url             : args.url,
+        transportOptions: Object.keys(headers).length
+            ? {requestInit: {headers}}
+            : {}
+    };
+}
+
+/**
+ * @summary Decodes a standard MCP call result into the tool payload when possible.
+ * @param {Object} result Raw SDK callTool result.
+ * @returns {*}
+ */
+function decodeToolResult(result) {
+    const firstText = result?.content?.find?.(entry => entry.type === 'text')?.text;
+
+    if (!firstText) {
+        return result;
+    }
+
+    try {
+        return JSON.parse(firstText);
+    } catch {
+        return result;
+    }
+}
+
+/**
+ * @summary Detects whether an ingestion summary should make the hook/CI fail.
+ * @param {*} payload Decoded tool payload.
+ * @returns {Boolean}
+ */
+function hasIngestFailure(payload) {
+    if (payload?.isError || payload?.code === 'KB_INGEST_VOLUME_EXCEEDED') {
+        return true;
+    }
+
+    return Array.isArray(payload?.errors) && payload.errors.length > 0;
+}
+
+/**
+ * @summary Calls `ingest_source_files` through a remote MCP client.
+ * @param {Object} options
+ * @param {Object} options.args Parsed CLI args.
+ * @param {ReadableStream} options.input Source stream for the envelope.
+ * @param {Function} [options.clientFactory] Test seam returning a connected-client-shaped object.
+ * @param {Object} [options.clientConfig] Test seam for ClientConfig.
+ * @returns {Promise<*>} Decoded tool payload.
+ */
+async function runPush({args, input, clientFactory, clientConfig = ClientConfig}) {
+    const envelope = applyEnvelopeDefaults(await readJsonPayload(input), args),
+          serverName = `knowledge-base-push-${Date.now()}`;
+
+    clientConfig.data.mcpServers[serverName] = buildServerConfig(args);
+
+    const client = clientFactory
+        ? clientFactory({serverName, clientName: args.clientName})
+        : Neo.create(Client, {serverName, clientName: args.clientName});
+
+    try {
+        await client.initAsync?.();
+        return decodeToolResult(await client.callTool('ingest_source_files', envelope));
+    } finally {
+        await client.close?.();
+        delete clientConfig.data.mcpServers[serverName];
+    }
+}
+
+/**
+ * @summary Validates parsed CLI args before network work begins.
+ * @param {Object} args Parsed CLI args.
+ * @returns {String[]} Human-readable validation errors.
+ */
+function validateArgs(args) {
+    const errors = [];
+
+    if (!args.url) {
+        errors.push('Missing --url or NEO_KB_MCP_URL.');
+    }
+
+    if (!args.fromFile && !args.fromStdin) {
+        errors.push('Provide --from-file or --from-stdin.');
+    }
+
+    if (args.fromFile && args.fromStdin) {
+        errors.push('Use only one of --from-file or --from-stdin.');
+    }
+
+    if (args.fromFile && !fs.existsSync(args.fromFile)) {
+        errors.push(`--from-file path does not exist: ${args.fromFile}`);
+    }
+
+    if (!['sse', 'streamable-http', 'streamableHttp'].includes(args.transport)) {
+        errors.push(`Unsupported --transport '${args.transport}'. Expected streamable-http or sse.`);
+    }
+
+    if (!args.allowUnauthenticated && !args.token) {
+        errors.push(`Missing bearer token: set --token, --token-env, or ${DEFAULT_TOKEN_ENV}. Use --allow-unauthenticated only for a local demo deployment.`);
+    }
+
+    return errors;
+}
+
+/**
+ * @summary CLI entry point.
+ * @returns {Promise<void>}
+ */
+async function kbPushClient() {
+    const args   = parseArgs(process.argv.slice(2)),
+          errors = validateArgs(args);
+
+    if (errors.length) {
+        printUsage();
+        errors.forEach(error => console.error(`Error: ${error}`));
+        process.exit(1);
+    }
+
+    const input = args.fromStdin ? process.stdin : fs.createReadStream(args.fromFile, 'utf8');
+
+    try {
+        const payload = await runPush({args, input});
+
+        console.log(JSON.stringify(payload, null, 2));
+        process.exit(hasIngestFailure(payload) ? 1 : 0);
+    } catch (error) {
+        console.error('KB push client failed:', error);
+        process.exit(1);
+    }
+}
+
+if (import.meta.url === pathToFileURL(process.argv[1] || '').href) {
+    kbPushClient();
+}
+
+export {
+    applyEnvelopeDefaults,
+    buildServerConfig,
+    decodeToolResult,
+    hasIngestFailure,
+    parseArgs,
+    readJsonPayload,
+    runPush,
+    validateArgs
+};

--- a/examples/cloud-deployment/pre-push-hook.sh
+++ b/examples/cloud-deployment/pre-push-hook.sh
@@ -10,9 +10,23 @@
 set -euo pipefail
 
 TENANT_ID="${NEO_KB_TENANT_ID:-example-tenant}"
+REPO_SLUG="${NEO_KB_REPO_SLUG:-example/repo}"
+MCP_URL="${NEO_KB_MCP_URL:-}"
+# The tenant-side MCP push client inside the neo.mjs dependency. Override via NEO_KB_PUSH_CLIENT.
+PUSH_CLIENT="${NEO_KB_PUSH_CLIENT:-node_modules/neo.mjs/buildScripts/ai/kbPushClient.mjs}"
 # The ai:ingest-tenant CLI inside the neo.mjs dependency. Override via NEO_INGEST_CLI.
 INGEST_CLI="${NEO_INGEST_CLI:-node_modules/neo.mjs/buildScripts/ai/ingestTenant.mjs}"
 EMPTY="0000000000000000000000000000000000000000"
+
+build_remote_envelope() {
+    CHANGED_PATHS="$changed" \
+    DELETED_PATHS="$deleted" \
+    BASE_REVISION="$base" \
+    HEAD_REVISION="$local_sha" \
+    REPO_SLUG="$REPO_SLUG" \
+    TENANT_ID="$TENANT_ID" \
+    node -e 'const fs=require("fs");const lines=s=>(s||"").split(/\n/).filter(Boolean);const files=lines(process.env.CHANGED_PATHS).filter(f=>fs.existsSync(f)).map(f=>({sourcePath:f,content:fs.readFileSync(f,"utf8")}));const deleted=lines(process.env.DELETED_PATHS).map(sourcePath=>({sourcePath,repoSlug:process.env.REPO_SLUG}));const envelope={tenantId:process.env.TENANT_ID,repoSlug:process.env.REPO_SLUG,files,deleted,baseRevision:process.env.BASE_REVISION,headRevision:process.env.HEAD_REVISION};process.stdout.write(JSON.stringify(envelope));'
+}
 
 # git feeds pre-push "<local-ref> <local-sha> <remote-ref> <remote-sha>" lines on stdin.
 while read -r local_ref local_sha remote_ref remote_sha; do
@@ -27,6 +41,24 @@ while read -r local_ref local_sha remote_ref remote_sha; do
     changed="$(git diff --name-only --diff-filter=ACMR "$base" "$local_sha" || true)"
     deleted="$(git diff --name-only --diff-filter=D    "$base" "$local_sha" || true)"
 
+    if [ -n "$MCP_URL" ]; then
+        if [ -z "$changed" ] && [ -z "$deleted" ]; then
+            echo "[kb-pre-push] no changed or deleted files to ingest"
+            continue
+        fi
+
+        # Remote tenant mode (#11743): build one content-bearing ingest_source_files
+        # envelope and submit it through the tenant-side StreamableHTTP/SSE MCP client.
+        # Auth comes from NEO_KB_INGEST_TOKEN (or NEO_KB_TOKEN_ENV).
+        envelope="$(build_remote_envelope)"
+        printf '%s\n' "$envelope" | \
+            NEO_KB_MCP_URL="$MCP_URL" \
+            NEO_KB_TENANT_ID="$TENANT_ID" \
+            NEO_KB_REPO_SLUG="$REPO_SLUG" \
+            node "$PUSH_CLIENT" --from-stdin
+        continue
+    fi
+
     if [ -n "$changed" ]; then
         # Stream each changed file as a raw ingest record — {sourcePath, content} JSONL —
         # into the bulk facade. With no parserId on the record, the server applies its
@@ -40,10 +72,10 @@ while read -r local_ref local_sha remote_ref remote_sha; do
         echo "[kb-pre-push] no changed files to ingest"
     fi
 
-    # --- Extension point: deletion signaling ---
-    # The bulk CLI ingests changed files only. To propagate deletions, send an
-    # `ingest_source_files` envelope carrying `deleted` tombstones plus
-    # `baseRevision`/`headRevision` (= "$base" / "$local_sha"). See HookWiring.md.
+    # --- Local bulk fallback limitation ---
+    # The bulk CLI ingests changed files only. To propagate deletions in tenant mode,
+    # set NEO_KB_MCP_URL so the hook uses ai:kb-push-client and sends an
+    # ingest_source_files envelope with tombstones plus base/head revisions.
     if [ -n "$deleted" ]; then
         echo "[kb-pre-push] $(printf '%s\n' "$deleted" | grep -c .) deleted path(s) — wire deletion signaling per HookWiring.md"
     fi

--- a/learn/agentos/cloud-deployment/Configuration.md
+++ b/learn/agentos/cloud-deployment/Configuration.md
@@ -48,6 +48,21 @@ A deployment's `config.mjs` is gitignored and copied from `config.template.mjs`.
 
 Each key is also bindable via an environment variable (`NEO_KB_DEFAULT_TENANT_ID`, `NEO_TRANSPORT`, `MCP_HTTP_PORT`, …) — see `config.template.mjs`'s `envBindings` map for the full set.
 
+## Tenant push-client environment
+
+`npm run ai:kb-push-client` runs in the tenant workspace or CI job, not inside the KB server process. It therefore has its own small environment surface:
+
+| Variable | Required | Meaning |
+|---|---|---|
+| `NEO_KB_MCP_URL` | Yes unless `--url` is passed | Remote KB MCP endpoint URL, for example `https://agent-os.example.com/kb/mcp`. |
+| `NEO_KB_MCP_TRANSPORT` | No | MCP client transport; defaults to `streamable-http`, accepts `sse` for older endpoint wiring. |
+| `NEO_KB_INGEST_TOKEN` | Yes for production | Bearer token for the repo-push automation identity. |
+| `NEO_KB_TOKEN_ENV` | No | Name of the environment variable that holds the bearer token when the deployment does not use `NEO_KB_INGEST_TOKEN`. |
+| `NEO_KB_TENANT_ID` | No | Envelope default for tenant id; authenticated server context remains authoritative. |
+| `NEO_KB_REPO_SLUG` | No | Envelope default for repo slug; use a deterministic, secret-free value such as `acme/app`. |
+
+The token is a KB MCP authorization credential, not a Git credential. Store it in the tenant hook/CI secret store and rotate it using the deployment's normal OIDC or workload-identity policy.
+
 ## Per-tenant config storage — `KnowledgeBaseTenantConfig` (#11637)
 
 A multi-tenant deployment cannot express every tenant's source/parser config as static `aiConfig` keys — each tenant needs its own, mutable at runtime, durable across restarts. Phase 2E ([#11637](https://github.com/neomjs/neo/issues/11637)) stores it as a graph node.

--- a/learn/agentos/cloud-deployment/HookWiring.md
+++ b/learn/agentos/cloud-deployment/HookWiring.md
@@ -1,23 +1,43 @@
 # Cloud-Native KB Ingestion — Hook Wiring
 
-> **Status — Phase 3B.** This guide documents the two Phase 2 ingestion facades of Epic [#11624](https://github.com/neomjs/neo/issues/11624) — the `ingest_source_files` MCP operation ([#11634](https://github.com/neomjs/neo/issues/11634)) and the `npm run ai:ingest-tenant` bulk CLI ([#11635](https://github.com/neomjs/neo/issues/11635)), both merged. The runnable `pre-push` hook and worked external workspace it references ship in the same Phase 3B change set under [`examples/cloud-deployment/`](../../../examples/cloud-deployment/).
+> **Status — Phase 3B + #11743.** This guide documents the shipped ingestion surfaces of Epic [#11624](https://github.com/neomjs/neo/issues/11624) plus the #11743 tenant-side repo-push client: the `ingest_source_files` MCP operation ([#11634](https://github.com/neomjs/neo/issues/11634)), the `npm run ai:kb-push-client` remote MCP wrapper, and the `npm run ai:ingest-tenant` bulk CLI ([#11635](https://github.com/neomjs/neo/issues/11635)). The runnable `pre-push` hook and worked external workspace it references ship under [`examples/cloud-deployment/`](../../../examples/cloud-deployment/).
 
-## Two facades, one ingestion service
+## Three operator surfaces, one ingestion service
 
-A tenant's source content reaches the Knowledge Base through one of two facades. Both call the same `KnowledgeBaseIngestionService.ingestSourceFiles` orchestrator and write to the unified Chroma `knowledge-base` collection — they differ in **who calls them** and in **work-volume policy**.
+A tenant's source content reaches the Knowledge Base through the same `KnowledgeBaseIngestionService.ingestSourceFiles` orchestrator and writes to the unified Chroma `knowledge-base` collection. The operational surfaces differ in **who calls them**, **where they run**, and **work-volume policy**.
 
 For the operator-facing decision model — how to choose repo slugs, treat credentials, inventory source families, and decide when to use each facade — read [Tenant Ingestion Model](./TenantIngestionModel.md) first.
 
-| Facade | Caller | Volume policy | Built for |
+| Surface | Caller | Volume policy | Built for |
 |---|---|---|---|
-| `ingest_source_files` | A remote MCP client of the `sse` / StreamableHTTP deployment — an agent in the tenant workspace, or a tenant push-client | Gated — refuses a batch over `mcpSyncMaxChunks` (default 50) | Incremental pushes: a commit's worth of changed files |
+| `ingest_source_files` | A remote MCP client of the `sse` / StreamableHTTP deployment — an agent in the tenant workspace, or a tenant push client | Gated — refuses a batch over `mcpSyncMaxChunks` (default 50); listed/callable only when the KB server runs with `transport === 'sse'` | Incremental pushes: a commit's worth of changed files |
+| `npm run ai:kb-push-client` | A tenant git hook or CI job; wraps the remote MCP call | Same MCP gate as `ingest_source_files` | Operator-facing repo-push invocation over StreamableHTTP/SSE |
 | `npm run ai:ingest-tenant` | A shell process co-located with the KB server — the cloud operator, a CI job | Ungated (`viaMcp: false`) | Initial tenant onboarding (5k–50k chunks), large back-fills |
 
 The fork between them is the [#10572](https://github.com/neomjs/neo/issues/10572) **MCP work-volume gate**. An MCP tool call holds the calling agent's turn open; embedding tens of thousands of chunks synchronously inside one call is the wrong shape. The gate makes that structural — `ingest_source_files` *refuses* an over-volume batch (it returns a refusal payload, it does not block), and the bulk CLI is the sanctioned path for the volume the gate rejects. `viaMcp: false` — passed only by the CLI — is the single sanctioned gate bypass.
 
-## Transport
+## Transport and auth model
 
 The KB MCP server runs dual-transport (`ai/mcp/server/knowledge-base/Server.mjs`): `stdio` for a local single-repo deployment, or `sse` (StreamableHTTP) for a cloud deployment serving remote tenants — selected by `aiConfig.transport` with `aiConfig.mcpHttpPort`. `ingest_source_files` is transport-gated: it is listed and callable only when the KB server runs with `transport === 'sse'`. Local `stdio` clients do not see it and direct calls fail closed with guidance to use the local CLI/service path instead. The `ai:ingest-tenant` CLI is **not** a remote facade — it imports the KB services directly and runs on the deployment host.
+
+The deployable repo-push path is `npm run ai:kb-push-client`. It is a tenant-side MCP client wrapper around `ingest_source_files`:
+
+```bash
+NEO_KB_MCP_URL="https://agent-os.example.com/kb/mcp" \
+NEO_KB_INGEST_TOKEN="$repo_push_token" \
+NEO_KB_TENANT_ID="client-org" \
+NEO_KB_REPO_SLUG="acme/app" \
+npm run ai:kb-push-client -- --from-stdin < envelope.json
+```
+
+The operator-facing primitive is the **repo-push automation identity**, not a human agent session:
+
+1. Create a service account or machine client in the deployment's OIDC provider, for example `kb-repo-push-client-org`.
+2. Configure the token audience/resource to match the KB deployment's public MCP resource. Behind the reference Caddy ingress, that means the canonical KB public URL exposed by `NEO_PUBLIC_URL` plus the `/mcp` endpoint path, commonly `https://agent-os.example.com/kb/mcp`.
+3. Store the access token or client-credentials exchange output in the tenant hook/CI secret store, exposed to the hook as `NEO_KB_INGEST_TOKEN`. Do not commit it, put it in `repoSlug`, or log it.
+4. Scope the identity to the tenant it represents. The server stamps the authoritative tenant identity from authenticated context; payload `tenantId` remains a default/claim, not authority.
+
+If a deployment deliberately runs unauthenticated for a local demo, pass `--allow-unauthenticated`; production tenant ingestion should not use that flag.
 
 ## The incremental facade — `ingest_source_files`
 
@@ -52,6 +72,39 @@ No envelope field is strictly required — the ingestion service validates and r
 ```
 
 A caller branches on `code`: split into sub-threshold `ingest_source_files` calls, or hand the back-fill to the bulk CLI. A successful call returns `{ingested, deleted, embeddingsGenerated, errors, tenantId, durationMs}`.
+
+## Tenant push client — `npm run ai:kb-push-client`
+
+The push client accepts a single JSON envelope and submits it to the remote MCP endpoint:
+
+```bash
+npm run ai:kb-push-client -- \
+    --url https://agent-os.example.com/kb/mcp \
+    --tenant-id client-org \
+    --repo-slug acme/app \
+    --from-file envelope.json
+```
+
+Environment defaults:
+
+| Variable | Meaning |
+|---|---|
+| `NEO_KB_MCP_URL` | Remote KB MCP endpoint URL, for example `https://agent-os.example.com/kb/mcp`. |
+| `NEO_KB_MCP_TRANSPORT` | Client transport; `streamable-http` by default, `sse` for older endpoint wiring. |
+| `NEO_KB_INGEST_TOKEN` | Bearer token for the repo-push automation identity. |
+| `NEO_KB_TENANT_ID` | Optional envelope default; server-side auth still stamps the authoritative tenant. |
+| `NEO_KB_REPO_SLUG` | Optional envelope default for records/manifests that omit `repoSlug`. |
+
+Failure signatures a hook/CI job should branch on:
+
+| Signature | Meaning | Operator response |
+|---|---|---|
+| `KB_INGEST_VOLUME_EXCEEDED` | Batch exceeds `mcpSyncMaxChunks`. | Split the envelope or use `ai:ingest-tenant` for bulk onboarding/backfill. |
+| HTTP 401 / `Unauthorized` | Token missing, expired, wrong audience/resource, or rejected by proxy/auth middleware. | Refresh the automation identity token and verify `NEO_PUBLIC_URL` / audience wiring. |
+| Tool not listed / MCP call rejected | The endpoint is not the KB MCP server, transport config is wrong, or the deployment gates ingest tools by transport/auth. | Verify `NEO_KB_MCP_URL`, transport, and server config before retrying. |
+| Non-empty `errors` array | The ingestion service accepted the call but one or more files failed validation/parsing. | Fail the hook/CI job and surface the structured `{code, message}` entries. |
+
+This client is the current #11743 MCP-over-StreamableHTTP answer. A non-MCP HTTP or queue receiver that reuses `KnowledgeBaseIngestionService` remains a future alternative if the MCP client path proves operationally awkward. Server-side ref-only webhook/clone ingestion remains the separate [#11731](https://github.com/neomjs/neo/issues/11731) exploration.
 
 ## The bulk facade — `npm run ai:ingest-tenant`
 
@@ -92,7 +145,7 @@ A `pre-push` hook is the recommended trigger: it fires once per `git push`, rece
 1. Read the pushed ref range (`<local-ref> <local-sha> <remote-ref> <remote-sha>`) from the hook's stdin.
 2. Enumerate changed files — `git diff --name-only --diff-filter=ACMR <remote-sha> <local-sha>` for adds/modifies, `--diff-filter=D` for deletes.
 3. Assemble the envelope — changed files into `files`, deleted paths into `deleted`, the SHA pair into `baseRevision` / `headRevision`.
-4. Submit it — a small push goes to the `sse` / StreamableHTTP `ingest_source_files` endpoint; an initial import of an existing repo goes to the bulk CLI. The submission step is the deployment-specific integration point: the hook hands the envelope to the tenant push client wired to the deployment endpoint. In local `stdio` mode, use the CLI/service path instead; the MCP tool is intentionally hidden.
+4. Submit it — when `NEO_KB_MCP_URL` is configured, pipe the envelope to `ai:kb-push-client`, which calls the `sse` / StreamableHTTP `ingest_source_files` endpoint; an initial import of an existing repo still goes to the deployment-host bulk CLI. In local `stdio` mode, use the CLI/service path instead; the MCP tool is intentionally hidden.
 5. Inspect the returned summary — a non-empty `errors` array fails the hook so the developer sees it.
 
 The example combines **tombstones + revision-boundary** — the precise-but-cheap pair for a hook that already runs `git diff`.
@@ -120,4 +173,4 @@ The example combines **tombstones + revision-boundary** — the precise-but-chea
 - [Custom Parsers](./CustomParsers.md) — authoring a parser that turns a tenant file format into `parsed-chunk-v1` records.
 - [Security](./Security.md) — write-side stamping, spoof-rejection, and the parser-execution boundary.
 - [`deletion-signaling-contract.md`](../../../ai/services/knowledge-base/parser/deletion-signaling-contract.md) · [`identity-tuple.md`](../../../ai/services/knowledge-base/parser/identity-tuple.md) — the ingestion contracts.
-- [#11634](https://github.com/neomjs/neo/issues/11634) `ingest_source_files` · [#11635](https://github.com/neomjs/neo/issues/11635) `ai:ingest-tenant` · [#10572](https://github.com/neomjs/neo/issues/10572) MCP work-volume gate.
+- [#11743](https://github.com/neomjs/neo/issues/11743) repo-push receiver/auth model · [#11634](https://github.com/neomjs/neo/issues/11634) `ingest_source_files` · [#11635](https://github.com/neomjs/neo/issues/11635) `ai:ingest-tenant` · [#10572](https://github.com/neomjs/neo/issues/10572) MCP work-volume gate.

--- a/learn/agentos/cloud-deployment/TenantIngestionModel.md
+++ b/learn/agentos/cloud-deployment/TenantIngestionModel.md
@@ -16,14 +16,15 @@ This model pairs with the D0 scheduler taxonomy in [#11721](https://github.com/n
 
 ## Entry Points
 
-Use the same underlying ingestion service through two facades:
+Use the same underlying ingestion service through three operational surfaces:
 
-| Facade | Use when | Volume / lifecycle |
+| Surface | Use when | Volume / lifecycle |
 |---|---|---|
 | `ingest_source_files` | A tenant agent or push client sends a bounded incremental change set to the cloud MCP endpoint running with `transport === 'sse'`. | MCP-callable only in the remote StreamableHTTP profile and volume-gated by `mcpSyncMaxChunks`; split or use the CLI when the gate refuses. |
+| `npm run ai:kb-push-client` | A tenant git hook or CI job needs an operator-facing invocation wrapper for the remote MCP call. | Runs in the tenant workspace, uses StreamableHTTP/SSE, carries an automation identity bearer token, and preserves the MCP gate. |
 | `npm run ai:ingest-tenant -- <tenantId> ...` | A deployment operator, CI job, or onboarding script performs an initial import, full backfill, or large re-push. | Runs on the deployment host, bypasses the MCP turn-volume gate via `viaMcp: false`, and holds the heavy-maintenance lease. |
 
-Both facades call `KnowledgeBaseIngestionService.ingestSourceFiles()`. The MCP facade is hidden and fail-closed for local `stdio` server sessions because repo-push ingestion is an operator-facing remote deployment path, not an interactive local agent tool. Do not document a third ingestion path for the MVP unless the implementation adds one.
+All three surfaces call `KnowledgeBaseIngestionService.ingestSourceFiles()`. The MCP facade is hidden and fail-closed for local `stdio` server sessions because repo-push ingestion is an operator-facing remote deployment path, not an interactive local agent tool. A future non-MCP HTTP/queue receiver may share the same service, but it is not the shipped #11743 path.
 
 ## Repository Identity
 
@@ -65,6 +66,7 @@ The push-based MVP path is credential-free from the KB server's perspective:
 - The tenant workspace already has access to its own repository.
 - The tenant push client reads local files and sends content or parsed chunks.
 - The KB server receives ingestion payloads, not Git credentials.
+- The repo-push automation identity token authorizes the tenant to call the KB MCP endpoint; it is not a Git credential and is never folded into `repoSlug`, manifests, or chunk metadata.
 
 Credential-bearing Git URLs are therefore rejected or treated as deferred clone-exploration input. They must not appear in:
 
@@ -76,6 +78,20 @@ Credential-bearing Git URLs are therefore rejected or treated as deferred clone-
 - source-family inventory output
 
 If a future server-side clone path becomes necessary, [#11731](https://github.com/neomjs/neo/issues/11731) owns the credential transport and storage contract before implementation begins.
+
+## Repo-Push Automation Identity
+
+For day-0 tenant push, create a machine/service account in the deployment's OIDC provider and scope it to the tenant repository source it represents. The tenant hook or CI job stores the resulting access token in its secret store and exposes it as `NEO_KB_INGEST_TOKEN`.
+
+The deployment's OAuth audience/resource must match the KB MCP public resource. Behind the reference ingress, the client URL is typically:
+
+```text
+https://agent-os.example.com/kb/mcp
+```
+
+The token's resource should match the canonical KB public URL configured by `NEO_PUBLIC_URL` / the auth provider. The exact token acquisition flow is operator-owned — client credentials, workload identity, or CI OIDC exchange are all valid — but the resulting token must be short-lived or rotated, tenant-scoped, and stored outside the repository.
+
+The server remains authoritative for tenant identity. `NEO_KB_TENANT_ID` is a client default for envelope construction; authenticated context still stamps or rejects tenant metadata according to deployment policy.
 
 ## Parser Dispatch
 
@@ -132,10 +148,11 @@ Incremental pushes should include deletion intent. Prefer this default shape:
 2. Build the source-family inventory.
 3. Choose dispatch for each family: raw server parse, registered server parser, client-side `parsed-chunk-v1`, unsupported, or excluded.
 4. Run initial import with `ai:ingest-tenant` when volume exceeds the MCP gate.
-5. Wire incremental `pre-push` or CI pushes through `ingest_source_files`.
-6. Include tombstones and revision boundaries; include manifests at reconciliation points.
-7. Fail the hook or CI job on structured ingestion errors instead of silently dropping files.
-8. Verify retrieval against the tenant corpus plus `neo-shared` content before handing the deployment to agents.
+5. Create the repo-push automation identity, configure token audience/resource, and store the token as `NEO_KB_INGEST_TOKEN` in the tenant hook or CI secret store.
+6. Wire incremental `pre-push` or CI pushes through `ai:kb-push-client` to the remote MCP endpoint.
+7. Include tombstones and revision boundaries; include manifests at reconciliation points.
+8. Fail the hook or CI job on structured ingestion errors instead of silently dropping files.
+9. Verify retrieval against the tenant corpus plus `neo-shared` content before handing the deployment to agents.
 
 ## Evidence Boundary
 
@@ -151,7 +168,7 @@ The day-0 tutorial should reuse this model rather than redefine it.
 
 ## Related
 
-- [Hook Wiring](./HookWiring.md) — the `ingest_source_files` and `ai:ingest-tenant` facades.
+- [Hook Wiring](./HookWiring.md) — the `ingest_source_files`, `ai:kb-push-client`, and `ai:ingest-tenant` surfaces.
 - [Custom Parsers](./CustomParsers.md) — `parsed-chunk-v1` and parser execution boundaries.
 - [Custom Sources](./CustomSources.md) — full-corpus Source path, mostly not the push-based tenant default.
 - [Security](./Security.md) — tenant stamping, spoof rejection, parser trust, and KB-as-cache recovery.

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
         "ai:defrag-sqlite"             : "node ./buildScripts/ai/defragSQLiteDB.mjs",
         "ai:download-kb"               : "node ./buildScripts/ai/downloadKnowledgeBase.mjs",
         "ai:ingest-tenant"             : "node ./buildScripts/ai/ingestTenant.mjs",
+        "ai:kb-push-client"            : "node ./buildScripts/ai/kbPushClient.mjs",
         "ai:mcp-client"                : "node ./ai/mcp/client/mcp-cli.mjs",
         "ai:mcp-server-file-system"    : "node ./ai/mcp/server/file-system/mcp-server.mjs",
         "ai:mcp-server-github-workflow": "node ./ai/mcp/server/github-workflow/mcp-server.mjs",

--- a/test/playwright/unit/ai/buildScripts/kbPushClient.spec.mjs
+++ b/test/playwright/unit/ai/buildScripts/kbPushClient.spec.mjs
@@ -71,6 +71,26 @@ test.describe('buildScripts/ai/kbPushClient — repo-push MCP client (#11743)', 
         });
     });
 
+    test('parseArgs falls back to dotenv-compatible environment defaults', () => {
+        const args = parseArgs(['--from-file', 'envelope.json'], {
+            NEO_KB_INGEST_TOKEN : 'env-token',
+            NEO_KB_MCP_URL      : 'https://kb.example.com/mcp',
+            NEO_KB_MCP_TRANSPORT: 'streamable-http',
+            NEO_KB_REPO_SLUG    : 'acme/app',
+            NEO_KB_TENANT_ID    : 'tenant-a'
+        });
+
+        expect(args).toMatchObject({
+            fromFile : 'envelope.json',
+            repoSlug : 'acme/app',
+            tenantId : 'tenant-a',
+            token    : 'env-token',
+            tokenEnv : 'NEO_KB_INGEST_TOKEN',
+            transport: 'streamable-http',
+            url      : 'https://kb.example.com/mcp'
+        });
+    });
+
     test('validateArgs requires an endpoint, payload source, and bearer token by default', () => {
         expect(validateArgs(parseArgs([], {}))).toEqual([
             'Missing --url or NEO_KB_MCP_URL.',
@@ -99,6 +119,14 @@ test.describe('buildScripts/ai/kbPushClient — repo-push MCP client (#11743)', 
 
         expect(validateArgs(args)).toEqual([
             "Unsupported --transport 'http'. Expected streamable-http or sse."
+        ]);
+    });
+
+    test('validateArgs surfaces Commander parse errors instead of accepting malformed argv', () => {
+        const args = parseArgs(['--url'], {});
+
+        expect(validateArgs(args)).toEqual([
+            "error: option '--url <url>' argument missing"
         ]);
     });
 

--- a/test/playwright/unit/ai/buildScripts/kbPushClient.spec.mjs
+++ b/test/playwright/unit/ai/buildScripts/kbPushClient.spec.mjs
@@ -1,0 +1,207 @@
+import {setup} from '../../../setup.mjs';
+
+setup({
+    neoConfig: {
+        unitTestMode: true
+    },
+    appConfig: {
+        name             : 'KbPushClientCliTest',
+        isMounted        : () => true,
+        vnodeInitialising: false
+    }
+});
+
+import {test, expect} from '@playwright/test';
+import Neo            from '../../../../../src/Neo.mjs';
+import * as core      from '../../../../../src/core/_export.mjs';
+import {Readable}     from 'stream';
+
+/**
+ * Unit coverage for the tenant-side KB push client (#11743).
+ *
+ * The script is the operator-facing StreamableHTTP/SSE invocation primitive for repo-push
+ * ingestion envelopes. Tests keep network/client work injected so parsing, auth headers,
+ * envelope defaults, and MCP result failure semantics are verified without a live KB server.
+ */
+
+test.describe('buildScripts/ai/kbPushClient — repo-push MCP client (#11743)', () => {
+    let applyEnvelopeDefaults,
+        buildServerConfig,
+        decodeToolResult,
+        hasIngestFailure,
+        parseArgs,
+        readJsonPayload,
+        runPush,
+        validateArgs;
+
+    test.beforeAll(async () => {
+        ({
+            applyEnvelopeDefaults,
+            buildServerConfig,
+            decodeToolResult,
+            hasIngestFailure,
+            parseArgs,
+            readJsonPayload,
+            runPush,
+            validateArgs
+        } = await import('../../../../../buildScripts/ai/kbPushClient.mjs'));
+    });
+
+    test('parseArgs reads endpoint, token-env, tenant, repo, transport, and stdin mode', () => {
+        const args = parseArgs(
+            [
+                '--url', 'https://kb.example.com/mcp',
+                '--from-stdin',
+                '--tenant-id', 'tenant-a',
+                '--repo-slug', 'acme/app',
+                '--transport', 'sse',
+                '--token-env', 'TOKEN_ENV'
+            ],
+            {TOKEN_ENV: 'secret-token'}
+        );
+
+        expect(args).toMatchObject({
+            fromStdin: true,
+            repoSlug : 'acme/app',
+            tenantId : 'tenant-a',
+            token    : 'secret-token',
+            tokenEnv : 'TOKEN_ENV',
+            transport: 'sse',
+            url      : 'https://kb.example.com/mcp'
+        });
+    });
+
+    test('validateArgs requires an endpoint, payload source, and bearer token by default', () => {
+        expect(validateArgs(parseArgs([], {}))).toEqual([
+            'Missing --url or NEO_KB_MCP_URL.',
+            'Provide --from-file or --from-stdin.',
+            'Missing bearer token: set --token, --token-env, or NEO_KB_INGEST_TOKEN. Use --allow-unauthenticated only for a local demo deployment.'
+        ]);
+    });
+
+    test('validateArgs allows unauthenticated only when explicitly requested', () => {
+        const args = parseArgs([
+            '--url', 'http://127.0.0.1:3000/mcp',
+            '--from-stdin',
+            '--allow-unauthenticated'
+        ], {});
+
+        expect(validateArgs(args)).toEqual([]);
+    });
+
+    test('validateArgs rejects unsupported transport aliases before client startup', () => {
+        const args = parseArgs([
+            '--url', 'https://kb.example.com/mcp',
+            '--from-stdin',
+            '--transport', 'http',
+            '--token', 'secret-token'
+        ], {});
+
+        expect(validateArgs(args)).toEqual([
+            "Unsupported --transport 'http'. Expected streamable-http or sse."
+        ]);
+    });
+
+    test('readJsonPayload parses a single envelope object from a stream', async () => {
+        const payload = await readJsonPayload(Readable.from(' { "files": [{"sourcePath":"a.mjs"}] } \n'));
+
+        expect(payload).toEqual({
+            files: [{sourcePath: 'a.mjs'}]
+        });
+    });
+
+    test('applyEnvelopeDefaults adds tenant and repo defaults without overwriting explicit payload fields', () => {
+        const normalized = applyEnvelopeDefaults({
+            tenantId        : 'payload-tenant',
+            manifestSnapshot: {pathsAfterPush: ['src/a.mjs']}
+        }, {
+            tenantId: 'cli-tenant',
+            repoSlug : 'acme/app'
+        });
+
+        expect(normalized).toEqual({
+            tenantId        : 'payload-tenant',
+            repoSlug         : 'acme/app',
+            manifestSnapshot: {
+                repoSlug      : 'acme/app',
+                pathsAfterPush: ['src/a.mjs']
+            }
+        });
+    });
+
+    test('buildServerConfig wires Authorization as a bearer token for remote MCP transport', () => {
+        expect(buildServerConfig({
+            token    : 'abc123',
+            transport: 'streamable-http',
+            url      : 'https://kb.example.com/mcp'
+        })).toEqual({
+            transportType   : 'streamable-http',
+            url             : 'https://kb.example.com/mcp',
+            transportOptions: {
+                requestInit: {
+                    headers: {
+                        Authorization: 'Bearer abc123'
+                    }
+                }
+            }
+        });
+    });
+
+    test('decodeToolResult parses JSON text payloads and failure detection catches structured failures', () => {
+        const decoded = decodeToolResult({
+            content: [{
+                type: 'text',
+                text: '{"code":"KB_INGEST_VOLUME_EXCEEDED","errors":[]}'
+            }]
+        });
+
+        expect(decoded.code).toBe('KB_INGEST_VOLUME_EXCEEDED');
+        expect(hasIngestFailure(decoded)).toBe(true);
+        expect(hasIngestFailure({errors: []})).toBe(false);
+        expect(hasIngestFailure({errors: [{code: 'X'}]})).toBe(true);
+    });
+
+    test('runPush calls ingest_source_files with envelope defaults and cleans transient client config', async () => {
+        const calls = [];
+        const clientConfig = {data: {mcpServers: {}}};
+        const args = parseArgs([
+            '--url', 'https://kb.example.com/mcp',
+            '--from-stdin',
+            '--tenant-id', 'tenant-a',
+            '--repo-slug', 'acme/app',
+            '--token', 'secret-token'
+        ], {});
+
+        const result = await runPush({
+            args,
+            input        : Readable.from('{"files":[{"sourcePath":"src/a.mjs","content":"x"}]}'),
+            clientConfig,
+            clientFactory: ({serverName, clientName}) => ({
+                async initAsync() {
+                    calls.push({type: 'init', serverName, clientName});
+                },
+                async callTool(name, envelope) {
+                    calls.push({type: 'call', name, envelope});
+                    return {content: [{type: 'text', text: '{"ingested":1,"errors":[]}'}]};
+                },
+                async close() {
+                    calls.push({type: 'close'});
+                }
+            })
+        });
+
+        expect(result).toEqual({ingested: 1, errors: []});
+        expect(calls[0].type).toBe('init');
+        expect(calls[1]).toEqual({
+            type    : 'call',
+            name    : 'ingest_source_files',
+            envelope: {
+                tenantId: 'tenant-a',
+                repoSlug : 'acme/app',
+                files    : [{sourcePath: 'src/a.mjs', content: 'x'}]
+            }
+        });
+        expect(calls[2].type).toBe('close');
+        expect(Object.keys(clientConfig.data.mcpServers)).toHaveLength(0);
+    });
+});


### PR DESCRIPTION
Authored by GPT-5 Codex (Codex Desktop). Session 2741c4bd-92b2-428b-92d3-ab718d9a7c41.

FAIR-band: over-target [17/30] - taking this lane despite over-target because the operator explicitly corrected no-idle watchdog behavior, #11743 is a prerequisite blocker for the #11728 day-0 ingestion/tutorial proof, and no peer was actively carrying the receiver/auth model.

Resolves #11743
Related: #11720
Related: #11728
Related: #11731

Adds the deployable repo-push invocation model for tenant KB ingestion: a tenant-side MCP push client (`ai:kb-push-client`) that sends content-bearing `ingest_source_files` envelopes to a remote KB `/mcp` endpoint, plus the docs and reference hook wiring for automation identity tokens, OAuth audience/resource setup, volume policy, and failure signatures.

Evidence: L2 (unit-tested injected MCP client, Commander/dotenv CLI parsing, static docs contract, hook syntax validation) -> L3 required for live tenant push against a deployed KB `/mcp` endpoint. Residual: #11728 day-0 tutorial/proof.

## Deltas from ticket
- The ticket's original non-MCP framing was corrected: this PR ships the MCP-over-StreamableHTTP path as the concrete MVP model and leaves a non-MCP HTTP/queue receiver as a future alternative only if the MCP client path proves operationally awkward.
- Adds the small tenant-side CLI wrapper because "MCP client" alone is not an operator-facing primitive; hooks/CI need a runnable command, token env contract, and failure semantics.
- Updates the reference `pre-push` hook to use the remote MCP client when `NEO_KB_MCP_URL` is configured, while retaining the local bulk CLI fallback for co-located demos/imports.
- Pre-review polish replaced the initial hand-rolled argv parser with `commander` and `dotenv/config`, reusing dependencies already present in Neo instead of carrying brittle manual parsing.
- Rebased after the recent deployment-profile/cookbook PR stack merged; conflict resolution preserves the merged transport-gated MCP wording while keeping the #11743 repo-push client surface.

## Slot Rationale
- Modified `learn/agentos/cloud-deployment/HookWiring.md`: disposition delta `rewrite`; rating medium trigger-frequency x high failure-severity x high enforceability. Reason: this guide is the operational handoff for push ingestion, and the #11743 correction prevents future agents from repeating the false "MCP impossible" framing while encoding the exact receiver/auth invocation model.
- Modified `learn/agentos/cloud-deployment/TenantIngestionModel.md`: disposition delta `keep`; rating medium trigger-frequency x high failure-severity x high enforceability. Reason: the tenant automation identity and token boundary are part of the MVP ingestion model that #11728 depends on.
- Modified `learn/agentos/cloud-deployment/Configuration.md`: disposition delta `keep`; rating low trigger-frequency x medium failure-severity x high enforceability. Reason: tenant-side env vars are not server config, but documenting them here gives operators one discoverable config index and avoids secret/token drift.

## Test Evidence
- `npm run test-unit -- test/playwright/unit/ai/buildScripts/kbPushClient.spec.mjs` - 11 passed after rebase.
- `bash -n examples/cloud-deployment/pre-push-hook.sh` - passed after rebase.
- `git diff --check origin/dev...HEAD` - passed after rebase.
- `git diff --check` - passed during conflict resolution.
- `git diff --cached --check` - passed before both original commits.
- Pre-push freshness check after rebase: `origin/dev` is `0d957393f9353b4d279709cafd8d1ecf850e4e17`; outgoing log contains only `8ed883bf9 feat(kb): add repo-push MCP client (#11743)` and `724f9cfd4 fix(kb): use commander for push client CLI (#11743)`.

## Post-Merge Validation
- [ ] #11728 can use `NEO_KB_MCP_URL`, `NEO_KB_INGEST_TOKEN`, `NEO_KB_TENANT_ID`, and `NEO_KB_REPO_SLUG` to run a live tenant push against the deployed KB `/mcp` endpoint.
- [ ] A production deployment verifies the repo-push automation identity token audience/resource matches the KB public URL and rejects a missing/expired token with a clear auth failure.
- [ ] A deliberately over-threshold push returns `KB_INGEST_VOLUME_EXCEEDED`, and the hook/CI path fails visibly rather than silently dropping files.

## Commits
- `8ed883bf9` - `feat(kb): add repo-push MCP client (#11743)`
- `724f9cfd4` - `fix(kb): use commander for push client CLI (#11743)`
