### PR TITLE
refactor(ai): rename orchestrator backup label (#12028)

### DIFF
--- a/ai/daemons/orchestrator/TaskDefinitions.mjs
+++ b/ai/daemons/orchestrator/TaskDefinitions.mjs
@@ -75,7 +75,7 @@ export function buildTaskDefinitions({
             expectedCommand: 'syncKnowledgeBase.mjs'
         },
         backup: {
-            label          : 'memory core backup',
+            label          : 'agent OS backup',
             command        : nodeBin,
             args           : [path.join(scriptDir, 'maintenance', 'backup.mjs')],
             pidFileName    : 'backup.pid',

--- a/test/playwright/unit/ai/daemons/orchestrator/daemon.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/daemon.spec.mjs
@@ -32,6 +32,7 @@ test.describe('ai/daemons/orchestrator/daemon.mjs (#11006/#11009)', () => {
 
         expect(tasks.backup.command).toBe('/test/node');
         expect(tasks.backup.args).toEqual([path.join(scriptDir, 'maintenance', 'backup.mjs')]);
+        expect(tasks.backup.label).toBe('agent OS backup');
         expect(tasks.backup.expectedCommand).toBe('backup.mjs');
     });
 


### PR DESCRIPTION
Resolves #12028

Authored by GPT-5 (Codex Desktop). Session 1578fb3e-7f5a-4b43-a6d0-ba00e66a9885.
FAIR-band: over-target [21/30] - taking this lane despite over-target because #12028 is the already-claimed, narrow sibling cleanup from the active deployment-friction batch and has minimal collision risk.

Renames the orchestrator backup task label from `memory core backup` to `agent OS backup`, matching the broader backup bundle documented by `ai/scripts/maintenance/backup.mjs` without changing task schema, command wiring, pid files, or backup behavior. Adds a focused TaskDefinitions assertion so the operator-facing log label remains intentional.

Evidence: L2 (focused unit assertion + static grep/diff checks) -> L3 required (fresh orchestrator boot log for emitted runtime line). Residual: post-merge boot-log confirmation [#12028].

## Deltas from ticket

- Chose `agent OS backup` from the ticket candidate set because it is concise and maps to the KB / Memory Core / graph / concepts / trajectories bundle scope.
- Added one test assertion for `tasks.backup.label`; no new config field or task-definition schema was introduced.
- Triage gate added the missing primary `enhancement` label before implementation; existing `ai`, `documentation`, and `refactoring` labels were retained.

## Test Evidence

- `npm run test-unit -- test/playwright/unit/ai/daemons/orchestrator/daemon.spec.mjs` -> 10 passed.
- `rg -n "memory core backup|agent OS backup" ai test/playwright/unit/ai/daemons/orchestrator` -> only the new source label and unit assertion remain under live code/test paths.
- `git diff --cached --check` -> clean before commit.
- Broader check: `npm run test-unit` was attempted both sandboxed and escalated. Sandboxed run failed 71 unrelated tests due EPERM/local-service constraints. Escalated run reduced to 18 unrelated failures: MCP health timeout, local provider/Ollama availability, KB `Error finding id`, memory lifecycle state checks, and existing grid delta baselines. The changed orchestrator file passed inside the escalated run.

## Post-Merge Validation

- [ ] Fresh orchestrator boot or periodic backup sweep logs `agent OS backup` in the ProcessSupervisor start/completion lines.

## Commits

- `198d47e3b` - `refactor(ai): rename orchestrator backup label (#12028)`