### PR TITLE
feat(ai): convert wake scripts to dual-mode exports (#10795)

### DIFF
--- a/ai/daemons/SwarmHeartbeatService.mjs
+++ b/ai/daemons/SwarmHeartbeatService.mjs
@@ -22,6 +22,11 @@ import {
     releaseHeartbeatLock,
     HEARTBEAT_LOCK_PATH
 } from '../scripts/heartbeatLock.mjs';
+import {checkSunsetted as checkSunsettedScript}     from '../scripts/checkSunsetted.mjs';
+import {resumeHarness as resumeHarnessScript}       from '../scripts/resumeHarness.mjs';
+import {checkAllAgentIdle as checkAllAgentIdleScript} from '../scripts/checkAllAgentIdle.mjs';
+import {idleOutNudge as idleOutNudgeScript}         from '../scripts/idleOutNudge.mjs';
+import {trioWakeCooldown as trioWakeCooldownScript} from '../scripts/trioWakeCooldown.mjs';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname  = path.dirname(__filename);
@@ -50,11 +55,11 @@ const DEFAULT_IDENTITY         = '@neo-gemini-3-1-pro';
  *     stat-based concurrency-lock check is replaced with the JS implementation already shared
  *     with the producer side (#10319 `withHeartbeatLock`).
  *
- * **Where subprocess invocation is preserved** (out-of-scope for v1; follow-up tracked as
- * #10795): `checkSunsetted.mjs`, `resumeHarness.mjs`, `checkAllAgentIdle.mjs`,
- * `idleOutNudge.mjs`, `trioWakeCooldown.mjs` are CLI-shape (no exported function entrypoint)
- * and converting each to dual-mode (CLI + module-export) is sibling work. Their subprocess
- * cost (~2-5s per cycle, fires every 5min) is operationally tolerable.
+ * **Where dual-mode script imports replace subprocess invocations** (#10795):
+ * `checkSunsetted.mjs`, `resumeHarness.mjs`, `checkAllAgentIdle.mjs`, `idleOutNudge.mjs`,
+ * and `trioWakeCooldown.mjs` now expose module entrypoints while preserving their CLI
+ * wrappers for `swarm-heartbeat.sh` and manual use. The daemon calls those exports directly
+ * to avoid 2-5s Node startup hops per poll cycle.
  *
  * **Persistent-process management:** invocation under launchd / systemd targets the
  * entry-point wrapper at `ai/scripts/swarm-heartbeat-daemon.mjs`, NOT this class file
@@ -184,12 +189,12 @@ class SwarmHeartbeatService extends Base {
      *   1. Concurrency-lock skip (active lock = expensive work in flight, skip pulse;
      *      stale lock = clear and continue per #10319).
      *   2. TTL sweep (`MailboxService.sweepExpiredTasks` — direct call, no subprocess).
-     *   3. Sunset detection via `checkSunsetted.mjs` subprocess.
-     *      - sunset=true + gate-open → fresh-session-spawn via `resumeHarness.mjs`.
+     *   3. Sunset detection via `checkSunsetted.mjs` direct export.
+     *      - sunset=true + gate-open → fresh-session-spawn via `resumeHarness.mjs` direct export.
      *      - sunset=true + gate-closed → log + skip (no spawn).
      *      - recommended_action=idle_out_nudge + gate-open → `idleOutNudge.mjs`.
-     *   4. All-agent-idle detection via `checkAllAgentIdle.mjs`.
-     *      - allIdle=true + gate-open → `trioWakeCooldown.mjs`.
+     *   4. All-agent-idle detection via `checkAllAgentIdle.mjs` direct export.
+     *      - allIdle=true + gate-open → `trioWakeCooldown.mjs` direct export.
      *   5. Heartbeat-bypass detection: identities with push-capable subscriptions
      *      (mcp-notifications / a2a-webhook) skip the token-economy fast-path because
      *      they receive wakes via push.
@@ -224,8 +229,8 @@ class SwarmHeartbeatService extends Base {
                 logger.error('[SwarmHeartbeatService] sweepExpiredTasks failed:', err)
             }
 
-            // Step 3: Sunset detection (subprocess — checkSunsetted.mjs is CLI-shape).
-            const sunsetJson = await this.runScriptJson('checkSunsetted.mjs', [this.identity]);
+            // Step 3: Sunset detection (direct module export; CLI wrapper preserved for shell consumers).
+            const sunsetJson = await this.checkSunsetted(this.identity);
             if (sunsetJson?.sunsetted) {
                 if (!await this.checkGateOpen()) {
                     const gateState = await this.readGate();
@@ -233,12 +238,12 @@ class SwarmHeartbeatService extends Base {
                     return
                 }
                 logger.info(`[SwarmHeartbeatService] Phase 1 Recovery Triggered for ${this.identity}. Reason: ${sunsetJson.reason}`);
-                await this.runScript('resumeHarness.mjs', [
+                await this.resumeHarness(
                     this.identity,
                     sunsetJson.reason || '',
                     sunsetJson.originSessionId || '',
-                    String(sunsetJson.abandonedCount || 0)
-                ]);
+                    sunsetJson.abandonedCount || 0
+                );
                 return
             }
 
@@ -250,20 +255,20 @@ class SwarmHeartbeatService extends Base {
                     return
                 }
                 logger.info(`[SwarmHeartbeatService] Idle-out nudge triggered for ${this.identity}`);
-                await this.runScript('idleOutNudge.mjs', [this.identity]);
+                await this.idleOutNudge(this.identity);
                 return
             }
 
-            // Step 4: All-agent-idle detection (subprocess).
+            // Step 4: All-agent-idle detection (direct module export; CLI wrapper preserved for shell consumers).
             const cycleId = String(Math.floor(Date.now() / 1000));
-            const allIdleJson = await this.runScriptJson('checkAllAgentIdle.mjs', [cycleId]);
+            const allIdleJson = await this.checkAllAgentIdle(cycleId);
             if (allIdleJson?.allIdle) {
                 logger.info(`[SwarmHeartbeatService] AllAgentIdle detected: ${JSON.stringify(allIdleJson)}`);
                 if (!await this.checkGateOpen()) {
                     const gateState = await this.readGate();
                     logger.warn(`[SwarmHeartbeatService] Wake safety gate closed; skipping trio wake dispatch. Gate reason: ${gateState.reason}`)
                 } else {
-                    await this.runScript('trioWakeCooldown.mjs', [JSON.stringify(allIdleJson)])
+                    await this.trioWakeCooldown(allIdleJson)
                 }
             }
 
@@ -337,6 +342,69 @@ class SwarmHeartbeatService extends Base {
      */
     async readGate() {
         return readGateState()
+    }
+
+    /**
+     * Test-stubbable seam over `checkSunsetted.mjs`'s dual-mode module export.
+     * @param {String} identity
+     * @returns {Promise<Object|null>}
+     * @protected
+     */
+    async checkSunsetted(identity) {
+        try {
+            return await checkSunsettedScript(identity)
+        } catch (err) {
+            logger.error('[SwarmHeartbeatService] checkSunsetted.mjs failed:', err.message);
+            return null
+        }
+    }
+
+    /**
+     * Test-stubbable seam over `resumeHarness.mjs`'s dual-mode module export.
+     * @param {String} identity
+     * @param {String} reason
+     * @param {String} originSessionId
+     * @param {Number} abandonedCount
+     * @returns {Promise<void>}
+     * @protected
+     */
+    async resumeHarness(identity, reason, originSessionId, abandonedCount) {
+        return resumeHarnessScript(identity, reason, originSessionId, abandonedCount)
+    }
+
+    /**
+     * Test-stubbable seam over `idleOutNudge.mjs`'s dual-mode module export.
+     * @param {String} identity
+     * @returns {Promise<void>}
+     * @protected
+     */
+    async idleOutNudge(identity) {
+        return idleOutNudgeScript(identity)
+    }
+
+    /**
+     * Test-stubbable seam over `checkAllAgentIdle.mjs`'s dual-mode module export.
+     * @param {String} cycleId
+     * @returns {Promise<Object|null>}
+     * @protected
+     */
+    async checkAllAgentIdle(cycleId) {
+        try {
+            return await checkAllAgentIdleScript(cycleId)
+        } catch (err) {
+            logger.error('[SwarmHeartbeatService] checkAllAgentIdle.mjs failed:', err.message);
+            return null
+        }
+    }
+
+    /**
+     * Test-stubbable seam over `trioWakeCooldown.mjs`'s dual-mode module export.
+     * @param {Object} signal
+     * @returns {Promise<Object|void>}
+     * @protected
+     */
+    async trioWakeCooldown(signal) {
+        return trioWakeCooldownScript(signal)
     }
 
     /**
@@ -456,8 +524,7 @@ class SwarmHeartbeatService extends Base {
 
     /**
      * Spawn a node subprocess for the named script and return its stdout.
-     * Used for CLI-shape recovery scripts that haven't been refactored to
-     * dual-mode export (#10795).
+     * Preserved for external command wrappers and any future CLI-only utilities.
      * @param {String} scriptName Name of script under `ai/scripts/`
      * @param {String[]} [args=[]]
      * @returns {Promise<String>} stdout content

--- a/ai/scripts/checkAllAgentIdle.mjs
+++ b/ai/scripts/checkAllAgentIdle.mjs
@@ -19,16 +19,22 @@
  */
 import Neo from '../../src/Neo.mjs';
 import * as core from '../../src/core/_export.mjs';
+import path from 'path';
+import { fileURLToPath } from 'url';
 import LifecycleService from '../services/memory-core/lifecycle/SystemLifecycleService.mjs';
 import GraphService from '../services/memory-core/GraphService.mjs';
 import { checkInflightLock } from './inflightLock.mjs';
 
-async function main() {
+/**
+ * @summary Compute whether every configured trio identity is past the idle threshold.
+ * @param {String} [cycleId] Stable heartbeat cycle identifier.
+ * @returns {Promise<Object>} All-agent-idle detector signal.
+ */
+export async function checkAllAgentIdle(cycleId = Math.floor(Date.now() / 1000).toString()) {
     await LifecycleService.initAsync();
     await GraphService.initAsync();
     const db = GraphService.db.storage.db;
 
-    const cycleId = process.argv[2] || Math.floor(Date.now() / 1000).toString();
     const identitiesEnv = process.env.NEO_TRIO_IDENTITIES || '@neo-gemini-3-1-pro,@neo-opus-4-7,@neo-gpt';
     const identities = identitiesEnv.split(',').map(s => s.trim()).filter(Boolean);
 
@@ -108,11 +114,20 @@ async function main() {
         details
     };
 
-    console.log(JSON.stringify(signal));
-    process.exit(0);
+    return signal;
 }
 
-main().catch(err => {
-    console.error('checkAllAgentIdle failed:', err.message);
-    process.exit(1);
-});
+async function main() {
+    const cycleId = process.argv[2] || Math.floor(Date.now() / 1000).toString();
+    const signal = await checkAllAgentIdle(cycleId);
+    console.log(JSON.stringify(signal));
+}
+
+const isMain = process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url);
+
+if (isMain) {
+    main().catch(err => {
+        console.error('checkAllAgentIdle failed:', err.message);
+        process.exit(1);
+    });
+}

--- a/ai/scripts/checkSunsetted.mjs
+++ b/ai/scripts/checkSunsetted.mjs
@@ -60,6 +60,8 @@
  */
 import Neo from '../../src/Neo.mjs';
 import * as core from '../../src/core/_export.mjs';
+import path from 'path';
+import { fileURLToPath } from 'url';
 import LifecycleService from '../services/memory-core/lifecycle/SystemLifecycleService.mjs';
 import GraphService from '../services/memory-core/GraphService.mjs';
 import { checkInflightLock } from './inflightLock.mjs';
@@ -71,15 +73,17 @@ import { checkInflightLock } from './inflightLock.mjs';
  */
 const IDLE_THRESHOLD_MS = parseInt(process.env.IDLE_THRESHOLD_MS, 10) || 10 * 60 * 1000;
 
-async function main() {
+/**
+ * @summary Compute the sunset / idle-out detector payload for one agent identity.
+ * @param {String} [identity] Agent identity to inspect.
+ * @returns {Promise<Object>} Structured detector contract consumed by shell and daemon paths.
+ */
+export async function checkSunsetted(identity = process.env.NEO_AGENT_IDENTITY || '@neo-gemini-3-1-pro') {
     await LifecycleService.initAsync();
 
     // Ensure GraphService is initialized
     await GraphService.initAsync();
     const db = GraphService.db.storage.db;
-
-    // Target identity for Phase 1/2
-    const identity = process.argv[2] || process.env.NEO_AGENT_IDENTITY || '@neo-gemini-3-1-pro';
 
     // 1. Query ALL subscriptions for this identity (regardless of status) so the
     //    detector can emit a structured `subscription_status` field rather than
@@ -229,7 +233,7 @@ async function main() {
     //    (#10673 AC5) preserve `sunsetted` / `reason` / `originSessionId` /
     //    `abandonedCount` for consumers not yet migrated to the new shape.
     //    `swarm-heartbeat.sh` jq parsing reads these legacy fields today.
-    console.log(JSON.stringify({
+    return {
         identity,
         sunset,
         idle_out_candidate: idleOutCandidate,
@@ -246,11 +250,20 @@ async function main() {
         reason,
         originSessionId,
         abandonedCount: lockData?.abandonedCount || 0
-    }));
-    process.exit(0);
+    };
 }
 
-main().catch(err => {
-    console.error('checkSunsetted failed:', err.message);
-    process.exit(1);
-});
+async function main() {
+    const identity = process.argv[2] || process.env.NEO_AGENT_IDENTITY || '@neo-gemini-3-1-pro';
+    const result = await checkSunsetted(identity);
+    console.log(JSON.stringify(result));
+}
+
+const isMain = process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url);
+
+if (isMain) {
+    main().catch(err => {
+        console.error('checkSunsetted failed:', err.message);
+        process.exit(1);
+    });
+}

--- a/ai/scripts/idleOutNudge.mjs
+++ b/ai/scripts/idleOutNudge.mjs
@@ -55,6 +55,8 @@
  */
 import Neo                       from '../../src/Neo.mjs';
 import * as core                 from '../../src/core/_export.mjs';
+import path                      from 'path';
+import {fileURLToPath}           from 'url';
 import LifecycleService          from '../services/memory-core/lifecycle/SystemLifecycleService.mjs';
 import GraphService              from '../services/memory-core/GraphService.mjs';
 import MailboxService            from '../services/memory-core/MailboxService.mjs';
@@ -89,7 +91,7 @@ const NUDGE_BODY_TEMPLATE = (identity) =>
  * @param {string} identity Target agent identity (e.g., '@neo-opus-4-7').
  * @returns {Promise<void>}
  */
-async function idleOutNudge(identity) {
+export async function idleOutNudge(identity) {
     // 1. Wake safety gate (#10648). Fail-closed; operator override via WAKE_GATE_OVERRIDE=1.
     if (hasOverride()) {
         console.error('[OVERRIDE] WAKE_GATE_OVERRIDE set; bypassing wake safety gate for idleOutNudge.');
@@ -147,18 +149,26 @@ async function idleOutNudge(identity) {
         //    nudges for this identity for the full BOOT_TIMEOUT_MS window.
         console.error(`[idleOutNudge] Failed to send nudge to ${identity}: ${err.message}`);
         await clearInflightLock(identity, 'idle_out_nudge').catch(() => {});
-        process.exit(1);
+        throw err;
     }
 }
 
-const identity = process.argv[2];
+async function main() {
+    const identity = process.argv[2];
 
-if (!identity) {
-    console.error('Usage: idleOutNudge.mjs <identity>');
-    process.exit(1);
+    if (!identity) {
+        console.error('Usage: idleOutNudge.mjs <identity>');
+        process.exit(1);
+    }
+
+    await idleOutNudge(identity);
 }
 
-idleOutNudge(identity).catch(err => {
-    console.error('idleOutNudge unexpected error:', err.message);
-    process.exit(1);
-});
+const isMain = process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url);
+
+if (isMain) {
+    main().catch(err => {
+        console.error('idleOutNudge unexpected error:', err.message);
+        process.exit(1);
+    });
+}

--- a/ai/scripts/resumeHarness.mjs
+++ b/ai/scripts/resumeHarness.mjs
@@ -26,7 +26,8 @@ import { readGateState, hasOverride } from './wakeSafetyGate.mjs';
 import { writeInflightLock, clearInflightLock } from './inflightLock.mjs';
 import { recordHarnessProcess, terminatePreviousHarness } from './harnessLifecycle.mjs';
 
-const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const __filename = fileURLToPath(import.meta.url);
+const __dirname  = path.dirname(__filename);
 
 /**
  * @summary Spawn a child process and (optionally) record its PID for later harness cleanup.
@@ -157,7 +158,15 @@ function buildBootGroundingPrompt(identity, reason, originSessionId) {
     ].join(' ');
 }
 
-async function resumeHarness(identity, reason, originSessionId, abandonedCount = 0) {
+/**
+ * @summary Resume a sunsetted agent by dispatching the configured fresh-session harness adapter.
+ * @param {String} identity Agent identity to resume.
+ * @param {String} reason Human-readable recovery reason.
+ * @param {String} originSessionId Prior Memory Core session anchor, if known.
+ * @param {Number} [abandonedCount=0] Prior abandoned wake action count for lock bookkeeping.
+ * @returns {Promise<void>}
+ */
+export async function resumeHarness(identity, reason, originSessionId, abandonedCount = 0) {
     // Wake safety gate (#10648, child of #10647). Direct fresh-session-spawn
     // invocations must also fail-closed when the substrate is unsafe — the
     // gate is consulted alongside (and ahead of) the existing cooldown. The
@@ -228,8 +237,7 @@ async function resumeHarness(identity, reason, originSessionId, abandonedCount =
     const harnessTarget = targetId ? HARNESS_REGISTRY[targetId] : null;
 
     if (!harnessTarget) {
-        console.error(`Unknown harness target for identity: ${identity}`);
-        process.exit(1);
+        throw new Error(`Unknown harness target for identity: ${identity}`);
     }
 
     const adapter = process.platform === 'darwin' ? harnessTarget.adapter : 'tmux';
@@ -406,21 +414,29 @@ async function resumeHarness(identity, reason, originSessionId, abandonedCount =
     } catch (err) {
         console.error(`Failed to resume ${identity} via ${adapter}: ${err.message}`);
         await clearInflightLock(identity, 'sunset_restart');
-        process.exit(1);
+        throw err;
     }
 }
 
-const identity        = process.argv[2];
-const reason          = process.argv[3] || 'Scheduled interval recovery';
-const originSessionId = process.argv[4] || ''; // Optional; populated by checkSunsetted post-#10611
-const abandonedCount  = parseInt(process.argv[5], 10) || 0;
+async function main() {
+    const identity        = process.argv[2];
+    const reason          = process.argv[3] || 'Scheduled interval recovery';
+    const originSessionId = process.argv[4] || ''; // Optional; populated by checkSunsetted post-#10611
+    const abandonedCount  = parseInt(process.argv[5], 10) || 0;
 
-if (!identity) {
-    console.error('Usage: resumeHarness.mjs <identity> [reason] [originSessionId] [abandonedCount]');
-    process.exit(1);
+    if (!identity) {
+        console.error('Usage: resumeHarness.mjs <identity> [reason] [originSessionId] [abandonedCount]');
+        process.exit(1);
+    }
+
+    await resumeHarness(identity, reason, originSessionId, abandonedCount);
 }
 
-resumeHarness(identity, reason, originSessionId, abandonedCount).catch(err => {
-    console.error('Unexpected error:', err.message);
-    process.exit(1);
-});
+const isMain = process.argv[1] && path.resolve(process.argv[1]) === __filename;
+
+if (isMain) {
+    main().catch(err => {
+        console.error('Unexpected error:', err.message);
+        process.exit(1);
+    });
+}

--- a/ai/scripts/trioWakeCooldown.mjs
+++ b/ai/scripts/trioWakeCooldown.mjs
@@ -7,6 +7,7 @@
  */
 import fs from 'fs-extra';
 import path from 'path';
+import {fileURLToPath} from 'url';
 import Neo from '../../src/Neo.mjs';
 import * as core from '../../src/core/_export.mjs';
 import { withHeartbeatLock } from './heartbeatLock.mjs';
@@ -19,23 +20,20 @@ import { writeInflightLock, clearInflightLock } from './inflightLock.mjs';
 const COOLDOWN_STATE_PATH = '.neo-ai-data/wake-daemon/trio-wake-cooldown.json';
 const COOLDOWN_LOCK_PATH = '.neo-ai-data/wake-daemon/trio-wake-cooldown.lock';
 
-async function main() {
-    const rawSignal = process.argv[2];
-    if (!rawSignal) return;
-
-    let signal;
-    try {
-        signal = JSON.parse(rawSignal);
-    } catch (err) {
-        console.error('trioWakeCooldown: Failed to parse signal:', err.message);
-        process.exit(1);
+/**
+ * @summary Dispatch the cooldown-bounded swarm-wide wake for an all-agent-idle signal.
+ * @param {Object} signal All-agent-idle detector signal.
+ * @returns {Promise<Object|void>} Dispatch outcome when the heartbeat lock implementation returns it.
+ */
+export async function trioWakeCooldown(signal) {
+    if (!signal) {
+        return {fired: false, reason: 'missing-signal'};
     }
-
     if (signal.allIdle !== true) {
-        return;
+        return {fired: false, reason: 'not-all-idle'};
     }
 
-    await withHeartbeatLock(async () => {
+    return withHeartbeatLock(async () => {
         // Enforce 10-minute (600s) default TTL to match swarm consensus (Regression Fix: #10626 vs 30m flaw)
         const ttlSeconds = parseInt(process.env.TRIO_WAKE_COOLDOWN_SECONDS, 10) || 600;
         const ttlMs = ttlSeconds * 1000;
@@ -52,7 +50,7 @@ async function main() {
         // If we are within the TTL window, suppress the wake
         if (timeSinceLastFire < ttlMs) {
             console.error(`[trioWakeCooldown] Suppressed: within TTL window (${ttlSeconds}s) since last wake.`);
-            return;
+            return {fired: false, reason: 'cooldown', ttlSeconds};
         }
 
         console.error(`[trioWakeCooldown] Firing SYSTEM WAKE for cycle ${signal.cycle_id} to ${signal.coordinator_recommendation}`);
@@ -93,10 +91,30 @@ async function main() {
         await fs.ensureDir(path.dirname(COOLDOWN_STATE_PATH));
         await fs.writeJson(COOLDOWN_STATE_PATH, state, { spaces: 2 });
 
+        return {fired: true, coordinator, cycle_id: signal.cycle_id};
     }, { lockPath: COOLDOWN_LOCK_PATH });
 }
 
-main().catch(err => {
-    console.error('trioWakeCooldown failed:', err.stack);
-    process.exit(1);
-});
+async function main() {
+    const rawSignal = process.argv[2];
+    if (!rawSignal) return;
+
+    let signal;
+    try {
+        signal = JSON.parse(rawSignal);
+    } catch (err) {
+        console.error('trioWakeCooldown: Failed to parse signal:', err.message);
+        process.exit(1);
+    }
+
+    await trioWakeCooldown(signal);
+}
+
+const isMain = process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url);
+
+if (isMain) {
+    main().catch(err => {
+        console.error('trioWakeCooldown failed:', err.stack);
+        process.exit(1);
+    });
+}

--- a/test/playwright/unit/ai/daemons/SwarmHeartbeatService.spec.mjs
+++ b/test/playwright/unit/ai/daemons/SwarmHeartbeatService.spec.mjs
@@ -32,8 +32,9 @@ import {test, expect} from '@playwright/test';
  *
  * Stubbing strategy: SwarmHeartbeatService exposes test-stubbable instance-method seams
  * (`checkHeartbeatLock`, `clearHeartbeatLock`, `sweepExpiredTasks`, `checkGateOpen`,
- * `readGate`, `runScript`, `runScriptJson`, `runCmd`, `getUnreadCount`, `getIssuesCount`,
- * `isPushCapable`, `injectTmux`) precisely so unit tests can override them without going
+ * `readGate`, `checkSunsetted`, `resumeHarness`, `idleOutNudge`, `checkAllAgentIdle`,
+ * `trioWakeCooldown`, `runScript`, `runScriptJson`, `runCmd`, `getUnreadCount`,
+ * `getIssuesCount`, `isPushCapable`, `injectTmux`) precisely so unit tests can override them without going
  * through the heavy substrate. Module-binding imports (e.g. `isGateOpen`) cannot be
  * reassigned at import-site in ES modules — instance methods are the seam that works.
  *
@@ -77,6 +78,11 @@ test.describe('Neo.ai.daemons.SwarmHeartbeatService', () => {
         SwarmHeartbeatService.sweepExpiredTasks  = async () => ({sweptCount: 0});
         SwarmHeartbeatService.checkGateOpen      = async () => true;
         SwarmHeartbeatService.readGate           = async () => ({state: 'enabled', reason: '', trippedAt: null, trippedBy: null});
+        SwarmHeartbeatService.checkSunsetted     = async () => null;
+        SwarmHeartbeatService.resumeHarness      = async () => {};
+        SwarmHeartbeatService.idleOutNudge       = async () => {};
+        SwarmHeartbeatService.checkAllAgentIdle  = async () => null;
+        SwarmHeartbeatService.trioWakeCooldown   = async () => {};
         SwarmHeartbeatService.runScriptJson      = async () => null;
         SwarmHeartbeatService.runScript          = async () => '';
         SwarmHeartbeatService.runCmd             = async () => '[]';
@@ -180,107 +186,110 @@ test.describe('Neo.ai.daemons.SwarmHeartbeatService', () => {
         SwarmHeartbeatService.checkGateOpen = async () => false;
         SwarmHeartbeatService.readGate      = async () => ({state: 'tripped', reason: 'test-tripped', trippedAt: null, trippedBy: 'test'});
 
-        const dispatched = [];
-        SwarmHeartbeatService.runScriptJson = async (name) => {
-            if (name === 'checkSunsetted.mjs') {
-                return {
-                    sunsetted          : true,
-                    reason             : 'No active WAKE_SUBSCRIPTION',
-                    originSessionId    : 'sid-123',
-                    abandonedCount     : 0,
-                    recommended_action : 'sunset_restart'
-                };
-            }
-            return null;
+        const resumeCalls = [];
+        SwarmHeartbeatService.checkSunsetted = async () => {
+            return {
+                sunsetted          : true,
+                reason             : 'No active WAKE_SUBSCRIPTION',
+                originSessionId    : 'sid-123',
+                abandonedCount     : 0,
+                recommended_action : 'sunset_restart'
+            };
         };
-        SwarmHeartbeatService.runScript = async (name, args) => { dispatched.push({name, args}); return '' };
+        SwarmHeartbeatService.resumeHarness = async (...args) => { resumeCalls.push(args) };
 
         await SwarmHeartbeatService.pulse();
 
         // Gate closed → no resumeHarness dispatch.
-        const resumeCalls = dispatched.filter(d => d.name === 'resumeHarness.mjs');
         expect(resumeCalls.length).toBe(0);
     });
 
     test('pulse() routes sunset to resumeHarness when gate is open', async () => {
         applyDefaultStubs();
-        const dispatched = [];
-        SwarmHeartbeatService.runScriptJson = async (name) => {
-            if (name === 'checkSunsetted.mjs') {
-                return {
-                    sunsetted          : true,
-                    reason             : 'Subscription missing',
-                    originSessionId    : 'sid-456',
-                    abandonedCount     : 2,
-                    recommended_action : 'sunset_restart'
-                };
-            }
-            return null;
+        const resumeCalls = [];
+        SwarmHeartbeatService.checkSunsetted = async () => {
+            return {
+                sunsetted          : true,
+                reason             : 'Subscription missing',
+                originSessionId    : 'sid-456',
+                abandonedCount     : 2,
+                recommended_action : 'sunset_restart'
+            };
         };
-        SwarmHeartbeatService.runScript = async (name, args) => { dispatched.push({name, args}); return '' };
+        SwarmHeartbeatService.resumeHarness = async (...args) => { resumeCalls.push(args) };
 
         await SwarmHeartbeatService.pulse();
 
-        const resumeCalls = dispatched.filter(d => d.name === 'resumeHarness.mjs');
         expect(resumeCalls.length).toBe(1);
-        expect(resumeCalls[0].args).toEqual(['@test', 'Subscription missing', 'sid-456', '2']);
+        expect(resumeCalls[0]).toEqual(['@test', 'Subscription missing', 'sid-456', 2]);
     });
 
     test('pulse() routes idle_out_nudge when gate is open and recommendation matches', async () => {
         applyDefaultStubs();
-        const dispatched = [];
-        SwarmHeartbeatService.runScriptJson = async (name) => {
-            if (name === 'checkSunsetted.mjs') {
-                return {
-                    sunsetted          : false,
-                    recommended_action : 'idle_out_nudge'
-                };
-            }
-            return null;
+        const nudgeCalls = [];
+        SwarmHeartbeatService.checkSunsetted = async () => {
+            return {
+                sunsetted          : false,
+                recommended_action : 'idle_out_nudge'
+            };
         };
-        SwarmHeartbeatService.runScript = async (name, args) => { dispatched.push({name, args}); return '' };
+        SwarmHeartbeatService.idleOutNudge = async (...args) => { nudgeCalls.push(args) };
 
         await SwarmHeartbeatService.pulse();
 
-        const nudgeCalls = dispatched.filter(d => d.name === 'idleOutNudge.mjs');
         expect(nudgeCalls.length).toBe(1);
-        expect(nudgeCalls[0].args).toEqual(['@test']);
+        expect(nudgeCalls[0]).toEqual(['@test']);
     });
 
     test('pulse() skips idle_out_nudge when gate is closed', async () => {
         applyDefaultStubs();
         SwarmHeartbeatService.checkGateOpen = async () => false;
 
-        const dispatched = [];
-        SwarmHeartbeatService.runScriptJson = async (name) => {
-            if (name === 'checkSunsetted.mjs') {
-                return {sunsetted: false, recommended_action: 'idle_out_nudge'};
-            }
-            return null;
-        };
-        SwarmHeartbeatService.runScript = async (name, args) => { dispatched.push({name, args}); return '' };
+        const nudgeCalls = [];
+        SwarmHeartbeatService.checkSunsetted = async () => ({sunsetted: false, recommended_action: 'idle_out_nudge'});
+        SwarmHeartbeatService.idleOutNudge   = async (...args) => { nudgeCalls.push(args) };
 
         await SwarmHeartbeatService.pulse();
 
-        const nudgeCalls = dispatched.filter(d => d.name === 'idleOutNudge.mjs');
         expect(nudgeCalls.length).toBe(0);
     });
 
     test('pulse() routes allIdle to trioWakeCooldown when gate is open', async () => {
         applyDefaultStubs();
-        const dispatched = [];
-        SwarmHeartbeatService.runScriptJson = async (name) => {
-            if (name === 'checkAllAgentIdle.mjs') return {allIdle: true, cycle_id: '1', identities: ['@a', '@b']};
-            return null;
-        };
-        SwarmHeartbeatService.runScript = async (name, args) => { dispatched.push({name, args}); return '' };
+        const trioCalls = [];
+        SwarmHeartbeatService.checkAllAgentIdle = async () => ({allIdle: true, cycle_id: '1', identities: ['@a', '@b']});
+        SwarmHeartbeatService.trioWakeCooldown  = async (signal) => { trioCalls.push(signal) };
 
         await SwarmHeartbeatService.pulse();
 
-        const trioCalls = dispatched.filter(d => d.name === 'trioWakeCooldown.mjs');
         expect(trioCalls.length).toBe(1);
-        // arg[0] is the JSON-stringified signal
-        expect(JSON.parse(trioCalls[0].args[0]).allIdle).toBe(true);
+        expect(trioCalls[0].allIdle).toBe(true);
+    });
+
+    test('pulse() does not subprocess-dispatch converted dual-mode wake scripts', async () => {
+        applyDefaultStubs();
+        const sunsetCalls = [];
+        const idleCalls = [];
+
+        SwarmHeartbeatService.checkSunsetted = async (identity) => {
+            sunsetCalls.push(identity);
+            return {sunsetted: false, recommended_action: 'no_action'};
+        };
+        SwarmHeartbeatService.checkAllAgentIdle = async (cycleId) => {
+            idleCalls.push(cycleId);
+            return {allIdle: false};
+        };
+        SwarmHeartbeatService.runScript = async () => {
+            throw new Error('runScript should not be called for converted wake scripts');
+        };
+        SwarmHeartbeatService.runScriptJson = async () => {
+            throw new Error('runScriptJson should not be called for converted wake scripts');
+        };
+
+        await SwarmHeartbeatService.pulse();
+
+        expect(sunsetCalls).toEqual(['@test']);
+        expect(idleCalls.length).toBe(1);
     });
 
     test('pulse() reschedules from finally block even when sweep throws', async () => {

--- a/test/playwright/unit/ai/scripts/wakeDualModeExports.spec.mjs
+++ b/test/playwright/unit/ai/scripts/wakeDualModeExports.spec.mjs
@@ -1,0 +1,50 @@
+import {setup} from '../../../setup.mjs';
+
+const appName = 'WakeDualModeExportsTest';
+
+setup({
+    neoConfig: {
+        unitTestMode: true
+    },
+    appConfig: {
+        name             : appName,
+        isMounted        : () => true,
+        vnodeInitialising: false
+    }
+});
+
+import Neo       from '../../../../../src/Neo.mjs';
+import * as core from '../../../../../src/core/_export.mjs';
+
+import {test, expect} from '@playwright/test';
+
+/**
+ * @summary Dual-mode export smoke coverage for the wake scripts converted by #10795.
+ *
+ * Importing these modules must expose callable functions without executing their CLI
+ * wrappers, so `SwarmHeartbeatService` can use the same logic directly while
+ * `swarm-heartbeat.sh` keeps its existing command-line contract.
+ */
+test.describe('ai/scripts wake dual-mode exports', () => {
+    test('converted wake scripts expose function entrypoints without running CLI wrappers', async () => {
+        const [
+            sunsetModule,
+            resumeModule,
+            allIdleModule,
+            nudgeModule,
+            trioModule
+        ] = await Promise.all([
+            import('../../../../../ai/scripts/checkSunsetted.mjs'),
+            import('../../../../../ai/scripts/resumeHarness.mjs'),
+            import('../../../../../ai/scripts/checkAllAgentIdle.mjs'),
+            import('../../../../../ai/scripts/idleOutNudge.mjs'),
+            import('../../../../../ai/scripts/trioWakeCooldown.mjs')
+        ]);
+
+        expect(typeof sunsetModule.checkSunsetted).toBe('function');
+        expect(typeof resumeModule.resumeHarness).toBe('function');
+        expect(typeof allIdleModule.checkAllAgentIdle).toBe('function');
+        expect(typeof nudgeModule.idleOutNudge).toBe('function');
+        expect(typeof trioModule.trioWakeCooldown).toBe('function');
+    });
+});


### PR DESCRIPTION
Resolves #10795

Authored by GPT-5 (Codex Desktop). Session 019e4c2e-c7aa-72a2-b0bc-58c0996c63f3.
FAIR-band: in-band [15/30]

Converts the five wake-substrate CLI scripts named by #10795 into dual-mode modules: each keeps its existing command-line wrapper while exposing a callable module entrypoint. `SwarmHeartbeatService` now calls those exports directly for sunset detection, resume dispatch, idle-out nudges, all-agent-idle detection, and trio wake cooldown dispatch, while retaining the generic subprocess seams for external commands and future CLI-only utilities.

Evidence: L2 (focused Neo unit specs, existing CLI-wrapper specs with CI-style substrate skips, syntax checks, and diff hygiene) -> L2 required (ticket ACs require module-export routing plus unit coverage). No residuals.

Related: #10671

## Deltas from ticket
- Preserved the old detector failure tolerance from `runScriptJson()` on the direct-import seams: detector failures log and return `null` so one detector error does not kill the heartbeat loop.
- Action dispatch exports (`resumeHarness`, `idleOutNudge`) throw in module mode and let their CLI wrappers retain process-exit behavior.

## Structural Pre-Flight
- New `.mjs` test file fast-path: `test/playwright/unit/ai/scripts/wakeDualModeExports.spec.mjs` follows the existing sibling pattern in `test/playwright/unit/ai/scripts/` (`checkSunsetted.spec.mjs`, `idleOutNudge.spec.mjs`, `trioWakeCooldown.spec.mjs`). No novel directory choice or architecture-map update needed.

## Test Evidence
- `node --check ai/scripts/checkSunsetted.mjs`
- `node --check ai/scripts/checkAllAgentIdle.mjs`
- `node --check ai/scripts/idleOutNudge.mjs`
- `node --check ai/scripts/resumeHarness.mjs`
- `node --check ai/scripts/trioWakeCooldown.mjs`
- `node --check ai/daemons/SwarmHeartbeatService.mjs`
- `node --check test/playwright/unit/ai/daemons/SwarmHeartbeatService.spec.mjs`
- `node --check test/playwright/unit/ai/scripts/wakeDualModeExports.spec.mjs`
- `npm run test-unit -- test/playwright/unit/ai/scripts/wakeDualModeExports.spec.mjs test/playwright/unit/ai/daemons/SwarmHeartbeatService.spec.mjs` -> 16 passed
- `env NEO_TEST_SKIP_CI=true npm run test-unit -- test/playwright/unit/ai/scripts/checkSunsetted.spec.mjs test/playwright/unit/ai/scripts/checkAllAgentIdle.spec.mjs test/playwright/unit/ai/scripts/idleOutNudge.spec.mjs test/playwright/unit/ai/scripts/resumeHarness.spec.mjs test/playwright/unit/ai/scripts/trioWakeCooldown.spec.mjs` -> 26 passed, 18 skipped
- `git diff --check`
- `git diff --cached --check`

## Post-Merge Validation
- [ ] Persistent heartbeat daemon logs show the converted wake paths executing without `node ai/scripts/*.mjs` subprocess hops.

## Commit
- `63301e50f` — `feat(ai): convert wake scripts to dual-mode exports (#10795)`
