### PR TITLE
fix(deploy): align local-model keep_alive defaults (#12089)

### DIFF
--- a/ai/deploy/docker-compose.yml
+++ b/ai/deploy/docker-compose.yml
@@ -243,7 +243,8 @@ services:
     environment:
       - OLLAMA_HOST=0.0.0.0:11434
       - OLLAMA_MODELS=/root/.ollama
-      - OLLAMA_KEEP_ALIVE=${NEO_LOCAL_MODEL_KEEP_ALIVE:-5m}
+      - OLLAMA_KEEP_ALIVE=${NEO_LOCAL_MODEL_KEEP_ALIVE:--1}
+      - OLLAMA_CONTEXT_LENGTH=${NEO_LOCAL_MODEL_CONTEXT_LENGTH:-262144}
     volumes:
       - local-model-data:/root/.ollama
     networks:
@@ -261,7 +262,7 @@ services:
     deploy:
       resources:
         limits:
-          memory: "${NEO_LOCAL_MODEL_MEMORY_LIMIT:-8g}"
+          memory: "${NEO_LOCAL_MODEL_MEMORY_LIMIT:-24g}"
           cpus: "${NEO_LOCAL_MODEL_CPU_LIMIT:-4.0}"
 
 # kb-server / mc-server stay internal-only (`expose`) on `neo-mcp-network`; the

--- a/ai/deploy/docker-compose.yml
+++ b/ai/deploy/docker-compose.yml
@@ -262,7 +262,7 @@ services:
     deploy:
       resources:
         limits:
-          memory: "${NEO_LOCAL_MODEL_MEMORY_LIMIT:-24g}"
+          memory: "${NEO_LOCAL_MODEL_MEMORY_LIMIT:-32g}"
           cpus: "${NEO_LOCAL_MODEL_CPU_LIMIT:-4.0}"
 
 # kb-server / mc-server stay internal-only (`expose`) on `neo-mcp-network`; the

--- a/learn/agentos/DeploymentCookbook.md
+++ b/learn/agentos/DeploymentCookbook.md
@@ -150,7 +150,7 @@ separate from Agent OS startup failures:
 ```sh
 NEO_LOCAL_MODEL_KEEP_ALIVE=-1 \
 NEO_LOCAL_MODEL_CONTEXT_LENGTH=262144 \
-NEO_LOCAL_MODEL_MEMORY_LIMIT=24g \
+NEO_LOCAL_MODEL_MEMORY_LIMIT=32g \
 docker compose -f ai/deploy/docker-compose.yml --profile local-model up -d local-model
 docker compose -f ai/deploy/docker-compose.yml --profile local-model exec local-model ollama pull <chat-model>
 docker compose -f ai/deploy/docker-compose.yml --profile local-model exec local-model ollama pull <embedding-model>
@@ -227,7 +227,7 @@ Supply these values per service/profile as needed:
 | `NEO_OPENAI_COMPATIBLE_API_KEY` | KB, MC, Orchestrator | Optional bearer token for OpenAI-compatible providers that require one; normally empty for the local compose service. |
 | `NEO_OLLAMA_KEEP_ALIVE`, `NEO_OPENAI_COMPATIBLE_KEEP_ALIVE` | KB, MC, Orchestrator | Provider request keep-alive override. Default `-1` keeps the selected local model resident unless the operator explicitly pins a shorter retention window or `0` unload control. |
 | `NEO_OLLAMA_REQUIRE_PARALLEL_MODELS`, `NEO_OPENAI_COMPATIBLE_REQUIRE_PARALLEL_MODELS` | KB, MC, Orchestrator | Local-provider residency expectation for chat + embedding coexistence. Default `2`; the provider-readiness check warns if the selected graph provider cannot observe that count and both configured model names. |
-| `NEO_LOCAL_MODEL_IMAGE`, `NEO_LOCAL_MODEL_KEEP_ALIVE`, `NEO_LOCAL_MODEL_CONTEXT_LENGTH`, `NEO_LOCAL_MODEL_MEMORY_LIMIT`, `NEO_LOCAL_MODEL_CPU_LIMIT` | `local-model` | Optional image/runtime/resource overrides for the self-hosted provider container. Defaults keep the model resident (`-1`), request 262144 context, and reserve a 24g memory envelope for Gemma-class local deployments unless the operator explicitly tunes down. |
+| `NEO_LOCAL_MODEL_IMAGE`, `NEO_LOCAL_MODEL_KEEP_ALIVE`, `NEO_LOCAL_MODEL_CONTEXT_LENGTH`, `NEO_LOCAL_MODEL_MEMORY_LIMIT`, `NEO_LOCAL_MODEL_CPU_LIMIT` | `local-model` | Optional image/runtime/resource overrides for the self-hosted provider container. Defaults keep the model resident (`-1`), request 262144 context, and reserve a 32g memory envelope for dual-resident chat + embedding Gemma-class local deployments unless the operator explicitly tunes down. |
 | `NEO_AUTO_SYNC=false` | KB | Prevents one-shot local KB sync during server startup. |
 | `NEO_KB_AUTO_START_DATABASE=false` | KB | Prevents the KB server from starting a local Chroma process. |
 | `NEO_MEM_AUTO_START_DATABASE=false` | MC | Prevents the MC server from starting a local Chroma process. |

--- a/learn/agentos/DeploymentCookbook.md
+++ b/learn/agentos/DeploymentCookbook.md
@@ -148,6 +148,9 @@ Use this profile in two phases so model provisioning failures are easy to
 separate from Agent OS startup failures:
 
 ```sh
+NEO_LOCAL_MODEL_KEEP_ALIVE=-1 \
+NEO_LOCAL_MODEL_CONTEXT_LENGTH=262144 \
+NEO_LOCAL_MODEL_MEMORY_LIMIT=24g \
 docker compose -f ai/deploy/docker-compose.yml --profile local-model up -d local-model
 docker compose -f ai/deploy/docker-compose.yml --profile local-model exec local-model ollama pull <chat-model>
 docker compose -f ai/deploy/docker-compose.yml --profile local-model exec local-model ollama pull <embedding-model>
@@ -173,7 +176,10 @@ model or is missing either configured model name. For native Ollama deployments,
 set the provider process environment to at least the same count:
 
 ```sh
-OLLAMA_MAX_LOADED_MODELS=2 ollama serve
+OLLAMA_KEEP_ALIVE=-1 \
+OLLAMA_CONTEXT_LENGTH=262144 \
+OLLAMA_MAX_LOADED_MODELS=2 \
+ollama serve
 ```
 
 For OpenAI-compatible providers, use the provider's own loaded-model cap or
@@ -221,7 +227,7 @@ Supply these values per service/profile as needed:
 | `NEO_OPENAI_COMPATIBLE_API_KEY` | KB, MC, Orchestrator | Optional bearer token for OpenAI-compatible providers that require one; normally empty for the local compose service. |
 | `NEO_OLLAMA_KEEP_ALIVE`, `NEO_OPENAI_COMPATIBLE_KEEP_ALIVE` | KB, MC, Orchestrator | Provider request keep-alive override. Default `-1` keeps the selected local model resident unless the operator explicitly pins a shorter retention window or `0` unload control. |
 | `NEO_OLLAMA_REQUIRE_PARALLEL_MODELS`, `NEO_OPENAI_COMPATIBLE_REQUIRE_PARALLEL_MODELS` | KB, MC, Orchestrator | Local-provider residency expectation for chat + embedding coexistence. Default `2`; the provider-readiness check warns if the selected graph provider cannot observe that count and both configured model names. |
-| `NEO_LOCAL_MODEL_IMAGE`, `NEO_LOCAL_MODEL_KEEP_ALIVE`, `NEO_LOCAL_MODEL_MEMORY_LIMIT`, `NEO_LOCAL_MODEL_CPU_LIMIT` | `local-model` | Optional image/runtime/resource overrides for the self-hosted provider container. |
+| `NEO_LOCAL_MODEL_IMAGE`, `NEO_LOCAL_MODEL_KEEP_ALIVE`, `NEO_LOCAL_MODEL_CONTEXT_LENGTH`, `NEO_LOCAL_MODEL_MEMORY_LIMIT`, `NEO_LOCAL_MODEL_CPU_LIMIT` | `local-model` | Optional image/runtime/resource overrides for the self-hosted provider container. Defaults keep the model resident (`-1`), request 262144 context, and reserve a 24g memory envelope for Gemma-class local deployments unless the operator explicitly tunes down. |
 | `NEO_AUTO_SYNC=false` | KB | Prevents one-shot local KB sync during server startup. |
 | `NEO_KB_AUTO_START_DATABASE=false` | KB | Prevents the KB server from starting a local Chroma process. |
 | `NEO_MEM_AUTO_START_DATABASE=false` | MC | Prevents the MC server from starting a local Chroma process. |

--- a/learn/agentos/SharedDeployment.md
+++ b/learn/agentos/SharedDeployment.md
@@ -94,7 +94,7 @@ export NEO_OPENAI_COMPATIBLE_API_KEY=  # leave empty for local servers
 
 This path uses the existing `Neo.ai.provider.OpenAiCompatible` chat-completions abstraction. Do not add a model-specific Qwen provider class for shared-deployment installs; local-model selection is an operator config concern.
 `NEO_OPENAI_COMPATIBLE_KEEP_ALIVE` and `NEO_OLLAMA_KEEP_ALIVE` default to `-1` so local providers keep the selected model resident across Agent OS calls unless operators explicitly choose a shorter retention window or `0` unload control.
-The optional `local-model` Docker profile mirrors that service primitive at the provider-runtime boundary: `OLLAMA_KEEP_ALIVE=-1`, `OLLAMA_CONTEXT_LENGTH=262144`, and a 24g default memory envelope unless overridden by `NEO_LOCAL_MODEL_*` deployment variables.
+The optional `local-model` Docker profile mirrors that service primitive at the provider-runtime boundary: `OLLAMA_KEEP_ALIVE=-1`, `OLLAMA_CONTEXT_LENGTH=262144`, and a 32g default memory envelope for dual-resident chat + embedding deployments unless overridden by `NEO_LOCAL_MODEL_*` deployment variables.
 
 ### Local-provider model residency
 

--- a/learn/agentos/SharedDeployment.md
+++ b/learn/agentos/SharedDeployment.md
@@ -94,6 +94,7 @@ export NEO_OPENAI_COMPATIBLE_API_KEY=  # leave empty for local servers
 
 This path uses the existing `Neo.ai.provider.OpenAiCompatible` chat-completions abstraction. Do not add a model-specific Qwen provider class for shared-deployment installs; local-model selection is an operator config concern.
 `NEO_OPENAI_COMPATIBLE_KEEP_ALIVE` and `NEO_OLLAMA_KEEP_ALIVE` default to `-1` so local providers keep the selected model resident across Agent OS calls unless operators explicitly choose a shorter retention window or `0` unload control.
+The optional `local-model` Docker profile mirrors that service primitive at the provider-runtime boundary: `OLLAMA_KEEP_ALIVE=-1`, `OLLAMA_CONTEXT_LENGTH=262144`, and a 24g default memory envelope unless overridden by `NEO_LOCAL_MODEL_*` deployment variables.
 
 ### Local-provider model residency
 

--- a/test/playwright/unit/ai/scripts/diagnostics/mcpHealthcheck.spec.mjs
+++ b/test/playwright/unit/ai/scripts/diagnostics/mcpHealthcheck.spec.mjs
@@ -209,11 +209,12 @@ test.describe('ai/scripts/diagnostics/mcpHealthcheck (#11725)', () => {
         expect(localModel.environment).toEqual(expect.arrayContaining([
             'OLLAMA_HOST=0.0.0.0:11434',
             'OLLAMA_MODELS=/root/.ollama',
-            'OLLAMA_KEEP_ALIVE=${NEO_LOCAL_MODEL_KEEP_ALIVE:-5m}'
+            'OLLAMA_KEEP_ALIVE=${NEO_LOCAL_MODEL_KEEP_ALIVE:--1}',
+            'OLLAMA_CONTEXT_LENGTH=${NEO_LOCAL_MODEL_CONTEXT_LENGTH:-262144}'
         ]));
         expect(localModel.healthcheck.test).toEqual(['CMD', 'ollama', 'list']);
         expect(localModel.deploy.resources.limits).toEqual({
-            memory: '${NEO_LOCAL_MODEL_MEMORY_LIMIT:-8g}',
+            memory: '${NEO_LOCAL_MODEL_MEMORY_LIMIT:-24g}',
             cpus  : '${NEO_LOCAL_MODEL_CPU_LIMIT:-4.0}'
         });
         expect(compose.volumes).toHaveProperty('local-model-data');

--- a/test/playwright/unit/ai/scripts/diagnostics/mcpHealthcheck.spec.mjs
+++ b/test/playwright/unit/ai/scripts/diagnostics/mcpHealthcheck.spec.mjs
@@ -214,7 +214,7 @@ test.describe('ai/scripts/diagnostics/mcpHealthcheck (#11725)', () => {
         ]));
         expect(localModel.healthcheck.test).toEqual(['CMD', 'ollama', 'list']);
         expect(localModel.deploy.resources.limits).toEqual({
-            memory: '${NEO_LOCAL_MODEL_MEMORY_LIMIT:-24g}',
+            memory: '${NEO_LOCAL_MODEL_MEMORY_LIMIT:-32g}',
             cpus  : '${NEO_LOCAL_MODEL_CPU_LIMIT:-4.0}'
         });
         expect(compose.volumes).toHaveProperty('local-model-data');


### PR DESCRIPTION
Resolves #12089

Authored by GPT-5 (Codex Desktop). Session f2619b83-0862-4a38-b5fa-11bcb9ee646d.

FAIR-band: over-target [14/30] -- taking this lane despite over-target because the operator opened nightshift v13 focus, #12089 is already assigned to neo-gpt, and the repo-local deployment drift was directly tied to the tenant env-var watch surface.

Aligns the optional Neo `local-model` compose profile with the resident-model contract established by PR #12093 and the downstream AC10 verification in issue comment https://github.com/neomjs/neo/issues/12089#issuecomment-4559783886. The provider container now defaults to `OLLAMA_KEEP_ALIVE=-1`, requests `OLLAMA_CONTEXT_LENGTH=262144`, and reserves a 32g memory envelope for dual-resident chat + embedding deployments unless operators explicitly override with `NEO_LOCAL_MODEL_*` variables.

Evidence: L2 (unit-level compose contract + Docker Compose config render + static diff checks) -> L2 required for repo-local compose/docs alignment. Residual: none for #12089 after peer AC10 V-B-A verified downstream `-1` / `262144` and corrected the memory envelope to 32g.

## Deltas from ticket

- Updates the PR from the ticket's original 24g AC10 memory envelope to 32g based on public downstream V-B-A in issue comment 4559783886: dual-model residency keeps chat (~19GB) and embedding (~5-6GB) resident together under `keep_alive=-1`, plus KV-cache and Ollama overhead.
- Adds `NEO_LOCAL_MODEL_CONTEXT_LENGTH` as a runtime-container override for the self-hosted Ollama service; no legacy alias or deprecation chain was added.
- Updates the default `NEO_LOCAL_MODEL_KEEP_ALIVE` fallback from `5m` to `-1`, mirroring the Neo provider request defaults from PR #12093.
- Updates the default `NEO_LOCAL_MODEL_MEMORY_LIMIT` from `8g` to `32g`, matching the downstream operator-empirical deployment envelope.
- Grounding: Ollama documents `OLLAMA_CONTEXT_LENGTH` and `OLLAMA_KEEP_ALIVE` as server environment controls; Neo provider request-level `keep_alive` remains covered by PR #12093.

## Config / Env Migration

Changed deployment variables:

- `NEO_LOCAL_MODEL_KEEP_ALIVE`: default fallback changed from `5m` to `-1`.
- `NEO_LOCAL_MODEL_CONTEXT_LENGTH`: new optional override, default `262144`.
- `NEO_LOCAL_MODEL_MEMORY_LIMIT`: default fallback changed from `8g` to `32g`.

Env-var policy: additive / hard-cut only. No legacy fallback names, deprecation warnings, or compatibility chain were introduced.

## Substrate Slot Rationale

Modified `learn/agentos/DeploymentCookbook.md`: disposition delta `rewrite` for the optional local-model profile operator recipe; reason is stale defaults would preserve the exact cold-start / under-sized runtime drift #12089 is meant to prevent. Rating: medium trigger-frequency x high failure-severity x high enforceability.

Modified `learn/agentos/SharedDeployment.md`: disposition delta `keep` as a compact operator-facing anchor for local-model runtime defaults. Rating: low trigger-frequency x medium failure-severity x high enforceability.

Retirement trigger: if local model lifecycle policy centralizes under a dedicated provider-runtime service guide, collapse these references into that single guide.

## Test Evidence

- `npm run test-unit -- test/playwright/unit/ai/scripts/diagnostics/mcpHealthcheck.spec.mjs` -> 9 passed after the 32g correction and post-rebase.
- `docker compose -f ai/deploy/docker-compose.yml --profile cloud --profile local-model config` -> passed after the 32g correction; rendered local-model env contains `OLLAMA_KEEP_ALIVE: "-1"`, `OLLAMA_CONTEXT_LENGTH: "262144"`, and memory `34359738368`.
- `git diff --check origin/dev...HEAD` -> passed after rebase.
- Current-head branch-history check: `git log origin/dev..HEAD --format=...` contains only #12089 commits and no stale magic-close keyword in commit bodies.
- Pre-push freshness check after upstream dev advanced: branch rebased onto `origin/dev` at `03484dc20`; force-with-lease push succeeded.

## Post-Merge Validation

- [ ] If operators intentionally need a smaller local-model envelope, pin `NEO_LOCAL_MODEL_KEEP_ALIVE`, `NEO_LOCAL_MODEL_CONTEXT_LENGTH`, or `NEO_LOCAL_MODEL_MEMORY_LIMIT` explicitly in deployment env.

## Commits

- `289b878d2` -- `fix(deploy): align local-model keep_alive defaults (#12089)`
- `fa4ceb44c` -- `fix(deploy): size local-model for dual residency (#12089)`