### PR TITLE
chore(ai): clean shared mcp comments (#11924)

### DIFF
--- a/ai/mcp/server/github-workflow/toolService.mjs
+++ b/ai/mcp/server/github-workflow/toolService.mjs
@@ -101,11 +101,11 @@ const syncAllOnDevOnly = buildDevBranchGuard(SyncService.runFullSync.bind(SyncSe
  * `syncAllOnDevOnly` test-surface precedent below.
  *
  * @param {Object|Number} options `pr_number` XOR `issue_number`, plus optional selectors.
- *                                A bare number is the legacy positional PR form.
+ *                                A bare number is the backward-compatible positional PR form.
  * @returns {Promise<Object>} Conversation data or a structured error.
  */
 async function getConversationRouter(options) {
-    // Legacy positional number form is always a pull request.
+    // Backward-compatible positional number form is always a pull request.
     if (typeof options === 'number') {
         return PullRequestService.getConversation(options);
     }

--- a/ai/mcp/server/shared/services/DestructiveOperationGuard.mjs
+++ b/ai/mcp/server/shared/services/DestructiveOperationGuard.mjs
@@ -19,13 +19,10 @@ export const DESTRUCTIVE_PRODUCTION_CONFIRMATION = 'CONFIRM_PRODUCTION_DESTRUCTI
  * - `neo-agent-graph`    — Memory Core graph collection (`aiConfig.collections.graph`).
  * - `neo-knowledge-base` — Knowledge Base canonical collection (`aiConfig.collectionName`).
  *
- * Names are hardcoded (not derived from config) so a caller that loads a misconfigured
- * `config.mjs` (e.g., running `npx playwright` without the unit-test config) still gets
- * the canonical name blocked. The empirical anchor is the 2026-05-17 Memory Core wipe,
- * where `aiConfig.collections.memory` returned canonical `'neo-agent-memory'` because
- * `UNIT_TEST_MODE` was absent in the bare-playwright invocation environment.
- *
- * @see https://github.com/neomjs/neo/issues/11652
+ * Names are hardcoded (not derived from config) so a caller that loads runtime config
+ * without the unit-test isolation layer still gets the canonical name blocked. This
+ * keeps test harness mistakes from resolving destructive targets to production
+ * collection names.
  */
 export const GUARDED_CANONICAL_COLLECTION_NAMES = Object.freeze(new Set([
     'neo-agent-memory',

--- a/ai/mcp/server/shared/services/RequestContextService.mjs
+++ b/ai/mcp/server/shared/services/RequestContextService.mjs
@@ -2,12 +2,12 @@ import { AsyncLocalStorage } from 'async_hooks';
 import Base from '../../../../../src/core/Base.mjs';
 
 /**
- * @summary Sentinel `userId` value tagging records that belong to the historical commons —
+ * @summary Sentinel `userId` value tagging records that belong to the shared baseline —
  * accessible to all tenants via the additive read filter.
  *
  * Reads in tenant-aware mode use `where: {$or: [{userId: <current>}, {userId: SHARED_USER_ID}]}`,
  * granting every authenticated tenant access to their own data PLUS the shared baseline.
- * The migration runner (`ai/scripts/migrations/backfillChromaSharedUserId.mjs`) tags legacy
+ * The migration runner (`ai/scripts/migrations/backfillChromaSharedUserId.mjs`) tags unscoped
  * ChromaDB records lacking a `userId` key with this sentinel so the additive
  * read filter can return them. New raw-memory writes tag with the resolved per-tenant userId;
  * session summaries involving named core swarm maintainers intentionally use `SHARED_USER_ID`
@@ -134,7 +134,7 @@ export function resolveSummaryVisibilityUserId({userId, participatingAgents} = {
  * any of the primitive leaking into their method signatures.
  *
  * **Module-level exports:**
- * - {@link SHARED_USER_ID} — sentinel value for legacy/commons records
+ * - {@link SHARED_USER_ID} — sentinel value for shared-baseline records
  * - {@link normalizeUserId} — `@`-prefix stripping boundary helper
  * - {@link resolveSummaryVisibilityUserId} — summary visibility resolver for core-swarm artifacts
  *
@@ -162,7 +162,7 @@ export function resolveSummaryVisibilityUserId({userId, participatingAgents} = {
  * 4. **Unresolved-identity fallthrough:** when neither transport resolves a userId (stdio with
  *    neither env-var nor authenticated `gh` CLI, offline daemon contexts), `getUserId()` returns
  *    `undefined` and services fall back to **single-tenant mode** — no tag on writes, no filter
- *    on reads. This preserves the legacy single-tenant behavior.
+ *    on reads. This preserves compatibility with unauthenticated local tool sessions.
  *
  * **Why AsyncLocalStorage and not explicit parameter threading:** userId is a cross-cutting
  * concern that every ChromaDB touch point cares about. Threading it as a parameter through
@@ -292,7 +292,7 @@ class RequestContextService extends Base {
      *
      * Extracted from the `Mcp-Session-Id` header by `TransportService`.
      * This is the primary driver for multi-tenant isolation in the Memory Core.
-     * When present, it completely overrides the legacy process-global fallback
+     * When present, it completely overrides the process-global fallback
      * in `SessionService`.
      *
      * @returns {String|undefined}

--- a/ai/mcp/server/shared/services/StdioIdentityResolver.mjs
+++ b/ai/mcp/server/shared/services/StdioIdentityResolver.mjs
@@ -19,7 +19,7 @@ import Base       from '../../../../../src/core/Base.mjs';
  *    who have `gh` installed and authenticated. Matches the `@me` shortcut semantics used
  *    across the Agent OS tooling surface.
  * 3. **`unresolved`** — neither path yielded an identity. Downstream services treat this as
- *    **single-tenant mode** (the legacy unauthenticated transport behavior). Not a startup
+ *    **single-tenant mode** (the unauthenticated local transport fallback). Not a startup
  *    failure — preserves the existing local-agent developer experience.
  *
  * **Intentionally NOT in scope:**

--- a/ai/services/github-workflow/IssueService.mjs
+++ b/ai/services/github-workflow/IssueService.mjs
@@ -179,7 +179,7 @@ class IssueService extends Base {
      * - `acknowledgedReassign: '<reason>'` — strict-replacement override. Clears existing
      *   assignees, assigns the new set, posts an audit-trail comment on the issue
      *   capturing the reason in a GitHub-visible artifact.
-     * - `requireUnassigned: false` — legacy blind-add (no precondition gate). Provided
+     * - `requireUnassigned: false` — compatibility blind-add (no precondition gate). Provided
      *   for backward-compat; new callers should not rely on this.
      *
      * **Co-owner-add deferral:** V1 supports only

--- a/ai/services/github-workflow/PullRequestService.mjs
+++ b/ai/services/github-workflow/PullRequestService.mjs
@@ -133,7 +133,7 @@ class PullRequestService extends Base {
      * selector to reduce context-fetch cost across review cycles.
      *
      * **Default behavior (no selectors):** returns full conversation — backward compatible
-     * with the legacy full-conversation shape that callers depend on.
+     * with the default full-conversation shape that existing callers depend on.
      *
      * **Selectors (first-match precedence, pick at most one):**
      * - `comment_id` — fetch ONLY the comment whose GitHub node ID matches. Used for A2A
@@ -151,8 +151,8 @@ class PullRequestService extends Base {
      * conversation sizes (up to a few dozen comments) client-side filter is simpler and
      * avoids multi-query cursor choreography.
      *
-     * @param {Object|number} options Either a number (legacy `prNumber` positional form, retained for
-     *                                backward compat) or an object with the shape below.
+     * @param {Object|number} options Either a number (backward-compatible `prNumber` positional form)
+     *                                or an object with the shape below.
      * @param {number}        options.pr_number         The pull request number (required when object form).
      * @param {string}        [options.comment_id]      Return only the matching comment's data; other
      *                                                  comments elided. PR title/body still returned.
@@ -164,7 +164,7 @@ class PullRequestService extends Base {
      * @returns {Promise<object>} Conversation data (optionally filtered) or a structured error.
      */
     async getConversation(options) {
-        // Accept legacy positional `prNumber` form for backward compatibility.
+        // Accept positional `prNumber` form for backward compatibility.
         // New callers use the object form for filter support.
         const {pr_number, comment_id, since_comment_id, last_n} = typeof options === 'number'
             ? {pr_number: options}

--- a/ai/services/github-workflow/sync/IssueSyncer.mjs
+++ b/ai/services/github-workflow/sync/IssueSyncer.mjs
@@ -383,8 +383,8 @@ class IssueSyncer extends Base {
             if (issue.oldVersion && issue.oldVersion !== version) {
                 // Suppress false-positive WARN volume during archive topology migrations. `oldVersion`
                 // derives from the cached path directory and can contain pre-cut title-derived strings
-                // that fail semver validation. Sealed-chunk enforcement already prevents those legacy
-                // buckets from causing actual moves, so only release-boundary recalculations where both
+                // that fail semver validation. Sealed-chunk enforcement already prevents those
+                // non-semver buckets from causing actual moves, so only release-boundary recalculations where both
                 // sides are valid semver remain WARN-worthy.
                 const oldIsValidTag = semver.valid(semver.clean(issue.oldVersion)) !== null;
                 const newIsValidTag = semver.valid(semver.clean(version))            !== null;

--- a/ai/services/github-workflow/sync/ReleaseNotesSyncer.mjs
+++ b/ai/services/github-workflow/sync/ReleaseNotesSyncer.mjs
@@ -77,7 +77,7 @@ class ReleaseNotesSyncer extends Base {
         const cachedReleases     = metadata.releases || {};
         const cachedReleaseArray = Object.values(cachedReleases);
 
-        // Phase 1: Quick check against the cached latest release
+        // Fast-path check against the cached latest release.
         if (cachedReleaseArray.length > 0) {
             try {
                 const latestData = await GraphqlService.query(FETCH_LATEST_RELEASE, {
@@ -86,7 +86,7 @@ class ReleaseNotesSyncer extends Base {
                 });
 
                 const latestRelease = latestData.repository.latestRelease;
-                // Sort by date to find the latest
+                // Sort by date to find the latest cached release.
                 cachedReleaseArray.sort((a, b) => new Date(a.publishedAt) - new Date(b.publishedAt));
                 const cachedLatest  = cachedReleaseArray[cachedReleaseArray.length - 1];
 
@@ -108,7 +108,7 @@ class ReleaseNotesSyncer extends Base {
             }
         }
 
-        // Phase 2: Full fetch with early exit
+        // Full paginated fetch with early exit.
         logger.info('Fetching releases from GitHub via GraphQL...');
 
         let allReleases   = [];


### PR DESCRIPTION
Authored by GPT-5 (Codex Desktop). Session d84ad2f1-c71c-4ce4-bec7-1167b9183637.

FAIR-band: over-target [18/30] — taking this lane despite over-target because #11924 is already assigned to @neo-gpt, no review-ready GPT-requested PR was available, and this is a narrow comment-only residual batch that avoids Claude active #11908/#12013 lanes and partner-tenant-sensitive deployment behavior.

Related: #11924
Related: #11912

Cleans the residual shared MCP and GitHub Workflow comment layer by replacing history-shaped wording with durable compatibility, fallback, and sync-contract descriptions. This batch keeps runtime behavior unchanged and leaves operator-visible strings / public contract references intact.

Evidence: L1 (comment-only static source diff, focused diagnostic, per-file syntax checks, diff whitespace checks) → L1 required (comment cleanup ACs; no runtime behavior ACs in this batch). Residual: remaining #11924 diagnostic matches are intentional false positives or runtime strings outside this comment-only batch.

## Deltas from ticket
This is a narrow residual batch after merged PRs #11949, #11972, and #12021. It deliberately does not rewrite stable cycle-template vocabulary, config date defaults, or runtime strings that cite public contract references.

## Test Evidence
- `node --check` on all 8 touched `.mjs` files.
- `git diff --check`
- `git diff --cached --check`
- `rg -n "#[0-9]{4,}|PR #[0-9]|AC[0-9]|Cycle|cycle-|202[0-9]|Phase [0-9]|temporary|legacy|TODO" ai/services/github-workflow ai/mcp/server/github-workflow ai/mcp/server/shared -g "*.mjs"` leaves only documented false positives: cycle-template vocabulary, config date defaults, and runtime strings/public contract references.
- `git log origin/dev..HEAD --format=%h%x09%s%n%b` confirmed no stale magic-close keyword for #11924.

## Post-Merge Validation
- [ ] Confirm #11924 remains open for any remaining grouped cleanup surfaces.

## Commits
- `e614a5d5f` — clean shared MCP/GitHub Workflow compatibility comments (#11924)