### PR TITLE
feat(ai): map Agent OS config defaults to Tier-1 (#11963)

### DIFF
--- a/ai/config.template.mjs
+++ b/ai/config.template.mjs
@@ -60,6 +60,98 @@ const defaultConfig = {
         trustProxyIdentity: process.env.NEO_AUTH_TRUST_PROXY_IDENTITY === 'true'
     },
     /**
+     * @summary Deployment-wide chat / generation model provider.
+     *
+     * Tier-1 source of truth for model-consuming Agent OS lanes. Memory Core maps
+     * this into its historical `modelProvider` key until runtime provider routing
+     * graduates from #10103 Sub-2. Supported values today: `gemini`,
+     * `openAiCompatible`.
+     * @type {String}
+     */
+    chatProvider: process.env.NEO_MODEL_PROVIDER || 'gemini',
+    /**
+     * @summary Backwards-compatible alias for the active chat provider.
+     *
+     * Existing Memory Core consumers still read `modelProvider`; keep the Tier-1
+     * template aligned with `chatProvider` so Sub-1 can move ownership without
+     * forcing runtime dispatch changes.
+     * @type {String}
+     */
+    modelProvider: process.env.NEO_MODEL_PROVIDER || 'gemini',
+    /**
+     * @summary Deployment-wide embedding provider selector.
+     *
+     * Shared by Memory Core embedding consumers and Knowledge Base ingestion
+     * paths. `NEO_CHROMA_EMBEDDING_PROVIDER` remains readable for the server-local
+     * deprecation window; the Tier-1 default uses the canonical env name.
+     * @type {String}
+     */
+    embeddingProvider: process.env.NEO_EMBEDDING_PROVIDER || process.env.NEO_CHROMA_EMBEDDING_PROVIDER || 'openAiCompatible',
+    /**
+     * @summary Deployment-wide Ollama provider defaults.
+     *
+     * These are configuration defaults only. Runtime dispatch support for native
+     * `ollama` is owned by #10103 Sub-2.
+     * @type {Object}
+     */
+    ollama: {
+        host          : process.env.NEO_OLLAMA_HOST || 'http://127.0.0.1:11434',
+        model         : process.env.NEO_OLLAMA_MODEL || 'gemma4:31b',
+        embeddingModel: process.env.NEO_OLLAMA_EMBEDDING_MODEL || 'qwen3-embedding'
+    },
+    /**
+     * @summary Deployment-wide OpenAI-compatible provider defaults.
+     *
+     * Covers MLX, LM Studio, Ollama's OpenAI-compatible surface, llama.cpp, and
+     * managed OpenAI-compatible endpoints.
+     * @type {Object}
+     */
+    openAiCompatible: {
+        host                    : process.env.NEO_OPENAI_COMPATIBLE_HOST || 'http://127.0.0.1:11434',
+        model                   : process.env.NEO_OPENAI_COMPATIBLE_MODEL || 'gemma-4-31b-it',
+        embeddingModel          : process.env.NEO_OPENAI_COMPATIBLE_EMBEDDING_MODEL || 'text-embedding-qwen3-embedding-8b',
+        apiKey                  : process.env.NEO_OPENAI_COMPATIBLE_API_KEY || '',
+        unloadRetryCount        : Number(process.env.NEO_OPENAI_COMPATIBLE_UNLOAD_RETRY_COUNT) || 3,
+        unloadRetryDelayMs      : Number(process.env.NEO_OPENAI_COMPATIBLE_UNLOAD_RETRY_DELAY_MS) || 500,
+        contextLimitTokens      : Number(process.env.NEO_OPENAI_COMPATIBLE_CONTEXT_LIMIT_TOKENS) || 32768,
+        safeProcessingLimitTokens: Number(process.env.NEO_OPENAI_COMPATIBLE_SAFE_PROCESSING_LIMIT_TOKENS) || undefined
+    },
+    /**
+     * @summary Deployment-wide Gemini model defaults.
+     *
+     * Memory Core still exposes these historical field names for Gemini-backed
+     * summary and embedding paths; Tier-1 owns the default tuple.
+     * @type {String}
+     */
+    modelName: 'gemini-2.5-flash',
+    /**
+     * @summary Deployment-wide Gemini embedding model default.
+     * @type {String}
+     */
+    embeddingModel: 'gemini-embedding-001',
+    /**
+     * @summary Enforced vector dimension across shared vector collections.
+     *
+     * Hard-configured to prevent schema wipes when operators change embedding
+     * providers. Gemini deployments must explicitly pair provider and dimension
+     * overrides.
+     * @type {Number}
+     */
+    vectorDimension: Number(process.env.NEO_VECTOR_DIMENSION) || 4096,
+    /**
+     * @summary Deployment-wide storage engine coordinates.
+     *
+     * `engines.chroma` is the unified Chroma topology from ADR 0003. Collection
+     * names and local persistence directories remain server-local.
+     * @type {Object}
+     */
+    engines: {
+        chroma: {
+            host: process.env.NEO_CHROMA_HOST || process.env.NEO_KB_CHROMA_HOST || 'localhost',
+            port: Number(process.env.NEO_CHROMA_PORT || process.env.NEO_KB_CHROMA_PORT) || 8000
+        }
+    },
+    /**
      * Agent OS maintenance orchestrator configuration.
      * @type {Object}
      */

--- a/ai/mcp/server/knowledge-base/config.template.mjs
+++ b/ai/mcp/server/knowledge-base/config.template.mjs
@@ -1,5 +1,6 @@
 import os              from 'os';
 import path            from 'path';
+import AiConfig        from '../../../config.template.mjs';
 import BaseConfig, { createConfigProxy } from '../shared/BaseConfig.mjs';
 import {fileURLToPath} from 'url';
 import Env from '../../../../src/util/Env.mjs';
@@ -93,13 +94,13 @@ const defaultConfig = {
      * @type {Object}
      */
     auth: {
-        host              : null,
-        port              : 8080,
-        realm             : 'master',
-        issuerUrl         : null,
-        clientId          : null,
-        clientSecret      : '',
-        trustProxyIdentity: false
+        host              : AiConfig.auth.host,
+        port              : AiConfig.auth.port,
+        realm             : AiConfig.auth.realm,
+        issuerUrl         : AiConfig.auth.issuerUrl,
+        clientId          : AiConfig.auth.clientId,
+        clientSecret      : AiConfig.auth.clientSecret,
+        trustProxyIdentity: AiConfig.auth.trustProxyIdentity
     },
     /**
      * A dummy embedding function to satisfy the ChromaDB API when embeddings are provided manually.
@@ -131,7 +132,7 @@ const defaultConfig = {
      * unified Chroma instance for both KB + MC, this points at the shared cloud-hosted Chroma.
      * @type {string}
      */
-    host: 'localhost',
+    host: AiConfig.engines.chroma.host,
     /**
      * The port the ChromaDB server for the knowledge base is listening on.
      *
@@ -139,7 +140,7 @@ const defaultConfig = {
      * fall back to the default with a console warning per the resolver validity contract.
      * @type {number}
      */
-    port: 8000,
+    port: AiConfig.engines.chroma.port,
     /**
      * The local persistence path for the agent knowledge-base server.
      * @type {string}

--- a/ai/mcp/server/memory-core/config.template.mjs
+++ b/ai/mcp/server/memory-core/config.template.mjs
@@ -1,4 +1,5 @@
 import path                              from 'path';
+import AiConfig                          from '../../../config.template.mjs';
 import BaseConfig, {createConfigProxy}   from '../shared/BaseConfig.mjs';
 import {fileURLToPath}                   from 'url';
 import Env                               from '../../../../src/util/Env.mjs';
@@ -111,20 +112,20 @@ const defaultConfig = {
      * @type {Object}
      */
     auth: {
-        host              : null,
-        port              : 8080,
-        realm             : 'master',
-        issuerUrl         : null,
-        clientId          : null,
-        clientSecret      : '',
-        trustProxyIdentity: false
+        host              : AiConfig.auth.host,
+        port              : AiConfig.auth.port,
+        realm             : AiConfig.auth.realm,
+        issuerUrl         : AiConfig.auth.issuerUrl,
+        clientId          : AiConfig.auth.clientId,
+        clientSecret      : AiConfig.auth.clientSecret,
+        trustProxyIdentity: AiConfig.auth.trustProxyIdentity
     },
     /**
      * Explicit override provider for the core LLM Engine (e.g. summarization).
      * Supported values: 'gemini', 'ollama', 'openAiCompatible'
      * @type {String}
      */
-    modelProvider: 'gemini',
+    modelProvider: AiConfig.modelProvider,
     /**
      * Canonical embedding provider for Memory Core and Knowledge Base embedding callsites.
      * Supported values: 'gemini', 'ollama', 'openAiCompatible'
@@ -136,26 +137,26 @@ const defaultConfig = {
      * a warning and feeds this unified selector.
      * @type {String}
      */
-    embeddingProvider: 'openAiCompatible',
+    embeddingProvider: AiConfig.embeddingProvider,
     /**
      * Settings for the Ollama integration
      */
     ollama: {
-        host          : 'http://127.0.0.1:11434',
-        model         : 'gemma4:31b',
-        embeddingModel: 'qwen3-embedding'
+        host          : AiConfig.ollama.host,
+        model         : AiConfig.ollama.model,
+        embeddingModel: AiConfig.ollama.embeddingModel
     },
     /**
      * Settings for the OpenAI-Compatible API integration (e.g., mlx-lm or mlx-openai-server)
      * WARNING: Never hardcode API keys here. Always export them via .env or globally.
      */
     openAiCompatible: {
-        host          : 'http://127.0.0.1:11434',
-        model         : 'gemma-4-31b-it',
-        embeddingModel: 'text-embedding-qwen3-embedding-8b',
-        apiKey        : '',
-        unloadRetryCount: 3,
-        unloadRetryDelayMs: 500,
+        host                    : AiConfig.openAiCompatible.host,
+        model                   : AiConfig.openAiCompatible.model,
+        embeddingModel          : AiConfig.openAiCompatible.embeddingModel,
+        apiKey                  : AiConfig.openAiCompatible.apiKey,
+        unloadRetryCount        : AiConfig.openAiCompatible.unloadRetryCount,
+        unloadRetryDelayMs      : AiConfig.openAiCompatible.unloadRetryDelayMs,
         /**
          * Configured context-window capacity of `model` measured in **tokens**.
          * Token-based per the Discussion #11444 / #11447 V1 graduation contract.
@@ -167,7 +168,7 @@ const defaultConfig = {
          * for Gemma-4-8B-IT, 131072 for Llama-3.1-70B 128K-context variants.
          * @type {number}
          */
-        contextLimitTokens: 32768,
+        contextLimitTokens: AiConfig.openAiCompatible.contextLimitTokens,
         /**
          * Optional safer processing threshold (tokens) below `contextLimitTokens` for
          * the upstream pre-check skip. When the estimated input token count exceeds
@@ -178,24 +179,24 @@ const defaultConfig = {
          * consensus.
          * @type {number|undefined}
          */
-        safeProcessingLimitTokens: undefined
+        safeProcessingLimitTokens: AiConfig.openAiCompatible.safeProcessingLimitTokens
     },
     /**
      * The enforced vector dimension across all SQLite collections.
      * Hard-configured here to prevent catastrophic schema wipes due to dynamic model changes.
      * @type {number}
      */
-    vectorDimension: 4096,
+    vectorDimension: AiConfig.vectorDimension,
     /**
      * The name of the Google Generative AI model for content generation.
      * @type {string}
      */
-    modelName: 'gemini-2.5-flash',
+    modelName: AiConfig.modelName,
     /**
      * The name of the Google Generative AI model for text embeddings.
      * @type {string}
      */
-    embeddingModel: 'gemini-embedding-001',
+    embeddingModel: AiConfig.embeddingModel,
     /**
      * Pagination limit for fetching records during session summarization scans.
      * Controls the batch size for memory and summary retrieval.
@@ -226,8 +227,8 @@ const defaultConfig = {
             dataDir: path.resolve(cwd, '.neo-ai-data/chroma/memory-core'),
             // #10808: prefer operator-facing `NEO_CHROMA_HOST/PORT` (cookbook Section 5);
             // `NEO_KB_CHROMA_HOST/PORT` remains readable for backwards-compat during deprecation window.
-            host   : 'localhost',
-            port   : 8000
+            host   : AiConfig.engines.chroma.host,
+            port   : AiConfig.engines.chroma.port
         }
     },
     /**

--- a/test/playwright/unit/ai/config.template.spec.mjs
+++ b/test/playwright/unit/ai/config.template.spec.mjs
@@ -23,6 +23,35 @@ test.describe('Tier 1 Config Immutability', () => {
         expect(Config.orchestrator.devSyncRoots).toEqual([]);
     });
 
+    test('ships Tier-1 provider and unified Chroma defaults', async () => {
+        expect(Config.chatProvider).toBe(process.env.NEO_MODEL_PROVIDER || 'gemini');
+        expect(Config.modelProvider).toBe(Config.chatProvider);
+        expect(Config.embeddingProvider).toBe(process.env.NEO_EMBEDDING_PROVIDER || process.env.NEO_CHROMA_EMBEDDING_PROVIDER || 'openAiCompatible');
+        expect(Config.vectorDimension).toBe(Number(process.env.NEO_VECTOR_DIMENSION) || 4096);
+        expect(Config.modelName).toBe('gemini-2.5-flash');
+        expect(Config.embeddingModel).toBe('gemini-embedding-001');
+
+        expect(Config.ollama).toMatchObject({
+            host          : process.env.NEO_OLLAMA_HOST || 'http://127.0.0.1:11434',
+            model         : process.env.NEO_OLLAMA_MODEL || 'gemma4:31b',
+            embeddingModel: process.env.NEO_OLLAMA_EMBEDDING_MODEL || 'qwen3-embedding'
+        });
+        expect(Config.openAiCompatible).toMatchObject({
+            host                    : process.env.NEO_OPENAI_COMPATIBLE_HOST || 'http://127.0.0.1:11434',
+            model                   : process.env.NEO_OPENAI_COMPATIBLE_MODEL || 'gemma-4-31b-it',
+            embeddingModel          : process.env.NEO_OPENAI_COMPATIBLE_EMBEDDING_MODEL || 'text-embedding-qwen3-embedding-8b',
+            apiKey                  : process.env.NEO_OPENAI_COMPATIBLE_API_KEY || '',
+            unloadRetryCount        : Number(process.env.NEO_OPENAI_COMPATIBLE_UNLOAD_RETRY_COUNT) || 3,
+            unloadRetryDelayMs      : Number(process.env.NEO_OPENAI_COMPATIBLE_UNLOAD_RETRY_DELAY_MS) || 500,
+            contextLimitTokens      : Number(process.env.NEO_OPENAI_COMPATIBLE_CONTEXT_LIMIT_TOKENS) || 32768,
+            safeProcessingLimitTokens: Number(process.env.NEO_OPENAI_COMPATIBLE_SAFE_PROCESSING_LIMIT_TOKENS) || undefined
+        });
+        expect(Config.engines.chroma).toEqual({
+            host: process.env.NEO_CHROMA_HOST || process.env.NEO_KB_CHROMA_HOST || 'localhost',
+            port: Number(process.env.NEO_CHROMA_PORT || process.env.NEO_KB_CHROMA_PORT) || 8000
+        });
+    });
+
     test('ships top-level deployment and maintenance policy defaults', async () => {
         expect(Config.orchestrator.deploymentMode).toBe('local');
         expect(Config.orchestrator.intervals).toMatchObject({

--- a/test/playwright/unit/ai/mcp/server/knowledge-base/config.template.spec.mjs
+++ b/test/playwright/unit/ai/mcp/server/knowledge-base/config.template.spec.mjs
@@ -1,0 +1,65 @@
+import {test, expect} from '@playwright/test';
+import Neo            from '../../../../../../../src/Neo.mjs';
+import AiConfig       from '../../../../../../../ai/config.template.mjs';
+
+test.describe('Knowledge Base Config Tier-1 defaults (#11963)', () => {
+    let originalEnv;
+    let config;
+
+    test.beforeAll(async () => {
+        originalEnv = {...process.env};
+
+        if (Neo.ai?.mcp?.server?.['knowledge-base']?.Config) {
+            delete Neo.ai.mcp.server['knowledge-base'].Config;
+        }
+        if (Neo.classHierarchyMap?.['Neo.ai.mcp.server.knowledge-base.Config']) {
+            delete Neo.classHierarchyMap['Neo.ai.mcp.server.knowledge-base.Config'];
+        }
+
+        config = (await import('../../../../../../../ai/mcp/server/knowledge-base/config.template.mjs')).default;
+    });
+
+    test.afterAll(() => {
+        if (Neo.ai?.mcp?.server?.['knowledge-base']?.Config) {
+            delete Neo.ai.mcp.server['knowledge-base'].Config;
+        }
+        if (Neo.classHierarchyMap?.['Neo.ai.mcp.server.knowledge-base.Config']) {
+            delete Neo.classHierarchyMap['Neo.ai.mcp.server.knowledge-base.Config'];
+        }
+    });
+
+    test.afterEach(() => {
+        Object.keys(process.env).forEach(key => {
+            if (!(key in originalEnv)) {
+                delete process.env[key];
+            } else {
+                process.env[key] = originalEnv[key];
+            }
+        });
+
+        config.data = Neo.clone(config.defaultConfig, true);
+        config.applyEnv();
+    });
+
+    test('maps deployment-wide Tier-1 auth and unified Chroma defaults', () => {
+        expect(config.auth).toEqual(AiConfig.auth);
+        expect(config.host).toBe(AiConfig.engines.chroma.host);
+        expect(config.port).toBe(AiConfig.engines.chroma.port);
+
+        expect(config.collectionName).toBe('neo-knowledge-base');
+        expect(config.path).toContain('.neo-ai-data/chroma/knowledge-base');
+    });
+
+    test('env overrides remain final after Tier-1 default mapping', () => {
+        process.env.NEO_AUTH_REALM = 'tenant-realm';
+        process.env.NEO_CHROMA_HOST = 'chroma';
+        process.env.NEO_CHROMA_PORT = '8010';
+
+        config.data = Neo.clone(config.defaultConfig, true);
+        config.applyEnv();
+
+        expect(config.auth.realm).toBe('tenant-realm');
+        expect(config.host).toBe('chroma');
+        expect(config.port).toBe(8010);
+    });
+});

--- a/test/playwright/unit/ai/mcp/server/memory-core/config.template.spec.mjs
+++ b/test/playwright/unit/ai/mcp/server/memory-core/config.template.spec.mjs
@@ -1,6 +1,7 @@
 import { test, expect } from '@playwright/test';
 import path from 'path';
 import Neo from '../../../../../../../src/Neo.mjs';
+import AiConfig from '../../../../../../../ai/config.template.mjs';
 
 test.describe('Memory Core Config (#10010)', () => {
     let originalEnv;
@@ -49,6 +50,42 @@ test.describe('Memory Core Config (#10010)', () => {
 
     test('defaultPolicy initializes to legacy', () => {
         expect(config.memorySharing.defaultPolicy).toBe('legacy');
+    });
+
+    test('maps deployment-wide Tier-1 defaults for provider, auth, and storage groups', () => {
+        expect(config.modelProvider).toBe(AiConfig.modelProvider);
+        expect(config.embeddingProvider).toBe(AiConfig.embeddingProvider);
+        expect(config.ollama).toEqual(AiConfig.ollama);
+        expect(config.openAiCompatible).toEqual(AiConfig.openAiCompatible);
+        expect(config.vectorDimension).toBe(AiConfig.vectorDimension);
+        expect(config.modelName).toBe(AiConfig.modelName);
+        expect(config.embeddingModel).toBe(AiConfig.embeddingModel);
+
+        expect(config.auth).toEqual(AiConfig.auth);
+        expect(config.engines.chroma).toMatchObject({
+            host: AiConfig.engines.chroma.host,
+            port: AiConfig.engines.chroma.port
+        });
+        expect(config.engines.chroma.dataDir).toContain('.neo-ai-data/chroma/memory-core');
+    });
+
+    test('env overrides remain final after Tier-1 default mapping', () => {
+        process.env.NEO_MODEL_PROVIDER = 'openAiCompatible';
+        process.env.NEO_EMBEDDING_PROVIDER = 'ollama';
+        process.env.NEO_AUTH_REALM = 'tenant-realm';
+        process.env.NEO_CHROMA_HOST = 'chroma';
+        process.env.NEO_CHROMA_PORT = '8010';
+
+        config.data = Neo.clone(config.defaultConfig, true);
+        config.applyEnv();
+
+        expect(config.modelProvider).toBe('openAiCompatible');
+        expect(config.embeddingProvider).toBe('ollama');
+        expect(config.auth.realm).toBe('tenant-realm');
+        expect(config.engines.chroma).toMatchObject({
+            host: 'chroma',
+            port: 8010
+        });
     });
 
     test('NEO_MEMORY_SHARING_DEFAULT_POLICY env override parses correctly', () => {


### PR DESCRIPTION
Resolves #11963

Authored by GPT-5 (Codex Desktop). Session e5a3acc3-d261-4ebf-96b1-4053ab0eafdf.

FAIR-band: over-target [14/30] — taking this lane despite over-target because the operator explicitly redirected the active lifecycle to #10103 cloud-deployment config graduation/sub work, and #11963 is the already self-assigned Sub-1.

Related: #10103
Discussion: #11961

Maps deployment-wide Agent OS defaults into Tier-1 `ai/config.template.mjs` and has Memory Core / Knowledge Base config templates consume those defaults while preserving server-local config files and env override precedence.

Evidence: L1 (static config-shape + focused unit/import contract checks) -> L1 required (config ownership, mapping, and env-precedence ACs). No residuals.

## Signal Ledger

| Family | Signal | Anchor |
|---|---|---|
| OpenAI / GPT | Authored graduation and closed Discussion #11961 as `[GRADUATED_TO_TICKET: #10103]` | #11961 body |
| Anthropic / Claude | `[GRADUATION_APPROVED]` for #11961 | https://github.com/neomjs/neo/discussions/11961#discussioncomment-17048473 |

## Unresolved Dissent

None known for the Sub-1 config-default mapping.

## Unresolved Liveness

Google/Gemini did not signal on #11961 before graduation. Residual provider-routing/runtime ambiguity is intentionally outside this PR and owned by Sub-2 (#11965); this PR only maps existing defaults and preserves current env names.

## Changed MCP Config Template Keys

- `ai/config.template.mjs`: adds Tier-1 `chatProvider`, `modelProvider`, `embeddingProvider`, `ollama`, `openAiCompatible`, `modelName`, `embeddingModel`, `vectorDimension`, and `engines.chroma`.
- `ai/mcp/server/memory-core/config.template.mjs`: maps auth, provider/model, vector-dimension, and unified Chroma host/port defaults from Tier-1.
- `ai/mcp/server/knowledge-base/config.template.mjs`: maps auth and unified Chroma host/port defaults from Tier-1.

Local `ai/mcp/server/*/config.mjs` files are gitignored and will not auto-update from this PR. Clones that rely on local file defaults should refresh or manually sync the Memory Core / Knowledge Base config shape after merge. Env overrides remain final; live MCP server restart is recommended after local config refresh.

## Deltas from ticket

Kept collection names, listener ports, parser/scoring/batch knobs, tenant source config, and Memory Core's local Chroma `dataDir` server-local. Runtime provider dispatch and native Ollama behavior remain Sub-2 scope.

## Test Evidence

- `npm run test-unit -- test/playwright/unit/ai/config.template.spec.mjs test/playwright/unit/ai/mcp/server/memory-core/config.template.spec.mjs test/playwright/unit/ai/mcp/server/knowledge-base/config.template.spec.mjs` -> 11 passed.
- `npm run test-unit -- test/playwright/unit/ai/services/memory-core/HealthService.spec.mjs test/playwright/unit/ai/services/knowledge-base/ChromaManager.spec.mjs test/playwright/unit/ai/services/memory-core/managers/ChromaManager.spec.mjs` -> 53 passed.
- `git diff --cached --check` -> passed.
- Neo-bootstrapped import smoke for Tier-1, Memory Core, and Knowledge Base config templates -> passed.

## Post-Merge Validation

- [ ] Refresh or manually sync gitignored Memory Core / Knowledge Base `config.mjs` files in active agent clones that need the new Tier-1 default mapping.
- [ ] Restart live MC/KB MCP servers in clones after local config refresh if they should observe the new defaults without relying purely on env overrides.

## Commit

- `be185784e` — `feat(ai): map Agent OS config defaults to Tier-1 (#11963)`
