### PR TITLE
feat(ai): surface Sandman stale assignment candidates (#10219)

### DIFF
--- a/ai/mcp/server/memory-core/config.template.mjs
+++ b/ai/mcp/server/memory-core/config.template.mjs
@@ -19,6 +19,7 @@ const __dirname  = path.dirname(__filename);
 
 const neoRootDir = path.resolve(__dirname, '../../../../');
 const cwd        = neoRootDir;
+const DAY_MS     = 24 * 60 * 60 * 1000;
 
 /**
  * @summary Configuration manager for the Memory Core MCP server.
@@ -143,6 +144,22 @@ class Config extends BaseConfig {
              * @type {string}
              */
             handoffFilePath: leaf(path.resolve(cwd, 'resources/content/sandman_handoff.md')),
+            /**
+             * Stale-assignment idle threshold used by `GoldenPathSynthesizer` when rendering
+             * Sandman handoff candidates. Defaults to the ticket-intake 7-day reassignment rule.
+             * @type {number}
+             */
+            goldenPathStaleAssignmentThresholdMs: leaf(7 * DAY_MS, 'NEO_GOLDEN_PATH_STALE_ASSIGNMENT_THRESHOLD_MS', 'number'),
+            /**
+             * Maximum stale-assignment candidates rendered into the Sandman handoff.
+             * @type {number}
+             */
+            goldenPathStaleAssignmentRenderLimit: leaf(20, 'NEO_GOLDEN_PATH_STALE_ASSIGNMENT_RENDER_LIMIT', 'number'),
+            /**
+             * Maximum recent open PR rows rendered inside `Active PR Cycle State`.
+             * @type {number}
+             */
+            goldenPathRecentOpenPrRenderLimit: leaf(5, 'NEO_GOLDEN_PATH_RECENT_OPEN_PR_RENDER_LIMIT', 'number'),
             /**
              * The Hebbian decay factor applied every 24 hours to the edge graph (e.g., 0.98 for ~79 day half-life).
              * @type {number}

--- a/ai/services/graph/GoldenPathSynthesizer.mjs
+++ b/ai/services/graph/GoldenPathSynthesizer.mjs
@@ -1,4 +1,5 @@
 import fs from 'fs';
+import matter from 'gray-matter';
 import path from 'path';
 import {fileURLToPath} from 'url';
 import { Memory_Config as aiConfig } from '../../services.mjs';
@@ -8,10 +9,14 @@ import { Memory_TextEmbeddingService as TextEmbeddingService } from '../../servi
 import { Memory_GraphService as GraphService } from '../../services.mjs';
 import Json from '../../../src/util/Json.mjs';
 import logger from '../../mcp/server/memory-core/logger.mjs';
+import {IDENTITIES} from '../../graph/identityRoots.mjs';
 import {buildGraphProvider, resolveGraphModelProvider} from './providerDispatch.mjs';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname  = path.dirname(__filename);
+const DAY_MS     = 24 * 60 * 60 * 1000;
+
+const MAINTAINER_PROGRESS_PATTERN = /\b(?:in[-\s]?progress|picking up|taking|claim(?:ed|ing)?|lane-claim|lane-state:\s*next-lane|working|implement(?:ing)?|opened\s+(?:PR|pull request)|PR\s*#\d+)\b/i;
 
 /**
  * @summary Returns the vector length emitted by an embedding provider.
@@ -88,6 +93,343 @@ class GoldenPathSynthesizer extends Base {
     }
 
     /**
+     * @summary Derives the core swarm login-to-family map from the AgentIdentity registry.
+     *
+     * `identityRoots.mjs` is the canonical handle indirection seam for named Neo maintainers.
+     * Golden Path renders must consume that registry instead of duplicating agent handles in
+     * daemon code.
+     *
+     * @returns {Object<String,String>} GitHub login to model-family map.
+     */
+    static getCoreSwarmAgentFamilies() {
+        return Object.fromEntries(
+            IDENTITIES
+                .filter(identity =>
+                    identity.type === 'AgentIdentity' &&
+                    identity.properties?.accountType === 'agent' &&
+                    identity.properties?.githubLogin &&
+                    identity.properties?.modelFamily
+                )
+                .map(identity => [
+                    identity.properties.githubLogin.replace(/^@/, ''),
+                    identity.properties.modelFamily
+                ])
+        )
+    }
+
+    /**
+     * @summary Returns canonical Neo agent GitHub logins from `identityRoots.mjs`.
+     *
+     * @returns {String[]} Agent logins without leading `@`.
+     */
+    static getAgentLogins() {
+        return Object.keys(this.getCoreSwarmAgentFamilies())
+    }
+
+    /**
+     * @summary Returns maintainer logins eligible for stale-assignment progress acknowledgements.
+     *
+     * #10219 intentionally keys this active detector to named agent maintainers only. Human-owner
+     * activity still appears as issue events, but the maintainer progress-ack set is derived from
+     * registry AgentIdentity logins.
+     *
+     * @returns {String[]} Agent maintainer logins without leading `@`.
+     */
+    static getStaleAssignmentMaintainers() {
+        return this.getAgentLogins()
+    }
+
+    /**
+     * @summary Collects local issue markdown files from the ordinal content tree.
+     *
+     * The GitHub content sync stores active issues in chunk directories under
+     * `resources/content/issues/`. This recursive helper keeps Golden Path
+     * enrichment compatible with the ordinal-100 content architecture without
+     * coupling stale-assignment logic to a single chunk layout.
+     *
+     * @param {String} rootDir Directory containing synced issue markdown files.
+     * @returns {String[]} Absolute markdown file paths sorted lexically for deterministic output.
+     */
+    static collectIssueMarkdownFiles(rootDir) {
+        const files = [];
+
+        function visit(dir) {
+            for (const entry of fs.readdirSync(dir, {withFileTypes: true})) {
+                const entryPath = path.join(dir, entry.name);
+
+                if (entry.isDirectory()) {
+                    visit(entryPath);
+                } else if (entry.isFile() && entry.name.endsWith('.md')) {
+                    files.push(entryPath);
+                }
+            }
+        }
+
+        visit(rootDir);
+
+        return files.sort()
+    }
+
+    /**
+     * @summary Extracts GitHub issue comment blocks from synced issue markdown.
+     *
+     * IssueSyncer renders comments as `### @user - timestamp` blocks. Regex is
+     * intentionally scoped to that stable serialized timeline shape; frontmatter is
+     * parsed separately through `gray-matter`.
+     *
+     * @param {String} content Markdown body without frontmatter.
+     * @returns {Array<{author: String, createdAt: String, body: String}>}
+     */
+    static extractIssueCommentBlocks(content) {
+        const comments = [];
+        const commentRegex = /^### @([^\s]+) - ([^\n]+)\n\n([\s\S]*?)(?=^### @|^- \d{4}-\d{2}-\d{2}T|\n## |\s*$)/gm;
+        let match;
+
+        while ((match = commentRegex.exec(content)) !== null) {
+            comments.push({
+                author   : match[1],
+                createdAt: match[2].trim(),
+                body     : match[3].trim()
+            });
+        }
+
+        return comments
+    }
+
+    /**
+     * @summary Extracts assignment events for the currently assigned issue owners.
+     *
+     * Assignment events provide the conservative clock-start when no assignee or
+     * maintainer comment exists yet. They are not a substitute for the 7-day
+     * qualifying-activity rule; they only prevent missing-comment timelines from
+     * producing `unknown` last-activity rows.
+     *
+     * @param {String} content Markdown body without frontmatter.
+     * @param {String[]} assignees Current assignee logins.
+     * @returns {Array<{author: String, createdAt: String, assignee: String}>}
+     */
+    static extractAssignmentEvents(content, assignees = []) {
+        const assigneeSet = new Set(assignees);
+        const events = [];
+        const assignmentRegex = /^- (\d{4}-\d{2}-\d{2}T[^\s]+) @([^\s]+) assigned to @([^\s]+)/gm;
+        let match;
+
+        while ((match = assignmentRegex.exec(content)) !== null) {
+            if (assigneeSet.has(match[3])) {
+                events.push({
+                    createdAt: match[1],
+                    author   : match[2],
+                    assignee : match[3]
+                });
+            }
+        }
+
+        return events
+    }
+
+    /**
+     * @summary Finds the last activity that satisfies the ticket-intake 7-day reassignment rule.
+     *
+     * Qualifying activity is an assignee comment or a maintainer progress
+     * acknowledgement. Assignment events and issue creation are conservative
+     * fallbacks for otherwise silent issues.
+     *
+     * @param {Object} issue Parsed issue record.
+     * @param {String[]} issue.assignees Current assignee logins.
+     * @param {String} issue.createdAt Issue creation timestamp.
+     * @param {String} issue.content Markdown body without frontmatter.
+     * @param {String[]} [maintainers=this.getStaleAssignmentMaintainers()] Maintainer logins.
+     * @returns {{createdAt: Date, author: String, reason: String}}
+     */
+    static findLastQualifyingAssignmentActivity(issue, maintainers = this.getStaleAssignmentMaintainers()) {
+        const assigneeSet  = new Set(issue.assignees || []);
+        const maintainerSet = new Set(maintainers);
+        const candidates   = [];
+
+        for (const comment of this.extractIssueCommentBlocks(issue.content || '')) {
+            const createdAt = new Date(comment.createdAt);
+            if (Number.isNaN(createdAt.getTime())) continue;
+
+            if (assigneeSet.has(comment.author)) {
+                candidates.push({createdAt, author: comment.author, reason: 'assignee-comment'});
+            } else if (maintainerSet.has(comment.author) && MAINTAINER_PROGRESS_PATTERN.test(comment.body)) {
+                candidates.push({createdAt, author: comment.author, reason: 'maintainer-progress-ack'});
+            }
+        }
+
+        for (const event of this.extractAssignmentEvents(issue.content || '', issue.assignees || [])) {
+            const createdAt = new Date(event.createdAt);
+            if (!Number.isNaN(createdAt.getTime())) {
+                candidates.push({createdAt, author: event.author, reason: `assignment:${event.assignee}`});
+            }
+        }
+
+        const createdAt = new Date(issue.createdAt);
+        if (!Number.isNaN(createdAt.getTime())) {
+            candidates.push({createdAt, author: issue.author || 'unknown', reason: 'issue-created'});
+        }
+
+        candidates.sort((a, b) => b.createdAt - a.createdAt);
+
+        return candidates[0] || null
+    }
+
+    /**
+     * @summary Builds stale-assignment candidates from local synced issue markdown.
+     *
+     * @param {Object} options
+     * @param {String} options.issuesDir Local synced issue directory.
+     * @param {Date} [options.now=new Date()] Current clock for deterministic tests.
+     * @param {Number} [options.thresholdMs=aiConfig.goldenPathStaleAssignmentThresholdMs] Stale threshold.
+     * @param {String[]} [options.maintainers=this.getStaleAssignmentMaintainers()] Maintainer logins.
+     * @returns {Array<Object>} Stale candidates sorted by oldest qualifying activity first.
+     */
+    static buildStaleAssignmentCandidates({
+        issuesDir,
+        now = new Date(),
+        thresholdMs = aiConfig.goldenPathStaleAssignmentThresholdMs,
+        maintainers = this.getStaleAssignmentMaintainers()
+    }) {
+        const candidates = [];
+        const nowDate    = now instanceof Date ? now : new Date(now);
+
+        for (const filePath of this.collectIssueMarkdownFiles(issuesDir)) {
+            let parsed;
+            try {
+                parsed = matter(fs.readFileSync(filePath, 'utf-8'));
+            } catch (error) {
+                logger.warn(`[GoldenPathSynthesizer] Failed to parse issue markdown for stale-assignment detector: ${filePath}`, error);
+                continue;
+            }
+
+            const meta      = parsed.data || {};
+            const labels    = Array.isArray(meta.labels) ? meta.labels : [];
+            const assignees = Array.isArray(meta.assignees) ? meta.assignees.filter(Boolean) : [];
+
+            if (meta.state !== 'OPEN' ||
+                assignees.length === 0 ||
+                labels.includes('needs-re-triage')) {
+                continue;
+            }
+
+            const lastActivity = this.findLastQualifyingAssignmentActivity({
+                assignees,
+                author   : meta.author,
+                content  : parsed.content,
+                createdAt: meta.createdAt
+            }, maintainers);
+
+            if (!lastActivity) continue;
+
+            const idleMs = nowDate - lastActivity.createdAt;
+            if (idleMs >= thresholdMs) {
+                candidates.push({
+                    assignees,
+                    daysIdle      : Math.floor(idleMs / DAY_MS),
+                    filePath,
+                    lastActivityAt: lastActivity.createdAt.toISOString(),
+                    lastActivityBy: lastActivity.author,
+                    number        : meta.id,
+                    reason        : lastActivity.reason,
+                    title         : meta.title || '(no title)',
+                    url           : meta.githubUrl
+                });
+            }
+        }
+
+        candidates.sort((a, b) => new Date(a.lastActivityAt) - new Date(b.lastActivityAt));
+
+        return candidates
+    }
+
+    /**
+     * @summary Renders the Sandman handoff stale-assignment section.
+     *
+     * @param {Array<Object>} candidates Stale assignment candidates.
+     * @param {Object} options
+     * @param {Date} [options.capturedAt=new Date()] Capture timestamp.
+     * @param {Number} [options.limit=aiConfig.goldenPathStaleAssignmentRenderLimit] Maximum candidates to render.
+     * @returns {String}
+     */
+    static renderStaleAssignmentCandidatesSection(candidates, {
+        capturedAt = new Date(),
+        limit = aiConfig.goldenPathStaleAssignmentRenderLimit
+    } = {}) {
+        let section = `\n## Stale Assignment Candidates\n\n`;
+        section += `*Captured at: ${capturedAt.toISOString()} (Source: local issue sync)*\n\n`;
+
+        if (candidates.length === 0) {
+            section += `No stale assignment candidates detected.\n`;
+            return section
+        }
+
+        const visibleCandidates = candidates.slice(0, limit);
+
+        if (candidates.length > visibleCandidates.length) {
+            section += `Showing ${visibleCandidates.length} of ${candidates.length} candidates, sorted oldest qualifying activity first.\n\n`;
+        }
+
+        for (const candidate of visibleCandidates) {
+            const assignees = candidate.assignees.map(assignee => `@${assignee}`).join(', ');
+            const issueRef  = candidate.url ? `[#${candidate.number}](${candidate.url})` : `#${candidate.number}`;
+            section += `- **${issueRef}** — ${candidate.title} — assignee ${assignees} — last qualifying activity ${candidate.lastActivityAt} by @${candidate.lastActivityBy} (${candidate.daysIdle} days ago; ${candidate.reason})\n`;
+        }
+
+        return section
+    }
+
+    /**
+     * @summary Determines whether a PR has cross-family review coverage.
+     *
+     * @param {Object} pr GitHub PR payload from `gh pr list`.
+     * @param {Object} [agentFamilies=this.getCoreSwarmAgentFamilies()] Login-to-family map.
+     * @returns {Boolean}
+     */
+    static hasCrossFamilyReview(pr, agentFamilies = this.getCoreSwarmAgentFamilies()) {
+        const authorLogin  = pr.author?.login;
+        const authorFamily = agentFamilies[authorLogin];
+        const reviews      = Array.isArray(pr.reviews) ? pr.reviews : [];
+
+        return reviews.some(review => {
+            const reviewerLogin = review.author?.login || review.author?.name || review.author?.login;
+            const reviewerFamily = agentFamilies[reviewerLogin];
+
+            if (!reviewerFamily) return false;
+            if (!authorFamily) return true;
+
+            return reviewerFamily !== authorFamily
+        })
+    }
+
+    /**
+     * @summary Renders a capped recent-open-PR list inside the existing Active PR Cycle section.
+     *
+     * @param {Object[]} prs GitHub PR payloads.
+     * @param {Object} options
+     * @param {Number} [options.limit=aiConfig.goldenPathRecentOpenPrRenderLimit] Maximum PRs to render.
+     * @returns {String}
+     */
+    static renderRecentOpenPrSummary(prs, {limit = aiConfig.goldenPathRecentOpenPrRenderLimit} = {}) {
+        const recent = [...prs]
+            .filter(pr => pr.createdAt)
+            .sort((a, b) => new Date(b.createdAt) - new Date(a.createdAt))
+            .slice(0, limit);
+
+        if (recent.length === 0) return '';
+
+        let section = `### Recent Open PRs\n`;
+
+        for (const pr of recent) {
+            const author = pr.author?.login || 'unknown';
+            section += `- **PR #${pr.number}**: [${pr.title}](${pr.url}) — author @${author} — opened ${pr.createdAt} — cross-family reviewed: ${this.hasCrossFamilyReview(pr) ? 'yes' : 'no'}\n`;
+        }
+
+        section += `\n`;
+
+        return section
+    }
+
+    /**
      * Synthesizes the Golden Path (strategic priorities) deterministically by analyzing Graph topology
      * combined with Vector Similarity (Hybrid GraphRAG).
      *
@@ -98,12 +440,14 @@ class GoldenPathSynthesizer extends Base {
      */
     async fetchOpenPRs() {
         const { execSync } = await import('child_process');
-        const rawPrData = execSync('gh pr list --state open --json number,url,author,title,body,headRefOid,reviewRequests,reviews,comments', { encoding: 'utf-8', stdio: ['pipe', 'pipe', 'ignore'] });
+        const rawPrData = execSync('gh pr list --state open --json number,url,author,title,body,headRefOid,reviewRequests,reviews,comments,createdAt', { encoding: 'utf-8', stdio: ['pipe', 'pipe', 'ignore'] });
         return JSON.parse(rawPrData);
     }
 
     async synthesizeGoldenPath({
-        repoEnrichmentEnabled = true
+        repoEnrichmentEnabled = true,
+        issuesDir = path.resolve(__dirname, '../../../resources/content/issues'),
+        now = new Date()
     } = {}) {
         logger.info('[GoldenPathSynthesizer] Initializing Hybrid GraphRAG Strategic Traversal...');
 
@@ -326,7 +670,7 @@ DO NOT output markdown, \`\`\`json blocks, or any other explanations. Provide pu
         handoffContent += `The Native Edge Graph has audited the codebase structurally. The following architectural coverage gaps currently exist natively within the SQLite matrix.\n\n`;
 
         const TTL_MS = 7 * 24 * 60 * 60 * 1000; // 7 days TTL (Time-to-Live)
-        const now = Date.now();
+        const gapNow = Date.now();
         let gapElementsCount = 0;
         let prunedGaps = 0;
 
@@ -339,7 +683,7 @@ DO NOT output markdown, \`\`\`json blocks, or any other explanations. Provide pu
 
         GraphService.db.nodes.items.forEach(node => {
             if (node.properties?.capabilityGap) {
-                const age = now - (node.properties.lastGapCheck || now);
+                const age = gapNow - (node.properties.lastGapCheck || gapNow);
                 if (age > TTL_MS) {
                     // Stale, prune it!
                     delete node.properties.capabilityGap;
@@ -447,18 +791,36 @@ DO NOT output markdown, \`\`\`json blocks, or any other explanations. Provide pu
             logger.warn(`[GoldenPathSynthesizer] ConsumerFriction section render failed: ${err.message}`);
         }
 
+        // --- Stale Assignment Candidates ---
+        let staleAssignmentAppend = '';
+        if (repoEnrichmentEnabled) {
+            try {
+                const Synthesizer = this.constructor;
+                const staleCandidates = Synthesizer.buildStaleAssignmentCandidates({
+                    issuesDir,
+                    now
+                });
+
+                staleAssignmentAppend = Synthesizer.renderStaleAssignmentCandidatesSection(staleCandidates, {capturedAt: now instanceof Date ? now : new Date(now)});
+            } catch (e) {
+                logger.warn('[GoldenPathSynthesizer] Failed to generate Stale Assignment Candidates', e);
+            }
+        }
+
         // --- Active PR Cycle State ---
         let prStateAppend = '';
         if (repoEnrichmentEnabled) {
             try {
+                const Synthesizer = this.constructor;
                 const prs = await this.fetchOpenPRs();
 
-                const agentLogins = ['neo-opus-4-7', 'neo-gemini-3-1-pro', 'neo-gpt'];
+                const agentLogins = Synthesizer.getAgentLogins();
                 const agentPrs = prs.filter(pr => pr.author && agentLogins.includes(pr.author.login));
 
-                if (agentPrs.length > 0) {
+                if (prs.length > 0) {
                     prStateAppend += `\n## Active PR Cycle State\n\n`;
                     prStateAppend += `*Captured at: ${new Date().toISOString()} (Source: GitHub Live)*\n\n`;
+                    prStateAppend += Synthesizer.renderRecentOpenPrSummary(prs);
 
                     // Group by agent
                     agentLogins.forEach(agent => {
@@ -574,7 +936,7 @@ DO NOT output markdown, \`\`\`json blocks, or any other explanations. Provide pu
             }
         }
 
-        handoffContent += `${prStateAppend}${backlogAppend}${markdownAppend}`;
+        handoffContent += `${staleAssignmentAppend}${prStateAppend}${backlogAppend}${markdownAppend}`;
 
         const handoffFile = aiConfig.handoffFilePath;
         fs.writeFileSync(handoffFile, handoffContent.trim() + '\n', 'utf-8');

--- a/test/playwright/unit/ai/services/graph/GoldenPathSynthesizer.spec.mjs
+++ b/test/playwright/unit/ai/services/graph/GoldenPathSynthesizer.spec.mjs
@@ -23,11 +23,15 @@ import child_process  from 'child_process';
 import {TestLifecycleHelper} from '../../services/memory-core/util.mjs';
 
 test.describe('Neo.ai.daemons.services.GoldenPathSynthesizer', () => {
+    test.describe.configure({mode: 'serial'});
+
     let GoldenPathSynthesizer;
     let aiConfig;
     let logger;
     let GraphService;
     let SystemLifecycleService;
+    let buildStaleAssignmentCandidates;
+    let renderStaleAssignmentCandidatesSection;
 
     let StorageRouter;
     let TextEmbeddingService;
@@ -35,6 +39,9 @@ test.describe('Neo.ai.daemons.services.GoldenPathSynthesizer', () => {
     let originalExecSync;
     let originalEmbeddingModel;
     let originalEmbeddingProvider;
+    let originalGoldenPathRecentOpenPrRenderLimit;
+    let originalGoldenPathStaleAssignmentRenderLimit;
+    let originalGoldenPathStaleAssignmentThresholdMs;
     let originalVectorDimension;
     let originalWarn;
 
@@ -53,7 +60,10 @@ test.describe('Neo.ai.daemons.services.GoldenPathSynthesizer', () => {
         tmpHandoffFile = path.join(tmpDir, `mock_sandman_handoff_${process.pid}_${Date.now()}.md`);
         aiConfig.handoffFilePath = tmpHandoffFile;
 
-        GoldenPathSynthesizer = (await import('../../../../../../ai/services/graph/GoldenPathSynthesizer.mjs')).default;
+        const GoldenPathSynthesizerModule = await import('../../../../../../ai/services/graph/GoldenPathSynthesizer.mjs');
+        GoldenPathSynthesizer = GoldenPathSynthesizerModule.default;
+        buildStaleAssignmentCandidates = GoldenPathSynthesizer.constructor.buildStaleAssignmentCandidates.bind(GoldenPathSynthesizer.constructor);
+        renderStaleAssignmentCandidatesSection = GoldenPathSynthesizer.constructor.renderStaleAssignmentCandidatesSection.bind(GoldenPathSynthesizer.constructor);
         GraphService = (await import('../../../../../../ai/services/memory-core/GraphService.mjs')).default;
         SystemLifecycleService = (await import('../../../../../../ai/services/memory-core/lifecycle/SystemLifecycleService.mjs')).default;
         StorageRouter = (await import('../../../../../../ai/services.mjs')).Memory_StorageRouter;
@@ -67,13 +77,23 @@ test.describe('Neo.ai.daemons.services.GoldenPathSynthesizer', () => {
         originalEmbeddingModel    = aiConfig.embeddingModel;
         originalEmbeddingProvider = aiConfig.embeddingProvider;
         originalExecSync          = child_process.execSync;
+        originalGoldenPathRecentOpenPrRenderLimit       = aiConfig.goldenPathRecentOpenPrRenderLimit;
+        originalGoldenPathStaleAssignmentRenderLimit    = aiConfig.goldenPathStaleAssignmentRenderLimit;
+        originalGoldenPathStaleAssignmentThresholdMs    = aiConfig.goldenPathStaleAssignmentThresholdMs;
         originalVectorDimension   = aiConfig.vectorDimension;
         originalWarn              = logger.warn;
+
+        aiConfig.goldenPathRecentOpenPrRenderLimit       = 5;
+        aiConfig.goldenPathStaleAssignmentRenderLimit    = 20;
+        aiConfig.goldenPathStaleAssignmentThresholdMs    = 7 * 24 * 60 * 60 * 1000;
     });
 
     test.afterEach(() => {
         aiConfig.embeddingModel    = originalEmbeddingModel;
         aiConfig.embeddingProvider = originalEmbeddingProvider;
+        aiConfig.goldenPathRecentOpenPrRenderLimit       = originalGoldenPathRecentOpenPrRenderLimit;
+        aiConfig.goldenPathStaleAssignmentRenderLimit    = originalGoldenPathStaleAssignmentRenderLimit;
+        aiConfig.goldenPathStaleAssignmentThresholdMs    = originalGoldenPathStaleAssignmentThresholdMs;
         aiConfig.vectorDimension   = originalVectorDimension;
         child_process.execSync     = originalExecSync;
         logger.warn                = originalWarn;
@@ -106,10 +126,11 @@ test.describe('Neo.ai.daemons.services.GoldenPathSynthesizer', () => {
                 author: { login: "neo-gemini-3-1-pro" },
                 title: "feat(ai): Automate PR Cycle State Extraction",
                 body: "lane-state: AWAITING_REVIEW\nCycle 2",
+                createdAt: "2026-05-11T00:00:00Z",
                 headRefOid: "abcdef1234567890",
                 reviewRequests: [{ login: "neo-opus-4-7" }],
                 reviews: [
-                    { state: "CHANGES_REQUESTED", body: "Needs more scope reduction.", submittedAt: "2026-05-11T00:00:00Z" }
+                    { state: "CHANGES_REQUESTED", body: "Needs more scope reduction.", submittedAt: "2026-05-11T00:00:00Z", author: {login: "neo-opus-4-7"} }
                 ],
                 comments: []
             }
@@ -130,6 +151,8 @@ test.describe('Neo.ai.daemons.services.GoldenPathSynthesizer', () => {
         const handoffContent = fs.readFileSync(tmpHandoffFile, 'utf-8');
 
         expect(handoffContent).toContain('## Active PR Cycle State');
+        expect(handoffContent).toContain('### Recent Open PRs');
+        expect(handoffContent).toContain('cross-family reviewed: yes');
         expect(handoffContent).toContain('### @neo-gemini-3-1-pro');
         expect(handoffContent).toContain('- **PR #11178**: [feat(ai): Automate PR Cycle State Extraction](https://github.com/neomjs/neo/pull/11178)');
         expect(handoffContent).toContain('- **Lane State**: `AWAITING_REVIEW`');
@@ -144,6 +167,7 @@ test.describe('Neo.ai.daemons.services.GoldenPathSynthesizer', () => {
         const originalGetSummaryCollection = StorageRouter.getSummaryCollection;
         const originalEmbedText = TextEmbeddingService.embedText;
         const originalFetchOpenPRs = GoldenPathSynthesizer.fetchOpenPRs;
+        const issuesDir = fs.mkdtempSync(path.join(os.tmpdir(), 'neo-recent-pr-issues-'));
         aiConfig.vectorDimension = 2;
 
         StorageRouter.getGraphCollection = async () => ({ query: async () => ({ ids: [['mock-id']], distances: [[0.1]] }) });
@@ -165,7 +189,210 @@ test.describe('Neo.ai.daemons.services.GoldenPathSynthesizer', () => {
         const handoffContent = fs.readFileSync(tmpHandoffFile, 'utf-8');
 
         expect(handoffContent).not.toContain('## Active PR Cycle State');
+        expect(handoffContent).not.toContain('## Stale Assignment Candidates');
         expect(handoffContent).not.toContain('## 📋 Latest Priority Backlog');
+    });
+
+    test('synthesizeGoldenPath renders stale assignment candidates from local issue sync', async () => {
+        const originalGetGraphCollection = StorageRouter.getGraphCollection;
+        const originalGetSummaryCollection = StorageRouter.getSummaryCollection;
+        const originalEmbedText = TextEmbeddingService.embedText;
+        const originalFetchOpenPRs = GoldenPathSynthesizer.fetchOpenPRs;
+        const issuesDir = fs.mkdtempSync(path.join(os.tmpdir(), 'neo-stale-issues-'));
+        const chunkDir  = path.join(issuesDir, 'chunk-1');
+        const now       = new Date('2026-05-28T00:00:00Z');
+        aiConfig.vectorDimension = 2;
+
+        fs.mkdirSync(chunkDir, {recursive: true});
+        fs.writeFileSync(path.join(chunkDir, 'issue-9001.md'), [
+            '---',
+            'id: 9001',
+            "title: 'Old assigned issue'",
+            'state: OPEN',
+            'labels:',
+            '  - enhancement',
+            'assignees:',
+            '  - neo-opus-4-7',
+            "createdAt: '2026-05-01T00:00:00Z'",
+            "updatedAt: '2026-05-10T00:00:00Z'",
+            "githubUrl: 'https://github.com/neomjs/neo/issues/9001'",
+            'author: neo-opus-4-7',
+            '---',
+            '# Old assigned issue',
+            '',
+            '## Timeline',
+            '',
+            '- 2026-05-01T00:00:00Z @tobiu assigned to @neo-opus-4-7',
+            '### @neo-opus-4-7 - 2026-05-10T00:00:00Z',
+            '',
+            'working on this'
+        ].join('\n'));
+        fs.writeFileSync(path.join(chunkDir, 'issue-9002.md'), [
+            '---',
+            'id: 9002',
+            "title: 'Fresh assigned issue'",
+            'state: OPEN',
+            'labels:',
+            '  - enhancement',
+            'assignees:',
+            '  - neo-gpt',
+            "createdAt: '2026-05-01T00:00:00Z'",
+            "updatedAt: '2026-05-27T00:00:00Z'",
+            "githubUrl: 'https://github.com/neomjs/neo/issues/9002'",
+            'author: neo-gpt',
+            '---',
+            '# Fresh assigned issue',
+            '',
+            '## Timeline',
+            '',
+            '### @neo-gpt - 2026-05-27T00:00:00Z',
+            '',
+            'still in progress'
+        ].join('\n'));
+        fs.writeFileSync(path.join(chunkDir, 'issue-9003.md'), [
+            '---',
+            'id: 9003',
+            "title: 'Rejected assigned issue'",
+            'state: OPEN',
+            'labels:',
+            '  - enhancement',
+            '  - needs-re-triage',
+            'assignees:',
+            '  - neo-gpt',
+            "createdAt: '2026-05-01T00:00:00Z'",
+            "updatedAt: '2026-05-01T00:00:00Z'",
+            "githubUrl: 'https://github.com/neomjs/neo/issues/9003'",
+            'author: neo-gpt',
+            '---',
+            '# Rejected assigned issue'
+        ].join('\n'));
+
+        StorageRouter.getGraphCollection = async () => ({ query: async () => ({ ids: [['mock-id']], distances: [[0.1]] }) });
+        StorageRouter.getSummaryCollection = async () => ({ get: async () => ({ documents: ['mock document'] }) });
+        TextEmbeddingService.embedText = async () => [0.1, 0.2];
+        GoldenPathSynthesizer.fetchOpenPRs = async () => [];
+
+        try {
+            await GoldenPathSynthesizer.synthesizeGoldenPath({issuesDir, now});
+        } finally {
+            GoldenPathSynthesizer.fetchOpenPRs = originalFetchOpenPRs;
+            StorageRouter.getGraphCollection   = originalGetGraphCollection;
+            StorageRouter.getSummaryCollection = originalGetSummaryCollection;
+            TextEmbeddingService.embedText     = originalEmbedText;
+            fs.rmSync(issuesDir, {recursive: true, force: true});
+        }
+
+        const handoffContent = fs.readFileSync(tmpHandoffFile, 'utf-8');
+
+        expect(handoffContent).toContain('## Stale Assignment Candidates');
+        expect(handoffContent).toContain('[#9001](https://github.com/neomjs/neo/issues/9001)');
+        expect(handoffContent).toContain('assignee @neo-opus-4-7');
+        expect(handoffContent).toContain('last qualifying activity 2026-05-10T00:00:00.000Z by @neo-opus-4-7');
+        expect(handoffContent).not.toContain('Fresh assigned issue');
+        expect(handoffContent).not.toContain('Rejected assigned issue');
+    });
+
+    test('synthesizeGoldenPath lists the 5 most recent open PRs with cross-family status', async () => {
+        const originalGetGraphCollection = StorageRouter.getGraphCollection;
+        const originalGetSummaryCollection = StorageRouter.getSummaryCollection;
+        const originalEmbedText = TextEmbeddingService.embedText;
+        const originalFetchOpenPRs = GoldenPathSynthesizer.fetchOpenPRs;
+        const issuesDir = fs.mkdtempSync(path.join(os.tmpdir(), 'neo-recent-pr-issues-'));
+        aiConfig.vectorDimension = 2;
+
+        StorageRouter.getGraphCollection = async () => ({ query: async () => ({ ids: [['mock-id']], distances: [[0.1]] }) });
+        StorageRouter.getSummaryCollection = async () => ({ get: async () => ({ documents: ['mock document'] }) });
+        TextEmbeddingService.embedText = async () => [0.1, 0.2];
+        GoldenPathSynthesizer.fetchOpenPRs = async () => [1, 2, 3, 4, 5, 6].map(number => ({
+            number,
+            url: `https://github.com/neomjs/neo/pull/${number}`,
+            author: {login: 'external-dev'},
+            title: `PR ${number}`,
+            body: '',
+            createdAt: `2026-05-${String(number).padStart(2, '0')}T00:00:00Z`,
+            headRefOid: `sha-${number}`,
+            reviewRequests: [],
+            reviews: number === 6 ? [{state: 'APPROVED', body: 'LGTM', submittedAt: '2026-05-06T01:00:00Z', author: {login: 'neo-opus-4-7'}}] : [],
+            comments: []
+        }));
+
+        try {
+            await GoldenPathSynthesizer.synthesizeGoldenPath({issuesDir});
+        } finally {
+            GoldenPathSynthesizer.fetchOpenPRs = originalFetchOpenPRs;
+            StorageRouter.getGraphCollection   = originalGetGraphCollection;
+            StorageRouter.getSummaryCollection = originalGetSummaryCollection;
+            TextEmbeddingService.embedText     = originalEmbedText;
+            fs.rmSync(issuesDir, {recursive: true, force: true});
+        }
+
+        const handoffContent = fs.readFileSync(tmpHandoffFile, 'utf-8');
+
+        expect(handoffContent).toContain('### Recent Open PRs');
+        expect(handoffContent).toContain('**PR #6**');
+        expect(handoffContent).toContain('cross-family reviewed: yes');
+        expect(handoffContent).toContain('**PR #2**');
+        expect(handoffContent).not.toContain('**PR #1**');
+    });
+
+    test('buildStaleAssignmentCandidates returns an empty set when no synced issue is stale', () => {
+        const issuesDir = fs.mkdtempSync(path.join(os.tmpdir(), 'neo-fresh-issues-'));
+        const chunkDir = path.join(issuesDir, 'chunk-1');
+        fs.mkdirSync(chunkDir, {recursive: true});
+        fs.writeFileSync(path.join(chunkDir, 'issue-9100.md'), [
+            '---',
+            'id: 9100',
+            "title: 'Fresh issue'",
+            'state: OPEN',
+            'labels:',
+            '  - enhancement',
+            'assignees:',
+            '  - neo-gpt',
+            "createdAt: '2026-05-20T00:00:00Z'",
+            "updatedAt: '2026-05-27T00:00:00Z'",
+            "githubUrl: 'https://github.com/neomjs/neo/issues/9100'",
+            'author: neo-gpt',
+            '---',
+            '# Fresh issue',
+            '',
+            '### @neo-gpt - 2026-05-27T00:00:00Z',
+            '',
+            'working'
+        ].join('\n'));
+
+        try {
+            const candidates = buildStaleAssignmentCandidates({
+                issuesDir,
+                now: new Date('2026-05-28T00:00:00Z')
+            });
+
+            expect(candidates).toEqual([]);
+        } finally {
+            fs.rmSync(issuesDir, {recursive: true, force: true});
+        }
+    });
+
+    test('renderStaleAssignmentCandidatesSection caps noisy local issue sync output', () => {
+        const candidates = Array.from({length: 3}, (_, index) => ({
+            assignees     : ['neo-gpt'],
+            daysIdle      : 10 + index,
+            lastActivityAt: `2026-05-0${index + 1}T00:00:00.000Z`,
+            lastActivityBy: 'neo-gpt',
+            number        : 9200 + index,
+            reason        : 'assignee-comment',
+            title         : `Candidate ${index + 1}`,
+            url           : `https://github.com/neomjs/neo/issues/${9200 + index}`
+        }));
+
+        const section = renderStaleAssignmentCandidatesSection(candidates, {
+            capturedAt: new Date('2026-05-28T00:00:00Z'),
+            limit     : 2
+        });
+
+        expect(section).toContain('Showing 2 of 3 candidates');
+        expect(section).toContain('Candidate 1');
+        expect(section).toContain('Candidate 2');
+        expect(section).not.toContain('Candidate 3');
     });
 
     test('synthesizeGoldenPath does not compose KB tenant telemetry into the handoff', () => {


### PR DESCRIPTION
Resolves #10219

Authored by GPT-5.5 (Codex Desktop). Session 019e6bee-56cb-77a3-9fc5-c175d289418c.

FAIR-band: in-band [14/30 — current author count over last 30 merged; verifier returned neo-opus-4-7:16, neo-gpt:14].

Adds Sandman handoff visibility for stale assigned tickets and broadens the Active PR Cycle State so the handoff shows the five newest open PRs, not only agent-authored PR groups. The stale-assignment detector reads the local synced issue markdown tree, applies the ticket-intake 7-day qualifying-activity rule, skips `needs-re-triage`, and renders a capped candidate list so `sandman_handoff.md` stays usable under large backlogs.

Evidence: L2 (unit-tested GoldenPathSynthesizer handoff composition with mocked GitHub PRs and local issue-sync fixtures) -> L3 required (post-merge Sandman/GoldenPath run against live synced repo state). Residual: post-merge handoff spot-check [#10219].

## Deltas from ticket

- Uses local `resources/content/issues` markdown as the candidate source instead of adding a live GitHub query path inside Sandman.
- Caps rendered stale candidates at the configured `goldenPathStaleAssignmentRenderLimit` and reports the full candidate count when capped.
- Adds a configured `Recent Open PRs` subsection with cross-family review status so non-agent open PRs still appear in the handoff.

## Deltas from Cycle-2 review

- Rebased onto current `origin/dev` after the recent merge wave.
- Replaced hardcoded Neo agent identities with `identityRoots.mjs`-derived AgentIdentity logins and model families.
- Moved stale-assignment threshold/render cap and recent-open-PR cap into `ai/mcp/server/memory-core/config.template.mjs` with env bindings.
- Moved the new stale-assignment and recent-open-PR helpers into static methods on `GoldenPathSynthesizer`; the spec now calls the class-static surface through the singleton constructor.
- Marked the GoldenPathSynthesizer unit describe block serial because it mutates Neo singleton/config state and the normal focused command had stale parallel import failures before serializing.

## Test Evidence

- `node --check ai/services/graph/GoldenPathSynthesizer.mjs`
- `node --check ai/mcp/server/memory-core/config.template.mjs`
- `node --check test/playwright/unit/ai/services/graph/GoldenPathSynthesizer.spec.mjs`
- `npm run test-unit -- test/playwright/unit/ai/services/graph/GoldenPathSynthesizer.spec.mjs` — 9 passed
- `npm run test-unit -- test/playwright/unit/ai/services/graph/GoldenPathSynthesizer.spec.mjs --workers=1` — 9 passed
- `git diff --check origin/dev...HEAD`
- Assignment gate verified with `gh api repos/neomjs/neo/issues/10219 --jq ...` -> open, assigned to `neo-gpt`, labels present
- Knowledge Base healthcheck: unhealthy, collection missing; intake used live GitHub, source reads, and Memory Core instead.

## Post-Merge Validation

- [ ] Run the next Sandman/GoldenPath cycle and confirm `resources/content/sandman_handoff.md` includes capped `Stale Assignment Candidates` plus `Recent Open PRs`.
- [ ] Spot-check at least one stale candidate against the live GitHub issue thread before any reassignment/comment action.

## Commits

- `7d79155ba` — `feat(ai): surface Sandman stale assignment candidates (#10219)`