### PR TITLE
docs(ai): standardize CLI parser convention (#11817)

### DIFF
--- a/buildScripts/README.md
+++ b/buildScripts/README.md
@@ -28,6 +28,42 @@ Tools for managing the AI infrastructure, including Vector Database operations a
 | `downloadKnowledgeBase.mjs` | `npm run ai:download-kb` | Downloads the latest pre-indexed Knowledge Base from the remote source. |
 | `syncKnowledgeBase.mjs` | `npm run ai:sync-kb` | Indexes the local codebase and updates the vector database with changes. |
 
+### AI/Operator CLI Parser Convention
+
+New or actively touched AI/operator CLI surfaces under `ai/scripts/` and `buildScripts/ai/`
+should use Commander-backed parsing by default. The repository already carries
+`commander` as a direct dependency, and Commander gives these scripts consistent
+help output, unknown-option rejection, missing-value rejection, and option default
+handling.
+
+Keep parser seams testable:
+
+- Export a pure parser helper such as `parseArgs(argv)` or pair it with
+  `createProgram()` when tests need a fresh `Command` instance.
+- In exported parser tests, use `exitOverride()` and suppress Commander output so
+  unknown flags, missing required options, missing option values, and help paths
+  can be asserted without terminating the test process.
+- Bespoke parsers are allowed only for legacy-stable or special-case surfaces.
+  When a bespoke parser is actively touched, either convert it or document why
+  Commander is the wrong fit and keep tests for unknown / missing option failure
+  semantics.
+
+#### Parser Surface Audit
+
+| Surface | Parser | Classification | Notes |
+| :--- | :--- | :--- | :--- |
+| `ai/scripts/revalidationSweep.mjs` | Commander | Converted now | Landed via #11815 with focused parser tests for defaults, values, unknown flags, missing required `--family`, and missing option value. |
+| `buildScripts/ai/defragChromaDB.mjs` | Commander | Existing standard | Already uses the shared Commander pattern. |
+| `buildScripts/ai/kbPushClient.mjs` | Commander | Existing standard | Keep as an example for exported parser seams and environment defaults. |
+| `buildScripts/ai/mcpHealthcheck.mjs` | Commander | Existing standard | Keep as an example for exported parser seams and dotenv-compatible defaults. |
+| `ai/scripts/lint-agents.mjs` | Bespoke | Legacy tolerated | Has focused tests and stable linter-specific semantics; convert when the parser is next materially touched. |
+| `ai/scripts/lint-skill-manifest.mjs` | Bespoke | Legacy tolerated | Stable linter-specific parser; convert when parser semantics are next materially touched. |
+| `ai/scripts/migrateWakeSubscriptions.mjs` | Bespoke | Future-touch conversion target | Convert on the next functional parser change rather than churning the script now. |
+| `ai/scripts/normalizeGraphIdentities.mjs` | Bespoke | Future-touch conversion target | Convert on the next functional parser change rather than churning the script now. |
+| `ai/scripts/backfillChromaSharedUserId.mjs` | Bespoke | Future-touch conversion target | Convert on the next functional parser change rather than churning the script now. |
+| `buildScripts/ai/ingestTenant.mjs` | Bespoke | Future-touch conversion target | Keep existing tenant-ingest tests; convert when parser behavior changes. |
+| `buildScripts/ai/restore.mjs` | Bespoke | Future-touch conversion target | Positional bundle parsing is covered by restore tests; convert when parser behavior changes. |
+
 ---
 
 ## 2. Build Operations (`buildScripts/build/`)


### PR DESCRIPTION
Authored by GPT-5 (Codex Desktop). Session 505396a0-9f61-475e-80e1-1634861379d2.

FAIR-band: over-target [15/30] -- corrective update of the existing #11817 branch after hidden README placement was rejected; no new lane was started.

Resolves #11817

Replaces the rejected hidden `buildScripts/README.md` authority surface with graph-queryable ADR 0016 at `learn/agentos/decisions/0016-ai-script-cli-parser-convention.md`. The ADR establishes Commander-first parsing as the default for new and actively touched AI script CLI surfaces while preserving stable legacy bespoke parsers until their parser semantics are touched or create observable friction.

Evidence: L1 (static diff audit plus prior #11815 parser-test precedent) -> L1 required (decision-record documentation only; no runtime code). Residual: legacy tolerated parser surfaces remain by design.

Decision Record impact: adds ADR 0016 and supersedes the ticket-body `Decision Record Impact: none` statement for #11817.

## Deltas from Previous PR State

- Removed the `buildScripts/README.md` change entirely.
- Rebased the branch on current `origin/dev`; the current diff is ADR-only.
- Reused `codex/11817-commander-cli-standard` per maintainer guidance instead of creating a second PR branch.

## Slot Rationale

- Added `learn/agentos/decisions/0016-ai-script-cli-parser-convention.md`: disposition `keep` as graph-queryable ADR, not turn-loaded instruction substrate. Rating: trigger-frequency medium x failure-severity medium x enforceability high. Decay mitigation: status remains Proposed until approved, green, and merged at the human merge gate; future supersession must name a concrete parser-contract failure or dependency change.

## Test Evidence

- `git diff --name-status origin/dev...ed8b752cd` -> only `learn/agentos/decisions/0016-ai-script-cli-parser-convention.md`.
- `git merge-base --is-ancestor origin/dev ed8b752cd` -> passed.
- `git diff --check origin/dev...ed8b752cd` -> passed.

## Post-Merge Validation

- [ ] Future AI script parser changes cite ADR 0016 as the Commander-first authority surface.

## Commit

- `ed8b752cd` -- `docs(agentos): add CLI parser ADR (#11817)`