### PR TITLE
fix(ai): detect silent empty-response as context-overflow in graph extractors (#12091)

### DIFF
--- a/ai/services/graph/SemanticGraphExtractor.mjs
+++ b/ai/services/graph/SemanticGraphExtractor.mjs
@@ -2,7 +2,7 @@ import fs from 'fs';
 import path from 'path';
 import aiConfig from '../../mcp/server/memory-core/config.mjs';
 import Base from '../../../src/core/Base.mjs';
-import {invokeWithGuardrail} from '../../services/memory-core/helpers/ConsumerFrictionHelper.mjs';
+import {emitConsumerFriction, invokeWithGuardrail} from '../../services/memory-core/helpers/ConsumerFrictionHelper.mjs';
 import GraphService from '../../services/memory-core/GraphService.mjs';
 import Json from '../../../src/util/Json.mjs';
 import logger from '../../mcp/server/memory-core/logger.mjs';
@@ -147,6 +147,33 @@ DO NOT output markdown, \`\`\`json blocks, or any other explanations. Provide pu
                 }
 
                 result = guardrailed.result;
+
+                // #12091: Silent context-overflow detection — the provider can stream-close
+                // immediately with an empty body when its loaded-model context window is
+                // smaller than the prompt (LM Studio loaded-context-cap signature:
+                // ttftMs===ttltMs, outputChars===0, no thrown error). The retry loop below
+                // appends the assistant echo + feedback prompt monotonically; if root cause
+                // is overflow, retries make it strictly worse. Emit the existing deterministic
+                // `'context-overflow'` symptom (auto-surfaces, no 3-emission threshold) and
+                // abort retry to break the amplification.
+                if (!result?.content || result.content.trim() === '') {
+                    logger.warn(`[SemanticGraphExtractor] Attempt ${attempt}: Empty response from provider for session ${session.meta.sessionId}; classifying as context-overflow (silent: no thrown error, no body).`);
+
+                    emitConsumerFriction({
+                        symptom                  : 'context-overflow',
+                        consumer                 : 'SemanticGraphExtractor',
+                        model                    : consumerModel,
+                        assetRef                 : session.meta.sessionId,
+                        serviceDomain            : 'dream-pipeline',
+                        emissionPoint            : 'post-invocation-failure',
+                        inputBytes               : Buffer.byteLength(inputPayloadText),
+                        contextLimitTokens       : consumerContextTokens,
+                        safeProcessingLimitTokens: consumerSafeTokens,
+                        note                     : `Silent empty-response from provider (no thrown error, no body). Prompt chars: ${inputPayloadText.length}. Attempt ${attempt}/${maxRetries}.`
+                    });
+
+                    return null;
+                }
 
                 // Extract using robust Json parser to catch malformed boundaries
                 payload = Json.extract(result.content);

--- a/ai/services/graph/SemanticGraphExtractor.mjs
+++ b/ai/services/graph/SemanticGraphExtractor.mjs
@@ -148,12 +148,12 @@ DO NOT output markdown, \`\`\`json blocks, or any other explanations. Provide pu
 
                 result = guardrailed.result;
 
-                // #12091: Silent context-overflow detection — the provider can stream-close
-                // immediately with an empty body when its loaded-model context window is
-                // smaller than the prompt (LM Studio loaded-context-cap signature:
-                // ttftMs===ttltMs, outputChars===0, no thrown error). The retry loop below
-                // appends the assistant echo + feedback prompt monotonically; if root cause
-                // is overflow, retries make it strictly worse. Emit the existing deterministic
+                // Silent context-overflow detection: provider can stream-close immediately
+                // with an empty body when its loaded-model context window is smaller than
+                // the prompt (LM Studio loaded-context-cap signature: ttftMs===ttltMs,
+                // outputChars===0, no thrown error). The retry loop below appends the
+                // assistant echo + feedback prompt monotonically — if root cause is overflow,
+                // retries make it strictly worse. Emit the existing deterministic
                 // `'context-overflow'` symptom (auto-surfaces, no 3-emission threshold) and
                 // abort retry to break the amplification.
                 if (!result?.content || result.content.trim() === '') {

--- a/ai/services/graph/TopologyInferenceEngine.mjs
+++ b/ai/services/graph/TopologyInferenceEngine.mjs
@@ -64,10 +64,11 @@ ${contextText}
 
             const result = await provider.generate(prompt);
 
-            // #12091: Silent context-overflow detection — see SemanticGraphExtractor for the
-            // full rationale; this is the parallel single-attempt path. Empty result.content
-            // with no thrown error is the LM Studio loaded-context-cap signature; emit the
-            // deterministic `'context-overflow'` symptom (auto-surfaces) and return early.
+            // Silent context-overflow detection (parallel single-attempt path): empty
+            // result.content with no thrown error is the LM Studio loaded-context-cap
+            // signature (ttftMs===ttltMs, outputChars===0). Emit the deterministic
+            // `'context-overflow'` symptom (auto-surfaces) and return early to avoid
+            // downstream null-payload handling on empty input.
             if (!result?.content || result.content.trim() === '') {
                 logger.warn(`[TopologyInferenceEngine] Empty response from provider for session ${sessionId}; classifying as context-overflow (silent: no thrown error, no body).`);
 

--- a/ai/services/graph/TopologyInferenceEngine.mjs
+++ b/ai/services/graph/TopologyInferenceEngine.mjs
@@ -3,6 +3,7 @@ import { Memory_Config as aiConfig } from '../../services.mjs';
 import Base from '../../../src/core/Base.mjs';
 import Json from '../../../src/util/Json.mjs';
 import logger from '../../mcp/server/memory-core/logger.mjs';
+import {emitConsumerFriction} from '../memory-core/helpers/ConsumerFrictionHelper.mjs';
 import {buildGraphProvider, resolveGraphModelProvider} from './providerDispatch.mjs';
 
 /**
@@ -62,6 +63,29 @@ ${contextText}
             });
 
             const result = await provider.generate(prompt);
+
+            // #12091: Silent context-overflow detection — see SemanticGraphExtractor for the
+            // full rationale; this is the parallel single-attempt path. Empty result.content
+            // with no thrown error is the LM Studio loaded-context-cap signature; emit the
+            // deterministic `'context-overflow'` symptom (auto-surfaces) and return early.
+            if (!result?.content || result.content.trim() === '') {
+                logger.warn(`[TopologyInferenceEngine] Empty response from provider for session ${sessionId}; classifying as context-overflow (silent: no thrown error, no body).`);
+
+                emitConsumerFriction({
+                    symptom                  : 'context-overflow',
+                    consumer                 : 'TopologyInferenceEngine',
+                    model                    : aiConfig[graphProvider]?.model,
+                    assetRef                 : sessionId,
+                    serviceDomain            : 'dream-pipeline',
+                    emissionPoint            : 'post-invocation-failure',
+                    inputBytes               : Buffer.byteLength(prompt),
+                    contextLimitTokens       : aiConfig.openAiCompatible.contextLimitTokens,
+                    safeProcessingLimitTokens: aiConfig.openAiCompatible.safeProcessingLimitTokens,
+                    note                     : `Silent empty-response from provider (no thrown error, no body). Prompt chars: ${prompt.length}.`
+                });
+
+                return;
+            }
 
             const payload = Json.extract(result.content);
             if (!payload || !Array.isArray(payload.conflicts) || payload.conflicts.length === 0) {

--- a/test/playwright/unit/ai/services/graph/SemanticGraphExtractor.spec.mjs
+++ b/test/playwright/unit/ai/services/graph/SemanticGraphExtractor.spec.mjs
@@ -289,6 +289,56 @@ test.describe('Neo.ai.daemons.services.SemanticGraphExtractor', () => {
         }
     });
 
+    test('detects silent empty-response as context-overflow + aborts retry amplification (#12091)', async () => {
+        const baseGenerate = OpenAiCompatible.prototype.generate;
+        let invocationCount = 0;
+
+        try {
+            clearAggregatedFrictions();
+
+            // Stub provider to return empty content (LM Studio silent-overflow signature:
+            // stream opens and closes immediately with no body, no thrown error).
+            OpenAiCompatible.prototype.generate = async function(messages) {
+                invocationCount++;
+                return {content: ''};
+            };
+
+            const result = await SemanticGraphExtractor.executeTriVectorExtraction({
+                id      : 'mock-empty-response-vector-id',
+                meta    : {sessionId: 'empty-response-overflow-session'},
+                document: 'Mock episodic history for silent empty-response detection.'
+            });
+
+            // AC4: returns null (no retry-loop amplification)
+            expect(result).toBeNull();
+
+            // AC6 (e): retry loop did NOT fire — single invocation only
+            expect(invocationCount).toBe(1);
+
+            const frictions = getAggregatedFrictions();
+            const friction  = frictions.find(item => item.assetRef === 'empty-response-overflow-session');
+
+            // AC2: emits via existing primitive — no new symptom enum entry needed
+            expect(friction).toBeDefined();
+            expect(friction.symptom).toBe('context-overflow');
+
+            // AC3: note carries empty-response-specific diagnostic
+            expect(friction.note).toContain('Silent empty-response from provider');
+            expect(friction.note).toContain('Prompt chars:');
+
+            // AC6 (e): deterministic-symptom auto-surface (no 3-emission threshold)
+            const aggregated = frictions.find(item => item.assetRef === 'empty-response-overflow-session');
+            expect(aggregated).toBeDefined();
+            expect(aggregated.count).toBe(1);
+
+            // Suggestion derived from existing primitive map: context-overflow → compress-payload
+            expect(friction.suggestionKind).toBe('compress-payload');
+        } finally {
+            OpenAiCompatible.prototype.generate = baseGenerate;
+            clearAggregatedFrictions();
+        }
+    });
+
     test('uses configured graph-provider model for consumer friction telemetry (#12059)', async () => {
         const originalGraphProvider                  = aiConfig.graphProvider;
         const originalOllamaModel                    = aiConfig.ollama?.model;


### PR DESCRIPTION
Resolves #12091

Authored by Claude Opus 4.7 (1M context).
FAIR-band: over-target [16/30] — taking this lane despite over-target because (a) ticket already self-assigned + prescription authored in cycle-1 substrate-correction, (b) implementation already in-flight this session, (c) surface is small (3 files, ~80 LOC) so yield cost outweighs distribution gain.

Empirical finding from PR #12076 Phase 2 benchmark run surfaced the friction: provider `ttftMs === ttltMs` + `outputChars === 0` for prompts ≥30K tokens — silent context-overflow rejection (loaded-model context window < bucket prompt size). Current `SemanticGraphExtractor` / `TopologyInferenceEngine` empty-response paths fall through to `Json.extract("")` → null → retry loop, which appends the empty assistant echo + feedback prompt monotonically. If root cause is overflow, retries make it strictly WORSE.

Adds detection-at-boundary that reuses the existing `'context-overflow'` deterministic-symptom primitive (auto-surfaces immediately, no 3-emission threshold) + returns null/early to break the amplification. Zero mutation to `ConsumerFrictionHelper.mjs` — leverages well-shaped primitive per @neo-gpt's cycle-1 V-B-A on the ticket.

Evidence: L2 (unit-covered detection + symptom emission + retry-skip + suggestion derivation) → L4 required (live LM Studio with prompt > loaded-context-cap reproducing the ttftMs===ttltMs signature). Residual: live provider validation post-merge [#12091].

## Deltas From Ticket

None — implementation matches the cycle-1 revised prescription exactly (zero `ConsumerFrictionHelper.mjs` mutation; reuse existing `'context-overflow'` primitive at detection boundary in both extractors).

## Contract Ledger

| Surface | Before | After | Consumer |
|---|---|---|---|
| `SemanticGraphExtractor.executeTriVectorExtraction` empty-result branch | falls through to `Json.extract("")` → null → retry loop with monotonic token amplification | early-detect + emit `'context-overflow'` friction + return null | ConsumerFrictionHelper aggregator (existing primitive) |
| `TopologyInferenceEngine.extractTopology` empty-result branch | falls through to `Json.extract("")` → undefined return | early-detect + emit `'context-overflow'` friction + return | ConsumerFrictionHelper aggregator (existing primitive) |
| Friction telemetry visibility for silent-overflow | NOT EMITTED (silent failure mode) | EMITTED via existing deterministic `'context-overflow'` symptom (surfaces immediately) | GoldenPathSynthesizer, A2A friction rendering, REM cycle logs |

## Acceptance Criteria mapping

- AC1: empty-`result.content` detection BEFORE `Json.extract` in `SemanticGraphExtractor.executeTriVectorExtraction` ✓ (line 152)
- AC2: emits `emitConsumerFriction({symptom: 'context-overflow', ...})` via existing primitive — no new symptom enum entry ✓
- AC3: `note` field carries "Silent empty-response from provider..." + `Prompt chars: N` ✓
- AC4: returns `null` aborting retry loop (no token-amplification) ✓
- AC5: same detection added to `TopologyInferenceEngine.extractTopology` parallel path ✓
- AC6: unit test asserts (a) `symptom === 'context-overflow'` (b) `note.includes('Silent empty-response')` (c) `invocationCount === 1` (no retry) (d) outer call returns `null` (e) `count === 1` (deterministic auto-surface) + suggestion derivation `compress-payload` ✓
- AC7: zero mutation to `ConsumerFrictionHelper.mjs` ✓

## Test Evidence

- `node --check ai/services/graph/SemanticGraphExtractor.mjs` ✓
- `node --check ai/services/graph/TopologyInferenceEngine.mjs` ✓
- `npm run test-unit -- test/playwright/unit/ai/services/graph/SemanticGraphExtractor.spec.mjs` — **6/6 passed (647ms)**, including the new `(#12091)` test

## Out of Scope

- `TopologyInferenceEngine.spec.mjs` does not exist yet. AC6 only mandates spec coverage on the SemanticGraphExtractor path. Filing a follow-up ticket for TopologyInferenceEngine spec creation would be the right shape if operator wants symmetric coverage.
- The third Json.extract site in `SemanticGraphExtractor` (line ~375, in `extractMessageConcepts`) has the same anti-pattern but is NOT named in the ticket ACs. Same rationale — follow-up if desired.

## Post-Merge Validation

- [ ] With LM Studio loaded-context-cap set BELOW the actual benchmark bucket prompt size, trigger Sandman REM cycle and verify `GoldenPathSynthesizer` handoff surfaces a `context-overflow` friction record with `consumer: 'SemanticGraphExtractor'` and the empty-response `note`.
- [ ] Confirm REM cycle no longer attempts retry-loop on empty-response (single invocation per attempt, no monotonic prompt growth).

## Commit

- `fix(ai): detect silent empty-response as context-overflow in graph extractors (#12091)`
