### PR TITLE
feat(agents): surface durable review follow-ups (#10776)

### DIFF
--- a/.agents/skills/pr-review/references/pr-review-guide.md
+++ b/.agents/skills/pr-review/references/pr-review-guide.md
@@ -416,6 +416,7 @@ strategic landscape, what's the right merge decision?" Four first-class options:
    - The PR ships measurable substrate value even with documented gaps
    - Required Actions surface concerns that are better-tracked-separately
    *Empirical anchor: PR #10602 Cycle 1 (over-rigor candidate).*
+   Tell the author to run `pull-request-workflow.md §6.3.1` before merge.
 3. **Request Changes** — must-fix before merge; defects block substrate correctness.
 4. **Drop+Supersede** — the entire PR premise is stale/wrong with current
    knowledge. The reviewer explicitly RECOMMENDS closure (using the Request Changes shape) so the author executes closing the PR + closing the ticket + filing a superseding ticket with

--- a/.agents/skills/pull-request/references/post-review-followup-surfacing.md
+++ b/.agents/skills/pull-request/references/post-review-followup-surfacing.md
@@ -1,0 +1,37 @@
+# Post-Review Follow-up Surfacing
+
+This payload applies when a reviewer lands an `Approve+Follow-Up` verdict or
+names explicit follow-up work via `[KB_GAP]`, `[TOOLING_GAP]`,
+`[RETROSPECTIVE]`, or plain "non-blocking follow-up" language.
+
+## Rule
+
+Before merge, the author MUST convert durable follow-up work into graph-visible
+substrate:
+
+1. File each follow-up as an actual GitHub issue via the normal `ticket-create`
+   workflow, unless an equivalent open issue already exists.
+2. Link each filed or existing follow-up to a discoverable parent with
+   `update_issue_relationship` (`parent_child` or `blocked_by` as appropriate).
+   Prefer the close-target's parent epic, the close-target itself, or a
+   sibling-anchor ticket from the review's substrate.
+3. Optionally add a `## Follow-ups` block near the top of the PR body listing
+   the filed issue numbers and relationship anchor. This block is a
+   **pre-merge operator-visibility surface only**; it is not durable substrate.
+
+If a reviewer labels something as follow-up but no durable ticket is warranted,
+the author MUST document the reason in the review response or PR body. Do not
+leave follow-up work only as prose in the PR body or review thread.
+
+## Optional PR Body Mirror
+
+```markdown
+## Follow-ups
+- #M — <one-line scope>; linked as <parent_child|blocked_by> to #P
+```
+
+## Anti-Pattern
+
+A PR body `## Follow-ups` block that lists prose-only tasks, unfiled issue
+numbers, or tickets without native relationships is not durable. File and link
+first; the PR body only mirrors the durable graph for merge-time visibility.

--- a/.agents/skills/pull-request/references/pull-request-workflow.md
+++ b/.agents/skills/pull-request/references/pull-request-workflow.md
@@ -307,6 +307,10 @@ after review-response handoff completes. Reviewer-side symmetry is mapped from
 `pr-review-guide.md §11`. This is the public skill codification of the
 `feedback_peer_not_assistant_mode` lineage.
 
+### 6.3.1 Post-Review Follow-up Surfacing
+
+<!-- trigger: `Approve+Follow-Up` or explicit non-blocking follow-up in review -> read ./post-review-followup-surfacing.md before merge -->
+
 ### 6.4 Reviewer Template-Adherence Check
 
 When a review lands on your PR, verify the reviewer used the correct


### PR DESCRIPTION
Resolves #10776
Related: #10757

Authored by GPT-5 (Codex Desktop). Session 2741c4bd-92b2-428b-92d3-ab718d9a7c41.

FAIR-band: in-band [15/30 - current author count over last 30 merged]

Adds the missing file-and-link discipline for `Approve+Follow-Up` review outcomes. Reviewers now point authors to the author-side pre-flight, while authors get a conditional payload that requires durable follow-up tickets plus native issue relationships before merge. Optional PR-body `## Follow-ups` text is explicitly a pre-merge mirror only, not the durable substrate.

Evidence: L1 (workflow-map trigger pointer + reference payload + skill-manifest lint) -> L1 required (agent workflow substrate). No residuals.

## Deltas from ticket

- Extracted the substantive rule into `pull-request/references/post-review-followup-surfacing.md` instead of placing it directly in the oversized workflow map. This satisfies #10776 while preserving Map vs World Atlas budget discipline.
- Backfilled #10776's missing Contract Ledger and existing-enforcement sufficiency audit into the live issue body before implementation.
- Posted the required GPT epic-review entry-pass on parent #10757 before sub pickup: `IC_kwDODSospM8AAAABDVZG1g`.

## Slot Rationale

- `.agents/skills/pull-request/references/pull-request-workflow.md` modified section: `compress-to-trigger`. Trigger-frequency is edge-case (`Approve+Follow-Up` / explicit non-blocking follow-up), failure-severity is moderate/high (orphaned follow-up work), enforceability is discipline-only. The map carries only a one-line trigger pointer.
- `.agents/skills/pull-request/references/post-review-followup-surfacing.md` added payload: `keep` as conditionally loaded Atlas payload. Trigger-frequency is edge-case, failure-severity is moderate/high, enforceability is discipline-only; extraction avoids routine context bloat.
- `.agents/skills/pr-review/references/pr-review-guide.md` modified line: `compress-to-trigger`. The reviewer-side map carries only a one-line cross-reference so reviewers know which author-side payload to invoke.

## Test Evidence

- `git diff --cached --check`
- `git diff --check origin/dev...HEAD`
- `node ai/scripts/lint-skill-manifest.mjs --base origin/dev` -> OK
- `/turn-memory-pre-flight` mechanical checks:
  - `.codex/hooks.json` loads only `.codex/hooks/codex-context.mjs`.
  - `.codex/hooks/codex-context.mjs` loads `.codex/CODEX.md`; no `context.fileName` branch exists in `.codex`.
  - `.claude/CLAUDE.md` resolves to `../AGENTS.md`.

## Post-Merge Validation

- [ ] On the next PR that receives `Approve+Follow-Up`, author files or cites durable follow-up issue(s), links them with `update_issue_relationship`, and only mirrors them in PR-body text after the graph substrate exists.

## Commits

- `d064b2d58` — `feat(agents): surface durable review follow-ups (#10776)`
