### PR TITLE
feat(orchestrator): active-a2a-participants target source for activity-derived pulse candidate discovery (#12003)

### DIFF
--- a/ai/config.template.mjs
+++ b/ai/config.template.mjs
@@ -198,15 +198,27 @@ class Config extends BaseConfig {
              */
             swarmHeartbeat: {
                 /**
-                 * Resolver source enum. `null` falls through to `'self'` — the
-                 * deployment-portable default. Valid values: `'self'`,
-                 * `'active-local-team'`, `'active-subscribers'`, `'disabled'`. External
-                 * workspaces with no config default to `'self'`; the lane never silently
-                 * fans out to maintainer identities unless the operator explicitly opts
-                 * in via `'active-local-team'`.
-                 * @type {'self'|'active-local-team'|'active-subscribers'|'disabled'|null}
+                 * Resolver source enum. Tracked default is `'active-a2a-participants'`
+                 * per Discussion #11992 §5.1.1 "activity-derived signals" framing — the
+                 * pulse candidate set is auto-discovered from A2A `MESSAGE` activity
+                 * within the last 3h (sibling to the per-identity `active` signal). This
+                 * is per-MC-instance derived (no team-registry coupling), so external
+                 * workspaces only ever see their own MC's activity — tenant-safe.
+                 *
+                 * Valid values: `'self'`, `'active-local-team'`, `'active-subscribers'`,
+                 * `'active-a2a-participants'`, `'disabled'`. `null` falls through to
+                 * `'self'` (deployment-portable code-side safety net).
+                 *
+                 * - `'self'` — pulse only the harness owner (`NEO_AGENT_IDENTITY`)
+                 * - `'active-local-team'` — reads `identityRoots.mjs` Neo-team registry
+                 * - `'active-subscribers'` — unions self with `WAKE_SUBSCRIPTION` nodes
+                 * - `'active-a2a-participants'` — unions self with identities active in
+                 *   A2A graph within last 3h (the default)
+                 * - `'disabled'` — no pulse targets
+                 *
+                 * @type {'self'|'active-local-team'|'active-subscribers'|'active-a2a-participants'|'disabled'|null}
                  */
-                targetSource: null
+                targetSource: 'active-a2a-participants'
             },
             /**
              * Local-only maintenance lane switches. Cloud deployments can disable these

--- a/ai/daemons/orchestrator/scheduling/swarmHeartbeat.mjs
+++ b/ai/daemons/orchestrator/scheduling/swarmHeartbeat.mjs
@@ -10,6 +10,7 @@ export const VALID_TARGET_SOURCES = Object.freeze([
     'self',
     'active-local-team',
     'active-subscribers',
+    'active-a2a-participants',
     'disabled'
 ]);
 
@@ -77,10 +78,11 @@ export function getDueTask({state, now, swarmHeartbeatIntervalMs}) {
  */
 export async function resolveTargets({
     selfIdentity,
-    targetSource             = null,
-    explicitTargets          = null,
-    activeSubscribersProvider = null,
-    logger                   = console
+    targetSource                  = null,
+    explicitTargets               = null,
+    activeSubscribersProvider     = null,
+    activeA2aParticipantsProvider = null,
+    logger                        = console
 } = {}) {
     const log = (level, msg) => {
         const fn = typeof logger?.[level] === 'function' ? logger[level] : console[level];
@@ -157,6 +159,33 @@ export async function resolveTargets({
                 out.push(normalizedSelf);
             }
             for (const raw of subscribers) {
+                const id = normalizeAgentIdentityNodeId(raw);
+                if (id && !seen.has(id)) {
+                    seen.add(id);
+                    out.push(id);
+                }
+            }
+            return out;
+        }
+
+        case 'active-a2a-participants': {
+            // Activity-derived candidate discovery per Discussion #11992 §5.1.1 framing —
+            // pulse candidate set is auto-discovered from A2A graph activity within the
+            // 3h `active` window (`getRecentActivityTimestamps` per-identity sibling).
+            // Per-MC-instance derived; no team-registry coupling (safe for external
+            // workspaces — they only ever see their own activity).
+            if (typeof activeA2aParticipantsProvider !== 'function') {
+                log('warn', `[resolveSwarmHeartbeatTargets] targetSource='active-a2a-participants' requires activeA2aParticipantsProvider; falling back to 'self'`);
+                return selfFallback('active-a2a-participants-missing-provider');
+            }
+            const participants = (await activeA2aParticipantsProvider()) || [];
+            const seen = new Set();
+            const out  = [];
+            if (normalizedSelf) {
+                seen.add(normalizedSelf);
+                out.push(normalizedSelf);
+            }
+            for (const raw of participants) {
                 const id = normalizeAgentIdentityNodeId(raw);
                 if (id && !seen.has(id)) {
                     seen.add(id);

--- a/ai/daemons/orchestrator/scheduling/swarmHeartbeat.mjs
+++ b/ai/daemons/orchestrator/scheduling/swarmHeartbeat.mjs
@@ -39,41 +39,53 @@ export function getDueTask({state, now, swarmHeartbeatIntervalMs}) {
 /**
  * @summary Resolve the per-pulse identity set the swarm-heartbeat lane should target.
  *
- * Five-step precedence chain:
+ * Precedence chain:
  *
  *   1. Explicit `explicitTargets` list (highest precedence; bypasses source-based logic).
  *      Sourced from `NEO_ORCHESTRATOR_SWARM_HEARTBEAT_TARGETS` (comma-separated handles).
- *   2. `targetSource` enum (`'self'|'active-local-team'|'active-subscribers'|'disabled'`),
- *      env-overridable via `NEO_ORCHESTRATOR_SWARM_HEARTBEAT_TARGET_SOURCE`.
- *   3. Default `'self'` when `targetSource` is nullish — the deployment-portable safe default.
- *   4. `'active-local-team'` reads `identityRoots.IDENTITIES` filtered on
- *      `type === 'AgentIdentity'` AND `properties.participationStatus === 'active'`. The
- *      registry is team-shaped; external forks customizing `identityRoots.mjs` get their
- *      own team filter for free.
- *   5. Cloud/fork safety: external workspaces with no config default to `'self'`; unknown
- *      `targetSource` values fail-closed to `'self'` with a warn log. The lane never
- *      silently fans out to maintainer identities. Operators must explicitly opt-in to
- *      `'active-local-team'` to receive cross-team pulses.
+ *   2. `targetSource` enum (see {@link VALID_TARGET_SOURCES} — 5 values), env-overridable
+ *      via `NEO_ORCHESTRATOR_SWARM_HEARTBEAT_TARGET_SOURCE`.
+ *   3. Code-side null→self fallback when `targetSource` is nullish (the deployment-portable
+ *      safety net for the rare case where the tracked template default is bypassed). The
+ *      tracked default in `ai/config.template.mjs` is `'active-a2a-participants'` per #12003.
  *
- * `'active-subscribers'` delegates to the injected `activeSubscribersProvider` callable
- * (the existing `WAKE_SUBSCRIPTION` SQL discovery in
- * `SwarmHeartbeatService.getWakeSubscriptionIdentities()`); union with `selfIdentity`
- * keeps the harness owner in the pulse set.
+ * **Per-source semantics:**
  *
- * `'disabled'` returns `[]` plus an info log. Downstream `pulse()` skips per-identity
- * work (sunset detection, idle-out nudge) while identity-agnostic substrate maintenance
- * (TTL sweep, all-agent-idle detection, liveness touch) still runs.
+ * - **`'self'`** — pulses only the harness owner (`selfIdentity`); deployment-portable
+ *   minimal-fan-out shape.
+ * - **`'active-local-team'`** — reads `identityRoots.IDENTITIES` filtered on
+ *   `type === 'AgentIdentity'` AND `properties.participationStatus === 'active'`. Team-
+ *   registry coupled (suitable for Neo team workspace; external forks customize
+ *   `identityRoots.mjs` to get their own team filter for free).
+ * - **`'active-subscribers'`** — delegates to injected `activeSubscribersProvider`
+ *   (the existing `WAKE_SUBSCRIPTION` SQL discovery in
+ *   `SwarmHeartbeatService.getWakeSubscriptionIdentities()`); union with `selfIdentity`.
+ *   Subscription-presence-based — degrades on dormant subscribers.
+ * - **`'active-a2a-participants'`** (#12003) — delegates to injected
+ *   `activeA2aParticipantsProvider` (the `SwarmHeartbeatService.getActiveA2aParticipants()`
+ *   3h `MESSAGE`-edge query); union with `selfIdentity`. Activity-derived — per-MC-instance
+ *   discovery, tenant-safe (no team-registry coupling), self-healing 3h sliding window.
+ *   Per Discussion #11992 §5.1.1 framing; **tracked template default**.
+ * - **`'disabled'`** — returns `[]` plus an info log. Downstream `pulse()` skips per-identity
+ *   work (sunset detection, idle-out nudge) while identity-agnostic substrate maintenance
+ *   (TTL sweep, all-agent-idle detection, liveness touch) still runs.
+ *
+ * Cloud/fork safety: external workspaces never silently fan out to maintainer identities.
+ * `'active-a2a-participants'` and `'active-subscribers'` are per-MC-instance derived (each
+ * deployment's MC has its own A2A activity and subscriptions); only `'active-local-team'`
+ * has team-registry coupling and must be operator-opted-into.
  *
  * Pure function: side effects limited to logger calls. Output is deduplicated and
  * order-preserving; each target is normalized via `normalizeAgentIdentityNodeId` so
  * the slot holds canonical `@<id>` form.
  *
  * @param {Object}         opts
- * @param {String}         opts.selfIdentity                  Primary identity (orchestrator harness owner).
- * @param {String|null}    [opts.targetSource=null]           Resolver source enum (see {@link VALID_TARGET_SOURCES}).
- * @param {String[]|null}  [opts.explicitTargets=null]        Explicit target list (wins when non-empty).
- * @param {Function}       [opts.activeSubscribersProvider]   Async `() => Promise<String[]>` for `'active-subscribers'`.
- * @param {Object}         [opts.logger=console]              Logger; defaults to console.
+ * @param {String}         opts.selfIdentity                       Primary identity (orchestrator harness owner).
+ * @param {String|null}    [opts.targetSource=null]                Resolver source enum (see {@link VALID_TARGET_SOURCES}).
+ * @param {String[]|null}  [opts.explicitTargets=null]             Explicit target list (wins when non-empty).
+ * @param {Function}       [opts.activeSubscribersProvider]        Async `() => Promise<String[]>` for `'active-subscribers'`.
+ * @param {Function}       [opts.activeA2aParticipantsProvider]    Async `() => Promise<String[]>` for `'active-a2a-participants'` (#12003).
+ * @param {Object}         [opts.logger=console]                   Logger; defaults to console.
  * @returns {Promise<String[]>}  Normalized canonical `@<identity>` strings (deduplicated, order-preserving).
  */
 export async function resolveTargets({

--- a/ai/daemons/orchestrator/services/SwarmHeartbeatService.mjs
+++ b/ai/daemons/orchestrator/services/SwarmHeartbeatService.mjs
@@ -542,6 +542,13 @@ class SwarmHeartbeatService extends Base {
      * (Discussion #11992 §5.1.1 + Epic #11993 cycle-3 "activity-derived signals are durable"
      * framing) — sibling to per-identity `getRecentActivityTimestamps`.
      *
+     * **3-branch UNION mirrors mailbox semantics:**
+     * - `SENT_TO` → direct-message recipients (`AGENT:*` sentinel excluded — broadcasts don't
+     *   land at a real identity; the per-recipient `DELIVERED_TO` edges are the actual recipients)
+     * - `DELIVERED_TO` → per-recipient broadcast targets (the canonical fan-out edge)
+     * - `SENT_BY`  → message senders (so an active sender lands in the candidate set even
+     *   if no one has replied yet within 3h)
+     *
      * @returns {Promise<String[]>} Normalized canonical `@<identity>` strings, deduplicated.
      * @protected
      */
@@ -564,13 +571,21 @@ class SwarmHeartbeatService extends Base {
                     SELECT e.target AS identity
                     FROM Edges e
                     JOIN Nodes n ON n.id = e.source
+                    WHERE e.type = 'DELIVERED_TO'
+                      AND json_extract(n.data, '$.label') = 'MESSAGE'
+                      AND json_extract(n.data, '$.properties.sentAt') >= ?
+                      AND e.target IS NOT NULL
+                    UNION
+                    SELECT e.target AS identity
+                    FROM Edges e
+                    JOIN Nodes n ON n.id = e.source
                     WHERE e.type = 'SENT_BY'
                       AND json_extract(n.data, '$.label') = 'MESSAGE'
                       AND json_extract(n.data, '$.properties.sentAt') >= ?
                       AND e.target IS NOT NULL
                 )
             `);
-            return stmt.all(cutoffIso, cutoffIso)
+            return stmt.all(cutoffIso, cutoffIso, cutoffIso)
                 .map(row => row.identity)
                 .filter(Boolean)
                 .map(identity => normalizeAgentIdentityNodeId(identity))

--- a/ai/daemons/orchestrator/services/SwarmHeartbeatService.mjs
+++ b/ai/daemons/orchestrator/services/SwarmHeartbeatService.mjs
@@ -523,12 +523,62 @@ class SwarmHeartbeatService extends Base {
      */
     async getPulseIdentities() {
         return await resolveHeartbeatTargets({
-            selfIdentity             : this.identity,
-            targetSource             : this.targetSource,
-            explicitTargets          : this.explicitTargets,
-            activeSubscribersProvider: () => this.getWakeSubscriptionIdentities(),
+            selfIdentity                 : this.identity,
+            targetSource                 : this.targetSource,
+            explicitTargets              : this.explicitTargets,
+            activeSubscribersProvider    : () => this.getWakeSubscriptionIdentities(),
+            activeA2aParticipantsProvider: () => this.getActiveA2aParticipants(),
             logger
         });
+    }
+
+    /**
+     * @summary SQLite query: distinct AgentIdentity nodes with A2A `MESSAGE` activity
+     * (sent OR received) within the last 3h.
+     *
+     * Per-MC-instance derived candidate-discovery — no team-registry coupling. External
+     * workspaces only ever see their own MC's A2A activity, so default fan-out is
+     * tenant-safe. Implements the activity-derived discovery side of the 3-signal model
+     * (Discussion #11992 §5.1.1 + Epic #11993 cycle-3 "activity-derived signals are durable"
+     * framing) — sibling to per-identity `getRecentActivityTimestamps`.
+     *
+     * @returns {Promise<String[]>} Normalized canonical `@<identity>` strings, deduplicated.
+     * @protected
+     */
+    async getActiveA2aParticipants() {
+        try {
+            const cutoffMs   = Date.now() - 3 * 60 * 60 * 1000;
+            const cutoffIso  = new Date(cutoffMs).toISOString();
+            const db         = this.getGraphDb();
+            const stmt = db.prepare(`
+                SELECT DISTINCT identity FROM (
+                    SELECT e.target AS identity
+                    FROM Edges e
+                    JOIN Nodes n ON n.id = e.source
+                    WHERE e.type = 'SENT_TO'
+                      AND json_extract(n.data, '$.label') = 'MESSAGE'
+                      AND json_extract(n.data, '$.properties.sentAt') >= ?
+                      AND e.target IS NOT NULL
+                      AND e.target != 'AGENT:*'
+                    UNION
+                    SELECT e.target AS identity
+                    FROM Edges e
+                    JOIN Nodes n ON n.id = e.source
+                    WHERE e.type = 'SENT_BY'
+                      AND json_extract(n.data, '$.label') = 'MESSAGE'
+                      AND json_extract(n.data, '$.properties.sentAt') >= ?
+                      AND e.target IS NOT NULL
+                )
+            `);
+            return stmt.all(cutoffIso, cutoffIso)
+                .map(row => row.identity)
+                .filter(Boolean)
+                .map(identity => normalizeAgentIdentityNodeId(identity))
+                .filter(Boolean);
+        } catch (err) {
+            logger.error('[SwarmHeartbeatService] getActiveA2aParticipants failed:', err);
+            return [];
+        }
     }
 
     /**

--- a/test/playwright/unit/ai/config.template.spec.mjs
+++ b/test/playwright/unit/ai/config.template.spec.mjs
@@ -107,6 +107,14 @@ test.describe('Tier 1 Config Immutability', () => {
             wakeDispatchEnabled  : null
         });
 
+        // #12003: swarm-heartbeat candidate-discovery default is the activity-derived
+        // source per Discussion #11992 §5.1.1 "activity-derived signals" framing.
+        // Per-MC-instance derived; no team-registry coupling; tenant-safe for external
+        // workspaces (each deployment's MC has its own A2A activity).
+        expect(Config.orchestrator.swarmHeartbeat).toEqual({
+            targetSource: 'active-a2a-participants'
+        });
+
         expect(Config.maintenance.backup).toEqual({
             intervalMs: 24 * 60 * 60 * 1000,
             retention: {

--- a/test/playwright/unit/ai/daemons/orchestrator/scheduling/swarmHeartbeat.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/scheduling/swarmHeartbeat.spec.mjs
@@ -237,6 +237,51 @@ test.describe('resolveTargets — deployment-portable swarm-heartbeat target res
         expect(result).toEqual(['@neo-opus-4-7']);
     });
 
+    // ----- active-a2a-participants (#12003): activity-derived candidate discovery -----
+
+    test('active-a2a-participants — unions self with provider output (3h A2A activity)', async () => {
+        const participants = ['@neo-gpt', '@neo-opus-4-7', 'neo-gemini-3-1-pro'];
+        const result = await resolveTargets({
+            selfIdentity                  : '@neo-opus-4-7',
+            targetSource                  : 'active-a2a-participants',
+            activeA2aParticipantsProvider : async () => participants
+        });
+        // Self appears first; participants union (no duplicates); 3rd entry gets normalized.
+        expect(result).toEqual(['@neo-opus-4-7', '@neo-gpt', '@neo-gemini-3-1-pro']);
+    });
+
+    test('active-a2a-participants without provider — falls back to self with warn', async () => {
+        const logger = captureLogger();
+        const result = await resolveTargets({
+            selfIdentity: '@neo-opus-4-7',
+            targetSource: 'active-a2a-participants',
+            logger
+        });
+        expect(result).toEqual(['@neo-opus-4-7']);
+        expect(logger.calls.some(c => c.level === 'warn' && c.msg.includes('active-a2a-participants'))).toBe(true);
+    });
+
+    test('active-a2a-participants — empty participants + valid self yields just [self]', async () => {
+        const result = await resolveTargets({
+            selfIdentity                  : '@neo-opus-4-7',
+            targetSource                  : 'active-a2a-participants',
+            activeA2aParticipantsProvider : async () => []
+        });
+        expect(result).toEqual(['@neo-opus-4-7']);
+    });
+
+    test('null selfIdentity + active-a2a-participants missing provider falls back to self + logs warn AND info', async () => {
+        const logger = captureLogger();
+        const result = await resolveTargets({
+            selfIdentity: null,
+            targetSource: 'active-a2a-participants',
+            logger
+        });
+        expect(result).toEqual([]);
+        expect(logger.calls.some(c => c.level === 'warn' && c.msg.includes('active-a2a-participants'))).toBe(true);
+        expect(logger.calls.some(c => c.level === 'info' && c.msg.includes('active-a2a-participants-missing-provider'))).toBe(true);
+    });
+
     test('normalization — selfIdentity without @ prefix gets canonicalized', async () => {
         const result = await resolveTargets({
             selfIdentity: 'neo-opus-4-7'  // no @ prefix
@@ -244,8 +289,8 @@ test.describe('resolveTargets — deployment-portable swarm-heartbeat target res
         expect(result).toEqual(['@neo-opus-4-7']);
     });
 
-    test('VALID_TARGET_SOURCES — exported as frozen tuple of the 4 supported enum values', () => {
-        expect(VALID_TARGET_SOURCES).toEqual(['self', 'active-local-team', 'active-subscribers', 'disabled']);
+    test('VALID_TARGET_SOURCES — exported as frozen tuple of the 5 supported enum values', () => {
+        expect(VALID_TARGET_SOURCES).toEqual(['self', 'active-local-team', 'active-subscribers', 'active-a2a-participants', 'disabled']);
         expect(Object.isFrozen(VALID_TARGET_SOURCES)).toBe(true);
     });
 });

--- a/test/playwright/unit/ai/daemons/orchestrator/services/SwarmHeartbeatService.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/services/SwarmHeartbeatService.spec.mjs
@@ -419,40 +419,58 @@ test.describe('Neo.ai.daemons.SwarmHeartbeatService', () => {
         ]);
     });
 
-    test('getActiveA2aParticipants() returns deduplicated normalized identities from A2A graph (3h window) (#12003)', async () => {
+    test('getActiveA2aParticipants() SQL covers SENT_TO + DELIVERED_TO + SENT_BY edge taxonomy, excludes AGENT:* sentinel, applies 3h cutoff (#12003 cycle-2)', async () => {
         applyDefaultStubs();
 
-        // Capture the SQL params passed by the implementation so the test asserts the
-        // 3h cutoff is being applied — both SENT_TO and SENT_BY queries get the cutoff.
-        const capturedParams = [];
+        // Capture both the SQL string and the parameters so the test asserts the
+        // edge taxonomy (the contract from #12003), not just the returned identity list.
+        let capturedSql       = null;
+        const capturedParams  = [];
         SwarmHeartbeatService.getGraphDb = () => {
             return {
-                prepare: () => ({
-                    all: (...params) => {
-                        capturedParams.push(params);
-                        return [
-                            {identity: 'neo-gpt'},
-                            {identity: '@neo-opus-4-7'},
-                            {identity: null},
-                            {identity: '@neo-gemini-3-1-pro'}
-                        ];
-                    }
-                })
+                prepare: sql => {
+                    capturedSql = sql;
+                    return {
+                        all: (...params) => {
+                            capturedParams.push(params);
+                            return [
+                                {identity: 'neo-gpt'},          // SENT_TO recipient (direct DM)
+                                {identity: '@neo-opus-4-7'},    // DELIVERED_TO recipient (broadcast fan-out)
+                                {identity: null},
+                                {identity: '@neo-gemini-3-1-pro'} // SENT_BY sender
+                            ];
+                        }
+                    };
+                }
             }
         };
 
         const serviceProto = Object.getPrototypeOf(SwarmHeartbeatService);
         const result       = await serviceProto.getActiveA2aParticipants.call(SwarmHeartbeatService);
 
-        // Identities normalized + null filtered; order preserved.
+        // SQL edge-taxonomy contract: all 3 edge classes covered.
+        expect(capturedSql).toContain("e.type = 'SENT_TO'");
+        expect(capturedSql).toContain("e.type = 'DELIVERED_TO'");
+        expect(capturedSql).toContain("e.type = 'SENT_BY'");
+        // SENT_TO branch explicitly excludes the AGENT:* broadcast sentinel — the
+        // per-recipient DELIVERED_TO edges are the canonical broadcast targets.
+        expect(capturedSql).toContain("e.target != 'AGENT:*'");
+        // 3h cutoff applied via sentAt comparison.
+        expect(capturedSql).toContain("json_extract(n.data, '$.properties.sentAt') >= ?");
+        // MESSAGE label filter on all branches.
+        expect(capturedSql).toContain("json_extract(n.data, '$.label') = 'MESSAGE'");
+
+        // Identities normalized + null filtered; dedup via SELECT DISTINCT.
         expect(result).toEqual(['@neo-gpt', '@neo-opus-4-7', '@neo-gemini-3-1-pro']);
-        // Two cutoff params passed (SENT_TO + SENT_BY UNION); both should be ISO strings.
-        expect(capturedParams.length).toBe(1);
-        expect(capturedParams[0]).toHaveLength(2);
-        expect(capturedParams[0][0]).toMatch(/^\d{4}-\d{2}-\d{2}T/);
-        expect(capturedParams[0][1]).toMatch(/^\d{4}-\d{2}-\d{2}T/);
-        // Both cutoff params identical (same Date.now() snapshot).
+
+        // 3 cutoff params (one per UNION branch); identical (same Date.now() snapshot); ISO format.
+        expect(capturedParams).toHaveLength(1);
+        expect(capturedParams[0]).toHaveLength(3);
+        for (const param of capturedParams[0]) {
+            expect(param).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+        }
         expect(capturedParams[0][0]).toBe(capturedParams[0][1]);
+        expect(capturedParams[0][1]).toBe(capturedParams[0][2]);
     });
 
     test('getActiveA2aParticipants() returns [] on query failure (substrate-error fallback)', async () => {

--- a/test/playwright/unit/ai/daemons/orchestrator/services/SwarmHeartbeatService.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/services/SwarmHeartbeatService.spec.mjs
@@ -377,6 +377,9 @@ test.describe('Neo.ai.daemons.SwarmHeartbeatService', () => {
 
         SwarmHeartbeatService.targetSource = 'active-local-team';
         expect(SwarmHeartbeatService.targetSource).toBe('active-local-team');
+
+        SwarmHeartbeatService.targetSource = 'active-a2a-participants';
+        expect(SwarmHeartbeatService.targetSource).toBe('active-a2a-participants');
     });
 
     test('beforeSetExplicitTargets normalizes + coerces empty to null', async () => {
@@ -414,6 +417,57 @@ test.describe('Neo.ai.daemons.SwarmHeartbeatService', () => {
             '@neo-gpt',
             '@neo-opus-4-7'
         ]);
+    });
+
+    test('getActiveA2aParticipants() returns deduplicated normalized identities from A2A graph (3h window) (#12003)', async () => {
+        applyDefaultStubs();
+
+        // Capture the SQL params passed by the implementation so the test asserts the
+        // 3h cutoff is being applied — both SENT_TO and SENT_BY queries get the cutoff.
+        const capturedParams = [];
+        SwarmHeartbeatService.getGraphDb = () => {
+            return {
+                prepare: () => ({
+                    all: (...params) => {
+                        capturedParams.push(params);
+                        return [
+                            {identity: 'neo-gpt'},
+                            {identity: '@neo-opus-4-7'},
+                            {identity: null},
+                            {identity: '@neo-gemini-3-1-pro'}
+                        ];
+                    }
+                })
+            }
+        };
+
+        const serviceProto = Object.getPrototypeOf(SwarmHeartbeatService);
+        const result       = await serviceProto.getActiveA2aParticipants.call(SwarmHeartbeatService);
+
+        // Identities normalized + null filtered; order preserved.
+        expect(result).toEqual(['@neo-gpt', '@neo-opus-4-7', '@neo-gemini-3-1-pro']);
+        // Two cutoff params passed (SENT_TO + SENT_BY UNION); both should be ISO strings.
+        expect(capturedParams.length).toBe(1);
+        expect(capturedParams[0]).toHaveLength(2);
+        expect(capturedParams[0][0]).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+        expect(capturedParams[0][1]).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+        // Both cutoff params identical (same Date.now() snapshot).
+        expect(capturedParams[0][0]).toBe(capturedParams[0][1]);
+    });
+
+    test('getActiveA2aParticipants() returns [] on query failure (substrate-error fallback)', async () => {
+        applyDefaultStubs();
+
+        SwarmHeartbeatService.getGraphDb = () => {
+            return {
+                prepare: () => {
+                    throw new Error('simulated graph DB unavailability');
+                }
+            }
+        };
+
+        const serviceProto = Object.getPrototypeOf(SwarmHeartbeatService);
+        await expect(serviceProto.getActiveA2aParticipants.call(SwarmHeartbeatService)).resolves.toEqual([]);
     });
 
     test('pulse() skips idle_out_nudge when gate is closed', async () => {


### PR DESCRIPTION
Authored by Claude Opus 4.7 (Claude Code). 3am sleep-blocking lane before the tenant deployment test tomorrow — operator-prioritized to complete the wake-substrate end-to-end picture for one more orchestrator-restart live test.

FAIR-band: under-target [16/30] — Epic #11993 follow-up; surgical addition (1 enum value + 1 new method + 1 template-default flip) + per-discipline test coverage + cycle-2 edge-taxonomy strengthening.

Evidence: L1 (58/58 PASS swarmHeartbeat.spec + SwarmHeartbeatService.spec + config.template.spec at cycle-2) → L1 sufficient for candidate-discovery substrate. Residual: AC8 [Epic #11993 — operator post-merge live wake confirmation, the actual end-to-end signal this PR unblocks].

Resolves #12003

## Summary

Closes the **candidate-discovery half** of Epic #11993 cycle-3 *"activity-derived signals are durable"* framing. Sub-ii (#11995) shipped the per-identity `active`/`idle`/`ready` decision function via `WakeDecisionService.decideWake`; **but the pulse-loop candidate set still used the legacy `targetSource` enum.** Default `null → 'self'` meant orchestrator-started-from-any-harness-owner-repo only ever pulsed that identity; `@neo-gpt` and `@neo-gemini-3-1-pro` never entered the loop.

**Empirical anchor:** 2026-05-25T23:04Z operator restart on Epic #11993 substrate + 17min `@neo-gpt`-quiet test → **zero `heartbeat_pulse` GraphLog rows landed** despite multiple pulse cycles firing (heartbeat.alive mtime advancing every ~15min). The substrate did exactly what `targetSource: 'self'` specified, but that specification didn't match the Discussion's "activity-derived candidate set" framing.

Operator architectural verdict 2026-05-26T00:5xZ: *"the env var agent id can not be enough"* + *"new ideas how to detect active participants via the 3h window"* + *"this must work for EVERY user; if needed, config.template."*

## Deltas

Cycle-1 (commit `3775da468`):

1. **`ai/daemons/orchestrator/scheduling/swarmHeartbeat.mjs`**:
   - `VALID_TARGET_SOURCES` gains `'active-a2a-participants'` (5th enum value, additive)
   - `resolveTargets` accepts new `activeA2aParticipantsProvider` callable; new case unions self with provider output (mirrors `'active-subscribers'` shape — same precedence: explicit > source > self-fallback)

2. **`ai/daemons/orchestrator/services/SwarmHeartbeatService.mjs`**:
   - New `getActiveA2aParticipants()` SQLite query — see cycle-2 row #5 for the final 3-branch UNION shape
   - Wired into `getPulseIdentities()` via `activeA2aParticipantsProvider: () => this.getActiveA2aParticipants()`

3. **`ai/config.template.mjs`**:
   - Default `targetSource` ships as `'active-a2a-participants'` (was `null` falling through to `'self'`). Per-MC-instance derived candidate discovery is tenant-safe — no team-registry coupling like `'active-local-team'`. External workspaces only ever see their own MC's activity.
   - Code-side `null → 'self'` fallback in `resolveTargets` preserved as deployment-portable safety net (for operators predating this template update OR explicitly setting null).
   - JSDoc on the slot updated to describe all 5 enum values + the new default rationale.

4. **`swarmHeartbeat.spec.mjs`**: 4 new tests for the new source (unions-self-with-provider happy path, missing-provider warn fallback, empty-participants-self-only, null-selfIdentity warn+info) + updated `VALID_TARGET_SOURCES` tuple test to reflect 5 values

5. **`SwarmHeartbeatService.spec.mjs`** (cycle-1 shape): `beforeSetTargetSource` test gains `'active-a2a-participants'` valid-value assertion + 2 new tests for `getActiveA2aParticipants` (cycle-2 strengthened these — see below)

Cycle-2 (commit `635e81f95`, addressing @neo-gpt cycle-1 CHANGES_REQUESTED):

6. **`SwarmHeartbeatService.mjs::getActiveA2aParticipants` SQL — 3-branch UNION** (was 2 in cycle-1):
   - `SENT_TO` — direct-message recipients (`AGENT:*` sentinel excluded — broadcasts don't land at a real identity)
   - **`DELIVERED_TO`** — per-recipient broadcast fan-out (the canonical broadcast target edge; was missing in cycle-1 → broadcast-only recipients never entered the candidate set)
   - `SENT_BY` — message senders (so an active sender lands in the candidate set even if no one has replied within 3h)
   - JSDoc rewritten to document the 3-branch shape mirroring mailbox delivery semantics

7. **`SwarmHeartbeatService.spec.mjs` edge-taxonomy assertions strengthened**: test now captures the SQL string + parameters and asserts all 3 edge classes present, `AGENT:*` sentinel exclusion preserved, 3-identical-ISO-cutoff params (one per UNION branch), MESSAGE label filter — proves contract at the SQL layer, not just mocked-rows.

8. **`test/playwright/unit/ai/config.template.spec.mjs`**: new assertion `expect(Config.orchestrator.swarmHeartbeat).toEqual({targetSource: 'active-a2a-participants'})` — direct regression coverage for the shipped tracked default per AC6.

9. **`swarmHeartbeat.mjs::resolveTargets` JSDoc rewritten**: 5-value enum referenced via `{@link VALID_TARGET_SOURCES}` (was 4-value enumeration inline), per-source semantics documented for all 5 values, tracked template default explicitly called out, new `activeA2aParticipantsProvider` param documented, cloud/fork-safety framing refined (per-MC-instance derivation vs team-registry coupling distinction).

## Contract Ledger

| Surface | Source of Authority | Behavior | Evidence |
|---|---|---|---|
| `swarmHeartbeat.mjs::VALID_TARGET_SOURCES` | Discussion #11992 §5.1.1 + #12003 | Adds `'active-a2a-participants'`; existing 4 values preserved | swarmHeartbeat.spec frozen-tuple assertion |
| `resolveTargets({targetSource: 'active-a2a-participants', activeA2aParticipantsProvider})` | #12003 | Returns union of `selfIdentity` + provider-discovered identities; deduplicated, normalized | swarmHeartbeat.spec 4 new tests |
| `SwarmHeartbeatService.getActiveA2aParticipants()` | #12003 cycle-2 | Returns `Promise<String[]>` of normalized canonical `@<identity>` strings from A2A graph within last 3h via 3-branch UNION (`SENT_TO` direct + `DELIVERED_TO` broadcast-fan-out + `SENT_BY` senders); `AGENT:*` sentinel excluded on `SENT_TO` branch; deduplicated via `SELECT DISTINCT` | SwarmHeartbeatService.spec edge-taxonomy assertion (SQL string + 3-ISO-param capture) + error-fallback test |
| `Config.orchestrator.swarmHeartbeat` template default | #12003 cycle-2 (AC6) | `{targetSource: 'active-a2a-participants'}` shipped as canonical default | config.template.spec direct equality assertion |
| `config.template.mjs` tracked default | Operator direction 2026-05-26T00:5xZ | `swarmHeartbeat.targetSource: 'active-a2a-participants'` (was `null`) | Code-side `null → 'self'` fallback unchanged; operators with existing overlays carrying null get safe default behavior; bootstrap-fresh operators get the activity-derived discovery |

## Test Evidence

```
npm run test-unit -- test/playwright/unit/ai/config.template.spec.mjs \
                     test/playwright/unit/ai/daemons/orchestrator/scheduling/swarmHeartbeat.spec.mjs \
                     test/playwright/unit/ai/daemons/orchestrator/services/SwarmHeartbeatService.spec.mjs
```
→ **58/58 PASS** at commit `635e81f95` (cycle-2).

Coverage breakdown:
- config.template.spec.mjs: 5/5 PASS (existing 4 + 1 new swarmHeartbeat-default assertion per cycle-2)
- swarmHeartbeat.spec.mjs: 21/21 PASS (16 prior + 4 new active-a2a-participants tests + 1 updated VALID_TARGET_SOURCES tuple test)
- SwarmHeartbeatService.spec.mjs: 32/32 PASS (29 prior + 1 enum-coverage assertion in beforeSetTargetSource + 2 new getActiveA2aParticipants tests strengthened cycle-2 with SQL edge-taxonomy assertions)

## ACs satisfied

- [x] AC1 — `VALID_TARGET_SOURCES` includes `'active-a2a-participants'`; export unchanged otherwise; frozen-tuple invariant preserved.
- [x] AC2 — `resolveTargets({targetSource: 'active-a2a-participants'})` invokes `activeA2aParticipantsProvider`, unions result with `selfIdentity`, deduplicates, normalizes.
- [x] AC3 — `SwarmHeartbeatService.getActiveA2aParticipants()` queries A2A `MESSAGE` nodes within last 3h via **3-branch UNION**: `SENT_TO` (direct recipients, `AGENT:*` excluded) + `DELIVERED_TO` (broadcast fan-out) + `SENT_BY` (senders); returns deduplicated canonical identities.
- [x] AC4 — Unit test: `resolveTargets` with `'active-a2a-participants'` returns expected union (happy path + provider-missing fallback + empty-result + null-self).
- [x] AC5 — Unit test: `getActiveA2aParticipants` with mock GraphService returns the right identity list (covers 3h cutoff + dedup + normalize + error-fallback).
- [x] AC6 — `ai/config.template.mjs` ships `targetSource: 'active-a2a-participants'` as tracked default. JSDoc on the slot documents all 5 enum values + per-MC-instance safety property.
- [ ] AC7 — Cross-family review per `pull-request §6.1` (this PR — @neo-gpt).
- [ ] AC8 — Post-merge operator-side validation: fresh checkout / template-respecting clone runs `npm run ai:orchestrator` with `@neo-gpt` idle >15m and no operator overlay; `heartbeat_pulse` GraphLog row lands within first pulse cycle; Codex Desktop wakes with `[WAKE]` block. The Epic #11993 AC8 that this PR unblocks end-to-end.

## Post-Merge Validation

Operator's tonight-test plan (3am, pre-the tenant-deployment-test):
1. Operator's `ai/config.mjs` overlay already updated (this branch) to `targetSource: 'active-a2a-participants'` so the next orchestrator restart picks up the new source without manual config edit
2. Restart orchestrator
3. Keep `@neo-gpt` quiet >15min
4. Watch for `heartbeat_pulse` row in `.neo-ai-data/sqlite/memory-core-graph.sqlite` GraphLog + Codex Desktop wake event

If wake fires for `@neo-gpt` end-to-end, Epic #11993 AC8 is confirmed and the wake substrate is operationally complete.

## Out of Scope

- Per-identity activity-window override (3h is the Discussion-fixed window; per-call override is speculative).
- Removing the legacy `'self' | 'active-local-team' | 'active-subscribers'` enum values — they remain available; the new value is additive.
- Evaluator-consolidation between `WakeSubscriptionService.resync` and `bridge/daemon.mjs::evaluateSubscription` — that's #12008 (separate Epic #11993 follow-up; different file surfaces).
- Bridge-daemon adapter dispatch logic — unchanged.

## Avoided Traps

- Changing the code-side null→self fallback — kept as deployment-portable safety net for external workspaces predating this template update OR explicitly setting null.
- Per-identity `active` check (Sub-ii's `getRecentActivityTimestamps`) — unchanged; this ticket adds a NEW candidate-discovery layer; per-identity decision is unchanged.
- Making the new provider call `MailboxService.listMessages` per known identity (circular — would require knowing identities upfront). The provider does a graph-level query that DISCOVERS identities from `MESSAGE` node adjacency.
- Cycle-1 ticket draft framing "NOT changing the default" — operator-corrected: substrate must work for every user without requiring a config flip. Template-default change is in scope.
- Cloud/fork-safety concern (silent fan-out to maintainer identities) applied to `'active-local-team'` which reads `identityRoots.mjs`. `'active-a2a-participants'` is per-MC-instance derived — no team-registry coupling — so external deployments only ever see their own activity. Safety concern is structurally absent for this source.

## Authority

Operator-prioritized 3am 2026-05-26 sleep-blocking lane before the tenant deployment test. Self-assigned to #12003 at file-time + lane-claimed earlier in session. Adjacent to #12008 (evaluator consolidation, self-assigned, impl-held); both Epic #11993 follow-ups, non-overlapping file surfaces.

Origin Session ID: `09321e82-482f-45aa-8e73-9d44381ff875`

Authored by [Claude Opus 4.7] (Claude Code).

## Commits

- `3775da468` — `feat(orchestrator): active-a2a-participants target source for activity-derived pulse candidate discovery (#12003)`
- `635e81f95` — `fix(orchestrator): DELIVERED_TO branch + template-default coverage + JSDoc — #12003 cycle-2`