### PR TITLE
feat(github-workflow): add manage_discussion tool (#10138)

### DIFF
--- a/ai/mcp/server/github-workflow/openapi.yaml
+++ b/ai/mcp/server/github-workflow/openapi.yaml
@@ -1129,6 +1129,77 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
 
+  /discussions/manage:
+    post:
+      summary: Manage GitHub Discussions (Update Body)
+      operationId: manage_discussion
+      x-pass-as-object: true
+      x-annotations:
+        readOnlyHint: false
+      description: |
+        Manages discussion-level operations on GitHub discussions.
+
+        **Action: 'update_body'**
+        - Replaces the body of an existing discussion in place (e.g. post-publication corrections to an Ideation Sandbox entry, keeping the body as the single source of truth instead of accumulating correction comments).
+        - Requires `discussion_number` and `body`.
+      tags: [Issues]
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - action
+                - discussion_number
+                - body
+              properties:
+                action:
+                  type: string
+                  enum: [update_body]
+                  description: The action to perform.
+                  example: update_body
+                discussion_number:
+                  type: integer
+                  description: The number of the discussion to update.
+                  example: 10137
+                body:
+                  type: string
+                  description: The new Markdown body for the discussion.
+      responses:
+        '200':
+          description: Discussion body updated successfully.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  discussionId:
+                    type: string
+                    description: The canonical GitHub global node ID of the discussion.
+                    example: "D_kwDODSospM4AmbhL"
+                  url:
+                    type: string
+                    description: The canonical HTTP URL of the discussion on github.com.
+                    example: "https://github.com/orgs/neomjs/discussions/10137"
+                  updatedAt:
+                    type: string
+                    format: date-time
+                    description: The last-modified timestamp (ISO-8601).
+                    example: "2026-05-16T02:49:38Z"
+        '400':
+          description: Bad Request.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Internal server error.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
   /discussions/comments/manage:
     post:
       summary: Manage Discussion Comments (Create or Update)

--- a/ai/mcp/server/github-workflow/toolService.mjs
+++ b/ai/mcp/server/github-workflow/toolService.mjs
@@ -147,6 +147,7 @@ const serviceMapping = {
     list_labels              : LabelService      .listLabels             .bind(LabelService),
     list_pull_requests       : PullRequestService.listPullRequests       .bind(PullRequestService),
     list_issues              : IssueService      .listIssues             .bind(IssueService),
+    manage_discussion        : DiscussionService .manageDiscussion       .bind(DiscussionService),
     manage_discussion_comment: DiscussionService .manageDiscussionComment.bind(DiscussionService),
     manage_issue_assignees   : IssueService      .manageIssueAssignees   .bind(IssueService),
     manage_issue_comment     : IssueService      .manageIssueComment     .bind(IssueService),

--- a/ai/services/github-workflow/DiscussionService.mjs
+++ b/ai/services/github-workflow/DiscussionService.mjs
@@ -4,7 +4,7 @@ import GraphqlService    from './GraphqlService.mjs';
 import RepositoryService from './RepositoryService.mjs';
 import logger            from '../../mcp/server/github-workflow/logger.mjs';
 import {GET_REPO_AND_DISCUSSION_CATEGORIES, GET_DISCUSSION_ID} from './queries/discussionQueries.mjs';
-import {CREATE_DISCUSSION, ADD_DISCUSSION_COMMENT, UPDATE_DISCUSSION_COMMENT} from './queries/mutations.mjs';
+import {CREATE_DISCUSSION, ADD_DISCUSSION_COMMENT, UPDATE_DISCUSSION, UPDATE_DISCUSSION_COMMENT} from './queries/mutations.mjs';
 
 const AGENT_ICONS = {
     gemini : '✦',
@@ -20,6 +20,7 @@ const AGENT_ICONS = {
  * Capabilities include:
  * - Creating discussions inside specific categories (default 'Ideas')
  * - Managing discussion comments
+ * - Updating discussion bodies
  *
  * @class Neo.ai.services.github-workflow.DiscussionService
  * @extends Neo.core.Base
@@ -90,7 +91,7 @@ class DiscussionService extends Base {
             const discussion = result.createDiscussion.discussion;
 
             logger.info(`Successfully created GitHub Discussion #${discussion.number}: ${discussion.url}`);
-            
+
             return {
                 discussionNumber: discussion.number,
                 url: discussion.url,
@@ -168,7 +169,7 @@ class DiscussionService extends Base {
             // Use ADD_DISCUSSION_COMMENT mutation
             const result = await GraphqlService.query(ADD_DISCUSSION_COMMENT, { discussionId, body: finalBody });
             const comment = result.addDiscussionComment.comment;
-            
+
             return {
                 message  : `Successfully created comment on discussion #${discussion_number}`,
                 commentId: comment.id,
@@ -252,6 +253,69 @@ class DiscussionService extends Base {
                 };
             }
             return this.updateComment(comment_id, body);
+        }
+    }
+
+    /**
+     * Manages discussion-level operations. Currently supports updating the discussion body,
+     * enabling post-publication corrections without accumulating correction comments.
+     * @param {object} options                    The options object
+     * @param {string} options.action             The action to perform: 'update_body'.
+     * @param {number} options.discussion_number  The number of the discussion to update.
+     * @param {string} options.body               The new Markdown body for the discussion.
+     * @returns {Promise<object>} A promise that resolves to {discussionId, url, updatedAt} or a structured error.
+     */
+    async manageDiscussion({action, discussion_number, body}) {
+        if (action !== 'update_body') {
+            return {
+                error  : 'Bad Request',
+                message: "Invalid action. Must be 'update_body'.",
+                code   : 'INVALID_ARGUMENTS'
+            };
+        }
+
+        if (!discussion_number || !body) {
+            return {
+                error  : 'Bad Request',
+                message: "Missing required argument: 'discussion_number' and 'body' are required for updating a discussion body.",
+                code   : 'MISSING_ARGUMENTS'
+            };
+        }
+
+        try {
+            // Resolve the discussion number to its global node ID
+            const idData = await GraphqlService.query(GET_DISCUSSION_ID, {
+                owner : aiConfig.owner,
+                repo  : aiConfig.repo,
+                number: discussion_number
+            });
+
+            if (!idData.repository.discussion) {
+                return {
+                    error  : 'Not Found',
+                    message: `Could not find discussion #${discussion_number}.`,
+                    code   : 'NOT_FOUND'
+                };
+            }
+
+            const discussionId = idData.repository.discussion.id;
+            const result       = await GraphqlService.query(UPDATE_DISCUSSION, {discussionId, body});
+            const discussion   = result.updateDiscussion.discussion;
+
+            logger.info(`Successfully updated body of GitHub Discussion #${discussion_number}: ${discussion.url}`);
+
+            return {
+                discussionId: discussion.id,
+                url         : discussion.url,
+                updatedAt   : discussion.updatedAt
+            };
+        } catch (error) {
+            logger.error(`Error updating discussion #${discussion_number} body via GraphQL:`, error);
+            return {
+                error  : 'GraphQL API request failed',
+                message: error.message,
+                code   : 'GRAPHQL_API_ERROR'
+            };
         }
     }
 }

--- a/ai/services/github-workflow/queries/mutations.mjs
+++ b/ai/services/github-workflow/queries/mutations.mjs
@@ -300,6 +300,25 @@ export const UPDATE_DISCUSSION_COMMENT = `
 `;
 
 /**
+ * Mutation to update an existing discussion's body.
+ *
+ * Variables required:
+ * - $discussionId: ID! - The global node ID of the discussion to update
+ * - $body: String! - The new discussion body
+ */
+export const UPDATE_DISCUSSION = `
+  mutation UpdateDiscussion($discussionId: ID!, $body: String!) {
+    updateDiscussion(input: {discussionId: $discussionId, body: $body}) {
+      discussion {
+        id
+        url
+        updatedAt
+      }
+    }
+  }
+`;
+
+/**
  * Mutation to update an issue's title and body.
  *
  * Variables required:

--- a/learn/agentos/GitHubWorkflow.md
+++ b/learn/agentos/GitHubWorkflow.md
@@ -113,6 +113,12 @@ The server exposes a comprehensive suite of tools via the Model Context Protocol
 
 *   **`list_labels`**: Enumerates all valid labels in the repository. *Always check this before applying labels.*
 
+### 4.5 Discussions
+
+*   **`create_discussion`**: Creates a new GitHub Discussion (default category `Ideas`). Used for the Ideation Sandbox.
+*   **`manage_discussion_comment`**: Creates or updates a comment on a Discussion (`action`: `create` | `update`).
+*   **`manage_discussion`**: Updates the body of an existing Discussion (`action`: `update_body`). Enables post-publication corrections to Ideation Sandbox entries through the MCP surface instead of a raw `gh api graphql` workaround.
+
 ## 5. Configuration
 
 The server is highly configurable via `config.mjs` or a custom configuration file passed via the `-c` or `--config` CLI flag. This allows you to override default settings—such as the target repository, file paths, or API limits—without modifying the source code.

--- a/test/playwright/unit/ai/services/github-workflow/DiscussionService.spec.mjs
+++ b/test/playwright/unit/ai/services/github-workflow/DiscussionService.spec.mjs
@@ -182,3 +182,157 @@ test.describe('Neo.ai.services.github-workflow.DiscussionService — manageDiscu
         });
     });
 });
+
+/**
+ * @summary Contract coverage for `DiscussionService.manageDiscussion` discussion-body update (#10138).
+ *
+ * `manageDiscussion` is a method on `DiscussionService` (mirroring `manageDiscussionComment`),
+ * so its spec lives alongside the existing service spec rather than under the `ai/mcp/server/`
+ * test tree named in #10138 AC5 — that AC assumed a standalone tool file that does not exist.
+ */
+test.describe('Neo.ai.services.github-workflow.DiscussionService — manageDiscussion (#10138)', () => {
+    let DiscussionService;
+    let GraphqlService;
+    let originalQuery;
+
+    test.beforeAll(async () => {
+        GraphqlService    = (await import('../../../../../../ai/services/github-workflow/GraphqlService.mjs')).default;
+        DiscussionService = (await import('../../../../../../ai/services/github-workflow/DiscussionService.mjs')).default;
+
+        originalQuery = GraphqlService.query.bind(GraphqlService);
+    });
+
+    test.afterAll(() => {
+        GraphqlService.query = originalQuery;
+    });
+
+    test('update_body returns {discussionId, url, updatedAt} on success', async () => {
+        const DISCUSSION_NODE_ID = 'D_kwDODSospM4AmbhL';
+        const DISCUSSION_URL     = 'https://github.com/orgs/neomjs/discussions/10137';
+        const UPDATED_TS         = '2026-05-16T02:49:38Z';
+        const NEW_BODY           = 'Corrected discussion body';
+
+        let callCount = 0;
+
+        GraphqlService.query = async (query, variables) => {
+            callCount++;
+            if (callCount === 1) {
+                // GET_DISCUSSION_ID lookup
+                expect(variables.number).toBe(10137);
+                return {repository: {discussion: {id: DISCUSSION_NODE_ID}}};
+            }
+            if (callCount === 2) {
+                // UPDATE_DISCUSSION mutation
+                expect(variables.discussionId).toBe(DISCUSSION_NODE_ID);
+                expect(variables.body).toBe(NEW_BODY);
+                return {
+                    updateDiscussion: {
+                        discussion: {
+                            id       : DISCUSSION_NODE_ID,
+                            url      : DISCUSSION_URL,
+                            updatedAt: UPDATED_TS
+                        }
+                    }
+                };
+            }
+            throw new Error(`Unexpected additional GraphqlService.query call: ${callCount}`);
+        };
+
+        const result = await DiscussionService.manageDiscussion({
+            action           : 'update_body',
+            discussion_number: 10137,
+            body             : NEW_BODY
+        });
+
+        expect(result).toEqual({
+            discussionId: DISCUSSION_NODE_ID,
+            url         : DISCUSSION_URL,
+            updatedAt   : UPDATED_TS
+        });
+
+        expect(callCount).toBe(2);
+    });
+
+    test('rejects invalid action (must be update_body)', async () => {
+        let callCount = 0;
+        GraphqlService.query = async () => { callCount++; return null; };
+
+        const result = await DiscussionService.manageDiscussion({
+            action           : 'update',
+            discussion_number: 10137,
+            body             : 'Ignored'
+        });
+
+        expect(result.error).toBe('Bad Request');
+        expect(result.code).toBe('INVALID_ARGUMENTS');
+        expect(callCount).toBe(0);
+    });
+
+    test('rejects missing discussion_number', async () => {
+        let callCount = 0;
+        GraphqlService.query = async () => { callCount++; return null; };
+
+        const result = await DiscussionService.manageDiscussion({
+            action: 'update_body',
+            body  : 'No discussion number'
+        });
+
+        expect(result.error).toBe('Bad Request');
+        expect(result.code).toBe('MISSING_ARGUMENTS');
+        expect(callCount).toBe(0);
+    });
+
+    test('rejects missing body', async () => {
+        let callCount = 0;
+        GraphqlService.query = async () => { callCount++; return null; };
+
+        const result = await DiscussionService.manageDiscussion({
+            action           : 'update_body',
+            discussion_number: 10137
+        });
+
+        expect(result.error).toBe('Bad Request');
+        expect(result.code).toBe('MISSING_ARGUMENTS');
+        expect(callCount).toBe(0);
+    });
+
+    test('returns NOT_FOUND when the discussion does not exist', async () => {
+        let callCount = 0;
+        GraphqlService.query = async () => {
+            callCount++;
+            return {repository: {discussion: null}};
+        };
+
+        const result = await DiscussionService.manageDiscussion({
+            action           : 'update_body',
+            discussion_number: 999999,
+            body             : 'Body for a missing discussion'
+        });
+
+        expect(result.error).toBe('Not Found');
+        expect(result.code).toBe('NOT_FOUND');
+        expect(callCount).toBe(1);
+    });
+
+    test('propagates GraphQL error shape on auth/API failure', async () => {
+        let callCount = 0;
+        GraphqlService.query = async () => {
+            callCount++;
+            if (callCount === 1) {
+                return {repository: {discussion: {id: 'D_kwDODSospM4AmbhL'}}};
+            }
+            // updateDiscussion on a non-owned discussion → GitHub permission error
+            throw new Error('Resource not accessible by integration');
+        };
+
+        const result = await DiscussionService.manageDiscussion({
+            action           : 'update_body',
+            discussion_number: 10137,
+            body             : 'Will fail on the mutation'
+        });
+
+        expect(result.error).toBe('GraphQL API request failed');
+        expect(result.code).toBe('GRAPHQL_API_ERROR');
+        expect(result.message).toContain('not accessible');
+    });
+});


### PR DESCRIPTION
Resolves #10138

Authored by Opus 4.7 (1M context) (Claude Code). Session ff79d594-1c1e-4181-ad9b-3d9150547699.

FAIR-band: over-target [14/30] — taking this lane despite over-target because: (a) explicit operator authorization ("you can grab the new ticket"); (b) the only under-target peer (Gemini, 0/30) has a documented unstable harness, making an `[author-yield]` handoff non-actionable; (c) among the two active authors I am the lower (GPT 16/30); (d) `[lane-claim]` for #10138 was broadcast to `AGENT:*` at 08:02Z with no peer pickup.

Adds the `manage_discussion` MCP tool to the github-workflow server. It updates a GitHub Discussion **body** in place (`action: 'update_body'`) via the `updateDiscussion` GraphQL mutation — closing the tool-surface gap that previously forced post-publication Ideation Sandbox corrections through correction comments (loss of body-as-source-of-truth) or a raw `gh api graphql` workaround (bypasses the MCP audit/logging substrate).

Evidence: L2 (`manageDiscussion` unit-tested with a mocked `GraphqlService` — 6 tests: success / invalid-action / missing-params / NOT_FOUND / auth-error; the underlying `updateDiscussion` mutation shape was empirically confirmed against the live GitHub API in #10138's 2026-05-16 amendment comment) → L4 required (AC8 — retroactive #11440/#11444 body updates via the deployed MCP tool). Residual: AC8 [#10138].

## Acceptance Criteria status

| AC | Status | Where |
|---|---|---|
| AC1 — `manage_discussion` registered in `openapi.yaml`, `action: 'update_body'` | done | `openapi.yaml` `/discussions/manage` |
| AC2 — `updateDiscussion(input: {discussionId, body})` invoked | done | `mutations.mjs` `UPDATE_DISCUSSION` |
| AC3 — params `action`, `discussion_number`, `body` | done | `DiscussionService.manageDiscussion` |
| AC4 — returns `{discussionId, url, updatedAt}` | done | `DiscussionService.manageDiscussion` |
| AC5 — unit test: success + missing-params + auth-error | done | `DiscussionService.spec.mjs` (see Delta 1) |
| AC6 — tool description <= 1024 chars, concise | done | 342 chars |
| AC7 — documented in `GitHubWorkflow.md` | done | new §4.5 Discussions |
| AC8 — retroactive #11440/#11444 body updates via the tool | post-merge | see Post-Merge Validation |

## Deltas from ticket

1. **Test location** — AC5 names `test/playwright/unit/ai/mcp/server/github-workflow/`. The tests live in `test/playwright/unit/ai/services/github-workflow/DiscussionService.spec.mjs` instead. The Contract Ledger assumed a standalone tool file (`tools/manageDiscussion.mjs`); the substrate reality — anticipated by the ticket's own "to be verified during implementation" — is that `manageDiscussion` is a method on `DiscussionService` (mirroring `manageDiscussionComment`). Tests follow the service file: they extend the existing `DiscussionService.spec.mjs`, exactly where `manageDiscussionComment` is already covered.
2. **Single-method, not dispatcher+delegate** — `manage_discussion` has one action today (`update_body`). `manageDiscussion` validates `action` inline rather than dispatching to a private `updateBody`; a dispatcher for a single action would be premature abstraction. When a second discussion-level action lands (lock/pin — explicitly out-of-scope future ops), that PR refactors to the dispatcher shape. The Contract Ledger's `DiscussionService.updateBody()` was specified "(or equivalent)" — `manageDiscussion` is the equivalent.
3. **Return shape** — `{discussionId, url, updatedAt}` exactly per AC4, with no `message` field (sibling `updateComment` returns `{message, commentId, ...}`); followed the explicit contract.

## Substrate-Mutation slot-rationale (§1.1 — touches `learn/agentos/`)

Adds **§4.5 Discussions** to `learn/agentos/GitHubWorkflow.md` (6 lines).

- **Added section:** §4.5 Discussions — disposition **`keep`**.
- **3-axis rating:** trigger-frequency *moderate* (read when an agent uses the gh-workflow discussion tools) x failure-severity *low-moderate* (absent docs = tool-rediscovery friction — the precise #10138 friction this ticket exists to close) x enforceability *high* (static enumeration; `McpServerListToolsSmoke.spec.mjs` cross-checks openapi operationIds vs `serviceMapping` keys).
- **Map vs Atlas:** `GitHubWorkflow.md` is conditionally-loaded World Atlas reference documentation, not always-loaded Map substrate. **Net always-loaded bytes added: 0.** The Substrate Accretion Defense net-reduce mandate applies to always-loaded substrate and is not triggered.
- **Sunset condition:** §4.5 retires only when the discussion tool family is removed from the server.
- §4.5 documents all three discussion tools (`create_discussion`, `manage_discussion_comment`, `manage_discussion`) — the prior two were already shipped but undocumented in §4; a §4.5 carrying only the new tool would be a worse doc.

## Test Evidence

```
npm run test-unit -- DiscussionService.spec.mjs McpServerListToolsSmoke.spec.mjs
-> 23 passed (12 DiscussionService + 11 cross-server listTools smoke)
```

- 6 new `manageDiscussion` tests: success path (`{discussionId, url, updatedAt}`, 2 GraphQL calls), invalid action, missing `discussion_number`, missing `body`, `NOT_FOUND`, GraphQL auth/API error propagation.
- The smoke spec confirms the new `manage_discussion` openapi operationId aligns with the `serviceMapping` key and the openapi YAML parses.

## Post-Merge Validation

- [ ] AC8 — once the github-workflow MCP server is redeployed with this tool, retroactively update Discussion #11440 and #11444 bodies via `manage_discussion({action: 'update_body', ...})`, validating the tool end-to-end against the live API (the path those discussions originally needed but used workarounds for).

## Commits

- `846813817` — feat(github-workflow): add manage_discussion tool (#10138)

## Evolution

Branch was rebased onto origin/dev after #11746 (`get_conversation` -> issues) merged. #11746 co-edited `toolService.mjs` (`serviceMapping` + `getConversationRouter`) and `openapi.yaml`; the regions are disjoint from this PR's `manage_discussion` additions and git auto-merged both cleanly.

## Related

- Origin: friction surfaced during the Discussion #10137 post-publication correction workflow.
- Pattern mirrored: `manage_discussion_comment` (create/update dispatcher on `DiscussionService`).
- Empirical recurrences folded into #10138: Discussion #11440 + #11444 graduations (2026-05-16) both hit this gap.