### PR TITLE
chore(ai): clean github-workflow source comments (#11924)

### DIFF
--- a/ai/mcp/server/github-workflow/toolService.mjs
+++ b/ai/mcp/server/github-workflow/toolService.mjs
@@ -20,7 +20,7 @@ const __dirname       = path.dirname(__filename);
 const openApiFilePath = path.join(__dirname, 'openapi.yaml');
 
 /**
- * #11145 — Default branch detector. Exec's `git branch --show-current` against the MCP
+ * Default branch detector. Exec's `git branch --show-current` against the MCP
  * server's projectRoot. Returns the trimmed branch name (or empty string on detached HEAD).
  * Throws on git execution failure.
  *
@@ -51,15 +51,15 @@ async function defaultBranchDetector() {
 }
 
 /**
- * #11145 — Wraps a SyncService method with a dev-branch-only guard at the tool boundary.
+ * Wraps a SyncService method with a dev-branch-only guard at the tool boundary.
  *
  * Why tool-boundary, not library: `SyncService` callers include the daemon path
  * (Orchestrator's PrimaryRepoSyncService, scheduled context, spawned in canonical-on-dev)
  * and build-scripts (`buildScripts/release/publish.mjs`, build-context). Both are legit.
  * Only the agent-callable MCP tool surface needs rejection — that's the violation vector.
  *
- * Description-as-policy on the OpenAPI tool was empirically insufficient: 5+/day @neo-
- * gemini-3-1-pro violations + the 2026-05-10 PR #11143 stale-branch + chore-sync race.
+ * Description-as-policy on the OpenAPI tool was empirically insufficient: repeated off-dev
+ * sync attempts showed that the tool boundary needs executable branch enforcement.
  *
  * Branch-detector is injectable for testability; default uses `git branch --show-current`.
  *
@@ -92,20 +92,20 @@ function buildDevBranchGuard(delegate, getBranch = defaultBranchDetector) {
 const syncAllOnDevOnly = buildDevBranchGuard(SyncService.runFullSync.bind(SyncService));
 
 /**
- * #10702 — `get_conversation` dispatch router. The tool serves BOTH pull requests and
+ * `get_conversation` dispatch router. The tool serves BOTH pull requests and
  * issues; it routes to the matching service by which identifier the caller supplied.
  * Rejects ambiguous (both ids) and empty (neither id) argument shapes with structured
  * errors so the failure is legible rather than a downstream null-deref.
  *
- * Exported for unit-test access (#10702), mirroring the `buildDevBranchGuard` /
+ * Exported for unit-test access, mirroring the `buildDevBranchGuard` /
  * `syncAllOnDevOnly` test-surface precedent below.
  *
  * @param {Object|Number} options `pr_number` XOR `issue_number`, plus optional selectors.
- *                                A bare number is the legacy positional PR form (pre-#10702).
+ *                                A bare number is the legacy positional PR form.
  * @returns {Promise<Object>} Conversation data or a structured error.
  */
 async function getConversationRouter(options) {
-    // Legacy positional number form predates #10702 and is always a pull request.
+    // Legacy positional number form is always a pull request.
     if (typeof options === 'number') {
         return PullRequestService.getConversation(options);
     }
@@ -160,7 +160,7 @@ const serviceMapping = {
     update_issue_relationship: IssueService      .updateIssueRelationship.bind(IssueService)
 };
 
-// Exported for unit-test access (#11145). `buildDevBranchGuard` accepts injected
+// Exported for unit-test access. `buildDevBranchGuard` accepts injected
 // `delegate` + `getBranch` for fixture-driven testing without spawning real `git`.
 export {buildDevBranchGuard, getConversationRouter, syncAllOnDevOnly};
 

--- a/ai/mcp/server/shared/helpers/DeploymentConfig.mjs
+++ b/ai/mcp/server/shared/helpers/DeploymentConfig.mjs
@@ -1,8 +1,8 @@
 /**
  * @summary Resolves the MCP server HTTP listening port.
  *
- * Pattern mirrors {@link Neo.ai.mcp.server.memory-core.helpers.EmbeddingProviderConfig#resolveEmbeddingProvider}
- * from PR #10810 — pure, testable, dependency-free; consumers (`Server.mjs` config templates)
+ * Pattern mirrors {@link Neo.ai.mcp.server.memory-core.helpers.EmbeddingProviderConfig#resolveEmbeddingProvider}:
+ * pure, testable, dependency-free; consumers (`Server.mjs` config templates)
  * call it once at config-load time.
  *
  * @param {Object}   options
@@ -32,8 +32,7 @@ export function resolveMcpHttpPort({env = process.env, warn = console.warn, defa
 /**
  * @summary Resolves the ChromaDB host.
  *
- * Per #10808 operator-facing env-var ergonomics: `NEO_CHROMA_HOST` is the canonical
- * operator-set env var (used by unified Chroma config).
+ * `NEO_CHROMA_HOST` is the canonical operator-set env var used by unified Chroma config.
  *
  * Pure function: takes env; returns resolved host string.
  *

--- a/ai/mcp/server/shared/services/AuthMiddleware.mjs
+++ b/ai/mcp/server/shared/services/AuthMiddleware.mjs
@@ -3,7 +3,7 @@ import Base from '../../../../../src/core/Base.mjs';
 /**
  * Set of argument keys that an MCP tool caller MUST NOT supply — the server always derives
  * these from the active `RequestContextService` (OIDC Bearer token for SSE, stdio env-var /
- * gh-CLI resolution per ticket #10145). Client-supplied values would let a Gemini-harness
+ * gh-CLI resolution). Client-supplied values would let a Gemini-harness
  * session forge a write attributed to `@neo-opus-4-7`, etc.
  *
  * **Scope note:** `recipient` / `to` fields are legitimate (destination address, not claim-of-
@@ -34,7 +34,7 @@ const IDENTITY_OVERRIDE_KEYS = new Set([
  *
  * **Present-day behavior:** no current MCP tool schema exposes any of the forbidden keys, so
  * this middleware is a no-op on every live tool call. It exists as **defense-in-depth** for
- * upcoming additions — particularly Mailbox (#10139) which adds `from` fields where the spoof
+ * upcoming additions — particularly Mailbox tooling, which adds `from` fields where the spoof
  * surface becomes real. Shipping the guard before the surface is the inverse of "patch after
  * incident" hygiene.
  *

--- a/ai/mcp/server/shared/services/AuthService.mjs
+++ b/ai/mcp/server/shared/services/AuthService.mjs
@@ -14,7 +14,7 @@ import Base from '../../../../../src/core/Base.mjs';
  *    to identify the required authorization server.
  * - **Audience Enforcement:** Strictly validates that the `aud` (Audience) claim in the
  *   Bearer token matches the MCP server's public URL to prevent passthrough attacks.
- * - **Identity Propagation (Epic #9999, ticket #10000):** The `verifyAccessToken` verifier
+ * - **Identity Propagation:** The `verifyAccessToken` verifier
  *   extracts `preferred_username` (or `sub` as fallback) from the introspection response and
  *   surfaces it as `userId` on the auth context. Downstream request handlers read this via
  *   `RequestContextService.getUserId()` to tag ChromaDB writes and filter reads per tenant,
@@ -158,7 +158,7 @@ class AuthService extends Base {
                 }
 
                 // Extract identity claims from the introspection response for downstream
-                // tenant isolation (ticket #10000). `preferred_username` is Keycloak / GitLab /
+                // tenant isolation. `preferred_username` is Keycloak / GitLab /
                 // many OIDC providers' convention for the human-readable login name; `sub` is the
                 // OIDC-spec-mandated subject identifier and the reliable fallback. Providers may
                 // omit `preferred_username` (e.g. machine-to-machine client credential flows),
@@ -174,7 +174,7 @@ class AuthService extends Base {
                     expiresAt: data.exp,
                     userId,
                     username,
-                    // Provenance tag consumed by `RequestContextService.getSource()` (#10145).
+                    // Provenance tag consumed by `RequestContextService.getSource()`.
                     // Distinguishes OIDC-derived identity from stdio env-var / gh-CLI paths.
                     source   : 'oidc'
                 };

--- a/ai/mcp/server/shared/services/DestructiveOperationGuard.mjs
+++ b/ai/mcp/server/shared/services/DestructiveOperationGuard.mjs
@@ -77,7 +77,7 @@ export class CanonicalCollectionGuardError extends Error {
  * Bypass paths (either is sufficient):
  *
  * 1. `process.env.UNIT_TEST_MODE === 'true'` — the test harness is loaded; `aiConfig.collections.*`
- *    resolves to process-isolated `test-*` prefixes per `config.mjs:228-229`, and the test
+ *    resolves to process-isolated `test-*` prefixes, and the test
  *    cleanup helpers are responsible for their own substrate.
  * 2. `confirmation === DESTRUCTIVE_PRODUCTION_CONFIRMATION` — operator-acknowledged production
  *    recovery (e.g., `restore.mjs --mode replace` already gates via `DestructiveOperationGuard`
@@ -98,9 +98,8 @@ export class CanonicalCollectionGuardError extends Error {
  *
  * **Why the gate is uniform (not canonical-set-gated):**
  *
- * Per @neo-gpt's PR #11656 Cycle 1 review (commentId PRR_kwDODSospM8AAAABAYwPjg, Required
- * Action 1) — a guard that returns early for non-canonical names leaves the "non-canonical
- * name as bypass surface" open. A production caller could invoke
+ * A guard that returns early for non-canonical names leaves the "non-canonical name as bypass
+ * surface" open. A production caller could invoke
  * `deleteCollection({name: 'arbitrary-collection'})` and bypass the substrate-level invariant
  * entirely. The uniform-gate shape forces every destructive caller to thread either the test
  * env or the explicit confirmation token, regardless of collection name.

--- a/ai/mcp/server/shared/services/RequestContextService.mjs
+++ b/ai/mcp/server/shared/services/RequestContextService.mjs
@@ -7,15 +7,13 @@ import Base from '../../../../../src/core/Base.mjs';
  *
  * Reads in tenant-aware mode use `where: {$or: [{userId: <current>}, {userId: SHARED_USER_ID}]}`,
  * granting every authenticated tenant access to their own data PLUS the shared baseline.
- * The migration runner (`ai/scripts/migrations/backfillChromaSharedUserId.mjs`, #10556) tags any
- * pre-#10145 ChromaDB records lacking a `userId` key with this sentinel so the additive
+ * The migration runner (`ai/scripts/migrations/backfillChromaSharedUserId.mjs`) tags legacy
+ * ChromaDB records lacking a `userId` key with this sentinel so the additive
  * read filter can return them. New raw-memory writes tag with the resolved per-tenant userId;
  * session summaries involving named core swarm maintainers intentionally use `SHARED_USER_ID`
- * so the compressed navigation artifact remains visible to every named peer (#11181).
+ * so the compressed navigation artifact remains visible to every named peer.
  *
  * @member {String}
- * @see #10556 — chromadb metadata backfill that introduces this sentinel
- * @see #10017 — adjacent SQLite Native Edge Graph migration (different storage layer, gradual)
  */
 export const SHARED_USER_ID = 'shared';
 
@@ -29,7 +27,6 @@ export const SHARED_USER_ID = 'shared';
  * tenant-aware summary reads.
  *
  * @member {String[]}
- * @see #11181 — restored summary visibility regression
  */
 export const CORE_SWARM_USER_IDS = Object.freeze([
     'neo-opus-4-7',
@@ -40,7 +37,6 @@ export const CORE_SWARM_USER_IDS = Object.freeze([
 /**
  * @summary AgentIdentity node-id form for {@link CORE_SWARM_USER_IDS}.
  * @member {String[]}
- * @see #11181
  */
 export const CORE_SWARM_AGENT_IDS = Object.freeze(
     CORE_SWARM_USER_IDS.map(userId => `@${userId}`)
@@ -50,7 +46,7 @@ export const CORE_SWARM_AGENT_IDS = Object.freeze(
  * @summary Strips the `@`-prefix from AgentIdentity-style identifiers so userId comparisons
  * are always canonical-form.
  *
- * AgentIdentity graph node IDs use the form `@neo-opus-4-7` (per #10144 seed convention),
+ * AgentIdentity graph node IDs use the form `@neo-opus-4-7`,
  * but ChromaDB metadata `userId` values are stored without the prefix (`neo-opus-4-7`).
  * Without a normalization boundary, code paths that mix the two forms produce silent
  * self-filtering — a write tags `userId: 'neo-opus-4-7'` but a read filter that uses
@@ -78,7 +74,6 @@ export function normalizeUserId(input) {
  *
  * @param {String|String[]|null|undefined} input Agent list to normalize.
  * @returns {String[]} Canonical userIds with empty entries removed.
- * @see #11181
  */
 export function parseAgentList(input) {
     if (input == null) return [];
@@ -101,7 +96,6 @@ export function parseAgentList(input) {
  *
  * @param {String|String[]|null|undefined} participatingAgents Summary metadata participant list.
  * @returns {Boolean}
- * @see #11181
  */
 export function hasCoreSwarmParticipant(participatingAgents) {
     const participants = new Set(parseAgentList(participatingAgents));
@@ -121,7 +115,6 @@ export function hasCoreSwarmParticipant(participatingAgents) {
  * @param {String|null|undefined} input.userId Active request userId.
  * @param {String|String[]|null|undefined} input.participatingAgents Summary participant metadata.
  * @returns {String|undefined} `shared`, a normalized userId, or undefined for single-tenant fallthrough.
- * @see #11181
  */
 export function resolveSummaryVisibilityUserId({userId, participatingAgents} = {}) {
     if (hasCoreSwarmParticipant(participatingAgents)) {
@@ -141,20 +134,20 @@ export function resolveSummaryVisibilityUserId({userId, participatingAgents} = {
  * any of the primitive leaking into their method signatures.
  *
  * **Module-level exports:**
- * - {@link SHARED_USER_ID} — sentinel value for legacy/commons records (#10556)
- * - {@link normalizeUserId} — `@`-prefix stripping boundary helper (#10556)
- * - {@link resolveSummaryVisibilityUserId} — summary visibility resolver for core-swarm artifacts (#11181)
+ * - {@link SHARED_USER_ID} — sentinel value for legacy/commons records
+ * - {@link normalizeUserId} — `@`-prefix stripping boundary helper
+ * - {@link resolveSummaryVisibilityUserId} — summary visibility resolver for core-swarm artifacts
  *
- * **Identity flow (Epic #9999, sub-epic #10016, tickets #10000 + #10145):**
+ * **Identity flow:**
  *
- * 1. **SSE transport (#10000):** `AuthService.verifyAccessToken` validates the incoming Bearer
+ * 1. **SSE transport:** `AuthService.verifyAccessToken` validates the incoming Bearer
  *    token via OIDC introspection and returns `{userId, username, ...}` on the auth context,
  *    extracted from the introspection response's `preferred_username` / `sub` / `name` /
  *    `email` claims. `TransportService` wraps each `/mcp` request with
  *    `RequestContextService.run({userId, username, agentIdentityNodeId, source: 'oidc'}, ...)`.
- * 2. **Stdio transport (#10145):** `StdioIdentityResolver` resolves identity at server boot
+ * 2. **Stdio transport:** `StdioIdentityResolver` resolves identity at server boot
  *    via `NEO_AGENT_IDENTITY` env-var or `gh api user` CLI fallback. The memory-core `Server`
- *    looks up the matching AgentIdentity graph node (per ticket #10144), then wraps every
+ *    looks up the matching AgentIdentity graph node, then wraps every
  *    `CallToolRequestSchema` dispatch with `RequestContextService.run({userId, username,
  *    agentIdentityNodeId, source: 'env-var' | 'gh-cli'}, ...)`. Stdio now reaches parity with
  *    SSE — per-agent GitHub account pinning tags writes with the correct tenant regardless of
@@ -169,7 +162,7 @@ export function resolveSummaryVisibilityUserId({userId, participatingAgents} = {
  * 4. **Unresolved-identity fallthrough:** when neither transport resolves a userId (stdio with
  *    neither env-var nor authenticated `gh` CLI, offline daemon contexts), `getUserId()` returns
  *    `undefined` and services fall back to **single-tenant mode** — no tag on writes, no filter
- *    on reads. Backward-compatible with pre-#10145 behavior.
+ *    on reads. This preserves the legacy single-tenant behavior.
  *
  * **Why AsyncLocalStorage and not explicit parameter threading:** userId is a cross-cutting
  * concern that every ChromaDB touch point cares about. Threading it as a parameter through
@@ -224,8 +217,7 @@ class RequestContextService extends Base {
      *                                                that as single-tenant fallthrough.
      * @param {String}   [context.username]           Human-readable display name for logging.
      * @param {String}   [context.agentIdentityNodeId] ID of the bound AgentIdentity graph node
-     *                                                (per ticket #10144's seed convention:
-     *                                                `@`-prefixed GitHub login). Populated when
+     *                                                (`@`-prefixed GitHub login). Populated when
      *                                                the resolved identity matches a seeded
      *                                                node in the Native Edge Graph. Null when
      *                                                the identity is unbound (e.g. unseeded
@@ -274,7 +266,7 @@ class RequestContextService extends Base {
     }
 
     /**
-     * Convenience accessor for the bound AgentIdentity graph-node ID (per ticket #10144).
+     * Convenience accessor for the bound AgentIdentity graph-node ID.
      * Services building `AUTHORED_BY` / `OWNED_BY` edges at write time use this to terminate
      * edges on the correct identity node. Returns `undefined` when no context is active, and
      * `null` when context is active but the resolved identity has no matching AgentIdentity

--- a/ai/mcp/server/shared/services/StdioIdentityResolver.mjs
+++ b/ai/mcp/server/shared/services/StdioIdentityResolver.mjs
@@ -7,20 +7,19 @@ import Base       from '../../../../../src/core/Base.mjs';
  * The stdio transport has no request-level authentication primitive (unlike the SSE transport's
  * OIDC Bearer token flow handled by `AuthService`). Identity must be pinned at process-boot time
  * so that every subsequent `callTool` dispatch inherits a consistent tenant tag via
- * `RequestContextService`, bringing stdio to **parity with the SSE identity propagation** shipped
- * by ticket #10000.
+ * `RequestContextService`, bringing stdio to **parity with the SSE identity propagation**.
  *
  * **Resolution chain** (first match wins):
  *
  * 1. **`NEO_AGENT_IDENTITY` environment variable** — explicit pinning for agent harnesses.
  *    Claude Code sets this via `.claude/settings.json`; Gemini via `.gemini/settings.json`; other
  *    harnesses via their native config surface. This is the authoritative path for per-model
- *    GitHub account binding (precedent: #10144 seed identities `@neo-opus-4-7`, `@neo-gemini-3-1-pro`).
+ *    GitHub account binding to seeded AgentIdentity node ids such as `@neo-opus-4-7`.
  * 2. **`gh api user` via the GitHub CLI** — zero-friction fallback for local human developers
  *    who have `gh` installed and authenticated. Matches the `@me` shortcut semantics used
  *    across the Agent OS tooling surface.
  * 3. **`unresolved`** — neither path yielded an identity. Downstream services treat this as
- *    **single-tenant mode** (backward-compatible with pre-#10145 behavior). Not a startup
+ *    **single-tenant mode** (the legacy unauthenticated transport behavior). Not a startup
  *    failure — preserves the existing local-agent developer experience.
  *
  * **Intentionally NOT in scope:**
@@ -60,7 +59,7 @@ class StdioIdentityResolver extends Base {
      *
      * **Normalization:** GitHub login strings are stored WITHOUT the leading `@` to match
      * GitHub API conventions (`gh api user .login` returns `neo-opus-4-7`, not `@neo-opus-4-7`).
-     * Callers that need the `@`-prefixed graph-node-id form (per #10144 seed convention) prepend
+     * Callers that need the `@`-prefixed graph-node-id form prepend
      * the `@` at lookup time.
      *
      * @returns {Promise<{githubLogin: String|null, username: String|null, source: String}>}

--- a/ai/mcp/server/shared/services/TransportService.mjs
+++ b/ai/mcp/server/shared/services/TransportService.mjs
@@ -15,7 +15,7 @@ import RequestContextService from './RequestContextService.mjs';
  * - **Auth Integration:** Automatically wires up the **Authorization Anchor** when OIDC
  *   configuration is detected in the environment.
  * - **CORS Enforcement:** Ensures cross-origin compatibility for modern browser-based AI agents.
- * - **Request-Context Propagation (ticket #10000):** Each `/mcp` request is wrapped in
+ * - **Request-Context Propagation:** Each `/mcp` request is wrapped in
  *   `RequestContextService.run({userId, username, sessionId}, ...)` before dispatching to the MCP
  *   transport. This bridges the gap between Express's per-request `req.auth` context and the
  *   service layer that runs inside `callTool(name, args)` — downstream services read the
@@ -177,12 +177,12 @@ class TransportService extends Base {
             }
 
             // Propagate the authenticated identity and sessionId into the async call chain so service methods
-            // can tag ChromaDB writes and filter reads per tenant (ticket #10000 + #10145).
+            // can tag ChromaDB writes and filter reads per tenant.
             //
             // Context-shape dispatch:
             // - If the concrete server (e.g. memory-core) implements `buildRequestContext()`,
             //   defer to it — the server may enrich the raw OIDC auth with server-specific
-            //   bindings like AgentIdentity graph-node IDs (memory-core's #10144 contract).
+            //   bindings like AgentIdentity graph-node IDs from memory-core.
             // - Otherwise fall back to the minimal `{userId, username}` shape — sufficient for
             //   servers (knowledge-base, gh-workflow) that don't own an identity graph.
             // - Finally, the `sessionId` from the transport is appended to whichever context

--- a/ai/services/github-workflow/IssueService.mjs
+++ b/ai/services/github-workflow/IssueService.mjs
@@ -71,7 +71,7 @@ class IssueService extends Base {
     /**
      * Fetches the conversation (title, body, author, comments) for an issue.
      *
-     * Issue-side twin of `PullRequestService.getConversation` (#10702). `get_conversation`
+     * Issue-side twin of `PullRequestService.getConversation`. `get_conversation`
      * is a single dual-purpose tool; `toolService` routes here when the caller supplies
      * `issue_number`. The selector contract (`comment_id` > `since_comment_id` > `last_n` >
      * full) is identical to the PR path; only the GraphQL resource type differs.
@@ -99,7 +99,7 @@ class IssueService extends Base {
             repo       : aiConfig.repo,
             issueNumber: issue_number,
             // get_conversation is one dual-purpose tool; the issue path shares the PR
-            // conversation comment cap rather than adding a separate config key (#10702).
+            // conversation comment cap rather than adding a separate config key.
             maxComments: aiConfig.pullRequest.maxCommentsPerPullRequest
         };
 
@@ -167,8 +167,8 @@ class IssueService extends Base {
     /**
      * @summary Assigns one or more users to a GitHub issue, or clears all assignees.
      *
-     * Implements the precondition + post-verify gate from #11537 (graduated from Discussion
-     * #11536). The "single guarded MCP operation" semantics — one MCP call performs
+     * Implements the precondition + post-verify gate for assignment changes. The
+     * "single guarded MCP operation" semantics — one MCP call performs
      * fetch-current → enforce gate → mutate → re-fetch (post-verify) → return the verified
      * state. Internally chains multiple GitHub API calls; consumers see one response with
      * honest race-window semantics (NOT strict CAS across concurrent MCP server instances).
@@ -178,12 +178,11 @@ class IssueService extends Base {
      *   `ASSIGNEE_CONFLICT` unless `acknowledgedReassign: '<reason>'` is provided.
      * - `acknowledgedReassign: '<reason>'` — strict-replacement override. Clears existing
      *   assignees, assigns the new set, posts an audit-trail comment on the issue
-     *   capturing the reason (per GPT STEP_BACK AC8: reason persistence in
-     *   GitHub-visible artifact).
+     *   capturing the reason in a GitHub-visible artifact.
      * - `requireUnassigned: false` — legacy blind-add (no precondition gate). Provided
      *   for backward-compat; new callers should not rely on this.
      *
-     * **Co-owner-add deferral (per Discussion #11536 OQ3 resolution):** V1 supports only
+     * **Co-owner-add deferral:** V1 supports only
      * strict-replacement override; co-owner-add (`acknowledgedCoOwner`) deferred to V2.
      * Rationale: simultaneous co-authorship is virtually nonexistent in our swarm topology
      * due to git-conflict chaos; cross-family corrective-authorship is always a handoff,
@@ -265,7 +264,7 @@ class IssueService extends Base {
             // Step 5 — post-verify: re-fetch and confirm the resulting assignee state.
             const verifiedAssignees = await this.#fetchCurrentAssignees(issue_number);
 
-            // Step 6 — audit-trail comment for overrides (per GPT STEP_BACK AC8 carry-forward).
+            // Step 6 — audit-trail comment for overrides.
             // Persists the reason as a GitHub-visible artifact (issue comment); reason must NOT be lost.
             if (isOverride) {
                 await this.#createReassignAuditComment(issue_number, currentAssignees, assignees, acknowledgedReassign);
@@ -421,7 +420,7 @@ class IssueService extends Base {
                 : idData.repository.issue.id;
 
             // Shared Mutation — capture response so we can surface the canonical comment
-            // identifier. Enables the A2A propagation pattern from #10272 §2.3: posting
+            // identifier. Enables the A2A propagation pattern: posting
             // a review comment returns the commentId, which the reviewer can then relay
             // via mailbox DM to the author; the author fetches just-this-comment via
             // `get_conversation({comment_id: ...})` instead of re-walking the whole thread.
@@ -457,7 +456,7 @@ class IssueService extends Base {
      * rather than orphaned creation rollback).
      *
      * This is the substrate-correct primitive that replaces the deprecated `release:v*`
-     * label-as-project-proxy pattern (#11233). Labels and projects are independent first-class
+     * label-as-project-proxy pattern. Labels and projects are independent first-class
      * GitHub primitives; the proxy pattern produces structural drift between them.
      *
      * @param {object}   options                       The options for creating the issue.
@@ -685,7 +684,7 @@ class IssueService extends Base {
      * Unified entry point for adding/removing/updating an issue's ProjectV2 memberships.
      *
      * Mirror-shape of `manageIssueLabels` for the project-membership substrate. The substrate-correct
-     * replacement for the deprecated `release:v*` label-as-project-membership-proxy pattern (#11233).
+     * replacement for the deprecated `release:v*` label-as-project-membership-proxy pattern.
      *
      * **Action: 'add'** — Attaches the issue to one or more ProjectV2 boards.
      *   Requires `projectNumbers: number[]`.
@@ -966,7 +965,7 @@ class IssueService extends Base {
      * @summary Consolidates assignee management into a single method.
      *
      * For `action: 'add'`, delegates to `assignIssue` which enforces the precondition
-     * + post-verify gate (#11537): `requireUnassigned: true` default + reason-bearing
+     * + post-verify gate: `requireUnassigned: true` default + reason-bearing
      * `acknowledgedReassign` override + audit-trail comment persistence.
      *
      * @param {object}   options                       The options object

--- a/ai/services/github-workflow/PullRequestService.mjs
+++ b/ai/services/github-workflow/PullRequestService.mjs
@@ -15,7 +15,7 @@ const execAsync     = promisify(exec);
 const execFileAsync = promisify(execFile);
 
 /**
- * **Visible** template-anchor substrings — checked AND named in the error response on miss (#11491).
+ * **Visible** template-anchor substrings — checked AND named in the error response on miss.
  *
  * These are the 7 evaluation-metric tags from `.agents/skills/pr-review/assets/pr-review-template.md`
  * (cycle-1) and `.agents/skills/pr-review/assets/pr-review-followup-template.md` (cycle-N). They are
@@ -41,7 +41,7 @@ const VISIBLE_PR_REVIEW_ANCHORS = [
 
 /**
  * **Invisible** template-anchor substrings — checked SILENTLY; NOT named in the error response
- * on miss. Defeats Goodhart anchor-stuffing (#11491 operator-directed enhancement 2026-05-16T21:16Z+).
+ * on miss. Defeats Goodhart anchor-stuffing while preserving useful diagnostics for visible misses.
  *
  * **Failure-mode the invisible layer prevents**:
  * A sophisticated agent receives the visible-list error, hallucinates a body that contains
@@ -50,11 +50,9 @@ const VISIBLE_PR_REVIEW_ANCHORS = [
  * Visible-only validation passes the malformed body. The invisible layer catches this by
  * checking structural anchors that span both cycle-1 and cycle-followup templates.
  *
- * **Empirical anchor**: review `4304287893` on PR #11499 (2026-05-16T21:16:25Z) contained
- * all 7 visible metric tags but missed `Depth Floor`, `Required Actions`, and
- * `Strategic-Fit Decision` (only had bare `Strategic-Fit`). The 3-minute-later corrected
- * review `4304295863` (21:19:24Z) had all three. These 3 substrings empirically distinguish
- * a structurally-correct review from a metric-tag-stuffed hallucination.
+ * **Empirical anchor**: a malformed review can contain all visible metric tags while missing
+ * `Depth Floor`, `Required Actions`, and `Strategic-Fit Decision` structure. These 3 substrings
+ * empirically distinguish a structurally-correct review from a metric-tag-stuffed hallucination.
  *
  * **Why these specific substrings**:
  * - `Depth Floor` — cycle-1 has `🔬 Depth Floor`, cycle-followup has `Delta Depth Floor`. Both contain the substring.
@@ -133,10 +131,10 @@ class PullRequestService extends Base {
 
     /**
      * Gets the conversation for a specific pull request, optionally filtered by comment
-     * selector to reduce context-fetch cost across review cycles (#10272 §2.2).
+     * selector to reduce context-fetch cost across review cycles.
      *
      * **Default behavior (no selectors):** returns full conversation — backward compatible
-     * with the pre-#10272 shape that callers depend on.
+     * with the legacy full-conversation shape that callers depend on.
      *
      * **Selectors (first-match precedence, pick at most one):**
      * - `comment_id` — fetch ONLY the comment whose GitHub node ID matches. Used for A2A
@@ -167,8 +165,8 @@ class PullRequestService extends Base {
      * @returns {Promise<object>} Conversation data (optionally filtered) or a structured error.
      */
     async getConversation(options) {
-        // Accept legacy positional `prNumber` form for backward compatibility with any
-        // caller predating #10272. New callers use the object form for filter support.
+        // Accept legacy positional `prNumber` form for backward compatibility.
+        // New callers use the object form for filter support.
         const {pr_number, comment_id, since_comment_id, last_n} = typeof options === 'number'
             ? {pr_number: options}
             : (options || {});
@@ -379,10 +377,9 @@ class PullRequestService extends Base {
     }
 
     /**
-     * @summary Atomic create or update of a formal GitHub pull request review (#11273).
+     * @summary Atomic create or update of a formal GitHub pull request review.
      *
-     * Closes the empirically-recurring formal-state gap pattern (PR #11234 + PR #11271
-     * empirical anchors): agents post substantive review prose via `manage_issue_comment`
+     * Closes the empirically-recurring formal-state gap pattern: agents post substantive review prose via `manage_issue_comment`
      * but forget the second `gh pr review --approve | --request-changes` step to flip
      * GitHub's `reviewDecision` surface, blocking the cross-family review mandate gate
      * per `pull-request §6.1`. This tool routes through the `addPullRequestReview`
@@ -410,8 +407,7 @@ class PullRequestService extends Base {
      * @param {String} [options.review_id]      The GraphQL node ID of the existing review (required for `update`; PRR_*).
      * @returns {Promise<Object>} Review payload on success (`{message, reviewId, state, url, submittedAt, databaseId?}`) or structured error.
      *
-     * @see #11273 (Atomic PR review create via dedicated github-workflow MCP tool)
-     * @see Discussion #11239 (graduation source; substrate-author = @neo-gemini-3-1-pro)
+     * @see Neo.ai.services.github-workflow.queries.mutations.ADD_PULL_REQUEST_REVIEW
      */
     async managePrReview({action, pr_number, state, body, review_id}) {
         if (!['create', 'update'].includes(action)) {
@@ -430,8 +426,8 @@ class PullRequestService extends Base {
             };
         }
 
-        // Tool-boundary mechanical body-shape validation (#11491).
-        // PR #11479 added a description-prose MANDATORY pre-step pointing to the pr-review SKILL.md;
+        // Tool-boundary mechanical body-shape validation.
+        // The tool description points callers to the pr-review SKILL.md;
         // this gate promotes that discipline-only guard to a mechanical floor with two layers:
         //
         // 1. VISIBLE layer — checked against VISIBLE_PR_REVIEW_ANCHORS; misses are named in the
@@ -478,8 +474,7 @@ class PullRequestService extends Base {
                 code    : 'PR_REVIEW_TEMPLATE_VALIDATION_FAILED',
                 // `missing_visible` lists the named-in-message visible misses. Invisible misses
                 // are intentionally NOT enumerated in the response body — even programmatic
-                // callers should be nudged toward the skill rather than the anchor list. This is
-                // the operator-directed invisibility safeguard (#11491 enhancement 2026-05-16).
+                // callers should be nudged toward the skill rather than the anchor list.
                 missing_visible: missingVisible,
                 skill          : skillPath,
                 template       : templatePath
@@ -625,7 +620,6 @@ class PullRequestService extends Base {
      * @param {string}    options.action             Either `'add'` or `'remove'`.
      * @returns {Promise<object>} Success message + reviewer payload on success, or structured error.
      *
-     * @see #10217 / Sub 3 of Epic #10214
      * @see pull-request-workflow.md §6.1 (cross-family mandate — invitation layer cross-reference)
      */
     async managePrReviewers({pr_number, reviewers, team_reviewers, action}) {


### PR DESCRIPTION
Authored by GPT-5 (Codex Desktop). Session e5a3acc3-d261-4ebf-96b1-4053ab0eafdf.

FAIR-band: over-target [20/30] — taking this lane despite over-target because #11924 was the remaining unassigned #11912 child after the review queue was human-gated, and it removes source-comment archaeology from the cloud-deployment-critical GitHub Workflow/shared MCP surfaces.

Refs #11924
Related: #11912

Comment-only first batch for #11924. This rewrites ticket/PR/AC archaeology in shared MCP identity/transport helpers and GitHub Workflow tool, PR, and issue services into durable intent, stable symbols, and local boundary language. It preserves runtime behavior, public API names, exact env vars, GraphQL semantics, and runtime strings.

Evidence: L1 (static source-comment diagnostics + diff review) -> L1 required (comment/JSDoc cleanup only). Residual: remaining sync/query/config source-comment candidates stay under #11924.

## Deltas from ticket

- Scoped this PR as the first #11924 batch instead of claiming full ticket completion.
- Touched batch baseline: 88 diagnostic matches across 10 files -> 11 after cleanup.
- Full #11924 diagnostic scope: 151 matches -> 76 after this batch.
- Remaining false positives / residuals include runtime error strings, stable review-template cycle terms, and untouched sync/query/config files.

## Test Evidence

- `rg --count-matches "ticket #|#[0-9]{4,}|\bAC[0-9]+\b|\bAC [0-9]+\b|Lane [A-Z]|cycle-[0-9]|PR #[0-9]+|:[0-9]+-[0-9]+" ai/services/github-workflow ai/mcp/server/github-workflow ai/mcp/server/shared --glob "*.mjs"` -> 151 before, 76 after.
- Touched-file diagnostic subset -> 88 before, 11 after.
- `git diff --check` passed.
- `git diff --cached --check` passed before commit.
- Pre-push freshness: `merge-base HEAD origin/dev == origin/dev`; outgoing log only `9cfab79ba chore(ai): clean github-workflow source comments (#11924)`.

## Post-Merge Validation

- [ ] Re-run the #11924 diagnostic on `dev` and continue with sync/query/config files until the child ticket can close.

## Commit

- `9cfab79ba` — `chore(ai): clean github-workflow source comments (#11924)`
