### PR TITLE
feat(ai): pin cloud-profile wake boundaries (#11725)

### DIFF
--- a/ai/deploy/docker-compose.yml
+++ b/ai/deploy/docker-compose.yml
@@ -79,6 +79,7 @@ services:
     environment:
       - NEO_TRANSPORT=sse
       - NEO_MC_PRIMARY=false
+      - NEO_MAILBOX_DEFAULT_REPLY_POLICY=blocked
       - NEO_AUTO_SUMMARIZE=false
       - NEO_MEM_AUTO_START_DATABASE=false
       - NEO_MEM_AUTO_START_INFERENCE=false
@@ -125,6 +126,11 @@ services:
         SERVICE_ENTRYPOINT: ai/scripts/orchestrator-daemon.mjs
     environment:
       - NEO_AI_DEPLOYMENT_MODE=cloud
+      - NEO_ORCHESTRATOR_PRIMARY_DEV_SYNC_ENABLED=false
+      - NEO_ORCHESTRATOR_KB_SYNC_ENABLED=false
+      - NEO_ORCHESTRATOR_BRIDGE_DAEMON_ENABLED=false
+      - NEO_ORCHESTRATOR_GOLDEN_PATH_REPO_ENRICHMENT_ENABLED=false
+      - NEO_ORCHESTRATOR_MLX_ENABLED=false
       - NEO_CHROMA_HOST=chroma
       - NEO_CHROMA_PORT=8000
       - NEO_MEMORY_DB_PATH=/app/.neo-ai-data/sqlite/memory-core-graph.sqlite

--- a/learn/agentos/DeploymentCookbook.md
+++ b/learn/agentos/DeploymentCookbook.md
@@ -54,6 +54,7 @@ lane back in. The explicit env overrides are:
 | `NEO_ORCHESTRATOR_BRIDGE_DAEMON_ENABLED=false` | Prevents desktop wake delivery through `osascript` / `tmux`. A2A message storage remains Memory Core behavior. |
 | `NEO_ORCHESTRATOR_GOLDEN_PATH_REPO_ENRICHMENT_ENABLED=false` | Keeps tenant deployments from emitting Neo-maintainer repo backlog/PR enrichment sections. |
 | `NEO_ORCHESTRATOR_MLX_ENABLED=false` | Keeps Apple-Silicon local inference out of the cloud profile unless a local-model variant explicitly opts in. |
+| `NEO_MAILBOX_DEFAULT_REPLY_POLICY=blocked` | Keeps cloud A2A message writes tenant-bound through the Memory Core `CAN_REPLY_TO` / reachable-counterparty policy; local wake delivery remains disabled by the orchestrator bridge toggle. |
 
 Sub D (#11725) owns the CI-safe negative proof that the cloud profile cannot run
 the forbidden local-only behavior. The current unit substrate already asserts
@@ -147,6 +148,7 @@ Supply these values per service/profile as needed:
 | `NEO_MEMORY_DB_PATH` | KB, MC, Orchestrator | Shared SQLite graph path or mounted graph-store path. |
 | `NEO_AUTH_TRUST_PROXY_IDENTITY=true` | KB, MC | Enables the trusted reverse-proxy identity-header path. |
 | `NEO_AUTH_ISSUER_URL`, `NEO_OAUTH_CLIENT_ID`, `NEO_OAUTH_CLIENT_SECRET` | KB, MC | Direct OIDC/OAuth mode inputs when the MCP server handles auth instead of a trusted proxy. |
+| `NEO_MAILBOX_DEFAULT_REPLY_POLICY=blocked` | MC | Enables the strict A2A reply policy for multi-tenant deployments. |
 | `NEO_AI_DEPLOYMENT_MODE=cloud` | Orchestrator | Selects the cloud maintenance profile. |
 | `NEO_ORCHESTRATOR_PRIMARY_DEV_SYNC_ENABLED=false` | Orchestrator | Disables local maintainer checkout sync. |
 | `NEO_ORCHESTRATOR_KB_SYNC_ENABLED=false` | Orchestrator | Disables local full-corpus KB sync. |

--- a/test/playwright/unit/ai/buildScripts/mcpHealthcheck.spec.mjs
+++ b/test/playwright/unit/ai/buildScripts/mcpHealthcheck.spec.mjs
@@ -7,6 +7,14 @@ test.describe('buildScripts/ai/mcpHealthcheck (#11725)', () => {
     let buildHeaders;
     let readToolJson;
     let runHealthcheck;
+    const readProductionCompose = () => yaml.load(fs.readFileSync(
+        new URL('../../../../../ai/deploy/docker-compose.yml', import.meta.url),
+        'utf8'
+    ));
+
+    function environmentMap(service) {
+        return Object.fromEntries(service.environment.map(entry => entry.split('=')));
+    }
 
     test.beforeAll(async () => {
         const mod = await import('../../../../../buildScripts/ai/mcpHealthcheck.mjs');
@@ -144,10 +152,7 @@ test.describe('buildScripts/ai/mcpHealthcheck (#11725)', () => {
     });
 
     test('production compose wires KB/MC MCP healthchecks before cloud orchestrator startup', () => {
-        const compose = yaml.load(fs.readFileSync(
-            new URL('../../../../../ai/deploy/docker-compose.yml', import.meta.url),
-            'utf8'
-        ));
+        const compose = readProductionCompose();
 
         expect(compose.services['kb-server'].healthcheck.test).toEqual([
             'CMD',
@@ -171,5 +176,22 @@ test.describe('buildScripts/ai/mcpHealthcheck (#11725)', () => {
 
         expect(compose.services.orchestrator.depends_on['kb-server']).toEqual({condition: 'service_healthy'});
         expect(compose.services.orchestrator.depends_on['mc-server']).toEqual({condition: 'service_healthy'});
+    });
+
+    test('production compose pins cloud-profile local wake and mailbox boundaries', () => {
+        const compose           = readProductionCompose();
+        const orchestratorEnv   = environmentMap(compose.services.orchestrator);
+        const memoryCoreEnv     = environmentMap(compose.services['mc-server']);
+
+        expect(orchestratorEnv).toMatchObject({
+            NEO_AI_DEPLOYMENT_MODE: 'cloud',
+            NEO_ORCHESTRATOR_PRIMARY_DEV_SYNC_ENABLED: 'false',
+            NEO_ORCHESTRATOR_KB_SYNC_ENABLED: 'false',
+            NEO_ORCHESTRATOR_BRIDGE_DAEMON_ENABLED: 'false',
+            NEO_ORCHESTRATOR_GOLDEN_PATH_REPO_ENRICHMENT_ENABLED: 'false',
+            NEO_ORCHESTRATOR_MLX_ENABLED: 'false'
+        });
+
+        expect(memoryCoreEnv.NEO_MAILBOX_DEFAULT_REPLY_POLICY).toBe('blocked');
     });
 });


### PR DESCRIPTION
Authored by GPT-5.5 (Codex Desktop). Session 019e4c2e-c7aa-72a2-b0bc-58c0996c63f3.

FAIR-band: in-band [15/30 - current author count over last 30 merged]

Refs #11725
Related: #11720
Related: #11751
Related: #11753
Related: #11728

## Deltas
- Pins the production cloud compose profile to explicit false toggles for local-only orchestrator lanes: primary-dev-sync, kbSync, bridgeDaemon wake delivery, Golden Path repo enrichment, and MLX.
- Sets the deployed Memory Core service to `NEO_MAILBOX_DEFAULT_REPLY_POLICY=blocked`, keeping cloud A2A writes on the strict tenant-bound reply policy while local wake delivery stays disabled.
- Extends the #11725 compose unit guard to parse `ai/deploy/docker-compose.yml` and assert the deployed wake/mailbox boundary directly.
- Updates `DeploymentCookbook.md` so the deployment authority names the strict mailbox env var alongside the orchestrator cloud-profile toggles.

Evidence: L2 deterministic compose-contract validation. This PR completes the CI-safe #11725 cloud-profile negative-behavior assertion after #11751 shipped MCP healthchecks / orchestrator health gating. The adoption-ladder journey-proof half is Claude owned in the parallel lane.

## Deltas from ticket
- Completes the cloud-profile negative-behavior slice: local desktop wake delivery is explicitly disabled/no-op through `NEO_ORCHESTRATOR_BRIDGE_DAEMON_ENABLED=false`; Memory Core A2A message writes are tenant-bound through `NEO_MAILBOX_DEFAULT_REPLY_POLICY=blocked`.
- Keeps the proof in the CI-safe lane. No heavyweight local-model or Docker runtime path was added to default CI.
- Leaves ticket 11728 alone. That ticket is tutorial-only and is already completed by merged PR #11753.
- Leaves ticket 11725 open after this PR; Claude owns the adoption-ladder journey-proof half as the parallel lane.

## Slot Rationale
- Modified `learn/agentos/DeploymentCookbook.md`: disposition delta `rewrite`; the cookbook is the #11720 deployment authority and now names the strict mailbox policy next to the cloud-profile wake/local-only toggles. This is conditional deployment documentation, not always-loaded agent substrate.
- Modified `ai/deploy/docker-compose.yml`: disposition `keep`; this is the production profile contract for #11725, so explicit env pins reduce future deployment drift.
- Modified `test/playwright/unit/ai/buildScripts/mcpHealthcheck.spec.mjs`: disposition `keep`; the test is a CI-safe drift guard over the compose contract.

## Test Evidence
- `npm run test-unit -- test/playwright/unit/ai/buildScripts/mcpHealthcheck.spec.mjs` - 8 passed.
- `npm run test-unit -- test/playwright/unit/ai/scripts/orchestrator-daemon.spec.mjs` - 9 passed.
- `git diff --check` - passed.
- `git diff --cached --check` - passed before commit.
- Pre-push freshness check: `merge-base HEAD origin/dev == origin/dev` at `06727b25f461250066fee107e2349e7a6284fed7`; outgoing log contains only `d7cb9fad6 feat(ai): pin cloud-profile wake boundaries (#11725)`.
- Not run: Docker runtime validation; this Codex environment does not provide Docker.

## Post-Merge Validation
- [ ] On a Docker-capable host, run `docker compose --profile cloud -f ai/deploy/docker-compose.yml config` and verify the orchestrator env pins plus MC mailbox policy render as expected.
- [ ] Start the cloud profile and confirm KB/MC healthchecks gate orchestrator startup as established by #11751.

## Residual Risk
- Ticket 11725 remains open until the parallel adoption-ladder journey-proof lane lands.
- Docker runtime behavior still needs host-level validation; the merged default-CI contract from this PR prevents the deployment profile from omitting the local wake/A2A negative assertions.

## Commits
- `d7cb9fad6` - `feat(ai): pin cloud-profile wake boundaries (#11725)`