### PR TITLE
feat(ai): move config ledgers into class substrate (#10103)

### DIFF
--- a/ai/config.template.mjs
+++ b/ai/config.template.mjs
@@ -13,496 +13,501 @@ const HOUR_MS = 60 * 60 * 1000;
 const DAY_MS  = 24 * HOUR_MS;
 
 /**
- * Top-level configuration object (Tier 1).
- * Defines the core immutable plain-data structures applied universally across all AI/MCP infrastructure.
- */
-const defaultConfig = {
-    neoRootDir,
-    projectRoot,
-    /**
-     * Global debug flag for all AI processes.
-     * @type {boolean}
-     */
-    debug: false,
-    /**
-     * Transport protocol ('stdio' or 'sse').
-     * @type {string}
-     */
-    transport: 'stdio',
-    /**
-     * Optional public canonical URL.
-     * @type {string|null}
-     */
-    publicUrl: null,
-    /**
-     * Port the MCP server's HTTP/SSE transport listens on.
-     * Sub-servers will typically override this with their own defaultPort.
-     * @type {number}
-     */
-    mcpHttpPort: 3000,
-    /**
-     * Optional Express middleware function for authentication.
-     * @type {Function|null}
-     */
-    authMiddleware: null,
-    /**
-     * Base authentication configuration.
-     * @type {Object}
-     */
-    auth: {
-        host              : null,
-        port              : 8080,
-        realm             : 'master',
-        issuerUrl         : null,
-        clientId          : null,
-        clientSecret      : '',
-        trustProxyIdentity: false
-    },
-    /**
-     * @summary Deployment-wide chat / generation model provider.
-     *
-     * Tier-1 source of truth for model-consuming Agent OS lanes. Memory Core maps
-     * this into its historical `modelProvider` key until runtime provider routing
-     * graduates from #10103 Sub-2. Supported values today: `gemini`,
-     * `openAiCompatible`.
-     * @type {String}
-     */
-    chatProvider: 'gemini',
-    /**
-     * @summary Runtime alias for the active chat provider.
-     *
-     * Existing Memory Core consumers read `modelProvider`; keep the Tier-1
-     * template aligned with `chatProvider` until provider routing converges on
-     * one canonical key.
-     * @type {String}
-     */
-    modelProvider: 'gemini',
-    /**
-     * @summary Deployment-wide embedding provider selector.
-     *
-     * Shared by Memory Core embedding consumers and Knowledge Base ingestion
-     * paths.
-     * @type {String}
-     */
-    embeddingProvider: 'openAiCompatible',
-    /**
-     * @summary Deployment-wide Ollama provider defaults.
-     *
-     * These are configuration defaults only. Runtime dispatch support for native
-     * `ollama` is owned by #10103 Sub-2.
-     * @type {Object}
-     */
-    ollama: {
-        host          : 'http://127.0.0.1:11434',
-        model         : 'gemma4:31b',
-        embeddingModel: 'qwen3-embedding'
-    },
-    /**
-     * @summary Deployment-wide OpenAI-compatible provider defaults.
-     *
-     * Covers MLX, LM Studio, Ollama's OpenAI-compatible surface, llama.cpp, and
-     * managed OpenAI-compatible endpoints.
-     * @type {Object}
-     */
-    openAiCompatible: {
-        host                    : 'http://127.0.0.1:11434',
-        model                   : 'gemma-4-31b-it',
-        embeddingModel          : 'text-embedding-qwen3-embedding-8b',
-        apiKey                  : '',
-        unloadRetryCount        : 3,
-        unloadRetryDelayMs      : 500,
-        contextLimitTokens      : 32768,
-        safeProcessingLimitTokens: undefined
-    },
-    /**
-     * @summary Deployment-wide Gemini model defaults.
-     *
-     * Memory Core still exposes these historical field names for Gemini-backed
-     * summary and embedding paths; Tier-1 owns the default tuple.
-     * @type {String}
-     */
-    modelName: 'gemini-2.5-flash',
-    /**
-     * @summary Deployment-wide Gemini embedding model default.
-     * @type {String}
-     */
-    embeddingModel: 'gemini-embedding-001',
-    /**
-     * @summary Enforced vector dimension across shared vector collections.
-     *
-     * Hard-configured to prevent schema wipes when operators change embedding
-     * providers. Gemini deployments must explicitly pair provider and dimension
-     * overrides.
-     * @type {Number}
-     */
-    vectorDimension: 4096,
-    /**
-     * @summary Deployment-wide storage engine coordinates.
-     *
-     * `engines.chroma` is the unified Chroma topology from ADR 0003. Collection
-     * names and local persistence directories remain server-local.
-     * @type {Object}
-     */
-    engines: {
-        chroma: {
-            host: 'localhost',
-            port: 8000
-        }
-    },
-    /**
-     * Agent OS maintenance orchestrator configuration.
-     * @type {Object}
-     */
-    orchestrator: {
-        /**
-         * Deployment profile for Agent OS maintenance ownership.
-         * `local` preserves maintainer-checkout behavior; `cloud` disables local-only
-         * maintenance lanes unless a narrower localOnly override opts them back in.
-         * @type {'local'|'cloud'}
-         */
-        deploymentMode: 'local',
-        /**
-         * Maintenance-loop intervals consumed by the orchestrator daemon.
-         * Env vars at the daemon boundary retain precedence over these defaults.
-         * @type {Object}
-         */
-        intervals: {
-            pollMs           : 3000,
-            summarySweepMs   : 10 * 60 * 1000,
-            kbSyncMs         : 30 * 60 * 1000,
-            backupMs         : DAY_MS,
-            primaryDevSyncMs : 10 * 60 * 1000,
-            tenantRepoSyncMs : 30 * 60 * 1000,
-            dreamMs          : HOUR_MS,
-            goldenPathMs     : HOUR_MS,
-            swarmHeartbeatMs : 15 * 60 * 1000
-        },
-        /**
-         * Swarm-heartbeat target-resolver config. Controls which identity set
-         * `SwarmHeartbeatService.pulse()` targets per cycle via the resolver
-         * precedence chain. Env override: `NEO_ORCHESTRATOR_SWARM_HEARTBEAT_TARGET_SOURCE`.
-         * Explicit list override (highest precedence):
-         * `NEO_ORCHESTRATOR_SWARM_HEARTBEAT_TARGETS` (comma-separated handles).
-         * @type {Object}
-         */
-        swarmHeartbeat: {
-            /**
-             * Resolver source enum. `null` falls through to `'self'` — the
-             * deployment-portable default. Valid values: `'self'`,
-             * `'active-local-team'`, `'active-subscribers'`, `'disabled'`. External
-             * workspaces with no config default to `'self'`; the lane never silently
-             * fans out to maintainer identities unless the operator explicitly opts
-             * in via `'active-local-team'`.
-             * @type {'self'|'active-local-team'|'active-subscribers'|'disabled'|null}
-             */
-            targetSource: null
-        },
-        /**
-         * Local-only maintenance lane switches. Cloud deployments can disable these
-         * without changing remote graph-backed A2A / Memory Core behavior.
-         * `null` means "use the deployment profile default" (`local` enables,
-         * `cloud` disables); set `true` only when explicitly opting a lane back in.
-         * @type {Object}
-         */
-        localOnly: {
-            primaryDevSyncEnabled: null,
-            kbSyncEnabled        : null,
-            bridgeDaemonEnabled  : null,
-            goldenPathRepoEnrichmentEnabled: null,
-            // `null` = use the deployment-profile default (local enables, cloud disables);
-            // the swarm-heartbeat lane is the folded-in wake-substrate pulse (#11766).
-            swarmHeartbeatEnabled: null,
-            // Reserved policy placeholder: no runtime consumer yet.
-            // `bridgeDaemonEnabled` is the active scheduler gate for desktop wake delivery.
-            wakeDispatchEnabled  : null
-        },
-        /**
-         * Cloud-only maintenance lane switches (mirror of `localOnly` with inverted
-         * deployment-default: `null` means "use the deployment-profile default" —
-         * cloud enables, local disables. Set `true` only when explicitly opting a
-         * lane back in for the LOCAL profile (e.g. operator-side smoke testing of
-         * tenant-repo-sync without a cloud-profile container).
-         * @type {Object}
-         */
-        cloudOnly: {
-            // tenant-repo-sync: cloud-deployable per ADR 0014 + #11740. Cloud
-            // profile defaults enabled when tenant repos are configured; local
-            // Neo-maintainer profile defaults disabled unless explicitly opted in.
-            tenantRepoSyncEnabled: null
-        },
-        /**
-         * Optional local Neo repo roots for the primary-dev-sync lane.
-         * Keep the template machine-neutral; set real absolute paths in gitignored
-         * `ai/config.mjs` or via `NEO_ORCHESTRATOR_DEV_SYNC_ROOTS`.
-         * @type {String[]}
-         */
-        devSyncRoots: [],
-        /**
-         * Tenant-repo-sync per-repo scheduling parameters (#11942 AC1).
-         *
-         * The cadence floor lives in `intervals.tenantRepoSyncMs` above (30min default).
-         * Per-repo cadence in `tenantRepos[].cadenceMs` (operator-set) overrides global.
-         *
-         * - `jitterRatio` caps the deterministic per-repo jitter offset as a fraction
-         *   of the base cadence. Default `0.20` (≤20% of cadence per AC1 prescription).
-         *   Set `0` to disable jitter entirely (deterministic-cadence-only, no anti-
-         *   thundering-herd protection — only safe for low-tenant deployments).
-         * - `sweepCadenceMs` is the frequency at which the orchestrator wakes the
-         *   tenant-repo-sync task. Decoupled from per-repo cadence (`intervals.tenantRepoSyncMs`)
-         *   so deterministic jitter can actually spread per-repo sync attempts across
-         *   the jitter window. A short sweep cadence + a long per-repo cadence means
-         *   each sweep checks all repos against their individual due-times; repos
-         *   become due at different sweeps based on their deterministic jitter offset.
-         *
-         * @type {Object}
-         */
-        tenantRepoSync: {
-            jitterRatio   : 0.20,
-            sweepCadenceMs: 60 * 1000
-        },
-        /**
-         * Orchestrator-owned MLX inference server config. Operators tune via gitignored
-         * `ai/config.mjs` or env vars (`NEO_ORCHESTRATOR_MLX_ENABLED`,
-         * `NEO_ORCHESTRATOR_MLX_MODEL`, `NEO_ORCHESTRATOR_MLX_PORT`).
-         *
-         * - `enabled`: whether the orchestrator should supervise an `mlx_lm.server` child
-         *   process. Disabled by default because LM Studio / other OpenAI-compatible
-         *   providers already own the normal inference endpoint; enable only when this
-         *   orchestrator should own MLX directly.
-         * - `model`: Hugging Face repo id or local path for `mlx_lm.server --model`.
-         *   Distinct from the OpenAI-compatible API payload model label (`NEO_OPENAI_COMPATIBLE_MODEL`).
-         * - `port`: OpenAI-compatible local-inference port.
-         * @type {Object}
-         */
-        mlx: {
-            enabled: false,
-            model  : 'mlx-community/gemma-4-31b-it-bf16',
-            port   : '11435'
-        },
-        /**
-         * Orchestrator-owned LM Studio CLI (`lms`) inference server config. Operators
-         * tune via gitignored `ai/config.mjs` or env vars (`NEO_ORCHESTRATOR_LMS_ENABLED`,
-         * `NEO_ORCHESTRATOR_LMS_MODEL`, `NEO_ORCHESTRATOR_LMS_PORT`).
-         *
-         * Parallel alternative to `orchestrator.mlx` — both serve OpenAI-compatible HTTP
-         * for local embedding workloads; pick at most one via the respective `enabled` flag.
-         *
-         * - `enabled`: whether the orchestrator should supervise an `lms server start`
-         *   child process. Disabled by default; **macOS-only** (LM Studio CLI is not
-         *   shipped for Linux containers, so this lane is local-dev substrate, not
-         *   cloud-deployment substrate).
-         * - `model`: model identifier the operator intends LM Studio to serve. The
-         *   orchestrator-managed `lms server start` lane currently brings the server up;
-         *   ensuring this model is loaded (via `lms load <model>` or `/v1/models` probe)
-         *   is tracked as #11986 AC5 residual and is NOT performed by this lane today.
-         *   Distinct from the OpenAI-compatible API payload label (`NEO_OPENAI_COMPATIBLE_MODEL`).
-         * - `port`: OpenAI-compatible local-inference port (LM Studio CLI default `1234`).
-         * @type {Object}
-         */
-        lms: {
-            enabled: false,
-            model  : 'qwen3-embedding-8b',
-            port   : '1234'
-        }
-    },
-    /**
-     * Agent OS maintenance policy shared by operator scripts and daemons.
-     * @type {Object}
-     */
-    maintenance: {
-        /**
-         * Canonical atomic-bundle backup policy. Bundles remain atomic; per-substrate
-         * retention is intentionally not represented here.
-         * @type {Object}
-         */
-        backup: {
-            intervalMs: DAY_MS,
-            retention: {
-                keepMinimum: 3,
-                maxDays    : 30
-            }
-        },
-        /**
-         * Chroma defrag policy. V1 exposes cadence as operator policy only; no daemon
-         * auto-spawns defrag from this value.
-         * @type {Object}
-         */
-        defrag: {
-            intervalMs: 7 * DAY_MS,
-            snapshotRetention: {
-                keepMinimum: 3,
-                maxDays    : 7
-            }
-        }
-    },
-    /**
-     * Knowledge Base operations configuration (Cloud-Native KB Ingestion, Epic #11624).
-     * @type {Object}
-     */
-    knowledgeBase: {
-        /**
-         * Phase 4D (#11642) — operator alert rules. Each entry is
-         * `{metric, threshold, severity, channels, deliveryMode?}`; see the #11642
-         * Contract Ledger. Empty by default — the alerting daemon no-ops with no rules.
-         * @type {Object[]}
-         */
-        alertRules: [],
-        /**
-         * Phase 4D (#11642) — master opt-in for the KB operator-alerting daemon.
-         * Disabled by default; the daemon exits early when false.
-         * @type {Boolean}
-         */
-        alertingEnabled: false,
-        /**
-         * Phase 4D (#11642) — alerting daemon poll interval in ms (default 15 min).
-         * @type {Number}
-         */
-        alertingIntervalMs: 15 * 60 * 1000,
-        /**
-         * Phase 4D (#11642) — per-`(tenant, metric, severity, channel)` hysteresis
-         * cooldown window in ms (default 1 h).
-         * @type {Number}
-         */
-        alertingCooldownMs: 60 * 60 * 1000,
-        /**
-         * Phase 4D (#11642) — rolling look-back window in ms for the per-tenant
-         * telemetry rollup the rule engine evaluates (default 1 h).
-         * @type {Number}
-         */
-        alertWindowMs: 60 * 60 * 1000,
-        /**
-         * Phase 4B (#11640) — master opt-in for the KB reconciliation daemon.
-         * Disabled by default; the daemon exits early when false.
-         * @type {Boolean}
-         */
-        reconciliationEnabled: false,
-        /**
-         * Phase 4B (#11640) — reconciliation daemon poll interval in ms (default 1 h).
-         * @type {Number}
-         */
-        reconciliationIntervalMs: 60 * 60 * 1000,
-        /**
-         * Phase 4B (#11640) — opt-in for the destructive auto-tombstone reconciliation
-         * action. Disabled by default — the daemon then detects config-stale chunks and
-         * emits Phase 4A telemetry only, issuing no `collection.delete`.
-         * @type {Boolean}
-         */
-        reconciliationAutoTombstone: false,
-        /**
-         * Phase 4B (#11640) — config-version-gap threshold above which a config-stale
-         * chunk becomes auto-tombstone-eligible: a chunk is actioned when
-         * `currentConfigVersion - chunk.tenantConfigVersion >= this`. Default `2` gives
-         * one full config epoch of grace. Consulted only when `reconciliationAutoTombstone`.
-         * @type {Number}
-         */
-        reconciliationOrphanVersionGap: 2,
-        /**
-         * Phase 4C (#11641) — master opt-in for the KB garbage-collection daemon.
-         * Disabled by default; the daemon exits early when false.
-         * @type {Boolean}
-         */
-        gcEnabled: false,
-        /**
-         * Phase 4C (#11641) — GC daemon poll interval in ms (default 24 h).
-         * @type {Number}
-         */
-        gcIntervalMs: 24 * 60 * 60 * 1000,
-        /**
-         * Phase 4C (#11641) — retention policy: `{maxAgeMs?, maxCount?}`. A chunk is
-         * retention-expired if it is older than `maxAgeMs` (by its `ingestedAt` stamp) OR
-         * ranks beyond the `maxCount` most-recent of its `{tenantId, repoSlug}` bucket.
-         * Empty `{}` (the default) expires nothing — conservative.
-         * @type {Object}
-         */
-        gcRetention: {},
-        /**
-         * Phase 4C (#11641) — opt-in for the destructive GC delete. Disabled by default —
-         * the daemon then detects retention-expired chunks and emits telemetry only,
-         * issuing no `collection.delete`.
-         * @type {Boolean}
-         */
-        gcAutoDelete: false,
-        /**
-         * Phase 4C (#11641) — cumulative-deletion fraction above which a GC tick emits a
-         * `defrag-recommended` signal (operators should then run `ai:defrag-kb`). `0`
-         * disables the signal. V1 emits the signal only — it does not spawn defrag.
-         * @type {Number}
-         */
-        gcDefragThreshold: 0.10
-    },
-    /**
-     * A dummy embedding function to satisfy ChromaDB when embeddings are provided manually.
-     * @returns {Object}
-     */
-    dummyEmbeddingFunction: {
-        generate   : () => null,
-        name       : 'dummy_embedding_function',
-        getConfig  : () => ({}),
-        constructor: {
-            buildFromConfig: () => ({
-                generate : () => null,
-                name     : 'dummy_embedding_function',
-                getConfig: () => ({})
-            })
-        }
-    }
-};
-
-/**
- * @summary Tier-1 environment-variable ledger.
- *
- * Binding shape mirrors `defaultConfig`; dotted binding keys are intentionally unsupported.
- */
-const envBindings = {
-    debug        : {var: 'NEO_DEBUG', parse: Env.parseBool},
-    transport    : 'NEO_TRANSPORT',
-    publicUrl    : {var: 'NEO_PUBLIC_URL', parse: Env.parseUrl},
-    mcpHttpPort  : {var: 'MCP_HTTP_PORT', parse: Env.parsePort},
-    auth         : {
-        host              : 'NEO_AUTH_HOST',
-        port              : {var: 'NEO_AUTH_PORT', parse: Env.parsePort},
-        realm             : 'NEO_AUTH_REALM',
-        issuerUrl         : 'NEO_AUTH_ISSUER_URL',
-        clientId          : 'NEO_OAUTH_CLIENT_ID',
-        clientSecret      : 'NEO_OAUTH_CLIENT_SECRET',
-        trustProxyIdentity: {var: 'NEO_AUTH_TRUST_PROXY_IDENTITY', parse: Env.parseBool}
-    },
-    chatProvider     : 'NEO_MODEL_PROVIDER',
-    modelProvider    : 'NEO_MODEL_PROVIDER',
-    embeddingProvider: 'NEO_EMBEDDING_PROVIDER',
-    ollama           : {
-        host          : 'NEO_OLLAMA_HOST',
-        model         : 'NEO_OLLAMA_MODEL',
-        embeddingModel: 'NEO_OLLAMA_EMBEDDING_MODEL'
-    },
-    openAiCompatible: {
-        host                    : 'NEO_OPENAI_COMPATIBLE_HOST',
-        model                   : 'NEO_OPENAI_COMPATIBLE_MODEL',
-        embeddingModel          : 'NEO_OPENAI_COMPATIBLE_EMBEDDING_MODEL',
-        apiKey                  : 'NEO_OPENAI_COMPATIBLE_API_KEY',
-        unloadRetryCount        : {var: 'NEO_OPENAI_COMPATIBLE_UNLOAD_RETRY_COUNT', parse: Env.parseNumber},
-        unloadRetryDelayMs      : {var: 'NEO_OPENAI_COMPATIBLE_UNLOAD_RETRY_DELAY_MS', parse: Env.parseNumber},
-        contextLimitTokens      : {var: 'NEO_OPENAI_COMPATIBLE_CONTEXT_LIMIT_TOKENS', parse: Env.parseNumber},
-        safeProcessingLimitTokens: {var: 'NEO_OPENAI_COMPATIBLE_SAFE_PROCESSING_LIMIT_TOKENS', parse: Env.parseNumber}
-    },
-    vectorDimension: {var: 'NEO_VECTOR_DIMENSION', parse: Env.parseNumber},
-    engines        : {
-        chroma: {
-            host: 'NEO_CHROMA_HOST',
-            port: {var: 'NEO_CHROMA_PORT', parse: Env.parsePort}
-        }
-    },
-    orchestrator: {
-        deploymentMode: 'NEO_AI_DEPLOYMENT_MODE'
-    }
-};
-
-/**
  * @class Neo.ai.Config
  * @extends Neo.ai.BaseConfig
  * @singleton
  */
 class Config extends BaseConfig {
+    /**
+     * Top-level configuration object (Tier 1).
+     * Defines the core immutable plain-data structures applied universally across all AI/MCP infrastructure.
+     */
+    static defaultConfig = {
+        neoRootDir,
+        projectRoot,
+        /**
+         * Universal JSONL backup/export directory for Agent OS databases.
+         * @type {string}
+         */
+        backupPath: path.resolve(neoRootDir, '.neo-ai-data/backups'),
+        /**
+         * Global debug flag for all AI processes.
+         * @type {boolean}
+         */
+        debug: false,
+        /**
+         * Transport protocol ('stdio' or 'sse').
+         * @type {string}
+         */
+        transport: 'stdio',
+        /**
+         * Optional public canonical URL.
+         * @type {string|null}
+         */
+        publicUrl: null,
+        /**
+         * Port the MCP server's HTTP/SSE transport listens on.
+         * Sub-servers will typically override this with their own defaultPort.
+         * @type {number}
+         */
+        mcpHttpPort: 3000,
+        /**
+         * Optional Express middleware function for authentication.
+         * @type {Function|null}
+         */
+        authMiddleware: null,
+        /**
+         * Base authentication configuration.
+         * @type {Object}
+         */
+        auth: {
+            host              : null,
+            port              : 8080,
+            realm             : 'master',
+            issuerUrl         : null,
+            clientId          : null,
+            clientSecret      : '',
+            trustProxyIdentity: false
+        },
+        /**
+         * @summary Deployment-wide chat / generation model provider.
+         *
+         * Tier-1 source of truth for model-consuming Agent OS lanes. Memory Core maps
+         * this into its historical `modelProvider` key until runtime provider routing
+         * graduates from #10103 Sub-2. Supported values today: `gemini`,
+         * `openAiCompatible`.
+         * @type {String}
+         */
+        chatProvider: 'gemini',
+        /**
+         * @summary Runtime alias for the active chat provider.
+         *
+         * Existing Memory Core consumers read `modelProvider`; keep the Tier-1
+         * template aligned with `chatProvider` until provider routing converges on
+         * one canonical key.
+         * @type {String}
+         */
+        modelProvider: 'gemini',
+        /**
+         * @summary Deployment-wide embedding provider selector.
+         *
+         * Shared by Memory Core embedding consumers and Knowledge Base ingestion
+         * paths.
+         * @type {String}
+         */
+        embeddingProvider: 'openAiCompatible',
+        /**
+         * @summary Deployment-wide Ollama provider defaults.
+         *
+         * These are configuration defaults only. Runtime dispatch support for native
+         * `ollama` is owned by #10103 Sub-2.
+         * @type {Object}
+         */
+        ollama: {
+            host          : 'http://127.0.0.1:11434',
+            model         : 'gemma4:31b',
+            embeddingModel: 'qwen3-embedding'
+        },
+        /**
+         * @summary Deployment-wide OpenAI-compatible provider defaults.
+         *
+         * Covers MLX, LM Studio, Ollama's OpenAI-compatible surface, llama.cpp, and
+         * managed OpenAI-compatible endpoints.
+         * @type {Object}
+         */
+        openAiCompatible: {
+            host                    : 'http://127.0.0.1:11434',
+            model                   : 'gemma-4-31b-it',
+            embeddingModel          : 'text-embedding-qwen3-embedding-8b',
+            apiKey                  : '',
+            unloadRetryCount        : 3,
+            unloadRetryDelayMs      : 500,
+            contextLimitTokens      : 32768,
+            safeProcessingLimitTokens: undefined
+        },
+        /**
+         * @summary Deployment-wide Gemini model defaults.
+         *
+         * Memory Core still exposes these historical field names for Gemini-backed
+         * summary and embedding paths; Tier-1 owns the default tuple.
+         * @type {String}
+         */
+        modelName: 'gemini-2.5-flash',
+        /**
+         * @summary Deployment-wide Gemini embedding model default.
+         * @type {String}
+         */
+        embeddingModel: 'gemini-embedding-001',
+        /**
+         * @summary Enforced vector dimension across shared vector collections.
+         *
+         * Hard-configured to prevent schema wipes when operators change embedding
+         * providers. Gemini deployments must explicitly pair provider and dimension
+         * overrides.
+         * @type {Number}
+         */
+        vectorDimension: 4096,
+        /**
+         * @summary Deployment-wide storage engine coordinates.
+         *
+         * `engines.chroma` is the unified Chroma topology from ADR 0003. Collection
+         * names and local persistence directories remain server-local.
+         * @type {Object}
+         */
+        engines: {
+            chroma: {
+                host: 'localhost',
+                port: 8000
+            }
+        },
+        /**
+         * Agent OS maintenance orchestrator configuration.
+         * @type {Object}
+         */
+        orchestrator: {
+            /**
+             * Deployment profile for Agent OS maintenance ownership.
+             * `local` preserves maintainer-checkout behavior; `cloud` disables local-only
+             * maintenance lanes unless a narrower localOnly override opts them back in.
+             * @type {'local'|'cloud'}
+             */
+            deploymentMode: 'local',
+            /**
+             * Maintenance-loop intervals consumed by the orchestrator daemon.
+             * Env vars at the daemon boundary retain precedence over these defaults.
+             * @type {Object}
+             */
+            intervals: {
+                pollMs           : 3000,
+                summarySweepMs   : 10 * 60 * 1000,
+                kbSyncMs         : 30 * 60 * 1000,
+                backupMs         : DAY_MS,
+                primaryDevSyncMs : 10 * 60 * 1000,
+                tenantRepoSyncMs : 30 * 60 * 1000,
+                dreamMs          : HOUR_MS,
+                goldenPathMs     : HOUR_MS,
+                swarmHeartbeatMs : 15 * 60 * 1000
+            },
+            /**
+             * Swarm-heartbeat target-resolver config. Controls which identity set
+             * `SwarmHeartbeatService.pulse()` targets per cycle via the resolver
+             * precedence chain. Env override: `NEO_ORCHESTRATOR_SWARM_HEARTBEAT_TARGET_SOURCE`.
+             * Explicit list override (highest precedence):
+             * `NEO_ORCHESTRATOR_SWARM_HEARTBEAT_TARGETS` (comma-separated handles).
+             * @type {Object}
+             */
+            swarmHeartbeat: {
+                /**
+                 * Resolver source enum. `null` falls through to `'self'` — the
+                 * deployment-portable default. Valid values: `'self'`,
+                 * `'active-local-team'`, `'active-subscribers'`, `'disabled'`. External
+                 * workspaces with no config default to `'self'`; the lane never silently
+                 * fans out to maintainer identities unless the operator explicitly opts
+                 * in via `'active-local-team'`.
+                 * @type {'self'|'active-local-team'|'active-subscribers'|'disabled'|null}
+                 */
+                targetSource: null
+            },
+            /**
+             * Local-only maintenance lane switches. Cloud deployments can disable these
+             * without changing remote graph-backed A2A / Memory Core behavior.
+             * `null` means "use the deployment profile default" (`local` enables,
+             * `cloud` disables); set `true` only when explicitly opting a lane back in.
+             * @type {Object}
+             */
+            localOnly: {
+                primaryDevSyncEnabled: null,
+                kbSyncEnabled        : null,
+                bridgeDaemonEnabled  : null,
+                goldenPathRepoEnrichmentEnabled: null,
+                // `null` = use the deployment-profile default (local enables, cloud disables);
+                // the swarm-heartbeat lane is the folded-in wake-substrate pulse (#11766).
+                swarmHeartbeatEnabled: null,
+                // Reserved policy placeholder: no runtime consumer yet.
+                // `bridgeDaemonEnabled` is the active scheduler gate for desktop wake delivery.
+                wakeDispatchEnabled  : null
+            },
+            /**
+             * Cloud-only maintenance lane switches (mirror of `localOnly` with inverted
+             * deployment-default: `null` means "use the deployment-profile default" —
+             * cloud enables, local disables. Set `true` only when explicitly opting a
+             * lane back in for the LOCAL profile (e.g. operator-side smoke testing of
+             * tenant-repo-sync without a cloud-profile container).
+             * @type {Object}
+             */
+            cloudOnly: {
+                // tenant-repo-sync: cloud-deployable per ADR 0014 + #11740. Cloud
+                // profile defaults enabled when tenant repos are configured; local
+                // Neo-maintainer profile defaults disabled unless explicitly opted in.
+                tenantRepoSyncEnabled: null
+            },
+            /**
+             * Optional local Neo repo roots for the primary-dev-sync lane.
+             * Keep the template machine-neutral; set real absolute paths in gitignored
+             * `ai/config.mjs` or via `NEO_ORCHESTRATOR_DEV_SYNC_ROOTS`.
+             * @type {String[]}
+             */
+            devSyncRoots: [],
+            /**
+             * Tenant-repo-sync per-repo scheduling parameters (#11942 AC1).
+             *
+             * The cadence floor lives in `intervals.tenantRepoSyncMs` above (30min default).
+             * Per-repo cadence in `tenantRepos[].cadenceMs` (operator-set) overrides global.
+             *
+             * - `jitterRatio` caps the deterministic per-repo jitter offset as a fraction
+             *   of the base cadence. Default `0.20` (≤20% of cadence per AC1 prescription).
+             *   Set `0` to disable jitter entirely (deterministic-cadence-only, no anti-
+             *   thundering-herd protection — only safe for low-tenant deployments).
+             * - `sweepCadenceMs` is the frequency at which the orchestrator wakes the
+             *   tenant-repo-sync task. Decoupled from per-repo cadence (`intervals.tenantRepoSyncMs`)
+             *   so deterministic jitter can actually spread per-repo sync attempts across
+             *   the jitter window. A short sweep cadence + a long per-repo cadence means
+             *   each sweep checks all repos against their individual due-times; repos
+             *   become due at different sweeps based on their deterministic jitter offset.
+             *
+             * @type {Object}
+             */
+            tenantRepoSync: {
+                jitterRatio   : 0.20,
+                sweepCadenceMs: 60 * 1000
+            },
+            /**
+             * Orchestrator-owned MLX inference server config. Operators tune via gitignored
+             * `ai/config.mjs` or env vars (`NEO_ORCHESTRATOR_MLX_ENABLED`,
+             * `NEO_ORCHESTRATOR_MLX_MODEL`, `NEO_ORCHESTRATOR_MLX_PORT`).
+             *
+             * - `enabled`: whether the orchestrator should supervise an `mlx_lm.server` child
+             *   process. Disabled by default because LM Studio / other OpenAI-compatible
+             *   providers already own the normal inference endpoint; enable only when this
+             *   orchestrator should own MLX directly.
+             * - `model`: Hugging Face repo id or local path for `mlx_lm.server --model`.
+             *   Distinct from the OpenAI-compatible API payload model label (`NEO_OPENAI_COMPATIBLE_MODEL`).
+             * - `port`: OpenAI-compatible local-inference port.
+             * @type {Object}
+             */
+            mlx: {
+                enabled: false,
+                model  : 'mlx-community/gemma-4-31b-it-bf16',
+                port   : '11435'
+            },
+            /**
+             * Orchestrator-owned LM Studio CLI (`lms`) inference server config. Operators
+             * tune via gitignored `ai/config.mjs` or env vars (`NEO_ORCHESTRATOR_LMS_ENABLED`,
+             * `NEO_ORCHESTRATOR_LMS_MODEL`, `NEO_ORCHESTRATOR_LMS_PORT`).
+             *
+             * Parallel alternative to `orchestrator.mlx` — both serve OpenAI-compatible HTTP
+             * for local embedding workloads; pick at most one via the respective `enabled` flag.
+             *
+             * - `enabled`: whether the orchestrator should supervise an `lms server start`
+             *   child process. Disabled by default; **macOS-only** (LM Studio CLI is not
+             *   shipped for Linux containers, so this lane is local-dev substrate, not
+             *   cloud-deployment substrate).
+             * - `model`: model identifier the operator intends LM Studio to serve. The
+             *   orchestrator-managed `lms server start` lane currently brings the server up;
+             *   ensuring this model is loaded (via `lms load <model>` or `/v1/models` probe)
+             *   is tracked as #11986 AC5 residual and is NOT performed by this lane today.
+             *   Distinct from the OpenAI-compatible API payload label (`NEO_OPENAI_COMPATIBLE_MODEL`).
+             * - `port`: OpenAI-compatible local-inference port (LM Studio CLI default `1234`).
+             * @type {Object}
+             */
+            lms: {
+                enabled: false,
+                model  : 'qwen3-embedding-8b',
+                port   : '1234'
+            }
+        },
+        /**
+         * Agent OS maintenance policy shared by operator scripts and daemons.
+         * @type {Object}
+         */
+        maintenance: {
+            /**
+             * Canonical atomic-bundle backup policy. Bundles remain atomic; per-substrate
+             * retention is intentionally not represented here.
+             * @type {Object}
+             */
+            backup: {
+                intervalMs: DAY_MS,
+                retention: {
+                    keepMinimum: 3,
+                    maxDays    : 30
+                }
+            },
+            /**
+             * Chroma defrag policy. V1 exposes cadence as operator policy only; no daemon
+             * auto-spawns defrag from this value.
+             * @type {Object}
+             */
+            defrag: {
+                intervalMs: 7 * DAY_MS,
+                snapshotRetention: {
+                    keepMinimum: 3,
+                    maxDays    : 7
+                }
+            }
+        },
+        /**
+         * Knowledge Base operations configuration (Cloud-Native KB Ingestion, Epic #11624).
+         * @type {Object}
+         */
+        knowledgeBase: {
+            /**
+             * Phase 4D (#11642) — operator alert rules. Each entry is
+             * `{metric, threshold, severity, channels, deliveryMode?}`; see the #11642
+             * Contract Ledger. Empty by default — the alerting daemon no-ops with no rules.
+             * @type {Object[]}
+             */
+            alertRules: [],
+            /**
+             * Phase 4D (#11642) — master opt-in for the KB operator-alerting daemon.
+             * Disabled by default; the daemon exits early when false.
+             * @type {Boolean}
+             */
+            alertingEnabled: false,
+            /**
+             * Phase 4D (#11642) — alerting daemon poll interval in ms (default 15 min).
+             * @type {Number}
+             */
+            alertingIntervalMs: 15 * 60 * 1000,
+            /**
+             * Phase 4D (#11642) — per-`(tenant, metric, severity, channel)` hysteresis
+             * cooldown window in ms (default 1 h).
+             * @type {Number}
+             */
+            alertingCooldownMs: 60 * 60 * 1000,
+            /**
+             * Phase 4D (#11642) — rolling look-back window in ms for the per-tenant
+             * telemetry rollup the rule engine evaluates (default 1 h).
+             * @type {Number}
+             */
+            alertWindowMs: 60 * 60 * 1000,
+            /**
+             * Phase 4B (#11640) — master opt-in for the KB reconciliation daemon.
+             * Disabled by default; the daemon exits early when false.
+             * @type {Boolean}
+             */
+            reconciliationEnabled: false,
+            /**
+             * Phase 4B (#11640) — reconciliation daemon poll interval in ms (default 1 h).
+             * @type {Number}
+             */
+            reconciliationIntervalMs: 60 * 60 * 1000,
+            /**
+             * Phase 4B (#11640) — opt-in for the destructive auto-tombstone reconciliation
+             * action. Disabled by default — the daemon then detects config-stale chunks and
+             * emits Phase 4A telemetry only, issuing no `collection.delete`.
+             * @type {Boolean}
+             */
+            reconciliationAutoTombstone: false,
+            /**
+             * Phase 4B (#11640) — config-version-gap threshold above which a config-stale
+             * chunk becomes auto-tombstone-eligible: a chunk is actioned when
+             * `currentConfigVersion - chunk.tenantConfigVersion >= this`. Default `2` gives
+             * one full config epoch of grace. Consulted only when `reconciliationAutoTombstone`.
+             * @type {Number}
+             */
+            reconciliationOrphanVersionGap: 2,
+            /**
+             * Phase 4C (#11641) — master opt-in for the KB garbage-collection daemon.
+             * Disabled by default; the daemon exits early when false.
+             * @type {Boolean}
+             */
+            gcEnabled: false,
+            /**
+             * Phase 4C (#11641) — GC daemon poll interval in ms (default 24 h).
+             * @type {Number}
+             */
+            gcIntervalMs: 24 * 60 * 60 * 1000,
+            /**
+             * Phase 4C (#11641) — retention policy: `{maxAgeMs?, maxCount?}`. A chunk is
+             * retention-expired if it is older than `maxAgeMs` (by its `ingestedAt` stamp) OR
+             * ranks beyond the `maxCount` most-recent of its `{tenantId, repoSlug}` bucket.
+             * Empty `{}` (the default) expires nothing — conservative.
+             * @type {Object}
+             */
+            gcRetention: {},
+            /**
+             * Phase 4C (#11641) — opt-in for the destructive GC delete. Disabled by default —
+             * the daemon then detects retention-expired chunks and emits telemetry only,
+             * issuing no `collection.delete`.
+             * @type {Boolean}
+             */
+            gcAutoDelete: false,
+            /**
+             * Phase 4C (#11641) — cumulative-deletion fraction above which a GC tick emits a
+             * `defrag-recommended` signal (operators should then run `ai:defrag-kb`). `0`
+             * disables the signal. V1 emits the signal only — it does not spawn defrag.
+             * @type {Number}
+             */
+            gcDefragThreshold: 0.10
+        },
+        /**
+         * A dummy embedding function to satisfy ChromaDB when embeddings are provided manually.
+         * @returns {Object}
+         */
+        dummyEmbeddingFunction: {
+            generate   : () => null,
+            name       : 'dummy_embedding_function',
+            getConfig  : () => ({}),
+            constructor: {
+                buildFromConfig: () => ({
+                    generate : () => null,
+                    name     : 'dummy_embedding_function',
+                    getConfig: () => ({})
+                })
+            }
+        }
+    };
+
+    /**
+     * @summary Tier-1 environment-variable ledger.
+     *
+     * Binding shape mirrors `defaultConfig`; dotted binding keys are intentionally unsupported.
+     */
+    static envBindings = {
+        debug        : {var: 'NEO_DEBUG', parse: Env.parseBool},
+        transport    : 'NEO_TRANSPORT',
+        publicUrl    : {var: 'NEO_PUBLIC_URL', parse: Env.parseUrl},
+        mcpHttpPort  : {var: 'MCP_HTTP_PORT', parse: Env.parsePort},
+        auth         : {
+            host              : 'NEO_AUTH_HOST',
+            port              : {var: 'NEO_AUTH_PORT', parse: Env.parsePort},
+            realm             : 'NEO_AUTH_REALM',
+            issuerUrl         : 'NEO_AUTH_ISSUER_URL',
+            clientId          : 'NEO_OAUTH_CLIENT_ID',
+            clientSecret      : 'NEO_OAUTH_CLIENT_SECRET',
+            trustProxyIdentity: {var: 'NEO_AUTH_TRUST_PROXY_IDENTITY', parse: Env.parseBool}
+        },
+        chatProvider     : 'NEO_MODEL_PROVIDER',
+        modelProvider    : 'NEO_MODEL_PROVIDER',
+        embeddingProvider: 'NEO_EMBEDDING_PROVIDER',
+        ollama           : {
+            host          : 'NEO_OLLAMA_HOST',
+            model         : 'NEO_OLLAMA_MODEL',
+            embeddingModel: 'NEO_OLLAMA_EMBEDDING_MODEL'
+        },
+        openAiCompatible: {
+            host                    : 'NEO_OPENAI_COMPATIBLE_HOST',
+            model                   : 'NEO_OPENAI_COMPATIBLE_MODEL',
+            embeddingModel          : 'NEO_OPENAI_COMPATIBLE_EMBEDDING_MODEL',
+            apiKey                  : 'NEO_OPENAI_COMPATIBLE_API_KEY',
+            unloadRetryCount        : {var: 'NEO_OPENAI_COMPATIBLE_UNLOAD_RETRY_COUNT', parse: Env.parseNumber},
+            unloadRetryDelayMs      : {var: 'NEO_OPENAI_COMPATIBLE_UNLOAD_RETRY_DELAY_MS', parse: Env.parseNumber},
+            contextLimitTokens      : {var: 'NEO_OPENAI_COMPATIBLE_CONTEXT_LIMIT_TOKENS', parse: Env.parseNumber},
+            safeProcessingLimitTokens: {var: 'NEO_OPENAI_COMPATIBLE_SAFE_PROCESSING_LIMIT_TOKENS', parse: Env.parseNumber}
+        },
+        vectorDimension: {var: 'NEO_VECTOR_DIMENSION', parse: Env.parseNumber},
+        backupPath     : 'NEO_BACKUP_PATH',
+        engines        : {
+            chroma: {
+                host: 'NEO_CHROMA_HOST',
+                port: {var: 'NEO_CHROMA_PORT', parse: Env.parsePort}
+            }
+        },
+        orchestrator: {
+            deploymentMode: 'NEO_AI_DEPLOYMENT_MODE'
+        }
+    };
     static config = {
         /**
          * @member {String} className='Neo.ai.Config'
@@ -517,11 +522,11 @@ class Config extends BaseConfig {
         /**
          * @member {Object} defaultConfig
          */
-        defaultConfig,
+        defaultConfig: this.defaultConfig,
         /**
          * @member {Object} envBindings
          */
-        envBindings
+        envBindings: this.envBindings
     }
 }
 

--- a/ai/mcp/server/github-workflow/config.template.mjs
+++ b/ai/mcp/server/github-workflow/config.template.mjs
@@ -22,248 +22,7 @@ function parseLogLevel(envVarName, {env = process.env, warn = console.warn} = {}
     return undefined;
 }
 
-/**
- * Default configuration object.
- * Defines the structure and default values for the server configuration.
- */
-const defaultConfig = {
-    /**
-     * The root directory of the project.
-     * @type {string}
-     */
-    projectRoot,
-    /**
-     * Global debug flag for all MCP servers.
-     * @type {boolean}
-     */
-    debug: false,
-    /**
-     * Minimum stderr log level for the GitHub workflow logger.
-     * @type {string}
-     */
-    logLevel: 'warn',
-    /**
-     * @summary Shared MCP logger policy for GitHub Workflow.
-     *
-     * Priority-filtered stderr only. `debug: true` promotes the default `warn`
-     * threshold to `debug`; no file sink is used for this workflow server.
-     * @type {Object}
-     */
-    logger: {
-        defaultLevel: 'warn',
-        fileSink    : false,
-        stderrMode  : 'threshold'
-    },
-    /**
-     * A dummy embedding function to satisfy the ChromaDB API when embeddings are provided manually.
-     * @returns {null}
-     */
-    dummyEmbeddingFunction: {
-        generate: () => null
-    },
-    /**
-     * Cache duration for healthy health checks (in milliseconds).
-     * Unhealthy results are never cached.
-     * @type {number}
-     */
-    healthCheckCacheDuration: 5 * 60 * 1000, // 5 minutes
-    /**
-     * The minimum required version of the GitHub CLI (`gh`).
-     * @type {string}
-     */
-    minGhVersion: '2.0.0',
-    /**
-     * The owner of the GitHub repository.
-     * @type {string}
-     */
-    owner: 'neomjs',
-    /**
-     * The name of the GitHub repository.
-     * @type {string}
-     */
-    repo: 'neo',
-    /**
-     * Whether to automatically trigger a full sync when the server starts.
-     * @type {boolean}
-     */
-    syncOnStartup: true,
-    /**
-     * Whether to automatically commit and push changes after a sync.
-     * Only executes if the user has write permissions and there are non-metadata changes.
-     * @type {boolean}
-     */
-    pushToRepoAfterSync: true,
-    /**
-     * Configuration for the issue synchronization service.
-     */
-    issueSync: {
-        /**
-         * The root directory for synced content.
-         * @type {string}
-         */
-        contentRoot: path.resolve(projectRoot, 'resources/content'),
-        /**
-         * The path to the directory for active issues.
-         * @type {string}
-         */
-        issuesDir: path.resolve(projectRoot, 'resources/content/issues'),
-        /**
-         * The root directory for version-based archives across all entities.
-         * @type {string}
-         */
-        archiveRoot: path.resolve(projectRoot, 'resources/content/archive'),
-        /**
-         * The path to the directory for discussions.
-         * @type {string}
-         */
-        discussionsDir: path.resolve(projectRoot, 'resources/content/discussions'),
-        /**
-         * The path to the directory for pull requests.
-         * @type {string}
-         */
-        pullsDir: path.resolve(projectRoot, 'resources/content/pulls'),
-        /**
-         * The path to the synchronization metadata file.
-         * @type {string}
-         */
-        metadataFile: path.resolve(projectRoot, 'resources/content/.sync-metadata.json'),
-        /**
-         * Labels that, when present on an issue, will cause it to be ignored and deleted locally.
-         * @type {string[]}
-         */
-        droppedLabels: ['dropped', 'wontfix', 'duplicate'],
-        /**
-         * The date from which to start synchronizing issues and releases.
-         * @type {string}
-         */
-        syncStartDate: '2025-01-01T00:00:00Z',
-        /**
-         * The path to the directory for release notes.
-         * @type {string}
-         */
-        releaseNotesDir: path.resolve(projectRoot, 'resources/content/release-notes'),
-        /**
-         * A prefix for issue filenames to prevent them from starting with a number (e.g., 'issue-').
-         * @type {string}
-         */
-        issueFilenamePrefix: 'issue-',
-        /**
-         * @member {String} discussionFilenamePrefix='discussion-'
-         */
-        discussionFilenamePrefix: 'discussion-',
-        /**
-         * A prefix for version-based archive directories (e.g., 'v' for 'v1.2.3').
-         * Applies to both milestone titles and release tags.
-         * @type {string}
-         */
-        versionDirectoryPrefix: 'v',
-        /**
-         * The maximum number of items per chunk directory in the archive.
-         * @type {number}
-         */
-        archiveChunkThreshold: 100,
-        /**
-         * A prefix for archive chunk directories (e.g., 'chunk-').
-         * @type {string}
-         */
-        archiveChunkPrefix: 'chunk-',
-        /**
-         * A prefix for release note filenames (e.g., 'v').
-         * @type {string}
-         */
-        releaseFilenamePrefix: 'v',
-        /**
-         * The maximum number of issues to fetch from the GitHub API in a single sync.
-         * Defensive ceiling against runaway pagination on a misconfigured GraphQL pageInfo while
-         * leaving enough headroom for clean-slate exhaustive emission under ADR 0004. The local
-         * droppedLabels filter further trims the actual processed set.
-         * @type {number}
-         */
-        maxIssues: 20000,
-        /**
-         * The maximum number of releases to fetch from the GitHub API.
-         * @type {number}
-         */
-        maxReleases: 1000,
-        /**
-         * The number of releases to fetch per page in GraphQL queries.
-         * @type {number}
-         */
-        releaseQueryLimit: 50,
-        /**
-         * The maximum buffer size for the `gh` CLI command output.
-         * @type {number}
-         */
-        maxGhOutputBuffer: 10 * 1024 * 1024, // 10 MB
-        /**
-         * The markdown delimiter used to separate the issue body from the comments section.
-         * @type {string}
-         */
-        commentSectionDelimiter: '## Comments',
-        /**
-         * Maximum number of labels to fetch per issue in GraphQL queries.
-         * @type {number}
-         */
-        maxLabelsPerIssue: 20,
-        /**
-         * Maximum number of labels to fetch for the entire repository in GraphQL queries.
-         * @type {number}
-         */
-        maxRepoLabels: 100,
-        /**
-         * Maximum number of assignees to fetch per issue in GraphQL queries.
-         * @type {number}
-         */
-        maxAssigneesPerIssue: 10,
-        /**
-         * Maximum number of sub-issues to fetch per issue in GraphQL queries.
-         * @type {number}
-         */
-        maxSubIssuesPerIssue: 100,
-        /**
-         * Maximum number of timeline items to fetch per issue in GraphQL queries.
-         * @type {number}
-         */
-        maxTimelineItemsPerIssue: 50
-    },
-    /**
-     * Configuration for pull request queries.
-     */
-    pullRequest: {
-        /**
-         * Default values for pull request queries.
-         */
-        defaults: {
-            /**
-             * The default number of pull requests to return.
-             * @type {number}
-             */
-            limit: 30,
-            /**
-             * The default state of pull requests to list.
-             * @type {string}
-             */
-            state: 'open'
-        },
-        /**
-         * The maximum number of pull requests that can be fetched in a single API call.
-         * @type {number}
-         */
-        maxLimit: 100,
-        /**
-         * Maximum number of comments to fetch per pull request in GraphQL queries.
-         * @type {number}
-         */
-        maxCommentsPerPullRequest: 100
-    }
-};
 
-const envBindings = {
-    issueSync: {
-        archiveRoot: 'NEO_MCP_GITHUB_ARCHIVE_ROOT'
-    },
-    logLevel: {var: 'NEO_LOG_LEVEL', parse: parseLogLevel}
-};
 
 /**
  * @summary Configuration manager for the GitHub Workflow MCP server.
@@ -276,6 +35,252 @@ const envBindings = {
  * @singleton
  */
 class Config extends BaseConfig {
+    /**
+     * Default configuration object.
+     * Defines the structure and default values for the server configuration.
+     */
+    static defaultConfig = {
+        /**
+         * The root directory of the project.
+         * @type {string}
+         */
+        projectRoot,
+        /**
+         * Global debug flag for all MCP servers.
+         * @type {boolean}
+         */
+        debug: false,
+        /**
+         * Minimum stderr log level for the GitHub workflow logger.
+         * @type {string}
+         */
+        logLevel: 'warn',
+        /**
+         * @summary Shared MCP logger policy for GitHub Workflow.
+         *
+         * Priority-filtered stderr only. `debug: true` promotes the default `warn`
+         * threshold to `debug`; no file sink is used for this workflow server.
+         * @type {Object}
+         */
+        logger: {
+            defaultLevel: 'warn',
+            fileSink    : false,
+            stderrMode  : 'threshold'
+        },
+        /**
+         * A dummy embedding function to satisfy the ChromaDB API when embeddings are provided manually.
+         * @returns {null}
+         */
+        dummyEmbeddingFunction: {
+            generate: () => null
+        },
+        /**
+         * Cache duration for healthy health checks (in milliseconds).
+         * Unhealthy results are never cached.
+         * @type {number}
+         */
+        healthCheckCacheDuration: 5 * 60 * 1000, // 5 minutes
+        /**
+         * The minimum required version of the GitHub CLI (`gh`).
+         * @type {string}
+         */
+        minGhVersion: '2.0.0',
+        /**
+         * The owner of the GitHub repository.
+         * @type {string}
+         */
+        owner: 'neomjs',
+        /**
+         * The name of the GitHub repository.
+         * @type {string}
+         */
+        repo: 'neo',
+        /**
+         * Whether to automatically trigger a full sync when the server starts.
+         * @type {boolean}
+         */
+        syncOnStartup: true,
+        /**
+         * Whether to automatically commit and push changes after a sync.
+         * Only executes if the user has write permissions and there are non-metadata changes.
+         * @type {boolean}
+         */
+        pushToRepoAfterSync: true,
+        /**
+         * Configuration for the issue synchronization service.
+         */
+        issueSync: {
+            /**
+             * The root directory for synced content.
+             * @type {string}
+             */
+            contentRoot: path.resolve(projectRoot, 'resources/content'),
+            /**
+             * The path to the directory for active issues.
+             * @type {string}
+             */
+            issuesDir: path.resolve(projectRoot, 'resources/content/issues'),
+            /**
+             * The root directory for version-based archives across all entities.
+             * @type {string}
+             */
+            archiveRoot: path.resolve(projectRoot, 'resources/content/archive'),
+            /**
+             * The path to the directory for discussions.
+             * @type {string}
+             */
+            discussionsDir: path.resolve(projectRoot, 'resources/content/discussions'),
+            /**
+             * The path to the directory for pull requests.
+             * @type {string}
+             */
+            pullsDir: path.resolve(projectRoot, 'resources/content/pulls'),
+            /**
+             * The path to the synchronization metadata file.
+             * @type {string}
+             */
+            metadataFile: path.resolve(projectRoot, 'resources/content/.sync-metadata.json'),
+            /**
+             * Labels that, when present on an issue, will cause it to be ignored and deleted locally.
+             * @type {string[]}
+             */
+            droppedLabels: ['dropped', 'wontfix', 'duplicate'],
+            /**
+             * The date from which to start synchronizing issues and releases.
+             * @type {string}
+             */
+            syncStartDate: '2025-01-01T00:00:00Z',
+            /**
+             * The path to the directory for release notes.
+             * @type {string}
+             */
+            releaseNotesDir: path.resolve(projectRoot, 'resources/content/release-notes'),
+            /**
+             * A prefix for issue filenames to prevent them from starting with a number (e.g., 'issue-').
+             * @type {string}
+             */
+            issueFilenamePrefix: 'issue-',
+            /**
+             * @member {String} discussionFilenamePrefix='discussion-'
+             */
+            discussionFilenamePrefix: 'discussion-',
+            /**
+             * A prefix for version-based archive directories (e.g., 'v' for 'v1.2.3').
+             * Applies to both milestone titles and release tags.
+             * @type {string}
+             */
+            versionDirectoryPrefix: 'v',
+            /**
+             * The maximum number of items per chunk directory in the archive.
+             * @type {number}
+             */
+            archiveChunkThreshold: 100,
+            /**
+             * A prefix for archive chunk directories (e.g., 'chunk-').
+             * @type {string}
+             */
+            archiveChunkPrefix: 'chunk-',
+            /**
+             * A prefix for release note filenames (e.g., 'v').
+             * @type {string}
+             */
+            releaseFilenamePrefix: 'v',
+            /**
+             * The maximum number of issues to fetch from the GitHub API in a single sync.
+             * Defensive ceiling against runaway pagination on a misconfigured GraphQL pageInfo while
+             * leaving enough headroom for clean-slate exhaustive emission under ADR 0004. The local
+             * droppedLabels filter further trims the actual processed set.
+             * @type {number}
+             */
+            maxIssues: 20000,
+            /**
+             * The maximum number of releases to fetch from the GitHub API.
+             * @type {number}
+             */
+            maxReleases: 1000,
+            /**
+             * The number of releases to fetch per page in GraphQL queries.
+             * @type {number}
+             */
+            releaseQueryLimit: 50,
+            /**
+             * The maximum buffer size for the `gh` CLI command output.
+             * @type {number}
+             */
+            maxGhOutputBuffer: 10 * 1024 * 1024, // 10 MB
+            /**
+             * The markdown delimiter used to separate the issue body from the comments section.
+             * @type {string}
+             */
+            commentSectionDelimiter: '## Comments',
+            /**
+             * Maximum number of labels to fetch per issue in GraphQL queries.
+             * @type {number}
+             */
+            maxLabelsPerIssue: 20,
+            /**
+             * Maximum number of labels to fetch for the entire repository in GraphQL queries.
+             * @type {number}
+             */
+            maxRepoLabels: 100,
+            /**
+             * Maximum number of assignees to fetch per issue in GraphQL queries.
+             * @type {number}
+             */
+            maxAssigneesPerIssue: 10,
+            /**
+             * Maximum number of sub-issues to fetch per issue in GraphQL queries.
+             * @type {number}
+             */
+            maxSubIssuesPerIssue: 100,
+            /**
+             * Maximum number of timeline items to fetch per issue in GraphQL queries.
+             * @type {number}
+             */
+            maxTimelineItemsPerIssue: 50
+        },
+        /**
+         * Configuration for pull request queries.
+         */
+        pullRequest: {
+            /**
+             * Default values for pull request queries.
+             */
+            defaults: {
+                /**
+                 * The default number of pull requests to return.
+                 * @type {number}
+                 */
+                limit: 30,
+                /**
+                 * The default state of pull requests to list.
+                 * @type {string}
+                 */
+                state: 'open'
+            },
+            /**
+             * The maximum number of pull requests that can be fetched in a single API call.
+             * @type {number}
+             */
+            maxLimit: 100,
+            /**
+             * Maximum number of comments to fetch per pull request in GraphQL queries.
+             * @type {number}
+             */
+            maxCommentsPerPullRequest: 100
+        }
+    };
+
+    /**
+     * Environment-variable ledger for GitHub Workflow server config.
+     * Binding shape mirrors `defaultConfig`.
+     */
+    static envBindings = {
+        issueSync: {
+            archiveRoot: 'NEO_MCP_GITHUB_ARCHIVE_ROOT'
+        },
+        logLevel: {var: 'NEO_LOG_LEVEL', parse: parseLogLevel}
+    };
     static config = {
         /**
          * @member {String} className='Neo.ai.mcp.server.github-workflow.Config'
@@ -290,11 +295,11 @@ class Config extends BaseConfig {
         /**
          * @member {Object} defaultConfig
          */
-        defaultConfig,
+        defaultConfig: this.defaultConfig,
         /**
          * @member {Object} envBindings
          */
-        envBindings
+        envBindings: this.envBindings
     }
 }
 const instance = Neo.setupClass(Config);

--- a/ai/mcp/server/gitlab-workflow/config.template.mjs
+++ b/ai/mcp/server/gitlab-workflow/config.template.mjs
@@ -30,77 +30,76 @@ function parseLogLevel(envVarName, {env = process.env, warn = console.warn} = {}
 }
 
 /**
- * @summary Default configuration for the GitLab Workflow MCP server scaffold.
- *
- * Keeps client-project GitLab host / PAT configuration out of tracked files.
- * The real GitLabClient subtask consumes the same keys when API calls land.
- */
-const defaultConfig = {
-    /**
-     * @member {String} projectRoot
-     */
-    projectRoot,
-    /**
-     * @member {Boolean} debug=false
-     */
-    debug: false,
-    /**
-     * @member {String} logLevel='warn'
-     */
-    logLevel: 'warn',
-    /**
-     * @summary Shared MCP logger policy for GitLab Workflow.
-     *
-     * Priority-filtered stderr only. `debug: true` promotes the default `warn`
-     * threshold to `debug`; no file sink is used for this workflow server.
-     * @member {Object} logger
-     */
-    logger: {
-        defaultLevel: 'warn',
-        fileSink    : false,
-        stderrMode  : 'threshold'
-    },
-    /**
-     * @member {String} transport='stdio'
-     */
-    transport: 'stdio',
-    /**
-     * @member {Object} gitlab
-     */
-    gitlab: {
-        /**
-         * GitLab instance base URL.
-         * @member {String} hostUrl='https://gitlab.com'
-         */
-        hostUrl: 'https://gitlab.com',
-        /**
-         * GitLab Personal Access Token. Empty in the tracked template.
-         * @member {String} token=''
-         */
-        token: ''
-    }
-};
-
-/**
- * @summary Environment-variable ledger for client-project GitLab MCP config.
- */
-const envBindings = {
-    debug           : {var: 'NEO_GITLAB_WORKFLOW_DEBUG', parse: Env.parseBool},
-    logLevel        : {var: 'NEO_GITLAB_WORKFLOW_LOG_LEVEL', parse: parseLogLevel},
-    transport       : {var: 'NEO_GITLAB_WORKFLOW_TRANSPORT', parse: Env.parseString},
-    gitlab          : {
-        hostUrl: {var: 'NEO_GITLAB_HOST', parse: Env.parseUrl},
-        token  : {var: 'NEO_GITLAB_PAT',  parse: Env.parseString}
-    }
-};
-
-/**
  * @summary GitLab Workflow MCP configuration singleton.
  *
  * @class Neo.ai.mcp.server.gitlab-workflow.Config
  * @extends Neo.ai.BaseConfig
  */
 class Config extends BaseConfig {
+    /**
+     * @summary Default configuration for the GitLab Workflow MCP server scaffold.
+     *
+     * Keeps client-project GitLab host / PAT configuration out of tracked files.
+     * The real GitLabClient subtask consumes the same keys when API calls land.
+     */
+    static defaultConfig = {
+        /**
+         * @member {String} projectRoot
+         */
+        projectRoot,
+        /**
+         * @member {Boolean} debug=false
+         */
+        debug: false,
+        /**
+         * @member {String} logLevel='warn'
+         */
+        logLevel: 'warn',
+        /**
+         * @summary Shared MCP logger policy for GitLab Workflow.
+         *
+         * Priority-filtered stderr only. `debug: true` promotes the default `warn`
+         * threshold to `debug`; no file sink is used for this workflow server.
+         * @member {Object} logger
+         */
+        logger: {
+            defaultLevel: 'warn',
+            fileSink    : false,
+            stderrMode  : 'threshold'
+        },
+        /**
+         * @member {String} transport='stdio'
+         */
+        transport: 'stdio',
+        /**
+         * @member {Object} gitlab
+         */
+        gitlab: {
+            /**
+             * GitLab instance base URL.
+             * @member {String} hostUrl='https://gitlab.com'
+             */
+            hostUrl: 'https://gitlab.com',
+            /**
+             * GitLab Personal Access Token. Empty in the tracked template.
+             * @member {String} token=''
+             */
+            token: ''
+        }
+    };
+
+    /**
+     * @summary Environment-variable ledger for client-project GitLab MCP config.
+     */
+    static envBindings = {
+        debug           : {var: 'NEO_GITLAB_WORKFLOW_DEBUG', parse: Env.parseBool},
+        logLevel        : {var: 'NEO_GITLAB_WORKFLOW_LOG_LEVEL', parse: parseLogLevel},
+        transport       : {var: 'NEO_GITLAB_WORKFLOW_TRANSPORT', parse: Env.parseString},
+        gitlab          : {
+            hostUrl: {var: 'NEO_GITLAB_HOST', parse: Env.parseUrl},
+            token  : {var: 'NEO_GITLAB_PAT',  parse: Env.parseString}
+        }
+    };
     static config = {
         /**
          * @member {String} className='Neo.ai.mcp.server.gitlab-workflow.Config'
@@ -115,11 +114,11 @@ class Config extends BaseConfig {
         /**
          * @member {Object} defaultConfig
          */
-        defaultConfig,
+        defaultConfig: this.defaultConfig,
         /**
          * @member {Object} envBindings
          */
-        envBindings
+        envBindings: this.envBindings
     }
 }
 

--- a/ai/mcp/server/knowledge-base/config.template.mjs
+++ b/ai/mcp/server/knowledge-base/config.template.mjs
@@ -10,359 +10,7 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname  = path.dirname(__filename);
 const neoRootDir = path.resolve(__dirname, '../../../../');
 
-/**
- * Default configuration object.
- * Defines the structure and default values for the server configuration.
- */
 
-const envBindings = {
-    autoSync         : { var: 'NEO_AUTO_SYNC', parse: Env.parseBool },
-    autoStartDatabase: { var: 'NEO_KB_AUTO_START_DATABASE', parse: Env.parseBool },
-    transport        : 'NEO_TRANSPORT',
-    mcpHttpPort      : { var: 'MCP_HTTP_PORT', parse: Env.parsePort },
-    publicUrl        : { var: 'NEO_PUBLIC_URL', parse: Env.parseUrl },
-    auth             : {
-        host              : 'NEO_AUTH_HOST',
-        port              : { var: 'NEO_AUTH_PORT', parse: Env.parsePort },
-        realm             : 'NEO_AUTH_REALM',
-        issuerUrl         : 'NEO_AUTH_ISSUER_URL',
-        clientId          : 'NEO_OAUTH_CLIENT_ID',
-        clientSecret      : 'NEO_OAUTH_CLIENT_SECRET',
-        trustProxyIdentity: { var: 'NEO_AUTH_TRUST_PROXY_IDENTITY', parse: Env.parseBool }
-    },
-    host                    : 'NEO_CHROMA_HOST',
-    port                    : { var: 'NEO_CHROMA_PORT', parse: Env.parsePort },
-    memoryCoreDbPath        : 'NEO_MEMORY_DB_PATH',
-    kbFaqMinCount           : { var: 'NEO_KB_FAQ_MIN_COUNT', parse: Env.parseNumber },
-    kbFaqSimilarityThreshold: { var: 'NEO_KB_FAQ_SIMILARITY_THRESHOLD', parse: Env.parseNumber },
-    kbFaqConceptLimit       : { var: 'NEO_KB_FAQ_CONCEPT_LIMIT', parse: Env.parseNumber },
-    defaultTenantId         : 'NEO_KB_DEFAULT_TENANT_ID',
-    defaultRepoSlug         : 'NEO_KB_DEFAULT_REPO_SLUG',
-    defaultVisibility       : 'NEO_KB_DEFAULT_VISIBILITY',
-    spoofRejectionMode      : 'NEO_KB_SPOOF_REJECTION_MODE'
-};
-
-const defaultConfig = {
-    neoRootDir,
-    /**
-     * Automatically synchronize the knowledge base on startup.
-     * @type {boolean}
-     */
-    autoSync: false,
-    /**
-     * Automatically start the local Chroma database process on startup.
-     * @type {boolean}
-     */
-    autoStartDatabase: false,
-    /**
-     * Global debug flag for all MCP servers.
-     * @type {boolean}
-     */
-    debug: false,
-    /**
-     * Transport protocol for the MCP server ('stdio' or 'sse').
-     * @type {string}
-     */
-    transport: 'stdio',
-    /**
-     * Port the MCP server's HTTP/SSE transport listens on (only used when `transport === 'sse'`).
-     *
-     * Operator env var: `MCP_HTTP_PORT`.
-     * @type {number}
-     */
-    mcpHttpPort: 3000,
-    /**
-     * Optional public canonical URL for this MCP server.
-     * When configured, this URL is explicitly used as the resource indicator
-     * for OAuth 2.1 / OIDC audience claims and SSE callback advertising.
-     * Required when deploying behind reverse proxies (Nginx/Caddy) where
-     * the internal host:port bindings do not match the public-facing URL.
-     * Example: 'https://mcp.neo.mjs.com/knowledge-base'
-     * @type {string|null}
-     */
-    publicUrl: null,
-    /**
-     * Optional Express middleware function for authentication (only used if transport is 'sse').
-     * @type {Function|null}
-     */
-    authMiddleware: null,
-    /**
-     * Authentication configuration for the server (OAuth 2.1 / OIDC).
-     * Only used when transport is 'sse'.
-     * @type {Object}
-     */
-    auth: {
-        host              : AiConfig.auth.host,
-        port              : AiConfig.auth.port,
-        realm             : AiConfig.auth.realm,
-        issuerUrl         : AiConfig.auth.issuerUrl,
-        clientId          : AiConfig.auth.clientId,
-        clientSecret      : AiConfig.auth.clientSecret,
-        trustProxyIdentity: AiConfig.auth.trustProxyIdentity
-    },
-    /**
-     * A dummy embedding function to satisfy the ChromaDB API when embeddings are provided manually.
-     *
-     * NOTE: This verbose structure is strictly required to prevent the ChromaDB client from
-     * flagging this as a "legacy" function, which triggers a persistent console warning:
-     * "No embedding function configuration found for collection..."
-     *
-     * The `chromadb` library checks for the presence of `name`, `getConfig`, and `buildFromConfig`.
-     * If any are missing, it defaults to legacy mode.
-     * @returns {Object} The dummy embedding function satisfying IEmbeddingFunction
-     */
-    dummyEmbeddingFunction: {
-        generate   : () => null,
-        name       : 'dummy_embedding_function',
-        getConfig  : () => ({}),
-        constructor: {
-            buildFromConfig: () => ({
-                generate : () => null,
-                name     : 'dummy_embedding_function',
-                getConfig: () => ({})
-            })
-        }
-    },
-    /**
-     * The hostname of the ChromaDB server for the knowledge base.
-     *
-     * Operator env var: `NEO_CHROMA_HOST`. For shared cloud deployments where KB hosts the
-     * unified Chroma instance for both KB + MC, this points at the shared cloud-hosted Chroma.
-     * @type {string}
-     */
-    host: AiConfig.engines.chroma.host,
-    /**
-     * The port the ChromaDB server for the knowledge base is listening on.
-     *
-     * Operator env var: `NEO_CHROMA_PORT`. Invalid values (non-integer / out-of-range)
-     * fall back to the default with a console warning per the resolver validity contract.
-     * @type {number}
-     */
-    port: AiConfig.engines.chroma.port,
-    /**
-     * The local persistence path for the agent knowledge-base server.
-     * @type {string}
-     */
-    path: path.resolve(neoRootDir, '.neo-ai-data/chroma/knowledge-base'),
-    /**
-     * @summary Shared SQLite destination for Knowledge Base query telemetry.
-     *
-     * Path to the shared Memory Core SQLite database used for Knowledge Base query telemetry.
-     * Mirrors the Neural Link recorder default so `kb_query_log` and `kb_query_faqs`
-     * land beside `nl_action_log` without coupling either MCP server's schema.
-     * @type {string}
-     */
-    memoryCoreDbPath: path.join(os.homedir(), '.neo-ai-data', 'memory-core.sqlite'),
-    /**
-     * @summary Repetition threshold for promoting KB queries into Agent FAQ clusters.
-     *
-     * Minimum repeated Knowledge Base queries required before an Agent FAQ becomes
-     * eligible for `[KB_DEMAND_GAP]` inference and `list_agent_faqs` reporting.
-     * @type {number}
-     */
-    kbFaqMinCount: 3,
-    /**
-     * @summary Calibration threshold for future embedding-backed Agent FAQ clustering.
-     *
-     * Calibration marker for FAQ clustering. The first implementation uses exact
-     * normalized-query grouping as the conservative 1.0 baseline; operators can
-     * lower this once embedding-backed similarity is measured against real traffic.
-     * @type {number}
-     */
-    kbFaqSimilarityThreshold: 1.0,
-    /**
-     * @summary Bound for Concept Ontology IDs attached to each Agent FAQ cluster.
-     *
-     * Maximum number of Concept Ontology IDs attached to each Agent FAQ.
-     * @type {number}
-     */
-    kbFaqConceptLimit: 5,
-    /**
-     * The path to the generated knowledge base JSONL file.
-     * @type {string}
-     */
-    dataPath: path.resolve(neoRootDir, 'dist/ai-knowledge-base.jsonl'),
-    /**
-     * The path to the generated class hierarchy JSON file.
-     * @type {string}
-     */
-    hierarchyPath: path.resolve(neoRootDir, 'docs/output/class-hierarchy.json'),
-    /**
-     * Directory for the always-on KB server diagnostic log files. The KB server's
-     * `logger.mjs` writes daily-rotated entries here regardless of `debug`, so long-running
-     * operations (sync, embedding loops, ChromaDB lifecycle) leave a tail-able diagnostic
-     * trail observable from the host shell. Default: `<neoRootDir>/.neo-ai-data/logs/`.
-     * @type {string}
-     */
-    logPath: path.resolve(neoRootDir, '.neo-ai-data/logs'),
-    /**
-     * @summary Shared MCP logger policy for Knowledge Base.
-     *
-     * Always-on file sink plus debug-gated stderr. The shared logger reads this
-     * per-server policy lazily, so tests and local config overrides can update
-     * `logPath` / `debug` before the next write without re-importing the module.
-     * @type {Object}
-     */
-    logger: {
-        filePrefix    : 'kb-server',
-        fileSink      : true,
-        stderrMode    : 'debug',
-        timestampStyle: 'plain'
-    },
-    /**
-     * The name of the ChromaDB collection for the knowledge base.
-     * @type {string}
-     */
-    collectionName: 'neo-knowledge-base',
-    /**
-     * When `true` (default), the SourceRegistry auto-registers Neo's
-     * 10 curated default Source classes. Cloud deployments that ingest only tenant content
-     * can set `false` to skip Neo's curated sources entirely.
-     * @type {boolean}
-     */
-    useDefaultSources: true,
-    /**
-     * When `true` (default), the SourceRegistry auto-registers Neo's
-     * built-in Parser classes. The default registry may be empty until parser modules are added.
-     * @type {boolean}
-     */
-    useDefaultParsers: true,
-    /**
-     * Declarative tenant-supplied Source registration.
-     * Each entry: `{SourceClass, sourceName?}`.
-     * @type {Array<{SourceClass: Object, sourceName?: string}>}
-     */
-    customSources: [],
-    /**
-     * Declarative tenant-supplied Parser registration.
-     * Each entry: `{ParserClass, parserId?}`.
-     * @type {Array<{ParserClass: Object, parserId?: string}>}
-     */
-    customParsers: [],
-    /**
-     * Per-source path overrides keyed by Source-class registry name.
-     * Empty entries or missing keys fall through to each Source class's hardcoded fallback
-     * (preserves byte-equivalence with existing deployment behavior). Shape varies per Source class —
-     * each interprets its own entry shape (string / string-array / path→type object).
-     * @type {Object<string,string|string[]|Object<string,string>>}
-     */
-    sourcePaths: {
-        AdrSource         : 'learn/agentos/decisions',
-        ConceptSource     : 'resources/content/concepts',
-        ReleaseNotesSource: '.github/RELEASE_NOTES',
-        SkillSource       : '.agents/skills',
-        TestSource        : 'test/playwright',
-        LearningSource    : 'learn/tree.json',
-        DiscussionSource  : ['resources/content/discussions',
-                             'resources/content/archive/discussions'],
-        PullRequestSource : ['resources/content/pulls',
-                             'resources/content/archive/pulls'],
-        TicketSource      : ['resources/content/issues',
-                             'resources/content/archive/issues'],
-        ApiSource         : {
-            'src'     : 'src',
-            'apps'    : 'app',
-            'examples': 'example',
-            'docs/app': 'app',
-            'ai'      : 'ai-infrastructure'
-        }
-    },
-    /**
-     * @summary Default tenant identity for Neo's curated Knowledge Base corpus — the team
-     * namespace visible across every tenant.
-     *
-     * Write side: `VectorService.embed()` stamps this when no authenticated ingestion context
-     * is supplied. Read side: `QueryService.queryDocuments` and `DocumentService`
-     * include it in the `where: {tenantId: {$in: [<requester>, <this>]}}` filter so every tenant
-     * additionally retrieves the curated corpus. Cloud ingestion paths override the write-side
-     * value with server-derived tenant context; client-supplied chunk metadata is never authoritative.
-     * @type {string}
-     */
-    defaultTenantId: 'neo-shared',
-    /**
-     * @summary Default repository slug for Neo's curated Knowledge Base corpus.
-     *
-     * Included in content hashing and Chroma IDs so byte-identical chunks from different
-     * tenant repositories cannot collide.
-     * @type {string}
-     */
-    defaultRepoSlug: 'neo',
-    /**
-     * @summary Default read visibility for embedded Knowledge Base chunks.
-     *
-     * Write paths stamp the authoritative value; tenant-aware read paths consume it for
-     * filtering.
-     * @type {string}
-     */
-    defaultVisibility: 'team',
-    /**
-     * @summary Policy for conflicting client-supplied tenant metadata.
-     *
-     * `'overwrite'` logs and replaces conflicting `{tenantId, repoSlug, visibility,
-     * originAgentIdentity}` fields with server-derived values. `'reject'` fails the
-     * embedding call with `KB_TENANT_SPOOF_REJECTED`.
-     * @type {'overwrite'|'reject'}
-     */
-    spoofRejectionMode: 'overwrite',
-    /**
-     * The name of the Google Generative AI model for content generation.
-     * @type {string}
-     */
-    modelName: 'gemini-2.5-flash',
-    /**
-     * The number of chunks to process in a single batch when embedding.
-     * @type {number}
-     */
-    batchSize: 50,
-    /**
-     * Work-volume gate for MCP-callable `manage_knowledge_base sync`: when
-     * the post-delta `chunksToProcess.length` exceeds this value AND the call originates
-     * via MCP tool dispatch, `VectorService.embed` refuses synchronous execution and
-     * returns a `KB_SYNC_VOLUME_EXCEEDED` error pointing the operator at the CLI path
-     * (`npm run ai:sync-kb`). CLI invocations bypass the gate.
-     *
-     * Default `50` aligns with `batchSize` — one batch is the floor for "small enough
-     * to run synchronously". Real latency depends on provider/tier/retry-state; the
-     * threshold is empirically tunable per deployment.
-     * @type {number}
-     */
-    mcpSyncMaxChunks: 50,
-    /**
-     * Delay in milliseconds between batches to avoid rate limits.
-     * @type {number}
-     */
-    batchDelay: 10000,
-    /**
-     * The maximum number of times to retry a failed embedding batch.
-     * @type {number}
-     */
-    maxRetries: 5,
-    /**
-     * The number of results to fetch from ChromaDB for a query.
-     * @type {number}
-     */
-    nResults: 100,
-    /**
-     * Weights used in the query scoring algorithm.
-     * @type {Object}
-     */
-    queryScoreWeights: {
-        baseIncrement    : 1,
-        sourcePathMatch  : 40,
-        fileNameMatch    : 30,
-        classNameMatch   : 20,
-        guideMatch       : 50,
-        conceptMatch     : 15,
-        blogMatch        : 5,
-        namePartMatch    : 30,
-        ticketPenalty    : -70,
-        releasePenalty   : -50,
-        baseFileBonus    : 20,
-        releaseExactMatch: 1000,
-        inheritanceBoost : 80,
-        inheritanceDecay : 0.6
-    }
-};
 
 /**
  * @summary Configuration manager for the Knowledge Base MCP server.
@@ -375,6 +23,364 @@ const defaultConfig = {
  * @singleton
  */
 class Config extends BaseConfig {
+    static defaultConfig = {
+        neoRootDir,
+        /**
+         * Universal JSONL backup/export directory inherited from Tier-1 config.
+         * @type {string}
+         */
+        backupPath: AiConfig.backupPath,
+        /**
+         * Automatically synchronize the knowledge base on startup.
+         * @type {boolean}
+         */
+        autoSync: false,
+        /**
+         * Automatically start the local Chroma database process on startup.
+         * @type {boolean}
+         */
+        autoStartDatabase: false,
+        /**
+         * Global debug flag for all MCP servers.
+         * @type {boolean}
+         */
+        debug: false,
+        /**
+         * Transport protocol for the MCP server ('stdio' or 'sse').
+         * @type {string}
+         */
+        transport: 'stdio',
+        /**
+         * Port the MCP server's HTTP/SSE transport listens on (only used when `transport === 'sse'`).
+         *
+         * Operator env var: `MCP_HTTP_PORT`.
+         * @type {number}
+         */
+        mcpHttpPort: 3000,
+        /**
+         * Optional public canonical URL for this MCP server.
+         * When configured, this URL is explicitly used as the resource indicator
+         * for OAuth 2.1 / OIDC audience claims and SSE callback advertising.
+         * Required when deploying behind reverse proxies (Nginx/Caddy) where
+         * the internal host:port bindings do not match the public-facing URL.
+         * Example: 'https://mcp.neo.mjs.com/knowledge-base'
+         * @type {string|null}
+         */
+        publicUrl: null,
+        /**
+         * Optional Express middleware function for authentication (only used if transport is 'sse').
+         * @type {Function|null}
+         */
+        authMiddleware: null,
+        /**
+         * Authentication configuration for the server (OAuth 2.1 / OIDC).
+         * Only used when transport is 'sse'.
+         * @type {Object}
+         */
+        auth: {
+            host              : AiConfig.auth.host,
+            port              : AiConfig.auth.port,
+            realm             : AiConfig.auth.realm,
+            issuerUrl         : AiConfig.auth.issuerUrl,
+            clientId          : AiConfig.auth.clientId,
+            clientSecret      : AiConfig.auth.clientSecret,
+            trustProxyIdentity: AiConfig.auth.trustProxyIdentity
+        },
+        /**
+         * A dummy embedding function to satisfy the ChromaDB API when embeddings are provided manually.
+         *
+         * NOTE: This verbose structure is strictly required to prevent the ChromaDB client from
+         * flagging this as a "legacy" function, which triggers a persistent console warning:
+         * "No embedding function configuration found for collection..."
+         *
+         * The `chromadb` library checks for the presence of `name`, `getConfig`, and `buildFromConfig`.
+         * If any are missing, it defaults to legacy mode.
+         * @returns {Object} The dummy embedding function satisfying IEmbeddingFunction
+         */
+        dummyEmbeddingFunction: {
+            generate   : () => null,
+            name       : 'dummy_embedding_function',
+            getConfig  : () => ({}),
+            constructor: {
+                buildFromConfig: () => ({
+                    generate : () => null,
+                    name     : 'dummy_embedding_function',
+                    getConfig: () => ({})
+                })
+            }
+        },
+        /**
+         * The hostname of the ChromaDB server for the knowledge base.
+         *
+         * Operator env var: `NEO_CHROMA_HOST`. For shared cloud deployments where KB hosts the
+         * unified Chroma instance for both KB + MC, this points at the shared cloud-hosted Chroma.
+         * @type {string}
+         */
+        host: AiConfig.engines.chroma.host,
+        /**
+         * The port the ChromaDB server for the knowledge base is listening on.
+         *
+         * Operator env var: `NEO_CHROMA_PORT`. Invalid values (non-integer / out-of-range)
+         * fall back to the default with a console warning per the resolver validity contract.
+         * @type {number}
+         */
+        port: AiConfig.engines.chroma.port,
+        /**
+         * The local persistence path for the agent knowledge-base server.
+         * @type {string}
+         */
+        path: path.resolve(neoRootDir, '.neo-ai-data/chroma/knowledge-base'),
+        /**
+         * @summary Shared SQLite destination for Knowledge Base query telemetry.
+         *
+         * Path to the shared Memory Core SQLite database used for Knowledge Base query telemetry.
+         * Mirrors the Neural Link recorder default so `kb_query_log` and `kb_query_faqs`
+         * land beside `nl_action_log` without coupling either MCP server's schema.
+         * @type {string}
+         */
+        memoryCoreDbPath: path.join(os.homedir(), '.neo-ai-data', 'memory-core.sqlite'),
+        /**
+         * @summary Repetition threshold for promoting KB queries into Agent FAQ clusters.
+         *
+         * Minimum repeated Knowledge Base queries required before an Agent FAQ becomes
+         * eligible for `[KB_DEMAND_GAP]` inference and `list_agent_faqs` reporting.
+         * @type {number}
+         */
+        kbFaqMinCount: 3,
+        /**
+         * @summary Calibration threshold for future embedding-backed Agent FAQ clustering.
+         *
+         * Calibration marker for FAQ clustering. The first implementation uses exact
+         * normalized-query grouping as the conservative 1.0 baseline; operators can
+         * lower this once embedding-backed similarity is measured against real traffic.
+         * @type {number}
+         */
+        kbFaqSimilarityThreshold: 1.0,
+        /**
+         * @summary Bound for Concept Ontology IDs attached to each Agent FAQ cluster.
+         *
+         * Maximum number of Concept Ontology IDs attached to each Agent FAQ.
+         * @type {number}
+         */
+        kbFaqConceptLimit: 5,
+        /**
+         * The path to the generated knowledge base JSONL file.
+         * @type {string}
+         */
+        dataPath: path.resolve(neoRootDir, 'dist/ai-knowledge-base.jsonl'),
+        /**
+         * The path to the generated class hierarchy JSON file.
+         * @type {string}
+         */
+        hierarchyPath: path.resolve(neoRootDir, 'docs/output/class-hierarchy.json'),
+        /**
+         * Directory for the always-on KB server diagnostic log files. The KB server's
+         * `logger.mjs` writes daily-rotated entries here regardless of `debug`, so long-running
+         * operations (sync, embedding loops, ChromaDB lifecycle) leave a tail-able diagnostic
+         * trail observable from the host shell. Default: `<neoRootDir>/.neo-ai-data/logs/`.
+         * @type {string}
+         */
+        logPath: path.resolve(neoRootDir, '.neo-ai-data/logs'),
+        /**
+         * @summary Shared MCP logger policy for Knowledge Base.
+         *
+         * Always-on file sink plus debug-gated stderr. The shared logger reads this
+         * per-server policy lazily, so tests and local config overrides can update
+         * `logPath` / `debug` before the next write without re-importing the module.
+         * @type {Object}
+         */
+        logger: {
+            filePrefix    : 'kb-server',
+            fileSink      : true,
+            stderrMode    : 'debug',
+            timestampStyle: 'plain'
+        },
+        /**
+         * The name of the ChromaDB collection for the knowledge base.
+         * @type {string}
+         */
+        collectionName: 'neo-knowledge-base',
+        /**
+         * When `true` (default), the SourceRegistry auto-registers Neo's
+         * 10 curated default Source classes. Cloud deployments that ingest only tenant content
+         * can set `false` to skip Neo's curated sources entirely.
+         * @type {boolean}
+         */
+        useDefaultSources: true,
+        /**
+         * When `true` (default), the SourceRegistry auto-registers Neo's
+         * built-in Parser classes. The default registry may be empty until parser modules are added.
+         * @type {boolean}
+         */
+        useDefaultParsers: true,
+        /**
+         * Declarative tenant-supplied Source registration.
+         * Each entry: `{SourceClass, sourceName?}`.
+         * @type {Array<{SourceClass: Object, sourceName?: string}>}
+         */
+        customSources: [],
+        /**
+         * Declarative tenant-supplied Parser registration.
+         * Each entry: `{ParserClass, parserId?}`.
+         * @type {Array<{ParserClass: Object, parserId?: string}>}
+         */
+        customParsers: [],
+        /**
+         * Per-source path overrides keyed by Source-class registry name.
+         * Empty entries or missing keys fall through to each Source class's hardcoded fallback
+         * (preserves byte-equivalence with existing deployment behavior). Shape varies per Source class —
+         * each interprets its own entry shape (string / string-array / path→type object).
+         * @type {Object<string,string|string[]|Object<string,string>>}
+         */
+        sourcePaths: {
+            AdrSource         : 'learn/agentos/decisions',
+            ConceptSource     : 'resources/content/concepts',
+            ReleaseNotesSource: '.github/RELEASE_NOTES',
+            SkillSource       : '.agents/skills',
+            TestSource        : 'test/playwright',
+            LearningSource    : 'learn/tree.json',
+            DiscussionSource  : ['resources/content/discussions',
+                                 'resources/content/archive/discussions'],
+            PullRequestSource : ['resources/content/pulls',
+                                 'resources/content/archive/pulls'],
+            TicketSource      : ['resources/content/issues',
+                                 'resources/content/archive/issues'],
+            ApiSource         : {
+                'src'     : 'src',
+                'apps'    : 'app',
+                'examples': 'example',
+                'docs/app': 'app',
+                'ai'      : 'ai-infrastructure'
+            }
+        },
+        /**
+         * @summary Default tenant identity for Neo's curated Knowledge Base corpus — the team
+         * namespace visible across every tenant.
+         *
+         * Write side: `VectorService.embed()` stamps this when no authenticated ingestion context
+         * is supplied. Read side: `QueryService.queryDocuments` and `DocumentService`
+         * include it in the `where: {tenantId: {$in: [<requester>, <this>]}}` filter so every tenant
+         * additionally retrieves the curated corpus. Cloud ingestion paths override the write-side
+         * value with server-derived tenant context; client-supplied chunk metadata is never authoritative.
+         * @type {string}
+         */
+        defaultTenantId: 'neo-shared',
+        /**
+         * @summary Default repository slug for Neo's curated Knowledge Base corpus.
+         *
+         * Included in content hashing and Chroma IDs so byte-identical chunks from different
+         * tenant repositories cannot collide.
+         * @type {string}
+         */
+        defaultRepoSlug: 'neo',
+        /**
+         * @summary Default read visibility for embedded Knowledge Base chunks.
+         *
+         * Write paths stamp the authoritative value; tenant-aware read paths consume it for
+         * filtering.
+         * @type {string}
+         */
+        defaultVisibility: 'team',
+        /**
+         * @summary Policy for conflicting client-supplied tenant metadata.
+         *
+         * `'overwrite'` logs and replaces conflicting `{tenantId, repoSlug, visibility,
+         * originAgentIdentity}` fields with server-derived values. `'reject'` fails the
+         * embedding call with `KB_TENANT_SPOOF_REJECTED`.
+         * @type {'overwrite'|'reject'}
+         */
+        spoofRejectionMode: 'overwrite',
+        /**
+         * The name of the Google Generative AI model for content generation.
+         * @type {string}
+         */
+        modelName: 'gemini-2.5-flash',
+        /**
+         * The number of chunks to process in a single batch when embedding.
+         * @type {number}
+         */
+        batchSize: 50,
+        /**
+         * Work-volume gate for MCP-callable `manage_knowledge_base sync`: when
+         * the post-delta `chunksToProcess.length` exceeds this value AND the call originates
+         * via MCP tool dispatch, `VectorService.embed` refuses synchronous execution and
+         * returns a `KB_SYNC_VOLUME_EXCEEDED` error pointing the operator at the CLI path
+         * (`npm run ai:sync-kb`). CLI invocations bypass the gate.
+         *
+         * Default `50` aligns with `batchSize` — one batch is the floor for "small enough
+         * to run synchronously". Real latency depends on provider/tier/retry-state; the
+         * threshold is empirically tunable per deployment.
+         * @type {number}
+         */
+        mcpSyncMaxChunks: 50,
+        /**
+         * Delay in milliseconds between batches to avoid rate limits.
+         * @type {number}
+         */
+        batchDelay: 10000,
+        /**
+         * The maximum number of times to retry a failed embedding batch.
+         * @type {number}
+         */
+        maxRetries: 5,
+        /**
+         * The number of results to fetch from ChromaDB for a query.
+         * @type {number}
+         */
+        nResults: 100,
+        /**
+         * Weights used in the query scoring algorithm.
+         * @type {Object}
+         */
+        queryScoreWeights: {
+            baseIncrement    : 1,
+            sourcePathMatch  : 40,
+            fileNameMatch    : 30,
+            classNameMatch   : 20,
+            guideMatch       : 50,
+            conceptMatch     : 15,
+            blogMatch        : 5,
+            namePartMatch    : 30,
+            ticketPenalty    : -70,
+            releasePenalty   : -50,
+            baseFileBonus    : 20,
+            releaseExactMatch: 1000,
+            inheritanceBoost : 80,
+            inheritanceDecay : 0.6
+        }
+    };
+
+    /**
+     * Environment-variable ledger for Knowledge Base server config.
+     * Binding shape mirrors `defaultConfig`.
+     */
+    static envBindings = {
+        autoSync         : { var: 'NEO_AUTO_SYNC', parse: Env.parseBool },
+        autoStartDatabase: { var: 'NEO_KB_AUTO_START_DATABASE', parse: Env.parseBool },
+        transport        : 'NEO_TRANSPORT',
+        mcpHttpPort      : { var: 'MCP_HTTP_PORT', parse: Env.parsePort },
+        publicUrl        : { var: 'NEO_PUBLIC_URL', parse: Env.parseUrl },
+        auth             : {
+            host              : 'NEO_AUTH_HOST',
+            port              : { var: 'NEO_AUTH_PORT', parse: Env.parsePort },
+            realm             : 'NEO_AUTH_REALM',
+            issuerUrl         : 'NEO_AUTH_ISSUER_URL',
+            clientId          : 'NEO_OAUTH_CLIENT_ID',
+            clientSecret      : 'NEO_OAUTH_CLIENT_SECRET',
+            trustProxyIdentity: { var: 'NEO_AUTH_TRUST_PROXY_IDENTITY', parse: Env.parseBool }
+            },
+            backupPath              : 'NEO_BACKUP_PATH',
+            host                    : 'NEO_CHROMA_HOST',
+            port                    : { var: 'NEO_CHROMA_PORT', parse: Env.parsePort },
+            memoryCoreDbPath        : 'NEO_MEMORY_DB_PATH',
+        kbFaqMinCount           : { var: 'NEO_KB_FAQ_MIN_COUNT', parse: Env.parseNumber },
+        kbFaqSimilarityThreshold: { var: 'NEO_KB_FAQ_SIMILARITY_THRESHOLD', parse: Env.parseNumber },
+        kbFaqConceptLimit       : { var: 'NEO_KB_FAQ_CONCEPT_LIMIT', parse: Env.parseNumber },
+        defaultTenantId         : 'NEO_KB_DEFAULT_TENANT_ID',
+        defaultRepoSlug         : 'NEO_KB_DEFAULT_REPO_SLUG',
+        defaultVisibility       : 'NEO_KB_DEFAULT_VISIBILITY',
+        spoofRejectionMode      : 'NEO_KB_SPOOF_REJECTION_MODE'
+    };
     static config = {
         /**
          * @member {String} className='Neo.ai.mcp.server.knowledge-base.Config'
@@ -389,11 +395,11 @@ class Config extends BaseConfig {
         /**
          * @member {Object} defaultConfig
          */
-        defaultConfig,
+        defaultConfig: this.defaultConfig,
         /**
          * @member {Object} envBindings
          */
-        envBindings
+        envBindings: this.envBindings
     }
 }
 const instance = Neo.setupClass(Config);

--- a/ai/mcp/server/memory-core/config.template.mjs
+++ b/ai/mcp/server/memory-core/config.template.mjs
@@ -20,468 +20,6 @@ const neoRootDir = path.resolve(__dirname, '../../../../');
 const cwd        = neoRootDir;
 
 /**
- * Default configuration object.
- * Defines the structure and default values for the server configuration.
- */
-const defaultConfig = {
-    /**
-     * Repo root, computed from this module's path. Exported for symmetry with the
-     * KB and Neural Link configs (#10584) so consumers (loggers, services, future)
-     * can read `aiConfig.neoRootDir` rather than recomputing the 4-level traversal
-     * locally. Module path is stable; the resolution is deterministic at boot.
-     * @type {string}
-     */
-    neoRootDir,
-    /**
-     * Automatically trigger session summarization on startup.
-     * @type {boolean}
-     */
-    autoSummarize: false,
-    /**
-     * Automatically start the local database process (Chroma/SQLite) on startup.
-     * @type {boolean}
-     */
-    autoStartDatabase: false,
-    /**
-     * Automatically start the local inference server on startup.
-     * @type {boolean}
-     */
-    autoStartInference: false,
-    /**
-     * Automatically trigger GraphRAG extraction on startup.
-     * @type {boolean}
-     */
-    autoDream: false,
-    /**
-     * @deprecated since PR #11101. Golden Path synthesis is now dynamically event-driven
-     * (triggered via MemoryService#mutateFrontier) rather than bound to MCP boot sequence.
-     * This boot-time flag remains for temporary backwards-compatibility but will be
-     * removed in a future release.
-     *
-     * Automatically trigger Golden Path Synthesis into the handoff file on startup.
-     * Crucial for headless swarm nodes (Mac 2) to physically generate sandman_handoff.md.
-     * @type {boolean}
-     */
-    autoGoldenPath: false,
-    /**
-     * Immediately parse each incoming memory turn (add_memory) for Graph Injection.
-     * @type {boolean}
-     */
-    realTimeMemoryParsing: false,
-    /**
-     * Automatically trigger FileSystem ingestion (Differential Graph Sync) on MCP server startup.
-     * @type {boolean}
-     */
-    autoIngestFileSystem: false,
-    /**
-     * Global debug flag for all MCP servers.
-     * @type {boolean}
-     */
-    debug: false,
-    /**
-     * Transport protocol for the MCP server ('stdio' or 'sse').
-     * @type {string}
-     */
-    transport: 'stdio',
-    /**
-     * Port the MCP server's HTTP/SSE transport listens on (only used when `transport === 'sse'`).
-     *
-     * Operator env var: `MCP_HTTP_PORT`.
-     * @type {number}
-     */
-    mcpHttpPort: 3001,
-    /**
-     * Optional public canonical URL for this MCP server.
-     * When configured, this URL is explicitly used as the resource indicator
-     * for OAuth 2.1 / OIDC audience claims and SSE callback advertising.
-     * Required when deploying behind reverse proxies (Nginx/Caddy) where
-     * the internal host:port bindings do not match the public-facing URL.
-     * Example: 'https://mcp.neo.mjs.com/memory-core'
-     * @type {string|null}
-     */
-    publicUrl: null,
-    /**
-     * Optional Express middleware function for authentication (only used if transport is 'sse').
-     * @type {Function|null}
-     */
-    authMiddleware: null,
-    /**
-     * Authentication configuration for the server (OAuth 2.1 / OIDC).
-     * Only used when transport is 'sse'.
-     * @type {Object}
-     */
-    auth: {
-        host              : AiConfig.auth.host,
-        port              : AiConfig.auth.port,
-        realm             : AiConfig.auth.realm,
-        issuerUrl         : AiConfig.auth.issuerUrl,
-        clientId          : AiConfig.auth.clientId,
-        clientSecret      : AiConfig.auth.clientSecret,
-        trustProxyIdentity: AiConfig.auth.trustProxyIdentity
-    },
-    /**
-     * Explicit override provider for the core LLM Engine (e.g. summarization).
-     * Supported values: 'gemini', 'ollama', 'openAiCompatible'
-     * @type {String}
-     */
-    modelProvider: AiConfig.modelProvider,
-    /**
-     * Canonical embedding provider for Memory Core and Knowledge Base embedding callsites.
-     * Supported values: 'gemini', 'ollama', 'openAiCompatible'
-     * Defaults to the local OpenAI-compatible Qwen3 route so the source tuple matches the
-     * unified 4096-dimension Chroma collection invariant. Gemini remains available as an
-     * explicit operator override and must be paired with `vectorDimension: 3072`.
-     *
-     * @type {String}
-     */
-    embeddingProvider: AiConfig.embeddingProvider,
-    /**
-     * Settings for the Ollama integration
-     */
-    ollama: {
-        host          : AiConfig.ollama.host,
-        model         : AiConfig.ollama.model,
-        embeddingModel: AiConfig.ollama.embeddingModel
-    },
-    /**
-     * Settings for the OpenAI-Compatible API integration (e.g., mlx-lm or mlx-openai-server)
-     * WARNING: Never hardcode API keys here. Always export them via .env or globally.
-     */
-    openAiCompatible: {
-        host                    : AiConfig.openAiCompatible.host,
-        model                   : AiConfig.openAiCompatible.model,
-        embeddingModel          : AiConfig.openAiCompatible.embeddingModel,
-        apiKey                  : AiConfig.openAiCompatible.apiKey,
-        unloadRetryCount        : AiConfig.openAiCompatible.unloadRetryCount,
-        unloadRetryDelayMs      : AiConfig.openAiCompatible.unloadRetryDelayMs,
-        /**
-         * Configured context-window capacity of `model` measured in **tokens**.
-         * Token-based per the Discussion #11444 / #11447 V1 graduation contract.
-         * Used by `ConsumerFrictionHelper.invokeWithGuardrail` to fire the upstream
-         * pre-check skip ("Angle 2") when an LLM input payload exceeds the consumer's
-         * safe processing band. Default is sized for Gemma-3-4B / Qwen3-8B class
-         * consumers (~32K-token context). Operators running models with different
-         * context windows should tune this to match the deployed model — e.g. 8192
-         * for Gemma-4-8B-IT, 131072 for Llama-3.1-70B 128K-context variants.
-         * @type {number}
-         */
-        contextLimitTokens: AiConfig.openAiCompatible.contextLimitTokens,
-        /**
-         * Optional safer processing threshold (tokens) below `contextLimitTokens` for
-         * the upstream pre-check skip. When the estimated input token count exceeds
-         * this value, `invokeWithGuardrail` emits a `size-precheck-skip` friction and
-         * does NOT invoke the consumer model. Defaults to 75% of `contextLimitTokens`
-         * when unset — leaves ~25% headroom for system-prompt envelope, repair-cycle
-         * prompt growth, and output-token reservation per Discussion #11444 Round-2
-         * consensus.
-         * @type {number|undefined}
-         */
-        safeProcessingLimitTokens: AiConfig.openAiCompatible.safeProcessingLimitTokens
-    },
-    /**
-     * The enforced vector dimension across all SQLite collections.
-     * Hard-configured here to prevent catastrophic schema wipes due to dynamic model changes.
-     * @type {number}
-     */
-    vectorDimension: AiConfig.vectorDimension,
-    /**
-     * The name of the Google Generative AI model for content generation.
-     * @type {string}
-     */
-    modelName: AiConfig.modelName,
-    /**
-     * The name of the Google Generative AI model for text embeddings.
-     * @type {string}
-     */
-    embeddingModel: AiConfig.embeddingModel,
-    /**
-     * Pagination limit for fetching records during session summarization scans.
-     * Controls the batch size for memory and summary retrieval.
-     * @type {number}
-     */
-    summarizationBatchLimit: 2000,
-    /**
-     * Maximum number of concurrent session summarization requests.
-     * Prevents hitting LLM/Embedding API rate limits during bulk operations.
-     * @type {number}
-     */
-    summarizationConcurrency: 5,
-    /**
-     * The target Storage Architecture to use.
-     * Note: Chroma is the only supported Vector DB.
-     * Options: 'hybrid' (Chroma vectors + SQLite graph), 'chroma' (Chroma vectors only).
-     * The default is explicitly 'hybrid' per Epic #9922 Two-Pillar RAG architecture.
-     */
-    engine: 'hybrid',
-    /**
-     * Database Engine Definitions
-     * This defines WHERE data is stored physically (for engines MC owns) and WHERE MC reaches
-     * into other services' engines. The flat `engines.chroma` path specifies the unified
-     * ChromaDB instance shared with the Knowledge Base.
-     */
-    engines: {
-        chroma: {
-            dataDir: path.resolve(cwd, '.neo-ai-data/chroma/memory-core'),
-            host   : AiConfig.engines.chroma.host,
-            port   : AiConfig.engines.chroma.port
-        }
-    },
-    /**
-     * Physical file paths for embedded/local datasets.
-     */
-    storagePaths: {
-        graph: process.env.UNIT_TEST_MODE === 'true' ? ':memory:' : path.resolve(cwd, '.neo-ai-data/sqlite/memory-core-graph.sqlite')
-    },
-    /**
-     * Data Schema/Table Names
-     * This defines WHAT the tables/collections are called logically.
-     */
-    collections: {
-        memory : process.env.UNIT_TEST_MODE === 'true' ? `test-memory-${Date.now()}-${Math.random().toString(36).substring(7)}` : 'neo-agent-memory',
-        session: process.env.UNIT_TEST_MODE === 'true' ? `test-session-${Date.now()}-${Math.random().toString(36).substring(7)}` : 'neo-agent-sessions',
-        graph  : 'neo-native-graph'
-    },
-    /**
-     * Datasets Schema/Paths
-     * This defines WHERE autonomous curation exports data.
-     */
-    datasets: {
-        rlaif: {
-            trajectories: path.resolve(cwd, '.neo-ai-data/datasets/rlaif/trajectories.jsonl')
-        }
-    },
-    /**
-     * Target markdown file used for autonomous agent-to-user reporting (offline jobs).
-     * @type {string}
-     */
-    handoffFilePath: path.resolve(cwd, 'resources/content/sandman_handoff.md'),
-    /**
-     * The Hebbian decay factor applied every 24 hours to the edge graph (e.g., 0.98 for ~79 day half-life).
-     * @type {number}
-     */
-    decayFactor: 0.98,
-    /**
-     * Minimum weight threshold for emitting `[GUIDE_GAP]`, `[EXAMPLE_GAP]`, and `[ORPHAN_CONCEPT]`
-     * signals on CONCEPT nodes during `GapInferenceEngine.inferConceptGraphGaps`.
-     *
-     * **Derivation:** `ConceptService.calculateWeight` returns `tier_score + uniqueness + coverage_deficit`
-     * where tier-1 gets `0.8`, tier-2 `0.5`, tier-3 `0.3`; uniqueness adds `0.2`; coverage deficit (no
-     * EXPLAINED_BY) adds `0.3`. The minimum a tier-1 concept can score is `0.8` (covered, non-unique).
-     * Setting threshold = `0.8` means *"at least tier-1 baseline priority"* — every tier-1 concept
-     * without a guide qualifies; tier-2/3 concepts qualify only if uniqueness + deficit push them above.
-     *
-     * Tune up to silence tier-2/3 noise as ontology grows (#10036 / #10037 / #10050); tune down to
-     * surface lower-priority concepts in the handoff.
-     * @type {number}
-     */
-    guideGapWeightThreshold: 0.8,
-    /**
-     * Operator-tuning knobs for `ConceptDiscoveryService` (#10036). Both values are read live
-     * at method-call time (not captured at module load) so tests + runtime overrides are honored.
-     *
-     * - `prScanLimit`: how many pull-request markdown files to process per discovery cycle.
-     *   PRs are sorted descending by PR number so the most-recent (freshest architectural
-     *   discourse) process first. Capping bounds per-cycle LLM cost against the ~300+ PR corpus.
-     * - `minSourceLength`: minimum source text length (chars) to trigger an LLM extraction call.
-     *   Short bodies aren't worth the provider round-trip; 200 ≈ 30 words of coherent prose.
-     *
-     * Expected to migrate to SDK-layer config per #10103 once the daemon/service config split
-     * lands — these are daemon concerns, not memory-core concerns.
-     * @type {Object}
-     */
-    conceptDiscovery: {
-        prScanLimit    : 20,
-        minSourceLength: 200
-    },
-    /**
-     * Universal JSONL backup/export directory for all databases.
-     * @type {string}
-     */
-    backupPath: path.resolve(cwd, '.neo-ai-data/backups'),
-    /**
-     * Phase 4 (#11663): bundle retention policy for `ai/scripts/maintenance/backup.mjs`.
-     * Bundles older than `maxDays` are eligible for deletion, but the newest
-     * `keepMinimum` bundles are retained unconditionally regardless of age.
-     * Defaults match the pre-#11663 hardcoded behavior (`K=3, N_DAYS=30`) so
-     * existing deployments are unaffected without operator action.
-     * @type {{keepMinimum: number, maxDays: number}}
-     */
-    backupRetention: {
-        keepMinimum: 3,
-        maxDays    : 30
-    },
-    /**
-     * Directory for the always-on Memory Core diagnostic log files (#10582). The MC
-     * server's `logger.mjs` writes daily-rotated entries here regardless of `debug`,
-     * so long-running operations (summarization, ingestion sweeps, ChromaDB
-     * lifecycle) leave a tail-able diagnostic trail observable from the host shell.
-     * Default: `<neoRootDir>/.neo-ai-data/logs/` — shared with the KB and Neural
-     * Link servers (each uses a distinct filename prefix: `mc-server-`, `kb-server-`,
-     * `nl-server-`). Per-server file isolation, single tailable directory.
-     * @type {string}
-     */
-    logPath: path.resolve(cwd, '.neo-ai-data/logs'),
-    /**
-     * @summary Shared MCP logger policy for Memory Core.
-     *
-     * Always-on file sink plus debug-gated stderr. `flush: true` preserves the
-     * short-lived script contract used by Sandman and other immediate-exit paths.
-     * @type {Object}
-     */
-    logger: {
-        filePrefix    : 'mc-server',
-        fileSink      : true,
-        flush         : true,
-        stderrMode    : 'debug',
-        timestampStyle: 'plain'
-    },
-    /**
-     * Mailbox substrate behavior configuration (#10252).
-     *
-     * Deployment-tier selectors for the A2A mailbox service. The A2A primitives
-     * themselves (Message nodes, SENT_BY / SENT_TO edges, CAN_REPLY_TO permission
-     * edges, PermissionService.grantPermission / revokePermission / listPermissions)
-     * remain unconditionally live regardless of these selectors — this block only
-     * tunes default enforcement policy to match deployment reality.
-     *
-     * @type {Object}
-     */
-    mailbox: {
-        /**
-         * Default reply policy for non-broadcast DMs. Controls whether `addMessage`
-         * to a specific AgentIdentity target requires a prior `CAN_REPLY_TO` grant
-         * or reachable-counterparty trust-lift (#10146 strict-isolation default),
-         * or accepts any authenticated sender as a peer.
-         *
-         * - `'blocked'` — strict-isolation default policy from #10146. Suited for
-         *   multi-user / multi-tenant Memory Core deployments and mixed-trust-tier
-         *   installations where cross-tenant boundaries must be enforced at the
-         *   substrate. Cross-tenant reach requires explicit `CAN_REPLY_TO` grants.
-         *   Reachable-counterparty trust-lift (#10179) relaxes the bootstrap once
-         *   any broadcast or direct message has flowed between the pair.
-         *
-         * - `'open'` — peer-trust mode. Suited for homogeneous trusted-frontier
-         *   swarms where every authenticated identity is a peer owned by the same
-         *   operator (e.g. local development with Claude + Gemini + future frontier
-         *   models). Eliminates the first-message bootstrap tax. `CAN_REPLY_TO`
-         *   edges still queryable via `grant_permission` / `list_permissions`;
-         *   enforcement simply skips the check.
-         *
-         * Does NOT weaken read-path scoping — `CAN_READ_INBOX_OF`,
-         * `CAN_READ_MEMORIES_OF`, `CAN_READ_SESSIONS_OF` remain strict regardless
-         * of this setting. Reading someone's inbox is categorically different
-         * from sending them a message; asymmetric treatment is intentional.
-         *
-         * Library default is `'open'`; multi-user / multi-tenant deployments
-         * override to `'blocked'` in their `config.mjs` as part of installation,
-         * or via the `NEO_MAILBOX_DEFAULT_REPLY_POLICY` environment variable.
-         *
-         * @type {'blocked'|'open'}
-         */
-        defaultReplyPolicy: 'open'
-    },
-    /**
-     * Memory sharing policy for multi-tenant isolation (#10010).
-     *
-     * Defines the retrieval scope for query_raw_memories and query_summaries:
-     * - 'private': strict tenant isolation. Only caller's owned rows.
-     * - 'team': team-wide context sharing for tagged records.
-     * - 'legacy': migration-window compatibility for pre-tenant-aware data.
-     *
-     * Invalid environment variables (NEO_MEMORY_SHARING_DEFAULT_POLICY) will
-     * fail loudly on boot rather than silently weakening isolation.
-     *
-     * @type {Object}
-     */
-    memorySharing: {
-        /**
-         * @type {'legacy'|'private'|'team'}
-         */
-        defaultPolicy: 'legacy'
-    },
-    /**
-     * Target file path for the lazy backfill queue of unresolved provenance edges.
-     * @type {string}
-     */
-    lazyEdgesQueuePath: path.resolve(cwd, 'ai/data/memory-core/lazy-edges.jsonl')
-};
-
-/**
- * Single source of truth for environment variable overrides.
- * Maps nested configuration paths to environment variables and parser functions.
- */
-const envBindings = {
-    autoSummarize        : { var: 'NEO_AUTO_SUMMARIZE', parse: Env.parseBool},
-    autoStartDatabase    : { var: 'NEO_MEM_AUTO_START_DATABASE', parse: Env.parseBool},
-    autoStartInference   : { var: 'NEO_MEM_AUTO_START_INFERENCE', parse: Env.parseBool},
-    autoDream            : { var: 'NEO_AUTO_DREAM', parse: Env.parseBool},
-    autoGoldenPath       : { var: 'NEO_AUTO_GOLDEN_PATH', parse: Env.parseBool},
-    realTimeMemoryParsing: { var: 'NEO_REAL_TIME_MEMORY_PARSING', parse: Env.parseBool},
-    autoIngestFileSystem : { var: 'NEO_AUTO_INGEST_FS', parse: Env.parseBool},
-    debug                : { var: 'NEO_DEBUG', parse: Env.parseBool},
-    transport            : 'NEO_TRANSPORT',
-    mcpHttpPort          : { var: 'MCP_HTTP_PORT', parse: Env.parsePort},
-    publicUrl            : { var: 'NEO_PUBLIC_URL', parse: Env.parseUrl},
-    auth                 : {
-        host              : 'NEO_AUTH_HOST',
-        port              : { var: 'NEO_AUTH_PORT', parse: Env.parsePort},
-        realm             : 'NEO_AUTH_REALM',
-        issuerUrl         : 'NEO_AUTH_ISSUER_URL',
-        clientId          : 'NEO_OAUTH_CLIENT_ID',
-        clientSecret      : 'NEO_OAUTH_CLIENT_SECRET',
-        trustProxyIdentity: { var: 'NEO_AUTH_TRUST_PROXY_IDENTITY', parse: Env.parseBool}
-    },
-    modelProvider     : 'NEO_MODEL_PROVIDER',
-    embeddingProvider : 'NEO_EMBEDDING_PROVIDER',
-    ollama            : {
-        host          : 'NEO_OLLAMA_HOST',
-        model         : 'NEO_OLLAMA_MODEL',
-        embeddingModel: 'NEO_OLLAMA_EMBEDDING_MODEL'
-    },
-    openAiCompatible: {
-        host              : 'NEO_OPENAI_COMPATIBLE_HOST',
-        model             : 'NEO_OPENAI_COMPATIBLE_MODEL',
-        embeddingModel    : 'NEO_OPENAI_COMPATIBLE_EMBEDDING_MODEL',
-        apiKey            : 'NEO_OPENAI_COMPATIBLE_API_KEY',
-        unloadRetryCount  : { var: 'NEO_OPENAI_COMPATIBLE_UNLOAD_RETRY_COUNT', parse: Env.parseNumber},
-        unloadRetryDelayMs: { var: 'NEO_OPENAI_COMPATIBLE_UNLOAD_RETRY_DELAY_MS', parse: Env.parseNumber}
-    },
-    vectorDimension: { var: 'NEO_VECTOR_DIMENSION', parse: Env.parseNumber},
-    engines        : {
-        chroma: {
-            host: 'NEO_CHROMA_HOST',
-            port: { var: 'NEO_CHROMA_PORT', parse: Env.parsePort}
-        }
-    },
-    collections: {
-        memory : 'NEO_MEMORY_COLLECTION_NAME',
-        session: 'NEO_SESSION_COLLECTION_NAME',
-        graph  : 'NEO_GRAPH_COLLECTION_NAME'
-    },
-    storagePaths: {
-        graph: 'NEO_MEMORY_DB_PATH'
-    },
-    datasets: {
-        rlaif: {
-            trajectories: 'NEO_RLAIF_PATH'
-        }
-    },
-    decayFactor            : { var: 'NEO_GRAPH_DECAY_FACTOR', parse: Env.parseNumber},
-    guideGapWeightThreshold: { var: 'NEO_GUIDE_GAP_WEIGHT_THRESHOLD', parse: Env.parseNumber},
-    conceptDiscovery       : {
-        prScanLimit    : { var: 'NEO_CONCEPT_DISCOVERY_PR_SCAN_LIMIT', parse: Env.parseNumber},
-        minSourceLength: { var: 'NEO_CONCEPT_DISCOVERY_MIN_SOURCE_LENGTH', parse: Env.parseNumber}
-    },
-    mailbox: {
-        defaultReplyPolicy: 'NEO_MAILBOX_DEFAULT_REPLY_POLICY'
-    },
-    memorySharing: {
-        defaultPolicy: { var: 'NEO_MEMORY_SHARING_DEFAULT_POLICY', parse: parseMemorySharingPolicy }
-    },
-    lazyEdgesQueuePath: 'NEO_LAZY_EDGES_QUEUE_PATH'
-};
-
-/**
  * @summary Configuration manager for the Memory Core MCP server.
  *
  * Supports loading configuration from a custom file and merging with defaults.
@@ -491,6 +29,468 @@ const envBindings = {
  * @singleton
  */
 class Config extends BaseConfig {
+    /**
+     * Default configuration object.
+     * Defines the structure and default values for the server configuration.
+     */
+    static defaultConfig = {
+        /**
+         * Repo root, computed from this module's path. Exported for symmetry with the
+         * KB and Neural Link configs (#10584) so consumers (loggers, services, future)
+         * can read `aiConfig.neoRootDir` rather than recomputing the 4-level traversal
+         * locally. Module path is stable; the resolution is deterministic at boot.
+         * @type {string}
+         */
+        neoRootDir,
+        /**
+         * Automatically trigger session summarization on startup.
+         * @type {boolean}
+         */
+        autoSummarize: false,
+        /**
+         * Automatically start the local database process (Chroma/SQLite) on startup.
+         * @type {boolean}
+         */
+        autoStartDatabase: false,
+        /**
+         * Automatically start the local inference server on startup.
+         * @type {boolean}
+         */
+        autoStartInference: false,
+        /**
+         * Automatically trigger GraphRAG extraction on startup.
+         * @type {boolean}
+         */
+        autoDream: false,
+        /**
+         * @deprecated since PR #11101. Golden Path synthesis is now dynamically event-driven
+         * (triggered via MemoryService#mutateFrontier) rather than bound to MCP boot sequence.
+         * This boot-time flag remains for temporary backwards-compatibility but will be
+         * removed in a future release.
+         *
+         * Automatically trigger Golden Path Synthesis into the handoff file on startup.
+         * Crucial for headless swarm nodes (Mac 2) to physically generate sandman_handoff.md.
+         * @type {boolean}
+         */
+        autoGoldenPath: false,
+        /**
+         * Immediately parse each incoming memory turn (add_memory) for Graph Injection.
+         * @type {boolean}
+         */
+        realTimeMemoryParsing: false,
+        /**
+         * Automatically trigger FileSystem ingestion (Differential Graph Sync) on MCP server startup.
+         * @type {boolean}
+         */
+        autoIngestFileSystem: false,
+        /**
+         * Global debug flag for all MCP servers.
+         * @type {boolean}
+         */
+        debug: false,
+        /**
+         * Transport protocol for the MCP server ('stdio' or 'sse').
+         * @type {string}
+         */
+        transport: 'stdio',
+        /**
+         * Port the MCP server's HTTP/SSE transport listens on (only used when `transport === 'sse'`).
+         *
+         * Operator env var: `MCP_HTTP_PORT`.
+         * @type {number}
+         */
+        mcpHttpPort: 3001,
+        /**
+         * Optional public canonical URL for this MCP server.
+         * When configured, this URL is explicitly used as the resource indicator
+         * for OAuth 2.1 / OIDC audience claims and SSE callback advertising.
+         * Required when deploying behind reverse proxies (Nginx/Caddy) where
+         * the internal host:port bindings do not match the public-facing URL.
+         * Example: 'https://mcp.neo.mjs.com/memory-core'
+         * @type {string|null}
+         */
+        publicUrl: null,
+        /**
+         * Optional Express middleware function for authentication (only used if transport is 'sse').
+         * @type {Function|null}
+         */
+        authMiddleware: null,
+        /**
+         * Authentication configuration for the server (OAuth 2.1 / OIDC).
+         * Only used when transport is 'sse'.
+         * @type {Object}
+         */
+        auth: {
+            host              : AiConfig.auth.host,
+            port              : AiConfig.auth.port,
+            realm             : AiConfig.auth.realm,
+            issuerUrl         : AiConfig.auth.issuerUrl,
+            clientId          : AiConfig.auth.clientId,
+            clientSecret      : AiConfig.auth.clientSecret,
+            trustProxyIdentity: AiConfig.auth.trustProxyIdentity
+        },
+        /**
+         * Explicit override provider for the core LLM Engine (e.g. summarization).
+         * Supported values: 'gemini', 'ollama', 'openAiCompatible'
+         * @type {String}
+         */
+        modelProvider: AiConfig.modelProvider,
+        /**
+         * Canonical embedding provider for Memory Core and Knowledge Base embedding callsites.
+         * Supported values: 'gemini', 'ollama', 'openAiCompatible'
+         * Defaults to the local OpenAI-compatible Qwen3 route so the source tuple matches the
+         * unified 4096-dimension Chroma collection invariant. Gemini remains available as an
+         * explicit operator override and must be paired with `vectorDimension: 3072`.
+         *
+         * @type {String}
+         */
+        embeddingProvider: AiConfig.embeddingProvider,
+        /**
+         * Settings for the Ollama integration
+         */
+        ollama: {
+            host          : AiConfig.ollama.host,
+            model         : AiConfig.ollama.model,
+            embeddingModel: AiConfig.ollama.embeddingModel
+        },
+        /**
+         * Settings for the OpenAI-Compatible API integration (e.g., mlx-lm or mlx-openai-server)
+         * WARNING: Never hardcode API keys here. Always export them via .env or globally.
+         */
+        openAiCompatible: {
+            host                    : AiConfig.openAiCompatible.host,
+            model                   : AiConfig.openAiCompatible.model,
+            embeddingModel          : AiConfig.openAiCompatible.embeddingModel,
+            apiKey                  : AiConfig.openAiCompatible.apiKey,
+            unloadRetryCount        : AiConfig.openAiCompatible.unloadRetryCount,
+            unloadRetryDelayMs      : AiConfig.openAiCompatible.unloadRetryDelayMs,
+            /**
+             * Configured context-window capacity of `model` measured in **tokens**.
+             * Token-based per the Discussion #11444 / #11447 V1 graduation contract.
+             * Used by `ConsumerFrictionHelper.invokeWithGuardrail` to fire the upstream
+             * pre-check skip ("Angle 2") when an LLM input payload exceeds the consumer's
+             * safe processing band. Default is sized for Gemma-3-4B / Qwen3-8B class
+             * consumers (~32K-token context). Operators running models with different
+             * context windows should tune this to match the deployed model — e.g. 8192
+             * for Gemma-4-8B-IT, 131072 for Llama-3.1-70B 128K-context variants.
+             * @type {number}
+             */
+            contextLimitTokens: AiConfig.openAiCompatible.contextLimitTokens,
+            /**
+             * Optional safer processing threshold (tokens) below `contextLimitTokens` for
+             * the upstream pre-check skip. When the estimated input token count exceeds
+             * this value, `invokeWithGuardrail` emits a `size-precheck-skip` friction and
+             * does NOT invoke the consumer model. Defaults to 75% of `contextLimitTokens`
+             * when unset — leaves ~25% headroom for system-prompt envelope, repair-cycle
+             * prompt growth, and output-token reservation per Discussion #11444 Round-2
+             * consensus.
+             * @type {number|undefined}
+             */
+            safeProcessingLimitTokens: AiConfig.openAiCompatible.safeProcessingLimitTokens
+        },
+        /**
+         * The enforced vector dimension across all SQLite collections.
+         * Hard-configured here to prevent catastrophic schema wipes due to dynamic model changes.
+         * @type {number}
+         */
+        vectorDimension: AiConfig.vectorDimension,
+        /**
+         * The name of the Google Generative AI model for content generation.
+         * @type {string}
+         */
+        modelName: AiConfig.modelName,
+        /**
+         * The name of the Google Generative AI model for text embeddings.
+         * @type {string}
+         */
+        embeddingModel: AiConfig.embeddingModel,
+        /**
+         * Pagination limit for fetching records during session summarization scans.
+         * Controls the batch size for memory and summary retrieval.
+         * @type {number}
+         */
+        summarizationBatchLimit: 2000,
+        /**
+         * Maximum number of concurrent session summarization requests.
+         * Prevents hitting LLM/Embedding API rate limits during bulk operations.
+         * @type {number}
+         */
+        summarizationConcurrency: 5,
+        /**
+         * The target Storage Architecture to use.
+         * Note: Chroma is the only supported Vector DB.
+         * Options: 'hybrid' (Chroma vectors + SQLite graph), 'chroma' (Chroma vectors only).
+         * The default is explicitly 'hybrid' per Epic #9922 Two-Pillar RAG architecture.
+         */
+        engine: 'hybrid',
+        /**
+         * Database Engine Definitions
+         * This defines WHERE data is stored physically (for engines MC owns) and WHERE MC reaches
+         * into other services' engines. The flat `engines.chroma` path specifies the unified
+         * ChromaDB instance shared with the Knowledge Base.
+         */
+        engines: {
+            chroma: {
+                dataDir: path.resolve(cwd, '.neo-ai-data/chroma/memory-core'),
+                host   : AiConfig.engines.chroma.host,
+                port   : AiConfig.engines.chroma.port
+            }
+        },
+        /**
+         * Physical file paths for embedded/local datasets.
+         */
+        storagePaths: {
+            graph: process.env.UNIT_TEST_MODE === 'true' ? ':memory:' : path.resolve(cwd, '.neo-ai-data/sqlite/memory-core-graph.sqlite')
+        },
+        /**
+         * Data Schema/Table Names
+         * This defines WHAT the tables/collections are called logically.
+         */
+        collections: {
+            memory : process.env.UNIT_TEST_MODE === 'true' ? `test-memory-${Date.now()}-${Math.random().toString(36).substring(7)}` : 'neo-agent-memory',
+            session: process.env.UNIT_TEST_MODE === 'true' ? `test-session-${Date.now()}-${Math.random().toString(36).substring(7)}` : 'neo-agent-sessions',
+            graph  : 'neo-native-graph'
+        },
+        /**
+         * Datasets Schema/Paths
+         * This defines WHERE autonomous curation exports data.
+         */
+        datasets: {
+            rlaif: {
+                trajectories: path.resolve(cwd, '.neo-ai-data/datasets/rlaif/trajectories.jsonl')
+            }
+        },
+        /**
+         * Target markdown file used for autonomous agent-to-user reporting (offline jobs).
+         * @type {string}
+         */
+        handoffFilePath: path.resolve(cwd, 'resources/content/sandman_handoff.md'),
+        /**
+         * The Hebbian decay factor applied every 24 hours to the edge graph (e.g., 0.98 for ~79 day half-life).
+         * @type {number}
+         */
+        decayFactor: 0.98,
+        /**
+         * Minimum weight threshold for emitting `[GUIDE_GAP]`, `[EXAMPLE_GAP]`, and `[ORPHAN_CONCEPT]`
+         * signals on CONCEPT nodes during `GapInferenceEngine.inferConceptGraphGaps`.
+         *
+         * **Derivation:** `ConceptService.calculateWeight` returns `tier_score + uniqueness + coverage_deficit`
+         * where tier-1 gets `0.8`, tier-2 `0.5`, tier-3 `0.3`; uniqueness adds `0.2`; coverage deficit (no
+         * EXPLAINED_BY) adds `0.3`. The minimum a tier-1 concept can score is `0.8` (covered, non-unique).
+         * Setting threshold = `0.8` means *"at least tier-1 baseline priority"* — every tier-1 concept
+         * without a guide qualifies; tier-2/3 concepts qualify only if uniqueness + deficit push them above.
+         *
+         * Tune up to silence tier-2/3 noise as ontology grows (#10036 / #10037 / #10050); tune down to
+         * surface lower-priority concepts in the handoff.
+         * @type {number}
+         */
+        guideGapWeightThreshold: 0.8,
+        /**
+         * Operator-tuning knobs for `ConceptDiscoveryService` (#10036). Both values are read live
+         * at method-call time (not captured at module load) so tests + runtime overrides are honored.
+         *
+         * - `prScanLimit`: how many pull-request markdown files to process per discovery cycle.
+         *   PRs are sorted descending by PR number so the most-recent (freshest architectural
+         *   discourse) process first. Capping bounds per-cycle LLM cost against the ~300+ PR corpus.
+         * - `minSourceLength`: minimum source text length (chars) to trigger an LLM extraction call.
+         *   Short bodies aren't worth the provider round-trip; 200 ≈ 30 words of coherent prose.
+         *
+         * Expected to migrate to SDK-layer config per #10103 once the daemon/service config split
+         * lands — these are daemon concerns, not memory-core concerns.
+         * @type {Object}
+         */
+        conceptDiscovery: {
+            prScanLimit    : 20,
+            minSourceLength: 200
+        },
+        /**
+         * Universal JSONL backup/export directory for all databases.
+         * @type {string}
+         */
+        backupPath: AiConfig.backupPath,
+        /**
+         * Phase 4 (#11663): bundle retention policy for `ai/scripts/maintenance/backup.mjs`.
+         * Bundles older than `maxDays` are eligible for deletion, but the newest
+         * `keepMinimum` bundles are retained unconditionally regardless of age.
+         * Defaults match the pre-#11663 hardcoded behavior (`K=3, N_DAYS=30`) so
+         * existing deployments are unaffected without operator action.
+         * @type {{keepMinimum: number, maxDays: number}}
+         */
+        backupRetention: {
+            keepMinimum: 3,
+            maxDays    : 30
+        },
+        /**
+         * Directory for the always-on Memory Core diagnostic log files (#10582). The MC
+         * server's `logger.mjs` writes daily-rotated entries here regardless of `debug`,
+         * so long-running operations (summarization, ingestion sweeps, ChromaDB
+         * lifecycle) leave a tail-able diagnostic trail observable from the host shell.
+         * Default: `<neoRootDir>/.neo-ai-data/logs/` — shared with the KB and Neural
+         * Link servers (each uses a distinct filename prefix: `mc-server-`, `kb-server-`,
+         * `nl-server-`). Per-server file isolation, single tailable directory.
+         * @type {string}
+         */
+        logPath: path.resolve(cwd, '.neo-ai-data/logs'),
+        /**
+         * @summary Shared MCP logger policy for Memory Core.
+         *
+         * Always-on file sink plus debug-gated stderr. `flush: true` preserves the
+         * short-lived script contract used by Sandman and other immediate-exit paths.
+         * @type {Object}
+         */
+        logger: {
+            filePrefix    : 'mc-server',
+            fileSink      : true,
+            flush         : true,
+            stderrMode    : 'debug',
+            timestampStyle: 'plain'
+        },
+        /**
+         * Mailbox substrate behavior configuration (#10252).
+         *
+         * Deployment-tier selectors for the A2A mailbox service. The A2A primitives
+         * themselves (Message nodes, SENT_BY / SENT_TO edges, CAN_REPLY_TO permission
+         * edges, PermissionService.grantPermission / revokePermission / listPermissions)
+         * remain unconditionally live regardless of these selectors — this block only
+         * tunes default enforcement policy to match deployment reality.
+         *
+         * @type {Object}
+         */
+        mailbox: {
+            /**
+             * Default reply policy for non-broadcast DMs. Controls whether `addMessage`
+             * to a specific AgentIdentity target requires a prior `CAN_REPLY_TO` grant
+             * or reachable-counterparty trust-lift (#10146 strict-isolation default),
+             * or accepts any authenticated sender as a peer.
+             *
+             * - `'blocked'` — strict-isolation default policy from #10146. Suited for
+             *   multi-user / multi-tenant Memory Core deployments and mixed-trust-tier
+             *   installations where cross-tenant boundaries must be enforced at the
+             *   substrate. Cross-tenant reach requires explicit `CAN_REPLY_TO` grants.
+             *   Reachable-counterparty trust-lift (#10179) relaxes the bootstrap once
+             *   any broadcast or direct message has flowed between the pair.
+             *
+             * - `'open'` — peer-trust mode. Suited for homogeneous trusted-frontier
+             *   swarms where every authenticated identity is a peer owned by the same
+             *   operator (e.g. local development with Claude + Gemini + future frontier
+             *   models). Eliminates the first-message bootstrap tax. `CAN_REPLY_TO`
+             *   edges still queryable via `grant_permission` / `list_permissions`;
+             *   enforcement simply skips the check.
+             *
+             * Does NOT weaken read-path scoping — `CAN_READ_INBOX_OF`,
+             * `CAN_READ_MEMORIES_OF`, `CAN_READ_SESSIONS_OF` remain strict regardless
+             * of this setting. Reading someone's inbox is categorically different
+             * from sending them a message; asymmetric treatment is intentional.
+             *
+             * Library default is `'open'`; multi-user / multi-tenant deployments
+             * override to `'blocked'` in their `config.mjs` as part of installation,
+             * or via the `NEO_MAILBOX_DEFAULT_REPLY_POLICY` environment variable.
+             *
+             * @type {'blocked'|'open'}
+             */
+            defaultReplyPolicy: 'open'
+        },
+        /**
+         * Memory sharing policy for multi-tenant isolation (#10010).
+         *
+         * Defines the retrieval scope for query_raw_memories and query_summaries:
+         * - 'private': strict tenant isolation. Only caller's owned rows.
+         * - 'team': team-wide context sharing for tagged records.
+         * - 'legacy': migration-window compatibility for pre-tenant-aware data.
+         *
+         * Invalid environment variables (NEO_MEMORY_SHARING_DEFAULT_POLICY) will
+         * fail loudly on boot rather than silently weakening isolation.
+         *
+         * @type {Object}
+         */
+        memorySharing: {
+            /**
+             * @type {'legacy'|'private'|'team'}
+             */
+            defaultPolicy: 'legacy'
+        },
+        /**
+         * Target file path for the lazy backfill queue of unresolved provenance edges.
+         * @type {string}
+         */
+        lazyEdgesQueuePath: path.resolve(cwd, 'ai/data/memory-core/lazy-edges.jsonl')
+    };
+
+    /**
+     * Single source of truth for environment variable overrides.
+     * Maps nested configuration paths to environment variables and parser functions.
+     */
+    static envBindings = {
+        autoSummarize        : { var: 'NEO_AUTO_SUMMARIZE', parse: Env.parseBool},
+        autoStartDatabase    : { var: 'NEO_MEM_AUTO_START_DATABASE', parse: Env.parseBool},
+        autoStartInference   : { var: 'NEO_MEM_AUTO_START_INFERENCE', parse: Env.parseBool},
+        autoDream            : { var: 'NEO_AUTO_DREAM', parse: Env.parseBool},
+        autoGoldenPath       : { var: 'NEO_AUTO_GOLDEN_PATH', parse: Env.parseBool},
+        realTimeMemoryParsing: { var: 'NEO_REAL_TIME_MEMORY_PARSING', parse: Env.parseBool},
+        autoIngestFileSystem : { var: 'NEO_AUTO_INGEST_FS', parse: Env.parseBool},
+        debug                : { var: 'NEO_DEBUG', parse: Env.parseBool},
+        transport            : 'NEO_TRANSPORT',
+        mcpHttpPort          : { var: 'MCP_HTTP_PORT', parse: Env.parsePort},
+        publicUrl            : { var: 'NEO_PUBLIC_URL', parse: Env.parseUrl},
+        auth                 : {
+            host              : 'NEO_AUTH_HOST',
+            port              : { var: 'NEO_AUTH_PORT', parse: Env.parsePort},
+            realm             : 'NEO_AUTH_REALM',
+            issuerUrl         : 'NEO_AUTH_ISSUER_URL',
+            clientId          : 'NEO_OAUTH_CLIENT_ID',
+            clientSecret      : 'NEO_OAUTH_CLIENT_SECRET',
+            trustProxyIdentity: { var: 'NEO_AUTH_TRUST_PROXY_IDENTITY', parse: Env.parseBool}
+        },
+        modelProvider     : 'NEO_MODEL_PROVIDER',
+        embeddingProvider : 'NEO_EMBEDDING_PROVIDER',
+        ollama            : {
+            host          : 'NEO_OLLAMA_HOST',
+            model         : 'NEO_OLLAMA_MODEL',
+            embeddingModel: 'NEO_OLLAMA_EMBEDDING_MODEL'
+        },
+        openAiCompatible: {
+            host              : 'NEO_OPENAI_COMPATIBLE_HOST',
+            model             : 'NEO_OPENAI_COMPATIBLE_MODEL',
+            embeddingModel    : 'NEO_OPENAI_COMPATIBLE_EMBEDDING_MODEL',
+            apiKey            : 'NEO_OPENAI_COMPATIBLE_API_KEY',
+            unloadRetryCount  : { var: 'NEO_OPENAI_COMPATIBLE_UNLOAD_RETRY_COUNT', parse: Env.parseNumber},
+            unloadRetryDelayMs: { var: 'NEO_OPENAI_COMPATIBLE_UNLOAD_RETRY_DELAY_MS', parse: Env.parseNumber}
+        },
+        vectorDimension: { var: 'NEO_VECTOR_DIMENSION', parse: Env.parseNumber},
+        backupPath     : 'NEO_BACKUP_PATH',
+        engines        : {
+            chroma: {
+                host: 'NEO_CHROMA_HOST',
+                port: { var: 'NEO_CHROMA_PORT', parse: Env.parsePort}
+            }
+        },
+        collections: {
+            memory : 'NEO_MEMORY_COLLECTION_NAME',
+            session: 'NEO_SESSION_COLLECTION_NAME',
+            graph  : 'NEO_GRAPH_COLLECTION_NAME'
+        },
+        storagePaths: {
+            graph: 'NEO_MEMORY_DB_PATH'
+        },
+        datasets: {
+            rlaif: {
+                trajectories: 'NEO_RLAIF_PATH'
+            }
+        },
+        decayFactor            : { var: 'NEO_GRAPH_DECAY_FACTOR', parse: Env.parseNumber},
+        guideGapWeightThreshold: { var: 'NEO_GUIDE_GAP_WEIGHT_THRESHOLD', parse: Env.parseNumber},
+        conceptDiscovery       : {
+            prScanLimit    : { var: 'NEO_CONCEPT_DISCOVERY_PR_SCAN_LIMIT', parse: Env.parseNumber},
+            minSourceLength: { var: 'NEO_CONCEPT_DISCOVERY_MIN_SOURCE_LENGTH', parse: Env.parseNumber}
+        },
+        mailbox: {
+            defaultReplyPolicy: 'NEO_MAILBOX_DEFAULT_REPLY_POLICY'
+        },
+        memorySharing: {
+            defaultPolicy: { var: 'NEO_MEMORY_SHARING_DEFAULT_POLICY', parse: parseMemorySharingPolicy }
+        },
+        lazyEdgesQueuePath: 'NEO_LAZY_EDGES_QUEUE_PATH'
+    };
     static config = {
         /**
          * @member {String} className='Neo.ai.mcp.server.memory-core.Config'
@@ -505,11 +505,11 @@ class Config extends BaseConfig {
         /**
          * @member {Object} defaultConfig
          */
-        defaultConfig,
+        defaultConfig: this.defaultConfig,
         /**
          * @member {Object} envBindings
          */
-        envBindings
+        envBindings: this.envBindings
     }
 }
 const instance = Neo.setupClass(Config);

--- a/ai/mcp/server/neural-link/config.template.mjs
+++ b/ai/mcp/server/neural-link/config.template.mjs
@@ -9,83 +9,7 @@ const __dirname  = path.dirname(__filename);
 const neoRootDir = path.resolve(__dirname, '../../../../');
 const cwd        = process.cwd();
 
-/**
- * Default configuration object.
- */
 
-const envBindings = {
-    'autoConnect': { var: 'NEO_NL_AUTO_CONNECT', parse: Env.parseBool },
-    'debug': { var: 'NEO_DEBUG', parse: Env.parseBool },
-    'port': { var: 'NEO_NL_PORT', parse: Env.parsePort },
-    'rpcTimeout': { var: 'NEO_NL_RPC_TIMEOUT', parse: Env.parseNumber },
-    'memoryCoreDbPath': 'NEO_MEMORY_DB_PATH',
-    'pruneLogsAfterDays': { var: 'NEO_NL_PRUNE_LOGS_AFTER_DAYS', parse: Env.parseNumber }
-};
-
-const defaultConfig = {
-    /**
-     * Repo root, computed from this module's path. Exported for symmetry with the
-     * KB and Memory Core configs (#10584) so consumers (loggers, services, future)
-     * can read `aiConfig.neoRootDir` rather than recomputing the 4-level traversal
-     * locally. Module path is stable; the resolution is deterministic at boot.
-     * @type {string}
-     */
-    neoRootDir,
-    /**
-     * Automatically connect to the bridge on startup.
-     * @type {boolean}
-     */
-    autoConnect: true,
-    /**
-     * Global debug flag.
-     * @type {boolean}
-     */
-    debug: false,
-    /**
-     * The port the WebSocket server is listening on.
-     * @type {number}
-     */
-    port: 8081,
-    /**
-     * Timeout for RPC calls in milliseconds.
-     * @type {number}
-     */
-    rpcTimeout: 10000,
-    /**
-     * Path to the memory core SQLite database for action logging.
-     * @type {string}
-     */
-    memoryCoreDbPath: path.join(os.homedir(), '.neo-ai-data', 'memory-core.sqlite'),
-    /**
-     * Directory for the always-on Neural Link diagnostic log files (#10582). The NL
-     * server's `logger.mjs` writes daily-rotated entries here regardless of `debug`,
-     * so long-running inspection chains and DOM/VDOM introspection sweeps leave a
-     * tail-able diagnostic trail observable from the host shell. Default:
-     * `<neoRootDir>/.neo-ai-data/logs/` — shared with the KB and Memory Core servers
-     * (each uses a distinct filename prefix: `nl-server-`, `kb-server-`, `mc-server-`).
-     * Per-server file isolation, single tailable directory.
-     * @type {string}
-     */
-    logPath: path.resolve(neoRootDir, '.neo-ai-data/logs'),
-    /**
-     * @summary Shared MCP logger policy for Neural Link.
-     *
-     * Always-on file sink plus tier-gated stderr: info/warn/error write without
-     * debug, while debug stays gated by `debug: true`.
-     * @type {Object}
-     */
-    logger: {
-        filePrefix    : 'nl-server',
-        fileSink      : true,
-        stderrMode    : 'tiered',
-        timestampStyle: 'bracketed'
-    },
-    /**
-     * Number of days to retain Action logs in the Neural Link Database.
-     * @type {number}
-     */
-    pruneLogsAfterDays: 14
-};
 
 /**
  * @summary Configuration manager for the Neural Link MCP server.
@@ -97,6 +21,82 @@ const defaultConfig = {
  * @singleton
  */
 class Config extends BaseConfig {
+    static defaultConfig = {
+        /**
+         * Repo root, computed from this module's path. Exported for symmetry with the
+         * KB and Memory Core configs (#10584) so consumers (loggers, services, future)
+         * can read `aiConfig.neoRootDir` rather than recomputing the 4-level traversal
+         * locally. Module path is stable; the resolution is deterministic at boot.
+         * @type {string}
+         */
+        neoRootDir,
+        /**
+         * Automatically connect to the bridge on startup.
+         * @type {boolean}
+         */
+        autoConnect: true,
+        /**
+         * Global debug flag.
+         * @type {boolean}
+         */
+        debug: false,
+        /**
+         * The port the WebSocket server is listening on.
+         * @type {number}
+         */
+        port: 8081,
+        /**
+         * Timeout for RPC calls in milliseconds.
+         * @type {number}
+         */
+        rpcTimeout: 10000,
+        /**
+         * Path to the memory core SQLite database for action logging.
+         * @type {string}
+         */
+        memoryCoreDbPath: path.join(os.homedir(), '.neo-ai-data', 'memory-core.sqlite'),
+        /**
+         * Directory for the always-on Neural Link diagnostic log files (#10582). The NL
+         * server's `logger.mjs` writes daily-rotated entries here regardless of `debug`,
+         * so long-running inspection chains and DOM/VDOM introspection sweeps leave a
+         * tail-able diagnostic trail observable from the host shell. Default:
+         * `<neoRootDir>/.neo-ai-data/logs/` — shared with the KB and Memory Core servers
+         * (each uses a distinct filename prefix: `nl-server-`, `kb-server-`, `mc-server-`).
+         * Per-server file isolation, single tailable directory.
+         * @type {string}
+         */
+        logPath: path.resolve(neoRootDir, '.neo-ai-data/logs'),
+        /**
+         * @summary Shared MCP logger policy for Neural Link.
+         *
+         * Always-on file sink plus tier-gated stderr: info/warn/error write without
+         * debug, while debug stays gated by `debug: true`.
+         * @type {Object}
+         */
+        logger: {
+            filePrefix    : 'nl-server',
+            fileSink      : true,
+            stderrMode    : 'tiered',
+            timestampStyle: 'bracketed'
+        },
+        /**
+         * Number of days to retain Action logs in the Neural Link Database.
+         * @type {number}
+         */
+        pruneLogsAfterDays: 14
+    };
+
+    /**
+     * Environment-variable ledger for Neural Link server config.
+     */
+    static envBindings = {
+        'autoConnect': { var: 'NEO_NL_AUTO_CONNECT', parse: Env.parseBool },
+        'debug': { var: 'NEO_DEBUG', parse: Env.parseBool },
+        'port': { var: 'NEO_NL_PORT', parse: Env.parsePort },
+        'rpcTimeout': { var: 'NEO_NL_RPC_TIMEOUT', parse: Env.parseNumber },
+        'memoryCoreDbPath': 'NEO_MEMORY_DB_PATH',
+        'pruneLogsAfterDays': { var: 'NEO_NL_PRUNE_LOGS_AFTER_DAYS', parse: Env.parseNumber }
+    };
     static config = {
         /**
          * @member {String} className='Neo.ai.mcp.server.neural-link.Config'
@@ -111,11 +111,11 @@ class Config extends BaseConfig {
         /**
          * @member {Object} defaultConfig
          */
-        defaultConfig,
+        defaultConfig: this.defaultConfig,
         /**
          * @member {Object} envBindings
          */
-        envBindings
+        envBindings: this.envBindings
     }
 }
 const instance = Neo.setupClass(Config);

--- a/test/playwright/fixtures/aiConfigDefaults.mjs
+++ b/test/playwright/fixtures/aiConfigDefaults.mjs
@@ -1,7 +1,12 @@
-import Neo      from '../../../src/Neo.mjs';
+import path            from 'path';
+import {fileURLToPath} from 'url';
+import Neo             from '../../../src/Neo.mjs';
 
 const HOUR_MS = 60 * 60 * 1000;
 const DAY_MS  = 24 * HOUR_MS;
+const __filename = fileURLToPath(import.meta.url);
+const __dirname  = path.dirname(__filename);
+const neoRootDir = path.resolve(__dirname, '../../..');
 
 /**
  * @module test/playwright/fixtures/aiConfigDefaults
@@ -65,6 +70,7 @@ function deepFreeze(value) {
  * @type {Readonly<Object>}
  */
 export const TIER1_DEFAULTS = deepFreeze(Neo.clone({
+    backupPath: process.env.NEO_BACKUP_PATH || path.resolve(neoRootDir, '.neo-ai-data/backups'),
     auth: {
         host              : process.env.NEO_AUTH_HOST || null,
         port              : Number(process.env.NEO_AUTH_PORT) || 8080,

--- a/test/playwright/unit/ai/config.template.spec.mjs
+++ b/test/playwright/unit/ai/config.template.spec.mjs
@@ -1,6 +1,8 @@
 import { test, expect } from '@playwright/test';
+import fs from 'fs/promises';
 import Neo from '../../../../src/Neo.mjs';
 import '../../../../src/core/_export.mjs';
+import {TIER1_DEFAULTS} from '../../fixtures/aiConfigDefaults.mjs';
 
 test.describe('Tier 1 Config Immutability', () => {
     let Config;
@@ -59,6 +61,7 @@ test.describe('Tier 1 Config Immutability', () => {
         expect(Config.modelProvider).toBe(Config.chatProvider);
         expect(Config.embeddingProvider).toBe(process.env.NEO_EMBEDDING_PROVIDER || 'openAiCompatible');
         expect(Config.vectorDimension).toBe(Number(process.env.NEO_VECTOR_DIMENSION) || 4096);
+        expect(Config.backupPath).toBe(TIER1_DEFAULTS.backupPath);
         expect(Config.modelName).toBe('gemini-2.5-flash');
         expect(Config.embeddingModel).toBe('gemini-embedding-001');
 
@@ -118,5 +121,24 @@ test.describe('Tier 1 Config Immutability', () => {
                 maxDays    : 7
             }
         });
+    });
+
+    test('keeps config ledgers inside config classes', async () => {
+        const templateUrls = [
+            '../../../../ai/config.template.mjs',
+            '../../../../ai/mcp/server/github-workflow/config.template.mjs',
+            '../../../../ai/mcp/server/gitlab-workflow/config.template.mjs',
+            '../../../../ai/mcp/server/knowledge-base/config.template.mjs',
+            '../../../../ai/mcp/server/memory-core/config.template.mjs',
+            '../../../../ai/mcp/server/neural-link/config.template.mjs'
+        ];
+
+        for (const templateUrl of templateUrls) {
+            const source = await fs.readFile(new URL(templateUrl, import.meta.url), 'utf8');
+
+            expect(source).not.toMatch(/^const\s+(defaultConfig|envBindings)\s*=/m);
+            expect(source).toMatch(/static\s+defaultConfig\s*=/);
+            expect(source).toMatch(/static\s+envBindings\s*=/);
+        }
     });
 });

--- a/test/playwright/unit/ai/mcp/server/knowledge-base/config.template.spec.mjs
+++ b/test/playwright/unit/ai/mcp/server/knowledge-base/config.template.spec.mjs
@@ -75,6 +75,7 @@ test.describe('Knowledge Base Config Tier-1 defaults (#11963)', () => {
 
     test('maps deployment-wide Tier-1 auth and unified Chroma defaults', () => {
         expect(config.auth).toEqual(TIER1_DEFAULTS.auth);
+        expect(config.backupPath).toBe(TIER1_DEFAULTS.backupPath);
         expect(config.host).toBe(TIER1_DEFAULTS.engines.chroma.host);
         expect(config.port).toBe(TIER1_DEFAULTS.engines.chroma.port);
 
@@ -84,6 +85,7 @@ test.describe('Knowledge Base Config Tier-1 defaults (#11963)', () => {
 
     test('env overrides remain final after Tier-1 default mapping', () => {
         process.env.NEO_AUTH_REALM = 'tenant-realm';
+        process.env.NEO_BACKUP_PATH = '/tmp/neo-kb-backups';
         process.env.NEO_CHROMA_HOST = 'chroma';
         process.env.NEO_CHROMA_PORT = '8010';
 
@@ -91,6 +93,7 @@ test.describe('Knowledge Base Config Tier-1 defaults (#11963)', () => {
         config.applyEnv();
 
         expect(config.auth.realm).toBe('tenant-realm');
+        expect(config.backupPath).toBe('/tmp/neo-kb-backups');
         expect(config.host).toBe('chroma');
         expect(config.port).toBe(8010);
     });

--- a/test/playwright/unit/ai/mcp/server/memory-core/config.template.spec.mjs
+++ b/test/playwright/unit/ai/mcp/server/memory-core/config.template.spec.mjs
@@ -89,6 +89,7 @@ test.describe('Memory Core Config (#10010)', () => {
         expect(config.ollama).toEqual(TIER1_DEFAULTS.ollama);
         expect(config.openAiCompatible).toEqual(TIER1_DEFAULTS.openAiCompatible);
         expect(config.vectorDimension).toBe(TIER1_DEFAULTS.vectorDimension);
+        expect(config.backupPath).toBe(TIER1_DEFAULTS.backupPath);
         expect(config.modelName).toBe(TIER1_DEFAULTS.modelName);
         expect(config.embeddingModel).toBe(TIER1_DEFAULTS.embeddingModel);
 
@@ -104,6 +105,7 @@ test.describe('Memory Core Config (#10010)', () => {
         process.env.NEO_MODEL_PROVIDER = 'openAiCompatible';
         process.env.NEO_EMBEDDING_PROVIDER = 'ollama';
         process.env.NEO_AUTH_REALM = 'tenant-realm';
+        process.env.NEO_BACKUP_PATH = '/tmp/neo-memory-backups';
         process.env.NEO_CHROMA_HOST = 'chroma';
         process.env.NEO_CHROMA_PORT = '8010';
 
@@ -113,6 +115,7 @@ test.describe('Memory Core Config (#10010)', () => {
         expect(config.modelProvider).toBe('openAiCompatible');
         expect(config.embeddingProvider).toBe('ollama');
         expect(config.auth.realm).toBe('tenant-realm');
+        expect(config.backupPath).toBe('/tmp/neo-memory-backups');
         expect(config.engines.chroma).toMatchObject({
             host: 'chroma',
             port: 8010


### PR DESCRIPTION
Related: #10103

Authored by GPT-5 (Codex Desktop). Session 3b454ac4-f2c6-4bf0-9c18-c0af6f432ffa.
FAIR-band: in-band [16/30]

Moves the remaining Agent OS config template ledgers into the Neo config classes themselves. `defaultConfig` and `envBindings` are now class-owned static fields across Tier-1 and MCP server templates, with `static config` referencing those class fields instead of module-scope constants. This keeps the already-delivered BaseConfig substrate shape while removing the last module-scope ledger pattern from the active templates.

Evidence: L2 (template import smoke + focused unit suite) -> L2 required (config substrate shape and env parser contract). No residuals for this cut.

## Deltas from ticket

This PR implements the narrowed current-state scope from the refreshed #10103 body, not the stale original three-sub rollout. It also folds in the still-live `backupPath` asymmetry: Tier-1 now owns the shared backup default, and Knowledge Base / Memory Core inherit it symmetrically while preserving `NEO_BACKUP_PATH` as the final env override.

## Config Template Sync

Changed config surfaces:
- Tier-1 `ai/config.template.mjs`: `defaultConfig` / `envBindings` moved into `Neo.ai.Config`; added `backupPath` + `NEO_BACKUP_PATH`.
- MCP server templates: `defaultConfig` / `envBindings` moved into each `Config` class for GitHub Workflow, GitLab Workflow, Knowledge Base, Memory Core, and Neural Link.
- Knowledge Base + Memory Core: `backupPath` now maps from Tier-1 and honors `NEO_BACKUP_PATH`.

Local `config.mjs` follow-up after merge: required for active clones. Run `node ai/scripts/setup/initServerConfigs.mjs --migrate-config` or `npm run prepare -- --migrate-config` to refresh ignored `ai/config.mjs` and `ai/mcp/server/*/config.mjs` overlays from the tracked templates. No ignored `config.mjs` file is committed here.

Harness restart: recommended for live MCP servers and the orchestrator because config singletons are initialized at module load.

## Test Evidence

- `node ai/scripts/setup/initServerConfigs.mjs --migrate-config` -> PASS locally; ignored overlays refreshed, not committed.
- `node --input-type=module -e "await import('./src/Neo.mjs'); await import('./src/core/_export.mjs'); await import('./ai/config.template.mjs'); await import('./ai/mcp/server/knowledge-base/config.template.mjs'); await import('./ai/mcp/server/memory-core/config.template.mjs'); await import('./ai/mcp/server/github-workflow/config.template.mjs'); await import('./ai/mcp/server/gitlab-workflow/config.template.mjs'); await import('./ai/mcp/server/neural-link/config.template.mjs'); console.log('template imports ok');"` -> PASS
- `npm run test-unit -- test/playwright/unit/util/Env.spec.mjs test/playwright/unit/ai/config.template.spec.mjs test/playwright/unit/ai/mcp/server/knowledge-base/config.template.spec.mjs test/playwright/unit/ai/mcp/server/memory-core/config.template.spec.mjs test/playwright/unit/ai/mcp/server/github-workflow/ConfigCompleteness.spec.mjs test/playwright/unit/test/fixtures/aiConfigDefaults.spec.mjs` -> 46/46 PASS
- `git diff --check origin/dev...HEAD` -> PASS
- `rg -n "^const\\s+(defaultConfig|envBindings)\\s*=" ai/config.template.mjs ai/mcp/server/*/config.template.mjs` -> no matches

## Post-Merge Validation

- [ ] Active agent clones refresh ignored config overlays from templates.
- [ ] Live MCP/orchestrator processes restart after overlay refresh.
- [ ] Confirm #10103 remaining scope after this PR: the module-scope ledger and backupPath rows should be complete; any remaining closure decision should use an epic-resolution pass, not an auto-close keyword.

## Commits

- `f4a73c5cb` — `feat(ai): move config ledgers into class substrate (#10103)`
