### PR TITLE
feat(orchestrator): WakeDecisionService 3-signal + readiness parser + backoff (#11995)

### DIFF
--- a/ai/daemons/orchestrator/services/WakeDecisionService.mjs
+++ b/ai/daemons/orchestrator/services/WakeDecisionService.mjs
@@ -1,0 +1,391 @@
+import fs   from 'fs-extra';
+import path from 'path';
+import Base from '../../../../src/core/Base.mjs';
+
+/**
+ * Default activity window (3h) within which any sent-or-received A2A keeps the
+ * identity in the `active` set. See Epic #11993 — substrate cannot depend on
+ * session-boundary signals (subscription updatedAt, boot markers) because Neo
+ * agent sessions routinely run 10h+ with multiple in-session context-compactions
+ * invisible to the orchestrator. A2A activity is the only durable signal.
+ * @type {Number}
+ */
+export const DEFAULT_ACTIVE_WINDOW_MS = 3 * 60 * 60 * 1000;
+
+/**
+ * Default idle threshold (15m). No A2A activity for this long → idle (wake
+ * candidate). Operator's manual-prompt edge case is handled because received
+ * activity at t=0 keeps the identity non-idle through t≈15m.
+ * @type {Number}
+ */
+export const DEFAULT_IDLE_WINDOW_MS = 15 * 60 * 1000;
+
+/**
+ * Default location for orchestrator-local backoff state. Sibling to
+ * `.neo-ai-data/wake-daemon/heartbeat.alive` and `trioWakeCooldown` precedent.
+ * Per Sub-ii AC2 / Epic #11993 OQ3 resolution: backoff state lives in
+ * orchestrator-local persisted file, NOT on `WAKE_SUBSCRIPTION` properties
+ * (would pollute client-deployment graph substrate), NOT a new graph node type.
+ * @type {String}
+ */
+export const DEFAULT_BACKOFF_STATE_FILE = path.resolve(
+    process.cwd(),
+    '.neo-ai-data',
+    'wake-daemon',
+    'backoff.json'
+);
+
+/**
+ * @summary 3-signal wake-decision substrate for orchestrator-driven harness wakes.
+ *
+ * Substrate-correct successor to the rejected MC HealthService projection
+ * (#11982) and the rejected "harness-side heartbeat workaround" framing
+ * (#11872). Implements the cycle-3 model from Discussion #11992 graduated to
+ * Epic #11993: **Wake = active AND idle AND ready** with each signal derived
+ * purely from existing graph activity + orchestrator-local persisted state.
+ *
+ * **Decision function** (`decideWake`) is pure: takes empirical inputs
+ * (current time, recent A2A timestamps, active readiness sentinel, active
+ * backoff window) and returns a wake-decision object. Caller (Sub-iii's
+ * `SwarmHeartbeatService.pulse()`) gathers the inputs and invokes this
+ * function; no graph or filesystem access inside the decision path.
+ *
+ * **Readiness sentinel parsing** (`parseReadinessSentinel` +
+ * `parseActiveReadinessSentinels`) reads structured A2A `task` envelope
+ * metadata; subject-only spoofing is rejected. Per Sub-ii AC5.
+ *
+ * **Backoff state** (instance methods) persists per-identity backoff windows
+ * to orchestrator-local file (mirror of `TaskStateService` pattern). Survives
+ * orchestrator restart, gracefully degrades on corrupt state, applies TTL
+ * expiry on read, isolates per-identity. Per Sub-ii AC3.
+ *
+ * @class Neo.ai.daemons.services.WakeDecisionService
+ * @extends Neo.core.Base
+ * @singleton
+ */
+export class WakeDecisionService extends Base {
+    static config = {
+        /**
+         * @member {String} className='Neo.ai.daemons.services.WakeDecisionService'
+         * @protected
+         */
+        className: 'Neo.ai.daemons.services.WakeDecisionService',
+        /**
+         * @member {Boolean} singleton=true
+         * @protected
+         */
+        singleton: true,
+        /**
+         * Path to the persisted backoff-state JSON file. Set via `configure()`.
+         * @member {String|null} stateFile_=null
+         * @protected
+         * @reactive
+         */
+        stateFile_: null,
+        /**
+         * Per-identity backoff state map. `{[identity]: {expiresAtMs, reason, recordedAtMs}, ...}`.
+         * Loaded from `stateFile` at `configure()` time. Mutated via `setBackoffWindow` /
+         * `clearBackoffWindow` / `clearExpiredWindows`.
+         * @member {Object|null} backoffState_=null
+         * @protected
+         * @reactive
+         */
+        backoffState_: null,
+        /**
+         * Injectable log function for orchestrator-style logging. Defaults to no-op.
+         * @member {Function|null} writeLogFn_=null
+         * @protected
+         * @reactive
+         */
+        writeLogFn_: null
+    }
+
+    /**
+     * Pure decision function — `Wake = active AND idle AND ready`.
+     *
+     * Each signal is independently necessary; dropping any one yields a
+     * documented pathological case (see Epic #11993 "drop-X" table). Returns
+     * a structured wake-decision envelope so callers can log specific reasons.
+     *
+     * @param {Object} input
+     * @param {String} input.identity Target agent identity (e.g., `@neo-gpt`). Echoed in result for logging; not used in branch logic.
+     * @param {Number} input.currentTimeMs Current time (caller-supplied to keep pure-function determinism).
+     * @param {Number[]} [input.recentActivityTimestamps=[]] Millisecond timestamps of A2A activity (sent OR received) within recent window. Caller produces this from `MailboxService.listMessages` filtered to last `activeWindowMs`.
+     * @param {Object|null} [input.activeReadinessSentinel=null] Active `[wake-readiness]` sentinel: `{ready, reason, expiresAtMs}` or `null`. Caller obtains via `parseActiveReadinessSentinels`.
+     * @param {Object|null} [input.activeBackoffWindow=null] Active backoff window for this identity: `{expiresAtMs, reason}` or `null`. Caller obtains via `getActiveBackoffWindow`.
+     * @param {Number} [input.activeWindowMs=DEFAULT_ACTIVE_WINDOW_MS] Duration treated as "active".
+     * @param {Number} [input.idleWindowMs=DEFAULT_IDLE_WINDOW_MS] Duration treated as "idle threshold".
+     * @returns {{wake: Boolean, reason: String, signals: {active: Boolean, idle: (Boolean|null), ready: (Boolean|null)}}}
+     */
+    static decideWake({
+        identity,
+        currentTimeMs,
+        recentActivityTimestamps = [],
+        activeReadinessSentinel  = null,
+        activeBackoffWindow      = null,
+        activeWindowMs           = DEFAULT_ACTIVE_WINDOW_MS,
+        idleWindowMs             = DEFAULT_IDLE_WINDOW_MS
+    } = {}) {
+        const active = recentActivityTimestamps.some(ts => currentTimeMs - ts <= activeWindowMs);
+        if (!active) {
+            return {
+                wake   : false,
+                reason : 'no-active-signal',
+                signals: {active: false, idle: null, ready: null}
+            };
+        }
+
+        const idle = !recentActivityTimestamps.some(ts => currentTimeMs - ts <= idleWindowMs);
+        if (!idle) {
+            return {
+                wake   : false,
+                reason : 'not-idle (recent activity within idleWindow)',
+                signals: {active: true, idle: false, ready: null}
+            };
+        }
+
+        const sentinelBlocks = activeReadinessSentinel?.ready === false &&
+                               activeReadinessSentinel?.expiresAtMs > currentTimeMs;
+        const backoffBlocks  = activeBackoffWindow?.expiresAtMs > currentTimeMs;
+        const ready          = !sentinelBlocks && !backoffBlocks;
+
+        if (!ready) {
+            const reason = sentinelBlocks
+                ? `not-ready (readiness sentinel: ${activeReadinessSentinel.reason || 'no reason given'})`
+                : `not-ready (backoff window active: ${activeBackoffWindow.reason || 'no reason given'})`;
+            return {
+                wake   : false,
+                reason,
+                signals: {active: true, idle: true, ready: false}
+            };
+        }
+
+        return {
+            wake   : true,
+            reason : 'active+idle+ready',
+            signals: {active: true, idle: true, ready: true}
+        };
+    }
+
+    /**
+     * Parses a single MESSAGE node's structured `task` envelope for a
+     * `[wake-readiness]` sentinel. Returns the sentinel or null.
+     *
+     * Authority for parsing is the structured `task` envelope, NOT the subject
+     * line. Subject + taggedConcepts remain human-visible for mailbox UI but
+     * are not parser inputs — subject-only spoofing is rejected (returns null).
+     *
+     * @param {Object} message Mailbox message node. Expected shape: `{properties: {task: {type, ready, reason, expiresAt}, ...}}`.
+     * @param {Number} currentTimeMs Caller-supplied current time (purity).
+     * @returns {{ready: Boolean, reason: String, expiresAtMs: Number, sourceMessageId: String}|null}
+     */
+    static parseReadinessSentinel(message, currentTimeMs) {
+        const task = message?.properties?.task;
+        if (!task || task.type !== 'wake-readiness') return null;
+
+        if (typeof task.ready !== 'boolean') return null;
+
+        const expiresAtMs = task.expiresAt ? Date.parse(task.expiresAt) : NaN;
+        if (!Number.isFinite(expiresAtMs)) return null;
+
+        if (expiresAtMs <= currentTimeMs) return null;
+
+        return {
+            ready          : task.ready,
+            reason         : typeof task.reason === 'string' ? task.reason : '',
+            expiresAtMs,
+            sourceMessageId: message.id || message.properties?.messageId || null
+        };
+    }
+
+    /**
+     * Composes the active readiness state from a list of candidate MESSAGE
+     * nodes. Most-restrictive-wins on `expiresAt`:
+     *
+     *   - Filters to non-expired `[wake-readiness]` sentinels via
+     *     `parseReadinessSentinel`.
+     *   - Among the remaining sentinels: if ANY block (`ready: false`),
+     *     return the one with the LATEST `expiresAt` (longest block applies).
+     *   - Otherwise (all sentinels say `ready: true`), return the one with
+     *     the EARLIEST `expiresAt` (most-restrictive: shortest "ready"
+     *     guarantee dominates, defending against author-set + operator-set
+     *     conflicts).
+     *   - Returns `null` if no active sentinels exist.
+     *
+     * Operator-set vs self-set sentinels compose by the same rule — author
+     * identity is not consulted in the merge (per Epic OQ4+OQ5).
+     *
+     * @param {Object[]} messages Candidate mailbox message nodes.
+     * @param {Number} currentTimeMs Caller-supplied current time.
+     * @returns {Object|null} Active sentinel `{ready, reason, expiresAtMs, sourceMessageId}` or null.
+     */
+    static parseActiveReadinessSentinels(messages, currentTimeMs) {
+        const sentinels = (messages || [])
+            .map(m => this.parseReadinessSentinel(m, currentTimeMs))
+            .filter(Boolean);
+
+        if (sentinels.length === 0) return null;
+
+        const blocking = sentinels.filter(s => s.ready === false);
+        if (blocking.length > 0) {
+            return blocking.reduce((latest, current) =>
+                current.expiresAtMs > latest.expiresAtMs ? current : latest
+            );
+        }
+
+        return sentinels.reduce((earliest, current) =>
+            current.expiresAtMs < earliest.expiresAtMs ? current : earliest
+        );
+    }
+
+    /**
+     * Configures the service. Required before any backoff-state read/write.
+     *
+     * @param {Object} options
+     * @param {String} [options.stateFile=DEFAULT_BACKOFF_STATE_FILE]
+     * @param {Function} [options.writeLogFn] Injectable logger.
+     * @returns {void}
+     */
+    configure(options = {}) {
+        this.stateFile    = options.stateFile || DEFAULT_BACKOFF_STATE_FILE;
+        this.writeLogFn   = options.writeLogFn || (() => {});
+        this.backoffState = this.readState();
+    }
+
+    /**
+     * Reads persisted backoff state. Corrupt state degrades gracefully to an
+     * empty backoff map (NOT a crash-loop). Per Sub-ii AC3.
+     * @returns {Object}
+     */
+    readState() {
+        if (!this.stateFile || !fs.existsSync(this.stateFile)) {
+            return {};
+        }
+
+        try {
+            const data = JSON.parse(fs.readFileSync(this.stateFile, 'utf8'));
+            return data && typeof data === 'object' ? data : {};
+        } catch (e) {
+            this.writeLog('ERROR', `[WakeDecisionService] Failed to read backoff state file ${this.stateFile}: ${e.message}`);
+            return {};
+        }
+    }
+
+    /**
+     * Persists the current backoff state envelope to disk.
+     * @returns {void}
+     */
+    writeState() {
+        if (!this.stateFile) return;
+
+        try {
+            fs.ensureDirSync(path.dirname(this.stateFile));
+            fs.writeFileSync(this.stateFile, JSON.stringify(this.backoffState, null, 2), 'utf8');
+        } catch (e) {
+            this.writeLog('ERROR', `[WakeDecisionService] Failed to write backoff state file ${this.stateFile}: ${e.message}`);
+        }
+    }
+
+    /**
+     * Returns the active backoff window for an identity, or null if none
+     * active. Applies TTL expiry on read (expired windows are pruned).
+     *
+     * @param {String} identity
+     * @param {Number} currentTimeMs Caller-supplied (purity at the read boundary).
+     * @returns {{expiresAtMs: Number, reason: String, recordedAtMs: Number}|null}
+     */
+    getActiveBackoffWindow(identity, currentTimeMs) {
+        if (!this.backoffState || !this.backoffState[identity]) return null;
+
+        const window = this.backoffState[identity];
+        if (window.expiresAtMs <= currentTimeMs) {
+            delete this.backoffState[identity];
+            this.writeState();
+            return null;
+        }
+
+        return window;
+    }
+
+    /**
+     * Records a backoff window for an identity. Replaces any existing window
+     * for the same identity (latest-wins; caller is responsible for upgrade
+     * semantics like exponential backoff increment).
+     *
+     * @param {Object} options
+     * @param {String} options.identity
+     * @param {Number} options.durationMs Window duration from `recordedAtMs`.
+     * @param {String} [options.reason=''] Operator-visible reason (e.g., 'rate-limit-exhausted', 'error-streak-3').
+     * @param {Number} [options.recordedAtMs=Date.now()] Caller-injectable for tests.
+     * @returns {Object} The recorded window.
+     */
+    setBackoffWindow({identity, durationMs, reason = '', recordedAtMs = Date.now()} = {}) {
+        if (!identity) throw new Error('[WakeDecisionService] setBackoffWindow requires identity');
+        if (!Number.isFinite(durationMs) || durationMs <= 0) {
+            throw new Error('[WakeDecisionService] setBackoffWindow requires positive durationMs');
+        }
+
+        const window = {
+            expiresAtMs: recordedAtMs + durationMs,
+            reason,
+            recordedAtMs
+        };
+
+        this.backoffState[identity] = window;
+        this.writeState();
+        return window;
+    }
+
+    /**
+     * Removes a backoff window for an identity (e.g., operator override clears
+     * an error-streak backoff).
+     *
+     * @param {String} identity
+     * @returns {Boolean} True if a window was cleared, false if no window was present.
+     */
+    clearBackoffWindow(identity) {
+        if (!this.backoffState || !this.backoffState[identity]) return false;
+
+        delete this.backoffState[identity];
+        this.writeState();
+        return true;
+    }
+
+    /**
+     * Sweeps all expired backoff windows. Returns the count of windows
+     * removed. Idempotent; safe to call on every pulse cycle.
+     *
+     * @param {Number} currentTimeMs
+     * @returns {Number}
+     */
+    clearExpiredWindows(currentTimeMs) {
+        if (!this.backoffState) return 0;
+
+        const identities = Object.keys(this.backoffState);
+        let cleared      = 0;
+
+        for (const identity of identities) {
+            if (this.backoffState[identity].expiresAtMs <= currentTimeMs) {
+                delete this.backoffState[identity];
+                cleared++;
+            }
+        }
+
+        if (cleared > 0) this.writeState();
+        return cleared;
+    }
+
+    /**
+     * Helper to call the injected log function.
+     * @param {String} level
+     * @param {String} message
+     * @returns {void}
+     */
+    writeLog(level, message) {
+        if (this.writeLogFn) {
+            this.writeLogFn(level, message);
+        }
+    }
+}
+
+export default Neo.setupClass(WakeDecisionService);

--- a/test/playwright/unit/ai/daemons/orchestrator/services/WakeDecisionService.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/services/WakeDecisionService.spec.mjs
@@ -1,0 +1,483 @@
+import {test, expect} from '@playwright/test';
+import fs             from 'fs-extra';
+import path           from 'path';
+import Neo            from '../../../../../../../src/Neo.mjs';
+import * as core      from '../../../../../../../src/core/_export.mjs';
+import {
+    WakeDecisionService,
+    DEFAULT_ACTIVE_WINDOW_MS,
+    DEFAULT_IDLE_WINDOW_MS
+} from '../../../../../../../ai/daemons/orchestrator/services/WakeDecisionService.mjs';
+
+function createStateFile(name) {
+    const dir = path.join(process.cwd(), 'tmp', `wake-decision-${process.pid}-${Date.now()}-${Math.random()}`);
+    fs.ensureDirSync(dir);
+    return path.join(dir, `${name}.json`);
+}
+
+const NOW = Date.parse('2026-05-25T20:00:00.000Z');
+
+test.describe('Neo.ai.daemons.services.WakeDecisionService (#11995, Sub-ii of Epic #11993)', () => {
+
+    // ---------------------------------------------------------------------
+    // decideWake — 3-signal pure function
+    // ---------------------------------------------------------------------
+
+    test.describe('decideWake — 3-signal pure function', () => {
+        test('happy path: active + idle + ready → wake', () => {
+            const result = WakeDecisionService.decideWake({
+                identity                : '@neo-gpt',
+                currentTimeMs           : NOW,
+                recentActivityTimestamps: [NOW - 30 * 60 * 1000] // 30min ago: in active window (3h), past idle window (15m)
+            });
+
+            expect(result.wake).toBe(true);
+            expect(result.reason).toBe('active+idle+ready');
+            expect(result.signals).toEqual({active: true, idle: true, ready: true});
+        });
+
+        test('drop active: no activity within 3h → no wake (pathological case 1)', () => {
+            const result = WakeDecisionService.decideWake({
+                identity                : '@neo-gpt',
+                currentTimeMs           : NOW,
+                recentActivityTimestamps: [NOW - 4 * 60 * 60 * 1000] // 4h ago: outside active window
+            });
+
+            expect(result.wake).toBe(false);
+            expect(result.reason).toBe('no-active-signal');
+            expect(result.signals.active).toBe(false);
+        });
+
+        test('drop idle: recent activity within 15m → no wake (operator manual-prompt grace, pathological case 2)', () => {
+            const result = WakeDecisionService.decideWake({
+                identity                : '@neo-gpt',
+                currentTimeMs           : NOW,
+                recentActivityTimestamps: [NOW - 10 * 60 * 1000] // 10min ago: in idle window → not idle
+            });
+
+            expect(result.wake).toBe(false);
+            expect(result.reason).toContain('not-idle');
+            expect(result.signals).toEqual({active: true, idle: false, ready: null});
+        });
+
+        test('drop ready (readiness sentinel): benched identity → no wake (pathological case 3a)', () => {
+            const result = WakeDecisionService.decideWake({
+                identity                : '@neo-gpt',
+                currentTimeMs           : NOW,
+                recentActivityTimestamps: [NOW - 30 * 60 * 1000],
+                activeReadinessSentinel : {ready: false, reason: 'operator-benched', expiresAtMs: NOW + 60 * 60 * 1000}
+            });
+
+            expect(result.wake).toBe(false);
+            expect(result.reason).toContain('not-ready');
+            expect(result.reason).toContain('operator-benched');
+            expect(result.signals).toEqual({active: true, idle: true, ready: false});
+        });
+
+        test('drop ready (backoff window): error-streak backoff → no wake (pathological case 3b)', () => {
+            const result = WakeDecisionService.decideWake({
+                identity                : '@neo-gpt',
+                currentTimeMs           : NOW,
+                recentActivityTimestamps: [NOW - 30 * 60 * 1000],
+                activeBackoffWindow     : {expiresAtMs: NOW + 30 * 60 * 1000, reason: 'error-streak-3'}
+            });
+
+            expect(result.wake).toBe(false);
+            expect(result.reason).toContain('not-ready');
+            expect(result.reason).toContain('backoff window');
+            expect(result.signals).toEqual({active: true, idle: true, ready: false});
+        });
+
+        test('expired readiness sentinel does not block (sentinel.expiresAtMs < currentTimeMs)', () => {
+            const result = WakeDecisionService.decideWake({
+                identity                : '@neo-gpt',
+                currentTimeMs           : NOW,
+                recentActivityTimestamps: [NOW - 30 * 60 * 1000],
+                activeReadinessSentinel : {ready: false, reason: 'expired-block', expiresAtMs: NOW - 60 * 1000}
+            });
+
+            expect(result.wake).toBe(true);
+        });
+
+        test('ready:true sentinel does not block (only ready:false blocks)', () => {
+            const result = WakeDecisionService.decideWake({
+                identity                : '@neo-gpt',
+                currentTimeMs           : NOW,
+                recentActivityTimestamps: [NOW - 30 * 60 * 1000],
+                activeReadinessSentinel : {ready: true, reason: 'manual-override', expiresAtMs: NOW + 60 * 60 * 1000}
+            });
+
+            expect(result.wake).toBe(true);
+        });
+
+        test('expired backoff window does not block', () => {
+            const result = WakeDecisionService.decideWake({
+                identity                : '@neo-gpt',
+                currentTimeMs           : NOW,
+                recentActivityTimestamps: [NOW - 30 * 60 * 1000],
+                activeBackoffWindow     : {expiresAtMs: NOW - 60 * 1000, reason: 'expired'}
+            });
+
+            expect(result.wake).toBe(true);
+        });
+
+        test('empty recentActivityTimestamps → no wake (no active signal)', () => {
+            const result = WakeDecisionService.decideWake({
+                identity     : '@neo-gpt',
+                currentTimeMs: NOW
+            });
+
+            expect(result.wake).toBe(false);
+            expect(result.reason).toBe('no-active-signal');
+        });
+
+        test('custom activeWindowMs + idleWindowMs respected', () => {
+            // Tighter active window (1h instead of 3h)
+            const result = WakeDecisionService.decideWake({
+                identity                : '@neo-gpt',
+                currentTimeMs           : NOW,
+                recentActivityTimestamps: [NOW - 90 * 60 * 1000], // 90min ago
+                activeWindowMs          : 60 * 60 * 1000          // 1h
+            });
+
+            expect(result.wake).toBe(false);
+            expect(result.reason).toBe('no-active-signal');
+        });
+    });
+
+    // ---------------------------------------------------------------------
+    // parseReadinessSentinel + parseActiveReadinessSentinels
+    // ---------------------------------------------------------------------
+
+    test.describe('Readiness sentinel parsing (Sub-ii AC4 + AC5)', () => {
+        test('structured task envelope with all fields → returns sentinel', () => {
+            const message = {
+                id        : 'MESSAGE:abc',
+                properties: {
+                    task: {
+                        type     : 'wake-readiness',
+                        ready    : false,
+                        reason   : 'rate-limit-exhausted',
+                        expiresAt: new Date(NOW + 60 * 60 * 1000).toISOString()
+                    }
+                }
+            };
+
+            const sentinel = WakeDecisionService.parseReadinessSentinel(message, NOW);
+
+            expect(sentinel).toMatchObject({
+                ready          : false,
+                reason         : 'rate-limit-exhausted',
+                sourceMessageId: 'MESSAGE:abc'
+            });
+            expect(sentinel.expiresAtMs).toBe(NOW + 60 * 60 * 1000);
+        });
+
+        test('subject-only spoofing (no task envelope) → returns null (AC5)', () => {
+            const message = {
+                id        : 'MESSAGE:spoof',
+                properties: {
+                    subject       : '[wake-readiness] benched until 2026-06-01',
+                    taggedConcepts: ['wake-readiness']
+                    // NO task envelope
+                }
+            };
+
+            const sentinel = WakeDecisionService.parseReadinessSentinel(message, NOW);
+            expect(sentinel).toBeNull();
+        });
+
+        test('task envelope with wrong type → returns null', () => {
+            const message = {
+                properties: {
+                    task: {type: 'a2a-task', ready: false, expiresAt: new Date(NOW + 1000).toISOString()}
+                }
+            };
+
+            expect(WakeDecisionService.parseReadinessSentinel(message, NOW)).toBeNull();
+        });
+
+        test('task envelope without ready field → returns null', () => {
+            const message = {
+                properties: {
+                    task: {type: 'wake-readiness', expiresAt: new Date(NOW + 1000).toISOString()}
+                }
+            };
+
+            expect(WakeDecisionService.parseReadinessSentinel(message, NOW)).toBeNull();
+        });
+
+        test('task envelope without valid expiresAt → returns null', () => {
+            const message = {
+                properties: {
+                    task: {type: 'wake-readiness', ready: false, expiresAt: 'not-a-date'}
+                }
+            };
+
+            expect(WakeDecisionService.parseReadinessSentinel(message, NOW)).toBeNull();
+        });
+
+        test('expired sentinel (expiresAt < currentTime) → returns null (auto-cleared)', () => {
+            const message = {
+                properties: {
+                    task: {type: 'wake-readiness', ready: false, expiresAt: new Date(NOW - 1000).toISOString()}
+                }
+            };
+
+            expect(WakeDecisionService.parseReadinessSentinel(message, NOW)).toBeNull();
+        });
+
+        test('parseActiveReadinessSentinels: multiple blocking sentinels → returns LATEST expiresAt (longest block wins)', () => {
+            const earlierBlock = {
+                id: 'm1',
+                properties: {task: {type: 'wake-readiness', ready: false, reason: 'first', expiresAt: new Date(NOW + 30 * 60 * 1000).toISOString()}}
+            };
+            const laterBlock = {
+                id: 'm2',
+                properties: {task: {type: 'wake-readiness', ready: false, reason: 'longer', expiresAt: new Date(NOW + 2 * 60 * 60 * 1000).toISOString()}}
+            };
+
+            const active = WakeDecisionService.parseActiveReadinessSentinels([earlierBlock, laterBlock], NOW);
+
+            expect(active.ready).toBe(false);
+            expect(active.reason).toBe('longer');
+            expect(active.expiresAtMs).toBe(NOW + 2 * 60 * 60 * 1000);
+        });
+
+        test('parseActiveReadinessSentinels: ready:false + ready:true mix → blocking (ready:false) wins regardless of expiresAt', () => {
+            const blockingNear = {
+                id: 'm1',
+                properties: {task: {type: 'wake-readiness', ready: false, reason: 'block', expiresAt: new Date(NOW + 5 * 60 * 1000).toISOString()}}
+            };
+            const readyFar = {
+                id: 'm2',
+                properties: {task: {type: 'wake-readiness', ready: true, reason: 'override-ready', expiresAt: new Date(NOW + 2 * 60 * 60 * 1000).toISOString()}}
+            };
+
+            const active = WakeDecisionService.parseActiveReadinessSentinels([blockingNear, readyFar], NOW);
+
+            expect(active.ready).toBe(false);
+            expect(active.reason).toBe('block');
+        });
+
+        test('parseActiveReadinessSentinels: all ready:true sentinels → returns EARLIEST expiresAt (most-restrictive)', () => {
+            const earlyReady = {
+                id: 'm1',
+                properties: {task: {type: 'wake-readiness', ready: true, reason: 'short', expiresAt: new Date(NOW + 5 * 60 * 1000).toISOString()}}
+            };
+            const lateReady = {
+                id: 'm2',
+                properties: {task: {type: 'wake-readiness', ready: true, reason: 'long', expiresAt: new Date(NOW + 60 * 60 * 1000).toISOString()}}
+            };
+
+            const active = WakeDecisionService.parseActiveReadinessSentinels([earlyReady, lateReady], NOW);
+
+            expect(active.ready).toBe(true);
+            expect(active.reason).toBe('short');
+            expect(active.expiresAtMs).toBe(NOW + 5 * 60 * 1000);
+        });
+
+        test('parseActiveReadinessSentinels: empty/no-sentinel-matching → returns null', () => {
+            const noise = [
+                {id: 'm1', properties: {task: {type: 'a2a-task', ready: false}}},
+                {id: 'm2', properties: {subject: '[wake-readiness] no task envelope'}}
+            ];
+
+            expect(WakeDecisionService.parseActiveReadinessSentinels(noise, NOW)).toBeNull();
+            expect(WakeDecisionService.parseActiveReadinessSentinels([], NOW)).toBeNull();
+        });
+    });
+
+    // ---------------------------------------------------------------------
+    // Backoff state persistence (Sub-ii AC3)
+    // ---------------------------------------------------------------------
+
+    test.describe('Backoff state persistence (Sub-ii AC2 + AC3)', () => {
+        test('set + read: setBackoffWindow stores window, getActiveBackoffWindow returns it', () => {
+            const stateFile = createStateFile('set-and-read');
+            const service   = Neo.create(WakeDecisionService);
+            service.configure({stateFile});
+
+            const window = service.setBackoffWindow({
+                identity    : '@neo-gpt',
+                durationMs  : 60 * 60 * 1000,
+                reason      : 'error-streak-3',
+                recordedAtMs: NOW
+            });
+
+            expect(window.expiresAtMs).toBe(NOW + 60 * 60 * 1000);
+
+            const active = service.getActiveBackoffWindow('@neo-gpt', NOW + 30 * 60 * 1000);
+            expect(active.reason).toBe('error-streak-3');
+            expect(active.expiresAtMs).toBe(NOW + 60 * 60 * 1000);
+        });
+
+        test('restart-persistence: state survives service re-instantiation', () => {
+            const stateFile = createStateFile('restart');
+            const service1  = Neo.create(WakeDecisionService);
+            service1.configure({stateFile});
+            service1.setBackoffWindow({identity: '@neo-gpt', durationMs: 60 * 60 * 1000, reason: 'persisted', recordedAtMs: NOW});
+
+            // Simulate restart: new service instance reads from same file
+            const service2 = Neo.create(WakeDecisionService);
+            service2.configure({stateFile});
+
+            const recovered = service2.getActiveBackoffWindow('@neo-gpt', NOW + 30 * 60 * 1000);
+            expect(recovered).not.toBeNull();
+            expect(recovered.reason).toBe('persisted');
+        });
+
+        test('corrupt-state fallback: malformed JSON file → empty state, no crash', () => {
+            const stateFile = createStateFile('corrupt');
+            fs.ensureDirSync(path.dirname(stateFile));
+            fs.writeFileSync(stateFile, '{not valid json', 'utf8');
+
+            const logs    = [];
+            const service = Neo.create(WakeDecisionService);
+            service.configure({stateFile, writeLogFn: (level, msg) => logs.push({level, msg})});
+
+            expect(service.backoffState).toEqual({});
+            expect(logs).toEqual(expect.arrayContaining([
+                expect.objectContaining({level: 'ERROR', msg: expect.stringMatching(/Failed to read backoff state file/)})
+            ]));
+
+            // Service still functional after corrupt-state recovery
+            service.setBackoffWindow({identity: '@neo-gpt', durationMs: 60_000, recordedAtMs: NOW});
+            expect(service.getActiveBackoffWindow('@neo-gpt', NOW)).not.toBeNull();
+        });
+
+        test('TTL expiry on read: expired window auto-cleared, getActive returns null', () => {
+            const stateFile = createStateFile('ttl-expiry');
+            const service   = Neo.create(WakeDecisionService);
+            service.configure({stateFile});
+
+            service.setBackoffWindow({identity: '@neo-gpt', durationMs: 60 * 1000, recordedAtMs: NOW});
+
+            // Read AFTER window expiry
+            const queryTime = NOW + 5 * 60 * 1000;
+            expect(service.getActiveBackoffWindow('@neo-gpt', queryTime)).toBeNull();
+            expect(service.backoffState['@neo-gpt']).toBeUndefined();
+        });
+
+        test('per-identity isolation: backoff for one identity does not affect others', () => {
+            const stateFile = createStateFile('isolation');
+            const service   = Neo.create(WakeDecisionService);
+            service.configure({stateFile});
+
+            service.setBackoffWindow({identity: '@neo-gpt', durationMs: 60 * 60 * 1000, reason: 'gpt-only', recordedAtMs: NOW});
+
+            expect(service.getActiveBackoffWindow('@neo-gpt', NOW)).not.toBeNull();
+            expect(service.getActiveBackoffWindow('@neo-opus-4-7', NOW)).toBeNull();
+            expect(service.getActiveBackoffWindow('@neo-gemini-3-1-pro', NOW)).toBeNull();
+        });
+
+        test('clearBackoffWindow: explicit clear removes the window', () => {
+            const stateFile = createStateFile('explicit-clear');
+            const service   = Neo.create(WakeDecisionService);
+            service.configure({stateFile});
+
+            service.setBackoffWindow({identity: '@neo-gpt', durationMs: 60 * 60 * 1000, recordedAtMs: NOW});
+            expect(service.clearBackoffWindow('@neo-gpt')).toBe(true);
+            expect(service.getActiveBackoffWindow('@neo-gpt', NOW)).toBeNull();
+
+            // Idempotent: second clear returns false
+            expect(service.clearBackoffWindow('@neo-gpt')).toBe(false);
+        });
+
+        test('clearExpiredWindows: sweeps all expired in one pass', () => {
+            const stateFile = createStateFile('sweep');
+            const service   = Neo.create(WakeDecisionService);
+            service.configure({stateFile});
+
+            service.setBackoffWindow({identity: '@a', durationMs: 1 * 60 * 1000, recordedAtMs: NOW}); // expires NOW+1min
+            service.setBackoffWindow({identity: '@b', durationMs: 2 * 60 * 1000, recordedAtMs: NOW}); // expires NOW+2min
+            service.setBackoffWindow({identity: '@c', durationMs: 60 * 60 * 1000, recordedAtMs: NOW}); // expires NOW+60min
+
+            const cleared = service.clearExpiredWindows(NOW + 5 * 60 * 1000); // After 5min, @a and @b expired
+            expect(cleared).toBe(2);
+            expect(service.getActiveBackoffWindow('@a', NOW + 5 * 60 * 1000)).toBeNull();
+            expect(service.getActiveBackoffWindow('@b', NOW + 5 * 60 * 1000)).toBeNull();
+            expect(service.getActiveBackoffWindow('@c', NOW + 5 * 60 * 1000)).not.toBeNull();
+        });
+
+        test('setBackoffWindow validation: missing identity throws', () => {
+            const stateFile = createStateFile('validation-1');
+            const service   = Neo.create(WakeDecisionService);
+            service.configure({stateFile});
+
+            expect(() => service.setBackoffWindow({durationMs: 60_000})).toThrow(/identity/);
+        });
+
+        test('setBackoffWindow validation: non-positive durationMs throws', () => {
+            const stateFile = createStateFile('validation-2');
+            const service   = Neo.create(WakeDecisionService);
+            service.configure({stateFile});
+
+            expect(() => service.setBackoffWindow({identity: '@a', durationMs: 0})).toThrow(/positive durationMs/);
+            expect(() => service.setBackoffWindow({identity: '@a', durationMs: -100})).toThrow(/positive durationMs/);
+            expect(() => service.setBackoffWindow({identity: '@a', durationMs: NaN})).toThrow(/positive durationMs/);
+        });
+    });
+
+    // ---------------------------------------------------------------------
+    // End-to-end composition: decideWake + readiness sentinels + backoff
+    // ---------------------------------------------------------------------
+
+    test.describe('End-to-end signal composition', () => {
+        test('full happy path: active activity + no sentinel + no backoff → wake', () => {
+            const stateFile = createStateFile('e2e-happy');
+            const service   = Neo.create(WakeDecisionService);
+            service.configure({stateFile});
+
+            const decision = WakeDecisionService.decideWake({
+                identity                : '@neo-gpt',
+                currentTimeMs           : NOW,
+                recentActivityTimestamps: [NOW - 30 * 60 * 1000],
+                activeReadinessSentinel : WakeDecisionService.parseActiveReadinessSentinels([], NOW),
+                activeBackoffWindow     : service.getActiveBackoffWindow('@neo-gpt', NOW)
+            });
+
+            expect(decision.wake).toBe(true);
+        });
+
+        test('full block path: backoff + recent error → no wake until backoff expires', () => {
+            const stateFile = createStateFile('e2e-block');
+            const service   = Neo.create(WakeDecisionService);
+            service.configure({stateFile});
+
+            service.setBackoffWindow({identity: '@neo-gpt', durationMs: 30 * 60 * 1000, reason: 'error-streak-3', recordedAtMs: NOW});
+
+            // Query at NOW+20min: activity at NOW is 20min stale (past idle) → idle check OK → backoff check fires
+            const decision1 = WakeDecisionService.decideWake({
+                identity                : '@neo-gpt',
+                currentTimeMs           : NOW + 20 * 60 * 1000,
+                recentActivityTimestamps: [NOW],
+                activeReadinessSentinel : null,
+                activeBackoffWindow     : service.getActiveBackoffWindow('@neo-gpt', NOW + 20 * 60 * 1000)
+            });
+
+            expect(decision1.wake).toBe(false);
+            expect(decision1.reason).toContain('error-streak-3');
+
+            // After backoff expires
+            const decision2 = WakeDecisionService.decideWake({
+                identity                : '@neo-gpt',
+                currentTimeMs           : NOW + 60 * 60 * 1000,
+                recentActivityTimestamps: [NOW + 20 * 60 * 1000],
+                activeReadinessSentinel : null,
+                activeBackoffWindow     : service.getActiveBackoffWindow('@neo-gpt', NOW + 60 * 60 * 1000)
+            });
+
+            expect(decision2.wake).toBe(true);
+        });
+    });
+
+    // ---------------------------------------------------------------------
+    // Constants (ensure defaults match Epic-documented 3h / 15m)
+    // ---------------------------------------------------------------------
+
+    test('DEFAULT_ACTIVE_WINDOW_MS is 3h, DEFAULT_IDLE_WINDOW_MS is 15m (per Epic #11993)', () => {
+        expect(DEFAULT_ACTIVE_WINDOW_MS).toBe(3 * 60 * 60 * 1000);
+        expect(DEFAULT_IDLE_WINDOW_MS).toBe(15 * 60 * 1000);
+    });
+});


### PR DESCRIPTION
Authored by Claude Opus 4.7 (Claude Code). Nightshift session continuation from #11993 wake-substrate Epic graduation.

FAIR-band: under-target [12/30] — Sub-ii of operator-graduated Epic (#11993); bounded scope (1 new service + 1 spec file).

Evidence: L1 (32/32 PASS pure-function + persisted-state coverage) → L1 required for Sub-ii ACs (pure-function + state-contract; L2-L3 deferred to Sub-iii integration). Residual: AC8 [#11993 Epic-level — operator-confirmation post-Sub-iii wiring].

Resolves #11995

## Summary

Implements Sub-ii of Epic #11993 (Wake substrate evolution): the 3-signal wake-decision function + structured readiness-sentinel parser + orchestrator-local persisted backoff state.

Per the cycle-3 graduated model from Discussion #11992:

```
Wake = active AND idle AND ready
```

Each signal derived purely from existing graph activity + orchestrator-local state — zero new MCP tools, zero new graph node types, zero subscription-substrate pollution. Per @neo-gpt cycle-2 V-B-A: backoff state lives in orchestrator-local persisted file (not `WAKE_SUBSCRIPTION` properties, not a new graph node type).

## Deltas

Cycle-1 body:
- New file `ai/daemons/orchestrator/services/WakeDecisionService.mjs` (singleton, extends Base).
- New spec `test/playwright/unit/ai/daemons/orchestrator/services/WakeDecisionService.spec.mjs` (32 tests).
- No existing-file modifications.

Cycle-2 body update (post @neo-gpt CHANGES_REQUESTED on body):
- Added this `## Deltas` section (lint anchor compliance per agent-pr-body-lint.yml).
- Tightened `Evidence:` line to canonical achieved-vs-required form.
- No code changes.

## Architectural shape

**New singleton:** `Neo.ai.daemons.services.WakeDecisionService` at `ai/daemons/orchestrator/services/WakeDecisionService.mjs`.

### Pure static functions (decision + parsing)

| API | Purpose |
|---|---|
| `decideWake({identity, currentTimeMs, recentActivityTimestamps, activeReadinessSentinel, activeBackoffWindow, activeWindowMs, idleWindowMs})` | Pure 3-signal decision; returns `{wake, reason, signals: {active, idle, ready}}`. Caller-supplied current time + activity timestamps keep purity. |
| `parseReadinessSentinel(message, currentTimeMs)` | Reads structured `task` envelope (`{type: 'wake-readiness', ready, reason, expiresAt}`). **Subject-only spoofing rejected** (per Sub-ii AC5 + @neo-gpt cycle-3 residual #4). Returns sentinel or null. |
| `parseActiveReadinessSentinels(messages, currentTimeMs)` | Most-restrictive-wins composition: `ready:false` with LATEST `expiresAt` wins over `ready:true`; among all-`ready:true`, EARLIEST `expiresAt` wins. Operator-set vs self-set sentinels compose by the same rule (author identity not consulted). |

### Instance backoff-state mgmt (persisted)

Mirror of `TaskStateService` pattern. State persisted to `.neo-ai-data/wake-daemon/backoff.json` (sibling of `trioWakeCooldown` precedent per @neo-gpt cycle-2 substrate citations).

| API | Purpose |
|---|---|
| `configure({stateFile, writeLogFn})` | Initialize service; reads state file. |
| `readState() / writeState()` | Persistence I/O. Corrupt state → empty map + logged ERROR (not crash-loop). |
| `getActiveBackoffWindow(identity, currentTimeMs)` | Returns active window or null. **TTL applied on read** (expired auto-cleared + persisted). |
| `setBackoffWindow({identity, durationMs, reason, recordedAtMs})` | Records window. Replaces existing (latest-wins; caller owns exponential-backoff upgrade semantics). Validates required fields. |
| `clearBackoffWindow(identity)` | Explicit clear. Idempotent (returns false if no window). |
| `clearExpiredWindows(currentTimeMs)` | Sweep all expired. Idempotent; safe on every pulse cycle. |

## Test Evidence

```
npm run test-unit -- test/playwright/unit/ai/daemons/orchestrator/services/WakeDecisionService.spec.mjs
```

→ **32/32 PASS (641ms)** at commit `c845aaea3`.

Coverage breakdown:

- **`decideWake` 3-signal pure function (10 tests):** happy path; drop-active (no activity in 3h); drop-idle (recent activity within 15m — operator manual-prompt grace); drop-ready-sentinel (benched identity); drop-ready-backoff (error-streak backoff); expired sentinel pass-through; `ready:true` sentinel non-blocking; expired backoff pass-through; empty timestamps; custom window overrides
- **Readiness sentinel parsing (10 tests):** structured-envelope happy path; **subject-only spoofing rejected** (AC5 satisfied); wrong type; missing `ready`; invalid `expiresAt`; expired auto-cleared; multi-sentinel longest-block-wins; mixed ready:false+ready:true (blocking dominates); all-ready-true earliest-wins; empty/no-match → null
- **Backoff state persistence (9 tests):** set+read; **restart-persistence** (new service instance reads same file); **corrupt-state fallback** (malformed JSON → empty + ERROR log, not crash); **TTL expiry on read** (auto-pruned); **per-identity isolation** (backoff for one identity does not affect others); explicit clear (idempotent); sweep expired; validation throws (missing identity, non-positive duration)
- **End-to-end composition (2 tests):** full happy path; full block-then-unblock cycle through backoff TTL
- **Constants (1 test):** `DEFAULT_ACTIVE_WINDOW_MS` = 3h, `DEFAULT_IDLE_WINDOW_MS` = 15m per Epic #11993

## Sub-ii ACs satisfied

- [x] Sub-ii.1 — 3-signal derivation pure function: `(identity, current-time, A2A-graph-state, readiness-sentinel-state, orchestrator-state-backoff) → wake-decision` ✓
- [x] Sub-ii.2 — Orchestrator-local backoff state in `.neo-ai-data/wake-daemon/backoff.json` (sibling of `trioWakeCooldown` precedent). Decision documented in `DEFAULT_BACKOFF_STATE_FILE` constant + module JSDoc. **NOT** on `WAKE_SUBSCRIPTION` properties; **NOT** a new graph node type.
- [x] Sub-ii.3 — Backoff state tests: restart-persistence, corrupt-state graceful fallback, TTL expiry, per-identity isolation — all covered ✓
- [x] Sub-ii.4 — Readiness-sentinel parser reads structured `task` envelope; subject-only spoofing rejected (test: "subject-only spoofing → returns null")
- [x] Sub-ii.5 — Unit tests cover all 4 known pathological cases (drop-active, drop-idle, drop-ready-sentinel, drop-ready-backoff) + operator manual-prompt grace ✓
- [ ] Sub-ii.6 — Cross-family review per `pull-request §6.1` (this PR — @neo-gpt cycle-1 posted CHANGES_REQUESTED on body lint; cycle-2 body update addresses)

## What this does NOT ship

Per Epic #11993 sub-decomposition:
- **`WakeSubscriptionService.emitHeartbeatPulse`** — Sub-i #11994 (now PR #11998, APPROVED by me)
- **`SwarmHeartbeatService.pulse()` Step 7 wiring** that consumes this Sub's decision function — Sub-iii #11996
- **tmux-inject + Shape A heartbeat-mailbox-path removal** — Sub-iii #11996

This PR ships the pure decision logic + persisted-state primitives. Sub-iii is the integration consumer.

## Architectural decisions made in this Sub (worth flagging for review)

1. **Pure decision function takes `recentActivityTimestamps: Number[]` as input** (not a graph reference). Keeps determinism + testability. Sub-iii's caller queries `MailboxService.listMessages` and filters to recent sent+received timestamps for the target identity before invoking `decideWake`.

2. **`parseActiveReadinessSentinels` composition rule** — chose "ready:false with LATEST `expiresAt` wins" over ready:true. Cycle-3 OQ4+OQ5 resolution called for "most-restrictive-wins on `expiresAt`" — the interpretation: longest block dominates short blocks (substrate safety); among all-ready, shortest guarantee dominates (defends against author/operator conflicts). This is documented in the JSDoc + the longest-block-wins test.

3. **Backoff state file location** — chose `.neo-ai-data/wake-daemon/backoff.json` over `orchestrator-state.json` per-task block. Rationale: `orchestrator-state.json` is per-task state (running/lastRunAt/etc.); backoff state is per-identity, orthogonal concern. Sibling file follows the `.neo-ai-data/wake-daemon/` precedent established by `trioWakeCooldown`. Cross-family reviewer can challenge if they prefer the per-task-block shape.

4. **`setBackoffWindow` validation throws** rather than silently no-ops on missing identity / invalid duration. Loud failures during impl-time; defends against caller bugs (e.g., Sub-iii passing undefined identity).

## Post-Merge Validation

- [ ] Sub-iii (#11996) integration: `SwarmHeartbeatService.pulse()` calls `decideWake` correctly; backoff state file appears in operator's `.neo-ai-data/wake-daemon/`
- [ ] Operator verifies (when Epic #11993 fully lands): heartbeat respects benched identity via self-A2A sentinel; backoff TTL expires correctly across orchestrator restart

## Avoided Traps

- ✓ Did NOT put backoff state on `WAKE_SUBSCRIPTION` properties — would pollute client-deployment graph substrate
- ✓ Did NOT add a new graph node type — substrate-additive cost not justified per Epic #11993 OQ3 resolution
- ✓ Did NOT parse subject patterns for sentinel detection — structured `task` envelope is the parser authority
- ✓ Did NOT add new MCP tools — operator constraint (tool cap ~100, recommended ≤50)
- ✓ Did NOT include `SwarmHeartbeatService` wiring in this PR — Sub-iii's clean responsibility boundary

## Authority

Epic #11993 graduated from Discussion #11992 with quorum (@neo-opus-4-7 AUTHOR_SIGNAL + @neo-gpt GRADUATION_APPROVED at cycle-3 body anchor 2026-05-25T20:50:21Z). Self-assigned to #11995 after coordinate-not-collide with @neo-gpt's self-assignment to Sub-i #11994.

Origin Session ID: `8f1a91ee-3ee4-4e4b-9865-b5810f6be353`

Authored by [Claude Opus 4.7] (Claude Code) — nightshift continuation from operator-approved Epic #11993 graduation.

## Commits

- `c845aaea3` — `feat(orchestrator): WakeDecisionService 3-signal + readiness parser + backoff (#11995)`
