### PR TITLE
refactor(github-workflow): retire PR archiveVersion metadata carry-forward (#11364)

### DIFF
--- a/ai/services/github-workflow/sync/MetadataManager.mjs
+++ b/ai/services/github-workflow/sync/MetadataManager.mjs
@@ -114,17 +114,19 @@ class MetadataManager extends Base {
             };
         }
 
-        // Prune pulls
+        // Prune pulls — `archiveVersion` is intentionally NOT persisted (#11364). Archive-bucket
+        // placement is derived fresh each sync from real milestone/release-date logic in
+        // PullRequestSyncer#planBuckets; a carried-forward archiveVersion could re-lock a stale
+        // (e.g. pre-release-cut) bucket into .sync-metadata.json.
         for (const [key, value] of Object.entries(metadata.pulls || {})) {
             prunedMetadata.pulls[key] = {
-                state         : value.state,
-                path          : value.path,
-                closedAt      : value.closedAt,
-                mergedAt      : value.mergedAt,
-                milestone     : value.milestone,
-                archiveVersion: value.archiveVersion,
-                updatedAt     : value.updatedAt,
-                contentHash   : value.contentHash
+                state      : value.state,
+                path       : value.path,
+                closedAt   : value.closedAt,
+                mergedAt   : value.mergedAt,
+                milestone  : value.milestone,
+                updatedAt  : value.updatedAt,
+                contentHash: value.contentHash
             };
         }
 

--- a/ai/services/github-workflow/sync/PullRequestSyncer.mjs
+++ b/ai/services/github-workflow/sync/PullRequestSyncer.mjs
@@ -82,41 +82,33 @@ class PullRequestSyncer extends Base {
      */
     #planBuckets(metadata, fetchedPullRequests = []) {
         const combined = new Map();
-        
+
         for (const [idStr, pr] of Object.entries(metadata.pulls || {})) {
             combined.set(parseInt(idStr, 10), {
-                number        : parseInt(idStr, 10),
-                state         : pr.state,
-                milestone     : pr.milestone ? { title: pr.milestone } : null,
-                closedAt      : pr.closedAt,
-                mergedAt      : pr.mergedAt,
-                archiveVersion: pr.archiveVersion
+                number   : parseInt(idStr, 10),
+                state    : pr.state,
+                milestone: pr.milestone ? { title: pr.milestone } : null,
+                closedAt : pr.closedAt,
+                mergedAt : pr.mergedAt
             });
         }
-        
-        for (const pr of fetchedPullRequests) {
-            const cached = metadata.pulls?.[pr.number];
 
+        for (const pr of fetchedPullRequests) {
             combined.set(pr.number, {
-                number        : pr.number,
-                state         : pr.state,
-                milestone     : pr.milestone,
-                closedAt      : pr.closedAt,
-                mergedAt      : pr.mergedAt,
-                archiveVersion: cached?.archiveVersion
+                number   : pr.number,
+                state    : pr.state,
+                milestone: pr.milestone,
+                closedAt : pr.closedAt,
+                mergedAt : pr.mergedAt
             });
         }
-        
+
         const buckets = new Map();
         const activeItems = [];
-        
+
         for (const pr of combined.values()) {
             let version = null;
-            if (pr.archiveVersion) {
-                version = pr.archiveVersion.startsWith(issueSyncConfig.versionDirectoryPrefix)
-                    ? pr.archiveVersion
-                    : issueSyncConfig.versionDirectoryPrefix + pr.archiveVersion;
-            } else if (pr.milestone?.title) {
+            if (pr.milestone?.title) {
                 version = pr.milestone.title.startsWith(issueSyncConfig.versionDirectoryPrefix)
                     ? pr.milestone.title
                     : issueSyncConfig.versionDirectoryPrefix + pr.milestone.title;
@@ -138,7 +130,7 @@ class PullRequestSyncer extends Base {
             if (!buckets.has(version)) buckets.set(version, []);
             buckets.get(version).push(pr);
         }
-        
+
         const plans = new Map();
 
         activeItems.sort((a, b) => a.number - b.number);
@@ -162,7 +154,7 @@ class PullRequestSyncer extends Base {
                 });
             });
         }
-        
+
         return plans;
     }
 
@@ -290,7 +282,7 @@ class PullRequestSyncer extends Base {
                 const cachedPull = cachedPulls[pr.number];
                 const oldPathRelative = cachedPull?.path;
                 const oldAbsolutePath = oldPathRelative ? this.#resolvePath(oldPathRelative) : null;
-                
+
                 const needsUpdate = !cachedPull ||
                     cachedPull.updatedAt !== pr.updatedAt ||
                     oldAbsolutePath !== targetPath;
@@ -298,7 +290,7 @@ class PullRequestSyncer extends Base {
                 // Diff cache
                 if (!needsUpdate && cachedPull && cachedPull.contentHash === currentHash) {
                     logger.debug(`Skipping pull request #${pr.number}, content unchanged.`);
-                    
+
                     // We must still transfer the hash and path to the new run's metadata to persist it
                     pr.contentHash = currentHash;
                     pr.relativeOutputPath = oldPathRelative;
@@ -307,7 +299,7 @@ class PullRequestSyncer extends Base {
 
                 await fs.mkdir(path.dirname(targetPath), { recursive: true });
                 await fs.writeFile(targetPath, content, 'utf-8');
-                
+
                 if (oldAbsolutePath && oldAbsolutePath !== targetPath) {
                     try {
                         await fs.unlink(oldAbsolutePath);
@@ -318,7 +310,7 @@ class PullRequestSyncer extends Base {
                 }
 
                 logger.debug(`✅ Synced pull request #${pr.number}`);
-                
+
                 pr.contentHash = currentHash;
                 pr.relativeOutputPath = this.#relativePath(targetPath);
 
@@ -328,7 +320,7 @@ class PullRequestSyncer extends Base {
                 logger.warn(`⚠️ Could not sync pull request #${pr.number}: ${e.message}`);
             }
         }
-        
+
         // Cache for the main orchestrator to merge
         metadata.pulls = {};
         const indexEntries = [];
@@ -337,15 +329,14 @@ class PullRequestSyncer extends Base {
             const plan = planBuckets.get(p.number);
 
             metadata.pulls[p.number] = {
-                number        : p.number,
-                contentHash   : p.contentHash,
-                state         : p.state,
-                updatedAt     : p.updatedAt,
-                closedAt      : p.closedAt || null,
-                mergedAt      : p.mergedAt || null,
-                milestone     : p.milestone?.title || null,
-                archiveVersion: p.state === 'OPEN' ? null : plan?.version || null,
-                path          : p.relativeOutputPath
+                number     : p.number,
+                contentHash: p.contentHash,
+                state      : p.state,
+                updatedAt  : p.updatedAt,
+                closedAt   : p.closedAt || null,
+                mergedAt   : p.mergedAt || null,
+                milestone  : p.milestone?.title || null,
+                path       : p.relativeOutputPath
             };
 
             indexEntries.push(createContentIndexEntry({

--- a/test/playwright/unit/ai/services/github-workflow/MetadataManager.spec.mjs
+++ b/test/playwright/unit/ai/services/github-workflow/MetadataManager.spec.mjs
@@ -160,7 +160,8 @@ test.describe('Neo.ai.services.github-workflow.sync.MetadataManager', () => {
         expect(loaded.pulls['789'].extraFieldShouldBePruned).toBeUndefined();
         expect(loaded.pulls['789'].mergedAt).toBe('2026-05-13T00:00:00Z');
         expect(loaded.pulls['789'].milestone).toBe('v1.0.0');
-        expect(loaded.pulls['789'].archiveVersion).toBe('v1.0.0');
+        // #11364: `archiveVersion` is retired — `save()` must prune it, never persist it.
+        expect(loaded.pulls['789'].archiveVersion).toBeUndefined();
         expect(loaded.pulls['789'].contentHash).toBe('hash3');
 
         // Backward compat

--- a/test/playwright/unit/ai/services/github-workflow/PullRequestSyncer.spec.mjs
+++ b/test/playwright/unit/ai/services/github-workflow/PullRequestSyncer.spec.mjs
@@ -68,8 +68,13 @@ test.describe('Neo.ai.services.github-workflow.sync.PullRequestSyncer', () => {
         await fs.remove(tmpRoot).catch(() => {});
     });
 
-    test('preserves cached archiveVersion for migrated closed PR paths', async () => {
+    test('stale cached archiveVersion does not force a closed-post-latest-release PR into archive/pulls/v13.0.0 (#11364)', async () => {
         const prNumber = 12345;
+
+        // Pre-#11364 metadata pinned this PR to a v13.0.0 archive bucket via the
+        // `archiveVersion` carry-forward. With the carry-forward retired, archive placement
+        // is derived fresh from real milestone/release logic — and a PR merged after the
+        // latest release with no milestone must land ACTIVE, not in the stale v13.0.0 bucket.
         const metadata = {
             pulls: {
                 [prNumber]: {
@@ -78,10 +83,15 @@ test.describe('Neo.ai.services.github-workflow.sync.PullRequestSyncer', () => {
                     closedAt      : '2026-05-01T00:00:00Z',
                     mergedAt      : '2026-05-01T00:00:00Z',
                     archiveVersion: 'v13.0.0',
-                    path          : `resources/content/pr-archive/123xx/pr-${prNumber}.md`
+                    path          : `resources/content/archive/pulls/v13.0.0/chunk-1/pr-${prNumber}.md`
                 }
             }
         };
+
+        // Latest release predates the PR's merge → no real release applies.
+        ReleaseNotesSyncer.sortedReleases = [
+            {tagName: 'v12.9.0', publishedAt: '2026-04-01T00:00:00Z'}
+        ];
 
         GraphqlService.query = async () => ({
             repository: {
@@ -95,14 +105,16 @@ test.describe('Neo.ai.services.github-workflow.sync.PullRequestSyncer', () => {
             }
         });
 
-        const stats = await PullRequestSyncer.syncPullRequests(metadata);
-        const chunkNumber = 1;
-        const targetPath = path.join(aiConfig.issueSync.archiveRoot, 'pulls', 'v13.0.0', `chunk-${chunkNumber}`, `pr-${prNumber}.md`);
+        const stats      = await PullRequestSyncer.syncPullRequests(metadata);
+        const activePath = path.join(aiConfig.issueSync.contentRoot, 'pulls', 'chunk-1', `pr-${prNumber}.md`);
+        const stalePath  = path.join(aiConfig.issueSync.contentRoot, 'archive', 'pulls', 'v13.0.0', 'chunk-1', `pr-${prNumber}.md`);
 
         expect(stats.synced).toEqual([prNumber]);
-        await expect(fs.pathExists(targetPath)).resolves.toBe(true);
-        expect(metadata.pulls[prNumber].archiveVersion).toBe('v13.0.0');
-        expect(metadata.pulls[prNumber].path).toBe(path.relative(aiConfig.projectRoot, targetPath));
+        await expect(fs.pathExists(activePath)).resolves.toBe(true);
+        await expect(fs.pathExists(stalePath)).resolves.toBe(false);
+        expect(metadata.pulls[prNumber].path).toBe(path.relative(aiConfig.projectRoot, activePath));
+        // `archiveVersion` is fully retired (#11364) — it is no longer written to metadata.
+        expect(metadata.pulls[prNumber].archiveVersion).toBeUndefined();
     });
 });
 


### PR DESCRIPTION
Resolves #11364
Related: #11372

Retires the `archiveVersion` metadata carry-forward from the GitHub-workflow PR syncer. Archive-bucket placement for closed/merged PRs is now derived fresh each sync from real milestone/release-date logic — a cached `.sync-metadata.json` `archiveVersion` can no longer re-lock a PR into a stale (e.g. pre-release-cut) archive bucket.

Authored by Opus 4.7 (1M context) (Claude Code). Session ff79d594-1c1e-4181-ad9b-3d9150547699.

FAIR-band: over-target [14/30] — taking this lane despite over-target: #11364 was already self-assigned to me; the only under-target peer (Gemini, 0/30) has a documented unstable harness so an `[author-yield]` is non-actionable; among the two active authors I am the lower (GPT 16/30); and I posted the #11372 epic-review that gates this exact sub.

Evidence: L2 (unit tests — `PullRequestSyncer.spec` + `MetadataManager.spec` — plus a static repo-wide `rg` carry-forward audit) → L2 required (all of #11364's ACs are unit-/static-covered). No residuals.

## Deltas from ticket

None — implemented exactly per #11364's 6 ACs. The diff is scoped strictly to the `archiveVersion` retirement; sibling sub #11365 (milestone-aware routing), adjacent in `PullRequestSyncer.mjs`, is untouched.

## What changed

`PullRequestSyncer.mjs#planBuckets`:
- Dropped `archiveVersion` from both the cached-metadata and fetched-PR hydration into the `combined` map (the now-dead `const cached` lookup went with it).
- Removed the `if (pr.archiveVersion)` branch from the version-resolution cascade — the first branch is now `milestone`, then release-date inference. Cached `archiveVersion` is no longer the primary archive-bucket source.

`PullRequestSyncer.mjs#syncPullRequests`:
- Dropped `archiveVersion` from the `metadata.pulls[N]` write — it is no longer a persistent field.

`MetadataManager.mjs#save`:
- Dropped `archiveVersion` from the pulls prune, with a WHY-comment so a future reader does not re-add it.

## Behavior delta

**Before:** a closed/merged PR with a cached `archiveVersion` (e.g. `v13.0.0`) was pinned to `archive/pulls/v13.0.0/` even when no real release applied.

**After:** the archive bucket is computed fresh from milestone → release-date each sync. A closed-post-latest-release PR with no milestone lands **active** (the post-#11360 contract); a stale `archiveVersion` is ignored entirely.

## AC coverage

| AC | Status |
|---|---|
| AC1 — audit `MetadataManager` / `PullRequestSyncer` for `archiveVersion` validity | done — it was live in 4 sites, all retired |
| AC2 — remove carry-forward from serialization + hydration | done — `MetadataManager` prune + `planBuckets` hydration |
| AC3 — no cached `pr.archiveVersion` as primary archive-bucket source | done — cascade branch removed; milestone/release logic only |
| AC4 — rewrite the `preserves cached archiveVersion` spec | done — `PullRequestSyncer.spec` rewritten to the post-#11364 contract |
| AC5 — regression: stale `archiveVersion: 'v13.0.0'` cannot force `archive/pulls/v13.0.0/` | done — new `PullRequestSyncer.spec` test asserts active placement |
| AC6 — `rg` shows no active stale carry-forward path | done — only the explanatory comment + targeted regression assertions remain |

## Test Evidence

```
npm run test-unit -- PullRequestSyncer.spec.mjs MetadataManager.spec.mjs
→ 2 passed
```

- `PullRequestSyncer.spec` — the rewritten test: a MERGED PR with stale cached `archiveVersion: 'v13.0.0'`, no milestone, and a latest release predating the merge → lands in `pulls/chunk-1/` (active), NOT `archive/pulls/v13.0.0/`; `metadata.pulls[N].archiveVersion` is `undefined`.
- `MetadataManager.spec` — the `'789'` pull keeps `archiveVersion: 'v1.0.0'` in input; the test now asserts `save()` prunes it (`toBeUndefined()`).
- AC6 audit: repo-wide `rg "archiveVersion"` over `*.mjs` returns only the `MetadataManager` WHY-comment + the two specs' regression input/assertions — no active runtime path; `defaultArchiveVersion` has zero matches (already retired by #11363).

## Post-Merge Validation

None — all six acceptance criteria are verified pre-merge by the unit tests above plus the static repo-wide `rg` audit (AC6). No behavior in this change is observable only after merge.

## Commits

- `15ccbaad1` — refactor(github-workflow): retire PR archiveVersion metadata carry-forward (#11364)

## Related

- Sub of Epic #11372 (ADR 0004 universal content architecture). My epic-review of #11372 (the `epic-review` gate for this sub): https://github.com/neomjs/neo/issues/11372#issuecomment-4517366245 — Greenlight, with the stale-premise caution this PR's premise re-verification resolved.
- Builds on the post-#11360 active/archive contract. Sibling sub #11365 (milestone-aware routing) is adjacent in `PullRequestSyncer.mjs` but untouched here — the diff is scoped strictly to the `archiveVersion` retirement.