### PR TITLE
fix(orchestrator): unblock tenant-repo CLI sync path (#12036)

### DIFF
--- a/ai/daemons/orchestrator/services/TenantRepoSyncService.mjs
+++ b/ai/daemons/orchestrator/services/TenantRepoSyncService.mjs
@@ -563,7 +563,7 @@ class TenantRepoSyncService extends Base {
      */
     async resolveIngestionService() {
         const services = await import('../../../services.mjs');
-        return services.KB_KnowledgeBaseIngestionService || services.KnowledgeBaseIngestionService;
+        return services.KB_IngestionService;
     }
 
     /**

--- a/ai/deploy/Dockerfile
+++ b/ai/deploy/Dockerfile
@@ -21,7 +21,10 @@ RUN npm rebuild better-sqlite3 && node ./ai/scripts/setup/initServerConfigs.mjs
 FROM node:24-alpine
 WORKDIR /app
 
-RUN apk add --no-cache libstdc++
+# `git` is required by `ai/services/knowledge-base/helpers/GitMirror.mjs` for
+# tenant-repo clone/fetch. The orchestrator daemon's tenantRepoSync lane and
+# the operator-bulk `syncTenantRepos.mjs` CLI both shell out to it.
+RUN apk add --no-cache libstdc++ git
 
 COPY --from=builder /app ./
 


### PR DESCRIPTION
Refs #12036

Authored by claude-opus-4-7 (Claude Code). Session 89412233-5a87-4e21-bd1a-492fca958fc1.

FAIR-band: under-target [9/30] — Self-Selection Rule 1 fires (under-band → bias toward author lane).

Fixes two of the three Day-0 substrate gaps captured in #12036 — the two mechanical fixes that unblock the operator-bulk CLI path `node ai/scripts/maintenance/syncTenantRepos.mjs --repo-slug <slug>` end-to-end. Bug C (`NEO_TENANT_REPO_MIRROR_ROOT` env var dead config) is deferred to a follow-up PR because it needs a design decision on global-default vs per-repo-override semantics before the mechanical fix.

Evidence: L4 (first cloud tenant-ingestion smoke — orchestrator-CLI sync over OAuth-gated stack ingested 5 chunks into `neo-knowledge-base` chroma collection, all correctly tagged `tenantId` / `repoSlug` / `parserId` / `rootKind`) → L4 required (AC6 first-time clean docker-compose path). Residual: Bug C ACs [#12036] deferred.

## Deltas from ticket (if any)

- Ticket #12036 captures **three** Day-0 substrate gaps; this PR addresses Bug A + Bug B. Bug C deferred — needs design call on whether `NEO_TENANT_REPO_MIRROR_ROOT` becomes a global default (with per-repo override semantics) or whether the canonical compose's env-var should simply be removed as a misleading dead config. Will surface in a separate PR after design review.
- Two additional friction signals surfaced during R3 verification (`KB_REVISION_BOUNDARY_INVALID` first-sync edge case + missing `branchRef` in `tenantRepos[]` schema) will be filed as separate tickets — they're orthogonal to the CLI-unblock scope.

### Bug A — Runtime image missing `git`

[`ai/deploy/Dockerfile`](https://github.com/neomjs/neo/blob/dev/ai/deploy/Dockerfile) runtime stage installed only `libstdc++`. `node:24-alpine` doesn't ship with `git`, but [`GitMirror.mjs`](https://github.com/neomjs/neo/blob/dev/ai/services/knowledge-base/helpers/GitMirror.mjs) shells out to `git clone` / `git fetch`. Failure: `[Backup] failed to capture gitSha: spawn git ENOENT` from orchestrator stderr; outer wrapper `KB_TENANT_REPO_SYNC_SYNC_FAILED (GitMirror clone failed)`. Fix adds `git` to the runtime-stage apk install (~23 MiB image-size delta).

### Bug B — `resolveIngestionService` wrong export name

[`TenantRepoSyncService.resolveIngestionService`](https://github.com/neomjs/neo/blob/dev/ai/daemons/orchestrator/services/TenantRepoSyncService.mjs#L564-L567) looked up `services.KB_KnowledgeBaseIngestionService || services.KnowledgeBaseIngestionService`. Neither is exported — the canonical export is `KB_IngestionService` ([`ai/services.mjs:212`](https://github.com/neomjs/neo/blob/dev/ai/services.mjs#L212), [`:282`](https://github.com/neomjs/neo/blob/dev/ai/services.mjs#L282)). Resolver always returned `undefined`; the downstream `ingestionService.ingestSourceFiles(...)` NPE'd. Fix returns `KB_IngestionService` directly and drops the silent-undefined `||` chain — resolver should fail loud, not pretend.

### Architectural sub-question (recorded, not resolved)

The orchestrator's `viaMcp: false` hardcoded at [line 442](https://github.com/neomjs/neo/blob/dev/ai/daemons/orchestrator/services/TenantRepoSyncService.mjs#L442) implies a same-process model. Under ADR 0014's cloud topology, orchestrator + kb-server are separate containers; the orchestrator's `KB_IngestionService` instance shares chroma + sqlite with kb-server's instance but is otherwise an independent process. Is in-process the intended path, or should the orchestrator route through kb-server's MCP `ingestSourceFiles` tool? This PR picks the export-name fix (preserves in-process); empirical R3 verification confirms it works. If consensus is MCP-call, that's a separate ticket.

### Why tests didn't catch Bug B

`test/playwright/unit/ai/daemons/orchestrator/services/TenantRepoSyncService.spec.mjs` stubs `knowledgeBaseIngestionService` as a constructor option rather than exercising `resolveIngestionService`. Same pattern as friction memory anchor `feedback_stub_tests_miss_adapter_drift` ([#11999](https://github.com/neomjs/neo/pull/11999)): stub-based tests pass while real adapter path is broken. Worth a separate ticket for a "real-resolver" smoke that catches export drift; flagged here so it doesn't get lost.

## Test Evidence

- **Build verification (Bug A)**: `docker compose up -d --build orchestrator` produces image with `git --version` resolving (`git version 2.52.0`). Verified inside running container via `docker compose exec orchestrator git --version`.
- **Empirical R3 sync (Bug A + B together)**: `docker compose exec orchestrator node ai/scripts/maintenance/syncTenantRepos.mjs --repo-slug <slug>`:
  ```
  [INFO] [TenantRepoSync] Refreshing <tenant>/<repo>.
  [INFO] [TenantRepoSync] <tenant>/<repo> completed: head=<head> ingested=5 deleted=0 (152928ms)
  [INFO] [TenantRepoSync] Cycle summary: 1 repos, 1 completed, 0 failed, 0 not-due.
  ```
- **Chroma verification**: Direct query of `neo-knowledge-base` collection via chromadb client returns `count=5`, all 5 chunks filterable by `where: {tenantId: '<tenant-id>'}` and carrying full metadata schema (`tenantId`, `repoSlug=<slug>`, `parserId=raw-text`, `rootKind=external-source`, `ingestedAt`, `hash`, `parserVersion`, `schemaVersion`).
- **CI (local)**: Unit test run for `TenantRepoSyncService.spec.mjs` hit a pre-existing `Neo.ai.Config` namespace collision in `unitTestMode` caused by operator-overlay loading. Orthogonal to this PR (operator overlay has `tenantRepos[]` config which trips namespace strictness); CI runs from clean checkout where the overlay doesn't load, so this should pass there.

## Post-Merge Validation

- [ ] CI green on this PR (Playwright unit suite passes from clean checkout).
- [ ] Downstream cloud-deploy fresh `docker compose up -d --build` produces orchestrator image with `git` resolvable.
- [ ] Operator with `tenantRepos[]` populated in gitignored `ai/mcp/server/knowledge-base/config.mjs` can run `syncTenantRepos.mjs --repo-slug <slug>` without `apk add git` workaround.
- [ ] Follow-up PR for Bug C (mirrorRoot env-var fallback) — operator can drop per-repo `mirrorRoot` override in tenantRepos[] entries once that lands.

## Related

- Refs #12036 (parent ticket — Bug A + B fixed here, Bug C deferred to follow-up PR)
- Sibling: #12032 (credentialRef `file:` scheme — multi-tenant credential scaling)
- Parent epic: #11731 (Server-side tenant-repo ingestion)
- Empirical anchor: #12030 (RawRepoSource opt-in, merged 2026-05-26)
