### PR TITLE
feat(ai): add live skill size report (#11902)

### DIFF
--- a/ai/scripts/lint/lint-skill-manifest.mjs
+++ b/ai/scripts/lint/lint-skill-manifest.mjs
@@ -19,9 +19,14 @@ const SKILLS_DIR    = path.join(ROOT_DIR, '.agents/skills');
 const CLAUDE_DIR    = path.join(ROOT_DIR, '.claude/skills');
 const MANIFEST_PATH = path.join(SKILLS_DIR, 'skills.manifest.json');
 const SCHEMA_PATH   = path.join(SKILLS_DIR, 'skills.manifest.schema.json');
+const REPORT_TOP_N  = 15;
 
 function parseArgs(argv = process.argv.slice(2)) {
-    const options = {base: null};
+    const options = {
+        base       : null,
+        reportSizes: false,
+        top        : REPORT_TOP_N
+    };
 
     for (let i = 0; i < argv.length; i++) {
         const arg = argv[i];
@@ -30,12 +35,28 @@ function parseArgs(argv = process.argv.slice(2)) {
             options.base = argv[++i];
         } else if (arg.startsWith('--base=')) {
             options.base = arg.slice('--base='.length);
+        } else if (arg === '--report-sizes') {
+            options.reportSizes = true;
+        } else if (arg === '--top') {
+            options.top = parseTopArg(argv[++i]);
+        } else if (arg.startsWith('--top=')) {
+            options.top = parseTopArg(arg.slice('--top='.length));
         } else {
             throw new Error(`Unknown argument: ${arg}`);
         }
     }
 
     return options;
+}
+
+function parseTopArg(value) {
+    const parsed = Number.parseInt(value, 10);
+
+    if (!Number.isInteger(parsed) || parsed < 1) {
+        throw new Error(`--top must be a positive integer, got: ${value}`);
+    }
+
+    return parsed;
 }
 
 function readJson(filePath) {
@@ -109,6 +130,79 @@ async function walkFiles(dir) {
     }
 
     return files;
+}
+
+function countMatches(text, regex) {
+    return (text.match(regex) || []).length;
+}
+
+function classifySizeReportRow(row) {
+    if (row.file.endsWith('/SKILL.md')) return 'keep';
+    if (row.bytes > 30000 || row.signals > 150) return 'compress-to-trigger';
+    if (row.lineRefs > 0 || row.history > 50) return 'rewrite';
+    if (row.file.includes('/audits/') && row.bytes > 10000) return 'move';
+
+    return 'keep';
+}
+
+async function skillMarkdownSizeReport({top = REPORT_TOP_N} = {}) {
+    const files = (await walkFiles(SKILLS_DIR))
+        .filter(file => file.endsWith('.md'))
+        .sort();
+
+    const rows = files.map(filePath => {
+        const text    = requireText(filePath);
+        const bytes   = Buffer.byteLength(text, 'utf8');
+        const lines   = text.split('\n').length;
+        const headings = countMatches(text, /^#{1,6}\s+/gm);
+        const musts   = countMatches(text, /\bMUST\b|\bMANDATORY\b|\bFORBIDDEN\b/g);
+        const history = countMatches(text, /\b(PR|Issue|Discussion)\s+#\d+|#\d{4,}|empirical anchor|lineage|histor/ig);
+        const lineRefs = countMatches(text, /[A-Za-z0-9_.\/-]+\.(mjs|md|js|json):\d+/g);
+        const provenance = countMatches(text, /archaeolog|provenance|incident|origin|lineage|empirical anchor/ig);
+        const triggers = countMatches(text, /trigger|when to read|read .* before|<!--\s*trigger:/ig);
+        const signals = Math.round(bytes / 1000) + headings + history * 2 + lineRefs * 3 + provenance * 2 + Math.max(0, musts - 10);
+
+        const row = {
+            file: path.relative(ROOT_DIR, filePath),
+            bytes,
+            lines,
+            headings,
+            musts,
+            history,
+            lineRefs,
+            provenance,
+            triggers,
+            signals
+        };
+
+        return {
+            ...row,
+            disposition: classifySizeReportRow(row)
+        };
+    }).sort((a, b) => b.signals - a.signals || b.bytes - a.bytes || a.file.localeCompare(b.file));
+
+    return {
+        summary: {
+            fileCount : rows.length,
+            totalBytes: rows.reduce((sum, row) => sum + row.bytes, 0),
+            totalLines: rows.reduce((sum, row) => sum + row.lines, 0)
+        },
+        rows: rows.slice(0, top)
+    };
+}
+
+function formatSkillMarkdownSizeReport(report) {
+    const lines = [
+        '[lint-skill-manifest] Skill Markdown size report (live)',
+        `files=${report.summary.fileCount} bytes=${report.summary.totalBytes} lines=${report.summary.totalLines}`,
+        'rank\tbytes\tlines\tsignals\tdisposition\tfile'
+    ];
+
+    report.rows.forEach((row, index) => {
+        lines.push(`${index + 1}\t${row.bytes}\t${row.lines}\t${row.signals}\t${row.disposition}\t${row.file}`);
+    });
+
+    return lines.join('\n');
 }
 
 async function payloadBytes(skillName) {
@@ -509,6 +603,12 @@ async function lint({base = null} = {}) {
 
 async function main() {
     const options = parseArgs();
+
+    if (options.reportSizes) {
+        console.log(formatSkillMarkdownSizeReport(await skillMarkdownSizeReport({top: options.top})));
+        return;
+    }
+
     const errors  = await lint(options);
 
     if (errors.length) {
@@ -529,4 +629,16 @@ if (process.argv[1] && path.resolve(process.argv[1]) === __filename) {
     });
 }
 
-export {checkOversizedWorkflowMaps, checkPerFileBudgets, checkSectionTriggers, parseSectionTriggers, lint, parseArgs, parseFrontmatter, validateManifestSchema};
+export {
+    checkOversizedWorkflowMaps,
+    checkPerFileBudgets,
+    checkSectionTriggers,
+    classifySizeReportRow,
+    formatSkillMarkdownSizeReport,
+    parseSectionTriggers,
+    skillMarkdownSizeReport,
+    lint,
+    parseArgs,
+    parseFrontmatter,
+    validateManifestSchema
+};

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
         "ai:prune-worktrees"           : "node ./ai/scripts/migrations/bootstrapWorktree.mjs --prune-stale",
         "ai:lint-agents"               : "node ./ai/scripts/lint/lint-agents.mjs",
         "ai:lint-skill-manifest"       : "node ./ai/scripts/lint/lint-skill-manifest.mjs",
+        "ai:skill-size-report"         : "node ./ai/scripts/lint/lint-skill-manifest.mjs --report-sizes",
         "ai:kb-alerting"               : "node ./ai/daemons/kb-alerting/daemon.mjs",
         "ai:kb-reconciliation"         : "node ./ai/daemons/kb-reconciliation/daemon.mjs",
         "ai:kb-gc"                     : "node ./ai/daemons/kb-gc/daemon.mjs",

--- a/test/playwright/unit/ai/scripts/lint/lintSkillManifest.spec.mjs
+++ b/test/playwright/unit/ai/scripts/lint/lintSkillManifest.spec.mjs
@@ -6,6 +6,8 @@ import {
     checkOversizedWorkflowMaps,
     checkPerFileBudgets,
     checkSectionTriggers,
+    classifySizeReportRow,
+    formatSkillMarkdownSizeReport,
     parseArgs,
     parseFrontmatter,
     parseSectionTriggers,
@@ -30,6 +32,73 @@ test.describe('ai/scripts/lint-skill-manifest (#11275)', () => {
 
         expect(parsed.name).toBe('test-skill');
         expect(parsed.description).toBe('Short: description');
+    });
+
+    test('parseArgs supports live size reports without changing lint defaults', () => {
+        expect(parseArgs(['--report-sizes', '--top', '3'])).toEqual({
+            base       : null,
+            reportSizes: true,
+            top        : 3
+        });
+
+        expect(parseArgs(['--base=origin/dev'])).toEqual({
+            base       : 'origin/dev',
+            reportSizes: false,
+            top        : 15
+        });
+    });
+
+    test('CLI emits a live skill size report on demand', () => {
+        const result = spawnSync('node', [scriptPath, '--report-sizes', '--top', '3'], {
+            cwd     : process.cwd(),
+            encoding: 'utf8'
+        });
+
+        expect(result.status, result.stderr).toBe(0);
+        expect(result.stdout).toContain('[lint-skill-manifest] Skill Markdown size report (live)');
+        expect(result.stdout).toContain('rank\tbytes\tlines\tsignals\tdisposition\tfile');
+        expect(result.stdout).toContain('.agents/skills/');
+    });
+
+    test('formatSkillMarkdownSizeReport renders current metrics without snapshot prose', () => {
+        const report = {
+            summary: {
+                fileCount : 2,
+                totalBytes: 300,
+                totalLines: 30
+            },
+            rows: [{
+                file       : '.agents/skills/example/references/a.md',
+                bytes      : 200,
+                lines      : 20,
+                signals    : 8,
+                disposition: 'keep'
+            }]
+        };
+
+        const text = formatSkillMarkdownSizeReport(report);
+
+        expect(text).toContain('files=2 bytes=300 lines=30');
+        expect(text).toContain('1\t200\t20\t8\tkeep\t.agents/skills/example/references/a.md');
+        expect(text).not.toContain('Created for');
+    });
+
+    test('classifySizeReportRow flags stale-history-heavy payloads for rewrite', () => {
+        expect(classifySizeReportRow({
+            file    : '.agents/skills/example/references/history.md',
+            bytes   : 12000,
+            signals : 80,
+            lineRefs: 2,
+            history : 20
+        })).toBe('rewrite');
+
+        expect(classifySizeReportRow({
+            file    : '.agents/skills/example/SKILL.md',
+            bytes   : 40000,
+            signals : 250,
+            lineRefs: 0,
+            history : 0
+        })).toBe('keep');
     });
 
     test('schema validator catches missing required skill fields', () => {


### PR DESCRIPTION
Authored by GPT-5 (Codex Desktop). Session 967e325b-d90a-43f4-9e91-c212e9bda746.

FAIR-band: under-target [11/30] — Self-Selection Rule 1 fires (under-band -> bias toward author lane).

Resolves #11902
Related: #11605

Adds live skill Markdown loaded-surface measurement to the existing `lint-skill-manifest` substrate. The new `--report-sizes` mode computes current file counts, bytes, lines, signal score, and candidate disposition from the working tree on demand, so #11902 no longer depends on a static inventory document that goes stale after a few PRs.

Evidence: L2 (CLI report mode + focused unit coverage + manifest lint) -> L2 required (tooling behavior and reproducible measurement ACs). No residuals.

## Deltas from ticket (if any)

- Operator step-back rejected the initial static-doc shape from closed PR #11903. This PR supersedes it with executable measurement in the skill-lint/check surface.
- No committed inventory report is added. Current numbers are generated by `npm run ai:skill-size-report -- --top <N>`.
- The npm alias is convenience only; the canonical implementation remains `ai/scripts/lint/lint-skill-manifest.mjs --report-sizes`.
- Disposition labels are computed as candidate hints for follow-up planning, not as permanent architecture truth.

## Test Evidence

- `npm run ai:skill-size-report -- --top 5` -> emits live report; current run showed 82 files, 489365 bytes, 5967 lines.
- `npm run ai:lint-skill-manifest -- --base origin/dev` -> OK.
- `npm run test-unit -- test/playwright/unit/ai/scripts/lint/lintSkillManifest.spec.mjs` -> 25 passed.
- `git diff --cached --check` -> clean before commit.
- `git diff --check` -> clean before push.
- Pre-push freshness check passed: `merge-base HEAD origin/dev == origin/dev`; outgoing log contains only `7ccae1f18`.

## Post-Merge Validation

- [ ] Run `npm run ai:skill-size-report -- --top 15` before filing #11605 follow-up cleanup children; use live output rather than copying stale totals into docs.

## Commits

- `7ccae1f18` — `feat(ai): add live skill size report (#11902)`