### PR TITLE
test(orchestrator): export-drift guard for resolveIngestionService (#12042)

### DIFF
--- a/test/playwright/unit/ai/daemons/orchestrator/services/TenantRepoSyncService.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/services/TenantRepoSyncService.spec.mjs
@@ -1117,21 +1117,26 @@ test.describe('TenantRepoSyncService.resolveIngestionService — export-drift gu
      * `runTask` arguments, bypassing `resolveIngestionService` entirely. That's how
      * the export-drift bug fixed in PR #12037 (lookup of the non-existent
      * `KB_KnowledgeBaseIngestionService` / `KnowledgeBaseIngestionService` names)
-     * escaped unit-test detection.
+     * escaped unit-test detection. This block covers all three drift classes:
      *
-     * A runtime test that imports `ai/services.mjs` and calls `resolveIngestionService()`
-     * is blocked here by the same `Neo.ai.Config` namespace collision pattern that the
-     * operator-overlay `ai/config.mjs` triggers under `unitTestMode` (template vs overlay
-     * double-register at `ai/config.template.mjs:578`). Static source-parsing catches
-     * the same drift without invoking class registration:
-     *
-     *   - Drift A: `services.mjs` renames `KB_IngestionService` → caught here.
+     *   - Drift A: `services.mjs` renames `KB_IngestionService` (static source guard).
      *   - Drift B: `TenantRepoSyncService.resolveIngestionService` looks up a different
-     *     symbol than what `services.mjs` exports → caught here.
-     *   - Drift C: `KB_IngestionService` shape loses `ingestSourceFiles` method →
-     *     NOT caught here (would need runtime test); residual gap documented.
+     *     symbol than what `services.mjs` exports (static source guard).
+     *   - Drift C: `KB_IngestionService` shape loses `ingestSourceFiles` method
+     *     (runtime resolver call + structural check).
+     *
+     * The runtime test (Drift C) calls the real resolver, which transitively imports
+     * `ai/services.mjs` → `ai/config.template.mjs`, which trips the `Neo.ai.Config`
+     * namespace-collision guard under `unitTestMode` because the operator overlay
+     * `ai/config.mjs` already registered that className. The guard's strict-mode
+     * behavior is to throw; the non-strict behavior is to return the existing
+     * namespace (a no-op for already-registered identical classes). Since we want
+     * the no-op behavior — this is exactly the case the guard's non-strict branch
+     * was written for ("different versions of Neo.mjs", per the comment at
+     * `src/Neo.mjs:811-818`) — we temporarily disable strict mode during the
+     * resolver call.
      */
-    const repoRoot   = path.resolve(__dirname, '../../../../../../../');
+    const repoRoot     = path.resolve(__dirname, '../../../../../../../');
     const servicesPath = path.join(repoRoot, 'ai/services.mjs');
     const resolverPath = path.join(repoRoot, 'ai/daemons/orchestrator/services/TenantRepoSyncService.mjs');
 
@@ -1147,5 +1152,20 @@ test.describe('TenantRepoSyncService.resolveIngestionService — export-drift gu
 
         expect(match, 'resolveIngestionService method body extractable').not.toBeNull();
         expect(match[1]).toContain('services.KB_IngestionService');
+    });
+
+    test('resolveIngestionService returns the canonical KB_IngestionService with ingestSourceFiles method (Drift C)', async () => {
+        const originalUnitTestMode = Neo.config.unitTestMode;
+        Neo.config.unitTestMode    = false;
+
+        try {
+            const ingestionService = await TenantRepoSyncService.resolveIngestionService();
+
+            expect(ingestionService).toBeDefined();
+            expect(ingestionService).not.toBeNull();
+            expect(typeof ingestionService.ingestSourceFiles).toBe('function');
+        } finally {
+            Neo.config.unitTestMode = originalUnitTestMode;
+        }
     });
 });

--- a/test/playwright/unit/ai/daemons/orchestrator/services/TenantRepoSyncService.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/services/TenantRepoSyncService.spec.mjs
@@ -1125,16 +1125,18 @@ test.describe('TenantRepoSyncService.resolveIngestionService — export-drift gu
      *   - Drift C: `KB_IngestionService` shape loses `ingestSourceFiles` method
      *     (runtime resolver call + structural check).
      *
-     * The runtime test (Drift C) calls the real resolver, which transitively imports
-     * `ai/services.mjs` → `ai/config.template.mjs`, which trips the `Neo.ai.Config`
-     * namespace-collision guard under `unitTestMode` because the operator overlay
-     * `ai/config.mjs` already registered that className. The guard's strict-mode
-     * behavior is to throw; the non-strict behavior is to return the existing
-     * namespace (a no-op for already-registered identical classes). Since we want
-     * the no-op behavior — this is exactly the case the guard's non-strict branch
-     * was written for ("different versions of Neo.mjs", per the comment at
-     * `src/Neo.mjs:811-818`) — we temporarily disable strict mode during the
-     * resolver call.
+     * The Drift C runtime test depends on the per-server `config.mjs` files being
+     * materialized — i.e., the bootstrap step in `ai/scripts/setup/initServerConfigs.mjs`
+     * rewrites `import AiConfig from '../../../config.template.mjs'` to
+     * `import AiConfig from '../../../config.mjs'` so that runtime code loads the
+     * operator overlay (which `Neo.ai.Config`-registers exactly once) instead of the
+     * template (which would register via a parallel chain and trip the `unitTestMode`
+     * namespace-collision guard at `src/Neo.mjs:820`). CI's `npm ci` runs the
+     * bootstrap on fresh clone, so this is the green path. Operator checkouts whose
+     * per-server `config.mjs` was generated before the materialization logic landed
+     * will hit the collision until they re-run `npm run prepare -- --migrate-config`
+     * OR manually update the import path. Documented in #12047 (open) for the
+     * materialization-migration substrate work.
      */
     const repoRoot     = path.resolve(__dirname, '../../../../../../../');
     const servicesPath = path.join(repoRoot, 'ai/services.mjs');
@@ -1155,17 +1157,10 @@ test.describe('TenantRepoSyncService.resolveIngestionService — export-drift gu
     });
 
     test('resolveIngestionService returns the canonical KB_IngestionService with ingestSourceFiles method (Drift C)', async () => {
-        const originalUnitTestMode = Neo.config.unitTestMode;
-        Neo.config.unitTestMode    = false;
+        const ingestionService = await TenantRepoSyncService.resolveIngestionService();
 
-        try {
-            const ingestionService = await TenantRepoSyncService.resolveIngestionService();
-
-            expect(ingestionService).toBeDefined();
-            expect(ingestionService).not.toBeNull();
-            expect(typeof ingestionService.ingestSourceFiles).toBe('function');
-        } finally {
-            Neo.config.unitTestMode = originalUnitTestMode;
-        }
+        expect(ingestionService).toBeDefined();
+        expect(ingestionService).not.toBeNull();
+        expect(typeof ingestionService.ingestSourceFiles).toBe('function');
     });
 });

--- a/test/playwright/unit/ai/daemons/orchestrator/services/TenantRepoSyncService.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/services/TenantRepoSyncService.spec.mjs
@@ -22,9 +22,13 @@ import InstanceManager from '../../../../../../../src/manager/Instance.mjs';
 import fs              from 'fs-extra';
 import os              from 'os';
 import path            from 'path';
+import {fileURLToPath} from 'url';
 
 import TenantRepoSyncService from '../../../../../../../ai/daemons/orchestrator/services/TenantRepoSyncService.mjs';
 import {deriveTenantRepoMirrorPath} from '../../../../../../../ai/services/knowledge-base/helpers/TenantRepoAccessContract.mjs';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname  = path.dirname(__filename);
 
 // Serial mode: TenantRepoSyncService is a singleton.
 test.describe.configure({mode: 'serial'});
@@ -1104,5 +1108,44 @@ test.describe('TenantRepoSyncService (#11790)', () => {
         expect(result.status).toBe('completed');
         expect(result.details.failedCount).toBe(1);
         expect(result.details.completedCount).toBe(1);
+    });
+});
+
+test.describe('TenantRepoSyncService.resolveIngestionService — export-drift guard (#12042)', () => {
+    /*
+     * Other tests in this file inject `knowledgeBaseIngestionService` directly via
+     * `runTask` arguments, bypassing `resolveIngestionService` entirely. That's how
+     * the export-drift bug fixed in PR #12037 (lookup of the non-existent
+     * `KB_KnowledgeBaseIngestionService` / `KnowledgeBaseIngestionService` names)
+     * escaped unit-test detection.
+     *
+     * A runtime test that imports `ai/services.mjs` and calls `resolveIngestionService()`
+     * is blocked here by the same `Neo.ai.Config` namespace collision pattern that the
+     * operator-overlay `ai/config.mjs` triggers under `unitTestMode` (template vs overlay
+     * double-register at `ai/config.template.mjs:578`). Static source-parsing catches
+     * the same drift without invoking class registration:
+     *
+     *   - Drift A: `services.mjs` renames `KB_IngestionService` → caught here.
+     *   - Drift B: `TenantRepoSyncService.resolveIngestionService` looks up a different
+     *     symbol than what `services.mjs` exports → caught here.
+     *   - Drift C: `KB_IngestionService` shape loses `ingestSourceFiles` method →
+     *     NOT caught here (would need runtime test); residual gap documented.
+     */
+    const repoRoot   = path.resolve(__dirname, '../../../../../../../');
+    const servicesPath = path.join(repoRoot, 'ai/services.mjs');
+    const resolverPath = path.join(repoRoot, 'ai/daemons/orchestrator/services/TenantRepoSyncService.mjs');
+
+    test('ai/services.mjs exports KB_IngestionService', async () => {
+        const source = await fs.readFile(servicesPath, 'utf-8');
+
+        expect(source).toMatch(/export\s*\{[^}]*\bKB_IngestionService\b[^}]*\}/s);
+    });
+
+    test('TenantRepoSyncService.resolveIngestionService references services.KB_IngestionService', async () => {
+        const source = await fs.readFile(resolverPath, 'utf-8');
+        const match  = source.match(/async\s+resolveIngestionService\s*\([^)]*\)\s*\{([\s\S]*?)\n\s{4}\}/);
+
+        expect(match, 'resolveIngestionService method body extractable').not.toBeNull();
+        expect(match[1]).toContain('services.KB_IngestionService');
     });
 });


### PR DESCRIPTION
Resolves #12042

Authored by claude-opus-4-7 (Claude Code). Session 89412233-5a87-4e21-bd1a-492fca958fc1.

FAIR-band: under-target [9/30] — Self-Selection Rule 1 fires (under-band → bias toward author lane).

Three export-drift guards covering all the drift classes from the cycle-1 review (`[KB_GAP]` finding by @neo-gpt) — the export-name escape pattern that hid Bug B in [PR #12037](https://github.com/neomjs/neo/pull/12037):

| Drift class | Mechanism | Caught by |
| --- | --- | --- |
| **A**: `services.mjs` renames `KB_IngestionService` | Static source-regex on `ai/services.mjs` export block | Test 1 |
| **B**: `resolveIngestionService` looks up wrong symbol | Static source-regex on method body | Test 2 |
| **C**: `KB_IngestionService` loses `ingestSourceFiles` method | Runtime resolver call + structural method-existence assertion | Test 3 |

### Cycle history

- **Cycle 1**: shipped Drift A + B static guards; Drift C blocked by `Neo.ai.Config` namespace-collision under `unitTestMode`. Reviewer flagged the close-target/evidence mismatch.
- **Cycle 2** (`8d0c8eae1`): added Drift C via per-test `Neo.config.unitTestMode = false` flip wrapped in `try/finally`. Worked but introduced a test-mode-bypass workaround.
- **Cycle 2.1** (`6481fbbf8`): operator pointed at the actual root cause — per-server `config.mjs` files (kb-server + memory-core) were supposed to be materialized by `ai/scripts/setup/initServerConfigs.mjs` to import from `'../../../config.mjs'` (operator overlay), but on operator-local checkouts that predate the materialization logic, they still import from `'../../../config.template.mjs'`. That's the double-registration root cause. With per-server `config.mjs` correctly materialized (CI's `npm ci` does this on fresh clone), the runtime resolver test loads the overlay exactly once — no collision, no flip needed. The flip was removed and the test simplified.

Evidence: L2 (static source guards + runtime resolver-call + structural assertion against the real `services.mjs` import chain, 30/30 passing) → L2 required (regression-protection for export-name drift class). **No residuals.**

## Deltas from ticket (if any)

None. Cycle-1 deviation (static-only with Drift C residual) addressed by cycle-2.1 follow-up commits. Original `Refs` vs `Resolves` ambiguity resolved — full close-target satisfied.

## Test Evidence

- `npm run test-unit -- test/playwright/unit/ai/daemons/orchestrator/services/TenantRepoSyncService.spec.mjs` → **30 passed (1.2s)**:
  - 27 preserved tests (full orchestration coverage).
  - 3 new tests under `describe('TenantRepoSyncService.resolveIngestionService — export-drift guard (#12042)')`:
    1. `ai/services.mjs exports KB_IngestionService` — Drift A static guard.
    2. `TenantRepoSyncService.resolveIngestionService references services.KB_IngestionService` — Drift B static guard.
    3. `resolveIngestionService returns the canonical KB_IngestionService with ingestSourceFiles method (Drift C)` — runtime call + structural assertion.

## Post-Merge Validation

- [ ] CI green on this PR.
- [ ] Sanity-check: a hypothetical future PR that (a) renames the export in `services.mjs` only, OR (b) renames the lookup in `resolveIngestionService` only, OR (c) removes/renames `ingestSourceFiles` on `KB_IngestionService` — fails at least one of the three tests instead of escaping to deployment-time discovery.

## Related

- Resolves #12042
- Empirical anchors: [@neo-gpt cycle-1 review of PR #12037](https://github.com/neomjs/neo/pull/12037#pullrequestreview-4366920525) `[KB_GAP]` finding + [@neo-gpt cycle-1 review of this PR](https://github.com/neomjs/neo/pull/12044) Required Actions + operator pointer at materialization root cause.
- Sibling R3 substrate gaps: [#12036](https://github.com/neomjs/neo/issues/12036), [#12039](https://github.com/neomjs/neo/pull/12043) (PR open), [#12040](https://github.com/neomjs/neo/pull/12045) (PR open), [#12032](https://github.com/neomjs/neo/pull/12046) (PR open).
- Substrate friction captured: [#12047](https://github.com/neomjs/neo/issues/12047) — per-server `config.mjs` auto-materialization migration for operator-local checkouts that predate the materialize logic.
