### PR TITLE
feat(kb): resolve pull-mode tenantRepos via tiered config resolver (#12145)

### DIFF
--- a/ai/daemons/orchestrator/services/TenantRepoSyncService.mjs
+++ b/ai/daemons/orchestrator/services/TenantRepoSyncService.mjs
@@ -5,7 +5,6 @@ import AiConfig from '../../../config.mjs';
 import {DEFAULT_DATA_DIR} from '../TaskDefinitions.mjs';
 import GitMirror from '../../../services/knowledge-base/helpers/GitMirror.mjs';
 import {buildIngestEnvelope} from '../../../services/knowledge-base/helpers/TenantRepoIngestEnvelopeBuilder.mjs';
-import {normalizeTenantRepoConfig} from '../../../services/knowledge-base/helpers/TenantRepoAccessContract.mjs';
 import {isRepoDue} from '../scheduling/tenantRepoSync.mjs';
 import {
     KB_TENANT_REPO_SYNC_SYNC_FAILED,
@@ -201,8 +200,7 @@ class TenantRepoSyncService extends Base {
      * @param {Object} options.taskStateService Orchestrator task-state service.
      * @param {Object} [options.healthService] HealthService-compatible sink.
      * @param {Function} [options.writeLog] Orchestrator logger.
-     * @param {Object} [options.tenantReposConfig] Pre-normalized tenantRepos config. If omitted, resolved from `aiConfig` via `normalizeTenantRepos`.
-     * @param {Object} [options.aiConfig] AI config object (test seam). Defaults to live import.
+     * @param {Object} [options.tenantReposConfig] Pre-normalized tenantRepos config. If omitted, resolved across config tiers via `KnowledgeBaseIngestionService.listConfiguredTenantRepos`.
      * @param {Object} [options.gitMirror=GitMirror] Injectable mirror primitive (test seam).
      * @param {Object} [options.knowledgeBaseIngestionService] KB ingestion service singleton (test seam). Resolved from `ai/services.mjs` if omitted.
      * @param {String[]} [options.onlyRepoSlugs] If provided, only sync repos whose `repoSlug` is in the list. Used by the manual CLI run path. Empty filter result against non-empty list surfaces `KB_TENANT_REPO_SYNC_REPO_NOT_CONFIGURED`.
@@ -217,7 +215,6 @@ class TenantRepoSyncService extends Base {
         healthService,
         writeLog,
         tenantReposConfig,
-        aiConfig,
         gitMirror = GitMirror,
         knowledgeBaseIngestionService,
         onlyRepoSlugs,
@@ -240,7 +237,7 @@ class TenantRepoSyncService extends Base {
 
         try {
             const result = await this.syncTenantRepos({
-                writeLog, tenantReposConfig, aiConfig, gitMirror, knowledgeBaseIngestionService, onlyRepoSlugs,
+                writeLog, tenantReposConfig, gitMirror, knowledgeBaseIngestionService, onlyRepoSlugs,
                 taskStateService, healthService, taskName, revisionsFilePath, envelopeBuilder,
                 globalCadenceMs, jitterRatio, seedBootstrap
             });
@@ -284,13 +281,13 @@ class TenantRepoSyncService extends Base {
      * @returns {Promise<Object>} `{status, details: {repoCount, completedCount, failedCount, results}}`.
      */
     async syncTenantRepos({
-        writeLog, tenantReposConfig, aiConfig, gitMirror, knowledgeBaseIngestionService, onlyRepoSlugs,
+        writeLog, tenantReposConfig, gitMirror, knowledgeBaseIngestionService, onlyRepoSlugs,
         taskStateService, healthService, taskName, revisionsFilePath, envelopeBuilder = buildIngestEnvelope,
         globalCadenceMs = AiConfig.data.orchestrator.intervals.tenantRepoSyncMs,
         jitterRatio     = AiConfig.data.orchestrator.tenantRepoSync.jitterRatio,
         seedBootstrap   = true
     }) {
-        const resolvedConfig = tenantReposConfig || await this.resolveTenantReposConfig({aiConfig});
+        const resolvedConfig = tenantReposConfig || await this.resolveTenantReposConfig({ingestionService: knowledgeBaseIngestionService});
         const allRepos       = resolvedConfig.tenantRepos || [];
         const repos          = onlyRepoSlugs
             ? allRepos.filter(r => onlyRepoSlugs.includes(r.repoSlug))
@@ -545,8 +542,13 @@ class TenantRepoSyncService extends Base {
     }
 
     /**
-     * Resolves the tenantRepos config from `aiConfig` via `TenantRepoAccessContract.normalizeTenantRepos`.
-     * Materializes per-repo `mirrorRoot` via a defensive fallback chain when the per-repo
+     * Resolves the effective `tenantRepos` across all tenants via the tiered resolver
+     * `KnowledgeBaseIngestionService.listConfiguredTenantRepos` (graph node > `kb-config.yaml`
+     * bootstrap > `aiConfig.tenantRepos[]` default, per-tenant single-winner, flattened). Replaces
+     * the prior direct `aiConfig.tenantRepos` read so the documented bootstrap / graph tiers are
+     * actually honored on the pull path (#12145).
+     *
+     * Then materializes per-repo `mirrorRoot` via a defensive fallback chain when the per-repo
      * override is absent:
      *
      *   1. `tier1MirrorRoot` (test seam — full short-circuit)
@@ -562,24 +564,24 @@ class TenantRepoSyncService extends Base {
      * `tenantRepoMirrorRoot` key — but the env var is still injected via compose, so
      * a direct `process.env` read keeps the resolver behavior correct regardless.
      *
-     * Test seams: `aiConfig` bypasses live import; `tier1MirrorRoot` short-circuits the
-     * chain; `orchestratorConfig` stubs the AiConfig.orchestrator section; `env` stubs
-     * `process.env` for fallback-chain testing.
+     * Test seams: `ingestionService` injects a stub KB service (bypasses the live singleton
+     * lookup); `tier1MirrorRoot` short-circuits the mirrorRoot chain; `orchestratorConfig`
+     * stubs the AiConfig.orchestrator section; `env` stubs `process.env`.
      *
-     * @param {Object} options
-     * @param {Object} [options.aiConfig] Pre-resolved config object.
+     * @param {Object} [options]
      * @param {String} [options.tier1MirrorRoot] Pre-resolved Tier-1 mirrorRoot default (test seam).
      * @param {Object} [options.orchestratorConfig=AiConfig.orchestrator] Stub for the AiConfig.orchestrator section (test seam).
      * @param {Object} [options.env=process.env] Stub for the env-var lookup (test seam).
+     * @param {Object} [options.ingestionService] Stub KB ingestion service (test seam); defaults to the live singleton.
      * @returns {Promise<{tenantRepos: Array<Object>}>}
      */
-    async resolveTenantReposConfig({aiConfig, tier1MirrorRoot, orchestratorConfig = AiConfig.orchestrator, env = process.env}) {
-        const cfg              = aiConfig || (await import('../../../mcp/server/knowledge-base/config.mjs')).default;
-        const tier1Default     = tier1MirrorRoot
+    async resolveTenantReposConfig({tier1MirrorRoot, orchestratorConfig = AiConfig.orchestrator, env = process.env, ingestionService} = {}) {
+        const tier1Default = tier1MirrorRoot
             ?? orchestratorConfig?.tenantRepoMirrorRoot
             ?? env.NEO_TENANT_REPO_MIRROR_ROOT
             ?? '/app/.neo-ai-data';
-        const normalized       = normalizeTenantRepoConfig({tenantRepos: cfg.tenantRepos || []});
+        const kbService    = ingestionService || await this.resolveIngestionService();
+        const normalized   = await kbService.listConfiguredTenantRepos();
 
         normalized.tenantRepos = normalized.tenantRepos.map(entry =>
             entry.mirrorRoot ? entry : {...entry, mirrorRoot: tier1Default}

--- a/ai/deploy/docker-compose.yml
+++ b/ai/deploy/docker-compose.yml
@@ -166,6 +166,14 @@ services:
       # scheduler lane writes bundles here. A host bind-mount keeps them across
       # container rebuilds and host-accessible for off-site copy / inspection.
       - ./.neo-ai-data/backups:/app/.neo-ai-data/backups
+      # kb-config.yaml bootstrap tier (#12145): deployments that provide a kb-config.yaml
+      # (per-tenant Source/Parser registration + pull-mode `tenantRepos`) MUST mount it
+      # read-only here AND on kb-server. The pull-mode sync's tiered resolver
+      # (TenantRepoSyncService -> KnowledgeBaseIngestionService.listConfiguredTenantRepos)
+      # reads it from `<neoRootDir>/kb-config.yaml` the same way kb-server resolves it at
+      # query time; without the mount the orchestrator silently falls back to the
+      # aiConfig.tenantRepos[] default tier only. Example:
+      #   - ./kb-config.yaml:/app/kb-config.yaml:ro
     depends_on:
       chroma:
         condition: service_healthy

--- a/ai/services/knowledge-base/KnowledgeBaseIngestionService.mjs
+++ b/ai/services/knowledge-base/KnowledgeBaseIngestionService.mjs
@@ -915,15 +915,19 @@ class KnowledgeBaseIngestionService extends Base {
         const effective = [];
 
         for (const tenantId of tenantIds) {
-            const graphRepos = this.graphService.getNodeRecord({id: `kb-config:${tenantId}`})?.properties?.tenantRepos,
-                  yamlRepos  = yamlTenants[tenantId]?.tenantRepos;
+            const graphRecord = this.graphService.getNodeRecord({id: `kb-config:${tenantId}`}),
+                  yamlEntry   = yamlTenants[tenantId];
 
+            // Tier winner is chosen by tier PRESENCE (matching getTenantConfig), NOT by a
+            // non-empty array: a graph record / yaml entry that declares `tenantRepos: []`
+            // intentionally means "no repos for this tenant" and MUST suppress lower tiers
+            // wholesale — selecting on `length > 0` would leak lower-tier repos through.
             let repos;
 
-            if (Array.isArray(graphRepos) && graphRepos.length > 0) {
-                repos = graphRepos;
-            } else if (Array.isArray(yamlRepos) && yamlRepos.length > 0) {
-                repos = yamlRepos;
+            if (graphRecord?.properties) {
+                repos = graphRecord.properties.tenantRepos || [];
+            } else if (yamlEntry) {
+                repos = yamlEntry.tenantRepos || [];
             } else {
                 repos = defaultRepos.filter(entry => (normalizeUserId(entry.tenantId) || entry.tenantId) === tenantId);
             }

--- a/ai/services/knowledge-base/KnowledgeBaseIngestionService.mjs
+++ b/ai/services/knowledge-base/KnowledgeBaseIngestionService.mjs
@@ -881,6 +881,60 @@ class KnowledgeBaseIngestionService extends Base {
     }
 
     /**
+     * @summary Enumerates every configured tenant's effective `tenantRepos`, flattened across tenants.
+     *
+     * The pull-mode sync lane (`TenantRepoSyncService`) needs the union of all tenants' polling
+     * configs. Resolution is per-tenant single-winner across the same tiers as `getTenantConfig` —
+     * graph node (`kb-config:<tenantId>`) > `kb-config.yaml` bootstrap > `aiConfig.tenantRepos[]`
+     * default — then flattened. A tenant's highest present tier wins WHOLESALE; tiers are never
+     * merged within a tenant (that would be a deliberate `getTenantConfig` semantics change).
+     *
+     * RLS: graph-tier reads go through `GraphService.getNodeRecord` — the same RLS-respecting path
+     * `getTenantConfig` uses, never a raw node scan. `kb-config:*` nodes carry `visibility:'team'`,
+     * so the context-less orchestrator resolves them while per-tenant ownership isolation is preserved.
+     *
+     * The tenant set is derived from the keyed tiers: `kb-config.yaml` `tenants.*` keys plus the
+     * distinct `tenantId`s in `aiConfig.tenantRepos[]`. A tenant configured ONLY via a graph node
+     * (no yaml / aiConfig entry) is out of scope until a `setTenantConfig` operator tool exists.
+     * @returns {Promise<{tenantRepos: Array<Object>}>} Contract-normalized; throws on a malformed entry.
+     */
+    async listConfiguredTenantRepos() {
+        await this.graphService.initAsync();
+
+        const bootstrap    = this.readKbConfigBootstrap(),
+              yamlTenants  = (bootstrap && bootstrap.tenants) || {},
+              defaultRepos = Array.isArray(aiConfig.tenantRepos) ? aiConfig.tenantRepos : [],
+              tenantIds    = new Set();
+
+        Object.keys(yamlTenants).forEach(key => tenantIds.add(key));
+        defaultRepos.forEach(entry => {
+            const id = entry && entry.tenantId;
+            if (id) tenantIds.add(normalizeUserId(id) || id);
+        });
+
+        const effective = [];
+
+        for (const tenantId of tenantIds) {
+            const graphRepos = this.graphService.getNodeRecord({id: `kb-config:${tenantId}`})?.properties?.tenantRepos,
+                  yamlRepos  = yamlTenants[tenantId]?.tenantRepos;
+
+            let repos;
+
+            if (Array.isArray(graphRepos) && graphRepos.length > 0) {
+                repos = graphRepos;
+            } else if (Array.isArray(yamlRepos) && yamlRepos.length > 0) {
+                repos = yamlRepos;
+            } else {
+                repos = defaultRepos.filter(entry => (normalizeUserId(entry.tenantId) || entry.tenantId) === tenantId);
+            }
+
+            repos.forEach(repo => effective.push(repo.tenantId ? repo : {...repo, tenantId}));
+        }
+
+        return normalizeTenantRepoConfig({tenantRepos: effective});
+    }
+
+    /**
      * @summary Persists a tenant's Knowledge Base ingestion config as a versioned graph node.
      *
      * Writes the `KnowledgeBaseTenantConfig` node (`kb-config:<tenantId>`); `version` increments on

--- a/learn/agentos/cloud-deployment/Configuration.md
+++ b/learn/agentos/cloud-deployment/Configuration.md
@@ -68,7 +68,7 @@ The token is a KB MCP authorization credential, not a Git credential. Store it i
 
 A multi-tenant deployment cannot express every tenant's source/parser config as static `aiConfig` keys — each tenant needs its own, mutable at runtime, durable across restarts. Phase 2E ([#11637](https://github.com/neomjs/neo/issues/11637)) stores it as a graph node.
 
-**The node.** One `KnowledgeBaseTenantConfig` node per tenant, id `kb-config:<tenantId>`, in the Native Edge Graph. Its `properties` carry the tenant's config payload — `{useDefaultSources, rawRepoSource, useDefaultParsers, customSources, customParsers, sourcePaths, version, userId}`. `version` increments on every mutation; `userId` is the [#10011](https://github.com/neomjs/neo/issues/10011) RLS ownership stamp — a tenant cannot read or mutate another tenant's config node.
+**The node.** One `KnowledgeBaseTenantConfig` node per tenant, id `kb-config:<tenantId>`, in the Native Edge Graph. Its `properties` carry the tenant's config payload — `{useDefaultSources, rawRepoSource, useDefaultParsers, customSources, customParsers, sourcePaths, tenantRepos, version, userId}`. `version` increments on every mutation; `userId` is the [#10011](https://github.com/neomjs/neo/issues/10011) RLS ownership stamp — a tenant cannot read or mutate another tenant's config node.
 
 **Resolution.** `KnowledgeBaseIngestionService.getTenantConfig({tenantId})` resolves a tenant's effective config through three tiers, first hit wins:
 
@@ -87,7 +87,13 @@ tenants:
     rawRepoSource: true
     customParsers: [...]
     sourcePaths: {...}
+    tenantRepos:
+      - cloneUrl: https://github.com/neomjs/create-app.git  # clean URL; no userinfo@
+        credentialRef: env:GIT_TOKEN                          # reference-only pointer; token lives outside the repo
+        branchRef: dev                                        # optional; defaults to 'HEAD' = remote default branch
 ```
+
+The `tenantRepos:` block is the bootstrap tier for the pull-mode polling config — `listConfiguredTenantRepos()` resolves it under the graph node → `kb-config.yaml` → `aiConfig` tiering.
 
 The YAML is bootstrap-only — the graph node is canonical once written. A malformed or absent file is fail-soft (logged, treated as absent → tier 3).
 

--- a/learn/agentos/cloud-deployment/CustomSources.md
+++ b/learn/agentos/cloud-deployment/CustomSources.md
@@ -101,7 +101,7 @@ A Source class is registered in the `SourceRegistry` singleton under a stable na
 
 ## Built-in Raw Repo Fallback
 
-Use `rawRepoSource: true` when a tenant needs day-0 ingestion before its repository shape is known well enough to justify a custom Source. This registers `RawRepoSource`, which walks `aiConfig.sourcePaths.RawRepoSource.root` and emits one raw-text parsed chunk per included file. It is not part of Neo's 10 curated default Sources, so zero-config Neo syncs never walk the full repository implicitly.
+Use `rawRepoSource: true` when a tenant needs day-0 ingestion before its repository shape is known well enough to justify a custom Source. This registers `RawRepoSource`, which walks `aiConfig.sourcePaths.RawRepoSource.root` and emits one raw-text parsed chunk per included file. It is not part of Neo's 10 curated default Sources, so zero-config Neo syncs never walk the full repository implicitly. This is the full-corpus Source-build path (`kbSync` lane / `npm run ai:sync-kb`) — **not** pull mode: server-side pull-mode ingestion takes the whole git tree from the deployment mirror regardless of `sourcePaths`.
 
 ```js
 rawRepoSource: true,

--- a/learn/agentos/cloud-deployment/Day0Tutorial.md
+++ b/learn/agentos/cloud-deployment/Day0Tutorial.md
@@ -572,10 +572,10 @@ The substrate that powers pull mode shipped via Epic [#11731](https://github.com
 
 **Skip this milestone if push covers your tenant content.** Pull is additive, not a prerequisite for the Day-0 operator handoff.
 
-If pull mode applies to your deployment, configure one tenant repo as a smoke:
+If pull mode applies to your deployment, configure one tenant repo as a smoke. The pull-mode polling config resolves through the same three tiers as the rest of tenant config: the `kb-config:<tenantId>` graph node → the `kb-config.yaml` bootstrap (`tenants.<id>.tenantRepos`) → the local `config.mjs` `aiConfig.tenantRepos[]` default. `kb-config.yaml` is the canonical bootstrap tier; the `config.mjs` overlay below remains the Tier-3 default fallback.
 
 ```js
-// In <NEO_SOURCE_DIR>/ai/mcp/server/knowledge-base/config.mjs (operator overlay):
+// In <NEO_SOURCE_DIR>/ai/mcp/server/knowledge-base/config.mjs (operator overlay — Tier-3 default):
 tenantRepos: [
     {
         tenantId      : 'client-org',

--- a/learn/agentos/cloud-deployment/MigrationPath.md
+++ b/learn/agentos/cloud-deployment/MigrationPath.md
@@ -40,7 +40,7 @@ The new config keys (`useDefaultSources`, `rawRepoSource`, `useDefaultParsers`, 
 
 ## Tenant-config persistence
 
-How a multi-tenant deployment *stores* its per-tenant configuration — the `KnowledgeBaseTenantConfig` graph-node shape, the `kb-config.yaml` bootstrap-vs-canonical semantics, config-version metadata — is defined by #11637 and documented in **[Configuration](./Configuration.md)**. A deployment's tenant config resolves through three tiers: the `kb-config:<tenantId>` graph node → the `kb-config.yaml` bootstrap → the local `config.mjs` defaults.
+How a multi-tenant deployment *stores* its per-tenant configuration — the `KnowledgeBaseTenantConfig` graph-node shape, the `kb-config.yaml` bootstrap-vs-canonical semantics, config-version metadata — is defined by #11637 and documented in **[Configuration](./Configuration.md)**. A deployment's tenant config resolves through three tiers: the `kb-config:<tenantId>` graph node → the `kb-config.yaml` bootstrap → the local `config.mjs` defaults. This tiering now also covers `tenantRepos` (the pull-mode polling config), resolved via `listConfiguredTenantRepos`.
 
 ## Breaking-change inventory
 

--- a/learn/agentos/cloud-deployment/TenantIngestionModel.md
+++ b/learn/agentos/cloud-deployment/TenantIngestionModel.md
@@ -69,6 +69,7 @@ The push-based MVP path is credential-free from the KB server's perspective:
 - The repo-push automation identity token authorizes the tenant to call the KB MCP endpoint; it is not a Git credential and is never folded into `repoSlug`, manifests, or chunk metadata.
 - Optional server-side pull config uses `tenantRepos[]` entries with clean `cloneUrl`, reference-only `credentialRef`, and normalized `repoSlug` (#11787). Credential-bearing `userinfo@` clone URLs are rejected before graph persistence; credential injection belongs to the `GitMirror` primitive (#11788). `GitMirror` resolves the credential reference only for the git subprocess invocation (`GIT_ASKPASS` for HTTPS, `GIT_SSH_COMMAND` for SSH) and keeps mirror contents on the deployment `tenant-repo-mirrors` volume mounted at `NEO_TENANT_REPO_MIRROR_ROOT`.
 - For the pull-based follow-up path, `TenantRepoIngestEnvelopeBuilder` adapts the Git mirror into the same ingestion service envelope (#11789). Linear history advances emit raw-file `files`, explicit `deleted` tombstones, `baseRevision`, and `headRevision`; bootstrap, missing-baseline, and non-linear history cases emit a full `files` snapshot plus `manifestSnapshot` so `KnowledgeBaseIngestionService.ingestSourceFiles()` can reconcile the claimed live file set without re-pointing the local `kbSync` lane.
+- Pull-mode **file selection** comes from the git mirror itself (`git ls-tree` / revision diff in `TenantRepoIngestEnvelopeBuilder`) and is independent of `kb-config.yaml`'s Source/Parser registration. In particular, `sourcePaths.RawRepoSource.root` is **not** honored on the pull path — the whole tracked tree is ingested. `rawRepoSource` / `sourcePaths` drive the full-corpus Source build (`kbSync` lane / `npm run ai:sync-kb`), a different path from pull mode.
 
 Credential-bearing Git URLs are therefore rejected or treated as deferred clone-exploration input. They must not appear in:
 
@@ -173,7 +174,7 @@ The pull lane (`tenant-repo-sync`) clones each configured repository into a depl
 
 ### Configuration
 
-The `aiConfig.tenantRepos[]` array is read by `KnowledgeBaseIngestionService.getTenantConfig()` via the `TenantRepoAccessContract` normalizer. Each entry:
+The orchestrator's pull-mode sync (`TenantRepoSyncService.resolveTenantReposConfig`) resolves `tenantRepos` via `KnowledgeBaseIngestionService.listConfiguredTenantRepos()`. That resolver enumerates each configured tenant's *effective* config across three tiers — `kb-config:<tenantId>` graph node > `kb-config.yaml` bootstrap > `aiConfig.tenantRepos[]` default — single-winner per tenant (a tenant's highest present tier wins wholesale; tiers are not merged within a tenant), then flattens `tenantRepos` across tenants. Each entry is normalized through the `TenantRepoAccessContract`. Each entry:
 
 ```js
 {

--- a/test/playwright/unit/ai/daemons/orchestrator/services/TenantRepoSyncService.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/services/TenantRepoSyncService.spec.mjs
@@ -1210,16 +1210,16 @@ test.describe('TenantRepoSyncService.resolveTenantReposConfig — Tier-1 mirrorR
      */
 
     test('absent per-repo mirrorRoot inherits Tier-1 default; explicit per-repo override wins', async () => {
-        const aiConfigStub = {
-            tenantRepos: [
+        const ingestionStub = {
+            listConfiguredTenantRepos: async () => ({tenantRepos: [
                 {tenantId: 't1', repoSlug: 'org/inherits', cloneUrl: 'https://github.com/neomjs/a.git', credentialRef: 'env:T'},
                 {tenantId: 't1', repoSlug: 'org/overrides', cloneUrl: 'https://github.com/neomjs/b.git', credentialRef: 'env:T', mirrorRoot: '/custom/root'}
-            ]
+            ]})
         };
 
         const result = await TenantRepoSyncService.resolveTenantReposConfig({
-            aiConfig       : aiConfigStub,
-            tier1MirrorRoot: '/app/.neo-ai-data'
+            ingestionService: ingestionStub,
+            tier1MirrorRoot : '/app/.neo-ai-data'
         });
 
         const inherits  = result.tenantRepos.find(r => r.repoSlug === 'org/inherits');
@@ -1230,15 +1230,15 @@ test.describe('TenantRepoSyncService.resolveTenantReposConfig — Tier-1 mirrorR
     });
 
     test('Tier-1 default + deriveTenantRepoMirrorPath produces canonical no-double-segment path', async () => {
-        const aiConfigStub = {
-            tenantRepos: [
+        const ingestionStub = {
+            listConfiguredTenantRepos: async () => ({tenantRepos: [
                 {tenantId: 'tenant-a', repoSlug: 'repo-a', cloneUrl: 'https://github.com/neomjs/a.git', credentialRef: 'env:T'}
-            ]
+            ]})
         };
 
         const result      = await TenantRepoSyncService.resolveTenantReposConfig({
-            aiConfig       : aiConfigStub,
-            tier1MirrorRoot: '/app/.neo-ai-data'
+            ingestionService: ingestionStub,
+            tier1MirrorRoot : '/app/.neo-ai-data'
         });
         const resolvedRepo = result.tenantRepos[0];
         const mirrorPath   = deriveTenantRepoMirrorPath({
@@ -1252,14 +1252,14 @@ test.describe('TenantRepoSyncService.resolveTenantReposConfig — Tier-1 mirrorR
     });
 
     test('stale-overlay defense: missing orchestratorConfig.tenantRepoMirrorRoot falls back to env var (#12036 cycle-2 RA1)', async () => {
-        const aiConfigStub = {
-            tenantRepos: [
+        const ingestionStub = {
+            listConfiguredTenantRepos: async () => ({tenantRepos: [
                 {tenantId: 't1', repoSlug: 'org/r', cloneUrl: 'https://github.com/o/r.git', credentialRef: 'env:T'}
-            ]
+            ]})
         };
 
         const result = await TenantRepoSyncService.resolveTenantReposConfig({
-            aiConfig          : aiConfigStub,
+            ingestionService  : ingestionStub,
             orchestratorConfig: {},  // simulate stale operator overlay (no tenantRepoMirrorRoot key)
             env               : {NEO_TENANT_REPO_MIRROR_ROOT: '/env-bound/root'}
         });
@@ -1268,14 +1268,14 @@ test.describe('TenantRepoSyncService.resolveTenantReposConfig — Tier-1 mirrorR
     });
 
     test('stale-overlay defense: missing orchestratorConfig AND no env var → hardcoded /app/.neo-ai-data (#12036 cycle-2 RA1)', async () => {
-        const aiConfigStub = {
-            tenantRepos: [
+        const ingestionStub = {
+            listConfiguredTenantRepos: async () => ({tenantRepos: [
                 {tenantId: 't1', repoSlug: 'org/r', cloneUrl: 'https://github.com/o/r.git', credentialRef: 'env:T'}
-            ]
+            ]})
         };
 
         const result = await TenantRepoSyncService.resolveTenantReposConfig({
-            aiConfig          : aiConfigStub,
+            ingestionService  : ingestionStub,
             orchestratorConfig: {},
             env               : {}
         });

--- a/test/playwright/unit/ai/services/knowledge-base/KnowledgeBaseIngestionService.spec.mjs
+++ b/test/playwright/unit/ai/services/knowledge-base/KnowledgeBaseIngestionService.spec.mjs
@@ -667,3 +667,100 @@ test.describe('KnowledgeBaseIngestionService.tenantConfig (#11637)', () => {
         expect((await Service.getTenantConfig({tenantId: 'tenant-z'})).source).toBe('default');
     });
 });
+
+test.describe('KnowledgeBaseIngestionService.listConfiguredTenantRepos (#12145)', () => {
+    let Service;
+    let originals;
+    let graphStub;
+
+    test.beforeAll(async () => {
+        Service = (await import('../../../../../../ai/services/knowledge-base/KnowledgeBaseIngestionService.mjs')).default;
+    });
+
+    test.beforeEach(() => {
+        graphStub = createGraphStub();
+        originals = {
+            graphService         : Service.graphService,
+            readKbConfigBootstrap: Service.readKbConfigBootstrap
+        };
+
+        Service.graphService          = graphStub;
+        Service.readKbConfigBootstrap = () => null;
+    });
+
+    test.afterEach(() => {
+        Object.assign(Service, originals);
+    });
+
+    function seedGraphConfig(tenantId, tenantRepos) {
+        graphStub.store.set(`kb-config:${tenantId}`, {
+            id        : `kb-config:${tenantId}`,
+            type      : 'KnowledgeBaseTenantConfig',
+            properties: {tenantId, tenantRepos, visibility: 'team'}
+        });
+    }
+
+    test('flattens per-tenant yaml-tier tenantRepos across tenants and stamps tenantId', async () => {
+        Service.readKbConfigBootstrap = () => ({
+            tenants: {
+                'tenant-a': {tenantRepos: [{cloneUrl: 'https://github.com/neomjs/a.git', credentialRef: 'env:A'}]},
+                'tenant-b': {tenantRepos: [{cloneUrl: 'https://github.com/neomjs/b.git', credentialRef: 'env:B'}]}
+            }
+        });
+
+        const {tenantRepos} = await Service.listConfiguredTenantRepos();
+
+        expect(tenantRepos).toHaveLength(2);
+        expect(tenantRepos.find(r => r.tenantId === 'tenant-a')).toMatchObject({
+            cloneUrl: 'https://github.com/neomjs/a.git', credentialRef: 'env:A', repoSlug: 'github.com/neomjs/a'
+        });
+        expect(tenantRepos.find(r => r.tenantId === 'tenant-b')).toMatchObject({
+            cloneUrl: 'https://github.com/neomjs/b.git', credentialRef: 'env:B'
+        });
+    });
+
+    test('graph-node tier wins WHOLESALE over yaml for the same tenant (no within-tenant merge)', async () => {
+        seedGraphConfig('tenant-a', [{cloneUrl: 'https://github.com/neomjs/graph.git', credentialRef: 'env:G'}]);
+        Service.readKbConfigBootstrap = () => ({
+            tenants: {'tenant-a': {tenantRepos: [{cloneUrl: 'https://github.com/neomjs/yaml.git', credentialRef: 'env:Y'}]}}
+        });
+
+        const {tenantRepos} = await Service.listConfiguredTenantRepos();
+
+        expect(tenantRepos).toHaveLength(1);
+        expect(tenantRepos[0]).toMatchObject({
+            tenantId: 'tenant-a', cloneUrl: 'https://github.com/neomjs/graph.git', credentialRef: 'env:G'
+        });
+    });
+
+    test('derives the tenant set from keyed tiers only — a graph-only tenant is not enumerated (no raw node scan)', async () => {
+        // A graph-only tenant (no yaml/aiConfig entry) is out of scope until a setTenantConfig
+        // operator tool exists. The resolver reads graph nodes per-tenant via getNodeRecord for
+        // tenants in the keyed set; it must NOT discover a node by scanning all graph rows.
+        seedGraphConfig('graph-only-tenant', [{cloneUrl: 'https://github.com/neomjs/x.git', credentialRef: 'env:X'}]);
+        Service.readKbConfigBootstrap = () => ({
+            tenants: {'tenant-a': {tenantRepos: [{cloneUrl: 'https://github.com/neomjs/a.git', credentialRef: 'env:A'}]}}
+        });
+
+        const {tenantRepos} = await Service.listConfiguredTenantRepos();
+
+        expect(tenantRepos).toHaveLength(1);
+        expect(tenantRepos[0].tenantId).toBe('tenant-a');
+        expect(tenantRepos.some(r => r.cloneUrl.includes('/x.git'))).toBe(false);
+    });
+
+    test('propagates the access-contract rejection for a yaml entry missing credentialRef', async () => {
+        Service.readKbConfigBootstrap = () => ({
+            tenants: {'tenant-a': {tenantRepos: [{cloneUrl: 'https://github.com/neomjs/a.git'}]}}
+        });
+
+        await expect(Service.listConfiguredTenantRepos()).rejects.toThrow();
+    });
+
+    test('returns an empty array when no tenant declares tenantRepos', async () => {
+        Service.readKbConfigBootstrap = () => ({tenants: {'tenant-a': {useDefaultSources: false}}});
+
+        const {tenantRepos} = await Service.listConfiguredTenantRepos();
+        expect(tenantRepos).toEqual([]);
+    });
+});

--- a/test/playwright/unit/ai/services/knowledge-base/KnowledgeBaseIngestionService.spec.mjs
+++ b/test/playwright/unit/ai/services/knowledge-base/KnowledgeBaseIngestionService.spec.mjs
@@ -19,6 +19,7 @@ import {test, expect} from '@playwright/test';
 import Neo            from '../../../../../../src/Neo.mjs';
 import * as core      from '../../../../../../src/core/_export.mjs';
 import fs             from 'fs-extra';
+import aiConfig       from '../../../../../../ai/mcp/server/knowledge-base/config.mjs';
 
 /**
  * Contract coverage for KnowledgeBaseIngestionService (#11633).
@@ -672,6 +673,7 @@ test.describe('KnowledgeBaseIngestionService.listConfiguredTenantRepos (#12145)'
     let Service;
     let originals;
     let graphStub;
+    let originalAiConfigRepos;
 
     test.beforeAll(async () => {
         Service = (await import('../../../../../../ai/services/knowledge-base/KnowledgeBaseIngestionService.mjs')).default;
@@ -683,6 +685,7 @@ test.describe('KnowledgeBaseIngestionService.listConfiguredTenantRepos (#12145)'
             graphService         : Service.graphService,
             readKbConfigBootstrap: Service.readKbConfigBootstrap
         };
+        originalAiConfigRepos = aiConfig.tenantRepos;
 
         Service.graphService          = graphStub;
         Service.readKbConfigBootstrap = () => null;
@@ -690,6 +693,7 @@ test.describe('KnowledgeBaseIngestionService.listConfiguredTenantRepos (#12145)'
 
     test.afterEach(() => {
         Object.assign(Service, originals);
+        aiConfig.tenantRepos = originalAiConfigRepos;
     });
 
     function seedGraphConfig(tenantId, tenantRepos) {
@@ -759,6 +763,29 @@ test.describe('KnowledgeBaseIngestionService.listConfiguredTenantRepos (#12145)'
 
     test('returns an empty array when no tenant declares tenantRepos', async () => {
         Service.readKbConfigBootstrap = () => ({tenants: {'tenant-a': {useDefaultSources: false}}});
+
+        const {tenantRepos} = await Service.listConfiguredTenantRepos();
+        expect(tenantRepos).toEqual([]);
+    });
+
+    test('graph-node tier with empty tenantRepos suppresses yaml + default for that tenant (presence-based winner)', async () => {
+        // An existing graph record declaring `tenantRepos: []` intentionally disables pull-mode for
+        // the tenant; it must win wholesale even though the array is empty — selecting on length > 0
+        // would leak the yaml/default repos back in (the cycle-1 fallback bug).
+        seedGraphConfig('tenant-a', []);
+        Service.readKbConfigBootstrap = () => ({
+            tenants: {'tenant-a': {tenantRepos: [{cloneUrl: 'https://github.com/neomjs/yaml.git', credentialRef: 'env:Y'}]}}
+        });
+
+        const {tenantRepos} = await Service.listConfiguredTenantRepos();
+        expect(tenantRepos).toEqual([]);
+    });
+
+    test('yaml tier with empty tenantRepos suppresses the aiConfig default tier for that tenant (presence-based winner)', async () => {
+        aiConfig.tenantRepos = [{tenantId: 'tenant-a', cloneUrl: 'https://github.com/neomjs/default.git', credentialRef: 'env:D'}];
+        Service.readKbConfigBootstrap = () => ({
+            tenants: {'tenant-a': {tenantRepos: []}}
+        });
 
         const {tenantRepos} = await Service.listConfiguredTenantRepos();
         expect(tenantRepos).toEqual([]);


### PR DESCRIPTION
Resolves #12145

Authored by Claude Opus 4.7 (Claude Code). Session efd8dc2e-2052-4089-814a-ab22cd8c6a62.

FAIR-band: operator-directed lane — #12145 was explicitly assigned by @tobiu; FAIR-band self-selection discipline is N/A for directed work.

Evidence: L2 (unit-tested tier resolution + flatten + single-winner + RLS-via-stub + orchestrator delegation; 66/66 passing) → L4 required (AC3 end-to-end pull sync honoring the `kb-config.yaml` tier on a live deployment). Residual: end-to-end deployment validation on a live tenant (post-merge).

## Summary

The orchestrator's pull-mode tenant-repo sync read `aiConfig.tenantRepos[]` directly, bypassing the documented graph > `kb-config.yaml` > `aiConfig` tiering (`TenantIngestionModel.md:335`). A tenant's `kb-config.yaml` polling config was therefore never honored on the pull path — contract drift, not a missing capability. This wires the pull lane through the existing tier model.

- **`KnowledgeBaseIngestionService.listConfiguredTenantRepos()`** (new): enumerates each configured tenant's *effective* `tenantRepos` — per-tenant single-winner across graph node (RLS-respecting `getNodeRecord`) > `kb-config.yaml` bootstrap > `aiConfig.tenantRepos[]` default — then flattens across tenants. No within-tenant tier merge; no raw node scan (the tenant set is derived from the keyed tiers, preserving the #10011 visibility model).
- **`TenantRepoSyncService.resolveTenantReposConfig`** delegates to it; the now-dead `aiConfig` test seam is retired through `runTask` / `syncTenantRepos`.
- **`ai/deploy/docker-compose.yml`**: documents the orchestrator `kb-config.yaml` RO-mount requirement for deployments using the bootstrap tier (the literal bind-mount lands in deployment composes).
- **Docs** (`learn/agentos/cloud-deployment/`): correct the pull-vs-full-corpus framing — pull-mode file selection comes from the git mirror, independent of `kb-config.yaml`'s `sourcePaths` (`sourcePaths.root` is not honored on the pull path); add `tenantRepos` to the tiered config model.

Resolver semantics per @neo-gpt's cross-family review (per-tenant single-winner + RLS-preservation guard) — see the #12145 comment thread.

## Deltas from ticket (if any)

- **AC1 / AC9 refined** per @neo-gpt's cross-family review — per-tenant single-winner (graph wins wholesale; no within-tenant merge) + the no-raw-scan RLS guard. Folded into the resolver + tests.
- **AC5** is realized in the canonical `ai/deploy/docker-compose.yml` as documented mount *guidance*; a literal bind-mount there would point at a non-existent file and break `compose up`, so the actual RO bind-mount lands in deployment composes.
- The standalone doc-fix (originally framed as a separate item) is folded into this PR's docs commit.

## Test Evidence

`npm run test-unit -- <KB spec> <TenantRepoSync spec>` → **66/66 passing**.
- New `listConfiguredTenantRepos` cases: flatten-across-tenants + `tenantId` stamping; graph tier wins wholesale over yaml (single-winner); graph-only tenant not enumerated (no raw scan); access-contract rejection propagation; empty-config.
- `resolveTenantReposConfig` mirrorRoot-fallback tests migrated to the `ingestionService` delegation seam.

## Substrate note (learn/agentos/ touch — PR-workflow §1.1)

The `learn/agentos/cloud-deployment/*` edits are factual corrections to operator-facing deployment guides, not agent-rule/skill substrate. Disposition: `rewrite` of existing doc sentences/examples to match shipped behavior. Decay-mitigation: the docs previously mis-framed `kb-config.yaml` as pull-mode-required and omitted `tenantRepos` from the tier model; aligning them with the code removes a demonstrated operator-confusion source. No new always-loaded rule substrate is added.

## Decision Record impact

`aligned-with ADR 0014` (cloud deployment topology + scheduler task taxonomy). Completes the documented tenant-config-storage intent (`TenantIngestionModel.md:335`); no ADR conflict.

## Post-Merge Validation
- [ ] On a live deployment, a tenant declared only via `kb-config.yaml` `tenants.<id>.tenantRepos` is cloned + ingested by the orchestrator pull lane (end-to-end, not just resolver-level).
- [ ] Deployment composes mount `kb-config.yaml` read-only into the orchestrator service.

## Commits
- `b30625943` — core: `listConfiguredTenantRepos` resolver + delegation + compose note
- `cd194353c` — tests: tier resolution + delegation (66/66)
- `fdfc8f450` — docs: tiering + pull-vs-full-corpus corrections

## Out of Scope
- `setTenantConfig` operator MCP tool for the graph tier (honored-if-present; not added here).
- The deployment-side config move (relocating a tenant's repo block from the gitignored `config.mjs` overlay into committed `kb-config.yaml`) — gated on this landing + a release.
