### PR TITLE
fix(build): bootstrapWorktree CLI resolves projectRoot to repo root (#12147)

### DIFF
--- a/ai/scripts/migrations/bootstrapWorktree.mjs
+++ b/ai/scripts/migrations/bootstrapWorktree.mjs
@@ -212,6 +212,22 @@ export async function resolveMainCheckout(cwd, {explicitRoot} = {}) {
 }
 
 /**
+ * @summary Resolves the repo root from this CLI module's directory.
+ *
+ * The script lives at `ai/scripts/migrations/bootstrapWorktree.mjs` — three levels below the
+ * repo root (`migrations/` → `scripts/` → `ai/` → root). Extracted + exported so the CLI
+ * `projectRoot` computation is unit-testable: the `isMain` block itself is not exercised by
+ * the spec, which is how the prior 2-level `'..', '..'` miss (→ `<root>/ai`, copying configs
+ * into `<root>/ai/ai/`) escaped coverage.
+ *
+ * @param {string} moduleDir Absolute directory of this module (the CLI `__dirname`).
+ * @returns {string} Absolute repo root.
+ */
+export function resolveCliProjectRoot(moduleDir) {
+    return path.resolve(moduleDir, '..', '..', '..');
+}
+
+/**
  * @summary Copies missing config.mjs files from the main checkout into the target project root.
  * Per-server configs are materialized after copy so their Tier-1 import points at the
  * copied operator overlay (`ai/config.mjs`) instead of `ai/config.template.mjs`.
@@ -898,7 +914,7 @@ const isMain = process.argv[1] && fileURLToPath(import.meta.url) === path.resolv
 if (isMain) {
     const __filename  = fileURLToPath(import.meta.url);
     const __dirname   = path.dirname(__filename);
-    const projectRoot = path.resolve(__dirname, '..', '..'); // ai/scripts/ → ai/ → root
+    const projectRoot = resolveCliProjectRoot(__dirname); // ai/scripts/migrations/ → scripts/ → ai/ → root
 
     const argv     = process.argv.slice(2);
     const args     = new Set(argv);

--- a/test/playwright/unit/ai/scripts/migrations/bootstrapWorktree.spec.mjs
+++ b/test/playwright/unit/ai/scripts/migrations/bootstrapWorktree.spec.mjs
@@ -35,6 +35,7 @@ test.describe('ai/scripts/bootstrapWorktree', () => {
     let installDependencies;
     let runBuildAll;
     let resolveMainCheckout;
+    let resolveCliProjectRoot;
     let parseWorktreePorcelain;
     let pruneStaleWorktrees;
     let BOOTSTRAP_CONFIGS;
@@ -59,6 +60,7 @@ test.describe('ai/scripts/bootstrapWorktree', () => {
         installDependencies      = mod.installDependencies;
         runBuildAll              = mod.runBuildAll;
         resolveMainCheckout      = mod.resolveMainCheckout;
+        resolveCliProjectRoot    = mod.resolveCliProjectRoot;
         parseWorktreePorcelain   = mod.parseWorktreePorcelain;
         pruneStaleWorktrees      = mod.pruneStaleWorktrees;
         BOOTSTRAP_CONFIGS        = mod.BOOTSTRAP_CONFIGS;
@@ -87,6 +89,14 @@ test.describe('ai/scripts/bootstrapWorktree', () => {
 
     test('exports the canonical BOOTSTRAP_CONFIGS list', () => {
         expect(BOOTSTRAP_CONFIGS).toEqual(fixtureConfigs);
+    });
+
+    test('resolveCliProjectRoot climbs migrations/ → scripts/ → ai/ → root (#12147)', () => {
+        // The script lives 3 levels deep at ai/scripts/migrations/; the repo root is 3 `..` up.
+        expect(resolveCliProjectRoot('/repo/ai/scripts/migrations')).toBe('/repo');
+        // Regression guard: the prior 2-level resolve mislanded at <root>/ai, so the CLI copied
+        // BOOTSTRAP_CONFIGS into <root>/ai/ai/ instead of the repo root.
+        expect(path.resolve('/repo/ai/scripts/migrations', '..', '..')).toBe('/repo/ai');
     });
 
     test('copies every missing config.mjs from main checkout into the worktree', async () => {


### PR DESCRIPTION
Resolves #12147

Authored by Claude Opus 4.7 (Claude Code). Session efd8dc2e-2052-4089-814a-ab22cd8c6a62.

FAIR-band: operator-directed quick-win — surfaced and greenlit by @tobiu during #12145; FAIR-band self-selection is N/A for directed work.

Evidence: L2 (unit-tested helper resolves `<root>/ai/scripts/migrations` → `<root>` + a regression guard; 35/35 bootstrapWorktree spec passing) → L2 sufficient (pure path-math fix, fully unit-covered). A post-merge L3 CLI run is optional confirmation.

## Summary

The `isMain` CLI block computed `path.resolve(__dirname, '..', '..')`, but the script lives at `ai/scripts/migrations/` (3 levels deep) — two `..` climbs only to `<root>/ai`, not the repo root. Config copies then landed in `<root>/ai/ai/`, the real `ai/config.mjs` never materialized, and worktree bootstrap left every `ai/services.mjs` consumer at `ERR_MODULE_NOT_FOUND`. The comment ("ai/scripts/ → ai/ → root") was stale from before the file moved into `migrations/`.

- Extract `resolveCliProjectRoot(moduleDir)` (three `..`), exported so the CLI `projectRoot` computation is unit-testable.
- `isMain` uses the helper; corrected the stale comment.
- Spec asserts the helper resolves to root + a regression guard for the prior 2-level mislanding.

## Deltas from ticket (if any)

None — implementation matches the ticket's prescription (extract + correct + test).

## Test Evidence

`npm run test-unit -- test/playwright/unit/ai/scripts/migrations/bootstrapWorktree.spec.mjs` → **35/35 passing**, including the new `resolveCliProjectRoot` case.

## Post-Merge Validation
- [ ] `node ai/scripts/migrations/bootstrapWorktree.mjs` in a fresh worktree hydrates `config.mjs` files at the repo root (no `ai/ai/` stray).

## Commits
- `d7f19c07d` — `resolveCliProjectRoot` helper + corrected level count + spec coverage
