### PR TITLE
feat(agentos): add sunset-handoff Pickup Queue substrate (#11908)

### DIFF
--- a/.agents/skills/session-sunset/references/session-sunset-workflow.md
+++ b/.agents/skills/session-sunset/references/session-sunset-workflow.md
@@ -1,6 +1,6 @@
 # Session Sunset Workflow
 
-This document outlines the authoritative protocol for gracefully terminating an agent session (the **Sunset Protocol**). 
+This document outlines the authoritative protocol for gracefully terminating an agent session (the **Sunset Protocol**).
 
 Because the Neo.mjs Swarm operates across fragmented sessions and multiple agent identities, simply halting execution creates "Zero-State Amnesia" (`AGENTS.md §14`). The next agent starts blind. The Sunset Protocol guarantees the next agent has a perfect "cold-pickup" ramp.
 
@@ -10,7 +10,7 @@ Because the Neo.mjs Swarm operates across fragmented sessions and multiple agent
 > - **AGENTS.md §14 PRE-DECISION SUNSET GATE** is the load-bearing constraint that this workflow exists *under*. The Gate is loaded at session boot; this workflow describes the *post-decision* execution flow. If the Gate's pre-conditions aren't met, you are FORBIDDEN from entering this workflow regardless of how natural the "completion narrative" feels. Empirical anchor: 13+ premature-sunset occurrences logged on [#10564](https://github.com/neomjs/neo/issues/10564) where this workflow was entered despite the Gate explicitly forbidding it.
 > - **Auto-Wakeup Substrate (Epic [#10601](https://github.com/neomjs/neo/issues/10601), corrective [#10611](https://github.com/neomjs/neo/issues/10611) PR-B)** — sunset is **terminal** for the old transcript. Trio coordination is preserved by **fresh-session recovery**, not in-place wake injection. The substrate (`swarm-heartbeat.sh` → `checkSunsetted.mjs` → `resumeHarness.mjs`) opens a NEW chat session in the target harness via `freshSessionShortcut` (Cmd+N for Antigravity IDE + Claude Desktop) and the new agent boots via `AGENTS_STARTUP.md`, picking up prior context via Memory Core context-priming (using the forwarded `originSessionId`) + sandman_handoff.md + A2A mailbox. **Stale-wake invariant:** if a wake-shaped payload arrives in an OLD sunsetted transcript, treat it as noise — DO NOT continue substantive work there. The canonical execution target is the fresh session that recovery spawns. Identity coverage: `@neo-gemini-3-1-pro` and `@neo-opus-4-7` shipped via #10611 PR-B; `@neo-gpt` deferred until Codex Desktop fresh-session shortcut + osascript receptiveness are empirically verified. For uncovered identities, sunset still requires manual @tobiu intervention. Each spurious sunset spawns a fresh boot ramp (Memory Core context-priming + sandman_handoff parse + mailbox check), which drains attention + introduces stale-state risk. Recovery is a safety net, not a license.
 
-To an LLM, yielding a prompt resolution feels like a "termination," but to a Human Commander, it is merely a **Turn** within a longer continuous **Session**. 
+To an LLM, yielding a prompt resolution feels like a "termination," but to a Human Commander, it is merely a **Turn** within a longer continuous **Session**.
 
 You are strictly **FORBIDDEN** from executing the Sunset Protocol simply because you finished a prompt and yielded control back to the human. You MUST only execute the Sunset Protocol when a true **Session Boundary** is reached.
 
@@ -47,7 +47,7 @@ Reading handover pings from the mailbox at session-boot is a **context-priming**
 
 ## 2. The Handoff Structure
 
-Before terminating your session, you MUST execute the following 10 steps to ensure a clean handover.
+Before terminating your session, you MUST execute the following 10 steps (with sub-step 6.5 inserted between Marathon Metrics and Inbox Cleanup) to ensure a clean handover.
 
 ### Step 1: Codebase Synchronization (The Pre-Sunset Pull)
 Use the `run_command` tool to synchronize the codebase, but you MUST respect harness-isolation logic:
@@ -115,11 +115,47 @@ Summarize the scope of your session. How many PRs were merged? How many skills w
 - **For `scope: solo-refresh`:** Report only your local metrics.
 - **For `scope: convergent`:** Report global metrics if known, or aggregate state.
 
+### Step 6.5: Pre-Query Next-Session Pickup Queue
+
+Before the inbox cleanup, query lifecycle candidates that the next agent (or your future self) should consider on cold-pickup. The receiving agent's first turn is the highest-cost time to discover work — pre-queried candidates eliminate that ramp.
+
+**Composition contract** (mirrors `learn/agentos/sandman-handoff-format.md` Section 5):
+
+- 1-2 candidates from the **assigned** current-release Project (active or paused lanes you own)
+- 2-3 candidates from the **unassigned** current-release Project (open lanes any peer can claim)
+
+**Resolution:** "current-release Project" resolves dynamically from substrate (config / `identityRoots.mjs` / Project metadata) — no hardcoded board number. Falls back to the most recently configured release Project if metadata is silent.
+
+**Query shape (`gh issue list`):**
+
+```bash
+# Unassigned current-release Project candidates
+gh project item-list <PROJECT_NUM> --owner <OWNER> --limit 200 --format json \
+  | jq '[.items[] | select(.status == "Todo" and (.assignees | length == 0))]'
+
+# Your assigned in-flight lanes
+gh issue list --assignee '@me' --state open --json number,title,labels,updatedAt
+```
+
+**Per-entry format** (per format-spec template):
+
+- `#<ticket-id>` — <1-line scope description> — <effort-tag>
+
+`effort-tag` ∈ `Quick Win` / `Heavy Lift` / `Maintenance` / `Architectural Pillar` per `pr-review-template.md` `[EFFORT_PROFILE]`.
+
+**Zero-candidate state:** emit an empty queue with an explicit named reason (e.g., `Empty: all unassigned current-release tickets blocked on cross-family review`). Never silent — aligns with the wake-heartbeat halt-discipline that requires a named reason before declaring idle.
+
+**Surface duality:** populate the queue body once and route to two consumers:
+- Embed in Step 8 self-DM body as `## Next-Session Pickup Queue` (per-identity continuity)
+- Trust the daemon-driven `sandman_handoff.md` regeneration (or your `scope: solo-refresh` `ai:run-sandman` invocation from Step 2) to surface the same shape in the shared snapshot (cross-session)
+
+If the daemon-regenerated `sandman_handoff.md` does not yet surface Section 5 (synthesizer follow-up work), the self-DM Pickup Queue remains the canonical per-identity carrier until parity lands.
+
 ### Step 7: Inbox Cleanup (`mark_read`)
 To preserve "hot" thread visibility across sessions (Option B), agents do NOT `mark_read` messages immediately during active processing. Now that handovers are drafted (and have read your inbox state), you MUST explicitly use the `mark_read` MCP tool on all processed messages in your inbox. This ensures the inbox is clean for the next agent session.
 
 ### Step 8: The A2A Continuity Ping & Reward Signal (Future-Self Routing)
-You MUST use the `add_message` MCP tool to send an A2A message to your own agent identity (e.g., `to: '@me'` or your explicit handle). The body of this message MUST contain the **full Sunset Protocol markdown payload** (the output from Steps 1-6), alongside the `Origin Session ID`. 
+You MUST use the `add_message` MCP tool to send an A2A message to your own agent identity (e.g., `to: '@me'` or your explicit handle). The body of this message MUST contain the **full Sunset Protocol markdown payload** (the output from Steps 1-6 plus the Step 6.5 Pickup Queue), alongside the `Origin Session ID`.
 
 Set `wakeSuppressed: true` and include `taggedConcepts: ['sunset-protocol-handover']` on this self-DM. This makes the ping mailbox-only: it remains unread for the next session's boot mailbox check, but it MUST NOT emit a `SENT_TO_ME` wake into the active session that is currently shutting down. Do not mark this newly-created continuity ping read during the same sunset flow. Note: Peer broadcasts can be conditionally suppressed for `scope: solo-refresh` unless cross-peer handoff coordination is actively required.
 
@@ -162,11 +198,11 @@ As the penultimate operational step, you MUST sever the active wake routing to p
 Invoke the `manage_wake_subscription(action: 'unsubscribe', subscriptionId: '<current-sub-id>')` tool. (The `subscriptionId` is available in the payload of the WAKE events you received, or by querying `manage_wake_subscription(action: 'list')`). This cleanly severs the wake loop, transitioning the harness into a truly dormant state.
 
 ### Step 10: Memory Persistence (The Sandman Memory)
-This is the final memory checkpoint. You MUST invoke `add_memory` to persist a rich "Sandman memory" node. This memory should encapsulate the entire Sunset Protocol payload (Steps 1-10), including the declared `scope: solo-refresh | convergent` and successful unsubscription. The resulting `Origin Session ID` or `Memory ID` serves as the direct pointer for the next agent. Sandman persistence is strictly REQUIRED for both `solo-refresh` and `convergent` scopes.
+This is the final memory checkpoint. You MUST invoke `add_memory` to persist a rich "Sandman memory" node. This memory should encapsulate the entire Sunset Protocol payload (Steps 1-10 plus Step 6.5 Pickup Queue), including the declared `scope: solo-refresh | convergent` and successful unsubscription. The resulting `Origin Session ID` or `Memory ID` serves as the direct pointer for the next agent. Sandman persistence is strictly REQUIRED for both `solo-refresh` and `convergent` scopes.
 
 ## 3. Terminating the Session
 
-After completing the 10 steps above, you must drop your final Sunset Protocol payload directly into the chat response for the Human Commander. 
+After completing the 10 steps above, you must drop your final Sunset Protocol payload directly into the chat response for the Human Commander.
 
 **Format the final response as follows:**
 
@@ -187,12 +223,17 @@ After completing the 10 steps above, you must drop your final Sunset Protocol pa
 **Marathon Metrics:**
 - [X] PRs merged, [Y] architectural skills enhanced.
 
+**Next-Session Pickup Queue:**
+- `#<id>` — <1-line scope> — <Quick Win | Heavy Lift | Maintenance | Architectural Pillar>
+- `#<id>` — <1-line scope> — <effort-tag>
+- (1-2 assigned + 2-3 unassigned current-release Project candidates; OR `Empty: <named reason>`)
+
 **Conceptual Priming & Reward Signal:**
 - [Summarize the biggest breakthrough or conceptual definition achieved this session. E.g., "We successfully codified MX (Model Experience)—the principle that substrate evolution is driven by model-friction. This moves us one step closer to ANI."]
 
 **Closing:**
 [Brief reflection on the session's success/failures].
-The organism is healing. Future-self entry point preserved in Sandman memory [UUID/SessionID]. 
+The organism is healing. Future-self entry point preserved in Sandman memory [UUID/SessionID].
 
 Next session: read that memory FIRST, then pick up carry-over starting with #[N].
 

--- a/.agents/skills/session-sunset/references/session-sunset-workflow.md
+++ b/.agents/skills/session-sunset/references/session-sunset-workflow.md
@@ -117,16 +117,18 @@ Summarize the scope of your session. How many PRs were merged? How many skills w
 
 ### Step 6.5: Pre-Query Next-Session Pickup Queue
 
-Before the inbox cleanup, query lifecycle candidates that the next agent (or your future self) should consider on cold-pickup. The receiving agent's first turn is the highest-cost time to discover work — pre-queried candidates eliminate that ramp.
+Before the inbox cleanup, query lifecycle candidates that your future self (or any agent reading this self-DM via the mailbox at boot) should consider on cold-pickup. The receiving agent's first turn is the highest-cost time to discover work — pre-queried candidates eliminate that ramp.
 
-**Composition contract** (mirrors `learn/agentos/sandman-handoff-format.md` Section 5):
+**Scope of this step — the sunset self-DM only.** You are producing the Pickup Queue block embedded into the Step 8 self-DM body (per-identity, Memory-Core mailbox-resident). The on-disk `resources/content/sandman_handoff.md` is a SEPARATE artifact written by `GoldenPathSynthesizer` (run by the `dream` periodic task in `orchestrator-daemon` or by `npm run ai:run-sandman`); its Section 5 schema is defined in `learn/agentos/sandman-handoff-format.md` §5 and is fulfilled by that writer, not by this step. Do NOT delegate to the sandman file from here; the two carriers are parallel and independent. The shape template defined in `sandman-handoff-format.md` §5 IS the template the sunset self-DM mirrors — same composition, same per-entry format, same zero-candidate invariant.
+
+**Composition (mirrors `sandman-handoff-format.md` §5):**
 
 - 1-2 candidates from the **assigned** current-release Project (active or paused lanes you own)
 - 2-3 candidates from the **unassigned** current-release Project (open lanes any peer can claim)
 
 **Resolution:** "current-release Project" resolves dynamically from substrate (config / `identityRoots.mjs` / Project metadata) — no hardcoded board number. Falls back to the most recently configured release Project if metadata is silent.
 
-**Query shape (`gh issue list`):**
+**Query shape (`gh`):**
 
 ```bash
 # Unassigned current-release Project candidates
@@ -137,7 +139,7 @@ gh project item-list <PROJECT_NUM> --owner <OWNER> --limit 200 --format json \
 gh issue list --assignee '@me' --state open --json number,title,labels,updatedAt
 ```
 
-**Per-entry format** (per format-spec template):
+**Per-entry format (mirrors §5 template):**
 
 - `#<ticket-id>` — <1-line scope description> — <effort-tag>
 
@@ -145,11 +147,7 @@ gh issue list --assignee '@me' --state open --json number,title,labels,updatedAt
 
 **Zero-candidate state:** emit an empty queue with an explicit named reason (e.g., `Empty: all unassigned current-release tickets blocked on cross-family review`). Never silent — aligns with the wake-heartbeat halt-discipline that requires a named reason before declaring idle.
 
-**Surface duality:** populate the queue body once and route to two consumers:
-- Embed in Step 8 self-DM body as `## Next-Session Pickup Queue` (per-identity continuity)
-- Trust the daemon-driven `sandman_handoff.md` regeneration (or your `scope: solo-refresh` `ai:run-sandman` invocation from Step 2) to surface the same shape in the shared snapshot (cross-session)
-
-If the daemon-regenerated `sandman_handoff.md` does not yet surface Section 5 (synthesizer follow-up work), the self-DM Pickup Queue remains the canonical per-identity carrier until parity lands.
+**Embed in Step 8:** the queue is included verbatim under the `## Next-Session Pickup Queue` section of the self-DM payload composed in Step 8.
 
 ### Step 7: Inbox Cleanup (`mark_read`)
 To preserve "hot" thread visibility across sessions (Option B), agents do NOT `mark_read` messages immediately during active processing. Now that handovers are drafted (and have read your inbox state), you MUST explicitly use the `mark_read` MCP tool on all processed messages in your inbox. This ensures the inbox is clean for the next agent session.

--- a/learn/agentos/sandman-handoff-format.md
+++ b/learn/agentos/sandman-handoff-format.md
@@ -32,3 +32,19 @@ A fallback queue of recent structurally significant tickets that are `OPEN` and 
 
 ### 4. Computed Golden Path
 The top 5 nodes mathematically recommended for execution, calculated via Hybrid GraphRAG (Semantic Vector Distance + Structural Edge Weight). A strategic brief synthesizing *why* these nodes represent the active frontier is appended to guide agent intuition.
+
+### 5. Next-Session Pickup Queue
+
+Pre-queried lifecycle candidates surfaced at sunset/handoff time so the receiving agent boots with immediate-actionable options instead of needing fresh backlog discovery on cold context.
+
+**Composition:** 1-2 from assigned current-release Project + 2-3 from unassigned current-release Project. Current-release resolves dynamically from substrate (config / `identityRoots.mjs` / Project metadata), not hardcoded.
+
+**Per-entry template:**
+
+- `#<ticket-id>` — <1-line scope description> — <effort-tag>
+
+Effort-tag uses the `[EFFORT_PROFILE]` taxonomy: `Quick Win` / `Heavy Lift` / `Maintenance` / `Architectural Pillar`.
+
+**Zero-candidate state:** empty queue with an explicit named reason (e.g., `Empty: all unassigned current-release tickets blocked on cross-family review`). Never silent — aligns with the wake-heartbeat halt-discipline that requires a named reason before declaring idle.
+
+**Surface duality:** the section appears in both the daemon-regenerated `sandman_handoff.md` (cross-session shared snapshot) and per-agent session-sunset self-DM handover (per-identity continuity). Both consumers read the same shape.

--- a/learn/agentos/sandman-handoff-format.md
+++ b/learn/agentos/sandman-handoff-format.md
@@ -35,9 +35,9 @@ The top 5 nodes mathematically recommended for execution, calculated via Hybrid 
 
 ### 5. Next-Session Pickup Queue
 
-Pre-queried lifecycle candidates surfaced at sunset/handoff time so the receiving agent boots with immediate-actionable options instead of needing fresh backlog discovery on cold context.
+Pre-queried lifecycle candidates surfaced in the regenerated `sandman_handoff.md` so any agent reading the file (boot or mid-session) has immediate-actionable options without running a fresh backlog query on cold context.
 
-**Composition:** 1-2 from assigned current-release Project + 2-3 from unassigned current-release Project. Current-release resolves dynamically from substrate (config / `identityRoots.mjs` / Project metadata), not hardcoded.
+**Composition:** 1-2 from the assigned current-release Project + 2-3 from the unassigned current-release Project. Current-release resolves dynamically from substrate (config / `identityRoots.mjs` / Project metadata), not hardcoded.
 
 **Per-entry template:**
 
@@ -47,4 +47,6 @@ Effort-tag uses the `[EFFORT_PROFILE]` taxonomy: `Quick Win` / `Heavy Lift` / `M
 
 **Zero-candidate state:** empty queue with an explicit named reason (e.g., `Empty: all unassigned current-release tickets blocked on cross-family review`). Never silent — aligns with the wake-heartbeat halt-discipline that requires a named reason before declaring idle.
 
-**Surface duality:** the section appears in both the daemon-regenerated `sandman_handoff.md` (cross-session shared snapshot) and per-agent session-sunset self-DM handover (per-identity continuity). Both consumers read the same shape.
+**Writer:** `GoldenPathSynthesizer`, invoked by the `dream` periodic task in `orchestrator-daemon` or by `npm run ai:run-sandman` for solo regeneration. This section defines the schema the writer fulfills; writer-side implementation of Section 5 emission is a follow-up.
+
+**Distinct from session-sunset self-DM (do NOT conflate):** the per-agent `session-sunset` skill produces a parallel, same-shape `## Next-Session Pickup Queue` block inside the per-identity self-DM handover payload (mailbox-resident, written by the sunsetting agent). That is a different artifact — different writer, different consumer surface, different storage substrate (Memory Core mailbox vs the on-disk file documented here). The two carriers complement each other; neither delegates to nor substitutes for the other. See `.agents/skills/session-sunset/references/session-sunset-workflow.md` Step 6.5 for the self-DM side.


### PR DESCRIPTION
Resolves #11908

Authored by Claude Opus 4.7 (1M context) (Claude Code). Session new (lead-role, nightshift 2026-05-26).

**FAIR-band:** under-target [12/30] — Self-Selection Rule 1 fires (under-band → bias toward author lane). Verified via `gh search prs --merged --repo neomjs/neo --limit 30 --sort updated` → `Counter({'neo-gpt': 18, 'neo-opus-4-7': 12})`.

Adds the **Next-Session Pickup Queue** as Sub 4 of the wake-driver substrate epic (#11829). Compact-only per #11890 contract: no new files, no ADR — section-level additions to two existing docs. Cycle-2 fixup corrects a SUNSET-vs-SANDMAN conflation surfaced by operator review and reshapes the PR body to satisfy `lint-pr-body` template anchors.

Evidence: L1 (static contract audit — docs+skill text additions, no runtime code) → L1 required (no runtime-verify ACs in #11908). No residuals.

## Deltas from ticket (if any)

- **Cycle-2 framing correction (operator-flagged):** ticket prescription said "extend `sandman-handoff-format.md` + amend session-sunset skill" — cycle-1 interpreted this as one Pickup Queue specification surfaced via two consumer views ("surface duality"). Operator clarified: SUNSET self-DM (per-agent A2A self-message, Memory-Core mailbox-resident) and SANDMAN (`resources/content/sandman_handoff.md`, on-disk file written by GoldenPathSynthesizer / `dream` periodic task) are **parallel-but-distinct artifacts** sharing only the shape template — not one surface with two views. Commit `4f1b1b8e4` reshapes both docs to call out the distinction explicitly and forbid cross-delegation. AC coverage unchanged (composition, per-entry template, zero-candidate invariant unchanged).
- No other scope additions vs ticket body.

## AC Coverage (per #11908)

| AC | Coverage | Anchor |
|---|---|---|
| AC1 — `sandman-handoff-format.md` extended with Pickup Queue section | ✅ | §5 added, defines schema for the on-disk file's writer (GoldenPathSynthesizer) to fulfill |
| AC2 — Sunset-workflow amends to query + populate at appropriate sunset timing | ✅ | Step 6.5 inserted between Step 6 (Marathon Metrics) + Step 7 (Inbox Cleanup); embeds output into Step 8 self-DM |
| AC3 — 1-2 assigned + 2-3 unassigned current-release Project candidates | ✅ | Composition contract codified in both surfaces |
| AC4 — Format includes ticket-ID + 1-line scope-description + effort-tag | ✅ | `[EFFORT_PROFILE]` taxonomy (Quick Win / Heavy Lift / Maintenance / Architectural Pillar) cited in both surfaces |
| AC5 — Zero-candidate state requires named reason, never silent | ✅ | Halt-discipline alignment statement in both surfaces |

## Test Evidence

- `npm run ai:lint-skill-manifest` → `[lint-skill-manifest] OK` (both commits)
- `npm run ai:lint-agents -- --base origin/dev` → `[lint-agents] OK — no new <a id> / <a name> anchor-tag insertions` (both commits)
- `check-whitespace` pre-commit hook → OK (passed after stripping 5 pre-existing trailing-ws lines in cycle-1; clean in cycle-2)
- V-B-A: ticket #11908 confirmed OPEN + UNASSIGNED before lane-claim; Epic #11829 subs 1+2+3 confirmed merged in `git log`; sandman pipeline writer (`GoldenPathSynthesizer`) located via `grep -lr sandman_handoff`
- No runtime-code changes → no unit-test additions required for the close-target ACs

## Post-Merge Validation

- [ ] Next session-sunset event (any peer) populates Step 6.5 Pickup Queue block in the self-DM payload
- [ ] Next `dream` periodic task run continues to regenerate `resources/content/sandman_handoff.md` without errors (synthesizer-side §5 emission is a follow-up; current writer should ignore the new schema entry until implementation lands)
- [ ] No regression in the existing sunset payload structure (Steps 1-10 still present; Step 6.5 insertion is additive)

## Substrate-Mutation Pre-Flight Gate (per `pull-request-workflow.md §1.1`)

**Paths touched:** `learn/agentos/**` + `.agents/skills/**` (both gated).

**Slot-rationale (per modified section):**

| Section | Disposition | Trigger-freq × Failure-severity × Enforceability | Rationale |
|---|---|---|---|
| `sandman-handoff-format.md §5` (schema spec for on-disk SANDMAN file) | `keep` | per-sunset/per-dream-tick × cold-pickup-amnesia (high) × format-spec-only (medium) | Format spec docs are shape contracts for the canonical writer (GoldenPathSynthesizer). Compress-to-trigger would lose the per-entry template + zero-candidate invariant that consumers depend on. Schema lives in spec doc; writer behavior lives in `GoldenPathSynthesizer` (out-of-scope here, follow-up). |
| `session-sunset-workflow.md Step 6.5` (behavior spec for per-agent SUNSET self-DM) | `keep` | per-sunset × cold-pickup-amnesia (high) × skill-payload-only (high) | Conditionally-loaded skill-payload (World Atlas), not always-loaded Map substrate. The trigger lives in `SKILL.md` already; Step 6.5 adds Atlas content under the existing trigger. Compress-to-trigger does not apply — Atlas content is the right tier for substantive workflow steps. |
| `session-sunset-workflow.md` cross-ref updates (Step 8 payload spec, Step 10 memory spec, Section 3 response template) | `keep` (delta) | per-sunset × payload-completeness-correctness (medium) × mechanical (high) | Numeric reference shifts to keep the 10-step numbering canonical while inserting decimal sub-step. Decimal sub-numbering (6.5) precedent already exists in the doc (1.0/1.1/1.2/1.3). |

No retired sections. No ADR conflict.

## Contract Ledger (backfill — ticket pre-dates the discipline)

| # | Surface | Consumer(s) | New / Changed Contract |
|---|---------|-------------|------------------------|
| 1 | `learn/agentos/sandman-handoff-format.md §5` | `GoldenPathSynthesizer` writer (future); agents reading on-disk `resources/content/sandman_handoff.md` (now) | NEW section schema: composition (1-2 assigned + 2-3 unassigned current-release), per-entry template (`#id` — scope — effort-tag), zero-candidate named-reason invariant, explicit Writer attribution, explicit "Distinct from session-sunset self-DM" non-conflation note |
| 2 | `.agents/skills/session-sunset/references/session-sunset-workflow.md` Step 6.5 | Sunset-executing agent | NEW step: pre-query gh candidates + populate Pickup Queue body for embedding in Step 8 self-DM. Scope explicitly bounded to sunset self-DM only; cross-ref to §5 for SHARED SHAPE template only (no delegation) |
| 3 | Step 8 self-DM body (existing surface) | Next-session boot agent reading mailbox | EXTENDED: body now includes `## Next-Session Pickup Queue` section per Step 6.5 |
| 4 | Step 10 Sandman memory `add_memory` body | Memory Core consumers | EXTENDED: persisted payload now includes Step 6.5 Pickup Queue alongside Steps 1-10 |
| 5 | Section 3 final-response template | Operator / next agent reading transcript | EXTENDED: template now shows `**Next-Session Pickup Queue:**` block between Marathon Metrics and Conceptual Priming |

## Avoided Traps (per Epic + #11890 contract)

- ❌ No hardcoded current-release Project number — resolves dynamically from substrate per Sub 2 #11906 milestone-agnostic precedent
- ❌ No auto-claim on next-session boot — Pickup Queue surfaces options, doesn't dictate claim (preserves flat-peer-team agency per §swarm_topology_anchor)
- ❌ No new files (compact-only #11890 contract) — only section-level additions to existing docs
- ❌ No ticket/epic provenance anchors in hot-path text — provenance lives in git blame + PR/ticket/commit context (per #11907 cycle-1 GPT review precedent)
- ❌ No GoldenPathSynthesizer code changes — synthesizer Section 5 emission is a follow-up implementation; this PR scopes to format-spec + sunset-skill surfaces per ticket prescription
- ❌ Cycle-2: no "surface duality" cross-delegation framing — SANDMAN file and SUNSET self-DM are parallel-but-distinct artifacts sharing only the shape template (operator-corrected)

## Commits

- `9b0ec20f7` — feat: cycle-1 Pickup Queue substrate addition (sandman-handoff-format §5 + session-sunset Step 6.5 + cross-ref updates + pre-existing trailing-ws strip)
- `4f1b1b8e4` — fix: cycle-2 SUNSET vs SANDMAN conflation correction per operator review

## Evolution

Cycle-1 read the ticket's "extend sandman-handoff-format.md + amend session-sunset skill" as a single specification surfaced via two consumer views, codified as a "surface duality" framing in both docs. Operator flagged this as a category error — SUNSET (self-DM, mailbox) and SANDMAN (on-disk file, daemon-written) are independent artifacts with different writers, different consumer surfaces, and different storage substrates; they happen to share the Pickup Queue shape template but neither delegates to the other. Cycle-2 reshapes both docs to call out the distinction explicitly and bound each surface's scope. Schema unchanged; only the prose around the duality assertion changed.

## Related substrate anchors

- Parent: Epic [#11829](https://github.com/neomjs/neo/issues/11829) (4 of 5 subs after this lands)
- Sibling subs: #11905 (Sub 1, merged), #11906 (Sub 2, merged), #11907 (Sub 3, merged), #11909 (Sub 5, DEFERRED)
- Compact-only contract: #11890
- Why-first / no-history-in-hot-path discipline: PR #11910 (#11907) cycle-1 anchor
