### PR TITLE
fix(deploy): keep KB source corpus in image (#12026)

### DIFF
--- a/ai/deploy/Dockerfile.dockerignore
+++ b/ai/deploy/Dockerfile.dockerignore
@@ -1,6 +1,5 @@
-# Runtime / agent state: host-only, never deployed.
+# Runtime / operator state: host-only, never deployed.
 .neo-ai-data
-.agents
 .claude
 .codex
 .env*
@@ -9,12 +8,15 @@
 .vscode
 tmp
 
-# Frontend, docs, examples, tests, and local KB corpus are not deploy runtime.
+# Agent harness state is host-only; skill substrate stays for KB ingestion.
+.agents/*
+!.agents/skills
+!.agents/skills/**
+
+# Workspace demo apps are not required for the Day-0 Neo-shared KB seed.
 apps
-docs
-examples
-learn
-resources
+
+# The integration harness mounts its narrow KB fixture path explicitly (#12024).
 test
 
 # Build / test artifacts: rebuilt in-container.

--- a/ai/deploy/Dockerfile.dockerignore
+++ b/ai/deploy/Dockerfile.dockerignore
@@ -16,6 +16,16 @@ tmp
 # Workspace demo apps are not required for the Day-0 Neo-shared KB seed.
 apps
 
+# Only the docs app source is needed in deploy images; generated docs/output is massive.
+docs
+!docs/app
+!docs/app/**
+
+# Keep resources/content for KB ingestion, but skip bulky runtime asset bundles.
+resources/images
+resources/fonts
+resources/examples
+
 # The integration harness mounts its narrow KB fixture path explicitly (#12024).
 test
 

--- a/learn/agentos/cloud-deployment/Day0Tutorial.md
+++ b/learn/agentos/cloud-deployment/Day0Tutorial.md
@@ -282,41 +282,24 @@ Expected payload fields:
 }
 ```
 
+Seed the Neo-shared corpus once inside the KB container before querying it:
+
+```bash
+docker compose \
+  -p "$NEO_DAY0_PROJECT" \
+  -f ai/deploy/docker-compose.test.yml \
+  exec -T kb-server \
+  npm run ai:sync-kb
+```
+
+For a production compose stack, use the same one-shot form against the deployed
+`kb-server`. This is an operator-triggered seed/import, not the periodic cloud
+orchestrator `kbSync` lane; `NEO_ORCHESTRATOR_KB_SYNC_ENABLED` remains `false`
+per [ADR 0014](../decisions/0014-cloud-deployment-topology-and-scheduler-task-taxonomy.md).
+
 Then query Neo-shared content:
 
 ```bash
-node - <<'NODE' > /tmp/day0-neo-shared.json
-const fs = require('fs');
-const content = fs.readFileSync('learn/agentos/cloud-deployment/TenantIngestionModel.md', 'utf8');
-
-process.stdout.write(JSON.stringify({
-  tenantId: 'neo-shared',
-  repoSlug: 'neo',
-  files: [{
-    sourcePath: 'learn/agentos/cloud-deployment/TenantIngestionModel.md',
-    parsedChunks: [{
-      schemaVersion: '1.0.0',
-      tenantId: 'neo-shared',
-      repoSlug: 'neo',
-      rootKind: 'neo-workspace',
-      sourcePath: 'learn/agentos/cloud-deployment/TenantIngestionModel.md',
-      content,
-      hashInputs: ['kind', 'name', 'content', 'sourcePath', 'parserId', 'parserVersion'],
-      parserId: 'day0-neo-shared-seed',
-      parserVersion: '1.0.0',
-      kind: 'guide',
-      name: 'Tenant Ingestion Model'
-    }]
-  }]
-}));
-NODE
-
-node /tmp/day0-call-tool.mjs \
-  "$NEO_KB_MCP_BASE_URL" \
-  neo-shared \
-  ingest_source_files \
-  /tmp/day0-neo-shared.json
-
 cat > /tmp/day0-kb-query.json <<'JSON'
 {
   "query": "cloud deployment tenant ingestion model",
@@ -340,8 +323,8 @@ Failure signatures:
 
 | Signature | Meaning | Fix |
 |---|---|---|
-| `collection does not exist` | The KB collection was not initialized. | Run the deployed KB sync/import step for Neo-shared content, or inspect KB startup logs. |
-| Empty answer with healthy DB | The curated Neo content is not indexed. | Run the deployment's Neo-shared KB sync before tenant onboarding. |
+| `collection does not exist` | The KB collection was not initialized. | Run the one-shot `kb-server` `npm run ai:sync-kb` command above, or inspect KB startup logs. |
+| Empty answer with healthy DB | The curated Neo content is not indexed. | Verify the image contains the Neo source trees and re-run the one-shot Neo-shared KB sync before tenant onboarding. |
 | `Tool not found: ask_knowledge_base` | The endpoint is not the KB MCP server. | Verify `/kb/mcp` routing and `NEO_PUBLIC_URL`. |
 
 ## Milestone 3 - Tenant Repo Ingestion


### PR DESCRIPTION
Authored by GPT-5 (Codex Desktop). Session 1578fb3e-7f5a-4b43-a6d0-ba00e66a9885.

FAIR-band: over-target [18/30] — taking this lane despite over-target because the operator explicitly directed a separate PR to preserve #12024's green CI, and #12026 is a time-critical cloud-deployment follow-up from the active a partner tenant Day-0 validation lane.

Evidence: L3 (built KB image path probe + disposable compose source-extraction run reached 21,801 chunks and embedding batch 10/436) -> L3 full embedding completion requested by AC4. Residual: AC4 [#12026].

Resolves #12026

## Summary

This PR keeps the Neo-shared source corpus available inside deploy-built KB images so an operator-triggered in-container `npm run ai:sync-kb` can seed the default Neo content.

Changes:

- Removes the over-broad `learn`, `resources`, and `examples` deploy-image exclusions.
- Ignores broad `docs` with an explicit `docs/app` exception, which keeps `ApiSource` input while dropping generated `docs/output`.
- Keeps `resources/content` for KB ingestion while excluding asset-heavy `resources/images`, `resources/fonts`, and `resources/examples`.
- Keeps `.agents/skills/**` while continuing to exclude other `.agents` harness state.
- Keeps `apps` excluded for the Day-0 seed scope.
- Keeps broad `test` excluded after #12024, because integration fixtures now arrive through the narrow compose-test bind mount.
- Updates Day-0 Milestone 2 to name the concrete one-shot `kb-server` sync command and distinguish it from the disabled cloud orchestrator `kbSync` lane.

## Deltas From Ticket

- `test/` remains excluded. #12024 merged before this branch was finalized and deliberately solved integration fixture access via a narrow `docker-compose.test.yml` bind mount. Reverting to a broad production-image `test/` include would undo that lean-image fix.
- `docs/app` is not excluded. Live `ApiSource` maps `docs/app` as a default KB source, so broad `docs` is paired with explicit `docs/app` exceptions to avoid carrying rebuilt `docs/output` into deploy images.
- `resources/content` is not excluded. Live `ConceptSource`, `DiscussionSource`, `PullRequestSource`, and `TicketSource` map into `resources/content/**`; asset/example subtrees `resources/images`, `resources/fonts`, and `resources/examples` stay excluded.
- `.agents/skills/**` is kept. Live `SkillSource` reads `.agents/skills`, while other `.agents` harness state remains excluded.

## Contract Ledger

| Target Surface | Source of Authority | Proposed Behavior | Fallback | Docs | Evidence |
|---|---|---|---|---|---|
| `ai/deploy/Dockerfile.dockerignore` | `ApiSource`, `LearningSource`, `ConceptSource`, `DiscussionSource`, `TicketSource`, `SkillSource`; #12024 integration-fixture mount | Keep KB-ingested source trees in the deploy image; keep `apps`, broad `test`, `docs/output`, `resources/images`, `resources/fonts`, and `resources/examples` excluded | Operator-side ingestion can still push explicit tenant/source envelopes, but default Neo-shared in-container sync needs the source trees | Inline dockerignore comments | Built image path probe: `learn`, `resources/content`, top-level `examples`, `docs/app`, `.agents/skills`, `src`, and `ai` present; `docs/output`, `resources/images`, `resources/fonts`, `resources/examples`, `apps`, `test`, and `dist` missing |
| Day-0 Tutorial Milestone 2 | ADR 0014 cloud profile; `ai:sync-kb` CLI | Document one-shot operator-triggered `kb-server npm run ai:sync-kb`; keep orchestrator `kbSync` disabled in cloud | Operator can use a deployment-specific equivalent compose project / public URL | `learn/agentos/cloud-deployment/Day0Tutorial.md` | Disposable compose run reached source extraction and began embedding without missing-source errors |

## Slot Rationale

This PR mutates `learn/agentos/**`, so it includes the substrate slot rationale required by the pull-request workflow.

- Modified section: Day-0 Tutorial Milestone 2. Disposition: `keep`; delta: replaces a manual single-file seed with the concrete Neo-shared corpus sync command. Rating: trigger-frequency medium, failure-severity high, enforceability high. Reason: this is the operator-facing first-run proof path for cloud Agent OS deployment, and the previous wording was unactionable once the deploy image excluded the source corpus.
- Decay mitigation: if the canonical Neo-shared seed path later moves from in-container sync to operator-side push/import, this section should be rewritten to the new command rather than preserved as historical guidance.

## Test Evidence

- `git diff --cached --check` passed before commit.
- `git diff --check origin/dev...HEAD` passed before push.
- `docker compose -f ai/deploy/docker-compose.test.yml config --quiet` passed.
- Dockerfile.dockerignore policy check passed: `docs` is excluded with ordered `docs/app` exceptions; `resources/images`, `resources/fonts`, and `resources/examples` are excluded; `learn`, top-level `examples`, `resources/content`, and `.agents/skills` remain included.
- Built KB image with `docker build -f ai/deploy/Dockerfile --build-arg TARGET_SERVER=knowledge-base -t neo-kb-context-12026 .`.
- Built-image path probe passed: `learn`, `resources/content`, top-level `examples`, `docs/app`, `.agents/skills`, `src`, and `ai` present; `docs/output`, `resources/images`, `resources/fonts`, `resources/examples`, `apps`, `test`, and `dist` missing.
- Disposable compose path probe passed with #12024's fixture mount active before the final docs/resources narrowing: `learn`, `resources`, `examples`, `docs`, `.agents/skills`, `test` present; `apps` missing.
- Disposable `kb-server npm run ai:sync-kb` progressed through all source extraction, created `21801` chunks, and reached embedding batch `10/436`; stopped intentionally because full embedding was trending far beyond the CI-time budget.

## Post-Merge Validation

- Complete a full `docker compose ... exec -T kb-server npm run ai:sync-kb` run against a deployment stack when the operator wants the heavy proof. The local run proved source availability and extraction; full 436-batch embedding completion was intentionally not waited out in this author turn.

## Review Routing

Primary reviewer requested: @neo-opus-4-7, because Claude filed #12026 and has the active a partner tenant mirror context for this cloud-deployment lane.