### PR TITLE
fix(ai): normalize KB alert sender identity (#11811)

### DIFF
--- a/ai/daemons/KbAlertingService.mjs
+++ b/ai/daemons/KbAlertingService.mjs
@@ -2,12 +2,13 @@
 // InstanceManager) lives in `ai/scripts/kb-alerting-daemon.mjs` per the canonical
 // Orchestrator class+wrapper pattern. `Neo.setupClass(KbAlertingService)` at file
 // bottom works via `globalThis.Neo`, populated by the entry-point bootstrap chain.
-import Base                  from '../../src/core/Base.mjs';
-import {Memory_Config as aiConfig} from '../services.mjs';
-import KBRecorderService     from '../services/knowledge-base/KBRecorderService.mjs';
-import MailboxService        from '../services/memory-core/MailboxService.mjs';
-import RequestContextService from '../mcp/server/shared/services/RequestContextService.mjs';
-import logger               from '../mcp/server/knowledge-base/logger.mjs';
+import Base                           from '../../src/core/Base.mjs';
+import {Memory_Config as aiConfig}    from '../services.mjs';
+import KBRecorderService              from '../services/knowledge-base/KBRecorderService.mjs';
+import MailboxService                 from '../services/memory-core/MailboxService.mjs';
+import RequestContextService          from '../mcp/server/shared/services/RequestContextService.mjs';
+import logger                         from '../mcp/server/knowledge-base/logger.mjs';
+import {normalizeAgentIdentityNodeId} from '../scripts/resumeHarness.mjs';
 import {
     DEFAULT_COOLDOWN_MS,
     evaluateAlertRules,
@@ -315,7 +316,9 @@ class KbAlertingService extends Base {
 
         const
             {subject, body} = formatAlertMessage(alert),
-            sender          = process.env.NEO_AGENT_IDENTITY || DEFAULT_SENDER;
+            sender          = process.env.NEO_AGENT_IDENTITY
+                ? normalizeAgentIdentityNodeId(process.env.NEO_AGENT_IDENTITY)
+                : DEFAULT_SENDER;
 
         await RequestContextService.run({agentIdentityNodeId: sender}, async () => {
             await MailboxService.addMessage({

--- a/test/playwright/unit/ai/daemons/KbAlertingService.spec.mjs
+++ b/test/playwright/unit/ai/daemons/KbAlertingService.spec.mjs
@@ -67,7 +67,8 @@ test.describe('Neo.ai.daemons.KbAlertingService (#11642)', () => {
             run             : RequestContextService.run,
             warn            : logger.warn,
             error           : logger.error,
-            recorderReady   : KBRecorderService.ready
+            recorderReady   : KBRecorderService.ready,
+            neoAgentIdentity: process.env.NEO_AGENT_IDENTITY
         };
 
         // `start()` awaits KBRecorderService.ready() — stub it to resolve immediately.
@@ -96,6 +97,12 @@ test.describe('Neo.ai.daemons.KbAlertingService (#11642)', () => {
         RequestContextService.run        = originals.run;
         logger.warn                      = originals.warn;
         logger.error                     = originals.error;
+
+        if (originals.neoAgentIdentity === undefined) {
+            delete process.env.NEO_AGENT_IDENTITY
+        } else {
+            process.env.NEO_AGENT_IDENTITY = originals.neoAgentIdentity
+        }
     });
 
     /**
@@ -257,15 +264,18 @@ test.describe('Neo.ai.daemons.KbAlertingService (#11642)', () => {
     test.describe('dispatchA2A', () => {
         /** Captures `addMessage` payloads + neutralizes the RequestContextService wrapper. */
         function captureA2A() {
-            const sent = [];
-            RequestContextService.run        = async (ctx, fn) => fn();
+            const sent = [], contexts = [];
+            RequestContextService.run        = async (ctx, fn) => {
+                contexts.push(ctx);
+                return fn()
+            };
             MailboxService.isReachableTarget = () => true; // tests below use resolvable targets
             MailboxService.addMessage        = async (args) => { sent.push(args); return {messageId: 'MESSAGE:test'} };
-            return sent;
+            return {sent, contexts};
         }
 
         test('direct-DM — dispatches addMessage to the canonical identity target', async () => {
-            const sent = captureA2A();
+            const {sent} = captureA2A();
 
             await KbAlertingService.dispatchA2A({
                 tenantId: 'tenant-x', repoSlug: 'repo-x', metric: 'errorRate', value: 0.3,
@@ -279,7 +289,7 @@ test.describe('Neo.ai.daemons.KbAlertingService (#11642)', () => {
         });
 
         test('explicit broadcast — dispatches to AGENT:* when the rule opts in', async () => {
-            const sent = captureA2A();
+            const {sent} = captureA2A();
 
             await KbAlertingService.dispatchA2A({
                 tenantId: 'tenant-x', repoSlug: 'repo-x', metric: 'errorRate', value: 0.3,
@@ -290,7 +300,7 @@ test.describe('Neo.ai.daemons.KbAlertingService (#11642)', () => {
         });
 
         test('audit delivery mode maps to wakeSuppressed:true; critical maps to high priority', async () => {
-            const sent = captureA2A();
+            const {sent} = captureA2A();
 
             await KbAlertingService.dispatchA2A({
                 tenantId: 'tenant-x', repoSlug: 'repo-x', metric: 'errorRate', value: 0.9,
@@ -301,10 +311,22 @@ test.describe('Neo.ai.daemons.KbAlertingService (#11642)', () => {
             expect(sent[0].priority).toBe('high');
         });
 
+        test('normalizes an unprefixed NEO_AGENT_IDENTITY before binding sender context (#11811)', async () => {
+            const {contexts} = captureA2A();
+            process.env.NEO_AGENT_IDENTITY = 'neo-opus-4-7';
+
+            await KbAlertingService.dispatchA2A({
+                tenantId: 'tenant-x', repoSlug: 'repo-x', metric: 'errorRate', value: 0.3,
+                threshold: 0.1, severity: 'warning', channel: 'a2a:@neo-gpt', deliveryMode: 'wake'
+            });
+
+            expect(contexts[0].agentIdentityNodeId).toBe('@neo-opus-4-7');
+        });
+
         test('skips an unresolvable A2A target before dispatch — no addMessage call', async () => {
             // #11642 Contract Ledger / @neo-gpt PR #11709 review: an unresolvable target
             // (not a registered @<identity>, not AGENT:*) must be rejected before dispatch.
-            const sent = captureA2A();
+            const {sent} = captureA2A();
             MailboxService.isReachableTarget = () => false; // simulate an unregistered target
             const warns = [];
             logger.warn = (msg) => { warns.push(msg) };


### PR DESCRIPTION
Authored by GPT-5 (Codex Desktop). Session 008b6468-bb2c-44a5-aa90-e2e97a1ac849.

FAIR-band: over-target [17/30] — taking this lane despite over-target because the operator pinned GPT lead-role, #11811 was already assigned to @neo-gpt, and the fix is a narrow v13 identity-hygiene bug with no peer-lane collision.

Resolves #11811

Normalizes the KB alerting daemon sender boundary so an unprefixed NEO_AGENT_IDENTITY value such as neo-opus-4-7 binds RequestContextService as @neo-opus-4-7 before MailboxService emits A2A alerts. The existing @system fallback remains unchanged when the env var is unset, and alert rule evaluation / scheduling / target pre-check behavior are untouched.

Evidence: L2 (focused unit tests for KbAlertingService sender context plus existing resumeHarness normalizer coverage) -> L2 required (all #11811 ACs are unit/static contract). No residuals.

## Deltas from ticket

None. The implementation reuses normalizeAgentIdentityNodeId() from resumeHarness and keeps the change scoped to the alert sender field.

## Test Evidence

- npm run test-unit -- test/playwright/unit/ai/daemons/KbAlertingService.spec.mjs — 17 passed
- npm run test-unit -- test/playwright/unit/ai/scripts/resumeHarness.spec.mjs — first sandbox run hit EPERM writing .neo-ai-data wake lock files; escalated rerun passed with 22 passed, 2 skipped
- git diff --check — passed
- git diff --cached --check — passed before commit

## Post-Merge Validation

- [ ] Optional live KB alert smoke test with NEO_AGENT_IDENTITY=neo-opus-4-7 confirms emitted A2A message sender is @neo-opus-4-7.

## Commit

- 545bd216e — fix(ai): normalize KB alert sender identity (#11811)