### PR TITLE
fix(ai): preserve config import materialization edits (#12047)

### DIFF
--- a/ai/scripts/setup/initServerConfigs.mjs
+++ b/ai/scripts/setup/initServerConfigs.mjs
@@ -16,8 +16,9 @@ import {fileURLToPath} from 'url';
  *    structural shape (top-level imports + named exports) against the template.
  *    Mismatched items emit a stderr warning listing what's new in the template.
  *    Operator can refresh the gitignored file by re-running with
- *    `npm run prepare -- --migrate-config` (overwrites `config.mjs` from the
- *    active template shape).
+ *    `npm run prepare -- --migrate-config`. Pure Tier-1 import materialization
+ *    drift is patched in place; broader structural drift still overwrites from
+ *    the active template shape.
  *
  * The Tier-1 pair is the canonical operator overlay for deployment-wide defaults
  * (cookbook §7). Runtime code MUST import from `ai/config.mjs`, never from
@@ -35,6 +36,10 @@ const serversDir = path.join(cwd, 'ai', 'mcp', 'server');
 const aiDir      = path.join(cwd, 'ai');
 
 const MIGRATE_FLAG = '--migrate-config';
+const MATERIALIZED_SERVER_IMPORTS = new Set([
+    '../../../config.mjs',
+    '../../../config.mjs:default'
+]);
 
 /**
  * Projects a `.mjs` file's structural shape — the surface that `initServerConfigs`
@@ -133,6 +138,22 @@ export function materializeServerConfigTemplate(src) {
 }
 
 /**
+ * Detects the narrow drift shape where an existing per-server `config.mjs`
+ * only needs its Tier-1 import materialized, not a full template overwrite.
+ *
+ * @param {{missingImports: String[], missingExports: String[], hasDrift: Boolean}} drift
+ * @returns {Boolean}
+ */
+export function isOnlyServerMaterializationDrift(drift) {
+    return Boolean(
+        drift.hasDrift &&
+        drift.missingExports.length === 0 &&
+        drift.missingImports.length > 0 &&
+        drift.missingImports.every(i => MATERIALIZED_SERVER_IMPORTS.has(i))
+    )
+}
+
+/**
  * Compares two projected shapes and returns the drift items present in
  * `templateShape` but missing from `configShape`. Symmetric drift (items in
  * config but not in template — operator-removed paths) is intentionally NOT
@@ -159,15 +180,17 @@ export function detectDrift(templateShape, configShape) {
  *
  *   1. Template absent — skip (log warning).
  *   2. Config missing — clone materialized template (preserves pre-#10815 behavior).
- *   3. Config present + drift detected — warn-only (default) OR overwrite
- *      from materialized template when invoked with `--migrate-config`.
+ *   3. Config present + drift detected — warn-only (default) OR migrate when
+ *      invoked with `--migrate-config`. Pure Tier-1 import materialization
+ *      patches the existing file in place; broader drift overwrites from the
+ *      materialized template.
  *
  * @param {Object}   [options]
  * @param {String[]} [options.argv=process.argv]   Argv source; injectable for tests.
  * @param {Object}   [options.logger=console]      Log sink; injectable for tests.
  * @param {String}   [options.serversRoot=serversDir]  Override for tests.
  * @returns {Promise<{
- *     processed: Array<{serverName: String, action: 'clone'|'silent'|'warn'|'migrate'|'skip-no-template', drift?: Object}>
+ *     processed: Array<{serverName: String, action: 'clone'|'silent'|'warn'|'migrate'|'skip-no-template', drift?: Object, migration?: String}>
  * }>}
  */
 export async function initConfigs({argv = process.argv, logger = console, serversRoot = serversDir} = {}) {
@@ -204,9 +227,10 @@ export async function initConfigs({argv = process.argv, logger = console, server
             continue;
         }
 
+        const activeSrc = await fs.readFile(activePath, 'utf-8');
         const drift = detectDrift(
             projectSourceShape(activeTemplateSrc),
-            await projectShape(activePath)
+            projectSourceShape(activeSrc)
         );
 
         if (!drift.hasDrift) {
@@ -215,6 +239,15 @@ export async function initConfigs({argv = process.argv, logger = console, server
         }
 
         if (migrate) {
+            const materializedActiveSrc = materializeServerConfigTemplate(activeSrc);
+
+            if (isOnlyServerMaterializationDrift(drift) && materializedActiveSrc !== activeSrc) {
+                logger.log(`[Neo AI] Materializing stale Tier-1 import for '${serverName}' (${MIGRATE_FLAG} set, preserving operator edits)...`);
+                await fs.writeFile(activePath, materializedActiveSrc, 'utf-8');
+                processed.push({serverName, action: 'migrate', migration: 'materialize-import-only', drift});
+                continue;
+            }
+
             logger.log(`[Neo AI] Migrating stale config for '${serverName}' (drift detected, ${MIGRATE_FLAG} set)...`);
             await fs.writeFile(activePath, activeTemplateSrc, 'utf-8');
             processed.push({serverName, action: 'migrate', drift});

--- a/test/playwright/unit/ai/scripts/setup/initServerConfigs.spec.mjs
+++ b/test/playwright/unit/ai/scripts/setup/initServerConfigs.spec.mjs
@@ -151,6 +151,80 @@ test.describe('initServerConfigs — template drift detection (#10815)', () => {
         expect(logger.entries.warn).toEqual([]);
     });
 
+    test('existing server config with stale Tier-1 template import warns without overwriting', async () => {
+        const templateSrc = [
+            `import AiConfig from '../../../config.template.mjs';`,
+            `export default {auth: AiConfig.auth};`,
+            ``
+        ].join('\n');
+        const configSrc = [
+            `import AiConfig from '../../../config.template.mjs';`,
+            `export const customKey = 'operator-preserved';`,
+            `export default {auth: AiConfig.auth, customKey};`,
+            ``
+        ].join('\n');
+        const root = buildServerSandbox({
+            sandboxName     : 'stale-tier1-import-warn',
+            templateContents: templateSrc,
+            configContents  : configSrc
+        });
+
+        const logger = recordingLogger();
+        const result = await initConfigs({
+            argv       : ['node', 'initServerConfigs.mjs'],
+            logger,
+            serversRoot: root
+        });
+
+        const action = result.processed.find(p => p.serverName === 'memory-core');
+        expect(action.action).toBe('warn');
+        expect(action.drift.missingImports).toEqual([
+            '../../../config.mjs',
+            '../../../config.mjs:default'
+        ]);
+        expect(logger.entries.warn.some(l => l.includes('+ import: ../../../config.mjs'))).toBe(true);
+
+        const onDisk = fs.readFileSync(path.join(root, 'memory-core', 'config.mjs'), 'utf-8');
+        expect(onDisk).toBe(configSrc);
+    });
+
+    test('--migrate-config materializes stale Tier-1 import without dropping operator edits', async () => {
+        const templateSrc = [
+            `import AiConfig from '../../../config.template.mjs';`,
+            `export default {auth: AiConfig.auth};`,
+            ``
+        ].join('\n');
+        const configSrc = [
+            `import AiConfig from '../../../config.template.mjs';`,
+            `export const customKey = 'operator-preserved';`,
+            `export default {auth: AiConfig.auth, customKey};`,
+            ``
+        ].join('\n');
+        const root = buildServerSandbox({
+            sandboxName     : 'stale-tier1-import-migrate',
+            templateContents: templateSrc,
+            configContents  : configSrc
+        });
+
+        const logger = recordingLogger();
+        const result = await initConfigs({
+            argv       : ['node', 'initServerConfigs.mjs', '--migrate-config'],
+            logger,
+            serversRoot: root
+        });
+
+        const action = result.processed.find(p => p.serverName === 'memory-core');
+        expect(action.action).toBe('migrate');
+        expect(action.migration).toBe('materialize-import-only');
+        expect(logger.entries.log.some(l => l.includes('preserving operator edits'))).toBe(true);
+
+        const onDisk = fs.readFileSync(path.join(root, 'memory-core', 'config.mjs'), 'utf-8');
+        expect(onDisk).toBe(materializeServerConfigTemplate(configSrc));
+        expect(onDisk).toContain(`from '../../../config.mjs'`);
+        expect(onDisk).toContain(`customKey = 'operator-preserved'`);
+        expect(onDisk).not.toContain('config.template.mjs');
+    });
+
     test('AC2: drifting config.mjs without --migrate-config emits warning, does not overwrite', async () => {
         const templateSrc = [
             `import path from 'path';`,


### PR DESCRIPTION
Fixes #12047

Authored by GPT-5 (Codex Desktop). Session 6ca1b510-51c3-4fac-aa39-a0fd6941318c.

FAIR-band: over-target [18/30] — taking this lane despite over-target because the operator asked for bug-first nightshift work, #12047 was unassigned, and the live V-B-A isolated a current deployment/config migration bug with a narrow two-file fix.

`initConfigs()` already warns when an existing per-server `config.mjs` still imports `../../../config.template.mjs`, but the only available migration path overwrote the whole operator-edited file from the active template. This PR keeps the existing destructive `--migrate-config` behavior for broader structural drift, while adding an import-only migration path for the pure Tier-1 materialization case so operator custom fields survive.

Evidence: L2 (focused unit coverage for warn-only behavior, import-only `--migrate-config`, and existing broad-overwrite migration) -> L2 required (bootstrap-script behavior is local and fully unit-testable). No residuals.

## Deltas from ticket

The original #12047 body framed this as a `unitTestMode` strictness problem. The live issue comment plus PR #12044 evidence narrowed the root cause to stale per-server config materialization. I retitled #12047 before opening this PR so the close target matches the implemented bug.

The implementation deliberately does not change `Neo.setupClass()` or `unitTestMode`; the strict namespace guard remains intact.

## What ships

| Surface | Disposition | Notes |
| --- | --- | --- |
| `ai/scripts/setup/initServerConfigs.mjs` | `fix` | Adds `isOnlyServerMaterializationDrift()` and an import-only `--migrate-config` branch for pure `../../../config.template.mjs` -> `../../../config.mjs` drift. |
| broader structural drift | `keep` | Existing `--migrate-config` full overwrite path is preserved when missing imports/exports go beyond Tier-1 materialization. |
| `initServerConfigs.spec.mjs` | `test` | Adds regression coverage for warn-only preservation and import-only migration preserving operator edits. |

## Test Evidence

```bash
npm run test-unit -- test/playwright/unit/ai/scripts/setup/initServerConfigs.spec.mjs
# 16 passed (577ms)

node --check ai/scripts/setup/initServerConfigs.mjs
# passed

git diff --check origin/dev...HEAD
# passed
```

## Post-Merge Validation

- [ ] Operator can run `npm run prepare -- --migrate-config` against an older per-server `config.mjs` whose only drift is the stale Tier-1 import and confirm local custom fields remain.

## Commit

- `8b529c4dd` — `fix(ai): preserve config import materialization edits (#12047)`
