### PR TITLE
feat(ai-restore): Chroma preserve-live merge parity for #importMemories (#11144)

### DIFF
--- a/ai/scripts/maintenance/restore.mjs
+++ b/ai/scripts/maintenance/restore.mjs
@@ -56,9 +56,10 @@ import {
  * - **Two-mode contract:**
  *     - `--mode merge` (default): idempotent. **Graph SQLite** uses `INSERT OR IGNORE` —
  *       backup-only IDs INSERT; live-existing IDs preserved (post-wipe re-ingestion stays
- *       authoritative). **Memory + summaries (Chroma)** still use `collection.upsert()` —
- *       preserve-live parity for the Chroma side is tracked at #11144. **Flat substrates**
- *       skip-if-target-non-empty (preserves operator additions). No `--force` required.
+ *       authoritative). **Memory + summaries (Chroma)** preflight existing IDs in chunks
+ *       via `collection.get({ids})` and `collection.add()` only the missing subset
+ *       (#11144 parity with graph-side semantic). **Flat substrates** skip-if-target-non-empty
+ *       (preserves operator additions). No `--force` required.
  *       Per-#11141: graph-side preserve-live semantic was silently broken pre-#11141 (used
  *       `INSERT OR REPLACE`); 2026-05-10 graph-wipe incident was the empirical anchor.
  *     - `--mode replace`: gated. Each embedded subsystem fires

--- a/ai/services/memory-core/DatabaseService.mjs
+++ b/ai/services/memory-core/DatabaseService.mjs
@@ -453,11 +453,21 @@ class DatabaseService extends Base {
 
             let totalImported        = 0;
             let targetCollectionName = '';
-            // #11141: per-substrate truthful counters surface alongside the aggregate so
+            // #11141 + #11144: per-substrate truthful counters surface alongside the aggregate so
             // operator validation can distinguish inserted vs skippedExisting vs failed
-            // post-merge. Currently only graph emits structured counts (`#importGraph`);
-            // memory/summaries upsert path is bulk + adds its count to memoriesInserted.
-            const subsystemCounts = {graph: null, memoriesInserted: 0};
+            // post-merge. Graph counts come from `#importGraph`. Chroma counts (memories,
+            // summaries) come from the mode-branched path below: merge mode preflights
+            // existing IDs in chunks + only `collection.add()`s missing IDs (preserve-live
+            // parity with graph-side INSERT OR IGNORE); replace mode runs `collection.upsert()`
+            // after subsystem truncate. `memoriesInserted` is preserved as a backward-compat
+            // aggregate of memories.inserted + summaries.inserted (matches #11141 `imported`
+            // field pattern at `importDatabase`'s aggregation layer).
+            const subsystemCounts = {
+                graph           : null,
+                memories        : {inserted: 0, skippedExisting: 0, failed: 0},
+                summaries       : {inserted: 0, skippedExisting: 0, failed: 0},
+                memoriesInserted: 0
+            };
 
             for (const filePath of filesToImport) {
                 logger.log(`Importing: ${filePath}`);
@@ -480,6 +490,10 @@ class DatabaseService extends Base {
 
                 targetCollectionName = collection.name; // roughly tracking target
 
+                // #11144: route per-file counters into the right substrate bucket so
+                // memories vs summaries truthful counts stay separable across multi-file batches.
+                const chromaCounts = isMemoryBackup ? subsystemCounts.memories : subsystemCounts.summaries;
+
                 const fileStream = fs.createReadStream(filePath);
                 const rl         = readline.createInterface({input: fileStream, crlfDelay: Infinity});
                 const records    = [];
@@ -500,7 +514,7 @@ class DatabaseService extends Base {
                     records.forEach(r => delete r.embedding);
                 }
 
-                // Chroma has TWO upsert limits: (1) record-count cap ~5461; (2) HTTP
+                // Chroma has TWO upsert/add limits: (1) record-count cap ~5461; (2) HTTP
                 // body size cap that 413-rejects large payloads. With 4096-dim qwen3
                 // embeddings (~32KB each) + document text, per-record is ~35-40KB.
                 // Chunk size 250 = ~10MB body, well within HTTP limits + record cap.
@@ -508,30 +522,84 @@ class DatabaseService extends Base {
                 //   - 9244 records: "Record set length 9244 exceeds max batch size 5461"
                 //   - 4000 records: "413: Payload Too Large"
                 const CHROMA_UPSERT_CHUNK_SIZE = 250;
-                for (let i = 0; i < records.length; i += CHROMA_UPSERT_CHUNK_SIZE) {
-                    const chunk = records.slice(i, i + CHROMA_UPSERT_CHUNK_SIZE);
-                    await collection.upsert({
-                        ids       : chunk.map(r => r.id),
-                        embeddings: chunk.map(r => r.embedding),
-                        metadatas : chunk.map(r => r.metadata),
-                        documents : chunk.map(r => r.document)
-                    });
-                    if (records.length > CHROMA_UPSERT_CHUNK_SIZE) {
-                        logger.log(`  upserted chunk ${Math.floor(i / CHROMA_UPSERT_CHUNK_SIZE) + 1}/${Math.ceil(records.length / CHROMA_UPSERT_CHUNK_SIZE)} (${chunk.length} records)`);
+
+                let fileInserted        = 0;
+                let fileSkippedExisting = 0;
+                let fileFailed          = 0;
+
+                if (mode === 'merge') {
+                    // #11144: preserve-live merge (Chroma parity with graph-side INSERT OR IGNORE
+                    // shipped in #11141). Chunked existence-check via `collection.get({ids})`,
+                    // then `collection.add()` for the missing-ID subset only. Live records
+                    // are NOT overwritten — the running daemon's authoritative state survives.
+                    const existingIds = new Set();
+                    for (let i = 0; i < records.length; i += CHROMA_UPSERT_CHUNK_SIZE) {
+                        const chunkIds  = records.slice(i, i + CHROMA_UPSERT_CHUNK_SIZE).map(r => r.id);
+                        const existence = await collection.get({ids: chunkIds, include: []});
+                        existence.ids.forEach(id => existingIds.add(id));
                     }
+
+                    const missing       = records.filter(r => !existingIds.has(r.id));
+                    fileSkippedExisting = existingIds.size;
+
+                    if (existingIds.size > 0) {
+                        logger.log(`  merge mode: ${existingIds.size} live ID(s) preserved; ${missing.length} new record(s) to insert.`);
+                    }
+
+                    for (let i = 0; i < missing.length; i += CHROMA_UPSERT_CHUNK_SIZE) {
+                        const chunk = missing.slice(i, i + CHROMA_UPSERT_CHUNK_SIZE);
+                        try {
+                            await collection.add({
+                                ids       : chunk.map(r => r.id),
+                                embeddings: chunk.map(r => r.embedding),
+                                metadatas : chunk.map(r => r.metadata),
+                                documents : chunk.map(r => r.document)
+                            });
+                            fileInserted += chunk.length;
+                        } catch (e) {
+                            fileFailed += chunk.length;
+                            logger.error(`[importMemories] add failed for chunk ${Math.floor(i / CHROMA_UPSERT_CHUNK_SIZE) + 1}: ${e.message}`);
+                        }
+                        if (missing.length > CHROMA_UPSERT_CHUNK_SIZE) {
+                            logger.log(`  added chunk ${Math.floor(i / CHROMA_UPSERT_CHUNK_SIZE) + 1}/${Math.ceil(missing.length / CHROMA_UPSERT_CHUNK_SIZE)} (${chunk.length} records)`);
+                        }
+                    }
+                } else {
+                    // Replace mode: subsystem already truncated above; upsert is safe
+                    // (no live rows to collide with). Fail-fast on chunk error matches
+                    // pre-#11144 behavior; the outer try/catch wraps it as DATABASE_IMPORT_ERROR.
+                    for (let i = 0; i < records.length; i += CHROMA_UPSERT_CHUNK_SIZE) {
+                        const chunk = records.slice(i, i + CHROMA_UPSERT_CHUNK_SIZE);
+                        await collection.upsert({
+                            ids       : chunk.map(r => r.id),
+                            embeddings: chunk.map(r => r.embedding),
+                            metadatas : chunk.map(r => r.metadata),
+                            documents : chunk.map(r => r.document)
+                        });
+                        if (records.length > CHROMA_UPSERT_CHUNK_SIZE) {
+                            logger.log(`  upserted chunk ${Math.floor(i / CHROMA_UPSERT_CHUNK_SIZE) + 1}/${Math.ceil(records.length / CHROMA_UPSERT_CHUNK_SIZE)} (${chunk.length} records)`);
+                        }
+                    }
+                    fileInserted = records.length;
                 }
 
-                totalImported           += records.length;
-                subsystemCounts.memoriesInserted += records.length;
+                chromaCounts.inserted            += fileInserted;
+                chromaCounts.skippedExisting     += fileSkippedExisting;
+                chromaCounts.failed              += fileFailed;
+                totalImported                    += fileInserted;
+                subsystemCounts.memoriesInserted += fileInserted;
             }
 
             return {
                 message : `Import batch complete. Successfully ingested ${totalImported} records across ${filesToImport.length} file(s).`,
                 imported: totalImported,
                 mode,
-                // #11141: structured per-substrate breakdown for operator validation.
+                // #11141 + #11144: structured per-substrate breakdown for operator validation.
                 // `graph` is null when no graph file was imported in this batch; otherwise
                 // exposes {nodes: {inserted,skippedExisting,failed}, edges: {inserted,skippedExisting,failed}}.
+                // `memories` + `summaries` each expose {inserted, skippedExisting, failed}
+                // — merge mode populates skippedExisting; replace mode runs upsert so
+                // skippedExisting stays 0. `memoriesInserted` is the backward-compat aggregate.
                 counts  : subsystemCounts
             };
         } catch (error) {

--- a/test/playwright/unit/ai/scripts/maintenance/restore-hardening.spec.mjs
+++ b/test/playwright/unit/ai/scripts/maintenance/restore-hardening.spec.mjs
@@ -130,18 +130,27 @@ test.describe('restore hardening regression (#11150 / #11151)', () => {
     // Test 3: Chunked Chroma upsert in #importMemories
     // ─────────────────────────────────────────────────────────────────────
 
-    test('#importMemories chunks Chroma collection.upsert() for large record sets', async () => {
+    test('#importMemories chunks Chroma write calls for large record sets (#11144: merge=add, replace=upsert)', async () => {
         // Black-box the chunking via the public manageDatabaseBackup({action:'import'})
         // surface. Mock the Memory_StorageRouter.getMemoryCollection to return a fake
-        // collection with an upsert spy; record per-call record-count, assert chunked.
+        // collection with add + get spies; record per-call record-count, assert chunked.
+        //
+        // #11144 changed merge-mode's Chroma primitive from `upsert()` to a preflight
+        // `get({ids})` existence check + `add()` for missing-only IDs. With no live
+        // records, every backup ID is "missing" → 1000 records still chunk into 4
+        // chunks of 250 (same CHROMA_UPSERT_CHUNK_SIZE budget). Also assert the
+        // existence-preflight is chunked at the same boundary.
         const SDK = await import('../../../../../../ai/services.mjs');
         const Memory_DatabaseService = SDK.Memory_DatabaseService;
         const Memory_StorageRouter   = SDK.Memory_StorageRouter;
 
-        const upsertCalls = [];
+        const addCalls    = [];
+        const getCalls    = [];
         const mockCollection = {
             name: 'neo-agent-memory',
-            upsert: async ({ids}) => { upsertCalls.push(ids.length); }
+            get   : async ({ids}) => { getCalls.push(ids.length); return {ids: []}; },
+            add   : async ({ids}) => { addCalls.push(ids.length); },
+            upsert: async ({ids}) => { addCalls.push(ids.length); } // replace-mode path safety
         };
         const originalGetMemColl = Memory_StorageRouter.getMemoryCollection;
         const originalGetSumColl = Memory_StorageRouter.getSummaryCollection;
@@ -149,7 +158,7 @@ test.describe('restore hardening regression (#11150 / #11151)', () => {
         Memory_StorageRouter.getSummaryCollection = async () => mockCollection;
 
         // Build synthetic JSONL bundle dir with 1000 records (> CHROMA_UPSERT_CHUNK_SIZE
-        // of 250 → expect ⌈1000/250⌉ = 4 calls).
+        // of 250 → expect ⌈1000/250⌉ = 4 add() calls + 4 get() preflight calls).
         const workRoot = await fsExtra.mkdtemp(path.join(os.tmpdir(), 'restore-hardening-chunk-'));
         const mcDir   = path.join(workRoot, 'mc-import');
         await fsExtra.ensureDir(mcDir);
@@ -171,10 +180,16 @@ test.describe('restore hardening regression (#11150 / #11151)', () => {
                 mode  : 'merge'
             });
 
-            // Assert chunking: each call <= 250, total records 1000, exactly 4 calls.
-            expect(upsertCalls.length).toBe(4);
-            expect(upsertCalls.reduce((a, b) => a + b, 0)).toBe(1000);
-            for (const callSize of upsertCalls) {
+            // Assert chunking on the merge-mode add() path: each call <= 250,
+            // total records 1000, exactly 4 calls.
+            expect(addCalls.length).toBe(4);
+            expect(addCalls.reduce((a, b) => a + b, 0)).toBe(1000);
+            for (const callSize of addCalls) {
+                expect(callSize).toBeLessThanOrEqual(250);
+            }
+            // Existence preflight also chunked at the same boundary.
+            expect(getCalls.length).toBe(4);
+            for (const callSize of getCalls) {
                 expect(callSize).toBeLessThanOrEqual(250);
             }
         } finally {

--- a/test/playwright/unit/ai/services/memory-core/DatabaseService.importMergeChroma.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/DatabaseService.importMergeChroma.spec.mjs
@@ -1,0 +1,290 @@
+import {setup} from '../../../../setup.mjs';
+
+const appName = 'MCImportMergeChromaTest';
+
+setup({
+    neoConfig: {
+        allowVdomUpdatesInTests: false,
+        unitTestMode           : true,
+        useDomApiRenderer      : false
+    },
+    appConfig: {
+        name             : appName,
+        isMounted        : () => true,
+        vnodeInitialising: false
+    }
+});
+
+import {test, expect}  from '@playwright/test';
+import Neo             from '../../../../../../src/Neo.mjs';
+import * as core       from '../../../../../../src/core/_export.mjs';
+import InstanceManager from '../../../../../../src/manager/Instance.mjs';
+import fs              from 'fs';
+import path            from 'path';
+
+// Serial mode: rewires singleton StorageRouter collection accessors across tests.
+test.describe.configure({mode: 'serial'});
+
+test.describe('Memory_DatabaseService — Chroma preserve-live parity for #importMemories (#11144)', () => {
+    let SDK, Memory_DatabaseService, Memory_StorageRouter;
+    let originalGetMemory, originalGetSummary, tmpDir;
+
+    /**
+     * Builds a recording fake Chroma collection used by the spec to assert that:
+     *   - merge mode preflights via `get({ids})` and only `add()`s missing-IDs
+     *   - replace mode calls `upsert()` for the full record set
+     *   - live records (in `liveIds`) survive a colliding merge import
+     */
+    function buildFakeCollection({name, liveIds = []}) {
+        const live      = new Set(liveIds);
+        const addCalls    = [];
+        const upsertCalls = [];
+
+        return {
+            name,
+            _live      : live,
+            addCalls,
+            upsertCalls,
+            get: async ({ids = [], include}) => {
+                // Existence-check shape: `get({ids, include: []})` — return live overlap.
+                const overlap = ids.filter(id => live.has(id));
+                return {ids: overlap};
+            },
+            add: async (payload) => {
+                addCalls.push(payload);
+                // Merge mode contract: `add()` rejects on duplicate ID (Chroma's
+                // insert-only primitive). Assert that here so a regression in the
+                // preflight filter would surface as a test failure.
+                for (const id of payload.ids) {
+                    if (live.has(id)) {
+                        throw new Error(`add() called with already-live id ${id} — preflight filter regression`);
+                    }
+                    live.add(id);
+                }
+            },
+            upsert: async (payload) => {
+                upsertCalls.push(payload);
+                for (const id of payload.ids) {
+                    live.add(id);
+                }
+            }
+        };
+    }
+
+    function writeJsonl(filePath, records) {
+        const stream = fs.createWriteStream(filePath);
+        for (const r of records) {
+            stream.write(JSON.stringify(r) + '\n');
+        }
+        return new Promise(resolve => stream.end(resolve));
+    }
+
+    test.beforeAll(async () => {
+        const aiConfig = (await import('../../../../../../ai/mcp/server/memory-core/config.mjs')).default;
+        if (!aiConfig.collections) aiConfig.collections = {};
+        aiConfig.collections.memory  = `test-memory-${process.pid}-${Date.now()}`;
+        aiConfig.collections.session = `test-session-${process.pid}-${Date.now()}`;
+
+        SDK                    = await import('../../../../../../ai/services.mjs');
+        Memory_DatabaseService = SDK.Memory_DatabaseService;
+        Memory_StorageRouter   = SDK.Memory_StorageRouter;
+
+        tmpDir = path.resolve(process.cwd(), 'tmp', `mc-import-merge-${process.pid}-${Date.now()}`);
+        fs.mkdirSync(tmpDir, {recursive: true});
+
+        originalGetMemory  = Memory_StorageRouter.getMemoryCollection.bind(Memory_StorageRouter);
+        originalGetSummary = Memory_StorageRouter.getSummaryCollection.bind(Memory_StorageRouter);
+    });
+
+    test.afterAll(async () => {
+        const {cleanupChromaManager} = await import('./util.mjs');
+        await cleanupChromaManager();
+
+        Memory_StorageRouter.getMemoryCollection  = originalGetMemory;
+        Memory_StorageRouter.getSummaryCollection = originalGetSummary;
+
+        if (tmpDir && fs.existsSync(tmpDir)) {
+            fs.rmSync(tmpDir, {recursive: true, force: true});
+        }
+    });
+
+    test('merge mode: ID collision preserves live record + only missing IDs get add()', async () => {
+        // Live state: mem-1 + mem-2 already exist; backup brings mem-1 (collision)
+        // + mem-3 + mem-4 (new). Expect 1 skipped, 2 inserted, 0 failed; the add()
+        // call must contain only [mem-3, mem-4] — never the colliding mem-1.
+        const memoryCollection = buildFakeCollection({name: 'fake-memories', liveIds: ['mem-1', 'mem-2']});
+        Memory_StorageRouter.getMemoryCollection  = async () => memoryCollection;
+        Memory_StorageRouter.getSummaryCollection = async () => buildFakeCollection({name: 'fake-summaries'});
+
+        const backupFile = path.join(tmpDir, `memory-backup-merge-collision-${Date.now()}.jsonl`);
+        await writeJsonl(backupFile, [
+            {id: 'mem-1', embedding: [0.1], metadata: {tag: 'BACKUP'}, document: 'backup-doc-for-mem-1'},
+            {id: 'mem-3', embedding: [0.3], metadata: {tag: 'NEW'},    document: 'new-doc-mem-3'},
+            {id: 'mem-4', embedding: [0.4], metadata: {tag: 'NEW'},    document: 'new-doc-mem-4'}
+        ]);
+
+        const result = await Memory_DatabaseService.manageDatabaseBackup({
+            action: 'import',
+            file  : backupFile,
+            mode  : 'merge'
+        });
+
+        expect(result.mode).toBe('merge');
+        expect(result.imported).toBe(2);
+        expect(result.counts.memories.inserted).toBe(2);
+        expect(result.counts.memories.skippedExisting).toBe(1);
+        expect(result.counts.memories.failed).toBe(0);
+        expect(result.counts.memoriesInserted).toBe(2);
+
+        // add() called exactly once with only the missing IDs
+        expect(memoryCollection.addCalls.length).toBe(1);
+        expect(memoryCollection.addCalls[0].ids.sort()).toEqual(['mem-3', 'mem-4']);
+
+        // upsert() never invoked in merge mode
+        expect(memoryCollection.upsertCalls.length).toBe(0);
+    });
+
+    test('merge mode: full collision = zero inserted, all skipped, add() never invoked', async () => {
+        const memoryCollection = buildFakeCollection({name: 'fake-memories', liveIds: ['mem-1', 'mem-2']});
+        Memory_StorageRouter.getMemoryCollection  = async () => memoryCollection;
+        Memory_StorageRouter.getSummaryCollection = async () => buildFakeCollection({name: 'fake-summaries'});
+
+        const backupFile = path.join(tmpDir, `memory-backup-merge-full-collide-${Date.now()}.jsonl`);
+        await writeJsonl(backupFile, [
+            {id: 'mem-1', embedding: [0.1], metadata: {tag: 'B'}, document: 'b1'},
+            {id: 'mem-2', embedding: [0.2], metadata: {tag: 'B'}, document: 'b2'}
+        ]);
+
+        const result = await Memory_DatabaseService.manageDatabaseBackup({
+            action: 'import',
+            file  : backupFile,
+            mode  : 'merge'
+        });
+
+        expect(result.counts.memories.inserted).toBe(0);
+        expect(result.counts.memories.skippedExisting).toBe(2);
+        expect(memoryCollection.addCalls.length).toBe(0);
+    });
+
+    test('merge mode: no collision = all inserted via add(), zero skipped', async () => {
+        const memoryCollection = buildFakeCollection({name: 'fake-memories', liveIds: []});
+        Memory_StorageRouter.getMemoryCollection  = async () => memoryCollection;
+        Memory_StorageRouter.getSummaryCollection = async () => buildFakeCollection({name: 'fake-summaries'});
+
+        const backupFile = path.join(tmpDir, `memory-backup-merge-no-collide-${Date.now()}.jsonl`);
+        await writeJsonl(backupFile, [
+            {id: 'fresh-1', embedding: [0.1], metadata: {tag: 'N'}, document: 'f1'},
+            {id: 'fresh-2', embedding: [0.2], metadata: {tag: 'N'}, document: 'f2'}
+        ]);
+
+        const result = await Memory_DatabaseService.manageDatabaseBackup({
+            action: 'import',
+            file  : backupFile,
+            mode  : 'merge'
+        });
+
+        expect(result.counts.memories.inserted).toBe(2);
+        expect(result.counts.memories.skippedExisting).toBe(0);
+        expect(memoryCollection.addCalls[0].ids.sort()).toEqual(['fresh-1', 'fresh-2']);
+        expect(memoryCollection.upsertCalls.length).toBe(0);
+    });
+
+    test('replace mode: upsert() called for full record set; merge-mode counters stay 0', async () => {
+        const memoryCollection = buildFakeCollection({name: 'fake-memories', liveIds: ['mem-1']});
+        Memory_StorageRouter.getMemoryCollection  = async () => memoryCollection;
+        Memory_StorageRouter.getSummaryCollection = async () => buildFakeCollection({name: 'fake-summaries'});
+
+        // truncateDatabase routes through CollectionProxy.drop() against the real
+        // production path's destructive-operation guard (#10845). The guard is
+        // covered by restore-hardening.spec.mjs and is not what this test verifies;
+        // stub it to a no-op so we exercise the post-truncate upsert branch in
+        // isolation. Restored at end of test.
+        const originalTruncate = Memory_DatabaseService.truncateDatabase.bind(Memory_DatabaseService);
+        Memory_DatabaseService.truncateDatabase = async () => ({message: 'stubbed for replace-mode upsert test'});
+
+        try {
+            const backupFile = path.join(tmpDir, `memory-backup-replace-${Date.now()}.jsonl`);
+            await writeJsonl(backupFile, [
+                {id: 'mem-1', embedding: [0.1], metadata: {tag: 'R'}, document: 'r1'},
+                {id: 'mem-2', embedding: [0.2], metadata: {tag: 'R'}, document: 'r2'}
+            ]);
+
+            const result = await Memory_DatabaseService.manageDatabaseBackup({
+                action: 'import',
+                file  : backupFile,
+                mode  : 'replace'
+            });
+
+            expect(result.mode).toBe('replace');
+            expect(memoryCollection.upsertCalls.length).toBe(1);
+            expect(memoryCollection.upsertCalls[0].ids.sort()).toEqual(['mem-1', 'mem-2']);
+            // skippedExisting stays 0 in replace mode (no preflight)
+            expect(result.counts.memories.skippedExisting).toBe(0);
+            expect(result.counts.memories.inserted).toBe(2);
+            // add() is the merge-mode primitive; never called in replace mode
+            expect(memoryCollection.addCalls.length).toBe(0);
+        } finally {
+            Memory_DatabaseService.truncateDatabase = originalTruncate;
+        }
+    });
+
+    test('merge mode: summaries follow the same preserve-live pattern', async () => {
+        const summariesCollection = buildFakeCollection({name: 'fake-summaries', liveIds: ['sum-1', 'sum-2']});
+        Memory_StorageRouter.getMemoryCollection  = async () => buildFakeCollection({name: 'fake-memories'});
+        Memory_StorageRouter.getSummaryCollection = async () => summariesCollection;
+
+        const backupFile = path.join(tmpDir, `summaries-backup-merge-${Date.now()}.jsonl`);
+        await writeJsonl(backupFile, [
+            {id: 'sum-1', embedding: [0.1], metadata: {tag: 'B'}, document: 'b1'}, // collides
+            {id: 'sum-3', embedding: [0.3], metadata: {tag: 'N'}, document: 'n3'}, // new
+            {id: 'sum-4', embedding: [0.4], metadata: {tag: 'N'}, document: 'n4'}  // new
+        ]);
+
+        const result = await Memory_DatabaseService.manageDatabaseBackup({
+            action: 'import',
+            file  : backupFile,
+            mode  : 'merge'
+        });
+
+        expect(result.counts.summaries.inserted).toBe(2);
+        expect(result.counts.summaries.skippedExisting).toBe(1);
+        expect(result.counts.summaries.failed).toBe(0);
+        // memories bucket stays untouched when only summaries-backup was imported
+        expect(result.counts.memories.inserted).toBe(0);
+        expect(result.counts.memories.skippedExisting).toBe(0);
+
+        expect(summariesCollection.addCalls.length).toBe(1);
+        expect(summariesCollection.addCalls[0].ids.sort()).toEqual(['sum-3', 'sum-4']);
+    });
+
+    test('return shape exposes structured counts for memories + summaries + backward-compat memoriesInserted', async () => {
+        const memoryCollection    = buildFakeCollection({name: 'fake-memories'});
+        const summariesCollection = buildFakeCollection({name: 'fake-summaries'});
+        Memory_StorageRouter.getMemoryCollection  = async () => memoryCollection;
+        Memory_StorageRouter.getSummaryCollection = async () => summariesCollection;
+
+        const memoryFile = path.join(tmpDir, `memory-backup-shape-${Date.now()}.jsonl`);
+        await writeJsonl(memoryFile, [
+            {id: 'shape-mem-1', embedding: [0.1], metadata: {}, document: 'd1'}
+        ]);
+
+        const result = await Memory_DatabaseService.manageDatabaseBackup({
+            action: 'import',
+            file  : memoryFile,
+            mode  : 'merge'
+        });
+
+        // Structured per-substrate breakdown
+        expect(result.counts).toBeDefined();
+        expect(result.counts.graph).toBeNull(); // no graph file in this batch
+        expect(result.counts.memories).toEqual({inserted: 1, skippedExisting: 0, failed: 0});
+        expect(result.counts.summaries).toEqual({inserted: 0, skippedExisting: 0, failed: 0});
+
+        // Backward-compat aggregate: memoriesInserted = memories.inserted + summaries.inserted
+        expect(result.counts.memoriesInserted).toBe(1);
+
+        // Top-level `imported` and `mode` preserved per #11141 contract
+        expect(result.imported).toBe(1);
+        expect(result.mode).toBe('merge');
+    });
+});


### PR DESCRIPTION
Resolves #11144

Authored by Claude Opus 4.7 (Claude Code, 1M context). Session 5572d9a5-558d-4bea-b416-e31496c289c4.

FAIR-band: over-target [14/30] — taking this lane on operator-direction. @tobiu delegated /peer-role to me for the 2026-05-24 backlog-walk marathon (~30 PRs over ~2h, latest-first). #11144 was self-assigned from prior session (2026-05-10) per @neo-gpt's #11141 peer-review recommendation.

Evidence: L2 (mocked Chroma collection + chunked add/get/upsert semantics exercised via spec; new spec covers ID-collision preserve-live, full-collision skip, no-collision insert, replace-mode upsert, summaries parity, return-shape contract) → L4 required for AC4 perf observation (real-Chroma chunked-batch wall-time vs pre-#11144 upsert path). Residual: AC4 `[L4-deferred — operator handoff needed]` — annotated on #11144 per @neo-gpt's #11921 review (2026-05-24); close-with-residual is the substrate-correct shape.

Closes the Chroma side of #11144 (follow-up to merged #11141): merge mode now preflights live IDs via chunked `collection.get({ids, include: []})` and inserts only the missing-ID subset via `collection.add()`, preserving live records on ID collision (parity with graph-side `INSERT OR IGNORE` from #11141). Replace mode keeps `collection.upsert()` post-truncate. Per-substrate truthful counters extended to memories + summaries blocks; `memoriesInserted` preserved as backward-compat aggregate.

## Contract Ledger

Authoritative ledger lives on the originating ticket: [#11144 § Contract Ledger](https://github.com/neomjs/neo/issues/11144#user-content-contract-ledger) (added 2026-05-24 per @neo-gpt's review surfacing the gap). Three surfaces documented:

1. `Memory_DatabaseService.importDatabase()` return shape — `counts` field structure change (additive; backward-compat aggregate preserved).
2. `Memory_DatabaseService.#importMemories` merge-mode primitive — `upsert` → preflight + `add()` for missing subset.
3. `Memory_DatabaseService.#importMemories` failure semantics — merge mode continues on per-chunk failure; replace mode stays fail-fast.

## Deltas from ticket (if any)

**AC4 close-with-residual annotation** added to ticket per @neo-gpt's #11921 review (2026-05-24). Real-Chroma perf observation requires a representative production backup + live cluster — agent sandbox cannot reach that. AC4 marked `[L4-deferred — operator handoff needed]` on the ticket; the chunked code path lands behind this PR and the perf observation is captured post-merge against a real bundle. This is the substrate-correct shape vs. blocking the PR on evidence the sandbox cannot produce.

**Return-shape extension** (additive): `subsystemCounts` now exposes `memories: {inserted, skippedExisting, failed}` + `summaries: {...}` while preserving `memoriesInserted` as backward-compat aggregate. Originally the ticket noted this as "deferred from #11141"; implementing here since the chunked path makes per-record outcome natural to thread.

## Test Evidence

- `npm run test-unit -- test/playwright/unit/ai/services/memory-core/DatabaseService.importMergeChroma.spec.mjs` — **6/6 PASS** (701ms). New spec covers:
  - merge mode: ID collision preserves live record + only missing IDs get `add()`
  - merge mode: full collision = zero inserted, all skipped, `add()` never invoked
  - merge mode: no collision = all inserted via `add()`, zero skipped
  - replace mode: `upsert()` called for full record set; merge-mode counters stay 0
  - merge mode: summaries follow the same preserve-live pattern
  - return shape exposes structured counts for memories + summaries + backward-compat `memoriesInserted`
- `npm run test-unit -- test/playwright/unit/ai/scripts/maintenance/restore-hardening.spec.mjs` — **3/3 PASS** (chunked-write test updated to spy `add()` for merge mode + assert chunked existence-preflight at same `CHROMA_UPSERT_CHUNK_SIZE = 250` boundary)
- Regression sweep across `DatabaseService.graphBackup.spec.mjs`, `DatabaseService.backupPath.spec.mjs`, `restore.spec.mjs`, `restore-filters.spec.mjs`, `restore-hardening.spec.mjs` — 33/33 PASS.

## Post-Merge Validation

- [ ] **AC4 perf observation (L4-deferred)** — real-environment merge-mode restore against a live Chroma cluster with a representative production backup (5000+ records). Measure wall-time vs pre-#11144 `upsert` baseline; confirm chunked preflight + add stays within the same order. Operator handoff per #11144 residual annotation.
- [ ] Real-environment verification that `add()` rejects duplicate IDs cleanly (the spec's fake collection actively rejects to catch preflight-filter regressions; need to confirm real Chroma's `add()` is the insert-only primitive as documented).
- [ ] Verify `subsystems.memories` and `subsystems.summaries` structured counts propagate through `restore.mjs subsystems` shape to operator-facing log output.

⚠️ **Commit-body close-target syntax issue (per @neo-gpt addendum 2026-05-24):** the commit body uses prose-embedded `Closes #11144 (follow-up to merged #11141).` rather than isolated-line syntax. The PR body's `Resolves #11144` (isolated line, syntax-exact) IS the primary close-target surface and will fire GitHub auto-close correctly. Force-push amend cleanup is blocked by harness policy without operator-explicit authorization (per `pull-request-workflow.md §9`). Awaiting operator decision on remediation path.

## Commits (if multi-commit)

- `832bb289f` — feat(ai-restore): Chroma preserve-live merge parity for #importMemories (#11144)

## Acceptance Criteria

- [x] `#importMemories` merge mode preflights live IDs + writes missing only (lines 471-509 of DatabaseService.mjs).
- [x] Same pattern for summaries (routed via `isMemoryBackup` heuristic; spec test validates summary collection).
- [x] Unit test: ID collision in merge mode preserves live record (does not overwrite).
- [ ] Performance: chunked batching keeps per-restore time under 2x current upsert path. **[L4-deferred — operator handoff needed]** per #11144 close-with-residual annotation (2026-05-24).
- [x] PR body cross-links #11141 (parent) + commentId 4416007918 (peer-review anchor).

## V-B-A surfaces worth reviewer attention

1. **Return-shape extension** documented in the #11144 Contract Ledger. Backward-compat preserved via aggregate field.
2. **`add()` chunked-failure behavior**: try/catch around `collection.add()` so per-chunk failure increments `failed` counter rather than fail-fast. Replace mode's `upsert()` stays fail-fast. Asymmetry intentional: merge is incremental + recoverable; replace is destructive + atomic.
3. **Existence-check ordering**: preflight `get()` across all chunks BEFORE any `add()`, accumulating `existingIds` into a Set. Set memory cost ≪ embedding payload + lets us log skipped-count up front.
4. **Real Chroma `add()` semantics**: spec's fake collection actively rejects `add()` calls with already-live IDs as a regression-detector. Real Chroma's `add()` is the insert-only primitive (vs `upsert()`); flagged in V-B-A.

## Avoided traps

- NOT touching graph-side `#importGraph` — already preserve-live per #11141.
- NOT renaming `CHROMA_UPSERT_CHUNK_SIZE` despite now applying to add+get — wider diff, no functional gain.
- NOT splitting memories vs summaries into separate private methods — inline routing via filename heuristic + per-bucket counter.
- NOT blocking PR on real-Chroma AC4 perf observation — sandbox cannot produce L4 evidence; close-with-residual is substrate-correct (per @neo-gpt's 2026-05-24 review).

Empirical anchors:
- #11141 parent ticket — graph-side preserve-live `INSERT OR IGNORE` (merged 2026-05-10)
- @neo-gpt's peer-review on #11141 — https://github.com/neomjs/neo/issues/11141#issuecomment-4416007918
- @neo-gpt's #11921 cross-family review (2026-05-24) — https://github.com/neomjs/neo/pull/11921#pullrequestreview-4353395789
- 2026-05-10 graph-wipe incident — same family of restore-primitive correctness work
