### PR TITLE
feat(kb): add raw repo source opt-in (#12029)

### DIFF
--- a/ai/mcp/server/knowledge-base/config.template.mjs
+++ b/ai/mcp/server/knowledge-base/config.template.mjs
@@ -208,6 +208,17 @@ class Config extends BaseConfig {
          */
         useDefaultSources: true,
         /**
+         * @summary Explicit opt-in fallback Source for unknown tenant repository shapes.
+         *
+         * When `true`, `SourceRegistry` registers `RawRepoSource` in addition to any default or
+         * custom Sources. It is intentionally disabled by default so zero-config Neo deployments
+         * keep the curated 10-source corpus and never walk the full repository tree implicitly.
+         *
+         * Operator env var: `NEO_KB_RAW_REPO_SOURCE`.
+         * @type {boolean}
+         */
+        rawRepoSource: false,
+        /**
          * When `true` (default), the SourceRegistry auto-registers Neo's
          * built-in Parser classes. The default registry may be empty until parser modules are added.
          * @type {boolean}
@@ -251,6 +262,31 @@ class Config extends BaseConfig {
                 'examples': 'example',
                 'docs/app': 'app',
                 'ai'      : 'ai-infrastructure'
+            },
+            RawRepoSource     : {
+                root             : '.',
+                includeExtensions: [],
+                excludeExtensions: [
+                    '.7z', '.avif', '.bin', '.bmp', '.bz2', '.class', '.dmg', '.eot',
+                    '.exe', '.gif', '.gz', '.ico', '.jar', '.jpeg', '.jpg', '.lockb',
+                    '.mov', '.mp3', '.mp4', '.otf', '.pdf', '.png', '.sqlite', '.tar',
+                    '.tgz', '.ttf', '.wasm', '.webm', '.webp', '.woff', '.woff2', '.zip'
+                ],
+                excludePaths: [
+                    '.git',
+                    '.neo-ai-data',
+                    'coverage',
+                    'dist',
+                    'docs/output',
+                    'node_modules',
+                    'package-lock.json',
+                    'playwright-report',
+                    'resources/examples',
+                    'resources/fonts',
+                    'resources/images',
+                    'test-results',
+                    'yarn.lock'
+                ]
             }
         },
         /**
@@ -368,11 +404,12 @@ class Config extends BaseConfig {
             clientId          : 'NEO_OAUTH_CLIENT_ID',
             clientSecret      : 'NEO_OAUTH_CLIENT_SECRET',
             trustProxyIdentity: { var: 'NEO_AUTH_TRUST_PROXY_IDENTITY', parse: Env.parseBool }
-            },
-            backupPath              : 'NEO_BACKUP_PATH',
-            host                    : 'NEO_CHROMA_HOST',
-            port                    : { var: 'NEO_CHROMA_PORT', parse: Env.parsePort },
-            memoryCoreDbPath        : 'NEO_MEMORY_DB_PATH',
+        },
+        rawRepoSource          : { var: 'NEO_KB_RAW_REPO_SOURCE', parse: Env.parseBool },
+        backupPath             : 'NEO_BACKUP_PATH',
+        host                   : 'NEO_CHROMA_HOST',
+        port                   : { var: 'NEO_CHROMA_PORT', parse: Env.parsePort },
+        memoryCoreDbPath       : 'NEO_MEMORY_DB_PATH',
         kbFaqMinCount           : { var: 'NEO_KB_FAQ_MIN_COUNT', parse: Env.parseNumber },
         kbFaqSimilarityThreshold: { var: 'NEO_KB_FAQ_SIMILARITY_THRESHOLD', parse: Env.parseNumber },
         kbFaqConceptLimit       : { var: 'NEO_KB_FAQ_CONCEPT_LIMIT', parse: Env.parseNumber },

--- a/ai/services/knowledge-base/KnowledgeBaseIngestionService.mjs
+++ b/ai/services/knowledge-base/KnowledgeBaseIngestionService.mjs
@@ -790,7 +790,7 @@ class KnowledgeBaseIngestionService extends Base {
      * the `kb-config.yaml` deployment bootstrap → the default source/parser registry from `aiConfig`.
      * @param {Object}  data
      * @param {String} [data.tenantId] Tenant id; normalized, defaults to `aiConfig.defaultTenantId`.
-     * @returns {Promise<{tenantId: String, source: String, version: Number, useDefaultSources: Boolean, useDefaultParsers: Boolean, customSources: Array, customParsers: Array, sourcePaths: Object}>}
+     * @returns {Promise<{tenantId: String, source: String, version: Number, useDefaultSources: Boolean, rawRepoSource: Boolean, useDefaultParsers: Boolean, customSources: Array, customParsers: Array, sourcePaths: Object}>}
      */
     async getTenantConfig({tenantId} = {}) {
         const resolvedTenant = normalizeUserId(tenantId) || aiConfig.defaultTenantId || 'neo-shared';
@@ -806,6 +806,7 @@ class KnowledgeBaseIngestionService extends Base {
                 source           : 'graph',
                 version          : p.version || 0,
                 useDefaultSources: p.useDefaultSources !== false,
+                rawRepoSource    : p.rawRepoSource === true,
                 useDefaultParsers: p.useDefaultParsers !== false,
                 customSources    : p.customSources || [],
                 customParsers    : p.customParsers || [],
@@ -825,6 +826,7 @@ class KnowledgeBaseIngestionService extends Base {
                 source           : 'yaml',
                 version          : 0,
                 useDefaultSources: normalizedBootstrap.useDefaultSources !== false,
+                rawRepoSource    : normalizedBootstrap.rawRepoSource === true,
                 useDefaultParsers: normalizedBootstrap.useDefaultParsers !== false,
                 customSources    : normalizedBootstrap.customSources || [],
                 customParsers    : normalizedBootstrap.customParsers || [],
@@ -841,6 +843,7 @@ class KnowledgeBaseIngestionService extends Base {
             source           : 'default',
             version          : 0,
             useDefaultSources: normalizedAiConfig.useDefaultSources !== false,
+            rawRepoSource    : normalizedAiConfig.rawRepoSource === true,
             useDefaultParsers: normalizedAiConfig.useDefaultParsers !== false,
             customSources    : normalizedAiConfig.customSources || [],
             customParsers    : normalizedAiConfig.customParsers || [],
@@ -890,8 +893,9 @@ class KnowledgeBaseIngestionService extends Base {
      *   detection to the default tier. Mirrors the `kb-manifest:<tenantId>` sibling node.
      * @param {Object} data
      * @param {String} data.tenantId Tenant id.
-     * @param {Object} [data.config={}] Config payload — `useDefaultSources` / `useDefaultParsers` /
-     *                                  `customSources` / `customParsers` / `sourcePaths`.
+     * @param {Object} [data.config={}] Config payload — `useDefaultSources` / `rawRepoSource` /
+     *                                  `useDefaultParsers` / `customSources` / `customParsers` /
+     *                                  `sourcePaths`.
      * @returns {Promise<{tenantId: String, version: Number}|{error: String, code: String, message: String}>}
      */
     async setTenantConfig({tenantId, config = {}} = {}) {
@@ -911,6 +915,7 @@ class KnowledgeBaseIngestionService extends Base {
                 properties: {
                     tenantId         : resolvedTenant,
                     useDefaultSources: normalizedConfig.useDefaultSources !== false,
+                    rawRepoSource    : normalizedConfig.rawRepoSource === true,
                     useDefaultParsers: normalizedConfig.useDefaultParsers !== false,
                     customSources    : normalizedConfig.customSources || [],
                     customParsers    : normalizedConfig.customParsers || [],

--- a/ai/services/knowledge-base/source/RawRepoSource.mjs
+++ b/ai/services/knowledge-base/source/RawRepoSource.mjs
@@ -1,0 +1,286 @@
+import Base     from './Base.mjs';
+import fs       from 'fs-extra';
+import path     from 'path';
+import aiConfig from '../../../mcp/server/knowledge-base/config.mjs';
+
+const DEFAULT_EXCLUDE_EXTENSIONS = Object.freeze([
+    '.7z', '.avif', '.bin', '.bmp', '.bz2', '.class', '.dmg', '.eot', '.exe',
+    '.gif', '.gz', '.ico', '.jar', '.jpeg', '.jpg', '.lockb', '.mov', '.mp3',
+    '.mp4', '.otf', '.pdf', '.png', '.sqlite', '.tar', '.tgz', '.ttf', '.wasm',
+    '.webm', '.webp', '.woff', '.woff2', '.zip'
+]);
+
+const DEFAULT_EXCLUDE_PATHS = Object.freeze([
+    '.git',
+    '.neo-ai-data',
+    'coverage',
+    'dist',
+    'docs/output',
+    'node_modules',
+    'package-lock.json',
+    'playwright-report',
+    'resources/examples',
+    'resources/fonts',
+    'resources/images',
+    'test-results',
+    'yarn.lock'
+]);
+
+const DEFAULT_CONFIG = Object.freeze({
+    excludeExtensions: DEFAULT_EXCLUDE_EXTENSIONS,
+    excludePaths     : DEFAULT_EXCLUDE_PATHS,
+    includeExtensions: [],
+    kind             : 'doc-section',
+    parserId         : 'raw-text',
+    parserVersion    : '1.0.0',
+    root             : '.',
+    rootKind         : 'external-source',
+    type             : 'raw'
+});
+
+/**
+ * @summary Extracts one raw-text Knowledge Base chunk per file from an arbitrary repository tree.
+ *
+ * `RawRepoSource` is an explicit opt-in bridge for tenants whose repository shape does not match
+ * Neo's curated Source classes and who have not authored a custom Source yet. It walks a configured
+ * repository root, skips common generated/binary/heavy paths, and emits each remaining file through
+ * the existing raw-text parsed-chunk contract. This keeps day-0 tenant ingestion possible without
+ * widening Neo's default 10-source corpus.
+ *
+ * @class Neo.ai.services.knowledge-base.source.RawRepoSource
+ * @extends Neo.ai.services.knowledge-base.source.Base
+ * @singleton
+ */
+class RawRepoSource extends Base {
+    static config = {
+        /**
+         * @member {String} className='Neo.ai.services.knowledge-base.source.RawRepoSource'
+         * @protected
+         */
+        className: 'Neo.ai.services.knowledge-base.source.RawRepoSource',
+        /**
+         * @member {Boolean} singleton=true
+         * @protected
+         */
+        singleton: true
+    }
+
+    /**
+     * @summary Extracts raw-text chunks from the configured repository root.
+     *
+     * Config is read from `aiConfig.sourcePaths.RawRepoSource`. A string value is treated as
+     * `{root: value}`; an object may define `root`, `includeExtensions`, `excludeExtensions`,
+     * `excludePaths`, `kind`, `type`, `parserId`, `parserVersion`, and `rootKind`.
+     *
+     * @param {Object}   writeStream  The JSONL write stream.
+     * @param {Function} createHashFn Function to create content hash.
+     * @returns {Promise<Number>} Number of file chunks extracted.
+     */
+    async extract(writeStream, createHashFn) {
+        const config   = this.normalizeConfig(aiConfig.sourcePaths?.RawRepoSource),
+              rootPath = path.resolve(aiConfig.neoRootDir, config.root);
+
+        if (!await fs.pathExists(rootPath)) {
+            return 0;
+        }
+
+        return await this.indexRawDirectory({
+            config,
+            createHashFn,
+            directoryPath: rootPath,
+            writeStream
+        });
+    }
+
+    /**
+     * @summary Recursively walks a directory and emits chunks for included files.
+     * @param {Object} options
+     * @returns {Promise<Number>}
+     * @protected
+     */
+    async indexRawDirectory({config, createHashFn, directoryPath, writeStream}) {
+        const entries = await fs.readdir(directoryPath, {withFileTypes: true});
+        entries.sort((a, b) => a.name.localeCompare(b.name));
+
+        let count = 0;
+
+        for (const entry of entries) {
+            const absolutePath = path.join(directoryPath, entry.name),
+                  sourcePath   = this.toSourcePath(path.relative(aiConfig.neoRootDir, absolutePath));
+
+            if (this.isPathExcluded(sourcePath, config.excludePaths)) {
+                continue;
+            }
+
+            if (entry.isDirectory()) {
+                count += await this.indexRawDirectory({
+                    config,
+                    createHashFn,
+                    directoryPath: absolutePath,
+                    writeStream
+                });
+            } else if (entry.isFile() && this.isFileIncluded(sourcePath, config)) {
+                const content = await fs.readFile(absolutePath, 'utf-8'),
+                      chunk   = this.createChunk({config, content, sourcePath});
+
+                chunk.hash = createHashFn(chunk);
+                writeStream.write(JSON.stringify(chunk) + '\n');
+                count++;
+            }
+        }
+
+        return count;
+    }
+
+    /**
+     * @summary Creates the raw-text parsed chunk for a source file.
+     * @param {Object} options
+     * @returns {Object}
+     * @protected
+     */
+    createChunk({config, content, sourcePath}) {
+        return {
+            schemaVersion: '1.0.0',
+            sourcePath,
+            source       : sourcePath,
+            content,
+            hashInputs   : ['kind', 'name', 'content', 'sourcePath', 'parserId', 'parserVersion'],
+            parserId     : config.parserId,
+            parserVersion: config.parserVersion,
+            rootKind     : config.rootKind,
+            kind         : config.kind,
+            type         : config.type,
+            name         : sourcePath
+        };
+    }
+
+    /**
+     * @summary Normalizes the source-specific config entry.
+     * @param {String|Object|null} rawConfig Raw `aiConfig.sourcePaths.RawRepoSource` value.
+     * @returns {Object}
+     * @protected
+     */
+    normalizeConfig(rawConfig) {
+        const input = typeof rawConfig === 'string' ? {root: rawConfig} : (rawConfig || {});
+
+        return {
+            ...DEFAULT_CONFIG,
+            ...input,
+            excludeExtensions: this.normalizeExtensions(input.excludeExtensions ?? DEFAULT_CONFIG.excludeExtensions),
+            excludePaths     : this.normalizePatterns(input.excludePaths ?? DEFAULT_CONFIG.excludePaths),
+            includeExtensions: this.normalizeExtensions(input.includeExtensions ?? DEFAULT_CONFIG.includeExtensions),
+            root             : input.root || DEFAULT_CONFIG.root
+        };
+    }
+
+    /**
+     * @summary Returns true when a file survives extension allow/deny filters.
+     * @param {String} sourcePath Source path relative to `aiConfig.neoRootDir`.
+     * @param {Object} config Normalized source config.
+     * @returns {Boolean}
+     * @protected
+     */
+    isFileIncluded(sourcePath, config) {
+        const extension = path.extname(sourcePath).toLowerCase();
+
+        if (config.excludeExtensions.includes(extension)) {
+            return false;
+        }
+
+        return config.includeExtensions.length === 0 || config.includeExtensions.includes(extension);
+    }
+
+    /**
+     * @summary Returns true when a repo-relative path matches an excluded path pattern.
+     * @param {String} sourcePath Source path relative to `aiConfig.neoRootDir`.
+     * @param {String[]} patterns Excluded path patterns.
+     * @returns {Boolean}
+     * @protected
+     */
+    isPathExcluded(sourcePath, patterns) {
+        const normalized = this.toSourcePath(sourcePath);
+
+        return patterns.some(pattern => this.matchesPathPattern(normalized, pattern));
+    }
+
+    /**
+     * @summary Matches simple repository path patterns without pulling in a glob dependency.
+     * @param {String} sourcePath Source path relative to `aiConfig.neoRootDir`.
+     * @param {String} pattern Exclusion pattern.
+     * @returns {Boolean}
+     * @protected
+     */
+    matchesPathPattern(sourcePath, pattern) {
+        const normalizedPattern = this.normalizeRelativePath(pattern);
+
+        if (!normalizedPattern) {
+            return false;
+        }
+
+        if (normalizedPattern.endsWith('/**')) {
+            const prefix = normalizedPattern.slice(0, -3);
+            return sourcePath === prefix || sourcePath.startsWith(`${prefix}/`);
+        }
+
+        if (normalizedPattern.startsWith('**/')) {
+            const suffix = normalizedPattern.slice(3);
+            return sourcePath === suffix || sourcePath.endsWith(`/${suffix}`);
+        }
+
+        if (normalizedPattern.includes('/')) {
+            return sourcePath === normalizedPattern ||
+                   sourcePath.startsWith(`${normalizedPattern}/`) ||
+                   sourcePath.endsWith(`/${normalizedPattern}`) ||
+                   sourcePath.includes(`/${normalizedPattern}/`);
+        }
+
+        return sourcePath.split('/').includes(normalizedPattern);
+    }
+
+    /**
+     * @summary Normalizes extension arrays to lowercase dot-prefixed values.
+     * @param {String[]} extensions Extension list.
+     * @returns {String[]}
+     * @protected
+     */
+    normalizeExtensions(extensions = []) {
+        return [...new Set((Array.isArray(extensions) ? extensions : [])
+            .map(extension => String(extension || '').trim().toLowerCase())
+            .filter(Boolean)
+            .map(extension => extension.startsWith('.') ? extension : `.${extension}`))];
+    }
+
+    /**
+     * @summary Normalizes path pattern arrays to slash-separated relative paths.
+     * @param {String[]} patterns Pattern list.
+     * @returns {String[]}
+     * @protected
+     */
+    normalizePatterns(patterns = []) {
+        return [...new Set((Array.isArray(patterns) ? patterns : [])
+            .map(pattern => this.normalizeRelativePath(pattern))
+            .filter(Boolean))];
+    }
+
+    /**
+     * @summary Normalizes a path-like value for config matching.
+     * @param {String} value Path-like value.
+     * @returns {String}
+     * @protected
+     */
+    normalizeRelativePath(value) {
+        return this.toSourcePath(value).replace(/^\.\//u, '').replace(/\/+$/u, '');
+    }
+
+    /**
+     * @summary Converts platform path separators to portable source-path separators.
+     * @param {String} value Path-like value.
+     * @returns {String}
+     * @protected
+     */
+    toSourcePath(value) {
+        return String(value || '').replaceAll(path.sep, '/').replaceAll('\\', '/');
+    }
+}
+
+export default Neo.setupClass(RawRepoSource);

--- a/ai/services/knowledge-base/source/_export.mjs
+++ b/ai/services/knowledge-base/source/_export.mjs
@@ -6,6 +6,7 @@ import ConceptSource     from './ConceptSource.mjs';
 import DiscussionSource  from './DiscussionSource.mjs';
 import LearningSource    from './LearningSource.mjs';
 import PullRequestSource from './PullRequestSource.mjs';
+import RawRepoSource     from './RawRepoSource.mjs';
 import ReleaseNotesSource from './ReleaseNotesSource.mjs';
 import SkillSource       from './SkillSource.mjs';
 import TestSource        from './TestSource.mjs';
@@ -24,8 +25,11 @@ import TicketSource      from './TicketSource.mjs';
  *   ensuring byte-equivalence with the prior KB generation pipeline.
  * - When `aiConfig.useDefaultSources === false` (cloud deployments opting out of Neo's
  *   curated content), no default registration occurs. The registry only contains whatever
- *   tenant-supplied sources register via `aiConfig.customSources` or programmatically via
- *   `SourceRegistry.registerSource(...)`.
+ *   tenant-supplied sources register via `aiConfig.customSources`, explicit `rawRepoSource`,
+ *   or programmatically via `SourceRegistry.registerSource(...)`.
+ * - When `aiConfig.rawRepoSource === true`, {@link RawRepoSource} registers as an
+ *   explicit opt-in fallback for tenants whose repo shape is unknown. It is intentionally
+ *   NOT part of {@link DEFAULT_SOURCES}; zero-config Neo sync keeps the legacy 10-source set.
  *
  * **Declarative custom-source/parser registration shape:**
  *
@@ -90,19 +94,29 @@ const DEFAULT_SOURCES = [
  * without depending on module-import singleton state.
  *
  * @param {Object}   registry          A `SourceRegistry`-shaped object exposing `registerSource(class, {sourceName?})` and `registerParser(class, {parserId?})`.
- * @param {Object}   config            A config object exposing `useDefaultSources` (boolean), `useDefaultParsers` (boolean), `customSources` (array), `customParsers` (array).
+ * @param {Object}   config            A config object exposing `useDefaultSources` (boolean), `rawRepoSource` (boolean), `useDefaultParsers` (boolean), `customSources` (array), `customParsers` (array).
  * @param {Object}   [options]
  * @param {Array}   [options.defaults] Override the default Source class set (testing-only override; production omits to use {@link DEFAULT_SOURCES}).
- * @returns {{defaultSourcesRegistered: Number, customSourcesRegistered: Number, customParsersRegistered: Number}}
+ * @returns {{defaultSourcesRegistered: Number, rawRepoSourceRegistered: Number, customSourcesRegistered: Number, customParsersRegistered: Number}}
  */
 export function applyConfigToRegistry(registry, config, {defaults = DEFAULT_SOURCES} = {}) {
-    const stats = {defaultSourcesRegistered: 0, customSourcesRegistered: 0, customParsersRegistered: 0};
+    const stats = {
+        defaultSourcesRegistered: 0,
+        rawRepoSourceRegistered: 0,
+        customSourcesRegistered : 0,
+        customParsersRegistered : 0
+    };
 
     if (config?.useDefaultSources !== false) {
         for (const SourceClass of defaults) {
             registry.registerSource(SourceClass);
             stats.defaultSourcesRegistered++;
         }
+    }
+
+    if (config?.rawRepoSource === true) {
+        registry.registerSource(RawRepoSource);
+        stats.rawRepoSourceRegistered++;
     }
 
     // Declarative custom-source registration via aiConfig.customSources (Phase 0/1B contract).
@@ -145,6 +159,7 @@ export {
     DiscussionSource,
     LearningSource,
     PullRequestSource,
+    RawRepoSource,
     ReleaseNotesSource,
     SkillSource,
     TestSource,

--- a/learn/agentos/cloud-deployment/Configuration.md
+++ b/learn/agentos/cloud-deployment/Configuration.md
@@ -22,6 +22,7 @@ A deployment's `config.mjs` is gitignored and copied from `config.template.mjs`.
 | Key | Default | Meaning |
 |---|---|---|
 | `useDefaultSources` | `true` | Auto-register Neo's 10 curated Source classes. A deployment ingesting only tenant content sets `false`. |
+| `rawRepoSource` | `false` | Explicitly registers `RawRepoSource`, a raw-text fallback that walks one configured repository root for tenants whose repo shape is unknown. |
 | `useDefaultParsers` | `true` | Auto-register Neo's built-in Parser classes (`SourceParser`, `DocumentationParser`, `TestParser`). |
 | `customSources` | `[]` | Declarative tenant Source registration — `[{SourceClass, sourceName?}]`. See [Custom Sources](./CustomSources.md). |
 | `customParsers` | `[]` | Declarative tenant Parser registration — `[{ParserClass, parserId?}]`. See [Custom Parsers](./CustomParsers.md). |
@@ -67,7 +68,7 @@ The token is a KB MCP authorization credential, not a Git credential. Store it i
 
 A multi-tenant deployment cannot express every tenant's source/parser config as static `aiConfig` keys — each tenant needs its own, mutable at runtime, durable across restarts. Phase 2E ([#11637](https://github.com/neomjs/neo/issues/11637)) stores it as a graph node.
 
-**The node.** One `KnowledgeBaseTenantConfig` node per tenant, id `kb-config:<tenantId>`, in the Native Edge Graph. Its `properties` carry the tenant's config payload — `{useDefaultSources, useDefaultParsers, customSources, customParsers, sourcePaths, version, userId}`. `version` increments on every mutation; `userId` is the [#10011](https://github.com/neomjs/neo/issues/10011) RLS ownership stamp — a tenant cannot read or mutate another tenant's config node.
+**The node.** One `KnowledgeBaseTenantConfig` node per tenant, id `kb-config:<tenantId>`, in the Native Edge Graph. Its `properties` carry the tenant's config payload — `{useDefaultSources, rawRepoSource, useDefaultParsers, customSources, customParsers, sourcePaths, version, userId}`. `version` increments on every mutation; `userId` is the [#10011](https://github.com/neomjs/neo/issues/10011) RLS ownership stamp — a tenant cannot read or mutate another tenant's config node.
 
 **Resolution.** `KnowledgeBaseIngestionService.getTenantConfig({tenantId})` resolves a tenant's effective config through three tiers, first hit wins:
 
@@ -83,6 +84,7 @@ A multi-tenant deployment cannot express every tenant's source/parser config as 
 tenants:
   client-org:
     useDefaultSources: false
+    rawRepoSource: true
     customParsers: [...]
     sourcePaths: {...}
 ```

--- a/learn/agentos/cloud-deployment/CustomSources.md
+++ b/learn/agentos/cloud-deployment/CustomSources.md
@@ -99,6 +99,25 @@ A Source class is registered in the `SourceRegistry` singleton under a stable na
 
 `aiConfig.useDefaultSources` (default `true`) controls whether Neo's 10 curated Source classes are also registered. A deployment indexing *only* tenant content sets it `false`; the registry then contains only the tenant's custom Sources. See [Configuration](./Configuration.md).
 
+## Built-in Raw Repo Fallback
+
+Use `rawRepoSource: true` when a tenant needs day-0 ingestion before its repository shape is known well enough to justify a custom Source. This registers `RawRepoSource`, which walks `aiConfig.sourcePaths.RawRepoSource.root` and emits one raw-text parsed chunk per included file. It is not part of Neo's 10 curated default Sources, so zero-config Neo syncs never walk the full repository implicitly.
+
+```js
+rawRepoSource: true,
+useDefaultSources: false,
+sourcePaths: {
+    RawRepoSource: {
+        root             : '.',
+        includeExtensions: ['.md', '.js', '.json'],
+        excludePaths     : ['.git', 'node_modules', 'dist', 'docs/output'],
+        excludeExtensions: ['.png', '.jpg', '.pdf', '.woff2']
+    }
+}
+```
+
+Graduate from `RawRepoSource` to a custom Source when a tenant needs semantic chunking, generated-manifest boundaries, or source-specific metadata.
+
 ## Path conventions
 
 A Source should not hard-code its territory path. Resolve it from `aiConfig.sourcePaths` keyed by the Source's registry name — `aiConfig.sourcePaths?.ProtoSource ?? '<fallback>'` — so a deployment whose layout differs overrides only that key. Each Source interprets its own entry shape (a string, a string-array, or a path→type object — see the built-in Source defaults in `config.template.mjs`).

--- a/learn/agentos/cloud-deployment/MigrationPath.md
+++ b/learn/agentos/cloud-deployment/MigrationPath.md
@@ -24,6 +24,7 @@ A single-repo deployment *is* a one-tenant deployment where the tenant is `neo-s
 Divergence from the single-repo default is **granular and opt-in**. An operator moving to a multi-tenant cloud deployment changes only what their topology requires:
 
 - **Skip Neo's curated content** — set `aiConfig.useDefaultSources = false`. The `SourceRegistry` then contains only tenant-supplied Sources.
+- **Unknown tenant repo shape** — set `aiConfig.rawRepoSource = true` to register the built-in raw-text fallback Source while a custom Source is still premature.
 - **Different repo layout** — override only the affected `aiConfig.sourcePaths` keys (e.g. a tenant whose guides live under `docs/guides/tree.json` rather than `learn/tree.json`). Un-overridden keys still resolve to Neo defaults.
 - **Register tenant Sources/Parsers** — populate `aiConfig.customSources` / `aiConfig.customParsers` with pre-imported tenant classes, or call `SourceRegistry.registerSource(...)` at runtime.
 - **Spoof-rejection policy** — a multi-tenant operator should consider `aiConfig.spoofRejectionMode: 'reject'` (fail-closed) over the `'overwrite'` default (see [Security](./Security.md)).
@@ -32,7 +33,7 @@ Each of these is a local config edit; none requires a code fork.
 
 ## Config-template clone-sync
 
-The new config keys (`useDefaultSources`, `useDefaultParsers`, `customSources`, `customParsers`, `sourcePaths`, `defaultTenantId`, `defaultRepoSlug`, `defaultVisibility`, `spoofRejectionMode`) live in `ai/mcp/server/knowledge-base/config.template.mjs` — the `SourceRegistry` keys via PR #11659, the `sourcePaths` keys via PR #11661, and the tenant-stamping keys via PR #11662. Each clone's local `config.mjs` is gitignored and copied from the template.
+The new config keys (`useDefaultSources`, `rawRepoSource`, `useDefaultParsers`, `customSources`, `customParsers`, `sourcePaths`, `defaultTenantId`, `defaultRepoSlug`, `defaultVisibility`, `spoofRejectionMode`) live in `ai/mcp/server/knowledge-base/config.template.mjs` — the `SourceRegistry` keys via PR #11659, the `sourcePaths` keys via PR #11661, and the tenant-stamping keys via PR #11662. Each clone's local `config.mjs` is gitignored and copied from the template.
 
 - **Zero-config deployments** need no local `config.mjs` edit — the runtime falls through to defaults when a key is absent.
 - **Cloud / tenant-mode deployments** add the keys they need to their local `config.mjs`. A harness restart picks up the change (config modules load once per MCP process).

--- a/learn/agentos/cloud-deployment/Overview.md
+++ b/learn/agentos/cloud-deployment/Overview.md
@@ -19,7 +19,7 @@ Phase 0/1 defines the data contracts cloud ingestion is built on. PRs #11647, #1
 | `parsed-chunk-v1` schema | #11629 / PR #11647 | The ingest-side chunk shape every Source/Parser emits. Rejects records carrying an `embedding` field (that field belongs only to the restore-only `backup-record-v1` sibling). |
 | Path-identity tuple | #11629 / PR #11647 | `{tenantId, repoSlug, rootKind, sourcePath}` in chunk metadata — replaces the legacy single-`neoRootDir`-relative `source` string. Neo's curated content uses `tenantId: 'neo-shared'`, `repoSlug: 'neo'`. |
 | Deletion-signaling contract | #11629 / PR #11647 | Tombstone + manifest + revision-boundary mechanisms for propagating source deletions into the index. |
-| `SourceRegistry` | #11658 / PR #11659 | Data-driven Source/Parser registration. `useDefaultSources` / `useDefaultParsers` gate Neo's curated sources; `customSources` / `customParsers` register tenant-supplied classes. |
+| `SourceRegistry` | #11658 / PR #11659 | Data-driven Source/Parser registration. `useDefaultSources` / `useDefaultParsers` gate Neo's curated sources; `customSources` / `customParsers` register tenant-supplied classes; `rawRepoSource` explicitly enables the built-in raw repo fallback. |
 | Per-source path externalization | #11660 / PR #11661 | `aiConfig.sourcePaths` — each default Source class reads its input path from config, so a tenant whose layout differs from Neo's can reuse the curated Source classes. |
 | Write-side tenant stamping | #11631 / PR #11662 | `VectorService.embed` server-stamps `{tenantId, repoSlug, visibility, originAgentIdentity}` from the authenticated ingestion context; client-supplied identity fields are overwritten or rejected. Tenant-aware Chroma IDs prevent byte-identical chunks from different tenants colliding. |
 
@@ -31,7 +31,7 @@ Per [ADR 0003 — Chroma Topology Unified Only](../decisions/0003-chroma-topolog
 
 ## Default-source inheritance
 
-A zero-config Neo deployment behaves identically with or without the cloud-ingestion substrate: `useDefaultSources` defaults to `true`, the `SourceRegistry` auto-registers Neo's 10 curated Source classes, and `aiConfig.sourcePaths` carries Neo's default layout. A cloud tenant opting out of Neo's curated content sets `useDefaultSources: false`; a tenant whose repo layout differs overrides only the `sourcePaths` keys it needs. Inheritance is the default; divergence is opt-in and granular.
+A zero-config Neo deployment behaves identically with or without the cloud-ingestion substrate: `useDefaultSources` defaults to `true`, `rawRepoSource` defaults to `false`, the `SourceRegistry` auto-registers Neo's 10 curated Source classes, and `aiConfig.sourcePaths` carries Neo's default layout. A cloud tenant opting out of Neo's curated content sets `useDefaultSources: false`; a tenant whose repo layout differs overrides only the `sourcePaths` keys it needs; a tenant with no known shape can opt into `rawRepoSource` as a day-0 fallback. Inheritance is the default; divergence is opt-in and granular.
 
 ## Registry contract split — Source vs Parser
 

--- a/test/playwright/fixtures/knowledgeBaseConfigDefaults.mjs
+++ b/test/playwright/fixtures/knowledgeBaseConfigDefaults.mjs
@@ -90,6 +90,31 @@ export const KB_DEFAULTS = deepFreeze(Neo.clone({
             'examples': 'example',
             'docs/app': 'app',
             'ai'      : 'ai-infrastructure'
+        },
+        RawRepoSource     : {
+            root             : '.',
+            includeExtensions: [],
+            excludeExtensions: [
+                '.7z', '.avif', '.bin', '.bmp', '.bz2', '.class', '.dmg', '.eot',
+                '.exe', '.gif', '.gz', '.ico', '.jar', '.jpeg', '.jpg', '.lockb',
+                '.mov', '.mp3', '.mp4', '.otf', '.pdf', '.png', '.sqlite', '.tar',
+                '.tgz', '.ttf', '.wasm', '.webm', '.webp', '.woff', '.woff2', '.zip'
+            ],
+            excludePaths: [
+                '.git',
+                '.neo-ai-data',
+                'coverage',
+                'dist',
+                'docs/output',
+                'node_modules',
+                'package-lock.json',
+                'playwright-report',
+                'resources/examples',
+                'resources/fonts',
+                'resources/images',
+                'test-results',
+                'yarn.lock'
+            ]
         }
     },
     collectionName    : 'neo-knowledge-base',
@@ -102,6 +127,7 @@ export const KB_DEFAULTS = deepFreeze(Neo.clone({
     defaultVisibility : 'team',
     spoofRejectionMode: 'overwrite',
     useDefaultSources : true,
+    rawRepoSource     : false,
     useDefaultParsers : true,
     batchSize         : 50,
     batchDelay        : 10000,

--- a/test/playwright/unit/ai/services/knowledge-base/KnowledgeBaseIngestionService.spec.mjs
+++ b/test/playwright/unit/ai/services/knowledge-base/KnowledgeBaseIngestionService.spec.mjs
@@ -470,7 +470,7 @@ test.describe('KnowledgeBaseIngestionService.tenantConfig (#11637)', () => {
     test('setTenantConfig persists a versioned KnowledgeBaseTenantConfig node that getTenantConfig reads back', async () => {
         const written = await Service.setTenantConfig({
             tenantId: 'tenant-a',
-            config  : {useDefaultSources: false, customParsers: [{parserId: 'es5'}]}
+            config  : {useDefaultSources: false, rawRepoSource: true, customParsers: [{parserId: 'es5'}]}
         });
         expect(written).toEqual({tenantId: 'tenant-a', version: 1});
 
@@ -483,6 +483,7 @@ test.describe('KnowledgeBaseIngestionService.tenantConfig (#11637)', () => {
             source           : 'graph',
             version          : 1,
             useDefaultSources: false,
+            rawRepoSource    : true,
             customParsers    : [{parserId: 'es5'}]
         });
     });
@@ -619,7 +620,7 @@ test.describe('KnowledgeBaseIngestionService.tenantConfig (#11637)', () => {
     test('getTenantConfig resolves the kb-config.yaml bootstrap tier when no graph node exists', async () => {
         Service.readKbConfigBootstrap = () => ({
             tenants: {
-                'tenant-a': {useDefaultSources: false, customSources: [{sourceName: 'BootstrapSource'}]}
+                'tenant-a': {useDefaultSources: false, rawRepoSource: true, customSources: [{sourceName: 'BootstrapSource'}]}
             }
         });
 
@@ -629,6 +630,7 @@ test.describe('KnowledgeBaseIngestionService.tenantConfig (#11637)', () => {
             source           : 'yaml',
             version          : 0,
             useDefaultSources: false,
+            rawRepoSource    : true,
             customSources    : [{sourceName: 'BootstrapSource'}]
         });
 

--- a/test/playwright/unit/ai/services/knowledge-base/source/RawRepoSource.spec.mjs
+++ b/test/playwright/unit/ai/services/knowledge-base/source/RawRepoSource.spec.mjs
@@ -1,0 +1,99 @@
+import {setup} from '../../../../../setup.mjs';
+
+const appName = 'RawRepoSourceTest';
+
+setup({
+    neoConfig: {
+        allowVdomUpdatesInTests: false,
+        unitTestMode           : true,
+        useDomApiRenderer      : false
+    },
+    appConfig: {
+        name             : appName,
+        isMounted        : () => true,
+        vnodeInitialising: false
+    }
+});
+
+import {test, expect}  from '@playwright/test';
+import Neo             from '../../../../../../../src/Neo.mjs';
+import * as core       from '../../../../../../../src/core/_export.mjs';
+import fs              from 'fs-extra';
+import os              from 'os';
+import path            from 'path';
+import aiConfig        from '../../../../../../../ai/mcp/server/knowledge-base/config.mjs';
+import RawRepoSource   from '../../../../../../../ai/services/knowledge-base/source/RawRepoSource.mjs';
+
+/**
+ * @summary Unit coverage for the explicit raw repository Source fallback added by #12029.
+ */
+test.describe('Neo.ai.services.knowledge-base.source.RawRepoSource (#12029)', () => {
+    let originalNeoRootDir, originalSourcePaths, tempDir;
+
+    test.beforeEach(async () => {
+        originalNeoRootDir = aiConfig.neoRootDir;
+        originalSourcePaths = aiConfig.sourcePaths;
+        tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'neo-raw-repo-source-'));
+
+        await fs.outputFile(path.join(tempDir, 'repo/README.md'), '# Tenant Repo\n');
+        await fs.outputFile(path.join(tempDir, 'repo/src/index.js'), 'export const value = 42;\n');
+        await fs.outputFile(path.join(tempDir, 'repo/dist/bundle.js'), 'generated\n');
+        await fs.outputFile(path.join(tempDir, 'repo/docs/output/all.json'), '{}\n');
+        await fs.outputFile(path.join(tempDir, 'repo/node_modules/pkg/index.js'), 'dependency\n');
+        await fs.outputFile(path.join(tempDir, 'repo/package-lock.json'), '{}\n');
+        await fs.outputFile(path.join(tempDir, 'repo/resources/images/logo.png'), 'not really png\n');
+        await fs.outputFile(path.join(tempDir, 'repo/assets/logo.png'), 'not really png\n');
+
+        aiConfig.neoRootDir = tempDir;
+        aiConfig.sourcePaths = {
+            RawRepoSource: {
+                root: 'repo'
+            }
+        };
+    });
+
+    test.afterEach(async () => {
+        aiConfig.neoRootDir = originalNeoRootDir;
+        aiConfig.sourcePaths = originalSourcePaths;
+        await fs.remove(tempDir);
+    });
+
+    test('emits one raw-text parsed chunk per included file and skips generated/binary defaults', async () => {
+        const chunks = [],
+              stream = {write: line => chunks.push(JSON.parse(line))};
+
+        const count = await RawRepoSource.extract(stream, chunk => `hash:${chunk.sourcePath}`);
+
+        expect(count).toBe(2);
+        expect(chunks.map(chunk => chunk.sourcePath)).toEqual([
+            'repo/README.md',
+            'repo/src/index.js'
+        ]);
+        expect(chunks[0]).toMatchObject({
+            schemaVersion: '1.0.0',
+            parserId     : 'raw-text',
+            parserVersion: '1.0.0',
+            rootKind     : 'external-source',
+            kind         : 'doc-section',
+            type         : 'raw',
+            name         : 'repo/README.md',
+            source       : 'repo/README.md',
+            hash         : 'hash:repo/README.md'
+        });
+    });
+
+    test('includeExtensions narrows the raw fallback to an explicit allowlist', async () => {
+        aiConfig.sourcePaths.RawRepoSource = {
+            root             : 'repo',
+            includeExtensions: ['md']
+        };
+
+        const chunks = [],
+              stream = {write: line => chunks.push(JSON.parse(line))};
+
+        const count = await RawRepoSource.extract(stream, chunk => `hash:${chunk.sourcePath}`);
+
+        expect(count).toBe(1);
+        expect(chunks[0].sourcePath).toBe('repo/README.md');
+    });
+});

--- a/test/playwright/unit/ai/services/knowledge-base/source/SourceRegistry.spec.mjs
+++ b/test/playwright/unit/ai/services/knowledge-base/source/SourceRegistry.spec.mjs
@@ -20,12 +20,13 @@ import Neo            from '../../../../../../../src/Neo.mjs';
 import * as core      from '../../../../../../../src/core/_export.mjs';
 
 test.describe('Neo.ai.services.knowledge-base.source.SourceRegistry (#11658)', () => {
-    let SourceRegistry, DEFAULT_SOURCES;
+    let SourceRegistry, DEFAULT_SOURCES, RawRepoSource;
 
     test.beforeAll(async () => {
         const exportModule = await import('../../../../../../../ai/services/knowledge-base/source/_export.mjs');
         SourceRegistry  = exportModule.default;
         DEFAULT_SOURCES = exportModule.DEFAULT_SOURCES;
+        RawRepoSource   = exportModule.RawRepoSource;
     });
 
     test.beforeEach(() => {
@@ -50,6 +51,7 @@ test.describe('Neo.ai.services.knowledge-base.source.SourceRegistry (#11658)', (
             'TicketSource',  // TicketSource BEFORE TestSource (matches pre-#11658 hardcoded order)
             'TestSource'
         ]);
+        expect(DEFAULT_SOURCES).not.toContain(RawRepoSource);
     });
 
     test('registerSource derives sourceName from className final segment when not supplied', () => {
@@ -199,6 +201,7 @@ test.describe('applyConfigToRegistry — config-driven registration path (#11658
         });
 
         expect(stats.defaultSourcesRegistered).toBe(0);
+        expect(stats.rawRepoSourceRegistered).toBe(0);
         expect(SourceRegistry.getSources()).toHaveLength(0);
         expect(SourceRegistry.getSourceNames()).toEqual([]);
     });
@@ -207,11 +210,23 @@ test.describe('applyConfigToRegistry — config-driven registration path (#11658
         const stats = applyConfigToRegistry(SourceRegistry, {});  // omitted toggle = truthy default
 
         expect(stats.defaultSourcesRegistered).toBe(10);
+        expect(stats.rawRepoSourceRegistered).toBe(0);
         expect(SourceRegistry.getSources()).toHaveLength(10);
         // First + last sentinel checks reaffirm insertion order without re-asserting the full sequence
         // (the byte-equivalence test in the prior describe block holds the order invariant).
         expect(SourceRegistry.getSourceNames()[0]).toBe('AdrSource');
         expect(SourceRegistry.getSourceNames()[9]).toBe('TestSource');
+    });
+
+    test('rawRepoSource:true registers RawRepoSource explicitly without widening DEFAULT_SOURCES', () => {
+        const stats = applyConfigToRegistry(SourceRegistry, {
+            rawRepoSource    : true,
+            useDefaultSources: false
+        });
+
+        expect(stats.rawRepoSourceRegistered).toBe(1);
+        expect(stats.defaultSourcesRegistered).toBe(0);
+        expect(SourceRegistry.getSourceNames()).toEqual(['RawRepoSource']);
     });
 
     test('declarative customSources entry registers tenant source class with sourceName override', () => {
@@ -289,6 +304,7 @@ test.describe('applyConfigToRegistry — config-driven registration path (#11658
 
         expect(stats).toEqual({
             defaultSourcesRegistered: 0,
+            rawRepoSourceRegistered: 0,
             customSourcesRegistered : 2,
             customParsersRegistered : 1
         });


### PR DESCRIPTION
Resolves #12029

Authored by GPT-5 (Codex Desktop). Session 1578fb3e-7f5a-4b43-a6d0-ba00e66a9885.

Adds an explicit `RawRepoSource` opt-in for tenants whose repository shape is not known yet. The source walks a configured repository root, skips generated/binary/heavy paths, and emits one raw-text parsed chunk per included file. `DEFAULT_SOURCES` remains the legacy 10 curated Neo sources; raw repo ingestion only registers when `rawRepoSource: true` is set.

FAIR-band: in-band. Single self-assigned ticket, bounded KB source/config/docs surface, no competing lane, no yield candidate.

Evidence: L2 (unit contract tests for raw extraction, registry opt-in, tenant-config propagation, config-template path guard, and tenant stamping spot-check) -> L2 required (source registration and extraction behavior are unit-verifiable without live tenant deployment). No residuals.

## Deltas from ticket

- Chose explicit opt-in (`rawRepoSource: true`) instead of implicit fallback when `useDefaultSources:false`, so operators never get a surprise full-repo walk.
- Added `NEO_KB_RAW_REPO_SOURCE` and `sourcePaths.RawRepoSource` defaults in the KB config template.
- Threaded `rawRepoSource` through `KnowledgeBaseTenantConfig` graph, yaml, and default resolution.

## Config Template Clone-Sync

Changed config keys: `rawRepoSource`, `sourcePaths.RawRepoSource`, and env binding `NEO_KB_RAW_REPO_SOURCE`.

Existing local `ai/mcp/server/knowledge-base/config.mjs` files do not need manual updates after merge because the default behavior is false/absent. To enable the feature in a clone, add `rawRepoSource: true` plus any `sourcePaths.RawRepoSource` overrides, or set `NEO_KB_RAW_REPO_SOURCE=true`. A KB MCP harness restart is required only after enabling or changing those local values.

## Substrate Slot Rationale

Modified `learn/agentos/cloud-deployment/*` documentation sections: disposition `keep`; trigger-frequency medium for cloud-ingestion authors/reviewers; failure-severity medium because the docs prevent config drift and accidental repo-wide ingestion; enforceability medium via PR review against the config template. This adds no always-loaded turn substrate; the docs remain conditionally loaded.

## Test Evidence

- `git diff --check origin/dev...HEAD` passed.
- `node --check ai/services/knowledge-base/source/RawRepoSource.mjs` passed.
- `node --check ai/services/knowledge-base/source/_export.mjs` passed.
- `node --check ai/mcp/server/knowledge-base/config.template.mjs` passed.
- `npm run test-unit -- test/playwright/unit/ai/services/knowledge-base/source/RawRepoSource.spec.mjs test/playwright/unit/ai/services/knowledge-base/source/SourceRegistry.spec.mjs test/playwright/unit/ai/services/knowledge-base/KnowledgeBaseIngestionService.spec.mjs test/playwright/unit/ai/services/knowledge-base/source/SourcePathsConfig.spec.mjs test/playwright/unit/ai/services/knowledge-base/VectorService.tenantStamping.spec.mjs` passed: 92/92.
- Full `npm run test-unit` attempted under sandbox: 2230 passed, 73 failed from sandbox/live-service surfaces (`EPERM`, Chroma, SQLite, local provider access), 45 did not run.
- Full `npm run test-unit` rerun outside sandbox: 2315 passed, 23 failed, 13 did not run; failures remained outside the #12029 touched specs, including MCP health timeouts, local provider dependencies, memory/session services, and existing grid/vdom specs. KB-adjacent `VectorService.tenantStamping` was rerun alone and passed 11/11.

## Post-Merge Validation

- [ ] CI confirms the focused KB tests and broader unit suite on the canonical runner.
- [ ] Optional operator smoke: enable `rawRepoSource: true` on a tenant sandbox and verify `RawRepoSource` appears in `SourceRegistry.getSourceNames()`.

## Commits

- `03f7673ed` - implementation.
- `b5b94939b` - CI retrigger after PR body anchor correction.