### PR TITLE
feat(orchestrator): Sub 18 Phase 1a — scheduling registry + collector + picker scaffolding (#11862)

### DIFF
--- a/ai/daemons/orchestrator/scheduling/collector.mjs
+++ b/ai/daemons/orchestrator/scheduling/collector.mjs
@@ -1,0 +1,66 @@
+/**
+ * Pure collector for the Orchestrator scheduling pipeline.
+ *
+ * Iterates a registry of coordinator descriptors, projects each to a due-trigger via the
+ * descriptor's `getDueTask(context)` adapter, normalizes the trigger shape, and attaches
+ * the descriptor as metadata so downstream `pickNextCandidate` can apply policy rules.
+ *
+ * **Hard guardrail (ticket #11862 AC5):** this module contains NO `switch(...)` body,
+ * NO `executionKind === ...` branching, NO `maintenanceClass === ...` branching, NO
+ * `if (... profile ...)` branching. Policy decisions live in `pickNextCandidate`; per-task
+ * destructuring lives in registry descriptor adapters. The collector itself is pure
+ * iteration + normalization + metadata attachment.
+ *
+ * **Failure isolation without state mutation (ticket #11862 AC4):** when a descriptor's
+ * `getDueTask` throws, the collector captures the error in the returned `errors` array
+ * rather than calling `healthService.recordTaskOutcome(...)` directly. Caller (Orchestrator)
+ * iterates the errors array and performs the state-mutating reporting. This keeps the
+ * collector observably pure — assertable via spy/before-after-snapshot in unit tests.
+ *
+ * @param {Object} options
+ * @param {Array<Object>} options.registry Frozen task-descriptor registry (see `registry.mjs`).
+ * @param {Object} options.context Uniform context passed to every descriptor's `getDueTask`.
+ *   Must include `state`, `now`, `intervals`, `enables`, `hooks` (descriptor-specific
+ *   destructure shape lives inside each descriptor's adapter closure).
+ * @returns {{candidates: Array<Object>, errors: Array<Object>}} Due candidates and per-task
+ *   errors, both as plain data structures. No side effects.
+ */
+export function collectDueCandidates({registry, context}) {
+    const candidates = [];
+    const errors     = [];
+
+    for (const descriptor of registry) {
+        try {
+            const trigger = descriptor.getDueTask(context);
+            if (trigger) {
+                candidates.push({
+                    taskName: descriptor.taskName,
+                    trigger : normalizeTrigger(trigger),
+                    descriptor
+                });
+            }
+        } catch (error) {
+            errors.push({taskName: descriptor.taskName, error});
+        }
+    }
+
+    return {candidates, errors};
+}
+
+/**
+ * Normalizes a getDueTask return value to a uniform `{reason, onSuccess}` shape.
+ *
+ * Historical `CadenceEngine.runIfDue` accepted both boolean-true and object triggers;
+ * the registry now uses object triggers exclusively per the Sub 20 scheduling-module
+ * harmonization (#11864). This normalizer preserves backward compatibility for any
+ * future module that returns a bare-boolean trigger.
+ *
+ * @param {Object|Boolean} trigger Raw trigger from `getDueTask`.
+ * @returns {Object} Normalized `{reason, onSuccess?, ...originalFields}`.
+ */
+function normalizeTrigger(trigger) {
+    if (typeof trigger === 'object') {
+        return trigger;
+    }
+    return {reason: 'periodic-sync'};
+}

--- a/ai/daemons/orchestrator/scheduling/picker.mjs
+++ b/ai/daemons/orchestrator/scheduling/picker.mjs
@@ -1,0 +1,101 @@
+/**
+ * Pure policy picker for the Orchestrator scheduling pipeline.
+ *
+ * Takes the collector's due-candidates array and applies a sequence of policy filters,
+ * then selects at most one winner per poll cycle. Each filter is a pure function
+ * `Array<candidate> → Array<candidate>`; the pipeline composes them in priority order.
+ *
+ * Stage order (matters — earlier stages narrow the candidate set before later stages):
+ *   1. `filterAlreadyRunning`           — drop candidates whose task is already in `runningTasks`
+ *   2. `filterExclusiveHeavyConflict`   — drop heavy candidates if another heavy is running
+ *   3. `filterUnmetDependencies`        — drop candidates whose `dependencies` are in `runningTasks`
+ *   4. `selectFirstCandidate`           — pick the first remaining (registry-order priority)
+ *
+ * **NO state mutation.** This module reads `runningTasks` + `policyContext` but never
+ * writes to `TaskStateService`, `HealthService`, or lease state. Caller is responsible
+ * for state transitions when the winner actually executes.
+ *
+ * **Continuous tasks (chroma, bridgeDaemon, mlx) are NOT handled here** — those are
+ * supervisor-restart-cooldown tasks handled directly in `Orchestrator#poll()` before
+ * this pipeline runs. See `registry.mjs` head comment for the design rationale.
+ *
+ * @param {Object} options
+ * @param {Array<Object>} options.candidates Due candidates from `collectDueCandidates`.
+ * @param {Set<String>|Array<String>} options.runningTasks Task names currently running
+ *   (per `TaskStateService.getRunning()` or equivalent).
+ * @param {Object} options.policyContext Additional policy state (currently unused;
+ *   reserved for future deployment-profile + cross-daemon-lease integration).
+ * @returns {Object|null} The winning candidate, or null if no candidate survives the pipeline.
+ */
+export function pickNextCandidate({candidates, runningTasks, policyContext = {}}) {
+    const runningSet = runningTasks instanceof Set ? runningTasks : new Set(runningTasks);
+
+    const stages = [
+        candidates => filterAlreadyRunning(candidates, runningSet),
+        candidates => filterExclusiveHeavyConflict(candidates, policyContext),
+        candidates => filterUnmetDependencies(candidates, runningSet)
+    ];
+
+    let remaining = candidates;
+    for (const stage of stages) {
+        remaining = stage(remaining);
+        if (remaining.length === 0) return null;
+    }
+
+    return selectFirstCandidate(remaining);
+}
+
+/**
+ * Drops candidates whose task is already in the running set.
+ * Same-task back-to-back execution is prevented by the per-task `lastRunAt` cooldown
+ * that the descriptor's `getDueTask` already enforces; this filter handles the case
+ * where a long-running task's poll-cycle overlap surfaces the same candidate twice.
+ */
+function filterAlreadyRunning(candidates, runningSet) {
+    return candidates.filter(candidate => !runningSet.has(candidate.taskName));
+}
+
+/**
+ * Heavy-class candidates (`maintenanceClass: 'heavy'`) require exclusive heavy access.
+ * If ANY task with `maintenanceClass: 'heavy'` is already running, drop all heavy
+ * candidates from this poll cycle.
+ *
+ * The caller must pre-compute `runningHeavyTasks` (a Set of currently-running task names
+ * whose descriptors carry `maintenanceClass: 'heavy'`) and pass it via `policyContext`.
+ * The picker cannot derive this from `runningSet` alone because running tasks are just
+ * names — they have no descriptor metadata. The caller owns the registry lookup.
+ *
+ * Lightweight, continuous, and graph-dependent candidates are unaffected by this filter.
+ */
+function filterExclusiveHeavyConflict(candidates, policyContext) {
+    const runningHeavy = policyContext.runningHeavyTasks;
+    if (!runningHeavy || runningHeavy.size === 0) return candidates;
+
+    return candidates.filter(candidate => candidate.descriptor.maintenanceClass !== 'heavy');
+}
+
+/**
+ * Drops candidates whose declared `dependencies` (other task names) are currently running.
+ * Example: `golden-path` declares `dependencies: ['dream']` so it waits until dream
+ * finishes before scheduling its own pass.
+ *
+ * Dependencies are static per descriptor; same-poll handoffs (a dependency started AND
+ * its dependent both due in the same poll) are handled by the caller — the picker only
+ * sees the running set at pipeline-entry time. Caller may re-collect after starting a
+ * dependency to allow same-poll handoff.
+ */
+function filterUnmetDependencies(candidates, runningSet) {
+    return candidates.filter(candidate => {
+        const deps = candidate.descriptor.dependencies || [];
+        return deps.every(dep => !runningSet.has(dep));
+    });
+}
+
+/**
+ * Selects the first candidate from the filtered list. Registry order is the priority:
+ * earlier descriptors win ties. Adjust `TASK_REGISTRY` order to change priority.
+ */
+function selectFirstCandidate(candidates) {
+    return candidates[0] ?? null;
+}
+

--- a/ai/daemons/orchestrator/scheduling/picker.mjs
+++ b/ai/daemons/orchestrator/scheduling/picker.mjs
@@ -98,4 +98,3 @@ function filterUnmetDependencies(candidates, runningSet) {
 function selectFirstCandidate(candidates) {
     return candidates[0] ?? null;
 }
-

--- a/ai/daemons/orchestrator/scheduling/registry.mjs
+++ b/ai/daemons/orchestrator/scheduling/registry.mjs
@@ -1,0 +1,143 @@
+import {getDueTask as getSummaryDueTask}             from './summary.mjs';
+import {getDueTask as getBackupDueTask}              from './backup.mjs';
+import {getDueTask as getDreamDueTask}               from './dream.mjs';
+import {getDueTask as getGoldenPathDueTask}          from './goldenPath.mjs';
+import {getDueTask as getPrimaryDevSyncDueTask}      from './primaryDevSync.mjs';
+import {getDueTask as getSwarmHeartbeatDueTask}      from './swarmHeartbeat.mjs';
+
+/**
+ * Coordinator-descriptor registry for the Orchestrator scheduling pipeline.
+ *
+ * Each descriptor maps a logical scheduling lane to:
+ *   - `taskName`         — stable identity for state, lease, and health-record keying
+ *   - `executionKind`    — dispatch discriminator for `Orchestrator#execute(winner)`
+ *   - `maintenanceClass` — backpressure-policy bucket for `pickNextCandidate`
+ *   - `backpressure`     — interaction rule with concurrent heavy maintenance
+ *   - `dependencies`     — task names that must NOT be running before this one starts
+ *   - `getDueTask`       — pure-function trigger projection (no I/O, no state writes)
+ *
+ * The `getDueTask` closure adapts the uniform `context` passed by the collector to each
+ * scheduling module's specific destructure shape. This adapter lives INSIDE the descriptor
+ * — the collector itself must remain branchless per `Orchestrator.spec` AC5 guardrail.
+ *
+ * Continuous tasks (`chroma`, `bridgeDaemon`, `mlx`) are intentionally NOT in this registry
+ * — they are supervisor-restart-cooldown tasks handled directly in `Orchestrator#poll()`
+ * before the cadence-driven pipeline runs. They have no cadence trigger, no due-check, and
+ * no backpressure interaction. Forcing them into the descriptor model would require a
+ * `maintenanceClass: 'continuous'` discriminator the picker would just bypass — pure ceremony.
+ *
+ * @see Orchestrator#poll
+ * @see collectDueCandidates
+ * @see pickNextCandidate
+ */
+export const TASK_REGISTRY = Object.freeze([
+    {
+        taskName        : 'summary',
+        executionKind   : 'supervised-child-process',
+        maintenanceClass: 'continuous',
+        backpressure    : 'none',
+        dependencies    : [],
+        getDueTask({db, state, now, intervals, hooks}) {
+            return getSummaryDueTask({
+                db,
+                state,
+                now,
+                summarySweepIntervalMs: intervals.summarySweep,
+                log                   : hooks.log
+            });
+        }
+    },
+    {
+        taskName        : 'kbSync',
+        executionKind   : 'supervised-child-process',
+        maintenanceClass: 'heavy',
+        backpressure    : 'exclusive-heavy',
+        dependencies    : [],
+        getDueTask({state, now, intervals, enables}) {
+            if (!enables.kbSync) return null;
+            const lastRunAt  = state.kbSync?.lastRunAt ?? 0;
+            const intervalMs = intervals.kbSync;
+            if (intervalMs > 0 && now - lastRunAt >= intervalMs) {
+                return {
+                    taskName: 'kbSync',
+                    source  : 'periodic-sync',
+                    reason  : `periodic-sync:${intervalMs}`
+                };
+            }
+            return null;
+        }
+    },
+    {
+        taskName        : 'backup',
+        executionKind   : 'supervised-child-process',
+        maintenanceClass: 'heavy',
+        backpressure    : 'exclusive-heavy',
+        dependencies    : [],
+        getDueTask({state, now, intervals}) {
+            return getBackupDueTask({
+                state,
+                now,
+                backupIntervalMs: intervals.backup
+            });
+        }
+    },
+    {
+        taskName        : 'primary-dev-sync',
+        executionKind   : 'service-runner',
+        maintenanceClass: 'continuous',
+        backpressure    : 'none',
+        dependencies    : [],
+        getDueTask({state, now, intervals, enables}) {
+            return getPrimaryDevSyncDueTask({
+                state,
+                now,
+                intervalMs: intervals.primaryDevSync,
+                enabled   : enables.primaryDevSync
+            });
+        }
+    },
+    {
+        taskName        : 'dream',
+        executionKind   : 'in-process-async',
+        maintenanceClass: 'graph-dependent',
+        backpressure    : 'after-heavy',
+        dependencies    : [],
+        getDueTask({state, now, intervals}) {
+            return getDreamDueTask({
+                state            : state.dream ?? {},
+                now,
+                dreamIntervalMs  : intervals.dream
+            });
+        }
+    },
+    {
+        taskName        : 'golden-path',
+        executionKind   : 'in-process-async',
+        maintenanceClass: 'graph-dependent',
+        backpressure    : 'after-heavy',
+        dependencies    : ['dream'],
+        getDueTask({state, now, intervals}) {
+            return getGoldenPathDueTask({
+                state               : state['golden-path'] ?? {},
+                now,
+                goldenPathIntervalMs: intervals.goldenPath
+            });
+        }
+    },
+    {
+        taskName        : 'swarm-heartbeat',
+        executionKind   : 'in-process-async',
+        maintenanceClass: 'lightweight-signal',
+        backpressure    : 'none',
+        dependencies    : [],
+        getDueTask({state, now, intervals, enables, hooks}) {
+            if (!enables.swarmHeartbeat) return null;
+            if (hooks.swarmHeartbeatInitFailed) return null;
+            return getSwarmHeartbeatDueTask({
+                state                   : state['swarm-heartbeat'] ?? {},
+                now,
+                swarmHeartbeatIntervalMs: intervals.swarmHeartbeat
+            });
+        }
+    }
+]);

--- a/test/playwright/unit/ai/daemons/orchestrator/scheduling/collector.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/scheduling/collector.spec.mjs
@@ -1,0 +1,146 @@
+import {test, expect} from '@playwright/test';
+import fs from 'fs/promises';
+import path from 'path';
+import {fileURLToPath} from 'url';
+import {collectDueCandidates} from '../../../../../../../ai/daemons/orchestrator/scheduling/collector.mjs';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname  = path.dirname(__filename);
+const COLLECTOR_PATH = path.resolve(__dirname, '../../../../../../../ai/daemons/orchestrator/scheduling/collector.mjs');
+
+function makeContext(overrides = {}) {
+    return {
+        db        : {},
+        state     : {},
+        now       : 1_000_000,
+        intervals : {
+            summarySweep   : 600_000,
+            kbSync         : 600_000,
+            backup         : 3_600_000,
+            primaryDevSync : 600_000,
+            dream          : 600_000,
+            goldenPath     : 600_000,
+            swarmHeartbeat : 600_000
+        },
+        enables   : {
+            kbSync         : false,
+            swarmHeartbeat : false,
+            primaryDevSync : false
+        },
+        hooks     : {
+            log                       : () => {},
+            swarmHeartbeatInitFailed  : false
+        },
+        ...overrides
+    };
+}
+
+test.describe('orchestrator/scheduling/collector (#11862 Sub 18)', () => {
+    test('returns {candidates, errors} with empty registry → both empty', () => {
+        const result = collectDueCandidates({registry: [], context: makeContext()});
+        expect(result.candidates).toEqual([]);
+        expect(result.errors).toEqual([]);
+    });
+
+    test('collects a single due candidate when descriptor returns a trigger', () => {
+        const descriptor = {
+            taskName        : 'fake-task',
+            executionKind   : 'in-process-async',
+            maintenanceClass: 'continuous',
+            backpressure    : 'none',
+            dependencies    : [],
+            getDueTask      : () => ({taskName: 'fake-task', reason: 'test-trigger'})
+        };
+        const {candidates, errors} = collectDueCandidates({registry: [descriptor], context: makeContext()});
+        expect(candidates).toHaveLength(1);
+        expect(candidates[0].taskName).toBe('fake-task');
+        expect(candidates[0].trigger.reason).toBe('test-trigger');
+        expect(candidates[0].descriptor).toBe(descriptor);
+        expect(errors).toEqual([]);
+    });
+
+    test('skips descriptors whose getDueTask returns null', () => {
+        const descriptor = {
+            taskName        : 'not-due',
+            executionKind   : 'in-process-async',
+            maintenanceClass: 'continuous',
+            backpressure    : 'none',
+            dependencies    : [],
+            getDueTask      : () => null
+        };
+        const {candidates, errors} = collectDueCandidates({registry: [descriptor], context: makeContext()});
+        expect(candidates).toEqual([]);
+        expect(errors).toEqual([]);
+    });
+
+    test('captures errors per descriptor without throwing (failure isolation, #11862 AC4)', () => {
+        const throwingDescriptor = {
+            taskName        : 'broken',
+            executionKind   : 'in-process-async',
+            maintenanceClass: 'continuous',
+            backpressure    : 'none',
+            dependencies    : [],
+            getDueTask      : () => { throw new Error('schedule failure'); }
+        };
+        const okDescriptor = {
+            taskName        : 'works',
+            executionKind   : 'in-process-async',
+            maintenanceClass: 'continuous',
+            backpressure    : 'none',
+            dependencies    : [],
+            getDueTask      : () => ({taskName: 'works', reason: 'ok'})
+        };
+        const {candidates, errors} = collectDueCandidates({
+            registry: [throwingDescriptor, okDescriptor],
+            context : makeContext()
+        });
+        expect(candidates).toHaveLength(1);
+        expect(candidates[0].taskName).toBe('works');
+        expect(errors).toHaveLength(1);
+        expect(errors[0].taskName).toBe('broken');
+        expect(errors[0].error.message).toBe('schedule failure');
+    });
+
+    test('NEGATIVE: collector causes no observable state mutation (#11862 AC4)', () => {
+        // Spies on hooks that COULD be misused for state mutation. Collector must not call them.
+        let logCallCount = 0;
+        const log = () => { logCallCount++; };
+
+        // Snapshot context before
+        const context = makeContext({hooks: {log, swarmHeartbeatInitFailed: false}});
+        const contextSnapshot = JSON.stringify({
+            state    : context.state,
+            intervals: context.intervals,
+            enables  : context.enables
+        });
+
+        const descriptor = {
+            taskName        : 'state-write-attempt',
+            executionKind   : 'in-process-async',
+            maintenanceClass: 'continuous',
+            backpressure    : 'none',
+            dependencies    : [],
+            getDueTask      : () => ({taskName: 'state-write-attempt', reason: 'test'})
+        };
+        collectDueCandidates({registry: [descriptor], context});
+
+        // Hook log NOT called (collector doesn't write to log)
+        expect(logCallCount).toBe(0);
+        // Context unchanged
+        const after = JSON.stringify({state: context.state, intervals: context.intervals, enables: context.enables});
+        expect(after).toBe(contextSnapshot);
+    });
+
+    test('HARD GUARDRAIL: source contains no executionKind/maintenanceClass/profile branching (#11862 AC5)', async () => {
+        const source = await fs.readFile(COLLECTOR_PATH, 'utf8');
+        // Strip comments (block + line) before matching so doc-comment text mentioning these
+        // tokens doesn't false-positive the guardrail.
+        const code = source
+            .replace(/\/\*[\s\S]*?\*\//g, '')   // /* ... */ block comments
+            .replace(/\/\/[^\n]*/g, '');         // // line comments
+        expect(code).not.toMatch(/switch\s*\(/);
+        expect(code).not.toMatch(/executionKind\s*===/);
+        expect(code).not.toMatch(/maintenanceClass\s*===/);
+        expect(code).not.toMatch(/if\s*\([^)]*profile/);
+    });
+});

--- a/test/playwright/unit/ai/daemons/orchestrator/scheduling/picker.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/scheduling/picker.spec.mjs
@@ -1,0 +1,123 @@
+import {test, expect} from '@playwright/test';
+import {pickNextCandidate} from '../../../../../../../ai/daemons/orchestrator/scheduling/picker.mjs';
+
+function makeCandidate(taskName, descriptorOverrides = {}) {
+    return {
+        taskName,
+        trigger: {reason: `${taskName}-test`},
+        descriptor: {
+            taskName,
+            executionKind   : 'in-process-async',
+            maintenanceClass: 'continuous',
+            backpressure    : 'none',
+            dependencies    : [],
+            ...descriptorOverrides
+        }
+    };
+}
+
+test.describe('orchestrator/scheduling/picker (#11862 Sub 18)', () => {
+    test('returns null when no candidates provided', () => {
+        expect(pickNextCandidate({candidates: [], runningTasks: []})).toBeNull();
+    });
+
+    test('returns the first candidate when none are running and no conflicts', () => {
+        const candidates = [makeCandidate('summary'), makeCandidate('backup')];
+        const winner = pickNextCandidate({candidates, runningTasks: []});
+        expect(winner.taskName).toBe('summary');
+    });
+
+    test('filterAlreadyRunning: drops candidates whose task is already running', () => {
+        const candidates = [makeCandidate('summary'), makeCandidate('backup')];
+        const winner = pickNextCandidate({candidates, runningTasks: ['summary']});
+        expect(winner.taskName).toBe('backup');
+    });
+
+    test('filterAlreadyRunning: handles Set or Array for runningTasks', () => {
+        const candidates = [makeCandidate('summary'), makeCandidate('backup')];
+        const winnerArr = pickNextCandidate({candidates, runningTasks: ['summary']});
+        const winnerSet = pickNextCandidate({candidates, runningTasks: new Set(['summary'])});
+        expect(winnerArr.taskName).toBe('backup');
+        expect(winnerSet.taskName).toBe('backup');
+    });
+
+    test('filterExclusiveHeavyConflict: drops heavy candidates when another heavy is running', () => {
+        const candidates = [
+            makeCandidate('backup', {maintenanceClass: 'heavy'}),    // heavy, also running
+            makeCandidate('kbSync', {maintenanceClass: 'heavy'}),
+            makeCandidate('summary', {maintenanceClass: 'continuous'})
+        ];
+        const winner = pickNextCandidate({
+            candidates,
+            runningTasks  : ['backup'],
+            policyContext : {runningHeavyTasks: new Set(['backup'])}
+        });
+        // backup filtered out by filterAlreadyRunning
+        // kbSync filtered out by filterExclusiveHeavyConflict (backup heavy in runningHeavyTasks)
+        // summary survives (continuous, not heavy)
+        expect(winner.taskName).toBe('summary');
+    });
+
+    test('filterExclusiveHeavyConflict: no-op when no heavy is running', () => {
+        const candidates = [
+            makeCandidate('backup', {maintenanceClass: 'heavy'}),
+            makeCandidate('kbSync', {maintenanceClass: 'heavy'})
+        ];
+        const winner = pickNextCandidate({
+            candidates,
+            runningTasks  : [],
+            policyContext : {runningHeavyTasks: new Set()}
+        });
+        expect(winner.taskName).toBe('backup');
+    });
+
+    test('filterUnmetDependencies: drops golden-path when dream is running', () => {
+        const candidates = [
+            makeCandidate('golden-path', {dependencies: ['dream']}),
+            makeCandidate('summary')
+        ];
+        const winner = pickNextCandidate({candidates, runningTasks: ['dream']});
+        expect(winner.taskName).toBe('summary');
+    });
+
+    test('filterUnmetDependencies: passes golden-path when dream is NOT running', () => {
+        const candidates = [
+            makeCandidate('golden-path', {dependencies: ['dream']}),
+            makeCandidate('summary')
+        ];
+        const winner = pickNextCandidate({candidates, runningTasks: []});
+        expect(winner.taskName).toBe('golden-path');
+    });
+
+    test('returns null when all candidates filtered out', () => {
+        const candidates = [
+            makeCandidate('summary'),
+            makeCandidate('backup')
+        ];
+        const winner = pickNextCandidate({candidates, runningTasks: ['summary', 'backup']});
+        expect(winner).toBeNull();
+    });
+
+    test('NEGATIVE: picker causes no state mutation', () => {
+        // Picker reads candidates + runningTasks; it must not mutate either.
+        const candidates = [makeCandidate('summary'), makeCandidate('backup')];
+        const candidatesSnapshot = JSON.stringify(candidates);
+        const runningTasks = ['some-task'];
+        const runningSnapshot = JSON.stringify(runningTasks);
+
+        pickNextCandidate({candidates, runningTasks});
+
+        expect(JSON.stringify(candidates)).toBe(candidatesSnapshot);
+        expect(JSON.stringify(runningTasks)).toBe(runningSnapshot);
+    });
+
+    test('selectFirstCandidate: registry-order priority preserved through pipeline', () => {
+        const candidates = [
+            makeCandidate('first'),
+            makeCandidate('second'),
+            makeCandidate('third')
+        ];
+        const winner = pickNextCandidate({candidates, runningTasks: []});
+        expect(winner.taskName).toBe('first');
+    });
+});

--- a/test/playwright/unit/ai/daemons/orchestrator/scheduling/registry.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/scheduling/registry.spec.mjs
@@ -1,0 +1,54 @@
+import {test, expect} from '@playwright/test';
+import {TASK_REGISTRY} from '../../../../../../../ai/daemons/orchestrator/scheduling/registry.mjs';
+
+const VALID_EXECUTION_KINDS = ['supervised-child-process', 'service-runner', 'in-process-async', 'local-only-service'];
+const VALID_MAINTENANCE_CLASSES = ['continuous', 'heavy', 'graph-dependent', 'lightweight-signal', 'local-only'];
+const VALID_BACKPRESSURE = ['none', 'exclusive-heavy', 'after-heavy'];
+
+test.describe('orchestrator/scheduling/registry (#11862 Sub 18)', () => {
+    test('TASK_REGISTRY is a frozen array (immutability invariant)', () => {
+        expect(Array.isArray(TASK_REGISTRY)).toBe(true);
+        expect(Object.isFrozen(TASK_REGISTRY)).toBe(true);
+    });
+
+    test('each descriptor has the required shape', () => {
+        for (const descriptor of TASK_REGISTRY) {
+            expect(typeof descriptor.taskName).toBe('string');
+            expect(descriptor.taskName.length).toBeGreaterThan(0);
+            expect(VALID_EXECUTION_KINDS).toContain(descriptor.executionKind);
+            expect(VALID_MAINTENANCE_CLASSES).toContain(descriptor.maintenanceClass);
+            expect(VALID_BACKPRESSURE).toContain(descriptor.backpressure);
+            expect(Array.isArray(descriptor.dependencies)).toBe(true);
+            expect(typeof descriptor.getDueTask).toBe('function');
+        }
+    });
+
+    test('taskName is unique across descriptors (no collision)', () => {
+        const names = TASK_REGISTRY.map(d => d.taskName);
+        expect(new Set(names).size).toBe(names.length);
+    });
+
+    test('dependencies reference valid taskNames (no dangling references)', () => {
+        const names = new Set(TASK_REGISTRY.map(d => d.taskName));
+        for (const descriptor of TASK_REGISTRY) {
+            for (const dep of descriptor.dependencies) {
+                expect(names).toContain(dep);
+            }
+        }
+    });
+
+    test('expected scheduling lanes are registered (#11862 Prescription parity)', () => {
+        const names = TASK_REGISTRY.map(d => d.taskName);
+        expect(names).toEqual(expect.arrayContaining([
+            'summary', 'kbSync', 'backup', 'primary-dev-sync',
+            'dream', 'golden-path', 'swarm-heartbeat'
+        ]));
+    });
+
+    test('continuous tasks (chroma/bridgeDaemon/mlx) are intentionally NOT in registry', () => {
+        const names = TASK_REGISTRY.map(d => d.taskName);
+        expect(names).not.toContain('chroma');
+        expect(names).not.toContain('bridgeDaemon');
+        expect(names).not.toContain('mlx');
+    });
+});


### PR DESCRIPTION
Authored by Claude Opus 4.7 (Claude Code). Session ba62643a-ae78-41b2-9ce5-e7890155760b.

FAIR-band: under-target [1/30].

Refs #11862 (Phase 1a of 3; non-closing reference per close-target discipline; #11900 carries Phase 1b MBS wiring + Phase 2 dispatch switch).

Evidence: L1 (scheduling/* registry + collector + picker specs 23/23 pass) → L1 required (substrate-quality unit-test coverage for new pure-function primitives). No residuals.

## Summary

**Drop+Supersede of PR #11899** — that PR conflated 3 distinct concerns (scaffolding + MBS wiring + Neo-conventions rework). GPT REQUEST_CHANGES (PRR_kwDODSospM8AAAABA3K5cQ) + operator critique (~13:11Z + ~13:18Z) surfaced (a) per-poll MBS binding refresh is not Neo best-practice, (b) afterSetX hooks missing `(value, oldValue)` signature per `core.Base.mjs:71-77`, (c) test-isolation failures reproduce on independent machines. Substrate-restraint discipline (`feedback_substrate_scope_restraint.md`) applied: 3 fix cycles + GPT empirical failure → Drop+Supersede over iteration.

This PR ships ONLY the scaffolding (Commit 019807f75 from prior branch): 3 new pure-function modules + 3 new spec files. Zero Orchestrator.mjs changes. MBS wiring + Neo-conventions rework moved to #11900 expansion.

## Files Changed (6 — 3 new source + 3 new spec)

- **NEW** `ai/daemons/orchestrator/scheduling/registry.mjs` (+90 LOC) — 7 frozen coordinator descriptors: summary, kbSync, backup, primary-dev-sync, dream, golden-path, swarm-heartbeat. Continuous tasks (chroma/bridgeDaemon/mlx) intentionally OUT of registry.
- **NEW** `ai/daemons/orchestrator/scheduling/collector.mjs` (+50 LOC) — `collectDueCandidates({registry, context})` returns `{candidates, errors}`. Failure-isolation via errors-as-data.
- **NEW** `ai/daemons/orchestrator/scheduling/picker.mjs` (+95 LOC) — `pickNextCandidate({candidates, runningTasks, policyContext})` with 3-stage pipeline.
- **NEW** 3 spec files in `test/playwright/unit/ai/daemons/orchestrator/scheduling/` — 23 tests; AC4 negative test + AC5 source-text guardrail enforced.

## Acceptance Criteria (Phase 1a of 3)

| AC | Status | Detail |
|----|--------|---------|
| AC1 (partial): Registry + collectDueCandidates + pickNextCandidate land | ✅ | Phase 1a; CadenceEngine.runIfDue executeFn drop deferred to Phase 2 (#11900) |
| AC4: collectDueCandidates no state mutation | ✅ | NEGATIVE test in collector.spec.mjs |
| AC5: collectDueCandidates contains no switch(profile) | ✅ | Source-text guardrail test in collector.spec.mjs |
| AC2, AC3, AC6, AC7: all Orchestrator.mjs-touching work | ⚠️ Deferred Phase 1b/2 | See #11900 expanded scope |

## Test Evidence

- `npm run test-unit -- test/playwright/unit/ai/daemons/orchestrator/scheduling/` → 23/23 pass
- Pre-commit `check-whitespace.mjs` + `lint-skill-manifest.mjs` pass
- `git diff --check origin/dev...HEAD` clean

## Out of Scope (Phase 1a)

- All Orchestrator.mjs modifications (MBS wiring, method deletions, executor wrapping) — deferred to Phase 1b (#11900)
- CadenceEngine.runIfDue executeFn drop — Phase 2 (#11900)
- Sub-13 cleanup (class @summary + section dividers) — Phase 2 (#11900)
- Test collapse (13 mock-heavy Orchestrator.spec.mjs tests) — Phase 2 (#11900)
- Neo-conventions rework (per-poll refresh removal + afterSetX signature fix + singleton-state-leak root cause) — Phase 1b (#11900)

## Avoided Traps

- ❌ Shipping PR #11899 with documented tech-debt that ships broken tests on independent machines (GPT empirical failure) — substrate-quality regression
- ❌ Iterating per-poll refresh fix beyond 3 cycles (`feedback_substrate_scope_restraint.md`)
- ❌ Bypassing Neo class system + `core.Base.mjs` reactive conventions in Phase 1 — moved to #11900 with explicit operator-mandate to "read Neo.mjs root + core.Base before working on Neo classes"
- ❌ Inflating Phase 1 scope to look "done" — honest scaffolding-only framing

## Depends on

Sub 19 #11861 (MaintenanceBackpressureService) — merged but NOT activated by this PR (Phase 1b in #11900 activates).

## Post-Merge Validation

- [ ] Next /pr-review on a PR touching ai/daemons/orchestrator/scheduling/ exercises the new primitives correctly
- [ ] #11900 Phase 1b scope confirmed: MBS wiring + per-orchestrator-instance state isolation (NOT singleton-leak workaround)

## Deltas from ticket

- Phase 1a/1b/2 split (was Phase 1/2 in prior PR #11899; further-decomposed after operator critique on Neo-conventions adherence + GPT empirical test-isolation failure).
- Substantive direction unchanged from #11862 Plan agent design; mechanical execution further-decomposed for substrate-correctness.

## Supersedes

PR #11899 (Drop+Supersede per substrate-restraint discipline after 3 fix cycles + GPT REQUEST_CHANGES). Branch `tobiu/11862-orchestrator-sub-18` retained for archaeology (commits 6eef402d3 + 6d7d1acd8 + 85e6b4928 document hypothesis-was-wrong cycles for future-session debug reference).

🤖 Generated with [Claude Code](https://claude.com/claude-code)