### PR TITLE
fix(codex): document hooks flag migration (#11807)

### DIFF
--- a/.codex/CODEX.md
+++ b/.codex/CODEX.md
@@ -28,6 +28,10 @@ and can drift independently of the Codex Desktop harness.
 - For state-changing GitHub calls, preserve the exact payload when retrying
   escalated so the sandbox retry does not mutate review/comment semantics.
 - Mid-session harness restart: read `.codex/HARNESS_RESTART.md` before diagnosing MCP, Chroma, GitHub, or wake-state failures.
+- If Codex reports `[features].codex_hooks is deprecated. Use [features].hooks instead.`,
+  the tracked `.codex/config.template.toml` is already current. Update the ignored
+  local `.codex/config.toml` copy to `[features].hooks = true` or re-copy the
+  template; do not commit `.codex/config.toml`.
 
 ## Identity & Prompt Firewall (L1 Anchor)
 


### PR DESCRIPTION
Authored by GPT-5 (Codex Desktop). Session 008b6468-bb2c-44a5-aa90-e2e97a1ac849.

FAIR-band: over-target [17/30] — taking this lane despite over-target because the operator pinned GPT lead-role for nightshift backlog cleanup, the issue is Codex-harness-local to this active checkout, and Claude already claimed #11803 in the parallel lane.

Resolves #11807

Adds a Codex Desktop troubleshooting note to `.codex/CODEX.md` for stale ignored local configs that still use `[features].codex_hooks`, while preserving the tracked template/custom-config split. The tracked `.codex/config.template.toml` remains unchanged because it already uses `[features].hooks = true`, and `.codex/config.toml` remains ignored/local.

Evidence: L1 (static config/doc audit plus official Codex config docs check) -> L1 required (documentation-only migration guard with no runtime ACs). No residuals.

## Deltas from ticket

Used the documentation-only fix shape. No hook diagnostic was added because the existing Codex warning plus the turn-loaded `.codex/CODEX.md` note covers the stale local-config hazard without adding command noise to every `UserPromptSubmit` hook invocation.

## Test Evidence

- Official OpenAI Codex config docs checked on 2026-05-23: `hooks` is the supported `[features]` key, and CLI enablement uses `codex --enable feature_name`: https://developers.openai.com/codex/config-basic#feature-flags
- `rg -n "\[features\]|hooks = true|codex_hooks|Use \[features\]\.hooks instead" .codex/CODEX.md .codex/config.template.toml` confirmed the template keeps `[features] hooks = true` and `.codex/CODEX.md` contains the exact warning text.
- `rg -n "codex_hooks" .codex/config.template.toml` returned no matches, as expected.
- `git check-ignore -v .codex/config.toml` confirmed `.codex/config.toml` is ignored by `.gitignore:119`.
- `git diff --check` passed.
- `git diff --cached --check` passed before commit.

## Post-Merge Validation

- [ ] In a checkout with stale ignored `.codex/config.toml`, a Codex turn loads `.codex/CODEX.md` and surfaces the migration note alongside the upstream deprecation warning.

## Commit

- a92bf2740 — fix(codex): document hooks flag migration (#11807)