### PR TITLE
feat(ai): split context-limits into localModels.{chat,embedding} role-keyed config (#12114)

### DIFF
--- a/ai/config.template.mjs
+++ b/ai/config.template.mjs
@@ -140,16 +140,71 @@ class Config extends BaseConfig {
             apiKey                  : '',
             unloadRetryCount        : 3,
             unloadRetryDelayMs      : 500,
-            keep_alive              : -1,
-            // gemma-4-31b-it (and gemma-4-26B MoE) native context = 256K (262,144) tokens.
-            // Cap sized for the model's actual capacity; env override
-            // `NEO_OPENAI_COMPATIBLE_CONTEXT_LIMIT_TOKENS` preserved for operator re-pinning.
-            contextLimitTokens      : 262144,
-            // Explicit ~76% of cap; ~62K tokens headroom for system-prompt envelope + LLM
-            // response generation. Prior `undefined` default fell back to 0.75 × cap via
-            // ConsumerFrictionHelper.DEFAULT_SAFE_FRACTION — explicit value avoids implicit
-            // drift if the cap moves again.
-            safeProcessingLimitTokens: 200000
+            keep_alive              : -1
+        },
+        /**
+         * @summary Local-model role-keyed context limits.
+         *
+         * The context-window axis for local-inference consumers is **model-role**
+         * (chat vs embedding), not provider-namespace. Remote providers (Gemini and
+         * future API-only endpoints) are API-bound — operators have no control over
+         * their context cap, so these knobs do not apply. Local providers
+         * (`openAiCompatible`, `ollama`) share these caps regardless of which serves
+         * the role, because the practical limit comes from the loaded model, not
+         * from the provider transport.
+         *
+         * Consumers read by model-role:
+         * - Chat-path consumers (graph extraction, session summary) → `localModels.chat.*`
+         * - Embedding-path consumers (Memory Core embedding, KB ingestion) → `localModels.embedding.*`
+         *
+         * @type {Object}
+         */
+        localModels: {
+            /**
+             * @summary Chat-model context limits in tokens.
+             *
+             * Tuned for `gemma-4-31b-it` (native 256K context). Operators serving
+             * smaller chat models should pin this to the actual loaded-model capacity;
+             * `ConsumerFrictionHelper.invokeWithGuardrail` uses these values to fire
+             * the upstream pre-check skip (emits `'context-overflow'` /
+             * `'size-precheck-skip'` friction) when composed input exceeds the safe
+             * processing band.
+             *
+             * `safeProcessingLimitTokens` is the explicit ~76% headroom band — leaves
+             * ~62K tokens for system-prompt envelope + LLM response generation. Explicit
+             * value avoids implicit `0.75 × cap` derivation drift if the cap moves.
+             *
+             * Env overrides: `NEO_LOCAL_MODELS_CHAT_CONTEXT_LIMIT_TOKENS`,
+             * `NEO_LOCAL_MODELS_CHAT_SAFE_PROCESSING_LIMIT_TOKENS`.
+             *
+             * @type {Object}
+             */
+            chat: {
+                contextLimitTokens      : 262144,
+                safeProcessingLimitTokens: 200000
+            },
+            /**
+             * @summary Embedding-model context limits in tokens.
+             *
+             * Conservative placeholder defaults. Operators must pin to their loaded
+             * embedding model's actual capability before operational reliance — for
+             * instance Qwen3-8B-embedding typically supports 32K context, but this
+             * default holds an 8K conservative floor until V-B-A confirms the value
+             * against the configured embedding model.
+             *
+             * No active consumer reads these yet; pre-positioned for the embedding
+             * consumer surface (TextEmbeddingService + KB ingestion retry-on-unload
+             * telemetry paths).
+             *
+             * Env overrides: `NEO_LOCAL_MODELS_EMBEDDING_CONTEXT_LIMIT_TOKENS`,
+             * `NEO_LOCAL_MODELS_EMBEDDING_SAFE_PROCESSING_LIMIT_TOKENS`.
+             *
+             * @type {Object}
+             */
+            embedding: {
+                contextLimitTokens      : 8192,
+                safeProcessingLimitTokens: 6144
+            }
         },
         /**
          * @summary Deployment-wide Gemini model defaults.
@@ -564,9 +619,17 @@ class Config extends BaseConfig {
             apiKey                  : 'NEO_OPENAI_COMPATIBLE_API_KEY',
             unloadRetryCount        : {var: 'NEO_OPENAI_COMPATIBLE_UNLOAD_RETRY_COUNT', parse: Env.parseNumber},
             unloadRetryDelayMs      : {var: 'NEO_OPENAI_COMPATIBLE_UNLOAD_RETRY_DELAY_MS', parse: Env.parseNumber},
-            keep_alive              : {var: 'NEO_OPENAI_COMPATIBLE_KEEP_ALIVE', parse: Env.parseKeepAlive},
-            contextLimitTokens      : {var: 'NEO_OPENAI_COMPATIBLE_CONTEXT_LIMIT_TOKENS', parse: Env.parseNumber},
-            safeProcessingLimitTokens: {var: 'NEO_OPENAI_COMPATIBLE_SAFE_PROCESSING_LIMIT_TOKENS', parse: Env.parseNumber}
+            keep_alive              : {var: 'NEO_OPENAI_COMPATIBLE_KEEP_ALIVE', parse: Env.parseKeepAlive}
+        },
+        localModels: {
+            chat: {
+                contextLimitTokens      : {var: 'NEO_LOCAL_MODELS_CHAT_CONTEXT_LIMIT_TOKENS', parse: Env.parseNumber},
+                safeProcessingLimitTokens: {var: 'NEO_LOCAL_MODELS_CHAT_SAFE_PROCESSING_LIMIT_TOKENS', parse: Env.parseNumber}
+            },
+            embedding: {
+                contextLimitTokens      : {var: 'NEO_LOCAL_MODELS_EMBEDDING_CONTEXT_LIMIT_TOKENS', parse: Env.parseNumber},
+                safeProcessingLimitTokens: {var: 'NEO_LOCAL_MODELS_EMBEDDING_SAFE_PROCESSING_LIMIT_TOKENS', parse: Env.parseNumber}
+            }
         },
         vectorDimension: {var: 'NEO_VECTOR_DIMENSION', parse: Env.parseNumber},
         backupPath                  : 'NEO_BACKUP_PATH',

--- a/ai/mcp/server/memory-core/config.template.mjs
+++ b/ai/mcp/server/memory-core/config.template.mjs
@@ -171,30 +171,28 @@ class Config extends BaseConfig {
             apiKey                  : AiConfig.openAiCompatible.apiKey,
             unloadRetryCount        : AiConfig.openAiCompatible.unloadRetryCount,
             unloadRetryDelayMs      : AiConfig.openAiCompatible.unloadRetryDelayMs,
-            keep_alive              : AiConfig.openAiCompatible.keep_alive,
-            /**
-             * Configured context-window capacity of `model` measured in **tokens**.
-             * Token-based per the Discussion #11444 / #11447 V1 graduation contract.
-             * Used by `ConsumerFrictionHelper.invokeWithGuardrail` to fire the upstream
-             * pre-check skip ("Angle 2") when an LLM input payload exceeds the consumer's
-             * safe processing band. Default is sized for Gemma-3-4B / Qwen3-8B class
-             * consumers (~32K-token context). Operators running models with different
-             * context windows should tune this to match the deployed model — e.g. 8192
-             * for Gemma-4-8B-IT, 131072 for Llama-3.1-70B 128K-context variants.
-             * @type {number}
-             */
-            contextLimitTokens: AiConfig.openAiCompatible.contextLimitTokens,
-            /**
-             * Optional safer processing threshold (tokens) below `contextLimitTokens` for
-             * the upstream pre-check skip. When the estimated input token count exceeds
-             * this value, `invokeWithGuardrail` emits a `size-precheck-skip` friction and
-             * does NOT invoke the consumer model. Defaults to 75% of `contextLimitTokens`
-             * when unset — leaves ~25% headroom for system-prompt envelope, repair-cycle
-             * prompt growth, and output-token reservation per Discussion #11444 Round-2
-             * consensus.
-             * @type {number|undefined}
-             */
-            safeProcessingLimitTokens: AiConfig.openAiCompatible.safeProcessingLimitTokens
+            keep_alive              : AiConfig.openAiCompatible.keep_alive
+        },
+        /**
+         * Local-model role-keyed context limits passthrough.
+         *
+         * Mirrors `AiConfig.localModels` into the Memory_Config surface so consumers
+         * importing the MC overlay (chat-path: SemanticGraphExtractor + TopologyInferenceEngine
+         * + SessionService summarizer; embedding-path: future TextEmbeddingService consumer
+         * surface) can read the role-keyed context-limit knobs directly. The context-window
+         * axis is model-role (chat vs embedding), not provider-namespace — local providers
+         * share these caps because the practical limit comes from the loaded model.
+         * @type {Object}
+         */
+        localModels: {
+            chat: {
+                contextLimitTokens      : AiConfig.localModels.chat.contextLimitTokens,
+                safeProcessingLimitTokens: AiConfig.localModels.chat.safeProcessingLimitTokens
+            },
+            embedding: {
+                contextLimitTokens      : AiConfig.localModels.embedding.contextLimitTokens,
+                safeProcessingLimitTokens: AiConfig.localModels.embedding.safeProcessingLimitTokens
+            }
         },
         /**
          * The enforced vector dimension across all SQLite collections.

--- a/ai/services/graph/SemanticGraphExtractor.mjs
+++ b/ai/services/graph/SemanticGraphExtractor.mjs
@@ -118,12 +118,14 @@ DO NOT output markdown, \`\`\`json blocks, or any other explanations. Provide pu
             // into friction symptoms. Friction is emitted into the in-memory aggregator
             // (with `serviceDomain: 'dream-pipeline'`) for handoff rendering by
             // `GoldenPathSynthesizer.synthesizeGoldenPath`.
-            // #11965 AC5 / #12059: consumerModel reflects the active graph-generation provider
-            // for accurate telemetry; openAiCompatible's context-limit knobs are kept as the conservative
-            // upstream pre-check threshold for both provider families.
+            // consumerModel reflects the active graph-generation provider for accurate
+            // telemetry; localModels.chat.* provides the role-keyed context-limit
+            // threshold (model-role axis, not provider-namespace — remote providers like
+            // Gemini are API-bound and don't expose these knobs; local providers
+            // share the same caps because the limit comes from the loaded model).
             const consumerModel          = aiConfig[graphProvider]?.model;
-            const consumerContextTokens  = aiConfig.openAiCompatible.contextLimitTokens;
-            const consumerSafeTokens     = aiConfig.openAiCompatible.safeProcessingLimitTokens;
+            const consumerContextTokens  = aiConfig.localModels.chat.contextLimitTokens;
+            const consumerSafeTokens     = aiConfig.localModels.chat.safeProcessingLimitTokens;
 
             while (attempt < maxRetries && !payload) {
                 attempt++;

--- a/ai/services/graph/TopologyInferenceEngine.mjs
+++ b/ai/services/graph/TopologyInferenceEngine.mjs
@@ -80,8 +80,8 @@ ${contextText}
                     serviceDomain            : 'dream-pipeline',
                     emissionPoint            : 'post-invocation-failure',
                     inputBytes               : Buffer.byteLength(prompt),
-                    contextLimitTokens       : aiConfig.openAiCompatible.contextLimitTokens,
-                    safeProcessingLimitTokens: aiConfig.openAiCompatible.safeProcessingLimitTokens,
+                    contextLimitTokens       : aiConfig.localModels.chat.contextLimitTokens,
+                    safeProcessingLimitTokens: aiConfig.localModels.chat.safeProcessingLimitTokens,
                     note                     : `Silent empty-response from provider (no thrown error, no body). Prompt chars: ${prompt.length}.`
                 });
 

--- a/ai/services/memory-core/SessionService.mjs
+++ b/ai/services/memory-core/SessionService.mjs
@@ -609,8 +609,8 @@ ${aggregatedContent}
             aiConfig.modelProvider === 'openAiCompatible' ? (aiConfig.openAiCompatible.model || 'openAiCompatible') :
             aiConfig.modelProvider === 'ollama'           ? (aiConfig.ollama?.model           || 'ollama') :
             (aiConfig.modelName || 'gemini');
-        const consumerContextTokens = aiConfig.openAiCompatible?.contextLimitTokens || 32768;
-        const consumerSafeTokens    = aiConfig.openAiCompatible?.safeProcessingLimitTokens;
+        const consumerContextTokens = aiConfig.localModels.chat.contextLimitTokens;
+        const consumerSafeTokens    = aiConfig.localModels.chat.safeProcessingLimitTokens;
         const guardrailed           = await invokeWithGuardrail({
             invocationFn             : () => this.model.generateContent(summaryPrompt),
             inputPayload             : summaryPrompt,

--- a/test/playwright/fixtures/aiConfigDefaults.mjs
+++ b/test/playwright/fixtures/aiConfigDefaults.mjs
@@ -113,9 +113,17 @@ export const TIER1_DEFAULTS = deepFreeze(Neo.clone({
         apiKey                  : process.env.NEO_OPENAI_COMPATIBLE_API_KEY || '',
         unloadRetryCount        : Number(process.env.NEO_OPENAI_COMPATIBLE_UNLOAD_RETRY_COUNT) || 3,
         unloadRetryDelayMs      : Number(process.env.NEO_OPENAI_COMPATIBLE_UNLOAD_RETRY_DELAY_MS) || 500,
-        keep_alive              : parseKeepAlive(process.env.NEO_OPENAI_COMPATIBLE_KEEP_ALIVE, -1),
-        contextLimitTokens      : Number(process.env.NEO_OPENAI_COMPATIBLE_CONTEXT_LIMIT_TOKENS) || 262144,
-        safeProcessingLimitTokens: Number(process.env.NEO_OPENAI_COMPATIBLE_SAFE_PROCESSING_LIMIT_TOKENS) || 200000
+        keep_alive              : parseKeepAlive(process.env.NEO_OPENAI_COMPATIBLE_KEEP_ALIVE, -1)
+    },
+    localModels: {
+        chat: {
+            contextLimitTokens      : Number(process.env.NEO_LOCAL_MODELS_CHAT_CONTEXT_LIMIT_TOKENS) || 262144,
+            safeProcessingLimitTokens: Number(process.env.NEO_LOCAL_MODELS_CHAT_SAFE_PROCESSING_LIMIT_TOKENS) || 200000
+        },
+        embedding: {
+            contextLimitTokens      : Number(process.env.NEO_LOCAL_MODELS_EMBEDDING_CONTEXT_LIMIT_TOKENS) || 8192,
+            safeProcessingLimitTokens: Number(process.env.NEO_LOCAL_MODELS_EMBEDDING_SAFE_PROCESSING_LIMIT_TOKENS) || 6144
+        }
     },
     vectorDimension: Number(process.env.NEO_VECTOR_DIMENSION) || 4096,
     modelName      : 'gemini-2.5-flash',

--- a/test/playwright/unit/ai/config.template.spec.mjs
+++ b/test/playwright/unit/ai/config.template.spec.mjs
@@ -79,9 +79,17 @@ test.describe('Tier 1 Config Immutability', () => {
             apiKey                  : process.env.NEO_OPENAI_COMPATIBLE_API_KEY || '',
             unloadRetryCount        : Number(process.env.NEO_OPENAI_COMPATIBLE_UNLOAD_RETRY_COUNT) || 3,
             unloadRetryDelayMs      : Number(process.env.NEO_OPENAI_COMPATIBLE_UNLOAD_RETRY_DELAY_MS) || 500,
-            keep_alive              : TIER1_DEFAULTS.openAiCompatible.keep_alive,
-            contextLimitTokens      : Number(process.env.NEO_OPENAI_COMPATIBLE_CONTEXT_LIMIT_TOKENS) || 262144,
-            safeProcessingLimitTokens: Number(process.env.NEO_OPENAI_COMPATIBLE_SAFE_PROCESSING_LIMIT_TOKENS) || 200000
+            keep_alive              : TIER1_DEFAULTS.openAiCompatible.keep_alive
+        });
+        expect(Config.localModels).toMatchObject({
+            chat: {
+                contextLimitTokens      : Number(process.env.NEO_LOCAL_MODELS_CHAT_CONTEXT_LIMIT_TOKENS) || 262144,
+                safeProcessingLimitTokens: Number(process.env.NEO_LOCAL_MODELS_CHAT_SAFE_PROCESSING_LIMIT_TOKENS) || 200000
+            },
+            embedding: {
+                contextLimitTokens      : Number(process.env.NEO_LOCAL_MODELS_EMBEDDING_CONTEXT_LIMIT_TOKENS) || 8192,
+                safeProcessingLimitTokens: Number(process.env.NEO_LOCAL_MODELS_EMBEDDING_SAFE_PROCESSING_LIMIT_TOKENS) || 6144
+            }
         });
         expect(Config.engines.chroma).toEqual({
             host: process.env.NEO_CHROMA_HOST || 'localhost',

--- a/test/playwright/unit/ai/services/graph/SemanticGraphExtractor.spec.mjs
+++ b/test/playwright/unit/ai/services/graph/SemanticGraphExtractor.spec.mjs
@@ -342,16 +342,16 @@ test.describe('Neo.ai.daemons.services.SemanticGraphExtractor', () => {
     test('uses configured graph-provider model for consumer friction telemetry (#12059)', async () => {
         const originalGraphProvider                  = aiConfig.graphProvider;
         const originalOllamaModel                    = aiConfig.ollama?.model;
-        const originalContextLimitTokens             = aiConfig.openAiCompatible.contextLimitTokens;
-        const originalSafeProcessingLimitTokens      = aiConfig.openAiCompatible.safeProcessingLimitTokens;
+        const originalContextLimitTokens             = aiConfig.localModels.chat.contextLimitTokens;
+        const originalSafeProcessingLimitTokens      = aiConfig.localModels.chat.safeProcessingLimitTokens;
 
         try {
             clearAggregatedFrictions();
 
             aiConfig.graphProvider                             = 'ollama';
             aiConfig.ollama.model                              = 'gemma4-real-model';
-            aiConfig.openAiCompatible.contextLimitTokens        = 8;
-            aiConfig.openAiCompatible.safeProcessingLimitTokens = 1;
+            aiConfig.localModels.chat.contextLimitTokens        = 8;
+            aiConfig.localModels.chat.safeProcessingLimitTokens = 1;
 
             const result = await SemanticGraphExtractor.executeTriVectorExtraction({
                 id      : 'mock-consumer-model-vector-id',
@@ -370,8 +370,8 @@ test.describe('Neo.ai.daemons.services.SemanticGraphExtractor', () => {
         } finally {
             aiConfig.graphProvider                             = originalGraphProvider;
             aiConfig.ollama.model                              = originalOllamaModel;
-            aiConfig.openAiCompatible.contextLimitTokens        = originalContextLimitTokens;
-            aiConfig.openAiCompatible.safeProcessingLimitTokens = originalSafeProcessingLimitTokens;
+            aiConfig.localModels.chat.contextLimitTokens        = originalContextLimitTokens;
+            aiConfig.localModels.chat.safeProcessingLimitTokens = originalSafeProcessingLimitTokens;
             clearAggregatedFrictions();
         }
     });


### PR DESCRIPTION
Resolves #12114

Authored by Claude Opus 4.7 (1M context).
FAIR-band: over-target [16/30] — operator-directed pickup ("12114 makes the most sense") + ticket already self-assigned + ticket-shaping authored this turn → execution in same turn satisfies the converged-shape commitment.

Operator surfaced during PR #12113 V-B-A: `aiConfig.openAiCompatible.contextLimitTokens` was hardcoded as the source for ALL 4 consumer sites regardless of active provider, but the actual context-window axis is **model-role** (chat vs embedding), not provider-namespace. Remote providers (Gemini) are API-bound — no operator control over context cap. Local providers (`openAiCompatible`, `ollama`) share these caps because the practical limit comes from the loaded model, not the provider transport.

Adds `aiConfig.localModels.{chat,embedding}.{contextLimitTokens,safeProcessingLimitTokens}` to the template + envBindings, mirrors through to MC overlay as a passthrough block, migrates 4 consumer sites to read from the role-keyed path, deletes the orphan `openAiCompatible.{context,safe}*` keys, and removes the `SessionService.mjs:612` hidden default fallback (`|| 32768`) — loud-fail on missing config per the operator's strict no-hidden-default-fallback contract.

Evidence: L2 (unit-covered consumer migration via 6/6 SemanticGraphExtractor.spec.mjs pass + Orchestrator.invariants.spec.mjs 20/20 pass; no regression on PR #12112 sibling substrate) → L4 required (live REM cycle exercise + operator override of embedding context-cap before the future TextEmbeddingService consumer comes online).

## Deltas From Ticket

None to AC1-AC5. Sub-stage detail on the open-question ACs:

- **AC6 (embedding default V-B-A)**: Conservative placeholder `8192/6144` adopted in template — JSDoc explicitly notes operators must pin to their loaded embedding model's actual capability before operational reliance (e.g. Qwen3-8B-embedding's 32K cap is plausible but not V-B-A'd against the live deployment in this PR; no current consumer reads these keys, so the placeholder is L1-safe).
- **AC7 (openAiCompatible legacy retention)**: Resolved **delete-in-same-PR**. Cleaner substrate single-source-of-truth; orphan keys in the operator's gitignored overlay are harmless; Stage 2 (#12104) template rewrite has zero in-flight code dependency on the old keys. Operator can request `keep-as-deprecated-passthrough` in cycle-1 review if there's a sequencing concern I missed.

## Contract Ledger

| Surface | Before | After | Consumer |
|---|---|---|---|
| Chat context limits (template) | `aiConfig.openAiCompatible.contextLimitTokens=262144` + `safeProcessingLimitTokens=200000` | `aiConfig.localModels.chat.contextLimitTokens=262144` + `safeProcessingLimitTokens=200000` (values preserved) | SemanticGraphExtractor + TopologyInferenceEngine + SessionService chat-path |
| Embedding context limits (template) | NOT present | `aiConfig.localModels.embedding.contextLimitTokens=8192` + `safeProcessingLimitTokens=6144` (conservative placeholder; operator-tunable) | Future TextEmbeddingService consumer (no current reader; AC6 V-B-A required before operational reliance) |
| Env bindings | `NEO_OPENAI_COMPATIBLE_CONTEXT_LIMIT_TOKENS` + `NEO_OPENAI_COMPATIBLE_SAFE_PROCESSING_LIMIT_TOKENS` | `NEO_LOCAL_MODELS_CHAT_CONTEXT_LIMIT_TOKENS` + `NEO_LOCAL_MODELS_CHAT_SAFE_PROCESSING_LIMIT_TOKENS` + `NEO_LOCAL_MODELS_EMBEDDING_CONTEXT_LIMIT_TOKENS` + `NEO_LOCAL_MODELS_EMBEDDING_SAFE_PROCESSING_LIMIT_TOKENS` | Operator env-override surface |
| MC overlay passthrough | `Memory_Config.openAiCompatible.contextLimitTokens` (nested under openAiCompatible block) | `Memory_Config.localModels.chat.{context,safe}LimitTokens` + `Memory_Config.localModels.embedding.{context,safe}LimitTokens` (new top-level passthrough block) | Chat-path consumers + future embedding-path consumers |
| Consumer migration | All 4 sites read `aiConfig.openAiCompatible.{context,safe}*` | All 4 sites read `aiConfig.localModels.chat.{context,safe}*` (chat-role) | Operator role-axis substrate invariant satisfied |
| SessionService hidden default | `aiConfig.openAiCompatible?.contextLimitTokens \|\| 32768` (line 612) | `aiConfig.localModels.chat.contextLimitTokens` (verbatim read, loud-fail on missing) | Eliminates §no_hidden_default_fallbacks contract violation |
| Source-comment archaeology | `SemanticGraphExtractor.mjs:121` ticket-anchored `// #11965 AC5 / #12059:` JSDoc rationale | Rewritten without ticket anchor; preserves the durable intent ("consumerModel reflects the active graph-generation provider; localModels.chat.* provides role-keyed context-limit threshold") | AGENTS_ATLAS.md §15.6 substrate hygiene |

## Test Evidence

- `node --check` on all 7 modified files: PASS
- `npm run test-unit -- test/playwright/unit/ai/services/graph/SemanticGraphExtractor.spec.mjs` — **6/6 passed (597ms)** including the new `(#12091)` empty-response test + `(#12059)` consumer-model-friction test (both adapted to localModels.chat.* assertions)
- `npm run test-unit -- test/playwright/unit/ai/daemons/orchestrator/Orchestrator.invariants.spec.mjs` — **20/20 passed (1.2s)** — verifies no regression on PR #12112's lms proactive load sibling substrate
- `rg -n "cycle-[0-9]|Lane [A-Z]|AC[0-9]|#[0-9]{4,5}|\.mjs:[0-9]+"` on all new lines: **zero violations** (AGENTS_ATLAS.md §15.6 compliance)
- `rg -n "openAiCompatible.contextLimitTokens|openAiCompatible.safeProcessingLimitTokens"` on `ai/` + `test/`: **zero residual references** (clean migration)

## Out of Scope

- **Operator overlay sync**: `ai/config.mjs` and `ai/mcp/server/memory-core/config.mjs` are gitignored — operators must manually sync the new `localModels` block from the template after pull-merge OR re-run `ai/scripts/setup/initServerConfigs.mjs`. Stage 0 (#12102) overlay-preserving template advancement script will automate this; until that ships, operator-local overlay edits are required for the role-keyed reads to function.
- **Pre-existing archaeology** in `TopologyInferenceEngine.mjs:140-166` (`#12062`, `Epic #12065 / #12068`, `PR #12077`) — not introduced by this PR, candidate for follow-up cleanup ticket.
- **Embedding consumer migration**: AC2 adds the template knobs but no consumer reads them yet. Future TextEmbeddingService telemetry work will wire them.

## Post-Merge Validation

- [ ] Operator pulls dev, syncs gitignored overlay (`ai/config.mjs` + `ai/mcp/server/memory-core/config.mjs`) to mirror the new `localModels` block, restarts orchestrator
- [ ] Verify `aiConfig.localModels.chat.contextLimitTokens` resolves to 262144 at runtime in the SemanticGraphExtractor + TopologyInferenceEngine + SessionService chat paths
- [ ] Verify `SessionService.summarizeSession()` no longer falls back to 32768 if config keys are missing — instead loud-fails with TypeError at guardrail call (or proceeds correctly with localModels.chat values)
- [ ] AC6 V-B-A: pin `localModels.embedding.contextLimitTokens` to the actual configured embedding model's capability (Qwen3-8B-embedding ≈ 32K) before TextEmbeddingService consumer goes online

## Related

- Parent: Epic #12101 (greenfield aiConfig substrate redesign — graduated from Discussion #12100)
- Sibling: #12104 (Stage 2 template rewrite — this PR's role-keyed substrate semantic naturally rides alongside Stage 2's template rewrite)
- Sibling: #12102 (Stage 0 overlay-preserving template advancement — would have auto-synced operator overlays for this change; not yet shipped)
- Sibling: PR #12113 (empty-response detection — kept the old `openAiCompatible.contextLimitTokens` references for interim consistency; this PR retires them)
- Sibling: #12090 (provider multi-model coexistence; PR #12112 lms proactive load) — orthogonal but adjacent

## Commit

- `feat(ai): split context-limits into localModels.{chat,embedding} role-keyed config (#12114)`
