### PR TITLE
feat(agentos): batch — extract goldenPath + harmonize summary/backup/primaryDevSync to scheduling/ (#11860 #11864)

### DIFF
--- a/ai/daemons/orchestrator/scheduling/backup.mjs
+++ b/ai/daemons/orchestrator/scheduling/backup.mjs
@@ -1,0 +1,36 @@
+/**
+ * Builds the task trigger for the backup periodic sweep. Pure function.
+ *
+ * @param {Object} options
+ * @param {Number} options.now Current timestamp in milliseconds.
+ * @param {Number} options.lastRunAt Last backup task start timestamp.
+ * @param {Number} options.intervalMs Periodic backup interval; `0` disables it.
+ * @returns {Object|null} A backup task trigger or null when no work is due.
+ */
+export function buildBackupTrigger({now, lastRunAt, intervalMs}) {
+    if (intervalMs > 0 && now - lastRunAt >= intervalMs) {
+        return {
+            taskName: 'backup',
+            source  : 'periodic-sweep',
+            reason  : `periodic-sweep:${intervalMs}`
+        };
+    }
+    return null;
+}
+
+/**
+ * Resolves the next backup task trigger.
+ *
+ * @param {Object} options
+ * @param {Object} options.state Current orchestrator task state.
+ * @param {Number} options.now Current timestamp in milliseconds.
+ * @param {Number} options.backupIntervalMs Periodic backup interval.
+ * @returns {Object|null}
+ */
+export function getDueTask({state, now, backupIntervalMs}) {
+    return buildBackupTrigger({
+        now,
+        intervalMs: backupIntervalMs,
+        lastRunAt : state.backup?.lastRunAt || 0
+    });
+}

--- a/ai/daemons/orchestrator/scheduling/goldenPath.mjs
+++ b/ai/daemons/orchestrator/scheduling/goldenPath.mjs
@@ -1,0 +1,21 @@
+/**
+ * Golden-path due-trigger projection. Returns a trigger descriptor when the
+ * configured interval has elapsed since `lastRunAt`; null otherwise. Pure function.
+ *
+ * @param {Object} options
+ * @param {Object} [options.state] Current task state for the golden-path lane (`{lastRunAt}`).
+ * @param {Number} options.now Current timestamp in milliseconds.
+ * @param {Number} options.goldenPathIntervalMs Periodic interval; `<= 0` disables.
+ * @returns {Object|null} A golden-path task trigger or null when no work is due.
+ */
+export function getDueTask({state, now, goldenPathIntervalMs}) {
+    const lastRunAt = state?.lastRunAt ?? 0;
+    if (goldenPathIntervalMs > 0 && now - lastRunAt >= goldenPathIntervalMs) {
+        return {
+            taskName: 'golden-path',
+            source  : 'periodic-golden-path',
+            reason  : `periodic-golden-path:${goldenPathIntervalMs}`
+        };
+    }
+    return null;
+}

--- a/ai/daemons/orchestrator/scheduling/primaryDevSync.mjs
+++ b/ai/daemons/orchestrator/scheduling/primaryDevSync.mjs
@@ -1,0 +1,42 @@
+import {PRIMARY_DEV_SYNC_TASK_NAME} from '../TaskDefinitions.mjs';
+
+/**
+ * Builds the trigger for the primary-checkout dev-sync lane. Pure function.
+ *
+ * @param {Object} options
+ * @param {Boolean} options.enabled Whether the lane is enabled.
+ * @param {Number} options.now Current timestamp in milliseconds.
+ * @param {Number} options.lastRunAt Last task start timestamp.
+ * @param {Number} options.intervalMs Poll interval; `0` disables it.
+ * @returns {Object|null}
+ */
+export function buildPrimaryRepoSyncTrigger({enabled, now, lastRunAt, intervalMs}) {
+    if (!enabled || intervalMs <= 0 || now - lastRunAt < intervalMs) {
+        return null;
+    }
+
+    return {
+        taskName: PRIMARY_DEV_SYNC_TASK_NAME,
+        source  : 'periodic-sweep',
+        reason  : `periodic-sweep:${intervalMs}`
+    };
+}
+
+/**
+ * Resolves the next primary-dev-sync trigger.
+ *
+ * @param {Object} options
+ * @param {Object} options.state Current orchestrator task state.
+ * @param {Number} options.now Current timestamp in milliseconds.
+ * @param {Number} options.intervalMs Poll interval.
+ * @param {Boolean} options.enabled Whether the lane is enabled.
+ * @returns {Object|null}
+ */
+export function getDueTask({state, now, intervalMs, enabled}) {
+    return buildPrimaryRepoSyncTrigger({
+        enabled,
+        now,
+        intervalMs,
+        lastRunAt: state[PRIMARY_DEV_SYNC_TASK_NAME]?.lastRunAt || 0
+    });
+}

--- a/ai/daemons/orchestrator/scheduling/summary.mjs
+++ b/ai/daemons/orchestrator/scheduling/summary.mjs
@@ -1,0 +1,89 @@
+import {
+    getUnreadSunsetHandovers,
+    markNodesAsRead
+} from '../../bridge/queries.mjs';
+
+/**
+ * Builds the task trigger for the summarization sweep lane.
+ *
+ * Two wake-up sources, in priority order:
+ * 1. Unread sunset handovers — priority because they unblock the next agent boot
+ * 2. Periodic sweep — fallback for ordinary unsummarized sessions
+ *
+ * Pure function. Test the scheduling contract without mounting the SQLite graph.
+ *
+ * @param {Object} options
+ * @param {Number} options.now Current timestamp in milliseconds.
+ * @param {Number} options.lastRunAt Last summary task start timestamp.
+ * @param {Number} options.intervalMs Periodic sweep interval; `0` disables the interval source.
+ * @param {Object[]} [options.handovers=[]] Unread sunset-handover message nodes.
+ * @returns {Object|null} A summary task trigger or null when no work is due.
+ */
+export function buildSummaryTrigger({now, lastRunAt, intervalMs, handovers = []}) {
+    if (handovers.length > 0) {
+        return {
+            taskName     : 'summary',
+            source       : 'sunset-handover',
+            reason       : `sunset-handover:${handovers.length}`,
+            handoverCount: handovers.length
+        };
+    }
+
+    if (intervalMs > 0 && now - lastRunAt >= intervalMs) {
+        return {
+            taskName: 'summary',
+            source  : 'periodic-sweep',
+            reason  : `periodic-sweep:${intervalMs}`
+        };
+    }
+
+    return null;
+}
+
+/**
+ * Resolves the next summary task trigger, including the post-success handover mark-read hook
+ * when the trigger source is sunset-handover.
+ *
+ * @param {Object} options
+ * @param {Object} options.db SQLite database handle.
+ * @param {Object} options.state Current orchestrator task state.
+ * @param {Number} options.now Current timestamp in milliseconds.
+ * @param {Number} options.summarySweepIntervalMs Periodic summary sweep interval.
+ * @param {Function} [options.getUnreadSunsetHandoversFn] Test seam for handover reads.
+ * @param {Function} [options.markNodesAsReadFn] Test seam for handover mark-read writes.
+ * @param {Function} [options.log] Optional orchestrator log function.
+ * @returns {Object|null} Task trigger with optional `onSuccess` callback, or null.
+ */
+export function getDueTask({
+    db,
+    state,
+    now,
+    summarySweepIntervalMs,
+    getUnreadSunsetHandoversFn = getUnreadSunsetHandovers,
+    markNodesAsReadFn          = markNodesAsRead,
+    log
+}) {
+    const handovers = getUnreadSunsetHandoversFn(db);
+    const trigger   = buildSummaryTrigger({
+        now,
+        handovers,
+        intervalMs: summarySweepIntervalMs,
+        lastRunAt : state.summary?.lastRunAt || 0
+    });
+
+    if (!trigger) {
+        return null;
+    }
+
+    if (trigger.source === 'sunset-handover') {
+        return {
+            ...trigger,
+            onSuccess: () => {
+                markNodesAsReadFn(db, handovers);
+                log?.('INFO', `[Orchestrator] Marked ${handovers.length} sunset handovers as read.`);
+            }
+        };
+    }
+
+    return trigger;
+}

--- a/test/playwright/unit/ai/daemons/orchestrator/scheduling/backup.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/scheduling/backup.spec.mjs
@@ -1,0 +1,43 @@
+import {test, expect} from '@playwright/test';
+import {
+    buildBackupTrigger,
+    getDueTask
+} from '../../../../../../../ai/daemons/orchestrator/scheduling/backup.mjs';
+
+test.describe('orchestrator/scheduling/backup (#11864 / Epic #11831)', () => {
+    test('buildBackupTrigger fires when the interval has elapsed', () => {
+        expect(buildBackupTrigger({now: 86400000, lastRunAt: 0, intervalMs: 86400000})).toEqual({
+            taskName: 'backup',
+            source  : 'periodic-sweep',
+            reason  : 'periodic-sweep:86400000'
+        });
+    });
+
+    test('buildBackupTrigger returns null when the interval has not elapsed', () => {
+        expect(buildBackupTrigger({now: 86399999, lastRunAt: 0, intervalMs: 86400000})).toBeNull();
+    });
+
+    test('buildBackupTrigger treats intervalMs <= 0 as disabled', () => {
+        expect(buildBackupTrigger({now: 999999999, lastRunAt: 0, intervalMs: 0})).toBeNull();
+    });
+
+    test('getDueTask wraps buildBackupTrigger with state mapping', () => {
+        expect(getDueTask({
+            state           : {backup: {lastRunAt: 1000}},
+            now             : 1000 + 86400000,
+            backupIntervalMs: 86400000
+        })).toEqual({
+            taskName: 'backup',
+            source  : 'periodic-sweep',
+            reason  : 'periodic-sweep:86400000'
+        });
+    });
+
+    test('getDueTask handles missing state.backup gracefully (lastRunAt defaults to 0)', () => {
+        expect(getDueTask({state: {}, now: 86400000, backupIntervalMs: 86400000})).toEqual({
+            taskName: 'backup',
+            source  : 'periodic-sweep',
+            reason  : 'periodic-sweep:86400000'
+        });
+    });
+});

--- a/test/playwright/unit/ai/daemons/orchestrator/scheduling/goldenPath.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/scheduling/goldenPath.spec.mjs
@@ -1,0 +1,39 @@
+import {test, expect} from '@playwright/test';
+import {
+    getDueTask
+} from '../../../../../../../ai/daemons/orchestrator/scheduling/goldenPath.mjs';
+
+test.describe('orchestrator/scheduling/goldenPath (#11860 / Epic #11831)', () => {
+    test('returns a periodic-golden-path trigger when the interval has elapsed', () => {
+        expect(getDueTask({
+            state               : {lastRunAt: 0},
+            now                 : 1800000,
+            goldenPathIntervalMs: 1800000
+        })).toEqual({
+            taskName: 'golden-path',
+            source  : 'periodic-golden-path',
+            reason  : 'periodic-golden-path:1800000'
+        });
+    });
+
+    test('returns null when the interval has not yet elapsed', () => {
+        expect(getDueTask({
+            state               : {lastRunAt: 0},
+            now                 : 1799999,
+            goldenPathIntervalMs: 1800000
+        })).toBeNull();
+    });
+
+    test('treats intervalMs <= 0 as disabled', () => {
+        expect(getDueTask({state: {lastRunAt: 0}, now: 999999999, goldenPathIntervalMs: 0})).toBeNull();
+        expect(getDueTask({state: {lastRunAt: 0}, now: 999999999, goldenPathIntervalMs: -1})).toBeNull();
+    });
+
+    test('handles missing state gracefully (lastRunAt defaults to 0)', () => {
+        expect(getDueTask({state: undefined, now: 1800000, goldenPathIntervalMs: 1800000})).toEqual({
+            taskName: 'golden-path',
+            source  : 'periodic-golden-path',
+            reason  : 'periodic-golden-path:1800000'
+        });
+    });
+});

--- a/test/playwright/unit/ai/daemons/orchestrator/scheduling/primaryDevSync.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/scheduling/primaryDevSync.spec.mjs
@@ -1,0 +1,50 @@
+import {test, expect} from '@playwright/test';
+import {
+    buildPrimaryRepoSyncTrigger,
+    getDueTask
+} from '../../../../../../../ai/daemons/orchestrator/scheduling/primaryDevSync.mjs';
+import {PRIMARY_DEV_SYNC_TASK_NAME} from '../../../../../../../ai/daemons/orchestrator/TaskDefinitions.mjs';
+
+test.describe('orchestrator/scheduling/primaryDevSync (#11864 / Epic #11831)', () => {
+    test('buildPrimaryRepoSyncTrigger fires when enabled + interval elapsed', () => {
+        expect(buildPrimaryRepoSyncTrigger({enabled: true, now: 60000, lastRunAt: 0, intervalMs: 60000})).toEqual({
+            taskName: PRIMARY_DEV_SYNC_TASK_NAME,
+            source  : 'periodic-sweep',
+            reason  : 'periodic-sweep:60000'
+        });
+    });
+
+    test('buildPrimaryRepoSyncTrigger returns null when disabled', () => {
+        expect(buildPrimaryRepoSyncTrigger({enabled: false, now: 999999999, lastRunAt: 0, intervalMs: 60000})).toBeNull();
+    });
+
+    test('buildPrimaryRepoSyncTrigger returns null when interval has not elapsed', () => {
+        expect(buildPrimaryRepoSyncTrigger({enabled: true, now: 59999, lastRunAt: 0, intervalMs: 60000})).toBeNull();
+    });
+
+    test('buildPrimaryRepoSyncTrigger treats intervalMs <= 0 as disabled', () => {
+        expect(buildPrimaryRepoSyncTrigger({enabled: true, now: 999999999, lastRunAt: 0, intervalMs: 0})).toBeNull();
+    });
+
+    test('getDueTask wraps buildPrimaryRepoSyncTrigger with state mapping (keyed by PRIMARY_DEV_SYNC_TASK_NAME)', () => {
+        expect(getDueTask({
+            state     : {[PRIMARY_DEV_SYNC_TASK_NAME]: {lastRunAt: 1000}},
+            now       : 1000 + 60000,
+            intervalMs: 60000,
+            enabled   : true
+        })).toEqual({
+            taskName: PRIMARY_DEV_SYNC_TASK_NAME,
+            source  : 'periodic-sweep',
+            reason  : 'periodic-sweep:60000'
+        });
+    });
+
+    test('getDueTask returns null when not enabled', () => {
+        expect(getDueTask({
+            state     : {[PRIMARY_DEV_SYNC_TASK_NAME]: {lastRunAt: 0}},
+            now       : 60000,
+            intervalMs: 60000,
+            enabled   : false
+        })).toBeNull();
+    });
+});

--- a/test/playwright/unit/ai/daemons/orchestrator/scheduling/summary.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/scheduling/summary.spec.mjs
@@ -1,0 +1,82 @@
+import {test, expect} from '@playwright/test';
+import {
+    buildSummaryTrigger,
+    getDueTask
+} from '../../../../../../../ai/daemons/orchestrator/scheduling/summary.mjs';
+
+test.describe('orchestrator/scheduling/summary (#11864 / Epic #11831)', () => {
+    test('buildSummaryTrigger prioritizes unread sunset handovers over the periodic sweep', () => {
+        expect(buildSummaryTrigger({
+            now       : 1200000,
+            lastRunAt : 0,
+            intervalMs: 600000,
+            handovers : [{id: 'MESSAGE:1'}, {id: 'MESSAGE:2'}]
+        })).toEqual({
+            taskName     : 'summary',
+            source       : 'sunset-handover',
+            reason       : 'sunset-handover:2',
+            handoverCount: 2
+        });
+    });
+
+    test('buildSummaryTrigger returns a periodic sweep trigger only when the interval is due', () => {
+        expect(buildSummaryTrigger({now: 599999, lastRunAt: 0, intervalMs: 600000, handovers: []})).toBeNull();
+
+        expect(buildSummaryTrigger({now: 600000, lastRunAt: 0, intervalMs: 600000, handovers: []})).toEqual({
+            taskName: 'summary',
+            source  : 'periodic-sweep',
+            reason  : 'periodic-sweep:600000'
+        });
+    });
+
+    test('buildSummaryTrigger does not schedule disabled periodic sweeps', () => {
+        expect(buildSummaryTrigger({now: 600000, lastRunAt: 0, intervalMs: 0, handovers: []})).toBeNull();
+    });
+
+    test('getDueTask returns null when no handovers and interval not elapsed', () => {
+        const result = getDueTask({
+            db                        : 'mock-db',
+            state                     : {summary: {lastRunAt: 0}},
+            now                       : 100,
+            summarySweepIntervalMs    : 600000,
+            getUnreadSunsetHandoversFn: () => []
+        });
+        expect(result).toBeNull();
+    });
+
+    test('getDueTask returns periodic-sweep trigger (no onSuccess) when interval elapsed', () => {
+        const result = getDueTask({
+            db                        : 'mock-db',
+            state                     : {summary: {lastRunAt: 0}},
+            now                       : 600000,
+            summarySweepIntervalMs    : 600000,
+            getUnreadSunsetHandoversFn: () => []
+        });
+        expect(result).toEqual({
+            taskName: 'summary',
+            source  : 'periodic-sweep',
+            reason  : 'periodic-sweep:600000'
+        });
+        expect(result.onSuccess).toBeUndefined();
+    });
+
+    test('getDueTask returns sunset-handover trigger with onSuccess callback', () => {
+        const markCalls = [];
+        const handovers = [{id: 'MESSAGE:1'}, {id: 'MESSAGE:2'}];
+        const result = getDueTask({
+            db                        : 'mock-db',
+            state                     : {summary: {lastRunAt: 0}},
+            now                       : 100,
+            summarySweepIntervalMs    : 600000,
+            getUnreadSunsetHandoversFn: () => handovers,
+            markNodesAsReadFn         : (db, nodes) => markCalls.push({db, nodes}),
+            log                       : () => {}
+        });
+        expect(result.source).toBe('sunset-handover');
+        expect(result.handoverCount).toBe(2);
+        expect(typeof result.onSuccess).toBe('function');
+
+        result.onSuccess();
+        expect(markCalls).toEqual([{db: 'mock-db', nodes: handovers}]);
+    });
+});


### PR DESCRIPTION
Authored by Claude Opus 4.7 (Claude Code). Session 5572d9a5-558d-4bea-b416-e31496c289c4.

FAIR-band: in-band [verify @ merge-gate]

Resolves #11860 (Sub 17)
Partial #11864 (Sub 20 — additive half; destructive half folds into Sub 18 #11862)

## Summary

Combined PR per @tobiu's CI-efficiency framing on PR #11865: 1-sub-per-PR is right for risky work, pure CI tax for near-identical mechanical extractions. 4 new `scheduling/<task>.mjs` pure-function modules + their specs land in one CI round instead of four (4×7min integration = 28min saved).

**Additive only.** Does NOT touch Orchestrator, does NOT delete the old class files, does NOT modify `PrimaryRepoSyncService`. The wire-up shift (Orchestrator imports + call sites + old-class deletions + PrimaryRepoSync trim) is Sub 18 #11862's atomic scope (registry + collectDueCandidates + pickNextCandidate + CadenceEngine correction). Keeping this PR additive reduces risk + matches Sub 18's planned wire-up scope.

Evidence: L1 (29/29 specs pass across all 6 scheduling/ files — 4 new + 2 from Subs 15/16) → L1 required for pure-function extraction (no behavioral change at orchestrator surface; new files not wired in this PR).

## New files (4 source + 4 spec)

- `ai/daemons/orchestrator/scheduling/goldenPath.mjs` (Sub 17 — pure interval projection)
- `ai/daemons/orchestrator/scheduling/summary.mjs` (Sub 20 — `buildSummaryTrigger` + `getDueTask` with sunset-handover priority + `onSuccess` hook for mark-read)
- `ai/daemons/orchestrator/scheduling/backup.mjs` (Sub 20 — `buildBackupTrigger` + `getDueTask`)
- `ai/daemons/orchestrator/scheduling/primaryDevSync.mjs` (Sub 20 — `buildPrimaryRepoSyncTrigger` + `getDueTask` with enabled-gate)

## Sub-15 / Sub-16 KISS lessons applied from the start

- Pure functions (no class extends Base, no singleton: true, no `Neo.setupClass`, no `Neo.gatekeep`)
- One JSDoc block per function (no file-level + function-level split)
- No decay-prone references (no `v13-path.md:N`, no section labels like `D3.1`, no neighboring-file method names)
- Specs don't import Neo bootstrap (no module-load gatekeep call requiring `globalThis.Neo`)

## Earned vs not-earned `buildTrigger` separate exports

`summary.mjs` IS the one earning the `buildTrigger` + `getDueTask` split — `getDueTask` does meaningful extra work (calls `getUnreadSunsetHandoversFn(db)` + attaches `onSuccess` mark-read closure). `backup.mjs` + `primaryDevSync.mjs` follow the same shape for consistency + to keep the test-seam pattern (overridable `getUnreadSunsetHandoversFn` / `markNodesAsReadFn`). `goldenPath.mjs` has only `getDueTask` (no extra work to warrant the split — matches `dream.mjs` precedent).

## Test Evidence

`npm run test-unit -- test/playwright/unit/ai/daemons/orchestrator/scheduling/` → **29/29 pass (691ms)**

Per-file:
- `dream.spec.mjs` (existing from Sub 15) — 4 tests
- `swarmHeartbeat.spec.mjs` (existing from Sub 16) — 4 tests
- `goldenPath.spec.mjs` (new) — 4 tests (interval-elapsed / not-elapsed / disabled / missing-state)
- `summary.spec.mjs` (new) — 6 tests (handover priority / periodic-sweep / disabled / getDueTask wrap / sunset-handover with onSuccess)
- `backup.spec.mjs` (new) — 5 tests (buildTrigger boundaries + getDueTask state mapping)
- `primaryDevSync.spec.mjs` (new) — 6 tests (enabled gate + interval / state mapping by PRIMARY_DEV_SYNC_TASK_NAME)

## Sub 18 #11862 scope expanded to include the destructive half

Sub 18 (Round-2 closer) now also owns:
- Delete `services/SummarizationCoordinatorService.mjs` + `services/BackupCoordinatorService.mjs`
- Trim `services/PrimaryRepoSyncService.mjs` (remove `buildPrimaryRepoSyncTrigger` + `getDueTask` method; keep `runTask` + sync logic + class — the 803-LOC service has earned its Service shape via substantive `runTask` state/I/O)
- Update Orchestrator imports + call sites to consume `scheduling/<task>.mjs` directly
- Remove now-stale `this.summarizationCoordinator` + `this.backupCoordinator` instance fields

## Post-Merge Validation

- [ ] No behavioral change observable in orchestrator boot or scheduling (additive only; new files not wired)
- [ ] Sub 18 #11862 cleanly imports the new files post-merge

## Deltas from tickets

- Sub 20 #11864 originally planned to do BOTH the additive (new scheduling/ files) AND destructive (delete old + Orchestrator update) work in one PR. Splitting: this PR does additive; Sub 18 absorbs destructive. Atomic risk surface per sub.
- File location uses `scheduling/<task>.mjs` (no `Service`/`Coordinator` suffix) per @tobiu's KISS feedback on PR #11863. Sub 17 / Sub 20 ticket titles still use `...CoordinatorService` naming — title naming churn deferred.

## Depends on

Epic #11831 (parent). Sub 15 #11858 + Sub 16 #11859 merged (established the scheduling/ pattern).

## Unblocks

Sub 18 #11862 atomic wire-up.

## Authority

Discussion #11857 Cycle-3.5 GPT `[GRADUATION_APPROVED]` + operator architectural ratify + operator KISS feedback chain on PRs #11863 and #11865.

Per @tobiu's "you and me" instruction for Epic #11831 lane: no peer-review broadcast.