### PR TITLE
refactor(agentos): Orchestrator collaborators as reactive configs + JSDoc intent-driven (#11854)

### DIFF
--- a/ai/daemons/orchestrator/Orchestrator.mjs
+++ b/ai/daemons/orchestrator/Orchestrator.mjs
@@ -1,5 +1,5 @@
 // Neo + core/_export + InstanceManager bootstrap belongs to the daemon entry point
-// (`ai/scripts/orchestrator-daemon.mjs`), NOT to this consumed-class file. Class files
+// (`ai/daemons/orchestrator/daemon.mjs`), NOT to this consumed-class file. Class files
 // rely on `globalThis.Neo` populated by the entry-point bootstrap; importing Neo here
 // would violate the entry-point-only invariant + risk partial-namespace damage if the
 // class were ever loaded outside its entry-point's chain.
@@ -123,47 +123,47 @@ function resolveDeploymentEnabled(key) {
 }
 
 /**
- * @summary Neo daemon class for Agent OS maintenance scheduling (#11009).
+ * @summary Neo daemon class for Agent OS maintenance scheduling.
  *
- * `ai/scripts/orchestrator-daemon.mjs` owns the Node-process boot wrapper:
- * PID file, lifecycle traps, and fatal-start isolation. This class owns the
- * actual maintenance loop, task-state persistence, subprocess execution,
- * recovery of already-running child tasks, and task outcome reporting through
+ * Schedules and runs Agent OS maintenance tasks (session summarization, KB sync,
+ * memory-core backup, primary-checkout dev-sync, dream pipeline, golden-path
+ * synthesis, swarm heartbeat) under per-task failure isolation — a thrown
+ * handover read, success hook, or task failure on one lane never stops the
+ * scheduling of any other lane.
+ *
+ * The entry-point `ai/daemons/orchestrator/daemon.mjs` owns the Node-process
+ * boot wrapper (PID file, lifecycle traps, fatal-start isolation). This class
+ * owns the maintenance loop, task-state persistence, child-process supervision,
+ * recovery of already-running child tasks, and task-outcome reporting through
  * `HealthService.recordTaskOutcome(...)`.
  *
- * Failure isolation is per task: summary scheduling and KB-sync scheduling are
- * wrapped independently so a thrown sunset-handover read or summary success hook
- * cannot stop the KB-sync lane, and a KB-sync failure cannot stop the next summary
- * sweep.
+ * All collaborators are reactive configs with sensible defaults (the imported
+ * singleton for stateless services; a class reference or `null` for the two that
+ * require lifecycle handling). Tests inject mocks via `Neo.create({collaborator: mock})`
+ * at construction or by assigning `instance.collaborator = mock` post-construct.
+ * - `cadenceEngine_` — interval cadence + due-time computation (class reference;
+ *   `beforeSet` performs polymorphic class/instance/config-object conversion +
+ *   destroys the prior instance on swap)
+ * - `processSupervisorService_` — child-process lifecycle (`beforeSet` constructs
+ *   the child from parent-sourced config; parent `afterSet*` hooks propagate
+ *   `dataDir` / `taskDefinitions` / `taskStateService` / `healthService` / `spawnFn`
+ *   mutations downstream so the child stays consistent with parent state)
+ * - `summarizationCoordinator_`, `backupCoordinator_`, `primaryRepoSyncService_`,
+ *   `dreamService_`, `swarmHeartbeatService_`, `goldenPathSynthesizer_`,
+ *   `initializeDatabaseFn_` — singleton defaults; tests override directly
  *
- * **Service-DI 4-way classification (#11833 / Epic #11831):**
- * - **(A) Class-system-managed utility collaborator** — `cadenceEngine_` reactive
- *   config with `beforeSet` + `ClassSystemUtil.beforeSetInstance` for polymorphic
- *   class/instance/config-object input and proper lifecycle on swap.
- * - **(B) Parent-configured child collaborator** — `processSupervisorService_`
- *   reactive config with `beforeSet` creation from parent-sourced config + parent
- *   `afterSet*` propagation hooks for `dataDir`/`taskDefinitions`/`taskStateService`/
- *   `healthService`/`spawnFn` so subsequent parent mutations flow to the child.
- * - **(C) Simple imported collaborator** — direct-import instance fields
- *   (`summarizationCoordinator`, `backupCoordinator`, etc.) — no class-system
- *   conversion, no parent-child propagation, no lifecycle side effect.
- * - **(D) Operator policy value** — lazy getters with the 2-value chain
- *   `Env.parseNumber(process.env.X, 'X') ?? AiConfig.orchestrator.intervals.X`
- *   for intervals + `Env.parseBool(...) ?? resolveDeploymentEnabled(...)` for booleans.
- *
- * No `configure()` shadow-resolver. No `DEFAULT_X_*_MS` constants. No
- * `parseInterval`/`parseEnabledFlag` helpers. No `processSupervisorService.set({...this...})`
- * context-replay block in `start()`.
+ * Operator policy (intervals + lane-enable booleans) is read via lazy getters that
+ * compose `Env.parseX(process.env.X, 'X') ?? AiConfig.orchestrator.X` for
+ * env-override-then-config-default precedence.
  *
  * @class Neo.ai.daemons.Orchestrator
  * @extends Neo.core.Base
  * @singleton
- * @see ai/scripts/orchestrator-daemon.mjs
- * @see ai/daemons/services/SummarizationCoordinatorService.mjs
+ * @see ai/daemons/orchestrator/daemon.mjs
+ * @see ai/daemons/orchestrator/services/SummarizationCoordinatorService.mjs
  * @see ai/services/memory-core/HealthService.mjs#recordTaskOutcome
  * @see learn/agentos/v13-path.md
  * @see #11009
- * @see #11833 (masterclass-reference refactor)
  */
 export class Orchestrator extends Base {
     static config = {
@@ -177,15 +177,11 @@ export class Orchestrator extends Base {
          * @protected
          */
         singleton: true,
-
-        // === Service-DI Class A: class-system-managed utility collaborator ===
         /**
          * @member {Neo.ai.daemons.services.CadenceEngine|Object|null} cadenceEngine_=null
          * @reactive
          */
         cadenceEngine_: null,
-
-        // === Service-DI Class B: parent-configured child collaborator + propagated parent props ===
         /**
          * @member {Neo.ai.daemons.services.ProcessSupervisorService|Object|null} processSupervisorService_=null
          * @reactive
@@ -215,19 +211,44 @@ export class Orchestrator extends Base {
          * @member {Function} spawnFn_=spawn
          * @reactive
          */
-        spawnFn_: spawn
+        spawnFn_: spawn,
+        /**
+         * @member {Object} summarizationCoordinator_=SummarizationCoordinatorService
+         * @reactive
+         */
+        summarizationCoordinator_: SummarizationCoordinatorService,
+        /**
+         * @member {Object} backupCoordinator_=BackupCoordinatorService
+         * @reactive
+         */
+        backupCoordinator_: BackupCoordinatorService,
+        /**
+         * @member {Object} primaryRepoSyncService_=PrimaryRepoSyncService
+         * @reactive
+         */
+        primaryRepoSyncService_: PrimaryRepoSyncService,
+        /**
+         * @member {Object} dreamService_=DreamService
+         * @reactive
+         */
+        dreamService_: DreamService,
+        /**
+         * @member {Object} swarmHeartbeatService_=SwarmHeartbeatService
+         * @reactive
+         */
+        swarmHeartbeatService_: SwarmHeartbeatService,
+        /**
+         * @member {Object} goldenPathSynthesizer_=GoldenPathSynthesizer
+         * @reactive
+         */
+        goldenPathSynthesizer_: GoldenPathSynthesizer,
+        /**
+         * @member {Function} initializeDatabaseFn_=initializeDatabase
+         * @reactive
+         */
+        initializeDatabaseFn_: initializeDatabase
     }
 
-    // === Service-DI Class C: simple imported collaborators (instance fields) ===
-    summarizationCoordinator = SummarizationCoordinatorService
-    backupCoordinator        = BackupCoordinatorService
-    primaryRepoSyncService   = PrimaryRepoSyncService
-    dreamService             = DreamService
-    swarmHeartbeatService    = SwarmHeartbeatService
-    goldenPathSynthesizer    = GoldenPathSynthesizer
-    initializeDatabaseFn     = initializeDatabase
-
-    // === Instance state (mutated at runtime; non-reactive) ===
     isPolling                     = false
     pollHandle                    = null
     db                            = null
@@ -247,7 +268,6 @@ export class Orchestrator extends Base {
      */
     processSupervisorWriteLog = (level, msg) => this.writeLog(level, msg)
 
-    // === Service-DI Class A: cadenceEngine beforeSet (polymorphic class/instance/config input) ===
     /**
      * @param {Neo.ai.daemons.services.CadenceEngine|Object|null} value
      * @param {Neo.ai.daemons.services.CadenceEngine|null} oldValue
@@ -258,7 +278,6 @@ export class Orchestrator extends Base {
         return ClassSystemUtil.beforeSetInstance(value, CadenceEngine, {});
     }
 
-    // === Service-DI Class B: processSupervisorService beforeSet + parent afterSet propagation ===
     /**
      * @param {Neo.ai.daemons.services.ProcessSupervisorService|Object|null} value
      * @returns {Neo.ai.daemons.services.ProcessSupervisorService}
@@ -290,7 +309,6 @@ export class Orchestrator extends Base {
         if (this.processSupervisorService) this.processSupervisorService.spawnFn = value;
     }
 
-    // === Service-DI Class D: operator policy values (lazy getters, 2-value chain) ===
     get pollIntervalMs() {
         return Env.parseNumber(process.env.NEO_ORCHESTRATOR_POLL_INTERVAL_MS, 'NEO_ORCHESTRATOR_POLL_INTERVAL_MS')
             ?? AiConfig.orchestrator.intervals.pollMs;


### PR DESCRIPTION
Authored by Claude Opus 4.7 (Claude Code). Session 5572d9a5-558d-4bea-b416-e31496c289c4.

FAIR-band: in-band [verify @ merge-gate]

Resolves #11854

## Summary

Sub 13 of Epic #11831 — reverts Sub 1's (#11833) over-engineered Service-DI classification, replaces with the canonical reactive-config-with-default pattern already used in the same file for `taskStateService_: TaskStateService` and `healthService_: HealthService`.

Self-critique: I introduced the "4-way classification" framing in Sub 1 to make singleton-alias instance fields look like architecture. The classification was the problem — there are only **2** patterns (reactive-config-with-lifecycle and reactive-config-with-default), not 4. @tobiu caught it on look-back review; the technical debt I introduced in Sub 1 obscured the substrate the entire Epic was supposed to be refactoring.

Evidence: L1 (119/119 orchestrator subsuite + 2007 pass / 0 fail / 2 skip / 13 did-not-run on full unit) → L1 required for substrate refactor (no behavior change; consumer code identical post-rewrite).

## Changes

**1. Class C field deletion + reactive-config elevation.** The 7 "Class C" instance-field aliases (`summarizationCoordinator`, `backupCoordinator`, `primaryRepoSyncService`, `dreamService`, `swarmHeartbeatService`, `goldenPathSynthesizer`, `initializeDatabaseFn`) deleted as standalone instance fields, re-declared as reactive configs in `static config` with the singleton import as default. Mirrors the existing `taskStateService_: TaskStateService` + `healthService_: HealthService` pattern.

Honest contract: tests inject mocks via `Neo.create({collab: mock})` at construction OR `instance.collab = mock` post-construct — the reactive-config slot is the legitimate test seam (NOT the "Service-DI Class C" framing I invented in Sub 1, which dressed plain instance fields up as architecture without using Neo's class system).

**2. Strip historical-context JSDoc.** Class `@summary` previously enumerated a "Service-DI 4-way classification (#11833 / Epic #11831)" with bullet definitions of (A)/(B)/(C)/(D), followed by a "No `configure()` shadow-resolver. No `DEFAULT_X_*_MS` constants. No `parseInterval`..." negative-trailer describing what prior PRs removed. Both are bloat — they describe the design *debate* not the design *intent*; git log holds the history. Replaced with intent-driven prose: what the class does, per-task failure isolation, the 2 collaborators with lifecycle vs 7 with singleton defaults.

**3. Delete 4 section divider comments.** `// === Service-DI Class A: ... ===` etc. removed. The classification framework itself was the anti-pattern; renaming "Class C → delegate field" would have preserved the same reduce-clarity surface.

**4. Stale `@see` + comment cleanup.** Removed `@see #11833 (masterclass-reference refactor)` (history-only). Fixed `(\`ai/scripts/orchestrator-daemon.mjs\`)` head comment to new post-Sub-8 path `ai/daemons/orchestrator/daemon.mjs`.

**5. Consumer code unchanged.** All 9 `this.<collaborator>.<method>(...)` call-sites preserved — they now resolve through the reactive-config getter instead of the deleted plain field. No behavior change at the call surface.

## Genuine reactive collaborators preserved

- `cadenceEngine_` — class reference; `beforeSet` performs polymorphic class/instance/config-object conversion + destroys prior instance on swap
- `processSupervisorService_` — class reference; `beforeSet` constructs the child from parent-sourced config; parent `afterSet*` hooks propagate `dataDir` / `taskDefinitions` / `taskStateService` / `healthService` / `spawnFn` mutations downstream

These keep their `beforeSet` / `afterSet` machinery — those have real lifecycle and parent-propagation reasons. Documented under their reactive-config-with-lifecycle pattern explicitly in the new JSDoc.

## Test Evidence

- Orchestrator subsuite (`test/playwright/unit/ai/daemons/orchestrator/`): **119/119 pass (5.7s)**
- **Full unit suite**: 2007 pass / 0 fail / 2 skip / 13 did-not-run

## Post-Merge Validation

- [ ] Operator restarts orchestrator → all task lanes spawn correctly (collaborator wiring unchanged at runtime)
- [ ] Integration suite passes on dev post-merge

## Deltas from ticket

- Implementation expanded beyond the original "delete the fields" prescription to "elevate them to reactive configs with singleton defaults." The original prescription was wrong — deleting the fields without a replacement test seam broke 13 tests that inject mocks via `this.<collab> = mock`. The reactive-config-with-default pattern restores test mockability while removing the anti-pattern (plain instance field NOT using Neo's class system). Same logical outcome (no plain field aliases) with a substrate-correct shape.

## Depends on

Epic #11831 Subs 8-12 (all merged).

## Unblocks

Sub 14 #11855 (centralize env-binding registry) — Sub 13 lands first to avoid Orchestrator merge conflicts on Sub 14's 14-call-site env getter rewrite.

Per @tobiu's "you and me" instruction: no peer-review broadcast on this lane.