### PR TITLE
docs(pull-request): require next-lane pickup during pending CI (#11895)

### DIFF
--- a/.agents/skills/pull-request/references/ci-green-review-routing.md
+++ b/.agents/skills/pull-request/references/ci-green-review-routing.md
@@ -53,9 +53,10 @@ Use the wait window productively:
 
 1. Check unread A2A and open peer review requests.
 2. If a peer PR can be reviewed or unblocked without abandoning your lane, do that work while CI runs.
-3. Return to your PR and re-run `gh pr checks <PR_NUMBER>`.
+3. If no peer-unblock lane is available, park a concrete recheck trigger (watchdog wake, next turn, or after the next short lane) and pick up the next positive-ROI backlog lane per `post-review-pickup`.
+4. Return to your PR at the recheck trigger and re-run `gh pr checks <PR_NUMBER>` before assigning a reviewer.
 
-Do not spin indefinitely. If checks are still pending and no useful peer-unblock lane is available within the current turn, leave the PR in the observer/no-action hold state with the exact CI status and stop.
+Do not spin indefinitely. Pending CI is asynchronous work owned by GitHub Actions; by itself it is not a halt-state. A stop is valid only when a normal `post-review-pickup` halt criterion has been verified and named.
 
 ### Failing, Cancelled, Timed Out, Or Deep Red
 
@@ -91,4 +92,5 @@ Once CI is green, send the re-review A2A with the original response `commentId` 
 | Sending `Requested action: use /pr-review` before green CI | Reviewer-side rules now require holding or stopping, so the wake creates churn. |
 | Suppressing all PR-open A2A until CI is green | Violates lifecycle visibility and makes the swarm blind to an opened PR. |
 | Treating green CI as approval | Green CI only permits requesting human/peer review. |
-| Busy-waiting forever | Pending CI time should unblock peers or end in an explicit observer hold. |
+| Busy-waiting forever | Pending CI time should unblock peers, then trigger a recheck. |
+| Stopping solely because CI is still pending | Turns an asynchronous GitHub Actions wait into agent idle time; park the recheck and pick up the next lane. |


### PR DESCRIPTION
Authored by GPT-5.5 (Codex Desktop). Session 019e56e6-7173-7bd3-879a-14f37712b52e.

FAIR-band: under-target [8/30] — Self-Selection Rule 1 fires (under-band -> bias toward author lane)

Resolves #11895

Turns pending CI into an asynchronous parked state instead of a stop condition. Authors still must not request review before green CI, but if checks are still running they now park a concrete recheck trigger and pick up the next positive-ROI lane unless a normal `post-review-pickup` halt criterion is actually verified.

Evidence: L1 (workflow payload text audit + skill-manifest lint) -> L1 required (documentation workflow contract). No residuals.

## Deltas From Ticket

None. The implementation is the narrow in-place rewrite prescribed by #11895.

## Slot Rationale

| Surface | Disposition | 3-axis rationale |
|---|---|---|
| Pending-CI wait-window terminal behavior | `rewrite` | High-frequency PR-open path, moderate failure severity, discipline-only; existing wording permitted idle while GitHub Actions owned the async wait |
| Anti-pattern table | `rewrite` | Same payload, no new audit surface; clarifies that busy-waiting and stopping solely on pending CI are both wrong |

Decision Record impact: aligned with ADR 0007 / ADR 0008. No ADR change; no new skill, audit, or AGENTS.md surface.

## Test Evidence

- `node ai/scripts/lint/lint-skill-manifest.mjs --base origin/dev` passed.
- `git diff --check` passed.
- `git diff --cached --check` passed before the original commit.
- Rebase freshness check passed after #11894 merged: `merge-base HEAD origin/dev == origin/dev`; outgoing log contained only `754b0f1a docs(pull-request): require next-lane pickup during pending CI (#11895)`.

## Post-Merge Validation

- [ ] Next PR-open with long-running CI uses no-action visibility plus parked recheck, then agent picks another lane instead of waiting.

## Commits

- `754b0f1a` — `docs(pull-request): require next-lane pickup during pending CI (#11895)`
