### PR TITLE
fix(ai): delegate Sandman runner to REM cycle (#12070)

### DIFF
--- a/ai/daemons/orchestrator/services/DreamService.mjs
+++ b/ai/daemons/orchestrator/services/DreamService.mjs
@@ -10,7 +10,6 @@ import { Memory_TextEmbeddingService as TextEmbeddingService } from '../../../se
 import { Memory_GraphService as GraphService } from '../../../services.mjs';
 import Json from '../../../../src/util/Json.mjs';
 import logger from '../../../mcp/server/memory-core/logger.mjs';
-import OpenAiCompatible from '../../../provider/OpenAiCompatible.mjs';
 import ConceptDiscoveryService from '../../../services/ingestion/ConceptDiscoveryService.mjs';
 import ConceptIngestor from '../../../services/ingestion/ConceptIngestor.mjs';
 import FileSystemIngestor from '../../../services/memory-core/FileSystemIngestor.mjs';
@@ -23,10 +22,11 @@ import TopologyInferenceEngine from '../../../services/graph/TopologyInferenceEn
 import GoldenPathSynthesizer from '../../../services/graph/GoldenPathSynthesizer.mjs';
 import AiConfig from '../../../config.mjs';
 import {
+    assertProviderReadinessConfig,
     createProviderFailureDiagnostic,
     getGraphProviderReadinessTarget,
     waitForProvider
-} from '../../../scripts/runners/runSandman.mjs';
+} from '../../../services/graph/ProviderReadinessHelper.mjs';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -327,7 +327,14 @@ class DreamService extends Base {
         // is unsupported or unreachable. Downstream pipeline calls would silently no-op
         // on missing provider; the typed `failed` envelope surfaces the root cause to
         // operator-facing health telemetry instead.
-        const gate = await this.checkProviderReadiness();
+        let gate;
+        try {
+            gate = await this.checkProviderReadiness();
+        } catch (e) {
+            return finalize('failed', {
+                error: {message: `checkProviderReadiness threw: ${e?.message || e}`, stack: e?.stack}
+            });
+        }
         if (!gate.ready) {
             return finalize('failed', {diagnostic: gate.diagnostic});
         }
@@ -410,7 +417,7 @@ class DreamService extends Base {
      * @returns {Promise<{ready: true} | {ready: false, diagnostic: Object}>}
      */
     async checkProviderReadiness() {
-        const readinessConfig = AiConfig.orchestrator.providerReadiness;
+        const readinessConfig = assertProviderReadinessConfig(AiConfig.orchestrator.providerReadiness);
         const target          = getGraphProviderReadinessTarget();
 
         if (!target.supported) {

--- a/ai/daemons/orchestrator/services/HeavyMaintenanceLeaseService.mjs
+++ b/ai/daemons/orchestrator/services/HeavyMaintenanceLeaseService.mjs
@@ -444,8 +444,8 @@ export async function releaseHeavyMaintenanceLease({
  * GraphService.decayGlobalTopology();
  * ```
  *
- * Canonical consumer reference: `ai/scripts/runners/runSandman.mjs`, where graph
- * decay runs inside the inner `finally` while the lease is still held.
+ * Canonical consumer reference: `ai/scripts/runners/runSandman.mjs`, which
+ * delegates to `DreamService.executeRemCycle()` while the lease is still held.
  *
  * ## Returned shape (what callers of `await withHeavyMaintenanceLease(...)` see)
  *

--- a/ai/scripts/runners/runSandman.mjs
+++ b/ai/scripts/runners/runSandman.mjs
@@ -1,252 +1,95 @@
 import Neo from '../../../src/Neo.mjs';
 import * as core from '../../../src/core/_export.mjs';
-import InstanceManager from '../../../src/manager/Instance.mjs';
-import AiConfig from '../../config.mjs';
 import Memory_Config from '../../mcp/server/memory-core/config.mjs';
-import Memory_Service from '../../services/memory-core/MemoryService.mjs';
 import DreamService from '../../daemons/orchestrator/services/DreamService.mjs';
-import GoldenPathSynthesizer from '../../services/graph/GoldenPathSynthesizer.mjs';
+import {
+    assertProviderReadinessConfig,
+    checkProvider,
+    createProviderFailureDiagnostic,
+    getGraphProviderReadinessTarget,
+    getOpenAiCompatibleHost,
+    recordProviderReadinessFailure,
+    waitForProvider
+} from '../../services/graph/ProviderReadinessHelper.mjs';
 import LifecycleService from '../../services/memory-core/lifecycle/SystemLifecycleService.mjs';
-import InferenceLifecycleService from '../../services/memory-core/lifecycle/InferenceLifecycleService.mjs';
-import GraphService from '../../services/memory-core/GraphService.mjs';
 import {withHeavyMaintenanceLease} from '../../daemons/orchestrator/services/HeavyMaintenanceLeaseService.mjs';
-import {isGraphModelProviderSupported, resolveGraphModelProvider} from '../../services/graph/providerDispatch.mjs';
-import logger from '../../mcp/server/memory-core/logger.mjs';
-import http from 'http';
 import {pathToFileURL} from 'url';
 
 /**
  * @module ai/scripts/runners/runSandman
  */
 
-/**
- * @summary Resolves the OpenAI-compatible host used by one Sandman graph-provider option.
- * @param {Object} config
- * @returns {String|undefined}
- */
-export function getOpenAiCompatibleHost(config = Memory_Config.data) {
-    return config.openAiCompatible?.host;
-}
+export {
+    assertProviderReadinessConfig,
+    checkProvider,
+    createProviderFailureDiagnostic,
+    getGraphProviderReadinessTarget,
+    getOpenAiCompatibleHost,
+    recordProviderReadinessFailure,
+    waitForProvider
+};
 
 /**
- * @summary Builds the provider readiness target for the resolved Sandman graph provider.
- * @param {Object} config
- * @returns {Object}
- */
-export function getGraphProviderReadinessTarget(config = Memory_Config.data) {
-    const provider  = resolveGraphModelProvider(config);
-    const supported = isGraphModelProviderSupported(provider);
-
-    if (!supported) {
-        return {
-            provider,
-            supported,
-            endpoint      : null,
-            host          : null,
-            model         : null,
-            embeddingModel: null,
-            url           : null
-        };
-    }
-
-    const isOllama = provider === 'ollama';
-    const host     = isOllama
-        ? config.ollama?.host
-        : getOpenAiCompatibleHost(config);
-    const endpoint = isOllama ? '/api/tags' : '/v1/models';
-    const model    = isOllama ? config.ollama?.model : config.openAiCompatible?.model;
-    const embeddingModel = isOllama
-        ? config.ollama?.embeddingModel
-        : config.openAiCompatible?.embeddingModel;
-    const url      = host ? `${host.replace(/\/+$/, '')}${endpoint}` : null;
-
-    return {
-        provider,
-        supported,
-        endpoint,
-        host,
-        model,
-        embeddingModel,
-        url
-    };
-}
-
-/**
- * @summary Probes the configured graph provider used by the Sandman REM pipeline.
+ * @summary Emits CLI-facing REM cycle outcome text and maps the typed outcome to a process code.
+ * @param {Object} outcome Result envelope returned by `DreamService.executeRemCycle()`.
  * @param {Object} options
- * @param {Object} options.config Provider-source config (aiConfig-shaped).
- * @param {Number} options.timeoutMs HTTP probe abandon threshold. Required; no module-level default.
- * @returns {Promise<Boolean>}
+ * @param {Object} [options.output=console] Terminal sink.
+ * @returns {Promise<Number>} Process exit code.
  */
-export function checkProvider({config, timeoutMs} = {}) {
-    if (typeof timeoutMs !== 'number') {
-        throw new TypeError('checkProvider: timeoutMs is required (pass from config.orchestrator.providerReadiness.timeoutMs)');
-    }
-    const target = getGraphProviderReadinessTarget(config ?? Memory_Config.data);
+export async function recordRemCycleOutcome(outcome, {output = console} = {}) {
+    const writeError = (...args) => typeof output.error === 'function'
+        ? output.error(...args)
+        : console.error(...args);
 
-    if (!target.supported) {
-        return Promise.resolve(false);
-    }
-
-    return new Promise(resolve => {
-        let settled = false;
-        const settle = value => {
-            if (!settled) {
-                settled = true;
-                resolve(value);
-            }
-        };
-
-        const req = http.get(target.url, response => {
-            response.resume();
-            settle(true);
-        });
-
-        req.setTimeout(timeoutMs, () => {
-            req.destroy();
-            settle(false);
-        });
-        req.on('error', () => settle(false));
-    });
-}
-
-/**
- * @summary Waits for the local provider readiness loop while exposing deterministic test seams.
- *
- * Probe parameters are required arguments — there are no module-level defaults. Callers
- * read `aiConfig.orchestrator.providerReadiness` and pass the values explicitly; this
- * keeps configuration as the single source of truth.
- *
- * @param {Object} options
- * @param {Function} [options.checkProvider] Injectable probe (defaults to `checkProvider` bound to the same `timeoutMs`).
- * @param {Number} options.attempts Retry cap.
- * @param {Number} options.delayMs Between-probe wait.
- * @param {Number} options.timeoutMs HTTP probe abandon threshold (also flows into the default `checkProvider` when no override is provided).
- * @param {Object} [options.output] Writable stream for dot-progress (defaults to `process.stdout`).
- * @returns {Promise<Object>}
- */
-export async function waitForProvider({
-    checkProvider: providerCheck,
-    attempts,
-    delayMs,
-    timeoutMs,
-    output = process.stdout
-} = {}) {
-    if (typeof attempts !== 'number' || typeof delayMs !== 'number' || typeof timeoutMs !== 'number') {
-        throw new TypeError('waitForProvider: attempts, delayMs, and timeoutMs are required (pass from config.orchestrator.providerReadiness)');
+    if (!outcome) {
+        writeError('❌ REM cycle did not return an outcome envelope.');
+        return 1;
     }
 
-    const probe = providerCheck ?? (() => checkProvider({timeoutMs}));
-    const startedAt = Date.now();
-
-    for (let i = 0; i < attempts; i++) {
-        if (await probe()) {
-            return {
-                running  : true,
-                attempts : i + 1,
-                elapsedMs: Date.now() - startedAt,
-                timeoutMs: attempts * delayMs
-            };
+    if (outcome.status === 'failed') {
+        if (outcome.diagnostic) {
+            await recordProviderReadinessFailure(outcome.diagnostic, {
+                stderr: message => writeError(message)
+            });
+        } else {
+            writeError('❌ REM cycle failed:', outcome.error?.message || outcome.error || outcome);
         }
-
-        output.write('.');
-        await new Promise(resolve => setTimeout(resolve, delayMs));
+        return 1;
     }
 
-    return {
-        running  : false,
-        attempts,
-        elapsedMs: Date.now() - startedAt,
-        timeoutMs: attempts * delayMs
-    };
+    if (outcome.status === 'skipped') {
+        output.log(`⏭️  Sandman skipped: ${outcome.skipReason || 'no work performed'}.`);
+        return 0;
+    }
+
+    output.log(`✅ Sandman cycle complete (${outcome.sessionsProcessed ?? 0} session(s) processed).`);
+    return 0;
 }
 
 /**
- * @summary Builds the durable Sandman provider-timeout breadcrumb for the Memory Core log.
+ * @summary Thin CLI wrapper for the canonical DreamService REM cycle.
  *
- * Field values flow from `config` and `waitResult` verbatim. Missing inputs surface as
- * `undefined` on the returned envelope (fail-loud); consumers MUST tolerate undefined
- * rather than relying on substitution.
+ * `DreamService.executeRemCycle()` owns the REM contract: provider readiness,
+ * zero-session semantics, failure envelopes, and graph decay. The CLI's only
+ * responsibility is to initialize services, acquire the cross-process heavy
+ * maintenance lease, call the canonical method inside that lease window, and
+ * translate the typed result into terminal output plus an exit code.
  *
  * @param {Object} options
- * @param {Object} options.config Provider-source config (aiConfig-shaped).
- * @param {Object} [options.waitResult] Result envelope from `waitForProvider`; omit when emitting on the unsupported-provider path.
- * @param {Object} [options.lifecycleStatus] Consumer-sourced lifecycle snapshot; surfaces verbatim on the envelope.
- * @param {String} [options.reason] One of `'PROVIDER_READINESS_TIMEOUT'`, `'UNSUPPORTED_GRAPH_PROVIDER'`.
- * @returns {Object}
+ * @param {Object} [options.dreamService=DreamService] Injectable DreamService facade for tests.
+ * @param {Object} [options.lifecycleService=LifecycleService] Injectable lifecycle facade for tests.
+ * @param {Function} [options.withLease=withHeavyMaintenanceLease] Injectable lease wrapper for tests.
+ * @param {Object} [options.output=console] Terminal sink.
+ * @param {Function} [options.exit=process.exit] Exit hook.
+ * @returns {Promise<*>}
  */
-export function createProviderFailureDiagnostic({
-    config = Memory_Config.data,
-    waitResult,
-    lifecycleStatus,
-    reason = 'PROVIDER_READINESS_TIMEOUT'
+export async function runSandman({
+    dreamService     = DreamService,
+    lifecycleService = LifecycleService,
+    withLease        = withHeavyMaintenanceLease,
+    output           = console,
+    exit             = code => process.exit(code)
 } = {}) {
-    const target = getGraphProviderReadinessTarget(config);
-    const unsupported = reason === 'UNSUPPORTED_GRAPH_PROVIDER';
-
-    return {
-        event          : unsupported
-            ? 'runSandman.unsupported_graph_provider'
-            : 'runSandman.provider_readiness_timeout',
-        reason,
-        provider       : target.provider,
-        graphProvider  : target.provider,
-        modelProvider  : config.modelProvider,
-        host           : target.host,
-        endpoint       : target.endpoint,
-        url            : target.url,
-        supported      : target.supported,
-        model          : target.model,
-        embeddingModel : target.embeddingModel,
-        attempts       : waitResult?.attempts,
-        elapsedMs      : waitResult?.elapsedMs,
-        timeoutMs      : waitResult?.timeoutMs,
-        lifecycleStatus,
-        nextAction     : target.supported
-            ? (
-                target.provider === 'openAiCompatible'
-                    ? 'Start the configured OpenAI-compatible / MLX provider, then rerun npm run ai:run-sandman.'
-                    : `Start the configured ${target.provider} provider, then rerun npm run ai:run-sandman.`
-            )
-            : "Set NEO_GRAPH_PROVIDER to 'openAiCompatible' or 'ollama', then rerun npm run ai:run-sandman."
-    };
-}
-
-/**
- * @summary Records the Sandman provider-timeout failure through terminal output and durable MC logging.
- * @param {Object} diagnostic
- * @param {Object} sinks
- * @param {Object} sinks.log
- * @param {Function} sinks.stderr
- * @returns {Promise<Object>}
- */
-export async function recordProviderReadinessFailure(
-    diagnostic,
-    {
-        log    = logger,
-        stderr = console.error
-    } = {}
-) {
-    const message = diagnostic.reason === 'UNSUPPORTED_GRAPH_PROVIDER'
-        ? `\n❌ Unsupported Sandman graph provider '${diagnostic.graphProvider}'. Expected one of: 'ollama', 'openAiCompatible'.`
-        : `\n❌ ${diagnostic.provider} provider is not running on ${diagnostic.host}${diagnostic.endpoint || ''}. Please start the configured provider manually.`;
-
-    stderr(message);
-    log.error(
-        diagnostic.reason === 'UNSUPPORTED_GRAPH_PROVIDER'
-            ? '[runSandman] unsupported graph provider'
-            : `[runSandman] ${diagnostic.provider} provider readiness timeout`,
-        diagnostic
-    );
-
-    if (typeof log.flush === 'function') {
-        await log.flush();
-    }
-
-    return {message, diagnostic};
-}
-
-export async function runSandman() {
     // Enable debug logging to see progress
     Memory_Config.data.debug = true;
 
@@ -256,127 +99,46 @@ export async function runSandman() {
     Memory_Config.data.autoSummarize = false;
     Memory_Config.data.autoGoldenPath = false;
 
-    console.log('⏳ Initializing Sandman REM Extraction Pipeline...');
+    output.log('⏳ Initializing Sandman REM Extraction Pipeline...');
 
     // Run the REM cycle under the shared heavy-maintenance lease so this CLI cannot
     // collide with the orchestrator's `dream` task or with other manual graph-heavy
-    // scripts. If another owner holds the lease, defer without running decay because
-    // no graph mutation occurred in this process.
+    // scripts. If another owner holds the lease, defer without running the cycle.
     let outcome;
     try {
-        outcome = await withHeavyMaintenanceLease(async () => {
-            // Preserve graceful failure for provider-readiness and DreamService errors while
-            // keeping graph-decay inside the lease window. `withHeavyMaintenanceLease`
-            // releases after the task settles, so the inner finally is the last safe place for
-            // graph mutation that must stay covered by the lease.
-            try {
-                console.log('   Waiting for Lifecycle Service to auto-boot orchestrators...');
-                await LifecycleService.ready();
-                console.log('   Lifecycle Service Ready. Database should be running.');
+        outcome = await withLease(async () => {
+            output.log('   Waiting for Lifecycle Service to auto-boot orchestrators...');
+            await lifecycleService.ready();
+            output.log('   Lifecycle Service Ready. Database should be running.');
 
-                console.log('   Waiting for graph provider to warm up load weights into VRAM...');
-                const target = getGraphProviderReadinessTarget();
+            output.log('   Waiting for DreamService Initialization...');
+            await dreamService.ready();
+            output.log('   DreamService Ready.');
 
-                if (!target.supported) {
-                    const diagnostic = createProviderFailureDiagnostic({
-                        reason         : 'UNSUPPORTED_GRAPH_PROVIDER',
-                        lifecycleStatus: InferenceLifecycleService.getStatus()
-                    });
+            output.log('✅ Services Ready. Entering REM Sleep...');
 
-                    await recordProviderReadinessFailure(diagnostic);
-                    process.exitCode = 1;
-                    return {providerReady: false, graphProvider: target.provider};
-                }
-
-                const readinessConfig = AiConfig.orchestrator.providerReadiness;
-                const waitResult = await waitForProvider({
-                    attempts : readinessConfig.attempts,
-                    delayMs  : readinessConfig.delayMs,
-                    timeoutMs: readinessConfig.timeoutMs
-                });
-
-                if (!waitResult.running) {
-                    const diagnostic = createProviderFailureDiagnostic({
-                        waitResult,
-                        lifecycleStatus: InferenceLifecycleService.getStatus()
-                    });
-
-                    await recordProviderReadinessFailure(diagnostic);
-                    process.exitCode = 1;
-                    return {providerReady: false};
-                }
-
-                console.log(`\n   ✅ ${target.provider} server is running (auto-boot successful).`);
-
-                console.log('   Waiting for DreamService Initialization...');
-                // We might need to ensure DreamService is fully inited, though it initAsync runs automatically upon Neo.setupClass
-                await DreamService.ready();
-                console.log('   DreamService Ready.');
-
-                console.log('✅ Services Ready. Entering REM Sleep...');
-
-                await runRemPipeline();
-                process.exitCode = 0;
-                return {providerReady: true};
-            } catch (e) {
-                console.error('❌ REM cycle failed:', e);
-                process.exitCode = 1;
-                return {providerReady: false, error: e.message};
-            } finally {
-                // Inside-the-lease decay (see header comment). Wrapping in try/catch preserves
-                // prior graceful-fail semantics: a decay failure must not throw out of the
-                // lease-wrapped task, since that would mask the inner return value AND propagate
-                // to the outer catch — which is reserved for lease-acquisition failures (fail-closed).
-                console.log('🧹 Triggering global topology decay & pruning mechanism...');
-                try {
-                    // decayGlobalTopology is synchronous; no await needed.
-                    GraphService.decayGlobalTopology();
-                } catch (e) {
-                    console.error('❌ Failed to decay topology:', e);
-                }
-            }
+            return dreamService.executeRemCycle({
+                reason      : 'manual-cli',
+                mode        : 'cli',
+                includeDecay: true
+            });
         }, {owner: 'sandman', reason: 'manual-cli', metadata: {script: 'ai/scripts/runners/runSandman.mjs'}});
     } catch (e) {
         // If lease acquisition fails, fail closed rather than mutating Memory Core graph state
         // without concurrency protection.
-        console.error('❌ REM cycle lease acquisition failed:', e);
-        process.exit(1);
+        output.error('❌ REM cycle lease acquisition failed:', e);
+        return exit(1);
     }
 
     if (outcome?.status === 'held') {
         const held = outcome.lease;
-        console.log(`⏸️  Deferred: heavy-maintenance lease held by '${held.owner}' (reason='${held.reason}', pid=${held.pid}, acquiredAt=${held.acquiredAt}).`);
-        console.log('   This script will not run while another heavy-maintenance task is active. Re-invoke once the active owner completes.');
-        // Skip the decay step on held — no graph mutation occurred + we don't hold the lease.
-        process.exit(0);
+        output.log(`⏸️  Deferred: heavy-maintenance lease held by '${held.owner}' (reason='${held.reason}', pid=${held.pid}, acquiredAt=${held.acquiredAt}).`);
+        output.log('   This script will not run while another heavy-maintenance task is active. Re-invoke once the active owner completes.');
+        return exit(0);
     }
 
-    // Reached here only when outcome.status === 'completed' — lease was acquired AND the
-    // inner work + inner-finally decay both ran INSIDE the lease window (see inner finally
-    // above for the release-timing invariant). Nothing further to do here besides honoring
-    // the inner exitCode contract.
-    process.exit(process.exitCode);
-}
-
-/**
- * Runs the Sandman REM cycle body after provider and service readiness gates pass.
- * Exposed for unit coverage so fatal DreamService failures cannot regress into
- * a misleading success log or successful process exit.
- * @param {Object} options
- * @param {Object} [options.dreamService=DreamService]
- * @param {Object} [options.goldenPathSynthesizer=GoldenPathSynthesizer]
- * @param {Object} [options.output=console]
- * @returns {Promise<void>}
- */
-export async function runRemPipeline({
-    dreamService          = DreamService,
-    goldenPathSynthesizer = GoldenPathSynthesizer,
-    output                = console
-} = {}) {
-    await dreamService.processUndigestedSessions();
-    await goldenPathSynthesizer.synthesizeGoldenPath();
-
-    output.log('✅ Sandman cycle complete.');
+    const exitCode = await recordRemCycleOutcome(outcome?.result, {output});
+    return exit(exitCode);
 }
 
 if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {

--- a/ai/services/graph/ProviderReadinessHelper.mjs
+++ b/ai/services/graph/ProviderReadinessHelper.mjs
@@ -1,0 +1,253 @@
+import http from 'http';
+import {Memory_Config as aiConfig} from '../../services.mjs';
+import logger from '../../mcp/server/memory-core/logger.mjs';
+import {isGraphModelProviderSupported, resolveGraphModelProvider} from './providerDispatch.mjs';
+
+/**
+ * @module ai/services/graph/ProviderReadinessHelper
+ */
+
+/**
+ * @summary Resolves the OpenAI-compatible host used by one REM graph-provider option.
+ * @param {Object} config
+ * @returns {String|undefined}
+ */
+export function getOpenAiCompatibleHost(config = aiConfig.data) {
+    return config.openAiCompatible?.host;
+}
+
+/**
+ * @summary Builds the provider readiness target for the resolved REM graph provider.
+ * @param {Object} config
+ * @returns {Object}
+ */
+export function getGraphProviderReadinessTarget(config = aiConfig.data) {
+    const provider  = resolveGraphModelProvider(config);
+    const supported = isGraphModelProviderSupported(provider);
+
+    if (!supported) {
+        return {
+            provider,
+            supported,
+            endpoint      : null,
+            host          : null,
+            model         : null,
+            embeddingModel: null,
+            url           : null
+        };
+    }
+
+    const isOllama = provider === 'ollama';
+    const host     = isOllama
+        ? config.ollama?.host
+        : getOpenAiCompatibleHost(config);
+    const endpoint = isOllama ? '/api/tags' : '/v1/models';
+    const model    = isOllama ? config.ollama?.model : config.openAiCompatible?.model;
+    const embeddingModel = isOllama
+        ? config.ollama?.embeddingModel
+        : config.openAiCompatible?.embeddingModel;
+    const url      = host ? `${host.replace(/\/+$/, '')}${endpoint}` : null;
+
+    return {
+        provider,
+        supported,
+        endpoint,
+        host,
+        model,
+        embeddingModel,
+        url
+    };
+}
+
+/**
+ * @summary Probes the configured graph provider used by the REM pipeline.
+ * @param {Object} options
+ * @param {Object} options.config Provider-source config (aiConfig-shaped).
+ * @param {Number} options.timeoutMs HTTP probe abandon threshold. Required; no module-level default.
+ * @returns {Promise<Boolean>}
+ */
+export function checkProvider({config, timeoutMs} = {}) {
+    if (typeof timeoutMs !== 'number') {
+        throw new TypeError('checkProvider: timeoutMs is required (pass from config.orchestrator.providerReadiness.timeoutMs)');
+    }
+    const target = getGraphProviderReadinessTarget(config ?? aiConfig.data);
+
+    if (!target.supported || !target.url) {
+        return Promise.resolve(false);
+    }
+
+    return new Promise(resolve => {
+        let settled = false;
+        const settle = value => {
+            if (!settled) {
+                settled = true;
+                resolve(value);
+            }
+        };
+
+        const req = http.get(target.url, response => {
+            response.resume();
+            settle(true);
+        });
+
+        req.setTimeout(timeoutMs, () => {
+            req.destroy();
+            settle(false);
+        });
+        req.on('error', () => settle(false));
+    });
+}
+
+/**
+ * @summary Waits for the local graph provider readiness loop while exposing deterministic test seams.
+ *
+ * Probe parameters are required arguments; callers read
+ * `AiConfig.orchestrator.providerReadiness` and pass the values explicitly so
+ * configuration remains the single source of truth.
+ *
+ * @param {Object} options
+ * @param {Function} [options.checkProvider] Injectable probe (defaults to `checkProvider` bound to the same `timeoutMs`).
+ * @param {Number} options.attempts Retry cap.
+ * @param {Number} options.delayMs Between-probe wait.
+ * @param {Number} options.timeoutMs HTTP probe abandon threshold (also flows into the default `checkProvider` when no override is provided).
+ * @param {Object} [options.output] Writable stream for dot-progress (defaults to `process.stdout`).
+ * @returns {Promise<Object>}
+ */
+export async function waitForProvider({
+    checkProvider: providerCheck,
+    attempts,
+    delayMs,
+    timeoutMs,
+    output = process.stdout
+} = {}) {
+    if (typeof attempts !== 'number' || typeof delayMs !== 'number' || typeof timeoutMs !== 'number') {
+        throw new TypeError('waitForProvider: attempts, delayMs, and timeoutMs are required (pass from config.orchestrator.providerReadiness)');
+    }
+
+    const probe = providerCheck ?? (() => checkProvider({timeoutMs}));
+    const startedAt = Date.now();
+
+    for (let i = 0; i < attempts; i++) {
+        if (await probe()) {
+            return {
+                running  : true,
+                attempts : i + 1,
+                elapsedMs: Date.now() - startedAt,
+                timeoutMs: attempts * delayMs
+            };
+        }
+
+        output.write('.');
+        await new Promise(resolve => setTimeout(resolve, delayMs));
+    }
+
+    return {
+        running  : false,
+        attempts,
+        elapsedMs: Date.now() - startedAt,
+        timeoutMs: attempts * delayMs
+    };
+}
+
+/**
+ * @summary Validates the required provider-readiness config shape without substituting defaults.
+ * @param {Object} readinessConfig `AiConfig.orchestrator.providerReadiness`.
+ * @returns {Object}
+ */
+export function assertProviderReadinessConfig(readinessConfig) {
+    if (!readinessConfig || typeof readinessConfig !== 'object') {
+        throw new TypeError('AiConfig.orchestrator.providerReadiness is required; copy the providerReadiness block from ai/config.template.mjs or set its env-backed values in ai/config.mjs');
+    }
+
+    const missing = ['attempts', 'delayMs', 'timeoutMs'].filter(key => typeof readinessConfig[key] !== 'number');
+    if (missing.length > 0) {
+        throw new TypeError(`AiConfig.orchestrator.providerReadiness.${missing.join('|')} must be configured as number(s); no code-level fallback is applied`);
+    }
+
+    return readinessConfig;
+}
+
+/**
+ * @summary Builds the durable provider-timeout breadcrumb for REM-cycle callers.
+ *
+ * Field values flow from `config` and `waitResult` verbatim. Missing inputs
+ * surface as `undefined` on the returned envelope (fail-loud); consumers MUST
+ * tolerate undefined rather than relying on substitution.
+ *
+ * @param {Object} options
+ * @param {Object} options.config Provider-source config (aiConfig-shaped).
+ * @param {Object} [options.waitResult] Result envelope from `waitForProvider`; omit when emitting on the unsupported-provider path.
+ * @param {Object} [options.lifecycleStatus] Consumer-sourced lifecycle snapshot; surfaces verbatim on the envelope.
+ * @param {String} [options.reason] One of `'PROVIDER_READINESS_TIMEOUT'`, `'UNSUPPORTED_GRAPH_PROVIDER'`.
+ * @returns {Object}
+ */
+export function createProviderFailureDiagnostic({
+    config = aiConfig.data,
+    waitResult,
+    lifecycleStatus,
+    reason = 'PROVIDER_READINESS_TIMEOUT'
+} = {}) {
+    const target = getGraphProviderReadinessTarget(config);
+    const unsupported = reason === 'UNSUPPORTED_GRAPH_PROVIDER';
+
+    return {
+        event          : unsupported
+            ? 'runSandman.unsupported_graph_provider'
+            : 'runSandman.provider_readiness_timeout',
+        reason,
+        provider       : target.provider,
+        graphProvider  : target.provider,
+        modelProvider  : config.modelProvider,
+        host           : target.host,
+        endpoint       : target.endpoint,
+        url            : target.url,
+        supported      : target.supported,
+        model          : target.model,
+        embeddingModel : target.embeddingModel,
+        attempts       : waitResult?.attempts,
+        elapsedMs      : waitResult?.elapsedMs,
+        timeoutMs      : waitResult?.timeoutMs,
+        lifecycleStatus,
+        nextAction     : target.supported
+            ? (
+                target.provider === 'openAiCompatible'
+                    ? 'Start the configured OpenAI-compatible / MLX provider, then rerun npm run ai:run-sandman.'
+                    : `Start the configured ${target.provider} provider, then rerun npm run ai:run-sandman.`
+            )
+            : "Set NEO_GRAPH_PROVIDER to 'openAiCompatible' or 'ollama', then rerun npm run ai:run-sandman."
+    };
+}
+
+/**
+ * @summary Records provider-readiness failure through terminal output and durable MC logging.
+ * @param {Object} diagnostic
+ * @param {Object} sinks
+ * @param {Object} sinks.log
+ * @param {Function} sinks.stderr
+ * @returns {Promise<Object>}
+ */
+export async function recordProviderReadinessFailure(
+    diagnostic,
+    {
+        log    = logger,
+        stderr = console.error
+    } = {}
+) {
+    const message = diagnostic.reason === 'UNSUPPORTED_GRAPH_PROVIDER'
+        ? `\n❌ Unsupported Sandman graph provider '${diagnostic.graphProvider}'. Expected one of: 'ollama', 'openAiCompatible'.`
+        : `\n❌ ${diagnostic.provider} provider is not running on ${diagnostic.host}${diagnostic.endpoint || ''}. Please start the configured provider manually.`;
+
+    stderr(message);
+    log.error(
+        diagnostic.reason === 'UNSUPPORTED_GRAPH_PROVIDER'
+            ? '[runSandman] unsupported graph provider'
+            : `[runSandman] ${diagnostic.provider} provider readiness timeout`,
+        diagnostic
+    );
+
+    if (typeof log.flush === 'function') {
+        await log.flush();
+    }
+
+    return {message, diagnostic};
+}

--- a/ai/services/memory-core/GraphService.mjs
+++ b/ai/services/memory-core/GraphService.mjs
@@ -529,7 +529,8 @@ class GraphService extends Base {
             systemNode = this.db.nodes.get('_SYSTEM_STATE');
         }
 
-        const lastDecayedAt = systemNode.properties?.lastDecayedAt || 0;
+        const systemProperties = systemNode.isRecord ? systemNode.get('properties') : systemNode.properties;
+        const lastDecayedAt    = systemProperties?.lastDecayedAt || 0;
         const now = Date.now();
         const hoursElapsed = (now - lastDecayedAt) / 3600000;
 
@@ -560,9 +561,10 @@ class GraphService extends Base {
 
         // Commit global clock update
         this.upsertNode({
-            ...systemNode,
+            id        : '_SYSTEM_STATE',
+            type      : systemNode.isRecord ? systemNode.get('label') : systemNode.label,
             properties: {
-                ...(systemNode.properties || {}),
+                ...(systemProperties || {}),
                 lastDecayedAt: now
             }
         });

--- a/test/playwright/unit/ai/daemons/orchestrator/services/DreamService.executeRemCycle.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/services/DreamService.executeRemCycle.spec.mjs
@@ -72,6 +72,20 @@ test.describe('DreamService.executeRemCycle typed outcome contract', () => {
         expect(outcome.durationMs).toBeGreaterThanOrEqual(0);
     });
 
+    test('returns failed status when provider-readiness config validation throws', async () => {
+        DreamService.checkProviderReadiness = async () => {
+            throw new TypeError('AiConfig.orchestrator.providerReadiness is required');
+        };
+
+        const outcome = await DreamService.executeRemCycle({reason: 'missing-config-test'});
+
+        expect(outcome.status).toBe('failed');
+        expect(outcome.error?.message).toContain('checkProviderReadiness threw');
+        expect(outcome.error?.message).toContain('providerReadiness is required');
+        expect(outcome.sessionsProcessed).toBeNull();
+        expect(outcome.diagnostic).toBeNull();
+    });
+
     test('returns skipped status when dryRun=true after gate passes', async () => {
         const outcome = await DreamService.executeRemCycle({reason: 'dry-run-test', dryRun: true});
 

--- a/test/playwright/unit/ai/scripts/maintenance/manualHeavyMaintenanceScriptLeaseAdoption.spec.mjs
+++ b/test/playwright/unit/ai/scripts/maintenance/manualHeavyMaintenanceScriptLeaseAdoption.spec.mjs
@@ -40,13 +40,13 @@ test.describe('Manual heavy-maintenance script lease adoption', () => {
      * task names — keep these in sync with `MaintenanceBackpressureService.mjs` DEFAULT_HEAVY_MAINTENANCE_TASK_NAMES.
      */
     const SCRIPTS = [
-        {file: 'runSandman.mjs',           owner: 'sandman'},
-        {file: 'syncKnowledgeBase.mjs',    owner: 'kbSync'},
-        {file: 'backup.mjs',               owner: 'backup'},
-        {file: 'syncGithubWorkflow.mjs',   owner: 'syncGithubWorkflow'}
+        {file: 'runSandman.mjs',           owner: 'sandman',            invocation: 'withLease('},
+        {file: 'syncKnowledgeBase.mjs',    owner: 'kbSync',             invocation: 'withHeavyMaintenanceLease('},
+        {file: 'backup.mjs',               owner: 'backup',             invocation: 'withHeavyMaintenanceLease('},
+        {file: 'syncGithubWorkflow.mjs',   owner: 'syncGithubWorkflow', invocation: 'withHeavyMaintenanceLease('}
     ];
 
-    for (const {file, owner} of SCRIPTS) {
+    for (const {file, owner, invocation} of SCRIPTS) {
         test(`${file}: imports withHeavyMaintenanceLease`, async () => {
             const source = await fs.readFile(scriptPath(file), 'utf-8');
             expect(source).toMatch(/import\s*\{[^}]*withHeavyMaintenanceLease[^}]*\}\s*from\s*['"]\.\.\/\.\.\/daemons\/orchestrator\/services\/HeavyMaintenanceLeaseService\.mjs['"]/);
@@ -55,7 +55,7 @@ test.describe('Manual heavy-maintenance script lease adoption', () => {
         test(`${file}: wraps heavy work with withHeavyMaintenanceLease + correct owner '${owner}'`, async () => {
             const source = await fs.readFile(scriptPath(file), 'utf-8');
             // Assert the wrapper is INVOKED (not just imported)
-            expect(source).toContain('withHeavyMaintenanceLease(');
+            expect(source).toContain(invocation);
             // Assert the correct owner string is passed
             expect(source).toMatch(new RegExp(`owner\\s*:\\s*['"]${owner}['"]`));
             // Assert the manual-cli reason tag is in place (distinguishes CLI invocations from orchestrator-spawned ones in lease telemetry)
@@ -69,17 +69,17 @@ test.describe('Manual heavy-maintenance script lease adoption', () => {
             // Assert the deferred message names the active owner (so the user sees who holds the lease)
             expect(source).toMatch(/Deferred:.*lease held by/i);
             // Assert process.exit(0) is called on held — non-error semantics per AC2
-            expect(source).toMatch(/process\.exit\(0\)/);
+            expect(source).toMatch(file === 'runSandman.mjs' ? /exit\(0\)/ : /process\.exit\(0\)/);
         });
     }
 
-    test('runSandman.mjs: fail-closed on lease-acquisition error — does NOT fall through to GraphService.decayGlobalTopology (per GPT review PRR_kwDODSospM8AAAABAJIdTg)', async () => {
+    test('runSandman.mjs: fail-closed on lease-acquisition error — does NOT continue to the REM cycle', async () => {
         // GPT's cycle-1 review (PR #11509 PRR_kwDODSospM8AAAABAJIdTg) caught: my prior code set
         // process.exitCode=1 in the outer catch but FELL THROUGH to GraphService.decayGlobalTopology()
         // which mutates SQLite graph edges + _SYSTEM_STATE. That defeats the substrate protection the
         // PR is shipping — the one path where the lease was NOT acquired could still mutate the graph.
         //
-        // Fix: process.exit(1) directly in the catch block to short-circuit before the decay call.
+        // Fix: exit(1) directly in the catch block to short-circuit before the canonical REM cycle.
         // This test pins the fail-closed contract via source inspection (subprocess test would require
         // heavy Neo + LifecycleService bootstrap; content-grep matches this spec's existing pattern).
         const source = await fs.readFile(scriptPath('runSandman.mjs'), 'utf-8');
@@ -89,67 +89,56 @@ test.describe('Manual heavy-maintenance script lease adoption', () => {
         expect(acquisitionCatchMatch).not.toBeNull();
         const catchBlock = acquisitionCatchMatch[0];
 
-        // The catch block MUST call process.exit(1) to short-circuit (not just set exitCode then fall through).
-        expect(catchBlock).toMatch(/process\.exit\(1\)/);
+        // The catch block MUST call exit(1) to short-circuit (not just set exitCode then fall through).
+        expect(catchBlock).toMatch(/exit\(1\)/);
 
         // Defensive: ensure the catch block does NOT contain the prior buggy pattern
         // (`process.exitCode = 1` without a subsequent `process.exit`).
         const hasExitCodeAssignment = /process\.exitCode\s*=\s*1/.test(catchBlock);
-        const hasExitCall           = /process\.exit\(1\)/      .test(catchBlock);
+        const hasExitCall           = /exit\(1\)/               .test(catchBlock);
         if (hasExitCodeAssignment) {
             expect(hasExitCall).toBe(true);
         }
     });
 
-    test('runSandman.mjs: decayGlobalTopology runs INSIDE the lease window (per GPT review PRR_kwDODSospM8AAAABAJKF8w)', async () => {
+    test('runSandman.mjs: canonical REM cycle runs INSIDE the lease window with graph decay enabled', async () => {
         // GPT's cycle-2 review caught: `withHeavyMaintenanceLease` releases the lease in its
         // own `finally` BEFORE returning, so calling `GraphService.decayGlobalTopology()` AFTER
         // `await withHeavyMaintenanceLease(...)` settles would mutate Memory Core graph state
         // OUTSIDE the lease — defeating the substrate protection this PR is shipping.
         //
-        // Fix: decay is invoked inside an inner `finally` block within the async task passed
-        // to `withHeavyMaintenanceLease`. JS guarantees the inner finally runs before the
-        // task's returned promise settles, so the wrapper's own finally (release) runs strictly
-        // after decay.
+        // Current SSOT shape: DreamService.executeRemCycle() owns graph decay. The CLI must call
+        // that canonical cycle with `includeDecay: true` from inside the async task passed to
+        // `withHeavyMaintenanceLease`; any post-wrapper call would run after lease release.
         //
         // This test pins the release-timing invariant via source-offset comparison:
-        // the decay call MUST appear before the wrapper's owner-config trailer AND before any
+        // the REM call MUST appear before the wrapper's owner-config trailer AND before any
         // post-wrapper outcome handling — both of which mark the boundary where the lease has
         // already been released by the wrapper.
         const source = await fs.readFile(scriptPath('runSandman.mjs'), 'utf-8');
 
-        const decayMatch = source.match(/GraphService\.decayGlobalTopology\(\)/);
-        expect(decayMatch, 'decayGlobalTopology() call must exist in runSandman.mjs').not.toBeNull();
+        const remCallMatch = source.match(/dreamService\.executeRemCycle\(\{[\s\S]*?includeDecay\s*:\s*true[\s\S]*?\}\)/);
+        expect(remCallMatch, 'DreamService.executeRemCycle({includeDecay:true}) call must exist in runSandman.mjs').not.toBeNull();
 
         // The wrapper's options trailer `}, {owner: 'sandman', ...})` marks the end of the
-        // async-task argument. Decay must appear textually BEFORE this trailer to be inside
+        // async-task argument. The REM cycle must appear textually BEFORE this trailer to be inside
         // the wrapped task.
         const wrapperOptionsMatch = source.match(/\}\s*,\s*\{\s*owner\s*:\s*['"]sandman['"]/);
         expect(wrapperOptionsMatch, "withHeavyMaintenanceLease wrapper's owner-config trailer must exist").not.toBeNull();
         expect(
-            decayMatch.index,
-            'decay must run INSIDE the wrapped task (before the wrapper-options trailer) so it executes while the lease is still held'
+            remCallMatch.index,
+            'the REM cycle must run INSIDE the wrapped task (before the wrapper-options trailer) so its graph decay executes while the lease is still held'
         ).toBeLessThan(wrapperOptionsMatch.index);
 
-        // Defensive: also assert decay appears BEFORE post-wrapper held-handling. Any decay
+        // Defensive: also assert the REM call appears BEFORE post-wrapper held-handling. Any
         // call after the `if (outcome?.status === 'held')` branch would necessarily run after
-        // the wrapper's release.
+        // the wrapper's release and outside the lease window.
         const postWrapperMarkerMatch = source.match(/if\s*\(\s*outcome\?\.status\s*===\s*['"]held['"]\s*\)/);
         expect(postWrapperMarkerMatch, 'post-wrapper held-handling branch must exist').not.toBeNull();
         expect(
-            decayMatch.index,
-            'decay must NOT appear after the post-wrapper held-check — that position is outside the lease window'
+            remCallMatch.index,
+            'the REM cycle must NOT appear after the post-wrapper held-check — that position is outside the lease window'
         ).toBeLessThan(postWrapperMarkerMatch.index);
-
-        // Defensive: the inner-task structure must contain a `finally {` block. This pins the
-        // structural mechanism (finally-block placement) rather than just the offset ordering,
-        // so a future refactor that accidentally moves decay into the wrapper's catch (which
-        // only fires on lease-acquisition failure → graph mutation outside the lease) is caught.
-        const innerFinallyMatch = source.match(/\}\s*finally\s*\{[\s\S]*?GraphService\.decayGlobalTopology\(\)/);
-        expect(
-            innerFinallyMatch,
-            'decayGlobalTopology must be invoked from inside a `finally {` block of the lease-wrapped task'
-        ).not.toBeNull();
     });
 
     test('all four scripts share the same lease-wrapper pattern (no per-script private locks)', async () => {

--- a/test/playwright/unit/ai/scripts/runners/runSandman.spec.mjs
+++ b/test/playwright/unit/ai/scripts/runners/runSandman.spec.mjs
@@ -89,6 +89,16 @@ test.describe('runSandman.mjs provider readiness diagnostics (#10587)', () => {
         await expect(runSandmanModule.waitForProvider()).rejects.toThrow(/attempts.*delayMs.*timeoutMs.*required/);
     });
 
+    test('assertProviderReadinessConfig fails loud when the SSOT config block is absent', () => {
+        expect(() => runSandmanModule.assertProviderReadinessConfig()).toThrow(/providerReadiness is required/);
+        expect(() => runSandmanModule.assertProviderReadinessConfig({attempts: 1, delayMs: 0})).toThrow(/timeoutMs.*configured/);
+        expect(runSandmanModule.assertProviderReadinessConfig({attempts: 1, delayMs: 0, timeoutMs: 10})).toEqual({
+            attempts : 1,
+            delayMs  : 0,
+            timeoutMs: 10
+        });
+    });
+
     test('checkProvider throws when timeoutMs is absent (config-as-SSOT contract)', () => {
         expect(() => runSandmanModule.checkProvider()).toThrow(/timeoutMs.*required/);
         expect(() => runSandmanModule.checkProvider({config: {graphProvider: 'openAiCompatible'}})).toThrow(/timeoutMs.*required/);
@@ -236,25 +246,134 @@ test.describe('runSandman.mjs provider readiness diagnostics (#10587)', () => {
         });
     });
 
-    test('runRemPipeline propagates REM failures without printing success (#11698)', async () => {
+    test('runSandman delegates exactly one canonical REM cycle inside the lease (#12070)', async () => {
+        const calls     = [];
         const logs = [];
+        const exitCodes = [];
 
-        await expect(runSandmanModule.runRemPipeline({
+        const result = await runSandmanModule.runSandman({
             dreamService: {
+                ready: async () => calls.push('dream.ready'),
+                executeRemCycle: async options => {
+                    calls.push(['executeRemCycle', options]);
+                    return {status: 'completed', sessionsProcessed: 2};
+                },
                 processUndigestedSessions: async () => {
-                    throw new Error('simulated REM failure');
+                    throw new Error('legacy REM path must not run');
                 }
             },
-            goldenPathSynthesizer: {
-                synthesizeGoldenPath: async () => {
-                    throw new Error('Golden Path must not run after REM failure');
-                }
+            lifecycleService: {
+                ready: async () => calls.push('lifecycle.ready')
+            },
+            withLease: async (task, options) => {
+                calls.push(['withLease', options]);
+                return {
+                    status  : 'completed',
+                    acquired: true,
+                    result  : await task({status: 'acquired'})
+                };
             },
             output: {
-                log: message => logs.push(message)
+                log  : message => logs.push(message),
+                error: message => logs.push(message)
+            },
+            exit: code => {
+                exitCodes.push(code);
+                return code;
             }
-        })).rejects.toThrow('simulated REM failure');
+        });
 
-        expect(logs.some(message => message.includes('Sandman cycle complete'))).toBe(false);
+        expect(result).toBe(0);
+        expect(exitCodes).toEqual([0]);
+        expect(calls).toEqual([
+            ['withLease', {
+                owner   : 'sandman',
+                reason  : 'manual-cli',
+                metadata: {script: 'ai/scripts/runners/runSandman.mjs'}
+            }],
+            'lifecycle.ready',
+            'dream.ready',
+            ['executeRemCycle', {
+                reason      : 'manual-cli',
+                mode        : 'cli',
+                includeDecay: true
+            }]
+        ]);
+        expect(logs.some(message => message.includes('Sandman cycle complete (2 session(s) processed)'))).toBe(true);
+    });
+
+    test('runSandman maps canonical REM failures to a failing process code (#12070)', async () => {
+        const logs      = [];
+        const exitCodes = [];
+
+        const result = await runSandmanModule.runSandman({
+            dreamService: {
+                ready: async () => {},
+                executeRemCycle: async () => ({
+                    status: 'failed',
+                    error : {message: 'simulated REM failure'}
+                })
+            },
+            lifecycleService: {
+                ready: async () => {}
+            },
+            withLease: async task => ({
+                status  : 'completed',
+                acquired: true,
+                result  : await task({status: 'acquired'})
+            }),
+            output: {
+                log  : message => logs.push(message),
+                error: (...args) => logs.push(args.join(' '))
+            },
+            exit: code => {
+                exitCodes.push(code);
+                return code;
+            }
+        });
+
+        expect(result).toBe(1);
+        expect(exitCodes).toEqual([1]);
+        expect(logs.some(message => message.includes('simulated REM failure'))).toBe(true);
+    });
+
+    test('runSandman defers without running DreamService when the maintenance lease is held (#12070)', async () => {
+        const logs      = [];
+        const exitCodes = [];
+
+        const result = await runSandmanModule.runSandman({
+            dreamService: {
+                ready: async () => {
+                    throw new Error('DreamService must not initialize when lease is held');
+                }
+            },
+            lifecycleService: {
+                ready: async () => {
+                    throw new Error('LifecycleService must not initialize when lease is held');
+                }
+            },
+            withLease: async () => ({
+                status  : 'held',
+                acquired: false,
+                lease   : {
+                    owner     : 'orchestrator',
+                    reason    : 'periodic-dream',
+                    pid       : 12345,
+                    acquiredAt: '2026-05-27T16:00:00.000Z'
+                }
+            }),
+            output: {
+                log  : message => logs.push(message),
+                error: message => logs.push(message)
+            },
+            exit: code => {
+                exitCodes.push(code);
+                return code;
+            }
+        });
+
+        expect(result).toBe(0);
+        expect(exitCodes).toEqual([0]);
+        expect(logs.some(message => message.includes("Deferred: heavy-maintenance lease held by 'orchestrator'"))).toBe(true);
     });
 });

--- a/test/playwright/unit/ai/services/memory-core/GraphService.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/GraphService.spec.mjs
@@ -137,6 +137,23 @@ test.describe('Neo.ai.services.memory-core.GraphService', () => {
         expect(() => GraphService.removeNodes(['ValidNode', undefined])).toThrow(/invalid node id/);
     });
 
+    test('decayGlobalTopology updates cached _SYSTEM_STATE records without losing the node id (#12070)', async () => {
+        await GraphService.upsertNode({
+            id        : '_SYSTEM_STATE',
+            type      : 'SYSTEM_CLOCK',
+            properties: {lastDecayedAt: 0}
+        });
+        await GraphService.upsertNode({id: 'DecaySource', type: 'TEST_NODE'});
+        await GraphService.upsertNode({id: 'DecayTarget', type: 'TEST_NODE'});
+        GraphService.linkNodes('DecaySource', 'DecayTarget', 'RELATES_TO', 1);
+
+        expect(() => GraphService.decayGlobalTopology(0.98, 0.2, true)).not.toThrow();
+
+        const systemNode = await GraphService.getNodeRecord({id: '_SYSTEM_STATE'});
+        expect(typeof systemNode.properties.lastDecayedAt).toBe('number');
+        expect(systemNode.properties.lastDecayedAt).toBeGreaterThan(0);
+    });
+
     test('getNodeRecord returns the properties blob that getNode strips (#11637)', async () => {
         test.skip(!!process.env.NEO_TEST_SKIP_CI, 'CI-skip: SqliteError disk I/O - bucket G3 (#10924)');
         await GraphService.upsertNode({


### PR DESCRIPTION
Resolves #12070

Authored by GPT-5 (Codex Desktop). Session 6ca1b510-51c3-4fac-aa39-a0fd6941318c.

Replaces the standalone Sandman runner's duplicated REM choreography with the canonical `DreamService.executeRemCycle()` path. The runner now only bootstraps Memory Core, takes the heavy-maintenance lease, calls the DreamService cycle inside that lease, and maps the typed outcome to CLI output/exit status. Provider readiness helpers live in `ai/services/graph/ProviderReadinessHelper.mjs` so the runner and DreamService share the graph-provider readiness seam without bloating the DreamService class file, and GraphService decay now preserves `_SYSTEM_STATE` ids when the system clock is a cached Neo Record.

Evidence: L4 (live `npm run ai:run-sandman` against local LM Studio provider, outside sandbox, completed `Sandman cycle complete (10 session(s) processed)`) -> L4 required (operator-reported Sandman CLI regression). Residual: semantic extractor output quality warnings still surface, but the runner/provider/decay regression no longer aborts Sandman.

FAIR-band: in-band; P0 regression mitigation under #12070, 9 tracked files, focused on the Sandman SSOT path plus the live decay crash found during proof.

## Deltas from ticket
The ticket text was stale after #12096: it still referred to `Orchestrator.executeRemCycle()`, `includeGoldenPath`, and a Sub 5 refresh helper. The merged source of authority is `DreamService.executeRemCycle({reason, mode, includeDecay, dryRun})`, so this PR does not add a Golden Path mode or a dead flag. It removes the independent runner choreography instead.

The live proof also exposed a second blocker in `GraphService.decayGlobalTopology()`: cached `_SYSTEM_STATE` Records were spread into `upsertNode()` without an `id`. That is fixed here because the canonical cycle includes decay and Sandman still could not complete without it.

Cycle-1 review corrected the provider-readiness file boundary: helper functions now live beside `providerDispatch.mjs`, `DreamService.mjs` is 542 LOC locally, and the class file has no `http` import or module-level exported helper functions.

## Test Evidence
- `node --check ai/scripts/runners/runSandman.mjs`
- `node --check ai/daemons/orchestrator/services/DreamService.mjs`
- `node --check ai/services/graph/ProviderReadinessHelper.mjs`
- `node --check ai/services/memory-core/GraphService.mjs`
- `git diff --check`
- `git diff --cached --check`
- `npm run ai:check-retired-primitives`
- `npm run test-unit -- test/playwright/unit/ai/scripts/maintenance/manualHeavyMaintenanceScriptLeaseAdoption.spec.mjs` -> 15 passed
- `npm run test-unit -- test/playwright/unit/ai/daemons/orchestrator/services/DreamService.executeRemCycle.spec.mjs test/playwright/unit/ai/scripts/runners/runSandman.spec.mjs test/playwright/unit/ai/services/memory-core/GraphService.spec.mjs` -> 47 passed
- `npm run test-unit -- test/playwright/unit/ai/daemons/orchestrator/Orchestrator.spec.mjs` -> 30 passed
- `npm run test-unit -- test/playwright/unit/ai/scripts/maintenance/manualHeavyMaintenanceScriptLeaseAdoption.spec.mjs test/playwright/unit/ai/scripts/runners/runSandman.spec.mjs test/playwright/unit/ai/daemons/orchestrator/services/DreamService.executeRemCycle.spec.mjs test/playwright/unit/ai/services/memory-core/GraphService.spec.mjs test/playwright/unit/ai/daemons/orchestrator/Orchestrator.spec.mjs` -> 92 passed
- `npm run ai:run-sandman` outside sandbox with LM Studio on port 1234 after helper extraction -> exit 0; `✅ Sandman cycle complete (10 session(s) processed).`

## Post-Merge Validation
- [ ] On a checkout with a current `ai/config.mjs`, run `npm run ai:run-sandman` and verify it delegates to DreamService and exits 0 without `gemini` provider dispatch.
- [ ] Confirm PR #12098's config-as-SSOT changes do not duplicate or weaken the fail-loud `providerReadiness` validation introduced here.

## Commit
- `bc98d22c5` — `fix(ai): delegate Sandman runner to REM cycle (#12070)`
