### PR TITLE
feat(orchestrator): per-repo jitter + exponential backoff for tenant-repo-sync (#11942 AC1)

### DIFF
--- a/ai/config.template.mjs
+++ b/ai/config.template.mjs
@@ -157,11 +157,18 @@ const defaultConfig = {
          *   of the base cadence. Default `0.20` (≤20% of cadence per AC1 prescription).
          *   Set `0` to disable jitter entirely (deterministic-cadence-only, no anti-
          *   thundering-herd protection — only safe for low-tenant deployments).
+         * - `sweepCadenceMs` is the frequency at which the orchestrator wakes the
+         *   tenant-repo-sync task. Decoupled from per-repo cadence (`intervals.tenantRepoSyncMs`)
+         *   so deterministic jitter can actually spread per-repo sync attempts across
+         *   the jitter window. A short sweep cadence + a long per-repo cadence means
+         *   each sweep checks all repos against their individual due-times; repos
+         *   become due at different sweeps based on their deterministic jitter offset.
          *
          * @type {Object}
          */
         tenantRepoSync: {
-            jitterRatio: 0.20
+            jitterRatio   : 0.20,
+            sweepCadenceMs: 60 * 1000
         },
         /**
          * Orchestrator-owned MLX inference server config. Operators tune via gitignored

--- a/ai/config.template.mjs
+++ b/ai/config.template.mjs
@@ -148,6 +148,22 @@ const defaultConfig = {
          */
         devSyncRoots: [],
         /**
+         * Tenant-repo-sync per-repo scheduling parameters (#11942 AC1).
+         *
+         * The cadence floor lives in `intervals.tenantRepoSyncMs` above (30min default).
+         * Per-repo cadence in `tenantRepos[].cadenceMs` (operator-set) overrides global.
+         *
+         * - `jitterRatio` caps the deterministic per-repo jitter offset as a fraction
+         *   of the base cadence. Default `0.20` (≤20% of cadence per AC1 prescription).
+         *   Set `0` to disable jitter entirely (deterministic-cadence-only, no anti-
+         *   thundering-herd protection — only safe for low-tenant deployments).
+         *
+         * @type {Object}
+         */
+        tenantRepoSync: {
+            jitterRatio: 0.20
+        },
+        /**
          * Orchestrator-owned MLX inference server config. Operators tune via gitignored
          * `ai/config.mjs` or env vars (`NEO_ORCHESTRATOR_MLX_ENABLED`,
          * `NEO_ORCHESTRATOR_MLX_MODEL`, `NEO_ORCHESTRATOR_MLX_PORT`).

--- a/ai/daemons/orchestrator/Orchestrator.mjs
+++ b/ai/daemons/orchestrator/Orchestrator.mjs
@@ -348,7 +348,26 @@ export class Orchestrator extends Base {
     get kbSyncIntervalMs()        { return Env.parseNumber('NEO_ORCHESTRATOR_KB_SYNC_INTERVAL_MS')          ?? AiConfig.orchestrator.intervals.kbSyncMs;           }
     get backupIntervalMs()        { return Env.parseNumber('NEO_ORCHESTRATOR_BACKUP_INTERVAL_MS')           ?? AiConfig.orchestrator.intervals.backupMs;           }
     get primaryDevSyncIntervalMs(){ return Env.parseNumber('NEO_ORCHESTRATOR_PRIMARY_DEV_SYNC_INTERVAL_MS') ?? AiConfig.orchestrator.intervals.primaryDevSyncMs;   }
+    /**
+     * Per-repo global cadence — the default time between sync attempts for a single
+     * configured tenant repo. Decoupled from the orchestrator-level sweep cadence
+     * (`tenantRepoSyncSweepCadenceMs`) so deterministic jitter can actually spread
+     * per-repo work across the jitter window. Env var name preserved for back-compat.
+     */
     get tenantRepoSyncIntervalMs(){ return Env.parseNumber('NEO_ORCHESTRATOR_TENANT_REPO_SYNC_INTERVAL_MS') ?? AiConfig.orchestrator.intervals.tenantRepoSyncMs;   }
+    /**
+     * Orchestrator-level sweep cadence — how often `tenant-repo-sync` is invoked.
+     * Short by design (default 1min) so per-repo deterministic jitter spreads
+     * actual sync attempts across the jitter window instead of synchronizing them
+     * onto the sweep boundary.
+     */
+    get tenantRepoSyncSweepCadenceMs(){ return Env.parseNumber('NEO_ORCHESTRATOR_TENANT_REPO_SYNC_SWEEP_CADENCE_MS') ?? AiConfig.orchestrator.tenantRepoSync.sweepCadenceMs; }
+    /**
+     * Per-repo jitter ratio (fraction of base cadence). Defaults to the configured
+     * `aiConfig.orchestrator.tenantRepoSync.jitterRatio`; env-overridable so
+     * deployment-specific tuning doesn't require a config-template edit.
+     */
+    get tenantRepoSyncJitterRatio()  { return Env.parseNumber('NEO_ORCHESTRATOR_TENANT_REPO_SYNC_JITTER_RATIO')   ?? AiConfig.orchestrator.tenantRepoSync.jitterRatio;     }
     get dreamIntervalMs()         { return Env.parseNumber('NEO_ORCHESTRATOR_DREAM_INTERVAL_MS')            ?? AiConfig.orchestrator.intervals.dreamMs;            }
     get goldenPathIntervalMs()    { return Env.parseNumber('NEO_ORCHESTRATOR_GOLDEN_PATH_INTERVAL_MS')      ?? AiConfig.orchestrator.intervals.goldenPathMs;       }
     get swarmHeartbeatIntervalMs(){ return Env.parseNumber('NEO_ORCHESTRATOR_SWARM_HEARTBEAT_INTERVAL_MS')  ?? AiConfig.orchestrator.intervals.swarmHeartbeatMs;   }
@@ -623,7 +642,7 @@ export class Orchestrator extends Base {
             return this.tenantRepoSyncGetDueTask({
                 state     : this.taskStateService.getState(),
                 now,
-                intervalMs: this.tenantRepoSyncIntervalMs,
+                intervalMs: this.tenantRepoSyncSweepCadenceMs,
                 enabled   : this.tenantRepoSyncEnabled
             });
         }, executeMaintenanceTask((taskName, reason) => {
@@ -632,7 +651,9 @@ export class Orchestrator extends Base {
                 reason,
                 taskStateService: this.taskStateService,
                 healthService   : this.healthService,
-                writeLog        : this.writeLog.bind(this)
+                writeLog        : this.writeLog.bind(this),
+                globalCadenceMs : this.tenantRepoSyncIntervalMs,
+                jitterRatio     : this.tenantRepoSyncJitterRatio
             });
         }), context);
 

--- a/ai/daemons/orchestrator/scheduling/tenantRepoSync.mjs
+++ b/ai/daemons/orchestrator/scheduling/tenantRepoSync.mjs
@@ -44,3 +44,91 @@ export function getDueTask({state, now, intervalMs, enabled}) {
         lastRunAt: state['tenant-repo-sync']?.lastRunAt || 0
     });
 }
+
+/**
+ * Default per-repo jitter ratio: a deterministic time offset of up to 20% of the
+ * configured cadence, derived from `tenantId + repoSlug` hash. The cap ensures
+ * jitter never grows unbounded relative to cadence + the deterministic origin
+ * means multiple `tenantRepoSync` daemons (e.g., HA pair, test repro) compute
+ * the same jitter for the same repo, preserving operator reproducibility.
+ *
+ * @type {Number}
+ */
+export const DEFAULT_JITTER_RATIO = 0.20;
+
+/**
+ * @summary Deterministic per-repo jitter offset in milliseconds.
+ *
+ * Prevents "thundering-herd" on first-bootstrap multi-tenant deployments where
+ * all configured `tenantRepos[]` entries would otherwise become due simultaneously
+ * (lastRunAttemptAt: 0 for all → all fire on cycle 1). Per-repo deterministic
+ * jitter spreads them across `[0, jitterRatio * baseCadenceMs)` based on a stable
+ * hash of `tenantId + repoSlug`, so operators see reproducible offsets across
+ * daemon restarts and HA failovers.
+ *
+ * Uses a simple multiplicative-prime hash (no crypto needed — output range is
+ * bounded by `jitterRatio * baseCadenceMs` which is operator-tunable; collision
+ * resistance isn't a security property). FNV-1a-style for stability across
+ * Node versions.
+ *
+ * @param {Object} options
+ * @param {String} options.tenantId
+ * @param {String} options.repoSlug
+ * @param {Number} options.baseCadenceMs Pre-jitter cadence; jitter offset capped at `jitterRatio * baseCadenceMs`.
+ * @param {Number} [options.jitterRatio=DEFAULT_JITTER_RATIO] Per-repo jitter cap as fraction of `baseCadenceMs`.
+ * @returns {Number} Non-negative jitter offset in milliseconds, `< jitterRatio * baseCadenceMs`.
+ */
+export function computeDeterministicJitter({tenantId, repoSlug, baseCadenceMs, jitterRatio = DEFAULT_JITTER_RATIO}) {
+    if (!Number.isFinite(baseCadenceMs) || baseCadenceMs <= 0) return 0;
+    if (!Number.isFinite(jitterRatio) || jitterRatio <= 0) return 0;
+
+    const seed = `${tenantId}/${repoSlug}`;
+    let hash   = 0x811c9dc5; // FNV-1a 32-bit offset basis
+    for (let i = 0; i < seed.length; i++) {
+        hash ^= seed.charCodeAt(i);
+        hash = Math.imul(hash, 0x01000193) >>> 0; // FNV-1a prime, force u32
+    }
+
+    const maxJitter = baseCadenceMs * jitterRatio;
+    return Math.floor((hash / 0xFFFFFFFF) * maxJitter);
+}
+
+/**
+ * @summary Decides whether a per-repo sync attempt is currently due.
+ *
+ * Per-repo due-check applies to each `tenantRepos[]` entry independently. The
+ * effective cadence for a repo is:
+ *
+ * ```
+ *   effectiveCadence = (configuredCadence + deterministicJitter) * 2^consecutiveFailures
+ * ```
+ *
+ * - `configuredCadence`: per-repo override (`repo.cadenceMs`) or global default (`globalCadenceMs`).
+ * - `deterministicJitter`: stable hash-based offset (see `computeDeterministicJitter`).
+ * - Backoff multiplier: `2^consecutiveFailures` (1× on fresh state, 2× after 1 fail, 4× after 2, ...).
+ *   Reset to 0 on successful sync (no multiplier).
+ *
+ * @param {Object} options
+ * @param {Object} options.repo Repo config from `tenantRepos[]` (must have `tenantId` + `repoSlug`; optional `cadenceMs` override).
+ * @param {Object} [options.persistedRepoState] Per-repo persisted state: `{lastIngestedRev, lastRunAttemptAt, consecutiveFailures}`. Defaults treated as bootstrap (lastRunAttemptAt=0, consecutiveFailures=0).
+ * @param {Number} options.now Current timestamp in ms.
+ * @param {Number} options.globalCadenceMs Global cadence fallback when repo has no override.
+ * @param {Number} [options.jitterRatio=DEFAULT_JITTER_RATIO]
+ * @returns {{due: Boolean, effectiveCadenceMs: Number, jitterMs: Number, backoffMultiplier: Number, lastRunAttemptAt: Number}}
+ */
+export function isRepoDue({repo, persistedRepoState, now, globalCadenceMs, jitterRatio = DEFAULT_JITTER_RATIO}) {
+    const baseCadenceMs       = Number.isFinite(repo?.cadenceMs) && repo.cadenceMs > 0 ? repo.cadenceMs : globalCadenceMs;
+    const consecutiveFailures = persistedRepoState?.consecutiveFailures ?? 0;
+    const lastRunAttemptAt    = persistedRepoState?.lastRunAttemptAt ?? 0;
+    const jitterMs            = computeDeterministicJitter({
+        tenantId: repo.tenantId,
+        repoSlug: repo.repoSlug,
+        baseCadenceMs,
+        jitterRatio
+    });
+    const backoffMultiplier   = Math.pow(2, Math.max(0, consecutiveFailures));
+    const effectiveCadenceMs  = (baseCadenceMs + jitterMs) * backoffMultiplier;
+    const due                 = (now - lastRunAttemptAt) >= effectiveCadenceMs;
+
+    return {due, effectiveCadenceMs, jitterMs, backoffMultiplier, lastRunAttemptAt};
+}

--- a/ai/daemons/orchestrator/scheduling/tenantRepoSync.mjs
+++ b/ai/daemons/orchestrator/scheduling/tenantRepoSync.mjs
@@ -46,17 +46,6 @@ export function getDueTask({state, now, intervalMs, enabled}) {
 }
 
 /**
- * Default per-repo jitter ratio: a deterministic time offset of up to 20% of the
- * configured cadence, derived from `tenantId + repoSlug` hash. The cap ensures
- * jitter never grows unbounded relative to cadence + the deterministic origin
- * means multiple `tenantRepoSync` daemons (e.g., HA pair, test repro) compute
- * the same jitter for the same repo, preserving operator reproducibility.
- *
- * @type {Number}
- */
-export const DEFAULT_JITTER_RATIO = 0.20;
-
-/**
  * @summary Deterministic per-repo jitter offset in milliseconds.
  *
  * Prevents "thundering-herd" on first-bootstrap multi-tenant deployments where
@@ -75,10 +64,10 @@ export const DEFAULT_JITTER_RATIO = 0.20;
  * @param {String} options.tenantId
  * @param {String} options.repoSlug
  * @param {Number} options.baseCadenceMs Pre-jitter cadence; jitter offset capped at `jitterRatio * baseCadenceMs`.
- * @param {Number} [options.jitterRatio=DEFAULT_JITTER_RATIO] Per-repo jitter cap as fraction of `baseCadenceMs`.
+ * @param {Number} [options.jitterRatio=0] Per-repo jitter cap as fraction of `baseCadenceMs`. Caller (typically `TenantRepoSyncService`) passes the value from `aiConfig.orchestrator.tenantRepoSync.jitterRatio`. Default `0` (no jitter) keeps pure-function behavior config-free; production callers always pass the configured value.
  * @returns {Number} Non-negative jitter offset in milliseconds, `< jitterRatio * baseCadenceMs`.
  */
-export function computeDeterministicJitter({tenantId, repoSlug, baseCadenceMs, jitterRatio = DEFAULT_JITTER_RATIO}) {
+export function computeDeterministicJitter({tenantId, repoSlug, baseCadenceMs, jitterRatio = 0}) {
     if (!Number.isFinite(baseCadenceMs) || baseCadenceMs <= 0) return 0;
     if (!Number.isFinite(jitterRatio) || jitterRatio <= 0) return 0;
 
@@ -113,10 +102,10 @@ export function computeDeterministicJitter({tenantId, repoSlug, baseCadenceMs, j
  * @param {Object} [options.persistedRepoState] Per-repo persisted state: `{lastIngestedRev, lastRunAttemptAt, consecutiveFailures}`. Defaults treated as bootstrap (lastRunAttemptAt=0, consecutiveFailures=0).
  * @param {Number} options.now Current timestamp in ms.
  * @param {Number} options.globalCadenceMs Global cadence fallback when repo has no override.
- * @param {Number} [options.jitterRatio=DEFAULT_JITTER_RATIO]
+ * @param {Number} [options.jitterRatio=0] Caller (typically `TenantRepoSyncService`) passes the value from `aiConfig.orchestrator.tenantRepoSync.jitterRatio`. Default `0` (no jitter) keeps the pure function config-free.
  * @returns {{due: Boolean, effectiveCadenceMs: Number, jitterMs: Number, backoffMultiplier: Number, lastRunAttemptAt: Number}}
  */
-export function isRepoDue({repo, persistedRepoState, now, globalCadenceMs, jitterRatio = DEFAULT_JITTER_RATIO}) {
+export function isRepoDue({repo, persistedRepoState, now, globalCadenceMs, jitterRatio = 0}) {
     const baseCadenceMs       = Number.isFinite(repo?.cadenceMs) && repo.cadenceMs > 0 ? repo.cadenceMs : globalCadenceMs;
     const consecutiveFailures = persistedRepoState?.consecutiveFailures ?? 0;
     const lastRunAttemptAt    = persistedRepoState?.lastRunAttemptAt ?? 0;

--- a/ai/daemons/orchestrator/services/TenantRepoSyncService.mjs
+++ b/ai/daemons/orchestrator/services/TenantRepoSyncService.mjs
@@ -224,7 +224,8 @@ class TenantRepoSyncService extends Base {
         revisionsFilePath,
         envelopeBuilder = buildIngestEnvelope,
         globalCadenceMs = AiConfig.data.orchestrator.intervals.tenantRepoSyncMs,
-        jitterRatio     = AiConfig.data.orchestrator.tenantRepoSync.jitterRatio
+        jitterRatio     = AiConfig.data.orchestrator.tenantRepoSync.jitterRatio,
+        seedBootstrap   = true
     } = {}) {
         const state = taskStateService.getTaskState(taskName);
 
@@ -241,7 +242,7 @@ class TenantRepoSyncService extends Base {
             const result = await this.syncTenantRepos({
                 writeLog, tenantReposConfig, aiConfig, gitMirror, knowledgeBaseIngestionService, onlyRepoSlugs,
                 taskStateService, healthService, taskName, revisionsFilePath, envelopeBuilder,
-                globalCadenceMs, jitterRatio
+                globalCadenceMs, jitterRatio, seedBootstrap
             });
             const status = result.status;
 
@@ -286,7 +287,8 @@ class TenantRepoSyncService extends Base {
         writeLog, tenantReposConfig, aiConfig, gitMirror, knowledgeBaseIngestionService, onlyRepoSlugs,
         taskStateService, healthService, taskName, revisionsFilePath, envelopeBuilder = buildIngestEnvelope,
         globalCadenceMs = AiConfig.data.orchestrator.intervals.tenantRepoSyncMs,
-        jitterRatio     = AiConfig.data.orchestrator.tenantRepoSync.jitterRatio
+        jitterRatio     = AiConfig.data.orchestrator.tenantRepoSync.jitterRatio,
+        seedBootstrap   = true
     }) {
         const resolvedConfig = tenantReposConfig || await this.resolveTenantReposConfig({aiConfig});
         const allRepos       = resolvedConfig.tenantRepos || [];
@@ -335,6 +337,39 @@ class TenantRepoSyncService extends Base {
         });
 
         let notDueCount = 0;
+
+        // #11942 AC1 cycle-2 (#11962): bootstrap-spread seeding. Without seeding,
+        // all fresh repos (lastRunAttemptAt=0) become due on the first sweep
+        // regardless of jitter — (now - 0) always exceeds any reasonable cadence.
+        // Seeding `lastRunAttemptAt = now - baseCadenceMs` makes the effective
+        // due-time `now + jitterMs`, so first-sync attempts spread across
+        // `[0, jitterRatio * baseCadenceMs)` per repo. Persisted state survives
+        // orchestrator restarts so HA-failover preserves the spread.
+        // Skipped when `onlyRepoSlugs` is set (manual CLI bypass) or when caller
+        // explicitly opts out via `seedBootstrap: false` (test seam for spec files
+        // that simulate "first cycle fires all repos").
+        let seededAny = false;
+        if (seedBootstrap && !onlyRepoSlugs) {
+            const sweepStartedMs = Date.now();
+            for (const repo of repos) {
+                const repoLabel = `${repo.tenantId}/${repo.repoSlug}`;
+                if (!persistedRevisions[repoLabel]) {
+                    const baseCadenceMs = (Number.isFinite(repo.cadenceMs) && repo.cadenceMs > 0)
+                        ? repo.cadenceMs
+                        : globalCadenceMs;
+                    persistedRevisions[repoLabel] = {
+                        lastIngestedRev    : null,
+                        lastRunAttemptAt   : sweepStartedMs - baseCadenceMs,
+                        consecutiveFailures: 0
+                    };
+                    seededAny = true;
+                    writeLog?.('INFO', `[TenantRepoSync] Bootstrap-seeding ${repoLabel} (sync scheduled within jitter window).`);
+                }
+            }
+            if (seededAny) {
+                await this.writePersistedRevisions({filePath: resolvedRevisionsPath, revisions: persistedRevisions});
+            }
+        }
 
         await Promise.all(repos.map(async (repo) => {
             const repoLabel    = `${repo.tenantId}/${repo.repoSlug}`;

--- a/ai/daemons/orchestrator/services/TenantRepoSyncService.mjs
+++ b/ai/daemons/orchestrator/services/TenantRepoSyncService.mjs
@@ -5,6 +5,9 @@ import {DEFAULT_DATA_DIR} from '../TaskDefinitions.mjs';
 import GitMirror from '../../../services/knowledge-base/helpers/GitMirror.mjs';
 import {buildIngestEnvelope} from '../../../services/knowledge-base/helpers/TenantRepoIngestEnvelopeBuilder.mjs';
 import {normalizeTenantRepoConfig} from '../../../services/knowledge-base/helpers/TenantRepoAccessContract.mjs';
+import {isRepoDue} from '../scheduling/tenantRepoSync.mjs';
+
+const DEFAULT_GLOBAL_CADENCE_MS = 30 * 60 * 1000; // 30min — matches AiConfig orchestrator.intervals.tenantRepoSyncMs default
 import {
     KB_TENANT_REPO_SYNC_SYNC_FAILED,
     KB_TENANT_REPO_SYNC_MANIFEST_UPDATE_FAILED,
@@ -220,7 +223,8 @@ class TenantRepoSyncService extends Base {
         knowledgeBaseIngestionService,
         onlyRepoSlugs,
         revisionsFilePath,
-        envelopeBuilder = buildIngestEnvelope
+        envelopeBuilder = buildIngestEnvelope,
+        globalCadenceMs = DEFAULT_GLOBAL_CADENCE_MS
     } = {}) {
         const state = taskStateService.getTaskState(taskName);
 
@@ -236,7 +240,8 @@ class TenantRepoSyncService extends Base {
         try {
             const result = await this.syncTenantRepos({
                 writeLog, tenantReposConfig, aiConfig, gitMirror, knowledgeBaseIngestionService, onlyRepoSlugs,
-                taskStateService, healthService, taskName, revisionsFilePath, envelopeBuilder
+                taskStateService, healthService, taskName, revisionsFilePath, envelopeBuilder,
+                globalCadenceMs
             });
             const status = result.status;
 
@@ -279,7 +284,8 @@ class TenantRepoSyncService extends Base {
      */
     async syncTenantRepos({
         writeLog, tenantReposConfig, aiConfig, gitMirror, knowledgeBaseIngestionService, onlyRepoSlugs,
-        taskStateService, healthService, taskName, revisionsFilePath, envelopeBuilder = buildIngestEnvelope
+        taskStateService, healthService, taskName, revisionsFilePath, envelopeBuilder = buildIngestEnvelope,
+        globalCadenceMs = DEFAULT_GLOBAL_CADENCE_MS
     }) {
         const resolvedConfig = tenantReposConfig || await this.resolveTenantReposConfig({aiConfig});
         const allRepos       = resolvedConfig.tenantRepos || [];
@@ -327,10 +333,44 @@ class TenantRepoSyncService extends Base {
             timeoutMs: this.concurrencyGateTimeoutMs
         });
 
+        let notDueCount = 0;
+
         await Promise.all(repos.map(async (repo) => {
-            const repoLabel = `${repo.tenantId}/${repo.repoSlug}`;
+            const repoLabel    = `${repo.tenantId}/${repo.repoSlug}`;
+            const priorState   = persistedRevisions[repoLabel] || null;
+            const startedMs    = Date.now();
+
+            // #11942 AC1 per-repo due check: deterministic jitter + exponential backoff
+            // applied on top of configured cadence. Manual CLI runs (onlyRepoSlugs filter)
+            // bypass the due-check — operator-initiated sync should always fire for the
+            // requested repos.
+            if (!onlyRepoSlugs) {
+                const dueState = isRepoDue({
+                    repo,
+                    persistedRepoState: priorState,
+                    now               : startedMs,
+                    globalCadenceMs
+                });
+
+                if (!dueState.due) {
+                    const nextDueAtMs = (priorState?.lastRunAttemptAt ?? 0) + dueState.effectiveCadenceMs;
+                    notDueCount++;
+                    writeLog?.('INFO', `[TenantRepoSync] ${repoLabel} not yet due (next ~${new Date(nextDueAtMs).toISOString()}, consecutiveFailures=${priorState?.consecutiveFailures ?? 0}, backoffX=${dueState.backoffMultiplier}).`);
+                    repoStates.push({
+                        tenantId           : repo.tenantId,
+                        repoSlug           : repo.repoSlug,
+                        lastIngestedRev    : priorState?.lastIngestedRev ? priorState.lastIngestedRev.slice(0, 8) : null,
+                        lastSyncAt         : priorState?.lastRunAttemptAt ? new Date(priorState.lastRunAttemptAt).toISOString() : null,
+                        status             : 'not-due',
+                        nextDueAt          : new Date(nextDueAtMs).toISOString(),
+                        effectiveCadenceMs : dueState.effectiveCadenceMs,
+                        consecutiveFailures: priorState?.consecutiveFailures ?? 0
+                    });
+                    return; // skip semaphore + work entirely
+                }
+            }
+
             let slotAcquired = false;
-            const startedMs = Date.now();
             try {
                 await semaphore.acquire();
                 slotAcquired = true;
@@ -354,7 +394,7 @@ class TenantRepoSyncService extends Base {
                     tenantId        : repo.tenantId,
                     repoSlug        : repo.repoSlug,
                     mirrorRoot      : repo.mirrorRoot,
-                    lastIngestedRev : persistedRevisions[repoLabel] || null,
+                    lastIngestedRev : priorState?.lastIngestedRev || null,
                     rootKind        : repo.rootKind || 'external-source',
                     parserId        : repo.parserId,
                     parserVersion   : repo.parserVersion,
@@ -366,11 +406,15 @@ class TenantRepoSyncService extends Base {
                     viaMcp: false // operator-bulk path
                 });
 
-                // Persist headRevision only on successful ingest. Bootstrap envelopes
-                // omit baseRevision but always carry headRevision.
-                if (envelope.headRevision) {
-                    persistedRevisions[repoLabel] = envelope.headRevision;
-                }
+                // #11942 AC1: persist full per-repo state on success. Reset consecutiveFailures
+                // to 0 (backoff is the multiplier-component of effectiveCadence; reset on
+                // successful sync per ticket prescription). lastRunAttemptAt advances to
+                // startedMs so subsequent due-checks measure from the actual attempt.
+                persistedRevisions[repoLabel] = {
+                    lastIngestedRev    : envelope.headRevision || priorState?.lastIngestedRev || null,
+                    lastRunAttemptAt   : startedMs,
+                    consecutiveFailures: 0
+                };
 
                 const durationMs = Date.now() - startedMs;
                 const shortHead  = envelope.headRevision ? envelope.headRevision.slice(0, 8) : null;
@@ -400,21 +444,35 @@ class TenantRepoSyncService extends Base {
             } catch (e) {
                 const code = isTenantRepoSyncErrorCode(e.code) ? e.code : KB_TENANT_REPO_SYNC_SYNC_FAILED;
                 writeLog?.('ERROR', `[TenantRepoSync] ${repoLabel} failed: ${code} (${e.message})`);
+
+                // #11942 AC1: increment consecutiveFailures on failure; preserve last good
+                // ingested revision so the next successful run starts from the correct base.
+                // lastRunAttemptAt advances even on failure (backoff measures from attempt
+                // start, not last-success).
+                const nextFailureCount = (priorState?.consecutiveFailures ?? 0) + 1;
+                persistedRevisions[repoLabel] = {
+                    lastIngestedRev    : priorState?.lastIngestedRev || null,
+                    lastRunAttemptAt   : startedMs,
+                    consecutiveFailures: nextFailureCount
+                };
+
                 repoStates.push({
-                    tenantId       : repo.tenantId,
-                    repoSlug       : repo.repoSlug,
-                    lastIngestedRev: persistedRevisions[repoLabel] ? persistedRevisions[repoLabel].slice(0, 8) : null,
-                    lastSyncAt     : new Date().toISOString(),
-                    status         : 'degraded', // quarantined disposition tracked in #11942 (per-repo backoff state)
-                    lastErrorCode  : code
+                    tenantId           : repo.tenantId,
+                    repoSlug           : repo.repoSlug,
+                    lastIngestedRev    : priorState?.lastIngestedRev ? priorState.lastIngestedRev.slice(0, 8) : null,
+                    lastSyncAt         : new Date().toISOString(),
+                    status             : 'degraded',
+                    lastErrorCode      : code,
+                    consecutiveFailures: nextFailureCount
                 });
                 failedCount++;
                 healthService?.recordTaskOutcome?.(taskName, 'failed', {
-                    repo    : repoLabel,
-                    tenantId: repo.tenantId,
-                    repoSlug: repo.repoSlug,
-                    error   : e.message,
-                    code
+                    repo               : repoLabel,
+                    tenantId           : repo.tenantId,
+                    repoSlug           : repo.repoSlug,
+                    error              : e.message,
+                    code,
+                    consecutiveFailures: nextFailureCount
                 });
                 // Continue with remaining repos — failure isolation per ticket prescription.
             } finally {
@@ -424,9 +482,16 @@ class TenantRepoSyncService extends Base {
 
         await this.writePersistedRevisions({filePath: resolvedRevisionsPath, revisions: persistedRevisions});
 
-        const status = failedCount === 0 ? 'completed' : (completedCount > 0 ? 'completed' : 'failed');
+        // Status logic: not-due repos don't change the success/failure tally — a cycle
+        // where ALL repos were not-due is still 'completed' (the cycle ran successfully;
+        // each repo's decision was honored). 'failed' only when actual work failed and no
+        // actual work succeeded.
+        const attemptedCount = completedCount + failedCount;
+        const status = attemptedCount === 0
+            ? 'completed' // all repos were not-due; cycle ran cleanly
+            : (failedCount === 0 ? 'completed' : (completedCount > 0 ? 'completed' : 'failed'));
 
-        writeLog?.('INFO', `[TenantRepoSync] Cycle summary: ${repos.length} repos, ${completedCount} completed, ${failedCount} failed.`);
+        writeLog?.('INFO', `[TenantRepoSync] Cycle summary: ${repos.length} repos, ${completedCount} completed, ${failedCount} failed, ${notDueCount} not-due.`);
 
         return {
             status,
@@ -434,6 +499,7 @@ class TenantRepoSyncService extends Base {
                 repoCount   : repos.length,
                 completedCount,
                 failedCount,
+                notDueCount,
                 repos       : repoStates
             }
         };
@@ -476,11 +542,26 @@ class TenantRepoSyncService extends Base {
     }
 
     /**
-     * Reads the per-tenant-repo lastIngestedRev map. Missing file = empty map (bootstrap).
+     * Reads the per-tenant-repo persisted state map. Missing file = empty map (bootstrap).
+     *
+     * Per-repo state shape (post-#11942 AC1):
+     * ```
+     * {
+     *   lastIngestedRev    : '<sha>',
+     *   lastRunAttemptAt   : <ms-epoch>,
+     *   consecutiveFailures: <int>
+     * }
+     * ```
+     *
+     * Backward-compatible read: pre-AC1 persistence stored bare SHA strings under
+     * `revisions[label]`. On read, string-shaped entries are auto-migrated to the
+     * full object shape (lastIngestedRev = old-string; lastRunAttemptAt = 0;
+     * consecutiveFailures = 0). Next write persists the new shape, completing the
+     * migration in-place.
      *
      * @param {Object} options
      * @param {String} options.filePath
-     * @returns {Promise<Object<String, String>>} `{ '<tenantId>/<repoSlug>': '<sha>' }`.
+     * @returns {Promise<Object<String, {lastIngestedRev: String, lastRunAttemptAt: Number, consecutiveFailures: Number}>>}
      */
     async readPersistedRevisions({filePath}) {
         if (!await fs.pathExists(filePath)) {
@@ -488,7 +569,26 @@ class TenantRepoSyncService extends Base {
         }
         try {
             const data = await fs.readJson(filePath);
-            return (data && typeof data === 'object' && data.revisions) ? {...data.revisions} : {};
+            if (!data || typeof data !== 'object' || !data.revisions) return {};
+
+            const normalized = {};
+            for (const [label, value] of Object.entries(data.revisions)) {
+                if (typeof value === 'string') {
+                    // Pre-AC1 shape: bare SHA string. Migrate to full state shape on read.
+                    normalized[label] = {
+                        lastIngestedRev    : value,
+                        lastRunAttemptAt   : 0,
+                        consecutiveFailures: 0
+                    };
+                } else if (value && typeof value === 'object') {
+                    normalized[label] = {
+                        lastIngestedRev    : value.lastIngestedRev || null,
+                        lastRunAttemptAt   : Number.isFinite(value.lastRunAttemptAt) ? value.lastRunAttemptAt : 0,
+                        consecutiveFailures: Number.isFinite(value.consecutiveFailures) ? value.consecutiveFailures : 0
+                    };
+                }
+            }
+            return normalized;
         } catch {
             return {};
         }

--- a/ai/daemons/orchestrator/services/TenantRepoSyncService.mjs
+++ b/ai/daemons/orchestrator/services/TenantRepoSyncService.mjs
@@ -1,13 +1,12 @@
 import fs from 'fs-extra';
 import path from 'node:path';
 import Base from '../../../../src/core/Base.mjs';
+import AiConfig from '../../../config.template.mjs';
 import {DEFAULT_DATA_DIR} from '../TaskDefinitions.mjs';
 import GitMirror from '../../../services/knowledge-base/helpers/GitMirror.mjs';
 import {buildIngestEnvelope} from '../../../services/knowledge-base/helpers/TenantRepoIngestEnvelopeBuilder.mjs';
 import {normalizeTenantRepoConfig} from '../../../services/knowledge-base/helpers/TenantRepoAccessContract.mjs';
 import {isRepoDue} from '../scheduling/tenantRepoSync.mjs';
-
-const DEFAULT_GLOBAL_CADENCE_MS = 30 * 60 * 1000; // 30min — matches AiConfig orchestrator.intervals.tenantRepoSyncMs default
 import {
     KB_TENANT_REPO_SYNC_SYNC_FAILED,
     KB_TENANT_REPO_SYNC_MANIFEST_UPDATE_FAILED,
@@ -224,7 +223,8 @@ class TenantRepoSyncService extends Base {
         onlyRepoSlugs,
         revisionsFilePath,
         envelopeBuilder = buildIngestEnvelope,
-        globalCadenceMs = DEFAULT_GLOBAL_CADENCE_MS
+        globalCadenceMs = AiConfig.data.orchestrator.intervals.tenantRepoSyncMs,
+        jitterRatio     = AiConfig.data.orchestrator.tenantRepoSync.jitterRatio
     } = {}) {
         const state = taskStateService.getTaskState(taskName);
 
@@ -241,7 +241,7 @@ class TenantRepoSyncService extends Base {
             const result = await this.syncTenantRepos({
                 writeLog, tenantReposConfig, aiConfig, gitMirror, knowledgeBaseIngestionService, onlyRepoSlugs,
                 taskStateService, healthService, taskName, revisionsFilePath, envelopeBuilder,
-                globalCadenceMs
+                globalCadenceMs, jitterRatio
             });
             const status = result.status;
 
@@ -285,7 +285,8 @@ class TenantRepoSyncService extends Base {
     async syncTenantRepos({
         writeLog, tenantReposConfig, aiConfig, gitMirror, knowledgeBaseIngestionService, onlyRepoSlugs,
         taskStateService, healthService, taskName, revisionsFilePath, envelopeBuilder = buildIngestEnvelope,
-        globalCadenceMs = DEFAULT_GLOBAL_CADENCE_MS
+        globalCadenceMs = AiConfig.data.orchestrator.intervals.tenantRepoSyncMs,
+        jitterRatio     = AiConfig.data.orchestrator.tenantRepoSync.jitterRatio
     }) {
         const resolvedConfig = tenantReposConfig || await this.resolveTenantReposConfig({aiConfig});
         const allRepos       = resolvedConfig.tenantRepos || [];
@@ -349,7 +350,8 @@ class TenantRepoSyncService extends Base {
                     repo,
                     persistedRepoState: priorState,
                     now               : startedMs,
-                    globalCadenceMs
+                    globalCadenceMs,
+                    jitterRatio
                 });
 
                 if (!dueState.due) {

--- a/test/playwright/unit/ai/daemons/orchestrator/scheduling/tenantRepoSync.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/scheduling/tenantRepoSync.spec.mjs
@@ -1,5 +1,11 @@
 import {test, expect} from '@playwright/test';
-import {buildTenantRepoSyncTrigger, getDueTask} from '../../../../../../../ai/daemons/orchestrator/scheduling/tenantRepoSync.mjs';
+import {
+    DEFAULT_JITTER_RATIO,
+    buildTenantRepoSyncTrigger,
+    computeDeterministicJitter,
+    getDueTask,
+    isRepoDue
+} from '../../../../../../../ai/daemons/orchestrator/scheduling/tenantRepoSync.mjs';
 
 test.describe('tenantRepoSync trigger (#11790)', () => {
     test('returns null when disabled', () => {
@@ -34,5 +40,121 @@ test.describe('tenantRepoSync trigger (#11790)', () => {
     test('getDueTask handles missing task state (bootstrap, lastRunAt=0)', () => {
         const trigger = getDueTask({state: {}, now: 70000, intervalMs: 60000, enabled: true});
         expect(trigger).not.toBeNull();
+    });
+});
+
+test.describe('computeDeterministicJitter (#11942 AC1)', () => {
+    test('returns 0 for invalid inputs', () => {
+        expect(computeDeterministicJitter({tenantId: 't1', repoSlug: 'org/repo', baseCadenceMs: 0})).toBe(0);
+        expect(computeDeterministicJitter({tenantId: 't1', repoSlug: 'org/repo', baseCadenceMs: -1})).toBe(0);
+        expect(computeDeterministicJitter({tenantId: 't1', repoSlug: 'org/repo', baseCadenceMs: NaN})).toBe(0);
+        expect(computeDeterministicJitter({tenantId: 't1', repoSlug: 'org/repo', baseCadenceMs: 1000, jitterRatio: 0})).toBe(0);
+        expect(computeDeterministicJitter({tenantId: 't1', repoSlug: 'org/repo', baseCadenceMs: 1000, jitterRatio: -0.1})).toBe(0);
+    });
+
+    test('deterministic — same (tenantId, repoSlug) → same jitter', () => {
+        const j1 = computeDeterministicJitter({tenantId: 'tenant-a', repoSlug: 'neomjs/create-app', baseCadenceMs: 60000});
+        const j2 = computeDeterministicJitter({tenantId: 'tenant-a', repoSlug: 'neomjs/create-app', baseCadenceMs: 60000});
+        expect(j1).toBe(j2);
+    });
+
+    test('bounded — jitter < jitterRatio * baseCadenceMs', () => {
+        for (const slug of ['neomjs/a', 'neomjs/b', 'neomjs/c', 'neomjs/d', 'neomjs/e']) {
+            const jitter = computeDeterministicJitter({tenantId: 'tenant-a', repoSlug: slug, baseCadenceMs: 60000});
+            expect(jitter).toBeGreaterThanOrEqual(0);
+            expect(jitter).toBeLessThan(60000 * DEFAULT_JITTER_RATIO);
+        }
+    });
+
+    test('distinct repos produce distinct jitter (anti-thundering-herd)', () => {
+        const jitters = ['neomjs/a', 'neomjs/b', 'neomjs/c', 'neomjs/d'].map(slug =>
+            computeDeterministicJitter({tenantId: 'tenant-a', repoSlug: slug, baseCadenceMs: 60000})
+        );
+        // At least 3 distinct values across 4 repos — proves the hash isn't degenerate.
+        // (Probabilistic guarantee, but with FNV-1a + 4 inputs the collision risk is negligible.)
+        const unique = new Set(jitters);
+        expect(unique.size).toBeGreaterThanOrEqual(3);
+    });
+
+    test('jitterRatio cap scales the jitter window', () => {
+        const jitter10pct = computeDeterministicJitter({
+            tenantId: 'tenant-a', repoSlug: 'neomjs/create-app', baseCadenceMs: 60000, jitterRatio: 0.10
+        });
+        const jitter20pct = computeDeterministicJitter({
+            tenantId: 'tenant-a', repoSlug: 'neomjs/create-app', baseCadenceMs: 60000, jitterRatio: 0.20
+        });
+        // 10% cap should produce smaller (or equal) jitter than 20% cap for the same seed.
+        expect(jitter10pct).toBeLessThanOrEqual(jitter20pct);
+        expect(jitter10pct).toBeLessThan(60000 * 0.10);
+        expect(jitter20pct).toBeLessThan(60000 * 0.20);
+    });
+});
+
+test.describe('isRepoDue (#11942 AC1)', () => {
+    const repo = {tenantId: 'tenant-a', repoSlug: 'neomjs/create-app'};
+
+    test('bootstrap (no persisted state) — due at now=0 with non-trivial cadence', () => {
+        // lastRunAttemptAt defaults to 0; now=0 means (now - 0) = 0 >= effectiveCadence iff cadence=0.
+        // With cadence>0 + jitter>=0, NOT due at the exact bootstrap moment.
+        const result = isRepoDue({repo, persistedRepoState: undefined, now: 0, globalCadenceMs: 60000});
+        expect(result.due).toBe(false);
+        expect(result.lastRunAttemptAt).toBe(0);
+    });
+
+    test('bootstrap — due once now exceeds effectiveCadence', () => {
+        const baseCadence = 60000;
+        const jitter      = computeDeterministicJitter({tenantId: 'tenant-a', repoSlug: 'neomjs/create-app', baseCadenceMs: baseCadence});
+        const due         = isRepoDue({repo, persistedRepoState: {lastRunAttemptAt: 0, consecutiveFailures: 0}, now: baseCadence + jitter + 1, globalCadenceMs: baseCadence});
+        expect(due.due).toBe(true);
+        expect(due.backoffMultiplier).toBe(1);
+    });
+
+    test('not yet due — interval not elapsed', () => {
+        const result = isRepoDue({
+            repo,
+            persistedRepoState: {lastRunAttemptAt: 100000, consecutiveFailures: 0},
+            now               : 100000 + 30000, // half the cadence
+            globalCadenceMs   : 60000
+        });
+        expect(result.due).toBe(false);
+    });
+
+    test('per-repo cadence override takes precedence over global', () => {
+        const result = isRepoDue({
+            repo              : {...repo, cadenceMs: 10000}, // 10s per-repo override
+            persistedRepoState: {lastRunAttemptAt: 0, consecutiveFailures: 0},
+            now               : 12000, // > 10s + small jitter
+            globalCadenceMs   : 60000   // global ignored
+        });
+        // baseCadence = 10000 (override), jitter <= 2000, effective <= 12000 → likely due at now=12000
+        expect(result.effectiveCadenceMs).toBeLessThan(12001);
+    });
+
+    test('backoff multiplier doubles effective cadence per consecutive failure', () => {
+        const baseCadence = 60000;
+        const baseline    = isRepoDue({repo, persistedRepoState: {lastRunAttemptAt: 0, consecutiveFailures: 0}, now: 0, globalCadenceMs: baseCadence});
+        const oneFailure  = isRepoDue({repo, persistedRepoState: {lastRunAttemptAt: 0, consecutiveFailures: 1}, now: 0, globalCadenceMs: baseCadence});
+        const twoFailures = isRepoDue({repo, persistedRepoState: {lastRunAttemptAt: 0, consecutiveFailures: 2}, now: 0, globalCadenceMs: baseCadence});
+
+        expect(baseline.backoffMultiplier).toBe(1);
+        expect(oneFailure.backoffMultiplier).toBe(2);
+        expect(twoFailures.backoffMultiplier).toBe(4);
+
+        // Effective cadence doubles per failure
+        expect(oneFailure.effectiveCadenceMs).toBe(baseline.effectiveCadenceMs * 2);
+        expect(twoFailures.effectiveCadenceMs).toBe(baseline.effectiveCadenceMs * 4);
+    });
+
+    test('backoff resets on consecutiveFailures: 0 — explicit success reset', () => {
+        const baseCadence = 60000;
+        const afterReset  = isRepoDue({repo, persistedRepoState: {lastRunAttemptAt: 0, consecutiveFailures: 0}, now: 0, globalCadenceMs: baseCadence});
+        expect(afterReset.backoffMultiplier).toBe(1);
+    });
+
+    test('deterministic — same inputs produce identical due-state envelope', () => {
+        const state = {lastRunAttemptAt: 100000, consecutiveFailures: 0};
+        const a     = isRepoDue({repo, persistedRepoState: state, now: 200000, globalCadenceMs: 60000});
+        const b     = isRepoDue({repo, persistedRepoState: state, now: 200000, globalCadenceMs: 60000});
+        expect(a).toEqual(b);
     });
 });

--- a/test/playwright/unit/ai/daemons/orchestrator/scheduling/tenantRepoSync.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/scheduling/tenantRepoSync.spec.mjs
@@ -1,6 +1,5 @@
 import {test, expect} from '@playwright/test';
 import {
-    DEFAULT_JITTER_RATIO,
     buildTenantRepoSyncTrigger,
     computeDeterministicJitter,
     getDueTask,
@@ -58,17 +57,34 @@ test.describe('computeDeterministicJitter (#11942 AC1)', () => {
         expect(j1).toBe(j2);
     });
 
-    test('bounded — jitter < jitterRatio * baseCadenceMs', () => {
+    test('bounded — default jitterRatio=0 (no jitter); explicit ratio → bounded by ratio*baseCadenceMs', () => {
+        // Default jitterRatio (when caller omits) is 0 → no jitter. Pure function stays
+        // config-free; the production caller (TenantRepoSyncService) supplies the actual
+        // ratio from AiConfig — that wiring is covered by service-level integration tests.
         for (const slug of ['neomjs/a', 'neomjs/b', 'neomjs/c', 'neomjs/d', 'neomjs/e']) {
-            const jitter = computeDeterministicJitter({tenantId: 'tenant-a', repoSlug: slug, baseCadenceMs: 60000});
+            const noJitter = computeDeterministicJitter({tenantId: 'tenant-a', repoSlug: slug, baseCadenceMs: 60000});
+            expect(noJitter).toBe(0);
+        }
+
+        // With explicit jitterRatio (test uses literal 0.20 — pure-function contract is
+        // ratio-in / jitter-out; whether AiConfig's canonical value is 0.20 is asserted
+        // separately in service-level integration tests).
+        for (const slug of ['neomjs/a', 'neomjs/b', 'neomjs/c', 'neomjs/d', 'neomjs/e']) {
+            const jitter = computeDeterministicJitter({
+                tenantId      : 'tenant-a',
+                repoSlug      : slug,
+                baseCadenceMs : 60000,
+                jitterRatio   : 0.20
+            });
             expect(jitter).toBeGreaterThanOrEqual(0);
-            expect(jitter).toBeLessThan(60000 * DEFAULT_JITTER_RATIO);
+            expect(jitter).toBeLessThan(60000 * 0.20);
         }
     });
 
     test('distinct repos produce distinct jitter (anti-thundering-herd)', () => {
+        // Explicit non-zero jitterRatio required for distinct jitters (default 0 → all zeros).
         const jitters = ['neomjs/a', 'neomjs/b', 'neomjs/c', 'neomjs/d'].map(slug =>
-            computeDeterministicJitter({tenantId: 'tenant-a', repoSlug: slug, baseCadenceMs: 60000})
+            computeDeterministicJitter({tenantId: 'tenant-a', repoSlug: slug, baseCadenceMs: 60000, jitterRatio: 0.20})
         );
         // At least 3 distinct values across 4 repos — proves the hash isn't degenerate.
         // (Probabilistic guarantee, but with FNV-1a + 4 inputs the collision risk is negligible.)

--- a/test/playwright/unit/ai/daemons/orchestrator/services/TenantRepoSyncService.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/services/TenantRepoSyncService.spec.mjs
@@ -163,7 +163,11 @@ test.describe('TenantRepoSyncService (#11790)', () => {
             gitMirror                    : makeFakeGitMirror({captureCalls: mirrorCalls}),
             envelopeBuilder              : makeFakeEnvelopeBuilder(),
             knowledgeBaseIngestionService: makeFakeIngestionService({captureCalls: ingestCalls}),
-            revisionsFilePath            : revisionsFile
+            revisionsFilePath            : revisionsFile,
+            // Bootstrap-seeding (#11942 AC1 cycle-2) defers fresh repos to a later sweep
+            // within the jitter window; this test simulates the in-loop iteration path
+            // and opts out so it can assert "first call processes all repos".
+            seedBootstrap                : false
         });
 
         expect(result.status).toBe('completed');
@@ -220,7 +224,8 @@ test.describe('TenantRepoSyncService (#11790)', () => {
             gitMirror                    : failingGitMirror,
             envelopeBuilder              : makeFakeEnvelopeBuilder(),
             knowledgeBaseIngestionService: makeFakeIngestionService(),
-            revisionsFilePath            : revisionsFile
+            revisionsFilePath            : revisionsFile,
+            seedBootstrap                : false
         });
 
         // Failures do NOT short-circuit — all 3 repos visited.
@@ -335,7 +340,8 @@ test.describe('TenantRepoSyncService (#11790)', () => {
             gitMirror                    : makeFakeGitMirror(),
             envelopeBuilder              : makeFakeEnvelopeBuilder(),
             knowledgeBaseIngestionService: makeFakeIngestionService(),
-            revisionsFilePath            : revisionsFile
+            revisionsFilePath            : revisionsFile,
+            seedBootstrap                : false
         });
 
         expect(result.details.repos).toBeDefined();
@@ -377,7 +383,8 @@ test.describe('TenantRepoSyncService (#11790)', () => {
             gitMirror                    : failingMirror,
             envelopeBuilder              : makeFakeEnvelopeBuilder(),
             knowledgeBaseIngestionService: makeFakeIngestionService(),
-            revisionsFilePath            : revisionsFile
+            revisionsFilePath            : revisionsFile,
+            seedBootstrap                : false
         });
 
         expect(result.status).toBe('failed');
@@ -407,7 +414,8 @@ test.describe('TenantRepoSyncService (#11790)', () => {
             gitMirror                    : makeFakeGitMirror(),
             envelopeBuilder              : makeFakeEnvelopeBuilder(),
             knowledgeBaseIngestionService: makeFakeIngestionService(),
-            revisionsFilePath            : revisionsFile
+            revisionsFilePath            : revisionsFile,
+            seedBootstrap                : false
         });
 
         const refreshLine = logLines.find(l => l.msg.includes('Refreshing t1/org/repo-a'));
@@ -546,7 +554,8 @@ test.describe('TenantRepoSyncService (#11790)', () => {
             gitMirror                    : trackingMirror,
             envelopeBuilder              : makeFakeEnvelopeBuilder(),
             knowledgeBaseIngestionService: makeFakeIngestionService(),
-            revisionsFilePath            : revisionsFile
+            revisionsFilePath            : revisionsFile,
+            seedBootstrap                : false
         });
 
         expect(result.status).toBe('completed');
@@ -588,7 +597,8 @@ test.describe('TenantRepoSyncService (#11790)', () => {
             gitMirror                    : trackingMirror,
             envelopeBuilder              : makeFakeEnvelopeBuilder(),
             knowledgeBaseIngestionService: makeFakeIngestionService(),
-            revisionsFilePath            : revisionsFile
+            revisionsFilePath            : revisionsFile,
+            seedBootstrap                : false
         });
 
         expect(result.status).toBe('completed');
@@ -683,7 +693,10 @@ test.describe('TenantRepoSyncService (#11790)', () => {
     test('jitter+backoff: persists consecutiveFailures increment on failure (#11942 AC1)', async () => {
         const taskStateService = createInMemoryTaskStateService();
 
-        // Bootstrap state — repo should be due immediately (lastRunAttemptAt=0).
+        // Opts out of #11942 AC1 cycle-2 (#11962) bootstrap seeding so the
+        // simulated failure path actually fires this sweep (instead of being
+        // deferred-as-seeded). Test verifies failure-increment semantics, not
+        // bootstrap-spread behavior.
         const failingMirror = {
             async cloneIfMissing() { throw new Error('Simulated clone failure'); },
             async fetch()          {},
@@ -703,7 +716,8 @@ test.describe('TenantRepoSyncService (#11790)', () => {
             gitMirror                    : failingMirror,
             envelopeBuilder              : makeFakeEnvelopeBuilder(),
             knowledgeBaseIngestionService: makeFakeIngestionService(),
-            revisionsFilePath            : revisionsFile
+            revisionsFilePath            : revisionsFile,
+            seedBootstrap                : false
         });
 
         expect(result.status).toBe('failed');
@@ -833,6 +847,205 @@ test.describe('TenantRepoSyncService (#11790)', () => {
         expect(ingestCalls).toHaveLength(1);
     });
 
+    // ─────────────────────────────────────────────────────────────────────────
+    // #11942 AC1 cycle-2 (#11962): bootstrap-spread seeding + decoupled-sweep
+    // composition + orchestrator-resolved cadence pass-through.
+    // ─────────────────────────────────────────────────────────────────────────
+
+    test('bootstrap-spread: first sweep seeds new repos with lastRunAttemptAt=now-baseCadence (#11942 AC1 cycle-2)', async () => {
+        const taskStateService = createInMemoryTaskStateService();
+        await provisionMirrorDir({tenantId: 't1', repoSlug: 'org/repo-a'});
+        await provisionMirrorDir({tenantId: 't1', repoSlug: 'org/repo-b'});
+
+        const baseCadenceMs = 1800000; // 30min — matches AiConfig default
+
+        const sweepStart = Date.now();
+        const result = await TenantRepoSyncService.runTask({
+            reason          : 'periodic-sweep:60000',
+            taskStateService,
+            tenantReposConfig: {tenantRepos: [
+                {tenantId: 't1', repoSlug: 'org/repo-a', mirrorRoot, cloneUrl: 'https://github.com/neomjs/a.git'},
+                {tenantId: 't1', repoSlug: 'org/repo-b', mirrorRoot, cloneUrl: 'https://github.com/neomjs/b.git'}
+            ]},
+            gitMirror                    : makeFakeGitMirror(),
+            envelopeBuilder              : makeFakeEnvelopeBuilder(),
+            knowledgeBaseIngestionService: makeFakeIngestionService(),
+            revisionsFilePath            : revisionsFile,
+            globalCadenceMs              : baseCadenceMs,
+            jitterRatio                  : 0.20
+            // seedBootstrap defaults to true (production behavior)
+        });
+
+        // First sweep: seeding fires, both repos seeded as not-due (waiting for jitter window).
+        expect(result.status).toBe('completed');
+        expect(result.details.repoCount).toBe(2);
+        expect(result.details.completedCount).toBe(0);
+        expect(result.details.notDueCount).toBe(2);
+
+        // Persisted state shows seeded `lastRunAttemptAt = sweepStart - baseCadenceMs`.
+        const persisted = await fs.readJson(revisionsFile);
+        const stateA = persisted.revisions['t1/org/repo-a'];
+        const stateB = persisted.revisions['t1/org/repo-b'];
+
+        expect(stateA).toBeTruthy();
+        expect(stateA.lastIngestedRev).toBeNull();
+        expect(stateA.consecutiveFailures).toBe(0);
+        expect(stateA.lastRunAttemptAt).toBeLessThanOrEqual(sweepStart - baseCadenceMs + 100); // allow tiny clock drift
+        expect(stateA.lastRunAttemptAt).toBeGreaterThanOrEqual(sweepStart - baseCadenceMs - 100);
+
+        expect(stateB).toBeTruthy();
+        expect(stateB.lastRunAttemptAt).toBeLessThanOrEqual(sweepStart - baseCadenceMs + 100);
+    });
+
+    test('bootstrap-spread: seeded repo becomes due on a later sweep within its jitter window (#11942 AC1 cycle-2)', async () => {
+        // Pre-populate persistence with a seeded state — simulating the state left by
+        // a prior bootstrap-spread sweep. Repo with deterministic jitter 0ms (smallest)
+        // should become due on any subsequent sweep; repo with larger jitter only on
+        // sweeps past its individual due-time.
+        const ingestCalls   = [];
+        const baseCadenceMs = 100; // tiny so test can advance via real Date.now
+
+        // Pre-write seeded state: lastRunAttemptAt = (now - baseCadence) → due at now + jitter
+        const seedTime  = Date.now() - baseCadenceMs;
+        await fs.writeJson(revisionsFile, {
+            revisions: {
+                't1/org/short-jitter': {lastIngestedRev: null, lastRunAttemptAt: seedTime, consecutiveFailures: 0},
+                't1/org/long-jitter' : {lastIngestedRev: null, lastRunAttemptAt: seedTime, consecutiveFailures: 0}
+            }
+        });
+
+        await provisionMirrorDir({tenantId: 't1', repoSlug: 'org/short-jitter'});
+        await provisionMirrorDir({tenantId: 't1', repoSlug: 'org/long-jitter'});
+
+        // With jitterRatio=0.50, jitter range = [0, 50ms). Deterministic per repo.
+        // Both repos seeded with lastRunAttemptAt = now - 100ms.
+        // After waiting 60ms (past most-likely jitter windows), the lower-jitter
+        // repo should be due. Don't assert which one — let determinism pick.
+        await new Promise(r => setTimeout(r, 60));
+
+        const result = await TenantRepoSyncService.runTask({
+            reason          : 'periodic-sweep:1000',
+            taskStateService: createInMemoryTaskStateService(),
+            tenantReposConfig: {tenantRepos: [
+                {tenantId: 't1', repoSlug: 'org/short-jitter', mirrorRoot, cloneUrl: 'https://github.com/neomjs/short.git'},
+                {tenantId: 't1', repoSlug: 'org/long-jitter',  mirrorRoot, cloneUrl: 'https://github.com/neomjs/long.git'}
+            ]},
+            gitMirror                    : makeFakeGitMirror(),
+            envelopeBuilder              : makeFakeEnvelopeBuilder(),
+            knowledgeBaseIngestionService: makeFakeIngestionService({captureCalls: ingestCalls}),
+            revisionsFilePath            : revisionsFile,
+            globalCadenceMs              : baseCadenceMs,
+            jitterRatio                  : 0.50,
+            seedBootstrap                : false // pre-seeded; don't re-seed
+        });
+
+        // Distribution proof: not-due-count + completed-count = 2 total; spread is real
+        // (at least one repo NOT processed because its jitter is past current elapsed time).
+        const distributed = result.details.completedCount + result.details.notDueCount;
+        expect(distributed).toBe(2);
+
+        // The deterministic-jitter spread means we expect at least 1 repo to be in each
+        // state ONLY when the wait happens to land between the two jitter offsets.
+        // Looser invariant that always holds: distribution sums to total repo count.
+    });
+
+    test('orchestrator-resolved globalCadenceMs flows through to isRepoDue (#11942 AC1 cycle-2 RA3)', async () => {
+        // Pre-populate priorState with a fresh lastRunAttemptAt so isRepoDue compares
+        // against the explicit globalCadenceMs passed via runTask args.
+        const recentMs = Date.now() - 100;
+        await fs.writeJson(revisionsFile, {
+            revisions: {
+                't1/org/repo': {lastIngestedRev: 'sha-prior', lastRunAttemptAt: recentMs, consecutiveFailures: 0}
+            }
+        });
+
+        await provisionMirrorDir({tenantId: 't1', repoSlug: 'org/repo'});
+
+        // Force the orchestrator-resolved cadence high enough that 100ms-elapsed
+        // is NOT due. Without explicit pass, the service would fall back to
+        // AiConfig.data.orchestrator.intervals.tenantRepoSyncMs default.
+        const result = await TenantRepoSyncService.runTask({
+            reason          : 'periodic-sweep:60000',
+            taskStateService: createInMemoryTaskStateService(),
+            tenantReposConfig: {tenantRepos: [
+                {tenantId: 't1', repoSlug: 'org/repo', mirrorRoot, cloneUrl: 'https://github.com/neomjs/repo.git'}
+            ]},
+            gitMirror                    : makeFakeGitMirror(),
+            envelopeBuilder              : makeFakeEnvelopeBuilder(),
+            knowledgeBaseIngestionService: makeFakeIngestionService(),
+            revisionsFilePath            : revisionsFile,
+            globalCadenceMs              : 60 * 60 * 1000, // 1 hour — high enough that 100ms-elapsed is not-due
+            jitterRatio                  : 0,              // strip jitter so cadence comparison is exact
+            seedBootstrap                : false           // pre-seeded
+        });
+
+        // 100ms elapsed vs 1-hour cadence → not due. Proves orchestrator-resolved cadence flowed through.
+        expect(result.details.notDueCount).toBe(1);
+        expect(result.details.completedCount).toBe(0);
+    });
+
+    test('orchestrator-resolved jitterRatio flows through to isRepoDue (#11942 AC1 cycle-2 RA3)', async () => {
+        // Pre-populate priorState with lastRunAttemptAt exactly at cadence-boundary
+        // so jitterRatio=0 → due (cadence elapsed), jitterRatio=0.50 with large jitter → not-due.
+        const baseCadenceMs = 1000;
+        const exactlyAtCadenceBoundary = Date.now() - baseCadenceMs;
+        await fs.writeJson(revisionsFile, {
+            revisions: {
+                't1/org/repo': {lastIngestedRev: 'sha-prior', lastRunAttemptAt: exactlyAtCadenceBoundary, consecutiveFailures: 0}
+            }
+        });
+
+        await provisionMirrorDir({tenantId: 't1', repoSlug: 'org/repo'});
+
+        // jitterRatio=0.50 + tenantId/repoSlug → jitter > 0 → effectiveCadence > baseCadence → not-due
+        // (because (now - lastRunAttemptAt) = baseCadenceMs < baseCadenceMs + jitter).
+        const result = await TenantRepoSyncService.runTask({
+            reason          : 'periodic-sweep:60000',
+            taskStateService: createInMemoryTaskStateService(),
+            tenantReposConfig: {tenantRepos: [
+                {tenantId: 't1', repoSlug: 'org/repo', mirrorRoot, cloneUrl: 'https://github.com/neomjs/repo.git'}
+            ]},
+            gitMirror                    : makeFakeGitMirror(),
+            envelopeBuilder              : makeFakeEnvelopeBuilder(),
+            knowledgeBaseIngestionService: makeFakeIngestionService(),
+            revisionsFilePath            : revisionsFile,
+            globalCadenceMs              : baseCadenceMs,
+            jitterRatio                  : 0.50, // non-zero jitter → adds offset → not-due at exact-cadence-boundary
+            seedBootstrap                : false
+        });
+
+        // Proves jitterRatio was used by isRepoDue (jitter offset added to effectiveCadence).
+        expect(result.details.notDueCount).toBe(1);
+        expect(result.details.completedCount).toBe(0);
+    });
+
+    test('manual CLI (onlyRepoSlugs) bypasses bootstrap seeding (#11942 AC1 cycle-2)', async () => {
+        // Operator-initiated sync must always fire regardless of bootstrap-seeding state.
+        const taskStateService = createInMemoryTaskStateService();
+        const ingestCalls      = [];
+
+        await provisionMirrorDir({tenantId: 't1', repoSlug: 'org/manual-target'});
+
+        const result = await TenantRepoSyncService.runTask({
+            reason          : 'manual',
+            taskStateService,
+            tenantReposConfig: {tenantRepos: [
+                {tenantId: 't1', repoSlug: 'org/manual-target', mirrorRoot, cloneUrl: 'https://github.com/neomjs/manual.git'}
+            ]},
+            gitMirror                    : makeFakeGitMirror(),
+            envelopeBuilder              : makeFakeEnvelopeBuilder(),
+            knowledgeBaseIngestionService: makeFakeIngestionService({captureCalls: ingestCalls}),
+            onlyRepoSlugs                : ['org/manual-target'],
+            revisionsFilePath            : revisionsFile
+            // seedBootstrap defaults to true but onlyRepoSlugs path skips seeding entirely.
+        });
+
+        expect(result.status).toBe('completed');
+        expect(result.details.completedCount).toBe(1);
+        expect(result.details.notDueCount).toBe(0); // manual path bypasses both seeding and due-check
+        expect(ingestCalls).toHaveLength(1);
+    });
+
     test('concurrency-gate: queued slot acquisition surfaces KB_TENANT_REPO_SYNC_CONCURRENCY_GATE_TIMEOUT (#11942 AC2)', async () => {
         TenantRepoSyncService.concurrencyLimit         = 1;
         TenantRepoSyncService.concurrencyGateTimeoutMs = 50;
@@ -868,7 +1081,8 @@ test.describe('TenantRepoSyncService (#11790)', () => {
             gitMirror                    : slowMirror,
             envelopeBuilder              : makeFakeEnvelopeBuilder(),
             knowledgeBaseIngestionService: makeFakeIngestionService(),
-            revisionsFilePath            : revisionsFile
+            revisionsFilePath            : revisionsFile,
+            seedBootstrap                : false
         });
 
         // Wait long enough for the queued repo's slot acquisition to time out (~50ms).

--- a/test/playwright/unit/ai/daemons/orchestrator/services/TenantRepoSyncService.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/services/TenantRepoSyncService.spec.mjs
@@ -636,6 +636,203 @@ test.describe('TenantRepoSyncService (#11790)', () => {
         expect(TenantRepoSyncService.concurrencyGateTimeoutMs).toBe(60000);
     });
 
+    test('jitter+backoff: skips not-due repo with prior recent lastRunAttemptAt (#11942 AC1)', async () => {
+        const taskStateService = createInMemoryTaskStateService();
+        const ingestCalls      = [];
+
+        // Pre-populate persistence with a recent lastRunAttemptAt — repo should be skipped.
+        const recentMs = Date.now() - 1000; // 1s ago
+        await fs.writeJson(revisionsFile, {
+            revisions: {
+                't1/neomjs/recent-repo': {
+                    lastIngestedRev    : 'sha-recent',
+                    lastRunAttemptAt   : recentMs,
+                    consecutiveFailures: 0
+                }
+            }
+        });
+
+        await provisionMirrorDir({tenantId: 't1', repoSlug: 'neomjs/recent-repo'});
+
+        const result = await TenantRepoSyncService.runTask({
+            reason          : 'periodic-sweep:1800000',
+            taskStateService,
+            tenantReposConfig: {tenantRepos: [
+                {tenantId: 't1', repoSlug: 'neomjs/recent-repo', mirrorRoot, cloneUrl: 'https://github.com/neomjs/recent-repo.git'}
+            ]},
+            globalCadenceMs              : 60 * 60 * 1000, // 1h cadence — recent run is well within window
+            gitMirror                    : makeFakeGitMirror(),
+            envelopeBuilder              : makeFakeEnvelopeBuilder(),
+            knowledgeBaseIngestionService: makeFakeIngestionService({captureCalls: ingestCalls}),
+            revisionsFilePath            : revisionsFile
+        });
+
+        expect(result.status).toBe('completed'); // not-due is not a failure
+        expect(result.details.notDueCount).toBe(1);
+        expect(result.details.completedCount).toBe(0);
+        expect(result.details.failedCount).toBe(0);
+        expect(ingestCalls).toHaveLength(0); // no actual ingest work
+
+        const repoState = result.details.repos[0];
+        expect(repoState.status).toBe('not-due');
+        expect(repoState.nextDueAt).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+        expect(repoState.effectiveCadenceMs).toBeGreaterThan(0);
+        expect(repoState.consecutiveFailures).toBe(0);
+    });
+
+    test('jitter+backoff: persists consecutiveFailures increment on failure (#11942 AC1)', async () => {
+        const taskStateService = createInMemoryTaskStateService();
+
+        // Bootstrap state — repo should be due immediately (lastRunAttemptAt=0).
+        const failingMirror = {
+            async cloneIfMissing() { throw new Error('Simulated clone failure'); },
+            async fetch()          {},
+            async resolveHead()    { return null; },
+            async isAncestor()     { return false; },
+            async diffRevisions()  { return {addedOrChanged: [], deleted: []}; }
+        };
+
+        await provisionMirrorDir({tenantId: 't1', repoSlug: 'neomjs/failing-repo'});
+
+        const result = await TenantRepoSyncService.runTask({
+            reason          : 'periodic-sweep:1800000',
+            taskStateService,
+            tenantReposConfig: {tenantRepos: [
+                {tenantId: 't1', repoSlug: 'neomjs/failing-repo', mirrorRoot, cloneUrl: 'https://github.com/neomjs/failing-repo.git'}
+            ]},
+            gitMirror                    : failingMirror,
+            envelopeBuilder              : makeFakeEnvelopeBuilder(),
+            knowledgeBaseIngestionService: makeFakeIngestionService(),
+            revisionsFilePath            : revisionsFile
+        });
+
+        expect(result.status).toBe('failed');
+        expect(result.details.failedCount).toBe(1);
+        expect(result.details.repos[0].consecutiveFailures).toBe(1);
+
+        // Persistence reflects the failure increment for next cycle's backoff calculation.
+        const persisted = await fs.readJson(revisionsFile);
+        expect(persisted.revisions['t1/neomjs/failing-repo']).toEqual({
+            lastIngestedRev    : null,
+            lastRunAttemptAt   : expect.any(Number),
+            consecutiveFailures: 1
+        });
+    });
+
+    test('jitter+backoff: persists consecutiveFailures reset on subsequent success (#11942 AC1)', async () => {
+        const taskStateService = createInMemoryTaskStateService();
+
+        // Pre-populate with consecutiveFailures=3 (from prior failures); also stale lastRunAttemptAt
+        // so the backoff'd effective cadence is still elapsed.
+        await fs.writeJson(revisionsFile, {
+            revisions: {
+                't1/neomjs/recovering-repo': {
+                    lastIngestedRev    : 'sha-old',
+                    lastRunAttemptAt   : 0, // very stale — backoff'd cadence is exceeded
+                    consecutiveFailures: 3
+                }
+            }
+        });
+
+        await provisionMirrorDir({tenantId: 't1', repoSlug: 'neomjs/recovering-repo'});
+
+        const result = await TenantRepoSyncService.runTask({
+            reason          : 'periodic-sweep:1800000',
+            taskStateService,
+            tenantReposConfig: {tenantRepos: [
+                {tenantId: 't1', repoSlug: 'neomjs/recovering-repo', mirrorRoot, cloneUrl: 'https://github.com/neomjs/recovering-repo.git'}
+            ]},
+            gitMirror                    : makeFakeGitMirror(),
+            envelopeBuilder              : makeFakeEnvelopeBuilder(),
+            knowledgeBaseIngestionService: makeFakeIngestionService(),
+            revisionsFilePath            : revisionsFile
+        });
+
+        expect(result.status).toBe('completed');
+        expect(result.details.completedCount).toBe(1);
+
+        // Persistence: consecutiveFailures reset to 0 on success.
+        const persisted = await fs.readJson(revisionsFile);
+        expect(persisted.revisions['t1/neomjs/recovering-repo'].consecutiveFailures).toBe(0);
+        expect(persisted.revisions['t1/neomjs/recovering-repo'].lastIngestedRev).toBe('sha-head-neomjs/recovering-repo');
+    });
+
+    test('jitter+backoff: backward-compatible read of pre-AC1 string-shaped persistence (#11942 AC1)', async () => {
+        const taskStateService = createInMemoryTaskStateService();
+
+        // Pre-AC1 persistence shape: bare SHA strings under revisions.
+        await fs.writeJson(revisionsFile, {
+            revisions: {
+                't1/neomjs/legacy-repo': 'sha-from-before-ac1'
+            }
+        });
+
+        await provisionMirrorDir({tenantId: 't1', repoSlug: 'neomjs/legacy-repo'});
+
+        const result = await TenantRepoSyncService.runTask({
+            reason          : 'periodic-sweep:1800000',
+            taskStateService,
+            tenantReposConfig: {tenantRepos: [
+                {tenantId: 't1', repoSlug: 'neomjs/legacy-repo', mirrorRoot, cloneUrl: 'https://github.com/neomjs/legacy-repo.git'}
+            ]},
+            gitMirror                    : makeFakeGitMirror(),
+            envelopeBuilder              : makeFakeEnvelopeBuilder(),
+            knowledgeBaseIngestionService: makeFakeIngestionService(),
+            revisionsFilePath            : revisionsFile
+        });
+
+        // Successful migration: pre-AC1 SHA was read as lastIngestedRev with zeroed state;
+        // run proceeds normally; persistence rewritten in new shape.
+        expect(result.status).toBe('completed');
+
+        const persisted = await fs.readJson(revisionsFile);
+        const state     = persisted.revisions['t1/neomjs/legacy-repo'];
+        expect(typeof state).toBe('object');
+        expect(state.lastIngestedRev).toBeTruthy();
+        expect(state.consecutiveFailures).toBe(0); // success path resets
+        expect(state.lastRunAttemptAt).toBeGreaterThan(0);
+    });
+
+    test('jitter+backoff: onlyRepoSlugs (manual CLI path) bypasses due-check (#11942 AC1)', async () => {
+        const taskStateService = createInMemoryTaskStateService();
+        const ingestCalls      = [];
+
+        // Pre-populate with very recent lastRunAttemptAt — would normally be not-due.
+        const recentMs = Date.now() - 1000;
+        await fs.writeJson(revisionsFile, {
+            revisions: {
+                't1/neomjs/manual-repo': {
+                    lastIngestedRev    : 'sha-recent',
+                    lastRunAttemptAt   : recentMs,
+                    consecutiveFailures: 0
+                }
+            }
+        });
+
+        await provisionMirrorDir({tenantId: 't1', repoSlug: 'neomjs/manual-repo'});
+
+        const result = await TenantRepoSyncService.runTask({
+            reason          : 'manual',
+            taskStateService,
+            tenantReposConfig: {tenantRepos: [
+                {tenantId: 't1', repoSlug: 'neomjs/manual-repo', mirrorRoot, cloneUrl: 'https://github.com/neomjs/manual-repo.git'}
+            ]},
+            onlyRepoSlugs                : ['neomjs/manual-repo'], // manual CLI path
+            globalCadenceMs              : 60 * 60 * 1000,
+            gitMirror                    : makeFakeGitMirror(),
+            envelopeBuilder              : makeFakeEnvelopeBuilder(),
+            knowledgeBaseIngestionService: makeFakeIngestionService({captureCalls: ingestCalls}),
+            revisionsFilePath            : revisionsFile
+        });
+
+        // Manual CLI invocation bypasses due-check — repo IS synced even though
+        // periodic-cycle would have skipped it.
+        expect(result.status).toBe('completed');
+        expect(result.details.completedCount).toBe(1);
+        expect(result.details.notDueCount).toBe(0); // onlyRepoSlugs bypasses due-check → no not-due skips
+        expect(ingestCalls).toHaveLength(1);
+    });
+
     test('concurrency-gate: queued slot acquisition surfaces KB_TENANT_REPO_SYNC_CONCURRENCY_GATE_TIMEOUT (#11942 AC2)', async () => {
         TenantRepoSyncService.concurrencyLimit         = 1;
         TenantRepoSyncService.concurrencyGateTimeoutMs = 50;


### PR DESCRIPTION
Authored by Claude Opus 4.7 (Claude Code). Session continuation from cloud-deployment-trial sprint.

FAIR-band: in-band [16/30] — operator-direction (focus on multi-user cloud deployment, v13 wrap-up ratio discipline). Live verifier (per @neo-gpt cycle-1): GPT 14 / Claude 16 over last 30 merged PRs.

Evidence: L1 (286/286 PASS across orchestrator/; 5 new cycle-2 integration tests proving bootstrap-spread + orchestrator-resolved cadence/jitter pass-through; manual CLI bypass; deterministic jitter; backoff state mutation).

Resolves #11942

## Summary

Cycle-2 closes #11942 **AC1** (per-repo cadence + deterministic jitter/backoff). With #11952 (AC3+AC4) and #11960 (AC2) already merged, this PR completes the #11942 Epic — all four ACs shipped after architectural cycle-2.

Operator-direction continuation: this is the natural follow-on lane after #11960 (AC2 concurrency-gate) merged. Per the v13 wrap-up ratio discipline, this PR uses an EXISTING ticket (#11942 AC1) — no new ticket cost.

## Architectural shift (cycle-2)

**Cycle-1 problem** (caught by @neo-gpt cycle-1 review at `5d374c7c`):

The cycle-1 implementation computed deterministic jitter correctly but the production scheduler invoked `tenant-repo-sync` on the **same cadence** used as the per-repo base cadence. With `lastRunAttemptAt=0` for fresh repos and `Date.now()` as `now`, all repos became due on cycle 1 → thundering herd despite jitter. After cycle 1, non-zero jitter caused all repos to miss the next sweep and become due together on the cycle after → thundering herd cycle 2.

That is **not** spread across `[0, jitterRatio * baseCadenceMs)`.

**Cycle-2 fix** (`cb010c1d5`):

Two architectural decoupling moves:

### 1. Sweep cadence vs per-repo cadence are now distinct configs

- **New** `AiConfig.orchestrator.tenantRepoSync.sweepCadenceMs` (default `60_000` = 1 min) drives Orchestrator scheduling.
- **Existing** `AiConfig.orchestrator.intervals.tenantRepoSyncMs` (default 30 min) is now strictly the per-repo default cadence read by `isRepoDue()`.
- Orchestrator scheduling fires every `sweepCadenceMs`; per-repo decisions use `globalCadenceMs` (= `tenantRepoSyncIntervalMs`); jitter actually spreads.

### 2. Bootstrap seeding (`syncTenantRepos`)

- Pre-seeds new repos with `lastRunAttemptAt = now - baseCadenceMs` before iteration. This makes effective due-time `now + jitterMs`, so subsequent short-cadence sweeps within the jitter window pick up repos at staggered times — actual spread, not synchronized thundering herd.
- Seeded state persists across orchestrator restarts so HA-failover preserves the spread.
- `onlyRepoSlugs` (manual CLI bypass) skips seeding entirely; operator-initiated sync always fires.

### 3. Cadence-passthrough (eliminates split source of truth)

Orchestrator now explicitly passes:
```js
return this.tenantRepoSyncService.runTask({
    taskName,
    reason,
    taskStateService: this.taskStateService,
    healthService   : this.healthService,
    writeLog        : this.writeLog.bind(this),
    globalCadenceMs : this.tenantRepoSyncIntervalMs,  // explicit pass — was AiConfig fallback
    jitterRatio     : this.tenantRepoSyncJitterRatio  // explicit pass — was AiConfig fallback
});
```

This eliminates the cycle-1 bug where `Orchestrator.mjs` computed `this.tenantRepoSyncIntervalMs` with env precedence but `runTask()` defaulted `globalCadenceMs` from `AiConfig.data.orchestrator.intervals.tenantRepoSyncMs` directly. Env-overridden deployments now see the same cadence at both layers.

### 4. New Orchestrator getters

- `tenantRepoSyncSweepCadenceMs` (env: `NEO_ORCHESTRATOR_TENANT_REPO_SYNC_SWEEP_CADENCE_MS`) — sweep frequency
- `tenantRepoSyncJitterRatio` (env: `NEO_ORCHESTRATOR_TENANT_REPO_SYNC_JITTER_RATIO`) — jitter ratio with env precedence

Existing `tenantRepoSyncIntervalMs` getter preserved with semantic shift to "per-repo cadence"; the `NEO_ORCHESTRATOR_TENANT_REPO_SYNC_INTERVAL_MS` env name is unchanged for back-compat (operators who set this for "faster testing" now get faster per-repo cadence under a 1-min sweep).

### 5. Test seam: `seedBootstrap` parameter

`runTask`/`syncTenantRepos` accept `seedBootstrap` (default `true` in production). Spec files that simulate "first cycle fires all repos" can opt out via `seedBootstrap: false`. Required because bootstrap-seeding defers the first-fire of new repos by design.

## Component shape

**Pure functions** in [`ai/daemons/orchestrator/scheduling/tenantRepoSync.mjs`](ai/daemons/orchestrator/scheduling/tenantRepoSync.mjs) — unchanged from cycle-1:
- `computeDeterministicJitter({tenantId, repoSlug, baseCadenceMs, jitterRatio})` — FNV-1a-based stable jitter offset
- `isRepoDue({repo, persistedRepoState, now, globalCadenceMs, jitterRatio})` — returns full envelope `{due, effectiveCadenceMs, jitterMs, backoffMultiplier, lastRunAttemptAt}`

**Persistence schema** (unchanged from cycle-1, with bootstrap-seeded values appearing on first observation):
```js
{ revisions: { 'tenantId/repoSlug': {
    lastIngestedRev    : 'sha' | null,
    lastRunAttemptAt   : 1716000000000,  // bootstrap-seeded: now - baseCadenceMs
    consecutiveFailures: 0
} } }
```

**`syncTenantRepos` per-sweep loop** (cycle-2 additions):
- Pre-pass: bootstrap-seed new repos (skipped on `onlyRepoSlugs` and when `seedBootstrap: false`)
- Per-repo due-check via `isRepoDue` (unchanged from cycle-1)
- Not-due repos: skip semaphore + work entirely, emit `status='not-due'` health entry
- Due repos: acquire semaphore + run work + mutate persisted state per outcome

**`runTask` + `syncTenantRepos` signatures** accept `globalCadenceMs` + `jitterRatio` + `seedBootstrap` parameters. Defaults preserved for back-compat with manual CLI invocations; Orchestrator passes orchestrator-resolved values explicitly.

## Deltas from ticket

None — cycle-2 implementation matches AC1 prescription:
- ✓ Per-repo cadence stored in `tenant-repo-sync-revisions.json` alongside `lastIngestedRev`
- ✓ Deterministic jitter via `repoSlug + tenantId` hash
- ✓ Jitter window ≤ 20% of cadence (default `jitterRatio: 0.20`)
- ✓ Backoff doubles on consecutive failures (multiplier `2^consecutiveFailures`)
- ✓ Resets on success (`consecutiveFailures = 0` after successful sync)

Cycle-2 additions beyond strict AC1 prescription (justified by review feedback):
- **Decoupled sweep cadence** — required for jitter to actually spread per-repo work
- **Bootstrap seeding** — required to spread the FIRST sweep (otherwise all repos due at lastRunAttemptAt=0)
- **Cadence/jitter pass-through** — eliminates split source of truth flagged by GPT
- **Manual CLI bypass** (`onlyRepoSlugs`) — unchanged from cycle-1
- **Health-payload `nextDueAt` visibility** — unchanged from cycle-1
- **Backward-compatible read of pre-AC1 string-shape persistence** — unchanged from cycle-1

## Test Evidence

```bash
npm run test-unit -- test/playwright/unit/ai/daemons/orchestrator/
```

→ **286/286 PASS** (8.0s)

The directly-touched specs:
- [`scheduling/tenantRepoSync.spec.mjs`](test/playwright/unit/ai/daemons/orchestrator/scheduling/tenantRepoSync.spec.mjs) — 18/18 (unchanged from cycle-1)
- [`services/TenantRepoSyncService.spec.mjs`](test/playwright/unit/ai/daemons/orchestrator/services/TenantRepoSyncService.spec.mjs) — 27/27 (22 from cycle-1 + 5 new cycle-2)

The 5 new cycle-2 integration tests cover:
1. **bootstrap-spread: first sweep seeds new repos with lastRunAttemptAt=now-baseCadence** — verifies seeded state, notDueCount=2 on the seeding sweep
2. **bootstrap-spread: seeded repo becomes due on a later sweep within its jitter window** — pre-seeds; advances time; verifies distribution sums correctly
3. **orchestrator-resolved globalCadenceMs flows through to isRepoDue** — explicit `globalCadenceMs: 1hr` makes a 100ms-elapsed repo not-due (RA3)
4. **orchestrator-resolved jitterRatio flows through to isRepoDue** — explicit `jitterRatio: 0.50` adds offset → not-due at exact-cadence-boundary (RA3)
5. **manual CLI (onlyRepoSlugs) bypasses bootstrap seeding** — operator-initiated sync always fires

## Cycle-2 changes (per @neo-gpt review at `5d374c7c`)

Pushed at `cb010c1d5`:

1. **RA1 — scheduler composition fix**: added `sweepCadenceMs` config (default 1min) + bootstrap seeding (`syncTenantRepos` pre-pass) so deterministic jitter actually spreads tenant repo work across the jitter window. Sweep cadence is now decoupled from per-repo cadence; first-bootstrap deployments no longer thundering-herd.
2. **RA2 — cadence pass-through**: Orchestrator now explicitly passes `globalCadenceMs: this.tenantRepoSyncIntervalMs` AND `jitterRatio: this.tenantRepoSyncJitterRatio` into `runTask()`. The cycle-1 split source of truth (env-resolved cadence at scheduler vs AiConfig-default at runTask) is gone.
3. **RA3 — integration tests**: 5 new tests in TenantRepoSyncService.spec.mjs covering bootstrap seeding, multi-sweep behavior, and cadence/jitter pass-through. Plus updated 8 existing tests with `seedBootstrap: false` opt-out (they test in-loop iteration semantics, not bootstrap behavior).
4. **RA4 — FAIR-band correction**: `[17/30]` (stale) → `[16/30]` (in-band per GPT's live verifier of last 30 merged PRs).

## Post-Merge Validation

- [ ] Operator confirms multi-tenant first-bootstrap deployment doesn't thundering-herd (clones spread across ~20% of cadence window via 1-min sweep cadence)
- [ ] Operator confirms a persistently-failing repo backs off (cycle 1 fail → 2× cadence; cycle 2 fail → 4× cadence; eventual success resets to 1×)
- [ ] Operator confirms `NEO_ORCHESTRATOR_TENANT_REPO_SYNC_SWEEP_CADENCE_MS` (new) and `NEO_ORCHESTRATOR_TENANT_REPO_SYNC_JITTER_RATIO` (new) env overrides take effect on next sweep
- [ ] `#11942` Epic complete with this merge — all 4 ACs shipped (AC1 = this PR; AC2 = #11960; AC3+AC4 = #11952)

## Avoided Traps

- ✓ Did NOT introduce a separate persistence file for per-repo state — extended existing `tenant-repo-sync-revisions.json` with backward-compat read, single-source-of-truth preserved
- ✓ Did NOT design a separate schedule-emitter that fires per-repo events — kept the existing single-task-per-cycle architecture with per-repo due-checks inside; matches the cloud-deployment-trial-tested shape
- ✓ Did NOT apply due-check or bootstrap seeding to manual CLI invocations — operator-initiated sync should always fire; `onlyRepoSlugs` bypass preserves manual sync semantics
- ✓ Did NOT introduce `schemaVersion` field speculatively — migration is detectable via shape-tell (string vs object); adding `schemaVersion` would be speculative-support per `feedback_truth_in_code`
- ✓ **(cycle-2)** Did NOT keep the cycle-1 split source of truth — Orchestrator now passes both `globalCadenceMs` and `jitterRatio` explicitly into `runTask()`; AiConfig defaults remain as the manual-CLI fallback only
- ✓ **(cycle-2)** Did NOT couple sweep cadence to per-repo cadence — they're separate configs; sweep fires frequently, per-repo decisions own their cadence

## v13 wrap-up ratio accounting

This PR uses EXISTING ticket #11942 (no new ticket cost). Per the operator's 2026-05-25 ratio constraint (1 new ticket : 2-3 PRs minimum):
- Session ratio so far: 2 new tickets (#11954 + #11955, both already merged) : 7 PRs landed (#11951 + #11952 + #11953-by-GPT + #11956 + #11957 + #11958-by-GPT + #11959 + #11960) ≈ 1:3.5 ratio
- This PR adds: 0 new ticket + 1 PR → 0:1 incremental → keeps overall ratio strongly positive
- Discussion #11961 graduation (now landed as #10103) added 1 epic + 3 sub-tickets (#11963, #11965, #11964) and 2 sub-PRs in-flight (#11967 + #11966) → multi-PR yield on existing graduation work

## Authority

#11942 was filed by me 2026-05-25 as a follow-up to #11790 cycle-1 review feedback. AC3+AC4 shipped via #11952, AC2 shipped via #11960, AC1 ships here. Self-assigned, operator-aligned with the "we need to make progress" framing on existing v13 tickets pre-graduation.

Authored by [Claude Opus 4.7] (Claude Code) — Session continuation from cloud-deployment-trial sprint.
