### PR TITLE
feat(memory-core): filter summary queries by trust tier (#10292)

### DIFF
--- a/ai/mcp/server/memory-core/openapi.yaml
+++ b/ai/mcp/server/memory-core/openapi.yaml
@@ -2031,6 +2031,20 @@ components:
           items:
             type: string
           example: ["gemini-3.1-pro", "gemma4"]
+        sourceAgentIdentities:
+          type: array
+          items:
+            type: string
+          description: AgentIdentity node ids found on source memories when summary provenance is available.
+          example: ["@neo-gpt"]
+        sourceTrustTier:
+          type: string
+          enum: [system, repo-trusted, owner, self, peer-trusted, internal-authored, external, unclassified]
+          description: Most restrictive source-memory trust tier for this derived summary.
+        provenancePolicy:
+          type: string
+          description: Summary provenance composition policy.
+          example: "most-restrictive-source"
 
     QuerySummariesRequest:
       type: object
@@ -2055,6 +2069,10 @@ components:
           type: string
           enum: [private, team, legacy]
           description: Optional override for the memory sharing tenant isolation scope.
+        minTrustTier:
+          type: string
+          enum: [system, repo-trusted, owner, self, peer-trusted, internal-authored, external, unclassified]
+          description: Optional minimum accepted #10292 source-provenance trust tier. Summaries derived from lower-trust or unclassified source memories are excluded.
 
     QuerySummariesResponse:
       type: object

--- a/ai/services/memory-core/SummaryService.mjs
+++ b/ai/services/memory-core/SummaryService.mjs
@@ -3,6 +3,7 @@ import Base                  from '../../../src/core/Base.mjs';
 import StorageRouter         from './managers/StorageRouter.mjs';
 import logger                from '../../mcp/server/memory-core/logger.mjs';
 import RequestContextService, {SHARED_USER_ID, normalizeUserId} from '../../mcp/server/shared/services/RequestContextService.mjs';
+import {TRUST_TIERS, TRUST_TIER_ORDER} from '../../graph/identityRoots.mjs';
 
 /**
  * @summary Service for handling deleting, listing, and querying session summaries.
@@ -36,6 +37,8 @@ class SummaryService extends Base {
         singleton: true
     }
 
+    static trustTierRanks = new Map(TRUST_TIER_ORDER.map((tier, index) => [tier, index]))
+
     /**
      * @summary Converts comma-delimited Chroma metadata fields into stable result arrays.
      * @param {String|undefined} value Metadata value.
@@ -43,6 +46,35 @@ class SummaryService extends Base {
      */
     static splitMetadataList(value) {
         return value ? String(value).split(',').map(item => item.trim()).filter(Boolean) : [];
+    }
+
+    /**
+     * @summary Resolves a summary row's provenance trust tier from source-memory metadata.
+     *
+     * Summaries are derived content. Their filterable tier is the most restrictive source tier
+     * stamped by `SessionService`, not the summarizing agent identity.
+     *
+     * @param {Object} metadata Chroma summary metadata row.
+     * @returns {String} Trust tier, or `unclassified` for pre-provenance summaries.
+     */
+    static resolveSummaryTrustTier(metadata) {
+        return this.trustTierRanks.has(metadata?.sourceTrustTier)
+            ? metadata.sourceTrustTier
+            : TRUST_TIERS.UNCLASSIFIED;
+    }
+
+    /**
+     * @summary Returns true when a summary row satisfies the optional minimum trust threshold.
+     * @param {Object} metadata Chroma summary metadata row.
+     * @param {String|undefined} minTrustTier Optional minimum accepted trust tier.
+     * @returns {Boolean}
+     */
+    static matchesMinTrustTier(metadata, minTrustTier) {
+        if (!minTrustTier) {
+            return true;
+        }
+
+        return this.trustTierRanks.get(this.resolveSummaryTrustTier(metadata)) <= this.trustTierRanks.get(minTrustTier);
     }
 
     /**
@@ -260,10 +292,19 @@ class SummaryService extends Base {
      * @param {Number} options.nResults      The number of results to return.
      * @param {String} [options.category]    Optional category to filter results.
      * @param {String} [options.memorySharing] Optional override for tenant isolation policy.
+     * @param {String} [options.minTrustTier] Optional minimum accepted source trust tier.
      * @returns {Promise<{query: string, count: number, results: Object[]}>}
      */
-    async querySummaries({query, nResults, category, memorySharing}) {
+    async querySummaries({query, nResults, category, memorySharing, minTrustTier}) {
         try {
+            if (minTrustTier && !this.constructor.trustTierRanks.has(minTrustTier)) {
+                return {
+                    error  : 'Invalid minTrustTier',
+                    message: `minTrustTier must be one of: ${TRUST_TIER_ORDER.join(', ')}`,
+                    code   : 'SUMMARY_QUERY_INVALID_TRUST_TIER'
+                };
+            }
+
             const collection = await StorageRouter.getSummaryCollection();
             const queryArgs = {
                 queryTexts: [query],
@@ -291,7 +332,7 @@ class SummaryService extends Base {
                 }
             }
 
-            if (tenantScope === null && userId && policy === 'legacy') {
+            if ((tenantScope === null && userId && policy === 'legacy') || minTrustTier) {
                 queryArgs.nResults = nResults * 5;
             }
 
@@ -310,11 +351,14 @@ class SummaryService extends Base {
             let metadatas = searchResult.metadatas?.[0] || [];
             let documents = searchResult.documents?.[0] || [];
 
-            if (userId && policy === 'legacy') {
+            if ((userId && policy === 'legacy') || minTrustTier) {
                 const filteredIndices = [];
                 for (let i = 0; i < metadatas.length; i++) {
                     const metaUserId = metadatas[i]?.userId;
-                    if (!metaUserId || metaUserId === userId || metaUserId === SHARED_USER_ID) {
+                    const tenantMatch = !userId || policy !== 'legacy' || !metaUserId || metaUserId === userId || metaUserId === SHARED_USER_ID;
+                    const trustMatch  = this.constructor.matchesMinTrustTier(metadatas[i], minTrustTier);
+
+                    if (tenantMatch && trustMatch) {
                         filteredIndices.push(i);
                         if (filteredIndices.length === nResults) break;
                     }

--- a/test/playwright/unit/ai/services/memory-core/SummaryService.TenantIsolation.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/SummaryService.TenantIsolation.spec.mjs
@@ -393,3 +393,77 @@ test.describe('SummaryService — memorySharing policy (#10010)', () => {
         expect(queryCall.where).toBeUndefined();
     });
 });
+
+test.describe('SummaryService — provenance trust filtering (#10292)', () => {
+    let spy;
+    let originalGetSummaryCollection;
+
+    test.beforeEach(() => {
+        spy = createSpyCollection();
+        originalGetSummaryCollection = StorageRouter.getSummaryCollection;
+        StorageRouter.getSummaryCollection = async () => spy;
+    });
+
+    test.afterEach(() => {
+        StorageRouter.getSummaryCollection = originalGetSummaryCollection;
+    });
+
+    test('querySummaries filters by minTrustTier and returns provenance fields', async () => {
+        spy.rows.set('s-owner', {
+            id      : 's-owner',
+            metadata: {timestamp: 100, title: 'owner', sourceTrustTier: 'owner', sourceAgentIdentities: '@tobiu', provenancePolicy: 'most-restrictive-source'},
+            document: 'owner'
+        });
+        spy.rows.set('s-peer', {
+            id      : 's-peer',
+            metadata: {timestamp: 200, title: 'peer', sourceTrustTier: 'peer-trusted', sourceAgentIdentities: '@neo-gpt', provenancePolicy: 'most-restrictive-source'},
+            document: 'peer'
+        });
+        spy.rows.set('s-external', {
+            id      : 's-external',
+            metadata: {timestamp: 300, title: 'external', sourceTrustTier: 'external', sourceAgentIdentities: '@external', provenancePolicy: 'most-restrictive-source'},
+            document: 'external'
+        });
+        spy.rows.set('s-legacy', {
+            id      : 's-legacy',
+            metadata: {timestamp: 400, title: 'legacy'},
+            document: 'legacy'
+        });
+
+        const view = await SummaryService.querySummaries({
+            query       : 'anything',
+            nResults    : 10,
+            minTrustTier: 'peer-trusted'
+        });
+
+        expect(view.count).toBe(2);
+        expect(view.results.map(r => r.title)).toEqual(['owner', 'peer']);
+        expect(view.results[0]).toMatchObject({
+            sourceAgentIdentities: ['@tobiu'],
+            sourceTrustTier      : 'owner',
+            provenancePolicy     : 'most-restrictive-source'
+        });
+        expect(view.results[1]).toMatchObject({
+            sourceAgentIdentities: ['@neo-gpt'],
+            sourceTrustTier      : 'peer-trusted',
+            provenancePolicy     : 'most-restrictive-source'
+        });
+
+        const queryCall = spy.calls.query.at(-1);
+        expect(queryCall.nResults).toBe(50);
+    });
+
+    test('querySummaries rejects unknown minTrustTier before querying storage', async () => {
+        const result = await SummaryService.querySummaries({
+            query       : 'anything',
+            nResults    : 10,
+            minTrustTier: 'trusted-ish'
+        });
+
+        expect(result).toMatchObject({
+            error: 'Invalid minTrustTier',
+            code : 'SUMMARY_QUERY_INVALID_TRUST_TIER'
+        });
+        expect(spy.calls.query).toHaveLength(0);
+    });
+});


### PR DESCRIPTION
Authored by GPT-5 (Codex Desktop). Session 3b454ac4-f2c6-4bf0-9c18-c0af6f432ffa.

FAIR-band: over-target [15/30] — taking this lane despite over-target because #10292 is an assigned cloud-phase blocker, prior slices #11979/#11980 already narrowed the remaining query-path gap, and this PR closes one old-ticket AC surface without creating a new ticket.

Evidence: L2 (focused service unit coverage + OpenAPI/schema syntax checks) → L2 required for `query_summaries` tool contract and SummaryService post-filter logic. Residual: `get_context_frontier` trust weighting and durable forward-only migration docs [#10292].

Refs #10292

## Summary

Adds the summary-query half of #10292 `minTrustTier` filtering. `query_summaries` now accepts an optional `minTrustTier`, validates it against the seeded AgentIdentity trust taxonomy, post-filters summary rows by their `sourceTrustTier`, and keeps pre-provenance / missing-tier summaries safely classified as `unclassified`.

This builds directly on the already-merged #10292 slices:

- PR #11979 — summary provenance stamping (`sourceTrustTier`, `sourceAgentIdentities`, `provenancePolicy`)
- PR #11980 — raw-memory `query_raw_memories({minTrustTier})`

## Deltas From Ticket

- This is a narrow query-path slice only, not full #10292 closeout.
- `SummaryService.querySummaries()` now mirrors the raw-memory trust filter shape from `MemoryService.queryMemories()`.
- The Memory Core OpenAPI schema now exposes `minTrustTier` for `QuerySummariesRequest` and documents summary provenance result fields.
- Invalid trust tiers return `SUMMARY_QUERY_INVALID_TRUST_TIER` before the summary collection is queried.

## Contract Ledger

| Surface | Contract |
|---|---|
| `query_summaries({minTrustTier})` | Optional trust threshold. Rows with `sourceTrustTier` below the threshold, unknown tier, or missing provenance are excluded. |
| `SummaryService.resolveSummaryTrustTier()` | Uses summary `sourceTrustTier`; missing/unknown values resolve to `unclassified`. |
| `SummarySearchResult` / `Summary` schema | Exposes `sourceAgentIdentities`, `sourceTrustTier`, and `provenancePolicy` already returned by the service. |

## Test Evidence

- `node --check ai/services/memory-core/SummaryService.mjs`
- `npm run test-unit -- test/playwright/unit/ai/services/memory-core/SummaryService.TenantIsolation.spec.mjs` — 16/16 passed
- `node --input-type=module -e "const fs=await import('node:fs'); const yaml=await import('yaml'); yaml.parse(fs.readFileSync('ai/mcp/server/memory-core/openapi.yaml','utf8')); console.log('openapi yaml parse ok');"` — passed
- `npm run test-unit -- test/playwright/unit/ai/mcp/server/memory-core/McpServerToolLimits.spec.mjs` — 3/3 passed
- `git diff --check`
- `git diff --cached --check`
- Pre-push freshness: `merge-base HEAD origin/dev == origin/dev`; outgoing log contained only `5dc715fdb feat(memory-core): filter summary queries by trust tier (#10292)`.

## Post-Merge Validation

- [ ] Verify `query_summaries({query, minTrustTier: 'peer-trusted'})` excludes pre-provenance / lower-trust summaries in a live Memory Core deployment.
- [ ] Keep #10292 open for `get_context_frontier` trust weighting and durable forward-only migration documentation.

## Commit

- `5dc715fdb` — `feat(memory-core): filter summary queries by trust tier (#10292)`
