### PR TITLE
feat(deploy): add orchestrator + ingress healthchecks for trial visibility (#11937)

### DIFF
--- a/ai/deploy/docker-compose.yml
+++ b/ai/deploy/docker-compose.yml
@@ -207,13 +207,12 @@ services:
       - neo-mcp-network
     profiles:
       - ingress
-    # TCP-port responsiveness on 443 (caddy's only public surface). The
-    # `--no-check-certificate` is necessary because caddy issues its internal
-    # ACME cert against the configured public hostname, not localhost. Without
-    # an explicit healthcheck, operators can't distinguish "caddy crashed" from
-    # "no requests arriving" during the trial window (#11937).
+    # TCP-port responsiveness on 443 (caddy's only public surface). Direct nc -z
+    # exit-status check — caddy:2-alpine includes BusyBox nc; exit 0 = port accepts
+    # TCP connection, non-zero = caddy crashed. Avoids the wget --quiet + grep
+    # silent-success-empty-output failure mode (#11939 cycle-1 review per @neo-gpt).
     healthcheck:
-      test: ["CMD-SHELL", "wget --no-check-certificate --quiet --tries=1 --spider https://127.0.0.1/ 2>&1 | grep -qE '(HTTP|Connecting|TLS)' || exit 1"]
+      test: ["CMD-SHELL", "nc -z 127.0.0.1 443"]
       interval: 30s
       timeout: 5s
       retries: 3

--- a/ai/deploy/docker-compose.yml
+++ b/ai/deploy/docker-compose.yml
@@ -170,6 +170,17 @@ services:
       - neo-mcp-network
     profiles:
       - cloud
+    # Liveness verified via TaskStateService's persistent state file (#11937).
+    # TaskStateService writes JSON state on every task lifecycle transition;
+    # mtime within 10 minutes (≫ swarm-heartbeat + summary cadences with safety
+    # margin) = orchestrator is alive and polling. 90s start_period covers the
+    # first-poll latency on cold container boot.
+    healthcheck:
+      test: ["CMD-SHELL", "node -e \"const fs=require('fs');const f=(process.env.NEO_AI_ORCHESTRATOR_DIR||'/app/.neo-ai-data/orchestrator-daemon')+'/state.json';try{const m=fs.statSync(f).mtimeMs;process.exit(Date.now()-m<600000?0:1)}catch(e){process.exit(1)}\""]
+      interval: 60s
+      timeout: 5s
+      retries: 3
+      start_period: 90s
     deploy:
       resources:
         limits:
@@ -196,6 +207,17 @@ services:
       - neo-mcp-network
     profiles:
       - ingress
+    # TCP-port responsiveness on 443 (caddy's only public surface). The
+    # `--no-check-certificate` is necessary because caddy issues its internal
+    # ACME cert against the configured public hostname, not localhost. Without
+    # an explicit healthcheck, operators can't distinguish "caddy crashed" from
+    # "no requests arriving" during the trial window (#11937).
+    healthcheck:
+      test: ["CMD-SHELL", "wget --no-check-certificate --quiet --tries=1 --spider https://127.0.0.1/ 2>&1 | grep -qE '(HTTP|Connecting|TLS)' || exit 1"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 30s
     deploy:
       resources:
         limits:


### PR DESCRIPTION
Resolves #11937

Authored by Claude Opus 4.7 (Claude Code, 1M context). Session 5572d9a5-558d-4bea-b416-e31496c289c4.

FAIR-band: over-target [10/30] — operator-direction (40h cloud-deployment trial sprint; @tobiu delegated lane self-selection after GPT took #11789 envelope builder). Live verifier query: GPT 20 / Claude 10 / Gemini 0 over last 30 merged PRs.

Evidence: L1 (static YAML structure validation via `yaml` library + manual healthcheck-script semantic review against existing chroma/kb/mc healthcheck patterns in same file) → L3 nominally required (AC4 = live `docker compose up` validation that healthchecks report `(healthy)` post-start_period). Residual: AC4 deferred to operator pre-trial smoke test [#11937].

Adds healthchecks to `orchestrator` (cloud profile) + `ingress` (caddy reverse proxy) — the 2 of 6 docker-compose services that lacked operator-visibility surface before this PR.

## Deltas from ticket (if any)

**Ingress healthcheck command** — ticket prescribed BusyBox `wget --no-check-certificate --spider` + grep for `HTTP\|Connecting\|TLS`. Final implementation uses `nc -z 127.0.0.1 443` (TCP-level probe) per @neo-gpt #11939 cycle-1 RA: the grep approach could fail-closed when wget exited 0 with no stderr (silent-success-empty-output failure mode). `nc -z` is unambiguous + present in caddy:2-alpine BusyBox. Orchestrator healthcheck follows ticket verbatim. Per-healthcheck rationale + interval-vs-cadence trade-offs documented inline as YAML comments.

## Contract Ledger

| Surface | Source of Authority | Contract Kept | Evidence |
|---|---|---|---|
| `orchestrator` service `healthcheck` | This ticket | State-file freshness check via `node -e fs.statSync(...).mtimeMs`. Defaults `NEO_AI_ORCHESTRATOR_DIR` to `/app/.neo-ai-data/orchestrator-daemon` (matches cloud-profile volume mount). 600000ms (10 min) tolerance > swarm-heartbeat + summary cadences with safety margin. | TaskStateService confirmed to write state on every lifecycle transition (`ai/daemons/orchestrator/services/TaskStateService.mjs:123`). |
| `ingress` service `healthcheck` | This ticket (cycle-1 amendment) | TCP-443 responsiveness via BusyBox `nc -z 127.0.0.1 443` (CMD-SHELL form). TCP-layer probe — no certificate-handshake or HTTP-response-body parsing required, so the auto-issued internal cert hostname-mismatch is not part of the contract. `nc` exits 0 only on successful TCP connect; no silent-success-empty-output failure mode. | caddy:2-alpine derives from Alpine Linux; BusyBox includes `nc` by default. |

No public-API change. No service-restart required (Docker re-evaluates healthchecks on the next `docker compose up` cycle).

## Test Evidence

- `node -e \"yaml.parse(...)\"` round-trip: all 6 services parse cleanly with valid `healthcheck` blocks
- Manual semantic review against the 4 existing healthcheck patterns in the same file: consistent indentation, valid CMD-SHELL syntax, interval/timeout/retries/start_period structure correct
- `grep -A 6 \"healthcheck:\"` post-edit shows 6 healthcheck blocks (chroma + kb-server + mc-server + orchestrator NEW + ingress NEW + local-model)
- **Note**: `docker compose config` validation was NOT run because docker is not available on the review host. Operator can verify pre-trial via `docker compose config` + `docker compose --profile cloud --profile ingress up` followed by `docker ps` showing `(healthy)` for both services after the respective `start_period` elapses.

## Post-Merge Validation

- [ ] **AC4 (deferred)** — operator pre-trial smoke test: `docker compose --profile cloud --profile ingress up`; observe both services report `(healthy)` in `docker ps` after the start_period elapses (90s for orchestrator, 30s for ingress). If either fails, the healthcheck command can be tuned via small follow-up PR without touching service config.
- [ ] During the trial: confirm `docker stats` + `docker ps` show stable `(healthy)` status for both services across the trial window. Failing healthchecks would surface immediately via `docker events --filter event=health_status`.

## Commits (if multi-commit)

- `fecc964f1` — feat(deploy): add orchestrator + ingress healthchecks for trial visibility
- `1e578d06f` — fix(deploy): ingress healthcheck via nc -z (no silent-success-empty-output) [resolves #11939 cycle-1 RA on healthcheck command]

## Acceptance Criteria

- [x] **AC1** — orchestrator service has healthcheck verifying state file mtime within 10min tolerance
- [x] **AC2** — ingress service has healthcheck verifying caddy TCP-443 responsiveness
- [x] **AC3 (partial)** — YAML structure parses cleanly via `yaml` library (all 6 services enumerated with healthcheck blocks). `docker compose config` schema validation NOT run on review host (no local docker); deferred to operator pre-trial validation.
- [ ] **AC4** — Local `docker compose --profile cloud --profile ingress up` smoke test → **deferred to operator pre-trial validation** (no local docker on review host)

## Deltas after cycle-1 review

@neo-gpt #11939 cycle-1 review caught 3 RAs:
1. **Ingress healthcheck silent-success bug**: original `wget --quiet --spider | grep` could fail-closed if wget exited 0 with no stderr output. Fixed in commit `1e578d06f` — direct `nc -z 127.0.0.1 443`.
2. **AC3 accounting**: marked AC3 as partial (YAML parse via `yaml` library was run; `docker compose config` was not — no local docker on review host).
3. **FAIR-band drift**: refreshed live count (10/30 vs my earlier 14/30 — verifier query post-recent-merge cohort).

## Avoided traps

- HTTP endpoint on orchestrator: state-file is canonical liveness signal; introducing HTTP server would balloon scope
- caddy admin API (:2019) check: admin port internal-only by default; TCP-443 `nc -z` sufficient + no extra surface
- Tight 10s interval matching other services: lane cadences are minute-scale; 60s matches actual lane semantics + reduces healthcheck noise

## Empirical anchor

Cloud-deployment trial readiness review 2026-05-24. Operator framing: "in theory we are there → many new deployment guides, orchestrator enhancements, docker, integration tests." This PR addresses the docker substrate slice — orchestrator + ingress healthcheck gap was visible on direct inspection of `docker-compose.yml`.

