### PR TITLE
fix(memory-core): route heartbeat pulses through bridge routes (#11994)

### DIFF
--- a/ai/daemons/bridge/daemon.mjs
+++ b/ai/daemons/bridge/daemon.mjs
@@ -322,8 +322,9 @@ async function pollLoop() {
  * Evaluates a GraphLog entry against a WAKE_SUBSCRIPTION trigger + filters.
  */
 function evaluateSubscription(sub, trace, entity, nodesMap, edgesMap) {
-    const trigger = sub.properties?.trigger;
-    const filters = sub.properties?.filters || {};
+    const trigger       = sub.properties?.trigger;
+    const harnessTarget = sub.properties?.harnessTarget;
+    const filters       = sub.properties?.filters || {};
     const agentIdentity = sub.properties?.agentIdentity;
 
     if (!agentIdentity) return null;
@@ -396,7 +397,7 @@ function evaluateSubscription(sub, trace, entity, nodesMap, edgesMap) {
                 logId: trace.log_id
             };
         }
-    } else if (trigger === 'HEARTBEAT_PULSE' && trace.entity_type === 'heartbeat_pulse') {
+    } else if (harnessTarget === 'bridge-daemon' && trace.entity_type === 'heartbeat_pulse') {
         const pulse = parseHeartbeatPulseEntityId(trace.entity_id);
         if (pulse?.targetIdentity === agentIdentity) {
             return {

--- a/ai/services/memory-core/WakeSubscriptionService.mjs
+++ b/ai/services/memory-core/WakeSubscriptionService.mjs
@@ -618,11 +618,10 @@ class WakeSubscriptionService extends Base {
     async emitHeartbeatPulse({targetIdentity} = {}) {
         if (!targetIdentity) throw new Error("Missing 'targetIdentity' parameter.");
 
-        const activeRoutes = this._getCandidateSubscriptions(targetIdentity, 'HEARTBEAT_PULSE', 'bridge-daemon')
-            .filter(subscription => (subscription.status || 'active') === 'active');
-
-        if (activeRoutes.length === 0) {
-            logger.info(`[WakeSubscription] heartbeat pulse skipped for ${targetIdentity}: no active bridge-daemon heartbeat subscription.`);
+        // Heartbeat pulses ride the existing bridge-daemon route; a dedicated
+        // HEARTBEAT_PULSE trigger is not exposed by manage_wake_subscription.
+        if (!this._hasActiveBridgeDaemonRoute(targetIdentity)) {
+            logger.info(`[WakeSubscription] heartbeat pulse skipped for ${targetIdentity}: no active bridge-daemon subscription.`);
             return {
                 status: 'skipped',
                 reason: 'no-active-bridge-daemon-subscription',
@@ -820,8 +819,10 @@ class WakeSubscriptionService extends Base {
      * @returns {Object|null} Wrapped heartbeat-pulse event or null.
      */
     _evaluateHeartbeatPulseAgainstSubscription(trace, subscription) {
-        if (subscription.trigger !== 'HEARTBEAT_PULSE') return null;
+        // Dispatch pulses through the existing bridge-daemon route, independent of the
+        // subscription trigger that originally established the route.
         if (trace.entity_type !== this.heartbeatPulseEntityType) return null;
+        if (subscription.harnessTarget !== 'bridge-daemon') return null;
 
         const pulse = this._parseHeartbeatPulseEntityId(trace.entity_id);
         if (!pulse || pulse.targetIdentity !== subscription.agentIdentity) return null;
@@ -1117,17 +1118,58 @@ class WakeSubscriptionService extends Base {
                 .map(({id, node}) => this._hydrateSubscriptionFromDurableNode(id, node));
         }
 
+        return this._getCandidateSubscriptionsFromMemory(owner, sub => sub.trigger === trigger && sub.harnessTarget === harnessTarget);
+    }
+
+    /**
+     * @summary Returns true if the identity has at least one active bridge-daemon
+     * subscription, regardless of trigger type.
+     *
+     * Heartbeat-pulse emission uses route reachability rather than a dedicated trigger.
+     *
+     * @param {String} identity AgentIdentity node id.
+     * @returns {Boolean}
+     * @protected
+     */
+    _hasActiveBridgeDaemonRoute(identity) {
+        const sqlite = GraphService.db?.storage?.db;
+        if (sqlite) {
+            const row = sqlite.prepare(`
+                SELECT count(*) as count FROM Nodes
+                WHERE json_extract(data, '$.label') = 'WAKE_SUBSCRIPTION'
+                  AND json_extract(data, '$.properties.agentIdentity') = ?
+                  AND json_extract(data, '$.properties.harnessTarget') = 'bridge-daemon'
+                  AND COALESCE(json_extract(data, '$.properties.status'), 'active') = 'active'
+            `).get(identity);
+            return (row?.count || 0) > 0;
+        }
+
+        return this._getCandidateSubscriptionsFromMemory(identity, sub => sub.harnessTarget === 'bridge-daemon').length > 0;
+    }
+
+    /**
+     * @summary In-memory subscription scan fallback for unit-test harnesses where the
+     * graph storage substrate is replaced. Pulls active nodes from `GraphService.db.nodes`
+     * and applies the caller-supplied predicate on the WAKE_SUBSCRIPTION's properties.
+     *
+     * @param {String} owner AgentIdentity node id.
+     * @param {Function} predicate Filter applied to the hydrated subscription entry.
+     * @returns {Object[]}
+     * @protected
+     */
+    _getCandidateSubscriptionsFromMemory(owner, predicate) {
         const candidates = [];
         const db         = GraphService.db;
         if (!db) return candidates;
 
         for (const node of db.nodes.items) {
-            if (node.label !== 'WAKE_SUBSCRIPTION') continue;
+            if (node.label !== 'WAKE_SUBSCRIPTION')   continue;
             const props = node.properties || {};
-            if (props.agentIdentity !== owner)     continue;
-            if (props.trigger !== trigger)         continue;
-            if (props.harnessTarget !== harnessTarget) continue;
-            candidates.push({id: node.id, ...props});
+            if (props.agentIdentity !== owner)        continue;
+            if ((props.status || 'active') !== 'active') continue;
+            const entry = {id: node.id, ...props};
+            if (!predicate(entry))                    continue;
+            candidates.push(entry);
         }
 
         return candidates;

--- a/test/playwright/unit/ai/daemons/bridge/daemon.spec.mjs
+++ b/test/playwright/unit/ai/daemons/bridge/daemon.spec.mjs
@@ -215,6 +215,63 @@ test.describe('Bridge Daemon', () => {
         expect(output).not.toContain('new messages');
     });
 
+    test('delivers heartbeat pulses through the existing SENT_TO_ME bridge-daemon route', async () => {
+        const subId = 'sub_' + crypto.randomUUID();
+        const agentId = '@test-agent-heartbeat-sent-to-me';
+
+        db.prepare('INSERT OR REPLACE INTO Nodes (id, data) VALUES (?, ?)').run(agentId, JSON.stringify({
+            id: agentId,
+            label: 'AGENT',
+            properties: { name: 'Test Agent Heartbeat Existing Route' }
+        }));
+
+        db.prepare('INSERT OR REPLACE INTO Nodes (id, data) VALUES (?, ?)').run(subId, JSON.stringify({
+            id: subId,
+            label: 'WAKE_SUBSCRIPTION',
+            properties: {
+                agentIdentity: agentId,
+                harnessTarget: 'bridge-daemon',
+                status: 'active',
+                trigger: 'SENT_TO_ME',
+                harnessTargetMetadata: {
+                    adapter: 'test',
+                    coalesceWindow: 1
+                }
+            }
+        }));
+
+        db.prepare('INSERT INTO GraphLog (entity_id, entity_type) VALUES (?, ?)').run(subId, 'nodes');
+
+        daemonProcess = spawn('node', ['ai/daemons/bridge/daemon.mjs'], {
+            stdio: 'pipe',
+            env: { ...process.env, NEO_AI_DB_PATH: DB_PATH, NEO_AI_DAEMON_DIR: DAEMON_DIR }
+        });
+
+        const deliveryPromise = new Promise((resolve, reject) => {
+            const timeout = setTimeout(() => reject(new Error('Daemon failed to deliver heartbeat pulse through existing route within timeout')), 10000);
+
+            daemonProcess.stdout.on('data', (data) => {
+                const out = data.toString();
+                if (out.includes('[Bridge Daemon Test Adapter] Delivered')) {
+                    clearTimeout(timeout);
+                    resolve(out);
+                }
+            });
+            daemonProcess.on('error', reject);
+        });
+
+        await new Promise(resolve => setTimeout(resolve, 1000));
+
+        const pulseId = `HEARTBEAT_PULSE:${agentId}:${crypto.randomUUID()}`;
+        db.prepare('INSERT INTO GraphLog (entity_id, entity_type) VALUES (?, ?)').run(pulseId, 'heartbeat_pulse');
+
+        const output = await deliveryPromise;
+        expect(output).toContain('[Bridge Daemon Test Adapter] Delivered');
+        expect(output).toContain('[WAKE][priority:normal]');
+        expect(output).toContain('heartbeat pulses');
+        expect(output).not.toContain('new messages');
+    });
+
     test('does not deliver wake events for wakeSuppressed mailbox-only messages', async () => {
         const subId = 'sub_' + crypto.randomUUID();
         const agentId = '@test-agent-suppressed';

--- a/test/playwright/unit/ai/services/memory-core/WakeSubscriptionService.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/WakeSubscriptionService.spec.mjs
@@ -993,7 +993,7 @@ test.describe('Neo.ai.services.memory-core.WakeSubscriptionService', () => {
         });
     });
 
-    test('emitHeartbeatPulse is an idempotent no-op without an active bridge heartbeat subscription', async () => {
+    test('emitHeartbeatPulse is an idempotent no-op without an active bridge-daemon subscription', async () => {
         const sqlite = GraphService.db.storage.db;
         const before = sqlite.prepare('SELECT MAX(log_id) as maxId FROM GraphLog').get().maxId || 0;
 
@@ -1010,6 +1010,57 @@ test.describe('Neo.ai.services.memory-core.WakeSubscriptionService', () => {
             reason        : 'no-active-bridge-daemon-subscription',
             targetIdentity: '@alice'
         });
+        expect(pulseRows).toBe(0);
+    });
+
+    test('emitHeartbeatPulse fires when only a SENT_TO_ME bridge-daemon subscription exists (Epic #11993 gate fix)', async () => {
+        // Production agents establish bridge-daemon routing through SENT_TO_ME subscriptions.
+        const sqlite = GraphService.db.storage.db;
+        const {subscriptionId} = insertDurableSubscription({
+            trigger              : 'SENT_TO_ME',
+            harnessTarget        : 'bridge-daemon',
+            harnessTargetMetadata: {appName: 'Codex'}
+        });
+        const before = sqlite.prepare('SELECT MAX(log_id) as maxId FROM GraphLog').get().maxId || 0;
+
+        const emitted = await WakeSubscriptionService.emitHeartbeatPulse({targetIdentity: '@alice'});
+
+        expect(emitted.status).toBe('emitted');
+        expect(emitted.targetIdentity).toBe('@alice');
+        expect(emitted.entityId).toMatch(/^HEARTBEAT_PULSE:@alice:/);
+        expect(emitted.logId).toBeGreaterThan(before);
+
+        // resync now delivers the pulse through that existing bridge-daemon route.
+        await RequestContextService.run({agentIdentityNodeId: '@alice'}, async () => {
+            const res = await WakeSubscriptionService.resync({subscriptionId, sinceLogId: before});
+            expect(res.eventsReplayed).toBe(1);
+            expect(res.events[0]).toMatchObject({
+                eventType    : 'wake/heartbeat_pulse',
+                agentIdentity: '@alice',
+                subscriptionId,
+                payload      : {targetIdentity: '@alice'}
+            });
+        });
+    });
+
+    test('emitHeartbeatPulse still no-ops when subscription is non-bridge-daemon (mcp-notifications / a2a-webhook)', async () => {
+        // Non-bridge routes remain outside the heartbeat-pulse transport contract.
+        const sqlite = GraphService.db.storage.db;
+        insertDurableSubscription({
+            trigger              : 'SENT_TO_ME',
+            harnessTarget        : 'mcp-notifications',
+            harnessTargetMetadata: {appName: 'noop'}
+        });
+        const before = sqlite.prepare('SELECT MAX(log_id) as maxId FROM GraphLog').get().maxId || 0;
+
+        const emitted = await WakeSubscriptionService.emitHeartbeatPulse({targetIdentity: '@alice'});
+
+        expect(emitted.status).toBe('skipped');
+        expect(emitted.reason).toBe('no-active-bridge-daemon-subscription');
+        const pulseRows = sqlite.prepare(`
+            SELECT COUNT(*) as count FROM GraphLog
+            WHERE log_id > ? AND entity_type = 'heartbeat_pulse'
+        `).get(before).count;
         expect(pulseRows).toBe(0);
     });
     // -----------------------------------------------------------------------------


### PR DESCRIPTION
Authored by GPT-5 (Codex Desktop). Session 3b454ac4-f2c6-4bf0-9c18-c0af6f432ffa.

FAIR-band: over-target [16/30] - taking this lane despite over-target because this is an operator-surfaced live wake incident in my already-claimed Sub-i substrate lane.

Evidence: L2 (service + bridge-daemon unit coverage of heartbeat pulse routing) -> L4 required for Epic #11993 AC8 live Codex Desktop wake. Residual: AC8 [#11993] plus candidate discovery [#12003].

Resolves #11994
Refs #11993
Refs #12003

## Summary

This reopens and completes the original Sub-i contract after live validation showed AC6 was only partially satisfied.

- `emitHeartbeatPulse()` now gates on any active `bridge-daemon` route for the target identity, instead of requiring an unreachable `HEARTBEAT_PULSE` trigger subscription.
- `WakeSubscriptionService.resync()` now delivers `heartbeat_pulse` rows through an existing bridge-daemon route, independent of the subscription trigger that established that route.
- `bridge/daemon.mjs` now mirrors the same production dispatch rule in its direct GraphLog polling path.
- Regression coverage proves both service-side replay and production bridge-daemon test-adapter delivery through an existing `SENT_TO_ME` bridge-daemon subscription.

## Deltas From Closed #11994

The prior #11994 implementation shipped the GraphLog-only pulse primitive and ADR shape, but the route gate was too narrow for production: live agents have `SENT_TO_ME` bridge-daemon subscriptions, not `HEARTBEAT_PULSE` subscriptions. That made Shape B silently no-op in the operator's live wake test.

This PR does not add a new wake concept. It corrects the original Sub-i route interpretation: heartbeat pulses ride the existing bridge-daemon route.

## Contract Ledger

| Surface | Source of Authority | Behavior | Evidence |
|---|---|---|---|
| `WakeSubscriptionService.emitHeartbeatPulse()` | #11994 + #11993 AC8 live validation | Emits when the target identity has any active `bridge-daemon` route; skips non-bridge routes | `WakeSubscriptionService.spec.mjs` 46/46 |
| `WakeSubscriptionService._evaluateHeartbeatPulseAgainstSubscription()` | Same route contract | Replays heartbeat pulses through bridge-daemon subscriptions regardless of trigger | `WakeSubscriptionService.spec.mjs` SENT_TO_ME bridge route regression |
| `bridge/daemon.mjs::evaluateSubscription()` | Production bridge dispatch path | Delivers `heartbeat_pulse` GraphLog rows through existing bridge-daemon routes | `daemon.spec.mjs` SENT_TO_ME route delivery regression |

## Signal Ledger

Discussion #11992 graduated into Epic #11993 and Sub-i #11994. This PR is a corrective completion of the already-graduated Sub-i delivery contract, not a new architectural proposal.

## Unresolved Dissent

None known for the route-gate shape. Candidate discovery is intentionally split to #12003 and owned separately.

## Unresolved Liveness

Epic #11993 AC8 remains operator-live until both halves land:

- #11994: route-evaluation and production bridge dispatch gate
- #12003: `active-a2a-participants` candidate discovery

## Test Evidence

- `git diff --cached --check` passed.
- `npm run test-unit -- test/playwright/unit/ai/services/memory-core/WakeSubscriptionService.spec.mjs` -> 46 passed.
- `npm run test-unit -- test/playwright/unit/ai/daemons/bridge/daemon.spec.mjs` -> 15 passed.

## Post-Merge Validation

- Operator sets the internal swarm deployment to a candidate source that includes `@neo-gpt` after #12003 lands.
- Restart orchestrator / bridge daemon.
- Leave Codex idle past one heartbeat cadence.
- Confirm a `heartbeat_pulse` GraphLog row lands and Codex receives a `[WAKE]` block without a mailbox `MESSAGE` row.

## Commits

- `625bda925` - `fix(memory-core): route heartbeat pulses through bridge routes (#11994)`
