### PR TITLE
refactor(kb): extract ingest source MCP facade (#12033)

### DIFF
--- a/ai/mcp/server/knowledge-base/ingestSourceFilesTool.mjs
+++ b/ai/mcp/server/knowledge-base/ingestSourceFilesTool.mjs
@@ -1,0 +1,98 @@
+import aiConfig                      from './config.mjs';
+import KnowledgeBaseIngestionService from '../../../services/knowledge-base/KnowledgeBaseIngestionService.mjs';
+
+const ingestToolName = 'ingest_source_files';
+
+/**
+ * @summary Normalizes optional MCP server prefixes before transport-gating tool names.
+ * @param {String} toolName The requested MCP tool name.
+ * @returns {String} The effective OpenAPI operation id.
+ */
+const getEffectiveToolName = toolName => {
+    const lastDoubleUnderscoreIndex = toolName.lastIndexOf('__');
+
+    return lastDoubleUnderscoreIndex !== -1
+        ? toolName.substring(lastDoubleUnderscoreIndex + 2)
+        : toolName;
+};
+
+/**
+ * @summary Returns true when the KB MCP server is in its remote StreamableHTTP profile.
+ * @returns {Boolean} True when remote tenant push clients may call `ingest_source_files`.
+ */
+const isRemoteIngestTransport = () => aiConfig.transport === 'sse';
+
+/**
+ * @summary Returns true when the ingest tool should appear in MCP tools/list.
+ * @returns {Boolean} True when the current transport exposes `ingest_source_files`.
+ */
+const isIngestSourceFilesToolVisible = () => isRemoteIngestTransport();
+
+/**
+ * @summary Fails closed when a local stdio client tries to invoke the remote push facade.
+ * @param {String} toolName The requested MCP tool name.
+ */
+const assertToolTransportAllowed = toolName => {
+    if (getEffectiveToolName(toolName) === ingestToolName && !isRemoteIngestTransport()) {
+        throw new Error(
+            '`ingest_source_files` is only exposed when the Knowledge Base MCP server runs ' +
+            'with `transport: "sse"` (StreamableHTTP). Use `npm run ai:ingest-tenant` or ' +
+            'direct service ingestion for local stdio workflows.'
+        );
+    }
+};
+
+/**
+ * @summary MCP facade for `KnowledgeBaseIngestionService.ingestSourceFiles`.
+ *
+ * An agent-initiated `ingest_source_files` push embeds synchronously; an oversized batch
+ * would freeze the calling agent. This facade counts the batch volume up-front and, when
+ * it exceeds `aiConfig.mcpSyncMaxChunks` (default 50), refuses with a structured
+ * `KB_INGEST_VOLUME_EXCEEDED` payload instead of dispatching to the service.
+ *
+ * Batch volume = the summed `parsedChunks` length across `files`, counting each raw
+ * (un-parsed) file as 1. Raw files are chunked server-side, so a small batch of large
+ * raw files can still exceed the threshold post-parse; the gate is a coarse up-front
+ * guard, not an exact post-parse count.
+ *
+ * The gate lives at the MCP facade (not threaded into the service) because the batch
+ * volume is knowable from the input alone, keeping service-layer ingestion logic
+ * unchanged and transport policy localized to the MCP facade.
+ *
+ * @param {Object}    args            The `ingest_source_files` tool envelope.
+ * @param {String}   [args.tenantId]  Authenticated tenant id.
+ * @param {Object[]} [args.files]     Raw file payloads or client-side parsed records.
+ * @returns {Promise<Object>} The `KnowledgeBaseIngestionService.ingestSourceFiles` summary,
+ *     OR a `{error, message, code: 'KB_INGEST_VOLUME_EXCEEDED', bulkPath, batchSize, threshold}`
+ *     refusal when the work-volume gate fires.
+ * @see https://github.com/neomjs/neo/issues/11634
+ * @see https://github.com/neomjs/neo/issues/10572
+ */
+const ingestSourceFilesViaMcp = async args => {
+    const
+        files     = Array.isArray(args?.files) ? args.files : [],
+        batchSize = files.reduce((sum, file) => sum + (Array.isArray(file?.parsedChunks) ? file.parsedChunks.length : 1), 0),
+        threshold = aiConfig.mcpSyncMaxChunks ?? 50;
+
+    if (batchSize > threshold) {
+        return {
+            error    : 'KB ingest work volume exceeds MCP-callable threshold',
+            message  : `Batch volume ${batchSize} exceeds the MCP-synchronous threshold ${threshold}. ` +
+                       `Re-invoke ingest_source_files with at most ${threshold} files/chunks per call; ` +
+                       `a tenant-scoped bulk ingestion facade is planned (Phase 2C).`,
+            code     : 'KB_INGEST_VOLUME_EXCEEDED',
+            bulkPath : null,
+            batchSize,
+            threshold
+        };
+    }
+
+    return KnowledgeBaseIngestionService.ingestSourceFiles(args);
+};
+
+export {
+    assertToolTransportAllowed,
+    ingestSourceFilesViaMcp,
+    ingestToolName,
+    isIngestSourceFilesToolVisible
+};

--- a/ai/mcp/server/knowledge-base/toolService.mjs
+++ b/ai/mcp/server/knowledge-base/toolService.mjs
@@ -1,54 +1,24 @@
 import path                          from 'path';
 import {fileURLToPath}               from 'url';
-import aiConfig                      from './config.mjs';
 import DatabaseService               from '../../../services/knowledge-base/DatabaseService.mjs';
 import DatabaseLifecycleService      from '../../../services/knowledge-base/DatabaseLifecycleService.mjs';
 import DocumentService               from '../../../services/knowledge-base/DocumentService.mjs';
 import HealthService                 from '../../../services/knowledge-base/HealthService.mjs';
 import KBRecorderService             from '../../../services/knowledge-base/KBRecorderService.mjs';
-import KnowledgeBaseIngestionService from '../../../services/knowledge-base/KnowledgeBaseIngestionService.mjs';
 import QueryService                  from '../../../services/knowledge-base/QueryService.mjs';
 import SearchService                 from '../../../services/knowledge-base/SearchService.mjs';
 import ToolService                   from '../../ToolService.mjs';
+import {
+    assertToolTransportAllowed,
+    ingestSourceFilesViaMcp,
+    ingestToolName,
+    isIngestSourceFilesToolVisible
+} from './ingestSourceFilesTool.mjs';
 
 const __filename      = fileURLToPath(import.meta.url);
 const __dirname       = path.dirname(__filename);
 /** @anchor test-isolation - ENV override to prevent parallel test mutations from corrupting the canonical file. Easily extensible to other servers via NEO_AI_MCP_<SERVER>_OPENAPI_PATH. */
 const openApiFilePath = process.env.NEO_AI_MCP_KB_OPENAPI_PATH || path.join(__dirname, 'openapi.yaml');
-const ingestToolName  = 'ingest_source_files';
-
-/**
- * @summary Normalizes optional MCP server prefixes before transport-gating tool names.
- * @param {String} toolName The requested MCP tool name.
- * @returns {String} The effective OpenAPI operation id.
- */
-const getEffectiveToolName = toolName => {
-    const lastDoubleUnderscoreIndex = toolName.lastIndexOf('__');
-
-    return lastDoubleUnderscoreIndex !== -1
-        ? toolName.substring(lastDoubleUnderscoreIndex + 2)
-        : toolName;
-};
-
-/**
- * @summary Returns true when the KB MCP server is in its remote StreamableHTTP profile.
- * @returns {Boolean} True when remote tenant push clients may call `ingest_source_files`.
- */
-const isRemoteIngestTransport = () => aiConfig.transport === 'sse';
-
-/**
- * @summary Fails closed when a local stdio client tries to invoke the remote push facade.
- * @param {String} toolName The requested MCP tool name.
- */
-const assertToolTransportAllowed = toolName => {
-    if (getEffectiveToolName(toolName) === ingestToolName && !isRemoteIngestTransport()) {
-        throw new Error(
-            '`ingest_source_files` is only exposed when the Knowledge Base MCP server runs ' +
-            'with `transport: "sse"` (StreamableHTTP). Use `npm run ai:ingest-tenant` or ' +
-            'direct service ingestion for local stdio workflows.'
-        );
-    }
-};
 
 /**
  * @summary Applies the KB transport visibility policy before returning MCP tools/list.
@@ -59,7 +29,7 @@ const assertToolTransportAllowed = toolName => {
  */
 const listTransportVisibleTools = ({cursor=0, limit} = {}) => {
     const allTools = toolService.listTools().tools.filter(tool => (
-        tool.name !== ingestToolName || isRemoteIngestTransport()
+        tool.name !== ingestToolName || isIngestSourceFilesToolVisible()
     ));
 
     if (!limit) {
@@ -79,54 +49,6 @@ const listTransportVisibleTools = ({cursor=0, limit} = {}) => {
         tools: toolsSlice,
         nextCursor
     };
-};
-
-/**
- * @summary MCP facade for `KnowledgeBaseIngestionService.ingestSourceFiles`.
- *
- * An agent-initiated `ingest_source_files` push embeds synchronously; an oversized batch
- * would freeze the calling agent. This facade counts the batch volume up-front and, when
- * it exceeds `aiConfig.mcpSyncMaxChunks` (default 50), refuses with a structured
- * `KB_INGEST_VOLUME_EXCEEDED` payload instead of dispatching to the service.
- *
- * Batch volume = the summed `parsedChunks` length across `files`, counting each raw
- * (un-parsed) file as 1. Raw files are chunked server-side, so a small batch of large
- * raw files can still exceed the threshold post-parse — the gate is a coarse up-front
- * guard, not an exact post-parse count.
- *
- * The gate lives at the MCP facade (not threaded into the service) because the batch
- * volume is knowable from the input alone, keeping service-layer ingestion logic
- * unchanged and transport policy localized to the MCP facade.
- *
- * @param {Object}    args            The `ingest_source_files` tool envelope.
- * @param {String}   [args.tenantId]  Authenticated tenant id.
- * @param {Object[]} [args.files]     Raw file payloads or client-side parsed records.
- * @returns {Promise<Object>} The `KnowledgeBaseIngestionService.ingestSourceFiles` summary,
- *     OR a `{error, message, code: 'KB_INGEST_VOLUME_EXCEEDED', bulkPath, batchSize, threshold}`
- *     refusal when the work-volume gate fires.
- * @see https://github.com/neomjs/neo/issues/11634
- * @see https://github.com/neomjs/neo/issues/10572
- */
-const ingestSourceFilesViaMcp = async args => {
-    const
-        files     = Array.isArray(args?.files) ? args.files : [],
-        batchSize = files.reduce((sum, file) => sum + (Array.isArray(file?.parsedChunks) ? file.parsedChunks.length : 1), 0),
-        threshold = aiConfig.mcpSyncMaxChunks ?? 50;
-
-    if (batchSize > threshold) {
-        return {
-            error    : 'KB ingest work volume exceeds MCP-callable threshold',
-            message  : `Batch volume ${batchSize} exceeds the MCP-synchronous threshold ${threshold}. ` +
-                       `Re-invoke ingest_source_files with at most ${threshold} files/chunks per call; ` +
-                       `a tenant-scoped bulk ingestion facade is planned (Phase 2C).`,
-            code     : 'KB_INGEST_VOLUME_EXCEEDED',
-            bulkPath : null,
-            batchSize,
-            threshold
-        };
-    }
-
-    return KnowledgeBaseIngestionService.ingestSourceFiles(args);
 };
 
 const serviceMapping = {

--- a/test/playwright/unit/ai/mcp/server/knowledge-base/IngestSourceFilesTool.spec.mjs
+++ b/test/playwright/unit/ai/mcp/server/knowledge-base/IngestSourceFilesTool.spec.mjs
@@ -27,7 +27,7 @@ import * as core      from '../../../../../../../src/core/_export.mjs';
  * up-front with a structured `KB_INGEST_VOLUME_EXCEEDED` payload instead of being
  * dispatched (which would embed synchronously and freeze the calling agent).
  *
- * The facade is tested directly (exported from `toolService.mjs`) so the gate logic
+ * The facade is tested directly from `ingestSourceFilesTool.mjs` so the gate logic
  * is isolated from the openapi -> Zod dispatch layer and the `callTool` telemetry
  * wrapper; `listTools()` separately confirms the openapi operation registers.
  *
@@ -42,8 +42,9 @@ test.describe('ingest_source_files MCP facade — work-volume gate (#11634)', ()
 
     test.beforeAll(async () => {
         const toolService = await import('../../../../../../../ai/mcp/server/knowledge-base/toolService.mjs');
+        const ingestTool  = await import('../../../../../../../ai/mcp/server/knowledge-base/ingestSourceFilesTool.mjs');
         callTool               = toolService.callTool;
-        ingestSourceFilesViaMcp = toolService.ingestSourceFilesViaMcp;
+        ingestSourceFilesViaMcp = ingestTool.ingestSourceFilesViaMcp;
         listTools               = toolService.listTools;
 
         KnowledgeBaseIngestionService = (await import('../../../../../../../ai/services/knowledge-base/KnowledgeBaseIngestionService.mjs')).default;


### PR DESCRIPTION
Resolves #12033

Authored by GPT-5 (Codex Desktop). Session 1578fb3e-7f5a-4b43-a6d0-ba00e66a9885.

FAIR-band: over-target [21/30] - taking this lane despite over-target because the operator surfaced the debt directly, the ticket was created in hot context, and the change is a narrow same-session refactor with low collision risk.

Extracts the retained `ingest_source_files` MCP facade out of the KB `toolService.mjs` mapping module into `ingestSourceFilesTool.mjs`. The generic mapping remains a composition layer, while the facade module now owns the batch-volume gate, transport visibility helper, and stdio fail-closed guard. Runtime behavior is intended to stay unchanged after #11743/#11744: remote SSE remains visible/callable; local stdio remains hidden and fail-closed.

Evidence: L2 targeted unit coverage -> L2 required for a no-behavior-change MCP facade refactor. Residual: no live deployed StreamableHTTP smoke in this PR.

## Deltas from Ticket

- Used a direct server-local sibling module at `ai/mcp/server/knowledge-base/ingestSourceFilesTool.mjs` rather than a new `tools/` subdirectory, after structural pre-flight. This avoids introducing a new directory role for one local facade.
- Kept `toolService.mjs` re-exporting `ingestSourceFilesViaMcp` for compatibility, while the spec imports the direct facade module to lock in the extraction.

## Structural Pre-Flight

Pre-Flight (structural full): considered `ai/mcp/server/knowledge-base/`, `ai/services/knowledge-base/helpers/`, and a new `ai/mcp/server/knowledge-base/tools/` subdirectory; consulted `learn/benefits/ArchitectureOverview.md` Structural Inventory, `learn/agentos/v13-path.md` M6 service/MCP boundary, ADR list, and sibling files. Chose an existing KB MCP-server-local sibling module because this is transport/tool-boundary policy over a retained remote facade, not reusable ingestion-domain logic. Map-maintenance: not needed; this decomposes an existing server-local file and introduces no new subsystem row.

## Test Evidence

- `npm run test-unit -- test/playwright/unit/ai/mcp/server/knowledge-base/IngestSourceFilesTool.spec.mjs` -> 6/6 passed.
- `git diff --check origin/dev...HEAD` -> passed.

## Post-Merge Validation

- [ ] No manual post-merge validation required beyond normal CI. The expected persistent signal is that KB MCP `ingest_source_files` remains visible only for SSE and remains hidden/fail-closed for stdio.

## Related

Discussion #12034 remains separate for the broader KB tenant-state/control-plane overlap question; this PR intentionally does not address that design surface.
