### PR TITLE
refactor(ai-services): extract chromaClientPrimitives shared module (#11111)

### DIFF
--- a/ai/services/knowledge-base/ChromaManager.mjs
+++ b/ai/services/knowledge-base/ChromaManager.mjs
@@ -3,7 +3,11 @@ import aiConfig                             from '../../mcp/server/knowledge-bas
 import logger                               from '../../mcp/server/knowledge-base/logger.mjs';
 import Base                                 from '../../../src/core/Base.mjs';
 import DatabaseLifecycleService             from './DatabaseLifecycleService.mjs';
-import {assertCanonicalCollectionDeleteAllowed} from '../../mcp/server/shared/services/DestructiveOperationGuard.mjs';
+import {
+    chromaConnect,
+    chromaDeleteCollection,
+    createSilentExecutor
+} from '../shared/vector/chromaClientPrimitives.mjs';
 
 const COLLECTION_ALREADY_EXISTS_RE = /already exists|already contains|conflict/i;
 const COLLECTION_NOT_FOUND_RE      = /does not exist|not found|not be found|could not be found|404/i;
@@ -68,19 +72,12 @@ class ChromaManager extends Base {
     }
 
     /**
-     * Establishes connection to ChromaDB.
+     * Establishes connection to ChromaDB via the shared `chromaConnect` primitive (#11111).
      * @returns {Promise<boolean>} True if connected, false otherwise
      */
     async connect() {
-        try {
-            await this.client.heartbeat();
-            this.connected = true;
-            return true;
-        } catch (e) {
-            this.connected = false;
-            logger.debug('[ChromaManager] ChromaDB not accessible:', e.message);
-            return false;
-        }
+        this.connected = await chromaConnect({client: this.client, logger});
+        return this.connected
     }
 
     /**
@@ -97,34 +94,14 @@ class ChromaManager extends Base {
         };
     }
 
-    #chromaLock = Promise.resolve();
-
     /**
-     * Executes a ChromaDB client function sequentially, ensuring console.warn
-     * is safely suppressed without overlapping race conditions.
-     * @param {Function} fn Async function to execute
-     * @returns {Promise<any>}
+     * Per-instance silent-execution function from the shared primitive (#11111).
+     * Each consumer gets its own isolated sequential lock. KB uses blanket suppression
+     * (no `filter` passed at call sites); MC's per-message filter is unaffected.
+     * @member {Function} #executeSilently
+     * @private
      */
-    async #executeSilently(fn) {
-        const nextLock = (async () => {
-            // Await the completion of the previous silent execution
-            await this.#chromaLock;
-
-            const originalWarn = console.warn;
-            console.warn = () => {}; // Suppress unwanted warnings from ChromaDB client
-
-            try {
-                return await fn();
-            } finally {
-                // Guaranteed sequential restore
-                console.warn = originalWarn;
-            }
-        })();
-
-        // Prevent chain crashing if an internal error occurs
-        this.#chromaLock = nextLock.catch(() => {});
-        return nextLock;
-    }
+    #executeSilently = createSilentExecutor()
 
     /**
      * @returns {Promise<Object>}
@@ -279,10 +256,10 @@ class ChromaManager extends Base {
     }
 
     /**
-     * Guarded delete-collection wrapper — peer of the Memory Core counterpart. Refuses
-     * canonical production collection names unless `UNIT_TEST_MODE=true` or a valid
-     * production `confirmation` token is supplied. See the Memory Core ChromaManager's
-     * `deleteCollection` JSDoc for the empirical anchor (2026-05-17 wipe) and rationale.
+     * Guarded delete-collection wrapper. Delegates to the shared `chromaDeleteCollection`
+     * primitive (#11111) which routes through `assertCanonicalCollectionDeleteAllowed` with
+     * `subsystem: 'knowledge-base'`. Refuses canonical production collection names unless
+     * `UNIT_TEST_MODE=true` or a valid production `confirmation` token is supplied.
      *
      * All Knowledge Base callers (`DatabaseService.truncateDatabase`, `VectorService.deleteCollection`,
      * future restore wrappers) MUST route through this method instead of bare
@@ -297,8 +274,7 @@ class ChromaManager extends Base {
      * @see https://github.com/neomjs/neo/issues/11652
      */
     async deleteCollection({name, confirmation} = {}) {
-        assertCanonicalCollectionDeleteAllowed({name, subsystem: 'knowledge-base', confirmation});
-        return await this.client.deleteCollection({name});
+        return chromaDeleteCollection({client: this.client, name, subsystem: 'knowledge-base', confirmation})
     }
 }
 

--- a/ai/services/memory-core/managers/ChromaManager.mjs
+++ b/ai/services/memory-core/managers/ChromaManager.mjs
@@ -3,7 +3,23 @@ import aiConfig                             from '../../../mcp/server/memory-cor
 import logger                               from '../../../mcp/server/memory-core/logger.mjs';
 import AbstractVectorManager                from './AbstractVectorManager.mjs';
 import ChromaLifecycleService               from '../lifecycle/ChromaLifecycleService.mjs';
-import {assertCanonicalCollectionDeleteAllowed} from '../../../mcp/server/shared/services/DestructiveOperationGuard.mjs';
+import {
+    chromaConnect,
+    chromaDeleteCollection,
+    createSilentExecutor
+} from '../../shared/vector/chromaClientPrimitives.mjs';
+
+/**
+ * Predicate suppression filter for MC: the four Chroma library messages that surface noisily
+ * during routine `getOrCreateCollection` calls with the dynamic embedding function. Everything
+ * else passes through to the real `console.warn`. Pre-#11111 this was inlined inside the
+ * ChromaManager's `#executeSilently` method; now passed to the shared primitive.
+ */
+const MC_WARN_FILTER = msg =>
+    msg.includes('No embedding function configuration found') ||
+    msg.includes('Could not deserialize the collection metadata') ||
+    msg.includes('dummy_embedding_function') ||
+    msg.includes('dynamic_text_embedding_service');
 
 /**
  * @summary Simple manager around the Chroma client that lazily caches frequently used collections.
@@ -76,19 +92,12 @@ class ChromaManager extends AbstractVectorManager {
     }
 
     /**
-     * Establishes connection to ChromaDB.
+     * Establishes connection to ChromaDB via the shared `chromaConnect` primitive (#11111).
      * @returns {Promise<boolean>} True if connected, false otherwise
      */
     async connect() {
-        try {
-            await this.client.heartbeat();
-            this.connected = true;
-            return true;
-        } catch (e) {
-            this.connected = false;
-            logger.debug('[ChromaManager] ChromaDB not accessible:', e.message);
-            return false;
-        }
+        this.connected = await chromaConnect({client: this.client, logger});
+        return this.connected
     }
 
     /**
@@ -107,44 +116,15 @@ class ChromaManager extends AbstractVectorManager {
         };
     }
 
-    #chromaLock = Promise.resolve();
-
     /**
-     * Executes a ChromaDB client function sequentially, ensuring console.warn
-     * is safely suppressed without overlapping race conditions.
-     * @param {Function} fn Async function to execute
-     * @returns {Promise<any>}
+     * Per-instance silent-execution function from the shared primitive (#11111).
+     * Each consumer gets its own isolated sequential lock. MC's call sites pass
+     * `{filter: MC_WARN_FILTER}` to suppress only the four specific Chroma library
+     * messages while letting everything else through.
+     * @member {Function} #executeSilently
+     * @private
      */
-    async #executeSilently(fn) {
-        const nextLock = (async () => {
-            // Await the completion of the previous silent execution
-            await this.#chromaLock;
-
-            const originalWarn = console.warn;
-            console.warn       = (...args) => {
-                const msg = args.join(' ');
-                if (msg.includes('No embedding function configuration found') ||
-                    msg.includes('Could not deserialize the collection metadata') ||
-                    msg.includes('dummy_embedding_function') ||
-                    msg.includes('dynamic_text_embedding_service')) {
-                    return;
-                }
-                originalWarn.apply(console, args);
-            };
-
-            try {
-                return await fn();
-            } finally {
-                // Guaranteed sequential restore
-                console.warn = originalWarn;
-            }
-        })();
-
-        // Prevent chain crashing if an internal error occurs
-        this.#chromaLock = nextLock.catch(() => {
-        });
-        return nextLock;
-    }
+    #executeSilently = createSilentExecutor()
 
     /**
      * Instantiates an IEmbeddingFunction wrapper for the chromadb client.
@@ -178,7 +158,7 @@ class ChromaManager extends AbstractVectorManager {
                     name             : collectionName,
                     embeddingFunction: this.#createEmbeddingFunction()
                 });
-            });
+            }, {filter: MC_WARN_FILTER});
         }
 
         this.memoryCollection = await this._memoryCollectionPromise;
@@ -196,7 +176,7 @@ class ChromaManager extends AbstractVectorManager {
                     name             : collectionName,
                     embeddingFunction: this.#createEmbeddingFunction()
                 });
-            });
+            }, {filter: MC_WARN_FILTER});
         }
 
         this.summaryCollection = await this._summaryCollectionPromise;
@@ -214,7 +194,7 @@ class ChromaManager extends AbstractVectorManager {
                     name             : collectionName,
                     embeddingFunction: this.#createEmbeddingFunction()
                 });
-            });
+            }, {filter: MC_WARN_FILTER});
         }
 
         this.graphCollection = await this._graphCollectionPromise;
@@ -242,8 +222,7 @@ class ChromaManager extends AbstractVectorManager {
      * @see https://github.com/neomjs/neo/issues/11652
      */
     async deleteCollection({name, confirmation} = {}) {
-        assertCanonicalCollectionDeleteAllowed({name, subsystem: 'memory-core', confirmation});
-        return await this.client.deleteCollection({name});
+        return chromaDeleteCollection({client: this.client, name, subsystem: 'memory-core', confirmation})
     }
 }
 

--- a/ai/services/shared/vector/chromaClientPrimitives.mjs
+++ b/ai/services/shared/vector/chromaClientPrimitives.mjs
@@ -1,0 +1,161 @@
+import {assertCanonicalCollectionDeleteAllowed} from '../../../mcp/server/shared/services/DestructiveOperationGuard.mjs';
+
+/**
+ * @summary Stateless helpers for the Chroma-client connection lifecycle, shared between the
+ * Knowledge Base ChromaManager and Memory Core ChromaManager (#11111).
+ *
+ * Each per-subsystem ChromaManager remains the owner of its `this.client` (the chromadb
+ * library's `ChromaClient` instance) so tests that mock-replace `ChromaManager.client =
+ * fakeClient` continue to work without modification. This module exports plain functions
+ * that read the client at call-time from the caller's argument list.
+ *
+ * **What this module owns (the dedup-eligible shared layer per #11111):**
+ *
+ * 1. **`chromaConnect({client, logger})`** — heartbeat-based readiness check. Returns a
+ *    boolean (true on success, false on failure). Non-throwing — the caller decides how to
+ *    react. Replaces ~10 lines of duplicated try/catch/heartbeat code in each ChromaManager.
+ *
+ * 2. **`createSilentExecutor()`** — returns a per-instance silent-execution function with
+ *    its own Promise-based sequential lock. Each ChromaManager instantiates one of these
+ *    once (typically as a private field) so its `executeSilently` calls don't race each
+ *    other's `console.warn` restore. Two filter shapes accepted:
+ *      - `{filter: null}` (default) — blanket suppression of all `console.warn` for the
+ *        duration of `fn`. Matches pre-#11111 KB behavior.
+ *      - `{filter: (msg) => boolean}` — predicate suppression; only messages whose joined-args
+ *        string returns true are suppressed. Matches pre-#11111 MC behavior which filters
+ *        for four specific Chroma library warnings.
+ *
+ * 3. **`chromaDeleteCollection({client, name, subsystem, confirmation})`** — guarded delete
+ *    wrapper. Routes through `assertCanonicalCollectionDeleteAllowed` with subsystem-scoped
+ *    canonical-name refusal. The substrate-level invariant (#11652) fires regardless of
+ *    harness or config state.
+ *
+ * **What this module does NOT own (per V-B-A on the ticket's prescription):**
+ *
+ * - `getOrCreateCollection` / `getCollection` / `createCollection` — collection-resolution
+ *   semantics differ substantially between KB (shadow-swap-aware resolver, see
+ *   `Neo.ai.services.knowledge-base.ChromaManager#resolveKnowledgeBaseCollection`) and MC
+ *   (plain `getOrCreateCollection` for three named collections). Sharing would either flatten
+ *   KB's swap safety or balloon the primitive with KB-specific phase awareness MC doesn't need.
+ * - `ensureDummyEmbedding` — KB uses `aiConfig.dummyEmbeddingFunction` (static); MC instantiates
+ *   a `TextEmbeddingService`-backed dynamic function per-call. Neither is shareable at the
+ *   client-wrapper layer.
+ * - `disconnect()` — neither consumer currently has a disconnect path; the chromadb client is
+ *   GC-managed. Speculative substrate per `feedback_truth_in_code`.
+ *
+ * Per-server collection-abstraction semantics (`getMemoryCollection`, `getSummaryCollection`,
+ * `getGraphCollection` for MC; `getKnowledgeBaseCollection` + shadow-swap resolution for KB)
+ * stay in the per-subsystem ChromaManager files. `AbstractVectorManager` (MC's multi-vector-engine
+ * abstraction) is MC-specific by design and is NOT lifted into this shared module.
+ *
+ * **Why functional helpers instead of a Neo class:**
+ *
+ * The ticket prescribed a `class ChromaClient extends Base` shape, but V-B-A on the actual
+ * call sites surfaced two constraints:
+ *   1. Tests heavily mock-replace `ChromaManager.client = fakeClient` (>14 occurrences in
+ *      `ChromaManager.spec.mjs` alone). A Neo-class composition with `this.chromaPrimitive.client`
+ *      would either break those tests or require complex pass-through getters with setter
+ *      pairs to preserve the test pattern.
+ *   2. The shared logic is stateless (apart from the silent-execution lock, which is naturally
+ *      per-instance via the factory). A Neo class for stateless logic is idiom-noise.
+ *
+ * Functional helpers preserve the test mocking pattern, match Neo's "Neo class for state /
+ * plain module for stateless utility" idiom, and produce a smaller, easier-to-review diff.
+ *
+ * @module ai/services/shared/vector/chromaClientPrimitives
+ * @see #11111
+ */
+
+/**
+ * Heartbeat-based readiness check. Sets nothing — caller is responsible for storing the
+ * boolean result on its instance state if needed.
+ *
+ * @param {Object} options
+ * @param {Object} options.client      The chromadb library client (with `.heartbeat()`).
+ * @param {Object} [options.logger]    Optional logger with `.debug()`; falls back to `console.debug`.
+ * @returns {Promise<Boolean>} True if heartbeat succeeded, false otherwise. Non-throwing.
+ */
+export async function chromaConnect({client, logger} = {}) {
+    try {
+        await client.heartbeat();
+        return true
+    } catch (e) {
+        (logger || console).debug?.('[ChromaClient] ChromaDB not accessible:', e.message);
+        return false
+    }
+}
+
+/**
+ * Returns a per-instance silent-execution function with its own sequential lock.
+ *
+ * The lock is closed over the returned function so each ChromaManager instance gets its
+ * own isolated suppression chain. Concurrent calls to the returned function serialize
+ * (each waits for the previous to fully restore `console.warn` before starting its own
+ * suppression window), preventing races where one call's `restore` overwrites another's
+ * `suppress`.
+ *
+ * @returns {Function} `executeSilently(fn, {filter}={})` — see inline doc.
+ */
+export function createSilentExecutor() {
+    let chromaLock = Promise.resolve();
+
+    /**
+     * Executes `fn` with `console.warn` suppressed.
+     *
+     * @param {Function} fn                            Async function to execute under suppression.
+     * @param {Object}  [options]
+     * @param {Function|null} [options.filter=null]    Predicate. If null, blanket-suppresses ALL warns.
+     *   If a function, suppresses only warns whose joined-args string returns true from `filter(msg)`;
+     *   everything else passes through to the original `console.warn`.
+     * @returns {Promise<*>} Whatever `fn` returns.
+     */
+    return async function executeSilently(fn, {filter = null} = {}) {
+        const nextLock = (async () => {
+            await chromaLock;
+
+            const originalWarn = console.warn;
+
+            if (filter) {
+                console.warn = (...args) => {
+                    const msg = args.join(' ');
+                    if (filter(msg)) return;
+                    originalWarn.apply(console, args)
+                }
+            } else {
+                console.warn = () => {}
+            }
+
+            try {
+                return await fn()
+            } finally {
+                console.warn = originalWarn
+            }
+        })();
+
+        chromaLock = nextLock.catch(() => {});
+        return nextLock
+    }
+}
+
+/**
+ * Guarded delete-collection wrapper. Refuses canonical production collection names unless
+ * `UNIT_TEST_MODE=true` or a valid production `confirmation` token is supplied.
+ *
+ * Empirical anchor: 2026-05-17 wipe where `npx playwright` bypassed
+ * `playwright.config.unit.mjs` (`UNIT_TEST_MODE` absent) → `aiConfig.collections.*` returned
+ * canonical names → a destructive cleanup helper dropped the live collections. The
+ * substrate-level guard fires regardless of harness or config state.
+ *
+ * @param {Object}  options
+ * @param {Object}  options.client          The chromadb library client (with `.deleteCollection`).
+ * @param {String}  options.name            Collection name to delete.
+ * @param {String}  options.subsystem       'knowledge-base' or 'memory-core' — scopes the canonical-name set.
+ * @param {String} [options.confirmation]   Production-recovery token; equals `CONFIRM_PRODUCTION_DESTRUCTIVE_AI_SUBSTRATE` for bypass.
+ * @returns {Promise<*>} Forwarded chromadb-client response.
+ * @throws {CanonicalCollectionGuardError} When `name` is canonical and neither bypass applies.
+ * @see https://github.com/neomjs/neo/issues/11652
+ */
+export async function chromaDeleteCollection({client, name, subsystem, confirmation} = {}) {
+    assertCanonicalCollectionDeleteAllowed({name, subsystem, confirmation});
+    return await client.deleteCollection({name})
+}

--- a/learn/benefits/ArchitectureOverview.md
+++ b/learn/benefits/ArchitectureOverview.md
@@ -379,6 +379,7 @@ Post-M6 ([#10986](https://github.com/neomjs/neo/issues/10986)) the per-MCP-serve
 | `ai/services/memory-core/` | Episodic memory services (post-M6 SDK location) | `MemoryService`, `SessionService`, `GraphService`, `MailboxService` | [ADR 0001](../agentos/decisions/0001-cross-process-cache-coherence.md), [ADR 0002](../agentos/decisions/0002-phase3-wake-substrate-standards-alignment.md) |
 | `ai/services/github-workflow/` | Issue/PR management services (post-M6 SDK location) | `IssueService`, `SyncService`, `LabelService` | — |
 | `ai/services/neural-link/` | Live app bridge services (post-M6 SDK location) | `ConnectionService`, `RecorderService` | — |
+| `ai/services/shared/vector/` | Cross-server vector-engine primitives consumed by per-server ChromaManager classes (KB + MC); functional helpers, not Neo classes | `chromaClientPrimitives.mjs` (`chromaConnect`, `createSilentExecutor`, `chromaDeleteCollection`) | — |
 | `ai/scripts/` | One-shot operator scripts + thin daemon boot wrappers | `bridge-daemon.mjs`, `orchestrator-daemon.mjs` | [ADR 0002](../agentos/decisions/0002-phase3-wake-substrate-standards-alignment.md) |
 | `ai/daemons/` | Long-running daemon classes | `Orchestrator`, `DreamService`, `SwarmHeartbeatService` | [ADR 0002](../agentos/decisions/0002-phase3-wake-substrate-standards-alignment.md) |
 | `ai/graph/` | Native Edge Graph (SQLite-backed knowledge graph) | `Database`, `Store`, `NodeModel` | [ADR 0001](../agentos/decisions/0001-cross-process-cache-coherence.md), [ADR 0015](../agentos/decisions/0015-graph-store-backend-posture.md) |


### PR DESCRIPTION
Resolves #11111

Authored by Claude Opus 4.7 (Claude Code, 1M context). Session 5572d9a5-558d-4bea-b416-e31496c289c4.

FAIR-band: over-target [14/30] — operator-direction (@tobiu delegated /peer-role for 2026-05-24 backlog-walk marathon).

Evidence: L2 (unit test pass on existing ChromaManager.spec.mjs + DestructiveOperationGuard.spec.mjs + MC tenant-isolation specs; behavior-preservation via composition with `this.client` field unchanged on both ChromaManager singletons) → L3 nominally required (AC6 boot-time smoke test of real KB + MC MCP servers against live Chroma). Residual: AC6 boot-smoke deferred to post-merge real-environment validation [#11111].

M6 retrospective dedup. Extracts the Chroma-client-wrapping primitives shared between KB + MC ChromaManager into a functional helper module. Per-server collection abstractions (`AbstractVectorManager`, shadow-swap resolution, embedding-function instantiation) stay per-server — that's per-server-specific by design.

## Deltas from ticket (if any)

**V-B-A correction on the ticket's prescription:**

1. **Functional helpers, not a Neo class.** Tests heavily mock-replace `ChromaManager.client = fakeClient` (>14 occurrences in `ChromaManager.spec.mjs` alone). A Neo-class composition would break those tests. The shared logic is stateless apart from a per-instance lock (factory-based). Functional helpers preserve test mocking + match Neo's idiom (Neo class for state, plain module for stateless utility).
2. **`getOrCreateCollection` / `ensureDummyEmbedding` / `disconnect` are NOT shareable.** Collection-resolution differs substantially (KB shadow-swap-aware; MC plain `getOrCreate` for three collections). Embedding-function setup differs (KB static config; MC dynamic TextEmbeddingService). `disconnect` is speculative substrate per `feedback_truth_in_code`.

Actual dedup-eligible surface extracted:
- `chromaConnect({client, logger})` — heartbeat-based readiness
- `createSilentExecutor()` — factory returning per-instance silent-execution function with sequential lock + configurable filter
- `chromaDeleteCollection({client, name, subsystem, confirmation})` — guarded delete

**Ticket count delta:** the ticket described MC as "two-collection abstraction (memory + summary)"; reality is **three collections** (memory + summary + graph via `getGraphCollection`). Doesn't change the design — three or two collections both stay in MC's file.

## Test Evidence

- `npm run test-unit -- test/playwright/unit/ai/services/knowledge-base/ChromaManager.spec.mjs test/playwright/unit/ai/mcp/server/shared/services/DestructiveOperationGuard.spec.mjs` — **20/20 PASS** (793ms). Covers `connect()` success/fail, `getKnowledgeBaseCollection` creation + caching, shadow-swap refusal, `invalidateCache`, `checkConnectivity`, all `DestructiveOperationGuard` paths including KB + MC subsystem routing.
- `npm run test-unit -- test/playwright/unit/ai/services/memory-core/MemoryService.TenantIsolation.spec.mjs test/playwright/unit/ai/services/memory-core/SummaryService.TenantIsolation.spec.mjs` — **27/27 PASS** (771ms). Exercises MC ChromaManager indirectly via tenant-scoped collection access.

## Post-Merge Validation

- [ ] (AC6) Boot-time smoke test: start both KB and MC MCP servers against live Chroma; verify `heartbeat` + `getOrCreateCollection` + (KB) shadow-swap resolution + (MC) memory/summary/graph collection access all work without surfacing Chroma library warnings (the silent-execution filter behavior).
- [ ] Real-Chroma exercise of `deleteCollection({name: 'neo-knowledge-base'})` (with `confirmation` token + `UNIT_TEST_MODE=true` bypass) to verify the subsystem-scoped guard fires correctly through the shared primitive.

## Commits (if multi-commit)

- `0dcd9ab08` — refactor(ai-services): extract chromaClientPrimitives shared module (#11111)
- `1627c3154` — docs(structural): add ai/services/shared/vector/ inventory row (#11111) [closes #11928 RA1: structural map-maintenance gap]

## Structural Pre-Flight / Map-Maintenance Evidence

Per @neo-gpt #11928 RA: `structural-pre-flight §2.4` requires Structural Inventory row for new `.mjs` files in previously-unlisted directories. `ai/services/shared/vector/chromaClientPrimitives.mjs` introduces the new `ai/services/shared/vector/` namespace.

**Addressed in commit `1627c3154`** (`docs(structural): add ai/services/shared/vector/ inventory row`): adds row to `learn/benefits/ArchitectureOverview.md` Structural Inventory between `ai/services/neural-link/` and `ai/scripts/`:

```
| `ai/services/shared/vector/` | Cross-server vector-engine primitives consumed by per-server ChromaManager classes (KB + MC); functional helpers, not Neo classes | `chromaClientPrimitives.mjs` (`chromaConnect`, `createSilentExecutor`, `chromaDeleteCollection`) | — |
```

The `vector/` subnamespace prepares for future SQLite-vector / other-vector primitives (`AbstractVectorManager` already exists at `ai/services/memory-core/managers/` but is MC-specific by design per #11111 V-B-A).

## Acceptance Criteria

- [x] **(AC1)** `ai/services/shared/vector/chromaClientPrimitives.mjs` created with extracted Chroma-client-wrapping logic + Anchor & Echo JSDoc.
- [x] **(AC2)** KB ChromaManager refactored to consume shared primitive; preserves single-collection abstraction + shadow-swap resolver.
- [x] **(AC3)** MC ChromaManager refactored to consume shared primitive; preserves `AbstractVectorManager` extension + multi-collection abstraction.
- [x] **(AC4)** All existing tests pass (20/20 KB ChromaManager + DestructiveOperationGuard; 27/27 MC tenant-isolation).
- [x] **(AC5)** Net line-count reduction across the 2 ChromaManager files (**-45 net lines**: KB -25, MC -20).
- [ ] **(AC6)** No behavior change in vector-collection access paths — deferred to post-merge real-environment smoke test (see Post-Merge Validation).

## Avoided traps

- NOT lifting `AbstractVectorManager` up — MC-specific by design.
- NOT forcing KB to extend `AbstractVectorManager` — would require implementing `getSummaryCollection()` KB doesn't need.
- NOT class-shaped shared primitive — test mocking + Neo idiom both push toward functional helpers.
- NOT extracting collection-resolution methods — shadow-swap-aware vs plain `getOrCreate` are per-server semantics, not shareable.

## Empirical anchors

- @tobiu's M6 4-item retrospective (2026-05-10): *"next item: 2 chroma service(s) [multiple files]. moved to the sdk, a lot of no longer needed duplication."*
- M6 epic #10986 (closed; mechanical SDK-relocation that this PR dedups behind)
- `AbstractVectorManager.mjs:13` — `@class Neo.ai.services.memory-core.managers.AbstractVectorManager` (namespace empirical anchor confirming MC-specificity)
