### PR TITLE
fix(memory-core): log Chroma boot config errors (#10270)

### DIFF
--- a/ai/services/memory-core/managers/ChromaManager.mjs
+++ b/ai/services/memory-core/managers/ChromaManager.mjs
@@ -78,8 +78,32 @@ class ChromaManager extends AbstractVectorManager {
         super.construct(config);
 
         // The client is constructed here; heartbeat/connection is evaluated lazily by `connect()`.
-        const {host, port} = aiConfig.engines.chroma;
+        const {host, port} = this.resolveChromaClientConfig(aiConfig);
         this.client        = new ChromaClient({host, port, ssl: false});
+    }
+
+    /**
+     * @summary Resolves and validates Memory Core's Chroma client coordinates before boot continues.
+     * @param {Object} config aiConfig-shaped configuration object.
+     * @returns {{host: String, port: Number}}
+     * @throws {Error} When `engines.chroma.{host, port}` is missing or malformed.
+     */
+    resolveChromaClientConfig(config) {
+        const chroma = config?.engines?.chroma;
+        const port   = Number(chroma?.port);
+
+        if (!chroma?.host || !Number.isFinite(port) || port <= 0) {
+            const message = 'ChromaManager: engines.chroma.{host, port} is required for Memory Core Chroma startup.';
+
+            logger.error(`[ChromaManager] Boot-time config error: ${message}`);
+
+            throw new Error(message);
+        }
+
+        return {
+            host: chroma.host,
+            port
+        }
     }
 
     /**

--- a/test/playwright/unit/ai/mcp/server/shared/services/DestructiveOperationGuard.spec.mjs
+++ b/test/playwright/unit/ai/mcp/server/shared/services/DestructiveOperationGuard.spec.mjs
@@ -201,11 +201,6 @@ test.describe('DestructiveOperationGuard call-site wiring (#10845)', () => {
         let deleteCalls = 0;
 
         proxy.getManagers = async () => [{
-            resolveChromaCoordinates: () => ({
-                host   : 'localhost',
-                port   : 8000,
-                dataDir: path.join(repoRoot, '.neo-ai-data/chroma/memory-core')
-            }),
             getMemoryCollection: async () => ({
                 name: 'neo-agent-memory'
             }),

--- a/test/playwright/unit/ai/services/memory-core/HealthService.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/HealthService.spec.mjs
@@ -219,14 +219,11 @@ test.describe('HealthService #11181 — buildChromaMigrationStats', () => {
  * correctness (does the value reach the MCP healthcheck response under both real topologies?) is
  * validated empirically post-merge via harness restart + healthcheck inspection.
  *
- * The function delegates coordinate resolution to `ChromaManager.resolveChromaCoordinates` — a pure
- * method extracted in #10001 whose own unit coverage exists separately. Here we verify the three
- * surface properties operators consume: `mode` (unified vs federated), `coordinates` (pass-through
- * of the resolver's output), and `resolvedVia` (the config-key-path string that names which branch
- * won).
+ * The function reads the current unified `engines.chroma` coordinates directly. Here we verify the
+ * three surface properties operators consume: `mode` (unified), `coordinates` (pass-through of the
+ * configured coordinates), and `resolvedVia` (the config-key-path string that names the source).
  *
  * @see Neo.ai.services.memory-core.HealthService#buildTopologyBlock
- * @see Neo.ai.services.memory-core.managers.ChromaManager#resolveChromaCoordinates
  */
 test.describe('HealthService #10127, #11011 — buildTopologyBlock', () => {
     let buildTopologyBlock;

--- a/test/playwright/unit/ai/services/memory-core/managers/ChromaManager.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/managers/ChromaManager.spec.mjs
@@ -19,6 +19,7 @@ import * as core      from '../../../../../../../src/core/_export.mjs';
 import InstanceManager from '../../../../../../../src/manager/Instance.mjs';
 import aiConfig       from '../../../../../../../ai/mcp/server/memory-core/config.mjs';
 import ChromaManager  from '../../../../../../../ai/services/memory-core/managers/ChromaManager.mjs';
+import logger         from '../../../../../../../ai/mcp/server/memory-core/logger.mjs';
 import SystemLifecycleService from '../../../../../../../ai/services/memory-core/lifecycle/SystemLifecycleService.mjs';
 import path           from 'path';
 
@@ -26,6 +27,24 @@ const tmpDir = path.resolve(process.cwd(), 'tmp');
 aiConfig.storagePaths.graph = path.join(tmpDir, 'test-graph-' + Date.now() + '-' + Math.random().toString(36).substring(7) + '.db');
 
 test.describe('Neo.ai.services.memory-core.managers.ChromaManager', () => {
+    test('logs an operator-actionable config error before throwing on missing Chroma coordinates', () => {
+        const errors        = [];
+        const originalError = logger.error;
+
+        logger.error = msg => errors.push(msg);
+
+        try {
+            expect(() => ChromaManager.resolveChromaClientConfig({engines: {}}))
+                .toThrow(/engines\.chroma\.\{host, port\}/);
+
+            expect(errors).toHaveLength(1);
+            expect(errors[0]).toContain('Boot-time config error');
+            expect(errors[0]).toContain('engines.chroma.{host, port}');
+        } finally {
+            logger.error = originalError;
+        }
+    });
+
     test('should prevent console.warn global state theft during concurrent collection fetching', async () => {
         // Set up a custom warn logger to inspect leaks
         const warningLogs = [];


### PR DESCRIPTION
Resolves #10270

Authored by GPT-5.5 (Codex Desktop). Session 019e5bac-15f3-7830-a59c-72772c757f9a.
FAIR-band: over-target [14/30] - taking this lane despite over-target because the operator explicitly directed stale-ticket cleanup and this is a narrow first-cloud-deploy config failure surface.

Adds fail-fast, logger-backed validation for Memory Core Chroma boot coordinates before constructing `ChromaClient`, so missing or malformed `engines.chroma.{host, port}` surfaces as an operator-actionable Memory Core log entry instead of an unnormalized boot failure.

Evidence: L2 (targeted Playwright unit coverage + static grep invariant) -> L2 required (class-level boot config contract). No residual pre-merge ACs.

## Deltas from ticket

The ticket body was refreshed before implementation because the old `resolveChromaCoordinates` prescription was stale. Current source validates the `aiConfig.engines.chroma` path used by `ChromaManager.construct()`.

The validation is intentionally kept on the owning `ChromaManager` class surface. No module-level helper was added.

## Contract Ledger

| Surface | Contract | Evidence |
|---|---|---|
| `ChromaManager.construct()` | validates `aiConfig.engines.chroma.{host, port}` before `new ChromaClient(...)` | `ChromaManager.spec.mjs` misconfig test |
| `ChromaManager.resolveChromaClientConfig(config)` | single-sources the log/error message and returns normalized `{host, port}` | direct unit call asserts throw + `logger.error` |
| Memory Core logger | receives `[ChromaManager] Boot-time config error: ...` before throw | logger spy in targeted unit test |
| stale `resolveChromaCoordinates` references | removed from live `ai/` and unit-test surfaces | `rg -n "resolveChromaCoordinates" ai test/playwright/unit/ai` -> no matches |

## Test Evidence

- `git diff --check` - PASS
- `npm run test-unit -- test/playwright/unit/ai/services/memory-core/managers/ChromaManager.spec.mjs test/playwright/unit/ai/services/memory-core/HealthService.spec.mjs test/playwright/unit/ai/mcp/server/shared/services/DestructiveOperationGuard.spec.mjs` - 60/60 PASS
- `rg -n "resolveChromaCoordinates" ai test/playwright/unit/ai` - no matches

## Post-Merge Validation

- [ ] Deliberately broken Memory Core `engines.chroma` config in a stdio harness surfaces the `[ChromaManager] Boot-time config error` line in operator-visible logs before startup aborts.

## Commits

- `74cdbbec0` - `fix(memory-core): log Chroma boot config errors (#10270)`