### PR TITLE
chore(ai): clean kb mcp source comments (#11923)

### DIFF
--- a/ai/mcp/server/knowledge-base/config.template.mjs
+++ b/ai/mcp/server/knowledge-base/config.template.mjs
@@ -67,8 +67,8 @@ const defaultConfig = {
     /**
      * Port the MCP server's HTTP/SSE transport listens on (only used when `transport === 'sse'`).
      *
-     * Operator env var: `MCP_HTTP_PORT`. The legacy `SSE_PORT` env var remains readable for one
-     * deprecation window per #10808; resolver emits a warning if both are set with different values.
+     * Operator env var: `MCP_HTTP_PORT`. The deprecated `SSE_PORT` alias remains readable during
+     * the migration window; resolver emits a warning if both are set with different values.
      * @type {number}
      */
     mcpHttpPort: 3000,
@@ -127,7 +127,7 @@ const defaultConfig = {
     /**
      * The hostname of the ChromaDB server for the knowledge base.
      *
-     * Operator env var: `NEO_CHROMA_HOST` (#10808). For shared cloud deployments where KB hosts the
+     * Operator env var: `NEO_CHROMA_HOST`. For shared cloud deployments where KB hosts the
      * unified Chroma instance for both KB + MC, this points at the shared cloud-hosted Chroma.
      * @type {string}
      */
@@ -135,7 +135,7 @@ const defaultConfig = {
     /**
      * The port the ChromaDB server for the knowledge base is listening on.
      *
-     * Operator env var: `NEO_CHROMA_PORT` (#10808). Invalid values (non-integer / out-of-range)
+     * Operator env var: `NEO_CHROMA_PORT`. Invalid values (non-integer / out-of-range)
      * fall back to the default with a console warning per the resolver validity contract.
      * @type {number}
      */
@@ -189,7 +189,7 @@ const defaultConfig = {
      */
     hierarchyPath: path.resolve(neoRootDir, 'docs/output/class-hierarchy.json'),
     /**
-     * Directory for the always-on KB server diagnostic log files (#10576). The KB server's
+     * Directory for the always-on KB server diagnostic log files. The KB server's
      * `logger.mjs` writes daily-rotated entries here regardless of `debug`, so long-running
      * operations (sync, embedding loops, ChromaDB lifecycle) leave a tail-able diagnostic
      * trail observable from the host shell. Default: `<neoRootDir>/.neo-ai-data/logs/`.
@@ -216,34 +216,34 @@ const defaultConfig = {
      */
     collectionName: 'neo-knowledge-base',
     /**
-     * Phase 0/1B (#11658): when `true` (default), the SourceRegistry auto-registers Neo's
+     * When `true` (default), the SourceRegistry auto-registers Neo's
      * 10 curated default Source classes. Cloud deployments that ingest only tenant content
      * can set `false` to skip Neo's curated sources entirely.
      * @type {boolean}
      */
     useDefaultSources: true,
     /**
-     * Phase 0/1B (#11658): when `true` (default), the SourceRegistry auto-registers Neo's
-     * built-in Parser classes (none ship in Phase 0/1B; populated in Phase 2 / Phase 3).
+     * When `true` (default), the SourceRegistry auto-registers Neo's
+     * built-in Parser classes. The default registry may be empty until parser modules are added.
      * @type {boolean}
      */
     useDefaultParsers: true,
     /**
-     * Phase 0/1B (#11658): declarative tenant-supplied Source registration.
+     * Declarative tenant-supplied Source registration.
      * Each entry: `{SourceClass, sourceName?}`.
      * @type {Array<{SourceClass: Object, sourceName?: string}>}
      */
     customSources: [],
     /**
-     * Phase 0/1B (#11658): declarative tenant-supplied Parser registration.
+     * Declarative tenant-supplied Parser registration.
      * Each entry: `{ParserClass, parserId?}`.
      * @type {Array<{ParserClass: Object, parserId?: string}>}
      */
     customParsers: [],
     /**
-     * Phase 0/1B-β (#11660): per-source path overrides keyed by Source-class registry name.
+     * Per-source path overrides keyed by Source-class registry name.
      * Empty entries or missing keys fall through to each Source class's hardcoded fallback
-     * (preserves byte-equivalence with pre-#11660 behavior). Shape varies per Source class —
+     * (preserves byte-equivalence with existing deployment behavior). Shape varies per Source class —
      * each interprets its own entry shape (string / string-array / path→type object).
      * @type {Object<string,string|string[]|Object<string,string>>}
      */
@@ -273,7 +273,7 @@ const defaultConfig = {
      * namespace visible across every tenant.
      *
      * Write side: `VectorService.embed()` stamps this when no authenticated ingestion context
-     * is supplied. Read side (#11632): `QueryService.queryDocuments` and `DocumentService`
+     * is supplied. Read side: `QueryService.queryDocuments` and `DocumentService`
      * include it in the `where: {tenantId: {$in: [<requester>, <this>]}}` filter so every tenant
      * additionally retrieves the curated corpus. Cloud ingestion paths override the write-side
      * value with server-derived tenant context; client-supplied chunk metadata is never authoritative.
@@ -291,8 +291,8 @@ const defaultConfig = {
     /**
      * @summary Default read visibility for embedded Knowledge Base chunks.
      *
-     * Phase 0/1C writes the authoritative value; Phase 2/3 read paths consume it for
-     * tenant-aware filtering.
+     * Write paths stamp the authoritative value; tenant-aware read paths consume it for
+     * filtering.
      * @type {string}
      */
     defaultVisibility: 'team',
@@ -316,7 +316,7 @@ const defaultConfig = {
      */
     batchSize: 50,
     /**
-     * Work-volume gate for MCP-callable `manage_knowledge_base sync` (#10572): when
+     * Work-volume gate for MCP-callable `manage_knowledge_base sync`: when
      * the post-delta `chunksToProcess.length` exceeds this value AND the call originates
      * via MCP tool dispatch, `VectorService.embed` refuses synchronous execution and
      * returns a `KB_SYNC_VOLUME_EXCEEDED` error pointing the operator at the CLI path
@@ -393,10 +393,10 @@ class Config extends BaseConfig {
     envBindings = envBindings;
 
     /**
-     * Applies legacy environment variable fallbacks
+     * Applies deprecated environment variable fallbacks.
      */
     applyLegacyEnv() {
-        // Handle legacy deprecation fallbacks explicitly
+        // Keep alias handling explicit so deprecation warnings stay local to config resolution.
         if (process.env.SSE_PORT && !process.env.MCP_HTTP_PORT) {
             console.warn('[Config] Deprecation warning: SSE_PORT is deprecated. Please use MCP_HTTP_PORT.');
             const legacyPort = Env.parsePort('SSE_PORT');

--- a/ai/mcp/server/knowledge-base/toolService.mjs
+++ b/ai/mcp/server/knowledge-base/toolService.mjs
@@ -82,8 +82,7 @@ const listTransportVisibleTools = ({cursor=0, limit} = {}) => {
 };
 
 /**
- * @summary MCP facade for `KnowledgeBaseIngestionService.ingestSourceFiles` — applies the
- * #10572 work-volume gate before dispatch.
+ * @summary MCP facade for `KnowledgeBaseIngestionService.ingestSourceFiles`.
  *
  * An agent-initiated `ingest_source_files` push embeds synchronously; an oversized batch
  * would freeze the calling agent. This facade counts the batch volume up-front and, when
@@ -96,8 +95,8 @@ const listTransportVisibleTools = ({cursor=0, limit} = {}) => {
  * guard, not an exact post-parse count.
  *
  * The gate lives at the MCP facade (not threaded into the service) because the batch
- * volume is knowable from the input alone, and #11634 keeps service-layer ingestion
- * logic (Phase 2A `KnowledgeBaseIngestionService`) untouched.
+ * volume is knowable from the input alone, keeping service-layer ingestion logic
+ * unchanged and transport policy localized to the MCP facade.
  *
  * @param {Object}    args            The `ingest_source_files` tool envelope.
  * @param {String}   [args.tenantId]  Authenticated tenant id.
@@ -138,11 +137,11 @@ const serviceMapping = {
     list_documents       : DocumentService         .listDocuments      .bind(DocumentService),
     list_agent_faqs      : KBRecorderService       .listAgentFaqs      .bind(KBRecorderService),
     manage_database      : DatabaseLifecycleService.manageDatabase     .bind(DatabaseLifecycleService),
-    // #10572: dispatch wrapper marks `viaMcp: true` so VectorService.embed can apply the
-    // work-volume gate. CLI invocations (via `npm run ai:sync-kb`) call DatabaseService.syncDatabase
-    // directly without `viaMcp`, bypassing the gate — explicit opt-in to long-running work.
+    // MCP dispatch marks `viaMcp: true` so VectorService.embed can apply the synchronous
+    // work-volume gate. CLI invocations call DatabaseService.syncDatabase directly without
+    // `viaMcp`, preserving explicit operator opt-in to long-running work.
     manage_knowledge_base: args => DatabaseService.manageKnowledgeBase({...args, viaMcp: true}),
-    // #11634: facade applies the #10572 work-volume gate before dispatch — see ingestSourceFilesViaMcp.
+    // Remote tenant ingestion applies the MCP work-volume gate before service dispatch.
     ingest_source_files  : ingestSourceFilesViaMcp,
     query_documents      : QueryService            .queryDocuments     .bind(QueryService)
 };


### PR DESCRIPTION
Resolves #11923
Related: #11912, #11931, #11932, #11933, #11936

Authored by GPT-5 (Codex Desktop). Session e5a3acc3-d261-4ebf-96b1-4053ab0eafdf.

FAIR-band: over-target [21/30] — taking this lane despite over-target because #11923 is already assigned to @neo-gpt and #11936 left this exact MCP Knowledge Base config/tooling residual as the final closeout slice.

Evidence: L1 (static source-comment diagnostic plus git diff hygiene) -> L1 required (comment/JSDoc-only cleanup). No runtime behavior changed.

Final #11923 closeout for the Knowledge Base MCP server comment batch. Prior #11923 PRs cleaned KB services (#11931), graph services (#11932), graph core (#11933), and ingestion services (#11936). This PR cleans the remaining tracked MCP Knowledge Base config/tooling comments that still encoded ticket IDs and phase chronology instead of stable operator contracts.

## Changes

- `ai/mcp/server/knowledge-base/config.template.mjs`
  - Rewrites environment-variable, SourceRegistry, tenant defaults, and work-volume-gate comments from ticket/phase anchors into durable config contracts.
  - Keeps deprecation semantics for `SSE_PORT` while removing historical issue-number phrasing.
- `ai/mcp/server/knowledge-base/toolService.mjs`
  - Rewrites the MCP ingest facade and `viaMcp` dispatch comments around the synchronous work-volume gate.
  - Keeps service dispatch and returned error payloads unchanged.

## Deltas from ticket

This is the final #11923 close-target PR after the prior grouped batches. It intentionally touches only tracked files. The gitignored local `ai/mcp/server/knowledge-base/config.mjs` was not committed and requires no operator sync because no config keys, shapes, or runtime defaults changed.

The unchanged runtime string `a tenant-scoped bulk ingestion facade is planned (Phase 2C).` remains out of scope: it is part of a returned MCP payload, not source-comment/JSDoc archaeology.

## MCP config template change guidance

- Changed config keys: none.
- Local `config.mjs` manual update after merge: none.
- Harness restart: unnecessary.
- Live MCP behavior in peer clones: unchanged; normal PR review notification is sufficient.

## Test Evidence

- Focused source-comment diff diagnostic on tracked MCP KB files: 19 removed ticket/phase/predecessor anchors; 0 added anchors.
- `git diff --check origin/dev...HEAD` -> pass.
- `git diff --cached --check` -> pass before commit.
- Unit tests not run: comment/JSDoc-only diff with no executable behavior changes.

## Post-Merge Validation

- [ ] Confirm #11923 auto-closes after merge.
- [ ] Parent #11912 remains open until all grouped source-comment cleanup subissues are reconciled through the epic closeout matrix.

## Commit

- `52e00bd6a` — `chore(ai): clean kb mcp source comments (#11923)`
