### PR TITLE
fix(data): api stores no longer auto-create a default Pipeline (#12170)

### DIFF
--- a/src/data/Store.mjs
+++ b/src/data/Store.mjs
@@ -432,6 +432,9 @@ class Store extends Collection {
     }
 
     /**
+     * api-configured stores load via the remotes-api RPC path inside load(), not via a pipeline.
+     * We therefore never auto-create a default Pipeline for them: otherwise load()'s `if (me.pipeline)`
+     * branch would shadow the `else if (me.api)` branch and an autoLoad store would never fire its RPC.
      * @param {Object|Neo.data.Pipeline|null} value
      * @param {Object|Neo.data.Pipeline|null} oldValue
      * @protected
@@ -440,9 +443,14 @@ class Store extends Collection {
     beforeSetPipeline(value, oldValue) {
         let me = this;
 
+        // api stores load via remotes-api, never a default pipeline
+        if (me.api) {
+            return null
+        }
+
         oldValue?.destroy();
 
-        if (!value && me.url && !me.api) {
+        if (!value && me.url) {
             // We store the promise so that load() can await it to prevent race conditions
             // e.g., when autoLoad: true triggers immediately after construction
             me.urlPipelinePromise = import('./connection/Xhr.mjs').then(() => {

--- a/test/playwright/unit/data/StoreApiPipeline.spec.mjs
+++ b/test/playwright/unit/data/StoreApiPipeline.spec.mjs
@@ -1,0 +1,69 @@
+import {setup} from '../../setup.mjs';
+
+const appName = 'StoreApiPipelineTest';
+
+setup({
+    appConfig: {
+        name: appName
+    }
+});
+
+import {test, expect} from '@playwright/test';
+import Neo            from '../../../../src/Neo.mjs';
+import * as core      from '../../../../src/core/_export.mjs';
+import Model          from '../../../../src/data/Model.mjs';
+import Pipeline       from '../../../../src/data/Pipeline.mjs';
+import Store          from '../../../../src/data/Store.mjs';
+
+const model = {
+    module: Model,
+    fields: [
+        {name: 'id',   type: 'String'},
+        {name: 'name', type: 'String'}
+    ]
+};
+
+/**
+ * @summary Regression: an api-configured Store must NOT auto-create a default Pipeline.
+ * If it did, Store.load()'s `if (me.pipeline)` branch would shadow the `else if (me.api)` RPC branch,
+ * so an `autoLoad: true` api store would never fire its remotes-api request.
+ */
+test.describe.serial('Neo.data.Store api vs pipeline', () => {
+    test('api-configured store has pipeline === null', () => {
+        const store = Neo.create(Store, {
+            api: {read: 'My.backend.Service.read'},
+            model
+        });
+
+        expect(store.api).not.toBe(null);
+        expect(store.pipeline).toBe(null);
+
+        store.destroy()
+    });
+
+    test('api-configured store with autoLoad: true still has pipeline === null', () => {
+        const store = Neo.create(Store, {
+            api     : {read: 'My.backend.Service.read'},
+            autoLoad: true,
+            model
+        });
+
+        // pipeline is resolved synchronously during construction; destroy() below cancels the
+        // pending autoLoad microtask (trap reject) before it would fire an RPC.
+        expect(store.pipeline).toBe(null);
+
+        store.destroy()
+    });
+
+    test('store without api or url still gets a default Pipeline (default preserved)', () => {
+        const store = Neo.create(Store, {
+            model,
+            items: [{id: '1', name: 'Item 1'}]
+        });
+
+        expect(store.api).toBe(null);
+        expect(store.pipeline).toBeInstanceOf(Pipeline);
+
+        store.destroy()
+    });
+});


### PR DESCRIPTION
Authored by Claude Opus 4.8 (Claude Code). Memory-core orchestrator was deactivated this session, so no Origin Session ID is available.

FAIR-band: operator-directed PR (explicit request) — not autonomous lane self-selection; swarm band-gating N/A.

Resolves #12170

api-configured stores were silently getting a default `Pipeline` instance, so `Store.load()`'s `if (me.pipeline)` branch always shadowed the `else if (me.api)` remotes-api branch — an `autoLoad: true` api store never fired its RPC. Surfaced while dogfooding #12134 in a real websocket-backed remotes-api app. A one-line guard in `beforeSetPipeline()` keeps api stores at `pipeline === null` so they reach the api branch (which already carries the #12132/#12134 fix).

Evidence: L1 (unit: api store → `pipeline === null` + non-api default preserved; api-branch reachability is deterministic once `pipeline === null`) → L3 live RPC confirmation deferred to the consuming app post dependency-bump. Residual: live autoLoad ws RPC.

## Root cause

`ClassSystemUtil.beforeSetInstance(value, Pipeline, …)` mints a default instance for a falsy value (`if (!config && DefaultClass) Neo.create(...)`). `beforeSetPipeline()` only skipped that path for the url case, so every api store got a spurious `Pipeline` (plus its `onPipelinePush` listener) and `load()` never reached the api branch.

## The fix

`src/data/Store.mjs` `beforeSetPipeline()`: return `null` early when `me.api` is set — api stores load via remotes-api, never a pipeline. The url guard simplifies to `!value && me.url` (the `!me.api` term is now subsumed by the early return). Order-independent: Neo resolves reactive configs on demand via `configSymbol`, so `me.api` reads correctly regardless of config processing order.

## Deltas from ticket

None of substance — implements #12170's prescribed `if (me.api) return null` guard verbatim (strict `api XOR pipeline` form). The `!value && me.api` permissive variant (which would preserve runtime api→pipeline switching) was considered and rejected per the ticket, weighed as a ~0.001% case.

## Test Evidence

New `test/playwright/unit/data/StoreApiPipeline.spec.mjs` — 3 cases: api → `pipeline===null`; api + `autoLoad:true` → `pipeline===null`; non-api → default `Pipeline` preserved.

- `npm run test-unit -- test/playwright/unit/data/StoreApiPipeline.spec.mjs` → **3 passed** (555ms)
- `npm run test-unit -- test/playwright/unit/data/` → **56 passed** (830ms) — no regression across the Store/TreeStore suite

## Post-Merge Validation

- [ ] A consuming remotes-api app (api store + `autoLoad: true`) renders data over the websocket after `npm update neo.mjs` — i.e. `load()` fires the RPC end-to-end.
