### PR TITLE
feat(deploy): source neo from a pinned git clone, not a local folder (#12150)

### DIFF
--- a/ai/deploy/Dockerfile
+++ b/ai/deploy/Dockerfile
@@ -16,7 +16,11 @@ FROM alpine/git AS source-git
 ARG NEO_REF
 ARG NEO_REPO_URL
 WORKDIR /neo
-RUN git clone --depth 1 --branch "${NEO_REF}" "${NEO_REPO_URL}" .
+# fetch + checkout (NOT `clone --branch`, which rejects raw SHAs) so NEO_REF accepts a
+# branch, a tag, OR a full commit SHA (the reproducible pin). GitHub serves reachable SHAs.
+RUN git init -q && git remote add origin "${NEO_REPO_URL}" \
+    && git fetch --depth 1 origin "${NEO_REF}" \
+    && git checkout -q --detach FETCH_HEAD
 
 FROM node:24-alpine AS source-local
 WORKDIR /neo

--- a/ai/deploy/Dockerfile
+++ b/ai/deploy/Dockerfile
@@ -15,11 +15,11 @@ ARG NEO_REPO_URL=https://github.com/neomjs/neo.git
 FROM alpine/git AS source-git
 ARG NEO_REF
 ARG NEO_REPO_URL
-WORKDIR /src
+WORKDIR /neo
 RUN git clone --depth 1 --branch "${NEO_REF}" "${NEO_REPO_URL}" .
 
 FROM node:24-alpine AS source-local
-WORKDIR /src
+WORKDIR /neo
 COPY . .
 
 # Select the source stage from the NEO_SOURCE build arg. In 'git' mode the source-local
@@ -34,13 +34,13 @@ WORKDIR /app
 # when installing on Alpine. The tools stay in this build stage.
 RUN apk add --no-cache python3 make g++
 
-COPY --from=source /src/package*.json ./
+COPY --from=source /neo/package*.json ./
 # --ignore-scripts skips the root `prepare` lifecycle hook before buildScripts/
 # is copied. Neo's Agent OS runtime packages currently live in devDependencies;
 # installing them here keeps that cost inside this Right-Hemisphere image.
 RUN npm ci --ignore-scripts
 
-COPY --from=source /src ./
+COPY --from=source /neo ./
 
 # Path A for #10964: generate gitignored per-server config.mjs files inside the
 # image so clean external checkouts do not need manual template copies.

--- a/ai/deploy/Dockerfile
+++ b/ai/deploy/Dockerfile
@@ -1,3 +1,31 @@
+# ---------------------------------------------------------------------------------------
+# Neo source acquisition (#12150). DEFAULT: a pinned git clone — portable (no co-located
+# local checkout required, so any operator / CI host can build), correct-branch + freshly
+# pulled, reproducible per ref. Dev iteration can opt into the local build context with
+# `--build-arg NEO_SOURCE=local` (the build context must then be the neo repo root). A
+# published npm package supersedes this after the v13 release.
+#   NEO_SOURCE   : 'git' (default) | 'local'
+#   NEO_REF      : git ref to clone (default 'dev'; pin to a tag/SHA for full reproducibility)
+#   NEO_REPO_URL : neo repository (MIT-licensed) to clone from
+# ---------------------------------------------------------------------------------------
+ARG NEO_SOURCE=git
+ARG NEO_REF=dev
+ARG NEO_REPO_URL=https://github.com/neomjs/neo.git
+
+FROM alpine/git AS source-git
+ARG NEO_REF
+ARG NEO_REPO_URL
+WORKDIR /src
+RUN git clone --depth 1 --branch "${NEO_REF}" "${NEO_REPO_URL}" .
+
+FROM node:24-alpine AS source-local
+WORKDIR /src
+COPY . .
+
+# Select the source stage from the NEO_SOURCE build arg. In 'git' mode the source-local
+# stage is never built, so no local build context is required (the portability fix).
+FROM source-${NEO_SOURCE} AS source
+
 FROM node:24-alpine AS builder
 
 WORKDIR /app
@@ -6,13 +34,13 @@ WORKDIR /app
 # when installing on Alpine. The tools stay in this build stage.
 RUN apk add --no-cache python3 make g++
 
-COPY package*.json ./
+COPY --from=source /src/package*.json ./
 # --ignore-scripts skips the root `prepare` lifecycle hook before buildScripts/
 # is copied. Neo's Agent OS runtime packages currently live in devDependencies;
 # installing them here keeps that cost inside this Right-Hemisphere image.
 RUN npm ci --ignore-scripts
 
-COPY . .
+COPY --from=source /src ./
 
 # Path A for #10964: generate gitignored per-server config.mjs files inside the
 # image so clean external checkouts do not need manual template copies.

--- a/ai/deploy/Dockerfile
+++ b/ai/deploy/Dockerfile
@@ -1,5 +1,5 @@
 # ---------------------------------------------------------------------------------------
-# Neo source acquisition (#12150). DEFAULT: a pinned git clone — portable (no co-located
+# Neo source acquisition. DEFAULT: a pinned git clone — portable (no co-located
 # local checkout required, so any operator / CI host can build), correct-branch + freshly
 # pulled, reproducible per ref. Dev iteration can opt into the local build context with
 # `--build-arg NEO_SOURCE=local` (the build context must then be the neo repo root). A

--- a/ai/deploy/docker-compose.dev.yml
+++ b/ai/deploy/docker-compose.dev.yml
@@ -20,6 +20,7 @@ services:
       context: ../..
       dockerfile: ai/deploy/Dockerfile
       args:
+        NEO_SOURCE: local  # build the local checkout for dev iteration, not a remote clone
         TARGET_SERVER: knowledge-base
     environment:
       - NEO_TRANSPORT=sse
@@ -45,6 +46,7 @@ services:
       context: ../..
       dockerfile: ai/deploy/Dockerfile
       args:
+        NEO_SOURCE: local  # build the local checkout for dev iteration, not a remote clone
         TARGET_SERVER: memory-core
     environment:
       - NEO_TRANSPORT=sse

--- a/ai/deploy/docker-compose.test.yml
+++ b/ai/deploy/docker-compose.test.yml
@@ -47,6 +47,7 @@ services:
       context: ../..
       dockerfile: ai/deploy/Dockerfile
       args:
+        NEO_SOURCE: local  # build the local checkout under test, not a remote clone
         TARGET_SERVER: knowledge-base
     environment:
       - NEO_TRANSPORT=sse
@@ -84,6 +85,7 @@ services:
       context: ../..
       dockerfile: ai/deploy/Dockerfile
       args:
+        NEO_SOURCE: local  # build the local checkout under test, not a remote clone
         TARGET_SERVER: knowledge-base
     environment:
       - NEO_TRANSPORT=sse
@@ -121,6 +123,7 @@ services:
       context: ../..
       dockerfile: ai/deploy/Dockerfile
       args:
+        NEO_SOURCE: local  # build the local checkout under test, not a remote clone
         TARGET_SERVER: memory-core
     environment:
       - NEO_TRANSPORT=sse
@@ -173,6 +176,7 @@ services:
       context: ../..
       dockerfile: ai/deploy/Dockerfile
       args:
+        NEO_SOURCE: local  # build the local checkout under test, not a remote clone
         TARGET_SERVER: memory-core
     environment:
       - NEO_TRANSPORT=sse

--- a/ai/deploy/docker-compose.yml
+++ b/ai/deploy/docker-compose.yml
@@ -36,8 +36,8 @@ services:
 
   kb-server:
     build:
-      context: ../..
-      dockerfile: ai/deploy/Dockerfile
+      context: .
+      dockerfile: Dockerfile
       args:
         TARGET_SERVER: knowledge-base
     environment:
@@ -79,8 +79,8 @@ services:
 
   mc-server:
     build:
-      context: ../..
-      dockerfile: ai/deploy/Dockerfile
+      context: .
+      dockerfile: Dockerfile
       args:
         TARGET_SERVER: memory-core
     environment:
@@ -135,8 +135,8 @@ services:
   # `cloud` profile — started by `docker compose --profile cloud up`.
   orchestrator:
     build:
-      context: ../..
-      dockerfile: ai/deploy/Dockerfile
+      context: .
+      dockerfile: Dockerfile
       args:
         SERVICE_ENTRYPOINT: ai/daemons/orchestrator/daemon.mjs
     environment:

--- a/learn/agentos/cloud-deployment/Day0Tutorial.md
+++ b/learn/agentos/cloud-deployment/Day0Tutorial.md
@@ -39,7 +39,7 @@ cd neo
 npm install
 ```
 
-> **Deploy images source neo independently (#12150).** The `ai/deploy` images build by
+> **Deploy images source neo independently.** The `ai/deploy` images build by
 > cloning neo at a pinned ref (`NEO_REF`, default `dev`), so they do **not** require a
 > co-located checkout — any operator or CI host can build them. This local checkout is for
 > running the tutorial's commands and for dev iteration (`--build-arg NEO_SOURCE=local`,

--- a/learn/agentos/cloud-deployment/Day0Tutorial.md
+++ b/learn/agentos/cloud-deployment/Day0Tutorial.md
@@ -39,6 +39,13 @@ cd neo
 npm install
 ```
 
+> **Deploy images source neo independently (#12150).** The `ai/deploy` images build by
+> cloning neo at a pinned ref (`NEO_REF`, default `dev`), so they do **not** require a
+> co-located checkout — any operator or CI host can build them. This local checkout is for
+> running the tutorial's commands and for dev iteration (`--build-arg NEO_SOURCE=local`,
+> with the neo repo root as the build context). Pin `NEO_REF` to a tag/SHA for a fully
+> reproducible deployment.
+
 Required local tools:
 
 | Tool | Check | Expected output |


### PR DESCRIPTION
Resolves #12150

Authored by Claude Opus 4.7 (Claude Code). Session efd8dc2e-2052-4089-814a-ab22cd8c6a62.

FAIR-band: operator-directed lane — #12150 surfaced + greenlit by @tobiu during the #12146 real-time dogfood; FAIR-band self-selection is N/A for directed work.

Evidence: L3 (`docker build --target source` from an **empty** context cloned neo@`dev`; the cloned source was verified to contain #12146 + #12148 — portability + correct-fresh-branch both proven) → L4 (full multi-service stack build + boot on a host) residual.

## Summary

The `ai/deploy` images built neo via `COPY . .` of a local co-located checkout (`NEO_SOURCE_DIR`) — non-portable (a second operator/CI host without that checkout has no build context → the build fails), non-reproducible (image = local working tree + whatever branch is checked out), version-coupled. This sources neo from a pinned GitHub clone instead. neo is MIT, so cloning + baking it has no license barrier.

- **Dockerfile**: an ARG-selectable source stage. `NEO_SOURCE=git` (default) shallow-clones neo at `NEO_REF` (default `dev`); `NEO_SOURCE=local` keeps the local build context for dev iteration. In git-mode the local stage is never built → no co-located checkout required (the portability fix).
- **docker-compose.yml**: the 3 neo services default to clone-mode (`context: .` — minimal, always-exists), so the reference pattern deployments mirror is now portable.
- **Day0Tutorial**: the deploy build sources neo independently; the local checkout is reframed as dev-only.

## Deltas from ticket (if any)

- The interim ref is the `dev` branch (mutable) per operator direction — branch-tracking deployments until v13; a tag/SHA is the reproducible pin (documented in the Dockerfile + Day0 note). Post-v13 npm-package sourcing is the future evolution (Out of Scope per the ticket).

## Test Evidence

`docker build --target source --build-arg NEO_REF=dev -f ai/deploy/Dockerfile <empty-tmpdir>` → builds; the cloned `/src` is neo@`dev`:
- `listConfiguredTenantRepos` present (#12146), `resolveCliProjectRoot` present (#12148), `HEAD → refs/heads/dev`.
- Built from an **empty context** → confirms no co-located checkout is required.

The full per-service image build (`COPY --from=source` + `npm ci` integration) is standard and exercised at deploy/CI build time (see Post-Merge).

## Substrate note (learn/agentos/ touch — PR-workflow §1.1)

The `Day0Tutorial.md` edit is a factual correction to an operator-facing deploy guide (not agent-rule/skill substrate). Disposition: `rewrite` (one added note) reflecting the shipped clone-mode sourcing. No always-loaded rule substrate is added.

## Post-Merge Validation
- [ ] A full `docker compose build` (all 3 neo services, clone-mode) succeeds on a host **without** a co-located neo checkout.
- [ ] Downstream deployment composes adopt clone-mode + drop the local `NEO_SOURCE_DIR` path.

## Commits
- `2ba858aac` — Dockerfile clone-mode source stage + compose clone-mode reference + Day0 note
