### PR TITLE
fix(mcp): allow null from in mailbox latestPreview schema for system messages (#11819)

### DIFF
--- a/ai/mcp/server/memory-core/openapi.yaml
+++ b/ai/mcp/server/memory-core/openapi.yaml
@@ -1815,7 +1815,8 @@ components:
                   example: "Re: First A2A handshake — Phase 4 split proposal"
                 from:
                   type: string
-                  description: The sender's AgentIdentity node id
+                  nullable: true
+                  description: The sender's AgentIdentity node id; `null` for system-sent messages (heartbeats, idle-out nudges) that have no SENT_BY edge in the graph
                   example: "@neo-gemini-3-1-pro"
                 sentAt:
                   type: string


### PR DESCRIPTION
Resolves #11819

Authored by Claude Opus 4.7 (Claude Code). Session continuity from prior-session `db6af029-1dd4-4a06-9788-06f911526b6b` per sunset-handoff; current session `b08bd969-3a3b-49a1-9bfe-9941820e7fbd`.

FAIR-band: in-band [9/30 — live verifier at cycle-1 review time per `gh search prs --merged --repo neomjs/neo --limit 30`; my earlier-session 10/30 + post-approve-extrapolation to 11/30 was wrong on two axes (PR-approve ≠ PR-merge; 30-window rolled, aging older PRs out)]

Evidence: L3 (empirical 4-observation anchor this session — `add_memory` MCP rejection on heartbeat-preview, workaround verified, schema layer isolated as sole drift surface; 2-line fix matches permissive shape `list_messages` already uses) → L3 sufficient (AC1–AC5 schema-only contract; no runtime ACs requiring further evidence ladder). No residuals.

OpenAPI schema rejected legitimate `from: null` in the `latestPreview` block of `add_memory` responses when the mailbox pointed at a system-sent message (heartbeats, idle-out nudges). `MemoryService.mjs:126-129` correctly returns null when no `SENT_BY` edge exists (system messages have no agent sender per graph-level invariant), but the strict schema rejected this at the MCP boundary — blocking `add_memory` end-of-turn consolidation until the heartbeat was manually marked-read first.

## Implementation

Single 2-line change to `ai/mcp/server/memory-core/openapi.yaml:1816-1818`:

```diff
                 from:
                   type: string
-                  description: The sender's AgentIdentity node id
+                  nullable: true
+                  description: The sender's AgentIdentity node id; `null` for system-sent messages (heartbeats, idle-out nudges) that have no SENT_BY edge in the graph
                   example: "@neo-gemini-3-1-pro"
```

Updated description preserves the empirical reality for future schema readers.

## Deltas from ticket

None of substance. The 5-AC prescription in #11819 is followed line-by-line. Single-file schema-shape correction.

## Slot-rationale (§1.1 Substrate-Mutation Pre-Flight Gate)

Not applicable — PR does not touch `AGENTS.md` / `AGENTS_ATLAS.md` / `.agents/skills/**` / `learn/agentos/**`. Single change is in `ai/mcp/server/*/openapi.yaml` MCP tool schema (closed-contract surface per `feedback_mcp_output_category_split` memory).

## Test Evidence

```bash
$ git diff ai/mcp/server/memory-core/openapi.yaml
 5 lines context, 2 insertions, 1 deletion (the schema fix)

# No new unit tests added — the change is a schema relaxation (nullable: true)
# matching the permissive shape list_messages already uses. Service layer
# (MemoryService.mjs:126-129) was already shape-correct; only schema was drifted.
# Net-new schema-validation test infrastructure (parse YAML + sample-payload
# validation) is disproportionate to a 2-line nullability fix.

# Empirical reproducer (cited in ticket body):
# - Pre-fix: add_memory rejects with `MCP error -32602: data/mailbox/latestPreview/from must be string`
#   when mailbox.latestPreview points at a heartbeat message (4 observed this session)
# - Post-fix: add_memory succeeds (schema accepts null from)
```

## Post-Merge Validation

- [ ] Next `add_memory` call following a system-heartbeat-only mailbox state (no agent-sent unread messages) succeeds without the `MCP error -32602` rejection. Verifiable by any agent's end-of-turn consolidation after heartbeat reception.
- [ ] No regression on `list_messages` (already permissive — should remain unchanged).

## Audits — collapsed

### N/A Audits — 🛂 📑 🪜 📜 🔌 🔗 🧪

N/A across listed dimensions: single-line OpenAPI schema relaxation. No provenance audit (not a major abstraction). No contract ledger needed (ticket carries it). Evidence is L3 empirical reproducer documented in ticket body. No authority citation. No wire-format change beyond making the schema accept what the service already returns. No cross-skill integration needed. No new unit tests required (matches existing list_messages permissive shape; service layer already correct).

### 📡 MCP-Tool-Description Budget Audit

- [x] Single-line preferred — `description` is single-line per Neo schema convention
- [x] No internal cross-refs in the description payload (no ticket numbers / session IDs / memory anchor names)
- [x] No architectural narrative — description names the call-site usage ("`null` for system-sent messages that have no SENT_BY edge in the graph")
- [x] No external standard URL added
- [x] 1024-char hard cap respected — `description` is well under 200 chars

**Findings:** Pass.

### 🛡️ CI / Security Checks Audit

Will verify after push completes via `gh pr checks`. Expected: all green (single-line YAML edit, no code surface).

## Related

- Empirical anchor: 4 observed `add_memory` rejections in session `b08bd969-3a3b-49a1-9bfe-9941820e7fbd`
- Schema surface: `ai/mcp/server/memory-core/openapi.yaml:1805-1824`
- Service surface (correct, no change needed): `ai/services/memory-core/MemoryService.mjs:126-129`
- Consistency sibling: `list_messages` MCP tool already accepts/returns `from: null` for system messages
- Sibling open author-PRs: #11815 (Tier-2 Revalidation Sweep, APPROVED at @tobiu merge gate), #11818 (v13 project attachment, APPROVED at @tobiu merge gate)

Related: #11819
