### PR TITLE
docs(day0): document macOS container runtimes (#12015)

### DIFF
--- a/learn/agentos/cloud-deployment/Day0Tutorial.md
+++ b/learn/agentos/cloud-deployment/Day0Tutorial.md
@@ -47,11 +47,30 @@ Required local tools:
 | npm | `npm --version` | a version string |
 | Docker Compose | `docker compose version` | a Compose version string |
 
+Container runtime choices:
+
+| Runtime | Fit | Setup hint |
+|---|---|---|
+| Docker Desktop | macOS / Windows desktop default. | Install Docker Desktop and start it before running `docker compose`. |
+| Docker Engine | Linux host or server default. | Install the Docker Engine and Compose plugin from your distribution or Docker packages. |
+| Colima | Open-source macOS VM runtime with Docker-compatible sockets. | Install `colima` plus Docker CLI tooling, then start a VM before running this tutorial. |
+| Podman | Docker-compatible alternative for teams already standardized on Podman. | Enable Docker-compatible Compose support and verify `docker compose version`. |
+| OrbStack | macOS desktop runtime with Docker-compatible CLI integration. | Install OrbStack, start it, and verify `docker compose version`. |
+
+All commands in this guide use Docker's canonical no-dash `docker compose`
+form. If your runtime only exposes the legacy `docker-compose` binary, wire it
+as a Docker CLI plugin before continuing.
+
+For local macOS VM runtimes such as Colima, size the VM for the Agent OS stack:
+use roughly 16 GiB as the practical minimum for Chroma + KB + MC +
+Orchestrator, and 24+ GiB when loading local chat models alongside the stack.
+
 Failure signatures:
 
 | Signature | Meaning | Fix |
 |---|---|---|
 | `docker: command not found` | Docker is not installed in this environment. | Install Docker Desktop / Docker Engine or run the tutorial on a Docker-capable host. |
+| `docker: unknown command: docker compose` | Docker CLI is installed, but the Compose plugin path is not wired. This is common after `brew install docker docker-compose` on macOS. | `mkdir -p ~/.docker/cli-plugins && ln -sf "$(brew --prefix)/bin/docker-compose" ~/.docker/cli-plugins/docker-compose` |
 | `Cannot connect to the Docker daemon` | Docker is installed but not running or not accessible. | Start Docker and verify `docker info`. |
 | `npm ERR!` during install | Dependencies are missing or the registry is unavailable. | Retry after network recovery; do not continue with a partial `node_modules`. |
 


### PR DESCRIPTION
Resolves #12015

Authored by GPT-5 (Codex Desktop). Session 1578fb3e-7f5a-4b43-a6d0-ba00e66a9885.

FAIR-band: over-target [18/30] - taking this docs lane despite over-target because the operator explicitly directed solo Neo-checkout work to continue bundling small tickets, #12015 was unassigned and self-claimable, and the change is a narrow Day-0 blocker removal after PR #12018 merged.

Documents Docker-compatible macOS/container-runtime alternatives in the Day-0 cloud deployment guide, clarifies the canonical no-dash `docker compose` command form, adds Colima/local-VM sizing guidance, and captures the missing Compose-plugin failure signature.

Evidence: L1 (static markdown diff, grep guard, and whitespace check) to L1 required (documentation-only ACs). No residuals.

Decision Record impact: none. ADR 0014 already accepts the containerized cloud deployment topology; this PR only clarifies host-runtime prerequisites and failure handling.

## Deltas from ticket
- Used `$(brew --prefix)` in the Compose-plugin symlink command instead of hard-coding `/opt/homebrew`, preserving the requested macOS fix while covering both Apple Silicon and Intel Homebrew prefixes.
- Kept the guidance local to `Day0Tutorial.md`; no code, compose, or shared prerequisite abstraction changes were required.

## Slot Rationale
- Modified section: `learn/agentos/cloud-deployment/Day0Tutorial.md` prerequisites and failure signatures.
- Disposition delta: keep as guide-local operational documentation; this adds no new always-loaded agent rule, critical gate, or skill trigger.
- Three-axis rating: trigger-frequency medium (Day-0 deployment setup), failure-severity medium-high (blocks first boot before orchestration can start), enforceability medium (static reviewer check plus grep guard for runtime names and plugin failure signature).
- Decay mitigation: runtime list is expressed as Docker-compatible choices rather than one blessed runtime; future drift is detectable through the existing guide and the grep guard for Colima/Podman/OrbStack/Compose-plugin coverage.

## Test Evidence
- `git diff --check`
- `git diff --cached --check`
- `rg -n -i "colima|podman|orbstack|docker: unknown command: docker compose|cli-plugins|docker compose version" learn/agentos/cloud-deployment/Day0Tutorial.md`
- Pre-push freshness: `git merge-base HEAD origin/dev` matched `git rev-parse origin/dev`; outgoing log contained only `aeabd3db0 docs(day0): document macOS container runtimes (#12015)`.

## Post-Merge Validation
- [ ] Verify #12015 closes via the `Resolves #12015` link.
- [ ] Confirm Day-0 readers can identify Docker Desktop, Docker Engine, Colima, Podman, and OrbStack as valid runtime options before starting the stack.

## Commits
- `aeabd3db0` - `docs(day0): document macOS container runtimes (#12015)`
