### PR TITLE
chore(ai): clean residual github workflow comments (#11924)

### DIFF
--- a/ai/services/github-workflow/IssueService.mjs
+++ b/ai/services/github-workflow/IssueService.mjs
@@ -315,8 +315,8 @@ class IssueService extends Base {
     /**
      * @summary Persists an `acknowledgedReassign` reason as a GitHub-visible audit-trail comment.
      *
-     * Per GPT STEP_BACK §4 carry-forward AC: the reason must be persisted in a GitHub-visible
-     * artifact (issue comment), NOT only transient event metadata. The comment becomes
+     * The reason must be persisted in a GitHub-visible artifact (issue comment),
+     * not only transient event metadata. The comment becomes
      * graph-readable provenance via the Native Edge Graph + Retrospective daemon's
      * comment-ingestion path.
      *

--- a/ai/services/github-workflow/PullRequestService.mjs
+++ b/ai/services/github-workflow/PullRequestService.mjs
@@ -50,7 +50,7 @@ const VISIBLE_PR_REVIEW_ANCHORS = [
  * Visible-only validation passes the malformed body. The invisible layer catches this by
  * checking structural anchors that span both cycle-1 and cycle-followup templates.
  *
- * **Empirical anchor**: a malformed review can contain all visible metric tags while missing
+ * **Observed failure mode**: a malformed review can contain all visible metric tags while missing
  * `Depth Floor`, `Required Actions`, and `Strategic-Fit Decision` structure. These 3 substrings
  * empirically distinguish a structurally-correct review from a metric-tag-stuffed hallucination.
  *
@@ -58,8 +58,7 @@ const VISIBLE_PR_REVIEW_ANCHORS = [
  * - `Depth Floor` — cycle-1 has `🔬 Depth Floor`, cycle-followup has `Delta Depth Floor`. Both contain the substring.
  * - `Required Actions` — both cycle-1 (`📋 Required Actions`) and cycle-followup carry the literal heading.
  * - `Strategic-Fit Decision` — cycle-1 (`🪜 Strategic-Fit Decision`) and cycle-followup (`Strategic-Fit Decision`)
- *   both include the word `Decision`. Hallucinated headings that drop `Decision` (as Gemini's
- *   review `4304287893` did) fail this check.
+ *   both include the word `Decision`. Hallucinated headings that drop `Decision` fail this check.
  *
  * **Asymmetry that makes this work**:
  * - Author who reads `.agents/skills/pr-review/SKILL.md` and follows the template → all checks pass

--- a/ai/services/github-workflow/SyncService.mjs
+++ b/ai/services/github-workflow/SyncService.mjs
@@ -258,7 +258,7 @@ class SyncService extends Base {
      *
      * The sync engine normally relies on `issue.updatedAt` to decide which issues need a fresh
      * pull. That gate is blind to several classes of drift: `timelineItems` truncation past the
-     * page cap (#10090), comment deletions (GitHub does not bump `updatedAt` on delete), and
+     * page cap, comment deletions (GitHub does not bump `updatedAt` on delete), and
      * relationship events where both sides fall outside the delta window. This endpoint is the
      * surgical recovery primitive — it force-refetches the listed issues, exhausts their full
      * timelineItems connection, rewrites the local markdown, and persists updated metadata.

--- a/ai/services/github-workflow/queries/issueQueries.mjs
+++ b/ai/services/github-workflow/queries/issueQueries.mjs
@@ -157,7 +157,7 @@ export const FETCH_ISSUES_FOR_SYNC = `
             ]) {
             # pageInfo enables continuation-fetching when an issue's timeline has outgrown
             # a single page of \`maxTimelineItems\`. Without this, tail events (including
-            # newly-authored comments) are silently dropped once totalCount > first. See #10090.
+            # newly-authored comments) are silently dropped once totalCount > first.
             pageInfo { hasNextPage endCursor }
             nodes {
               __typename
@@ -839,7 +839,7 @@ export const GET_ISSUE_PARENT = `
  * @summary Fetches the current assignee logins for a single issue.
  *
  * Narrow query used by `manage_issue_assignees` as the precondition fetch step in the
- * precondition + post-verify gate (#11537). Distinct from `FETCH_SINGLE_ISSUE` which
+ * precondition + post-verify gate. Distinct from `FETCH_SINGLE_ISSUE` which
  * also pulls timeline, sub-issues, blocking relationships — too heavy for a gate check.
  *
  * Variables required:
@@ -867,7 +867,7 @@ export const GET_ISSUE_ASSIGNEES = `
  *
  * Issue-side twin of `pullRequestQueries.GET_CONVERSATION` — identical shape, querying the
  * `issue` field instead of `pullRequest`. Powers the `get_conversation` tool when the
- * caller supplies an `issue_number` (#10702).
+ * caller supplies an `issue_number`.
  *
  * Variables required:
  * - $owner: String! - Repository owner

--- a/ai/services/github-workflow/queries/mutations.mjs
+++ b/ai/services/github-workflow/queries/mutations.mjs
@@ -39,9 +39,9 @@ export const ADD_BLOCKED_BY = `
  * Mutation to add a comment to a subject (issue or PR).
  *
  * Returns the new comment's `id`, `url`, and `createdAt` so the caller can surface
- * the canonical identifier for A2A propagation patterns (per #10272 §2.3 —
- * comment-ID hand-off via mailbox DMs lets the recipient `get_conversation` fetch
- * just-this-comment via the `comment_id` param instead of re-fetching the whole thread).
+ * the canonical identifier for A2A propagation patterns. Comment-ID hand-off via
+ * mailbox DMs lets the recipient fetch just that comment through `get_conversation`
+ * with the `comment_id` param instead of re-fetching the whole thread.
  *
  * Variables required:
  * - $subjectId: ID! - The global ID of the issue or PR
@@ -388,7 +388,7 @@ export const GET_PROJECT_V2_METADATA = `
 /**
  * Mutation to add an existing issue (or PR) to a ProjectV2 board.
  *
- * Substrate-correct replacement for the `release:v*` label-as-project-proxy pattern (#11233).
+ * Substrate-correct replacement for the `release:v*` label-as-project-proxy pattern.
  * Labels are categorization primitives; projects are first-class membership primitives — they
  * are independent GitHub concepts that cannot be reduced to one another without structural drift.
  *
@@ -516,14 +516,13 @@ export const GET_PULL_REQUEST_ID = `
 `;
 
 /**
- * Mutation to create a formal pull request review with state transition (#11273).
+ * Mutation to create a formal pull request review with a GitHub review-state transition.
  *
  * Atomic alternative to the historical two-step `manage_issue_comment` → `gh pr review`
  * chain. Single call posts the substantive review body AND flips GitHub's
- * `reviewDecision` surface. Replaces the formal-state-gap pattern empirically anchored
- * by PR #11234 (Gemini) + PR #11271 (Opus) where agents posted review prose but
- * forgot the second formal-state flip, blocking the cross-family review mandate
- * gate per `pull-request §6.1`.
+ * `reviewDecision` surface. This keeps review prose and formal review state bound
+ * to one API operation, preventing comments that look like reviews while leaving
+ * GitHub's merge-gate state unchanged.
  *
  * `event` is GitHub's `PullRequestReviewEvent` enum: APPROVE, REQUEST_CHANGES, COMMENT.
  * (PENDING and DISMISS are deliberately out of scope; PENDING creates a draft,
@@ -557,7 +556,7 @@ export const ADD_PULL_REQUEST_REVIEW = `
 `;
 
 /**
- * Mutation to update an existing pull request review's body (#11273).
+ * Mutation to update an existing pull request review's body.
  *
  * Companion to `ADD_PULL_REQUEST_REVIEW` for the `update` action — the GitHub API
  * allows updating a review's body after submission but does NOT allow changing

--- a/ai/services/github-workflow/shared/contentPath.mjs
+++ b/ai/services/github-workflow/shared/contentPath.mjs
@@ -2,7 +2,7 @@ import path from 'path';
 
 /**
  * @module ai/services/github-workflow/shared/contentPath
- * @summary Universal ordinal-100 path-resolution primitive for `resources/content/` substrate per ADR 0004.
+ * @summary Universal ordinal-100 path-resolution primitive for the `resources/content/` substrate.
  *
  * This helper is the single source-of-truth for active-tier and archive-tier on-disk path math
  * across all content types (issues, pulls, discussions, release-notes). It supersedes the
@@ -17,11 +17,10 @@ import path from 'path';
  *   4. Archive tier path: `{contentRoot}/archive/{type}/{version|bucket}/chunk-{N}/{filename}`
  *
  * No flat-vs-chunked branching. No ID-range math. No `<NNN>xx/` folders. ONE primitive applied
- * universally per the operator-confirmed `"consistency is key. same for all. own id chunks."`
- * directive (ADR 0004 §1.1).
+ * universally under ADR 0004's single path-resolution contract.
  *
  * **Sealed-chunk invariant:** `.github/workflows/prevent-reopen.yml` enforces that closed items
- * past their 24h-grace window cannot be reopened (CI auto-re-closes + creates new ticket).
+ * past their 24h-grace window cannot be reopened; the CI guard preserves archive immutability.
  * Therefore once a chunk is sealed at archive-cut, membership is mechanically immutable — this
  * is what makes the ordinal chunking safe. Anyone reading this helper MUST mentally factor that
  * primitive in (ADR 0004 §5.4 anti-pattern: "Skipping `prevent-reopen.yml` in the mental model").
@@ -33,8 +32,6 @@ import path from 'path';
  * ADR 0004 start-to-finish, then verify the chosen pattern against this helper's signature.
  *
  * @see ADR 0004 (`learn/agentos/decisions/0004-github-content-architecture.md`)
- * @see Epic #11372
- * @see #11379 (this implementation ticket)
  * @see .github/workflows/prevent-reopen.yml (sealed-chunk substrate)
  */
 
@@ -90,12 +87,12 @@ export const DEFAULT_CHUNK_PREFIX    = 'chunk-';
  * @throws {TypeError} If any segment / integer invariant is violated
  *
  * @example
- *   // Active tier — issue #1234 at ordinal index 42 (chunk 1)
+ *   // Active tier — issue 1234 at ordinal index 42 (chunk 1)
  *   contentPath({contentRoot: 'resources/content', type: 'issues', filename: 'issue-1234.md', itemIndex: 42})
  *   // → 'resources/content/issues/chunk-1/issue-1234.md'
  *
  * @example
- *   // Archive tier — pull #999 at ordinal index 250 in v12.1.0 (chunk 3)
+ *   // Archive tier — pull 999 at ordinal index 250 in v12.1.0 (chunk 3)
  *   contentPath({
  *     contentRoot: 'resources/content', type: 'pulls', version: 'v12.1.0',
  *     filename: 'pr-999.md', itemIndex: 250
@@ -122,8 +119,8 @@ export default function contentPath(config = {}) {
     validateNonNegativeInteger(itemIndex, 'itemIndex');
     validateBucketXor({version, bucket});
 
-    // Presence-aware validation per #11381 GPT review RA1: supplying `version: ''` or `bucket: ''`
-    // is a contract violation (caller signaled archive-tier routing with a non-empty value missing).
+    // Presence-aware validation: supplying `version: ''` or `bucket: ''` is a
+    // contract violation (caller signaled archive-tier routing without a value).
     // Distinguish key-not-supplied (undefined / null) from key-supplied-as-empty (which must throw).
     if (version !== undefined && version !== null) validateSegment(version, 'version');
     if (bucket  !== undefined && bucket  !== null) validateSegment(bucket,  'bucket');
@@ -159,8 +156,8 @@ export function contentBucketDir(config = {}) {
     validateSegment(type,        'type');
     validateBucketXor({version, bucket});
 
-    // Presence-aware validation (see #11381 GPT review RA1 / `contentPath` body): supplied-but-empty
-    // archive-tier selectors must fail-loud rather than silently routing to active-tier.
+    // Supplied-but-empty archive-tier selectors must fail-loud rather than
+    // silently routing to active-tier.
     if (version !== undefined && version !== null) validateSegment(version, 'version');
     if (bucket  !== undefined && bucket  !== null) validateSegment(bucket,  'bucket');
 
@@ -190,10 +187,10 @@ export function chunkNumberFor(itemIndex, itemsPerChunk = DEFAULT_ITEMS_PER_CHUN
  * Supplying both is a programming error (archive disambiguation conflict); supplying neither
  * is the legitimate "active tier" path and is permitted.
  *
- * Presence-aware semantics (per #11381 GPT review RA1): supplying both keys is a conflict
- * even if both values are empty strings — the caller signaled archive-tier intent on two
- * different axes simultaneously. Non-emptiness of the supplied value is validated separately
- * by `validateSegment` at the call site.
+ * Presence-aware semantics: supplying both keys is a conflict even if both values are
+ * empty strings — the caller signaled archive-tier intent on two different axes
+ * simultaneously. Non-emptiness of the supplied value is validated separately by
+ * `validateSegment` at the call site.
  *
  * @param {Object} config
  * @param {String} [config.version]

--- a/ai/services/github-workflow/sync/IssueSyncer.mjs
+++ b/ai/services/github-workflow/sync/IssueSyncer.mjs
@@ -702,7 +702,7 @@ class IssueSyncer extends Base {
         const lastSyncDate = metadata.lastSync ? new Date(metadata.lastSync) : new Date(0);
 
         allIssues.forEach(issue => {
-            // 1. Existing Parent Check (Legacy but safe)
+            // 1. Parent field check for relationships already present on the fetched node.
             if (issue.parent) {
                 relatedIssuesToUpdate.add(issue.parent.number);
             }


### PR DESCRIPTION
Refs #11924
Related: #11912

Authored by GPT-5 (Codex Desktop). Session 1578fb3e-7f5a-4b43-a6d0-ba00e66a9885.

FAIR-band: over-target [18/30] - taking this lane despite over-target because #11924 is already assigned to @neo-gpt, has prior @neo-gpt partial PRs, has no active PR, and this is a narrow residual cleanup batch after the deployment-ticket siblings were already closed.

This PR continues the #11924 GitHub Workflow/shared MCP source-comment cleanup without closing the parent subissue. It removes residual ticket/PR-cycle archaeology from comment/JSDoc surfaces in path planning, issue/PR mutation helpers, assignment-audit docs, and sync diagnostics while preserving runtime strings, public API names, log-message payloads, and behavior.

Evidence: L1 (static diff, focused grep-count comparison, syntax checks, and whitespace check) to L1 required (comment-only partial cleanup). Residual: #11924 remains open for remaining source-comment batches.

Decision Record impact: none. This stays aligned with ADR 0005 and ADR 0008 as source-comment cleanup; no runtime contract or architecture decision changes.

## Deltas from ticket
- Partial batch only; PR intentionally uses `Refs #11924` rather than a close keyword.
- Left runtime strings and current template terminology untouched even when the focused diagnostic still matches them.
- Removed `contentPath.mjs` from the focused residual hit list entirely; reduced several nearby GitHub Workflow residuals without widening into unrelated generated or runtime surfaces.

## Test Evidence
- `git diff --check`
- `git diff --cached --check`
- `git diff --check origin/dev...HEAD`
- `node --check ai/services/github-workflow/shared/contentPath.mjs`
- `node --check ai/services/github-workflow/queries/mutations.mjs`
- `node --check ai/services/github-workflow/queries/issueQueries.mjs`
- `node --check ai/services/github-workflow/IssueService.mjs`
- `node --check ai/services/github-workflow/PullRequestService.mjs`
- `node --check ai/services/github-workflow/SyncService.mjs`
- `node --check ai/services/github-workflow/sync/IssueSyncer.mjs`
- Focused residual grep pattern:
  `(?i)(PR #|#[0-9]{4,}|AC[0-9]|cycle|phase|legacy|historical|archaeology|lane|ticket)`
- Before/after highlights from the focused grep:
  - `ai/services/github-workflow/shared/contentPath.mjs`: 7 -> 0
  - `ai/services/github-workflow/queries/mutations.mjs`: 6 -> 1
  - `ai/services/github-workflow/queries/issueQueries.mjs`: 7 -> 4
  - `ai/services/github-workflow/SyncService.mjs`: 3 -> 2
  - `ai/services/github-workflow/sync/IssueSyncer.mjs`: 9 -> 8
- Pre-push freshness: `git merge-base HEAD origin/dev` matched `git rev-parse origin/dev`.
- Partial-resolution branch-history check: `git log origin/dev..HEAD --format='%h%x09%s%n%b'` showed only `fdd0e846d chore(ai): clean residual github workflow comments (#11924)` and no close keyword.

## Post-Merge Validation
- [ ] Confirm #11924 remains open after merge.
- [ ] Continue residual #11924 cleanup in a later batch, with runtime strings and template terminology classified as false positives where appropriate.

## Commits
- `fdd0e846d` - `chore(ai): clean residual github workflow comments (#11924)`
