### PR TITLE
feat(memory-core): stamp summary provenance (#10292)

### DIFF
--- a/ai/services/memory-core/SessionService.mjs
+++ b/ai/services/memory-core/SessionService.mjs
@@ -8,59 +8,6 @@ import OpenAiCompatibleProvider from '../../provider/OpenAiCompatible.mjs';
 import OllamaProvider           from '../../provider/Ollama.mjs';
 import {IDENTITIES, TRUST_TIERS, TRUST_TIER_ORDER} from '../../graph/identityRoots.mjs';
 
-const
-    identityTrustTiers = new Map(IDENTITIES.map(identity => [identity.id, identity.properties?.trustTier || TRUST_TIERS.UNCLASSIFIED])),
-    trustTierRanks     = new Map(TRUST_TIER_ORDER.map((tier, index) => [tier, index]));
-
-/**
- * @summary Resolves source-memory provenance for a derived session summary.
- *
- * A session summary is derived content: it must retain the most restrictive trust tier of
- * its source memories so the summarizer cannot launder lower-trust material into its own
- * higher-trust identity. Unknown or pre-provenance memories therefore collapse to
- * `unclassified`.
- *
- * @param {Object[]} [metadatas=[]] Source memory metadata rows.
- * @returns {{sourceAgentIdentities: String[], sourceTrustTier: String, unclassifiedSourceCount: Number}}
- */
-export function resolveSummarySourceProvenance(metadatas = []) {
-    const sourceAgentIdentities = new Set();
-    let sourceTrustTier         = null,
-        unclassifiedSourceCount = 0;
-
-    for (const metadata of metadatas || []) {
-        const agentIdentity = typeof metadata?.agentIdentity === 'string' && metadata.agentIdentity
-            ? metadata.agentIdentity
-            : null;
-        const knownTrustTier = agentIdentity ? identityTrustTiers.get(agentIdentity) : null;
-        const trustTier = agentIdentity
-            ? (knownTrustTier || TRUST_TIERS.UNCLASSIFIED)
-            : TRUST_TIERS.UNCLASSIFIED;
-
-        if (agentIdentity) {
-            sourceAgentIdentities.add(agentIdentity);
-        }
-
-        if (!knownTrustTier) {
-            unclassifiedSourceCount++;
-        }
-
-        if (
-            sourceTrustTier === null ||
-            (trustTierRanks.get(trustTier) ?? trustTierRanks.get(TRUST_TIERS.UNCLASSIFIED)) >
-            (trustTierRanks.get(sourceTrustTier) ?? trustTierRanks.get(TRUST_TIERS.UNCLASSIFIED))
-        ) {
-            sourceTrustTier = trustTier;
-        }
-    }
-
-    return {
-        sourceAgentIdentities: [...sourceAgentIdentities],
-        sourceTrustTier     : sourceTrustTier || TRUST_TIERS.UNCLASSIFIED,
-        unclassifiedSourceCount
-    };
-}
-
 /**
  * @summary Builds the chat-completion model wrapper for the configured `modelProvider`.
  *
@@ -214,6 +161,59 @@ class SessionService extends Base {
          * @protected
          */
         singleton: true
+    }
+
+    static identityTrustTiers = new Map(IDENTITIES.map(identity => [identity.id, identity.properties?.trustTier || TRUST_TIERS.UNCLASSIFIED]))
+
+    static trustTierRanks = new Map(TRUST_TIER_ORDER.map((tier, index) => [tier, index]))
+
+    /**
+     * @summary Resolves source-memory provenance for a derived session summary.
+     *
+     * A session summary is derived content: it must retain the most restrictive trust tier of
+     * its source memories so the summarizer cannot launder lower-trust material into its own
+     * higher-trust identity. Unknown or pre-provenance memories therefore collapse to
+     * `unclassified`.
+     *
+     * @param {Object[]} [metadatas=[]] Source memory metadata rows.
+     * @returns {{sourceAgentIdentities: String[], sourceTrustTier: String, unclassifiedSourceCount: Number}}
+     */
+    static resolveSummarySourceProvenance(metadatas = []) {
+        const sourceAgentIdentities = new Set();
+        let sourceTrustTier         = null,
+            unclassifiedSourceCount = 0;
+
+        for (const metadata of metadatas || []) {
+            const agentIdentity = typeof metadata?.agentIdentity === 'string' && metadata.agentIdentity
+                ? metadata.agentIdentity
+                : null;
+            const knownTrustTier = agentIdentity ? this.identityTrustTiers.get(agentIdentity) : null;
+            const trustTier = agentIdentity
+                ? (knownTrustTier || TRUST_TIERS.UNCLASSIFIED)
+                : TRUST_TIERS.UNCLASSIFIED;
+
+            if (agentIdentity) {
+                sourceAgentIdentities.add(agentIdentity);
+            }
+
+            if (!knownTrustTier) {
+                unclassifiedSourceCount++;
+            }
+
+            if (
+                sourceTrustTier === null ||
+                (this.trustTierRanks.get(trustTier) ?? this.trustTierRanks.get(TRUST_TIERS.UNCLASSIFIED)) >
+                (this.trustTierRanks.get(sourceTrustTier) ?? this.trustTierRanks.get(TRUST_TIERS.UNCLASSIFIED))
+            ) {
+                sourceTrustTier = trustTier;
+            }
+        }
+
+        return {
+            sourceAgentIdentities: [...sourceAgentIdentities],
+            sourceTrustTier     : sourceTrustTier || TRUST_TIERS.UNCLASSIFIED,
+            unclassifiedSourceCount
+        };
     }
 
     /**
@@ -641,7 +641,7 @@ ${aggregatedContent}
             userId: RequestContextService.getUserId(),
             participatingAgents
         });
-        const sourceProvenance = resolveSummarySourceProvenance(memories.metadatas);
+        const sourceProvenance = this.constructor.resolveSummarySourceProvenance(memories.metadatas);
 
         const summaryMetadata = {
             sessionId, timestamp: lastActivity, memoryCount: memories.ids.length,
@@ -685,7 +685,7 @@ ${aggregatedContent}
         // Tie the summary strategically to the current focal point
         GraphService.linkNodes('frontier', summaryId, 'SESSION_COMPLETED', 1.0);
 
-        const graphAgentIdentities = sourceProvenance.sourceAgentIdentities.filter(agentIdentity => identityTrustTiers.has(agentIdentity));
+        const graphAgentIdentities = sourceProvenance.sourceAgentIdentities.filter(agentIdentity => this.constructor.identityTrustTiers.has(agentIdentity));
 
         for (const agentIdentity of graphAgentIdentities) {
             GraphService.linkNodes(summaryId, agentIdentity, 'AUTHORED_BY', 1.0, {

--- a/ai/services/memory-core/SessionService.mjs
+++ b/ai/services/memory-core/SessionService.mjs
@@ -6,6 +6,60 @@ import crypto from 'crypto';
 import GraphService from './GraphService.mjs';
 import OpenAiCompatibleProvider from '../../provider/OpenAiCompatible.mjs';
 import OllamaProvider           from '../../provider/Ollama.mjs';
+import {IDENTITIES, TRUST_TIERS, TRUST_TIER_ORDER} from '../../graph/identityRoots.mjs';
+
+const
+    identityTrustTiers = new Map(IDENTITIES.map(identity => [identity.id, identity.properties?.trustTier || TRUST_TIERS.UNCLASSIFIED])),
+    trustTierRanks     = new Map(TRUST_TIER_ORDER.map((tier, index) => [tier, index]));
+
+/**
+ * @summary Resolves source-memory provenance for a derived session summary.
+ *
+ * A session summary is derived content: it must retain the most restrictive trust tier of
+ * its source memories so the summarizer cannot launder lower-trust material into its own
+ * higher-trust identity. Unknown or pre-provenance memories therefore collapse to
+ * `unclassified`.
+ *
+ * @param {Object[]} [metadatas=[]] Source memory metadata rows.
+ * @returns {{sourceAgentIdentities: String[], sourceTrustTier: String, unclassifiedSourceCount: Number}}
+ */
+export function resolveSummarySourceProvenance(metadatas = []) {
+    const sourceAgentIdentities = new Set();
+    let sourceTrustTier         = null,
+        unclassifiedSourceCount = 0;
+
+    for (const metadata of metadatas || []) {
+        const agentIdentity = typeof metadata?.agentIdentity === 'string' && metadata.agentIdentity
+            ? metadata.agentIdentity
+            : null;
+        const knownTrustTier = agentIdentity ? identityTrustTiers.get(agentIdentity) : null;
+        const trustTier = agentIdentity
+            ? (knownTrustTier || TRUST_TIERS.UNCLASSIFIED)
+            : TRUST_TIERS.UNCLASSIFIED;
+
+        if (agentIdentity) {
+            sourceAgentIdentities.add(agentIdentity);
+        }
+
+        if (!knownTrustTier) {
+            unclassifiedSourceCount++;
+        }
+
+        if (
+            sourceTrustTier === null ||
+            (trustTierRanks.get(trustTier) ?? trustTierRanks.get(TRUST_TIERS.UNCLASSIFIED)) >
+            (trustTierRanks.get(sourceTrustTier) ?? trustTierRanks.get(TRUST_TIERS.UNCLASSIFIED))
+        ) {
+            sourceTrustTier = trustTier;
+        }
+    }
+
+    return {
+        sourceAgentIdentities: [...sourceAgentIdentities],
+        sourceTrustTier     : sourceTrustTier || TRUST_TIERS.UNCLASSIFIED,
+        unclassifiedSourceCount
+    };
+}
 
 /**
  * @summary Builds the chat-completion model wrapper for the configured `modelProvider`.
@@ -578,6 +632,7 @@ ${aggregatedContent}
         const { summary, title, category, quality, productivity, impact, complexity, technologies } = summaryData;
 
         const summaryId = `summary_${sessionId}`;
+        const timestamp = new Date(lastActivity).toISOString();
 
         // Multi-tenant isolation tag (#10000, #11181): private summaries keep the active
         // request userId; core-swarm summaries use the shared sentinel so every named peer can
@@ -586,6 +641,7 @@ ${aggregatedContent}
             userId: RequestContextService.getUserId(),
             participatingAgents
         });
+        const sourceProvenance = resolveSummarySourceProvenance(memories.metadatas);
 
         const summaryMetadata = {
             sessionId, timestamp: lastActivity, memoryCount: memories.ids.length,
@@ -594,8 +650,14 @@ ${aggregatedContent}
             participatingAgents: participatingAgents.join(','),
             models: models.join(','),
             totalToolCalls,
-            toolsUsed: Array.from(allToolsUsed).join(',')
+            toolsUsed: Array.from(allToolsUsed).join(','),
+            sourceAgentIdentities: sourceProvenance.sourceAgentIdentities.join(','),
+            sourceTrustTier      : sourceProvenance.sourceTrustTier,
+            provenancePolicy     : 'most-restrictive-source'
         };
+        if (sourceProvenance.unclassifiedSourceCount > 0) {
+            summaryMetadata.unclassifiedSourceCount = sourceProvenance.unclassifiedSourceCount;
+        }
         if (userId) summaryMetadata.userId = userId;
 
         await this.sessionsCollection.upsert({
@@ -610,11 +672,29 @@ ${aggregatedContent}
             type: 'SESSION_SUMMARY',
             name: title,
             description: `${category} session by ${participatingAgents.join(', ')}`,
-            semanticVectorId: summaryId
+            semanticVectorId: summaryId,
+            properties: {
+                sessionId,
+                sourceAgentIdentities: sourceProvenance.sourceAgentIdentities,
+                sourceTrustTier      : sourceProvenance.sourceTrustTier,
+                provenancePolicy     : 'most-restrictive-source',
+                ...(userId ? {userId} : {})
+            }
         });
 
         // Tie the summary strategically to the current focal point
         GraphService.linkNodes('frontier', summaryId, 'SESSION_COMPLETED', 1.0);
+
+        const graphAgentIdentities = sourceProvenance.sourceAgentIdentities.filter(agentIdentity => identityTrustTiers.has(agentIdentity));
+
+        for (const agentIdentity of graphAgentIdentities) {
+            GraphService.linkNodes(summaryId, agentIdentity, 'AUTHORED_BY', 1.0, {
+                timestamp,
+                userId          : agentIdentity,
+                sharedEntity    : true,
+                provenancePolicy: 'most-restrictive-source'
+            });
+        }
 
         // --- 2. Semantic Extraction (Regex Linkage) ---
         const issueRegex = /(?:#|issue-)(\d+)/gi;

--- a/ai/services/memory-core/SummaryService.mjs
+++ b/ai/services/memory-core/SummaryService.mjs
@@ -4,6 +4,14 @@ import StorageRouter         from './managers/StorageRouter.mjs';
 import logger                from '../../mcp/server/memory-core/logger.mjs';
 import RequestContextService, {SHARED_USER_ID, normalizeUserId} from '../../mcp/server/shared/services/RequestContextService.mjs';
 
+/**
+ * @summary Converts comma-delimited Chroma metadata fields into stable result arrays.
+ * @param {String|undefined} value Metadata value.
+ * @returns {String[]} Trimmed, non-empty values.
+ */
+function splitMetadataList(value) {
+    return value ? String(value).split(',').map(item => item.trim()).filter(Boolean) : [];
+}
 
 /**
  * @summary Service for handling deleting, listing, and querying session summaries.
@@ -222,7 +230,10 @@ class SummaryService extends Base {
                     complexity  : Number(metadata.complexity) || 0,
                     technologies: techSource
                         ? techSource.split(',').map(item => item.trim()).filter(Boolean)
-                        : []
+                        : [],
+                    sourceAgentIdentities: splitMetadataList(metadata.sourceAgentIdentities),
+                    sourceTrustTier      : metadata.sourceTrustTier,
+                    provenancePolicy     : metadata.provenancePolicy
                 };
             }).filter(Boolean);
 
@@ -336,6 +347,9 @@ class SummaryService extends Base {
                     technologies: techSource
                         ? techSource.split(',').map(item => item.trim()).filter(Boolean)
                         : [],
+                    sourceAgentIdentities: splitMetadataList(metadata.sourceAgentIdentities),
+                    sourceTrustTier      : metadata.sourceTrustTier,
+                    provenancePolicy     : metadata.provenancePolicy,
                     distance,
                     relevanceScore
                 };

--- a/ai/services/memory-core/SummaryService.mjs
+++ b/ai/services/memory-core/SummaryService.mjs
@@ -5,15 +5,6 @@ import logger                from '../../mcp/server/memory-core/logger.mjs';
 import RequestContextService, {SHARED_USER_ID, normalizeUserId} from '../../mcp/server/shared/services/RequestContextService.mjs';
 
 /**
- * @summary Converts comma-delimited Chroma metadata fields into stable result arrays.
- * @param {String|undefined} value Metadata value.
- * @returns {String[]} Trimmed, non-empty values.
- */
-function splitMetadataList(value) {
-    return value ? String(value).split(',').map(item => item.trim()).filter(Boolean) : [];
-}
-
-/**
  * @summary Service for handling deleting, listing, and querying session summaries.
  *
  * This service manages the high-level session summaries. It allows for retrieving past summaries to provide context,
@@ -43,6 +34,15 @@ class SummaryService extends Base {
          * @protected
          */
         singleton: true
+    }
+
+    /**
+     * @summary Converts comma-delimited Chroma metadata fields into stable result arrays.
+     * @param {String|undefined} value Metadata value.
+     * @returns {String[]} Trimmed, non-empty values.
+     */
+    static splitMetadataList(value) {
+        return value ? String(value).split(',').map(item => item.trim()).filter(Boolean) : [];
     }
 
     /**
@@ -231,7 +231,7 @@ class SummaryService extends Base {
                     technologies: techSource
                         ? techSource.split(',').map(item => item.trim()).filter(Boolean)
                         : [],
-                    sourceAgentIdentities: splitMetadataList(metadata.sourceAgentIdentities),
+                    sourceAgentIdentities: this.constructor.splitMetadataList(metadata.sourceAgentIdentities),
                     sourceTrustTier      : metadata.sourceTrustTier,
                     provenancePolicy     : metadata.provenancePolicy
                 };
@@ -347,7 +347,7 @@ class SummaryService extends Base {
                     technologies: techSource
                         ? techSource.split(',').map(item => item.trim()).filter(Boolean)
                         : [],
-                    sourceAgentIdentities: splitMetadataList(metadata.sourceAgentIdentities),
+                    sourceAgentIdentities: this.constructor.splitMetadataList(metadata.sourceAgentIdentities),
                     sourceTrustTier      : metadata.sourceTrustTier,
                     provenancePolicy     : metadata.provenancePolicy,
                     distance,

--- a/test/playwright/unit/ai/services/memory-core/SessionService.buildChatModel.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/SessionService.buildChatModel.spec.mjs
@@ -157,7 +157,6 @@ test.describe('SessionService summary provenance (#10292)', () => {
     let GraphService;
     let RequestContextService;
     let SessionService;
-    let resolveSummarySourceProvenance;
 
     let originalIngestAntigravityArtifacts;
     let originalLinkNodes;
@@ -173,10 +172,9 @@ test.describe('SessionService summary provenance (#10292)', () => {
     test.beforeAll(async () => {
         const mod = await import('../../../../../../ai/services/memory-core/SessionService.mjs');
 
-        SessionService                 = mod.default;
-        resolveSummarySourceProvenance = mod.resolveSummarySourceProvenance;
-        GraphService                   = (await import('../../../../../../ai/services/memory-core/GraphService.mjs')).default;
-        RequestContextService          = (await import('../../../../../../ai/mcp/server/shared/services/RequestContextService.mjs')).default;
+        SessionService        = mod.default;
+        GraphService          = (await import('../../../../../../ai/services/memory-core/GraphService.mjs')).default;
+        RequestContextService = (await import('../../../../../../ai/mcp/server/shared/services/RequestContextService.mjs')).default;
     });
 
     test.beforeEach(() => {
@@ -259,7 +257,7 @@ test.describe('SessionService summary provenance (#10292)', () => {
     });
 
     test('resolveSummarySourceProvenance uses the most restrictive source tier', () => {
-        const result = resolveSummarySourceProvenance([
+        const result = SessionService.constructor.resolveSummarySourceProvenance([
             {agentIdentity: '@tobiu'},
             {agentIdentity: '@neo-gpt'},
             {agentIdentity: '@external-contributor'},

--- a/test/playwright/unit/ai/services/memory-core/SessionService.buildChatModel.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/SessionService.buildChatModel.spec.mjs
@@ -152,3 +152,161 @@ test.describe('SessionService.buildChatModel (#11965 Sub-2)', () => {
         expect(factoryCalls).toEqual([{apiKey: 'gem-key', modelName: 'gemini-pro'}]);
     });
 });
+
+test.describe('SessionService summary provenance (#10292)', () => {
+    let GraphService;
+    let RequestContextService;
+    let SessionService;
+    let resolveSummarySourceProvenance;
+
+    let originalIngestAntigravityArtifacts;
+    let originalLinkNodes;
+    let originalMemoryCollection;
+    let originalModel;
+    let originalSessionsCollection;
+    let originalUpsertNode;
+
+    let linkNodesCalls;
+    let sessionUpserts;
+    let upsertNodeCalls;
+
+    test.beforeAll(async () => {
+        const mod = await import('../../../../../../ai/services/memory-core/SessionService.mjs');
+
+        SessionService                 = mod.default;
+        resolveSummarySourceProvenance = mod.resolveSummarySourceProvenance;
+        GraphService                   = (await import('../../../../../../ai/services/memory-core/GraphService.mjs')).default;
+        RequestContextService          = (await import('../../../../../../ai/mcp/server/shared/services/RequestContextService.mjs')).default;
+    });
+
+    test.beforeEach(() => {
+        linkNodesCalls = [];
+        sessionUpserts = [];
+        upsertNodeCalls = [];
+
+        originalIngestAntigravityArtifacts = SessionService.ingestAntigravityArtifacts;
+        originalMemoryCollection           = SessionService.memoryCollection;
+        originalModel                      = SessionService.model;
+        originalSessionsCollection         = SessionService.sessionsCollection;
+        originalLinkNodes                  = GraphService.linkNodes;
+        originalUpsertNode                 = GraphService.upsertNode;
+
+        SessionService.ingestAntigravityArtifacts = async () => {};
+        SessionService.memoryCollection = {
+            async get() {
+                return {
+                    ids      : ['memory-1', 'memory-2', 'memory-3'],
+                    documents: [
+                        'User Prompt: work on #10292',
+                        'Agent Thought: peer-trusted source',
+                        'Agent Response: unclassified source'
+                    ],
+                    metadatas: [{
+                        timestamp    : 10,
+                        agent        : 'neo-gpt',
+                        model        : 'gpt-5.5',
+                        agentIdentity: '@neo-gpt'
+                    }, {
+                        timestamp    : 20,
+                        agent        : 'external-contributor',
+                        model        : 'unknown',
+                        agentIdentity: '@external-contributor'
+                    }, {
+                        timestamp: 30
+                    }]
+                };
+            }
+        };
+        SessionService.sessionsCollection = {
+            async upsert(payload) {
+                sessionUpserts.push(payload);
+            }
+        };
+        SessionService.model = {
+            async generateContent() {
+                return {
+                    response: {
+                        text: () => JSON.stringify({
+                            summary     : 'Summary mentions #10292.',
+                            title       : 'Summary Provenance',
+                            category    : 'feature',
+                            quality     : 80,
+                            productivity: 75,
+                            impact      : 70,
+                            complexity  : 55,
+                            technologies: ['memory-core']
+                        })
+                    }
+                };
+            }
+        };
+
+        GraphService.linkNodes = (...args) => {
+            linkNodesCalls.push(args);
+        };
+        GraphService.upsertNode = (node) => {
+            upsertNodeCalls.push(node);
+        };
+    });
+
+    test.afterEach(() => {
+        SessionService.ingestAntigravityArtifacts = originalIngestAntigravityArtifacts;
+        SessionService.memoryCollection           = originalMemoryCollection;
+        SessionService.model                      = originalModel;
+        SessionService.sessionsCollection         = originalSessionsCollection;
+        GraphService.linkNodes                    = originalLinkNodes;
+        GraphService.upsertNode                   = originalUpsertNode;
+    });
+
+    test('resolveSummarySourceProvenance uses the most restrictive source tier', () => {
+        const result = resolveSummarySourceProvenance([
+            {agentIdentity: '@tobiu'},
+            {agentIdentity: '@neo-gpt'},
+            {agentIdentity: '@external-contributor'},
+            {}
+        ]);
+
+        expect(result.sourceAgentIdentities).toEqual(['@tobiu', '@neo-gpt', '@external-contributor']);
+        expect(result.sourceTrustTier).toBe('unclassified');
+        expect(result.unclassifiedSourceCount).toBe(2);
+    });
+
+    test('summarizeSession stamps summary provenance without laundering source trust', async () => {
+        const result = await RequestContextService.run({
+            userId             : 'tobiu',
+            username           : 'Tobias',
+            agentIdentityNodeId: '@tobiu',
+            source             : 'oidc'
+        }, () => SessionService.summarizeSession('summary-provenance-session'));
+
+        expect(result.summaryId).toBe('summary_summary-provenance-session');
+
+        expect(sessionUpserts).toHaveLength(1);
+        const metadata = sessionUpserts[0].metadatas[0];
+
+        expect(metadata.sourceAgentIdentities).toBe('@neo-gpt,@external-contributor');
+        expect(metadata.sourceTrustTier).toBe('unclassified');
+        expect(metadata.provenancePolicy).toBe('most-restrictive-source');
+        expect(metadata.unclassifiedSourceCount).toBe(2);
+
+        const summaryNode = upsertNodeCalls.find(node => node.id === result.summaryId);
+        expect(summaryNode.properties).toMatchObject({
+            sourceAgentIdentities: ['@neo-gpt', '@external-contributor'],
+            sourceTrustTier      : 'unclassified',
+            provenancePolicy     : 'most-restrictive-source'
+        });
+
+        const authoredByEdges = linkNodesCalls.filter(([, , relationship]) => relationship === 'AUTHORED_BY');
+        expect(authoredByEdges).toHaveLength(1);
+        expect(authoredByEdges[0][0]).toBe(result.summaryId);
+        expect(authoredByEdges[0][1]).toBe('@neo-gpt');
+        expect(authoredByEdges[0][4]).toMatchObject({
+            userId          : '@neo-gpt',
+            sharedEntity    : true,
+            provenancePolicy: 'most-restrictive-source'
+        });
+
+        expect(authoredByEdges.some(([, target]) => target === '@tobiu')).toBe(false);
+        expect(authoredByEdges.some(([, target]) => target === '@external-contributor')).toBe(false);
+    });
+});


### PR DESCRIPTION
Authored by GPT-5.5 (Codex Desktop). Session 019e5bac-15f3-7830-a59c-72772c757f9a.

FAIR-band: in-band [12/30 — current author count over last 30 merged]

Refs #10292

Adds the second #10292 provenance slice for derived session summaries. `SessionService.summarizeSession()` now derives summary provenance from source memory metadata, carries the most restrictive source trust tier forward, and emits summary `AUTHORED_BY` graph edges only for known seeded source identities. `SummaryService` list/query results expose the provenance metadata when present.

Evidence: L2 (syntax checks + focused Playwright unit tests for summary provenance and SummaryService tenant read surfaces) → L2 required (slice-2 summary write metadata and result projection are service-level logic). Residual: `minTrustTier` query filters, `get_context_frontier` weighting, and durable forward-only migration docs [#10292].

## Deltas from ticket

- Current source writes summaries in `SessionService.summarizeSession()`, not `SummaryService`; the implementation lands at the real write boundary and keeps `SummaryService` read-only.
- Summary provenance uses `provenancePolicy: most-restrictive-source` so derived summaries do not inherit the summarizer's higher trust tier when source memories are lower-trust or unknown.
- Unknown / pre-provenance source memories force `sourceTrustTier: unclassified`; unknown source identities remain Chroma metadata and do not receive graph `AUTHORED_BY` edges.

## Test Evidence

- `node --check ai/services/memory-core/SessionService.mjs`
- `node --check ai/services/memory-core/SummaryService.mjs`
- `npm run test-unit -- test/playwright/unit/ai/services/memory-core/SessionService.buildChatModel.spec.mjs` — 8 passed
- `npm run test-unit -- test/playwright/unit/ai/services/memory-core/SummaryService.TenantIsolation.spec.mjs` — 14 passed
- `git diff --check origin/dev...HEAD`
- `git log origin/dev..HEAD --format='%h%x09%s%n%b'` — one commit, no magic close keyword

## Post-Merge Validation

- [ ] Summarize a mixed-provenance session in a live Memory Core deployment and verify `sourceTrustTier`, `sourceAgentIdentities`, and `provenancePolicy` are present on the summary row.
- [ ] Keep #10292 open for query-path `minTrustTier`, `get_context_frontier` trust weighting, and durable forward-only migration documentation.

## Commits

- `ee8a95e00` — `feat(memory-core): stamp summary provenance (#10292)`
