### PR TITLE
feat(memory-core): native Ollama runtime dispatch + provider.embed() method (#11965 Sub-2)

### DIFF
--- a/ai/provider/Ollama.mjs
+++ b/ai/provider/Ollama.mjs
@@ -24,6 +24,14 @@ class OllamaProvider extends Base {
          */
         modelName: 'gemma4',
         /**
+         * Dedicated embedding model (e.g., `nomic-embed-text`, `mxbai-embed-large`).
+         * Distinct from `modelName` which is the chat/generation model.
+         * Falls back to `modelName` when unset (some Ollama chat models support
+         * embeddings, though operators typically configure a dedicated embedding model).
+         * @member {String} embeddingModel=null
+         */
+        embeddingModel: null,
+        /**
          * @member {String[]} requiredEnv=[]
          */
         requiredEnv: []
@@ -164,6 +172,87 @@ class OllamaProvider extends Base {
         } catch (error) {
             // Re-throw to let the caller handle it or gracefully degrade
             // instead of vomiting a raw fetch trace if the daemon is offline
+            throw error;
+        }
+    }
+
+    /**
+     * @summary Generates embedding vectors for one or more input texts via Ollama's
+     * native `/api/embed` endpoint.
+     *
+     * The native endpoint accepts a string OR array-of-strings for `input` and returns
+     * `{embeddings: number[][]}`. Always returns an array-of-arrays for caller
+     * uniformity — single-string callers receive `[[...]]` shape just like batch.
+     *
+     * Distinct from the OpenAI-compatible `/v1/embeddings` path: this uses Ollama's
+     * native API (matches the rest of this provider class) so operators who explicitly
+     * choose `embeddingProvider: 'ollama'` get the native semantics without depending
+     * on Ollama's OpenAI-compat surface.
+     *
+     * Uses the `embeddingModel` config slot when set; falls back to `modelName` (the
+     * chat model) if `embeddingModel` is unset — Ollama supports embeddings from many
+     * chat models but operators typically want a dedicated embedding model like
+     * `nomic-embed-text`.
+     *
+     * @param {String|String[]} input Single text or array of texts to embed.
+     * @param {Object} [options]
+     * @param {String} [options.model] Override the configured `embeddingModel` / `modelName`.
+     * @returns {Promise<{embeddings: Number[][], raw: Object}>}
+     */
+    async embed(input, options = {}) {
+        const model = options.model || this.embeddingModel || this.modelName;
+        const payload = {
+            model,
+            input
+        };
+
+        try {
+            const parsedUrl  = new URL(`${this.host}/api/embed`);
+            const httpModule = parsedUrl.protocol === 'https:' ? await import('https') : await import('http');
+
+            let resolveFunc, rejectFunc;
+            const responsePromise = new Promise((res, rej) => {
+                resolveFunc = res;
+                rejectFunc  = rej;
+            });
+
+            const req = httpModule.request(parsedUrl, {
+                method : 'POST',
+                headers: {'Content-Type': 'application/json'},
+                timeout: 60 * 60 * 1000 // 1h timeout matches generate()
+            }, (res) => {
+                let body = '';
+                res.on('data', chunk => body += chunk);
+                res.on('end', () => {
+                    if (res.statusCode < 200 || res.statusCode >= 300) {
+                        rejectFunc(new Error(`Ollama embed API error: ${res.statusCode} - ${body}`));
+                    } else {
+                        try {
+                            const result = JSON.parse(body);
+                            resolveFunc(result);
+                        } catch (e) {
+                            rejectFunc(new Error(`Failed to parse Ollama embed response: ${e.message}`));
+                        }
+                    }
+                });
+            });
+
+            req.on('error', err => rejectFunc(err));
+
+            req.on('timeout', () => {
+                req.destroy();
+                rejectFunc(new Error('Ollama embed request timed out after 1 hour'));
+            });
+
+            req.write(JSON.stringify(payload));
+            req.end();
+
+            const result = await responsePromise;
+            return {
+                embeddings: result.embeddings || [],
+                raw       : result
+            };
+        } catch (error) {
             throw error;
         }
     }

--- a/ai/services/graph/GoldenPathSynthesizer.mjs
+++ b/ai/services/graph/GoldenPathSynthesizer.mjs
@@ -8,7 +8,7 @@ import { Memory_TextEmbeddingService as TextEmbeddingService } from '../../servi
 import { Memory_GraphService as GraphService } from '../../services.mjs';
 import Json from '../../../src/util/Json.mjs';
 import logger from '../../mcp/server/memory-core/logger.mjs';
-import OpenAiCompatible from '../../provider/OpenAiCompatible.mjs';
+import {buildGraphProvider} from './providerDispatch.mjs';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname  = path.dirname(__filename);
@@ -279,10 +279,11 @@ class GoldenPathSynthesizer extends Base {
             });
 
             try {
-                logger.info('[GoldenPathSynthesizer] Instantiating API provider to interpret Mathematical Golden Path...');
-                const provider = Neo.create(OpenAiCompatible, {
-                    modelName: aiConfig.openAiCompatible.model,
-                    host: aiConfig.openAiCompatible.host
+                logger.info(`[GoldenPathSynthesizer] Instantiating ${aiConfig.modelProvider} provider to interpret Mathematical Golden Path...`);
+                const provider = buildGraphProvider({
+                    modelProvider         : aiConfig.modelProvider,
+                    ollamaConfig          : aiConfig.ollama,
+                    openAiCompatibleConfig: aiConfig.openAiCompatible
                 });
 
                 // Get adjacent frontier topology for context

--- a/ai/services/graph/SemanticGraphExtractor.mjs
+++ b/ai/services/graph/SemanticGraphExtractor.mjs
@@ -6,7 +6,7 @@ import {invokeWithGuardrail} from '../../services/memory-core/helpers/ConsumerFr
 import GraphService from '../../services/memory-core/GraphService.mjs';
 import Json from '../../../src/util/Json.mjs';
 import logger from '../../mcp/server/memory-core/logger.mjs';
-import OpenAiCompatible from '../../provider/OpenAiCompatible.mjs';
+import {buildGraphProvider} from './providerDispatch.mjs';
 
 /**
  * @class Neo.ai.daemons.services.SemanticGraphExtractor
@@ -93,9 +93,10 @@ When extracting entities, you MUST emit provenance edges linking them back to th
 DO NOT output markdown, \`\`\`json blocks, or any other explanations. Provide purely the JSON object.`;
 
         try {
-            const provider = Neo.create(OpenAiCompatible, {
-                modelName: aiConfig.openAiCompatible.model,
-                host: aiConfig.openAiCompatible.host
+            const provider = buildGraphProvider({
+                modelProvider         : aiConfig.modelProvider,
+                ollamaConfig          : aiConfig.ollama,
+                openAiCompatibleConfig: aiConfig.openAiCompatible
             });
 
             // Format boundaries securely
@@ -111,12 +112,17 @@ DO NOT output markdown, \`\`\`json blocks, or any other explanations. Provide pu
 
             // Wrap each LLM invocation with the Consumer-Friction guardrail. The upstream
             // pre-check skips invocation when the composed messages' estimated token count
-            // exceeds the consumer's safe processing band (default 75% of
-            // `aiConfig.openAiCompatible.contextLimitTokens`). The downstream try/catch
-            // categorizes engine-level failures into friction symptoms. Friction is emitted
-            // into the in-memory aggregator (with `serviceDomain: 'dream-pipeline'`) for
-            // handoff rendering by `GoldenPathSynthesizer.synthesizeGoldenPath`.
-            const consumerModel          = aiConfig.openAiCompatible.model || 'openAiCompatible';
+            // exceeds the consumer's safe processing band (default 75% of the consumer's
+            // context limit). The downstream try/catch categorizes engine-level failures
+            // into friction symptoms. Friction is emitted into the in-memory aggregator
+            // (with `serviceDomain: 'dream-pipeline'`) for handoff rendering by
+            // `GoldenPathSynthesizer.synthesizeGoldenPath`.
+            // #11965 AC5: consumerModel reflects the active modelProvider for accurate
+            // telemetry; openAiCompatible's context-limit knobs are kept as the conservative
+            // upstream pre-check threshold for both provider families.
+            const consumerModel          = aiConfig.modelProvider === 'ollama'
+                ? aiConfig.ollama?.model || 'ollama'
+                : aiConfig.openAiCompatible?.model || 'openAiCompatible';
             const consumerContextTokens  = aiConfig.openAiCompatible.contextLimitTokens || 32768;
             const consumerSafeTokens     = aiConfig.openAiCompatible.safeProcessingLimitTokens;
 
@@ -348,9 +354,10 @@ Enforce this STRICT JSON schema:
 DO NOT output markdown, \`\`\`json blocks, or any other explanations. Provide purely the JSON object.`;
 
         try {
-            const provider = Neo.create(OpenAiCompatible, {
-                modelName: aiConfig.openAiCompatible.model,
-                host: aiConfig.openAiCompatible.host
+            const provider = buildGraphProvider({
+                modelProvider         : aiConfig.modelProvider,
+                ollamaConfig          : aiConfig.ollama,
+                openAiCompatibleConfig: aiConfig.openAiCompatible
             });
 
             const messages = [

--- a/ai/services/graph/TopologyInferenceEngine.mjs
+++ b/ai/services/graph/TopologyInferenceEngine.mjs
@@ -3,7 +3,7 @@ import { Memory_Config as aiConfig } from '../../services.mjs';
 import Base from '../../../src/core/Base.mjs';
 import Json from '../../../src/util/Json.mjs';
 import logger from '../../mcp/server/memory-core/logger.mjs';
-import OpenAiCompatible from '../../provider/OpenAiCompatible.mjs';
+import {buildGraphProvider} from './providerDispatch.mjs';
 
 /**
  * @class Neo.ai.daemons.services.TopologyInferenceEngine
@@ -54,9 +54,10 @@ DO NOT output markdown, \`\`\`json blocks, or any other explanations. Provide pu
 ${contextText}
 `;
         try {
-            const provider = Neo.create(OpenAiCompatible, {
-                modelName: aiConfig.openAiCompatible.model,
-                host: aiConfig.openAiCompatible.host
+            const provider = buildGraphProvider({
+                modelProvider         : aiConfig.modelProvider,
+                ollamaConfig          : aiConfig.ollama,
+                openAiCompatibleConfig: aiConfig.openAiCompatible
             });
 
             const result = await provider.generate(prompt);

--- a/ai/services/graph/providerDispatch.mjs
+++ b/ai/services/graph/providerDispatch.mjs
@@ -1,0 +1,61 @@
+import Ollama           from '../../provider/Ollama.mjs';
+import OpenAiCompatible from '../../provider/OpenAiCompatible.mjs';
+
+/**
+ * @summary Provider dispatch for graph-generation services (#11965 AC5).
+ *
+ * Closes #11965 AC5 "Dream/REM graph-mutator provider reachability is not
+ * hardwired to the wrong provider family" by giving graph-generation callsites
+ * (`SemanticGraphExtractor`, `GoldenPathSynthesizer`, `TopologyInferenceEngine`)
+ * a single dispatch seam that honors `aiConfig.modelProvider`. Without this
+ * indirection, cloud deployments configured for native Ollama would still see
+ * graph generation hit OpenAI-compatible endpoints, breaking the operator
+ * client-need signal that flipped OQ2 disposition during Discussion #11961
+ * graduation (cloud-deployment clients prefer Ollama; no Mac OS in cloud rules
+ * out MLX).
+ *
+ * Pure function with injectable provider factories so tests can verify
+ * selector behavior without hitting real Ollama / OpenAI-compatible endpoints.
+ * Mirrors the `buildChatModel` pattern in `SessionService.mjs` so reviewers
+ * recognize the shape.
+ *
+ * @param {Object} options
+ * @param {String} options.modelProvider One of `'ollama'`, `'openAiCompatible'`.
+ *     Unknown values throw explicitly (no silent fallback to a different family).
+ * @param {Object} [options.ollamaConfig] `{host, model, embeddingModel}` config block.
+ * @param {Object} [options.openAiCompatibleConfig] `{host, model, apiKey, ...}` config block.
+ * @param {Function} [options.ollamaProviderFactory] Test seam — defaults to `Neo.create(Ollama, cfg)`.
+ * @param {Function} [options.openAiCompatibleProviderFactory] Test seam — defaults to `Neo.create(OpenAiCompatible, cfg)`.
+ * @returns {{generate: Function}} Provider instance with `generate(prompt, options)` method.
+ *     Both native Ollama and OpenAI-compatible providers expose this shape.
+ * @throws {Error} For unsupported `modelProvider` values.
+ */
+export function buildGraphProvider({
+    modelProvider,
+    ollamaConfig,
+    openAiCompatibleConfig,
+    ollamaProviderFactory          = (cfg) => Neo.create(Ollama, cfg),
+    openAiCompatibleProviderFactory = (cfg) => Neo.create(OpenAiCompatible, cfg)
+}) {
+    switch (modelProvider) {
+        case 'ollama':
+            return ollamaProviderFactory({
+                modelName     : ollamaConfig?.model,
+                host          : ollamaConfig?.host,
+                embeddingModel: ollamaConfig?.embeddingModel || null
+            });
+
+        case 'openAiCompatible':
+            return openAiCompatibleProviderFactory({
+                modelName: openAiCompatibleConfig?.model,
+                host     : openAiCompatibleConfig?.host,
+                apiKey   : openAiCompatibleConfig?.apiKey || ''
+            });
+
+        default:
+            throw new Error(
+                `buildGraphProvider: unsupported modelProvider '${modelProvider}'. ` +
+                `Expected one of: 'ollama', 'openAiCompatible'.`
+            );
+    }
+}

--- a/ai/services/memory-core/SessionService.mjs
+++ b/ai/services/memory-core/SessionService.mjs
@@ -6,6 +6,88 @@ import crypto from 'crypto';
 import GraphService from './GraphService.mjs';
 import OpenAiCompatibleProvider from '../../provider/OpenAiCompatible.mjs';
 import OllamaProvider           from '../../provider/Ollama.mjs';
+
+/**
+ * @summary Builds the chat-completion model wrapper for the configured `modelProvider`.
+ *
+ * Pure-ish: side effects are limited to logging + provider instantiation via the
+ * injected factories. Returns a `{generateContent}` shim that wraps the provider's
+ * `generate()` in a Gemini-shaped response envelope (`{response: {text()}}`) so
+ * downstream consumers (`summarizeSession`, `invokeWithGuardrail`) stay
+ * provider-agnostic.
+ *
+ * Extracted from `SessionService.construct()` for #11965 Sub-2 cycle-2 testability:
+ * tests can pass mocked provider factories to verify selector boundaries + envelope
+ * shape without hitting real Ollama / OpenAI-compatible endpoints. Production
+ * `construct()` calls this with `Neo.create`-based factories that return real
+ * provider class instances.
+ *
+ * @param {Object} options
+ * @param {String} options.modelProvider 'gemini' | 'openAiCompatible' | 'ollama'.
+ * @param {Object} [options.openAiCompatibleConfig] Slice of `aiConfig.openAiCompatible` ({host, apiKey, model}).
+ * @param {Object} [options.ollamaConfig] Slice of `aiConfig.ollama` ({host, model, embeddingModel}).
+ * @param {String} [options.geminiApiKey] `GEMINI_API_KEY` env value (passed for testability).
+ * @param {String} [options.geminiModelName] `aiConfig.modelName` (Gemini model name).
+ * @param {Function} [options.ollamaProviderFactory] Test seam — defaults to `Neo.create(OllamaProvider, cfg)`.
+ * @param {Function} [options.openAiCompatibleProviderFactory] Test seam — defaults to `Neo.create(OpenAiCompatibleProvider, cfg)`.
+ * @param {Function} [options.geminiClientFactory] Test seam — defaults to `new GoogleGenerativeAI(...).getGenerativeModel({model})`.
+ * @returns {Object|null} Gemini-shaped `{generateContent}` model, OR `null` for gemini without API key.
+ * @throws {Error} When `modelProvider` is not in the supported set.
+ */
+export function buildChatModel({
+    modelProvider,
+    openAiCompatibleConfig,
+    ollamaConfig,
+    geminiApiKey,
+    geminiModelName,
+    ollamaProviderFactory          = (cfg) => Neo.create(OllamaProvider, cfg),
+    openAiCompatibleProviderFactory = (cfg) => Neo.create(OpenAiCompatibleProvider, cfg),
+    geminiClientFactory             = (apiKey, modelName) => new GoogleGenerativeAI(apiKey).getGenerativeModel({model: modelName})
+} = {}) {
+    if (modelProvider === 'openAiCompatible') {
+        const cfg = openAiCompatibleConfig || {};
+        const provider = openAiCompatibleProviderFactory({
+            apiKey   : cfg.apiKey,
+            host     : cfg.host,
+            modelName: cfg.model
+        });
+        return {
+            generateContent: async (promptText) => {
+                provider.apiKey    = cfg.apiKey;
+                provider.host      = cfg.host;
+                provider.modelName = cfg.model;
+                const result  = await provider.generate(promptText);
+                const content = result.content || result.raw?.message?.content || '';
+                return {response: {text: () => content}};
+            }
+        };
+    }
+
+    if (modelProvider === 'ollama') {
+        const cfg = ollamaConfig || {};
+        const provider = ollamaProviderFactory({
+            host          : cfg.host           || 'http://127.0.0.1:11434',
+            modelName     : cfg.model          || 'gemma4',
+            embeddingModel: cfg.embeddingModel || null
+        });
+        return {
+            generateContent: async (promptText) => {
+                provider.host      = cfg.host  || provider.host;
+                provider.modelName = cfg.model || provider.modelName;
+                const result  = await provider.generate(promptText);
+                const content = result.content || result.raw?.message?.content || '';
+                return {response: {text: () => content}};
+            }
+        };
+    }
+
+    if (modelProvider === 'gemini') {
+        if (!geminiApiKey) return null;
+        return geminiClientFactory(geminiApiKey, geminiModelName);
+    }
+
+    throw new Error(`SessionService: unsupported modelProvider '${modelProvider}'. Expected one of: 'gemini', 'openAiCompatible', 'ollama'.`);
+}
 import StorageRouter from './managers/StorageRouter.mjs';
 import HealthService from './HealthService.mjs';
 import Json from '../../../src/util/Json.mjs';
@@ -105,60 +187,24 @@ class SessionService extends Base {
             }
         }
 
+        // #11965 Sub-2 cycle-2: delegate to extracted `buildChatModel` helper for
+        // testability + explicit unsupported-provider rejection (throws if modelProvider
+        // is not in the supported set, fail-loud rather than silent Gemini fallthrough).
         if (aiConfig.modelProvider === 'openAiCompatible') {
             logger.info(`[SessionService] Initializing generation model via OpenAI-Compatible API (${aiConfig.openAiCompatible.model})`);
-            const provider = Neo.create(OpenAiCompatibleProvider, {
-                apiKey   : aiConfig.openAiCompatible.apiKey,
-                host     : aiConfig.openAiCompatible.host,
-                modelName: aiConfig.openAiCompatible.model
-            });
-
-            this.model = {
-                generateContent: async (promptText) => {
-                    logger.info(`[OpenAiCompatible] Sending summarization prompt (${promptText.length} chars)`);
-                    provider.apiKey    = aiConfig.openAiCompatible.apiKey;
-                    provider.host      = aiConfig.openAiCompatible.host;
-                    provider.modelName = aiConfig.openAiCompatible.model;
-
-                    const result  = await provider.generate(promptText);
-                    const content = result.content || result.raw?.message?.content || '';
-
-                    return {response: {text: () => content}};
-                }
-            };
         } else if (aiConfig.modelProvider === 'ollama') {
-            // #11965 Sub-2: native Ollama chat dispatch via Neo.ai.provider.Ollama.
-            // Wraps the provider's `generate()` chat-completions call in the Gemini-shaped
-            // {response: {text: () => content}} envelope so the rest of SessionService
-            // (summarization, invokeWithGuardrail, etc.) stays provider-agnostic.
             logger.info(`[SessionService] Initializing generation model via native Ollama (${aiConfig.ollama?.model || '<unset>'})`);
-            const provider = Neo.create(OllamaProvider, {
-                host          : aiConfig.ollama?.host          || 'http://127.0.0.1:11434',
-                modelName     : aiConfig.ollama?.model         || 'gemma4',
-                embeddingModel: aiConfig.ollama?.embeddingModel || null
-            });
-
-            this.model = {
-                generateContent: async (promptText) => {
-                    logger.info(`[Ollama] Sending summarization prompt (${promptText.length} chars)`);
-                    // Refresh provider config per request — matches OpenAiCompatible-path
-                    // semantic so runtime config mutation by tests / embedded operators
-                    // still applies to subsequent invocations.
-                    provider.host      = aiConfig.ollama?.host  || provider.host;
-                    provider.modelName = aiConfig.ollama?.model || provider.modelName;
-
-                    const result  = await provider.generate(promptText);
-                    const content = result.content || result.raw?.message?.content || '';
-
-                    return {response: {text: () => content}};
-                }
-            };
-        } else {
+        } else if (aiConfig.modelProvider === 'gemini') {
             logger.info(`[SessionService] Initializing generation model via Gemini (${aiConfig.modelName})`);
-            const geminiKey = process.env.GEMINI_API_KEY;
-            const genAI = new GoogleGenerativeAI(geminiKey);
-            this.model = genAI.getGenerativeModel({ model: aiConfig.modelName });
         }
+
+        this.model = buildChatModel({
+            modelProvider          : aiConfig.modelProvider,
+            openAiCompatibleConfig : aiConfig.openAiCompatible,
+            ollamaConfig           : aiConfig.ollama,
+            geminiApiKey           : process.env.GEMINI_API_KEY,
+            geminiModelName        : aiConfig.modelName
+        });
     }
 
     /**

--- a/ai/services/memory-core/SessionService.mjs
+++ b/ai/services/memory-core/SessionService.mjs
@@ -5,6 +5,7 @@ import {invokeWithGuardrail} from './helpers/ConsumerFrictionHelper.mjs';
 import crypto from 'crypto';
 import GraphService from './GraphService.mjs';
 import OpenAiCompatibleProvider from '../../provider/OpenAiCompatible.mjs';
+import OllamaProvider           from '../../provider/Ollama.mjs';
 import StorageRouter from './managers/StorageRouter.mjs';
 import HealthService from './HealthService.mjs';
 import Json from '../../../src/util/Json.mjs';
@@ -118,6 +119,33 @@ class SessionService extends Base {
                     provider.apiKey    = aiConfig.openAiCompatible.apiKey;
                     provider.host      = aiConfig.openAiCompatible.host;
                     provider.modelName = aiConfig.openAiCompatible.model;
+
+                    const result  = await provider.generate(promptText);
+                    const content = result.content || result.raw?.message?.content || '';
+
+                    return {response: {text: () => content}};
+                }
+            };
+        } else if (aiConfig.modelProvider === 'ollama') {
+            // #11965 Sub-2: native Ollama chat dispatch via Neo.ai.provider.Ollama.
+            // Wraps the provider's `generate()` chat-completions call in the Gemini-shaped
+            // {response: {text: () => content}} envelope so the rest of SessionService
+            // (summarization, invokeWithGuardrail, etc.) stays provider-agnostic.
+            logger.info(`[SessionService] Initializing generation model via native Ollama (${aiConfig.ollama?.model || '<unset>'})`);
+            const provider = Neo.create(OllamaProvider, {
+                host          : aiConfig.ollama?.host          || 'http://127.0.0.1:11434',
+                modelName     : aiConfig.ollama?.model         || 'gemma4',
+                embeddingModel: aiConfig.ollama?.embeddingModel || null
+            });
+
+            this.model = {
+                generateContent: async (promptText) => {
+                    logger.info(`[Ollama] Sending summarization prompt (${promptText.length} chars)`);
+                    // Refresh provider config per request — matches OpenAiCompatible-path
+                    // semantic so runtime config mutation by tests / embedded operators
+                    // still applies to subsequent invocations.
+                    provider.host      = aiConfig.ollama?.host  || provider.host;
+                    provider.modelName = aiConfig.ollama?.model || provider.modelName;
 
                     const result  = await provider.generate(promptText);
                     const content = result.content || result.raw?.message?.content || '';
@@ -469,9 +497,12 @@ ${aggregatedContent}
         // try/catch) categorizes engine-level failures into friction symptoms. Friction is
         // emitted with `serviceDomain: 'memory-core'` for handoff rendering by
         // `GoldenPathSynthesizer.synthesizeGoldenPath`.
-        const consumerModel         = aiConfig.modelProvider === 'openAiCompatible'
-            ? (aiConfig.openAiCompatible.model || 'openAiCompatible')
-            : (aiConfig.modelName || 'gemini');
+        // #11965 Sub-2: consumer model naming covers all three active providers for
+        // guardrail/log surfaces.
+        const consumerModel =
+            aiConfig.modelProvider === 'openAiCompatible' ? (aiConfig.openAiCompatible.model || 'openAiCompatible') :
+            aiConfig.modelProvider === 'ollama'           ? (aiConfig.ollama?.model           || 'ollama') :
+            (aiConfig.modelName || 'gemini');
         const consumerContextTokens = aiConfig.openAiCompatible?.contextLimitTokens || 32768;
         const consumerSafeTokens    = aiConfig.openAiCompatible?.safeProcessingLimitTokens;
         const guardrailed           = await invokeWithGuardrail({

--- a/ai/services/memory-core/TextEmbeddingService.mjs
+++ b/ai/services/memory-core/TextEmbeddingService.mjs
@@ -193,7 +193,7 @@ class TextEmbeddingService extends Base {
             const provider = this.#getOllamaProvider();
             const result   = await provider.embed(text);
             return result.embeddings?.[0];
-        } else {
+        } else if (explicitProvider === 'gemini') {
             const geminiKey = process.env.GEMINI_API_KEY;
             if (!geminiKey) {
                  throw new Error('Semantic search unavailable: GEMINI_API_KEY is missing.');
@@ -203,6 +203,12 @@ class TextEmbeddingService extends Base {
             }
             const result = await this.embeddingModel.embedContent(text);
             return result.embedding.values;
+        } else {
+            // #11965 Sub-2 cycle-2: explicit unsupported-provider rejection. Pre-AC1
+            // fallthrough quietly routed any unknown name into the Gemini path; that
+            // silent-fallback was speculative-support. Fail loudly with the expected
+            // provider set so operators see misconfiguration immediately.
+            throw new Error(`TextEmbeddingService: unsupported embedding provider '${explicitProvider}'. Expected one of: 'gemini', 'openAiCompatible', 'ollama'.`);
         }
     }
 
@@ -225,7 +231,7 @@ class TextEmbeddingService extends Base {
             const provider = this.#getOllamaProvider();
             const result   = await provider.embed(texts);
             return result.embeddings || [];
-        } else {
+        } else if (explicitProvider === 'gemini') {
             const geminiKey = process.env.GEMINI_API_KEY;
             if (!geminiKey) {
                  throw new Error('Semantic search unavailable: GEMINI_API_KEY is missing.');
@@ -237,6 +243,9 @@ class TextEmbeddingService extends Base {
             const requests = texts.map(text => ({model: aiConfig.embeddingModel, content: {parts: [{text}]}}));
             const result = await this.embeddingModel.batchEmbedContents({ requests });
             return result.embeddings.map(e => e.values);
+        } else {
+            // #11965 Sub-2 cycle-2: explicit unsupported-provider rejection (matches embedText).
+            throw new Error(`TextEmbeddingService: unsupported embedding provider '${explicitProvider}'. Expected one of: 'gemini', 'openAiCompatible', 'ollama'.`);
         }
     }
 }

--- a/ai/services/memory-core/TextEmbeddingService.mjs
+++ b/ai/services/memory-core/TextEmbeddingService.mjs
@@ -2,6 +2,7 @@ import {GoogleGenerativeAI} from '@google/generative-ai';
 import aiConfig             from '../../mcp/server/memory-core/config.mjs';
 import Base                 from '../../../src/core/Base.mjs';
 import logger               from '../../mcp/server/memory-core/logger.mjs';
+import OllamaProvider       from '../../provider/Ollama.mjs';
 
 /**
  * Determines whether TextEmbeddingService needs a Gemini embedding client for the active provider.
@@ -42,7 +43,18 @@ class TextEmbeddingService extends Base {
          * @protected
          * @reactive
          */
-        embeddingModel_: null
+        embeddingModel_: null,
+        /**
+         * Lazy-instantiated `Neo.ai.provider.Ollama` instance used by the native
+         * Ollama embedding-dispatch path (#11965 Sub-2 of #10103). Created on first
+         * `embedText`/`embedTexts` call with `explicitProvider === 'ollama'`. Tests
+         * inject a fake by setting this directly via the singleton, bypassing the
+         * lazy-init path.
+         * @member {Object|null} ollamaProvider_=null
+         * @protected
+         * @reactive
+         */
+        ollamaProvider_: null
     }
 
     /**
@@ -138,6 +150,30 @@ class TextEmbeddingService extends Base {
     }
 
     /**
+     * @summary Lazy-instantiates or returns the cached native Ollama provider client.
+     *
+     * Reads host + embeddingModel from `aiConfig.ollama`. Caches the instance on the
+     * singleton's reactive `ollamaProvider_` slot. Test seam: tests can set
+     * `TextEmbeddingService.ollamaProvider` directly with a fake to bypass real-host
+     * instantiation.
+     *
+     * @returns {OllamaProvider}
+     * @protected
+     */
+    #getOllamaProvider() {
+        if (this.ollamaProvider) return this.ollamaProvider;
+
+        const config = aiConfig.ollama || {};
+        const provider = Neo.create(OllamaProvider, {
+            host          : config.host           || 'http://127.0.0.1:11434',
+            modelName     : config.model          || 'gemma4',
+            embeddingModel: config.embeddingModel || null
+        });
+        this.ollamaProvider = provider;
+        return provider;
+    }
+
+    /**
      * Creates an embedding vector for the provided text.
      * @param {String} text The text to embed.
      * @param {String} explicitProvider The embedding provider to use.
@@ -150,6 +186,13 @@ class TextEmbeddingService extends Base {
             const { unloadRetryCount = 3 } = aiConfig.openAiCompatible;
             const result = await this.#postOpenAiCompatible(text, unloadRetryCount);
             return result.data?.[0]?.embedding;
+        } else if (explicitProvider === 'ollama') {
+            // #11965 Sub-2: native Ollama embedding dispatch via Neo.ai.provider.Ollama.
+            // Single-input call returns shape `{embeddings: [[...]]}`; we project the
+            // single inner array since this method is the per-text variant.
+            const provider = this.#getOllamaProvider();
+            const result   = await provider.embed(text);
+            return result.embeddings?.[0];
         } else {
             const geminiKey = process.env.GEMINI_API_KEY;
             if (!geminiKey) {
@@ -176,6 +219,12 @@ class TextEmbeddingService extends Base {
             const { unloadRetryCount = 3 } = aiConfig.openAiCompatible;
             const result = await this.#postOpenAiCompatible(texts, unloadRetryCount);
             return result.data.sort((a, b) => a.index - b.index).map(d => d.embedding);
+        } else if (explicitProvider === 'ollama') {
+            // #11965 Sub-2: native Ollama batch embedding dispatch. Ollama's /api/embed
+            // accepts array-of-strings natively + returns parallel embeddings array.
+            const provider = this.#getOllamaProvider();
+            const result   = await provider.embed(texts);
+            return result.embeddings || [];
         } else {
             const geminiKey = process.env.GEMINI_API_KEY;
             if (!geminiKey) {

--- a/test/playwright/unit/ai/services/graph/SemanticGraphExtractor.spec.mjs
+++ b/test/playwright/unit/ai/services/graph/SemanticGraphExtractor.spec.mjs
@@ -45,6 +45,14 @@ test.describe('Neo.ai.daemons.services.SemanticGraphExtractor', () => {
         aiConfig.lazyEdgesQueuePath   = path.join(tmpDir, `lazy-edges-${process.pid}-${Date.now()}.jsonl`);
         aiConfig.autoIngestFileSystem = false;
 
+        // #11965 Sub-2 cycle-3: graph services now dispatch provider via
+        // aiConfig.modelProvider through buildGraphProvider. Memory Core's
+        // default modelProvider is 'gemini' which is out of Sub-2 graph scope
+        // (gemini-graph dispatch deferred to Sub-3 / follow-up). This test
+        // stubs OpenAiCompatible.prototype.generate, so force the dispatch
+        // path to 'openAiCompatible'.
+        aiConfig.modelProvider = 'openAiCompatible';
+
         GraphService           = (await import('../../../../../../ai/services/memory-core/GraphService.mjs')).default;
         SemanticGraphExtractor = (await import('../../../../../../ai/services/graph/SemanticGraphExtractor.mjs')).default;
         SystemLifecycleService = (await import('../../../../../../ai/services/memory-core/lifecycle/SystemLifecycleService.mjs')).default;

--- a/test/playwright/unit/ai/services/graph/providerDispatch.spec.mjs
+++ b/test/playwright/unit/ai/services/graph/providerDispatch.spec.mjs
@@ -1,0 +1,144 @@
+import {setup} from '../../../../setup.mjs';
+
+const appName = 'GraphProviderDispatchTest';
+
+setup({
+    neoConfig: {
+        unitTestMode: true
+    },
+    appConfig: {
+        name             : appName,
+        isMounted        : () => true,
+        vnodeInitialising: false
+    }
+});
+
+import {test, expect} from '@playwright/test';
+import Neo            from '../../../../../../src/Neo.mjs';
+import * as core      from '../../../../../../src/core/_export.mjs';
+
+/**
+ * @summary Focused unit coverage for `buildGraphProvider` shared dispatch
+ * helper used by SemanticGraphExtractor, GoldenPathSynthesizer, and
+ * TopologyInferenceEngine. Closes #11965 AC5 graph-mutator provider
+ * reachability — these services previously hardwired `OpenAiCompatible`,
+ * breaking cloud deployments configured for native Ollama.
+ *
+ * Tests verify selector boundaries + provider config pass-through via
+ * injected factories. No real Ollama / OpenAI-compatible endpoints reached.
+ *
+ * @see ai/services/graph/providerDispatch.mjs
+ * @see https://github.com/neomjs/neo/issues/11965
+ */
+test.describe('buildGraphProvider (#11965 Sub-2 cycle-3)', () => {
+    let buildGraphProvider;
+
+    test.beforeAll(async () => {
+        const mod = await import('../../../../../../ai/services/graph/providerDispatch.mjs');
+        buildGraphProvider = mod.buildGraphProvider;
+    });
+
+    test('throws for unsupported modelProvider (no silent fallback)', () => {
+        expect(() => buildGraphProvider({
+            modelProvider: 'bogus-provider'
+        })).toThrow(/buildGraphProvider: unsupported modelProvider 'bogus-provider'.*Expected one of.*ollama.*openAiCompatible/);
+
+        expect(() => buildGraphProvider({
+            modelProvider: 'gemini' // gemini is not supported for graph dispatch (Sub-3 scope)
+        })).toThrow(/buildGraphProvider: unsupported modelProvider 'gemini'/);
+    });
+
+    test('modelProvider=ollama instantiates native Ollama provider with config', () => {
+        const factoryCalls = [];
+        const fakeProvider = {generate: async () => ({content: 'ollama-result'})};
+
+        const provider = buildGraphProvider({
+            modelProvider        : 'ollama',
+            ollamaConfig         : {host: 'http://ollama.test', model: 'gemma4', embeddingModel: 'qwen-embed'},
+            ollamaProviderFactory: (cfg) => {
+                factoryCalls.push(cfg);
+                return fakeProvider;
+            }
+        });
+
+        expect(provider).toBe(fakeProvider);
+        expect(factoryCalls).toEqual([{
+            modelName     : 'gemma4',
+            host          : 'http://ollama.test',
+            embeddingModel: 'qwen-embed'
+        }]);
+    });
+
+    test('modelProvider=ollama defaults embeddingModel to null when not configured', () => {
+        const factoryCalls = [];
+        buildGraphProvider({
+            modelProvider        : 'ollama',
+            ollamaConfig         : {host: 'http://ollama.test', model: 'gemma4'}, // no embeddingModel
+            ollamaProviderFactory: (cfg) => { factoryCalls.push(cfg); return {generate: async () => ({})}; }
+        });
+
+        expect(factoryCalls[0].embeddingModel).toBe(null);
+    });
+
+    test('modelProvider=openAiCompatible instantiates OpenAi-compatible provider with config', () => {
+        const factoryCalls = [];
+        const fakeProvider = {generate: async () => ({content: 'oai-result'})};
+
+        const provider = buildGraphProvider({
+            modelProvider                  : 'openAiCompatible',
+            openAiCompatibleConfig         : {host: 'http://oai.test', model: 'gemma-4-31b', apiKey: 'sk-test'},
+            openAiCompatibleProviderFactory: (cfg) => {
+                factoryCalls.push(cfg);
+                return fakeProvider;
+            }
+        });
+
+        expect(provider).toBe(fakeProvider);
+        expect(factoryCalls).toEqual([{
+            modelName: 'gemma-4-31b',
+            host     : 'http://oai.test',
+            apiKey   : 'sk-test'
+        }]);
+    });
+
+    test('modelProvider=openAiCompatible defaults apiKey to empty when not configured', () => {
+        const factoryCalls = [];
+        buildGraphProvider({
+            modelProvider                  : 'openAiCompatible',
+            openAiCompatibleConfig         : {host: 'http://oai.test', model: 'oai-model'}, // no apiKey
+            openAiCompatibleProviderFactory: (cfg) => { factoryCalls.push(cfg); return {generate: async () => ({})}; }
+        });
+
+        expect(factoryCalls[0].apiKey).toBe('');
+    });
+
+    test('returned provider exposes generate() method (Ollama envelope shape)', async () => {
+        const provider = buildGraphProvider({
+            modelProvider        : 'ollama',
+            ollamaConfig         : {host: 'http://ollama.test', model: 'gemma4'},
+            ollamaProviderFactory: () => ({
+                async generate(input) {
+                    return {content: 'ollama-generated', raw: {message: {content: 'ollama-generated'}}};
+                }
+            })
+        });
+
+        const result = await provider.generate('hello world');
+        expect(result.content).toBe('ollama-generated');
+    });
+
+    test('returned provider exposes generate() method (OpenAiCompatible envelope shape)', async () => {
+        const provider = buildGraphProvider({
+            modelProvider                  : 'openAiCompatible',
+            openAiCompatibleConfig         : {host: 'http://oai.test', model: 'oai-model'},
+            openAiCompatibleProviderFactory: () => ({
+                async generate(input) {
+                    return {content: 'oai-generated'};
+                }
+            })
+        });
+
+        const result = await provider.generate('hello world');
+        expect(result.content).toBe('oai-generated');
+    });
+});

--- a/test/playwright/unit/ai/services/memory-core/SessionService.buildChatModel.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/SessionService.buildChatModel.spec.mjs
@@ -1,0 +1,165 @@
+import {setup} from '../../../../setup.mjs';
+
+const appName = 'SessionServiceBuildChatModelTest';
+
+setup({
+    neoConfig: {
+        unitTestMode: true
+    },
+    appConfig: {
+        name             : appName,
+        isMounted        : () => true,
+        vnodeInitialising: false
+    }
+});
+
+import {test, expect} from '@playwright/test';
+import Neo            from '../../../../../../src/Neo.mjs';
+import * as core      from '../../../../../../src/core/_export.mjs';
+
+/**
+ * @summary Focused unit coverage for `buildChatModel` extracted from `SessionService.construct()`.
+ *
+ * Tests verify selector boundaries + envelope shape for `modelProvider`
+ * values. Provider factories are injected so tests never hit real
+ * Ollama / OpenAI-compatible endpoints. Filed per @neo-gpt cycle-1 review
+ * of PR #11966 (Sub-2 of #10103, native Ollama wire-up).
+ *
+ * @see ai/services/memory-core/SessionService.mjs#buildChatModel
+ * @see https://github.com/neomjs/neo/issues/11965
+ */
+test.describe('SessionService.buildChatModel (#11965 Sub-2)', () => {
+    let buildChatModel;
+
+    test.beforeAll(async () => {
+        const mod = await import('../../../../../../ai/services/memory-core/SessionService.mjs');
+        buildChatModel = mod.buildChatModel;
+    });
+
+    test('throws for unsupported modelProvider (no silent Gemini fallthrough)', () => {
+        expect(() => buildChatModel({
+            modelProvider: 'bogus-provider'
+        })).toThrow(/unsupported modelProvider 'bogus-provider'.*Expected one of.*gemini.*openAiCompatible.*ollama/);
+
+        expect(() => buildChatModel({
+            modelProvider: 'mystery'
+        })).toThrow(/unsupported modelProvider 'mystery'/);
+    });
+
+    test('modelProvider=ollama returns generateContent wrapping native Ollama provider', async () => {
+        const captured = [];
+        const fakeOllama = {
+            host         : 'fake://injected',
+            modelName    : 'fake-injected',
+            async generate(promptText) {
+                captured.push({promptText, host: this.host, modelName: this.modelName});
+                return {content: 'fake-content-for: ' + promptText, raw: {message: {content: 'fake-content-for: ' + promptText}}};
+            }
+        };
+
+        const model = buildChatModel({
+            modelProvider          : 'ollama',
+            ollamaConfig           : {host: 'http://ollama.test', model: 'test-gemma', embeddingModel: null},
+            ollamaProviderFactory  : (cfg) => {
+                fakeOllama.host      = cfg.host;
+                fakeOllama.modelName = cfg.modelName;
+                return fakeOllama;
+            }
+        });
+
+        expect(model).toBeTruthy();
+        expect(typeof model.generateContent).toBe('function');
+
+        const response = await model.generateContent('hello world');
+
+        // Envelope shape: Gemini-compatible {response: {text()}}.
+        expect(typeof response.response.text).toBe('function');
+        expect(response.response.text()).toBe('fake-content-for: hello world');
+
+        // Provider received the host/model from injected config.
+        expect(captured).toHaveLength(1);
+        expect(captured[0]).toEqual({
+            promptText: 'hello world',
+            host      : 'http://ollama.test',
+            modelName : 'test-gemma'
+        });
+    });
+
+    test('modelProvider=ollama refreshes provider host/model per invocation', async () => {
+        const captured = [];
+        const fakeOllama = {
+            host     : null,
+            modelName: null,
+            async generate(promptText) {
+                captured.push({promptText, host: this.host, modelName: this.modelName});
+                return {content: 'r:' + promptText};
+            }
+        };
+
+        // Pass a mutable ollamaConfig ref so we can change it between invocations.
+        const ollamaConfig = {host: 'http://v1.test', model: 'model-v1'};
+        const model = buildChatModel({
+            modelProvider         : 'ollama',
+            ollamaConfig,
+            ollamaProviderFactory : () => fakeOllama
+        });
+
+        await model.generateContent('first');
+        ollamaConfig.host  = 'http://v2.test';
+        ollamaConfig.model = 'model-v2';
+        await model.generateContent('second');
+
+        expect(captured).toEqual([
+            {promptText: 'first',  host: 'http://v1.test', modelName: 'model-v1'},
+            {promptText: 'second', host: 'http://v2.test', modelName: 'model-v2'}
+        ]);
+    });
+
+    test('modelProvider=openAiCompatible returns generateContent wrapping OpenAi-compatible provider', async () => {
+        const captured = [];
+        const fakeProvider = {
+            host     : null,
+            modelName: null,
+            apiKey   : null,
+            async generate(promptText) {
+                captured.push({promptText, host: this.host, modelName: this.modelName, apiKey: this.apiKey});
+                return {content: 'oai:' + promptText};
+            }
+        };
+
+        const model = buildChatModel({
+            modelProvider                  : 'openAiCompatible',
+            openAiCompatibleConfig         : {host: 'http://oai.test', apiKey: 'sk-test', model: 'oai-model'},
+            openAiCompatibleProviderFactory: () => fakeProvider
+        });
+
+        expect(model).toBeTruthy();
+        const response = await model.generateContent('hello');
+        expect(response.response.text()).toBe('oai:hello');
+        expect(captured[0]).toMatchObject({host: 'http://oai.test', modelName: 'oai-model', apiKey: 'sk-test'});
+    });
+
+    test('modelProvider=gemini returns null when geminiApiKey is missing', () => {
+        const model = buildChatModel({
+            modelProvider: 'gemini',
+            geminiApiKey : null
+        });
+        expect(model).toBe(null);
+    });
+
+    test('modelProvider=gemini delegates to geminiClientFactory when key present', () => {
+        const fakeGemini = {generateContent: async () => ({response: {text: () => 'gemini-mock'}})};
+        const factoryCalls = [];
+        const model = buildChatModel({
+            modelProvider       : 'gemini',
+            geminiApiKey        : 'gem-key',
+            geminiModelName     : 'gemini-pro',
+            geminiClientFactory : (apiKey, modelName) => {
+                factoryCalls.push({apiKey, modelName});
+                return fakeGemini;
+            }
+        });
+        expect(model).toBe(fakeGemini);
+        expect(factoryCalls).toEqual([{apiKey: 'gem-key', modelName: 'gemini-pro'}]);
+    });
+});

--- a/test/playwright/unit/ai/services/memory-core/TextEmbeddingService.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/TextEmbeddingService.spec.mjs
@@ -48,3 +48,89 @@ test.describe('TextEmbeddingService #10804 — shouldInitializeGeminiEmbeddingCl
         })).toBe(false);
     });
 });
+
+test.describe('TextEmbeddingService #11965 Sub-2 — native Ollama dispatch', () => {
+    let TextEmbeddingService;
+
+    test.beforeAll(async () => {
+        const mod = await import('../../../../../../ai/services/memory-core/TextEmbeddingService.mjs');
+        TextEmbeddingService = mod.default;
+    });
+
+    test.afterEach(() => {
+        // Restore singleton ollamaProvider slot — fake injection across tests must not leak.
+        TextEmbeddingService.ollamaProvider = null;
+    });
+
+    test('embedText dispatches to native Ollama provider when explicitProvider=ollama', async () => {
+        const captured  = [];
+        const fakeOllama = {
+            async embed(input) {
+                captured.push({input});
+                return {embeddings: [[0.1, 0.2, 0.3]], raw: {model: 'fake-model'}};
+            }
+        };
+        TextEmbeddingService.ollamaProvider = fakeOllama;
+
+        const result = await TextEmbeddingService.embedText('hello world', 'ollama');
+
+        expect(result).toEqual([0.1, 0.2, 0.3]);
+        expect(captured).toEqual([{input: 'hello world'}]);
+    });
+
+    test('embedTexts dispatches batch to native Ollama provider when explicitProvider=ollama', async () => {
+        const captured  = [];
+        const fakeOllama = {
+            async embed(input) {
+                captured.push({input});
+                return {
+                    embeddings: [
+                        [0.1, 0.2],
+                        [0.3, 0.4],
+                        [0.5, 0.6]
+                    ],
+                    raw: {model: 'fake-model'}
+                };
+            }
+        };
+        TextEmbeddingService.ollamaProvider = fakeOllama;
+
+        const result = await TextEmbeddingService.embedTexts(['a', 'b', 'c'], 'ollama');
+
+        expect(result).toEqual([[0.1, 0.2], [0.3, 0.4], [0.5, 0.6]]);
+        expect(captured).toEqual([{input: ['a', 'b', 'c']}]);
+    });
+
+    test('embedText with explicitProvider=ollama returns empty when provider returns no embeddings', async () => {
+        TextEmbeddingService.ollamaProvider = {
+            async embed() { return {embeddings: [], raw: {}}; }
+        };
+
+        const result = await TextEmbeddingService.embedText('hello', 'ollama');
+        expect(result).toBeUndefined(); // embeddings[0] of empty array
+    });
+
+    test('embedText with explicitProvider=openAiCompatible does NOT dispatch to Ollama', async () => {
+        const ollamaCalls = [];
+        TextEmbeddingService.ollamaProvider = {
+            async embed(input) { ollamaCalls.push(input); return {embeddings: [[9, 9, 9]]}; }
+        };
+
+        // openAiCompatible path tries to hit /v1/embeddings — let it fail; we only assert
+        // that the Ollama fake was NOT called.
+        await TextEmbeddingService.embedText('hello', 'openAiCompatible').catch(() => {});
+        expect(ollamaCalls).toEqual([]);
+    });
+
+    test('embedText with explicitProvider=gemini does NOT dispatch to Ollama', async () => {
+        const ollamaCalls = [];
+        TextEmbeddingService.ollamaProvider = {
+            async embed(input) { ollamaCalls.push(input); return {embeddings: [[9, 9, 9]]}; }
+        };
+
+        // gemini path checks GEMINI_API_KEY + embeddingModel; without those it throws
+        // — we only assert the Ollama fake wasn't called regardless of throw.
+        await TextEmbeddingService.embedText('hello', 'gemini').catch(() => {});
+        expect(ollamaCalls).toEqual([]);
+    });
+});

--- a/test/playwright/unit/ai/services/memory-core/TextEmbeddingService.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/TextEmbeddingService.spec.mjs
@@ -133,4 +133,20 @@ test.describe('TextEmbeddingService #11965 Sub-2 — native Ollama dispatch', ()
         await TextEmbeddingService.embedText('hello', 'gemini').catch(() => {});
         expect(ollamaCalls).toEqual([]);
     });
+
+    test('embedText throws explicitly for unsupported provider (no silent Gemini fallthrough)', async () => {
+        // #11965 Sub-2 cycle-2 (per @neo-gpt review): pre-cycle-2, any unknown
+        // explicitProvider value fell through to the Gemini branch. That silent-fallback
+        // masked misconfiguration. Now an unsupported value throws with the expected set
+        // named in the message.
+        await expect(TextEmbeddingService.embedText('hello', 'bogus-provider')).rejects.toThrow(
+            /unsupported embedding provider 'bogus-provider'.*Expected one of.*gemini.*openAiCompatible.*ollama/
+        );
+    });
+
+    test('embedTexts throws explicitly for unsupported provider (no silent Gemini fallthrough)', async () => {
+        await expect(TextEmbeddingService.embedTexts(['a', 'b'], 'mystery-provider')).rejects.toThrow(
+            /unsupported embedding provider 'mystery-provider'.*Expected one of.*gemini.*openAiCompatible.*ollama/
+        );
+    });
 });


### PR DESCRIPTION
Authored by Claude Opus 4.7 (Claude Code). Session continuation from cloud-deployment-trial sprint.

FAIR-band: in-band [16/30] — operator-direction (focus on multi-user cloud deployment; #11961-graduated Sub-2). Live verifier (per @neo-gpt cycle-1): GPT 14 / Claude 16 over last 30 merged PRs.

Evidence: L1 (38/38 PASS — 9 TextEmbeddingService dispatch + selector-boundary tests + 6 SessionService.buildChatModel tests + 7 new buildGraphProvider selector-boundary + factory-pass-through tests + 4 SemanticGraphExtractor regression tests + 4 GoldenPathSynthesizer tests + 8 LazyEdgeDrainer tests). All three #11965 Contract Ledger rows (chat + embedding + graph-mutator) now have shipped runtime coverage.

Closes #11965

## Summary

Sub-2 of #10103 (graduated from Discussion #11961). Wires native Ollama runtime dispatch across the three #11965 Contract Ledger surfaces — chat (SessionService), embeddings (TextEmbeddingService), and graph generation (SemanticGraphExtractor / GoldenPathSynthesizer / TopologyInferenceEngine). Adds the missing `embed()` method to `Neo.ai.provider.Ollama` since the provider class existed but was chat-only. Cycle-3 closes the graph-mutator provider-reachability AC5 flagged by GPT's cycle-2 review.

Per the operator client-need signal that flipped OQ2 disposition during graduation (cloud-deployment clients prefer Ollama; no Mac OS in cloud rules out MLX; graph processing must work), native Ollama is **ACTIVE wire-up target** across chat + embeddings + graph. OpenAI-compat-with-Ollama remains documented common-subset fallback.

## Changes

### Stage 1: `Neo.ai.provider.Ollama.embed()` method ([`ai/provider/Ollama.mjs`](ai/provider/Ollama.mjs))

The provider class existed with `generate()` (chat) + `stream()` (streaming chat) but had **no embeddings method**. Sub-2's first task was adding it.

- New `embed(input, options)` method calls Ollama's native `/api/embed` endpoint
- Accepts single string OR array-of-strings (Ollama native API supports both)
- Returns `{embeddings: Number[][], raw: Object}` — always 2D array for caller uniformity
- New `embeddingModel` config slot (default `null` → falls back to `modelName`)
- Same native `http(s).request` shape as existing `generate()` method (1h timeout)

### Stage 2: TextEmbeddingService runtime dispatch ([`ai/services/memory-core/TextEmbeddingService.mjs`](ai/services/memory-core/TextEmbeddingService.mjs))

- New private `#getOllamaProvider()` lazy-instantiates + caches a native Ollama provider on the singleton's reactive `ollamaProvider_` slot
- `embedText('text', 'ollama')` → `provider.embed(text)` → projects single embedding from Ollama's always-2D response
- `embedTexts(['t1', 't2'], 'ollama')` → `provider.embed([...])` → returns full embeddings array directly (Ollama's batch shape matches consumer expectation)
- Reads `host` / `model` / `embeddingModel` from `aiConfig.ollama` block
- **Cycle-2**: explicit `case 'gemini':` branch + explicit throw for unsupported provider names. Closes GPT's cycle-1 RA1 — `embedText('hi', 'bogus')` no longer silently falls through to the Gemini path; it throws `unsupported embedding provider 'bogus'. Expected one of: 'gemini', 'openAiCompatible', 'ollama'.`
- Test seam: tests can set `TextEmbeddingService.ollamaProvider` directly to inject a fake, bypassing the lazy-init path

### Stage 3: SessionService chat dispatch ([`ai/services/memory-core/SessionService.mjs`](ai/services/memory-core/SessionService.mjs))

- New `else if (aiConfig.modelProvider === 'ollama')` branch in `construct()` between `openAiCompatible` and `gemini` paths
- Creates `Neo.ai.provider.Ollama` instance with operator-configured `host` / `model` / `embeddingModel` (defaults match the OllamaProvider class)
- Exposes the Gemini-shaped `{response: {text: () => content}}` envelope via `this.model.generateContent` shim — keeps downstream consumers (`summarizeSession`, `invokeWithGuardrail`) provider-agnostic
- Per-request config refresh matches openAiCompatible-path semantic (runtime config mutation by tests / embedded operators still applies)
- `consumerModel` naming logic (line 472) extended to surface `aiConfig.ollama.model` for guardrail/log identification — pure ternary expansion
- **Cycle-2**: extracted exported `buildChatModel({modelProvider, openAiCompatibleConfig, ollamaConfig, geminiApiKey, geminiModelName, ollamaProviderFactory, openAiCompatibleProviderFactory, geminiClientFactory})` from `construct()`. Returns the Gemini-shaped `{generateContent}` shim for ollama/openAiCompatible, `null` for gemini-without-key, throws explicitly for unsupported `modelProvider`. Closes GPT's cycle-1 RA2 — selector boundaries are now unit-tested with injected provider factories, no longer relying on structural-symmetry argument.

### Stage 4: Graph-generation provider dispatch ([`ai/services/graph/providerDispatch.mjs`](ai/services/graph/providerDispatch.mjs) NEW + 3 graph services)

Closes GPT's cycle-2 follow-up RA — #11965 AC5 graph-mutator provider reachability.

**Before**: `SemanticGraphExtractor.mjs` (2 callsites at lines 96 + 351), `GoldenPathSynthesizer.mjs` (1 callsite at line 283), and `TopologyInferenceEngine.mjs` (1 callsite at line 57) all directly instantiated `Neo.create(OpenAiCompatible, {...})`. Cloud deployments configured for native Ollama would still see graph generation hit OpenAI-compatible endpoints — speculative-support pattern.

**After**: shared `buildGraphProvider({modelProvider, ollamaConfig, openAiCompatibleConfig, ollamaProviderFactory, openAiCompatibleProviderFactory})` helper in [`ai/services/graph/providerDispatch.mjs`](ai/services/graph/providerDispatch.mjs):
- Pure function (mirrors `SessionService.buildChatModel` shape) with injectable provider factories so tests verify selector behavior without hitting real endpoints
- Dispatches based on `aiConfig.modelProvider`; supports `'ollama'` and `'openAiCompatible'`
- Throws explicitly for unsupported `modelProvider` (no silent fallback)
- All 4 graph-service callsites migrated; `SemanticGraphExtractor.consumerModel` (used for `invokeWithGuardrail` telemetry) now reflects the active modelProvider so friction-aggregation logs attribute work to the right provider family

**Gemini graph dispatch deferred**: out of Sub-2 scope. Gemini's API shape (`genAI.getGenerativeModel({model}).generateContent(...)`) is structurally distinct from the `provider.generate(prompt)` contract used by Ollama / OpenAiCompatible, and graph services would need refactoring beyond simple provider swap. The Memory Core default `modelProvider: 'gemini'` is fine for chat (`SessionService.buildChatModel` returns a Gemini-shaped envelope), but operators wanting graph generation must currently configure `modelProvider: 'ollama'` or `'openAiCompatible'`. Sub-3 (#11964) or a follow-up may extend `buildGraphProvider` to Gemini once the API-shape adapter is in scope.

**Test fixture update**: [`SemanticGraphExtractor.spec.mjs`](test/playwright/unit/ai/services/graph/SemanticGraphExtractor.spec.mjs) now sets `aiConfig.modelProvider = 'openAiCompatible'` explicitly in `beforeAll` because the test stubs `OpenAiCompatible.prototype.generate`. Other existing graph specs unchanged (they don't exercise the dispatch path).

### Stage 5: observational branch status (no code change)

The `case 'ollama':` branches in [`GoldenPathSynthesizer.mjs:38-40`](ai/services/graph/GoldenPathSynthesizer.mjs#L38-L40) (model-name lookup) and [`HealthService.mjs:197-203`](ai/services/memory-core/HealthService.mjs#L197-L203) (health-payload projection) were previously **vestigial half-support** — they read `aiConfig.ollama.*` correctly but the actual runtime dispatch never honored `'ollama'`. With this PR's wiring, those branches become **active observational**: they now report the active provider state correctly, not advertise speculative-support.

## Test Evidence

```bash
npm run test-unit -- \
  test/playwright/unit/ai/services/memory-core/TextEmbeddingService.spec.mjs \
  test/playwright/unit/ai/services/memory-core/SessionService.buildChatModel.spec.mjs \
  test/playwright/unit/ai/services/graph/
```

→ **38/38 PASS** (15 from cycle-2 + 23 across `test/playwright/unit/ai/services/graph/` — 7 cycle-3 buildGraphProvider + 4 SemanticGraphExtractor + 4 GoldenPathSynthesizer + 8 LazyEdgeDrainer):

[`TextEmbeddingService.spec.mjs`](test/playwright/unit/ai/services/memory-core/TextEmbeddingService.spec.mjs) — **9/9** (cycle-2):
1. (existing) `shouldInitializeGeminiEmbeddingClient` returns true only for unified gemini provider
2. (existing) does not consult removed Chroma/SQLite provider selectors
3. `embedText` dispatches to native Ollama when `explicitProvider='ollama'`
4. `embedTexts` dispatches batch to native Ollama when `explicitProvider='ollama'`
5. `embedText` returns empty when Ollama returns empty embeddings array (edge case)
6. `embedText` with `explicitProvider='openAiCompatible'` does NOT dispatch to Ollama
7. `embedText` with `explicitProvider='gemini'` does NOT dispatch to Ollama
8. `embedText` throws explicitly for unsupported provider (no silent Gemini fallthrough)
9. `embedTexts` throws explicitly for unsupported provider (no silent Gemini fallthrough)

[`SessionService.buildChatModel.spec.mjs`](test/playwright/unit/ai/services/memory-core/SessionService.buildChatModel.spec.mjs) — **6/6** (cycle-2):
1. throws for unsupported `modelProvider` (no silent Gemini fallthrough)
2. `modelProvider=ollama` returns `generateContent` wrapping native Ollama provider with correct envelope shape
3. `modelProvider=ollama` refreshes provider host/model per invocation (mutable config ref pattern)
4. `modelProvider=openAiCompatible` returns `generateContent` wrapping OpenAi-compatible provider
5. `modelProvider=gemini` returns `null` when `geminiApiKey` is missing
6. `modelProvider=gemini` delegates to `geminiClientFactory` when key present

[`providerDispatch.spec.mjs`](test/playwright/unit/ai/services/graph/providerDispatch.spec.mjs) — **7/7 (new in cycle-3)**:
1. throws for unsupported `modelProvider` (no silent fallback; covers `'bogus-provider'` + `'gemini'`)
2. `modelProvider=ollama` instantiates native Ollama provider with config pass-through
3. `modelProvider=ollama` defaults `embeddingModel` to `null` when not configured
4. `modelProvider=openAiCompatible` instantiates OpenAi-compatible provider with config pass-through
5. `modelProvider=openAiCompatible` defaults `apiKey` to empty when not configured
6. returned provider exposes `generate()` method (Ollama envelope shape)
7. returned provider exposes `generate()` method (OpenAiCompatible envelope shape)

[`SemanticGraphExtractor.spec.mjs`](test/playwright/unit/ai/services/graph/SemanticGraphExtractor.spec.mjs) — **4/4** (cycle-3 fixture update preserves existing behavior under explicit dispatch):
- provenance edges + lazy back-fill queueing
- concepts extraction from message bodies
- graceful failure handling
- malformed graph node/edge handling

[`GoldenPathSynthesizer.spec.mjs`](test/playwright/unit/ai/services/graph/GoldenPathSynthesizer.spec.mjs) — **4/4** (untouched; regression-clean under new buildGraphProvider seam).

[`LazyEdgeDrainer.spec.mjs`](test/playwright/unit/ai/services/graph/LazyEdgeDrainer.spec.mjs) — **8/8** (untouched; regression-clean).

## Cycle-3 changes (per @neo-gpt cycle-2 follow-up review)

Pushed at `c9689361c`:

1. **AC5 — graph-mutator provider reachability**: extracted `buildGraphProvider` helper; migrated 4 callsites in 3 graph-generation services. Cloud deployments configured for native Ollama now route graph generation through native `/api/chat` endpoints instead of OpenAI-compatible.
2. **Default `modelProvider: 'gemini'` impact**: documented in this body. Gemini graph dispatch is out of Sub-2 scope (API-shape adapter needed); operators wanting graph generation must currently configure `modelProvider: 'ollama'` or `'openAiCompatible'`. Tests opt the legacy fixture into the openAiCompatible path explicitly.
3. **Provider-method test coverage** (RA from cycle-1): `providerDispatch.spec.mjs` covers config pass-through (model/host/apiKey/embeddingModel) at the buildGraphProvider seam. The HTTP request/response shape for `Neo.ai.provider.Ollama.embed()` itself is structurally inspected; end-to-end HTTP shape remains Sub-3 scope per the explicit ticket boundary in #11964.

## Cycle-2 changes (per @neo-gpt cycle-1 review at `6bad18a2d`)

Pushed at `8fd46f68e`:

1. **RA1 — explicit unsupported-provider rejection in TextEmbeddingService**: added `case 'gemini':` + `default: throw` in `embedText()` and `embedTexts()`.
2. **RA2 — focused SessionService selector-boundary coverage**: extracted `buildChatModel` with injectable provider factories; 6 new tests.
3. **RA3 — provider HTTP shape coverage**: deferred to Sub-3; Evidence/Deltas narrowed accordingly.
4. **RA4 — FAIR-band correction**: `[17/30]` (stale) → `[16/30]` (in-band per GPT's live verifier).
5. **RA5 — Evidence/Deltas tightening**: structural-symmetry argument removed; replaced with concrete buildChatModel selector-boundary coverage.

## Deltas from ticket

**Gemini graph dispatch deferred** (NOT a content delta on #11965 contract; explicit scope-shape note for reviewer):

- #11965 AC5 ("Dream/REM graph-mutator provider reachability is not hardwired to the wrong provider family") is now satisfied for the `ollama` and `openAiCompatible` families. The Memory Core default `modelProvider: 'gemini'` causes graph services to throw at runtime — this is correct truth-in-code behavior given Gemini's distinct API shape, but operators must configure a graph-supported provider to use the graph services.
- A follow-up ticket may extend `buildGraphProvider` to handle Gemini once the API-shape adapter is in scope. This was not in Sub-2 scope per the explicit ticket boundary (Sub-2 owns runtime provider routing for the `ollama`/`openAiCompatible` axis introduced in #11961 OQ2).

## Post-Merge Validation

- [ ] Operator confirms cloud deployment with `modelProvider: 'ollama'` initializes successfully (`construct()` selects Ollama branch; log line shows native provider init)
- [ ] Operator confirms `embeddingProvider: 'ollama'` produces real vector embeddings via Ollama's `/api/embed` endpoint
- [ ] Operator confirms graph services (Dream/REM pipeline) hit the configured provider's chat endpoint instead of hardwired OpenAI-compatible
- [ ] Operator with `modelProvider: 'gemini'` running graph services receives the explicit throw — file follow-up ticket if Gemini graph dispatch is needed for cloud-deployment-trial timing
- [ ] Sub-3 (#11964) cloud readiness tests will exercise the full chat path end-to-end including dream/REM graph-mutator coverage (per #11961 OQ6 disposition)

## Avoided Traps

- ✓ Did NOT collapse chat + embeddings into one vague `modelProvider` axis — the provider-axis split (`chatProvider`/`embeddingProvider` per #11961 OQ2) is preserved structurally even though full Tier-1 lift happens in Sub-1 (#11963 / #11967)
- ✓ Did NOT add `embed()` method as fallback to chat — Ollama's native `/api/embed` endpoint is the canonical path, separate from `/api/chat`
- ✓ Did NOT replace OpenAiCompatible-with-Ollama fallback — both paths now coexist; operators choose based on feature needs
- ✓ Did NOT introduce a new "Ollama bridge" abstraction — the existing `Neo.ai.provider.Ollama` class was the substrate; just added the missing embed() method
- ✓ **(cycle-2)** Did NOT silently fall through to Gemini path for unsupported provider names — explicit throws at both selectors (TextEmbeddingService + SessionService.buildChatModel) close the selector boundaries
- ✓ **(cycle-3)** Did NOT leave graph services hardwired to OpenAiCompatible — all 4 callsites now dispatch via `buildGraphProvider`; AC5 satisfied
- ✓ **(cycle-3)** Did NOT add speculative Gemini graph dispatch — that requires a distinct API-shape adapter and belongs to follow-up scope, not Sub-2; throwing for `modelProvider: 'gemini'` is truth-in-code

## Authority

#11965 was created by @neo-gpt as Sub-2 of the graduated Discussion #11961 (Agent OS config ownership Epic). Per the operator's 2026-05-25 2-lane split plan, this sub is mine. Self-assigned + impl in same turn per swarm-topology-anchor §AND-discipline.

Companion sub-tickets:
- Sub-1 ([#11963](https://github.com/neomjs/neo/issues/11963)) — Tier-1 config lift (assigned to @neo-gpt; PR [#11967](https://github.com/neomjs/neo/pull/11967) APPROVED by @neo-opus-4-7 cross-family review)
- Sub-3 ([#11964](https://github.com/neomjs/neo/issues/11964)) — Cloud provider readiness tests (unassigned; opens after Sub-1 + Sub-2 land)

Authored by [Claude Opus 4.7] (Claude Code) — Session continuation from cloud-deployment-trial sprint.
