### PR TITLE
feat(kb): support file credential refs (#12032)

### DIFF
--- a/ai/services/knowledge-base/helpers/GitMirror.mjs
+++ b/ai/services/knowledge-base/helpers/GitMirror.mjs
@@ -111,6 +111,10 @@ function normalizeCredentialRef(credentialRef) {
             return {type: 'ssh', keyPath: credentialRef.slice(4)};
         }
 
+        if (credentialRef.startsWith('file:')) {
+            return {type: 'file', filePath: credentialRef.slice(5)};
+        }
+
         return {type: 'env', name: credentialRef};
     }
 
@@ -132,6 +136,32 @@ function normalizeCredentialRef(credentialRef) {
  */
 function shellQuote(value) {
     return `'${String(value).replace(/'/gu, `'\\''`)}'`;
+}
+
+/**
+ * @summary Builds the transient askpass environment for HTTPS git credentials.
+ * @param {Object} options
+ * @param {String} options.secret Resolved credential material.
+ * @param {String} [options.username='x-access-token'] Git username returned by askpass.
+ * @returns {Promise<{env: Object, secretHints: String[], cleanup: Function}>}
+ * @private
+ */
+async function createAskPassCredentialEnvironment({secret, username = 'x-access-token'} = {}) {
+    const askPassDir  = await fs.mkdtemp(path.join(os.tmpdir(), 'neo-gitmirror-askpass-'));
+    const askPassPath = path.join(askPassDir, 'askpass.sh');
+    const gitUsername = username || 'x-access-token';
+
+    await fs.writeFile(askPassPath, ASKPASS_SCRIPT, {mode: 0o700});
+
+    return {
+        env: {
+            GIT_ASKPASS           : askPassPath,
+            NEO_GITMIRROR_PASSWORD: secret,
+            NEO_GITMIRROR_USERNAME: gitUsername
+        },
+        secretHints: [secret],
+        cleanup    : () => fs.remove(askPassDir)
+    };
 }
 
 /**
@@ -159,20 +189,37 @@ async function resolveCredentialEnvironment({credentialRef} = {}) {
             );
         }
 
-        const askPassDir  = await fs.mkdtemp(path.join(os.tmpdir(), 'neo-gitmirror-askpass-'));
-        const askPassPath = path.join(askPassDir, 'askpass.sh');
+        return createAskPassCredentialEnvironment({secret, username: ref.username});
+    }
 
-        await fs.writeFile(askPassPath, ASKPASS_SCRIPT, {mode: 0o700});
+    if (ref.type === 'file') {
+        if (!ref.filePath) {
+            throw createGitMirrorError(
+                'KB_GITMIRROR_CREDENTIAL_REF_INVALID',
+                'GitMirror file credentialRef requires filePath'
+            );
+        }
 
-        return {
-            env: {
-                GIT_ASKPASS           : askPassPath,
-                NEO_GITMIRROR_PASSWORD: secret,
-                NEO_GITMIRROR_USERNAME: ref.username || 'x-access-token'
-            },
-            secretHints: [secret],
-            cleanup    : () => fs.remove(askPassDir)
-        };
+        let secret;
+
+        try {
+            secret = (await fs.readFile(ref.filePath, 'utf-8')).trim();
+        } catch (error) {
+            throw createGitMirrorError(
+                'KB_GITMIRROR_CREDENTIAL_REF_INVALID',
+                'GitMirror file credentialRef could not be resolved',
+                {cause: error}
+            );
+        }
+
+        if (!secret) {
+            throw createGitMirrorError(
+                'KB_GITMIRROR_CREDENTIAL_REF_INVALID',
+                'GitMirror file credentialRef resolved to empty secret'
+            );
+        }
+
+        return createAskPassCredentialEnvironment({secret, username: ref.username});
     }
 
     if (ref.type === 'ssh') {

--- a/learn/agentos/cloud-deployment/TenantIngestionModel.md
+++ b/learn/agentos/cloud-deployment/TenantIngestionModel.md
@@ -180,7 +180,7 @@ The `aiConfig.tenantRepos[]` array is read by `KnowledgeBaseIngestionService.get
     tenantId      : 'neomjs',                           // server-derived; must match the authenticated tenant for stamping
     repoSlug      : 'neomjs/create-app',                // tenant-owned, namespaced, never credential-bearing
     cloneUrl      : 'https://github.com/neomjs/create-app.git',  // clean URL; no userinfo@
-    credentialRef : 'env:NEO_TENANT_NEOMJS_TOKEN',      // reference only; resolved by GitMirror at subprocess time
+    credentialRef : 'file:/run/secrets/neomjs_repo_token', // env:VAR and ssh:/path remain supported
     rootKind      : 'external-source',                  // 'neo-workspace' | 'bare-repo' | 'external-source'
     parserId      : 'raw-text',                         // optional; defaults to family dispatch
     parserVersion : '1'                                 // optional
@@ -188,6 +188,8 @@ The `aiConfig.tenantRepos[]` array is read by `KnowledgeBaseIngestionService.get
 ```
 
 **Credential-bearing `cloneUrl` strings (`https://user:token@...`) are rejected at config normalization.** The `credentialRef` is a reference (env-var name, secret-store path, etc.) that `GitMirror` resolves only at the git subprocess invocation boundary (`GIT_ASKPASS` for HTTPS, `GIT_SSH_COMMAND` for SSH). The deployment graph never persists resolved credentials.
+
+Use `file:/run/secrets/<name>` when the deployment mounts Git credentials through Docker `secrets:` or a Kubernetes Secret volume. `GitMirror` reads and trims the file at subprocess time, then feeds the value through the same transient `GIT_ASKPASS` path as `env:` credentials; empty or missing files fail before git runs.
 
 For the canonical config schema and rejection rules, see [`TenantRepoAccessContract.mjs`](../../../ai/services/knowledge-base/helpers/TenantRepoAccessContract.mjs).
 

--- a/test/playwright/unit/ai/services/knowledge-base/GitMirror.spec.mjs
+++ b/test/playwright/unit/ai/services/knowledge-base/GitMirror.spec.mjs
@@ -80,6 +80,41 @@ test.describe('GitMirror (#11788)', () => {
         };
     }
 
+    async function withFakeGitCapture(callback) {
+        const originalPath = process.env.PATH;
+        const binDir       = path.join(root, 'fake-bin');
+        const capturePath  = path.join(root, 'git-env.txt');
+        const gitPath      = path.join(binDir, 'git');
+
+        await fs.ensureDir(binDir);
+        await fs.writeFile(gitPath, `#!/bin/sh
+{
+    printf '%s\\n' "GIT_ASKPASS=$GIT_ASKPASS"
+    printf '%s\\n' "NEO_GITMIRROR_PASSWORD=$NEO_GITMIRROR_PASSWORD"
+    printf '%s\\n' "NEO_GITMIRROR_USERNAME=$NEO_GITMIRROR_USERNAME"
+} > ${JSON.stringify(capturePath)}
+printf 'fatal: token %s\\n' "$NEO_GITMIRROR_PASSWORD" >&2
+exit 1
+`);
+        await fs.chmod(gitPath, 0o755);
+
+        process.env.PATH = `${binDir}${path.delimiter}${originalPath}`;
+
+        try {
+            await callback(capturePath);
+        } finally {
+            process.env.PATH = originalPath;
+        }
+    }
+
+    function parseCapturedEnv(raw) {
+        return Object.fromEntries(raw.trim().split('\n').map(line => {
+            const index = line.indexOf('=');
+
+            return [line.slice(0, index), line.slice(index + 1)];
+        }));
+    }
+
     test('clones a local source repo as an idempotent bare mirror', async () => {
         const source = await createSourceRepo();
         const first  = await cloneIfMissing(mirrorOptions(source));
@@ -163,6 +198,72 @@ test.describe('GitMirror (#11788)', () => {
             cloneUrl     : path.join(root, 'other-source'),
             credentialRef: 'env:NEO_GITMIRROR_MISSING_TOKEN',
             repoSlug     : 'local/other-source'
+        })).rejects.toMatchObject({code: 'KB_GITMIRROR_CREDENTIAL_REF_INVALID'});
+    });
+
+    test('resolves file credentialRef strings through askpass and redacts the resolved secret', async () => {
+        const secretPath = path.join(root, 'tenant-token');
+
+        await fs.writeFile(secretPath, ' file-secret-token \n');
+
+        await withFakeGitCapture(async capturePath => {
+            try {
+                await cloneIfMissing({
+                    ...mirrorOptions('https://example.com/tenant/repo.git'),
+                    credentialRef: `file:${secretPath}`
+                });
+            } catch (error) {
+                const captured = parseCapturedEnv(await fs.readFile(capturePath, 'utf-8'));
+
+                expect(error).toMatchObject({code: 'KB_GITMIRROR_CLONE_FAILED'});
+                expect(error.stderr).toContain('[REDACTED]');
+                expect(error.stderr).not.toContain('file-secret-token');
+                expect(captured.NEO_GITMIRROR_PASSWORD).toBe('file-secret-token');
+                expect(captured.NEO_GITMIRROR_USERNAME).toBe('x-access-token');
+                await expect(fs.pathExists(path.dirname(captured.GIT_ASKPASS))).resolves.toBe(false);
+                return;
+            }
+
+            throw new Error('Expected fake git failure');
+        });
+    });
+
+    test('passes file credentialRef objects through with explicit username', async () => {
+        const secretPath = path.join(root, 'tenant-token-object');
+
+        await fs.writeFile(secretPath, 'object-secret-token\n');
+
+        await withFakeGitCapture(async capturePath => {
+            await expect(cloneIfMissing({
+                ...mirrorOptions('https://example.com/tenant/repo.git'),
+                credentialRef: {
+                    type    : 'file',
+                    filePath: secretPath,
+                    username: 'deploy-token'
+                }
+            })).rejects.toMatchObject({code: 'KB_GITMIRROR_CLONE_FAILED'});
+
+            const captured = parseCapturedEnv(await fs.readFile(capturePath, 'utf-8'));
+
+            expect(captured.NEO_GITMIRROR_PASSWORD).toBe('object-secret-token');
+            expect(captured.NEO_GITMIRROR_USERNAME).toBe('deploy-token');
+        });
+    });
+
+    test('rejects empty or missing file credentialRef targets', async () => {
+        const emptyPath   = path.join(root, 'empty-token');
+        const missingPath = path.join(root, 'missing-token');
+
+        await fs.writeFile(emptyPath, ' \n');
+
+        await expect(cloneIfMissing({
+            ...mirrorOptions('https://example.com/tenant/repo.git'),
+            credentialRef: `file:${emptyPath}`
+        })).rejects.toMatchObject({code: 'KB_GITMIRROR_CREDENTIAL_REF_INVALID'});
+
+        await expect(cloneIfMissing({
+            ...mirrorOptions('https://example.com/tenant/repo.git'),
+            credentialRef: {type: 'file', filePath: missingPath}
         })).rejects.toMatchObject({code: 'KB_GITMIRROR_CREDENTIAL_REF_INVALID'});
     });
 


### PR DESCRIPTION
Resolves #12032

Authored by GPT-5 (Codex Desktop). Session 1578fb3e-7f5a-4b43-a6d0-ba00e66a9885.

FAIR-band: over-target [21/30] — taking this lane despite over-target because the operator/peer R3 split put Claude on #12039, #12040, and #12042 while #12032 was the remaining small credential unlock adjacent to GPT's current KB ingestion context.

Adds `file:` credential references to the GitMirror tenant-repo credential boundary. `credentialRef: 'file:/absolute/path'` now normalizes to a file-backed reference, reads and trims the mounted secret only at git subprocess time, feeds it through the same transient askpass environment as `env:`, and rejects missing or empty files with `KB_GITMIRROR_CREDENTIAL_REF_INVALID`. The cloud deployment ingestion guide now names the Docker secrets / Kubernetes Secret volume pattern.

Evidence: L2 (focused unit suites with fake-git env capture plus adjacent tenant repo access/sync contract coverage) → L2 required (credentialRef normalization, resolution, redaction, and docs ACs). No residuals.

Decision Record impact: aligned-with ADR 0014.

## Deltas from ticket

None. `vault:` / secret-manager plugin schemes remain out of scope.

## Slot Rationale

Modified section: `learn/agentos/cloud-deployment/TenantIngestionModel.md` server-side pull configuration note.

Disposition delta: keep → keep. The operator-facing credential-boundary guide needs the supported `credentialRef` schemes next to `tenantRepos[]` configuration because this is where Docker/Kubernetes operators make the secret-mount choice.

3-axis rating: trigger-frequency medium, failure-severity high, enforceability high.

Decay mitigation: if a dedicated credentialRef reference page exists later, move the scheme matrix there and keep only a short link from this guide.

## Test Evidence

- `npm run test-unit -- test/playwright/unit/ai/services/knowledge-base/GitMirror.spec.mjs` — 9 passed.
- `npm run test-unit -- test/playwright/unit/ai/services/knowledge-base/TenantRepoAccessContract.spec.mjs` — 6 passed.
- `npm run test-unit -- test/playwright/unit/ai/daemons/orchestrator/services/TenantRepoSyncService.spec.mjs` — 27 passed.
- `git diff --check` — passed.
- `git diff --cached --check` — passed before commit.

## Post-Merge Validation

- [ ] CI stays green on the GitMirror credentialRef and tenant-repo sync suites.

## Commits

- `b544a43eb` — `feat(kb): support file credential refs (#12032)`
