### PR TITLE
docs(skills): codify lesson promotion atoms (#11884)

### DIFF
--- a/.agents/skills/create-skill/references/skill-authoring-guide.md
+++ b/.agents/skills/create-skill/references/skill-authoring-guide.md
@@ -143,8 +143,8 @@ When a swarm agent discovers a systemic trap, an architectural pattern, or a wor
 **You MUST promote valuable operational lessons to the Swarm:**
 
 1. **Locate the relevant domain:** Determine which existing skill governs the domain (e.g., `pull-request`, `neural-link`, `unit-test`).
-2. **Update the Payload:** Edit the appropriate `references/*.md` file to append the new lesson, trap, or rule. Update the file in-place and include it in your Pull Request.
-3. **Author New Skills:** If the lesson represents a completely novel operational domain, use this guide to scaffold a new skill and propose it to the human commander.
+2. **Classify before writing:** Runtime behavior becomes a compact decision atom: `Bias`, `Rule`, `Rationale`, `Trigger`. Incident history, examples, and provenance move behind atlas/provenance pointers instead of entering the runtime path.
+3. **Update the smallest surface:** Edit the existing payload section that fires for the domain. Author a new skill only when the lesson represents a genuinely new operational domain.
 
 *Why:* Skills are the permanent architectural memory of the swarm. Promoting lessons ensures the next agent does not repeat your expensive mistakes.
 

--- a/learn/agentos/decisions/0008-skill-anatomy-and-authoring-contract.md
+++ b/learn/agentos/decisions/0008-skill-anatomy-and-authoring-contract.md
@@ -89,6 +89,17 @@ ln -sf ../../.agents/skills/my-skill .claude/skills/my-skill
 
 When authoring sections within a skill (SKILL.md Map OR references/ Atlas), apply the 3-Axis Slot Rule from ADR 0007: evaluate each section on trigger-frequency × failure-severity × enforceability, then assign disposition (`keep` / `move` / `compress-to-trigger` / `rewrite` / `retire`). The substrate-vs-discipline tag (`MACHINE-ENFORCEABLE-CANDIDATE` / `DISCIPLINE-ONLY`) preserves authorial intent across compaction cycles. PR #11436 amends ADR 0007 to add a `recursive-reload-required` annotation column for skill manifest entries that are load-bearing for post-pruning behavioral-discipline recall.
 
+### 2.7 Lesson Promotion Atom
+
+Operational lessons promoted into skill substrate SHOULD be compressed into a decision atom before adding runtime prose:
+
+- **Bias** — the wrong default model or behavior the lesson is correcting.
+- **Rule** — the smallest durable behavior future agents must execute.
+- **Rationale** — the current architectural reason the rule exists.
+- **Trigger** — the condition that loads deeper payload or provenance, if needed.
+
+Runtime atoms belong in the skill payload section that actually fires. Incident history, examples, and provenance belong behind atlas/provenance pointers. New skills are reserved for genuinely new operational domains, not for every expensive lesson.
+
 ---
 
 ## 3. Consumers


### PR DESCRIPTION
Authored by GPT-5.5 (Codex Desktop). Session 019e56e6-7173-7bd3-879a-14f37712b52e.

FAIR-band: in-band [10/30]

Resolves #11884
Related: #11605

Codifies the lesson-promotion decision atom in ADR 0008 and rewrites the existing create-skill Lesson Promotion Path so agents classify lessons before appending prose. The resulting shape keeps runtime guidance compact: durable behavior enters the firing payload as `Bias` / `Rule` / `Rationale` / `Trigger`; historical/provenance detail stays behind atlas/provenance pointers.

Evidence: L1 (static docs + skill substrate lint) -> L1 required (documentation/substrate contract ACs). No residuals.

## Deltas from ticket

- Chose an in-place ADR 0008 amendment instead of a successor ADR because the change extends the existing skill-anatomy contract.
- Left `.agents/skills/create-skill/SKILL.md` unchanged; the router already points to the payload and did not need more loaded text.
- Did not migrate existing pr-review/pull-request skill bodies; this PR only changes the authoring contract for future lesson promotion.

## Substrate Mutation Rationale

- ADR 0008 `Lesson Promotion Atom`: `keep` inside the ADR decision section. Trigger-frequency is skill-authoring only, failure-severity is medium, enforceability is discipline-only; ADR placement keeps the WHY graph-queryable without loading it every turn.
- `create-skill` Lesson Promotion Path: `rewrite` of an existing payload section. It replaces append-first guidance with classify-first routing and has no `SKILL.md` router byte increase.
- Decision Record impact: ADR 0008 amended in place; no conflict with ADR 0007 compaction discipline.

## Test Evidence

- `git diff --check`
- `node ai/scripts/lint/lint-skill-manifest.mjs --base origin/dev`
- `node ai/scripts/lint/lint-agents.mjs --base origin/dev`
- `git diff --cached --check`

## Post-Merge Validation

- [ ] Future skill lesson-promotion changes route runtime lessons through the compact decision atom instead of appending incident history to runtime payloads.

## Commits

- `965ea0874` - `docs(skills): codify lesson promotion atoms (#11884)`
