### PR TITLE
chore(ai): clean kb service source comments (#11923)

### DIFF
--- a/ai/services/knowledge-base/DatabaseService.mjs
+++ b/ai/services/knowledge-base/DatabaseService.mjs
@@ -3,9 +3,9 @@ import Base                      from '../../../src/core/Base.mjs';
 import ChromaManager             from './ChromaManager.mjs';
 import DestructiveOperationGuard from '../../mcp/server/shared/services/DestructiveOperationGuard.mjs';
 import VectorService             from './VectorService.mjs';
-// Phase 0/1B (#11658): SourceRegistry replaces the hardcoded source-list. Importing
-// `./source/_export.mjs` triggers auto-registration of Neo's default Source classes when
-// `aiConfig.useDefaultSources !== false`, plus declarative `aiConfig.customSources` entries.
+// SourceRegistry owns KB source discovery. Importing `./source/_export.mjs` triggers
+// auto-registration of Neo's default Source classes when `aiConfig.useDefaultSources !== false`,
+// plus declarative `aiConfig.customSources` entries.
 import SourceRegistry            from './source/_export.mjs';
 import crypto                    from 'crypto';
 import dotenv                    from 'dotenv';
@@ -42,13 +42,12 @@ dotenv.config({
  * 4.  **Backup Surface:** Exposes `manageDatabaseBackup({action: 'export'})` as a peer to
  *     `Memory_DatabaseService.manageDatabaseBackup`, reached via the `ai/services.mjs` SDK
  *     boundary. Deliberately NOT registered as an MCP tool in `toolService.mjs` — the
- *     `npm run ai:backup` script-over-tool path protects the ~80-tool MCP budget (see
- *     #9903 precedent, #10132 for retirement rationale). `makeSafe` no-match passthrough
- *     forwards raw args through the SDK when no openapi operation is registered.
+ *     `npm run ai:backup` script-over-tool path protects the MCP tool budget. `makeSafe`
+ *     no-match passthrough forwards raw args through the SDK when no openapi operation is
+ *     registered.
  *     Non-destructive — captures the current ChromaDB collection state as JSONL for
  *     consumption by the canonical backup orchestrator (`ai/scripts/maintenance/backup.mjs`),
- *     without triggering sync, re-embedding, or compaction. See #10129 for the
- *     atomic-bundle substrate design.
+ *     without triggering sync, re-embedding, or compaction.
  *
  * @class Neo.ai.services.knowledge-base.DatabaseService
  * @extends Neo.core.Base
@@ -101,7 +100,7 @@ class DatabaseService extends Base {
      * backup orchestrator (`ai/scripts/maintenance/backup.mjs`) to populate the `kb/` subfolder
      * of an atomic timestamped bundle, or invoked standalone for ad-hoc KB snapshots.
      * Non-destructive: reads the current collection state without triggering sync, re-embed,
-     * or compaction. See #10129 for bundle layout.
+     * or compaction.
      *
      * @param {Object}  options
      * @param {String} [options.backupPath=aiConfig.backupPath] Directory for the JSONL artifact.
@@ -124,8 +123,8 @@ class DatabaseService extends Base {
     /**
      * Helper method to stream a ChromaDB collection into a timestamped JSONL artifact.
      * Mirror of `Memory_DatabaseService#exportCollection` — duplicated deliberately to keep
-     * each MCP service's backup logic locally discoverable (see #10129 Phase 3: peer scripts,
-     * not delegation). Pagination cap + surgical per-id rescue mode make this robust against
+     * each service's backup logic locally discoverable instead of delegating across
+     * subsystems. Pagination cap + surgical per-id rescue mode make this robust against
      * partially corrupted HNSW segments.
      *
      * @param {Object} collection The ChromaDB collection to export.
@@ -213,15 +212,14 @@ class DatabaseService extends Base {
      * @summary Dispatcher for knowledge-base backup operations — peer of `Memory_DatabaseService.manageDatabaseBackup`.
      *
      * Reached exclusively via the `ai/services.mjs` SDK — deliberately NOT registered as an
-     * MCP tool in `toolService.mjs` serviceMapping (script-over-tool per #9903 precedent, to
-     * protect the ~80-tool MCP budget against the 100-tool harness cap; see #10132 for the
-     * full retirement rationale). `makeSafe` no-match passthrough forwards raw args through
-     * when no matching openapi operation is found, so `backup.mjs` can invoke this dispatcher
-     * with `{action, backupPath}` without a Zod schema. The manual throw below is the actual
+     * MCP tool in `toolService.mjs` serviceMapping to protect the MCP tool budget against
+     * harness caps. `makeSafe` no-match passthrough forwards raw args through when no
+     * matching openapi operation is found, so `backup.mjs` can invoke this dispatcher with
+     * `{action, backupPath}` without a Zod schema. The manual throw below is the actual
      * rejection path for invalid actions.
      *
      * Supports `action: 'export'`, `'import'`, and `'truncate'`. Import + truncate are the
-     * AC-B (#10871) restore-tooling counterparts to `'export'`, peer-symmetric with
+     * restore-tooling counterparts to `'export'`, peer-symmetric with
      * `Memory_DatabaseService.manageDatabaseBackup`.
      *
      * @param {Object}  options
@@ -253,7 +251,7 @@ class DatabaseService extends Base {
      * cost-free.
      *
      * Peer-symmetric counterpart of `exportDatabase`. Called by the canonical restore
-     * orchestrator (`ai/scripts/maintenance/restore.mjs`, #10871 AC-B).
+     * orchestrator (`ai/scripts/maintenance/restore.mjs`).
      *
      * @param {Object}        options
      * @param {String}        options.file               Absolute path to a JSONL file OR a directory containing `.jsonl` files.
@@ -321,7 +319,7 @@ class DatabaseService extends Base {
                     continue;
                 }
 
-                // Per #11653: KB chunks store content in `metadata.content`, not in Chroma's
+                // KB chunks store content in `metadata.content`, not in Chroma's
                 // primary `document` slot — so 100% of KB backup records carry `document: null`.
                 // Chroma's `collection.upsert` rejects null entries in the `documents` array
                 // with "Expected each document to be a string, but got object". Omit the
@@ -399,7 +397,7 @@ class DatabaseService extends Base {
                 confirmation
             });
 
-            // Route through ChromaManager.deleteCollection (#11652 substrate-level guard).
+            // Route through ChromaManager.deleteCollection so the canonical-name guard applies.
             // The path-target guard above already passed `assertDestructiveTargetAllowed`;
             // forward the operator confirmation so the canonical-name guard accepts it.
             await ChromaManager.deleteCollection({name: collectionName, confirmation});
@@ -425,7 +423,7 @@ class DatabaseService extends Base {
      * @param {String}        params.action       'sync', 'create', 'embed', or 'delete'
      * @param {Boolean}      [params.viaMcp]      True when dispatched from the MCP toolService
      *                                            wrapper; threaded through to `embed()` to enable
-     *                                            the work-volume gate (#10572). CLI callers
+     *                                            the work-volume gate. CLI callers
      *                                            omit this and bypass the gate.
      * @param {String}       [params.staleStrategy] Optional VectorService stale strategy.
      * @param {String|Object} [params.confirmation] Explicit production confirmation token for delete.
@@ -469,13 +467,12 @@ class DatabaseService extends Base {
         const writeStream = fs.createWriteStream(outputPath);
         let totalChunks   = 0;
 
-        // Phase 0/1B (#11658): sources discovered via SourceRegistry instead of a hardcoded
-        // array. Default Neo sources auto-register at import-time via `./source/_export.mjs`
-        // unless `aiConfig.useDefaultSources === false`; tenant-supplied custom sources
-        // register either declaratively via `aiConfig.customSources` or programmatically
-        // via `SourceRegistry.registerSource(...)`. Insertion order is preserved — the
-        // 10 default Neo sources appear in the same order as the pre-#11658 hardcoded
-        // array, so byte-equivalence of the generated JSONL is preserved.
+        // Sources are discovered via SourceRegistry instead of a hardcoded array. Default
+        // Neo sources auto-register at import-time via `./source/_export.mjs` unless
+        // `aiConfig.useDefaultSources === false`; tenant-supplied custom sources register
+        // either declaratively via `aiConfig.customSources` or programmatically via
+        // `SourceRegistry.registerSource(...)`. Insertion order is preserved for
+        // byte-equivalent generated JSONL output.
         const sources      = SourceRegistry.getSources();
         const createHashFn = this.createContentHash.bind(this);
 
@@ -512,7 +509,7 @@ class DatabaseService extends Base {
      * Delegates to VectorService.
      * @param {Object}  [opts]
      * @param {Boolean} [opts.viaMcp=false] True when invoked via MCP tool dispatch;
-     *                                      threaded to VectorService.embed for #10572's
+     *                                      threaded to VectorService.embed for the
      *                                      work-volume gate.
      * @param {String}  [opts.staleStrategy] Explicit stale-data handling strategy.
      * @returns {Promise<object>} A promise that resolves to a success message, OR a
@@ -565,7 +562,7 @@ class DatabaseService extends Base {
      * This provides a simple, single-command way to update the knowledge base from scratch.
      * @param {Object}  [opts]
      * @param {Boolean} [opts.viaMcp=false] True when invoked via MCP tool dispatch;
-     *                                      threaded to embed() for #10572's work-volume gate.
+     *                                      threaded to embed() for the work-volume gate.
      * @param {String}  [opts.staleStrategy] Explicit stale-data handling strategy.
      * @returns {Promise<object>} A promise that resolves to the final success message from the embedding step.
      */

--- a/ai/services/knowledge-base/KnowledgeBaseIngestionService.mjs
+++ b/ai/services/knowledge-base/KnowledgeBaseIngestionService.mjs
@@ -23,10 +23,10 @@ const __dirname  = path.dirname(__filename);
 const PARSED_CHUNK_SCHEMA_PATH = path.join(__dirname, 'parser/parsed-chunk-v1.schema.json');
 
 /**
- * @summary Orchestrates Phase 2 Knowledge Base ingestion pushes.
+ * @summary Orchestrates tenant-aware Knowledge Base ingestion pushes.
  *
  * `KnowledgeBaseIngestionService` is the service-layer substrate consumed by the
- * Phase 2 MCP and bulk facades. It validates the caller tenant boundary, accepts
+ * MCP and bulk ingestion facades. It validates the caller tenant boundary, accepts
  * client-side parsed `parsed-chunk-v1` records or server-side raw file payloads,
  * rejects restore-only embedding records, applies deletion signaling, and delegates
  * embedding/upsert work to {@link Neo.ai.services.knowledge-base.VectorService}.
@@ -39,7 +39,6 @@ const PARSED_CHUNK_SCHEMA_PATH = path.join(__dirname, 'parser/parsed-chunk-v1.sc
  * @class Neo.ai.services.knowledge-base.KnowledgeBaseIngestionService
  * @extends Neo.core.Base
  * @singleton
- * @see https://github.com/neomjs/neo/issues/11633
  */
 class KnowledgeBaseIngestionService extends Base {
     static config = {
@@ -60,7 +59,7 @@ class KnowledgeBaseIngestionService extends Base {
         chromaManager: ChromaManager,
         /**
          * @member {Object} graphService=GraphService
-         * @summary Native Edge Graph service backing the #11637 `KnowledgeBaseTenantConfig` node. Injectable for tests.
+         * @summary Native Edge Graph service backing the `KnowledgeBaseTenantConfig` node. Injectable for tests.
          */
         graphService: GraphService,
         /**
@@ -70,7 +69,7 @@ class KnowledgeBaseIngestionService extends Base {
         recorderService: KBRecorderService,
         /**
          * @member {Object|null} revisionResolver=null
-         * @summary Optional Phase 2E revision-boundary resolver used to derive deleted paths.
+         * @summary Optional revision-boundary resolver used to derive deleted paths.
          */
         revisionResolver: null,
         /**
@@ -107,11 +106,11 @@ class KnowledgeBaseIngestionService extends Base {
      * @param {Object} [payload.manifestSnapshot] Post-push manifest (`{repoSlug, pathsAfterPush}`).
      * @param {String} [payload.baseRevision] Previous revision boundary.
      * @param {String} [payload.headRevision] Current revision boundary.
-     * @param {Boolean} [payload.viaMcp=true] Caller-selected work-volume-gate mode (#11635 Phase 2C).
-     *                                        Omitted / truthy → MCP-safe: the #10572 gate in
-     *                                        `VectorService.embed` applies. Explicit `false` (the
-     *                                        `ai:ingest-tenant` bulk CLI path) bypasses the gate —
-     *                                        opt-in to long-running bulk work.
+     * @param {Boolean} [payload.viaMcp=true] Caller-selected work-volume-gate mode. Omitted
+     *                                        or truthy values keep `VectorService.embed`
+     *                                        MCP-safe. Explicit `false` (the `ai:ingest-tenant`
+     *                                        bulk CLI path) bypasses the gate as an opt-in to
+     *                                        long-running bulk work.
      * @returns {Promise<{ingested: Number, deleted: Number, embeddingsGenerated: Number, errors: Array, tenantId: String, durationMs: Number}>}
      */
     async ingestSourceFiles(payload = {}) {
@@ -122,7 +121,7 @@ class KnowledgeBaseIngestionService extends Base {
             const tenantContext = this.resolveTenantContext(payload);
             summary.tenantId    = tenantContext.tenantId;
 
-            // #11637 — resolve the active tenant-config version for chunk-metadata stamping.
+            // Resolve the active tenant-config version for chunk-metadata stamping.
             // Fail-soft: a graph read must never break an ingest, so a resolution failure degrades to 0.
             try {
                 tenantContext.configVersion = (await this.getTenantConfig({tenantId: tenantContext.tenantId})).version;
@@ -243,11 +242,11 @@ class KnowledgeBaseIngestionService extends Base {
     }
 
     /**
-     * @summary Groups parsed chunks by repoSlug and routes each group to VectorService.embed(),
-     * threading the caller-selected `viaMcp` work-volume-gate mode (#11635 Phase 2C).
+     * @summary Groups parsed chunks by repoSlug and routes each group to VectorService.embed().
      * @param {Object}  options
-     * @param {Boolean} [options.viaMcp=true] Forwarded to `VectorService.embed`; `true` keeps the
-     *                                        #10572 work-volume gate, `false` (bulk CLI) bypasses it.
+     * @param {Boolean} [options.viaMcp=true] Forwarded to `VectorService.embed`; `true` keeps
+     *                                        the MCP work-volume gate, `false` (bulk CLI)
+     *                                        bypasses it.
      * @returns {Promise<void>}
      * @protected
      */
@@ -421,11 +420,11 @@ class KnowledgeBaseIngestionService extends Base {
     }
 
     /**
-     * @summary Reads the persisted claimed-state manifests for one tenant (#11711).
+     * @summary Reads the persisted claimed-state manifests for one tenant.
      *
      * The sibling `kb-manifest:<tenantId>` graph node stores push-manifest state outside
-     * `KnowledgeBaseTenantConfig`: config `version` is the #11640 staleness signal and must
-     * not increment on routine pushes. Missing or RLS-hidden nodes resolve to an empty map so
+     * `KnowledgeBaseTenantConfig`: config `version` is the staleness signal and must not
+     * increment on routine pushes. Missing or RLS-hidden nodes resolve to an empty map so
      * reconciliation never actions rows without a claimed baseline.
      *
      * @param {Object}  data
@@ -453,7 +452,7 @@ class KnowledgeBaseIngestionService extends Base {
     }
 
     /**
-     * @summary Reads one persisted tenant/repo claimed-state manifest (#11711).
+     * @summary Reads one persisted tenant/repo claimed-state manifest.
      * @param {Object} data
      * @param {String} data.tenantId Tenant id.
      * @param {String} data.repoSlug Repo slug.
@@ -474,7 +473,7 @@ class KnowledgeBaseIngestionService extends Base {
     }
 
     /**
-     * @summary Persists one repo's post-push claimed-state manifest without bumping config version (#11711).
+     * @summary Persists one repo's post-push claimed-state manifest without bumping config version.
      *
      * RLS: writes still pass through {@link resolveTenantContext}. `GraphService.upsertNode`
      * stamps `properties.userId` when a request-scoped identity is active, while
@@ -537,7 +536,7 @@ class KnowledgeBaseIngestionService extends Base {
     }
 
     /**
-     * @summary Best-effort persistence hook for the push manifest already consumed by deletion signaling (#11711).
+     * @summary Best-effort persistence hook for the push manifest already consumed by deletion signaling.
      * @param {Object} options
      * @returns {Promise<void>}
      * @protected
@@ -709,7 +708,7 @@ class KnowledgeBaseIngestionService extends Base {
     }
 
     /**
-     * @summary Resolves revision-boundary tombstones via an injected Phase 2E resolver.
+     * @summary Resolves revision-boundary tombstones via an injected resolver.
      * @param {Object} options
      * @returns {Promise<Array<Object>>}
      * @protected
@@ -785,7 +784,7 @@ class KnowledgeBaseIngestionService extends Base {
     }
 
     /**
-     * @summary Resolves a tenant's Knowledge Base ingestion config (#11637 Phase 2E).
+     * @summary Resolves a tenant's Knowledge Base ingestion config.
      *
      * Three-tier resolution: the `KnowledgeBaseTenantConfig` graph node (`kb-config:<tenantId>`) →
      * the `kb-config.yaml` deployment bootstrap → the default source/parser registry from `aiConfig`.
@@ -851,7 +850,7 @@ class KnowledgeBaseIngestionService extends Base {
     }
 
     /**
-     * @summary Reads the optional `kb-config.yaml` deployment bootstrap, fail-soft (#11637 Phase 2E).
+     * @summary Reads the optional `kb-config.yaml` deployment bootstrap, fail-soft.
      *
      * The bootstrap is a deployment-root first-deploy convenience (`{tenants: {<tenantId>: {...}}}`);
      * the `KnowledgeBaseTenantConfig` graph node remains the canonical store. A missing or malformed
@@ -875,7 +874,7 @@ class KnowledgeBaseIngestionService extends Base {
     }
 
     /**
-     * @summary Persists a tenant's Knowledge Base ingestion config as a versioned graph node (#11637 Phase 2E).
+     * @summary Persists a tenant's Knowledge Base ingestion config as a versioned graph node.
      *
      * Writes the `KnowledgeBaseTenantConfig` node (`kb-config:<tenantId>`); `version` increments on
      * each mutation. RLS — two distinct layers:
@@ -883,12 +882,12 @@ class KnowledgeBaseIngestionService extends Base {
      *   (`KB_INGEST_TENANT_MISMATCH`). The explicit gate is required because `GraphService.upsertNode`
      *   auto-stamps the *caller's* identity onto `properties.userId` — an un-gated cross-tenant write
      *   would silently re-own the node rather than be rejected.
-     * - **Read visibility (#11716):** the node is marked `visibility:'team'` so the offline KB
-     *   reconciliation daemon (#11640) — which reads `getTenantConfig` with no request context —
-     *   can resolve it. `GraphService.getNodeRecord` exposes only ownerless / owner-matched /
+     * - **Read visibility:** the node is marked `visibility:'team'` so the offline KB
+     *   reconciliation daemon — which reads `getTenantConfig` with no request context — can
+     *   resolve it. `GraphService.getNodeRecord` exposes only ownerless / owner-matched /
      *   shared / `visibility:'team'` nodes; a request-authored (`userId`-stamped) config node
      *   without this marker is invisible to the daemon, silently degrading config-staleness
-     *   detection to the default tier. Mirrors the `kb-manifest:<tenantId>` sibling node (#11711).
+     *   detection to the default tier. Mirrors the `kb-manifest:<tenantId>` sibling node.
      * @param {Object} data
      * @param {String} data.tenantId Tenant id.
      * @param {Object} [data.config={}] Config payload — `useDefaultSources` / `useDefaultParsers` /

--- a/ai/services/knowledge-base/VectorService.mjs
+++ b/ai/services/knowledge-base/VectorService.mjs
@@ -80,7 +80,7 @@ class VectorService extends Base {
                 confirmation
             });
 
-            // Route through ChromaManager.deleteCollection (#11652 substrate-level guard).
+            // Route through ChromaManager.deleteCollection so the canonical-name guard applies.
             // Forward the operator confirmation so the canonical-name guard accepts it.
             await ChromaManager.deleteCollection({name: collectionName, confirmation});
             ChromaManager.invalidateKnowledgeBaseCollectionCache();
@@ -100,10 +100,9 @@ class VectorService extends Base {
     /**
      * Returns the tenant-isolation config surface.
      *
-     * Phase 0/1C runs inside the Knowledge Base server config directly, while the
-     * graduated contract documents the portable `aiConfig.knowledgeBase.*` shape for
-     * future shared AI config surfaces. Supporting both keeps this write boundary stable
-     * across the Phase 2/3 ingestion API work.
+     * The Knowledge Base server config can expose tenant fields directly or through the
+     * portable `aiConfig.knowledgeBase.*` shape used by shared AI config surfaces.
+     * Supporting both keeps this write boundary stable across ingestion API variants.
      *
      * @returns {Object} Tenant-isolation configuration object.
      */
@@ -122,17 +121,16 @@ class VectorService extends Base {
      * @param {String} [tenantContext.repoSlug] Repository slug within the tenant.
      * @param {String} [tenantContext.visibility] Visibility scope for read-side filtering.
      * @param {String} [tenantContext.originAgentIdentity] Authenticated agent identity.
-     * @param {Number} [tenantContext.configVersion] Active `KnowledgeBaseTenantConfig` version (#11637);
+     * @param {Number} [tenantContext.configVersion] Active `KnowledgeBaseTenantConfig` version;
      *                                               stamped onto chunk metadata as `tenantConfigVersion`.
      * `ingestedAt` (epoch ms, server-stamped via `Date.now()`) is added unconditionally —
-     * the #11712 retention / GC / reconciliation substrate. It marks when the chunk row is
+     * the retention / GC / reconciliation timestamp. It marks when the chunk row is
      * **actually embedded / upserted**: `embed()`'s zero-change fast path skips an unchanged
      * same-content re-push, so that chunk keeps its prior `ingestedAt` (a content change
      * yields a *new* chunk row — new content-hash ID — with its own fresh `ingestedAt`).
      * It is purely server-derived (never client-authored), so it is also a
-     * `TENANT_GUARDED_FIELDS` member. Consumers MUST treat a missing `ingestedAt` (a chunk
-     * embedded before #11712) as unknown-age and fail-safe — never expire / action a chunk
-     * with no timestamp.
+     * `TENANT_GUARDED_FIELDS` member. Consumers MUST treat a missing `ingestedAt` as
+     * unknown-age and fail-safe — never expire or action a chunk with no timestamp.
      * @returns {{tenantId: String, repoSlug: String, visibility: String, tenantConfigVersion: Number, ingestedAt: Number, originAgentIdentity: String|undefined}}
      */
     resolveTenantStamp(tenantContext = {}) {
@@ -351,7 +349,6 @@ class VectorService extends Base {
      * @param {Object[]} options.knowledgeBase   Full tenant-stamped corpus.
      * @param {Number}   options.idsToDeleteCount Logical stale-id count removed from the canonical view.
      * @returns {Promise<Object>} Embedding result.
-     * @see https://github.com/neomjs/neo/issues/11683
      */
     async embedViaShadowSwap({liveCollection, knowledgeBase, idsToDeleteCount}) {
         const shadowName  = this.createSwapCollectionName('shadow');
@@ -422,7 +419,6 @@ class VectorService extends Base {
      * @param {Object} options.shadowCollection Shadow collection handle to park.
      * @param {String} options.shadowName       Original active shadow collection name.
      * @returns {Promise<String|null>} Parked name, or `null` if parking failed.
-     * @see https://github.com/neomjs/neo/issues/11685
      */
     async parkFailedShadowCollection({shadowCollection, shadowName}) {
         const failedShadowName = this.createSwapCollectionName('failed-shadow');
@@ -440,7 +436,7 @@ class VectorService extends Base {
     /**
      * Reads a JSONL file, enriches data, generates embeddings, and updates ChromaDB.
      *
-     * **Work-volume gate (#10572):** when invoked via MCP (`viaMcp: true`), refuses
+     * **Work-volume gate:** when invoked via MCP (`viaMcp: true`), refuses
      * synchronous execution if `chunksToProcess.length` exceeds `aiConfig.mcpSyncMaxChunks`
      * (default 50, aligned with `batchSize`). Returns a structured `{error, code, ...}`
      * payload that the MCP server's `Server.mjs` converts to `isError: true` per its
@@ -453,7 +449,7 @@ class VectorService extends Base {
      *                                             enables the work-volume gate.
      * @param {Object}  [opts.tenantContext]       Server-derived tenant stamp context.
      * @param {Boolean} [opts.deleteStale=true]    True applies full-corpus stale-id deletion.
-     *                                             Incremental Phase 2 pushes pass `false` and
+     *                                             Incremental ingestion pushes pass `false` and
      *                                             use explicit deletion signaling instead.
      * @param {String}  [opts.staleStrategy]       Stale handling strategy. `delete-upfront`
      *                                             preserves the historical behavior;
@@ -461,7 +457,6 @@ class VectorService extends Base {
      *                                             before promoting it to the canonical name.
      * @returns {Promise<object>} A promise that resolves to a success message, OR a
      *     `{error, code: 'KB_SYNC_VOLUME_EXCEEDED', ...}` shape when the MCP gate fires.
-     * @see #10572
      */
     async embed(knowledgeBasePath, {viaMcp = false, tenantContext = {}, deleteStale = true, staleStrategy} = {}) {
         logger.log('Starting knowledge base embedding...');
@@ -576,7 +571,7 @@ class VectorService extends Base {
             return {message, embedded: 0, deleted: idsToDelete.length};
         }
 
-        // Work-volume gate (#10572): refuse synchronous embedding via MCP when the
+        // Work-volume gate: refuse synchronous embedding via MCP when the
         // post-delta queue exceeds the configured threshold. The threshold default
         // matches `batchSize` (one batch is the floor for "small enough to run
         // synchronously"); real latency is provider/tier/retry-state-dependent so


### PR DESCRIPTION
Refs #11923
Related: #11912

Authored by GPT-5 (Codex Desktop). Session e5a3acc3-d261-4ebf-96b1-4053ab0eafdf.

FAIR-band: over-target [16/30] — taking this lane despite over-target because @tobiu delegated /lead-role for the latest-first v13 backlog walk, #11923 was self-assigned and lane-claimed, and this first KB-service slice keeps the freshly shaped #11912 epic moving without colliding with Claude's active lanes.

Evidence: L1 (static source-comment diagnostic + `git diff --check`) -> L1 required (comment/JSDoc-only cleanup). No runtime residuals for this PR slice; #11923 remains open for the remaining graph and ingestion groups.

Cleaned the first Knowledge Base service batch under #11923:

- `ai/services/knowledge-base/KnowledgeBaseIngestionService.mjs`
- `ai/services/knowledge-base/DatabaseService.mjs`
- `ai/services/knowledge-base/VectorService.mjs`

The diff rewrites ticket, AC, phase, and PR-history source comments into durable service-contract phrasing: tenant config stamping, SourceRegistry discovery, backup/restore boundaries, destructive-collection guards, manifest storage, and work-volume gating. No executable code changed.

## Deltas from ticket

This is a partial #11923 PR, not a close-target. The ticket covers KB, graph, and ingestion groups; this PR only clears the highest-cohesion KB service slice. Graph, identity, MCP-KB, and ingestion bridge files remain for follow-up PRs.

One diagnostic hit remains intentionally untouched:

- `KnowledgeBaseIngestionService.mjs`: runtime error string `Revision-boundary deletion requires Phase 2E tenant config storage / resolver (#11637).`

That string is executable diagnostic output, not source comment/JSDoc, so this PR preserves it to keep the change behavior-neutral.

## Test Evidence

- Focused diagnostic before edit:
  - `KnowledgeBaseIngestionService.mjs`: 18 matches
  - `DatabaseService.mjs`: 17 matches
  - `VectorService.mjs`: 7 matches
  - Total: 42 matches
- Focused diagnostic after edit:
  - `rg --count-matches "ticket #|#[0-9]{4,}|\\bAC[0-9]+\\b|\\bAC [0-9]+\\b|Lane [A-Z]|cycle-[0-9]|PR #[0-9]+|:[0-9]+-[0-9]+" ai/services/knowledge-base/KnowledgeBaseIngestionService.mjs ai/services/knowledge-base/DatabaseService.mjs ai/services/knowledge-base/VectorService.mjs`
  - Result: `KnowledgeBaseIngestionService.mjs:1`, with the remaining hit in a runtime string.
- `rg -n "\\bPhase\\b|#[0-9]{4,}|\\bAC[0-9]+\\b|\\bAC [0-9]+\\b" ai/services/knowledge-base/KnowledgeBaseIngestionService.mjs ai/services/knowledge-base/DatabaseService.mjs ai/services/knowledge-base/VectorService.mjs`
  - Result: only the preserved runtime error string.
- `git diff --check origin/dev...HEAD` — pass.
- Unit tests not run: comment/JSDoc-only diff with no executable code changes.

## Post-Merge Validation

- [ ] Continue #11923 with graph/identity and ingestion-service source-comment batches.
- [ ] Keep #11912 open until all grouped subissues are complete and the epic closeout matrix is reconciled.

## Commits

- `23917482f` — `chore(ai): clean kb service source comments (#11923)`
