### PR TITLE
feat(ai): warn on provider model capacity gaps (#12090)

### DIFF
--- a/ai/config.template.mjs
+++ b/ai/config.template.mjs
@@ -121,10 +121,11 @@ class Config extends BaseConfig {
          * @type {Object}
          */
         ollama: {
-            host          : 'http://127.0.0.1:11434',
-            model         : 'gemma4:31b',
-            embeddingModel: 'qwen3-embedding',
-            keep_alive    : -1
+            host                 : 'http://127.0.0.1:11434',
+            model                : 'gemma4:31b',
+            embeddingModel       : 'qwen3-embedding',
+            keep_alive           : -1,
+            requireParallelModels: 2
         },
         /**
          * @summary Deployment-wide OpenAI-compatible provider defaults.
@@ -134,13 +135,14 @@ class Config extends BaseConfig {
          * @type {Object}
          */
         openAiCompatible: {
-            host                    : 'http://127.0.0.1:11434',
-            model                   : 'gemma-4-31b-it',
-            embeddingModel          : 'text-embedding-qwen3-embedding-8b',
-            apiKey                  : '',
-            unloadRetryCount        : 3,
-            unloadRetryDelayMs      : 500,
-            keep_alive              : -1
+            host                 : 'http://127.0.0.1:11434',
+            model                : 'gemma-4-31b-it',
+            embeddingModel       : 'text-embedding-qwen3-embedding-8b',
+            apiKey               : '',
+            unloadRetryCount     : 3,
+            unloadRetryDelayMs   : 500,
+            keep_alive           : -1,
+            requireParallelModels: 2
         },
         /**
          * @summary Local-model role-keyed context limits.
@@ -607,19 +609,21 @@ class Config extends BaseConfig {
         graphProvider    : 'NEO_GRAPH_PROVIDER',
         embeddingProvider: 'NEO_EMBEDDING_PROVIDER',
         ollama           : {
-            host          : 'NEO_OLLAMA_HOST',
-            model         : 'NEO_OLLAMA_MODEL',
-            embeddingModel: 'NEO_OLLAMA_EMBEDDING_MODEL',
-            keep_alive    : {var: 'NEO_OLLAMA_KEEP_ALIVE', parse: Env.parseKeepAlive}
+            host                 : 'NEO_OLLAMA_HOST',
+            model                : 'NEO_OLLAMA_MODEL',
+            embeddingModel       : 'NEO_OLLAMA_EMBEDDING_MODEL',
+            keep_alive           : {var: 'NEO_OLLAMA_KEEP_ALIVE', parse: Env.parseKeepAlive},
+            requireParallelModels: {var: 'NEO_OLLAMA_REQUIRE_PARALLEL_MODELS', parse: Env.parseNumber}
         },
         openAiCompatible: {
-            host                    : 'NEO_OPENAI_COMPATIBLE_HOST',
-            model                   : 'NEO_OPENAI_COMPATIBLE_MODEL',
-            embeddingModel          : 'NEO_OPENAI_COMPATIBLE_EMBEDDING_MODEL',
-            apiKey                  : 'NEO_OPENAI_COMPATIBLE_API_KEY',
-            unloadRetryCount        : {var: 'NEO_OPENAI_COMPATIBLE_UNLOAD_RETRY_COUNT', parse: Env.parseNumber},
-            unloadRetryDelayMs      : {var: 'NEO_OPENAI_COMPATIBLE_UNLOAD_RETRY_DELAY_MS', parse: Env.parseNumber},
-            keep_alive              : {var: 'NEO_OPENAI_COMPATIBLE_KEEP_ALIVE', parse: Env.parseKeepAlive}
+            host                 : 'NEO_OPENAI_COMPATIBLE_HOST',
+            model                : 'NEO_OPENAI_COMPATIBLE_MODEL',
+            embeddingModel       : 'NEO_OPENAI_COMPATIBLE_EMBEDDING_MODEL',
+            apiKey               : 'NEO_OPENAI_COMPATIBLE_API_KEY',
+            unloadRetryCount     : {var: 'NEO_OPENAI_COMPATIBLE_UNLOAD_RETRY_COUNT', parse: Env.parseNumber},
+            unloadRetryDelayMs   : {var: 'NEO_OPENAI_COMPATIBLE_UNLOAD_RETRY_DELAY_MS', parse: Env.parseNumber},
+            keep_alive           : {var: 'NEO_OPENAI_COMPATIBLE_KEEP_ALIVE', parse: Env.parseKeepAlive},
+            requireParallelModels: {var: 'NEO_OPENAI_COMPATIBLE_REQUIRE_PARALLEL_MODELS', parse: Env.parseNumber}
         },
         localModels: {
             chat: {

--- a/ai/daemons/orchestrator/services/DreamService.mjs
+++ b/ai/daemons/orchestrator/services/DreamService.mjs
@@ -25,7 +25,8 @@ import {
     assertProviderReadinessConfig,
     createProviderFailureDiagnostic,
     getGraphProviderReadinessTarget,
-    waitForProvider
+    waitForProvider,
+    warnProviderParallelModelCapacity
 } from '../../../services/graph/ProviderReadinessHelper.mjs';
 
 const __filename = fileURLToPath(import.meta.url);
@@ -443,7 +444,12 @@ class DreamService extends Base {
             };
         }
 
-        return {ready: true};
+        const capacity = await warnProviderParallelModelCapacity({
+            config   : AiConfig,
+            timeoutMs: readinessConfig.timeoutMs
+        });
+
+        return {ready: true, capacity};
     }
 
     /**

--- a/ai/mcp/server/memory-core/config.template.mjs
+++ b/ai/mcp/server/memory-core/config.template.mjs
@@ -155,23 +155,25 @@ class Config extends BaseConfig {
          * Settings for the Ollama integration
          */
         ollama: {
-            host          : AiConfig.ollama.host,
-            model         : AiConfig.ollama.model,
-            embeddingModel: AiConfig.ollama.embeddingModel,
-            keep_alive    : AiConfig.ollama.keep_alive
+            host                 : AiConfig.ollama.host,
+            model                : AiConfig.ollama.model,
+            embeddingModel       : AiConfig.ollama.embeddingModel,
+            keep_alive           : AiConfig.ollama.keep_alive,
+            requireParallelModels: AiConfig.ollama.requireParallelModels
         },
         /**
          * Settings for the OpenAI-Compatible API integration (e.g., mlx-lm or mlx-openai-server)
          * WARNING: Never hardcode API keys here. Always export them via .env or globally.
          */
         openAiCompatible: {
-            host                    : AiConfig.openAiCompatible.host,
-            model                   : AiConfig.openAiCompatible.model,
-            embeddingModel          : AiConfig.openAiCompatible.embeddingModel,
-            apiKey                  : AiConfig.openAiCompatible.apiKey,
-            unloadRetryCount        : AiConfig.openAiCompatible.unloadRetryCount,
-            unloadRetryDelayMs      : AiConfig.openAiCompatible.unloadRetryDelayMs,
-            keep_alive              : AiConfig.openAiCompatible.keep_alive
+            host                 : AiConfig.openAiCompatible.host,
+            model                : AiConfig.openAiCompatible.model,
+            embeddingModel       : AiConfig.openAiCompatible.embeddingModel,
+            apiKey               : AiConfig.openAiCompatible.apiKey,
+            unloadRetryCount     : AiConfig.openAiCompatible.unloadRetryCount,
+            unloadRetryDelayMs   : AiConfig.openAiCompatible.unloadRetryDelayMs,
+            keep_alive           : AiConfig.openAiCompatible.keep_alive,
+            requireParallelModels: AiConfig.openAiCompatible.requireParallelModels
         },
         /**
          * Local-model role-keyed context limits passthrough.
@@ -451,19 +453,21 @@ class Config extends BaseConfig {
         graphProvider     : 'NEO_GRAPH_PROVIDER',
         embeddingProvider : 'NEO_EMBEDDING_PROVIDER',
         ollama            : {
-            host          : 'NEO_OLLAMA_HOST',
-            model         : 'NEO_OLLAMA_MODEL',
-            embeddingModel: 'NEO_OLLAMA_EMBEDDING_MODEL',
-            keep_alive    : { var: 'NEO_OLLAMA_KEEP_ALIVE', parse: Env.parseKeepAlive}
+            host                 : 'NEO_OLLAMA_HOST',
+            model                : 'NEO_OLLAMA_MODEL',
+            embeddingModel       : 'NEO_OLLAMA_EMBEDDING_MODEL',
+            keep_alive           : { var: 'NEO_OLLAMA_KEEP_ALIVE', parse: Env.parseKeepAlive},
+            requireParallelModels: { var: 'NEO_OLLAMA_REQUIRE_PARALLEL_MODELS', parse: Env.parseNumber}
         },
         openAiCompatible: {
-            host              : 'NEO_OPENAI_COMPATIBLE_HOST',
-            model             : 'NEO_OPENAI_COMPATIBLE_MODEL',
-            embeddingModel    : 'NEO_OPENAI_COMPATIBLE_EMBEDDING_MODEL',
-            apiKey            : 'NEO_OPENAI_COMPATIBLE_API_KEY',
-            unloadRetryCount  : { var: 'NEO_OPENAI_COMPATIBLE_UNLOAD_RETRY_COUNT', parse: Env.parseNumber},
-            unloadRetryDelayMs: { var: 'NEO_OPENAI_COMPATIBLE_UNLOAD_RETRY_DELAY_MS', parse: Env.parseNumber},
-            keep_alive        : { var: 'NEO_OPENAI_COMPATIBLE_KEEP_ALIVE', parse: Env.parseKeepAlive}
+            host                 : 'NEO_OPENAI_COMPATIBLE_HOST',
+            model                : 'NEO_OPENAI_COMPATIBLE_MODEL',
+            embeddingModel       : 'NEO_OPENAI_COMPATIBLE_EMBEDDING_MODEL',
+            apiKey               : 'NEO_OPENAI_COMPATIBLE_API_KEY',
+            unloadRetryCount     : { var: 'NEO_OPENAI_COMPATIBLE_UNLOAD_RETRY_COUNT', parse: Env.parseNumber},
+            unloadRetryDelayMs   : { var: 'NEO_OPENAI_COMPATIBLE_UNLOAD_RETRY_DELAY_MS', parse: Env.parseNumber},
+            keep_alive           : { var: 'NEO_OPENAI_COMPATIBLE_KEEP_ALIVE', parse: Env.parseKeepAlive},
+            requireParallelModels: { var: 'NEO_OPENAI_COMPATIBLE_REQUIRE_PARALLEL_MODELS', parse: Env.parseNumber}
         },
         vectorDimension: { var: 'NEO_VECTOR_DIMENSION', parse: Env.parseNumber},
         backupPath     : 'NEO_BACKUP_PATH',

--- a/ai/services/graph/ProviderReadinessHelper.mjs
+++ b/ai/services/graph/ProviderReadinessHelper.mjs
@@ -39,6 +39,26 @@ export function getOpenAiCompatibleModelIds(payload) {
 }
 
 /**
+ * @summary Extracts currently loaded model identifiers from an Ollama `/api/ps` payload.
+ *
+ * Native Ollama exposes currently resident models as `models: [{name, model}]`.
+ * `id` is accepted as a tolerance seam for compatible local-server variants, but
+ * the returned list still represents observed residency, not a config default.
+ *
+ * @param {Object} payload Parsed `/api/ps` response.
+ * @returns {String[]}
+ */
+export function getOllamaRunningModelIds(payload) {
+    if (!Array.isArray(payload?.models)) {
+        return [];
+    }
+
+    return [...new Set(payload.models
+        .map(item => item?.name || item?.model || item?.id)
+        .filter(Boolean))];
+}
+
+/**
  * @summary Fetches model ids from an OpenAI-compatible provider.
  *
  * @param {Object} options
@@ -67,6 +87,37 @@ export async function fetchOpenAiCompatibleModelIds({host, timeoutMs, fetchFn = 
     }
 
     return getOpenAiCompatibleModelIds(await response.json());
+}
+
+/**
+ * @summary Fetches currently resident model ids from native Ollama.
+ *
+ * @param {Object} options
+ * @param {String} options.host Provider host.
+ * @param {Number} options.timeoutMs HTTP timeout. Required; no module-level default.
+ * @param {Function} [options.fetchFn=fetch] Fetch seam for tests.
+ * @returns {Promise<String[]>}
+ */
+export async function fetchOllamaRunningModelIds({host, timeoutMs, fetchFn = fetch} = {}) {
+    if (!host) {
+        throw new TypeError('fetchOllamaRunningModelIds: host is required');
+    }
+    if (typeof timeoutMs !== 'number') {
+        throw new TypeError('fetchOllamaRunningModelIds: timeoutMs is required');
+    }
+
+    const url      = new URL('/api/ps', host).toString();
+    const response = await fetchFn(url, {
+        method: 'GET',
+        signal: AbortSignal.timeout(timeoutMs)
+    });
+
+    if (!response.ok) {
+        const text = typeof response.text === 'function' ? await response.text() : '';
+        throw new Error(`Ollama running-model enumeration failed: HTTP ${response.status}${text ? ` - ${text}` : ''}`);
+    }
+
+    return getOllamaRunningModelIds(await response.json());
 }
 
 /**
@@ -245,6 +296,166 @@ export function getGraphProviderReadinessTarget(config = aiConfig.data) {
         embeddingModel,
         url
     };
+}
+
+/**
+ * @summary Builds the configured chat / embedding model set for capacity probes.
+ * @param {Object} target Provider readiness target.
+ * @returns {String[]}
+ */
+export function getRequiredProviderModels(target) {
+    return [...new Set([target?.model, target?.embeddingModel].filter(Boolean))];
+}
+
+/**
+ * @summary Creates the operator-facing warning for insufficient parallel model residency.
+ * @param {Object} options
+ * @returns {String}
+ */
+export function createParallelModelCapacityWarning({
+    provider,
+    model,
+    embeddingModel,
+    requiredModels,
+    availableModels,
+    missingModels,
+    observedCount,
+    requireParallelModels
+}) {
+    const available = availableModels.length ? availableModels.join(', ') : 'none';
+    const missing   = missingModels.length ? missingModels.join(', ') : 'none';
+    const base      = `[provider/${provider}] expected ${requireParallelModels}+ models loaded ` +
+        `(chat=${model || 'unset'}, embedding=${embeddingModel || 'unset'}); observed ${observedCount} loaded ` +
+        `(available=${available}, required=${requiredModels.join(', ') || 'none'}, missing=${missing}); ` +
+        'model swap penalty likely;';
+
+    return provider === 'ollama'
+        ? `${base} set OLLAMA_MAX_LOADED_MODELS=${requireParallelModels} in the Ollama server environment.`
+        : `${base} raise the OpenAI-compatible server loaded-model cap to ${requireParallelModels} and pre-load both models.`;
+}
+
+/**
+ * @summary Probes whether the configured graph provider has chat + embedding models resident together.
+ *
+ * This is an observability check only. It never mutates provider state and it does
+ * not substitute defaults for missing config leaves; callers decide whether to warn
+ * or fail based on the returned envelope.
+ *
+ * @param {Object} options
+ * @param {Object} options.config Provider-source config (aiConfig-shaped).
+ * @param {Number} options.timeoutMs HTTP probe timeout. Required; no module-level default.
+ * @param {Function} [options.fetchOpenAiCompatibleModels] Injectable OpenAI-compatible model-list probe.
+ * @param {Function} [options.fetchOllamaModels] Injectable Ollama running-model probe.
+ * @returns {Promise<Object>}
+ */
+export async function probeProviderParallelModelCapacity({
+    config,
+    timeoutMs,
+    fetchOpenAiCompatibleModels = opts => fetchOpenAiCompatibleModelIds(opts),
+    fetchOllamaModels           = opts => fetchOllamaRunningModelIds(opts)
+} = {}) {
+    if (!config || typeof config !== 'object') {
+        throw new TypeError('probeProviderParallelModelCapacity: config is required');
+    }
+    if (typeof timeoutMs !== 'number') {
+        throw new TypeError('probeProviderParallelModelCapacity: timeoutMs is required');
+    }
+
+    const target = getGraphProviderReadinessTarget(config);
+
+    if (!target.supported || !target.host) {
+        return {
+            ready    : true,
+            skipped  : true,
+            provider : target.provider,
+            supported: target.supported,
+            reason   : target.supported ? 'missing-host' : 'unsupported-provider'
+        };
+    }
+
+    const providerConfig = config[target.provider];
+    const requireParallelModels = providerConfig?.requireParallelModels;
+
+    if (typeof requireParallelModels !== 'number') {
+        throw new TypeError(`probeProviderParallelModelCapacity: config.${target.provider}.requireParallelModels must be configured as a number`);
+    }
+
+    const requiredModels = getRequiredProviderModels(target);
+    const availableModels = target.provider === 'ollama'
+        ? await fetchOllamaModels({host: target.host, timeoutMs})
+        : await fetchOpenAiCompatibleModels({host: target.host, timeoutMs});
+    const uniqueAvailable = [...new Set(availableModels)];
+    const missingModels   = requiredModels.filter(model => !uniqueAvailable.includes(model));
+    const observedCount   = uniqueAvailable.length;
+    const ready           = observedCount >= requireParallelModels && missingModels.length === 0;
+
+    return {
+        ready,
+        provider             : target.provider,
+        host                 : target.host,
+        model                : target.model,
+        embeddingModel       : target.embeddingModel,
+        requireParallelModels,
+        requiredModels,
+        availableModels      : uniqueAvailable,
+        missingModels,
+        observedCount,
+        warning              : ready ? null : createParallelModelCapacityWarning({
+            provider: target.provider,
+            model   : target.model,
+            embeddingModel: target.embeddingModel,
+            requiredModels,
+            availableModels: uniqueAvailable,
+            missingModels,
+            observedCount,
+            requireParallelModels
+        })
+    };
+}
+
+/**
+ * @summary Emits a non-blocking warning when provider model residency cannot satisfy the REM cycle.
+ *
+ * The provider must already be reachable before callers invoke this helper. Probe
+ * failures become WARN records, not boot blockers, because readiness itself is
+ * owned by `waitForProvider()`.
+ *
+ * @param {Object} options
+ * @param {Object} options.config Provider-source config (aiConfig-shaped).
+ * @param {Number} options.timeoutMs HTTP probe timeout. Required; no module-level default.
+ * @param {Object} [options.log=logger] Logger seam.
+ * @returns {Promise<Object>}
+ */
+export async function warnProviderParallelModelCapacity({
+    config,
+    timeoutMs,
+    log = logger,
+    ...probeOptions
+} = {}) {
+    try {
+        const result = await probeProviderParallelModelCapacity({
+            config,
+            timeoutMs,
+            ...probeOptions
+        });
+
+        if (!result.ready && result.warning) {
+            log.warn?.(result.warning, result);
+        }
+
+        return result;
+    } catch (error) {
+        const provider = config ? resolveGraphModelProvider(config) : 'unknown';
+        const result = {
+            ready   : false,
+            provider,
+            error   : {message: error?.message || String(error)},
+            warning : `[provider/${provider}] parallel-model capacity probe failed: ${error?.message || error}`
+        };
+
+        log.warn?.(result.warning, result);
+        return result;
+    }
 }
 
 /**

--- a/ai/services/graph/ProviderReadinessHelper.mjs
+++ b/ai/services/graph/ProviderReadinessHelper.mjs
@@ -1,5 +1,6 @@
 import http from 'http';
 import {execFile} from 'child_process';
+import Neo from '../../../src/Neo.mjs';
 import {Memory_Config as aiConfig} from '../../services.mjs';
 import logger from '../../mcp/server/memory-core/logger.mjs';
 import {isGraphModelProviderSupported, resolveGraphModelProvider} from './providerDispatch.mjs';
@@ -376,7 +377,7 @@ export async function probeProviderParallelModelCapacity({
     const providerConfig = config[target.provider];
     const requireParallelModels = providerConfig?.requireParallelModels;
 
-    if (typeof requireParallelModels !== 'number') {
+    if (!Neo.isNumber(requireParallelModels)) {
         throw new TypeError(`probeProviderParallelModelCapacity: config.${target.provider}.requireParallelModels must be configured as a number`);
     }
 

--- a/learn/agentos/DeploymentCookbook.md
+++ b/learn/agentos/DeploymentCookbook.md
@@ -162,8 +162,23 @@ NEO_OPENAI_COMPATIBLE_HOST=http://local-model:11434 \
 NEO_OPENAI_COMPATIBLE_MODEL=<chat-model> \
 NEO_OPENAI_COMPATIBLE_EMBEDDING_MODEL=<embedding-model> \
 NEO_OPENAI_COMPATIBLE_KEEP_ALIVE=-1 \
+NEO_OPENAI_COMPATIBLE_REQUIRE_PARALLEL_MODELS=2 \
 docker compose -f ai/deploy/docker-compose.yml --profile cloud --profile local-model up --build
 ```
+
+The `requireParallelModels` setting is Neo's observable contract for local
+providers: the chat and embedding model must fit resident at the same time. The
+orchestrator warns when the configured graph provider only reports one loaded
+model or is missing either configured model name. For native Ollama deployments,
+set the provider process environment to at least the same count:
+
+```sh
+OLLAMA_MAX_LOADED_MODELS=2 ollama serve
+```
+
+For OpenAI-compatible providers, use the provider's own loaded-model cap or
+pre-load setting (for example LM Studio's loaded-model/JIT setting) and verify
+`GET /v1/models` lists both configured model ids before running Sandman.
 
 The expected failure signatures are:
 
@@ -205,6 +220,7 @@ Supply these values per service/profile as needed:
 | `NEO_OPENAI_COMPATIBLE_MODEL`, `NEO_OPENAI_COMPATIBLE_EMBEDDING_MODEL` | KB, MC, Orchestrator | Chat and embedding model names already present in the local-model runtime. |
 | `NEO_OPENAI_COMPATIBLE_API_KEY` | KB, MC, Orchestrator | Optional bearer token for OpenAI-compatible providers that require one; normally empty for the local compose service. |
 | `NEO_OLLAMA_KEEP_ALIVE`, `NEO_OPENAI_COMPATIBLE_KEEP_ALIVE` | KB, MC, Orchestrator | Provider request keep-alive override. Default `-1` keeps the selected local model resident unless the operator explicitly pins a shorter retention window or `0` unload control. |
+| `NEO_OLLAMA_REQUIRE_PARALLEL_MODELS`, `NEO_OPENAI_COMPATIBLE_REQUIRE_PARALLEL_MODELS` | KB, MC, Orchestrator | Local-provider residency expectation for chat + embedding coexistence. Default `2`; the provider-readiness check warns if the selected graph provider cannot observe that count and both configured model names. |
 | `NEO_LOCAL_MODEL_IMAGE`, `NEO_LOCAL_MODEL_KEEP_ALIVE`, `NEO_LOCAL_MODEL_MEMORY_LIMIT`, `NEO_LOCAL_MODEL_CPU_LIMIT` | `local-model` | Optional image/runtime/resource overrides for the self-hosted provider container. |
 | `NEO_AUTO_SYNC=false` | KB | Prevents one-shot local KB sync during server startup. |
 | `NEO_KB_AUTO_START_DATABASE=false` | KB | Prevents the KB server from starting a local Chroma process. |

--- a/learn/agentos/SharedDeployment.md
+++ b/learn/agentos/SharedDeployment.md
@@ -95,6 +95,28 @@ export NEO_OPENAI_COMPATIBLE_API_KEY=  # leave empty for local servers
 This path uses the existing `Neo.ai.provider.OpenAiCompatible` chat-completions abstraction. Do not add a model-specific Qwen provider class for shared-deployment installs; local-model selection is an operator config concern.
 `NEO_OPENAI_COMPATIBLE_KEEP_ALIVE` and `NEO_OLLAMA_KEEP_ALIVE` default to `-1` so local providers keep the selected model resident across Agent OS calls unless operators explicitly choose a shorter retention window or `0` unload control.
 
+### Local-provider model residency
+
+REM and Sandman alternate between a chat model and an embedding model. Local
+providers therefore need both models resident at the same time; otherwise each
+chat-to-embedding switch can evict the previous model and reintroduce cold-load
+latency despite `keep_alive=-1`.
+
+Neo declares this requirement with provider-level config:
+
+```bash
+export NEO_OLLAMA_REQUIRE_PARALLEL_MODELS=2
+export NEO_OPENAI_COMPATIBLE_REQUIRE_PARALLEL_MODELS=2
+```
+
+The defaults are `2` because the standard local setup uses one chat model and
+one embedding model. The boot-time provider-readiness check warns, but does not
+block startup, when the selected provider cannot observe both configured model
+names as loaded/available. Native Ollama deployments must satisfy the warning by
+starting `ollama serve` with `OLLAMA_MAX_LOADED_MODELS` set to at least the same
+count; OpenAI-compatible servers must use their provider-specific loaded-model
+cap or pre-load setting so the chat and embedding model stay resident together.
+
 ## Authentication
 
 Shared deployments need to know **which agent originated each request** so memories, summaries, and graph edges are attributed correctly. The Memory Core supports two authentication paths:

--- a/test/playwright/fixtures/aiConfigDefaults.mjs
+++ b/test/playwright/fixtures/aiConfigDefaults.mjs
@@ -101,19 +101,21 @@ export const TIER1_DEFAULTS = deepFreeze(Neo.clone({
     graphProvider    : process.env.NEO_GRAPH_PROVIDER || 'openAiCompatible',
     embeddingProvider: process.env.NEO_EMBEDDING_PROVIDER || 'openAiCompatible',
     ollama: {
-        host          : process.env.NEO_OLLAMA_HOST || 'http://127.0.0.1:11434',
-        model         : process.env.NEO_OLLAMA_MODEL || 'gemma4:31b',
-        embeddingModel: process.env.NEO_OLLAMA_EMBEDDING_MODEL || 'qwen3-embedding',
-        keep_alive    : parseKeepAlive(process.env.NEO_OLLAMA_KEEP_ALIVE, -1)
+        host                 : process.env.NEO_OLLAMA_HOST || 'http://127.0.0.1:11434',
+        model                : process.env.NEO_OLLAMA_MODEL || 'gemma4:31b',
+        embeddingModel       : process.env.NEO_OLLAMA_EMBEDDING_MODEL || 'qwen3-embedding',
+        keep_alive           : parseKeepAlive(process.env.NEO_OLLAMA_KEEP_ALIVE, -1),
+        requireParallelModels: Number(process.env.NEO_OLLAMA_REQUIRE_PARALLEL_MODELS) || 2
     },
     openAiCompatible: {
-        host                    : process.env.NEO_OPENAI_COMPATIBLE_HOST || 'http://127.0.0.1:11434',
-        model                   : process.env.NEO_OPENAI_COMPATIBLE_MODEL || 'gemma-4-31b-it',
-        embeddingModel          : process.env.NEO_OPENAI_COMPATIBLE_EMBEDDING_MODEL || 'text-embedding-qwen3-embedding-8b',
-        apiKey                  : process.env.NEO_OPENAI_COMPATIBLE_API_KEY || '',
-        unloadRetryCount        : Number(process.env.NEO_OPENAI_COMPATIBLE_UNLOAD_RETRY_COUNT) || 3,
-        unloadRetryDelayMs      : Number(process.env.NEO_OPENAI_COMPATIBLE_UNLOAD_RETRY_DELAY_MS) || 500,
-        keep_alive              : parseKeepAlive(process.env.NEO_OPENAI_COMPATIBLE_KEEP_ALIVE, -1)
+        host                 : process.env.NEO_OPENAI_COMPATIBLE_HOST || 'http://127.0.0.1:11434',
+        model                : process.env.NEO_OPENAI_COMPATIBLE_MODEL || 'gemma-4-31b-it',
+        embeddingModel       : process.env.NEO_OPENAI_COMPATIBLE_EMBEDDING_MODEL || 'text-embedding-qwen3-embedding-8b',
+        apiKey               : process.env.NEO_OPENAI_COMPATIBLE_API_KEY || '',
+        unloadRetryCount     : Number(process.env.NEO_OPENAI_COMPATIBLE_UNLOAD_RETRY_COUNT) || 3,
+        unloadRetryDelayMs   : Number(process.env.NEO_OPENAI_COMPATIBLE_UNLOAD_RETRY_DELAY_MS) || 500,
+        keep_alive           : parseKeepAlive(process.env.NEO_OPENAI_COMPATIBLE_KEEP_ALIVE, -1),
+        requireParallelModels: Number(process.env.NEO_OPENAI_COMPATIBLE_REQUIRE_PARALLEL_MODELS) || 2
     },
     localModels: {
         chat: {

--- a/test/playwright/unit/ai/config.template.spec.mjs
+++ b/test/playwright/unit/ai/config.template.spec.mjs
@@ -67,19 +67,21 @@ test.describe('Tier 1 Config Immutability', () => {
         expect(Config.embeddingModel).toBe('gemini-embedding-001');
 
         expect(Config.ollama).toMatchObject({
-            host          : process.env.NEO_OLLAMA_HOST || 'http://127.0.0.1:11434',
-            model         : process.env.NEO_OLLAMA_MODEL || 'gemma4:31b',
-            embeddingModel: process.env.NEO_OLLAMA_EMBEDDING_MODEL || 'qwen3-embedding',
-            keep_alive    : TIER1_DEFAULTS.ollama.keep_alive
+            host                 : process.env.NEO_OLLAMA_HOST || 'http://127.0.0.1:11434',
+            model                : process.env.NEO_OLLAMA_MODEL || 'gemma4:31b',
+            embeddingModel       : process.env.NEO_OLLAMA_EMBEDDING_MODEL || 'qwen3-embedding',
+            keep_alive           : TIER1_DEFAULTS.ollama.keep_alive,
+            requireParallelModels: TIER1_DEFAULTS.ollama.requireParallelModels
         });
         expect(Config.openAiCompatible).toMatchObject({
-            host                    : process.env.NEO_OPENAI_COMPATIBLE_HOST || 'http://127.0.0.1:11434',
-            model                   : process.env.NEO_OPENAI_COMPATIBLE_MODEL || 'gemma-4-31b-it',
-            embeddingModel          : process.env.NEO_OPENAI_COMPATIBLE_EMBEDDING_MODEL || 'text-embedding-qwen3-embedding-8b',
-            apiKey                  : process.env.NEO_OPENAI_COMPATIBLE_API_KEY || '',
-            unloadRetryCount        : Number(process.env.NEO_OPENAI_COMPATIBLE_UNLOAD_RETRY_COUNT) || 3,
-            unloadRetryDelayMs      : Number(process.env.NEO_OPENAI_COMPATIBLE_UNLOAD_RETRY_DELAY_MS) || 500,
-            keep_alive              : TIER1_DEFAULTS.openAiCompatible.keep_alive
+            host                 : process.env.NEO_OPENAI_COMPATIBLE_HOST || 'http://127.0.0.1:11434',
+            model                : process.env.NEO_OPENAI_COMPATIBLE_MODEL || 'gemma-4-31b-it',
+            embeddingModel       : process.env.NEO_OPENAI_COMPATIBLE_EMBEDDING_MODEL || 'text-embedding-qwen3-embedding-8b',
+            apiKey               : process.env.NEO_OPENAI_COMPATIBLE_API_KEY || '',
+            unloadRetryCount     : Number(process.env.NEO_OPENAI_COMPATIBLE_UNLOAD_RETRY_COUNT) || 3,
+            unloadRetryDelayMs   : Number(process.env.NEO_OPENAI_COMPATIBLE_UNLOAD_RETRY_DELAY_MS) || 500,
+            keep_alive           : TIER1_DEFAULTS.openAiCompatible.keep_alive,
+            requireParallelModels: TIER1_DEFAULTS.openAiCompatible.requireParallelModels
         });
         expect(Config.localModels).toMatchObject({
             chat: {

--- a/test/playwright/unit/ai/mcp/server/memory-core/config.template.spec.mjs
+++ b/test/playwright/unit/ai/mcp/server/memory-core/config.template.spec.mjs
@@ -114,7 +114,9 @@ test.describe('Memory Core Config (#10010)', () => {
         process.env.NEO_AUTH_REALM = 'tenant-realm';
         process.env.NEO_BACKUP_PATH = '/tmp/neo-memory-backups';
         process.env.NEO_OLLAMA_KEEP_ALIVE = '0';
+        process.env.NEO_OLLAMA_REQUIRE_PARALLEL_MODELS = '3';
         process.env.NEO_OPENAI_COMPATIBLE_KEEP_ALIVE = '10m';
+        process.env.NEO_OPENAI_COMPATIBLE_REQUIRE_PARALLEL_MODELS = '4';
         process.env.NEO_CHROMA_HOST = 'chroma';
         process.env.NEO_CHROMA_PORT = '8010';
 
@@ -127,7 +129,9 @@ test.describe('Memory Core Config (#10010)', () => {
         expect(config.auth.realm).toBe('tenant-realm');
         expect(config.backupPath).toBe('/tmp/neo-memory-backups');
         expect(config.ollama.keep_alive).toBe(0);
+        expect(config.ollama.requireParallelModels).toBe(3);
         expect(config.openAiCompatible.keep_alive).toBe('10m');
+        expect(config.openAiCompatible.requireParallelModels).toBe(4);
         expect(config.engines.chroma).toMatchObject({
             host: 'chroma',
             port: 8010

--- a/test/playwright/unit/ai/scripts/runners/runSandman.spec.mjs
+++ b/test/playwright/unit/ai/scripts/runners/runSandman.spec.mjs
@@ -225,6 +225,35 @@ test.describe('runSandman.mjs provider readiness diagnostics (#10587)', () => {
         expect(warnings[0][0]).toContain('parallel-model capacity probe failed');
     });
 
+    test('warnProviderParallelModelCapacity rejects non-finite requireParallelModels values', async () => {
+        for (const requireParallelModels of [NaN, Infinity, -Infinity]) {
+            const warnings = [];
+            let fetched = false;
+            const result = await providerReadinessHelper.warnProviderParallelModelCapacity({
+                config: {
+                    graphProvider: 'openAiCompatible',
+                    openAiCompatible: {
+                        host          : 'http://oai.test',
+                        model         : 'gemma-4-31b-it',
+                        embeddingModel: 'text-embedding-qwen3-embedding-8b',
+                        requireParallelModels
+                    }
+                },
+                timeoutMs                  : 25,
+                fetchOpenAiCompatibleModels: async () => {
+                    fetched = true;
+                    return [];
+                },
+                log: {warn: (...args) => warnings.push(args)}
+            });
+
+            expect(fetched).toBe(false);
+            expect(result.ready).toBe(false);
+            expect(result.error.message).toContain('requireParallelModels');
+            expect(warnings[0][0]).toContain('parallel-model capacity probe failed');
+        }
+    });
+
     test('ensureLmsModelsLoaded invokes lms load for missing chat and embedding models', async () => {
         const loads = [];
         const modelSnapshots = [

--- a/test/playwright/unit/ai/scripts/runners/runSandman.spec.mjs
+++ b/test/playwright/unit/ai/scripts/runners/runSandman.spec.mjs
@@ -119,6 +119,112 @@ test.describe('runSandman.mjs provider readiness diagnostics (#10587)', () => {
         expect(providerReadinessHelper.getOpenAiCompatibleModelIds({data: null})).toEqual([]);
     });
 
+    test('extracts native Ollama resident model ids from /api/ps variants', () => {
+        expect(providerReadinessHelper.getOllamaRunningModelIds({
+            models: [
+                {name: 'gemma4:31b'},
+                {model: 'qwen3-embedding'},
+                {id: 'fallback-model'},
+                {name: 'gemma4:31b'},
+                {}
+            ]
+        })).toEqual(['gemma4:31b', 'qwen3-embedding', 'fallback-model']);
+
+        expect(providerReadinessHelper.getOllamaRunningModelIds({models: null})).toEqual([]);
+    });
+
+    test('fetchOllamaRunningModelIds probes native Ollama /api/ps', async () => {
+        const calls = [];
+        const result = await providerReadinessHelper.fetchOllamaRunningModelIds({
+            host     : 'http://ollama.test',
+            timeoutMs: 25,
+            fetchFn  : async (url, options) => {
+                calls.push({url, method: options.method});
+                return {
+                    ok  : true,
+                    json: async () => ({
+                        models: [{name: 'gemma4:31b'}, {name: 'qwen3-embedding'}]
+                    })
+                };
+            }
+        });
+
+        expect(result).toEqual(['gemma4:31b', 'qwen3-embedding']);
+        expect(calls).toEqual([{url: 'http://ollama.test/api/ps', method: 'GET'}]);
+    });
+
+    test('warnProviderParallelModelCapacity warns for native Ollama missing the embedding model', async () => {
+        const warnings = [];
+        const result = await providerReadinessHelper.warnProviderParallelModelCapacity({
+            config: {
+                graphProvider: 'ollama',
+                modelProvider: 'openAiCompatible',
+                ollama: {
+                    host                 : 'http://ollama.test',
+                    model                : 'gemma4:31b',
+                    embeddingModel       : 'qwen3-embedding',
+                    requireParallelModels: 2
+                }
+            },
+            timeoutMs        : 25,
+            fetchOllamaModels: async () => ['gemma4:31b'],
+            log              : {warn: (...args) => warnings.push(args)}
+        });
+
+        expect(result.ready).toBe(false);
+        expect(result.missingModels).toEqual(['qwen3-embedding']);
+        expect(result.warning).toContain('set OLLAMA_MAX_LOADED_MODELS=2');
+        expect(warnings).toHaveLength(1);
+        expect(warnings[0][0]).toContain('[provider/ollama]');
+    });
+
+    test('warnProviderParallelModelCapacity passes when OpenAI-compatible lists both models', async () => {
+        const warnings = [];
+        const result = await providerReadinessHelper.warnProviderParallelModelCapacity({
+            config: {
+                graphProvider: 'openAiCompatible',
+                modelProvider: 'gemini',
+                openAiCompatible: {
+                    host                 : 'http://oai.test',
+                    model                : 'gemma-4-31b-it',
+                    embeddingModel       : 'text-embedding-qwen3-embedding-8b',
+                    requireParallelModels: 2
+                }
+            },
+            timeoutMs                     : 25,
+            fetchOpenAiCompatibleModels   : async () => ['gemma-4-31b-it', 'text-embedding-qwen3-embedding-8b'],
+            log                           : {warn: (...args) => warnings.push(args)}
+        });
+
+        expect(result).toMatchObject({
+            ready                : true,
+            provider             : 'openAiCompatible',
+            requireParallelModels: 2,
+            missingModels        : []
+        });
+        expect(warnings).toEqual([]);
+    });
+
+    test('warnProviderParallelModelCapacity warns when requireParallelModels is missing', async () => {
+        const warnings = [];
+        const result = await providerReadinessHelper.warnProviderParallelModelCapacity({
+            config: {
+                graphProvider: 'openAiCompatible',
+                openAiCompatible: {
+                    host          : 'http://oai.test',
+                    model         : 'gemma-4-31b-it',
+                    embeddingModel: 'text-embedding-qwen3-embedding-8b'
+                }
+            },
+            timeoutMs: 25,
+            log      : {warn: (...args) => warnings.push(args)}
+        });
+
+        expect(result.ready).toBe(false);
+        expect(result.error.message).toContain('requireParallelModels');
+        expect(warnings[0][0]).toContain('parallel-model capacity probe failed');
+    });
+
     test('ensureLmsModelsLoaded invokes lms load for missing chat and embedding models', async () => {
         const loads = [];
         const modelSnapshots = [


### PR DESCRIPTION
Resolves #12090

Authored by GPT-5.5 (Codex Desktop). Session 019e6696-e50d-7e80-a8e3-b3cfb3639ba5.
FAIR-band: in-band [13/30 - current author count over last 30 merged].

Adds the remaining #12090 read-side substrate after PR #12112 handled LM Studio pre-warm: Neo now declares provider-level parallel-model expectations, probes the configured graph provider at the existing DreamService provider-readiness boundary, and emits a non-blocking WARN when chat + embedding model coexistence is not observable.

Evidence: L2 unit coverage for config propagation, Ollama /api/ps parsing, OpenAI-compatible /v1/models parsing, and warning envelopes; local runtime import probe confirms config-backed success path. L4 live provider validation remains post-merge because the warning depends on the operator deployment state.

## Deltas From Ticket

- AC1-AC2: adds `ollama.requireParallelModels` and `openAiCompatible.requireParallelModels`, default `2`, with env overrides.
- AC3: adds native Ollama `/api/ps` resident-model enumeration and WARN text naming `OLLAMA_MAX_LOADED_MODELS`.
- AC4: reuses OpenAI-compatible `/v1/models` enumeration for the symmetric warning path.
- AC5: extends focused Sandman/provider-readiness unit coverage for both provider families.
- AC6: documents the multi-model mandate in `DeploymentCookbook.md` and `SharedDeployment.md`.
- AC7: migration note is below; existing deployments without the underlying provider cap see WARN only, not a boot block.
- AC8 was already shipped by PR #12112. This PR intentionally does not touch `TaskDefinitions.mjs` or `loadLmsModel`.

## Contract Ledger

| Surface | Before | After | Consumer |
|---|---|---|---|
| `aiConfig.ollama.requireParallelModels` | absent | default `2`, env-backed by `NEO_OLLAMA_REQUIRE_PARALLEL_MODELS` | DreamService capacity warning for native Ollama graph provider |
| `aiConfig.openAiCompatible.requireParallelModels` | absent | default `2`, env-backed by `NEO_OPENAI_COMPATIBLE_REQUIRE_PARALLEL_MODELS` | DreamService capacity warning for OpenAI-compatible graph provider |
| Memory Core config overlay | provider blocks had `keep_alive` only | mirrors `requireParallelModels` from Tier-1 config | MC/DreamService consumers using `Memory_Config` shape |
| Provider readiness helper | reachability only (`/api/tags` or `/v1/models`) | adds read-only model-residency probes and warning envelopes | DreamService `checkProviderReadiness()` after reachability passes |
| Native Ollama probe | none | `GET /api/ps`, extract `models[].name/model/id` | warns if configured chat or embedding model is not resident |
| OpenAI-compatible probe | `/v1/models` reachability + LMS pre-warm helper | `/v1/models` ids also feed capacity warning | warns if both configured model ids are not listed |
| Boot behavior | provider unreachable could fail REM cycle | provider reachable but under-capacity only WARNs | no boot-blocking regression |

## MCP Config Template Change

Changed config keys:
- `ollama.requireParallelModels`
- `openAiCompatible.requireParallelModels`

New env vars:
- `NEO_OLLAMA_REQUIRE_PARALLEL_MODELS`
- `NEO_OPENAI_COMPATIBLE_REQUIRE_PARALLEL_MODELS`

Local follow-up: gitignored `ai/config.mjs` and `ai/mcp/server/memory-core/config.mjs` need the new keys after merge. I refreshed my local ignored overlays for validation, but no `config.mjs` files are committed. Harness/orchestrator restart is recommended after pulling the merge so running processes read the new keys.

## Substrate Slot Rationale

- `learn/agentos/DeploymentCookbook.md` local-model profile paragraph: disposition `keep`; trigger-frequency medium (local-provider/cloud deployment setup), failure-severity high (model-swap ping-pong can break Sandman economics), enforceability medium (config + WARN path makes the deployment check observable).
- `learn/agentos/SharedDeployment.md` local-provider model residency section: disposition `keep`; trigger-frequency medium (shared/local provider setup), failure-severity high, enforceability medium via `requireParallelModels` and provider-readiness logging.

These are docs in conditional deployment guides, not always-loaded turn substrate. They add operator recovery context directly adjacent to the provider configuration surfaces they explain.

## Test Evidence

- `node --check ai/services/graph/ProviderReadinessHelper.mjs` passed.
- `node --check ai/daemons/orchestrator/services/DreamService.mjs` passed.
- `node --check ai/config.template.mjs` passed.
- `node --check ai/mcp/server/memory-core/config.template.mjs` passed.
- `git diff --check` passed.
- `npm run test-unit -- test/playwright/unit/ai/scripts/runners/runSandman.spec.mjs test/playwright/unit/ai/config.template.spec.mjs test/playwright/unit/ai/mcp/server/memory-core/config.template.spec.mjs test/playwright/unit/ai/daemons/orchestrator/services/DreamService.executeRemCycle.spec.mjs` - 41/41 passed.
- Local runtime import probe: `probeProviderParallelModelCapacity()` returned ready for configured OpenAI-compatible chat + embedding model ids with `requireParallelModels=2`.

## Out of Scope

- #12117 `loadLmsModel --context-length` threading. That is Claude-owned write-side work and intentionally separate from this read-side warning lane.
- Mutating provider server caps. Ollama `OLLAMA_MAX_LOADED_MODELS` and OpenAI-compatible loaded-model caps remain operator/server settings.
- Live Sandman L4 verification. This PR makes the warning observable; an operator deployment run must prove the actual provider is configured correctly.

## Post-Merge Validation

- [ ] Pull dev and sync ignored `ai/config.mjs` plus `ai/mcp/server/memory-core/config.mjs` from templates or with the local overlay procedure.
- [ ] Restart orchestrator/MCP harnesses so the new config leaves are loaded.
- [ ] For native Ollama: run with `OLLAMA_MAX_LOADED_MODELS=2`, pre-load chat + embedding, verify `/api/ps` shows both names, then run Sandman and confirm no capacity WARN.
- [ ] For OpenAI-compatible: verify `/v1/models` lists both configured ids and Sandman emits no capacity WARN.
- [ ] Intentionally run with only one resident/listed model once and confirm the WARN names the missing model and corrective cap.

## Related

- PR #12112 handled the LM Studio pre-warm sub-scope of #12090.
- #12117 handles context-length threading for `lms load`; complementary but not part of this PR.
- #12089 supplied the `keep_alive=-1` substrate; this PR guards the multi-model coexistence requirement that makes keep-alive effective.

## Commit

- `0148f6111` - `feat(ai): warn on provider model capacity gaps (#12090)`