### PR TITLE
feat(ai): add deployed MCP healthchecks (#11725)

### DIFF
--- a/ai/deploy/docker-compose.yml
+++ b/ai/deploy/docker-compose.yml
@@ -58,6 +58,12 @@ services:
       - neo-mcp-network
     expose:
       - "3000"
+    healthcheck:
+      test: ["CMD", "node", "./buildScripts/ai/mcpHealthcheck.mjs", "--url", "http://127.0.0.1:3000", "--client-name", "neo-kb-container-healthcheck"]
+      interval: 10s
+      timeout: 10s
+      retries: 12
+      start_period: 45s
     deploy:
       resources:
         limits:
@@ -93,6 +99,12 @@ services:
       - neo-mcp-network
     expose:
       - "3001"
+    healthcheck:
+      test: ["CMD", "node", "./buildScripts/ai/mcpHealthcheck.mjs", "--url", "http://127.0.0.1:3001", "--client-name", "neo-mc-container-healthcheck"]
+      interval: 10s
+      timeout: 10s
+      retries: 12
+      start_period: 45s
     deploy:
       resources:
         limits:
@@ -124,6 +136,10 @@ services:
       - ./.neo-ai-data/backups:/app/.neo-ai-data/backups
     depends_on:
       chroma:
+        condition: service_healthy
+      kb-server:
+        condition: service_healthy
+      mc-server:
         condition: service_healthy
     networks:
       - neo-mcp-network

--- a/buildScripts/ai/mcpHealthcheck.mjs
+++ b/buildScripts/ai/mcpHealthcheck.mjs
@@ -1,0 +1,177 @@
+import 'dotenv/config';
+
+import {Command}                       from 'commander';
+import {Client}                        from '@modelcontextprotocol/sdk/client/index.js';
+import {StreamableHTTPClientTransport} from '@modelcontextprotocol/sdk/client/streamableHttp.js';
+import {pathToFileURL}                 from 'url';
+
+/**
+ * @module buildScripts/ai/mcpHealthcheck
+ * @summary Runs an MCP `healthcheck` tool call against a StreamableHTTP endpoint.
+ *
+ * Docker healthchecks need a small, deterministic process that proves more than
+ * "the TCP port is open" without adding a parallel HTTP `/healthcheck` route to
+ * each MCP server. This script connects to `/mcp`, invokes the existing
+ * `healthcheck` tool, verifies the returned status, and exits non-zero on any
+ * transport, tool, parse, or status failure.
+ *
+ * @see https://github.com/neomjs/neo/issues/11725
+ */
+
+export const DEFAULT_URL = 'http://127.0.0.1:3000';
+
+/**
+ * @summary Parses CLI arguments and dotenv-backed environment defaults.
+ * @param {String[]} [argv=[]] CLI arguments without `node` / script path.
+ * @param {Object} [env=process.env] Environment source.
+ * @returns {Object}
+ */
+export function parseArgs(argv = [], env = process.env) {
+    const program = new Command();
+
+    program
+        .name('mcpHealthcheck')
+        .description('Call an MCP StreamableHTTP healthcheck tool and exit non-zero unless it is healthy.')
+        .exitOverride()
+        .allowExcessArguments(false)
+        .option('--url <url>', 'Base URL of the MCP server.', env.NEO_MCP_HEALTHCHECK_URL || DEFAULT_URL)
+        .option('--identity <identity>', 'Trusted proxy identity header value.', env.NEO_MCP_HEALTHCHECK_IDENTITY || 'neo-container-healthcheck')
+        .option('--bearer-token-env <name>', 'Environment variable containing an OAuth bearer token.', env.NEO_MCP_HEALTHCHECK_TOKEN_ENV || 'NEO_MCP_HEALTHCHECK_TOKEN')
+        .option('--expected-status <status>', 'Expected healthcheck status value.', env.NEO_MCP_HEALTHCHECK_EXPECTED_STATUS || 'healthy')
+        .option('--client-name <name>', 'MCP client name.', env.NEO_MCP_HEALTHCHECK_CLIENT_NAME || 'neo-container-healthcheck');
+
+    program.parse(argv, {from: 'user'});
+
+    const options = program.opts();
+
+    return {
+        url           : options.url,
+        identity      : options.identity,
+        bearerToken   : env[options.bearerTokenEnv] || null,
+        expectedStatus: options.expectedStatus,
+        clientName    : options.clientName
+    };
+}
+
+/**
+ * @summary Builds request headers for the StreamableHTTP transport.
+ * @param {Object} options
+ * @param {String|null} [options.identity]
+ * @param {String|null} [options.bearerToken]
+ * @returns {Object}
+ */
+export function buildHeaders({identity = null, bearerToken = null} = {}) {
+    const headers = {};
+
+    if (identity) {
+        headers['X-PREFERRED-USERNAME'] = identity;
+    }
+    if (bearerToken) {
+        headers['Authorization'] = `Bearer ${bearerToken}`;
+    }
+
+    return headers;
+}
+
+/**
+ * @summary Reads the JSON payload from an MCP SDK tool result.
+ * @param {Object} result The SDK tool-call result.
+ * @returns {Object}
+ */
+export function readToolJson(result) {
+    if (result?.structuredContent) {
+        return result.structuredContent;
+    }
+
+    const text = result?.content?.find(item => item.type === 'text')?.text;
+
+    if (!text) {
+        throw new Error('MCP healthcheck returned no JSON payload.');
+    }
+
+    return JSON.parse(text);
+}
+
+/**
+ * @summary Calls the remote MCP `healthcheck` tool and validates the returned status.
+ * @param {Object} options
+ * @param {String|URL} options.url The MCP server base URL.
+ * @param {String|null} [options.identity]
+ * @param {String|null} [options.bearerToken]
+ * @param {String} [options.expectedStatus='healthy']
+ * @param {String} [options.clientName='neo-container-healthcheck']
+ * @param {typeof Client} [options.ClientClass=Client] Injectable SDK client for tests.
+ * @param {typeof StreamableHTTPClientTransport} [options.TransportClass=StreamableHTTPClientTransport] Injectable transport for tests.
+ * @returns {Promise<Object>}
+ */
+export async function runHealthcheck({
+    url,
+    identity       = 'neo-container-healthcheck',
+    bearerToken    = null,
+    expectedStatus = 'healthy',
+    clientName     = 'neo-container-healthcheck',
+    ClientClass    = Client,
+    TransportClass = StreamableHTTPClientTransport
+}) {
+    const baseUrl = new URL(url);
+    const headers = buildHeaders({identity, bearerToken});
+
+    const transport = new TransportClass(new URL('/mcp', baseUrl), {
+        requestInit: {headers}
+    });
+
+    const client = new ClientClass({
+        name   : clientName,
+        version: '1.0.0'
+    }, {
+        capabilities: {}
+    });
+
+    await client.connect(transport);
+
+    try {
+        const result = await client.callTool({name: 'healthcheck', arguments: {}});
+
+        if (result?.isError) {
+            throw new Error('MCP healthcheck tool returned isError=true.');
+        }
+
+        const health = readToolJson(result);
+
+        if (health.status !== expectedStatus) {
+            throw new Error(`Expected healthcheck status '${expectedStatus}', got '${health.status || '<missing>'}'.`);
+        }
+
+        return {
+            status: health.status,
+            url   : baseUrl.toString()
+        };
+    } finally {
+        await client.close?.();
+    }
+}
+
+async function main() {
+    let options;
+
+    try {
+        options = parseArgs(process.argv.slice(2));
+    } catch (error) {
+        if (error.code === 'commander.helpDisplayed') {
+            return;
+        }
+        throw error;
+    }
+
+    try {
+        const result = await runHealthcheck(options);
+        console.log(JSON.stringify(result));
+    } catch (error) {
+        console.error(error.message);
+        process.exitCode = 1;
+    }
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+    await main();
+}

--- a/learn/agentos/DeploymentCookbook.md
+++ b/learn/agentos/DeploymentCookbook.md
@@ -14,14 +14,15 @@ record, see [ADR 0014](decisions/0014-cloud-deployment-topology-and-scheduler-ta
 The current reference compose file in [`ai/deploy/`](../../ai/deploy/) is a
 profile-structured Agent OS stack. The default profile starts the MCP baseline:
 `chroma`, `kb-server`, and `mc-server`. The `cloud` profile adds the
-cloud-safe `orchestrator`. The compose header also reserves the `ingress` and
-`local-model` profile slots for later deployment variants.
+cloud-safe `orchestrator`; the `ingress` profile adds the Caddy reverse proxy.
+The compose header reserves the `local-model` profile slot for a later provider
+variant.
 
 | Service / profile | Current baseline | D0 target |
 |---|---|---|
-| default profile | `chroma`, `kb-server`, and `mc-server`; all three declare per-service `deploy.resources.limits`. `chroma` owns the only Docker healthcheck currently in the stack. | Keep as the baseline MCP stack: Chroma as the unified vector-store primitive, KB/MC as separate request-serving MCP containers, and Sub D-owned MCP readiness proof for the server containers. |
-| `cloud` profile | Adds the `orchestrator` service with `NEO_AI_DEPLOYMENT_MODE=cloud`, shared SQLite volume access, and its own resource envelope. | Keep as the Agent OS maintenance control-plane container, running only the cloud-safe scheduler lanes from ADR 0014. |
-| `ingress` profile slot | Reserved in the compose header; no service is wired yet. KB and MC are internal-only via `expose`. | Sub C (#11724) adds reverse proxy / TLS termination and public MCP URL wiring. |
+| default profile | `chroma`, `kb-server`, and `mc-server`; all three declare per-service `deploy.resources.limits` and Docker readiness gates. Chroma uses a TCP probe; KB and MC use an MCP `/mcp` healthcheck tool call. | Keep as the baseline MCP stack: Chroma as the unified vector-store primitive and KB/MC as separate request-serving MCP containers with production readiness semantics. |
+| `cloud` profile | Adds the `orchestrator` service with `NEO_AI_DEPLOYMENT_MODE=cloud`, shared SQLite volume access, its own resource envelope, and startup gated on healthy KB/MC services. | Keep as the Agent OS maintenance control-plane container, running only the cloud-safe scheduler lanes from ADR 0014 after the MCP substrate is ready. |
+| `ingress` profile | Adds the Caddy reverse proxy for TLS termination and public `/kb/*` / `/mc/*` path routing while KB and MC remain internal-only via `expose`. | Keep as the public boundary for auth/header stripping and MCP URL routing. |
 | `local-model` profile slot | Reserved in the compose header; no service is wired yet. | Optional self-hosted provider variant. External provider endpoints remain the MVP default. |
 
 The service boundary is intentional: KB and MC serve MCP requests, Chroma stores
@@ -54,17 +55,19 @@ lane back in. The explicit env overrides are:
 | `NEO_ORCHESTRATOR_MLX_ENABLED=false` | Keeps Apple-Silicon local inference out of the cloud profile unless a local-model variant explicitly opts in. |
 
 Sub D (#11725) owns the CI-safe negative proof that the cloud profile cannot run
-the forbidden local-only behavior. This cookbook records the contract; it does
-not claim that proof has already landed.
+the forbidden local-only behavior. The current unit substrate already asserts
+that cloud-mode default resolution disables `primary-dev-sync`, `kbSync`,
+`bridgeDaemon`, and Golden Path repo enrichment unless an operator explicitly
+opts a lane back in.
 
 ## Section 3: Container Packaging
 
-Use per-service containers. Sub B (#11723) delivered the current
+Use per-service containers. Sub B (#11723) delivered the
 profile-structured compose baseline: default MCP stack, `cloud` orchestrator
 profile, reserved `ingress` / `local-model` slots, and per-service resource
-limits. Sub C (#11724) and Sub D (#11725) still own the remaining
-production-profile hardening, so the compose file is closer to the target but
-not yet a complete production profile.
+limits. Sub C (#11724) added the reference ingress and redeploy-safe backup
+volume wiring. Sub D (#11725) adds KB/MC container readiness semantics and gates
+the cloud orchestrator on those MCP server healthchecks.
 
 Required production-profile properties:
 
@@ -73,14 +76,17 @@ Delivered by Sub B:
 - Dedicated containers for `chroma`, `kb-server`, `mc-server`, and cloud-safe
   `orchestrator`.
 - Resource envelopes for each declared service.
-- Default and `cloud` compose profiles, with reserved `ingress` and
-  `local-model` slots.
+- Default and `cloud` compose profiles, with the `local-model` slot reserved.
 
-Still owned by Sub C / Sub D:
+Delivered by Sub C / Sub D:
 
 - Reverse proxy / TLS ingress and public MCP URL wiring.
 - Volumes for backup bundles that survive container rebuilds.
-- Healthcheck/readiness semantics for KB, MC, and orchestrator.
+- Healthcheck/readiness semantics for KB and MC, plus cloud-orchestrator startup
+  gating on healthy MCP server containers.
+
+Still owned by follow-up deployment hardening:
+
 - Optional platform variants for Kubernetes, managed Chroma, managed SQL, and
   external model providers without changing the logical service model.
 
@@ -151,6 +157,9 @@ Supply these values per service/profile as needed:
 | `NEO_MEM_AUTO_START_DATABASE=false` | MC | Prevents the MC server from starting a local Chroma process. |
 | `NEO_MEM_AUTO_START_INFERENCE=false` | MC | Prevents the MC server from starting local inference. |
 | `NEO_AUTO_SUMMARIZE`, `NEO_AUTO_DREAM`, `NEO_AUTO_GOLDEN_PATH`, `NEO_REAL_TIME_MEMORY_PARSING`, `NEO_AUTO_INGEST_FS` | MC | Local/server startup toggles; leave disabled unless the deployment owns those daemon behaviors explicitly. |
+| `NEO_MCP_HEALTHCHECK_URL` | Healthcheck CLI | Optional override for `npm run ai:mcp-healthcheck`; compose passes explicit internal URLs instead. |
+| `NEO_MCP_HEALTHCHECK_IDENTITY` | Healthcheck CLI | Trusted proxy identity value used by the MCP healthcheck probe when proxy-header auth is enabled. |
+| `NEO_MCP_HEALTHCHECK_TOKEN_ENV` / `NEO_MCP_HEALTHCHECK_TOKEN` | Healthcheck CLI | Optional bearer-token slot for direct OIDC/OAuth protected MCP healthchecks. |
 
 The top-level AI config template is [`ai/config.template.mjs`](../../ai/config.template.mjs).
 The cloud-ingestion tenant config guide is
@@ -200,9 +209,23 @@ Do not add real local clone paths to `package.json` or
 
 ## Section 8: Healthcheck and Journey Proof
 
-Deployed proof uses MCP tool calls, not a direct HTTP `/healthcheck` route. Call
-each server's `healthcheck` tool over its `/mcp` endpoint through the same public
-URL and auth path used by real agents.
+Deployed proof uses MCP tool calls, not a direct HTTP `/healthcheck` route. The
+production compose file runs `node ./buildScripts/ai/mcpHealthcheck.mjs` inside
+the KB and MC containers. That script opens a StreamableHTTP client against the
+local `/mcp` endpoint, calls the existing `healthcheck` tool, and exits non-zero
+unless the payload reports the expected status. Operators can run the same probe
+manually with `npm run ai:mcp-healthcheck`.
+
+The Docker readiness contract is:
+
+- Chroma is ready when its TCP listener is reachable.
+- KB is ready when `healthcheck` succeeds over `http://127.0.0.1:3000/mcp`.
+- MC is ready when `healthcheck` succeeds over `http://127.0.0.1:3001/mcp`.
+- The `cloud` orchestrator profile starts only after Chroma, KB, and MC are
+  healthy via compose `condition: service_healthy`.
+
+For public deployed proof, call each server's `healthcheck` tool over its `/mcp`
+endpoint through the same public URL and auth path used by real agents.
 
 Operator verification anchors:
 

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
         "ai:download-kb"               : "node ./buildScripts/ai/downloadKnowledgeBase.mjs",
         "ai:ingest-tenant"             : "node ./buildScripts/ai/ingestTenant.mjs",
         "ai:kb-push-client"            : "node ./buildScripts/ai/kbPushClient.mjs",
+        "ai:mcp-healthcheck"           : "node ./buildScripts/ai/mcpHealthcheck.mjs",
         "ai:mcp-client"                : "node ./ai/mcp/client/mcp-cli.mjs",
         "ai:mcp-server-file-system"    : "node ./ai/mcp/server/file-system/mcp-server.mjs",
         "ai:mcp-server-github-workflow": "node ./ai/mcp/server/github-workflow/mcp-server.mjs",

--- a/test/playwright/unit/ai/buildScripts/mcpHealthcheck.spec.mjs
+++ b/test/playwright/unit/ai/buildScripts/mcpHealthcheck.spec.mjs
@@ -1,0 +1,175 @@
+import {test, expect} from '@playwright/test';
+import fs             from 'fs';
+import yaml           from 'js-yaml';
+
+test.describe('buildScripts/ai/mcpHealthcheck (#11725)', () => {
+    let parseArgs;
+    let buildHeaders;
+    let readToolJson;
+    let runHealthcheck;
+
+    test.beforeAll(async () => {
+        const mod = await import('../../../../../buildScripts/ai/mcpHealthcheck.mjs');
+
+        parseArgs      = mod.parseArgs;
+        buildHeaders   = mod.buildHeaders;
+        readToolJson   = mod.readToolJson;
+        runHealthcheck = mod.runHealthcheck;
+    });
+
+    test('parseArgs uses dotenv-compatible environment defaults', () => {
+        const args = parseArgs([], {
+            NEO_MCP_HEALTHCHECK_URL            : 'http://mc-server:3001',
+            NEO_MCP_HEALTHCHECK_IDENTITY       : 'deploy-probe',
+            NEO_MCP_HEALTHCHECK_TOKEN_ENV      : 'TOKEN_SLOT',
+            TOKEN_SLOT                         : 'secret-token',
+            NEO_MCP_HEALTHCHECK_EXPECTED_STATUS: 'ready',
+            NEO_MCP_HEALTHCHECK_CLIENT_NAME    : 'deploy-client'
+        });
+
+        expect(args).toEqual({
+            url           : 'http://mc-server:3001',
+            identity      : 'deploy-probe',
+            bearerToken   : 'secret-token',
+            expectedStatus: 'ready',
+            clientName    : 'deploy-client'
+        });
+    });
+
+    test('parseArgs lets CLI flags override environment defaults', () => {
+        const args = parseArgs([
+            '--url', 'http://127.0.0.1:3000',
+            '--identity', 'cli-identity',
+            '--bearer-token-env', 'CLI_TOKEN',
+            '--expected-status', 'healthy',
+            '--client-name', 'cli-client'
+        ], {
+            NEO_MCP_HEALTHCHECK_URL      : 'http://ignored:3000',
+            NEO_MCP_HEALTHCHECK_IDENTITY : 'ignored',
+            NEO_MCP_HEALTHCHECK_TOKEN_ENV: 'IGNORED_TOKEN',
+            CLI_TOKEN                    : 'cli-secret'
+        });
+
+        expect(args).toMatchObject({
+            url           : 'http://127.0.0.1:3000',
+            identity      : 'cli-identity',
+            bearerToken   : 'cli-secret',
+            expectedStatus: 'healthy',
+            clientName    : 'cli-client'
+        });
+    });
+
+    test('buildHeaders includes proxy identity and bearer token only when configured', () => {
+        expect(buildHeaders({identity: 'probe', bearerToken: 'token'})).toEqual({
+            'X-PREFERRED-USERNAME': 'probe',
+            'Authorization'       : 'Bearer token'
+        });
+
+        expect(buildHeaders({identity: null, bearerToken: null})).toEqual({});
+    });
+
+    test('readToolJson supports structuredContent and JSON text fallback', () => {
+        expect(readToolJson({structuredContent: {status: 'healthy'}})).toEqual({status: 'healthy'});
+
+        expect(readToolJson({
+            content: [{type: 'text', text: '{"status":"healthy"}'}]
+        })).toEqual({status: 'healthy'});
+    });
+
+    test('runHealthcheck calls /mcp healthcheck and closes the client', async () => {
+        const calls = [];
+
+        class FakeTransport {
+            constructor(url, options) {
+                this.url     = url;
+                this.options = options;
+            }
+        }
+
+        class FakeClient {
+            constructor(identity, options) {
+                calls.push({type: 'client', identity, options});
+            }
+
+            async connect(transport) {
+                calls.push({type: 'connect', url: transport.url.toString(), headers: transport.options.requestInit.headers});
+            }
+
+            async callTool(request) {
+                calls.push({type: 'callTool', request});
+
+                return {structuredContent: {status: 'healthy'}};
+            }
+
+            async close() {
+                calls.push({type: 'close'});
+            }
+        }
+
+        const result = await runHealthcheck({
+            url           : 'http://127.0.0.1:3000',
+            identity      : 'probe',
+            bearerToken   : 'token',
+            ClientClass   : FakeClient,
+            TransportClass: FakeTransport
+        });
+
+        expect(result).toEqual({
+            status: 'healthy',
+            url   : 'http://127.0.0.1:3000/'
+        });
+        expect(calls).toEqual([
+            {type: 'client', identity: {name: 'neo-container-healthcheck', version: '1.0.0'}, options: {capabilities: {}}},
+            {type: 'connect', url: 'http://127.0.0.1:3000/mcp', headers: {'X-PREFERRED-USERNAME': 'probe', Authorization: 'Bearer token'}},
+            {type: 'callTool', request: {name: 'healthcheck', arguments: {}}},
+            {type: 'close'}
+        ]);
+    });
+
+    test('runHealthcheck fails on unhealthy status', async () => {
+        class FakeTransport {}
+        class FakeClient {
+            async connect() {}
+            async callTool() {
+                return {structuredContent: {status: 'degraded'}};
+            }
+            async close() {}
+        }
+
+        await expect(runHealthcheck({
+            url           : 'http://127.0.0.1:3000',
+            ClientClass   : FakeClient,
+            TransportClass: FakeTransport
+        })).rejects.toThrow("Expected healthcheck status 'healthy', got 'degraded'.");
+    });
+
+    test('production compose wires KB/MC MCP healthchecks before cloud orchestrator startup', () => {
+        const compose = yaml.load(fs.readFileSync(
+            new URL('../../../../../ai/deploy/docker-compose.yml', import.meta.url),
+            'utf8'
+        ));
+
+        expect(compose.services['kb-server'].healthcheck.test).toEqual([
+            'CMD',
+            'node',
+            './buildScripts/ai/mcpHealthcheck.mjs',
+            '--url',
+            'http://127.0.0.1:3000',
+            '--client-name',
+            'neo-kb-container-healthcheck'
+        ]);
+
+        expect(compose.services['mc-server'].healthcheck.test).toEqual([
+            'CMD',
+            'node',
+            './buildScripts/ai/mcpHealthcheck.mjs',
+            '--url',
+            'http://127.0.0.1:3001',
+            '--client-name',
+            'neo-mc-container-healthcheck'
+        ]);
+
+        expect(compose.services.orchestrator.depends_on['kb-server']).toEqual({condition: 'service_healthy'});
+        expect(compose.services.orchestrator.depends_on['mc-server']).toEqual({condition: 'service_healthy'});
+    });
+});


### PR DESCRIPTION
Authored by GPT-5 Codex (Codex Desktop). Session 2741c4bd-92b2-428b-92d3-ab718d9a7c41.

FAIR-band: in-band [15/30 - current author count over last 30 merged]

Refs #11725
Related: #11720
Related: #11721
Related: #11724
Related: #11728

Adds the production-profile readiness slice for Sub D: a small `ai:mcp-healthcheck` CLI that calls an MCP server's existing `healthcheck` tool over StreamableHTTP, Docker healthchecks for the KB and MC containers, and a cloud orchestrator startup gate that waits for both MCP server containers to become healthy.

Evidence: L2 (unit-tested MCP probe, YAML-parsed production compose contract, existing cloud-mode scheduler negative unit proof) -> L3/L4 required for the full #11725 adoption ladder and live deployed journey proof. Residual: #11725 remains open for the full milestone 0-7 journey proof; #11728 consumes the live tenant-ingestion tutorial proof after #11749 merges.

## Deltas from ticket

- This is intentionally a partial #11725 PR: it ships KB/MC container readiness semantics and the orchestrator-in-stack health gate, but does not claim to complete the entire milestone 0-7 journey proof.
- Reuses existing MCP `healthcheck` tool surfaces instead of adding plain HTTP `/healthcheck` routes.
- Adds a static/unit compose guard rather than depending on Docker availability in default CI; the local Codex environment does not have the `docker` CLI installed.

## Slot Rationale

- Modified `learn/agentos/DeploymentCookbook.md`: disposition delta `rewrite`; rating medium trigger-frequency x high failure-severity x high enforceability. Reason: the cookbook is the F1 deployment authority for #11720, and its stale "Chroma only" readiness text would mislead #11728 operators after this PR lands. The update replaces stale ownership prose with the concrete MCP readiness contract and compose dependency gate.

## Test Evidence

- `npm run test-unit -- test/playwright/unit/ai/buildScripts/mcpHealthcheck.spec.mjs` - 7 passed.
- `npm run test-unit -- test/playwright/unit/ai/scripts/orchestrator-daemon.spec.mjs` - 9 passed.
- `node ./buildScripts/ai/mcpHealthcheck.mjs --help` - passed.
- `ruby -e 'require "yaml"; YAML.load_file("ai/deploy/docker-compose.yml"); puts "yaml ok"'` - passed.
- `git diff --check` - passed.
- `git diff --cached --check` - passed before commit.
- Pre-push freshness check: `merge-base HEAD origin/dev == origin/dev` at `9af579b667de3549ede98601660cf5ba4770e565`; outgoing log contains only `54aa4696b feat(ai): add deployed MCP healthchecks (#11725)`.
- Not run: `docker compose -f ai/deploy/docker-compose.yml config` because this Codex environment has no `docker` executable.

## Post-Merge Validation

- [ ] In a Docker-capable environment, run `docker compose -f ai/deploy/docker-compose.yml config`.
- [ ] Start the default profile and verify `kb-server` and `mc-server` report healthy after MCP healthcheck probes pass.
- [ ] Start `--profile cloud` and verify the orchestrator waits for healthy KB/MC services before booting.
- [ ] Through the public ingress/auth path, call KB and MC `healthcheck` tools over `/mcp` and compare payloads with the internal container-readiness proof.

## Commits

- `54aa4696b` - `feat(ai): add deployed MCP healthchecks (#11725)`
