### PR TITLE
fix(ai): skip no-op primary-dev KB cascades (#11783)

### DIFF
--- a/ai/daemons/services/PrimaryRepoSyncService.mjs
+++ b/ai/daemons/services/PrimaryRepoSyncService.mjs
@@ -13,6 +13,48 @@ const META_SYNC_PATH = 'resources/content/.sync-metadata.json';
 export const DEV_SYNC_ROOTS_ENV_VAR = 'NEO_ORCHESTRATOR_DEV_SYNC_ROOTS';
 export const DEV_SYNC_ROOTS_CONFIG_KEY = 'orchestrator.devSyncRoots';
 
+const KB_RELEVANT_PATH_PREFIXES = Object.freeze([
+    '.agents/skills/',
+    '.github/RELEASE_NOTES/',
+    'ai/',
+    'apps/',
+    'docs/app/',
+    'examples/',
+    'learn/',
+    'resources/content/',
+    'src/',
+    'test/playwright/'
+]);
+
+const KB_RELEVANT_PATHS = Object.freeze(new Set([
+    'docs/output/class-hierarchy.json'
+]));
+
+const KB_IRRELEVANT_PATHS = Object.freeze(new Set([
+    META_SYNC_PATH
+]));
+
+/**
+ * @summary Checks whether a changed repository path can affect generated KB corpus chunks.
+ *
+ * The predicate mirrors Neo's default `SourceRegistry` roots conservatively. The decision
+ * layer falls back to the full KB cascade whenever the revision or changed-path probes fail;
+ * this helper only classifies concrete paths from a verified git diff.
+ *
+ * @param {String} filePath Repository-relative path.
+ * @returns {Boolean}
+ */
+export function isKbRelevantChangePath(filePath) {
+    const normalized = String(filePath || '').replace(/\\/g, '/').replace(/^\.\//, '');
+
+    if (!normalized || KB_IRRELEVANT_PATHS.has(normalized)) {
+        return false;
+    }
+
+    return KB_RELEVANT_PATHS.has(normalized) ||
+        KB_RELEVANT_PATH_PREFIXES.some(prefix => normalized.startsWith(prefix));
+}
+
 /**
  * @summary Parses the primary-dev-sync enable flag.
  *
@@ -336,9 +378,13 @@ class PrimaryRepoSyncService extends Base {
             kbSync: false
         };
 
-        if (completed > 0) {
+        const kbSyncRequired = rootResults.some(result => result.status === 'completed' && result.kbSyncRequired !== false);
+
+        if (completed > 0 && kbSyncRequired) {
             this.runKbSync(primaryRoot, execFileSyncFn, {taskStateService, healthService});
             details.kbSync = true;
+        } else if (completed > 0) {
+            details.reasonCode = 'no-kb-relevant-changes';
         } else if (rootResults.length === 0) {
             details.reasonCode = 'no-configured-roots';
         } else if (failed > 0) {
@@ -410,13 +456,22 @@ class PrimaryRepoSyncService extends Base {
         }
 
         try {
+            const oldHead = this.resolveOptionalHead(root, execFileSyncFn);
             this.git(['pull', '--ff-only', REMOTE_NAME, DEV_BRANCH], root, execFileSyncFn);
-            if (runKbSync) {
+            const newHead = this.resolveOptionalHead(root, execFileSyncFn);
+            const kbSyncDecision = this.resolveKbSyncDecision({root, oldHead, newHead, execFileSyncFn});
+            if (runKbSync && kbSyncDecision.kbSyncRequired) {
                 this.runKbSync(root, execFileSyncFn, {taskStateService, healthService});
             }
             return {
                 status : 'completed',
-                details: {...rootDetails, behind, layer: 'ff-pull', kbSync: runKbSync}
+                details: {
+                    ...rootDetails,
+                    behind,
+                    layer : 'ff-pull',
+                    kbSync: runKbSync && kbSyncDecision.kbSyncRequired,
+                    ...kbSyncDecision
+                }
             };
         } catch (e) {
             const postPullStatus = this.git(['status', '--porcelain'], root, execFileSyncFn);
@@ -474,15 +529,25 @@ class PrimaryRepoSyncService extends Base {
         const rootDetails = {[rootKey]: root};
 
         writeLog?.('INFO', `[PrimaryRepoSync] Resetting ${META_SYNC_PATH} before fast-forward pull.`);
+        const oldHead = this.resolveOptionalHead(root, execFileSyncFn);
         this.git(['checkout', '--', META_SYNC_PATH], root, execFileSyncFn);
         this.git(['pull', '--ff-only', REMOTE_NAME, DEV_BRANCH], root, execFileSyncFn);
-        if (runKbSync) {
+        const newHead = this.resolveOptionalHead(root, execFileSyncFn);
+        const kbSyncDecision = this.resolveKbSyncDecision({root, oldHead, newHead, execFileSyncFn});
+        if (runKbSync && kbSyncDecision.kbSyncRequired) {
             this.runKbSync(root, execFileSyncFn, {taskStateService, healthService});
         }
 
         return {
             status : 'completed',
-            details: {...rootDetails, behind, layer: 'meta-sync-reset', resolved: 'meta-sync', kbSync: runKbSync}
+            details: {
+                ...rootDetails,
+                behind,
+                layer   : 'meta-sync-reset',
+                resolved: 'meta-sync',
+                kbSync  : runKbSync && kbSyncDecision.kbSyncRequired,
+                ...kbSyncDecision
+            }
         };
     }
 
@@ -588,6 +653,104 @@ class PrimaryRepoSyncService extends Base {
         const parsed = parseInt(output || '0', 10);
 
         return Number.isNaN(parsed) ? 0 : parsed;
+    }
+
+    /**
+     * Resolves the current repository HEAD.
+     * @param {String} root Repository root.
+     * @param {Function} execFileSyncFn Command execution seam.
+     * @returns {String}
+     */
+    resolveHead(root, execFileSyncFn) {
+        return this.git(['rev-parse', 'HEAD'], root, execFileSyncFn).trim();
+    }
+
+    /**
+     * Resolves HEAD without blocking the pull path when the probe itself fails.
+     * @param {String} root Repository root.
+     * @param {Function} execFileSyncFn Command execution seam.
+     * @returns {String|null}
+     */
+    resolveOptionalHead(root, execFileSyncFn) {
+        try {
+            return this.resolveHead(root, execFileSyncFn);
+        } catch (e) {
+            return null;
+        }
+    }
+
+    /**
+     * Resolves the changed paths for one revision boundary.
+     * @param {Object} options
+     * @param {String} options.root Repository root.
+     * @param {String} options.oldHead Previous HEAD.
+     * @param {String} options.newHead Current HEAD.
+     * @param {Function} options.execFileSyncFn Command execution seam.
+     * @returns {String[]}
+     */
+    resolveChangedPaths({root, oldHead, newHead, execFileSyncFn}) {
+        const output = this.git(['diff', '--name-only', `${oldHead}..${newHead}`], root, execFileSyncFn).trim();
+
+        return output ? output.split('\n').map(item => item.trim()).filter(Boolean) : [];
+    }
+
+    /**
+     * Decides whether a successful dev pull needs the expensive KB cascade.
+     * @param {Object} options
+     * @param {String} options.root Repository root.
+     * @param {String} options.oldHead Previous HEAD.
+     * @param {String} options.newHead Current HEAD.
+     * @param {Function} options.execFileSyncFn Command execution seam.
+     * @returns {Object}
+     */
+    resolveKbSyncDecision({root, oldHead, newHead, execFileSyncFn}) {
+        if (!oldHead || !newHead) {
+            return {
+                kbSyncRequired  : true,
+                kbSyncReasonCode: 'kb-relevance-unknown-head',
+                oldHead,
+                newHead
+            };
+        }
+
+        if (oldHead === newHead) {
+            return {
+                kbSyncRequired     : false,
+                kbSyncReasonCode   : 'no-kb-relevant-changes',
+                reasonCode         : 'no-kb-relevant-changes',
+                oldHead,
+                newHead,
+                changedPathCount   : 0,
+                kbChangedPathCount : 0,
+                kbChangedPathSample: []
+            };
+        }
+
+        let changedPaths;
+        try {
+            changedPaths = this.resolveChangedPaths({root, oldHead, newHead, execFileSyncFn});
+        } catch (e) {
+            return {
+                kbSyncRequired  : true,
+                kbSyncReasonCode: 'kb-relevance-check-failed',
+                oldHead,
+                newHead,
+                error         : e.message
+            };
+        }
+
+        const kbChangedPaths = changedPaths.filter(isKbRelevantChangePath);
+
+        return {
+            kbSyncRequired     : kbChangedPaths.length > 0,
+            kbSyncReasonCode   : kbChangedPaths.length > 0 ? 'kb-relevant-changes' : 'no-kb-relevant-changes',
+            ...(kbChangedPaths.length > 0 ? {} : {reasonCode: 'no-kb-relevant-changes'}),
+            oldHead,
+            newHead,
+            changedPathCount   : changedPaths.length,
+            kbChangedPathCount : kbChangedPaths.length,
+            kbChangedPathSample: kbChangedPaths.slice(0, 10)
+        };
     }
 
     /**

--- a/test/playwright/unit/ai/daemons/services/PrimaryRepoSyncService.spec.mjs
+++ b/test/playwright/unit/ai/daemons/services/PrimaryRepoSyncService.spec.mjs
@@ -5,6 +5,7 @@ import PrimaryRepoSyncService, {
     buildPrimaryRepoSyncTrigger,
     DEV_SYNC_ROOTS_CONFIG_KEY,
     DEV_SYNC_ROOTS_ENV_VAR,
+    isKbRelevantChangePath,
     parseDevSyncRoots,
     parseEnabledFlag
 } from '../../../../../../ai/daemons/services/PrimaryRepoSyncService.mjs';
@@ -128,6 +129,37 @@ test.describe('PrimaryRepoSyncService (#11017)', () => {
         });
     });
 
+    test('classifies KB-relevant change paths conservatively', () => {
+        expect(isKbRelevantChangePath('src/button/Base.mjs')).toBe(true);
+        expect(isKbRelevantChangePath('ai/services/knowledge-base/source/ApiSource.mjs')).toBe(true);
+        expect(isKbRelevantChangePath('docs/output/class-hierarchy.json')).toBe(true);
+        expect(isKbRelevantChangePath('resources/content/issues/chunk-13/issue-11783.md')).toBe(true);
+        expect(isKbRelevantChangePath('resources/content/.sync-metadata.json')).toBe(false);
+        expect(isKbRelevantChangePath('.codex/config.template.toml')).toBe(false);
+        expect(isKbRelevantChangePath('package.json')).toBe(false);
+    });
+
+    test('falls back to KB cascade when changed-path detection fails', () => {
+        const execStub = createExecStub([{
+            cmd  : 'git',
+            args : ['diff', '--name-only', 'old-head..new-head'],
+            error: 'bad revision'
+        }]);
+
+        expect(PrimaryRepoSyncService.resolveKbSyncDecision({
+            root          : '/primary/neo',
+            oldHead       : 'old-head',
+            newHead       : 'new-head',
+            execFileSyncFn: execStub
+        })).toEqual({
+            kbSyncRequired  : true,
+            kbSyncReasonCode: 'kb-relevance-check-failed',
+            oldHead         : 'old-head',
+            newHead         : 'new-head',
+            error           : 'bad revision'
+        });
+    });
+
     test('resolves primary checkout from worktree list and falls back to git-common-dir', () => {
         const worktreeExec = createExecStub([{
             cmd   : 'git',
@@ -204,25 +236,44 @@ test.describe('PrimaryRepoSyncService (#11017)', () => {
             args  : ['status', '--porcelain'],
             output: ''
         }, {
+            cmd   : 'git',
+            args  : ['rev-parse', 'HEAD'],
+            output: 'old-head\n'
+        }, {
             cmd : 'git',
             args: ['pull', '--ff-only', 'origin', 'dev']
+        }, {
+            cmd   : 'git',
+            args  : ['rev-parse', 'HEAD'],
+            output: 'new-head\n'
+        }, {
+            cmd   : 'git',
+            args  : ['diff', '--name-only', 'old-head..new-head'],
+            output: 'src/button/Base.mjs\n'
         }, {
             cmd : process.platform === 'win32' ? 'npm.cmd' : 'npm',
             args: ['run', 'ai:sync-kb']
         }]);
 
-        expect(PrimaryRepoSyncService.syncPrimaryDev({
+        const result = PrimaryRepoSyncService.syncPrimaryDev({
             cwd           : '/primary/neo',
             execFileSyncFn: execStub,
             writeLog      : () => {}
-        })).toEqual({
-            status : 'completed',
-            details: {
-                primaryRoot: '/primary/neo',
-                behind     : 2,
-                layer      : 'ff-pull',
-                kbSync     : true
-            }
+        });
+
+        expect(result.status).toBe('completed');
+        expect(result.details).toMatchObject({
+            primaryRoot        : '/primary/neo',
+            behind             : 2,
+            layer              : 'ff-pull',
+            kbSync             : true,
+            kbSyncRequired     : true,
+            kbSyncReasonCode   : 'kb-relevant-changes',
+            oldHead            : 'old-head',
+            newHead            : 'new-head',
+            changedPathCount   : 1,
+            kbChangedPathCount : 1,
+            kbChangedPathSample: ['src/button/Base.mjs']
         });
     });
 
@@ -247,14 +298,23 @@ test.describe('PrimaryRepoSyncService (#11017)', () => {
             args  : ['status', '--porcelain'],
             output: ' M resources/content/.sync-metadata.json\n'
         }, {
+            cmd   : 'git',
+            args  : ['rev-parse', 'HEAD'],
+            output: 'old-head\n'
+        }, {
             cmd : 'git',
             args: ['checkout', '--', 'resources/content/.sync-metadata.json']
         }, {
             cmd : 'git',
             args: ['pull', '--ff-only', 'origin', 'dev']
         }, {
-            cmd : process.platform === 'win32' ? 'npm.cmd' : 'npm',
-            args: ['run', 'ai:sync-kb']
+            cmd   : 'git',
+            args  : ['rev-parse', 'HEAD'],
+            output: 'new-head\n'
+        }, {
+            cmd   : 'git',
+            args  : ['diff', '--name-only', 'old-head..new-head'],
+            output: 'resources/content/.sync-metadata.json\n'
         }]);
 
         const result = PrimaryRepoSyncService.syncPrimaryDev({
@@ -265,6 +325,15 @@ test.describe('PrimaryRepoSyncService (#11017)', () => {
 
         expect(result.status).toBe('completed');
         expect(result.details.resolved).toBe('meta-sync');
+        expect(result.details).toMatchObject({
+            kbSync            : false,
+            kbSyncRequired    : false,
+            kbSyncReasonCode  : 'no-kb-relevant-changes',
+            reasonCode        : 'no-kb-relevant-changes',
+            changedPathCount  : 1,
+            kbChangedPathCount: 0
+        });
+        expect(execStub.calls.map(call => call.cmd)).not.toContain(process.platform === 'win32' ? 'npm.cmd' : 'npm');
     });
 
     test('syncs configured dev roots and cascades KB once from the owning checkout', () => {
@@ -296,8 +365,20 @@ test.describe('PrimaryRepoSyncService (#11017)', () => {
             args  : ['status', '--porcelain'],
             output: ''
         }, {
+            cmd   : 'git',
+            args  : ['rev-parse', 'HEAD'],
+            output: 'old-head\n'
+        }, {
             cmd : 'git',
             args: ['pull', '--ff-only', 'origin', 'dev']
+        }, {
+            cmd   : 'git',
+            args  : ['rev-parse', 'HEAD'],
+            output: 'new-head\n'
+        }, {
+            cmd   : 'git',
+            args  : ['diff', '--name-only', 'old-head..new-head'],
+            output: 'learn/guides/testing/UnitTesting.md\n'
         }, {
             cmd   : 'git',
             args  : ['rev-parse', '--show-toplevel'],
@@ -339,11 +420,18 @@ test.describe('PrimaryRepoSyncService (#11017)', () => {
                 skipped    : 1,
                 failed     : 0,
                 roots      : [{
-                    status: 'completed',
-                    root  : '/primary/neo',
-                    behind: 2,
-                    layer : 'ff-pull',
-                    kbSync: false
+                    status             : 'completed',
+                    root               : '/primary/neo',
+                    behind             : 2,
+                    layer              : 'ff-pull',
+                    kbSync             : false,
+                    kbSyncRequired     : true,
+                    kbSyncReasonCode   : 'kb-relevant-changes',
+                    oldHead            : 'old-head',
+                    newHead            : 'new-head',
+                    changedPathCount   : 1,
+                    kbChangedPathCount : 1,
+                    kbChangedPathSample: ['learn/guides/testing/UnitTesting.md']
                 }, {
                     status    : 'skipped',
                     reasonCode: 'up-to-date',
@@ -355,6 +443,76 @@ test.describe('PrimaryRepoSyncService (#11017)', () => {
         });
         expect(execStub.calls.filter(call => call.cmd.includes('npm') || call.cmd === 'npm').length).toBe(1);
         expect(execStub.calls.at(-1).cwd).toBe('/primary/neo');
+    });
+
+    test('skips configured-root KB cascade when completed roots changed no KB inputs', () => {
+        const execStub = createExecStub([{
+            cmd   : 'git',
+            args  : ['worktree', 'list', '--porcelain'],
+            output: 'worktree /primary/neo\n'
+        }, {
+            cmd   : 'git',
+            args  : ['rev-parse', '--show-toplevel'],
+            output: '/primary/neo\n'
+        }, {
+            cmd : 'git',
+            args: ['fetch', 'origin', 'dev', '--quiet']
+        }, {
+            cmd   : 'git',
+            args  : ['rev-parse', '--verify', 'origin/dev'],
+            output: 'abc123\n'
+        }, {
+            cmd   : 'git',
+            args  : ['rev-parse', '--abbrev-ref', 'HEAD'],
+            output: 'dev\n'
+        }, {
+            cmd   : 'git',
+            args  : ['rev-list', '--count', 'dev..origin/dev'],
+            output: '1\n'
+        }, {
+            cmd   : 'git',
+            args  : ['status', '--porcelain'],
+            output: ''
+        }, {
+            cmd   : 'git',
+            args  : ['rev-parse', 'HEAD'],
+            output: 'old-head\n'
+        }, {
+            cmd : 'git',
+            args: ['pull', '--ff-only', 'origin', 'dev']
+        }, {
+            cmd   : 'git',
+            args  : ['rev-parse', 'HEAD'],
+            output: 'new-head\n'
+        }, {
+            cmd   : 'git',
+            args  : ['diff', '--name-only', 'old-head..new-head'],
+            output: '.codex/config.template.toml\n'
+        }]);
+
+        const result = PrimaryRepoSyncService.syncPrimaryDev({
+            cwd               : '/primary/neo',
+            execFileSyncFn    : execStub,
+            writeLog          : () => {},
+            devSyncRootsConfig: '["/primary/neo"]'
+        });
+
+        expect(result.status).toBe('completed');
+        expect(result.details).toMatchObject({
+            mode      : 'configured-roots',
+            completed : 1,
+            kbSync    : false,
+            reasonCode: 'no-kb-relevant-changes'
+        });
+        expect(result.details.roots[0]).toMatchObject({
+            status            : 'completed',
+            kbSyncRequired    : false,
+            kbSyncReasonCode  : 'no-kb-relevant-changes',
+            reasonCode        : 'no-kb-relevant-changes',
+            changedPathCount  : 1,
+            kbChangedPathCount: 0
+        });
+        expect(execStub.calls.map(call => call.cmd)).not.toContain(process.platform === 'win32' ? 'npm.cmd' : 'npm');
     });
 
     test('configured non-dev roots fetch origin/dev but never switch branches', () => {


### PR DESCRIPTION
Resolves #11783

Authored by GPT-5.5 (Codex Desktop). Session 019e5111-6366-7b01-82e0-df2d9b738841.
FAIR-band: over-target [18/30] - taking this lane despite over-target because the operator surfaced live no-op KB cascade logs, Claude was slowed by API issues, and the patch is a narrow daemon optimization that removes immediate orchestrator pressure.

Primary dev sync now snapshots HEAD before and after a successful pull, computes `git diff --name-only oldHEAD..newHEAD`, and only runs the expensive KB cascade when the changed paths intersect Neo's default KB source roots. Generated metadata-only and other non-KB changes skip the Chroma-heavy `npm run ai:sync-kb` path, while failed HEAD/diff probes fall back to the existing full cascade.

Evidence: L2 (mock-git command dispatch plus focused unit coverage of cascade/skip/fallback paths) -> L2 required (daemon decision contract). No residuals.

## Deltas from Ticket

- Implemented per-pull revision-diff gating instead of a persistent branch-SHA cache. `PrimaryRepoSyncService` already skips when `origin/dev` has no new commits; this patch removes the expensive cascade after a successful pull whose changed files cannot affect the KB corpus.
- Kept fallback behavior conservative: missing HEADs or failed changed-path detection still run the full KB cascade.
- Applied the same decision result to configured-root aggregation so one KB-relevant completed root still cascades once from the owning checkout, while all-non-KB completed roots skip.

## Test Evidence

- `git diff --check`
- `node --check ai/daemons/services/PrimaryRepoSyncService.mjs`
- `node --check test/playwright/unit/ai/daemons/services/PrimaryRepoSyncService.spec.mjs`
- `npm run test-unit -- test/playwright/unit/ai/daemons/services/PrimaryRepoSyncService.spec.mjs` -> 21 passed
- V-B-A source-root check: verified `SourceRegistry` default sources and `ai/mcp/server/knowledge-base/config.template.mjs` `sourcePaths` before finalizing the path predicate.

## Post-Merge Validation

- [ ] Observe one orchestrator primary-dev-sync cycle with only non-KB changed paths and confirm it reports `no-kb-relevant-changes` without spawning `npm run ai:sync-kb`.
- [ ] Observe a later KB-relevant pull (`src/`, `learn/`, `ai/`, `resources/content/`, etc.) and confirm the cascade still runs once.

## Commits

- `414b0d8af` - `fix(ai): skip no-op primary-dev KB cascades (#11783)`
