### PR TITLE
fix(ai): derive all-idle cycle id from state (#10633)

### DIFF
--- a/ai/daemons/SwarmHeartbeatService.mjs
+++ b/ai/daemons/SwarmHeartbeatService.mjs
@@ -259,9 +259,9 @@ class SwarmHeartbeatService extends Base {
                 return
             }
 
-            // Step 4: All-agent-idle detection (direct module export; CLI wrapper preserved for shell consumers).
-            const cycleId = String(Math.floor(Date.now() / 1000));
-            const allIdleJson = await this.checkAllAgentIdle(cycleId);
+            // Step 4: All-agent-idle detection. `checkAllAgentIdle.mjs` owns the
+            // logical cycle id so the cooldown key remains stable across pulses.
+            const allIdleJson = await this.checkAllAgentIdle();
             if (allIdleJson?.allIdle) {
                 logger.info(`[SwarmHeartbeatService] AllAgentIdle detected: ${JSON.stringify(allIdleJson)}`);
                 if (!await this.checkGateOpen()) {
@@ -384,13 +384,12 @@ class SwarmHeartbeatService extends Base {
 
     /**
      * Test-stubbable seam over `checkAllAgentIdle.mjs`'s dual-mode module export.
-     * @param {String} cycleId
      * @returns {Promise<Object|null>}
      * @protected
      */
-    async checkAllAgentIdle(cycleId) {
+    async checkAllAgentIdle() {
         try {
-            return await checkAllAgentIdleScript(cycleId)
+            return await checkAllAgentIdleScript()
         } catch (err) {
             logger.error('[SwarmHeartbeatService] checkAllAgentIdle.mjs failed:', err.message);
             return null

--- a/ai/scripts/checkAllAgentIdle.mjs
+++ b/ai/scripts/checkAllAgentIdle.mjs
@@ -19,6 +19,7 @@
  */
 import Neo from '../../src/Neo.mjs';
 import * as core from '../../src/core/_export.mjs';
+import { createHash } from 'crypto';
 import path from 'path';
 import { fileURLToPath } from 'url';
 import LifecycleService from '../services/memory-core/lifecycle/SystemLifecycleService.mjs';
@@ -26,11 +27,31 @@ import GraphService from '../services/memory-core/GraphService.mjs';
 import { checkInflightLock } from './inflightLock.mjs';
 
 /**
+ * @summary Derive a logical all-agent-idle cycle id from the observed identity state.
+ * @param {String[]} identities Configured agent identities.
+ * @param {Object<String, {lastMemTime: ?String, inFlightNudge: Boolean}>} details Per-identity idle details.
+ * @returns {String}
+ */
+export function deriveAllAgentIdleCycleId(identities, details) {
+    const stateKey = [...identities].sort().map(identity => {
+        const detail  = details[identity] || {};
+        const lastMem = detail.lastMemTime || 'never';
+        const nudge   = detail.inFlightNudge ? 'in-flight' : 'clear';
+
+        return `${identity}:${lastMem}:${nudge}`
+    }).join('|');
+
+    return createHash('sha256')
+        .update(stateKey)
+        .digest('hex')
+        .slice(0, 16)
+}
+
+/**
  * @summary Compute whether every configured trio identity is past the idle threshold.
- * @param {String} [cycleId] Stable heartbeat cycle identifier.
  * @returns {Promise<Object>} All-agent-idle detector signal.
  */
-export async function checkAllAgentIdle(cycleId = Math.floor(Date.now() / 1000).toString()) {
+export async function checkAllAgentIdle() {
     await LifecycleService.initAsync();
     await GraphService.initAsync();
     const db = GraphService.db.storage.db;
@@ -106,6 +127,8 @@ export async function checkAllAgentIdle(cycleId = Math.floor(Date.now() / 1000).
         }
     }
 
+    const cycleId = deriveAllAgentIdleCycleId(identities, details);
+
     const signal = {
         allIdle,
         cycle_id: cycleId,
@@ -118,8 +141,7 @@ export async function checkAllAgentIdle(cycleId = Math.floor(Date.now() / 1000).
 }
 
 async function main() {
-    const cycleId = process.argv[2] || Math.floor(Date.now() / 1000).toString();
-    const signal = await checkAllAgentIdle(cycleId);
+    const signal = await checkAllAgentIdle();
     console.log(JSON.stringify(signal));
 }
 

--- a/ai/scripts/swarm-heartbeat.sh
+++ b/ai/scripts/swarm-heartbeat.sh
@@ -204,8 +204,7 @@ heartbeat_pulse() {
         fi
 
         # All-agent-idle detection (Phase 3 Substrate Primitive #10625)
-        local cycle_id=$(date +%s)
-        local all_idle_json=$(node "${script_dir}/checkAllAgentIdle.mjs" "$cycle_id" 2>>"$SWEEP_LOG")
+        local all_idle_json=$(node "${script_dir}/checkAllAgentIdle.mjs" 2>>"$SWEEP_LOG")
         if [ $? -eq 0 ] && [ -n "$all_idle_json" ]; then
             local is_all_idle=$(echo "$all_idle_json" | jq -r '.allIdle')
             if [ "$is_all_idle" = "true" ]; then

--- a/test/playwright/unit/ai/daemons/SwarmHeartbeatService.spec.mjs
+++ b/test/playwright/unit/ai/daemons/SwarmHeartbeatService.spec.mjs
@@ -275,8 +275,8 @@ test.describe('Neo.ai.daemons.SwarmHeartbeatService', () => {
             sunsetCalls.push(identity);
             return {sunsetted: false, recommended_action: 'no_action'};
         };
-        SwarmHeartbeatService.checkAllAgentIdle = async (cycleId) => {
-            idleCalls.push(cycleId);
+        SwarmHeartbeatService.checkAllAgentIdle = async (...args) => {
+            idleCalls.push(args);
             return {allIdle: false};
         };
         SwarmHeartbeatService.runScript = async () => {
@@ -289,7 +289,7 @@ test.describe('Neo.ai.daemons.SwarmHeartbeatService', () => {
         await SwarmHeartbeatService.pulse();
 
         expect(sunsetCalls).toEqual(['@test']);
-        expect(idleCalls.length).toBe(1);
+        expect(idleCalls).toEqual([[]]);
     });
 
     test('pulse() reschedules from finally block even when sweep throws', async () => {

--- a/test/playwright/unit/ai/scripts/checkAllAgentIdle.spec.mjs
+++ b/test/playwright/unit/ai/scripts/checkAllAgentIdle.spec.mjs
@@ -19,6 +19,7 @@ import {execFileSync} from 'child_process';
 import path           from 'path';
 import Neo            from '../../../../../src/Neo.mjs';
 import * as core      from '../../../../../src/core/_export.mjs';
+import {deriveAllAgentIdleCycleId} from '../../../../../ai/scripts/checkAllAgentIdle.mjs';
 
 /**
  * @summary Validation for Phase 3 Substrate Primitive #10625: All-Agent-Idle Detection.
@@ -55,7 +56,7 @@ test.describe('ai/scripts/checkAllAgentIdle', () => {
 
         // 2. Execute script
         const scriptPath = path.resolve(process.cwd(), 'ai/scripts/checkAllAgentIdle.mjs');
-        const output = execFileSync('node', [scriptPath, '12345'], {
+        const output = execFileSync('node', [scriptPath], {
             encoding: 'utf-8',
             env: { 
                 ...process.env, 
@@ -68,7 +69,19 @@ test.describe('ai/scripts/checkAllAgentIdle', () => {
 
         // 3. Assert positive signal
         expect(parsed.allIdle).toBe(true);
-        expect(parsed.cycle_id).toBe('12345');
+        expect(parsed.cycle_id).toBe(deriveAllAgentIdleCycleId(
+            ['@neo-test-agent-1', '@neo-test-agent-2'],
+            {
+                '@neo-test-agent-1': {
+                    lastMemTime   : oldTime,
+                    inFlightNudge : false
+                },
+                '@neo-test-agent-2': {
+                    lastMemTime   : oldTime,
+                    inFlightNudge : false
+                }
+            }
+        ));
         expect(parsed.identities.length).toBe(2);
         expect(parsed.details['@neo-test-agent-1'].ageMs).toBeGreaterThan(600000);
         expect(parsed.details['@neo-test-agent-2'].ageMs).toBeGreaterThan(600000);
@@ -107,7 +120,7 @@ test.describe('ai/scripts/checkAllAgentIdle', () => {
 
         // 2. Execute script
         const scriptPath = path.resolve(process.cwd(), 'ai/scripts/checkAllAgentIdle.mjs');
-        const output = execFileSync('node', [scriptPath, '12346'], {
+        const output = execFileSync('node', [scriptPath], {
             encoding: 'utf-8',
             env: { 
                 ...process.env, 
@@ -126,7 +139,7 @@ test.describe('ai/scripts/checkAllAgentIdle', () => {
     test('checkAllAgentIdle.mjs treats boundary condition (no AGENT_MEMORY rows) as fully idle', async () => {
         // Execute script with an entirely unknown identity set
         const scriptPath = path.resolve(process.cwd(), 'ai/scripts/checkAllAgentIdle.mjs');
-        const output = execFileSync('node', [scriptPath, '12347'], {
+        const output = execFileSync('node', [scriptPath], {
             encoding: 'utf-8',
             env: { 
                 ...process.env, 
@@ -139,8 +152,43 @@ test.describe('ai/scripts/checkAllAgentIdle', () => {
 
         // Assert boundary signal
         expect(parsed.allIdle).toBe(true);
+        expect(parsed.cycle_id).toBe(deriveAllAgentIdleCycleId(
+            ['@neo-ghost-agent-1'],
+            {
+                '@neo-ghost-agent-1': {
+                    lastMemTime   : null,
+                    inFlightNudge : false
+                }
+            }
+        ));
         expect(parsed.details['@neo-ghost-agent-1'].lastMemTime).toBeNull();
         expect(parsed.details['@neo-ghost-agent-1'].ageMs).toBe(null); // Infinity JSON encodes to null
+    });
+
+    test('deriveAllAgentIdleCycleId is stable for the same observed all-idle state', () => {
+        const details = {
+            '@neo-test-agent-1': {lastMemTime: '2026-05-22T10:00:00.000Z', inFlightNudge: false},
+            '@neo-test-agent-2': {lastMemTime: '2026-05-22T10:05:00.000Z', inFlightNudge: false}
+        };
+
+        const firstCycleId  = deriveAllAgentIdleCycleId(['@neo-test-agent-2', '@neo-test-agent-1'], details);
+        const secondCycleId = deriveAllAgentIdleCycleId(['@neo-test-agent-1', '@neo-test-agent-2'], details);
+
+        expect(firstCycleId).toBe(secondCycleId);
+    });
+
+    test('deriveAllAgentIdleCycleId rotates when an identity timestamp changes', () => {
+        const initialDetails = {
+            '@neo-test-agent-1': {lastMemTime: '2026-05-22T10:00:00.000Z', inFlightNudge: false},
+            '@neo-test-agent-2': {lastMemTime: '2026-05-22T10:05:00.000Z', inFlightNudge: false}
+        };
+        const updatedDetails = {
+            ...initialDetails,
+            '@neo-test-agent-2': {lastMemTime: '2026-05-22T10:08:00.000Z', inFlightNudge: false}
+        };
+
+        expect(deriveAllAgentIdleCycleId(['@neo-test-agent-1', '@neo-test-agent-2'], initialDetails))
+            .not.toBe(deriveAllAgentIdleCycleId(['@neo-test-agent-1', '@neo-test-agent-2'], updatedDetails));
     });
 
     test('swarm-heartbeat.sh integrates the all-agent-idle detection properly', async () => {
@@ -149,5 +197,6 @@ test.describe('ai/scripts/checkAllAgentIdle', () => {
         const allIdleIndex = script.indexOf('checkAllAgentIdle.mjs');
         
         expect(allIdleIndex).toBeGreaterThan(-1);
+        expect(script).not.toContain('local cycle_id=$(date +%s)');
     });
 });


### PR DESCRIPTION
Authored by GPT-5 (Codex Desktop). Session 2741c4bd-92b2-428b-92d3-ab718d9a7c41.

FAIR-band: in-band [15/30 - current author count over last 30 merged]

Resolves #10633

Fixes all-agent-idle cycle IDs so they are derived from observed per-identity state rather than heartbeat pulse timestamps. The detector now hashes sorted identity state, including each identity's last memory timestamp and in-flight nudge state, and both shell and daemon callers stop passing timestamp arguments. This keeps the same all-idle window stable across pulses and rotates the cooldown key when an identity's observed state changes.

Evidence: L2 (node syntax checks, diff hygiene, focused Playwright unit coverage) -> L2 required (producer/daemon contract covered by unit specs). No residuals.

## Deltas from ticket
- The cycle key uses the full per-identity observed state vector instead of only one earliest timestamp. This strengthens the ticket invariant: any identity activity changes the key, even if the oldest identity remains unchanged.
- Added an import-safe helper export and CLI main guard for deterministic unit coverage. Broader dual-mode conversion shipped in #11761.
- Rebased on the merged #11761 direct-import shape while preserving the state-derived cycle-id semantics.

## Test Evidence
- `node --check ai/scripts/checkAllAgentIdle.mjs`
- `node --check ai/daemons/SwarmHeartbeatService.mjs`
- `git diff --check origin/dev...HEAD`
- `env NEO_TEST_SKIP_CI=true npm run test-unit -- test/playwright/unit/ai/scripts/checkAllAgentIdle.spec.mjs test/playwright/unit/ai/daemons/SwarmHeartbeatService.spec.mjs` -> 19 passed, 2 skipped
- Empirical anchor: PR #10632 Cycle 1 review surfaced the timestamp-derived `cycle_id` failure at the cooldown-consumption layer.

## Post-Merge Validation
- [ ] Observe one all-idle window across two heartbeat pulses and confirm the logged `cycle_id` remains stable until an identity records new memory or in-flight nudge state changes.

## Related
- PR #11761 — broader wake-script dual-mode conversion, now merged and preserved by this branch's rebase.

## Commits
- `82a9d3d13` — `fix(ai): derive all-idle cycle id from state (#10633)`
