### PR TITLE
chore(orchestrator): retire task-name-constant indirection in TaskDefinitions.mjs (#11955)

### DIFF
--- a/ai/daemons/orchestrator/Orchestrator.mjs
+++ b/ai/daemons/orchestrator/Orchestrator.mjs
@@ -34,11 +34,6 @@ import SwarmHeartbeatService             from './services/SwarmHeartbeatService.
 import GoldenPathSynthesizer             from '../../services/graph/GoldenPathSynthesizer.mjs';
 import {getDueTask as tenantRepoSyncGetDueTaskImport} from './scheduling/tenantRepoSync.mjs';
 import {
-    PRIMARY_DEV_SYNC_TASK_NAME,
-    TENANT_REPO_SYNC_TASK_NAME,
-    DREAM_TASK_NAME,
-    GOLDEN_PATH_TASK_NAME,
-    SWARM_HEARTBEAT_TASK_NAME,
     DEFAULT_DB_PATH,
     DEFAULT_DATA_DIR,
     DEFAULT_SCRIPT_DIR,
@@ -600,7 +595,7 @@ export class Orchestrator extends Base {
             });
         }, executeMaintenanceTask(executeTask), context);
 
-        this.cadenceEngine.runIfDue(PRIMARY_DEV_SYNC_TASK_NAME, () => {
+        this.cadenceEngine.runIfDue('primary-dev-sync', () => {
             return this.primaryDevSyncGetDueTask({
                 state     : this.taskStateService.getState(),
                 now,
@@ -624,7 +619,7 @@ export class Orchestrator extends Base {
             });
         }), context);
 
-        this.cadenceEngine.runIfDue(TENANT_REPO_SYNC_TASK_NAME, () => {
+        this.cadenceEngine.runIfDue('tenant-repo-sync', () => {
             return this.tenantRepoSyncGetDueTask({
                 state     : this.taskStateService.getState(),
                 now,
@@ -641,10 +636,10 @@ export class Orchestrator extends Base {
             });
         }), context);
 
-        this.cadenceEngine.runIfDue(DREAM_TASK_NAME, () => {
+        this.cadenceEngine.runIfDue('dream', () => {
             if (this.cadenceEngine.shouldRunIntervalTask({
                 now,
-                lastRunAt : this.taskStateService.getTaskState(DREAM_TASK_NAME)?.lastRunAt,
+                lastRunAt : this.taskStateService.getTaskState('dream')?.lastRunAt,
                 intervalMs: this.dreamIntervalMs
             })) {
                 return { reason: `periodic-dream:${this.dreamIntervalMs}` };
@@ -665,10 +660,10 @@ export class Orchestrator extends Base {
             }
         }), context);
 
-        this.cadenceEngine.runIfDue(GOLDEN_PATH_TASK_NAME, () => {
+        this.cadenceEngine.runIfDue('golden-path', () => {
             if (this.cadenceEngine.shouldRunIntervalTask({
                 now,
-                lastRunAt : this.taskStateService.getTaskState(GOLDEN_PATH_TASK_NAME)?.lastRunAt,
+                lastRunAt : this.taskStateService.getTaskState('golden-path')?.lastRunAt,
                 intervalMs: this.goldenPathIntervalMs
             })) {
                 return { reason: `periodic-golden-path:${this.goldenPathIntervalMs}` };
@@ -694,7 +689,7 @@ export class Orchestrator extends Base {
         // Swarm-heartbeat lane. NOT heavy maintenance — the pulse is a light
         // wake-substrate check, so the executor runs directly (no `executeMaintenanceTask`
         // wrap). `reason` is passed as a string straight from `CadenceEngine.runIfDue`.
-        this.cadenceEngine.runIfDue(SWARM_HEARTBEAT_TASK_NAME, () => {
+        this.cadenceEngine.runIfDue('swarm-heartbeat', () => {
             if (!this.swarmHeartbeatEnabled) {
                 return null;
             }
@@ -706,7 +701,7 @@ export class Orchestrator extends Base {
             }
             if (this.cadenceEngine.shouldRunIntervalTask({
                 now,
-                lastRunAt : this.taskStateService.getTaskState(SWARM_HEARTBEAT_TASK_NAME)?.lastRunAt,
+                lastRunAt : this.taskStateService.getTaskState('swarm-heartbeat')?.lastRunAt,
                 intervalMs: this.swarmHeartbeatIntervalMs
             })) {
                 return { reason: `periodic-heartbeat:${this.swarmHeartbeatIntervalMs}` };

--- a/ai/daemons/orchestrator/TaskDefinitions.mjs
+++ b/ai/daemons/orchestrator/TaskDefinitions.mjs
@@ -4,12 +4,6 @@ import {fileURLToPath} from 'url';
 const __filename = fileURLToPath(import.meta.url);
 const __dirname  = path.dirname(__filename);
 
-export const PRIMARY_DEV_SYNC_TASK_NAME           = 'primary-dev-sync';
-export const TENANT_REPO_SYNC_TASK_NAME           = 'tenant-repo-sync';
-export const DREAM_TASK_NAME                      = 'dream';
-export const GOLDEN_PATH_TASK_NAME                = 'golden-path';
-export const SWARM_HEARTBEAT_TASK_NAME            = 'swarm-heartbeat';
-
 export const DEFAULT_DB_PATH    = process.env.NEO_AI_DB_PATH || '.neo-ai-data/sqlite/memory-core-graph.sqlite';
 export const DEFAULT_DATA_DIR   = process.env.NEO_AI_ORCHESTRATOR_DIR || '.neo-ai-data/orchestrator-daemon';
 export const DEFAULT_SCRIPT_DIR = path.resolve(__dirname, '../../scripts');
@@ -79,31 +73,31 @@ export function buildTaskDefinitions({
             pidFileName    : 'backup.pid',
             expectedCommand: 'backup.mjs'
         },
-        [PRIMARY_DEV_SYNC_TASK_NAME]: {
+        'primary-dev-sync': {
             label          : 'primary checkout dev sync',
             pidFileName    : 'primary-dev-sync.pid',
             expectedCommand: 'PrimaryRepoSyncService',
             serviceTask    : true
         },
-        [TENANT_REPO_SYNC_TASK_NAME]: {
+        'tenant-repo-sync': {
             label          : 'tenant repo sync (cloud)',
             pidFileName    : 'tenant-repo-sync.pid',
             expectedCommand: 'TenantRepoSyncService',
             serviceTask    : true
         },
-        [DREAM_TASK_NAME]: {
+        dream: {
             label          : 'REM sleep graph extraction',
             pidFileName    : 'dream.pid',
             expectedCommand: 'DreamService',
             serviceTask    : true
         },
-        [GOLDEN_PATH_TASK_NAME]: {
+        'golden-path': {
             label          : 'golden path synthesis',
             pidFileName    : 'golden-path.pid',
             expectedCommand: 'GoldenPathSynthesizer',
             serviceTask    : true
         },
-        [SWARM_HEARTBEAT_TASK_NAME]: {
+        'swarm-heartbeat': {
             label          : 'swarm heartbeat pulse',
             pidFileName    : 'swarm-heartbeat.pid',
             expectedCommand: 'SwarmHeartbeatService',

--- a/ai/daemons/orchestrator/scheduling/primaryDevSync.mjs
+++ b/ai/daemons/orchestrator/scheduling/primaryDevSync.mjs
@@ -1,5 +1,3 @@
-import {PRIMARY_DEV_SYNC_TASK_NAME} from '../TaskDefinitions.mjs';
-
 /**
  * Builds the trigger for the primary-checkout dev-sync lane. Pure function.
  *
@@ -16,7 +14,7 @@ export function buildPrimaryRepoSyncTrigger({enabled, now, lastRunAt, intervalMs
     }
 
     return {
-        taskName: PRIMARY_DEV_SYNC_TASK_NAME,
+        taskName: 'primary-dev-sync',
         source  : 'periodic-sweep',
         reason  : `periodic-sweep:${intervalMs}`
     };
@@ -37,6 +35,6 @@ export function getDueTask({state, now, intervalMs, enabled}) {
         enabled,
         now,
         intervalMs,
-        lastRunAt: state[PRIMARY_DEV_SYNC_TASK_NAME]?.lastRunAt || 0
+        lastRunAt: state['primary-dev-sync']?.lastRunAt || 0
     });
 }

--- a/ai/daemons/orchestrator/scheduling/tenantRepoSync.mjs
+++ b/ai/daemons/orchestrator/scheduling/tenantRepoSync.mjs
@@ -1,5 +1,3 @@
-import {TENANT_REPO_SYNC_TASK_NAME} from '../TaskDefinitions.mjs';
-
 /**
  * Builds the trigger for the cloud-deployable tenant-repo-sync lane.
  * Mirror of `buildPrimaryRepoSyncTrigger` in `./primaryDevSync.mjs` — pure function;
@@ -22,7 +20,7 @@ export function buildTenantRepoSyncTrigger({enabled, now, lastRunAt, intervalMs}
     }
 
     return {
-        taskName: TENANT_REPO_SYNC_TASK_NAME,
+        taskName: 'tenant-repo-sync',
         source  : 'periodic-sweep',
         reason  : `periodic-sweep:${intervalMs}`
     };
@@ -43,6 +41,6 @@ export function getDueTask({state, now, intervalMs, enabled}) {
         enabled,
         now,
         intervalMs,
-        lastRunAt: state[TENANT_REPO_SYNC_TASK_NAME]?.lastRunAt || 0
+        lastRunAt: state['tenant-repo-sync']?.lastRunAt || 0
     });
 }

--- a/ai/daemons/orchestrator/services/MaintenanceBackpressureService.mjs
+++ b/ai/daemons/orchestrator/services/MaintenanceBackpressureService.mjs
@@ -5,12 +5,7 @@ import {
     acquireHeavyMaintenanceLeaseSync,
     releaseHeavyMaintenanceLeaseSync
 } from './HeavyMaintenanceLeaseService.mjs';
-import {
-    DREAM_TASK_NAME,
-    GOLDEN_PATH_TASK_NAME,
-    PRIMARY_DEV_SYNC_TASK_NAME,
-    DEFAULT_DATA_DIR
-} from '../TaskDefinitions.mjs';
+import {DEFAULT_DATA_DIR} from '../TaskDefinitions.mjs';
 
 /**
  * Canonical set of heavy-maintenance task names that participate in the cross-poll
@@ -24,8 +19,8 @@ export const DEFAULT_HEAVY_MAINTENANCE_TASK_NAMES = Object.freeze([
     'summary',
     'kbSync',
     'backup',
-    PRIMARY_DEV_SYNC_TASK_NAME,
-    DREAM_TASK_NAME
+    'primary-dev-sync',
+    'dream'
 ]);
 
 /**
@@ -34,7 +29,7 @@ export const DEFAULT_HEAVY_MAINTENANCE_TASK_NAMES = Object.freeze([
  * @type {ReadonlyArray<String>}
  */
 export const DEFAULT_GOLDEN_PATH_DEPENDENCY_TASK_NAMES = Object.freeze([
-    DREAM_TASK_NAME
+    'dream'
 ]);
 
 // ============================================================================
@@ -513,7 +508,7 @@ export class MaintenanceBackpressureService extends Base {
      * dependency gate to avoid reading a partial graph state.
      *
      * @param {Object} options
-     * @param {String} options.taskName Stable orchestrator task name (`GOLDEN_PATH_TASK_NAME`).
+     * @param {String} options.taskName Stable orchestrator task name (`'golden-path'`).
      * @param {Function} options.executeFn Task body `(taskName, reason) => result`.
      * @param {Object} [options.reason] Scheduling reason.
      * @param {Object} options.activeHeavyTask Mutable `{name: String|null}` tracker for the current poll.
@@ -527,7 +522,7 @@ export class MaintenanceBackpressureService extends Base {
 
         if (blockingTaskName) {
             this.recordDeferral({
-                taskName  : GOLDEN_PATH_TASK_NAME,
+                taskName  : 'golden-path',
                 reasonCode: 'golden-path-dependency-backpressure',
                 reasonText,
                 blockingTaskName

--- a/ai/daemons/orchestrator/services/PrimaryRepoSyncService.mjs
+++ b/ai/daemons/orchestrator/services/PrimaryRepoSyncService.mjs
@@ -2,10 +2,6 @@
 import {execFileSync} from 'child_process';
 import path           from 'path';
 import Base           from '../../../../src/core/Base.mjs';
-import {
-    PRIMARY_DEV_SYNC_TASK_NAME
-} from '../TaskDefinitions.mjs';
-
 const DEV_BRANCH     = 'dev';
 const REMOTE_NAME    = 'origin';
 const REMOTE_REF     = `${REMOTE_NAME}/${DEV_BRANCH}`;
@@ -153,7 +149,7 @@ class PrimaryRepoSyncService extends Base {
     /**
      * Runs the task under the orchestrator state and health envelopes.
      * @param {Object} options
-     * @param {String} [options.taskName=PRIMARY_DEV_SYNC_TASK_NAME]
+     * @param {String} [options.taskName='primary-dev-sync']
      * @param {String} options.reason Scheduling reason.
      * @param {Object} options.taskStateService Orchestrator task-state service.
      * @param {Object} options.healthService HealthService-compatible sink.
@@ -165,7 +161,7 @@ class PrimaryRepoSyncService extends Base {
      * @returns {Object} Execution result.
      */
     runTask({
-        taskName = PRIMARY_DEV_SYNC_TASK_NAME,
+        taskName = 'primary-dev-sync',
         reason,
         taskStateService,
         healthService,

--- a/ai/daemons/orchestrator/services/TenantRepoSyncService.mjs
+++ b/ai/daemons/orchestrator/services/TenantRepoSyncService.mjs
@@ -1,7 +1,7 @@
 import fs from 'fs-extra';
 import path from 'node:path';
 import Base from '../../../../src/core/Base.mjs';
-import {DEFAULT_DATA_DIR, TENANT_REPO_SYNC_TASK_NAME} from '../TaskDefinitions.mjs';
+import {DEFAULT_DATA_DIR} from '../TaskDefinitions.mjs';
 import GitMirror from '../../../services/knowledge-base/helpers/GitMirror.mjs';
 import {buildIngestEnvelope} from '../../../services/knowledge-base/helpers/TenantRepoIngestEnvelopeBuilder.mjs';
 import {normalizeTenantRepoConfig} from '../../../services/knowledge-base/helpers/TenantRepoAccessContract.mjs';
@@ -84,7 +84,7 @@ class TenantRepoSyncService extends Base {
      * | `KB_TENANT_REPO_SYNC_CONCURRENCY_GATE_TIMEOUT` | reserved | future concurrency-limit gate (#11942 AC2); no current emitter |
      *
      * @param {Object} options
-     * @param {String} [options.taskName=TENANT_REPO_SYNC_TASK_NAME]
+     * @param {String} [options.taskName='tenant-repo-sync']
      * @param {String} options.reason Scheduling reason (e.g. `'periodic-sweep:1800000'` or `'manual'`).
      * @param {Object} options.taskStateService Orchestrator task-state service.
      * @param {Object} [options.healthService] HealthService-compatible sink.
@@ -99,7 +99,7 @@ class TenantRepoSyncService extends Base {
      * @returns {Promise<Object>} `{status, details}` — status ∈ {`completed`, `failed`, `skipped`}.
      */
     async runTask({
-        taskName = TENANT_REPO_SYNC_TASK_NAME,
+        taskName = 'tenant-repo-sync',
         reason,
         taskStateService,
         healthService,

--- a/test/playwright/unit/ai/daemons/orchestrator/Orchestrator.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/Orchestrator.spec.mjs
@@ -16,11 +16,6 @@ import {
     DEV_SYNC_ROOTS_ENV_VAR
 } from '../../../../../../ai/daemons/orchestrator/services/PrimaryRepoSyncService.mjs';
 import {
-    PRIMARY_DEV_SYNC_TASK_NAME,
-    TENANT_REPO_SYNC_TASK_NAME,
-    DREAM_TASK_NAME,
-    GOLDEN_PATH_TASK_NAME,
-    SWARM_HEARTBEAT_TASK_NAME,
     buildTaskDefinitions
 } from '../../../../../../ai/daemons/orchestrator/TaskDefinitions.mjs';
 import TaskStateService, { createInitialTaskState } from '../../../../../../ai/daemons/orchestrator/services/TaskStateService.mjs';
@@ -139,7 +134,7 @@ test.describe('Neo.ai.daemons.Orchestrator (#11009)', () => {
             nodeBin  : '/node'
         }));
 
-        expect(Object.keys(state)).toEqual(['chroma', 'bridgeDaemon', 'summary', 'kbSync', 'backup', PRIMARY_DEV_SYNC_TASK_NAME, TENANT_REPO_SYNC_TASK_NAME, DREAM_TASK_NAME, GOLDEN_PATH_TASK_NAME, SWARM_HEARTBEAT_TASK_NAME]);
+        expect(Object.keys(state)).toEqual(['chroma', 'bridgeDaemon', 'summary', 'kbSync', 'backup', 'primary-dev-sync', 'tenant-repo-sync', 'dream', 'golden-path', 'swarm-heartbeat']);
         expect(state.mlx).toBeUndefined();
         expect(state.memoryCoreChroma).toBeUndefined();
         expect(state.summary).toMatchObject({
@@ -280,7 +275,7 @@ test.describe('Neo.ai.daemons.Orchestrator (#11009)', () => {
 
         const orchestrator = createTestOrchestrator();
 
-        TaskStateService.taskState[GOLDEN_PATH_TASK_NAME].running = true;
+        TaskStateService.taskState['golden-path'].running = true;
         orchestrator.processSupervisorService = {
             runTask(taskName, reason) {
                 started.push({taskName, reason});
@@ -358,17 +353,17 @@ test.describe('Neo.ai.daemons.Orchestrator (#11009)', () => {
             }
         });
 
-        TaskStateService.taskState[DREAM_TASK_NAME].running = true;
+        TaskStateService.taskState['dream'].running = true;
         orchestrator.writeLog = (level, message) => logs.push({level, message});
 
         orchestrator.poll();
 
         expect(calls).toEqual([]);
         expect(outcomes).toContainEqual({
-            taskName: GOLDEN_PATH_TASK_NAME,
+            taskName: 'golden-path',
             status  : 'skipped',
             details : expect.objectContaining({
-                blockingTaskName: DREAM_TASK_NAME,
+                blockingTaskName: 'dream',
                 reason          : 'periodic-golden-path:600000',
                 reasonCode      : 'golden-path-dependency-backpressure'
             })
@@ -529,7 +524,7 @@ test.describe('Neo.ai.daemons.Orchestrator (#11009)', () => {
             primaryDevSyncEnabled   : true,
             primaryDevSyncIntervalMs: 600000,
             primaryDevSyncGetDueTask: () => ({
-                taskName: PRIMARY_DEV_SYNC_TASK_NAME,
+                taskName: 'primary-dev-sync',
                 reason  : 'periodic-sweep:600000'
             }),
             primaryRepoSyncService  : {
@@ -546,7 +541,7 @@ test.describe('Neo.ai.daemons.Orchestrator (#11009)', () => {
         orchestrator.poll();
 
         expect(started).toEqual([{
-            taskName: PRIMARY_DEV_SYNC_TASK_NAME,
+            taskName: 'primary-dev-sync',
             reason  : 'periodic-sweep:600000'
         }]);
     });
@@ -559,7 +554,7 @@ test.describe('Neo.ai.daemons.Orchestrator (#11009)', () => {
             tenantRepoSyncEnabled   : true,
             tenantRepoSyncIntervalMs: 600000,
             tenantRepoSyncGetDueTask: () => ({
-                taskName: TENANT_REPO_SYNC_TASK_NAME,
+                taskName: 'tenant-repo-sync',
                 source  : 'periodic-sweep',
                 reason  : 'periodic-sweep:600000'
             }),
@@ -577,7 +572,7 @@ test.describe('Neo.ai.daemons.Orchestrator (#11009)', () => {
         orchestrator.poll();
 
         expect(started).toEqual([{
-            taskName: TENANT_REPO_SYNC_TASK_NAME,
+            taskName: 'tenant-repo-sync',
             reason  : 'periodic-sweep:600000'
         }]);
     });
@@ -618,7 +613,7 @@ test.describe('Neo.ai.daemons.Orchestrator (#11009)', () => {
                 primaryDevSyncIntervalMs  : 600000,
                 primaryDevSyncRootsConfig : ['/config/neo'],
                 primaryDevSyncGetDueTask  : () => ({
-                    taskName: PRIMARY_DEV_SYNC_TASK_NAME,
+                    taskName: 'primary-dev-sync',
                     reason  : 'periodic-sweep:600000'
                 }),
                 primaryRepoSyncService    : {
@@ -684,13 +679,13 @@ test.describe('Neo.ai.daemons.Orchestrator (#11009)', () => {
         expect([...DEFAULT_HEAVY_MAINTENANCE_TASK_NAMES].sort()).toEqual([
             'backup',
             'kbSync',
-            PRIMARY_DEV_SYNC_TASK_NAME,
-            DREAM_TASK_NAME,
+            'primary-dev-sync',
+            'dream',
             'summary'
         ].sort());
         expect(Object.isFrozen(DEFAULT_HEAVY_MAINTENANCE_TASK_NAMES)).toBe(true);
         // Defensive: golden-path is intentionally OUT per #11511 / #11512 (light maintenance).
-        expect(DEFAULT_HEAVY_MAINTENANCE_TASK_NAMES).not.toContain(GOLDEN_PATH_TASK_NAME);
+        expect(DEFAULT_HEAVY_MAINTENANCE_TASK_NAMES).not.toContain('golden-path');
     });
 
     test('defers due backup when another heavy maintenance task is already running (#11513 AC3)', () => {
@@ -793,7 +788,7 @@ test.describe('Neo.ai.daemons.Orchestrator (#11009)', () => {
 
         expect(dreamCalls).toEqual([]);
         expect(outcomes).toContainEqual({
-            taskName: DREAM_TASK_NAME,
+            taskName: 'dream',
             status  : 'skipped',
             details : expect.objectContaining({
                 blockingTaskName: 'summary',
@@ -816,7 +811,7 @@ test.describe('Neo.ai.daemons.Orchestrator (#11009)', () => {
             primaryDevSyncGetDueTask: () => {
                 getDueTaskCalls.push('called');
                 return {
-                    taskName: PRIMARY_DEV_SYNC_TASK_NAME,
+                    taskName: 'primary-dev-sync',
                     reason  : 'periodic-primary-dev-sync:test'
                 };
             },
@@ -834,7 +829,7 @@ test.describe('Neo.ai.daemons.Orchestrator (#11009)', () => {
         expect(getDueTaskCalls.length).toBeGreaterThan(0);
         expect(runTaskCalls).toEqual([]);
         expect(outcomes).toContainEqual({
-            taskName: PRIMARY_DEV_SYNC_TASK_NAME,
+            taskName: 'primary-dev-sync',
             status  : 'skipped',
             details : expect.objectContaining({
                 blockingTaskName: 'summary',
@@ -992,12 +987,12 @@ test.describe('Neo.ai.daemons.Orchestrator (#11009)', () => {
         await Promise.resolve();
 
         expect(outcomes).toContainEqual({
-            taskName: SWARM_HEARTBEAT_TASK_NAME,
+            taskName: 'swarm-heartbeat',
             status  : 'running',
             details : expect.objectContaining({reason: 'periodic-heartbeat:600000'})
         });
         expect(outcomes).toContainEqual({
-            taskName: SWARM_HEARTBEAT_TASK_NAME,
+            taskName: 'swarm-heartbeat',
             status  : 'completed',
             details : expect.objectContaining({reason: 'periodic-heartbeat:600000'})
         });

--- a/test/playwright/unit/ai/daemons/orchestrator/scheduling/primaryDevSync.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/scheduling/primaryDevSync.spec.mjs
@@ -3,12 +3,11 @@ import {
     buildPrimaryRepoSyncTrigger,
     getDueTask
 } from '../../../../../../../ai/daemons/orchestrator/scheduling/primaryDevSync.mjs';
-import {PRIMARY_DEV_SYNC_TASK_NAME} from '../../../../../../../ai/daemons/orchestrator/TaskDefinitions.mjs';
 
 test.describe('orchestrator/scheduling/primaryDevSync (#11864 / Epic #11831)', () => {
     test('buildPrimaryRepoSyncTrigger fires when enabled + interval elapsed', () => {
         expect(buildPrimaryRepoSyncTrigger({enabled: true, now: 60000, lastRunAt: 0, intervalMs: 60000})).toEqual({
-            taskName: PRIMARY_DEV_SYNC_TASK_NAME,
+            taskName: 'primary-dev-sync',
             source  : 'periodic-sweep',
             reason  : 'periodic-sweep:60000'
         });
@@ -26,14 +25,14 @@ test.describe('orchestrator/scheduling/primaryDevSync (#11864 / Epic #11831)', (
         expect(buildPrimaryRepoSyncTrigger({enabled: true, now: 999999999, lastRunAt: 0, intervalMs: 0})).toBeNull();
     });
 
-    test('getDueTask wraps buildPrimaryRepoSyncTrigger with state mapping (keyed by PRIMARY_DEV_SYNC_TASK_NAME)', () => {
+    test('getDueTask wraps buildPrimaryRepoSyncTrigger with state mapping (keyed by primary-dev-sync)', () => {
         expect(getDueTask({
-            state     : {[PRIMARY_DEV_SYNC_TASK_NAME]: {lastRunAt: 1000}},
+            state     : {['primary-dev-sync']: {lastRunAt: 1000}},
             now       : 1000 + 60000,
             intervalMs: 60000,
             enabled   : true
         })).toEqual({
-            taskName: PRIMARY_DEV_SYNC_TASK_NAME,
+            taskName: 'primary-dev-sync',
             source  : 'periodic-sweep',
             reason  : 'periodic-sweep:60000'
         });
@@ -41,7 +40,7 @@ test.describe('orchestrator/scheduling/primaryDevSync (#11864 / Epic #11831)', (
 
     test('getDueTask returns null when not enabled', () => {
         expect(getDueTask({
-            state     : {[PRIMARY_DEV_SYNC_TASK_NAME]: {lastRunAt: 0}},
+            state     : {['primary-dev-sync']: {lastRunAt: 0}},
             now       : 60000,
             intervalMs: 60000,
             enabled   : false

--- a/test/playwright/unit/ai/daemons/orchestrator/scheduling/tenantRepoSync.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/scheduling/tenantRepoSync.spec.mjs
@@ -1,6 +1,5 @@
 import {test, expect} from '@playwright/test';
 import {buildTenantRepoSyncTrigger, getDueTask} from '../../../../../../../ai/daemons/orchestrator/scheduling/tenantRepoSync.mjs';
-import {TENANT_REPO_SYNC_TASK_NAME} from '../../../../../../../ai/daemons/orchestrator/TaskDefinitions.mjs';
 
 test.describe('tenantRepoSync trigger (#11790)', () => {
     test('returns null when disabled', () => {
@@ -19,17 +18,17 @@ test.describe('tenantRepoSync trigger (#11790)', () => {
     test('returns trigger when enabled + interval elapsed', () => {
         const trigger = buildTenantRepoSyncTrigger({enabled: true, now: 70000, lastRunAt: 0, intervalMs: 60000});
         expect(trigger).toEqual({
-            taskName: TENANT_REPO_SYNC_TASK_NAME,
+            taskName: 'tenant-repo-sync',
             source  : 'periodic-sweep',
             reason  : 'periodic-sweep:60000'
         });
     });
 
     test('getDueTask derives lastRunAt from state', () => {
-        const state = {[TENANT_REPO_SYNC_TASK_NAME]: {lastRunAt: 5000}};
+        const state = {['tenant-repo-sync']: {lastRunAt: 5000}};
         const trigger = getDueTask({state, now: 70000, intervalMs: 60000, enabled: true});
         expect(trigger).not.toBeNull();
-        expect(trigger.taskName).toBe(TENANT_REPO_SYNC_TASK_NAME);
+        expect(trigger.taskName).toBe('tenant-repo-sync');
     });
 
     test('getDueTask handles missing task state (bootstrap, lastRunAt=0)', () => {

--- a/test/playwright/unit/ai/daemons/orchestrator/services/MaintenanceBackpressureService.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/services/MaintenanceBackpressureService.spec.mjs
@@ -13,11 +13,6 @@ import {
     recordDeferral,
     resolveHeavyMaintenanceLeasePath
 } from '../../../../../../../ai/daemons/orchestrator/services/MaintenanceBackpressureService.mjs';
-import {
-    DREAM_TASK_NAME,
-    GOLDEN_PATH_TASK_NAME,
-    PRIMARY_DEV_SYNC_TASK_NAME
-} from '../../../../../../../ai/daemons/orchestrator/TaskDefinitions.mjs';
 
 // A non-heavy task name (must NOT be in DEFAULT_HEAVY_MAINTENANCE_TASK_NAMES) for
 // passthrough tests of `acquireLeaseAndExecute`.
@@ -61,18 +56,18 @@ test.describe('Neo.ai.daemons.orchestrator.services.MaintenanceBackpressureServi
     test('DEFAULT_HEAVY_MAINTENANCE_TASK_NAMES pins the canonical heavy-classification set', () => {
         expect([...DEFAULT_HEAVY_MAINTENANCE_TASK_NAMES].sort()).toEqual([
             'backup',
-            DREAM_TASK_NAME,
+            'dream',
             'kbSync',
-            PRIMARY_DEV_SYNC_TASK_NAME,
+            'primary-dev-sync',
             'summary'
         ].sort());
         expect(Object.isFrozen(DEFAULT_HEAVY_MAINTENANCE_TASK_NAMES)).toBe(true);
         // Golden Path is light maintenance per #11511 / PR #11512 — must NOT be in heavy set
-        expect(DEFAULT_HEAVY_MAINTENANCE_TASK_NAMES).not.toContain(GOLDEN_PATH_TASK_NAME);
+        expect(DEFAULT_HEAVY_MAINTENANCE_TASK_NAMES).not.toContain('golden-path');
     });
 
     test('DEFAULT_GOLDEN_PATH_DEPENDENCY_TASK_NAMES pins the dependency set', () => {
-        expect([...DEFAULT_GOLDEN_PATH_DEPENDENCY_TASK_NAMES]).toEqual([DREAM_TASK_NAME]);
+        expect([...DEFAULT_GOLDEN_PATH_DEPENDENCY_TASK_NAMES]).toEqual(['dream']);
         expect(Object.isFrozen(DEFAULT_GOLDEN_PATH_DEPENDENCY_TASK_NAMES)).toBe(true);
     });
 
@@ -86,14 +81,14 @@ test.describe('Neo.ai.daemons.orchestrator.services.MaintenanceBackpressureServi
             heavyMaintenanceTaskNames: DEFAULT_HEAVY_MAINTENANCE_TASK_NAMES
         })).toBe(true);
         expect(isHeavyMaintenanceTask({
-            taskName                 : GOLDEN_PATH_TASK_NAME,
+            taskName                 : 'golden-path',
             heavyMaintenanceTaskNames: DEFAULT_HEAVY_MAINTENANCE_TASK_NAMES
         })).toBe(false);
     });
 
     test('isGoldenPathDependencyTask returns membership in dependency set', () => {
         expect(isGoldenPathDependencyTask({
-            taskName                     : DREAM_TASK_NAME,
+            taskName                     : 'dream',
             goldenPathDependencyTaskNames: DEFAULT_GOLDEN_PATH_DEPENDENCY_TASK_NAMES
         })).toBe(true);
         expect(isGoldenPathDependencyTask({
@@ -132,15 +127,15 @@ test.describe('Neo.ai.daemons.orchestrator.services.MaintenanceBackpressureServi
         expect(getActiveGoldenPathDependencyTask({
             goldenPathDependencyTaskNames: DEFAULT_GOLDEN_PATH_DEPENDENCY_TASK_NAMES,
             taskStateService,
-            activeTaskName               : DREAM_TASK_NAME
-        })).toBe(DREAM_TASK_NAME);
+            activeTaskName               : 'dream'
+        })).toBe('dream');
 
         // activeTaskName is NOT a dependency → fall back to state scan
         expect(getActiveGoldenPathDependencyTask({
             goldenPathDependencyTaskNames: DEFAULT_GOLDEN_PATH_DEPENDENCY_TASK_NAMES,
-            taskStateService             : buildTaskStateService({[DREAM_TASK_NAME]: {running: true}}),
+            taskStateService             : buildTaskStateService({['dream']: {running: true}}),
             activeTaskName               : 'summary'
-        })).toBe(DREAM_TASK_NAME);
+        })).toBe('dream');
 
         // No dependency running, no active dependency → null
         expect(getActiveGoldenPathDependencyTask({
@@ -271,13 +266,13 @@ test.describe('Neo.ai.daemons.orchestrator.services.MaintenanceBackpressureServi
 
         recordDeferral({
             deferralLogKeys,
-            taskName       : GOLDEN_PATH_TASK_NAME,
+            taskName       : 'golden-path',
             reasonCode     : 'golden-path-dependency-backpressure',
             reasonText     : `periodic-golden-path:1800000`,
-            blockingTaskName: DREAM_TASK_NAME,
+            blockingTaskName: 'dream',
             taskDefinitions: {
-                [GOLDEN_PATH_TASK_NAME]: {label: 'Golden Path'},
-                [DREAM_TASK_NAME]      : {label: 'Dream cycle'}
+                ['golden-path']: {label: 'Golden Path'},
+                ['dream']      : {label: 'Dream cycle'}
             },
             writeLog: (level, message) => logCalls.push({level, message})
         });
@@ -477,12 +472,12 @@ test.describe('Neo.ai.daemons.orchestrator.services.MaintenanceBackpressureServi
     test('executeWithGoldenPathDependencyGate defers when dependency task is running', () => {
         const outcomeCalls = [];
         const service      = buildService({
-            taskStateService: buildTaskStateService({[DREAM_TASK_NAME]: {running: true}}),
+            taskStateService: buildTaskStateService({['dream']: {running: true}}),
             healthService   : {recordTaskOutcome: (t, s, p) => outcomeCalls.push({t, s, p})}
         });
 
         const result = service.executeWithGoldenPathDependencyGate({
-            taskName       : GOLDEN_PATH_TASK_NAME,
+            taskName       : 'golden-path',
             executeFn      : () => { throw new Error('should not execute'); },
             reason         : 'periodic-golden-path',
             activeHeavyTask: {name: null}
@@ -490,7 +485,7 @@ test.describe('Neo.ai.daemons.orchestrator.services.MaintenanceBackpressureServi
 
         expect(result).toBe(false);
         expect(outcomeCalls[0].p.reasonCode).toBe('golden-path-dependency-backpressure');
-        expect(outcomeCalls[0].p.blockingTaskName).toBe(DREAM_TASK_NAME);
+        expect(outcomeCalls[0].p.blockingTaskName).toBe('dream');
     });
 
     test('executeWithGoldenPathDependencyGate passes through when no dependency is running', () => {
@@ -500,13 +495,13 @@ test.describe('Neo.ai.daemons.orchestrator.services.MaintenanceBackpressureServi
         });
 
         const result = service.executeWithGoldenPathDependencyGate({
-            taskName       : GOLDEN_PATH_TASK_NAME,
+            taskName       : 'golden-path',
             executeFn      : (taskName, reason) => { executions.push({taskName, reason}); return 'gp-done'; },
             reason         : 'periodic-golden-path',
             activeHeavyTask: {name: null}
         });
 
-        expect(executions).toEqual([{taskName: GOLDEN_PATH_TASK_NAME, reason: 'periodic-golden-path'}]);
+        expect(executions).toEqual([{taskName: 'golden-path', reason: 'periodic-golden-path'}]);
         expect(result).toBe('gp-done');
     });
 });

--- a/test/playwright/unit/ai/daemons/orchestrator/services/PrimaryRepoSyncService.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/services/PrimaryRepoSyncService.spec.mjs
@@ -7,9 +7,6 @@ import PrimaryRepoSyncService, {
     isKbRelevantChangePath,
     parseDevSyncRoots
 } from '../../../../../../../ai/daemons/orchestrator/services/PrimaryRepoSyncService.mjs';
-import {
-    PRIMARY_DEV_SYNC_TASK_NAME
-} from '../../../../../../../ai/daemons/orchestrator/TaskDefinitions.mjs';
 
 function createExecStub(steps) {
     const calls = [];
@@ -682,8 +679,8 @@ test.describe('PrimaryRepoSyncService (#11017)', () => {
 
         expect(result.status).toBe('skipped');
         expect(taskStateService.events).toEqual([
-            ['started', PRIMARY_DEV_SYNC_TASK_NAME, 'periodic-sweep:600000'],
-            ['skipped', PRIMARY_DEV_SYNC_TASK_NAME]
+            ['started', 'primary-dev-sync', 'periodic-sweep:600000'],
+            ['skipped', 'primary-dev-sync']
         ]);
         expect(outcomes[0].status).toBe('skipped');
         expect(outcomes[0].details.reasonCode).toBe('up-to-date');

--- a/test/playwright/unit/ai/daemons/orchestrator/services/TenantRepoSyncService.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/services/TenantRepoSyncService.spec.mjs
@@ -24,7 +24,6 @@ import os              from 'os';
 import path            from 'path';
 
 import TenantRepoSyncService from '../../../../../../../ai/daemons/orchestrator/services/TenantRepoSyncService.mjs';
-import {TENANT_REPO_SYNC_TASK_NAME} from '../../../../../../../ai/daemons/orchestrator/TaskDefinitions.mjs';
 import {deriveTenantRepoMirrorPath} from '../../../../../../../ai/services/knowledge-base/helpers/TenantRepoAccessContract.mjs';
 
 // Serial mode: TenantRepoSyncService is a singleton.
@@ -123,12 +122,12 @@ test.describe('TenantRepoSyncService (#11790)', () => {
         expect(result.status).toBe('skipped');
         expect(result.details.reason).toBe('no-tenant-repos-configured');
         expect(result.details.repoCount).toBe(0);
-        expect(taskStateService.taskState[TENANT_REPO_SYNC_TASK_NAME].skippedAt).toBeTruthy();
+        expect(taskStateService.taskState['tenant-repo-sync'].skippedAt).toBeTruthy();
     });
 
     test('skipped when already running (re-entrancy guard)', async () => {
         const taskStateService = createInMemoryTaskStateService();
-        taskStateService.taskState[TENANT_REPO_SYNC_TASK_NAME] = {running: true, pid: 12345};
+        taskStateService.taskState['tenant-repo-sync'] = {running: true, pid: 12345};
 
         const result = await TenantRepoSyncService.runTask({
             reason          : 'periodic',


### PR DESCRIPTION
Authored by Claude Opus 4.7 (Claude Code). Session continuation from cloud-deployment-trial sprint.

FAIR-band: under-target [14/30] — operator-direction (focus on multi-user cloud deployment, 2-lane coordination). Live verifier: GPT 17 / Claude 14 over last 30 merged PRs.

Evidence: L1 (246/246 PASS across orchestrator-tree post-migration; targeted-pattern grep returns zero hits for the 5 retired alias constants).

Resolves #11955

## Summary

Inline 5 task-name string constants and remove the 5 export declarations from `ai/daemons/orchestrator/TaskDefinitions.mjs`. Pure inline-replacement refactor: no behavior change, net -39 LOC.

Operator-flagged 2026-05-25 during TaskDefinitions.mjs technical-debt exploration: *"some vars feel not needed like DREAM_TASK_NAME => why should someone want to rename it."* Companion to #11075 (MLX config migration, PR #11957) but a **distinct concern shape** — this is over-abstraction, not misplacement.

## Changes

### The argument

`PRIMARY_DEV_SYNC_TASK_NAME = 'primary-dev-sync'` (and 4 siblings) added a layer of import-side indirection with zero rename-insurance value. The string values are stable cross-substrate identifiers — the same literals serve as:

- Property keys on the `tasks` registry in `buildTaskDefinitions()`
- PID file basenames (`dream.pid`, `tenant-repo-sync.pid`, …)
- Task-state DB keys consumed by `TaskStateService`
- Health-payload field names emitted by `HealthService`
- Log-line substrings
- Test fixture keys
- Doc references in `learn/agentos/`

Renaming any literal would cascade across all these non-import surfaces — so the import-side constant insures nothing. The `buildTaskDefinitions().tasks` object already serves as the canonical registry; the constants duplicated that discoverability without adding it.

### Surface audit

**Source files** (5 + TaskDefinitions.mjs):
- [`TaskDefinitions.mjs`](ai/daemons/orchestrator/TaskDefinitions.mjs) — 5 export decls removed; computed-property-key `[CONSTANT]: { ... }` → quoted-literal `'name': { ... }` (`dream` is unquoted bareword since no special chars)
- [`Orchestrator.mjs`](ai/daemons/orchestrator/Orchestrator.mjs) — 5 import lines collapsed; ~10 use-site replacements (cadenceEngine.runIfDue calls + state lookups)
- [`scheduling/primaryDevSync.mjs`](ai/daemons/orchestrator/scheduling/primaryDevSync.mjs) — 1 import + 2 use-site replacements
- [`scheduling/tenantRepoSync.mjs`](ai/daemons/orchestrator/scheduling/tenantRepoSync.mjs) — 1 import + 2 use-site replacements
- [`services/PrimaryRepoSyncService.mjs`](ai/daemons/orchestrator/services/PrimaryRepoSyncService.mjs) — 1 import + 1 default-param replacement
- [`services/TenantRepoSyncService.mjs`](ai/daemons/orchestrator/services/TenantRepoSyncService.mjs) — 1 import collapsed; 1 default-param replacement
- [`services/MaintenanceBackpressureService.mjs`](ai/daemons/orchestrator/services/MaintenanceBackpressureService.mjs) — 3 imports collapsed; `DEFAULT_HEAVY_MAINTENANCE_TASK_NAMES` + `DEFAULT_GOLDEN_PATH_DEPENDENCY_TASK_NAMES` arrays now contain literals directly

**Test files** (6):
- [`Orchestrator.spec.mjs`](test/playwright/unit/ai/daemons/orchestrator/Orchestrator.spec.mjs) — 5 imports collapsed; ~12 use-site replacements (task-name fixtures, state-keyed assertions)
- [`MaintenanceBackpressureService.spec.mjs`](test/playwright/unit/ai/daemons/orchestrator/services/MaintenanceBackpressureService.spec.mjs) — 3 imports collapsed; ~12 use-site replacements
- 4 other spec files — 1-2 imports + few use-site replacements each

### What stays

- `DEFAULT_HEAVY_MAINTENANCE_TASK_NAMES` + `DEFAULT_GOLDEN_PATH_DEPENDENCY_TASK_NAMES` array exports remain (those are different semantics — they're _enumerations of task-membership in a behavior class_, not aliases for individual literals)
- `NON_HEAVY_TASK_NAME` local constant in MaintenanceBackpressureService.spec.mjs (intentional test-scoped variable, not a rename-aliased import)
- `DEFAULT_DB_PATH` / `DEFAULT_DATA_DIR` / `DEFAULT_SCRIPT_DIR` in TaskDefinitions.mjs (these are env-var-overridable path resolvers, semantically distinct from task-name labels)
- `DEFAULT_MLX_MODEL` / `DEFAULT_MLX_PORT` / `DEFAULT_MLX_ENABLED` + `resolveMlxEnabled` — those are #11075's concern; tracked separately in PR #11957

## Deltas from ticket

**AC6 grep-pattern tightening** (cycle-1 review reconciliation per @neo-gpt at https://github.com/neomjs/neo/pull/11959):

The original #11955 AC6 stated `grep -rn "_TASK_NAME" ai/ test/` should return zero hits. That pattern was overly broad — it also matches the legitimate `DEFAULT_HEAVY_MAINTENANCE_TASK_NAMES` / `DEFAULT_GOLDEN_PATH_DEPENDENCY_TASK_NAMES` array exports + the local `NON_HEAVY_TASK_NAME` test constant, all of which are intentional and out of scope for this retirement (they're membership-set classifications + local test scopes, not import-side aliases for individual literals).

The corrected AC6 is documented at https://github.com/neomjs/neo/issues/11955#issuecomment — it targets the 5 retired alias constants exactly:

```bash
grep -rEn 'PRIMARY_DEV_SYNC_TASK_NAME|TENANT_REPO_SYNC_TASK_NAME|DREAM_TASK_NAME|GOLDEN_PATH_TASK_NAME|SWARM_HEARTBEAT_TASK_NAME' ai/ test/
```

→ Returns zero hits at head `acdc683224b07e88d0912ad1f88c936f91dfbc73`. The shipped implementation satisfies the corrected AC; the original AC was imprecisely written.

## Test Evidence

```bash
npm run test-unit -- test/playwright/unit/ai/daemons/orchestrator/
```

→ **246/246 PASS** (7.2s)

Grep-AC verification (precise pattern per corrected AC6):
```bash
grep -rEn 'PRIMARY_DEV_SYNC_TASK_NAME|TENANT_REPO_SYNC_TASK_NAME|DREAM_TASK_NAME|GOLDEN_PATH_TASK_NAME|SWARM_HEARTBEAT_TASK_NAME' --include="*.mjs" ai/ test/
```

→ **Zero hits.** Legitimate `DEFAULT_*_TASK_NAMES` membership-set exports + `NON_HEAVY_TASK_NAME` test-scoped constant remain by design (documented in "What stays" above).

## Post-Merge Validation

- [ ] Operator confirms no downstream substrate (docs, learn/, MCP tool schemas) carried `_TASK_NAME` literal references for the 5 retired aliases

## Avoided Traps

- ✓ Did NOT replace with an enum object (e.g., `TASK_NAMES.DREAM`) — that's the same indirection in a different shape; doesn't change the cost/benefit
- ✓ Did NOT bundle with #11075 MLX migration — distinct concern (over-abstraction vs misplacement), separate ticket per `feedback_ticket_prescription_clarity`
- ✓ Did NOT retire `DEFAULT_*` path resolvers in the same PR — those have legitimate env-var-coercion semantics, different shape
- ✓ Did NOT retire `DEFAULT_HEAVY_MAINTENANCE_TASK_NAMES` / `DEFAULT_GOLDEN_PATH_DEPENDENCY_TASK_NAMES` — those are membership-set classifications, not import-side aliases

## Authority

#11955 was filed by me 2026-05-25 in the same turn the operator surfaced the concern. Self-assigned; implementation in same turn per swarm-topology-anchor §AND-discipline. AC6 corrected post-cycle-1 review for substrate-precision.

Authored by [Claude Opus 4.7] (Claude Code) — Session continuation from cloud-deployment-trial sprint.