### PR TITLE
test(deploy): adoption-ladder journey proof — milestones 3-7 (#11725)

### DIFF
--- a/test/playwright/integration/AdoptionLadderJourney.integration.spec.mjs
+++ b/test/playwright/integration/AdoptionLadderJourney.integration.spec.mjs
@@ -1,6 +1,6 @@
-import {randomUUID}                                                       from 'node:crypto';
-import {test, expect}                                                     from '@playwright/test';
-import {callHealthcheck, callJsonTool, createIdentityClient, getReadiness} from './fixtures/mcpClient.mjs';
+import {randomUUID}                                                                     from 'node:crypto';
+import {test, expect}                                                                   from '@playwright/test';
+import {callHealthcheck, callJsonTool, createIdentityClient, getReadiness, readToolJson} from './fixtures/mcpClient.mjs';
 
 /**
  * #11725 Sub D — the incremental adoption-ladder journey proof (Discussion #11718 §8).
@@ -24,9 +24,15 @@ import {callHealthcheck, callJsonTool, createIdentityClient, getReadiness} from 
  * reconciliation) remain owned by the per-capability specs above; duplicating them here
  * would couple the journey proof to embedding-fixture internals.
  *
- * First slice (`Refs #11725`): milestones 0-2 — the connectivity ladder. Milestones 3-7
- * (tenant ingestion, client-side parser, bulk/backfill path, optional server-side clone,
- * backup → redeploy → handoff) follow as the next slice.
+ * Ladder coverage (`Refs #11725`): milestones 0-5 run as LIVE rungs — the connectivity
+ * ladder (0-2) plus tenant ingestion (3), the `parsed-chunk-v1` client-side-parser
+ * transport gate (4), and the bulk/backfill volume gate (5). Milestones 6-7 are
+ * documented-DEFERRED rungs, not fabricated assertions: server-side clone (6) is post-MVP
+ * (#11731 exploration; ADR 0014 D3 keeps it out of the MVP profile) and the full
+ * backup → redeploy → handoff round-trip (7) is owned by the per-capability backup specs
+ * plus test-evidence lane (3) — a single Playwright spec cannot redeploy the
+ * `composeWebServer` stack mid-run. Each deferred rung carries a precise `test.skip`
+ * citation so the ladder reaches all 8 milestones without over-claiming.
  *
  * @see https://github.com/neomjs/neo/issues/11725
  */
@@ -34,7 +40,33 @@ import {callHealthcheck, callJsonTool, createIdentityClient, getReadiness} from 
 const KB_URL = process.env.NEO_INTEGRATION_KB_URL || 'http://127.0.0.1:13000';
 const MC_URL = process.env.NEO_INTEGRATION_MC_URL || 'http://127.0.0.1:13001';
 
-test.describe('Adoption-ladder journey proof — #11725 Sub D (milestones 0-2)', () => {
+/**
+ * Builds a well-formed `parsed-chunk-v1` record — the shape a fresh operator's client-side
+ * parser emits. Mirrors the golden `expected-chunks.jsonl` fixture field set so the deployed
+ * Knowledge Base's Ajv `parsed-chunk-v1` validator accepts it verbatim.
+ * @param {String} sentinel       A per-run unique marker.
+ * @param {Object} [overrides={}] Fields to override (e.g. a contract-violating `schemaVersion`).
+ * @returns {Object} A `parsed-chunk-v1` record.
+ */
+function journeyParsedChunk(sentinel, overrides = {}) {
+    return {
+        schemaVersion: '1.0.0',
+        tenantId     : 'journey-operator',
+        repoSlug     : 'journey-ladder',
+        rootKind     : 'neo-workspace',
+        sourcePath   : `journey/${sentinel}.mjs`,
+        content      : `adoption-ladder journey chunk — ${sentinel}`,
+        hashInputs   : ['kind', 'name', 'content', 'sourcePath', 'parserId', 'parserVersion'],
+        parserId     : 'journey-fixture-parser',
+        parserVersion: '1.0.0',
+        kind         : 'module-context',
+        name         : 'Journey.AdoptionLadder',
+        className    : 'Journey.AdoptionLadder',
+        ...overrides
+    };
+}
+
+test.describe('Adoption-ladder journey proof — #11725 Sub D (milestones 0-7)', () => {
     test.beforeEach(async () => {
         const readiness = await getReadiness();
 
@@ -112,5 +144,118 @@ test.describe('Adoption-ladder journey proof — #11725 Sub D (milestones 0-2)',
         } finally {
             await client.close();
         }
+    });
+
+    test('Milestone 3 — tenant ingestion: the operator pushes parsed source content into their tenant over remote MCP', async () => {
+        const sentinel = `journey-ladder-m3-${randomUUID()}`;
+        const client   = await createIdentityClient({
+            baseUrl   : KB_URL,
+            identity  : 'journey-operator',
+            clientName: 'neo-journey-kb-ingest'
+        });
+
+        try {
+            const pushResult = await callJsonTool(client, 'ingest_source_files', {
+                tenantId: 'journey-operator',
+                repoSlug: 'journey-ladder',
+                files   : [{parsedChunks: [journeyParsedChunk(sentinel)]}]
+            });
+
+            // Path-level: the tenant write path answered cleanly. Deep tenant-isolation and
+            // retrieval-fidelity assertions stay owned by ai/kb-ingestion/multi-tenant.spec.
+            expect(pushResult.errors, 'a well-formed parsed chunk ingests without errors').toEqual([]);
+            expect(pushResult.ingested, 'ingest_source_files reports the chunk persisted').toBeGreaterThan(0);
+        } finally {
+            await client.close();
+        }
+    });
+
+    test('Milestone 4 — client-side parser: the deployed KB enforces the parsed-chunk-v1 transport contract', async () => {
+        const sentinel = `journey-ladder-m4-${randomUUID()}`;
+        const client   = await createIdentityClient({
+            baseUrl   : KB_URL,
+            identity  : 'journey-operator',
+            clientName: 'neo-journey-kb-parser'
+        });
+
+        try {
+            // A remote operator cannot register a server-side parser — the only ingestion
+            // path is client-side parsing into `parsed-chunk-v1` records. This rung proves
+            // the deployed server enforces that transport contract: a contract-violating
+            // chunk is rejected with structured, machine-readable feedback, not a crash.
+            const rejected = await callJsonTool(client, 'ingest_source_files', {
+                tenantId: 'journey-operator',
+                repoSlug: 'journey-ladder',
+                files   : [{parsedChunks: [journeyParsedChunk(sentinel, {schemaVersion: '0.9.0'})]}]
+            });
+
+            expect(Array.isArray(rejected.errors), 'the transport gate returns a structured errors array').toBe(true);
+            expect(rejected.errors.length, 'the contract-violating chunk surfaces at least one error').toBeGreaterThan(0);
+            expect(
+                rejected.errors.every(error => typeof error.code === 'string'),
+                'each transport-gate error carries a machine-readable code'
+            ).toBe(true);
+        } finally {
+            await client.close();
+        }
+    });
+
+    test('Milestone 5 — bulk/backfill: an over-threshold push is routed to the bulk path, not embedded inline', async () => {
+        const sentinel = `journey-ladder-m5-${randomUUID()}`;
+        const client   = await createIdentityClient({
+            baseUrl   : KB_URL,
+            identity  : 'journey-operator',
+            clientName: 'neo-journey-kb-bulk'
+        });
+
+        // 60 raw files clear the deployed `mcpSyncMaxChunks` default (50). The volume gate
+        // refuses up-front — before embedding — so this rung stays cheap.
+        const oversizedBatch = Array.from({length: 60}, (_, index) => ({
+            path   : `journey/bulk-${index}-${sentinel}.mjs`,
+            content: `adoption-ladder bulk backfill chunk ${index} — ${sentinel}`
+        }));
+
+        try {
+            const result = await client.callTool({
+                name     : 'ingest_source_files',
+                arguments: {tenantId: 'journey-operator', repoSlug: 'journey-ladder', files: oversizedBatch}
+            });
+            const gate = readToolJson(result, 'ingest_source_files volume gate');
+
+            // Path-level: the operator who exceeds the per-call limit is routed to the
+            // bulk/backfill path — the gate reports the batch size, the configured
+            // threshold, and the bulk-path pointer instead of embedding 60 chunks inline.
+            expect(gate.code, 'an over-threshold push returns the volume gate').toBe('KB_INGEST_VOLUME_EXCEEDED');
+            expect(gate.batchSize, 'the gate echoes the rejected batch size').toBe(60);
+            expect(typeof gate.threshold, 'the gate reports the configured threshold').toBe('number');
+            expect(gate.batchSize, 'the rejected batch is above the threshold').toBeGreaterThan(gate.threshold);
+            expect(
+                Object.prototype.hasOwnProperty.call(gate, 'bulkPath'),
+                'the gate surfaces the bulk-path pointer — the backfill route'
+            ).toBe(true);
+        } finally {
+            await client.close();
+        }
+    });
+
+    test('Milestone 6 — optional server-side clone: post-MVP, not in the deployed MVP profile', async () => {
+        test.skip(true,
+            'Server-side repo-clone ingestion is post-MVP — owned by #11731 (exploration) and ' +
+            'kept out of the MVP cloud profile by ADR 0014 (D3). The MVP adoption ladder is ' +
+            'push-ingestion: a fresh operator pushes parsed-chunk-v1 records through milestones ' +
+            '3-5. This rung stays a deliberate no-op until #11731 adopts or rejects pull ' +
+            'ingestion (see #11740 for the ADR-amendment escape hatch).'
+        );
+    });
+
+    test('Milestone 7 — backup → redeploy → handoff: round-trip owned by the per-capability backup specs', async () => {
+        test.skip(true,
+            'The backup → wipe → restore round-trip is owned by KBBackupRestoreWipe.integration.spec.mjs ' +
+            '(#11644) and BackupRestoreWipe.integration.spec.mjs. The full redeploy → handoff demo — ' +
+            'stopping and recreating the container stack — is test-evidence lane (3), the manual ' +
+            'real-world harness, explicitly out of the lane-(1) CI-safe scope per this spec header: a ' +
+            'single Playwright spec running against an already-up composeWebServer cannot redeploy ' +
+            'the stack mid-run without breaking sibling specs.'
+        );
     });
 });

--- a/test/playwright/integration/AdoptionLadderJourney.integration.spec.mjs
+++ b/test/playwright/integration/AdoptionLadderJourney.integration.spec.mjs
@@ -1,6 +1,6 @@
-import {randomUUID}                                                                     from 'node:crypto';
-import {test, expect}                                                                   from '@playwright/test';
-import {callHealthcheck, callJsonTool, createIdentityClient, getReadiness, readToolJson} from './fixtures/mcpClient.mjs';
+import {randomUUID}                                                       from 'node:crypto';
+import {test, expect}                                                     from '@playwright/test';
+import {callHealthcheck, callJsonTool, createIdentityClient, getReadiness} from './fixtures/mcpClient.mjs';
 
 /**
  * #11725 Sub D — the incremental adoption-ladder journey proof (Discussion #11718 §8).
@@ -200,7 +200,7 @@ test.describe('Adoption-ladder journey proof — #11725 Sub D (milestones 0-7)',
         }
     });
 
-    test('Milestone 5 — bulk/backfill: an over-threshold push is routed to the bulk path, not embedded inline', async () => {
+    test('Milestone 5 — bulk/backfill: an over-threshold push is refused by the volume gate, not embedded inline', async () => {
         const sentinel = `journey-ladder-m5-${randomUUID()}`;
         const client   = await createIdentityClient({
             baseUrl   : KB_URL,
@@ -216,23 +216,21 @@ test.describe('Adoption-ladder journey proof — #11725 Sub D (milestones 0-7)',
         }));
 
         try {
-            const result = await client.callTool({
+            const result    = await client.callTool({
                 name     : 'ingest_source_files',
                 arguments: {tenantId: 'journey-operator', repoSlug: 'journey-ladder', files: oversizedBatch}
             });
-            const gate = readToolJson(result, 'ingest_source_files volume gate');
+            const errorText = result.content?.find(item => item.type === 'text')?.text || '';
 
-            // Path-level: the operator who exceeds the per-call limit is routed to the
-            // bulk/backfill path — the gate reports the batch size, the configured
-            // threshold, and the bulk-path pointer instead of embedding 60 chunks inline.
-            expect(gate.code, 'an over-threshold push returns the volume gate').toBe('KB_INGEST_VOLUME_EXCEEDED');
-            expect(gate.batchSize, 'the gate echoes the rejected batch size').toBe(60);
-            expect(typeof gate.threshold, 'the gate reports the configured threshold').toBe('number');
-            expect(gate.batchSize, 'the rejected batch is above the threshold').toBeGreaterThan(gate.threshold);
-            expect(
-                Object.prototype.hasOwnProperty.call(gate, 'bulkPath'),
-                'the gate surfaces the bulk-path pointer — the backfill route'
-            ).toBe(true);
+            // Path-level: the operator who exceeds the per-call limit is REFUSED up-front —
+            // the deployed server returns a volume-gate tool error directing the operator to
+            // split the batch, rather than embedding 60 chunks inline. Over remote MCP the
+            // gate surfaces as an isError result (BaseServer wraps any `{error}` payload), so
+            // the structured KB_INGEST_VOLUME_EXCEEDED contract (code / bulkPath) stays owned
+            // by the in-process ai/kb-ingestion/multi-tenant.spec coverage.
+            expect(result.isError, 'an over-threshold push is refused, not embedded inline').toBe(true);
+            expect(errorText, 'the refusal identifies the work-volume gate').toContain('work volume exceeds');
+            expect(errorText, 'the refusal echoes the rejected batch volume').toContain('Batch volume 60');
         } finally {
             await client.close();
         }


### PR DESCRIPTION
Refs #11725
Related: #11720

Authored by Opus 4.7 (Claude Code). Session ff79d594-1c1e-4181-ad9b-3d9150547699.

FAIR-band: over-target [15/30] — taking this lane per explicit operator-direction ("continue with GPT on 2 lanes"; focus #11720/#11725). 15/30 is a balanced 2-peer-active split (peer @neo-gpt also 15/30; @neo-gemini-3-1-pro 0/30) — even against the empirical active-swarm size, over-target only against the nominal 3-peer 10/30 target. Continuity lane: this slice extends my own #11757.

Extends `AdoptionLadderJourney.integration.spec.mjs` (milestones 0-2, merged via #11757) with milestones 3-7, completing the #11725 adoption-ladder journey proof to all 8 rungs. Milestones 3-5 are live remote-MCP rungs; milestones 6-7 are documented-deferred rungs with precise `test.skip` citations — honest under-claiming, not fabricated green.

Evidence: L1 (local sandbox has no Docker — static `node --check` + source-contract V-B-A) → L3 achieved by CI `integration-unified` (green on head `1a643e1b`; milestones 3-5 run live against the dockerized cloud-profile stack). Milestones 6-7 are documented-deferred rungs (L1 citation). No residual blocking ACs for this slice.

## What ships

**Live rungs** (run against `docker-compose.test.yml` via `composeWebServer`):
- **M3 — tenant ingestion**: the operator pushes a `parsed-chunk-v1` record into their tenant over remote MCP; asserts the write path answers cleanly (`errors: []`, `ingested > 0`).
- **M4 — client-side parser**: a remote operator cannot register a server-side parser — the only ingestion path is client-side parsing into `parsed-chunk-v1`. Asserts the deployed KB enforces that transport contract: a contract-violating chunk (`schemaVersion: '0.9.0'`) is rejected with a structured, machine-readable `errors` array, not a transport crash.
- **M5 — bulk/backfill**: a 60-file batch clears the deployed `mcpSyncMaxChunks` default (50); asserts the over-threshold push is **refused**. Over remote MCP the volume gate surfaces as an `isError` tool result — `BaseServer.formatToolResult` wraps the gate's `{error}` payload as a `Tool Error: …` text block — so M5 asserts `result.isError === true` plus the volume-gate identifiers in the error text. The structured `KB_INGEST_VOLUME_EXCEEDED` payload (`code` / `bulkPath`) is not MCP-transport-readable and stays owned by the in-process `ai/kb-ingestion/multi-tenant.spec` coverage.

**Documented-deferred rungs** (`test.skip` with precise citation):
- **M6 — server-side clone**: post-MVP — owned by #11731 (exploration); ADR 0014 D3 keeps server-side cloning out of the MVP profile. The MVP ladder is push-ingestion (M3-M5).
- **M7 — backup → redeploy → handoff**: the deep backup→wipe→restore round-trip is owned by `KBBackupRestoreWipe.integration.spec.mjs` (#11644) + `BackupRestoreWipe.integration.spec.mjs`. The full redeploy demo is test-evidence lane (3) (manual harness) — a single Playwright spec cannot redeploy the `composeWebServer` stack mid-run without breaking sibling specs.

Assertions are deliberately PATH-LEVEL — each rung proves the deployed stack is operationally reachable through the operator journey. Deep capability assertions (tenant isolation, retrieval fidelity, reconciliation, backup fidelity) stay owned by the per-capability specs; duplicating them here would couple the journey proof to embedding-fixture internals.

## Deltas from ticket

#11725 AC lists "the incremental adoption-ladder journey proof (Milestone 0–7)". This slice completes the spec to all 8 rungs, but milestones 6-7 land as documented-deferred rungs rather than live assertions — M6's capability (#11731 server-side clone) does not exist in the MVP, and M7's redeploy is structurally outside lane-(1) CI. This is intentional honest under-claiming. Whether #11725 is kept open or rescoped is for epic-resolution / @tobiu to decide, not this PR — it links the ticket via `Refs` only, with no GitHub auto-closing keyword.

## Test Evidence

- `node --check` on the spec — syntax OK; check-whitespace pre-commit hook passed.
- M5 source-contract V-B-A: the KB volume gate (`toolService.mjs` `ingestSourceFilesViaMcp`) returns a `{error, message, code, …}` payload; `BaseServer.formatToolResult` (`BaseServer.mjs:360-388`) sets `isError` for any `{error}`-bearing result and emits a `Tool Error: <error>. Message: <message>` text block with no `structuredContent`. M5 asserts that transport reality. Threshold default 50 confirmed (`config.mjs:301`, not overridden in `docker-compose.test.yml`).
- Live verification is CI `integration-unified` (lane 1, green on head `1a643e1b`) — Docker is unavailable in the local sandbox; CI is the spec's designed verification environment, mirroring #11757.

## Post-Merge Validation

None — milestones 3-5 are verified live by CI `integration-unified` pre-merge (green on head `1a643e1b`); milestones 6-7 are documented-deferred `test.skip` rungs.

## Commits

- `5ec9f8a55` — extend the adoption-ladder journey proof to milestones 3-7.
- `1a643e1bf` — milestone 5: assert the volume gate's MCP tool-error shape (CI fix).