### PR TITLE
feat(ai): rename Chroma persist store to unified (#12155)

### DIFF
--- a/ai/config.template.mjs
+++ b/ai/config.template.mjs
@@ -248,13 +248,15 @@ class Config extends BaseConfig {
              * `engines.chroma` is the unified Chroma topology from ADR 0003: ONE daemon, ONE persist
              * dir, shared by Knowledge Base + Memory Core. `dataDir` is the fixed canonical persist dir
              * read by both server configs + the `defragChromaDB` maintenance script; the local
-             * orchestrator launches the daemon against the same fixed path. Collection NAMES remain
-             * server-local; the persist DIR is unified.
+             * orchestrator launches the daemon against the same fixed path. The leaf is named `unified`
+             * (identical local + cloud) — it holds every realm (KB + MC + graph + sessions), so a
+             * realm-specific name would misrepresent the store. Collection NAMES remain server-local;
+             * the persist DIR is unified.
              * @type {Object}
              */
             engines: {
                 chroma: {
-                    dataDir: leaf(path.resolve(neoRootDir, '.neo-ai-data/chroma/knowledge-base')),
+                    dataDir: leaf(path.resolve(neoRootDir, '.neo-ai-data/chroma/unified')),
                     host   : leaf('localhost', 'NEO_CHROMA_HOST', 'string'),
                     port   : leaf(8000, 'NEO_CHROMA_PORT', 'port')
                 }

--- a/ai/daemons/orchestrator/TaskDefinitions.mjs
+++ b/ai/daemons/orchestrator/TaskDefinitions.mjs
@@ -64,7 +64,7 @@ export function buildTaskDefinitions({
             // cwd==repoRoot. Kept as a relative literal here (not SSOT-sourced) for daemon-launch
             // resilience: a stale config.mjs lacking the SSOT key would otherwise launch the daemon
             // with `--path undefined`. Keep this value in sync with engines.chroma.dataDir.
-            args           : ['run', '--path', '.neo-ai-data/chroma/knowledge-base', '--port', String(chromaPort)],
+            args           : ['run', '--path', '.neo-ai-data/chroma/unified', '--port', String(chromaPort)],
             pidFileName    : 'chroma.pid',
             expectedCommand: 'chroma',
             singletonPort  : chromaPort

--- a/ai/deploy/docker-compose.dev.yml
+++ b/ai/deploy/docker-compose.dev.yml
@@ -1,9 +1,15 @@
 services:
   chroma:
     image: chromadb/chroma:1.5.9
+    # One flat unified persist dir, identical local + cloud (ADR 0003 / Epic #12153).
+    # PERSIST_DIRECTORY is REQUIRED: the image persists to its WORKDIR-relative default
+    # (/chroma/chroma) and IGNORES a mount elsewhere, so the env must point at the same
+    # leaf as the tmpfs mount or the daemon writes outside the tmpfs.
+    environment:
+      - PERSIST_DIRECTORY=/chroma/unified
     # Tmpfs-mode option for Chroma when used as test fixture (cross-link to #10805)
     tmpfs:
-      - /chroma/chroma
+      - /chroma/unified
     healthcheck:
       test: ["CMD-SHELL", "bash -c '</dev/tcp/127.0.0.1/8000'"]
       interval: 10s

--- a/ai/deploy/docker-compose.test.yml
+++ b/ai/deploy/docker-compose.test.yml
@@ -1,8 +1,14 @@
 services:
   chroma:
     image: chromadb/chroma:1.5.9
+    # One flat unified persist dir, identical local + cloud (ADR 0003 / Epic #12153).
+    # PERSIST_DIRECTORY is REQUIRED: the image persists to its WORKDIR-relative default
+    # (/chroma/chroma) and IGNORES a mount elsewhere, so the env must point at the same
+    # leaf as the tmpfs mount or the daemon writes outside the tmpfs.
+    environment:
+      - PERSIST_DIRECTORY=/chroma/unified
     tmpfs:
-      - /chroma/chroma
+      - /chroma/unified
     # The published chromadb/chroma:1.5.9 image is a single 541MB compiled binary
     # at /usr/local/bin/chroma (built via docker-bake.hcl, not the GitHub Dockerfile).
     # It has NO python, NO python3, NO curl, NO wget — empirically verified via

--- a/ai/deploy/docker-compose.yml
+++ b/ai/deploy/docker-compose.yml
@@ -18,8 +18,15 @@
 services:
   chroma:
     image: chromadb/chroma:1.5.9
+    # One flat unified persist dir, identical local + cloud (ADR 0003 / Epic #12153).
+    # PERSIST_DIRECTORY is REQUIRED, not optional: the chromadb/chroma:1.5.9 image persists
+    # to its WORKDIR-relative default (/chroma/chroma) and IGNORES a volume mounted elsewhere.
+    # Without this env the daemon would write to an ephemeral container layer while the named
+    # volume sat empty. The mount and the env MUST stay in lockstep on the same leaf.
+    environment:
+      - PERSIST_DIRECTORY=/chroma/unified
     volumes:
-      - chroma-data:/chroma/chroma
+      - chroma-data:/chroma/unified
     healthcheck:
       test: ["CMD-SHELL", "bash -c '</dev/tcp/127.0.0.1/8000'"]
       interval: 10s

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
         "ai:orchestrator"              : "node ./ai/daemons/orchestrator/daemon.mjs",
         "ai:revalidation-sweep"        : "node ./ai/scripts/lifecycle/revalidationSweep.mjs",
         "ai:run-sandman"               : "node ./ai/scripts/runners/runSandman.mjs",
-        "ai:server"                    : "chroma run --path ./.neo-ai-data/chroma/knowledge-base",
+        "ai:server"                    : "chroma run --path ./.neo-ai-data/chroma/unified",
         "ai:server-neural-link"        : "node ./ai/mcp/server/neural-link/run-bridge.mjs",
         "ai:summarize-sessions"        : "node ./ai/scripts/lifecycle/summarize-sessions.mjs",
         "ai:sync-github-workflow"      : "node ./ai/scripts/maintenance/syncGithubWorkflow.mjs",

--- a/test/playwright/fixtures/aiConfigDefaults.mjs
+++ b/test/playwright/fixtures/aiConfigDefaults.mjs
@@ -132,7 +132,7 @@ export const TIER1_DEFAULTS = deepFreeze(Neo.clone({
     embeddingModel : 'gemini-embedding-001',
     engines: {
         chroma: {
-            dataDir: path.resolve(neoRootDir, '.neo-ai-data/chroma/knowledge-base'),
+            dataDir: path.resolve(neoRootDir, '.neo-ai-data/chroma/unified'),
             host   : process.env.NEO_CHROMA_HOST || 'localhost',
             port   : Number(process.env.NEO_CHROMA_PORT) || 8000
         }

--- a/test/playwright/fixtures/knowledgeBaseConfigDefaults.mjs
+++ b/test/playwright/fixtures/knowledgeBaseConfigDefaults.mjs
@@ -118,7 +118,7 @@ export const KB_DEFAULTS = deepFreeze(Neo.clone({
         }
     },
     collectionName    : 'neo-knowledge-base',
-    path              : path.resolve(neoRootDir, '.neo-ai-data/chroma/knowledge-base'),
+    path              : path.resolve(neoRootDir, '.neo-ai-data/chroma/unified'),
     dataPath          : path.resolve(neoRootDir, 'dist/ai-knowledge-base.jsonl'),
     hierarchyPath     : path.resolve(neoRootDir, 'docs/output/class-hierarchy.json'),
     logPath           : path.resolve(neoRootDir, '.neo-ai-data/logs'),

--- a/test/playwright/integration/ai/daemons/workspaceSafety.spec.mjs
+++ b/test/playwright/integration/ai/daemons/workspaceSafety.spec.mjs
@@ -137,7 +137,7 @@ test.describe('Orchestrator workspace-safety integration (#11948 / Sub-5 AC5 of 
 
     test('AC1+AC2+AC3+AC4 — fresh-workspace cloud-mode boot self-bootstraps sqlite + reaches [Orchestrator] Started without fatal log surface', async () => {
         // cwd=workspaceDir isolates every cwd-relative side effect the daemon and its
-        // supervised children create (chroma's `.neo-ai-data/chroma/knowledge-base`,
+        // supervised children create (chroma's `.neo-ai-data/chroma/unified`,
         // task PID files, etc.) so the test cannot collide with a concurrently running
         // operator-owned daemon on the same host.
         daemonProcess = spawn('node', [DAEMON_ENTRY], {

--- a/test/playwright/unit/ai/config.template.spec.mjs
+++ b/test/playwright/unit/ai/config.template.spec.mjs
@@ -94,7 +94,7 @@ test.describe('Tier 1 Config Immutability', () => {
             }
         });
         expect(Config.engines.chroma).toEqual({
-            dataDir: expect.stringMatching(/\.neo-ai-data[/\\]chroma[/\\]knowledge-base$/),
+            dataDir: expect.stringMatching(/\.neo-ai-data[/\\]chroma[/\\]unified$/),
             host   : process.env.NEO_CHROMA_HOST || 'localhost',
             port   : Number(process.env.NEO_CHROMA_PORT) || 8000
         });

--- a/test/playwright/unit/ai/mcp/server/knowledge-base/config.template.spec.mjs
+++ b/test/playwright/unit/ai/mcp/server/knowledge-base/config.template.spec.mjs
@@ -98,7 +98,7 @@ test.describe('Knowledge Base Config Tier-1 defaults (#11963)', () => {
         expect(config.host).toBe(TIER1_DEFAULTS.engines.chroma.host);
         expect(config.port).toBe(TIER1_DEFAULTS.engines.chroma.port);
         expect(config.collectionName).toBe('neo-knowledge-base');
-        expect(config.path).toContain('.neo-ai-data/chroma/knowledge-base');
+        expect(config.path).toContain('.neo-ai-data/chroma/unified');
     });
 
     test('env overrides win — KB-local leaves at the child, Tier-1-owned leaves at the owner (inherited)', () => {

--- a/test/playwright/unit/ai/mcp/server/memory-core/config.template.spec.mjs
+++ b/test/playwright/unit/ai/mcp/server/memory-core/config.template.spec.mjs
@@ -119,7 +119,7 @@ test.describe('Memory Core Config (#10010)', () => {
         // MC reads the unified persist-dir SSOT, not a server-local dir.
         // Was the stale `.neo-ai-data/chroma/memory-core` — the bug.
         expect(config.engines.chroma.dataDir).toBe(TIER1_DEFAULTS.engines.chroma.dataDir);
-        expect(config.engines.chroma.dataDir).toContain('.neo-ai-data/chroma/knowledge-base');
+        expect(config.engines.chroma.dataDir).toContain('.neo-ai-data/chroma/unified');
     });
 
     test('inherits concrete graphProvider defaults from Tier-1 config', () => {

--- a/test/playwright/unit/ai/mcp/server/shared/services/DestructiveOperationGuard.spec.mjs
+++ b/test/playwright/unit/ai/mcp/server/shared/services/DestructiveOperationGuard.spec.mjs
@@ -100,7 +100,7 @@ test.describe('Neo.ai.mcp.server.shared.services.DestructiveOperationGuard (#108
             mode     : 'delete',
             target   : {
                 collectionName: 'neo-knowledge-base',
-                path          : path.join(repoRoot, '.neo-ai-data/chroma/knowledge-base'),
+                path          : path.join(repoRoot, '.neo-ai-data/chroma/unified'),
                 repoRoot
             },
             env: {}
@@ -131,7 +131,7 @@ test.describe('Neo.ai.mcp.server.shared.services.DestructiveOperationGuard (#108
             subsystem: 'memory-core',
             mode     : 'drop',
             target   : {
-                path: path.join(repoRoot, '.neo-ai-data/chroma/memory-core'),
+                path: path.join(repoRoot, '.neo-ai-data/chroma/unified'),
                 repoRoot
             },
             env: {
@@ -144,7 +144,7 @@ test.describe('Neo.ai.mcp.server.shared.services.DestructiveOperationGuard (#108
 
     test('requires both bypass env and explicit confirmation for production targets', async () => {
         const target = {
-            path: path.join(repoRoot, '.neo-ai-data/chroma/memory-core'),
+            path: path.join(repoRoot, '.neo-ai-data/chroma/unified'),
             repoRoot
         };
 


### PR DESCRIPTION
Authored by Claude Opus 4.8 (Claude Code), @neo-opus-4-7. Session efd8dc2e-2052-4089-814a-ab22cd8c6a62.

FAIR-band: moot — sole active implementer (@neo-gpt reviews-only at ~1%; @neo-gemini-3-1-pro benched).

Evidence: L2 — config.template + KB/MC config.template + DestructiveOperationGuard specs green (26 passed) + `node --check`. L3 — the one-time local data move is a manual operator step (below), NOT shipped code.

Resolves #12155 (sub of Epic #12153; implements ADR 0017).

## Summary
Renames the single Chroma persist store leaf `knowledge-base` → `unified` (local + cloud), implementing ADR 0017's one-flat-store decision + dev/prod parity. The dir holds every realm (KB + MC + sessions + graph), so a realm-specific name misrepresented it.

- `engines.chroma.dataDir` SSOT + the orchestrator chroma `--path` + the `ai:server` script → `…/chroma/unified`.
- The three deploy compose files mount `/chroma/unified` **+ set `PERSIST_DIRECTORY=/chroma/unified`** (the `chromadb/chroma:1.5.9` image persists to its WORKDIR-relative default and ignores a mount-only change — verified vs the 1.5.9 source).
- Config test specs + fixtures updated to the `unified` leaf.

Net diff: 13 files, ~55 lines.

## One-time local migration (manual — this is the only deployment that exists)
No migration code ships — it would be permanent dead code after a single run on the one machine that exists. The live data moves once on @tobiu's machine, stack stopped:
1. Stop the AI stack (orchestrator + the chroma daemon).
2. Back up: `cp -r .neo-ai-data/chroma/knowledge-base .neo-ai-data/backups/chroma-kb-$(date +%s)`
3. `mv .neo-ai-data/chroma/knowledge-base .neo-ai-data/chroma/unified`
4. (optional) `rm -rf .neo-ai-data/chroma/memory-core` — the stale federated leftover.
5. Restart with the new config.

## Decision Record impact
`aligned-with ADR 0017` (Single Flat Unified Store). No new ADR.

## Deltas from ticket
- **Trimmed from a migration framework to a rename + a manual step.** The first pass (commits `f6d47e238` / `803dc3bd1`) built an idempotent migration script + an orchestrator strand-guard + a 315-line spec (~1000 lines). Per operator review, that is over-engineering for a ONE-TIME `mv` on the single machine that exists — it would be permanent dead code. The `d3624c7d0` commit removes it; the migration is the documented manual step above. (On squash-merge, `dev` gets a single clean rename-only commit.)
- **Out of scope (flagged):** stale `/chroma/chroma` / `knowledge-base` path refs in `learn/agentos/cloud-deployment/PipelineWiring.md` + `learn/agentos/tooling/RestorationRunbook.md` belong to the guides sub #12158.

## Test Evidence
- `npm run test-unit -- <config.template + KB/MC config.template + DestructiveOperationGuard specs>` — **26 passed**.
- `node --check` on every edited `.mjs`: clean.

## Post-Merge Validation
- [ ] @tobiu runs the one-time manual migration above (stack stopped → backup → `mv` → restart); confirm the `unified` store serves (KB + MC search green).
- [ ] Cloud (when a deployment exists): confirm `PERSIST_DIRECTORY=/chroma/unified` + the mount persist on a fresh deploy.

## Commits
- `f6d47e238` rename + (since-removed) migration framework · `803dc3bd1` strip ticket-id comment refs · `d3624c7d0` trim to rename-only.