### PR TITLE
feat(deploy): downstream deployment-pipeline wiring reference (#11733)

### DIFF
--- a/examples/cloud-deployment/README.md
+++ b/examples/cloud-deployment/README.md
@@ -7,8 +7,9 @@ guide tree (Epic #11624 — Cloud-Native KB Ingestion).
 |---|---|
 | [`minimal-external-workspace/`](./minimal-external-workspace/) | An external tenant workspace with a custom Source + custom Parser for a non-Neo file format (`.proto`). |
 | [`pre-push-hook.sh`](./pre-push-hook.sh) | A git `pre-push` hook that streams a push's changed files through `ai:kb-push-client` when `NEO_KB_MCP_URL` is configured, with the local `ai:ingest-tenant` bulk facade as fallback. |
+| [`deploy-pipeline.sh`](./deploy-pipeline.sh) | A CI-neutral downstream deploy/redeploy job for the Agent OS compose stack — build, redeploy-safe container recreate, and a `--wait` health gate. Contract: [Pipeline Wiring](../../learn/agentos/cloud-deployment/PipelineWiring.md). |
 
-These are *minimal* demonstrations of the ingestion contracts, not production
+These are *minimal* demonstrations of the ingestion and deployment contracts, not production
 deployments. Read [Overview](../../learn/agentos/cloud-deployment/Overview.md) first,
 then [Tenant Ingestion Model](../../learn/agentos/cloud-deployment/TenantIngestionModel.md)
 for the operational repo-identity, credential-boundary, and source-family inventory rules before

--- a/examples/cloud-deployment/deploy-pipeline.sh
+++ b/examples/cloud-deployment/deploy-pipeline.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+#
+# deploy-pipeline.sh — reference downstream deploy/redeploy job for the cloud
+# Agent OS stack (post-MVP residual #11733).
+#
+# A CI job (GitHub Actions / GitLab CI / Jenkins / ...) calls this on the
+# deployment host. It is intentionally CI-system-neutral — the wiring is the
+# reference, not the CI vendor.
+#
+# Usage:    examples/cloud-deployment/deploy-pipeline.sh [compose-profile ...]
+#           NEO_DEPLOY_PROFILES="cloud ingress" examples/cloud-deployment/deploy-pipeline.sh
+# Contract: learn/agentos/cloud-deployment/PipelineWiring.md
+#
+# Redeploy-safe: recreates containers and KEEPS persistent state. It never runs
+# `docker compose down -v` (that wipes the Memory Core primary store) and pins
+# an explicit `--project-name` so every redeploy reattaches the same volumes.
+#
+set -euo pipefail
+
+# Resolve the compose file from this script's location so the deployment is not
+# tied to the caller's working directory. Deploy from a STABLE host checkout —
+# the backup-bundle bind-mount is a relative path; see PipelineWiring.md.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+COMPOSE_FILE="${NEO_DEPLOY_COMPOSE_FILE:-$SCRIPT_DIR/../../ai/deploy/docker-compose.yml}"
+
+# A stable project name pins named-volume identity across redeploys.
+PROJECT_NAME="${NEO_DEPLOY_PROJECT_NAME:-neo-agent-os}"
+
+# Profiles to deploy. Default: the full cloud stack + ingress. Override by
+# passing profile names as arguments, or via NEO_DEPLOY_PROFILES.
+profile_args=()
+if [ "$#" -gt 0 ]; then
+    for p in "$@"; do profile_args+=(--profile "$p"); done
+else
+    for p in ${NEO_DEPLOY_PROFILES:-cloud ingress}; do profile_args+=(--profile "$p"); done
+fi
+
+compose() { docker compose -f "$COMPOSE_FILE" -p "$PROJECT_NAME" "${profile_args[@]}" "$@"; }
+
+echo "[deploy] revision: $(git -C "$SCRIPT_DIR" describe --tags --always 2>/dev/null || echo unknown)"
+echo "[deploy] compose:  $COMPOSE_FILE"
+echo "[deploy] project:  $PROJECT_NAME"
+echo "[deploy] profiles: ${profile_args[*]}"
+
+# Build + recreate containers, KEEPING named volumes and the backup bind-mount.
+# `--wait` blocks until every service with a healthcheck reports healthy and
+# exits non-zero if one does not — this is the deploy health gate. `set -e`
+# then fails the job, so a broken redeploy is never reported as success.
+compose up -d --build --wait
+
+echo "[deploy] all services healthy — redeploy complete"
+compose ps

--- a/learn/agentos/DeploymentCookbook.md
+++ b/learn/agentos/DeploymentCookbook.md
@@ -128,8 +128,9 @@ The deployment substrates have different recovery properties:
   scales with tenant count.
 - Memory Core graph/session data is a primary store. A wipe between backups is
   data loss.
-- Backup bundles need their own durable volume or managed-object-storage target;
-  the baseline compose file does not yet provide this.
+- Backup bundles persist via a host bind-mount (`./.neo-ai-data/backups` on the
+  `cloud`-profile orchestrator) that survives container rebuilds; off-site copy
+  or a managed-object-storage target is the disaster-recovery layer above that.
 
 The orchestrator consumes model-provider endpoints for `summary`, `dream`, and
 similar lanes. External provider endpoints are the MVP default. A self-hosted
@@ -332,7 +333,8 @@ Post-MVP residual work is tracked separately under:
 - [#11732](https://github.com/neomjs/neo/issues/11732) - graph-store evolution
   beyond the SQLite + mounted-volume MVP baseline.
 - [#11733](https://github.com/neomjs/neo/issues/11733) - downstream external
-  deployment-pipeline wiring.
+  deployment-pipeline wiring. Delivered post-MVP — see [Downstream Pipeline
+  Wiring](cloud-deployment/PipelineWiring.md).
 - [#11734](https://github.com/neomjs/neo/issues/11734) - optional local-model
   runtime container profile.
 - [#11735](https://github.com/neomjs/neo/issues/11735) - tenant-source

--- a/learn/agentos/cloud-deployment/PipelineWiring.md
+++ b/learn/agentos/cloud-deployment/PipelineWiring.md
@@ -47,6 +47,7 @@ The deployment's persistent state (`ai/deploy/docker-compose.yml`):
 | Chroma vectors | `chroma-data` named volume → `/chroma/chroma` | `down -v`, or the project name changes (recoverable by re-sync/re-push, at cost) |
 | Backup bundles | host bind-mount `./.neo-ai-data/backups` on the `cloud`-profile `orchestrator` | the compose file's host location changes between runs |
 | TLS certs / CA | `caddy-data` / `caddy-config` named volumes (`ingress` profile) | `down -v` (re-issued on next start — watch ACME rate limits) |
+| Local model store — opt-in `local-model` profile | `local-model-data` named volume → `/root/.ollama` | `down -v`, or the project name changes (recoverable — re-pull the models) |
 
 Three rules keep a redeploy job safe:
 

--- a/learn/agentos/cloud-deployment/PipelineWiring.md
+++ b/learn/agentos/cloud-deployment/PipelineWiring.md
@@ -1,0 +1,91 @@
+# Cloud Deployment — Downstream Pipeline Wiring
+
+> **Status — Post-MVP residual [#11733](https://github.com/neomjs/neo/issues/11733).** Epic [#11720](https://github.com/neomjs/neo/issues/11720) shipped the in-repo deployment proof: the profile-structured [`ai/deploy/`](../../../ai/deploy/) compose stack, the deployed MCP healthcheck, and the [Day-0 Cloud Deployment Tutorial](./Day0Tutorial.md). This guide is the next phase — wiring that deployment into an external team's downstream CI/CD pipeline so a release can build, deploy, and redeploy the Agent OS stack without a human running `docker compose` by hand. It is a *reference integration*, not a turnkey pipeline: CI systems differ, so the moving parts are documented here and a CI-system-neutral reference script ships under [`examples/cloud-deployment/deploy-pipeline.sh`](../../../examples/cloud-deployment/deploy-pipeline.sh).
+
+## Deployment-pipeline vs content-pipeline
+
+Two different "pipelines" touch a cloud Agent OS deployment — keep them distinct:
+
+| Pipeline | What it moves | Trigger | Guide |
+|---|---|---|---|
+| **Content pipeline** | Tenant *repo content* into the Knowledge Base | a tenant `git push` / commit | [Hook Wiring](./HookWiring.md) |
+| **Deployment pipeline** | The Agent OS *containers themselves* — build, deploy, redeploy | a release tag / a protected `deploy` branch / a manual dispatch | **this guide** |
+
+Hook Wiring is about ingesting what a tenant *writes*. This guide is about shipping the *deployment* — the `chroma` / `kb-server` / `mc-server` / `orchestrator` / `ingress` containers — when the Agent OS image or compose profile changes.
+
+## The reference pipeline shape
+
+A downstream deploy job runs on the deployment host (or a runner with Docker access to it) and performs a fixed sequence:
+
+1. **Check out** the pinned Agent OS revision — a release tag, not an arbitrary commit (see *Release-gating*).
+2. **Build** the images — `docker compose -f ai/deploy/docker-compose.yml [--profile …] build`.
+3. **Redeploy** — recreate the containers against the *existing* persistence volumes (see *Redeploy-safe persistence*).
+4. **Gate on health** — block until the deployed MCP healthchecks pass; fail the job if they do not.
+5. **Report** — surface the healthcheck result so a failed deploy is visible.
+
+[`examples/cloud-deployment/deploy-pipeline.sh`](../../../examples/cloud-deployment/deploy-pipeline.sh) is a runnable reference for steps 2–5. A CI job (GitHub Actions, GitLab CI, Jenkins, …) calls it; the script is CI-system-neutral so the wiring is not locked to one vendor.
+
+## Release-gating
+
+Do not redeploy on every commit. The Agent OS deployment is a stateful service; a redeploy recreates containers and briefly interrupts MCP availability. Gate the deploy job on a deliberate signal:
+
+- **Release tag** — the recommended default. The pipeline triggers on a tag (e.g. `v*`) and deploys that exact revision; the tag name becomes the deployed-version record.
+- **A protected `deploy` branch** — an update to a branch that only release automation or a maintainer can advance.
+- **Manual dispatch** — an operator-triggered job for controlled rollouts.
+
+Avoid "deploy on every push to `dev`": it couples MCP availability to ordinary development cadence.
+
+## Redeploy-safe persistence
+
+This is the load-bearing rule. A pipeline-driven redeploy **recreates containers**; it must **not destroy persistent state**. Sub C ([#11724](https://github.com/neomjs/neo/issues/11724)) already made the deployment redeploy-safe — the pipeline's job is to not undo it.
+
+The deployment's persistent state (`ai/deploy/docker-compose.yml`):
+
+| State | Mechanism | Lost when... |
+|---|---|---|
+| Memory Core graph + sessions — the **primary store** | `shared-sqlite-data` named volume → `/app/.neo-ai-data/sqlite` | `down -v`, or the Compose project name changes |
+| Chroma vectors | `chroma-data` named volume → `/chroma/chroma` | `down -v`, or the project name changes (recoverable by re-sync/re-push, at cost) |
+| Backup bundles | host bind-mount `./.neo-ai-data/backups` on the `cloud`-profile `orchestrator` | the compose file's host location changes between runs |
+| TLS certs / CA | `caddy-data` / `caddy-config` named volumes (`ingress` profile) | `down -v` (re-issued on next start — watch ACME rate limits) |
+
+Three rules keep a redeploy job safe:
+
+1. **Recreate, never wipe.** Redeploy with `docker compose up -d --build` (or `docker compose down` then `up`). Both recreate containers and keep volumes. **Never `docker compose down -v`** in a redeploy job — `-v` removes the named volumes and wipes the Memory Core primary store. `-v` belongs only in a deliberate teardown.
+2. **Pin the Compose project name.** Named volumes are identified as `<project-name>_<volume>`. The project name defaults to the compose-file directory's basename (`deploy`). A redeploy run with a different `--project-name` (or after the compose file moves) gets *fresh, empty* volumes — the old data is intact but unreferenced. Pass an explicit, stable `--project-name` (the reference script pins one) so every redeploy reattaches the same volumes.
+3. **Deploy from a stable host location.** The backup-bundle bind-mount `./.neo-ai-data/backups` resolves relative to the compose file's project directory. If the deployment repo is checked out to a different host path on each run — common with ephemeral CI runners — the bind-mount points at a different host directory each time and prior bundles are orphaned. Deploy from a **persistent checkout location** on the deployment host, not an ephemeral per-run runner workspace; or retarget backups to an absolute host path / managed object storage.
+
+Off-site copy of the backup bundles is the disaster-recovery layer *above* redeploy-safety: redeploy-safety keeps state across a container *recreate*; backups plus off-site copy cover host loss.
+
+**Verification:** the redeploy-survival check is [Day-0 Tutorial Milestone 7](./Day0Tutorial.md) — a `docker compose down && docker compose up --build` cycle, then confirm the Memory Core store and backup bundles are intact. Run that check once when the pipeline is first wired; subsequent redeploys rely on the named-volume + project-name + bind-mount contract above.
+
+## The health gate
+
+A redeploy is not "done" when `docker compose up` returns — it is done when the MCP servers report healthy. The compose file already declares Docker healthchecks (`mcpHealthcheck.mjs` over `/mcp`); a deploy job should gate on them so a broken deploy fails loudly:
+
+- `docker compose ... up -d --build --wait` blocks until every service with a healthcheck is healthy and exits non-zero if one does not — the simplest gate, used by the reference script.
+- Or poll `docker compose ps` / the healthcheck CLI (`npm run ai:mcp-healthcheck`) and fail the job on a non-healthy result.
+
+A deploy job that does not gate on health reports success while serving a broken stack. See [Deployment Cookbook §8](../DeploymentCookbook.md) for the healthcheck/readiness contract.
+
+## Failure signatures
+
+| Signature | Likely cause | Pipeline response |
+|---|---|---|
+| Healthcheck never goes healthy after redeploy | image build broken, a required env var unset, or Chroma unreachable | fail the job; surface `docker compose logs`; the prior volumes are intact for a retry |
+| Memory Core store empty after redeploy | the job ran `docker compose down -v`, or redeployed under a different `--project-name` | never `-v`; pin `--project-name` — the old volume still holds the data, reattach it |
+| Backup bundles missing after redeploy | redeployed from a different host checkout location (relative bind-mount) | deploy from a stable checkout path; recover bundles from the prior host directory |
+| TLS cert re-issued / ACME rate-limited each deploy | `caddy-data` removed by `down -v` | stop using `-v` so the issued certs persist |
+
+## Out of scope
+
+- The MVP backup/persistence *implementation* — owned by Sub C [#11724](https://github.com/neomjs/neo/issues/11724); this guide documents how a pipeline *preserves* it.
+- A turnkey, vendor-specific CI workflow — CI systems differ; this guide plus the reference script are the CI-neutral substrate a team adapts.
+- Multi-instance / blue-green / zero-downtime deploy topologies — a later evolution; the reference shape is single-instance recreate-in-place.
+
+## Related
+
+- [Deployment Cookbook](../DeploymentCookbook.md) — the deployment authority: topology, profiles, persistence (§5), healthcheck contract (§8).
+- [Day-0 Cloud Deployment Tutorial](./Day0Tutorial.md) — the first-run path; Milestone 7 is the redeploy-survival check this pipeline automates.
+- [Hook Wiring](./HookWiring.md) — the *content* pipeline (tenant repo content into the KB), distinct from this *deployment* pipeline.
+- [`examples/cloud-deployment/deploy-pipeline.sh`](../../../examples/cloud-deployment/deploy-pipeline.sh) — the runnable, CI-neutral reference deploy/redeploy script.
+- [ADR 0014](../decisions/0014-cloud-deployment-topology-and-scheduler-task-taxonomy.md) — the cloud topology + scheduler taxonomy this deployment implements.

--- a/learn/tree.json
+++ b/learn/tree.json
@@ -46,6 +46,7 @@
             {"name": "Custom Sources",                                 "parentId": "AgentOS/CloudDeployment",                             "id": "agentos/cloud-deployment/CustomSources"},
             {"name": "Custom Parsers",                                 "parentId": "AgentOS/CloudDeployment",                             "id": "agentos/cloud-deployment/CustomParsers"},
             {"name": "Hook Wiring",                                     "parentId": "AgentOS/CloudDeployment",                             "id": "agentos/cloud-deployment/HookWiring"},
+            {"name": "Pipeline Wiring",                                "parentId": "AgentOS/CloudDeployment",                             "id": "agentos/cloud-deployment/PipelineWiring"},
             {"name": "Security",                                       "parentId": "AgentOS/CloudDeployment",                             "id": "agentos/cloud-deployment/Security"},
             {"name": "Migration Path",                                 "parentId": "AgentOS/CloudDeployment",                             "id": "agentos/cloud-deployment/MigrationPath"},
         {"name": "Config Substrate Env-Var Audit",                     "parentId": "AgentOS",                                             "id": "agentos/ConfigSubstrateEnvVarAudit"},


### PR DESCRIPTION
Resolves #11733

Adds a reference downstream-pipeline integration for the containerized Agent OS deployment — the post-MVP residual that wires the `ai/deploy/` compose stack into an external team's CI/CD pipeline (build / release-gated deploy / automated redeploy), with redeploy-safe persistence the load-bearing concern.

Authored by Neo Opus 4.7 (Claude Code). Session 0b0a7cee-f2c4-4e1f-9eeb-cdc6bd0330fb.

FAIR-band: under-target [11/30] — Self-Selection Rule 1 fires (under-band → bias toward author lane).

Evidence: L1 (reference guide + CI-neutral deploy script — a static deliverable; the redeploy-safety claims are V-B-A'd against the live `ai/deploy/docker-compose.yml`) → L1 required (#11733's ACs are "exists or is documented" / reference-integration, satisfiable by static contract). The L4 runtime redeploy-survival proof is the existing Day-0 Tutorial Milestone 7 check, not new to this PR. No residuals.

## What shipped

- **New guide — `learn/agentos/cloud-deployment/PipelineWiring.md`**: the reference downstream-pipeline integration. Covers the deployment-pipeline-vs-content-pipeline distinction (this is *not* `HookWiring.md`), the 5-step reference shape, release-gating, redeploy-safe persistence, the health gate, and failure signatures.
- **New sample — `examples/cloud-deployment/deploy-pipeline.sh`**: a CI-neutral reference deploy/redeploy script — builds + recreates containers, pins `--project-name` for stable named-volume identity, uses `up --wait` as the health gate, never `down -v`.
- **`learn/agentos/DeploymentCookbook.md`**: Section 10's #11733 residual line now points to the delivered guide; Section 5's stale "the baseline compose file does not yet provide [backup persistence]" sentence is corrected — the compose *does* provide it, via the `cloud`-profile orchestrator's `./.neo-ai-data/backups` bind-mount.
- **`examples/cloud-deployment/README.md`** + **`learn/tree.json`**: register the new sample + guide.

## Slot Rationale (§1.1 substrate-mutation gate)

Touches `learn/agentos/**`:
- **Added — `PipelineWiring.md`** (new guide): disposition **`keep`**. Trigger-frequency low (operators wiring a deployment pipeline), failure-severity medium-high (a redeploy that runs `down -v` wipes the Memory Core primary store — data loss), enforceability medium (guide + reference script, not a mechanical gate). Conditionally-read guide-tree entry, **not** always-loaded Map substrate — zero turn-loaded-budget accretion. Decay-mitigation: sits in the `cloud-deployment/` guide tree with its siblings; supersedable by a managed-platform deployment guide.
- **Modified — `DeploymentCookbook.md`**: disposition delta `keep` → `keep`. Section 10 #11733 line → delivered-guide pointer; Section 5 stale backup-persistence claim corrected. Conditionally-read authority doc — no size-budget concern.

## Deltas from ticket

- #11733 AC2 ("pipeline-driven redeploy preserves the #11724 persistence guarantees") surfaced a stale claim in `DeploymentCookbook.md` Section 5 — it said the baseline compose provides no backup-bundle persistence, but the orchestrator service has carried a `./.neo-ai-data/backups` bind-mount since Sub C #11724. Corrected in-PR for deployment-doc coherence — it is the persistence story #11733 builds on.
- During #11733 ticket-intake the deployment-subsystem-guide audit confirmed the existing CI/hook docs (`HookWiring.md`) cover tenant-*content* repo-push only; the deployment pipeline is genuinely unaddressed. The new guide opens with that distinction so the two pipelines are never conflated.

## Test Evidence

- No unit test: the deliverable is reference documentation + a CI-neutral shell script — it changes no runtime code and no compose shape. The sibling sample `pre-push-hook.sh` carries no unit test for the same reason.
- `git diff --check` — clean (the pre-commit `check-whitespace` hook passed both commits).
- `learn/tree.json` — `JSON.parse`-validated; the new `agentos/cloud-deployment/PipelineWiring` id maps to the created file.
- Redeploy-safety claims (named-volume / bind-mount survival, `down -v` data-loss, project-name pinning) V-B-A'd against the live `ai/deploy/docker-compose.yml`.

## Post-Merge Validation

- [ ] On a Docker-capable host, run `examples/cloud-deployment/deploy-pipeline.sh` against a built stack; confirm `up --wait` gates on health.
- [ ] Run the Day-0 Tutorial Milestone 7 redeploy-survival check (`docker compose down && up --build`) and confirm the Memory Core store + backup bundles survive — the L4 proof of AC2.

## Commits

- `47a294955` — feat(deploy): add downstream deployment-pipeline wiring reference
- `1a5fc9a5c` — feat(deploy): note local-model-data volume in the redeploy-safety table

## Related

- Epic #11730 (Post-MVP Residual Workstreams); epic-review Greenlit — https://github.com/neomjs/neo/issues/11730#issuecomment-4521147417
- ADR 0014 — cloud deployment topology + scheduler taxonomy.