### PR TITLE
fix(deploy): restore ingress TLS and integration fixtures (#12022, #12023)

### DIFF
--- a/ai/daemons/orchestrator/services/TenantRepoSyncService.mjs
+++ b/ai/daemons/orchestrator/services/TenantRepoSyncService.mjs
@@ -568,7 +568,7 @@ class TenantRepoSyncService extends Base {
 
     /**
      * Default per-tenant-repo lastIngestedRev persistence file path. Lives next to
-     * the orchestrator state file (`<DEFAULT_DATA_DIR>/state.json` per `TaskDefinitions.mjs`)
+     * the orchestrator state file (`<DEFAULT_DATA_DIR>/orchestrator-state.json`)
      * so the two persistence surfaces share lifecycle (same data-dir = same recovery scope).
      * Separate file (not inlined into TaskStateService's state) prevents `markCompleted/markFailed`
      * task-lifecycle writes from racing with revision-map writes.

--- a/ai/deploy/Caddyfile
+++ b/ai/deploy/Caddyfile
@@ -8,10 +8,11 @@
 # Wired into ai/deploy/docker-compose.yml as the `ingress` profile service:
 #   docker compose --profile cloud --profile ingress up
 #
-# Copy-paste-runnable as-is: `tls internal` issues a self-signed certificate, so
-# the stack stands up with zero operator configuration. For production, replace
-# `:443` with your real hostname — Caddy then auto-provisions a publicly-trusted
-# certificate — or mount certs and swap `tls internal` for `tls /cert.pem /key.pem`.
+# Copy-paste-runnable as-is: NEO_DEPLOY_HOSTNAME defaults to localhost, giving
+# `tls internal` a concrete identifier for self-signed certificate issuance. For
+# production, set NEO_DEPLOY_HOSTNAME to your real hostname — Caddy then
+# auto-provisions a publicly-trusted certificate — or mount certs and swap
+# `tls internal` for `tls /cert.pem /key.pem`.
 #
 # Security threat model: the MCP servers run with trustProxyIdentity, trusting the
 # X-PREFERRED-USERNAME header for authorization. Any client-supplied value for that
@@ -24,33 +25,33 @@
 # `request_header`. `route` pins literal order — see ai/mcp/deploy/proxy/Caddyfile.
 # ------------------------------------------------------------------------------
 
-:443 {
-    tls internal
+{$NEO_DEPLOY_HOSTNAME:localhost}:443 {
+	tls internal
 
-    route {
-        # 1. SECURITY — strip client-supplied identity headers before anything trusts them.
-        request_header -X-Preferred-Username
-        request_header -X-Auth-Request-Preferred-Username
+	route {
+		# 1. SECURITY — strip client-supplied identity headers before anything trusts them.
+		request_header -X-Preferred-Username
+		request_header -X-Auth-Request-Preferred-Username
 
-        # 2. OPTIONAL auth layer. Uncomment and provision an oauth2-proxy (operator-owned
-        #    OIDC) for enforced identity. Without it the stack still stands up, but identity
-        #    is unenforced — reference/demo posture only; never run multi-tenant unauthed.
-        # forward_auth oauth2-proxy:4180 {
-        #     uri /oauth2/auth
-        #     copy_headers X-Auth-Request-Preferred-Username
-        # }
+		# 2. OPTIONAL auth layer. Uncomment and provision an oauth2-proxy (operator-owned
+		#    OIDC) for enforced identity. Without it the stack still stands up, but identity
+		#    is unenforced — reference/demo posture only; never run multi-tenant unauthed.
+		# forward_auth oauth2-proxy:4180 {
+		#     uri /oauth2/auth
+		#     copy_headers X-Auth-Request-Preferred-Username
+		# }
 
-        # 3. Knowledge Base MCP server — compose service DNS, internal port 3000.
-        #    With the optional auth layer enabled, inject the trusted identity header
-        #    inside this block, e.g.:
-        #    `header_up X-Preferred-Username {http.request.header.X-Auth-Request-Preferred-Username}`
-        handle_path /kb/* {
-            reverse_proxy kb-server:3000
-        }
+		# 3. Knowledge Base MCP server — compose service DNS, internal port 3000.
+		#    With the optional auth layer enabled, inject the trusted identity header
+		#    inside this block, e.g.:
+		#    `header_up X-Preferred-Username {http.request.header.X-Auth-Request-Preferred-Username}`
+		handle_path /kb/* {
+			reverse_proxy kb-server:3000
+		}
 
-        # 4. Memory Core MCP server — compose service DNS, internal port 3001.
-        handle_path /mc/* {
-            reverse_proxy mc-server:3001
-        }
-    }
+		# 4. Memory Core MCP server — compose service DNS, internal port 3001.
+		handle_path /mc/* {
+			reverse_proxy mc-server:3001
+		}
+	}
 }

--- a/ai/deploy/docker-compose.test.yml
+++ b/ai/deploy/docker-compose.test.yml
@@ -64,6 +64,11 @@ services:
       - NEO_OPENAI_COMPATIBLE_API_KEY=test-integration-key
     tmpfs:
       - /tmp/neo-integration
+    volumes:
+      # Production deploy images keep the broad `test` tree out of the build
+      # context; this test-only mount preserves the KB ingestion golden fixtures
+      # that the integration matrix executes from inside the kb-server container.
+      - ../../test/playwright/integration/ai/kb-ingestion/fixtures/external-workspaces:/app/test/playwright/integration/ai/kb-ingestion/fixtures/external-workspaces:ro
     depends_on:
       chroma:
         condition: service_healthy

--- a/ai/deploy/docker-compose.yml
+++ b/ai/deploy/docker-compose.yml
@@ -177,7 +177,7 @@ services:
     # margin) = orchestrator is alive and polling. 90s start_period covers the
     # first-poll latency on cold container boot.
     healthcheck:
-      test: ["CMD-SHELL", "node -e \"const fs=require('fs');const f=(process.env.NEO_AI_ORCHESTRATOR_DIR||'/app/.neo-ai-data/orchestrator-daemon')+'/state.json';try{const m=fs.statSync(f).mtimeMs;process.exit(Date.now()-m<600000?0:1)}catch(e){process.exit(1)}\""]
+      test: ["CMD-SHELL", "node -e \"const fs=require('fs');const f=(process.env.NEO_AI_ORCHESTRATOR_DIR||'/app/.neo-ai-data/orchestrator-daemon')+'/orchestrator-state.json';try{const m=fs.statSync(f).mtimeMs;process.exit(Date.now()-m<600000?0:1)}catch(e){process.exit(1)}\""]
       interval: 60s
       timeout: 5s
       retries: 3

--- a/ai/deploy/docker-compose.yml
+++ b/ai/deploy/docker-compose.yml
@@ -197,6 +197,8 @@ services:
     image: caddy:2-alpine
     ports:
       - "443:443"
+    environment:
+      - NEO_DEPLOY_HOSTNAME=${NEO_DEPLOY_HOSTNAME:-localhost}
     volumes:
       - ./Caddyfile:/etc/caddy/Caddyfile:ro
       - caddy-data:/data

--- a/learn/agentos/cloud-deployment/Day0Tutorial.md
+++ b/learn/agentos/cloud-deployment/Day0Tutorial.md
@@ -23,6 +23,11 @@ The commands below use local demo endpoints. Replace the URLs, tenant id, repo
 slug, and tokens with deployment values once the same path is run behind Caddy
 or another production ingress.
 
+When using the optional ingress profile, `ai/deploy/Caddyfile` binds
+`tls internal` to `NEO_DEPLOY_HOSTNAME`, defaulting to `localhost`. Set
+`NEO_DEPLOY_HOSTNAME` before starting the ingress service when testing a named
+host.
+
 ## Prerequisites
 
 Run from a Neo checkout that contains the cloud deployment profile and

--- a/test/playwright/unit/ai/config.template.spec.mjs
+++ b/test/playwright/unit/ai/config.template.spec.mjs
@@ -101,6 +101,7 @@ test.describe('Tier 1 Config Immutability', () => {
         expect(Config.orchestrator.localOnly).toEqual({
             primaryDevSyncEnabled: null,
             kbSyncEnabled        : null,
+            chromaDaemonEnabled  : null,
             bridgeDaemonEnabled  : null,
             goldenPathRepoEnrichmentEnabled: null,
             swarmHeartbeatEnabled: null,


### PR DESCRIPTION
Resolves #12022
Resolves #12023
Resolves #12025

Authored by GPT-5.5 (Codex Desktop). Session 019e63ad-9964-7651-abf9-23053f16d22b.
FAIR-band: over-target [18/30] — taking this lane despite over-target because the operator explicitly relaxed FAIR-band while GPT is the only active repo-local author harness, and this is a time-critical CI/deploy regression lane blocking interpretation of #12020/#12021.

Restores the Day-0 ingress hostname contract, the integration test fixture contract, and the cloud orchestrator healthcheck filename contract without reopening the large deploy build context that #12017 fixed. The ingress Caddyfile now binds `tls internal` to `NEO_DEPLOY_HOSTNAME` with a `localhost` default, the integration compose stack mounts only the KB ingestion golden fixture subtree into `kb-server`, and the orchestrator healthcheck now probes the actual `orchestrator-state.json` file written by `Orchestrator.mjs`.

Evidence: L2 (Caddy config validation + compose config validation + targeted unit validation + built-image context audit) → L4 required (#12022 live ingress TLS handshake/log proof, #12023 GitHub-hosted integration-unified validation, #12025 live cloud compose `--wait` health proof). Residual: current-head CI should re-confirm full unit/integration on GitHub Linux; #12022/#12025 still benefit from operator/reviewer live compose curl/log/health validation because this local Colima daemon cannot bind-mount the repo from `/Users/Shared` into helper containers.

## Deltas from ticket

- #12023: implemented the narrow test-only mount path rather than weakening `ai/deploy/Dockerfile.dockerignore`; the built deploy image still excludes `/app/test`.
- #12022: used the env-driven hostname option (`{$NEO_DEPLOY_HOSTNAME:localhost}:443`) so the Day-0 path stays copy-paste runnable while production can override the hostname.
- #12022: `ai/mcp/deploy/proxy/Caddyfile` already uses an explicit `mcp.example.com` site address rather than a bare `:443 { tls internal }` block, so no sibling change was needed there.
- #12023 CI follow-up: added the missing `chromaDaemonEnabled` expectation to `test/playwright/unit/ai/config.template.spec.mjs` after PR #12024 CI showed the stale assertion as the only non-flaky unit failure.
- #12025: used the low-blast path of updating the compose healthcheck and JSDoc to match `Orchestrator.mjs`, not renaming the state file.

## Slot Rationale

Modified `learn/agentos/cloud-deployment/Day0Tutorial.md` only to mirror the runtime Caddy hostname contract. Disposition delta: `keep -> keep`; this is operator-facing Day-0 documentation, not turn-loaded instruction substrate. Trigger-frequency is limited to cloud deployment onboarding, failure-severity is high for ingress TLS, and enforceability is high through the Caddyfile/compose validation in this PR.

Env-var change audit: this adds `NEO_DEPLOY_HOSTNAME`; it does not rename an existing variable and introduces no deprecated alias/fallback chain. The runtime default is a clean one-step `localhost` default in compose/Caddy.

## Test Evidence

- `git diff --check` passed.
- `git diff --cached --check` passed before both commits.
- `docker run --rm -i -e NEO_DEPLOY_HOSTNAME=localhost caddy:2-alpine caddy validate --adapter caddyfile --config - < ai/deploy/Caddyfile` passed with `Valid configuration`.
- `docker compose --profile ingress -f ai/deploy/docker-compose.yml config` passed and resolved `NEO_DEPLOY_HOSTNAME: localhost` for the ingress service.
- `docker compose --profile cloud -f ai/deploy/docker-compose.yml config` passed and resolved the orchestrator healthcheck probe to `/orchestrator-state.json`.
- `docker compose -f ai/deploy/docker-compose.test.yml config` passed and resolved the targeted KB fixture bind mount to `/app/test/playwright/integration/ai/kb-ingestion/fixtures/external-workspaces`.
- `npm run test-unit -- test/playwright/unit/ai/config.template.spec.mjs` passed: 5/5.
- `rg -n '/state\\.json\\b|<DEFAULT_DATA_DIR>/state\\.json|\\+ ?["']\\/state\\.json' ai` returned no matches.\n- `npm run test-integration-unified -- test/playwright/integration/ai/kb-ingestion/multi-tenant.spec.mjs` attempted; local run blocked before tests by Colima bind-mounting `/Users/Shared/...` as unavailable to existing helper containers (`mock-openai-embedding-server.mjs` / `mock-oidc-server.mjs` MODULE_NOT_FOUND). This is a local daemon mount ceiling, not a spec failure; the compose stack was cleaned up with `docker compose -p neo-integration-test -f ai/deploy/docker-compose.test.yml down --remove-orphans`.\n- During that attempted run, Docker build context transfer remained `7.41MB`, preserving the #12017 context shrink.\n- `docker run --rm neo-integration-test-kb-server sh -c 'test ! -e /app/test && test -e /app/ai/deploy/Dockerfile'` passed, confirming the built deploy image still excludes broad tests.\n- PR #12024 first-head CI confirmed `integration-unified` SUCCESS before the #12025/unit follow-up commit; current-head CI is re-running after `efc46fb80`.\n\n## Post-Merge Validation\n\n- [ ] GitHub Actions `integration-unified` no longer fails with ENOENT for `/app/test/playwright/integration/ai/kb-ingestion/fixtures/external-workspaces/mini-neo-workspace/expected-chunks.jsonl`.\n- [ ] Fresh ingress boot with `NEO_DEPLOY_HOSTNAME=localhost` emits Caddy certificate-obtained logs for `localhost` and `curl -k https://localhost/` reaches an HTTP response instead of a TLS handshake failure.\n- [ ] Fresh cloud boot with the orchestrator profile reports Docker health `healthy` once `orchestrator-state.json` has been written.\n\n## Commits\n\n- `4ba0b4c05` — `fix(deploy): restore ingress TLS and integration fixtures (#12022, #12023)`\n- `efc46fb80` — `fix(deploy): align orchestrator healthcheck state path (#12025, #12023)`