### PR TITLE
fix(data): autoLoad awaits remotes-api registration (#12132)

### DIFF
--- a/src/data/Store.mjs
+++ b/src/data/Store.mjs
@@ -995,6 +995,13 @@ class Store extends Collection {
                 fn       = apiArray.pop(),
                 service  = Neo.ns(apiArray.join('.'));
 
+            // The remotes-api registers asynchronously (Neo.remotes.Api.initAsync()); if the stub
+            // is not registered yet, wait for it to finish initializing before giving up.
+            if (!service && Neo.config.remotesApiUrl) {
+                await (await import('../remotes/Api.mjs')).default.ready();
+                service = Neo.ns(apiArray.join('.'))
+            }
+
             if (!service) {
                 console.error('Api is not defined', this)
             } else {

--- a/src/remotes/Api.mjs
+++ b/src/remotes/Api.mjs
@@ -44,14 +44,14 @@ class Api extends Base {
      */
     generateRemoteStream(service, stream, config = {}) {
         let pipeline;
-        
+
         if (config.parser || config.normalizer || config.pipeline) {
             let pipelineConfig = config.pipeline || {
                 parser    : config.parser,
                 normalizer: config.normalizer
             };
-            
-            pipelineConfig.workerExecution = 'app'; 
+
+            pipelineConfig.workerExecution = 'app';
             import('../data/Pipeline.mjs').then(module => {
                 pipeline = Neo.create(module.default, pipelineConfig);
             });
@@ -59,7 +59,7 @@ class Api extends Base {
 
         return function(params, callback) {
             let callbackId = Neo.core.IdGenerator.getId('rpc-stream-');
-            
+
             if (typeof callback !== 'function') {
                 throw new Error('rpc stream proxy requires a callback function as the second parameter');
             }
@@ -83,7 +83,7 @@ class Api extends Base {
                 params: [params],
                 service
             });
-            
+
             return () => {
                 delete Neo.worker.App.rpcStreamCallbacks[callbackId];
                 Neo.currentWorker.sendMessage('data', {
@@ -97,9 +97,23 @@ class Api extends Base {
     }
 
     /**
-     *
+     * Awaits load() so the singleton only reaches `isReady` once the remotes-api JSON is fetched
+     * and the service stubs are registered. Consumers (e.g. an api-backed Store racing the
+     * registration on boot) can `await Neo.remotes.Api.ready()`.
+     * @returns {Promise<void>}
      */
-    load() {
+    async initAsync() {
+        await super.initAsync();
+
+        if (Neo.config.remotesApiUrl) {
+            await this.load()
+        }
+    }
+
+    /**
+     * @returns {Promise<void>}
+     */
+    async load() {
         let {config}    = Neo,
             useMjsFiles = config.environment === 'development' || config.environment === 'dist/esm',
             path        = config.remotesApiUrl;
@@ -112,12 +126,11 @@ class Api extends Base {
             path = (useMjsFiles ? '../../' : './') + path
         }
 
-        fetch(path)
-            .then(response => response.json())
-            .then(data => {
-                Neo.currentWorker.sendMessage('data', {action: 'registerApi', data});
-                this.register(data)
-            })
+        const response = await fetch(path),
+              data     = await response.json();
+
+        Neo.currentWorker.sendMessage('data', {action: 'registerApi', data});
+        this.register(data)
     }
 
     /**
@@ -135,7 +148,7 @@ class Api extends Base {
                         parser    : methodValue.parser,
                         normalizer: methodValue.normalizer
                     };
-                    
+
                     pipelineConfig.workerExecution = 'data';
 
                     Promise.all([
@@ -146,9 +159,9 @@ class Api extends Base {
                             module: RpcModule.default,
                             api   : `${api.namespace}.${service}`
                         };
-                        
+
                         let pipeline = Neo.create(PipelineModule.default, pipelineConfig);
-                        
+
                         ns[method] = function(...args) {
                             return pipeline.execute(method, args[0]);
                         }

--- a/src/worker/App.mjs
+++ b/src/worker/App.mjs
@@ -127,8 +127,8 @@ class App extends Base {
      * Remote method to use inside main threads for creating neo based class instances.
      * Be aware that you can only pass configs which can get converted into pure JSON.
      *
-     * @warning This provides legacy testing support for environments where Neural Link 
-     * is not available (e.g. React wrappers). For native Neo.mjs E2E testing, 
+     * @warning This provides legacy testing support for environments where Neural Link
+     * is not available (e.g. React wrappers). For native Neo.mjs E2E testing,
      * use the Neural Link Bridge instead.
      *
      * Mounting a component into the document.body
@@ -217,9 +217,9 @@ class App extends Base {
 
     /**
      * Remote method to use inside main threads for destroying neo based class instances.
-     * 
-     * @warning This provides legacy testing support for environments where Neural Link 
-     * is not available (e.g. React wrappers). For native Neo.mjs E2E testing, 
+     *
+     * @warning This provides legacy testing support for environments where Neural Link
+     * is not available (e.g. React wrappers). For native Neo.mjs E2E testing,
      * use the Neural Link Bridge instead.
      *
      * @example:
@@ -326,11 +326,11 @@ class App extends Base {
 
     /**
      * Get configs of any app realm based Neo instance from main
-     * 
-     * @warning This provides legacy testing support for environments where Neural Link 
-     * is not available (e.g. React wrappers). For native Neo.mjs E2E testing, 
+     *
+     * @warning This provides legacy testing support for environments where Neural Link
+     * is not available (e.g. React wrappers). For native Neo.mjs E2E testing,
      * use the Neural Link Bridge instead.
-     * 
+     *
      * @param {Object} data
      * @param {String} data.id
      * @param {String|String[]} data.keys
@@ -545,9 +545,9 @@ class App extends Base {
      * This operation is **atomic** and state-preserving when moving within the same browser window.
      * It relies on `Neo.container.Base.insert` to handle the silent removal from the old parent,
      * ensuring that the DOM node is physically moved rather than destroyed and recreated.
-     * 
-     * @warning This provides legacy testing support for environments where Neural Link 
-     * is not available (e.g. React wrappers). For native Neo.mjs E2E testing, 
+     *
+     * @warning This provides legacy testing support for environments where Neural Link
+     * is not available (e.g. React wrappers). For native Neo.mjs E2E testing,
      * use the Neural Link Bridge instead.
      *
      * @param {Object} data
@@ -735,7 +735,7 @@ class App extends Base {
                 .then(data => {me.createThemeMap(data)});
         }
 
-        config.remotesApiUrl && import('../remotes/Api.mjs').then(module => module.default.load());
+        config.remotesApiUrl && import('../remotes/Api.mjs');
 
         if (config.useAiClient && !config.isGitHubPages) {
             let {environment, useAiClient} = config,
@@ -839,11 +839,11 @@ class App extends Base {
 
     /**
      * Set configs of any app realm based Neo instance from main
-     * 
-     * @warning This provides legacy testing support for environments where Neural Link 
-     * is not available (e.g. React wrappers). For native Neo.mjs E2E testing, 
+     *
+     * @warning This provides legacy testing support for environments where Neural Link
+     * is not available (e.g. React wrappers). For native Neo.mjs E2E testing,
      * use the Neural Link Bridge instead.
-     * 
+     *
      * @param {Object} data
      * @param {String} data.id
      * @returns {Object}


### PR DESCRIPTION
Authored by Claude Opus 4.7 (Claude Code) as @neo-opus-4-7. Session provenance: lane-claim A2A `MESSAGE:894591f6` (#12132).

FAIR-band: **operator-directed pickup** — the operator explicitly assigned #12132 (and #12133) this session, superseding the standing "no new items until open team PRs merge" hold. Author-lane pickup discipline is N/A for directed work.

Resolves #12132

A `Store` with `autoLoad: true` + a websocket `api` lost a boot race: `Store.onConstructed()` fires `load()` one microtask after construction, but the `remotes-api` stubs register behind an async dynamic import + `fetch`, so `load()` found no stub and bailed at `console.error('Api is not defined')` — no RPC, no load.

The fix reuses the existing `core.Base` `initAsync()`/`ready()` lifecycle rather than a hand-rolled promise:
- `Neo.remotes.Api` awaits `load()` inside `initAsync()`, so the singleton only reaches `isReady` once the api JSON is fetched and the service stubs are registered.
- `Store.load()`'s `api` branch awaits `Neo.remotes.Api.ready()` when the stub is missing (gated on `Neo.config.remotesApiUrl`) before giving up, then re-resolves the stub.
- `src/worker/App.mjs` now just imports the module (creation triggers `initAsync` → `load`); the explicit `.then(module.default.load())` is removed to avoid a double-load.

`url`/static `autoLoad` stores and apps without `remotesApiUrl` are unaffected; no boot latency added for non-remote apps.

Evidence: L1 (53/53 `test/playwright/unit/data/` regression green; rides the `core/Base` `initAsync`/`ready()` primitive) → L3 required (api-store `autoLoad`s on boot — observable runtime effect across the App↔Data worker boundary the single-thread unit sim cannot model). Residual: runtime AC verified via integration with a real `autoLoad:true` + websocket-`api` store. [#12132]

## Deltas from ticket
- The ticket proposed a "registration-ready signal on `Neo.remotes.Api`"; implemented via the existing `initAsync`/`ready()` primitive instead of a bespoke promise — cleaner, less new surface.
- Incidental: removed pre-existing trailing whitespace flagged by the `check-shorthand` pre-commit hook in the two touched files (`App.mjs` duplicated JSDoc blocks, `Api.mjs`). Mechanical, no logic change.

## Test Evidence
- `npm run test-unit -- test/playwright/unit/data/` → **53 passed** (no regression from the `Store.load` change).
- `node --check` clean on all three changed files.
- A dedicated boot-race unit test is impractical: the `api` load path bottoms out in a cross-worker RPC (`promiseMessage('data', {action:'rpc'})`) the single-thread unit sim does not model, and the remotes `Api` singleton is created at import-time (mocks cannot be injected before `initAsync`). The fix rides the already-covered `initAsync`/`ready()` primitive.

## Post-Merge Validation
- [ ] In a live app, a `Store` with `autoLoad: true` + websocket `api: {read}` populates on boot with no controller-side workaround.
- [ ] No `"Api is not defined"` console error for a correctly-wired remote `api` store on boot.

## Cross-family review
Per §6.1 this needs a cross-family Approved review before merge; will route to a primary reviewer once CI is green.
