### PR TITLE
fix(kb): bump SourceParser acorn ecmaVersion to 'latest' for ES2025 import attributes (#11973)

### DIFF
--- a/ai/services/knowledge-base/parser/SourceParser.mjs
+++ b/ai/services/knowledge-base/parser/SourceParser.mjs
@@ -53,7 +53,10 @@ class SourceParser extends Base {
         }
 
         try {
-            ast = acorn.parse(content, { sourceType: 'module', locations: true, ecmaVersion: 2022 });
+            // `ecmaVersion: 'latest'` lets acorn auto-track its highest-supported syntax
+            // rather than pinning a literal year that future TC39 features (e.g. import
+            // attributes `with {type: 'json'}`, decorators) would silently fail to parse.
+            ast = acorn.parse(content, { sourceType: 'module', locations: true, ecmaVersion: 'latest' });
         } catch (e) {
             logger.warn(`Failed to parse source file ${filePath}: ${e.message}`);
             return [];

--- a/test/playwright/unit/ai/services/knowledge-base/parser/SourceParser.spec.mjs
+++ b/test/playwright/unit/ai/services/knowledge-base/parser/SourceParser.spec.mjs
@@ -1,0 +1,83 @@
+import {setup} from '../../../../../setup.mjs';
+
+const appName = 'SourceParserTest';
+
+setup({
+    neoConfig: {
+        unitTestMode: true
+    },
+    appConfig: {
+        name             : appName,
+        isMounted        : () => true,
+        vnodeInitialising: false
+    }
+});
+
+import {test, expect} from '@playwright/test';
+import Neo            from '../../../../../../../src/Neo.mjs';
+import * as core      from '../../../../../../../src/core/_export.mjs';
+
+/**
+ * @summary Verifies SourceParser handles modern ES syntax that acorn's older
+ * `ecmaVersion` pins would reject. The regression-anchor case is ES2025
+ * import attributes (`with {type: 'json'}`), but the same `ecmaVersion: 'latest'`
+ * setting covers other recent additions like decorators and class-field syntax.
+ */
+test.describe('SourceParser', () => {
+    let SourceParser;
+
+    test.beforeAll(async () => {
+        SourceParser = (await import('../../../../../../../ai/services/knowledge-base/parser/SourceParser.mjs')).default;
+    });
+
+    test('parses ES2025 import attributes (`with {type: \'json\'}`) without warning', () => {
+        const fixture = `import packageJson from '../../../package.json' with {type: 'json'};
+
+const version = packageJson.version;
+
+export default {version};
+`;
+        const chunks = SourceParser.parse(fixture, 'fixture/import-with.mjs');
+
+        // Acorn under `ecmaVersion: 'latest'` succeeds; older pins (e.g. 2022)
+        // returned an empty chunk array via the catch-branch warning path.
+        // The parser doesn't emit class/method chunks for a plain module like
+        // this fixture, but it MUST NOT bail with zero chunks due to parse
+        // failure either. The contract here is "no parse error" rather than
+        // "must produce N chunks".
+        expect(Array.isArray(chunks)).toBe(true);
+    });
+
+    test('parses shebang-prefixed module entry scripts', () => {
+        const fixture = `#!/usr/bin/env node
+import fs from 'fs';
+
+class Tool {
+    static config = {
+        className: 'Test.Tool'
+    }
+
+    run() { return fs.readFileSync('x'); }
+}
+
+export default Tool;
+`;
+        const chunks = SourceParser.parse(fixture, 'fixture/shebang.mjs');
+
+        expect(Array.isArray(chunks)).toBe(true);
+        // Shebang stripping should leave the class+method parseable.
+        const methodChunk = chunks.find(chunk => chunk.type === 'method' || chunk.kind === 'method');
+        if (methodChunk) {
+            expect(typeof methodChunk).toBe('object');
+        }
+    });
+
+    test('returns empty array (warn-not-throw) for truly malformed source', () => {
+        const fixture = `import x from 'y'; this is not valid javascript {{{`;
+        const chunks = SourceParser.parse(fixture, 'fixture/malformed.mjs');
+
+        // Parse failure path: chunks=[] (warning logged, caller continues with
+        // empty result rather than crashing the KB sync).
+        expect(chunks).toEqual([]);
+    });
+});

--- a/test/playwright/unit/ai/services/knowledge-base/parser/SourceParser.spec.mjs
+++ b/test/playwright/unit/ai/services/knowledge-base/parser/SourceParser.spec.mjs
@@ -30,7 +30,7 @@ test.describe('SourceParser', () => {
         SourceParser = (await import('../../../../../../../ai/services/knowledge-base/parser/SourceParser.mjs')).default;
     });
 
-    test('parses ES2025 import attributes (`with {type: \'json\'}`) without warning', () => {
+    test('parses ES2025 import attributes (`with {type: \'json\'}`) and produces a module-context chunk', () => {
         const fixture = `import packageJson from '../../../package.json' with {type: 'json'};
 
 const version = packageJson.version;
@@ -39,16 +39,19 @@ export default {version};
 `;
         const chunks = SourceParser.parse(fixture, 'fixture/import-with.mjs');
 
-        // Acorn under `ecmaVersion: 'latest'` succeeds; older pins (e.g. 2022)
-        // returned an empty chunk array via the catch-branch warning path.
-        // The parser doesn't emit class/method chunks for a plain module like
-        // this fixture, but it MUST NOT bail with zero chunks due to parse
-        // failure either. The contract here is "no parse error" rather than
-        // "must produce N chunks".
-        expect(Array.isArray(chunks)).toBe(true);
+        // Success-only oracle: under the old `ecmaVersion: 2022` pin, acorn
+        // rejects the `with` keyword and `parse()` falls into the warn-catch
+        // branch that returns `[]`. An `Array.isArray(chunks)` assertion alone
+        // would pass on BOTH the broken and fixed paths (false-positive). We
+        // assert on the artifact only the fixed path produces: one
+        // `module-context` chunk (the no-class branch emits exactly one).
+        expect(chunks).toHaveLength(1);
+        expect(chunks[0].kind).toBe('module-context');
+        expect(chunks[0].source).toBe('fixture/import-with.mjs');
+        expect(chunks[0].content).toContain("with {type: 'json'}");
     });
 
-    test('parses shebang-prefixed module entry scripts', () => {
+    test('parses shebang-prefixed module entry scripts and emits class/method chunks', () => {
         const fixture = `#!/usr/bin/env node
 import fs from 'fs';
 
@@ -64,20 +67,26 @@ export default Tool;
 `;
         const chunks = SourceParser.parse(fixture, 'fixture/shebang.mjs');
 
-        expect(Array.isArray(chunks)).toBe(true);
-        // Shebang stripping should leave the class+method parseable.
-        const methodChunk = chunks.find(chunk => chunk.type === 'method' || chunk.kind === 'method');
-        if (methodChunk) {
-            expect(typeof methodChunk).toBe('object');
-        }
+        // Success-only oracle: shebang-stripping path must yield more than
+        // module-context. The class body produces a config chunk and at
+        // least one method chunk; a pre-fix parse failure would return [].
+        expect(chunks.length).toBeGreaterThan(1);
+        const kinds = chunks.map(c => c.kind);
+        expect(kinds).toContain('module-context');
+        expect(kinds).toContain('class-config');
+        const methodChunk = chunks.find(c => c.kind === 'method' || c.type === 'method');
+        expect(methodChunk).toBeTruthy();
     });
 
     test('returns empty array (warn-not-throw) for truly malformed source', () => {
         const fixture = `import x from 'y'; this is not valid javascript {{{`;
         const chunks = SourceParser.parse(fixture, 'fixture/malformed.mjs');
 
-        // Parse failure path: chunks=[] (warning logged, caller continues with
-        // empty result rather than crashing the KB sync).
+        // Parse failure path: chunks=[] (warning logged, caller continues
+        // with empty result rather than crashing the KB sync). The
+        // malformed-source contract is preserved across the ecmaVersion
+        // bump — only success cases shift; legitimately unparseable input
+        // still warns and returns empty.
         expect(chunks).toEqual([]);
     });
 });


### PR DESCRIPTION
Authored by Claude Opus 4.7 (Claude Code). Operator-flagged KB-sync regression surfaced 2026-05-25 via `npm run ai:orchestrator` daemon log.

FAIR-band: in-band [16/30] — corrective lane, 1-line fix + focused regression-anchor test. Live verifier (per @neo-gpt anchor): GPT 14 / Claude 16 over last 30 merged PRs.

Evidence: L1 (3/3 PASS on new `SourceParser.spec.mjs` regression-anchor + shebang + malformed-source coverage). L1 sufficient — the failure mode is fully reproducible at the parser-unit boundary; daemon-level KB-sync run is a downstream consumer of the now-fixed parser.

Resolves #11973

## Summary

Operator's `ai:orchestrator` daemon emitted:

```
[WARN] Failed to parse source file ai/scripts/maintenance/downloadKnowledgeBase.mjs: Unexpected token (5:48)
[WARN] Failed to parse source file ai/scripts/maintenance/uploadKnowledgeBase.mjs: Unexpected token (5:48)
```

Root cause: [`ai/services/knowledge-base/parser/SourceParser.mjs:58`](ai/services/knowledge-base/parser/SourceParser.mjs#L58) hardcoded `acorn.parse(..., {ecmaVersion: 2022})`. Both failing files use ES2025 import-attribute syntax at line 5 column 48:

```js
import packageJson from '../../../package.json' with {type: 'json'};
```

Acorn `8.16.0` (currently pinned) supports this under `ecmaVersion: 'latest'` or `2025`; rejects it under `2022`.

**Blast scope**: WARN-only — KB sync completes; the 2 affected files just dropped from source chunks. Agents querying the KB about `downloadKnowledgeBase`/`uploadKnowledgeBase` got zero source-level matches. Not a stop-the-world but degrades agent-facing observability.

**Provenance**: `import with` syntax introduced 2026-05-23 in commit `e6c9df098` (#11848/#11853 buildScripts/ai → ai/scripts collapse refactor). KB sync silently dropped chunks since then; today's orchestrator restart triggered a full re-parse and surfaced the WARN.

## Changes

### Stage 1: bump `ecmaVersion` to `'latest'` ([`ai/services/knowledge-base/parser/SourceParser.mjs:58`](ai/services/knowledge-base/parser/SourceParser.mjs#L58))

Single-line fix:

```diff
- ast = acorn.parse(content, { sourceType: 'module', locations: true, ecmaVersion: 2022 });
+ ast = acorn.parse(content, { sourceType: 'module', locations: true, ecmaVersion: 'latest' });
```

`'latest'` is acorn's documented sentinel for "the most recent ECMA version this release supports" — auto-tracks new syntax across acorn upgrades without further literal-year bumps when ES2026+ features land. Inline JSDoc comment explains the choice.

### Stage 2: regression-anchor test ([`test/playwright/unit/ai/services/knowledge-base/parser/SourceParser.spec.mjs`](test/playwright/unit/ai/services/knowledge-base/parser/SourceParser.spec.mjs) NEW)

3 tests at the canonical `test/playwright/unit/ai/services/knowledge-base/parser/` location:

1. **`parses ES2025 import attributes (with {type: 'json'}) without warning`** — regression anchor. Fixture matches the shape that broke in `downloadKnowledgeBase.mjs` / `uploadKnowledgeBase.mjs`. Pre-fix this returned `[]` via the warn-branch; post-fix it returns the parsed-chunks array.
2. **`parses shebang-prefixed module entry scripts`** — confirms the shebang-stripping branch still works under the new ecmaVersion.
3. **`returns empty array (warn-not-throw) for truly malformed source`** — confirms the catch-branch contract is preserved (caller continues with empty result, no crash).

## Test Evidence

```bash
npm run test-unit -- test/playwright/unit/ai/services/knowledge-base/parser/SourceParser.spec.mjs
```

→ **3/3 PASS** (641ms).

Acorn-version V-B-A (run during diagnosis):

```bash
$ node -e "import('acorn').then(a => { ['latest', 2025, 2022].forEach(v => { try { a.parse(\"import x from 'y.json' with {type: 'json'}\", {sourceType:'module', ecmaVersion: v}); console.log(v + ': OK'); } catch(e) { console.log(v + ':', e.message); } }) })"
latest: OK
2025: OK
2022: Unexpected token (1:23)
```

## Deltas from ticket

None — all 4 ACs satisfied.

## Post-Merge Validation

- [ ] Operator restarts `npm run ai:orchestrator` after merge; KB-sync daemon log no longer emits `Failed to parse source file ai/scripts/maintenance/downloadKnowledgeBase.mjs` or `uploadKnowledgeBase.mjs` warnings.
- [ ] Optional: query KB for `downloadKnowledgeBase` after the next full sync; should now return source-level chunks (previously empty due to parse drop).

## Avoided Traps

- ✓ Did NOT switch `ecmaVersion: 2025` instead of `'latest'` — the literal year locks future agents into another hardcoded bump when ES2026+ syntax lands.
- ✓ Did NOT add a fallback `try { 'latest' } catch { 2022 }` block — defensive code that never fires is noise; acorn's contract is documented.
- ✓ Did NOT touch the 2 maintenance scripts using `import with` — they're authoring the canonical modern shape; the parser is the surface to fix.
- ✓ Did NOT audit-and-bump every other parser in the codebase — out of scope per ticket; file follow-up if any similar pins surface.

Authored by [Claude Opus 4.7] (Claude Code).
