### PR TITLE
feat(memory-core): filter raw memories by trust tier (#10292)

### DIFF
--- a/ai/mcp/server/memory-core/openapi.yaml
+++ b/ai/mcp/server/memory-core/openapi.yaml
@@ -1878,6 +1878,15 @@ components:
           type: string
           nullable: true
           example: "gemini-3.1-pro"
+        agentIdentity:
+          type: string
+          nullable: true
+          description: "AgentIdentity node id that authored the memory when provenance is available."
+          example: "@neo-gpt"
+        trustTier:
+          type: string
+          enum: [system, repo-trusted, owner, self, peer-trusted, internal-authored, external, unclassified]
+          description: "#10292 content-provenance trust tier resolved from the memory's AgentIdentity."
 
     QueryMemoriesRequest:
       type: object
@@ -1901,6 +1910,10 @@ components:
           type: string
           enum: [private, team, legacy]
           description: Optional override for the memory sharing tenant isolation scope.
+        minTrustTier:
+          type: string
+          enum: [system, repo-trusted, owner, self, peer-trusted, internal-authored, external, unclassified]
+          description: Optional minimum accepted #10292 provenance trust tier. Results authored by lower-trust or unclassified identities are excluded.
 
     QueryMemoriesResponse:
       type: object

--- a/ai/services/memory-core/MemoryService.mjs
+++ b/ai/services/memory-core/MemoryService.mjs
@@ -8,10 +8,6 @@ import aiConfig              from '../../mcp/server/memory-core/config.mjs';
 import RequestContextService, {SHARED_USER_ID, normalizeUserId} from '../../mcp/server/shared/services/RequestContextService.mjs';
 import {IDENTITIES, TRUST_TIERS, TRUST_TIER_ORDER} from '../../graph/identityRoots.mjs';
 
-const
-    identityTrustTiers = new Map(IDENTITIES.map(identity => [identity.id, identity.properties?.trustTier || TRUST_TIERS.UNCLASSIFIED])),
-    trustTierRanks     = new Map(TRUST_TIER_ORDER.map((tier, index) => [tier, index]));
-
 /**
  * Computes a lightweight inbox snapshot for the bound AgentIdentity to piggyback on every
  * `add_memory` response — the per-turn **mailbox delta signal**.
@@ -148,30 +144,6 @@ function buildMailboxDelta() {
 }
 
 /**
- * @summary Resolves a raw memory row's #10292 trust tier from its AgentIdentity metadata.
- * @param {Object} metadata Chroma metadata row.
- * @returns {String} Trust tier, or `unclassified` when no seeded identity matches.
- */
-function resolveMemoryTrustTier(metadata) {
-    return identityTrustTiers.get(metadata?.agentIdentity) || TRUST_TIERS.UNCLASSIFIED;
-}
-
-/**
- * @summary Returns true when a row satisfies the optional minimum trust threshold.
- * @param {Object} metadata Chroma metadata row.
- * @param {String|undefined} minTrustTier Optional minimum accepted trust tier.
- * @returns {Boolean}
- */
-function matchesMinTrustTier(metadata, minTrustTier) {
-    if (!minTrustTier) {
-        return true;
-    }
-
-    return trustTierRanks.get(resolveMemoryTrustTier(metadata)) <= trustTierRanks.get(minTrustTier);
-}
-
-
-/**
  * @summary Service for handling adding, listing, and querying agent memories.
  *
  * This service acts as the primary interface for interacting with the 'memories' collection in ChromaDB.
@@ -205,6 +177,33 @@ class MemoryService extends Base {
          * @protected
          */
         singleton: true
+    }
+
+    static identityTrustTiers = new Map(IDENTITIES.map(identity => [identity.id, identity.properties?.trustTier || TRUST_TIERS.UNCLASSIFIED]))
+
+    static trustTierRanks = new Map(TRUST_TIER_ORDER.map((tier, index) => [tier, index]))
+
+    /**
+     * @summary Resolves a raw memory row's #10292 trust tier from its AgentIdentity metadata.
+     * @param {Object} metadata Chroma metadata row.
+     * @returns {String} Trust tier, or `unclassified` when no seeded identity matches.
+     */
+    static resolveMemoryTrustTier(metadata) {
+        return this.identityTrustTiers.get(metadata?.agentIdentity) || TRUST_TIERS.UNCLASSIFIED;
+    }
+
+    /**
+     * @summary Returns true when a row satisfies the optional minimum trust threshold.
+     * @param {Object} metadata Chroma metadata row.
+     * @param {String|undefined} minTrustTier Optional minimum accepted trust tier.
+     * @returns {Boolean}
+     */
+    static matchesMinTrustTier(metadata, minTrustTier) {
+        if (!minTrustTier) {
+            return true;
+        }
+
+        return this.trustTierRanks.get(this.resolveMemoryTrustTier(metadata)) <= this.trustTierRanks.get(minTrustTier);
     }
 
     /**
@@ -436,7 +435,7 @@ class MemoryService extends Base {
      */
     async queryMemories({query, nResults, sessionId, memorySharing, minTrustTier}) {
         try {
-            if (minTrustTier && !trustTierRanks.has(minTrustTier)) {
+            if (minTrustTier && !this.constructor.trustTierRanks.has(minTrustTier)) {
                 return {
                     error  : 'Invalid minTrustTier',
                     message: `minTrustTier must be one of: ${TRUST_TIER_ORDER.join(', ')}`,
@@ -494,7 +493,7 @@ class MemoryService extends Base {
                 for (let i = 0; i < metadatas.length; i++) {
                     const metaUserId = metadatas[i]?.userId;
                     const tenantMatch = !userId || policy !== 'legacy' || !metaUserId || metaUserId === userId || metaUserId === SHARED_USER_ID;
-                    const trustMatch  = matchesMinTrustTier(metadatas[i], minTrustTier);
+                    const trustMatch  = this.constructor.matchesMinTrustTier(metadatas[i], minTrustTier);
 
                     if (tenantMatch && trustMatch) {
                         filteredIndices.push(i);
@@ -511,7 +510,7 @@ class MemoryService extends Base {
                 const distance       = Number(distances[index] ?? 0);
                 const relevanceScore = Number((1 / (1 + distance)).toFixed(6));
                 const agentIdentity  = metadata.agentIdentity || null;
-                const trustTier      = resolveMemoryTrustTier(metadata);
+                const trustTier      = this.constructor.resolveMemoryTrustTier(metadata);
 
                 return {
                     id,

--- a/ai/services/memory-core/MemoryService.mjs
+++ b/ai/services/memory-core/MemoryService.mjs
@@ -6,6 +6,11 @@ import logger                from '../../mcp/server/memory-core/logger.mjs';
 import SessionService        from './SessionService.mjs';
 import aiConfig              from '../../mcp/server/memory-core/config.mjs';
 import RequestContextService, {SHARED_USER_ID, normalizeUserId} from '../../mcp/server/shared/services/RequestContextService.mjs';
+import {IDENTITIES, TRUST_TIERS, TRUST_TIER_ORDER} from '../../graph/identityRoots.mjs';
+
+const
+    identityTrustTiers = new Map(IDENTITIES.map(identity => [identity.id, identity.properties?.trustTier || TRUST_TIERS.UNCLASSIFIED])),
+    trustTierRanks     = new Map(TRUST_TIER_ORDER.map((tier, index) => [tier, index]));
 
 /**
  * Computes a lightweight inbox snapshot for the bound AgentIdentity to piggyback on every
@@ -140,6 +145,29 @@ function buildMailboxDelta() {
         logger.warn('[MemoryService] Mailbox delta query failed (non-fatal, memory write unaffected):', error.message);
         return null;
     }
+}
+
+/**
+ * @summary Resolves a raw memory row's #10292 trust tier from its AgentIdentity metadata.
+ * @param {Object} metadata Chroma metadata row.
+ * @returns {String} Trust tier, or `unclassified` when no seeded identity matches.
+ */
+function resolveMemoryTrustTier(metadata) {
+    return identityTrustTiers.get(metadata?.agentIdentity) || TRUST_TIERS.UNCLASSIFIED;
+}
+
+/**
+ * @summary Returns true when a row satisfies the optional minimum trust threshold.
+ * @param {Object} metadata Chroma metadata row.
+ * @param {String|undefined} minTrustTier Optional minimum accepted trust tier.
+ * @returns {Boolean}
+ */
+function matchesMinTrustTier(metadata, minTrustTier) {
+    if (!minTrustTier) {
+        return true;
+    }
+
+    return trustTierRanks.get(resolveMemoryTrustTier(metadata)) <= trustTierRanks.get(minTrustTier);
 }
 
 
@@ -403,10 +431,19 @@ class MemoryService extends Base {
      * @param {Number} options.nResults      The number of results to return.
      * @param {String} [options.sessionId]   Optional session ID to filter results.
      * @param {String} [options.memorySharing] Optional override for tenant isolation policy.
+     * @param {String} [options.minTrustTier] Optional #10292 minimum accepted trust tier.
      * @returns {Promise<{query: string, count: number, results: Object[]}>}
      */
-    async queryMemories({query, nResults, sessionId, memorySharing}) {
+    async queryMemories({query, nResults, sessionId, memorySharing, minTrustTier}) {
         try {
+            if (minTrustTier && !trustTierRanks.has(minTrustTier)) {
+                return {
+                    error  : 'Invalid minTrustTier',
+                    message: `minTrustTier must be one of: ${TRUST_TIER_ORDER.join(', ')}`,
+                    code   : 'MEMORY_QUERY_INVALID_TRUST_TIER'
+                };
+            }
+
             const collection = await StorageRouter.getMemoryCollection();
             const queryArgs = {
                 queryTexts: [query],
@@ -434,7 +471,7 @@ class MemoryService extends Base {
                 }
             }
 
-            if (tenantScope === null && userId && policy === 'legacy') {
+            if ((tenantScope === null && userId && policy === 'legacy') || minTrustTier) {
                 queryArgs.nResults = nResults * 5;
             }
 
@@ -452,11 +489,14 @@ class MemoryService extends Base {
             let distances = searchResult.distances?.[0] || [];
             let metadatas = searchResult.metadatas?.[0] || [];
 
-            if (userId && policy === 'legacy') {
+            if ((userId && policy === 'legacy') || minTrustTier) {
                 const filteredIndices = [];
                 for (let i = 0; i < metadatas.length; i++) {
                     const metaUserId = metadatas[i]?.userId;
-                    if (!metaUserId || metaUserId === userId || metaUserId === SHARED_USER_ID) {
+                    const tenantMatch = !userId || policy !== 'legacy' || !metaUserId || metaUserId === userId || metaUserId === SHARED_USER_ID;
+                    const trustMatch  = matchesMinTrustTier(metadatas[i], minTrustTier);
+
+                    if (tenantMatch && trustMatch) {
                         filteredIndices.push(i);
                         if (filteredIndices.length === nResults) break;
                     }
@@ -470,6 +510,8 @@ class MemoryService extends Base {
                 const metadata       = metadatas[index] || {};
                 const distance       = Number(distances[index] ?? 0);
                 const relevanceScore = Number((1 / (1 + distance)).toFixed(6));
+                const agentIdentity  = metadata.agentIdentity || null;
+                const trustTier      = resolveMemoryTrustTier(metadata);
 
                 return {
                     id,
@@ -479,6 +521,8 @@ class MemoryService extends Base {
                     thought  : metadata.thought,
                     response : metadata.response,
                     type     : metadata.type,
+                    agentIdentity,
+                    trustTier,
                     distance,
                     relevanceScore
                 };

--- a/test/playwright/unit/ai/services/memory-core/MemoryService.TenantIsolation.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/MemoryService.TenantIsolation.spec.mjs
@@ -382,3 +382,84 @@ test.describe('MemoryService — memorySharing policy (#10010)', () => {
         expect(queryCall.where).toBeUndefined();
     });
 });
+
+test.describe('MemoryService — raw-memory trust-tier filtering (#10292)', () => {
+    let spyCollection;
+    let originalGetMemoryCollection;
+
+    test.beforeEach(() => {
+        spyCollection                     = createSpyCollection();
+        originalGetMemoryCollection       = StorageRouter.getMemoryCollection;
+        StorageRouter.getMemoryCollection = async () => spyCollection;
+    });
+
+    test.afterEach(() => {
+        StorageRouter.getMemoryCollection = originalGetMemoryCollection;
+    });
+
+    test('queryMemories filters by minTrustTier and returns provenance fields', async () => {
+        spyCollection.rows.set('m-owner', {
+            id: 'm-owner',
+            metadata: {
+                agentIdentity: '@tobiu',
+                prompt       : 'owner',
+                sessionId    : 's',
+                timestamp    : 100
+            },
+            document: 'owner'
+        });
+        spyCollection.rows.set('m-peer', {
+            id: 'm-peer',
+            metadata: {
+                agentIdentity: '@neo-gpt',
+                prompt       : 'peer',
+                sessionId    : 's',
+                timestamp    : 200
+            },
+            document: 'peer'
+        });
+        spyCollection.rows.set('m-unclassified', {
+            id: 'm-unclassified',
+            metadata: {
+                prompt   : 'legacy',
+                sessionId: 's',
+                timestamp: 300
+            },
+            document: 'legacy'
+        });
+
+        const view = await MemoryService.queryMemories({
+            query       : 'anything',
+            nResults    : 3,
+            minTrustTier: 'peer-trusted'
+        });
+
+        expect(view.count).toBe(2);
+        expect(view.results.map(result => result.prompt).sort()).toEqual(['owner', 'peer']);
+        expect(view.results.find(result => result.prompt === 'owner')).toMatchObject({
+            agentIdentity: '@tobiu',
+            trustTier    : 'owner'
+        });
+        expect(view.results.find(result => result.prompt === 'peer')).toMatchObject({
+            agentIdentity: '@neo-gpt',
+            trustTier    : 'peer-trusted'
+        });
+
+        const queryCall = spyCollection.queryCalls.at(-1);
+        expect(queryCall.nResults).toBe(15);
+    });
+
+    test('queryMemories rejects unknown minTrustTier before querying storage', async () => {
+        const view = await MemoryService.queryMemories({
+            query       : 'anything',
+            nResults    : 3,
+            minTrustTier: 'trusted-ish'
+        });
+
+        expect(view).toMatchObject({
+            error: 'Invalid minTrustTier',
+            code : 'MEMORY_QUERY_INVALID_TRUST_TIER'
+        });
+        expect(spyCollection.queryCalls).toHaveLength(0);
+    });
+});


### PR DESCRIPTION
Authored by GPT-5.5 (Codex Desktop). Session 019e5bac-15f3-7830-a59c-72772c757f9a.

FAIR-band: in-band [12/30 — current author count over last 30 merged]

Refs #10292

Adds the raw-memory query half of #10292 `minTrustTier` filtering. `query_raw_memories` now accepts an optional `minTrustTier`, resolves each row's trust tier from the seeded AgentIdentity taxonomy, post-filters below-threshold or unclassified rows, and returns `agentIdentity` / `trustTier` in raw-memory search results.

Evidence: L2 (focused Playwright unit coverage + syntax/diff hygiene) → L2 required (raw-memory query contract and service filtering are unit-testable service logic). Residual: `query_summaries` minTrustTier, `get_context_frontier` trust weighting, and durable forward-only migration docs [#10292].

## Deltas from ticket

- This is a narrow raw-memory query slice only. Summary query filtering waits for the summary-provenance PR (#11979) to land because summary filtering needs `sourceTrustTier` on summary rows.
- Unknown or unseeded `agentIdentity` values resolve to `unclassified`, preserving the safe default from #10292.
- Invalid `minTrustTier` values return `MEMORY_QUERY_INVALID_TRUST_TIER` before storage is queried.

## Test Evidence

- `node --check ai/services/memory-core/MemoryService.mjs`
- `npm run test-unit -- test/playwright/unit/ai/services/memory-core/MemoryService.TenantIsolation.spec.mjs` — 15 passed
- `git diff --check origin/dev...HEAD`
- `git log origin/dev..HEAD --format='%h%x09%s%n%b'` — one commit, no magic close keyword

## Post-Merge Validation

- [ ] Verify `query_raw_memories({query, minTrustTier: 'peer-trusted'})` excludes unclassified/pre-provenance rows in a live Memory Core deployment.
- [ ] Keep #10292 open for summary query filtering, context-frontier weighting, and durable forward-only migration documentation.

## Commits

- `8901b83fe` — `feat(memory-core): filter raw memories by trust tier (#10292)`
