### PR TITLE
fix(memory-core): hard-fail culled mailbox delivery edges (#10284)

### DIFF
--- a/ai/daemons/orchestrator/services/SwarmHeartbeatService.mjs
+++ b/ai/daemons/orchestrator/services/SwarmHeartbeatService.mjs
@@ -546,8 +546,8 @@ class SwarmHeartbeatService extends Base {
      * - `SENT_TO` → direct-message recipients (`AGENT:*` sentinel excluded — broadcasts don't
      *   land at a real identity; the per-recipient `DELIVERED_TO` edges are the actual recipients)
      * - `DELIVERED_TO` → per-recipient broadcast targets (the canonical fan-out edge)
-     * - `SENT_BY`  → message senders (so an active sender lands in the candidate set even
-     *   if no one has replied yet within 3h)
+     * - `SENT_BY`  → agent message senders (so an active sender lands in the candidate set even
+     *   if no one has replied yet within 3h; the `@system` lifecycle sender is excluded)
      *
      * @returns {Promise<String[]>} Normalized canonical `@<identity>` strings, deduplicated.
      * @protected
@@ -589,6 +589,7 @@ class SwarmHeartbeatService extends Base {
                 .map(row => row.identity)
                 .filter(Boolean)
                 .map(identity => normalizeAgentIdentityNodeId(identity))
+                .filter(identity => identity !== '@system')
                 .filter(Boolean);
         } catch (err) {
             logger.error('[SwarmHeartbeatService] getActiveA2aParticipants failed:', err);

--- a/ai/graph/identityRoots.mjs
+++ b/ai/graph/identityRoots.mjs
@@ -1,5 +1,5 @@
 /**
- * @summary Central definition of AgentIdentity and BroadcastSentinel root nodes for the Memory Core Graph.
+ * @summary Central definition of system, AgentIdentity, and BroadcastSentinel root nodes for the Memory Core Graph.
  *
  * This shared list provides the definitive addressable identity surface for the A2A Mailbox
  * substrate.
@@ -7,8 +7,8 @@
  * Capability fields (`contextWindowInput`, `hosting`, `tier`, etc.) per ADR 0012 Model-Stats
  * Framework. Source-cited values mirror `learn/agentos/ModelStats.md`; the registry is the
  * canonical authority for capability-data drift detection. `trustTier` is the #10292 content
- * provenance taxonomy used by Memory Core consumers to distinguish owner, peer-trusted, external,
- * and unclassified authorship at ingestion/query boundaries.
+ * provenance taxonomy used by Memory Core consumers to distinguish system, owner, peer-trusted,
+ * external, and unclassified authorship at ingestion/query boundaries.
  *
  * It is used for both:
  * 1. Boot-time self-seeding in `GraphService.initAsync`
@@ -54,6 +54,20 @@ export const TRUST_TIER_ORDER = Object.freeze([
 ]);
 
 export const IDENTITIES = [
+    {
+        id: '@system',
+        type: 'System',
+        name: 'System Sender',
+        description: 'Non-human system sender used for lifecycle-generated mailbox messages.',
+        properties: {
+            githubLogin: null,
+            displayName: 'System',
+            modelFamily: null,
+            accountType: 'system',
+            trustTier  : TRUST_TIERS.SYSTEM,
+            createdAt  : new Date().toISOString()
+        }
+    },
     {
         id: '@neo-opus-4-7',
         type: 'AgentIdentity',

--- a/ai/scripts/setup/seedAgentIdentities.mjs
+++ b/ai/scripts/setup/seedAgentIdentities.mjs
@@ -7,12 +7,13 @@
  * (see "Test pollution hazard" section in learn/agentos/IdentitySchema.md). Re-seeding is safe —
  * existing createdAt is preserved — but the upstream cause should be fixed rather than masked.
  *
- * @summary Seeds initial AgentIdentity + BroadcastSentinel nodes into the Neo.mjs Memory Core Native Graph.
+ * @summary Seeds initial system, AgentIdentity, and BroadcastSentinel nodes into the Neo.mjs Memory Core Native Graph.
  *
  * These nodes form the **addressable identity surface** for the A2A Mailbox substrate (#10139):
- * human owners (`@tobiu`), model-backed agents (`@neo-opus-4-7`, `@neo-gemini-3-1-pro`), and the
- * `AGENT:*` broadcast sentinel that carries fan-out `SENT_TO` edges emitted by
- * {@link Neo.ai.services.memory-core.MailboxService#addMessage} for broadcast traffic.
+ * the lifecycle system sender (`@system`), human owners (`@tobiu`), model-backed agents
+ * (`@neo-opus-4-7`, `@neo-gemini-3-1-pro`), and the `AGENT:*` broadcast sentinel that carries
+ * fan-out `SENT_TO` edges emitted by {@link Neo.ai.services.memory-core.MailboxService#addMessage}
+ * for broadcast traffic.
  *
  * **Why the broadcast sentinel needs to be a real graph node (#10174):** `GraphService.linkNodes`
  * enforces an FK-style guard that culls edges whose endpoints aren't present in the Nodes table.

--- a/ai/services/memory-core/MailboxService.mjs
+++ b/ai/services/memory-core/MailboxService.mjs
@@ -174,6 +174,53 @@ function getBroadcastDeliveryEdge(messageId, target) {
     return getBroadcastDeliveryEdges(messageId).find(edge => getRecordField(edge, 'target') === target) || null;
 }
 
+/**
+ * @summary Creates a delivery-critical mailbox edge and verifies SQLite persisted it.
+ *
+ * `GraphService.linkNodes()` intentionally culls missing-endpoint edges for broad graph
+ * extraction callers. Mailbox delivery edges have a stricter contract: returning
+ * `{status: 'sent'}` without `SENT_BY`, `SENT_TO`, or broadcast `DELIVERED_TO` rows makes
+ * the MESSAGE structurally unroutable. This helper keeps the hard-fail local to the
+ * mailbox write path instead of changing GraphService's global cull-tolerant semantics.
+ *
+ * @param {String} source Source graph node id.
+ * @param {String} target Target graph node id.
+ * @param {String} type Mailbox delivery edge type.
+ * @param {Number} weight Edge weight.
+ * @param {Object} properties Edge properties.
+ * @param {Object} [diagnostics={}] Additional caller-target diagnostics for error text.
+ * @throws {Error} When the edge does not exist in SQLite after `linkNodes()`.
+ */
+function linkRequiredMailboxEdgeOrThrow(source, target, type, weight, properties, diagnostics = {}) {
+    GraphService.linkNodes(source, target, type, weight, properties);
+
+    const sqlite = GraphService.db?.storage?.db;
+    if (!sqlite) {
+        throw new Error(`[MailboxService] Routing edge creation failed: ${source} -[${type}]-> ${target}. SQLite graph storage is unavailable after GraphService.linkNodes().`);
+    }
+
+    const edgeCount = sqlite.prepare('SELECT count(*) as count FROM Edges WHERE source = ? AND target = ? AND type = ?')
+        .get(source, target, type)
+        .count;
+
+    if (edgeCount !== 1) {
+        const fkVerifyCount = sqlite.prepare('SELECT count(*) as count FROM Nodes WHERE id IN (?, ?)')
+            .get(source, target)
+            .count;
+
+        const details = diagnostics.preNormalizeTo !== undefined
+            ? ` Caller target: ${JSON.stringify(diagnostics.preNormalizeTo)} -> ${JSON.stringify(diagnostics.postNormalizeTo)}.`
+            : '';
+
+        throw new Error(
+            `[MailboxService] Routing edge creation failed: ${source} -[${type}]-> ${target}. ` +
+            `Expected exactly 1 edge row after GraphService.linkNodes(), found ${edgeCount}. ` +
+            `FK endpoint count: ${fkVerifyCount}. GraphService.mjs linkNodes FK guard may have culled the edge.` +
+            details
+        );
+    }
+}
+
 function hasBroadcastDeliveryEdges(messageId) {
     return getBroadcastDeliveryEdges(messageId).length > 0;
 }
@@ -472,50 +519,26 @@ class MailboxService extends Base {
             properties: messageProperties
         });
 
-        // 2. Map the routing edges
-        GraphService.linkNodes(messageId, sentBy, 'SENT_BY', 1.0, { timestamp, userId: sentBy, sharedEntity: true });
-        GraphService.linkNodes(messageId, to, 'SENT_TO', 1.0, { timestamp, userId: sentBy, sharedEntity: true });
+        // 2. Map the delivery-critical routing edges. These must fail loudly if
+        // GraphService's FK guard culls them; otherwise `addMessage()` can return a
+        // misleading success for an unroutable MESSAGE.
+        const routingDiagnostics = {preNormalizeTo, postNormalizeTo};
+        linkRequiredMailboxEdgeOrThrow(messageId, sentBy, 'SENT_BY', 1.0, { timestamp, userId: sentBy, sharedEntity: true }, routingDiagnostics);
+        linkRequiredMailboxEdgeOrThrow(messageId, to, 'SENT_TO', 1.0, { timestamp, userId: sentBy, sharedEntity: true }, routingDiagnostics);
         if (to === 'AGENT:*') {
             for (const recipient of getBroadcastAudience(sentBy)) {
-                GraphService.linkNodes(messageId, recipient, 'DELIVERED_TO', 1.0, {
+                linkRequiredMailboxEdgeOrThrow(messageId, recipient, 'DELIVERED_TO', 1.0, {
                     deliveredAt: timestamp,
                     readAt: null,
                     deliveryKind: 'broadcast',
                     userId: sentBy,
                     sharedEntity: true
-                });
+                }, routingDiagnostics);
             }
         }
 
-        // Make SENT_TO edge-creation failures loud and cross-process readable.
-        try {
-            const edgeCount = GraphService.db.storage.db.prepare('SELECT count(*) as count FROM Edges WHERE source = ? AND target = ? AND type = ?').get(messageId, to, 'SENT_TO').count;
-            if (edgeCount === 0) {
-                const fkVerifyCount = GraphService.db.storage.db.prepare('SELECT count(*) as count FROM Nodes WHERE id IN (?, ?)').get(messageId, to).count;
-
-                const logEntry = {
-                    msg: "[#10347 Phase 1] Intermittent SENT_TO edge cull detected",
-                    timestamp,
-                    caller_passed_to: preNormalizeTo,
-                    pre_normalize_to: preNormalizeTo,
-                    post_normalize_to: postNormalizeTo,
-                    fk_verify_count: fkVerifyCount,
-                    identity_binding_me: sentBy,
-                    edge_type: 'SENT_TO',
-                    message_id: messageId
-                };
-
-                Promise.all([import('fs'), import('path'), import('../../mcp/server/memory-core/logger.mjs')]).then(([{ default: fs }, { default: path }, { default: logger }]) => {
-                    logger.warn(JSON.stringify(logEntry));
-                    const logPath = path.join(path.dirname(aiConfig.storagePaths.graph), 'sent-to-cull.jsonl');
-                    fs.appendFileSync(logPath, JSON.stringify(logEntry) + '\n');
-                });
-            }
-        } catch (e) {
-            // fail silently on observability errors to not break the message send
-        }
-
-        // 3. Map additional graph semantic edges
+        // 3. Map additional graph semantic edges. These remain cull-tolerant:
+        // mailbox delivery does not depend on optional provenance/thread/concept links.
         if (originSessionId) GraphService.linkNodes(messageId, originSessionId, 'ORIGINATES_IN', 1.0, { timestamp, userId: sentBy, sharedEntity: true });
         if (inReplyTo) GraphService.linkNodes(messageId, inReplyTo, 'IN_REPLY_TO', 1.0, { timestamp, userId: sentBy, sharedEntity: true });
         if (partOfThread) GraphService.linkNodes(messageId, partOfThread, 'PART_OF_THREAD', 1.0, { timestamp, userId: sentBy, sharedEntity: true });

--- a/test/playwright/unit/ai/daemons/orchestrator/services/SwarmHeartbeatService.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/services/SwarmHeartbeatService.spec.mjs
@@ -437,7 +437,8 @@ test.describe('Neo.ai.daemons.SwarmHeartbeatService', () => {
                                 {identity: 'neo-gpt'},          // SENT_TO recipient (direct DM)
                                 {identity: '@neo-opus-4-7'},    // DELIVERED_TO recipient (broadcast fan-out)
                                 {identity: null},
-                                {identity: '@neo-gemini-3-1-pro'} // SENT_BY sender
+                                {identity: '@neo-gemini-3-1-pro'}, // SENT_BY sender
+                                {identity: '@system'}              // lifecycle sender, excluded
                             ];
                         }
                     };
@@ -460,7 +461,7 @@ test.describe('Neo.ai.daemons.SwarmHeartbeatService', () => {
         // MESSAGE label filter on all branches.
         expect(capturedSql).toContain("json_extract(n.data, '$.label') = 'MESSAGE'");
 
-        // Identities normalized + null filtered; dedup via SELECT DISTINCT.
+        // Identities normalized + null/system filtered; dedup via SELECT DISTINCT.
         expect(result).toEqual(['@neo-gpt', '@neo-opus-4-7', '@neo-gemini-3-1-pro']);
 
         // 3 cutoff params (one per UNION branch); identical (same Date.now() snapshot); ISO format.

--- a/test/playwright/unit/ai/services/memory-core/GraphService.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/GraphService.spec.mjs
@@ -715,7 +715,11 @@ test.describe('Neo.ai.services.memory-core.GraphService', () => {
         // Run the boot sequence
         await GraphService.initAsync();
 
-        // Assert all four identities are present with correct types
+        // Assert the system sender plus core identities are present with correct types
+        const system = await GraphService.getNode({id: '@system'});
+        expect(system).toBeTruthy();
+        expect(system.type).toBe('System');
+
         const geminiPro = await GraphService.getNode({id: '@neo-gemini-3-1-pro'});
         expect(geminiPro).toBeTruthy();
         expect(geminiPro.type).toBe('AgentIdentity');

--- a/test/playwright/unit/ai/services/memory-core/MailboxService.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/MailboxService.spec.mjs
@@ -133,6 +133,58 @@ test.describe('Neo.ai.services.memory-core.MailboxService', () => {
         expect(sentTo).toBe('@bob');
     });
 
+    test('addMessage throws when a required SENT_TO routing edge is culled (#10284)', async () => {
+        await RequestContextService.run({ agentIdentityNodeId: '@bob' }, async () => {
+            await PermissionService.grantPermission({ to: '@alice', scope: 'CAN_REPLY_TO' });
+        });
+
+        const originalLinkNodes = GraphService.linkNodes;
+
+        try {
+            GraphService.linkNodes = function(source, target, relationship, weight, properties) {
+                if (relationship === 'SENT_TO') {
+                    return;
+                }
+
+                return originalLinkNodes.call(GraphService, source, target, relationship, weight, properties);
+            };
+
+            await RequestContextService.run({ agentIdentityNodeId: '@alice' }, async () => {
+                await expect(MailboxService.addMessage({
+                    to     : '@bob',
+                    subject: 'culled route',
+                    body   : 'body'
+                })).rejects.toThrow(/Routing edge creation failed: MESSAGE:.* -\[SENT_TO\]-> @bob/);
+            });
+        } finally {
+            GraphService.linkNodes = originalLinkNodes;
+        }
+    });
+
+    test('addMessage throws when a required broadcast DELIVERED_TO edge is culled (#10284)', async () => {
+        const originalLinkNodes = GraphService.linkNodes;
+
+        try {
+            GraphService.linkNodes = function(source, target, relationship, weight, properties) {
+                if (relationship === 'DELIVERED_TO') {
+                    return;
+                }
+
+                return originalLinkNodes.call(GraphService, source, target, relationship, weight, properties);
+            };
+
+            await RequestContextService.run({ agentIdentityNodeId: '@alice' }, async () => {
+                await expect(MailboxService.addMessage({
+                    to     : 'AGENT:*',
+                    subject: 'culled broadcast',
+                    body   : 'body'
+                })).rejects.toThrow(/Routing edge creation failed: MESSAGE:.* -\[DELIVERED_TO\]-> @bob/);
+            });
+        } finally {
+            GraphService.linkNodes = originalLinkNodes;
+        }
+    });
+
     test('listMessages properly isolates by identity', async () => {
         await RequestContextService.run({ agentIdentityNodeId: '@bob' }, async () => {
             await PermissionService.grantPermission({ to: '@alice', scope: 'CAN_REPLY_TO' });

--- a/test/playwright/unit/ai/services/memory-core/MemoryService.Schema.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/MemoryService.Schema.spec.mjs
@@ -125,6 +125,7 @@ test.describe('MemoryService — AGENT_MEMORY Schema (#10620)', () => {
         }
 
         expect(IDENTITIES.find(identity => identity.id === '@tobiu').properties.trustTier).toBe(TRUST_TIERS.OWNER);
+        expect(IDENTITIES.find(identity => identity.id === '@system').properties.trustTier).toBe(TRUST_TIERS.SYSTEM);
         expect(IDENTITIES.find(identity => identity.id === '@neo-gpt').properties.trustTier).toBe(TRUST_TIERS.PEER_TRUSTED);
         expect(IDENTITIES.find(identity => identity.id === '@neo-opus-4-7').properties.trustTier).toBe(TRUST_TIERS.PEER_TRUSTED);
         expect(IDENTITIES.find(identity => identity.id === 'AGENT:*').properties.trustTier).toBe(TRUST_TIERS.UNCLASSIFIED);


### PR DESCRIPTION
Resolves #10284

Authored by GPT-5 (Codex Desktop). Session 6ca1b510-51c3-4fac-aa39-a0fd6941318c.

FAIR-band: over-target [18/30] - taking this lane despite over-target because #10284 is a live bug-mitigation lane for the current wake/A2A graph-pruning failure mode, and no review-requested PRs were available at pickup time.

Evidence: L2 (unit-level cull reproduction against MailboxService plus real SQLite edge verification) -> L2 required (issue ACs require addMessage to stop reporting success when delivery routing edges are culled). No residuals.

MailboxService now treats delivery-critical graph edges as a strict write contract. `addMessage()` creates and verifies `SENT_BY`, direct `SENT_TO`, and broadcast `DELIVERED_TO` rows before it can report `{status: 'sent'}`, so GraphService's missing-endpoint cull guard can no longer turn a structurally unroutable MESSAGE into a silent success. The follow-up commit also seeds `@system` as a non-AgentIdentity system sender root, preserving lifecycle-generated `SENT_BY` edges without making system a broadcast recipient.

## Deltas from Ticket

The current substrate already contained a partial successor from #10347: an async `SENT_TO` cull warning path that logged and then allowed `addMessage()` to keep succeeding. This PR replaces that soft observability path with a local hard-fail wrapper for mailbox delivery edges.

Scope is intentionally limited to delivery-critical routing edges:

- `SENT_BY`
- `SENT_TO`
- broadcast `DELIVERED_TO`

Optional semantic/provenance links remain cull-tolerant because mailbox delivery does not depend on them, and existing callers can pass values that are not guaranteed graph nodes, such as `relatedTickets: ['#N']` or free-form manual concepts. Changing GraphService globally would risk breaking Dream/graph extraction callers that intentionally rely on cull-tolerant linking.

CI surfaced one legitimate adjacent endpoint after the initial PR open: `trioWakeCooldown.mjs` sends lifecycle mailbox messages from `@system`, but `@system` was not previously a graph root because silent `SENT_BY` culling hid the gap. The branch now seeds `@system` with `type: 'System'` / `trustTier: system`, and `SwarmHeartbeatService.getActiveA2aParticipants()` filters `@system` out so system-originated wakes do not become fake active maintainer participants.

## Test Evidence

- `node --check ai/services/memory-core/MailboxService.mjs`
- `node --check test/playwright/unit/ai/services/memory-core/MailboxService.spec.mjs`
- `node --check ai/graph/identityRoots.mjs`
- `node --check ai/daemons/orchestrator/services/SwarmHeartbeatService.mjs`
- `node --check ai/scripts/setup/seedAgentIdentities.mjs`
- `npm run test-unit -- test/playwright/unit/ai/services/memory-core/MailboxService.spec.mjs` - 61 passed; non-fatal Chroma cleanup warnings were emitted after some tests when deleting test collections
- `npm run test-unit -- test/playwright/unit/ai/scripts/lifecycle/trioWakeCooldown.spec.mjs` - 3 passed; run escalated locally because `.neo-ai-data/wake-daemon` is a symlink outside the Codex sandbox
- `npm run test-unit -- test/playwright/unit/ai/daemons/orchestrator/services/SwarmHeartbeatService.spec.mjs test/playwright/unit/ai/services/memory-core/MemoryService.Schema.spec.mjs test/playwright/unit/ai/services/memory-core/GraphService.spec.mjs` - 59 passed; non-fatal Chroma cleanup warnings
- `npm run test-unit -- test/playwright/unit/ai/services/memory-core/WriteSideInvariant.spec.mjs` - 3 passed; non-fatal Chroma cleanup warnings
- `git diff --check`
- `git diff --cached --check`

## Post-Merge Validation

- [ ] A future delivery-edge cull during A2A send surfaces as a tool-call error/log instead of false `{status: 'sent'}`.
- [ ] Downstream #10347-style diagnostics can use the thrown error details instead of recovering from `sent-to-cull.jsonl`.

## Substrate

No turn-loaded, skill-loaded, or `learn/agentos/**` instruction substrate changed.

## Avoided Traps

- Did not change `GraphService.linkNodes()` global cull semantics.
- Did not hard-fail optional semantic/provenance links that are not delivery requirements.
- Did not model `@system` as an `AgentIdentity`, preventing broadcast fan-out and active-participant accounting drift.
- Did not add retry/backoff behavior; this PR only removes the silent-success failure mode.

## Commit

- `c0350b80c` - `fix(memory-core): hard-fail culled mailbox delivery edges (#10284)`
- `77907c959` - `fix(memory-core): seed system mailbox sender (#10284)`
