### PR TITLE
refactor(ai): defrag uses canonical dummyEmbeddingFunction; drop github-workflow copy (#12165)

### DIFF
--- a/ai/mcp/server/github-workflow/config.template.mjs
+++ b/ai/mcp/server/github-workflow/config.template.mjs
@@ -78,13 +78,6 @@ class Config extends BaseConfig {
                 stderrMode  : 'threshold'
             }},
             /**
-             * A dummy embedding function to satisfy the ChromaDB API when embeddings are provided manually.
-             * @returns {null}
-             */
-            dummyEmbeddingFunction: {default: {
-                generate: () => null
-            }},
-            /**
              * Cache duration for healthy health checks (in milliseconds).
              * Unhealthy results are never cached.
              * @type {number}

--- a/ai/mcp/server/knowledge-base/config.template.mjs
+++ b/ai/mcp/server/knowledge-base/config.template.mjs
@@ -101,13 +101,28 @@ class Config extends BaseConfig {
                 trustProxyIdentity: {env: 'NEO_AUTH_TRUST_PROXY_IDENTITY', default: AiConfig.auth.trustProxyIdentity, parse: Env.parseBool}
             },
             /**
-             * Dummy embedding function — inherited from the Tier-1 single source of truth
-             * `AiConfig.dummyEmbeddingFunction` (#12165). Satisfies the ChromaDB API when embeddings
-             * are provided manually; the verbose anti-legacy structure (name / getConfig /
-             * buildFromConfig) lives once at Tier-1.
+             * A dummy embedding function to satisfy the ChromaDB API when embeddings are provided manually.
+             *
+             * NOTE: This verbose structure is strictly required to prevent the ChromaDB client from
+             * flagging this as a "legacy" function, which triggers a persistent console warning:
+             * "No embedding function configuration found for collection..."
+             *
+             * The `chromadb` library checks for the presence of `name`, `getConfig`, and `buildFromConfig`.
+             * If any are missing, it defaults to legacy mode.
              * @returns {Object} The dummy embedding function satisfying IEmbeddingFunction
              */
-            dummyEmbeddingFunction: {default: AiConfig.dummyEmbeddingFunction},
+            dummyEmbeddingFunction: {default: {
+                generate   : () => null,
+                name       : 'dummy_embedding_function',
+                getConfig  : () => ({}),
+                constructor: {
+                    buildFromConfig: () => ({
+                        generate : () => null,
+                        name     : 'dummy_embedding_function',
+                        getConfig: () => ({})
+                    })
+                }
+            }},
             /**
              * The hostname of the ChromaDB server for the knowledge base.
              *

--- a/ai/mcp/server/knowledge-base/config.template.mjs
+++ b/ai/mcp/server/knowledge-base/config.template.mjs
@@ -101,28 +101,13 @@ class Config extends BaseConfig {
                 trustProxyIdentity: {env: 'NEO_AUTH_TRUST_PROXY_IDENTITY', default: AiConfig.auth.trustProxyIdentity, parse: Env.parseBool}
             },
             /**
-             * A dummy embedding function to satisfy the ChromaDB API when embeddings are provided manually.
-             *
-             * NOTE: This verbose structure is strictly required to prevent the ChromaDB client from
-             * flagging this as a "legacy" function, which triggers a persistent console warning:
-             * "No embedding function configuration found for collection..."
-             *
-             * The `chromadb` library checks for the presence of `name`, `getConfig`, and `buildFromConfig`.
-             * If any are missing, it defaults to legacy mode.
+             * Dummy embedding function — inherited from the Tier-1 single source of truth
+             * `AiConfig.dummyEmbeddingFunction` (#12165). Satisfies the ChromaDB API when embeddings
+             * are provided manually; the verbose anti-legacy structure (name / getConfig /
+             * buildFromConfig) lives once at Tier-1.
              * @returns {Object} The dummy embedding function satisfying IEmbeddingFunction
              */
-            dummyEmbeddingFunction: {default: {
-                generate   : () => null,
-                name       : 'dummy_embedding_function',
-                getConfig  : () => ({}),
-                constructor: {
-                    buildFromConfig: () => ({
-                        generate : () => null,
-                        name     : 'dummy_embedding_function',
-                        getConfig: () => ({})
-                    })
-                }
-            }},
+            dummyEmbeddingFunction: {default: AiConfig.dummyEmbeddingFunction},
             /**
              * The hostname of the ChromaDB server for the knowledge base.
              *

--- a/ai/scripts/maintenance/defragChromaDB.mjs
+++ b/ai/scripts/maintenance/defragChromaDB.mjs
@@ -373,14 +373,9 @@ async function defragChromaDB() {
             port: config.port
         });
 
-        // Dummy embedding function required by Chroma client to handle raw embeddings
-        // without attempting to re-generate them via an external provider.
-        const dummyEf = {
-            generate   : () => null,
-            name       : 'dummy',
-            getConfig  : () => ({}),
-            constructor: {buildFromConfig: () => ({generate: () => null})}
-        };
+        // Dummy embedding function — single source of truth: Tier-1 AiConfig.dummyEmbeddingFunction (#12165).
+        // Satisfies the Chroma client for raw embeddings without re-generating via a provider.
+        const dummyEf = AiConfig.dummyEmbeddingFunction;
 
         // 3. Extract All Data (Multi-Collection)
         console.log(`\n3️⃣  Fetching data from all collections...`);


### PR DESCRIPTION
Resolves #12165
Related: #12101, #12166

Authored by Claude Opus 4.8 (Claude Code 1M). Session b124b83a-2cca-4a2b-a711-64868439ba1e.

FAIR-band: over-target [20/30] — operator-direction (operator "dig in" on the #12101 follow-up subs). Rebalance: #12168 (the foundation) offered to under-target @neo-gpt [10/30] — see A2A.

**Scope narrowed during review** (operator architectural challenge): this PR carries only the two **chain-independent** dummy-EF cleanups. The KB realm-leaf dedup is explicitly **out** — see below.

## What shipped

- **defragChromaDB.mjs** — hardcoded `const dummyEf = {name:'dummy', …}` → `const dummyEf = AiConfig.dummyEmbeddingFunction`. The defrag is a maintenance **script** reading the canonical Tier-1 source at point-of-use (a consumer read, not a child-provider re-assign). The old `name:'dummy'` is exactly what chromadb-3.x mapped to the (non-existent) `@chroma-core/dummy` package → the deserialization warning during `chroma defrag (knowledge-base)`.
- **github-workflow/config.template.mjs** — `dummyEmbeddingFunction` removed (the server never imports chroma — dead config; `grep -c chromadb` = 0).

## Explicitly NOT in this PR (deferred to #12166)

KB's `dummyEmbeddingFunction` consolidation. An interim attempt used `dummyEmbeddingFunction: {default: AiConfig.dummyEmbeddingFunction}` — but that is the **child-provider-re-assigns-parent anti-pattern** (`default: AiConfig.x`) that Epic #12101 exists to eliminate. KB already carries that pattern for `auth.*` / `backupPath` / `engines.chroma.*` (from #12164); **all** of them — `dummyEmbeddingFunction` included — are removed in **#12166** via chain-inheritance (KB *omits* the leaves and inherits them through `getParent()`), never re-assigned. So this PR does not touch KB.

## Commits

- `613f721ec` — initial (defrag + GH-workflow + an interim KB snapshot).
- `e1dbf00a4` — reverts the KB snapshot per the architectural review above. **Net diff vs dev = defrag + github-workflow only** (squash-merge collapses the add-then-revert).

## Deltas from ticket

KB dedup removed from #12165 scope → moved to #12166 (it requires the parent chain to do without a snapshot). #12165 ticket rescoped to match.

## Evidence

Evidence: L1 (static config-shape + Neo-bootstrapped import) → L2 desired for warning-clear. Residual: defrag warning-clear needs a live `chroma defrag` run [#12165 post-merge]; suppression fallback tracked on #12102.

- github-workflow template parses + `dummyEmbeddingFunction === undefined` (Neo-bootstrapped import).
- `defragChromaDB.mjs` imports `AiConfig` from `../../config.mjs`; `AiConfig.dummyEmbeddingFunction` resolves to the canonical Tier-1 EF (`name='dummy_embedding_function'` + verbose anti-legacy structure).

## Test Evidence

- Affected specs grep-confirmed to NOT assert the `dummyEmbeddingFunction` structure (github-workflow `ConfigCompleteness.spec` asserts `issueSync` keys only). Edits don't red them.
- Full Playwright suite runs in CI (worktree has no `node_modules`).

## MCP config-template change

- `github-workflow/config.template.mjs`: `dummyEmbeddingFunction` removed.
- **Local `config.mjs` follow-up after merge:** regenerate each clone's gitignored github-workflow `config.mjs` from the template; restart that MCP server. No `config.mjs` committed.

## Post-Merge Validation

- [ ] Regenerate github-workflow `config.mjs`; restart its MCP server.
- [ ] Confirm `chroma defrag (knowledge-base)` no longer emits `@chroma-core/dummy is not installed`. If residual, suppression follow-up is on #12102.
