### PR TITLE
feat(memory-core): stamp raw-memory provenance (#10292)

### DIFF
--- a/ai/graph/identityRoots.mjs
+++ b/ai/graph/identityRoots.mjs
@@ -6,12 +6,52 @@
  *
  * Capability fields (`contextWindowInput`, `hosting`, `tier`, etc.) per ADR 0012 Model-Stats
  * Framework. Source-cited values mirror `learn/agentos/ModelStats.md`; the registry is the
- * canonical authority for capability-data drift detection.
+ * canonical authority for capability-data drift detection. `trustTier` is the #10292 content
+ * provenance taxonomy used by Memory Core consumers to distinguish owner, peer-trusted, external,
+ * and unclassified authorship at ingestion/query boundaries.
  *
  * It is used for both:
  * 1. Boot-time self-seeding in `GraphService.initAsync`
  * 2. Explicit manual recovery via `ai/scripts/setup/seedAgentIdentities.mjs`
  */
+
+/**
+ * @summary Content-provenance trust taxonomy for AgentIdentity roots.
+ *
+ * Higher-level Memory Core query filtering and frontier weighting use these stable string
+ * values; do not replace them with display labels.
+ *
+ * @member {Object}
+ */
+export const TRUST_TIERS = Object.freeze({
+    SYSTEM           : 'system',
+    REPO_TRUSTED     : 'repo-trusted',
+    OWNER            : 'owner',
+    SELF             : 'self',
+    PEER_TRUSTED     : 'peer-trusted',
+    INTERNAL_AUTHORED: 'internal-authored',
+    EXTERNAL         : 'external',
+    UNCLASSIFIED     : 'unclassified'
+});
+
+/**
+ * @summary Highest-to-lowest trust ordering for the #10292 provenance taxonomy.
+ *
+ * The order is intentionally exported next to the enum so query-path slices can compare tiers
+ * without duplicating ranking tables.
+ *
+ * @member {String[]}
+ */
+export const TRUST_TIER_ORDER = Object.freeze([
+    TRUST_TIERS.SYSTEM,
+    TRUST_TIERS.REPO_TRUSTED,
+    TRUST_TIERS.OWNER,
+    TRUST_TIERS.SELF,
+    TRUST_TIERS.PEER_TRUSTED,
+    TRUST_TIERS.INTERNAL_AUTHORED,
+    TRUST_TIERS.EXTERNAL,
+    TRUST_TIERS.UNCLASSIFIED
+]);
 
 export const IDENTITIES = [
     {
@@ -24,6 +64,7 @@ export const IDENTITIES = [
             displayName: 'Claude Opus 4.7',
             modelFamily: 'claude',
             accountType: 'agent',
+            trustTier  : TRUST_TIERS.PEER_TRUSTED,
             subscriptionTemplate: {
                 trigger: 'SENT_TO_ME',
                 harnessTarget: 'bridge-daemon',
@@ -73,6 +114,7 @@ export const IDENTITIES = [
             displayName: 'Gemini 3.1 Pro',
             modelFamily: 'gemini',
             accountType: 'agent',
+            trustTier  : TRUST_TIERS.PEER_TRUSTED,
             subscriptionTemplate: {
                 trigger: 'SENT_TO_ME',
                 harnessTarget: 'bridge-daemon',
@@ -123,6 +165,7 @@ export const IDENTITIES = [
             displayName: 'Tobias Uhlig',
             modelFamily: null,
             accountType: 'human',
+            trustTier  : TRUST_TIERS.OWNER,
             createdAt: new Date().toISOString()
         }
     },
@@ -136,6 +179,7 @@ export const IDENTITIES = [
             displayName: 'Codex',
             modelFamily: 'gpt',
             accountType: 'agent',
+            trustTier  : TRUST_TIERS.PEER_TRUSTED,
             subscriptionTemplate: {
                 trigger: 'SENT_TO_ME',
                 harnessTarget: 'bridge-daemon',
@@ -183,6 +227,7 @@ export const IDENTITIES = [
             displayName: 'Broadcast',
             modelFamily: null,
             accountType: 'sentinel',
+            trustTier  : TRUST_TIERS.UNCLASSIFIED,
             createdAt: new Date().toISOString()
         }
     }

--- a/ai/services/memory-core/MemoryService.mjs
+++ b/ai/services/memory-core/MemoryService.mjs
@@ -189,6 +189,12 @@ class MemoryService extends Base {
 
     /**
      * Adds a new memory to the collection.
+     *
+     * When the MCP transport has resolved a real `AgentIdentity`, the write stamps both the
+     * Chroma metadata (`agentIdentity`) and a graph `AUTHORED_BY` edge. Fallback-only identities
+     * remain scalar metadata so single-tenant and unseeded callers do not create edges to nodes
+     * that do not exist.
+     *
      * @param {Object} options
      * @param {String} options.prompt    The user's prompt.
      * @param {String} options.response  The agent's response.
@@ -228,8 +234,13 @@ class MemoryService extends Base {
 
             // Tenant-isolation tag: present only when a request context was established
             // by the SSE transport layer. In stdio mode it is absent — single-tenant fallthrough.
-            const userId = normalizeUserId(RequestContextService.getUserId());
+            const requestIdentity   = RequestContextService.getAgentIdentityNodeId();
+            const userId            = normalizeUserId(RequestContextService.getUserId());
+            const canonicalIdentity = requestIdentity
+                || (userId ? `@${userId}` : (agent?.startsWith('@') ? agent : (agent ? `@${agent}` : undefined)));
+
             if (userId) metadata.userId = userId;
+            if (canonicalIdentity) metadata.agentIdentity = canonicalIdentity;
 
             if (agent) metadata.agent = agent;
             if (model) metadata.model = model;
@@ -243,10 +254,6 @@ class MemoryService extends Base {
                 metadatas: [metadata],
                 documents: [combinedText]
             });
-
-            // Derive canonical graph identity. Fallback to formatting userId, or passing raw agent.
-            const canonicalIdentity = RequestContextService.getAgentIdentityNodeId()
-                || (userId ? `@${userId}` : (agent?.startsWith('@') ? agent : (agent ? `@${agent}` : undefined)));
 
             // 1. Topologically inject the new memory into the Native Edge Graph
             GraphService.upsertNode({
@@ -263,15 +270,26 @@ class MemoryService extends Base {
                 }
             });
 
-            // 2. Link this memory dynamically to the active context frontier
+            // 2. Stamp write-time provenance when the transport resolved a real AgentIdentity.
+            // Fallback-only identities remain scalar metadata so single-tenant/unseeded callers
+            // keep working without hallucinated graph edges to nodes that do not exist.
+            if (requestIdentity) {
+                GraphService.linkNodes(memoryId, requestIdentity, 'AUTHORED_BY', 1.0, {
+                    timestamp,
+                    userId      : requestIdentity,
+                    sharedEntity: true
+                });
+            }
+
+            // 3. Link this memory dynamically to the active context frontier
             GraphService.linkNodes('frontier', memoryId, 'SPAWNED_MEMORY', 0.8);
 
-            // 3. Real-Time A2A JSON Parsing (Deprecated)
+            // 4. Real-Time A2A JSON Parsing (Deprecated)
             if (aiConfig.realTimeMemoryParsing) {
                 logger.warn(`[MemoryService] Real-Time parsing skipped: DreamService decoupled. Awaiting REM sleep.`);
             }
 
-            // 4. Mailbox delta signal: per-turn piggyback of inbox unread-count + latest preview.
+            // 5. Mailbox delta signal: per-turn piggyback of inbox unread-count + latest preview.
             //    Non-fatal — buildMailboxDelta swallows its own errors and returns null on failure,
             //    so a degraded mailbox query never blocks a successful memory write.
             const mailbox = buildMailboxDelta();

--- a/test/playwright/unit/ai/services/memory-core/MemoryService.Schema.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/MemoryService.Schema.spec.mjs
@@ -16,8 +16,10 @@ setup({
 import {test, expect}        from '@playwright/test';
 import Neo                   from '../../../../../../src/Neo.mjs';
 import * as core             from '../../../../../../src/core/_export.mjs';
+import {IDENTITIES, TRUST_TIERS, TRUST_TIER_ORDER} from '../../../../../../ai/graph/identityRoots.mjs';
 import MemoryService         from '../../../../../../ai/services/memory-core/MemoryService.mjs';
 import StorageRouter         from '../../../../../../ai/services/memory-core/managers/StorageRouter.mjs';
+import RequestContextService from '../../../../../../ai/mcp/server/shared/services/RequestContextService.mjs';
 
 /**
  * Validates the AGENT_MEMORY graph node payload structure to prevent hollow-success regressions
@@ -28,6 +30,8 @@ test.describe('MemoryService — AGENT_MEMORY Schema (#10620)', () => {
     let originalGetMemoryCollection;
     let originalUpsertNode;
     let originalLinkNodes;
+    let collectionAddCalls = [];
+    let linkNodesCalls = [];
     let upsertNodeCalls = [];
 
     let GraphService;
@@ -37,9 +41,13 @@ test.describe('MemoryService — AGENT_MEMORY Schema (#10620)', () => {
     });
 
     test.beforeEach(() => {
+        collectionAddCalls = [];
+        linkNodesCalls     = [];
         upsertNodeCalls = [];
         spyCollection = {
-            async add() {}
+            async add(payload) {
+                collectionAddCalls.push(payload);
+            }
         };
         originalGetMemoryCollection = StorageRouter.getMemoryCollection;
         StorageRouter.getMemoryCollection = async () => spyCollection;
@@ -50,7 +58,9 @@ test.describe('MemoryService — AGENT_MEMORY Schema (#10620)', () => {
         GraphService.upsertNode = (node) => {
             upsertNodeCalls.push(node);
         };
-        GraphService.linkNodes = () => {};
+        GraphService.linkNodes = (...args) => {
+            linkNodesCalls.push(args);
+        };
     });
 
     test.afterEach(() => {
@@ -95,5 +105,83 @@ test.describe('MemoryService — AGENT_MEMORY Schema (#10620)', () => {
 
         expect(node.type).toBe('AGENT_MEMORY');
         expect(node.properties.agentIdentity).toBe('@neo-gemini-3-1-pro');
+    });
+
+    test('identity roots expose the 8-tier trust taxonomy required by #10292', () => {
+        expect(TRUST_TIER_ORDER).toEqual([
+            'system',
+            'repo-trusted',
+            'owner',
+            'self',
+            'peer-trusted',
+            'internal-authored',
+            'external',
+            'unclassified'
+        ]);
+
+        const values = new Set(Object.values(TRUST_TIERS));
+        for (const identity of IDENTITIES) {
+            expect(values.has(identity.properties.trustTier)).toBe(true);
+        }
+
+        expect(IDENTITIES.find(identity => identity.id === '@tobiu').properties.trustTier).toBe(TRUST_TIERS.OWNER);
+        expect(IDENTITIES.find(identity => identity.id === '@neo-gpt').properties.trustTier).toBe(TRUST_TIERS.PEER_TRUSTED);
+        expect(IDENTITIES.find(identity => identity.id === '@neo-opus-4-7').properties.trustTier).toBe(TRUST_TIERS.PEER_TRUSTED);
+        expect(IDENTITIES.find(identity => identity.id === 'AGENT:*').properties.trustTier).toBe(TRUST_TIERS.UNCLASSIFIED);
+    });
+
+    test('addMemory stamps request-bound AgentIdentity into Chroma metadata and AUTHORED_BY edge', async () => {
+        const result = await RequestContextService.run({
+            userId             : 'neo-gpt',
+            username           : 'neo-gpt',
+            agentIdentityNodeId: '@neo-gpt',
+            source             : 'env-var'
+        }, () => MemoryService.addMemory({
+            sessionId: 'session-abc',
+            prompt   : 'hello',
+            thought  : 'thinking',
+            response : 'hi'
+        }));
+
+        expect(collectionAddCalls).toHaveLength(1);
+        expect(collectionAddCalls[0].metadatas[0].userId).toBe('neo-gpt');
+        expect(collectionAddCalls[0].metadatas[0].agentIdentity).toBe('@neo-gpt');
+
+        expect(upsertNodeCalls).toHaveLength(1);
+        expect(upsertNodeCalls[0].properties.agentIdentity).toBe('@neo-gpt');
+
+        const authoredBy = linkNodesCalls.find(([, , relationship]) => relationship === 'AUTHORED_BY');
+        expect(authoredBy).toBeDefined();
+        expect(authoredBy[0]).toBe(result.id);
+        expect(authoredBy[1]).toBe('@neo-gpt');
+        expect(authoredBy[3]).toBe(1.0);
+        expect(authoredBy[4]).toMatchObject({
+            userId      : '@neo-gpt',
+            sharedEntity: true
+        });
+
+        const spawned = linkNodesCalls.find(([, , relationship]) => relationship === 'SPAWNED_MEMORY');
+        expect(spawned).toBeDefined();
+    });
+
+    test('addMemory preserves unresolved-identity fallthrough without hallucinating AUTHORED_BY edges', async () => {
+        await RequestContextService.run({
+            userId             : 'external-contributor',
+            username           : 'External Contributor',
+            agentIdentityNodeId: null,
+            source             : 'unresolved'
+        }, () => MemoryService.addMemory({
+            sessionId: 'session-unbound',
+            prompt   : 'hello',
+            thought  : 'thinking',
+            response : 'hi'
+        }));
+
+        expect(collectionAddCalls).toHaveLength(1);
+        expect(collectionAddCalls[0].metadatas[0].userId).toBe('external-contributor');
+        expect(collectionAddCalls[0].metadatas[0].agentIdentity).toBe('@external-contributor');
+
+        expect(linkNodesCalls.some(([, , relationship]) => relationship === 'AUTHORED_BY')).toBe(false);
+        expect(linkNodesCalls.some(([, , relationship]) => relationship === 'SPAWNED_MEMORY')).toBe(true);
     });
 });


### PR DESCRIPTION
Authored by GPT-5 (Codex Desktop). Session request-bound via Memory Core.

FAIR-band: over-target [17/30] — positive-ROI lane despite over-target because the operator redirected the sprint toward multi-user cloud deployment readiness, and #10292 is the active P1 provenance primitive for cloud-phase Memory Core trust boundaries.

Refs #10292

Adds the first forward-looking provenance slice for Memory Core raw-memory writes: seeded AgentIdentity roots now carry the #10292 eight-tier `trustTier` taxonomy, and `MemoryService.addMemory()` stamps request-bound raw-memory writes with both Chroma `agentIdentity` metadata and a graph `AUTHORED_BY` edge when the transport resolved a real AgentIdentity.

Evidence: L1 (focused unit coverage for identity taxonomy + raw-memory provenance write path) → L1 required for this forward-only slice. Residual: query `minTrustTier`, summaries/mailbox expansion, migration note, and frontier weighting remain in #10292.

## Deltas from ticket

This PR intentionally keeps #10292 open. The ticket covers the full provenance system, including query filtering, summary/mailbox expansion, downstream frontier weighting, and migration documentation. This slice ships the smallest load-bearing write-time primitive:

- `TRUST_TIERS` + `TRUST_TIER_ORDER` exported from `ai/graph/identityRoots.mjs`.
- Seeded identities gain stable `trustTier` values (`owner`, `peer-trusted`, `unclassified`).
- `MemoryService.addMemory()` stores canonical `agentIdentity` in Chroma metadata.
- Request-bound writes emit `AGENT_MEMORY -AUTHORED_BY-> AgentIdentity`.
- Unresolved identities keep scalar metadata only, avoiding hallucinated graph edges to missing nodes.

## Test Evidence

- `npm run test-unit -- test/playwright/unit/ai/services/memory-core/MemoryService.Schema.spec.mjs` -> 5/5 PASS
- `npm run test-unit -- test/playwright/unit/ai/services/memory-core/MemoryService.TenantIsolation.spec.mjs` -> 13/13 PASS
- `npm run test-unit -- test/playwright/unit/ai/services/memory-core/GraphService.spec.mjs` -> 25/25 PASS
- `git diff --check` -> PASS
- `git diff --cached --check` -> PASS before commit

## Post-Merge Validation

- [ ] Confirm newly added raw memories from stdio-bound named agents carry `agentIdentity` metadata and an `AUTHORED_BY` edge in the live Memory Core graph.
- [ ] Continue #10292 with query-path `minTrustTier` filtering and downstream weighting slices.

## Commit

- `6edbb4824` — `feat(memory-core): stamp raw-memory provenance (#10292)`
