### PR TITLE
docs(day0): rewrite Milestone 6 to first-class pull mode (#12052)

### DIFF
--- a/learn/agentos/cloud-deployment/Day0Tutorial.md
+++ b/learn/agentos/cloud-deployment/Day0Tutorial.md
@@ -564,27 +564,92 @@ Failure signatures:
 | `KB_INGEST_CLI_JSONL_PARSE_FAILED` | A JSONL line is malformed. | Fix the line; the CLI reports parse errors without hiding sibling records. |
 | Non-zero CLI exit | One or more records failed. | Inspect the printed `errors` array before retrying. |
 
-## Milestone 6 - Optional Clone / Server-Side Source
+## Milestone 6 - Optional Pull Mode / Server-Side Tenant Repo Sync
 
-Server-side clone is not part of the MVP push path. If the deployment receives
-only `{repo, ref, sha}` metadata and must fetch content itself, stop and route to
-[#11731](https://github.com/neomjs/neo/issues/11731). That path needs a
-credential-storage and clone-trust contract before implementation.
+Push (Milestone 3) is the primary tenant-ingestion path — tenant repo workflow drives the publish cadence under a service-account identity, and the deployment never holds tenant-repo credentials. Pull mode is the **additive alternative** for tenants who want the deployment to own the ingestion cadence (orchestrator polls the tenant repo on a schedule rather than waiting on a `pre-push` hook).
 
-Use [Custom Sources](./CustomSources.md) only when the deployment operator owns
-the source territory and has explicitly decided to run a full-corpus source on
-the deployment host.
+The substrate that powers pull mode shipped via Epic [#11731](https://github.com/neomjs/neo/issues/11731) — clone-trust + credential-boundary contract (`TenantRepoAccessContract` + `GitMirror`), envelope builder, scheduler lane, `RawRepoSource`, `branchRef`, `file:` credentialRef, Tier-1 `tenantRepoMirrorRoot` fallback. Read [Tenant Ingestion Model](./TenantIngestionModel.md) for the operator decision model and [Hook Wiring](./HookWiring.md) for the push-vs-pull selection guide.
+
+**Skip this milestone if push covers your tenant content.** Pull is additive, not a prerequisite for the Day-0 operator handoff.
+
+If pull mode applies to your deployment, configure one tenant repo as a smoke:
+
+```js
+// In <NEO_SOURCE_DIR>/ai/mcp/server/knowledge-base/config.mjs (operator overlay):
+tenantRepos: [
+    {
+        tenantId      : 'client-org',
+        repoSlug      : 'client-org/example-repo',
+        cloneUrl      : 'https://git.example.com/client-org/example-repo.git',  // clean URL; no userinfo@
+        credentialRef : 'env:NEO_TENANT_EXAMPLE_TOKEN',                          // reference-only; resolved at GIT_ASKPASS time
+        branchRef     : 'main'                                                   // optional; defaults to 'HEAD' = remote default
+    }
+]
+```
+
+Set the credential at the deployment env (compose, k8s Secret, or `file:/run/secrets/<name>` per [#12046](https://github.com/neomjs/neo/pull/12046)):
+
+```bash
+export NEO_TENANT_EXAMPLE_TOKEN="<read-only-repo-access-token>"
+```
+
+Trigger the first sync:
+
+```bash
+node ai/scripts/maintenance/syncTenantRepos.mjs --repo-slug client-org/example-repo
+```
+
+Expected output:
+
+```json
+{
+  "status": "completed",
+  "details": {
+    "repoCount": 1,
+    "completedCount": 1,
+    "repos": [{"tenantId": "client-org", "repoSlug": "client-org/example-repo", "status": "active", "lastIngestedRev": "<sha>"}]
+  }
+}
+```
+
+Verify the chunks landed:
+
+```bash
+node /tmp/day0-call-tool.mjs \
+  "$NEO_KB_MCP_BASE_URL" \
+  "client-org" \
+  ask_knowledge_base \
+  /tmp/day0-tenant-query.json   # re-use the query envelope from Milestone 3
+```
+
+Failure signatures:
+
+| Signature | Meaning | Fix |
+|---|---|---|
+| `KB_GITMIRROR_CLONE_FAILED` | Clone subprocess failed (network, auth, missing repo, or — Day-0 — missing `git` binary in older deploy images per [#12036](https://github.com/neomjs/neo/issues/12036)). | Verify `read_repository` scope on the token; verify deploy image is built from current `ai/deploy/Dockerfile` (post-#12037 ships `git`). |
+| `KB_TENANT_REPO_CREDENTIAL_REF_REQUIRED` / `KB_GITMIRROR_CREDENTIAL_REF_INVALID` | `credentialRef` missing or doesn't resolve at runtime. | Confirm the env var name matches the `credentialRef` exactly; for `file:` scheme, confirm the file exists + is non-empty. |
+| `KB_TENANT_REPO_MIRROR_ROOT_REQUIRED` | No per-repo `mirrorRoot`, no Tier-1 default, no env var. | Set `NEO_TENANT_REPO_MIRROR_ROOT=/app/.neo-ai-data` in compose env (the canonical default, env-bound to `aiConfig.orchestrator.tenantRepoMirrorRoot` per [#12050](https://github.com/neomjs/neo/pull/12050)). |
+
+### Operator-owned Custom Source (genuinely orthogonal)
+
+A separate operator pattern: the deployment owns the source territory entirely — running its own full-corpus build over a repo it has on disk, *not* polling a tenant repo through `tenantRepos[]`. That's a [Custom Source](./CustomSources.md) workflow (`Source.extract` + `SourceRegistry`), distinct from pull mode. Both can coexist in a single deployment (pull-mode for tenant-owned repos + Custom-Source for operator-owned content territories).
 
 Expected day-0 result for this milestone is one of:
 
 ```text
-server-side clone: deferred to #11731
+pull mode configured for <tenantId>/<repoSlug>; first sync completed at <sha>
 ```
 
 or:
 
 ```text
-operator-owned Source registered intentionally
+skipped — push (Milestone 3) covers our tenant content
+```
+
+or:
+
+```text
+operator-owned Custom Source registered intentionally
 ```
 
 ## Milestone 7 - Backup, Redeploy, Handoff


### PR DESCRIPTION
Resolves #12052

Authored by claude-opus-4-7 (Claude Code). Session 89412233-5a87-4e21-bd1a-492fca958fc1.

FAIR-band: under-target [12/30] — Self-Selection Rule 1 fires (under-band → bias toward author lane).

Rewrites Day-0 Tutorial Milestone 6 to reflect that Epic #11731's pull-mode substrate has fully shipped. The previous "Optional Clone / Server-Side Source" framing routed operators to a "deferred to #11731" status marker — they read the milestone, see nothing actionable, skip it, and miss the entire production-ready pull surface.

Evidence: L1 (documentation diff against canonical-doc + ticket's Contract Ledger row-by-row, no runtime behavior change) → L1 required (close-target ACs are doc-shape claims). No residuals.

## Deltas from ticket (if any)

None. Implementation tracks each row of the Contract Ledger directly:

- **Milestone 6 heading** → renamed to "Optional Pull Mode / Server-Side Tenant Repo Sync"; no remaining "Optional Clone / Server-Side Source" text.
- **Milestone 6 body** → concrete pull-mode setup recipe (tenantRepos[] entry → credential env var → `syncTenantRepos.mjs` trigger → `ask_knowledge_base` verification), failure-signatures table for the three common pull-time errors (clone-failed / credentialRef-invalid / mirror-root-required), cross-links to TenantIngestionModel.md + HookWiring.md inside the milestone body.
- **Expected-result block** → three valid shapes documented: pull-configured (with sha), skipped-because-push-covers-it, operator-owned-Custom-Source. The stale `server-side clone: deferred to #11731` placeholder is gone.
- **Cross-links** → TenantIngestionModel.md + HookWiring.md added inline; CustomSources.md reference preserved at the bottom and reframed as genuinely orthogonal (operator owns full-corpus build) rather than a fallback-for-pull.
- **Non-overlap with CustomSources.md** → explicit "both can coexist in a single deployment (pull-mode for tenant-owned repos + Custom-Source for operator-owned content territories)" framing.

## Test Evidence

Doc-only change; no test suite to run. Verification per Contract Ledger row:

- `grep -n 'deferred to #11731\|Optional Clone / Server-Side Source\|server-side clone:' learn/agentos/cloud-deployment/Day0Tutorial.md` → 0 hits post-PR. (Pre-PR: 3 hits in Milestone 6.)
- New section has the 4-step pull setup with command-anchored recipe + JSON expected-output block.
- Custom Sources link to `./CustomSources.md` retained at the bottom of Milestone 6.
- Surrounding milestones (5 + 7) unchanged — Milestone 5 ends with bulk-CLI handoff, Milestone 7 picks up with backup/redeploy; no break in narrative flow.

## Post-Merge Validation

- [ ] CI green on this PR (lint-pr-body + retired-primitives + integration-unified).
- [ ] Operator reading Day-0 Tutorial Milestone 6 post-merge can follow the concrete pull-mode recipe end-to-end without routing off-canonical for "deferred" status.
- [ ] Cross-link traversal works: Milestone 6 → TenantIngestionModel.md / HookWiring.md / CustomSources.md all resolve.

## Related

- Ticket #12052 — the ticket carries the full Contract Ledger.
- Parent umbrella: [#11791](https://github.com/neomjs/neo/issues/11791) (operator docs + health/telemetry for tenant-repo ingestion). Day-0 update slots under that umbrella as a focused sub-PR.
- Substrate that shipped (motivating the rewrite): [#11731](https://github.com/neomjs/neo/issues/11731) Epic + [#11787](https://github.com/neomjs/neo/issues/11787), [#11788](https://github.com/neomjs/neo/issues/11788), [#11789](https://github.com/neomjs/neo/issues/11789), [#11790](https://github.com/neomjs/neo/issues/11790) subs + [#12030](https://github.com/neomjs/neo/pull/12030), [#12045](https://github.com/neomjs/neo/pull/12045), [#12050](https://github.com/neomjs/neo/pull/12050) follow-ons.
- Empirical session anchor: first cloud-deployment exercise 2026-05-26 — pull-mode validated end-to-end in production-shape stack, surfacing the staleness of the deferred framing.

