### PR TITLE
refactor(orchestrator): collapse env-or-config getters into envBindings; drop in-code env reads + resolver bypasses (#12097)

### DIFF
--- a/ai/config.template.mjs
+++ b/ai/config.template.mjs
@@ -31,6 +31,12 @@ class Config extends BaseConfig {
          */
         backupPath: path.resolve(neoRootDir, '.neo-ai-data/backups'),
         /**
+         * Path to the wake-daemon liveness sentinel touched on every swarm-heartbeat
+         * pulse. Operators / tests can isolate the path via `NEO_HEARTBEAT_ALIVE_PATH`.
+         * @type {string}
+         */
+        wakeDaemonHeartbeatAlivePath: path.resolve(neoRootDir, '.neo-ai-data/wake-daemon/heartbeat.alive'),
+        /**
          * Global debug flag for all AI processes.
          * @type {boolean}
          */
@@ -563,7 +569,8 @@ class Config extends BaseConfig {
             safeProcessingLimitTokens: {var: 'NEO_OPENAI_COMPATIBLE_SAFE_PROCESSING_LIMIT_TOKENS', parse: Env.parseNumber}
         },
         vectorDimension: {var: 'NEO_VECTOR_DIMENSION', parse: Env.parseNumber},
-        backupPath     : 'NEO_BACKUP_PATH',
+        backupPath                  : 'NEO_BACKUP_PATH',
+        wakeDaemonHeartbeatAlivePath: 'NEO_HEARTBEAT_ALIVE_PATH',
         engines        : {
             chroma: {
                 host: 'NEO_CHROMA_HOST',
@@ -573,10 +580,51 @@ class Config extends BaseConfig {
         orchestrator: {
             deploymentMode      : 'NEO_AI_DEPLOYMENT_MODE',
             tenantRepoMirrorRoot: 'NEO_TENANT_REPO_MIRROR_ROOT',
+            devSyncRoots        : {var: 'NEO_ORCHESTRATOR_DEV_SYNC_ROOTS', parse: Env.parseString},
             providerReadiness   : {
                 attempts : {var: 'NEO_ORCHESTRATOR_PROVIDER_READY_ATTEMPTS', parse: Env.parseNumber},
                 delayMs  : {var: 'NEO_ORCHESTRATOR_PROVIDER_READY_DELAY_MS', parse: Env.parseNumber},
                 timeoutMs: {var: 'NEO_ORCHESTRATOR_PROVIDER_READY_TIMEOUT_MS', parse: Env.parseNumber}
+            },
+            intervals: {
+                pollMs           : {var: 'NEO_ORCHESTRATOR_POLL_INTERVAL_MS',              parse: Env.parseNumber},
+                summarySweepMs   : {var: 'NEO_ORCHESTRATOR_SUMMARY_SWEEP_INTERVAL_MS',     parse: Env.parseNumber},
+                kbSyncMs         : {var: 'NEO_ORCHESTRATOR_KB_SYNC_INTERVAL_MS',           parse: Env.parseNumber},
+                backupMs         : {var: 'NEO_ORCHESTRATOR_BACKUP_INTERVAL_MS',            parse: Env.parseNumber},
+                primaryDevSyncMs : {var: 'NEO_ORCHESTRATOR_PRIMARY_DEV_SYNC_INTERVAL_MS',  parse: Env.parseNumber},
+                tenantRepoSyncMs : {var: 'NEO_ORCHESTRATOR_TENANT_REPO_SYNC_INTERVAL_MS',  parse: Env.parseNumber},
+                dreamMs          : {var: 'NEO_ORCHESTRATOR_DREAM_INTERVAL_MS',             parse: Env.parseNumber},
+                goldenPathMs     : {var: 'NEO_ORCHESTRATOR_GOLDEN_PATH_INTERVAL_MS',       parse: Env.parseNumber},
+                swarmHeartbeatMs : {var: 'NEO_ORCHESTRATOR_SWARM_HEARTBEAT_INTERVAL_MS',   parse: Env.parseNumber}
+            },
+            tenantRepoSync: {
+                sweepCadenceMs: {var: 'NEO_ORCHESTRATOR_TENANT_REPO_SYNC_SWEEP_CADENCE_MS', parse: Env.parseNumber},
+                jitterRatio   : {var: 'NEO_ORCHESTRATOR_TENANT_REPO_SYNC_JITTER_RATIO',     parse: Env.parseNumber}
+            },
+            swarmHeartbeat: {
+                targetSource: 'NEO_ORCHESTRATOR_SWARM_HEARTBEAT_TARGET_SOURCE',
+                targets     : 'NEO_ORCHESTRATOR_SWARM_HEARTBEAT_TARGETS'
+            },
+            localOnly: {
+                kbSyncEnabled                  : {var: 'NEO_ORCHESTRATOR_KB_SYNC_ENABLED',                       parse: Env.parseBool},
+                primaryDevSyncEnabled          : {var: 'NEO_ORCHESTRATOR_PRIMARY_DEV_SYNC_ENABLED',              parse: Env.parseBool},
+                chromaDaemonEnabled            : {var: 'NEO_ORCHESTRATOR_CHROMA_DAEMON_ENABLED',                 parse: Env.parseBool},
+                bridgeDaemonEnabled            : {var: 'NEO_ORCHESTRATOR_BRIDGE_DAEMON_ENABLED',                 parse: Env.parseBool},
+                swarmHeartbeatEnabled          : {var: 'NEO_ORCHESTRATOR_SWARM_HEARTBEAT_ENABLED',               parse: Env.parseBool},
+                goldenPathRepoEnrichmentEnabled: {var: 'NEO_ORCHESTRATOR_GOLDEN_PATH_REPO_ENRICHMENT_ENABLED',   parse: Env.parseBool}
+            },
+            cloudOnly: {
+                tenantRepoSyncEnabled: {var: 'NEO_ORCHESTRATOR_TENANT_REPO_SYNC_ENABLED', parse: Env.parseBool}
+            },
+            mlx: {
+                enabled: {var: 'NEO_ORCHESTRATOR_MLX_ENABLED', parse: Env.parseBool},
+                model  : 'NEO_ORCHESTRATOR_MLX_MODEL',
+                port   : 'NEO_ORCHESTRATOR_MLX_PORT'
+            },
+            lms: {
+                enabled: {var: 'NEO_ORCHESTRATOR_LMS_ENABLED', parse: Env.parseBool},
+                model  : 'NEO_ORCHESTRATOR_LMS_MODEL',
+                port   : 'NEO_ORCHESTRATOR_LMS_PORT'
             }
         }
     };

--- a/ai/daemons/orchestrator/Orchestrator.mjs
+++ b/ai/daemons/orchestrator/Orchestrator.mjs
@@ -16,10 +16,7 @@ import MaintenanceBackpressureService, {
     DEFAULT_HEAVY_MAINTENANCE_TASK_NAMES,
     DEFAULT_GOLDEN_PATH_DEPENDENCY_TASK_NAMES
 } from './services/MaintenanceBackpressureService.mjs';
-import PrimaryRepoSyncService, {
-    DEV_SYNC_ROOTS_CONFIG_KEY,
-    DEV_SYNC_ROOTS_ENV_VAR
-} from './services/PrimaryRepoSyncService.mjs';
+import PrimaryRepoSyncService from './services/PrimaryRepoSyncService.mjs';
 import TenantRepoSyncService             from './services/TenantRepoSyncService.mjs';
 import {getDueTask as summaryGetDueTaskImport}        from './scheduling/summary.mjs';
 import {getDueTask as backupGetDueTaskImport}         from './scheduling/backup.mjs';
@@ -91,31 +88,14 @@ export async function initializeDatabaseSelfBootstrap(dbPath) {
     return storage.db;
 }
 
-export function resolvePrimaryDevSyncRootsConfig({envValue, configValue}) {
-    if (!Neo.isEmpty(envValue)) {
-        return envValue;
-    }
-
-    if (Array.isArray(configValue) && configValue.length === 0) {
-        return null;
-    }
-
-    return configValue;
-}
-
-/**
- * Resolves the operator-visible dev-sync roots config source label.
- * @param {Object} options
- * @param {String|undefined|null} options.envValue Environment value.
- * @returns {String}
- */
-export function resolvePrimaryDevSyncRootsSource({envValue}) {
-    if (!Neo.isEmpty(envValue)) {
-        return DEV_SYNC_ROOTS_ENV_VAR;
-    }
-
-    return DEV_SYNC_ROOTS_CONFIG_KEY;
-}
+// dev-sync roots precedence used to live in two resolver helpers
+// (`resolvePrimaryDevSyncRootsConfig` + `resolvePrimaryDevSyncRootsSource`) plus a
+// caller-side `process.env[DEV_SYNC_ROOTS_ENV_VAR]` read. Both layers are removed
+// in favour of the SSOT chain: `ai/config.template.mjs::orchestrator.devSyncRoots`
+// (with `envBindings.orchestrator.devSyncRoots → NEO_ORCHESTRATOR_DEV_SYNC_ROOTS`)
+// owns env-vs-config precedence at config-load time. Operator-instance overrides
+// flow through the `primaryDevSyncRootsConfig` Class A/B reactive config slot,
+// defaulting to the env-applied tier-1 value when the operator does not pass one.
 
 /**
  * Resolves a deployment-aware boolean toggle from `AiConfig.orchestrator.localOnly[key]`.
@@ -387,70 +367,67 @@ export class Orchestrator extends Base {
         this.maintenanceBackpressureService.heavyMaintenanceLeasePath = value;
     }
 
-    // === Service-DI Class D: operator policy values (lazy getters, 2-value chain) ===
-    get pollIntervalMs()          { return Env.parseNumber('NEO_ORCHESTRATOR_POLL_INTERVAL_MS')             ?? AiConfig.orchestrator.intervals.pollMs;             }
-    get summarySweepIntervalMs()  { return Env.parseNumber('NEO_ORCHESTRATOR_SUMMARY_SWEEP_INTERVAL_MS')    ?? AiConfig.orchestrator.intervals.summarySweepMs;     }
-    get kbSyncIntervalMs()        { return Env.parseNumber('NEO_ORCHESTRATOR_KB_SYNC_INTERVAL_MS')          ?? AiConfig.orchestrator.intervals.kbSyncMs;           }
-    get backupIntervalMs()        { return Env.parseNumber('NEO_ORCHESTRATOR_BACKUP_INTERVAL_MS')           ?? AiConfig.orchestrator.intervals.backupMs;           }
-    get primaryDevSyncIntervalMs(){ return Env.parseNumber('NEO_ORCHESTRATOR_PRIMARY_DEV_SYNC_INTERVAL_MS') ?? AiConfig.orchestrator.intervals.primaryDevSyncMs;   }
+    // === Operator policy values — config-template + envBindings is the SSOT ===
+    // Env vars are declared on `ai/config.template.mjs::envBindings.orchestrator.*` and
+    // applied at config-load time. Consumers read `AiConfig.orchestrator.X.Y` directly;
+    // there is no per-access env probe here. The previous per-getter env reads were
+    // architectural drift relative to the post-M6 service-decomposition pattern.
+    get pollIntervalMs()              { return AiConfig.orchestrator.intervals.pollMs;            }
+    get summarySweepIntervalMs()      { return AiConfig.orchestrator.intervals.summarySweepMs;    }
+    get kbSyncIntervalMs()            { return AiConfig.orchestrator.intervals.kbSyncMs;          }
+    get backupIntervalMs()            { return AiConfig.orchestrator.intervals.backupMs;          }
+    get primaryDevSyncIntervalMs()    { return AiConfig.orchestrator.intervals.primaryDevSyncMs;  }
     /**
      * Per-repo global cadence — the default time between sync attempts for a single
-     * configured tenant repo. Decoupled from the orchestrator-level sweep cadence
-     * (`tenantRepoSyncSweepCadenceMs`) so deterministic jitter can actually spread
-     * per-repo work across the jitter window. Env var name preserved for back-compat.
+     * configured tenant repo. Decoupled from the orchestrator-level sweep cadence so
+     * deterministic jitter can spread per-repo work across the jitter window.
      */
-    get tenantRepoSyncIntervalMs(){ return Env.parseNumber('NEO_ORCHESTRATOR_TENANT_REPO_SYNC_INTERVAL_MS') ?? AiConfig.orchestrator.intervals.tenantRepoSyncMs;   }
+    get tenantRepoSyncIntervalMs()    { return AiConfig.orchestrator.intervals.tenantRepoSyncMs;  }
     /**
      * Orchestrator-level sweep cadence — how often `tenant-repo-sync` is invoked.
-     * Short by design (default 1min) so per-repo deterministic jitter spreads
-     * actual sync attempts across the jitter window instead of synchronizing them
-     * onto the sweep boundary.
+     * Short by design (default 1min) so per-repo deterministic jitter spreads actual
+     * sync attempts across the jitter window instead of synchronizing them onto the
+     * sweep boundary.
      */
-    get tenantRepoSyncSweepCadenceMs(){ return Env.parseNumber('NEO_ORCHESTRATOR_TENANT_REPO_SYNC_SWEEP_CADENCE_MS') ?? AiConfig.orchestrator.tenantRepoSync.sweepCadenceMs; }
-    /**
-     * Per-repo jitter ratio (fraction of base cadence). Defaults to the configured
-     * `aiConfig.orchestrator.tenantRepoSync.jitterRatio`; env-overridable so
-     * deployment-specific tuning doesn't require a config-template edit.
-     */
-    get tenantRepoSyncJitterRatio()  { return Env.parseNumber('NEO_ORCHESTRATOR_TENANT_REPO_SYNC_JITTER_RATIO')   ?? AiConfig.orchestrator.tenantRepoSync.jitterRatio;     }
-    get dreamIntervalMs()         { return Env.parseNumber('NEO_ORCHESTRATOR_DREAM_INTERVAL_MS')            ?? AiConfig.orchestrator.intervals.dreamMs;            }
-    get goldenPathIntervalMs()    { return Env.parseNumber('NEO_ORCHESTRATOR_GOLDEN_PATH_INTERVAL_MS')      ?? AiConfig.orchestrator.intervals.goldenPathMs;       }
-    get swarmHeartbeatIntervalMs(){ return Env.parseNumber('NEO_ORCHESTRATOR_SWARM_HEARTBEAT_INTERVAL_MS')  ?? AiConfig.orchestrator.intervals.swarmHeartbeatMs;   }
-    get swarmHeartbeatIdentity()  { return Env.parseString('NEO_AGENT_IDENTITY');                                                                                  }
-    get swarmHeartbeatTargetSource() { return Env.parseString('NEO_ORCHESTRATOR_SWARM_HEARTBEAT_TARGET_SOURCE') ?? AiConfig.orchestrator.swarmHeartbeat?.targetSource ?? null; }
+    get tenantRepoSyncSweepCadenceMs(){ return AiConfig.orchestrator.tenantRepoSync.sweepCadenceMs; }
+    get tenantRepoSyncJitterRatio()   { return AiConfig.orchestrator.tenantRepoSync.jitterRatio;    }
+    get dreamIntervalMs()             { return AiConfig.orchestrator.intervals.dreamMs;             }
+    get goldenPathIntervalMs()        { return AiConfig.orchestrator.intervals.goldenPathMs;        }
+    get swarmHeartbeatIntervalMs()    { return AiConfig.orchestrator.intervals.swarmHeartbeatMs;    }
+    get swarmHeartbeatIdentity()      { return Env.parseString('NEO_AGENT_IDENTITY');               }
+    get swarmHeartbeatTargetSource()  { return AiConfig.orchestrator.swarmHeartbeat?.targetSource ?? null; }
     /**
      * Explicit env-driven target list for the swarm-heartbeat resolver. Comma-separated
      * `@handle` form via `NEO_ORCHESTRATOR_SWARM_HEARTBEAT_TARGETS`. Empty or absent →
-     * `null` so the resolver falls through to `targetSource` semantics.
+     * `null` so the resolver falls through to `targetSource` semantics. The raw string
+     * arrives via `AiConfig.orchestrator.swarmHeartbeat.targets`; this getter splits +
+     * trims because the array-shape parsing is consumer-side concern, not config-shape.
      * @returns {String[]|null}
      */
     get swarmHeartbeatExplicitTargets() {
-        const raw = Env.parseString('NEO_ORCHESTRATOR_SWARM_HEARTBEAT_TARGETS');
+        const raw = AiConfig.orchestrator.swarmHeartbeat?.targets;
         if (!raw) return null;
-        const list = raw.split(',').map(s => s.trim()).filter(Boolean);
+        const list = String(raw).split(',').map(s => s.trim()).filter(Boolean);
         return list.length > 0 ? list : null;
     }
 
-    get kbSyncEnabled()                  { return Env.parseBool('NEO_ORCHESTRATOR_KB_SYNC_ENABLED')                     ?? resolveDeploymentEnabled('kbSyncEnabled');                  }
-    get primaryDevSyncEnabled()          { return Env.parseBool('NEO_ORCHESTRATOR_PRIMARY_DEV_SYNC_ENABLED')            ?? resolveDeploymentEnabled('primaryDevSyncEnabled');          }
-    get tenantRepoSyncEnabled()          { return Env.parseBool('NEO_ORCHESTRATOR_TENANT_REPO_SYNC_ENABLED')            ?? resolveCloudOnlyEnabled('tenantRepoSyncEnabled');           }
-    get chromaDaemonEnabled()            { return Env.parseBool('NEO_ORCHESTRATOR_CHROMA_DAEMON_ENABLED')               ?? resolveDeploymentEnabled('chromaDaemonEnabled');            }
-    get bridgeDaemonEnabled()            { return Env.parseBool('NEO_ORCHESTRATOR_BRIDGE_DAEMON_ENABLED')               ?? resolveDeploymentEnabled('bridgeDaemonEnabled');            }
-    get swarmHeartbeatEnabled()          { return Env.parseBool('NEO_ORCHESTRATOR_SWARM_HEARTBEAT_ENABLED')             ?? resolveDeploymentEnabled('swarmHeartbeatEnabled');          }
-    get goldenPathRepoEnrichmentEnabled(){ return Env.parseBool('NEO_ORCHESTRATOR_GOLDEN_PATH_REPO_ENRICHMENT_ENABLED') ?? resolveDeploymentEnabled('goldenPathRepoEnrichmentEnabled');}
+    get kbSyncEnabled()                  { return resolveDeploymentEnabled('kbSyncEnabled');                  }
+    get primaryDevSyncEnabled()          { return resolveDeploymentEnabled('primaryDevSyncEnabled');          }
+    get tenantRepoSyncEnabled()          { return resolveCloudOnlyEnabled('tenantRepoSyncEnabled');           }
+    get chromaDaemonEnabled()            { return resolveDeploymentEnabled('chromaDaemonEnabled');            }
+    get bridgeDaemonEnabled()            { return resolveDeploymentEnabled('bridgeDaemonEnabled');            }
+    get swarmHeartbeatEnabled()          { return resolveDeploymentEnabled('swarmHeartbeatEnabled');          }
+    get goldenPathRepoEnrichmentEnabled(){ return resolveDeploymentEnabled('goldenPathRepoEnrichmentEnabled');}
 
-    // MLX inference-server lane config (supervised continuous task; opt-in via AiConfig.orchestrator.mlx.enabled).
-    // Canonical defaults live in `ai/config.template.mjs::orchestrator.mlx`; env vars override per the 2-value chain.
-    get mlxEnabled() { return Env.parseBool('NEO_ORCHESTRATOR_MLX_ENABLED') ?? !!AiConfig.orchestrator.mlx?.enabled; }
-    get mlxModel()   { return Env.parseString('NEO_ORCHESTRATOR_MLX_MODEL') ?? AiConfig.orchestrator.mlx?.model;      }
-    get mlxPort()    { return Env.parseString('NEO_ORCHESTRATOR_MLX_PORT')  ?? AiConfig.orchestrator.mlx?.port;       }
+    // MLX + LM Studio CLI inference-server lane config. Canonical defaults + env overrides
+    // live in `ai/config.template.mjs::orchestrator.{mlx,lms}` + `envBindings.orchestrator.{mlx,lms}`.
+    get mlxEnabled() { return !!AiConfig.orchestrator.mlx?.enabled; }
+    get mlxModel()   { return AiConfig.orchestrator.mlx?.model;     }
+    get mlxPort()    { return AiConfig.orchestrator.mlx?.port;      }
 
-    // LM Studio CLI inference-server lane config (parallel-alternative to MLX; opt-in via
-    // AiConfig.orchestrator.lms.enabled). Mutually exclusive in practice — operators pick one.
-    // Canonical defaults live in `ai/config.template.mjs::orchestrator.lms`.
-    get lmsEnabled() { return Env.parseBool('NEO_ORCHESTRATOR_LMS_ENABLED') ?? !!AiConfig.orchestrator.lms?.enabled; }
-    get lmsModel()   { return Env.parseString('NEO_ORCHESTRATOR_LMS_MODEL') ?? AiConfig.orchestrator.lms?.model;      }
-    get lmsPort()    { return Env.parseString('NEO_ORCHESTRATOR_LMS_PORT')  ?? AiConfig.orchestrator.lms?.port;       }
+    get lmsEnabled() { return !!AiConfig.orchestrator.lms?.enabled; }
+    get lmsModel()   { return AiConfig.orchestrator.lms?.model;     }
+    get lmsPort()    { return AiConfig.orchestrator.lms?.port;      }
 
     /**
      * Starts the orchestrator process loop after the wrapper has selected this process.
@@ -500,7 +477,9 @@ export class Orchestrator extends Base {
         this.logFile                   = options.logFile  || path.join(dataDir, 'orchestrator.log');
         this.stateFile                 = options.stateFile || path.join(dataDir, 'orchestrator-state.json');
         this.heavyMaintenanceLeasePath = options.heavyMaintenanceLeasePath ?? this.heavyMaintenanceLeasePath;
-        this.primaryDevSyncRootsConfig = options.primaryDevSyncRootsConfig ?? null;
+        this.primaryDevSyncRootsConfig = options.primaryDevSyncRootsConfig !== undefined
+            ? options.primaryDevSyncRootsConfig
+            : AiConfig.orchestrator.devSyncRoots;
         this.maintenanceDeferralLogKeys = new Set();
 
         fs.ensureDirSync(this.dataDir);
@@ -693,13 +672,7 @@ export class Orchestrator extends Base {
                 taskStateService  : this.taskStateService,
                 healthService     : this.healthService,
                 writeLog          : this.writeLog.bind(this),
-                devSyncRootsConfig: resolvePrimaryDevSyncRootsConfig({
-                    envValue   : process.env[DEV_SYNC_ROOTS_ENV_VAR],
-                    configValue: this.primaryDevSyncRootsConfig
-                }),
-                devSyncRootsSource: resolvePrimaryDevSyncRootsSource({
-                    envValue: process.env[DEV_SYNC_ROOTS_ENV_VAR]
-                })
+                devSyncRootsConfig: this.primaryDevSyncRootsConfig
             });
         }), context);
 

--- a/ai/daemons/orchestrator/services/PrimaryRepoSyncService.mjs
+++ b/ai/daemons/orchestrator/services/PrimaryRepoSyncService.mjs
@@ -7,7 +7,6 @@ const REMOTE_NAME    = 'origin';
 const REMOTE_REF     = `${REMOTE_NAME}/${DEV_BRANCH}`;
 const META_SYNC_PATH = 'resources/content/.sync-metadata.json';
 export const DEV_SYNC_ROOTS_ENV_VAR = 'NEO_ORCHESTRATOR_DEV_SYNC_ROOTS';
-export const DEV_SYNC_ROOTS_CONFIG_KEY = 'orchestrator.devSyncRoots';
 
 const KB_RELEVANT_PATH_PREFIXES = Object.freeze([
     '.agents/skills/',
@@ -156,8 +155,7 @@ class PrimaryRepoSyncService extends Base {
      * @param {Function} [options.writeLog] Orchestrator logger.
      * @param {String} [options.cwd=process.cwd()] Invocation directory.
      * @param {Function} [options.execFileSyncFn=execFileSync] Test seam.
-     * @param {String[]|String|undefined|null} [options.devSyncRootsConfig=process.env.NEO_ORCHESTRATOR_DEV_SYNC_ROOTS] Optional configured roots.
-     * @param {String} [options.devSyncRootsSource=NEO_ORCHESTRATOR_DEV_SYNC_ROOTS] Config source label.
+     * @param {String[]|String|undefined|null} options.devSyncRootsConfig Configured roots. Callers (Orchestrator) resolve from `AiConfig.orchestrator.devSyncRoots` (env-applied via `envBindings.orchestrator.devSyncRoots → NEO_ORCHESTRATOR_DEV_SYNC_ROOTS`); the service does not read env directly.
      * @returns {Object} Execution result.
      */
     runTask({
@@ -168,8 +166,7 @@ class PrimaryRepoSyncService extends Base {
         writeLog,
         cwd = process.cwd(),
         execFileSyncFn = execFileSync,
-        devSyncRootsConfig = process.env[DEV_SYNC_ROOTS_ENV_VAR],
-        devSyncRootsSource = DEV_SYNC_ROOTS_ENV_VAR
+        devSyncRootsConfig
     }) {
         const state = taskStateService.getTaskState(taskName);
 
@@ -183,7 +180,7 @@ class PrimaryRepoSyncService extends Base {
         taskStateService.markStarted(taskName, reason);
 
         try {
-            const result = this.syncPrimaryDev({cwd, execFileSyncFn, writeLog, devSyncRootsConfig, devSyncRootsSource, taskStateService, healthService});
+            const result = this.syncPrimaryDev({cwd, execFileSyncFn, writeLog, devSyncRootsConfig, taskStateService, healthService});
             const status = result.status === 'completed' ? 'completed' : result.status === 'failed' ? 'failed' : 'skipped';
 
             if (status === 'completed') {
@@ -212,8 +209,7 @@ class PrimaryRepoSyncService extends Base {
      * @param {String} options.cwd Invocation directory.
      * @param {Function} options.execFileSyncFn Command execution seam.
      * @param {Function} [options.writeLog] Optional logger.
-     * @param {String[]|String|undefined|null} [options.devSyncRootsConfig=process.env.NEO_ORCHESTRATOR_DEV_SYNC_ROOTS] Optional configured roots.
-     * @param {String} [options.devSyncRootsSource=NEO_ORCHESTRATOR_DEV_SYNC_ROOTS] Config source label.
+     * @param {String[]|String|undefined|null} options.devSyncRootsConfig Configured roots. Callers resolve from `AiConfig.orchestrator.devSyncRoots`; service does not read env directly.
      * @param {Object} [options.taskStateService] Optional `TaskStateService` forwarded to the eventual `runKbSync()` cascade so the nested KB sync is observable as a first-class `kbSync` task lifecycle event. Pass-through only; this method does not consume the service directly.
      * @param {Object} [options.healthService] Optional `HealthService` forwarded to the eventual `runKbSync()` cascade for `recordTaskOutcome('kbSync', ..., {parent: 'primary-dev-sync', ...})` observability. Pass-through only; this method does not consume the service directly.
      * @returns {Object}
@@ -222,17 +218,16 @@ class PrimaryRepoSyncService extends Base {
         cwd,
         execFileSyncFn,
         writeLog,
-        devSyncRootsConfig = process.env[DEV_SYNC_ROOTS_ENV_VAR],
-        devSyncRootsSource = DEV_SYNC_ROOTS_ENV_VAR,
+        devSyncRootsConfig,
         taskStateService,
         healthService
     }) {
-        const rootsConfig = parseDevSyncRoots(devSyncRootsConfig, devSyncRootsSource);
+        const rootsConfig = parseDevSyncRoots(devSyncRootsConfig, DEV_SYNC_ROOTS_ENV_VAR);
 
         if (rootsConfig.status === 'invalid') {
             return this.skip(rootsConfig.reasonCode, {
                 envVar: DEV_SYNC_ROOTS_ENV_VAR,
-                source: devSyncRootsSource,
+                source: DEV_SYNC_ROOTS_ENV_VAR,
                 error : rootsConfig.error
             }, writeLog);
         }

--- a/ai/daemons/orchestrator/services/SwarmHeartbeatService.mjs
+++ b/ai/daemons/orchestrator/services/SwarmHeartbeatService.mjs
@@ -7,6 +7,7 @@ import fs              from 'fs/promises';
 import path            from 'path';
 import {fileURLToPath} from 'url';
 import Base            from '../../../../src/core/Base.mjs';
+import AiConfig        from '../../../config.mjs';
 import {
     Memory_GraphService     as GraphService,
     Memory_LifecycleService as LifecycleService
@@ -57,7 +58,7 @@ const PUSH_CAPABLE_TARGETS     = Object.freeze(['mcp-notifications', 'a2a-webhoo
  * @see ai/services/memory-core/HealthService.mjs
  */
 function heartbeatAlivePath() {
-    return process.env.NEO_HEARTBEAT_ALIVE_PATH || path.resolve(__dirname, '../../../../.neo-ai-data/wake-daemon/heartbeat.alive')
+    return AiConfig.wakeDaemonHeartbeatAlivePath;
 }
 
 /**

--- a/test/playwright/unit/ai/daemons/orchestrator/Orchestrator.invariants.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/Orchestrator.invariants.spec.mjs
@@ -135,33 +135,24 @@ function restoreConfigObject(target, prior) {
     Object.assign(target, prior);
 }
 
-test.describe('Orchestrator config precedence (#11834 AC2)', () => {
-    test('env var overrides AiConfig.data for interval values', () => {
+test.describe('Orchestrator config getters delegate to AiConfig (envBindings is the env-precedence SSOT)', () => {
+    test('interval getter reads AiConfig.orchestrator.intervals verbatim', () => {
         AiConfig.orchestrator.intervals.kbSyncMs = 60_000;
-        process.env.NEO_ORCHESTRATOR_KB_SYNC_INTERVAL_MS = '999000';
+        expect(createMinimalOrchestrator().kbSyncIntervalMs).toBe(60_000);
 
-        const orchestrator = createMinimalOrchestrator();
-        expect(orchestrator.kbSyncIntervalMs).toBe(999000);
-    });
-
-    test('AiConfig.data is consulted when env var is absent', () => {
-        delete process.env.NEO_ORCHESTRATOR_KB_SYNC_INTERVAL_MS;
         AiConfig.orchestrator.intervals.kbSyncMs = 12345;
-
-        const orchestrator = createMinimalOrchestrator();
-        expect(orchestrator.kbSyncIntervalMs).toBe(12345);
+        expect(createMinimalOrchestrator().kbSyncIntervalMs).toBe(12345);
     });
 
-    test('env var overrides AiConfig.data for boolean enable flags (localOnly)', () => {
+    test('boolean enable getter reads AiConfig.orchestrator.localOnly verbatim when value is explicit', () => {
         AiConfig.orchestrator.localOnly.kbSyncEnabled = false;
-        process.env.NEO_ORCHESTRATOR_KB_SYNC_ENABLED = 'true';
+        expect(createMinimalOrchestrator().kbSyncEnabled).toBe(false);
 
-        const orchestrator = createMinimalOrchestrator();
-        expect(orchestrator.kbSyncEnabled).toBe(true);
+        AiConfig.orchestrator.localOnly.kbSyncEnabled = true;
+        expect(createMinimalOrchestrator().kbSyncEnabled).toBe(true);
     });
 
     test('AiConfig.localOnly.X=null falls through to deployment-profile default (local enables, cloud disables)', () => {
-        delete process.env.NEO_ORCHESTRATOR_KB_SYNC_ENABLED;
         AiConfig.orchestrator.localOnly.kbSyncEnabled = null;
 
         AiConfig.orchestrator.deploymentMode = 'local';
@@ -171,8 +162,7 @@ test.describe('Orchestrator config precedence (#11834 AC2)', () => {
         expect(createMinimalOrchestrator().kbSyncEnabled).toBe(false);
     });
 
-    test('chromaDaemonEnabled follows deployment profile default and env override (#12019)', () => {
-        delete process.env.NEO_ORCHESTRATOR_CHROMA_DAEMON_ENABLED;
+    test('chromaDaemonEnabled follows deployment profile default + explicit override (#12019)', () => {
         AiConfig.orchestrator.localOnly.chromaDaemonEnabled = null;
 
         AiConfig.orchestrator.deploymentMode = 'local';
@@ -181,10 +171,10 @@ test.describe('Orchestrator config precedence (#11834 AC2)', () => {
         AiConfig.orchestrator.deploymentMode = 'cloud';
         expect(createMinimalOrchestrator().chromaDaemonEnabled).toBe(false);
 
-        process.env.NEO_ORCHESTRATOR_CHROMA_DAEMON_ENABLED = 'true';
+        AiConfig.orchestrator.localOnly.chromaDaemonEnabled = true;
         expect(createMinimalOrchestrator().chromaDaemonEnabled).toBe(true);
 
-        process.env.NEO_ORCHESTRATOR_CHROMA_DAEMON_ENABLED = 'false';
+        AiConfig.orchestrator.localOnly.chromaDaemonEnabled = false;
         AiConfig.orchestrator.deploymentMode = 'local';
         expect(createMinimalOrchestrator().chromaDaemonEnabled).toBe(false);
     });
@@ -205,39 +195,19 @@ test.describe('Orchestrator config precedence (#11834 AC2)', () => {
     // env vars are saved/restored by the file-level beforeEach/afterEach hooks above —
     // individual tests can mutate freely without leak risk.
 
-    test('mlxEnabled: env var wins over AiConfig.orchestrator.mlx.enabled', () => {
-        AiConfig.orchestrator.mlx = {enabled: false, model: 'm', port: '11435'};
-        process.env.NEO_ORCHESTRATOR_MLX_ENABLED = 'true';
-
-        expect(createMinimalOrchestrator().mlxEnabled).toBe(true);
-    });
-
-    test('mlxEnabled: explicit env=false overrides an enabled AiConfig default', () => {
-        // Coverage parity with the deleted resolveMlxConfig "explicit env=false overrides
-        // an enabled AiConfig default" test branch. This is the path most at risk if the
-        // getter's `??` operator drifts to `||` later.
-        AiConfig.orchestrator.mlx = {enabled: true, model: 'm', port: '11435'};
-        process.env.NEO_ORCHESTRATOR_MLX_ENABLED = 'false';
-
-        expect(createMinimalOrchestrator().mlxEnabled).toBe(false);
-    });
-
-    test('mlxEnabled / mlxModel / mlxPort: AiConfig consulted when env vars absent', () => {
-        delete process.env.NEO_ORCHESTRATOR_MLX_ENABLED;
-        delete process.env.NEO_ORCHESTRATOR_MLX_MODEL;
-        delete process.env.NEO_ORCHESTRATOR_MLX_PORT;
+    test('mlxEnabled / mlxModel / mlxPort getters read AiConfig.orchestrator.mlx verbatim', () => {
         AiConfig.orchestrator.mlx = {enabled: true, model: 'mlx-from-config', port: '11999'};
 
         const o = createMinimalOrchestrator();
         expect(o.mlxEnabled).toBe(true);
         expect(o.mlxModel).toBe('mlx-from-config');
         expect(o.mlxPort).toBe('11999');
+
+        AiConfig.orchestrator.mlx = {enabled: false, model: 'm', port: '11435'};
+        expect(createMinimalOrchestrator().mlxEnabled).toBe(false);
     });
 
     test('mlx getters undefined-safe when AiConfig.orchestrator.mlx is missing', () => {
-        delete process.env.NEO_ORCHESTRATOR_MLX_ENABLED;
-        delete process.env.NEO_ORCHESTRATOR_MLX_MODEL;
-        delete process.env.NEO_ORCHESTRATOR_MLX_PORT;
         delete AiConfig.orchestrator.mlx;
 
         const o = createMinimalOrchestrator();
@@ -246,39 +216,19 @@ test.describe('Orchestrator config precedence (#11834 AC2)', () => {
         expect(o.mlxPort).toBeUndefined();
     });
 
-    test('lmsEnabled: env var wins over AiConfig.orchestrator.lms.enabled', () => {
-        AiConfig.orchestrator.lms = {enabled: false, model: 'qwen', port: '1234'};
-        process.env.NEO_ORCHESTRATOR_LMS_ENABLED = 'true';
-
-        expect(createMinimalOrchestrator().lmsEnabled).toBe(true);
-    });
-
-    test('lmsEnabled: explicit env=false overrides an enabled AiConfig default', () => {
-        // Coverage parity with the deleted resolveLmsConfig "explicit env=false overrides
-        // an enabled AiConfig default" test branch. Sibling of the mlx false-env-override
-        // test above — same `??` vs `||` regression hazard.
-        AiConfig.orchestrator.lms = {enabled: true, model: 'qwen', port: '1234'};
-        process.env.NEO_ORCHESTRATOR_LMS_ENABLED = 'false';
-
-        expect(createMinimalOrchestrator().lmsEnabled).toBe(false);
-    });
-
-    test('lmsEnabled / lmsModel / lmsPort: AiConfig consulted when env vars absent', () => {
-        delete process.env.NEO_ORCHESTRATOR_LMS_ENABLED;
-        delete process.env.NEO_ORCHESTRATOR_LMS_MODEL;
-        delete process.env.NEO_ORCHESTRATOR_LMS_PORT;
+    test('lmsEnabled / lmsModel / lmsPort getters read AiConfig.orchestrator.lms verbatim', () => {
         AiConfig.orchestrator.lms = {enabled: true, model: 'lms-from-config', port: '4242'};
 
         const o = createMinimalOrchestrator();
         expect(o.lmsEnabled).toBe(true);
         expect(o.lmsModel).toBe('lms-from-config');
         expect(o.lmsPort).toBe('4242');
+
+        AiConfig.orchestrator.lms = {enabled: false, model: 'qwen', port: '1234'};
+        expect(createMinimalOrchestrator().lmsEnabled).toBe(false);
     });
 
     test('lms getters undefined-safe when AiConfig.orchestrator.lms is missing', () => {
-        delete process.env.NEO_ORCHESTRATOR_LMS_ENABLED;
-        delete process.env.NEO_ORCHESTRATOR_LMS_MODEL;
-        delete process.env.NEO_ORCHESTRATOR_LMS_PORT;
         delete AiConfig.orchestrator.lms;
 
         const o = createMinimalOrchestrator();

--- a/test/playwright/unit/ai/daemons/orchestrator/Orchestrator.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/Orchestrator.spec.mjs
@@ -3,18 +3,10 @@ import path from 'path';
 import Neo from '../../../../../../src/Neo.mjs';
 import * as core from '../../../../../../src/core/_export.mjs';
 import AiConfig from '../../../../../../ai/config.mjs';
-import {
-    Orchestrator,
-    resolvePrimaryDevSyncRootsConfig,
-    resolvePrimaryDevSyncRootsSource
-} from '../../../../../../ai/daemons/orchestrator/Orchestrator.mjs';
+import {Orchestrator} from '../../../../../../ai/daemons/orchestrator/Orchestrator.mjs';
 import {
     DEFAULT_HEAVY_MAINTENANCE_TASK_NAMES
 } from '../../../../../../ai/daemons/orchestrator/services/MaintenanceBackpressureService.mjs';
-import {
-    DEV_SYNC_ROOTS_CONFIG_KEY,
-    DEV_SYNC_ROOTS_ENV_VAR
-} from '../../../../../../ai/daemons/orchestrator/services/PrimaryRepoSyncService.mjs';
 import {
     buildTaskDefinitions
 } from '../../../../../../ai/daemons/orchestrator/TaskDefinitions.mjs';
@@ -676,64 +668,36 @@ test.describe('Neo.ai.daemons.Orchestrator (#11009)', () => {
         expect(started).toEqual([]);
     });
 
-    test('passes local dev-sync roots to primary-dev-sync while env keeps precedence', () => {
-        const originalEnvValue = process.env[DEV_SYNC_ROOTS_ENV_VAR];
-        delete process.env[DEV_SYNC_ROOTS_ENV_VAR];
-
-        try {
-            const received = [];
-            const orchestrator = createTestOrchestrator({
-                kbSyncIntervalMs          : 0,
-                backupIntervalMs          : 0,
-                primaryDevSyncEnabled     : true,
-                primaryDevSyncIntervalMs  : 600000,
-                primaryDevSyncRootsConfig : ['/config/neo'],
-                primaryDevSyncGetDueTask  : () => ({
-                    taskName: 'primary-dev-sync',
-                    reason  : 'periodic-sweep:600000'
-                }),
-                primaryRepoSyncService    : {
-                    runTask(options) {
-                        received.push({
-                            value : options.devSyncRootsConfig,
-                            source: options.devSyncRootsSource
-                        });
-                    }
+    test('delegates the configured dev-sync roots to PrimaryRepoSyncService via options.devSyncRootsConfig', () => {
+        const received = [];
+        const orchestrator = createTestOrchestrator({
+            kbSyncIntervalMs          : 0,
+            backupIntervalMs          : 0,
+            primaryDevSyncEnabled     : true,
+            primaryDevSyncIntervalMs  : 600000,
+            primaryDevSyncRootsConfig : ['/config/neo'],
+            primaryDevSyncGetDueTask  : () => ({
+                taskName: 'primary-dev-sync',
+                reason  : 'periodic-sweep:600000'
+            }),
+            primaryRepoSyncService    : {
+                runTask(options) {
+                    received.push(options.devSyncRootsConfig);
                 }
-            });
-
-            orchestrator.processSupervisorService = {
-                runTask() {}
-            };
-
-            orchestrator.poll();
-
-            process.env[DEV_SYNC_ROOTS_ENV_VAR] = '["/env/neo"]';
-            orchestrator.poll();
-
-            expect(received).toEqual([{
-                value : ['/config/neo'],
-                source: DEV_SYNC_ROOTS_CONFIG_KEY
-            }, {
-                value : '["/env/neo"]',
-                source: DEV_SYNC_ROOTS_ENV_VAR
-            }]);
-            expect(resolvePrimaryDevSyncRootsConfig({
-                envValue   : '',
-                configValue: ['/config/neo']
-            })).toEqual(['/config/neo']);
-            expect(resolvePrimaryDevSyncRootsConfig({
-                envValue   : '',
-                configValue: []
-            })).toBeNull();
-            expect(resolvePrimaryDevSyncRootsSource({envValue: ''})).toBe(DEV_SYNC_ROOTS_CONFIG_KEY);
-        } finally {
-            if (originalEnvValue === undefined) {
-                delete process.env[DEV_SYNC_ROOTS_ENV_VAR];
-            } else {
-                process.env[DEV_SYNC_ROOTS_ENV_VAR] = originalEnvValue;
             }
-        }
+        });
+
+        orchestrator.processSupervisorService = {
+            runTask() {}
+        };
+
+        orchestrator.poll();
+
+        // Per the SSOT contract, env precedence is owned by `envBindings.orchestrator.devSyncRoots`
+        // at config-load time, not by a runtime resolver. The orchestrator is responsible only for
+        // delegating the resolved value via `options.devSyncRootsConfig`. Env-precedence assertions
+        // belong to the envBindings tier, not this test.
+        expect(received).toEqual([['/config/neo']]);
     });
 
     // ─────────────────────────────────────────────────────────────────────────────

--- a/test/playwright/unit/ai/daemons/orchestrator/services/PrimaryRepoSyncService.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/services/PrimaryRepoSyncService.spec.mjs
@@ -2,7 +2,6 @@ import {test, expect} from '@playwright/test';
 import Neo       from '../../../../../../../src/Neo.mjs';
 import * as core from '../../../../../../../src/core/_export.mjs';
 import PrimaryRepoSyncService, {
-    DEV_SYNC_ROOTS_CONFIG_KEY,
     DEV_SYNC_ROOTS_ENV_VAR,
     isKbRelevantChangePath,
     parseDevSyncRoots
@@ -626,13 +625,12 @@ test.describe('PrimaryRepoSyncService (#11017)', () => {
         expect(execStub.calls.map(call => call.args[0])).not.toContain('pull');
     });
 
-    test('uses the local config source label for malformed configured roots', () => {
+    test('reports the canonical env-var name for malformed configured roots', () => {
         const result = PrimaryRepoSyncService.syncPrimaryDev({
             cwd               : '/primary/neo',
             execFileSyncFn    : createExecStub([]),
             writeLog          : () => {},
-            devSyncRootsConfig: ['relative/neo'],
-            devSyncRootsSource: DEV_SYNC_ROOTS_CONFIG_KEY
+            devSyncRootsConfig: ['relative/neo']
         });
 
         expect(result).toEqual({
@@ -640,8 +638,8 @@ test.describe('PrimaryRepoSyncService (#11017)', () => {
             details: {
                 reasonCode: 'invalid-dev-sync-roots',
                 envVar    : DEV_SYNC_ROOTS_ENV_VAR,
-                source    : DEV_SYNC_ROOTS_CONFIG_KEY,
-                error     : 'orchestrator.devSyncRoots entries must be absolute path strings.'
+                source    : DEV_SYNC_ROOTS_ENV_VAR,
+                error     : `${DEV_SYNC_ROOTS_ENV_VAR} entries must be absolute path strings.`
             }
         });
     });

--- a/test/playwright/unit/ai/daemons/orchestrator/services/SwarmHeartbeatService.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/services/SwarmHeartbeatService.spec.mjs
@@ -22,6 +22,7 @@ setup({
 // bootstrap pattern in TaskStateService.spec / ProcessSupervisorService.spec post-#11049/#11054.
 import Neo       from '../../../../../../../src/Neo.mjs';
 import * as core from '../../../../../../../src/core/_export.mjs';
+import AiConfig  from '../../../../../../../ai/config.mjs';
 
 import {test, expect} from '@playwright/test';
 
@@ -729,19 +730,20 @@ test.describe('Neo.ai.daemons.SwarmHeartbeatService', () => {
         expect(capturedArgs[0]).toEqual(['@neo-gpt', 'mcp-notifications', 'a2a-webhook', 'bridge-daemon']);
     });
 
-    test('heartbeatAlivePath() defaults to the repo-root path HealthService reads (#11872)', async () => {
-        const original = process.env.NEO_HEARTBEAT_ALIVE_PATH;
-        delete process.env.NEO_HEARTBEAT_ALIVE_PATH;
+    test('heartbeatAlivePath() reads AiConfig.wakeDaemonHeartbeatAlivePath verbatim (#11872)', async () => {
+        const original = AiConfig.wakeDaemonHeartbeatAlivePath;
 
         try {
-            expect(heartbeatAlivePath()).toBe(path.resolve(process.cwd(), '.neo-ai-data/wake-daemon/heartbeat.alive'));
+            // Per the SSOT contract, env precedence is owned by `envBindings.wakeDaemonHeartbeatAlivePath
+            // → NEO_HEARTBEAT_ALIVE_PATH` at config-load time. The service reads the resolved value
+            // directly; tests simulate env-applied state by mutating AiConfig.
+            expect(heartbeatAlivePath()).toBe(AiConfig.wakeDaemonHeartbeatAlivePath);
 
             const overridePath = path.join(os.tmpdir(), `neo-heartbeat-override-${Date.now()}.alive`);
-            process.env.NEO_HEARTBEAT_ALIVE_PATH = overridePath;
+            AiConfig.wakeDaemonHeartbeatAlivePath = overridePath;
             expect(heartbeatAlivePath()).toBe(overridePath);
         } finally {
-            if (original === undefined) delete process.env.NEO_HEARTBEAT_ALIVE_PATH;
-            else                        process.env.NEO_HEARTBEAT_ALIVE_PATH = original;
+            AiConfig.wakeDaemonHeartbeatAlivePath = original;
         }
     });
 
@@ -758,8 +760,8 @@ test.describe('Neo.ai.daemons.SwarmHeartbeatService', () => {
         delete SwarmHeartbeatService.touchLivenessFile;
 
         const alivePath = path.join(os.tmpdir(), `neo-heartbeat-alive-${Date.now()}.alive`);
-        const original  = process.env.NEO_HEARTBEAT_ALIVE_PATH;
-        process.env.NEO_HEARTBEAT_ALIVE_PATH = alivePath;
+        const original  = AiConfig.wakeDaemonHeartbeatAlivePath;
+        AiConfig.wakeDaemonHeartbeatAlivePath = alivePath;
 
         try {
             const before = Date.now();
@@ -770,8 +772,7 @@ test.describe('Neo.ai.daemons.SwarmHeartbeatService', () => {
             const stat = await fs.stat(alivePath);
             expect(stat.mtime.getTime()).toBeGreaterThanOrEqual(before - 1000);
         } finally {
-            if (original === undefined) delete process.env.NEO_HEARTBEAT_ALIVE_PATH;
-            else                        process.env.NEO_HEARTBEAT_ALIVE_PATH = original;
+            AiConfig.wakeDaemonHeartbeatAlivePath = original;
             await fs.rm(alivePath, {force: true});
         }
     });


### PR DESCRIPTION
Authored by Claude Opus 4.7 (Claude Code). Session ba55de70-c601-448e-9eb4-9c214be1d9c6.

**FAIR-band:** operator-directed audit + execution at 2026-05-27T15:50Z. Operator anchor: *"are you still aware of our config and env var patterns? this one did not get created inside this session. however, it is not the only spot. the orchestrator needs a review."* Then at 16:21Z: *"do we REALLY need 3-4 PRs, or can we do it with 1-2? go!"* — committing to single comprehensive PR.

Closes #12097

Audit + single-PR consolidation of orchestrator config/env-pattern violations predating the operator-stated NO HIDDEN DEFAULT VALUE FALLBACKS IN CODE contract (banked at `feedback_no_hidden_default_fallbacks.md`; PR #12061 cycle-4 anchor). `envBindings.orchestrator.*` now owns env-vs-config precedence at config-load time for 29 keys previously resolved via per-access getters in `Orchestrator.mjs`; the orchestrator + sibling services read `AiConfig.X.Y` directly.

Evidence: L2 (`npm run test-unit -- --grep "Orchestrator|PrimaryRepoSync|SwarmHeartbeat|config.template"` → 384/386 pass locally; the 2 remaining DreamService failures are PRE-EXISTING — verified via `git stash` baseline test on the same grep, identical failures both pre- and post-refactor; unrelated to this PR's scope). L4 deferred to the post-merge runtime check that the orchestrator daemon boot reads the env-applied values via envBindings.

## Deltas from ticket (if any)

Two intentional preservations vs the ticket's "delete all resolvers" framing:

1. **`resolveDeploymentEnabled` + `resolveCloudOnlyEnabled` kept** — they encode the documented `null`-means-deployment-default sentinel on `localOnly`/`cloudOnly` config slots. The helpers don't read env (env is handled by envBindings); they pure-derive from AiConfig. The operator-visible `null` semantic on those slots is preserved as part of the deliberate config contract. The getters that previously combined env-read + helper now just call the helper.
2. **2 getters stayed in Orchestrator.mjs**:
   - `swarmHeartbeatIdentity` reads `NEO_AGENT_IDENTITY` directly — this is a top-level identity var, not orchestrator-scoped; moving it into orchestrator envBindings would be wrong shape. Lives at the higher-tier identity boundary.
   - `swarmHeartbeatExplicitTargets` does consumer-side comma-separated string → array splitting. The raw string lands via the new `AiConfig.orchestrator.swarmHeartbeat.targets` envBinding; the getter just splits + trims. Array-shape parsing is consumer-side concern, not config-shape.

## What changes

### `ai/config.template.mjs` (+50 LOC)

- **`defaultConfig`** gains `wakeDaemonHeartbeatAlivePath` (neoRootDir-rooted default).
- **`envBindings.orchestrator.*`** gains 26 new entries: intervals (9), tenantRepoSync.{sweep,jitter}, swarmHeartbeat.{targetSource,targets}, localOnly.* (6 enable flags), cloudOnly.tenantRepoSyncEnabled, mlx.{enabled,model,port}, lms.{enabled,model,port}, devSyncRoots.
- **`envBindings`** gains `wakeDaemonHeartbeatAlivePath: 'NEO_HEARTBEAT_ALIVE_PATH'`.

### `ai/daemons/orchestrator/Orchestrator.mjs` (+39 / -104)

- DELETE 27 of 29 env-reading getters; replacements read `AiConfig.orchestrator.X.Y` directly.
- DELETE 2 export functions (`resolvePrimaryDevSyncRootsConfig` + `resolvePrimaryDevSyncRootsSource`) — env precedence is the envBindings tier's responsibility.
- DELETE import of `DEV_SYNC_ROOTS_CONFIG_KEY` + `DEV_SYNC_ROOTS_ENV_VAR` from PrimaryRepoSyncService (no longer needed at this layer).
- `this.primaryDevSyncRootsConfig` instance field defaults to `AiConfig.orchestrator.devSyncRoots` when no explicit constructor value is passed.
- Dream-task callback delegates `devSyncRootsConfig: this.primaryDevSyncRootsConfig` directly (no resolver call, no env probe).

### `ai/daemons/orchestrator/services/PrimaryRepoSyncService.mjs` (+5 / -14)

- DELETE `devSyncRootsConfig = process.env[DEV_SYNC_ROOTS_ENV_VAR]` default-parameter env reads from `runTask` + `syncPrimaryDev`.
- DELETE `devSyncRootsSource` parameter — `syncPrimaryDev` hardcodes the canonical `NEO_ORCHESTRATOR_DEV_SYNC_ROOTS` label for error reporting since envBindings now owns precedence.
- DELETE `export const DEV_SYNC_ROOTS_CONFIG_KEY` (last consumer was a now-deleted test assertion).

### `ai/daemons/orchestrator/services/SwarmHeartbeatService.mjs` (+1 / -2)

- ADD `import AiConfig from '../../../config.mjs'`.
- `heartbeatAlivePath()` now reads `AiConfig.wakeDaemonHeartbeatAlivePath` instead of `process.env.NEO_HEARTBEAT_ALIVE_PATH || path.resolve(__dirname, '...')`.

### Tests (4 files updated)

- `Orchestrator.spec.mjs`: `'passes local dev-sync roots to primary-dev-sync while env keeps precedence'` → `'delegates the configured dev-sync roots to PrimaryRepoSyncService via options.devSyncRootsConfig'`. Drops env-precedence assertions (now envBindings tier's responsibility) + drops `devSyncRootsSource` assertion (param removed).
- `Orchestrator.invariants.spec.mjs`: describe block renamed from `'Orchestrator config precedence'` to `'Orchestrator config getters delegate to AiConfig (envBindings is the env-precedence SSOT)'`. Tests rewritten to assert getter→AiConfig delegation rather than env-precedence. Deployment-default null-fallthrough invariants preserved (they're the resolver helpers' contract).
- `PrimaryRepoSyncService.spec.mjs`: test name + error message expectation aligned to the new `DEV_SYNC_ROOTS_ENV_VAR`-canonical source label.
- `SwarmHeartbeatService.spec.mjs`: `heartbeatAlivePath` test mutates `AiConfig.wakeDaemonHeartbeatAlivePath` instead of `process.env.NEO_HEARTBEAT_ALIVE_PATH`.

## Test Evidence

- `npm run test-unit -- --grep "Orchestrator|PrimaryRepoSync|SwarmHeartbeat|config.template"` → 384/386 pass locally. 2 failures (`DreamService.spec` `synthesizeGoldenPath` + `should retry extraction on malformed JSON payload`) are PRE-EXISTING — confirmed via `git stash; npm run test-unit -- --grep "DreamService.*should retry extraction"; git stash pop` showing the same failure on pre-refactor baseline. Out of scope for this PR.
- §15.6 diagnostic on added lines: zero new violations (the one `(#12019)` match is a `test('...')` label, which is the documented §15.6 exception per `feedback_jsdoc_archaeology_self_audit`).
- Capability-framing audit: zero downstream-deployment-partner mentions.
- Pre-existing `(#11834 AC2)` describe-block label updated to remove the ticket reference per §15.6 (renamed to plain prose).

## Post-Merge Validation

- [ ] Boot the orchestrator daemon (`npm run ai:orchestrator` or equivalent) with `NEO_ORCHESTRATOR_POLL_INTERVAL_MS=5000` set in the env and confirm the running orchestrator's `pollIntervalMs` matches the env value (verifies envBindings.orchestrator.intervals.pollMs is correctly applied at config-load time).
- [ ] Same probe with `NEO_HEARTBEAT_ALIVE_PATH=/tmp/heartbeat.alive` and confirm the SwarmHeartbeatService's next pulse touches the override path.
- [ ] Confirm `Orchestrator.mjs` line count net-decreased relative to dev (cycle-1 deletes 27 getters + 2 resolver functions; thinning is part of the operator-flagged restoration arc).

## Commits

- `08805fa50` — refactor(orchestrator): collapse env-or-config getters into envBindings; drop in-code env reads + resolver bypasses (#12097)

## Evolution

The four anti-pattern clusters (env-reading getters, resolver functions, direct `process.env || hardcoded`, default-parameter env reads) all collapse under one fix shape because they all violate the same architectural mandate: env-vs-config precedence belongs to the envBindings tier, not to runtime code. Each cluster bypassed envBindings in a different way; the single PR re-routes all four through the canonical surface so future drift is caught at the envBindings layer instead of leaking into 30+ places. Operator's "1-2 PRs, go!" framing made the single-PR consolidation the explicit shape — the alternative would have been 3-4 narrow PRs that share the same architectural fix and force three review cycles for one architectural correction.
