### PR TITLE
feat(kb): add tenant repo access contract (#11787)

### DIFF
--- a/ai/services/knowledge-base/KnowledgeBaseIngestionService.mjs
+++ b/ai/services/knowledge-base/KnowledgeBaseIngestionService.mjs
@@ -6,6 +6,8 @@ import KBRecorderService     from './KBRecorderService.mjs';
 import RequestContextService,
        {normalizeUserId}    from '../../mcp/server/shared/services/RequestContextService.mjs';
 import SourceRegistry        from './source/_export.mjs';
+import {normalizeTenantRepoConfig}
+                             from './helpers/TenantRepoAccessContract.mjs';
 import VectorService         from './VectorService.mjs';
 import aiConfig              from '../../mcp/server/knowledge-base/config.mjs';
 import crypto                from 'crypto';
@@ -808,7 +810,8 @@ class KnowledgeBaseIngestionService extends Base {
                 useDefaultParsers: p.useDefaultParsers !== false,
                 customSources    : p.customSources || [],
                 customParsers    : p.customParsers || [],
-                sourcePaths      : p.sourcePaths    || {}
+                sourcePaths      : p.sourcePaths    || {},
+                tenantRepos      : p.tenantRepos    || []
             };
         }
 
@@ -816,28 +819,34 @@ class KnowledgeBaseIngestionService extends Base {
         const bootstrap = this.readKbConfigBootstrap()?.tenants?.[resolvedTenant];
 
         if (bootstrap) {
+            const normalizedBootstrap = normalizeTenantRepoConfig(bootstrap);
+
             return {
                 tenantId         : resolvedTenant,
                 source           : 'yaml',
                 version          : 0,
-                useDefaultSources: bootstrap.useDefaultSources !== false,
-                useDefaultParsers: bootstrap.useDefaultParsers !== false,
-                customSources    : bootstrap.customSources || [],
-                customParsers    : bootstrap.customParsers || [],
-                sourcePaths      : bootstrap.sourcePaths    || {}
+                useDefaultSources: normalizedBootstrap.useDefaultSources !== false,
+                useDefaultParsers: normalizedBootstrap.useDefaultParsers !== false,
+                customSources    : normalizedBootstrap.customSources || [],
+                customParsers    : normalizedBootstrap.customParsers || [],
+                sourcePaths      : normalizedBootstrap.sourcePaths    || {},
+                tenantRepos      : normalizedBootstrap.tenantRepos    || []
             };
         }
 
         // Tier 3 — default source/parser registry.
+        const normalizedAiConfig = normalizeTenantRepoConfig(aiConfig);
+
         return {
             tenantId         : resolvedTenant,
             source           : 'default',
             version          : 0,
-            useDefaultSources: aiConfig.useDefaultSources !== false,
-            useDefaultParsers: aiConfig.useDefaultParsers !== false,
-            customSources    : aiConfig.customSources || [],
-            customParsers    : aiConfig.customParsers || [],
-            sourcePaths      : aiConfig.sourcePaths    || {}
+            useDefaultSources: normalizedAiConfig.useDefaultSources !== false,
+            useDefaultParsers: normalizedAiConfig.useDefaultParsers !== false,
+            customSources    : normalizedAiConfig.customSources || [],
+            customParsers    : normalizedAiConfig.customParsers || [],
+            sourcePaths      : normalizedAiConfig.sourcePaths    || {},
+            tenantRepos      : normalizedAiConfig.tenantRepos    || []
         };
     }
 
@@ -888,7 +897,8 @@ class KnowledgeBaseIngestionService extends Base {
      */
     async setTenantConfig({tenantId, config = {}} = {}) {
         try {
-            const {tenantId: resolvedTenant} = this.resolveTenantContext({tenantId});
+            const {tenantId: resolvedTenant} = this.resolveTenantContext({tenantId}),
+                  normalizedConfig           = normalizeTenantRepoConfig(config);
 
             await this.graphService.initAsync();
 
@@ -901,11 +911,12 @@ class KnowledgeBaseIngestionService extends Base {
                 type      : 'KnowledgeBaseTenantConfig',
                 properties: {
                     tenantId         : resolvedTenant,
-                    useDefaultSources: config.useDefaultSources !== false,
-                    useDefaultParsers: config.useDefaultParsers !== false,
-                    customSources    : config.customSources || [],
-                    customParsers    : config.customParsers || [],
-                    sourcePaths      : config.sourcePaths    || {},
+                    useDefaultSources: normalizedConfig.useDefaultSources !== false,
+                    useDefaultParsers: normalizedConfig.useDefaultParsers !== false,
+                    customSources    : normalizedConfig.customSources || [],
+                    customParsers    : normalizedConfig.customParsers || [],
+                    sourcePaths      : normalizedConfig.sourcePaths    || {},
+                    tenantRepos      : normalizedConfig.tenantRepos    || [],
                     version,
                     visibility       : 'team'
                 }

--- a/ai/services/knowledge-base/helpers/TenantRepoAccessContract.mjs
+++ b/ai/services/knowledge-base/helpers/TenantRepoAccessContract.mjs
@@ -1,0 +1,319 @@
+import path from 'path';
+
+/**
+ * @summary Normalizes and guards tenant repo-access config entries for server-side KB ingestion.
+ *
+ * The tenant repo-sync lane (#11731) intentionally separates clean repository identity from
+ * credential material. A tenant config entry may name a `credentialRef`, but `cloneUrl` and
+ * `repoSlug` must stay safe for graph persistence, logs, and telemetry. Git credentials are
+ * injected later by the Git mirror worker (#11788), not stored in the Knowledge Base config node.
+ *
+ * @see https://github.com/neomjs/neo/issues/11787
+ */
+
+const URL_WITH_USERINFO_RE = /^[a-z][a-z0-9+.-]*:\/\/[^/\s@]+@/iu;
+const SCP_LIKE_USERINFO_RE = /^[^/\s@:]+@[^/\s@:]+:/u;
+const SECRET_REPLACEMENT   = '[REDACTED]';
+
+/**
+ * @summary Creates a contract error with a stable code for callers and tests.
+ * @param {String} code Stable error code.
+ * @param {String} message Human-readable error message.
+ * @returns {Error}
+ * @private
+ */
+function createContractError(code, message) {
+    const error = new Error(message);
+
+    error.code = code;
+
+    return error;
+}
+
+/**
+ * @summary Escapes a string for safe literal use inside a regular expression.
+ * @param {String} value String to escape.
+ * @returns {String}
+ * @private
+ */
+function escapeRegExp(value) {
+    return value.replace(/[.*+?^${}()|[\]\\]/gu, '\\$&');
+}
+
+/**
+ * @summary Strips the terminal `.git` suffix and surrounding slashes from a repo identity segment.
+ * @param {String} value Repo identity candidate.
+ * @returns {String}
+ * @private
+ */
+function stripRepoSuffix(value) {
+    return value.replace(/^\/+/u, '').replace(/\/+$/u, '').replace(/\.git$/iu, '');
+}
+
+/**
+ * @summary Normalizes one path segment used in tenant repo mirror paths.
+ * @param {String} value Segment candidate.
+ * @param {String} code Stable error code.
+ * @param {String} label Human-readable segment label.
+ * @returns {String}
+ * @private
+ */
+function normalizeMirrorPathSegment(value, code, label) {
+    const segment = String(value || '').trim();
+
+    if (
+        !segment ||
+        segment === '.' ||
+        segment === '..' ||
+        segment.includes('/') ||
+        segment.includes('\\') ||
+        segment.includes('@') ||
+        segment.includes(':') ||
+        /\s/u.test(segment)
+    ) {
+        throw createContractError(code, `Tenant repo mirror path requires a clean ${label}`);
+    }
+
+    return segment;
+}
+
+/**
+ * @summary Returns true when a clone URL embeds userinfo that could carry credentials.
+ * @param {String} cloneUrl Candidate clone URL.
+ * @returns {Boolean}
+ */
+export function hasCloneUrlUserInfo(cloneUrl) {
+    const value = String(cloneUrl || '').trim();
+
+    return URL_WITH_USERINFO_RE.test(value) || SCP_LIKE_USERINFO_RE.test(value);
+}
+
+/**
+ * @summary Throws when a clone URL contains credential-shaped material.
+ * @param {String} cloneUrl Candidate clone URL.
+ * @returns {String} Trimmed clone URL.
+ */
+export function assertCleanCloneUrl(cloneUrl) {
+    const value = String(cloneUrl || '').trim();
+
+    if (!value) {
+        throw createContractError(
+            'KB_TENANT_REPO_CLONE_URL_REQUIRED',
+            'Tenant repo config requires a non-empty cloneUrl'
+        );
+    }
+
+    if (hasCloneUrlUserInfo(value)) {
+        throw createContractError(
+            'KB_TENANT_REPO_CLONE_URL_CREDENTIALS',
+            'Tenant repo cloneUrl must not embed userinfo or credentials'
+        );
+    }
+
+    if (/[?#]/u.test(value)) {
+        throw createContractError(
+            'KB_TENANT_REPO_CLONE_URL_CREDENTIALS',
+            'Tenant repo cloneUrl must not include query strings or fragments'
+        );
+    }
+
+    return value;
+}
+
+/**
+ * @summary Derives a deterministic, credential-free repo slug from a clean clone URL.
+ *
+ * The output is `host/org/repo` for URL-style clone URLs, or `host/path` for clean scp-like
+ * clone strings. Caller-provided `repoSlug` values pass through {@link normalizeRepoSlug}
+ * instead; this helper only fills the omission case.
+ *
+ * @param {String} cloneUrl Clean clone URL.
+ * @returns {String}
+ */
+export function deriveRepoSlugFromCloneUrl(cloneUrl) {
+    const value = assertCleanCloneUrl(cloneUrl);
+
+    try {
+        const url = new URL(value);
+
+        if (!url.hostname || !url.pathname || url.pathname === '/') {
+            throw new Error('missing repo path');
+        }
+
+        return normalizeRepoSlug(`${url.hostname}/${stripRepoSuffix(url.pathname)}`);
+    } catch (error) {
+        const scpLike = value.match(/^([^/\s@:]+):(.+)$/u);
+
+        if (scpLike) {
+            return normalizeRepoSlug(`${scpLike[1]}/${stripRepoSuffix(scpLike[2])}`);
+        }
+
+        throw createContractError(
+            'KB_TENANT_REPO_CLONE_URL_INVALID',
+            'Tenant repo cloneUrl must be a clean URL or host:path git reference'
+        );
+    }
+}
+
+/**
+ * @summary Normalizes a repo slug while keeping it safe for graph persistence and logs.
+ * @param {String} repoSlug Repo slug candidate.
+ * @returns {String}
+ */
+export function normalizeRepoSlug(repoSlug) {
+    const value = stripRepoSuffix(String(repoSlug || '').trim());
+
+    if (!value) {
+        throw createContractError(
+            'KB_TENANT_REPO_SLUG_REQUIRED',
+            'Tenant repo config requires a repoSlug or derivable cloneUrl'
+        );
+    }
+
+    if (
+        value.includes('://') ||
+        value.includes('@') ||
+        value.includes(':') ||
+        value.includes('..') ||
+        value.startsWith('/') ||
+        value.includes('\\') ||
+        /[\s?#]/u.test(value)
+    ) {
+        throw createContractError(
+            'KB_TENANT_REPO_SLUG_INVALID',
+            'Tenant repo repoSlug must be a clean repository identity'
+        );
+    }
+
+    return value;
+}
+
+/**
+ * @summary Normalizes one tenant repo-access config entry and enforces the no-secret boundary.
+ * @param {Object} entry Tenant repo-access config entry.
+ * @returns {{cloneUrl: String, credentialRef: String|Object, repoSlug: String}}
+ */
+export function normalizeTenantRepoEntry(entry = {}) {
+    if (!entry || typeof entry !== 'object' || Array.isArray(entry)) {
+        throw createContractError(
+            'KB_TENANT_REPO_ENTRY_INVALID',
+            'Tenant repo config entries must be objects'
+        );
+    }
+
+    const cloneUrl = assertCleanCloneUrl(entry.cloneUrl);
+
+    if (!entry.credentialRef) {
+        throw createContractError(
+            'KB_TENANT_REPO_CREDENTIAL_REF_REQUIRED',
+            'Tenant repo config entries require credentialRef'
+        );
+    }
+
+    return {
+        ...entry,
+        cloneUrl,
+        credentialRef: entry.credentialRef,
+        repoSlug     : entry.repoSlug ? normalizeRepoSlug(entry.repoSlug) : deriveRepoSlugFromCloneUrl(cloneUrl)
+    };
+}
+
+/**
+ * @summary Normalizes an optional `tenantRepos` config array.
+ * @param {Object} config Tenant KB config payload.
+ * @returns {Object}
+ */
+export function normalizeTenantRepoConfig(config = {}) {
+    if (!Object.hasOwn(config, 'tenantRepos')) {
+        return config;
+    }
+
+    if (!Array.isArray(config.tenantRepos)) {
+        throw createContractError(
+            'KB_TENANT_REPOS_INVALID',
+            'Tenant repo config tenantRepos must be an array'
+        );
+    }
+
+    return {
+        ...config,
+        tenantRepos: config.tenantRepos.map(entry => normalizeTenantRepoEntry(entry))
+    };
+}
+
+/**
+ * @summary Derives the credential-free local mirror path for a tenant repo.
+ *
+ * This helper intentionally only maps already-normalized identity values to a filesystem path.
+ * Git clone/fetch lifecycle and credential injection remain owned by the Git mirror primitive (#11788).
+ *
+ * @param {Object} data
+ * @param {String} data.mirrorRoot Root directory for tenant repo mirrors.
+ * @param {String} data.tenantId Tenant id.
+ * @param {String} data.repoSlug Clean repo slug.
+ * @returns {String}
+ */
+export function deriveTenantRepoMirrorPath({mirrorRoot, tenantId, repoSlug} = {}) {
+    const root = String(mirrorRoot || '').trim();
+
+    if (!root) {
+        throw createContractError(
+            'KB_TENANT_REPO_MIRROR_ROOT_REQUIRED',
+            'Tenant repo mirror path requires mirrorRoot'
+        );
+    }
+
+    const tenantSegment = normalizeMirrorPathSegment(
+        tenantId,
+        'KB_TENANT_REPO_MIRROR_TENANT_INVALID',
+        'tenantId'
+    );
+    const repoSegments = normalizeRepoSlug(repoSlug)
+        .split('/')
+        .map(segment => normalizeMirrorPathSegment(
+            segment,
+            'KB_TENANT_REPO_MIRROR_REPO_INVALID',
+            'repoSlug segment'
+        ));
+
+    return path.join(root, 'tenant-repos', tenantSegment, ...repoSegments);
+}
+
+/**
+ * @summary Redacts tenant repo credentials from strings or structured log payloads.
+ *
+ * This is deliberately small: it strips URL/scp-style userinfo and replaces explicit secret hints.
+ * The helper is for defensive log formatting; credential acquisition remains outside this module.
+ *
+ * @param {*} input String, array, object, or primitive to redact.
+ * @param {Object} [options]
+ * @param {String[]} [options.secretHints] Optional known secret values to replace.
+ * @returns {*} A redacted copy of `input`.
+ */
+export function redactTenantRepoSecrets(input, {secretHints = []} = {}) {
+    if (typeof input === 'string') {
+        let redacted = input
+            .replace(/([a-z][a-z0-9+.-]*:\/\/)[^/\s@]+@/giu, `$1${SECRET_REPLACEMENT}@`)
+            .replace(/(^|\s)([^/\s@:]+)@([^/\s@:]+:)/gu, `$1${SECRET_REPLACEMENT}@$3`);
+
+        for (const secret of secretHints) {
+            if (typeof secret === 'string' && secret.length > 0) {
+                redacted = redacted.replace(new RegExp(escapeRegExp(secret), 'gu'), SECRET_REPLACEMENT);
+            }
+        }
+
+        return redacted;
+    }
+
+    if (Array.isArray(input)) {
+        return input.map(item => redactTenantRepoSecrets(item, {secretHints}));
+    }
+
+    if (input && typeof input === 'object') {
+        return Object.fromEntries(
+            Object.entries(input).map(([key, value]) => [key, redactTenantRepoSecrets(value, {secretHints})])
+        );
+    }
+
+    return input;
+}

--- a/learn/agentos/cloud-deployment/TenantIngestionModel.md
+++ b/learn/agentos/cloud-deployment/TenantIngestionModel.md
@@ -10,7 +10,7 @@ For the MVP deployment path, tenant ingestion is **push-based**:
 2. The tenant sends raw file deltas or `parsed-chunk-v1` records to the deployment.
 3. The KB server validates the payload, stamps the authoritative tenant tuple, embeds the chunk text server-side, and writes into the shared `knowledge-base` collection.
 
-The deployment does **not** need clone credentials for the MVP path. Server-side repo cloning is a later exploration owned by [#11731](https://github.com/neomjs/neo/issues/11731) and only starts if push-based ingestion proves insufficient.
+The deployment does **not** need clone credentials for the MVP path. Server-side repo cloning is the additive tenant-repo-sync path owned by [#11731](https://github.com/neomjs/neo/issues/11731) after the push MVP; it does not repoint the existing ingestion API or weaken the no-secret persistence boundary.
 
 This model pairs with the D0 scheduler taxonomy in [#11721](https://github.com/neomjs/neo/issues/11721): local maintainer checkout sync stays local-only, while cloud tenant content arrives through the push-based path below.
 
@@ -67,6 +67,7 @@ The push-based MVP path is credential-free from the KB server's perspective:
 - The tenant push client reads local files and sends content or parsed chunks.
 - The KB server receives ingestion payloads, not Git credentials.
 - The repo-push automation identity token authorizes the tenant to call the KB MCP endpoint; it is not a Git credential and is never folded into `repoSlug`, manifests, or chunk metadata.
+- Optional server-side pull config uses `tenantRepos[]` entries with clean `cloneUrl`, reference-only `credentialRef`, and normalized `repoSlug` (#11787). Credential-bearing `userinfo@` clone URLs are rejected before graph persistence; credential injection belongs to the future Git mirror worker (#11788).
 
 Credential-bearing Git URLs are therefore rejected or treated as deferred clone-exploration input. They must not appear in:
 

--- a/test/playwright/unit/ai/services/knowledge-base/KnowledgeBaseIngestionService.spec.mjs
+++ b/test/playwright/unit/ai/services/knowledge-base/KnowledgeBaseIngestionService.spec.mjs
@@ -523,6 +523,46 @@ test.describe('KnowledgeBaseIngestionService.tenantConfig (#11637)', () => {
         expect(bumped.properties.visibility).toBe('team');
     });
 
+    test('setTenantConfig normalizes tenant repo-access entries without persisting credentials (#11787)', async () => {
+        const written = await Service.setTenantConfig({
+            tenantId: 'tenant-a',
+            config  : {
+                tenantRepos: [{
+                    cloneUrl     : 'https://github.com/neomjs/neo.git',
+                    credentialRef: 'env:GITHUB_TOKEN'
+                }]
+            }
+        });
+
+        expect(written).toEqual({tenantId: 'tenant-a', version: 1});
+
+        const node = graphStub.store.get('kb-config:tenant-a');
+
+        expect(node.properties.tenantRepos).toEqual([{
+            cloneUrl     : 'https://github.com/neomjs/neo.git',
+            credentialRef: 'env:GITHUB_TOKEN',
+            repoSlug     : 'github.com/neomjs/neo'
+        }]);
+
+        expect((await Service.getTenantConfig({tenantId: 'tenant-a'})).tenantRepos).toEqual(node.properties.tenantRepos);
+    });
+
+    test('setTenantConfig rejects credential-bearing tenant repo clone URLs (#11787)', async () => {
+        const result = await Service.setTenantConfig({
+            tenantId: 'tenant-a',
+            config  : {
+                tenantRepos: [{
+                    cloneUrl     : 'https://token:secret@github.com/neomjs/neo.git',
+                    credentialRef: 'env:GITHUB_TOKEN'
+                }]
+            }
+        });
+
+        expect(result.code).toBe('KB_TENANT_REPO_CLONE_URL_CREDENTIALS');
+        expect(result.error).toBe('Tenant config write failed');
+        expect(graphStub.store.has('kb-config:tenant-a')).toBe(false);
+    });
+
     test('setTenantManifest persists repo manifests without bumping KnowledgeBaseTenantConfig.version (#11711)', async () => {
         await Service.setTenantConfig({tenantId: 'tenant-a', config: {customParsers: [{parserId: 'alpha'}]}});
 

--- a/test/playwright/unit/ai/services/knowledge-base/TenantRepoAccessContract.spec.mjs
+++ b/test/playwright/unit/ai/services/knowledge-base/TenantRepoAccessContract.spec.mjs
@@ -1,0 +1,105 @@
+import {test, expect} from '@playwright/test';
+
+import {
+    assertCleanCloneUrl,
+    deriveRepoSlugFromCloneUrl,
+    deriveTenantRepoMirrorPath,
+    hasCloneUrlUserInfo,
+    normalizeRepoSlug,
+    normalizeTenantRepoConfig,
+    normalizeTenantRepoEntry,
+    redactTenantRepoSecrets
+} from '../../../../../../ai/services/knowledge-base/helpers/TenantRepoAccessContract.mjs';
+
+/**
+ * @summary Contract tests for tenant repo-access config normalization (#11787).
+ *
+ * The helper is pure by design: it validates tenant-side repo identities without touching Git,
+ * env vars, credential helpers, or the Knowledge Base graph. The Git mirror worker (#11788)
+ * owns credential injection; this layer owns the no-secret persistence boundary.
+ *
+ * @see https://github.com/neomjs/neo/issues/11787
+ * @see ai/services/knowledge-base/helpers/TenantRepoAccessContract.mjs
+ */
+
+test.describe('TenantRepoAccessContract (#11787)', () => {
+    test('derives a deterministic repoSlug from a clean URL cloneUrl', () => {
+        expect(deriveRepoSlugFromCloneUrl('https://github.com/neomjs/neo.git')).toBe('github.com/neomjs/neo');
+        expect(deriveRepoSlugFromCloneUrl('ssh://github.com/neomjs/neo.git')).toBe('github.com/neomjs/neo');
+        expect(deriveRepoSlugFromCloneUrl('github.com:neomjs/neo.git')).toBe('github.com/neomjs/neo');
+    });
+
+    test('normalizes tenant repo entries while preserving credentialRef as a reference only', () => {
+        expect(normalizeTenantRepoEntry({
+            cloneUrl     : 'https://github.com/neomjs/neo.git',
+            credentialRef: 'env:GITHUB_TOKEN'
+        })).toEqual({
+            cloneUrl     : 'https://github.com/neomjs/neo.git',
+            credentialRef: 'env:GITHUB_TOKEN',
+            repoSlug     : 'github.com/neomjs/neo'
+        });
+
+        expect(normalizeTenantRepoConfig({
+            tenantRepos: [{
+                cloneUrl     : 'https://github.com/neomjs/neo.git',
+                credentialRef: 'helper:github-app-installation',
+                repoSlug     : 'github.com/neomjs/custom'
+            }]
+        }).tenantRepos[0].repoSlug).toBe('github.com/neomjs/custom');
+    });
+
+    test('rejects cloneUrl userinfo before config persistence', () => {
+        expect(hasCloneUrlUserInfo('https://token:secret@github.com/neomjs/neo.git')).toBe(true);
+        expect(hasCloneUrlUserInfo('git@github.com:neomjs/neo.git')).toBe(true);
+        expect(hasCloneUrlUserInfo('https://github.com/neomjs/neo.git')).toBe(false);
+
+        expect(() => normalizeTenantRepoEntry({
+            cloneUrl     : 'https://token:secret@github.com/neomjs/neo.git',
+            credentialRef: 'env:GITHUB_TOKEN'
+        })).toThrow(/must not embed userinfo/u);
+
+        expect(() => assertCleanCloneUrl('https://github.com/neomjs/neo.git?token=secret'))
+            .toThrow(/query strings or fragments/u);
+    });
+
+    test('rejects repoSlug values that look like URLs, credentials, or traversal', () => {
+        expect(() => normalizeRepoSlug('https://github.com/neomjs/neo')).toThrow(/clean repository identity/u);
+        expect(() => normalizeRepoSlug('token@github.com/neomjs/neo')).toThrow(/clean repository identity/u);
+        expect(() => normalizeRepoSlug('github.com:token/neomjs/neo')).toThrow(/clean repository identity/u);
+        expect(() => normalizeRepoSlug('github.com/neomjs/../neo')).toThrow(/clean repository identity/u);
+    });
+
+    test('redacts URL userinfo and explicit secret hints from nested log payloads', () => {
+        const redacted = redactTenantRepoSecrets({
+            command          : 'git clone https://token:secret@github.com/neomjs/neo.git',
+            capturedGitStderr: ['fatal: auth failed for token secret-value'],
+            health           : {lastError: 'secret-value leaked from helper'}
+        }, {
+            secretHints: ['secret-value']
+        });
+
+        expect(redacted).toEqual({
+            command          : 'git clone https://[REDACTED]@github.com/neomjs/neo.git',
+            capturedGitStderr: ['fatal: auth failed for token [REDACTED]'],
+            health           : {lastError: '[REDACTED] leaked from helper'}
+        });
+    });
+
+    test('derives mirror paths from tenantId and repoSlug without credential material', () => {
+        const mirrorPath = deriveTenantRepoMirrorPath({
+            mirrorRoot: '/var/lib/neo-kb',
+            tenantId  : 'tenant-a',
+            repoSlug  : 'github.com/neomjs/neo.git'
+        });
+
+        expect(mirrorPath).toBe('/var/lib/neo-kb/tenant-repos/tenant-a/github.com/neomjs/neo');
+        expect(mirrorPath).not.toContain('@');
+        expect(mirrorPath).not.toContain(':');
+
+        expect(() => deriveTenantRepoMirrorPath({
+            mirrorRoot: '/var/lib/neo-kb',
+            tenantId  : 'tenant-a',
+            repoSlug  : 'token@github.com/neomjs/neo'
+        })).toThrow(/clean repository identity/u);
+    });
+});


### PR DESCRIPTION
Resolves #11787

Authored by GPT-5.5 (Codex Desktop). Session 019e525f-8f29-7a01-bca9-c098f3f98481.
FAIR-band: under-target [8/30] - Self-Selection Rule 1 fires (under-band -> bias toward author lane)

Adds the tenant repo-access contract layer for the server-side tenant-repo-sync path: clean `tenantRepos[]` config entries, credential-bearing clone URL rejection, deterministic repoSlug and mirror-path derivation, and a defensive redaction helper for git/log/telemetry/health payloads.

Evidence: L2 (focused unit tests for config persistence/rejection, redaction, repoSlug derivation, and mirror-path derivation) -> L2 required (the #11787 contract and no-secret helper ACs are unit-testable before the #11788 GitMirror runtime exists). No residuals.

## Deltas from ticket
- Rejects clone URL query strings and fragments as credential-shaped material in addition to `userinfo@`.
- Adds `deriveTenantRepoMirrorPath()` as the narrow mirror-path contract helper without implementing clone/fetch lifecycle.
- Updates `TenantIngestionModel.md` to align with ADR 0014: server-side pull is additive after the push MVP, not failure-gated by push insufficiency.

## Signal Ledger
- Source Discussion: #11782 -> Epic #11731 -> leaf sub #11787.
- Implemented scope: Credentialed Repo-Access Contract only.
- This PR does not introduce new scope beyond #11787; #11788 still owns GitMirror clone/fetch and credential injection.

## Unresolved Dissent
None observed during #11787 intake or implementation.

## Unresolved Liveness
No new liveness gap. Live clone/fetch runtime validation remains owned by #11788 because that primitive is out of scope for #11787.

## Slot Rationale
- Modified `learn/agentos/cloud-deployment/TenantIngestionModel.md` Decision Summary and Credential Boundary sections.
- Disposition delta: rewrite-in-place; the deployer-facing model needed correction after ADR 0014 amended tenant-repo-sync from later exploration to additive post-MVP lane.
- Rating: trigger-frequency 2 x failure-severity 4 x enforceability 3. This belongs in the deployment guide, not turn-loaded substrate; no new always-loaded rule was added.
- Decision Record impact: aligns with ADR 0014 2026-05-23 amendment; no ADR mutation needed.

## Test Evidence
- `npm run test-unit -- test/playwright/unit/ai/services/knowledge-base/TenantRepoAccessContract.spec.mjs` - 6 passed.
- `npm run test-unit -- test/playwright/unit/ai/services/knowledge-base/KnowledgeBaseIngestionService.spec.mjs` - 24 passed.
- `git diff --check` - passed.
- `git diff --cached --check` - passed before commit/amend.
- Pre-push freshness: `merge-base HEAD origin/dev == origin/dev`; outgoing log contained only `a5840859e feat(kb): add tenant repo access contract (#11787)`.

## Post-Merge Validation
- [ ] #11788 consumes `TenantRepoAccessContract.mjs` for GitMirror credential injection and redacted captured output.
- [ ] Confirm #11787 auto-closes on merge.

## Commit
- `a5840859e` - `feat(kb): add tenant repo access contract (#11787)`