### PR TITLE
chore(ai): clean github workflow sync comments (#11924)

### DIFF
--- a/ai/mcp/server/github-workflow/config.template.mjs
+++ b/ai/mcp/server/github-workflow/config.template.mjs
@@ -174,12 +174,9 @@ const defaultConfig = {
         releaseFilenamePrefix: 'v',
         /**
          * The maximum number of issues to fetch from the GitHub API in a single sync.
-         * Defensive ceiling against runaway pagination on a misconfigured GraphQL pageInfo.
-         * Bumped from 10000 → 20000 in #11451 Cycle 2 to support clean-slate exhaustive
-         * emission per ADR 0004 §3.6 — Neo's repo currently has 8,502 issues + 2,816 PRs
-         * (V-B-A'd via GitHub search 2026-05-16 per @neo-gpt review PRR_kwDODSospM8AAAABAIZAdg;
-         * ~135% defensive headroom on issues). The local droppedLabels filter further trims
-         * the actual processed set.
+         * Defensive ceiling against runaway pagination on a misconfigured GraphQL pageInfo while
+         * leaving enough headroom for clean-slate exhaustive emission under ADR 0004. The local
+         * droppedLabels filter further trims the actual processed set.
          * @type {number}
          */
         maxIssues: 20000,

--- a/ai/services/github-workflow/SyncService.mjs
+++ b/ai/services/github-workflow/SyncService.mjs
@@ -99,7 +99,7 @@ class SyncService extends Base {
      * 7.  Syncs discussions into local Markdown files via `DiscussionSyncer`.
      * 8.  Syncs pull requests into local Markdown files via `PullRequestSyncer`.
      * 9.  Carries `metadata.discussions` + `metadata.pulls` onto `newMetadata` so the
-     *     per-syncer cache populations survive `MetadataManager.save` (#11573).
+     *     per-syncer cache populations survive `MetadataManager.save`.
      * 10. Caches releases in `newMetadata` for next run.
      * 11. Saves the updated, pruned metadata to disk via `MetadataManager`.
      * @returns {Promise<object>} A comprehensive object containing detailed statistics and timing
@@ -136,7 +136,7 @@ class SyncService extends Base {
             newMetadata.pushFailures = newMetadata.pushFailures.filter(failedId => !newMetadata.issues[failedId]);
         }
 
-        // 9. Carry over per-syncer metadata mutations (#11573).
+        // 9. Carry over per-syncer metadata mutations.
         //
         // `newMetadata` is a fresh object constructed by `IssueSyncer.pullFromGitHub` carrying
         // only `{issues, pushFailures, lastSync}`. `DiscussionSyncer.syncDiscussions(metadata)`
@@ -145,10 +145,9 @@ class SyncService extends Base {
         // carry-over, those mutations are dropped at `save(newMetadata)` and the on-disk diff
         // cache stays empty after every sync.
         //
-        // Empirical anchor: operator V-B-A 2026-05-18 caught 0/104 on-disk Discussion markdown
-        // files lacking `closed`/`closedAt` despite #11554 having merged the frontmatter-emit
-        // fix. The compounding factor — alongside stale MCP daemon code paths — was the
-        // metadata.discussions = {} state that prevented any cache reconciliation.
+        // This prevents a fresh metadata object from dropping discussion and PR cache populations
+        // created by their dedicated syncers, which would otherwise leave the on-disk diff cache
+        // empty after every sync.
         newMetadata.discussions = metadata.discussions || {};
         newMetadata.pulls       = metadata.pulls       || {};
 

--- a/ai/services/github-workflow/sync/DiscussionSyncer.mjs
+++ b/ai/services/github-workflow/sync/DiscussionSyncer.mjs
@@ -117,12 +117,10 @@ class DiscussionSyncer extends Base {
                 }
             }
 
-            // Closed-post-latest-release: no release-version applies. Keep in active per Epic
-            // #11187 Phase 6 mental model — archive folders for vN.M.K are created at release-cut
-            // by publish.mjs, never pre-staged. The previous `'legacy'` fallback created the
-            // architectural bug fixed by #11360. #getDiscussionPath falls back to active-flat path
-            // when archivePlan returns no entry (was previously returning null; now consistent
-            // with IssueSyncer/PullRequestSyncer).
+            // Closed-post-latest-release: no release-version applies yet. Keep in active because
+            // archive folders for vN.M.K are created at release cut by publish.mjs, never pre-staged.
+            // `#getDiscussionPath` falls back to the active-flat path when archivePlan returns no entry,
+            // matching IssueSyncer and PullRequestSyncer.
             if (!discussion.closed || !version) {
                 activeItems.push(discussion.number);
                 continue;
@@ -273,14 +271,10 @@ class DiscussionSyncer extends Base {
                 // Gray-matter serialization
                 const content = matter.stringify(body, frontmatter);
 
-                // #11573 integrity gate: empirically catches the failure mode where a stale
-                // MCP daemon code path silently drops frontmatter fields (e.g., #11554 shipped
-                // but old MCP processes kept writing pre-fix content). THROWS on missing keys
-                // per the ticket Contract Ledger ("post-sync integrity assertion fails when a
-                // synced discussion lacks a required frontmatter key"). The existing
-                // per-discussion `try { ... } catch (e)` at the loop boundary (#312-314) catches
-                // the throw, logs the warning, and skips the write — broken-frontmatter files
-                // are NEVER persisted, but the sync run continues with other discussions.
+                // Integrity gate: catches stale daemon code paths that silently drop frontmatter fields.
+                // The per-discussion `try { ... } catch (e)` at the loop boundary catches the throw,
+                // logs the warning, and skips the write, so broken-frontmatter files are never
+                // persisted while the sync run continues with other discussions.
                 const integrity = verifyDiscussionFrontmatter(content);
                 if (!integrity.ok) {
                     throw new Error(`Discussion #${discussion.number} serialized content missing required frontmatter keys: ${integrity.missing.join(', ')}. ADR 0011 / #11573 contract violation — likely stale MCP daemon code path.`);

--- a/ai/services/github-workflow/sync/IssueSyncer.mjs
+++ b/ai/services/github-workflow/sync/IssueSyncer.mjs
@@ -118,12 +118,10 @@ class IssueSyncer extends Base {
     /**
      * @summary Counts `ISSUE_COMMENT` nodes in an issue's exhausted `timelineItems` set.
      *
-     * Post-#10090 pagination-exhaust (`#exhaustTimelineItems`) guarantees `timelineItems.nodes`
-     * contains the complete per-issue event stream — including every surviving comment. This
-     * method returns the authoritative `commentsTotal` for metadata persistence, replacing the
-     * pre-timeline-era `issue.comments.totalCount` scalar (#10110). Single source of truth:
-     * the metadata value is now structurally guaranteed to match what the timeline renders in
-     * the local markdown.
+     * Timeline exhaustion (`#exhaustTimelineItems`) guarantees `timelineItems.nodes` contains the
+     * complete per-issue event stream — including every surviving comment. This method returns the
+     * authoritative `commentsTotal` for metadata persistence, replacing the older scalar count with
+     * the same source used to render local markdown.
      *
      * MUST be called only after `#exhaustTimelineItems(issue)` has run; otherwise the count
      * reflects only the first timeline page and will under-report on long-timeline issues.
@@ -144,14 +142,10 @@ class IssueSyncer extends Base {
      * @private
      */
     #formatIssueMarkdown(issue) {
-        // Defensive null-safety per #11481 (follow-up to #11474 / PR #11476's whack-a-mole gap):
-        // GitHub GraphQL returns null for issue.author when the author has been deleted (Ghost
-        // user), and individual nodes within labels/assignees/subIssues/blockedBy/blocking can
-        // also be null when their referenced entities are deleted. Each deref site uses optional
-        // chaining + filter-out for list entries. Fallback conventions match #11476's: 'Ghost'
-        // for users (matches existing line-186 actor/author convention); '(no title)' for
-        // missing entity titles; filter-out for null list entries (preserves array integrity
-        // without injecting fallback objects into structured fields).
+        // GitHub GraphQL may return null authors or relationship nodes after users, labels, or
+        // linked issues are deleted. Each dereference site uses optional chaining plus stable
+        // fallback conventions: `Ghost` for users, `(no title)` for missing titles, and filtering
+        // for null list entries so structured fields keep only real entities.
         const frontmatter = {
             id                : issue.number,
             title             : issue.title?.replace(lineBreaksRegex, ' ') || '(no title)',
@@ -162,7 +156,7 @@ class IssueSyncer extends Base {
             updatedAt         : issue.updatedAt,
             githubUrl         : issue.url,
             author            : issue.author?.login || 'Ghost',
-            commentsCount     : this.#countTimelineComments(issue), // Derived from the exhausted timeline — #10110
+            commentsCount     : this.#countTimelineComments(issue), // Derived from the exhausted timeline.
             parentIssue       : issue.parent?.number ?? null,
             subIssues         : (issue.subIssues?.nodes || []).map(sub =>
                 sub ? `[${sub.state === 'CLOSED' ? 'x' : ' '}] ${sub.number} ${sub.title?.replace(lineBreaksRegex, ' ') || '(no title)'}` : null
@@ -216,13 +210,9 @@ class IssueSyncer extends Base {
 
         let details = '';
 
-        // Defensive null-safety per #11474: GitHub GraphQL returns null for referenced
-        // entities that have been deleted (users, labels, sub-issues, parent issues,
-        // blocking issues, commits, cross-referenced sources). Each deref site uses
-        // optional chaining + a fallback marker so a single null doesn't abort a sync
-        // run that's already processed thousands of issues. Fallback conventions:
-        // `'Ghost'` for users (matches existing actor/author convention at line 186);
-        // `'(deleted X)'` for named entities; `'?'` for numeric references.
+        // GitHub GraphQL can null out referenced entities after deletion. Optional chaining plus
+        // stable fallback markers keep a single missing user, label, issue, commit, or source from
+        // aborting a long sync run after thousands of issues have already been processed.
         switch (event.__typename) {
             case 'LabeledEvent':
                 details = `added the \`${event.label?.name || '(deleted label)'}\` label`;
@@ -328,9 +318,8 @@ class IssueSyncer extends Base {
         }
 
         for (const issue of fetchedIssues) {
-            // Null-safety per #11481: GitHub may return null label nodes or null name fields
-            // when labels have been deleted. Filter-out null/empty so droppedLabels matching
-            // works on the valid subset.
+            // GitHub may return null label nodes or null name fields after labels are deleted.
+            // Filter null/empty entries so droppedLabels matching operates on the valid subset.
             const labels = issue.labels?.nodes
                 ? issue.labels.nodes.map(l => l?.name?.toLowerCase()).filter(Boolean)
                 : issue.labels?.map(l => l?.name?.toLowerCase() || (typeof l === 'string' ? l.toLowerCase() : null)).filter(Boolean) || [];
@@ -370,13 +359,10 @@ class IssueSyncer extends Base {
                         : issueSyncConfig.versionDirectoryPrefix + issue.milestone.title;
                 } else if (issue.oldVersion && semver.valid(semver.clean(issue.oldVersion)) !== null) {
                     // Use cached path-derived version when present and valid semver. Unchanged closed
-                    // issues seeded from existing serialized metadata may lack milestone data (legacy
-                    // entries pre-#11594 metadata-persistence fix) but still have a known on-disk
-                    // bucket via oldVersion (path-derived at ~L310-317). Skipping closedAt timestamp
-                    // inference here prevents false-positive bucket-shift WARN on unchanged archived
-                    // issues — the path IS the canonical bucket when no milestone data exists.
-                    // Per #11594 AC3 / AC4(b): oldVersion precedence for unchanged closed issues.
-                    // (#11594 Cycle 2 fix per @neo-gpt PR #11607 Cycle 2 review.)
+                    // issues seeded from existing serialized metadata may lack milestone data but still
+                    // have a known on-disk bucket via oldVersion. Skipping closedAt timestamp inference
+                    // here prevents false-positive bucket-shift WARN on unchanged archived issues: the
+                    // path is the canonical bucket when no milestone data exists.
                     version = issue.oldVersion;
                 } else if (issue.closedAt) {
                     const closed = new Date(issue.closedAt);
@@ -395,18 +381,16 @@ class IssueSyncer extends Base {
             }
 
             if (issue.oldVersion && issue.oldVersion !== version) {
-                // Filter false-positive WARN volume during ADR 0004 clean-cut migration window (#11486).
-                // `oldVersion` derives from the cached path's directory name (see lines ~310-317); during
-                // migration, that contains pre-cut title-derived strings (e.g. 'vneo.d.ts - Typescript
-                // definitions...') that fail semver validation. Sealed-chunk enforcement at the
-                // reconcile step (~L569/L575) already prevents these from causing actual moves, so
-                // emitting WARN is pure noise. Real release-boundary recalculations (e.g. v11.12.0 →
-                // v11.13.0) where both sides are valid semver remain at WARN.
+                // Suppress false-positive WARN volume during archive topology migrations. `oldVersion`
+                // derives from the cached path directory and can contain pre-cut title-derived strings
+                // that fail semver validation. Sealed-chunk enforcement already prevents those legacy
+                // buckets from causing actual moves, so only release-boundary recalculations where both
+                // sides are valid semver remain WARN-worthy.
                 const oldIsValidTag = semver.valid(semver.clean(issue.oldVersion)) !== null;
                 const newIsValidTag = semver.valid(semver.clean(version))            !== null;
 
                 if (oldIsValidTag && newIsValidTag) {
-                    // Dedupe across multiple `#planBuckets` call sites within one sync cycle (#11486).
+                    // Dedupe across multiple `#planBuckets` call sites within one sync cycle.
                     if (!this.#warnedAnomalies.has(issue.number)) {
                         this.#warnedAnomalies.add(issue.number);
                         logger.warn(`🚨 [ARCHIVE ANOMALY] Issue #${issue.number} closedAt shift detected: moving from bucket '${issue.oldVersion}' to '${version}'. Dry-run review required.`);
@@ -460,7 +444,7 @@ class IssueSyncer extends Base {
         const filename = `${issueSyncConfig.issueFilenamePrefix}${issue.number}.md`;
 
         // Handle both GraphQL (issue.labels.nodes) and potential direct array.
-        // Null-safety per #11481: filter-out null nodes / null name fields (deleted labels).
+        // Filter null nodes and missing label names left behind by deleted labels.
         const labels = issue.labels?.nodes
             ? issue.labels.nodes.map(l => l?.name?.toLowerCase()).filter(Boolean)
             : issue.labels?.map(l => l?.name?.toLowerCase() || (typeof l === 'string' ? l.toLowerCase() : null)).filter(Boolean) || [];
@@ -520,10 +504,9 @@ class IssueSyncer extends Base {
     async pullFromGitHub(metadata) {
         logger.info('📥 Fetching issues from GitHub via GraphQL...');
 
-        // Reset per-sync-cycle dedupe set for ARCHIVE ANOMALY WARN emission (#11486).
-        // pullFromGitHub is the natural top-of-sync entrypoint; reconcileClosedIssueLocations and
-        // refetchIssuesByNumber called later in the cycle will reuse the same set, so the same
-        // issue is WARN'd at most once per full sync.
+        // Reset per-sync-cycle dedupe set for ARCHIVE ANOMALY WARN emission. pullFromGitHub is
+        // the natural top-of-sync entrypoint; reconcileClosedIssueLocations and refetchIssuesByNumber
+        // called later in the cycle reuse the same set, so each issue warns at most once per full sync.
         this.#warnedAnomalies.clear();
 
         let allIssues   = [];
@@ -542,14 +525,10 @@ class IssueSyncer extends Base {
                     limit           : 100,
                     cursor,
                     states          : ['OPEN', 'CLOSED'],
-                    // Clean-slate sync (metadata.lastSync null) needs to traverse the full repo
-                    // history per ADR 0004 §1.3 + §3.6; falling back to syncStartDate (2025-01-01)
-                    // would miss pre-2025 issues that haven't been touched since then. Use an
-                    // explicit pre-Neo date in that path so GraphQL pulls every issue, then local
-                    // droppedLabels + maxIssues caps trim the actual processed set. Empirical anchor:
-                    // PR #11461 Cycle 1 review (PRR_kwDODSospM8AAAABAIXzdA) — GPT V-B-A'd the
-                    // clean-slate rehydration premise as falsified for caps; this is the symmetric
-                    // fix for the date-window slice.
+                    // Clean-slate sync (`metadata.lastSync === null`) must traverse the full repo
+                    // history per ADR 0004. Falling back to the normal syncStartDate would miss old
+                    // issues that have not been touched since that date. Use an explicit pre-Neo date,
+                    // then let droppedLabels and maxIssues caps trim the actual processed set.
                     since           : metadata.lastSync || '2017-01-01T00:00:00Z',
                     maxLabels       : issueSyncConfig.maxLabelsPerIssue,
                     maxAssignees    : issueSyncConfig.maxAssigneesPerIssue,
@@ -651,8 +630,8 @@ class IssueSyncer extends Base {
                 stats.pulled.count++;
                 stats.pulled.issues.push(issueNumber);
 
-                // Continuation-fetch the full timeline if the first page was truncated.
-                // Prevents silent comment-body + structural-event loss on active Epics (#10090).
+                // Continuation-fetch the full timeline if the first page was truncated, preventing
+                // silent comment-body and structural-event loss on long-running issues.
                 await this.#exhaustTimelineItems(issue);
 
                 const markdown = this.#formatIssueMarkdown(issue);
@@ -687,7 +666,7 @@ class IssueSyncer extends Base {
                 milestone    : issue.milestone?.title || null,
                 title        : issue.title,
                 contentHash,                                    // Store hash for push comparison
-                commentsTotal: this.#countTimelineComments(issue) // Derived from the exhausted timeline — #10110
+                commentsTotal: this.#countTimelineComments(issue) // Derived from the exhausted timeline.
             };
 
             const plan = planBuckets.get(issueNumber);
@@ -781,7 +760,7 @@ class IssueSyncer extends Base {
      *
      * Bypasses the delta-sync `updatedAt` gate. Use this when the local file is known to have
      * drifted from GitHub for reasons that do NOT bump `issue.updatedAt`:
-     *   - `timelineItems` truncation (the original cap-related divergence — see #10090)
+     *   - `timelineItems` truncation
      *   - Comment deletions (GitHub does not update `updatedAt` on delete)
      *   - Relationship events (sub-issue/blocking edges) when both sides are outside the delta window
      *
@@ -853,7 +832,7 @@ class IssueSyncer extends Base {
                     milestone    : issue.milestone?.title || null,
                     title        : issue.title,
                     contentHash,
-                    commentsTotal: this.#countTimelineComments(issue) // Derived from the exhausted timeline — #10110
+                    commentsTotal: this.#countTimelineComments(issue) // Derived from the exhausted timeline.
                 };
 
                 if (indexMutations) {

--- a/ai/services/github-workflow/sync/MetadataManager.mjs
+++ b/ai/services/github-workflow/sync/MetadataManager.mjs
@@ -82,26 +82,23 @@ class MetadataManager extends Base {
                 closedAt     : value.closedAt,
                 updatedAt    : value.updatedAt,
                 contentHash  : value.contentHash,
-                // milestone persisted as string-title (symmetric with IssueSyncer hydrate at L324:
-                // `issue.milestone ? { title: issue.milestone } : null`). Without this, planBuckets
-                // falls through to closedAt-based release-date inference and re-classifies unchanged
-                // closed issues every sync, emitting persistent ARCHIVE ANOMALY WARN noise (#11594).
+                // Persist milestone as a string-title, symmetric with IssueSyncer hydration into
+                // `{title}` form. Without this, planBuckets falls through to closedAt-based release-date
+                // inference and re-classifies unchanged closed issues every sync, emitting persistent
+                // ARCHIVE ANOMALY WARN noise.
                 //
                 // Shape handling: `IssueSyncer.pullFromGitHub` seeds `newMetadata.issues` from existing
                 // serialized metadata (already string form), THEN overwrites fetched issues with the
                 // object form (`{title: '...'}`). The prune must preserve BOTH paths: string entries
                 // (unchanged cached issues) pass through verbatim; object entries (freshly fetched)
                 // get `.title` extracted. A naive `value.milestone?.title || null` would prune cached
-                // strings back to `null` on every save (regression of regression — caught by @neo-gpt
-                // review PR #11607 Cycle 1).
+                // strings back to `null` on every save.
                 milestone    : typeof value.milestone === 'string'
                     ? value.milestone
                     : (value.milestone?.title || null),
                 // commentsTotal is the count of ISSUE_COMMENT nodes derived from the exhausted
-                // timelineItems connection (#10110). Single source of truth: the metadata value
-                // is structurally guaranteed to match the rendered markdown because both are
-                // produced from the same timeline. Pre-#10110 entries fed this from the separate
-                // comments.totalCount scalar (a pre-timeline-era leftover), now superseded.
+                // timelineItems connection. The metadata value is structurally guaranteed to match
+                // the rendered markdown because both are produced from the same timeline.
                 commentsTotal: value.commentsTotal
             };
         }
@@ -114,10 +111,9 @@ class MetadataManager extends Base {
             };
         }
 
-        // Prune pulls — `archiveVersion` is intentionally NOT persisted (#11364). Archive-bucket
-        // placement is derived fresh each sync from real milestone/release-date logic in
-        // PullRequestSyncer#planBuckets; a carried-forward archiveVersion could re-lock a stale
-        // (e.g. pre-release-cut) bucket into .sync-metadata.json.
+        // Prune pulls — `archiveVersion` is intentionally NOT persisted. Archive-bucket placement is
+        // derived fresh each sync from real milestone/release-date logic in PullRequestSyncer#planBuckets;
+        // a carried-forward archiveVersion could re-lock a stale bucket into .sync-metadata.json.
         for (const [key, value] of Object.entries(metadata.pulls || {})) {
             prunedMetadata.pulls[key] = {
                 state      : value.state,

--- a/ai/services/github-workflow/sync/verifyFrontmatterIntegrity.mjs
+++ b/ai/services/github-workflow/sync/verifyFrontmatterIntegrity.mjs
@@ -5,24 +5,19 @@
  * Discussion / Issue / PullRequest syncers; sibling-file-lift applies; no novel directory choice.
  *
  * @summary Validates that the YAML frontmatter block of serialized markdown carries the expected
- * top-level keys before persistence (#11573). Closes the V-B-A gap where #11554's frontmatter-emit
- * fix shipped with green CI but the production effect was never verified — 0 of 104 on-disk
- * Discussion markdown files carried the new `closed` / `closedAt` keys despite the merged code path.
+ * top-level keys before persistence. Guards the production effect of frontmatter migrations, where
+ * green CI alone does not prove that live sync writers are serializing the new keys.
  *
  * Intentionally a pure helper:
  * - Uses `gray-matter` (the same parser the syncer uses) to isolate the frontmatter block from
- *   the markdown body. This eliminates the body-line false-positive class GPT empirically caught
- *   in PR #11574 cycle-1 V-B-A (where a body line starting with `closed:` falsely satisfied a
- *   missing-key check against the actual frontmatter).
+ *   the markdown body. This eliminates the body-line false-positive class where a body line starting
+ *   with `closed:` falsely satisfies a missing-key check against the actual frontmatter.
  * - No Neo runtime dependency (importable from any sync context, including non-Neo callers).
  * - No filesystem IO (operates on the in-memory `content` string just before `fs.writeFile`).
  * - No logger dependency (returns a structured result; caller decides log level + action).
  *
  * Cost model: one `gray-matter` parse per discussion (~100/sync × ~1ms = sub-100ms — far below
  * the network + serialize cost of a sync run).
- *
- * @see #11573 (this ticket) / #11554 (originally fixed frontmatter shape) / PR #11574 cycle-1
- *      (GPT V-B-A — the body-line false-positive that drove the gray-matter scope fix)
  */
 import matter from 'gray-matter';
 
@@ -67,8 +62,8 @@ function verifyFrontmatterIntegrity(content, requiredKeys) {
 
 /**
  * Convenience wrapper for the Discussion syncer's required key set. Centralizes the
- * "what counts as a complete Discussion frontmatter" contract so future regression
- * tickets can extend this single list instead of grepping all syncers.
+ * "what counts as a complete Discussion frontmatter" contract so future migrations
+ * can extend this single list instead of grepping all syncers.
  *
  * Currently mirrors `DiscussionSyncer.mjs:241-250` frontmatter object construction.
  *


### PR DESCRIPTION
Refs #11924
Related: #11912

Authored by GPT-5 (Codex Desktop). Session 3b454ac4-f2c6-4bf0-9c18-c0af6f432ffa.
FAIR-band: in-band [13/30 — current author count over last 30 merged]

Cleans the second GitHub Workflow source-comment batch for #11924 by replacing ticket-cycle archaeology with durable intent comments. This keeps the implementation contracts discoverable without preserving stale PR-review chronology inside source files.

Evidence: L1 (static source-comment diagnostic + syntax/diff checks) → L1 required (comment/JSDoc cleanup with no runtime-verify ACs). No residuals.

## Config Template Sync
- Changed config keys: none. `ai/mcp/server/github-workflow/config.template.mjs` changed comment text only.
- Local `config.mjs` follow-up: none.
- Harness restart: unnecessary.

## Deltas from ticket
- #11949 already reduced the full #11924 diagnostic from 151 to 76. This batch reduces the remaining scoped archaeology-token diagnostic from 76 to 30 overall, with touched-file residuals at 3.
- Preserved runtime behavior, public APIs, schema names, and runtime error strings.

## Test Evidence
- `git diff --check`
- `git diff --cached --check`
- `node --check ai/mcp/server/github-workflow/config.template.mjs`
- `node --check ai/services/github-workflow/SyncService.mjs`
- `node --check ai/services/github-workflow/sync/DiscussionSyncer.mjs`
- `node --check ai/services/github-workflow/sync/IssueSyncer.mjs`
- `node --check ai/services/github-workflow/sync/MetadataManager.mjs`
- `node --check ai/services/github-workflow/sync/verifyFrontmatterIntegrity.mjs`
- `rg --count-matches "ticket #|#[0-9]{4,}|\bAC[0-9]+\b|\bAC [0-9]+\b|Lane [A-Z]|cycle-[0-9]|PR #[0-9]+|:[0-9]+-[0-9]+" ai/services/github-workflow ai/mcp/server/github-workflow ai/mcp/server/shared --glob "*.mjs"` → 30 residual matches overall.
- Same diagnostic limited to touched files → 3 residual matches.

## Post-Merge Validation
- [ ] Re-run the #11924 diagnostic against `dev` and continue residual GitHub Workflow/shared MCP groups, especially `IssueService`, `PullRequestService`, query/mutation helpers, and `contentPath`.
- [ ] Keep #11924 open until shared MCP `.mjs` comment cleanup is complete.

## Commits
- `1255f4276` — `chore(ai): clean github workflow sync comments (#11924)`