### PR TITLE
docs(ideation): reference manage_discussion body updates (#11752)

### DIFF
--- a/.agents/skills/ideation-sandbox/references/ideation-sandbox-workflow.md
+++ b/.agents/skills/ideation-sandbox/references/ideation-sandbox-workflow.md
@@ -25,7 +25,7 @@ When engaging in deep architectural design, brainstorming, or encountering "Unkn
 
 ## 3. Author's Note Convention (The #10119 Annotation Pattern)
 Discussions are meant to evolve. Instead of creating noisy parallel comment threads to reflect updates to the core idea, the authoritative substrate is the Discussion body itself. 
-- Use **"the #10119 annotation pattern"**: Treat the Discussion body like a PR diff. When the idea evolves, edit the body directly (like a force-push). 
+- Use **"the #10119 annotation pattern"**: Treat the Discussion body like a PR diff. When the idea evolves, edit the body directly with `manage_discussion({action: 'update_body', discussion_number, body})` (like a force-push).
 - Add top-of-body annotation markers (e.g. `> **Update 2026-04-24:** Refined the VDOM syncing section based on feedback below.`) to signal what changed. 
 - You may add a brief comment to notify thread participants, but the body remains the single source of truth.
 


### PR DESCRIPTION
Authored by GPT-5.5 (Codex Desktop). Session 019e4c2e-c7aa-72a2-b0bc-58c0996c63f3.

FAIR-band: over-target [16/30] - taking this narrow substrate-shaping lane despite over-target because post-review pickup required forward motion, #11752 was unassigned/unblocked after #11750 merged, and the change is a one-clause discoverability fix for a tool I had just reviewed.

## Deltas
- Updates `.agents/skills/ideation-sandbox/references/ideation-sandbox-workflow.md` §3 in place.
- Names `manage_discussion({action: 'update_body', discussion_number, body})` as the MCP mechanism for the existing instruction to edit the Discussion body directly.
- Leaves `ideation-sandbox/SKILL.md` untouched and adds no new section.

Evidence: L1 static substrate validation. The target line, tool documentation, and merged #11750 gate were verified before editing.

## Test Evidence
- `gh api repos/neomjs/neo/issues/11752 --jq ...` confirmed #11752 open/unassigned and scoped to the §3 clause.
- `gh pr view 11750 --json state,mergedAt,reviewDecision` confirmed PR #11750 is merged.
- `rg -n "Author's Note|#10119|edit the .*body|manage_discussion|update_body" ...` confirmed the missing ideation-sandbox pointer and existing GitHubWorkflow tool docs.
- `git diff --check`
- `git diff --cached --check`
- `node ai/scripts/lint-skill-manifest.mjs --base origin/dev`

## Post-Merge Validation
- [ ] Future ideation-sandbox body-correction passes can discover `manage_discussion({action: 'update_body', discussion_number, body})` directly from §3 without rediscovering raw GraphQL.

## Slot Rationale
- Modified `.agents/skills/ideation-sandbox/references/ideation-sandbox-workflow.md` §3: disposition delta `keep`; trigger-frequency medium for ideation authors, failure-severity medium because missing the pointer causes raw GraphQL rediscovery or correction-comment drift, enforceability medium because the tool name is concrete and grep-auditable.
- Placement stays in the Atlas payload, not the router; Progressive Disclosure is preserved and no always-loaded substrate expands.

## Related
Resolves #11752
Follows #10138 / PR #11750
