### PR TITLE
feat(mcp): GitLab Workflow server scaffold (#11768)

### DIFF
--- a/ai/mcp/server/gitlab-workflow/Server.mjs
+++ b/ai/mcp/server/gitlab-workflow/Server.mjs
@@ -1,0 +1,64 @@
+import BaseServer            from '../BaseServer.mjs';
+import aiConfig              from './config.mjs';
+import logger                from './logger.mjs';
+import HealthService         from '../../../services/gitlab-workflow/HealthService.mjs';
+import {listTools, callTool} from './toolService.mjs';
+
+/**
+ * @summary The GitLab Workflow MCP Server application.
+ *
+ * @class Neo.ai.mcp.server.gitlab-workflow.Server
+ * @extends Neo.ai.mcp.server.BaseServer
+ */
+class Server extends BaseServer {
+    static config = {
+        /**
+         * @member {String} className='Neo.ai.mcp.server.gitlab-workflow.Server'
+         * @protected
+         */
+        className: 'Neo.ai.mcp.server.gitlab-workflow.Server'
+    }
+
+    aiConfig = aiConfig
+    logger   = logger
+
+    getServerMetadata() {
+        return {
+            name        : 'neo-gitlab-workflow',
+            version     : process.env.npm_package_version || '1.0.0',
+            capabilities: {
+                tools: {listChanged: false}
+            }
+        };
+    }
+
+    getToolService() {
+        return {listTools, callTool};
+    }
+
+    getDependentServices() {
+        return [];
+    }
+
+    getHealthService() {
+        return HealthService;
+    }
+
+    getHealthExemptTools() {
+        return ['healthcheck'];
+    }
+
+    async afterHealthcheck(health) {
+        // No caching logic for GitLab implemented yet.
+    }
+
+    logStartupStatus(health) {
+        if (health.status === 'unhealthy') {
+            logger.warn('⚠️  [Startup] GitLab CLI is not available. Server will start but tools will fail until resolved.');
+        } else {
+            logger.info('✅ [Startup] GitLab CLI health check passed');
+        }
+    }
+}
+
+export default Neo.setupClass(Server);

--- a/ai/mcp/server/gitlab-workflow/config.template.mjs
+++ b/ai/mcp/server/gitlab-workflow/config.template.mjs
@@ -1,0 +1,10 @@
+import Config from '../../Config.mjs';
+
+const aiConfig = Neo.create(Config, {
+    data: {
+        gitlabUrl: 'https://gitlab.com',
+        token: process.env.GITLAB_TOKEN || ''
+    }
+});
+
+export default aiConfig;

--- a/ai/mcp/server/gitlab-workflow/logger.mjs
+++ b/ai/mcp/server/gitlab-workflow/logger.mjs
@@ -1,16 +1,54 @@
-import winston from 'winston';
+import aiConfig from './config.mjs';
 
-const logger = winston.createLogger({
-    level: 'info',
-    format: winston.format.combine(
-        winston.format.timestamp(),
-        winston.format.json()
-    ),
-    transports: [
-        new winston.transports.Console({
-            format: winston.format.simple()
-        })
-    ]
-});
+/**
+ * A simple stderr logger with priority-based filtering.
+ * Keeps MCP server noise low by default while preserving fail-loud error output.
+ */
+const logger = {};
+
+const LEVEL_PRIORITY = {
+    error: 0,
+    warn : 1,
+    info : 2,
+    log  : 2,
+    debug: 3
+};
+
+const DEFAULT_LOG_LEVEL = 'warn';
+
+const getConfiguredLogLevel = () => {
+    const configuredLevel = aiConfig.logLevel;
+
+    if (aiConfig.debug && (!configuredLevel || configuredLevel === DEFAULT_LOG_LEVEL)) {
+        return 'debug';
+    }
+
+    if (configuredLevel && LEVEL_PRIORITY[configuredLevel] !== undefined) {
+        return configuredLevel;
+    }
+
+    return aiConfig.debug ? 'debug' : DEFAULT_LOG_LEVEL;
+};
+
+const createLogMethod = (level) => {
+    return (...args) => {
+        if (level === 'error') {
+            console.error(`[${level.toUpperCase()}]`, ...args);
+            return;
+        }
+
+        const configuredLevel = getConfiguredLogLevel();
+
+        if (LEVEL_PRIORITY[level] <= LEVEL_PRIORITY[configuredLevel]) {
+            console.error(`[${level.toUpperCase()}]`, ...args);
+        }
+    };
+};
+
+logger.debug = createLogMethod('debug');
+logger.info  = createLogMethod('info');
+logger.log   = createLogMethod('log');
+logger.warn  = createLogMethod('warn');
+logger.error = createLogMethod('error');
 
 export default logger;

--- a/ai/mcp/server/gitlab-workflow/logger.mjs
+++ b/ai/mcp/server/gitlab-workflow/logger.mjs
@@ -1,0 +1,16 @@
+import winston from 'winston';
+
+const logger = winston.createLogger({
+    level: 'info',
+    format: winston.format.combine(
+        winston.format.timestamp(),
+        winston.format.json()
+    ),
+    transports: [
+        new winston.transports.Console({
+            format: winston.format.simple()
+        })
+    ]
+});
+
+export default logger;

--- a/ai/mcp/server/gitlab-workflow/mcp-server.mjs
+++ b/ai/mcp/server/gitlab-workflow/mcp-server.mjs
@@ -1,0 +1,33 @@
+import 'dotenv/config';
+import {Command}       from 'commander';
+import Neo             from '../../../../src/Neo.mjs';
+import * as core       from '../../../../src/core/_export.mjs';
+import InstanceManager from '../../../../src/manager/Instance.mjs';
+import aiConfig        from './config.mjs';
+import logger          from './logger.mjs';
+import Server          from './Server.mjs';
+import {sanitizeInput} from '../../../../buildScripts/util/Sanitizer.mjs';
+
+const program = new Command();
+
+program
+    .name('neo-gitlab-workflow-mcp')
+    .description('Neo.mjs GitLab Workflow MCP Server')
+    .option('-c, --config <path>', 'Path to the configuration file', sanitizeInput)
+    .option('-d, --debug', 'Enable debug logging')
+    .parse(process.argv);
+
+const options = program.opts();
+
+if (options.debug) {
+    aiConfig.data.debug = true;
+}
+
+try {
+    await Neo.create(Server, {
+        configFile: options.config
+    }).ready();
+} catch (error) {
+    logger.error('Fatal error during server initialization:', error);
+    process.exit(1);
+}

--- a/ai/mcp/server/gitlab-workflow/openapi.yaml
+++ b/ai/mcp/server/gitlab-workflow/openapi.yaml
@@ -1,0 +1,33 @@
+openapi: 3.0.0
+info:
+  title: Neo GitLab Workflow MCP API
+  version: 1.0.0
+paths:
+  /healthcheck:
+    get:
+      operationId: healthcheck
+      summary: Health check
+      responses:
+        '200':
+          description: OK
+  /issue:
+    get:
+      operationId: get_issue
+      summary: Get issue
+      responses:
+        '200':
+          description: OK
+  /merge-request:
+    get:
+      operationId: get_merge_request
+      summary: Get MR
+      responses:
+        '200':
+          description: OK
+  /local-file:
+    get:
+      operationId: get_local_file
+      summary: Get Local File
+      responses:
+        '200':
+          description: OK

--- a/ai/mcp/server/gitlab-workflow/toolService.mjs
+++ b/ai/mcp/server/gitlab-workflow/toolService.mjs
@@ -1,0 +1,28 @@
+import path               from 'path';
+import {fileURLToPath}    from 'url';
+import HealthService      from '../../../services/gitlab-workflow/HealthService.mjs';
+import IssueService       from '../../../services/gitlab-workflow/IssueService.mjs';
+import MergeRequestService from '../../../services/gitlab-workflow/MergeRequestService.mjs';
+import LocalFileService   from '../../../services/gitlab-workflow/LocalFileService.mjs';
+import ToolService        from '../../ToolService.mjs';
+
+const __filename      = fileURLToPath(import.meta.url);
+const __dirname       = path.dirname(__filename);
+const openApiFilePath = path.join(__dirname, 'openapi.yaml');
+
+const serviceMapping = {
+    healthcheck          : HealthService.healthcheck.bind(HealthService),
+    get_issue            : IssueService.getIssue.bind(IssueService),
+    get_merge_request    : MergeRequestService.getMergeRequest.bind(MergeRequestService),
+    get_local_file       : LocalFileService.getLocalFile.bind(LocalFileService)
+};
+
+const toolService = Neo.create(ToolService, {
+    openApiFilePath,
+    serviceMapping
+});
+
+const callTool  = toolService.callTool .bind(toolService);
+const listTools = toolService.listTools.bind(toolService);
+
+export {callTool, listTools};

--- a/ai/services/gitlab-workflow/HealthService.mjs
+++ b/ai/services/gitlab-workflow/HealthService.mjs
@@ -1,0 +1,14 @@
+import Base from '../../../src/core/Base.mjs';
+
+class HealthService extends Base {
+    static config = {
+        className: 'Neo.ai.services.gitlab-workflow.HealthService',
+        singleton: true
+    }
+
+    async healthcheck() {
+        return { status: 'healthy', gitlabCli: { available: true } };
+    }
+}
+
+export default Neo.setupClass(HealthService);

--- a/ai/services/gitlab-workflow/IssueService.mjs
+++ b/ai/services/gitlab-workflow/IssueService.mjs
@@ -1,0 +1,14 @@
+import Base from '../../../src/core/Base.mjs';
+
+class IssueService extends Base {
+    static config = {
+        className: 'Neo.ai.services.gitlab-workflow.IssueService',
+        singleton: true
+    }
+
+    async getIssue(options) {
+        return { id: options?.id || 1, title: 'Stubbed Issue' };
+    }
+}
+
+export default Neo.setupClass(IssueService);

--- a/ai/services/gitlab-workflow/LocalFileService.mjs
+++ b/ai/services/gitlab-workflow/LocalFileService.mjs
@@ -1,0 +1,14 @@
+import Base from '../../../src/core/Base.mjs';
+
+class LocalFileService extends Base {
+    static config = {
+        className: 'Neo.ai.services.gitlab-workflow.LocalFileService',
+        singleton: true
+    }
+
+    async getLocalFile(options) {
+        return { path: options?.path || '', content: 'Stubbed File Content' };
+    }
+}
+
+export default Neo.setupClass(LocalFileService);

--- a/ai/services/gitlab-workflow/MergeRequestService.mjs
+++ b/ai/services/gitlab-workflow/MergeRequestService.mjs
@@ -1,0 +1,14 @@
+import Base from '../../../src/core/Base.mjs';
+
+class MergeRequestService extends Base {
+    static config = {
+        className: 'Neo.ai.services.gitlab-workflow.MergeRequestService',
+        singleton: true
+    }
+
+    async getMergeRequest(options) {
+        return { id: options?.id || 1, title: 'Stubbed MR' };
+    }
+}
+
+export default Neo.setupClass(MergeRequestService);


### PR DESCRIPTION
Authored by @neo-gemini-3-1-pro (Antigravity). Session 23c06234-5288-42c1-a669-359858d36afb.

FAIR-band: under-target [0/30] — Self-Selection Rule 1 fires (under-band → bias toward author lane)

Resolves #11768

Scaffolds the initial structure for the GitLab Workflow MCP server, adhering to the current decoupled  branch architecture (MCP edge in `ai/mcp/server/gitlab-workflow` and services in `ai/services/gitlab-workflow`). 

Evidence: L1 (static config-shape audit) → L1 required (no runtime-verify ACs). No residuals.

## Deltas from ticket (if any)
None.

## Test Evidence
Ran `npm run build-all` to verify that the components are syntactically sound and resolve correctly in the build chain.

## Post-Merge Validation
- [ ] Implement actual API calls in the service stubs in subsequent subs.