### PR TITLE
docs(mcp): document create_issue @me assignee alias (#12038)

### DIFF
--- a/ai/mcp/server/github-workflow/openapi.yaml
+++ b/ai/mcp/server/github-workflow/openapi.yaml
@@ -961,7 +961,8 @@ paths:
                   type: array
                   items:
                     type: string
-                  description: (Optional) An array of GitHub user logins to assign to the issue. Requires write permissions.
+                  description: (Optional) An array of GitHub user logins to assign to the issue. Use `@me` to assign the authenticated user. Requires write permissions.
+                  example: ["@me"]
                   default: []
                 projects:
                   type: array

--- a/ai/services/github-workflow/IssueService.mjs
+++ b/ai/services/github-workflow/IssueService.mjs
@@ -463,7 +463,8 @@ class IssueService extends Base {
      * @param {string}   options.title                 The title of the issue.
      * @param {string}   [options.body='']             The Markdown body of the issue.
      * @param {string[]} [options.labels=[]]           An array of labels to add to the issue.
-     * @param {string[]} [options.assignees=[]]        An array of user logins to assign.
+     * @param {string[]} [options.assignees=[]]        An array of user logins to assign. Use `@me`
+     *     to assign the authenticated GitHub user.
      * @param {Array<{projectNumber: number}>} [options.projects=[]] An array of ProjectV2 memberships
      *     to attach atomically after issue creation. Each entry specifies the org-level project number.
      * @returns {Promise<object>} A promise that resolves to the new issue's data or a structured error.

--- a/test/playwright/unit/ai/mcp/server/github-workflow/ToolRegistration.spec.mjs
+++ b/test/playwright/unit/ai/mcp/server/github-workflow/ToolRegistration.spec.mjs
@@ -2,6 +2,7 @@ import {test, expect}  from '@playwright/test';
 import fs              from 'fs';
 import path            from 'path';
 import {fileURLToPath} from 'url';
+import yaml            from 'js-yaml';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname  = path.dirname(__filename);
@@ -57,5 +58,20 @@ test.describe('GitHub Workflow MCP Server Tool Registration', () => {
         expect(keys.includes('manage_pr_review'),
             `FAIL: manage_pr_review not found in toolService mapping — #11273 substrate-correct atomic-PR-review primitive (closes formal-state gap pattern from PR #11234 + PR #11271 empirical anchors). Keys found: ${keys.join(', ')}`
         ).toBe(true);
+    });
+
+    test('create_issue documents @me for assignee self-assignment (#12038)', () => {
+        const filePath = path.resolve(__dirname, '../../../../../../../ai/mcp/server/github-workflow/openapi.yaml');
+
+        expect(fs.existsSync(filePath), `openapi.yaml not found at ${filePath}`).toBe(true);
+
+        const fileContent = fs.readFileSync(filePath, 'utf8'),
+              doc         = yaml.load(fileContent),
+              operation   = doc.paths['/issues'].post,
+              assignees   = operation.requestBody.content['application/json'].schema.properties.assignees;
+
+        expect(operation.operationId).toBe('create_issue');
+        expect(assignees.description).toContain('@me');
+        expect(assignees.example).toContain('@me');
     });
 });


### PR DESCRIPTION
Resolves #12038

Authored by GPT-5 (Codex Desktop). Session 1578fb3e-7f5a-4b43-a6d0-ba00e66a9885.

FAIR-band: over-target [22/30] — taking this lane despite over-target because this is a just-verified MCP contract ambiguity with a tiny docs/test delta, and the user explicitly marked comparable trivial work as not worth blocking on Claude review.

Evidence: contract-doc-only MCP change; targeted GitHub workflow tool-registration unit spec passed, and OpenAPI validator compliance passed.

## Summary

Documents the existing `@me` self-assignment alias on the GitHub workflow MCP `create_issue.assignees` input. The runtime behavior already exists through the delegated `gh issue create --assignee` path; this PR makes the MCP contract match that behavior.

## Deltas From Ticket

- Updated `ai/mcp/server/github-workflow/openapi.yaml` so `create_issue.assignees` explicitly documents `@me` and includes an `@me` example.
- Updated `IssueService.createIssue()` JSDoc to mirror the contract.
- Added a focused regression test that parses the OpenAPI schema and asserts `create_issue.assignees` documents `@me`.

## Test Evidence

- `git diff --check`
- `npm run test-unit -- test/playwright/unit/ai/mcp/server/github-workflow/ToolRegistration.spec.mjs` — 4/4 passed
- `npm run test-unit -- test/playwright/unit/ai/mcp/validation/OpenApiValidatorCompliance.spec.mjs` — 26/26 passed

## Review Scope

This is a micro documentation/schema contract update with no runtime behavior change. Cross-family review is not requested unless the operator wants one; the PR should still run CI normally.

## Post-Merge Validation

- [ ] `create_issue` tool metadata shown to MCP clients advertises `@me` for assignee self-assignment.

## Out Of Scope

- Adding `@copilot` to the MCP contract.
- Implementing custom `@me` resolution in `IssueService`.
- Changing issue creation, permission, label, assignee, or ProjectV2 runtime behavior.

## Commit

- `49d7d5697` — `docs(mcp): document create_issue @me assignee alias (#12038)`