### PR TITLE
fix(ai): route Sandman graph providers explicitly (#12059)

### DIFF
--- a/ai/config.template.mjs
+++ b/ai/config.template.mjs
@@ -89,6 +89,15 @@ class Config extends BaseConfig {
          */
         modelProvider: 'gemini',
         /**
+         * @summary Provider selector for Dream/Sandman graph-generation work.
+         *
+         * Graph extraction deliberately does not use the generic chat provider axis:
+         * chat/summarization may use Gemini, while graph-generation dispatch only
+         * supports native Ollama or OpenAI-compatible endpoints.
+         * @type {String}
+         */
+        graphProvider: 'openAiCompatible',
+        /**
          * @summary Deployment-wide embedding provider selector.
          *
          * Shared by Memory Core embedding consumers and Knowledge Base ingestion
@@ -506,6 +515,7 @@ class Config extends BaseConfig {
         },
         chatProvider     : 'NEO_MODEL_PROVIDER',
         modelProvider    : 'NEO_MODEL_PROVIDER',
+        graphProvider    : 'NEO_GRAPH_PROVIDER',
         embeddingProvider: 'NEO_EMBEDDING_PROVIDER',
         ollama           : {
             host          : 'NEO_OLLAMA_HOST',

--- a/ai/config.template.mjs
+++ b/ai/config.template.mjs
@@ -89,16 +89,17 @@ class Config extends BaseConfig {
          */
         modelProvider: 'gemini',
         /**
-         * @summary Optional provider selector for Dream/Sandman graph-generation work.
+         * @summary Provider selector for Dream/Sandman graph-generation work.
          *
          * Graph extraction deliberately does not use the generic chat provider axis:
          * chat/summarization may use Gemini, while graph-generation dispatch only
-         * supports native Ollama or OpenAI-compatible endpoints. Leave this null to
-         * let `resolveGraphModelProvider()` derive the graph route from the active
-         * deployment model provider; set it only for an explicit graph-lane override.
-         * @type {String|null}
+         * supports native Ollama or OpenAI-compatible endpoints. The `auto` policy
+         * derives native Ollama when `modelProvider` is `ollama`; otherwise it uses
+         * the OpenAI-compatible graph route. Set `NEO_GRAPH_PROVIDER` only for an
+         * explicit graph-lane override.
+         * @type {'auto'|'ollama'|'openAiCompatible'}
          */
-        graphProvider: null,
+        graphProvider: 'auto',
         /**
          * @summary Deployment-wide embedding provider selector.
          *

--- a/ai/config.template.mjs
+++ b/ai/config.template.mjs
@@ -89,14 +89,16 @@ class Config extends BaseConfig {
          */
         modelProvider: 'gemini',
         /**
-         * @summary Provider selector for Dream/Sandman graph-generation work.
+         * @summary Optional provider selector for Dream/Sandman graph-generation work.
          *
          * Graph extraction deliberately does not use the generic chat provider axis:
          * chat/summarization may use Gemini, while graph-generation dispatch only
-         * supports native Ollama or OpenAI-compatible endpoints.
-         * @type {String}
+         * supports native Ollama or OpenAI-compatible endpoints. Leave this null to
+         * let `resolveGraphModelProvider()` derive the graph route from the active
+         * deployment model provider; set it only for an explicit graph-lane override.
+         * @type {String|null}
          */
-        graphProvider: 'openAiCompatible',
+        graphProvider: null,
         /**
          * @summary Deployment-wide embedding provider selector.
          *

--- a/ai/config.template.mjs
+++ b/ai/config.template.mjs
@@ -93,13 +93,12 @@ class Config extends BaseConfig {
          *
          * Graph extraction deliberately does not use the generic chat provider axis:
          * chat/summarization may use Gemini, while graph-generation dispatch only
-         * supports native Ollama or OpenAI-compatible endpoints. The `auto` policy
-         * derives native Ollama when `modelProvider` is `ollama`; otherwise it uses
-         * the OpenAI-compatible graph route. Set `NEO_GRAPH_PROVIDER` only for an
-         * explicit graph-lane override.
-         * @type {'auto'|'ollama'|'openAiCompatible'}
+         * supports native Ollama or OpenAI-compatible endpoints. Defaults to the
+         * OpenAI-compatible graph route; set `NEO_GRAPH_PROVIDER=ollama` for
+         * deployments that run graph extraction against native Ollama.
+         * @type {'ollama'|'openAiCompatible'}
          */
-        graphProvider: 'auto',
+        graphProvider: 'openAiCompatible',
         /**
          * @summary Deployment-wide embedding provider selector.
          *

--- a/ai/mcp/server/memory-core/config.template.mjs
+++ b/ai/mcp/server/memory-core/config.template.mjs
@@ -141,7 +141,7 @@ class Config extends BaseConfig {
          * Supported values: 'ollama', 'openAiCompatible'
          * @type {String|null}
          */
-        graphProvider: AiConfig.graphProvider ?? null,
+        graphProvider: AiConfig.graphProvider,
         /**
          * Canonical embedding provider for Memory Core and Knowledge Base embedding callsites.
          * Supported values: 'gemini', 'ollama', 'openAiCompatible'

--- a/ai/mcp/server/memory-core/config.template.mjs
+++ b/ai/mcp/server/memory-core/config.template.mjs
@@ -137,8 +137,7 @@ class Config extends BaseConfig {
         modelProvider: AiConfig.modelProvider,
         /**
          * Provider selector for Dream/Sandman graph-generation lanes.
-         * `auto` preserves the Tier-1 resolver's modelProvider-derived fallback.
-         * Supported values: 'auto', 'ollama', 'openAiCompatible'
+         * Supported values: 'ollama', 'openAiCompatible'
          * @type {String}
          */
         graphProvider: AiConfig.graphProvider,

--- a/ai/mcp/server/memory-core/config.template.mjs
+++ b/ai/mcp/server/memory-core/config.template.mjs
@@ -136,10 +136,10 @@ class Config extends BaseConfig {
          */
         modelProvider: AiConfig.modelProvider,
         /**
-         * Optional provider override for Dream/Sandman graph-generation lanes.
-         * Null preserves the Tier-1 resolver's modelProvider-derived fallback.
-         * Supported values: 'ollama', 'openAiCompatible'
-         * @type {String|null}
+         * Provider selector for Dream/Sandman graph-generation lanes.
+         * `auto` preserves the Tier-1 resolver's modelProvider-derived fallback.
+         * Supported values: 'auto', 'ollama', 'openAiCompatible'
+         * @type {String}
          */
         graphProvider: AiConfig.graphProvider,
         /**

--- a/ai/mcp/server/memory-core/config.template.mjs
+++ b/ai/mcp/server/memory-core/config.template.mjs
@@ -136,11 +136,12 @@ class Config extends BaseConfig {
          */
         modelProvider: AiConfig.modelProvider,
         /**
-         * Explicit provider for Dream/Sandman graph-generation lanes.
+         * Optional provider override for Dream/Sandman graph-generation lanes.
+         * Null preserves the Tier-1 resolver's modelProvider-derived fallback.
          * Supported values: 'ollama', 'openAiCompatible'
-         * @type {String}
+         * @type {String|null}
          */
-        graphProvider: AiConfig.graphProvider || 'openAiCompatible',
+        graphProvider: AiConfig.graphProvider ?? null,
         /**
          * Canonical embedding provider for Memory Core and Knowledge Base embedding callsites.
          * Supported values: 'gemini', 'ollama', 'openAiCompatible'

--- a/ai/mcp/server/memory-core/config.template.mjs
+++ b/ai/mcp/server/memory-core/config.template.mjs
@@ -136,6 +136,12 @@ class Config extends BaseConfig {
          */
         modelProvider: AiConfig.modelProvider,
         /**
+         * Explicit provider for Dream/Sandman graph-generation lanes.
+         * Supported values: 'ollama', 'openAiCompatible'
+         * @type {String}
+         */
+        graphProvider: AiConfig.graphProvider || 'openAiCompatible',
+        /**
          * Canonical embedding provider for Memory Core and Knowledge Base embedding callsites.
          * Supported values: 'gemini', 'ollama', 'openAiCompatible'
          * Defaults to the local OpenAI-compatible Qwen3 route so the source tuple matches the
@@ -442,6 +448,7 @@ class Config extends BaseConfig {
             trustProxyIdentity: { var: 'NEO_AUTH_TRUST_PROXY_IDENTITY', parse: Env.parseBool}
         },
         modelProvider     : 'NEO_MODEL_PROVIDER',
+        graphProvider     : 'NEO_GRAPH_PROVIDER',
         embeddingProvider : 'NEO_EMBEDDING_PROVIDER',
         ollama            : {
             host          : 'NEO_OLLAMA_HOST',

--- a/ai/scripts/runners/runSandman.mjs
+++ b/ai/scripts/runners/runSandman.mjs
@@ -9,6 +9,7 @@ import LifecycleService from '../../services/memory-core/lifecycle/SystemLifecyc
 import InferenceLifecycleService from '../../services/memory-core/lifecycle/InferenceLifecycleService.mjs';
 import GraphService from '../../services/memory-core/GraphService.mjs';
 import {withHeavyMaintenanceLease} from '../../daemons/orchestrator/services/HeavyMaintenanceLeaseService.mjs';
+import {isGraphModelProviderSupported, resolveGraphModelProvider} from '../../services/graph/providerDispatch.mjs';
 import logger from '../../mcp/server/memory-core/logger.mjs';
 import http from 'http';
 import {pathToFileURL} from 'url';
@@ -18,11 +19,12 @@ import {pathToFileURL} from 'url';
  */
 
 const DEFAULT_OPENAI_COMPATIBLE_HOST = 'http://127.0.0.1:8000';
+const DEFAULT_OLLAMA_HOST            = 'http://127.0.0.1:11434';
 const PROVIDER_READY_ATTEMPTS        = 30;
 const PROVIDER_READY_RETRY_MS        = 1000;
 
 /**
- * @summary Resolves the OpenAI-compatible host that the Sandman REM pipeline must reach.
+ * @summary Resolves the OpenAI-compatible host used by one Sandman graph-provider option.
  * @param {Object} config
  * @returns {String}
  */
@@ -31,12 +33,59 @@ export function getOpenAiCompatibleHost(config = Memory_Config.data) {
 }
 
 /**
- * @summary Probes the configured OpenAI-compatible provider used by the Sandman REM pipeline.
+ * @summary Builds the provider readiness target for the resolved Sandman graph provider.
+ * @param {Object} config
+ * @returns {Object}
+ */
+export function getGraphProviderReadinessTarget(config = Memory_Config.data) {
+    const provider  = resolveGraphModelProvider(config);
+    const supported = isGraphModelProviderSupported(provider);
+
+    if (!supported) {
+        return {
+            provider,
+            supported,
+            endpoint      : null,
+            host          : null,
+            model         : null,
+            embeddingModel: null,
+            url           : null
+        };
+    }
+
+    const isOllama = provider === 'ollama';
+    const host     = isOllama
+        ? config.ollama?.host || DEFAULT_OLLAMA_HOST
+        : getOpenAiCompatibleHost(config);
+    const endpoint = isOllama ? '/api/tags' : '/v1/models';
+    const model    = isOllama ? config.ollama?.model || null : config.openAiCompatible?.model || null;
+    const embeddingModel = isOllama
+        ? config.ollama?.embeddingModel || null
+        : config.openAiCompatible?.embeddingModel || null;
+    const url      = `${host.replace(/\/+$/, '')}${endpoint}`;
+
+    return {
+        provider,
+        supported,
+        endpoint,
+        host,
+        model,
+        embeddingModel,
+        url
+    };
+}
+
+/**
+ * @summary Probes the configured graph provider used by the Sandman REM pipeline.
  * @param {Object} config
  * @returns {Promise<Boolean>}
  */
 export function checkProvider(config = Memory_Config.data) {
-    const host = getOpenAiCompatibleHost(config);
+    const target = getGraphProviderReadinessTarget(config);
+
+    if (!target.supported) {
+        return Promise.resolve(false);
+    }
 
     return new Promise(resolve => {
         let settled = false;
@@ -47,7 +96,7 @@ export function checkProvider(config = Memory_Config.data) {
             }
         };
 
-        const req = http.get(`${host}/v1/models`, response => {
+        const req = http.get(target.url, response => {
             response.resume();
             settle(true);
         });
@@ -110,21 +159,37 @@ export async function waitForProvider({
 export function createProviderFailureDiagnostic({
     config = Memory_Config.data,
     waitResult,
-    lifecycleStatus = null
+    lifecycleStatus = null,
+    reason = 'PROVIDER_READINESS_TIMEOUT'
 } = {}) {
+    const target = getGraphProviderReadinessTarget(config);
+    const unsupported = reason === 'UNSUPPORTED_GRAPH_PROVIDER';
+
     return {
-        event          : 'runSandman.provider_readiness_timeout',
-        reason         : 'PROVIDER_READINESS_TIMEOUT',
-        provider       : 'openAiCompatible',
+        event          : unsupported
+            ? 'runSandman.unsupported_graph_provider'
+            : 'runSandman.provider_readiness_timeout',
+        reason,
+        provider       : target.provider,
+        graphProvider  : target.provider,
         modelProvider  : config.modelProvider || null,
-        host           : getOpenAiCompatibleHost(config),
-        model          : config.openAiCompatible?.model || null,
-        embeddingModel : config.openAiCompatible?.embeddingModel || null,
+        host           : target.host,
+        endpoint       : target.endpoint,
+        url            : target.url,
+        supported      : target.supported,
+        model          : target.model,
+        embeddingModel : target.embeddingModel,
         attempts       : waitResult?.attempts ?? null,
         elapsedMs      : waitResult?.elapsedMs ?? null,
         timeoutMs      : waitResult?.timeoutMs ?? null,
         lifecycleStatus,
-        nextAction     : 'Start the configured OpenAI-compatible / MLX provider, then rerun npm run ai:run-sandman.'
+        nextAction     : target.supported
+            ? (
+                target.provider === 'openAiCompatible'
+                    ? 'Start the configured OpenAI-compatible / MLX provider, then rerun npm run ai:run-sandman.'
+                    : `Start the configured ${target.provider} provider, then rerun npm run ai:run-sandman.`
+            )
+            : "Set NEO_GRAPH_PROVIDER to 'openAiCompatible' or 'ollama', then rerun npm run ai:run-sandman."
     };
 }
 
@@ -143,10 +208,17 @@ export async function recordProviderReadinessFailure(
         stderr = console.error
     } = {}
 ) {
-    const message = `\n❌ openAiCompatible server is not running on ${diagnostic.host}. Please start your MLX provider manually.`;
+    const message = diagnostic.reason === 'UNSUPPORTED_GRAPH_PROVIDER'
+        ? `\n❌ Unsupported Sandman graph provider '${diagnostic.graphProvider}'. Expected one of: 'ollama', 'openAiCompatible'.`
+        : `\n❌ ${diagnostic.provider} provider is not running on ${diagnostic.host}${diagnostic.endpoint || ''}. Please start the configured provider manually.`;
 
     stderr(message);
-    log.error('[runSandman] openAiCompatible provider readiness timeout', diagnostic);
+    log.error(
+        diagnostic.reason === 'UNSUPPORTED_GRAPH_PROVIDER'
+            ? '[runSandman] unsupported graph provider'
+            : `[runSandman] ${diagnostic.provider} provider readiness timeout`,
+        diagnostic
+    );
 
     if (typeof log.flush === 'function') {
         await log.flush();
@@ -183,7 +255,20 @@ export async function runSandman() {
                 await LifecycleService.ready();
                 console.log('   Lifecycle Service Ready. Database should be running.');
 
-                console.log('   Waiting for MLX provider to warm up load weights into VRAM...');
+                console.log('   Waiting for graph provider to warm up load weights into VRAM...');
+                const target = getGraphProviderReadinessTarget();
+
+                if (!target.supported) {
+                    const diagnostic = createProviderFailureDiagnostic({
+                        reason         : 'UNSUPPORTED_GRAPH_PROVIDER',
+                        lifecycleStatus: InferenceLifecycleService.getStatus()
+                    });
+
+                    await recordProviderReadinessFailure(diagnostic);
+                    process.exitCode = 1;
+                    return {providerReady: false, graphProvider: target.provider};
+                }
+
                 const waitResult = await waitForProvider();
 
                 if (!waitResult.running) {
@@ -197,7 +282,7 @@ export async function runSandman() {
                     return {providerReady: false};
                 }
 
-                console.log('\n   ✅ openAiCompatible server is running (auto-boot successful).');
+                console.log(`\n   ✅ ${target.provider} server is running (auto-boot successful).`);
 
                 console.log('   Waiting for DreamService Initialization...');
                 // We might need to ensure DreamService is fully inited, though it initAsync runs automatically upon Neo.setupClass

--- a/ai/scripts/runners/runSandman.mjs
+++ b/ai/scripts/runners/runSandman.mjs
@@ -18,18 +18,16 @@ import {pathToFileURL} from 'url';
  * @module ai/scripts/runners/runSandman
  */
 
-const DEFAULT_OPENAI_COMPATIBLE_HOST = 'http://127.0.0.1:8000';
-const DEFAULT_OLLAMA_HOST            = 'http://127.0.0.1:11434';
-const PROVIDER_READY_ATTEMPTS        = 30;
-const PROVIDER_READY_RETRY_MS        = 1000;
+const PROVIDER_READY_ATTEMPTS = 30;
+const PROVIDER_READY_RETRY_MS = 1000;
 
 /**
  * @summary Resolves the OpenAI-compatible host used by one Sandman graph-provider option.
  * @param {Object} config
- * @returns {String}
+ * @returns {String|undefined}
  */
 export function getOpenAiCompatibleHost(config = Memory_Config.data) {
-    return config.openAiCompatible?.host || DEFAULT_OPENAI_COMPATIBLE_HOST;
+    return config.openAiCompatible?.host;
 }
 
 /**
@@ -55,14 +53,14 @@ export function getGraphProviderReadinessTarget(config = Memory_Config.data) {
 
     const isOllama = provider === 'ollama';
     const host     = isOllama
-        ? config.ollama?.host || DEFAULT_OLLAMA_HOST
+        ? config.ollama?.host
         : getOpenAiCompatibleHost(config);
     const endpoint = isOllama ? '/api/tags' : '/v1/models';
-    const model    = isOllama ? config.ollama?.model || null : config.openAiCompatible?.model || null;
+    const model    = isOllama ? config.ollama?.model : config.openAiCompatible?.model;
     const embeddingModel = isOllama
-        ? config.ollama?.embeddingModel || null
-        : config.openAiCompatible?.embeddingModel || null;
-    const url      = `${host.replace(/\/+$/, '')}${endpoint}`;
+        ? config.ollama?.embeddingModel
+        : config.openAiCompatible?.embeddingModel;
+    const url      = host ? `${host.replace(/\/+$/, '')}${endpoint}` : null;
 
     return {
         provider,
@@ -172,7 +170,7 @@ export function createProviderFailureDiagnostic({
         reason,
         provider       : target.provider,
         graphProvider  : target.provider,
-        modelProvider  : config.modelProvider || null,
+        modelProvider  : config.modelProvider,
         host           : target.host,
         endpoint       : target.endpoint,
         url            : target.url,

--- a/ai/services/graph/GoldenPathSynthesizer.mjs
+++ b/ai/services/graph/GoldenPathSynthesizer.mjs
@@ -8,7 +8,7 @@ import { Memory_TextEmbeddingService as TextEmbeddingService } from '../../servi
 import { Memory_GraphService as GraphService } from '../../services.mjs';
 import Json from '../../../src/util/Json.mjs';
 import logger from '../../mcp/server/memory-core/logger.mjs';
-import {buildGraphProvider} from './providerDispatch.mjs';
+import {buildGraphProvider, resolveGraphModelProvider} from './providerDispatch.mjs';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname  = path.dirname(__filename);
@@ -279,9 +279,10 @@ class GoldenPathSynthesizer extends Base {
             });
 
             try {
-                logger.info(`[GoldenPathSynthesizer] Instantiating ${aiConfig.modelProvider} provider to interpret Mathematical Golden Path...`);
+                const graphProvider = resolveGraphModelProvider(aiConfig);
+                logger.info(`[GoldenPathSynthesizer] Instantiating ${graphProvider} provider to interpret Mathematical Golden Path...`);
                 const provider = buildGraphProvider({
-                    modelProvider         : aiConfig.modelProvider,
+                    modelProvider         : graphProvider,
                     ollamaConfig          : aiConfig.ollama,
                     openAiCompatibleConfig: aiConfig.openAiCompatible
                 });

--- a/ai/services/graph/SemanticGraphExtractor.mjs
+++ b/ai/services/graph/SemanticGraphExtractor.mjs
@@ -121,9 +121,7 @@ DO NOT output markdown, \`\`\`json blocks, or any other explanations. Provide pu
             // #11965 AC5 / #12059: consumerModel reflects the active graph-generation provider
             // for accurate telemetry; openAiCompatible's context-limit knobs are kept as the conservative
             // upstream pre-check threshold for both provider families.
-            const consumerModel          = graphProvider === 'ollama'
-                ? aiConfig.ollama?.model || 'ollama'
-                : aiConfig.openAiCompatible?.model || 'openAiCompatible';
+            const consumerModel          = aiConfig[graphProvider]?.model;
             const consumerContextTokens  = aiConfig.openAiCompatible.contextLimitTokens || 32768;
             const consumerSafeTokens     = aiConfig.openAiCompatible.safeProcessingLimitTokens;
 

--- a/ai/services/graph/SemanticGraphExtractor.mjs
+++ b/ai/services/graph/SemanticGraphExtractor.mjs
@@ -6,7 +6,7 @@ import {invokeWithGuardrail} from '../../services/memory-core/helpers/ConsumerFr
 import GraphService from '../../services/memory-core/GraphService.mjs';
 import Json from '../../../src/util/Json.mjs';
 import logger from '../../mcp/server/memory-core/logger.mjs';
-import {buildGraphProvider} from './providerDispatch.mjs';
+import {buildGraphProvider, resolveGraphModelProvider} from './providerDispatch.mjs';
 
 /**
  * @class Neo.ai.daemons.services.SemanticGraphExtractor
@@ -93,8 +93,9 @@ When extracting entities, you MUST emit provenance edges linking them back to th
 DO NOT output markdown, \`\`\`json blocks, or any other explanations. Provide purely the JSON object.`;
 
         try {
+            const graphProvider = resolveGraphModelProvider(aiConfig);
             const provider = buildGraphProvider({
-                modelProvider         : aiConfig.modelProvider,
+                modelProvider         : graphProvider,
                 ollamaConfig          : aiConfig.ollama,
                 openAiCompatibleConfig: aiConfig.openAiCompatible
             });
@@ -117,10 +118,10 @@ DO NOT output markdown, \`\`\`json blocks, or any other explanations. Provide pu
             // into friction symptoms. Friction is emitted into the in-memory aggregator
             // (with `serviceDomain: 'dream-pipeline'`) for handoff rendering by
             // `GoldenPathSynthesizer.synthesizeGoldenPath`.
-            // #11965 AC5: consumerModel reflects the active modelProvider for accurate
-            // telemetry; openAiCompatible's context-limit knobs are kept as the conservative
+            // #11965 AC5 / #12059: consumerModel reflects the active graph-generation provider
+            // for accurate telemetry; openAiCompatible's context-limit knobs are kept as the conservative
             // upstream pre-check threshold for both provider families.
-            const consumerModel          = aiConfig.modelProvider === 'ollama'
+            const consumerModel          = graphProvider === 'ollama'
                 ? aiConfig.ollama?.model || 'ollama'
                 : aiConfig.openAiCompatible?.model || 'openAiCompatible';
             const consumerContextTokens  = aiConfig.openAiCompatible.contextLimitTokens || 32768;
@@ -354,8 +355,9 @@ Enforce this STRICT JSON schema:
 DO NOT output markdown, \`\`\`json blocks, or any other explanations. Provide purely the JSON object.`;
 
         try {
+            const graphProvider = resolveGraphModelProvider(aiConfig);
             const provider = buildGraphProvider({
-                modelProvider         : aiConfig.modelProvider,
+                modelProvider         : graphProvider,
                 ollamaConfig          : aiConfig.ollama,
                 openAiCompatibleConfig: aiConfig.openAiCompatible
             });

--- a/ai/services/graph/SemanticGraphExtractor.mjs
+++ b/ai/services/graph/SemanticGraphExtractor.mjs
@@ -122,7 +122,7 @@ DO NOT output markdown, \`\`\`json blocks, or any other explanations. Provide pu
             // for accurate telemetry; openAiCompatible's context-limit knobs are kept as the conservative
             // upstream pre-check threshold for both provider families.
             const consumerModel          = aiConfig[graphProvider]?.model;
-            const consumerContextTokens  = aiConfig.openAiCompatible.contextLimitTokens || 32768;
+            const consumerContextTokens  = aiConfig.openAiCompatible.contextLimitTokens;
             const consumerSafeTokens     = aiConfig.openAiCompatible.safeProcessingLimitTokens;
 
             while (attempt < maxRetries && !payload) {

--- a/ai/services/graph/TopologyInferenceEngine.mjs
+++ b/ai/services/graph/TopologyInferenceEngine.mjs
@@ -3,7 +3,7 @@ import { Memory_Config as aiConfig } from '../../services.mjs';
 import Base from '../../../src/core/Base.mjs';
 import Json from '../../../src/util/Json.mjs';
 import logger from '../../mcp/server/memory-core/logger.mjs';
-import {buildGraphProvider} from './providerDispatch.mjs';
+import {buildGraphProvider, resolveGraphModelProvider} from './providerDispatch.mjs';
 
 /**
  * @class Neo.ai.daemons.services.TopologyInferenceEngine
@@ -54,8 +54,9 @@ DO NOT output markdown, \`\`\`json blocks, or any other explanations. Provide pu
 ${contextText}
 `;
         try {
+            const graphProvider = resolveGraphModelProvider(aiConfig);
             const provider = buildGraphProvider({
-                modelProvider         : aiConfig.modelProvider,
+                modelProvider         : graphProvider,
                 ollamaConfig          : aiConfig.ollama,
                 openAiCompatibleConfig: aiConfig.openAiCompatible
             });

--- a/ai/services/graph/providerDispatch.mjs
+++ b/ai/services/graph/providerDispatch.mjs
@@ -1,7 +1,6 @@
 import Ollama           from '../../provider/Ollama.mjs';
 import OpenAiCompatible from '../../provider/OpenAiCompatible.mjs';
 
-export const GRAPH_PROVIDER_AUTO   = 'auto';
 export const GRAPH_MODEL_PROVIDERS = Object.freeze(['ollama', 'openAiCompatible']);
 
 /**
@@ -9,22 +8,16 @@ export const GRAPH_MODEL_PROVIDERS = Object.freeze(['ollama', 'openAiCompatible'
  *
  * Graph extraction is not the same provider axis as generic Memory Core summarization:
  * summary/chat paths may still use Gemini, while graph-generation dispatch deliberately
- * supports only native Ollama or an OpenAI-compatible local/provider endpoint. The
- * explicit `auto` selector defaults to OpenAI-compatible unless the deployment
- * selected native Ollama for the generic model provider.
+ * supports only native Ollama or an OpenAI-compatible local/provider endpoint.
+ * Configuration is the single source of truth; this helper returns the configured
+ * graph provider verbatim instead of synthesizing hidden defaults from other axes.
  *
  * @param {Object} config aiConfig-shaped object.
- * @returns {String} `'ollama'` or `'openAiCompatible'` by default; explicit invalid
- *     `graphProvider` values are returned so {@link buildGraphProvider} can fail loudly.
+ * @returns {String|undefined} Configured `graphProvider`; explicit invalid values are
+ *     returned so {@link buildGraphProvider} can fail loudly.
  */
 export function resolveGraphModelProvider(config = {}) {
-    if (config.graphProvider && config.graphProvider !== GRAPH_PROVIDER_AUTO) {
-        return config.graphProvider;
-    }
-
-    return config.modelProvider === 'ollama'
-        ? 'ollama'
-        : 'openAiCompatible';
+    return config.graphProvider;
 }
 
 /**

--- a/ai/services/graph/providerDispatch.mjs
+++ b/ai/services/graph/providerDispatch.mjs
@@ -1,9 +1,43 @@
 import Ollama           from '../../provider/Ollama.mjs';
 import OpenAiCompatible from '../../provider/OpenAiCompatible.mjs';
 
+export const GRAPH_MODEL_PROVIDERS = Object.freeze(['ollama', 'openAiCompatible']);
+
+/**
+ * @summary Resolves the provider selector used by Dream/Sandman graph-generation lanes.
+ *
+ * Graph extraction is not the same provider axis as generic Memory Core summarization:
+ * summary/chat paths may still use Gemini, while graph-generation dispatch deliberately
+ * supports only native Ollama or an OpenAI-compatible local/provider endpoint. When no
+ * graph-specific selector is configured, default to OpenAI-compatible unless the deployment
+ * explicitly selected native Ollama for the generic model provider.
+ *
+ * @param {Object} config aiConfig-shaped object.
+ * @returns {String} `'ollama'` or `'openAiCompatible'` by default; explicit invalid
+ *     `graphProvider` values are returned so {@link buildGraphProvider} can fail loudly.
+ */
+export function resolveGraphModelProvider(config = {}) {
+    if (config.graphProvider) {
+        return config.graphProvider;
+    }
+
+    return config.modelProvider === 'ollama'
+        ? 'ollama'
+        : 'openAiCompatible';
+}
+
+/**
+ * @summary Returns true when `provider` is supported by graph-generation dispatch.
+ * @param {String} provider
+ * @returns {Boolean}
+ */
+export function isGraphModelProviderSupported(provider) {
+    return GRAPH_MODEL_PROVIDERS.includes(provider);
+}
+
 /**
  * @summary Resolves a chat-capable provider for graph-generation callsites
- * based on the active `modelProvider` selector.
+ * based on the graph-generation provider selector.
  *
  * Graph-generation services (`SemanticGraphExtractor`, `GoldenPathSynthesizer`,
  * `TopologyInferenceEngine`) all need a `provider.generate(prompt)`-shaped

--- a/ai/services/graph/providerDispatch.mjs
+++ b/ai/services/graph/providerDispatch.mjs
@@ -1,6 +1,7 @@
 import Ollama           from '../../provider/Ollama.mjs';
 import OpenAiCompatible from '../../provider/OpenAiCompatible.mjs';
 
+export const GRAPH_PROVIDER_AUTO   = 'auto';
 export const GRAPH_MODEL_PROVIDERS = Object.freeze(['ollama', 'openAiCompatible']);
 
 /**
@@ -8,16 +9,16 @@ export const GRAPH_MODEL_PROVIDERS = Object.freeze(['ollama', 'openAiCompatible'
  *
  * Graph extraction is not the same provider axis as generic Memory Core summarization:
  * summary/chat paths may still use Gemini, while graph-generation dispatch deliberately
- * supports only native Ollama or an OpenAI-compatible local/provider endpoint. When no
- * graph-specific selector is configured, default to OpenAI-compatible unless the deployment
- * explicitly selected native Ollama for the generic model provider.
+ * supports only native Ollama or an OpenAI-compatible local/provider endpoint. The
+ * explicit `auto` selector defaults to OpenAI-compatible unless the deployment
+ * selected native Ollama for the generic model provider.
  *
  * @param {Object} config aiConfig-shaped object.
  * @returns {String} `'ollama'` or `'openAiCompatible'` by default; explicit invalid
  *     `graphProvider` values are returned so {@link buildGraphProvider} can fail loudly.
  */
 export function resolveGraphModelProvider(config = {}) {
-    if (config.graphProvider) {
+    if (config.graphProvider && config.graphProvider !== GRAPH_PROVIDER_AUTO) {
         return config.graphProvider;
     }
 

--- a/learn/agentos/DreamPipeline.md
+++ b/learn/agentos/DreamPipeline.md
@@ -318,7 +318,7 @@ The DreamService is controlled by `ai/mcp/server/memory-core/config.mjs`:
 | `autoDream` | `true` | Process undigested sessions on startup |
 | `autoGoldenPath` | `true` | Synthesize Golden Path on startup |
 | `remSleepBatchLimit` | `10` | Max sessions to process per cycle |
-| `modelProvider` | `'openAiCompatible'` | LLM provider for extraction |
+| `graphProvider` | `'openAiCompatible'` | LLM provider for Dream/Sandman graph extraction |
 | `handoffFilePath` | `resources/content/sandman_handoff.md` | Output path |
 
 ## How It All Connects

--- a/test/playwright/fixtures/aiConfigDefaults.mjs
+++ b/test/playwright/fixtures/aiConfigDefaults.mjs
@@ -81,7 +81,7 @@ export const TIER1_DEFAULTS = deepFreeze(Neo.clone({
         trustProxyIdentity: process.env.NEO_AUTH_TRUST_PROXY_IDENTITY === 'true'
     },
     modelProvider    : process.env.NEO_MODEL_PROVIDER || 'gemini',
-    graphProvider    : process.env.NEO_GRAPH_PROVIDER || 'openAiCompatible',
+    graphProvider    : process.env.NEO_GRAPH_PROVIDER || null,
     embeddingProvider: process.env.NEO_EMBEDDING_PROVIDER || 'openAiCompatible',
     ollama: {
         host          : process.env.NEO_OLLAMA_HOST || 'http://127.0.0.1:11434',

--- a/test/playwright/fixtures/aiConfigDefaults.mjs
+++ b/test/playwright/fixtures/aiConfigDefaults.mjs
@@ -81,6 +81,7 @@ export const TIER1_DEFAULTS = deepFreeze(Neo.clone({
         trustProxyIdentity: process.env.NEO_AUTH_TRUST_PROXY_IDENTITY === 'true'
     },
     modelProvider    : process.env.NEO_MODEL_PROVIDER || 'gemini',
+    graphProvider    : process.env.NEO_GRAPH_PROVIDER || 'openAiCompatible',
     embeddingProvider: process.env.NEO_EMBEDDING_PROVIDER || 'openAiCompatible',
     ollama: {
         host          : process.env.NEO_OLLAMA_HOST || 'http://127.0.0.1:11434',

--- a/test/playwright/fixtures/aiConfigDefaults.mjs
+++ b/test/playwright/fixtures/aiConfigDefaults.mjs
@@ -81,7 +81,7 @@ export const TIER1_DEFAULTS = deepFreeze(Neo.clone({
         trustProxyIdentity: process.env.NEO_AUTH_TRUST_PROXY_IDENTITY === 'true'
     },
     modelProvider    : process.env.NEO_MODEL_PROVIDER || 'gemini',
-    graphProvider    : process.env.NEO_GRAPH_PROVIDER || 'auto',
+    graphProvider    : process.env.NEO_GRAPH_PROVIDER || 'openAiCompatible',
     embeddingProvider: process.env.NEO_EMBEDDING_PROVIDER || 'openAiCompatible',
     ollama: {
         host          : process.env.NEO_OLLAMA_HOST || 'http://127.0.0.1:11434',

--- a/test/playwright/fixtures/aiConfigDefaults.mjs
+++ b/test/playwright/fixtures/aiConfigDefaults.mjs
@@ -81,7 +81,7 @@ export const TIER1_DEFAULTS = deepFreeze(Neo.clone({
         trustProxyIdentity: process.env.NEO_AUTH_TRUST_PROXY_IDENTITY === 'true'
     },
     modelProvider    : process.env.NEO_MODEL_PROVIDER || 'gemini',
-    graphProvider    : process.env.NEO_GRAPH_PROVIDER || null,
+    graphProvider    : process.env.NEO_GRAPH_PROVIDER || 'auto',
     embeddingProvider: process.env.NEO_EMBEDDING_PROVIDER || 'openAiCompatible',
     ollama: {
         host          : process.env.NEO_OLLAMA_HOST || 'http://127.0.0.1:11434',

--- a/test/playwright/unit/ai/config.template.spec.mjs
+++ b/test/playwright/unit/ai/config.template.spec.mjs
@@ -59,7 +59,7 @@ test.describe('Tier 1 Config Immutability', () => {
     test('ships Tier-1 provider and unified Chroma defaults', async () => {
         expect(Config.chatProvider).toBe(process.env.NEO_MODEL_PROVIDER || 'gemini');
         expect(Config.modelProvider).toBe(Config.chatProvider);
-        expect(Config.graphProvider).toBe(process.env.NEO_GRAPH_PROVIDER || 'openAiCompatible');
+        expect(Config.graphProvider).toBe(process.env.NEO_GRAPH_PROVIDER || null);
         expect(Config.embeddingProvider).toBe(process.env.NEO_EMBEDDING_PROVIDER || 'openAiCompatible');
         expect(Config.vectorDimension).toBe(Number(process.env.NEO_VECTOR_DIMENSION) || 4096);
         expect(Config.backupPath).toBe(TIER1_DEFAULTS.backupPath);

--- a/test/playwright/unit/ai/config.template.spec.mjs
+++ b/test/playwright/unit/ai/config.template.spec.mjs
@@ -59,7 +59,7 @@ test.describe('Tier 1 Config Immutability', () => {
     test('ships Tier-1 provider and unified Chroma defaults', async () => {
         expect(Config.chatProvider).toBe(process.env.NEO_MODEL_PROVIDER || 'gemini');
         expect(Config.modelProvider).toBe(Config.chatProvider);
-        expect(Config.graphProvider).toBe(process.env.NEO_GRAPH_PROVIDER || null);
+        expect(Config.graphProvider).toBe(process.env.NEO_GRAPH_PROVIDER || 'auto');
         expect(Config.embeddingProvider).toBe(process.env.NEO_EMBEDDING_PROVIDER || 'openAiCompatible');
         expect(Config.vectorDimension).toBe(Number(process.env.NEO_VECTOR_DIMENSION) || 4096);
         expect(Config.backupPath).toBe(TIER1_DEFAULTS.backupPath);

--- a/test/playwright/unit/ai/config.template.spec.mjs
+++ b/test/playwright/unit/ai/config.template.spec.mjs
@@ -59,7 +59,7 @@ test.describe('Tier 1 Config Immutability', () => {
     test('ships Tier-1 provider and unified Chroma defaults', async () => {
         expect(Config.chatProvider).toBe(process.env.NEO_MODEL_PROVIDER || 'gemini');
         expect(Config.modelProvider).toBe(Config.chatProvider);
-        expect(Config.graphProvider).toBe(process.env.NEO_GRAPH_PROVIDER || 'auto');
+        expect(Config.graphProvider).toBe(process.env.NEO_GRAPH_PROVIDER || 'openAiCompatible');
         expect(Config.embeddingProvider).toBe(process.env.NEO_EMBEDDING_PROVIDER || 'openAiCompatible');
         expect(Config.vectorDimension).toBe(Number(process.env.NEO_VECTOR_DIMENSION) || 4096);
         expect(Config.backupPath).toBe(TIER1_DEFAULTS.backupPath);

--- a/test/playwright/unit/ai/config.template.spec.mjs
+++ b/test/playwright/unit/ai/config.template.spec.mjs
@@ -59,6 +59,7 @@ test.describe('Tier 1 Config Immutability', () => {
     test('ships Tier-1 provider and unified Chroma defaults', async () => {
         expect(Config.chatProvider).toBe(process.env.NEO_MODEL_PROVIDER || 'gemini');
         expect(Config.modelProvider).toBe(Config.chatProvider);
+        expect(Config.graphProvider).toBe(process.env.NEO_GRAPH_PROVIDER || 'openAiCompatible');
         expect(Config.embeddingProvider).toBe(process.env.NEO_EMBEDDING_PROVIDER || 'openAiCompatible');
         expect(Config.vectorDimension).toBe(Number(process.env.NEO_VECTOR_DIMENSION) || 4096);
         expect(Config.backupPath).toBe(TIER1_DEFAULTS.backupPath);

--- a/test/playwright/unit/ai/mcp/server/memory-core/config.template.spec.mjs
+++ b/test/playwright/unit/ai/mcp/server/memory-core/config.template.spec.mjs
@@ -102,6 +102,11 @@ test.describe('Memory Core Config (#10010)', () => {
         expect(config.engines.chroma.dataDir).toContain('.neo-ai-data/chroma/memory-core');
     });
 
+    test('preserves null graphProvider defaults so graph routing derives from modelProvider', () => {
+        expect(TIER1_DEFAULTS.graphProvider).toBe(null);
+        expect(config.graphProvider).toBe(null);
+    });
+
     test('env overrides remain final after Tier-1 default mapping', () => {
         process.env.NEO_MODEL_PROVIDER = 'openAiCompatible';
         process.env.NEO_GRAPH_PROVIDER = 'ollama';

--- a/test/playwright/unit/ai/mcp/server/memory-core/config.template.spec.mjs
+++ b/test/playwright/unit/ai/mcp/server/memory-core/config.template.spec.mjs
@@ -85,6 +85,7 @@ test.describe('Memory Core Config (#10010)', () => {
 
     test('maps deployment-wide Tier-1 defaults for provider, auth, and storage groups', () => {
         expect(config.modelProvider).toBe(TIER1_DEFAULTS.modelProvider);
+        expect(config.graphProvider).toBe(TIER1_DEFAULTS.graphProvider);
         expect(config.embeddingProvider).toBe(TIER1_DEFAULTS.embeddingProvider);
         expect(config.ollama).toEqual(TIER1_DEFAULTS.ollama);
         expect(config.openAiCompatible).toEqual(TIER1_DEFAULTS.openAiCompatible);
@@ -103,6 +104,7 @@ test.describe('Memory Core Config (#10010)', () => {
 
     test('env overrides remain final after Tier-1 default mapping', () => {
         process.env.NEO_MODEL_PROVIDER = 'openAiCompatible';
+        process.env.NEO_GRAPH_PROVIDER = 'ollama';
         process.env.NEO_EMBEDDING_PROVIDER = 'ollama';
         process.env.NEO_AUTH_REALM = 'tenant-realm';
         process.env.NEO_BACKUP_PATH = '/tmp/neo-memory-backups';
@@ -113,6 +115,7 @@ test.describe('Memory Core Config (#10010)', () => {
         config.applyEnv();
 
         expect(config.modelProvider).toBe('openAiCompatible');
+        expect(config.graphProvider).toBe('ollama');
         expect(config.embeddingProvider).toBe('ollama');
         expect(config.auth.realm).toBe('tenant-realm');
         expect(config.backupPath).toBe('/tmp/neo-memory-backups');

--- a/test/playwright/unit/ai/mcp/server/memory-core/config.template.spec.mjs
+++ b/test/playwright/unit/ai/mcp/server/memory-core/config.template.spec.mjs
@@ -102,9 +102,9 @@ test.describe('Memory Core Config (#10010)', () => {
         expect(config.engines.chroma.dataDir).toContain('.neo-ai-data/chroma/memory-core');
     });
 
-    test('preserves explicit auto graphProvider defaults so graph routing derives from modelProvider', () => {
-        expect(TIER1_DEFAULTS.graphProvider).toBe('auto');
-        expect(config.graphProvider).toBe('auto');
+    test('inherits concrete graphProvider defaults from Tier-1 config', () => {
+        expect(TIER1_DEFAULTS.graphProvider).toBe('openAiCompatible');
+        expect(config.graphProvider).toBe('openAiCompatible');
     });
 
     test('env overrides remain final after Tier-1 default mapping', () => {

--- a/test/playwright/unit/ai/mcp/server/memory-core/config.template.spec.mjs
+++ b/test/playwright/unit/ai/mcp/server/memory-core/config.template.spec.mjs
@@ -102,9 +102,9 @@ test.describe('Memory Core Config (#10010)', () => {
         expect(config.engines.chroma.dataDir).toContain('.neo-ai-data/chroma/memory-core');
     });
 
-    test('preserves null graphProvider defaults so graph routing derives from modelProvider', () => {
-        expect(TIER1_DEFAULTS.graphProvider).toBe(null);
-        expect(config.graphProvider).toBe(null);
+    test('preserves explicit auto graphProvider defaults so graph routing derives from modelProvider', () => {
+        expect(TIER1_DEFAULTS.graphProvider).toBe('auto');
+        expect(config.graphProvider).toBe('auto');
     });
 
     test('env overrides remain final after Tier-1 default mapping', () => {

--- a/test/playwright/unit/ai/scripts/runners/runSandman.spec.mjs
+++ b/test/playwright/unit/ai/scripts/runners/runSandman.spec.mjs
@@ -81,10 +81,44 @@ test.describe('runSandman.mjs provider readiness diagnostics (#10587)', () => {
         expect(dots).toBe('...');
     });
 
+    test('resolves readiness target from graphProvider instead of generic modelProvider', () => {
+        expect(runSandmanModule.getGraphProviderReadinessTarget({
+            modelProvider: 'gemini',
+            openAiCompatible: {
+                host : 'http://127.0.0.1:13090',
+                model: 'mlx-community/gemma-4'
+            }
+        })).toMatchObject({
+            provider : 'openAiCompatible',
+            supported: true,
+            endpoint : '/v1/models',
+            host     : 'http://127.0.0.1:13090',
+            model    : 'mlx-community/gemma-4',
+            url      : 'http://127.0.0.1:13090/v1/models'
+        });
+
+        expect(runSandmanModule.getGraphProviderReadinessTarget({
+            modelProvider : 'gemini',
+            graphProvider : 'ollama',
+            ollama        : {
+                host : 'http://127.0.0.1:11434/',
+                model: 'gemma4:31b'
+            }
+        })).toMatchObject({
+            provider : 'ollama',
+            supported: true,
+            endpoint : '/api/tags',
+            host     : 'http://127.0.0.1:11434/',
+            model    : 'gemma4:31b',
+            url      : 'http://127.0.0.1:11434/api/tags'
+        });
+    });
+
     test('records a durable provider-timeout breadcrumb without leaking secrets', async () => {
         const diagnostic = runSandmanModule.createProviderFailureDiagnostic({
             config: {
                 modelProvider: 'openAiCompatible',
+                graphProvider: 'openAiCompatible',
                 openAiCompatible: {
                     host          : 'http://127.0.0.1:11435',
                     model         : 'mlx-community/test-model',
@@ -117,10 +151,38 @@ test.describe('runSandman.mjs provider readiness diagnostics (#10587)', () => {
         expect(result.message).toContain('http://127.0.0.1:11435');
         expect(logLines).toContain('[runSandman] openAiCompatible provider readiness timeout');
         expect(logLines).toContain('PROVIDER_READINESS_TIMEOUT');
+        expect(logLines).toContain('"graphProvider":"openAiCompatible"');
+        expect(logLines).toContain('/v1/models');
         expect(logLines).toContain('http://127.0.0.1:11435');
         expect(logLines).toContain('mlx-community/test-model');
         expect(logLines).toContain('Start the configured OpenAI-compatible / MLX provider');
         expect(logLines).not.toContain('must-not-be-logged');
+    });
+
+    test('unsupported graphProvider fails before readiness polling', async () => {
+        const diagnostic = runSandmanModule.createProviderFailureDiagnostic({
+            config: {
+                modelProvider : 'gemini',
+                graphProvider : 'gemini',
+                openAiCompatible: {
+                    apiKey: 'must-not-be-logged'
+                }
+            },
+            reason: 'UNSUPPORTED_GRAPH_PROVIDER'
+        });
+
+        const result = await runSandmanModule.recordProviderReadinessFailure(diagnostic, {
+            stderr: () => {}
+        });
+
+        expect(result.message).toContain("Unsupported Sandman graph provider 'gemini'");
+        expect(result.diagnostic).toMatchObject({
+            reason        : 'UNSUPPORTED_GRAPH_PROVIDER',
+            graphProvider : 'gemini',
+            supported     : false,
+            host          : null,
+            endpoint      : null
+        });
     });
 
     test('runRemPipeline propagates REM failures without printing success (#11698)', async () => {

--- a/test/playwright/unit/ai/scripts/runners/runSandman.spec.mjs
+++ b/test/playwright/unit/ai/scripts/runners/runSandman.spec.mjs
@@ -112,6 +112,19 @@ test.describe('runSandman.mjs provider readiness diagnostics (#10587)', () => {
             model    : 'gemma4:31b',
             url      : 'http://127.0.0.1:11434/api/tags'
         });
+
+        expect(runSandmanModule.getGraphProviderReadinessTarget({
+            modelProvider : 'ollama',
+            graphProvider : null,
+            ollama        : {
+                host : 'http://127.0.0.1:11434',
+                model: 'gemma4:31b'
+            }
+        })).toMatchObject({
+            provider : 'ollama',
+            supported: true,
+            endpoint : '/api/tags'
+        });
     });
 
     test('records a durable provider-timeout breadcrumb without leaking secrets', async () => {

--- a/test/playwright/unit/ai/scripts/runners/runSandman.spec.mjs
+++ b/test/playwright/unit/ai/scripts/runners/runSandman.spec.mjs
@@ -83,7 +83,8 @@ test.describe('runSandman.mjs provider readiness diagnostics (#10587)', () => {
 
     test('resolves readiness target from graphProvider instead of generic modelProvider', () => {
         expect(runSandmanModule.getGraphProviderReadinessTarget({
-            modelProvider: 'gemini',
+            modelProvider : 'gemini',
+            graphProvider : 'openAiCompatible',
             openAiCompatible: {
                 host : 'http://127.0.0.1:13090',
                 model: 'mlx-community/gemma-4'
@@ -115,15 +116,20 @@ test.describe('runSandman.mjs provider readiness diagnostics (#10587)', () => {
 
         expect(runSandmanModule.getGraphProviderReadinessTarget({
             modelProvider : 'ollama',
-            graphProvider : null,
+            graphProvider : 'openAiCompatible',
+            openAiCompatible: {
+                host : 'http://127.0.0.1:13091',
+                model: 'mlx-community/gemma-4'
+            },
             ollama        : {
                 host : 'http://127.0.0.1:11434',
                 model: 'gemma4:31b'
             }
         })).toMatchObject({
-            provider : 'ollama',
+            provider : 'openAiCompatible',
             supported: true,
-            endpoint : '/api/tags'
+            endpoint : '/v1/models',
+            host     : 'http://127.0.0.1:13091'
         });
     });
 

--- a/test/playwright/unit/ai/services/graph/SemanticGraphExtractor.spec.mjs
+++ b/test/playwright/unit/ai/services/graph/SemanticGraphExtractor.spec.mjs
@@ -19,6 +19,10 @@ import * as core      from '../../../../../../src/core/_export.mjs';
 import fs             from 'fs';
 import path           from 'path';
 import {TestLifecycleHelper} from '../../services/memory-core/util.mjs';
+import {
+    clearAggregatedFrictions,
+    getAggregatedFrictions
+} from '../../../../../../ai/services/memory-core/helpers/ConsumerFrictionHelper.mjs';
 
 test.describe('Neo.ai.daemons.services.SemanticGraphExtractor', () => {
     test.describe.configure({mode: 'serial'});
@@ -282,6 +286,43 @@ test.describe('Neo.ai.daemons.services.SemanticGraphExtractor', () => {
 
         } finally {
             OpenAiCompatible.prototype.generate = baseGenerate;
+        }
+    });
+
+    test('uses configured graph-provider model for consumer friction telemetry (#12059)', async () => {
+        const originalGraphProvider                  = aiConfig.graphProvider;
+        const originalOllamaModel                    = aiConfig.ollama?.model;
+        const originalContextLimitTokens             = aiConfig.openAiCompatible.contextLimitTokens;
+        const originalSafeProcessingLimitTokens      = aiConfig.openAiCompatible.safeProcessingLimitTokens;
+
+        try {
+            clearAggregatedFrictions();
+
+            aiConfig.graphProvider                             = 'ollama';
+            aiConfig.ollama.model                              = 'gemma4-real-model';
+            aiConfig.openAiCompatible.contextLimitTokens        = 8;
+            aiConfig.openAiCompatible.safeProcessingLimitTokens = 1;
+
+            const result = await SemanticGraphExtractor.executeTriVectorExtraction({
+                id      : 'mock-consumer-model-vector-id',
+                meta    : {sessionId: 'consumer-model-telemetry-session'},
+                document: 'Force guardrail pre-check so provider.generate is never invoked.'
+            });
+
+            expect(result).toBeNull();
+
+            const frictions = getAggregatedFrictions();
+            const friction  = frictions.find(item => item.assetRef === 'consumer-model-telemetry-session');
+
+            expect(friction).toBeDefined();
+            expect(friction.model).toBe('gemma4-real-model');
+            expect(friction.model).not.toBe('ollama');
+        } finally {
+            aiConfig.graphProvider                             = originalGraphProvider;
+            aiConfig.ollama.model                              = originalOllamaModel;
+            aiConfig.openAiCompatible.contextLimitTokens        = originalContextLimitTokens;
+            aiConfig.openAiCompatible.safeProcessingLimitTokens = originalSafeProcessingLimitTokens;
+            clearAggregatedFrictions();
         }
     });
 });

--- a/test/playwright/unit/ai/services/graph/providerDispatch.spec.mjs
+++ b/test/playwright/unit/ai/services/graph/providerDispatch.spec.mjs
@@ -19,10 +19,28 @@ import * as core      from '../../../../../../src/core/_export.mjs';
 
 test.describe('buildGraphProvider (#11965 Sub-2 cycle-3)', () => {
     let buildGraphProvider;
+    let resolveGraphModelProvider;
 
     test.beforeAll(async () => {
         const mod = await import('../../../../../../ai/services/graph/providerDispatch.mjs');
-        buildGraphProvider = mod.buildGraphProvider;
+        buildGraphProvider        = mod.buildGraphProvider;
+        resolveGraphModelProvider = mod.resolveGraphModelProvider;
+    });
+
+    test('resolves graph provider independently from generic Gemini modelProvider (#12059)', () => {
+        expect(resolveGraphModelProvider({
+            modelProvider: 'gemini'
+        })).toBe('openAiCompatible');
+
+        expect(resolveGraphModelProvider({
+            modelProvider : 'gemini',
+            graphProvider : 'ollama'
+        })).toBe('ollama');
+
+        expect(resolveGraphModelProvider({
+            modelProvider : 'openAiCompatible',
+            graphProvider : 'bogus-provider'
+        })).toBe('bogus-provider');
     });
 
     test('throws for unsupported modelProvider (no silent fallback)', () => {

--- a/test/playwright/unit/ai/services/graph/providerDispatch.spec.mjs
+++ b/test/playwright/unit/ai/services/graph/providerDispatch.spec.mjs
@@ -27,14 +27,10 @@ test.describe('buildGraphProvider (#11965 Sub-2 cycle-3)', () => {
         resolveGraphModelProvider = mod.resolveGraphModelProvider;
     });
 
-    test('resolves graph provider independently from generic Gemini modelProvider (#12059)', () => {
-        expect(resolveGraphModelProvider({
-            modelProvider: 'gemini'
-        })).toBe('openAiCompatible');
-
+    test('returns configured graph provider without generic modelProvider fallback (#12059)', () => {
         expect(resolveGraphModelProvider({
             modelProvider : 'gemini',
-            graphProvider : 'auto'
+            graphProvider : 'openAiCompatible'
         })).toBe('openAiCompatible');
 
         expect(resolveGraphModelProvider({
@@ -44,8 +40,12 @@ test.describe('buildGraphProvider (#11965 Sub-2 cycle-3)', () => {
 
         expect(resolveGraphModelProvider({
             modelProvider : 'ollama',
-            graphProvider : 'auto'
-        })).toBe('ollama');
+            graphProvider : 'openAiCompatible'
+        })).toBe('openAiCompatible');
+
+        expect(resolveGraphModelProvider({
+            modelProvider: 'ollama'
+        })).toBeUndefined();
 
         expect(resolveGraphModelProvider({
             modelProvider : 'openAiCompatible',

--- a/test/playwright/unit/ai/services/graph/providerDispatch.spec.mjs
+++ b/test/playwright/unit/ai/services/graph/providerDispatch.spec.mjs
@@ -38,6 +38,11 @@ test.describe('buildGraphProvider (#11965 Sub-2 cycle-3)', () => {
         })).toBe('ollama');
 
         expect(resolveGraphModelProvider({
+            modelProvider : 'ollama',
+            graphProvider : null
+        })).toBe('ollama');
+
+        expect(resolveGraphModelProvider({
             modelProvider : 'openAiCompatible',
             graphProvider : 'bogus-provider'
         })).toBe('bogus-provider');

--- a/test/playwright/unit/ai/services/graph/providerDispatch.spec.mjs
+++ b/test/playwright/unit/ai/services/graph/providerDispatch.spec.mjs
@@ -34,12 +34,17 @@ test.describe('buildGraphProvider (#11965 Sub-2 cycle-3)', () => {
 
         expect(resolveGraphModelProvider({
             modelProvider : 'gemini',
+            graphProvider : 'auto'
+        })).toBe('openAiCompatible');
+
+        expect(resolveGraphModelProvider({
+            modelProvider : 'gemini',
             graphProvider : 'ollama'
         })).toBe('ollama');
 
         expect(resolveGraphModelProvider({
             modelProvider : 'ollama',
-            graphProvider : null
+            graphProvider : 'auto'
         })).toBe('ollama');
 
         expect(resolveGraphModelProvider({


### PR DESCRIPTION
Resolves #12059

Authored by GPT-5 (Codex Desktop). Session d84ad2f1-c71c-4ce4-bec7-1167b9183637.

FAIR-band: over-target [18/30] — taking this lane despite over-target because this is an operator-declared P0 Sandman incident and the branch was already assigned to @neo-gpt during recovery.

Sandman/Dream graph extraction now uses a graph-specific provider selector instead of the generic chat/summarization `modelProvider`. The tracked template ships the concrete default `graphProvider: 'openAiCompatible'`; deployments that run graph extraction against native Ollama use the explicit `NEO_GRAPH_PROVIDER=ollama` override. Resolver code returns the configured graph provider verbatim, so there is no hidden fallback from `modelProvider`, no `auto` policy, and no null/absence default.

Evidence: L2 (focused unit coverage for selector, explicit config behavior, Memory Core template mapping, Sandman readiness diagnostics, and graph consumer-model telemetry) -> L4 required (full manual `npm run ai:run-sandman` against live Memory Core). Residual: live Sandman REM run remains operator-gated because it mutates production Memory Core graph/session state.

## Deltas from ticket

The implementation adds `graphProvider` rather than `graphModelProvider`/`graphModel`. Existing provider blocks already own their model names (`openAiCompatible.model`, `ollama.model`), so a second graph-model field would introduce a duplicate model-name axis without a ticket AC requiring it.

`runSandman.mjs` now probes the configured graph provider endpoint: `/v1/models` for OpenAI-compatible and `/api/tags` for Ollama. Unsupported graph providers produce an explicit `UNSUPPORTED_GRAPH_PROVIDER` diagnostic before the readiness loop.

`SemanticGraphExtractor` now derives `consumerModel` directly from `aiConfig[graphProvider]?.model` for ConsumerFriction telemetry. This removes the inherited provider-name fallback (`'ollama'` / `'openAiCompatible'`) and keeps model identity sourced from the provider config block.

The final corrective shape follows the operator contract: config is SSOT. Code no longer synthesizes `graphProvider` from `modelProvider`, and `SemanticGraphExtractor` no longer duplicates the OpenAI-compatible context default with `|| 32768`.

## MCP Config Template Change

Changed config keys:

- Added `graphProvider` to `ai/config.template.mjs`, defaulting to `'openAiCompatible'`.
- Added `NEO_GRAPH_PROVIDER` env binding to the Tier-1 config template for explicit graph-lane overrides.
- Added Memory Core template mapping for `graphProvider` as verbatim `AiConfig.graphProvider`, preserving the existing overlay SSOT pattern without introducing an MC-local default.

Default behavior:

- Template default: `modelProvider=gemini`, `graphProvider=openAiCompatible` -> resolved graph provider `openAiCompatible`.
- Ollama chat deployment without graph override: `NEO_MODEL_PROVIDER=ollama`, `graphProvider=openAiCompatible` -> resolved graph provider `openAiCompatible` by design; no hidden fallback.
- Ollama graph deployment: `NEO_GRAPH_PROVIDER=ollama` -> resolved graph provider `ollama`.

Local `config.mjs` follow-up: tracked templates are corrected by this PR. Any already-materialized local config remains operator-owned deployment state and should be regenerated or explicitly reviewed during deployment maintenance.

Harness restart: recommended before retrying `npm run ai:run-sandman`, so the runner and graph services load the new provider selector.

Peer notification: sent A2A to @neo-opus-4-7 and `AGENT:*` during implementation and after each pre-merge blocker fixup.

## Slot Rationale

Touched `learn/agentos/DreamPipeline.md`.

Modified section: Dream Pipeline configuration table.

Disposition delta: keep -> keep. Trigger-frequency is low, failure-severity is high, enforceability is medium. The table is not always-loaded instruction substrate; the edit replaces a stale `modelProvider` row with `graphProvider` so future Sandman operator/debugging sessions do not reintroduce graph/chat provider-axis confusion.

## Test Evidence

- `node --check ai/config.template.mjs` -> passed.
- `node --check ai/mcp/server/memory-core/config.template.mjs` -> passed.
- `node --check ai/scripts/runners/runSandman.mjs` -> passed.
- `node --check ai/services/graph/SemanticGraphExtractor.mjs` -> passed.
- `node --check ai/services/graph/providerDispatch.mjs` -> passed.
- Pattern audit over touched files found no `GRAPH_PROVIDER_AUTO`, `graphProvider: 'auto'`, `graphProvider: null`, `modelProvider === 'ollama'` resolver derivation, duplicate `contextLimitTokens || 32768`, or provider host default constants.
- `npm run test-unit -- test/playwright/unit/ai/services/graph/providerDispatch.spec.mjs test/playwright/unit/ai/scripts/runners/runSandman.spec.mjs test/playwright/unit/ai/config.template.spec.mjs test/playwright/unit/ai/mcp/server/memory-core/config.template.spec.mjs test/playwright/unit/ai/services/graph/SemanticGraphExtractor.spec.mjs` -> 29 passed after the final no-hidden-fallback correction.
- Runtime probe, default env -> `{"modelProvider":"gemini","graphProvider":"openAiCompatible","resolvedGraphProvider":"openAiCompatible"}`.
- Runtime probe, `NEO_MODEL_PROVIDER=ollama` -> `{"modelProvider":"ollama","graphProvider":"openAiCompatible","resolvedGraphProvider":"openAiCompatible"}`.
- Runtime probe, `NEO_GRAPH_PROVIDER=ollama` -> `{"modelProvider":"gemini","graphProvider":"ollama","resolvedGraphProvider":"ollama"}`.
- `git diff --check` and `git diff --cached --check` -> passed after the final correction.
- Branch freshness note: after the original PR opened, `origin/dev` advanced by hourly data sync commit `4e1f2ee61`. I did not rebase only to absorb generated sync churn; PR #12061 remained mergeable before the blocker-fix pushes.

## Post-Merge Validation

- [ ] Restart the relevant Memory Core / orchestrator process before retrying manual Sandman.
- [ ] With operator approval, run `npm run ai:run-sandman` once and verify Tri-Vector extraction dispatches `openAiCompatible` for default deployments or `ollama` only when `NEO_GRAPH_PROVIDER=ollama` is configured, never `gemini`.
- [ ] Verify deployment-local generated configs are regenerated or explicitly reviewed so stale local `config.mjs` files do not pin an unintended graph-provider value.

## Commit

- `0c9bd40e0` — `fix(ai): route Sandman graph providers explicitly (#12059)`
- `0b8879c6d` — `fix(ai): preserve graphProvider null default (#12059)`
- `89a2fb08e` — `fix(ai): inherit graphProvider overlay verbatim (#12059)`
- `95ee5536f` — `fix(ai): derive graph consumer model from provider config (#12059)`
- `eb8f99f77` — `fix(ai): replace graph provider null default (#12059)` — superseded by final operator-selected shape.
- `33ce62457` — `fix(ai): make graph provider config explicit (#12059)`

## Review cycle

- @neo-opus-4-7 approved cycle-1 before the operator-surfaced a partner tenant safety blocker.
- Cycle-2 blocker fixes removed the hard `openAiCompatible` default, but incorrectly replaced it with a null template default. Operator veto rejected this as absence-of-configuration.
- Cycle-3 blocker fix collapsed `SemanticGraphExtractor` `consumerModel` from ternary + `||` provider-name fallbacks to `aiConfig[graphProvider]?.model`, with a ConsumerFriction telemetry regression test proving native Ollama reports the configured model name rather than `'ollama'`.
- Cycle-4a replaced null with `auto`, but that still violated the operator's no-hidden-fallback contract and is superseded.
- Cycle-4b restores concrete `graphProvider: 'openAiCompatible'`, keeps `NEO_GRAPH_PROVIDER` as the explicit override path, and removes graph-provider/context hidden fallback logic from the touched production paths.