### PR TITLE
feat(ai): add graph integrity audit runner (#10462)

### DIFF
--- a/ai/scripts/maintenance/auditGraphIntegrity.mjs
+++ b/ai/scripts/maintenance/auditGraphIntegrity.mjs
@@ -1,0 +1,464 @@
+import 'dotenv/config';
+import fsExtra         from 'fs-extra';
+import path            from 'path';
+import {fileURLToPath} from 'url';
+
+import {
+    Memory_GraphService as GraphService,
+    Memory_LifecycleService,
+    Memory_StorageRouter as StorageRouter
+} from '../../services.mjs';
+
+const __filename   = fileURLToPath(import.meta.url);
+const __dirname    = path.dirname(__filename);
+const PROJECT_ROOT = path.resolve(__dirname, '../../..');
+
+export const DEFAULT_AUDIT_ROOT = path.join(PROJECT_ROOT, '.neo-ai-data', 'audits');
+
+const SEVERITY_RANK = {
+    clean: 0,
+    soft : 1,
+    hard : 2
+};
+
+/**
+ * @summary Parse CLI arguments for the graph-integrity audit runner.
+ *
+ * The default threshold follows #10462: any non-zero divergence up to 5% is
+ * `soft`; divergence above 5% is `hard`. Operators can override it via
+ * `--hard-threshold` or `GRAPH_INTEGRITY_HARD_THRESHOLD`.
+ *
+ * @param {String[]} argv CLI argv slice.
+ * @param {Object} env Environment source.
+ * @returns {Object}
+ */
+export function parseArgs(argv, env = process.env) {
+    const args = {
+        outputDir    : env.GRAPH_INTEGRITY_AUDIT_DIR || DEFAULT_AUDIT_ROOT,
+        pageSize     : parsePositiveInt(env.GRAPH_INTEGRITY_PAGE_SIZE, 1000),
+        hardThreshold: parseRatio(env.GRAPH_INTEGRITY_HARD_THRESHOLD, 0.05)
+    };
+
+    for (let i = 0; i < argv.length; i++) {
+        const arg = argv[i];
+
+        if (arg === '--output-dir') {
+            args.outputDir = argv[++i];
+        } else if (arg.startsWith('--output-dir=')) {
+            args.outputDir = arg.slice('--output-dir='.length);
+        } else if (arg === '--page-size') {
+            args.pageSize = parsePositiveInt(argv[++i], args.pageSize);
+        } else if (arg.startsWith('--page-size=')) {
+            args.pageSize = parsePositiveInt(arg.slice('--page-size='.length), args.pageSize);
+        } else if (arg === '--hard-threshold') {
+            args.hardThreshold = parseRatio(argv[++i], args.hardThreshold);
+        } else if (arg.startsWith('--hard-threshold=')) {
+            args.hardThreshold = parseRatio(arg.slice('--hard-threshold='.length), args.hardThreshold);
+        } else if (arg === '--help' || arg === '-h') {
+            args.help = true;
+        } else {
+            throw new Error(`Unknown flag: ${arg}`);
+        }
+    }
+
+    return args;
+}
+
+/**
+ * @summary Group raw Memory Core Chroma rows by logical `sessionId`.
+ *
+ * @param {Object} collection Chroma-compatible memory collection.
+ * @param {Object} options
+ * @param {Number} options.pageSize Chroma pagination size.
+ * @returns {Promise<Map<String, Object>>}
+ */
+export async function collectMemorySessionCounts(collection, {pageSize = 1000} = {}) {
+    const counts = new Map();
+    let offset   = 0;
+
+    while (true) {
+        const page = await collection.get({
+            include: ['metadatas'],
+            limit  : pageSize,
+            offset
+        });
+
+        const ids = page?.ids || [];
+        if (ids.length === 0) break;
+
+        for (let i = 0; i < ids.length; i++) {
+            const
+                meta      = page.metadatas?.[i] || {},
+                sessionId = meta.sessionId;
+
+            if (!sessionId) continue;
+
+            const current = counts.get(sessionId) || {
+                sessionId,
+                expectedMemoryCount: 0,
+                userId             : meta.userId || null
+            };
+
+            current.expectedMemoryCount++;
+            if (!current.userId && meta.userId) current.userId = meta.userId;
+            counts.set(sessionId, current);
+        }
+
+        if (ids.length < pageSize) break;
+        offset += ids.length;
+    }
+
+    return counts;
+}
+
+/**
+ * @summary Map Chroma summary rows by logical `sessionId`.
+ *
+ * @param {Object} collection Chroma-compatible summary collection.
+ * @param {Object} options
+ * @param {Number} options.pageSize Chroma pagination size.
+ * @returns {Promise<Map<String, Object>>}
+ */
+export async function collectSummarySessions(collection, {pageSize = 1000} = {}) {
+    const sessions = new Map();
+    let offset     = 0;
+
+    while (true) {
+        const page = await collection.get({
+            include: ['metadatas'],
+            limit  : pageSize,
+            offset
+        });
+
+        const ids = page?.ids || [];
+        if (ids.length === 0) break;
+
+        for (let i = 0; i < ids.length; i++) {
+            const
+                meta      = page.metadatas?.[i] || {},
+                sessionId = meta.sessionId;
+
+            if (!sessionId) continue;
+
+            sessions.set(sessionId, {
+                sessionId,
+                chromaSessionId: ids[i],
+                title          : meta.title || null,
+                userId         : meta.userId || null
+            });
+        }
+
+        if (ids.length < pageSize) break;
+        offset += ids.length;
+    }
+
+    return sessions;
+}
+
+/**
+ * @summary List SESSION graph nodes directly from the Memory Core graph store.
+ *
+ * #10462 is an observation-only runner. This direct SQLite read mirrors the
+ * graph observability helpers without adding a public service method before
+ * the report contract has empirical mileage.
+ *
+ * @param {Object} graphService Memory GraphService singleton or test double.
+ * @returns {Map<String, Object>}
+ */
+export function listGraphSessions(graphService) {
+    const sqliteDb = graphService?.db?.storage?.db;
+    const sessions = new Map();
+
+    if (!sqliteDb) return sessions;
+
+    const rows = sqliteDb.prepare(`
+        SELECT id, data FROM Nodes
+        WHERE json_extract(data, '$.label') = 'SESSION'
+    `).all();
+
+    for (const row of rows) {
+        const
+            data      = JSON.parse(row.data),
+            sessionId = data.properties?.sessionId || stripSessionPrefix(row.id);
+
+        if (!sessionId) continue;
+
+        sessions.set(sessionId, {
+            sessionId,
+            sessionNodeId: row.id,
+            userId       : data.properties?.userId || null
+        });
+    }
+
+    return sessions;
+}
+
+/**
+ * @summary Create the graph-integrity report and exit-code contract.
+ *
+ * @param {Object} options
+ * @param {Map<String, Object>} options.memorySessionCounts Raw Chroma memory counts by session.
+ * @param {Map<String, Object>} options.summarySessions Chroma summary rows by session.
+ * @param {Map<String, Object>} options.graphSessions Graph SESSION nodes by session.
+ * @param {Function} options.getActualMemoryCount Returns graph `ORIGINATES_IN` count for a session.
+ * @param {Function} options.getEntityRelationCount Optional full entity-relation count.
+ * @param {String} options.generatedAt ISO timestamp.
+ * @param {Number} options.hardThreshold Hard threshold ratio.
+ * @returns {Object}
+ */
+export function createGraphIntegrityReport({
+    memorySessionCounts,
+    summarySessions,
+    graphSessions,
+    getActualMemoryCount,
+    getEntityRelationCount = null,
+    generatedAt    = new Date().toISOString(),
+    hardThreshold  = 0.05
+}) {
+    const sessionIds = new Set([
+        ...memorySessionCounts.keys(),
+        ...summarySessions.keys(),
+        ...graphSessions.keys()
+    ]);
+
+    const entries = [...sessionIds].sort().map(sessionId => {
+        const
+            memory       = memorySessionCounts.get(sessionId) || {},
+            summary      = summarySessions.get(sessionId) || {},
+            graph        = graphSessions.get(sessionId) || {},
+            expected     = memory.expectedMemoryCount || 0,
+            actual       = Number(getActualMemoryCount(sessionId) || 0),
+            entityCount  = typeof getEntityRelationCount === 'function'
+                ? Number(getEntityRelationCount(sessionId) || 0)
+                : null,
+            divergence   = expected - actual,
+            severity     = classifyDivergence({expected, actual, hardThreshold});
+
+        return {
+            sessionId,
+            sessionNodeId       : graph.sessionNodeId || `session:${sessionId}`,
+            chromaSessionId     : summary.chromaSessionId || null,
+            expectedMemoryCount : expected,
+            actualMemoryCount   : actual,
+            entityRelationCount : entityCount,
+            divergence,
+            divergenceRatio     : calculateDivergenceRatio(expected, actual),
+            severity,
+            graphSessionPresent : graphSessions.has(sessionId),
+            chromaMemoryPresent : memorySessionCounts.has(sessionId),
+            chromaSummaryPresent: summarySessions.has(sessionId),
+            userId              : graph.userId || memory.userId || summary.userId || null
+        };
+    });
+
+    const summary = summarizeEntries(entries);
+
+    return {
+        generatedAt,
+        thresholds: {
+            hardDivergenceRatio: hardThreshold
+        },
+        summary,
+        entries,
+        exitCode: summary.exitCode
+    };
+}
+
+/**
+ * @summary Run the audit against live Memory Core services and write the report.
+ *
+ * @param {Object} options
+ * @returns {Promise<Object>}
+ */
+export async function runAudit({
+    graphService  = GraphService,
+    storageRouter = StorageRouter,
+    lifecycle     = Memory_LifecycleService,
+    fsModule      = fsExtra,
+    outputDir     = DEFAULT_AUDIT_ROOT,
+    pageSize      = 1000,
+    hardThreshold = 0.05,
+    logger        = console
+} = {}) {
+    await lifecycle.ready();
+    await graphService.initAsync();
+
+    const [memoryCollection, summaryCollection] = await Promise.all([
+        storageRouter.getMemoryCollection(),
+        storageRouter.getSummaryCollection()
+    ]);
+
+    const [memorySessionCounts, summarySessions] = await Promise.all([
+        collectMemorySessionCounts(memoryCollection, {pageSize}),
+        collectSummarySessions(summaryCollection, {pageSize})
+    ]);
+
+    const graphSessions = listGraphSessions(graphService);
+
+    const report = createGraphIntegrityReport({
+        memorySessionCounts,
+        summarySessions,
+        graphSessions,
+        getActualMemoryCount  : sessionId => countGraphOriginatesInEdges(graphService, sessionId),
+        getEntityRelationCount: sessionId => graphService.getSessionEntityCount(sessionId),
+        hardThreshold
+    });
+
+    const reportPath = await writeReport(report, {fsModule, outputDir});
+    logger.log(`[auditGraphIntegrity] Wrote ${reportPath}`);
+    logger.log(`[auditGraphIntegrity] ${JSON.stringify(report.summary)}`);
+
+    return {report, reportPath, exitCode: report.exitCode};
+}
+
+/**
+ * @summary Persist the report as timestamped JSON under `.neo-ai-data/audits/`.
+ * @param {Object} report Report object.
+ * @param {Object} options
+ * @returns {Promise<String>} Absolute report path.
+ */
+export async function writeReport(report, {
+    fsModule  = fsExtra,
+    outputDir = DEFAULT_AUDIT_ROOT
+} = {}) {
+    await fsModule.ensureDir(outputDir);
+
+    const
+        safeTimestamp = report.generatedAt.replace(/:/g, '-'),
+        reportPath    = path.join(outputDir, `graph-integrity-${safeTimestamp}.json`);
+
+    await fsModule.writeJson(reportPath, report, {spaces: 2});
+    return reportPath;
+}
+
+/**
+ * @summary Count graph `ORIGINATES_IN` memory edges targeting one session.
+ *
+ * This is intentionally narrower than `GraphService.getSessionEntityCount()`,
+ * which counts every inbound entity relation to the session. #10462's
+ * `actualMemoryCount` contract compares raw Chroma memory rows with graph
+ * `ORIGINATES_IN(Memory -> Session)` edges, so the edge-type filter is part
+ * of the audit contract.
+ *
+ * @param {Object} graphService Memory GraphService singleton or test double.
+ * @param {String} sessionId Logical session ID, with or without `session:` prefix.
+ * @returns {Number}
+ */
+export function countGraphOriginatesInEdges(graphService, sessionId) {
+    if (!sessionId || typeof sessionId !== 'string') return 0;
+
+    const sqliteDb = graphService?.db?.storage?.db;
+    if (!sqliteDb) return 0;
+
+    const
+        normalizedId = normalizeSessionNodeId(graphService, sessionId),
+        stmt         = sqliteDb.prepare(`
+            SELECT count(*) as count FROM Edges
+            WHERE target = ?
+              AND type = 'ORIGINATES_IN'
+        `);
+
+    return Number(stmt.get(normalizedId)?.count || 0);
+}
+
+/**
+ * @summary Classify a session-level divergence.
+ * @param {Object} options
+ * @returns {String}
+ */
+export function classifyDivergence({expected, actual, hardThreshold = 0.05}) {
+    const divergence = Math.abs(expected - actual);
+
+    if (divergence === 0) return 'clean';
+    if (calculateDivergenceRatio(expected, actual) <= hardThreshold) return 'soft';
+    return 'hard';
+}
+
+function calculateDivergenceRatio(expected, actual) {
+    const divergence = Math.abs(expected - actual);
+    if (divergence === 0) return 0;
+    return expected > 0 ? divergence / expected : 1;
+}
+
+function summarizeEntries(entries) {
+    const summary = {
+        totalSessions       : entries.length,
+        clean               : 0,
+        soft                : 0,
+        hard                : 0,
+        graphMissing        : 0,
+        chromaMemoryMissing : 0,
+        chromaSummaryMissing: 0,
+        worstSeverity       : 'clean',
+        exitCode            : 0
+    };
+
+    for (const entry of entries) {
+        summary[entry.severity]++;
+        if (!entry.graphSessionPresent) summary.graphMissing++;
+        if (!entry.chromaMemoryPresent) summary.chromaMemoryMissing++;
+        if (!entry.chromaSummaryPresent) summary.chromaSummaryMissing++;
+
+        if (SEVERITY_RANK[entry.severity] > SEVERITY_RANK[summary.worstSeverity]) {
+            summary.worstSeverity = entry.severity;
+        }
+    }
+
+    summary.exitCode = SEVERITY_RANK[summary.worstSeverity];
+    return summary;
+}
+
+function parsePositiveInt(value, fallback) {
+    const parsed = parseInt(value, 10);
+    return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+}
+
+function parseRatio(value, fallback) {
+    const parsed = parseFloat(value);
+    return Number.isFinite(parsed) && parsed >= 0 ? parsed : fallback;
+}
+
+function stripSessionPrefix(id) {
+    return typeof id === 'string' ? id.replace(/^session:/i, '') : null;
+}
+
+function normalizeSessionNodeId(graphService, sessionId) {
+    const prefixed = /^(session|memory):/i.test(sessionId)
+        ? sessionId
+        : `session:${sessionId}`;
+
+    return typeof graphService?.normalizeGraphNodeId === 'function'
+        ? graphService.normalizeGraphNodeId(prefixed)
+        : prefixed.toLowerCase();
+}
+
+function printHelp() {
+    console.log([
+        'Usage: npm run ai:audit-integrity -- [options]',
+        '',
+        'Options:',
+        '  --output-dir <path>       Report directory (default: .neo-ai-data/audits)',
+        '  --page-size <n>           Chroma pagination size (default: 1000)',
+        '  --hard-threshold <ratio>  Hard severity threshold (default: 0.05)',
+        '  -h, --help                Show this help'
+    ].join('\n'));
+}
+
+async function main() {
+    const args = parseArgs(process.argv.slice(2));
+    if (args.help) {
+        printHelp();
+        return {exitCode: 0};
+    }
+
+    return runAudit(args);
+}
+
+if (process.argv[1] && fileURLToPath(import.meta.url) === path.resolve(process.argv[1])) {
+    main()
+        .then(({exitCode}) => process.exit(exitCode))
+        .catch(error => {
+            console.error('[auditGraphIntegrity] Fatal:', error);
+            process.exit(2);
+        });
+}

--- a/ai/scripts/maintenance/auditGraphIntegrity.mjs
+++ b/ai/scripts/maintenance/auditGraphIntegrity.mjs
@@ -1,4 +1,5 @@
 import 'dotenv/config';
+import {Command}       from 'commander';
 import fsExtra         from 'fs-extra';
 import path            from 'path';
 import {fileURLToPath} from 'url';
@@ -22,44 +23,66 @@ const SEVERITY_RANK = {
 };
 
 /**
- * @summary Parse CLI arguments for the graph-integrity audit runner.
+ * @summary Creates the Commander parser for the graph-integrity audit runner.
  *
  * The default threshold follows #10462: any non-zero divergence up to 5% is
  * `soft`; divergence above 5% is `hard`. Operators can override it via
  * `--hard-threshold` or `GRAPH_INTEGRITY_HARD_THRESHOLD`.
  *
+ * @param {Object} env Environment source.
+ * @returns {Command}
+ */
+function createArgParser(env = process.env) {
+    const program = new Command();
+
+    program
+        .name('ai:audit-integrity')
+        .description('Run the read-only Memory Core graph-integrity audit.')
+        .exitOverride()
+        .configureOutput({
+            writeErr: () => {},
+            writeOut: () => {}
+        })
+        .helpOption(false)
+        .allowExcessArguments(false)
+        .option('--output-dir <path>', 'Report directory.', env.GRAPH_INTEGRITY_AUDIT_DIR || DEFAULT_AUDIT_ROOT)
+        .option(
+            '--page-size <n>',
+            'Chroma pagination size.',
+            value => parsePositiveInt(value, 1000),
+            parsePositiveInt(env.GRAPH_INTEGRITY_PAGE_SIZE, 1000)
+        )
+        .option(
+            '--hard-threshold <ratio>',
+            'Hard severity threshold ratio.',
+            value => parseRatio(value, 0.05),
+            parseRatio(env.GRAPH_INTEGRITY_HARD_THRESHOLD, 0.05)
+        )
+        .option('-h, --help', 'Show help');
+
+    return program;
+}
+
+/**
+ * @summary Parse CLI arguments for the graph-integrity audit runner.
  * @param {String[]} argv CLI argv slice.
  * @param {Object} env Environment source.
  * @returns {Object}
  */
 export function parseArgs(argv, env = process.env) {
+    const program = createArgParser(env);
+
+    program.parse(argv, {from: 'user'});
+
+    const options = program.opts();
+
     const args = {
-        outputDir    : env.GRAPH_INTEGRITY_AUDIT_DIR || DEFAULT_AUDIT_ROOT,
-        pageSize     : parsePositiveInt(env.GRAPH_INTEGRITY_PAGE_SIZE, 1000),
-        hardThreshold: parseRatio(env.GRAPH_INTEGRITY_HARD_THRESHOLD, 0.05)
+        outputDir    : options.outputDir,
+        pageSize     : options.pageSize,
+        hardThreshold: options.hardThreshold
     };
 
-    for (let i = 0; i < argv.length; i++) {
-        const arg = argv[i];
-
-        if (arg === '--output-dir') {
-            args.outputDir = argv[++i];
-        } else if (arg.startsWith('--output-dir=')) {
-            args.outputDir = arg.slice('--output-dir='.length);
-        } else if (arg === '--page-size') {
-            args.pageSize = parsePositiveInt(argv[++i], args.pageSize);
-        } else if (arg.startsWith('--page-size=')) {
-            args.pageSize = parsePositiveInt(arg.slice('--page-size='.length), args.pageSize);
-        } else if (arg === '--hard-threshold') {
-            args.hardThreshold = parseRatio(argv[++i], args.hardThreshold);
-        } else if (arg.startsWith('--hard-threshold=')) {
-            args.hardThreshold = parseRatio(arg.slice('--hard-threshold='.length), args.hardThreshold);
-        } else if (arg === '--help' || arg === '-h') {
-            args.help = true;
-        } else {
-            throw new Error(`Unknown flag: ${arg}`);
-        }
-    }
+    if (options.help) args.help = true;
 
     return args;
 }
@@ -433,15 +456,7 @@ function normalizeSessionNodeId(graphService, sessionId) {
 }
 
 function printHelp() {
-    console.log([
-        'Usage: npm run ai:audit-integrity -- [options]',
-        '',
-        'Options:',
-        '  --output-dir <path>       Report directory (default: .neo-ai-data/audits)',
-        '  --page-size <n>           Chroma pagination size (default: 1000)',
-        '  --hard-threshold <ratio>  Hard severity threshold (default: 0.05)',
-        '  -h, --help                Show this help'
-    ].join('\n'));
+    console.log(createArgParser().helpInformation().trimEnd());
 }
 
 async function main() {

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
         "add-reactive-tags"            : "node ./buildScripts/helpers/addReactiveTags.mjs",
         "ai:agent"                     : "node ./ai/scripts/runners/runAgent.mjs",
         "ai:analyze-nl-telemetry"      : "node ./ai/scripts/diagnostics/analyzeNlTelemetry.mjs",
+        "ai:audit-integrity"           : "node ./ai/scripts/maintenance/auditGraphIntegrity.mjs",
         "ai:backup"                    : "node ./ai/scripts/maintenance/backup.mjs",
         "ai:benchmark-gemma4"          : "node ./ai/scripts/benchmark/gemma4-rem-benchmark.mjs",
         "ai:check-retired-primitives"  : "node ./ai/scripts/diagnostics/check-retired-primitives.mjs",

--- a/test/playwright/unit/ai/scripts/maintenance/auditGraphIntegrity.spec.mjs
+++ b/test/playwright/unit/ai/scripts/maintenance/auditGraphIntegrity.spec.mjs
@@ -1,0 +1,180 @@
+import {setup} from '../../../../setup.mjs';
+import Neo             from '../../../../../../src/Neo.mjs';
+import * as core       from '../../../../../../src/core/_export.mjs';
+import InstanceManager from '../../../../../../src/manager/Instance.mjs';
+
+const appName = 'AuditGraphIntegrityTest';
+
+setup({
+    neoConfig: {
+        allowVdomUpdatesInTests: false,
+        unitTestMode           : true,
+        useDomApiRenderer      : false
+    },
+    appConfig: {
+        name             : appName,
+        isMounted        : () => true,
+        vnodeInitialising: false
+    }
+});
+
+import {test, expect} from '@playwright/test';
+import fsExtra        from 'fs-extra';
+import os             from 'os';
+import path           from 'path';
+
+test.describe('auditGraphIntegrity.mjs (#10462)', () => {
+    let mod;
+    let workRoot;
+
+    test.beforeAll(async () => {
+        mod      = await import('../../../../../../ai/scripts/maintenance/auditGraphIntegrity.mjs');
+        workRoot = await fsExtra.mkdtemp(path.join(os.tmpdir(), 'audit-graph-integrity-'));
+    });
+
+    test.afterAll(async () => {
+        if (workRoot) await fsExtra.remove(workRoot);
+    });
+
+    test('parseArgs supports env defaults and CLI overrides', () => {
+        const args = mod.parseArgs([
+            '--output-dir=/tmp/audits',
+            '--page-size', '25',
+            '--hard-threshold', '0.10'
+        ], {
+            GRAPH_INTEGRITY_AUDIT_DIR     : '/env/audits',
+            GRAPH_INTEGRITY_PAGE_SIZE     : '50',
+            GRAPH_INTEGRITY_HARD_THRESHOLD: '0.07'
+        });
+
+        expect(args).toEqual({
+            outputDir    : '/tmp/audits',
+            pageSize     : 25,
+            hardThreshold: 0.10
+        });
+    });
+
+    test('collectMemorySessionCounts groups raw memories by sessionId across pages', async () => {
+        const collection = fakeCollection([
+            {id: 'm1', metadata: {sessionId: 'session-a', userId: 'neo-gpt'}},
+            {id: 'm2', metadata: {sessionId: 'session-a', userId: 'neo-gpt'}},
+            {id: 'm3', metadata: {sessionId: 'session-b', userId: 'neo-opus-4-7'}},
+            {id: 'm4', metadata: {missing: 'sessionId'}},
+            {id: 'm5', metadata: {sessionId: 'session-b', userId: 'neo-opus-4-7'}}
+        ]);
+
+        const counts = await mod.collectMemorySessionCounts(collection, {pageSize: 2});
+
+        expect([...counts.keys()].sort()).toEqual(['session-a', 'session-b']);
+        expect(counts.get('session-a').expectedMemoryCount).toBe(2);
+        expect(counts.get('session-b').expectedMemoryCount).toBe(2);
+        expect(collection.calls.map(call => call.offset)).toEqual([0, 2, 4]);
+    });
+
+    test('createGraphIntegrityReport classifies clean, soft, and hard sessions and returns worst exit code', () => {
+        const memorySessionCounts = new Map([
+            ['clean-session', {sessionId: 'clean-session', expectedMemoryCount: 10, userId: 'shared'}],
+            ['soft-session',  {sessionId: 'soft-session',  expectedMemoryCount: 100, userId: 'shared'}],
+            ['hard-session',  {sessionId: 'hard-session',  expectedMemoryCount: 100, userId: 'shared'}]
+        ]);
+        const summarySessions = new Map([
+            ['clean-session', {sessionId: 'clean-session', chromaSessionId: 'summary-clean'}],
+            ['soft-session',  {sessionId: 'soft-session',  chromaSessionId: 'summary-soft'}],
+            ['hard-session',  {sessionId: 'hard-session',  chromaSessionId: 'summary-hard'}]
+        ]);
+        const graphSessions = new Map([
+            ['clean-session', {sessionId: 'clean-session', sessionNodeId: 'session:clean-session'}],
+            ['soft-session',  {sessionId: 'soft-session',  sessionNodeId: 'session:soft-session'}],
+            ['hard-session',  {sessionId: 'hard-session',  sessionNodeId: 'session:hard-session'}]
+        ]);
+        const actualCounts = new Map([
+            ['clean-session', 10],
+            ['soft-session',  97],
+            ['hard-session',  80]
+        ]);
+
+        const report = mod.createGraphIntegrityReport({
+            memorySessionCounts,
+            summarySessions,
+            graphSessions,
+            generatedAt         : '2026-05-28T04:00:00.000Z',
+            hardThreshold       : 0.05,
+            getActualMemoryCount: sessionId => actualCounts.get(sessionId)
+        });
+
+        expect(report.summary).toMatchObject({
+            totalSessions: 3,
+            clean        : 1,
+            soft         : 1,
+            hard         : 1,
+            worstSeverity: 'hard',
+            exitCode     : 2
+        });
+
+        const soft = report.entries.find(entry => entry.sessionId === 'soft-session');
+        expect(soft).toMatchObject({
+            sessionNodeId      : 'session:soft-session',
+            chromaSessionId    : 'summary-soft',
+            expectedMemoryCount: 100,
+            actualMemoryCount  : 97,
+            divergence         : 3,
+            severity           : 'soft'
+        });
+        expect(soft.divergenceRatio).toBeCloseTo(0.03, 5);
+    });
+
+    test('countGraphOriginatesInEdges filters by target session and ORIGINATES_IN edge type', () => {
+        const graphService = {
+            normalizeGraphNodeId: id => id.toLowerCase(),
+            db: {
+                storage: {
+                    db: {
+                        prepare: sql => {
+                            expect(sql).toContain('FROM Edges');
+                            expect(sql).toContain("type = 'ORIGINATES_IN'");
+
+                            return {
+                                get: targetId => {
+                                    expect(targetId).toBe('session:abc-123');
+                                    return {count: 4};
+                                }
+                            };
+                        }
+                    }
+                }
+            }
+        };
+
+        expect(mod.countGraphOriginatesInEdges(graphService, 'SESSION:ABC-123')).toBe(4);
+    });
+
+    test('writeReport emits timestamped JSON under the audit directory', async () => {
+        const report = {
+            generatedAt: '2026-05-28T04:01:02.003Z',
+            summary    : {exitCode: 0},
+            entries    : [],
+            exitCode   : 0
+        };
+
+        const reportPath = await mod.writeReport(report, {outputDir: workRoot});
+
+        expect(path.basename(reportPath)).toBe('graph-integrity-2026-05-28T04-01-02.003Z.json');
+        expect(await fsExtra.readJson(reportPath)).toEqual(report);
+    });
+});
+
+function fakeCollection(rows) {
+    const calls = [];
+
+    return {
+        calls,
+        get: async ({limit, offset = 0}) => {
+            calls.push({limit, offset});
+            const sliced = rows.slice(offset, offset + limit);
+            return {
+                ids      : sliced.map(row => row.id),
+                metadatas: sliced.map(row => row.metadata)
+            };
+        }
+    };
+}


### PR DESCRIPTION
Authored by GPT-5 (Codex Desktop). Session f2619b83-0862-4a38-b5fa-11bcb9ee646d.

FAIR-band: in-band [15/30]

Resolves #10462

Adds `npm run ai:audit-integrity`, a read-only Memory Core graph-integrity audit that groups raw Chroma memories by logical session, compares them with graph `ORIGINATES_IN(Memory -> Session)` edges, writes timestamped JSON reports under `.neo-ai-data/audits/`, and returns severity exit codes for operator or CI branching.

Evidence: L3 (live read-only run against local ChromaDB + graph wrote a report and returned severity exit code) → L3 required (`npm run ai:audit-integrity` end-to-end + report/exit-code ACs). No residuals.

## Deltas from ticket

- Chose `ai/scripts/maintenance/auditGraphIntegrity.mjs` rather than the older `buildScripts/ai/...` option because current Structural Inventory and package scripts place one-shot AI maintenance runners under `ai/scripts/maintenance/`.
- `actualMemoryCount` intentionally filters graph `ORIGINATES_IN` edges. The broader #12081 `GraphService.getSessionEntityCount()` helper is included as `entityRelationCount` diagnostic context because it counts every inbound entity relation, not only memory completeness edges.
- Threshold and runtime controls are configurable via `GRAPH_INTEGRITY_HARD_THRESHOLD`, `GRAPH_INTEGRITY_PAGE_SIZE`, `GRAPH_INTEGRITY_AUDIT_DIR`, and matching CLI flags.

## Test Evidence

- `node --check ai/scripts/maintenance/auditGraphIntegrity.mjs`
- `node --check test/playwright/unit/ai/scripts/maintenance/auditGraphIntegrity.spec.mjs`
- `npm run test-unit -- test/playwright/unit/ai/scripts/maintenance/auditGraphIntegrity.spec.mjs` — 5 passed
- `git diff --check`
- `npm run ai:audit-integrity -- --output-dir /private/tmp/neo-graph-integrity-audit --page-size 5000` — wrote `/private/tmp/neo-graph-integrity-audit/graph-integrity-2026-05-28T04-12-22.785Z.json`; returned exit code 2 by contract because the live substrate currently reports `1137` sessions, `1110` hard divergences, `1109` missing graph sessions.

## Post-Merge Validation

- [ ] Operator can run `npm run ai:audit-integrity` and inspect the timestamped report under `.neo-ai-data/audits/`.
- [ ] Use the report to decide whether #10153 lazy back-fill or a narrower backfill follow-up should consume the detected missing graph-session set.

## Commits

- `3d834a77c` — `feat(ai): add graph integrity audit runner (#10462)`

## Evolution

V-B-A corrected one implementation assumption before commit: `GraphService.getSessionEntityCount()` is a broad entity-yield helper, not the exact memory-completeness count #10462 needs. The audit now uses a narrow read-only `ORIGINATES_IN` edge count for `actualMemoryCount` and keeps the broader helper as diagnostic context.