### PR TITLE
feat(ai): expose REM pipeline state MCP tool (#12087)

### DIFF
--- a/ai/mcp/server/memory-core/openapi.yaml
+++ b/ai/mcp/server/memory-core/openapi.yaml
@@ -112,6 +112,42 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
 
+  /rem/pipeline-state:
+    post:
+      summary: Get REM Pipeline State
+      operationId: get_rem_pipeline_state
+      x-pass-as-object: true
+      x-annotations:
+        readOnlyHint: true
+      description: >
+        Returns the 5-axis REM pipeline observability snapshot: undigested Chroma summaries,
+        graph-digested Chroma summaries, SQLite SESSION nodes, topology conflicts, and optional
+        per-session entity count.
+      tags: [Health]
+      requestBody:
+        required: false
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                sessionId:
+                  type: string
+                  description: Optional session id for per-session entity-count projection.
+      responses:
+        '200':
+          description: REM pipeline state snapshot.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RemPipelineStateResponse'
+        '500':
+          description: Operation failed.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
   /memories:
     post:
       summary: Add New Memory
@@ -1438,6 +1474,42 @@ paths:
 
 components:
   schemas:
+    RemPipelineStateResponse:
+      type: object
+      required:
+        - undigested
+        - digested
+        - sessionNodes
+        - topologyConflicts
+      properties:
+        undigested:
+          type: integer
+          description: Chroma session summaries without graphDigested true in the current batch window.
+          example: 8
+        digested:
+          type: integer
+          description: Chroma session summaries with graphDigested true in the current batch window.
+          example: 109
+        sessionNodes:
+          type: integer
+          description: Deployment-wide SQLite SESSION node count.
+          example: 109
+        topologyConflicts:
+          type: integer
+          description: Conflict entries currently present in the Sandman handoff file.
+          example: 2
+        perSession:
+          type: object
+          nullable: true
+          properties:
+            sessionId:
+              type: string
+              description: Session id supplied by the caller.
+              example: "550e8400-e29b-41d4-a716-446655440000"
+            entityCount:
+              type: integer
+              description: Inbound graph entity/provenance edge count for the session.
+              example: 17
     HealthCheckResponse:
       type: object
       properties:

--- a/ai/mcp/server/memory-core/toolService.mjs
+++ b/ai/mcp/server/memory-core/toolService.mjs
@@ -36,6 +36,7 @@ const serviceMapping = {
     add_message           : MailboxService          .addMessage          .bind(MailboxService),
     list_messages         : MailboxService          .listMessages        .bind(MailboxService),
     get_message           : MailboxService          .getMessage          .bind(MailboxService),
+    get_rem_pipeline_state: HealthService           .getRemPipelineState .bind(HealthService),
     mark_read             : MailboxService          .markRead            .bind(MailboxService),
     archive_message       : MailboxService          .archiveMessage      .bind(MailboxService),
     delete_message        : MailboxService          .deleteMessage       .bind(MailboxService),

--- a/ai/services/memory-core/HealthService.mjs
+++ b/ai/services/memory-core/HealthService.mjs
@@ -598,6 +598,81 @@ export function buildChromaMigrationStats(metadatas, {summaryCollection = false}
     return stats;
 }
 
+/**
+ * @summary Runs one REM observability axis probe with zero-value fallback.
+ *
+ * The MCP surface is operator-facing diagnostics, not a scheduling input. A
+ * single unavailable backing store must not hide every other axis, so failures
+ * are logged and projected as `0` in line with #12087's fallback contract.
+ *
+ * @param {String} label Human-readable axis label for warning logs
+ * @param {Function} fn Probe function returning the axis count
+ * @returns {Promise<Number>} Axis count or `0` on failure
+ */
+async function resolveRemAxis(label, fn) {
+    try {
+        return await fn();
+    } catch (e) {
+        logger.warn(`[HealthService] get_rem_pipeline_state axis ${label} failed:`, e?.message ?? e);
+        return 0;
+    }
+}
+
+/**
+ * @summary Builds the operator-facing 5-axis REM pipeline state projection.
+ *
+ * This composes the Phase 1a axis helpers from Epic #12065 Sub 2 into a single
+ * MCP-safe read envelope without mutating the Dream Pipeline. The helper remains
+ * in the Memory Core service boundary because the MCP server layer maps
+ * operationIds to existing services after the post-M6 service lift.
+ *
+ * @param {Object} [options]
+ * @param {String} [options.sessionId] Optional session id for per-session entity yield
+ * @returns {Promise<Object>} 5-axis REM pipeline state projection
+ * @see ChromaManager#getUndigestedSessionCount
+ * @see ChromaManager#getGraphDigestedCount
+ * @see Neo.ai.services.memory-core.GraphService#getSessionNodeCount
+ * @see Neo.ai.daemons.services.TopologyInferenceEngine#getTopologyConflictCount
+ * @see https://github.com/neomjs/neo/issues/12087
+ */
+export async function buildRemPipelineState({sessionId} = {}) {
+    const [
+        {default: GraphService},
+        {default: TopologyInferenceEngine}
+    ] = await Promise.all([
+        import('./GraphService.mjs'),
+        import('../graph/TopologyInferenceEngine.mjs')
+    ]);
+
+    const [
+        undigested,
+        digested,
+        sessionNodes,
+        topologyConflicts
+    ] = await Promise.all([
+        resolveRemAxis('undigested',        () => ChromaManager.getUndigestedSessionCount()),
+        resolveRemAxis('digested',          () => ChromaManager.getGraphDigestedCount()),
+        resolveRemAxis('sessionNodes',      () => GraphService.getSessionNodeCount()),
+        resolveRemAxis('topologyConflicts', () => TopologyInferenceEngine.getTopologyConflictCount())
+    ]);
+
+    const state = {
+        undigested,
+        digested,
+        sessionNodes,
+        topologyConflicts
+    };
+
+    if (sessionId) {
+        state.perSession = {
+            sessionId,
+            entityCount: await resolveRemAxis('perSession.entityCount', () => GraphService.getSessionEntityCount(sessionId))
+        };
+    }
+
+    return state;
+}
+
 class HealthService extends Base {
     static config = {
         /**
@@ -1156,6 +1231,21 @@ class HealthService extends Base {
                 code   : 'HEALTH_CHECK_ERROR'
             };
         }
+    }
+
+    /**
+     * Public API: returns the 5-axis REM pipeline observability state.
+     *
+     * This method backs the `get_rem_pipeline_state` MCP tool. It deliberately
+     * avoids the broader healthcheck cache because the operator-facing axis
+     * counts are cheap and should reflect the latest Chroma/SQLite/handoff state.
+     *
+     * @param {Object} [options]
+     * @param {String} [options.sessionId] Optional session id for per-session entity yield
+     * @returns {Promise<Object>} 5-axis REM pipeline state projection
+     */
+    async getRemPipelineState(options = {}) {
+        return buildRemPipelineState(options);
     }
 
     /**

--- a/learn/agentos/rem-state-model.md
+++ b/learn/agentos/rem-state-model.md
@@ -1,0 +1,80 @@
+# REM State Model
+
+## 5-Axis Snapshot
+
+The REM pipeline exposes a read-only Memory Core MCP tool, `get_rem_pipeline_state`,
+for operator-visible pipeline health. Phase 1b is a projection layer over the
+Phase 1a helpers; it does not write graph nodes or mutate Sandman state.
+
+```js
+{
+    undigested       : Number, // Chroma summaries without graphDigested true
+    digested         : Number, // Chroma summaries with graphDigested true
+    sessionNodes     : Number, // SQLite SESSION nodes
+    topologyConflicts: Number, // handoff conflict entries
+    perSession       : {
+        sessionId  : String,
+        entityCount: Number // inbound graph entity/provenance edges
+    }
+}
+```
+
+The key diagnostic is divergence between `digested` and `sessionNodes`. A healthy
+REM digest path keeps those counts close within a batch window; a wide gap means
+Chroma believes sessions were digested while the Native Edge Graph did not receive
+matching SESSION nodes. This is the failure class surfaced by the 76x divergence
+anchor from Epic #12065 Sub 2.
+
+## Source Anchors
+
+PR #12081 shipped the Phase 1a helper JSDocs that define the current axis
+contracts in `ChromaManager`, `GraphService`, and `TopologyInferenceEngine`.
+This MCP projection intentionally composes those helpers instead of redefining
+their semantics at the server layer.
+
+PR #12077 shipped the Sub 1 Sandman silent-failure forensics runbook. Use that
+runbook when the axis snapshot indicates drift; this page only explains how to
+read the snapshot and where Phase 2 state will attach.
+
+## MCP Usage
+
+Use the deployment-wide snapshot first:
+
+```js
+await callTool('get_rem_pipeline_state', {});
+```
+
+When a specific session looks suspicious, pass `sessionId` to include Axis C:
+
+```js
+await callTool('get_rem_pipeline_state', {
+    sessionId: '550e8400-e29b-41d4-a716-446655440000'
+});
+```
+
+## Operator Cookbook
+
+Check `undigested` to confirm the queue is actually draining. If it remains high
+across multiple REM cycles, the graph extraction arm is not catching up or the
+provider is not completing enough sessions per cycle.
+
+Compare `digested` with `sessionNodes`. If `digested` rises but `sessionNodes`
+does not, the pipeline is setting `graphDigested` without durable SESSION-node
+growth. That is a silent-failure signal and should be investigated before trusting
+the Sandman handoff.
+
+Use `topologyConflicts` as the handoff-conflict count only. A zero value does not
+prove topology extraction succeeded; it can also mean the provider/error path
+returned no durable conflict entries. Phase 2 will add per-cycle stage outcomes to
+disambiguate no-conflict from extraction-failed.
+
+Use `perSession.entityCount` to inspect extraction yield for a single session. A
+digested session with zero inbound entity/provenance edges is suspicious when the
+payload clearly contained entities.
+
+## Phase 2 Pointer
+
+Phase 2 extends this scaffold with append-only JSONL cycle state, per-phase
+wall-clock timings, and cadence-overflow detection. That state belongs off-graph
+so a broken REM run does not mutate the active control plane while diagnosing
+itself.

--- a/test/playwright/unit/ai/mcp/server/memory-core/McpServerToolLimits.spec.mjs
+++ b/test/playwright/unit/ai/mcp/server/memory-core/McpServerToolLimits.spec.mjs
@@ -87,4 +87,18 @@ test.describe('Neo.ai.mcp.server.memory-core Tool limits', () => {
         expect(neighbor.properties.semanticVectorId.description).toContain('semantic vector identifier');
         expect(neighbor.additionalProperties).not.toBe(false);
     });
+
+    test('get_rem_pipeline_state surfaces the REM axis-count output contract (#12087)', async () => {
+        const { tools } = await toolService.listTools();
+        const tool = tools.find(item => item.name === 'get_rem_pipeline_state');
+
+        expect(tool).toBeTruthy();
+        expect(tool.annotations.readOnlyHint).toBe(true);
+        expect(tool.outputSchema.properties.undigested.type).toBe('integer');
+        expect(tool.outputSchema.properties.digested.type).toBe('integer');
+        expect(tool.outputSchema.properties.sessionNodes.type).toBe('integer');
+        expect(tool.outputSchema.properties.topologyConflicts.type).toBe('integer');
+        const perSession = tool.outputSchema.properties.perSession.anyOf.find(item => item.type === 'object');
+        expect(perSession.properties.entityCount.type).toBe('integer');
+    });
 });

--- a/test/playwright/unit/ai/services/rem-observability.spec.mjs
+++ b/test/playwright/unit/ai/services/rem-observability.spec.mjs
@@ -367,4 +367,53 @@ test.describe('ai/services REM observability axis helpers (#12068 Sub 2 Part A)'
             expect(await TopologyInferenceEngine.getTopologyConflictCount()).toBe(0);
         });
     });
+
+    test.describe('Memory Core MCP get_rem_pipeline_state', () => {
+        test('projects all 5 axes plus optional per-session entity count through the MCP tool', async () => {
+            ChromaManager.getSummaryCollection = async () => makeFakeSummaryCollection([
+                {id: 's1', meta: {sessionId: 's1'}},
+                {id: 's2', meta: {sessionId: 's2', graphDigested: true}},
+                {id: 's3', meta: {sessionId: 's3', graphDigested: 'true'}},
+                {id: 's4', meta: {sessionId: 's4'}}
+            ]);
+
+            GraphService.db = makeFakeGraphDb((sql) => {
+                if (sql.includes('FROM Nodes')) {
+                    return {get: () => ({c: 2})};
+                }
+
+                return {get: (id) => {
+                    expect(id).toBe('session:s1');
+                    return {count: 9};
+                }};
+            });
+
+            const handoffPath = uniqueHandoffPath('mcp-state');
+            await mkdir(tmpRoot, {recursive: true});
+            await writeFile(handoffPath, [
+                '# Sandman Handoff Alerts',
+                '',
+                '## Active Conflicts',
+                '',
+                '- **[SUPERSEDES]** `issue-100`: foo (Source Session: s1)',
+                '- **[DUPLICATE]** `issue-101`: bar (Source Session: s2)',
+                ''
+            ].join('\n'), 'utf8');
+            aiConfig.data.handoffFilePath = handoffPath;
+
+            const {callTool} = await import('../../../../../ai/mcp/server/memory-core/toolService.mjs');
+            const state = await callTool('get_rem_pipeline_state', {sessionId: 's1'});
+
+            expect(state).toEqual({
+                undigested       : 2,
+                digested         : 2,
+                sessionNodes     : 2,
+                topologyConflicts: 2,
+                perSession       : {
+                    sessionId  : 's1',
+                    entityCount: 9
+                }
+            });
+        });
+    });
 });


### PR DESCRIPTION
Resolves #12087

Authored by GPT-5 (Codex Desktop). Session 6ca1b510-51c3-4fac-aa39-a0fd6941318c.

FAIR-band: over-target [17/30] - taking this lane despite over-target because #12087 is a fresh Epic #12065 dependency that unblocks #12088 wall-clock JSONL state work, and the operator explicitly asked to focus recent backlog bug-mitigation lanes after team PRs merged.

This PR exposes the merged Phase 1a REM observability helpers through a read-only Memory Core MCP tool, `get_rem_pipeline_state`, and adds the operator-facing `learn/agentos/rem-state-model.md` scaffold for interpreting the 5-axis snapshot.

Evidence: L2 (MCP tool call path unit coverage + OpenAPI/listTools schema smoke + syntax/diff checks) -> L2 required (AC1-AC6 MCP exposure, response envelope, doc scaffold, unit coverage, OpenAPI tool-limit validation, Phase 1b-to-Phase 2 sequencing note). No residuals.

## Deltas from ticket

- Selected a dedicated `get_rem_pipeline_state` tool instead of extending `manage_database`, keeping lifecycle control and REM observability as separate MCP operations.
- Kept the implementation in `HealthService` to match the post-M6 service-boundary pattern where `ai/mcp/server/<name>/` maps operationIds to services rather than owning logic.
- Added per-axis zero fallback logging so one unavailable backing store does not erase the rest of the operator snapshot.
- Phase 2 JSONL state, wall-clock timing, and cadence-overflow detection remain excluded and are still owned by #12088.

## Substrate Slot Rationale

Added `learn/agentos/rem-state-model.md` as an operator reference, not always-loaded turn substrate.

- Disposition: keep. Rating: medium trigger-frequency x high failure-severity x high enforceability.
- Rationale: the page is the Phase 1b doc scaffold required by #12087 and is only loaded when diagnosing REM/Sandman state, while linking forward to #12088 instead of embedding future run-state mechanics prematurely.
- Retirement trigger: if Phase 2 centralizes REM run-state documentation under a broader Sandman operations guide, this page should compress into that guide or become the schema subpage.

## Test Evidence

- `npm run test-unit -- test/playwright/unit/ai/services/rem-observability.spec.mjs test/playwright/unit/ai/mcp/server/memory-core/McpServerToolLimits.spec.mjs test/playwright/unit/ai/mcp/server/McpServerListToolsSmoke.spec.mjs` -> 38 passed before rebase.
- Same command after rebasing onto current `origin/dev` -> 38 passed.
- `git diff --check` passed.
- `git diff --check origin/dev...HEAD` passed.
- `node --check ai/services/memory-core/HealthService.mjs` passed.
- `node --check ai/mcp/server/memory-core/toolService.mjs` passed.
- Pre-push freshness check: `merge-base HEAD origin/dev == origin/dev`.

## Post-Merge Validation

- [ ] Restart or reconnect any long-running Memory Core MCP server process, then verify `tools/list` includes `get_rem_pipeline_state`.
- [ ] Use `get_rem_pipeline_state` against the operator substrate before starting #12088 so the Phase 2 JSONL baseline captures the current axis snapshot.

## Commits

- `4be41a450` - MCP exposure, schema, docs, and focused tests for #12087

## Evolution

#12088 was considered first, but its body explicitly blocks on this Phase 1b MCP exposure. The lane therefore stepped back one dependency level and implemented #12087 before the Phase 2 JSONL/wall-clock state model.