### PR TITLE
feat(ai): add REM run state tracking (#12088)

### DIFF
--- a/ai/config.template.mjs
+++ b/ai/config.template.mjs
@@ -295,9 +295,10 @@ class Config extends BaseConfig {
                 backupMs         : DAY_MS,
                 primaryDevSyncMs : 10 * 60 * 1000,
                 tenantRepoSyncMs : 30 * 60 * 1000,
-                dreamMs          : HOUR_MS,
-                goldenPathMs     : HOUR_MS,
-                swarmHeartbeatMs : 15 * 60 * 1000
+                dreamMs               : HOUR_MS,
+                dreamOverflowThreshold: 0.8,
+                goldenPathMs          : HOUR_MS,
+                swarmHeartbeatMs      : 15 * 60 * 1000
             },
             /**
              * Swarm-heartbeat target-resolver config. Controls which identity set
@@ -660,9 +661,10 @@ class Config extends BaseConfig {
                 backupMs         : {var: 'NEO_ORCHESTRATOR_BACKUP_INTERVAL_MS',            parse: Env.parseNumber},
                 primaryDevSyncMs : {var: 'NEO_ORCHESTRATOR_PRIMARY_DEV_SYNC_INTERVAL_MS',  parse: Env.parseNumber},
                 tenantRepoSyncMs : {var: 'NEO_ORCHESTRATOR_TENANT_REPO_SYNC_INTERVAL_MS',  parse: Env.parseNumber},
-                dreamMs          : {var: 'NEO_ORCHESTRATOR_DREAM_INTERVAL_MS',             parse: Env.parseNumber},
-                goldenPathMs     : {var: 'NEO_ORCHESTRATOR_GOLDEN_PATH_INTERVAL_MS',       parse: Env.parseNumber},
-                swarmHeartbeatMs : {var: 'NEO_ORCHESTRATOR_SWARM_HEARTBEAT_INTERVAL_MS',   parse: Env.parseNumber}
+                dreamMs               : {var: 'NEO_ORCHESTRATOR_DREAM_INTERVAL_MS',             parse: Env.parseNumber},
+                dreamOverflowThreshold: {var: 'NEO_ORCHESTRATOR_DREAM_OVERFLOW_THRESHOLD', parse: Env.parseNumber},
+                goldenPathMs          : {var: 'NEO_ORCHESTRATOR_GOLDEN_PATH_INTERVAL_MS',       parse: Env.parseNumber},
+                swarmHeartbeatMs      : {var: 'NEO_ORCHESTRATOR_SWARM_HEARTBEAT_INTERVAL_MS',   parse: Env.parseNumber}
             },
             tenantRepoSync: {
                 sweepCadenceMs: {var: 'NEO_ORCHESTRATOR_TENANT_REPO_SYNC_SWEEP_CADENCE_MS', parse: Env.parseNumber},

--- a/ai/daemons/orchestrator/services/DreamService.mjs
+++ b/ai/daemons/orchestrator/services/DreamService.mjs
@@ -28,9 +28,46 @@ import {
     waitForProvider,
     warnProviderParallelModelCapacity
 } from '../../../services/graph/ProviderReadinessHelper.mjs';
+import {
+    appendRemRunState,
+    createRemPhaseState,
+    createRemRunStateEntry
+} from '../../../services/memory-core/helpers/RemRunStateStore.mjs';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
+
+function estimatePayloadTokens(payload) {
+    const text = payload === undefined || payload === null ? '' : String(payload);
+    return Math.ceil(Buffer.byteLength(text, 'utf8') / 4);
+}
+
+function toErrorMessage(error) {
+    return error && error.message !== undefined ? String(error.message) : String(error);
+}
+
+function nonEmptyValue(value, fallback) {
+    return value === undefined || value === null || value === '' ? fallback : value;
+}
+
+function getLastFailedPhase(perPhaseStates) {
+    for (let i = perPhaseStates.length - 1; i >= 0; i--) {
+        if (perPhaseStates[i].status === 'failed') {
+            return perPhaseStates[i].phase;
+        }
+    }
+    return 'processUndigestedSessions';
+}
+
+function finishPhase(phase, startedAt, status, details = {}) {
+    return createRemPhaseState({
+        phase,
+        startedAt,
+        completedAt: Date.now(),
+        status,
+        details
+    });
+}
 
 /**
  * @summary Service for offline GraphRAG extraction ("REM Sleep").
@@ -147,25 +184,43 @@ class DreamService extends Base {
     async processUndigestedSessions() {
         if (this.isProcessing) {
             logger.debug('[DreamService] REM pipeline is already running. Skipping trigger.');
-            return;
+            return {
+                perPhaseStates  : [finishPhase('concurrentGuard', Date.now(), 'skipped', {reasonCode: 'already-processing'})],
+                perSessionStates: []
+            };
         }
 
         this.isProcessing = true;
+        const perPhaseStates   = [];
+        const perSessionStates = [];
 
         if (aiConfig.modelProvider === 'openAiCompatible') {
+            const providerStart = Date.now();
             try {
                 const url = new URL('/v1/models', aiConfig.openAiCompatible.host || 'http://127.0.0.1:8000');
                 const ping = await fetch(url.toString(), { method: 'GET', signal: AbortSignal.timeout(5000) });
                 if (!ping.ok) throw new Error('API provider not running');
+                perPhaseStates.push(finishPhase('legacyProviderProbe', providerStart, 'completed', {
+                    provider: aiConfig.modelProvider
+                }));
             } catch (e) {
                 logger.error('[DreamService] API provider service is unreachable. Aborting REM pipeline to prevent queue failures.');
                 this.isProcessing = false;
-                return;
+                perPhaseStates.push(finishPhase('legacyProviderProbe', providerStart, 'failed', {
+                    provider: aiConfig.modelProvider,
+                    error   : toErrorMessage(e)
+                }));
+                return {perPhaseStates, perSessionStates};
             }
         }
 
         try {
-            const sessions = await this.findUndigestedSessions();
+            const sessionQueryStart = Date.now();
+            const sessions          = await this.findUndigestedSessions();
+            perPhaseStates.push(finishPhase('sessionQuery', sessionQueryStart, 'completed', {
+                sessionsFound: sessions.length
+            }));
+
             if (sessions.length === 0) {
                 logger.info('[DreamService] No undigested session memories found. Proceeding to ambient task execution.');
             } else {
@@ -175,10 +230,28 @@ class DreamService extends Base {
                 // into the Native Edge Graph as first-class CONCEPT nodes + typed edges. Runs BEFORE
                 // FileSystemIngestor so downstream gap inference can traverse concept-graph relationships
                 // deterministically instead of regex-matching token lists against file paths.
-                await ConceptIngestor.syncConceptsToGraph();
+                const conceptIngestStart = Date.now();
+                try {
+                    await ConceptIngestor.syncConceptsToGraph();
+                    perPhaseStates.push(finishPhase('conceptIngest', conceptIngestStart, 'completed'));
+                } catch (e) {
+                    perPhaseStates.push(finishPhase('conceptIngest', conceptIngestStart, 'failed', {
+                        error: toErrorMessage(e)
+                    }));
+                    throw e;
+                }
 
                 // Phase 1: Ingest Live Workspace Files for Gap Analysis context mapping
-                await FileSystemIngestor.syncWorkspaceToGraph();
+                const workspaceIngestStart = Date.now();
+                try {
+                    await FileSystemIngestor.syncWorkspaceToGraph();
+                    perPhaseStates.push(finishPhase('workspaceIngest', workspaceIngestStart, 'completed'));
+                } catch (e) {
+                    perPhaseStates.push(finishPhase('workspaceIngest', workspaceIngestStart, 'failed', {
+                        error: toErrorMessage(e)
+                    }));
+                    throw e;
+                }
 
                 for (const session of sessions) {
                     logger.info(`[DreamService] Preparing session ${session.meta.sessionId} ("${session.meta.title}") for REM extraction.`);
@@ -204,34 +277,142 @@ class DreamService extends Base {
                     session.document = rawEpisodicMemory;
                     logger.info(`[DreamService]   -> Payload size (chars): ${session.document.length}`);
 
+                    const sessionState = {
+                        sessionId          : session.meta.sessionId,
+                        payloadSizeTokens  : estimatePayloadTokens(session.document),
+                        memorySessionIngest: {status: 'skipped', errorReasons: []},
+                        triVector          : {status: 'skipped', attempts: 0},
+                        topology           : {status: 'skipped', conflictCount: 0},
+                        gapSession         : {status: 'skipped'},
+                        graphDigestedFlag  : false,
+                        failureReasons     : []
+                    };
+                    perSessionStates.push(sessionState);
+
                     // Phase 2a: Memory/Session graph ingestion — runs BEFORE SemanticGraphExtractor
                     // so future provenance edges from extracted entities attach to real
                     // MEMORY/SESSION nodes rather than dangling at `sessionId` scalars. Deterministic
                     // Chroma-ID → graph-node mapping; no LLM cost, idempotent via payloadHash.
                     const ingestStart = Date.now();
-                    const ingestStats = await MemorySessionIngestor.syncSessionToGraph(session);
-                    const ingestErrors = ingestStats.errors?.length ?? 0;
+                    let ingestStats;
+                    try {
+                        ingestStats = await MemorySessionIngestor.syncSessionToGraph(session);
+                    } catch (e) {
+                        sessionState.memorySessionIngest = {
+                            status      : 'failed',
+                            errorReasons: [toErrorMessage(e)]
+                        };
+                        sessionState.failureReasons.push(toErrorMessage(e));
+                        perPhaseStates.push(finishPhase('memorySessionIngest', ingestStart, 'failed', {
+                            sessionId: session.meta.sessionId,
+                            error    : toErrorMessage(e)
+                        }));
+                        throw e;
+                    }
+                    const rawIngestErrors = Array.isArray(ingestStats.errors) ? ingestStats.errors : [];
+                    const ingestErrors    = rawIngestErrors.length;
                     const ingestTime = ((Date.now() - ingestStart) / 1000).toFixed(1);
                     logger.info(`[DreamService]   -> Memory/Session graph ingestion took: ${ingestTime}s (${ingestStats.memoriesUpserted} upserted, ${ingestStats.memoriesSkipped} skipped, ${ingestErrors} errors)`);
+
+                    const ingestErrorReasons = rawIngestErrors.map(item => toErrorMessage(item));
+
+                    sessionState.memorySessionIngest = {
+                        status      : ingestErrors > 0 ? 'failed' : 'completed',
+                        errorReasons: ingestErrorReasons
+                    };
+                    if (ingestErrors > 0) {
+                        sessionState.failureReasons.push(...ingestErrorReasons);
+                    }
+                    perPhaseStates.push(finishPhase('memorySessionIngest', ingestStart, ingestErrors > 0 ? 'failed' : 'completed', {
+                        sessionId       : session.meta.sessionId,
+                        memoriesUpserted: ingestStats.memoriesUpserted,
+                        memoriesSkipped : ingestStats.memoriesSkipped,
+                        errors          : ingestErrors
+                    }));
 
                     if (ingestErrors > 0) {
                         logger.warn(`[DreamService] Session ${session.meta.sessionId} had ${ingestErrors} memory-ingestion error(s); graphDigested will NOT be set this cycle.`);
                     }
 
                     const startTime = Date.now();
-                    const success = await SemanticGraphExtractor.executeTriVectorExtraction(session);
+                    let success;
+                    try {
+                        success = await SemanticGraphExtractor.executeTriVectorExtraction(session);
+                    } catch (e) {
+                        sessionState.triVector = {
+                            status   : 'failed',
+                            attempts : 1,
+                            errorKind: toErrorMessage(e)
+                        };
+                        sessionState.failureReasons.push(toErrorMessage(e));
+                        perPhaseStates.push(finishPhase('triVector', startTime, 'failed', {
+                            sessionId: session.meta.sessionId,
+                            error    : toErrorMessage(e)
+                        }));
+                        throw e;
+                    }
                     const triVectorTime = ((Date.now() - startTime) / 1000).toFixed(1);
                     logger.info(`[DreamService]   -> Tri-Vector Synthesis took: ${triVectorTime}s`);
+                    sessionState.triVector = {
+                        status   : success ? 'completed' : 'failed',
+                        attempts : 1,
+                        errorKind: success ? undefined : 'null-result'
+                    };
+                    if (!success) {
+                        sessionState.failureReasons.push('tri-vector extraction returned null');
+                    }
+                    perPhaseStates.push(finishPhase('triVector', startTime, success ? 'completed' : 'failed', {
+                        sessionId: session.meta.sessionId
+                    }));
 
                     const topoStart = Date.now();
-                    await TopologyInferenceEngine.extractTopology(session.document, session.meta.sessionId);
+                    try {
+                        await TopologyInferenceEngine.extractTopology(session.document, session.meta.sessionId);
+                    } catch (e) {
+                        sessionState.topology = {
+                            status       : 'failed',
+                            conflictCount: 0
+                        };
+                        sessionState.failureReasons.push(toErrorMessage(e));
+                        perPhaseStates.push(finishPhase('topology', topoStart, 'failed', {
+                            sessionId: session.meta.sessionId,
+                            error    : toErrorMessage(e)
+                        }));
+                        throw e;
+                    }
                     const topoTime = ((Date.now() - topoStart) / 1000).toFixed(1);
                     logger.info(`[DreamService]   -> Topological Conflicts took: ${topoTime}s`);
+                    const conflictCount = await TopologyInferenceEngine.getTopologyConflictCount();
+                    sessionState.topology = {
+                        status: 'completed',
+                        conflictCount
+                    };
+                    perPhaseStates.push(finishPhase('topology', topoStart, 'completed', {
+                        sessionId: session.meta.sessionId,
+                        conflictCount
+                    }));
 
                     const capStart = Date.now();
-                    await this.inferTestGapsFromSession(success);
+                    try {
+                        await this.inferTestGapsFromSession(success);
+                    } catch (e) {
+                        sessionState.gapSession = {
+                            status      : 'failed',
+                            errorReasons: [toErrorMessage(e)]
+                        };
+                        sessionState.failureReasons.push(toErrorMessage(e));
+                        perPhaseStates.push(finishPhase('gapSession', capStart, 'failed', {
+                            sessionId: session.meta.sessionId,
+                            error    : toErrorMessage(e)
+                        }));
+                        throw e;
+                    }
                     const capTime = ((Date.now() - capStart) / 1000).toFixed(1);
                     logger.info(`[DreamService]   -> Session TEST_GAP Inference took: ${capTime}s`);
+                    sessionState.gapSession = {status: 'completed'};
+                    perPhaseStates.push(finishPhase('gapSession', capStart, 'completed', {
+                        sessionId: session.meta.sessionId
+                    }));
 
                     logger.info(`[DreamService] Total Session Digest Time: ${((Date.now() - startTime) / 1000).toFixed(1)}s`);
 
@@ -240,6 +421,7 @@ class DreamService extends Base {
                             ids: [session.id],
                             metadatas: [{ ...session.meta, graphDigested: true }]
                         });
+                        sessionState.graphDigestedFlag = true;
                         logger.info(`[DreamService] Session ${session.meta.sessionId} marked as graphDigested in Memory Core.`);
                     }
                 }
@@ -248,16 +430,35 @@ class DreamService extends Base {
                 // for every invocation within a single REM cycle, so running it once after
                 // the session loop replaces redundant traversals.
                 const conceptGapStart = Date.now();
-                await this.inferConceptGraphGaps();
-                logger.info(`[DreamService] Cycle-scope GUIDE_GAP / EXAMPLE_GAP Inference took: ${((Date.now() - conceptGapStart) / 1000).toFixed(1)}s`);
+                try {
+                    await this.inferConceptGraphGaps();
+                    logger.info(`[DreamService] Cycle-scope GUIDE_GAP / EXAMPLE_GAP Inference took: ${((Date.now() - conceptGapStart) / 1000).toFixed(1)}s`);
+                    perPhaseStates.push(finishPhase('conceptGap', conceptGapStart, 'completed'));
+                } catch (e) {
+                    perPhaseStates.push(finishPhase('conceptGap', conceptGapStart, 'failed', {
+                        error: toErrorMessage(e)
+                    }));
+                    throw e;
+                }
             }
 
             // Universal Fade (Garbage Collection)
-            await this.runGarbageCollection();
+            const garbageCollectionStart = Date.now();
+            try {
+                await this.runGarbageCollection();
+                perPhaseStates.push(finishPhase('garbageCollection', garbageCollectionStart, 'completed'));
+            } catch (e) {
+                perPhaseStates.push(finishPhase('garbageCollection', garbageCollectionStart, 'failed', {
+                    error: toErrorMessage(e)
+                }));
+                throw e;
+            }
 
             logger.info('[DreamService] REM pipeline completed.');
+            return {perPhaseStates, perSessionStates};
         } catch (error) {
             logger.error('[DreamService] Failed to process undigested sessions:', error);
+            error.remState = {perPhaseStates, perSessionStates};
             throw error;
         } finally {
             this.isProcessing = false;
@@ -300,8 +501,11 @@ class DreamService extends Base {
         includeDecay = true,
         dryRun       = false
     } = {}) {
-        const startedAt = new Date();
-        const runId     = `rem-${startedAt.toISOString()}-${Math.random().toString(36).slice(2, 8)}`;
+        const startedAtMs = Date.now();
+        const startedAt   = new Date(startedAtMs);
+        const runId       = `rem-${crypto.randomUUID()}`;
+        const perPhaseStates = [];
+        let perSessionStates = [];
 
         const baseOutcome = {
             runId,
@@ -316,87 +520,184 @@ class DreamService extends Base {
             error            : null
         };
 
-        const finalize = (status, extras = {}) => ({
-            ...baseOutcome,
-            ...extras,
-            status,
-            completedAt: new Date().toISOString(),
-            durationMs : Date.now() - startedAt.getTime()
-        });
+        const finalize = async (status, extras = {}) => {
+            const completedAtMs = Date.now();
+            const completedAt   = new Date(completedAtMs).toISOString();
+            const durationMs    = completedAtMs - startedAtMs;
+            const outcome       = {
+                ...baseOutcome,
+                ...extras,
+                status,
+                completedAt,
+                durationMs
+            };
 
-        // Provider gate — abort with rich diagnostic when the configured graph provider
+            try {
+                const stateEntry = createRemRunStateEntry({
+                    runId,
+                    reason,
+                    startedAt          : startedAtMs,
+                    completedAt        : completedAtMs,
+                    configuredCadenceMs: AiConfig.orchestrator.intervals.dreamMs,
+                    overflowThreshold  : AiConfig.orchestrator.intervals.dreamOverflowThreshold,
+                    outcome            : status,
+                    reasonCode         : nonEmptyValue(extras.reasonCode, status),
+                    failurePhase       : nonEmptyValue(extras.failurePhase, null),
+                    failureReason      : nonEmptyValue(extras.failureReason, nonEmptyValue(extras.error?.message, nonEmptyValue(extras.diagnostic?.reason, null))),
+                    perPhaseStates,
+                    perSessionStates
+                });
+
+                if (stateEntry.cycleOverflowSignal) {
+                    logger.warn(`[Orchestrator] REM cycle wall-clock ${stateEntry.wallClockMs}ms exceeded ${Math.round(AiConfig.orchestrator.intervals.dreamOverflowThreshold * 100)}% of configured cadence ${stateEntry.configuredCadenceMs}ms; back-to-back overlap risk`);
+                }
+
+                await appendRemRunState(stateEntry, {dir: aiConfig.remRunStateDir});
+            } catch (e) {
+                logger.error('[DreamService] Failed to write REM run state:', e);
+                outcome.stateWriteError = toErrorMessage(e);
+            }
+
+            return outcome;
+        };
+
+        // Provider gate: abort with rich diagnostic when the configured graph provider
         // is unsupported or unreachable. Downstream pipeline calls would silently no-op
         // on missing provider; the typed `failed` envelope surfaces the root cause to
         // operator-facing health telemetry instead.
         let gate;
+        const providerStart = Date.now();
         try {
             gate = await this.checkProviderReadiness();
+            perPhaseStates.push(finishPhase('providerReady', providerStart, gate.ready ? 'completed' : 'failed', {
+                diagnostic: nonEmptyValue(gate.diagnostic, null)
+            }));
         } catch (e) {
-            return finalize('failed', {
-                error: {message: `checkProviderReadiness threw: ${e?.message || e}`, stack: e?.stack}
+            perPhaseStates.push(finishPhase('providerReady', providerStart, 'failed', {
+                error: toErrorMessage(e)
+            }));
+            const message = toErrorMessage(e);
+            return await finalize('failed', {
+                reasonCode  : 'provider-readiness-threw',
+                failurePhase: 'providerReady',
+                error       : {message: `checkProviderReadiness threw: ${message}`, stack: e?.stack}
             });
         }
         if (!gate.ready) {
-            return finalize('failed', {diagnostic: gate.diagnostic});
+            return await finalize('failed', {
+                reasonCode   : 'provider-unreachable',
+                failurePhase : 'providerReady',
+                failureReason: gate.diagnostic?.reason,
+                diagnostic   : gate.diagnostic
+            });
         }
 
-        // Dry-run short-circuit — used by callers that want to verify readiness without
+        // Dry-run short-circuit: used by callers that want to verify readiness without
         // running the pipeline (e.g. operator probes, smoke tests).
         if (dryRun) {
-            return finalize('skipped', {skipReason: 'dry-run requested'});
+            perPhaseStates.push(finishPhase('dryRun', Date.now(), 'skipped', {reasonCode: 'dry-run'}));
+            return await finalize('skipped', {reasonCode: 'dry-run', skipReason: 'dry-run requested'});
         }
 
-        // Concurrent-invocation guard — exposes the in-flight state as a stage outcome
+        // Concurrent-invocation guard: exposes the in-flight state as a stage outcome
         // rather than the prior debug-only log line that hid double-fires from operator
         // health telemetry.
         if (this.isProcessing) {
-            return finalize('skipped', {skipReason: 'dreamService.isProcessing already true (concurrent invocation)'});
+            perPhaseStates.push(finishPhase('concurrentGuard', Date.now(), 'skipped', {reasonCode: 'already-processing'}));
+            return await finalize('skipped', {
+                reasonCode: 'already-processing',
+                skipReason: 'dreamService.isProcessing already true (concurrent invocation)'
+            });
         }
 
-        // Pre-count query — distinguishes the no-work `skipped` path from the
+        // Pre-count query: distinguishes the no-work `skipped` path from the
         // work-completed `completed` path without requiring a return-value refactor on
         // processUndigestedSessions. A pre-call query is cheaper than the alternative
         // of inspecting graph state after the fact.
         let sessionCount = 0;
+        const sessionQueryStart = Date.now();
         try {
             const undigested = await this.findUndigestedSessions();
             sessionCount = Array.isArray(undigested) ? undigested.length : 0;
+            perPhaseStates.push(finishPhase('sessionQuery', sessionQueryStart, 'completed', {sessionsFound: sessionCount}));
         } catch (e) {
-            return finalize('failed', {
-                error: {message: `findUndigestedSessions threw: ${e?.message || e}`, stack: e?.stack}
+            const message = toErrorMessage(e);
+            perPhaseStates.push(finishPhase('sessionQuery', sessionQueryStart, 'failed', {error: message}));
+            return await finalize('failed', {
+                reasonCode  : 'session-query-failed',
+                failurePhase: 'sessionQuery',
+                error       : {message: `findUndigestedSessions threw: ${message}`, stack: e?.stack}
             });
         }
 
-        // No-work path — still run decay (it self-skips when the 24-hour Algorithmic
+        // No-work path: still run decay (it self-skips when the 24-hour Algorithmic
         // Lock isn't due) so decay cadence is not coupled to session-arrival cadence.
         if (sessionCount === 0) {
             if (includeDecay) {
+                const decayStart = Date.now();
                 try {
                     await GraphService.decayGlobalTopology();
+                    perPhaseStates.push(finishPhase('decay', decayStart, 'completed', {sessionsProcessed: 0}));
                 } catch (e) {
-                    return finalize('failed', {
-                        error            : {message: `decayGlobalTopology threw on zero-session path: ${e?.message || e}`, stack: e?.stack},
+                    const message = toErrorMessage(e);
+                    perPhaseStates.push(finishPhase('decay', decayStart, 'failed', {error: message}));
+                    return await finalize('failed', {
+                        reasonCode       : 'decay-failed',
+                        failurePhase     : 'decay',
+                        error            : {message: `decayGlobalTopology threw on zero-session path: ${message}`, stack: e?.stack},
                         sessionsProcessed: 0
                     });
                 }
             }
-            return finalize('skipped', {sessionsProcessed: 0, skipReason: 'no undigested sessions'});
+            return await finalize('skipped', {
+                reasonCode       : 'no-undigested-sessions',
+                sessionsProcessed: 0,
+                skipReason       : 'no undigested sessions'
+            });
         }
 
-        // Work path — process sessions, then run decay as the cycle-finalization step
+        // Work path: process sessions, then run decay as the cycle-finalization step
         // under the same lease window the caller already holds.
         try {
-            await this.processUndigestedSessions();
+            const processStart = Date.now();
+            const processResult = await this.processUndigestedSessions();
+            if (Array.isArray(processResult?.perPhaseStates)) {
+                perPhaseStates.push(...processResult.perPhaseStates);
+            }
+            perPhaseStates.push(finishPhase('processUndigestedSessions', processStart, 'completed', {
+                sessionsProcessed: sessionCount
+            }));
+            perSessionStates = Array.isArray(processResult?.perSessionStates) ? processResult.perSessionStates : [];
 
             if (includeDecay) {
-                await GraphService.decayGlobalTopology();
+                const decayStart = Date.now();
+                try {
+                    await GraphService.decayGlobalTopology();
+                    perPhaseStates.push(finishPhase('decay', decayStart, 'completed', {sessionsProcessed: sessionCount}));
+                } catch (e) {
+                    perPhaseStates.push(finishPhase('decay', decayStart, 'failed', {
+                        error: toErrorMessage(e)
+                    }));
+                    throw e;
+                }
             }
 
-            return finalize('completed', {sessionsProcessed: sessionCount});
+            return await finalize('completed', {reasonCode: 'ok', sessionsProcessed: sessionCount});
         } catch (e) {
-            return finalize('failed', {
+            if (e.remState) {
+                if (Array.isArray(e.remState.perPhaseStates)) {
+                    perPhaseStates.push(...e.remState.perPhaseStates);
+                }
+                perSessionStates = Array.isArray(e.remState.perSessionStates) ? e.remState.perSessionStates : [];
+            }
+
+            const failedPhase = getLastFailedPhase(perPhaseStates);
+
+            return await finalize('failed', {
+                reasonCode       : 'extraction-failed',
+                failurePhase     : failedPhase,
                 sessionsProcessed: sessionCount,
-                error            : {message: String(e?.message || e), stack: e?.stack}
+                error            : {message: toErrorMessage(e), stack: e?.stack}
             });
         }
     }

--- a/ai/mcp/server/memory-core/config.template.mjs
+++ b/ai/mcp/server/memory-core/config.template.mjs
@@ -269,6 +269,16 @@ class Config extends BaseConfig {
             }
         },
         /**
+         * Directory for per-cycle REM run/stage JSONL state artifacts.
+         * @type {string}
+         */
+        remRunStateDir: path.resolve(cwd, '.neo-ai-data/rem-runs'),
+        /**
+         * Number of recent REM cycles projected by `get_rem_pipeline_state`.
+         * @type {number}
+         */
+        remRunRecentLimit: 5,
+        /**
          * Target markdown file used for autonomous agent-to-user reporting (offline jobs).
          * @type {string}
          */
@@ -470,8 +480,10 @@ class Config extends BaseConfig {
             requireParallelModels: { var: 'NEO_OPENAI_COMPATIBLE_REQUIRE_PARALLEL_MODELS', parse: Env.parseNumber}
         },
         vectorDimension: { var: 'NEO_VECTOR_DIMENSION', parse: Env.parseNumber},
-        backupPath     : 'NEO_BACKUP_PATH',
-        engines        : {
+        backupPath       : 'NEO_BACKUP_PATH',
+        remRunStateDir   : 'NEO_REM_RUN_STATE_DIR',
+        remRunRecentLimit: {var: 'NEO_REM_RUN_RECENT_LIMIT', parse: Env.parseNumber},
+        engines          : {
             chroma: {
                 host: 'NEO_CHROMA_HOST',
                 port: { var: 'NEO_CHROMA_PORT', parse: Env.parsePort}

--- a/ai/mcp/server/memory-core/openapi.yaml
+++ b/ai/mcp/server/memory-core/openapi.yaml
@@ -122,7 +122,7 @@ paths:
       description: >
         Returns the 5-axis REM pipeline observability snapshot: undigested Chroma summaries,
         graph-digested Chroma summaries, SQLite SESSION nodes, topology conflicts, and optional
-        per-session entity count.
+        per-session entity count, plus recent REM cycle state projected from the JSONL run store.
       tags: [Health]
       requestBody:
         required: false
@@ -1481,6 +1481,7 @@ components:
         - digested
         - sessionNodes
         - topologyConflicts
+        - recentCycles
       properties:
         undigested:
           type: integer
@@ -1498,6 +1499,39 @@ components:
           type: integer
           description: Conflict entries currently present in the Sandman handoff file.
           example: 2
+        recentCycles:
+          type: array
+          description: Recent REM cycle summaries read from the gitignored JSONL run-state store.
+          items:
+            type: object
+            required:
+              - runId
+              - wallClockMs
+              - cycleOverflowSignal
+              - cycleOverflowRatio
+              - outcome
+            properties:
+              runId:
+                type: string
+                description: Durable REM cycle id.
+                example: "rem-550e8400-e29b-41d4-a716-446655440000"
+              wallClockMs:
+                type: integer
+                description: Cycle wall-clock duration in milliseconds.
+                example: 42000
+              cycleOverflowSignal:
+                type: boolean
+                description: Whether wall-clock duration exceeded the configured cadence threshold.
+                example: false
+              cycleOverflowRatio:
+                type: number
+                description: Cycle duration divided by configured cadence.
+                example: 0.42
+              outcome:
+                type: string
+                description: Typed cycle outcome.
+                enum: [completed, skipped, failed]
+                example: "completed"
         perSession:
           type: object
           nullable: true

--- a/ai/services/memory-core/HealthService.mjs
+++ b/ai/services/memory-core/HealthService.mjs
@@ -14,6 +14,7 @@ import {
     hasCoreSwarmParticipant,
     normalizeUserId
 } from '../../mcp/server/shared/services/RequestContextService.mjs';
+import {readRecentRemRunStates} from './helpers/RemRunStateStore.mjs';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
@@ -619,7 +620,24 @@ async function resolveRemAxis(label, fn) {
 }
 
 /**
- * @summary Builds the operator-facing 5-axis REM pipeline state projection.
+ * @summary Runs one REM observability block probe with a typed fallback.
+ *
+ * @param {String} label Human-readable block label for warning logs
+ * @param {Function} fn Probe function returning the block value
+ * @param {*} fallback Fallback value when the probe throws
+ * @returns {Promise<*>} Block value or fallback on failure
+ */
+async function resolveRemBlock(label, fn, fallback) {
+    try {
+        return await fn();
+    } catch (e) {
+        logger.warn(`[HealthService] get_rem_pipeline_state block ${label} failed:`, e?.message ?? e);
+        return fallback;
+    }
+}
+
+/**
+ * @summary Builds the operator-facing REM pipeline state projection.
  *
  * This composes the Phase 1a axis helpers from Epic #12065 Sub 2 into a single
  * MCP-safe read envelope without mutating the Dream Pipeline. The helper remains
@@ -628,7 +646,7 @@ async function resolveRemAxis(label, fn) {
  *
  * @param {Object} [options]
  * @param {String} [options.sessionId] Optional session id for per-session entity yield
- * @returns {Promise<Object>} 5-axis REM pipeline state projection
+ * @returns {Promise<Object>} REM pipeline state projection
  * @see ChromaManager#getUndigestedSessionCount
  * @see ChromaManager#getGraphDigestedCount
  * @see Neo.ai.services.memory-core.GraphService#getSessionNodeCount
@@ -656,11 +674,27 @@ export async function buildRemPipelineState({sessionId} = {}) {
         resolveRemAxis('topologyConflicts', () => TopologyInferenceEngine.getTopologyConflictCount())
     ]);
 
+    const recentCycles = await resolveRemBlock('recentCycles', async () => {
+        const entries = await readRecentRemRunStates({
+            dir  : aiConfig.remRunStateDir,
+            limit: aiConfig.remRunRecentLimit
+        });
+
+        return entries.map(entry => ({
+            runId              : entry.runId,
+            wallClockMs        : entry.wallClockMs,
+            cycleOverflowSignal: entry.cycleOverflowSignal,
+            cycleOverflowRatio : entry.cycleOverflowRatio,
+            outcome            : entry.outcome
+        }));
+    }, []);
+
     const state = {
         undigested,
         digested,
         sessionNodes,
-        topologyConflicts
+        topologyConflicts,
+        recentCycles
     };
 
     if (sessionId) {

--- a/ai/services/memory-core/helpers/RemRunStateStore.mjs
+++ b/ai/services/memory-core/helpers/RemRunStateStore.mjs
@@ -1,0 +1,200 @@
+import fs   from 'fs/promises';
+import path from 'path';
+
+/**
+ * @summary Builds the gitignored file name used for one REM run state artifact.
+ *
+ * @param {String} runId Stable cycle id.
+ * @returns {String} JSONL file name.
+ */
+export function getRemRunStateFileName(runId) {
+    if (typeof runId !== 'string' || runId.length === 0) {
+        throw new TypeError('getRemRunStateFileName: runId is required');
+    }
+
+    return `${runId.replace(/[^a-zA-Z0-9_.-]/g, '_')}.jsonl`;
+}
+
+/**
+ * @summary Calculates a wall-clock duration from epoch millisecond timestamps.
+ *
+ * @param {Number} startedAt Epoch milliseconds.
+ * @param {Number} completedAt Epoch milliseconds.
+ * @returns {Number} Non-negative wall-clock duration.
+ */
+export function getWallClockMs(startedAt, completedAt) {
+    if (!Number.isFinite(startedAt)) {
+        throw new TypeError('getWallClockMs: startedAt must be a finite number');
+    }
+    if (!Number.isFinite(completedAt)) {
+        throw new TypeError('getWallClockMs: completedAt must be a finite number');
+    }
+
+    return Math.max(0, completedAt - startedAt);
+}
+
+/**
+ * @summary Creates one phase-state entry with derived wall-clock timing.
+ *
+ * @param {Object} options
+ * @param {String} options.phase Phase identifier.
+ * @param {Number} options.startedAt Epoch milliseconds.
+ * @param {Number} options.completedAt Epoch milliseconds.
+ * @param {String} options.status completed | skipped | failed.
+ * @param {Object} [options.details={}] Phase-specific diagnostics.
+ * @returns {Object} Phase state entry.
+ */
+export function createRemPhaseState({
+    phase,
+    startedAt,
+    completedAt,
+    status,
+    details = {}
+}) {
+    if (typeof phase !== 'string' || phase.length === 0) {
+        throw new TypeError('createRemPhaseState: phase is required');
+    }
+    if (!['completed', 'skipped', 'failed'].includes(status)) {
+        throw new TypeError(`createRemPhaseState: invalid status '${status}'`);
+    }
+
+    return {
+        phase,
+        startedAt,
+        completedAt,
+        wallClockMs: getWallClockMs(startedAt, completedAt),
+        status,
+        details
+    };
+}
+
+/**
+ * @summary Creates the durable cycle-level REM state entry.
+ *
+ * @param {Object} options
+ * @returns {Object} JSONL-ready state entry.
+ */
+export function createRemRunStateEntry({
+    runId,
+    reason,
+    startedAt,
+    completedAt,
+    configuredCadenceMs,
+    overflowThreshold,
+    outcome,
+    reasonCode,
+    failurePhase = null,
+    failureReason = null,
+    perPhaseStates = [],
+    perSessionStates = []
+}) {
+    if (typeof runId !== 'string' || runId.length === 0) {
+        throw new TypeError('createRemRunStateEntry: runId is required');
+    }
+    if (!Number.isFinite(configuredCadenceMs) || configuredCadenceMs <= 0) {
+        throw new TypeError('createRemRunStateEntry: configuredCadenceMs must be a positive number');
+    }
+    if (!Number.isFinite(overflowThreshold) || overflowThreshold <= 0) {
+        throw new TypeError('createRemRunStateEntry: overflowThreshold must be a positive number');
+    }
+
+    const wallClockMs             = getWallClockMs(startedAt, completedAt);
+    const cycleOverflowRatio      = wallClockMs / configuredCadenceMs;
+    const completedPhases         = perPhaseStates.filter(item => item.status === 'completed');
+    const lastCompletedPhaseEntry = completedPhases.length > 0 ? completedPhases[completedPhases.length - 1] : null;
+
+    return {
+        runId,
+        reason,
+        startedAt,
+        completedAt,
+        wallClockMs,
+        configuredCadenceMs,
+        cycleOverflowSignal: wallClockMs > configuredCadenceMs * overflowThreshold,
+        cycleOverflowRatio,
+        outcome,
+        reasonCode,
+        failurePhase,
+        failureReason,
+        lastSuccessfulPhase: lastCompletedPhaseEntry ? lastCompletedPhaseEntry.phase : null,
+        cycleScopePhases   : perPhaseStates.map(item => item.phase),
+        perPhaseStates,
+        perSessionStates
+    };
+}
+
+/**
+ * @summary Appends one REM run state entry into its per-run JSONL artifact.
+ *
+ * @param {Object} entry JSONL-ready REM run state entry.
+ * @param {Object} options
+ * @param {String} options.dir Directory for per-run state files.
+ * @returns {Promise<String>} Written file path.
+ */
+export async function appendRemRunState(entry, {dir} = {}) {
+    if (!dir) {
+        throw new TypeError('appendRemRunState: dir is required');
+    }
+
+    await fs.mkdir(dir, {recursive: true});
+
+    const filePath = path.join(dir, getRemRunStateFileName(entry.runId));
+    await fs.appendFile(filePath, `${JSON.stringify(entry)}\n`, 'utf8');
+
+    return filePath;
+}
+
+/**
+ * @summary Reads the most recent REM run state entries from the JSONL store.
+ *
+ * @param {Object} options
+ * @param {String} options.dir Directory for per-run state files.
+ * @param {Number} options.limit Maximum entries to return.
+ * @returns {Promise<Object[]>} Most recent state entries, newest first.
+ */
+export async function readRecentRemRunStates({dir, limit} = {}) {
+    if (!dir || !Number.isFinite(limit) || limit <= 0) {
+        return [];
+    }
+
+    let names;
+    try {
+        names = await fs.readdir(dir);
+    } catch (e) {
+        if (e?.code === 'ENOENT') return [];
+        throw e;
+    }
+
+    const files = await Promise.all(names
+        .filter(name => name.endsWith('.jsonl'))
+        .map(async name => {
+            const filePath = path.join(dir, name);
+            const stat     = await fs.stat(filePath);
+            return {filePath, mtimeMs: stat.mtimeMs};
+        }));
+
+    const entries = [];
+
+    for (const file of files.sort((a, b) => b.mtimeMs - a.mtimeMs)) {
+        if (entries.length >= limit) break;
+
+        const text  = await fs.readFile(file.filePath, 'utf8');
+        const lines = text.trim().split('\n').filter(Boolean);
+        const line  = lines.length > 0 ? lines[lines.length - 1] : null;
+        if (!line) continue;
+
+        try {
+            entries.push(JSON.parse(line));
+        } catch (e) {
+            // A corrupt diagnostic artifact should not take down the healthcheck surface.
+        }
+    }
+
+    return entries
+        .sort((a, b) => {
+            const aCompletedAt = Number.isFinite(a.completedAt) ? a.completedAt : 0;
+            const bCompletedAt = Number.isFinite(b.completedAt) ? b.completedAt : 0;
+            return bCompletedAt - aCompletedAt;
+        })
+        .slice(0, limit);
+}

--- a/learn/agentos/rem-state-model.md
+++ b/learn/agentos/rem-state-model.md
@@ -12,6 +12,13 @@ Phase 1a helpers; it does not write graph nodes or mutate Sandman state.
     digested         : Number, // Chroma summaries with graphDigested true
     sessionNodes     : Number, // SQLite SESSION nodes
     topologyConflicts: Number, // handoff conflict entries
+    recentCycles     : [{
+        runId              : String,
+        wallClockMs        : Number,
+        cycleOverflowSignal: Boolean,
+        cycleOverflowRatio : Number,
+        outcome            : String
+    }],
     perSession       : {
         sessionId  : String,
         entityCount: Number // inbound graph entity/provenance edges
@@ -65,16 +72,47 @@ the Sandman handoff.
 
 Use `topologyConflicts` as the handoff-conflict count only. A zero value does not
 prove topology extraction succeeded; it can also mean the provider/error path
-returned no durable conflict entries. Phase 2 will add per-cycle stage outcomes to
-disambiguate no-conflict from extraction-failed.
+returned no durable conflict entries. Use `recentCycles` for the cycle-level
+outcome and overflow signal before treating zero conflicts as a clean run.
 
 Use `perSession.entityCount` to inspect extraction yield for a single session. A
 digested session with zero inbound entity/provenance edges is suspicious when the
 payload clearly contained entities.
 
-## Phase 2 Pointer
+## Durable Cycle State
 
-Phase 2 extends this scaffold with append-only JSONL cycle state, per-phase
-wall-clock timings, and cadence-overflow detection. That state belongs off-graph
-so a broken REM run does not mutate the active control plane while diagnosing
-itself.
+`DreamService.executeRemCycle()` writes one append-only JSONL artifact per run
+under the gitignored `NEO_REM_RUN_STATE_DIR` directory
+(`.neo-ai-data/rem-runs` by default). The file name is the sanitized `runId`, and
+each line is a complete cycle snapshot:
+
+```js
+{
+    runId,
+    reason,
+    startedAt,
+    completedAt,
+    wallClockMs,
+    configuredCadenceMs,
+    cycleOverflowSignal,
+    cycleOverflowRatio,
+    outcome,
+    reasonCode,
+    failurePhase,
+    failureReason,
+    lastSuccessfulPhase,
+    cycleScopePhases,
+    perPhaseStates,
+    perSessionStates
+}
+```
+
+The JSONL store is deliberately off-graph. A broken REM run can diagnose itself
+without mutating the Native Edge Graph control plane. `get_rem_pipeline_state`
+projects only the recent cycle summary fields so operator dashboards stay small;
+inspect the JSONL artifact directly when phase-level or per-session failure
+reasons are needed.
+
+Set `NEO_ORCHESTRATOR_DREAM_OVERFLOW_THRESHOLD` to tune the overflow warning
+ratio against the configured dream cadence. The default is `0.8`, meaning a
+cycle that consumes more than 80% of its cadence is flagged as an overlap risk.

--- a/test/playwright/unit/ai/daemons/orchestrator/services/DreamService.executeRemCycle.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/services/DreamService.executeRemCycle.spec.mjs
@@ -2,6 +2,12 @@ import {test, expect} from '@playwright/test';
 import Neo from '../../../../../../../src/Neo.mjs';
 import * as core from '../../../../../../../src/core/_export.mjs';
 import DreamService from '../../../../../../../ai/daemons/orchestrator/services/DreamService.mjs';
+import AiConfig from '../../../../../../../ai/config.mjs';
+import {Memory_Config as MemoryConfig} from '../../../../../../../ai/services.mjs';
+import logger from '../../../../../../../ai/mcp/server/memory-core/logger.mjs';
+import {mkdtemp, readdir, readFile, rm} from 'fs/promises';
+import os from 'os';
+import path from 'path';
 
 /**
  * @summary Focused coverage for the typed-outcome contract of `DreamService.executeRemCycle()`.
@@ -28,9 +34,23 @@ const ORIGINAL_KEYS = [
 ];
 
 let originals;
+let configOriginals;
+let tmpDir;
 
-test.beforeEach(() => {
+test.beforeEach(async () => {
     originals = Object.fromEntries(ORIGINAL_KEYS.map(key => [key, DreamService[key]]));
+    configOriginals = {
+        dreamMs               : AiConfig.orchestrator.intervals.dreamMs,
+        dreamOverflowThreshold: AiConfig.orchestrator.intervals.dreamOverflowThreshold,
+        remRunStateDir        : MemoryConfig.remRunStateDir,
+        remRunRecentLimit     : MemoryConfig.remRunRecentLimit
+    };
+    tmpDir = await mkdtemp(path.join(os.tmpdir(), 'neo-dream-cycle-state-'));
+
+    AiConfig.orchestrator.intervals.dreamMs                = 1000;
+    AiConfig.orchestrator.intervals.dreamOverflowThreshold = 0.8;
+    MemoryConfig.remRunStateDir                            = tmpDir;
+    MemoryConfig.remRunRecentLimit                         = 3;
 
     DreamService.isProcessing              = false;
     DreamService.findUndigestedSessions    = async () => [];
@@ -38,10 +58,17 @@ test.beforeEach(() => {
     DreamService.checkProviderReadiness    = async () => ({ready: true});
 });
 
-test.afterEach(() => {
+test.afterEach(async () => {
     for (const key of ORIGINAL_KEYS) {
         DreamService[key] = originals[key];
     }
+
+    AiConfig.orchestrator.intervals.dreamMs                = configOriginals.dreamMs;
+    AiConfig.orchestrator.intervals.dreamOverflowThreshold = configOriginals.dreamOverflowThreshold;
+    MemoryConfig.remRunStateDir                            = configOriginals.remRunStateDir;
+    MemoryConfig.remRunRecentLimit                         = configOriginals.remRunRecentLimit;
+
+    await rm(tmpDir, {recursive: true, force: true});
 });
 
 test.describe('DreamService.executeRemCycle typed outcome contract', () => {
@@ -182,5 +209,64 @@ test.describe('DreamService.executeRemCycle typed outcome contract', () => {
 
         expect(outcome.reason).toBe('periodic-dream:3600000');
         expect(outcome.mode).toBe('periodic');
+    });
+
+    test('writes durable REM run-state JSONL with phase telemetry', async () => {
+        const outcome = await DreamService.executeRemCycle({
+            reason: 'state-write-test',
+            dryRun: true
+        });
+
+        const files = await readdir(tmpDir);
+        expect(files).toHaveLength(1);
+        expect(files[0]).toMatch(/^rem-.*\.jsonl$/);
+
+        const lines = (await readFile(path.join(tmpDir, files[0]), 'utf8')).trim().split('\n');
+        const entry = JSON.parse(lines[0]);
+
+        expect(outcome.stateWriteError).toBeUndefined();
+        expect(entry.runId).toBe(outcome.runId);
+        expect(entry.reason).toBe('state-write-test');
+        expect(entry.outcome).toBe('skipped');
+        expect(entry.reasonCode).toBe('dry-run');
+        expect(entry.configuredCadenceMs).toBe(1000);
+        expect(entry.cycleOverflowSignal).toBe(false);
+        expect(entry.cycleScopePhases).toEqual(['providerReady', 'dryRun']);
+        expect(entry.perPhaseStates.map(phase => phase.phase)).toEqual(['providerReady', 'dryRun']);
+        expect(entry.perSessionStates).toEqual([]);
+    });
+
+    test('logs a warning when cycle wall-clock exceeds the cadence threshold', async () => {
+        const originalNow  = Date.now;
+        const originalWarn = logger.warn;
+        const warnings     = [];
+        const ticks        = [1000, 1000, 1100, 1700, 1800, 2100];
+
+        Date.now = () => ticks.length > 0 ? ticks.shift() : 2100;
+        logger.warn = (...args) => warnings.push(args.join(' '));
+
+        try {
+            await DreamService.executeRemCycle({
+                reason: 'overflow-warning-test',
+                dryRun: true
+            });
+        } finally {
+            Date.now    = originalNow;
+            logger.warn = originalWarn;
+        }
+
+        expect(warnings.some(message => message.includes('back-to-back overlap risk'))).toBe(true);
+    });
+
+    test('surfaces stale config overlay errors without hiding the typed outcome', async () => {
+        AiConfig.orchestrator.intervals.dreamOverflowThreshold = undefined;
+
+        const outcome = await DreamService.executeRemCycle({
+            reason: 'stale-config-test',
+            dryRun: true
+        });
+
+        expect(outcome.status).toBe('skipped');
+        expect(outcome.stateWriteError).toContain('overflowThreshold must be a positive number');
     });
 });

--- a/test/playwright/unit/ai/mcp/server/memory-core/McpServerToolLimits.spec.mjs
+++ b/test/playwright/unit/ai/mcp/server/memory-core/McpServerToolLimits.spec.mjs
@@ -98,6 +98,9 @@ test.describe('Neo.ai.mcp.server.memory-core Tool limits', () => {
         expect(tool.outputSchema.properties.digested.type).toBe('integer');
         expect(tool.outputSchema.properties.sessionNodes.type).toBe('integer');
         expect(tool.outputSchema.properties.topologyConflicts.type).toBe('integer');
+        expect(tool.outputSchema.properties.recentCycles.type).toBe('array');
+        expect(tool.outputSchema.properties.recentCycles.items.properties.runId.type).toBe('string');
+        expect(tool.outputSchema.properties.recentCycles.items.properties.cycleOverflowSignal.type).toBe('boolean');
         const perSession = tool.outputSchema.properties.perSession.anyOf.find(item => item.type === 'object');
         expect(perSession.properties.entityCount.type).toBe('integer');
     });

--- a/test/playwright/unit/ai/services/memory-core/helpers/RemRunStateStore.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/helpers/RemRunStateStore.spec.mjs
@@ -1,0 +1,102 @@
+import {test, expect} from '@playwright/test';
+import Neo             from '../../../../../../../src/Neo.mjs';
+import * as core       from '../../../../../../../src/core/_export.mjs';
+import {mkdtemp, rm}   from 'fs/promises';
+import os              from 'os';
+import path            from 'path';
+
+import {
+    appendRemRunState,
+    createRemPhaseState,
+    createRemRunStateEntry,
+    getRemRunStateFileName,
+    readRecentRemRunStates
+} from '../../../../../../../ai/services/memory-core/helpers/RemRunStateStore.mjs';
+
+test.describe('RemRunStateStore', () => {
+    let tmpDir;
+
+    test.beforeEach(async () => {
+        tmpDir = await mkdtemp(path.join(os.tmpdir(), 'neo-rem-run-state-'));
+    });
+
+    test.afterEach(async () => {
+        await rm(tmpDir, {recursive: true, force: true});
+    });
+
+    test('sanitizes run ids into portable JSONL file names', () => {
+        expect(getRemRunStateFileName('rem-2026-05-28T03:00:00.000Z')).toBe('rem-2026-05-28T03_00_00.000Z.jsonl');
+    });
+
+    test('creates phase entries with derived wall-clock timing', () => {
+        expect(createRemPhaseState({
+            phase      : 'triVector',
+            startedAt  : 1000,
+            completedAt: 1250,
+            status     : 'completed',
+            details    : {sessionId: 's1'}
+        })).toEqual({
+            phase      : 'triVector',
+            startedAt  : 1000,
+            completedAt: 1250,
+            wallClockMs: 250,
+            status     : 'completed',
+            details    : {sessionId: 's1'}
+        });
+    });
+
+    test('creates cycle entries with cadence-overflow fields', () => {
+        const entry = createRemRunStateEntry({
+            runId              : 'rem-test',
+            reason             : 'periodic-dream:100',
+            startedAt          : 1000,
+            completedAt        : 1090,
+            configuredCadenceMs: 100,
+            overflowThreshold  : 0.8,
+            outcome            : 'completed',
+            reasonCode         : 'ok',
+            perPhaseStates     : [
+                createRemPhaseState({phase: 'providerReady', startedAt: 1000, completedAt: 1010, status: 'completed'}),
+                createRemPhaseState({phase: 'triVector', startedAt: 1010, completedAt: 1090, status: 'completed'})
+            ],
+            perSessionStates: [{sessionId: 's1'}]
+        });
+
+        expect(entry.wallClockMs).toBe(90);
+        expect(entry.cycleOverflowRatio).toBe(0.9);
+        expect(entry.cycleOverflowSignal).toBe(true);
+        expect(entry.lastSuccessfulPhase).toBe('triVector');
+        expect(entry.cycleScopePhases).toEqual(['providerReady', 'triVector']);
+    });
+
+    test('appends and reads recent run entries newest first', async () => {
+        const older = createRemRunStateEntry({
+            runId              : 'rem-old',
+            reason             : 'manual',
+            startedAt          : 1000,
+            completedAt        : 1100,
+            configuredCadenceMs: 1000,
+            overflowThreshold  : 0.8,
+            outcome            : 'completed',
+            reasonCode         : 'ok'
+        });
+
+        const newer = createRemRunStateEntry({
+            runId              : 'rem-new',
+            reason             : 'manual',
+            startedAt          : 2000,
+            completedAt        : 2100,
+            configuredCadenceMs: 1000,
+            overflowThreshold  : 0.8,
+            outcome            : 'skipped',
+            reasonCode         : 'no-undigested-sessions'
+        });
+
+        await appendRemRunState(older, {dir: tmpDir});
+        await appendRemRunState(newer, {dir: tmpDir});
+
+        const recent = await readRecentRemRunStates({dir: tmpDir, limit: 1});
+
+        expect(recent.map(entry => entry.runId)).toEqual(['rem-new']);
+    });
+});

--- a/test/playwright/unit/ai/services/rem-observability.spec.mjs
+++ b/test/playwright/unit/ai/services/rem-observability.spec.mjs
@@ -21,6 +21,10 @@ import path               from 'path';
 import {fileURLToPath}    from 'url';
 import Neo                from '../../../../../src/Neo.mjs';
 import * as core          from '../../../../../src/core/_export.mjs';
+import {
+    appendRemRunState,
+    createRemRunStateEntry
+} from '../../../../../ai/services/memory-core/helpers/RemRunStateStore.mjs';
 
 /**
  * @summary Cross-service unit coverage for the 5-axis REM observability primitive
@@ -105,7 +109,7 @@ function makeFakeGraphDb(prepareImpl) {
 
 test.describe('ai/services REM observability axis helpers (#12068 Sub 2 Part A)', () => {
     let ChromaManager, GraphService, TopologyInferenceEngine;
-    let originalGetSummaryCollection, originalGraphDb, originalHandoffPath;
+    let originalGetSummaryCollection, originalGraphDb, originalHandoffPath, originalRemRunStateDir, originalRemRunRecentLimit;
     let aiConfig;
 
     test.beforeAll(async () => {
@@ -126,12 +130,19 @@ test.describe('ai/services REM observability axis helpers (#12068 Sub 2 Part A)'
         originalGetSummaryCollection = ChromaManager.getSummaryCollection;
         originalGraphDb              = GraphService.db;
         originalHandoffPath          = aiConfig.data.handoffFilePath;
+        originalRemRunStateDir       = aiConfig.remRunStateDir;
+        originalRemRunRecentLimit    = aiConfig.remRunRecentLimit;
+
+        aiConfig.remRunStateDir      = path.join(tmpRoot, `rem-runs-${crypto.randomUUID()}`);
+        aiConfig.remRunRecentLimit   = 5;
     });
 
     test.afterEach(() => {
         ChromaManager.getSummaryCollection = originalGetSummaryCollection;
         GraphService.db                    = originalGraphDb;
         aiConfig.data.handoffFilePath      = originalHandoffPath;
+        aiConfig.remRunStateDir            = originalRemRunStateDir;
+        aiConfig.remRunRecentLimit         = originalRemRunRecentLimit;
     });
 
     test.describe('ChromaManager.getUndigestedSessionCount', () => {
@@ -409,11 +420,57 @@ test.describe('ai/services REM observability axis helpers (#12068 Sub 2 Part A)'
                 digested         : 2,
                 sessionNodes     : 2,
                 topologyConflicts: 2,
+                recentCycles     : [],
                 perSession       : {
                     sessionId  : 's1',
                     entityCount: 9
                 }
             });
+        });
+
+        test('projects recent JSONL cycle state through the MCP tool', async () => {
+            ChromaManager.getSummaryCollection = async () => makeFakeSummaryCollection([]);
+            GraphService.db = makeFakeGraphDb((sql) => {
+                if (sql.includes('FROM Nodes')) {
+                    return {get: () => ({c: 0})};
+                }
+
+                return {get: () => ({count: 0})};
+            });
+            aiConfig.remRunRecentLimit = 1;
+
+            await appendRemRunState(createRemRunStateEntry({
+                runId              : 'rem-old',
+                reason             : 'manual',
+                startedAt          : 1000,
+                completedAt        : 1100,
+                configuredCadenceMs: 1000,
+                overflowThreshold  : 0.8,
+                outcome            : 'completed',
+                reasonCode         : 'ok'
+            }), {dir: aiConfig.remRunStateDir});
+
+            await appendRemRunState(createRemRunStateEntry({
+                runId              : 'rem-new',
+                reason             : 'manual',
+                startedAt          : 2000,
+                completedAt        : 2900,
+                configuredCadenceMs: 1000,
+                overflowThreshold  : 0.8,
+                outcome            : 'skipped',
+                reasonCode         : 'no-undigested-sessions'
+            }), {dir: aiConfig.remRunStateDir});
+
+            const {callTool} = await import('../../../../../ai/mcp/server/memory-core/toolService.mjs');
+            const state = await callTool('get_rem_pipeline_state', {});
+
+            expect(state.recentCycles).toEqual([{
+                runId              : 'rem-new',
+                wallClockMs        : 900,
+                cycleOverflowSignal: true,
+                cycleOverflowRatio : 0.9,
+                outcome            : 'skipped'
+            }]);
         });
     });
 });


### PR DESCRIPTION
Resolves #12088

Authored by GPT-5 (Codex Desktop). Session f2619b83-0862-4a38-b5fa-11bcb9ee646d.

FAIR-band: over-target [14/30] — taking this lane despite over-target because #12088 was the GPT-owned Part B tracker after #12068 reconciliation and directly advances the operator-prioritized Sandman/orchestrator closeout.

Adds durable REM cycle state tracking: `DreamService.executeRemCycle()` now writes one JSONL artifact per run with cycle wall-clock, configured cadence, overflow signal/ratio, ordered phase states, and per-session stage outcomes. `processUndigestedSessions()` now returns the per-phase/per-session state needed by that writer, and Memory Core `get_rem_pipeline_state` projects recent cycle trend fields for operator visibility.

Evidence: L2 (focused unit coverage for JSONL writer, cycle telemetry, MCP schema/projection, overflow WARN, and stale-config `stateWriteError`) -> L4 required (AC7 live operator substrate wall-clock trending after merge). Residual: AC7 [#12088].

Related: #12065
Related: #12068
Related: #12087

## Deltas from ticket

- Integrated the writer at `executeRemCycle()` because the typed cycle entrypoint has already landed; `processUndigestedSessions()` feeds it state instead of owning the top-level artifact write directly.
- Stale ignored local config overlays are surfaced as `stateWriteError` on the typed outcome rather than crashing before the outcome returns.
- `readRecentRemRunStates()` skips corrupt JSONL tail lines so a damaged diagnostic artifact does not hide the rest of the health snapshot.

## MCP Config Template Changes

Changed keys:
- `ai/config.template.mjs`: `orchestrator.intervals.dreamOverflowThreshold`, env `NEO_ORCHESTRATOR_DREAM_OVERFLOW_THRESHOLD`.
- `ai/mcp/server/memory-core/config.template.mjs`: `remRunStateDir`, `remRunRecentLimit`, env `NEO_REM_RUN_STATE_DIR`, `NEO_REM_RUN_RECENT_LIMIT`.

Local follow-up: active clones with gitignored `ai/config.mjs` or `ai/mcp/server/memory-core/config.mjs` need a manual shape refresh or equivalent env overrides after merge. Harness/process restart is recommended for long-running orchestrator and Memory Core MCP processes so they read the new keys.

## Slot Rationale

- Modified `learn/agentos/rem-state-model.md`: disposition `keep`; delta is `rewrite` from future Phase 2 pointer to current durable-cycle operator contract. Rating: trigger-frequency medium x failure-severity high x enforceability medium. Decay mitigation: rewrite or retire this section when the REM state store schema changes or a later retention policy supersedes the JSONL operator guidance.

## Test Evidence

- `node --check` passed for modified runtime modules, config templates, and touched specs.
- `npm run test-unit -- test/playwright/unit/ai/services/memory-core/helpers/RemRunStateStore.spec.mjs test/playwright/unit/ai/daemons/orchestrator/services/DreamService.executeRemCycle.spec.mjs test/playwright/unit/ai/services/rem-observability.spec.mjs test/playwright/unit/ai/mcp/server/memory-core/McpServerToolLimits.spec.mjs` -> 45 passed.
- `git diff --check` and `git diff --cached --check` passed.
- Pre-push freshness check: `git rev-list --left-right --count origin/dev...HEAD` -> `0 1`.

## Post-Merge Validation

- [ ] Refresh ignored local config overlays or set the new env vars in active clones, then restart long-running orchestrator/Memory Core processes.
- [ ] After the next real REM cycle, call `get_rem_pipeline_state` and inspect `.neo-ai-data/rem-runs/<runId>.jsonl` for live `wallClockMs`, `cycleOverflowRatio`, and phase/session telemetry.

## Commit

- `1ebf2c939` — `feat(ai): add REM run state tracking (#12088)`