### PR TITLE
docs(skills): codify why-first source comments (#11890)

### DIFF
--- a/.agents/skills/pr-review/assets/pr-review-template.md
+++ b/.agents/skills/pr-review/assets/pr-review-template.md
@@ -45,7 +45,7 @@ OR
 Verify symmetry between stated framing and mechanical implementation:
 
 - [ ] PR description: framing matches what the diff substantiates (no overshoot)
-- [ ] Anchor & Echo summaries: precise codebase terminology, no metaphor that overshoots the implementation
+- [ ] Anchor & Echo summaries: precise codebase terminology, no metaphor or source-code snapshot anchor (ticket/PR/lane/AC/cycle/line number) that overshoots durable intent
 - [ ] `[RETROSPECTIVE]` tag: accurately characterizes what shipped (no inflation of architectural significance)
 - [ ] Linked anchors: cited tickets/PRs actually establish the claimed pattern (no borrowed authority)
 

--- a/.agents/skills/pr-review/references/pr-review-guide.md
+++ b/.agents/skills/pr-review/references/pr-review-guide.md
@@ -261,7 +261,7 @@ Unaudited rhetorical drift poisons the `ask_knowledge_base` ingestion pipeline. 
 Reviewers MUST verify symmetry between **stated framing** and **mechanical implementation**:
 
 1. **PR description** — does the architectural narrative accurately describe the boundaries and capabilities of the code? Or does the prose claim more than the diff substantiates?
-2. **Anchor & Echo summaries** (`AGENTS.md §15.2`) — does new JSDoc reuse precise codebase terminology, or does it lean on metaphor that overshoots the implementation?
+2. **Anchor & Echo summaries** (`AGENTS.md §15.2`) — does new JSDoc reuse precise codebase terminology, or does it lean on metaphor / source-comment archaeology that overshoots durable intent?
 3. **`[RETROSPECTIVE]` tags** (§4) — does the takeaway accurately characterize what shipped, or does it inflate the architectural significance of a routine change?
 4. **Linked-anchor accuracy** — when prose claims "implements pattern X from #N" or "similar to PR #M", does the cited reference actually establish that pattern, or is it being cited for borrowed authority?
 

--- a/learn/agentos/AGENTS_ATLAS.md
+++ b/learn/agentos/AGENTS_ATLAS.md
@@ -124,6 +124,7 @@ Per `AGENTS.md` §pr_diff_equals_pr_body: PR body + review templates are graph-i
 - Stage 2: Query for Memory (`query_summaries`, `query_raw_memories`). Mandatory for regressions, surprises, architecture queries, trade-offs.
 **15.4 Ask the Expert Protocol:** Treat `ask_knowledge_base` as an Embedded RAG Sub-Agent.
 **15.5 Neo Identity Anchor:** in main `AGENTS.md` §neo_identity_anchor as the per-turn anti-drift priming surface.
+**15.6 Source-comment intent filter:** Anchor & Echo comments explain durable intent, invariant, or local boundary. Living source comments default away from ticket / PR / lane / AC / cycle / line-number anchors; promote durable history to ADR/Atlas/learn/owning-primitive docs or cite a stable symbol. Snapshot archaeology belongs in PRs, tickets, commits, and Discussions. Diagnostic-first command: `rg -n "cycle-[0-9]|Lane [A-Z]|AC[0-9]|#[0-9]{4,5}|\\.mjs:[0-9]+" <changed-source-paths>` (candidate-only). Examples: avoid `core/Base.mjs:589-595`, lane/AC/ticket prose, and consumer comments re-explaining `initAsync()`/dotenv; prefer `Base#ready()`, local boundary language, credential separation by `credentialRef`, or `SwarmHeartbeatService#pulse()` cadence ownership.
 
 ## §implementation_loop [DISCIPLINE-ONLY]
 Step 1: Query & Analyze. Step 2: Implement Changes. Step 3: Verify.


### PR DESCRIPTION
Authored by GPT-5 (Codex Desktop). Session 967e325b-d90a-43f4-9e91-c212e9bda746.

FAIR-band: under-target [9/30] — Self-Selection Rule 1 fires (under-band -> bias toward author lane).

Resolves #11890

Codifies the why-first source-comment contract without repeating the closed #11892 failure shape: no new audit file, no new recurring review-template section, and no `AGENTS.md` expansion. The rule is folded into existing Rhetorical-Drift wording plus one Atlas discoverability line.

Evidence: L1 (static substrate diff + skill/agent lint + KB/JSDoc source review) -> L1 required (documentation-discipline substrate; no runtime ACs). No residuals.

## Deltas from ticket

- Compact-only implementation: 3 changed lines total, no new files.
- The review template keeps one existing checklist line and does not add a new Source-Code Why-First section.
- Diagnostic-first support is a candidate-only `rg` command in `AGENTS_ATLAS.md`, not a new script or CI failure.
- Decision Record impact: aligned with ADR 0007/0008 compaction and Map-vs-Atlas discipline; no ADR amendment required.

## Signal Ledger

| Family | Signal | Anchor |
| --- | --- | --- |
| OpenAI | AUTHOR_SIGNAL | Discussion #11889 / issue #11890 |
| Anthropic | GRADUATION_APPROVED | Discussion #11889 reconfirmation noted in #11890 |
| Google | Unresolved Liveness | Operator-benched per #11890; non-Tier-2 scope |

## Substrate Slot Rationale

| Surface | Disposition | 3-axis rating | Rationale |
| --- | --- | --- | --- |
| `pr-review-guide.md` §7.4 checklist line | rewrite | review-time / medium / discipline-only | Adds the source-comment archaeology filter to the existing rhetorical-drift audit; guide delta stays below the 250-byte map cap. |
| `pr-review-template.md` Rhetorical-Drift checklist | rewrite | review-time / medium / discipline-only | Reuses the existing checklist line instead of adding another recurring audit block. |
| `AGENTS_ATLAS.md` §15.6 | compress-to-trigger | occasional architectural sweep / medium / discipline-only | One discoverability line carries the durable rule and diagnostic; no always-loaded `AGENTS.md` impact. |

Net substrate impact: 3 insertions / 2 deletions across existing files; no new payloads; no always-loaded turn-substrate expansion.

## Test Evidence

- `node ai/scripts/lint/lint-skill-manifest.mjs --base origin/dev` -> OK
- `node ai/scripts/lint/lint-agents.mjs --base origin/dev` -> OK
- `git diff --check origin/dev...HEAD` -> OK
- `git diff --cached --check` -> OK before commit
- KB/JSDoc source review: `DatabaseService#createKnowledgeBase()` reads source through `SourceParser`; `ConceptDiscoveryService` already excludes issue IDs / PR numbers as concepts. No KB pipeline depends on ticket IDs in source comments.
- Lint audit: no eslint config file is present; `package.json` has `jsdoc-api` for docs generation, not `eslint-plugin-jsdoc`; existing `ai/scripts/lint/*` surfaces do not enforce source-comment archaeology.

## Post-Merge Validation

- [ ] Next PR that adds source comments can use the existing Rhetorical-Drift checklist line to flag snapshot anchors without loading another audit template.

## Evolution

Closed PR #11892 proved the wrong shape: a new audit file plus a new template block solved placement but not focus-window cost. This PR keeps the behavior and removes the ceremony.
