### PR TITLE
fix(worktree): materialize copied config overlays (#12051)

### DIFF
--- a/ai/scripts/migrations/bootstrapWorktree.mjs
+++ b/ai/scripts/migrations/bootstrapWorktree.mjs
@@ -1,13 +1,14 @@
 /**
- * @summary Copies gitignored `ai/mcp/server/<name>/config.mjs` files from the main git
- * checkout into the current git worktree, and optionally symlinks the gitignored
- * substrate-data subdirs of `.neo-ai-data/` (sqlite, chroma, wake-daemon, etc.) so
+ * @summary Copies gitignored `ai/config.mjs` plus per-server config overlays from
+ * the main git checkout into the current git worktree, and optionally symlinks the
+ * gitignored substrate-data subdirs of `.neo-ai-data/` (sqlite, chroma, wake-daemon, etc.) so
  * Memory Core, knowledge-base, and bridge-daemon state is unified across worktree
  * MCP server processes — while leaving the git-tracked `concepts/` subdir untouched.
  *
- * **Background (config copy):** `ai/mcp/server/{github-workflow,knowledge-base,memory-core,neural-link}/config.mjs`
- * are gitignored (they are copy-from-template files for local overrides). Fresh git worktrees
- * under `.claude/worktrees/<name>/` therefore cannot run any script that imports
+ * **Background (config copy):** `ai/config.mjs` is the Tier-1 operator overlay.
+ * `ai/mcp/server/{github-workflow,knowledge-base,memory-core,neural-link}/config.mjs`
+ * are gitignored per-server overlays. Fresh git worktrees under
+ * `.claude/worktrees/<name>/` therefore cannot run any script that imports
  * `ai/services.mjs`:
  *
  * ```
@@ -93,7 +94,9 @@
  *
  * Idempotent: files that already exist are skipped; subdirs already symlinked report
  * `'already-linked'`. Refuses to run from the main checkout itself (no-op when worktree
- * root === resolved canonical root).
+ * root === resolved canonical root). Copied per-server configs are materialized through
+ * {@link materializeServerConfigTemplate}, so stale canonical overlays that still import
+ * `../../../config.template.mjs` point at the worktree-local `../../../config.mjs` instead.
  *
  * @see https://github.com/neomjs/neo/issues/10095
  * @see https://github.com/neomjs/neo/issues/10224 (closed predecessor — coarse-grained symlink)
@@ -101,6 +104,7 @@
  * @see https://github.com/neomjs/neo/issues/10432 / #10433 (granular per-subdir refinement)
  * @see https://github.com/neomjs/neo/issues/10435 (independent-clone topology extension)
  * @see https://github.com/neomjs/neo/issues/10591 (gitignored single-file symlink extension)
+ * @see https://github.com/neomjs/neo/issues/12051 (Tier-1 config + materialize-on-copy)
  */
 import {execFile}       from 'child_process';
 import fs               from 'fs/promises';
@@ -108,9 +112,12 @@ import path             from 'path';
 import {fileURLToPath}  from 'url';
 import {promisify}      from 'util';
 
+import {materializeServerConfigTemplate} from '../setup/initServerConfigs.mjs';
+
 const execFileAsync = promisify(execFile);
 
 export const BOOTSTRAP_CONFIGS = [
+    'ai/config.mjs',
     'ai/mcp/server/github-workflow/config.mjs',
     'ai/mcp/server/knowledge-base/config.mjs',
     'ai/mcp/server/memory-core/config.mjs',
@@ -206,6 +213,8 @@ export async function resolveMainCheckout(cwd, {explicitRoot} = {}) {
 
 /**
  * @summary Copies missing config.mjs files from the main checkout into the target project root.
+ * Per-server configs are materialized after copy so their Tier-1 import points at the
+ * copied operator overlay (`ai/config.mjs`) instead of `ai/config.template.mjs`.
  *
  * Pure function form for testability — accepts explicit `mainCheckout`, `projectRoot`, and
  * `configs` arguments. CLI mode (bottom of file) resolves these via git.
@@ -245,11 +254,19 @@ export async function bootstrapWorktree({mainCheckout, projectRoot, configs = BO
 
         await fs.mkdir(path.dirname(dst), {recursive: true});
         await fs.copyFile(src, dst);
+        if (isPerServerConfig(rel)) {
+            const copiedSrc = await fs.readFile(dst, 'utf-8');
+            await fs.writeFile(dst, materializeServerConfigTemplate(copiedSrc), 'utf-8');
+        }
         result.copied.push(rel);
         log(`copied: ${rel}`);
     }
 
     return result;
+}
+
+function isPerServerConfig(rel) {
+    return rel.startsWith('ai/mcp/server/') && rel.endsWith('/config.mjs');
 }
 
 async function exists(p) {

--- a/test/playwright/unit/ai/scripts/migrations/bootstrapWorktree.spec.mjs
+++ b/test/playwright/unit/ai/scripts/migrations/bootstrapWorktree.spec.mjs
@@ -44,6 +44,7 @@ test.describe('ai/scripts/bootstrapWorktree', () => {
     let fakeWorktree;
 
     const fixtureConfigs = [
+        'ai/config.mjs',
         'ai/mcp/server/github-workflow/config.mjs',
         'ai/mcp/server/knowledge-base/config.mjs',
         'ai/mcp/server/memory-core/config.mjs',
@@ -109,7 +110,7 @@ test.describe('ai/scripts/bootstrapWorktree', () => {
     });
 
     test('is idempotent — re-running after partial seed leaves existing files untouched', async () => {
-        // Pre-seed one of the four with distinct content; confirm it's preserved.
+        // Pre-seed one config with distinct content; confirm it's preserved.
         const preseeded    = fixtureConfigs[0];
         const preseededDst = path.join(fakeWorktree, preseeded);
         await fs.ensureDir(path.dirname(preseededDst));
@@ -158,6 +159,75 @@ test.describe('ai/scripts/bootstrapWorktree', () => {
 
         expect(result.missing).toEqual([removed]);
         expect(result.copied).toEqual(fixtureConfigs.filter(c => c !== removed));
+    });
+
+    test('copies Tier-1 config and materializes stale per-server AiConfig imports (#12051)', async () => {
+        const tier1Rel      = 'ai/config.mjs';
+        const serverRel     = 'ai/mcp/server/memory-core/config.mjs';
+        const tier1Content  = [
+            `export default {`,
+            `    tenantRepos: [{tenantId: 'acme', repoSlug: 'org/repo'}],`,
+            `    customOperatorKey: 'preserved'`,
+            `};`,
+            ``
+        ].join('\n');
+        const serverContent = [
+            `import AiConfig from '../../../config.template.mjs';`,
+            `export const customKey = 'preserved-server-edit';`,
+            `export default {`,
+            `    tenantRepos: AiConfig.tenantRepos,`,
+            `    customKey`,
+            `};`,
+            ``
+        ].join('\n');
+
+        await fs.writeFile(path.join(fakeMainCheckout, tier1Rel), tier1Content, 'utf-8');
+        await fs.writeFile(path.join(fakeMainCheckout, serverRel), serverContent, 'utf-8');
+
+        const result = await bootstrapWorktree({
+            mainCheckout: fakeMainCheckout,
+            projectRoot : fakeWorktree,
+            configs     : [tier1Rel, serverRel],
+            log         : () => {}
+        });
+
+        expect(result.copied).toEqual([tier1Rel, serverRel]);
+
+        const copiedTier1  = await fs.readFile(path.join(fakeWorktree, tier1Rel), 'utf-8');
+        const copiedServer = await fs.readFile(path.join(fakeWorktree, serverRel), 'utf-8');
+
+        expect(copiedTier1).toBe(tier1Content);
+        expect(copiedTier1).toContain(`tenantRepos`);
+        expect(copiedTier1).toContain(`customOperatorKey: 'preserved'`);
+        expect(copiedServer).toContain(`from '../../../config.mjs'`);
+        expect(copiedServer).not.toContain(`../../../config.template.mjs`);
+        expect(copiedServer).toContain(`customKey = 'preserved-server-edit'`);
+    });
+
+    test('preserves existing destination configs without materializing them (#12051)', async () => {
+        const staleServerRel = 'ai/mcp/server/memory-core/config.mjs';
+        const dst            = path.join(fakeWorktree, staleServerRel);
+        const existing       = [
+            `import AiConfig from '../../../config.template.mjs';`,
+            `export default {tenantRepos: AiConfig.tenantRepos};`,
+            ``
+        ].join('\n');
+
+        await fs.ensureDir(path.dirname(dst));
+        await fs.writeFile(dst, existing, 'utf-8');
+
+        const result = await bootstrapWorktree({
+            mainCheckout: fakeMainCheckout,
+            projectRoot : fakeWorktree,
+            configs     : [staleServerRel],
+            log         : () => {}
+        });
+
+        expect(result.copied).toHaveLength(0);
+        expect(result.skipped).toEqual([staleServerRel]);
+
+        const preserved = await fs.readFile(dst, 'utf-8');
+        expect(preserved).toBe(existing);
     });
 
     // --------------------------------------------------------------------------------


### PR DESCRIPTION
Resolves #12051

Authored by GPT-5.5 (Codex Desktop). Session 019e63ad-9964-7651-abf9-23053f16d22b.
FAIR-band: over-target [18/30] — taking this lane despite over-target because #12051 was the current ledger-unblocked #12050 follow-up, no `neo-gpt` review requests were pending, and @neo-opus-4-7 explicitly handed off the unblocked lane.

`bootstrapWorktree` now hydrates top-level `ai/config.mjs` alongside the four per-server overlays. Newly copied per-server configs run through `materializeServerConfigTemplate()` so stale canonical imports are rewritten from `../../../config.template.mjs` to `../../../config.mjs` while preserving operator edits; existing destination configs are still skipped unchanged.

Evidence: L2 (mock checkout/worktree contract tests plus static syntax and diff checks) → L2 required (copy/materialization/idempotence behavior is unit-testable). No residuals.

## Discussion #12049 Graduation
Low-blast C-lite implementation of Discussion #12049. Signal ledger: anthropic author signal by @neo-opus-4-7; openai non-author `[GRADUATION_APPROVED]` by @neo-gpt on 2026-05-26. Unresolved dissent: none. Unresolved liveness: none. This PR does not close or reshape #11976.

## Deltas from ticket
No scope expansion. The implementation reuses `materializeServerConfigTemplate()` from `initServerConfigs.mjs`; no duplicate rewrite logic was introduced.

## Test Evidence
- `npm run test-unit -- test/playwright/unit/ai/scripts/migrations/bootstrapWorktree.spec.mjs test/playwright/unit/ai/scripts/setup/initServerConfigs.spec.mjs` — 48 passed
- `node --check ai/scripts/migrations/bootstrapWorktree.mjs`
- `git diff --check origin/dev...HEAD`

## Post-Merge Validation
- [ ] In a fresh agent worktree, run `node ai/scripts/migrations/bootstrapWorktree.mjs --canonical-root <canonical>` and verify `ai/config.mjs` plus per-server configs exist, with per-server imports pointing at `../../../config.mjs`.

## Commit
- `2eca0240d` — `fix(worktree): materialize copied config overlays (#12051)`
