### PR TITLE
chore(ai): clean residual memory-core comments (#11922)

### DIFF
--- a/ai/services/memory-core/CoalescingEngineService.mjs
+++ b/ai/services/memory-core/CoalescingEngineService.mjs
@@ -4,7 +4,7 @@ import WebhookDeliveryService  from './WebhookDeliveryService.mjs';
 import logger                  from '../../mcp/server/memory-core/logger.mjs';
 
 /**
- * @summary Token-economy throttle / coalescing engine for the Phase 3 cross-harness
+ * @summary Token-economy throttle / coalescing engine for the cross-harness
  * autonomous wake substrate (ADR 0002 §6.4).
  *
  * Wake events MUST NOT be 1:1 with the underlying event stream at high velocity. This
@@ -18,7 +18,7 @@ import logger                  from '../../mcp/server/memory-core/logger.mjs';
  * subscription's trigger+filter spec. The engine maintains a per-subscription timer; at
  * timer fire, it builds a structured digest payload and dispatches to the channel
  * appropriate for `subscription.harnessTarget`:
- * - `mcp-notifications` → Shape A's MCP notification emit-point (wired by #10358)
+ * - `mcp-notifications` → raw MCP notification emit-point for direct MCP clients
  * - `a2a-webhook` → `WebhookDeliveryService.deliver` (Shape B, already wired)
  * - `bridge-daemon` → no-op (Shape C handles its own coalescing in-process per ADR §6.3)
  * - `disabled` / `none` → no-op (subscription opted out of push)
@@ -31,7 +31,6 @@ import logger                  from '../../mcp/server/memory-core/logger.mjs';
  * @extends Neo.core.Base
  * @singleton
  * @see learn/agentos/decisions/0002-phase3-wake-substrate-standards-alignment.md §6.4
- * @see #10357 (parent Epic) #10362 (this sub) #10358 (Shape A consumer)
  */
 class CoalescingEngineService extends Base {
     static config = {
@@ -128,9 +127,7 @@ class CoalescingEngineService extends Base {
         const target = subscription.harnessTarget;
 
         if (target === 'mcp-notifications') {
-            // TRACKING: #10400 - Bypass coalescing and emit raw events to mcp-notifications.
-            // External harnesses (like Antigravity IDE) expect raw event payloads directly,
-            // not the 'wake/digest' envelope.
+            // Direct MCP clients expect raw event payloads, not the `wake/digest` envelope.
             this._dispatchRaw(subscription, event).catch(e => {
                 logger.error(`[CoalescingEngine] _dispatchRaw failed: ${e.message}`);
             });
@@ -338,7 +335,7 @@ class CoalescingEngineService extends Base {
 
     /**
      * Dispatches a raw event envelope via the channel matching `subscription.harnessTarget`.
-     * Used exclusively for the `rawDelivery` bypass (Tracking: #10400).
+     * Used exclusively for the `rawDelivery` bypass.
      *
      * @protected
      * @param {Object} subscription
@@ -371,8 +368,7 @@ class CoalescingEngineService extends Base {
 
             for (const server of this.mcpServers) {
                 try {
-                    // TRACKING: #10400 Fix
-                    // The Antigravity IDE harness specifically expects raw events over MCP.
+                    // Direct MCP consumers expect raw events over MCP.
                     // We deliberately bypass the ADR 0002 `wake/digest` wire-contract here.
                     await server.notification({
                         method: 'notifications/message',

--- a/ai/services/memory-core/PermissionService.mjs
+++ b/ai/services/memory-core/PermissionService.mjs
@@ -7,9 +7,9 @@ import logger from '../../mcp/server/memory-core/logger.mjs';
 /**
  * @summary Service for managing cross-tenant permission edges in the Native Graph.
  *
- * Implements the explicit permission checks required for Phase 3 (#10146).
- * The default policy is strict-isolation (opt-in visibility). Permissions are
- * granted via Graph edges representing the capability.
+ * Implements explicit permission checks for the strict-isolation mailbox and
+ * memory-sharing model. The default policy is opt-in visibility: permissions
+ * are granted via Graph edges representing the capability.
  *
  * Edge Structure:
  * - A permission capability flows from the grantee to the granter.
@@ -40,7 +40,7 @@ class PermissionService extends Base {
      * @member {String[]} validScopes
      * @protected
      * @summary Whitelist of semantic edge types for agent-to-agent permissions.
-     * Includes BLOCKED_BY: A negative-intent primitive ensuring hard isolation overrides (e.g. #10255).
+     * Includes BLOCKED_BY: a negative-intent primitive ensuring hard isolation overrides.
      */
     validScopes = ['CAN_READ_INBOX_OF', 'CAN_READ_MEMORIES_OF', 'CAN_READ_SESSIONS_OF', 'CAN_REPLY_TO', 'BLOCKED_BY']
 
@@ -63,8 +63,8 @@ class PermissionService extends Base {
             throw new Error(`Invalid scope. Must be one of: ${this.validScopes.join(', ')}`);
         }
 
-        // Verify target exists in SQLite directly (not in-memory cache, per sibling ticket's
-        // lazy-load root-cause fix). Identity creation is a privileged operation (seedAgentIdentities.mjs);
+        // Verify target exists in SQLite directly, not in the in-memory cache. Identity
+        // creation is a privileged operation (seedAgentIdentities.mjs);
         // it should NOT be an implicit side-effect of a permission grant. Stubbing with type 'AGENT'
         // + stripped metadata destroys seed data and creates type-inconsistent nodes.
         // Pattern mirrors linkNodes:179-185 (FK-style existence guard).


### PR DESCRIPTION
Authored by GPT-5 (Codex Desktop). Session f2619b83-0862-4a38-b5fa-11bcb9ee646d.

FAIR-band: over-target [14/30] - taking this lane despite over-target because it is a tiny, already-assigned #11922 residual cleanup/closeout batch with no runtime surface and clears owned v13 cleanup debt.

Refs #11922
Related: #11912

Removes residual source-comment archaeology from two Memory Core files by rewriting historical phase/ticket markers into stable runtime-contract wording. This keeps the cleanup aligned with the #11912 source-comment contract while preserving behavior.

Evidence: L1 (static source-comment cleanup plus syntax/diff checks) -> L1 required (comment/JSDoc-only cleanup ACs). No residuals for this batch.

## Deltas from ticket
- Narrowed to `PermissionService.mjs` and `CoalescingEngineService.mjs` residual anchors discovered after earlier #11922 merges.
- Preserved runtime behavior and runtime strings; no generated/config surfaces touched.

## Test Evidence
- `git grep -n -E "#[0-9]{4,}|PR #[0-9]{4,}|AC[0-9]+|Cycle [0-9]|cycle-[0-9]|Discussion #[0-9]{4,}|phase [0-9]" origin/dev -- ai/services/memory-core/PermissionService.mjs ai/services/memory-core/CoalescingEngineService.mjs` showed 7 pre-existing residual anchors in touched files.
- `rg -n "#[0-9]{4,}|PR #[0-9]{4,}|AC[0-9]+|Cycle [0-9]|cycle-[0-9]|Discussion #[0-9]{4,}|phase [0-9]" ai/services/memory-core/PermissionService.mjs ai/services/memory-core/CoalescingEngineService.mjs` returned no matches after cleanup.
- `node --check ai/services/memory-core/PermissionService.mjs` passed.
- `node --check ai/services/memory-core/CoalescingEngineService.mjs` passed.
- `git diff --check origin/dev...HEAD` passed.
- Branch freshness: `merge-base HEAD origin/dev == origin/dev`; branch history contains only `f5ccfbd2f chore(ai): clean residual memory-core comments (#11922)`.

## Post-Merge Validation
- [ ] Re-run the #11922 focused diagnostic when the broader Memory Core group is ready for issue closeout.

## Commit
- `f5ccfbd2f` - `chore(ai): clean residual memory-core comments (#11922)`