### PR TITLE
test(ai): restore DreamService provider isolation (#12007)

### DIFF
--- a/test/playwright/unit/ai/daemons/orchestrator/services/DreamService.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/services/DreamService.spec.mjs
@@ -910,7 +910,8 @@ test.describe('Neo.ai.services.memory-core.DreamService', () => {
 
         // Setup markdown with a conflicting gap to verify dynamic stripping / injection sequence
         const aiConfig = (await import('../../../../../../../ai/mcp/server/memory-core/config.mjs')).default;
-        const handoffFile = aiConfig.handoffFilePath;
+        const handoffFile = aiConfig.handoffFilePath,
+              originalModelProvider = aiConfig.modelProvider;
 
         // Restore actual file system write for this test specifically
         const mockWriteFile = fs.writeFileSync;
@@ -918,55 +919,62 @@ test.describe('Neo.ai.services.memory-core.DreamService', () => {
 
         fs.writeFileSync(handoffFile, '- **[Codebase Gap]** Node `Fake`: Exists\n\n## Computed Golden Path\nOld Path\n', 'utf8');
 
-        // Execute Golden Path Synthesizer
-        await DreamService.synthesizeGoldenPath();
+        aiConfig.modelProvider = 'openAiCompatible';
 
-        const finalContent = fs.readFileSync(handoffFile, 'utf8');
+        try {
+            // Execute Golden Path Synthesizer
+            await DreamService.synthesizeGoldenPath();
 
-        // Verification Loop
-        expect(finalContent).toContain('Epic Hero');
-        expect(finalContent).toContain('Weak Task');
-        expect(finalContent).not.toContain('Blocked Task'); // REJECTED topologically by GraphService
-        expect(finalContent).not.toContain('Massive Stale Feature'); // REJECTED mathematically by Negative ROI penalty
-        expect(finalContent).toContain('Math synthesis works natively.');
-        expect(finalContent.indexOf('- **[Codebase Gap]**')).toBeLessThan(finalContent.indexOf('## Computed Golden Path'));
-        expect(finalContent).not.toContain('Old Path');
+            const finalContent = fs.readFileSync(handoffFile, 'utf8');
 
-        // #10087: planted CONCEPT with [ORPHAN_CONCEPT] must surface as a dedicated section
-        expect(finalContent).toContain('⚠️ Orphaned Concepts');
-        expect(finalContent).toContain('Reactivity');
-        expect(finalContent).toContain('Concept Reverification Queue');
-        expect(finalContent).toContain('Config System');
-        expect(finalContent).toContain('Agent FAQ Demand Gaps');
-        expect(finalContent).toContain('reactive config');
+            // Verification Loop
+            expect(finalContent).toContain('Epic Hero');
+            expect(finalContent).toContain('Weak Task');
+            expect(finalContent).not.toContain('Blocked Task'); // REJECTED topologically by GraphService
+            expect(finalContent).not.toContain('Massive Stale Feature'); // REJECTED mathematically by Negative ROI penalty
+            expect(finalContent).toContain('Math synthesis works natively.');
+            expect(finalContent.indexOf('- **[Codebase Gap]**')).toBeLessThan(finalContent.indexOf('## Computed Golden Path'));
+            expect(finalContent).not.toContain('Old Path');
 
-        // Run AGAIN to trigger duplication prevention natively
-        await DreamService.synthesizeGoldenPath();
-        const twiceContent = fs.readFileSync(handoffFile, 'utf8');
+            // #10087: planted CONCEPT with [ORPHAN_CONCEPT] must surface as a dedicated section
+            expect(finalContent).toContain('⚠️ Orphaned Concepts');
+            expect(finalContent).toContain('Reactivity');
+            expect(finalContent).toContain('Concept Reverification Queue');
+            expect(finalContent).toContain('Config System');
+            expect(finalContent).toContain('Agent FAQ Demand Gaps');
+            expect(finalContent).toContain('reactive config');
 
-        // Count capabilities gaps to ensure idempotence
-        const firstCount = finalContent.split('[Codebase Gap]').length;
-        const secondCount = twiceContent.split('[Codebase Gap]').length;
-        expect(secondCount).toBe(firstCount);
+            // Run AGAIN to trigger duplication prevention natively
+            await DreamService.synthesizeGoldenPath();
+            const twiceContent = fs.readFileSync(handoffFile, 'utf8');
 
-        // Restore
-        OpenAiCompatible.prototype.generate = baseGenerate;
-        TextEmbeddingService.embedText = baseEmbed;
-        fs.writeFileSync = mockWriteFile;
-        StorageRouter.getSummaryCollection = originalGetSummary;
-        StorageRouter.getGraphCollection = originalGetGraph;
-        if (originalPrepare) {
-             GraphService.db.storage.db.prepare = originalPrepare;
-        } else {
-             delete GraphService.db.storage.db.prepare;
+            // Count capabilities gaps to ensure idempotence
+            const firstCount = finalContent.split('[Codebase Gap]').length;
+            const secondCount = twiceContent.split('[Codebase Gap]').length;
+            expect(secondCount).toBe(firstCount);
+        } finally {
+            OpenAiCompatible.prototype.generate = baseGenerate;
+            TextEmbeddingService.embedText = baseEmbed;
+            fs.writeFileSync = mockWriteFile;
+            StorageRouter.getSummaryCollection = originalGetSummary;
+            StorageRouter.getGraphCollection = originalGetGraph;
+            aiConfig.modelProvider = originalModelProvider;
+
+            if (originalPrepare) {
+                 GraphService.db.storage.db.prepare = originalPrepare;
+            } else {
+                 delete GraphService.db.storage.db.prepare;
+            }
+            GraphService.linkNodes          = originalLinkNodes;
+            GraphService.getContextFrontier = originalGetContextFrontier;
         }
-        GraphService.linkNodes          = originalLinkNodes;
-        GraphService.getContextFrontier = originalGetContextFrontier;
     });
 
     test('should retry extraction on malformed JSON payload up to 3 times to fix #9913', async () => {
         let executionCount = 0;
-        const baseGenerate = OpenAiCompatible.prototype.generate;
+        const aiConfig = (await import('../../../../../../../ai/mcp/server/memory-core/config.mjs')).default,
+              baseGenerate = OpenAiCompatible.prototype.generate,
+              originalModelProvider = aiConfig.modelProvider;
 
         // Mock to fail twice with invalid JSON, then succeed on the 3rd attempt
         OpenAiCompatible.prototype.generate = async function(messages) {
@@ -995,26 +1003,30 @@ test.describe('Neo.ai.services.memory-core.DreamService', () => {
             };
         };
 
-        const session = {
-            meta: { sessionId: 'playwright-retry-test' },
-            document: "Mock episodic history"
-        };
+        aiConfig.modelProvider = 'openAiCompatible';
 
-        const result = await SemanticGraphExtractor.executeTriVectorExtraction(session);
+        try {
+            const session = {
+                meta: { sessionId: 'playwright-retry-test' },
+                document: "Mock episodic history"
+            };
 
-        // Assert that the LLM was called 3 times natively due to the retry loop wrapping
-        expect(executionCount).toBe(3);
+            const result = await SemanticGraphExtractor.executeTriVectorExtraction(session);
 
-        // Assert the returned result is strictly not null since attempt 3 passed
-        expect(result).not.toBeNull();
-        expect(result.session_artifact).toBeDefined();
+            // Assert that the LLM was called 3 times natively due to the retry loop wrapping
+            expect(executionCount).toBe(3);
 
-        // Check if the feedback logic was appended to the provider messages
-        const lastMessage = providerPrompt[providerPrompt.length - 1];
-        expect(lastMessage.role).toBe('user');
-        expect(lastMessage.content).toContain('failed internal schema validation');
+            // Assert the returned result is strictly not null since attempt 3 passed
+            expect(result).not.toBeNull();
+            expect(result.session_artifact).toBeDefined();
 
-        // Restore global function
-        OpenAiCompatible.prototype.generate = baseGenerate;
+            // Check if the feedback logic was appended to the provider messages
+            const lastMessage = providerPrompt[providerPrompt.length - 1];
+            expect(lastMessage.role).toBe('user');
+            expect(lastMessage.content).toContain('failed internal schema validation');
+        } finally {
+            aiConfig.modelProvider = originalModelProvider;
+            OpenAiCompatible.prototype.generate = baseGenerate;
+        }
     });
 });


### PR DESCRIPTION
Resolves #12007
Related: #11993

Authored by GPT-5.5 (Codex Desktop). Session 019e5bac-15f3-7830-a59c-72772c757f9a.

FAIR-band: over-target [17/30] - taking this lane despite over-target because #12007 is the unassigned failing-test sub for the GPT-owned Epic #11993 and it directly protects the cloud-deployment readiness lane.

Restores the two dev-floor DreamService unit tests by pinning the test-local graph provider selector to openAiCompatible while their existing OpenAiCompatible.prototype.generate mocks are active. No production path changed.

Evidence: L2 (unit suite with local ChromaDB access for graph-backed tests) -> L2 required (AC1-AC5 unit/integration validation). No residuals.

## Deltas from ticket
The ticket expected 326/326 for the orchestrator tree. The current dev tree contains 334 orchestrator tests; the broad verification is therefore 334/334 PASS.

Git-bisect/root-cause classification:
- `58d352ba5` (`feat(memory-core): native Ollama runtime dispatch + provider.embed() method (#11965 Sub-2) (#11966)`) added provider dispatch used by graph services. These two tests still mocked `OpenAiCompatible.prototype.generate`, but the active `aiConfig.modelProvider` no longer guaranteed that class would be selected.
- `a838ff875` (`feat(ai): hard-cut config env substrate (#10103) (#11988)`) made top-level provider selection a live config substrate. If the provider selector was not `openAiCompatible`, the old mock was bypassed: the synthesis test swallowed provider failure and omitted the strategic brief, while the malformed-JSON retry test never incremented executionCount.
- The retry loop and production synthesizer behavior are unchanged; the tests now restore the intended provider path and cleanly restore `aiConfig.modelProvider` in `finally`.

## Test Evidence
- `npm run test-unit -- test/playwright/unit/ai/daemons/orchestrator/services/DreamService.spec.mjs` -> 15/15 PASS.
- `npm run test-unit -- test/playwright/unit/ai/daemons/orchestrator/services/DreamServiceGoldenPath.spec.mjs` -> 1/1 PASS with local ChromaDB access.
- `npm run test-unit -- test/playwright/unit/ai/daemons/orchestrator/` -> 334/334 PASS with local ChromaDB access.
- `git diff --cached --check` -> PASS.
- Pre-push freshness: `merge-base HEAD origin/dev == origin/dev`; outgoing log contains only `dd1162db4`.

## Post-Merge Validation
- [ ] Re-run `npm run test-unit -- test/playwright/unit/ai/daemons/orchestrator/` on `dev` after merge to confirm the 334-test orchestrator tree remains green in the shared CI environment.

## Commit
- `dd1162db4` - `test(ai): restore DreamService provider isolation (#12007)`