### PR TITLE
feat(orchestrator): stable KB_TENANT_REPO_SYNC_* error code taxonomy (#11942 AC3+AC4)

### DIFF
--- a/ai/daemons/orchestrator/services/TenantRepoSyncErrors.mjs
+++ b/ai/daemons/orchestrator/services/TenantRepoSyncErrors.mjs
@@ -1,0 +1,73 @@
+/**
+ * @summary Stable error-code taxonomy for the tenant-repo-sync lane.
+ *
+ * Operators branch on `error.code`, not message prose. All error paths in
+ * `TenantRepoSyncService` + the manual CLI route through this taxonomy so the
+ * health-payload `lastErrorCode` field and operator logs carry a stable identifier
+ * regardless of the underlying GitMirror / envelope-builder / ingestion error.
+ *
+ * Codes use the `KB_TENANT_REPO_SYNC_` prefix to distinguish them from sibling
+ * subsystem prefixes (`KB_GITMIRROR_`, `KB_INGEST_`, `KB_TENANT_REPO_ACCESS_`).
+ *
+ * @see learn/agentos/cloud-deployment/TenantIngestionModel.md — operator quarantine runbook
+ */
+
+export const KB_TENANT_REPO_SYNC_SYNC_FAILED            = 'KB_TENANT_REPO_SYNC_SYNC_FAILED';
+export const KB_TENANT_REPO_SYNC_REPO_NOT_CONFIGURED    = 'KB_TENANT_REPO_SYNC_REPO_NOT_CONFIGURED';
+export const KB_TENANT_REPO_SYNC_TENANT_NOT_FOUND       = 'KB_TENANT_REPO_SYNC_TENANT_NOT_FOUND';
+export const KB_TENANT_REPO_SYNC_MANIFEST_UPDATE_FAILED = 'KB_TENANT_REPO_SYNC_MANIFEST_UPDATE_FAILED';
+export const KB_TENANT_REPO_SYNC_CONCURRENCY_GATE_TIMEOUT = 'KB_TENANT_REPO_SYNC_CONCURRENCY_GATE_TIMEOUT';
+
+/**
+ * @summary Frozen set of all valid tenant-repo-sync error codes.
+ *
+ * Test surfaces use this to assert exhaustive coverage; the runtime uses it for
+ * `isTenantRepoSyncErrorCode(code)` membership checks at boundary handlers.
+ *
+ * @type {ReadonlySet<String>}
+ */
+export const TENANT_REPO_SYNC_ERROR_CODES = Object.freeze(new Set([
+    KB_TENANT_REPO_SYNC_SYNC_FAILED,
+    KB_TENANT_REPO_SYNC_REPO_NOT_CONFIGURED,
+    KB_TENANT_REPO_SYNC_TENANT_NOT_FOUND,
+    KB_TENANT_REPO_SYNC_MANIFEST_UPDATE_FAILED,
+    KB_TENANT_REPO_SYNC_CONCURRENCY_GATE_TIMEOUT
+]));
+
+/**
+ * @summary `Error` subclass carrying a stable `code` field plus optional metadata.
+ *
+ * Throw from service / CLI paths when surfacing a tenant-repo-sync-specific error.
+ * Operators read `error.code` from logs and the health-payload `lastErrorCode`
+ * field; the `meta` object carries non-secret context (tenantId, repoSlug,
+ * resolved phase) that helps the runbook locate the failure.
+ *
+ * Underlying transport-layer errors (GitMirror auth failure, ChromaDB write
+ * failure, etc.) should be wrapped with `KB_TENANT_REPO_SYNC_SYNC_FAILED` and
+ * the underlying `error.message` preserved (after secret redaction at the
+ * GitMirror boundary per `TenantRepoAccessContract.redactTenantRepoSecrets`).
+ */
+export class TenantRepoSyncError extends Error {
+    /**
+     * @param {String} code Stable code from this module's exported constants.
+     * @param {String} message Operator-readable description (already redacted).
+     * @param {Object} [meta] Non-secret structured context (tenantId, repoSlug, phase, etc.).
+     */
+    constructor(code, message, meta = {}) {
+        super(message);
+        this.name = 'TenantRepoSyncError';
+        this.code = code;
+        this.meta = meta;
+    }
+}
+
+/**
+ * Returns `true` when `code` is a recognized tenant-repo-sync error code.
+ * Used by boundary handlers to decide whether to wrap-as-SYNC_FAILED or pass-through.
+ *
+ * @param {String|null|undefined} code
+ * @returns {Boolean}
+ */
+export function isTenantRepoSyncErrorCode(code) {
+    return typeof code === 'string' && TENANT_REPO_SYNC_ERROR_CODES.has(code);
+}

--- a/ai/daemons/orchestrator/services/TenantRepoSyncErrors.mjs
+++ b/ai/daemons/orchestrator/services/TenantRepoSyncErrors.mjs
@@ -19,20 +19,26 @@ export const KB_TENANT_REPO_SYNC_MANIFEST_UPDATE_FAILED = 'KB_TENANT_REPO_SYNC_M
 export const KB_TENANT_REPO_SYNC_CONCURRENCY_GATE_TIMEOUT = 'KB_TENANT_REPO_SYNC_CONCURRENCY_GATE_TIMEOUT';
 
 /**
- * @summary Frozen set of all valid tenant-repo-sync error codes.
+ * @summary Frozen enumeration of all valid tenant-repo-sync error codes.
  *
- * Test surfaces use this to assert exhaustive coverage; the runtime uses it for
- * `isTenantRepoSyncErrorCode(code)` membership checks at boundary handlers.
+ * Exported as a `Object.freeze`'d Array because `Object.freeze(new Set(...))` does NOT
+ * freeze Set membership — `.add()` still mutates the internal collection even after freeze.
+ * A frozen array, by contrast, rejects `.push()`, indexed assignment, and length mutation
+ * in strict mode (ES modules are strict by default), giving true immutability of the
+ * exported substrate. Boundary membership checks go through `isTenantRepoSyncErrorCode()`,
+ * which uses a module-internal Set for O(1) lookup.
  *
- * @type {ReadonlySet<String>}
+ * @type {ReadonlyArray<String>}
  */
-export const TENANT_REPO_SYNC_ERROR_CODES = Object.freeze(new Set([
+export const TENANT_REPO_SYNC_ERROR_CODES = Object.freeze([
     KB_TENANT_REPO_SYNC_SYNC_FAILED,
     KB_TENANT_REPO_SYNC_REPO_NOT_CONFIGURED,
     KB_TENANT_REPO_SYNC_TENANT_NOT_FOUND,
     KB_TENANT_REPO_SYNC_MANIFEST_UPDATE_FAILED,
     KB_TENANT_REPO_SYNC_CONCURRENCY_GATE_TIMEOUT
-]));
+]);
+
+const TENANT_REPO_SYNC_ERROR_CODE_SET = new Set(TENANT_REPO_SYNC_ERROR_CODES);
 
 /**
  * @summary `Error` subclass carrying a stable `code` field plus optional metadata.
@@ -69,5 +75,5 @@ export class TenantRepoSyncError extends Error {
  * @returns {Boolean}
  */
 export function isTenantRepoSyncErrorCode(code) {
-    return typeof code === 'string' && TENANT_REPO_SYNC_ERROR_CODES.has(code);
+    return typeof code === 'string' && TENANT_REPO_SYNC_ERROR_CODE_SET.has(code);
 }

--- a/ai/daemons/orchestrator/services/TenantRepoSyncService.mjs
+++ b/ai/daemons/orchestrator/services/TenantRepoSyncService.mjs
@@ -141,10 +141,21 @@ class TenantRepoSyncService extends Base {
             healthService?.recordTaskOutcome?.(taskName, status, {reason, ...result.details});
             return result;
         } catch (e) {
-            const details = {reason, phase: 'tenant-repo-sync', error: e.message};
+            // Propagate stable error code + meta when the throw is a TenantRepoSyncError;
+            // otherwise wrap as the unspecific KB_TENANT_REPO_SYNC_SYNC_FAILED so operators
+            // can branch on `error.code` instead of message prose.
+            const code      = isTenantRepoSyncErrorCode(e.code) ? e.code : KB_TENANT_REPO_SYNC_SYNC_FAILED;
+            const meta      = (e instanceof TenantRepoSyncError) ? e.meta : undefined;
+            const details   = {
+                reason,
+                phase     : 'tenant-repo-sync',
+                error     : e.message,
+                reasonCode: code,
+                ...(meta ? {meta} : {})
+            };
 
             taskStateService.markFailed(taskName, null);
-            writeLog?.('ERROR', `[TenantRepoSync] Failed: ${e.message}`);
+            writeLog?.('ERROR', `[TenantRepoSync] Failed: ${code} (${e.message})`);
             healthService?.recordTaskOutcome?.(taskName, 'failed', details);
             return {status: 'failed', details};
         }

--- a/ai/daemons/orchestrator/services/TenantRepoSyncService.mjs
+++ b/ai/daemons/orchestrator/services/TenantRepoSyncService.mjs
@@ -5,6 +5,13 @@ import {DEFAULT_DATA_DIR, TENANT_REPO_SYNC_TASK_NAME} from '../TaskDefinitions.m
 import GitMirror from '../../../services/knowledge-base/helpers/GitMirror.mjs';
 import {buildIngestEnvelope} from '../../../services/knowledge-base/helpers/TenantRepoIngestEnvelopeBuilder.mjs';
 import {normalizeTenantRepoConfig} from '../../../services/knowledge-base/helpers/TenantRepoAccessContract.mjs';
+import {
+    KB_TENANT_REPO_SYNC_SYNC_FAILED,
+    KB_TENANT_REPO_SYNC_MANIFEST_UPDATE_FAILED,
+    KB_TENANT_REPO_SYNC_REPO_NOT_CONFIGURED,
+    TenantRepoSyncError,
+    isTenantRepoSyncErrorCode
+} from './TenantRepoSyncErrors.mjs';
 
 const PERSISTED_REVISIONS_FILE_NAME = 'tenant-repo-sync-revisions.json';
 
@@ -61,6 +68,21 @@ class TenantRepoSyncService extends Base {
     /**
      * Runs the tenant-repo-sync task under orchestrator state + health envelopes.
      *
+     * Error code taxonomy (see `./TenantRepoSyncErrors.mjs`). Operators branch on
+     * `details.repos[i].lastErrorCode` for per-repo failures and `details.reasonCode`
+     * for outer-task structural failures. Underlying transport errors
+     * (GitMirror auth, ChromaDB write, etc.) are wrapped as
+     * `KB_TENANT_REPO_SYNC_SYNC_FAILED` so callers can rely on the stable prefix
+     * without parsing message prose.
+     *
+     * | Code | Surface | Trigger |
+     * |---|---|---|
+     * | `KB_TENANT_REPO_SYNC_SYNC_FAILED` | per-repo `lastErrorCode` | underlying clone/fetch/envelope/ingest failure (wraps the original error) |
+     * | `KB_TENANT_REPO_SYNC_REPO_NOT_CONFIGURED` | outer `details.reasonCode` | `onlyRepoSlugs` filter requested a slug that is not in `tenantRepos[]` |
+     * | `KB_TENANT_REPO_SYNC_MANIFEST_UPDATE_FAILED` | outer `details.reasonCode` | `tenant-repo-sync-revisions.json` write failure (next cycle retries idempotently) |
+     * | `KB_TENANT_REPO_SYNC_TENANT_NOT_FOUND` | reserved | future `--tenant-id` CLI flag; no current emitter |
+     * | `KB_TENANT_REPO_SYNC_CONCURRENCY_GATE_TIMEOUT` | reserved | future concurrency-limit gate (#11942 AC2); no current emitter |
+     *
      * @param {Object} options
      * @param {String} [options.taskName=TENANT_REPO_SYNC_TASK_NAME]
      * @param {String} options.reason Scheduling reason (e.g. `'periodic-sweep:1800000'` or `'manual'`).
@@ -71,7 +93,7 @@ class TenantRepoSyncService extends Base {
      * @param {Object} [options.aiConfig] AI config object (test seam). Defaults to live import.
      * @param {Object} [options.gitMirror=GitMirror] Injectable mirror primitive (test seam).
      * @param {Object} [options.knowledgeBaseIngestionService] KB ingestion service singleton (test seam). Resolved from `ai/services.mjs` if omitted.
-     * @param {String[]} [options.onlyRepoSlugs] If provided, only sync repos whose `repoSlug` is in the list. Used by the manual CLI run path.
+     * @param {String[]} [options.onlyRepoSlugs] If provided, only sync repos whose `repoSlug` is in the list. Used by the manual CLI run path. Empty filter result against non-empty list surfaces `KB_TENANT_REPO_SYNC_REPO_NOT_CONFIGURED`.
      * @param {String} [options.revisionsFilePath] Override the per-tenant-repo lastIngestedRev persistence file path (test seam). Defaults to `<DEFAULT_DATA_DIR>/tenant-repo-sync-revisions.json`.
      * @param {Function} [options.envelopeBuilder=buildIngestEnvelope] Injectable envelope-builder (test seam). Production callers omit; unit tests pass a fake that returns canned envelope shape.
      * @returns {Promise<Object>} `{status, details}` — status ∈ {`completed`, `failed`, `skipped`}.
@@ -143,6 +165,24 @@ class TenantRepoSyncService extends Base {
         const repos          = onlyRepoSlugs
             ? allRepos.filter(r => onlyRepoSlugs.includes(r.repoSlug))
             : allRepos;
+
+        // Distinguish "operator-requested-unknown-slug" from "no config at all".
+        // Empty filter result with non-empty onlyRepoSlugs = stable REPO_NOT_CONFIGURED
+        // error so the CLI / future API surface can branch on `error.code`.
+        if (repos.length === 0 && onlyRepoSlugs?.length > 0) {
+            const knownSlugs   = allRepos.map(r => r.repoSlug);
+            const unknownSlugs = onlyRepoSlugs.filter(s => !knownSlugs.includes(s));
+            const details = {
+                reason     : 'repo-not-configured',
+                reasonCode : KB_TENANT_REPO_SYNC_REPO_NOT_CONFIGURED,
+                repoCount  : 0,
+                requestedSlugs: onlyRepoSlugs,
+                unknownSlugs,
+                configuredSlugs: knownSlugs
+            };
+            writeLog?.('WARN', `[TenantRepoSync] Requested repoSlug(s) not configured: ${unknownSlugs.join(', ')}. Configured: ${knownSlugs.join(', ') || '(none)'}.`);
+            return {status: 'failed', details};
+        }
 
         if (repos.length === 0) {
             const details = {reason: 'no-tenant-repos-configured', repoCount: 0};
@@ -225,9 +265,7 @@ class TenantRepoSyncService extends Base {
                     durationMs
                 });
             } catch (e) {
-                const code = typeof e.code === 'string' && e.code.startsWith('KB_TENANT_REPO_SYNC_')
-                    ? e.code
-                    : 'KB_TENANT_REPO_SYNC_SYNC_FAILED';
+                const code = isTenantRepoSyncErrorCode(e.code) ? e.code : KB_TENANT_REPO_SYNC_SYNC_FAILED;
                 writeLog?.('ERROR', `[TenantRepoSync] ${repoLabel} failed: ${code} (${e.message})`);
                 repoStates.push({
                     tenantId       : repo.tenantId,
@@ -326,14 +364,26 @@ class TenantRepoSyncService extends Base {
      * directory on first write so a fresh deployment doesn't need explicit dir
      * provisioning.
      *
+     * Throws `TenantRepoSyncError(KB_TENANT_REPO_SYNC_MANIFEST_UPDATE_FAILED)` on
+     * write failure so the next cycle re-detects the same diff and retries
+     * idempotently (per-repo failure isolation contract).
+     *
      * @param {Object} options
      * @param {String} options.filePath
      * @param {Object<String, String>} options.revisions
      * @returns {Promise<void>}
      */
     async writePersistedRevisions({filePath, revisions}) {
-        await fs.ensureDir(path.dirname(filePath));
-        await fs.writeJson(filePath, {revisions}, {spaces: 2});
+        try {
+            await fs.ensureDir(path.dirname(filePath));
+            await fs.writeJson(filePath, {revisions}, {spaces: 2});
+        } catch (e) {
+            throw new TenantRepoSyncError(
+                KB_TENANT_REPO_SYNC_MANIFEST_UPDATE_FAILED,
+                `Failed to persist tenant-repo-sync revisions at ${filePath}: ${e.message}`,
+                {filePath, phase: 'manifest-update'}
+            );
+        }
     }
 }
 

--- a/ai/scripts/maintenance/syncTenantRepos.mjs
+++ b/ai/scripts/maintenance/syncTenantRepos.mjs
@@ -54,7 +54,9 @@ tenantRepo. Pass --repo-slug to scope to a specific repo (repeatable).
 
 Exit codes:
   0  completed (or partial-completed with at least one repo successful)
-  1  failed (all repos failed) or skipped (no configured tenantRepos)`);
+  1  failed (all repos failed) or skipped (no configured tenantRepos)
+  3  --repo-slug requested but the named repo is not configured (KB_TENANT_REPO_SYNC_REPO_NOT_CONFIGURED)
+  2  argument-parse error`);
 }
 
 /**
@@ -109,7 +111,14 @@ async function main() {
     });
 
     console.log(JSON.stringify(result, null, 2));
-    process.exit(result.status === 'completed' ? 0 : 1);
+
+    if (result.status === 'completed') {
+        process.exit(0);
+    }
+    if (result.status === 'failed' && result.details?.reasonCode === 'KB_TENANT_REPO_SYNC_REPO_NOT_CONFIGURED') {
+        process.exit(3);
+    }
+    process.exit(1);
 }
 
 main().catch(err => {

--- a/learn/agentos/cloud-deployment/TenantIngestionModel.md
+++ b/learn/agentos/cloud-deployment/TenantIngestionModel.md
@@ -273,6 +273,20 @@ The operator readiness endpoint reads this shape from `HealthService` — there 
 
 Status is computed from per-repo `lastIngestedRev` + recent-failure-count state; the projection is deterministic, no separate persisted status column.
 
+### Stable Error Code Taxonomy
+
+Per-repo failures carry a stable `lastErrorCode` field on the health payload; operators branch on `error.code`, not message prose. Codes live in [`TenantRepoSyncErrors.mjs`](../../../ai/daemons/orchestrator/services/TenantRepoSyncErrors.mjs).
+
+| Code | Where it surfaces | Trigger |
+|---|---|---|
+| `KB_TENANT_REPO_SYNC_SYNC_FAILED` | per-repo `lastErrorCode` | Underlying clone/fetch/envelope/ingest failure (wraps the original error after secret redaction at the GitMirror boundary) |
+| `KB_TENANT_REPO_SYNC_REPO_NOT_CONFIGURED` | outer `details.reasonCode` | Manual CLI requested a `--repo-slug` that is not present in `tenantRepos[]` config. CLI exits with code `3`. |
+| `KB_TENANT_REPO_SYNC_MANIFEST_UPDATE_FAILED` | outer `details.reasonCode` | `tenant-repo-sync-revisions.json` write failure. Next cycle re-detects the same diff and retries idempotently — no manual recovery needed if the underlying filesystem issue is resolved. |
+| `KB_TENANT_REPO_SYNC_TENANT_NOT_FOUND` | reserved | Future `--tenant-id` CLI flag; no current emitter. |
+| `KB_TENANT_REPO_SYNC_CONCURRENCY_GATE_TIMEOUT` | reserved | Future concurrency-limit gate (tracked in [#11942](https://github.com/neomjs/neo/issues/11942) AC2); no current emitter. |
+
+The `KB_TENANT_REPO_SYNC_*` prefix distinguishes these codes from sibling-subsystem error families (`KB_GITMIRROR_*`, `KB_INGEST_*`, `KB_TENANT_REPO_ACCESS_*`).
+
 ### Quarantine Runbook
 
 When a repo enters `quarantined`, the lane stops attempting it on periodic cycles until the operator acts. Steps:

--- a/test/playwright/unit/ai/daemons/orchestrator/services/TenantRepoSyncErrors.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/services/TenantRepoSyncErrors.spec.mjs
@@ -1,0 +1,74 @@
+import {test, expect} from '@playwright/test';
+import {
+    KB_TENANT_REPO_SYNC_SYNC_FAILED,
+    KB_TENANT_REPO_SYNC_REPO_NOT_CONFIGURED,
+    KB_TENANT_REPO_SYNC_TENANT_NOT_FOUND,
+    KB_TENANT_REPO_SYNC_MANIFEST_UPDATE_FAILED,
+    KB_TENANT_REPO_SYNC_CONCURRENCY_GATE_TIMEOUT,
+    TENANT_REPO_SYNC_ERROR_CODES,
+    TenantRepoSyncError,
+    isTenantRepoSyncErrorCode
+} from '../../../../../../../ai/daemons/orchestrator/services/TenantRepoSyncErrors.mjs';
+
+test.describe('TenantRepoSyncErrors taxonomy (#11942 AC3+AC4)', () => {
+    test('all exported codes carry the canonical KB_TENANT_REPO_SYNC_ prefix', () => {
+        const codes = [
+            KB_TENANT_REPO_SYNC_SYNC_FAILED,
+            KB_TENANT_REPO_SYNC_REPO_NOT_CONFIGURED,
+            KB_TENANT_REPO_SYNC_TENANT_NOT_FOUND,
+            KB_TENANT_REPO_SYNC_MANIFEST_UPDATE_FAILED,
+            KB_TENANT_REPO_SYNC_CONCURRENCY_GATE_TIMEOUT
+        ];
+
+        codes.forEach(code => {
+            expect(code).toMatch(/^KB_TENANT_REPO_SYNC_/);
+        });
+    });
+
+    test('TENANT_REPO_SYNC_ERROR_CODES set contains exactly the exported codes', () => {
+        expect(TENANT_REPO_SYNC_ERROR_CODES.size).toBe(5);
+        expect(TENANT_REPO_SYNC_ERROR_CODES.has(KB_TENANT_REPO_SYNC_SYNC_FAILED)).toBe(true);
+        expect(TENANT_REPO_SYNC_ERROR_CODES.has(KB_TENANT_REPO_SYNC_REPO_NOT_CONFIGURED)).toBe(true);
+        expect(TENANT_REPO_SYNC_ERROR_CODES.has(KB_TENANT_REPO_SYNC_TENANT_NOT_FOUND)).toBe(true);
+        expect(TENANT_REPO_SYNC_ERROR_CODES.has(KB_TENANT_REPO_SYNC_MANIFEST_UPDATE_FAILED)).toBe(true);
+        expect(TENANT_REPO_SYNC_ERROR_CODES.has(KB_TENANT_REPO_SYNC_CONCURRENCY_GATE_TIMEOUT)).toBe(true);
+    });
+
+    test('TENANT_REPO_SYNC_ERROR_CODES is frozen (immutable taxonomy at module load)', () => {
+        expect(Object.isFrozen(TENANT_REPO_SYNC_ERROR_CODES)).toBe(true);
+    });
+
+    test('isTenantRepoSyncErrorCode discriminates membership correctly', () => {
+        expect(isTenantRepoSyncErrorCode(KB_TENANT_REPO_SYNC_SYNC_FAILED)).toBe(true);
+        expect(isTenantRepoSyncErrorCode('KB_GITMIRROR_FETCH_FAILED')).toBe(false);
+        expect(isTenantRepoSyncErrorCode('KB_TENANT_REPO_SYNC_UNKNOWN_FUTURE_CODE')).toBe(false);
+        expect(isTenantRepoSyncErrorCode(null)).toBe(false);
+        expect(isTenantRepoSyncErrorCode(undefined)).toBe(false);
+        expect(isTenantRepoSyncErrorCode(123)).toBe(false);
+    });
+
+    test('TenantRepoSyncError carries code + meta and inherits from Error', () => {
+        const err = new TenantRepoSyncError(
+            KB_TENANT_REPO_SYNC_SYNC_FAILED,
+            'fetch failed',
+            {tenantId: 't1', repoSlug: 'org/repo', phase: 'fetch'}
+        );
+
+        expect(err).toBeInstanceOf(Error);
+        expect(err.name).toBe('TenantRepoSyncError');
+        expect(err.code).toBe(KB_TENANT_REPO_SYNC_SYNC_FAILED);
+        expect(err.message).toBe('fetch failed');
+        expect(err.meta).toEqual({tenantId: 't1', repoSlug: 'org/repo', phase: 'fetch'});
+    });
+
+    test('TenantRepoSyncError meta defaults to empty object when omitted', () => {
+        const err = new TenantRepoSyncError(KB_TENANT_REPO_SYNC_MANIFEST_UPDATE_FAILED, 'write failed');
+        expect(err.meta).toEqual({});
+    });
+
+    test('TenantRepoSyncError preserves stack trace for debugging', () => {
+        const err = new TenantRepoSyncError(KB_TENANT_REPO_SYNC_SYNC_FAILED, 'test');
+        expect(err.stack).toBeTruthy();
+        expect(err.stack).toContain('TenantRepoSyncError');
+    });
+});

--- a/test/playwright/unit/ai/daemons/orchestrator/services/TenantRepoSyncErrors.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/services/TenantRepoSyncErrors.spec.mjs
@@ -25,17 +25,28 @@ test.describe('TenantRepoSyncErrors taxonomy (#11942 AC3+AC4)', () => {
         });
     });
 
-    test('TENANT_REPO_SYNC_ERROR_CODES set contains exactly the exported codes', () => {
-        expect(TENANT_REPO_SYNC_ERROR_CODES.size).toBe(5);
-        expect(TENANT_REPO_SYNC_ERROR_CODES.has(KB_TENANT_REPO_SYNC_SYNC_FAILED)).toBe(true);
-        expect(TENANT_REPO_SYNC_ERROR_CODES.has(KB_TENANT_REPO_SYNC_REPO_NOT_CONFIGURED)).toBe(true);
-        expect(TENANT_REPO_SYNC_ERROR_CODES.has(KB_TENANT_REPO_SYNC_TENANT_NOT_FOUND)).toBe(true);
-        expect(TENANT_REPO_SYNC_ERROR_CODES.has(KB_TENANT_REPO_SYNC_MANIFEST_UPDATE_FAILED)).toBe(true);
-        expect(TENANT_REPO_SYNC_ERROR_CODES.has(KB_TENANT_REPO_SYNC_CONCURRENCY_GATE_TIMEOUT)).toBe(true);
+    test('TENANT_REPO_SYNC_ERROR_CODES array contains exactly the exported codes', () => {
+        expect(Array.isArray(TENANT_REPO_SYNC_ERROR_CODES)).toBe(true);
+        expect(TENANT_REPO_SYNC_ERROR_CODES.length).toBe(5);
+        expect(TENANT_REPO_SYNC_ERROR_CODES).toContain(KB_TENANT_REPO_SYNC_SYNC_FAILED);
+        expect(TENANT_REPO_SYNC_ERROR_CODES).toContain(KB_TENANT_REPO_SYNC_REPO_NOT_CONFIGURED);
+        expect(TENANT_REPO_SYNC_ERROR_CODES).toContain(KB_TENANT_REPO_SYNC_TENANT_NOT_FOUND);
+        expect(TENANT_REPO_SYNC_ERROR_CODES).toContain(KB_TENANT_REPO_SYNC_MANIFEST_UPDATE_FAILED);
+        expect(TENANT_REPO_SYNC_ERROR_CODES).toContain(KB_TENANT_REPO_SYNC_CONCURRENCY_GATE_TIMEOUT);
     });
 
-    test('TENANT_REPO_SYNC_ERROR_CODES is frozen (immutable taxonomy at module load)', () => {
+    test('TENANT_REPO_SYNC_ERROR_CODES is truly immutable — external mutation rejected', () => {
+        // Object.freeze(new Set(...)) freezes the Set wrapper's properties but NOT
+        // Set membership — .add() still mutates the underlying collection. Object.freeze
+        // on an array, by contrast, rejects .push / indexed assignment / length mutation
+        // in strict mode. ES modules are strict by default, so these throw.
         expect(Object.isFrozen(TENANT_REPO_SYNC_ERROR_CODES)).toBe(true);
+        expect(() => TENANT_REPO_SYNC_ERROR_CODES.push('KB_TENANT_REPO_SYNC_MUTATED')).toThrow(TypeError);
+        expect(() => { TENANT_REPO_SYNC_ERROR_CODES[5] = 'KB_TENANT_REPO_SYNC_MUTATED'; }).toThrow(TypeError);
+        expect(() => { TENANT_REPO_SYNC_ERROR_CODES.length = 0; }).toThrow(TypeError);
+        expect(TENANT_REPO_SYNC_ERROR_CODES.length).toBe(5);
+        expect(TENANT_REPO_SYNC_ERROR_CODES).not.toContain('KB_TENANT_REPO_SYNC_MUTATED');
+        expect(isTenantRepoSyncErrorCode('KB_TENANT_REPO_SYNC_MUTATED')).toBe(false);
     });
 
     test('isTenantRepoSyncErrorCode discriminates membership correctly', () => {

--- a/test/playwright/unit/ai/daemons/orchestrator/services/TenantRepoSyncService.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/services/TenantRepoSyncService.spec.mjs
@@ -420,4 +420,60 @@ test.describe('TenantRepoSyncService (#11790)', () => {
         expect(summaryLine).toBeDefined();
         expect(summaryLine.msg).toMatch(/1 repos, 1 completed, 0 failed/);
     });
+
+    test('--repo-slug filter against unknown slug surfaces stable KB_TENANT_REPO_SYNC_REPO_NOT_CONFIGURED', async () => {
+        const taskStateService = createInMemoryTaskStateService();
+        const logLines         = [];
+        await provisionMirrorDir({tenantId: 't1', repoSlug: 'org/known'});
+
+        const result = await TenantRepoSyncService.runTask({
+            reason          : 'manual',
+            taskStateService,
+            writeLog        : (level, msg) => logLines.push({level, msg}),
+            tenantReposConfig: {tenantRepos: [
+                {tenantId: 't1', repoSlug: 'org/known', mirrorRoot, cloneUrl: 'https://example.com/known.git'}
+            ]},
+            onlyRepoSlugs                : ['org/unknown', 'org/also-unknown'],
+            gitMirror                    : makeFakeGitMirror(),
+            envelopeBuilder              : makeFakeEnvelopeBuilder(),
+            knowledgeBaseIngestionService: makeFakeIngestionService(),
+            revisionsFilePath            : revisionsFile
+        });
+
+        expect(result.status).toBe('failed');
+        expect(result.details.reasonCode).toBe('KB_TENANT_REPO_SYNC_REPO_NOT_CONFIGURED');
+        expect(result.details.requestedSlugs).toEqual(['org/unknown', 'org/also-unknown']);
+        expect(result.details.unknownSlugs).toEqual(['org/unknown', 'org/also-unknown']);
+        expect(result.details.configuredSlugs).toEqual(['org/known']);
+
+        const warn = logLines.find(l => l.msg.includes('Requested repoSlug'));
+        expect(warn).toBeDefined();
+        expect(warn.level).toBe('WARN');
+    });
+
+    test('writePersistedRevisions wraps fs write failure as KB_TENANT_REPO_SYNC_MANIFEST_UPDATE_FAILED', async () => {
+        const readOnlyParent = path.join(tmpDir, 'read-only-parent');
+        await fs.ensureDir(readOnlyParent);
+        await fs.chmod(readOnlyParent, 0o500); // r-x — write blocked
+
+        try {
+            let thrown = null;
+            try {
+                await TenantRepoSyncService.writePersistedRevisions({
+                    filePath : path.join(readOnlyParent, 'subdir', 'revisions.json'),
+                    revisions: {'t1/org/repo': 'sha-abc'}
+                });
+            } catch (e) {
+                thrown = e;
+            }
+
+            expect(thrown).toBeTruthy();
+            expect(thrown.name).toBe('TenantRepoSyncError');
+            expect(thrown.code).toBe('KB_TENANT_REPO_SYNC_MANIFEST_UPDATE_FAILED');
+            expect(thrown.meta.phase).toBe('manifest-update');
+            expect(thrown.meta.filePath).toContain('revisions.json');
+        } finally {
+            await fs.chmod(readOnlyParent, 0o700);
+        }
+    });
 });

--- a/test/playwright/unit/ai/daemons/orchestrator/services/TenantRepoSyncService.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/services/TenantRepoSyncService.spec.mjs
@@ -476,4 +476,38 @@ test.describe('TenantRepoSyncService (#11790)', () => {
             await fs.chmod(readOnlyParent, 0o700);
         }
     });
+
+    test('runTask propagates TenantRepoSyncError code + meta through outer details when syncTenantRepos throws', async () => {
+        const taskStateService = createInMemoryTaskStateService();
+        const logLines         = [];
+        await provisionMirrorDir({tenantId: 't1', repoSlug: 'org/repo-a'});
+
+        const readOnlyParent = path.join(tmpDir, 'ro-parent');
+        await fs.ensureDir(readOnlyParent);
+        await fs.chmod(readOnlyParent, 0o500);
+
+        try {
+            const result = await TenantRepoSyncService.runTask({
+                reason          : 'periodic-sweep:60000',
+                taskStateService,
+                writeLog        : (level, msg) => logLines.push({level, msg}),
+                tenantReposConfig: {tenantRepos: [
+                    {tenantId: 't1', repoSlug: 'org/repo-a', mirrorRoot, cloneUrl: 'https://example.com/a.git'}
+                ]},
+                gitMirror                    : makeFakeGitMirror(),
+                envelopeBuilder              : makeFakeEnvelopeBuilder(),
+                knowledgeBaseIngestionService: makeFakeIngestionService(),
+                revisionsFilePath            : path.join(readOnlyParent, 'subdir', 'revisions.json')
+            });
+
+            expect(result.status).toBe('failed');
+            expect(result.details.reasonCode).toBe('KB_TENANT_REPO_SYNC_MANIFEST_UPDATE_FAILED');
+            expect(result.details.meta?.phase).toBe('manifest-update');
+            expect(result.details.meta?.filePath).toContain('revisions.json');
+            const errLine = logLines.find(l => l.level === 'ERROR' && l.msg.includes('KB_TENANT_REPO_SYNC_MANIFEST_UPDATE_FAILED'));
+            expect(errLine).toBeDefined();
+        } finally {
+            await fs.chmod(readOnlyParent, 0o700);
+        }
+    });
 });


### PR DESCRIPTION
Authored by Claude Opus 4.7 (Claude Code). Session continuation from cloud-deployment-trial sprint.

FAIR-band: under-target [13/30] — operator-direction (focus on multi-user cloud deployment, 2-lane coordination; GPT on #10292 provenance). Live verifier: GPT 17 / Claude 13 over last 30 merged PRs.

Evidence: L1 (7/7 TenantRepoSyncErrors spec pass; 12/12 TenantRepoSyncService spec pass post-cycle-1 propagation fix; 19/19 stacked-spec pair pass; 255/255 broader orchestrator-tree pass; docs round-trip verified).

Refs #11942
Related: #11791 (stacked base; auto-retargets to dev on merge)

## Summary

Scope-narrowed slice of #11942 covering AC3 (stable `KB_TENANT_REPO_SYNC_*` error codes) + AC4 (JSDoc taxonomy). AC1 (per-repo jitter/backoff) and AC2 (concurrency-limit gate) remain tracked under #11942 as production-scale sophistication residuals — independent PRs.

## Changes

### New module: `ai/daemons/orchestrator/services/TenantRepoSyncErrors.mjs`

- 5 stable error-code constants with the canonical `KB_TENANT_REPO_SYNC_` prefix
- `TENANT_REPO_SYNC_ERROR_CODES` frozen set for membership checks
- `TenantRepoSyncError` class with `code` + `meta` payload
- `isTenantRepoSyncErrorCode(code)` boundary-check helper

**Codes shipped:**

| Code | Where it surfaces | Trigger |
|---|---|---|
| `KB_TENANT_REPO_SYNC_SYNC_FAILED` | per-repo `lastErrorCode` | Underlying clone/fetch/envelope/ingest failure (wrap; already used in #11791) |
| `KB_TENANT_REPO_SYNC_REPO_NOT_CONFIGURED` | outer `details.reasonCode` | `onlyRepoSlugs` filter against unknown slug |
| `KB_TENANT_REPO_SYNC_MANIFEST_UPDATE_FAILED` | outer `details.reasonCode` | `tenant-repo-sync-revisions.json` write failure |
| `KB_TENANT_REPO_SYNC_TENANT_NOT_FOUND` | reserved | Future `--tenant-id` CLI flag; no current emitter |
| `KB_TENANT_REPO_SYNC_CONCURRENCY_GATE_TIMEOUT` | reserved | #11942 AC2 concurrency gate; no current emitter |

### `TenantRepoSyncService.mjs`

- Catch block uses `isTenantRepoSyncErrorCode` discriminator instead of hardcoded string-prefix check
- New `REPO_NOT_CONFIGURED` path: when `onlyRepoSlugs` filter returns empty against non-empty list, returns `{status: 'failed', details: {reasonCode, unknownSlugs, configuredSlugs}}` with operator-visible WARN log naming the offending slugs
- `writePersistedRevisions` wraps fs failure as `TenantRepoSyncError(MANIFEST_UPDATE_FAILED)` with `phase` + `filePath` meta. Next cycle retries idempotently per the per-repo failure isolation contract.
- `runTask` JSDoc gains full error-code taxonomy table

### `syncTenantRepos.mjs` CLI

- Exit code `3` reserved for `KB_TENANT_REPO_SYNC_REPO_NOT_CONFIGURED` (distinguishes operator-error from operational-failure)
- `--help` documents the 0/1/3/2 exit code matrix

### `learn/agentos/cloud-deployment/TenantIngestionModel.md`

- New "Stable Error Code Taxonomy" subsection enumerates all 5 codes
- Names sibling-subsystem prefixes (`KB_GITMIRROR_*`, `KB_INGEST_*`, `KB_TENANT_REPO_ACCESS_*`) so operators distinguish error families

## Deltas from ticket (if any)

**Scope narrowed to AC3+AC4 only**. #11942 also covers AC1 (per-repo cadence + deterministic jitter/backoff) + AC2 (concurrency-limit gate). Those are production-scale state-machine work — each PR-sized on its own. This PR ships the taxonomy + the immediate use-sites (`SYNC_FAILED` wrap, `REPO_NOT_CONFIGURED` CLI surface, `MANIFEST_UPDATE_FAILED` persistence wrap). Reserved codes (`TENANT_NOT_FOUND`, `CONCURRENCY_GATE_TIMEOUT`) are intentionally pre-declared so the taxonomy is complete at module load — future code that introduces those triggers just imports the existing constant. Close-target as `Refs #11942`, not `Resolves` — ticket closes when AC1 + AC2 ship.

**Stacked on PR #11951** (#11791). The error-code wiring builds on #11791's catch-block + per-repo health-payload shape. Once #11951 merges, GitHub auto-retargets this PR to `dev` and the diff narrows to my surface only.

## Test Evidence

- `npm run test-unit -- test/playwright/unit/ai/daemons/orchestrator/services/TenantRepoSyncErrors.spec.mjs test/playwright/unit/ai/daemons/orchestrator/services/TenantRepoSyncService.spec.mjs` → **18/18 PASS** (726ms)
- `npm run test-unit -- test/playwright/unit/ai/daemons/orchestrator/` → **255/255 PASS** (6.8s) — no neighbor-spec regressions
- New tests covering: prefix invariant, set membership exactness, frozen taxonomy, `isTenantRepoSyncErrorCode` discrimination, `TenantRepoSyncError` shape + default meta + stack-trace preservation, `REPO_NOT_CONFIGURED` reason-payload + WARN-log, `MANIFEST_UPDATE_FAILED` wrap on fs write failure (validated against a chmod-0500 directory)

## Post-Merge Validation

- [ ] Operator confirms `details.repos[i].lastErrorCode` populates with stable prefixes in the deployed Memory Core healthcheck output during the cloud-deployment trial
- [ ] CLI exit code `3` validated via `node ./ai/scripts/maintenance/syncTenantRepos.mjs --repo-slug nonexistent-slug` smoke test pre-trial
- [ ] AC1 (jitter/backoff) + AC2 (concurrency-gate) tracked in #11942; this PR is `Refs`, not `Resolves`

## Depends on

PR #11951 (#11791 — operator docs + health/telemetry). Same underlying tenant-repo-sync substrate; my taxonomy work refines its catch-block + health-payload shape.

## Unblocks

40h cloud-deployment trial — operators now have stable error codes to branch on in logs + health payload. Quarantine runbook in TenantIngestionModel.md becomes actionable (operators look up the code, find the runbook step).

## Authority

#11942 was filed by me 2026-05-25 as a follow-up to #11790 cycle-1 review feedback (per `pull-request-workflow §10` Maintainer Polish Fast Path scope). Operator-direction post-batch-1+#11941 merges: "continue with a focus on the multi user cloud deployment, and coordinate on 2 lanes." This PR is my second cloud-deployment lane closer.

## Deltas after cycle-1 review

@neo-gpt #11952 review-hold flagged a real bug + 1 metadata blocker:

1. **Code/meta propagation bug** (real, not stylistic): `runTask` outer catch was preserving only `e.message` into `details`, silently swallowing `e.code` + `e.meta`. Verified probe at the pre-fix head returned no `reasonCode` when `writePersistedRevisions` threw `TenantRepoSyncError(MANIFEST_UPDATE_FAILED)` — the inner test asserted the throw shape but NOT the propagation through `runTask`. Fixed at `7952a645e`: catch block now discriminates via `isTenantRepoSyncErrorCode(e.code)`, propagates `e.meta` when `e instanceof TenantRepoSyncError`, wraps non-recognized errors as `KB_TENANT_REPO_SYNC_SYNC_FAILED`. Log line now carries the stable code: `[TenantRepoSync] Failed: KB_TENANT_REPO_SYNC_* (msg)`. New test asserts the full propagation chain through a read-only revisions-dir fixture.

2. **FAIR-band placeholder**: refreshed `under-target [verify @ merge-gate]` to `under-target [13/30]` per live verifier (GPT 17 / Claude 13 of last 30 merged PRs).

CI surface note (informational, not blocking): the stacked-PR pattern (this PR's base is `agent/11791-...` not `dev`) means only `lint-pr-body` fires at the PR-head until #11951 merges and GitHub auto-retargets to `dev` — full CI fires post-retarget. Same dynamic as the original #11790↔#11789 stack.

