### PR TITLE
fix(ai): prewarm lms chat and embedding models (#12090)

### DIFF
--- a/ai/config.template.mjs
+++ b/ai/config.template.mjs
@@ -371,10 +371,10 @@ class Config extends BaseConfig {
              *   child process. Disabled by default; **macOS-only** (LM Studio CLI is not
              *   shipped for Linux containers, so this lane is local-dev substrate, not
              *   cloud-deployment substrate).
-             * - `model`: model identifier the operator intends LM Studio to serve. The
-             *   orchestrator-managed `lms server start` lane currently brings the server up;
-             *   ensuring this model is loaded (via `lms load <model>` or `/v1/models` probe)
-             *   is tracked as #11986 AC5 residual and is NOT performed by this lane today.
+             * - `model`: legacy single-model field kept for existing operator overlays. The
+             *   orchestrator-managed `lms server start` lane pre-warms the configured
+             *   OpenAI-compatible chat + embedding models (`openAiCompatible.model` and
+             *   `openAiCompatible.embeddingModel`) via `lms load <model>` after server spawn.
              *   Distinct from the OpenAI-compatible API payload label (`NEO_OPENAI_COMPATIBLE_MODEL`).
              * - `port`: OpenAI-compatible local-inference port (LM Studio CLI default `1234`).
              * @type {Object}

--- a/ai/daemons/orchestrator/Orchestrator.mjs
+++ b/ai/daemons/orchestrator/Orchestrator.mjs
@@ -428,6 +428,13 @@ export class Orchestrator extends Base {
     get lmsEnabled() { return !!AiConfig.orchestrator.lms?.enabled; }
     get lmsModel()   { return AiConfig.orchestrator.lms?.model;     }
     get lmsPort()    { return AiConfig.orchestrator.lms?.port;      }
+    get lmsHost()    { return AiConfig.openAiCompatible?.host;      }
+    get lmsModels()  {
+        return [...new Set([
+            AiConfig.openAiCompatible?.model,
+            AiConfig.openAiCompatible?.embeddingModel
+        ].filter(Boolean))];
+    }
 
     /**
      * Starts the orchestrator process loop after the wrapper has selected this process.
@@ -469,7 +476,10 @@ export class Orchestrator extends Base {
             mlxPort   : this.mlxPort,
             lmsEnabled: this.lmsEnabled,
             lmsModel  : this.lmsModel,
-            lmsPort   : this.lmsPort
+            lmsModels : this.lmsModels,
+            lmsHost   : this.lmsHost,
+            lmsPort   : this.lmsPort,
+            providerReadiness: AiConfig.orchestrator.providerReadiness
         });
 
         // Non-reactive boot-wrapper-provided instance state
@@ -609,7 +619,8 @@ export class Orchestrator extends Base {
         const continuousTasks = [
             ...(this.chromaDaemonEnabled ? ['chroma'] : []),
             ...(this.bridgeDaemonEnabled ? ['bridgeDaemon'] : []),
-            'mlx'
+            'mlx',
+            'lms'
         ];
         const RESTART_COOLDOWN_MS = 15000;
         for (const taskName of continuousTasks) {

--- a/ai/daemons/orchestrator/TaskDefinitions.mjs
+++ b/ai/daemons/orchestrator/TaskDefinitions.mjs
@@ -31,8 +31,11 @@ export const DEFAULT_SCRIPT_DIR = path.resolve(__dirname, '../../scripts');
  * @param {String} [options.mlxModel] MLX launch model: a Hugging Face repo id or local path.
  * @param {String|Number} [options.mlxPort] MLX OpenAI-compatible local inference port.
  * @param {Boolean} [options.lmsEnabled=false] Whether to launch an orchestrator-owned LM Studio CLI server.
- * @param {String} [options.lmsModel] LM Studio model identifier (informational; lifecycle currently spawns `lms server start` only — see #11986 AC5 for the model-load probe follow-up).
+ * @param {String} [options.lmsModel] Legacy single LM Studio model identifier.
+ * @param {String[]} [options.lmsModels] LM Studio model identifiers that must be resident after spawn.
+ * @param {String} [options.lmsHost] OpenAI-compatible host exposed by the LM Studio server.
  * @param {String|Number} [options.lmsPort] LM Studio OpenAI-compatible local inference port (CLI default `1234`).
+ * @param {Object} [options.providerReadiness] Provider-readiness retry / timeout config.
  * @returns {Object}
  */
 export function buildTaskDefinitions({
@@ -43,7 +46,10 @@ export function buildTaskDefinitions({
     mlxPort,
     lmsEnabled = false,
     lmsModel,
-    lmsPort
+    lmsModels,
+    lmsHost,
+    lmsPort,
+    providerReadiness
 } = {}) {
     const tasks = {
         chroma: {
@@ -124,12 +130,28 @@ export function buildTaskDefinitions({
     }
 
     if (lmsEnabled) {
+        const requiredModels = Array.isArray(lmsModels) && lmsModels.length > 0
+            ? lmsModels
+            : [lmsModel].filter(Boolean);
+
         tasks.lms = {
             label          : 'lms server (LM Studio CLI)',
             command        : 'lms',
             args           : ['server', 'start', '--port', String(lmsPort)],
             pidFileName    : 'lms.pid',
-            expectedCommand: 'lms server'
+            expectedCommand: 'lms server',
+            requiredModels,
+            postSpawn      : async () => {
+                const {ensureLmsModelsLoaded} = await import('../../services/graph/ProviderReadinessHelper.mjs');
+
+                return ensureLmsModelsLoaded({
+                    host     : lmsHost,
+                    models   : requiredModels,
+                    attempts : providerReadiness?.attempts,
+                    delayMs  : providerReadiness?.delayMs,
+                    timeoutMs: providerReadiness?.timeoutMs
+                });
+            }
         };
     }
 

--- a/ai/daemons/orchestrator/services/ProcessSupervisorService.mjs
+++ b/ai/daemons/orchestrator/services/ProcessSupervisorService.mjs
@@ -252,6 +252,61 @@ export class ProcessSupervisorService extends Base {
     }
 
     /**
+     * Runs an optional post-spawn readiness hook for long-running child tasks.
+     *
+     * The child process can be alive before its provider surface is useful. LM Studio's
+     * `lms server start` is the concrete case: the HTTP server can listen while no chat
+     * or embedding model is resident. A task-level hook lets the task own that readiness
+     * contract while this supervisor remains provider-agnostic.
+     *
+     * @param {Object} options
+     * @param {String} options.taskName Task key.
+     * @param {Object} options.task Task definition.
+     * @param {String} options.reason Scheduling reason.
+     * @param {Object} options.child Spawned child process.
+     * @param {Function} options.clear Completion/failure finalizer.
+     * @param {Function} options.isCleared Completion-state guard.
+     * @returns {void}
+     */
+    runPostSpawnHook({taskName, task, reason, child, clear, isCleared}) {
+        if (typeof task.postSpawn !== 'function') {
+            return;
+        }
+
+        Promise.resolve()
+            .then(() => task.postSpawn({
+                taskName,
+                task,
+                reason,
+                pid     : child.pid || null,
+                writeLog: this.writeLog
+            }))
+            .then(result => {
+                if (isCleared?.()) {
+                    return;
+                }
+                this.taskStateService.markReady?.(taskName);
+                this.writeLog?.('INFO', `[ProcessSupervisor] ${task.label} readiness hook completed successfully.`);
+                this.recordTaskOutcome(taskName, 'ready', {
+                    reason,
+                    pid      : child.pid || null,
+                    readyAt  : new Date().toISOString(),
+                    readiness: result || null
+                });
+            })
+            .catch(error => {
+                if (isCleared?.()) {
+                    return;
+                }
+                this.writeLog?.('ERROR', `[ProcessSupervisor] ${task.label} readiness hook failed: ${error.message}`);
+                try {
+                    child.kill?.('SIGTERM');
+                } catch (e) {}
+                clear(null, error, 'post-spawn-readiness');
+            });
+    }
+
+    /**
      * Starts a child task and wires completion status back into task state and HealthService.
      * @param {String} taskName Task key.
      * @param {String} reason Scheduling reason.
@@ -307,7 +362,7 @@ export class ProcessSupervisorService extends Base {
         this.recordTaskOutcome(taskName, 'running', {reason, pid: child.pid || null, startedAt: new Date().toISOString()});
 
         let cleared = false;
-        const clear = (code, error) => {
+        const clear = (code, error, phase = 'start') => {
             if (cleared) {
                 return;
             }
@@ -322,8 +377,8 @@ export class ProcessSupervisorService extends Base {
 
             if (error) {
                 this.taskStateService.markFailed(taskName, null);
-                this.writeLog?.('ERROR', `[ProcessSupervisor] ${task.label} failed to start: ${error.message}`);
-                this.recordTaskOutcome(taskName, 'failed', {reason, phase: 'start', error: error.message});
+                this.writeLog?.('ERROR', `[ProcessSupervisor] ${task.label} failed during ${phase}: ${error.message}`);
+                this.recordTaskOutcome(taskName, 'failed', {reason, phase, error: error.message});
             } else if (code === 0) {
                 try {
                     const completedAt = new Date().toISOString();
@@ -349,8 +404,10 @@ export class ProcessSupervisorService extends Base {
             }
         };
 
+        this.runPostSpawnHook({taskName, task, reason, child, clear, isCleared: () => cleared});
+
         child.on('close', code => clear(code));
-        child.on('error', err => clear(null, err));
+        child.on('error', err => clear(null, err, 'child-process'));
 
         return true;
     }

--- a/ai/daemons/orchestrator/services/TaskStateService.mjs
+++ b/ai/daemons/orchestrator/services/TaskStateService.mjs
@@ -197,6 +197,18 @@ export class TaskStateService extends Base {
     }
 
     /**
+     * Marks a long-running task as ready without clearing its running PID.
+     * @param {String} taskName
+     * @returns {void}
+     */
+    markReady(taskName) {
+        const state = this.taskState[taskName];
+        state.lastExitCode  = 0;
+        state.lastSuccessAt = new Date().toISOString();
+        this.writeState();
+    }
+
+    /**
      * Marks a task as skipped without treating the no-op as a successful run.
      * @param {String} taskName
      * @returns {void}

--- a/ai/services/graph/ProviderReadinessHelper.mjs
+++ b/ai/services/graph/ProviderReadinessHelper.mjs
@@ -1,4 +1,5 @@
 import http from 'http';
+import {execFile} from 'child_process';
 import {Memory_Config as aiConfig} from '../../services.mjs';
 import logger from '../../mcp/server/memory-core/logger.mjs';
 import {isGraphModelProviderSupported, resolveGraphModelProvider} from './providerDispatch.mjs';
@@ -14,6 +15,193 @@ import {isGraphModelProviderSupported, resolveGraphModelProvider} from './provid
  */
 export function getOpenAiCompatibleHost(config = aiConfig.data) {
     return config.openAiCompatible?.host;
+}
+
+/**
+ * @summary Extracts model identifiers from an OpenAI-compatible `/v1/models` payload.
+ *
+ * LM Studio, MLX, vLLM, and llama.cpp-compatible servers all expose the OpenAI
+ * `data: [{id}]` shape for this endpoint. The extra `model` / `name` fallbacks
+ * keep the readiness probe tolerant of local-server variants without changing the
+ * public contract.
+ *
+ * @param {Object} payload Parsed `/v1/models` response.
+ * @returns {String[]}
+ */
+export function getOpenAiCompatibleModelIds(payload) {
+    if (!Array.isArray(payload?.data)) {
+        return [];
+    }
+
+    return payload.data
+        .map(item => item?.id || item?.model || item?.name)
+        .filter(Boolean);
+}
+
+/**
+ * @summary Fetches model ids from an OpenAI-compatible provider.
+ *
+ * @param {Object} options
+ * @param {String} options.host Provider host.
+ * @param {Number} options.timeoutMs HTTP timeout. Required; no module-level default.
+ * @param {Function} [options.fetchFn=fetch] Fetch seam for tests.
+ * @returns {Promise<String[]>}
+ */
+export async function fetchOpenAiCompatibleModelIds({host, timeoutMs, fetchFn = fetch} = {}) {
+    if (!host) {
+        throw new TypeError('fetchOpenAiCompatibleModelIds: host is required');
+    }
+    if (typeof timeoutMs !== 'number') {
+        throw new TypeError('fetchOpenAiCompatibleModelIds: timeoutMs is required');
+    }
+
+    const url      = new URL('/v1/models', host).toString();
+    const response = await fetchFn(url, {
+        method: 'GET',
+        signal: AbortSignal.timeout(timeoutMs)
+    });
+
+    if (!response.ok) {
+        const text = typeof response.text === 'function' ? await response.text() : '';
+        throw new Error(`OpenAI-compatible model enumeration failed: HTTP ${response.status}${text ? ` - ${text}` : ''}`);
+    }
+
+    return getOpenAiCompatibleModelIds(await response.json());
+}
+
+/**
+ * @summary Invokes `lms load <model>` for one LM Studio model.
+ *
+ * @param {String} model LM Studio model identifier.
+ * @param {Object} [options]
+ * @param {Function} [options.execFileFn=execFile] Child-process seam for tests.
+ * @returns {Promise<void>}
+ */
+export function loadLmsModel(model, {execFileFn = execFile} = {}) {
+    if (!model) {
+        return Promise.reject(new TypeError('loadLmsModel: model is required'));
+    }
+
+    return new Promise((resolve, reject) => {
+        execFileFn('lms', ['load', model], (error, stdout = '', stderr = '') => {
+            if (error) {
+                reject(new Error(`lms load ${model} failed: ${error.message}${stderr ? `; stderr=${stderr.trim()}` : ''}`));
+                return;
+            }
+
+            resolve({stdout, stderr});
+        });
+    });
+}
+
+/**
+ * @summary Ensures LM Studio has all configured OpenAI-compatible models loaded.
+ *
+ * The orchestrator-owned `lms server start` task gets the server process running;
+ * this helper adds the model-residency half by probing `/v1/models`, invoking
+ * `lms load <model>` for missing chat / embedding models, then waiting until the
+ * endpoint enumerates both. Parameters come from config-owned callers so the helper
+ * has no hidden retry or timeout defaults.
+ *
+ * @param {Object} options
+ * @param {String} options.host OpenAI-compatible host.
+ * @param {String[]} options.models Required resident model ids.
+ * @param {Number} options.attempts Probe attempts after load.
+ * @param {Number} options.delayMs Delay between probes.
+ * @param {Number} options.timeoutMs HTTP probe timeout.
+ * @param {Function} [options.fetchModelIds] Injectable model-list probe.
+ * @param {Function} [options.loadModel] Injectable model-load function.
+ * @param {Object} [options.log=logger] Logger seam.
+ * @returns {Promise<Object>}
+ */
+export async function ensureLmsModelsLoaded({
+    host,
+    models,
+    attempts,
+    delayMs,
+    timeoutMs,
+    fetchModelIds = opts => fetchOpenAiCompatibleModelIds(opts),
+    loadModel     = model => loadLmsModel(model),
+    log           = logger
+} = {}) {
+    if (!Array.isArray(models) || models.length === 0) {
+        throw new TypeError('ensureLmsModelsLoaded: models must contain at least one configured model');
+    }
+    if (typeof attempts !== 'number' || typeof delayMs !== 'number' || typeof timeoutMs !== 'number') {
+        throw new TypeError('ensureLmsModelsLoaded: attempts, delayMs, and timeoutMs are required');
+    }
+
+    const requiredModels = [...new Set(models.filter(Boolean))];
+    if (requiredModels.length === 0) {
+        throw new TypeError('ensureLmsModelsLoaded: models must contain at least one configured model');
+    }
+
+    const getMissing = available => requiredModels.filter(model => !available.includes(model));
+    const probeModels = async phase => {
+        let lastError;
+
+        for (let attempt = 1; attempt <= attempts; attempt++) {
+            try {
+                return {
+                    attempt,
+                    availableModels: await fetchModelIds({host, timeoutMs})
+                };
+            } catch (error) {
+                lastError = error;
+                if (attempt < attempts) {
+                    await new Promise(resolve => setTimeout(resolve, delayMs));
+                }
+            }
+        }
+
+        throw new Error(`LM Studio model readiness failed during ${phase}: ${lastError?.message || lastError}`);
+    };
+
+    let {availableModels} = await probeModels('initial /v1/models probe');
+    let missingModels   = getMissing(availableModels);
+    const loadedModels  = [...missingModels];
+
+    if (missingModels.length === 0) {
+        return {
+            ready       : true,
+            loadedModels: [],
+            requiredModels,
+            availableModels,
+            attempts    : 1
+        };
+    }
+
+    for (const model of missingModels) {
+        log.info?.(`[ProviderReadinessHelper] Loading LM Studio model '${model}' via lms load.`);
+        await loadModel(model);
+    }
+
+    const startedAt = Date.now();
+    for (let attempt = 1; attempt <= attempts; attempt++) {
+        ({availableModels} = await probeModels('post-load /v1/models probe'));
+        missingModels   = getMissing(availableModels);
+
+        if (missingModels.length === 0) {
+            return {
+                ready       : true,
+                loadedModels,
+                requiredModels,
+                availableModels,
+                attempts    : attempt,
+                elapsedMs   : Date.now() - startedAt
+            };
+        }
+
+        if (attempt < attempts) {
+            await new Promise(resolve => setTimeout(resolve, delayMs));
+        }
+    }
+
+    throw new Error(
+        `LM Studio model readiness failed: missing ${missingModels.join(', ')} from ${host}/v1/models after ` +
+        `${attempts} attempt(s). Run ${missingModels.map(model => `lms load ${model}`).join(' && ')} ` +
+        'or raise the LM Studio loaded-model cap so chat and embedding models can stay resident together.'
+    );
 }
 
 /**

--- a/test/playwright/unit/ai/daemons/orchestrator/Orchestrator.invariants.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/Orchestrator.invariants.spec.mjs
@@ -27,6 +27,7 @@ let savedCloudOnly       = null;
 let savedDeploymentMode  = null;
 let savedMlxConfig                   = undefined;
 let savedLmsConfig                   = undefined;
+let savedOpenAiCompatibleConfig      = undefined;
 let savedEnvKbSyncEnabled            = undefined;
 let savedEnvKbSyncInterval           = undefined;
 let savedEnvTenantRepoSyncEnabled    = undefined;
@@ -71,6 +72,7 @@ test.beforeEach(() => {
     savedDeploymentMode = AiConfig.orchestrator.deploymentMode;
     savedMlxConfig      = AiConfig.orchestrator.mlx ? {...AiConfig.orchestrator.mlx} : undefined;
     savedLmsConfig      = AiConfig.orchestrator.lms ? {...AiConfig.orchestrator.lms} : undefined;
+    savedOpenAiCompatibleConfig = AiConfig.openAiCompatible ? {...AiConfig.openAiCompatible} : undefined;
 
     savedEnvKbSyncEnabled          = process.env.NEO_ORCHESTRATOR_KB_SYNC_ENABLED;
     savedEnvKbSyncInterval         = process.env.NEO_ORCHESTRATOR_KB_SYNC_INTERVAL_MS;
@@ -102,6 +104,11 @@ test.afterEach(() => {
         delete AiConfig.orchestrator.lms;
     } else {
         AiConfig.orchestrator.lms = savedLmsConfig;
+    }
+    if (savedOpenAiCompatibleConfig === undefined) {
+        delete AiConfig.openAiCompatible;
+    } else {
+        AiConfig.openAiCompatible = savedOpenAiCompatibleConfig;
     }
 
     restoreEnv('NEO_ORCHESTRATOR_KB_SYNC_ENABLED',           savedEnvKbSyncEnabled);
@@ -218,11 +225,18 @@ test.describe('Orchestrator config getters delegate to AiConfig (envBindings is 
 
     test('lmsEnabled / lmsModel / lmsPort getters read AiConfig.orchestrator.lms verbatim', () => {
         AiConfig.orchestrator.lms = {enabled: true, model: 'lms-from-config', port: '4242'};
+        AiConfig.openAiCompatible = {
+            host          : 'http://127.0.0.1:4242',
+            model         : 'chat-from-config',
+            embeddingModel: 'embedding-from-config'
+        };
 
         const o = createMinimalOrchestrator();
         expect(o.lmsEnabled).toBe(true);
         expect(o.lmsModel).toBe('lms-from-config');
         expect(o.lmsPort).toBe('4242');
+        expect(o.lmsHost).toBe('http://127.0.0.1:4242');
+        expect(o.lmsModels).toEqual(['chat-from-config', 'embedding-from-config']);
 
         AiConfig.orchestrator.lms = {enabled: false, model: 'qwen', port: '1234'};
         expect(createMinimalOrchestrator().lmsEnabled).toBe(false);

--- a/test/playwright/unit/ai/daemons/orchestrator/Orchestrator.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/Orchestrator.spec.mjs
@@ -43,7 +43,7 @@ function createTestOrchestrator(config = {}) {
         writeLogFn     : () => {}
     });
     TaskStateService.taskState = createInitialTaskState(taskDefinitions);
-    ['chroma', 'bridgeDaemon', 'mlx'].forEach(name => {
+    ['chroma', 'bridgeDaemon', 'mlx', 'lms'].forEach(name => {
         if (TaskStateService.taskState[name]) {
             TaskStateService.taskState[name].running = true;
         }
@@ -448,6 +448,39 @@ test.describe('Neo.ai.daemons.Orchestrator (#11009)', () => {
         }]);
     });
 
+    test('supervises lms as a continuous provider task when configured (#12090)', () => {
+        const started = [];
+        const taskDefinitions = buildTaskDefinitions({
+            scriptDir : path.resolve(process.cwd(), 'ai/scripts'),
+            nodeBin   : process.argv[0],
+            lmsEnabled: true,
+            lmsModels : ['chat-model', 'embedding-model'],
+            lmsHost   : 'http://127.0.0.1:1234',
+            lmsPort   : 1234,
+            providerReadiness: {attempts: 2, delayMs: 0, timeoutMs: 50}
+        });
+        const orchestrator = createTestOrchestrator({
+            taskDefinitions,
+            kbSyncEnabled: false
+        });
+
+        TaskStateService.taskState.lms.running   = false;
+        TaskStateService.taskState.lms.lastRunAt = 0;
+        orchestrator.processSupervisorService = {
+            runTask(taskName, reason) {
+                started.push({taskName, reason});
+                return true;
+            }
+        };
+
+        orchestrator.poll();
+
+        expect(started).toContainEqual({
+            taskName: 'lms',
+            reason  : 'supervisor-restart'
+        });
+    });
+
     test('skips chroma daemon supervision in cloud mode while keeping local default (#12019)', () => {
         const cloudStarted = [];
         const cloudOrchestrator = createTestOrchestrator({
@@ -576,12 +609,16 @@ test.describe('Neo.ai.daemons.Orchestrator (#11009)', () => {
             nodeBin   : process.argv[0],
             lmsEnabled: true,
             lmsModel  : 'qwen3-embedding-8b',
+            lmsModels : ['gemma4-31b', 'qwen3-8b'],
+            lmsHost   : 'http://127.0.0.1:4242',
+            providerReadiness: {attempts: 2, delayMs: 0, timeoutMs: 50},
             lmsPort   : 4242
         });
 
         expect(orchestrator.taskDefinitions.lms.command).toBe('lms');
         expect(orchestrator.taskDefinitions.lms.args).toEqual(['server', 'start', '--port', '4242']);
         expect(orchestrator.taskDefinitions.lms.pidFileName).toBe('lms.pid');
+        expect(orchestrator.taskDefinitions.lms.requiredModels).toEqual(['gemma4-31b', 'qwen3-8b']);
     });
 
     test('routes primary-dev-sync through its service coordinator', () => {

--- a/test/playwright/unit/ai/daemons/orchestrator/daemon.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/daemon.spec.mjs
@@ -144,6 +144,9 @@ test.describe('ai/daemons/orchestrator/daemon.mjs (#11006/#11009)', () => {
                 nodeBin   : '/test/node',
                 lmsEnabled: true,
                 lmsModel  : 'explicit-model',
+                lmsModels : ['chat-model', 'embedding-model'],
+                lmsHost   : 'http://127.0.0.1:4242',
+                providerReadiness: {attempts: 2, delayMs: 0, timeoutMs: 50},
                 lmsPort   : 4242
             });
 
@@ -151,6 +154,8 @@ test.describe('ai/daemons/orchestrator/daemon.mjs (#11006/#11009)', () => {
             expect(explicitTasks.lms.args).toEqual(['server', 'start', '--port', '4242']);
             expect(explicitTasks.lms.expectedCommand).toBe('lms server');
             expect(explicitTasks.lms.pidFileName).toBe('lms.pid');
+            expect(explicitTasks.lms.requiredModels).toEqual(['chat-model', 'embedding-model']);
+            expect(typeof explicitTasks.lms.postSpawn).toBe('function');
             expect(explicitTasks.lms.args).not.toContain('99999');
         } finally {
             for (const [key, value] of [

--- a/test/playwright/unit/ai/daemons/orchestrator/services/ProcessSupervisorService.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/services/ProcessSupervisorService.spec.mjs
@@ -28,6 +28,7 @@ function createTestService() {
         markSpawned: () => {},
         markFailed: () => {},
         markCompleted: () => {},
+        markReady: () => {},
         clearRecovered: () => true,
         adoptRunning: () => {}
     };
@@ -143,5 +144,64 @@ test.describe('Neo.ai.daemons.services.ProcessSupervisorService', () => {
 
         expect(skipLogs.length).toBe(2);
         expect(skippedOutcomes.length).toBe(3);
+    });
+
+    test('runTask records ready state after a post-spawn hook succeeds', async () => {
+        const { service, taskOutcomes } = createTestService();
+        let readyMarked = false;
+
+        service.taskDefinitions.mockTask.postSpawn = async () => ({models: ['chat', 'embedding']});
+        service.taskStateService.markReady = taskName => {
+            readyMarked = taskName === 'mockTask';
+        };
+        service.spawnFn = () => ({
+            pid   : 9999,
+            stderr: {on: () => {}},
+            on    : () => {}
+        });
+
+        expect(service.runTask('mockTask', 'test-reason')).toBe(true);
+        await new Promise(resolve => setTimeout(resolve, 0));
+
+        expect(readyMarked).toBe(true);
+        expect(taskOutcomes).toContainEqual(expect.objectContaining({
+            status  : 'ready',
+            taskName: 'mockTask',
+            details : expect.objectContaining({
+                readiness: {models: ['chat', 'embedding']}
+            })
+        }));
+    });
+
+    test('runTask fails and terminates the child when a post-spawn hook fails', async () => {
+        const { service, taskOutcomes } = createTestService();
+        let killed = false;
+        let failed = false;
+
+        service.taskDefinitions.mockTask.postSpawn = async () => {
+            throw new Error('models missing');
+        };
+        service.taskStateService.markFailed = taskName => {
+            failed = taskName === 'mockTask';
+        };
+        service.spawnFn = () => ({
+            pid   : 9999,
+            stderr: {on: () => {}},
+            kill  : () => { killed = true; },
+            on    : () => {}
+        });
+
+        expect(service.runTask('mockTask', 'test-reason')).toBe(true);
+        await new Promise(resolve => setTimeout(resolve, 0));
+
+        expect(killed).toBe(true);
+        expect(failed).toBe(true);
+        expect(taskOutcomes).toContainEqual(expect.objectContaining({
+            status : 'failed',
+            details: expect.objectContaining({
+                phase: 'post-spawn-readiness',
+                error: 'models missing'
+            })
+        }));
     });
 });

--- a/test/playwright/unit/ai/scripts/runners/runSandman.spec.mjs
+++ b/test/playwright/unit/ai/scripts/runners/runSandman.spec.mjs
@@ -36,6 +36,7 @@ test.describe('runSandman.mjs provider readiness diagnostics (#10587)', () => {
     let aiConfig;
     let logger;
     let runSandmanModule;
+    let providerReadinessHelper;
     let tmpLogDir;
     let originalLogPath;
 
@@ -48,6 +49,7 @@ test.describe('runSandman.mjs provider readiness diagnostics (#10587)', () => {
 
         logger           = (await import('../../../../../../ai/mcp/server/memory-core/logger.mjs')).default;
         runSandmanModule = await import('../../../../../../ai/scripts/runners/runSandman.mjs');
+        providerReadinessHelper = await import('../../../../../../ai/services/graph/ProviderReadinessHelper.mjs');
     });
 
     test.afterAll(() => {
@@ -102,6 +104,75 @@ test.describe('runSandman.mjs provider readiness diagnostics (#10587)', () => {
     test('checkProvider throws when timeoutMs is absent (config-as-SSOT contract)', () => {
         expect(() => runSandmanModule.checkProvider()).toThrow(/timeoutMs.*required/);
         expect(() => runSandmanModule.checkProvider({config: {graphProvider: 'openAiCompatible'}})).toThrow(/timeoutMs.*required/);
+    });
+
+    test('extracts OpenAI-compatible model ids from provider variants', () => {
+        expect(providerReadinessHelper.getOpenAiCompatibleModelIds({
+            data: [
+                {id: 'chat-model'},
+                {model: 'embedding-model'},
+                {name: 'fallback-model'},
+                {}
+            ]
+        })).toEqual(['chat-model', 'embedding-model', 'fallback-model']);
+
+        expect(providerReadinessHelper.getOpenAiCompatibleModelIds({data: null})).toEqual([]);
+    });
+
+    test('ensureLmsModelsLoaded invokes lms load for missing chat and embedding models', async () => {
+        const loads = [];
+        const modelSnapshots = [
+            [],
+            ['chat-model'],
+            ['chat-model', 'embedding-model']
+        ];
+
+        const result = await providerReadinessHelper.ensureLmsModelsLoaded({
+            host     : 'http://127.0.0.1:1234',
+            models   : ['chat-model', 'embedding-model'],
+            attempts : 3,
+            delayMs  : 0,
+            timeoutMs: 50,
+            fetchModelIds: async () => modelSnapshots.shift() || ['chat-model', 'embedding-model'],
+            loadModel    : async model => loads.push(model),
+            log          : {info: () => {}}
+        });
+
+        expect(loads).toEqual(['chat-model', 'embedding-model']);
+        expect(result).toMatchObject({
+            ready       : true,
+            loadedModels: ['chat-model', 'embedding-model'],
+            requiredModels: ['chat-model', 'embedding-model'],
+            availableModels: ['chat-model', 'embedding-model']
+        });
+    });
+
+    test('ensureLmsModelsLoaded skips lms load when both models are already resident', async () => {
+        const loads = [];
+
+        const result = await providerReadinessHelper.ensureLmsModelsLoaded({
+            host     : 'http://127.0.0.1:1234',
+            models   : ['chat-model', 'embedding-model'],
+            attempts : 1,
+            delayMs  : 0,
+            timeoutMs: 50,
+            fetchModelIds: async () => ['chat-model', 'embedding-model'],
+            loadModel    : async model => loads.push(model)
+        });
+
+        expect(loads).toEqual([]);
+        expect(result).toMatchObject({
+            ready       : true,
+            loadedModels: [],
+            attempts    : 1
+        });
+    });
+
+    test('ensureLmsModelsLoaded fails loud when readiness config is incomplete', async () => {
+        await expect(providerReadinessHelper.ensureLmsModelsLoaded({
+            host  : 'http://127.0.0.1:1234',
+            models: ['chat-model']
+        })).rejects.toThrow(/attempts.*delayMs.*timeoutMs.*required/);
     });
 
     test('resolves readiness target from graphProvider instead of generic modelProvider', () => {


### PR DESCRIPTION
Related: #12090
Related: #11986

Authored by GPT-5 (Codex Desktop). Session 6ca1b510-51c3-4fac-aa39-a0fd6941318c.
Provenance: consumed @neo-opus-4-7 A2A P0 handoff; peer session id was not included in the wake payload.
FAIR-band: over-target [14/30] — taking this lane despite over-target because this is an operator-directed P0 Sandman regression and confidential tenant deployment dependency.

Adds orchestrator-owned LM Studio model residency after `lms server start`: the task now loads the configured OpenAI-compatible chat model and embedding model, then waits until `/v1/models` enumerates both before marking the long-running child task ready. A readiness failure fails the supervised task, terminates the child, and records a provider-specific health outcome instead of letting Sandman discover the missing model later.

Scope boundary: this PR handles #12090 AC8 / LM Studio pre-warm only. It does NOT complete the Ollama cloud-deployment path; #12090 remains open for the Ollama `requireParallelModels` config, `/api/ps` capacity probe, WARN diagnostics, docs, and deployment validation.

Evidence: L2 (unit-covered orchestrator supervision, post-spawn failure path, and injected `lms load` / `/v1/models` behavior) -> L4 required (real LM Studio process with both configured models resident in deployment). Residual: live provider restart validation after merge plus remaining Ollama capacity/probe work [#12090].

## Deltas From Ticket

- Uses `AiConfig.openAiCompatible.model` and `AiConfig.openAiCompatible.embeddingModel` as the model list forwarded by `Orchestrator.start()`; `orchestrator.lms.model` remains only a legacy direct-caller fallback in `TaskDefinitions`.
- Keeps retry and timeout ownership in `AiConfig.orchestrator.providerReadiness`; the helper throws when callers omit those values instead of substituting hidden defaults.
- Adds a generic `postSpawn` child-task readiness hook to `ProcessSupervisorService`, so provider-specific readiness stays in the task definition while supervision remains provider-agnostic.
- Updates only the tracked `ai/config.template.mjs` documentation. The gitignored local `ai/config.mjs` copy is intentionally not mutated by this PR.
- Leaves the Ollama cloud path in #12090 for a separate implementation slice; that path must validate server-side model coexistence rather than relying on LM Studio `lms load`.

## Contract Ledger

| Contract | Source of authority | This PR behavior |
|---|---|---|
| Required resident models | `AiConfig.openAiCompatible.model` + `AiConfig.openAiCompatible.embeddingModel` | Deduped list passed into the `lms` task from `Orchestrator.start()` |
| Readiness timing | `AiConfig.orchestrator.providerReadiness` | Explicit `attempts`, `delayMs`, `timeoutMs`; no helper-level config fallback |
| Spawn/readiness boundary | `ProcessSupervisorService` task lifecycle | Child is `running` after spawn, `ready` only after post-spawn hook succeeds |
| Failure handling | Task health + persisted task state | Failed readiness kills the child, clears PID state, and records `phase: post-spawn-readiness` |
| Local config files | `ai/config.template.mjs` tracked; `ai/config.mjs` gitignored | Template docs updated; operator-local config left untouched |
| Ollama coexistence | #12090 AC1/AC3/AC5/AC6/AC7 | Out of scope for this PR; remains open |

## Test Evidence

- `node --check ai/services/graph/ProviderReadinessHelper.mjs`
- `node --check ai/daemons/orchestrator/TaskDefinitions.mjs`
- `node --check ai/daemons/orchestrator/Orchestrator.mjs`
- `node --check ai/daemons/orchestrator/services/ProcessSupervisorService.mjs`
- `node --check ai/daemons/orchestrator/services/TaskStateService.mjs`
- `git diff --check origin/dev...HEAD`
- `npm run test-unit -- test/playwright/unit/ai/scripts/runners/runSandman.spec.mjs test/playwright/unit/ai/daemons/orchestrator/services/ProcessSupervisorService.spec.mjs test/playwright/unit/ai/daemons/orchestrator/daemon.spec.mjs test/playwright/unit/ai/daemons/orchestrator/Orchestrator.spec.mjs test/playwright/unit/ai/daemons/orchestrator/Orchestrator.invariants.spec.mjs` — 83 passed

## Post-Merge Validation

- [ ] With an LM Studio deployment config, set `NEO_ORCHESTRATOR_LMS_ENABLED=true` and align `NEO_OPENAI_COMPATIBLE_HOST`, `NEO_OPENAI_COMPATIBLE_MODEL`, and `NEO_OPENAI_COMPATIBLE_EMBEDDING_MODEL` to the resident LM Studio target.
- [ ] Restart the orchestrator and verify logs show `lms load <chat-model>` and `lms load <embedding-model>` only when `/v1/models` is missing either model.
- [ ] Confirm `/v1/models` enumerates both configured models and the `lms` task records a `ready` health outcome.
- [ ] Rerun `npm run ai:run-sandman` against the same provider config and verify the REM cycle no longer reaches graph extraction with an unloaded provider surface.
- [ ] Keep #12090 open after this PR merges; the Ollama provider path still needs the capacity/probe/docs implementation for cloud deployment.

## Commit

- `50abf8ef0` — `fix(ai): prewarm lms chat and embedding models (#12090)`