### PR TITLE
feat(ai): hard-cut config env substrate (#10103)

### DIFF
--- a/ai/BaseConfig.mjs
+++ b/ai/BaseConfig.mjs
@@ -1,7 +1,7 @@
 import fs   from 'fs/promises';
 import path from 'path';
-import Base  from '../../../../src/core/Base.mjs';
-import Env   from '../../../../src/util/Env.mjs';
+import Base  from '../src/core/Base.mjs';
+import Env   from '../src/util/Env.mjs';
 
 /**
  * @summary Base configuration manager for Neo MCP servers.
@@ -9,33 +9,32 @@ import Env   from '../../../../src/util/Env.mjs';
  * Provides shared logic for file-based configuration loading, deep merging,
  * and environment variable application.
  *
- * @class Neo.ai.mcp.server.shared.BaseConfig
+ * @class Neo.ai.BaseConfig
  * @extends Neo.core.Base
  */
 class BaseConfig extends Base {
     static config = {
         /**
-         * @member {String} className='Neo.ai.mcp.server.shared.BaseConfig'
+         * @member {String} className='Neo.ai.BaseConfig'
          * @protected
          */
-        className: 'Neo.ai.mcp.server.shared.BaseConfig'
+        className: 'Neo.ai.BaseConfig',
+        /**
+         * The current configuration object.
+         * @member {Object|null} data=null
+         */
+        data: null,
+        /**
+         * Server default configuration object.
+         * @member {Object} defaultConfig={}
+         */
+        defaultConfig: {},
+        /**
+         * Nested env-var binding ledger. Shape mirrors `defaultConfig`.
+         * @member {Object} envBindings={}
+         */
+        envBindings: {}
     }
-
-    /**
-     * The current configuration object.
-     * @member {Object} data
-     */
-    data = null;
-
-    /**
-     * @member {Object} defaultConfig={}
-     */
-    defaultConfig = {};
-
-    /**
-     * @member {Object} envBindings={}
-     */
-    envBindings = {};
 
     /**
      * Initializes the configuration object by deep cloning the defaults.
@@ -52,15 +51,6 @@ class BaseConfig extends Base {
      */
     applyEnv() {
         Env.applyEnvBindings(this.data, this.envBindings, process.env, console.warn);
-        this.applyLegacyEnv();
-    }
-
-    /**
-     * Hook for subclasses to handle specific environment variable deprecations or fallbacks.
-     * @protected
-     */
-    applyLegacyEnv() {
-        // Override in subclass if needed
     }
 
     /**
@@ -104,7 +94,7 @@ class BaseConfig extends Base {
 
 /**
  * Creates a Proxy to delegate unknown properties to the underlying data object.
- * @param {Neo.ai.mcp.server.shared.BaseConfig} instance
+ * @param {Neo.ai.BaseConfig} instance
  * @returns {Proxy}
  */
 export function createConfigProxy(instance) {
@@ -123,4 +113,4 @@ export function createConfigProxy(instance) {
     });
 }
 
-export { BaseConfig as default };
+export default Neo.setupClass(BaseConfig);

--- a/ai/config.template.mjs
+++ b/ai/config.template.mjs
@@ -1,8 +1,7 @@
-import fs              from 'fs/promises';
 import path            from 'path';
 import {fileURLToPath} from 'url';
-import Base            from '../src/core/Base.mjs';
-import {resolveMcpHttpPort, resolvePublicUrl} from './mcp/server/shared/helpers/DeploymentConfig.mjs';
+import BaseConfig, {createConfigProxy} from './BaseConfig.mjs';
+import Env             from '../src/util/Env.mjs';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname  = path.dirname(__filename);
@@ -29,18 +28,18 @@ const defaultConfig = {
      * Transport protocol ('stdio' or 'sse').
      * @type {string}
      */
-    transport: process.env.NEO_TRANSPORT || 'stdio',
+    transport: 'stdio',
     /**
      * Optional public canonical URL.
      * @type {string|null}
      */
-    publicUrl: resolvePublicUrl(),
+    publicUrl: null,
     /**
      * Port the MCP server's HTTP/SSE transport listens on.
      * Sub-servers will typically override this with their own defaultPort.
      * @type {number}
      */
-    mcpHttpPort: resolveMcpHttpPort({defaultPort: 3000}),
+    mcpHttpPort: 3000,
     /**
      * Optional Express middleware function for authentication.
      * @type {Function|null}
@@ -51,13 +50,13 @@ const defaultConfig = {
      * @type {Object}
      */
     auth: {
-        host              : process.env.NEO_AUTH_HOST || null,
-        port              : Number(process.env.NEO_AUTH_PORT) || 8080,
-        realm             : process.env.NEO_AUTH_REALM || 'master',
-        issuerUrl         : process.env.NEO_AUTH_ISSUER_URL || null,
-        clientId          : process.env.NEO_OAUTH_CLIENT_ID || null,
-        clientSecret      : process.env.NEO_OAUTH_CLIENT_SECRET || '',
-        trustProxyIdentity: process.env.NEO_AUTH_TRUST_PROXY_IDENTITY === 'true'
+        host              : null,
+        port              : 8080,
+        realm             : 'master',
+        issuerUrl         : null,
+        clientId          : null,
+        clientSecret      : '',
+        trustProxyIdentity: false
     },
     /**
      * @summary Deployment-wide chat / generation model provider.
@@ -68,16 +67,16 @@ const defaultConfig = {
      * `openAiCompatible`.
      * @type {String}
      */
-    chatProvider: process.env.NEO_MODEL_PROVIDER || 'gemini',
+    chatProvider: 'gemini',
     /**
-     * @summary Backwards-compatible alias for the active chat provider.
+     * @summary Runtime alias for the active chat provider.
      *
-     * Existing Memory Core consumers still read `modelProvider`; keep the Tier-1
-     * template aligned with `chatProvider` so Sub-1 can move ownership without
-     * forcing runtime dispatch changes.
+     * Existing Memory Core consumers read `modelProvider`; keep the Tier-1
+     * template aligned with `chatProvider` until provider routing converges on
+     * one canonical key.
      * @type {String}
      */
-    modelProvider: process.env.NEO_MODEL_PROVIDER || 'gemini',
+    modelProvider: 'gemini',
     /**
      * @summary Deployment-wide embedding provider selector.
      *
@@ -85,7 +84,7 @@ const defaultConfig = {
      * paths.
      * @type {String}
      */
-    embeddingProvider: process.env.NEO_EMBEDDING_PROVIDER || 'openAiCompatible',
+    embeddingProvider: 'openAiCompatible',
     /**
      * @summary Deployment-wide Ollama provider defaults.
      *
@@ -94,9 +93,9 @@ const defaultConfig = {
      * @type {Object}
      */
     ollama: {
-        host          : process.env.NEO_OLLAMA_HOST || 'http://127.0.0.1:11434',
-        model         : process.env.NEO_OLLAMA_MODEL || 'gemma4:31b',
-        embeddingModel: process.env.NEO_OLLAMA_EMBEDDING_MODEL || 'qwen3-embedding'
+        host          : 'http://127.0.0.1:11434',
+        model         : 'gemma4:31b',
+        embeddingModel: 'qwen3-embedding'
     },
     /**
      * @summary Deployment-wide OpenAI-compatible provider defaults.
@@ -106,14 +105,14 @@ const defaultConfig = {
      * @type {Object}
      */
     openAiCompatible: {
-        host                    : process.env.NEO_OPENAI_COMPATIBLE_HOST || 'http://127.0.0.1:11434',
-        model                   : process.env.NEO_OPENAI_COMPATIBLE_MODEL || 'gemma-4-31b-it',
-        embeddingModel          : process.env.NEO_OPENAI_COMPATIBLE_EMBEDDING_MODEL || 'text-embedding-qwen3-embedding-8b',
-        apiKey                  : process.env.NEO_OPENAI_COMPATIBLE_API_KEY || '',
-        unloadRetryCount        : Number(process.env.NEO_OPENAI_COMPATIBLE_UNLOAD_RETRY_COUNT) || 3,
-        unloadRetryDelayMs      : Number(process.env.NEO_OPENAI_COMPATIBLE_UNLOAD_RETRY_DELAY_MS) || 500,
-        contextLimitTokens      : Number(process.env.NEO_OPENAI_COMPATIBLE_CONTEXT_LIMIT_TOKENS) || 32768,
-        safeProcessingLimitTokens: Number(process.env.NEO_OPENAI_COMPATIBLE_SAFE_PROCESSING_LIMIT_TOKENS) || undefined
+        host                    : 'http://127.0.0.1:11434',
+        model                   : 'gemma-4-31b-it',
+        embeddingModel          : 'text-embedding-qwen3-embedding-8b',
+        apiKey                  : '',
+        unloadRetryCount        : 3,
+        unloadRetryDelayMs      : 500,
+        contextLimitTokens      : 32768,
+        safeProcessingLimitTokens: undefined
     },
     /**
      * @summary Deployment-wide Gemini model defaults.
@@ -136,7 +135,7 @@ const defaultConfig = {
      * overrides.
      * @type {Number}
      */
-    vectorDimension: Number(process.env.NEO_VECTOR_DIMENSION) || 4096,
+    vectorDimension: 4096,
     /**
      * @summary Deployment-wide storage engine coordinates.
      *
@@ -146,8 +145,8 @@ const defaultConfig = {
      */
     engines: {
         chroma: {
-            host: process.env.NEO_CHROMA_HOST || 'localhost',
-            port: Number(process.env.NEO_CHROMA_PORT) || 8000
+            host: 'localhost',
+            port: 8000
         }
     },
     /**
@@ -161,7 +160,7 @@ const defaultConfig = {
          * maintenance lanes unless a narrower localOnly override opts them back in.
          * @type {'local'|'cloud'}
          */
-        deploymentMode: process.env.NEO_AI_DEPLOYMENT_MODE || 'local',
+        deploymentMode: 'local',
         /**
          * Maintenance-loop intervals consumed by the orchestrator daemon.
          * Env vars at the daemon boundary retain precedence over these defaults.
@@ -425,11 +424,60 @@ const defaultConfig = {
 };
 
 /**
+ * @summary Tier-1 environment-variable ledger.
+ *
+ * Binding shape mirrors `defaultConfig`; dotted binding keys are intentionally unsupported.
+ */
+const envBindings = {
+    debug        : {var: 'NEO_DEBUG', parse: Env.parseBool},
+    transport    : 'NEO_TRANSPORT',
+    publicUrl    : {var: 'NEO_PUBLIC_URL', parse: Env.parseUrl},
+    mcpHttpPort  : {var: 'MCP_HTTP_PORT', parse: Env.parsePort},
+    auth         : {
+        host              : 'NEO_AUTH_HOST',
+        port              : {var: 'NEO_AUTH_PORT', parse: Env.parsePort},
+        realm             : 'NEO_AUTH_REALM',
+        issuerUrl         : 'NEO_AUTH_ISSUER_URL',
+        clientId          : 'NEO_OAUTH_CLIENT_ID',
+        clientSecret      : 'NEO_OAUTH_CLIENT_SECRET',
+        trustProxyIdentity: {var: 'NEO_AUTH_TRUST_PROXY_IDENTITY', parse: Env.parseBool}
+    },
+    chatProvider     : 'NEO_MODEL_PROVIDER',
+    modelProvider    : 'NEO_MODEL_PROVIDER',
+    embeddingProvider: 'NEO_EMBEDDING_PROVIDER',
+    ollama           : {
+        host          : 'NEO_OLLAMA_HOST',
+        model         : 'NEO_OLLAMA_MODEL',
+        embeddingModel: 'NEO_OLLAMA_EMBEDDING_MODEL'
+    },
+    openAiCompatible: {
+        host                    : 'NEO_OPENAI_COMPATIBLE_HOST',
+        model                   : 'NEO_OPENAI_COMPATIBLE_MODEL',
+        embeddingModel          : 'NEO_OPENAI_COMPATIBLE_EMBEDDING_MODEL',
+        apiKey                  : 'NEO_OPENAI_COMPATIBLE_API_KEY',
+        unloadRetryCount        : {var: 'NEO_OPENAI_COMPATIBLE_UNLOAD_RETRY_COUNT', parse: Env.parseNumber},
+        unloadRetryDelayMs      : {var: 'NEO_OPENAI_COMPATIBLE_UNLOAD_RETRY_DELAY_MS', parse: Env.parseNumber},
+        contextLimitTokens      : {var: 'NEO_OPENAI_COMPATIBLE_CONTEXT_LIMIT_TOKENS', parse: Env.parseNumber},
+        safeProcessingLimitTokens: {var: 'NEO_OPENAI_COMPATIBLE_SAFE_PROCESSING_LIMIT_TOKENS', parse: Env.parseNumber}
+    },
+    vectorDimension: {var: 'NEO_VECTOR_DIMENSION', parse: Env.parseNumber},
+    engines        : {
+        chroma: {
+            host: 'NEO_CHROMA_HOST',
+            port: {var: 'NEO_CHROMA_PORT', parse: Env.parsePort}
+        }
+    },
+    orchestrator: {
+        deploymentMode: 'NEO_AI_DEPLOYMENT_MODE'
+    }
+};
+
+/**
  * @class Neo.ai.Config
- * @extends Neo.core.Base
+ * @extends Neo.ai.BaseConfig
  * @singleton
  */
-class Config extends Base {
+class Config extends BaseConfig {
     static config = {
         /**
          * @member {String} className='Neo.ai.Config'
@@ -440,62 +488,18 @@ class Config extends Base {
          * @member {Boolean} singleton=true
          * @protected
          */
-        singleton: true
-    }
-
-    /**
-     * The configuration data object.
-     * @member {Object} data
-     */
-    data = null;
-
-    /**
-     * @param {Object} config
-     */
-    construct(config) {
-        super.construct(config);
-        this.data = Neo.clone(defaultConfig, true);
-    }
-
-    /**
-     * Loads a JSON or MJS configuration file and merges it into the current data.
-     * @param {String} filePath
-     */
-    async load(filePath) {
-        if (!filePath) return;
-
-        try {
-            const absolutePath = path.resolve(filePath);
-            const ext          = path.extname(absolutePath);
-            let   customConfig;
-
-            if (ext === '.mjs' || ext === '.js') {
-                const module = await import(absolutePath);
-                customConfig = module.default;
-            } else {
-                const content = await fs.readFile(absolutePath, 'utf-8');
-                customConfig  = JSON.parse(content);
-            }
-
-            // Deep merge custom config into the data object
-            Neo.merge(this.data, customConfig);
-
-            console.error(`[Config] Loaded custom configuration from ${absolutePath}`);
-
-        } catch (error) {
-            console.error(`[Config] Failed to load configuration from ${filePath}:`, error.message);
-            throw error;
-        }
+        singleton: true,
+        /**
+         * @member {Object} defaultConfig
+         */
+        defaultConfig,
+        /**
+         * @member {Object} envBindings
+         */
+        envBindings
     }
 }
 
 const instance = Neo.setupClass(Config);
 
-export default new Proxy(instance, {
-    get(target, prop, receiver) {
-        if (Reflect.has(target, prop)) {
-            return Reflect.get(target, prop, receiver);
-        }
-        return target.data[prop];
-    }
-});
+export default createConfigProxy(instance);

--- a/ai/mcp/server/github-workflow/config.template.mjs
+++ b/ai/mcp/server/github-workflow/config.template.mjs
@@ -1,6 +1,6 @@
 import path            from 'path';
 import {fileURLToPath} from 'url';
-import BaseConfig, { createConfigProxy } from '../shared/BaseConfig.mjs';
+import BaseConfig, { createConfigProxy } from '../../../BaseConfig.mjs';
 
 const __filename  = fileURLToPath(import.meta.url);
 const __dirname   = path.dirname(__filename);
@@ -259,8 +259,10 @@ const defaultConfig = {
 };
 
 const envBindings = {
-    'issueSync.archiveRoot': 'NEO_MCP_GITHUB_ARCHIVE_ROOT',
-    'logLevel': { var: 'NEO_LOG_LEVEL', parse: parseLogLevel }
+    issueSync: {
+        archiveRoot: 'NEO_MCP_GITHUB_ARCHIVE_ROOT'
+    },
+    logLevel: {var: 'NEO_LOG_LEVEL', parse: parseLogLevel}
 };
 
 /**
@@ -270,7 +272,7 @@ const envBindings = {
  * The configuration handles GitHub repository details, sync settings, and server behavior options.
  *
  * @class Neo.ai.mcp.server.github-workflow.Config
- * @extends Neo.core.Base
+ * @extends Neo.ai.BaseConfig
  * @singleton
  */
 class Config extends BaseConfig {
@@ -284,12 +286,16 @@ class Config extends BaseConfig {
          * @member {Boolean} singleton=true
          * @protected
          */
-        singleton: true
+        singleton: true,
+        /**
+         * @member {Object} defaultConfig
+         */
+        defaultConfig,
+        /**
+         * @member {Object} envBindings
+         */
+        envBindings
     }
-
-    defaultConfig = defaultConfig;
-    envBindings = envBindings;
-
 }
 const instance = Neo.setupClass(Config);
 

--- a/ai/mcp/server/gitlab-workflow/config.template.mjs
+++ b/ai/mcp/server/gitlab-workflow/config.template.mjs
@@ -1,6 +1,6 @@
 import path                                       from 'path';
 import {fileURLToPath}                            from 'url';
-import BaseConfig, {createConfigProxy}            from '../shared/BaseConfig.mjs';
+import BaseConfig, {createConfigProxy}            from '../../../BaseConfig.mjs';
 import Env from '../../../../src/util/Env.mjs';
 
 const __filename     = fileURLToPath(import.meta.url);
@@ -88,15 +88,17 @@ const envBindings = {
     debug           : {var: 'NEO_GITLAB_WORKFLOW_DEBUG', parse: Env.parseBool},
     logLevel        : {var: 'NEO_GITLAB_WORKFLOW_LOG_LEVEL', parse: parseLogLevel},
     transport       : {var: 'NEO_GITLAB_WORKFLOW_TRANSPORT', parse: Env.parseString},
-    'gitlab.hostUrl': {var: 'NEO_GITLAB_HOST', parse: Env.parseUrl},
-    'gitlab.token'  : {var: 'NEO_GITLAB_PAT', parse: Env.parseString}
+    gitlab          : {
+        hostUrl: {var: 'NEO_GITLAB_HOST', parse: Env.parseUrl},
+        token  : {var: 'NEO_GITLAB_PAT',  parse: Env.parseString}
+    }
 };
 
 /**
  * @summary GitLab Workflow MCP configuration singleton.
  *
  * @class Neo.ai.mcp.server.gitlab-workflow.Config
- * @extends Neo.ai.mcp.server.shared.BaseConfig
+ * @extends Neo.ai.BaseConfig
  */
 class Config extends BaseConfig {
     static config = {
@@ -109,11 +111,16 @@ class Config extends BaseConfig {
          * @member {Boolean} singleton=true
          * @protected
          */
-        singleton: true
+        singleton: true,
+        /**
+         * @member {Object} defaultConfig
+         */
+        defaultConfig,
+        /**
+         * @member {Object} envBindings
+         */
+        envBindings
     }
-
-    defaultConfig = defaultConfig
-    envBindings   = envBindings
 }
 
 const instance = Neo.setupClass(Config);

--- a/ai/mcp/server/knowledge-base/config.template.mjs
+++ b/ai/mcp/server/knowledge-base/config.template.mjs
@@ -1,7 +1,7 @@
 import os              from 'os';
 import path            from 'path';
 import AiConfig        from '../../../config.template.mjs';
-import BaseConfig, { createConfigProxy } from '../shared/BaseConfig.mjs';
+import BaseConfig, { createConfigProxy } from '../../../BaseConfig.mjs';
 import {fileURLToPath} from 'url';
 import Env from '../../../../src/util/Env.mjs';
 
@@ -16,31 +16,30 @@ const neoRootDir = path.resolve(__dirname, '../../../../');
  */
 
 const envBindings = {
-    'autoSync': { var: 'NEO_AUTO_SYNC', parse: Env.parseBool },
-    'autoStartDatabase': { var: 'NEO_KB_AUTO_START_DATABASE', parse: Env.parseBool },
-    'transport': 'NEO_TRANSPORT',
-    'mcpHttpPort': { var: 'MCP_HTTP_PORT', parse: Env.parsePort },
-    'publicUrl': { var: 'NEO_PUBLIC_URL', parse: Env.parseUrl },
-
-    'auth.host': 'NEO_AUTH_HOST',
-    'auth.port': { var: 'NEO_AUTH_PORT', parse: Env.parsePort },
-    'auth.realm': 'NEO_AUTH_REALM',
-    'auth.issuerUrl': 'NEO_AUTH_ISSUER_URL',
-    'auth.clientId': 'NEO_OAUTH_CLIENT_ID',
-    'auth.clientSecret': 'NEO_OAUTH_CLIENT_SECRET',
-    'auth.trustProxyIdentity': { var: 'NEO_AUTH_TRUST_PROXY_IDENTITY', parse: Env.parseBool },
-
-    'host': 'NEO_CHROMA_HOST',
-    'port': { var: 'NEO_CHROMA_PORT', parse: Env.parsePort },
-
-    'memoryCoreDbPath': 'NEO_MEMORY_DB_PATH',
-    'kbFaqMinCount': { var: 'NEO_KB_FAQ_MIN_COUNT', parse: Env.parseNumber },
-    'kbFaqSimilarityThreshold': { var: 'NEO_KB_FAQ_SIMILARITY_THRESHOLD', parse: Env.parseNumber },
-    'kbFaqConceptLimit': { var: 'NEO_KB_FAQ_CONCEPT_LIMIT', parse: Env.parseNumber },
-    'defaultTenantId': 'NEO_KB_DEFAULT_TENANT_ID',
-    'defaultRepoSlug': 'NEO_KB_DEFAULT_REPO_SLUG',
-    'defaultVisibility': 'NEO_KB_DEFAULT_VISIBILITY',
-    'spoofRejectionMode': 'NEO_KB_SPOOF_REJECTION_MODE'
+    autoSync         : { var: 'NEO_AUTO_SYNC', parse: Env.parseBool },
+    autoStartDatabase: { var: 'NEO_KB_AUTO_START_DATABASE', parse: Env.parseBool },
+    transport        : 'NEO_TRANSPORT',
+    mcpHttpPort      : { var: 'MCP_HTTP_PORT', parse: Env.parsePort },
+    publicUrl        : { var: 'NEO_PUBLIC_URL', parse: Env.parseUrl },
+    auth             : {
+        host              : 'NEO_AUTH_HOST',
+        port              : { var: 'NEO_AUTH_PORT', parse: Env.parsePort },
+        realm             : 'NEO_AUTH_REALM',
+        issuerUrl         : 'NEO_AUTH_ISSUER_URL',
+        clientId          : 'NEO_OAUTH_CLIENT_ID',
+        clientSecret      : 'NEO_OAUTH_CLIENT_SECRET',
+        trustProxyIdentity: { var: 'NEO_AUTH_TRUST_PROXY_IDENTITY', parse: Env.parseBool }
+    },
+    host                    : 'NEO_CHROMA_HOST',
+    port                    : { var: 'NEO_CHROMA_PORT', parse: Env.parsePort },
+    memoryCoreDbPath        : 'NEO_MEMORY_DB_PATH',
+    kbFaqMinCount           : { var: 'NEO_KB_FAQ_MIN_COUNT', parse: Env.parseNumber },
+    kbFaqSimilarityThreshold: { var: 'NEO_KB_FAQ_SIMILARITY_THRESHOLD', parse: Env.parseNumber },
+    kbFaqConceptLimit       : { var: 'NEO_KB_FAQ_CONCEPT_LIMIT', parse: Env.parseNumber },
+    defaultTenantId         : 'NEO_KB_DEFAULT_TENANT_ID',
+    defaultRepoSlug         : 'NEO_KB_DEFAULT_REPO_SLUG',
+    defaultVisibility       : 'NEO_KB_DEFAULT_VISIBILITY',
+    spoofRejectionMode      : 'NEO_KB_SPOOF_REJECTION_MODE'
 };
 
 const defaultConfig = {
@@ -372,7 +371,7 @@ const defaultConfig = {
  * Supports loading configuration from a custom file and merging with defaults.
  *
  * @class Neo.ai.mcp.server.knowledge-base.Config
- * @extends Neo.core.Base
+ * @extends Neo.ai.BaseConfig
  * @singleton
  */
 class Config extends BaseConfig {
@@ -386,12 +385,16 @@ class Config extends BaseConfig {
          * @member {Boolean} singleton=true
          * @protected
          */
-        singleton: true
+        singleton: true,
+        /**
+         * @member {Object} defaultConfig
+         */
+        defaultConfig,
+        /**
+         * @member {Object} envBindings
+         */
+        envBindings
     }
-
-    defaultConfig = defaultConfig;
-    envBindings = envBindings;
-
 }
 const instance = Neo.setupClass(Config);
 

--- a/ai/mcp/server/memory-core/config.template.mjs
+++ b/ai/mcp/server/memory-core/config.template.mjs
@@ -1,6 +1,6 @@
 import path                              from 'path';
 import AiConfig                          from '../../../config.template.mjs';
-import BaseConfig, {createConfigProxy}   from '../shared/BaseConfig.mjs';
+import BaseConfig, {createConfigProxy}   from '../../../BaseConfig.mjs';
 import {fileURLToPath}                   from 'url';
 import Env                               from '../../../../src/util/Env.mjs';
 
@@ -408,64 +408,77 @@ const defaultConfig = {
 
 /**
  * Single source of truth for environment variable overrides.
- * Maps dot-notation paths in the configuration object to environment variables and parser functions.
+ * Maps nested configuration paths to environment variables and parser functions.
  */
 const envBindings = {
-    'autoSummarize': { var: 'NEO_AUTO_SUMMARIZE', parse: Env.parseBool},
-    'autoStartDatabase': { var: 'NEO_MEM_AUTO_START_DATABASE', parse: Env.parseBool},
-    'autoStartInference': { var: 'NEO_MEM_AUTO_START_INFERENCE', parse: Env.parseBool},
-    'autoDream': { var: 'NEO_AUTO_DREAM', parse: Env.parseBool},
-    'autoGoldenPath': { var: 'NEO_AUTO_GOLDEN_PATH', parse: Env.parseBool},
-    'realTimeMemoryParsing': { var: 'NEO_REAL_TIME_MEMORY_PARSING', parse: Env.parseBool},
-    'autoIngestFileSystem': { var: 'NEO_AUTO_INGEST_FS', parse: Env.parseBool},
-    'debug': { var: 'NEO_DEBUG', parse: Env.parseBool},
-    'transport': 'NEO_TRANSPORT',
-    'mcpHttpPort': { var: 'MCP_HTTP_PORT', parse: Env.parsePort},
-    'publicUrl': { var: 'NEO_PUBLIC_URL', parse: Env.parseUrl},
-
-    'auth.host': 'NEO_AUTH_HOST',
-    'auth.port': { var: 'NEO_AUTH_PORT', parse: Env.parsePort},
-    'auth.realm': 'NEO_AUTH_REALM',
-    'auth.issuerUrl': 'NEO_AUTH_ISSUER_URL',
-    'auth.clientId': 'NEO_OAUTH_CLIENT_ID',
-    'auth.clientSecret': 'NEO_OAUTH_CLIENT_SECRET',
-    'auth.trustProxyIdentity': { var: 'NEO_AUTH_TRUST_PROXY_IDENTITY', parse: Env.parseBool},
-
-    'modelProvider': 'NEO_MODEL_PROVIDER',
-    'embeddingProvider': 'NEO_EMBEDDING_PROVIDER',
-
-    'ollama.host': 'NEO_OLLAMA_HOST',
-    'ollama.model': 'NEO_OLLAMA_MODEL',
-    'ollama.embeddingModel': 'NEO_OLLAMA_EMBEDDING_MODEL',
-
-    'openAiCompatible.host': 'NEO_OPENAI_COMPATIBLE_HOST',
-    'openAiCompatible.model': 'NEO_OPENAI_COMPATIBLE_MODEL',
-    'openAiCompatible.embeddingModel': 'NEO_OPENAI_COMPATIBLE_EMBEDDING_MODEL',
-    'openAiCompatible.apiKey': 'NEO_OPENAI_COMPATIBLE_API_KEY',
-    'openAiCompatible.unloadRetryCount': { var: 'NEO_OPENAI_COMPATIBLE_UNLOAD_RETRY_COUNT', parse: Env.parseNumber},
-    'openAiCompatible.unloadRetryDelayMs': { var: 'NEO_OPENAI_COMPATIBLE_UNLOAD_RETRY_DELAY_MS', parse: Env.parseNumber},
-
-    'vectorDimension': { var: 'NEO_VECTOR_DIMENSION', parse: Env.parseNumber},
-
-    'engines.chroma.host': 'NEO_CHROMA_HOST',
-    'engines.chroma.port': { var: 'NEO_CHROMA_PORT', parse: Env.parsePort},
-
-    'collections.memory': 'NEO_MEMORY_COLLECTION_NAME',
-    'collections.session': 'NEO_SESSION_COLLECTION_NAME',
-    'collections.graph': 'NEO_GRAPH_COLLECTION_NAME',
-
-    'storagePaths.graph': 'NEO_MEMORY_DB_PATH',
-
-    'datasets.rlaif.trajectories': 'NEO_RLAIF_PATH',
-    'decayFactor': { var: 'NEO_GRAPH_DECAY_FACTOR', parse: Env.parseNumber},
-    'guideGapWeightThreshold': { var: 'NEO_GUIDE_GAP_WEIGHT_THRESHOLD', parse: Env.parseNumber},
-
-    'conceptDiscovery.prScanLimit': { var: 'NEO_CONCEPT_DISCOVERY_PR_SCAN_LIMIT', parse: Env.parseNumber},
-    'conceptDiscovery.minSourceLength': { var: 'NEO_CONCEPT_DISCOVERY_MIN_SOURCE_LENGTH', parse: Env.parseNumber},
-
-    'mailbox.defaultReplyPolicy': 'NEO_MAILBOX_DEFAULT_REPLY_POLICY',
-    'memorySharing.defaultPolicy': { var: 'NEO_MEMORY_SHARING_DEFAULT_POLICY', parse: parseMemorySharingPolicy },
-    'lazyEdgesQueuePath': 'NEO_LAZY_EDGES_QUEUE_PATH'
+    autoSummarize        : { var: 'NEO_AUTO_SUMMARIZE', parse: Env.parseBool},
+    autoStartDatabase    : { var: 'NEO_MEM_AUTO_START_DATABASE', parse: Env.parseBool},
+    autoStartInference   : { var: 'NEO_MEM_AUTO_START_INFERENCE', parse: Env.parseBool},
+    autoDream            : { var: 'NEO_AUTO_DREAM', parse: Env.parseBool},
+    autoGoldenPath       : { var: 'NEO_AUTO_GOLDEN_PATH', parse: Env.parseBool},
+    realTimeMemoryParsing: { var: 'NEO_REAL_TIME_MEMORY_PARSING', parse: Env.parseBool},
+    autoIngestFileSystem : { var: 'NEO_AUTO_INGEST_FS', parse: Env.parseBool},
+    debug                : { var: 'NEO_DEBUG', parse: Env.parseBool},
+    transport            : 'NEO_TRANSPORT',
+    mcpHttpPort          : { var: 'MCP_HTTP_PORT', parse: Env.parsePort},
+    publicUrl            : { var: 'NEO_PUBLIC_URL', parse: Env.parseUrl},
+    auth                 : {
+        host              : 'NEO_AUTH_HOST',
+        port              : { var: 'NEO_AUTH_PORT', parse: Env.parsePort},
+        realm             : 'NEO_AUTH_REALM',
+        issuerUrl         : 'NEO_AUTH_ISSUER_URL',
+        clientId          : 'NEO_OAUTH_CLIENT_ID',
+        clientSecret      : 'NEO_OAUTH_CLIENT_SECRET',
+        trustProxyIdentity: { var: 'NEO_AUTH_TRUST_PROXY_IDENTITY', parse: Env.parseBool}
+    },
+    modelProvider     : 'NEO_MODEL_PROVIDER',
+    embeddingProvider : 'NEO_EMBEDDING_PROVIDER',
+    ollama            : {
+        host          : 'NEO_OLLAMA_HOST',
+        model         : 'NEO_OLLAMA_MODEL',
+        embeddingModel: 'NEO_OLLAMA_EMBEDDING_MODEL'
+    },
+    openAiCompatible: {
+        host              : 'NEO_OPENAI_COMPATIBLE_HOST',
+        model             : 'NEO_OPENAI_COMPATIBLE_MODEL',
+        embeddingModel    : 'NEO_OPENAI_COMPATIBLE_EMBEDDING_MODEL',
+        apiKey            : 'NEO_OPENAI_COMPATIBLE_API_KEY',
+        unloadRetryCount  : { var: 'NEO_OPENAI_COMPATIBLE_UNLOAD_RETRY_COUNT', parse: Env.parseNumber},
+        unloadRetryDelayMs: { var: 'NEO_OPENAI_COMPATIBLE_UNLOAD_RETRY_DELAY_MS', parse: Env.parseNumber}
+    },
+    vectorDimension: { var: 'NEO_VECTOR_DIMENSION', parse: Env.parseNumber},
+    engines        : {
+        chroma: {
+            host: 'NEO_CHROMA_HOST',
+            port: { var: 'NEO_CHROMA_PORT', parse: Env.parsePort}
+        }
+    },
+    collections: {
+        memory : 'NEO_MEMORY_COLLECTION_NAME',
+        session: 'NEO_SESSION_COLLECTION_NAME',
+        graph  : 'NEO_GRAPH_COLLECTION_NAME'
+    },
+    storagePaths: {
+        graph: 'NEO_MEMORY_DB_PATH'
+    },
+    datasets: {
+        rlaif: {
+            trajectories: 'NEO_RLAIF_PATH'
+        }
+    },
+    decayFactor            : { var: 'NEO_GRAPH_DECAY_FACTOR', parse: Env.parseNumber},
+    guideGapWeightThreshold: { var: 'NEO_GUIDE_GAP_WEIGHT_THRESHOLD', parse: Env.parseNumber},
+    conceptDiscovery       : {
+        prScanLimit    : { var: 'NEO_CONCEPT_DISCOVERY_PR_SCAN_LIMIT', parse: Env.parseNumber},
+        minSourceLength: { var: 'NEO_CONCEPT_DISCOVERY_MIN_SOURCE_LENGTH', parse: Env.parseNumber}
+    },
+    mailbox: {
+        defaultReplyPolicy: 'NEO_MAILBOX_DEFAULT_REPLY_POLICY'
+    },
+    memorySharing: {
+        defaultPolicy: { var: 'NEO_MEMORY_SHARING_DEFAULT_POLICY', parse: parseMemorySharingPolicy }
+    },
+    lazyEdgesQueuePath: 'NEO_LAZY_EDGES_QUEUE_PATH'
 };
 
 /**
@@ -474,7 +487,7 @@ const envBindings = {
  * Supports loading configuration from a custom file and merging with defaults.
  *
  * @class Neo.ai.mcp.server.memory-core.Config
- * @extends Neo.core.Base
+ * @extends Neo.ai.BaseConfig
  * @singleton
  */
 class Config extends BaseConfig {
@@ -488,12 +501,16 @@ class Config extends BaseConfig {
          * @member {Boolean} singleton=true
          * @protected
          */
-        singleton: true
+        singleton: true,
+        /**
+         * @member {Object} defaultConfig
+         */
+        defaultConfig,
+        /**
+         * @member {Object} envBindings
+         */
+        envBindings
     }
-
-    defaultConfig = defaultConfig;
-    envBindings = envBindings;
-
 }
 const instance = Neo.setupClass(Config);
 

--- a/ai/mcp/server/neural-link/config.template.mjs
+++ b/ai/mcp/server/neural-link/config.template.mjs
@@ -1,7 +1,7 @@
 import os              from 'os';
 import path            from 'path';
 import {fileURLToPath} from 'url';
-import BaseConfig, { createConfigProxy } from '../shared/BaseConfig.mjs';
+import BaseConfig, { createConfigProxy } from '../../../BaseConfig.mjs';
 import Env from '../../../../src/util/Env.mjs';
 
 const __filename = fileURLToPath(import.meta.url);
@@ -93,7 +93,7 @@ const defaultConfig = {
  * Supports loading configuration from a custom file and merging with defaults.
  *
  * @class Neo.ai.mcp.server.neural-link.Config
- * @extends Neo.core.Base
+ * @extends Neo.ai.BaseConfig
  * @singleton
  */
 class Config extends BaseConfig {
@@ -107,23 +107,16 @@ class Config extends BaseConfig {
          * @member {Boolean} singleton=true
          * @protected
          */
-        singleton: true
+        singleton: true,
+        /**
+         * @member {Object} defaultConfig
+         */
+        defaultConfig,
+        /**
+         * @member {Object} envBindings
+         */
+        envBindings
     }
-
-    defaultConfig = defaultConfig;
-    envBindings = envBindings;
-
-    /**
-     * Applies legacy environment variable fallbacks
-     */
-    applyLegacyEnv() {
-        // NEO_MEMORY_CORE_DB_PATH fallback for memoryCoreDbPath
-        if (process.env.NEO_MEMORY_CORE_DB_PATH && !process.env.NEO_MEMORY_DB_PATH) {
-            this.data.memoryCoreDbPath = process.env.NEO_MEMORY_CORE_DB_PATH;
-        }
-    }
-
-
 }
 const instance = Neo.setupClass(Config);
 

--- a/learn/benefits/ArchitectureOverview.md
+++ b/learn/benefits/ArchitectureOverview.md
@@ -372,6 +372,7 @@ Post-M6 ([#10986](https://github.com/neomjs/neo/issues/10986)) the per-MCP-serve
 |---|---|---|---|
 | `ai/Agent.mjs` | Agent base class | `Agent` | — |
 | `ai/agent/` | Cognitive runtime | `Loop`, `Orchestrator`, `Scheduler` | — |
+| `ai/config.template.mjs`, `ai/BaseConfig.mjs` | Tier-1 Agent OS config template and shared config base consumed by top-level and MCP server configs | `Config`, `BaseConfig` | — |
 | `ai/context/` | Context window management | `Assembler` | — |
 | `ai/provider/` | LLM abstraction | `Gemini`, `Ollama`, `OpenAiCompatible` | — |
 | `ai/services.mjs` | SDK with Zod validation aggregator | — | — |

--- a/src/util/Env.mjs
+++ b/src/util/Env.mjs
@@ -42,13 +42,13 @@ const Env = {
     /**
      * Bulk-apply env→config bindings.
      *
-     * Binding shapes:
-     * - `{<dotted.path>: <envVarName>}` — implicit `parseString` parser
-     * - `{<dotted.path>: {var: <envVarName>, parse: <parserFn>}}` — typed parser
+     * Binding shapes mirror the config object shape:
+     * - `{auth: {host: <envVarName>}}` — implicit `parseString` parser
+     * - `{auth: {port: {var: <envVarName>, parse: <parserFn>}}}` — typed parser
      *
      * Bindings whose env var is absent or whose parser returns undefined are skipped
-     * (leaves the existing `data` value untouched). Uses `Neo.ns()` for namespace-walk;
-     * warns + skips if an intermediate is not an object.
+     * (leaves the existing `data` value untouched). Uses `Neo.assignToNs()` for the
+     * final assignment; warns + skips if an intermediate is not an object.
      *
      * Note: binding paths are developer-authored at source level (NOT env-value-derived);
      * env values become typed leaf values via the parser, never path keys. No prototype-
@@ -60,24 +60,41 @@ const Env = {
      * @param {Function} [warn=console.warn]
      */
     applyEnvBindings(data, envBindings, env = process.env, warn = console.warn) {
-        for (const [path, binding] of Object.entries(envBindings)) {
-            const { var: varName, parse } = typeof binding === 'string'
-                ? { var: binding, parse: Env.parseString }
+        const applyBinding = (path, binding) => {
+            const {var: varName, parse = Env.parseString} = typeof binding === 'string'
+                ? {var: binding, parse: Env.parseString}
                 : binding;
 
             const result = parse(varName, {env, warn});
-            if (result === undefined) continue;
+            if (result === undefined) return;
 
-            const keys     = path.split('.');
-            const finalKey = keys.pop();
-            const parent   = keys.length ? Neo.ns(keys, false, data) : data;
+            const parentPath = path.slice(0, -1),
+                  parent     = parentPath.length ? Neo.ns(parentPath, false, data) : data;
 
             if (Neo.isObject(parent)) {
-                parent[finalKey] = result;
+                Neo.assignToNs(path, result, data);
             } else {
-                warn(`[Neo.util.Env] Cannot bind ${varName} to "${path}" — intermediate is not an object.`);
+                warn(`[Neo.util.Env] Cannot bind ${varName} to "${path.join('.')}" — intermediate is not an object.`);
             }
-        }
+        };
+
+        const walk = (bindings, path = []) => {
+            for (const [key, binding] of Object.entries(bindings)) {
+                const isBindingDescriptor = Neo.isObject(binding) && Object.prototype.hasOwnProperty.call(binding, 'var');
+
+                if (key.includes('.')) {
+                    throw new Error(`[Neo.util.Env] Dotted envBinding paths are not supported: "${path.concat(key).join('.')}". Use nested binding objects.`);
+                }
+
+                if (typeof binding === 'string' || isBindingDescriptor) {
+                    applyBinding(path.concat(key), binding);
+                } else if (Neo.isObject(binding)) {
+                    walk(binding, path.concat(key));
+                }
+            }
+        };
+
+        walk(envBindings);
     },
 
     /**

--- a/test/playwright/unit/util/Env.spec.mjs
+++ b/test/playwright/unit/util/Env.spec.mjs
@@ -158,7 +158,7 @@ test.describe('Neo.util.Env', () => {
     test.describe('applyEnvBindings', () => {
         test('warns + skips when intermediate is not an object (developer-authored path mistake)', () => {
             const data = { a: { b: 'leaf' } };
-            const bindings = { 'a.b.c': { var: 'TEST_X', parse: Env.parseNumber } };
+            const bindings = { a: { b: { c: { var: 'TEST_X', parse: Env.parseNumber } } } };
             Env.applyEnvBindings(data, bindings, { TEST_X: '42' }, captureWarn);
             expect(data.a.b).toBe('leaf');
             expect(warns.length).toBe(1);
@@ -174,10 +174,42 @@ test.describe('Neo.util.Env', () => {
 
         test('applies typed bindings with custom parser', () => {
             const data = { config: { port: 0 } };
-            const bindings = { 'config.port': { var: 'TEST_PORT', parse: Env.parsePort } };
+            const bindings = { config: { port: { var: 'TEST_PORT', parse: Env.parsePort } } };
             const env = { TEST_PORT: '8080' };
             Env.applyEnvBindings(data, bindings, env);
             expect(data.config.port).toBe(8080);
+        });
+
+        test('applies nested bindings which mirror the config object shape', () => {
+            const data = {
+                auth: {
+                    host: '',
+                    port: 0
+                }
+            };
+            const bindings = {
+                auth: {
+                    host: 'TEST_AUTH_HOST',
+                    port: { var: 'TEST_AUTH_PORT', parse: Env.parsePort }
+                }
+            };
+            const env = {
+                TEST_AUTH_HOST: 'auth.local',
+                TEST_AUTH_PORT: '8080'
+            };
+
+            Env.applyEnvBindings(data, bindings, env);
+
+            expect(data.auth).toEqual({
+                host: 'auth.local',
+                port: 8080
+            });
+        });
+
+        test('rejects dotted binding keys', () => {
+            expect(() => {
+                Env.applyEnvBindings({}, {'auth.host': 'TEST_AUTH_HOST'}, { TEST_AUTH_HOST: 'auth.local' });
+            }).toThrow(/Dotted envBinding paths are not supported/);
         });
 
         test('skips bindings when env var absent (leaves existing data untouched)', () => {


### PR DESCRIPTION
Related: #10103

Authored by GPT-5 (Codex Desktop). Session 3b454ac4-f2c6-4bf0-9c18-c0af6f432ffa.
FAIR-band: in-band [14/30 — current author count over last 30 merged]

Hard-cuts the Agent OS config env substrate to the v13 shape: Tier-1 and MCP config templates now route defaults and env ledgers through Neo `static config`, env binding keys mirror nested config objects, the shared config base lives at top-level `ai/BaseConfig.mjs`, and legacy env hook surfaces are removed.

Evidence: L2 (template import smoke + focused unit suite) → L2 required (config substrate shape and env parser contract). No residuals.

## Deltas from ticket

Operator clarification applied: no backwards-compatibility layer is preserved. Dotted env binding keys now throw, `applyLegacyEnv()` is gone, and the neural-link legacy memory-core DB env fallback is removed. Follow-up hint applied: `BaseConfig` moved out of MCP-server ownership because `ai/config.template.mjs` is now a direct consumer.

## Config Template Sync

Changed config keys and surfaces:
- Tier-1 `ai/config.template.mjs`: `debug`, `transport`, `publicUrl`, `mcpHttpPort`, `auth.*`, `chatProvider`, `modelProvider`, `embeddingProvider`, `ollama.*`, `openAiCompatible.*`, `vectorDimension`, `engines.chroma.*`, `orchestrator.deploymentMode`.
- MCP templates: Knowledge Base `auth.*`; Memory Core `auth.*`, `ollama.*`, `openAiCompatible.*`, `engines.chroma.*`, `collections.*`, `storagePaths.*`, `datasets.rlaif.*`, `conceptDiscovery.*`, `mailbox.*`, `memorySharing.*`; GitHub Workflow `issueSync.archiveRoot`; GitLab Workflow `gitlab.*`.
- Shared config base: `ai/BaseConfig.mjs`; `data`, `defaultConfig`, and `envBindings` are now Neo static config entries.
- Architecture map: `learn/benefits/ArchitectureOverview.md` now records the Tier-1 config/base-config home.

Local `config.mjs` follow-up after merge: required for active clones. Run `npm run prepare -- --migrate-config` or otherwise refresh the ignored `ai/config.mjs` and `ai/mcp/server/*/config.mjs` overlays from the tracked templates. No ignored `config.mjs` file is committed here.

Harness restart: recommended for live MCP servers and the orchestrator because config singletons are initialized at module load.

## Test Evidence

- `node --input-type=module -e "await import('./src/Neo.mjs'); await import('./src/core/_export.mjs'); await import('./ai/config.template.mjs'); await import('./ai/mcp/server/knowledge-base/config.template.mjs'); await import('./ai/mcp/server/memory-core/config.template.mjs'); await import('./ai/mcp/server/github-workflow/config.template.mjs'); await import('./ai/mcp/server/gitlab-workflow/config.template.mjs'); await import('./ai/mcp/server/neural-link/config.template.mjs'); console.log('template imports ok');"` → PASS
- `npm run test-unit -- test/playwright/unit/util/Env.spec.mjs test/playwright/unit/ai/config.template.spec.mjs test/playwright/unit/ai/mcp/server/knowledge-base/config.template.spec.mjs test/playwright/unit/ai/mcp/server/memory-core/config.template.spec.mjs test/playwright/unit/ai/mcp/server/github-workflow/ConfigCompleteness.spec.mjs` → 40 passed
- `git diff --cached --check` → PASS
- `git diff --check origin/dev...HEAD` → PASS

## Post-Merge Validation

- [ ] Active agent clones refresh ignored local config overlays from templates.
- [ ] Live MCP/orchestrator processes are restarted after overlay refresh.
- [ ] Confirm no `applyLegacyEnv` surface remains in refreshed runtime overlays.

## Commits

- `5dd0740ef` — `feat(ai): hard-cut config env substrate (#10103)`
