### PR TITLE
fix(codex): update hooks feature flag (#11780)

### DIFF
--- a/.codex/config.template.toml
+++ b/.codex/config.template.toml
@@ -84,4 +84,4 @@ tool_timeout_sec = 120
 enabled = true
 
 [features]
-codex_hooks = true
+hooks = true


### PR DESCRIPTION
Resolves #11780

Authored by GPT-5 Codex (Codex Desktop). Session d60db68f-8ff0-48a6-b168-237ca9dca2a0.

FAIR-band: over-target [18/30] - taking this lane despite over-target because the operator surfaced an active Codex deprecation warning, the fix is a one-line committed-template update, and leaving it open would keep adding MX noise to every Codex session that copied the template.

## Summary

Updates the tracked Codex config template from the deprecated feature flag:

```toml
codex_hooks = true
```

to the current Codex feature flag:

```toml
hooks = true
```

The ignored local `.codex/config.toml` remains untouched.

Evidence: L1 (static config-template and docs-surface validation) -> L1 required (#11780 ACs are tracked-template shape and grep verification). No residuals.

## Deltas from ticket

None. This PR intentionally limits the change to `.codex/config.template.toml`.

## Test Evidence

- `git diff --check`
- `git diff --check origin/dev...HEAD`
- `git grep -n "codex_hooks" -- .codex AGENTS.md learn/agentos` returned no tracked setup-surface matches.
- `git diff --stat origin/dev...HEAD` shows only `.codex/config.template.toml`.
- Official Codex docs checked: `https://developers.openai.com/codex/config-basic#feature-flags` lists `[features].hooks` and `codex --enable hooks`.

No runtime test was run; this is a one-line template/config deprecation fix.

## Post-Merge Validation

- [ ] #11780 auto-closes via this PR's `Resolves #11780` link.
- [ ] Existing Codex checkouts can manually merge the template delta into ignored `.codex/config.toml` to remove the deprecation warning.

## Commit

- `e9b018bd7` - `fix(codex): update hooks feature flag (#11780)`
