### PR TITLE
feat(ai): orchestrator recycles chroma after max runtime (#12138)

### DIFF
--- a/ai/config.template.mjs
+++ b/ai/config.template.mjs
@@ -472,8 +472,10 @@ class Config extends BaseConfig {
                 }
             },
             /**
-             * Chroma defrag policy. V1 exposes cadence as operator policy only; no daemon
-             * auto-spawns defrag from this value.
+             * Chroma defrag policy. Cadence here is operator policy only — no daemon
+             * auto-spawns defrag from THIS value. (The one orchestrator path that auto-spawns
+             * `ai:defrag-kb` is the #12138 max-runtime recycle, driven by
+             * `orchestrator.chroma.maxRuntimeMs` — a distinct config, not this cadence.)
              * @type {Object}
              */
             defrag: {

--- a/ai/config.template.mjs
+++ b/ai/config.template.mjs
@@ -301,6 +301,17 @@ class Config extends BaseConfig {
                 swarmHeartbeatMs      : 15 * 60 * 1000
             },
             /**
+             * Chroma daemon recycle policy (#12138). The orchestrator kills and respawns the
+             * supervised Chroma daemon once its uptime exceeds `maxRuntimeMs`, then runs a
+             * unified-store-safe defrag against the fresh daemon. `0` disables recycling.
+             * Env override: `NEO_CHROMA_MAX_RUNTIME_MS`. The lane is gated by
+             * `localOnly.chromaDaemonEnabled` — a no-op when Chroma is externally managed.
+             * @type {Object}
+             */
+            chroma: {
+                maxRuntimeMs: DAY_MS
+            },
+            /**
              * Swarm-heartbeat target-resolver config. Controls which identity set
              * `SwarmHeartbeatService.pulse()` targets per cycle via the resolver
              * precedence chain. Env override: `NEO_ORCHESTRATOR_SWARM_HEARTBEAT_TARGET_SOURCE`.
@@ -665,6 +676,9 @@ class Config extends BaseConfig {
                 dreamOverflowThreshold: {var: 'NEO_ORCHESTRATOR_DREAM_OVERFLOW_THRESHOLD', parse: Env.parseNumber},
                 goldenPathMs          : {var: 'NEO_ORCHESTRATOR_GOLDEN_PATH_INTERVAL_MS',       parse: Env.parseNumber},
                 swarmHeartbeatMs      : {var: 'NEO_ORCHESTRATOR_SWARM_HEARTBEAT_INTERVAL_MS',   parse: Env.parseNumber}
+            },
+            chroma: {
+                maxRuntimeMs: {var: 'NEO_CHROMA_MAX_RUNTIME_MS', parse: Env.parseNumber}
             },
             tenantRepoSync: {
                 sweepCadenceMs: {var: 'NEO_ORCHESTRATOR_TENANT_REPO_SYNC_SWEEP_CADENCE_MS', parse: Env.parseNumber},

--- a/ai/daemons/orchestrator/Orchestrator.mjs
+++ b/ai/daemons/orchestrator/Orchestrator.mjs
@@ -417,6 +417,7 @@ export class Orchestrator extends Base {
     get tenantRepoSyncEnabled()          { return resolveCloudOnlyEnabled('tenantRepoSyncEnabled');           }
     get chromaDaemonEnabled()            { return resolveDeploymentEnabled('chromaDaemonEnabled');            }
     get chromaPort()                     { return AiConfig.engines.chroma?.port;                              }
+    get chromaMaxRuntimeMs()             { return AiConfig.orchestrator.chroma?.maxRuntimeMs;                  }
     get bridgeDaemonEnabled()            { return resolveDeploymentEnabled('bridgeDaemonEnabled');            }
     get swarmHeartbeatEnabled()          { return resolveDeploymentEnabled('swarmHeartbeatEnabled');          }
     get goldenPathRepoEnrichmentEnabled(){ return resolveDeploymentEnabled('goldenPathRepoEnrichmentEnabled');}

--- a/ai/daemons/orchestrator/Orchestrator.mjs
+++ b/ai/daemons/orchestrator/Orchestrator.mjs
@@ -630,7 +630,11 @@ export class Orchestrator extends Base {
      */
     isChromaRecycleDue(state, now) {
         const maxRuntimeMs = this.chromaMaxRuntimeMs;
-        return Boolean(state?.running) && maxRuntimeMs > 0 && (now - (state.lastRunAt || 0)) > maxRuntimeMs;
+        const lastRunAt    = state?.lastRunAt || 0;
+        // lastRunAt === 0 means no recorded spawn (uninitialized / never started): uptime is
+        // undefined, so never recycle. A genuinely running daemon always carries a real start
+        // stamp (markStarted), so this only excludes inconsistent/uninitialized state.
+        return Boolean(state?.running) && maxRuntimeMs > 0 && lastRunAt > 0 && (now - lastRunAt) > maxRuntimeMs;
     }
 
     /**

--- a/ai/daemons/orchestrator/Orchestrator.mjs
+++ b/ai/daemons/orchestrator/Orchestrator.mjs
@@ -5,6 +5,7 @@
 // class were ever loaded outside its entry-point's chain.
 import fs                          from 'fs-extra';
 import {spawn}                     from 'child_process';
+import net                         from 'net';
 import path                        from 'path';
 import Base                        from '../../../src/core/Base.mjs';
 import ClassSystemUtil             from '../../../src/util/ClassSystem.mjs';
@@ -501,6 +502,11 @@ export class Orchestrator extends Base {
             ? options.primaryDevSyncRootsConfig
             : AiConfig.orchestrator.devSyncRoots;
         this.maintenanceDeferralLogKeys = new Set();
+        // #12138 chroma max-runtime recycle: in-memory flags (not persisted — re-derived from
+        // uptime if the orchestrator restarts mid-recycle). `_chromaDefragPending` gates the
+        // post-restart defrag; `_chromaDefragInFlight` prevents poll re-entry during the probe.
+        this._chromaDefragPending  = false;
+        this._chromaDefragInFlight = false;
 
         fs.ensureDirSync(this.dataDir);
 
@@ -615,6 +621,38 @@ export class Orchestrator extends Base {
     }
 
     /**
+     * Whether the supervised Chroma daemon's uptime has exceeded the configured recycle
+     * ceiling. Pure predicate over task state + `chromaMaxRuntimeMs`; a `0`/absent ceiling
+     * disables recycling.
+     * @param {Object} state Chroma task state ({running, lastRunAt}).
+     * @param {Number} now Epoch ms.
+     * @returns {Boolean}
+     */
+    isChromaRecycleDue(state, now) {
+        const maxRuntimeMs = this.chromaMaxRuntimeMs;
+        return Boolean(state?.running) && maxRuntimeMs > 0 && (now - (state.lastRunAt || 0)) > maxRuntimeMs;
+    }
+
+    /**
+     * Resolves true once a TCP connection to the local Chroma port succeeds — a
+     * connection-ready proxy mirroring the integration stack's `/dev/tcp` healthcheck.
+     * Overridable in tests; never rejects.
+     * @param {Object} [options]
+     * @param {Number} [options.timeoutMs=2000] Probe timeout.
+     * @returns {Promise<Boolean>}
+     */
+    probeChromaReady({timeoutMs = 2000} = {}) {
+        return new Promise(resolve => {
+            const socket = net.connect({host: 'localhost', port: this.chromaPort});
+            const finish = result => { socket.destroy(); resolve(result); };
+            socket.setTimeout(timeoutMs);
+            socket.once('connect', () => finish(true));
+            socket.once('timeout', () => finish(false));
+            socket.once('error',   () => finish(false));
+        });
+    }
+
+    /**
      * Executes a sweep and schedules the next poll when the daemon remains active.
      * @returns {void}
      */
@@ -639,11 +677,39 @@ export class Orchestrator extends Base {
             this.processSupervisorService.reapDuplicateListeners(taskName);
 
             const state = this.taskStateService.getTaskState(taskName);
+
+            // Max-runtime recycle (#12138): kill an over-age chroma daemon (SIGKILL — chroma
+            // ignores SIGTERM) so the restart branch below respawns it; the KB defrag fires
+            // once the fresh daemon is connection-ready. Implicitly gated by chromaDaemonEnabled
+            // (chroma is only a continuousTask when that lane is enabled).
+            if (taskName === 'chroma' && this.isChromaRecycleDue(state, now)) {
+                this.processSupervisorService.killTask('chroma', `max-runtime:${now - (state.lastRunAt || 0)}ms>${this.chromaMaxRuntimeMs}ms`);
+                this._chromaDefragPending = true;
+                continue;
+            }
+
             if (state && !state.running) {
                 const lastRunAt = state.lastRunAt || 0;
                 if (now - lastRunAt > RESTART_COOLDOWN_MS) {
                     executeTask(taskName, 'supervisor-restart');
                 }
+            }
+
+            // Post-recycle defrag (#12138): once the restarted chroma is connection-ready, run
+            // the unified-store-safe KB defrag against the fresh daemon. MC defrag is deferred
+            // (no rebuild-from-source fallback) to #12142. The in-flight guard prevents poll
+            // re-entry while the async readiness probe is pending.
+            if (taskName === 'chroma' && state?.running && this._chromaDefragPending && !this._chromaDefragInFlight) {
+                this._chromaDefragInFlight = true;
+                this.probeChromaReady()
+                    .then(ready => {
+                        if (ready && this._chromaDefragPending) {
+                            this._chromaDefragPending = false;
+                            executeTask('chromaDefrag', 'chroma-recycle-defrag');
+                        }
+                    })
+                    .catch(() => {})
+                    .finally(() => { this._chromaDefragInFlight = false; });
             }
         }
 

--- a/ai/daemons/orchestrator/Orchestrator.mjs
+++ b/ai/daemons/orchestrator/Orchestrator.mjs
@@ -502,9 +502,14 @@ export class Orchestrator extends Base {
             ? options.primaryDevSyncRootsConfig
             : AiConfig.orchestrator.devSyncRoots;
         this.maintenanceDeferralLogKeys = new Set();
-        // #12138 chroma max-runtime recycle: in-memory flags (not persisted — re-derived from
-        // uptime if the orchestrator restarts mid-recycle). `_chromaDefragPending` gates the
-        // post-restart defrag; `_chromaDefragInFlight` prevents poll re-entry during the probe.
+        // #12138 chroma max-runtime recycle: process-local (non-persisted) flags.
+        // `_chromaDefragPending` gates the post-restart defrag; `_chromaDefragInFlight` prevents
+        // poll re-entry during the readiness probe. The defrag is BEST-EFFORT: if the orchestrator
+        // restarts after killTask but before the defrag fires, the flag is lost and the defrag is
+        // skipped for that cycle — the next max-runtime recycle compacts the store. This is sound
+        // for an idempotent compaction step (persisting the intent would instead introduce a
+        // pending-forever / endless-retry failure mode); the kill→restart, the primary recycle
+        // value, is unaffected by an orchestrator restart.
         this._chromaDefragPending  = false;
         this._chromaDefragInFlight = false;
 

--- a/ai/daemons/orchestrator/TaskDefinitions.mjs
+++ b/ai/daemons/orchestrator/TaskDefinitions.mjs
@@ -92,6 +92,16 @@ export function buildTaskDefinitions({
             pidFileName    : 'backup.pid',
             expectedCommand: 'backup.mjs'
         },
+        // One-shot KB defrag spawned by the chroma max-runtime recycle (#12138) once the
+        // freshly-restarted daemon is connection-ready. Unified-store-safe (rebuilds the KB
+        // collection, preserves MC segment dirs per #12140). NOT a continuousTask.
+        chromaDefrag: {
+            label          : 'chroma defrag (knowledge-base)',
+            command        : nodeBin,
+            args           : [path.join(scriptDir, 'maintenance', 'defragChromaDB.mjs'), '--target', 'knowledge-base'],
+            pidFileName    : 'chroma-defrag.pid',
+            expectedCommand: 'defragChromaDB.mjs'
+        },
         'primary-dev-sync': {
             label          : 'primary checkout dev sync',
             pidFileName    : 'primary-dev-sync.pid',

--- a/ai/daemons/orchestrator/services/ProcessSupervisorService.mjs
+++ b/ai/daemons/orchestrator/services/ProcessSupervisorService.mjs
@@ -500,6 +500,24 @@ export class ProcessSupervisorService extends Base {
         }
         process.kill(pid, 'SIGKILL');
     }
+
+    /**
+     * Recycles a supervised task: SIGKILLs its tracked process (no-op under UNIT_TEST_MODE)
+     * and marks it recycled so the poll loop respawns a fresh one. Used by the chroma
+     * max-runtime recycle (#12138). Safe when no pid is currently tracked (e.g. already exited).
+     * @param {String} taskName
+     * @param {String} reason
+     * @returns {void}
+     */
+    killTask(taskName, reason) {
+        const pid = this.taskStateService.getTaskState(taskName)?.pid;
+        if (pid) {
+            this.killProcess(pid);
+        }
+        this.taskStateService.markRecycled(taskName);
+        this.recordTaskOutcome(taskName, 'recycled', {reason, pid: pid ?? null, recycledAt: new Date().toISOString()});
+        this.writeLog?.('INFO', `[ProcessSupervisor] Recycled ${this.taskDefinitions[taskName]?.label || taskName} (PID: ${pid ?? 'none'}); reason: ${reason}.`);
+    }
 }
 
 export default Neo.setupClass(ProcessSupervisorService);

--- a/ai/daemons/orchestrator/services/TaskStateService.mjs
+++ b/ai/daemons/orchestrator/services/TaskStateService.mjs
@@ -222,6 +222,21 @@ export class TaskStateService extends Base {
     }
 
     /**
+     * Marks a task as recycled — process intentionally killed for restart. Clears running +
+     * pid so the supervisor loop respawns it; intentionally records no error/success
+     * timestamp (a recycle is neither a failure nor a successful completion). Used by the
+     * chroma max-runtime recycle (#12138).
+     * @param {String} taskName
+     * @returns {void}
+     */
+    markRecycled(taskName) {
+        const state = this.taskState[taskName];
+        state.running = false;
+        state.pid     = null;
+        this.writeState();
+    }
+
+    /**
      * Marks a task as failed.
      * @param {String} taskName
      * @param {Number|null} code

--- a/test/playwright/unit/ai/daemons/orchestrator/Orchestrator.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/Orchestrator.spec.mjs
@@ -143,7 +143,7 @@ test.describe('Neo.ai.daemons.Orchestrator (#11009)', () => {
             nodeBin  : '/node'
         }));
 
-        expect(Object.keys(state)).toEqual(['chroma', 'bridgeDaemon', 'summary', 'kbSync', 'backup', 'primary-dev-sync', 'tenant-repo-sync', 'dream', 'golden-path', 'swarm-heartbeat']);
+        expect(Object.keys(state)).toEqual(['chroma', 'bridgeDaemon', 'summary', 'kbSync', 'backup', 'chromaDefrag', 'primary-dev-sync', 'tenant-repo-sync', 'dream', 'golden-path', 'swarm-heartbeat']);
         expect(state.mlx).toBeUndefined();
         expect(state.memoryCoreChroma).toBeUndefined();
         expect(state.summary).toMatchObject({
@@ -1149,4 +1149,124 @@ test.describe('Neo.ai.daemons.Orchestrator (#11009)', () => {
         expect(dreamState?.lastReason).toBe('PROVIDER_READINESS_TIMEOUT');
     });
 
+});
+
+test.describe('Neo.ai.daemons.Orchestrator — chroma max-runtime recycle (#12138)', () => {
+    let savedChroma;
+
+    test.beforeEach(() => { savedChroma = AiConfig.orchestrator.chroma; });
+    test.afterEach(()  => { AiConfig.orchestrator.chroma = savedChroma; });
+
+    function recycleMock(sink) {
+        return {
+            reapDuplicateListeners() {},
+            killTask(taskName, reason) { sink.killed.push({taskName, reason}); },
+            runTask(taskName, reason)  { sink.started.push({taskName, reason}); return true; }
+        };
+    }
+
+    test('isChromaRecycleDue: true only when running, ceiling > 0, and uptime exceeds it', () => {
+        AiConfig.orchestrator.chroma = {maxRuntimeMs: 1000};
+        const orchestrator = createTestOrchestrator();
+        const now          = Date.now();
+
+        expect(orchestrator.isChromaRecycleDue({running: true,  lastRunAt: now - 5000}, now)).toBe(true);
+        expect(orchestrator.isChromaRecycleDue({running: true,  lastRunAt: now - 500},  now)).toBe(false);
+        expect(orchestrator.isChromaRecycleDue({running: false, lastRunAt: now - 5000}, now)).toBe(false);
+    });
+
+    test('isChromaRecycleDue: false when the ceiling is 0 or absent (recycling disabled)', () => {
+        const orchestrator = createTestOrchestrator();
+        const now          = Date.now();
+
+        AiConfig.orchestrator.chroma = {maxRuntimeMs: 0};
+        expect(orchestrator.isChromaRecycleDue({running: true, lastRunAt: now - 999999}, now)).toBe(false);
+
+        AiConfig.orchestrator.chroma = undefined;
+        expect(orchestrator.isChromaRecycleDue({running: true, lastRunAt: now - 999999}, now)).toBe(false);
+    });
+
+    test('recycles an over-age chroma daemon: kills it and flags a pending defrag', () => {
+        AiConfig.orchestrator.chroma = {maxRuntimeMs: 1000};
+        const sink         = {killed: [], started: []};
+        const orchestrator = createTestOrchestrator();
+
+        TaskStateService.taskState.chroma.running   = true;
+        TaskStateService.taskState.chroma.lastRunAt = Date.now() - 5000;
+        orchestrator.processSupervisorService = recycleMock(sink);
+
+        orchestrator.poll();
+
+        expect(sink.killed).toHaveLength(1);
+        expect(sink.killed[0].taskName).toBe('chroma');
+        expect(sink.killed[0].reason).toContain('max-runtime');
+        expect(orchestrator._chromaDefragPending).toBe(true);
+    });
+
+    test('does not recycle a chroma daemon within its max-runtime ceiling', () => {
+        AiConfig.orchestrator.chroma = {maxRuntimeMs: 60000};
+        const sink         = {killed: [], started: []};
+        const orchestrator = createTestOrchestrator();
+
+        TaskStateService.taskState.chroma.running   = true;
+        TaskStateService.taskState.chroma.lastRunAt = Date.now() - 1000;
+        orchestrator.processSupervisorService = recycleMock(sink);
+
+        orchestrator.poll();
+
+        expect(sink.killed).toEqual([]);
+        expect(orchestrator._chromaDefragPending).toBeFalsy();
+    });
+
+    test('does not recycle chroma in cloud mode (daemon lane disabled)', () => {
+        AiConfig.orchestrator.chroma = {maxRuntimeMs: 1000};
+        const sink         = {killed: [], started: []};
+        const orchestrator = createTestOrchestrator({deploymentMode: 'cloud', kbSyncEnabled: false});
+
+        TaskStateService.taskState.chroma.running   = true;
+        TaskStateService.taskState.chroma.lastRunAt = Date.now() - 5000;
+        orchestrator.processSupervisorService = recycleMock(sink);
+
+        orchestrator.poll();
+
+        expect(sink.killed).toEqual([]);
+        expect(orchestrator._chromaDefragPending).toBeFalsy();
+    });
+
+    test('spawns the KB defrag once the restarted chroma is connection-ready', async () => {
+        AiConfig.orchestrator.chroma = {maxRuntimeMs: 60000};
+        const sink         = {killed: [], started: []};
+        const orchestrator = createTestOrchestrator();
+
+        // Post-kill state: chroma restarted + running (fresh lastRunAt → not recycle-due), defrag pending.
+        TaskStateService.taskState.chroma.running   = true;
+        TaskStateService.taskState.chroma.lastRunAt = Date.now();
+        orchestrator._chromaDefragPending = true;
+        orchestrator.probeChromaReady     = () => Promise.resolve(true);
+        orchestrator.processSupervisorService = recycleMock(sink);
+
+        orchestrator.poll();
+        await new Promise(resolve => setTimeout(resolve, 10));
+
+        expect(sink.started).toContainEqual({taskName: 'chromaDefrag', reason: 'chroma-recycle-defrag'});
+        expect(orchestrator._chromaDefragPending).toBe(false);
+    });
+
+    test('does not spawn the defrag while the restarted chroma is not yet connection-ready', async () => {
+        AiConfig.orchestrator.chroma = {maxRuntimeMs: 60000};
+        const sink         = {killed: [], started: []};
+        const orchestrator = createTestOrchestrator();
+
+        TaskStateService.taskState.chroma.running   = true;
+        TaskStateService.taskState.chroma.lastRunAt = Date.now();
+        orchestrator._chromaDefragPending = true;
+        orchestrator.probeChromaReady     = () => Promise.resolve(false);
+        orchestrator.processSupervisorService = recycleMock(sink);
+
+        orchestrator.poll();
+        await new Promise(resolve => setTimeout(resolve, 10));
+
+        expect(sink.started.find(s => s.taskName === 'chromaDefrag')).toBeUndefined();
+        expect(orchestrator._chromaDefragPending).toBe(true);
+    });
 });

--- a/test/playwright/unit/ai/daemons/orchestrator/Orchestrator.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/Orchestrator.spec.mjs
@@ -1173,6 +1173,26 @@ test.describe('Neo.ai.daemons.Orchestrator — chroma max-runtime recycle (#1213
         expect(orchestrator.isChromaRecycleDue({running: true,  lastRunAt: now - 5000}, now)).toBe(true);
         expect(orchestrator.isChromaRecycleDue({running: true,  lastRunAt: now - 500},  now)).toBe(false);
         expect(orchestrator.isChromaRecycleDue({running: false, lastRunAt: now - 5000}, now)).toBe(false);
+        // lastRunAt === 0 (uninitialized / harness default) must NOT read as huge uptime.
+        expect(orchestrator.isChromaRecycleDue({running: true,  lastRunAt: 0},          now)).toBe(false);
+    });
+
+    test('does not recycle a running chroma with an uninitialized start stamp (lastRunAt=0)', () => {
+        // Regression for the CI-only failure: the harness sets chroma.running=true with the
+        // default lastRunAt=0; with a real maxRuntimeMs this previously read as now-0 = huge
+        // uptime and spuriously recycled, polluting unrelated poll() tests.
+        AiConfig.orchestrator.chroma = {maxRuntimeMs: 1000};
+        const sink         = {killed: [], started: []};
+        const orchestrator = createTestOrchestrator();
+
+        TaskStateService.taskState.chroma.running   = true;
+        TaskStateService.taskState.chroma.lastRunAt = 0;
+        orchestrator.processSupervisorService = recycleMock(sink);
+
+        orchestrator.poll();
+
+        expect(sink.killed).toEqual([]);
+        expect(orchestrator._chromaDefragPending).toBeFalsy();
     });
 
     test('isChromaRecycleDue: false when the ceiling is 0 or absent (recycling disabled)', () => {

--- a/test/playwright/unit/ai/daemons/orchestrator/services/ProcessSupervisorService.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/services/ProcessSupervisorService.spec.mjs
@@ -259,4 +259,47 @@ test.describe('Neo.ai.daemons.services.ProcessSupervisorService', () => {
         expect(service.reapDuplicateListeners('mockTask')).toBe(2);
         expect(killed).toEqual([200, 300]);
     });
+
+    test('killTask SIGKILLs the tracked pid, marks the task recycled, and records the outcome (#12138)', () => {
+        const {service, taskOutcomes} = createTestService();
+        const killed   = [];
+        const recycled = [];
+
+        service.taskStateService.getTaskState = () => ({running: true, pid: 4242});
+        service.taskStateService.markRecycled = name => recycled.push(name);
+        service.killProcess                   = pid => killed.push(pid);
+
+        service.killTask('mockTask', 'max-runtime:test');
+
+        expect(killed).toEqual([4242]);
+        expect(recycled).toEqual(['mockTask']);
+        expect(taskOutcomes).toContainEqual(
+            expect.objectContaining({taskName: 'mockTask', status: 'recycled'})
+        );
+    });
+
+    test('killTask is safe when no pid is tracked: no kill attempted, still marks recycled (#12138)', () => {
+        const {service, taskOutcomes} = createTestService();
+        const killed   = [];
+        const recycled = [];
+
+        service.taskStateService.getTaskState = () => ({running: false, pid: null});
+        service.taskStateService.markRecycled = name => recycled.push(name);
+        service.killProcess                   = pid => killed.push(pid);
+
+        service.killTask('mockTask', 'max-runtime:test');
+
+        expect(killed).toEqual([]);
+        expect(recycled).toEqual(['mockTask']);
+        expect(taskOutcomes).toContainEqual(
+            expect.objectContaining({taskName: 'mockTask', status: 'recycled'})
+        );
+    });
+
+    test('killProcess is a no-op under UNIT_TEST_MODE — no real process is touched (#12138 AC)', () => {
+        const {service} = createTestService();
+        // Unit tests run with UNIT_TEST_MODE=true; killProcess must return before any process.kill.
+        expect(process.env.UNIT_TEST_MODE).toBe('true');
+        expect(() => service.killProcess(999999999)).not.toThrow();
+    });
 });


### PR DESCRIPTION
Authored by Claude Opus (Claude Code), @neo-opus-4-7. Session f6a4a820-1d95-40e7-910f-b47ad68f51f8.

FAIR-band: moot — sole active implementer this window (@neo-gpt reviews-only at ~2% weekly until ~2026-05-31; @neo-gemini-3-1-pro benched). Treated as nightshift-exempt.

Resolves #12138

The orchestrator now recycles the supervised Chroma daemon once its uptime exceeds `orchestrator.chroma.maxRuntimeMs` (default 24h; env `NEO_CHROMA_MAX_RUNTIME_MS`): SIGKILL the over-age process (chroma ignores SIGTERM — empirically confirmed in the ticket), let the existing supervisor branch respawn it, then run the unified-store-safe `ai:defrag-kb` against the fresh daemon once it is connection-ready. Gated by `chromaDaemonEnabled` (no-op in cloud / externally-managed). MC defrag is intentionally deferred to a shadow-swap-safe #12142 — MC has no rebuild-from-source fallback, so it must never be nuke-rebuilt.

Built on #12140 (PR #12141, merged): the recycle's defrag is the now-unified-store-safe `ai:defrag-kb`.

Evidence: L2 (all affected specs green — recycle trigger, disabled/cloud gating, within-ceiling, readiness-gated defrag, `killTask`, `UNIT_TEST_MODE` kill no-op) → L3 ideal for the AC "(post-merge) operator-observed: a daemon older than `maxRuntimeMs` is recycled + the store is compacted." Residual: that L3 operator observation (Post-Merge Validation below).

## Implementation

- `orchestrator.chroma.maxRuntimeMs` config (24h default) + `NEO_CHROMA_MAX_RUNTIME_MS` envBinding + `Orchestrator.chromaMaxRuntimeMs` getter (reads config verbatim, no hidden fallback).
- `Orchestrator`: `isChromaRecycleDue` predicate, `probeChromaReady` TCP readiness gate (overridable), and poll() recycle + post-restart-defrag branches driven by an in-memory pending-defrag flag.
- `ProcessSupervisorService.killTask`: SIGKILLs the tracked pid (no-op under `UNIT_TEST_MODE`) + `markRecycled` + records the `recycled` outcome.
- `TaskStateService.markRecycled`: clears running/pid so the supervisor loop respawns (robust for adopted processes; no task-state envelope change).
- `TaskDefinitions`: one-shot `chromaDefrag` task (`node defragChromaDB.mjs --target knowledge-base`).
- `config.template.mjs`: `maintenance.defrag` doc carve-out noting the recycle is the one orchestrator path that auto-spawns defrag.

## AC mapping

1. `orchestrator.chroma.maxRuntimeMs` config + env + concrete default — ✅.
2. Recycles in kill→restart→defrag order, gated by `chromaDaemonEnabled` — ✅ (poll recycle/restart/defrag branches; cloud-gated test).
3. Recycle uses `kill -9` (SIGTERM not attempted) — ✅ (`killProcess` = SIGKILL).
4. Defrag runs only after the restarted daemon is connection-ready, using the unified-store-safe defrag — ✅ (`probeChromaReady` gate + `ai:defrag-kb`; ready/not-ready tests).
5. Unit tests: max-runtime trigger logic; kill no-op under `UNIT_TEST_MODE` — ✅.
6. (post-merge) operator-observed recycle + compaction — ⏳ Post-Merge Validation.

## Deltas from ticket

- **Readiness gate:** chroma had no `postSpawn` probe, and adding a general one risks the existing postSpawn-failure path SIGTERM-killing a slow-starting chroma. So the readiness check is a recycle-scoped `probeChromaReady` TCP probe (overridable in tests), not a general chroma `postSpawn` — narrower blast radius.
- **Pending-defrag** is a process-local (non-persisted) flag, not a task-state envelope field. The post-recycle defrag is therefore **best-effort**: a mid-recycle orchestrator restart (after `killTask`, before the defrag) skips it for that cycle, and the next max-runtime recycle compacts the store. Sound for an idempotent compaction step — persisting the intent would instead add a pending-forever / endless-retry failure mode; the kill→restart (the primary recycle value) is unaffected. (Narrowed per @neo-gpt review — corrected an earlier inaccurate "re-derived from uptime" claim.)
- **Shadow-swap** for the rebuild (ticket "ideally") is out of scope; the recycle runs the existing `ai:defrag-kb` (KB-safe per #12140). MC rebuild + shadow-swap → #12142.

## Test Evidence

```
npm run test-unit -- test/playwright/unit/ai/daemons/orchestrator/Orchestrator.spec.mjs
  39 passed   (incl. 8 new recycle specs)
npm run test-unit -- .../services/ProcessSupervisorService.spec.mjs .../services/TaskStateService.spec.mjs
  18 passed   (ProcessSupervisor 14 incl. 3 new killTask specs; TaskState 4)
```

## Post-Merge Validation

- [ ] With `chromaDaemonEnabled` + a low `NEO_CHROMA_MAX_RUNTIME_MS`, confirm the orchestrator recycles a chroma daemon older than the ceiling (kill → respawn → `ai:defrag-kb`) and that BOTH KB and MC vector queries still return afterward (MC preserved, never rebuilt).

## Commits

- `aac7c43c3` — config scaffolding (`maxRuntimeMs` + env + getter).
- `6968aaf02` — recycle logic + tests.
- `d72e08032` — fix: skip recycle when `lastRunAt=0` (uninitialized) + regression test.
- `b197936a5` — narrow the post-recycle defrag to best-effort (review follow-up).
