### PR TITLE
feat(ai): thread --context-length through loadLmsModel from localModels role-keyed limits (#12117)

### DIFF
--- a/ai/daemons/orchestrator/Orchestrator.mjs
+++ b/ai/daemons/orchestrator/Orchestrator.mjs
@@ -435,6 +435,30 @@ export class Orchestrator extends Base {
             AiConfig.openAiCompatible?.embeddingModel
         ].filter(Boolean))];
     }
+    /**
+     * Per-model `--context-length` overrides for the orchestrator-managed `lms load`
+     * invocation. Keyed by model id; values flow from the role-keyed
+     * `aiConfig.localModels.{chat,embedding}.contextLimitTokens` so the loaded-cap
+     * matches the neo-side consumer-friction threshold. Closes the silent
+     * context-mismatch failure mode (loaded modelfile-default cap < prompt-size →
+     * empty downstream body).
+     * @member {Object}
+     */
+    get lmsContextLengths() {
+        const map     = {};
+        const chat    = AiConfig.openAiCompatible?.model;
+        const embed   = AiConfig.openAiCompatible?.embeddingModel;
+        const chatCap = AiConfig.localModels?.chat?.contextLimitTokens;
+        const embCap  = AiConfig.localModels?.embedding?.contextLimitTokens;
+
+        if (chat && typeof chatCap === 'number' && Number.isFinite(chatCap)) {
+            map[chat] = chatCap;
+        }
+        if (embed && typeof embCap === 'number' && Number.isFinite(embCap)) {
+            map[embed] = embCap;
+        }
+        return map;
+    }
 
     /**
      * Starts the orchestrator process loop after the wrapper has selected this process.
@@ -479,6 +503,7 @@ export class Orchestrator extends Base {
             lmsModels : this.lmsModels,
             lmsHost   : this.lmsHost,
             lmsPort   : this.lmsPort,
+            lmsContextLengths: this.lmsContextLengths,
             providerReadiness: AiConfig.orchestrator.providerReadiness
         });
 

--- a/ai/daemons/orchestrator/Orchestrator.mjs
+++ b/ai/daemons/orchestrator/Orchestrator.mjs
@@ -10,6 +10,7 @@ import Base                        from '../../../src/core/Base.mjs';
 import ClassSystemUtil             from '../../../src/util/ClassSystem.mjs';
 import Env                         from '../../../src/util/Env.mjs';
 import AiConfig                    from '../../config.mjs';
+import {buildLmsContextLengthsMap} from '../../services/graph/ProviderReadinessHelper.mjs';
 import HealthService               from '../../services/memory-core/HealthService.mjs';
 import SQLite                      from '../../graph/storage/SQLite.mjs';
 import MaintenanceBackpressureService, {
@@ -435,30 +436,6 @@ export class Orchestrator extends Base {
             AiConfig.openAiCompatible?.embeddingModel
         ].filter(Boolean))];
     }
-    /**
-     * Per-model `--context-length` overrides for the orchestrator-managed `lms load`
-     * invocation. Keyed by model id; values flow from the role-keyed
-     * `aiConfig.localModels.{chat,embedding}.contextLimitTokens` so the loaded-cap
-     * matches the neo-side consumer-friction threshold. Closes the silent
-     * context-mismatch failure mode (loaded modelfile-default cap < prompt-size →
-     * empty downstream body).
-     * @member {Object}
-     */
-    get lmsContextLengths() {
-        const map     = {};
-        const chat    = AiConfig.openAiCompatible?.model;
-        const embed   = AiConfig.openAiCompatible?.embeddingModel;
-        const chatCap = AiConfig.localModels?.chat?.contextLimitTokens;
-        const embCap  = AiConfig.localModels?.embedding?.contextLimitTokens;
-
-        if (chat && typeof chatCap === 'number' && Number.isFinite(chatCap)) {
-            map[chat] = chatCap;
-        }
-        if (embed && typeof embCap === 'number' && Number.isFinite(embCap)) {
-            map[embed] = embCap;
-        }
-        return map;
-    }
 
     /**
      * Starts the orchestrator process loop after the wrapper has selected this process.
@@ -503,7 +480,12 @@ export class Orchestrator extends Base {
             lmsModels : this.lmsModels,
             lmsHost   : this.lmsHost,
             lmsPort   : this.lmsPort,
-            lmsContextLengths: this.lmsContextLengths,
+            lmsContextLengths: buildLmsContextLengthsMap({
+                chatModel             : AiConfig.openAiCompatible?.model,
+                embeddingModel        : AiConfig.openAiCompatible?.embeddingModel,
+                chatContextLength     : AiConfig.localModels?.chat?.contextLimitTokens,
+                embeddingContextLength: AiConfig.localModels?.embedding?.contextLimitTokens
+            }),
             providerReadiness: AiConfig.orchestrator.providerReadiness
         });
 

--- a/ai/daemons/orchestrator/TaskDefinitions.mjs
+++ b/ai/daemons/orchestrator/TaskDefinitions.mjs
@@ -35,6 +35,7 @@ export const DEFAULT_SCRIPT_DIR = path.resolve(__dirname, '../../scripts');
  * @param {String[]} [options.lmsModels] LM Studio model identifiers that must be resident after spawn.
  * @param {String} [options.lmsHost] OpenAI-compatible host exposed by the LM Studio server.
  * @param {String|Number} [options.lmsPort] LM Studio OpenAI-compatible local inference port (CLI default `1234`).
+ * @param {Object} [options.lmsContextLengths] Per-model `--context-length` override map keyed by model id (chat + embedding from `aiConfig.localModels.{chat,embedding}.contextLimitTokens`).
  * @param {Object} [options.providerReadiness] Provider-readiness retry / timeout config.
  * @returns {Object}
  */
@@ -49,6 +50,7 @@ export function buildTaskDefinitions({
     lmsModels,
     lmsHost,
     lmsPort,
+    lmsContextLengths,
     providerReadiness
 } = {}) {
     const tasks = {
@@ -145,11 +147,12 @@ export function buildTaskDefinitions({
                 const {ensureLmsModelsLoaded} = await import('../../services/graph/ProviderReadinessHelper.mjs');
 
                 return ensureLmsModelsLoaded({
-                    host     : lmsHost,
-                    models   : requiredModels,
-                    attempts : providerReadiness?.attempts,
-                    delayMs  : providerReadiness?.delayMs,
-                    timeoutMs: providerReadiness?.timeoutMs
+                    host           : lmsHost,
+                    models         : requiredModels,
+                    contextLengths : lmsContextLengths,
+                    attempts       : providerReadiness?.attempts,
+                    delayMs        : providerReadiness?.delayMs,
+                    timeoutMs      : providerReadiness?.timeoutMs
                 });
             }
         };

--- a/ai/services/graph/ProviderReadinessHelper.mjs
+++ b/ai/services/graph/ProviderReadinessHelper.mjs
@@ -142,7 +142,7 @@ export function loadLmsModel(model, {execFileFn = execFile, contextLength} = {})
     }
 
     const args = ['load', model];
-    if (typeof contextLength === 'number' && Number.isFinite(contextLength)) {
+    if (Neo.isNumber(contextLength)) {
         args.push('--context-length', String(contextLength));
     }
 
@@ -186,7 +186,7 @@ export function buildLmsContextLengthsMap({
 } = {}) {
     const map = {};
     const setMax = (modelId, value) => {
-        if (!modelId || typeof value !== 'number' || !Number.isFinite(value)) {
+        if (!modelId || !Neo.isNumber(value)) {
             return;
         }
         // Same-model chat+embedding edge: when both roles share a model id (operator
@@ -288,8 +288,7 @@ export async function ensureLmsModelsLoaded({
     // BUT preserve the declared requiredModels input order (filter rather than concat-dedupe).
     const modelsToLoad = requiredModels.filter(model => {
         if (initialMissing.includes(model)) return true;
-        const cap = contextLengths?.[model];
-        return typeof cap === 'number' && Number.isFinite(cap);
+        return Neo.isNumber(contextLengths?.[model]);
     });
     const loadedModels = [...modelsToLoad];
 
@@ -305,7 +304,7 @@ export async function ensureLmsModelsLoaded({
 
     for (const model of modelsToLoad) {
         const contextLength = contextLengths?.[model];
-        const contextSuffix = typeof contextLength === 'number' && Number.isFinite(contextLength)
+        const contextSuffix = Neo.isNumber(contextLength)
             ? ` --context-length ${contextLength}`
             : '';
         const reason = initialMissing.includes(model)

--- a/ai/services/graph/ProviderReadinessHelper.mjs
+++ b/ai/services/graph/ProviderReadinessHelper.mjs
@@ -122,20 +122,32 @@ export async function fetchOllamaRunningModelIds({host, timeoutMs, fetchFn = fet
 }
 
 /**
- * @summary Invokes `lms load <model>` for one LM Studio model.
+ * @summary Invokes `lms load <model> [--context-length <N>]` for one LM Studio model.
+ *
+ * When `contextLength` is provided, appends `--context-length <N>` to the `lms`
+ * CLI arguments so the model loads with the operator-declared context window
+ * instead of the modelfile default (typically 4K-8K). Closes the silent
+ * context-mismatch failure mode where downstream chat invocations exceed the
+ * loaded-model cap and return empty bodies.
  *
  * @param {String} model LM Studio model identifier.
  * @param {Object} [options]
  * @param {Function} [options.execFileFn=execFile] Child-process seam for tests.
- * @returns {Promise<void>}
+ * @param {Number} [options.contextLength] LM Studio loaded-model context-window override (tokens).
+ * @returns {Promise<{stdout: String, stderr: String}>}
  */
-export function loadLmsModel(model, {execFileFn = execFile} = {}) {
+export function loadLmsModel(model, {execFileFn = execFile, contextLength} = {}) {
     if (!model) {
         return Promise.reject(new TypeError('loadLmsModel: model is required'));
     }
 
+    const args = ['load', model];
+    if (typeof contextLength === 'number' && Number.isFinite(contextLength)) {
+        args.push('--context-length', String(contextLength));
+    }
+
     return new Promise((resolve, reject) => {
-        execFileFn('lms', ['load', model], (error, stdout = '', stderr = '') => {
+        execFileFn('lms', args, (error, stdout = '', stderr = '') => {
             if (error) {
                 reject(new Error(`lms load ${model} failed: ${error.message}${stderr ? `; stderr=${stderr.trim()}` : ''}`));
                 return;
@@ -155,12 +167,20 @@ export function loadLmsModel(model, {execFileFn = execFile} = {}) {
  * endpoint enumerates both. Parameters come from config-owned callers so the helper
  * has no hidden retry or timeout defaults.
  *
+ * Per-model context-length overrides flow through the optional `contextLengths`
+ * map (`{[modelId]: tokens}`). When present, the helper invokes
+ * `lms load <model> --context-length <N>` for that model so the loaded context
+ * window matches the neo-side `aiConfig.localModels.{chat,embedding}.contextLimitTokens`
+ * threshold. Closes the silent context-mismatch failure mode (loaded-cap <
+ * prompt-size → empty downstream body).
+ *
  * @param {Object} options
  * @param {String} options.host OpenAI-compatible host.
  * @param {String[]} options.models Required resident model ids.
  * @param {Number} options.attempts Probe attempts after load.
  * @param {Number} options.delayMs Delay between probes.
  * @param {Number} options.timeoutMs HTTP probe timeout.
+ * @param {Object} [options.contextLengths] Per-model context-length override map keyed by model id.
  * @param {Function} [options.fetchModelIds] Injectable model-list probe.
  * @param {Function} [options.loadModel] Injectable model-load function.
  * @param {Object} [options.log=logger] Logger seam.
@@ -172,8 +192,9 @@ export async function ensureLmsModelsLoaded({
     attempts,
     delayMs,
     timeoutMs,
+    contextLengths = {},
     fetchModelIds = opts => fetchOpenAiCompatibleModelIds(opts),
-    loadModel     = model => loadLmsModel(model),
+    loadModel     = (model, options) => loadLmsModel(model, options),
     log           = logger
 } = {}) {
     if (!Array.isArray(models) || models.length === 0) {
@@ -224,8 +245,12 @@ export async function ensureLmsModelsLoaded({
     }
 
     for (const model of missingModels) {
-        log.info?.(`[ProviderReadinessHelper] Loading LM Studio model '${model}' via lms load.`);
-        await loadModel(model);
+        const contextLength = contextLengths?.[model];
+        const contextSuffix = typeof contextLength === 'number' && Number.isFinite(contextLength)
+            ? ` --context-length ${contextLength}`
+            : '';
+        log.info?.(`[ProviderReadinessHelper] Loading LM Studio model '${model}' via lms load${contextSuffix}.`);
+        await loadModel(model, {contextLength});
     }
 
     const startedAt = Date.now();

--- a/ai/services/graph/ProviderReadinessHelper.mjs
+++ b/ai/services/graph/ProviderReadinessHelper.mjs
@@ -185,12 +185,20 @@ export function buildLmsContextLengthsMap({
     embeddingContextLength
 } = {}) {
     const map = {};
-    if (chatModel && typeof chatContextLength === 'number' && Number.isFinite(chatContextLength)) {
-        map[chatModel] = chatContextLength;
-    }
-    if (embeddingModel && typeof embeddingContextLength === 'number' && Number.isFinite(embeddingContextLength)) {
-        map[embeddingModel] = embeddingContextLength;
-    }
+    const setMax = (modelId, value) => {
+        if (!modelId || typeof value !== 'number' || !Number.isFinite(value)) {
+            return;
+        }
+        // Same-model chat+embedding edge: when both roles share a model id (operator
+        // points chat + embedding at the same identifier), keep the LARGER cap so
+        // the role with the bigger context-window envelope is not silently capped
+        // by the smaller role's threshold.
+        if (map[modelId] === undefined || value > map[modelId]) {
+            map[modelId] = value;
+        }
+    };
+    setMax(chatModel, chatContextLength);
+    setMax(embeddingModel, embeddingContextLength);
     return map;
 }
 
@@ -267,10 +275,25 @@ export async function ensureLmsModelsLoaded({
     };
 
     let {availableModels} = await probeModels('initial /v1/models probe');
-    let missingModels   = getMissing(availableModels);
-    const loadedModels  = [...missingModels];
+    const initialMissing  = getMissing(availableModels);
 
-    if (missingModels.length === 0) {
+    // Force-include context-configured models in the load set even when already
+    // resident in /v1/models. `/v1/models` reports presence only — it does NOT
+    // expose the loaded context window, so model-id presence is insufficient to
+    // confirm the loaded cap matches the operator-declared threshold. Without
+    // this re-load, the exact #12117 regression survives orchestrator restarts:
+    // a model loaded with the modelfile-default context window (~4K-8K) would
+    // be accepted as ready while every chat invocation silently overflows.
+    // Force-include each context-configured model in the load set even if resident,
+    // BUT preserve the declared requiredModels input order (filter rather than concat-dedupe).
+    const modelsToLoad = requiredModels.filter(model => {
+        if (initialMissing.includes(model)) return true;
+        const cap = contextLengths?.[model];
+        return typeof cap === 'number' && Number.isFinite(cap);
+    });
+    const loadedModels = [...modelsToLoad];
+
+    if (modelsToLoad.length === 0) {
         return {
             ready       : true,
             loadedModels: [],
@@ -280,14 +303,19 @@ export async function ensureLmsModelsLoaded({
         };
     }
 
-    for (const model of missingModels) {
+    for (const model of modelsToLoad) {
         const contextLength = contextLengths?.[model];
         const contextSuffix = typeof contextLength === 'number' && Number.isFinite(contextLength)
             ? ` --context-length ${contextLength}`
             : '';
-        log.info?.(`[ProviderReadinessHelper] Loading LM Studio model '${model}' via lms load${contextSuffix}.`);
+        const reason = initialMissing.includes(model)
+            ? 'missing from /v1/models'
+            : 'context-length enforcement on resident model';
+        log.info?.(`[ProviderReadinessHelper] Loading LM Studio model '${model}' via lms load${contextSuffix} (${reason}).`);
         await loadModel(model, {contextLength});
     }
+
+    let missingModels = initialMissing;
 
     const startedAt = Date.now();
     for (let attempt = 1; attempt <= attempts; attempt++) {

--- a/ai/services/graph/ProviderReadinessHelper.mjs
+++ b/ai/services/graph/ProviderReadinessHelper.mjs
@@ -1,6 +1,5 @@
 import http from 'http';
 import {execFile} from 'child_process';
-import Neo from '../../../src/Neo.mjs';
 import {Memory_Config as aiConfig} from '../../services.mjs';
 import logger from '../../mcp/server/memory-core/logger.mjs';
 import {isGraphModelProviderSupported, resolveGraphModelProvider} from './providerDispatch.mjs';

--- a/ai/services/graph/ProviderReadinessHelper.mjs
+++ b/ai/services/graph/ProviderReadinessHelper.mjs
@@ -159,6 +159,42 @@ export function loadLmsModel(model, {execFileFn = execFile, contextLength} = {})
 }
 
 /**
+ * @summary Builds the per-model `--context-length` override map for `ensureLmsModelsLoaded`.
+ *
+ * Composes the resolved chat + embedding model identifiers with their respective
+ * role-keyed context-length thresholds into the `{[modelId]: tokens}` shape the
+ * helper's `contextLengths` parameter consumes. Callers (Orchestrator boot path)
+ * resolve the four inputs from their own config substrate and pass them in —
+ * keeps this helper module decoupled from any specific config-shape source.
+ *
+ * Skips entries when the model id is missing OR the context-length is not a
+ * finite number, so partially-configured deployments produce a partial map
+ * rather than corrupted entries.
+ *
+ * @param {Object} options
+ * @param {String} [options.chatModel] Chat model identifier (e.g. `aiConfig.openAiCompatible.model`).
+ * @param {String} [options.embeddingModel] Embedding model identifier.
+ * @param {Number} [options.chatContextLength] Chat-role context window in tokens.
+ * @param {Number} [options.embeddingContextLength] Embedding-role context window in tokens.
+ * @returns {Object} Map keyed by model id with finite-number context-length values.
+ */
+export function buildLmsContextLengthsMap({
+    chatModel,
+    embeddingModel,
+    chatContextLength,
+    embeddingContextLength
+} = {}) {
+    const map = {};
+    if (chatModel && typeof chatContextLength === 'number' && Number.isFinite(chatContextLength)) {
+        map[chatModel] = chatContextLength;
+    }
+    if (embeddingModel && typeof embeddingContextLength === 'number' && Number.isFinite(embeddingContextLength)) {
+        map[embeddingModel] = embeddingContextLength;
+    }
+    return map;
+}
+
+/**
  * @summary Ensures LM Studio has all configured OpenAI-compatible models loaded.
  *
  * The orchestrator-owned `lms server start` task gets the server process running;

--- a/test/playwright/unit/ai/daemons/orchestrator/Orchestrator.invariants.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/Orchestrator.invariants.spec.mjs
@@ -242,6 +242,45 @@ test.describe('Orchestrator config getters delegate to AiConfig (envBindings is 
         expect(createMinimalOrchestrator().lmsEnabled).toBe(false);
     });
 
+    test('lmsContextLengths getter builds per-model map from AiConfig.localModels.{chat,embedding}.contextLimitTokens (#12117)', () => {
+        AiConfig.openAiCompatible = {
+            host          : 'http://127.0.0.1:1234',
+            model         : 'chat-from-config',
+            embeddingModel: 'embedding-from-config'
+        };
+
+        const savedLocalModels = AiConfig.localModels ? {
+            chat     : AiConfig.localModels.chat ? {...AiConfig.localModels.chat} : undefined,
+            embedding: AiConfig.localModels.embedding ? {...AiConfig.localModels.embedding} : undefined
+        } : undefined;
+
+        try {
+            AiConfig.localModels = {
+                chat     : {contextLimitTokens: 262144, safeProcessingLimitTokens: 200000},
+                embedding: {contextLimitTokens: 8192,   safeProcessingLimitTokens: 6144}
+            };
+            const o = createMinimalOrchestrator();
+            expect(o.lmsContextLengths).toEqual({
+                'chat-from-config'     : 262144,
+                'embedding-from-config': 8192
+            });
+
+            // Defensive: missing config keys produce empty map, not undefined/NaN
+            AiConfig.localModels = {chat: {}, embedding: {}};
+            expect(createMinimalOrchestrator().lmsContextLengths).toEqual({});
+
+            // Partial config: only chat present
+            AiConfig.localModels = {chat: {contextLimitTokens: 99999}, embedding: undefined};
+            expect(createMinimalOrchestrator().lmsContextLengths).toEqual({'chat-from-config': 99999});
+        } finally {
+            if (savedLocalModels === undefined) {
+                delete AiConfig.localModels;
+            } else {
+                AiConfig.localModels = savedLocalModels;
+            }
+        }
+    });
+
     test('lms getters undefined-safe when AiConfig.orchestrator.lms is missing', () => {
         delete AiConfig.orchestrator.lms;
 

--- a/test/playwright/unit/ai/daemons/orchestrator/Orchestrator.invariants.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/Orchestrator.invariants.spec.mjs
@@ -242,44 +242,6 @@ test.describe('Orchestrator config getters delegate to AiConfig (envBindings is 
         expect(createMinimalOrchestrator().lmsEnabled).toBe(false);
     });
 
-    test('lmsContextLengths getter builds per-model map from AiConfig.localModels.{chat,embedding}.contextLimitTokens (#12117)', () => {
-        AiConfig.openAiCompatible = {
-            host          : 'http://127.0.0.1:1234',
-            model         : 'chat-from-config',
-            embeddingModel: 'embedding-from-config'
-        };
-
-        const savedLocalModels = AiConfig.localModels ? {
-            chat     : AiConfig.localModels.chat ? {...AiConfig.localModels.chat} : undefined,
-            embedding: AiConfig.localModels.embedding ? {...AiConfig.localModels.embedding} : undefined
-        } : undefined;
-
-        try {
-            AiConfig.localModels = {
-                chat     : {contextLimitTokens: 262144, safeProcessingLimitTokens: 200000},
-                embedding: {contextLimitTokens: 8192,   safeProcessingLimitTokens: 6144}
-            };
-            const o = createMinimalOrchestrator();
-            expect(o.lmsContextLengths).toEqual({
-                'chat-from-config'     : 262144,
-                'embedding-from-config': 8192
-            });
-
-            // Defensive: missing config keys produce empty map, not undefined/NaN
-            AiConfig.localModels = {chat: {}, embedding: {}};
-            expect(createMinimalOrchestrator().lmsContextLengths).toEqual({});
-
-            // Partial config: only chat present
-            AiConfig.localModels = {chat: {contextLimitTokens: 99999}, embedding: undefined};
-            expect(createMinimalOrchestrator().lmsContextLengths).toEqual({'chat-from-config': 99999});
-        } finally {
-            if (savedLocalModels === undefined) {
-                delete AiConfig.localModels;
-            } else {
-                AiConfig.localModels = savedLocalModels;
-            }
-        }
-    });
 
     test('lms getters undefined-safe when AiConfig.orchestrator.lms is missing', () => {
         delete AiConfig.orchestrator.lms;

--- a/test/playwright/unit/ai/scripts/runners/runSandman.spec.mjs
+++ b/test/playwright/unit/ai/scripts/runners/runSandman.spec.mjs
@@ -282,7 +282,7 @@ test.describe('runSandman.mjs provider readiness diagnostics (#10587)', () => {
         });
     });
 
-    test('ensureLmsModelsLoaded skips lms load when both models are already resident', async () => {
+    test('ensureLmsModelsLoaded skips lms load when both models are already resident AND no contextLengths configured', async () => {
         const loads = [];
 
         const result = await providerReadinessHelper.ensureLmsModelsLoaded({
@@ -301,6 +301,61 @@ test.describe('runSandman.mjs provider readiness diagnostics (#10587)', () => {
             loadedModels: [],
             attempts    : 1
         });
+    });
+
+    test('ensureLmsModelsLoaded force-reloads context-configured models even when already resident (#12117 RA1 — closes silent wrong-context regression)', async () => {
+        const loadCalls = [];
+
+        const result = await providerReadinessHelper.ensureLmsModelsLoaded({
+            host          : 'http://127.0.0.1:1234',
+            models        : ['chat-model', 'embedding-model'],
+            contextLengths: {'chat-model': 262144, 'embedding-model': 8192},
+            attempts      : 1,
+            delayMs       : 0,
+            timeoutMs     : 50,
+            // Both models ALREADY resident — without the RA1 fix, this scenario returned
+            // ready with zero loadModel calls, leaving any modelfile-default loaded
+            // context window in place. With the fix, context-configured models are
+            // force-included in the load set.
+            fetchModelIds : async () => ['chat-model', 'embedding-model'],
+            loadModel     : async (model, options) => loadCalls.push({model, contextLength: options?.contextLength}),
+            log           : {info: () => {}}
+        });
+
+        expect(loadCalls).toEqual([
+            {model: 'chat-model',      contextLength: 262144},
+            {model: 'embedding-model', contextLength: 8192}
+        ]);
+        expect(result.ready).toBe(true);
+        expect(result.loadedModels).toEqual(['chat-model', 'embedding-model']);
+    });
+
+    test('ensureLmsModelsLoaded mixes missing + context-configured force-reload paths correctly (#12117 RA1)', async () => {
+        const loadCalls = [];
+        const modelSnapshots = [
+            ['chat-model'],                      // chat resident, embedding missing
+            ['chat-model', 'embedding-model']    // post-load: both present
+        ];
+
+        const result = await providerReadinessHelper.ensureLmsModelsLoaded({
+            host          : 'http://127.0.0.1:1234',
+            models        : ['chat-model', 'embedding-model'],
+            // Only chat has a configured context-length; embedding must still load as missing
+            contextLengths: {'chat-model': 262144},
+            attempts      : 2,
+            delayMs       : 0,
+            timeoutMs     : 50,
+            fetchModelIds : async () => modelSnapshots.shift() || ['chat-model', 'embedding-model'],
+            loadModel     : async (model, options) => loadCalls.push({model, contextLength: options?.contextLength}),
+            log           : {info: () => {}}
+        });
+
+        // Both models should load: embedding because missing, chat because context-configured
+        expect(loadCalls).toEqual([
+            {model: 'chat-model',      contextLength: 262144},
+            {model: 'embedding-model', contextLength: undefined}
+        ]);
+        expect(result.ready).toBe(true);
     });
 
     test('ensureLmsModelsLoaded fails loud when readiness config is incomplete', async () => {
@@ -403,6 +458,34 @@ test.describe('runSandman.mjs provider readiness diagnostics (#10587)', () => {
                 chatContextLength: bad
             })).toEqual({});
         }
+    });
+
+    test('buildLmsContextLengthsMap preserves max cap when chat and embedding share a model id (#12117 RA2)', () => {
+        // Same model id for both roles — must not let smaller embedding cap overwrite
+        // the larger chat cap (would silently break chat invocations).
+        expect(providerReadinessHelper.buildLmsContextLengthsMap({
+            chatModel             : 'shared-model',
+            embeddingModel        : 'shared-model',
+            chatContextLength     : 262144,
+            embeddingContextLength: 8192
+        })).toEqual({'shared-model': 262144});
+
+        // Order independence: same result if smaller declared first (already handled
+        // because the setMax helper compares both directions)
+        expect(providerReadinessHelper.buildLmsContextLengthsMap({
+            chatModel             : 'shared-model',
+            embeddingModel        : 'shared-model',
+            chatContextLength     : 8192,
+            embeddingContextLength: 262144
+        })).toEqual({'shared-model': 262144});
+
+        // Same value both roles: idempotent
+        expect(providerReadinessHelper.buildLmsContextLengthsMap({
+            chatModel             : 'shared-model',
+            embeddingModel        : 'shared-model',
+            chatContextLength     : 99999,
+            embeddingContextLength: 99999
+        })).toEqual({'shared-model': 99999});
     });
 
     test('buildLmsContextLengthsMap returns partial map when only one role is configured (#12117)', () => {

--- a/test/playwright/unit/ai/scripts/runners/runSandman.spec.mjs
+++ b/test/playwright/unit/ai/scripts/runners/runSandman.spec.mjs
@@ -310,6 +310,78 @@ test.describe('runSandman.mjs provider readiness diagnostics (#10587)', () => {
         })).rejects.toThrow(/attempts.*delayMs.*timeoutMs.*required/);
     });
 
+    test('ensureLmsModelsLoaded threads per-model contextLengths into loadModel invocations (#12117)', async () => {
+        const loadCalls = [];
+        const modelSnapshots = [
+            [],
+            ['chat-model', 'embedding-model']
+        ];
+
+        const result = await providerReadinessHelper.ensureLmsModelsLoaded({
+            host          : 'http://127.0.0.1:1234',
+            models        : ['chat-model', 'embedding-model'],
+            contextLengths: {'chat-model': 262144, 'embedding-model': 8192},
+            attempts      : 2,
+            delayMs       : 0,
+            timeoutMs     : 50,
+            fetchModelIds : async () => modelSnapshots.shift() || ['chat-model', 'embedding-model'],
+            loadModel     : async (model, options) => loadCalls.push({model, options}),
+            log           : {info: () => {}}
+        });
+
+        expect(loadCalls).toEqual([
+            {model: 'chat-model',      options: {contextLength: 262144}},
+            {model: 'embedding-model', options: {contextLength: 8192}}
+        ]);
+        expect(result.ready).toBe(true);
+        expect(result.loadedModels).toEqual(['chat-model', 'embedding-model']);
+    });
+
+    test('loadLmsModel appends --context-length to execFile args when provided (#12117)', async () => {
+        const execCalls = [];
+        const execFileStub = (cmd, args, callback) => {
+            execCalls.push({cmd, args});
+            callback(null, '', '');
+        };
+
+        await providerReadinessHelper.loadLmsModel('chat-model', {
+            execFileFn   : execFileStub,
+            contextLength: 262144
+        });
+
+        expect(execCalls).toEqual([
+            {cmd: 'lms', args: ['load', 'chat-model', '--context-length', '262144']}
+        ]);
+    });
+
+    test('loadLmsModel omits --context-length when not provided (backward compat)', async () => {
+        const execCalls = [];
+        const execFileStub = (cmd, args, callback) => {
+            execCalls.push({cmd, args});
+            callback(null, '', '');
+        };
+
+        await providerReadinessHelper.loadLmsModel('legacy-model', {execFileFn: execFileStub});
+
+        expect(execCalls).toEqual([
+            {cmd: 'lms', args: ['load', 'legacy-model']}
+        ]);
+    });
+
+    test('loadLmsModel omits --context-length when contextLength is non-finite (defensive)', async () => {
+        const execCalls = [];
+        const execFileStub = (cmd, args, callback) => {
+            execCalls.push({cmd, args});
+            callback(null, '', '');
+        };
+
+        for (const badValue of [undefined, null, NaN, Infinity, 'big', {}]) {
+            execCalls.length = 0;
+            await providerReadinessHelper.loadLmsModel('m', {execFileFn: execFileStub, contextLength: badValue});
+            expect(execCalls[0].args).toEqual(['load', 'm']);
+        }
+    });
+
     test('resolves readiness target from graphProvider instead of generic modelProvider', () => {
         expect(runSandmanModule.getGraphProviderReadinessTarget({
             modelProvider : 'gemini',

--- a/test/playwright/unit/ai/scripts/runners/runSandman.spec.mjs
+++ b/test/playwright/unit/ai/scripts/runners/runSandman.spec.mjs
@@ -368,6 +368,55 @@ test.describe('runSandman.mjs provider readiness diagnostics (#10587)', () => {
         ]);
     });
 
+    test('buildLmsContextLengthsMap composes full map when all four inputs are finite (#12117)', () => {
+        expect(providerReadinessHelper.buildLmsContextLengthsMap({
+            chatModel             : 'chat-from-config',
+            embeddingModel        : 'embedding-from-config',
+            chatContextLength     : 262144,
+            embeddingContextLength: 8192
+        })).toEqual({
+            'chat-from-config'     : 262144,
+            'embedding-from-config': 8192
+        });
+    });
+
+    test('buildLmsContextLengthsMap returns empty map when inputs are missing or non-finite (#12117)', () => {
+        // All missing
+        expect(providerReadinessHelper.buildLmsContextLengthsMap({})).toEqual({});
+
+        // Models present but context-lengths missing
+        expect(providerReadinessHelper.buildLmsContextLengthsMap({
+            chatModel     : 'chat',
+            embeddingModel: 'embedding'
+        })).toEqual({});
+
+        // Context-lengths present but models missing
+        expect(providerReadinessHelper.buildLmsContextLengthsMap({
+            chatContextLength     : 262144,
+            embeddingContextLength: 8192
+        })).toEqual({});
+
+        // Non-finite context-lengths defensive: NaN, Infinity, non-number all skipped
+        for (const bad of [NaN, Infinity, -Infinity, '262144', null, undefined]) {
+            expect(providerReadinessHelper.buildLmsContextLengthsMap({
+                chatModel        : 'chat',
+                chatContextLength: bad
+            })).toEqual({});
+        }
+    });
+
+    test('buildLmsContextLengthsMap returns partial map when only one role is configured (#12117)', () => {
+        expect(providerReadinessHelper.buildLmsContextLengthsMap({
+            chatModel        : 'chat-only',
+            chatContextLength: 99999
+        })).toEqual({'chat-only': 99999});
+
+        expect(providerReadinessHelper.buildLmsContextLengthsMap({
+            embeddingModel        : 'embedding-only',
+            embeddingContextLength: 8192
+        })).toEqual({'embedding-only': 8192});
+    });
+
     test('loadLmsModel omits --context-length when contextLength is non-finite (defensive)', async () => {
         const execCalls = [];
         const execFileStub = (cmd, args, callback) => {


### PR DESCRIPTION
Resolves #12117

Authored by Claude Opus 4.7 (1M context).
FAIR-band: over-target [16/30] — operator-directed bug-fix exception ("bugs always have a prio; broken sandman => chat and embedding model issues is worth fixing"). Lane self-claimed after operator override of ticket-explosion-pause stance.

PR #12112 landed proactive `lms load <model>` on orchestrator-managed lms task spawn, but `loadLmsModel` invokes `execFile` without `--context-length`. LM Studio falls back to the modelfile-default context window (typically 4K-8K for gemma-4-31b-it), which silently overflows on any meaningful chat prompt and produces empty downstream body. PR #12113's detection now classifies this loudly as `context-overflow` friction, but the upstream substrate gap remained.

This PR closes the gap by threading per-model context-length from `aiConfig.localModels.{chat,embedding}.contextLimitTokens` (PR #12115's role-keyed split) through `Orchestrator.lmsContextLengths` getter → `TaskDefinitions.lms.postSpawn` → `ensureLmsModelsLoaded` → `loadLmsModel`'s `execFile` args. The orchestrator now loads chat + embedding models with the operator-declared context window so the loaded cap matches the neo-side consumer-friction threshold.

Empirical anchor: 2026-05-27 post-PR-#12115-merge orchestrator restart + `ai:run-sandman` → 10 sessions silent-empty across both extractor paths (SemanticGraphExtractor + TopologyInferenceEngine); operator manually ran `lms load gemma-4-31b-it --context-length 262144` to recover. This PR makes that recovery step automatic.

Evidence: L2 (unit-covered: contextLength→execFile args threading + ensureLmsModelsLoaded→loadModel(id, {contextLength}) flow + Orchestrator.lmsContextLengths getter with multiple input shapes; defensive coverage on undefined/null/NaN/Infinity/non-number contextLength) → L4 required (live LM Studio + orchestrator restart with `lmsEnabled=true` + neo-side `localModels.chat.contextLimitTokens=262144` → verify `lms ps` shows model loaded WITH `--context-length 262144`; Sandman REM cycle produces real Tri-Vector content). Residual: live provider validation post-merge.

## Deltas From Ticket

None to ticket prescription. Cycle-1 refinements (responding to @neo-gpt cycle-1 review):

1. **Architectural placement** (cycle-1 challenge by @tobiu): `lmsContextLengths` map-builder moved from `Orchestrator.lmsContextLengths` getter to pure-function `buildLmsContextLengthsMap` exported from `ProviderReadinessHelper.mjs`. Orchestrator now resolves the 4 AiConfig values inline and delegates to the helper — no LM-Studio domain accretion in the orchestrator boundary. Aligns with existing helper-module idiom (`fetchOpenAiCompatibleModelIds`, `loadLmsModel` etc. all take resolved values).

2. **Resident-wrong-context enforcement** (cycle-1 RA1 by @neo-gpt — closes the exact #12117 regression): `ensureLmsModelsLoaded` previously short-circuited when all required models appeared in `/v1/models`, skipping `lms load` even when context-length was configured. `/v1/models` reports presence only — does NOT expose loaded context window. The fix: force-include context-configured models in the load set regardless of resident state. New test `ensureLmsModelsLoaded force-reloads context-configured models even when already resident (#12117 RA1)` covers the exact regression scenario.

3. **Same-model chat+embedding overwrite** (cycle-1 RA2 by @neo-gpt): when `chatModel === embeddingModel` (operator points both roles at the same identifier), `buildLmsContextLengthsMap` previously let the second assignment (typically embedding's smaller cap) overwrite the first (chat's larger cap), silently capping chat invocations. Now uses `Math.max`-style semantic via shared `setMax(modelId, value)` helper — larger cap wins regardless of declaration order. New test covers both directions + idempotent same-value case.

All 5 ACs from #12117 still mechanically addressed:
- AC1 ✓ `loadLmsModel` accepts `contextLength` option; appends `--context-length` to execFile args when finite
- AC2 ✓ `ensureLmsModelsLoaded` accepts `contextLengths: {[id]: number}` map; threads to each `loadModel(id, {contextLength})` call AND force-reloads context-configured residents (RA1)
- AC3 ✓ `TaskDefinitions.lms.postSpawn` delegates to `buildLmsContextLengthsMap` from `aiConfig.localModels.{chat,embedding}.contextLimitTokens`; same-model edge handled via Math.max (RA2)
- AC4 ✓ Unit tests: 9 total covering `--context-length` threading + ensureLmsModelsLoaded contextLengths happy + skip-when-no-context + force-reload-resident (RA1) + mixed-missing-and-resident + buildLmsContextLengthsMap full/empty/partial/same-model-max (RA2) + backward-compat omission + defensive non-finite
- AC5 ✓ No regression: 25/25 runSandman + 20/20 Orchestrator.invariants + 41/41 Orchestrator/daemon all pass

## Contract Ledger

| Surface | Before | After | Consumer |
|---|---|---|---|
| `loadLmsModel(model, options)` | `execFile('lms', ['load', model], ...)` — modelfile-default context | When `contextLength` is finite number, args become `['load', model, '--context-length', String(contextLength)]` | Orchestrator lms task postSpawn |
| `ensureLmsModelsLoaded(options)` | No per-model context awareness | New optional `contextLengths: {[modelId]: tokens}` map; threads per-model into each `loadModel(id, {contextLength})` call | Orchestrator-managed proactive load |
| `ProviderReadinessHelper.buildLmsContextLengthsMap` | (did not exist) | Pure helper composing `{[chatModel]: cap, [embeddingModel]: cap}` from resolved inputs; `Math.max`-style merge on same-model chat+embedding to preserve the larger cap; gracefully skips missing/non-finite values | Orchestrator boot path |
| `ensureLmsModelsLoaded` early-return on resident | Returned ready when all `requiredModels` appeared in `/v1/models`, skipping `lms load` even with configured context-length | Force-includes context-configured models in load set regardless of resident state; only returns early when zero missing AND zero context-configured | Closes #12117 RA1 regression — `/v1/models` reports presence only, NOT loaded context window |
| `buildTaskDefinitions({lmsContextLengths})` | (param did not exist) | New optional param flowed into postSpawn closure | Orchestrator.start() boot path |
| Loaded-cap vs neo-threshold alignment | Independent — operator manually aligns via `lms load --context-length` | Orchestrator-owned via threading; auto-aligned on each lms task spawn | Eliminates L4 silent-context-mismatch failure mode |

## Test Evidence

- `node --check` on all 5 modified files: PASS
- `npm run test-unit -- test/playwright/unit/ai/scripts/runners/runSandman.spec.mjs` — **19/19 passed (860ms)** including 4 new `(#12117)` tests
- `npm run test-unit -- test/playwright/unit/ai/daemons/orchestrator/Orchestrator.invariants.spec.mjs` — **21/21 passed (1.1s)** including 1 new `(#12117)` test
- `npm run test-unit -- test/playwright/unit/ai/daemons/orchestrator/Orchestrator.spec.mjs test/playwright/unit/ai/daemons/orchestrator/daemon.spec.mjs` — **41/41 passed (1.1s)** — no regression on existing lms task definition assertions
- `rg -n "cycle-[0-9]|Lane [A-Z]|AC[0-9]|#[0-9]{4,5}|\.mjs:[0-9]+"` on new production-code lines: **zero violations** (AGENTS_ATLAS.md §15.6); test.describe `(#12117)` labels are the test-traceability boundary exception per `feedback_jsdoc_archaeology_self_audit`

## Out of Scope

- **Operator overlay sync**: same as PR #12115 — gitignored `ai/config.mjs` overlay needs `localModels.{chat,embedding}` block synced for the read to resolve. PR #12115 already required this; this PR adds no new overlay sync burden.
- **`lms unload <model>` before `lms load <model> --context-length <N>`**: dual-instance stacking risk (LM Studio may keep both old + new instances loaded simultaneously, causing routing ambiguity). This PR does not address that — its scope is the load-side `--context-length` threading. If dual-instance routing is the dominant failure mode after this lands, a follow-up ticket on `loadLmsModel` to prepend `lms unload <model>` would close it. Operator's running `lms ps` diagnostic will clarify whether dual-instance is the actual symptom.
- **GPT's #12090-remaining lane** (Ollama `/api/ps` + OpenAi-compatible `/v1/models` capacity probes + warnings): complementary observability surface; this PR is the write-side architectural fix.

## Post-Merge Validation

- [ ] Operator syncs gitignored overlay if needed (`localModels.chat.contextLimitTokens=262144` already in template per PR #12115); restarts orchestrator
- [ ] `lmsEnabled=true` + orchestrator restart → lms task spawns, `loadLmsModel` invokes `lms load <chat-model> --context-length 262144` AND `lms load <embedding-model> --context-length 8192` (or whatever the operator pins; defaults are placeholders per #12114 AC6)
- [ ] `lms ps` shows models loaded with declared context-length
- [ ] `npm run ai:run-sandman` → Sandman REM cycle produces real Tri-Vector + Topology content (no silent-empty `context-overflow` friction unless prompt actually exceeds the operator-declared cap)

## Related

- Parent: Epic #12101 (greenfield aiConfig substrate redesign — `localModels` role-keyed split lives here)
- Source: PR #12112 (#12090 lms proactive load — established postSpawn hook + ensureLmsModelsLoaded; this PR completes the threading)
- Sibling: #12114 (role-keyed context-limits — established the `localModels.{chat,embedding}.contextLimitTokens` source-of-truth this PR threads from)
- Sibling: #12116 (ConsumerFrictionHelper loud-fail defense-in-depth — same anti-pattern class, consumer-side instead of provider-side)
- Sibling: #12090 (provider multi-model coexistence — GPT's remaining lane covers the observability side via `/v1/models` capacity probes)

## Commit

- `feat(ai): thread --context-length through loadLmsModel from localModels role-keyed limits (#12117)`
