### PR TITLE
feat(orchestrator): workspace-safety integration test (#11948)

### DIFF
--- a/test/playwright/integration/ai/daemons/workspaceSafety.spec.mjs
+++ b/test/playwright/integration/ai/daemons/workspaceSafety.spec.mjs
@@ -1,0 +1,290 @@
+/**
+ * @module test/playwright/integration/ai/daemons/workspaceSafety
+ * @summary Workspace-safety integration test for the Agent OS orchestrator daemon.
+ *
+ * Validates that a fresh `npx-neo-app`-style workspace can spawn the orchestrator
+ * daemon under `NEO_AI_DEPLOYMENT_MODE=cloud` without crashing on missing Neo-team
+ * substrate (identityRoots entries, operator-only config, pre-existing data dir).
+ * Companion to the AC1-AC4 invariant tests in `Orchestrator.externalConfig.spec.mjs`;
+ * this is the runtime proof for #11837 Sub-5 AC5 that PR #11946 deferred as too
+ * heavy for unit-test scope.
+ *
+ * Two probes:
+ *  1. Cloud-deployment-mode boot: confirms the daemon reaches the `[Orchestrator]
+ *     Started.` log line within a reasonable timeout, with no `UnhandledPromiseRejection`
+ *     / uncaught error surfaces. Cloud profile defaults disable kbSync, primaryDevSync,
+ *     bridgeDaemon, and swarmHeartbeat lanes — verifies those gates fire silently
+ *     rather than throwing on missing substrate.
+ *  2. Local-deployment-mode swarm-heartbeat degrade-with-log: confirms the
+ *     `[resolveSwarmHeartbeatTargets] 'self' resolved to self but selfIdentity is
+ *     null — disabled` log line is emitted within a single pulse interval when the
+ *     daemon runs without `NEO_AGENT_IDENTITY` (the npx-neo-app default).
+ *
+ * @see https://github.com/neomjs/neo/issues/11948
+ * @see https://github.com/neomjs/neo/issues/11837
+ * @see ai/daemons/orchestrator/daemon.mjs
+ * @see ai/daemons/orchestrator/scheduling/swarmHeartbeat.mjs
+ */
+import {spawn}          from 'node:child_process';
+import fs               from 'node:fs/promises';
+import os               from 'node:os';
+import path             from 'node:path';
+import {fileURLToPath}  from 'node:url';
+import Database         from 'better-sqlite3';
+import {test, expect}   from '@playwright/test';
+
+const __filename   = fileURLToPath(import.meta.url);
+const __dirname    = path.dirname(__filename);
+const repoRoot     = path.resolve(__dirname, '../../../../..');
+const DAEMON_ENTRY = path.join(repoRoot, 'ai/daemons/orchestrator/daemon.mjs');
+
+const BOOT_TIMEOUT_MS  = 30000;
+const PULSE_TIMEOUT_MS = 30000;
+const SIGTERM_GRACE_MS = 5000;
+
+/**
+ * @summary Minimal sqlite schema sufficient for the orchestrator's boot-time open.
+ *
+ * The orchestrator delegates DB init to
+ * `ai/daemons/bridge/queries.mjs::initializeDatabase`, which opens with
+ * `fileMustExist: true` and calls `process.exit(1)` when the file is missing. A
+ * fresh `npx-neo-app` workspace doesn't ship the file, so a downstream "ensure
+ * sqlite exists" bootstrap step is needed before this test can probe behavior
+ * past line 476 of Orchestrator.mjs. The schema below is the subset
+ * `ai/graph/storage/SQLite.mjs::initSchema()` would create on first boot of the
+ * Memory Core MCP server — pre-creating it here keeps the test focused on
+ * Neo-team-substrate-dependent degrade-with-log paths rather than the unrelated
+ * "missing sqlite" hard-exit (tracked as a separate follow-up ticket).
+ */
+function initSqliteSchema(dbPath) {
+    const db = new Database(dbPath);
+    try {
+        db.pragma('journal_mode = WAL');
+        db.exec(`
+            CREATE TABLE IF NOT EXISTS Nodes (
+                id      TEXT PRIMARY KEY,
+                user_id TEXT,
+                data    TEXT NOT NULL
+            );
+            CREATE TABLE IF NOT EXISTS Edges (
+                id      TEXT PRIMARY KEY,
+                user_id TEXT,
+                source  TEXT NOT NULL,
+                target  TEXT NOT NULL,
+                type    TEXT NOT NULL,
+                data    TEXT NOT NULL
+            );
+            CREATE INDEX IF NOT EXISTS idx_edges_source ON Edges(source);
+            CREATE INDEX IF NOT EXISTS idx_edges_target ON Edges(target);
+            CREATE TABLE IF NOT EXISTS GraphLog (
+                log_id        INTEGER PRIMARY KEY AUTOINCREMENT,
+                user_id       TEXT,
+                operation     TEXT NOT NULL,
+                entity_type   TEXT NOT NULL,
+                entity_id     TEXT NOT NULL,
+                data          TEXT,
+                created_at    TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+            );
+        `);
+    } finally {
+        db.close();
+    }
+}
+
+/**
+ * @summary Polls a log file until a predicate matches its content or the timeout elapses.
+ * @param {String} logPath
+ * @param {(content:String)=>Boolean} predicate
+ * @param {Number} timeoutMs
+ * @returns {Promise<String>} The matching content snapshot.
+ */
+async function waitForLogContent(logPath, predicate, timeoutMs) {
+    const deadline = Date.now() + timeoutMs;
+    let lastContent = '';
+
+    while (Date.now() < deadline) {
+        try {
+            lastContent = await fs.readFile(logPath, 'utf8');
+            if (predicate(lastContent)) return lastContent;
+        } catch (err) {
+            if (err.code !== 'ENOENT') throw err;
+        }
+        await new Promise(resolve => setTimeout(resolve, 200));
+    }
+
+    throw new Error(`Timed out after ${timeoutMs}ms waiting for log predicate. Last content (${lastContent.length} bytes):\n${lastContent}`);
+}
+
+/**
+ * @summary Sends SIGTERM and waits for the child process to exit, force-killing on timeout.
+ * @param {import('node:child_process').ChildProcess} daemonProcess
+ * @returns {Promise<{code:Number|null, signal:String|null}>}
+ */
+async function terminateDaemon(daemonProcess) {
+    if (!daemonProcess || daemonProcess.exitCode !== null) {
+        return {code: daemonProcess?.exitCode ?? null, signal: null};
+    }
+
+    return new Promise(resolve => {
+        const timeout = setTimeout(() => {
+            try {
+                daemonProcess.kill('SIGKILL');
+            } catch {}
+            resolve({code: daemonProcess.exitCode, signal: 'SIGKILL'});
+        }, SIGTERM_GRACE_MS);
+
+        daemonProcess.once('exit', (code, signal) => {
+            clearTimeout(timeout);
+            resolve({code, signal});
+        });
+
+        try {
+            daemonProcess.kill('SIGTERM');
+        } catch {
+            clearTimeout(timeout);
+            resolve({code: daemonProcess.exitCode, signal: null});
+        }
+    });
+}
+
+test.describe('Orchestrator workspace-safety integration (#11948 / Sub-5 AC5 of #11837)', () => {
+    // Long-running daemon boot + isolation tests run sequentially.
+    test.describe.configure({mode: 'serial'});
+
+    let workspaceDir;
+    let dataDir;
+    let logPath;
+    let dbPath;
+    let daemonProcess;
+    let stdoutBuf;
+    let stderrBuf;
+
+    test.beforeEach(async () => {
+        workspaceDir = await fs.mkdtemp(path.join(os.tmpdir(), 'neo-workspace-safety-'));
+        dataDir      = path.join(workspaceDir, 'orchestrator-daemon');
+        logPath      = path.join(dataDir, 'orchestrator.log');
+        dbPath       = path.join(workspaceDir, 'memory-core-graph.sqlite');
+        // Mimic the post-MC-first-boot substrate shape an external user would have
+        // after running their first Memory Core MCP server. AC5 is about Neo-team
+        // identity substrate being absent, not about the sqlite file itself.
+        initSqliteSchema(dbPath);
+        daemonProcess = null;
+        stdoutBuf = '';
+        stderrBuf = '';
+    });
+
+    test.afterEach(async () => {
+        if (daemonProcess) {
+            await terminateDaemon(daemonProcess);
+        }
+        if (workspaceDir) {
+            await fs.rm(workspaceDir, {recursive: true, force: true});
+        }
+    });
+
+    test('AC3 — cloud-deployment-mode boot reaches [Orchestrator] Started without uncaught errors', async () => {
+        // cwd=workspaceDir isolates every cwd-relative side effect the daemon and its
+        // supervised children create (chroma's `.neo-ai-data/chroma/knowledge-base`,
+        // task PID files, etc.) so the test cannot collide with a concurrently running
+        // operator-owned daemon on the same host.
+        daemonProcess = spawn('node', [DAEMON_ENTRY], {
+            cwd: workspaceDir,
+            env: {
+                ...process.env,
+                NEO_AI_DEPLOYMENT_MODE  : 'cloud',
+                NEO_AI_ORCHESTRATOR_DIR : dataDir,
+                NEO_AI_DB_PATH          : dbPath,
+                NEO_HEARTBEAT_ALIVE_PATH: path.join(workspaceDir, 'heartbeat.alive'),
+                NEO_BACKUP_PATH         : path.join(workspaceDir, 'backups')
+            },
+            stdio: ['ignore', 'pipe', 'pipe']
+        });
+
+        daemonProcess.stdout.on('data', chunk => { stdoutBuf += chunk.toString(); });
+        daemonProcess.stderr.on('data', chunk => { stderrBuf += chunk.toString(); });
+
+        const logContent = await waitForLogContent(
+            logPath,
+            content => content.includes('[Orchestrator] Started.'),
+            BOOT_TIMEOUT_MS
+        );
+
+        // AC3: Process is still alive after boot completion.
+        expect(daemonProcess.exitCode, `daemon exited prematurely. stdout:\n${stdoutBuf}\nstderr:\n${stderrBuf}`).toBeNull();
+
+        // AC3: Boot path emits no fatal error surface.
+        const fatalPatterns = [
+            /UnhandledPromiseRejection/i,
+            /uncaughtException/i,
+            /\[Orchestrator\] Failed to start/i
+        ];
+        for (const pattern of fatalPatterns) {
+            expect(stderrBuf, `stderr contained fatal pattern ${pattern}`).not.toMatch(pattern);
+            expect(logContent, `log contained fatal pattern ${pattern}`).not.toMatch(pattern);
+        }
+
+        // AC4: Cloud profile sentinel — confirms the daemon reached the Started log line.
+        // The lanes that need Neo-team substrate (swarmHeartbeat, primaryDevSync, kbSync,
+        // bridgeDaemon) are gated by resolveDeploymentEnabled() returning false in cloud
+        // mode, so they neither initialize nor throw. Absence of init-failure log lines IS
+        // the graceful-degradation signal in this profile.
+        expect(logContent).not.toMatch(/\[Orchestrator\] Swarm heartbeat init failed/i);
+    });
+
+    test('AC4 — swarm-heartbeat target resolver degrades-with-log when selfIdentity is missing', async () => {
+        // Local deployment mode keeps the swarm-heartbeat lane enabled so the resolver
+        // fires. A short pulse interval forces a pulse cycle within the test window.
+        // Empty NEO_AGENT_IDENTITY + targetSource='self' triggers the documented
+        // disables-with-log path in `swarmHeartbeat.resolveTargets`.
+        daemonProcess = spawn('node', [DAEMON_ENTRY], {
+            cwd: workspaceDir,
+            env: {
+                ...process.env,
+                NEO_AI_DEPLOYMENT_MODE                          : 'local',
+                NEO_AI_ORCHESTRATOR_DIR                         : dataDir,
+                NEO_AI_DB_PATH                                  : dbPath,
+                NEO_HEARTBEAT_ALIVE_PATH                        : path.join(workspaceDir, 'heartbeat.alive'),
+                NEO_BACKUP_PATH                                 : path.join(workspaceDir, 'backups'),
+                NEO_AGENT_IDENTITY                              : '',
+                NEO_ORCHESTRATOR_SWARM_HEARTBEAT_TARGET_SOURCE  : 'self',
+                NEO_ORCHESTRATOR_SWARM_HEARTBEAT_INTERVAL_MS    : '1000',
+                NEO_ORCHESTRATOR_POLL_INTERVAL_MS               : '500',
+                // NEO_DEBUG=true unlocks the memory-core logger's stderr forward
+                // (stderrMode: 'debug' gates stderr behind aiConfig.debug). Without it
+                // the resolver log goes to the file-sink only — which by default lives
+                // under the canonical Neo root, not the test's isolated workspace.
+                NEO_DEBUG                                       : 'true',
+                // Disable side-lanes that would spawn external binaries or touch other
+                // shared substrate during the test window.
+                NEO_ORCHESTRATOR_BRIDGE_DAEMON_ENABLED          : 'false',
+                NEO_ORCHESTRATOR_KB_SYNC_ENABLED                : 'false',
+                NEO_ORCHESTRATOR_PRIMARY_DEV_SYNC_ENABLED       : 'false'
+            },
+            stdio: ['ignore', 'pipe', 'pipe']
+        });
+
+        daemonProcess.stdout.on('data', chunk => { stdoutBuf += chunk.toString(); });
+        daemonProcess.stderr.on('data', chunk => { stderrBuf += chunk.toString(); });
+
+        // Wait for the resolver disable-with-log surface. The exact phrase comes from
+        // ai/daemons/orchestrator/scheduling/swarmHeartbeat.mjs line ~115.
+        const combinedSignal = () => `${stdoutBuf}\n${stderrBuf}`;
+        const deadline = Date.now() + PULSE_TIMEOUT_MS;
+        let matched = false;
+        while (Date.now() < deadline) {
+            if (/\[resolveSwarmHeartbeatTargets\][^\n]*selfIdentity is null[^\n]*disabled/i.test(combinedSignal())) {
+                matched = true;
+                break;
+            }
+            await new Promise(resolve => setTimeout(resolve, 200));
+        }
+
+        expect(matched,
+            `Resolver disable-with-log surface did not appear within ${PULSE_TIMEOUT_MS}ms. ` +
+            `daemon exitCode=${daemonProcess.exitCode}\nstdout:\n${stdoutBuf}\nstderr:\n${stderrBuf}`
+        ).toBe(true);
+
+        // Process must still be alive — the resolver degrade-with-log path is non-fatal.
+        expect(daemonProcess.exitCode).toBeNull();
+    });
+});


### PR DESCRIPTION
Resolves #11948.

**Self-Identification:** Claude Opus 4.7 (Claude Code worktree-isolated harness).

**FAIR-band: under-target [13/30] — Self-Selection Rule 1 fires (under-band → bias toward author lane).** Verifier query at gate time returned `Counter({'neo-gpt': 17, 'neo-opus-4-7': 13})` over the last 30 merged PRs; target band for two active families is ~15/30.

Adds two child-process spawn probes under `test/playwright/integration/ai/daemons/workspaceSafety.spec.mjs` that boot the orchestrator daemon in an isolated temp workspace and assert clean boot + graceful-degradation log surfaces — the runtime proof for #11837 Sub-5 AC5 that PR #11946 deferred as too heavy for unit-test scope.

Evidence: L2 (real `node ai/daemons/orchestrator/daemon.mjs` child-process spawn under cwd-isolated temp workspace; real sqlite pre-init via better-sqlite3; real log-file polling for `[Orchestrator] Started.` + real stderr regex match for `[resolveSwarmHeartbeatTargets] selfIdentity is null — disabled`) → L2 required (#11948 AC3/AC4 are runtime daemon-boot contracts verifiable in the CI integration-unified job). No residuals.

## Summary

- Runtime probe for #11837 Sub-5 AC5 (workspace-safety contract) that PR #11946 deferred as too heavy for unit-test scope. PR #11946 shipped AC1-AC3 invariant tests + AC4 audit-time verification.
- Two `test/playwright/integration/ai/daemons/workspaceSafety.spec.mjs` probes spawn the orchestrator daemon as a child process under isolated env-var paths and assert clean boot + graceful-degradation log lines.
- Zero production-code touch. Single new test file, +290 LOC.

## Architectural framing

The new probes complement the existing `Orchestrator.externalConfig.spec.mjs` unit tests (audit-time verification that `resolveDeploymentEnabled` / `resolveCloudOnlyEnabled` route the relevant lanes through deployment-aware gates) with a **runtime** signal that the actual daemon-boot path:

1. Reaches the `[Orchestrator] Started.` log line under cloud-deployment mode with isolated paths and no uncaught error surfaces; and
2. Actually CALLS `resolveSwarmHeartbeatTargets` and survives the resolver's documented `null selfIdentity + targetSource='self'` disable-with-log path (the canonical Neo-team-substrate-absent scenario the AC is about).

Both probes spawn the daemon entry point `node ai/daemons/orchestrator/daemon.mjs` directly. cwd is set to the per-test `workspaceDir` so every cwd-relative side effect the daemon and its supervised children create (chroma's `.neo-ai-data/chroma/knowledge-base`, task PID files under the orchestrator data dir, etc.) lands inside the test workspace — the test cannot collide with a concurrently-running operator-owned daemon on the same host.

## Test design notes

- **AC3 probe (cloud mode):** asserts `[Orchestrator] Started.` appears in the per-test log file within 30s, then audits both the log file and stderr for `UnhandledPromiseRejection` / `uncaughtException` / `[Orchestrator] Failed to start` / `Swarm heartbeat init failed` patterns. Cloud profile mechanically gates kbSync, primaryDevSync, bridgeDaemon, and swarmHeartbeat off via `resolveDeploymentEnabled` returning false — the test verifies those gates fire silently rather than throwing.
- **AC4 probe (local mode):** sets `NEO_AGENT_IDENTITY=''` + `NEO_ORCHESTRATOR_SWARM_HEARTBEAT_TARGET_SOURCE=self` + `NEO_ORCHESTRATOR_SWARM_HEARTBEAT_INTERVAL_MS=1000` + `NEO_ORCHESTRATOR_POLL_INTERVAL_MS=500` so the swarm-heartbeat lane fires at least once within the 30s window. `NEO_DEBUG=true` unlocks the memory-core logger's stderr forward (`stderrMode: 'debug'`) so the resolver log surface is observable from the test process. Side-lanes (bridge-daemon / kbSync / primaryDevSync) are env-disabled to reduce noise + side-effect surface.

## Out-of-scope follow-ups surfaced during impl

The integration test infra surfaced one substrate issue worth tracking separately (matching the ticket's Out-of-Scope clause: "file as separate sub-tickets if discovered"):

- `ai/daemons/bridge/queries.mjs::initializeDatabase` opens with `fileMustExist: true` + `process.exit(1)` on missing file, which means a fresh `npx-neo-app` workspace daemon hard-crashes before ever reaching the configurability-aware lanes. The test pre-creates a minimal sqlite schema to bypass this for now; **TODO**: file follow-up ticket to either auto-create the file on first boot or replace the `process.exit(1)` with a fail-with-clear-log path so the rest of the orchestrator's degrade-with-log discipline can apply.

## Deltas

- Bisect/diagnostic: smoke-tested both probes locally against the same Node + better-sqlite3 versions CI runs; both reach the asserted log lines within ~2s of daemon spawn under cwd-isolated workspace fixtures.
- Test isolation: `test.describe.configure({mode: 'serial'})` so the two daemon-spawn probes don't race child-process resources or the shared cwd-relative chroma directory.

## Decision Record impact

None. No ADR-tracked substrate changed. The test is additive infrastructure for an existing AC contract.

## Authorship

Authored by Claude Opus 4.7 (Claude Code worktree-isolated harness).

## Test Evidence

- `test/playwright/integration/ai/daemons/workspaceSafety.spec.mjs` — 2 new tests, +290 LOC.
- Smoke runs (manual, pre-PR): AC3 probe daemon stayed alive after `[Orchestrator] Started.` log line landed at t=~2s; AC4 probe surfaced `[resolveSwarmHeartbeatTargets] 'self' resolved to self but selfIdentity is null — disabled (no pulse targets).` on stderr within ~3s under `NEO_DEBUG=true`.
- CI integration-unified job is the canonical signal; local smoke also passes the assertions.

## Post-Merge Validation

- Confirm CI integration-unified job stays green on subsequent dev-branch PRs (the new probes become part of the integration floor for #11837 Sub-5 AC5).
- Watch for the follow-up bug ticket above (orchestrator fileMustExist hard-crash) — landing the substrate fix later will allow the test fixture's `initSqliteSchema` helper to retire.

