### PR TITLE
fix(ai): route heartbeat through active wake subscriptions (#11872)

### DIFF
--- a/ai/daemons/orchestrator/services/SwarmHeartbeatService.mjs
+++ b/ai/daemons/orchestrator/services/SwarmHeartbeatService.mjs
@@ -36,6 +36,7 @@ const __dirname  = path.dirname(__filename);
 
 const DEFAULT_POLL_INTERVAL_MS = 5 * 60 * 1000;
 const DEFAULT_IDENTITY         = '@neo-gemini-3-1-pro';
+const PUSH_CAPABLE_TARGETS     = Object.freeze(['mcp-notifications', 'a2a-webhook', 'bridge-daemon']);
 
 /**
  * @summary Neo-singleton swarm-heartbeat lane for the Phase 1/3 wake substrate.
@@ -95,6 +96,9 @@ class SwarmHeartbeatService extends Base {
         isInitialized_: false,
         /**
          * Identity this lane polls for (e.g. `@neo-gemini-3-1-pro`).
+         * Kept as the primary fallback / tmux identity. Active WAKE_SUBSCRIPTION
+         * identities are discovered per pulse so the Orchestrator is not bound to
+         * the identity of the harness that launched it (#11872).
          * @member {String|null} identity_=null
          * @protected
          * @reactive
@@ -155,10 +159,13 @@ class SwarmHeartbeatService extends Base {
      *      - sunset=true + gate-open → fresh-session-spawn via `resumeHarness.mjs` direct export.
      *      - sunset=true + gate-closed → log + skip (no spawn).
      *      - recommended_action=idle_out_nudge + gate-open → `idleOutNudge.mjs`.
+     *      - runs for the primary identity plus every active WAKE_SUBSCRIPTION
+     *        identity, so Codex/Claude/Gemini routes are monitored by subscription
+     *        reality rather than by the Orchestrator process owner's env var (#11872).
      *   4. All-agent-idle detection via `checkAllAgentIdle.mjs` direct export.
      *      - allIdle=true + gate-open → `trioWakeCooldown.mjs` direct export.
      *   5. Heartbeat-bypass detection: identities with push-capable subscriptions
-     *      (mcp-notifications / a2a-webhook) skip the token-economy fast-path because
+     *      (mcp-notifications / a2a-webhook / bridge-daemon) skip the token-economy fast-path because
      *      they receive wakes via push.
      *   6. Token-economy gate: skip pulse if mailbox unread + open issues both zero.
      *   7. Tmux-inject pulse prompt to `$TMUX_SESSION` (preserved from shell shape).
@@ -195,34 +202,36 @@ class SwarmHeartbeatService extends Base {
             logger.error('[SwarmHeartbeatService] sweepExpiredTasks failed:', err)
         }
 
-        // Step 3: Sunset detection (direct module export; CLI wrapper preserved for shell consumers).
-        const sunsetJson = await this.checkSunsetted(this.identity);
-        if (sunsetJson?.sunsetted) {
-            if (!await this.checkGateOpen()) {
-                const gateState = await this.readGate();
-                logger.warn(`[SwarmHeartbeatService] Wake safety gate closed; skipping fresh-session-spawn for ${this.identity}. Sunset reason: ${sunsetJson.reason}. Gate reason: ${gateState.reason}`);
-                return
+        // Step 3: Sunset / idle-out detection (direct module exports; CLI wrappers preserved for shell consumers).
+        const pulseIdentities = await this.getPulseIdentities();
+        for (const identity of pulseIdentities) {
+            const sunsetJson = await this.checkSunsetted(identity);
+            if (sunsetJson?.sunsetted) {
+                if (!await this.checkGateOpen()) {
+                    const gateState = await this.readGate();
+                    logger.warn(`[SwarmHeartbeatService] Wake safety gate closed; skipping fresh-session-spawn for ${identity}. Sunset reason: ${sunsetJson.reason}. Gate reason: ${gateState.reason}`);
+                    continue
+                }
+                logger.info(`[SwarmHeartbeatService] Phase 1 Recovery Triggered for ${identity}. Reason: ${sunsetJson.reason}`);
+                await this.resumeHarness(
+                    identity,
+                    sunsetJson.reason || '',
+                    sunsetJson.originSessionId || '',
+                    sunsetJson.abandonedCount || 0
+                );
+                continue
             }
-            logger.info(`[SwarmHeartbeatService] Phase 1 Recovery Triggered for ${this.identity}. Reason: ${sunsetJson.reason}`);
-            await this.resumeHarness(
-                this.identity,
-                sunsetJson.reason || '',
-                sunsetJson.originSessionId || '',
-                sunsetJson.abandonedCount || 0
-            );
-            return
-        }
 
-        const recommendedAction = sunsetJson?.recommended_action || 'no_action';
-        if (recommendedAction === 'idle_out_nudge') {
-            if (!await this.checkGateOpen()) {
-                const gateState = await this.readGate();
-                logger.warn(`[SwarmHeartbeatService] Wake safety gate closed; skipping idle-out nudge for ${this.identity}. Gate reason: ${gateState.reason}`);
-                return
+            const recommendedAction = sunsetJson?.recommended_action || 'no_action';
+            if (recommendedAction === 'idle_out_nudge') {
+                if (!await this.checkGateOpen()) {
+                    const gateState = await this.readGate();
+                    logger.warn(`[SwarmHeartbeatService] Wake safety gate closed; skipping idle-out nudge for ${identity}. Gate reason: ${gateState.reason}`);
+                    continue
+                }
+                logger.info(`[SwarmHeartbeatService] Idle-out nudge triggered for ${identity}`);
+                await this.idleOutNudge(identity)
             }
-            logger.info(`[SwarmHeartbeatService] Idle-out nudge triggered for ${this.identity}`);
-            await this.idleOutNudge(this.identity);
-            return
         }
 
         // Step 4: All-agent-idle detection. `checkAllAgentIdle.mjs` owns the
@@ -401,6 +410,71 @@ class SwarmHeartbeatService extends Base {
     }
 
     /**
+     * @summary Resolves the per-pulse identity set from the primary fallback plus active wake subscriptions.
+     *
+     * `NEO_AGENT_IDENTITY` identifies the daemon/harness process owner; it must not
+     * be the exclusive set of wake targets. The subscription graph is the live route
+     * truth for desktop agents, so active `WAKE_SUBSCRIPTION` identities are swept on
+     * every pulse (#11872).
+     *
+     * @returns {Promise<String[]>}
+     * @protected
+     */
+    async getPulseIdentities() {
+        const identities = new Set();
+
+        if (this.identity) {
+            identities.add(this.identity)
+        }
+
+        for (const identity of await this.getWakeSubscriptionIdentities()) {
+            identities.add(identity)
+        }
+
+        if (identities.size === 0) {
+            identities.add(DEFAULT_IDENTITY)
+        }
+
+        return Array.from(identities)
+    }
+
+    /**
+     * SQLite query: active `WAKE_SUBSCRIPTION` identities that can receive an in-place wake.
+     * @returns {Promise<String[]>}
+     * @protected
+     */
+    async getWakeSubscriptionIdentities() {
+        try {
+            const db = this.getGraphDb();
+            const stmt = db.prepare(`
+                SELECT DISTINCT json_extract(data, '$.properties.agentIdentity') as identity
+                FROM Nodes
+                WHERE json_extract(data, '$.label') = 'WAKE_SUBSCRIPTION'
+                  AND json_extract(data, '$.properties.trigger') = 'SENT_TO_ME'
+                  AND COALESCE(json_extract(data, '$.properties.status'), 'active') = 'active'
+                  AND COALESCE(json_extract(data, '$.properties.harnessTarget'), '') != 'disabled'
+                  AND json_extract(data, '$.properties.agentIdentity') IS NOT NULL
+            `);
+            return stmt.all()
+                .map(row => row.identity)
+                .filter(Boolean)
+                .map(identity => normalizeAgentIdentityNodeId(identity))
+        } catch (err) {
+            logger.error('[SwarmHeartbeatService] getWakeSubscriptionIdentities failed:', err);
+            return []
+        }
+    }
+
+    /**
+     * Test-stubbable seam over the SDK GraphService database handle.
+     * @returns {Object} better-sqlite3 database handle
+     * @protected
+     */
+    getGraphDb() {
+        return GraphService.db.storage.db
+    }
+
+    /**
      * SQLite query: count of unread MESSAGE-label nodes addressed to the polled identity.
      * Direct DMs use MESSAGE.properties.readAt; #11029 broadcasts use per-recipient
      * DELIVERED_TO.readAt edges, with a legacy fallback for old broadcasts lacking receipts.
@@ -409,7 +483,7 @@ class SwarmHeartbeatService extends Base {
      */
     async getUnreadCount() {
         try {
-            const db = GraphService.db.storage.db;
+            const db = this.getGraphDb();
             const stmt = db.prepare(`
                 WITH unread_messages AS (
                     SELECT n.id AS messageId
@@ -473,23 +547,24 @@ class SwarmHeartbeatService extends Base {
 
     /**
      * Check whether the polled identity has a push-capable subscription
-     * (`harnessTarget IN ('mcp-notifications', 'a2a-webhook')` and not `degraded`).
+     * (`harnessTarget IN ('mcp-notifications', 'a2a-webhook', 'bridge-daemon')` and not `degraded`).
      * @param {String} identity
      * @returns {Promise<Boolean>}
      * @protected
      */
     async isPushCapable(identity) {
         try {
-            const db = GraphService.db.storage.db;
+            const db = this.getGraphDb();
             const stmt = db.prepare(`
                 SELECT count(*) as count
                 FROM Nodes
                 WHERE json_extract(data, '$.label') = 'WAKE_SUBSCRIPTION'
                   AND json_extract(data, '$.properties.agentIdentity') = ?
-                  AND json_extract(data, '$.properties.harnessTarget') IN ('mcp-notifications', 'a2a-webhook')
+                  AND json_extract(data, '$.properties.trigger') = 'SENT_TO_ME'
+                  AND json_extract(data, '$.properties.harnessTarget') IN (${PUSH_CAPABLE_TARGETS.map(() => '?').join(', ')})
                   AND COALESCE(json_extract(data, '$.properties.status'), 'active') != 'degraded'
             `);
-            const row = stmt.get(identity);
+            const row = stmt.get(identity, ...PUSH_CAPABLE_TARGETS);
             return (row?.count || 0) > 0
         } catch (err) {
             logger.error('[SwarmHeartbeatService] isPushCapable query failed:', err);

--- a/learn/agentos/wake-substrate/NightShiftLeasedDriver.md
+++ b/learn/agentos/wake-substrate/NightShiftLeasedDriver.md
@@ -117,6 +117,12 @@ mailbox prose.
 idle-out recovery. This contract owns lane-driver responsibility. Do not create
 a second heartbeat primitive for #10763.
 
+Wake-recipient coverage is subscription-derived: the Orchestrator heartbeat
+sweeps active `WAKE_SUBSCRIPTION` identities per pulse. A maintainer harness is
+night-shift reachable only when its route is active and Memory Core healthcheck
+shows a fresh heartbeat pulse; route presence alone means the bridge can receive
+A2A messages, not that the watchdog lane is currently running.
+
 ## 7. Minimal Message Shape
 
 Lane claim:

--- a/learn/agentos/wake-substrate/PersistentProcessManagement.md
+++ b/learn/agentos/wake-substrate/PersistentProcessManagement.md
@@ -84,7 +84,16 @@ A healthy idle heartbeat lane may emit nothing for many cycles in a row (no expi
 
 > ⚠️ **Lock-as-evidence anti-pattern:** the file `.neo-ai-data/heartbeat-concurrency.lock` is **producer-side state** — created by `acquireHeartbeatLock` when expensive agent work starts (#10319 `withHeartbeatLock`), removed when that work finishes. The heartbeat lane only *inspects + releases stale locks*, never touches it on healthy idle pulses. **Do not watch the lock's mtime as a polling-health indicator** — a healthy lane may go hours without touching it.
 
-### 3b. Healthcheck-side verification (#10783)
+### 3b. Verify active wake-recipient coverage
+
+The Orchestrator heartbeat process identity is not the wake-recipient set. Each pulse sweeps the primary fallback identity plus active `WAKE_SUBSCRIPTION` identities, so desktop harnesses that are currently reachable through `bridge-daemon`, `mcp-notifications`, or `a2a-webhook` are part of sunset / idle-out detection even when the Orchestrator daemon was launched by another agent identity.
+
+For night-shift readiness, verify both layers:
+
+- **Route layer:** `manage_wake_subscription({action: 'list'})` shows an active subscription for each intended maintainer identity. For Codex Desktop, the target is typically `harnessTarget: 'bridge-daemon'` with `harnessTargetMetadata.appName: 'Codex'`.
+- **Pulse layer:** Memory Core healthcheck reports `features.wake.daemonRunning: true` and a recent `lastPulseAt`. An active Codex route with a stale heartbeat means the bridge can receive A2A messages, but the Orchestrator is not currently driving the watchdog lane.
+
+### 3c. Healthcheck-side verification (#10783)
 
 For a single-call observability check, the Memory Core healthcheck surfaces the wake substrate's operational dimensions in one block. Call any healthcheck-emitting tool (e.g. `mcp__neo-mjs-memory-core__healthcheck`) and inspect the `features.wake` block:
 

--- a/test/playwright/unit/ai/daemons/orchestrator/services/SwarmHeartbeatService.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/services/SwarmHeartbeatService.spec.mjs
@@ -51,6 +51,7 @@ import {test, expect} from '@playwright/test';
  */
 test.describe('Neo.ai.daemons.SwarmHeartbeatService', () => {
     let SwarmHeartbeatService;
+    let GraphService;
     let originalLifecycleInit;
     let originalGraphServiceInit;
 
@@ -59,7 +60,7 @@ test.describe('Neo.ai.daemons.SwarmHeartbeatService', () => {
 
         const services = await import('../../../../../../../ai/services.mjs');
         const LifecycleService = services.Memory_LifecycleService;
-        const GraphService     = services.Memory_GraphService;
+        GraphService           = services.Memory_GraphService;
 
         originalLifecycleInit    = LifecycleService.initAsync;
         originalGraphServiceInit = GraphService.initAsync;
@@ -96,9 +97,11 @@ test.describe('Neo.ai.daemons.SwarmHeartbeatService', () => {
         SwarmHeartbeatService.idleOutNudge       = async () => {};
         SwarmHeartbeatService.checkAllAgentIdle  = async () => null;
         SwarmHeartbeatService.trioWakeCooldown   = async () => {};
+        SwarmHeartbeatService.getWakeSubscriptionIdentities = async () => [];
         SwarmHeartbeatService.runScriptJson      = async () => null;
         SwarmHeartbeatService.runScript          = async () => '';
         SwarmHeartbeatService.runCmd             = async () => '[]';
+        delete SwarmHeartbeatService.getGraphDb;
         SwarmHeartbeatService.getUnreadCount     = async () => 0;
         SwarmHeartbeatService.getIssuesCount     = async () => 0;
         SwarmHeartbeatService.isPushCapable      = async () => false;
@@ -110,6 +113,7 @@ test.describe('Neo.ai.daemons.SwarmHeartbeatService', () => {
         SwarmHeartbeatService.isInitialized  = false;
         SwarmHeartbeatService.identity       = null;
         SwarmHeartbeatService.pollIntervalMs = 5 * 60 * 1000;
+        delete SwarmHeartbeatService.getGraphDb;
     });
 
     test('initAsync() is idempotent — second call is a no-op once initialized', async () => {
@@ -235,10 +239,11 @@ test.describe('Neo.ai.daemons.SwarmHeartbeatService', () => {
     test('pulse() routes idle_out_nudge when gate is open and recommendation matches', async () => {
         applyDefaultStubs();
         const nudgeCalls = [];
-        SwarmHeartbeatService.checkSunsetted = async () => {
+        SwarmHeartbeatService.checkSunsetted = async (identity) => {
             return {
+                identity,
                 sunsetted          : false,
-                recommended_action : 'idle_out_nudge'
+                recommended_action : identity === '@test' ? 'idle_out_nudge' : 'no_action'
             };
         };
         SwarmHeartbeatService.idleOutNudge = async (...args) => { nudgeCalls.push(args) };
@@ -247,6 +252,44 @@ test.describe('Neo.ai.daemons.SwarmHeartbeatService', () => {
 
         expect(nudgeCalls.length).toBe(1);
         expect(nudgeCalls[0]).toEqual(['@test']);
+    });
+
+    test('pulse() checks active WAKE_SUBSCRIPTION identities in addition to the primary identity (#11872)', async () => {
+        applyDefaultStubs();
+
+        const sunsetChecks = [];
+        SwarmHeartbeatService.getWakeSubscriptionIdentities = async () => ['@neo-opus-4-7', '@neo-gpt', '@neo-gpt'];
+        SwarmHeartbeatService.checkSunsetted = async (identity) => {
+            sunsetChecks.push(identity);
+            return {sunsetted: false, recommended_action: 'no_action'};
+        };
+
+        await SwarmHeartbeatService.pulse();
+
+        expect(sunsetChecks).toEqual(['@test', '@neo-opus-4-7', '@neo-gpt']);
+    });
+
+    test('getWakeSubscriptionIdentities() normalizes active subscription identities and filters disabled routes (#11872)', async () => {
+        applyDefaultStubs();
+
+        SwarmHeartbeatService.getGraphDb = () => {
+            return {
+                prepare: () => ({
+                    all: () => [
+                        {identity: 'neo-gpt'},
+                        {identity: '@neo-opus-4-7'},
+                        {identity: null}
+                    ]
+                })
+            }
+        };
+
+        const serviceProto = Object.getPrototypeOf(SwarmHeartbeatService);
+
+        await expect(serviceProto.getWakeSubscriptionIdentities.call(SwarmHeartbeatService)).resolves.toEqual([
+            '@neo-gpt',
+            '@neo-opus-4-7'
+        ]);
     });
 
     test('pulse() skips idle_out_nudge when gate is closed', async () => {
@@ -345,6 +388,29 @@ test.describe('Neo.ai.daemons.SwarmHeartbeatService', () => {
         await SwarmHeartbeatService.pulse();
         // Push-capable bypass — no tmux injection even with high unread count.
         expect(injected.length).toBe(0);
+    });
+
+    test('isPushCapable() treats bridge-daemon as push-capable so Codex does not fall through to tmux (#11872)', async () => {
+        applyDefaultStubs();
+
+        const capturedArgs = [];
+        SwarmHeartbeatService.getGraphDb = () => {
+            return {
+                prepare: () => {
+                    return {
+                        get: (...args) => {
+                            capturedArgs.push(args);
+                            return {count: 1}
+                        }
+                    }
+                }
+            }
+        };
+
+        const serviceProto = Object.getPrototypeOf(SwarmHeartbeatService);
+
+        await expect(serviceProto.isPushCapable.call(SwarmHeartbeatService, '@neo-gpt')).resolves.toBe(true);
+        expect(capturedArgs[0]).toEqual(['@neo-gpt', 'mcp-notifications', 'a2a-webhook', 'bridge-daemon']);
     });
 
     test('pulse() includes expired-count in prompt when sweep yields > 0', async () => {


### PR DESCRIPTION
Related: #11872

Authored by GPT-5 (Codex Desktop). Session 967e325b-d90a-43f4-9e91-c212e9bda746.
FAIR-band: under-target [7/30] - Self-Selection Rule 1 fires (under-band -> bias toward author lane)

Routes the Orchestrator swarm-heartbeat lane through active `SENT_TO_ME` wake subscriptions instead of treating the daemon process identity as the only wake target. This lets an active @neo-gpt Codex bridge route participate in sunset / idle-out detection when the Orchestrator was launched under another agent identity, and it treats `bridge-daemon` as push-capable so Codex no longer falls through to the tmux fallback.

Evidence: L2 (focused unit coverage for active subscription sweep plus bridge-daemon push-capable bypass) -> L4 required (operator-host nightshift proof that Orchestrator wakes Codex and the temporary Codex heartbeat automation can be retired). Residual: AC6 [#11872].

## Deltas from ticket
- Implements the durable code-side route inside the existing #10671 / #11766 heartbeat lane; no second heartbeat primitive.
- Adds a `getGraphDb()` test seam so SQL route checks stay unit-testable without mutating the SDK-safe GraphService proxy.
- Keeps Claude core.Base cleanup out of scope; this PR only changes wake-recipient discovery and bridge-daemon bypass behavior.
- Leaves the local Codex heartbeat automation as a temporary operational workaround until L4 validation proves it can be disabled.

## Slot Rationale
- `learn/agentos/wake-substrate/PersistentProcessManagement.md`: disposition `keep`; trigger frequency low-to-medium (night-shift readiness checks), failure severity high (silent watchdog absence), enforceability human/operator runbook. Modified section adds route-layer vs pulse-layer verification.
- `learn/agentos/wake-substrate/NightShiftLeasedDriver.md`: disposition `keep`; trigger frequency low-to-medium (watchdog / driver-lease boundaries), failure severity high, enforceability reviewer/operator discipline. Modified section clarifies that route presence alone is not heartbeat freshness.

Decision Record impact: no ADR update. The change aligns with ADR 0002 wake-substrate routing and ADR 0014 local-only swarm-heartbeat classification.

## Test Evidence
- `node --check ai/daemons/orchestrator/services/SwarmHeartbeatService.mjs`
- `node --check test/playwright/unit/ai/daemons/orchestrator/services/SwarmHeartbeatService.spec.mjs`
- `npm run test-unit -- test/playwright/unit/ai/daemons/orchestrator/services/SwarmHeartbeatService.spec.mjs` -> 19 passed (871ms)
- `git diff --check origin/dev...HEAD`
- Freshness: `merge-base HEAD origin/dev == origin/dev` after rebase onto `fd332746b`.

## Post-Merge Validation
- [ ] Restart or observe the operator-host Orchestrator heartbeat and confirm `features.wake.daemonRunning: true` plus a recent `lastPulseAt`.
- [ ] With @neo-gpt active bridge subscription, verify the heartbeat pulse sweeps @neo-gpt and routes idle-out through A2A / bridge-daemon without relying on the Codex heartbeat automation.
- [ ] Pause or retire temporary Codex `nightshift-lifecycle-driver` only after Orchestrator delivery is proven, to avoid duplicate pings.

## Commits
- `4d0594222` - `fix(ai): route heartbeat through active wake subscriptions (#11872)`