### PR TITLE
feat(mcp): scaffold GitLab workflow tool registry (#11768)

### DIFF
--- a/ai/mcp/server/gitlab-workflow/Server.mjs
+++ b/ai/mcp/server/gitlab-workflow/Server.mjs
@@ -1,0 +1,90 @@
+import BaseServer            from '../BaseServer.mjs';
+import aiConfig              from './config.mjs';
+import logger                from './logger.mjs';
+import HealthService         from '../../../services/gitlab-workflow/HealthService.mjs';
+import {listTools, callTool} from './toolService.mjs';
+
+/**
+ * @summary The GitLab Workflow MCP Server application.
+ *
+ * Bootstraps the GitLab Workflow MCP surface as a sibling to `github-workflow`.
+ * This initial scaffold deliberately registers the #11768 tool contract while
+ * leaving real GitLab API calls to the later GitLabClient / syncer subtasks.
+ *
+ * @class Neo.ai.mcp.server.gitlab-workflow.Server
+ * @extends Neo.ai.mcp.server.BaseServer
+ */
+class Server extends BaseServer {
+    static config = {
+        /**
+         * @member {String} className='Neo.ai.mcp.server.gitlab-workflow.Server'
+         * @protected
+         */
+        className: 'Neo.ai.mcp.server.gitlab-workflow.Server'
+    }
+
+    aiConfig = aiConfig
+    logger   = logger
+
+    /**
+     * @summary MCP server identity for `createMcpServer()`.
+     * @returns {{name: String, version: String, capabilities: Object}}
+     */
+    getServerMetadata() {
+        return {
+            name        : 'neo-gitlab-workflow',
+            version     : process.env.npm_package_version || '1.0.0',
+            capabilities: {
+                tools: {listChanged: false}
+            }
+        };
+    }
+
+    /**
+     * @summary Per-server tool registry for ListTools / CallTool dispatch.
+     * @returns {{listTools: Function, callTool: Function}}
+     */
+    getToolService() {
+        return {listTools, callTool};
+    }
+
+    /**
+     * @summary GitLab API/sync services are intentionally absent from this scaffold.
+     * Later subtasks add dependent services once real API clients and syncers exist.
+     * @returns {Array<Object>}
+     */
+    getDependentServices() {
+        return [];
+    }
+
+    /**
+     * @summary HealthService for the scaffold healthcheck gate.
+     * @returns {Object}
+     */
+    getHealthService() {
+        return HealthService;
+    }
+
+    /**
+     * @summary Tools allowed without the healthcheck gate.
+     * @returns {Array<String>}
+     */
+    getHealthExemptTools() {
+        return ['healthcheck'];
+    }
+
+    /**
+     * @summary GitLab-workflow-specific startup status formatting.
+     * @param {Object} health
+     */
+    logStartupStatus(health) {
+        if (health.status === 'healthy') {
+            logger.info('[Startup] GitLab Workflow MCP scaffold health check passed');
+        } else {
+            logger.warn(`[Startup] GitLab Workflow MCP scaffold reported ${health.status}`);
+            (health.details || []).forEach(detail => logger.warn(`    ${detail}`));
+        }
+    }
+}
+
+export default Neo.setupClass(Server);

--- a/ai/mcp/server/gitlab-workflow/config.template.mjs
+++ b/ai/mcp/server/gitlab-workflow/config.template.mjs
@@ -1,0 +1,107 @@
+import path                                       from 'path';
+import {fileURLToPath}                            from 'url';
+import BaseConfig, {createConfigProxy}            from '../shared/BaseConfig.mjs';
+import {parseBool, parseString, parseUrl}         from '../shared/helpers/EnvConfig.mjs';
+
+const __filename     = fileURLToPath(import.meta.url);
+const __dirname      = path.dirname(__filename);
+const packageRoot    = path.resolve(__dirname, '../../../../');
+const projectRoot    = process.cwd() === '/' ? packageRoot : process.cwd();
+const validLogLevels = ['error', 'warn', 'info', 'log', 'debug'];
+
+/**
+ * @summary Parses a GitLab Workflow MCP log level from environment input.
+ * @param {String} rawValue
+ * @param {String} envVarName
+ * @param {Function} [warn=console.warn]
+ * @returns {String|undefined}
+ */
+function parseLogLevel(rawValue, envVarName, warn = console.warn) {
+    const value = String(rawValue).trim().toLowerCase();
+
+    if (validLogLevels.includes(value)) {
+        return value;
+    }
+
+    warn(`[Config] Invalid ${envVarName} value: "${rawValue}" (must be one of: ${validLogLevels.join(', ')}); falling back.`);
+    return undefined;
+}
+
+/**
+ * @summary Default configuration for the GitLab Workflow MCP server scaffold.
+ *
+ * Keeps client-project GitLab host / PAT configuration out of tracked files.
+ * The real GitLabClient subtask consumes the same keys when API calls land.
+ */
+const defaultConfig = {
+    /**
+     * @member {String} projectRoot
+     */
+    projectRoot,
+    /**
+     * @member {Boolean} debug=false
+     */
+    debug: false,
+    /**
+     * @member {String} logLevel='warn'
+     */
+    logLevel: 'warn',
+    /**
+     * @member {String} transport='stdio'
+     */
+    transport: 'stdio',
+    /**
+     * @member {Object} gitlab
+     */
+    gitlab: {
+        /**
+         * GitLab instance base URL.
+         * @member {String} hostUrl='https://gitlab.com'
+         */
+        hostUrl: 'https://gitlab.com',
+        /**
+         * GitLab Personal Access Token. Empty in the tracked template.
+         * @member {String} token=''
+         */
+        token: ''
+    }
+};
+
+/**
+ * @summary Environment-variable ledger for client-project GitLab MCP config.
+ */
+const envBindings = {
+    debug           : {var: 'NEO_GITLAB_WORKFLOW_DEBUG', parse: parseBool},
+    logLevel        : {var: 'NEO_GITLAB_WORKFLOW_LOG_LEVEL', parse: parseLogLevel},
+    transport       : {var: 'NEO_GITLAB_WORKFLOW_TRANSPORT', parse: parseString},
+    'gitlab.hostUrl': {var: 'NEO_GITLAB_HOST', parse: parseUrl},
+    'gitlab.token'  : {var: 'NEO_GITLAB_PAT', parse: parseString}
+};
+
+/**
+ * @summary GitLab Workflow MCP configuration singleton.
+ *
+ * @class Neo.ai.mcp.server.gitlab-workflow.Config
+ * @extends Neo.ai.mcp.server.shared.BaseConfig
+ */
+class Config extends BaseConfig {
+    static config = {
+        /**
+         * @member {String} className='Neo.ai.mcp.server.gitlab-workflow.Config'
+         * @protected
+         */
+        className: 'Neo.ai.mcp.server.gitlab-workflow.Config',
+        /**
+         * @member {Boolean} singleton=true
+         * @protected
+         */
+        singleton: true
+    }
+
+    defaultConfig = defaultConfig
+    envBindings   = envBindings
+}
+
+const instance = Neo.setupClass(Config);
+
+export default createConfigProxy(instance);

--- a/ai/mcp/server/gitlab-workflow/logger.mjs
+++ b/ai/mcp/server/gitlab-workflow/logger.mjs
@@ -1,0 +1,65 @@
+import aiConfig from './config.mjs';
+
+/**
+ * @summary Stderr logger for the GitLab Workflow MCP server.
+ *
+ * Mirrors the sibling workflow-server logger and keeps MCP stdout reserved for
+ * protocol traffic while allowing operator-selected verbosity via config/env.
+ */
+const logger = {};
+
+const LEVEL_PRIORITY = {
+    error: 0,
+    warn : 1,
+    info : 2,
+    log  : 2,
+    debug: 3
+};
+
+const DEFAULT_LOG_LEVEL = 'warn';
+
+/**
+ * @summary Resolves the effective log level from config and debug state.
+ * @returns {String}
+ */
+const getConfiguredLogLevel = () => {
+    const configuredLevel = aiConfig.logLevel;
+
+    if (aiConfig.debug && (!configuredLevel || configuredLevel === DEFAULT_LOG_LEVEL)) {
+        return 'debug';
+    }
+
+    if (configuredLevel && LEVEL_PRIORITY[configuredLevel] !== undefined) {
+        return configuredLevel;
+    }
+
+    return aiConfig.debug ? 'debug' : DEFAULT_LOG_LEVEL;
+};
+
+/**
+ * @summary Creates one stderr log function with priority filtering.
+ * @param {String} level
+ * @returns {Function}
+ */
+const createLogMethod = (level) => {
+    return (...args) => {
+        if (level === 'error') {
+            console.error(`[${level.toUpperCase()}]`, ...args);
+            return;
+        }
+
+        const configuredLevel = getConfiguredLogLevel();
+
+        if (LEVEL_PRIORITY[level] <= LEVEL_PRIORITY[configuredLevel]) {
+            console.error(`[${level.toUpperCase()}]`, ...args);
+        }
+    };
+};
+
+logger.debug = createLogMethod('debug');
+logger.info  = createLogMethod('info');
+logger.log   = createLogMethod('log');
+logger.warn  = createLogMethod('warn');
+logger.error = createLogMethod('error');
+
+export default logger;

--- a/ai/mcp/server/gitlab-workflow/mcp-server.mjs
+++ b/ai/mcp/server/gitlab-workflow/mcp-server.mjs
@@ -1,0 +1,33 @@
+import 'dotenv/config';
+import {Command}       from 'commander';
+import Neo             from '../../../../src/Neo.mjs';
+import * as core       from '../../../../src/core/_export.mjs';
+import InstanceManager from '../../../../src/manager/Instance.mjs';
+import aiConfig        from './config.mjs';
+import logger          from './logger.mjs';
+import Server          from './Server.mjs';
+import {sanitizeInput} from '../../../../buildScripts/util/Sanitizer.mjs';
+
+const program = new Command();
+
+program
+    .name('neo-gitlab-workflow-mcp')
+    .description('Neo.mjs GitLab Workflow MCP Server')
+    .option('-c, --config <path>', 'Path to the configuration file', sanitizeInput)
+    .option('-d, --debug', 'Enable debug logging')
+    .parse(process.argv);
+
+const options = program.opts();
+
+if (options.debug) {
+    aiConfig.data.debug = true;
+}
+
+try {
+    await Neo.create(Server, {
+        configFile: options.config
+    }).ready();
+} catch (error) {
+    logger.error('Fatal error during server initialization:', error);
+    process.exit(1);
+}

--- a/ai/mcp/server/gitlab-workflow/openapi.yaml
+++ b/ai/mcp/server/gitlab-workflow/openapi.yaml
@@ -1,0 +1,335 @@
+openapi: 3.0.0
+info:
+  title: Neo GitLab Workflow MCP API
+  version: 1.0.0
+paths:
+  /healthcheck:
+    get:
+      operationId: healthcheck
+      summary: Healthcheck
+      description: Returns scaffold-level GitLab Workflow MCP server health.
+      tags: [System]
+      x-annotations:
+        readOnlyHint: true
+      responses:
+        '200':
+          description: GitLab Workflow MCP health state.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HealthResponse'
+
+  /issues:
+    get:
+      operationId: list_issues
+      summary: List GitLab issues
+      description: Lists GitLab issues. Scaffolded until the GitLabClient subtask lands.
+      tags: [Issues]
+      x-pass-as-object: true
+      x-annotations:
+        readOnlyHint: true
+      parameters:
+        - name: limit
+          in: query
+          required: false
+          description: Maximum number of issues to return.
+          schema:
+            type: integer
+            minimum: 1
+            maximum: 100
+            default: 30
+        - name: state
+          in: query
+          required: false
+          description: Filter issues by state.
+          schema:
+            type: string
+            enum: [opened, closed, all]
+            default: opened
+        - name: labels
+          in: query
+          required: false
+          description: Comma separated list of labels to filter by.
+          schema:
+            type: string
+        - name: assignee
+          in: query
+          required: false
+          description: Filter issues by a single GitLab username.
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Scaffolded issue list response.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ListResponse'
+    post:
+      operationId: create_issue
+      summary: Create a GitLab issue
+      description: Creates a GitLab issue. Scaffolded until the GitLabClient subtask lands.
+      tags: [Issues]
+      x-pass-as-object: true
+      x-annotations:
+        readOnlyHint: false
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [title]
+              properties:
+                title:
+                  type: string
+                  description: Issue title.
+                body:
+                  type: string
+                  description: Issue description.
+                  default: ''
+                labels:
+                  type: array
+                  items:
+                    type: string
+                  description: Labels to apply.
+                  default: []
+                assignees:
+                  type: array
+                  items:
+                    type: string
+                  description: GitLab usernames to assign.
+                  default: []
+      responses:
+        '200':
+          description: Scaffolded create response.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ScaffoldResponse'
+
+  /merge-requests:
+    get:
+      operationId: list_merge_requests
+      summary: List GitLab merge requests
+      description: Lists GitLab merge requests. Scaffolded until the GitLabClient subtask lands.
+      tags: [Merge Requests]
+      x-pass-as-object: true
+      x-annotations:
+        readOnlyHint: true
+      parameters:
+        - name: limit
+          in: query
+          required: false
+          description: Maximum number of merge requests to return.
+          schema:
+            type: integer
+            minimum: 1
+            maximum: 100
+            default: 30
+        - name: state
+          in: query
+          required: false
+          description: Filter merge requests by state.
+          schema:
+            type: string
+            enum: [opened, closed, merged, all]
+            default: opened
+        - name: author
+          in: query
+          required: false
+          description: Filter merge requests by GitLab username.
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Scaffolded merge-request list response.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ListResponse'
+
+  /local/issues/{issue_number}:
+    get:
+      operationId: get_local_issue_by_id
+      summary: Get a local GitLab issue file
+      description: Retrieves a local GitLab issue markdown file by issue number. Scaffolded until syncer subtasks land.
+      tags: [Local Files]
+      x-pass-as-object: true
+      x-annotations:
+        readOnlyHint: true
+      parameters:
+        - name: issue_number
+          in: path
+          required: true
+          description: GitLab issue number.
+          schema:
+            type: integer
+      responses:
+        '200':
+          description: Scaffolded local issue lookup response.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ScaffoldResponse'
+
+  /comments/manage:
+    post:
+      operationId: manage_issue_comment
+      summary: Manage GitLab issue comments
+      description: Creates or updates GitLab issue comments. Scaffolded until the GitLabClient subtask lands.
+      tags: [Issues]
+      x-pass-as-object: true
+      x-annotations:
+        readOnlyHint: false
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [action, issue_number, body]
+              properties:
+                action:
+                  type: string
+                  enum: [create, update]
+                  description: Comment action.
+                issue_number:
+                  type: integer
+                  description: GitLab issue number.
+                note_id:
+                  type: integer
+                  description: GitLab note id for updates.
+                body:
+                  type: string
+                  description: Comment body.
+      responses:
+        '200':
+          description: Scaffolded comment-management response.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ScaffoldResponse'
+
+  /issues/{issue_number}/labels/manage:
+    post:
+      operationId: manage_issue_labels
+      summary: Manage GitLab issue labels
+      description: Adds or removes GitLab issue labels. Scaffolded until the GitLabClient subtask lands.
+      tags: [Issues]
+      x-pass-as-object: true
+      x-annotations:
+        readOnlyHint: false
+      parameters:
+        - name: issue_number
+          in: path
+          required: true
+          description: GitLab issue number.
+          schema:
+            type: integer
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [action, labels]
+              properties:
+                action:
+                  type: string
+                  enum: [add, remove]
+                  description: Label action.
+                labels:
+                  type: array
+                  items:
+                    type: string
+                  description: Labels to add or remove.
+      responses:
+        '200':
+          description: Scaffolded label-management response.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ScaffoldResponse'
+
+  /issues/{issue_number}/assignees/manage:
+    post:
+      operationId: manage_issue_assignees
+      summary: Manage GitLab issue assignees
+      description: Adds or removes GitLab issue assignees. Scaffolded until the GitLabClient subtask lands.
+      tags: [Issues]
+      x-pass-as-object: true
+      x-annotations:
+        readOnlyHint: false
+      parameters:
+        - name: issue_number
+          in: path
+          required: true
+          description: GitLab issue number.
+          schema:
+            type: integer
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [action, assignees]
+              properties:
+                action:
+                  type: string
+                  enum: [add, remove]
+                  description: Assignee action.
+                assignees:
+                  type: array
+                  items:
+                    type: string
+                  description: GitLab usernames to add or remove.
+      responses:
+        '200':
+          description: Scaffolded assignee-management response.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ScaffoldResponse'
+
+components:
+  schemas:
+    HealthResponse:
+      type: object
+      properties:
+        status:
+          type: string
+        gitlab:
+          type: object
+          additionalProperties: true
+        details:
+          type: array
+          items:
+            type: string
+    ListResponse:
+      type: object
+      properties:
+        status:
+          type: string
+        items:
+          type: array
+          items:
+            type: object
+            additionalProperties: true
+        count:
+          type: integer
+        message:
+          type: string
+    ScaffoldResponse:
+      type: object
+      properties:
+        status:
+          type: string
+        tool:
+          type: string
+        message:
+          type: string
+        received:
+          type: object
+          additionalProperties: true

--- a/ai/mcp/server/gitlab-workflow/toolService.mjs
+++ b/ai/mcp/server/gitlab-workflow/toolService.mjs
@@ -1,0 +1,39 @@
+import path                from 'path';
+import {fileURLToPath}     from 'url';
+import HealthService       from '../../../services/gitlab-workflow/HealthService.mjs';
+import IssueService        from '../../../services/gitlab-workflow/IssueService.mjs';
+import LocalFileService    from '../../../services/gitlab-workflow/LocalFileService.mjs';
+import MergeRequestService from '../../../services/gitlab-workflow/MergeRequestService.mjs';
+import ToolService         from '../../ToolService.mjs';
+
+const __filename      = fileURLToPath(import.meta.url);
+const __dirname       = path.dirname(__filename);
+const openApiFilePath = path.join(__dirname, 'openapi.yaml');
+
+/**
+ * @summary #11768 GitLab Workflow scaffold tool registry.
+ *
+ * The operation IDs intentionally match the ticket's initial mirrored surface.
+ * Service implementations return scaffold responses until the later GitLabClient
+ * and syncer subtasks replace them with real GitLab API behavior.
+ */
+const serviceMapping = {
+    create_issue             : IssueService       .createIssue          .bind(IssueService),
+    get_local_issue_by_id    : LocalFileService   .getIssueById         .bind(LocalFileService),
+    healthcheck              : HealthService      .healthcheck          .bind(HealthService),
+    list_issues              : IssueService       .listIssues           .bind(IssueService),
+    list_merge_requests      : MergeRequestService.listMergeRequests    .bind(MergeRequestService),
+    manage_issue_assignees   : IssueService       .manageIssueAssignees .bind(IssueService),
+    manage_issue_comment     : IssueService       .manageIssueComment   .bind(IssueService),
+    manage_issue_labels      : IssueService       .manageIssueLabels    .bind(IssueService)
+};
+
+const toolService = Neo.create(ToolService, {
+    openApiFilePath,
+    serviceMapping
+});
+
+const callTool  = toolService.callTool .bind(toolService);
+const listTools = toolService.listTools.bind(toolService);
+
+export {callTool, listTools};

--- a/ai/services/gitlab-workflow/HealthService.mjs
+++ b/ai/services/gitlab-workflow/HealthService.mjs
@@ -1,0 +1,52 @@
+import aiConfig from '../../mcp/server/gitlab-workflow/config.mjs';
+import Base     from '../../../src/core/Base.mjs';
+
+/**
+ * @summary Scaffold health service for the GitLab Workflow MCP server.
+ *
+ * The initial #11768 lane only registers the MCP surface. It validates that the
+ * server has a GitLab host configuration and reports whether a PAT is configured,
+ * without pretending that real API connectivity exists before GitLabClient lands.
+ *
+ * @class Neo.ai.services.gitlab-workflow.HealthService
+ * @extends Neo.core.Base
+ * @singleton
+ */
+class HealthService extends Base {
+    static config = {
+        /**
+         * @member {String} className='Neo.ai.services.gitlab-workflow.HealthService'
+         * @protected
+         */
+        className: 'Neo.ai.services.gitlab-workflow.HealthService',
+        /**
+         * @member {Boolean} singleton=true
+         * @protected
+         */
+        singleton: true
+    }
+
+    /**
+     * @summary Returns scaffold health and config visibility for GitLab workflow tools.
+     * @returns {Promise<Object>}
+     */
+    async healthcheck() {
+        const hostUrl = aiConfig.gitlab?.hostUrl || '';
+        const details = [];
+
+        if (!hostUrl) {
+            details.push('Missing GitLab host URL; set NEO_GITLAB_HOST or config.gitlab.hostUrl.');
+        }
+
+        return {
+            status: details.length ? 'unhealthy' : 'healthy',
+            gitlab: {
+                hostUrl,
+                tokenConfigured: Boolean(aiConfig.gitlab?.token)
+            },
+            details
+        };
+    }
+}
+
+export default Neo.setupClass(HealthService);

--- a/ai/services/gitlab-workflow/IssueService.mjs
+++ b/ai/services/gitlab-workflow/IssueService.mjs
@@ -1,0 +1,94 @@
+import Base from '../../../src/core/Base.mjs';
+
+/**
+ * @summary Scaffold issue-tool service for GitLab Workflow MCP.
+ *
+ * Registers the #11768 issue operations with truthful scaffold responses. Real
+ * GitLab API calls are intentionally deferred to the GitLabClient subtask so this
+ * lane can establish the MCP contract without fabricating persistence behavior.
+ *
+ * @class Neo.ai.services.gitlab-workflow.IssueService
+ * @extends Neo.core.Base
+ * @singleton
+ */
+class IssueService extends Base {
+    static config = {
+        /**
+         * @member {String} className='Neo.ai.services.gitlab-workflow.IssueService'
+         * @protected
+         */
+        className: 'Neo.ai.services.gitlab-workflow.IssueService',
+        /**
+         * @member {Boolean} singleton=true
+         * @protected
+         */
+        singleton: true
+    }
+
+    /**
+     * @summary Builds a truthful scaffold response for a GitLab issue tool.
+     * @param {String} tool
+     * @param {Object} [received={}]
+     * @returns {Object}
+     * @private
+     */
+    #scaffold(tool, received = {}) {
+        return {
+            status : 'scaffolded',
+            tool,
+            message: 'GitLab Workflow MCP tool is registered; real GitLab API behavior lands with the GitLabClient subtask.',
+            received
+        };
+    }
+
+    /**
+     * @summary Lists GitLab issues once the GitLabClient subtask is implemented.
+     * @param {Object} [options={}]
+     * @returns {Promise<Object>}
+     */
+    async listIssues(options = {}) {
+        return {
+            ...this.#scaffold('list_issues', options),
+            items: [],
+            count: 0
+        };
+    }
+
+    /**
+     * @summary Creates a GitLab issue once the GitLabClient subtask is implemented.
+     * @param {Object} options
+     * @returns {Promise<Object>}
+     */
+    async createIssue(options) {
+        return this.#scaffold('create_issue', options);
+    }
+
+    /**
+     * @summary Creates or updates GitLab issue comments once the GitLabClient subtask is implemented.
+     * @param {Object} options
+     * @returns {Promise<Object>}
+     */
+    async manageIssueComment(options) {
+        return this.#scaffold('manage_issue_comment', options);
+    }
+
+    /**
+     * @summary Adds or removes GitLab issue labels once the GitLabClient subtask is implemented.
+     * @param {Object} options
+     * @returns {Promise<Object>}
+     */
+    async manageIssueLabels(options) {
+        return this.#scaffold('manage_issue_labels', options);
+    }
+
+    /**
+     * @summary Adds or removes GitLab issue assignees once the GitLabClient subtask is implemented.
+     * @param {Object} options
+     * @returns {Promise<Object>}
+     */
+    async manageIssueAssignees(options) {
+        return this.#scaffold('manage_issue_assignees', options);
+    }
+}
+
+export default Neo.setupClass(IssueService);

--- a/ai/services/gitlab-workflow/LocalFileService.mjs
+++ b/ai/services/gitlab-workflow/LocalFileService.mjs
@@ -1,0 +1,43 @@
+import Base from '../../../src/core/Base.mjs';
+
+/**
+ * @summary Scaffold local-file service for GitLab issue markdown.
+ *
+ * The initial #11768 lane registers `get_local_issue_by_id` so clients can learn
+ * the future local-cache contract. The syncer subtask owns real
+ * `resources/content/gitlab/...` file IO.
+ *
+ * @class Neo.ai.services.gitlab-workflow.LocalFileService
+ * @extends Neo.core.Base
+ * @singleton
+ */
+class LocalFileService extends Base {
+    static config = {
+        /**
+         * @member {String} className='Neo.ai.services.gitlab-workflow.LocalFileService'
+         * @protected
+         */
+        className: 'Neo.ai.services.gitlab-workflow.LocalFileService',
+        /**
+         * @member {Boolean} singleton=true
+         * @protected
+         */
+        singleton: true
+    }
+
+    /**
+     * @summary Retrieves a GitLab issue markdown file once the syncer subtask lands.
+     * @param {Object} options
+     * @returns {Promise<Object>}
+     */
+    async getIssueById(options) {
+        return {
+            status : 'scaffolded',
+            tool   : 'get_local_issue_by_id',
+            message: 'GitLab local issue cache is registered; real file IO lands with the syncer subtask.',
+            received: options
+        };
+    }
+}
+
+export default Neo.setupClass(LocalFileService);

--- a/ai/services/gitlab-workflow/MergeRequestService.mjs
+++ b/ai/services/gitlab-workflow/MergeRequestService.mjs
@@ -1,0 +1,44 @@
+import Base from '../../../src/core/Base.mjs';
+
+/**
+ * @summary Scaffold merge-request service for GitLab Workflow MCP.
+ *
+ * Registers the #11768 merge-request list operation with a truthful scaffold
+ * response. Real API calls are deferred to the GitLabClient subtask.
+ *
+ * @class Neo.ai.services.gitlab-workflow.MergeRequestService
+ * @extends Neo.core.Base
+ * @singleton
+ */
+class MergeRequestService extends Base {
+    static config = {
+        /**
+         * @member {String} className='Neo.ai.services.gitlab-workflow.MergeRequestService'
+         * @protected
+         */
+        className: 'Neo.ai.services.gitlab-workflow.MergeRequestService',
+        /**
+         * @member {Boolean} singleton=true
+         * @protected
+         */
+        singleton: true
+    }
+
+    /**
+     * @summary Lists GitLab merge requests once the GitLabClient subtask is implemented.
+     * @param {Object} [options={}]
+     * @returns {Promise<Object>}
+     */
+    async listMergeRequests(options = {}) {
+        return {
+            status : 'scaffolded',
+            tool   : 'list_merge_requests',
+            message: 'GitLab Workflow MCP tool is registered; real GitLab API behavior lands with the GitLabClient subtask.',
+            received: options,
+            items  : [],
+            count  : 0
+        };
+    }
+}
+
+export default Neo.setupClass(MergeRequestService);


### PR DESCRIPTION
Authored by GPT-5 Codex (Codex Desktop). Session 2741c4bd-92b2-428b-92d3-ab718d9a7c41.

FAIR-band: over-target [17/30] — taking this lane despite over-target because this is an operator-directed corrective supersede: Gemini is unavailable, PR #11771 is open with a false tool-surface claim, and a Request Changes loop would dead-end.

Resolves #11768

Supersedes PR #11771. This branch keeps the useful GitLab Workflow MCP scaffold idea, but rebuilds the tool registry against the live #11768 acceptance criteria rather than approving the incomplete Gemini branch.

Evidence: L1 (static contract-shape audit + OpenAPI/tool-registry verification) → L1 required (scaffold/tool registry ACs). No residuals.

## Deltas from ticket
- Uses the established sibling pattern `Server.mjs` + `mcp-server.mjs` from `github-workflow`; the ticket text named `server.mjs`, but the repo pattern is the capitalized class file plus lowercase executable entrypoint.
- Registers the exact #11768 operation IDs: `healthcheck`, `list_issues`, `list_merge_requests`, `get_local_issue_by_id`, `create_issue`, `manage_issue_comment`, `manage_issue_labels`, `manage_issue_assignees`.
- Service methods return truthful scaffold responses instead of fake GitLab data. Real GitLab API behavior remains out of scope for the GitLabClient and syncer subtasks.

## MCP Config Template Notes
Changed config keys in `ai/mcp/server/gitlab-workflow/config.template.mjs`: `debug`, `logLevel`, `transport`, `gitlab.hostUrl`, `gitlab.token`.

Env bindings: `NEO_GITLAB_WORKFLOW_DEBUG`, `NEO_GITLAB_WORKFLOW_LOG_LEVEL`, `NEO_GITLAB_WORKFLOW_TRANSPORT`, `NEO_GITLAB_HOST`, `NEO_GITLAB_PAT`.

Local `ai/mcp/server/gitlab-workflow/config.mjs` is gitignored and must be generated from the template before running the new server; `npm run prepare` / `initServerConfigs.mjs` handles this clone. Harness restart is unnecessary unless an operator is actively launching this new MCP server in the same clone.

## Test Evidence
- `git diff --cached --check` passed before commit.
- `node --check` passed for all new `.mjs` files.
- Parsed `openapi.yaml` and verified the eight expected operation IDs.
- Direct `toolService.listTools()` import emitted the eight expected tools after cloning the ignored local `config.mjs` from the template.
- `npm run build-all` was attempted and failed on existing `examples/cloud-deployment/minimal-external-workspace` webpack resolution issues (`neo.mjs/...` aliases and `node:` scheme imports), not on the GitLab workflow files.

## Post-Merge Validation
- [ ] Do not merge PR #11771; close it as superseded after this PR is accepted.
- [ ] In any clone that launches `gitlab-workflow`, run `npm run prepare` or otherwise clone the gitignored config from the new template before starting the server.

## Commit
- `49c252193` — `feat(mcp): scaffold GitLab workflow tool registry (#11768)`