### PR TITLE
test(agentos): prove cloud provider readiness (#11964)

### DIFF
--- a/ai/deploy/mock-openai-embedding-server.mjs
+++ b/ai/deploy/mock-openai-embedding-server.mjs
@@ -5,6 +5,7 @@ const host       = process.env.NEO_TEST_EMBEDDING_HOST || '0.0.0.0';
 const port       = Number(process.env.NEO_TEST_EMBEDDING_PORT || 11434);
 const dimensions = Number(process.env.NEO_TEST_EMBEDDING_DIMENSIONS || 4096);
 const modelName  = process.env.NEO_TEST_EMBEDDING_MODEL || 'text-embedding-qwen3-embedding-8b';
+const chatModel  = process.env.NEO_TEST_CHAT_MODEL || process.env.NEO_OPENAI_COMPATIBLE_MODEL || 'gemma-4-31b-it';
 
 /**
  * @summary Reads a JSON request body.
@@ -57,39 +58,124 @@ function buildEmbedding(text) {
     });
 }
 
+/**
+ * @summary Extracts a deterministic chat response from an OpenAI-compatible payload.
+ * Extracts a deterministic chat response from an OpenAI-compatible payload.
+ * @param {Object} payload The OpenAI-compatible chat completion payload.
+ * @returns {String} A deterministic response body.
+ */
+function buildChatResponse(payload) {
+    const messages = Array.isArray(payload.messages) ? payload.messages : [];
+    const lastUser = [...messages].reverse().find(message => message.role === 'user');
+    const content  = lastUser?.content || messages.at(-1)?.content || '';
+    const fullPrompt = messages.map(message => message.content).join('\n');
+
+    if (fullPrompt.includes('session_artifact') && fullPrompt.includes('cloud-readiness-graph-sentinel')) {
+        return JSON.stringify({
+            a2a_version: '1.0',
+            agent_id   : 'neo-integration',
+            session_artifact: {
+                graph: {
+                    nodes: [{
+                        id         : 'CONCEPT:cloud-readiness-graph-sentinel',
+                        type       : 'CONCEPT',
+                        name       : 'cloud-readiness-graph-sentinel',
+                        description: 'Deterministic provider-readiness node emitted by the mock OpenAI-compatible server.'
+                    }],
+                    edges: []
+                }
+            }
+        });
+    }
+
+    return JSON.stringify({
+        provider: 'openAiCompatible',
+        model   : payload.model || chatModel,
+        echo    : String(content).slice(0, 240)
+    });
+}
+
+/**
+ * @summary Sends a streaming OpenAI-compatible chat completion response.
+ * Sends a streaming OpenAI-compatible chat completion response.
+ * @param {http.ServerResponse} response The outgoing HTTP response.
+ * @param {String} content The deterministic completion content.
+ * @returns {void}
+ */
+function sendChatStream(response, content) {
+    response.writeHead(200, {
+        'content-type' : 'text/event-stream',
+        'cache-control': 'no-cache',
+        connection     : 'keep-alive'
+    });
+    response.write(`data: ${JSON.stringify({choices: [{delta: {content}}]})}\n\n`);
+    response.write('data: [DONE]\n\n');
+    response.end();
+}
+
 const server = http.createServer(async (request, response) => {
     if (request.method === 'GET' && request.url === '/health') {
-        sendJson(response, 200, {status: 'ok', dimensions, model: modelName});
+        sendJson(response, 200, {status: 'ok', dimensions, embeddingModel: modelName, chatModel});
         return;
     }
 
-    if (request.method !== 'POST' || request.url !== '/v1/embeddings') {
+    if (request.method !== 'POST') {
         sendJson(response, 404, {error: 'Not found'});
         return;
     }
 
     try {
         const payload = await readJson(request);
-        const inputs  = Array.isArray(payload.input) ? payload.input : [payload.input ?? ''];
 
-        sendJson(response, 200, {
-            object: 'list',
-            model : payload.model || modelName,
-            data  : inputs.map((input, index) => ({
-                object   : 'embedding',
-                index,
-                embedding: buildEmbedding(input)
-            })),
-            usage : {
-                prompt_tokens: 0,
-                total_tokens : 0
+        if (request.url === '/v1/embeddings') {
+            const inputs = Array.isArray(payload.input) ? payload.input : [payload.input ?? ''];
+
+            sendJson(response, 200, {
+                object: 'list',
+                model : payload.model || modelName,
+                data  : inputs.map((input, index) => ({
+                    object   : 'embedding',
+                    index,
+                    embedding: buildEmbedding(input)
+                })),
+                usage : {
+                    prompt_tokens: 0,
+                    total_tokens : 0
+                }
+            });
+            return;
+        }
+
+        if (request.url === '/v1/chat/completions') {
+            const content = buildChatResponse(payload);
+
+            if (payload.stream !== false) {
+                sendChatStream(response, content);
+                return;
             }
-        });
+
+            sendJson(response, 200, {
+                id     : 'chatcmpl-neo-integration',
+                object : 'chat.completion',
+                model  : payload.model || chatModel,
+                choices: [{
+                    index  : 0,
+                    message: {
+                        role: 'assistant',
+                        content
+                    },
+                    finish_reason: 'stop'
+                }]
+            });
+            return;
+        }
+
+        sendJson(response, 404, {error: 'Not found'});
     } catch (error) {
         sendJson(response, 400, {error: error.message});
     }
 });
 
 server.listen(port, host, () => {
-    console.log(`[mock-openai-embedding-server] listening on ${host}:${port}`);
+    console.log(`[mock-openai-compatible-server] listening on ${host}:${port}`);
 });

--- a/learn/agentos/cloud-deployment/Day0Tutorial.md
+++ b/learn/agentos/cloud-deployment/Day0Tutorial.md
@@ -53,8 +53,8 @@ Failure signatures:
 ## Milestone 0 - Runnable Remote-MCP Healthcheck Demo
 
 Start the day-0 fixture stack. It uses the same Dockerized topology as the
-integration harness: Chroma, a deterministic OpenAI-compatible embedding mock,
-KB, and MC.
+integration harness: Chroma, a deterministic OpenAI-compatible provider mock
+that serves embeddings plus chat completions, KB, and MC.
 
 ```bash
 export NEO_DAY0_PROJECT="neo-day0"
@@ -119,6 +119,33 @@ Expected output from each command includes:
 
 If Docker is unavailable, the host cannot execute the Docker proof. That is an
 environment blocker, not a Neo deployment result.
+
+The healthcheck proves MCP transport, auth stamping, Chroma connectivity, and
+provider configuration visibility. It is not by itself a full model-readiness
+proof. The integration suite also exercises the same cloud profile through
+`test/playwright/integration/CloudProviderReadiness.integration.spec.mjs`, which
+calls the deployed Memory Core container against explicit mocked provider
+endpoints for:
+
+- OpenAI-compatible `/v1/embeddings`
+- streaming OpenAI-compatible `/v1/chat/completions`
+- the Dream/REM graph-mutator provider dispatch seam
+
+For production, provider/auth/storage ownership starts at the Tier-1
+`ai/config.template.mjs` contract. KB and MC consume that shared provider and
+auth shape, while keeping server-local boundaries for ports, collection names,
+SQLite paths, and MCP transport details. The two supported cloud-provider
+profiles are intentionally distinct:
+
+| Profile | Selectors | Endpoint shape | Use when |
+|---|---|---|---|
+| Native Ollama | `NEO_MODEL_PROVIDER=ollama`, `NEO_EMBEDDING_PROVIDER=ollama` | Ollama `/api/chat` and `/api/embed` | The deployment exposes a real Ollama service and you want native Ollama request semantics. |
+| OpenAI-compatible fallback | `NEO_MODEL_PROVIDER=openAiCompatible`, `NEO_EMBEDDING_PROVIDER=openAiCompatible` | `/v1/chat/completions` and `/v1/embeddings` | The deployment runs MLX, LM Studio, llama.cpp, managed OpenAI-compatible infrastructure, or an Ollama endpoint that intentionally exposes the OpenAI-compatible surface. |
+
+Do not mix the selectors accidentally. A native Ollama deployment should prove
+the native routes; an OpenAI-compatible deployment should prove both `/v1`
+routes. Container health or embeddings-only success is not enough to hand a
+cloud deployment to agents.
 
 For the production profile, the same readiness idea is encoded in
 [`ai/deploy/docker-compose.yml`](../../../ai/deploy/docker-compose.yml): Chroma

--- a/test/playwright/integration/CloudProviderReadiness.integration.spec.mjs
+++ b/test/playwright/integration/CloudProviderReadiness.integration.spec.mjs
@@ -1,0 +1,142 @@
+import {spawnSync}     from 'node:child_process';
+import path            from 'node:path';
+import {fileURLToPath} from 'node:url';
+import {test, expect}  from '@playwright/test';
+import {getReadiness}  from './fixtures/mcpClient.mjs';
+
+const __filename  = fileURLToPath(import.meta.url);
+const __dirname   = path.dirname(__filename);
+const repoRoot    = path.resolve(__dirname, '../../..');
+const composeFile = path.join(repoRoot, 'ai/deploy/docker-compose.test.yml');
+const projectName = process.env.NEO_INTEGRATION_COMPOSE_PROJECT || 'neo-integration-test';
+
+const NEO_BOOTSTRAP = `
+    await import('./src/Neo.mjs');
+    await import('./src/core/_export.mjs');
+`;
+
+/**
+ * @summary Runs Docker Compose against the integration fixture project.
+ * Runs Docker Compose against the integration fixture project.
+ * @param {String[]} args Docker Compose arguments after the compose file selector.
+ * @returns {import('node:child_process').SpawnSyncReturns<String>}
+ */
+function dockerCompose(args) {
+    return spawnSync('docker', ['compose', '-p', projectName, '-f', composeFile, ...args], {
+        cwd      : repoRoot,
+        encoding : 'utf8',
+        maxBuffer: 10 * 1024 * 1024
+    });
+}
+
+/**
+ * @summary Runs an ES module snippet inside the deployed Memory Core container.
+ * Runs an ES module snippet inside the deployed Memory Core container.
+ * @param {String} code The JavaScript source to execute.
+ * @param {Object} [payload] JSON payload exposed as NEO_TEST_PAYLOAD.
+ * @returns {Object}
+ */
+function execMemoryCoreJson(code, payload={}) {
+    const result = dockerCompose([
+        'exec',
+        '-T',
+        '-e',
+        `NEO_TEST_PAYLOAD=${JSON.stringify(payload)}`,
+        'mc-server',
+        'node',
+        '--input-type=module',
+        '-e',
+        code
+    ]);
+    const output = [
+        result.stdout?.trim(),
+        result.stderr?.trim()
+    ].filter(Boolean).join('\n');
+
+    expect(result.status, output || result.error?.message || 'mc-server exec failed').toBe(0);
+
+    const jsonLine = result.stdout.trim().split('\n').filter(Boolean).reverse().find(line => {
+        try {
+            JSON.parse(line);
+            return true;
+        } catch {
+            return false;
+        }
+    });
+    expect(jsonLine, output).toBeTruthy();
+
+    return JSON.parse(jsonLine);
+}
+
+test.describe('Cloud provider readiness integration (#11964)', () => {
+    test('proves embeddings and chat completions under the cloud OpenAI-compatible profile', async () => {
+        const readiness = await getReadiness();
+
+        test.skip(readiness.dockerAvailable === false, `Docker unavailable: ${readiness.reason}`);
+
+        expect(readiness.servicesReady, readiness.reason).toBe(true);
+
+        const result = execMemoryCoreJson(`
+            ${NEO_BOOTSTRAP}
+
+            const {Memory_LifecycleService, Memory_TextEmbeddingService, Memory_SessionService} = await import('./ai/services.mjs');
+            const aiConfig = (await import('./ai/mcp/server/memory-core/config.mjs')).default;
+            const sentinel = 'cloud-readiness-chat-sentinel';
+
+            await Memory_LifecycleService.ready();
+
+            const embedding = await Memory_TextEmbeddingService.embedText(
+                'cloud-readiness-embedding-sentinel',
+                aiConfig.embeddingProvider
+            );
+            const chat = await Memory_SessionService.model.generateContent(sentinel);
+
+            console.log(JSON.stringify({
+                embeddingProvider: aiConfig.embeddingProvider,
+                modelProvider    : aiConfig.modelProvider,
+                embeddingLength  : embedding.length,
+                embeddingFirst   : embedding[0],
+                chatText         : chat.response.text()
+            }));
+        `);
+
+        expect(result.embeddingProvider).toBe('openAiCompatible');
+        expect(result.modelProvider).toBe('openAiCompatible');
+        expect(result.embeddingLength).toBe(4096);
+        expect(typeof result.embeddingFirst).toBe('number');
+        expect(result.chatText).toContain('"provider":"openAiCompatible"');
+        expect(result.chatText).toContain('cloud-readiness-chat-sentinel');
+    });
+
+    test('proves the Dream/REM graph-mutator path uses the deployed provider', async () => {
+        const readiness = await getReadiness();
+
+        test.skip(readiness.dockerAvailable === false, `Docker unavailable: ${readiness.reason}`);
+
+        expect(readiness.servicesReady, readiness.reason).toBe(true);
+
+        const result = execMemoryCoreJson(`
+            ${NEO_BOOTSTRAP}
+
+            const aiConfig = (await import('./ai/mcp/server/memory-core/config.mjs')).default;
+            const {Memory_LifecycleService} = await import('./ai/services.mjs');
+            const SemanticGraphExtractor = (await import('./ai/services/graph/SemanticGraphExtractor.mjs')).default;
+
+            await Memory_LifecycleService.ready();
+
+            const extraction = await SemanticGraphExtractor.executeTriVectorExtraction({
+                id      : 'cloud-readiness-vector-id',
+                meta    : {sessionId: 'cloud-readiness-session'},
+                document: 'Dream REM graph mutation provider proof cloud-readiness-graph-sentinel'
+            });
+
+            console.log(JSON.stringify({
+                modelProvider: aiConfig.modelProvider,
+                nodeIds      : extraction?.session_artifact?.graph?.nodes?.map(node => node.id) || []
+            }));
+        `);
+
+        expect(result.modelProvider).toBe('openAiCompatible');
+        expect(result.nodeIds).toContain('CONCEPT:cloud-readiness-graph-sentinel');
+    });
+});


### PR DESCRIPTION
Resolves #11964

Authored by GPT-5.5 (Codex Desktop). Session 019e5bac-15f3-7830-a59c-72772c757f9a.

FAIR-band: in-band [13/30 — current author count over last 30 merged]

This adds the missing cloud-provider readiness proof for #10103 Sub-3: the Dockerized OpenAI-compatible mock now serves both embeddings and streaming chat completions, a new integration spec probes the deployed Memory Core container for embeddings/chat/dream graph-provider use, and the Day-0 guide now states the real provider/auth/storage ownership contract and the native-Ollama vs OpenAI-compatible fallback distinction.

Evidence: L2 (syntax, staged whitespace, and targeted integration harness invocation; local Docker unavailable) → L3 required (Docker-capable mocked provider readiness for embeddings, chat, and Dream/REM graph mutation). Residual: CI/Post-merge Docker runner must execute `CloudProviderReadiness.integration.spec.mjs` [#11964].

Related: #10103
Discussion: #11961

## Signal Ledger

| Family | Identity | Signal | Anchor |
|---|---|---|---|
| openai | @neo-gpt | `[AUTHOR_SIGNAL]`; #11961 body-cycle-6 graduated #10103 with Sub-3 docs + readiness tests | https://github.com/orgs/neomjs/discussions/11961 |
| anthropic | @neo-opus-4-7 | `[GRADUATION_APPROVED]`; OQ6 readiness is embeddings + chat + dream/REM, not session summarization | https://github.com/neomjs/neo/discussions/11961#discussioncomment-17048473 |
| google | @neo-gemini-3-1-pro | Pending provider-routing review; documented liveness, not a blocker under the quorum threshold | #11961 body `## Unresolved Liveness` |

## Unresolved Dissent

(empty)

## Unresolved Liveness

Google-family provider-routing-axis review remained pending in #11961. The implementation stays within the graduated Sub-3 contract and does not change provider dispatch semantics.

## Slot Rationale

- Modified `learn/agentos/cloud-deployment/Day0Tutorial.md` Milestone 0 provider-readiness guidance. Disposition: `keep` in the operator guide, no turn-loaded substrate expansion. Rating: low trigger-frequency x high failure-severity x medium enforceability. Rationale: the Day-0 cloud handoff is the operator-facing place where "healthcheck is not model readiness" must be visible next to the runnable compose proof.

## Deltas from ticket

- The explicit mocked provider coverage uses the existing OpenAI-compatible fixture service rather than adding a separate native Ollama mock. Native Ollama runtime support remains covered by #11965/#11966; this PR documents the distinction and proves the current cloud fixture profile.
- The Dream/REM readiness path runs through `SemanticGraphExtractor.executeTriVectorExtraction()` inside the deployed Memory Core container, using the provider dispatch path rather than session summarization.

## Test Evidence

- `node --check ai/deploy/mock-openai-embedding-server.mjs` — PASS
- `node --check test/playwright/integration/CloudProviderReadiness.integration.spec.mjs` — PASS
- `git diff --cached --check` — PASS
- `npm run test-integration-unified -- test/playwright/integration/CloudProviderReadiness.integration.spec.mjs` — command executed; local result `2 skipped` because Docker is not installed in this environment.
- `docker info` — local environment blocker confirmed: `zsh:1: command not found: docker`.

## Post-Merge Validation

- [ ] CI or a Docker-capable operator host runs `npm run test-integration-unified -- test/playwright/integration/CloudProviderReadiness.integration.spec.mjs` and observes the two readiness tests execute rather than skip.
- [ ] Day-0 fixture stack health still reports KB/MC healthy after the provider mock change.

## Commits

- `16a5bb697` — `test(agentos): prove cloud provider readiness (#11964)`
