### PR TITLE
feat(kb): add tenant repo ingest envelope builder (#11789)

### DIFF
--- a/ai/services/knowledge-base/helpers/GitMirror.mjs
+++ b/ai/services/knowledge-base/helpers/GitMirror.mjs
@@ -496,7 +496,7 @@ export async function diffRevisions({mirrorRoot, tenantId, repoSlug, baseRevisio
 
     await isUsableMirror(mirrorPath);
 
-    const result = await runGit(['diff', '--name-status', '-z', baseRevision, headRevision], {
+    const result = await runGit(['diff', '--name-status', '-z', '-M', baseRevision, headRevision], {
         cwd           : mirrorPath,
         failureCode   : 'KB_GITMIRROR_DIFF_FAILED',
         failureMessage: 'GitMirror revision diff failed'
@@ -507,7 +507,26 @@ export async function diffRevisions({mirrorRoot, tenantId, repoSlug, baseRevisio
 
     for (let i = 0; i < parts.length;) {
         const status = parts[i++];
-        const file   = parts[i++];
+
+        if (status.startsWith('R')) {
+            const oldFile = parts[i++],
+                  newFile = parts[i++];
+
+            if (oldFile) deleted.add(oldFile);
+            if (newFile) addedOrChanged.add(newFile);
+            continue;
+        }
+
+        if (status.startsWith('C')) {
+            i++;
+
+            const newFile = parts[i++];
+
+            if (newFile) addedOrChanged.add(newFile);
+            continue;
+        }
+
+        const file = parts[i++];
 
         if (!file) continue;
 

--- a/ai/services/knowledge-base/helpers/TenantRepoIngestEnvelopeBuilder.mjs
+++ b/ai/services/knowledge-base/helpers/TenantRepoIngestEnvelopeBuilder.mjs
@@ -1,0 +1,328 @@
+import {execFile}  from 'child_process';
+import fs          from 'fs-extra';
+import {promisify} from 'util';
+
+import GitMirror from './GitMirror.mjs';
+import {
+    deriveTenantRepoMirrorPath,
+    normalizeRepoSlug,
+    redactTenantRepoSecrets
+} from './TenantRepoAccessContract.mjs';
+
+const execFileAsync = promisify(execFile);
+const GIT_MAX_BUFFER = 50 * 1024 * 1024;
+
+/**
+ * @summary Builds `KnowledgeBaseIngestionService.ingestSourceFiles()` envelopes from tenant Git mirrors.
+ *
+ * `TenantRepoIngestEnvelopeBuilder` is the #11789 adapter between the low-level
+ * persistent mirror primitive (#11788) and the tenant KB ingestion payload contract.
+ * Linear history advances emit bounded raw-file deltas plus tombstones; bootstrap,
+ * missing-baseline, and force-push cases fall back to a full manifest-carrying
+ * snapshot so the ingestion service can reconcile the claimed live path set without
+ * relying on a stale revision boundary.
+ *
+ * @see https://github.com/neomjs/neo/issues/11789
+ * @see ai/services/knowledge-base/KnowledgeBaseIngestionService.mjs
+ */
+
+/**
+ * @summary Creates a stable envelope-builder error.
+ * @param {String} code Stable `KB_INGEST_ENVELOPE_*` error code.
+ * @param {String} message Human-readable message.
+ * @param {Object} details={}
+ * @returns {Error}
+ * @private
+ */
+function createIngestEnvelopeError(code, message, details = {}) {
+    const error = new Error(redactTenantRepoSecrets(message, details));
+
+    error.code = code;
+
+    if (details.stdout) {
+        error.stdout = redactTenantRepoSecrets(details.stdout, details);
+    }
+
+    if (details.stderr) {
+        error.stderr = redactTenantRepoSecrets(details.stderr, details);
+    }
+
+    if (details.exitCode !== undefined) {
+        error.exitCode = details.exitCode;
+    }
+
+    if (details.cause) {
+        error.cause = details.cause;
+    }
+
+    return error;
+}
+
+/**
+ * @summary Returns the mirror path while converting contract errors into builder errors.
+ * @param {Object} options
+ * @returns {String}
+ * @private
+ */
+function getMirrorPath({mirrorRoot, tenantId, repoSlug} = {}) {
+    try {
+        return deriveTenantRepoMirrorPath({mirrorRoot, tenantId, repoSlug});
+    } catch (error) {
+        throw createIngestEnvelopeError(
+            'KB_INGEST_ENVELOPE_MIRROR_PATH_INVALID',
+            error.message,
+            {cause: error}
+        );
+    }
+}
+
+/**
+ * @summary Runs read-only git commands against an existing bare mirror.
+ * @param {String} mirrorPath Local mirror path.
+ * @param {String[]} args Git arguments.
+ * @param {Object} options={}
+ * @returns {Promise<String>}
+ * @private
+ */
+async function runMirrorGit(mirrorPath, args, {
+    failureCode = 'KB_INGEST_ENVELOPE_GIT_FAILED',
+    failureMessage = 'Tenant repo ingest envelope git command failed'
+} = {}) {
+    try {
+        const {stdout} = await execFileAsync('git', args, {
+            cwd      : mirrorPath,
+            maxBuffer: GIT_MAX_BUFFER
+        });
+
+        return stdout;
+    } catch (error) {
+        throw createIngestEnvelopeError(failureCode, failureMessage, {
+            cause   : error,
+            exitCode: error.code,
+            stdout  : error.stdout,
+            stderr  : error.stderr
+        });
+    }
+}
+
+/**
+ * @summary Resolves and validates a commit ref inside the mirror.
+ * @param {Object} options
+ * @returns {Promise<String|null>}
+ * @private
+ */
+async function resolveRevision({gitMirror, identity, ref, fallbackToFull = false}) {
+    if (!ref) {
+        return null;
+    }
+
+    try {
+        return await gitMirror.resolveHead({...identity, ref});
+    } catch (error) {
+        if (fallbackToFull && error.code === 'KB_GITMIRROR_REF_NOT_FOUND') {
+            return null;
+        }
+
+        const code = error.code === 'KB_GITMIRROR_REF_NOT_FOUND'
+            ? 'KB_INGEST_ENVELOPE_REF_NOT_FOUND'
+            : error.code === 'KB_GITMIRROR_MIRROR_PATH_INVALID'
+                ? 'KB_INGEST_ENVELOPE_MIRROR_INVALID'
+                : 'KB_INGEST_ENVELOPE_REF_RESOLVE_FAILED';
+
+        throw createIngestEnvelopeError(
+            code,
+            error.message,
+            {cause: error}
+        );
+    }
+}
+
+/**
+ * @summary Lists all repo-relative paths present at a revision.
+ * @param {Object} options
+ * @returns {Promise<Array<String>>}
+ * @private
+ */
+async function listRevisionPaths({mirrorPath, revision}) {
+    const stdout = await runMirrorGit(
+        mirrorPath,
+        ['ls-tree', '-r', '-z', '--name-only', revision],
+        {
+            failureCode   : 'KB_INGEST_ENVELOPE_LIST_FAILED',
+            failureMessage: 'Tenant repo ingest envelope failed to list revision paths'
+        }
+    );
+
+    return stdout.split('\0').filter(Boolean).sort();
+}
+
+/**
+ * @summary Reads one text file from a revision.
+ * @param {Object} options
+ * @returns {Promise<String>}
+ * @private
+ */
+async function readRevisionFile({mirrorPath, revision, sourcePath}) {
+    if (!sourcePath || sourcePath.includes('\0')) {
+        throw createIngestEnvelopeError(
+            'KB_INGEST_ENVELOPE_PATH_INVALID',
+            'Tenant repo ingest envelope received an invalid sourcePath'
+        );
+    }
+
+    return await runMirrorGit(
+        mirrorPath,
+        ['show', `${revision}:${sourcePath}`],
+        {
+            failureCode   : 'KB_INGEST_ENVELOPE_FILE_READ_FAILED',
+            failureMessage: `Tenant repo ingest envelope failed to read '${sourcePath}'`
+        }
+    );
+}
+
+/**
+ * @summary Builds raw-file payload records from source paths.
+ * @param {Object} options
+ * @returns {Promise<Array<Object>>}
+ * @private
+ */
+async function buildFilePayloads({mirrorPath, revision, paths, repoSlug, rootKind, parserId, parserVersion}) {
+    const files = [];
+
+    for (const sourcePath of paths) {
+        files.push({
+            sourcePath,
+            repoSlug,
+            rootKind,
+            content: await readRevisionFile({mirrorPath, revision, sourcePath}),
+            ...(parserId ? {parserId} : {}),
+            ...(parserVersion ? {parserVersion} : {})
+        });
+    }
+
+    return files;
+}
+
+/**
+ * @summary Builds a manifest-carrying full ingest envelope for bootstrap and non-linear history.
+ * @param {Object} options
+ * @returns {Promise<Object>}
+ * @private
+ */
+async function buildFullEnvelope({identity, mirrorPath, headRevision, rootKind, parserId, parserVersion}) {
+    const paths = await listRevisionPaths({mirrorPath, revision: headRevision});
+    const files = await buildFilePayloads({
+        mirrorPath,
+        revision: headRevision,
+        paths,
+        repoSlug: identity.repoSlug,
+        rootKind,
+        parserId,
+        parserVersion
+    });
+
+    return {
+        tenantId: identity.tenantId,
+        repoSlug : identity.repoSlug,
+        files,
+        headRevision,
+        manifestSnapshot: {
+            repoSlug      : identity.repoSlug,
+            pathsAfterPush: paths
+        }
+    };
+}
+
+/**
+ * @summary Builds a KnowledgeBaseIngestionService raw-file ingest envelope from a tenant repo mirror.
+ * @param {Object} options
+ * @param {String} options.tenantId Tenant id.
+ * @param {String} options.repoSlug Clean tenant repository identity.
+ * @param {String} options.mirrorRoot Root directory for tenant repo mirrors.
+ * @param {String} [options.lastIngestedRev] Previously ingested commit SHA/ref.
+ * @param {String} [options.newHead='HEAD'] New commit SHA/ref to ingest.
+ * @param {String} [options.rootKind='external-source'] Raw-file root kind for parser metadata.
+ * @param {String} [options.parserId] Optional server parser id.
+ * @param {String} [options.parserVersion] Optional parser version.
+ * @param {Object} [options.gitMirror=GitMirror] Injectable GitMirror implementation for tests.
+ * @returns {Promise<Object>}
+ */
+export async function buildIngestEnvelope({
+    tenantId,
+    repoSlug,
+    mirrorRoot,
+    lastIngestedRev,
+    newHead = 'HEAD',
+    rootKind = 'external-source',
+    parserId,
+    parserVersion,
+    gitMirror = GitMirror
+} = {}) {
+    const identity = {
+        tenantId,
+        repoSlug: normalizeRepoSlug(repoSlug),
+        mirrorRoot
+    };
+    const mirrorPath = getMirrorPath(identity);
+
+    if (!await fs.pathExists(mirrorPath)) {
+        throw createIngestEnvelopeError(
+            'KB_INGEST_ENVELOPE_MIRROR_MISSING',
+            'Tenant repo ingest envelope requires an existing GitMirror mirror'
+        );
+    }
+
+    const headRevision = await resolveRevision({gitMirror, identity, ref: newHead});
+    const baseRevision = await resolveRevision({
+        gitMirror,
+        identity,
+        ref           : lastIngestedRev,
+        fallbackToFull: true
+    });
+
+    if (!baseRevision) {
+        return await buildFullEnvelope({identity, mirrorPath, headRevision, rootKind, parserId, parserVersion});
+    }
+
+    const linear = await gitMirror.isAncestor({
+        ...identity,
+        ancestor  : baseRevision,
+        descendant: headRevision
+    });
+
+    if (!linear) {
+        return await buildFullEnvelope({identity, mirrorPath, headRevision, rootKind, parserId, parserVersion});
+    }
+
+    const diff = await gitMirror.diffRevisions({
+        ...identity,
+        baseRevision,
+        headRevision
+    });
+    const paths = [...new Set(diff.addedOrChanged || [])].sort();
+
+    return {
+        tenantId: identity.tenantId,
+        repoSlug : identity.repoSlug,
+        files: await buildFilePayloads({
+            mirrorPath,
+            revision: headRevision,
+            paths,
+            repoSlug: identity.repoSlug,
+            rootKind,
+            parserId,
+            parserVersion
+        }),
+        deleted: [...new Set(diff.deleted || [])]
+            .sort()
+            .map(sourcePath => ({sourcePath, repoSlug: identity.repoSlug})),
+        baseRevision,
+        headRevision
+    };
+}
+
+const TenantRepoIngestEnvelopeBuilder = {
+    buildIngestEnvelope
+};
+
+export default TenantRepoIngestEnvelopeBuilder;

--- a/learn/agentos/cloud-deployment/TenantIngestionModel.md
+++ b/learn/agentos/cloud-deployment/TenantIngestionModel.md
@@ -68,6 +68,7 @@ The push-based MVP path is credential-free from the KB server's perspective:
 - The KB server receives ingestion payloads, not Git credentials.
 - The repo-push automation identity token authorizes the tenant to call the KB MCP endpoint; it is not a Git credential and is never folded into `repoSlug`, manifests, or chunk metadata.
 - Optional server-side pull config uses `tenantRepos[]` entries with clean `cloneUrl`, reference-only `credentialRef`, and normalized `repoSlug` (#11787). Credential-bearing `userinfo@` clone URLs are rejected before graph persistence; credential injection belongs to the `GitMirror` primitive (#11788). `GitMirror` resolves the credential reference only for the git subprocess invocation (`GIT_ASKPASS` for HTTPS, `GIT_SSH_COMMAND` for SSH) and keeps mirror contents on the deployment `tenant-repo-mirrors` volume mounted at `NEO_TENANT_REPO_MIRROR_ROOT`.
+- For the pull-based follow-up path, `TenantRepoIngestEnvelopeBuilder` adapts the Git mirror into the same ingestion service envelope (#11789). Linear history advances emit raw-file `files`, explicit `deleted` tombstones, `baseRevision`, and `headRevision`; bootstrap, missing-baseline, and non-linear history cases emit a full `files` snapshot plus `manifestSnapshot` so `KnowledgeBaseIngestionService.ingestSourceFiles()` can reconcile the claimed live file set without re-pointing the local `kbSync` lane.
 
 Credential-bearing Git URLs are therefore rejected or treated as deferred clone-exploration input. They must not appear in:
 

--- a/test/playwright/unit/ai/services/knowledge-base/GitMirror.spec.mjs
+++ b/test/playwright/unit/ai/services/knowledge-base/GitMirror.spec.mjs
@@ -65,6 +65,12 @@ test.describe('GitMirror (#11788)', () => {
         await git(['-c', 'user.name=Neo Test', '-c', 'user.email=test@example.com', 'commit', '-m', 'second'], source);
     }
 
+    async function commitRenameRevision(source) {
+        await git(['mv', 'alpha.txt', 'renamed-alpha.txt'], source);
+        await git(['add', '-A'], source);
+        await git(['-c', 'user.name=Neo Test', '-c', 'user.email=test@example.com', 'commit', '-m', 'rename alpha'], source);
+    }
+
     function mirrorOptions(source) {
         return {
             cloneUrl  : source,
@@ -119,6 +125,23 @@ test.describe('GitMirror (#11788)', () => {
             .resolves.toBe(false);
         expect(diff.addedOrChanged.sort()).toEqual(['alpha.txt', 'beta.txt']);
         expect(diff.deleted).toEqual(['remove-me.txt']);
+    });
+
+    test('represents renames as new live paths plus old tombstones', async () => {
+        const source = await createSourceRepo();
+
+        await cloneIfMissing(mirrorOptions(source));
+
+        const baseRevision = await resolveHead({...mirrorOptions(source), ref: 'main'});
+
+        await commitRenameRevision(source);
+        await fetch(mirrorOptions(source));
+
+        const headRevision = await resolveHead({...mirrorOptions(source), ref: 'main'});
+        const diff         = await diffRevisions({...mirrorOptions(source), baseRevision, headRevision});
+
+        expect(diff.addedOrChanged).toEqual(['renamed-alpha.txt']);
+        expect(diff.deleted).toEqual(['alpha.txt']);
     });
 
     test('throws stable errors for missing refs and invalid mirrors', async () => {

--- a/test/playwright/unit/ai/services/knowledge-base/TenantRepoIngestEnvelopeBuilder.spec.mjs
+++ b/test/playwright/unit/ai/services/knowledge-base/TenantRepoIngestEnvelopeBuilder.spec.mjs
@@ -1,0 +1,189 @@
+import {test, expect} from '@playwright/test';
+
+import fs             from 'fs-extra';
+import os             from 'os';
+import path           from 'path';
+import {execFile}     from 'child_process';
+import {promisify}    from 'util';
+
+import {cloneIfMissing, fetch, resolveHead}
+                       from '../../../../../../ai/services/knowledge-base/helpers/GitMirror.mjs';
+import TenantRepoIngestEnvelopeBuilder, {
+    buildIngestEnvelope
+} from '../../../../../../ai/services/knowledge-base/helpers/TenantRepoIngestEnvelopeBuilder.mjs';
+
+const execFileAsync = promisify(execFile);
+
+/**
+ * @summary Contract tests for the tenant GitMirror to KB ingest envelope adapter (#11789).
+ *
+ * The builder emits the live `KnowledgeBaseIngestionService.ingestSourceFiles()`
+ * payload shape: `files`, `deleted`, `manifestSnapshot`, `baseRevision`, and
+ * `headRevision`. Tests use local Git repositories only; no tenant credentials or
+ * external network access are required.
+ *
+ * @see https://github.com/neomjs/neo/issues/11789
+ * @see ai/services/knowledge-base/helpers/TenantRepoIngestEnvelopeBuilder.mjs
+ * @see ai/services/knowledge-base/KnowledgeBaseIngestionService.mjs
+ */
+
+test.describe('TenantRepoIngestEnvelopeBuilder (#11789)', () => {
+    let root;
+
+    test.beforeEach(async () => {
+        root = await fs.mkdtemp(path.join(os.tmpdir(), 'neo-ingest-envelope-test-'));
+    });
+
+    test.afterEach(async () => {
+        await fs.remove(root);
+    });
+
+    async function git(args, cwd) {
+        const {stdout} = await execFileAsync('git', args, {cwd});
+        return stdout.trim();
+    }
+
+    async function createSourceRepo() {
+        const source = path.join(root, 'source');
+
+        await fs.ensureDir(source);
+        await git(['init', '--initial-branch=main'], source);
+        await fs.ensureDir(path.join(source, 'docs'));
+        await fs.writeFile(path.join(source, 'alpha.txt'), 'alpha v1\n');
+        await fs.writeFile(path.join(source, 'docs', 'guide.md'), '# Guide\n');
+        await fs.writeFile(path.join(source, 'remove-me.txt'), 'remove me\n');
+        await git(['add', '.'], source);
+        await git(['-c', 'user.name=Neo Test', '-c', 'user.email=test@example.com', 'commit', '-m', 'initial'], source);
+
+        return source;
+    }
+
+    async function commitSecondRevision(source) {
+        await fs.writeFile(path.join(source, 'alpha.txt'), 'alpha v2\n');
+        await fs.writeFile(path.join(source, 'beta.txt'), 'beta\n');
+        await fs.remove(path.join(source, 'remove-me.txt'));
+        await git(['add', '-A'], source);
+        await git(['-c', 'user.name=Neo Test', '-c', 'user.email=test@example.com', 'commit', '-m', 'second'], source);
+    }
+
+    async function createMirror(source) {
+        const options = {
+            cloneUrl  : source,
+            mirrorRoot: path.join(root, 'mirrors'),
+            repoSlug  : 'local/source',
+            tenantId  : 'tenant-a'
+        };
+
+        await cloneIfMissing(options);
+
+        return options;
+    }
+
+    test('builds a manifest-carrying full envelope when no baseline exists', async () => {
+        const source  = await createSourceRepo();
+        const options = await createMirror(source);
+        const newHead = await resolveHead({...options, ref: 'main'});
+        const envelope = await buildIngestEnvelope({
+            ...options,
+            newHead,
+            rootKind: 'bare-repo'
+        });
+
+        expect(envelope).toMatchObject({
+            tenantId    : 'tenant-a',
+            repoSlug    : 'local/source',
+            headRevision: newHead,
+            manifestSnapshot: {
+                repoSlug      : 'local/source',
+                pathsAfterPush: ['alpha.txt', 'docs/guide.md', 'remove-me.txt']
+            }
+        });
+        expect(envelope.baseRevision).toBeUndefined();
+        expect(envelope.deleted).toBeUndefined();
+        expect(envelope.files.map(file => file.sourcePath)).toEqual(['alpha.txt', 'docs/guide.md', 'remove-me.txt']);
+        expect(envelope.files.find(file => file.sourcePath === 'docs/guide.md')).toMatchObject({
+            repoSlug: 'local/source',
+            rootKind: 'bare-repo',
+            content: '# Guide\n'
+        });
+    });
+
+    test('builds a bounded delta envelope for linear history advances', async () => {
+        const source  = await createSourceRepo();
+        const options = await createMirror(source);
+        const baseRevision = await resolveHead({...options, ref: 'main'});
+
+        await commitSecondRevision(source);
+        await fetch(options);
+
+        const headRevision = await resolveHead({...options, ref: 'main'});
+        const envelope     = await TenantRepoIngestEnvelopeBuilder.buildIngestEnvelope({
+            ...options,
+            lastIngestedRev: baseRevision,
+            newHead        : headRevision,
+            parserId       : 'raw-text',
+            parserVersion  : 'test-parser-v1'
+        });
+
+        expect(envelope).toMatchObject({
+            tenantId    : 'tenant-a',
+            repoSlug    : 'local/source',
+            baseRevision,
+            headRevision,
+            deleted: [{sourcePath: 'remove-me.txt', repoSlug: 'local/source'}]
+        });
+        expect(envelope.manifestSnapshot).toBeUndefined();
+        expect(envelope.files.map(file => [file.sourcePath, file.content])).toEqual([
+            ['alpha.txt', 'alpha v2\n'],
+            ['beta.txt', 'beta\n']
+        ]);
+        expect(envelope.files[0]).toMatchObject({
+            parserId     : 'raw-text',
+            parserVersion: 'test-parser-v1'
+        });
+    });
+
+    test('falls back to a full manifest snapshot when history is non-linear', async () => {
+        const source  = await createSourceRepo();
+        const options = await createMirror(source);
+        const baseRevision = await resolveHead({...options, ref: 'main'});
+
+        await commitSecondRevision(source);
+        await fetch(options);
+
+        const headRevision = await resolveHead({...options, ref: 'main'});
+        const envelope     = await buildIngestEnvelope({
+            ...options,
+            lastIngestedRev: headRevision,
+            newHead        : baseRevision
+        });
+
+        expect(envelope.baseRevision).toBeUndefined();
+        expect(envelope.deleted).toBeUndefined();
+        expect(envelope.manifestSnapshot).toEqual({
+            repoSlug      : 'local/source',
+            pathsAfterPush: ['alpha.txt', 'docs/guide.md', 'remove-me.txt']
+        });
+        expect(envelope.files.map(file => file.sourcePath)).toEqual(['alpha.txt', 'docs/guide.md', 'remove-me.txt']);
+    });
+
+    test('throws stable errors for missing mirrors and missing head refs', async () => {
+        const source  = await createSourceRepo();
+        const options = await createMirror(source);
+
+        await expect(buildIngestEnvelope({
+            ...options,
+            tenantId: '../bad',
+            newHead : 'main'
+        })).rejects.toMatchObject({code: 'KB_INGEST_ENVELOPE_MIRROR_PATH_INVALID'});
+        await expect(buildIngestEnvelope({
+            ...options,
+            repoSlug: 'local/missing',
+            newHead : 'main'
+        })).rejects.toMatchObject({code: 'KB_INGEST_ENVELOPE_MIRROR_MISSING'});
+        await expect(buildIngestEnvelope({
+            ...options,
+            newHead: 'missing-ref'
+        })).rejects.toMatchObject({code: 'KB_INGEST_ENVELOPE_REF_NOT_FOUND'});
+    });
+});


### PR DESCRIPTION
Authored by GPT-5.5 (Codex Desktop). Session 019e5bac-15f3-7830-a59c-72772c757f9a.

FAIR-band: over-target [20/30] — taking this lane despite over-target because the operator surfaced a 40h external-team cloud deployment trial and #11789 is the high-ROI bridge from merged #11788 GitMirror to the #11790 scheduler lane.

Resolves #11789
Related: #11731

Adds `TenantRepoIngestEnvelopeBuilder`, the adapter that turns a persistent tenant GitMirror into the live `KnowledgeBaseIngestionService.ingestSourceFiles()` envelope. Linear history emits bounded raw-file deltas plus tombstones; bootstrap, missing-baseline, and non-linear history fall back to a full manifest snapshot so the KB can reconcile claimed live paths without re-pointing local `kbSync`.

Evidence: L2 (local Git fixture unit tests for mirror diff and ingest envelope contracts) → L2 required (server-side envelope construction is fully unit-verifiable without external tenant credentials). No residuals.

## Deltas from ticket
- Added rename-aware GitMirror diff handling so a renamed source becomes a new live path plus an old-path tombstone.
- Anchored the pull-ingestion envelope shape in the existing cloud deployment guide instead of creating a parallel guide tree.

## Slot Rationale
- Modified `learn/agentos/cloud-deployment/TenantIngestionModel.md`: existing conditional operator guide, disposition `keep`; trigger-frequency low-to-medium, failure-severity high for cloud tenant ingestion, enforceability high through direct helper and service references. This is not always-loaded substrate expansion; it prevents duplicate pull-ingestion docs by anchoring #11789 in the existing cloud-deployment model.

## Test Evidence
- `npm run test-unit -- test/playwright/unit/ai/services/knowledge-base/GitMirror.spec.mjs test/playwright/unit/ai/services/knowledge-base/TenantRepoIngestEnvelopeBuilder.spec.mjs` → 10 passed.
- `git diff --check` → passed.
- `git diff --cached --check` → passed before commit.
- Pre-push freshness: `merge-base HEAD origin/dev == origin/dev`; outgoing log contained only `cdd96cf094d2 feat(kb): add tenant repo ingest envelope builder (#11789)`.

## Post-Merge Validation
- [ ] #11790 tenant-repo-sync scheduler can consume `buildIngestEnvelope()` for its first integration path.
- [ ] Cloud deployment trial can validate pull-based tenant ingestion against a deployment-mounted `tenant-repo-mirrors` volume.

## Commit
- `cdd96cf094d2` — `feat(kb): add tenant repo ingest envelope builder (#11789)`