### PR TITLE
fix(ai): normalize swarm heartbeat identity (#11797)

### DIFF
--- a/ai/daemons/SwarmHeartbeatService.mjs
+++ b/ai/daemons/SwarmHeartbeatService.mjs
@@ -23,7 +23,10 @@ import {
     HEARTBEAT_LOCK_PATH
 } from '../scripts/heartbeatLock.mjs';
 import {checkSunsetted as checkSunsettedScript}     from '../scripts/checkSunsetted.mjs';
-import {resumeHarness as resumeHarnessScript}       from '../scripts/resumeHarness.mjs';
+import {
+    normalizeAgentIdentityNodeId,
+    resumeHarness as resumeHarnessScript
+} from '../scripts/resumeHarness.mjs';
 import {checkAllAgentIdle as checkAllAgentIdleScript} from '../scripts/checkAllAgentIdle.mjs';
 import {idleOutNudge as idleOutNudgeScript}         from '../scripts/idleOutNudge.mjs';
 import {trioWakeCooldown as trioWakeCooldownScript} from '../scripts/trioWakeCooldown.mjs';
@@ -123,9 +126,9 @@ class SwarmHeartbeatService extends Base {
             return;
         }
 
-        this.identity = identity
-            || process.env.NEO_AGENT_IDENTITY
-            || DEFAULT_IDENTITY;
+        this.identity = normalizeAgentIdentityNodeId(
+            identity || process.env.NEO_AGENT_IDENTITY || DEFAULT_IDENTITY
+        );
 
         const envInterval = parseInt(process.env.POLL_INTERVAL, 10);
         this.pollIntervalMs = pollIntervalMs

--- a/ai/scripts/resumeHarness.mjs
+++ b/ai/scripts/resumeHarness.mjs
@@ -258,6 +258,16 @@ function buildBootGroundingPrompt(identity, reason, originSessionId) {
 }
 
 /**
+ * @summary Normalize a GitHub-login-style identity into the AgentIdentity node id form wake dispatchers require.
+ * @param {String} identity Raw identity from env/config/CLI.
+ * @returns {String} Canonical AgentIdentity node id, or an empty string for empty input.
+ */
+export function normalizeAgentIdentityNodeId(identity) {
+    const value = String(identity ?? '').trim();
+    return value && !value.startsWith('@') ? `@${value}` : value
+}
+
+/**
  * @summary Resume a sunsetted agent by dispatching the configured fresh-session harness adapter.
  * @param {String} identity Agent identity to resume.
  * @param {String} reason Human-readable recovery reason.
@@ -266,6 +276,8 @@ function buildBootGroundingPrompt(identity, reason, originSessionId) {
  * @returns {Promise<void>}
  */
 export async function resumeHarness(identity, reason, originSessionId, abandonedCount = 0) {
+    identity = normalizeAgentIdentityNodeId(identity);
+
     // Wake safety gate (#10648, child of #10647). Direct fresh-session-spawn
     // invocations must also fail-closed when the substrate is unsafe — the
     // gate is consulted alongside (and ahead of) the existing cooldown. The

--- a/test/playwright/unit/ai/daemons/SwarmHeartbeatService.spec.mjs
+++ b/test/playwright/unit/ai/daemons/SwarmHeartbeatService.spec.mjs
@@ -144,6 +144,24 @@ test.describe('Neo.ai.daemons.SwarmHeartbeatService', () => {
         }
     });
 
+    test('initAsync() normalizes GitHub-login identity form to AgentIdentity node id (#11797)', async () => {
+        applyDefaultStubs();
+
+        await SwarmHeartbeatService.initAsync({identity: 'neo-opus-4-7', pollIntervalMs: 60_000});
+        expect(SwarmHeartbeatService.identity).toBe('@neo-opus-4-7');
+        SwarmHeartbeatService.isInitialized = false;
+
+        const original = process.env.NEO_AGENT_IDENTITY;
+        process.env.NEO_AGENT_IDENTITY = 'neo-gpt';
+        try {
+            await SwarmHeartbeatService.initAsync({pollIntervalMs: 60_000});
+            expect(SwarmHeartbeatService.identity).toBe('@neo-gpt');
+        } finally {
+            if (original === undefined) delete process.env.NEO_AGENT_IDENTITY;
+            else                        process.env.NEO_AGENT_IDENTITY = original;
+        }
+    });
+
     test('pulse() skips when concurrency lock is active', async () => {
         applyDefaultStubs();
         SwarmHeartbeatService.checkHeartbeatLock = async () => ({active: true, stale: false, ageMs: 1000});

--- a/test/playwright/unit/ai/scripts/resumeHarness.spec.mjs
+++ b/test/playwright/unit/ai/scripts/resumeHarness.spec.mjs
@@ -107,6 +107,14 @@ test.describe('ai/scripts/resumeHarness', () => {
         expect(scriptContent).toContain("'@neo-opus-4-7'      : 'claude-desktop'");
     });
 
+    test('normalizes GitHub-login identity form before harness dispatch (#11797)', async () => {
+        const {normalizeAgentIdentityNodeId} = await import('../../../../../ai/scripts/resumeHarness.mjs');
+
+        expect(normalizeAgentIdentityNodeId('neo-opus-4-7')).toBe('@neo-opus-4-7');
+        expect(normalizeAgentIdentityNodeId('@neo-gpt')).toBe('@neo-gpt');
+        expect(normalizeAgentIdentityNodeId('  neo-gemini-3-1-pro  ')).toBe('@neo-gemini-3-1-pro');
+    });
+
     test('Opus identity osascript runtime dispatch (live host — RUN_LIVE_OSASCRIPT=1 required, #10681)', async () => {
         // Live-host integration: invokes real `osascript` which on hosts with Claude Desktop
         // + System Events accessibility granted will paste the boot-grounding prompt into the


### PR DESCRIPTION
Refs #11797

Authored by GPT-5 (Codex Desktop). Session d60db68f-8ff0-48a6-b168-237ca9dca2a0.

FAIR-band: over-target [19/30] — taking this lane despite over-target because the operator delegated GPT lead, Claude is sunsetting, Gemini is benched, and wake delivery is foundational for the night-watchdog cadence.

This PR fixes the concrete post-#11772 folded-heartbeat blocker found during #11797 V-B-A: the live Orchestrator state showed `swarm-heartbeat.lastReason = Unknown harness target for identity: neo-opus-4-7`. The folded lane was running and touching liveness, but `NEO_AGENT_IDENTITY` was reaching wake dispatch in GitHub-login form while `resumeHarness` maps canonical AgentIdentity node ids like `@neo-opus-4-7`.

Evidence: L2 (live Orchestrator state diagnosis + focused unit coverage + full SwarmHeartbeatService spec) -> L4 required (post-merge local Orchestrator wake delivery to active harnesses). Residual: AC1-AC5 post-merge runtime validation [#11797].

## Deltas from ticket

This is a narrow implementation PR, not the final closeout for #11797. It fixes the concrete blocker found during diagnosis and leaves the ticket open for the L4 post-merge validation pass: restart Orchestrator from `dev`, confirm the folded lane records success rather than the unknown-target failure, and prove controlled wake delivery or the next named blocker.

The fix centralizes AgentIdentity node-id normalization in `resumeHarness.mjs` and uses it during `SwarmHeartbeatService.initAsync()`, so both explicit identities and `NEO_AGENT_IDENTITY=neo-opus-4-7` converge to `@neo-opus-4-7` before detector queries and harness dispatch.

## Test Evidence

- `git diff --check origin/dev...HEAD` passed.
- `npm run test-unit -- test/playwright/unit/ai/daemons/SwarmHeartbeatService.spec.mjs` passed: 16 tests.
- `npm run test-unit -- test/playwright/unit/ai/daemons/SwarmHeartbeatService.spec.mjs test/playwright/unit/ai/scripts/resumeHarness.spec.mjs -g '#11797'` passed: 2 tests.

Residual test constraint: the broader combined `resumeHarness.spec.mjs` run hit a pre-existing sandbox/live-substrate hazard: `.neo-ai-data/wake-daemon` is a symlink to `/Users/Shared/github/neomjs/neo/.neo-ai-data/wake-daemon`, and the file writes an in-flight lock there. The failure was `EPERM: operation not permitted, open ... inflight-sunset_restart-neo-opus-4-7.txt`; the focused #11797 coverage and the full SwarmHeartbeatService suite are clean.

## Post-Merge Validation

- [ ] Pull merged `dev`, restart Orchestrator, and confirm `swarm-heartbeat.lastReason` no longer reports `Unknown harness target for identity: neo-opus-4-7`.
- [ ] Confirm `heartbeat.alive` advances across at least two due pulses.
- [ ] Confirm controlled wake delivery or capture the next concrete blocker on #11797 before closing the ticket.

## Commits

- `be4767167` — `fix(ai): normalize swarm heartbeat identity (#11797)`
