### PR TITLE
fix(ai): promote Ollama stream keep_alive (#12080)

### DIFF
--- a/ai/provider/Ollama.mjs
+++ b/ai/provider/Ollama.mjs
@@ -267,6 +267,15 @@ class OllamaProvider extends Base {
     async *stream(input, options = {}) {
         const payload = this.preparePayload(input, options, true);
 
+        if (Object.prototype.hasOwnProperty.call(options, 'keep_alive')) {
+            payload.keep_alive = options.keep_alive;
+            delete payload.options?.keep_alive;
+
+            if (payload.options && Object.keys(payload.options).length === 0) {
+                delete payload.options;
+            }
+        }
+
         try {
             const response = await fetch(`${this.host}/api/chat`, {
                 method : 'POST',

--- a/test/playwright/unit/ai/provider/KeepAlive.spec.mjs
+++ b/test/playwright/unit/ai/provider/KeepAlive.spec.mjs
@@ -1,0 +1,136 @@
+import {setup} from '../../../setup.mjs';
+
+const appName = 'AiProviderKeepAliveTest';
+
+setup({
+    neoConfig: {
+        unitTestMode: true
+    },
+    appConfig: {
+        name             : appName,
+        isMounted        : () => true,
+        vnodeInitialising: false
+    }
+});
+
+import {test, expect} from '@playwright/test';
+import Neo            from '../../../../../src/Neo.mjs';
+import * as core      from '../../../../../src/core/_export.mjs';
+
+function createReadableStream(chunks) {
+    const encoder = new TextEncoder();
+    const encoded = chunks.map(chunk => encoder.encode(chunk));
+
+    return {
+        getReader() {
+            let index = 0;
+
+            return {
+                async read() {
+                    if (index >= encoded.length) {
+                        return {done: true};
+                    }
+
+                    return {
+                        done : false,
+                        value: encoded[index++]
+                    };
+                }
+            };
+        }
+    };
+}
+
+test.describe('AI provider keep_alive payload shape (#12080)', () => {
+    let OllamaProvider;
+    let OpenAiCompatibleProvider;
+    let originalFetch;
+
+    test.beforeAll(async () => {
+        OllamaProvider           = (await import('../../../../../ai/provider/Ollama.mjs')).default;
+        OpenAiCompatibleProvider = (await import('../../../../../ai/provider/OpenAiCompatible.mjs')).default;
+    });
+
+    test.beforeEach(() => {
+        originalFetch = globalThis.fetch;
+    });
+
+    test.afterEach(() => {
+        globalThis.fetch = originalFetch;
+    });
+
+    test('Ollama.stream() promotes keep_alive to top-level payload', async () => {
+        let capturedPayload;
+
+        globalThis.fetch = async (url, init) => {
+            expect(url).toBe('http://ollama.test/api/chat');
+            capturedPayload = JSON.parse(init.body);
+
+            return {
+                ok  : true,
+                body: createReadableStream([
+                    '{"message":{"content":"ok"},"done":false}\n',
+                    '{"message":{"content":" done"},"done":true}\n'
+                ])
+            };
+        };
+
+        const provider = Neo.create(OllamaProvider, {
+            host     : 'http://ollama.test',
+            modelName: 'gemma4-test'
+        });
+        const chunks = [];
+
+        for await (const chunk of provider.stream('hello', {keep_alive: '10m', temperature: 0.2})) {
+            chunks.push(chunk);
+        }
+
+        expect(chunks).toEqual(['ok', ' done']);
+        expect(capturedPayload).toMatchObject({
+            model     : 'gemma4-test',
+            stream    : true,
+            keep_alive: '10m',
+            options   : {
+                temperature: 0.2
+            }
+        });
+        expect(capturedPayload.options.keep_alive).toBeUndefined();
+    });
+
+    test('OpenAiCompatible.stream() already keeps keep_alive top-level', async () => {
+        let capturedPayload;
+
+        globalThis.fetch = async (url, init) => {
+            expect(url).toBe('http://openai-compatible.test/v1/chat/completions');
+            capturedPayload = JSON.parse(init.body);
+
+            return {
+                ok  : true,
+                body: createReadableStream([
+                    'data: {"choices":[{"delta":{"content":"ok"}}]}\n\n',
+                    'data: [DONE]\n\n'
+                ])
+            };
+        };
+
+        const provider = Neo.create(OpenAiCompatibleProvider, {
+            host     : 'http://openai-compatible.test',
+            modelName: 'gemma4-test'
+        });
+        const chunks = [];
+
+        for await (const chunk of provider.stream('hello', {keep_alive: '10m', num_ctx: 8192, temperature: 0.2})) {
+            chunks.push(chunk);
+        }
+
+        expect(chunks).toEqual(['ok']);
+        expect(capturedPayload).toMatchObject({
+            model     : 'gemma4-test',
+            stream    : true,
+            keep_alive: '10m',
+            temperature: 0.2
+        });
+        expect(capturedPayload.options).toBeUndefined();
+        expect(capturedPayload.num_ctx).toBeUndefined();
+    });
+});


### PR DESCRIPTION
Refs #12080

Authored by GPT-5 (Codex Desktop). Session 6ca1b510-51c3-4fac-aa39-a0fd6941318c.
FAIR-band: over-target [18/30] — taking this lane despite over-target because the operator explicitly prioritized the new Epic #12065 bug-mitigation path, #12080 was already self-assigned to @neo-gpt, and this branch is the narrow unblocking provider patch while PR #12076 carries the benchmark artifact dependency.

Promotes caller-supplied `keep_alive` from `Ollama.stream()` options into the top-level Ollama `/api/chat` payload so streaming calls can reuse model context windows the same way the benchmark path expects. The patch deliberately does not add a default stream lifetime; it only fixes the serialization shape when callers provide `keep_alive`.

Evidence: L2 (provider mock-fetch unit verifies serialized payload shape for `Ollama.stream()` and the OpenAI-compatible non-regression path) → L2 required (AC1/AC2/AC5 provider contract). Residual: AC3/AC4 [#12080] blocked on PR #12076 merge.

## Deltas from ticket

- Ships AC1, AC2, and AC5 only.
- Leaves AC3/AC4 open because `ai/scripts/benchmark/keep-alive-probe.mjs` and `learn/agentos/gemma4-rem-benchmark.md` are introduced by PR #12076 and are not present on current `dev`.
- Keeps `Ollama.stream()` narrower than `Ollama.generate()` by not forcing the existing `generate()` default `keep_alive: "1h"` onto every streaming request.

## Test Evidence

- `npm run test-unit -- test/playwright/unit/ai/provider/KeepAlive.spec.mjs` → 2 passed.
- `node --check ai/provider/Ollama.mjs` → passed.
- `node --check test/playwright/unit/ai/provider/KeepAlive.spec.mjs` → passed.
- `git diff --cached --check` → passed before commit.
- `git diff --check origin/dev...HEAD` → passed after commit.
- Partial-resolution branch-history check: `git log origin/dev..HEAD --format=%H%x09%s%n%b` contains only `2204598b73ce04a93eab93060ddbe2ceed3de220 fix(ai): promote Ollama stream keep_alive (#12080)` and no closing keyword.
- Pre-push freshness check: `merge-base HEAD origin/dev == origin/dev`; outgoing log contained only `2204598b7 fix(ai): promote Ollama stream keep_alive (#12080)`.

## Post-Merge Validation

- [ ] After PR #12076 lands, finish #12080 AC3/AC4 by enabling the Ollama path in `ai/scripts/benchmark/keep-alive-probe.mjs` and updating `learn/agentos/gemma4-rem-benchmark.md`.

## Commits

- `2204598b7` — `fix(ai): promote Ollama stream keep_alive (#12080)`
