### PR TITLE
chore(cloud-deployment): rename acme/* placeholders to neomjs-owned (#11954)

### DIFF
--- a/learn/agentos/cloud-deployment/Configuration.md
+++ b/learn/agentos/cloud-deployment/Configuration.md
@@ -59,7 +59,7 @@ Each key is also bindable via an environment variable (`NEO_KB_DEFAULT_TENANT_ID
 | `NEO_KB_INGEST_TOKEN` | Yes for production | Bearer token for the repo-push automation identity. |
 | `NEO_KB_TOKEN_ENV` | No | Name of the environment variable that holds the bearer token when the deployment does not use `NEO_KB_INGEST_TOKEN`. |
 | `NEO_KB_TENANT_ID` | No | Envelope default for tenant id; authenticated server context remains authoritative. |
-| `NEO_KB_REPO_SLUG` | No | Envelope default for repo slug; use a deterministic, secret-free value such as `acme/app`. |
+| `NEO_KB_REPO_SLUG` | No | Envelope default for repo slug; use a deterministic, secret-free value such as `neomjs/create-app`. |
 
 The token is a KB MCP authorization credential, not a Git credential. Store it in the tenant hook/CI secret store and rotate it using the deployment's normal OIDC or workload-identity policy.
 

--- a/learn/agentos/cloud-deployment/Day0Tutorial.md
+++ b/learn/agentos/cloud-deployment/Day0Tutorial.md
@@ -318,7 +318,7 @@ Pick a secret-free tenant tuple:
 
 ```bash
 export NEO_KB_TENANT_ID="client-org"
-export NEO_KB_REPO_SLUG="acme/app"
+export NEO_KB_REPO_SLUG="neomjs/create-app"
 export NEO_KB_INGEST_TOKEN="<repo-push-automation-token>"
 ```
 
@@ -328,7 +328,7 @@ Create a small content-bearing envelope:
 cat > /tmp/day0-envelope.json <<'JSON'
 {
   "tenantId": "client-org",
-  "repoSlug": "acme/app",
+  "repoSlug": "neomjs/create-app",
   "files": [
     {
       "sourcePath": "docs/hello.md",
@@ -424,13 +424,13 @@ const content = fs.readFileSync('proto/example.proto', 'utf8');
 
 process.stdout.write(JSON.stringify({
   tenantId: 'client-org',
-  repoSlug: 'acme/app',
+  repoSlug: 'neomjs/create-app',
   files: [{
     sourcePath: 'proto/example.proto',
     parsedChunks: [{
       schemaVersion: '1.0.0',
       tenantId: 'client-org',
-      repoSlug: 'acme/app',
+      repoSlug: 'neomjs/create-app',
       rootKind: 'external-source',
       sourcePath: 'proto/example.proto',
       content,
@@ -492,7 +492,7 @@ for (let i = 0; i < 3; i++) {
   process.stdout.write(JSON.stringify({
     schemaVersion: '1.0.0',
     tenantId: 'client-org',
-    repoSlug: 'acme/app',
+    repoSlug: 'neomjs/create-app',
     rootKind: 'external-source',
     sourcePath: `bulk/doc-${i}.md`,
     content: `# Bulk doc ${i}\n\nBulk import smoke record ${i}.`,

--- a/learn/agentos/cloud-deployment/HookWiring.md
+++ b/learn/agentos/cloud-deployment/HookWiring.md
@@ -26,7 +26,7 @@ The deployable repo-push path is `npm run ai:kb-push-client`. It is a tenant-sid
 NEO_KB_MCP_URL="https://agent-os.example.com/kb/mcp" \
 NEO_KB_INGEST_TOKEN="$repo_push_token" \
 NEO_KB_TENANT_ID="client-org" \
-NEO_KB_REPO_SLUG="acme/app" \
+NEO_KB_REPO_SLUG="neomjs/create-app" \
 npm run ai:kb-push-client -- --from-stdin < envelope.json
 ```
 
@@ -81,7 +81,7 @@ The push client accepts a single JSON envelope and submits it to the remote MCP 
 npm run ai:kb-push-client -- \
     --url https://agent-os.example.com/kb/mcp \
     --tenant-id client-org \
-    --repo-slug acme/app \
+    --repo-slug neomjs/create-app \
     --from-file envelope.json
 ```
 

--- a/learn/agentos/cloud-deployment/TenantIngestionModel.md
+++ b/learn/agentos/cloud-deployment/TenantIngestionModel.md
@@ -50,8 +50,8 @@ Recommended `repoSlug` shape:
 Examples:
 
 ```text
-acme/app
-acme/docs
+neomjs/create-app
+neomjs/neo
 internal/platform
 ```
 

--- a/test/playwright/unit/ai/scripts/maintenance/kbPushClient.spec.mjs
+++ b/test/playwright/unit/ai/scripts/maintenance/kbPushClient.spec.mjs
@@ -53,7 +53,7 @@ test.describe('ai/scripts/maintenance/kbPushClient — repo-push MCP client (#11
                 '--url', 'https://kb.example.com/mcp',
                 '--from-stdin',
                 '--tenant-id', 'tenant-a',
-                '--repo-slug', 'acme/app',
+                '--repo-slug', 'neomjs/create-app',
                 '--transport', 'sse',
                 '--token-env', 'TOKEN_ENV'
             ],
@@ -62,7 +62,7 @@ test.describe('ai/scripts/maintenance/kbPushClient — repo-push MCP client (#11
 
         expect(args).toMatchObject({
             fromStdin: true,
-            repoSlug : 'acme/app',
+            repoSlug : 'neomjs/create-app',
             tenantId : 'tenant-a',
             token    : 'secret-token',
             tokenEnv : 'TOKEN_ENV',
@@ -76,13 +76,13 @@ test.describe('ai/scripts/maintenance/kbPushClient — repo-push MCP client (#11
             NEO_KB_INGEST_TOKEN : 'env-token',
             NEO_KB_MCP_URL      : 'https://kb.example.com/mcp',
             NEO_KB_MCP_TRANSPORT: 'streamable-http',
-            NEO_KB_REPO_SLUG    : 'acme/app',
+            NEO_KB_REPO_SLUG    : 'neomjs/create-app',
             NEO_KB_TENANT_ID    : 'tenant-a'
         });
 
         expect(args).toMatchObject({
             fromFile : 'envelope.json',
-            repoSlug : 'acme/app',
+            repoSlug : 'neomjs/create-app',
             tenantId : 'tenant-a',
             token    : 'env-token',
             tokenEnv : 'NEO_KB_INGEST_TOKEN',
@@ -144,14 +144,14 @@ test.describe('ai/scripts/maintenance/kbPushClient — repo-push MCP client (#11
             manifestSnapshot: {pathsAfterPush: ['src/a.mjs']}
         }, {
             tenantId: 'cli-tenant',
-            repoSlug : 'acme/app'
+            repoSlug : 'neomjs/create-app'
         });
 
         expect(normalized).toEqual({
             tenantId        : 'payload-tenant',
-            repoSlug         : 'acme/app',
+            repoSlug         : 'neomjs/create-app',
             manifestSnapshot: {
-                repoSlug      : 'acme/app',
+                repoSlug      : 'neomjs/create-app',
                 pathsAfterPush: ['src/a.mjs']
             }
         });
@@ -196,7 +196,7 @@ test.describe('ai/scripts/maintenance/kbPushClient — repo-push MCP client (#11
             '--url', 'https://kb.example.com/mcp',
             '--from-stdin',
             '--tenant-id', 'tenant-a',
-            '--repo-slug', 'acme/app',
+            '--repo-slug', 'neomjs/create-app',
             '--token', 'secret-token'
         ], {});
 
@@ -225,7 +225,7 @@ test.describe('ai/scripts/maintenance/kbPushClient — repo-push MCP client (#11
             name    : 'ingest_source_files',
             envelope: {
                 tenantId: 'tenant-a',
-                repoSlug : 'acme/app',
+                repoSlug : 'neomjs/create-app',
                 files    : [{sourcePath: 'src/a.mjs', content: 'x'}]
             }
         });

--- a/test/playwright/unit/ai/services/knowledge-base/GitMirror.spec.mjs
+++ b/test/playwright/unit/ai/services/knowledge-base/GitMirror.spec.mjs
@@ -155,7 +155,7 @@ test.describe('GitMirror (#11788)', () => {
             .rejects.toMatchObject({code: 'KB_GITMIRROR_MIRROR_PATH_INVALID'});
         await expect(cloneIfMissing({
             ...mirrorOptions(source),
-            cloneUrl: 'https://token:secret@example.com/acme/repo.git',
+            cloneUrl: 'https://token:secret@example.com/tenant-a/repo-x.git',
             repoSlug: 'local/credential-url'
         })).rejects.toMatchObject({code: 'KB_GITMIRROR_CLONE_FAILED'});
         await expect(cloneIfMissing({

--- a/test/playwright/unit/ai/services/knowledge-base/KbTenantHealthHelper.spec.mjs
+++ b/test/playwright/unit/ai/services/knowledge-base/KbTenantHealthHelper.spec.mjs
@@ -55,8 +55,8 @@ test.describe.configure({mode: 'serial'});
  */
 const TWO_TENANT_ROLLUP = [
     {
-        tenantId       : 'tenant-acme',
-        repoSlug       : 'acme-web',
+        tenantId       : 'tenant-a',
+        repoSlug       : 'neomjs/create-app',
         eventCount     : 12,
         ingestEvents   : 9,
         tombstoneEvents: 2,
@@ -155,7 +155,7 @@ test.describe('KbTenantHealthHelper (#11639)', () => {
             const dataRows = section.split('\n').filter(line => line.startsWith('| `'));
 
             expect(dataRows).toHaveLength(2);
-            expect(section).toContain('| `tenant-acme` | `acme-web` | 12 | 9 | 2 | 0 | 1 | 8.3% | 340 | 18 |');
+            expect(section).toContain('| `tenant-a` | `neomjs/create-app` | 12 | 9 | 2 | 0 | 1 | 8.3% | 340 | 18 |');
             expect(section).toContain('| `neo-shared` | `neo` | 4 | 4 | 0 | 0 | 0 | 0.0% | 88 | 0 |');
         });
 


### PR DESCRIPTION
Authored by Claude Opus 4.7 (Claude Code). Session continuation from cloud-deployment-trial sprint.

FAIR-band: under-target [14/30] — operator-direction (focus on multi-user cloud deployment, 2-lane coordination). Live verifier: GPT 17 / Claude 14 over last 30 merged PRs (incrementing post-#11951 merge).

Evidence: L1 (29/29 affected-spec pass — KbTenantHealthHelper 14/14, GitMirror 8/8, kbPushClient 7/7); grep `acme` returns zero placeholder hits across the targeted scope.

Resolves #11954

## Summary

Replace third-party GitHub org placeholders across operator-facing cloud-deployment docs + test fixtures. Operator-flagged 2026-05-25 during PR #11951 cycle-1 review: `acme` and `acme-corp` are both real public GitHub orgs, so the placeholders risked (a) misdirecting operators who try to clone the example, (b) name-collision if those orgs ever publish a repo with the matching slug, (c) implying association with a real third-party org.

PR #11951 fixed `acme-corp/widgets` → `neomjs/create-app` in the new "Server-Side Pull Mode" section but did not touch the broader codebase. This PR completes the cleanup across the 7 remaining placeholder surfaces.

## Changes

### Operator-facing docs (`learn/agentos/cloud-deployment/`)

- **`HookWiring.md`** (2 lines) — `NEO_KB_REPO_SLUG="acme/app"` env-var example + `--repo-slug acme/app` CLI example → `neomjs/create-app`
- **`Configuration.md`** (1 line) — env-var description: `acme/app` → `neomjs/create-app`
- **`TenantIngestionModel.md`** (2 lines) — Repository Identity examples block: `acme/app` + `acme/docs` → `neomjs/create-app` + `neomjs/neo` (two-repo example shape preserved)
- **`Day0Tutorial.md`** (5 lines) — `acme/app` across env exports, ingestion payload examples, command-line invocations → `neomjs/create-app`

### Test fixtures

- **`KbTenantHealthHelper.spec.mjs`** (3 occurrences each) — `tenant-acme` → `tenant-a` (tenant identifier, explicit placeholder per ticket recommendation); `acme-web` → `neomjs/create-app` (repoSlug; consistency with docs); markdown table assertion on line 158 updated to match
- **`GitMirror.spec.mjs`** (1 line) — credential-bearing URL fixture: `acme/repo` → `tenant-a/repo-x` (preserves the `token:secret@example.com/` shape so the secret-redaction test still validates the intended path; private-tenant placeholder shape reinforces the test's "private repo requiring credentials" semantics)
- **`kbPushClient.spec.mjs`** (8 occurrences) — `acme/app` as repoSlug across multiple `it(...)` blocks → `neomjs/create-app`

## Deltas from ticket (if any)

None. Implementation matches the ticket prescription exactly:
- Docs: `neomjs/create-app` (primary) + `neomjs/neo` (secondary slot) per ticket
- Test fixtures: hybrid scheme per ticket option — `tenant-a` for tenant identifier, `tenant-a/repo-x` for the credential-URL anti-collision placeholder shape, `neomjs/create-app` for repoSlug values requiring docs-consistency

ACME-TLS-protocol references in `PipelineWiring.md` are explicitly out of scope per the ticket (legitimate technical term, not placeholders) and remain untouched. Devindex tracking data and KB-resync data also out of scope per ticket.

## Test Evidence

```bash
npm run test-unit -- test/playwright/unit/ai/services/knowledge-base/KbTenantHealthHelper.spec.mjs \
                     test/playwright/unit/ai/services/knowledge-base/GitMirror.spec.mjs \
                     test/playwright/unit/ai/scripts/maintenance/kbPushClient.spec.mjs
```

→ **29/29 PASS** (959ms)

Grep-AC verification:

```bash
grep -rni "acme" --include="*.md" --include="*.mjs" --include="*.json" \
    learn/agentos/cloud-deployment/ \
    test/playwright/unit/ai/services/knowledge-base/ \
    test/playwright/unit/ai/scripts/maintenance/ \
    | grep -v "ACME-TLS\|ACME provider\|ACME directly\|acme.example\|acme-protocol\|ACME rate"
```

→ **zero placeholder hits** (only legitimate ACME-TLS-protocol references remain in `PipelineWiring.md`, out of scope)

## Post-Merge Validation

- [ ] Operator confirms docs read consistently across `learn/agentos/cloud-deployment/` tree (no mixed `acme/*` + `neomjs/*` cognitive load)
- [ ] No downstream substrate (Memory Core, KB collections) carries stale `acme/*` chunks — separate KB resync handles that boundary

## Avoided Traps

- ✓ No blanket `sed s/acme/neomjs/g` — would have corrupted legitimate ACME-protocol mentions in `PipelineWiring.md`
- ✓ Preserved `token:secret@` credential-bearing URL shape in `GitMirror.spec.mjs` so the secret-redaction test still validates its intended path
- ✓ Renamed both `acme/app` and `acme/docs` together in `TenantIngestionModel.md` to preserve the two-repo example shape

## Authority

#11954 was filed by me 2026-05-25 as a follow-up to operator's cycle-1 flag during PR #11951 review. Self-assigned, open lane. Memory entry [`feedback_example_placeholders_no_third_party_namespaces`](https://github.com/neomjs/neo/issues?q=) codifies the discipline.

Authored by [Claude Opus 4.7] (Claude Code) — Session continuation from cloud-deployment-trial sprint.