### PR TITLE
fix(ai): defrag-memory uses the unified Chroma persist-dir SSOT (#12142)

### DIFF
--- a/ai/config.template.mjs
+++ b/ai/config.template.mjs
@@ -233,14 +233,19 @@ class Config extends BaseConfig {
         /**
          * @summary Deployment-wide storage engine coordinates.
          *
-         * `engines.chroma` is the unified Chroma topology from ADR 0003. Collection
-         * names and local persistence directories remain server-local.
+         * `engines.chroma` is the unified Chroma topology from ADR 0003: ONE daemon, ONE persist
+         * dir, shared by Knowledge Base + Memory Core. `dataDir` is the single source of truth for
+         * that persist dir — the orchestrator launches the daemon against it, and both server
+         * configs + the `defragChromaDB` maintenance script read it. Collection NAMES remain
+         * server-local; the persist DIR does not (it is unified — #12142). Env override:
+         * `NEO_CHROMA_DATA_DIR`.
          * @type {Object}
          */
         engines: {
             chroma: {
-                host: 'localhost',
-                port: 8000
+                dataDir: path.resolve(neoRootDir, '.neo-ai-data/chroma/knowledge-base'),
+                host   : 'localhost',
+                port   : 8000
             }
         },
         /**
@@ -654,8 +659,9 @@ class Config extends BaseConfig {
         wakeDaemonHeartbeatAlivePath: 'NEO_HEARTBEAT_ALIVE_PATH',
         engines        : {
             chroma: {
-                host: 'NEO_CHROMA_HOST',
-                port: {var: 'NEO_CHROMA_PORT', parse: Env.parsePort}
+                dataDir: 'NEO_CHROMA_DATA_DIR',
+                host   : 'NEO_CHROMA_HOST',
+                port   : {var: 'NEO_CHROMA_PORT', parse: Env.parsePort}
             }
         },
         orchestrator: {

--- a/ai/config.template.mjs
+++ b/ai/config.template.mjs
@@ -234,11 +234,10 @@ class Config extends BaseConfig {
          * @summary Deployment-wide storage engine coordinates.
          *
          * `engines.chroma` is the unified Chroma topology from ADR 0003: ONE daemon, ONE persist
-         * dir, shared by Knowledge Base + Memory Core. `dataDir` is the single source of truth for
-         * that persist dir — the orchestrator launches the daemon against it, and both server
-         * configs + the `defragChromaDB` maintenance script read it. Collection NAMES remain
-         * server-local; the persist DIR does not (it is unified). Env override:
-         * `NEO_CHROMA_DATA_DIR`.
+         * dir, shared by Knowledge Base + Memory Core. `dataDir` is the fixed canonical persist dir
+         * read by both server configs + the `defragChromaDB` maintenance script; the local
+         * orchestrator launches the daemon against the same fixed path. Collection NAMES remain
+         * server-local; the persist DIR is unified.
          * @type {Object}
          */
         engines: {
@@ -659,7 +658,6 @@ class Config extends BaseConfig {
         wakeDaemonHeartbeatAlivePath: 'NEO_HEARTBEAT_ALIVE_PATH',
         engines        : {
             chroma: {
-                dataDir: 'NEO_CHROMA_DATA_DIR',
                 host   : 'NEO_CHROMA_HOST',
                 port   : {var: 'NEO_CHROMA_PORT', parse: Env.parsePort}
             }

--- a/ai/config.template.mjs
+++ b/ai/config.template.mjs
@@ -237,7 +237,7 @@ class Config extends BaseConfig {
          * dir, shared by Knowledge Base + Memory Core. `dataDir` is the single source of truth for
          * that persist dir — the orchestrator launches the daemon against it, and both server
          * configs + the `defragChromaDB` maintenance script read it. Collection NAMES remain
-         * server-local; the persist DIR does not (it is unified — #12142). Env override:
+         * server-local; the persist DIR does not (it is unified). Env override:
          * `NEO_CHROMA_DATA_DIR`.
          * @type {Object}
          */

--- a/ai/daemons/orchestrator/TaskDefinitions.mjs
+++ b/ai/daemons/orchestrator/TaskDefinitions.mjs
@@ -60,7 +60,7 @@ export function buildTaskDefinitions({
             label          : 'chroma daemon',
             command        : 'chroma',
             // The --path persist dir resolves to the same dir as AiConfig.engines.chroma.dataDir
-            // — the SSOT that KB/MC configs + defragChromaDB read (#12142) — under the standard
+            // — the SSOT that KB/MC configs + defragChromaDB read — under the standard
             // cwd==repoRoot. Kept as a relative literal here (not SSOT-sourced) for daemon-launch
             // resilience: a stale config.mjs lacking the SSOT key would otherwise launch the daemon
             // with `--path undefined`. Keep this value in sync with engines.chroma.dataDir.

--- a/ai/daemons/orchestrator/TaskDefinitions.mjs
+++ b/ai/daemons/orchestrator/TaskDefinitions.mjs
@@ -59,6 +59,11 @@ export function buildTaskDefinitions({
         chroma: {
             label          : 'chroma daemon',
             command        : 'chroma',
+            // The --path persist dir resolves to the same dir as AiConfig.engines.chroma.dataDir
+            // — the SSOT that KB/MC configs + defragChromaDB read (#12142) — under the standard
+            // cwd==repoRoot. Kept as a relative literal here (not SSOT-sourced) for daemon-launch
+            // resilience: a stale config.mjs lacking the SSOT key would otherwise launch the daemon
+            // with `--path undefined`. Keep this value in sync with engines.chroma.dataDir.
             args           : ['run', '--path', '.neo-ai-data/chroma/knowledge-base', '--port', String(chromaPort)],
             pidFileName    : 'chroma.pid',
             expectedCommand: 'chroma',

--- a/ai/mcp/server/knowledge-base/config.template.mjs
+++ b/ai/mcp/server/knowledge-base/config.template.mjs
@@ -127,7 +127,7 @@ class Config extends BaseConfig {
         port: AiConfig.engines.chroma.port,
         /**
          * The unified Chroma persist directory, read from the single source of truth
-         * `AiConfig.engines.chroma.dataDir` (#12142). MUST equal the orchestrator daemon's
+         * `AiConfig.engines.chroma.dataDir`. MUST equal the orchestrator daemon's
          * `--path` (kept literal there for daemon-launch resilience against a stale config.mjs).
          * @type {string}
          */

--- a/ai/mcp/server/knowledge-base/config.template.mjs
+++ b/ai/mcp/server/knowledge-base/config.template.mjs
@@ -126,10 +126,12 @@ class Config extends BaseConfig {
          */
         port: AiConfig.engines.chroma.port,
         /**
-         * The local persistence path for the agent knowledge-base server.
+         * The unified Chroma persist directory, read from the single source of truth
+         * `AiConfig.engines.chroma.dataDir` (#12142). MUST equal the orchestrator daemon's
+         * `--path` (kept literal there for daemon-launch resilience against a stale config.mjs).
          * @type {string}
          */
-        path: path.resolve(neoRootDir, '.neo-ai-data/chroma/knowledge-base'),
+        path: AiConfig.engines.chroma.dataDir,
         /**
          * @summary Shared SQLite destination for Knowledge Base query telemetry.
          *

--- a/ai/mcp/server/memory-core/config.template.mjs
+++ b/ai/mcp/server/memory-core/config.template.mjs
@@ -239,7 +239,10 @@ class Config extends BaseConfig {
          */
         engines: {
             chroma: {
-                dataDir: path.resolve(cwd, '.neo-ai-data/chroma/memory-core'),
+                // #12142: read the unified persist dir from the SSOT. Was the stale
+                // '.neo-ai-data/chroma/memory-core' — MC is a CLIENT of the one unified store
+                // (ADR 0003), so its physical dir must be the shared dir, not a server-local one.
+                dataDir: AiConfig.engines.chroma.dataDir,
                 host   : AiConfig.engines.chroma.host,
                 port   : AiConfig.engines.chroma.port
             }

--- a/ai/mcp/server/memory-core/config.template.mjs
+++ b/ai/mcp/server/memory-core/config.template.mjs
@@ -239,7 +239,7 @@ class Config extends BaseConfig {
          */
         engines: {
             chroma: {
-                // #12142: read the unified persist dir from the SSOT. Was the stale
+                // Read the unified persist dir from the SSOT. Was the stale
                 // '.neo-ai-data/chroma/memory-core' — MC is a CLIENT of the one unified store
                 // (ADR 0003), so its physical dir must be the shared dir, not a server-local one.
                 dataDir: AiConfig.engines.chroma.dataDir,

--- a/test/playwright/fixtures/aiConfigDefaults.mjs
+++ b/test/playwright/fixtures/aiConfigDefaults.mjs
@@ -132,7 +132,7 @@ export const TIER1_DEFAULTS = deepFreeze(Neo.clone({
     embeddingModel : 'gemini-embedding-001',
     engines: {
         chroma: {
-            dataDir: process.env.NEO_CHROMA_DATA_DIR || path.resolve(neoRootDir, '.neo-ai-data/chroma/knowledge-base'),
+            dataDir: path.resolve(neoRootDir, '.neo-ai-data/chroma/knowledge-base'),
             host   : process.env.NEO_CHROMA_HOST || 'localhost',
             port   : Number(process.env.NEO_CHROMA_PORT) || 8000
         }

--- a/test/playwright/fixtures/aiConfigDefaults.mjs
+++ b/test/playwright/fixtures/aiConfigDefaults.mjs
@@ -132,8 +132,9 @@ export const TIER1_DEFAULTS = deepFreeze(Neo.clone({
     embeddingModel : 'gemini-embedding-001',
     engines: {
         chroma: {
-            host: process.env.NEO_CHROMA_HOST || 'localhost',
-            port: Number(process.env.NEO_CHROMA_PORT) || 8000
+            dataDir: process.env.NEO_CHROMA_DATA_DIR || path.resolve(neoRootDir, '.neo-ai-data/chroma/knowledge-base'),
+            host   : process.env.NEO_CHROMA_HOST || 'localhost',
+            port   : Number(process.env.NEO_CHROMA_PORT) || 8000
         }
     },
     orchestrator: {

--- a/test/playwright/unit/ai/config.template.spec.mjs
+++ b/test/playwright/unit/ai/config.template.spec.mjs
@@ -94,8 +94,9 @@ test.describe('Tier 1 Config Immutability', () => {
             }
         });
         expect(Config.engines.chroma).toEqual({
-            host: process.env.NEO_CHROMA_HOST || 'localhost',
-            port: Number(process.env.NEO_CHROMA_PORT) || 8000
+            dataDir: process.env.NEO_CHROMA_DATA_DIR || expect.stringMatching(/\.neo-ai-data[/\\]chroma[/\\]knowledge-base$/),
+            host   : process.env.NEO_CHROMA_HOST || 'localhost',
+            port   : Number(process.env.NEO_CHROMA_PORT) || 8000
         });
     });
 

--- a/test/playwright/unit/ai/config.template.spec.mjs
+++ b/test/playwright/unit/ai/config.template.spec.mjs
@@ -94,7 +94,7 @@ test.describe('Tier 1 Config Immutability', () => {
             }
         });
         expect(Config.engines.chroma).toEqual({
-            dataDir: process.env.NEO_CHROMA_DATA_DIR || expect.stringMatching(/\.neo-ai-data[/\\]chroma[/\\]knowledge-base$/),
+            dataDir: expect.stringMatching(/\.neo-ai-data[/\\]chroma[/\\]knowledge-base$/),
             host   : process.env.NEO_CHROMA_HOST || 'localhost',
             port   : Number(process.env.NEO_CHROMA_PORT) || 8000
         });

--- a/test/playwright/unit/ai/mcp/server/memory-core/config.template.spec.mjs
+++ b/test/playwright/unit/ai/mcp/server/memory-core/config.template.spec.mjs
@@ -99,7 +99,10 @@ test.describe('Memory Core Config (#10010)', () => {
             host: TIER1_DEFAULTS.engines.chroma.host,
             port: TIER1_DEFAULTS.engines.chroma.port
         });
-        expect(config.engines.chroma.dataDir).toContain('.neo-ai-data/chroma/memory-core');
+        // #12142: MC reads the unified persist-dir SSOT (`AiConfig.engines.chroma.dataDir`),
+        // not a server-local dir. Was the stale `.neo-ai-data/chroma/memory-core` — the bug.
+        expect(config.engines.chroma.dataDir).toBe(TIER1_DEFAULTS.engines.chroma.dataDir);
+        expect(config.engines.chroma.dataDir).toContain('.neo-ai-data/chroma/knowledge-base');
     });
 
     test('inherits concrete graphProvider defaults from Tier-1 config', () => {

--- a/test/playwright/unit/ai/mcp/server/memory-core/config.template.spec.mjs
+++ b/test/playwright/unit/ai/mcp/server/memory-core/config.template.spec.mjs
@@ -99,7 +99,7 @@ test.describe('Memory Core Config (#10010)', () => {
             host: TIER1_DEFAULTS.engines.chroma.host,
             port: TIER1_DEFAULTS.engines.chroma.port
         });
-        // #12142: MC reads the unified persist-dir SSOT (`AiConfig.engines.chroma.dataDir`),
+        // MC reads the unified persist-dir SSOT (`AiConfig.engines.chroma.dataDir`),
         // not a server-local dir. Was the stale `.neo-ai-data/chroma/memory-core` — the bug.
         expect(config.engines.chroma.dataDir).toBe(TIER1_DEFAULTS.engines.chroma.dataDir);
         expect(config.engines.chroma.dataDir).toContain('.neo-ai-data/chroma/knowledge-base');


### PR DESCRIPTION
> **Review update (`d1b510737`, per @neo-gpt's review):** the `NEO_CHROMA_DATA_DIR` env override is **removed** — `engines.chroma.dataDir` is now a **fixed canonical path** (no `process.env || …` branch). All consumers — both server configs, `defragChromaDB`, and the orchestrator daemon-launch literal — resolve to the same fixed path, so the value is mechanically consistent and the override-split @neo-gpt caught is structurally impossible. Wiring the orchestrator `--path` through the resolved value (for a future end-to-end override) + the `knowledge-base → unified` rename land in epic **#12153** (sub **#12155**). See [the review response](https://github.com/neomjs/neo/pull/12152#issuecomment-4569263845).

---

Authored by Claude Opus (Claude Code), @neo-opus-4-7. Session f6a4a820-1d95-40e7-910f-b47ad68f51f8.

FAIR-band: moot — sole active implementer (@neo-gpt reviews-only at ~1% until ~2026-05-31; @neo-gemini-3-1-pro benched).

Resolves #12142

`ai:defrag-memory` targeted a stale, server-local `.neo-ai-data/chroma/memory-core` dir (the MC config `dataDir`), but the unified store (ADR 0003) is one daemon + one persist dir — the KB's `.neo-ai-data/chroma/knowledge-base`. So `ai:defrag-memory` operated on the wrong directory (or hard-exited when it was absent).

This makes `AiConfig.engines.chroma.dataDir` the fixed canonical persist dir (= the current live value), and points KB config `path` + MC config `dataDir` at it. MC's `dataDir` now resolves to the unified store, so the defrag `memory-core` target (which reads `cfg.engines.chroma.dataDir`) hits the live store. **No consumer's resolved dir changes** — the value equals the prior KB value, so KB + the daemon are byte-for-byte unaffected.

Evidence: L2 (the config-template specs — fixed-path shape + MC-reads-unified — are template-based + harness-independent, verified locally) → L3 ideal for AC1 (a real `ai:defrag-memory` run against the live unified store). Residual: AC1 end-to-end [manual / post-merge].

## Implementation

- `config.template.mjs`: `engines.chroma.dataDir` is the fixed canonical persist dir (`path.resolve(neoRootDir, '.neo-ai-data/chroma/knowledge-base')`) + an accurate docstring (the persist dir is unified, read by both server configs + `defragChromaDB`; the local orchestrator launches the daemon against the same fixed path).
- KB config `path` + MC config `dataDir` → `AiConfig.engines.chroma.dataDir` (MC was the stale `memory-core` — the bug).
- Defrag adapters unchanged — they already read `cfg.path` / `cfg.engines.chroma.dataDir`, which now resolve to the canonical path.
- Orchestrator `--path`: a relative literal matching the canonical path. Centralizing it onto the resolved value lands in epic #12153 / #12155.

## AC mapping

1. `ai:defrag-memory` targets the unified store — ✅ (MC `dataDir` → canonical path → defrag target).
2. Single canonical persist dir; no hidden `||` / `??` fallback — ✅ (servers read it verbatim; the env-override branch was removed per review).
3. KB behavior unchanged — ✅ (value = KB's prior value).
4. Unit coverage that MC resolves to the unified path — ✅ (MC config.template.spec).

## Deltas from ticket

- **Servers + defrag read the canonical path; the orchestrator `--path` is a matching literal.** Full centralization (orchestrator reads the resolved value) + any runtime override land with the `knowledge-base → unified` rename in epic #12153 (sub #12155) — there the override is mechanically honored across the daemon too.
- **Shadow-swap** robustness for the (manual, snapshot-protected, #12140-safe) MC defrag remains a tracked follow-up.

## Test Evidence

```
npm run test-unit -- <config.template + aiConfigDefaults + KB/MC config.template + HealthService + ChromaManager + DestructiveOperationGuard + defrag-segment-cleanup>
  83 passed   (initial)
npm run test-unit -- config.template.spec + KB/MC config.template.spec   (post override-removal, d1b510737)
  13 passed
npm run test-unit -- test/playwright/unit/ai/daemons/orchestrator/daemon.spec.mjs
  10 passed
```

## Post-Merge Validation

- [ ] After re-hydrating `config.mjs` from the template, run `ai:defrag-memory` against the live unified store and confirm it targets `.neo-ai-data/chroma/knowledge-base` (compacts MC collections, preserves KB — #12140-safe), not the stale `memory-core` dir.

## Commits

- `591746914` — persist-dir canonical value + KB/MC reads + orchestrator cross-ref + tests.
- `6c2c38de3` — drop decay-prone ticket-id refs from the SSOT comments.
- `d1b510737` — remove the half-honored `NEO_CHROMA_DATA_DIR` override → fixed canonical path (per @neo-gpt review).

## Deployment migration

Existing `config.mjs` copies must be re-hydrated from the template to pick up `engines.chroma.dataDir` (the established template-addition migration; CI + new worktrees hydrate automatically).
