### PR TITLE
feat(buildScripts): add check-shorthand.mjs substrate gate (#11930)

### DIFF
--- a/buildScripts/util/check-shorthand.mjs
+++ b/buildScripts/util/check-shorthand.mjs
@@ -1,3 +1,4 @@
+import {program}            from 'commander';
 import {execSync, spawnSync} from 'node:child_process';
 import {readFileSync}        from 'node:fs';
 import path                  from 'node:path';
@@ -22,17 +23,31 @@ if (path.resolve(scriptRoot) !== path.resolve(gitRoot)) {
     process.exit(1);
 }
 
-const shorthandRegex = /^(\s+)([a-zA-Z_$][a-zA-Z0-9_$]*)\s*:\s*\2\s*[,}]/;
-const defaultDirs    = ['ai', 'src', 'test/playwright'];
+const DEFAULT_DIRS    = ['ai', 'src', 'test/playwright'];
+const DEFAULT_IGNORES = ['.claude', '.codex', 'dist', 'node_modules'];
+const SHORTHAND_RE    = /^(\s+)([a-zA-Z_$][a-zA-Z0-9_$]*)\s*:\s*\2\s*[,}]/;
+
+program
+    .name('check-shorthand')
+    .description('Substrate gate against `key: key` verbose-form regression in .mjs files.')
+    .argument('[files...]', 'Specific .mjs files to scan (lint-staged passes staged paths here). When omitted, falls back to scanning --dirs.')
+    .option('-d, --dirs <list>', 'Comma-separated directories to scan in default mode.', DEFAULT_DIRS.join(','))
+    .option('-i, --ignore <list>', 'Comma-separated path fragments to exclude from default-mode scan.', DEFAULT_IGNORES.join(','))
+    .option('-q, --quiet', 'Suppress the per-violation listing; print summary only.', false)
+    .showHelpAfterError();
+
+program.parse(process.argv);
+
+const argvFiles = program.args;
+const options   = program.opts();
+const scanDirs  = options.dirs.split(',').map(s => s.trim()).filter(Boolean);
+const ignores   = options.ignore.split(',').map(s => s.trim()).filter(Boolean);
 
 function collectDefaultFiles() {
-    const args = ['-type', 'f', '-name', '*.mjs',
-        '-not', '-path', '*/.claude/*',
-        '-not', '-path', '*/.codex/*',
-        '-not', '-path', '*/dist/*',
-        '-not', '-path', '*/node_modules/*'
-    ];
-    const result = spawnSync('find', [...defaultDirs, ...args], {cwd: gitRoot, encoding: 'utf-8'});
+    const findArgs = ['-type', 'f', '-name', '*.mjs'];
+    ignores.forEach(ignore => findArgs.push('-not', '-path', `*/${ignore}/*`));
+
+    const result = spawnSync('find', [...scanDirs, ...findArgs], {cwd: gitRoot, encoding: 'utf-8'});
     if (result.status !== 0) {
         console.error('\x1b[31mError: find command failed.\x1b[0m');
         console.error(result.stderr);
@@ -41,8 +56,7 @@ function collectDefaultFiles() {
     return result.stdout.trim().split('\n').filter(Boolean);
 }
 
-const argvFiles = process.argv.slice(2);
-const files     = argvFiles.length > 0
+const files = argvFiles.length > 0
     ? argvFiles.filter(f => f.endsWith('.mjs'))
     : collectDefaultFiles();
 
@@ -62,7 +76,7 @@ for (const file of files) {
     }
     const lines = content.split('\n');
     lines.forEach((line, index) => {
-        if (shorthandRegex.test(line)) {
+        if (SHORTHAND_RE.test(line)) {
             violations.push(`${file}:${index + 1}: ${line.trim()}`);
         }
     });
@@ -70,8 +84,10 @@ for (const file of files) {
 
 if (violations.length > 0) {
     console.error(`\x1b[31mcheck-shorthand: ${violations.length} verbose key:key form(s) found:\x1b[0m`);
-    violations.forEach(v => console.error('  ' + v));
-    console.error('\nUse ES2015 shorthand: {key} instead of {key: key}.');
+    if (!options.quiet) {
+        violations.forEach(v => console.error('  ' + v));
+        console.error('\nUse ES2015 shorthand: {key} instead of {key: key}.');
+    }
     process.exit(1);
 }
 

--- a/buildScripts/util/check-shorthand.mjs
+++ b/buildScripts/util/check-shorthand.mjs
@@ -1,0 +1,78 @@
+import {execSync, spawnSync} from 'node:child_process';
+import {readFileSync}        from 'node:fs';
+import path                  from 'node:path';
+import process               from 'node:process';
+import {fileURLToPath}       from 'node:url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname  = path.dirname(__filename);
+const scriptRoot = path.resolve(__dirname, '../..');
+
+let gitRoot;
+try {
+    gitRoot = execSync('git rev-parse --show-toplevel', {cwd: scriptRoot, encoding: 'utf-8'}).trim();
+} catch (e) {
+    console.error('\x1b[31mError: Could not determine git repository root.\x1b[0m');
+    process.exit(1);
+}
+
+if (path.resolve(scriptRoot) !== path.resolve(gitRoot)) {
+    console.error('\x1b[31mError: Script repository root mismatch.\x1b[0m');
+    console.error(`check-shorthand.mjs is located under '${scriptRoot}', but the git repository root is '${gitRoot}'.`);
+    process.exit(1);
+}
+
+const shorthandRegex = /^(\s+)([a-zA-Z_$][a-zA-Z0-9_$]*)\s*:\s*\2\s*[,}]/;
+const defaultDirs    = ['ai', 'src', 'test/playwright'];
+
+function collectDefaultFiles() {
+    const args = ['-type', 'f', '-name', '*.mjs',
+        '-not', '-path', '*/.claude/*',
+        '-not', '-path', '*/.codex/*',
+        '-not', '-path', '*/dist/*',
+        '-not', '-path', '*/node_modules/*'
+    ];
+    const result = spawnSync('find', [...defaultDirs, ...args], {cwd: gitRoot, encoding: 'utf-8'});
+    if (result.status !== 0) {
+        console.error('\x1b[31mError: find command failed.\x1b[0m');
+        console.error(result.stderr);
+        process.exit(1);
+    }
+    return result.stdout.trim().split('\n').filter(Boolean);
+}
+
+const argvFiles = process.argv.slice(2);
+const files     = argvFiles.length > 0
+    ? argvFiles.filter(f => f.endsWith('.mjs'))
+    : collectDefaultFiles();
+
+if (files.length === 0) {
+    console.log('check-shorthand: 0 .mjs files in scope, nothing to check.');
+    process.exit(0);
+}
+
+const violations = [];
+for (const file of files) {
+    let content;
+    try {
+        content = readFileSync(file, 'utf-8');
+    } catch (e) {
+        console.error(`check-shorthand: could not read ${file}: ${e.message}`);
+        continue;
+    }
+    const lines = content.split('\n');
+    lines.forEach((line, index) => {
+        if (shorthandRegex.test(line)) {
+            violations.push(`${file}:${index + 1}: ${line.trim()}`);
+        }
+    });
+}
+
+if (violations.length > 0) {
+    console.error(`\x1b[31mcheck-shorthand: ${violations.length} verbose key:key form(s) found:\x1b[0m`);
+    violations.forEach(v => console.error('  ' + v));
+    console.error('\nUse ES2015 shorthand: {key} instead of {key: key}.');
+    process.exit(1);
+}
+
+console.log(`check-shorthand: ${files.length} files scanned, 0 violations.`);

--- a/package.json
+++ b/package.json
@@ -227,6 +227,9 @@
     "lint-staged": {
         "*": [
             "node ./buildScripts/util/check-whitespace.mjs"
+        ],
+        "*.mjs": [
+            "node ./buildScripts/util/check-shorthand.mjs"
         ]
     }
 }


### PR DESCRIPTION
Resolves #11930

Authored by Claude Opus 4.7 (1M context) (Claude Code). Session new (lead-role, nightshift 2026-05-26).

**FAIR-band:** under-target [12/30] — Self-Selection Rule 1 fires (under-band → bias toward author lane).

Mechanical substrate gate against `key: key` verbose-form regression in `.mjs` files. Follows Neo's existing `buildScripts/util/check-*.mjs` convention rather than introducing an ESLint dependency (per #11926 cycle-1 V-B-A finding that Neo has no ESLint config). Closes the deferred AC2 from #11306.

Evidence: L1 (static contract audit — buildScripts utility script + lint-staged config; no Neo runtime touch) → L1 required. No residuals.

## Deltas from ticket (cycle-1 + cycle-2)

**Cycle-1 deltas:**
- **Dual-mode invocation**: ticket prescription showed standalone-scan-only; the implementation also supports lint-staged per-file invocation (argv files OR default scan).
- **Git-root verification**: lifted from `check-chore-sync.mjs` precedent. Prevents cross-checkout false diagnostics when invoked from a git worktree.
- **Default-dir exclusions extended**: ticket excluded `.claude/`, `dist/`, `node_modules/`; implementation also excludes `.codex/` (sibling agent harness scratch dir).

**Cycle-2 delta (operator review "why not use commander?"):**
- **Switched from bare `process.argv.slice(2)` to commander.** V-B-A confirmed `commander ^14.0.3` is in `package.json` and is the project's argv idiom (used in `defragChromaDB`, `mcpHealthcheck`, `kbPushClient`, `copyFolder`, `buildThreads`, etc.). Cycle-1 lifted the bare-argv shape from `check-whitespace.mjs` (closest sibling) — wrong precedent; sibling proximity doesn't override project standard.
- **New CLI surface:** `--dirs <list>` (default `ai,src,test/playwright`), `--ignore <list>` (default `.claude,.codex,dist,node_modules`), `--quiet` flag, auto-generated `--help`, `showHelpAfterError()`.
- **Side-finding from `--dirs buildScripts` ad-hoc test:** 5 real violations across docs SEO/release helpers plus checkReactiveTags: `buildScripts/docs/index/release.mjs:100` (`date   : date,`), `buildScripts/docs/seo/generate.mjs:245`/`:269`/`:306` (`filePath: filePath,` ×3), `buildScripts/helpers/checkReactiveTags.mjs:127` (`className: className,`). Out of #11306 sweep scope which covered `ai,src,test/playwright`; flagged as follow-up consideration (separate PR if you want a `buildScripts/` sweep added).

## AC Coverage (per #11930)

| AC | Coverage | Evidence |
|---|---|---|
| AC1 — `buildScripts/util/check-shorthand.mjs` created with regex + scan logic | ✅ | New file (94 lines post-cycle-2) |
| AC2 — `package.json` `lint-staged` extended for `*.mjs` files | ✅ | New `"*.mjs"` entry in lint-staged block (cycle-1) |
| AC3 — `node buildScripts/util/check-shorthand.mjs` exits 0 on current dev | ✅ | `1081 files scanned, 0 violations.` (exit 0) |
| AC4 — Pre-commit hook fires; verified via synthetic verbose-form test | ✅ | Indented `a: a,` in test file → exit 1 with violation listing |

## Test Evidence

**Cycle-2 (commander rewrite):**
- `node buildScripts/util/check-shorthand.mjs --help` → renders usage block with all options
- AC3 standalone (default `ai,src,test/playwright`): `1081 files scanned, 0 violations.` exit 0
- Lint-staged single-file: `1 files scanned, 0 violations.` exit 0
- AC4 indented violator (`{...\n    a: a,\n...}`): `1 verbose key:key form(s) found:` exit 1
- `--quiet` mode: summary-only output, exit 1 preserved
- `--dirs buildScripts` override: scans non-default dirs, surfaces 5 real violations (`release.mjs:100` `date`; `generate.mjs:245`/`:269`/`:306` `filePath` ×3; `checkReactiveTags.mjs:127` `className`)
- `--ignore` override: works as expected (custom path-fragment exclusions)
- `npm run ai:lint-skill-manifest` → `[lint-skill-manifest] OK`
- Pre-commit hook on cycle-2 commit ran successfully

## Post-Merge Validation

- [ ] After merge, run `node buildScripts/util/check-shorthand.mjs` on a fresh `git pull` of dev — expect "0 violations"
- [ ] Confirm pre-commit hook blocks a synthetic test commit that re-introduces `key: key` verbose form
- [ ] Monitor first 5-10 staged-`*.mjs` commits post-merge to confirm no false-positives interrupt normal author flow

## Substrate-Mutation Pre-Flight Gate

**Paths touched:** `buildScripts/util/check-shorthand.mjs` (new) + `package.json` (lint-staged config). Not gated under `pull-request-workflow.md §1.1` — neither path falls under `AGENTS.md` / `AGENTS_ATLAS.md` / `.agents/skills/**` / `learn/agentos/**`. Slot-rationale not required.

## Avoided Traps

- ❌ No ESLint dependency introduction — Neo has no ESLint config; following existing `check-*.mjs` convention preserves toolchain minimalism (per #11926 cycle-1 V-B-A finding)
- ❌ No false-positive on numeric keys (`0: 0`) — identifier-start anchor in regex per @neo-gpt #11926 cycle-1 review feedback
- ❌ Cycle-1 followed sibling-precedent (bare argv) instead of project standard (commander) — cycle-2 corrected via operator review surface
- ❌ Cycle-2 default `--dirs` deliberately matches #11306 sweep scope (ai/src/test/playwright); buildScripts/ violation flagged for separate decision rather than scope-creeping this PR

## Commits

- `1eed417ea` — cycle-1: check-shorthand.mjs + lint-staged wiring (bare argv)
- `a5debd4bb` — cycle-2: commander rewrite per operator review

## Related substrate anchors

- Parent intent: #11306 (original shorthand-form sweep; AC2 deferred to this follow-up)
- Sibling PR precedent: #11926 (the cycle-1 V-B-A that surfaced the ESLint mis-shape)
- Convention precedents: `buildScripts/util/check-whitespace.mjs`, `buildScripts/util/check-chore-sync.mjs` (bare-argv siblings, non-canonical pattern); `ai/scripts/maintenance/defragChromaDB.mjs` (canonical commander idiom)

