### PR TITLE
feat(kb): add tenant repo git mirror (#11788)

### DIFF
--- a/ai/deploy/docker-compose.yml
+++ b/ai/deploy/docker-compose.yml
@@ -142,6 +142,7 @@ services:
       - NEO_ORCHESTRATOR_BRIDGE_DAEMON_ENABLED=false
       - NEO_ORCHESTRATOR_GOLDEN_PATH_REPO_ENRICHMENT_ENABLED=false
       - NEO_ORCHESTRATOR_MLX_ENABLED=false
+      - NEO_TENANT_REPO_MIRROR_ROOT=/app/.neo-ai-data/tenant-repos
       - NEO_MODEL_PROVIDER=${NEO_MODEL_PROVIDER:-}
       - NEO_EMBEDDING_PROVIDER=${NEO_EMBEDDING_PROVIDER:-}
       - NEO_OPENAI_COMPATIBLE_HOST=${NEO_OPENAI_COMPATIBLE_HOST:-}
@@ -153,6 +154,7 @@ services:
       - NEO_MEMORY_DB_PATH=/app/.neo-ai-data/sqlite/memory-core-graph.sqlite
     volumes:
       - shared-sqlite-data:/app/.neo-ai-data/sqlite
+      - tenant-repo-mirrors:/app/.neo-ai-data/tenant-repos
       # Redeploy-safe backup persistence (Sub C #11724): the cloud-safe `backup`
       # scheduler lane writes bundles here. A host bind-mount keeps them across
       # container rebuilds and host-accessible for off-site copy / inspection.
@@ -243,6 +245,7 @@ networks:
 volumes:
   chroma-data:
   shared-sqlite-data:
+  tenant-repo-mirrors:
   caddy-data:
   caddy-config:
   local-model-data:

--- a/ai/services/knowledge-base/helpers/GitMirror.mjs
+++ b/ai/services/knowledge-base/helpers/GitMirror.mjs
@@ -1,0 +1,535 @@
+import {spawn} from 'child_process';
+import fs      from 'fs-extra';
+import os      from 'os';
+import path    from 'path';
+
+import {
+    assertCleanCloneUrl,
+    deriveTenantRepoMirrorPath,
+    redactTenantRepoSecrets
+} from './TenantRepoAccessContract.mjs';
+
+/**
+ * @summary Git-backed persistent mirror primitive for server-side tenant repo ingestion.
+ *
+ * `GitMirror` owns only the low-level mirror lifecycle for #11788: clone-if-missing,
+ * fetch, ref resolution, ancestry checks, and revision diffs. It deliberately consumes
+ * the #11787 clean repo-access helpers instead of deriving paths or persisting
+ * credential material itself. Higher-level `tenant-repo-sync` cadence and
+ * `ingestSourceFiles()` envelope construction remain owned by sibling subs #11790
+ * and #11789.
+ *
+ * @see https://github.com/neomjs/neo/issues/11788
+ * @see https://github.com/neomjs/neo/issues/11787
+ */
+
+const GIT_TERMINAL_PROMPT_DISABLED = '0';
+const ASKPASS_SCRIPT = `#!/bin/sh
+case "$1" in
+    *Username*|*username*) printf '%s\\n' "\${NEO_GITMIRROR_USERNAME:-x-access-token}" ;;
+    *) printf '%s\\n' "$NEO_GITMIRROR_PASSWORD" ;;
+esac
+`;
+
+/**
+ * @summary Creates a stable GitMirror error for callers and tests.
+ * @param {String} code Stable `KB_GITMIRROR_*` error code.
+ * @param {String} message Human-readable message.
+ * @param {Object} details={}
+ * @returns {Error}
+ * @private
+ */
+function createGitMirrorError(code, message, details = {}) {
+    const secretHints = details.secretHints || [];
+    const error       = new Error(redactTenantRepoSecrets(message, {secretHints}));
+
+    error.code = code;
+
+    if (details.stdout) {
+        error.stdout = redactTenantRepoSecrets(details.stdout, {secretHints});
+    }
+
+    if (details.stderr) {
+        error.stderr = redactTenantRepoSecrets(details.stderr, {secretHints});
+    }
+
+    if (details.exitCode !== undefined) {
+        error.exitCode = details.exitCode;
+    }
+
+    if (details.cause) {
+        error.cause = details.cause;
+    }
+
+    return error;
+}
+
+/**
+ * @summary Returns a narrow subprocess environment instead of inheriting credential-bearing shell state.
+ * @param {Object} overrides Git-specific environment overrides.
+ * @returns {Object}
+ * @private
+ */
+function createGitEnv(overrides = {}) {
+    const env = {
+        GIT_TERMINAL_PROMPT: GIT_TERMINAL_PROMPT_DISABLED
+    };
+
+    for (const key of ['PATH', 'HOME', 'TMPDIR', 'TEMP', 'SystemRoot', 'USERPROFILE']) {
+        if (process.env[key]) {
+            env[key] = process.env[key];
+        }
+    }
+
+    return {
+        ...env,
+        ...overrides
+    };
+}
+
+/**
+ * @summary Normalizes supported credential reference shapes.
+ * @param {String|Object|null} credentialRef Durable credential reference.
+ * @returns {Object|null}
+ * @private
+ */
+function normalizeCredentialRef(credentialRef) {
+    if (!credentialRef) {
+        return null;
+    }
+
+    if (typeof credentialRef === 'string') {
+        if (credentialRef === 'none') {
+            return {type: 'none'};
+        }
+
+        if (credentialRef.startsWith('env:')) {
+            return {type: 'env', name: credentialRef.slice(4)};
+        }
+
+        if (credentialRef.startsWith('ssh:')) {
+            return {type: 'ssh', keyPath: credentialRef.slice(4)};
+        }
+
+        return {type: 'env', name: credentialRef};
+    }
+
+    if (typeof credentialRef === 'object' && !Array.isArray(credentialRef)) {
+        return credentialRef;
+    }
+
+    throw createGitMirrorError(
+        'KB_GITMIRROR_CREDENTIAL_REF_INVALID',
+        'GitMirror credentialRef must be a string, object, or omitted for local mirrors'
+    );
+}
+
+/**
+ * @summary Quotes one shell token for `GIT_SSH_COMMAND`.
+ * @param {String} value Shell token.
+ * @returns {String}
+ * @private
+ */
+function shellQuote(value) {
+    return `'${String(value).replace(/'/gu, `'\\''`)}'`;
+}
+
+/**
+ * @summary Resolves transient git credential environment overrides.
+ * @param {Object} options
+ * @param {String|Object|null} options.credentialRef Durable credential reference.
+ * @returns {Promise<{env: Object, secretHints: String[], cleanup: Function}>}
+ * @private
+ */
+async function resolveCredentialEnvironment({credentialRef} = {}) {
+    const ref = normalizeCredentialRef(credentialRef);
+
+    if (!ref || ref.type === 'none') {
+        return {env: {}, secretHints: [], cleanup: async () => {}};
+    }
+
+    if (ref.type === 'env') {
+        const name   = ref.name;
+        const secret = process.env[name];
+
+        if (!name || !secret) {
+            throw createGitMirrorError(
+                'KB_GITMIRROR_CREDENTIAL_REF_INVALID',
+                'GitMirror env credentialRef could not be resolved'
+            );
+        }
+
+        const askPassDir  = await fs.mkdtemp(path.join(os.tmpdir(), 'neo-gitmirror-askpass-'));
+        const askPassPath = path.join(askPassDir, 'askpass.sh');
+
+        await fs.writeFile(askPassPath, ASKPASS_SCRIPT, {mode: 0o700});
+
+        return {
+            env: {
+                GIT_ASKPASS           : askPassPath,
+                NEO_GITMIRROR_PASSWORD: secret,
+                NEO_GITMIRROR_USERNAME: ref.username || 'x-access-token'
+            },
+            secretHints: [secret],
+            cleanup    : () => fs.remove(askPassDir)
+        };
+    }
+
+    if (ref.type === 'ssh') {
+        if (!ref.keyPath) {
+            throw createGitMirrorError(
+                'KB_GITMIRROR_CREDENTIAL_REF_INVALID',
+                'GitMirror ssh credentialRef requires keyPath'
+            );
+        }
+
+        return {
+            env: {
+                GIT_SSH_COMMAND: [
+                    'ssh',
+                    '-i',
+                    shellQuote(ref.keyPath),
+                    '-o',
+                    'IdentitiesOnly=yes',
+                    '-o',
+                    'StrictHostKeyChecking=accept-new'
+                ].join(' ')
+            },
+            secretHints: [],
+            cleanup    : async () => {}
+        };
+    }
+
+    throw createGitMirrorError(
+        'KB_GITMIRROR_CREDENTIAL_REF_INVALID',
+        `GitMirror unsupported credentialRef type: ${ref.type}`
+    );
+}
+
+/**
+ * @summary Runs git with redacted error reporting.
+ * @param {String[]} args Git arguments.
+ * @param {Object} options={}
+ * @returns {Promise<{exitCode: Number, stdout: String, stderr: String}>}
+ * @private
+ */
+async function runGit(args, {
+    acceptedExitCodes = [0],
+    cwd,
+    credentialRef,
+    failureCode = 'KB_GITMIRROR_GIT_FAILED',
+    failureMessage = 'GitMirror git command failed'
+} = {}) {
+    const credential = await resolveCredentialEnvironment({credentialRef});
+
+    try {
+        const result = await new Promise((resolve, reject) => {
+            const child = spawn('git', args, {
+                cwd,
+                env  : createGitEnv(credential.env),
+                stdio: ['ignore', 'pipe', 'pipe']
+            });
+            let stdout = '';
+            let stderr = '';
+
+            child.stdout.on('data', data => {
+                stdout += data;
+            });
+
+            child.stderr.on('data', data => {
+                stderr += data;
+            });
+
+            child.on('error', reject);
+            child.on('close', exitCode => resolve({exitCode, stdout, stderr}));
+        });
+
+        if (!acceptedExitCodes.includes(result.exitCode)) {
+            throw createGitMirrorError(failureCode, failureMessage, {
+                ...result,
+                secretHints: credential.secretHints
+            });
+        }
+
+        return {
+            exitCode: result.exitCode,
+            stdout  : redactTenantRepoSecrets(result.stdout, {secretHints: credential.secretHints}),
+            stderr  : redactTenantRepoSecrets(result.stderr, {secretHints: credential.secretHints})
+        };
+    } catch (error) {
+        if (error.code?.startsWith?.('KB_GITMIRROR_')) {
+            throw error;
+        }
+
+        throw createGitMirrorError(failureCode, failureMessage, {
+            cause      : error,
+            secretHints: credential.secretHints
+        });
+    } finally {
+        await credential.cleanup();
+    }
+}
+
+/**
+ * @summary Derives and validates the mirror path contract.
+ * @param {Object} options
+ * @returns {String}
+ * @private
+ */
+function getMirrorPath({mirrorRoot, tenantId, repoSlug} = {}) {
+    try {
+        return deriveTenantRepoMirrorPath({mirrorRoot, tenantId, repoSlug});
+    } catch (error) {
+        throw createGitMirrorError(
+            'KB_GITMIRROR_MIRROR_PATH_INVALID',
+            error.message,
+            {cause: error}
+        );
+    }
+}
+
+/**
+ * @summary Returns true when a directory is a usable git mirror.
+ * @param {String} mirrorPath Local mirror path.
+ * @returns {Promise<Boolean>}
+ * @private
+ */
+async function isUsableMirror(mirrorPath) {
+    if (!await fs.pathExists(mirrorPath)) {
+        return false;
+    }
+
+    const stat = await fs.stat(mirrorPath);
+
+    if (!stat.isDirectory()) {
+        throw createGitMirrorError(
+            'KB_GITMIRROR_MIRROR_PATH_INVALID',
+            'GitMirror path exists but is not a directory'
+        );
+    }
+
+    const result = await runGit(['rev-parse', '--git-dir'], {
+        acceptedExitCodes: [0, 128],
+        cwd              : mirrorPath,
+        failureCode      : 'KB_GITMIRROR_MIRROR_PATH_INVALID',
+        failureMessage   : 'GitMirror path validation failed'
+    });
+
+    if (result.exitCode === 0) {
+        return true;
+    }
+
+    throw createGitMirrorError(
+        'KB_GITMIRROR_MIRROR_PATH_INVALID',
+        'GitMirror path exists but is not a git repository',
+        result
+    );
+}
+
+/**
+ * @summary Lists git refs for fetch-change detection.
+ * @param {String} mirrorPath Local mirror path.
+ * @returns {Promise<Map<String, String>>}
+ * @private
+ */
+async function listRefs(mirrorPath) {
+    const result = await runGit(['for-each-ref', '--format=%(refname) %(objectname)'], {
+        cwd           : mirrorPath,
+        failureCode   : 'KB_GITMIRROR_FETCH_FAILED',
+        failureMessage: 'GitMirror failed to inspect refs'
+    });
+    const refs = new Map();
+
+    for (const line of result.stdout.split('\n')) {
+        if (!line.trim()) continue;
+
+        const [ref, objectId] = line.trim().split(/\s+/u);
+        refs.set(ref, objectId);
+    }
+
+    return refs;
+}
+
+/**
+ * @summary Computes changed refs between two ref maps.
+ * @param {Map<String, String>} before Refs before fetch.
+ * @param {Map<String, String>} after Refs after fetch.
+ * @returns {Object[]}
+ * @private
+ */
+function getChangedRefs(before, after) {
+    const changed = [];
+
+    for (const [ref, objectId] of after) {
+        if (before.get(ref) !== objectId) {
+            changed.push({
+                ref,
+                before: before.get(ref) || null,
+                after : objectId
+            });
+        }
+    }
+
+    return changed;
+}
+
+/**
+ * @summary Clones a tenant repository as a persistent bare mirror if absent.
+ * @param {Object} options
+ * @returns {Promise<{mirrorPath: String, cloned: Boolean}>}
+ */
+export async function cloneIfMissing({mirrorRoot, tenantId, repoSlug, cloneUrl, credentialRef} = {}) {
+    const mirrorPath = getMirrorPath({mirrorRoot, tenantId, repoSlug});
+
+    if (await isUsableMirror(mirrorPath)) {
+        return {mirrorPath, cloned: false};
+    }
+
+    let cleanCloneUrl;
+
+    try {
+        cleanCloneUrl = assertCleanCloneUrl(cloneUrl);
+    } catch (error) {
+        throw createGitMirrorError(
+            'KB_GITMIRROR_CLONE_FAILED',
+            error.message,
+            {cause: error}
+        );
+    }
+
+    await fs.ensureDir(path.dirname(mirrorPath));
+    await runGit(['clone', '--mirror', cleanCloneUrl, mirrorPath], {
+        credentialRef,
+        failureCode   : 'KB_GITMIRROR_CLONE_FAILED',
+        failureMessage: 'GitMirror clone failed'
+    });
+
+    return {mirrorPath, cloned: true};
+}
+
+/**
+ * @summary Fetches all refs in an existing tenant repo mirror.
+ * @param {Object} options
+ * @returns {Promise<{fetchedAt: String, mirrorPath: String, newRevisions: Object[]}>}
+ */
+export async function fetch({mirrorRoot, tenantId, repoSlug, credentialRef} = {}) {
+    const mirrorPath = getMirrorPath({mirrorRoot, tenantId, repoSlug});
+
+    await isUsableMirror(mirrorPath);
+
+    const before = await listRefs(mirrorPath);
+
+    await runGit(['fetch', '--all', '--prune'], {
+        cwd           : mirrorPath,
+        credentialRef,
+        failureCode   : 'KB_GITMIRROR_FETCH_FAILED',
+        failureMessage: 'GitMirror fetch failed'
+    });
+
+    const after = await listRefs(mirrorPath);
+
+    return {
+        fetchedAt   : new Date().toISOString(),
+        mirrorPath,
+        newRevisions: getChangedRefs(before, after)
+    };
+}
+
+/**
+ * @summary Resolves a ref to a full commit SHA inside the mirror.
+ * @param {Object} options
+ * @returns {Promise<String>}
+ */
+export async function resolveHead({mirrorRoot, tenantId, repoSlug, ref = 'HEAD'} = {}) {
+    const mirrorPath = getMirrorPath({mirrorRoot, tenantId, repoSlug});
+
+    await isUsableMirror(mirrorPath);
+
+    try {
+        const result = await runGit(['rev-parse', '--verify', `${ref}^{commit}`], {
+            cwd           : mirrorPath,
+            failureCode   : 'KB_GITMIRROR_REF_NOT_FOUND',
+            failureMessage: 'GitMirror ref not found'
+        });
+
+        return result.stdout.trim();
+    } catch (error) {
+        if (error.code === 'KB_GITMIRROR_REF_NOT_FOUND') {
+            throw error;
+        }
+
+        throw createGitMirrorError(
+            'KB_GITMIRROR_REF_NOT_FOUND',
+            'GitMirror ref not found',
+            {cause: error}
+        );
+    }
+}
+
+/**
+ * @summary Returns whether `ancestor` is reachable from `descendant`.
+ * @param {Object} options
+ * @returns {Promise<Boolean>}
+ */
+export async function isAncestor({mirrorRoot, tenantId, repoSlug, ancestor, descendant} = {}) {
+    const mirrorPath = getMirrorPath({mirrorRoot, tenantId, repoSlug});
+
+    await isUsableMirror(mirrorPath);
+
+    const result = await runGit(['merge-base', '--is-ancestor', ancestor, descendant], {
+        acceptedExitCodes: [0, 1],
+        cwd              : mirrorPath,
+        failureCode      : 'KB_GITMIRROR_REF_NOT_FOUND',
+        failureMessage   : 'GitMirror ancestry check failed'
+    });
+
+    return result.exitCode === 0;
+}
+
+/**
+ * @summary Returns changed and deleted repo-relative paths between revisions.
+ * @param {Object} options
+ * @returns {Promise<{addedOrChanged: String[], deleted: String[]}>}
+ */
+export async function diffRevisions({mirrorRoot, tenantId, repoSlug, baseRevision, headRevision} = {}) {
+    const mirrorPath = getMirrorPath({mirrorRoot, tenantId, repoSlug});
+
+    await isUsableMirror(mirrorPath);
+
+    const result = await runGit(['diff', '--name-status', '-z', baseRevision, headRevision], {
+        cwd           : mirrorPath,
+        failureCode   : 'KB_GITMIRROR_DIFF_FAILED',
+        failureMessage: 'GitMirror revision diff failed'
+    });
+    const parts          = result.stdout.split('\0').filter(Boolean);
+    const addedOrChanged = new Set();
+    const deleted        = new Set();
+
+    for (let i = 0; i < parts.length;) {
+        const status = parts[i++];
+        const file   = parts[i++];
+
+        if (!file) continue;
+
+        if (status.startsWith('D')) {
+            deleted.add(file);
+        } else {
+            addedOrChanged.add(file);
+        }
+    }
+
+    return {
+        addedOrChanged: Array.from(addedOrChanged),
+        deleted       : Array.from(deleted)
+    };
+}
+
+const GitMirror = {
+    cloneIfMissing,
+    diffRevisions,
+    fetch,
+    isAncestor,
+    resolveHead
+};
+
+export default GitMirror;

--- a/learn/agentos/cloud-deployment/TenantIngestionModel.md
+++ b/learn/agentos/cloud-deployment/TenantIngestionModel.md
@@ -67,7 +67,7 @@ The push-based MVP path is credential-free from the KB server's perspective:
 - The tenant push client reads local files and sends content or parsed chunks.
 - The KB server receives ingestion payloads, not Git credentials.
 - The repo-push automation identity token authorizes the tenant to call the KB MCP endpoint; it is not a Git credential and is never folded into `repoSlug`, manifests, or chunk metadata.
-- Optional server-side pull config uses `tenantRepos[]` entries with clean `cloneUrl`, reference-only `credentialRef`, and normalized `repoSlug` (#11787). Credential-bearing `userinfo@` clone URLs are rejected before graph persistence; credential injection belongs to the future Git mirror worker (#11788).
+- Optional server-side pull config uses `tenantRepos[]` entries with clean `cloneUrl`, reference-only `credentialRef`, and normalized `repoSlug` (#11787). Credential-bearing `userinfo@` clone URLs are rejected before graph persistence; credential injection belongs to the `GitMirror` primitive (#11788). `GitMirror` resolves the credential reference only for the git subprocess invocation (`GIT_ASKPASS` for HTTPS, `GIT_SSH_COMMAND` for SSH) and keeps mirror contents on the deployment `tenant-repo-mirrors` volume mounted at `NEO_TENANT_REPO_MIRROR_ROOT`.
 
 Credential-bearing Git URLs are therefore rejected or treated as deferred clone-exploration input. They must not appear in:
 

--- a/test/playwright/unit/ai/services/knowledge-base/GitMirror.spec.mjs
+++ b/test/playwright/unit/ai/services/knowledge-base/GitMirror.spec.mjs
@@ -1,0 +1,164 @@
+import {test, expect} from '@playwright/test';
+
+import fs             from 'fs-extra';
+import os             from 'os';
+import path           from 'path';
+import {execFile}     from 'child_process';
+import {promisify}    from 'util';
+
+import GitMirror, {
+    cloneIfMissing,
+    diffRevisions,
+    fetch,
+    isAncestor,
+    resolveHead
+} from '../../../../../../ai/services/knowledge-base/helpers/GitMirror.mjs';
+
+const execFileAsync = promisify(execFile);
+
+/**
+ * @summary Contract tests for the persistent Git mirror primitive (#11788).
+ *
+ * The tests use local fixture repositories only. Credentialed remote acquisition is
+ * represented by no-leak failure assertions so the suite never depends on provider
+ * credentials or network availability.
+ *
+ * @see https://github.com/neomjs/neo/issues/11788
+ * @see ai/services/knowledge-base/helpers/GitMirror.mjs
+ */
+
+test.describe('GitMirror (#11788)', () => {
+    let root;
+
+    test.beforeEach(async () => {
+        root = await fs.mkdtemp(path.join(os.tmpdir(), 'neo-gitmirror-test-'));
+    });
+
+    test.afterEach(async () => {
+        delete process.env.NEO_GITMIRROR_TEST_TOKEN;
+        await fs.remove(root);
+    });
+
+    async function git(args, cwd) {
+        const {stdout} = await execFileAsync('git', args, {cwd});
+        return stdout.trim();
+    }
+
+    async function createSourceRepo() {
+        const source = path.join(root, 'source');
+
+        await fs.ensureDir(source);
+        await git(['init', '--initial-branch=main'], source);
+        await fs.writeFile(path.join(source, 'alpha.txt'), 'alpha v1\n');
+        await fs.writeFile(path.join(source, 'remove-me.txt'), 'remove me\n');
+        await git(['add', '.'], source);
+        await git(['-c', 'user.name=Neo Test', '-c', 'user.email=test@example.com', 'commit', '-m', 'initial'], source);
+
+        return source;
+    }
+
+    async function commitSecondRevision(source) {
+        await fs.writeFile(path.join(source, 'alpha.txt'), 'alpha v2\n');
+        await fs.writeFile(path.join(source, 'beta.txt'), 'beta\n');
+        await fs.remove(path.join(source, 'remove-me.txt'));
+        await git(['add', '-A'], source);
+        await git(['-c', 'user.name=Neo Test', '-c', 'user.email=test@example.com', 'commit', '-m', 'second'], source);
+    }
+
+    function mirrorOptions(source) {
+        return {
+            cloneUrl  : source,
+            mirrorRoot: path.join(root, 'mirrors'),
+            repoSlug  : 'local/source',
+            tenantId  : 'tenant-a'
+        };
+    }
+
+    test('clones a local source repo as an idempotent bare mirror', async () => {
+        const source = await createSourceRepo();
+        const first  = await cloneIfMissing(mirrorOptions(source));
+        const second = await GitMirror.cloneIfMissing(mirrorOptions(source));
+
+        expect(first.cloned).toBe(true);
+        expect(second).toEqual({mirrorPath: first.mirrorPath, cloned: false});
+        await expect(fs.pathExists(path.join(first.mirrorPath, 'HEAD'))).resolves.toBe(true);
+    });
+
+    test('fetches new revisions and resolves refs', async () => {
+        const source = await createSourceRepo();
+        const mirror = await cloneIfMissing(mirrorOptions(source));
+        const before = await resolveHead({...mirrorOptions(source), ref: 'main'});
+
+        await commitSecondRevision(source);
+
+        const result = await fetch(mirrorOptions(source));
+        const after  = await resolveHead({...mirrorOptions(source), ref: 'main'});
+
+        expect(result.mirrorPath).toBe(mirror.mirrorPath);
+        expect(result.fetchedAt).toMatch(/^\d{4}-\d{2}-\d{2}T/u);
+        expect(result.newRevisions.some(item => item.ref === 'refs/heads/main')).toBe(true);
+        expect(after).not.toBe(before);
+    });
+
+    test('checks ancestry and returns changed plus deleted paths between revisions', async () => {
+        const source = await createSourceRepo();
+
+        await cloneIfMissing(mirrorOptions(source));
+
+        const baseRevision = await resolveHead({...mirrorOptions(source), ref: 'main'});
+
+        await commitSecondRevision(source);
+        await fetch(mirrorOptions(source));
+
+        const headRevision = await resolveHead({...mirrorOptions(source), ref: 'main'});
+        const diff         = await diffRevisions({...mirrorOptions(source), baseRevision, headRevision});
+
+        await expect(isAncestor({...mirrorOptions(source), ancestor: baseRevision, descendant: headRevision}))
+            .resolves.toBe(true);
+        await expect(isAncestor({...mirrorOptions(source), ancestor: headRevision, descendant: baseRevision}))
+            .resolves.toBe(false);
+        expect(diff.addedOrChanged.sort()).toEqual(['alpha.txt', 'beta.txt']);
+        expect(diff.deleted).toEqual(['remove-me.txt']);
+    });
+
+    test('throws stable errors for missing refs and invalid mirrors', async () => {
+        const source = await createSourceRepo();
+
+        await cloneIfMissing(mirrorOptions(source));
+
+        await expect(resolveHead({...mirrorOptions(source), ref: 'missing-ref'}))
+            .rejects.toMatchObject({code: 'KB_GITMIRROR_REF_NOT_FOUND'});
+        await expect(cloneIfMissing({...mirrorOptions(source), tenantId: '../bad'}))
+            .rejects.toMatchObject({code: 'KB_GITMIRROR_MIRROR_PATH_INVALID'});
+        await expect(cloneIfMissing({
+            ...mirrorOptions(source),
+            cloneUrl: 'https://token:secret@example.com/acme/repo.git',
+            repoSlug: 'local/credential-url'
+        })).rejects.toMatchObject({code: 'KB_GITMIRROR_CLONE_FAILED'});
+        await expect(cloneIfMissing({
+            ...mirrorOptions(source),
+            cloneUrl     : path.join(root, 'other-source'),
+            credentialRef: 'env:NEO_GITMIRROR_MISSING_TOKEN',
+            repoSlug     : 'local/other-source'
+        })).rejects.toMatchObject({code: 'KB_GITMIRROR_CREDENTIAL_REF_INVALID'});
+    });
+
+    test('keeps credential hints out of durable error surfaces', async () => {
+        process.env.NEO_GITMIRROR_TEST_TOKEN = 'super-secret-token';
+
+        await expect(cloneIfMissing({
+            ...mirrorOptions(path.join(root, 'missing-source')),
+            credentialRef: 'env:NEO_GITMIRROR_TEST_TOKEN'
+        })).rejects.toMatchObject({code: 'KB_GITMIRROR_CLONE_FAILED'});
+
+        try {
+            await cloneIfMissing({
+                ...mirrorOptions(path.join(root, 'missing-source')),
+                credentialRef: 'env:NEO_GITMIRROR_TEST_TOKEN'
+            });
+        } catch (error) {
+            expect(error.message).not.toContain('super-secret-token');
+            expect(error.stderr || '').not.toContain('super-secret-token');
+        }
+    });
+});


### PR DESCRIPTION
Resolves #11788

Authored by GPT-5.5 (Codex Desktop). Session 967e325b-d90a-43f4-9e91-c212e9bda746.

FAIR-band: under-target [8/30] — Self-Selection Rule 1 fires (under-band -> bias toward author lane)

Implements the persistent `GitMirror` primitive for tenant-repo pull ingestion: clone-if-missing, fetch, ref resolution, ancestry checks, revision diffs, redacted git failure surfaces, and a deployment mirror volume. This PR is currently stacked on PR #11880 / #11787 because the credentialed repo-access contract is approved but not yet merged; the #11788 commit is the top commit on this branch.

Evidence: L2 (local git fixture unit tests + compose YAML assertion + focused adjacent contract regression) -> L2 required (#11788 ACs are local git/contract/deployment-shape verifiable). No residuals for #11788; sibling work remains in #11789, #11790, and #11791.

## Deltas from ticket

- Structural pre-flight corrected the stale candidate placement. This checkout has no `ai/daemons/services/`; `GitMirror` lands under `ai/services/knowledge-base/helpers/` beside `TenantRepoAccessContract.mjs`, matching the current post-M6 KB SDK/helper boundary.
- The #11788 Contract Ledger was updated before PR open to include `KB_GITMIRROR_CREDENTIAL_REF_INVALID`, matching the implemented credential-reference failure surface.
- The branch includes the rebased #11787 prerequisite commit until #11880 lands. After #11880 merges, this branch should be refreshed so the PR diff collapses to the #11788 surfaces.

## Structural Pre-Flight

Pre-Flight (structural fast-path): authoring `ai/services/knowledge-base/helpers/GitMirror.mjs` matches the sibling pattern of `ai/services/knowledge-base/helpers/TenantRepoAccessContract.mjs` in `ai/services/knowledge-base/helpers/`; both are KB tenant-ingestion helper primitives, with the daemon lane consuming them later through the service layer. Sibling-file-lift applies; no novel directory choice. Map-maintenance: not needed because `ai/services/knowledge-base/` is already in the Structural Inventory and this is another helper under that existing service boundary.

Decision Record impact: no ADR mutation. This implements the existing ADR 0014 tenant-repo-sync amendment and #11788 Contract Ledger.

## Substrate Slot Rationale

- Modified `learn/agentos/cloud-deployment/TenantIngestionModel.md` / Credential Boundary. Disposition: keep. Rationale: the guide already owns tenant-ingestion operator semantics; the edit replaces future-tense placeholder wording with the concrete #11788 primitive and volume contract. Decay mitigation: when #11790/#11791 land, this note can be compressed into the final tenant-repo-sync operator flow.

## Test Evidence

- `npm run test-unit -- test/playwright/unit/ai/services/knowledge-base/GitMirror.spec.mjs`
- `npm run test-unit -- test/playwright/unit/ai/services/knowledge-base/GitMirror.spec.mjs test/playwright/unit/ai/services/knowledge-base/TenantRepoAccessContract.spec.mjs`
- `git diff --check origin/dev...HEAD`
- `node -e "import fs from 'fs'; import yaml from 'js-yaml'; const compose=yaml.load(fs.readFileSync('ai/deploy/docker-compose.yml','utf8')); if (!Object.hasOwn(compose.volumes,'tenant-repo-mirrors')) throw new Error('missing tenant-repo-mirrors volume'); const volumes=compose.services.orchestrator.volumes || []; if (!volumes.includes('tenant-repo-mirrors:/app/.neo-ai-data/tenant-repos')) throw new Error('missing orchestrator mirror mount'); console.log('compose mirror volume ok')"`

## Post-Merge Validation

- [ ] After #11880 merges, rebase/refresh this branch so the visible PR diff drops the #11787 prerequisite surfaces.
- [ ] In a cloud compose smoke, verify `tenant-repo-mirrors` survives orchestrator container recreation.

## Commits

- `de20fee37` — `feat(kb): add tenant repo git mirror (#11788)`
