### PR TITLE
fix(ai): KB release artifact is collection-scoped, never the whole .neo-ai-data (#12157)

### DIFF
--- a/ai/scripts/maintenance/downloadKnowledgeBase.mjs
+++ b/ai/scripts/maintenance/downloadKnowledgeBase.mjs
@@ -1,78 +1,236 @@
-import fs          from 'fs-extra';
-import path        from 'path';
-import {exec}      from 'child_process';
-import {promisify} from 'util';
-import packageJson from '../../../package.json' with {type: 'json'};
+import {execFile}       from 'child_process';
+import fs               from 'fs-extra';
+import os               from 'os';
+import path             from 'path';
+import {promisify}      from 'util';
+import {fileURLToPath}  from 'url';
+
+// Neo namespace bootstrap (entry-point invariant). `Neo` + `core/_export` populate
+// `globalThis.Neo` so that `ai/services.mjs` → Compare.mjs `Neo.gatekeep` resolves.
+import Neo              from '../../../src/Neo.mjs';
+import * as core        from '../../../src/core/_export.mjs';
+
+import AiConfig         from '../../config.mjs';
+import kbConfig         from '../../mcp/server/knowledge-base/config.mjs';
+
+import {
+    KB_ChromaManager,
+    KB_DatabaseService,
+    KB_LifecycleService
+} from '../../services.mjs';
+
+import {
+    ARTIFACT_BASENAME,
+    ARTIFACT_META_FILENAME,
+    assertCollectionScopedArtifact
+} from './knowledgeBaseArtifact.mjs';
+
+const execFileAsync = promisify(execFile);
 
 /**
  * @module ai/scripts/maintenance/downloadKnowledgeBase
+ * @summary Fetches the collection-scoped Knowledge Base release artifact and ingests it into the
+ * consumer's `neo-knowledge-base` ChromaDB collection — **merge-only**, never clobbering the
+ * user's `.neo-ai-data` or any Memory Core collection.
+ *
+ * Runs on every `npm install` via the `prepare` script, so the contract is strictly additive:
+ *
+ * - **Skip-if-populated:** if the consumer's KB collection already holds records, the download is
+ *   skipped entirely (`npm run ai:sync-kb` is the incremental-update path).
+ * - **Collection-scoped import:** the artifact is unzipped to a temp dir and ingested via the
+ *   canonical SDK (`KB_DatabaseService.manageDatabaseBackup({action: 'import', mode: 'merge'})`).
+ *   The data directory is never directory-restored; Memory Core collections are never touched.
+ * - **Defense-in-depth:** `assertCollectionScopedArtifact` runs on the unzipped contents before
+ *   import, so a malformed artifact carrying Memory Core data or a `sqlite/` payload is rejected.
+ * - **Embedding-provenance check:** the artifact's `embeddingProvider`/`dimension` metadata is
+ *   compared to the consumer's config; a mismatch warns (recall would silently degrade against
+ *   the shipped raw vectors) without aborting npm install.
+ * - **Soft-fail:** every failure path returns rather than `process.exit(1)` so `npm install`
+ *   never breaks for standard consumers.
+ *
+ * @see ai/scripts/maintenance/uploadKnowledgeBase.mjs
+ * @see ai/services/knowledge-base/DatabaseService.mjs
  */
 
-const execAsync = promisify(exec);
-const cwd       = process.cwd();
+const __filename   = fileURLToPath(import.meta.url);
+const __dirname    = path.dirname(__filename);
+const PROJECT_ROOT = path.resolve(__dirname, '../../..');
 
-async function downloadKnowledgeBase() {
-    const version   = packageJson.version;
-    const zipName   = 'neo-ai-data.zip';
-    const url       = `https://github.com/neomjs/neo/releases/download/${version}/${zipName}`;
-    const targetDir = path.resolve(cwd);
-    const zipPath   = path.resolve(targetDir, zipName);
-    const kbDir     = path.resolve(targetDir, '.neo-ai-data');
+/**
+ * Resolves the release tag from `package.json`.
+ * @returns {Promise<String>}
+ */
+async function resolveVersion() {
+    const fromEnv = process.env.npm_package_version;
+    if (fromEnv) {
+        return fromEnv;
+    }
+    const pkg = await fs.readJson(path.join(PROJECT_ROOT, 'package.json'));
+    return pkg.version;
+}
 
-    console.log(`Checking for existing Knowledge Base...`);
-    if (await fs.pathExists(kbDir)) {
-        // Simple check: exists.
-        // Future improvement: Check version/hash?
-        console.log(`✅ Knowledge Base found at ${kbDir}`);
-        console.log(`   Skipping download. Run 'npm run ai:sync-kb' to update incrementally.`);
-        return;
+/**
+ * Returns the consumer's current Knowledge Base collection record count, or `null` when the
+ * collection / Chroma daemon cannot be reached (treated as "not populated, attempt download").
+ *
+ * @param {Object} chromaManager KB ChromaManager SDK seam.
+ * @returns {Promise<Number|null>}
+ */
+async function readKbCollectionCount(chromaManager) {
+    try {
+        const collection = await chromaManager.getKnowledgeBaseCollection();
+        return await collection.count();
+    } catch {
+        return null;
+    }
+}
+
+/**
+ * Unzips the downloaded artifact into a directory using the platform-native tool.
+ *
+ * @param {String} zipPath    Absolute path to the downloaded zip.
+ * @param {String} targetDir  Absolute path to extract into.
+ * @returns {Promise<void>}
+ */
+async function unzipArtifact(zipPath, targetDir) {
+    try {
+        await execFileAsync('unzip', ['-o', '-q', zipPath, '-d', targetDir]);
+    } catch (e) {
+        if (process.platform === 'win32') {
+            await execFileAsync('powershell', ['-command', `Expand-Archive -Force '${zipPath}' '${targetDir}'`]);
+        } else {
+            throw new Error('Failed to unzip the Knowledge Base artifact. Install "unzip" or extract it manually.');
+        }
+    }
+}
+
+/**
+ * Executes the merge-only Knowledge Base download + ingest workflow.
+ *
+ * @param {Object}  [options]
+ * @param {String}  [options.tagName]            Override the resolved release tag (tests).
+ * @param {Object}  [options.chromaManager]      KB ChromaManager SDK seam (tests).
+ * @param {Object}  [options.databaseService]    KB database SDK seam (tests).
+ * @param {Object}  [options.lifecycleService]   KB lifecycle SDK seam (tests).
+ * @param {Object}  [options.embeddingConfig]    Tier-1 AI config seam exposing `embeddingProvider` + `vectorDimension`.
+ * @param {Function}[options.fetchImpl=fetch]    Fetch seam (tests).
+ * @param {String}  [options.workRoot]           Override the download/extract parent dir (tests). Defaults to OS tempdir.
+ * @param {Object}  [options.logger=console]     Log sink.
+ * @returns {Promise<{status: String, imported?: Number, reason?: String}>}
+ */
+export async function downloadKnowledgeBase({
+    tagName,
+    chromaManager    = KB_ChromaManager,
+    databaseService  = KB_DatabaseService,
+    lifecycleService = KB_LifecycleService,
+    embeddingConfig  = AiConfig,
+    fetchImpl        = fetch,
+    workRoot         = os.tmpdir(),
+    logger           = console
+} = {}) {
+    const resolvedTag  = tagName ?? await resolveVersion();
+    const artifactName = ARTIFACT_BASENAME;
+    const url          = `https://github.com/neomjs/neo/releases/download/${resolvedTag}/${artifactName}`;
+
+    // Merge-only guard: never re-import over a populated consumer collection.
+    logger.log('Checking for an existing Knowledge Base collection...');
+    await lifecycleService.ready();
+    const existingCount = await readKbCollectionCount(chromaManager);
+
+    if (typeof existingCount === 'number' && existingCount > 0) {
+        logger.log(`✅ Knowledge Base already populated (${existingCount} chunks). Skipping download. Run 'npm run ai:sync-kb' to update incrementally.`);
+        return {status: 'skipped', reason: 'collection-populated'};
     }
 
-    console.log(`⬇️  Downloading Knowledge Base artifact for v${version}...`);
-    console.log(`   URL: ${url}`);
+    const downloadDir = path.join(workRoot, `neo-kb-download-${process.pid}-${Date.now()}`);
+    const extractDir  = path.join(downloadDir, 'extract');
+    const zipPath     = path.join(downloadDir, artifactName);
+
+    await fs.ensureDir(extractDir);
 
     try {
-        const response = await fetch(url);
+        logger.log(`⬇️  Downloading Knowledge Base artifact for v${resolvedTag}...`);
+        logger.log(`   URL: ${url}`);
+
+        const response = await fetchImpl(url);
         if (!response.ok) {
             if (response.status === 404) {
-                // This is expected for Dev versions or before the artifact is uploaded.
-                console.warn(`⚠️  Artifact not found (404). This might be a development version.`);
-                console.log(`   You can build the Knowledge Base locally with 'npm run ai:sync-kb' (takes ~25 mins).`);
-                return; // Soft fail (don't break npm install)
+                logger.warn(`⚠️  Artifact not found (404). This is expected for development versions or before the release asset is uploaded.`);
+                logger.log(`   Build the Knowledge Base locally with 'npm run ai:sync-kb'.`);
+                return {status: 'absent', reason: 'artifact-404'};
             }
             throw new Error(`Download failed: ${response.status} ${response.statusText}`);
         }
 
         const arrayBuffer = await response.arrayBuffer();
         await fs.writeFile(zipPath, Buffer.from(arrayBuffer));
-        console.log(`✅ Download complete (${(arrayBuffer.byteLength / 1024 / 1024).toFixed(2)} MB).`);
+        logger.log(`✅ Downloaded ${artifactName} (${(arrayBuffer.byteLength / 1024 / 1024).toFixed(2)} MB).`);
 
-        console.log(`📦 Unzipping...`);
-        try {
-            // Try native unzip command (macOS/Linux)
-            await execAsync(`unzip -o "${zipPath}" -d "${targetDir}"`);
-        } catch (e) {
-            // Fallback for Windows PowerShell
-            if (process.platform === 'win32') {
-                 await execAsync(`powershell -command "Expand-Archive -Force '${zipPath}' '${targetDir}'"`);
-            } else {
-                throw new Error('Failed to unzip. Please install "unzip" or manually unzip the file.');
-            }
-        }
+        await unzipArtifact(zipPath, extractDir);
 
-        console.log(`✅ Unzip complete.`);
+        // Defense-in-depth: reject a malformed artifact carrying Memory Core data or sqlite/.
+        await assertCollectionScopedArtifact({artifactDir: extractDir});
 
-        // Cleanup
-        await fs.remove(zipPath);
-        console.log(`🧹 Cleaned up zip file.`);
+        await warnOnEmbeddingMismatch({extractDir, embeddingConfig, logger});
 
-        console.log(`
-🎉 Knowledge Base is ready!`);
+        // Collection-scoped, merge-only import. Never directory-restores .neo-ai-data;
+        // never touches a Memory Core collection.
+        logger.log('📥 Importing Knowledge Base collection (merge mode)...');
+        const result = await databaseService.manageDatabaseBackup({
+            action: 'import',
+            file  : extractDir,
+            mode  : 'merge'
+        });
 
+        logger.log(`✅ Knowledge Base ready (imported ${result.imported} chunks).`);
+        return {status: 'imported', imported: result.imported};
     } catch (error) {
-        console.error(`❌ Error: ${error.message}`);
-        // Do not exit(1) to avoid breaking npm install for standard users if fetch fails
+        // Soft-fail so npm install never breaks for standard consumers.
+        logger.error(`❌ Knowledge Base download failed (non-fatal): ${error.message}`);
+        return {status: 'error', reason: error.message};
+    } finally {
+        await fs.remove(downloadDir);
     }
 }
 
-downloadKnowledgeBase();
+/**
+ * Compares the artifact's embedding provenance to the consumer's config and warns on a mismatch.
+ * Raw vectors round-trip on import (no re-embedding), so a provider/dimension divergence would
+ * silently degrade recall — a warning makes that visible without aborting npm install.
+ *
+ * @param {Object} options
+ * @param {String} options.extractDir      Unzipped artifact directory.
+ * @param {Object} options.embeddingConfig Tier-1 AI config exposing `embeddingProvider` + `vectorDimension`.
+ * @param {Object} options.logger          Log sink.
+ * @returns {Promise<void>}
+ */
+async function warnOnEmbeddingMismatch({extractDir, embeddingConfig, logger}) {
+    const metaPath = path.join(extractDir, ARTIFACT_META_FILENAME);
+    if (!await fs.pathExists(metaPath)) {
+        logger.warn(`⚠️  Artifact has no ${ARTIFACT_META_FILENAME}; cannot verify embedding provider/dimension compatibility.`);
+        return;
+    }
+
+    const meta              = await fs.readJson(metaPath);
+    const localProvider     = embeddingConfig.embeddingProvider;
+    const localDimension    = embeddingConfig.vectorDimension;
+
+    if (meta.embeddingProvider !== localProvider || meta.dimension !== localDimension) {
+        logger.warn(
+            `⚠️  Embedding mismatch: artifact was built with provider='${meta.embeddingProvider}' dimension=${meta.dimension}, ` +
+            `your config uses provider='${localProvider}' dimension=${localDimension}. ` +
+            `Imported vectors are used as-is (no re-embedding); recall against new queries may be degraded. ` +
+            `Re-run 'npm run ai:sync-kb' to re-embed against your provider.`
+        );
+    }
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+    downloadKnowledgeBase()
+        .then(() => process.exit(0))
+        .catch(error => {
+            // Reaching here is unexpected (the workflow soft-fails internally); still never break install.
+            console.error(`❌ Knowledge Base download failed (non-fatal): ${error.message}`);
+            process.exit(0);
+        });
+}

--- a/ai/scripts/maintenance/knowledgeBaseArtifact.mjs
+++ b/ai/scripts/maintenance/knowledgeBaseArtifact.mjs
@@ -1,0 +1,103 @@
+import fs   from 'fs-extra';
+import path from 'path';
+
+/**
+ * @module ai/scripts/maintenance/knowledgeBaseArtifact
+ * @summary Single source of truth for the collection-scoped Knowledge Base release artifact —
+ * its canonical name, JSONL/metadata filenames, and the defense-in-depth guard that proves the
+ * artifact carries ONLY the public `neo-knowledge-base` collection (never Memory Core or a
+ * `sqlite/` payload).
+ *
+ * Shared by `uploadKnowledgeBase.mjs` (build side), `downloadKnowledgeBase.mjs` (consumer side),
+ * and `buildScripts/release/publish.mjs` (pipeline) so the asset name can never drift across the
+ * three surfaces again.
+ *
+ * @see ai/scripts/maintenance/uploadKnowledgeBase.mjs
+ * @see ai/scripts/maintenance/downloadKnowledgeBase.mjs
+ */
+
+/**
+ * Canonical release-asset filename. Reconciled with the asset actually published on prior
+ * releases. The artifact is a zip of a flat staging dir (JSONL export + metadata), NOT a zip of
+ * any on-disk data directory.
+ * @type {String}
+ */
+export const ARTIFACT_BASENAME = 'chroma-neo-knowledge-base.zip';
+
+/**
+ * Filename prefix the KB SDK export writes (`KB_DatabaseService#exportCollection` →
+ * `knowledge-base-backup-<ISO-timestamp>.jsonl`). The artifact-scope guard treats any other
+ * `.jsonl` basename as a leak.
+ * @type {String}
+ */
+export const KB_BACKUP_FILE_PREFIX = 'knowledge-base-backup-';
+
+/**
+ * Metadata sidecar filename inside the artifact. Carries `embeddingProvider` + `dimension`
+ * provenance. The KB import SDK only consumes `.jsonl` files, so this `.json` sidecar rides
+ * along without being ingested as a record.
+ * @type {String}
+ */
+export const ARTIFACT_META_FILENAME = 'kb-artifact-meta.json';
+
+/**
+ * Collection-name prefixes owned by Memory Core. Their presence inside the artifact staging dir
+ * (as a `<prefix>*.jsonl` export or a directory) is a hard leak — the privacy failure this whole
+ * artifact-shape change exists to prevent.
+ * @type {String[]}
+ */
+export const MEMORY_CORE_COLLECTION_PREFIXES = ['neo-agent-memory', 'neo-agent-sessions', 'neo-native-graph'];
+
+/**
+ * Asserts a staged (or unzipped) artifact directory is collection-scoped to the public
+ * Knowledge Base collection. Throws on the first sign of a Memory Core leak so the failure is
+ * loud at build time and at ingest time.
+ *
+ * Rejection conditions:
+ * - Any `sqlite/` (or `*.sqlite`) entry — the graph/vector store must never ship.
+ * - Any entry whose name begins with a Memory Core collection prefix.
+ * - Any `.jsonl` whose basename does not begin with the KB export prefix (an unexpected export).
+ *
+ * The metadata sidecar (`ARTIFACT_META_FILENAME`) is the only permitted non-`.jsonl` file.
+ *
+ * @param {Object} options
+ * @param {String} options.artifactDir Absolute path to the staged/unzipped artifact directory.
+ * @param {Object} [options.fsModule=fs] Filesystem seam (tests).
+ * @returns {Promise<{entries: String[], jsonlFiles: String[]}>} Inventory of the validated dir.
+ */
+export async function assertCollectionScopedArtifact({artifactDir, fsModule = fs}) {
+    if (!await fsModule.pathExists(artifactDir)) {
+        throw new Error(`Artifact directory not found: ${artifactDir}`);
+    }
+
+    const entries = await fsModule.readdir(artifactDir);
+    const jsonlFiles = [];
+
+    for (const entry of entries) {
+        const lower = entry.toLowerCase();
+
+        if (lower === 'sqlite' || lower.endsWith('.sqlite') || lower.endsWith('.sqlite3')) {
+            throw new Error(`Artifact scope violation: '${entry}' is a SQLite payload. The release artifact must carry ONLY the '${KB_BACKUP_FILE_PREFIX}*.jsonl' Knowledge Base collection.`);
+        }
+
+        const leakedPrefix = MEMORY_CORE_COLLECTION_PREFIXES.find(prefix => entry.startsWith(prefix));
+        if (leakedPrefix) {
+            throw new Error(`Artifact scope violation: '${entry}' belongs to Memory Core collection '${leakedPrefix}'. The release artifact must carry ONLY the Knowledge Base collection.`);
+        }
+
+        if (entry.endsWith('.jsonl')) {
+            if (!entry.startsWith(KB_BACKUP_FILE_PREFIX)) {
+                throw new Error(`Artifact scope violation: unexpected JSONL export '${entry}'. Only '${KB_BACKUP_FILE_PREFIX}*.jsonl' (the Knowledge Base collection) is permitted.`);
+            }
+            jsonlFiles.push(entry);
+        } else if (entry !== ARTIFACT_META_FILENAME) {
+            throw new Error(`Artifact scope violation: unexpected entry '${entry}'. Permitted: '${KB_BACKUP_FILE_PREFIX}*.jsonl' and '${ARTIFACT_META_FILENAME}'.`);
+        }
+    }
+
+    if (jsonlFiles.length === 0) {
+        throw new Error(`Artifact scope violation: no '${KB_BACKUP_FILE_PREFIX}*.jsonl' Knowledge Base export found in ${artifactDir}.`);
+    }
+
+    return {entries, jsonlFiles};
+}

--- a/ai/scripts/maintenance/uploadKnowledgeBase.mjs
+++ b/ai/scripts/maintenance/uploadKnowledgeBase.mjs
@@ -1,110 +1,227 @@
-import fs          from 'fs-extra';
-import path        from 'path';
-import {exec}      from 'child_process';
-import {promisify} from 'util';
-import packageJson from '../../../package.json' with {type: 'json'};
+import {execFile}       from 'child_process';
+import fs               from 'fs-extra';
+import os               from 'os';
+import path             from 'path';
+import readline         from 'readline';
+import {promisify}      from 'util';
+import {fileURLToPath}  from 'url';
 
-const execAsync = promisify(exec);
-const cwd       = process.cwd();
+// Neo namespace bootstrap (entry-point invariant). `Neo` + `core/_export` populate
+// `globalThis.Neo` so that `ai/services.mjs` → Compare.mjs `Neo.gatekeep` resolves.
+import Neo              from '../../../src/Neo.mjs';
+import * as core        from '../../../src/core/_export.mjs';
+
+import AiConfig         from '../../config.mjs';
+import kbConfig         from '../../mcp/server/knowledge-base/config.mjs';
+
+import {
+    KB_DatabaseService,
+    KB_LifecycleService
+} from '../../services.mjs';
+
+import {
+    ARTIFACT_BASENAME,
+    KB_BACKUP_FILE_PREFIX,
+    ARTIFACT_META_FILENAME,
+    MEMORY_CORE_COLLECTION_PREFIXES,
+    assertCollectionScopedArtifact
+} from './knowledgeBaseArtifact.mjs';
+
+const execFileAsync = promisify(execFile);
 
 /**
- * @summary Automates the packaging and uploading of the AI Knowledge Base to GitHub Releases.
+ * @module ai/scripts/maintenance/uploadKnowledgeBase
+ * @summary Packages the Knowledge Base ChromaDB collection into a collection-scoped release
+ * artifact and uploads it to the matching GitHub Release.
  *
- * This script is a critical part of the release pipeline. It ensures that the ChromaDB knowledge base
- * is properly optimized (defragmented), packaged (zipped), and attached to the current GitHub release.
+ * ## Why collection-scoped
  *
- * Key Steps:
- * 1.  **Defragmentation**: Triggers `npm run ai:defrag-kb` to ensure the uploaded artifact is compact.
- * 2.  **Verification**: Checks that the corresponding GitHub release tag exists.
- * 3.  **Packaging**: Compresses the `chroma-neo-knowledge-base` directory.
- * 4.  **Upload**: Uses the GitHub CLI (`gh`) to upload the zip file to the release assets.
- * 5.  **Cleanup**: Removes the temporary zip file to keep the workspace clean.
+ * The release artifact carries ONLY the public `neo-knowledge-base` ChromaDB collection,
+ * exported as portable JSONL via the canonical `ai/services.mjs` SDK boundary
+ * (`KB_DatabaseService.manageDatabaseBackup({action: 'export'})` — the same path
+ * `ai/scripts/maintenance/backup.mjs` uses). It never bundles the `.neo-ai-data` data
+ * directory, which holds private Memory Core memories, the graph SQLite, and the A2A
+ * mailbox. A defense-in-depth assertion (`assertCollectionScopedArtifact`) fails the upload
+ * if any Memory Core collection or a `sqlite/` payload leaks into the staged artifact.
  *
- * @module buildScripts/uploadKnowledgeBase
- * @see buildScripts/defragChromaDB.mjs
- * @see buildScripts/publishRelease.mjs
+ * ## Artifact shape
+ *
+ * The artifact is a zip of a staging directory containing exactly two entries:
+ * - `knowledge-base-backup-<ISO-timestamp>.jsonl` — the collection export (raw vectors round-trip).
+ * - `kb-artifact-meta.json` — `embeddingProvider` + `dimension` provenance so a download-side
+ *   recall mismatch (model/dimension drift against the shipped raw vectors) is detectable.
+ *
+ * ## Pipeline position
+ *
+ * Invoked by `buildScripts/release/publish.mjs` after the GitHub Release is created. The
+ * canonical artifact basename is shared with `downloadKnowledgeBase.mjs` and the publish
+ * pipeline via `knowledgeBaseArtifact.mjs`.
+ *
+ * @see ai/scripts/maintenance/downloadKnowledgeBase.mjs
+ * @see ai/scripts/maintenance/backup.mjs
+ * @see ai/services/knowledge-base/DatabaseService.mjs
  */
+
+const __filename   = fileURLToPath(import.meta.url);
+const __dirname    = path.dirname(__filename);
+const PROJECT_ROOT = path.resolve(__dirname, '../../..');
 
 /**
- * Executes the knowledge base upload workflow.
+ * Reads `package.json` for the release tag. Best-effort `npm_package_version` first so the
+ * value matches the invoking npm context, then a direct read of the repo `package.json`.
  *
- * This function handles the entire process from optimization to upload. It includes robustness checks
- * to ensure that the database exists and that the release tag is valid before proceeding.
- * It uses a `try...finally` block to guarantee that the large temporary zip file is deleted
- * even if the upload fails.
- *
- * @async
- * @returns {Promise<void>}
- * @keywords knowledge base, release, github, upload, automation, chromadb, deployment
+ * @returns {Promise<String>} The semver version string.
  */
-async function uploadKnowledgeBase() {
-    const {version} = packageJson;
-    const tagName   = version;
-    const sourceDir = '.neo-ai-data';
-    const zipName   = 'neo-ai-data.zip';
-    const zipPath   = path.resolve(cwd, zipName);
-    let exitCode    = 0;
-
-    // 1. Check if DB exists
-    if (!await fs.pathExists(sourceDir)) {
-        console.error(`❌ Error: ${sourceDir} not found. Run 'npm run ai:sync-kb' first.`);
-        process.exit(1);
+async function resolveVersion() {
+    const fromEnv = process.env.npm_package_version;
+    if (fromEnv) {
+        return fromEnv;
     }
+    const pkg = await fs.readJson(path.join(PROJECT_ROOT, 'package.json'));
+    return pkg.version;
+}
 
-    // 2. Defragment Database (Ensure clean artifact)
-    // We enforce defragmentation before upload to prevent distributing bloated, fragmented index files
-    // to users. This keeps the download size manageable and the database performant.
-    console.log(`🧹 Running Defragmentation (npm run ai:defrag-kb)...`);
-    try {
-        const { stdout } = await execAsync('npm run ai:defrag-kb');
-        console.log(stdout);
-    } catch (e) {
-        console.error(`❌ Defragmentation failed: ${e.message}`);
-        console.error('Ensure the AI server is running (npm run ai:server) if required by the defrag script.');
-        process.exit(1);
-    }
-
-    // 3. Check if release exists (Fail fast)
-    // We verify the release tag exists on GitHub before attempting strictly local operations (zipping),
-    // to save time and resources in case of a configuration error.
-    console.log(`🔍 Checking for GitHub Release ${tagName}...`);
-    try {
-        await execAsync(`gh release view ${tagName}`);
-    } catch {
-        console.error(`❌ Release ${tagName} not found on GitHub.`);
-        console.log('Ensure you have pushed the tag or created the draft release.');
-        process.exit(1);
-    }
-
-    // 4. Zip and Upload (Try/Finally for cleanup)
-    try {
-        // Zip
-        console.log(`📦 Zipping ${sourceDir}...`);
-        await execAsync(`zip -r -q "${zipName}" "${sourceDir}"`);
-        const stats = await fs.stat(zipPath);
-        console.log(`✅ Zipped: ${zipName} (${(stats.size / 1024 / 1024).toFixed(2)} MB)`);
-
-        // Upload
-        console.log(`⬆️  Uploading to GitHub Release ${tagName}...`);
-        await execAsync(`gh release upload ${tagName} "${zipName}" --clobber`);
-        console.log(`✅ Upload complete!`);
-        console.log(`   https://github.com/neomjs/neo/releases/download/${tagName}/${zipName}`);
-
-    } catch (e) {
-        console.error('❌ Operation failed:', e.message);
-        exitCode = 1;
-    } finally {
-        // 5. Cleanup
-        // Always remove the temporary zip file, regardless of success or failure.
-        if (await fs.pathExists(zipPath)) {
-            await fs.remove(zipPath);
-            console.log(`🧹 Cleaned up ${zipName}`);
+/**
+ * Counts non-empty JSONL lines in a file (one record per line). Used both for the metadata
+ * `recordCount` stamp and as a guard against shipping an empty artifact.
+ *
+ * @param {String} filePath Absolute path to a `.jsonl` file.
+ * @returns {Promise<Number>}
+ */
+async function countJsonlRecords(filePath) {
+    const rl = readline.createInterface({
+        input    : fs.createReadStream(filePath),
+        crlfDelay: Infinity
+    });
+    let count = 0;
+    for await (const line of rl) {
+        if (line.trim()) {
+            count++;
         }
     }
+    return count;
+}
 
-    if (exitCode !== 0) {
-        process.exit(exitCode);
+/**
+ * Executes the collection-scoped Knowledge Base upload workflow.
+ *
+ * @param {Object}  [options]
+ * @param {String}  [options.tagName]            Override the resolved release tag (tests).
+ * @param {Object}  [options.databaseService]    KB database SDK seam (tests).
+ * @param {Object}  [options.lifecycleService]   KB lifecycle SDK seam (tests).
+ * @param {Object}  [options.embeddingConfig]    Tier-1 AI config seam exposing `embeddingProvider` + `vectorDimension`.
+ * @param {Object}  [options.knowledgeBaseConfig] KB server config seam exposing `collectionName`.
+ * @param {Function}[options.runGh]              Async `(args[]) => Promise` seam for `gh` invocations (tests).
+ * @param {Boolean} [options.skipReleaseCheck]   Skip the `gh release view` pre-flight (tests).
+ * @param {Boolean} [options.skipUpload]         Stage + assert + meta only; do not invoke `gh release upload` (tests).
+ * @param {String}  [options.stageRoot]          Override the staging-dir parent (tests). Defaults to OS tempdir.
+ * @param {Object}  [options.logger=console]     Log sink.
+ * @returns {Promise<{tagName: String, artifactName: String, recordCount: Number, embeddingProvider: String, dimension: Number, artifactPath: String}>}
+ */
+export async function uploadKnowledgeBase({
+    tagName,
+    databaseService     = KB_DatabaseService,
+    lifecycleService    = KB_LifecycleService,
+    embeddingConfig     = AiConfig,
+    knowledgeBaseConfig = kbConfig,
+    runGh               = (args) => execFileAsync('gh', args),
+    skipReleaseCheck    = false,
+    skipUpload          = false,
+    stageRoot           = os.tmpdir(),
+    logger              = console
+} = {}) {
+    const resolvedTag       = tagName ?? await resolveVersion();
+    const collectionName    = knowledgeBaseConfig.collectionName;
+    const embeddingProvider = embeddingConfig.embeddingProvider;
+    const dimension         = embeddingConfig.vectorDimension;
+    const artifactName      = ARTIFACT_BASENAME;
+
+    const stageDir    = path.join(stageRoot, `neo-kb-artifact-${process.pid}-${Date.now()}`);
+    const artifactDir = path.dirname(path.resolve(PROJECT_ROOT, artifactName));
+    const artifactPath = path.resolve(PROJECT_ROOT, artifactName);
+
+    await fs.ensureDir(stageDir);
+
+    try {
+        // 1. Verify the release tag exists before doing local work (fail fast).
+        if (!skipReleaseCheck) {
+            logger.log(`🔍 Checking for GitHub Release ${resolvedTag}...`);
+            try {
+                await runGh(['release', 'view', resolvedTag]);
+            } catch {
+                throw new Error(`Release ${resolvedTag} not found on GitHub. Push the tag or create the draft release first.`);
+            }
+        }
+
+        // 2. Export ONLY the neo-knowledge-base collection to JSONL via the canonical SDK.
+        await lifecycleService.ready();
+        logger.log(`📤 Exporting collection '${collectionName}' to JSONL...`);
+        await databaseService.manageDatabaseBackup({action: 'export', backupPath: stageDir});
+
+        const stagedJsonl = (await fs.readdir(stageDir))
+            .filter(name => name.startsWith(KB_BACKUP_FILE_PREFIX) && name.endsWith('.jsonl'));
+
+        if (stagedJsonl.length !== 1) {
+            throw new Error(
+                `Expected exactly one '${KB_BACKUP_FILE_PREFIX}*.jsonl' export in the staging dir, found ${stagedJsonl.length}. ` +
+                `Refusing to build an ambiguous artifact.`
+            );
+        }
+
+        const jsonlPath    = path.join(stageDir, stagedJsonl[0]);
+        const recordCount  = await countJsonlRecords(jsonlPath);
+
+        if (recordCount === 0) {
+            throw new Error(`Knowledge Base collection '${collectionName}' exported 0 records. Run 'npm run ai:sync-kb' before releasing.`);
+        }
+
+        // 3. Stamp embedding provenance so a download-side model/dimension drift is detectable.
+        const meta = {
+            artifactVersion  : 1,
+            collection       : collectionName,
+            embeddingProvider,
+            dimension,
+            recordCount,
+            neoVersion       : resolvedTag,
+            createdAt        : new Date().toISOString()
+        };
+        await fs.writeJson(path.join(stageDir, ARTIFACT_META_FILENAME), meta, {spaces: 2});
+
+        // 4. Defense-in-depth: prove the staged artifact is collection-scoped (no MC, no sqlite/).
+        await assertCollectionScopedArtifact({artifactDir: stageDir});
+        logger.log(`✅ Artifact is collection-scoped: ${recordCount} '${collectionName}' chunks, no Memory Core collections, no sqlite/.`);
+
+        // 5. Zip the staging dir CONTENTS (flat) into the canonical artifact, then upload.
+        await fs.ensureDir(artifactDir);
+        await fs.remove(artifactPath);
+        logger.log(`📦 Packaging ${artifactName}...`);
+        // `-j` flattens — the zip holds the JSONL + meta at its root, never a `.neo-ai-data` tree.
+        await execFileAsync('zip', ['-j', '-q', artifactPath, jsonlPath, path.join(stageDir, ARTIFACT_META_FILENAME)]);
+
+        const stats = await fs.stat(artifactPath);
+        logger.log(`✅ Packaged: ${artifactName} (${(stats.size / 1024 / 1024).toFixed(2)} MB)`);
+
+        if (!skipUpload) {
+            logger.log(`⬆️  Uploading to GitHub Release ${resolvedTag}...`);
+            await runGh(['release', 'upload', resolvedTag, artifactPath, '--clobber']);
+            logger.log(`✅ Upload complete: https://github.com/neomjs/neo/releases/download/${resolvedTag}/${artifactName}`);
+        }
+
+        return {tagName: resolvedTag, artifactName, recordCount, embeddingProvider, dimension, artifactPath};
+    } finally {
+        await fs.remove(stageDir);
+        if (!skipUpload && await fs.pathExists(artifactPath)) {
+            await fs.remove(artifactPath);
+            logger.log(`🧹 Cleaned up ${artifactName}`);
+        }
     }
 }
 
-uploadKnowledgeBase();
+if (import.meta.url === `file://${process.argv[1]}`) {
+    uploadKnowledgeBase()
+        .then(() => process.exit(0))
+        .catch(error => {
+            console.error('❌ Knowledge Base upload failed:', error.message);
+            process.exit(1);
+        });
+}

--- a/test/playwright/unit/ai/scripts/maintenance/knowledgeBaseArtifact.spec.mjs
+++ b/test/playwright/unit/ai/scripts/maintenance/knowledgeBaseArtifact.spec.mjs
@@ -1,0 +1,315 @@
+import {setup} from '../../../../setup.mjs';
+
+const appName = 'KnowledgeBaseArtifactTest';
+
+setup({
+    neoConfig: {
+        allowVdomUpdatesInTests: false,
+        unitTestMode           : true,
+        useDomApiRenderer      : false
+    },
+    appConfig: {
+        name             : appName,
+        isMounted        : () => true,
+        vnodeInitialising: false
+    }
+});
+
+import {test, expect} from '@playwright/test';
+import Neo            from '../../../../../../src/Neo.mjs';
+import * as core      from '../../../../../../src/core/_export.mjs';
+import fs             from 'fs';
+import fsExtra        from 'fs-extra';
+import os             from 'os';
+import path           from 'path';
+
+// Serial mode: upload/download specs swap real KB SDK singleton methods via seams indirectly;
+// keep file-local ordering deterministic for local multi-worker runs. CI uses workers:1.
+test.describe.configure({mode: 'serial'});
+
+test.describe('Knowledge Base release artifact — collection-scoped contract (#12157)', () => {
+    let assertCollectionScopedArtifact, ARTIFACT_BASENAME, ARTIFACT_META_FILENAME, KB_BACKUP_FILE_PREFIX;
+    let uploadKnowledgeBase, downloadKnowledgeBase;
+    let workRoot;
+
+    const silentLogger = {log: () => {}, warn: () => {}, error: () => {}};
+
+    /** A KB SDK seam that records its calls and returns a configurable shape. */
+    const makeDatabaseServiceSeam = ({onExport, importResult} = {}) => {
+        const calls = [];
+        return {
+            calls,
+            manageDatabaseBackup: async ({action, ...rest}) => {
+                calls.push({action, ...rest});
+                if (action === 'export') {
+                    await onExport?.({action, ...rest});
+                    return {message: 'export ok'};
+                }
+                if (action === 'import') {
+                    return importResult ?? {message: 'import ok', imported: 0, mode: rest.mode};
+                }
+                throw new Error(`unexpected action ${action}`);
+            }
+        };
+    };
+
+    const readyLifecycleSeam = () => ({ready: async () => {}});
+
+    test.beforeAll(async () => {
+        ({
+            assertCollectionScopedArtifact,
+            ARTIFACT_BASENAME,
+            ARTIFACT_META_FILENAME,
+            KB_BACKUP_FILE_PREFIX
+        } = await import('../../../../../../ai/scripts/maintenance/knowledgeBaseArtifact.mjs'));
+
+        ({uploadKnowledgeBase}   = await import('../../../../../../ai/scripts/maintenance/uploadKnowledgeBase.mjs'));
+        ({downloadKnowledgeBase} = await import('../../../../../../ai/scripts/maintenance/downloadKnowledgeBase.mjs'));
+
+        workRoot = path.resolve(process.cwd(), 'tmp', `kb-artifact-${process.pid}-${Date.now()}`);
+        fs.mkdirSync(workRoot, {recursive: true});
+    });
+
+    test.afterAll(() => {
+        if (workRoot && fs.existsSync(workRoot)) {
+            fs.rmSync(workRoot, {recursive: true, force: true});
+        }
+    });
+
+    // ───────── assertCollectionScopedArtifact: the no-MC-leak guard ─────────
+
+    test('canonical asset name is reconciled to a single constant', () => {
+        expect(ARTIFACT_BASENAME).toBe('chroma-neo-knowledge-base.zip');
+    });
+
+    test('accepts a clean KB-only artifact (JSONL export + meta sidecar)', async () => {
+        const dir = path.join(workRoot, 'clean');
+        await fsExtra.ensureDir(dir);
+        fs.writeFileSync(path.join(dir, `${KB_BACKUP_FILE_PREFIX}2026-01-01.jsonl`), '{"id":"kb-1"}\n');
+        fs.writeFileSync(path.join(dir, ARTIFACT_META_FILENAME), '{"collection":"neo-knowledge-base"}');
+
+        const result = await assertCollectionScopedArtifact({artifactDir: dir});
+        expect(result.jsonlFiles).toEqual([`${KB_BACKUP_FILE_PREFIX}2026-01-01.jsonl`]);
+    });
+
+    test('rejects a Memory Core memory collection leak', async () => {
+        const dir = path.join(workRoot, 'leak-memory');
+        await fsExtra.ensureDir(dir);
+        fs.writeFileSync(path.join(dir, `${KB_BACKUP_FILE_PREFIX}2026-01-01.jsonl`), '{"id":"kb-1"}\n');
+        fs.writeFileSync(path.join(dir, 'neo-agent-memory-backup-2026-01-01.jsonl'), '{"id":"mem-1"}\n');
+
+        await expect(assertCollectionScopedArtifact({artifactDir: dir}))
+            .rejects.toThrow(/Memory Core collection 'neo-agent-memory'/);
+    });
+
+    test('rejects a Memory Core sessions + native-graph collection leak', async () => {
+        for (const leak of ['neo-agent-sessions-backup.jsonl', 'neo-native-graph-backup.jsonl']) {
+            const dir = path.join(workRoot, `leak-${leak}`);
+            await fsExtra.ensureDir(dir);
+            fs.writeFileSync(path.join(dir, `${KB_BACKUP_FILE_PREFIX}x.jsonl`), '{"id":"kb"}\n');
+            fs.writeFileSync(path.join(dir, leak), '{"id":"x"}\n');
+            await expect(assertCollectionScopedArtifact({artifactDir: dir}))
+                .rejects.toThrow(/Artifact scope violation/);
+        }
+    });
+
+    test('rejects a sqlite/ payload (graph store)', async () => {
+        const dir = path.join(workRoot, 'leak-sqlite-dir');
+        await fsExtra.ensureDir(path.join(dir, 'sqlite'));
+        fs.writeFileSync(path.join(dir, `${KB_BACKUP_FILE_PREFIX}x.jsonl`), '{"id":"kb"}\n');
+
+        await expect(assertCollectionScopedArtifact({artifactDir: dir}))
+            .rejects.toThrow(/SQLite payload/);
+    });
+
+    test('rejects a loose *.sqlite file', async () => {
+        const dir = path.join(workRoot, 'leak-sqlite-file');
+        await fsExtra.ensureDir(dir);
+        fs.writeFileSync(path.join(dir, `${KB_BACKUP_FILE_PREFIX}x.jsonl`), '{"id":"kb"}\n');
+        fs.writeFileSync(path.join(dir, 'memory-core-graph.sqlite'), 'binary');
+
+        await expect(assertCollectionScopedArtifact({artifactDir: dir}))
+            .rejects.toThrow(/SQLite payload/);
+    });
+
+    test('rejects an unexpected non-KB JSONL export', async () => {
+        const dir = path.join(workRoot, 'leak-unexpected-jsonl');
+        await fsExtra.ensureDir(dir);
+        fs.writeFileSync(path.join(dir, 'something-else.jsonl'), '{"id":"x"}\n');
+
+        await expect(assertCollectionScopedArtifact({artifactDir: dir}))
+            .rejects.toThrow(/unexpected JSONL export/);
+    });
+
+    test('rejects an artifact with no KB export at all', async () => {
+        const dir = path.join(workRoot, 'leak-empty');
+        await fsExtra.ensureDir(dir);
+        fs.writeFileSync(path.join(dir, ARTIFACT_META_FILENAME), '{}');
+
+        await expect(assertCollectionScopedArtifact({artifactDir: dir}))
+            .rejects.toThrow(/no '.*' Knowledge Base export found/);
+    });
+
+    // ───────── uploadKnowledgeBase: collection-scoped staging ─────────
+
+    test('upload stages ONLY the KB collection + a provenance meta, then asserts scope', async () => {
+        const stageRoot = path.join(workRoot, 'upload-stage-clean');
+        await fsExtra.ensureDir(stageRoot);
+
+        // Export seam writes a single KB JSONL into the staging dir the SDK was handed.
+        const databaseService = makeDatabaseServiceSeam({
+            onExport: async ({backupPath}) => {
+                fs.writeFileSync(path.join(backupPath, `${KB_BACKUP_FILE_PREFIX}2026-05-29.jsonl`), '{"id":"kb-1"}\n{"id":"kb-2"}\n');
+            }
+        });
+
+        const ghCalls = [];
+        const result  = await uploadKnowledgeBase({
+            tagName            : '99.0.0',
+            databaseService,
+            lifecycleService   : readyLifecycleSeam(),
+            embeddingConfig    : {embeddingProvider: 'openAiCompatible', vectorDimension: 4096},
+            knowledgeBaseConfig: {collectionName: 'neo-knowledge-base'},
+            runGh              : async (args) => { ghCalls.push(args); },
+            stageRoot,
+            logger             : silentLogger
+        });
+
+        expect(result.recordCount).toBe(2);
+        expect(result.embeddingProvider).toBe('openAiCompatible');
+        expect(result.dimension).toBe(4096);
+        expect(result.artifactName).toBe('chroma-neo-knowledge-base.zip');
+
+        // Export was requested; upload was attempted (release-check + upload gh calls).
+        expect(databaseService.calls[0].action).toBe('export');
+        expect(ghCalls.some(a => a[0] === 'release' && a[1] === 'upload')).toBe(true);
+
+        // The staging dir is cleaned up in finally; the local artifact too.
+        expect(fs.existsSync(result.artifactPath)).toBe(false);
+    });
+
+    test('upload fails fast when the export yields zero records', async () => {
+        const stageRoot = path.join(workRoot, 'upload-stage-empty');
+        await fsExtra.ensureDir(stageRoot);
+
+        const databaseService = makeDatabaseServiceSeam({
+            onExport: async ({backupPath}) => {
+                fs.writeFileSync(path.join(backupPath, `${KB_BACKUP_FILE_PREFIX}empty.jsonl`), '');
+            }
+        });
+
+        await expect(uploadKnowledgeBase({
+            tagName            : '99.0.0',
+            databaseService,
+            lifecycleService   : readyLifecycleSeam(),
+            embeddingConfig    : {embeddingProvider: 'openAiCompatible', vectorDimension: 4096},
+            knowledgeBaseConfig: {collectionName: 'neo-knowledge-base'},
+            runGh              : async () => {},
+            skipReleaseCheck   : true,
+            stageRoot,
+            logger             : silentLogger
+        })).rejects.toThrow(/exported 0 records/);
+    });
+
+    // ───────── downloadKnowledgeBase: merge-only contract ─────────
+
+    test('download skips entirely when the consumer KB collection is already populated', async () => {
+        const databaseService = makeDatabaseServiceSeam({});
+        const fetchCalls      = [];
+
+        const result = await downloadKnowledgeBase({
+            tagName         : '99.0.0',
+            chromaManager   : {getKnowledgeBaseCollection: async () => ({count: async () => 42})},
+            databaseService,
+            lifecycleService: readyLifecycleSeam(),
+            embeddingConfig : {embeddingProvider: 'openAiCompatible', vectorDimension: 4096},
+            fetchImpl       : async (url) => { fetchCalls.push(url); return {ok: false, status: 404}; },
+            workRoot        : path.join(workRoot, 'dl-populated'),
+            logger          : silentLogger
+        });
+
+        expect(result.status).toBe('skipped');
+        expect(result.reason).toBe('collection-populated');
+        // Merge-only guard means NO network call and NO import when already populated.
+        expect(fetchCalls.length).toBe(0);
+        expect(databaseService.calls.length).toBe(0);
+    });
+
+    test('download soft-fails (no throw) on a 404 artifact for empty consumer collection', async () => {
+        const databaseService = makeDatabaseServiceSeam({});
+
+        const result = await downloadKnowledgeBase({
+            tagName         : '99.0.0',
+            chromaManager   : {getKnowledgeBaseCollection: async () => ({count: async () => 0})},
+            databaseService,
+            lifecycleService: readyLifecycleSeam(),
+            embeddingConfig : {embeddingProvider: 'openAiCompatible', vectorDimension: 4096},
+            fetchImpl       : async () => ({ok: false, status: 404}),
+            workRoot        : path.join(workRoot, 'dl-404'),
+            logger          : silentLogger
+        });
+
+        expect(result.status).toBe('absent');
+        expect(databaseService.calls.length).toBe(0);
+    });
+
+    test('download imports collection-scoped (merge) when the artifact round-trips a real zip', async () => {
+        // Build a real artifact via uploadKnowledgeBase(skipUpload) so the download path exercises
+        // the REAL zip → unzip → assert → import chain, not a stubbed extract dir.
+        const stageRoot   = path.join(workRoot, 'roundtrip-stage');
+        const releaseRoot = path.join(workRoot, 'roundtrip-release');
+        await fsExtra.ensureDir(stageRoot);
+        await fsExtra.ensureDir(releaseRoot);
+
+        const uploadDbSeam = makeDatabaseServiceSeam({
+            onExport: async ({backupPath}) => {
+                fs.writeFileSync(path.join(backupPath, `${KB_BACKUP_FILE_PREFIX}rt.jsonl`), '{"id":"kb-1","embedding":[0.1],"metadata":{"content":"x"},"document":null}\n');
+            }
+        });
+
+        const built = await uploadKnowledgeBase({
+            tagName            : '99.0.0',
+            databaseService    : uploadDbSeam,
+            lifecycleService   : readyLifecycleSeam(),
+            embeddingConfig    : {embeddingProvider: 'openAiCompatible', vectorDimension: 4096},
+            knowledgeBaseConfig: {collectionName: 'neo-knowledge-base'},
+            runGh              : async () => {},
+            skipReleaseCheck   : true,
+            skipUpload         : true,
+            stageRoot,
+            logger             : silentLogger
+        });
+
+        // Move the built artifact to a stable path the fake fetch can serve as bytes, then
+        // clear the repo-root original (skipUpload retains it; the upload-only path cleans itself).
+        const servedZip = path.join(releaseRoot, ARTIFACT_BASENAME);
+        fs.copyFileSync(built.artifactPath, servedZip);
+        fs.rmSync(built.artifactPath, {force: true});
+        const zipBytes = fs.readFileSync(servedZip);
+
+        const downloadDbSeam = makeDatabaseServiceSeam({importResult: {message: 'ok', imported: 1, mode: 'merge'}});
+
+        const result = await downloadKnowledgeBase({
+            tagName         : '99.0.0',
+            chromaManager   : {getKnowledgeBaseCollection: async () => ({count: async () => 0})},
+            databaseService : downloadDbSeam,
+            lifecycleService: readyLifecycleSeam(),
+            embeddingConfig : {embeddingProvider: 'openAiCompatible', vectorDimension: 4096},
+            fetchImpl       : async () => ({ok: true, status: 200, arrayBuffer: async () => zipBytes.buffer.slice(zipBytes.byteOffset, zipBytes.byteOffset + zipBytes.byteLength)}),
+            workRoot        : path.join(workRoot, 'dl-roundtrip'),
+            logger          : silentLogger
+        });
+
+        expect(result.status).toBe('imported');
+        expect(result.imported).toBe(1);
+
+        const importCall = downloadDbSeam.calls.find(c => c.action === 'import');
+        expect(importCall.mode).toBe('merge');
+        // The SDK is handed the unzipped extract DIRECTORY (collection-scoped import), never
+        // the `.zip` artifact and never the user's `.neo-ai-data` data dir. (The dir itself is
+        // cleaned up in the workflow's finally block, so we assert on the path shape.)
+        expect(path.basename(importCall.file)).toBe('extract');
+        expect(importCall.file.endsWith('.zip')).toBe(false);
+        expect(importCall.file).not.toContain('.neo-ai-data');
+    });
+});


### PR DESCRIPTION
Authored by Claude Opus 4.8 (Claude Code), @neo-opus-4-7. Session efd8dc2e-2052-4089-814a-ab22cd8c6a62. Implemented via an isolated-worktree subagent under my direction; I reviewed both rewrites + the guard module end-to-end before opening.

FAIR-band: moot — sole active implementer (@neo-gpt reviews-only at ~1%; @neo-gemini-3-1-pro benched).

Evidence: L2 — the new `knowledgeBaseArtifact.spec.mjs` (13 tests, incl. a real zip→unzip→assert→import round-trip + a negative case per leak vector) + `backup`/`restore` regression (18) reported green by the implementing run; CI re-verifies here. I read `uploadKnowledgeBase.mjs`, `downloadKnowledgeBase.mjs`, and the guard module end-to-end. L3 (live export/import against a running Chroma daemon) is post-merge manual.

Resolves #12157 (sub of Epic #12153).

## Summary

Fixes the latent privacy leak in the KB release pipeline. `uploadKnowledgeBase.mjs` previously did `zip -r neo-ai-data.zip .neo-ai-data` — the whole private tree (agent memories, the graph SQLite, the A2A mailbox) — and `downloadKnowledgeBase.mjs` extracted it over the consumer's data dir on every `npm install` (the `prepare` hook). Both now route through the canonical collection-scoped JSONL SDK (`KB_DatabaseService.manageDatabaseBackup`), exactly as `backup.mjs` / `restore.mjs` do:

- **Upload** exports ONLY the `neo-knowledge-base` collection to JSONL, stamps `embeddingProvider` + `dimension` provenance, asserts collection-scope, and `zip -j`s a flat artifact (JSONL + meta at root — never a `.neo-ai-data` tree).
- **Download** is merge-only: skips if the consumer's KB collection is already populated, imports collection-scoped (`mode:'merge'`), never directory-restores `.neo-ai-data` or touches a Memory Core collection, and soft-fails so `npm install` never breaks.
- A shared `knowledgeBaseArtifact.mjs` SSOT holds the single canonical asset name (`chroma-neo-knowledge-base.zip` — the name actually published, reconciling the `neo-ai-data.zip` drift) + a defense-in-depth `assertCollectionScopedArtifact` guard that throws on any `sqlite/` payload, any `neo-agent-memory`/`-sessions`/`-native-graph` entry, or any unexpected JSONL — enforced on BOTH the build and consumer sides.

## Changes
- `ai/scripts/maintenance/uploadKnowledgeBase.mjs` — full rewrite (collection-scoped export; no whole-dir zip).
- `ai/scripts/maintenance/downloadKnowledgeBase.mjs` — full rewrite (merge-only import; never clobbers).
- `ai/scripts/maintenance/knowledgeBaseArtifact.mjs` — NEW shared SSOT (canonical asset name + the scope guard).
- `test/playwright/unit/ai/scripts/maintenance/knowledgeBaseArtifact.spec.mjs` — NEW (13 tests).

## Decision Record impact
`aligned-with ADR 0017` (Single Flat Unified Store, PR #12159) — implements its "shipping = collection-scoped export" separation layer. No new ADR.

## Deltas from ticket
- #12157 scoped the collection-scoped export/import. The implementation additionally extracts a shared `knowledgeBaseArtifact.mjs` SSOT (sibling-lift, colocated with `backup`/`restore`) so the asset name can never drift across upload / download / `publish.mjs` again — beyond the literal ticket text but the structurally-correct shape.
- `package.json` needed no change: `ai:download-kb` + `prepare` already point at the correct script path (the behavior changed, not the location).

## Test Evidence
- `node --check` on all 4 `.mjs` files: pass.
- `knowledgeBaseArtifact.spec.mjs`: 13/13 (incl. the real round-trip + per-leak-vector negatives).
- `backup.spec.mjs` + `restore.spec.mjs` regression: 18/18.
- Pre-commit hooks (check-whitespace + check-shorthand): clean.

## Post-Merge Validation
- [ ] Run a real release-export against the live Chroma daemon and confirm the artifact contains ONLY `knowledge-base-backup-*.jsonl` + `kb-artifact-meta.json` (no MC collection, no `sqlite/`).
- [ ] Pre-existing `buildScripts/README.md` path-drift (stale `buildScripts/ai/…` script refs, flagged by the implementing run) — a separate doc follow-up, not in this PR's scope.

## Commits
- `a0353d0bd` — collection-scoped KB release artifact + shared SSOT guard + tests.