### PR TITLE
feat(agentos): bump swarmHeartbeatMs default 5m → 15m (#11840)

### DIFF
--- a/ai/config.template.mjs
+++ b/ai/config.template.mjs
@@ -84,7 +84,7 @@ const defaultConfig = {
             primaryDevSyncMs : 10 * 60 * 1000,
             dreamMs          : HOUR_MS,
             goldenPathMs     : HOUR_MS,
-            swarmHeartbeatMs : 5 * 60 * 1000
+            swarmHeartbeatMs : 15 * 60 * 1000
         },
         /**
          * Local-only maintenance lane switches. Cloud deployments can disable these

--- a/test/playwright/unit/ai/config.template.spec.mjs
+++ b/test/playwright/unit/ai/config.template.spec.mjs
@@ -33,7 +33,7 @@ test.describe('Tier 1 Config Immutability', () => {
             primaryDevSyncMs: 10 * 60 * 1000,
             dreamMs         : 60 * 60 * 1000,
             goldenPathMs    : 60 * 60 * 1000,
-            swarmHeartbeatMs: 5 * 60 * 1000
+            swarmHeartbeatMs: 15 * 60 * 1000
         });
         expect(Config.orchestrator.localOnly).toEqual({
             primaryDevSyncEnabled: null,


### PR DESCRIPTION
Authored by Claude Opus 4.7 (Claude Code). Session 5572d9a5-558d-4bea-b416-e31496c289c4.

FAIR-band: in-band [verify @ merge-gate]

Resolves #11840

## Summary

1-line data-only tuning: `ai/config.template.mjs:87 orchestrator.intervals.swarmHeartbeatMs` from `5 * 60 * 1000` (5m) to `15 * 60 * 1000` (15m).

Per @tobiu: current wake-substrate pulse is too frequent; 15m reduces wakeup noise without losing operationally-useful cadence.

## Substrate context

`swarmHeartbeatMs` is the folded-in wake-substrate pulse (per #11766) — the canonical heartbeat driving `SwarmHeartbeatService.pulse()` + downstream `idleOutNudge`. Not the same as `summarySweepMs` (summarization cycle) or `primaryDevSyncMs` (git sync cycle); those concerns stay at their current defaults.

## Deltas from ticket

- Ticket scope was "1-line config bump" but actually requires **2-line change** (config + paired Tier 1 Config Immutability assertion) since the suite locks default values intentionally. Discovered on first CI run when the toMatchObject assertion broke. Commit `9e72b749c` syncs the test.

Evidence: L1 (config value + immutability-suite assertion) — required L1 covered; no runtime behavior surface beyond cadence delta.

## Test Evidence

- `npm run test-unit -- test/playwright/unit/ai/config.template.spec.mjs` → **3/3 pass (506ms)** including the Tier 1 Config Immutability `toMatchObject` assertion locked at the new `swarmHeartbeatMs: 15 * 60 * 1000` default
- Tier 1 Config Immutability suite is the substrate-discipline guard that catches silent default drift (worked exactly as designed — caught the initial unsynced assertion on first CI run; commit `9e72b749c` re-locks at the new canonical)
- `git diff origin/dev -- ai/config.template.mjs` → 1 line changed (`swarmHeartbeatMs : 5 * 60 * 1000` → `15 * 60 * 1000`), no other interval values touched
- Existing `NEO_ORCHESTRATOR_SWARM_HEARTBEAT_MS` env-var override mechanism unchanged (no env-handling code touched)

## Post-Merge Validation

- [ ] Operator observes reduced wake-message frequency on the @neo-opus-4-7 / @neo-gpt mailbox (15m cadence instead of 5m)
- [ ] No regression in idle-out detection (15m is still well below typical agent idle-out windows)
