### PR TITLE
feat(agentos): centralize env-binding registry — ai/config/env.mjs + dotenv lift (#11855)

### DIFF
--- a/ai/config/env.mjs
+++ b/ai/config/env.mjs
@@ -1,0 +1,64 @@
+import 'dotenv/config';
+import Env from '../../src/util/Env.mjs';
+
+/**
+ * Single declaration per env var: name → parser. Adding a new env var means
+ * one entry here, then `env.<NAME>` everywhere downstream. Renaming an env var
+ * means one edit here — consumers reference the canonical key, not the literal
+ * string at every call-site.
+ *
+ * @type {Object<String, Function>}
+ */
+const bindings = {
+    NEO_ORCHESTRATOR_POLL_INTERVAL_MS                   : Env.parseNumber,
+    NEO_ORCHESTRATOR_SUMMARY_SWEEP_INTERVAL_MS          : Env.parseNumber,
+    NEO_ORCHESTRATOR_KB_SYNC_INTERVAL_MS                : Env.parseNumber,
+    NEO_ORCHESTRATOR_BACKUP_INTERVAL_MS                 : Env.parseNumber,
+    NEO_ORCHESTRATOR_PRIMARY_DEV_SYNC_INTERVAL_MS       : Env.parseNumber,
+    NEO_ORCHESTRATOR_DREAM_INTERVAL_MS                  : Env.parseNumber,
+    NEO_ORCHESTRATOR_GOLDEN_PATH_INTERVAL_MS            : Env.parseNumber,
+    NEO_ORCHESTRATOR_SWARM_HEARTBEAT_INTERVAL_MS        : Env.parseNumber,
+    NEO_ORCHESTRATOR_KB_SYNC_ENABLED                    : Env.parseBool,
+    NEO_ORCHESTRATOR_PRIMARY_DEV_SYNC_ENABLED           : Env.parseBool,
+    NEO_ORCHESTRATOR_BRIDGE_DAEMON_ENABLED              : Env.parseBool,
+    NEO_ORCHESTRATOR_SWARM_HEARTBEAT_ENABLED            : Env.parseBool,
+    NEO_ORCHESTRATOR_GOLDEN_PATH_REPO_ENRICHMENT_ENABLED: Env.parseBool
+};
+
+/**
+ * @summary Builds a typed env-var registry from a name → parser binding map.
+ *
+ * Iterates bindings, runs each parser against the source env, returns an object
+ * keyed by env-var name with decoded values. Absent or invalid values map to
+ * `undefined` so consumers can chain with `??` against config defaults.
+ *
+ * @param {Object} options
+ * @param {Object<String, Function>} options.bindings env-var name → parser function.
+ * @param {Object} [options.source=process.env] Source env object (override for tests).
+ * @returns {Object<String, *>}
+ */
+export function buildEnv({bindings: bindingMap, source = process.env}) {
+    const result = {};
+    for (const [name, parse] of Object.entries(bindingMap)) {
+        result[name] = parse(source[name], name);
+    }
+    return result;
+}
+
+/**
+ * Eager-bound env-var registry. Loaded once at module load (after `dotenv/config`
+ * has merged any local `.env` file into `process.env`). Consumers import this
+ * default export and reference `env.NEO_X` instead of `Env.parseX(process.env.X, 'X')`.
+ *
+ * @example
+ * import env from 'neo.mjs/ai/config/env.mjs';
+ * get pollIntervalMs() {
+ *     return env.NEO_ORCHESTRATOR_POLL_INTERVAL_MS ?? AiConfig.orchestrator.intervals.pollMs;
+ * }
+ *
+ * @type {Object<String, *>}
+ */
+const env = buildEnv({bindings});
+
+export default env;
+export {bindings};

--- a/ai/daemons/orchestrator/Orchestrator.mjs
+++ b/ai/daemons/orchestrator/Orchestrator.mjs
@@ -8,7 +8,7 @@ import {spawn}                     from 'child_process';
 import path                        from 'path';
 import Base                        from '../../../src/core/Base.mjs';
 import ClassSystemUtil             from '../../../src/util/ClassSystem.mjs';
-import Env                         from '../../../src/util/Env.mjs';
+import env                         from '../../config/env.mjs';
 import AiConfig                    from '../../config.template.mjs';
 import HealthService               from '../../services/memory-core/HealthService.mjs';
 import {
@@ -148,8 +148,9 @@ function resolveDeploymentEnabled(key) {
  *   (`summarizationCoordinator`, `backupCoordinator`, etc.) — no class-system
  *   conversion, no parent-child propagation, no lifecycle side effect.
  * - **(D) Operator policy value** — lazy getters with the 2-value chain
- *   `Env.parseNumber(process.env.X, 'X') ?? AiConfig.orchestrator.intervals.X`
- *   for intervals + `Env.parseBool(...) ?? resolveDeploymentEnabled(...)` for booleans.
+ *   `env.NEO_X ?? AiConfig.orchestrator.intervals.X` for intervals +
+ *   `env.NEO_X ?? resolveDeploymentEnabled(...)` for booleans. `env` is the
+ *   centralized binding registry from `ai/config/env.mjs`.
  *
  * No `configure()` shadow-resolver. No `DEFAULT_X_*_MS` constants. No
  * `parseInterval`/`parseEnabledFlag` helpers. No `processSupervisorService.set({...this...})`
@@ -291,58 +292,20 @@ export class Orchestrator extends Base {
     }
 
     // === Service-DI Class D: operator policy values (lazy getters, 2-value chain) ===
-    get pollIntervalMs() {
-        return Env.parseNumber(process.env.NEO_ORCHESTRATOR_POLL_INTERVAL_MS, 'NEO_ORCHESTRATOR_POLL_INTERVAL_MS')
-            ?? AiConfig.orchestrator.intervals.pollMs;
-    }
-    get summarySweepIntervalMs() {
-        return Env.parseNumber(process.env.NEO_ORCHESTRATOR_SUMMARY_SWEEP_INTERVAL_MS, 'NEO_ORCHESTRATOR_SUMMARY_SWEEP_INTERVAL_MS')
-            ?? AiConfig.orchestrator.intervals.summarySweepMs;
-    }
-    get kbSyncIntervalMs() {
-        return Env.parseNumber(process.env.NEO_ORCHESTRATOR_KB_SYNC_INTERVAL_MS, 'NEO_ORCHESTRATOR_KB_SYNC_INTERVAL_MS')
-            ?? AiConfig.orchestrator.intervals.kbSyncMs;
-    }
-    get backupIntervalMs() {
-        return Env.parseNumber(process.env.NEO_ORCHESTRATOR_BACKUP_INTERVAL_MS, 'NEO_ORCHESTRATOR_BACKUP_INTERVAL_MS')
-            ?? AiConfig.orchestrator.intervals.backupMs;
-    }
-    get primaryDevSyncIntervalMs() {
-        return Env.parseNumber(process.env.NEO_ORCHESTRATOR_PRIMARY_DEV_SYNC_INTERVAL_MS, 'NEO_ORCHESTRATOR_PRIMARY_DEV_SYNC_INTERVAL_MS')
-            ?? AiConfig.orchestrator.intervals.primaryDevSyncMs;
-    }
-    get dreamIntervalMs() {
-        return Env.parseNumber(process.env.NEO_ORCHESTRATOR_DREAM_INTERVAL_MS, 'NEO_ORCHESTRATOR_DREAM_INTERVAL_MS')
-            ?? AiConfig.orchestrator.intervals.dreamMs;
-    }
-    get goldenPathIntervalMs() {
-        return Env.parseNumber(process.env.NEO_ORCHESTRATOR_GOLDEN_PATH_INTERVAL_MS, 'NEO_ORCHESTRATOR_GOLDEN_PATH_INTERVAL_MS')
-            ?? AiConfig.orchestrator.intervals.goldenPathMs;
-    }
-    get swarmHeartbeatIntervalMs() {
-        return Env.parseNumber(process.env.NEO_ORCHESTRATOR_SWARM_HEARTBEAT_INTERVAL_MS, 'NEO_ORCHESTRATOR_SWARM_HEARTBEAT_INTERVAL_MS')
-            ?? AiConfig.orchestrator.intervals.swarmHeartbeatMs;
-    }
-    get kbSyncEnabled() {
-        return Env.parseBool(process.env.NEO_ORCHESTRATOR_KB_SYNC_ENABLED, 'NEO_ORCHESTRATOR_KB_SYNC_ENABLED')
-            ?? resolveDeploymentEnabled('kbSyncEnabled');
-    }
-    get primaryDevSyncEnabled() {
-        return Env.parseBool(process.env.NEO_ORCHESTRATOR_PRIMARY_DEV_SYNC_ENABLED, 'NEO_ORCHESTRATOR_PRIMARY_DEV_SYNC_ENABLED')
-            ?? resolveDeploymentEnabled('primaryDevSyncEnabled');
-    }
-    get bridgeDaemonEnabled() {
-        return Env.parseBool(process.env.NEO_ORCHESTRATOR_BRIDGE_DAEMON_ENABLED, 'NEO_ORCHESTRATOR_BRIDGE_DAEMON_ENABLED')
-            ?? resolveDeploymentEnabled('bridgeDaemonEnabled');
-    }
-    get swarmHeartbeatEnabled() {
-        return Env.parseBool(process.env.NEO_ORCHESTRATOR_SWARM_HEARTBEAT_ENABLED, 'NEO_ORCHESTRATOR_SWARM_HEARTBEAT_ENABLED')
-            ?? resolveDeploymentEnabled('swarmHeartbeatEnabled');
-    }
-    get goldenPathRepoEnrichmentEnabled() {
-        return Env.parseBool(process.env.NEO_ORCHESTRATOR_GOLDEN_PATH_REPO_ENRICHMENT_ENABLED, 'NEO_ORCHESTRATOR_GOLDEN_PATH_REPO_ENRICHMENT_ENABLED')
-            ?? resolveDeploymentEnabled('goldenPathRepoEnrichmentEnabled');
-    }
+    get pollIntervalMs()          { return env.NEO_ORCHESTRATOR_POLL_INTERVAL_MS              ?? AiConfig.orchestrator.intervals.pollMs;             }
+    get summarySweepIntervalMs()  { return env.NEO_ORCHESTRATOR_SUMMARY_SWEEP_INTERVAL_MS     ?? AiConfig.orchestrator.intervals.summarySweepMs;     }
+    get kbSyncIntervalMs()        { return env.NEO_ORCHESTRATOR_KB_SYNC_INTERVAL_MS           ?? AiConfig.orchestrator.intervals.kbSyncMs;           }
+    get backupIntervalMs()        { return env.NEO_ORCHESTRATOR_BACKUP_INTERVAL_MS            ?? AiConfig.orchestrator.intervals.backupMs;           }
+    get primaryDevSyncIntervalMs(){ return env.NEO_ORCHESTRATOR_PRIMARY_DEV_SYNC_INTERVAL_MS  ?? AiConfig.orchestrator.intervals.primaryDevSyncMs;   }
+    get dreamIntervalMs()         { return env.NEO_ORCHESTRATOR_DREAM_INTERVAL_MS             ?? AiConfig.orchestrator.intervals.dreamMs;            }
+    get goldenPathIntervalMs()    { return env.NEO_ORCHESTRATOR_GOLDEN_PATH_INTERVAL_MS       ?? AiConfig.orchestrator.intervals.goldenPathMs;       }
+    get swarmHeartbeatIntervalMs(){ return env.NEO_ORCHESTRATOR_SWARM_HEARTBEAT_INTERVAL_MS   ?? AiConfig.orchestrator.intervals.swarmHeartbeatMs;   }
+
+    get kbSyncEnabled()                  { return env.NEO_ORCHESTRATOR_KB_SYNC_ENABLED                     ?? resolveDeploymentEnabled('kbSyncEnabled');                  }
+    get primaryDevSyncEnabled()          { return env.NEO_ORCHESTRATOR_PRIMARY_DEV_SYNC_ENABLED            ?? resolveDeploymentEnabled('primaryDevSyncEnabled');          }
+    get bridgeDaemonEnabled()            { return env.NEO_ORCHESTRATOR_BRIDGE_DAEMON_ENABLED               ?? resolveDeploymentEnabled('bridgeDaemonEnabled');            }
+    get swarmHeartbeatEnabled()          { return env.NEO_ORCHESTRATOR_SWARM_HEARTBEAT_ENABLED             ?? resolveDeploymentEnabled('swarmHeartbeatEnabled');          }
+    get goldenPathRepoEnrichmentEnabled(){ return env.NEO_ORCHESTRATOR_GOLDEN_PATH_REPO_ENRICHMENT_ENABLED ?? resolveDeploymentEnabled('goldenPathRepoEnrichmentEnabled');}
 
     /**
      * Starts the orchestrator process loop after the wrapper has selected this process.
@@ -412,8 +375,8 @@ export class Orchestrator extends Base {
                 await this.swarmHeartbeatService.initAsync({pollIntervalMs: this.swarmHeartbeatIntervalMs});
             } catch (e) {
                 this.writeLog('ERROR', `[Orchestrator] Swarm heartbeat init failed; lane disabled this run: ${e.message}`);
-                // Force-disable for this run by stashing in env; getter will re-read.
-                process.env.NEO_ORCHESTRATOR_SWARM_HEARTBEAT_ENABLED = 'false';
+                // Force-disable for this run by mutating the env registry; getter will re-read.
+                env.NEO_ORCHESTRATOR_SWARM_HEARTBEAT_ENABLED = false;
             }
         }
 

--- a/src/util/Env.mjs
+++ b/src/util/Env.mjs
@@ -9,7 +9,10 @@
  *
  * Decoders know NOTHING about specific configs, defaults, or domain consumers — they only
  * answer "env var absent (undefined) / decoded value / invalid (warn + undefined)". Fallback
- * policy lives at the consumer call-site (e.g., `Env.parseNumber(process.env.X, 'X') ?? AiConfig.X`).
+ * policy lives at the consumer call-site. Prefer a centralized binding registry (e.g.,
+ * `ai/config/env.mjs`) over per-call-site `Env.parseX(process.env.X, 'X')` invocations:
+ * the registry collapses the env-var name into a single declaration so consumers reference
+ * `env.X ?? AiConfig.X` instead of repeating the string literal at every read site.
  *
  * Uses the gatekeep pattern (lightweight stateless utility — no Base inheritance, no
  * reactive configs, no lifecycle hooks), mirroring `src/core/IdGenerator.mjs` precedent.

--- a/test/playwright/unit/ai/config/env.spec.mjs
+++ b/test/playwright/unit/ai/config/env.spec.mjs
@@ -1,0 +1,77 @@
+import {setup} from '../../../setup.mjs';
+
+const appName = 'AiConfigEnvTest';
+
+setup({
+    appConfig: {
+        name: appName
+    }
+});
+
+import {test, expect} from '@playwright/test';
+import Neo            from '../../../../../src/Neo.mjs';
+import * as core      from '../../../../../src/core/_export.mjs';
+import Env            from '../../../../../src/util/Env.mjs';
+import {buildEnv}     from '../../../../../ai/config/env.mjs';
+
+test.describe('ai/config/env (binding registry)', () => {
+    test('absent env var maps to undefined (preserves ?? fallback chain)', () => {
+        const result = buildEnv({
+            bindings: {FOO: Env.parseNumber, BAR: Env.parseBool},
+            source  : {}
+        });
+        expect(result).toEqual({FOO: undefined, BAR: undefined});
+    });
+
+    test('valid env values are parsed per binding parser type', () => {
+        const result = buildEnv({
+            bindings: {COUNT: Env.parseNumber, ENABLED: Env.parseBool},
+            source  : {COUNT: '42', ENABLED: 'true'}
+        });
+        expect(result).toEqual({COUNT: 42, ENABLED: true});
+    });
+
+    test('invalid env values map to undefined (parser warned, ?? still falls through)', () => {
+        const warns  = [];
+        const Parser = (raw, name) => Env.parseNumber(raw, name, (...args) => warns.push(args));
+        const result = buildEnv({
+            bindings: {COUNT: Parser},
+            source  : {COUNT: 'not-a-number'}
+        });
+        expect(result.COUNT).toBeUndefined();
+        expect(warns.length).toBe(1);
+        expect(warns[0][0]).toContain('COUNT');
+    });
+
+    test('explicit ?? fallback still resolves to defaults when registry value is undefined', () => {
+        const registry  = buildEnv({bindings: {LIMIT: Env.parseNumber}, source: {}});
+        const fallback  = 99;
+        expect(registry.LIMIT ?? fallback).toBe(99);
+    });
+
+    test('registry surfaces only declared bindings (no leakage from source env)', () => {
+        const result = buildEnv({
+            bindings: {ONE: Env.parseNumber},
+            source  : {ONE: '1', TWO: '2', NEO_LEAK_TEST: 'leak'}
+        });
+        expect(Object.keys(result)).toEqual(['ONE']);
+        expect(result.ONE).toBe(1);
+    });
+
+    test('mixed parser registry: bool + number coexist in same call', () => {
+        const result = buildEnv({
+            bindings: {
+                NEO_ORCHESTRATOR_POLL_INTERVAL_MS: Env.parseNumber,
+                NEO_ORCHESTRATOR_KB_SYNC_ENABLED : Env.parseBool
+            },
+            source: {
+                NEO_ORCHESTRATOR_POLL_INTERVAL_MS: '5000',
+                NEO_ORCHESTRATOR_KB_SYNC_ENABLED : 'false'
+            }
+        });
+        expect(result).toEqual({
+            NEO_ORCHESTRATOR_POLL_INTERVAL_MS: 5000,
+            NEO_ORCHESTRATOR_KB_SYNC_ENABLED : false
+        });
+    });
+});

--- a/test/playwright/unit/util/Env.spec.mjs
+++ b/test/playwright/unit/util/Env.spec.mjs
@@ -43,7 +43,8 @@ test.describe('Neo.util.Env', () => {
         });
 
         test('?? fallback pattern works correctly with absent input', () => {
-            // The load-bearing consumer pattern: Env.parseNumber(process.env.X, 'X') ?? AiConfig.X
+            // The ?? fallback contract underpinning the consumer pattern (e.g., via the
+            // `ai/config/env.mjs` binding registry): env.X ?? AiConfig.X.
             // This MUST fall through to fallback when env var is absent (NOT NaN, which ?? would skip).
             const fallback = 99;
             expect(Env.parseNumber(undefined, 'X', captureWarn) ?? fallback).toBe(99);


### PR DESCRIPTION
Authored by Claude Opus 4.7 (Claude Code). Session 5572d9a5-558d-4bea-b416-e31496c289c4.

FAIR-band: in-band [verify @ merge-gate]

Resolves #11855 (Sub 14 of Epic #11831)

Evidence: L1 (6/6 new env.spec + 2049/2049 full unit suite, 0 failures) → L1 required for binding-registry extraction (pure-function consumer-pattern collapse; env-registry shape is single eager-bound object). No residuals.

## Summary

Single-source binding registry for all `NEO_ORCHESTRATOR_*` env vars consumed by `Orchestrator.mjs`. Replaces 13 inline `Env.parseX(process.env.NAME, 'NAME') ?? AiConfig.X` call-sites with `env.NAME ?? AiConfig.X`. Adds `dotenv/config` at the registry module load so local `.env` files auto-populate `process.env`.

**Why**: rename drift (change the env-var name in one spot, miss the matching string literal at the consumer); audit opacity (no single file enumerated which env vars the system reads); no `.env` file integration (dotenv was already a devDependency but consumers read `process.env.X` directly).

## New files

- `ai/config/env.mjs` (64 LOC) — `bindings` map (13 NEO_ORCHESTRATOR_* vars + parsers), `buildEnv({bindings, source})` pure function (extracted for testability), default-export `env` object eagerly bound at module load after `dotenv/config`.
- `test/playwright/unit/ai/config/env.spec.mjs` (77 LOC, 6 tests) — `buildEnv` pure-function coverage: absent var → undefined, valid parse, invalid parse + warn, `??` fallback chain, no-leakage from source env, mixed bool+number parsers.

## Touched files

- `ai/daemons/orchestrator/Orchestrator.mjs` (-77 +25 net) — Dropped `import Env`; added `import env from '../../config/env.mjs'`. 13 lazy getters collapsed from 4-line invocations to single-line `env.NAME ?? AiConfig.X` reads. JSDoc Class-D description updated to reflect the new pattern. Line 416 init-failure path: `process.env.NEO_ORCHESTRATOR_SWARM_HEARTBEAT_ENABLED = 'false'` → `env.NEO_ORCHESTRATOR_SWARM_HEARTBEAT_ENABLED = false` (mutates the registry object; getter re-reads).
- `src/util/Env.mjs` — JSDoc updated to point at the registry pattern over the per-call-site `Env.parseX(process.env.X, 'X')` invocation.
- `test/playwright/unit/util/Env.spec.mjs` — Test comment updated for consistency.

## Design choices

**`buildEnv({bindings, source})` pure function** lifted out of the default-export construction so unit tests don't need to fight the module-cache-busting + env-mutation-before-import dance that the eager-bound singleton would otherwise require. The module-level `env` is `buildEnv({bindings})` against `process.env`.

**Registry keyed by env-var name** (`env.NEO_ORCHESTRATOR_KB_SYNC_ENABLED`) not semantic name (`env.kbSyncEnabled`). Per ticket's avoided traps: the semantic mapping is the consumer's call (different consumers may want different defaults via `??`); the registry's job is the typed env-var slot, not the policy.

**Eager binding at module load** preserved per ticket guidance (env vars don't change at runtime in production). The one runtime-mutation site (`swarmHeartbeatEnabled` init-failure path) now mutates the registry object directly — observable behavior identical because the object is mutable and the getter re-reads on every call.

**Scope discipline**: 16 grep matches for `Env.parseX(process.env...)` — 13 in Orchestrator.mjs getters (migrated), 3 in JSDoc/comments (updated). The broader pattern of bare `process.env.NEO_X || default` direct reads in `ai/config.template.mjs`, `ai/daemons/bridge/daemon.mjs`, `KbAlertingService`, `TaskDefinitions.mjs` is out of scope — those follow a different shape (config-source defaults, not consumer fallbacks).

## Test Evidence

- `npm run test-unit -- --grep="ai/config/env"` → **6/6 pass (2.0s)**
- `npm run test-unit -- --grep="ai/config/env|Orchestrator|Env"` → **231 passed, 0 failed (8.7s)**
- `npm run test-unit` (full suite) → **2049 passed, 2 skipped, 6 did not run, 0 failed (56.4s)**

## Post-Merge Validation

- [ ] No behavioral change observable in orchestrator boot or scheduling (consumer pattern preserves `env.X ?? AiConfig.X` chain semantics)
- [ ] Local `.env` files now auto-load via `dotenv/config` — pre-existing prod boots unaffected (no `.env` file present → dotenv silently no-ops)

## AC mapping

| AC | Status |
|----|--------|
| 1. `ai/config/env.mjs` with binding registry covering NEO_* vars discovered via pre-survey | ✓ 13 NEO_ORCHESTRATOR_* vars covered (grep-clean for `Env.parseX(process.env...)` pattern in `ai/`) |
| 2. `dotenv/config` imported at module load — `.env` auto-load | ✓ Line 1 of `ai/config/env.mjs` |
| 3. All consumers migrated from `Env.parseX(process.env.NAME, 'NAME')` → `env.NAME` | ✓ 13/13 getters in Orchestrator.mjs migrated |
| 4. `src/util/Env.mjs:12` JSDoc updated — recommends registry pattern | ✓ JSDoc now points at the binding registry shape |
| 5. Unit test for `ai/config/env.mjs` covering absent/valid/invalid/leakage/mixed-parser paths | ✓ 6 tests cover all required paths; module-cache-busting + .env-load tests deferred per Deltas |
| 6. Zero remaining `Env.parseX(process.env.NAME, 'NAME')` in `ai/` | ✓ `git grep -E "Env\.parse(Bool\|Number\|Port\|Url\|String)\(process\.env" -- 'ai/'` returns 0 |
| 7. All existing unit + integration tests pass | ✓ 2049/2049 full unit suite, 0 failures |

## Deltas from ticket

- AC 5 sub-bullets `.env`-file load + override precedence: those test dotenv's contract, not this PR's code. The `buildEnv({bindings, source})` pure-function shape lets the spec cover the registry logic without re-validating upstream dotenv. If operator wants explicit dotenv-integration tests, separate ticket would add them via `dotenv.config({path})` programmatic API.
- Avoided-trap "Don't pre-suppose the registry's filesystem location": went with the ticket's proposed `ai/config/env.mjs` (sibling to `ai/config.template.mjs` — consistent thematic bucket). Happy to move if operator prefers another path.

## Depends on

Epic #11831. Independent of Sub 19 #11861 (different surface — Sub 19 touches the §E-H methods; Sub 14 touches the §D lazy getters). Either ordering merges cleanly.

## Unblocks

Closes the env-binding anti-pattern that survived the Sub-1 masterclass refactor — completes the Epic #11831 cleanup pass at this layer (Sub 18 #11862 then closes the remaining Round-2 surface).

## Authority

Discussion #11857 Cycle-3.5 graduation + operator architectural ratify. Per @tobiu's "you and me" instruction for Epic #11831 lane: no peer-review broadcast.