### PR TITLE
feat(ai): add heartbeat pulse wake event (#11994)

### DIFF
--- a/ai/daemons/bridge/daemon.mjs
+++ b/ai/daemons/bridge/daemon.mjs
@@ -292,7 +292,10 @@ async function pollLoop() {
                 const edgesMap = new Map(edgesData.map(r => [r.id, JSON.parse(r.data)]));
 
                 for (const trace of logs) {
-                    const entity = trace.entity_type === 'nodes' ? nodesMap.get(trace.entity_id) : edgesMap.get(trace.entity_id);
+                    const entity = trace.entity_type === 'nodes' ? nodesMap.get(trace.entity_id)
+                        : trace.entity_type === 'edges' ? edgesMap.get(trace.entity_id)
+                        : trace.entity_type === 'heartbeat_pulse' ? {id: trace.entity_id, type: 'HEARTBEAT_PULSE'}
+                        : null;
                     if (!entity) continue; // entity might have been deleted, skipping for wake events unless it's a deletion trigger, but currently we focus on creation/updates
 
                     for (const sub of subscriptions) {
@@ -393,9 +396,38 @@ function evaluateSubscription(sub, trace, entity, nodesMap, edgesMap) {
                 logId: trace.log_id
             };
         }
+    } else if (trigger === 'HEARTBEAT_PULSE' && trace.entity_type === 'heartbeat_pulse') {
+        const pulse = parseHeartbeatPulseEntityId(trace.entity_id);
+        if (pulse?.targetIdentity === agentIdentity) {
+            return {
+                type: 'heartbeat',
+                targetIdentity: pulse.targetIdentity,
+                pulseId: pulse.pulseId,
+                logId: trace.log_id
+            };
+        }
     }
 
     return null;
+}
+
+/**
+ * Parses a GraphLog-only heartbeat pulse entity id.
+ * @param {String} entityId Encoded `HEARTBEAT_PULSE:<identity>:<uuid>` id.
+ * @returns {{targetIdentity:String,pulseId:String}|null} Parsed pulse.
+ */
+function parseHeartbeatPulseEntityId(entityId) {
+    const prefix = 'HEARTBEAT_PULSE:';
+    if (!entityId?.startsWith(prefix)) return null;
+
+    const body      = entityId.slice(prefix.length);
+    const separator = body.lastIndexOf(':');
+    if (separator <= 0 || separator === body.length - 1) return null;
+
+    return {
+        targetIdentity: body.slice(0, separator),
+        pulseId       : body.slice(separator + 1)
+    };
 }
 
 
@@ -427,6 +459,8 @@ function queueEvent(subscription, eventPayload) {
             return existing.taskId === eventPayload.taskId && existing.newState === eventPayload.newState;
         } else if (eventPayload.type === 'permission') {
             return existing.scope === eventPayload.scope && existing.grantedBy === eventPayload.grantedBy;
+        } else if (eventPayload.type === 'heartbeat') {
+            return existing.pulseId === eventPayload.pulseId;
         }
         return false;
     });
@@ -509,11 +543,12 @@ async function flushSubscription(subId) {
     const N = queue.length;
     const identity = subscription.properties?.agentIdentity;
 
-    let messages = [], tasks = [], permissions = [];
+    let messages = [], tasks = [], permissions = [], heartbeats = [];
     for (const ev of queue) {
         if (ev.type === 'message') messages.push(ev);
         else if (ev.type === 'task') tasks.push(ev);
         else if (ev.type === 'permission') permissions.push(ev);
+        else if (ev.type === 'heartbeat') heartbeats.push(ev);
     }
 
     let breakdown = '';
@@ -532,6 +567,10 @@ async function flushSubscription(subId) {
     if (permissions.length > 0) {
         const latest = permissions[permissions.length - 1];
         breakdown += `\n- ${permissions.length} permissions granted (latest: ${latest.scope} by ${latest.grantedBy})`;
+    }
+    if (heartbeats.length > 0) {
+        const latest = heartbeats[heartbeats.length - 1];
+        breakdown += `\n- ${heartbeats.length} heartbeat pulses (latest GraphLog: ${latest.logId})`;
     }
 
     const digest = `[WAKE][priority:${digestPriority}] ${N} events for ${identity}: ${breakdown}\n\nSubscription: ${subId}`;

--- a/ai/services/memory-core/WakeSubscriptionService.mjs
+++ b/ai/services/memory-core/WakeSubscriptionService.mjs
@@ -44,7 +44,19 @@ class WakeSubscriptionService extends Base {
      * @member {String[]} validTriggers
      * @protected
      */
-    validTriggers = ['SENT_TO_ME', 'TASK_STATE_CHANGED', 'PERMISSION_GRANTED']
+    validTriggers = ['SENT_TO_ME', 'TASK_STATE_CHANGED', 'PERMISSION_GRANTED', 'HEARTBEAT_PULSE']
+
+    /**
+     * @member {String} heartbeatPulseEntityType='heartbeat_pulse'
+     * @protected
+     */
+    heartbeatPulseEntityType = 'heartbeat_pulse'
+
+    /**
+     * @member {String} heartbeatPulseEntityPrefix='HEARTBEAT_PULSE'
+     * @protected
+     */
+    heartbeatPulseEntityPrefix = 'HEARTBEAT_PULSE'
 
     /**
      * @member {String[]} validHarnessTargets
@@ -593,6 +605,51 @@ class WakeSubscriptionService extends Base {
     }
 
     /**
+     * @summary Emits a durable GraphLog-only heartbeat pulse for an active bridge-daemon route.
+     *
+     * Heartbeat pulses are interrupt transport hints, not mailbox content. The pulse writes only a
+     * tagged `GraphLog` row, never a `MESSAGE` node or `SENT_TO` edge, so it is replayable by
+     * `resync()` and bridge-daemon tailing without surfacing in inbox listings.
+     *
+     * @param {Object} opts
+     * @param {String} opts.targetIdentity AgentIdentity node id that should receive the pulse.
+     * @returns {Promise<Object>} Emission status and optional `logId`.
+     */
+    async emitHeartbeatPulse({targetIdentity} = {}) {
+        if (!targetIdentity) throw new Error("Missing 'targetIdentity' parameter.");
+
+        const activeRoutes = this._getCandidateSubscriptions(targetIdentity, 'HEARTBEAT_PULSE', 'bridge-daemon')
+            .filter(subscription => (subscription.status || 'active') === 'active');
+
+        if (activeRoutes.length === 0) {
+            logger.info(`[WakeSubscription] heartbeat pulse skipped for ${targetIdentity}: no active bridge-daemon heartbeat subscription.`);
+            return {
+                status: 'skipped',
+                reason: 'no-active-bridge-daemon-subscription',
+                targetIdentity
+            };
+        }
+
+        const sqlite = GraphService.db?.storage?.db;
+        if (!sqlite?.prepare) {
+            throw new Error('Cannot emit heartbeat pulse: GraphLog storage unavailable.');
+        }
+
+        const entityId = this._createHeartbeatPulseEntityId(targetIdentity);
+        sqlite.prepare('INSERT INTO GraphLog(entity_id, entity_type) VALUES (?, ?)').run(entityId, this.heartbeatPulseEntityType);
+
+        const logId = this._getEntityLogId(entityId);
+        logger.info(`[WakeSubscription] emitted heartbeat pulse for ${targetIdentity} at GraphLog ${logId}.`);
+
+        return {
+            status: 'emitted',
+            targetIdentity,
+            entityId,
+            logId
+        };
+    }
+
+    /**
      * Replays GraphLog deltas matching the subscription's current trigger+filter spec,
      * starting from `sinceLogId`. Returns the matching event payloads as data; the
      * channel-specific re-emission (MCP notifications / webhook POST / daemon dispatch)
@@ -637,6 +694,10 @@ class WakeSubscriptionService extends Base {
             const matched = this._evaluateNodeAgainstSubscription(nodeId, subscription, logId);
             if (matched) events.push(matched);
         }
+        for (const pulseTrace of this._getHeartbeatPulseLogEntries(sinceLogId)) {
+            const matched = this._evaluateHeartbeatPulseAgainstSubscription(pulseTrace, subscription);
+            if (matched) events.push(matched);
+        }
 
         return {
             subscriptionId,
@@ -658,6 +719,25 @@ class WakeSubscriptionService extends Base {
             const row = GraphService.db.storage.db.prepare('SELECT MAX(log_id) as maxId FROM GraphLog WHERE entity_id = ?').get(entityId);
             return row?.maxId || null;
         } catch (e) { return null; }
+    }
+
+    /**
+     * Reads heartbeat pulse GraphLog rows after a cursor.
+     * @protected
+     * @param {Number} sinceLogId Client watermark.
+     * @returns {Object[]} GraphLog heartbeat pulse rows.
+     */
+    _getHeartbeatPulseLogEntries(sinceLogId) {
+        const sqlite = GraphService.db?.storage?.db;
+        if (!sqlite?.prepare) return [];
+
+        return sqlite.prepare(`
+            SELECT log_id, entity_id, entity_type
+            FROM GraphLog
+            WHERE log_id > ?
+              AND entity_type = ?
+            ORDER BY log_id ASC
+        `).all(sinceLogId, this.heartbeatPulseEntityType);
     }
 
     /**
@@ -733,6 +813,26 @@ class WakeSubscriptionService extends Base {
     }
 
     /**
+     * Evaluates a GraphLog-only heartbeat pulse against a subscription.
+     * @protected
+     * @param {Object} trace GraphLog heartbeat pulse row.
+     * @param {Object} subscription The cached WAKE_SUBSCRIPTION entry.
+     * @returns {Object|null} Wrapped heartbeat-pulse event or null.
+     */
+    _evaluateHeartbeatPulseAgainstSubscription(trace, subscription) {
+        if (subscription.trigger !== 'HEARTBEAT_PULSE') return null;
+        if (trace.entity_type !== this.heartbeatPulseEntityType) return null;
+
+        const pulse = this._parseHeartbeatPulseEntityId(trace.entity_id);
+        if (!pulse || pulse.targetIdentity !== subscription.agentIdentity) return null;
+
+        return this._wrapEvent('wake/heartbeat_pulse', subscription, {
+            targetIdentity: pulse.targetIdentity,
+            pulseId       : pulse.pulseId
+        }, trace.log_id);
+    }
+
+    /**
      * Builds the wake/sent_to_me payload from a MESSAGE node.
      * @protected
      * @param {Object} messageNode Graph node with `properties` (from / subject / priority / taggedConcepts / inReplyTo / to)
@@ -754,7 +854,7 @@ class WakeSubscriptionService extends Base {
     /**
      * Wraps a payload in the standard wake notification envelope per ADR 0002 §6.1.1-§6.1.3.
      * @protected
-     * @param {String} eventType One of `wake/sent_to_me`, `wake/task_state_changed`, `wake/permission_granted`
+     * @param {String} eventType One of `wake/sent_to_me`, `wake/task_state_changed`, `wake/permission_granted`, `wake/heartbeat_pulse`
      * @param {Object} subscription Cached WAKE_SUBSCRIPTION entry (provides `id` + `agentIdentity`)
      * @param {Object} payload Trigger-specific inner payload built by the matching `_build*Payload` helper
      * @param {String|Number} logIdAnchor GraphLog `log_id` anchor preserved across re-emissions for cursor-based catchup
@@ -770,6 +870,36 @@ class WakeSubscriptionService extends Base {
             subscriptionId: subscription.id,
             payload,
             emittedAt     : new Date().toISOString()
+        };
+    }
+
+    /**
+     * Creates the stable GraphLog entity id for a heartbeat pulse.
+     * @protected
+     * @param {String} targetIdentity AgentIdentity node id.
+     * @returns {String} Encoded heartbeat pulse entity id.
+     */
+    _createHeartbeatPulseEntityId(targetIdentity) {
+        return `${this.heartbeatPulseEntityPrefix}:${targetIdentity}:${crypto.randomUUID()}`;
+    }
+
+    /**
+     * Parses a heartbeat pulse GraphLog entity id.
+     * @protected
+     * @param {String} entityId Encoded heartbeat pulse entity id.
+     * @returns {{targetIdentity:String,pulseId:String}|null} Parsed pulse identity.
+     */
+    _parseHeartbeatPulseEntityId(entityId) {
+        const prefix = `${this.heartbeatPulseEntityPrefix}:`;
+        if (!entityId?.startsWith(prefix)) return null;
+
+        const body      = entityId.slice(prefix.length);
+        const separator = body.lastIndexOf(':');
+        if (separator <= 0 || separator === body.length - 1) return null;
+
+        return {
+            targetIdentity: body.slice(0, separator),
+            pulseId       : body.slice(separator + 1)
         };
     }
 

--- a/learn/agentos/decisions/0002-phase3-wake-substrate-standards-alignment.md
+++ b/learn/agentos/decisions/0002-phase3-wake-substrate-standards-alignment.md
@@ -422,7 +422,10 @@ by Shape C bridge daemon.
 
 - Each wake event carries `logId` (the originating `GraphLog.log_id` of the
   substrate mutation that triggered it) plus `eventId` (a ULID unique per
-  emission). See §6.1.1-6.1.3 payloads.
+  emission). See §6.1.1-6.1.3 payloads. Shape B heartbeat pulses use the
+  same watermark contract through an explicit `heartbeat_pulse` GraphLog row:
+  no `MESSAGE` node and no `SENT_TO` edge are created, so reconnect replay can
+  wake the bridge daemon without adding inbox-visible content.
 - Client persists `lastSeenLogId` per subscription — typically in
   harness-local state alongside the subscription ID. The persistence
   granularity is the client's call: per-event commit (most durable, more

--- a/test/playwright/unit/ai/daemons/bridge/daemon.spec.mjs
+++ b/test/playwright/unit/ai/daemons/bridge/daemon.spec.mjs
@@ -158,6 +158,63 @@ test.describe('Bridge Daemon', () => {
         expect(logContents).toContain('[Bridge Daemon Test Adapter] Delivered');          // Same delivery line as stdout
     });
 
+    test('delivers GraphLog-only heartbeat pulses via test adapter', async () => {
+        const subId = 'sub_' + crypto.randomUUID();
+        const agentId = '@test-agent-heartbeat';
+
+        db.prepare('INSERT OR REPLACE INTO Nodes (id, data) VALUES (?, ?)').run(agentId, JSON.stringify({
+            id: agentId,
+            label: 'AGENT',
+            properties: { name: 'Test Agent Heartbeat' }
+        }));
+
+        db.prepare('INSERT OR REPLACE INTO Nodes (id, data) VALUES (?, ?)').run(subId, JSON.stringify({
+            id: subId,
+            label: 'WAKE_SUBSCRIPTION',
+            properties: {
+                agentIdentity: agentId,
+                harnessTarget: 'bridge-daemon',
+                status: 'active',
+                trigger: 'HEARTBEAT_PULSE',
+                harnessTargetMetadata: {
+                    adapter: 'test',
+                    coalesceWindow: 1
+                }
+            }
+        }));
+
+        db.prepare('INSERT INTO GraphLog (entity_id, entity_type) VALUES (?, ?)').run(subId, 'nodes');
+
+        daemonProcess = spawn('node', ['ai/daemons/bridge/daemon.mjs'], {
+            stdio: 'pipe',
+            env: { ...process.env, NEO_AI_DB_PATH: DB_PATH, NEO_AI_DAEMON_DIR: DAEMON_DIR }
+        });
+
+        const deliveryPromise = new Promise((resolve, reject) => {
+            const timeout = setTimeout(() => reject(new Error('Daemon failed to deliver heartbeat pulse within timeout')), 10000);
+
+            daemonProcess.stdout.on('data', (data) => {
+                const out = data.toString();
+                if (out.includes('[Bridge Daemon Test Adapter] Delivered')) {
+                    clearTimeout(timeout);
+                    resolve(out);
+                }
+            });
+            daemonProcess.on('error', reject);
+        });
+
+        await new Promise(resolve => setTimeout(resolve, 1000));
+
+        const pulseId = `HEARTBEAT_PULSE:${agentId}:${crypto.randomUUID()}`;
+        db.prepare('INSERT INTO GraphLog (entity_id, entity_type) VALUES (?, ?)').run(pulseId, 'heartbeat_pulse');
+
+        const output = await deliveryPromise;
+        expect(output).toContain('[Bridge Daemon Test Adapter] Delivered');
+        expect(output).toContain('[WAKE][priority:normal]');
+        expect(output).toContain('heartbeat pulses');
+        expect(output).not.toContain('new messages');
+    });
+
     test('does not deliver wake events for wakeSuppressed mailbox-only messages', async () => {
         const subId = 'sub_' + crypto.randomUUID();
         const agentId = '@test-agent-suppressed';

--- a/test/playwright/unit/ai/services/memory-core/WakeSubscriptionService.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/WakeSubscriptionService.spec.mjs
@@ -949,6 +949,69 @@ test.describe('Neo.ai.services.memory-core.WakeSubscriptionService', () => {
             expect(res.eventsReplayed).toBe(0);
         });
     });
+
+    test('emitHeartbeatPulse writes only a heartbeat GraphLog row and replays through resync', async () => {
+        const sqlite = GraphService.db.storage.db;
+        const {subscriptionId} = insertDurableSubscription({
+            trigger              : 'HEARTBEAT_PULSE',
+            harnessTarget        : 'bridge-daemon',
+            harnessTargetMetadata: {appName: 'Codex'}
+        });
+        const before = sqlite.prepare('SELECT MAX(log_id) as maxId FROM GraphLog').get().maxId || 0;
+
+        const emitted = await WakeSubscriptionService.emitHeartbeatPulse({targetIdentity: '@alice'});
+
+        expect(emitted.status).toBe('emitted');
+        expect(emitted.targetIdentity).toBe('@alice');
+        expect(emitted.entityId).toMatch(/^HEARTBEAT_PULSE:@alice:/);
+        expect(emitted.logId).toBeGreaterThan(before);
+
+        const messageRows = sqlite.prepare(`
+            SELECT COUNT(*) as count
+            FROM Nodes
+            WHERE json_extract(data, '$.label') = 'MESSAGE'
+        `).get().count;
+        const sentToRows = sqlite.prepare("SELECT COUNT(*) as count FROM Edges WHERE type = 'SENT_TO'").get().count;
+        expect(messageRows).toBe(0);
+        expect(sentToRows).toBe(0);
+
+        await RequestContextService.run({agentIdentityNodeId: '@alice'}, async () => {
+            const res = await WakeSubscriptionService.resync({subscriptionId, sinceLogId: before});
+
+            expect(res.subscriptionId).toBe(subscriptionId);
+            expect(res.eventsReplayed).toBe(1);
+            expect(res.lastLogId).toBe(emitted.logId);
+            expect(res.events[0]).toMatchObject({
+                eventType    : 'wake/heartbeat_pulse',
+                logId        : emitted.logId,
+                agentIdentity: '@alice',
+                subscriptionId,
+                payload      : {
+                    targetIdentity: '@alice'
+                }
+            });
+        });
+    });
+
+    test('emitHeartbeatPulse is an idempotent no-op without an active bridge heartbeat subscription', async () => {
+        const sqlite = GraphService.db.storage.db;
+        const before = sqlite.prepare('SELECT MAX(log_id) as maxId FROM GraphLog').get().maxId || 0;
+
+        const emitted = await WakeSubscriptionService.emitHeartbeatPulse({targetIdentity: '@alice'});
+        const pulseRows = sqlite.prepare(`
+            SELECT COUNT(*) as count
+            FROM GraphLog
+            WHERE log_id > ?
+              AND entity_type = 'heartbeat_pulse'
+        `).get(before).count;
+
+        expect(emitted).toEqual({
+            status        : 'skipped',
+            reason        : 'no-active-bridge-daemon-subscription',
+            targetIdentity: '@alice'
+        });
+        expect(pulseRows).toBe(0);
+    });
     // -----------------------------------------------------------------------------
     // pump()
     // -----------------------------------------------------------------------------


### PR DESCRIPTION
Resolves #11994
Related: #11993

Authored by GPT-5.5 (Codex Desktop). Session 019e5bac-15f3-7830-a59c-72772c757f9a.

FAIR-band: over-target [14/30] - taking this lane despite over-target because the operator/peer lane split assigned #11994 to @neo-gpt, and this sub is the dependency-gating Shape B primitive for Epic #11993 before #11996 can remove legacy heartbeat paths.

Adds the Shape B heartbeat pulse primitive: `WakeSubscriptionService.emitHeartbeatPulse({targetIdentity})` now emits a GraphLog-only `heartbeat_pulse` row for active bridge-daemon heartbeat subscriptions. The pulse replays through `resync()` as `wake/heartbeat_pulse`, bridge-daemon tailing can dispatch it through the existing adapter queue, and no `MESSAGE` node or `SENT_TO` edge is created.

Evidence: L2 (Memory Core SQLite GraphLog replay + spawned bridge-daemon test adapter) -> L2 required (Sub-i service/daemon contract). No residuals.

## Signal Ledger

| Family | Identity | Signal | Anchor |
|---|---|---|---|
| anthropic | @neo-opus-4-7 | `[AUTHOR_SIGNAL]` - Discussion #11992 cycle-3 body `2026-05-25T20:50:21Z` | https://github.com/orgs/neomjs/discussions/11992 |
| openai | @neo-gpt | `[GRADUATION_APPROVED]` - Discussion #11992 cycle-3 body `2026-05-25T20:50:21Z` | https://github.com/neomjs/neo/discussions/11992#discussioncomment-17054029 |
| google | @neo-gemini-3-1-pro | operator-benched per @tobiu 2026-05-25 | Epic #11993 `Unresolved Liveness` |

## Unresolved Dissent

| Family | Identity | Concern | Disposition |
|---|---|---|---|
| openai | @neo-gpt | Cycle-1 Shape A-first graduation, `fresh` signal validity, backoff location | Yielded by Discussion #11992 cycle-3. Final cycle-3 signal was APPROVED. |
| anthropic | @neo-opus-4-7 | Cycle-2 Shape-A-as-fallback hedge | Yielded cycle-3 after operator pushback. Shape A was removed from the accepted path. |

## Unresolved Liveness

| Family | Identity | Disposition |
|---|---|---|
| google | @neo-gemini-3-1-pro | Operator-benched. Graduation completed with Anthropic-author + OpenAI-non-author quorum per #11993. Tier-1 substrate, no revalidationTrigger AC required. |

## Deltas from ticket

- Kept the implementation to Sub-i only: no 3-signal derivation, no readiness parser, no orchestrator backoff state, and no legacy tmux/Shape A cleanup.
- Used a dedicated `HEARTBEAT_PULSE` trigger plus encoded GraphLog entity id (`HEARTBEAT_PULSE:<identity>:<uuid>`) so the event remains replayable without durable mailbox artifacts.
- Updated ADR 0002 §6.1.6 to make the ephemeral GraphLog heartbeat semantic explicit.

## Slot Rationale

Decision Record impact: amends ADR 0002 §6.1.6.

Modified section: `learn/agentos/decisions/0002-phase3-wake-substrate-standards-alignment.md` §6.1.6.

Disposition delta: keep -> keep. The section already owns dropped-connection and GraphLog watermark semantics; this edit narrows future interpretation by documenting that heartbeat pulses are GraphLog-only and not mailbox content.

3-axis rating: trigger-frequency high (wake substrate and reconnect semantics are core runtime behavior), failure-severity high (wrong interpretation recreates mailbox spam or untracked wake loss), enforceability medium (unit coverage validates service and bridge behavior; post-merge end-to-end Codex wake remains an Epic-level validation).

## Test Evidence

- `node --check ai/services/memory-core/WakeSubscriptionService.mjs` - passed
- `node --check ai/daemons/bridge/daemon.mjs` - passed
- `npm run test-unit -- test/playwright/unit/ai/services/memory-core/WakeSubscriptionService.spec.mjs` - 44 passed after rebase; existing cleanup warning about Chroma collection deletion remained post-run
- `npm run test-unit -- test/playwright/unit/ai/daemons/bridge/daemon.spec.mjs` - 14 passed after rebase when run outside sandbox; the sandboxed run failed before assertions because `.neo-ai-data/sqlite` is a symlink outside the writable sandbox
- `git diff --check` - passed

## Post-Merge Validation

- [ ] #11995 can consume `HEARTBEAT_PULSE` without adding Shape A mailbox semantics.
- [ ] #11996 can remove tmux-inject and Shape A mailbox heartbeat paths after #11994 and #11995 are both merged.

## Commits

- `92197cde4` - `feat(ai): add heartbeat pulse wake event (#11994)`
