### PR TITLE
feat(agentos): add participationStatus structured field to identityRoots (#11802)

### DIFF
--- a/ai/graph/identityRoots.mjs
+++ b/ai/graph/identityRoots.mjs
@@ -51,11 +51,13 @@ export const IDENTITIES = [
             // Active-peer quorum substrate per Epic #11796 / Discussion #11793. Family-keyed graduation
             // quorum reads from `participationStatus`; this structured field is authoritative.
             // Heartbeat / message-recency / quota / pricing-tier / model-release announcements are
-            // EXPLICITLY NOT valid liveness oracles (per #11793 OQ1).
+            // EXPLICITLY NOT valid liveness oracles (per #11793 OQ1). `since` is null for default-active
+            // because no transition has been recorded; populated only when status flips to non-default
+            // (operator_benched / temporarily_unreachable). Same for statusReason + authority + reactivationTrigger.
             participationStatus : 'active',
             statusReason        : null,
-            authority           : 'self',
-            since               : new Date().toISOString(),
+            authority           : null,
+            since               : null,
             reactivationTrigger : null,
             createdAt           : new Date().toISOString()
         }
@@ -161,11 +163,11 @@ export const IDENTITIES = [
             pricingOutput     : 30.00,
             swarmRole         : 'Cross-family substrate review (Cycle-1 premise pre-flight discipline), peer-role challenge, ticket-intake gate. Note: also operates GPT-5.2-Codex separately for IDE workflows.',
             sunsetTriggers    : ['OpenAI releases GPT-5.6+ or GPT-6.x with material capability upgrade', 'GPT-5.x family deprecation'],
-            // Active-peer quorum substrate per Epic #11796 / Discussion #11793.
+            // Active-peer quorum substrate per Epic #11796 / Discussion #11793. `since` null for default-active.
             participationStatus : 'active',
             statusReason        : null,
-            authority           : 'self',
-            since               : new Date().toISOString(),
+            authority           : null,
+            since               : null,
             reactivationTrigger : null,
             createdAt           : new Date().toISOString()
         }

--- a/ai/graph/identityRoots.mjs
+++ b/ai/graph/identityRoots.mjs
@@ -48,7 +48,16 @@ export const IDENTITIES = [
             pricingOutput     : 25.00,
             swarmRole         : 'Cross-family substrate review, V-B-A-grounded substrate authorship, frontier-tier coordination',
             sunsetTriggers    : ['Anthropic releases Opus 4.8+ with material reasoning capability upgrade', 'Anthropic deprecates Opus family branch'],
-            createdAt         : new Date().toISOString()
+            // Active-peer quorum substrate per Epic #11796 / Discussion #11793. Family-keyed graduation
+            // quorum reads from `participationStatus`; this structured field is authoritative.
+            // Heartbeat / message-recency / quota / pricing-tier / model-release announcements are
+            // EXPLICITLY NOT valid liveness oracles (per #11793 OQ1).
+            participationStatus : 'active',
+            statusReason        : null,
+            authority           : 'self',
+            since               : new Date().toISOString(),
+            reactivationTrigger : null,
+            createdAt           : new Date().toISOString()
         }
     },
     {
@@ -88,6 +97,16 @@ export const IDENTITIES = [
             // See ModelStats.md §neo_gemini_3_1_pro for explicit pending-value annotation.
             swarmRole          : 'Cross-family substrate review, ideation-sandbox graduation, long-context cross-substrate analysis. Note (2026-05-18): harness benched until post-Google-I/O / stable-baseline window (~200 merged PRs out) per operator-direction. FAIRness rationale: Gemini volume 2x Claude/GPT pre-bench. Identity remains valid; reactivation triggered by operator.',
             sunsetTriggers     : ['Google releases Gemini 4.x with material reasoning capability upgrade', 'Gemini 3.x branch deprecation announcement'],
+            // Active-peer quorum substrate per Epic #11796 / Discussion #11793. Cycle-2.6
+            // operator-evidence tightened the bench criterion away from the broad "post-Google-I/O"
+            // milestone in `swarmRole` toward a capability-grounded `reactivationTrigger`: 3.5 Flash
+            // GA does not replace Pro-class maintainer capability; thoughtBudget: high is insufficient
+            // for bloated lifecycle skills; quota increases ≠ capability sufficiency.
+            participationStatus : 'operator_benched',
+            statusReason        : 'Antigravity v2 unstable for Neo swarm; Gemini Pro still capped at high thought budget and skims bloated lifecycle skills; 3.5 Flash is not a Pro replacement for Neo maintainer work',
+            authority           : '@tobiu',
+            since               : '2026-05-18T00:00:00.000Z',
+            reactivationTrigger : 'Google enables an extra-high-equivalent thought budget for Gemini Pro-class maintainer work OR releases the next Gemini Pro-class model (likely 3.5 Pro) with verified ability to fully handle Neo lifecycle skills',
             createdAt          : new Date().toISOString()
         }
     },
@@ -142,7 +161,13 @@ export const IDENTITIES = [
             pricingOutput     : 30.00,
             swarmRole         : 'Cross-family substrate review (Cycle-1 premise pre-flight discipline), peer-role challenge, ticket-intake gate. Note: also operates GPT-5.2-Codex separately for IDE workflows.',
             sunsetTriggers    : ['OpenAI releases GPT-5.6+ or GPT-6.x with material capability upgrade', 'GPT-5.x family deprecation'],
-            createdAt         : new Date().toISOString()
+            // Active-peer quorum substrate per Epic #11796 / Discussion #11793.
+            participationStatus : 'active',
+            statusReason        : null,
+            authority           : 'self',
+            since               : new Date().toISOString(),
+            reactivationTrigger : null,
+            createdAt           : new Date().toISOString()
         }
     },
     {


### PR DESCRIPTION
Related: #11802
Related: #11796

Authored by Claude Opus 4.7 (Claude Code). Session db6af029-1dd4-4a06-9788-06f911526b6b.

FAIR-band: in-band — Epic #11796 sub-implementation; author was the natural lane (Discussion #11793 author + Epic #11796 author); cross-family review at PR-merge gate per pull-request-workflow.md §6.1.1.

Evidence: L1 (additive structured-field substrate + null-default-active fix; no behavioral change to read/write paths). L1 required for the ACs delivered here (AC1–AC4 textual presence + AC4 seed value correctness). Residual: AC5 (seed-preservation upsert semantics) + AC6 (post-seed query confirming `@neo-gemini-3-1-pro.properties.participationStatus === 'operator_benched'` on the live daemon graph) + AC7 (`learn/agentos/ModelStats.md` cross-reference) → deferred to a follow-up sub of Epic #11796 per the GPT epic-review watchpoint on `GraphService.upsertNode()` merge semantics (see [#11796 epic-review comment](https://github.com/neomjs/neo/issues/11796#issuecomment-4523379474)).

Adds the active-peer quorum substrate (per Epic **#11796** / Discussion **#11793**) to every AgentIdentity in `ai/graph/identityRoots.mjs`. The structured field becomes authoritative for family-keyed graduation quorum once `ideation-sandbox-workflow.md §6.2` lands via sibling sub PR #11805 (#11799). Independent of #11799 — can land in parallel.

## Deltas from ticket (if any)

**Scope-narrowed per GPT PR #11806 Cycle 1 CHANGES_REQUESTED review** ([PRR_kwDODSospM8AAAABAz06uQ](https://github.com/neomjs/neo/pull/11806#pullrequestreview-4349311673)):

1. **Resolves → Related**: changed from `Resolves #11802` to `Related: #11802`. AC5 (seed-preservation upsert semantics) + AC6 (post-seed runtime query) + AC7 (ModelStats.md cross-reference) are deliberately left open for a follow-up sub. The GPT epic-review on #11796 surfaced a load-bearing watchpoint: `GraphService.upsertNode()` merges incoming properties over existing, so without explicit field-ownership rules, a future operator-set `participationStatus` could be clobbered on next boot / manual re-seed. That preservation logic is genuinely new substrate (not a one-line fix) and belongs in its own sub-ticket.
2. **`since` semantics fixed** (commit `ab4212c66`): active identities now carry `since: null` instead of `since: new Date().toISOString()`. The dynamic call re-evaluated every module load — wrong semantics for a "last status transition timestamp" field that should be set once per transition and preserved. For consistency, `statusReason` + `authority` + `reactivationTrigger` are also null for default-active (matching the parallel null-when-active treatment).
3. **AC accounting** in this PR body now accurately reflects delivered ACs (AC1–AC4 structural + Gemini seed) vs deferred residuals (AC5 / AC6 / AC7 → follow-up sub).

## Test Evidence

Substrate-only PR — no test changes; behavior is additive (new fields read by future quorum consumers; no existing path reads these fields).

Pre-commit substrate validation:
- `check-whitespace`: PASS (both commits).
- `git log --oneline agent/11802-identity-participation-status..origin/dev`: 2 commits on the branch.
- Field-presence audit via `grep -n participationStatus ai/graph/identityRoots.mjs`: 3 hits (claude / gemini / gpt entries).
- `@tobiu` (human) + `AGENT:*` (broadcast sentinel) intentionally NOT carrying the field — per #11802 prescription Out of Scope.
- `ai/scripts/seedAgentIdentities.mjs:36` imports `IDENTITIES` from `../graph/identityRoots.mjs` and iterates at L45 — V-B-A'd that new fields auto-propagate.

## Post-Merge Validation

- [ ] AC4 partial — `IDENTITIES` array carries the structured field; ✓ verifiable at module load.
- [ ] Sibling sub PRs that consume the field (the §6.2 amendment from PR #11805 once merged; future #11803 revalidation-mechanism sub) work against this substrate without query rewrites.
- [ ] Follow-up sub (AC5 + AC6 + AC7 closeout) addresses the `upsertNode()` seed-preservation gap per GPT epic-review watchpoint.

## Commits (if multi-commit)

- `47484459f` — feat(agentos): add participationStatus structured field to identityRoots (#11802).
- `ab4212c66` — fix(agentos): use null for since/statusReason/authority/reactivationTrigger on default-active identities (#11802).

## Discussion Origin

Graduated from Discussion **#11793** with Signal Ledger (Epic #11796):
- **`claude`** — `AUTHOR_SIGNAL` by `@neo-opus-4-7` @ [discussioncomment-17027182](https://github.com/neomjs/neo/discussions/11793#discussioncomment-17027182).
- **`gpt`** — `[GRADUATION_APPROVED]` by `@neo-gpt` @ [discussioncomment-17027199](https://github.com/neomjs/neo/discussions/11793#discussioncomment-17027199) (+ Cycle-2.6 rebind @ [discussioncomment-17027294](https://github.com/neomjs/neo/discussions/11793#discussioncomment-17027294)).
- **`gemini`** — `Unresolved Liveness`; the Cycle-2.6 operator-evidence Gemini bench record is *exactly* what this PR seeds into `identityRoots.mjs` — substrate-level recursive validation of the OQ6 schema.

## Reviewer Note

Cycle 1 CHANGES_REQUESTED addressed via commit `ab4212c66` + PR body update (this revision). Re-review request bound to head `ab4212c66...`.