### PR TITLE
fix(ai): IssueIngestor resolves internal authors from registry (#12130)

### DIFF
--- a/ai/services/ingestion/IssueIngestor.mjs
+++ b/ai/services/ingestion/IssueIngestor.mjs
@@ -7,6 +7,7 @@ import Base from '../../../src/core/Base.mjs';
 import { Memory_StorageRouter as StorageRouter } from '../../services.mjs';
 import { Memory_GraphService as GraphService } from '../../services.mjs';
 import logger from '../../mcp/server/memory-core/logger.mjs';
+import {IDENTITIES} from '../../graph/identityRoots.mjs';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname  = path.dirname(__filename);
@@ -50,6 +51,32 @@ class IssueIngestor extends Base {
          * @protected
          */
         singleton: true
+    }
+
+    /**
+     * @summary Bare GitHub logins of registered internal authors (human owner + swarm maintainers),
+     * derived from the canonical identity registry. The `@` prefix is stripped to match GitHub
+     * issue-author logins. An empty set disables the community multiplier (safe degrade) instead of
+     * boosting every ticket.
+     * @member {Set<String>} internalAuthorLogins
+     * @static
+     */
+    static internalAuthorLogins = new Set(
+        IDENTITIES.map(identity => identity.properties?.githubLogin).filter(Boolean).map(login => login.replace(/^@/, ''))
+    )
+
+    /**
+     * @summary Whether a ticket author qualifies for the community-multiplier boost: true when the
+     * author exists, the internal-author registry is non-empty, and the author is not a registered
+     * maintainer. The non-empty guard makes an unconfigured deployment degrade safely (multiplier
+     * off) rather than treating every ticket as community-authored.
+     * @param {String} author Ticket GitHub author login (bare form).
+     * @param {Set<String>} [internalAuthorLogins=IssueIngestor.internalAuthorLogins] Injectable internal-author set (test seam).
+     * @returns {Boolean}
+     * @static
+     */
+    static isCommunityAuthor(author, internalAuthorLogins = IssueIngestor.internalAuthorLogins) {
+        return Boolean(author) && internalAuthorLogins.size > 0 && !internalAuthorLogins.has(author)
     }
 
     /**
@@ -190,8 +217,8 @@ class IssueIngestor extends Base {
                             baseWeight = 0.05;
                             logger.debug(`[IssueIngestor] Discounting topological weight for ${issueId} because it is BLOCKED_BY an OPEN issue.`);
                         } else {
-                            // Community Multiplier: Boost if ticket is external and has been triaged
-                            if (meta.author && meta.author !== 'tobiu') {
+                            // Community Multiplier: boost externally-authored (non-maintainer) tickets that have been triaged.
+                            if (IssueIngestor.isCommunityAuthor(meta.author)) {
                                 if (Array.isArray(meta.labels) && meta.labels.length > 0) {
                                     baseWeight += 0.5;
                                 }

--- a/test/playwright/unit/ai/services/ingestion/IssueIngestor.spec.mjs
+++ b/test/playwright/unit/ai/services/ingestion/IssueIngestor.spec.mjs
@@ -210,12 +210,12 @@ test.describe('Neo.ai.daemons.services.IssueIngestor', () => {
 });
 
 /**
- * Community-multiplier internal-author resolution (#12130). Replaces the prior hardcoded
+ * Community-multiplier internal-author resolution. Replaces the prior hardcoded
  * `meta.author !== 'tobiu'` check with a set derived from the canonical identity registry
  * (`ai/graph/identityRoots.mjs`). The empty-registry case must degrade safely (multiplier OFF),
  * not invert into boosting every ticket.
  */
-test.describe('Neo.ai.daemons.services.IssueIngestor — community-multiplier internal-author set (#12130)', () => {
+test.describe('Neo.ai.daemons.services.IssueIngestor — community-multiplier internal-author set', () => {
     let IssueIngestorClass;
 
     test.beforeAll(async () => {

--- a/test/playwright/unit/ai/services/ingestion/IssueIngestor.spec.mjs
+++ b/test/playwright/unit/ai/services/ingestion/IssueIngestor.spec.mjs
@@ -208,3 +208,54 @@ test.describe('Neo.ai.daemons.services.IssueIngestor', () => {
         });
     });
 });
+
+/**
+ * Community-multiplier internal-author resolution (#12130). Replaces the prior hardcoded
+ * `meta.author !== 'tobiu'` check with a set derived from the canonical identity registry
+ * (`ai/graph/identityRoots.mjs`). The empty-registry case must degrade safely (multiplier OFF),
+ * not invert into boosting every ticket.
+ */
+test.describe('Neo.ai.daemons.services.IssueIngestor — community-multiplier internal-author set (#12130)', () => {
+    let IssueIngestorClass;
+
+    test.beforeAll(async () => {
+        // The default export is the singleton instance; the static set + decision live on its class.
+        IssueIngestorClass = (await import('../../../../../../ai/services/ingestion/IssueIngestor.mjs')).default.constructor;
+    });
+
+    test('internalAuthorLogins is derived from the identity registry as bare logins (no @, no nulls)', () => {
+        const logins = IssueIngestorClass.internalAuthorLogins;
+
+        expect(logins).toBeInstanceOf(Set);
+        expect(logins.size).toBeGreaterThan(0);
+        // Owner + a known agent maintainer, normalized to bare form (matches GitHub issue authors).
+        expect(logins.has('tobiu')).toBe(true);
+        expect(logins.has('neo-opus-4-7')).toBe(true);
+        // The leading-@ registry form and null/empty entries must NOT leak through.
+        expect(logins.has('@tobiu')).toBe(false);
+        expect(logins.has('')).toBe(false);
+        expect([...logins].every(Boolean)).toBe(true);
+    });
+
+    test('isCommunityAuthor: a registered maintainer is NOT a community author (no boost)', () => {
+        expect(IssueIngestorClass.isCommunityAuthor('tobiu')).toBe(false);
+        expect(IssueIngestorClass.isCommunityAuthor('neo-opus-4-7')).toBe(false);
+    });
+
+    test('isCommunityAuthor: an external author IS a community author (boost eligible)', () => {
+        expect(IssueIngestorClass.isCommunityAuthor('some-external-contributor')).toBe(true);
+    });
+
+    test('isCommunityAuthor: a missing author is never a community author', () => {
+        expect(IssueIngestorClass.isCommunityAuthor('')).toBe(false);
+        expect(IssueIngestorClass.isCommunityAuthor(undefined)).toBe(false);
+        expect(IssueIngestorClass.isCommunityAuthor(null)).toBe(false);
+    });
+
+    test('isCommunityAuthor: an empty internal-author registry disables the multiplier (safe degrade, not boost-all)', () => {
+        // Negative-mutation guard: with an empty set, even an "external" author must NOT be boosted —
+        // the `size > 0` clause is what prevents the inverted every-ticket-boosted failure mode.
+        expect(IssueIngestorClass.isCommunityAuthor('some-external-contributor', new Set())).toBe(false);
+        expect(IssueIngestorClass.isCommunityAuthor('tobiu', new Set())).toBe(false);
+    });
+});


### PR DESCRIPTION
Authored by Claude Opus (Claude Code), @neo-opus-4-7. Session f6a4a820-1d95-40e7-910f-b47ad68f51f8.

FAIR-band: in-band [15/30 — current author count over last 30 merged]

Resolves #12130

`IssueIngestor`'s community-multiplier hardcoded the operator login `'tobiu'` as the internal-author proxy (`IssueIngestor.mjs:194`). In any fork / `npx neo-app` / non-neomjs tenant there is no `'tobiu'`, so `meta.author !== 'tobiu'` was true for **every** ticket — the deployment's own maintainer tickets included — inverting the community multiplier into an indiscriminate `+0.5` boost-all.

The internal-author set is now derived from the canonical identity registry (`ai/graph/identityRoots.mjs`), normalized to bare logins to match GitHub issue authors, mirroring the established `MemoryService.identityTrustTiers` static-derivation pattern. A `static isCommunityAuthor()` seam carries the decision; its `size > 0` guard makes an empty registry degrade safely (multiplier OFF) rather than boost-all.

Evidence: L2 (unit tests — registry-derived set shape, internal not boosted, external boosted, missing-author no-fire, empty-set negative-mutation; full IssueIngestor spec 7 passed) → L2 required (ACs are config-derivation + pure-decision logic, fully unit-coverable). No residuals.

## Implementation

- Import `{IDENTITIES}` from `ai/graph/identityRoots.mjs`.
- `static internalAuthorLogins` = `new Set(IDENTITIES.map(i => i.properties?.githubLogin).filter(Boolean).map(strip leading @))`.
- `static isCommunityAuthor(author, internalAuthorLogins = IssueIngestor.internalAuthorLogins)` — injectable seam returning `Boolean(author) && set.size > 0 && !set.has(author)`.
- Replace the `meta.author !== 'tobiu'` guard with `IssueIngestor.isCommunityAuthor(meta.author)`.

## Deltas from ticket

Took the Tier-2 option of resolving from `identityRoots.mjs` (the canonical registry) over a new `aiConfig.internalAuthorLogins` key — lowest new surface, and the registry already is the deployment's maintainer SSOT. An external deployment seeds its own `identityRoots`; registering no logins disables the multiplier via the `size > 0` guard (the ticket's documented safe degrade), not a boost-all. Out-of-scope JSDoc `@neo-*` mentions left to the archaeology-cleanup epic per the ticket.

## AC mapping

1. `'tobiu'` literal removed; internal-author set resolved from `identityRoots.mjs` — ✅.
2. Zero-config default = the deployment's registry maintainers (not a hardcoded login); empty registry / external deployment → safe degrade — ✅.
3. Unit coverage: internal not boosted / external boosted / empty-set no-fire — ✅.
4. No hidden-default-fallback (`||` / `??`); registry read verbatim — ✅.

## Test Evidence

```
npm run test-unit -- test/playwright/unit/ai/services/ingestion/IssueIngestor.spec.mjs
  7 passed (910ms)
```

## Post-Merge Validation

- [ ] On the next orchestrator ingest cycle, confirm the community multiplier still fires for externally-authored triaged tickets and not for registered-maintainer tickets — the live-registry end-to-end path (the added unit tests cover the derivation + decision in isolation).
