### PR TITLE
fix(ai): defrag keeps live segment dirs in unified store (#12140)

### DIFF
--- a/ai/scripts/maintenance/defragChromaDB.mjs
+++ b/ai/scripts/maintenance/defragChromaDB.mjs
@@ -40,8 +40,10 @@ import AiConfig        from '../../config.mjs';
  *     marking the underlying index files as obsolete.
  * 4.  **Load (Restoration)**: The collections are recreated, and the buffered data is re-inserted in batches.
  *     This forces ChromaDB to rebuild the HNSW indices from scratch, resulting in a compact, defragmented state.
- * 5.  **Cleanup (Physical)**: The filesystem is scanned for orphaned UUID directories (leftover from previous
- *     fragmented states) that do not match the active collection IDs. These orphans are physically deleted.
+ * 5.  **Cleanup (Physical)**: The filesystem is scanned for orphaned segment directories — UUID dirs absent
+ *     from the live segment registry (`chroma.sqlite3` `segments` table) — which are physically deleted. The
+ *     keep-set is the *segment* registry (on-disk dirs are segment-named), spanning the whole shared store,
+ *     never a single target's collection ids.
  *
  * Usage:
  * `node buildScripts/defragChromaDB.mjs --target knowledge-base`
@@ -232,6 +234,71 @@ function vacuumSqlite(dbDir) {
 }
 
 /**
+ * Resolves the set of live Chroma segment ids registered in a persist dir's
+ * `chroma.sqlite3`. On-disk UUID directories are named by *segment* id (VECTOR /
+ * METADATA), which is a disjoint UUID space from *collection* id — so the segment
+ * registry, not recreated collection ids, is the authoritative keep-set for physical
+ * orphan cleanup. In the unified topology a single persist dir is shared across all
+ * subsystems, so the keep-set must span the whole instance, never one target.
+ *
+ * @param {Object} options
+ * @param {String} options.dbPath Persist dir containing `chroma.sqlite3`.
+ * @param {Function} [options.execFn=execSync] `child_process.execSync` seam (testing).
+ * @returns {Set<String>} Live segment ids; empty when no sqlite is present.
+ */
+export function resolveLiveSegmentIds({dbPath, execFn = execSync} = {}) {
+    const sqlitePath = path.join(dbPath, 'chroma.sqlite3');
+
+    if (!fs.existsSync(sqlitePath)) {
+        return new Set();
+    }
+
+    const raw = execFn(`sqlite3 "${sqlitePath}" "SELECT id FROM segments;"`, {
+        encoding : 'utf8',
+        maxBuffer: 64 * 1024 * 1024
+    });
+
+    return new Set(raw.split('\n').map(line => line.trim()).filter(Boolean));
+}
+
+/**
+ * Removes orphaned segment directories: on-disk UUID dirs whose name is not a live
+ * segment id. Preserves every live segment dir (across all collections) and any
+ * non-UUID entry. This is the unified-store-safe keep-set; the prior collection-id
+ * keep-set matched zero segment dirs and deleted live HNSW indices on next restart.
+ *
+ * @param {Object} options
+ * @param {String} options.dbPath Persist dir to scan.
+ * @param {Set<String>} options.liveSegmentIds Authoritative keep-set of live segment ids.
+ * @param {Object} [options.fsModule=fs] `fs-extra` seam (testing).
+ * @param {Function} [options.log=console.log] Log seam (testing).
+ * @returns {Promise<{kept: String[], removed: String[]}>}
+ */
+export async function cleanOrphanedSegmentDirs({dbPath, liveSegmentIds, fsModule = fs, log = console.log}) {
+    const kept    = [];
+    const removed = [];
+    const entries = await fsModule.readdir(dbPath, {withFileTypes: true});
+
+    for (const entry of entries) {
+        // UUIDv4 heuristic (36 chars, contains hyphen) guards non-segment system entries.
+        if (!entry.isDirectory() || entry.name.length !== 36 || !entry.name.includes('-')) {
+            continue;
+        }
+
+        if (liveSegmentIds.has(entry.name)) {
+            kept.push(entry.name);
+            log(`   ✨ Keeping live segment: ${entry.name}`);
+        } else {
+            removed.push(entry.name);
+            log(`   🗑️  Deleting orphan: ${entry.name}`);
+            await fsModule.remove(path.join(dbPath, entry.name));
+        }
+    }
+
+    return {kept, removed};
+}
+
+/**
  * Main execution function for the defragmentation process.
  *
  * It orchestrates the Backup -> Extract -> Nuke -> Load -> Cleanup pipeline.
@@ -413,8 +480,7 @@ async function defragChromaDB() {
         // 5. Load (Restore)
         // Re-creating the collection triggers a clean build of the HNSW index.
         console.log(`\n5️⃣  Restoring Data...`);
-        const newCollectionIds = [];
-        let hasRestoreErrors   = false;
+        let hasRestoreErrors = false;
 
         for (const colName of config.collections) {
             try {
@@ -431,7 +497,6 @@ async function defragChromaDB() {
                     metadata         : {"hnsw:space": "cosine"}
                 });
 
-                newCollectionIds.push(newCollection.id);
                 console.log(`     New ID: ${newCollection.id}`);
 
                 const total     = data.ids.length;
@@ -464,26 +529,16 @@ async function defragChromaDB() {
         }
 
         // 6. Cleanup (Physical)
-        // Scan the directory for UUID folders that are NOT in our list of active collection IDs.
-        console.log(`\n6️⃣  Cleaning up orphaned index folders...`);
-        console.log(`   Active IDs: ${newCollectionIds.join(', ')}`);
+        // Keep-set is the authoritative live-SEGMENT-id registry, not the recreated
+        // collection ids: on-disk UUID dirs are segment-named (disjoint from collection
+        // ids), and the unified store shares one persist dir across subsystems, so a
+        // collection-id / single-target keep-set deletes live data.
+        console.log(`\n6️⃣  Cleaning up orphaned segment directories...`);
+        const liveSegmentIds = resolveLiveSegmentIds({dbPath: DB_PATH});
+        console.log(`   Live segments: ${liveSegmentIds.size}`);
 
-        const entries = await fs.readdir(DB_PATH, {withFileTypes: true});
-        for (const entry of entries) {
-            if (entry.isDirectory()) {
-                // Heuristic: UUIDv4 Check (36 chars, contains hyphen)
-                // This prevents accidental deletion of system folders (e.g., 'chroma.sqlite3' directory if it existed)
-                if (entry.name.length === 36 && entry.name.includes('-')) {
-                    if (!newCollectionIds.includes(entry.name)) {
-                        const orphanPath = path.join(DB_PATH, entry.name);
-                        console.log(`   🗑️  Deleting orphan: ${entry.name}`);
-                        await fs.remove(orphanPath);
-                    } else {
-                        console.log(`   ✨ Keeping active: ${entry.name}`);
-                    }
-                }
-            }
-        }
+        const {kept, removed} = await cleanOrphanedSegmentDirs({dbPath: DB_PATH, liveSegmentIds});
+        console.log(`   Kept ${kept.length} live segment dirs; removed ${removed.length} orphans.`);
 
         // 7. Vacuum (SQLite)
         console.log(`\n7️⃣  Vacuuming SQLite Database...`);

--- a/test/playwright/unit/ai/scripts/maintenance/defrag-segment-cleanup.spec.mjs
+++ b/test/playwright/unit/ai/scripts/maintenance/defrag-segment-cleanup.spec.mjs
@@ -1,0 +1,192 @@
+import {setup} from '../../../../setup.mjs';
+
+const appName = 'DefragSegmentCleanupTest';
+
+setup({
+    neoConfig: {
+        allowVdomUpdatesInTests: false,
+        unitTestMode           : true,
+        useDomApiRenderer      : false
+    },
+    appConfig: {
+        name             : appName,
+        isMounted        : () => true,
+        vnodeInitialising: false
+    }
+});
+
+import {test, expect} from '@playwright/test';
+import Neo            from '../../../../../../src/Neo.mjs';
+import * as core      from '../../../../../../src/core/_export.mjs';
+import {execSync}     from 'child_process';
+import fs             from 'fs-extra';
+import path           from 'path';
+
+/**
+ * Verifies the unified-store-safe physical orphan cleanup in
+ * `ai/scripts/maintenance/defragChromaDB.mjs`: `resolveLiveSegmentIds` +
+ * `cleanOrphanedSegmentDirs`.
+ *
+ * Regression anchor: the prior step-6 keep-set was built from recreated *collection* ids,
+ * but on-disk UUID dirs are named by *segment* id — a disjoint UUID space. The collection-id
+ * keep-set therefore matched zero live dirs and deleted every live HNSW segment across BOTH
+ * subsystems sharing the single unified persist dir (`learn/agentos/decisions/0003-chroma-topology-unified-only.md`).
+ * These tests pin the corrected segment-registry keep-set with an explicit negative-mutation
+ * assertion: live segment dirs (this target AND a sibling collection) survive; only true
+ * orphans are removed.
+ */
+// Serial mode: shared dynamic-import symbol + tmp filesystem state. Mirrors the
+// backup-retention.spec.mjs rationale; CI runs workers=1, this is a local-DX safeguard.
+test.describe.configure({mode: 'serial'});
+
+test.describe('defragChromaDB segment cleanup — unified-store-safe keep-set (#12140)', () => {
+    let resolveLiveSegmentIds;
+    let cleanOrphanedSegmentDirs;
+    let tmpRoot;
+    let nudge           = 0;
+    let sqlite3Available = false;
+
+    test.beforeAll(async () => {
+        const mod = await import('../../../../../../ai/scripts/maintenance/defragChromaDB.mjs');
+        resolveLiveSegmentIds    = mod.resolveLiveSegmentIds;
+        cleanOrphanedSegmentDirs = mod.cleanOrphanedSegmentDirs;
+
+        try {
+            execSync('sqlite3 --version', {stdio: 'ignore'});
+            sqlite3Available = true;
+        } catch (e) {
+            sqlite3Available = false;
+        }
+    });
+
+    test.beforeEach(async () => {
+        tmpRoot = path.resolve(process.cwd(), 'tmp', `defrag-segment-cleanup-${process.pid}-${Date.now()}-${++nudge}`);
+        await fs.ensureDir(tmpRoot);
+    });
+
+    test.afterEach(async () => {
+        if (tmpRoot && await fs.pathExists(tmpRoot)) {
+            await fs.remove(tmpRoot);
+        }
+    });
+
+    /**
+     * Seeds a UUID-named directory simulating an on-disk HNSW segment dir, with a marker file.
+     */
+    async function seedSegmentDir(uuid) {
+        const dirPath = path.join(tmpRoot, uuid);
+        await fs.ensureDir(dirPath);
+        await fs.writeFile(path.join(dirPath, 'data_level0.bin'), 'hnsw-index-marker');
+        return uuid;
+    }
+
+    test('preserves every live segment dir (this target AND sibling) and removes only true orphans', async () => {
+        // Realistic 36-char hyphenated segment-id UUIDs. Two are live (this target + a
+        // sibling collection sharing the unified store); one is a true orphan absent from
+        // the live registry.
+        const thisTargetLive = '11111111-1111-4111-8111-111111111111';
+        const siblingLive    = '22222222-2222-4222-8222-222222222222';
+        const trueOrphan     = '33333333-3333-4333-8333-333333333333';
+        // Non-segment dirs that must survive the heuristic guard:
+        //   - short name fails the 36-char branch
+        //   - 36-char-no-hyphen fails the `includes('-')` branch
+        const shortDir       = 'system-cache';
+        const noHyphen36     = 'abcdefabcdefabcdefabcdefabcdef123456';
+
+        await seedSegmentDir(thisTargetLive);
+        await seedSegmentDir(siblingLive);
+        await seedSegmentDir(trueOrphan);
+        await fs.ensureDir(path.join(tmpRoot, shortDir));
+        await fs.ensureDir(path.join(tmpRoot, noHyphen36));
+        // A real persist dir always contains chroma.sqlite3 (a FILE) — the isDirectory guard
+        // must leave it untouched.
+        await fs.writeFile(path.join(tmpRoot, 'chroma.sqlite3'), 'sqlite-marker');
+
+        const liveSegmentIds = new Set([thisTargetLive, siblingLive]);
+
+        const {kept, removed} = await cleanOrphanedSegmentDirs({
+            dbPath: tmpRoot,
+            liveSegmentIds,
+            log   : () => {}
+        });
+
+        // Negative-mutation: both live segment dirs survive on disk.
+        expect(await fs.pathExists(path.join(tmpRoot, thisTargetLive))).toBe(true);
+        expect(await fs.pathExists(path.join(tmpRoot, siblingLive))).toBe(true);
+        // Non-segment entries survive (heuristic + isDirectory guards).
+        expect(await fs.pathExists(path.join(tmpRoot, shortDir))).toBe(true);
+        expect(await fs.pathExists(path.join(tmpRoot, noHyphen36))).toBe(true);
+        expect(await fs.pathExists(path.join(tmpRoot, 'chroma.sqlite3'))).toBe(true);
+        // Only the true orphan is physically removed.
+        expect(await fs.pathExists(path.join(tmpRoot, trueOrphan))).toBe(false);
+
+        // Return contract.
+        expect(kept.sort()).toEqual([thisTargetLive, siblingLive].sort());
+        expect(removed).toEqual([trueOrphan]);
+    });
+
+    test('skips UUID-named entries that are files, not directories', async () => {
+        const liveSeg     = '66666666-6666-4666-8666-666666666666';
+        const uuidNamedFile = '77777777-7777-4777-8777-777777777777';
+
+        await seedSegmentDir(liveSeg);
+        // A stray file whose name matches the UUID heuristic must not be removed: the
+        // isDirectory guard short-circuits before any fs.remove.
+        await fs.writeFile(path.join(tmpRoot, uuidNamedFile), 'not-a-dir');
+
+        const {kept, removed} = await cleanOrphanedSegmentDirs({
+            dbPath        : tmpRoot,
+            liveSegmentIds: new Set([liveSeg]),
+            log           : () => {}
+        });
+
+        expect(await fs.pathExists(path.join(tmpRoot, uuidNamedFile))).toBe(true);
+        expect(removed).toHaveLength(0);
+        expect(kept).toEqual([liveSeg]);
+    });
+
+    test('resolveLiveSegmentIds parses multiline sqlite output, trimming blanks and whitespace', async () => {
+        // Existence guard requires a real chroma.sqlite3 file present before execFn runs.
+        await fs.writeFile(path.join(tmpRoot, 'chroma.sqlite3'), 'sqlite-marker');
+
+        const result = resolveLiveSegmentIds({
+            dbPath: tmpRoot,
+            execFn: () => 'seg-a\n  seg-b  \n\n\nseg-c\n'
+        });
+
+        expect(result).toBeInstanceOf(Set);
+        expect([...result].sort()).toEqual(['seg-a', 'seg-b', 'seg-c']);
+    });
+
+    test('resolveLiveSegmentIds returns an empty Set and never shells out when no chroma.sqlite3 is present', () => {
+        let execCalled = false;
+
+        const result = resolveLiveSegmentIds({
+            dbPath: tmpRoot,  // empty dir, no chroma.sqlite3
+            execFn: () => { execCalled = true; return ''; }
+        });
+
+        expect(result).toBeInstanceOf(Set);
+        expect(result.size).toBe(0);
+        expect(execCalled).toBe(false);
+    });
+
+    test('resolveLiveSegmentIds reads ids from a real chroma.sqlite3 via the real sqlite3 CLI', async () => {
+        test.skip(!sqlite3Available, 'sqlite3 CLI not available in this environment');
+
+        const sqlitePath = path.join(tmpRoot, 'chroma.sqlite3');
+        const idA        = '44444444-4444-4444-8444-444444444444';
+        const idB        = '55555555-5555-4555-8555-555555555555';
+
+        // Build a minimal real segments table — exercises the production SELECT against the
+        // actual sqlite3 CLI output shape (stub-drift guard: the default execFn is used).
+        execSync(
+            `sqlite3 "${sqlitePath}" "CREATE TABLE segments (id TEXT PRIMARY KEY); INSERT INTO segments (id) VALUES ('${idA}'), ('${idB}');"`,
+            {stdio: 'ignore'}
+        );
+
+        const result = resolveLiveSegmentIds({dbPath: tmpRoot});
+
+        expect([...result].sort()).toEqual([idA, idB].sort());
+    });
+});


### PR DESCRIPTION
Authored by Claude Opus (Claude Code), @neo-opus-4-7. Session f6a4a820-1d95-40e7-910f-b47ad68f51f8.

FAIR-band: in-band [15/30 — current author count over last 30 merged]

Resolves #12140

Makes `ai/scripts/maintenance/defragChromaDB.mjs` safe for the unified Chroma store (ADR 0003) so it can be driven automatically by the `#12138` recycle chain. Step-6 orphan cleanup built its keep-set from recreated **collection** ids, but on-disk UUID dirs are named by **segment** id — a disjoint UUID space. The keep-set matched zero live dirs, so on the next daemon restart every collection's live HNSW segment dir was physically deleted, across **both** Knowledge Base and Memory Core (they share the one persist dir). The fix re-derives the keep-set from the authoritative live-segment registry (`SELECT id FROM segments` in `chroma.sqlite3`) via the same `sqlite3`-CLI pattern the script already uses for `VACUUM` — no new dependency. True orphans are still removed, so defrag keeps its compaction value.

Evidence: L2 (unit tests incl. a real `sqlite3` CLI exercising the live `segments` read + a negative-mutation orphan-cleanup assertion) → L3 ideal for AC2 (a full `ai:defrag-kb` run against a live multi-collection store + daemon restart). Residual: AC2 end-to-end, deferred to manual verification / the `#12138` recycle exercise. Residual: AC2 [#12138].

## Implementation

- Removed the `newCollectionIds` keep-set (collection ids never match on-disk segment-id dirs).
- Added two exported, injectable helpers matching the existing `cleanOldBackups` seam pattern:
  - `resolveLiveSegmentIds({dbPath, execFn})` → `Set<string>` of live segment ids; returns an empty Set (without shelling out) when no `chroma.sqlite3` is present.
  - `cleanOrphanedSegmentDirs({dbPath, liveSegmentIds, fsModule, log})` → `{kept, removed}`; deletes a UUID dir iff its name is absent from the live-segment set, preserving every live segment dir (all collections) and any non-UUID / non-directory entry.
- Rewrote step 6 to source the keep-set from `resolveLiveSegmentIds` and delegate physical removal to `cleanOrphanedSegmentDirs`.
- Updated the class-level docstring step-5 narrative to describe the segment-registry keep-set.

## AC mapping

1. Keep-set sourced from the live `segments` registry — ✅ `resolveLiveSegmentIds`.
2. Sibling collections' live VECTOR dirs preserved (no MC data loss) — ✅ unit-simulated (sibling-live dir survives); full live-store run is the L3 residual above.
3. True orphans still removed — ✅ asserted in the negative-mutation test.
4. Logic extracted into exported, unit-testable helpers with injectable fs/exec seams — ✅.
5. Negative-mutation unit test (this-target live + sibling live + true-orphan + non-UUID seed; orphan removed, live + non-UUID preserved) — ✅.

## Deltas from ticket

Beyond AC5's minimum seed set, the spec also asserts: a 36-char-no-hyphen dir survives (exercises the second half of the UUID heuristic), a UUID-named **file** is skipped (`isDirectory` guard), and `resolveLiveSegmentIds` short-circuits without shelling out when no sqlite is present. Added a guarded real-`sqlite3` integration test (skips if the CLI is unavailable) so the production `SELECT` runs against the actual CLI output shape rather than a stub only.

## Test Evidence

```
npm run test-unit -- test/playwright/unit/ai/scripts/maintenance/defrag-segment-cleanup.spec.mjs
  5 passed (552ms)
```

The real-`sqlite3` integration test executed (not skipped) in this environment.

## Post-Merge Validation

- [ ] Run `ai:defrag-kb` against the live unified store, then restart the Chroma daemon and confirm both KB and MC vector queries still return results (the AC2 L3 residual; will also be exercised by the `#12138` recycle chain).
