### PR TITLE
feat(test-fixtures): add KB_DEFAULTS + migrate SourcePathsConfig drift-vulnerable assertion (#11981)

### DIFF
--- a/test/playwright/fixtures/knowledgeBaseConfigDefaults.mjs
+++ b/test/playwright/fixtures/knowledgeBaseConfigDefaults.mjs
@@ -1,0 +1,114 @@
+import path            from 'path';
+import {fileURLToPath} from 'url';
+import Neo             from '../../../src/Neo.mjs';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname  = path.dirname(__filename);
+const neoRootDir = path.resolve(__dirname, '../../..');
+
+/**
+ * @module test/playwright/fixtures/knowledgeBaseConfigDefaults
+ * @summary Deterministic Knowledge Base per-server config defaults for test assertions.
+ *
+ * Sub-2 of #11976 — per-server fixture establishing the Sub-1 (#11977/#11978)
+ * pattern at the per-server (KB) tier. Tests asserting on canonical
+ * KB-template-defined values (`sourcePaths`, `collectionName`, `path`, etc.)
+ * should compare against {@link KB_DEFAULTS} rather than reading from the live
+ * `ai/mcp/server/knowledge-base/config.mjs` overlay or the live overlay-merged
+ * template singleton. The overlay is gitignored and operator-customized;
+ * runtime-singleton reads are not deterministic across deployments.
+ *
+ * **Per-server vs Tier-1 boundary:**
+ * - {@link KB_DEFAULTS} mirrors only KB-template-defined fields (those declared
+ *   inline in `knowledge-base/config.template.mjs` `defaultConfig`).
+ * - Tier-1 fields (`auth`, `engines.chroma.host/port`, `modelProvider`, etc.)
+ *   that the KB template imports via `AiConfig.X` references are intentionally
+ *   NOT mirrored here — assertions on those fields should use
+ *   `TIER1_DEFAULTS` from `aiConfigDefaults.mjs` instead. Mixing them would
+ *   create a second source of truth and reintroduce the drift this fixture
+ *   exists to prevent.
+ *
+ * **Determinism contract:**
+ * - Inlined from the KB template's canonical default values, not imported.
+ *   Importing `ai/mcp/server/knowledge-base/config.template.mjs` would register
+ *   `Neo.ai.mcp.server.knowledge-base.Config` at fixture-import time, which
+ *   can collide with specs that override the singleton via per-test `delete`/
+ *   restore patterns (e.g., `SourcePathsConfig.spec.mjs`). Plain-data inline
+ *   sidesteps the class-registration ordering hazard, matching Sub-1's
+ *   `aiConfigDefaults.mjs` pattern.
+ * - Deep-cloned via `Neo.clone(obj, true, true)` (Neo's canonical deep-clone
+ *   primitive) and recursively frozen via the local `deepFreeze` helper.
+ *   Nested groups (`sourcePaths.ApiSource`, etc.) hold no shared references
+ *   with any live config singleton.
+ *
+ * @see test/playwright/fixtures/aiConfigDefaults.mjs — Tier-1 sibling
+ * @see ai/mcp/server/knowledge-base/config.template.mjs — KB-template source of truth
+ */
+
+/**
+ * Recursively freezes every plain-object / array node in the given value.
+ * Returns the same value for chaining. No-op on primitives + functions.
+ *
+ * Local to this fixture for the same reason as `aiConfigDefaults.mjs`: Neo
+ * doesn't ship a recursive-freeze counterpart to `Neo.clone`. Retires when
+ * (if) a `Neo.freeze` primitive lands.
+ *
+ * @param {*} value
+ * @returns {*}
+ */
+function deepFreeze(value) {
+    if (value === null || typeof value !== 'object') return value;
+    Object.values(value).forEach(deepFreeze);
+    return Object.freeze(value);
+}
+
+/**
+ * Deep-frozen snapshot of KB-template-defined default values. Use for
+ * deterministic assertions in tests that would otherwise read the live
+ * overlay-merged KB config singleton.
+ *
+ * Includes the KB-template-specific fields most commonly asserted on. For
+ * Tier-1 fields the template imports via `AiConfig.X`, use `TIER1_DEFAULTS`
+ * from `aiConfigDefaults.mjs` instead.
+ *
+ * @type {Readonly<Object>}
+ */
+export const KB_DEFAULTS = deepFreeze(Neo.clone({
+    sourcePaths: {
+        AdrSource         : 'learn/agentos/decisions',
+        ConceptSource     : 'resources/content/concepts',
+        ReleaseNotesSource: '.github/RELEASE_NOTES',
+        SkillSource       : '.agents/skills',
+        TestSource        : 'test/playwright',
+        LearningSource    : 'learn/tree.json',
+        DiscussionSource  : ['resources/content/discussions', 'resources/content/archive/discussions'],
+        PullRequestSource : ['resources/content/pulls',       'resources/content/archive/pulls'],
+        TicketSource      : ['resources/content/issues',      'resources/content/archive/issues'],
+        ApiSource         : {
+            'src'     : 'src',
+            'apps'    : 'app',
+            'examples': 'example',
+            'docs/app': 'app',
+            'ai'      : 'ai-infrastructure'
+        }
+    },
+    collectionName    : 'neo-knowledge-base',
+    path              : path.resolve(neoRootDir, '.neo-ai-data/chroma/knowledge-base'),
+    dataPath          : path.resolve(neoRootDir, 'dist/ai-knowledge-base.jsonl'),
+    hierarchyPath     : path.resolve(neoRootDir, 'docs/output/class-hierarchy.json'),
+    logPath           : path.resolve(neoRootDir, '.neo-ai-data/logs'),
+    defaultTenantId   : 'neo-shared',
+    defaultRepoSlug   : 'neo',
+    defaultVisibility : 'team',
+    spoofRejectionMode: 'overwrite',
+    useDefaultSources : true,
+    useDefaultParsers : true,
+    batchSize         : 50,
+    batchDelay        : 10000,
+    maxRetries        : 5,
+    nResults          : 100,
+    autoSync          : false,
+    autoStartDatabase : false,
+    transport         : 'stdio',
+    mcpHttpPort       : 3000
+}, true, true));

--- a/test/playwright/unit/ai/services/knowledge-base/source/SourcePathsConfig.spec.mjs
+++ b/test/playwright/unit/ai/services/knowledge-base/source/SourcePathsConfig.spec.mjs
@@ -18,6 +18,7 @@ setup({
 import {test, expect}  from '@playwright/test';
 import Neo             from '../../../../../../../src/Neo.mjs';
 import * as core       from '../../../../../../../src/core/_export.mjs';
+import {KB_DEFAULTS}   from '../../../../../fixtures/knowledgeBaseConfigDefaults.mjs';
 import fs              from 'fs-extra';
 import path            from 'path';
 import {fileURLToPath} from 'url';
@@ -307,7 +308,11 @@ test.describe('aiConfig.sourcePaths config-driven path resolution (#11660)', () 
 
     test.describe('LearningSource — base directory derived from tree path', () => {
         test('default learn/tree.json → base directory is learn/', () => {
-            const treePath = aiConfig.sourcePaths?.LearningSource ?? 'learn/tree.json';
+            // Read from KB_DEFAULTS fixture (frozen snapshot of KB-template defaults) rather
+            // than the live overlay-merged singleton — operator-customized
+            // `sourcePaths.LearningSource` would otherwise break this canonical-default check.
+            // #11981 / Sub-2 of #11976 (1-spec drift-migration scope).
+            const treePath = KB_DEFAULTS.sourcePaths?.LearningSource ?? 'learn/tree.json';
             const basePath = path.dirname(treePath);
             expect(basePath).toBe('learn');
         });


### PR DESCRIPTION
Authored by Claude Opus 4.7 (Claude Code). Nightshift continuation after Epic #11993 wake-substrate evolution merged.

FAIR-band: under-target [6/30] — bounded Sub-2 of #11976 KB-drift Epic per ticket's V-B-A scope correction (1 spec migrated, not 18).

Evidence: L1 (36/36 PASS SourcePathsConfig.spec.mjs + 291/291 PASS broader KB suite) → L1 sufficient for fixture+test-migration scope. Residual: none.

Resolves #11981

## Summary

Sub-2 of Epic #11976 (Tests import config.mjs operator-overlay instead of config.template.mjs canonical defaults — drift risk). Adds per-server KB fixture establishing the Sub-1 (#11977/#11978) `TIER1_DEFAULTS` pattern at the per-server tier, and migrates the single drift-vulnerable assertion the ticket's V-B-A audit identified.

## Deltas

Cycle-1 body:
- New file `test/playwright/fixtures/knowledgeBaseConfigDefaults.mjs` — inlines KB-template canonical default values (sourcePaths + collectionName + path + dataPath + hierarchyPath + logPath + defaultTenantId + spoofRejectionMode + batch/retry/sync KB-specific fields) as a deep-frozen snapshot via `Neo.clone(obj, true, true)` + local `deepFreeze` helper. Mirrors `aiConfigDefaults.mjs` shape and rationale.
- Migrated 1 spec: `test/playwright/unit/ai/services/knowledge-base/source/SourcePathsConfig.spec.mjs` line 310 — LearningSource base-directory test now reads `KB_DEFAULTS.sourcePaths?.LearningSource` instead of the live overlay-merged `aiConfig.sourcePaths?.LearningSource`. Operator-customizing `sourcePaths.LearningSource` no longer breaks the canonical-default check.
- 17 other KB specs intentionally untouched — mutation/round-trip/setup-wiring patterns are drift-immune by design per the ticket's V-B-A audit.

Cycle-2 body update (addressing @neo-gpt cycle-1 CHANGES_REQUESTED, no code changes):
- Added `## Post-Merge Validation` section with AC5 operator-side smoke (template-required anchor; satisfies the `lint-pr-body` check).
- Updated #11981 ticket body to reconcile the close-target ACs with the shipped inline-frozen-fixture shape (no `KBConfig` re-export). The V-B-A divergence from the original prescription is now documented in the ticket's `## The Fix` section.

## V-B-A scope correction applied

The umbrella #11976 estimated 18 KB `config.mjs` imports as candidates. The ticket's V-B-A on actual usage found only **1 spec drift-vulnerable**: SourcePathsConfig.spec.mjs:310 `aiConfig.sourcePaths?.LearningSource` (reads live overlay → operator customizing `LearningSource` breaks the canonical 'learn' base assertion). The other 17 specs use:
- Mutation-style: `aiConfig.X = mock; ... ; aiConfig.X = original` (drift-immune via mutation-restore)
- Round-trip: `expect(collection.name).toBe(aiConfig.collectionName)` (drift-immune — round-trips overlay value through itself)
- Setup-wiring: `path.resolve(aiConfig.neoRootDir, 'tmp', ...)` (drift-immune — uses live values for setup, not as assertion targets)
- Delete-then-fallback: tests that delete `aiConfig.sourcePaths` THEN read with `??` fallback (drift-immune — explicit delete makes the fallback fire regardless of operator state)

## Architectural shape

`KB_DEFAULTS` is a deep-frozen snapshot of inlined KB-template canonical values. Inlining (rather than importing `knowledge-base/config.template.mjs` directly) sidesteps the class-registration ordering hazard explained in `aiConfigDefaults.mjs` JSDoc — importing the template registers `Neo.ai.mcp.server.knowledge-base.Config`, which collides with specs that override the singleton via per-test `delete`/restore patterns (this spec being the prime example at lines 70-82).

**Per-server vs Tier-1 boundary:** KB_DEFAULTS mirrors only KB-template-defined fields. Tier-1 fields (`auth`, `engines.chroma`, `modelProvider`, etc.) that the KB template imports via `AiConfig.X` remain assertion territory for `TIER1_DEFAULTS` from `aiConfigDefaults.mjs`. JSDoc on the fixture explicitly documents this boundary so future callers don't conflate them.

## Test Evidence

```
npm run test-unit -- test/playwright/unit/ai/services/knowledge-base/source/SourcePathsConfig.spec.mjs
```
→ **36/36 PASS (666ms)** at commit `e36493f09`.

```
npm run test-unit -- test/playwright/unit/ai/services/knowledge-base/
```
→ **291/291 PASS (3.0s)** at commit `e36493f09`. No regression in the broader KB test surface; Sub-1's worker-collision scenario from #11969 verified passing.

## ACs satisfied

- [x] AC1 — `test/playwright/fixtures/knowledgeBaseConfigDefaults.mjs` exists with `KB_DEFAULTS` export + JSDoc explaining the per-server vs Tier-1 boundary
- [x] AC2 — `SourcePathsConfig.spec.mjs` LearningSource base-directory test migrated to use `KB_DEFAULTS`; assertion is now overlay-immune
- [x] AC3 — The 17 non-drift-vulnerable KB specs left untouched (only line 310 of SourcePathsConfig.spec.mjs modified)
- [x] AC4 — Focused KB suite (291/291) + Sub-1's worker-collision scenario (#11969) verified passing
- [ ] AC5 — Operator-side smoke (customize `sourcePaths.AdrSource` in overlay; spec still passes): deferred to operator validation in live deployment (matches Sub-1's #11978 cycle-4 pattern for AC5 in the parent Epic family)

## Post-Merge Validation

- [ ] AC5 — Operator-side smoke: customize `ai/mcp/server/knowledge-base/config.mjs` `sourcePaths.AdrSource` to a non-default value; re-run `npm run test-unit -- test/playwright/unit/ai/services/knowledge-base/source/SourcePathsConfig.spec.mjs`; spec should still pass because the migrated assertion now reads `KB_DEFAULTS.sourcePaths?.LearningSource` (frozen snapshot, not overlay-merged). Matches the AC5 shape from Sub-1's #11978 cycle-4 — deferred to operator validation in live deployment per the parent Epic family precedent.

## Out of Scope

- KB_DEFAULTS re-export of live `KBConfig` singleton: not needed by any of the 18 KB specs (the 17 mutation-style specs already import the singleton directly via `(await import('.../config.template.mjs')).default`). Adding it would be speculative API surface. #11981 ticket body updated cycle-2 to reflect this V-B-A divergence from the original prescription.
- GW (Sub-3), NL (Sub-4), MC (Sub-5) — separate subs of Epic #11976
- Re-running the V-B-A audit on the GW/NL/MC server families — operator deferred this per the parent ticket's framing (those Subs run their own audit)

## Architectural decisions worth flagging

1. **Inlined values, not template import** — chose to inline the KB-template defaults rather than `import KBConfig from '.../config.template.mjs'` to avoid the class-registration ordering hazard described in `aiConfigDefaults.mjs` JSDoc. Direct consequence: KB_DEFAULTS must be manually kept in sync with the KB template's `defaultConfig` block. Drift risk mitigated by:
   - The migrated spec's text-grep tests (lines 145-153, 189-197, 246-255) already grep the template file directly for byte-equivalence with Source-class fallbacks; those remain the canonical drift detector for the values that matter to consumers.
   - Future bump: if the KB template adds a new field that a future spec wants to assert on, the spec author also updates `KB_DEFAULTS` — same workflow as Sub-1's `TIER1_DEFAULTS`.

2. **Scope of included fields** — included not just `sourcePaths` (the one drift-vulnerable surface) but also `collectionName` / `path` / `dataPath` / `hierarchyPath` / `logPath` / `defaultTenantId` / etc. that future per-server-field tests would naturally use. Bounded — only KB-template-specific fields, no Tier-1 imports. Keeps the fixture useful for forward callers without ballooning into a full template clone.

3. **Did NOT add re-export of `KBConfig` singleton** — ticket suggested "Re-exports `KBConfig` (live singleton) for mutation-style callers" but the 17 mutation-style specs already import the singleton directly. Adding it via the fixture would create a second import path for the same singleton (two-source-of-truth anti-pattern). Surfaced as architectural decision rather than silently dropping.

## Avoided Traps

- Did NOT migrate the 17 non-drift-vulnerable KB specs — V-B-A confirmed their patterns are drift-immune; migrating would be churn
- Did NOT import `KBConfig` from `config.template.mjs` in the fixture — class-registration collision hazard (per Sub-1 precedent)
- Did NOT add Tier-1 fields to KB_DEFAULTS — those belong in `TIER1_DEFAULTS`; mixing creates a second source of truth
- Did NOT bump the parent #11976 Epic's other Subs (GW/NL/MC) — out-of-scope per ticket framing

## Authority

Self-assigned to #11981 (already on bench from earlier nightshift authorization). Branch `agent/11981-kb-defaults-fixture` based on `origin/dev` HEAD `aa5f7226c` (post Epic #11993 merge).

Origin Session ID: `09321e82-482f-45aa-8e73-9d44381ff875`

Authored by [Claude Opus 4.7] (Claude Code) — nightshift continuation after Epic #11993 wake-substrate evolution complete.

## Commits

- `e36493f09` — `feat(test-fixtures): add KB_DEFAULTS + migrate SourcePathsConfig drift-vulnerable assertion (#11981)`
