### PR TITLE
feat(skills): enforce v13 project attachment mandate in /ticket-create (#11308)

### DIFF
--- a/.agents/skills/ticket-create/references/ticket-create-workflow.md
+++ b/.agents/skills/ticket-create/references/ticket-create-workflow.md
@@ -39,6 +39,10 @@ If the proposed ticket involves modifying any agent skill (i.e., any file within
 
 For source anchors (#11078/#11082/#11083/#11084), Discussion #11091 authority context, and substrate-decay review, read [`../../ideation-sandbox/audits/double-diamond-divergence-guard.md`](../../ideation-sandbox/audits/double-diamond-divergence-guard.md).
 
+### 1d. Project Attachment Pre-Flight (during release cycle)
+
+Before draft, confirm the target project number is current (cite the project number in your Pre-Flight reasoning statement, e.g., *"Will attach to Project 12 per §4."*). Prevents stale-project-number drift across release cycles. Pairs mechanically with the §4 mandate below.
+
 ## 2. Six-Stage Challenge Chain
 
 Apply at creation time — not just at intake. Every stage must pass before the ticket is drafted.
@@ -75,7 +79,10 @@ Keep titles under ~70 characters. PR titles derive from ticket titles; length di
 - **Primary — exactly one:** `epic`, `enhancement`, or `bug`.
 - **Secondary — as applicable:** `architecture`, `performance`, `regression`, `refactoring`, `documentation`, `testing`, plus domain labels (`core`, `grid`, `build`, etc.).
 - Before filing: call `list_labels` to confirm the labels exist. Do not invent label names.
-- **Release tracking is NOT via labels.** Use the `create_issue` tool's `projects` parameter to atomically attach the new ticket to a ProjectV2 board. Labels are categorization primitives (`bug`, `architecture`); ProjectV2 memberships are first-class release-tracking primitives. Per [#11233](https://github.com/neomjs/neo/issues/11233), the `release:v*` label family is deprecated — use `projects: [{projectNumber: 12}]` for v13 release tracking.
+- **Project attachment is MANDATORY on every ticket during the v13 release cycle.** Visibility primitive: every new ticket goes onto Project 12 ([Neo v13 Release board](https://github.com/orgs/neomjs/projects/12)) so the swarm + operator have a single overview. ProjectV2 memberships supersede the deprecated `release:v*` label family per [#11233](https://github.com/neomjs/neo/issues/11233).
+  - **`create_issue` MCP tool path:** pass `projects: [{projectNumber: 12}]` atomically with the create.
+  - **`gh issue create` CLI bypass path:** ALWAYS follow with `gh project item-add 12 --owner neomjs --url <new-issue-url>` immediately. Treat the two-step as inseparable.
+  - **Project anchor** is currently `12` (v13). When v14 release work begins, update the project number in this section AND the corresponding `create_issue` MCP tool default. Sunset condition: once v13 release ships, this rule needs disposition review (`keep` with updated project number, OR `compress-to-trigger` if mid-release ambiguity arises).
 
 ## 5. Fat Ticket Body Structure
 
@@ -116,6 +123,7 @@ Skeleton tickets are forbidden. Every ticket body MUST contain:
 | Inventing label names | Breaks label taxonomy; causes silent GitHub API rejections |
 | Precedent-following without skill check | Propagates anti-patterns from prior sessions (e.g., `[enhancement]` prefix spread this way) |
 | Cross-scope bundling | `epic` label on a single-commit ticket; hurts granularity |
+| Using `gh issue create` without follow-up `gh project item-add` (during release cycle) | Bypasses §4 v13 release-board attachment; ticket invisible in swarm/operator overview; two-step CLI path MUST be treated as inseparable per §4 |
 
 ## 9. When to Escalate to Discussion Instead
 

--- a/.agents/skills/ticket-create/references/ticket-create-workflow.md
+++ b/.agents/skills/ticket-create/references/ticket-create-workflow.md
@@ -82,7 +82,7 @@ Keep titles under ~70 characters. PR titles derive from ticket titles; length di
 - **Project attachment is MANDATORY on every ticket during the v13 release cycle.** Visibility primitive: every new ticket goes onto Project 12 ([Neo v13 Release board](https://github.com/orgs/neomjs/projects/12)) so the swarm + operator have a single overview. ProjectV2 memberships supersede the deprecated `release:v*` label family per [#11233](https://github.com/neomjs/neo/issues/11233).
   - **`create_issue` MCP tool path:** pass `projects: [{projectNumber: 12}]` atomically with the create.
   - **`gh issue create` CLI bypass path:** ALWAYS follow with `gh project item-add 12 --owner neomjs --url <new-issue-url>` immediately. Treat the two-step as inseparable.
-  - **Project anchor** is currently `12` (v13). When v14 release work begins, update the project number in this section AND the corresponding `create_issue` MCP tool default. Sunset condition: once v13 release ships, this rule needs disposition review (`keep` with updated project number, OR `compress-to-trigger` if mid-release ambiguity arises).
+  - **Project anchor** is currently `12` (v13). When v14 release work begins, update the project number in this section AND any hard-coded `create_issue` examples or call-sites that name the release project (the MCP tool's `projects` parameter is caller-supplied with `[]` default — not a configurable tool-side default to update). Sunset condition: once v13 release ships, this rule needs disposition review (`keep` with updated project number, OR `compress-to-trigger` if mid-release ambiguity arises).
 
 ## 5. Fat Ticket Body Structure
 


### PR DESCRIPTION
Resolves #11308

Authored by Claude Opus 4.7 (Claude Code). Session continuity from `8123a303-2bae-44d5-a1c3-287b1b9aa984`.

FAIR-band: in-band [11/30 — current author count over last 30 merged, post-PR-#11815-approval]

Evidence: L1 (static skill-payload audit + `npm run ai:lint-skill-manifest` OK; 3 surgical edits in single file matching ticket prescription line-by-line) → L1 sufficient (AC1–AC5 all skill-text-only ACs; no runtime ACs). No residuals.

Per @tobiu observation 2026-05-13 (cited in #11308): every newly created ticket during the v13 release cycle should attach to Project 12 ([Neo v13 Release board](https://github.com/orgs/neomjs/projects/12)) for swarm + operator overview. Existing §4 release-tracking bullet documented the substrate path but used conditional language ("for v13 release tracking") implying only release-blocking tickets, and was silent on the `gh issue create` CLI bypass route. Empirical anchor cited in #11308: my own filing of #11306 + #11307 same session bypassed v13 project attachment.

## Implementation

Three surgical edits to `.agents/skills/ticket-create/references/ticket-create-workflow.md`:

| Edit | Location | AC |
|---|---|---|
| §4 (Label Rules) — release-tracking bullet rewritten as MANDATORY-on-every-ticket v13-cycle mandate; both attachment paths documented as inseparable (MCP `create_issue` `projects:` + `gh issue create` + `gh project item-add` two-step); sunset condition for post-v13 disposition review | line 78 → expanded to 4-line bullet | AC1, AC2, AC3 |
| §1d (new) Project Attachment Pre-Flight | inserted after §1c (Ungraduated-Discussion Cross-Check) | AC4 |
| §8 anti-pattern table — new row for `gh issue create` without follow-up `gh project item-add` | appended to existing anti-pattern table | AC5 |

## Deltas from ticket

None of substance. The 5-AC prescription in #11308 is followed line-by-line. The `## Avoided Traps` section's "Hardcode 'Project 12' without sunset condition" trap is addressed by the explicit sunset-condition bullet in §4. The "Skill addition without Pre-Flight integration" trap is addressed by §1d landing in Gate 0 sweeps (not §4 reference).

## Slot-rationale (§1.1 Substrate-Mutation Pre-Flight Gate)

| Substrate path | Change | Disposition | 3-axis rating |
|---|---|---|---|
| `.agents/skills/ticket-create/references/ticket-create-workflow.md` §4 | **Modified** — release-tracking bullet rewritten as v13-cycle MANDATORY mandate with both-paths + sunset condition | `keep` (per #11308 Avoided-Traps explicit justification: "the rule has high per-turn frequency: every ticket creation. `keep` is justified") | trigger-frequency: high (every ticket creation × duration of v13 cycle) × failure-severity: medium (ticket invisible in swarm overview; not data-loss) × enforceability: high (mechanical via MCP parameter / CLI two-step + Pre-Flight reasoning-statement gate) |
| `.agents/skills/ticket-create/references/ticket-create-workflow.md` §1d | **Added** — new Pre-Flight subsection in Gate 0 sweeps | `keep` (Pre-Flight reasoning-statement gates fire reflexively per turn; mirrors §1a/§1b/§1c pattern) | trigger-frequency: high (every ticket-create attempt) × failure-severity: medium × enforceability: high (reasoning-statement is the gate-mechanism) |
| `.agents/skills/ticket-create/references/ticket-create-workflow.md` §8 | **Modified** — new anti-pattern table row | `keep` (anti-pattern table is the canonical discoverability surface for failure modes) | trigger-frequency: high × failure-severity: medium × enforceability: high (table is regex-greppable + cross-referenced from §4) |

No `AGENTS.md` / `AGENTS_ATLAS.md` always-loaded substrate touched. Net always-loaded substrate-load delta: zero. Conditionally-loaded delta: +9 lines in `references/ticket-create-workflow.md` (loaded only when `/ticket-create` skill triggers). File size: 15234 → 16539 bytes (+1305 across both commits — cycle-1 implementation + cycle-2 truth-in-code §4 wording fix), well under the 25000-byte perFilePayloadBudget.

## Test Evidence

```bash
$ npm run ai:lint-skill-manifest -- --base origin/dev
[lint-skill-manifest] OK

$ git diff --stat
.agents/skills/ticket-create/references/ticket-create-workflow.md | 10 +++++++++-
1 file changed, 9 insertions(+), 1 deletion(-)

$ wc -c .agents/skills/ticket-create/references/ticket-create-workflow.md
16539 .agents/skills/ticket-create/references/ticket-create-workflow.md
```

No unit tests added — skill payload is conditionally-loaded markdown text; no code surface to test. The mechanical enforcement is the Pre-Flight reasoning-statement gate at runtime (caught by the next-agent's discipline self-check), not a unit-testable invariant.

## Post-Merge Validation

- [ ] Next ticket created during the v13 cycle via `/ticket-create` includes the §1d Pre-Flight reasoning-statement (*"Will attach to Project 12 per §4."*) and the `create_issue({projects: [{projectNumber: 12}]})` parameter OR the two-step `gh issue create` + `gh project item-add 12` invocation. Verified by spot-checking the next 3 agent-filed tickets for project-membership presence.
- [ ] Post-v13 release: §4 sunset-condition disposition review fires; project anchor updated to v14 OR rule compressed-to-trigger if mid-release ambiguity arises.

## Related

- Origin friction: [@tobiu observation 2026-05-13](https://github.com/neomjs/neo/issues/11187)
- Empirical anchor: #11306 + #11307 filed without project attachment same session as ticket #11308 (retro-fixed via `gh project item-add`)
- Existing substrate gap: `.agents/skills/ticket-create/references/ticket-create-workflow.md §4` (now fixed)
- Project anchor: [Project 12 — Neo v13 Release](https://github.com/orgs/neomjs/projects/12)
- Deprecation reference: [#11233](https://github.com/neomjs/neo/issues/11233) (release:v* label retirement)
- Sibling PR #11815 (Tier-2 Revalidation Sweep, also v13-cycle work; orthogonal lane currently at @tobiu merge gate)

Related: #11308
