### PR TITLE
feat(kb): add branchRef to tenantRepos[] schema (#12040)

### DIFF
--- a/ai/daemons/orchestrator/services/TenantRepoSyncService.mjs
+++ b/ai/daemons/orchestrator/services/TenantRepoSyncService.mjs
@@ -432,6 +432,7 @@ class TenantRepoSyncService extends Base {
                     repoSlug        : repo.repoSlug,
                     mirrorRoot      : repo.mirrorRoot,
                     lastIngestedRev : priorState?.lastIngestedRev || null,
+                    newHead         : repo.branchRef || 'HEAD',
                     rootKind        : repo.rootKind || 'external-source',
                     parserId        : repo.parserId,
                     parserVersion   : repo.parserVersion,

--- a/ai/services/knowledge-base/helpers/TenantRepoAccessContract.mjs
+++ b/ai/services/knowledge-base/helpers/TenantRepoAccessContract.mjs
@@ -191,7 +191,12 @@ export function normalizeRepoSlug(repoSlug) {
 /**
  * @summary Normalizes one tenant repo-access config entry and enforces the no-secret boundary.
  * @param {Object} entry Tenant repo-access config entry.
- * @returns {{cloneUrl: String, credentialRef: String|Object, repoSlug: String}}
+ * @param {String} [entry.branchRef] Optional git ref (branch / tag / sha) to ingest from. When
+ *     omitted the downstream envelope builder defaults to `'HEAD'` (= remote default branch).
+ *     Useful for tenants whose canonical product-source-of-truth branch differs from the
+ *     repo's default branch (e.g., trunk-based teams using `dev` as integration line and
+ *     `main` as release-tag-only).
+ * @returns {{cloneUrl: String, credentialRef: String|Object, repoSlug: String, branchRef?: String}}
  */
 export function normalizeTenantRepoEntry(entry = {}) {
     if (!entry || typeof entry !== 'object' || Array.isArray(entry)) {
@@ -207,6 +212,13 @@ export function normalizeTenantRepoEntry(entry = {}) {
         throw createContractError(
             'KB_TENANT_REPO_CREDENTIAL_REF_REQUIRED',
             'Tenant repo config entries require credentialRef'
+        );
+    }
+
+    if (Object.hasOwn(entry, 'branchRef') && (typeof entry.branchRef !== 'string' || entry.branchRef.trim() === '')) {
+        throw createContractError(
+            'KB_TENANT_REPO_ENTRY_INVALID',
+            'Tenant repo config branchRef must be a non-empty string when present'
         );
     }
 

--- a/learn/agentos/cloud-deployment/TenantIngestionModel.md
+++ b/learn/agentos/cloud-deployment/TenantIngestionModel.md
@@ -181,6 +181,7 @@ The `aiConfig.tenantRepos[]` array is read by `KnowledgeBaseIngestionService.get
     repoSlug      : 'neomjs/create-app',                // tenant-owned, namespaced, never credential-bearing
     cloneUrl      : 'https://github.com/neomjs/create-app.git',  // clean URL; no userinfo@
     credentialRef : 'file:/run/secrets/neomjs_repo_token', // env:VAR and ssh:/path remain supported
+    branchRef     : 'dev',                              // optional; git ref (branch/tag/sha) to ingest from. Default: 'HEAD' = remote default branch
     rootKind      : 'external-source',                  // 'neo-workspace' | 'bare-repo' | 'external-source'
     parserId      : 'raw-text',                         // optional; defaults to family dispatch
     parserVersion : '1'                                 // optional
@@ -190,6 +191,8 @@ The `aiConfig.tenantRepos[]` array is read by `KnowledgeBaseIngestionService.get
 **Credential-bearing `cloneUrl` strings (`https://user:token@...`) are rejected at config normalization.** The `credentialRef` is a reference (env-var name, secret-store path, etc.) that `GitMirror` resolves only at the git subprocess invocation boundary (`GIT_ASKPASS` for HTTPS, `GIT_SSH_COMMAND` for SSH). The deployment graph never persists resolved credentials.
 
 Use `file:/run/secrets/<name>` when the deployment mounts Git credentials through Docker `secrets:` or a Kubernetes Secret volume. `GitMirror` reads and trims the file at subprocess time, then feeds the value through the same transient `GIT_ASKPASS` path as `env:` credentials; empty or missing files fail before git runs.
+
+**`branchRef` (optional)** selects which git ref to ingest from. Omitted = `'HEAD'` = the remote's default branch. Useful when the canonical product-source-of-truth branch differs from the repo's default branch — e.g., trunk-based teams using `dev` as integration line + `main` as release-tag-only. Validated as a non-empty string at config normalization; accepts any git ref name (branch, tag, sha) since it flows through `gitMirror.resolveHead()`.
 
 For the canonical config schema and rejection rules, see [`TenantRepoAccessContract.mjs`](../../../ai/services/knowledge-base/helpers/TenantRepoAccessContract.mjs).
 

--- a/test/playwright/unit/ai/daemons/orchestrator/services/TenantRepoSyncService.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/services/TenantRepoSyncService.spec.mjs
@@ -1109,6 +1109,37 @@ test.describe('TenantRepoSyncService (#11790)', () => {
         expect(result.details.failedCount).toBe(1);
         expect(result.details.completedCount).toBe(1);
     });
+
+    test('branchRef from tenantRepos[] flows through to envelopeBuilder.newHead (#12040)', async () => {
+        const taskStateService = createInMemoryTaskStateService();
+        const envelopeCalls    = [];
+
+        await provisionMirrorDir({tenantId: 't1', repoSlug: 'org/repo-with-branch'});
+        await provisionMirrorDir({tenantId: 't1', repoSlug: 'org/repo-default'});
+
+        await TenantRepoSyncService.runTask({
+            reason          : 'periodic-sweep:60000',
+            taskStateService,
+            tenantReposConfig: {tenantRepos: [
+                {tenantId: 't1', repoSlug: 'org/repo-with-branch', mirrorRoot, cloneUrl: 'https://github.com/neomjs/a.git', branchRef: 'dev'},
+                {tenantId: 't1', repoSlug: 'org/repo-default',     mirrorRoot, cloneUrl: 'https://github.com/neomjs/b.git'}
+            ]},
+            gitMirror                    : makeFakeGitMirror(),
+            envelopeBuilder              : makeFakeEnvelopeBuilder({captureCalls: envelopeCalls}),
+            knowledgeBaseIngestionService: makeFakeIngestionService(),
+            revisionsFilePath            : revisionsFile,
+            seedBootstrap                : false
+        });
+
+        const branchCall  = envelopeCalls.find(c => c.args.repoSlug === 'org/repo-with-branch');
+        const defaultCall = envelopeCalls.find(c => c.args.repoSlug === 'org/repo-default');
+
+        expect(branchCall, 'envelope builder called for repo-with-branch').toBeDefined();
+        expect(branchCall.args.newHead).toBe('dev');
+
+        expect(defaultCall, 'envelope builder called for repo-default').toBeDefined();
+        expect(defaultCall.args.newHead).toBe('HEAD');
+    });
 });
 
 test.describe('TenantRepoSyncService.resolveIngestionService — export-drift guard (#12042)', () => {

--- a/test/playwright/unit/ai/services/knowledge-base/TenantRepoAccessContract.spec.mjs
+++ b/test/playwright/unit/ai/services/knowledge-base/TenantRepoAccessContract.spec.mjs
@@ -48,6 +48,35 @@ test.describe('TenantRepoAccessContract (#11787)', () => {
         }).tenantRepos[0].repoSlug).toBe('github.com/neomjs/custom');
     });
 
+    test('preserves optional branchRef when valid (#12040)', () => {
+        expect(normalizeTenantRepoEntry({
+            cloneUrl     : 'https://github.com/neomjs/neo.git',
+            credentialRef: 'env:GITHUB_TOKEN',
+            branchRef    : 'dev'
+        })).toMatchObject({
+            cloneUrl     : 'https://github.com/neomjs/neo.git',
+            credentialRef: 'env:GITHUB_TOKEN',
+            repoSlug     : 'github.com/neomjs/neo',
+            branchRef    : 'dev'
+        });
+    });
+
+    test('rejects invalid branchRef shapes (#12040)', () => {
+        const base = {
+            cloneUrl     : 'https://github.com/neomjs/neo.git',
+            credentialRef: 'env:GITHUB_TOKEN'
+        };
+
+        expect(() => normalizeTenantRepoEntry({...base, branchRef: ''}))
+            .toThrow(/branchRef must be a non-empty string/u);
+        expect(() => normalizeTenantRepoEntry({...base, branchRef: '   '}))
+            .toThrow(/branchRef must be a non-empty string/u);
+        expect(() => normalizeTenantRepoEntry({...base, branchRef: 123}))
+            .toThrow(/branchRef must be a non-empty string/u);
+        expect(() => normalizeTenantRepoEntry({...base, branchRef: null}))
+            .toThrow(/branchRef must be a non-empty string/u);
+    });
+
     test('rejects cloneUrl userinfo before config persistence', () => {
         expect(hasCloneUrlUserInfo('https://token:secret@github.com/neomjs/neo.git')).toBe(true);
         expect(hasCloneUrlUserInfo('git@github.com:neomjs/neo.git')).toBe(true);


### PR DESCRIPTION
Resolves #12040

Authored by claude-opus-4-7 (Claude Code). Session 89412233-5a87-4e21-bd1a-492fca958fc1.

FAIR-band: under-target [9/30] — Self-Selection Rule 1 fires (under-band → bias toward author lane).

Adds optional `branchRef` field to tenant-repo config entries. When omitted, downstream envelope builder uses its existing `'HEAD'` default (= remote default branch) — backward-compatible. When set, the value plumbs through `TenantRepoSyncService` → envelope builder's `newHead` parameter → `gitMirror.resolveHead({ref: branchRef})`. Unblocks ingestion from non-default branches (e.g., trunk-based teams using `dev` as integration line + `main` as release-tag-only).

Evidence: L2 (unit-test coverage of positive + negative schema validation, plumbing assertion that branchRef flows to envelopeBuilder.args.newHead, 36/36 passing) → L2 required (close-target ACs are observable at the schema + plumbing boundary). Residual: full L4 deployment-smoke (ingesting a non-default branch in a live cloud stack) would lock the end-to-end path; covered downstream by operator validation, not blocking.

## Deltas from ticket (if any)

Internal-name decision: the envelope builder's existing parameter is `newHead`; the schema-facing name in the ticket is `branchRef`. Picked: `branchRef` at the operator-config layer + `newHead` preserved as the internal plumbing parameter. The rename happens at the `TenantRepoSyncService` callsite (`newHead: repo.branchRef || 'HEAD'`). Rationale: schema name is the operator-facing surface; `newHead` is implementation detail and renaming it across all envelope-builder docs/tests would widen scope beyond the ticket.

## Test Evidence

- `npm run test-unit -- test/playwright/unit/ai/services/knowledge-base/TenantRepoAccessContract.spec.mjs test/playwright/unit/ai/daemons/orchestrator/services/TenantRepoSyncService.spec.mjs` → **36 passed (1.1s)**:
  - **TenantRepoAccessContract** — 2 new tests:
    - `preserves optional branchRef when valid (#12040)`: positive case.
    - `rejects invalid branchRef shapes (#12040)`: 4-way negative coverage (empty, whitespace-only, non-string number, null).
  - **TenantRepoSyncService** — 1 new test:
    - `branchRef from tenantRepos[] flows through to envelopeBuilder.newHead (#12040)`: two-repo fixture — one with `branchRef: 'dev'`, one without; asserts `envelopeBuilder.args.newHead === 'dev'` vs `=== 'HEAD'` respectively.

## Post-Merge Validation

- [ ] CI green on this PR.
- [ ] Downstream cloud deployment: setting `branchRef: 'dev'` (or any non-default branch) on a tenantRepos[] entry resolves the configured branch's HEAD on the next sync; mirror clone still uses `--mirror` so all refs remain available for future re-targeting without re-cloning.

## Related

- Resolves #12040
- Sibling R3 substrate gaps (all open): [#12036](https://github.com/neomjs/neo/issues/12036) (Bug C — mirrorRoot env-var fallback), [#12039](https://github.com/neomjs/neo/pull/12043) (PR open — null baseRevision first-sync), [#12042](https://github.com/neomjs/neo/pull/12044) (PR open — export-drift guard), [#12032](https://github.com/neomjs/neo/issues/12032) (credentialRef `file:` scheme).
- Empirical anchor: first cloud-deployment tenant-ingestion smoke, 2026-05-26.
