### PR TITLE
feat(orchestrator): supervise lms server lifecycle as orchestrator task (#11986)

### DIFF
--- a/ai/config.template.mjs
+++ b/ai/config.template.mjs
@@ -279,6 +279,28 @@ const defaultConfig = {
             enabled: false,
             model  : 'mlx-community/gemma-4-31b-it-bf16',
             port   : '11435'
+        },
+        /**
+         * Orchestrator-owned LM Studio CLI (`lms`) inference server config. Operators
+         * tune via gitignored `ai/config.mjs` or env vars (`NEO_ORCHESTRATOR_LMS_ENABLED`,
+         * `NEO_ORCHESTRATOR_LMS_MODEL`, `NEO_ORCHESTRATOR_LMS_PORT`).
+         *
+         * Parallel alternative to `orchestrator.mlx` — both serve OpenAI-compatible HTTP
+         * for local embedding workloads; pick at most one via the respective `enabled` flag.
+         *
+         * - `enabled`: whether the orchestrator should supervise an `lms server start`
+         *   child process. Disabled by default; **macOS-only** (LM Studio CLI is not
+         *   shipped for Linux containers, so this lane is local-dev substrate, not
+         *   cloud-deployment substrate).
+         * - `model`: model identifier loaded into LM Studio. Distinct from the
+         *   OpenAI-compatible API payload label (`NEO_OPENAI_COMPATIBLE_MODEL`).
+         * - `port`: OpenAI-compatible local-inference port (LM Studio CLI default `1234`).
+         * @type {Object}
+         */
+        lms: {
+            enabled: false,
+            model  : 'qwen3-embedding-8b',
+            port   : '1234'
         }
     },
     /**

--- a/ai/config.template.mjs
+++ b/ai/config.template.mjs
@@ -292,8 +292,11 @@ const defaultConfig = {
          *   child process. Disabled by default; **macOS-only** (LM Studio CLI is not
          *   shipped for Linux containers, so this lane is local-dev substrate, not
          *   cloud-deployment substrate).
-         * - `model`: model identifier loaded into LM Studio. Distinct from the
-         *   OpenAI-compatible API payload label (`NEO_OPENAI_COMPATIBLE_MODEL`).
+         * - `model`: model identifier the operator intends LM Studio to serve. The
+         *   orchestrator-managed `lms server start` lane currently brings the server up;
+         *   ensuring this model is loaded (via `lms load <model>` or `/v1/models` probe)
+         *   is tracked as #11986 AC5 residual and is NOT performed by this lane today.
+         *   Distinct from the OpenAI-compatible API payload label (`NEO_OPENAI_COMPATIBLE_MODEL`).
          * - `port`: OpenAI-compatible local-inference port (LM Studio CLI default `1234`).
          * @type {Object}
          */

--- a/ai/daemons/orchestrator/Orchestrator.mjs
+++ b/ai/daemons/orchestrator/Orchestrator.mjs
@@ -407,6 +407,9 @@ export class Orchestrator extends Base {
      * @param {Boolean} [options.mlxEnabled]
      * @param {String}  [options.mlxModel]
      * @param {String}  [options.mlxPort]
+     * @param {Boolean} [options.lmsEnabled]
+     * @param {String}  [options.lmsModel]
+     * @param {String}  [options.lmsPort]
      * @param {String[]|String|null} [options.primaryDevSyncRootsConfig]
      * @returns {Promise<void>}
      */
@@ -427,7 +430,10 @@ export class Orchestrator extends Base {
             nodeBin   : options.nodeBin || process.argv[0],
             mlxEnabled: options.mlxEnabled ?? undefined,
             mlxModel  : options.mlxModel || undefined,
-            mlxPort   : options.mlxPort  || undefined
+            mlxPort   : options.mlxPort  || undefined,
+            lmsEnabled: options.lmsEnabled ?? undefined,
+            lmsModel  : options.lmsModel || undefined,
+            lmsPort   : options.lmsPort  || undefined
         });
 
         // Non-reactive boot-wrapper-provided instance state

--- a/ai/daemons/orchestrator/TaskDefinitions.mjs
+++ b/ai/daemons/orchestrator/TaskDefinitions.mjs
@@ -11,11 +11,12 @@ export const DEFAULT_SCRIPT_DIR = path.resolve(__dirname, '../../scripts');
 /**
  * @summary Builds child-process commands for orchestrator-owned maintenance tasks.
  *
- * Pure function: receives concrete `mlxEnabled` / `mlxModel` / `mlxPort` values from the
- * caller; performs no env-var lookups and carries no embedded MLX defaults. The
- * canonical MLX defaults live in `ai/config.template.mjs` under `orchestrator.mlx`;
- * `daemon.mjs::resolveMlxConfig` applies env-var overrides and forwards the resolved
- * values via `Orchestrator.start({mlxEnabled, mlxModel, mlxPort})`.
+ * Pure function: receives concrete `mlxEnabled` / `mlxModel` / `mlxPort` and
+ * `lmsEnabled` / `lmsModel` / `lmsPort` values from the caller; performs no env-var
+ * lookups and carries no embedded MLX or LM Studio defaults. The canonical defaults
+ * live in `ai/config.template.mjs` under `orchestrator.mlx` and `orchestrator.lms`;
+ * `daemon.mjs::resolveMlxConfig` / `resolveLmsConfig` apply env-var overrides and
+ * forward the resolved values via `Orchestrator.start({mlx*, lms*})`.
  *
  * The orchestrator intentionally shells out to existing manual maintenance scripts for
  * Piece C instead of reimplementing their internals. This keeps orchestration separate
@@ -27,7 +28,10 @@ export const DEFAULT_SCRIPT_DIR = path.resolve(__dirname, '../../scripts');
  * @param {String} [options.nodeBin] Node executable.
  * @param {Boolean} [options.mlxEnabled=false] Whether to launch an orchestrator-owned mlx_lm.server.
  * @param {String} [options.mlxModel] MLX launch model: a Hugging Face repo id or local path.
- * @param {String|Number} [options.mlxPort] OpenAI-compatible local inference port.
+ * @param {String|Number} [options.mlxPort] MLX OpenAI-compatible local inference port.
+ * @param {Boolean} [options.lmsEnabled=false] Whether to launch an orchestrator-owned LM Studio CLI server.
+ * @param {String} [options.lmsModel] LM Studio model identifier (informational; lifecycle currently spawns `lms server start` only — see #11986 AC5 for the model-load probe follow-up).
+ * @param {String|Number} [options.lmsPort] LM Studio OpenAI-compatible local inference port (CLI default `1234`).
  * @returns {Object}
  */
 export function buildTaskDefinitions({
@@ -35,7 +39,10 @@ export function buildTaskDefinitions({
     nodeBin    = process.argv[0],
     mlxEnabled = false,
     mlxModel,
-    mlxPort
+    mlxPort,
+    lmsEnabled = false,
+    lmsModel,
+    lmsPort
 } = {}) {
     const tasks = {
         chroma: {
@@ -112,6 +119,16 @@ export function buildTaskDefinitions({
             args           : ['-m', 'mlx_lm.server', '--model', mlxModel, '--port', String(mlxPort)],
             pidFileName    : 'mlx.pid',
             expectedCommand: 'mlx_lm.server'
+        };
+    }
+
+    if (lmsEnabled) {
+        tasks.lms = {
+            label          : 'lms server (LM Studio CLI)',
+            command        : 'lms',
+            args           : ['server', 'start', '--port', String(lmsPort)],
+            pidFileName    : 'lms.pid',
+            expectedCommand: 'lms server'
         };
     }
 

--- a/ai/daemons/orchestrator/daemon.mjs
+++ b/ai/daemons/orchestrator/daemon.mjs
@@ -294,6 +294,38 @@ export function resolveMlxConfig({orchestratorConfig = {}, env = process.env} = 
 }
 
 /**
+ * Resolves the effective LM Studio CLI (`lms`) inference-server config by overlaying
+ * env-var overrides onto `AiConfig.orchestrator.lms`. Operators tune via gitignored
+ * `ai/config.mjs` or env (`NEO_ORCHESTRATOR_LMS_{ENABLED,MODEL,PORT}`); canonical
+ * defaults (`enabled: false`, `qwen3-embedding-8b` model, port `'1234'`) live in
+ * `ai/config.template.mjs` — this helper does not re-embed them.
+ *
+ * Mirror of `resolveMlxConfig` — the `lms` task is the parallel-alternative
+ * macOS-only local embedding server lane. Both `mlx` and `lms` lanes are mutually
+ * exclusive in practice (operators pick one via the respective `enabled` flag),
+ * though the orchestrator does not enforce that — two enabled lanes would bind
+ * different ports and operate independently.
+ *
+ * Boolean parsing for `NEO_ORCHESTRATOR_LMS_ENABLED` goes through
+ * `Neo.util.Env.parseBool` for canonical token semantics
+ * (true/yes/on/1, false/no/off/0, case-insensitive, trimmed).
+ *
+ * @param {Object} [options]
+ * @param {Object} [options.orchestratorConfig={}] Slice of `AiConfig.orchestrator`.
+ * @param {Object} [options.env=process.env] Env-var source (test-injectable).
+ * @returns {{enabled: Boolean, model: String, port: String}}
+ */
+export function resolveLmsConfig({orchestratorConfig = {}, env = process.env} = {}) {
+    const lms = orchestratorConfig.lms || {};
+
+    return {
+        enabled: Env.parseBool('NEO_ORCHESTRATOR_LMS_ENABLED', {env}) ?? !!lms.enabled,
+        model  : env.NEO_ORCHESTRATOR_LMS_MODEL || lms.model,
+        port   : env.NEO_ORCHESTRATOR_LMS_PORT  || lms.port
+    };
+}
+
+/**
  * Starts the singleton orchestrator daemon.
  * @param {Object} [options] Runtime overrides for tests or process managers.
  * @returns {Promise<void>}
@@ -306,6 +338,7 @@ export async function startOrchestrator(options = {}) {
     const orchestratorConfig = AiConfig.orchestrator || {};
     const maintenanceConfig  = AiConfig.maintenance || {};
     const mlx                = resolveMlxConfig({orchestratorConfig});
+    const lms                = resolveLmsConfig({orchestratorConfig});
 
     return Orchestrator.start({
         dataDir: DAEMON_DATA_DIR,
@@ -313,6 +346,9 @@ export async function startOrchestrator(options = {}) {
         mlxEnabled: mlx.enabled,
         mlxModel  : mlx.model,
         mlxPort   : mlx.port,
+        lmsEnabled: lms.enabled,
+        lmsModel  : lms.model,
+        lmsPort   : lms.port,
         ...resolveOrchestratorStartOptions({orchestratorConfig, maintenanceConfig}),
         ...options
     });

--- a/test/playwright/unit/ai/daemons/orchestrator/Orchestrator.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/Orchestrator.spec.mjs
@@ -516,6 +516,22 @@ test.describe('Neo.ai.daemons.Orchestrator (#11009)', () => {
         expect(orchestrator.taskDefinitions.mlx.args).not.toContain('gemma-4-31b-it');
     });
 
+    test('passes local lms launch port config into task definitions (#11986)', () => {
+        const orchestrator = Neo.create(Orchestrator);
+        orchestrator.dataDir         = '/tmp/orchestrator-test-lms-port';
+        orchestrator.taskDefinitions = buildTaskDefinitions({
+            scriptDir : path.resolve(process.cwd(), 'ai/scripts'),
+            nodeBin   : process.argv[0],
+            lmsEnabled: true,
+            lmsModel  : 'qwen3-embedding-8b',
+            lmsPort   : 4242
+        });
+
+        expect(orchestrator.taskDefinitions.lms.command).toBe('lms');
+        expect(orchestrator.taskDefinitions.lms.args).toEqual(['server', 'start', '--port', '4242']);
+        expect(orchestrator.taskDefinitions.lms.pidFileName).toBe('lms.pid');
+    });
+
     test('routes primary-dev-sync through its service coordinator', () => {
         const started = [];
         const orchestrator = createTestOrchestrator({

--- a/test/playwright/unit/ai/daemons/orchestrator/daemon.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/daemon.spec.mjs
@@ -6,6 +6,7 @@ import '../../../../../../src/core/_export.mjs';
 import {
     LOCAL_AI_CONFIG_FILE,
     loadLocalAiConfig,
+    resolveLmsConfig,
     resolveMlxConfig,
     resolveOrchestratorStartOptions
 } from '../../../../../../ai/daemons/orchestrator/daemon.mjs';
@@ -198,6 +199,124 @@ test.describe('ai/daemons/orchestrator/daemon.mjs (#11006/#11009)', () => {
         // post-#11075 migration. TaskDefinitions.mjs no longer carries them.
         expect(templateSource).toMatch(
             /mlx:\s*\{[\s\S]*enabled:\s*false[\s\S]*model\s*:\s*'mlx-community\/gemma-4-31b-it-bf16'[\s\S]*port\s*:\s*'11435'[\s\S]*\}/
+        );
+    });
+
+    // -----------------------------------------------------------------------------
+    // #11986 — LM Studio CLI (`lms`) orchestrator-managed lifecycle (mirror of MLX)
+    // -----------------------------------------------------------------------------
+
+    test('buildTaskDefinitions is pure: tasks.lms is omitted when lmsEnabled is false', () => {
+        const scriptDir = path.resolve(process.cwd(), 'ai/scripts');
+        const tasks     = buildTaskDefinitions({scriptDir, nodeBin: '/test/node'});
+
+        expect(tasks.lms).toBeUndefined();
+    });
+
+    test('buildTaskDefinitions is pure: no env-var lookups; concrete lmsModel/lmsPort flow through', () => {
+        // Architectural contract: TaskDefinitions.mjs has no embedded LM Studio
+        // defaults and no env-var reads. Caller (daemon.mjs via resolveLmsConfig)
+        // resolves AiConfig + env-vars and forwards concrete values. This test
+        // documents the pure-function contract by setting env-vars that would have
+        // been picked up if the implementation leaked and verifying they are ignored.
+        const scriptDir = path.resolve(process.cwd(), 'ai/scripts');
+        const originalLmsModel   = process.env.NEO_ORCHESTRATOR_LMS_MODEL;
+        const originalLmsEnabled = process.env.NEO_ORCHESTRATOR_LMS_ENABLED;
+        const originalLmsPort    = process.env.NEO_ORCHESTRATOR_LMS_PORT;
+
+        process.env.NEO_ORCHESTRATOR_LMS_ENABLED = 'true';
+        process.env.NEO_ORCHESTRATOR_LMS_MODEL   = 'env-leaked-model';
+        process.env.NEO_ORCHESTRATOR_LMS_PORT    = '99999';
+
+        try {
+            // Default: lmsEnabled=false; env-vars are ignored.
+            const tasks = buildTaskDefinitions({scriptDir, nodeBin: '/test/node'});
+            expect(tasks.lms).toBeUndefined();
+
+            // Explicit values are passed through verbatim; env-vars are still ignored.
+            const explicitTasks = buildTaskDefinitions({
+                scriptDir,
+                nodeBin   : '/test/node',
+                lmsEnabled: true,
+                lmsModel  : 'explicit-model',
+                lmsPort   : 4242
+            });
+
+            expect(explicitTasks.lms.command).toBe('lms');
+            expect(explicitTasks.lms.args).toEqual(['server', 'start', '--port', '4242']);
+            expect(explicitTasks.lms.expectedCommand).toBe('lms server');
+            expect(explicitTasks.lms.pidFileName).toBe('lms.pid');
+            expect(explicitTasks.lms.args).not.toContain('99999');
+        } finally {
+            for (const [key, value] of [
+                ['NEO_ORCHESTRATOR_LMS_MODEL',   originalLmsModel],
+                ['NEO_ORCHESTRATOR_LMS_ENABLED', originalLmsEnabled],
+                ['NEO_ORCHESTRATOR_LMS_PORT',    originalLmsPort]
+            ]) {
+                if (value === undefined) {
+                    delete process.env[key];
+                } else {
+                    process.env[key] = value;
+                }
+            }
+        }
+    });
+
+    test('resolveLmsConfig overlays env-var precedence onto AiConfig.orchestrator.lms', () => {
+        const aiConfigDefaults = {
+            lms: {
+                enabled: false,
+                model  : 'qwen3-embedding-8b',
+                port   : '1234'
+            }
+        };
+
+        // No env overrides: AiConfig defaults flow through.
+        expect(resolveLmsConfig({orchestratorConfig: aiConfigDefaults, env: {}})).toEqual({
+            enabled: false,
+            model  : 'qwen3-embedding-8b',
+            port   : '1234'
+        });
+
+        // Env overrides win.
+        expect(resolveLmsConfig({
+            orchestratorConfig: aiConfigDefaults,
+            env               : {
+                NEO_ORCHESTRATOR_LMS_ENABLED: 'true',
+                NEO_ORCHESTRATOR_LMS_MODEL  : 'env-model',
+                NEO_ORCHESTRATOR_LMS_PORT   : '4242'
+            }
+        })).toEqual({
+            enabled: true,
+            model  : 'env-model',
+            port   : '4242'
+        });
+
+        // Explicit env=false overrides an enabled AiConfig default.
+        expect(resolveLmsConfig({
+            orchestratorConfig: {lms: {...aiConfigDefaults.lms, enabled: true}},
+            env               : {NEO_ORCHESTRATOR_LMS_ENABLED: 'false'}
+        })).toEqual({
+            enabled: false,
+            model  : 'qwen3-embedding-8b',
+            port   : '1234'
+        });
+
+        // Missing orchestratorConfig.lms: undefined-safe, no crash; values undefined.
+        expect(resolveLmsConfig({orchestratorConfig: {}, env: {}})).toEqual({
+            enabled: false,
+            model  : undefined,
+            port   : undefined
+        });
+    });
+
+    test('AiConfig.orchestrator.lms ships canonical LM Studio launch defaults', async () => {
+        const templateSource = fs.readFileSync(path.resolve(process.cwd(), 'ai/config.template.mjs'), 'utf8');
+
+        // AiConfig template is the single source of truth for LM Studio defaults.
+        // TaskDefinitions.mjs is a pure function that consumes these via caller-resolved values.
+        expect(templateSource).toMatch(
+            /lms:\s*\{[\s\S]*enabled:\s*false[\s\S]*model\s*:\s*'qwen3-embedding-8b'[\s\S]*port\s*:\s*'1234'[\s\S]*\}/
         );
     });
 


### PR DESCRIPTION
Authored by Claude Opus 4.7 (Claude Code). Session continuation from cloud-deployment-trial sprint.

FAIR-band: under-target [15/30] — operator-direction (focus on local-dev embedding-server lifecycle gap that blocked add_memory). Mirror-pattern shape (no novel architecture); narrow surface across 4 source files + 2 spec files.

Evidence: L1 (45/45 PASS across direct-impact tree: daemon.spec.mjs + Orchestrator.spec.mjs + TaskDefinitions.invariants.spec.mjs). L3 post-merge for AC8 (operator-confirms-restart-cycle). Residual: AC5 model-load probe [#11986 — partial-resolution; AC5 stays open as L<N>-deferred].

Refs #11986 (partial-resolution; AC5 + Contract Ledger row 4 deferred — see Deltas)

## Summary

Restore LM Studio CLI (`lms`) auto-boot as an orchestrator-managed task. Mirror of the existing `mlx_lm.server` task shape (#11075 / PR #11957) for the parallel macOS-only local-embedding-server lane.

**Regression chain:** #9833 (closed 2026-04-09, commit `0a3812c4c`) originally shipped LM Studio auto-boot in `ai/services/memory-core/lifecycle/InferenceLifecycleService.mjs::startInferenceServer()`. PR #11096 closing #11093 ("Centralize daemon supervision", commit `7e596385e`) gutted the MC-side spawn but never landed the orchestrator-side counterpart. `InferenceLifecycleService::startInferenceServer()` now just warns `"AgentOrchestrator should be managing it"` and returns `{status: 'offline'}` — and the orchestrator had no `lms` task. Net effect: nobody restarted `lms server` when it died.

**Empirical anchor:** 2026-05-25 today — embedding endpoint at `127.0.0.1:1234` went silent at `13:00:50Z` (per `orchestrator.log:45546`), 46min after the last successful kbSync at `12:14:27Z`. Stayed dark until operator manually re-ran `lms server start`. Multiple downstream failures cascaded: `add_memory`, `ask_knowledge_base`, KB sync periodic-sync exiting code 1, `dream` task hitting the same endpoint.

## Architectural shape

**Parallel-alternative** to `orchestrator.mlx`:

| | `orchestrator.mlx` | `orchestrator.lms` |
|---|---|---|
| `enabled` default | `false` | `false` |
| `model` default | `'mlx-community/gemma-4-31b-it-bf16'` | `'qwen3-embedding-8b'` |
| `port` default | `'11435'` | `'1234'` (LM Studio CLI default) |
| Launches | `mlx_lm.server` via Python venv | `lms server start` |
| Platform | macOS / Linux | macOS only |
| Scope | local-dev OR cloud-deployment | local-dev only |

Both lanes serve OpenAI-compatible HTTP for local embedding workloads. Operators pick one via the respective `enabled` flag; both enabled simultaneously is allowed but unusual (different ports, operator chooses which one `openAiCompatible.host` resolves to).

## Changes

### Source files

- **`ai/config.template.mjs`** (`+27 / -0` after cycle-2 JSDoc tighten) — added `orchestrator.lms` namespace. JSDoc explicitly calls out the macOS-only scope, parallel-alternative-to-mlx relationship, AND the AC5-deferred state of the `model` field (server-up ≠ model-loaded; ensuring model is loaded is tracked as #11986 AC5 residual).
- **`ai/daemons/orchestrator/daemon.mjs`** (`+36 / -0`) — added `resolveLmsConfig({orchestratorConfig, env})` helper. Exact mirror of `resolveMlxConfig` shape: reads env-vars `NEO_ORCHESTRATOR_LMS_{ENABLED,MODEL,PORT}` with `Env.parseBool` canonical boolean parsing; falls back to `AiConfig.orchestrator.lms`. `startOrchestrator()` invokes both helpers and passes `lmsEnabled/lmsModel/lmsPort` through to `Orchestrator.start()`.
- **`ai/daemons/orchestrator/TaskDefinitions.mjs`** (`+22 / -9`) — `buildTaskDefinitions` accepts `lmsEnabled / lmsModel / lmsPort` params. Conditional task emission: `tasks.lms = {command: 'lms', args: ['server', 'start', '--port', String(lmsPort)], pidFileName: 'lms.pid', expectedCommand: 'lms server'}`. `lms` binary resolves via `PATH` (operator's `.zshenv` exports `PATH=$PATH:/Users/tobiasuhlig/.lmstudio/bin`), exact mirror of how `chroma` task resolves. **Note**: `lmsModel` is plumbed through but currently informational only (passed via the JSDoc-documented `lms` task but not consumed by a model-load step) — see #11986 AC5 residual.
- **`ai/daemons/orchestrator/Orchestrator.mjs`** (`+7 / -1`) — `start()` accepts `lmsEnabled / lmsModel / lmsPort`; passes through to `buildTaskDefinitions`.

### Tests

- **`test/playwright/unit/ai/daemons/orchestrator/daemon.spec.mjs`** (`+119 / -0`) — 4 new tests mirroring the MLX pattern: pure-function-no-env-leak, concrete-values-flow-through, `resolveLmsConfig` env-precedence (4 sub-cases), AiConfig canonical defaults regex assertion.
- **`test/playwright/unit/ai/daemons/orchestrator/Orchestrator.spec.mjs`** (`+16 / -0`) — 1 new test mirroring the MLX pass-through coverage: `lmsEnabled / lmsModel / lmsPort` flow into task definitions correctly.

## Deltas from ticket — partial-resolution framing

**This PR ships AC1–AC4 + AC6 + AC7 of #11986. AC5 + Contract Ledger row 4 (Orchestrator-side model-load probe) explicitly deferred — #11986 stays OPEN.**

Cycle-1 reviewer (@neo-gpt) correctly flagged that the original `Resolves #11986` close-target compressed server-up and model-ready into the same delivered state. Substantive content unchanged; close-target reshaped to `Refs #11986` so the ticket stays open for AC5 follow-up rather than auto-closing on merge.

AC5 deferral rationale (preserved from cycle-1 body): the model-load probe (`lms load <model>` if absent in `/v1/models`) requires either a new `postSpawnProbe` hook in `ProcessSupervisor` or a wrapper script chaining `lms server start && lms load <model>`. Both shapes are additive substrate beyond the load-bearing lifecycle restoration. Server-lifecycle restoration is the load-bearing AC for unblocking the regression; LM Studio remembers the last-loaded model across restarts in practice, so the model-load probe is an additional safety net for cold-boot scenarios.

**Cycle-2 changes:**
- Close-target: `Resolves #11986` → `Refs #11986`
- `ai/config.template.mjs` JSDoc on `orchestrator.lms.model`: tightened from "model identifier loaded into LM Studio" → "model identifier the operator intends LM Studio to serve... ensuring this model is loaded... is tracked as #11986 AC5 residual and is NOT performed by this lane today."
- This PR-body updated: Refs framing, Deltas restated, Evidence line surfaces the AC5 residual explicitly

## Test Evidence

```
npm run test-unit -- test/playwright/unit/ai/daemons/orchestrator/daemon.spec.mjs \
                     test/playwright/unit/ai/daemons/orchestrator/Orchestrator.spec.mjs \
                     test/playwright/unit/ai/daemons/orchestrator/TaskDefinitions.invariants.spec.mjs
```

→ **45/45 PASS (1.1s)** at cycle-2 head `f611ee0a8`.

Two pre-existing `DreamService.spec.mjs` failures observed in the broader orchestrator test tree — verified unrelated to this diff by running on clean origin/dev (same 2 failures, same line numbers).

## Post-Merge Validation

- [ ] Operator confirms enabling `NEO_ORCHESTRATOR_LMS_ENABLED=true` (or `AiConfig.orchestrator.lms.enabled: true` in overlay) causes the orchestrator to spawn `lms server start --port 1234` on next restart
- [ ] Kill the `lms` process manually and confirm `ProcessSupervisor` restarts it (the load-bearing AC for the regression fix)
- [ ] After restart, confirm `add_memory` round-trips end-to-end (canonical smoke test for the embedding pipeline)
- [ ] Confirm `orchestrator-state.json` shows `lms` task entry with `lastSuccessAt` populated
- [ ] #11986 AC5 follow-up tracked in the still-open ticket; not part of this PR's validation surface

## Avoided Traps

- ✓ Did NOT put the lifecycle back into `InferenceLifecycleService` — that's MC substrate; daemon supervision lives in the Orchestrator per the #11093 architecture. Re-gutting MC would re-introduce the boundary violation.
- ✓ Did NOT bundle a healthcheck active embedding-endpoint probe — separate concern (MC HealthService observability honesty), separate ticket.
- ✓ Did NOT replace `tasks.mlx` with `tasks.lms` — parallel namespaces, not mutually exclusive.
- ✓ Did NOT reinvent the HTTP probe — preserved `InferenceLifecycleService::isInferenceRunning()` as the canonical `/v1/models` probe shape for future AC5 model-load probe work.
- ✓ Did NOT compress AC5 into this PR's scope while shipping `Resolves #11986` — cycle-2 corrected the close-target framing to `Refs` so the ticket stays open for AC5 follow-up.

## Authority

#11986 was filed by me 2026-05-25 in the same turn the operator surfaced the gap. Self-assigned; implementation in same turn per swarm-topology-anchor §AND-discipline. Operator green-lit the implementation explicitly after confirming the parallel-alternative-to-mlx framing. Cycle-2 close-target reshape per @neo-gpt's cycle-1 substantive review (PRR commentId in conversation thread).

Origin Session ID: `8f1a91ee-3ee4-4e4b-9865-b5810f6be353`

Authored by [Claude Opus 4.7] (Claude Code) — Session continuation from cloud-deployment-trial sprint.

## Commits

- `eb320abd4` — `feat(orchestrator): supervise lms server lifecycle as orchestrator task (#11986)`
- `f611ee0a8` — `fix(orchestrator): clarify lms.model JSDoc — flag AC5 residual (#11986)`
