### PR TITLE
fix(ai): resolve antigravity cli path fallback (#10684)

### DIFF
--- a/ai/scripts/resumeHarness.mjs
+++ b/ai/scripts/resumeHarness.mjs
@@ -18,6 +18,7 @@
  * @see .agents/skills/session-sunset/references/session-sunset-workflow.md §1
  */
 import { spawn } from 'child_process';
+import { constants as fsConstants } from 'fs';
 import fs from 'fs/promises';
 import os from 'os';
 import path from 'path';
@@ -116,6 +117,82 @@ async function resolveClaudeCliPath() {
  */
 function resolveCodexCliPath() {
     return process.env.CODEX_CLI_PATH || 'codex';
+}
+
+/**
+ * @summary Check whether a candidate CLI path exists and is executable.
+ *
+ * @param {string} filePath
+ * @returns {Promise<boolean>}
+ */
+async function fileIsExecutable(filePath) {
+    try {
+        await fs.access(filePath, fsConstants.X_OK);
+        return true;
+    } catch (err) {
+        return false;
+    }
+}
+
+/**
+ * @summary Resolve the first executable match for a command on PATH.
+ *
+ * @param {string} command
+ * @returns {Promise<?string>} Absolute executable path, or `null` when absent.
+ */
+async function findExecutableOnPath(command) {
+    const pathEntries = (process.env.PATH || '').split(path.delimiter).filter(Boolean);
+    const extensions = process.platform === 'win32' && !path.extname(command)
+        ? ['.cmd', '.exe', '.bat', '']
+        : [''];
+
+    for (const entry of pathEntries) {
+        for (const extension of extensions) {
+            const candidate = path.join(entry, `${command}${extension}`);
+            if (await fileIsExecutable(candidate)) return candidate;
+        }
+    }
+
+    return null;
+}
+
+/**
+ * @summary Resolve the Antigravity CLI across host platforms.
+ *
+ * `ANTIGRAVITY_CLI_PATH` is the authoritative override for tests and unusual
+ * installs. Otherwise, macOS uses the known app-bundle path, Windows tries the
+ * common user-local install shape, and every platform falls back to PATH lookup.
+ *
+ * @returns {Promise<string>} Absolute path to an Antigravity CLI executable.
+ */
+async function resolveAntigravityCliPath() {
+    if (process.env.ANTIGRAVITY_CLI_PATH) {
+        if (await fileIsExecutable(process.env.ANTIGRAVITY_CLI_PATH)) return process.env.ANTIGRAVITY_CLI_PATH;
+        throw new Error(`ANTIGRAVITY_CLI_PATH points to missing executable: ${process.env.ANTIGRAVITY_CLI_PATH}`);
+    }
+
+    const candidates = [];
+
+    if (process.platform === 'darwin') {
+        candidates.push('/Applications/Antigravity.app/Contents/Resources/app/bin/antigravity');
+    } else if (process.platform === 'win32' && process.env.LOCALAPPDATA) {
+        candidates.push(
+            path.join(process.env.LOCALAPPDATA, 'Programs', 'Antigravity', 'bin', 'antigravity.cmd'),
+            path.join(process.env.LOCALAPPDATA, 'Programs', 'Antigravity', 'resources', 'app', 'bin', 'antigravity.cmd')
+        );
+    }
+
+    const pathCandidate = await findExecutableOnPath('antigravity');
+    if (pathCandidate) candidates.push(pathCandidate);
+
+    for (const candidate of candidates) {
+        if (await fileIsExecutable(candidate)) return candidate;
+    }
+
+    throw new Error(
+        `Antigravity CLI not found for platform ${process.platform}. ` +
+        'Set ANTIGRAVITY_CLI_PATH to the executable path, or install `antigravity` on PATH.'
+    );
 }
 
 /**
@@ -240,7 +317,9 @@ export async function resumeHarness(identity, reason, originSessionId, abandoned
         throw new Error(`Unknown harness target for identity: ${identity}`);
     }
 
-    const adapter = process.platform === 'darwin' ? harnessTarget.adapter : 'tmux';
+    const adapter = harnessTarget.adapter === 'antigravity-cli'
+        ? harnessTarget.adapter
+        : process.platform === 'darwin' ? harnessTarget.adapter : 'tmux';
 
     // Write the inflight lock BEFORE taking action to secure the boot ramp (Issue #10674)
     await writeInflightLock(identity, 'sunset_restart', abandonedCount);
@@ -265,11 +344,10 @@ export async function resumeHarness(identity, reason, originSessionId, abandoned
     try {
         if (adapter === 'antigravity-cli') {
             /**
-             * @anchor antigravity-cli-mac-specific
-             * @summary Hardcoded path relies on Mac OS Application Bundle structure.
-             * @todo Abstract for cross-platform execution (Windows/Linux) per Issue #10684.
+             * @anchor antigravity-cli-path-resolution
+             * @summary Cross-platform Antigravity CLI resolution for fresh-session spawn.
              */
-            const cliPath = process.env.ANTIGRAVITY_CLI_PATH || '/Applications/Antigravity.app/Contents/Resources/app/bin/antigravity';
+            const cliPath = await resolveAntigravityCliPath();
             const args = ['chat', '-n', payload];
             await spawnAsync(cliPath, args, identity);
             console.log(`Successfully resumed ${identity} via antigravity-cli`);

--- a/ai/scripts/resumeHarness.mjs
+++ b/ai/scripts/resumeHarness.mjs
@@ -196,6 +196,25 @@ async function resolveAntigravityCliPath() {
 }
 
 /**
+ * @summary Select the runtime harness adapter for the current host platform.
+ *
+ * Antigravity keeps its native CLI path on POSIX hosts. Windows remains on the
+ * tmux fallback until #11767 adds a safe `.cmd`/`.bat` execution substrate.
+ *
+ * @param {Object} harnessTarget
+ * @param {string} harnessTarget.adapter
+ * @param {string} [hostPlatform=process.platform]
+ * @returns {string}
+ */
+export function selectHarnessAdapter(harnessTarget, hostPlatform = process.platform) {
+    if (harnessTarget.adapter === 'antigravity-cli') {
+        return hostPlatform === 'win32' ? 'tmux' : harnessTarget.adapter;
+    }
+
+    return hostPlatform === 'darwin' ? harnessTarget.adapter : 'tmux';
+}
+
+/**
  * @summary Fail-closed guard for the live Codex Desktop app-server adapter.
  *
  * `codex debug app-server send-message-v2` creates/injects into a real Codex
@@ -317,9 +336,7 @@ export async function resumeHarness(identity, reason, originSessionId, abandoned
         throw new Error(`Unknown harness target for identity: ${identity}`);
     }
 
-    const adapter = harnessTarget.adapter === 'antigravity-cli'
-        ? harnessTarget.adapter
-        : process.platform === 'darwin' ? harnessTarget.adapter : 'tmux';
+    const adapter = selectHarnessAdapter(harnessTarget);
 
     // Write the inflight lock BEFORE taking action to secure the boot ramp (Issue #10674)
     await writeInflightLock(identity, 'sunset_restart', abandonedCount);

--- a/test/playwright/unit/ai/scripts/resumeHarness.spec.mjs
+++ b/test/playwright/unit/ai/scripts/resumeHarness.spec.mjs
@@ -344,6 +344,16 @@ test.describe('ai/scripts/resumeHarness', () => {
         }
     });
 
+    test('Antigravity CLI: win32 stays on tmux until .cmd execution follow-up (#11767)', async () => {
+        const { selectHarnessAdapter } = await import('../../../../../ai/scripts/resumeHarness.mjs');
+
+        expect(selectHarnessAdapter({ adapter: 'antigravity-cli' }, 'linux')).toBe('antigravity-cli');
+        expect(selectHarnessAdapter({ adapter: 'antigravity-cli' }, 'darwin')).toBe('antigravity-cli');
+        expect(selectHarnessAdapter({ adapter: 'antigravity-cli' }, 'win32')).toBe('tmux');
+        expect(selectHarnessAdapter({ adapter: 'claude-cli' }, 'linux')).toBe('tmux');
+        expect(selectHarnessAdapter({ adapter: 'claude-cli' }, 'darwin')).toBe('claude-cli');
+    });
+
     test('Antigravity CLI: missing executable reports actionable path diagnostic (#10684)', async () => {
         test.skip(skipCiSubstrateData, 'CI-skip: substrate data not seeded - bucket C (#10903)');
 

--- a/test/playwright/unit/ai/scripts/resumeHarness.spec.mjs
+++ b/test/playwright/unit/ai/scripts/resumeHarness.spec.mjs
@@ -319,10 +319,11 @@ test.describe('ai/scripts/resumeHarness', () => {
     });
 
     test('Antigravity CLI: adapter executes chat -n <payload> via ANTIGRAVITY_CLI_PATH (#10680)', async () => {
-        test.skip(process.platform !== 'darwin', 'Antigravity CLI is currently mac-specific (#10684)');
         test.skip(skipCiSubstrateData, 'CI-skip: substrate data not seeded - bucket C (#10903)');
 
-        // Create a mock executable to capture the command shape without launching the real IDE
+        // Create a mock executable to capture the command shape without launching the real IDE.
+        // The env override exercises the cross-platform adapter path without depending on
+        // host-specific Antigravity installs.
         const mockPath = path.join(os.tmpdir(), `mock-ag-${randomUUID()}`);
         const outPath = path.join(os.tmpdir(), `out-ag-${randomUUID()}`);
         fs.writeFileSync(mockPath, `#!/usr/bin/env node\nconst fs = require('fs');\nfs.writeFileSync('${outPath}', JSON.stringify(process.argv.slice(2)));\n`, { mode: 0o755 });
@@ -340,6 +341,24 @@ test.describe('ai/scripts/resumeHarness', () => {
         } finally {
             if (fs.existsSync(mockPath)) fs.unlinkSync(mockPath);
             if (fs.existsSync(outPath)) fs.unlinkSync(outPath);
+        }
+    });
+
+    test('Antigravity CLI: missing executable reports actionable path diagnostic (#10684)', async () => {
+        test.skip(skipCiSubstrateData, 'CI-skip: substrate data not seeded - bucket C (#10903)');
+
+        const missingPath = path.join(os.tmpdir(), `missing-ag-${randomUUID()}`);
+
+        try {
+            const env = { ...overrideEnv, ANTIGRAVITY_CLI_PATH: missingPath };
+            execFileSync('node', [scriptPath, '@neo-gemini-3-1-pro', 'testReason'], { encoding: 'utf-8', stdio: 'pipe', env });
+            test.fail('Should have exited with a missing Antigravity CLI diagnostic');
+        } catch (e) {
+            expect(e.status).toBe(1);
+            const stderr = e.stderr.toString();
+            expect(stderr).toContain('Failed to resume @neo-gemini-3-1-pro via antigravity-cli');
+            expect(stderr).toContain('ANTIGRAVITY_CLI_PATH points to missing executable');
+            expect(stderr).toContain(missingPath);
         }
     });
 


### PR DESCRIPTION
Authored by GPT-5 (Codex Desktop). Session 2741c4bd-92b2-428b-92d3-ab718d9a7c41.
FAIR-band: in-band [15/30 - current author count over last 30 merged]

Refs #10684
Related follow-up: #11767

Keeps the Antigravity fresh-session adapter on the native `antigravity-cli` path for POSIX hosts, with portable CLI path resolution through `ANTIGRAVITY_CLI_PATH`, host defaults, and PATH lookup. After review cycle 1, Windows is deliberately held on the existing tmux fallback until #11767 implements safe `.cmd` / `.bat` execution; path resolution alone is not treated as Windows execution support.

Evidence: L2 (mock executable dispatch, missing-path diagnostic unit coverage, win32 adapter-selection coverage, and static syntax checks) -> L4 required (real Antigravity host fresh-session spawn proof; Windows `.cmd` / `.bat` execution tracked in #11767). Residual: host-level Antigravity launch proof and Windows batch-wrapper execution proof.

## Deltas from ticket
- Scope narrowed after review cycle 1: this PR delivers Antigravity path resolution plus Linux/POSIX execution and explicitly avoids routing Windows into a known-broken `.cmd` spawn path.
- Windows interim behavior stays on the existing tmux fallback for the Antigravity identity until #11767 adds a safe Windows batch-wrapper execution substrate.
- Codex and Claude non-macOS behavior still use the existing tmux fallback unless their own adapters are explicitly made cross-platform by separate tickets.
- No live Antigravity host was launched; coverage uses the established mock-executable pattern for harness adapters.

## Test Evidence
- `node --check ai/scripts/resumeHarness.mjs`
- `git diff --check origin/dev...HEAD`
- `git diff --cached --check`
- `npm run test-unit -- test/playwright/unit/ai/scripts/resumeHarness.spec.mjs` — first sandbox run hit the known `.neo-ai-data/wake-daemon` EPERM lock-file write; reran with sandbox escalation and got 19 passed, 2 skipped.

## Post-Merge Validation
- [ ] On a Linux Antigravity host, set `ANTIGRAVITY_CLI_PATH` or install `antigravity` on PATH and run a controlled fresh-session recovery probe for `@neo-gemini-3-1-pro`.
- [ ] Handle the Windows `.cmd` / `.bat` execution path in #11767 before claiming real Windows Antigravity CLI execution.

## Commits
- `e057204e5` — `fix(ai): resolve antigravity cli cross-platform (#10684)`
- `0f1e61a9a` — `fix(ai): narrow antigravity win32 fallback (#10684)`
