### PR TITLE
feat(orchestrator): migrate MLX config to AiConfig + resolveMlxConfig helper (#11075)

### DIFF
--- a/ai/config.template.mjs
+++ b/ai/config.template.mjs
@@ -148,18 +148,23 @@ const defaultConfig = {
          */
         devSyncRoots: [],
         /**
-         * MLX model artifact used to launch the orchestrator-owned inference server.
-         * This is a Hugging Face repo id or local path for `mlx_lm.server --model`, not
-         * the OpenAI-compatible API payload model label. Set this in gitignored
-         * `ai/config.mjs` or via `NEO_ORCHESTRATOR_MLX_MODEL`. Disabled by default
-         * because LM Studio / other OpenAI-compatible providers already own the normal
-         * inference endpoint; enable only when this orchestrator should supervise MLX
-         * by setting `enabled: true` or `NEO_ORCHESTRATOR_MLX_ENABLED=true`.
+         * Orchestrator-owned MLX inference server config. Operators tune via gitignored
+         * `ai/config.mjs` or env vars (`NEO_ORCHESTRATOR_MLX_ENABLED`,
+         * `NEO_ORCHESTRATOR_MLX_MODEL`, `NEO_ORCHESTRATOR_MLX_PORT`).
+         *
+         * - `enabled`: whether the orchestrator should supervise an `mlx_lm.server` child
+         *   process. Disabled by default because LM Studio / other OpenAI-compatible
+         *   providers already own the normal inference endpoint; enable only when this
+         *   orchestrator should own MLX directly.
+         * - `model`: Hugging Face repo id or local path for `mlx_lm.server --model`.
+         *   Distinct from the OpenAI-compatible API payload model label (`NEO_OPENAI_COMPATIBLE_MODEL`).
+         * - `port`: OpenAI-compatible local-inference port.
          * @type {Object}
          */
         mlx: {
             enabled: false,
-            model: null
+            model  : 'mlx-community/gemma-4-31b-it-bf16',
+            port   : '11435'
         }
     },
     /**

--- a/ai/daemons/orchestrator/Orchestrator.mjs
+++ b/ai/daemons/orchestrator/Orchestrator.mjs
@@ -392,6 +392,7 @@ export class Orchestrator extends Base {
      * @param {String} [options.nodeBin]
      * @param {Boolean} [options.mlxEnabled]
      * @param {String}  [options.mlxModel]
+     * @param {String}  [options.mlxPort]
      * @param {String[]|String|null} [options.primaryDevSyncRootsConfig]
      * @returns {Promise<void>}
      */
@@ -411,7 +412,8 @@ export class Orchestrator extends Base {
             scriptDir,
             nodeBin   : options.nodeBin || process.argv[0],
             mlxEnabled: options.mlxEnabled ?? undefined,
-            mlxModel  : options.mlxModel || undefined
+            mlxModel  : options.mlxModel || undefined,
+            mlxPort   : options.mlxPort  || undefined
         });
 
         // Non-reactive boot-wrapper-provided instance state

--- a/ai/daemons/orchestrator/TaskDefinitions.mjs
+++ b/ai/daemons/orchestrator/TaskDefinitions.mjs
@@ -9,33 +9,19 @@ export const TENANT_REPO_SYNC_TASK_NAME           = 'tenant-repo-sync';
 export const DREAM_TASK_NAME                      = 'dream';
 export const GOLDEN_PATH_TASK_NAME                = 'golden-path';
 export const SWARM_HEARTBEAT_TASK_NAME            = 'swarm-heartbeat';
-export const DEFAULT_MLX_MODEL                    = 'mlx-community/gemma-4-31b-it-bf16';
-export const DEFAULT_MLX_PORT                     = '11435';
-export const DEFAULT_MLX_ENABLED                  = false;
 
 export const DEFAULT_DB_PATH    = process.env.NEO_AI_DB_PATH || '.neo-ai-data/sqlite/memory-core-graph.sqlite';
 export const DEFAULT_DATA_DIR   = process.env.NEO_AI_ORCHESTRATOR_DIR || '.neo-ai-data/orchestrator-daemon';
 export const DEFAULT_SCRIPT_DIR = path.resolve(__dirname, '../../scripts');
 
 /**
- * Resolves whether the orchestrator should own an mlx_lm.server child process.
- * @param {String|Boolean|null|undefined} value Explicit value or env-var payload.
- * @returns {Boolean}
- */
-export function resolveMlxEnabled(value = process.env.NEO_ORCHESTRATOR_MLX_ENABLED) {
-    if (value === undefined || value === null || value === '') {
-        return DEFAULT_MLX_ENABLED;
-    }
-
-    if (typeof value === 'boolean') {
-        return value;
-    }
-
-    return String(value).toLowerCase() === 'true';
-}
-
-/**
  * @summary Builds child-process commands for orchestrator-owned maintenance tasks.
+ *
+ * Pure function: receives concrete `mlxEnabled` / `mlxModel` / `mlxPort` values from the
+ * caller; performs no env-var lookups and carries no embedded MLX defaults. The
+ * canonical MLX defaults live in `ai/config.template.mjs` under `orchestrator.mlx`;
+ * `daemon.mjs::resolveMlxConfig` applies env-var overrides and forwards the resolved
+ * values via `Orchestrator.start({mlxEnabled, mlxModel, mlxPort})`.
  *
  * The orchestrator intentionally shells out to existing manual maintenance scripts for
  * Piece C instead of reimplementing their internals. This keeps orchestration separate
@@ -45,17 +31,17 @@ export function resolveMlxEnabled(value = process.env.NEO_ORCHESTRATOR_MLX_ENABL
  * @param {Object} [options]
  * @param {String} [options.scriptDir] Script directory.
  * @param {String} [options.nodeBin] Node executable.
- * @param {Boolean} [options.mlxEnabled] Whether to launch an orchestrator-owned mlx_lm.server.
+ * @param {Boolean} [options.mlxEnabled=false] Whether to launch an orchestrator-owned mlx_lm.server.
  * @param {String} [options.mlxModel] MLX launch model: a Hugging Face repo id or local path.
  * @param {String|Number} [options.mlxPort] OpenAI-compatible local inference port.
  * @returns {Object}
  */
 export function buildTaskDefinitions({
-    scriptDir = DEFAULT_SCRIPT_DIR,
-    nodeBin   = process.argv[0],
-    mlxEnabled = resolveMlxEnabled(),
-    mlxModel  = process.env.NEO_ORCHESTRATOR_MLX_MODEL || DEFAULT_MLX_MODEL,
-    mlxPort   = DEFAULT_MLX_PORT
+    scriptDir  = DEFAULT_SCRIPT_DIR,
+    nodeBin    = process.argv[0],
+    mlxEnabled = false,
+    mlxModel,
+    mlxPort
 } = {}) {
     const tasks = {
         chroma: {
@@ -125,7 +111,7 @@ export function buildTaskDefinitions({
         }
     };
 
-    if (resolveMlxEnabled(mlxEnabled)) {
+    if (mlxEnabled) {
         tasks.mlx = {
             label          : 'mlx inference',
             command        : path.resolve(scriptDir, '../mcp/server/memory-core/.venv/bin/python'),

--- a/ai/daemons/orchestrator/daemon.mjs
+++ b/ai/daemons/orchestrator/daemon.mjs
@@ -267,6 +267,29 @@ export function resolveOrchestratorStartOptions({
 }
 
 /**
+ * Resolves the effective MLX inference-server config by overlaying env-var overrides
+ * onto `AiConfig.orchestrator.mlx`. Operators tune via gitignored `ai/config.mjs`
+ * or env (`NEO_ORCHESTRATOR_MLX_{ENABLED,MODEL,PORT}`); canonical defaults
+ * (`enabled: false`, Gemma-4 model, port `'11435'`) live in
+ * `ai/config.template.mjs` — this helper does not re-embed them.
+ *
+ * @param {Object} [options]
+ * @param {Object} [options.orchestratorConfig={}] Slice of `AiConfig.orchestrator`.
+ * @param {Object} [options.env=process.env] Env-var source (test-injectable).
+ * @returns {{enabled: Boolean, model: String, port: String}}
+ */
+export function resolveMlxConfig({orchestratorConfig = {}, env = process.env} = {}) {
+    const mlx        = orchestratorConfig.mlx || {};
+    const envEnabled = env.NEO_ORCHESTRATOR_MLX_ENABLED;
+
+    return {
+        enabled: envEnabled !== undefined ? envEnabled === 'true' : !!mlx.enabled,
+        model  : env.NEO_ORCHESTRATOR_MLX_MODEL || mlx.model,
+        port   : env.NEO_ORCHESTRATOR_MLX_PORT  || mlx.port
+    };
+}
+
+/**
  * Starts the singleton orchestrator daemon.
  * @param {Object} [options] Runtime overrides for tests or process managers.
  * @returns {Promise<void>}
@@ -278,15 +301,14 @@ export async function startOrchestrator(options = {}) {
     await loadLocalAiConfig();
     const orchestratorConfig = AiConfig.orchestrator || {};
     const maintenanceConfig  = AiConfig.maintenance || {};
-    const mlxConfig          = orchestratorConfig.mlx || {};
-    const mlxEnabled         = process.env.NEO_ORCHESTRATOR_MLX_ENABLED !== undefined
-        ? undefined
-        : mlxConfig.enabled;
+    const mlx                = resolveMlxConfig({orchestratorConfig});
+
     return Orchestrator.start({
         dataDir: DAEMON_DATA_DIR,
         primaryDevSyncRootsConfig: orchestratorConfig.devSyncRoots,
-        mlxEnabled: mlxEnabled ?? undefined,
-        mlxModel  : mlxConfig.model || undefined,
+        mlxEnabled: mlx.enabled,
+        mlxModel  : mlx.model,
+        mlxPort   : mlx.port,
         ...resolveOrchestratorStartOptions({orchestratorConfig, maintenanceConfig}),
         ...options
     });

--- a/ai/daemons/orchestrator/daemon.mjs
+++ b/ai/daemons/orchestrator/daemon.mjs
@@ -31,6 +31,7 @@ import fs from 'fs-extra';
 import path from 'path';
 import {execSync} from 'child_process';
 import AiConfig from '../../config.template.mjs';
+import Env from '../../../src/util/Env.mjs';
 import Orchestrator from './Orchestrator.mjs';
 
 const DAEMON_DATA_DIR = process.env.NEO_AI_ORCHESTRATOR_DIR || '.neo-ai-data/orchestrator-daemon';
@@ -273,17 +274,20 @@ export function resolveOrchestratorStartOptions({
  * (`enabled: false`, Gemma-4 model, port `'11435'`) live in
  * `ai/config.template.mjs` — this helper does not re-embed them.
  *
+ * Boolean parsing for `NEO_ORCHESTRATOR_MLX_ENABLED` goes through
+ * `Neo.util.Env.parseBool` for canonical token semantics
+ * (true/yes/on/1, false/no/off/0, case-insensitive, trimmed).
+ *
  * @param {Object} [options]
  * @param {Object} [options.orchestratorConfig={}] Slice of `AiConfig.orchestrator`.
  * @param {Object} [options.env=process.env] Env-var source (test-injectable).
  * @returns {{enabled: Boolean, model: String, port: String}}
  */
 export function resolveMlxConfig({orchestratorConfig = {}, env = process.env} = {}) {
-    const mlx        = orchestratorConfig.mlx || {};
-    const envEnabled = env.NEO_ORCHESTRATOR_MLX_ENABLED;
+    const mlx = orchestratorConfig.mlx || {};
 
     return {
-        enabled: envEnabled !== undefined ? envEnabled === 'true' : !!mlx.enabled,
+        enabled: Env.parseBool('NEO_ORCHESTRATOR_MLX_ENABLED', {env}) ?? !!mlx.enabled,
         model  : env.NEO_ORCHESTRATOR_MLX_MODEL || mlx.model,
         port   : env.NEO_ORCHESTRATOR_MLX_PORT  || mlx.port
     };

--- a/test/playwright/unit/ai/daemons/orchestrator/Orchestrator.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/Orchestrator.spec.mjs
@@ -521,25 +521,6 @@ test.describe('Neo.ai.daemons.Orchestrator (#11009)', () => {
         expect(orchestrator.taskDefinitions.mlx.args).not.toContain('gemma-4-31b-it');
     });
 
-    test('falls back to the dedicated mlx default when local config is null', () => {
-        // Post Sub 1 #11833: configure() removed; the null→undefined input shim lives in
-        // start() before calling buildTaskDefinitions. The shim (`options.mlxModel || undefined`)
-        // converts caller-provided null to undefined so the buildTaskDefinitions destructuring
-        // default fires. Test asserts that path explicitly.
-        const orchestrator = Neo.create(Orchestrator);
-        const mlxModelInput = null;
-        orchestrator.dataDir         = '/tmp/orchestrator-test-mlx-null';
-        orchestrator.taskDefinitions = buildTaskDefinitions({
-            scriptDir : path.resolve(process.cwd(), 'ai/scripts'),
-            nodeBin   : process.argv[0],
-            mlxEnabled: true,
-            mlxModel  : mlxModelInput || undefined  // matches start() boundary translation
-        });
-
-        expect(orchestrator.taskDefinitions.mlx.args).toContain('mlx-community/gemma-4-31b-it-bf16');
-        expect(orchestrator.taskDefinitions.mlx.args).not.toContain(null);
-    });
-
     test('routes primary-dev-sync through its service coordinator', () => {
         const started = [];
         const orchestrator = createTestOrchestrator({

--- a/test/playwright/unit/ai/daemons/orchestrator/daemon.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/daemon.spec.mjs
@@ -6,14 +6,11 @@ import '../../../../../../src/core/_export.mjs';
 import {
     LOCAL_AI_CONFIG_FILE,
     loadLocalAiConfig,
+    resolveMlxConfig,
     resolveOrchestratorStartOptions
 } from '../../../../../../ai/daemons/orchestrator/daemon.mjs';
 import {
-    DEFAULT_MLX_ENABLED,
-    DEFAULT_MLX_MODEL,
-    DEFAULT_MLX_PORT,
-    buildTaskDefinitions,
-    resolveMlxEnabled
+    buildTaskDefinitions
 } from '../../../../../../ai/daemons/orchestrator/TaskDefinitions.mjs';
 
 test.describe('ai/daemons/orchestrator/daemon.mjs (#11006/#11009)', () => {
@@ -39,126 +36,126 @@ test.describe('ai/daemons/orchestrator/daemon.mjs (#11006/#11009)', () => {
         expect(tasks.backup.expectedCommand).toBe('backup.mjs');
     });
 
-    test('keeps mlx inference opt-in with the dedicated Gemma 4 MLX launch default', () => {
-        const scriptDir     = path.resolve(process.cwd(), 'ai/scripts');
-        const originalApiModel = process.env.NEO_OPENAI_COMPATIBLE_MODEL;
-        const originalMlxModel = process.env.NEO_ORCHESTRATOR_MLX_MODEL;
-        const originalMlxEnabled = process.env.NEO_ORCHESTRATOR_MLX_ENABLED;
+    test('buildTaskDefinitions is pure: tasks.mlx is omitted when mlxEnabled is false', () => {
+        const scriptDir = path.resolve(process.cwd(), 'ai/scripts');
+        const tasks     = buildTaskDefinitions({scriptDir, nodeBin: '/test/node'});
 
-        delete process.env.NEO_OPENAI_COMPATIBLE_MODEL;
-        delete process.env.NEO_ORCHESTRATOR_MLX_MODEL;
-        delete process.env.NEO_ORCHESTRATOR_MLX_ENABLED;
+        expect(tasks.mlx).toBeUndefined();
+    });
+
+    test('buildTaskDefinitions is pure: no env-var lookups; concrete mlxModel/mlxPort flow through', () => {
+        // Architectural contract post-#11075: TaskDefinitions.mjs has no embedded MLX
+        // defaults and no env-var reads. Caller (daemon.mjs via resolveMlxConfig)
+        // resolves AiConfig + env-vars and forwards concrete values. This test
+        // documents the pure-function contract by setting env-vars that would have
+        // been picked up by the old behavior and verifying they are ignored.
+        const scriptDir = path.resolve(process.cwd(), 'ai/scripts');
+        const originalMlxModel   = process.env.NEO_ORCHESTRATOR_MLX_MODEL;
+        const originalMlxEnabled = process.env.NEO_ORCHESTRATOR_MLX_ENABLED;
+        const originalMlxPort    = process.env.NEO_ORCHESTRATOR_MLX_PORT;
+
+        process.env.NEO_ORCHESTRATOR_MLX_ENABLED = 'true';
+        process.env.NEO_ORCHESTRATOR_MLX_MODEL   = 'env-leaked-model';
+        process.env.NEO_ORCHESTRATOR_MLX_PORT    = '99999';
 
         try {
+            // Default: mlxEnabled=false; env-vars are ignored.
             const tasks = buildTaskDefinitions({scriptDir, nodeBin: '/test/node'});
-
-            expect(DEFAULT_MLX_ENABLED).toBe(false);
-            expect(DEFAULT_MLX_MODEL).toBe('mlx-community/gemma-4-31b-it-bf16');
-            expect(DEFAULT_MLX_PORT).toBe('11435');
             expect(tasks.mlx).toBeUndefined();
 
-            const enabledTasks = buildTaskDefinitions({scriptDir, nodeBin: '/test/node', mlxEnabled: true});
+            // Explicit values are passed through verbatim; env-vars are still ignored.
+            const explicitTasks = buildTaskDefinitions({
+                scriptDir,
+                nodeBin   : '/test/node',
+                mlxEnabled: true,
+                mlxModel  : 'explicit-model',
+                mlxPort   : 12345
+            });
 
-            expect(enabledTasks.mlx.args).toEqual([
+            expect(explicitTasks.mlx.args).toEqual([
                 '-m',
                 'mlx_lm.server',
                 '--model',
-                DEFAULT_MLX_MODEL,
+                'explicit-model',
                 '--port',
-                DEFAULT_MLX_PORT
+                '12345'
             ]);
-            expect(enabledTasks.mlx.args).not.toContain('mlx-community/gemma-2-27b-it-4bit');
-            expect(enabledTasks.mlx.args).not.toContain('gemma-4-31b-it');
-            expect(resolveMlxEnabled('true')).toBe(true);
-            expect(resolveMlxEnabled('false')).toBe(false);
+            expect(explicitTasks.mlx.args).not.toContain('env-leaked-model');
+            expect(explicitTasks.mlx.args).not.toContain('99999');
         } finally {
-            if (originalApiModel !== undefined) {
-                process.env.NEO_OPENAI_COMPATIBLE_MODEL = originalApiModel;
-            }
-            if (originalMlxModel !== undefined) {
-                process.env.NEO_ORCHESTRATOR_MLX_MODEL = originalMlxModel;
-            }
-            if (originalMlxEnabled !== undefined) {
-                process.env.NEO_ORCHESTRATOR_MLX_ENABLED = originalMlxEnabled;
+            for (const [key, value] of [
+                ['NEO_ORCHESTRATOR_MLX_MODEL',   originalMlxModel],
+                ['NEO_ORCHESTRATOR_MLX_ENABLED', originalMlxEnabled],
+                ['NEO_ORCHESTRATOR_MLX_PORT',    originalMlxPort]
+            ]) {
+                if (value === undefined) {
+                    delete process.env[key];
+                } else {
+                    process.env[key] = value;
+                }
             }
         }
     });
 
-    test('separates OpenAI-compatible API labels from local mlx launch model overrides', () => {
-        const scriptDir     = path.resolve(process.cwd(), 'ai/scripts');
-        const originalApiModel = process.env.NEO_OPENAI_COMPATIBLE_MODEL;
-        const originalMlxModel = process.env.NEO_ORCHESTRATOR_MLX_MODEL;
-        const originalMlxEnabled = process.env.NEO_ORCHESTRATOR_MLX_ENABLED;
-
-        process.env.NEO_OPENAI_COMPATIBLE_MODEL = 'api-label-only';
-        delete process.env.NEO_ORCHESTRATOR_MLX_MODEL;
-        delete process.env.NEO_ORCHESTRATOR_MLX_ENABLED;
-
-        try {
-            const apiEnvTasks = buildTaskDefinitions({scriptDir, nodeBin: '/test/node'});
-
-            expect(apiEnvTasks.mlx).toBeUndefined();
-
-            process.env.NEO_ORCHESTRATOR_MLX_ENABLED = 'true';
-
-            const enabledDefaultTasks = buildTaskDefinitions({scriptDir, nodeBin: '/test/node'});
-
-            expect(enabledDefaultTasks.mlx.args).toEqual([
-                '-m',
-                'mlx_lm.server',
-                '--model',
-                DEFAULT_MLX_MODEL,
-                '--port',
-                DEFAULT_MLX_PORT
-            ]);
-
-            process.env.NEO_ORCHESTRATOR_MLX_MODEL = 'local-mlx-launch-model';
-
-            const mlxEnvTasks = buildTaskDefinitions({scriptDir, nodeBin: '/test/node'});
-
-            expect(mlxEnvTasks.mlx.args).toEqual([
-                '-m',
-                'mlx_lm.server',
-                '--model',
-                'local-mlx-launch-model',
-                '--port',
-                DEFAULT_MLX_PORT
-            ]);
-        } finally {
-            if (originalApiModel === undefined) {
-                delete process.env.NEO_OPENAI_COMPATIBLE_MODEL;
-            } else {
-                process.env.NEO_OPENAI_COMPATIBLE_MODEL = originalApiModel;
+    test('resolveMlxConfig overlays env-var precedence onto AiConfig.orchestrator.mlx', () => {
+        const aiConfigDefaults = {
+            mlx: {
+                enabled: false,
+                model  : 'mlx-community/gemma-4-31b-it-bf16',
+                port   : '11435'
             }
-            if (originalMlxModel === undefined) {
-                delete process.env.NEO_ORCHESTRATOR_MLX_MODEL;
-            } else {
-                process.env.NEO_ORCHESTRATOR_MLX_MODEL = originalMlxModel;
-            }
-            if (originalMlxEnabled === undefined) {
-                delete process.env.NEO_ORCHESTRATOR_MLX_ENABLED;
-            } else {
-                process.env.NEO_ORCHESTRATOR_MLX_ENABLED = originalMlxEnabled;
-            }
-        }
+        };
 
-        const explicitTasks = buildTaskDefinitions({
-            scriptDir,
-            nodeBin   : '/test/node',
-            mlxEnabled: true,
-            mlxModel  : 'explicit-model',
-            mlxPort   : 12345
+        // No env overrides: AiConfig defaults flow through.
+        expect(resolveMlxConfig({orchestratorConfig: aiConfigDefaults, env: {}})).toEqual({
+            enabled: false,
+            model  : 'mlx-community/gemma-4-31b-it-bf16',
+            port   : '11435'
         });
 
-        expect(explicitTasks.mlx.args).toEqual([
-            '-m',
-            'mlx_lm.server',
-            '--model',
-            'explicit-model',
-            '--port',
-            '12345'
-        ]);
-        expect(explicitTasks.summary.command).toBe('/test/node');
+        // Env overrides win.
+        expect(resolveMlxConfig({
+            orchestratorConfig: aiConfigDefaults,
+            env               : {
+                NEO_ORCHESTRATOR_MLX_ENABLED: 'true',
+                NEO_ORCHESTRATOR_MLX_MODEL  : 'env-model',
+                NEO_ORCHESTRATOR_MLX_PORT   : '11999'
+            }
+        })).toEqual({
+            enabled: true,
+            model  : 'env-model',
+            port   : '11999'
+        });
+
+        // Explicit env=false overrides an enabled AiConfig default.
+        expect(resolveMlxConfig({
+            orchestratorConfig: {mlx: {...aiConfigDefaults.mlx, enabled: true}},
+            env               : {NEO_ORCHESTRATOR_MLX_ENABLED: 'false'}
+        })).toEqual({
+            enabled: false,
+            model  : 'mlx-community/gemma-4-31b-it-bf16',
+            port   : '11435'
+        });
+
+        // Missing orchestratorConfig.mlx: undefined-safe, no crash; values undefined.
+        expect(resolveMlxConfig({orchestratorConfig: {}, env: {}})).toEqual({
+            enabled: false,
+            model  : undefined,
+            port   : undefined
+        });
+    });
+
+    test('AiConfig.orchestrator.mlx ships canonical MLX launch defaults', async () => {
+        const aiConfigModule = await import('../../../../../../ai/config.template.mjs');
+        const aiConfig       = aiConfigModule.default;
+
+        // AiConfig template is the single source of truth for MLX defaults
+        // post-#11075 migration. TaskDefinitions.mjs no longer carries them.
+        expect(aiConfig.data.orchestrator.mlx).toEqual({
+            enabled: false,
+            model  : 'mlx-community/gemma-4-31b-it-bf16',
+            port   : '11435'
+        });
     });
 
     test('keeps bridge-daemon wake-only and routes maintenance ownership to the daemon class', () => {

--- a/test/playwright/unit/ai/daemons/orchestrator/daemon.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/daemon.spec.mjs
@@ -145,6 +145,52 @@ test.describe('ai/daemons/orchestrator/daemon.mjs (#11006/#11009)', () => {
         });
     });
 
+    test('resolveMlxConfig accepts canonical boolean tokens via Env.parseBool (TRUE/yes/on/1 + FALSE/no/off/0)', () => {
+        // Per Neo.util.Env.parseBool token semantics — case-insensitive, trimmed.
+        // Token sets: TRUE_TOKENS=['true','yes','on','1'], FALSE_TOKENS=['false','no','off','0'].
+        const aiDefaultDisabled = {mlx: {enabled: false, model: 'm', port: 'p'}};
+        const aiDefaultEnabled  = {mlx: {enabled: true,  model: 'm', port: 'p'}};
+
+        // Truthy tokens (against an AiConfig default of `enabled: false` — env wins on each).
+        for (const truthy of ['true', 'TRUE', 'True', 'yes', 'YES', 'on', 'ON', '1']) {
+            expect(resolveMlxConfig({
+                orchestratorConfig: aiDefaultDisabled,
+                env               : {NEO_ORCHESTRATOR_MLX_ENABLED: truthy}
+            }).enabled).toBe(true);
+        }
+
+        // Falsy tokens (against an AiConfig default of `enabled: true` — env wins on each).
+        for (const falsy of ['false', 'FALSE', 'False', 'no', 'NO', 'off', 'OFF', '0']) {
+            expect(resolveMlxConfig({
+                orchestratorConfig: aiDefaultEnabled,
+                env               : {NEO_ORCHESTRATOR_MLX_ENABLED: falsy}
+            }).enabled).toBe(false);
+        }
+
+        // Whitespace-tolerant per Env.parseBool's trim semantics.
+        expect(resolveMlxConfig({
+            orchestratorConfig: aiDefaultDisabled,
+            env               : {NEO_ORCHESTRATOR_MLX_ENABLED: '  yes  '}
+        }).enabled).toBe(true);
+
+        // Invalid token: Env.parseBool returns undefined → falls back to AiConfig default.
+        // (Env warns to console; suppression is the caller's concern, not asserted here.)
+        const originalWarn = console.warn;
+        console.warn       = () => {};
+        try {
+            expect(resolveMlxConfig({
+                orchestratorConfig: aiDefaultEnabled,
+                env               : {NEO_ORCHESTRATOR_MLX_ENABLED: 'maybe'}
+            }).enabled).toBe(true);
+            expect(resolveMlxConfig({
+                orchestratorConfig: aiDefaultDisabled,
+                env               : {NEO_ORCHESTRATOR_MLX_ENABLED: 'maybe'}
+            }).enabled).toBe(false);
+        } finally {
+            console.warn = originalWarn;
+        }
+    });
+
     test('AiConfig.orchestrator.mlx ships canonical MLX launch defaults', async () => {
         const aiConfigModule = await import('../../../../../../ai/config.template.mjs');
         const aiConfig       = aiConfigModule.default;


### PR DESCRIPTION
Authored by Claude Opus 4.7 (Claude Code). Session continuation from cloud-deployment-trial sprint.

FAIR-band: under-target [14/30] — operator-direction (focus on multi-user cloud deployment, 2-lane coordination). Live verifier: GPT 17 / Claude 14 over last 30 merged PRs.

Evidence: L1 (247/247 PASS across orchestrator-tree post-migration; the migrated AiConfig defaults + new `resolveMlxConfig` helper covered by 4 cleaner replacement tests).

Resolves #11075

## Summary

Migrate the 3 MLX config constants (`DEFAULT_MLX_MODEL` / `DEFAULT_MLX_PORT` / `DEFAULT_MLX_ENABLED`) + `resolveMlxEnabled` helper from `ai/daemons/orchestrator/TaskDefinitions.mjs` (code substrate) to `ai/config.template.mjs` (config substrate) under the existing `orchestrator.mlx` namespace. Add a new `daemon.mjs::resolveMlxConfig` helper that overlays env-var precedence onto AiConfig.

Operator-flagged 2026-05-25 during TaskDefinitions.mjs technical-debt exploration: *"some vars feel not needed... other items are REAL configuration values that belong into ai/config.template.mjs (and for that there should be a ticket already)."* Status comment on #11075 (this turn) confirmed the remaining concrete gap was the MLX surface.

## Changes

### Architectural shift

**Before**: MLX defaults inlined in `TaskDefinitions.mjs` constants + a `resolveMlxEnabled` helper that read `NEO_ORCHESTRATOR_MLX_ENABLED` from env. `buildTaskDefinitions` performed its own env-var lookups for `NEO_ORCHESTRATOR_MLX_MODEL` and fell back to `DEFAULT_MLX_MODEL`/`DEFAULT_MLX_PORT`. Layered env+default resolution split across `daemon.mjs` + `TaskDefinitions.mjs`.

**After**:
- **`ai/config.template.mjs`** owns canonical defaults (`orchestrator.mlx.{enabled, model, port}` — including the new `port: '11435'` slot operators previously couldn't tune)
- **`ai/daemons/orchestrator/daemon.mjs::resolveMlxConfig`** overlays env-vars (`NEO_ORCHESTRATOR_MLX_{ENABLED,MODEL,PORT}`) onto AiConfig at the daemon boundary
- **`ai/daemons/orchestrator/TaskDefinitions.mjs::buildTaskDefinitions`** becomes a pure function — receives concrete `{mlxEnabled, mlxModel, mlxPort}` from the caller; performs no env-var lookups, carries no embedded defaults

### New operator-facing capability

`NEO_ORCHESTRATOR_MLX_PORT` env-var is now respected at the daemon boundary. Previously the port was hardcoded with no operator override path; this PR closes that gap as a side-effect of the migration.

### File-level breakdown

- `ai/config.template.mjs:160-167` — expand `orchestrator.mlx` namespace: `{enabled: false, model: 'mlx-community/gemma-4-31b-it-bf16', port: '11435'}`. JSDoc updated to enumerate the 3 env-var override knobs.
- `ai/daemons/orchestrator/daemon.mjs` — add `resolveMlxConfig({orchestratorConfig, env})` helper following the `resolveOrchestratorStartOptions` sibling pattern. Integrate into `startOrchestrator()`.
- `ai/daemons/orchestrator/Orchestrator.mjs:393-415` — add `mlxPort` to `start()` options; pass through to `buildTaskDefinitions`.
- `ai/daemons/orchestrator/TaskDefinitions.mjs` — remove `DEFAULT_MLX_MODEL` / `DEFAULT_MLX_PORT` / `DEFAULT_MLX_ENABLED` exports + `resolveMlxEnabled` helper. Simplify `buildTaskDefinitions` signature: `mlxEnabled` defaults to `false`; `mlxModel` / `mlxPort` have no defaults (caller's responsibility).
- `Orchestrator.spec.mjs` — delete "falls back to dedicated mlx default" test (deprecated contract; the daemon now owns the fallback via AiConfig).
- `daemon.spec.mjs` — replace 2 tests covering buildTaskDefinitions' env-var resolution with 4 cleaner tests:
  1. buildTaskDefinitions is pure: tasks.mlx is omitted when mlxEnabled: false
  2. buildTaskDefinitions is pure: no env-var lookups; env-vars present but ignored when concrete values passed
  3. resolveMlxConfig overlays env-var precedence onto AiConfig.orchestrator.mlx (4 sub-cases)
  4. AiConfig.orchestrator.mlx ships canonical MLX launch defaults

## Deltas from ticket (if any)

None substantive. The #11075 ticket explicitly says "Audited surfaces (non-exhaustive; pickup-time intake should expand)" — MLX values were not in the original enumeration but fit the ticket's umbrella. Status comment 2026-05-25 (https://github.com/neomjs/neo/issues/11075#issuecomment-4532133592) added them explicitly. All other originally-enumerated surfaces (intervals, backup retention) were migrated by prior PRs (#11069+ / #11790+) — confirmed via grep + AiConfig read.

The ticket's ACs are now substantively satisfied across the orchestrator config audit. Close-target: `Resolves #11075`.

## Test Evidence

```bash
npm run test-unit -- test/playwright/unit/ai/daemons/orchestrator/
```

→ **247/247 PASS** (8.8s)

Targeted reruns of the directly-affected specs:
- `daemon.spec.mjs` — replaces 2 old MLX tests with 4 new ones (buildTaskDefinitions purity + resolveMlxConfig precedence + AiConfig defaults)
- `Orchestrator.spec.mjs` — 1 deprecated fallback test deleted; the remaining MLX coverage (pass-through into task definitions) still passes verbatim

## Post-Merge Validation

- [ ] Operator confirms MLX defaults still apply via `NEO_ORCHESTRATOR_MLX_ENABLED=true` (the env-var path is unchanged; only the default-resolution layer moved)
- [ ] Smoke test the new `NEO_ORCHESTRATOR_MLX_PORT` env-var: `NEO_ORCHESTRATOR_MLX_PORT=12000 NEO_ORCHESTRATOR_MLX_ENABLED=true node ai/daemons/orchestrator/daemon.mjs` should launch `mlx_lm.server --port 12000`
- [ ] No tenant-side config schemas reference the removed `DEFAULT_MLX_*` symbols (grep clean across `ai/` / `test/`)

## Avoided Traps

- ✓ Did NOT keep the env-var lookups inside `buildTaskDefinitions` — the layered env+default resolution moved cleanly to the daemon boundary, leaving `buildTaskDefinitions` as a pure function
- ✓ Did NOT introduce defensive fallback defaults in `resolveMlxConfig` (would have duplicated AiConfig's defaults across two files; AiConfig template is the single source of truth)
- ✓ Did NOT delete the "passes local mlx launch model config" Orchestrator.spec test — it covers pass-through which is preserved. Only the deprecated "falls back to default" test was removed.

## Authority

#11075 was filed by me 2026-05-10 as a deferred exploration ticket pending orchestrator-validation milestone clearance. That milestone has shipped across #11069 / #11070-#11074 / #11790 / #11791 / #11837 / #11942 substrate (status comment 2026-05-25 confirmed). Operator-direction this turn: TaskDefinitions.mjs tech-debt exploration → MLX values are the concrete remaining gap.

Self-assigned, open lane → impl in same turn per swarm-topology-anchor §AND-discipline.

Authored by [Claude Opus 4.7] (Claude Code) — Session continuation from cloud-deployment-trial sprint.