### PR TITLE
docs(cloud-deployment): document provider keep_alive + orchestrator-readiness env vars (#12094)

### DIFF
--- a/learn/agentos/cloud-deployment/Configuration.md
+++ b/learn/agentos/cloud-deployment/Configuration.md
@@ -97,6 +97,36 @@ The YAML is bootstrap-only — the graph node is canonical once written. A malfo
 
 The default-resolved tier means a single-repo deployment needs no tenant config at all: `getTenantConfig` falls through to tier 3 (`aiConfig`), which carries Neo's defaults. Divergence is opt-in and granular — a tenant overrides only the keys its topology requires. See [Migration Path](./MigrationPath.md) for the full zero-config upgrade story.
 
+## Model-provider runtime + orchestrator-readiness
+
+Beyond KB ingestion, a cloud deployment tunes the model-provider request behaviour and the orchestrator's provider-readiness probe through five env vars. All carry resident-friendly defaults — a zero-config deployment keeps local models warm across REM/Sandman cycles and probes patiently on cold start.
+
+### Provider request `keep_alive`
+
+| Variable | Default | Meaning |
+|---|---|---|
+| `NEO_OLLAMA_KEEP_ALIVE` | `-1` (resident) | Per-request `keep_alive` value Neo sends on every Ollama generation/stream call. `-1` keeps the model resident across cycles; a duration string (e.g. `5m`) or `0` (unload after request) overrides it. |
+| `NEO_OPENAI_COMPATIBLE_KEEP_ALIVE` | `-1` (resident) | Per-request `keep_alive` field for OpenAI-compatible servers that honour the Ollama extension (e.g. LM Studio, Ollama's `/v1/...` surface). Same `-1` / duration / `0` semantics. |
+
+**Native server var vs Neo per-request override.** A self-hosted Ollama server also reads a *native* `OLLAMA_KEEP_ALIVE` env var that controls the server's default cache retention for requests arriving *without* a per-request `keep_alive`. These are distinct surfaces, and the interaction matters:
+
+- Native `OLLAMA_KEEP_ALIVE` is the server default for requests that omit `keep_alive`.
+- Neo's `NEO_OLLAMA_KEEP_ALIVE` (default `-1`) is sent on *every* Neo-issued request and **overrides** the server default for that request.
+- So with Neo's `-1` default, the model stays resident regardless of the native `OLLAMA_KEEP_ALIVE` value.
+- An operator who shortens native `OLLAMA_KEEP_ALIVE` to reclaim host memory must **also** set `NEO_OLLAMA_KEEP_ALIVE` to a matching shorter window — otherwise Neo's per-request `-1` keeps the model pinned and the native shortening has no effect on Neo traffic.
+
+### Orchestrator provider-readiness probe
+
+Before the orchestrator runs a model-dependent task (e.g. the REM/Sandman dream cycle), it probes the configured provider until the provider answers or the retry budget is exhausted. Tuning is useful on cold-start-slow or capacity-constrained hosts.
+
+| Variable | Default | Meaning |
+|---|---|---|
+| `NEO_ORCHESTRATOR_PROVIDER_READY_ATTEMPTS` | `30` | Maximum readiness-probe attempts before the orchestrator gives up on the provider for that cycle. |
+| `NEO_ORCHESTRATOR_PROVIDER_READY_DELAY_MS` | `1000` | Wait between probe attempts (ms). |
+| `NEO_ORCHESTRATOR_PROVIDER_READY_TIMEOUT_MS` | `3000` | Per-probe HTTP timeout (ms). |
+
+These three are orchestrator-config-scoped (`ai/config.template.mjs` `orchestrator.providerReadiness`) and are not read by the MCP server processes, so — unlike the two `keep_alive` vars above — they do not appear in the MCP-server-scoped [Config Substrate Env-Var Audit](../ConfigSubstrateEnvVarAudit.md).
+
 ## Related
 
 - [Overview](./Overview.md) — the contract split + default-source inheritance.


### PR DESCRIPTION
Refs #12094

Authored by Claude Opus 4.7 1M (Claude Code). Session `d84680be-4fdb-4b5d-9fe8-e83dad71dfbe`.

FAIR-band: nightshift-exempt per operator directive (2026-05-28 ~00:58Z: "FAIR bands do not apply for nightshifts").

Documents the 5 deployment env vars introduced by PR #12092 (orchestrator provider-readiness probe) + PR #12093 (provider `keep_alive` defaults), which shipped without cloud-deployment docs — `Configuration.md` had zero hits for any of them.

Evidence: L1 (static doc content — greppable presence of all 5 vars + the interaction note + scope-boundary explanation). No runtime ACs. No residuals on the Neo side.

## What shipped (Neo-side, AC1)

New "Model-provider runtime + orchestrator-readiness" section in `learn/agentos/cloud-deployment/Configuration.md`:
- `NEO_OLLAMA_KEEP_ALIVE` + `NEO_OPENAI_COMPATIBLE_KEEP_ALIVE` (default `-1`/resident; per-request override semantics)
- The **native `OLLAMA_KEEP_ALIVE` vs Neo `NEO_OLLAMA_KEEP_ALIVE`** interaction — the key operator friction: native-keep_alive shortening has no effect on Neo traffic unless `NEO_OLLAMA_KEEP_ALIVE` is also shortened (Neo sends its per-request `-1` on every call, overriding the server default).
- `NEO_ORCHESTRATOR_PROVIDER_READY_ATTEMPTS`/`DELAY_MS`/`TIMEOUT_MS` (defaults `30`/`1000`/`3000`; readiness-probe tuning).

## Deltas from ticket — AC2 scope-correction

#12094 AC2 planned to backfill the 3 `PROVIDER_READY_*` vars into `ConfigSubstrateEnvVarAudit.md`. **V-B-A deviation:** that audit explicitly scopes to `ai/mcp/server/**` env reads (its Scope section), and the PROVIDER_READY vars have **zero reads under `ai/mcp/server/**`** — they're orchestrator-daemon-scoped (`ai/config.template.mjs` `orchestrator.providerReadiness` → `ai/daemons/orchestrator/*` + `ai/services/graph/ProviderReadinessHelper.mjs`). Backfilling them would violate the audit's stated scope. The 2 keep_alive vars correctly remain in the audit (read by the memory-core MCP server at `ai/mcp/server/memory-core/config.template.mjs:459/469`). The new Configuration.md section documents this scope boundary inline rather than polluting the MCP-server audit. **AC2 is satisfied-by-correction: the audit doc is already correct for its scope; no change needed.**

## Residual (out of this PR — downstream repo)

AC3/AC4 (downstream-deployment `.env.example` commented examples + `README.md` operator-tuning section) are explicitly a **separate MR in the downstream-deployment repo** per the ticket. Using `Refs #12094` (not `Resolves`) so the ticket stays open until the downstream-side lands. Neo-side capability framing only; no commercial-partner names.

## Test Evidence

Docs-only — no tests required (per `pr-review-guide §7.5`). Verification:
- `grep -c` for all 5 vars in `Configuration.md`: was 0 → now 5 present.
- `grep` confirmed PROVIDER_READY vars have zero `ai/mcp/server/**` reads (AC2 scope basis).

## Post-Merge Validation

- [ ] Downstream-deployment `.env.example` + `README.md` updated in the downstream repo (AC3/AC4) — then close #12094.

## Commits

- `8c8decc4e` — docs(cloud-deployment): document provider keep_alive + orchestrator-readiness env vars (#12094)
