### PR TITLE
feat(util): Neo.util.Env substrate primitive for env-var parsing (#11832)

### DIFF
--- a/src/util/Env.mjs
+++ b/src/util/Env.mjs
@@ -170,9 +170,11 @@ class Env extends Base {
 
     /**
      * Set a value at a dotted path on a config object, guarding against prototype pollution.
-     * Intermediate keys must already exist as objects; the leaf key is assigned directly.
-     *
-     * Refuses to traverse `__proto__` / `constructor` / `prototype` keys.
+     * Delegates namespace-walking to `Neo.ns()` (the canonical Neo primitive at `src/Neo.mjs:683`);
+     * adds the pollution-guard + non-object-intermediate-refusal that `Neo.ns` does not provide
+     * (env-binding-substrate-specific concerns — input paths derive from operator-provided
+     * env-binding maps which is a hostile-input surface unlike the trusted class-name input
+     * `Neo.ns` was designed for).
      *
      * @param {Object} obj Target object.
      * @param {String} path Dotted path (e.g., `'orchestrator.intervals.pollMs'`).
@@ -180,25 +182,22 @@ class Env extends Base {
      */
     static setDeep(obj, path, value) {
         const keys = path.split('.');
-        let current = obj;
-        for (let i = 0; i < keys.length - 1; i++) {
-            const key = keys[i];
+        // Guard ALL keys (including the leaf) against prototype pollution
+        for (const key of keys) {
             if (key === '__proto__' || key === 'constructor' || key === 'prototype') {
                 console.warn(`[Neo.util.Env] Prototype pollution attempt blocked for path "${path}"`);
                 return;
             }
-            if (typeof current[key] !== 'object' || current[key] === null) {
-                console.warn(`[Neo.util.Env] Cannot set path "${path}" because intermediate key "${key}" is not an object.`);
-                return;
-            }
-            current = current[key];
         }
-        const finalKey = keys[keys.length - 1];
-        if (finalKey === '__proto__' || finalKey === 'constructor' || finalKey === 'prototype') {
-            console.warn(`[Neo.util.Env] Prototype pollution attempt blocked for path "${path}"`);
+        const parentKeys = keys.slice(0, -1);
+        const finalKey   = keys[keys.length - 1];
+        // Use Neo.ns for the namespace walk; create=false preserves "refuses non-object intermediate" semantic
+        const parent = parentKeys.length ? Neo.ns(parentKeys, false, obj) : obj;
+        if (parent === null || typeof parent !== 'object') {
+            console.warn(`[Neo.util.Env] Cannot set path "${path}" because intermediate key is not an object.`);
             return;
         }
-        current[finalKey] = value;
+        parent[finalKey] = value;
     }
 }
 

--- a/src/util/Env.mjs
+++ b/src/util/Env.mjs
@@ -163,8 +163,7 @@ class Env extends Base {
                 : binding;
 
             const raw = env[varName];
-            if (globalThis.Neo && Neo.isEmpty(raw)) continue;
-            if (!globalThis.Neo && (raw === undefined || raw === null || raw === '')) continue;
+            if (Neo.isEmpty(raw)) continue;
 
             const result = parse(raw, varName, warn);
             if (result === undefined) continue;

--- a/src/util/Env.mjs
+++ b/src/util/Env.mjs
@@ -1,9 +1,5 @@
-import Base from '../core/Base.mjs';
-
 /**
- * @class Neo.util.Env
- * @extends Neo.core.Base
- * @summary Pure value-decoders for environment-variable substrate.
+ * Pure value-decoders for environment-variable substrate.
  *
  * Substrate-tier landing: env-parser primitive at Neo.util.X namespace (Tier-1 Neo substrate),
  * NOT on domain classes. Consolidates `ai/mcp/server/shared/helpers/EnvConfig.mjs`
@@ -15,124 +11,26 @@ import Base from '../core/Base.mjs';
  * answer "env var absent (undefined) / decoded value / invalid (warn + undefined)". Fallback
  * policy lives at the consumer call-site (e.g., `Env.parseNumber(process.env.X, 'X') ?? AiConfig.X`).
  *
- * Lifted from prior anchor: `ai/mcp/server/shared/helpers/EnvConfig.mjs`.
+ * Uses the gatekeep pattern (lightweight stateless utility — no Base inheritance, no
+ * reactive configs, no lifecycle hooks), mirroring `src/core/IdGenerator.mjs` precedent.
+ *
+ * @namespace Neo.util.Env
  */
-class Env extends Base {
-    static config = {
-        /**
-         * @member {String} className='Neo.util.Env'
-         * @protected
-         */
-        className: 'Neo.util.Env'
-    }
-
+const Env = {
     /**
      * Tokens accepted as `true` by `parseBool` (case-insensitive after trim).
-     * Covers both the MCP convention (`'true'`) and the daemon convention (`'yes'`/`'on'`/`'1'`).
+     * Covers both MCP (`'true'`) and daemon (`'yes'`/`'on'`/`'1'`) conventions.
      * @member {String[]} TRUE_TOKENS
-     * @static
      */
-    static TRUE_TOKENS = ['true', 'yes', 'on', '1']
+    TRUE_TOKENS: ['true', 'yes', 'on', '1'],
 
     /**
      * Tokens accepted as `false` by `parseBool` (case-insensitive after trim).
      * Preserves `PrimaryRepoSyncService.parseEnabledFlag` legacy semantics
      * (`'0'` / `'false'` / `'no'` / `'off'` → false).
      * @member {String[]} FALSE_TOKENS
-     * @static
      */
-    static FALSE_TOKENS = ['false', 'no', 'off', '0']
-
-    /**
-     * Decode env value as port (integer 1..65535).
-     * @param {String|undefined} rawValue
-     * @param {String} envVarName Diagnostic name for warnings.
-     * @param {Function} [warn=console.warn]
-     * @returns {Number|undefined} Decoded port, or undefined on absent / out-of-range.
-     */
-    static parsePort(rawValue, envVarName, warn = console.warn) {
-        if (Neo.isEmpty(rawValue)) return;
-        const num = Number(rawValue);
-        if (!Number.isInteger(num) || num <= 0 || num > 65535) {
-            warn(`[Neo.util.Env] Invalid ${envVarName}="${rawValue}" (must be integer in 1..65535); falling back.`);
-            return;
-        }
-        return num;
-    }
-
-    /**
-     * Decode env value as URL, normalized (trailing slash stripped).
-     * @param {String|undefined} rawValue
-     * @param {String} envVarName
-     * @param {Function} [warn=console.warn]
-     * @returns {String|undefined} Normalized URL, or undefined on absent / malformed.
-     */
-    static parseUrl(rawValue, envVarName, warn = console.warn) {
-        if (Neo.isEmpty(rawValue)) return;
-        try {
-            const url = new URL(rawValue);
-            return url.href.endsWith('/') ? url.href.slice(0, -1) : url.href;
-        } catch (e) {
-            warn(`[Neo.util.Env] Invalid ${envVarName}="${rawValue}" (must be a valid URL); falling back.`);
-        }
-    }
-
-    /**
-     * Decode env value as boolean.
-     *
-     * Token semantics (case-insensitive, trimmed):
-     * - true:  `'true'`, `'yes'`, `'on'`, `'1'`
-     * - false: `'false'`, `'no'`, `'off'`, `'0'`
-     * - other: warn + undefined
-     *
-     * Preserves both the strict MCP convention (`'true'` / `'false'`) and the permissive
-     * daemon convention (`PrimaryRepoSyncService.parseEnabledFlag` blocked `'0'` / `'no'` / `'off'`).
-     *
-     * @param {String|undefined} rawValue
-     * @param {String} envVarName
-     * @param {Function} [warn=console.warn]
-     * @returns {Boolean|undefined}
-     */
-    static parseBool(rawValue, envVarName, warn = console.warn) {
-        if (Neo.isEmpty(rawValue)) return;
-        const normalized = String(rawValue).trim().toLowerCase();
-        if (Env.TRUE_TOKENS.includes(normalized))  return true;
-        if (Env.FALSE_TOKENS.includes(normalized)) return false;
-        warn(`[Neo.util.Env] Invalid ${envVarName}="${rawValue}" (must be one of true/false/yes/no/on/off/1/0); falling back.`);
-    }
-
-    /**
-     * Identity passthrough — signals "we explicitly want the raw string".
-     * Used for env vars that are themselves identifiers, paths, or labels.
-     * @param {String|undefined} rawValue
-     * @returns {String|undefined}
-     */
-    static parseString(rawValue) {
-        return rawValue;
-    }
-
-    /**
-     * Decode env value as a finite number.
-     *
-     * Note: `Number(undefined)` returns `NaN`, NOT undefined — and `NaN ?? fallback` does
-     * NOT fall through to `fallback` because `??` only fires on nullish. The explicit
-     * undefined-return for absent input is load-bearing for the `Env.parseNumber(...) ?? AiConfig.X`
-     * consumer pattern.
-     *
-     * @param {String|undefined} rawValue
-     * @param {String} envVarName
-     * @param {Function} [warn=console.warn]
-     * @returns {Number|undefined} Decoded number, or undefined on absent / non-finite.
-     */
-    static parseNumber(rawValue, envVarName, warn = console.warn) {
-        if (Neo.isEmpty(rawValue)) return;
-        const num = Number(rawValue);
-        if (!Number.isFinite(num)) {
-            warn(`[Neo.util.Env] Invalid ${envVarName}="${rawValue}" (must be a finite number); falling back.`);
-            return;
-        }
-        return num;
-    }
+    FALSE_TOKENS: ['false', 'no', 'off', '0'],
 
     /**
      * Bulk-apply env→config bindings.
@@ -154,7 +52,7 @@ class Env extends Base {
      * @param {Object} [env=process.env]
      * @param {Function} [warn=console.warn]
      */
-    static applyEnvBindings(data, envBindings, env = process.env, warn = console.warn) {
+    applyEnvBindings(data, envBindings, env = process.env, warn = console.warn) {
         for (const [path, binding] of Object.entries(envBindings)) {
             const { var: varName, parse } = typeof binding === 'string'
                 ? { var: binding, parse: Env.parseString }
@@ -176,7 +74,93 @@ class Env extends Base {
                 warn(`[Neo.util.Env] Cannot bind ${varName} to "${path}" — intermediate is not an object.`);
             }
         }
-    }
-}
+    },
 
-export default Neo.setupClass(Env);
+    /**
+     * Decode env value as boolean.
+     *
+     * Token semantics (case-insensitive, trimmed):
+     * - true:  `'true'`, `'yes'`, `'on'`, `'1'`
+     * - false: `'false'`, `'no'`, `'off'`, `'0'`
+     * - other: warn + undefined
+     *
+     * @param {String|undefined} rawValue
+     * @param {String} envVarName
+     * @param {Function} [warn=console.warn]
+     * @returns {Boolean|undefined}
+     */
+    parseBool(rawValue, envVarName, warn = console.warn) {
+        if (Neo.isEmpty(rawValue)) return;
+        const normalized = String(rawValue).trim().toLowerCase();
+        if (Env.TRUE_TOKENS.includes(normalized))  return true;
+        if (Env.FALSE_TOKENS.includes(normalized)) return false;
+        warn(`[Neo.util.Env] Invalid ${envVarName}="${rawValue}" (must be one of true/false/yes/no/on/off/1/0); falling back.`);
+    },
+
+    /**
+     * Decode env value as a finite number.
+     *
+     * Note: `Number(undefined)` returns `NaN` (not undefined), and `NaN ?? fallback` does
+     * NOT fire `??` (only fires on nullish). The undefined-return for absent input is
+     * load-bearing for the `Env.parseNumber(...) ?? AiConfig.X` consumer pattern.
+     *
+     * @param {String|undefined} rawValue
+     * @param {String} envVarName
+     * @param {Function} [warn=console.warn]
+     * @returns {Number|undefined}
+     */
+    parseNumber(rawValue, envVarName, warn = console.warn) {
+        if (Neo.isEmpty(rawValue)) return;
+        const num = Number(rawValue);
+        if (!Number.isFinite(num)) {
+            warn(`[Neo.util.Env] Invalid ${envVarName}="${rawValue}" (must be a finite number); falling back.`);
+            return;
+        }
+        return num;
+    },
+
+    /**
+     * Decode env value as port (integer 1..65535).
+     * @param {String|undefined} rawValue
+     * @param {String} envVarName
+     * @param {Function} [warn=console.warn]
+     * @returns {Number|undefined}
+     */
+    parsePort(rawValue, envVarName, warn = console.warn) {
+        if (Neo.isEmpty(rawValue)) return;
+        const num = Number(rawValue);
+        if (!Number.isInteger(num) || num <= 0 || num > 65535) {
+            warn(`[Neo.util.Env] Invalid ${envVarName}="${rawValue}" (must be integer in 1..65535); falling back.`);
+            return;
+        }
+        return num;
+    },
+
+    /**
+     * Identity passthrough — signals "we explicitly want the raw string".
+     * @param {String|undefined} rawValue
+     * @returns {String|undefined}
+     */
+    parseString(rawValue) {
+        return rawValue;
+    },
+
+    /**
+     * Decode env value as URL, normalized (trailing slash stripped).
+     * @param {String|undefined} rawValue
+     * @param {String} envVarName
+     * @param {Function} [warn=console.warn]
+     * @returns {String|undefined}
+     */
+    parseUrl(rawValue, envVarName, warn = console.warn) {
+        if (Neo.isEmpty(rawValue)) return;
+        try {
+            const url = new URL(rawValue);
+            return url.href.endsWith('/') ? url.href.slice(0, -1) : url.href;
+        } catch (e) {
+            warn(`[Neo.util.Env] Invalid ${envVarName}="${rawValue}" (must be a valid URL); falling back.`);
+        }
+    }
+};
+
+export default Neo.gatekeep(Env, 'Neo.util.Env');

--- a/src/util/Env.mjs
+++ b/src/util/Env.mjs
@@ -51,11 +51,11 @@ class Env extends Base {
      * @returns {Number|undefined} Decoded port, or undefined on absent / out-of-range.
      */
     static parsePort(rawValue, envVarName, warn = console.warn) {
-        if (rawValue === undefined || rawValue === null || rawValue === '') return undefined;
+        if (Neo.isEmpty(rawValue)) return;
         const num = Number(rawValue);
         if (!Number.isInteger(num) || num <= 0 || num > 65535) {
             warn(`[Neo.util.Env] Invalid ${envVarName}="${rawValue}" (must be integer in 1..65535); falling back.`);
-            return undefined;
+            return;
         }
         return num;
     }
@@ -68,13 +68,12 @@ class Env extends Base {
      * @returns {String|undefined} Normalized URL, or undefined on absent / malformed.
      */
     static parseUrl(rawValue, envVarName, warn = console.warn) {
-        if (rawValue === undefined || rawValue === null || rawValue === '') return undefined;
+        if (Neo.isEmpty(rawValue)) return;
         try {
             const url = new URL(rawValue);
             return url.href.endsWith('/') ? url.href.slice(0, -1) : url.href;
         } catch (e) {
             warn(`[Neo.util.Env] Invalid ${envVarName}="${rawValue}" (must be a valid URL); falling back.`);
-            return undefined;
         }
     }
 
@@ -95,12 +94,11 @@ class Env extends Base {
      * @returns {Boolean|undefined}
      */
     static parseBool(rawValue, envVarName, warn = console.warn) {
-        if (rawValue === undefined || rawValue === null || rawValue === '') return undefined;
+        if (Neo.isEmpty(rawValue)) return;
         const normalized = String(rawValue).trim().toLowerCase();
         if (Env.TRUE_TOKENS.includes(normalized))  return true;
         if (Env.FALSE_TOKENS.includes(normalized)) return false;
         warn(`[Neo.util.Env] Invalid ${envVarName}="${rawValue}" (must be one of true/false/yes/no/on/off/1/0); falling back.`);
-        return undefined;
     }
 
     /**
@@ -127,11 +125,11 @@ class Env extends Base {
      * @returns {Number|undefined} Decoded number, or undefined on absent / non-finite.
      */
     static parseNumber(rawValue, envVarName, warn = console.warn) {
-        if (rawValue === undefined || rawValue === null || rawValue === '') return undefined;
+        if (Neo.isEmpty(rawValue)) return;
         const num = Number(rawValue);
         if (!Number.isFinite(num)) {
             warn(`[Neo.util.Env] Invalid ${envVarName}="${rawValue}" (must be a finite number); falling back.`);
-            return undefined;
+            return;
         }
         return num;
     }
@@ -172,7 +170,7 @@ class Env extends Base {
             const finalKey = keys.pop();
             const parent   = keys.length ? Neo.ns(keys, false, data) : data;
 
-            if (parent && typeof parent === 'object') {
+            if (Neo.isObject(parent)) {
                 parent[finalKey] = result;
             } else {
                 warn(`[Neo.util.Env] Cannot bind ${varName} to "${path}" — intermediate is not an object.`);

--- a/src/util/Env.mjs
+++ b/src/util/Env.mjs
@@ -137,14 +137,19 @@ class Env extends Base {
     }
 
     /**
-     * Bulk-apply env→config bindings with prototype-pollution guards.
+     * Bulk-apply env→config bindings.
      *
      * Binding shapes:
      * - `{<dotted.path>: <envVarName>}` — implicit `parseString` parser
      * - `{<dotted.path>: {var: <envVarName>, parse: <parserFn>}}` — typed parser
      *
      * Bindings whose env var is absent or whose parser returns undefined are skipped
-     * (leaves the existing `data` value untouched).
+     * (leaves the existing `data` value untouched). Uses `Neo.ns()` for namespace-walk;
+     * warns + skips if an intermediate is not an object.
+     *
+     * Note: binding paths are developer-authored at source level (NOT env-value-derived);
+     * env values become typed leaf values via the parser, never path keys. No prototype-
+     * pollution attack surface from env input.
      *
      * @param {Object} data Mutable config object.
      * @param {Object} envBindings Path → binding map.
@@ -164,40 +169,16 @@ class Env extends Base {
             const result = parse(raw, varName, warn);
             if (result === undefined) continue;
 
-            Env.setDeep(data, path, result);
-        }
-    }
+            const keys     = path.split('.');
+            const finalKey = keys.pop();
+            const parent   = keys.length ? Neo.ns(keys, false, data) : data;
 
-    /**
-     * Set a value at a dotted path on a config object, guarding against prototype pollution.
-     * Delegates namespace-walking to `Neo.ns()` (the canonical Neo primitive at `src/Neo.mjs:683`);
-     * adds the pollution-guard + non-object-intermediate-refusal that `Neo.ns` does not provide
-     * (env-binding-substrate-specific concerns — input paths derive from operator-provided
-     * env-binding maps which is a hostile-input surface unlike the trusted class-name input
-     * `Neo.ns` was designed for).
-     *
-     * @param {Object} obj Target object.
-     * @param {String} path Dotted path (e.g., `'orchestrator.intervals.pollMs'`).
-     * @param {*} value Value to assign at the leaf.
-     */
-    static setDeep(obj, path, value) {
-        const keys = path.split('.');
-        // Guard ALL keys (including the leaf) against prototype pollution
-        for (const key of keys) {
-            if (key === '__proto__' || key === 'constructor' || key === 'prototype') {
-                console.warn(`[Neo.util.Env] Prototype pollution attempt blocked for path "${path}"`);
-                return;
+            if (parent && typeof parent === 'object') {
+                parent[finalKey] = result;
+            } else {
+                warn(`[Neo.util.Env] Cannot bind ${varName} to "${path}" — intermediate is not an object.`);
             }
         }
-        const parentKeys = keys.slice(0, -1);
-        const finalKey   = keys[keys.length - 1];
-        // Use Neo.ns for the namespace walk; create=false preserves "refuses non-object intermediate" semantic
-        const parent = parentKeys.length ? Neo.ns(parentKeys, false, obj) : obj;
-        if (parent === null || typeof parent !== 'object') {
-            console.warn(`[Neo.util.Env] Cannot set path "${path}" because intermediate key is not an object.`);
-            return;
-        }
-        parent[finalKey] = value;
     }
 }
 

--- a/src/util/Env.mjs
+++ b/src/util/Env.mjs
@@ -1,0 +1,205 @@
+import Base from '../core/Base.mjs';
+
+/**
+ * @class Neo.util.Env
+ * @extends Neo.core.Base
+ * @summary Pure value-decoders for environment-variable substrate.
+ *
+ * Substrate-tier landing: env-parser primitive at Neo.util.X namespace (Tier-1 Neo substrate),
+ * NOT on domain classes. Consolidates `ai/mcp/server/shared/helpers/EnvConfig.mjs`
+ * (was Tier-2 MCP-shared), `ai/daemons/services/CadenceEngine.parseInterval` (was Tier-3
+ * domain), and `ai/daemons/services/PrimaryRepoSyncService.parseEnabledFlag` (was Tier-3
+ * domain).
+ *
+ * Decoders know NOTHING about specific configs, defaults, or domain consumers — they only
+ * answer "env var absent (undefined) / decoded value / invalid (warn + undefined)". Fallback
+ * policy lives at the consumer call-site (e.g., `Env.parseNumber(process.env.X, 'X') ?? AiConfig.X`).
+ *
+ * Lifted from prior anchor: `ai/mcp/server/shared/helpers/EnvConfig.mjs`.
+ */
+class Env extends Base {
+    static config = {
+        /**
+         * @member {String} className='Neo.util.Env'
+         * @protected
+         */
+        className: 'Neo.util.Env'
+    }
+
+    /**
+     * Tokens accepted as `true` by `parseBool` (case-insensitive after trim).
+     * Covers both the MCP convention (`'true'`) and the daemon convention (`'yes'`/`'on'`/`'1'`).
+     * @member {String[]} TRUE_TOKENS
+     * @static
+     */
+    static TRUE_TOKENS = ['true', 'yes', 'on', '1']
+
+    /**
+     * Tokens accepted as `false` by `parseBool` (case-insensitive after trim).
+     * Preserves `PrimaryRepoSyncService.parseEnabledFlag` legacy semantics
+     * (`'0'` / `'false'` / `'no'` / `'off'` → false).
+     * @member {String[]} FALSE_TOKENS
+     * @static
+     */
+    static FALSE_TOKENS = ['false', 'no', 'off', '0']
+
+    /**
+     * Decode env value as port (integer 1..65535).
+     * @param {String|undefined} rawValue
+     * @param {String} envVarName Diagnostic name for warnings.
+     * @param {Function} [warn=console.warn]
+     * @returns {Number|undefined} Decoded port, or undefined on absent / out-of-range.
+     */
+    static parsePort(rawValue, envVarName, warn = console.warn) {
+        if (rawValue === undefined || rawValue === null || rawValue === '') return undefined;
+        const num = Number(rawValue);
+        if (!Number.isInteger(num) || num <= 0 || num > 65535) {
+            warn(`[Neo.util.Env] Invalid ${envVarName}="${rawValue}" (must be integer in 1..65535); falling back.`);
+            return undefined;
+        }
+        return num;
+    }
+
+    /**
+     * Decode env value as URL, normalized (trailing slash stripped).
+     * @param {String|undefined} rawValue
+     * @param {String} envVarName
+     * @param {Function} [warn=console.warn]
+     * @returns {String|undefined} Normalized URL, or undefined on absent / malformed.
+     */
+    static parseUrl(rawValue, envVarName, warn = console.warn) {
+        if (rawValue === undefined || rawValue === null || rawValue === '') return undefined;
+        try {
+            const url = new URL(rawValue);
+            return url.href.endsWith('/') ? url.href.slice(0, -1) : url.href;
+        } catch (e) {
+            warn(`[Neo.util.Env] Invalid ${envVarName}="${rawValue}" (must be a valid URL); falling back.`);
+            return undefined;
+        }
+    }
+
+    /**
+     * Decode env value as boolean.
+     *
+     * Token semantics (case-insensitive, trimmed):
+     * - true:  `'true'`, `'yes'`, `'on'`, `'1'`
+     * - false: `'false'`, `'no'`, `'off'`, `'0'`
+     * - other: warn + undefined
+     *
+     * Preserves both the strict MCP convention (`'true'` / `'false'`) and the permissive
+     * daemon convention (`PrimaryRepoSyncService.parseEnabledFlag` blocked `'0'` / `'no'` / `'off'`).
+     *
+     * @param {String|undefined} rawValue
+     * @param {String} envVarName
+     * @param {Function} [warn=console.warn]
+     * @returns {Boolean|undefined}
+     */
+    static parseBool(rawValue, envVarName, warn = console.warn) {
+        if (rawValue === undefined || rawValue === null || rawValue === '') return undefined;
+        const normalized = String(rawValue).trim().toLowerCase();
+        if (Env.TRUE_TOKENS.includes(normalized))  return true;
+        if (Env.FALSE_TOKENS.includes(normalized)) return false;
+        warn(`[Neo.util.Env] Invalid ${envVarName}="${rawValue}" (must be one of true/false/yes/no/on/off/1/0); falling back.`);
+        return undefined;
+    }
+
+    /**
+     * Identity passthrough — signals "we explicitly want the raw string".
+     * Used for env vars that are themselves identifiers, paths, or labels.
+     * @param {String|undefined} rawValue
+     * @returns {String|undefined}
+     */
+    static parseString(rawValue) {
+        return rawValue;
+    }
+
+    /**
+     * Decode env value as a finite number.
+     *
+     * Note: `Number(undefined)` returns `NaN`, NOT undefined — and `NaN ?? fallback` does
+     * NOT fall through to `fallback` because `??` only fires on nullish. The explicit
+     * undefined-return for absent input is load-bearing for the `Env.parseNumber(...) ?? AiConfig.X`
+     * consumer pattern.
+     *
+     * @param {String|undefined} rawValue
+     * @param {String} envVarName
+     * @param {Function} [warn=console.warn]
+     * @returns {Number|undefined} Decoded number, or undefined on absent / non-finite.
+     */
+    static parseNumber(rawValue, envVarName, warn = console.warn) {
+        if (rawValue === undefined || rawValue === null || rawValue === '') return undefined;
+        const num = Number(rawValue);
+        if (!Number.isFinite(num)) {
+            warn(`[Neo.util.Env] Invalid ${envVarName}="${rawValue}" (must be a finite number); falling back.`);
+            return undefined;
+        }
+        return num;
+    }
+
+    /**
+     * Bulk-apply env→config bindings with prototype-pollution guards.
+     *
+     * Binding shapes:
+     * - `{<dotted.path>: <envVarName>}` — implicit `parseString` parser
+     * - `{<dotted.path>: {var: <envVarName>, parse: <parserFn>}}` — typed parser
+     *
+     * Bindings whose env var is absent or whose parser returns undefined are skipped
+     * (leaves the existing `data` value untouched).
+     *
+     * @param {Object} data Mutable config object.
+     * @param {Object} envBindings Path → binding map.
+     * @param {Object} [env=process.env]
+     * @param {Function} [warn=console.warn]
+     */
+    static applyEnvBindings(data, envBindings, env = process.env, warn = console.warn) {
+        for (const [path, binding] of Object.entries(envBindings)) {
+            const { var: varName, parse } = typeof binding === 'string'
+                ? { var: binding, parse: Env.parseString }
+                : binding;
+
+            const raw = env[varName];
+            if (globalThis.Neo && Neo.isEmpty(raw)) continue;
+            if (!globalThis.Neo && (raw === undefined || raw === null || raw === '')) continue;
+
+            const result = parse(raw, varName, warn);
+            if (result === undefined) continue;
+
+            Env.setDeep(data, path, result);
+        }
+    }
+
+    /**
+     * Set a value at a dotted path on a config object, guarding against prototype pollution.
+     * Intermediate keys must already exist as objects; the leaf key is assigned directly.
+     *
+     * Refuses to traverse `__proto__` / `constructor` / `prototype` keys.
+     *
+     * @param {Object} obj Target object.
+     * @param {String} path Dotted path (e.g., `'orchestrator.intervals.pollMs'`).
+     * @param {*} value Value to assign at the leaf.
+     */
+    static setDeep(obj, path, value) {
+        const keys = path.split('.');
+        let current = obj;
+        for (let i = 0; i < keys.length - 1; i++) {
+            const key = keys[i];
+            if (key === '__proto__' || key === 'constructor' || key === 'prototype') {
+                console.warn(`[Neo.util.Env] Prototype pollution attempt blocked for path "${path}"`);
+                return;
+            }
+            if (typeof current[key] !== 'object' || current[key] === null) {
+                console.warn(`[Neo.util.Env] Cannot set path "${path}" because intermediate key "${key}" is not an object.`);
+                return;
+            }
+            current = current[key];
+        }
+        const finalKey = keys[keys.length - 1];
+        if (finalKey === '__proto__' || finalKey === 'constructor' || finalKey === 'prototype') {
+            console.warn(`[Neo.util.Env] Prototype pollution attempt blocked for path "${path}"`);
+            return;
+        }
+        current[finalKey] = value;
+    }
+}
+
+export default Neo.setupClass(Env);

--- a/src/util/_export.mjs
+++ b/src/util/_export.mjs
@@ -2,6 +2,7 @@ import NeoArray         from './Array.mjs';
 import ClassSystem      from './ClassSystem.mjs';
 import Css              from './Css.mjs';
 import Date             from './Date.mjs';
+import Env              from './Env.mjs';
 import * as Function    from './Function.mjs';
 import HashHistory      from './HashHistory.mjs';
 import Json             from './Json.mjs';
@@ -13,4 +14,4 @@ import Style            from './Style.mjs';
 import VDom             from './VDom.mjs';
 import VNode            from './VNode.mjs';
 
-export {ClassSystem, Css, Date, Function, HashHistory, Json, KeyNavigation, Logger, Matrix, NeoArray, Rectangle, Style, VDom, VNode};
+export {ClassSystem, Css, Date, Env, Function, HashHistory, Json, KeyNavigation, Logger, Matrix, NeoArray, Rectangle, Style, VDom, VNode};

--- a/test/playwright/unit/util/Env.spec.mjs
+++ b/test/playwright/unit/util/Env.spec.mjs
@@ -135,33 +135,15 @@ test.describe('Neo.util.Env', () => {
         });
     });
 
-    test.describe('setDeep', () => {
-        test('sets value at simple path', () => {
-            const obj = { a: { b: { c: 1 } } };
-            Env.setDeep(obj, 'a.b.c', 42);
-            expect(obj.a.b.c).toBe(42);
-        });
-
-        test('blocks prototype pollution via __proto__', () => {
-            const obj = { a: {} };
-            Env.setDeep(obj, 'a.__proto__.polluted', 'YES');
-            expect({}.polluted).toBe(undefined);
-        });
-
-        test('blocks prototype pollution via constructor', () => {
-            const obj = { a: {} };
-            Env.setDeep(obj, 'a.constructor.prototype.polluted', 'YES');
-            expect({}.polluted).toBe(undefined);
-        });
-
-        test('refuses to traverse non-object intermediate keys', () => {
-            const obj = { a: { b: 'leaf' } };
-            Env.setDeep(obj, 'a.b.c', 42);
-            expect(obj.a.b).toBe('leaf');
-        });
-    });
-
     test.describe('applyEnvBindings', () => {
+        test('warns + skips when intermediate is not an object (developer-authored path mistake)', () => {
+            const data = { a: { b: 'leaf' } };
+            const bindings = { 'a.b.c': { var: 'TEST_X', parse: Env.parseNumber } };
+            Env.applyEnvBindings(data, bindings, { TEST_X: '42' }, captureWarn);
+            expect(data.a.b).toBe('leaf');
+            expect(warns.length).toBe(1);
+        });
+
         test('applies string bindings from env', () => {
             const data = { name: '' };
             const bindings = { name: 'TEST_NAME' };

--- a/test/playwright/unit/util/Env.spec.mjs
+++ b/test/playwright/unit/util/Env.spec.mjs
@@ -1,0 +1,196 @@
+import { setup } from '../../setup.mjs';
+
+const appName = 'EnvTest';
+
+setup({
+    appConfig: {
+        name: appName
+    }
+});
+
+import {test, expect} from '@playwright/test';
+import Neo            from '../../../../src/Neo.mjs';
+import * as core      from '../../../../src/core/_export.mjs';
+import Env            from '../../../../src/util/Env.mjs';
+
+test.describe('Neo.util.Env', () => {
+    let warns;
+    const captureWarn = (...args) => { warns.push(args); };
+
+    test.beforeEach(() => { warns = []; });
+
+    test.describe('parseNumber', () => {
+        test('returns undefined for absent / null / empty (no warn — absent is not malformed)', () => {
+            expect(Env.parseNumber(undefined, 'X', captureWarn)).toBe(undefined);
+            expect(Env.parseNumber(null,      'X', captureWarn)).toBe(undefined);
+            expect(Env.parseNumber('',        'X', captureWarn)).toBe(undefined);
+            expect(warns.length).toBe(0);
+        });
+
+        test('decodes well-formed numbers', () => {
+            expect(Env.parseNumber('42',   'X', captureWarn)).toBe(42);
+            expect(Env.parseNumber('3.14', 'X', captureWarn)).toBe(3.14);
+            expect(Env.parseNumber('-7',   'X', captureWarn)).toBe(-7);
+            expect(Env.parseNumber('0',    'X', captureWarn)).toBe(0);
+            expect(warns.length).toBe(0);
+        });
+
+        test('warns + returns undefined on non-finite input (Number(undefined) === NaN gotcha protection)', () => {
+            expect(Env.parseNumber('abc',      'X', captureWarn)).toBe(undefined);
+            expect(Env.parseNumber('NaN',      'X', captureWarn)).toBe(undefined);
+            expect(Env.parseNumber('Infinity', 'X', captureWarn)).toBe(undefined);
+            expect(warns.length).toBe(3);
+        });
+
+        test('?? fallback pattern works correctly with absent input', () => {
+            // The load-bearing consumer pattern: Env.parseNumber(process.env.X, 'X') ?? AiConfig.X
+            // This MUST fall through to fallback when env var is absent (NOT NaN, which ?? would skip).
+            const fallback = 99;
+            expect(Env.parseNumber(undefined, 'X', captureWarn) ?? fallback).toBe(99);
+            expect(Env.parseNumber('',        'X', captureWarn) ?? fallback).toBe(99);
+            expect(Env.parseNumber('42',      'X', captureWarn) ?? fallback).toBe(42);
+        });
+    });
+
+    test.describe('parseBool', () => {
+        test('returns undefined for absent / null / empty', () => {
+            expect(Env.parseBool(undefined, 'X', captureWarn)).toBe(undefined);
+            expect(Env.parseBool(null,      'X', captureWarn)).toBe(undefined);
+            expect(Env.parseBool('',        'X', captureWarn)).toBe(undefined);
+            expect(warns.length).toBe(0);
+        });
+
+        test('accepts true tokens: true, yes, on, 1 (case-insensitive)', () => {
+            expect(Env.parseBool('true', 'X', captureWarn)).toBe(true);
+            expect(Env.parseBool('TRUE', 'X', captureWarn)).toBe(true);
+            expect(Env.parseBool('yes',  'X', captureWarn)).toBe(true);
+            expect(Env.parseBool('YES',  'X', captureWarn)).toBe(true);
+            expect(Env.parseBool('on',   'X', captureWarn)).toBe(true);
+            expect(Env.parseBool('1',    'X', captureWarn)).toBe(true);
+            expect(warns.length).toBe(0);
+        });
+
+        test('preserves PrimaryRepoSyncService.parseEnabledFlag legacy false tokens: 0, false, no, off', () => {
+            expect(Env.parseBool('false', 'X', captureWarn)).toBe(false);
+            expect(Env.parseBool('FALSE', 'X', captureWarn)).toBe(false);
+            expect(Env.parseBool('no',    'X', captureWarn)).toBe(false);
+            expect(Env.parseBool('NO',    'X', captureWarn)).toBe(false);
+            expect(Env.parseBool('off',   'X', captureWarn)).toBe(false);
+            expect(Env.parseBool('0',     'X', captureWarn)).toBe(false);
+            expect(warns.length).toBe(0);
+        });
+
+        test('warns + returns undefined on unknown tokens', () => {
+            expect(Env.parseBool('maybe',  'X', captureWarn)).toBe(undefined);
+            expect(Env.parseBool('truthy', 'X', captureWarn)).toBe(undefined);
+            expect(warns.length).toBe(2);
+        });
+    });
+
+    test.describe('parsePort', () => {
+        test('returns undefined for absent', () => {
+            expect(Env.parsePort(undefined, 'X', captureWarn)).toBe(undefined);
+            expect(warns.length).toBe(0);
+        });
+
+        test('decodes valid ports in 1..65535', () => {
+            expect(Env.parsePort('1',     'X', captureWarn)).toBe(1);
+            expect(Env.parsePort('8080',  'X', captureWarn)).toBe(8080);
+            expect(Env.parsePort('65535', 'X', captureWarn)).toBe(65535);
+            expect(warns.length).toBe(0);
+        });
+
+        test('warns + returns undefined for out-of-range / non-integer / non-numeric', () => {
+            expect(Env.parsePort('0',     'X', captureWarn)).toBe(undefined);
+            expect(Env.parsePort('65536', 'X', captureWarn)).toBe(undefined);
+            expect(Env.parsePort('-1',    'X', captureWarn)).toBe(undefined);
+            expect(Env.parsePort('3.14',  'X', captureWarn)).toBe(undefined);
+            expect(Env.parsePort('abc',   'X', captureWarn)).toBe(undefined);
+            expect(warns.length).toBe(5);
+        });
+    });
+
+    test.describe('parseUrl', () => {
+        test('returns undefined for absent', () => {
+            expect(Env.parseUrl(undefined, 'X', captureWarn)).toBe(undefined);
+        });
+
+        test('decodes + normalizes (strips trailing slash)', () => {
+            expect(Env.parseUrl('https://example.com/',  'X', captureWarn)).toBe('https://example.com');
+            expect(Env.parseUrl('https://example.com/x', 'X', captureWarn)).toBe('https://example.com/x');
+        });
+
+        test('warns + returns undefined for malformed URL', () => {
+            expect(Env.parseUrl('not a url', 'X', captureWarn)).toBe(undefined);
+            expect(Env.parseUrl('://bad',    'X', captureWarn)).toBe(undefined);
+            expect(warns.length).toBe(2);
+        });
+    });
+
+    test.describe('parseString', () => {
+        test('passthrough identity', () => {
+            expect(Env.parseString('hello')).toBe('hello');
+            expect(Env.parseString('')).toBe('');
+            expect(Env.parseString(undefined)).toBe(undefined);
+        });
+    });
+
+    test.describe('setDeep', () => {
+        test('sets value at simple path', () => {
+            const obj = { a: { b: { c: 1 } } };
+            Env.setDeep(obj, 'a.b.c', 42);
+            expect(obj.a.b.c).toBe(42);
+        });
+
+        test('blocks prototype pollution via __proto__', () => {
+            const obj = { a: {} };
+            Env.setDeep(obj, 'a.__proto__.polluted', 'YES');
+            expect({}.polluted).toBe(undefined);
+        });
+
+        test('blocks prototype pollution via constructor', () => {
+            const obj = { a: {} };
+            Env.setDeep(obj, 'a.constructor.prototype.polluted', 'YES');
+            expect({}.polluted).toBe(undefined);
+        });
+
+        test('refuses to traverse non-object intermediate keys', () => {
+            const obj = { a: { b: 'leaf' } };
+            Env.setDeep(obj, 'a.b.c', 42);
+            expect(obj.a.b).toBe('leaf');
+        });
+    });
+
+    test.describe('applyEnvBindings', () => {
+        test('applies string bindings from env', () => {
+            const data = { name: '' };
+            const bindings = { name: 'TEST_NAME' };
+            const env = { TEST_NAME: 'orchestrator' };
+            Env.applyEnvBindings(data, bindings, env);
+            expect(data.name).toBe('orchestrator');
+        });
+
+        test('applies typed bindings with custom parser', () => {
+            const data = { config: { port: 0 } };
+            const bindings = { 'config.port': { var: 'TEST_PORT', parse: Env.parsePort } };
+            const env = { TEST_PORT: '8080' };
+            Env.applyEnvBindings(data, bindings, env);
+            expect(data.config.port).toBe(8080);
+        });
+
+        test('skips bindings when env var absent (leaves existing data untouched)', () => {
+            const data = { port: 99 };
+            const bindings = { port: { var: 'TEST_ABSENT', parse: Env.parsePort } };
+            Env.applyEnvBindings(data, bindings, {});
+            expect(data.port).toBe(99);
+        });
+
+        test('skips bindings when parser returns undefined (malformed input warned)', () => {
+            const data = { port: 99 };
+            const bindings = { port: { var: 'TEST_BAD', parse: Env.parsePort } };
+            Env.applyEnvBindings(data, bindings, { TEST_BAD: 'not-a-port' }, captureWarn);
+            expect(data.port).toBe(99);
+            expect(warns.length).toBe(1);
+        });
+    });
+});


### PR DESCRIPTION
Authored by Claude Opus 4.7 (Claude Code). Session 5572d9a5-558d-4bea-b416-e31496c289c4.

FAIR-band: in-band [verify @ merge-gate]

Resolves #11832

## Summary

THIN substrate-prerequisite for Sub 1 (#11833) Orchestrator masterclass-reference refactor. Lifts `ai/mcp/server/shared/helpers/EnvConfig.mjs` parsers to `src/util/Env.mjs` as `Neo.util.Env`, using the **gatekeep pattern** (lightweight plain-object utility, no Base inheritance) mirroring `src/core/IdGenerator.mjs` precedent.

Provides the env-parser primitive at Neo substrate-utility tier (Tier-1) instead of on a domain class. Sub 1 consumes via `Env.parseNumber(process.env.X, 'X') ?? AiConfig.X` for the operator-mandated 2-value chain.

## API Surface

| Method | Behavior |
|---|---|
| `parseNumber(rawValue, envVarName, warn?)` | Decode finite number; absent → undefined; non-finite → warn + undefined |
| `parseBool(rawValue, envVarName, warn?)` | Decode boolean; permissive token set (preserves both MCP + daemon conventions) |
| `parsePort(rawValue, envVarName, warn?)` | Decode integer 1..65535; out-of-range → warn + undefined |
| `parseUrl(rawValue, envVarName, warn?)` | Decode + normalize URL (strips trailing slash); malformed → warn + undefined |
| `parseString(rawValue)` | Identity passthrough (signals "we explicitly want the string") |
| `applyEnvBindings(data, bindings, env?, warn?)` | Bulk-apply env→config bindings (delegates namespace-walk to `Neo.ns`) |

## Boolean Compatibility (AC9-mandated)

`parseBool` preserves both `EnvConfig.parseBool` (`'true'`/`'false'` strict) AND `PrimaryRepoSyncService.parseEnabledFlag` (`'0'`/`'no'`/`'off'` permissive false) semantics:

- **true:** `'true'`, `'yes'`, `'on'`, `'1'` (case-insensitive after trim)
- **false:** `'false'`, `'no'`, `'off'`, `'0'`
- **other:** warn + undefined

No silent behavior change for existing MCP or daemon consumers.

## Critical correctness — `Number(undefined) === NaN` gotcha protection

`parseNumber` returns `undefined` (NOT NaN) for absent/empty input. This is **load-bearing** for the consumer pattern `Env.parseNumber(process.env.X, 'X') ?? AiConfig.X` because `??` only fires on nullish — if `parseNumber` returned NaN, the `??` would silently skip the AiConfig fallback. Caught by GPT's `node -e` empirical falsification on Discussion #11828 Cycle-2.

## Substrate-tier discipline

Decoders sit BELOW the policy line. They know NOTHING about:
- `AiConfig` / specific consumer configs
- Default values
- Env-var aliases
- Fallback chains
- Domain-specific consumers (Orchestrator / CadenceEngine / etc.)

Fallback to `AiConfig` stays at the consumer call-site. No env-parser methods on domain classes (the Cycle-3 STRONG VETO outcome from @tobiu).

## What this PR does NOT do (scope-bounded)

Per Discussion #11828 Cycle-3.1 deferral fixup #3 (avoid recreating the #11075 "start somewhere" failure):

- ❌ Does NOT delete `ai/mcp/server/shared/helpers/EnvConfig.mjs` (deferred to Sub 6a/6b MCP consumer rewire)
- ❌ Does NOT delete `CadenceEngine.parseInterval` (deferred to Sub 3 / Sub 1)
- ❌ Does NOT delete `PrimaryRepoSyncService.parseEnabledFlag` (deferred to Sub 3 / Sub 6c daemon migration)
- ❌ Does NOT migrate the 61-file / 80 env-var consumer surface (decomposes into Sub 6a/6b/6c/6d)

The follow-up consumer-cluster migration tickets land in parallel after Sub 1 sets the masterclass-reference pattern. This PR unblocks Sub 1 within ~1 PR review budget.

## Test Evidence

- `npm run test-unit -- test/playwright/unit/util/Env.spec.mjs` → **20 passed (602ms)**

Test coverage spans:
- `parseNumber`: absent/null/empty → undefined no warn (4 tests including ?? fallback pattern), well-formed (4 values), non-finite warn + undefined (3 cases)
- `parseBool`: absent/null/empty no warn, true tokens case-insensitive (6 values), false tokens preserving PrimaryRepoSyncService legacy (6 values), unknown tokens warn + undefined
- `parsePort`: absent, valid 1..65535 (3 values), out-of-range/non-integer/non-numeric warn + undefined (5 cases)
- `parseUrl`: absent, normalization (trailing slash strip), malformed warn + undefined
- `parseString`: identity passthrough
- `applyEnvBindings`: string bindings, typed bindings, skip-on-absent, skip-on-malformed, warn + skip when intermediate is not an object

## Deltas from ticket

- **AC1 substrate-pattern shift (operator-corrected mid-PR):** ticket said "Create `src/util/Env.mjs` extending `Base`, `Neo.setupClass()` registered... Mirrors `src/util/String.mjs` static-class pattern." Operator correctly flagged this as over-engineering — Env is pure stateless value-decoders with no Base-inherited behavior (no reactive configs, no lifecycle hooks, no instances). Implementation uses the **gatekeep pattern** (`Neo.gatekeep(Env, 'Neo.util.Env')`) mirroring `src/core/IdGenerator.mjs`, the canonical Neo precedent for lightweight stateless utility namespaces. Public API surface (`import Env from '...'` + `Env.parseNumber()` / etc) unchanged. Test surface unchanged.
- **`setDeep` dropped (operator-corrected mid-PR):** ticket implied `setDeep` would be part of the API surface (lifted from EnvConfig.mjs). Operator correctly flagged the prototype-pollution guards as cargo-cult over-engineering — env binding paths are developer-authored at source level (not env-value-derived); env values become typed leaf values via parsers, never path keys. `setDeep` dropped entirely; minimal namespace-walk inlined in `applyEnvBindings` using `Neo.ns`. Zero external consumers (verified via grep ai/ src/).
- **API surface refinement:** `applyEnvBindings` simplified to use `Neo.isEmpty(raw)` + `Neo.isObject(parent)` canonical primitives instead of hand-rolled equivalents. Removed impossible-condition `globalThis.Neo` guard (this file IS Neo.util.Env — Neo is guaranteed loaded by call-time).
- Optional `parseFloat` / `parseJSON` deferred to future consumer-driven additions.

Evidence: L1 (focused unit tests + gatekeep namespace registration) → L1 required for substrate-utility primitive (no runtime behavior change for existing consumers; pure additive).

## Test plan

- [ ] Reviewer runs `npm run test-unit -- test/playwright/unit/util/Env.spec.mjs` and confirms 20/20 pass
- [ ] Reviewer verifies `import Env from '<path>/src/util/Env.mjs'` works from both ai/daemons/ and ai/mcp/ paths
- [ ] Reviewer confirms `src/util/_export.mjs` barrel addition follows the alphabetical sort convention
- [ ] Reviewer confirms boolean compatibility note in AC9 is satisfied by the test suite's "preserves PrimaryRepoSyncService.parseEnabledFlag legacy false tokens" test

## Post-Merge Validation

- [ ] Sub 1 (#11833) Orchestrator masterclass-reference PR can consume `Env.parseNumber(process.env.X, 'X') ?? AiConfig.X` via direct `import Env from '../../src/util/Env.mjs'`
- [ ] Sub 6a/6b/6c follow-up consumer-cluster migration PRs can begin in parallel (no Sub-1 blocker)
- [ ] `EnvConfig.mjs` consumers continue working unmodified until Sub 6a/6b MCP rewire lands (no silent behavior change)

