### PR TITLE
refactor(agentos): delete obsolete CadenceEngine.parseInterval + PrimaryRepoSyncService.parseEnabledFlag (#11835)

### DIFF
--- a/ai/daemons/services/CadenceEngine.mjs
+++ b/ai/daemons/services/CadenceEngine.mjs
@@ -20,25 +20,10 @@ export class CadenceEngine extends Base {
         className: 'Neo.ai.daemons.services.CadenceEngine'
     }
 
-    /**
-     * @summary Parses daemon interval env vars while preserving `0` as disabled.
-     *
-     * @param {String|undefined} value Environment value.
-     * @param {Number} fallback Fallback interval in milliseconds.
-     * @returns {Number}
-     */
-    parseInterval(value, fallback) {
-        if (value === undefined || value === null || value === '') {
-            return fallback;
-        }
-
-        const parsed = parseInt(value, 10);
-        if (Number.isNaN(parsed)) {
-            return fallback;
-        }
-
-        return Math.max(parsed, 0);
-    }
+    // parseInterval() removed per Epic #11831 Sub 3 (#11835): consumer migrated to
+    // Neo.util.Env.parseNumber (Sub 6 #11832) + caller wraps in `Math.max(0, n)` if
+    // non-negative semantics required. Orchestrator (the sole runtime consumer) was
+    // rewired in Sub 1 (#11833).
 
     /**
      * @summary Returns true when an interval task is due and not disabled.

--- a/ai/daemons/services/CadenceEngine.mjs
+++ b/ai/daemons/services/CadenceEngine.mjs
@@ -20,11 +20,6 @@ export class CadenceEngine extends Base {
         className: 'Neo.ai.daemons.services.CadenceEngine'
     }
 
-    // parseInterval() removed per Epic #11831 Sub 3 (#11835): consumer migrated to
-    // Neo.util.Env.parseNumber (Sub 6 #11832) + caller wraps in `Math.max(0, n)` if
-    // non-negative semantics required. Orchestrator (the sole runtime consumer) was
-    // rewired in Sub 1 (#11833).
-
     /**
      * @summary Returns true when an interval task is due and not disabled.
      *

--- a/ai/daemons/services/PrimaryRepoSyncService.mjs
+++ b/ai/daemons/services/PrimaryRepoSyncService.mjs
@@ -55,11 +55,6 @@ export function isKbRelevantChangePath(filePath) {
         KB_RELEVANT_PATH_PREFIXES.some(prefix => normalized.startsWith(prefix));
 }
 
-// parseEnabledFlag() removed per Epic #11831 Sub 3 (#11835): consumer migrated to
-// Neo.util.Env.parseBool which preserves legacy false tokens ('0', 'false', 'no', 'off')
-// per Sub 6 (#11832) AC9 boolean compatibility. Orchestrator (the sole runtime consumer)
-// was rewired in Sub 1 (#11833).
-
 /**
  * @summary Parses the optional multi-checkout dev-sync root list (#11135).
  *

--- a/ai/daemons/services/PrimaryRepoSyncService.mjs
+++ b/ai/daemons/services/PrimaryRepoSyncService.mjs
@@ -55,20 +55,10 @@ export function isKbRelevantChangePath(filePath) {
         KB_RELEVANT_PATH_PREFIXES.some(prefix => normalized.startsWith(prefix));
 }
 
-/**
- * @summary Parses the primary-dev-sync enable flag.
- *
- * @param {String|undefined|null} value Environment value.
- * @param {Boolean} [fallback=true] Fallback flag.
- * @returns {Boolean}
- */
-export function parseEnabledFlag(value, fallback=true) {
-    if (value === undefined || value === null || value === '') {
-        return fallback;
-    }
-
-    return !['0', 'false', 'no', 'off'].includes(String(value).toLowerCase());
-}
+// parseEnabledFlag() removed per Epic #11831 Sub 3 (#11835): consumer migrated to
+// Neo.util.Env.parseBool which preserves legacy false tokens ('0', 'false', 'no', 'off')
+// per Sub 6 (#11832) AC9 boolean compatibility. Orchestrator (the sole runtime consumer)
+// was rewired in Sub 1 (#11833).
 
 /**
  * @summary Parses the optional multi-checkout dev-sync root list (#11135).

--- a/test/playwright/unit/ai/daemons/services/CadenceEngine.spec.mjs
+++ b/test/playwright/unit/ai/daemons/services/CadenceEngine.spec.mjs
@@ -5,12 +5,6 @@ import InstanceManager from '../../../../../../src/manager/Instance.mjs';
 import CadenceEngine   from '../../../../../../ai/daemons/services/CadenceEngine.mjs';
 
 test.describe('Neo.ai.daemons.services.CadenceEngine (#11051)', () => {
-    // Post Sub 1 #11833: CadenceEngine no longer `singleton: true` (per @tobiu:
-    // classes that take external configs cannot be singletons). Tests construct
-    // per-test instances via Neo.create.
-    // Post Sub 3 #11835: parseInterval() removed (consumer migrated to
-    // Neo.util.Env.parseNumber per Sub 6 #11832; 3 tests for that method deleted —
-    // coverage lives in test/playwright/unit/util/Env.spec.mjs).
     let ce;
     test.beforeEach(() => { ce = Neo.create(CadenceEngine); });
 

--- a/test/playwright/unit/ai/daemons/services/CadenceEngine.spec.mjs
+++ b/test/playwright/unit/ai/daemons/services/CadenceEngine.spec.mjs
@@ -7,26 +7,12 @@ import CadenceEngine   from '../../../../../../ai/daemons/services/CadenceEngine
 test.describe('Neo.ai.daemons.services.CadenceEngine (#11051)', () => {
     // Post Sub 1 #11833: CadenceEngine no longer `singleton: true` (per @tobiu:
     // classes that take external configs cannot be singletons). Tests construct
-    // per-test instances. parseInterval() is also queued for removal by Sub 3
-    // #11835 (replaced by Neo.util.Env.parseNumber).
+    // per-test instances via Neo.create.
+    // Post Sub 3 #11835: parseInterval() removed (consumer migrated to
+    // Neo.util.Env.parseNumber per Sub 6 #11832; 3 tests for that method deleted —
+    // coverage lives in test/playwright/unit/util/Env.spec.mjs).
     let ce;
     test.beforeEach(() => { ce = Neo.create(CadenceEngine); });
-
-    test('parseInterval() returns fallback for undefined/null/empty', () => {
-        expect(ce.parseInterval(undefined, 3000)).toBe(3000);
-        expect(ce.parseInterval(null, 3000)).toBe(3000);
-        expect(ce.parseInterval('', 3000)).toBe(3000);
-    });
-
-    test('parseInterval() parses valid numbers and prevents negative intervals', () => {
-        expect(ce.parseInterval('5000', 3000)).toBe(5000);
-        expect(ce.parseInterval('0', 3000)).toBe(0);
-        expect(ce.parseInterval('-5000', 3000)).toBe(0);
-    });
-
-    test('parseInterval() returns fallback for NaN', () => {
-        expect(ce.parseInterval('not-a-number', 3000)).toBe(3000);
-    });
 
     test('shouldRunIntervalTask() correctly evaluates due tasks', () => {
         // Disabled

--- a/test/playwright/unit/ai/daemons/services/PrimaryRepoSyncService.spec.mjs
+++ b/test/playwright/unit/ai/daemons/services/PrimaryRepoSyncService.spec.mjs
@@ -6,8 +6,7 @@ import PrimaryRepoSyncService, {
     DEV_SYNC_ROOTS_CONFIG_KEY,
     DEV_SYNC_ROOTS_ENV_VAR,
     isKbRelevantChangePath,
-    parseDevSyncRoots,
-    parseEnabledFlag
+    parseDevSyncRoots
 } from '../../../../../../ai/daemons/services/PrimaryRepoSyncService.mjs';
 import {
     PRIMARY_DEV_SYNC_TASK_NAME
@@ -76,12 +75,10 @@ function createTaskStateService(running=false) {
 }
 
 test.describe('PrimaryRepoSyncService (#11017)', () => {
-    test('builds interval triggers and parses the enable flag', () => {
-        expect(parseEnabledFlag(undefined)).toBe(true);
-        expect(parseEnabledFlag('false')).toBe(false);
-        expect(parseEnabledFlag('0')).toBe(false);
-        expect(parseEnabledFlag('true')).toBe(true);
-
+    // Post Sub 3 #11835: parseEnabledFlag() removed; coverage migrated to
+    // test/playwright/unit/util/Env.spec.mjs ("preserves PrimaryRepoSyncService.parseEnabledFlag
+    // legacy false tokens: 0, false, no, off").
+    test('builds interval triggers', () => {
         expect(buildPrimaryRepoSyncTrigger({
             enabled   : true,
             now       : 600000,

--- a/test/playwright/unit/ai/daemons/services/PrimaryRepoSyncService.spec.mjs
+++ b/test/playwright/unit/ai/daemons/services/PrimaryRepoSyncService.spec.mjs
@@ -75,9 +75,6 @@ function createTaskStateService(running=false) {
 }
 
 test.describe('PrimaryRepoSyncService (#11017)', () => {
-    // Post Sub 3 #11835: parseEnabledFlag() removed; coverage migrated to
-    // test/playwright/unit/util/Env.spec.mjs ("preserves PrimaryRepoSyncService.parseEnabledFlag
-    // legacy false tokens: 0, false, no, off").
     test('builds interval triggers', () => {
         expect(buildPrimaryRepoSyncTrigger({
             enabled   : true,


### PR DESCRIPTION
Authored by Claude Opus 4.7 (Claude Code). Session 5572d9a5-558d-4bea-b416-e31496c289c4.

FAIR-band: in-band [verify @ merge-gate]

Resolves #11835

## Summary

Sub 3 of Epic #11831. Deletes two parser surfaces whose sole runtime consumer (Orchestrator) was rewired in Sub 1 (#11833) to use `Neo.util.Env` from Sub 6 (#11832). Both functions had zero remaining non-test consumers per grep — pure dead code removal.

## Surfaces removed

| Surface | Before | After (Orchestrator) | Justification |
|---|---|---|---|
| `CadenceEngine.parseInterval(value, fallback)` | parseInt + clamp + fallback | `Env.parseNumber(process.env.X, 'X') ?? AiConfig.X` lazy getter | Substrate-utility-tier `Neo.util.Env` covers env-var parsing; AiConfig holds the canonical default |
| `PrimaryRepoSyncService.parseEnabledFlag(value, fallback)` | hardcoded `['0','false','no','off']` blocklist | `Env.parseBool(process.env.X, 'X') ?? resolveDeploymentEnabled('X')` lazy getter | `Env.parseBool` preserves all 4 legacy false tokens per Sub 6 (#11832) AC9 boolean compatibility |

## No behavior change

`Env.parseBool` token semantics (Sub 6 AC9):
- **true:** `'true'`, `'yes'`, `'on'`, `'1'` (case-insensitive after trim)
- **false:** `'false'`, `'no'`, `'off'`, `'0'`
- **other:** warn + undefined

Strictly a superset of `parseEnabledFlag`'s `['0','false','no','off']` false-token set. Any caller that previously got `false` from `parseEnabledFlag` continues to get `false` from `Env.parseBool`.

`Env.parseNumber` semantics: returns `undefined` for absent input (vs `parseInterval`'s fallback). The consumer pattern `Env.parseNumber(...) ?? AiConfig.X` recovers the fallback at the call-site (the operator-mandated 2-value chain). `Math.max(0, n)` clamp deferred to caller — Orchestrator does not need it (intervals already validated by AiConfig schema).

## Deltas from ticket

- **Sub 3 AC4 (SwarmHeartbeatService:37 LOCAL drift) + AC5 (KbAlertRuleEngine:56 DEFAULT_COOLDOWN_MS)** deferred to Sub 4 #11836 (sibling-daemon propagation) because their full removal requires consumer rewires that are Sub-1-style daemon refactors, not pure deletions. This PR scopes to the dead-code surfaces.
- **#11827 closure** deferred to post-merge `gh issue close #11827 --reason 'superseded by Epic #11831 Sub 3 #11835'` — the ticket was an audit-record absorbed by this Epic.

Evidence: L1 (49/49 unit tests pass post-deletion) → L1 required (pure dead-code removal; behavioral parity proven by Sub 6 AC9 + Sub 1 #11833's already-merged consumer rewire).

## Test Evidence

- `npm run test-unit -- test/playwright/unit/ai/daemons/services/CadenceEngine.spec.mjs test/playwright/unit/ai/daemons/services/PrimaryRepoSyncService.spec.mjs test/playwright/unit/ai/daemons/Orchestrator.spec.mjs` → **49/49 pass (1.3s)**

Test surface migration:
- `CadenceEngine.spec.mjs` — 3 `parseInterval` tests removed (covered by `test/playwright/unit/util/Env.spec.mjs` `parseNumber` test suite)
- `PrimaryRepoSyncService.spec.mjs` — `parseEnabledFlag` import + 4 inline assertions removed (covered by `test/playwright/unit/util/Env.spec.mjs` "preserves PrimaryRepoSyncService.parseEnabledFlag legacy false tokens" test)
- `Orchestrator.spec.mjs` — already migrated by Sub 1 (#11833) merged

File-size delta: -42 lines net across 4 files (-59 deletions / +17 insertions).

## Post-Merge Validation

- [ ] Operator verifies orchestrator daemon continues to run cleanly post-merge (no behavior change expected — pure dead-code removal)
- [ ] Close #11827 with `gh issue close 11827 --reason 'superseded by Epic #11831 Sub 3 #11835'`
- [ ] Sub 4 #11836 next: sibling daemon propagation (SwarmHeartbeatService + KbAlertingService + KbReconciliationService + KbGarbageCollectionService + GapInferenceEngine) — naturally absorbs the deferred AC4/AC5 deletions