### PR TITLE
feat(agentos): extract MaintenanceBackpressureService — predicates + deferral recording + lease/dependency executor wrappers (#11861)

### DIFF
--- a/ai/daemons/orchestrator/Orchestrator.mjs
+++ b/ai/daemons/orchestrator/Orchestrator.mjs
@@ -20,6 +20,10 @@ import {
     acquireHeavyMaintenanceLeaseSync,
     releaseHeavyMaintenanceLeaseSync
 } from './services/HeavyMaintenanceLeaseService.mjs';
+import {
+    DEFAULT_HEAVY_MAINTENANCE_TASK_NAMES,
+    DEFAULT_GOLDEN_PATH_DEPENDENCY_TASK_NAMES
+} from './services/MaintenanceBackpressureService.mjs';
 import PrimaryRepoSyncService, {
     DEV_SYNC_ROOTS_CONFIG_KEY,
     DEV_SYNC_ROOTS_ENV_VAR
@@ -40,40 +44,6 @@ import {
     DEFAULT_SCRIPT_DIR,
     buildTaskDefinitions
 } from './TaskDefinitions.mjs';
-
-/**
- * Canonical set of heavy-maintenance task names that participate in the orchestrator's
- * cross-poll backpressure invariant: at any time, across orchestrator-owned tasks AND
- * lease-aware manual scripts (see `HeavyMaintenanceLeaseService` + Lane C wrappers in
- * `ai/scripts/maintenance/*.mjs`), at most one substrate-heavy maintenance job may hold the
- * heavy-maintenance lease.
- *
- * Membership rationale per #11503:
- * - `summary` / `kbSync` / `dream` — Memory Core graph + Chroma write-heavy
- * - `backup` — exports KB Chroma + Memory Core Chroma + SQLite graph state; substrate-heavy
- *   even though it doesn't mutate, because concurrent IO with other heavy classes is the
- *   contention surface (added by #11513 — Lane A of #11503)
- * - `PRIMARY_DEV_SYNC_TASK_NAME` — git fetch + nested KB sync cascade
- *
- * Intentionally NOT in the heavy set:
- * - `GOLDEN_PATH_TASK_NAME` — classified as light maintenance per #11511 / PR #11512
- *   (synthesizer reads the graph; does not write the heavy substrates)
- *
- * Cross-poll deferral coverage lives in `test/playwright/unit/ai/daemons/Orchestrator.spec.mjs`.
- *
- * @type {ReadonlyArray<String>}
- */
-export const DEFAULT_HEAVY_MAINTENANCE_TASK_NAMES = Object.freeze([
-    'summary',
-    'kbSync',
-    'backup',
-    PRIMARY_DEV_SYNC_TASK_NAME,
-    DREAM_TASK_NAME
-]);
-
-export const DEFAULT_GOLDEN_PATH_DEPENDENCY_TASK_NAMES = Object.freeze([
-    DREAM_TASK_NAME
-]);
 
 /**
  * Resolves the dev-sync roots config while preserving env-var precedence.

--- a/ai/daemons/orchestrator/services/MaintenanceBackpressureService.mjs
+++ b/ai/daemons/orchestrator/services/MaintenanceBackpressureService.mjs
@@ -1,0 +1,549 @@
+import path from 'path';
+import Neo  from '../../../../src/Neo.mjs';
+import Base from '../../../../src/core/Base.mjs';
+import {
+    acquireHeavyMaintenanceLeaseSync,
+    releaseHeavyMaintenanceLeaseSync
+} from './HeavyMaintenanceLeaseService.mjs';
+import {
+    DREAM_TASK_NAME,
+    GOLDEN_PATH_TASK_NAME,
+    PRIMARY_DEV_SYNC_TASK_NAME,
+    DEFAULT_DATA_DIR
+} from '../TaskDefinitions.mjs';
+
+/**
+ * Canonical set of heavy-maintenance task names that participate in the cross-poll
+ * backpressure invariant: across orchestrator-owned tasks AND lease-aware manual scripts
+ * (`ai/scripts/maintenance/*.mjs`), at most one substrate-heavy maintenance job may hold
+ * the heavy-maintenance lease at a time.
+ *
+ * @type {ReadonlyArray<String>}
+ */
+export const DEFAULT_HEAVY_MAINTENANCE_TASK_NAMES = Object.freeze([
+    'summary',
+    'kbSync',
+    'backup',
+    PRIMARY_DEV_SYNC_TASK_NAME,
+    DREAM_TASK_NAME
+]);
+
+/**
+ * Tasks whose graph writes must complete before Golden Path frontier refresh runs.
+ *
+ * @type {ReadonlyArray<String>}
+ */
+export const DEFAULT_GOLDEN_PATH_DEPENDENCY_TASK_NAMES = Object.freeze([
+    DREAM_TASK_NAME
+]);
+
+// ============================================================================
+// Group 1 — Read-only predicates / finders (pure functions, no side effects)
+// ============================================================================
+
+/**
+ * @summary Checks whether a task participates in cross-task maintenance backpressure.
+ *
+ * @param {Object} options
+ * @param {String} options.taskName Stable orchestrator task name.
+ * @param {ReadonlyArray<String>} options.heavyMaintenanceTaskNames Heavy-classification set.
+ * @returns {Boolean}
+ */
+export function isHeavyMaintenanceTask({taskName, heavyMaintenanceTaskNames}) {
+    return heavyMaintenanceTaskNames.includes(taskName);
+}
+
+/**
+ * @summary Checks whether a task's graph writes block Golden Path frontier refresh.
+ *
+ * @param {Object} options
+ * @param {String} options.taskName Stable orchestrator task name.
+ * @param {ReadonlyArray<String>} options.goldenPathDependencyTaskNames Dependency set.
+ * @returns {Boolean}
+ */
+export function isGoldenPathDependencyTask({taskName, goldenPathDependencyTaskNames}) {
+    return goldenPathDependencyTaskNames.includes(taskName);
+}
+
+/**
+ * @summary Finds the first running heavy-maintenance task other than the excluded one.
+ *
+ * @param {Object} options
+ * @param {ReadonlyArray<String>} options.heavyMaintenanceTaskNames Heavy-classification set.
+ * @param {Object} options.taskStateService Service exposing `getTaskState(name)`.
+ * @param {String|null} [options.excludeTaskName=null] Task name to ignore.
+ * @returns {String|null}
+ */
+export function getActiveHeavyMaintenanceTask({
+    heavyMaintenanceTaskNames,
+    taskStateService,
+    excludeTaskName = null
+}) {
+    for (const taskName of heavyMaintenanceTaskNames) {
+        if (taskName === excludeTaskName) continue;
+        if (taskStateService.getTaskState(taskName)?.running) return taskName;
+    }
+    return null;
+}
+
+/**
+ * @summary Finds a running task that would make Golden Path read a partial graph state.
+ *
+ * @param {Object} options
+ * @param {ReadonlyArray<String>} options.goldenPathDependencyTaskNames Dependency set.
+ * @param {Object} options.taskStateService Service exposing `getTaskState(name)`.
+ * @param {String|null} [options.activeTaskName=null] Newly started task in the current poll.
+ * @returns {String|null}
+ */
+export function getActiveGoldenPathDependencyTask({
+    goldenPathDependencyTaskNames,
+    taskStateService,
+    activeTaskName = null
+}) {
+    if (activeTaskName && goldenPathDependencyTaskNames.includes(activeTaskName)) {
+        return activeTaskName;
+    }
+    for (const taskName of goldenPathDependencyTaskNames) {
+        if (taskStateService.getTaskState(taskName)?.running) return taskName;
+    }
+    return null;
+}
+
+/**
+ * @summary Resolves the shared heavy-maintenance lease file path with multi-tier fallback.
+ *
+ * Defensive at use-site rather than configure-time so direct-poll callers (unit tests
+ * bypassing `start()`) inherit a `dataDir`-scoped path instead of accidentally writing
+ * to the canonical production lease.
+ *
+ * @param {Object} options
+ * @param {String|null|undefined} options.heavyMaintenanceLeasePath Explicit override.
+ * @param {String|null|undefined} options.dataDir Daemon data directory.
+ * @returns {String}
+ */
+export function resolveHeavyMaintenanceLeasePath({heavyMaintenanceLeasePath, dataDir}) {
+    if (heavyMaintenanceLeasePath) return heavyMaintenanceLeasePath;
+    return path.join(dataDir || DEFAULT_DATA_DIR, 'heavy-maintenance-lease.json');
+}
+
+// ============================================================================
+// Group 2 — Deferral recording (pure functions; mutate caller-owned dedup Set)
+// ============================================================================
+
+/**
+ * @summary Clears all dedupe keys for a task once it is no longer deferred.
+ *
+ * @param {Object} options
+ * @param {Set<String>} options.deferralLogKeys Caller-owned dedup Set.
+ * @param {String} options.taskName Stable orchestrator task name.
+ * @returns {void}
+ */
+export function clearDeferralLogState({deferralLogKeys, taskName}) {
+    if (!deferralLogKeys) return;
+    const prefix = `${taskName}:`;
+    for (const key of deferralLogKeys) {
+        if (key.startsWith(prefix)) deferralLogKeys.delete(key);
+    }
+}
+
+/**
+ * @summary Records a sparse non-error deferral, polymorphic on `reasonCode`.
+ *
+ * Three reason classes share one entry point so operator dashboards + Memory Core graph
+ * ingestion can route deferrals via a single shape with a discriminator field. Dedup
+ * keys are constructed per-class so equivalent recurring deferrals collapse to one log
+ * line, while distinct blocker/owner combinations remain separately tracked.
+ *
+ * | `reasonCode`                            | Blocker source            | Used by                    |
+ * |-----------------------------------------|---------------------------|----------------------------|
+ * | `'heavy-maintenance-backpressure'`      | `blockingTaskName`        | Intra-process heavy tasks  |
+ * | `'heavy-maintenance-lease-held'`        | `holdingLease.owner`      | Inter-process file lease   |
+ * | `'golden-path-dependency-backpressure'` | `blockingTaskName`        | Golden Path graph waits    |
+ *
+ * @param {Object} options
+ * @param {Set<String>} options.deferralLogKeys Caller-owned dedup Set.
+ * @param {String} options.taskName Deferred task name.
+ * @param {String} options.reasonCode Discriminator field.
+ * @param {String} options.reasonText Scheduling reason for the deferred task.
+ * @param {String|null} [options.blockingTaskName=null] Active blocker (intra-process / golden-path).
+ * @param {Object|null} [options.holdingLease=null] Active lease payload (cross-daemon only).
+ * @param {Object} [options.taskDefinitions={}] Task-definition map for label resolution.
+ * @param {Function} [options.writeLog=()=>{}] Logger function `(level, message) => void`.
+ * @param {Object|null} [options.healthService=null] Optional `recordTaskOutcome(name, status, payload)` sink.
+ * @returns {void}
+ */
+export function recordDeferral({
+    deferralLogKeys,
+    taskName,
+    reasonCode,
+    reasonText,
+    blockingTaskName = null,
+    holdingLease     = null,
+    taskDefinitions  = {},
+    writeLog         = () => {},
+    healthService    = null
+}) {
+    const isLeaseHeld = reasonCode === 'heavy-maintenance-lease-held';
+    const holderOwner = holdingLease?.owner || 'unknown';
+    const dedupKey    = isLeaseHeld
+        ? `${taskName}:lease-held-by-${holderOwner}:${reasonText}`
+        : `${taskName}:${blockingTaskName}:${reasonText}`;
+
+    if (!deferralLogKeys.has(dedupKey)) {
+        const taskLabel = taskDefinitions?.[taskName]?.label || taskName;
+
+        if (isLeaseHeld) {
+            writeLog('INFO', `[Orchestrator] Deferring ${taskLabel}; cross-daemon heavy-maintenance lease held by ${holderOwner} (${reasonText}).`);
+        } else {
+            const blockingLabel = taskDefinitions?.[blockingTaskName]?.label || blockingTaskName;
+            writeLog('INFO', `[Orchestrator] Deferring ${taskLabel}; ${reasonCode === 'golden-path-dependency-backpressure' ? 'dependency task' : 'heavy maintenance task'} ${blockingLabel} is active (${reasonText}).`);
+        }
+
+        deferralLogKeys.add(dedupKey);
+    }
+
+    const outcomePayload = {
+        reason    : reasonText,
+        reasonCode,
+        deferredAt: new Date().toISOString()
+    };
+    if (isLeaseHeld) {
+        outcomePayload.holdingOwner = holderOwner;
+        outcomePayload.holdingPid   = holdingLease?.pid;
+    } else {
+        outcomePayload.blockingTaskName = blockingTaskName;
+    }
+
+    healthService?.recordTaskOutcome?.(taskName, 'skipped', outcomePayload);
+}
+
+// ============================================================================
+// Group 3 — Executor wrappers (Neo-class methods; orchestrate state + leases)
+// ============================================================================
+
+/**
+ * @summary Cross-task maintenance backpressure + cross-daemon lease coordination.
+ *
+ * Owns the orchestrator's execution-phase policy surface: heavy/dependency classification
+ * predicates, deferral recording, lease acquisition + release wrapping, and Golden Path
+ * dependency gating. The Orchestrator delegates these concerns here so its scheduling
+ * loop can be a generic registry-driven dispatch.
+ *
+ * The service WRAPS the existing `HeavyMaintenanceLeaseService` primitives — it does not
+ * replace them. Lease IO (acquire / release / inspect) remains in that service; this
+ * service owns the policy of WHEN to acquire, defer, or record.
+ *
+ * @class Neo.ai.daemons.orchestrator.services.MaintenanceBackpressureService
+ * @extends Neo.core.Base
+ * @singleton
+ */
+export class MaintenanceBackpressureService extends Base {
+    static config = {
+        /**
+         * @member {String} className='Neo.ai.daemons.orchestrator.services.MaintenanceBackpressureService'
+         * @protected
+         */
+        className: 'Neo.ai.daemons.orchestrator.services.MaintenanceBackpressureService',
+        /**
+         * @member {Boolean} singleton=true
+         * @protected
+         */
+        singleton: true,
+        /**
+         * @member {ReadonlyArray<String>} heavyMaintenanceTaskNames_=DEFAULT_HEAVY_MAINTENANCE_TASK_NAMES
+         * @reactive
+         */
+        heavyMaintenanceTaskNames_: DEFAULT_HEAVY_MAINTENANCE_TASK_NAMES,
+        /**
+         * @member {ReadonlyArray<String>} goldenPathDependencyTaskNames_=DEFAULT_GOLDEN_PATH_DEPENDENCY_TASK_NAMES
+         * @reactive
+         */
+        goldenPathDependencyTaskNames_: DEFAULT_GOLDEN_PATH_DEPENDENCY_TASK_NAMES,
+        /**
+         * @member {String|null} heavyMaintenanceLeasePath_=null
+         * @reactive
+         */
+        heavyMaintenanceLeasePath_: null,
+        /**
+         * @member {String} dataDir_=DEFAULT_DATA_DIR
+         * @reactive
+         */
+        dataDir_: DEFAULT_DATA_DIR,
+        /**
+         * @member {Object|null} taskStateService_=null
+         * @reactive
+         */
+        taskStateService_: null,
+        /**
+         * @member {Object|null} healthService_=null
+         * @reactive
+         */
+        healthService_: null,
+        /**
+         * @member {Object|null} taskDefinitions_=null
+         * @reactive
+         */
+        taskDefinitions_: null,
+        /**
+         * @member {Function} writeLog_=()=>{}
+         * @reactive
+         */
+        writeLog_: () => {},
+        /**
+         * @member {Function} acquireLeaseFn_=acquireHeavyMaintenanceLeaseSync
+         * @reactive
+         */
+        acquireLeaseFn_: acquireHeavyMaintenanceLeaseSync,
+        /**
+         * @member {Function} releaseLeaseFn_=releaseHeavyMaintenanceLeaseSync
+         * @reactive
+         */
+        releaseLeaseFn_: releaseHeavyMaintenanceLeaseSync
+    }
+
+    /**
+     * Per-instance dedup Set for sparse deferral logging.
+     * @member {Set<String>} deferralLogKeys
+     */
+    deferralLogKeys = new Set()
+
+    // --- Predicate / finder delegations to module-level pure functions ---
+
+    /**
+     * @param {String} taskName Stable orchestrator task name.
+     * @returns {Boolean}
+     */
+    isHeavyMaintenanceTask(taskName) {
+        return isHeavyMaintenanceTask({taskName, heavyMaintenanceTaskNames: this.heavyMaintenanceTaskNames});
+    }
+
+    /**
+     * @param {String} taskName Stable orchestrator task name.
+     * @returns {Boolean}
+     */
+    isGoldenPathDependencyTask(taskName) {
+        return isGoldenPathDependencyTask({taskName, goldenPathDependencyTaskNames: this.goldenPathDependencyTaskNames});
+    }
+
+    /**
+     * @param {Object} [options]
+     * @param {String|null} [options.excludeTaskName=null]
+     * @returns {String|null}
+     */
+    getActiveHeavyMaintenanceTask({excludeTaskName = null} = {}) {
+        return getActiveHeavyMaintenanceTask({
+            heavyMaintenanceTaskNames: this.heavyMaintenanceTaskNames,
+            taskStateService         : this.taskStateService,
+            excludeTaskName
+        });
+    }
+
+    /**
+     * @param {Object} [options]
+     * @param {String|null} [options.activeTaskName=null]
+     * @returns {String|null}
+     */
+    getActiveGoldenPathDependencyTask({activeTaskName = null} = {}) {
+        return getActiveGoldenPathDependencyTask({
+            goldenPathDependencyTaskNames: this.goldenPathDependencyTaskNames,
+            taskStateService             : this.taskStateService,
+            activeTaskName
+        });
+    }
+
+    /**
+     * @returns {String}
+     */
+    resolveHeavyMaintenanceLeasePath() {
+        return resolveHeavyMaintenanceLeasePath({
+            heavyMaintenanceLeasePath: this.heavyMaintenanceLeasePath,
+            dataDir                  : this.dataDir
+        });
+    }
+
+    // --- Deferral recording delegations ---
+
+    /**
+     * @param {String} taskName Stable orchestrator task name.
+     * @returns {void}
+     */
+    clearDeferralLogState(taskName) {
+        clearDeferralLogState({deferralLogKeys: this.deferralLogKeys, taskName});
+    }
+
+    /**
+     * @param {Object} options
+     * @param {String} options.taskName Deferred task name.
+     * @param {String} options.reasonCode Discriminator field.
+     * @param {String} options.reasonText Scheduling reason.
+     * @param {String|null} [options.blockingTaskName]
+     * @param {Object|null} [options.holdingLease]
+     * @returns {void}
+     */
+    recordDeferral({taskName, reasonCode, reasonText, blockingTaskName = null, holdingLease = null}) {
+        recordDeferral({
+            deferralLogKeys: this.deferralLogKeys,
+            taskName,
+            reasonCode,
+            reasonText,
+            blockingTaskName,
+            holdingLease,
+            taskDefinitions: this.taskDefinitions,
+            writeLog       : this.writeLog,
+            healthService  : this.healthService
+        });
+    }
+
+    // --- Executor wrappers (Group 3 entry points) ---
+
+    /**
+     * Wraps a heavy-maintenance task executor with intra-process backpressure +
+     * inter-process lease acquisition + deferral recording + release-on-completion.
+     *
+     * Two-tier backpressure:
+     * 1. **Intra-process:** `activeHeavyTask` tracker serializes heavy tasks within
+     *    a single orchestrator poll cycle.
+     * 2. **Inter-process:** shared file lease at `heavyMaintenanceLeasePath`
+     *    serializes heavy tasks across concurrent orchestrator daemons + lease-aware
+     *    manual CLI scripts.
+     *
+     * Lease release timing: synchronous `false` return → release immediately;
+     * thenable → release on settle (both fulfill and reject); other → release
+     * immediately. A synchronous throw from `executeFn` releases the lease before
+     * re-throwing.
+     *
+     * @param {Object} options
+     * @param {String} options.taskName Stable orchestrator task name.
+     * @param {Function} options.executeFn Task body `(taskName, reason, onSuccess, taskOptions) => result`.
+     * @param {Object} [options.reason] Scheduling reason (string or trigger object).
+     * @param {Function|null} [options.onSuccess=null] Success hook forwarded to `executeFn`.
+     * @param {Object} options.activeHeavyTask Mutable `{name: String|null}` tracker for the current poll.
+     * @returns {Boolean|Promise|*} `false` when deferred; otherwise whatever `executeFn` returns.
+     */
+    acquireLeaseAndExecute({taskName, executeFn, reason, onSuccess = null, activeHeavyTask}) {
+        const reasonText = reason || 'scheduled';
+
+        if (!this.isHeavyMaintenanceTask(taskName)) {
+            this.clearDeferralLogState(taskName);
+            return executeFn(taskName, reason, onSuccess);
+        }
+
+        const blockingTaskName = activeHeavyTask?.name && activeHeavyTask.name !== taskName
+            ? activeHeavyTask.name
+            : this.getActiveHeavyMaintenanceTask({excludeTaskName: taskName});
+
+        if (blockingTaskName) {
+            this.recordDeferral({
+                taskName,
+                reasonCode: 'heavy-maintenance-backpressure',
+                reasonText,
+                blockingTaskName
+            });
+            return false;
+        }
+
+        let acquisition;
+        try {
+            acquisition = this.acquireLeaseFn({
+                owner    : taskName,
+                reason   : reasonText,
+                metadata : {source: 'orchestrator'},
+                leasePath: this.resolveHeavyMaintenanceLeasePath()
+            });
+        } catch (e) {
+            this.writeLog('ERROR', `[Orchestrator] Heavy-maintenance lease acquire failed for ${taskName}: ${e.message}`);
+            this.healthService?.recordTaskOutcome?.(taskName, 'failed', {
+                reason    : reasonText,
+                reasonCode: 'heavy-maintenance-lease-acquire-error',
+                error     : e.message,
+                failedAt  : new Date().toISOString()
+            });
+            return false;
+        }
+
+        if (!acquisition.acquired) {
+            this.recordDeferral({
+                taskName,
+                reasonCode  : 'heavy-maintenance-lease-held',
+                reasonText,
+                holdingLease: acquisition.lease
+            });
+            return false;
+        }
+
+        this.clearDeferralLogState(taskName);
+
+        const releaseLease = () => {
+            try {
+                this.releaseLeaseFn({
+                    token    : acquisition.lease.token,
+                    leasePath: this.resolveHeavyMaintenanceLeasePath()
+                });
+            } catch (e) {
+                this.writeLog('ERROR', `[Orchestrator] Heavy-maintenance lease release failed for ${taskName}: ${e.message}`);
+            }
+        };
+
+        const taskOptions = {
+            env       : {NEO_HEAVY_MAINTENANCE_LEASE_INHERITED_TOKEN: acquisition.lease.token},
+            onComplete: releaseLease
+        };
+
+        let result;
+        try {
+            result = executeFn(taskName, reason, onSuccess, taskOptions);
+        } catch (e) {
+            releaseLease();
+            throw e;
+        }
+
+        if (result === false) {
+            releaseLease();
+        } else if (result && typeof result.then === 'function') {
+            result.then(releaseLease, releaseLease);
+        } else if (result !== true) {
+            releaseLease();
+        }
+
+        if (result !== false && activeHeavyTask) {
+            activeHeavyTask.name = taskName;
+        }
+
+        return result;
+    }
+
+    /**
+     * Wraps Golden Path execution with dependency ordering. Does NOT acquire a lease —
+     * Golden Path is graph-dependent but classified as light maintenance (the synthesizer
+     * reads the graph; it does not write the heavy substrates), so it only needs the
+     * dependency gate to avoid reading a partial graph state.
+     *
+     * @param {Object} options
+     * @param {String} options.taskName Stable orchestrator task name (`GOLDEN_PATH_TASK_NAME`).
+     * @param {Function} options.executeFn Task body `(taskName, reason) => result`.
+     * @param {Object} [options.reason] Scheduling reason.
+     * @param {Object} options.activeHeavyTask Mutable `{name: String|null}` tracker for the current poll.
+     * @returns {Boolean|*} `false` when deferred; otherwise whatever `executeFn` returns.
+     */
+    executeWithGoldenPathDependencyGate({taskName, executeFn, reason, activeHeavyTask}) {
+        const reasonText = reason || 'scheduled';
+        const blockingTaskName = this.getActiveGoldenPathDependencyTask({
+            activeTaskName: activeHeavyTask?.name
+        });
+
+        if (blockingTaskName) {
+            this.recordDeferral({
+                taskName  : GOLDEN_PATH_TASK_NAME,
+                reasonCode: 'golden-path-dependency-backpressure',
+                reasonText,
+                blockingTaskName
+            });
+            return false;
+        }
+
+        this.clearDeferralLogState(taskName);
+        return executeFn(taskName, reason);
+    }
+}
+
+export default Neo.setupClass(MaintenanceBackpressureService);

--- a/test/playwright/unit/ai/daemons/orchestrator/Orchestrator.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/Orchestrator.spec.mjs
@@ -4,11 +4,13 @@ import Neo from '../../../../../../src/Neo.mjs';
 import * as core from '../../../../../../src/core/_export.mjs';
 import AiConfig from '../../../../../../ai/config.template.mjs';
 import {
-    DEFAULT_HEAVY_MAINTENANCE_TASK_NAMES,
     Orchestrator,
     resolvePrimaryDevSyncRootsConfig,
     resolvePrimaryDevSyncRootsSource
 } from '../../../../../../ai/daemons/orchestrator/Orchestrator.mjs';
+import {
+    DEFAULT_HEAVY_MAINTENANCE_TASK_NAMES
+} from '../../../../../../ai/daemons/orchestrator/services/MaintenanceBackpressureService.mjs';
 import {
     DEV_SYNC_ROOTS_CONFIG_KEY,
     DEV_SYNC_ROOTS_ENV_VAR

--- a/test/playwright/unit/ai/daemons/orchestrator/services/MaintenanceBackpressureService.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/services/MaintenanceBackpressureService.spec.mjs
@@ -1,0 +1,513 @@
+import {test, expect} from '@playwright/test';
+import Neo            from '../../../../../../../src/Neo.mjs';
+import * as core      from '../../../../../../../src/core/_export.mjs';
+import {
+    DEFAULT_GOLDEN_PATH_DEPENDENCY_TASK_NAMES,
+    DEFAULT_HEAVY_MAINTENANCE_TASK_NAMES,
+    MaintenanceBackpressureService,
+    clearDeferralLogState,
+    getActiveGoldenPathDependencyTask,
+    getActiveHeavyMaintenanceTask,
+    isGoldenPathDependencyTask,
+    isHeavyMaintenanceTask,
+    recordDeferral,
+    resolveHeavyMaintenanceLeasePath
+} from '../../../../../../../ai/daemons/orchestrator/services/MaintenanceBackpressureService.mjs';
+import {
+    DREAM_TASK_NAME,
+    GOLDEN_PATH_TASK_NAME,
+    PRIMARY_DEV_SYNC_TASK_NAME
+} from '../../../../../../../ai/daemons/orchestrator/TaskDefinitions.mjs';
+
+// A non-heavy task name (must NOT be in DEFAULT_HEAVY_MAINTENANCE_TASK_NAMES) for
+// passthrough tests of `acquireLeaseAndExecute`.
+const NON_HEAVY_TASK_NAME = 'swarm-heartbeat';
+
+/**
+ * Builds a minimal `taskStateService`-shaped stub for predicate / finder tests.
+ * @param {Object} stateByTaskName Map of taskName → state-object.
+ * @returns {Object}
+ */
+function buildTaskStateService(stateByTaskName = {}) {
+    return {
+        getTaskState(name) {
+            return stateByTaskName[name] || null;
+        }
+    };
+}
+
+/**
+ * Builds a fresh `MaintenanceBackpressureService` instance per test with safe defaults
+ * and the supplied overrides. Avoids singleton state contamination across tests.
+ *
+ * @param {Object} [overrides] Config overrides.
+ * @returns {MaintenanceBackpressureService}
+ */
+function buildService(overrides = {}) {
+    return Neo.create(MaintenanceBackpressureService, {
+        heavyMaintenanceTaskNames    : DEFAULT_HEAVY_MAINTENANCE_TASK_NAMES,
+        goldenPathDependencyTaskNames: DEFAULT_GOLDEN_PATH_DEPENDENCY_TASK_NAMES,
+        writeLog                     : () => {},
+        ...overrides
+    });
+}
+
+test.describe('Neo.ai.daemons.orchestrator.services.MaintenanceBackpressureService', () => {
+
+    // ====================================================================
+    // Constants — pin the canonical heavy + golden-path classification sets
+    // ====================================================================
+
+    test('DEFAULT_HEAVY_MAINTENANCE_TASK_NAMES pins the canonical heavy-classification set', () => {
+        expect([...DEFAULT_HEAVY_MAINTENANCE_TASK_NAMES].sort()).toEqual([
+            'backup',
+            DREAM_TASK_NAME,
+            'kbSync',
+            PRIMARY_DEV_SYNC_TASK_NAME,
+            'summary'
+        ].sort());
+        expect(Object.isFrozen(DEFAULT_HEAVY_MAINTENANCE_TASK_NAMES)).toBe(true);
+        // Golden Path is light maintenance per #11511 / PR #11512 — must NOT be in heavy set
+        expect(DEFAULT_HEAVY_MAINTENANCE_TASK_NAMES).not.toContain(GOLDEN_PATH_TASK_NAME);
+    });
+
+    test('DEFAULT_GOLDEN_PATH_DEPENDENCY_TASK_NAMES pins the dependency set', () => {
+        expect([...DEFAULT_GOLDEN_PATH_DEPENDENCY_TASK_NAMES]).toEqual([DREAM_TASK_NAME]);
+        expect(Object.isFrozen(DEFAULT_GOLDEN_PATH_DEPENDENCY_TASK_NAMES)).toBe(true);
+    });
+
+    // ====================================================================
+    // Group 1 — Pure predicates + finders
+    // ====================================================================
+
+    test('isHeavyMaintenanceTask returns membership in heavy set', () => {
+        expect(isHeavyMaintenanceTask({
+            taskName                 : 'summary',
+            heavyMaintenanceTaskNames: DEFAULT_HEAVY_MAINTENANCE_TASK_NAMES
+        })).toBe(true);
+        expect(isHeavyMaintenanceTask({
+            taskName                 : GOLDEN_PATH_TASK_NAME,
+            heavyMaintenanceTaskNames: DEFAULT_HEAVY_MAINTENANCE_TASK_NAMES
+        })).toBe(false);
+    });
+
+    test('isGoldenPathDependencyTask returns membership in dependency set', () => {
+        expect(isGoldenPathDependencyTask({
+            taskName                     : DREAM_TASK_NAME,
+            goldenPathDependencyTaskNames: DEFAULT_GOLDEN_PATH_DEPENDENCY_TASK_NAMES
+        })).toBe(true);
+        expect(isGoldenPathDependencyTask({
+            taskName                     : 'summary',
+            goldenPathDependencyTaskNames: DEFAULT_GOLDEN_PATH_DEPENDENCY_TASK_NAMES
+        })).toBe(false);
+    });
+
+    test('getActiveHeavyMaintenanceTask returns first running heavy task, honors exclude', () => {
+        const taskStateService = buildTaskStateService({
+            summary: {running: true},
+            kbSync : {running: true}
+        });
+
+        expect(getActiveHeavyMaintenanceTask({
+            heavyMaintenanceTaskNames: DEFAULT_HEAVY_MAINTENANCE_TASK_NAMES,
+            taskStateService
+        })).toBe('summary');
+
+        expect(getActiveHeavyMaintenanceTask({
+            heavyMaintenanceTaskNames: DEFAULT_HEAVY_MAINTENANCE_TASK_NAMES,
+            taskStateService,
+            excludeTaskName          : 'summary'
+        })).toBe('kbSync');
+
+        expect(getActiveHeavyMaintenanceTask({
+            heavyMaintenanceTaskNames: DEFAULT_HEAVY_MAINTENANCE_TASK_NAMES,
+            taskStateService         : buildTaskStateService({})
+        })).toBeNull();
+    });
+
+    test('getActiveGoldenPathDependencyTask prioritizes activeTaskName when it is a dependency', () => {
+        const taskStateService = buildTaskStateService({});
+
+        // activeTaskName is a dependency → returned without consulting state
+        expect(getActiveGoldenPathDependencyTask({
+            goldenPathDependencyTaskNames: DEFAULT_GOLDEN_PATH_DEPENDENCY_TASK_NAMES,
+            taskStateService,
+            activeTaskName               : DREAM_TASK_NAME
+        })).toBe(DREAM_TASK_NAME);
+
+        // activeTaskName is NOT a dependency → fall back to state scan
+        expect(getActiveGoldenPathDependencyTask({
+            goldenPathDependencyTaskNames: DEFAULT_GOLDEN_PATH_DEPENDENCY_TASK_NAMES,
+            taskStateService             : buildTaskStateService({[DREAM_TASK_NAME]: {running: true}}),
+            activeTaskName               : 'summary'
+        })).toBe(DREAM_TASK_NAME);
+
+        // No dependency running, no active dependency → null
+        expect(getActiveGoldenPathDependencyTask({
+            goldenPathDependencyTaskNames: DEFAULT_GOLDEN_PATH_DEPENDENCY_TASK_NAMES,
+            taskStateService             : buildTaskStateService({})
+        })).toBeNull();
+    });
+
+    test('resolveHeavyMaintenanceLeasePath honors explicit override before dataDir fallback', () => {
+        expect(resolveHeavyMaintenanceLeasePath({
+            heavyMaintenanceLeasePath: '/tmp/explicit.json',
+            dataDir                  : '/ignored'
+        })).toBe('/tmp/explicit.json');
+
+        expect(resolveHeavyMaintenanceLeasePath({
+            heavyMaintenanceLeasePath: null,
+            dataDir                  : '/data/orch'
+        })).toBe('/data/orch/heavy-maintenance-lease.json');
+
+        // dataDir missing falls back to DEFAULT_DATA_DIR
+        const result = resolveHeavyMaintenanceLeasePath({heavyMaintenanceLeasePath: null, dataDir: null});
+        expect(result.endsWith('heavy-maintenance-lease.json')).toBe(true);
+    });
+
+    // ====================================================================
+    // Group 2 — Pure deferral recording (polymorphic on reasonCode)
+    // ====================================================================
+
+    test('clearDeferralLogState removes only keys prefixed with taskName', () => {
+        const deferralLogKeys = new Set(['summary:kbSync:r1', 'summary:dream:r2', 'kbSync:summary:r3']);
+        clearDeferralLogState({deferralLogKeys, taskName: 'summary'});
+
+        expect([...deferralLogKeys]).toEqual(['kbSync:summary:r3']);
+    });
+
+    test('recordDeferral (intra-process heavy backpressure) dedupes + emits skipped outcome', () => {
+        const deferralLogKeys = new Set();
+        const logCalls        = [];
+        const outcomeCalls    = [];
+        const writeLog        = (level, message) => logCalls.push({level, message});
+        const healthService   = {
+            recordTaskOutcome(taskName, status, payload) {
+                outcomeCalls.push({taskName, status, payload});
+            }
+        };
+
+        recordDeferral({
+            deferralLogKeys,
+            taskName       : 'kbSync',
+            reasonCode     : 'heavy-maintenance-backpressure',
+            reasonText     : 'periodic-sync:1800000',
+            blockingTaskName: 'summary',
+            taskDefinitions: {summary: {label: 'Sunset summary'}, kbSync: {label: 'KB sync'}},
+            writeLog,
+            healthService
+        });
+        // Repeat — must dedupe the log line but still emit an outcome each time
+        recordDeferral({
+            deferralLogKeys,
+            taskName       : 'kbSync',
+            reasonCode     : 'heavy-maintenance-backpressure',
+            reasonText     : 'periodic-sync:1800000',
+            blockingTaskName: 'summary',
+            taskDefinitions: {summary: {label: 'Sunset summary'}, kbSync: {label: 'KB sync'}},
+            writeLog,
+            healthService
+        });
+
+        expect(logCalls.length).toBe(1);
+        expect(logCalls[0].level).toBe('INFO');
+        expect(logCalls[0].message).toContain('Deferring KB sync');
+        expect(logCalls[0].message).toContain('Sunset summary is active');
+        expect(logCalls[0].message).toContain('periodic-sync:1800000');
+
+        expect(outcomeCalls.length).toBe(2);
+        expect(outcomeCalls[0]).toMatchObject({
+            taskName: 'kbSync',
+            status  : 'skipped',
+            payload : {
+                reason          : 'periodic-sync:1800000',
+                reasonCode      : 'heavy-maintenance-backpressure',
+                blockingTaskName: 'summary'
+            }
+        });
+        expect(outcomeCalls[0].payload.deferredAt).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+    });
+
+    test('recordDeferral (cross-daemon lease-held) uses holdingLease owner in key + payload', () => {
+        const deferralLogKeys = new Set();
+        const logCalls        = [];
+        const outcomeCalls    = [];
+
+        recordDeferral({
+            deferralLogKeys,
+            taskName     : 'backup',
+            reasonCode   : 'heavy-maintenance-lease-held',
+            reasonText   : 'periodic-sweep:86400000',
+            holdingLease : {owner: 'sandman', pid: 4242},
+            writeLog     : (level, message) => logCalls.push({level, message}),
+            healthService: {recordTaskOutcome: (taskName, status, payload) => outcomeCalls.push({taskName, status, payload})}
+        });
+
+        expect(logCalls[0].message).toContain('cross-daemon heavy-maintenance lease held by sandman');
+        expect(outcomeCalls[0].payload).toMatchObject({
+            reason      : 'periodic-sweep:86400000',
+            reasonCode  : 'heavy-maintenance-lease-held',
+            holdingOwner: 'sandman',
+            holdingPid  : 4242
+        });
+        expect(outcomeCalls[0].payload.blockingTaskName).toBeUndefined();
+
+        // Same task + different owner → distinct key, distinct log
+        recordDeferral({
+            deferralLogKeys,
+            taskName     : 'backup',
+            reasonCode   : 'heavy-maintenance-lease-held',
+            reasonText   : 'periodic-sweep:86400000',
+            holdingLease : {owner: 'kbSync', pid: 7777},
+            writeLog     : (level, message) => logCalls.push({level, message}),
+            healthService: {recordTaskOutcome: (taskName, status, payload) => outcomeCalls.push({taskName, status, payload})}
+        });
+        expect(logCalls.length).toBe(2);
+    });
+
+    test('recordDeferral (golden-path dependency backpressure) labels dependency task in log', () => {
+        const deferralLogKeys = new Set();
+        const logCalls        = [];
+
+        recordDeferral({
+            deferralLogKeys,
+            taskName       : GOLDEN_PATH_TASK_NAME,
+            reasonCode     : 'golden-path-dependency-backpressure',
+            reasonText     : `periodic-golden-path:1800000`,
+            blockingTaskName: DREAM_TASK_NAME,
+            taskDefinitions: {
+                [GOLDEN_PATH_TASK_NAME]: {label: 'Golden Path'},
+                [DREAM_TASK_NAME]      : {label: 'Dream cycle'}
+            },
+            writeLog: (level, message) => logCalls.push({level, message})
+        });
+
+        expect(logCalls[0].message).toContain('Deferring Golden Path');
+        expect(logCalls[0].message).toContain('dependency task Dream cycle is active');
+    });
+
+    test('recordDeferral handles missing healthService gracefully', () => {
+        const deferralLogKeys = new Set();
+        // No healthService → must not throw
+        expect(() => recordDeferral({
+            deferralLogKeys,
+            taskName       : 'kbSync',
+            reasonCode     : 'heavy-maintenance-backpressure',
+            reasonText     : 'periodic-sync',
+            blockingTaskName: 'summary'
+        })).not.toThrow();
+    });
+
+    // ====================================================================
+    // Group 3 — Executor wrappers (Neo-class integration tests with stubs)
+    // ====================================================================
+
+    test('acquireLeaseAndExecute passes through non-heavy tasks without lease IO', () => {
+        const acquireCalls = [];
+        const executions   = [];
+        const service      = buildService({
+            heavyMaintenanceTaskNames: DEFAULT_HEAVY_MAINTENANCE_TASK_NAMES,
+            taskStateService         : buildTaskStateService({}),
+            acquireLeaseFn           : opts => { acquireCalls.push(opts); return {acquired: true, lease: {token: 't'}}; },
+            releaseLeaseFn           : () => {}
+        });
+
+        const activeHeavyTask = {name: null};
+        const result = service.acquireLeaseAndExecute({
+            taskName       : NON_HEAVY_TASK_NAME,
+            executeFn      : (taskName, reason) => { executions.push({taskName, reason}); return true; },
+            reason         : 'periodic-heartbeat',
+            activeHeavyTask
+        });
+
+        expect(acquireCalls.length).toBe(0);
+        expect(executions).toEqual([{taskName: NON_HEAVY_TASK_NAME, reason: 'periodic-heartbeat'}]);
+        expect(result).toBe(true);
+        expect(activeHeavyTask.name).toBeNull();
+    });
+
+    test('acquireLeaseAndExecute defers intra-process when another heavy task is running', () => {
+        const outcomeCalls = [];
+        const service      = buildService({
+            taskStateService: buildTaskStateService({summary: {running: true}}),
+            healthService   : {recordTaskOutcome: (t, s, p) => outcomeCalls.push({t, s, p})},
+            acquireLeaseFn  : () => { throw new Error('should not acquire'); },
+            releaseLeaseFn  : () => {}
+        });
+
+        const activeHeavyTask = {name: 'summary'};
+        const result = service.acquireLeaseAndExecute({
+            taskName       : 'kbSync',
+            executeFn      : () => { throw new Error('should not execute'); },
+            reason         : 'periodic-sync',
+            activeHeavyTask
+        });
+
+        expect(result).toBe(false);
+        expect(outcomeCalls[0].s).toBe('skipped');
+        expect(outcomeCalls[0].p.reasonCode).toBe('heavy-maintenance-backpressure');
+        expect(outcomeCalls[0].p.blockingTaskName).toBe('summary');
+    });
+
+    test('acquireLeaseAndExecute defers cross-daemon when lease is held', () => {
+        const outcomeCalls = [];
+        const service      = buildService({
+            taskStateService: buildTaskStateService({}),
+            healthService   : {recordTaskOutcome: (t, s, p) => outcomeCalls.push({t, s, p})},
+            acquireLeaseFn  : () => ({acquired: false, lease: {owner: 'sandman', pid: 99}}),
+            releaseLeaseFn  : () => {}
+        });
+
+        const activeHeavyTask = {name: null};
+        const result = service.acquireLeaseAndExecute({
+            taskName       : 'backup',
+            executeFn      : () => { throw new Error('should not execute'); },
+            reason         : 'periodic-sweep',
+            activeHeavyTask
+        });
+
+        expect(result).toBe(false);
+        expect(outcomeCalls[0].p.reasonCode).toBe('heavy-maintenance-lease-held');
+        expect(outcomeCalls[0].p.holdingOwner).toBe('sandman');
+    });
+
+    test('acquireLeaseAndExecute records failure outcome on lease-acquire throw', () => {
+        const outcomeCalls = [];
+        const service      = buildService({
+            taskStateService: buildTaskStateService({}),
+            healthService   : {recordTaskOutcome: (t, s, p) => outcomeCalls.push({t, s, p})},
+            acquireLeaseFn  : () => { throw new Error('disk full'); },
+            releaseLeaseFn  : () => {}
+        });
+
+        const result = service.acquireLeaseAndExecute({
+            taskName       : 'kbSync',
+            executeFn      : () => { throw new Error('should not execute'); },
+            reason         : 'periodic-sync',
+            activeHeavyTask: {name: null}
+        });
+
+        expect(result).toBe(false);
+        expect(outcomeCalls[0].s).toBe('failed');
+        expect(outcomeCalls[0].p.reasonCode).toBe('heavy-maintenance-lease-acquire-error');
+        expect(outcomeCalls[0].p.error).toBe('disk full');
+    });
+
+    test('acquireLeaseAndExecute acquires + executes + releases on synchronous false return', () => {
+        const releases = [];
+        const service  = buildService({
+            taskStateService: buildTaskStateService({}),
+            acquireLeaseFn  : () => ({acquired: true, lease: {token: 'tok-1'}}),
+            releaseLeaseFn  : opts => releases.push(opts.token)
+        });
+
+        const activeHeavyTask = {name: null};
+        const result = service.acquireLeaseAndExecute({
+            taskName       : 'kbSync',
+            executeFn      : () => false, // task self-declined → still must release
+            reason         : 'periodic-sync',
+            activeHeavyTask
+        });
+
+        expect(result).toBe(false);
+        expect(releases).toEqual(['tok-1']);
+        // false result → activeHeavyTask.name unchanged
+        expect(activeHeavyTask.name).toBeNull();
+    });
+
+    test('acquireLeaseAndExecute releases on async settle (fulfill)', async () => {
+        const releases = [];
+        const service  = buildService({
+            taskStateService: buildTaskStateService({}),
+            acquireLeaseFn  : () => ({acquired: true, lease: {token: 'tok-2'}}),
+            releaseLeaseFn  : opts => releases.push(opts.token)
+        });
+
+        const activeHeavyTask = {name: null};
+        const result = service.acquireLeaseAndExecute({
+            taskName       : 'kbSync',
+            executeFn      : async () => 'work-done',
+            reason         : 'periodic-sync',
+            activeHeavyTask
+        });
+
+        await result;
+        expect(await result).toBe('work-done');
+        expect(releases).toEqual(['tok-2']);
+        expect(activeHeavyTask.name).toBe('kbSync');
+    });
+
+    test('acquireLeaseAndExecute releases on async settle (reject) without swallowing rejection', async () => {
+        const releases = [];
+        const service  = buildService({
+            taskStateService: buildTaskStateService({}),
+            acquireLeaseFn  : () => ({acquired: true, lease: {token: 'tok-3'}}),
+            releaseLeaseFn  : opts => releases.push(opts.token)
+        });
+
+        const result = service.acquireLeaseAndExecute({
+            taskName       : 'kbSync',
+            executeFn      : async () => { throw new Error('boom'); },
+            reason         : 'periodic-sync',
+            activeHeavyTask: {name: null}
+        });
+
+        await expect(result).rejects.toThrow('boom');
+        expect(releases).toEqual(['tok-3']);
+    });
+
+    test('acquireLeaseAndExecute releases on synchronous throw from executeFn', () => {
+        const releases = [];
+        const service  = buildService({
+            taskStateService: buildTaskStateService({}),
+            acquireLeaseFn  : () => ({acquired: true, lease: {token: 'tok-4'}}),
+            releaseLeaseFn  : opts => releases.push(opts.token)
+        });
+
+        expect(() => service.acquireLeaseAndExecute({
+            taskName       : 'kbSync',
+            executeFn      : () => { throw new Error('sync boom'); },
+            reason         : 'periodic-sync',
+            activeHeavyTask: {name: null}
+        })).toThrow('sync boom');
+
+        expect(releases).toEqual(['tok-4']);
+    });
+
+    test('executeWithGoldenPathDependencyGate defers when dependency task is running', () => {
+        const outcomeCalls = [];
+        const service      = buildService({
+            taskStateService: buildTaskStateService({[DREAM_TASK_NAME]: {running: true}}),
+            healthService   : {recordTaskOutcome: (t, s, p) => outcomeCalls.push({t, s, p})}
+        });
+
+        const result = service.executeWithGoldenPathDependencyGate({
+            taskName       : GOLDEN_PATH_TASK_NAME,
+            executeFn      : () => { throw new Error('should not execute'); },
+            reason         : 'periodic-golden-path',
+            activeHeavyTask: {name: null}
+        });
+
+        expect(result).toBe(false);
+        expect(outcomeCalls[0].p.reasonCode).toBe('golden-path-dependency-backpressure');
+        expect(outcomeCalls[0].p.blockingTaskName).toBe(DREAM_TASK_NAME);
+    });
+
+    test('executeWithGoldenPathDependencyGate passes through when no dependency is running', () => {
+        const executions = [];
+        const service    = buildService({
+            taskStateService: buildTaskStateService({})
+        });
+
+        const result = service.executeWithGoldenPathDependencyGate({
+            taskName       : GOLDEN_PATH_TASK_NAME,
+            executeFn      : (taskName, reason) => { executions.push({taskName, reason}); return 'gp-done'; },
+            reason         : 'periodic-golden-path',
+            activeHeavyTask: {name: null}
+        });
+
+        expect(executions).toEqual([{taskName: GOLDEN_PATH_TASK_NAME, reason: 'periodic-golden-path'}]);
+        expect(result).toBe('gp-done');
+    });
+});
+

--- a/test/playwright/unit/ai/scripts/maintenance/manualHeavyMaintenanceScriptLeaseAdoption.spec.mjs
+++ b/test/playwright/unit/ai/scripts/maintenance/manualHeavyMaintenanceScriptLeaseAdoption.spec.mjs
@@ -1,6 +1,6 @@
 import {setup} from '../../../../setup.mjs';
 
-const appName = 'LaneCManualScriptLeaseAdoptionTest';
+const appName = 'ManualHeavyMaintenanceScriptLeaseAdoptionTest';
 
 setup({
     neoConfig: {
@@ -20,36 +20,24 @@ import Neo            from '../../../../../../src/Neo.mjs';
 import * as core      from '../../../../../../src/core/_export.mjs';
 
 /**
- * @summary Lane C of #11503 — verifies that the four operator-runnable heavy-maintenance CLI
- * scripts wrap their substrate-heavy work with the shared `withHeavyMaintenanceLease` primitive
- * (PR #11506 / #11505) and handle the `held` outcome with a clean non-error exit.
+ * @summary Verifies that operator-runnable heavy-maintenance CLI scripts wrap their
+ * substrate-heavy work with the shared `withHeavyMaintenanceLease` primitive and handle
+ * the `held` outcome with a clean non-error exit.
  *
- * This spec uses content-verification (parse the script source for the expected import +
- * wrapper call + held-status branch) rather than subprocess execution because:
- * - Each script imports services.mjs / Neo / lifecycle services that initialize on module load,
- *   making subprocess-per-test runs slow (multi-second) and flaky if any background daemon
- *   is contending the same Chroma instance.
- * - The underlying `withHeavyMaintenanceLease` is already tested by PR #11506's
- *   `HeavyMaintenanceLeaseService.spec.mjs` (8/8 passing); Lane C just needs to verify the
- *   WIRING is in place across all four scripts.
- *
- * Empirical anchor: today's wedge cascade at 2026-05-16T19:27Z showed the orchestrator's own
- * kbSync subprocess in a collision class that would have allowed a manual `npm run ai:sync-kb`
- * to compound the contention. Lane C closes that class at the script surface; this spec
- * proves the wiring landed.
- *
- * @see #11503 (umbrella)
- * @see #11505 (lease primitive ticket) / PR #11506 (lease primitive implementation)
- * @see #11507 (this ticket)
+ * Content-verification approach (parse the script source for the expected import +
+ * wrapper call + held-status branch) rather than subprocess execution because each script
+ * boots Neo + lifecycle services on module load, making subprocess-per-test runs slow and
+ * contention-flaky. The underlying `withHeavyMaintenanceLease` is covered separately by
+ * `HeavyMaintenanceLeaseService.spec.mjs`; this spec verifies the WIRING per script.
  */
-test.describe('Lane C / #11507 — manual heavy-maintenance script lease adoption', () => {
+test.describe('Manual heavy-maintenance script lease adoption', () => {
     const scriptsRoot = path.resolve(process.cwd(), 'ai/scripts');
     const scriptPath = file => path.join(scriptsRoot, file === 'runSandman.mjs' ? 'runners' : 'maintenance', file);
 
     /**
      * Maps each script to its expected lease `owner` string. Owner strings are stable
      * identifiers used by both the wrapper-side defer message and the orchestrator-side
-     * task names — keep these in sync with `Orchestrator.mjs` DEFAULT_HEAVY_MAINTENANCE_TASK_NAMES.
+     * task names — keep these in sync with `MaintenanceBackpressureService.mjs` DEFAULT_HEAVY_MAINTENANCE_TASK_NAMES.
      */
     const SCRIPTS = [
         {file: 'runSandman.mjs',           owner: 'sandman'},


### PR DESCRIPTION
Authored by Claude Opus 4.7 (Claude Code). Session 5572d9a5-558d-4bea-b416-e31496c289c4.

FAIR-band: in-band [verify @ merge-gate]

Resolves #11861 (Sub 19 of Epic #11831)

Evidence: L1 (22/22 new MaintenanceBackpressureService spec + 206/206 orchestrator suite + 2059/2059 full unit suite, 0 failures) → L1 required for additive pure-function-first extraction (no behavioral mutation at orchestrator surface; Sub 18 #11862 wires the new service). No residuals.

## Summary

B-prime extraction: moves the orchestrator's execution-phase policy surface (heavy/dependency classification predicates + deferral recording + lease/dependency executor wrappers) into a single new service so the Sub 18 closer can wire `poll()` as a generic registry-driven dispatch.

**Additive only.** Does NOT delete the inline `§E-H` methods from `Orchestrator.mjs` — Sub 18 #11862 owns the cutover (wire `poll()` to call the new service + delete the old inline methods). This keeps the per-sub risk surface atomic and matches the Sub 17/20 batched precedent on PR #11866.

## New files

- `ai/daemons/orchestrator/services/MaintenanceBackpressureService.mjs` — 3 internally-visible surface groups (pure predicates/finders → consolidated `recordDeferral` → executor wrappers wrapping `HeavyMaintenanceLeaseService` primitives). 549 LOC.
- `test/playwright/unit/ai/daemons/orchestrator/services/MaintenanceBackpressureService.spec.mjs` — 22 tests covering predicate/finder edge cases, all 3 `reasonCode` branches of `recordDeferral`, and integration coverage for both executor wrappers (deferral paths + acquire/throw/release/promise-settle paths). 513 LOC.

## Touched files (re-routes only — no behavioral change)

- `ai/daemons/orchestrator/Orchestrator.mjs` — Drops the local `DEFAULT_HEAVY_MAINTENANCE_TASK_NAMES` + `DEFAULT_GOLDEN_PATH_DEPENDENCY_TASK_NAMES` definitions; imports them from the new canonical home. Single source of truth, zero drift risk between Sub-19 and Sub-18 merge windows. (No re-export — v13 work is unreleased, no backward-compat substrate needed.)
- `test/playwright/unit/ai/daemons/orchestrator/Orchestrator.spec.mjs` — Import path swap for `DEFAULT_HEAVY_MAINTENANCE_TASK_NAMES` (Orchestrator.mjs → MaintenanceBackpressureService.mjs). Spec assertions unchanged.

## Filename / describe cleanup (operator-flagged)

- Renamed `laneCManualScriptLeaseAdoption.spec.mjs` → `manualHeavyMaintenanceScriptLeaseAdoption.spec.mjs`. "Lane C" is opaque epic-lineage drift baked into a filename — same Sub-15 decay-prone-reference lesson applied to file names + describe strings.
- Updated `appName` const + `test.describe` accordingly.
- Applied the same lesson proactively to my new files: dropped `§E §F §G §H` discussion-specific section labels from JSDoc, dropped `(#11861 / Epic #11831)` describe-string anchors, dropped `(#11513 AC2)` test-name anchors — kept descriptive prose.

## Design choices

**Pure-function-first shape** matches the `HeavyMaintenanceLeaseService.mjs` precedent: module-level exports are the primary API (testable in isolation, no Neo bootstrap required); the Neo class is a thin wrapper holding instance state (`deferralLogKeys` Set) + injecting collaborators via reactive configs.

**Consolidated `recordDeferral`** replaces the 3 prior methods (`recordMaintenanceDeferral` / `recordCrossDaemonLeaseDeferral` / `recordGoldenPathDependencyDeferral`) with a single entry point polymorphic on `reasonCode`. Dedup-key construction varies per class (lease-held uses owner; others use blockingTaskName), but log message format + outcome payload shape collapse to one code path.

**Executor wrappers preserve the lease-release timing contract exactly**: synchronous `false` → release immediately; thenable → release on settle (both fulfill + reject); synchronous throw → release before re-throwing; other → release immediately.

**No post-construction assignment bags** (Sub-1 anti-pattern guard per #11857 Cycle-3.5 GPT signal): swappable dependencies (`taskStateService`, `healthService`, `taskDefinitions`, `acquireLeaseFn`, `releaseLeaseFn`) all flow through reactive class configs.

## Test Evidence

- `npm run test-unit -- --grep="MaintenanceBackpressureService"` → **22/22 pass (2.8s)**
- `npm run test-unit -- --grep="Orchestrator|Manual heavy-maintenance script"` → **206/206 pass (10.2s)**
- `npm run test-unit` (full suite) → **2059 passed, 2 skipped, 13 did not run, 0 failed (2.1m)**

L1 evidence for pure-function extraction + additive-only change: no behavioral mutation at orchestrator surface in this PR (Sub 18 wires the new service).

## Post-Merge Validation

- [ ] Sub 18 #11862 cleanly imports `MaintenanceBackpressureService` for `poll()` wire-up
- [ ] No behavioral change observable in orchestrator boot or scheduling (additive only)

## AC mapping

| AC | Status |
|----|--------|
| 1. Service ships with 3 surface groups, visibly separate | ✓ Section-divider comments separate predicates/finders, deferral recording, and executor wrappers |
| 2. Wraps / delegates to existing `HeavyMaintenanceLeaseService` (does NOT replace) | ✓ Imports `acquireHeavyMaintenanceLeaseSync` + `releaseHeavyMaintenanceLeaseSync` as swappable config defaults |
| 3. Pure-function unit tests for predicates + finders | ✓ 5 dedicated tests (`isHeavyMaintenanceTask`, `isGoldenPathDependencyTask`, `getActiveHeavyMaintenanceTask` with exclude, `getActiveGoldenPathDependencyTask` priority, `resolveHeavyMaintenanceLeasePath` fallback chain) |
| 4. Integration tests for executor wrappers using lease seams | ✓ 8 tests covering deferral classes + all 4 release timings + throw path |
| 5. Orchestrator's `poll()` calls service methods | Sub 18 #11862 territory (this PR is additive) |
| 6. Sub 19 extracts ≥70% of §E-H ~303 LOC | ✓ All ~303 LOC of substantive logic reflected in the new service (predicates 57 + deferral 109 + heavy executor 114 + golden-path executor 23 = 303) |

## Deltas from ticket

- `DEFAULT_HEAVY_MAINTENANCE_TASK_NAMES` + `DEFAULT_GOLDEN_PATH_DEPENDENCY_TASK_NAMES` constants live in `MaintenanceBackpressureService.mjs` as the canonical home; Orchestrator.mjs imports (no re-export). Per operator: "v13 work, never released, no backwards-compat bloat."
- Filename rename + describe-string cleanup of pre-existing `laneCManualScriptLeaseAdoption.spec.mjs` folded in — operator-flagged friction caught during this lane.

## Depends on

Epic #11831. Independent of Subs 14-17 + 20 (already merged or independent).

## Unblocks

Sub 18 #11862 (Round-2 closer) — Orchestrator generic registry wire-up + CadenceEngine pure-trigger-builder correction. Sub 18 wires `poll()` to call `MaintenanceBackpressureService.acquireLeaseAndExecute({...})` + `.executeWithGoldenPathDependencyGate({...})` and deletes the now-dead inline `§E-H` methods.

## Authority

Discussion #11857 Cycle-3.5 GPT `[GRADUATION_APPROVED]` + operator architectural ratify.

Per @tobiu's "you and me" instruction for Epic #11831 lane: no peer-review broadcast.