### PR TITLE
chore(ai): clean ingestion source comments (#11923)

### DIFF
--- a/ai/services/ingestion/ConceptDiscoveryService.mjs
+++ b/ai/services/ingestion/ConceptDiscoveryService.mjs
@@ -101,8 +101,8 @@ const CANDIDATE_DEFAULTS = {
  * it writes candidate rows INTO the JSONL that `ConceptIngestor` picks up next cycle. Split
  * by direction of data flow and trust level: curator-asserted rows vs LLM-proposed rows.
  *
- * **Why single JSONL (no staging file)?** Per the #10036 intake discussion, a
- * `candidates.jsonl` split would duplicate the curator's review surface. The weight gate
+ * **Why single JSONL (no staging file)?** A separate candidate file would duplicate
+ * the curator's review surface. The weight gate
  * (`guideGapWeightThreshold`) plus the `validated: false` flag silence unvalidated rows in
  * `sandman_handoff.md`; git diff on `nodes.jsonl` is the review UI.
  *
@@ -134,7 +134,7 @@ class ConceptDiscoveryService extends Base {
     /**
      * Instance-level override for the per-cycle PR cap. Tests mutate this directly for
      * deterministic cap behavior; production falls back to `aiConfig.data.conceptDiscovery
-     * .prScanLimit` (#10086 config-lift pattern — live read at call time, not module load).
+     * .prScanLimit` so config is read at call time instead of module load.
      * @member {Number|null} prScanLimit=null
      */
     prScanLimit = null

--- a/ai/services/ingestion/ConceptIngestor.mjs
+++ b/ai/services/ingestion/ConceptIngestor.mjs
@@ -47,7 +47,7 @@ function stableStringify(value) {
  * into the Native Edge Graph (SQLite) as first-class graph citizens — CONCEPT nodes plus typed edges
  * (PARENT_CONCEPT, IMPLEMENTED_BY, EXPLAINED_BY, EXEMPLIFIED_BY, ANALOGOUS_TO).
  *
- * This service is the Phase-0 bridge between the version-controlled concept graph maintained as
+ * This service is the bridge between the version-controlled concept graph maintained as
  * JSONL (cheap to edit, diff-friendly, PR-reviewable) and the runtime Native Edge Graph that
  * `GapInferenceEngine` traverses for deterministic gap detection. It mirrors the ingestor pattern
  * established by `IssueIngestor` and `FileSystemIngestor` — a singleton with a single public
@@ -56,14 +56,14 @@ function stableStringify(value) {
  * **Why differential sync?** The REM pipeline runs on local models (currently `gemma4-31b` — a
  * 256K-context frontier-capable open-weight model distilled from Gemini 3). Capability is not the
  * concern; I/O throughput is. Hashing concept payloads and skipping unchanged rows eliminates
- * redundant SQLite writes across cycles — 59 nodes today, potentially thousands after
- * #10050/#10036/#10037 enrichment. Cheap, deterministic, auditable.
+ * redundant SQLite writes across cycles — compact today, potentially thousands of nodes
+ * as ontology enrichment expands. Cheap, deterministic, auditable.
  *
- * **Why upsert-only, no deletions in Phase 1?** Concept removal is a data-hygiene concern handled
+ * **Why upsert-only, no deletions here?** Concept removal is a data-hygiene concern handled
  * by `GraphMaintenanceService`'s Fade / Apoptosis passes. This ingestor is strictly additive.
  *
- * This class is the canonical example of **deterministic graph ingestion** referenced by #10080
- * (relevance-bounded query layer) and the `tech-debt-radar` unbounded-API detection in #10082.
+ * This class is the canonical example of **deterministic graph ingestion** consumed by
+ * relevance-bounded query layers and tech-debt radar sweeps.
  *
  * @class Neo.ai.daemons.services.ConceptIngestor
  * @extends Neo.core.Base
@@ -102,14 +102,14 @@ class ConceptIngestor extends Base {
             tags       : conceptNode.tags        ?? [],
             tier       : conceptNode.tier        ?? 0,
             uniqueToNeo: !!conceptNode.uniqueToNeo,
-            // #10036: validated flag — unvalidated concepts are candidates from ConceptDiscoveryService
-            // awaiting human curation. `undefined` (legacy rows pre-#10036) is treated as validated.
+            // Unvalidated concepts are candidates from ConceptDiscoveryService awaiting human
+            // curation. `undefined` from legacy rows is treated as validated.
             // Flipping `validated: false → true` during curator review must trigger re-upsert, so the
             // flag contributes to the hash.
             validated  : conceptNode.validated !== false,
-            // #10574: verifiedAt freshness metadata is non-destructive. It queues re-verification
-            // work but never fades the CONCEPT node or its edges. Missing legacy values normalize
-            // to null and must trigger re-upsert when curators later stamp an ISO date.
+            // Freshness metadata is non-destructive. It queues re-verification work but never
+            // fades the CONCEPT node or its edges. Missing legacy values normalize to null and
+            // must trigger re-upsert when curators later stamp an ISO date.
             verifiedAt : conceptNode.verifiedAt ?? null
         };
 
@@ -198,8 +198,8 @@ class ConceptIngestor extends Base {
      * `capabilityGap` channel from this service — that emission lives in
      * `GapInferenceEngine.inferConceptGraphGaps`, which weight-gates the signal and routes it
      * through the same `capabilityGap` tag channel + `sandman_handoff.md` section pattern as
-     * `[GUIDE_GAP]` and `[EXAMPLE_GAP]`. See #10087 for the architectural rationale — per-orphan
-     * `logger.warn` was ephemeral in an offline daemon, the graph+handoff plane is durable.
+     * `[GUIDE_GAP]` and `[EXAMPLE_GAP]`. Per-orphan `logger.warn` output is ephemeral in an
+     * offline daemon; the graph+handoff plane is durable.
      *
      * @returns {Promise<Object>} Ingestion statistics: `{conceptsProcessed, conceptsUpserted, conceptsSkipped, edgesReplaced, orphansDetected, errors}`
      */
@@ -274,7 +274,7 @@ class ConceptIngestor extends Base {
                     // Orphan detection — no IMPLEMENTED_BY means no source code anchors this concept.
                     // Counted here for the cycle-summary stats line; the actionable `[ORPHAN_CONCEPT]`
                     // gap signal is emitted by `GapInferenceEngine.inferConceptGraphGaps` through the
-                    // durable `capabilityGap` channel + `sandman_handoff.md` section (see #10087).
+                    // durable `capabilityGap` channel + `sandman_handoff.md` section.
                     const hasImplementedBy = newEdges.some(e => e.type === CONCEPT_EDGE_TYPES.IMPLEMENTED_BY);
                     if (!hasImplementedBy && conceptNode.tier > 0) {
                         stats.orphansDetected++;

--- a/ai/services/ingestion/MemorySessionIngestor.mjs
+++ b/ai/services/ingestion/MemorySessionIngestor.mjs
@@ -29,7 +29,7 @@ function stableStringify(value) {
  * @summary Service that lifts Memory Core artifacts (session summaries + raw per-turn memories)
  * into the Native Edge Graph as first-class SESSION and MEMORY nodes — the **structural layer**
  * downstream consumers (mailbox `IN_REPLY_TO`, identity `AUTHORED_BY`, thread reconstruction,
- * #10030 concept-edge reach-back) traverse.
+ * and concept-edge reach-back) traverse.
  *
  * Prior to this service, memories + summaries existed only as Chroma rows — extracted entities
  * (concepts, classes, methods) were graph citizens but their source memories were not, leaving
@@ -57,9 +57,8 @@ function stableStringify(value) {
  * No module-level monkey-patching, no global-state mutation, no test-only branches in the
  * production code path.
  *
- * This service is the **structural-layer prerequisite** for the mailbox (#10139), AgentIdentity
- * ownership (#10016), Gemma4 extractor provenance edges (#10152), and lazy back-fill (#10153)
- * work streams under the Graph-first Memory artifacts sub-epic (#10143).
+ * This service is the **structural-layer prerequisite** for mailbox threading, AgentIdentity
+ * ownership, extractor provenance edges, and lazy graph back-fill work streams.
  *
  * @class Neo.ai.daemons.services.MemorySessionIngestor
  * @extends Neo.core.Base
@@ -170,8 +169,8 @@ class MemorySessionIngestor extends Base {
                     properties: {
                         chromaId    : session.id,
                         createdAt   : session.meta.createdAt,
-                        // Provenance marker distinguishing live REM-cycle ingestion from #10153
-                        // lazy back-fill. Queries discriminating between the two sources use
+                        // Provenance marker distinguishing live REM-cycle ingestion from lazy
+                        // back-fill. Queries discriminating between the two sources use
                         // `liveIngested` vs `backfilled` on the node's properties.
                         liveIngested: true,
                         payloadHash : sessionPayloadHash,
@@ -246,18 +245,17 @@ class MemorySessionIngestor extends Base {
 
     /**
      * Back-fills a single MEMORY or SESSION graph node from its Chroma source row — the per-row
-     * analog of `syncSessionToGraph` (which is batch-per-session). Invoked by #10153's lazy
+     * analog of `syncSessionToGraph` (which is batch-per-session). Invoked by the lazy
      * back-fill mechanism when `GraphService.linkNodes` encounters a missing target matching
      * the `memory:` or `session:` prefix pattern.
      *
      * **Graph-node-id convention:** the canonical form is lowercase (`memory:<chromaId>`,
      * `session:<sessionId>`) matching the IDs produced by `syncSessionToGraph`. This method
      * accepts **case-insensitive** prefix matching so it can consume edges queued with the
-     * uppercase convention used by `SemanticGraphExtractor`'s lazy-edges queue (#10165) without
-     * requiring a canonical-format migration. The back-filled node always lands under the
+     * uppercase convention used by `SemanticGraphExtractor`'s lazy-edges queue without requiring
+     * a canonical-format migration. The back-filled node always lands under the
      * lowercase canonical ID; callers whose edge had the uppercase form should have their edge
-     * target re-normalized at the same call site (see the `linkNodes` prefix-normalization path
-     * landed in #10153).
+     * target re-normalized at the same call site via the `linkNodes` prefix-normalization path.
      *
      * **Memory → Session dependency:** a Memory's `sessionId` metadata points at its parent
      * Session. Back-filling a Memory whose parent Session is absent would dangle the


### PR DESCRIPTION
Refs #11923
Related: #11912

Authored by GPT-5.5 (Codex Desktop). Session 019e5bac-15f3-7830-a59c-72772c757f9a.

FAIR-band: over-target [20/30] - taking this lane despite over-target because #11923 was already assigned to @neo-gpt, the watchdog had no review-requested PR ready for approval, and live diagnostics showed a bounded ingestion residual under the v13 #11912 epic.

Evidence: L1 (static source-comment diagnostic plus git diff check) -> L1 required (comment/JSDoc-only cleanup). No runtime behavior changed in this PR slice; #11923 remains open for MCP Knowledge Base config/tooling comments.

Cleaned the ingestion-service batch under #11923:

- ai/services/ingestion/ConceptDiscoveryService.mjs
- ai/services/ingestion/ConceptIngestor.mjs
- ai/services/ingestion/MemorySessionIngestor.mjs

The diff rewrites ticket, phase, and PR archaeology into durable ingestion contracts: single-JSONL candidate review, call-time config reads, deterministic concept graph ingestion, concept freshness metadata, durable orphan-gap routing, Memory/Session structural-layer projection, and lazy graph back-fill. No executable code changed.

## Deltas from ticket

This is a partial #11923 PR, not a close-target. It covers ai/services/ingestion/*.mjs source comments only. MCP Knowledge Base config/tooling comments remain for follow-up PRs before #11923 can close.

## Test Evidence

- Focused diagnostic before edit on origin/dev: 14 matches in ai/services/ingestion.
- Focused diagnostic after edit: no matches for ticket/PR/AC/lane/cycle/range archaeology in ai/services/ingestion.
- Broader touched-folder check: no matches for Phase, issue IDs, or AC anchors in ai/services/ingestion.
- git diff --check origin/dev...HEAD - pass.
- Unit tests not run: comment/JSDoc-only diff with no executable behavior changes.

## Post-Merge Validation

- [ ] Continue #11923 with MCP Knowledge Base config/tooling comments.
- [ ] Keep #11912 open until all grouped subissues are complete and the epic closeout matrix is reconciled.

## Commits

- 4c3437775 - chore(ai): clean ingestion source comments (#11923)
