### PR TITLE
feat(memory-core): surface Codex wake target readiness (#11872)

### DIFF
--- a/ai/services/memory-core/HealthService.mjs
+++ b/ai/services/memory-core/HealthService.mjs
@@ -53,6 +53,61 @@ function heartbeatLivenessStaleMs() {
 }
 
 /**
+ * @summary Normalizes an AgentIdentity handle for wake-readiness observability.
+ *
+ * Healthcheck projections should expose the same canonical `@<identity>` shape
+ * operators see in A2A and wake-subscription state, while staying independent
+ * from the Orchestrator class boot chain.
+ * @param {String|null|undefined} value
+ * @returns {String|null}
+ */
+function normalizeAgentHandle(value) {
+    if (!value) return null;
+    const trimmed = String(value).trim();
+    if (!trimmed) return null;
+    return trimmed.startsWith('@') ? trimmed : `@${trimmed}`;
+}
+
+/**
+ * @summary Projects swarm-heartbeat target config into the wake health block.
+ *
+ * This is the operator-facing counterpart to
+ * `SwarmHeartbeatService.getPulseIdentities()`: it does not query live
+ * subscriptions, but it makes the effective target-selection mode visible so a
+ * self-only Orchestrator heartbeat cannot look "healthy" while never being able
+ * to route Codex nightshift wake checks.
+ *
+ * @param {Object} [cfg=aiConfig] aiConfig-shaped input
+ * @param {Object} [env=process.env] Environment source for deterministic tests
+ * @returns {{targetSource: String, targetMode: String, explicitTargets: String[],
+ *     selfIdentity: String|null, codexEligibleByTargetConfig: Boolean}}
+ */
+export function buildWakeTargetConfigBlock(cfg = aiConfig, env = process.env) {
+    const rawTargets = env.NEO_ORCHESTRATOR_SWARM_HEARTBEAT_TARGETS || '';
+    const explicitTargets = rawTargets
+        .split(',')
+        .map(normalizeAgentHandle)
+        .filter(Boolean);
+
+    const targetSource = env.NEO_ORCHESTRATOR_SWARM_HEARTBEAT_TARGET_SOURCE ||
+        cfg.orchestrator?.swarmHeartbeat?.targetSource ||
+        'self';
+    const selfIdentity = normalizeAgentHandle(env.NEO_AGENT_IDENTITY);
+    const targetMode   = explicitTargets.length > 0 ? 'explicit-targets' : targetSource;
+
+    return {
+        targetSource,
+        targetMode,
+        explicitTargets,
+        selfIdentity,
+        codexEligibleByTargetConfig: explicitTargets.includes('@neo-gpt') ||
+            targetSource === 'active-subscribers' ||
+            targetSource === 'active-local-team' ||
+            (targetSource === 'self' && selfIdentity === '@neo-gpt')
+    };
+}
+
+/**
  * @summary Projects the stdio identity state into the healthcheck-payload shape.
  *
  * Pure function: takes the cached stdioIdentity context (or null) and returns the
@@ -357,6 +412,10 @@ export function buildAuthProviderBlock(cfg) {
  * - `lastPulseAt`: ISO timestamp of the liveness file mtime, or `null` if absent.
  * - `secondsSinceLastPulse`: derived seconds since last pulse. Surfaces "alive but stalled" when
  *   `daemonRunning` is `false` but a previous mtime exists.
+ * - `targetSource` / `targetMode` / `explicitTargets` / `selfIdentity` /
+ *   `codexEligibleByTargetConfig`: effective Orchestrator target-selection
+ *   config. These fields prevent a self-only heartbeat from masquerading as
+ *   Codex nightshift-ready merely because the liveness file is fresh.
  *
  * **Liveness signal substrate:** the heartbeat concurrency lock at
  * `.neo-ai-data/heartbeat-concurrency.lock` is touched only when expensive Agent OS work runs
@@ -373,7 +432,8 @@ export function buildAuthProviderBlock(cfg) {
  * @param {Number|Date} [now=Date.now()] Time source for deterministic tests
  * @returns {Promise<{gateState: String, gateReason: String, gateTrippedAt: String|null,
  *     gateTrippedBy: String|null, daemonRunning: Boolean, lastPulseAt: String|null,
- *     secondsSinceLastPulse: Number|null}>}
+ *     secondsSinceLastPulse: Number|null, targetSource: String, targetMode: String,
+ *     explicitTargets: String[], selfIdentity: String|null, codexEligibleByTargetConfig: Boolean}>}
  * @see ai/scripts/lifecycle/wakeSafetyGate.mjs
  * @see ai/daemons/SwarmHeartbeatService.mjs — the swarm-heartbeat lane that touches the liveness file
  * @see learn/agentos/wake-substrate/PersistentProcessManagement.md
@@ -423,7 +483,7 @@ export async function buildWakeFeaturesBlock(now = Date.now()) {
         // Other errors (permission, etc.) also degrade gracefully to defaults.
     }
 
-    return {...gateBlock, ...livenessBlock};
+    return {...gateBlock, ...livenessBlock, ...buildWakeTargetConfigBlock()};
 }
 
 /**

--- a/ai/services/memory-core/HealthService.mjs
+++ b/ai/services/memory-core/HealthService.mjs
@@ -53,61 +53,6 @@ function heartbeatLivenessStaleMs() {
 }
 
 /**
- * @summary Normalizes an AgentIdentity handle for wake-readiness observability.
- *
- * Healthcheck projections should expose the same canonical `@<identity>` shape
- * operators see in A2A and wake-subscription state, while staying independent
- * from the Orchestrator class boot chain.
- * @param {String|null|undefined} value
- * @returns {String|null}
- */
-function normalizeAgentHandle(value) {
-    if (!value) return null;
-    const trimmed = String(value).trim();
-    if (!trimmed) return null;
-    return trimmed.startsWith('@') ? trimmed : `@${trimmed}`;
-}
-
-/**
- * @summary Projects swarm-heartbeat target config into the wake health block.
- *
- * This is the operator-facing counterpart to
- * `SwarmHeartbeatService.getPulseIdentities()`: it does not query live
- * subscriptions, but it makes the effective target-selection mode visible so a
- * self-only Orchestrator heartbeat cannot look "healthy" while never being able
- * to route Codex nightshift wake checks.
- *
- * @param {Object} [cfg=aiConfig] aiConfig-shaped input
- * @param {Object} [env=process.env] Environment source for deterministic tests
- * @returns {{targetSource: String, targetMode: String, explicitTargets: String[],
- *     selfIdentity: String|null, codexEligibleByTargetConfig: Boolean}}
- */
-export function buildWakeTargetConfigBlock(cfg = aiConfig, env = process.env) {
-    const rawTargets = env.NEO_ORCHESTRATOR_SWARM_HEARTBEAT_TARGETS || '';
-    const explicitTargets = rawTargets
-        .split(',')
-        .map(normalizeAgentHandle)
-        .filter(Boolean);
-
-    const targetSource = env.NEO_ORCHESTRATOR_SWARM_HEARTBEAT_TARGET_SOURCE ||
-        cfg.orchestrator?.swarmHeartbeat?.targetSource ||
-        'self';
-    const selfIdentity = normalizeAgentHandle(env.NEO_AGENT_IDENTITY);
-    const targetMode   = explicitTargets.length > 0 ? 'explicit-targets' : targetSource;
-
-    return {
-        targetSource,
-        targetMode,
-        explicitTargets,
-        selfIdentity,
-        codexEligibleByTargetConfig: explicitTargets.includes('@neo-gpt') ||
-            targetSource === 'active-subscribers' ||
-            targetSource === 'active-local-team' ||
-            (targetSource === 'self' && selfIdentity === '@neo-gpt')
-    };
-}
-
-/**
  * @summary Projects the stdio identity state into the healthcheck-payload shape.
  *
  * Pure function: takes the cached stdioIdentity context (or null) and returns the
@@ -412,10 +357,10 @@ export function buildAuthProviderBlock(cfg) {
  * - `lastPulseAt`: ISO timestamp of the liveness file mtime, or `null` if absent.
  * - `secondsSinceLastPulse`: derived seconds since last pulse. Surfaces "alive but stalled" when
  *   `daemonRunning` is `false` but a previous mtime exists.
- * - `targetSource` / `targetMode` / `explicitTargets` / `selfIdentity` /
- *   `codexEligibleByTargetConfig`: effective Orchestrator target-selection
- *   config. These fields prevent a self-only heartbeat from masquerading as
- *   Codex nightshift-ready merely because the liveness file is fresh.
+ * - `targetSource` / `targetMode` / `explicitTargets` / `selfIdentity`: effective
+ *   Orchestrator target-selection config. These fields expose config shape
+ *   without claiming route eligibility; callers must pair them with live
+ *   subscription evidence for identity-specific readiness.
  *
  * **Liveness signal substrate:** the heartbeat concurrency lock at
  * `.neo-ai-data/heartbeat-concurrency.lock` is touched only when expensive Agent OS work runs
@@ -433,7 +378,7 @@ export function buildAuthProviderBlock(cfg) {
  * @returns {Promise<{gateState: String, gateReason: String, gateTrippedAt: String|null,
  *     gateTrippedBy: String|null, daemonRunning: Boolean, lastPulseAt: String|null,
  *     secondsSinceLastPulse: Number|null, targetSource: String, targetMode: String,
- *     explicitTargets: String[], selfIdentity: String|null, codexEligibleByTargetConfig: Boolean}>}
+ *     explicitTargets: String[], selfIdentity: String|null}>}
  * @see ai/scripts/lifecycle/wakeSafetyGate.mjs
  * @see ai/daemons/SwarmHeartbeatService.mjs — the swarm-heartbeat lane that touches the liveness file
  * @see learn/agentos/wake-substrate/PersistentProcessManagement.md
@@ -483,7 +428,7 @@ export async function buildWakeFeaturesBlock(now = Date.now()) {
         // Other errors (permission, etc.) also degrade gracefully to defaults.
     }
 
-    return {...gateBlock, ...livenessBlock, ...buildWakeTargetConfigBlock()};
+    return {...gateBlock, ...livenessBlock, ...HealthService.buildWakeTargetConfigBlock()};
 }
 
 /**
@@ -659,6 +604,59 @@ export function buildChromaMigrationStats(metadatas, {summaryCollection = false}
 }
 
 class HealthService extends Base {
+    /**
+     * @summary Normalizes an AgentIdentity handle for wake-readiness observability.
+     *
+     * Healthcheck projections expose the same canonical `@<identity>` shape operators
+     * see in A2A and wake-subscription state while staying independent from the
+     * Orchestrator class boot chain.
+     * @param {String|null|undefined} value
+     * @returns {String|null}
+     */
+    static normalizeAgentHandle(value) {
+        if (!value) return null;
+
+        const trimmed = String(value).trim();
+
+        if (!trimmed) return null;
+
+        return trimmed.startsWith('@') ? trimmed : `@${trimmed}`;
+    }
+
+    /**
+     * @summary Projects swarm-heartbeat target config into the wake health block.
+     *
+     * This is the operator-facing counterpart to
+     * `SwarmHeartbeatService.getPulseIdentities()`: it does not query live
+     * subscriptions or make identity-specific readiness claims. Instead, it makes
+     * the effective target-selection mode visible so callers can combine it with
+     * live wake-subscription evidence.
+     *
+     * @param {Object} [cfg=aiConfig] aiConfig-shaped input
+     * @param {Object} [env=process.env] Environment source for deterministic tests
+     * @returns {{targetSource: String, targetMode: String, explicitTargets: String[],
+     *     selfIdentity: String|null}}
+     */
+    static buildWakeTargetConfigBlock(cfg = aiConfig, env = process.env) {
+        const rawTargets = env.NEO_ORCHESTRATOR_SWARM_HEARTBEAT_TARGETS || '',
+              explicitTargets = rawTargets
+                  .split(',')
+                  .map(value => this.normalizeAgentHandle(value))
+                  .filter(Boolean),
+              targetSource = env.NEO_ORCHESTRATOR_SWARM_HEARTBEAT_TARGET_SOURCE ||
+                  cfg.orchestrator?.swarmHeartbeat?.targetSource ||
+                  'self',
+              selfIdentity = this.normalizeAgentHandle(env.NEO_AGENT_IDENTITY),
+              targetMode   = explicitTargets.length > 0 ? 'explicit-targets' : targetSource;
+
+        return {
+            targetSource,
+            targetMode,
+            explicitTargets,
+            selfIdentity
+        };
+    }
+
     static config = {
         /**
          * @member {String} className='Neo.ai.services.memory-core.HealthService'

--- a/test/playwright/unit/ai/services/memory-core/HealthService.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/HealthService.spec.mjs
@@ -709,11 +709,14 @@ test.describe('HealthService #10844 — buildBackupStateBlock', () => {
  */
 test.describe('HealthService #10783 — buildWakeFeaturesBlock', () => {
     let buildWakeFeaturesBlock;
+    let buildWakeTargetConfigBlock;
+    let originalWakeEnv;
     let tmpDir;
 
     test.beforeAll(async () => {
         const mod = await import('../../../../../../ai/services/memory-core/HealthService.mjs');
-        buildWakeFeaturesBlock = mod.buildWakeFeaturesBlock;
+        buildWakeFeaturesBlock      = mod.buildWakeFeaturesBlock;
+        buildWakeTargetConfigBlock = mod.buildWakeTargetConfigBlock;
 
         const os   = await import('os');
         const path = await import('path');
@@ -733,6 +736,15 @@ test.describe('HealthService #10783 — buildWakeFeaturesBlock', () => {
         const path = await import('path');
         const fs   = await import('fs/promises');
 
+        originalWakeEnv = {
+            NEO_AGENT_IDENTITY                            : process.env.NEO_AGENT_IDENTITY,
+            NEO_ORCHESTRATOR_SWARM_HEARTBEAT_TARGET_SOURCE: process.env.NEO_ORCHESTRATOR_SWARM_HEARTBEAT_TARGET_SOURCE,
+            NEO_ORCHESTRATOR_SWARM_HEARTBEAT_TARGETS      : process.env.NEO_ORCHESTRATOR_SWARM_HEARTBEAT_TARGETS
+        };
+        delete process.env.NEO_AGENT_IDENTITY;
+        delete process.env.NEO_ORCHESTRATOR_SWARM_HEARTBEAT_TARGET_SOURCE;
+        delete process.env.NEO_ORCHESTRATOR_SWARM_HEARTBEAT_TARGETS;
+
         process.env.WAKE_GATE_FILE_PATH      = path.join(tmpDir, `gate-${Date.now()}.json`);
         process.env.NEO_HEARTBEAT_ALIVE_PATH = path.join(tmpDir, `alive-${Date.now()}`);
 
@@ -744,6 +756,62 @@ test.describe('HealthService #10783 — buildWakeFeaturesBlock', () => {
     test.afterEach(() => {
         delete process.env.WAKE_GATE_FILE_PATH;
         delete process.env.NEO_HEARTBEAT_ALIVE_PATH;
+
+        for (const [key, value] of Object.entries(originalWakeEnv || {})) {
+            if (value === undefined) delete process.env[key];
+            else                     process.env[key] = value;
+        }
+    });
+
+    test('target config defaults to self-only and marks Codex ineligible', () => {
+        const result = buildWakeTargetConfigBlock(
+            {orchestrator: {swarmHeartbeat: {targetSource: null}}},
+            {}
+        );
+
+        expect(result).toEqual({
+            targetSource                  : 'self',
+            targetMode                    : 'self',
+            explicitTargets               : [],
+            selfIdentity                  : null,
+            codexEligibleByTargetConfig   : false
+        });
+    });
+
+    test('active-subscribers target source marks Codex eligible for subscription-aware pulses', () => {
+        const result = buildWakeTargetConfigBlock(
+            {orchestrator: {swarmHeartbeat: {targetSource: null}}},
+            {
+                NEO_AGENT_IDENTITY                            : 'neo-opus-4-7',
+                NEO_ORCHESTRATOR_SWARM_HEARTBEAT_TARGET_SOURCE: 'active-subscribers'
+            }
+        );
+
+        expect(result).toMatchObject({
+            targetSource               : 'active-subscribers',
+            targetMode                 : 'active-subscribers',
+            explicitTargets            : [],
+            selfIdentity               : '@neo-opus-4-7',
+            codexEligibleByTargetConfig: true
+        });
+    });
+
+    test('explicit targets normalize handles and mark Codex eligible', () => {
+        const result = buildWakeTargetConfigBlock(
+            {orchestrator: {swarmHeartbeat: {targetSource: 'self'}}},
+            {
+                NEO_AGENT_IDENTITY                      : 'neo-opus-4-7',
+                NEO_ORCHESTRATOR_SWARM_HEARTBEAT_TARGETS: 'neo-gpt, @neo-opus-4-7'
+            }
+        );
+
+        expect(result).toEqual({
+            targetSource               : 'self',
+            targetMode                 : 'explicit-targets',
+            explicitTargets            : ['@neo-gpt', '@neo-opus-4-7'],
+            selfIdentity               : '@neo-opus-4-7',
+            codexEligibleByTargetConfig: true
+        });
     });
 
     test('gate enabled + liveness fresh → daemonRunning true, gateState enabled', async () => {
@@ -885,7 +953,12 @@ test.describe('HealthService #10783 — buildWakeFeaturesBlock', () => {
             gateTrippedBy        : null,
             daemonRunning        : false,
             lastPulseAt          : null,
-            secondsSinceLastPulse: null
+            secondsSinceLastPulse: null,
+            targetSource         : 'self',
+            targetMode           : 'self',
+            explicitTargets      : [],
+            selfIdentity         : null,
+            codexEligibleByTargetConfig: false
         });
     });
 

--- a/test/playwright/unit/ai/services/memory-core/HealthService.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/HealthService.spec.mjs
@@ -716,7 +716,7 @@ test.describe('HealthService #10783 — buildWakeFeaturesBlock', () => {
     test.beforeAll(async () => {
         const mod = await import('../../../../../../ai/services/memory-core/HealthService.mjs');
         buildWakeFeaturesBlock      = mod.buildWakeFeaturesBlock;
-        buildWakeTargetConfigBlock = mod.buildWakeTargetConfigBlock;
+        buildWakeTargetConfigBlock = mod.default.constructor.buildWakeTargetConfigBlock.bind(mod.default.constructor);
 
         const os   = await import('os');
         const path = await import('path');
@@ -763,7 +763,7 @@ test.describe('HealthService #10783 — buildWakeFeaturesBlock', () => {
         }
     });
 
-    test('target config defaults to self-only and marks Codex ineligible', () => {
+    test('target config defaults to self-only without asserting identity eligibility', () => {
         const result = buildWakeTargetConfigBlock(
             {orchestrator: {swarmHeartbeat: {targetSource: null}}},
             {}
@@ -773,12 +773,11 @@ test.describe('HealthService #10783 — buildWakeFeaturesBlock', () => {
             targetSource                  : 'self',
             targetMode                    : 'self',
             explicitTargets               : [],
-            selfIdentity                  : null,
-            codexEligibleByTargetConfig   : false
+            selfIdentity                  : null
         });
     });
 
-    test('active-subscribers target source marks Codex eligible for subscription-aware pulses', () => {
+    test('active-subscribers target source surfaces subscription-aware mode only', () => {
         const result = buildWakeTargetConfigBlock(
             {orchestrator: {swarmHeartbeat: {targetSource: null}}},
             {
@@ -791,12 +790,11 @@ test.describe('HealthService #10783 — buildWakeFeaturesBlock', () => {
             targetSource               : 'active-subscribers',
             targetMode                 : 'active-subscribers',
             explicitTargets            : [],
-            selfIdentity               : '@neo-opus-4-7',
-            codexEligibleByTargetConfig: true
+            selfIdentity               : '@neo-opus-4-7'
         });
     });
 
-    test('explicit targets normalize handles and mark Codex eligible', () => {
+    test('explicit targets normalize handles without hard-coded identity readiness', () => {
         const result = buildWakeTargetConfigBlock(
             {orchestrator: {swarmHeartbeat: {targetSource: 'self'}}},
             {
@@ -809,8 +807,7 @@ test.describe('HealthService #10783 — buildWakeFeaturesBlock', () => {
             targetSource               : 'self',
             targetMode                 : 'explicit-targets',
             explicitTargets            : ['@neo-gpt', '@neo-opus-4-7'],
-            selfIdentity               : '@neo-opus-4-7',
-            codexEligibleByTargetConfig: true
+            selfIdentity               : '@neo-opus-4-7'
         });
     });
 
@@ -957,8 +954,7 @@ test.describe('HealthService #10783 — buildWakeFeaturesBlock', () => {
             targetSource         : 'self',
             targetMode           : 'self',
             explicitTargets      : [],
-            selfIdentity         : null,
-            codexEligibleByTargetConfig: false
+            selfIdentity         : null
         });
     });
 


### PR DESCRIPTION
Authored by GPT-5 (Codex Desktop). Session 019e5bac-15f3-7830-a59c-72772c757f9a.

FAIR-band: in-band [14/30 - current author count over last 30 merged]

Refs #11872

## Summary

Adds an operator-visible target-selection projection to `features.wake` in the Memory Core healthcheck. The wake block now reports the effective swarm-heartbeat target source, explicit target list, self identity, and target mode.

This is a narrow visibility slice for #11872: a fresh heartbeat liveness file alone no longer implies a specific agent can be reached. Identity-specific readiness still requires pairing this config projection with live wake-subscription evidence.

## Deltas

- Extends `buildWakeFeaturesBlock()` with neutral target config fields: `targetSource`, `targetMode`, `explicitTargets`, and `selfIdentity`.
- Moves the newly added target-config projection and handle normalization into `HealthService` static methods instead of module-level helpers.
- Removes the hard-coded `@neo-gpt` / `codexEligibleByTargetConfig` shortcut; the health block no longer claims Codex readiness from config alone.
- Adds unit coverage for self-only, active-subscribers, and explicit-target projection shapes without asserting identity-specific delivery.

## Source Of Authority

- Operator observation: Orchestrator logs showed heartbeat nudges reaching Claude while Codex only continued via the local Codex automation workaround.
- #11872 AC2 / AC6: if Orchestrator heartbeat does not directly drive Codex, the supported fallback/config state must be operator-visible.
- `SwarmHeartbeatService.getPulseIdentities()` / `resolveTargets()` own the actual routing semantics; this PR only mirrors the effective config in health output.

## Evidence

Evidence: L2 focused unit evidence. This is a healthcheck projection and unit-spec change; no live host wake delivery was executed.

## Contract Ledger

| Surface | Proposed Behavior | Evidence |
|---|---|---|
| `features.wake.targetSource` / `targetMode` | Exposes whether the heartbeat is self-only, subscription-aware, active-team, disabled, or explicit-target driven | Unit coverage for self-only, active-subscribers, and explicit target shapes |
| `features.wake.explicitTargets` / `selfIdentity` | Surfaces the configured target handles and process self identity without hard-coded agent readiness claims | HealthService projection tests |
| Existing liveness fields | Preserve gate/liveness behavior and stale-threshold semantics | Full HealthService spec passes |

## Test Evidence

- `node --check ai/services/memory-core/HealthService.mjs`
- `node --check test/playwright/unit/ai/services/memory-core/HealthService.spec.mjs`
- `npm run test-unit -- test/playwright/unit/ai/services/memory-core/HealthService.spec.mjs` -> 48 passed
- `git diff --check`
- `git diff --cached --check`

## Post-Merge Validation

- [ ] Run `healthcheck` while Orchestrator is in self-only mode under a non-Codex identity and confirm the target config surfaces `targetSource: self` plus that process `selfIdentity`.
- [ ] Set `NEO_ORCHESTRATOR_SWARM_HEARTBEAT_TARGET_SOURCE=active-subscribers` or explicit targets containing `@neo-gpt` and confirm the health block surfaces the config mode without claiming delivery.
- [ ] Pair the health output with live wake-subscription evidence before deciding whether the temporary Codex heartbeat automation can be disabled.

## Commit

- `2b02fb063` - `feat(memory-core): surface Codex wake target readiness (#11872)`
- `204e5c232` - `fix(memory-core): neutralize wake target health projection (#11872)`