### PR TITLE
fix(orchestrator): align heartbeat liveness path (#11872)

### DIFF
--- a/ai/daemons/orchestrator/services/SwarmHeartbeatService.mjs
+++ b/ai/daemons/orchestrator/services/SwarmHeartbeatService.mjs
@@ -42,6 +42,22 @@ const DEFAULT_POLL_INTERVAL_MS = 5 * 60 * 1000;
 const PUSH_CAPABLE_TARGETS     = Object.freeze(['mcp-notifications', 'a2a-webhook', 'bridge-daemon']);
 
 /**
+ * @summary Resolves the heartbeat liveness file path shared with HealthService.
+ *
+ * `HealthService` reads the repo-root `.neo-ai-data/wake-daemon/heartbeat.alive`
+ * mtime to project `features.wake.daemonRunning`. This producer must touch the
+ * same path or health checks can remain stale while pulses execute. Tests and
+ * operator probes can isolate the path via `NEO_HEARTBEAT_ALIVE_PATH`, matching
+ * the consumer-side override contract.
+ *
+ * @returns {String}
+ * @see ai/services/memory-core/HealthService.mjs
+ */
+function heartbeatAlivePath() {
+    return process.env.NEO_HEARTBEAT_ALIVE_PATH || path.resolve(__dirname, '../../../../.neo-ai-data/wake-daemon/heartbeat.alive')
+}
+
+/**
  * @summary Neo-singleton swarm-heartbeat lane for Agent OS wake maintenance.
  *
  * The Orchestrator owns the persistent process and scheduler. It awaits
@@ -347,8 +363,7 @@ class SwarmHeartbeatService extends Base {
      * @returns {Promise<void>}
      */
     async touchLivenessFile() {
-        const alivePath = process.env.NEO_HEARTBEAT_ALIVE_PATH
-            || path.resolve(__dirname, '../../.neo-ai-data/wake-daemon/heartbeat.alive');
+        const alivePath = heartbeatAlivePath();
         const now = new Date();
         try {
             await fs.utimes(alivePath, now, now)
@@ -711,4 +726,4 @@ class SwarmHeartbeatService extends Base {
 
 export default Neo.setupClass(SwarmHeartbeatService);
 
-export {HEARTBEAT_LOCK_PATH, DEFAULT_POLL_INTERVAL_MS};
+export {HEARTBEAT_LOCK_PATH, DEFAULT_POLL_INTERVAL_MS, heartbeatAlivePath};

--- a/test/playwright/unit/ai/daemons/orchestrator/services/SwarmHeartbeatService.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/services/SwarmHeartbeatService.spec.mjs
@@ -64,12 +64,15 @@ import {test, expect} from '@playwright/test';
  */
 test.describe('Neo.ai.daemons.SwarmHeartbeatService', () => {
     let SwarmHeartbeatService;
+    let heartbeatAlivePath;
     let GraphService;
     let originalLifecycleInit;
     let originalGraphServiceInit;
 
     test.beforeAll(async () => {
-        SwarmHeartbeatService = (await import('../../../../../../../ai/daemons/orchestrator/services/SwarmHeartbeatService.mjs')).default;
+        const swarmHeartbeatModule = await import('../../../../../../../ai/daemons/orchestrator/services/SwarmHeartbeatService.mjs');
+        SwarmHeartbeatService = swarmHeartbeatModule.default;
+        heartbeatAlivePath    = swarmHeartbeatModule.heartbeatAlivePath;
 
         const services = await import('../../../../../../../ai/services.mjs');
         const LifecycleService = services.Memory_LifecycleService;
@@ -503,6 +506,22 @@ test.describe('Neo.ai.daemons.SwarmHeartbeatService', () => {
 
         await expect(serviceProto.isPushCapable.call(SwarmHeartbeatService, '@neo-gpt')).resolves.toBe(true);
         expect(capturedArgs[0]).toEqual(['@neo-gpt', 'mcp-notifications', 'a2a-webhook', 'bridge-daemon']);
+    });
+
+    test('heartbeatAlivePath() defaults to the repo-root path HealthService reads (#11872)', async () => {
+        const original = process.env.NEO_HEARTBEAT_ALIVE_PATH;
+        delete process.env.NEO_HEARTBEAT_ALIVE_PATH;
+
+        try {
+            expect(heartbeatAlivePath()).toBe(path.resolve(process.cwd(), '.neo-ai-data/wake-daemon/heartbeat.alive'));
+
+            const overridePath = path.join(os.tmpdir(), `neo-heartbeat-override-${Date.now()}.alive`);
+            process.env.NEO_HEARTBEAT_ALIVE_PATH = overridePath;
+            expect(heartbeatAlivePath()).toBe(overridePath);
+        } finally {
+            if (original === undefined) delete process.env.NEO_HEARTBEAT_ALIVE_PATH;
+            else                        process.env.NEO_HEARTBEAT_ALIVE_PATH = original;
+        }
     });
 
     test('pulse() includes expired-count in prompt when sweep yields > 0', async () => {


### PR DESCRIPTION
Authored by GPT-5 (Codex Desktop). Session e5a3acc3-d261-4ebf-96b1-4053ab0eafdf.

FAIR-band: in-band [17/30 — current author count over last 30 merged]

Evidence: L1 (focused unit coverage; live host validation remains post-merge/operator-host).

Refs #11872
Related: #11829

## Summary

Narrow #11872 slice: align the SwarmHeartbeatService heartbeat liveness producer path with the HealthService consumer path. The fresh operator log showed heartbeat work executing while Memory Core health still reported `daemonRunning=false` and a stale `lastPulseAt`; source V-B-A found the producer default path resolved under `ai/daemons/.neo-ai-data/...` while the consumer reads repo-root `.neo-ai-data/...`.

This PR fixes the observability/liveness branch first so the subsequent routing/config parity proof has a trustworthy health signal. It does not claim to close all of #11872.

## Changes

- Adds `heartbeatAlivePath()` in `SwarmHeartbeatService.mjs` with Anchor & Echo documentation.
- Makes `touchLivenessFile()` use that resolver.
- Preserves the existing `NEO_HEARTBEAT_ALIVE_PATH` override for tests and operator probes.
- Adds focused unit coverage proving the default path is repo-root `.neo-ai-data/wake-daemon/heartbeat.alive`, matching the path HealthService reads, and that the env override still wins.

## Contract Ledger

| Surface | Contract | Status |
|---|---|---|
| `NEO_HEARTBEAT_ALIVE_PATH` | Optional override for producer/consumer liveness-file isolation | Preserved |
| Default liveness path | Producer and HealthService consumer use repo-root `.neo-ai-data/wake-daemon/heartbeat.alive` | Fixed |
| `features.wake.daemonRunning` | Health projection should reflect the file touched by SwarmHeartbeatService pulse step 0 | Restored for default config |

## Deltas from ticket

#11872 remains open after this PR. This fixes the liveness-path mismatch surfaced during V-B-A, but the routing/config branch still needs operator-host validation: if the Orchestrator is running with `targetSource=null`, the resolver defaults to `self`, so a Claude-owned process nudging only `@neo-opus-4-7` is expected. Cross-family parity still needs `active-subscribers` or explicit targets to be verified on the host.

## Test Evidence

- `git diff --check`
- `npm run test-unit -- test/playwright/unit/ai/daemons/orchestrator/services/SwarmHeartbeatService.spec.mjs` -> 24/24 PASS
- `npm run test-unit -- test/playwright/unit/ai/daemons/orchestrator/scheduling/swarmHeartbeat.spec.mjs test/playwright/unit/ai/daemons/orchestrator/services/SwarmHeartbeatService.spec.mjs` -> 44/44 PASS

## Post-Merge Validation

- [ ] Restart or observe the operator-host Orchestrator after this lands.
- [ ] Confirm `features.wake.daemonRunning=true` and `lastPulseAt` advances after a swarm-heartbeat pulse without setting `NEO_HEARTBEAT_ALIVE_PATH`.
- [ ] Then run the controlled routing/config parity test for @neo-gpt vs @neo-opus-4-7 under the intended `targetSource` / explicit-target configuration.

## Authored by

GPT-5 (Codex Desktop), `@neo-gpt`.

## Commit

- `fae8c9ea4` — `fix(orchestrator): align heartbeat liveness path (#11872)`