### PR TITLE
fix(kb): treat null baseRevision as first-sync (#12039)

### DIFF
--- a/ai/services/knowledge-base/KnowledgeBaseIngestionService.mjs
+++ b/ai/services/knowledge-base/KnowledgeBaseIngestionService.mjs
@@ -714,10 +714,14 @@ class KnowledgeBaseIngestionService extends Base {
      * @protected
      */
     async resolveRevisionTombstones({baseRevision, headRevision, tenantContext, summary}) {
-        if (!baseRevision || !headRevision) {
+        if (!baseRevision) {
+            return [];
+        }
+
+        if (!headRevision) {
             summary.errors.push(this.createError({
                 code   : 'KB_REVISION_BOUNDARY_INVALID',
-                message: '`baseRevision` and `headRevision` must be provided together.'
+                message: '`headRevision` is required when `baseRevision` is provided.'
             }));
             return [];
         }

--- a/test/playwright/unit/ai/services/knowledge-base/KnowledgeBaseIngestionService.spec.mjs
+++ b/test/playwright/unit/ai/services/knowledge-base/KnowledgeBaseIngestionService.spec.mjs
@@ -242,6 +242,35 @@ test.describe('KnowledgeBaseIngestionService.ingestSourceFiles', () => {
         expect(metrics[0].eventType).toBe('error');
     });
 
+    test('treats null baseRevision as first-sync (no boundary, no error)', async () => {
+        const summary = await Service.ingestSourceFiles({
+            tenantId    : 'tenant-a',
+            repoSlug    : 'repo-a',
+            files       : [],
+            baseRevision: null,
+            headRevision: 'head'
+        });
+
+        expect(summary.errors.some(e => e.code === 'KB_REVISION_BOUNDARY_INVALID')).toBe(false);
+        expect(summary.errors.some(e => e.code === 'KB_REVISION_BOUNDARY_UNAVAILABLE')).toBe(false);
+        expect(metrics[0]?.eventType).not.toBe('error');
+    });
+
+    test('rejects baseRevision-set with null headRevision via the new error message', async () => {
+        const summary = await Service.ingestSourceFiles({
+            tenantId    : 'tenant-a',
+            repoSlug    : 'repo-a',
+            files       : [],
+            baseRevision: 'base',
+            headRevision: null
+        });
+
+        expect(summary.errors[0]).toMatchObject({
+            code   : 'KB_REVISION_BOUNDARY_INVALID',
+            message: '`headRevision` is required when `baseRevision` is provided.'
+        });
+    });
+
     test('reports unavailable revision-boundary deletion resolver without throwing', async () => {
         const summary = await Service.ingestSourceFiles({
             tenantId    : 'tenant-a',


### PR DESCRIPTION
Resolves #12039

Authored by claude-opus-4-7 (Claude Code). Session 89412233-5a87-4e21-bd1a-492fca958fc1.

FAIR-band: under-target [9/30] — Self-Selection Rule 1 fires (under-band → bias toward author lane).

`resolveRevisionTombstones` validated `baseRevision` + `headRevision` as both-or-neither, but the first tenant-repo sync has a legitimately null `baseRevision` (no prior `lastIngestedRev`) and a set `headRevision` (the newly-resolved HEAD). The old validator pushed a spurious `KB_REVISION_BOUNDARY_INVALID` onto `summary.errors`, which propagated to `kb_ingestion_metrics` as `event_type=error` even though the embedding pipeline succeeded. Fix is an early-return when `baseRevision` is null — no boundary to traverse means no tombstones to resolve and no error.

Evidence: L2 (unit-test coverage of new null-base case + mixed-null negative case + preserved happy-path tests, 26/26 passing) → L2 required (close-target ACs are observable at the validator-boundary level; full L4 deployment-smoke verification was already shown empirically on the originating R3 exercise in [#12039](https://github.com/neomjs/neo/issues/12039) — that's what surfaced this bug). Residual: none.

## Deltas from ticket (if any)

Picked Option 1 from the ticket body (early-return in `resolveRevisionTombstones`) over Option 2 (caller-side guard). Rationale: keeps boundary semantics localized to the method that owns them — the caller doesn't need to know about first-sync edge cases. The tightened error message for the mixed-null case (`"headRevision required when baseRevision is provided"`) is more diagnostic than the old "both must be provided together" (which was ambiguous about which side was wrong).

## Test Evidence

- `npm run test-unit -- test/playwright/unit/ai/services/knowledge-base/KnowledgeBaseIngestionService.spec.mjs` → **26 passed (752ms)**. Two new tests added:
  - `treats null baseRevision as first-sync (no boundary, no error)`: asserts `summary.errors` carries no `KB_REVISION_BOUNDARY_INVALID` and no `KB_REVISION_BOUNDARY_UNAVAILABLE`; asserts metric `eventType !== 'error'`.
  - `rejects baseRevision-set with null headRevision via the new error message`: asserts `summary.errors[0]` has the new tightened message text.
- Preserved tests (24/24): both-set-resolver-unavailable, both-set-tombstone-resolution, all the orchestration tests.

## Post-Merge Validation

- [ ] CI green on this PR.
- [ ] Downstream: next first-tenant sync against a fresh repo no longer records `event_type=error` in `kb_ingestion_metrics`; the row carries `eventType` consistent with the actual outcome (e.g., `tombstone` if applicable, otherwise no error event).

## Related

- Resolves #12039
- Sibling R3 substrate gaps: [#12036](https://github.com/neomjs/neo/issues/12036) (3 Day-0 gaps, partial fix in [#12037](https://github.com/neomjs/neo/pull/12037)), [#12040](https://github.com/neomjs/neo/issues/12040) (branchRef schema), [#12042](https://github.com/neomjs/neo/issues/12042) (real-resolver smoke), [#12032](https://github.com/neomjs/neo/issues/12032) (credentialRef `file:` scheme).
- Empirical anchor: first cloud-deployment tenant-ingestion smoke, 2026-05-26.
