### PR TITLE
feat(orchestrator): add resolveSwarmHeartbeatTargets with 5-step precedence chain (#11905)

### DIFF
--- a/ai/config.template.mjs
+++ b/ai/config.template.mjs
@@ -87,6 +87,25 @@ const defaultConfig = {
             swarmHeartbeatMs : 15 * 60 * 1000
         },
         /**
+         * Swarm-heartbeat target-resolver config (Sub 1 #11905 / Epic #11829 Layer 2).
+         * Controls which identity set `SwarmHeartbeatService.pulse()` targets per cycle
+         * via the {@link resolveTargets} 5-step precedence chain. Env override:
+         * `NEO_ORCHESTRATOR_SWARM_HEARTBEAT_TARGET_SOURCE`. Explicit list override
+         * (highest precedence): `NEO_ORCHESTRATOR_SWARM_HEARTBEAT_TARGETS` (comma-separated).
+         * @type {Object}
+         */
+        swarmHeartbeat: {
+            /**
+             * Resolver source enum. `null` falls through to `'self'` — the deployment-portable
+             * default. Valid values: `'self'`, `'active-local-team'`, `'active-subscribers'`,
+             * `'disabled'`. AC3 fork-safety: external workspaces with no config default to
+             * `'self'`; the lane NEVER silently fans out to Neo maintainer identities unless
+             * the operator explicitly opts in via `'active-local-team'`.
+             * @type {'self'|'active-local-team'|'active-subscribers'|'disabled'|null}
+             */
+            targetSource: null
+        },
+        /**
          * Local-only maintenance lane switches. Cloud deployments can disable these
          * without changing remote graph-backed A2A / Memory Core behavior.
          * `null` means "use the deployment profile default" (`local` enables,

--- a/ai/config.template.mjs
+++ b/ai/config.template.mjs
@@ -87,20 +87,21 @@ const defaultConfig = {
             swarmHeartbeatMs : 15 * 60 * 1000
         },
         /**
-         * Swarm-heartbeat target-resolver config (Sub 1 #11905 / Epic #11829 Layer 2).
-         * Controls which identity set `SwarmHeartbeatService.pulse()` targets per cycle
-         * via the {@link resolveTargets} 5-step precedence chain. Env override:
-         * `NEO_ORCHESTRATOR_SWARM_HEARTBEAT_TARGET_SOURCE`. Explicit list override
-         * (highest precedence): `NEO_ORCHESTRATOR_SWARM_HEARTBEAT_TARGETS` (comma-separated).
+         * Swarm-heartbeat target-resolver config. Controls which identity set
+         * `SwarmHeartbeatService.pulse()` targets per cycle via the resolver
+         * precedence chain. Env override: `NEO_ORCHESTRATOR_SWARM_HEARTBEAT_TARGET_SOURCE`.
+         * Explicit list override (highest precedence):
+         * `NEO_ORCHESTRATOR_SWARM_HEARTBEAT_TARGETS` (comma-separated handles).
          * @type {Object}
          */
         swarmHeartbeat: {
             /**
-             * Resolver source enum. `null` falls through to `'self'` — the deployment-portable
-             * default. Valid values: `'self'`, `'active-local-team'`, `'active-subscribers'`,
-             * `'disabled'`. AC3 fork-safety: external workspaces with no config default to
-             * `'self'`; the lane NEVER silently fans out to Neo maintainer identities unless
-             * the operator explicitly opts in via `'active-local-team'`.
+             * Resolver source enum. `null` falls through to `'self'` — the
+             * deployment-portable default. Valid values: `'self'`,
+             * `'active-local-team'`, `'active-subscribers'`, `'disabled'`. External
+             * workspaces with no config default to `'self'`; the lane never silently
+             * fans out to maintainer identities unless the operator explicitly opts
+             * in via `'active-local-team'`.
              * @type {'self'|'active-local-team'|'active-subscribers'|'disabled'|null}
              */
             targetSource: null

--- a/ai/daemons/orchestrator/Orchestrator.mjs
+++ b/ai/daemons/orchestrator/Orchestrator.mjs
@@ -274,6 +274,20 @@ export class Orchestrator extends Base {
     get goldenPathIntervalMs()    { return Env.parseNumber('NEO_ORCHESTRATOR_GOLDEN_PATH_INTERVAL_MS')      ?? AiConfig.orchestrator.intervals.goldenPathMs;       }
     get swarmHeartbeatIntervalMs(){ return Env.parseNumber('NEO_ORCHESTRATOR_SWARM_HEARTBEAT_INTERVAL_MS')  ?? AiConfig.orchestrator.intervals.swarmHeartbeatMs;   }
     get swarmHeartbeatIdentity()  { return Env.parseString('NEO_AGENT_IDENTITY');                                                                                  }
+    get swarmHeartbeatTargetSource() { return Env.parseString('NEO_ORCHESTRATOR_SWARM_HEARTBEAT_TARGET_SOURCE') ?? AiConfig.orchestrator.swarmHeartbeat?.targetSource ?? null; }
+    /**
+     * Explicit env-driven target list for the swarm-heartbeat resolver. Comma-separated
+     * `@handle` form via `NEO_ORCHESTRATOR_SWARM_HEARTBEAT_TARGETS`. Empty/absent →
+     * `null` so the resolver falls through to `targetSource` semantics. Sub 1 #11905 /
+     * Epic #11829 Layer 2.
+     * @returns {String[]|null}
+     */
+    get swarmHeartbeatExplicitTargets() {
+        const raw = Env.parseString('NEO_ORCHESTRATOR_SWARM_HEARTBEAT_TARGETS');
+        if (!raw) return null;
+        const list = raw.split(',').map(s => s.trim()).filter(Boolean);
+        return list.length > 0 ? list : null;
+    }
 
     get kbSyncEnabled()                  { return Env.parseBool('NEO_ORCHESTRATOR_KB_SYNC_ENABLED')                     ?? resolveDeploymentEnabled('kbSyncEnabled');                  }
     get primaryDevSyncEnabled()          { return Env.parseBool('NEO_ORCHESTRATOR_PRIMARY_DEV_SYNC_ENABLED')            ?? resolveDeploymentEnabled('primaryDevSyncEnabled');          }
@@ -352,8 +366,10 @@ export class Orchestrator extends Base {
                 // initAsync() is identity-agnostic (peer-service .ready() only); identity
                 // and pollIntervalMs are read by pulse() per tick, so post-init assignment
                 // is sufficient. Order matches the JSDoc contract on the service class.
-                this.swarmHeartbeatService.identity       = this.swarmHeartbeatIdentity;
-                this.swarmHeartbeatService.pollIntervalMs = this.swarmHeartbeatIntervalMs;
+                this.swarmHeartbeatService.identity        = this.swarmHeartbeatIdentity;
+                this.swarmHeartbeatService.pollIntervalMs  = this.swarmHeartbeatIntervalMs;
+                this.swarmHeartbeatService.targetSource    = this.swarmHeartbeatTargetSource;
+                this.swarmHeartbeatService.explicitTargets = this.swarmHeartbeatExplicitTargets;
                 await this.swarmHeartbeatService.ready();
             } catch (e) {
                 this.writeLog('ERROR', `[Orchestrator] Swarm heartbeat init failed; lane disabled this run: ${e.message}`);

--- a/ai/daemons/orchestrator/Orchestrator.mjs
+++ b/ai/daemons/orchestrator/Orchestrator.mjs
@@ -277,9 +277,8 @@ export class Orchestrator extends Base {
     get swarmHeartbeatTargetSource() { return Env.parseString('NEO_ORCHESTRATOR_SWARM_HEARTBEAT_TARGET_SOURCE') ?? AiConfig.orchestrator.swarmHeartbeat?.targetSource ?? null; }
     /**
      * Explicit env-driven target list for the swarm-heartbeat resolver. Comma-separated
-     * `@handle` form via `NEO_ORCHESTRATOR_SWARM_HEARTBEAT_TARGETS`. Empty/absent →
-     * `null` so the resolver falls through to `targetSource` semantics. Sub 1 #11905 /
-     * Epic #11829 Layer 2.
+     * `@handle` form via `NEO_ORCHESTRATOR_SWARM_HEARTBEAT_TARGETS`. Empty or absent →
+     * `null` so the resolver falls through to `targetSource` semantics.
      * @returns {String[]|null}
      */
     get swarmHeartbeatExplicitTargets() {

--- a/ai/daemons/orchestrator/scheduling/swarmHeartbeat.mjs
+++ b/ai/daemons/orchestrator/scheduling/swarmHeartbeat.mjs
@@ -38,38 +38,39 @@ export function getDueTask({state, now, swarmHeartbeatIntervalMs}) {
 /**
  * @summary Resolve the per-pulse identity set the swarm-heartbeat lane should target.
  *
- * 5-step precedence chain (Epic #11829 AC2, Sub 1 #11905):
+ * Five-step precedence chain:
  *
- *   1. Explicit `explicitTargets` env list (highest precedence; bypasses source-based logic).
+ *   1. Explicit `explicitTargets` list (highest precedence; bypasses source-based logic).
  *      Sourced from `NEO_ORCHESTRATOR_SWARM_HEARTBEAT_TARGETS` (comma-separated handles).
- *   2. `targetSource` enum (`'self'|'active-local-team'|'active-subscribers'|'disabled'`).
- *      Env-overridable via `NEO_ORCHESTRATOR_SWARM_HEARTBEAT_TARGET_SOURCE`.
- *   3. Default `'self'` when `targetSource` is nullish — the safe deployment-portable default.
+ *   2. `targetSource` enum (`'self'|'active-local-team'|'active-subscribers'|'disabled'`),
+ *      env-overridable via `NEO_ORCHESTRATOR_SWARM_HEARTBEAT_TARGET_SOURCE`.
+ *   3. Default `'self'` when `targetSource` is nullish — the deployment-portable safe default.
  *   4. `'active-local-team'` reads `identityRoots.IDENTITIES` filtered on
  *      `type === 'AgentIdentity'` AND `properties.participationStatus === 'active'`. The
- *      registry is Neo-maintainer-team-shaped; external forks customizing `identityRoots.mjs`
- *      get their own team filter for free.
- *   5. Cloud / fork safety per ADR 0014 §149-159: external workspaces with no config default to
- *      `'self'`; unknown `targetSource` values fail-closed to `'self'` (+ warn). The lane NEVER
- *      silently fans out to Neo maintainer identities in an external deployment. Operators must
- *      explicitly opt-in to `'active-local-team'` to receive cross-team pulses.
+ *      registry is team-shaped; external forks customizing `identityRoots.mjs` get their
+ *      own team filter for free.
+ *   5. Cloud/fork safety: external workspaces with no config default to `'self'`; unknown
+ *      `targetSource` values fail-closed to `'self'` with a warn log. The lane never
+ *      silently fans out to maintainer identities. Operators must explicitly opt-in to
+ *      `'active-local-team'` to receive cross-team pulses.
  *
  * `'active-subscribers'` delegates to the injected `activeSubscribersProvider` callable
- * (the existing `WAKE_SUBSCRIPTION` SQL discovery in `SwarmHeartbeatService.getWakeSubscriptionIdentities()`);
- * the union with `selfIdentity` preserves the pre-#11905 `getPulseIdentities()` shape so
- * the primary harness owner remains in the pulse set.
+ * (the existing `WAKE_SUBSCRIPTION` SQL discovery in
+ * `SwarmHeartbeatService.getWakeSubscriptionIdentities()`); union with `selfIdentity`
+ * keeps the harness owner in the pulse set.
  *
- * `'disabled'` returns `[]` + emits an info log. Downstream `pulse()` skips all per-identity
- * work (sunset detection, idle-out nudge) but the lane still runs identity-agnostic
- * substrate maintenance (TTL sweep, all-agent-idle detection, liveness touch).
+ * `'disabled'` returns `[]` plus an info log. Downstream `pulse()` skips per-identity
+ * work (sunset detection, idle-out nudge) while identity-agnostic substrate maintenance
+ * (TTL sweep, all-agent-idle detection, liveness touch) still runs.
  *
- * Pure function: side effects limited to logger calls. Output is deduplicated + order-preserving;
- * each target is normalized via `normalizeAgentIdentityNodeId` so the slot holds canonical `@<id>` form.
+ * Pure function: side effects limited to logger calls. Output is deduplicated and
+ * order-preserving; each target is normalized via `normalizeAgentIdentityNodeId` so
+ * the slot holds canonical `@<id>` form.
  *
  * @param {Object}         opts
  * @param {String}         opts.selfIdentity                  Primary identity (orchestrator harness owner).
  * @param {String|null}    [opts.targetSource=null]           Resolver source enum (see {@link VALID_TARGET_SOURCES}).
- * @param {String[]|null}  [opts.explicitTargets=null]        Explicit env-driven target list (wins when non-empty).
+ * @param {String[]|null}  [opts.explicitTargets=null]        Explicit target list (wins when non-empty).
  * @param {Function}       [opts.activeSubscribersProvider]   Async `() => Promise<String[]>` for `'active-subscribers'`.
  * @param {Object}         [opts.logger=console]              Logger; defaults to console.
  * @returns {Promise<String[]>}  Normalized canonical `@<identity>` strings (deduplicated, order-preserving).
@@ -89,12 +90,10 @@ export async function resolveTargets({
     const normalizedSelf = selfIdentity ? normalizeAgentIdentityNodeId(selfIdentity) : null;
 
     /**
-     * Self-fallback helper: returns `[selfIdentity]` when present, or emits an
-     * observable info log + returns `[]` when `selfIdentity` is null. AC3 fork-safety
-     * requires "defaults to 'self' OR disables-with-log — NEVER silently fans out
-     * to Neo maintainer identities." Silent `[]` would satisfy the no-leak property
-     * but miss the disables-with-log property; the log surfaces the misconfiguration
-     * so operators can set `NEO_AGENT_IDENTITY` or explicitly opt-in to
+     * Self-fallback: returns `[selfIdentity]` when present, otherwise emits an
+     * observable info log and returns `[]`. Silent `[]` would satisfy no-leak but
+     * miss the disables-with-log property; the log surfaces the misconfiguration so
+     * operators can set `NEO_AGENT_IDENTITY` or explicitly opt-in to
      * `targetSource='disabled'`.
      */
     const selfFallback = (resolvedFrom) => {

--- a/ai/daemons/orchestrator/scheduling/swarmHeartbeat.mjs
+++ b/ai/daemons/orchestrator/scheduling/swarmHeartbeat.mjs
@@ -1,3 +1,18 @@
+import {IDENTITIES}                   from '../../../graph/identityRoots.mjs';
+import {normalizeAgentIdentityNodeId} from '../../../scripts/lifecycle/resumeHarness.mjs';
+
+/**
+ * Valid `targetSource` enum values for `resolveTargets`. Exported so
+ * `SwarmHeartbeatService.beforeSetTargetSource` and unit tests share one
+ * source-of-truth and stay drift-free.
+ */
+export const VALID_TARGET_SOURCES = Object.freeze([
+    'self',
+    'active-local-team',
+    'active-subscribers',
+    'disabled'
+]);
+
 /**
  * Swarm-heartbeat due-trigger projection. Returns a trigger descriptor when the
  * configured interval has elapsed since `lastRunAt`; null otherwise. Pure function.
@@ -18,4 +33,125 @@ export function getDueTask({state, now, swarmHeartbeatIntervalMs}) {
         };
     }
     return null;
+}
+
+/**
+ * @summary Resolve the per-pulse identity set the swarm-heartbeat lane should target.
+ *
+ * 5-step precedence chain (Epic #11829 AC2, Sub 1 #11905):
+ *
+ *   1. Explicit `explicitTargets` env list (highest precedence; bypasses source-based logic).
+ *      Sourced from `NEO_ORCHESTRATOR_SWARM_HEARTBEAT_TARGETS` (comma-separated handles).
+ *   2. `targetSource` enum (`'self'|'active-local-team'|'active-subscribers'|'disabled'`).
+ *      Env-overridable via `NEO_ORCHESTRATOR_SWARM_HEARTBEAT_TARGET_SOURCE`.
+ *   3. Default `'self'` when `targetSource` is nullish — the safe deployment-portable default.
+ *   4. `'active-local-team'` reads `identityRoots.IDENTITIES` filtered on
+ *      `type === 'AgentIdentity'` AND `properties.participationStatus === 'active'`. The
+ *      registry is Neo-maintainer-team-shaped; external forks customizing `identityRoots.mjs`
+ *      get their own team filter for free.
+ *   5. Cloud / fork safety per ADR 0014 §149-159: external workspaces with no config default to
+ *      `'self'`; unknown `targetSource` values fail-closed to `'self'` (+ warn). The lane NEVER
+ *      silently fans out to Neo maintainer identities in an external deployment. Operators must
+ *      explicitly opt-in to `'active-local-team'` to receive cross-team pulses.
+ *
+ * `'active-subscribers'` delegates to the injected `activeSubscribersProvider` callable
+ * (the existing `WAKE_SUBSCRIPTION` SQL discovery in `SwarmHeartbeatService.getWakeSubscriptionIdentities()`);
+ * the union with `selfIdentity` preserves the pre-#11905 `getPulseIdentities()` shape so
+ * the primary harness owner remains in the pulse set.
+ *
+ * `'disabled'` returns `[]` + emits an info log. Downstream `pulse()` skips all per-identity
+ * work (sunset detection, idle-out nudge) but the lane still runs identity-agnostic
+ * substrate maintenance (TTL sweep, all-agent-idle detection, liveness touch).
+ *
+ * Pure function: side effects limited to logger calls. Output is deduplicated + order-preserving;
+ * each target is normalized via `normalizeAgentIdentityNodeId` so the slot holds canonical `@<id>` form.
+ *
+ * @param {Object}         opts
+ * @param {String}         opts.selfIdentity                  Primary identity (orchestrator harness owner).
+ * @param {String|null}    [opts.targetSource=null]           Resolver source enum (see {@link VALID_TARGET_SOURCES}).
+ * @param {String[]|null}  [opts.explicitTargets=null]        Explicit env-driven target list (wins when non-empty).
+ * @param {Function}       [opts.activeSubscribersProvider]   Async `() => Promise<String[]>` for `'active-subscribers'`.
+ * @param {Object}         [opts.logger=console]              Logger; defaults to console.
+ * @returns {Promise<String[]>}  Normalized canonical `@<identity>` strings (deduplicated, order-preserving).
+ */
+export async function resolveTargets({
+    selfIdentity,
+    targetSource             = null,
+    explicitTargets          = null,
+    activeSubscribersProvider = null,
+    logger                   = console
+} = {}) {
+    const log = (level, msg) => {
+        const fn = typeof logger?.[level] === 'function' ? logger[level] : console[level];
+        fn?.call(logger, msg);
+    };
+
+    const normalizedSelf = selfIdentity ? normalizeAgentIdentityNodeId(selfIdentity) : null;
+
+    // Step 1: explicit env target list (override-all). Empty array / null falls through.
+    if (Array.isArray(explicitTargets) && explicitTargets.length > 0) {
+        const seen = new Set();
+        const out  = [];
+        for (const raw of explicitTargets) {
+            const id = normalizeAgentIdentityNodeId(raw);
+            if (id && !seen.has(id)) {
+                seen.add(id);
+                out.push(id);
+            }
+        }
+        return out;
+    }
+
+    // Step 2 + 3: targetSource enum (nullish → 'self')
+    const source = targetSource || 'self';
+
+    switch (source) {
+        case 'self':
+            return normalizedSelf ? [normalizedSelf] : [];
+
+        case 'disabled':
+            log('info', '[resolveSwarmHeartbeatTargets] disabled — no pulse targets');
+            return [];
+
+        case 'active-local-team': {
+            const seen = new Set();
+            const out  = [];
+            for (const entry of IDENTITIES) {
+                if (entry.type !== 'AgentIdentity') continue;
+                if (entry.properties?.participationStatus !== 'active') continue;
+                const id = normalizeAgentIdentityNodeId(entry.id);
+                if (id && !seen.has(id)) {
+                    seen.add(id);
+                    out.push(id);
+                }
+            }
+            return out;
+        }
+
+        case 'active-subscribers': {
+            if (typeof activeSubscribersProvider !== 'function') {
+                log('warn', `[resolveSwarmHeartbeatTargets] targetSource='active-subscribers' requires activeSubscribersProvider; falling back to 'self'`);
+                return normalizedSelf ? [normalizedSelf] : [];
+            }
+            const subscribers = (await activeSubscribersProvider()) || [];
+            const seen = new Set();
+            const out  = [];
+            if (normalizedSelf) {
+                seen.add(normalizedSelf);
+                out.push(normalizedSelf);
+            }
+            for (const raw of subscribers) {
+                const id = normalizeAgentIdentityNodeId(raw);
+                if (id && !seen.has(id)) {
+                    seen.add(id);
+                    out.push(id);
+                }
+            }
+            return out;
+        }
+
+        default:
+            log('warn', `[resolveSwarmHeartbeatTargets] Unknown targetSource '${source}' (valid: ${VALID_TARGET_SOURCES.join('|')}); falling back to 'self'`);
+            return normalizedSelf ? [normalizedSelf] : [];
+    }
 }

--- a/ai/daemons/orchestrator/scheduling/swarmHeartbeat.mjs
+++ b/ai/daemons/orchestrator/scheduling/swarmHeartbeat.mjs
@@ -88,6 +88,23 @@ export async function resolveTargets({
 
     const normalizedSelf = selfIdentity ? normalizeAgentIdentityNodeId(selfIdentity) : null;
 
+    /**
+     * Self-fallback helper: returns `[selfIdentity]` when present, or emits an
+     * observable info log + returns `[]` when `selfIdentity` is null. AC3 fork-safety
+     * requires "defaults to 'self' OR disables-with-log — NEVER silently fans out
+     * to Neo maintainer identities." Silent `[]` would satisfy the no-leak property
+     * but miss the disables-with-log property; the log surfaces the misconfiguration
+     * so operators can set `NEO_AGENT_IDENTITY` or explicitly opt-in to
+     * `targetSource='disabled'`.
+     */
+    const selfFallback = (resolvedFrom) => {
+        if (!normalizedSelf) {
+            log('info', `[resolveSwarmHeartbeatTargets] '${resolvedFrom}' resolved to self but selfIdentity is null — disabled (no pulse targets). Set NEO_AGENT_IDENTITY or orchestrator.swarmHeartbeat.targetSource='disabled' explicitly to silence this notice.`);
+            return [];
+        }
+        return [normalizedSelf];
+    };
+
     // Step 1: explicit env target list (override-all). Empty array / null falls through.
     if (Array.isArray(explicitTargets) && explicitTargets.length > 0) {
         const seen = new Set();
@@ -107,7 +124,7 @@ export async function resolveTargets({
 
     switch (source) {
         case 'self':
-            return normalizedSelf ? [normalizedSelf] : [];
+            return selfFallback('self');
 
         case 'disabled':
             log('info', '[resolveSwarmHeartbeatTargets] disabled — no pulse targets');
@@ -131,7 +148,7 @@ export async function resolveTargets({
         case 'active-subscribers': {
             if (typeof activeSubscribersProvider !== 'function') {
                 log('warn', `[resolveSwarmHeartbeatTargets] targetSource='active-subscribers' requires activeSubscribersProvider; falling back to 'self'`);
-                return normalizedSelf ? [normalizedSelf] : [];
+                return selfFallback('active-subscribers-missing-provider');
             }
             const subscribers = (await activeSubscribersProvider()) || [];
             const seen = new Set();
@@ -152,6 +169,6 @@ export async function resolveTargets({
 
         default:
             log('warn', `[resolveSwarmHeartbeatTargets] Unknown targetSource '${source}' (valid: ${VALID_TARGET_SOURCES.join('|')}); falling back to 'self'`);
-            return normalizedSelf ? [normalizedSelf] : [];
+            return selfFallback('unknown-source-fallback');
     }
 }

--- a/ai/daemons/orchestrator/services/SwarmHeartbeatService.mjs
+++ b/ai/daemons/orchestrator/services/SwarmHeartbeatService.mjs
@@ -30,11 +30,19 @@ import {
 import {checkAllAgentIdle as checkAllAgentIdleScript} from '../../../scripts/lifecycle/checkAllAgentIdle.mjs';
 import {idleOutNudge as idleOutNudgeScript}         from '../../../scripts/lifecycle/idleOutNudge.mjs';
 import {trioWakeCooldown as trioWakeCooldownScript} from '../../../scripts/lifecycle/trioWakeCooldown.mjs';
+import {
+    resolveTargets        as resolveHeartbeatTargets,
+    VALID_TARGET_SOURCES
+} from '../scheduling/swarmHeartbeat.mjs';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname  = path.dirname(__filename);
 
 const DEFAULT_POLL_INTERVAL_MS = 5 * 60 * 1000;
+// Legacy export retained for any backwards-compatible consumers. Sub 1 #11905
+// removed this as the `beforeSetIdentity` fallback target (AC3 fork-safety pivot:
+// external forks must not silently inherit a Neo maintainer identity); the
+// resolver returns [] when `selfIdentity` is null, surfacing the misconfiguration.
 const DEFAULT_IDENTITY         = '@neo-gemini-3-1-pro';
 const PUSH_CAPABLE_TARGETS     = Object.freeze(['mcp-notifications', 'a2a-webhook', 'bridge-daemon']);
 
@@ -109,18 +117,18 @@ class SwarmHeartbeatService extends Base {
          */
         singleton: true,
         /**
-         * Identity this lane polls for (e.g. `@neo-gemini-3-1-pro`). Kept as the
-         * primary fallback / tmux identity. Active WAKE_SUBSCRIPTION identities
-         * are discovered per pulse so the Orchestrator is not bound to the
-         * identity of the harness that launched it (#11872). Parent (Orchestrator)
-         * sets this via reactive config assignment BEFORE `await service.ready()`
-         * in `start()` — the framework already fired identity-agnostic
-         * `initAsync()` at module-load, so the BEFORE-`.ready()` ordering matches
-         * the canonical Neo.create-flows-configs-pre-init shape and the actual
-         * `Orchestrator.start()` code. `null` falls back to `DEFAULT_IDENTITY`
-         * via `beforeSetIdentity`, which also normalizes via
+         * Primary identity this lane pulses for (e.g. `@neo-gpt`). Consumed by the
+         * resolver as `selfIdentity` for `'self'` and `'active-subscribers'` sources
+         * (Sub 1 #11905 / Epic #11829 Layer 2). Parent (Orchestrator) sets this via
+         * reactive config assignment BEFORE `await service.ready()` in `start()` —
+         * the framework already fired identity-agnostic `initAsync()` at module-load,
+         * so the BEFORE-`.ready()` ordering matches the canonical
+         * Neo.create-flows-configs-pre-init shape and the actual
+         * `Orchestrator.start()` code. `beforeSetIdentity` normalizes via
          * `normalizeAgentIdentityNodeId` so the slot always holds a canonical
-         * `@<identity>` form.
+         * `@<identity>` form; null/empty values store `null` (Sub 1 #11905 AC3
+         * fork-safety pivot — no longer falls back to DEFAULT_IDENTITY since that
+         * would leak a Neo maintainer identity into external deployments).
          * @member {String|null} identity_=null
          * @reactive
          */
@@ -134,20 +142,85 @@ class SwarmHeartbeatService extends Base {
          * @member {Number} pollIntervalMs_=300000
          * @reactive
          */
-        pollIntervalMs_: DEFAULT_POLL_INTERVAL_MS
+        pollIntervalMs_: DEFAULT_POLL_INTERVAL_MS,
+        /**
+         * Target-resolver source enum consumed by `getPulseIdentities()` per pulse
+         * (Sub 1 #11905 / Epic #11829 Layer 2). Controls which identity set the lane
+         * pulses for. `'self'` (default) is deployment-portable — external forks
+         * pulse only the harness owner. `'active-local-team'` reads `identityRoots`
+         * (Neo-team profile only). `'active-subscribers'` unions self with active
+         * `WAKE_SUBSCRIPTION` identities. `'disabled'` skips all per-identity pulse
+         * work (substrate maintenance still runs). Parent (Orchestrator) sets this
+         * via reactive assignment from `AiConfig.orchestrator.swarmHeartbeat.targetSource`
+         * (env override `NEO_ORCHESTRATOR_SWARM_HEARTBEAT_TARGET_SOURCE`). Invalid
+         * values coerce to `null` via `beforeSetTargetSource` (the resolver then
+         * applies its own 'self' fallback). See {@link VALID_TARGET_SOURCES}.
+         * @member {String|null} targetSource_=null
+         * @reactive
+         */
+        targetSource_: null,
+        /**
+         * Explicit identity list (Step 1 in the 5-step precedence chain). When set
+         * and non-empty, the resolver bypasses `targetSource` and pulses these targets
+         * verbatim (post-normalization). Parent (Orchestrator) sources this from
+         * `NEO_ORCHESTRATOR_SWARM_HEARTBEAT_TARGETS` (comma-separated handles).
+         * Empty arrays + non-arrays coerce to `null` via `beforeSetExplicitTargets`
+         * (resolver then falls through to `targetSource` semantics).
+         * @member {String[]|null} explicitTargets_=null
+         * @reactive
+         */
+        explicitTargets_: null
     }
 
     /**
-     * Normalizes identity to canonical `@<identity>` form. Falls back to
-     * `DEFAULT_IDENTITY` when value is null/empty (the static-config default
-     * intentionally null'd so parent can override; if neither parent nor env
-     * provides identity, this fallback kicks in).
+     * Normalizes identity to canonical `@<identity>` form. Returns `null` when value
+     * is null/empty (Sub 1 #11905 AC3 fork-safety pivot: removed the prior
+     * `DEFAULT_IDENTITY = '@neo-gemini-3-1-pro'` fallback that leaked a Neo
+     * maintainer identity into external-fork deployments). External operators
+     * MUST set `NEO_AGENT_IDENTITY` (or `swarmHeartbeat.targetSource: 'disabled'`)
+     * — the resolver returns `[]` when `selfIdentity` is null + `targetSource`
+     * defaults to `'self'`, surfacing the misconfiguration as "no pulses fire"
+     * rather than "silently fans out to Neo identities." `DEFAULT_IDENTITY` is
+     * still exported for backwards-compatible consumers but no longer the
+     * fallback target.
      * @param {String|null} value
-     * @returns {String}
+     * @returns {String|null}
      */
     beforeSetIdentity(value) {
-        if (!value) return DEFAULT_IDENTITY;
+        if (!value) return null;
         return normalizeAgentIdentityNodeId(value);
+    }
+
+    /**
+     * Validates `targetSource` against {@link VALID_TARGET_SOURCES}. Invalid values
+     * coerce to `null` (+ warn); the resolver then applies its own 'self' fallback.
+     * Keeping the coercion at config-set time means downstream `getPulseIdentities()`
+     * sees only validated values + the resolver's `default:` branch is reachable only
+     * via direct programmatic misuse, not via operator config.
+     * @param {String|null} value
+     * @returns {String|null}
+     */
+    beforeSetTargetSource(value) {
+        if (value === null || value === undefined || value === '') return null;
+        if (!VALID_TARGET_SOURCES.includes(value)) {
+            logger.warn(`[SwarmHeartbeatService] Invalid targetSource '${value}' (valid: ${VALID_TARGET_SOURCES.join('|')}); coercing to null`);
+            return null;
+        }
+        return value;
+    }
+
+    /**
+     * Normalizes `explicitTargets` to canonical `@<identity>` form. Empty arrays and
+     * non-arrays coerce to `null` so the resolver falls through to `targetSource`
+     * semantics. Per-element normalization mirrors `beforeSetIdentity` so the slot
+     * stores invariant canonical form.
+     * @param {String[]|null} value
+     * @returns {String[]|null}
+     */
+    beforeSetExplicitTargets(value) {
+        if (!Array.isArray(value) || value.length === 0) return null;
+        const out = value.map(normalizeAgentIdentityNodeId).filter(Boolean);
+        return out.length > 0 ? out : null;
     }
 
     /**
@@ -437,32 +510,31 @@ class SwarmHeartbeatService extends Base {
     }
 
     /**
-     * @summary Resolves the per-pulse identity set from the primary fallback plus active wake subscriptions.
+     * @summary Resolves the per-pulse identity set via the {@link resolveHeartbeatTargets} resolver.
      *
-     * `NEO_AGENT_IDENTITY` identifies the daemon/harness process owner; it must not
-     * be the exclusive set of wake targets. The subscription graph is the live route
-     * truth for desktop agents, so active `WAKE_SUBSCRIPTION` identities are swept on
-     * every pulse (#11872).
+     * Delegates to the pure-function resolver in `scheduling/swarmHeartbeat.mjs` (Sub 1 #11905 /
+     * Epic #11829 Layer 2). Resolver consumes the reactive `targetSource` + `explicitTargets`
+     * configs set by the parent Orchestrator and falls back to the deployment-portable `'self'`
+     * source when no operator config is present.
+     *
+     * The previous shape (#11872) hardcoded a union of `this.identity` + the active
+     * `WAKE_SUBSCRIPTION` SQL discovery + a `DEFAULT_IDENTITY` Neo-team fallback. The
+     * fallback would leak Neo maintainer identities into external-fork deployments;
+     * the resolver replaces it with the 5-step precedence chain + AC3 fork-safety semantics.
+     * The `'active-subscribers'` source preserves the pre-#11905 behavior for operators who
+     * opt-in.
      *
      * @returns {Promise<String[]>}
      * @protected
      */
     async getPulseIdentities() {
-        const identities = new Set();
-
-        if (this.identity) {
-            identities.add(this.identity)
-        }
-
-        for (const identity of await this.getWakeSubscriptionIdentities()) {
-            identities.add(identity)
-        }
-
-        if (identities.size === 0) {
-            identities.add(DEFAULT_IDENTITY)
-        }
-
-        return Array.from(identities)
+        return await resolveHeartbeatTargets({
+            selfIdentity             : this.identity,
+            targetSource             : this.targetSource,
+            explicitTargets          : this.explicitTargets,
+            activeSubscribersProvider: () => this.getWakeSubscriptionIdentities(),
+            logger
+        });
     }
 
     /**

--- a/ai/daemons/orchestrator/services/SwarmHeartbeatService.mjs
+++ b/ai/daemons/orchestrator/services/SwarmHeartbeatService.mjs
@@ -39,11 +39,6 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname  = path.dirname(__filename);
 
 const DEFAULT_POLL_INTERVAL_MS = 5 * 60 * 1000;
-// Legacy export retained for any backwards-compatible consumers. Sub 1 #11905
-// removed this as the `beforeSetIdentity` fallback target (AC3 fork-safety pivot:
-// external forks must not silently inherit a Neo maintainer identity); the
-// resolver returns [] when `selfIdentity` is null, surfacing the misconfiguration.
-const DEFAULT_IDENTITY         = '@neo-gemini-3-1-pro';
 const PUSH_CAPABLE_TARGETS     = Object.freeze(['mcp-notifications', 'a2a-webhook', 'bridge-daemon']);
 
 /**
@@ -117,18 +112,14 @@ class SwarmHeartbeatService extends Base {
          */
         singleton: true,
         /**
-         * Primary identity this lane pulses for (e.g. `@neo-gpt`). Consumed by the
-         * resolver as `selfIdentity` for `'self'` and `'active-subscribers'` sources
-         * (Sub 1 #11905 / Epic #11829 Layer 2). Parent (Orchestrator) sets this via
-         * reactive config assignment BEFORE `await service.ready()` in `start()` —
-         * the framework already fired identity-agnostic `initAsync()` at module-load,
-         * so the BEFORE-`.ready()` ordering matches the canonical
-         * Neo.create-flows-configs-pre-init shape and the actual
-         * `Orchestrator.start()` code. `beforeSetIdentity` normalizes via
-         * `normalizeAgentIdentityNodeId` so the slot always holds a canonical
-         * `@<identity>` form; null/empty values store `null` (Sub 1 #11905 AC3
-         * fork-safety pivot — no longer falls back to DEFAULT_IDENTITY since that
-         * would leak a Neo maintainer identity into external deployments).
+         * Primary identity this lane pulses for. Consumed by the resolver as
+         * `selfIdentity` for `'self'` and `'active-subscribers'` sources. Parent
+         * (Orchestrator) sets this via reactive config assignment before
+         * `await service.ready()` in `start()`. `beforeSetIdentity` normalizes via
+         * `normalizeAgentIdentityNodeId` so the slot holds canonical `@<identity>`
+         * form; null/empty values store `null` so external workspaces with no
+         * configured identity surface the misconfiguration through the resolver's
+         * disables-with-log path rather than silently inheriting a default.
          * @member {String|null} identity_=null
          * @reactive
          */
@@ -144,28 +135,28 @@ class SwarmHeartbeatService extends Base {
          */
         pollIntervalMs_: DEFAULT_POLL_INTERVAL_MS,
         /**
-         * Target-resolver source enum consumed by `getPulseIdentities()` per pulse
-         * (Sub 1 #11905 / Epic #11829 Layer 2). Controls which identity set the lane
-         * pulses for. `'self'` (default) is deployment-portable — external forks
-         * pulse only the harness owner. `'active-local-team'` reads `identityRoots`
-         * (Neo-team profile only). `'active-subscribers'` unions self with active
-         * `WAKE_SUBSCRIPTION` identities. `'disabled'` skips all per-identity pulse
-         * work (substrate maintenance still runs). Parent (Orchestrator) sets this
-         * via reactive assignment from `AiConfig.orchestrator.swarmHeartbeat.targetSource`
-         * (env override `NEO_ORCHESTRATOR_SWARM_HEARTBEAT_TARGET_SOURCE`). Invalid
-         * values coerce to `null` via `beforeSetTargetSource` (the resolver then
-         * applies its own 'self' fallback). See {@link VALID_TARGET_SOURCES}.
+         * Target-resolver source enum consumed by `getPulseIdentities()` per pulse.
+         * Controls which identity set the lane pulses for. `'self'` (default) is
+         * deployment-portable — external workspaces pulse only the harness owner.
+         * `'active-local-team'` reads `identityRoots` (team profile). `'active-subscribers'`
+         * unions self with active `WAKE_SUBSCRIPTION` identities. `'disabled'` skips
+         * all per-identity pulse work (substrate maintenance still runs). Parent
+         * (Orchestrator) sets this via reactive assignment from
+         * `AiConfig.orchestrator.swarmHeartbeat.targetSource` (env override
+         * `NEO_ORCHESTRATOR_SWARM_HEARTBEAT_TARGET_SOURCE`). Invalid values coerce
+         * to `null` via `beforeSetTargetSource`; the resolver then applies its own
+         * `'self'` fallback. See {@link VALID_TARGET_SOURCES}.
          * @member {String|null} targetSource_=null
          * @reactive
          */
         targetSource_: null,
         /**
-         * Explicit identity list (Step 1 in the 5-step precedence chain). When set
-         * and non-empty, the resolver bypasses `targetSource` and pulses these targets
+         * Explicit identity list — top-of-precedence resolver override. When set and
+         * non-empty, the resolver bypasses `targetSource` and pulses these targets
          * verbatim (post-normalization). Parent (Orchestrator) sources this from
          * `NEO_ORCHESTRATOR_SWARM_HEARTBEAT_TARGETS` (comma-separated handles).
-         * Empty arrays + non-arrays coerce to `null` via `beforeSetExplicitTargets`
-         * (resolver then falls through to `targetSource` semantics).
+         * Empty arrays and non-arrays coerce to `null` via `beforeSetExplicitTargets`;
+         * the resolver then falls through to `targetSource` semantics.
          * @member {String[]|null} explicitTargets_=null
          * @reactive
          */
@@ -173,16 +164,11 @@ class SwarmHeartbeatService extends Base {
     }
 
     /**
-     * Normalizes identity to canonical `@<identity>` form. Returns `null` when value
-     * is null/empty (Sub 1 #11905 AC3 fork-safety pivot: removed the prior
-     * `DEFAULT_IDENTITY = '@neo-gemini-3-1-pro'` fallback that leaked a Neo
-     * maintainer identity into external-fork deployments). External operators
-     * MUST set `NEO_AGENT_IDENTITY` (or `swarmHeartbeat.targetSource: 'disabled'`)
-     * — the resolver returns `[]` when `selfIdentity` is null + `targetSource`
-     * defaults to `'self'`, surfacing the misconfiguration as "no pulses fire"
-     * rather than "silently fans out to Neo identities." `DEFAULT_IDENTITY` is
-     * still exported for backwards-compatible consumers but no longer the
-     * fallback target.
+     * Normalizes identity to canonical `@<identity>` form. Returns `null` for
+     * empty values so unconfigured deployments surface the misconfiguration via
+     * the resolver's disables-with-log path rather than silently inheriting a
+     * maintainer identity. External operators must set `NEO_AGENT_IDENTITY` (or
+     * `swarmHeartbeat.targetSource: 'disabled'`) to activate pulses.
      * @param {String|null} value
      * @returns {String|null}
      */
@@ -512,17 +498,11 @@ class SwarmHeartbeatService extends Base {
     /**
      * @summary Resolves the per-pulse identity set via the {@link resolveHeartbeatTargets} resolver.
      *
-     * Delegates to the pure-function resolver in `scheduling/swarmHeartbeat.mjs` (Sub 1 #11905 /
-     * Epic #11829 Layer 2). Resolver consumes the reactive `targetSource` + `explicitTargets`
-     * configs set by the parent Orchestrator and falls back to the deployment-portable `'self'`
-     * source when no operator config is present.
-     *
-     * The previous shape (#11872) hardcoded a union of `this.identity` + the active
-     * `WAKE_SUBSCRIPTION` SQL discovery + a `DEFAULT_IDENTITY` Neo-team fallback. The
-     * fallback would leak Neo maintainer identities into external-fork deployments;
-     * the resolver replaces it with the 5-step precedence chain + AC3 fork-safety semantics.
-     * The `'active-subscribers'` source preserves the pre-#11905 behavior for operators who
-     * opt-in.
+     * Delegates to the pure-function resolver in `scheduling/swarmHeartbeat.mjs`, which
+     * consumes the reactive `targetSource` and `explicitTargets` configs and falls back to
+     * the deployment-portable `'self'` source when no operator config is present. The
+     * `'active-subscribers'` source unions the harness owner with active `WAKE_SUBSCRIPTION`
+     * identities discovered via `getWakeSubscriptionIdentities()`.
      *
      * @returns {Promise<String[]>}
      * @protected
@@ -750,4 +730,4 @@ class SwarmHeartbeatService extends Base {
 
 export default Neo.setupClass(SwarmHeartbeatService);
 
-export {HEARTBEAT_LOCK_PATH, DEFAULT_POLL_INTERVAL_MS, DEFAULT_IDENTITY};
+export {HEARTBEAT_LOCK_PATH, DEFAULT_POLL_INTERVAL_MS};

--- a/test/playwright/unit/ai/daemons/orchestrator/scheduling/swarmHeartbeat.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/scheduling/swarmHeartbeat.spec.mjs
@@ -183,11 +183,50 @@ test.describe('resolveTargets (Sub 1 #11905 / Epic #11829 Layer 2)', () => {
         expect(logger.calls.some(c => VALID_TARGET_SOURCES.every(v => c.msg.includes(v)))).toBe(true);
     });
 
-    test('AC3 fork-safety — null selfIdentity + no source returns [] (operator must notice, not silent leak)', async () => {
+    test('AC3 fork-safety — null selfIdentity + no source returns [] AND logs disables-with-log notice (per GPT PR #11913 cycle-1 RA1)', async () => {
+        const logger = captureLogger();
         const result = await resolveTargets({
-            selfIdentity: null
+            selfIdentity: null,
+            logger
         });
         expect(result).toEqual([]);
+        // AC3 wording: "defaults to 'self' OR disables-with-log — NEVER silently fans out".
+        // The info log surfaces the misconfiguration so operators notice and either set
+        // NEO_AGENT_IDENTITY or explicitly opt-in to targetSource='disabled'.
+        const infoMatch = logger.calls.find(c =>
+            c.level === 'info' &&
+            c.msg.includes("'self' resolved to self") &&
+            c.msg.includes('selfIdentity is null') &&
+            c.msg.includes('disabled')
+        );
+        expect(infoMatch).toBeTruthy();
+        // Operator-actionable guidance must name both knobs.
+        expect(infoMatch.msg).toContain('NEO_AGENT_IDENTITY');
+        expect(infoMatch.msg).toContain("targetSource='disabled'");
+    });
+
+    test('AC3 fork-safety — null selfIdentity + unknown source falls back to self + logs both warn (unknown) AND info (null-self)', async () => {
+        const logger = captureLogger();
+        const result = await resolveTargets({
+            selfIdentity: null,
+            targetSource: 'bogus-source-name',
+            logger
+        });
+        expect(result).toEqual([]);
+        expect(logger.calls.some(c => c.level === 'warn' && c.msg.includes('bogus-source-name'))).toBe(true);
+        expect(logger.calls.some(c => c.level === 'info' && c.msg.includes('unknown-source-fallback'))).toBe(true);
+    });
+
+    test('AC3 fork-safety — null selfIdentity + active-subscribers missing provider falls back to self + logs warn AND info', async () => {
+        const logger = captureLogger();
+        const result = await resolveTargets({
+            selfIdentity: null,
+            targetSource: 'active-subscribers',
+            logger
+        });
+        expect(result).toEqual([]);
+        expect(logger.calls.some(c => c.level === 'warn' && c.msg.includes('active-subscribers'))).toBe(true);
+        expect(logger.calls.some(c => c.level === 'info' && c.msg.includes('active-subscribers-missing-provider'))).toBe(true);
     });
 
     test('Step 5 / active-subscribers — empty subscribers + valid self yields just [self]', async () => {

--- a/test/playwright/unit/ai/daemons/orchestrator/scheduling/swarmHeartbeat.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/scheduling/swarmHeartbeat.spec.mjs
@@ -1,7 +1,10 @@
 import {test, expect} from '@playwright/test';
 import {
-    getDueTask
+    getDueTask,
+    resolveTargets,
+    VALID_TARGET_SOURCES
 } from '../../../../../../../ai/daemons/orchestrator/scheduling/swarmHeartbeat.mjs';
+import {IDENTITIES} from '../../../../../../../ai/graph/identityRoots.mjs';
 
 test.describe('orchestrator/scheduling/swarmHeartbeat (#11859 / Epic #11831)', () => {
     test('returns a periodic-heartbeat trigger when the interval has elapsed since lastRunAt', () => {
@@ -48,5 +51,163 @@ test.describe('orchestrator/scheduling/swarmHeartbeat (#11859 / Epic #11831)', (
             source  : 'periodic-heartbeat',
             reason  : 'periodic-heartbeat:900000'
         });
+    });
+});
+
+test.describe('resolveTargets (Sub 1 #11905 / Epic #11829 Layer 2)', () => {
+    /** Build a stub logger that captures level + msg so we can assert + suppress noise. */
+    function captureLogger() {
+        const calls = [];
+        return {
+            calls,
+            info: msg => calls.push({level: 'info', msg}),
+            warn: msg => calls.push({level: 'warn', msg}),
+            error: msg => calls.push({level: 'error', msg})
+        };
+    }
+
+    test('AC4 / Step 3 — no-config defaults to self (deployment-portable safe default)', async () => {
+        const logger = captureLogger();
+        const result = await resolveTargets({
+            selfIdentity: '@neo-opus-4-7',
+            logger
+        });
+        expect(result).toEqual(['@neo-opus-4-7']);
+        expect(logger.calls).toEqual([]);
+    });
+
+    test('AC4 / Step 3 — explicit null targetSource defaults to self', async () => {
+        const logger = captureLogger();
+        const result = await resolveTargets({
+            selfIdentity: '@neo-gpt',
+            targetSource: null,
+            logger
+        });
+        expect(result).toEqual(['@neo-gpt']);
+        expect(logger.calls).toEqual([]);
+    });
+
+    test('AC4 / Step 1 — explicit target list wins over targetSource', async () => {
+        const logger = captureLogger();
+        const result = await resolveTargets({
+            selfIdentity   : '@neo-opus-4-7',
+            targetSource   : 'active-local-team',   // would normally be honored
+            explicitTargets: ['@some-external-agent', 'neo-gpt'],  // wins; gets normalized
+            logger
+        });
+        expect(result).toEqual(['@some-external-agent', '@neo-gpt']);
+        expect(logger.calls).toEqual([]);
+    });
+
+    test('Step 1 — explicit target list deduplicates while preserving order', async () => {
+        const result = await resolveTargets({
+            selfIdentity   : '@neo-opus-4-7',
+            explicitTargets: ['@a', '@b', '@a', '@c', '@b']
+        });
+        expect(result).toEqual(['@a', '@b', '@c']);
+    });
+
+    test('Step 1 — empty explicitTargets array falls through to targetSource semantics', async () => {
+        const result = await resolveTargets({
+            selfIdentity   : '@neo-opus-4-7',
+            targetSource   : 'self',
+            explicitTargets: []
+        });
+        expect(result).toEqual(['@neo-opus-4-7']);
+    });
+
+    test('AC4 / Step 4 — active-local-team reads identityRoots filtered on participationStatus active', async () => {
+        const result = await resolveTargets({
+            selfIdentity: '@neo-opus-4-7',
+            targetSource: 'active-local-team'
+        });
+        // Resolver output should match the IDENTITIES filter; we compute the expected set
+        // off the live registry to keep this test resilient to peer membership changes.
+        const expected = IDENTITIES
+            .filter(i => i.type === 'AgentIdentity' && i.properties?.participationStatus === 'active')
+            .map(i => i.id);
+        expect(result).toEqual(expected);
+        // AC3 fork-safety check: result should NOT contain non-active maintainers (e.g., a
+        // benched Gemini identity must be filtered out unless its status flips back to 'active').
+        const benched = IDENTITIES
+            .filter(i => i.type === 'AgentIdentity' && i.properties?.participationStatus !== 'active')
+            .map(i => i.id);
+        for (const id of benched) {
+            expect(result).not.toContain(id);
+        }
+    });
+
+    test('Step 5 / disabled — returns empty list + logs info', async () => {
+        const logger = captureLogger();
+        const result = await resolveTargets({
+            selfIdentity: '@neo-opus-4-7',
+            targetSource: 'disabled',
+            logger
+        });
+        expect(result).toEqual([]);
+        expect(logger.calls.some(c => c.level === 'info' && c.msg.includes('disabled'))).toBe(true);
+    });
+
+    test('Step 5 / active-subscribers — unions self with provider output (preserves pre-#11905 shape)', async () => {
+        const subscribers = ['@neo-gpt', '@neo-opus-4-7', 'neo-gemini-3-1-pro'];
+        const result = await resolveTargets({
+            selfIdentity              : '@neo-opus-4-7',
+            targetSource              : 'active-subscribers',
+            activeSubscribersProvider: async () => subscribers
+        });
+        // Self appears first; subscribers union (no duplicates); 3rd entry gets normalized.
+        expect(result).toEqual(['@neo-opus-4-7', '@neo-gpt', '@neo-gemini-3-1-pro']);
+    });
+
+    test('Step 5 / active-subscribers without provider — falls back to self with warn', async () => {
+        const logger = captureLogger();
+        const result = await resolveTargets({
+            selfIdentity: '@neo-opus-4-7',
+            targetSource: 'active-subscribers',
+            logger
+        });
+        expect(result).toEqual(['@neo-opus-4-7']);
+        expect(logger.calls.some(c => c.level === 'warn' && c.msg.includes('active-subscribers'))).toBe(true);
+    });
+
+    test('AC4 / Step 5 — unknown targetSource fails closed to self + warns', async () => {
+        const logger = captureLogger();
+        const result = await resolveTargets({
+            selfIdentity: '@neo-opus-4-7',
+            targetSource: 'this-source-does-not-exist',
+            logger
+        });
+        expect(result).toEqual(['@neo-opus-4-7']);
+        expect(logger.calls.some(c => c.level === 'warn' && c.msg.includes('this-source-does-not-exist'))).toBe(true);
+        // Operator should be told what valid values exist.
+        expect(logger.calls.some(c => VALID_TARGET_SOURCES.every(v => c.msg.includes(v)))).toBe(true);
+    });
+
+    test('AC3 fork-safety — null selfIdentity + no source returns [] (operator must notice, not silent leak)', async () => {
+        const result = await resolveTargets({
+            selfIdentity: null
+        });
+        expect(result).toEqual([]);
+    });
+
+    test('Step 5 / active-subscribers — empty subscribers + valid self yields just [self]', async () => {
+        const result = await resolveTargets({
+            selfIdentity              : '@neo-opus-4-7',
+            targetSource              : 'active-subscribers',
+            activeSubscribersProvider: async () => []
+        });
+        expect(result).toEqual(['@neo-opus-4-7']);
+    });
+
+    test('normalization — selfIdentity without @ prefix gets canonicalized', async () => {
+        const result = await resolveTargets({
+            selfIdentity: 'neo-opus-4-7'  // no @ prefix
+        });
+        expect(result).toEqual(['@neo-opus-4-7']);
+    });
+
+    test('VALID_TARGET_SOURCES — exported as frozen tuple of the 4 supported enum values', () => {
+        expect(VALID_TARGET_SOURCES).toEqual(['self', 'active-local-team', 'active-subscribers', 'disabled']);
+        expect(Object.isFrozen(VALID_TARGET_SOURCES)).toBe(true);
     });
 });

--- a/test/playwright/unit/ai/daemons/orchestrator/scheduling/swarmHeartbeat.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/scheduling/swarmHeartbeat.spec.mjs
@@ -54,7 +54,7 @@ test.describe('orchestrator/scheduling/swarmHeartbeat (#11859 / Epic #11831)', (
     });
 });
 
-test.describe('resolveTargets (Sub 1 #11905 / Epic #11829 Layer 2)', () => {
+test.describe('resolveTargets — deployment-portable swarm-heartbeat target resolver', () => {
     /** Build a stub logger that captures level + msg so we can assert + suppress noise. */
     function captureLogger() {
         const calls = [];
@@ -66,7 +66,7 @@ test.describe('resolveTargets (Sub 1 #11905 / Epic #11829 Layer 2)', () => {
         };
     }
 
-    test('AC4 / Step 3 — no-config defaults to self (deployment-portable safe default)', async () => {
+    test('no-config defaults to self (deployment-portable safe default)', async () => {
         const logger = captureLogger();
         const result = await resolveTargets({
             selfIdentity: '@neo-opus-4-7',
@@ -76,7 +76,7 @@ test.describe('resolveTargets (Sub 1 #11905 / Epic #11829 Layer 2)', () => {
         expect(logger.calls).toEqual([]);
     });
 
-    test('AC4 / Step 3 — explicit null targetSource defaults to self', async () => {
+    test('explicit null targetSource defaults to self', async () => {
         const logger = captureLogger();
         const result = await resolveTargets({
             selfIdentity: '@neo-gpt',
@@ -87,7 +87,7 @@ test.describe('resolveTargets (Sub 1 #11905 / Epic #11829 Layer 2)', () => {
         expect(logger.calls).toEqual([]);
     });
 
-    test('AC4 / Step 1 — explicit target list wins over targetSource', async () => {
+    test('explicit target list wins over targetSource', async () => {
         const logger = captureLogger();
         const result = await resolveTargets({
             selfIdentity   : '@neo-opus-4-7',
@@ -99,7 +99,7 @@ test.describe('resolveTargets (Sub 1 #11905 / Epic #11829 Layer 2)', () => {
         expect(logger.calls).toEqual([]);
     });
 
-    test('Step 1 — explicit target list deduplicates while preserving order', async () => {
+    test('explicit target list deduplicates while preserving order', async () => {
         const result = await resolveTargets({
             selfIdentity   : '@neo-opus-4-7',
             explicitTargets: ['@a', '@b', '@a', '@c', '@b']
@@ -107,7 +107,7 @@ test.describe('resolveTargets (Sub 1 #11905 / Epic #11829 Layer 2)', () => {
         expect(result).toEqual(['@a', '@b', '@c']);
     });
 
-    test('Step 1 — empty explicitTargets array falls through to targetSource semantics', async () => {
+    test('empty explicitTargets array falls through to targetSource semantics', async () => {
         const result = await resolveTargets({
             selfIdentity   : '@neo-opus-4-7',
             targetSource   : 'self',
@@ -116,19 +116,19 @@ test.describe('resolveTargets (Sub 1 #11905 / Epic #11829 Layer 2)', () => {
         expect(result).toEqual(['@neo-opus-4-7']);
     });
 
-    test('AC4 / Step 4 — active-local-team reads identityRoots filtered on participationStatus active', async () => {
+    test('active-local-team reads identityRoots filtered on participationStatus active', async () => {
         const result = await resolveTargets({
             selfIdentity: '@neo-opus-4-7',
             targetSource: 'active-local-team'
         });
-        // Resolver output should match the IDENTITIES filter; we compute the expected set
-        // off the live registry to keep this test resilient to peer membership changes.
+        // Compute the expected set off the live registry to keep this test resilient
+        // to membership changes.
         const expected = IDENTITIES
             .filter(i => i.type === 'AgentIdentity' && i.properties?.participationStatus === 'active')
             .map(i => i.id);
         expect(result).toEqual(expected);
-        // AC3 fork-safety check: result should NOT contain non-active maintainers (e.g., a
-        // benched Gemini identity must be filtered out unless its status flips back to 'active').
+        // Non-active maintainers (e.g. a benched identity) must be filtered out unless
+        // their status flips back to 'active'.
         const benched = IDENTITIES
             .filter(i => i.type === 'AgentIdentity' && i.properties?.participationStatus !== 'active')
             .map(i => i.id);
@@ -137,7 +137,7 @@ test.describe('resolveTargets (Sub 1 #11905 / Epic #11829 Layer 2)', () => {
         }
     });
 
-    test('Step 5 / disabled — returns empty list + logs info', async () => {
+    test('disabled — returns empty list + logs info', async () => {
         const logger = captureLogger();
         const result = await resolveTargets({
             selfIdentity: '@neo-opus-4-7',
@@ -148,7 +148,7 @@ test.describe('resolveTargets (Sub 1 #11905 / Epic #11829 Layer 2)', () => {
         expect(logger.calls.some(c => c.level === 'info' && c.msg.includes('disabled'))).toBe(true);
     });
 
-    test('Step 5 / active-subscribers — unions self with provider output (preserves pre-#11905 shape)', async () => {
+    test('active-subscribers — unions self with provider output', async () => {
         const subscribers = ['@neo-gpt', '@neo-opus-4-7', 'neo-gemini-3-1-pro'];
         const result = await resolveTargets({
             selfIdentity              : '@neo-opus-4-7',
@@ -159,7 +159,7 @@ test.describe('resolveTargets (Sub 1 #11905 / Epic #11829 Layer 2)', () => {
         expect(result).toEqual(['@neo-opus-4-7', '@neo-gpt', '@neo-gemini-3-1-pro']);
     });
 
-    test('Step 5 / active-subscribers without provider — falls back to self with warn', async () => {
+    test('active-subscribers without provider — falls back to self with warn', async () => {
         const logger = captureLogger();
         const result = await resolveTargets({
             selfIdentity: '@neo-opus-4-7',
@@ -170,7 +170,7 @@ test.describe('resolveTargets (Sub 1 #11905 / Epic #11829 Layer 2)', () => {
         expect(logger.calls.some(c => c.level === 'warn' && c.msg.includes('active-subscribers'))).toBe(true);
     });
 
-    test('AC4 / Step 5 — unknown targetSource fails closed to self + warns', async () => {
+    test('unknown targetSource fails closed to self + warns', async () => {
         const logger = captureLogger();
         const result = await resolveTargets({
             selfIdentity: '@neo-opus-4-7',
@@ -183,14 +183,13 @@ test.describe('resolveTargets (Sub 1 #11905 / Epic #11829 Layer 2)', () => {
         expect(logger.calls.some(c => VALID_TARGET_SOURCES.every(v => c.msg.includes(v)))).toBe(true);
     });
 
-    test('AC3 fork-safety — null selfIdentity + no source returns [] AND logs disables-with-log notice (per GPT PR #11913 cycle-1 RA1)', async () => {
+    test('null selfIdentity + no source returns [] AND logs disables-with-log notice', async () => {
         const logger = captureLogger();
         const result = await resolveTargets({
             selfIdentity: null,
             logger
         });
         expect(result).toEqual([]);
-        // AC3 wording: "defaults to 'self' OR disables-with-log — NEVER silently fans out".
         // The info log surfaces the misconfiguration so operators notice and either set
         // NEO_AGENT_IDENTITY or explicitly opt-in to targetSource='disabled'.
         const infoMatch = logger.calls.find(c =>
@@ -205,7 +204,7 @@ test.describe('resolveTargets (Sub 1 #11905 / Epic #11829 Layer 2)', () => {
         expect(infoMatch.msg).toContain("targetSource='disabled'");
     });
 
-    test('AC3 fork-safety — null selfIdentity + unknown source falls back to self + logs both warn (unknown) AND info (null-self)', async () => {
+    test('null selfIdentity + unknown source falls back to self + logs warn AND info', async () => {
         const logger = captureLogger();
         const result = await resolveTargets({
             selfIdentity: null,
@@ -217,7 +216,7 @@ test.describe('resolveTargets (Sub 1 #11905 / Epic #11829 Layer 2)', () => {
         expect(logger.calls.some(c => c.level === 'info' && c.msg.includes('unknown-source-fallback'))).toBe(true);
     });
 
-    test('AC3 fork-safety — null selfIdentity + active-subscribers missing provider falls back to self + logs warn AND info', async () => {
+    test('null selfIdentity + active-subscribers missing provider falls back to self + logs warn AND info', async () => {
         const logger = captureLogger();
         const result = await resolveTargets({
             selfIdentity: null,
@@ -229,7 +228,7 @@ test.describe('resolveTargets (Sub 1 #11905 / Epic #11829 Layer 2)', () => {
         expect(logger.calls.some(c => c.level === 'info' && c.msg.includes('active-subscribers-missing-provider'))).toBe(true);
     });
 
-    test('Step 5 / active-subscribers — empty subscribers + valid self yields just [self]', async () => {
+    test('active-subscribers — empty subscribers + valid self yields just [self]', async () => {
         const result = await resolveTargets({
             selfIdentity              : '@neo-opus-4-7',
             targetSource              : 'active-subscribers',

--- a/test/playwright/unit/ai/daemons/orchestrator/services/SwarmHeartbeatService.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/services/SwarmHeartbeatService.spec.mjs
@@ -29,7 +29,7 @@ import {test, expect} from '@playwright/test';
 /**
  * @summary Unit coverage for `ai/daemons/orchestrator/services/SwarmHeartbeatService.mjs` (#10789 AC6, #11766 fold).
  *
- * Covers: `beforeSetIdentity` normalization + null-on-empty (#11797 + #11874 + Sub 1 #11905 AC3 pivot),
+ * Covers: `beforeSetIdentity` normalization + null-on-empty fork-safety,
  * concurrency-lock skip-vs-clear, sunset-detection-routes-to-resumeHarness, gate-tripped
  * blocks high-authority dispatch, idle-out-nudge routing, push-capable bypass,
  * sweep-failure isolation within `pulse()`.
@@ -130,9 +130,8 @@ test.describe('Neo.ai.daemons.SwarmHeartbeatService', () => {
 
     test.afterEach(async () => {
         // Reset identity/pollIntervalMs/targetSource/explicitTargets to fresh-creation
-        // baselines so cases don't bleed. No isInitialized reset (the band-aid was dropped
-        // per #11874 core.Base contract restoration; framework #readyPromise handles
-        // idempotency). The targetSource/explicitTargets resets are Sub 1 #11905 additions.
+        // baselines so cases don't bleed across tests. Framework #readyPromise handles
+        // initAsync idempotency without needing an explicit reset.
         SwarmHeartbeatService.identity        = null;
         SwarmHeartbeatService.pollIntervalMs  = 5 * 60 * 1000;
         SwarmHeartbeatService.targetSource    = null;
@@ -140,7 +139,7 @@ test.describe('Neo.ai.daemons.SwarmHeartbeatService', () => {
         delete SwarmHeartbeatService.getGraphDb;
     });
 
-    test('beforeSetIdentity normalizes GitHub-login form + returns null on empty (#11797, #11874, Sub 1 #11905 AC3 pivot)', async () => {
+    test('beforeSetIdentity normalizes GitHub-login form + returns null on empty', async () => {
         // GitHub-login form: 'neo-opus-4-7' → '@neo-opus-4-7' (normalizer prepends '@')
         SwarmHeartbeatService.identity = 'neo-opus-4-7';
         expect(SwarmHeartbeatService.identity).toBe('@neo-opus-4-7');
@@ -149,11 +148,9 @@ test.describe('Neo.ai.daemons.SwarmHeartbeatService', () => {
         SwarmHeartbeatService.identity = '@neo-gpt';
         expect(SwarmHeartbeatService.identity).toBe('@neo-gpt');
 
-        // Sub 1 #11905 AC3 fork-safety pivot: empty values return null (NOT
-        // DEFAULT_IDENTITY = '@neo-gemini-3-1-pro' as in pre-#11905 shape). The
-        // resolver returns [] when selfIdentity is null + targetSource defaults
-        // to 'self', surfacing the misconfiguration as "no pulses fire" rather
-        // than "silently fans out to Neo identities." External forks MUST set
+        // Empty values return null so unconfigured deployments surface the
+        // misconfiguration via the resolver's disables-with-log path rather than
+        // silently inheriting a maintainer identity. External operators must set
         // NEO_AGENT_IDENTITY or swarmHeartbeat.targetSource: 'disabled'.
         SwarmHeartbeatService.identity = null;
         expect(SwarmHeartbeatService.identity).toBeNull();
@@ -163,7 +160,7 @@ test.describe('Neo.ai.daemons.SwarmHeartbeatService', () => {
         expect(SwarmHeartbeatService.identity).toBeNull();
     });
 
-    test('pulse() with null identity + default targetSource pulses zero identities (Sub 1 #11905 AC3 fork-safety)', async () => {
+    test('pulse() with null identity + default targetSource pulses zero identities', async () => {
         applyDefaultStubs();
         SwarmHeartbeatService.identity = null;  // external fork misconfiguration scenario
 
@@ -175,7 +172,7 @@ test.describe('Neo.ai.daemons.SwarmHeartbeatService', () => {
 
         await SwarmHeartbeatService.pulse();
 
-        // Zero per-identity iterations — the lane silently no-ops (no Neo identity leak).
+        // Zero per-identity iterations — the lane silently no-ops (no identity leak).
         // Substrate maintenance (sweep, all-agent-idle) still ran.
         expect(sunsetChecks).toEqual([]);
     });
@@ -268,12 +265,10 @@ test.describe('Neo.ai.daemons.SwarmHeartbeatService', () => {
         expect(nudgeCalls[0]).toEqual(['@test']);
     });
 
-    test('pulse() with targetSource=active-subscribers checks WAKE_SUBSCRIPTION identities in addition to primary identity (#11872 / Sub 1 #11905)', async () => {
+    test('pulse() with targetSource=active-subscribers checks WAKE_SUBSCRIPTION identities in addition to primary identity', async () => {
         applyDefaultStubs();
-        // Sub 1 #11905: default targetSource changed null→'self' for AC3 fork-safety;
-        // tests exercising the pre-#11905 union-with-subscribers shape must explicitly
-        // opt-in to 'active-subscribers'. Mirrors Neo-operator deployment ergonomic
-        // (set in gitignored ai/config.mjs OR via NEO_ORCHESTRATOR_SWARM_HEARTBEAT_TARGET_SOURCE).
+        // Default targetSource is null → resolver `'self'` for fork-safety; opt-in to
+        // 'active-subscribers' to exercise the union-with-WAKE_SUBSCRIPTION shape.
         SwarmHeartbeatService.targetSource = 'active-subscribers';
 
         const sunsetChecks = [];
@@ -288,7 +283,7 @@ test.describe('Neo.ai.daemons.SwarmHeartbeatService', () => {
         expect(sunsetChecks).toEqual(['@test', '@neo-opus-4-7', '@neo-gpt']);
     });
 
-    test('pulse() with default targetSource=self pulses only primary identity (Sub 1 #11905 AC3 fork-safety)', async () => {
+    test('pulse() with default targetSource=self pulses only primary identity', async () => {
         applyDefaultStubs();
         // No targetSource explicitly set → resolver default ('self'). Even if WAKE_SUBSCRIPTION
         // data is present, the lane only pulses the primary identity. External forks see
@@ -306,7 +301,7 @@ test.describe('Neo.ai.daemons.SwarmHeartbeatService', () => {
         expect(sunsetChecks).toEqual(['@test']);
     });
 
-    test('pulse() with targetSource=disabled skips all per-identity work (Sub 1 #11905)', async () => {
+    test('pulse() with targetSource=disabled skips all per-identity work', async () => {
         applyDefaultStubs();
         SwarmHeartbeatService.targetSource = 'disabled';
         SwarmHeartbeatService.getWakeSubscriptionIdentities = async () => ['@neo-opus-4-7'];
@@ -323,7 +318,7 @@ test.describe('Neo.ai.daemons.SwarmHeartbeatService', () => {
         expect(sunsetChecks).toEqual([]);
     });
 
-    test('pulse() with explicitTargets bypasses targetSource (Sub 1 #11905)', async () => {
+    test('pulse() with explicitTargets bypasses targetSource', async () => {
         applyDefaultStubs();
         SwarmHeartbeatService.targetSource    = 'disabled';                // would normally skip all
         SwarmHeartbeatService.explicitTargets = ['@ext-a', 'ext-b'];        // wins; 'ext-b' normalizes
@@ -339,7 +334,7 @@ test.describe('Neo.ai.daemons.SwarmHeartbeatService', () => {
         expect(sunsetChecks).toEqual(['@ext-a', '@ext-b']);
     });
 
-    test('beforeSetTargetSource coerces invalid values to null (Sub 1 #11905)', async () => {
+    test('beforeSetTargetSource coerces invalid values to null', async () => {
         SwarmHeartbeatService.targetSource = 'self';
         expect(SwarmHeartbeatService.targetSource).toBe('self');
 
@@ -353,7 +348,7 @@ test.describe('Neo.ai.daemons.SwarmHeartbeatService', () => {
         expect(SwarmHeartbeatService.targetSource).toBe('active-local-team');
     });
 
-    test('beforeSetExplicitTargets normalizes + coerces empty to null (Sub 1 #11905)', async () => {
+    test('beforeSetExplicitTargets normalizes + coerces empty to null', async () => {
         SwarmHeartbeatService.explicitTargets = ['neo-opus-4-7', '@neo-gpt'];
         expect(SwarmHeartbeatService.explicitTargets).toEqual(['@neo-opus-4-7', '@neo-gpt']);
 

--- a/test/playwright/unit/ai/daemons/orchestrator/services/SwarmHeartbeatService.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/services/SwarmHeartbeatService.spec.mjs
@@ -29,7 +29,7 @@ import {test, expect} from '@playwright/test';
 /**
  * @summary Unit coverage for `ai/daemons/orchestrator/services/SwarmHeartbeatService.mjs` (#10789 AC6, #11766 fold).
  *
- * Covers: `beforeSetIdentity` normalization + DEFAULT_IDENTITY fallback (#11797 + #11874),
+ * Covers: `beforeSetIdentity` normalization + null-on-empty (#11797 + #11874 + Sub 1 #11905 AC3 pivot),
  * concurrency-lock skip-vs-clear, sunset-detection-routes-to-resumeHarness, gate-tripped
  * blocks high-authority dispatch, idle-out-nudge routing, push-capable bypass,
  * sweep-failure isolation within `pulse()`.
@@ -129,15 +129,18 @@ test.describe('Neo.ai.daemons.SwarmHeartbeatService', () => {
     }
 
     test.afterEach(async () => {
-        // Reset identity/pollIntervalMs to fresh-creation baseline so cases don't bleed.
-        // No isInitialized reset (the band-aid was dropped per #11874 core.Base contract
-        // restoration; framework #readyPromise handles idempotency).
-        SwarmHeartbeatService.identity       = null;
-        SwarmHeartbeatService.pollIntervalMs = 5 * 60 * 1000;
+        // Reset identity/pollIntervalMs/targetSource/explicitTargets to fresh-creation
+        // baselines so cases don't bleed. No isInitialized reset (the band-aid was dropped
+        // per #11874 core.Base contract restoration; framework #readyPromise handles
+        // idempotency). The targetSource/explicitTargets resets are Sub 1 #11905 additions.
+        SwarmHeartbeatService.identity        = null;
+        SwarmHeartbeatService.pollIntervalMs  = 5 * 60 * 1000;
+        SwarmHeartbeatService.targetSource    = null;
+        SwarmHeartbeatService.explicitTargets = null;
         delete SwarmHeartbeatService.getGraphDb;
     });
 
-    test('beforeSetIdentity normalizes GitHub-login form + falls back to DEFAULT_IDENTITY (#11797, #11874)', async () => {
+    test('beforeSetIdentity normalizes GitHub-login form + returns null on empty (#11797, #11874, Sub 1 #11905 AC3 pivot)', async () => {
         // GitHub-login form: 'neo-opus-4-7' → '@neo-opus-4-7' (normalizer prepends '@')
         SwarmHeartbeatService.identity = 'neo-opus-4-7';
         expect(SwarmHeartbeatService.identity).toBe('@neo-opus-4-7');
@@ -146,14 +149,35 @@ test.describe('Neo.ai.daemons.SwarmHeartbeatService', () => {
         SwarmHeartbeatService.identity = '@neo-gpt';
         expect(SwarmHeartbeatService.identity).toBe('@neo-gpt');
 
-        // Null falls back to DEFAULT_IDENTITY (@neo-gemini-3-1-pro) — preserves the
-        // legacy pre-#11874 behavior where unset identity → default polled agent.
+        // Sub 1 #11905 AC3 fork-safety pivot: empty values return null (NOT
+        // DEFAULT_IDENTITY = '@neo-gemini-3-1-pro' as in pre-#11905 shape). The
+        // resolver returns [] when selfIdentity is null + targetSource defaults
+        // to 'self', surfacing the misconfiguration as "no pulses fire" rather
+        // than "silently fans out to Neo identities." External forks MUST set
+        // NEO_AGENT_IDENTITY or swarmHeartbeat.targetSource: 'disabled'.
         SwarmHeartbeatService.identity = null;
-        expect(SwarmHeartbeatService.identity).toBe('@neo-gemini-3-1-pro');
+        expect(SwarmHeartbeatService.identity).toBeNull();
 
-        // Empty string also falls back (treated as no-value)
+        // Empty string also returns null (treated as no-value)
         SwarmHeartbeatService.identity = '';
-        expect(SwarmHeartbeatService.identity).toBe('@neo-gemini-3-1-pro');
+        expect(SwarmHeartbeatService.identity).toBeNull();
+    });
+
+    test('pulse() with null identity + default targetSource pulses zero identities (Sub 1 #11905 AC3 fork-safety)', async () => {
+        applyDefaultStubs();
+        SwarmHeartbeatService.identity = null;  // external fork misconfiguration scenario
+
+        const sunsetChecks = [];
+        SwarmHeartbeatService.checkSunsetted = async (identity) => {
+            sunsetChecks.push(identity);
+            return {sunsetted: false, recommended_action: 'no_action'};
+        };
+
+        await SwarmHeartbeatService.pulse();
+
+        // Zero per-identity iterations — the lane silently no-ops (no Neo identity leak).
+        // Substrate maintenance (sweep, all-agent-idle) still ran.
+        expect(sunsetChecks).toEqual([]);
     });
 
     test('pulse() skips when concurrency lock is active', async () => {
@@ -244,8 +268,13 @@ test.describe('Neo.ai.daemons.SwarmHeartbeatService', () => {
         expect(nudgeCalls[0]).toEqual(['@test']);
     });
 
-    test('pulse() checks active WAKE_SUBSCRIPTION identities in addition to the primary identity (#11872)', async () => {
+    test('pulse() with targetSource=active-subscribers checks WAKE_SUBSCRIPTION identities in addition to primary identity (#11872 / Sub 1 #11905)', async () => {
         applyDefaultStubs();
+        // Sub 1 #11905: default targetSource changed null→'self' for AC3 fork-safety;
+        // tests exercising the pre-#11905 union-with-subscribers shape must explicitly
+        // opt-in to 'active-subscribers'. Mirrors Neo-operator deployment ergonomic
+        // (set in gitignored ai/config.mjs OR via NEO_ORCHESTRATOR_SWARM_HEARTBEAT_TARGET_SOURCE).
+        SwarmHeartbeatService.targetSource = 'active-subscribers';
 
         const sunsetChecks = [];
         SwarmHeartbeatService.getWakeSubscriptionIdentities = async () => ['@neo-opus-4-7', '@neo-gpt', '@neo-gpt'];
@@ -257,6 +286,85 @@ test.describe('Neo.ai.daemons.SwarmHeartbeatService', () => {
         await SwarmHeartbeatService.pulse();
 
         expect(sunsetChecks).toEqual(['@test', '@neo-opus-4-7', '@neo-gpt']);
+    });
+
+    test('pulse() with default targetSource=self pulses only primary identity (Sub 1 #11905 AC3 fork-safety)', async () => {
+        applyDefaultStubs();
+        // No targetSource explicitly set → resolver default ('self'). Even if WAKE_SUBSCRIPTION
+        // data is present, the lane only pulses the primary identity. External forks see
+        // identical safe behavior by default.
+        SwarmHeartbeatService.getWakeSubscriptionIdentities = async () => ['@neo-opus-4-7', '@neo-gpt'];
+
+        const sunsetChecks = [];
+        SwarmHeartbeatService.checkSunsetted = async (identity) => {
+            sunsetChecks.push(identity);
+            return {sunsetted: false, recommended_action: 'no_action'};
+        };
+
+        await SwarmHeartbeatService.pulse();
+
+        expect(sunsetChecks).toEqual(['@test']);
+    });
+
+    test('pulse() with targetSource=disabled skips all per-identity work (Sub 1 #11905)', async () => {
+        applyDefaultStubs();
+        SwarmHeartbeatService.targetSource = 'disabled';
+        SwarmHeartbeatService.getWakeSubscriptionIdentities = async () => ['@neo-opus-4-7'];
+
+        const sunsetChecks = [];
+        SwarmHeartbeatService.checkSunsetted = async (identity) => {
+            sunsetChecks.push(identity);
+            return {sunsetted: false, recommended_action: 'no_action'};
+        };
+
+        await SwarmHeartbeatService.pulse();
+
+        // Zero per-identity iterations; substrate maintenance (sweep, all-agent-idle) still ran.
+        expect(sunsetChecks).toEqual([]);
+    });
+
+    test('pulse() with explicitTargets bypasses targetSource (Sub 1 #11905)', async () => {
+        applyDefaultStubs();
+        SwarmHeartbeatService.targetSource    = 'disabled';                // would normally skip all
+        SwarmHeartbeatService.explicitTargets = ['@ext-a', 'ext-b'];        // wins; 'ext-b' normalizes
+
+        const sunsetChecks = [];
+        SwarmHeartbeatService.checkSunsetted = async (identity) => {
+            sunsetChecks.push(identity);
+            return {sunsetted: false, recommended_action: 'no_action'};
+        };
+
+        await SwarmHeartbeatService.pulse();
+
+        expect(sunsetChecks).toEqual(['@ext-a', '@ext-b']);
+    });
+
+    test('beforeSetTargetSource coerces invalid values to null (Sub 1 #11905)', async () => {
+        SwarmHeartbeatService.targetSource = 'self';
+        expect(SwarmHeartbeatService.targetSource).toBe('self');
+
+        SwarmHeartbeatService.targetSource = 'bogus-source';
+        expect(SwarmHeartbeatService.targetSource).toBeNull();
+
+        SwarmHeartbeatService.targetSource = '';
+        expect(SwarmHeartbeatService.targetSource).toBeNull();
+
+        SwarmHeartbeatService.targetSource = 'active-local-team';
+        expect(SwarmHeartbeatService.targetSource).toBe('active-local-team');
+    });
+
+    test('beforeSetExplicitTargets normalizes + coerces empty to null (Sub 1 #11905)', async () => {
+        SwarmHeartbeatService.explicitTargets = ['neo-opus-4-7', '@neo-gpt'];
+        expect(SwarmHeartbeatService.explicitTargets).toEqual(['@neo-opus-4-7', '@neo-gpt']);
+
+        SwarmHeartbeatService.explicitTargets = [];
+        expect(SwarmHeartbeatService.explicitTargets).toBeNull();
+
+        SwarmHeartbeatService.explicitTargets = null;
+        expect(SwarmHeartbeatService.explicitTargets).toBeNull();
+
+        SwarmHeartbeatService.explicitTargets = 'not-an-array';
+        expect(SwarmHeartbeatService.explicitTargets).toBeNull();
     });
 
     test('getWakeSubscriptionIdentities() normalizes active subscription identities and filters disabled routes (#11872)', async () => {


### PR DESCRIPTION
Resolves #11905

Adds the deployment-portable heartbeat target resolver per Epic #11829 AC2 / Sub 1 (BLOCKING). The pure-function `resolveTargets()` exported from `scheduling/swarmHeartbeat.mjs` walks a 5-step precedence chain that selects which identity set `SwarmHeartbeatService.pulse()` targets per cycle, replacing the pre-#11905 hardcoded union-with-WAKE_SUBSCRIPTION shape. AC3 fork-safety pivot completes the substrate by removing the `DEFAULT_IDENTITY = '@neo-gemini-3-1-pro'` upstream fallback that leaked a Neo maintainer identity into external-fork deployments.

FAIR-band: over-target [20/30] — taking this lane despite over-target because BLOCKING Epic #11829 + sole-available-author (GPT busy on #11904 pr-review density compression; Gemini operator-benched ~1mo); operator nightshift-mode 2-parallel-lanes directive.

Evidence: L2 (unit-tested pure function + integration tests verifying pulse delegation, AC3 null-identity no-op, all 4 source enums) → L2 sufficient for Sub 1 close target (the resolver is a pure-function contract; production-load validation is the Epic-level AC7).

## Deltas from ticket (if any)

- **File path correction:** ticket body references `ai/daemons/services/SwarmHeartbeatService.mjs:102/:129-131/:199/:224` — those paths are stale (Sub 8 #11844 moved the cluster to `ai/daemons/orchestrator/services/`). Implementation uses the correct location.
- **Resolver location:** prescription is silent on resolver file location. Co-located with the existing `scheduling/swarmHeartbeat.mjs` due-trigger projection as a second export — same lane-policy domain, two pure-function primitives (when + who) in one place. The `services/` folder is reserved for `*Service.mjs` Neo classes per existing convention.
- **AC3 scope expansion:** ticket AC3 specifies "external workspace defaults to `'self'` OR disables-with-log — NEVER silently fans out to Neo maintainer identities." Implementing the resolver alone is AC3-incomplete because `beforeSetIdentity`'s `DEFAULT_IDENTITY = '@neo-gemini-3-1-pro'` upstream fallback would still leak. Removed the fallback (returns `null` on empty); the resolver returns `[]` for `selfIdentity=null` + `targetSource='self'` (default), surfacing the misconfiguration as "no pulses fire" rather than "silently fans out." Cycle-3 further removed the `DEFAULT_IDENTITY` constant and export entirely after `grep` confirmed no external consumer.
- **`'active-subscribers'` semantics:** unions self + subscribers to preserve pre-#11905 union shape; the existing test (`#11872 WAKE_SUBSCRIPTION iteration`) updated to opt-in to `'active-subscribers'` explicitly.

## Test Evidence

- `npm run test-unit -- --grep "swarmHeartbeat|SwarmHeartbeat"` → **43 passed (2.4s)** (cycle-3 / latest head; cycle-1 was 41)
  - 18 `resolveTargets` pure-function tests covering all 5 precedence steps + AC3 fork-safety + AC4 named scenarios (no-config-defaults-self, explicit-target-list, active-local-team, unknown-target-fail-closed)
  - 5 new `SwarmHeartbeatService.pulse()` integration tests covering: default-self, disabled, explicitTargets-bypass, beforeSetTargetSource coercion, beforeSetExplicitTargets normalization
  - 1 new AC3 fork-safety test: null identity + default source → zero per-identity iterations
  - 4 existing `getDueTask` tests unchanged
  - Existing pulse tests pass (one updated to opt-in to `'active-subscribers'` for WAKE_SUBSCRIPTION iteration)
- `npm run test-unit -- --grep "Orchestrator"` → **211 passed (9.5s)** — confirms `Orchestrator.start()` wire-up doesn't break sibling lanes
- `git diff --check` → clean (no trailing whitespace)

## Post-Merge Validation

- [ ] @tobiu local orchestrator restart: confirm `NEO_AGENT_IDENTITY` set → `getPulseIdentities()` returns `['@neo-opus-4-7']` (default `'self'`) per orchestrator log
- [ ] Try `NEO_ORCHESTRATOR_SWARM_HEARTBEAT_TARGET_SOURCE=active-subscribers` → log shows N nudge lines where N = active WAKE_SUBSCRIPTION count + self (pre-#11905 behavior preserved as opt-in)
- [ ] Sub 2 #11906 + Sub 4 #11908 unblocked (AC2 cardinality logging is now resolver-driven, not hardcoded)
- [ ] Epic #11829 AC7 cross-family symmetric validation tracking (Codex nightshift-lifecycle-driver watchdog retirable when this lands + Sub 1-2-3-4 all merged)


## Cycle-2 (per GPT review)

- **RA1 — null-self disables-with-log**: resolver `selfFallback()` helper now emits an info log naming both operator knobs (`NEO_AGENT_IDENTITY` env + `targetSource='disabled'` config) when `selfIdentity` is null. Extracted to share the observable behavior across the `'self'` branch, the unknown-source fallback, and the active-subscribers-missing-provider fallback. AC3 wording now fully honored (no leak AND disables-with-log).
- **RA2 — Contract Ledger**: appended to ticket #11905 body covering 11 named public-contract surface points (3 env vars + 1 AiConfig key + 4 resolver enum branches + 3 config-set hooks). PR diff matches ledger exactly.

Cycle-2 test evidence: `npm run test-unit -- --grep "swarmHeartbeat|SwarmHeartbeat"` -> 43 passed (was 41 cycle-1; +2 new tests for unknown-source + active-subscribers-missing-provider null-self paths, +1 upgraded AC3 fork-safety test asserting the info log payload).


## Cycle-3 (per GPT review)

- **RA1 — Remove dead DEFAULT_IDENTITY export**: confirmed via grep no external consumer; removed the const and the named export. Test docstring + reference updated to drop the same name.
- **RA2 — Strip ticket/epic/AC/cycle/history anchors from added/edited prose**: applied across `scheduling/swarmHeartbeat.mjs` (resolveTargets JSDoc + selfFallback helper), `services/SwarmHeartbeatService.mjs` (identity_/targetSource_/explicitTargets_/beforeSetIdentity/getPulseIdentities), `ai/config.template.mjs` (swarmHeartbeat.targetSource slot), and both spec files (describe block + 19 test names + spec header docstring). Provenance now lives in git blame + PR/ticket/commit context. Pre-existing tests (e.g. `isPushCapable() ... (#11872)`) retain their original anchors per the review scope.

Cycle-3 net: +106 / -132 LOC across the same 5 files. 43 tests pass (unchanged from cycle-2).

## Commits

- `07907e62c` — cycle-1: feat(orchestrator): add resolveSwarmHeartbeatTargets with 5-step precedence chain (#11905)
- `a35702d58` — cycle-2: feat(orchestrator): make AC3 null-self path observable + Contract Ledger (#11905)
- `3bcea60e9` — cycle-3: chore(orchestrator): strip provenance + remove dead DEFAULT_IDENTITY export (#11905)

Authored by Claude Opus 4.7 (1M context, Claude Code).
