### PR TITLE
test(deploy): adoption-ladder journey proof — milestones 0-2 (#11725)

### DIFF
--- a/test/playwright/integration/AdoptionLadderJourney.integration.spec.mjs
+++ b/test/playwright/integration/AdoptionLadderJourney.integration.spec.mjs
@@ -1,0 +1,116 @@
+import {randomUUID}                                                       from 'node:crypto';
+import {test, expect}                                                     from '@playwright/test';
+import {callHealthcheck, callJsonTool, createIdentityClient, getReadiness} from './fixtures/mcpClient.mjs';
+
+/**
+ * #11725 Sub D — the incremental adoption-ladder journey proof (Discussion #11718 §8).
+ *
+ * The per-capability integration specs (`healthcheck`, `RemoteMcpTransport`,
+ * `ai/kb-ingestion/multi-tenant`, `BackupRestoreWipe`) each prove ONE rung in isolation.
+ * This spec proves the operator JOURNEY: the adoption-ladder milestones run as an ordered,
+ * each-independently-verifiable sequence against the same Dockerized cloud-profile stack a
+ * fresh operator deploys — the central #11720 mission proof ("a fresh agent/operator
+ * completes the adoption ladder without tacit maintainer knowledge").
+ *
+ * Test-evidence lane (1) — CI-safe deterministic (per @neo-gpt's #11718 test-strategy
+ * `DC_kwDODSospM4BA4Rx`): runs against `ai/deploy/docker-compose.test.yml` via the
+ * integration `composeWebServer`; no heavyweight local-model inference. Lanes (2) the
+ * heavyweight local/docker provider proof and (3) the manual real-world harness demo are
+ * kept distinct and are not run here.
+ *
+ * Milestone assertions are deliberately PATH-LEVEL — each rung proves the deployed stack
+ * is operationally reachable through the operator journey (connect + the core tool path
+ * answers cleanly). Deep capability assertions (retrieval fidelity, tenant isolation,
+ * reconciliation) remain owned by the per-capability specs above; duplicating them here
+ * would couple the journey proof to embedding-fixture internals.
+ *
+ * First slice (`Refs #11725`): milestones 0-2 — the connectivity ladder. Milestones 3-7
+ * (tenant ingestion, client-side parser, bulk/backfill path, optional server-side clone,
+ * backup → redeploy → handoff) follow as the next slice.
+ *
+ * @see https://github.com/neomjs/neo/issues/11725
+ */
+
+const KB_URL = process.env.NEO_INTEGRATION_KB_URL || 'http://127.0.0.1:13000';
+const MC_URL = process.env.NEO_INTEGRATION_MC_URL || 'http://127.0.0.1:13001';
+
+test.describe('Adoption-ladder journey proof — #11725 Sub D (milestones 0-2)', () => {
+    test.beforeEach(async () => {
+        const readiness = await getReadiness();
+
+        test.skip(readiness.dockerAvailable === false, `Docker unavailable: ${readiness.reason}`);
+        expect(readiness.servicesReady, readiness.reason).toBe(true);
+    });
+
+    test('Milestone 0 — runnable remote-MCP healthcheck demo: KB and MC answer healthy over /mcp', async () => {
+        const [kbHealth, mcHealth] = await Promise.all([
+            callHealthcheck(KB_URL),
+            callHealthcheck(MC_URL)
+        ]);
+
+        expect(kbHealth.status, 'KB healthcheck over /mcp').toBe('healthy');
+        expect(mcHealth.status, 'MC healthcheck over /mcp').toBe('healthy');
+    });
+
+    test('Milestone 1 — Memory Core connection: the write + query paths answer over remote MCP', async () => {
+        const sentinel = `journey-ladder-m1-${randomUUID()}`;
+        const client   = await createIdentityClient({
+            baseUrl   : MC_URL,
+            identity  : 'journey-operator',
+            clientName: 'neo-journey-mc'
+        });
+
+        try {
+            const health = await callJsonTool(client, 'healthcheck');
+            expect(health.status, 'MC healthcheck before the round-trip').toBe('healthy');
+
+            const written = await callJsonTool(client, 'add_memory', {
+                prompt  : `adoption-ladder milestone 1 — ${sentinel}`,
+                thought : 'journey-proof write path reached over remote MCP',
+                response: sentinel,
+                agent   : 'journey-operator'
+            });
+            expect(written.id, 'add_memory returns a persisted memory id').toBeTruthy();
+
+            // callJsonTool already asserts the tool did not return isError — reaching here
+            // proves the query path answered cleanly for the same operator identity.
+            const queried = await callJsonTool(client, 'query_raw_memories', {query: sentinel});
+            expect(queried, 'query_raw_memories returns a structured payload').toBeDefined();
+        } finally {
+            await client.close();
+        }
+    });
+
+    test('Milestone 2 — Knowledge Base connection: the Neo-shared corpus query path answers over remote MCP', async () => {
+        const client = await createIdentityClient({
+            baseUrl   : KB_URL,
+            identity  : 'journey-operator',
+            clientName: 'neo-journey-kb'
+        });
+
+        try {
+            const health = await callJsonTool(client, 'healthcheck');
+            expect(health.status, 'KB healthcheck before the query').toBe('healthy');
+            expect(
+                health.database.connection.collections.knowledgeBase.exists,
+                'the knowledge-base collection exists on the deployed stack'
+            ).toBe(true);
+
+            const query = await callJsonTool(client, 'query_documents', {
+                query: 'What is Neo.mjs?',
+                limit: 2
+            });
+
+            // The deployed KB may or may not be pre-seeded with the Neo-shared corpus; the
+            // journey rung proves the query PATH answers cleanly, so accept either a
+            // structured result set or an explicit empty-corpus message.
+            if (query.message) {
+                expect(typeof query.message, 'an empty-corpus query returns a message string').toBe('string');
+            } else {
+                expect(Array.isArray(query.results), 'query_documents returns a results array').toBe(true);
+            }
+        } finally {
+            await client.close();
+        }
+    });
+});


### PR DESCRIPTION
Refs #11725
Related: #11720

Authored by Opus 4.7 (1M context) (Claude Code). Session ff79d594-1c1e-4181-ad9b-3d9150547699.

FAIR-band: over-target [15/30] — operator-directed lane ("continue with GPT on 2 lanes", 2026-05-22). GPT + I are exactly even at 15/15; the only under-target peer (Gemini, 0/30) has a documented unstable harness. GPT took #11725's negative-assertions residual; this PR is the paired journey-proof residual.

Adds the milestone-sequenced **adoption-ladder journey proof** for Epic #11720 Sub D #11725 — the central #11720 mission-proof artifact (Discussion #11718 §8). The existing per-capability integration specs (`healthcheck`, `RemoteMcpTransport`, `multi-tenant` ingestion, `BackupRestoreWipe`) each prove one rung in isolation; this spec proves the operator JOURNEY — the milestones run as an ordered, each-independently-verifiable ladder against the same Dockerized cloud-profile stack a fresh operator deploys.

Evidence: L1 (spec authored + `node --check` syntax-verified; faithful mirror of the established integration-spec pattern) → L3 achieved via the `integration-unified` CI run against `docker-compose.test.yml` (pre-merge gate). Residual: AC4 milestones 3-7 [#11725].

## Deltas from ticket

This is a `Refs #11725` first slice, not the whole Sub D. Per the operator-directed 2-lane coordination (A2A-confirmed with @neo-gpt), #11725's residual ACs split two ways:
- **This PR** — AC4 journey proof, milestones 0-2 (the connectivity ladder: remote-MCP healthcheck demo → Memory Core connection → Knowledge Base connection).
- **@neo-gpt** — AC5/AC6 cloud-profile negative-behavior assertions.

Milestones 3-7 (tenant ingestion, client-side parser, bulk/backfill path, optional server-side clone, backup → redeploy → handoff) follow as the next journey-proof slice.

Milestone assertions are deliberately **path-level** — each rung proves the deployed stack is operationally reachable through the operator journey (connect + the core tool path answers cleanly). Deep capability assertions (retrieval fidelity, tenant isolation, reconciliation) remain owned by the per-capability integration specs; duplicating them here would couple the journey proof to embedding-fixture internals. The journey proof's distinct value is the *sequenced operator-reachability ladder*.

## Test Evidence

- `node --check test/playwright/integration/AdoptionLadderJourney.integration.spec.mjs` → passed.
- The spec mirrors the established integration pattern (`getReadiness` → `test.skip` on no-Docker → `createIdentityClient` / `callJsonTool`) from `healthcheck.spec.mjs` + `KBRemoteMcpTransport.integration.spec.mjs`.
- Live milestone execution runs in the `integration-unified` CI job against `docker-compose.test.yml` (the pre-merge gate). In a no-Docker authoring sandbox the spec skips cleanly via the `dockerAvailable === false` guard — the documented sandbox ceiling (the same one #11751 / #11753 hit).

## Post-Merge Validation

- [ ] `integration-unified` CI confirmed exercising milestones 0-2 against the Dockerized KB/MC stack with all three passing (visible on this PR's checks before merge).
- [ ] A Docker-capable operator/agent extends this with milestones 3-7 for the complete #11725 AC4 journey proof.

## Commits

- `3223027d1` — test(deploy): add adoption-ladder journey proof — milestones 0-2 (#11725)

## Related

- Sub D of Epic #11720 (Cloud Agent OS Deployment Readiness). My epic-resolution of #11720 ([IC_kwDODSospM8AAAABDUciXA](https://github.com/neomjs/neo/issues/11720#issuecomment-4517732956)) identified #11725's journey proof as the sole #11720 KEEP_OPEN blocker — this PR is the first slice closing it.
- Paired lane: @neo-gpt on #11725's cloud-profile negative-behavior assertions.