### PR TITLE
feat(ai): 5-axis REM observability primitive helpers + 22-case unit coverage (#12068 Sub 2 Phase 1a)

### DIFF
--- a/ai/services/graph/TopologyInferenceEngine.mjs
+++ b/ai/services/graph/TopologyInferenceEngine.mjs
@@ -107,6 +107,52 @@ ${contextText}
             }
         }
     }
+
+    /**
+     * @summary Count topological-conflict entries emitted to `sandman_handoff.md`.
+     * This is **Axis D** of the 5-axis REM observability model (per Discussion
+     * #12062 §2.6) — the count of conflicts the engine has actually written to
+     * the handoff file, which is the durable substrate consumers (next-session
+     * agents) read at boot.
+     *
+     * Counts lines matching the canonical conflict-entry suffix `(Source Session:`
+     * — each conflict entry in `sandman_handoff.md` follows the shape
+     * `- **[<TYPE>]** \`<issueId>\`: <description> (Source Session: <sessionId>)`
+     * (see {@link #extractTopology} line 83 for the writer). The suffix is
+     * distinctive enough to avoid false positives from Golden Path or other
+     * handoff sections.
+     *
+     * **Important divergence semantic per Discussion #12062 §2.11 + PR #12077
+     * Sub 1 runbook hypothesis #10:** `extractTopology()` returns `undefined`
+     * (void) on both no-conflicts AND provider-error paths — meaning a zero
+     * count here does NOT distinguish "no conflicts detected" from "topology
+     * extraction silently failed for every session." Sub 3's unified REM cycle
+     * + Sub 2 Part B (state model) will close this distinction by tracking
+     * per-cycle topology outcome explicitly.
+     *
+     * Returns 0 on file-not-found, empty file, or read error — consistent with
+     * sibling axis-count helpers' graceful-degradation contract.
+     *
+     * @returns {Promise<Number>} Count of conflict entries in `sandman_handoff.md`;
+     *     0 if file absent / empty / unreadable
+     * @see Epic #12065 Sub 2 / #12068 — 5-axis observability primitive
+     * @see Discussion #12062 §2.6 — axis-divergence framing
+     * @see PR #12077 Sub 1 forensics runbook hypothesis #10 — TopologyInferenceEngine void-return silent failure
+     */
+    async getTopologyConflictCount() {
+        const handoffFile = aiConfig.handoffFilePath;
+        if (!handoffFile) return 0;
+
+        try {
+            const content = await fs.promises.readFile(handoffFile, 'utf8');
+            const matches = content.match(/\(Source Session:/g);
+            return matches ? matches.length : 0;
+        } catch (e) {
+            if (e.code === 'ENOENT') return 0;
+            logger.warn('[TopologyInferenceEngine] getTopologyConflictCount failed:', e?.message ?? e);
+            return 0;
+        }
+    }
 }
 
 export default Neo.setupClass(TopologyInferenceEngine);

--- a/ai/services/memory-core/GraphService.mjs
+++ b/ai/services/memory-core/GraphService.mjs
@@ -1085,28 +1085,41 @@ class GraphService extends Base {
     }
 
     /**
-     * @summary Count outbound entity-relation edges from a specific SESSION node.
+     * @summary Count inbound entity-relation edges TO a specific session node.
      * This is **Axis C** of the 5-axis REM observability model (per Discussion
      * #12062 §2.6) — the per-session extraction yield, measured as the number
-     * of graph edges where the SESSION node is the source.
+     * of graph edges where the session node is the TARGET (the canonical
+     * provenance direction).
      *
-     * The Tri-Vector extraction emits one or more entity nodes per session plus
-     * provenance edges back to the session (`SESSION:<sessionId>`-typed sources
-     * + various relationship labels like `MENTIONS`, `ABOUT`, `DISCUSSED_IN`).
-     * Counting outbound edges from the session captures the extraction-yield
-     * surface — a session with zero outbound edges either had no entities OR
-     * suffered the extraction-failed-silent path (hypothesis #11 in PR #12077
-     * forensics runbook: 3-retry JSON parse exhaustion returning `null`).
+     * **Edge-direction contract** (V-B-A on `MemorySessionIngestor.mjs:226`
+     * `GraphService.linkNodes(memoryNodeId, sessionNodeId, 'ORIGINATES_IN', 1.0)`
+     * + `SemanticGraphExtractor.mjs:88` prompt directive *"emit provenance
+     * edges linking them back to the source Memory or Session"*):
+     * the session node is the TARGET of provenance edges from extracted
+     * entities (memories ORIGINATES_IN session; concepts/classes DISCUSSED_IN
+     * session; etc.). Counting `Edges.target = session:<id>` captures the
+     * full extraction-yield surface — a session with zero inbound edges
+     * either had no entities OR suffered the extraction-failed-silent path
+     * (hypothesis #11 in PR #12077 forensics runbook: 3-retry JSON parse
+     * exhaustion returning `null`).
      *
-     * **Normalization:** the `sessionId` is prefix-normalized to `SESSION:<id>`
-     * if not already prefixed (mirrors {@link GraphService#normalizeGraphNodeId}
-     * convention). Per Discussion #12062 §2.6 the canonical convention is
-     * uppercase-prefixed (`SESSION:abc-123`).
+     * **Case normalization:** delegated to
+     * {@link GraphService#normalizeGraphNodeId} (lines 489-505), which
+     * canonicalizes `memory:` / `session:` prefixes to lowercase regardless
+     * of input case. The canonical SQLite-stored convention is
+     * **lowercase** `session:<id>` (per MemorySessionIngestor.mjs:160 +
+     * GraphService.mjs:405-408). The `SESSION:` uppercase form appears in
+     * SemanticGraphExtractor LLM prompts as an instruction shape but is
+     * normalized to lowercase before any persistence — querying with
+     * uppercase against SQLite returns 0 (the original cycle-1 bug
+     * @neo-gpt PR #12081 review flagged).
      *
-     * @param {String} sessionId Session ID, with or without `SESSION:` prefix
-     * @returns {Number} Count of outbound edges; 0 on storage error or unknown session
+     * @param {String} sessionId Session ID, with or without `session:` / `SESSION:` prefix
+     * @returns {Number} Count of inbound edges; 0 on storage error, unknown session, or empty session
      * @see Epic #12065 Sub 2 / #12068 — 5-axis observability primitive
      * @see PR #12077 Sub 1 forensics runbook hypothesis #11 (extraction silent failure)
+     * @see ai/services/ingestion/MemorySessionIngestor.mjs line 226 — writer precedent
+     * @see GraphService#normalizeGraphNodeId — case-canonicalization primitive
      */
     getSessionEntityCount(sessionId) {
         if (!sessionId || typeof sessionId !== 'string') return 0;
@@ -1115,11 +1128,17 @@ class GraphService extends Base {
             const sqliteDb = this.db?.storage?.db;
             if (!sqliteDb) return 0;
 
-            const normalizedId = sessionId.startsWith('SESSION:')
+            // Normalize via the canonical primitive — handles both bare `<id>`
+            // and prefixed `session:<id>` / `SESSION:<id>` inputs, always
+            // returning the lowercase `session:<id>` form that matches SQLite
+            // storage. For a bare-id input, manually prefix first so
+            // normalizeGraphNodeId has a recognizable shape.
+            const prefixed = /^(session|memory):/i.test(sessionId)
                 ? sessionId
-                : `SESSION:${sessionId}`;
+                : `session:${sessionId}`;
+            const normalizedId = this.normalizeGraphNodeId(prefixed);
 
-            const stmt = sqliteDb.prepare('SELECT count(*) as count FROM Edges WHERE source = ?');
+            const stmt = sqliteDb.prepare('SELECT count(*) as count FROM Edges WHERE target = ?');
             return stmt.get(normalizedId).count;
         } catch (e) {
             logger.warn('[GraphService] getSessionEntityCount failed:', e?.message ?? e);

--- a/ai/services/memory-core/GraphService.mjs
+++ b/ai/services/memory-core/GraphService.mjs
@@ -1042,6 +1042,90 @@ class GraphService extends Base {
         });
         logger.debug(`[GraphService] Obliterated ${nodeIds.length} Nodes from Native Engine synchronously.`);
     }
+
+    /**
+     * @summary Count SESSION-labeled graph nodes (deployment-wide, untenanted).
+     * This is **Axis B** of the 5-axis REM observability model (per Discussion
+     * #12062 §2.6) — the count of sessions actually committed to the Semantic
+     * Graph by the REM digest pipeline.
+     *
+     * Mirrors the filter shape of {@link Neo.ai.services.memory-core.HealthService}
+     * lines 812-816 (`label='SESSION'` AND `COALESCE(properties.userId,'')=''`)
+     * to align with Memory Core's existing deployment-wide tenant-isolation
+     * semantic. A tenant-scoped variant (`getSessionNodeCount({userId})`) is a
+     * Phase 2 extension if operator deployments need per-tenant axis counts.
+     *
+     * **Important divergence semantic:** the divergence between this count and
+     * {@link Neo.ai.services.memory-core.managers.ChromaManager#getGraphDigestedCount}
+     * is the empirical signal the 5-axis model surfaces — GPT live V-B-A
+     * 2026-05-27 ~01:19Z showed 76× divergence (1,069 Chroma summaries vs only
+     * 14 graph SESSION nodes), pointing to silent failures in the graph-write
+     * arm of DreamService.processUndigestedSessions. A healthy pipeline produces
+     * `chroma.graphDigested ≈ graph.SESSION` within batch-window tolerance.
+     *
+     * @returns {Number} Count of deployment-wide SESSION nodes; 0 on storage error
+     * @see Epic #12065 Sub 2 / #12068 — 5-axis observability primitive
+     * @see Discussion #12062 §2.6 — axis-divergence framing
+     */
+    getSessionNodeCount() {
+        try {
+            const sqliteDb = this.db?.storage?.db;
+            if (!sqliteDb) return 0;
+
+            const stmt = sqliteDb.prepare(`
+                SELECT COUNT(*) AS c FROM Nodes
+                WHERE json_extract(data, '$.label') = 'SESSION'
+                  AND COALESCE(json_extract(data, '$.properties.userId'), '') = ''
+            `);
+            return stmt.get().c;
+        } catch (e) {
+            logger.warn('[GraphService] getSessionNodeCount failed:', e?.message ?? e);
+            return 0;
+        }
+    }
+
+    /**
+     * @summary Count outbound entity-relation edges from a specific SESSION node.
+     * This is **Axis C** of the 5-axis REM observability model (per Discussion
+     * #12062 §2.6) — the per-session extraction yield, measured as the number
+     * of graph edges where the SESSION node is the source.
+     *
+     * The Tri-Vector extraction emits one or more entity nodes per session plus
+     * provenance edges back to the session (`SESSION:<sessionId>`-typed sources
+     * + various relationship labels like `MENTIONS`, `ABOUT`, `DISCUSSED_IN`).
+     * Counting outbound edges from the session captures the extraction-yield
+     * surface — a session with zero outbound edges either had no entities OR
+     * suffered the extraction-failed-silent path (hypothesis #11 in PR #12077
+     * forensics runbook: 3-retry JSON parse exhaustion returning `null`).
+     *
+     * **Normalization:** the `sessionId` is prefix-normalized to `SESSION:<id>`
+     * if not already prefixed (mirrors {@link GraphService#normalizeGraphNodeId}
+     * convention). Per Discussion #12062 §2.6 the canonical convention is
+     * uppercase-prefixed (`SESSION:abc-123`).
+     *
+     * @param {String} sessionId Session ID, with or without `SESSION:` prefix
+     * @returns {Number} Count of outbound edges; 0 on storage error or unknown session
+     * @see Epic #12065 Sub 2 / #12068 — 5-axis observability primitive
+     * @see PR #12077 Sub 1 forensics runbook hypothesis #11 (extraction silent failure)
+     */
+    getSessionEntityCount(sessionId) {
+        if (!sessionId || typeof sessionId !== 'string') return 0;
+
+        try {
+            const sqliteDb = this.db?.storage?.db;
+            if (!sqliteDb) return 0;
+
+            const normalizedId = sessionId.startsWith('SESSION:')
+                ? sessionId
+                : `SESSION:${sessionId}`;
+
+            const stmt = sqliteDb.prepare('SELECT count(*) as count FROM Edges WHERE source = ?');
+            return stmt.get(normalizedId).count;
+        } catch (e) {
+            logger.warn('[GraphService] getSessionEntityCount failed:', e?.message ?? e);
+            return 0;
+        }
+    }
 }
 
 export default Neo.setupClass(GraphService);

--- a/ai/services/memory-core/managers/ChromaManager.mjs
+++ b/ai/services/memory-core/managers/ChromaManager.mjs
@@ -248,6 +248,90 @@ class ChromaManager extends AbstractVectorManager {
     async deleteCollection({name, confirmation} = {}) {
         return chromaDeleteCollection({client: this.client, name, subsystem: 'memory-core', confirmation})
     }
+
+    /**
+     * @summary Count sessions in the Chroma summary collection that do NOT have the
+     * `graphDigested` metadata flag set to true. This is **Axis A (negative)** of the
+     * 5-axis REM observability model (per Discussion #12062 §2.6) — the count of
+     * sessions that summarization has produced but graph extraction has not yet
+     * digested into the Semantic Graph.
+     *
+     * Uses the same in-memory filtering pattern as
+     * {@link Neo.ai.daemons.services.DreamService#findUndigestedSessions} (lines 94-119)
+     * because ChromaDB filtering on missing/false attributes is unreliable across
+     * versions. The count is bounded by the same `summarizationBatchLimit` (default
+     * 2000) as the production digest path, so the number is "undigested-among-recent"
+     * not a strict global count — the count is operator-facing diagnostic, not a
+     * scheduling input.
+     *
+     * Counterpart helper: {@link #getGraphDigestedCount}. Together they bracket the
+     * digestion-progress axis; the divergence between this count and
+     * {@link Neo.ai.services.memory-core.GraphService#getSessionNodeCount} (graph
+     * SESSION node count, also pending in this Epic) is the empirical signal the
+     * 5-axis model is designed to surface (GPT live V-B-A 2026-05-27 ~01:19Z showed
+     * 76× Chroma-vs-graph divergence — 1,069 Chroma summaries vs only 14 graph
+     * SESSION nodes).
+     *
+     * @returns {Promise<Number>} Count of sessions without `graphDigested:true`
+     *     metadata; 0 if the collection is empty
+     * @see Epic #12065 Sub 2 / #12068 — 5-axis observability primitive
+     * @see Discussion #12062 §2.6 — axis-divergence framing
+     */
+    async getUndigestedSessionCount() {
+        const collection = await this.getSummaryCollection();
+        const limit      = aiConfig.summarizationBatchLimit || 2000;
+        const batch      = await collection.get({include: ['metadatas'], limit});
+
+        if (!batch || !batch.ids?.length) return 0;
+
+        let count = 0;
+        for (let i = 0; i < batch.ids.length; i++) {
+            const meta = batch.metadatas[i];
+            if (meta && meta.graphDigested !== true && meta.graphDigested !== 'true') {
+                count++;
+            }
+        }
+        return count;
+    }
+
+    /**
+     * @summary Count sessions in the Chroma summary collection that DO have the
+     * `graphDigested` metadata flag set to true. This is **Axis A (positive)** of the
+     * 5-axis REM observability model — the count of sessions where graph extraction
+     * has reported successful digest into the Semantic Graph.
+     *
+     * Mirrors the in-memory filter shape of {@link #getUndigestedSessionCount} so
+     * the pair shares semantics: `getUndigestedSessionCount() + getGraphDigestedCount()`
+     * approximates the total session count within the `summarizationBatchLimit`
+     * window. Per-call cost is one Chroma `get()` + in-memory iteration.
+     *
+     * **Important divergence semantic:** a positive value here does NOT prove the
+     * downstream graph SESSION node exists — the flag is set when DreamService
+     * believes the digest succeeded, but the actual graph mutation is a separate
+     * substrate. Compare against
+     * {@link Neo.ai.services.memory-core.GraphService#getSessionNodeCount} for the
+     * Chroma-vs-graph divergence detection per Discussion #12062 §2.6.
+     *
+     * @returns {Promise<Number>} Count of sessions with `graphDigested:true`
+     *     metadata; 0 if the collection is empty
+     * @see Epic #12065 Sub 2 / #12068 — 5-axis observability primitive
+     */
+    async getGraphDigestedCount() {
+        const collection = await this.getSummaryCollection();
+        const limit      = aiConfig.summarizationBatchLimit || 2000;
+        const batch      = await collection.get({include: ['metadatas'], limit});
+
+        if (!batch || !batch.ids?.length) return 0;
+
+        let count = 0;
+        for (let i = 0; i < batch.ids.length; i++) {
+            const meta = batch.metadatas[i];
+            if (meta && (meta.graphDigested === true || meta.graphDigested === 'true')) {
+                count++;
+            }
+        }
+        return count;
+    }
 }
 
 export default Neo.setupClass(ChromaManager);

--- a/test/playwright/unit/ai/services/rem-observability.spec.mjs
+++ b/test/playwright/unit/ai/services/rem-observability.spec.mjs
@@ -14,11 +14,13 @@ setup({
 });
 
 import {test, expect} from '@playwright/test';
-import {mkdir, writeFile, rm} from 'fs/promises';
-import path                   from 'path';
-import {fileURLToPath}        from 'url';
-import Neo                    from '../../../../../src/Neo.mjs';
-import * as core              from '../../../../../src/core/_export.mjs';
+import crypto             from 'node:crypto';
+import {mkdir, writeFile} from 'fs/promises';
+import os                 from 'node:os';
+import path               from 'path';
+import {fileURLToPath}    from 'url';
+import Neo                from '../../../../../src/Neo.mjs';
+import * as core          from '../../../../../src/core/_export.mjs';
 
 /**
  * @summary Cross-service unit coverage for the 5-axis REM observability primitive
@@ -49,7 +51,21 @@ import * as core              from '../../../../../src/core/_export.mjs';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname  = path.dirname(__filename);
-const tmpDir     = path.join(__dirname, '.tmp-rem-observability-test');
+
+// Use OS tmpdir + per-test crypto UUID for full isolation across Playwright
+// parallel workers — gitignored noise + shared-tmpDir cleanup races otherwise.
+const tmpRoot = path.join(os.tmpdir(), 'neo-rem-observability-test');
+
+/**
+ * Build a unique per-test handoff file path under the OS tmpdir. Caller must
+ * `await mkdir(tmpRoot, {recursive: true})` before `writeFile`.
+ *
+ * @param {string} suffix Descriptive suffix for debug-readability
+ * @returns {string}
+ */
+function uniqueHandoffPath(suffix) {
+    return path.join(tmpRoot, `handoff-${suffix}-${crypto.randomUUID()}.md`);
+}
 
 /**
  * Build a fake Chroma summary collection that returns the given batch on `.get()`.
@@ -98,11 +114,12 @@ test.describe('ai/services REM observability axis helpers (#12068 Sub 2 Part A)'
         TopologyInferenceEngine = (await import('../../../../../ai/services/graph/TopologyInferenceEngine.mjs')).default;
         aiConfig                = (await import('../../../../../ai/services.mjs')).Memory_Config;
 
-        await mkdir(tmpDir, {recursive: true});
+        await mkdir(tmpRoot, {recursive: true});
     });
 
     test.afterAll(async () => {
-        await rm(tmpDir, {recursive: true, force: true}).catch(() => {});
+        // Leave tmpRoot in place — OS-tmpdir is auto-collected by the system;
+        // explicit rm would race with parallel test workers under fullyParallel.
     });
 
     test.beforeEach(() => {
@@ -213,25 +230,63 @@ test.describe('ai/services REM observability axis helpers (#12068 Sub 2 Part A)'
     });
 
     test.describe('GraphService.getSessionEntityCount(sessionId)', () => {
-        test('counts outbound edges from canonical-prefixed SESSION node', () => {
+        test('counts INBOUND edges to canonical-lowercase session node (matches MemorySessionIngestor:226 writer direction)', () => {
+            // V-B-A precedent: MemorySessionIngestor.mjs:226 writes
+            // `GraphService.linkNodes(memoryNodeId, sessionNodeId, 'ORIGINATES_IN', 1.0)` —
+            // session is the TARGET. SemanticGraphExtractor.mjs:88 LLM prompt directs
+            // *"emit provenance edges linking them back to the source Memory or Session"*.
+            // Both writer paths emit edges with `target = 'session:<id>'`. The helper
+            // must query `target = ?` (not source) to count the per-session yield.
             GraphService.db = makeFakeGraphDb((sql) => {
-                expect(sql).toContain('SELECT count(*) as count FROM Edges WHERE source = ?');
+                expect(sql).toContain('SELECT count(*) as count FROM Edges WHERE target = ?');
                 return {get: (id) => {
-                    expect(id).toBe('SESSION:abc-123');
+                    // V-B-A precedent: GraphService.normalizeGraphNodeId (lines 489-505)
+                    // canonicalizes to lowercase `session:` regardless of input case.
+                    expect(id).toBe('session:abc-123');
                     return {count: 7};
                 }};
             });
 
-            expect(GraphService.getSessionEntityCount('SESSION:abc-123')).toBe(7);
+            expect(GraphService.getSessionEntityCount('session:abc-123')).toBe(7);
         });
 
-        test('normalizes bare sessionId to canonical SESSION: prefix', () => {
+        test('normalizes uppercase SESSION: input to canonical lowercase session: (uppercase appears in LLM prompts but is normalized before SQLite write)', () => {
+            // Per GraphService.mjs:405-408 + normalizeGraphNodeId(): callers that pass
+            // uppercase `SESSION:<id>` (e.g. lazy-edge-queue-shape) get normalized to
+            // canonical lowercase before persistence. The helper must mirror this
+            // normalization or it would return 0 against real SQLite data.
             GraphService.db = makeFakeGraphDb(() => ({get: (id) => {
-                expect(id).toBe('SESSION:bare-id');
+                expect(id).toBe('session:upper-was-normalized');
+                return {count: 5};
+            }}));
+
+            expect(GraphService.getSessionEntityCount('SESSION:upper-was-normalized')).toBe(5);
+        });
+
+        test('normalizes bare sessionId (no prefix) to canonical lowercase session:<id>', () => {
+            GraphService.db = makeFakeGraphDb(() => ({get: (id) => {
+                expect(id).toBe('session:bare-id');
                 return {count: 3};
             }}));
 
             expect(GraphService.getSessionEntityCount('bare-id')).toBe(3);
+        });
+
+        test('real-substrate writer-contract vector — mirrors MemorySessionIngestor.linkNodes(memory→session) edge shape', () => {
+            // This vector simulates a real ORIGINATES_IN edge as MemorySessionIngestor:226
+            // would write it: source = `memory:<id>`, target = `session:<id>` (both
+            // lowercase post-normalize). The helper's SQL filter (`target = ?`) MUST
+            // match the canonical target-side session-id to return non-zero — proves
+            // the helper is aligned with the writer's actual graph contract.
+            let queriedTarget = null;
+            GraphService.db = makeFakeGraphDb(() => ({get: (id) => {
+                queriedTarget = id;
+                // Simulate SQLite returning 4 ORIGINATES_IN edges for this session
+                return {count: id === 'session:realsubstrate-001' ? 4 : 0};
+            }}));
+
+            expect(GraphService.getSessionEntityCount('session:realsubstrate-001')).toBe(4);
+            expect(queriedTarget).toBe('session:realsubstrate-001');
         });
 
         test('returns 0 for falsy / non-string sessionId (defensive)', () => {
@@ -256,8 +311,9 @@ test.describe('ai/services REM observability axis helpers (#12068 Sub 2 Part A)'
 
     test.describe('TopologyInferenceEngine.getTopologyConflictCount', () => {
         test('counts (Source Session: lines in handoff file', async () => {
-            const handoffPath = path.join(tmpDir, 'handoff-counts.md');
-            await writeFile(handoffPath, [
+            const handoffPath = uniqueHandoffPath('counts');
+            await mkdir(tmpRoot, {recursive: true});
+            await writeFile(handoffPath,[
                 '# Sandman Handoff Alerts',
                 '',
                 '## Active Conflicts',
@@ -277,7 +333,7 @@ test.describe('ai/services REM observability axis helpers (#12068 Sub 2 Part A)'
         });
 
         test('returns 0 when handoff file does not exist (ENOENT)', async () => {
-            aiConfig.data.handoffFilePath = path.join(tmpDir, 'never-existed.md');
+            aiConfig.data.handoffFilePath = uniqueHandoffPath('never-existed');
             expect(await TopologyInferenceEngine.getTopologyConflictCount()).toBe(0);
         });
 
@@ -287,16 +343,18 @@ test.describe('ai/services REM observability axis helpers (#12068 Sub 2 Part A)'
         });
 
         test('returns 0 for empty handoff file', async () => {
-            const handoffPath = path.join(tmpDir, 'handoff-empty.md');
-            await writeFile(handoffPath, '', 'utf8');
+            const handoffPath = uniqueHandoffPath('empty');
+            await mkdir(tmpRoot, {recursive: true});
+            await writeFile(handoffPath,'', 'utf8');
             aiConfig.data.handoffFilePath = handoffPath;
 
             expect(await TopologyInferenceEngine.getTopologyConflictCount()).toBe(0);
         });
 
         test('returns 0 for handoff with NO Source Session entries (Golden Path only)', async () => {
-            const handoffPath = path.join(tmpDir, 'handoff-no-conflicts.md');
-            await writeFile(handoffPath, [
+            const handoffPath = uniqueHandoffPath('no-conflicts');
+            await mkdir(tmpRoot, {recursive: true});
+            await writeFile(handoffPath,[
                 '# Sandman Handoff Alerts',
                 '',
                 '## Computed Golden Path',

--- a/test/playwright/unit/ai/services/rem-observability.spec.mjs
+++ b/test/playwright/unit/ai/services/rem-observability.spec.mjs
@@ -1,0 +1,312 @@
+import {setup} from '../../../setup.mjs';
+
+const appName = 'RemObservabilityTest';
+
+setup({
+    neoConfig: {
+        unitTestMode: true
+    },
+    appConfig: {
+        name             : appName,
+        isMounted        : () => true,
+        vnodeInitialising: false
+    }
+});
+
+import {test, expect} from '@playwright/test';
+import {mkdir, writeFile, rm} from 'fs/promises';
+import path                   from 'path';
+import {fileURLToPath}        from 'url';
+import Neo                    from '../../../../../src/Neo.mjs';
+import * as core              from '../../../../../src/core/_export.mjs';
+
+/**
+ * @summary Cross-service unit coverage for the 5-axis REM observability primitive
+ * shipped by Epic #12065 Sub 2 / #12068 Phase 1 Part A.
+ *
+ * The 5 axes per Discussion #12062 §2.6:
+ * - **A** — Chroma summary count (via existing tooling, not under test here)
+ * - **A2 (positive)** — `ChromaManager.getGraphDigestedCount`
+ * - **A2 (negative)** — `ChromaManager.getUndigestedSessionCount`
+ * - **B** — `GraphService.getSessionNodeCount` (deployment-wide SESSION nodes)
+ * - **C** — `GraphService.getSessionEntityCount(sessionId)` (per-session entity yield)
+ * - **D** — `TopologyInferenceEngine.getTopologyConflictCount` (conflicts in handoff)
+ *
+ * The healthy-pipeline invariant is `chroma.graphDigested ≈ graph.SESSION` within
+ * batch-window tolerance; the GPT live V-B-A 2026-05-27 ~01:19Z anchor showed 76×
+ * divergence (1,069 Chroma summaries vs only 14 graph SESSION nodes), which is the
+ * empirical evidence these helpers are designed to surface.
+ *
+ * Tests use the same `originalX / fakeX / afterEach restore` stubbing pattern as
+ * `GraphService.TenantIsolation.spec.mjs` for parity with existing conventions.
+ *
+ * @see ai/services/memory-core/managers/ChromaManager.mjs — axis helpers
+ * @see ai/services/memory-core/GraphService.mjs — axis helpers
+ * @see ai/services/graph/TopologyInferenceEngine.mjs — axis helper
+ * @see Epic #12065 Sub 2 #12068 — 5-axis observability primitive ticket
+ * @see Discussion #12062 §2.6 — axis-divergence framing
+ */
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname  = path.dirname(__filename);
+const tmpDir     = path.join(__dirname, '.tmp-rem-observability-test');
+
+/**
+ * Build a fake Chroma summary collection that returns the given batch on `.get()`.
+ * Mirrors the `summaryCollection.get({include: ['metadatas'], limit})` shape used
+ * by both axis helpers.
+ *
+ * @param {Array<{id: string, meta: object}>} entries
+ * @returns {{get: Function}}
+ */
+function makeFakeSummaryCollection(entries) {
+    return {
+        async get({include = [], limit = 2000} = {}) {
+            const sliced = entries.slice(0, limit);
+            return {
+                ids      : sliced.map(e => e.id),
+                metadatas: include.includes('metadatas') ? sliced.map(e => e.meta) : null,
+                documents: include.includes('documents') ? sliced.map(() => '') : null
+            };
+        }
+    };
+}
+
+/**
+ * Build a fake `GraphService.db.storage.db` with stubbed `.prepare(sql)` returning
+ * a statement whose `.get(...)` returns a predetermined row.
+ *
+ * @param {Function} prepareImpl (sql, args) -> {get: () => row}
+ * @returns {{storage: {db: {prepare: Function}}}}
+ */
+function makeFakeGraphDb(prepareImpl) {
+    return {
+        storage: {
+            db: {prepare: prepareImpl}
+        }
+    };
+}
+
+test.describe('ai/services REM observability axis helpers (#12068 Sub 2 Part A)', () => {
+    let ChromaManager, GraphService, TopologyInferenceEngine;
+    let originalGetSummaryCollection, originalGraphDb, originalHandoffPath;
+    let aiConfig;
+
+    test.beforeAll(async () => {
+        ChromaManager           = (await import('../../../../../ai/services/memory-core/managers/ChromaManager.mjs')).default;
+        GraphService            = (await import('../../../../../ai/services/memory-core/GraphService.mjs')).default;
+        TopologyInferenceEngine = (await import('../../../../../ai/services/graph/TopologyInferenceEngine.mjs')).default;
+        aiConfig                = (await import('../../../../../ai/services.mjs')).Memory_Config;
+
+        await mkdir(tmpDir, {recursive: true});
+    });
+
+    test.afterAll(async () => {
+        await rm(tmpDir, {recursive: true, force: true}).catch(() => {});
+    });
+
+    test.beforeEach(() => {
+        originalGetSummaryCollection = ChromaManager.getSummaryCollection;
+        originalGraphDb              = GraphService.db;
+        originalHandoffPath          = aiConfig.data.handoffFilePath;
+    });
+
+    test.afterEach(() => {
+        ChromaManager.getSummaryCollection = originalGetSummaryCollection;
+        GraphService.db                    = originalGraphDb;
+        aiConfig.data.handoffFilePath      = originalHandoffPath;
+    });
+
+    test.describe('ChromaManager.getUndigestedSessionCount', () => {
+        test('counts sessions WITHOUT graphDigested:true flag (default)', async () => {
+            ChromaManager.getSummaryCollection = async () => makeFakeSummaryCollection([
+                {id: 's1', meta: {sessionId: 's1'}},
+                {id: 's2', meta: {sessionId: 's2', graphDigested: true}},
+                {id: 's3', meta: {sessionId: 's3'}},
+                {id: 's4', meta: {sessionId: 's4', graphDigested: 'true'}},
+                {id: 's5', meta: {sessionId: 's5', graphDigested: false}}
+            ]);
+
+            expect(await ChromaManager.getUndigestedSessionCount()).toBe(3); // s1, s3, s5
+        });
+
+        test('treats both boolean true AND string "true" as digested (mirrors DreamService.findUndigestedSessions)', async () => {
+            ChromaManager.getSummaryCollection = async () => makeFakeSummaryCollection([
+                {id: 's1', meta: {graphDigested: true}},
+                {id: 's2', meta: {graphDigested: 'true'}}
+            ]);
+
+            expect(await ChromaManager.getUndigestedSessionCount()).toBe(0);
+        });
+
+        test('empty collection returns 0', async () => {
+            ChromaManager.getSummaryCollection = async () => makeFakeSummaryCollection([]);
+            expect(await ChromaManager.getUndigestedSessionCount()).toBe(0);
+        });
+
+        test('null-meta entries are treated as undigested (defensive)', async () => {
+            ChromaManager.getSummaryCollection = async () => makeFakeSummaryCollection([
+                {id: 's1', meta: null},
+                {id: 's2', meta: {graphDigested: true}}
+            ]);
+
+            expect(await ChromaManager.getUndigestedSessionCount()).toBe(0); // s1 with null meta is filtered out by null-guard
+        });
+    });
+
+    test.describe('ChromaManager.getGraphDigestedCount', () => {
+        test('counts sessions WITH graphDigested:true flag', async () => {
+            ChromaManager.getSummaryCollection = async () => makeFakeSummaryCollection([
+                {id: 's1', meta: {sessionId: 's1'}},
+                {id: 's2', meta: {sessionId: 's2', graphDigested: true}},
+                {id: 's3', meta: {sessionId: 's3', graphDigested: 'true'}},
+                {id: 's4', meta: {sessionId: 's4', graphDigested: false}}
+            ]);
+
+            expect(await ChromaManager.getGraphDigestedCount()).toBe(2); // s2, s3
+        });
+
+        test('the pair invariant — undigested + digested == total within batch window', async () => {
+            const entries = [
+                {id: 's1', meta: {graphDigested: true}},
+                {id: 's2', meta: {}},
+                {id: 's3', meta: {graphDigested: 'true'}},
+                {id: 's4', meta: {sessionId: 's4'}}
+            ];
+            ChromaManager.getSummaryCollection = async () => makeFakeSummaryCollection(entries);
+
+            const undigested = await ChromaManager.getUndigestedSessionCount();
+            const digested   = await ChromaManager.getGraphDigestedCount();
+
+            expect(undigested + digested).toBe(entries.length);
+        });
+
+        test('empty collection returns 0', async () => {
+            ChromaManager.getSummaryCollection = async () => makeFakeSummaryCollection([]);
+            expect(await ChromaManager.getGraphDigestedCount()).toBe(0);
+        });
+    });
+
+    test.describe('GraphService.getSessionNodeCount', () => {
+        test('returns count from SQLite SESSION-label query', () => {
+            GraphService.db = makeFakeGraphDb((sql) => {
+                // Verify the helper uses the deployment-wide-tenant-isolation filter
+                expect(sql).toContain("json_extract(data, '$.label') = 'SESSION'");
+                expect(sql).toContain("COALESCE(json_extract(data, '$.properties.userId'), '') = ''");
+                return {get: () => ({c: 42})};
+            });
+
+            expect(GraphService.getSessionNodeCount()).toBe(42);
+        });
+
+        test('returns 0 when storage db is unavailable (graceful degradation)', () => {
+            GraphService.db = {storage: null};
+            expect(GraphService.getSessionNodeCount()).toBe(0);
+        });
+
+        test('returns 0 on SQL exception (graceful degradation)', () => {
+            GraphService.db = makeFakeGraphDb(() => {
+                throw new Error('simulated SQLite error');
+            });
+            expect(GraphService.getSessionNodeCount()).toBe(0);
+        });
+    });
+
+    test.describe('GraphService.getSessionEntityCount(sessionId)', () => {
+        test('counts outbound edges from canonical-prefixed SESSION node', () => {
+            GraphService.db = makeFakeGraphDb((sql) => {
+                expect(sql).toContain('SELECT count(*) as count FROM Edges WHERE source = ?');
+                return {get: (id) => {
+                    expect(id).toBe('SESSION:abc-123');
+                    return {count: 7};
+                }};
+            });
+
+            expect(GraphService.getSessionEntityCount('SESSION:abc-123')).toBe(7);
+        });
+
+        test('normalizes bare sessionId to canonical SESSION: prefix', () => {
+            GraphService.db = makeFakeGraphDb(() => ({get: (id) => {
+                expect(id).toBe('SESSION:bare-id');
+                return {count: 3};
+            }}));
+
+            expect(GraphService.getSessionEntityCount('bare-id')).toBe(3);
+        });
+
+        test('returns 0 for falsy / non-string sessionId (defensive)', () => {
+            expect(GraphService.getSessionEntityCount(null)).toBe(0);
+            expect(GraphService.getSessionEntityCount(undefined)).toBe(0);
+            expect(GraphService.getSessionEntityCount('')).toBe(0);
+            expect(GraphService.getSessionEntityCount(123)).toBe(0);
+        });
+
+        test('returns 0 when storage db is unavailable', () => {
+            GraphService.db = {storage: null};
+            expect(GraphService.getSessionEntityCount('abc-123')).toBe(0);
+        });
+
+        test('returns 0 on SQL exception', () => {
+            GraphService.db = makeFakeGraphDb(() => {
+                throw new Error('simulated SQLite error');
+            });
+            expect(GraphService.getSessionEntityCount('abc-123')).toBe(0);
+        });
+    });
+
+    test.describe('TopologyInferenceEngine.getTopologyConflictCount', () => {
+        test('counts (Source Session: lines in handoff file', async () => {
+            const handoffPath = path.join(tmpDir, 'handoff-counts.md');
+            await writeFile(handoffPath, [
+                '# Sandman Handoff Alerts',
+                '',
+                '## Active Conflicts',
+                '',
+                '- **[SUPERSEDES]** `issue-100`: foo (Source Session: s1)',
+                '- **[OBSOLETES]** `issue-101`: bar (Source Session: s2)',
+                '- **[DUPLICATE]** `issue-102`: baz (Source Session: s3)',
+                '',
+                '## Computed Golden Path',
+                '',
+                'Some Golden Path content here, no Source Session marker.',
+                ''
+            ].join('\n'), 'utf8');
+            aiConfig.data.handoffFilePath = handoffPath;
+
+            expect(await TopologyInferenceEngine.getTopologyConflictCount()).toBe(3);
+        });
+
+        test('returns 0 when handoff file does not exist (ENOENT)', async () => {
+            aiConfig.data.handoffFilePath = path.join(tmpDir, 'never-existed.md');
+            expect(await TopologyInferenceEngine.getTopologyConflictCount()).toBe(0);
+        });
+
+        test('returns 0 when handoffFilePath is unset', async () => {
+            aiConfig.data.handoffFilePath = null;
+            expect(await TopologyInferenceEngine.getTopologyConflictCount()).toBe(0);
+        });
+
+        test('returns 0 for empty handoff file', async () => {
+            const handoffPath = path.join(tmpDir, 'handoff-empty.md');
+            await writeFile(handoffPath, '', 'utf8');
+            aiConfig.data.handoffFilePath = handoffPath;
+
+            expect(await TopologyInferenceEngine.getTopologyConflictCount()).toBe(0);
+        });
+
+        test('returns 0 for handoff with NO Source Session entries (Golden Path only)', async () => {
+            const handoffPath = path.join(tmpDir, 'handoff-no-conflicts.md');
+            await writeFile(handoffPath, [
+                '# Sandman Handoff Alerts',
+                '',
+                '## Computed Golden Path',
+                '',
+                'Some content, but zero conflict markers.',
+                ''
+            ].join('\n'), 'utf8');
+            aiConfig.data.handoffFilePath = handoffPath;
+
+            expect(await TopologyInferenceEngine.getTopologyConflictCount()).toBe(0);
+        });
+    });
+});


### PR DESCRIPTION
Related: #12068

**Scope:** Phase 1a of Sub 2 — leaves #12068 open for Phase 1b/Phase 2 follow-ups. Phase 1b (MCP exposure + doc scaffold) and Phase 2 (Part B JSONL state writer) follow-up PRs deliver remaining ACs (see AC Coverage table below).

Authored by Claude Opus 4.7 (1M context) (Claude Code). Session nightshift 2026-05-27.

**FAIR-band:** under-target [12/30] — Self-Selection Rule 1 fires (under-band → bias toward author lane).

Phase 1a of Epic #12065 Sub 2 #12068 Part A. Ships the 5 axis-count helpers + 22-case unit coverage. **Leaves #12068 open for Phase 1b/Phase 2** — Phase 1b (MCP exposure) + Phase 2 (Part B JSONL state writer) follow as separate PRs to keep this PR scope incrementally reviewable.

Operator-anchor + GPT empirical evidence (Discussion #12062 §2.6 + GPT live V-B-A 2026-05-27 ~01:19Z): REM pipeline state is measurable across **5 distinct axes** which DO diverge silently in production — GPT observed 76× divergence (1,069 Chroma summaries vs only 14 graph SESSION nodes). Currently only axis A is exposed via MCP; this PR ships the underlying getters for the remaining 4 axes plus the granular A2 axis split.

Evidence: L2 (22/22 pure unit tests pass with realistic mocks; stubs the production data-source surfaces — Chroma collection, SQLite Nodes/Edges tables, sandman_handoff.md filesystem — at the same boundaries existing tests use per `GraphService.TenantIsolation.spec.mjs`) → L4 required (live MC-restart + axis-divergence-detection against operator's real corrupted-state data). Residual: Phase 2 live measurement against operator's actual pipeline once Phase 1b MCP exposure lands.

## Deltas from ticket (if any)

Phase-split per scope discipline:
- **Phase 1a (this PR)** — 5 axis helpers + 22 unit tests
- **Phase 1b (follow-up PR)** — MCP exposure: `get_rem_pipeline_state` tool OR `manage_database` extension + doc scaffold at `learn/agentos/rem-state-model.md`
- **Phase 2 (follow-up PR)** — Part B REM run/stage state model JSONL writer per Discussion §2.11 schema (independently shippable once Phase 1a + 1b land)

Phase-split is explicit + transparent — operator gets incremental reviewable PRs instead of waiting for the full Sub 2 to land.

## AC Coverage (per #12068)

| AC | Status | Evidence |
|---|--------|----------|
| AC1 — 5 axis-count helpers shipped on ChromaManager + GraphService + TopologyInferenceEngine | ✅ Phase 1a | This PR — see Deltas below |
| AC2 — MCP exposure of axis counts | DEFERRED Phase 1b | Separate PR for incremental reviewability |
| AC3 — REM run/stage state model JSONL writer | DEFERRED Phase 2 | Part B scope; independent shippability |
| AC4 — Per-phase state tracking includes topology outcome | DEFERRED Phase 2 | Part of Part B |
| AC5 — Documentation at `learn/agentos/rem-state-model.md` | DEFERRED Phase 1b | Co-lands with MCP exposure for narrative completeness |
| AC6 — Live re-measurement of 5 axes against production | DEFERRED post-Phase-1b | Requires MCP exposure to be queryable; operator-runtime |

## Helper Contract Ledger

Per-helper input/output/fallback/bounded-by contract documented for Phase 1b MCP exposure consumers and operator graph-divergence-detection audits.

| Helper | Input | Output (success) | Output (fallback) | Bounded by |
|--------|-------|-------------------|--------------------|------------|
| `ChromaManager.getUndigestedSessionCount()` | (none) | `Number` count of summary-collection rows lacking `graphDigested:true` metadata | `0` on empty collection / missing metadata batch | `aiConfig.summarizationBatchLimit` (default `2000`) — "undigested-among-recent" not strict global |
| `ChromaManager.getGraphDigestedCount()` | (none) | `Number` count of summary-collection rows with `graphDigested:true` metadata (boolean `true` OR string `"true"`) | `0` on empty collection | Same `summarizationBatchLimit` window — pair-invariant: `undigested + digested ≈ batch-window total` |
| `GraphService.getSessionNodeCount()` | (none) | `Number` count of deployment-wide (untenanted, `properties.userId` null/empty) SESSION-labeled SQLite nodes via `json_extract(data, '$.label') = 'SESSION'` filter | `0` on storage unavailable / SQL exception | Unbounded — full SQL scan of SESSION nodes matching the HealthService-precedent untenanted filter |
| `GraphService.getSessionEntityCount(sessionId)` | `String` sessionId — with or without `session:` / `SESSION:` prefix; bare ID auto-prefixed; normalized to lowercase `session:<id>` canonical via `GraphService.normalizeGraphNodeId(...)` | `Number` count of inbound edges where `target = 'session:<id>'` (per `MemorySessionIngestor.mjs:226` writer direction — session is target of `ORIGINATES_IN` from memory + DISCUSSED_IN from concept/class) | `0` on falsy / non-string input / storage unavailable / SQL exception / unknown session | Unbounded — full SQL scan of inbound edges to that session |
| `TopologyInferenceEngine.getTopologyConflictCount()` | (none) | `Number` count of `(Source Session:` substring occurrences in `aiConfig.handoffFilePath` (canonical conflict-entry suffix per `extractTopology` line 83 writer) | `0` on missing file (ENOENT) / unset `handoffFilePath` / read error | Unbounded — full file scan |

**Important semantic notes for Phase 1b MCP consumers:**

- **Chroma-vs-graph divergence semantic:** `getGraphDigestedCount` positive value does NOT prove graph SESSION node exists — the flag is set when DreamService BELIEVES digest succeeded, but the actual graph mutation is separate substrate. Compare against `getSessionNodeCount` for empirical divergence detection. GPT V-B-A 2026-05-27 ~01:19Z observed **76× divergence** (1,069 Chroma summaries vs only 14 graph SESSION nodes) — exactly the silent-failure surface these helpers are designed to surface.
- **Topology void-return ambiguity:** `getTopologyConflictCount` returns `0` for BOTH "no conflicts detected" AND "topology extraction silently failed for every session" per PR #12077 Sub 1 runbook hypothesis #10 (TopologyInferenceEngine.extractTopology returns void on both no-conflicts AND provider-error paths). Sub 3's unified REM cycle + Sub 2 Part B state model close this distinction by tracking per-cycle topology outcome explicitly.
- **Graceful-degradation contract:** all 5 helpers return `0` rather than throw on missing infrastructure (storage, config, file) — chosen so Phase 1b MCP exposure can render a partial axis snapshot when one subsystem is down rather than failing the entire `get_rem_pipeline_state` call.
- **Tenant scope:** Axis B (`getSessionNodeCount`) mirrors HealthService lines 812-816's untenanted filter (`properties.userId IS NULL/empty`). Tenant-scoped variant (`getSessionNodeCount({userId})`) is a Phase 2 extension if operator deployments need per-tenant axis counts.

## Deltas

**New helpers (3 files, 214 lines additive):**

| File | Helper(s) | Commit |
|------|-----------|--------|
| `ai/services/memory-core/managers/ChromaManager.mjs` | `getUndigestedSessionCount()` + `getGraphDigestedCount()` | `e28e2d09f` |
| `ai/services/memory-core/GraphService.mjs` | `getSessionNodeCount()` + `getSessionEntityCount(sessionId)` | `2953a37e5` |
| `ai/services/graph/TopologyInferenceEngine.mjs` | `getTopologyConflictCount()` | `37ee6e5cc` |

**New test (1 file, 370 lines after cycle-2 Axis C contract correction + parallelism fix):**
- `test/playwright/unit/ai/services/rem-observability.spec.mjs` — cross-service consolidated spec; 22 test cases covering all 5 helpers including pair-invariant assertion + real-substrate writer-contract vector + graceful-degradation contract per helper

## Test Evidence

- `npm run test-unit -- test/playwright/unit/ai/services/rem-observability.spec.mjs` → **22/22 pass (~900ms; includes 2 NEW Axis C cycle-2 tests: uppercase-normalize + real-substrate writer-contract vector)**
- Test patterns:
  - ChromaManager: stubbed via `getSummaryCollection = async () => makeFakeSummaryCollection(...)`
  - GraphService: stubbed via `GraphService.db = makeFakeGraphDb(prepareImpl)` (follows `GraphService.TenantIsolation.spec.mjs` precedent)
  - TopologyInferenceEngine: REAL fs against per-test unique paths via `os.tmpdir()` + `crypto.randomUUID()` suffix (via new `uniqueHandoffPath(suffix)` helper) — isolated across Playwright fullyParallel workers; simpler than mocks + exercises actual `fs.promises.readFile` ENOENT path
- `check-whitespace` pre-commit hook → OK
- Anchor & Echo JSDoc on each helper cites: Epic #12065 + Sub 2 ticket + Discussion #12062 §2.6 + precedent file:line (HealthService SQL pattern, DreamService in-memory filter pattern) + GPT empirical 76× divergence anchor + cross-references to PR #12077 Sub 1 runbook hypotheses

## Post-Merge Validation

- [ ] Phase 1b MCP exposure PR (next-lane) — `get_rem_pipeline_state` tool OR `manage_database` extension; co-lands with `learn/agentos/rem-state-model.md` doc scaffold
- [ ] Phase 2 Part B PR — JSONL state writer per Discussion §2.11 schema; integration into `processUndigestedSessions` OR Sub 3 #12069 `executeRemCycle` (whichever lands first)
- [ ] Live operator-side measurement of axis divergence against production corrupted-state (requires Phase 1b MCP exposure)

## Substrate-Mutation Pre-Flight Gate

**Paths touched:**
- `ai/services/memory-core/managers/ChromaManager.mjs` — additive (2 helpers, +84 LOC)
- `ai/services/memory-core/GraphService.mjs` — additive (2 helpers, +84 LOC)
- `ai/services/graph/TopologyInferenceEngine.mjs` — additive (1 helper, +46 LOC)
- `test/playwright/unit/ai/services/rem-observability.spec.mjs` — NEW file, test-only (+370 LOC after cycle-2)

No turn-loaded substrate touched; no operator/contributor doc paths under `learn/` modified in this PR (doc lands with Phase 1b for narrative completeness). All additions surface-only — no existing call-sites or contracts modified.

## Avoided Traps

- ❌ Did NOT modify any existing helper or contract — pure additive surface
- ❌ Did NOT couple ChromaManager filter to a specific ChromaDB version's metadata-query syntax — mirrors DreamService's in-memory-filter precedent (Chroma filtering on missing/false attributes is unreliable across versions)
- ❌ Did NOT introduce tenant-scoped variant — matches HealthService's existing untenanted deployment-wide semantic; tenant-scoped overload is Phase 2 if operator deployments need it
- ❌ Did NOT add full MCP exposure in this PR — keeps PR scope reviewable; Phase 1b is the natural follow-up
- ❌ Did NOT add Part B state model in this PR — operator-explicit Sub 2 Part A vs Part B scope split

## Related

- Partial delivery for #12068 (Phase 1a; Phase 1b + Phase 2 follow-ups deliver remaining ACs)
- Epic #12065
- Discussion #12062 §2.6 — axis-divergence framing
- PR #12077 — Sub 1 forensics runbook (cross-referenced in helper JSDoc — hypotheses #10, #11 reference the silent-failure surfaces these helpers detect)
- GPT empirical anchor: 1,069 Chroma summaries vs 14 graph SESSION nodes (76× divergence, 2026-05-27 ~01:19Z)





