### PR TITLE
refactor(orchestrator): delete daemon.mjs router dead code; consolidate mlx/lms config into Orchestrator getters (#12005)

### DIFF
--- a/ai/daemons/orchestrator/Orchestrator.mjs
+++ b/ai/daemons/orchestrator/Orchestrator.mjs
@@ -393,8 +393,27 @@ export class Orchestrator extends Base {
     get swarmHeartbeatEnabled()          { return Env.parseBool('NEO_ORCHESTRATOR_SWARM_HEARTBEAT_ENABLED')             ?? resolveDeploymentEnabled('swarmHeartbeatEnabled');          }
     get goldenPathRepoEnrichmentEnabled(){ return Env.parseBool('NEO_ORCHESTRATOR_GOLDEN_PATH_REPO_ENRICHMENT_ENABLED') ?? resolveDeploymentEnabled('goldenPathRepoEnrichmentEnabled');}
 
+    // MLX inference-server lane config (supervised continuous task; opt-in via AiConfig.orchestrator.mlx.enabled).
+    // Canonical defaults live in `ai/config.template.mjs::orchestrator.mlx`; env vars override per the 2-value chain.
+    get mlxEnabled() { return Env.parseBool('NEO_ORCHESTRATOR_MLX_ENABLED') ?? !!AiConfig.orchestrator.mlx?.enabled; }
+    get mlxModel()   { return Env.parseString('NEO_ORCHESTRATOR_MLX_MODEL') ?? AiConfig.orchestrator.mlx?.model;      }
+    get mlxPort()    { return Env.parseString('NEO_ORCHESTRATOR_MLX_PORT')  ?? AiConfig.orchestrator.mlx?.port;       }
+
+    // LM Studio CLI inference-server lane config (parallel-alternative to MLX; opt-in via
+    // AiConfig.orchestrator.lms.enabled). Mutually exclusive in practice — operators pick one.
+    // Canonical defaults live in `ai/config.template.mjs::orchestrator.lms`.
+    get lmsEnabled() { return Env.parseBool('NEO_ORCHESTRATOR_LMS_ENABLED') ?? !!AiConfig.orchestrator.lms?.enabled; }
+    get lmsModel()   { return Env.parseString('NEO_ORCHESTRATOR_LMS_MODEL') ?? AiConfig.orchestrator.lms?.model;      }
+    get lmsPort()    { return Env.parseString('NEO_ORCHESTRATOR_LMS_PORT')  ?? AiConfig.orchestrator.lms?.port;       }
+
     /**
      * Starts the orchestrator process loop after the wrapper has selected this process.
+     *
+     * Lane-internal config (intervals, enable flags, mlx/lms server tuning) is NOT read
+     * from `options`. The Orchestrator owns those via getters that consult env vars +
+     * `AiConfig.orchestrator.X` directly. Test fixtures override individual lane configs
+     * via env vars or by stubbing the getter on a test instance.
+     *
      * @param {Object} [options] Boot-wrapper paths + harness/process seams.
      * @param {String} [options.scriptDir]
      * @param {String} [options.dataDir]
@@ -404,12 +423,6 @@ export class Orchestrator extends Base {
      * @param {String} [options.heavyMaintenanceLeasePath]
      * @param {Object} [options.taskDefinitions] Pre-built task definitions (test-injection).
      * @param {String} [options.nodeBin]
-     * @param {Boolean} [options.mlxEnabled]
-     * @param {String}  [options.mlxModel]
-     * @param {String}  [options.mlxPort]
-     * @param {Boolean} [options.lmsEnabled]
-     * @param {String}  [options.lmsModel]
-     * @param {String}  [options.lmsPort]
      * @param {String[]|String|null} [options.primaryDevSyncRootsConfig]
      * @returns {Promise<void>}
      */
@@ -428,12 +441,12 @@ export class Orchestrator extends Base {
         this.taskDefinitions = options.taskDefinitions || buildTaskDefinitions({
             scriptDir,
             nodeBin   : options.nodeBin || process.argv[0],
-            mlxEnabled: options.mlxEnabled ?? undefined,
-            mlxModel  : options.mlxModel || undefined,
-            mlxPort   : options.mlxPort  || undefined,
-            lmsEnabled: options.lmsEnabled ?? undefined,
-            lmsModel  : options.lmsModel || undefined,
-            lmsPort   : options.lmsPort  || undefined
+            mlxEnabled: this.mlxEnabled,
+            mlxModel  : this.mlxModel,
+            mlxPort   : this.mlxPort,
+            lmsEnabled: this.lmsEnabled,
+            lmsModel  : this.lmsModel,
+            lmsPort   : this.lmsPort
         });
 
         // Non-reactive boot-wrapper-provided instance state

--- a/ai/daemons/orchestrator/TaskDefinitions.mjs
+++ b/ai/daemons/orchestrator/TaskDefinitions.mjs
@@ -15,8 +15,9 @@ export const DEFAULT_SCRIPT_DIR = path.resolve(__dirname, '../../scripts');
  * `lmsEnabled` / `lmsModel` / `lmsPort` values from the caller; performs no env-var
  * lookups and carries no embedded MLX or LM Studio defaults. The canonical defaults
  * live in `ai/config.template.mjs` under `orchestrator.mlx` and `orchestrator.lms`;
- * `daemon.mjs::resolveMlxConfig` / `resolveLmsConfig` apply env-var overrides and
- * forward the resolved values via `Orchestrator.start({mlx*, lms*})`.
+ * `Orchestrator` exposes them via env-overrideable getters
+ * (`mlxEnabled`/`mlxModel`/`mlxPort`/`lmsEnabled`/`lmsModel`/`lmsPort`) and forwards
+ * the resolved values via `Orchestrator.start()`.
  *
  * The orchestrator intentionally shells out to existing manual maintenance scripts for
  * Piece C instead of reimplementing their internals. This keeps orchestration separate

--- a/ai/daemons/orchestrator/daemon.mjs
+++ b/ai/daemons/orchestrator/daemon.mjs
@@ -31,31 +31,12 @@ import fs from 'fs-extra';
 import path from 'path';
 import {execSync} from 'child_process';
 import AiConfig from '../../config.mjs';
-import Env from '../../../src/util/Env.mjs';
 import Orchestrator from './Orchestrator.mjs';
 
 const DAEMON_DATA_DIR = process.env.NEO_AI_ORCHESTRATOR_DIR || '.neo-ai-data/orchestrator-daemon';
 const PID_FILE        = path.join(DAEMON_DATA_DIR, 'orchestrator-daemon.pid');
 const LOG_FILE        = path.join(DAEMON_DATA_DIR, 'orchestrator.log');
 export const LOCAL_AI_CONFIG_FILE = fileURLToPath(new URL('../../config.mjs', import.meta.url));
-
-const hasEnvValue = (env, key) => env[key] !== undefined && env[key] !== null && env[key] !== '';
-
-function assignConfigInterval(options, key, value, envNames, env) {
-    if (envNames.some(name => hasEnvValue(env, name))) return;
-    if (Number.isFinite(value) && value > 0) {
-        options[key] = value;
-    }
-}
-
-function assignLocalOnlyToggle(options, key, value, envName, deploymentMode, env) {
-    if (hasEnvValue(env, envName)) return;
-    if (typeof value === 'boolean') {
-        options[key] = value;
-    } else if (deploymentMode === 'cloud') {
-        options[key] = false;
-    }
-}
 
 function writeLog(level, message) {
     const timestamp = new Date().toISOString();
@@ -172,162 +153,16 @@ export async function loadLocalAiConfig({
 }
 
 /**
- * Resolves daemon start options from the Tier-1 AI config while preserving env precedence.
- * @param {Object} [options]
- * @param {Object} [options.orchestratorConfig={}] Top-level `orchestrator` config block.
- * @param {Object} [options.maintenanceConfig={}] Top-level `maintenance` config block.
- * @param {Object} [options.env=process.env] Environment source.
- * @returns {Object}
- */
-export function resolveOrchestratorStartOptions({
-    orchestratorConfig = {},
-    maintenanceConfig  = {},
-    env                = process.env
-} = {}) {
-    const options   = {};
-    const intervals = orchestratorConfig.intervals || {};
-
-    assignConfigInterval(options, 'pollIntervalMs', intervals.pollMs, ['NEO_ORCHESTRATOR_POLL_INTERVAL_MS'], env);
-    assignConfigInterval(
-        options,
-        'summarySweepIntervalMs',
-        intervals.summarySweepMs,
-        ['NEO_ORCHESTRATOR_SUMMARY_SWEEP_INTERVAL_MS', 'NEO_SUMMARIZATION_SWEEP_INTERVAL_MS'],
-        env
-    );
-    assignConfigInterval(options, 'kbSyncIntervalMs', intervals.kbSyncMs, ['NEO_ORCHESTRATOR_KB_SYNC_INTERVAL_MS'], env);
-    assignConfigInterval(
-        options,
-        'backupIntervalMs',
-        intervals.backupMs ?? maintenanceConfig.backup?.intervalMs,
-        ['NEO_ORCHESTRATOR_BACKUP_INTERVAL_MS'],
-        env
-    );
-    assignConfigInterval(
-        options,
-        'primaryDevSyncIntervalMs',
-        intervals.primaryDevSyncMs,
-        ['NEO_ORCHESTRATOR_PRIMARY_DEV_SYNC_INTERVAL_MS'],
-        env
-    );
-    assignConfigInterval(options, 'dreamIntervalMs', intervals.dreamMs, [], env);
-    assignConfigInterval(options, 'goldenPathIntervalMs', intervals.goldenPathMs, [], env);
-    assignConfigInterval(
-        options,
-        'swarmHeartbeatIntervalMs',
-        intervals.swarmHeartbeatMs,
-        ['NEO_ORCHESTRATOR_SWARM_HEARTBEAT_INTERVAL_MS'],
-        env
-    );
-
-    const deploymentMode = orchestratorConfig.deploymentMode || 'local';
-    const localOnly      = orchestratorConfig.localOnly || {};
-
-    assignLocalOnlyToggle(
-        options,
-        'primaryDevSyncEnabled',
-        localOnly.primaryDevSyncEnabled,
-        'NEO_ORCHESTRATOR_PRIMARY_DEV_SYNC_ENABLED',
-        deploymentMode,
-        env
-    );
-    assignLocalOnlyToggle(
-        options,
-        'kbSyncEnabled',
-        localOnly.kbSyncEnabled,
-        'NEO_ORCHESTRATOR_KB_SYNC_ENABLED',
-        deploymentMode,
-        env
-    );
-    assignLocalOnlyToggle(
-        options,
-        'bridgeDaemonEnabled',
-        localOnly.bridgeDaemonEnabled,
-        'NEO_ORCHESTRATOR_BRIDGE_DAEMON_ENABLED',
-        deploymentMode,
-        env
-    );
-    assignLocalOnlyToggle(
-        options,
-        'goldenPathRepoEnrichmentEnabled',
-        localOnly.goldenPathRepoEnrichmentEnabled,
-        'NEO_ORCHESTRATOR_GOLDEN_PATH_REPO_ENRICHMENT_ENABLED',
-        deploymentMode,
-        env
-    );
-    assignLocalOnlyToggle(
-        options,
-        'swarmHeartbeatEnabled',
-        localOnly.swarmHeartbeatEnabled,
-        'NEO_ORCHESTRATOR_SWARM_HEARTBEAT_ENABLED',
-        deploymentMode,
-        env
-    );
-
-    return options;
-}
-
-/**
- * Resolves the effective MLX inference-server config by overlaying env-var overrides
- * onto `AiConfig.orchestrator.mlx`. Operators tune via gitignored `ai/config.mjs`
- * or env (`NEO_ORCHESTRATOR_MLX_{ENABLED,MODEL,PORT}`); canonical defaults
- * (`enabled: false`, Gemma-4 model, port `'11435'`) live in
- * `ai/config.template.mjs` — this helper does not re-embed them.
- *
- * Boolean parsing for `NEO_ORCHESTRATOR_MLX_ENABLED` goes through
- * `Neo.util.Env.parseBool` for canonical token semantics
- * (true/yes/on/1, false/no/off/0, case-insensitive, trimmed).
- *
- * @param {Object} [options]
- * @param {Object} [options.orchestratorConfig={}] Slice of `AiConfig.orchestrator`.
- * @param {Object} [options.env=process.env] Env-var source (test-injectable).
- * @returns {{enabled: Boolean, model: String, port: String}}
- */
-export function resolveMlxConfig({orchestratorConfig = {}, env = process.env} = {}) {
-    const mlx = orchestratorConfig.mlx || {};
-
-    return {
-        enabled: Env.parseBool('NEO_ORCHESTRATOR_MLX_ENABLED', {env}) ?? !!mlx.enabled,
-        model  : env.NEO_ORCHESTRATOR_MLX_MODEL || mlx.model,
-        port   : env.NEO_ORCHESTRATOR_MLX_PORT  || mlx.port
-    };
-}
-
-/**
- * Resolves the effective LM Studio CLI (`lms`) inference-server config by overlaying
- * env-var overrides onto `AiConfig.orchestrator.lms`. Operators tune via gitignored
- * `ai/config.mjs` or env (`NEO_ORCHESTRATOR_LMS_{ENABLED,MODEL,PORT}`); canonical
- * defaults (`enabled: false`, `qwen3-embedding-8b` model, port `'1234'`) live in
- * `ai/config.template.mjs` — this helper does not re-embed them.
- *
- * Mirror of `resolveMlxConfig` — the `lms` task is the parallel-alternative
- * macOS-only local embedding server lane. Both `mlx` and `lms` lanes are mutually
- * exclusive in practice (operators pick one via the respective `enabled` flag),
- * though the orchestrator does not enforce that — two enabled lanes would bind
- * different ports and operate independently.
- *
- * Boolean parsing for `NEO_ORCHESTRATOR_LMS_ENABLED` goes through
- * `Neo.util.Env.parseBool` for canonical token semantics
- * (true/yes/on/1, false/no/off/0, case-insensitive, trimmed).
- *
- * @param {Object} [options]
- * @param {Object} [options.orchestratorConfig={}] Slice of `AiConfig.orchestrator`.
- * @param {Object} [options.env=process.env] Env-var source (test-injectable).
- * @returns {{enabled: Boolean, model: String, port: String}}
- */
-export function resolveLmsConfig({orchestratorConfig = {}, env = process.env} = {}) {
-    const lms = orchestratorConfig.lms || {};
-
-    return {
-        enabled: Env.parseBool('NEO_ORCHESTRATOR_LMS_ENABLED', {env}) ?? !!lms.enabled,
-        model  : env.NEO_ORCHESTRATOR_LMS_MODEL || lms.model,
-        port   : env.NEO_ORCHESTRATOR_LMS_PORT  || lms.port
-    };
-}
-
-/**
  * Starts the singleton orchestrator daemon.
- * @param {Object} [options] Runtime overrides for tests or process managers.
+ *
+ * Thin process-boot wrapper: PID singleton enforcement, signal handlers, env-file
+ * loading, Neo namespace bootstrap (already done at module-top), local AI config
+ * load, then delegation to `Orchestrator.start()`. Lane-internal config (intervals,
+ * enable flags, mlx/lms server tuning) is read by the Orchestrator itself via
+ * env-precedence getters that consult `AiConfig.orchestrator.X` directly — this
+ * function does NOT pre-resolve those into a flat options bag.
+ *
+ * @param {Object} [options] Test-injection seams (scriptDir, dbPath, taskDefinitions, ...).
  * @returns {Promise<void>}
  */
 export async function startOrchestrator(options = {}) {
@@ -335,21 +170,10 @@ export async function startOrchestrator(options = {}) {
     await enforceSingleton();
     setupCleanupHandlers();
     await loadLocalAiConfig();
-    const orchestratorConfig = AiConfig.orchestrator || {};
-    const maintenanceConfig  = AiConfig.maintenance || {};
-    const mlx                = resolveMlxConfig({orchestratorConfig});
-    const lms                = resolveLmsConfig({orchestratorConfig});
 
     return Orchestrator.start({
         dataDir: DAEMON_DATA_DIR,
-        primaryDevSyncRootsConfig: orchestratorConfig.devSyncRoots,
-        mlxEnabled: mlx.enabled,
-        mlxModel  : mlx.model,
-        mlxPort   : mlx.port,
-        lmsEnabled: lms.enabled,
-        lmsModel  : lms.model,
-        lmsPort   : lms.port,
-        ...resolveOrchestratorStartOptions({orchestratorConfig, maintenanceConfig}),
+        primaryDevSyncRootsConfig: AiConfig.orchestrator?.devSyncRoots,
         ...options
     });
 }

--- a/test/playwright/unit/ai/daemons/orchestrator/Orchestrator.invariants.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/Orchestrator.invariants.spec.mjs
@@ -25,10 +25,18 @@ let savedIntervals       = null;
 let savedLocalOnly       = null;
 let savedCloudOnly       = null;
 let savedDeploymentMode  = null;
+let savedMlxConfig                   = undefined;
+let savedLmsConfig                   = undefined;
 let savedEnvKbSyncEnabled            = undefined;
 let savedEnvKbSyncInterval           = undefined;
 let savedEnvTenantRepoSyncEnabled    = undefined;
 let savedEnvTenantRepoSyncInterval   = undefined;
+let savedEnvMlxEnabled               = undefined;
+let savedEnvMlxModel                 = undefined;
+let savedEnvMlxPort                  = undefined;
+let savedEnvLmsEnabled               = undefined;
+let savedEnvLmsModel                 = undefined;
+let savedEnvLmsPort                  = undefined;
 
 function createMinimalOrchestrator() {
     const taskDefinitions = buildTaskDefinitions({
@@ -60,11 +68,19 @@ test.beforeEach(() => {
     savedLocalOnly      = {...AiConfig.orchestrator.localOnly};
     savedCloudOnly      = AiConfig.orchestrator.cloudOnly ? {...AiConfig.orchestrator.cloudOnly} : null;
     savedDeploymentMode = AiConfig.orchestrator.deploymentMode;
+    savedMlxConfig      = AiConfig.orchestrator.mlx ? {...AiConfig.orchestrator.mlx} : undefined;
+    savedLmsConfig      = AiConfig.orchestrator.lms ? {...AiConfig.orchestrator.lms} : undefined;
 
     savedEnvKbSyncEnabled          = process.env.NEO_ORCHESTRATOR_KB_SYNC_ENABLED;
     savedEnvKbSyncInterval         = process.env.NEO_ORCHESTRATOR_KB_SYNC_INTERVAL_MS;
     savedEnvTenantRepoSyncEnabled  = process.env.NEO_ORCHESTRATOR_TENANT_REPO_SYNC_ENABLED;
     savedEnvTenantRepoSyncInterval = process.env.NEO_ORCHESTRATOR_TENANT_REPO_SYNC_INTERVAL_MS;
+    savedEnvMlxEnabled             = process.env.NEO_ORCHESTRATOR_MLX_ENABLED;
+    savedEnvMlxModel               = process.env.NEO_ORCHESTRATOR_MLX_MODEL;
+    savedEnvMlxPort                = process.env.NEO_ORCHESTRATOR_MLX_PORT;
+    savedEnvLmsEnabled             = process.env.NEO_ORCHESTRATOR_LMS_ENABLED;
+    savedEnvLmsModel               = process.env.NEO_ORCHESTRATOR_LMS_MODEL;
+    savedEnvLmsPort                = process.env.NEO_ORCHESTRATOR_LMS_PORT;
 });
 
 test.afterEach(() => {
@@ -75,10 +91,27 @@ test.afterEach(() => {
     }
     AiConfig.orchestrator.deploymentMode = savedDeploymentMode;
 
+    if (savedMlxConfig === undefined) {
+        delete AiConfig.orchestrator.mlx;
+    } else {
+        AiConfig.orchestrator.mlx = savedMlxConfig;
+    }
+    if (savedLmsConfig === undefined) {
+        delete AiConfig.orchestrator.lms;
+    } else {
+        AiConfig.orchestrator.lms = savedLmsConfig;
+    }
+
     restoreEnv('NEO_ORCHESTRATOR_KB_SYNC_ENABLED',           savedEnvKbSyncEnabled);
     restoreEnv('NEO_ORCHESTRATOR_KB_SYNC_INTERVAL_MS',       savedEnvKbSyncInterval);
     restoreEnv('NEO_ORCHESTRATOR_TENANT_REPO_SYNC_ENABLED',  savedEnvTenantRepoSyncEnabled);
     restoreEnv('NEO_ORCHESTRATOR_TENANT_REPO_SYNC_INTERVAL_MS', savedEnvTenantRepoSyncInterval);
+    restoreEnv('NEO_ORCHESTRATOR_MLX_ENABLED',               savedEnvMlxEnabled);
+    restoreEnv('NEO_ORCHESTRATOR_MLX_MODEL',                 savedEnvMlxModel);
+    restoreEnv('NEO_ORCHESTRATOR_MLX_PORT',                  savedEnvMlxPort);
+    restoreEnv('NEO_ORCHESTRATOR_LMS_ENABLED',               savedEnvLmsEnabled);
+    restoreEnv('NEO_ORCHESTRATOR_LMS_MODEL',                 savedEnvLmsModel);
+    restoreEnv('NEO_ORCHESTRATOR_LMS_PORT',                  savedEnvLmsPort);
 });
 
 function restoreEnv(name, prior) {
@@ -137,15 +170,25 @@ test.describe('Orchestrator config precedence (#11834 AC2)', () => {
     });
 
     // === mlx + lms supervised-server lane getters (#12005) ===
+    // AiConfig.orchestrator.mlx + .lms + the 6 NEO_ORCHESTRATOR_{MLX,LMS}_{ENABLED,MODEL,PORT}
+    // env vars are saved/restored by the file-level beforeEach/afterEach hooks above —
+    // individual tests can mutate freely without leak risk.
 
     test('mlxEnabled: env var wins over AiConfig.orchestrator.mlx.enabled', () => {
         AiConfig.orchestrator.mlx = {enabled: false, model: 'm', port: '11435'};
         process.env.NEO_ORCHESTRATOR_MLX_ENABLED = 'true';
-        try {
-            expect(createMinimalOrchestrator().mlxEnabled).toBe(true);
-        } finally {
-            delete process.env.NEO_ORCHESTRATOR_MLX_ENABLED;
-        }
+
+        expect(createMinimalOrchestrator().mlxEnabled).toBe(true);
+    });
+
+    test('mlxEnabled: explicit env=false overrides an enabled AiConfig default', () => {
+        // Coverage parity with the deleted resolveMlxConfig "explicit env=false overrides
+        // an enabled AiConfig default" test branch. This is the path most at risk if the
+        // getter's `??` operator drifts to `||` later.
+        AiConfig.orchestrator.mlx = {enabled: true, model: 'm', port: '11435'};
+        process.env.NEO_ORCHESTRATOR_MLX_ENABLED = 'false';
+
+        expect(createMinimalOrchestrator().mlxEnabled).toBe(false);
     });
 
     test('mlxEnabled / mlxModel / mlxPort: AiConfig consulted when env vars absent', () => {
@@ -164,26 +207,29 @@ test.describe('Orchestrator config precedence (#11834 AC2)', () => {
         delete process.env.NEO_ORCHESTRATOR_MLX_ENABLED;
         delete process.env.NEO_ORCHESTRATOR_MLX_MODEL;
         delete process.env.NEO_ORCHESTRATOR_MLX_PORT;
-        const savedMlx = AiConfig.orchestrator.mlx;
         delete AiConfig.orchestrator.mlx;
-        try {
-            const o = createMinimalOrchestrator();
-            expect(o.mlxEnabled).toBe(false);
-            expect(o.mlxModel).toBeUndefined();
-            expect(o.mlxPort).toBeUndefined();
-        } finally {
-            if (savedMlx !== undefined) AiConfig.orchestrator.mlx = savedMlx;
-        }
+
+        const o = createMinimalOrchestrator();
+        expect(o.mlxEnabled).toBe(false);
+        expect(o.mlxModel).toBeUndefined();
+        expect(o.mlxPort).toBeUndefined();
     });
 
     test('lmsEnabled: env var wins over AiConfig.orchestrator.lms.enabled', () => {
         AiConfig.orchestrator.lms = {enabled: false, model: 'qwen', port: '1234'};
         process.env.NEO_ORCHESTRATOR_LMS_ENABLED = 'true';
-        try {
-            expect(createMinimalOrchestrator().lmsEnabled).toBe(true);
-        } finally {
-            delete process.env.NEO_ORCHESTRATOR_LMS_ENABLED;
-        }
+
+        expect(createMinimalOrchestrator().lmsEnabled).toBe(true);
+    });
+
+    test('lmsEnabled: explicit env=false overrides an enabled AiConfig default', () => {
+        // Coverage parity with the deleted resolveLmsConfig "explicit env=false overrides
+        // an enabled AiConfig default" test branch. Sibling of the mlx false-env-override
+        // test above — same `??` vs `||` regression hazard.
+        AiConfig.orchestrator.lms = {enabled: true, model: 'qwen', port: '1234'};
+        process.env.NEO_ORCHESTRATOR_LMS_ENABLED = 'false';
+
+        expect(createMinimalOrchestrator().lmsEnabled).toBe(false);
     });
 
     test('lmsEnabled / lmsModel / lmsPort: AiConfig consulted when env vars absent', () => {
@@ -202,16 +248,12 @@ test.describe('Orchestrator config precedence (#11834 AC2)', () => {
         delete process.env.NEO_ORCHESTRATOR_LMS_ENABLED;
         delete process.env.NEO_ORCHESTRATOR_LMS_MODEL;
         delete process.env.NEO_ORCHESTRATOR_LMS_PORT;
-        const savedLms = AiConfig.orchestrator.lms;
         delete AiConfig.orchestrator.lms;
-        try {
-            const o = createMinimalOrchestrator();
-            expect(o.lmsEnabled).toBe(false);
-            expect(o.lmsModel).toBeUndefined();
-            expect(o.lmsPort).toBeUndefined();
-        } finally {
-            if (savedLms !== undefined) AiConfig.orchestrator.lms = savedLms;
-        }
+
+        const o = createMinimalOrchestrator();
+        expect(o.lmsEnabled).toBe(false);
+        expect(o.lmsModel).toBeUndefined();
+        expect(o.lmsPort).toBeUndefined();
     });
 });
 

--- a/test/playwright/unit/ai/daemons/orchestrator/Orchestrator.invariants.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/Orchestrator.invariants.spec.mjs
@@ -135,6 +135,84 @@ test.describe('Orchestrator config precedence (#11834 AC2)', () => {
         expect(AiConfig.orchestrator.intervals.kbSyncMs).toBe(99_000);
         expect(AiConfig.orchestrator.localOnly.kbSyncEnabled).toBe(!baselineLocalKbs);
     });
+
+    // === mlx + lms supervised-server lane getters (#12005) ===
+
+    test('mlxEnabled: env var wins over AiConfig.orchestrator.mlx.enabled', () => {
+        AiConfig.orchestrator.mlx = {enabled: false, model: 'm', port: '11435'};
+        process.env.NEO_ORCHESTRATOR_MLX_ENABLED = 'true';
+        try {
+            expect(createMinimalOrchestrator().mlxEnabled).toBe(true);
+        } finally {
+            delete process.env.NEO_ORCHESTRATOR_MLX_ENABLED;
+        }
+    });
+
+    test('mlxEnabled / mlxModel / mlxPort: AiConfig consulted when env vars absent', () => {
+        delete process.env.NEO_ORCHESTRATOR_MLX_ENABLED;
+        delete process.env.NEO_ORCHESTRATOR_MLX_MODEL;
+        delete process.env.NEO_ORCHESTRATOR_MLX_PORT;
+        AiConfig.orchestrator.mlx = {enabled: true, model: 'mlx-from-config', port: '11999'};
+
+        const o = createMinimalOrchestrator();
+        expect(o.mlxEnabled).toBe(true);
+        expect(o.mlxModel).toBe('mlx-from-config');
+        expect(o.mlxPort).toBe('11999');
+    });
+
+    test('mlx getters undefined-safe when AiConfig.orchestrator.mlx is missing', () => {
+        delete process.env.NEO_ORCHESTRATOR_MLX_ENABLED;
+        delete process.env.NEO_ORCHESTRATOR_MLX_MODEL;
+        delete process.env.NEO_ORCHESTRATOR_MLX_PORT;
+        const savedMlx = AiConfig.orchestrator.mlx;
+        delete AiConfig.orchestrator.mlx;
+        try {
+            const o = createMinimalOrchestrator();
+            expect(o.mlxEnabled).toBe(false);
+            expect(o.mlxModel).toBeUndefined();
+            expect(o.mlxPort).toBeUndefined();
+        } finally {
+            if (savedMlx !== undefined) AiConfig.orchestrator.mlx = savedMlx;
+        }
+    });
+
+    test('lmsEnabled: env var wins over AiConfig.orchestrator.lms.enabled', () => {
+        AiConfig.orchestrator.lms = {enabled: false, model: 'qwen', port: '1234'};
+        process.env.NEO_ORCHESTRATOR_LMS_ENABLED = 'true';
+        try {
+            expect(createMinimalOrchestrator().lmsEnabled).toBe(true);
+        } finally {
+            delete process.env.NEO_ORCHESTRATOR_LMS_ENABLED;
+        }
+    });
+
+    test('lmsEnabled / lmsModel / lmsPort: AiConfig consulted when env vars absent', () => {
+        delete process.env.NEO_ORCHESTRATOR_LMS_ENABLED;
+        delete process.env.NEO_ORCHESTRATOR_LMS_MODEL;
+        delete process.env.NEO_ORCHESTRATOR_LMS_PORT;
+        AiConfig.orchestrator.lms = {enabled: true, model: 'lms-from-config', port: '4242'};
+
+        const o = createMinimalOrchestrator();
+        expect(o.lmsEnabled).toBe(true);
+        expect(o.lmsModel).toBe('lms-from-config');
+        expect(o.lmsPort).toBe('4242');
+    });
+
+    test('lms getters undefined-safe when AiConfig.orchestrator.lms is missing', () => {
+        delete process.env.NEO_ORCHESTRATOR_LMS_ENABLED;
+        delete process.env.NEO_ORCHESTRATOR_LMS_MODEL;
+        delete process.env.NEO_ORCHESTRATOR_LMS_PORT;
+        const savedLms = AiConfig.orchestrator.lms;
+        delete AiConfig.orchestrator.lms;
+        try {
+            const o = createMinimalOrchestrator();
+            expect(o.lmsEnabled).toBe(false);
+            expect(o.lmsModel).toBeUndefined();
+            expect(o.lmsPort).toBeUndefined();
+        } finally {
+            if (savedLms !== undefined) AiConfig.orchestrator.lms = savedLms;
+        }
+    });
 });
 
 test.describe('Orchestrator parent-prop propagation (#11834 AC3)', () => {

--- a/test/playwright/unit/ai/daemons/orchestrator/daemon.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/daemon.spec.mjs
@@ -5,10 +5,7 @@ import '../../../../../../src/Neo.mjs';
 import '../../../../../../src/core/_export.mjs';
 import {
     LOCAL_AI_CONFIG_FILE,
-    loadLocalAiConfig,
-    resolveLmsConfig,
-    resolveMlxConfig,
-    resolveOrchestratorStartOptions
+    loadLocalAiConfig
 } from '../../../../../../ai/daemons/orchestrator/daemon.mjs';
 import {
     buildTaskDefinitions
@@ -46,10 +43,10 @@ test.describe('ai/daemons/orchestrator/daemon.mjs (#11006/#11009)', () => {
 
     test('buildTaskDefinitions is pure: no env-var lookups; concrete mlxModel/mlxPort flow through', () => {
         // Architectural contract post-#11075: TaskDefinitions.mjs has no embedded MLX
-        // defaults and no env-var reads. Caller (daemon.mjs via resolveMlxConfig)
-        // resolves AiConfig + env-vars and forwards concrete values. This test
-        // documents the pure-function contract by setting env-vars that would have
-        // been picked up by the old behavior and verifying they are ignored.
+        // defaults and no env-var reads. Caller (Orchestrator via its mlx* getters
+        // reading AiConfig + env-vars) forwards concrete values. This test documents
+        // the pure-function contract by setting env-vars that would have been picked
+        // up by the old behavior and verifying they are ignored.
         const scriptDir = path.resolve(process.cwd(), 'ai/scripts');
         const originalMlxModel   = process.env.NEO_ORCHESTRATOR_MLX_MODEL;
         const originalMlxEnabled = process.env.NEO_ORCHESTRATOR_MLX_ENABLED;
@@ -98,100 +95,6 @@ test.describe('ai/daemons/orchestrator/daemon.mjs (#11006/#11009)', () => {
         }
     });
 
-    test('resolveMlxConfig overlays env-var precedence onto AiConfig.orchestrator.mlx', () => {
-        const aiConfigDefaults = {
-            mlx: {
-                enabled: false,
-                model  : 'mlx-community/gemma-4-31b-it-bf16',
-                port   : '11435'
-            }
-        };
-
-        // No env overrides: AiConfig defaults flow through.
-        expect(resolveMlxConfig({orchestratorConfig: aiConfigDefaults, env: {}})).toEqual({
-            enabled: false,
-            model  : 'mlx-community/gemma-4-31b-it-bf16',
-            port   : '11435'
-        });
-
-        // Env overrides win.
-        expect(resolveMlxConfig({
-            orchestratorConfig: aiConfigDefaults,
-            env               : {
-                NEO_ORCHESTRATOR_MLX_ENABLED: 'true',
-                NEO_ORCHESTRATOR_MLX_MODEL  : 'env-model',
-                NEO_ORCHESTRATOR_MLX_PORT   : '11999'
-            }
-        })).toEqual({
-            enabled: true,
-            model  : 'env-model',
-            port   : '11999'
-        });
-
-        // Explicit env=false overrides an enabled AiConfig default.
-        expect(resolveMlxConfig({
-            orchestratorConfig: {mlx: {...aiConfigDefaults.mlx, enabled: true}},
-            env               : {NEO_ORCHESTRATOR_MLX_ENABLED: 'false'}
-        })).toEqual({
-            enabled: false,
-            model  : 'mlx-community/gemma-4-31b-it-bf16',
-            port   : '11435'
-        });
-
-        // Missing orchestratorConfig.mlx: undefined-safe, no crash; values undefined.
-        expect(resolveMlxConfig({orchestratorConfig: {}, env: {}})).toEqual({
-            enabled: false,
-            model  : undefined,
-            port   : undefined
-        });
-    });
-
-    test('resolveMlxConfig accepts canonical boolean tokens via Env.parseBool (TRUE/yes/on/1 + FALSE/no/off/0)', () => {
-        // Per Neo.util.Env.parseBool token semantics — case-insensitive, trimmed.
-        // Token sets: TRUE_TOKENS=['true','yes','on','1'], FALSE_TOKENS=['false','no','off','0'].
-        const aiDefaultDisabled = {mlx: {enabled: false, model: 'm', port: 'p'}};
-        const aiDefaultEnabled  = {mlx: {enabled: true,  model: 'm', port: 'p'}};
-
-        // Truthy tokens (against an AiConfig default of `enabled: false` — env wins on each).
-        for (const truthy of ['true', 'TRUE', 'True', 'yes', 'YES', 'on', 'ON', '1']) {
-            expect(resolveMlxConfig({
-                orchestratorConfig: aiDefaultDisabled,
-                env               : {NEO_ORCHESTRATOR_MLX_ENABLED: truthy}
-            }).enabled).toBe(true);
-        }
-
-        // Falsy tokens (against an AiConfig default of `enabled: true` — env wins on each).
-        for (const falsy of ['false', 'FALSE', 'False', 'no', 'NO', 'off', 'OFF', '0']) {
-            expect(resolveMlxConfig({
-                orchestratorConfig: aiDefaultEnabled,
-                env               : {NEO_ORCHESTRATOR_MLX_ENABLED: falsy}
-            }).enabled).toBe(false);
-        }
-
-        // Whitespace-tolerant per Env.parseBool's trim semantics.
-        expect(resolveMlxConfig({
-            orchestratorConfig: aiDefaultDisabled,
-            env               : {NEO_ORCHESTRATOR_MLX_ENABLED: '  yes  '}
-        }).enabled).toBe(true);
-
-        // Invalid token: Env.parseBool returns undefined → falls back to AiConfig default.
-        // (Env warns to console; suppression is the caller's concern, not asserted here.)
-        const originalWarn = console.warn;
-        console.warn       = () => {};
-        try {
-            expect(resolveMlxConfig({
-                orchestratorConfig: aiDefaultEnabled,
-                env               : {NEO_ORCHESTRATOR_MLX_ENABLED: 'maybe'}
-            }).enabled).toBe(true);
-            expect(resolveMlxConfig({
-                orchestratorConfig: aiDefaultDisabled,
-                env               : {NEO_ORCHESTRATOR_MLX_ENABLED: 'maybe'}
-            }).enabled).toBe(false);
-        } finally {
-            console.warn = originalWarn;
-        }
-    });
-
     test('AiConfig.orchestrator.mlx ships canonical MLX launch defaults', async () => {
         const templateSource = fs.readFileSync(path.resolve(process.cwd(), 'ai/config.template.mjs'), 'utf8');
 
@@ -215,10 +118,10 @@ test.describe('ai/daemons/orchestrator/daemon.mjs (#11006/#11009)', () => {
 
     test('buildTaskDefinitions is pure: no env-var lookups; concrete lmsModel/lmsPort flow through', () => {
         // Architectural contract: TaskDefinitions.mjs has no embedded LM Studio
-        // defaults and no env-var reads. Caller (daemon.mjs via resolveLmsConfig)
-        // resolves AiConfig + env-vars and forwards concrete values. This test
-        // documents the pure-function contract by setting env-vars that would have
-        // been picked up if the implementation leaked and verifying they are ignored.
+        // defaults and no env-var reads. Caller (Orchestrator via its lms* getters
+        // reading AiConfig + env-vars) forwards concrete values. This test documents
+        // the pure-function contract by setting env-vars that would have been picked
+        // up if the implementation leaked and verifying they are ignored.
         const scriptDir = path.resolve(process.cwd(), 'ai/scripts');
         const originalLmsModel   = process.env.NEO_ORCHESTRATOR_LMS_MODEL;
         const originalLmsEnabled = process.env.NEO_ORCHESTRATOR_LMS_ENABLED;
@@ -260,54 +163,6 @@ test.describe('ai/daemons/orchestrator/daemon.mjs (#11006/#11009)', () => {
                 }
             }
         }
-    });
-
-    test('resolveLmsConfig overlays env-var precedence onto AiConfig.orchestrator.lms', () => {
-        const aiConfigDefaults = {
-            lms: {
-                enabled: false,
-                model  : 'qwen3-embedding-8b',
-                port   : '1234'
-            }
-        };
-
-        // No env overrides: AiConfig defaults flow through.
-        expect(resolveLmsConfig({orchestratorConfig: aiConfigDefaults, env: {}})).toEqual({
-            enabled: false,
-            model  : 'qwen3-embedding-8b',
-            port   : '1234'
-        });
-
-        // Env overrides win.
-        expect(resolveLmsConfig({
-            orchestratorConfig: aiConfigDefaults,
-            env               : {
-                NEO_ORCHESTRATOR_LMS_ENABLED: 'true',
-                NEO_ORCHESTRATOR_LMS_MODEL  : 'env-model',
-                NEO_ORCHESTRATOR_LMS_PORT   : '4242'
-            }
-        })).toEqual({
-            enabled: true,
-            model  : 'env-model',
-            port   : '4242'
-        });
-
-        // Explicit env=false overrides an enabled AiConfig default.
-        expect(resolveLmsConfig({
-            orchestratorConfig: {lms: {...aiConfigDefaults.lms, enabled: true}},
-            env               : {NEO_ORCHESTRATOR_LMS_ENABLED: 'false'}
-        })).toEqual({
-            enabled: false,
-            model  : 'qwen3-embedding-8b',
-            port   : '1234'
-        });
-
-        // Missing orchestratorConfig.lms: undefined-safe, no crash; values undefined.
-        expect(resolveLmsConfig({orchestratorConfig: {}, env: {}})).toEqual({
-            enabled: false,
-            model  : undefined,
-            port   : undefined
-        });
     });
 
     test('AiConfig.orchestrator.lms ships canonical LM Studio launch defaults', async () => {
@@ -383,154 +238,4 @@ test.describe('ai/daemons/orchestrator/daemon.mjs (#11006/#11009)', () => {
         expect(LOCAL_AI_CONFIG_FILE).toBe(path.resolve(process.cwd(), 'ai/config.mjs'));
     });
 
-    test('resolves orchestrator intervals from top-level config when env overrides are absent', () => {
-        expect(resolveOrchestratorStartOptions({
-            orchestratorConfig: {
-                deploymentMode: 'local',
-                intervals: {
-                    pollMs          : 11,
-                    summarySweepMs  : 22,
-                    kbSyncMs        : 33,
-                    backupMs        : 44,
-                    primaryDevSyncMs: 55,
-                    dreamMs         : 66,
-                    goldenPathMs    : 77
-                },
-                localOnly: {
-                    primaryDevSyncEnabled: true,
-                    kbSyncEnabled        : true,
-                    bridgeDaemonEnabled  : true,
-                    goldenPathRepoEnrichmentEnabled: true
-                }
-            },
-            env: {}
-        })).toEqual({
-            pollIntervalMs          : 11,
-            summarySweepIntervalMs  : 22,
-            kbSyncIntervalMs        : 33,
-            backupIntervalMs        : 44,
-            primaryDevSyncIntervalMs: 55,
-            dreamIntervalMs         : 66,
-            goldenPathIntervalMs    : 77,
-            primaryDevSyncEnabled   : true,
-            kbSyncEnabled           : true,
-            bridgeDaemonEnabled     : true,
-            goldenPathRepoEnrichmentEnabled: true
-        });
-    });
-
-    test('falls back to maintenance backup cadence when orchestrator cadence omits backupMs', () => {
-        expect(resolveOrchestratorStartOptions({
-            orchestratorConfig: {
-                intervals: {
-                    pollMs: 11
-                }
-            },
-            maintenanceConfig: {
-                backup: {
-                    intervalMs: 88
-                }
-            },
-            env: {}
-        })).toMatchObject({
-            pollIntervalMs  : 11,
-            backupIntervalMs: 88
-        });
-    });
-
-    test('preserves env precedence over config-derived orchestrator options', () => {
-        const options = resolveOrchestratorStartOptions({
-            orchestratorConfig: {
-                deploymentMode: 'cloud',
-                intervals: {
-                    pollMs          : 11,
-                    summarySweepMs  : 22,
-                    kbSyncMs        : 33,
-                    backupMs        : 44,
-                    primaryDevSyncMs: 55
-                }
-            },
-            env: {
-                NEO_ORCHESTRATOR_POLL_INTERVAL_MS            : '100',
-                NEO_SUMMARIZATION_SWEEP_INTERVAL_MS          : '200',
-                NEO_ORCHESTRATOR_KB_SYNC_INTERVAL_MS         : '300',
-                NEO_ORCHESTRATOR_BACKUP_INTERVAL_MS          : '400',
-                NEO_ORCHESTRATOR_PRIMARY_DEV_SYNC_INTERVAL_MS: '500',
-                NEO_ORCHESTRATOR_PRIMARY_DEV_SYNC_ENABLED    : 'false',
-                NEO_ORCHESTRATOR_KB_SYNC_ENABLED             : 'false',
-                NEO_ORCHESTRATOR_BRIDGE_DAEMON_ENABLED       : 'false',
-                NEO_ORCHESTRATOR_GOLDEN_PATH_REPO_ENRICHMENT_ENABLED: 'false'
-            }
-        });
-
-        expect(options).not.toHaveProperty('pollIntervalMs');
-        expect(options).not.toHaveProperty('summarySweepIntervalMs');
-        expect(options).not.toHaveProperty('kbSyncIntervalMs');
-        expect(options).not.toHaveProperty('backupIntervalMs');
-        expect(options).not.toHaveProperty('primaryDevSyncIntervalMs');
-        expect(options).not.toHaveProperty('primaryDevSyncEnabled');
-        expect(options).not.toHaveProperty('kbSyncEnabled');
-        expect(options).not.toHaveProperty('bridgeDaemonEnabled');
-        expect(options).not.toHaveProperty('goldenPathRepoEnrichmentEnabled');
-    });
-
-    test('disables local-only scheduler lanes for cloud deployments unless explicitly enabled', () => {
-        expect(resolveOrchestratorStartOptions({
-            orchestratorConfig: {
-                deploymentMode: 'cloud',
-                localOnly     : {}
-            },
-            env: {}
-        })).toMatchObject({
-            primaryDevSyncEnabled: false,
-            kbSyncEnabled        : false,
-            bridgeDaemonEnabled  : false,
-            goldenPathRepoEnrichmentEnabled: false
-        });
-
-        expect(resolveOrchestratorStartOptions({
-            orchestratorConfig: {
-                deploymentMode: 'cloud',
-                localOnly: {
-                    primaryDevSyncEnabled: true,
-                    kbSyncEnabled        : true,
-                    bridgeDaemonEnabled  : true,
-                    goldenPathRepoEnrichmentEnabled: true
-                }
-            },
-            env: {}
-        })).toMatchObject({
-            primaryDevSyncEnabled: true,
-            kbSyncEnabled        : true,
-            bridgeDaemonEnabled  : true,
-            goldenPathRepoEnrichmentEnabled: true
-        });
-    });
-
-    test('resolves the swarm-heartbeat lane per deployment profile (#11766)', () => {
-        // Cloud profile, no explicit override -> lane disabled.
-        expect(resolveOrchestratorStartOptions({
-            orchestratorConfig: {deploymentMode: 'cloud', localOnly: {}},
-            env: {}
-        })).toMatchObject({swarmHeartbeatEnabled: false});
-
-        // Local profile, no explicit override -> option left unset so the
-        // Orchestrator.configure() parseEnabledFlag(..., true) default (lane ON) applies.
-        expect(resolveOrchestratorStartOptions({
-            orchestratorConfig: {deploymentMode: 'local', localOnly: {}},
-            env: {}
-        })).not.toHaveProperty('swarmHeartbeatEnabled');
-
-        // Explicit opt-in overrides the cloud default.
-        expect(resolveOrchestratorStartOptions({
-            orchestratorConfig: {deploymentMode: 'cloud', localOnly: {swarmHeartbeatEnabled: true}},
-            env: {}
-        })).toMatchObject({swarmHeartbeatEnabled: true});
-
-        // Heartbeat interval resolves from config when the env override is absent.
-        expect(resolveOrchestratorStartOptions({
-            orchestratorConfig: {deploymentMode: 'local', intervals: {swarmHeartbeatMs: 90000}},
-            env: {}
-        })).toMatchObject({swarmHeartbeatIntervalMs: 90000});
-    });
 });


### PR DESCRIPTION
Authored by Claude Opus 4.7 (Claude Code). Operator-prioritized after PR #12004 merge — substrate-cleanup palate-cleanser between wake-substrate lanes.

FAIR-band: under-target [12/30] — surgical deletion + getter consolidation; 5 files, -503/+124 LOC net.

Evidence: L1 (daemon.spec 9/9 + Orchestrator.invariants 22/22 + broader orchestrator tree 324/326 PASS — 2 pre-existing unrelated DreamService failures noted) → L1 sufficient for cleanup + new getter coverage. Residual: AC6 [operator live-smoke `npm run ai:orchestrator` post-merge].

Resolves #12005

## Summary

Completes the "thin Orchestrator" refactor wave (25+ recent tickets) by deleting the daemon.mjs config router that was left behind. The Orchestrator's own getter pattern (`get summarySweepIntervalMs() { return Env.parseNumber('NEO_...') ?? AiConfig.orchestrator.intervals.X; }` at lines 347-394) supersedes the daemon.mjs router — it does the same env-override + AiConfig fallback resolution. `Orchestrator.start({...resolveOrchestratorStartOptions()})` never consumed the 13 keys the resolver produced. ~80 LOC of pure dead code, pinned in place by 8+ daemon.spec.mjs test blocks asserting the dead resolver's output shape.

Per operator V-B-A challenge 2026-05-26T00:0xZ: *"looking at ai/daemons/orchestrator/daemon.mjs => to me this looks like it is doing its own thing. many configs which feel like they do no longer belong there at all."* Confirmed empirically + corrected.

## Deltas

- **`ai/daemons/orchestrator/daemon.mjs`** (362 → 186 LOC, -176 LOC):
  - Deleted `resolveOrchestratorStartOptions` + `assignConfigInterval` + `assignLocalOnlyToggle` (dead code — output never consumed by `Orchestrator.start`).
  - Deleted `resolveMlxConfig` + `resolveLmsConfig` (consolidated to Orchestrator getters).
  - Removed unused `Env` import.
  - Collapsed `startOrchestrator()` to thin process-boot wrapper: PID + signals + dotenv + Neo bootstrap + `loadLocalAiConfig` + delegate to `Orchestrator.start({dataDir, primaryDevSyncRootsConfig, ...options})`.

- **`ai/daemons/orchestrator/Orchestrator.mjs`** (+13 LOC):
  - 6 new getters mirroring the existing interval-getter pattern:
    - `get mlxEnabled() { return Env.parseBool('NEO_ORCHESTRATOR_MLX_ENABLED') ?? !!AiConfig.orchestrator.mlx?.enabled; }`
    - `get mlxModel()`, `get mlxPort()`, `get lmsEnabled()`, `get lmsModel()`, `get lmsPort()` — same pattern with respective env names + AiConfig slots.
  - `Orchestrator.start()` reads mlx/lms from `this.X` getters instead of `options.X`. JSDoc updated to remove mlx/lms from options signature (only test-injection seams remain).

- **`ai/daemons/orchestrator/TaskDefinitions.mjs`**:
  - JSDoc refreshed to reference Orchestrator getters instead of deleted daemon.mjs resolvers.

- **`test/playwright/unit/ai/daemons/orchestrator/daemon.spec.mjs`** (536 → 241 LOC, -295 LOC):
  - Deleted imports for removed `resolveOrchestratorStartOptions` / `resolveMlxConfig` / `resolveLmsConfig`.
  - Deleted 5 test blocks for removed resolvers (the dead-code-test anchor pattern that pinned the dead code in place).
  - Refreshed buildTaskDefinitions test comments to point at Orchestrator getters.

- **`test/playwright/unit/ai/daemons/orchestrator/Orchestrator.invariants.spec.mjs`** (+78 LOC):
  - 6 new tests for the new mlx/lms getters (env-precedence + AiConfig fallback + undefined-safety per getter). Mirrors the existing `kbSyncIntervalMs` getter-test pattern at lines 93-126.

## Contract Ledger

| Surface | Source of Authority | Behavior | Evidence |
|---|---|---|---|
| `daemon.mjs::startOrchestrator` | #12005 | Thin process-boot wrapper: PID + signals + dotenv + Neo + loadLocalAiConfig + delegate. No config pre-resolution. | daemon.spec.mjs 9/9 |
| `Orchestrator.mjs::mlxEnabled/mlxModel/mlxPort` (3 new getters) | #12005 + #11986/#11987 lms substrate | Env.parseBool/parseString first, AiConfig.orchestrator.mlx?.{enabled,model,port} fallback | Orchestrator.invariants.spec.mjs 22/22 (3 new tests) |
| `Orchestrator.mjs::lmsEnabled/lmsModel/lmsPort` (3 new getters) | #12005 + #11986/#11987 | Same pattern for lms; canonical defaults in `ai/config.template.mjs::orchestrator.lms` | Orchestrator.invariants.spec.mjs (3 new tests) |
| `Orchestrator.start()` mlx/lms consumption | #12005 | Reads `this.mlxEnabled/this.mlxModel/this.mlxPort/this.lmsEnabled/this.lmsModel/this.lmsPort` to build `buildTaskDefinitions` args | Existing orchestrator.spec.mjs coverage unaffected (no behavioral change) |
| `daemon.spec.mjs` test surface | #12005 | Tests for removed resolvers removed; buildTaskDefinitions + loadLocalAiConfig + bridge-daemon-isolation tests preserved + comment-refreshed | 9/9 PASS at commit `e366e1136` |

## Test Evidence

```
npm run test-unit -- test/playwright/unit/ai/daemons/orchestrator/daemon.spec.mjs
```
→ **9/9 PASS** at commit `e366e1136` (was 17 with dead-code tests; the 8 deleted tests verified the deleted code path).

```
npm run test-unit -- test/playwright/unit/ai/daemons/orchestrator/Orchestrator.invariants.spec.mjs
```
→ **22/22 PASS** at commit `e366e1136` (16 prior + 6 new mlx/lms getter tests). New tests cover env-precedence + AiConfig fallback + undefined-safety per getter.

```
npm run test-unit -- test/playwright/unit/ai/daemons/orchestrator/
```
→ **324/326 PASS** at commit `e366e1136`. Two unrelated pre-existing failures in `DreamService.spec.mjs` (sandman handoff fixture issues, same as noted in PR #11999 evidence — not caused by this change; my changes don't touch DreamService).

## ACs satisfied

- [x] AC1 — `daemon.mjs::resolveOrchestratorStartOptions`, `assignConfigInterval`, `assignLocalOnlyToggle` deleted entirely.
- [x] AC2 — `daemon.mjs::resolveMlxConfig`, `resolveLmsConfig` deleted; `Orchestrator` exposes 6 new getters mirroring the existing env+AiConfig fallback pattern.
- [x] AC3 — `Orchestrator.start()` consumes mlx/lms config via `this.X` getters (not via `options.X`); `buildTaskDefinitions` call at start():432-438 updated.
- [x] AC4 — `daemon.mjs::startOrchestrator` collapsed to thin boot wrapper (PID, signals, Neo bootstrap, config load, delegate). Only test-injection seams remain in the options signature.
- [x] AC5 — `daemon.spec.mjs` test blocks for the removed resolvers deleted. New Orchestrator getter test coverage for mlx/lms added in `Orchestrator.invariants.spec.mjs` (mirrors interval-getter test patterns).
- [ ] AC6 — Live smoke (deferred to operator post-merge): `npm run ai:orchestrator` boots cleanly; all lanes resolve cadence via getters; mlx/lms tasks (if enabled in config) launch correctly.
- [x] AC7 — Static grep clean: `grep -rn "resolveOrchestratorStartOptions\|resolveMlxConfig\|resolveLmsConfig\|assignConfigInterval\|assignLocalOnlyToggle" ai/ test/ --include='*.mjs'` returns **zero matches** post-commit.
- [ ] AC8 — Cross-family review per `pull-request §6.1` — this PR.

## Post-Merge Validation

- [ ] AC6 — Operator runs `npm run ai:orchestrator` from a fresh checkout; verifies (a) orchestrator boots without errors, (b) all 6 cadence-driven lanes (summary, kbSync, backup, primaryDevSync, dream, goldenPath, swarmHeartbeat) resolve their cadence via the Orchestrator getter chain, (c) if `mlx.enabled` or `lms.enabled` is set in `ai/config.mjs`, the respective task launches with model + port from the AiConfig slot.

## Avoided Traps

- Preserving `resolveOrchestratorStartOptions` as a "backwards-compat shim" — operator's standing rule: "no backwards compatibility for these config migrations." The flat-options bag was always discarded; preserving it would extend the dead-code lifetime indefinitely.
- Moving mlx/lms config INTO each task definition's module — would diverge from the established interval-getter pattern; consistency wins.
- Keeping the daemon.spec.mjs dead-code-test blocks "for archaeology" — removed-code tests are debt; the removed code's intent is preserved in this commit's body + ticket #12005 body + git history.
- Touching the legacy enum-based `targetSource` (out of scope; #12003 addresses activity-derived candidate discovery as a separate lane).

## Authority

Operator-prioritized after PR #12004 merge ("12005 first?" 2026-05-26T00:1xZ). Self-assigned to #12005 at file-time + lane-claimed to AGENT:* before any tracked-file edit (§critical_gates #7 satisfied this time — lesson from the prior PR #11999 process slip).

Origin Session ID: `09321e82-482f-45aa-8e73-9d44381ff875`

Authored by [Claude Opus 4.7] (Claude Code) — substrate-cleanup completion of the 25+-ticket "thin Orchestrator" refactor wave.

## Commits

- `e366e1136` — `refactor(orchestrator): delete daemon.mjs router dead code; consolidate mlx/lms config into Orchestrator getters (#12005)`
