### PR TITLE
fix(ai): remove stale graph config consumers (#10126)

### DIFF
--- a/ai/scripts/diagnostics/analyzeNlTelemetry.mjs
+++ b/ai/scripts/diagnostics/analyzeNlTelemetry.mjs
@@ -20,7 +20,7 @@ const __dirname = path.dirname(__filename);
 const ROOT_DIR = path.resolve(__dirname, '../../../');
 import aiConfig from '../../mcp/server/memory-core/config.mjs';
 
-const DB_PATH = process.env.NEO_MEMORY_DB_PATH || path.join(aiConfig.engines.neo.dataDir, aiConfig.engines.neo.filename);
+const DB_PATH = process.env.NEO_MEMORY_DB_PATH || aiConfig.storagePaths.graph;
 const RLAIF_PATH = aiConfig.datasets.rlaif.trajectories;
 
 const sessionId = process.argv[2];

--- a/ai/scripts/maintenance/recreateGraphDb.mjs
+++ b/ai/scripts/maintenance/recreateGraphDb.mjs
@@ -14,10 +14,11 @@ import StorageRouter   from '../../services/memory-core/managers/StorageRouter.m
 async function recreateGraphDb() {
     console.log('⏳ Initializing Graph DB Recreation Script...');
 
-    const dbPath = path.resolve(aiConfig.engines.neo.dataDir, aiConfig.engines.neo.filename);
+    const dbPath = path.resolve(aiConfig.storagePaths.graph);
+    aiConfig.storagePaths.graph = dbPath;
 
     // 1. Delete Native Edge Graph structural elements ONLY (do not destroy standard SQLite Vector memory schemas)
-    console.log(`   Deleting Native Edge Graph Database schema nodes...`);
+    console.log(`   Deleting Native Edge Graph Database schema nodes at ${dbPath}...`);
     // Connect explicitly via GraphService bounds
     await GraphService.ready();
     if (GraphService.db && GraphService.db.storage) {

--- a/test/playwright/unit/ai/scripts/diagnostics/analyzeNlTelemetry.spec.mjs
+++ b/test/playwright/unit/ai/scripts/diagnostics/analyzeNlTelemetry.spec.mjs
@@ -128,4 +128,18 @@ test.describe('Neo.ai.scripts.analyzeNlTelemetry', () => {
         expect(data).toContain('whitebox_e2e_introspection');
         expect(data).toContain('Navigate to user profile');
     });
+
+    test('uses current storagePaths.graph config instead of retired graph-engine paths (#10126)', () => {
+        const diagnosticsSource = fs.readFileSync(scriptPath, 'utf8');
+        const maintenanceSource = fs.readFileSync(
+            path.resolve(process.cwd(), 'ai/scripts/maintenance/recreateGraphDb.mjs'),
+            'utf8'
+        );
+        const retiredPath = ['aiConfig', 'engines', 'neo'].join('.');
+
+        expect(diagnosticsSource).toContain('aiConfig.storagePaths.graph');
+        expect(maintenanceSource).toContain('aiConfig.storagePaths.graph');
+        expect(diagnosticsSource).not.toContain(retiredPath);
+        expect(maintenanceSource).not.toContain(retiredPath);
+    });
 });


### PR DESCRIPTION
Authored by GPT-5 (Codex Desktop). Session 3b454ac4-f2c6-4bf0-9c18-c0af6f432ffa.

FAIR-band: in-band [15/30]

Resolves #10126

Removes the remaining live consumers of the retired `aiConfig.engines.neo` graph path surface from maintenance/diagnostic scripts. Both now route through the current `aiConfig.storagePaths.graph` key, while `analyzeNlTelemetry` preserves `NEO_MEMORY_DB_PATH` as the operator/test override.

Evidence: L1 (targeted unit spec + syntax checks + static grep invariant) -> L1 required (stale config-consumer cleanup). No residuals.

## Deltas from ticket

The ticket's original `SessionSummarization.spec.mjs` symptom was already fixed before pickup. This PR implements the still-valid current intent from the rewritten ticket body: the two remaining script consumers found by live grep.

## Test Evidence

- `npm run test-unit -- test/playwright/unit/ai/scripts/diagnostics/analyzeNlTelemetry.spec.mjs` -> 4/4 PASS
- `node --check ai/scripts/maintenance/recreateGraphDb.mjs` -> PASS
- `node --check ai/scripts/diagnostics/analyzeNlTelemetry.mjs` -> PASS
- `rg -n "aiConfig\\.engines\\.neo|engines\\.neo" ai test/playwright/unit/ai` -> no matches
- `git diff --check` -> PASS

## Implementation Notes

- `ai/scripts/diagnostics/analyzeNlTelemetry.mjs` now resolves `DB_PATH` as `NEO_MEMORY_DB_PATH || aiConfig.storagePaths.graph`.
- `ai/scripts/maintenance/recreateGraphDb.mjs` normalizes `aiConfig.storagePaths.graph` through `path.resolve()` before `GraphService.ready()` so the script and service agree on the active graph path.
- Added focused regression coverage to the existing diagnostics script spec to pin both script sources away from the retired key.

## Post-Merge Validation

- [ ] Operators running the affected scripts do not hit config-shape errors from missing `engines.neo`.

## Commits

- `0327721a2` - `fix(ai): remove stale graph config consumers (#10126)`
